### PR TITLE
docs(pipeline): lightweight PR conventions (refs #15)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 ## Why
 
-<!-- The motivation. What problem does this solve / what does it enable? Reference issue if any. -->
+<!-- Motivation + linked issue. Use `Closes #N` so GitHub auto-closes the issue on merge. -->
+
+Closes #
 
 ## What
 
@@ -8,12 +10,21 @@
 
 ## How to verify
 
-<!-- Repro steps a reviewer can run to confirm it works. -->
+<!-- Repro steps a reviewer can copy-paste to confirm the change works. -->
+
+## Test evidence
+
+<!-- docker test output, path to docs/tests/report-testN.txt, or screenshot.
+     Leave "n/a" for docs-only / template changes. -->
 
 ## Checklist
 
-- [ ] Tests pass locally
-- [ ] Docs updated (if user-visible)
-- [ ] No secrets / tokens / private IPs in diff
-- [ ] Conventional Commits message
-- [ ] CHANGELOG entry (if release-worthy)
+- [ ] Relevant tests pass locally (`bun test`, docker test, etc.)
+- [ ] `docs-site/docs/changelog.md` updated (for user-visible changes)
+- [ ] Docs synced (interface / command / behavior changes)
+- [ ] No secrets / tokens / private IPs / `/home/<user>` paths in the diff
+- [ ] Conventional Commits message (`feat:` / `fix:` / `chore:` / `docs:` / `test:` / `refactor:`)
+- [ ] **No `Co-Authored-By: Claude*` footer** (OSS rule)
+- [ ] Issue linked via `Closes #N` (or `Refs #N` if it doesn't close)
+
+<!-- Pipeline reference: #15 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,14 +34,27 @@ Direct PRs without prior discussion are welcome but might be redirected if they 
   - `chore: bump deps`
   - `refactor: extract V`
   - `test: add coverage for U`
+- **No `Co-Authored-By: Claude*` footer** in commits (OSS rule)
+- No secrets / tokens / private IPs / `/home/<user>` paths in commits or diffs
+
+## How changes get merged (lightweight pipeline)
+
+Substantive changes (`agent-network/` / `server/` / `agent-node/` / `agent-network-dashboard/` / root-level `*.md`) should go through a **Pull Request**:
+
+1. Branch off `origin/main` (suggested name: `fix/issue-<N>-<slug>` or `feat/<short-name>`)
+2. Implement + commit + push the branch
+3. Open a PR — fill in the [PR template](./.github/PULL_REQUEST_TEMPLATE.md)
+4. `Closes #N` in the description auto-closes the linked issue on merge
+5. At least 1 maintainer reviews, squash-merges
+6. GitHub auto-deletes the head branch on merge
+
+Docs-only updates (`docs/**`, `docs-site/docs/**`) can be pushed directly to `main` for now — there is an automated docs-loop that maintains them with high frequency; gating them through PR review would block that.
+
+For the longer-term design (CI checks, branch protection, CODEOWNERS, preview release automation, etc.), see [#15](https://github.com/sleep2agi/agent-network/issues/15) — being rolled out incrementally as the project grows.
 
 ## PR checklist
 
-- [ ] Tests pass locally (`bun test` in the affected subproject)
-- [ ] Docs updated if user-visible behavior changed (`docs-site/`)
-- [ ] No secrets, tokens, or private IPs introduced (we run `gitleaks` in CI)
-- [ ] Changelog entry added if release-worthy
-- [ ] PR description explains **why**, not just **what**
+See the [PR template](./.github/PULL_REQUEST_TEMPLATE.md) — the checklist lives there and stays in sync.
 
 ## Code style
 


### PR DESCRIPTION
## Why

Refs #15 — first concrete step on the PR-based pipeline. Keeps it light so it doesn't trip over the things I found while probing the heavier design:

- `e2e-docker.yml` has been red on `main` for several recent commits already (issue #13 fix + multiple docs rounds)
- the originally-planned `typecheck.yml` had a `bun tsc` vs `bunx tsc` discrepancy across `agent-network/` (has TS devDep) and `server/` (doesn't) — also `agent-node/` has no `tsconfig.json` at all
- docs-loop pushes to `main` every minute; requiring status checks today would freeze it

So this PR ships **only the bits that don't require working CI**, and explicitly carves docs-loop out of the PR requirement. The heavier rails (typecheck workflow, branch protection with required checks, CODEOWNERS, release automation) stay deferred under #15 until the project actually needs them and the green-baseline issues are fixed.

## What

- `.github/PULL_REQUEST_TEMPLATE.md` — restructured: `Closes #` placeholder, **Test evidence** section, tightened checklist (Conventional Commits, no `Co-Authored-By: Claude*` footer, secrets/PII redaction reminder).
- `CONTRIBUTING.md` — added a short "How changes get merged" section: code subprojects + root-level `.md` go through PR; `docs/**` and `docs-site/docs/**` are exempt for docs-loop; links #15 for the longer-term roadmap.

## How to verify

1. Click `Files changed` → confirm only two files modified.
2. Open `Conversation` and confirm GitHub rendered the **new** PR template above (not the old `## Why / ## What / ## How to verify / ## Checklist` 5-item template). The current PR is itself the test fixture.
3. Read `CONTRIBUTING.md` → confirm new section explicitly carves out docs-loop.

## Test evidence

n/a — template + docs-only change. Behavior is "this PR description and its checkboxes themselves render correctly", which you can read in the GitHub UI.

## Checklist

- [x] Relevant tests pass locally (n/a)
- [x] `docs-site/docs/changelog.md` updated (not user-visible; n/a)
- [x] Docs synced (CONTRIBUTING.md is the doc itself)
- [x] No secrets / tokens / private IPs / `/home/<user>` paths in the diff
- [x] Conventional Commits message
- [x] **No `Co-Authored-By: Claude*` footer**
- [x] Issue linked via `Refs #15` (PR doesn't close #15 — issue stays open for the longer-term rollout)
