### PR TITLE
docs(account): document anet passwd side-effects (closes #17)

### DIFF
--- a/docs-site/docs/en/guide/account-system.md
+++ b/docs-site/docs/en/guide/account-system.md
@@ -78,6 +78,50 @@ anet whoami
 anet passwd
 ```
 
+::: details What happens after I change my password? (v0.8)
+
+Common question ([#17](https://github.com/sleep2agi/agent-network/issues/17)). Full side-effect list:
+
+**Current device (the one running `anet passwd`)**
+- CLI receives a freshly-issued `utok_`, auto-writes it to `~/.anet/config.json`
+- Subsequent `anet` commands keep working — **no re-login needed**
+
+**Other devices / other CLI sessions**
+- Server **revokes every old `utok_` for that user** (including the admin-utok.json bootstrap one)
+- Next API call returns `401 unauthorized` → must `anet login` to get a fresh `utok_`
+- The more devices you have, the louder the rotate. Check with `anet token ls` before rotating.
+
+**Dashboard (browser)**
+- Logged-in tab: next REST request returns 401 → Dashboard redirects to login → enter new password → fresh cookie
+- Since v0.8 the Dashboard is a thin cookie-proxy ([security model](/en/concepts/security#dashboard-auth-v0-8-thin-cookie-proxy)); the expired cookie is cleared automatically.
+
+**Agent Nodes (`ntok_`)**
+- **Unaffected.** `ntok_` is per-node-per-network and independent of user password.
+- Running agents keep running; `anet doctor --fix` still patches ntok_ issues separately.
+
+**Hub host's `~/.anet/server/admin-utok.json`** (edge case)
+- The admin `utok_` written there at bootstrap time is also revoked
+- The file **content is not auto-rotated** to the new utok_
+- Subsequent local commands (e.g. `anet hub admin reset-user <other>`) that read admin-utok.json will hit 401
+- Workaround for now: re-run `anet login --username admin --password <new-password>` to refresh `~/.anet/config.json`; admin-utok.json is a one-time bootstrap credential — `config.json` is the authoritative source going forward. A proper auto-sync fix is queued for v0.9.
+
+**Audit log**
+- `audit_log` records a `password_changed` row (or `password_reset_by_admin` if the change came via reset-user)
+- View with `anet hub admin audit-log` (owner permission)
+
+**Password strength check (server-side)**
+- ≥ 8 characters + not in the top-1000 weak-password dictionary
+- First bootstrap admin allowed ≥ 4 chars as exception
+- Weak password → server rejects with `password too weak` / `password too short`
+
+**Forgot the old password?**
+- Can't use `anet passwd` (requires old password)
+- On the Hub machine, run `anet hub admin reset-user <username>` to force-reset (local owner permission, bypasses HTTP check)
+
+Deeper: [Token system](/en/concepts/tokens) / [Security design](/en/concepts/security#password-security)
+
+:::
+
 ### Creating Accounts for Others
 
 Have them run on their own computer:

--- a/docs-site/docs/guide/account-system.md
+++ b/docs-site/docs/guide/account-system.md
@@ -78,6 +78,50 @@ anet whoami
 anet passwd
 ```
 
+::: details 改密码后会发生什么？（v0.8）
+
+这是常见疑问 ([#17](https://github.com/sleep2agi/agent-network/issues/17))，把所有副作用列清楚：
+
+**当前设备（运行 `anet passwd` 的那台）**
+- CLI 拿到新签发的 `utok_`，自动写回 `~/.anet/config.json`
+- 后续 `anet` 命令照旧能用，**无需重新登录**
+
+**其他设备 / 其他 CLI session**
+- 服务端**撤销该用户所有旧 `utok_`**（包括 admin-utok.json bootstrap 时颁的）
+- 下次 API 调用拿 `401 unauthorized` → 必须 `anet login` 重新登录拿新 `utok_`
+- 设备越多，rotate 噪音越大 — 改密码前可以先 `anet token ls` 看一眼
+
+**Dashboard（浏览器）**
+- 已登录的 tab：下一次 REST 请求拿 401 → Dashboard 跳回登录页 → 输入新密码 → 拿新 cookie
+- Dashboard v0.8 是 thin cookie-proxy（[安全设计](/concepts/security#dashboard-鉴权)），cookie 失效后自动清
+
+**Agent Node (`ntok_`)**
+- **不受影响**。`ntok_` 是 per-node-per-network 维度的 token，独立于用户密码
+- 跑着的 agent 继续跑，不会被打断；`anet doctor --fix` 仍能修 ntok_ 问题
+
+**Hub 主机的 `~/.anet/server/admin-utok.json`**（边界 case）
+- bootstrap 时写的 admin `utok_` 也被一并 revoke
+- 该文件**内容不会自动同步**为新 utok_
+- 如果你之后用 `anet hub admin reset-user <other>` 这种本机命令读 admin-utok.json → **会拿 401**
+- 当前的兜底：手动跑 `anet login --username admin --password <新密码>`，刷新 `~/.anet/config.json`；admin-utok.json 是 bootstrap 一次性凭证，长期使用以 config.json 为准。完整修复留 follow-up（v0.9）。
+
+**审计日志**
+- `audit_log` 写入一条 `password_changed`（or `password_reset_by_admin` 走 reset-user 路径）
+- `anet hub admin audit-log` 可看（owner 权限）
+
+**密码强度限制（写入新密码前 server 校验）**
+- ≥ 8 字符 + 不在 top-1000 弱密码字典里
+- 首次 bootstrap admin 例外允许 ≥ 4
+- 弱密码 → server 拒，返回 `password too weak` / `password too short`
+
+**忘记旧密码怎么办？**
+- 不能用 `anet passwd`（要求输旧密码）
+- 在 Hub 主机跑 `anet hub admin reset-user <username>` 强制重置（owner 本机权限即可，绕过 HTTP 校验）
+
+更深入：[Token 体系](/concepts/tokens) / [安全设计](/concepts/security#密码安全)
+
+:::
+
 ### 给别人开账号
 
 让对方在自己电脑上运行：


### PR DESCRIPTION
## Why

Closes #17

issue #17 问"更改密码后会发生啥？"。现有 `account-system.md` 只列了 `anet passwd` 命令，没解释副作用 — 用户改完不知道其他设备 / Dashboard / agent 会怎样，admin-utok.json 边界 case 也没文档。

## What

`docs-site/docs/guide/account-system.md` + EN 镜像在 `### 修改密码` 段加一个 expandable `:::details` block，覆盖 7 类副作用：

1. 当前设备：utok_ 自动 rotate 到 `~/.anet/config.json`，无需 re-login
2. 其他设备 / CLI session：旧 utok_ 全 revoke → 下次 401 → re-login
3. Dashboard：cookie 失效自动跳登录页（v0.8 thin cookie-proxy）
4. Agent Node `ntok_`：**不受影响**（独立维度）
5. Hub host 的 `~/.anet/server/admin-utok.json`：边界 case — bootstrap 凭证被 revoke 但文件不自动同步，给出工作绕过 + v0.9 fix queued
6. Audit log：`password_changed` / `password_reset_by_admin` entry
7. 密码强度校验 + 忘密码兜底（`anet hub admin reset-user`）

跟 `concepts/tokens.md` / `concepts/security.md` 内嵌引用串起来。

## How to verify

```bash
cd docs-site && npm run build
# 应该 "build complete in Xs"，无 dead link
```

浏览器打开 anet.sh `/guide/account-system#修改密码`，点开 `:::details` 折叠块，7 项全显示。

## Test evidence

```
build complete in 53.27s.
```

无 dead link。EN 镜像跟 ZH 内容对齐（7 条副作用一致）。

## Checklist

- [x] Relevant tests pass locally (docs build green)
- [x] `docs-site/docs/changelog.md` updated (n/a — docs-only minor)
- [x] Docs synced (是 doc 本身)
- [x] No secrets / tokens / private IPs / `/home/<user>` paths
- [x] Conventional Commits (`docs:`)
- [x] No `Co-Authored-By: Claude*` footer
- [x] Issue linked via `Closes #17`

## 边界 case 跟进

admin-utok.json bootstrap 凭证不自动同步是一个**实际的轻量 bug**，本 PR 仅文档化绕过路径，v0.9 应该正式修：让 `anet passwd` 检测当前用户是不是 admin + admin-utok.json 是不是自己的 token，是则同步写入新 utok_。

我先不主动开新 issue，让 v0.9 实施时通信牛看到这段文档自然知道要修。如果 Vincent 想立刻开 issue tracking，说一声。
