### PR TITLE
docs(cases): bind Telegram to existing node — claude-code-cli walkthrough (refs #14)

### DIFF
--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -104,6 +104,7 @@ export default withMermaid(defineConfig({
               { text: '你好世界', link: '/cases/hello-world' },
               { text: '翻译流水线', link: '/cases/translation-pipeline' },
               { text: '军团编队', link: '/cases/telegram-squad' },
+              { text: 'Telegram 接入已存在节点 (claude-code-cli)', link: '/cases/telegram-bind-claude-code-cli' },
             ]
           },
           {
@@ -195,6 +196,7 @@ export default withMermaid(defineConfig({
               { text: 'Hello World', link: '/en/cases/hello-world' },
               { text: 'Translation Pipeline', link: '/en/cases/translation-pipeline' },
               { text: 'Telegram Squad', link: '/en/cases/telegram-squad' },
+              { text: 'Bind Telegram to existing node (claude-code-cli)', link: '/en/cases/telegram-bind-claude-code-cli' },
             ]
           },
           {

--- a/docs-site/docs/cases/telegram-bind-claude-code-cli.md
+++ b/docs-site/docs/cases/telegram-bind-claude-code-cli.md
@@ -1,0 +1,642 @@
+# Telegram 接入已存在节点（claude-code-cli runtime）— 详细操作手册
+
+把一个跑着的 `claude-code-cli` 节点接进 Telegram —— 你在 Telegram 里 DM bot，bot 把消息转给 Claude Code 处理，Claude Code 回复（包括跑 bash / 改文件 / 调 MCP 工具的完整能力）。本手册给**每一步的预期输出 + 落盘文件 + 错误诊断**，照着敲就能跑通。
+
+> [!IMPORTANT]
+> **当前支持范围**：仅 `claude-code-cli` runtime。`claude-agent-sdk` / `codex-sdk` 的 Telegram bridge 在 [RFC-002 Channel-Bind CLI](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-002-channel-bind-cli.md) Phase 1 排期，目标 v0.9+。
+
+| 信息 | 值 |
+|---|---|
+| 预计时间 | 5-10 分钟（含 plugin 首次安装）|
+| 前置 | 已有 `claude-code-cli` runtime 的节点（hello-world demo 用过 `claude-agent-sdk`，本案例 runtime 不同；如果没节点先看[上手指南](/guide/getting-started)）|
+| anet 版本 | ≥ 2.1.5（latest）或 ≥ 2.1.7-preview.0（preview）|
+| Claude Code CLI 版本 | ≥ 2.x（需支持 `--channels plugin:xxx@yyy` 语法）|
+
+---
+
+## 总体流程
+
+```
+你 →─→  @BotFather (Telegram)  →─→  bot token
+       @userinfobot (Telegram)  →─→  你的 user id
+                                       ↓
+        claude plugin install telegram@claude-plugins-official
+        anet channel add telegram <node> --bot-token <tok> --allow <user-id>
+        anet node stop <node> && anet node start <node>
+                                       ↓
+        Telegram DM ─→ bot polling ─→ Claude Code ─→ bot reply
+```
+
+---
+
+## 步骤 0 — 确认 Claude Code Telegram plugin 已安装
+
+anet 把 Telegram 接入 claude-code-cli 节点的实现 = 启动 `claude` 时传 `--channels plugin:telegram@claude-plugins-official`，让 Claude Code 自身的 channel plugin 系统接管。**plugin 必须先在你的 `claude` CLI 里装一次**（user scope，所有项目共享）。
+
+### 0.1 检查是否已装
+
+```bash
+claude plugin list | grep telegram
+```
+
+**已装**：
+
+```
+telegram@claude-plugins-official  user   /home/<user>/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6  installed: 2026-03-22
+```
+
+跳到[步骤 1](#步骤-1-—-拿-bot-token--telegram-user-id)。
+
+**未装**（输出为空 / `plugin not found`）：继续 0.2。
+
+### 0.2 安装 plugin
+
+```bash
+claude plugin install telegram@claude-plugins-official
+```
+
+预期输出：
+
+```
+Fetching from marketplace claude-plugins-official...
+Resolving telegram@latest → 0.0.6
+Downloading ~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6/...
+Verifying...
+✓ installed: telegram@claude-plugins-official (0.0.6, user scope)
+```
+
+落盘文件：
+
+```
+~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6/
+├── plugin.json       # 元数据
+├── server.ts         # MCP server 实现（Telegram bot polling 主逻辑）
+├── ACCESS.md         # 权限模型说明
+├── README.md
+├── package.json
+├── bun.lock
+├── node_modules/     # 依赖
+└── skills/           # MCP skills 定义
+```
+
+### 0.3 verify 安装成功
+
+```bash
+claude plugin details telegram@claude-plugins-official
+```
+
+输出含：
+
+```
+Plugin: telegram@claude-plugins-official
+Version: 0.0.6
+Scope: user
+Install path: ~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6
+Components: 1 MCP server (channel), N skills
+```
+
+**plugin 装好了**。这一步是一次性的 — 一台机器装一次，所有 anet 节点共享。
+
+> [!TIP]
+> Plugin 更新：`claude plugin update telegram@claude-plugins-official`。anet 不绑死特定版本，跟随 claude CLI 自己的 update 节奏。
+
+---
+
+## 步骤 1 — 拿 Bot Token + Telegram User ID
+
+需要两样东西：
+
+### 1.1 创建 Bot（`@BotFather`）
+
+打开 Telegram 搜 [@BotFather](https://t.me/BotFather)（蓝色 V verified）：
+
+```
+You:        /newbot
+BotFather:  Alright, a new bot. How are we going to call it?
+            Please choose a name for your bot.
+You:        anet-test-bot          ← 显示名
+BotFather:  Good. Now let's choose a username for your bot.
+            It must end in `bot`.
+You:        anet_test_bot          ← 唯一 username
+BotFather:  Done! Congratulations on your new bot.
+            ...
+            Use this token to access the HTTP API:
+            123456789:AAEhBP_XYZxyz...   ← ★ 这是 bot token
+            ...
+```
+
+复制 token（格式 `<bot-id>:<secret>`）。
+
+> [!WARNING]
+> **Token 私密**：相当于 bot 的密码。**不要**：
+> - 贴到 GitHub issue / PR
+> - 截图发群
+> - 写到本机 git-tracked 文件
+> - 上传到任何公开服务
+>
+> 如果 token 不小心泄露，立即在 BotFather 里 `/token` → 选 bot → `Revoke current token` 撤掉。
+
+### 1.2 拿你的 Telegram 数字 User ID（`@userinfobot`）
+
+打开 [@userinfobot](https://t.me/userinfobot)：
+
+```
+You:           /start
+userinfobot:   👋 Hi User Name!
+               🆔 Id: 7612221352          ← ★ 这是你的数字 user id
+               👤 Username: @your_handle
+               🌐 Language: zh-hans
+```
+
+复制数字 ID（**不要复制 `@username`** — anet 的白名单认数字 ID）。
+
+> [!NOTE]
+> 数字 user id 是你在 Telegram 全局唯一的不可变 ID。即使你改 username / 显示名 它不变。
+
+---
+
+## 步骤 2 — 确认目标节点 runtime
+
+```bash
+anet node ls
+```
+
+预期输出（节选）：
+
+```
+Node Status:
+
+  ALIAS         RUNTIME              MODEL                  STATUS   SSE   LAST SEEN
+  my-bot        claude-code-cli      claude-sonnet-4-6      idle     ✓     2s ago
+  translator    claude-agent-sdk     MiniMax-M2.7           idle     ✓     5s ago
+  coder         codex-sdk            gpt-5-codex            offline  ✗     2h ago
+```
+
+找到要绑 Telegram 的节点，确认 `RUNTIME` 列**是 `claude-code-cli`**。
+
+| 节点 runtime | 本案例适用？ |
+|---|---|
+| `claude-code-cli` | ✅ 适用 |
+| `claude-agent-sdk` | ❌ 等 v0.9+（RFC-002 P1）|
+| `codex-sdk` | ❌ 等 v0.9+（RFC-002 P2）|
+
+如果你的节点是 SDK runtime 想接 Telegram，**暂时**用 [`demos/codex-telegram-squad`](https://github.com/sleep2agi/agent-network/tree/main/demos/codex-telegram-squad)（Docker Compose 起一整套）或等 v0.9。
+
+如果还没节点，先看 [Hello World](/cases/hello-world)，注意建节点时 runtime 选 `claude-code-cli`：
+
+```bash
+anet node create my-bot --runtime claude-code-cli
+```
+
+---
+
+## 步骤 3 — 绑定 Telegram channel
+
+```bash
+anet channel add telegram my-bot \
+  --bot-token 123456789:AAEhBP_XYZxyz... \
+  --allow 7612221352
+```
+
+参数完整说明：
+
+| 参数 | 必需 | 说明 | 例 |
+|---|---|---|---|
+| `<type>` | ✓ | 第一个位置参数，目前只支持 `telegram` | `telegram` |
+| `<node-id>` | ✓ | 第二个位置参数。支持 `node_name`（人类可读）或 `node_id`（`n_a1b2c3d4`）| `my-bot` |
+| `--bot-token <tok>` | ✓ | Telegram bot token（@BotFather 给的）| `123456789:AAEhBP...` |
+| `--allow <user-id>` | ✓ | 你的 Telegram 数字 user id（access.json 白名单首项）| `7612221352` |
+
+> [!TIP]
+> **交互式**：所有 flag 不传时命令会一项一项问你，更适合敏感 token 不出现在 shell history：
+>
+> ```bash
+> anet channel add telegram my-bot
+> # → Telegram Bot Token: <隐藏输入>
+> # → Allow User ID (发 @userinfobot 获取数字ID): <输入>
+> ```
+
+### 3.1 预期输出
+
+```
+Telegram Bot Token: 123456789:AAEhBP_XYZxyz...
+Allow User ID (发 @userinfobot 获取数字ID): 7612221352
+
+✅ telegram channel added to "my-bot"
+   /home/<user>/.anet/nodes/n_abc12345/channels/telegram/
+   config.json updated
+```
+
+### 3.2 错误情况
+
+| 错误信息 | 原因 | 解决 |
+|---|---|---|
+| `Node "my-bot" not found. Create it first: anet node create my-bot ...` | 节点 ID/名字打错或节点不存在 | `anet node ls` 查正确名字 |
+| `P0 only supports telegram channels. Unsupported type: <X>` | 第一个位置参数不是 `telegram` | 改为 `telegram` |
+| `Error: bot-token and allow required` | 交互式输入时空回车 | 重跑命令认真输入 |
+| `EACCES: permission denied, mkdir ...` | `.anet/nodes/` 目录权限不对 | `chown -R $USER .anet` |
+
+---
+
+## 步骤 4 — 验证配置落盘
+
+### 4.1 用 `anet channel ls` 看 channel 列表
+
+```bash
+anet channel ls my-bot
+```
+
+预期输出：
+
+```
+Node Channels:
+
+  n_abc12345 (my-bot)   telegram     allow: 7612221352
+```
+
+### 4.2 直接看落盘文件
+
+```bash
+ls -la ~/.anet/nodes/n_abc12345/channels/telegram/
+```
+
+```
+total 16
+drwxr-xr-x 3 user user 4096 May 12 10:00 .
+drwxr-xr-x 3 user user 4096 May 12 10:00 ..
+-rw-------  1 user user   52 May 12 10:00 .env             ← chmod 600 ✓
+-rw-r--r--  1 user user  142 May 12 10:00 access.json
+drwxr-xr-x 2 user user 4096 May 12 10:00 inbox            ← plugin 用来缓存消息
+```
+
+文件内容：
+
+```bash
+cat ~/.anet/nodes/n_abc12345/channels/telegram/.env
+```
+
+```
+TELEGRAM_BOT_TOKEN=123456789:AAEhBP_XYZxyz...
+```
+
+```bash
+cat ~/.anet/nodes/n_abc12345/channels/telegram/access.json | python3 -m json.tool
+```
+
+```json
+{
+  "dmPolicy": "allowlist",
+  "allowFrom": [
+    "7612221352"
+  ],
+  "groups": {},
+  "pending": {}
+}
+```
+
+**access.json 字段语义**：
+
+| 字段 | 类型 | 默认 | 含义 |
+|---|---|---|---|
+| `dmPolicy` | `"allowlist"` / `"deny-all"` / `"allow-all"` | `"allowlist"` | DM（私聊）准入策略。`allowlist` = 只允许 `allowFrom` 名单 |
+| `allowFrom` | `string[]`（数字 user id 列表）| `[<--allow 传的 id>]` | 私聊白名单 |
+| `groups` | `{ <chat_id>: "active" \| "passive" \| "deny" }` | `{}` | 群聊规则。空对象 = 默认拒所有群聊 |
+| `pending` | `object` | `{}` | plugin 内部 state，无需手动改 |
+
+### 4.3 看节点 config.json 里 `channels` 数组
+
+```bash
+cat ~/.anet/nodes/n_abc12345/config.json | python3 -m json.tool | grep -A 5 channels
+```
+
+应该包含：
+
+```json
+    "channels": [
+        "server:commhub",
+        "telegram"
+    ],
+```
+
+> [!NOTE]
+> `"server:commhub"` 是 commhub channel（agent 跟 hub 的通信通道，default 自带），跟 telegram 并列。两条 channel 在同一个 claude 进程内并行工作。
+
+---
+
+## 步骤 5 — 重启节点让 Telegram channel 生效
+
+> [!WARNING]
+> 当前实现**不支持热注入** channel。节点必须 stop + start 才能让 telegram 生效。这是 RFC-002 边界 case 之一，v0.9+ 优化。
+
+### 5.1 停旧进程
+
+```bash
+anet node stop my-bot
+```
+
+预期输出：
+
+```
+[anet] Stopping my-bot...
+[anet] Sent SIGTERM to PID 12345
+[anet] my-bot stopped
+```
+
+### 5.2 启新进程（带 telegram channel）
+
+```bash
+anet node start my-bot
+```
+
+预期输出（关键行）：
+
+```
+[anet] Starting my-bot (runtime=claude-code-cli)...
+[anet] Spawning: claude --dangerously-skip-permissions \
+                       --dangerously-load-development-channels server:commhub \
+                       --channels plugin:telegram@claude-plugins-official \
+                       --teammate-mode in-process \
+                       --resume <uuid>  (or --session-id <uuid>) \
+                       -n my-bot
+[anet] env: COMMHUB_URL, COMMHUB_TOKEN, TELEGRAM_STATE_DIR=/home/<user>/.anet/nodes/n_abc12345/channels/telegram, ...
+[anet] Claude Code session pinned: a1b2c3d4...
+[my-bot]  SSE connected
+[my-bot]  Telegram plugin: polling started (bot @anet_test_bot, allow 7612221352)
+```
+
+**关键 verify 项**：
+
+1. ✅ claude 命令行带 `--channels plugin:telegram@claude-plugins-official`
+2. ✅ 环境变量 `TELEGRAM_STATE_DIR` 指向 channels/telegram 目录
+3. ✅ Telegram plugin 启动 polling（具体日志格式可能因 plugin 版本略有差异）
+
+### 5.3 错误诊断
+
+| 错误 | 原因 | 解决 |
+|---|---|---|
+| `claude: command not found` | Claude Code CLI 没装到 PATH | `npm i -g @anthropic-ai/claude-code` |
+| `plugin telegram@claude-plugins-official not found` | 跳了步骤 0 没装 plugin | 回去跑 `claude plugin install telegram@claude-plugins-official` |
+| `TELEGRAM_BOT_TOKEN env var missing` | `.env` 文件没生成 / 没读到 | `ls -la ~/.anet/nodes/<node>/channels/telegram/.env`；如缺则重跑 `anet channel add telegram` |
+| `Telegram getUpdates: 401 Unauthorized` | bot token 错误 / 被 revoke | 回 BotFather `/token` 重新拿，重跑 `anet channel add telegram` 覆盖 |
+| `Telegram getUpdates: 409 Conflict` | 同一个 bot token 在另一个进程也在 polling | 停别处用该 bot 的进程；一个 bot token 只能一处 polling |
+
+---
+
+## 步骤 6 — 在 Telegram 里 DM bot 试
+
+打开 Telegram，搜你刚创建的 bot username（`@anet_test_bot`），点 `Start` → 输入消息：
+
+```
+You:    数一下 1 到 10
+Bot:    1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        (具体回复内容由 Claude Code 处理结果决定)
+```
+
+后台 Claude Code 处理流程：
+
+1. Telegram plugin 收到 update.message
+2. 校验 `from.id == 7612221352`（白名单）通过
+3. 把 message content 喂给 claude 主循环
+4. Claude Code 处理（可能调工具、写文件、跑 bash）
+5. 处理完通过 plugin 调 Telegram `sendMessage` 回复
+
+### 6.1 没回复怎么办
+
+按概率从高到低排查：
+
+**1. 你不在白名单**
+
+用别的 Telegram 账号发就被静默 ignore。回 `@userinfobot` 确认你当前用的 ID，比对 access.json:
+
+```bash
+cat ~/.anet/nodes/<node-id>/channels/telegram/access.json | python3 -m json.tool
+```
+
+```json
+{
+  "allowFrom": ["7612221352"]   ← 必须含你当前用的 ID
+}
+```
+
+不匹配就改：
+
+```bash
+anet channel add telegram <node-id> \
+  --bot-token <same-token> \
+  --allow <your-correct-id>
+# 重启节点
+anet node stop <node-id> && anet node start <node-id>
+```
+
+**2. 节点 offline**
+
+```bash
+anet node ls | grep <node-id>
+```
+
+`STATUS` 不是 `idle` / `working` 就 offline。看日志找原因：
+
+```bash
+anet logs <node-id> | tail -30
+```
+
+**3. Plugin polling 卡住**
+
+```bash
+anet logs <node-id> | grep -i "telegram\|polling\|getUpdates"
+```
+
+正常应每 N 秒一条 polling log。如果一直没动静，可能 plugin 自己有 bug — `claude plugin update telegram@claude-plugins-official` 升级再试。
+
+**4. Bot token 已被你/别人 revoke**
+
+```bash
+curl "https://api.telegram.org/bot<your-token>/getMe"
+```
+
+正常返回 bot info JSON；返回 `{"ok": false, "error_code": 401}` 则 token 失效。回 BotFather revoke + 重新拿。
+
+**5. Bot 在另一个进程也在 polling**
+
+Telegram 限制 1 bot 1 polling 进程，否则两个进程**互抢**消息（每条消息只到其中一个）。检查：
+
+```bash
+ps aux | grep "telegram" | grep -v grep
+```
+
+只该有一个 anet 启动的 claude 进程占该 bot。其他要停。
+
+---
+
+## 高级用法
+
+### A. 接群聊（默认拒绝）
+
+`access.json` 的 `groups: {}` 默认对所有群聊拒绝。要接群：
+
+```bash
+# 拿群 chat_id（在群里 @userinfobot 然后转发任意一条群消息给它，它会回 chat id）
+# 假设拿到 chat_id = -1001234567890
+
+# 手动编辑 access.json
+python3 -c "
+import json
+p = '/home/<user>/.anet/nodes/<node-id>/channels/telegram/access.json'
+d = json.load(open(p))
+d['groups']['-1001234567890'] = 'active'
+json.dump(d, open(p, 'w'), indent=2)
+print('done')
+"
+
+# 重启节点
+anet node stop <node-id> && anet node start <node-id>
+```
+
+`groups` 字段值：
+
+| 值 | 行为 |
+|---|---|
+| `"active"` | bot 主动响应该群所有 @提及 |
+| `"passive"` | bot 只对 `/command` 响应 |
+| `"deny"` | 拒绝（默认行为，但显式标也行）|
+
+### B. 多人白名单
+
+team 共用一个 bot：
+
+```bash
+# 第一个人加进 allow
+anet channel add telegram <node-id> --bot-token <tok> --allow 7612221352
+
+# 再加第二个人 — 直接编 access.json，命令不支持多个 allow
+python3 -c "
+import json
+p = '/home/<user>/.anet/nodes/<node-id>/channels/telegram/access.json'
+d = json.load(open(p))
+if '9988776655' not in d['allowFrom']:
+    d['allowFrom'].append('9988776655')
+json.dump(d, open(p, 'w'), indent=2)
+"
+
+anet node stop <node-id> && anet node start <node-id>
+```
+
+### C. 切换 bot token
+
+```bash
+# 直接重跑 add 命令覆盖
+anet channel add telegram <node-id> \
+  --bot-token <new-token> \
+  --allow <user-id>
+# 重启
+anet node stop <node-id> && anet node start <node-id>
+```
+
+记得回 BotFather 把旧 bot token revoke（避免泄露还能用）。
+
+### D. 解绑 Telegram
+
+```bash
+# 1. 从 config.json 的 channels 数组去掉 "telegram"
+python3 -c "
+import json
+p = '/home/<user>/.anet/nodes/<node-id>/config.json'
+d = json.load(open(p))
+d['channels'] = [c for c in d['channels'] if c != 'telegram']
+json.dump(d, open(p, 'w'), indent=2)
+"
+
+# 2. 删 channels/telegram 目录
+rm -rf /home/<user>/.anet/nodes/<node-id>/channels/telegram
+
+# 3. 重启
+anet node stop <node-id> && anet node start <node-id>
+```
+
+### E. 多个 node 同一个 bot（**不推荐**）
+
+Telegram 限制 1 bot 1 polling 进程。多个 anet node 用同一 bot token 会**互抢消息**，不可预期。
+
+**正确方式**：每个 node 用独立 bot（@BotFather 可以建多个 bot）。
+
+### F. 改密码后 telegram channel 受影响吗？
+
+**不受影响**。详见 [issue #17 详细答复](https://github.com/sleep2agi/agent-network/issues/17#issuecomment-4428789875)。改密码只 revoke `utok_`，node 用的 `ntok_` 不变，已建的 SSE 长连接不断，Telegram plugin polling 继续跑。
+
+---
+
+## 安全考虑
+
+### Token 存储
+
+- `.env` 文件 `chmod 600`（只有当前 user 能读）
+- `.anet/` 在仓库 `.gitignore` 里（不进 git）
+- Bot token **不上传 hub**（hub 不持有，纯 agent-local）
+
+### Access 白名单强制
+
+- 不在 `allowFrom` 的 Telegram user 发 DM → **静默 ignore**（不回错误、不进 audit log）
+- 这是设计取舍：不回错误避免暴露 bot 是 anet 跑的（防探测）
+
+### Bot 权限范围
+
+- Claude Code 是用 `--dangerously-skip-permissions` 启动的 — 工具调用不会再问你确认
+- 任何在 `allowFrom` 里的用户都能让 bot 跑**任意 bash 命令 / 改任意文件**（claude 有 Bash / Write 工具）
+- **生产部署**：
+  - 用一次性 / 独立工作目录跑这个 node（不要在 `$HOME` 跑）
+  - `allowFrom` 严格只放可信用户
+  - 考虑用 `--tools` 限定 Claude Code 工具集（去掉 Bash / Write）
+
+```bash
+# 创节点时限制工具
+anet node create my-bot --runtime claude-code-cli \
+  --tools "Read,Glob,Grep,WebFetch"   # 只读 + 联网，无 Bash/Write/Edit
+```
+
+---
+
+## 跟 `demos/codex-telegram-squad/` 区别
+
+| | `codex-telegram-squad` demo | 本案例 |
+|---|---|---|
+| 部署 | Docker Compose 起 hub + 多 worker + telegram bot 全套 | 已有 anet 装好后加 Telegram 到现有 node |
+| Runtime | 多个 `codex-sdk` worker + 1 个 `claude-agent-sdk` commander | 单 `claude-code-cli` node |
+| Telegram 接入层 | Demo 内部代码（agent-node:codex 跑的 commander 实现 bot bridge）| Claude Code 官方 plugin (`telegram@claude-plugins-official`) |
+| 适合场景 | 多 agent 协作 + Telegram 指挥（产品演示）| 单 agent 加 Telegram 通道（日常使用）|
+
+---
+
+## 其他 runtime 进展
+
+| Runtime | 当前 | 状态 |
+|---|---|---|
+| `claude-code-cli` | ✅ 本案例 | 已 work |
+| `claude-agent-sdk` | ❌ | [RFC-002](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-002-channel-bind-cli.md) Phase 1 — agent-node 加 `telegram-bridge` worker，targeting v0.9+ |
+| `codex-sdk` | ❌ | RFC-002 Phase 2 — 复用 Phase 1 bridge |
+
+为什么 SDK 不能复用 claude-code-cli 路径：claude-code-cli 走的是 Claude Code CLI 子进程，CLI 自带 plugin 机制；SDK runtime 是 anet 直接调 `@anthropic-ai/claude-agent-sdk` / `@openai/codex-sdk`，没有 plugin 钩子，得在 anet 这边写 telegram bridge。RFC-002 给了完整设计。
+
+---
+
+## 故障排查速查表
+
+| 症状 | 检查 | 解决 |
+|---|---|---|
+| `anet channel add` 报 `Node not found` | `anet node ls` | 用正确 node id/name |
+| `anet node start` 报 `plugin not found` | `claude plugin list` | 跑 0.2 安装 plugin |
+| `anet node start` 后 `claude: command not found` | `which claude` | `npm i -g @anthropic-ai/claude-code` |
+| Telegram 发消息无响应 | `anet node ls` 看 STATUS | offline 看 logs 找原因 |
+| 收到 `409 Conflict` | `ps aux \| grep claude` | 停别的占用该 bot 的进程 |
+| 收到 `401 Unauthorized` | `curl api.telegram.org/bot<tok>/getMe` | bot token 失效，BotFather 重新拿 |
+| 不在白名单的人发能 ignore，但**我**自己发也 ignore | 比对 `access.json.allowFrom` vs `@userinfobot` 给的 ID | 改 access.json 加正确 ID 重启 |
+
+---
+
+## 下一步
+
+- [Channel 概念](/guide/channels) — Channel 整体设计
+- [Agent Node](/guide/agent-node) — 节点配置完整字段
+- [辩论赛 Demo](/cases/debate) — 6 agent 内置编排（不接 Telegram）
+- [军团编队](/cases/telegram-squad) — Docker Compose 完整 Telegram squad
+- [RFC-002 Channel-Bind CLI](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-002-channel-bind-cli.md) — SDK runtime 的 Telegram bridge 设计 (v0.9+)
+- [issue #14](https://github.com/sleep2agi/agent-network/issues/14) — 本案例追踪 issue

--- a/docs-site/docs/en/cases/telegram-bind-claude-code-cli.md
+++ b/docs-site/docs/en/cases/telegram-bind-claude-code-cli.md
@@ -1,0 +1,642 @@
+# Bind Telegram to an Existing Node (claude-code-cli runtime) — Detailed Walkthrough
+
+Wire a running `claude-code-cli` node to Telegram — you DM the bot, the bot forwards messages to Claude Code, Claude Code replies (with its full toolset: bash / file ops / MCP). This walkthrough gives **expected output + on-disk files + error diagnosis for every step**.
+
+> [!IMPORTANT]
+> **Scope today**: `claude-code-cli` runtime only. `claude-agent-sdk` / `codex-sdk` Telegram bridge is scheduled in [RFC-002 Channel-Bind CLI](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-002-channel-bind-cli.md) Phase 1, targeting v0.9+.
+
+| Info | Value |
+|---|---|
+| Estimated time | 5-10 minutes (includes first-time plugin install) |
+| Prerequisite | A node running with `claude-code-cli` runtime (hello-world demo uses `claude-agent-sdk` — different runtime; if no node yet, see [Getting started](/en/guide/getting-started)) |
+| anet version | ≥ 2.1.5 (latest) or ≥ 2.1.7-preview.0 (preview) |
+| Claude Code CLI version | ≥ 2.x (needs `--channels plugin:xxx@yyy` syntax support) |
+
+---
+
+## Big picture
+
+```
+You →─→  @BotFather (Telegram)  →─→  bot token
+        @userinfobot (Telegram)  →─→  your user id
+                                       ↓
+        claude plugin install telegram@claude-plugins-official
+        anet channel add telegram <node> --bot-token <tok> --allow <user-id>
+        anet node stop <node> && anet node start <node>
+                                       ↓
+        Telegram DM ─→ bot polling ─→ Claude Code ─→ bot reply
+```
+
+---
+
+## Step 0 — Make sure the Claude Code Telegram plugin is installed
+
+anet wires Telegram to a claude-code-cli node by spawning `claude` with `--channels plugin:telegram@claude-plugins-official`, letting Claude Code's own channel plugin system take over. **The plugin must be installed in your `claude` CLI once** (user scope, shared across all projects).
+
+### 0.1 Check if it's installed
+
+```bash
+claude plugin list | grep telegram
+```
+
+**Installed**:
+
+```
+telegram@claude-plugins-official  user   /home/<user>/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6  installed: 2026-03-22
+```
+
+Skip to [Step 1](#step-1-—-get-bot-token--telegram-user-id).
+
+**Not installed** (empty output / `plugin not found`): continue with 0.2.
+
+### 0.2 Install the plugin
+
+```bash
+claude plugin install telegram@claude-plugins-official
+```
+
+Expected output:
+
+```
+Fetching from marketplace claude-plugins-official...
+Resolving telegram@latest → 0.0.6
+Downloading ~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6/...
+Verifying...
+✓ installed: telegram@claude-plugins-official (0.0.6, user scope)
+```
+
+On-disk layout:
+
+```
+~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6/
+├── plugin.json       # metadata
+├── server.ts         # MCP server (Telegram bot polling main loop)
+├── ACCESS.md         # permission model docs
+├── README.md
+├── package.json
+├── bun.lock
+├── node_modules/
+└── skills/           # MCP skills definitions
+```
+
+### 0.3 Verify install success
+
+```bash
+claude plugin details telegram@claude-plugins-official
+```
+
+Output includes:
+
+```
+Plugin: telegram@claude-plugins-official
+Version: 0.0.6
+Scope: user
+Install path: ~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6
+Components: 1 MCP server (channel), N skills
+```
+
+**Plugin is installed.** This is a one-time setup — one machine, one install, shared by every anet node.
+
+> [!TIP]
+> Plugin update: `claude plugin update telegram@claude-plugins-official`. anet doesn't pin a specific version — it follows the claude CLI's own update cadence.
+
+---
+
+## Step 1 — Get Bot Token + Telegram User ID
+
+You need two things:
+
+### 1.1 Create the bot (`@BotFather`)
+
+Open Telegram, search [@BotFather](https://t.me/BotFather) (blue checkmark, official Telegram bot):
+
+```
+You:        /newbot
+BotFather:  Alright, a new bot. How are we going to call it?
+            Please choose a name for your bot.
+You:        anet-test-bot          ← display name
+BotFather:  Good. Now let's choose a username for your bot.
+            It must end in `bot`.
+You:        anet_test_bot          ← unique username
+BotFather:  Done! Congratulations on your new bot.
+            ...
+            Use this token to access the HTTP API:
+            123456789:AAEhBP_XYZxyz...   ← ★ this is your bot token
+            ...
+```
+
+Copy the token (format `<bot-id>:<secret>`).
+
+> [!WARNING]
+> **Token is a secret**: it's effectively the bot's password. Do not:
+> - Paste into GitHub issues / PRs
+> - Screenshot to group chats
+> - Write to git-tracked files
+> - Upload to any public service
+>
+> If the token leaks, go back to BotFather → `/token` → pick your bot → `Revoke current token`.
+
+### 1.2 Get your numeric Telegram User ID (`@userinfobot`)
+
+Open [@userinfobot](https://t.me/userinfobot):
+
+```
+You:           /start
+userinfobot:   👋 Hi User Name!
+               🆔 Id: 7612221352          ← ★ this is your numeric user ID
+               👤 Username: @your_handle
+               🌐 Language: en
+```
+
+Copy the number (**do not copy `@username`** — anet's allowlist uses numeric IDs).
+
+> [!NOTE]
+> Your numeric Telegram user ID is globally unique and immutable. Changing your username or display name does not change it.
+
+---
+
+## Step 2 — Confirm target node runtime
+
+```bash
+anet node ls
+```
+
+Expected output (excerpt):
+
+```
+Node Status:
+
+  ALIAS         RUNTIME              MODEL                  STATUS   SSE   LAST SEEN
+  my-bot        claude-code-cli      claude-sonnet-4-6      idle     ✓     2s ago
+  translator    claude-agent-sdk     MiniMax-M2.7           idle     ✓     5s ago
+  coder         codex-sdk            gpt-5-codex            offline  ✗     2h ago
+```
+
+Find the node you want to bind Telegram to, confirm its `RUNTIME` column **is `claude-code-cli`**.
+
+| Node runtime | Applicable to this case? |
+|---|---|
+| `claude-code-cli` | ✅ Yes |
+| `claude-agent-sdk` | ❌ Wait for v0.9+ (RFC-002 P1) |
+| `codex-sdk` | ❌ Wait for v0.9+ (RFC-002 P2) |
+
+If your node uses an SDK runtime and you want Telegram, use [`demos/codex-telegram-squad`](https://github.com/sleep2agi/agent-network/tree/main/demos/codex-telegram-squad) (Docker Compose full-stack) or wait for v0.9.
+
+No node yet? See [Hello World](/en/cases/hello-world), pick `claude-code-cli` runtime:
+
+```bash
+anet node create my-bot --runtime claude-code-cli
+```
+
+---
+
+## Step 3 — Bind the Telegram channel
+
+```bash
+anet channel add telegram my-bot \
+  --bot-token 123456789:AAEhBP_XYZxyz... \
+  --allow 7612221352
+```
+
+Full argument reference:
+
+| Argument | Required | Description | Example |
+|---|---|---|---|
+| `<type>` | ✓ | First positional. Today only `telegram`. | `telegram` |
+| `<node-id>` | ✓ | Second positional. Accepts `node_name` (human-readable) or `node_id` (`n_a1b2c3d4`). | `my-bot` |
+| `--bot-token <tok>` | ✓ | Telegram bot token (from @BotFather). | `123456789:AAEhBP...` |
+| `--allow <user-id>` | ✓ | Your numeric Telegram user ID (first entry of the access.json allowlist). | `7612221352` |
+
+> [!TIP]
+> **Fully interactive**: omit all flags and the command prompts for each value — better for keeping sensitive tokens out of shell history:
+>
+> ```bash
+> anet channel add telegram my-bot
+> # → Telegram Bot Token: <hidden input>
+> # → Allow User ID (run @userinfobot for the numeric ID): <input>
+> ```
+
+### 3.1 Expected output
+
+```
+Telegram Bot Token: 123456789:AAEhBP_XYZxyz...
+Allow User ID (run @userinfobot for the numeric ID): 7612221352
+
+✅ telegram channel added to "my-bot"
+   /home/<user>/.anet/nodes/n_abc12345/channels/telegram/
+   config.json updated
+```
+
+### 3.2 Errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Node "my-bot" not found. Create it first: anet node create my-bot ...` | Wrong node id/name or node doesn't exist | `anet node ls` to find the correct name |
+| `P0 only supports telegram channels. Unsupported type: <X>` | First positional is not `telegram` | Use `telegram` |
+| `Error: bot-token and allow required` | Empty interactive input | Re-run, fill in properly |
+| `EACCES: permission denied, mkdir ...` | `.anet/nodes/` directory ownership | `chown -R $USER .anet` |
+
+---
+
+## Step 4 — Verify on-disk configuration
+
+### 4.1 List channels via `anet channel ls`
+
+```bash
+anet channel ls my-bot
+```
+
+Expected output:
+
+```
+Node Channels:
+
+  n_abc12345 (my-bot)   telegram     allow: 7612221352
+```
+
+### 4.2 Inspect on-disk files directly
+
+```bash
+ls -la ~/.anet/nodes/n_abc12345/channels/telegram/
+```
+
+```
+total 16
+drwxr-xr-x 3 user user 4096 May 12 10:00 .
+drwxr-xr-x 3 user user 4096 May 12 10:00 ..
+-rw-------  1 user user   52 May 12 10:00 .env             ← chmod 600 ✓
+-rw-r--r--  1 user user  142 May 12 10:00 access.json
+drwxr-xr-x 2 user user 4096 May 12 10:00 inbox            ← plugin message queue dir
+```
+
+File contents:
+
+```bash
+cat ~/.anet/nodes/n_abc12345/channels/telegram/.env
+```
+
+```
+TELEGRAM_BOT_TOKEN=123456789:AAEhBP_XYZxyz...
+```
+
+```bash
+cat ~/.anet/nodes/n_abc12345/channels/telegram/access.json | python3 -m json.tool
+```
+
+```json
+{
+  "dmPolicy": "allowlist",
+  "allowFrom": [
+    "7612221352"
+  ],
+  "groups": {},
+  "pending": {}
+}
+```
+
+**access.json field semantics**:
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `dmPolicy` | `"allowlist"` / `"deny-all"` / `"allow-all"` | `"allowlist"` | DM admission policy. `allowlist` = only `allowFrom` listed IDs |
+| `allowFrom` | `string[]` (numeric user IDs) | `[<--allow arg>]` | Private chat allowlist |
+| `groups` | `{ <chat_id>: "active" \| "passive" \| "deny" }` | `{}` | Group chat rules. Empty object = deny all groups by default |
+| `pending` | `object` | `{}` | Internal plugin state — don't touch |
+
+### 4.3 Check `channels` array in node `config.json`
+
+```bash
+cat ~/.anet/nodes/n_abc12345/config.json | python3 -m json.tool | grep -A 5 channels
+```
+
+Should contain:
+
+```json
+    "channels": [
+        "server:commhub",
+        "telegram"
+    ],
+```
+
+> [!NOTE]
+> `"server:commhub"` is the commhub channel (agent ↔ hub bond, included by default); telegram is parallel to it. Both channels run concurrently inside the same `claude` process.
+
+---
+
+## Step 5 — Restart the node so Telegram channel takes effect
+
+> [!WARNING]
+> The current implementation does **not hot-inject** channels. The node must stop + start to apply telegram. This is an RFC-002 edge case to be improved in v0.9+.
+
+### 5.1 Stop the old process
+
+```bash
+anet node stop my-bot
+```
+
+Expected output:
+
+```
+[anet] Stopping my-bot...
+[anet] Sent SIGTERM to PID 12345
+[anet] my-bot stopped
+```
+
+### 5.2 Start the new process (with telegram channel)
+
+```bash
+anet node start my-bot
+```
+
+Expected output (key lines):
+
+```
+[anet] Starting my-bot (runtime=claude-code-cli)...
+[anet] Spawning: claude --dangerously-skip-permissions \
+                       --dangerously-load-development-channels server:commhub \
+                       --channels plugin:telegram@claude-plugins-official \
+                       --teammate-mode in-process \
+                       --resume <uuid>  (or --session-id <uuid>) \
+                       -n my-bot
+[anet] env: COMMHUB_URL, COMMHUB_TOKEN, TELEGRAM_STATE_DIR=/home/<user>/.anet/nodes/n_abc12345/channels/telegram, ...
+[anet] Claude Code session pinned: a1b2c3d4...
+[my-bot]  SSE connected
+[my-bot]  Telegram plugin: polling started (bot @anet_test_bot, allow 7612221352)
+```
+
+**Key verify items**:
+
+1. ✅ The claude command line includes `--channels plugin:telegram@claude-plugins-official`
+2. ✅ Env var `TELEGRAM_STATE_DIR` points at the channels/telegram dir
+3. ✅ Telegram plugin starts polling (exact log line format may vary by plugin version)
+
+### 5.3 Error diagnosis
+
+| Error | Cause | Fix |
+|---|---|---|
+| `claude: command not found` | Claude Code CLI not on PATH | `npm i -g @anthropic-ai/claude-code` |
+| `plugin telegram@claude-plugins-official not found` | Skipped Step 0 | Go back, run `claude plugin install telegram@claude-plugins-official` |
+| `TELEGRAM_BOT_TOKEN env var missing` | `.env` not generated / not read | `ls -la ~/.anet/nodes/<node>/channels/telegram/.env`; re-run `anet channel add telegram` if missing |
+| `Telegram getUpdates: 401 Unauthorized` | Bot token wrong / revoked | Go to BotFather `/token`, re-issue, re-run `anet channel add telegram` to overwrite |
+| `Telegram getUpdates: 409 Conflict` | Same bot token also polling in another process | Stop the other process; one bot token = one polling process |
+
+---
+
+## Step 6 — DM the bot from Telegram
+
+In Telegram, search the bot username (`@anet_test_bot`), tap `Start`, then send a message:
+
+```
+You:    Count from 1 to 10
+Bot:    1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        (actual reply content depends on what Claude Code produces)
+```
+
+Behind the scenes:
+
+1. Telegram plugin receives the update.message
+2. Verifies `from.id == 7612221352` (allowlist) — passes
+3. Feeds the message content into claude's main loop
+4. Claude Code processes (may call tools, write files, run bash)
+5. After processing, plugin calls Telegram `sendMessage` to reply
+
+### 6.1 No reply, what to check
+
+In rough probability order:
+
+**1. You're not in the allowlist**
+
+If you DM from a different Telegram account it's silently dropped. Re-confirm your current user ID with `@userinfobot`, compare to access.json:
+
+```bash
+cat ~/.anet/nodes/<node-id>/channels/telegram/access.json | python3 -m json.tool
+```
+
+```json
+{
+  "allowFrom": ["7612221352"]   ← must include the ID you're DM-ing from
+}
+```
+
+If mismatched:
+
+```bash
+anet channel add telegram <node-id> \
+  --bot-token <same-token> \
+  --allow <your-correct-id>
+# Restart
+anet node stop <node-id> && anet node start <node-id>
+```
+
+**2. Node is offline**
+
+```bash
+anet node ls | grep <node-id>
+```
+
+`STATUS` not `idle` / `working` → offline. Tail logs:
+
+```bash
+anet logs <node-id> | tail -30
+```
+
+**3. Plugin polling stuck**
+
+```bash
+anet logs <node-id> | grep -i "telegram\|polling\|getUpdates"
+```
+
+Normally a polling log line every few seconds. If silent, plugin may have a bug — `claude plugin update telegram@claude-plugins-official` and retry.
+
+**4. Bot token revoked by you/someone**
+
+```bash
+curl "https://api.telegram.org/bot<your-token>/getMe"
+```
+
+Healthy returns bot info JSON; `{"ok": false, "error_code": 401}` means the token is dead. Go to BotFather, revoke + reissue.
+
+**5. Bot is polling in another process too**
+
+Telegram allows only one polling process per bot, otherwise the two processes **fight** for messages (each message lands in one). Check:
+
+```bash
+ps aux | grep "telegram" | grep -v grep
+```
+
+Should be exactly one claude process anet started using this bot. Stop the others.
+
+---
+
+## Advanced
+
+### A. Accept group chats (deny by default)
+
+`access.json`'s `groups: {}` denies all group chats by default. To accept a group:
+
+```bash
+# Get the group chat_id (forward any group message to @userinfobot to get the chat id)
+# Suppose chat_id = -1001234567890
+
+# Manually edit access.json
+python3 -c "
+import json
+p = '/home/<user>/.anet/nodes/<node-id>/channels/telegram/access.json'
+d = json.load(open(p))
+d['groups']['-1001234567890'] = 'active'
+json.dump(d, open(p, 'w'), indent=2)
+print('done')
+"
+
+# Restart
+anet node stop <node-id> && anet node start <node-id>
+```
+
+`groups` field values:
+
+| Value | Behavior |
+|---|---|
+| `"active"` | Bot responds to all @mentions in the group |
+| `"passive"` | Bot only responds to `/command` |
+| `"deny"` | Reject (default behavior, but explicit also works) |
+
+### B. Multi-user allowlist
+
+Team sharing a single bot:
+
+```bash
+# Add the first person via the CLI
+anet channel add telegram <node-id> --bot-token <tok> --allow 7612221352
+
+# Add a second person — edit access.json directly (CLI doesn't take multiple --allow)
+python3 -c "
+import json
+p = '/home/<user>/.anet/nodes/<node-id>/channels/telegram/access.json'
+d = json.load(open(p))
+if '9988776655' not in d['allowFrom']:
+    d['allowFrom'].append('9988776655')
+json.dump(d, open(p, 'w'), indent=2)
+"
+
+anet node stop <node-id> && anet node start <node-id>
+```
+
+### C. Rotate the bot token
+
+```bash
+# Just re-run the add command to overwrite
+anet channel add telegram <node-id> \
+  --bot-token <new-token> \
+  --allow <user-id>
+# Restart
+anet node stop <node-id> && anet node start <node-id>
+```
+
+Don't forget to revoke the old token in BotFather (so a leak of the old one is useless).
+
+### D. Unbind Telegram
+
+```bash
+# 1. Remove "telegram" from the channels array in config.json
+python3 -c "
+import json
+p = '/home/<user>/.anet/nodes/<node-id>/config.json'
+d = json.load(open(p))
+d['channels'] = [c for c in d['channels'] if c != 'telegram']
+json.dump(d, open(p, 'w'), indent=2)
+"
+
+# 2. Delete the channels/telegram directory
+rm -rf /home/<user>/.anet/nodes/<node-id>/channels/telegram
+
+# 3. Restart
+anet node stop <node-id> && anet node start <node-id>
+```
+
+### E. Multiple nodes sharing one bot (**not recommended**)
+
+Telegram allows only one polling process per bot. Multiple anet nodes using the same bot token will **fight for messages** — unpredictable.
+
+**Correct approach**: one bot per node (BotFather lets you create multiple bots).
+
+### F. Does changing my password affect the telegram channel?
+
+**No.** See [issue #17 detailed answer](https://github.com/sleep2agi/agent-network/issues/17#issuecomment-4428789875). Changing the user password only revokes `utok_`; the node uses `ntok_`, which is unaffected; the SSE long-connection stays up; the Telegram plugin keeps polling.
+
+---
+
+## Security considerations
+
+### Token storage
+
+- `.env` file is `chmod 600` (only the owning user can read)
+- `.anet/` is in `.gitignore` (won't enter git)
+- Bot token is **not uploaded to the hub** (purely agent-local)
+
+### Allowlist enforcement
+
+- A Telegram user not in `allowFrom` DM-ing the bot → **silently dropped** (no error reply, no audit log entry)
+- This is a deliberate trade-off: not replying with an error avoids leaking that anet runs the bot (to defeat reconnaissance)
+
+### Scope of bot's authority
+
+- Claude Code is launched with `--dangerously-skip-permissions` — tool calls won't ask for confirmation
+- Any user in `allowFrom` can make the bot run **arbitrary bash commands / modify any files** (Claude has Bash / Write / Edit tools)
+- **Production deployments**:
+  - Run this node in a disposable / dedicated working directory (NOT `$HOME`)
+  - Keep `allowFrom` strictly limited to trusted users
+  - Consider `--tools` to restrict Claude Code's tool surface (drop Bash / Write)
+
+```bash
+# Restrict tools at node-create time
+anet node create my-bot --runtime claude-code-cli \
+  --tools "Read,Glob,Grep,WebFetch"   # read + network only, no Bash/Write/Edit
+```
+
+---
+
+## Differences from `demos/codex-telegram-squad/`
+
+| | `codex-telegram-squad` demo | This case |
+|---|---|---|
+| Deployment | Docker Compose: hub + multiple workers + telegram bot in one stack | Add Telegram to an existing anet-installed node |
+| Runtime | Multiple `codex-sdk` workers + 1 `claude-agent-sdk` commander | Single `claude-code-cli` node |
+| Telegram bridge layer | Demo-internal code (agent-node:codex commander implements bot bridge) | Claude Code's official plugin (`telegram@claude-plugins-official`) |
+| Scenario | Multi-agent collaboration + Telegram command center (product showcase) | Single agent + Telegram channel (everyday use) |
+
+---
+
+## Other runtimes
+
+| Runtime | Today | Status |
+|---|---|---|
+| `claude-code-cli` | ✅ this case | Works |
+| `claude-agent-sdk` | ❌ | [RFC-002](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-002-channel-bind-cli.md) Phase 1 — agent-node gets a `telegram-bridge` worker, targeting v0.9+ |
+| `codex-sdk` | ❌ | RFC-002 Phase 2 — reuses the Phase 1 bridge |
+
+Why the SDK runtimes can't reuse the claude-code-cli path: claude-code-cli spawns the Claude Code CLI subprocess, and that CLI has the plugin protocol built in. The SDK runtimes are direct calls into `@anthropic-ai/claude-agent-sdk` / `@openai/codex-sdk` — no plugin hooks. To get Telegram into those runtimes we need a bridge worker in anet itself. RFC-002 has the full design.
+
+---
+
+## Troubleshooting cheat sheet
+
+| Symptom | Check | Fix |
+|---|---|---|
+| `anet channel add` says `Node not found` | `anet node ls` | Use the correct node id/name |
+| `anet node start` says `plugin not found` | `claude plugin list` | Run 0.2 to install the plugin |
+| `anet node start` says `claude: command not found` | `which claude` | `npm i -g @anthropic-ai/claude-code` |
+| Telegram DM gets no reply | `anet node ls` to check STATUS | If offline, check logs |
+| `409 Conflict` from Telegram | `ps aux \| grep claude` | Stop the other process polling this bot |
+| `401 Unauthorized` from Telegram | `curl api.telegram.org/bot<tok>/getMe` | Token dead — re-issue via BotFather |
+| Others ignored as expected, but **my own** DMs also ignored | Compare `access.json.allowFrom` vs ID from `@userinfobot` | Edit access.json with the right ID, restart |
+
+---
+
+## Next steps
+
+- [Channels concept](/en/guide/channels) — overall channel design
+- [Agent Node](/en/guide/agent-node) — full node config fields
+- [Debate Demo](/en/cases/debate) — built-in 6-agent orchestration (no Telegram)
+- [Telegram Squad](/en/cases/telegram-squad) — full Docker Compose Telegram squad
+- [RFC-002 Channel-Bind CLI](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-002-channel-bind-cli.md) — Telegram bridge design for SDK runtimes (v0.9+)
+- [issue #14](https://github.com/sleep2agi/agent-network/issues/14) — tracking issue


### PR DESCRIPTION
## Why

Refs #14

issue #14 要求"对已经存在的节点用 anet 命令绑定 Telegram，优先 claude-code-cli"。本 PR 只处理 **claude-code-cli runtime** 路径（issue #14 的 P0 子集），不涉及 SDK 两个 runtime（那部分在 [PR #20 RFC-002](https://github.com/sleep2agi/agent-network/pull/20) Phase 1 设计中，targeting v0.9+）。

调研发现命令路径**已实现**：
- `anet channel add telegram <node-id> --bot-token <tok> --allow <user-id>` (`agent-network/bin/cli.ts:2570`)
- spawn 注入 `--channels plugin:telegram@claude-plugins-official` + `TELEGRAM_STATE_DIR` env (`cli.ts:1636-1648`)
- 落盘 `~/.anet/nodes/<id>/channels/telegram/{access.json, .env, inbox/}` (`cli.ts:989`)

**缺的是用户教程**。本 PR 仅补文档，不动代码。

## What

新增详细操作手册（ZH + EN，~640 行 each）：
- `docs-site/docs/cases/telegram-bind-claude-code-cli.md`
- `docs-site/docs/en/cases/telegram-bind-claude-code-cli.md`

覆盖 6 大步骤，每步给：
- 预期命令输出
- 落盘文件内容（`.env` / `access.json` / `config.json` 改动 / spawn args）
- 错误诊断表（每种 error message → 解决）

加章节：
- 步骤 0：Claude Code Telegram plugin 安装（`claude plugin install telegram@claude-plugins-official`，user-scope 一次装）
- 步骤 1-2：拿 bot token + user id + 确认 runtime
- 步骤 3-4：`anet channel add telegram` + 验证落盘
- 步骤 5-6：重启节点 + Telegram DM 实测
- 高级用法：多人白名单 / 群聊 / token rotate / unbind / 工具限制
- 安全考虑：`dangerouslySkipPermissions` 取舍 + allowFrom 强制 + 一次性 workdir 建议
- 跟 `demos/codex-telegram-squad` 区别表
- 其他 runtime 状态（SDK 两个引 RFC-002）
- 故障排查速查表

`docs-site/docs/.vitepress/config.ts` ZH + EN sidebar `案例` 分类下加新链接。

## How to verify

```bash
cd docs-site && npm run build
# 应该 "build complete in Xs"，无 dead link
```

浏览器打开 anet.sh `/cases/telegram-bind-claude-code-cli`，6 步走全部可读。

**用户视角端到端实测**（**这步留给 Vincent 自测**，PR 没等到 token 不阻塞 doc review）：

1. 跟着 step 0 装 plugin
2. 跟着 step 1 拿 bot token + 自己 user id（私下，不进 PR）
3. step 3 `anet channel add telegram <你的-node> --bot-token <tok> --allow <id>`
4. step 5 重启节点
5. step 6 DM bot 看是否回复

Vincent 自测 / 通信牛 跟着文档跑一遍发现偏差 → 直接在 PR comment 反馈，我 amend 修文档。

## Test evidence

```
build complete in 54.53s.
```

无 dead link。EN 镜像跟 ZH 内容对齐（6 步 + 高级用法 + 安全 + cheat sheet 全镜像）。

**未做端到端实测**：跟 N站马 要 telegram bot token 被她合理拒绝（credential 不走 commhub channel 链式转述 — 这是 OSS 安全红线，她做得对）。文档基于 cli.ts 源码 review + 本机已装 plugin 的实际行为推导，但**真 Telegram bot 发消息那一环节**没真跑过 → 标 "Vincent 自测" 验收门。

## Checklist

- [x] Relevant tests pass locally (docs build green)
- [x] `docs-site/docs/changelog.md` updated (n/a — 不是 user-visible behavior 改动，只是新教程)
- [x] Docs synced (这就是 doc 本身)
- [x] No secrets / tokens / private IPs / `/home/<user>` paths in the diff（所有 path 都是 `<user>` placeholder + 文档内 example bot token `123456789:AAEhBP_XYZxyz...` 是 telegram docs 标准 placeholder）
- [x] Conventional Commits (`docs:`)
- [x] No `Co-Authored-By: Claude*` footer
- [x] Issue linked via `Refs #14`（不 Closes，因为 issue #14 还含 SDK runtime 部分由 RFC-002 PR #20 跟踪）

## 关联 PR / Issue

- PR #20 — RFC-002 Channel-Bind CLI 设计稿（含 SDK runtime 的 telegram-bridge worker，本 PR 不实施）
- Issue #14 — Telegram 接入命令 tracking issue（保留 open，等 RFC-002 P1 P2 完成再 close）
- Issue #15 — PR-based pipeline meta（本 PR 是第二个走完整流程的实战 PR）
