### PR TITLE
chore: remove legacy 'anet quickstart' command (closes #45)

### DIFF
--- a/agent-network/README.md
+++ b/agent-network/README.md
@@ -125,7 +125,6 @@ anet init project                  # write .mcp.json + CLAUDE.md         [verifi
 
 Listed for transparency — these commands exist but are not part of the primary supported path.
 
-- `anet quickstart` — legacy v0.6 guided setup (still in code but not in docs); use `anet hub start` + `anet init` + `anet login` + `anet node create` instead.
 - `anet license` / `anet activate` — v0.6 legacy trial / pro-license commands. **No longer needed after Apache 2.0 OSS.** Hub still keeps a SQLite `licenses` table for backward-compat (creates a 14-day trial on first run). On `license_expired`, see [troubleshooting](https://anet.sh/en/troubleshooting).
 - `anet network create` / `anet network invite` / cross-user network sharing — code is in, no full E2E.
 - `anet channel add telegram|wechat|feishu` — channel code exists; only the Telegram-oriented paths are actively exercised.

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2836,145 +2836,6 @@ function timeAgo(dateStr: string): string {
   return `${Math.floor(diff / 86400000)}d`;
 }
 
-// ── quickstart ──
-
-async function quickstartCommand() {
-  console.log(`
-╔══════════════════════════════════════════════════╗
-║   🚀 anet quickstart — 3 分钟搭建 Agent 网络     ║
-╚══════════════════════════════════════════════════╝
-`);
-
-  const gc = loadGlobal();
-  const qsOpts = parseOpts();
-
-  // Step 1: Hub
-  if (!gc.hub) {
-    console.log("Step 1/4: CommHub Server");
-    console.log("  你需要一个 CommHub Server。两种方式:");
-    console.log("  a) 本机启动: 另开终端运行 bunx @sleep2agi/commhub-server");
-    console.log("  b) 连接远程: 输入服务器地址");
-    console.log();
-    const hubUrl = await ask("CommHub URL [http://127.0.0.1:9200]") || "http://127.0.0.1:9200";
-    gc.hub = hubUrl;
-    saveGlobal(gc);
-    console.log(`  ✅ Hub: ${hubUrl}\n`);
-  } else {
-    console.log(`Step 1/4: Hub ✅ ${gc.hub}\n`);
-  }
-
-  // Step 1.5: Check server is reachable
-  try {
-    const health = await fetch(`${gc.hub}/health`, { signal: AbortSignal.timeout(5000) }).then(r => r.json() as any).catch(() => null);
-    if (!health?.ok) {
-      console.log(`  ⚠ Server not reachable at ${gc.hub}`);
-      console.log(`  Make sure CommHub is running: bunx @sleep2agi/commhub-server`);
-      console.log(`  Or check the URL and try again.\n`);
-      return;
-    }
-    console.log(`  ✅ Server online (v${health.version || "?"})\n`);
-  } catch {
-    console.log(`  ⚠ Cannot connect to ${gc.hub}. Start server first.\n`);
-    return;
-  }
-
-  // Step 2: Register/Login
-  if (!gc.token || !gc.user) {
-    console.log("Step 2/4: 创建账号");
-    const username = qsOpts.username || qsOpts.user || await ask("用户名");
-    const password = qsOpts.password || qsOpts.pass || await ask("密码 (≥6位)");
-    closeRL();
-    if (!username || !password) { closeRL(); console.error("需要用户名和密码。用法: anet quickstart --username xxx --password xxx"); return; }
-
-    // Try register first, if exists then login
-    let res = await fetch(`${gc.hub}/api/auth/register`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username, password }),
-    }).then(r => r.json() as any).catch(() => null);
-
-    if (!res?.ok) {
-      // Try login
-      res = await fetch(`${gc.hub}/api/auth/login`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password }),
-      }).then(r => r.json() as any).catch(() => null);
-    }
-
-    if (!res?.ok) { closeRL(); console.error(`  ❌ 失败: ${res?.error || "无法连接"}`); return; }
-
-    gc.token = res.token;
-    gc.user = res.user;
-    const nets = await fetch(`${gc.hub}/api/networks`, { headers: { Authorization: `Bearer ${res.token}` } }).then(r => r.json() as any).catch(() => ({ networks: [] }));
-    if (nets.networks?.length > 0) {
-      gc.network_id = nets.networks[0].network_id;
-      gc.network_name = nets.networks[0].network_name;
-    }
-    saveGlobal(gc);
-    console.log(`  ✅ 登录成功: ${res.user.username}\n`);
-  } else {
-    console.log(`Step 2/4: 已登录 ✅ ${gc.user.username}\n`);
-  }
-
-  // Step 3: Create agent
-  console.log("Step 3/4: 创建你的第一个 Agent");
-  const agentName = qsOpts.agent || qsOpts.name || await ask("Agent 名称 [my-agent]") || "my-agent";
-  closeRL();
-
-  // Check if already exists
-  const existing = resolveNodeRef(agentName);
-  if (!existing) {
-    let runtime = qsOpts.runtime || "codex-sdk";
-    // Only show interactive selection if no runtime specified and TTY available
-    if (!qsOpts.runtime && process.stdin.isTTY) {
-      const runtimes = ["codex-sdk (GPT-5.4)", "http-api (MiniMax/OpenAI)", "claude-agent-sdk (Claude)"];
-      console.log("\n  Runtime 选择:");
-      runtimes.forEach((r, i) => console.log(`    ${i + 1}) ${r}`));
-      try {
-        const choice = await (async () => {
-          const { select: sel } = await import("@inquirer/prompts");
-          return sel({
-            message: "选择 Runtime:",
-            choices: [
-              { value: "codex-sdk", name: "codex-sdk (GPT-5.4) — 推荐" },
-              { value: "http-api", name: "http-api (MiniMax/OpenAI 兼容)" },
-              { value: "claude-agent-sdk", name: "claude-agent-sdk (Claude Code)" },
-            ],
-          });
-        })();
-        runtime = choice;
-      } catch {
-        // inquirer not available, use default
-      }
-    } else if (!qsOpts.runtime) {
-      console.log(`  Using default runtime: ${runtime}`);
-    }
-
-    const createArgs = ["create", agentName, "--runtime", runtime];
-    if (runtime === "codex-sdk") createArgs.push("--model", "gpt-5.4");
-    args.splice(0, args.length, ...createArgs);
-    await createCommand();
-  } else {
-    console.log(`  ✅ Agent "${agentName}" 已存在\n`);
-  }
-
-  // Step 4: Done!
-  console.log(`
-╔══════════════════════════════════════════════════╗
-║   🎉 设置完成！                                   ║
-╠══════════════════════════════════════════════════╣
-║                                                   ║
-║   启动 Agent:  anet node start ${agentName.padEnd(15)}   ║
-║   查看状态:    anet status                         ║
-║   查看任务:    anet tasks                          ║
-║   网络管理:    anet network ls                     ║
-║   系统诊断:    anet doctor                         ║
-║                                                   ║
-╚══════════════════════════════════════════════════╝
-`);
-}
-
 // ── register ──
 
 async function registerCommand() {
@@ -5236,7 +5097,19 @@ switch (command) {
   case "config": configShowCommand(); break;
   case "login": await loginCommand(); break;
   case "register": await registerCommand(); break;
-  case "quickstart": await quickstartCommand(); break;
+  case "quickstart": {
+    // Removed per issue #45. Print migration help and exit non-zero so users
+    // notice the breakage instead of silently failing.
+    console.error(`[anet] ⚠ 'anet quickstart' 已删除（per #45）。改用现代命令组合:
+  anet hub start          # 起 CommHub Server
+  anet setup              # 装 runtime deps + 选 runtime (wizard)
+  anet register           # 创建账号
+  anet login              # 登录
+  anet node create <name> # 创建 agent
+
+或一键 demo: cd demos/hello-world && docker compose up`);
+    process.exit(1);
+  }
   case "logout": logoutCommand(); break;
   case "whoami": await whoamiCommand(); break;
   case "network": await networkCommand(); break;

--- a/docs-site/docs/en/guide/cli.md
+++ b/docs-site/docs/en/guide/cli.md
@@ -18,7 +18,6 @@ After installation, the `anet` command is available globally.
 |------|------|------|
 | `anet init` | Configure hub address | verified |
 | `anet init project` | Configure Claude Code project (`project` is a literal subcommand, not a placeholder) | verified |
-| `anet quickstart` | One-shot interactive bootstrap: hub + dashboard + node | Experimental (no E2E; [getting-started](/en/guide/getting-started) recommends the 1–7 step-by-step path for better control) |
 
 ### Server Management
 

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -172,7 +172,6 @@ You can also do this in two commands: `anet init --hub http://<HUB-LAN-IP>:9200`
 :::
 
 ::: warning Not verified (treat as experimental)
-- `anet quickstart` — command still available in the CLI (one-shot hub + dashboard + node), but this guide recommends the step-by-step 1–7 above (more controllable, easier to debug); the quickstart path is not E2E covered.
 - `codex-sdk` runtime end-to-end.
 - `claude-code-cli` runtime end-to-end.
 - `anet license` / `anet activate` — v0.6 legacy trial commands, **no longer needed after Apache 2.0 OSS**. The current Hub still keeps a SQLite licenses table + creates a 14-day trial (checked on `send_task`); on `license_expired` see [troubleshooting](/en/troubleshooting).

--- a/docs-site/docs/guide/cli.md
+++ b/docs-site/docs/guide/cli.md
@@ -18,7 +18,6 @@ npm install -g @sleep2agi/agent-network
 |------|------|------|
 | `anet init` | 配置 hub 地址 | 已验证 |
 | `anet init project` | 配置 Claude Code 项目（`project` 是固定子命令，不是项目名占位符） | 已验证 |
-| `anet quickstart` | 一键起 hub + dashboard + node（交互式向导） | 实验性（E2E 未覆盖；[getting-started](/guide/getting-started) 推荐改用 1-7 step-by-step，更可控） |
 
 ### 服务器管理
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -176,7 +176,6 @@ anet node start remote-bot
 :::
 
 ::: warning 未验证（请自行评估）
-- `anet quickstart` —— 命令仍在 CLI 中可用（一键起 hub + dashboard + node），但本指南改推上面 1-7 步的 step-by-step（更可控、出问题好定位）；quickstart 路径 E2E 未覆盖
 - `codex-sdk` runtime 的端到端流程
 - `claude-code-cli` runtime 的端到端流程
 - `anet license` / `anet activate` —— v0.6 legacy trial 命令，**Apache 2.0 OSS 后不再需要**；当前 Hub 仍保留 SQLite licenses 表 + 14 天 trial 创建（送 `send_task` 时检查），命中 `license_expired` 见 [troubleshooting](/troubleshooting)


### PR DESCRIPTION
## Author & Helpers

**Author (Primary)**: 通信工程马

**Helpers**:
- 通信龙: dispatch + review (Option A confirm, scope contract)
- Vincent: issue raise (#45, telegram 4192+4193+4194)

**Tier review gate**: 通信龙 (Lead, post-onboarding 单审 OK，breaking change 加 doc 双语走 PR)

## Why

Closes #45

Vincent 4192 raise: "quickstart 彻底删了吧，内容都放到 demo 里面"

`anet quickstart` 是 v0.6 legacy 4 步 wizard，**功能跟现代命令组合 redundant**：

- Step 1: 配 hub URL (没起 hub，只检测健康)
- Step 2: register/login user
- Step 3: 创建 1 agent
- Step 4: 打印提示

现代命令 (`anet hub start + anet setup + anet register + anet login + anet node create`) 已 cover 全部功能 + 更可控 + 已 maintain。demos/hello-world docker-compose 已 cover "一键起 hub + agent" use case，新增 `demos/quickstart/` 会跟 hello-world 重叠 (per 调研 Option A 推荐 → 通信龙 confirm)。

## What

| 文件 | 改动 | 行 |
|------|------|---|
| `agent-network/bin/cli.ts` | 删 `quickstartCommand()` function (L2839-2976, 138 行) | -138 |
| `agent-network/bin/cli.ts` | dispatch case `"quickstart"` 改 deprecation message + `process.exit(1)` | -1 +13 |
| `agent-network/README.md` | 删 legacy `anet quickstart` 行 | -1 |
| `docs-site/docs/guide/cli.md` | ZH 删命令表 row | -1 |
| `docs-site/docs/en/guide/cli.md` | EN 删命令表 row | -1 |
| `docs-site/docs/guide/getting-started.md` | ZH 删未验证 bullet | -1 |
| `docs-site/docs/en/guide/getting-started.md` | EN 删 Not-verified bullet | -1 |

Total: 6 files, **+13 -145**

## Migration path (per bottom-up SOP)

老用户跑 `anet quickstart` 现在输出 **helpful deprecation message** + `exit(1)`（非 silent fail）:

```
[anet] ⚠ 'anet quickstart' 已删除（per #45）。改用现代命令组合:
  anet hub start          # 起 CommHub Server
  anet setup              # 装 runtime deps + 选 runtime (wizard)
  anet register           # 创建账号
  anet login              # 登录
  anet node create <name> # 创建 agent

或一键 demo: cd demos/hello-world && docker compose up
```

## What's NOT changed (Frozen archive per RELEASE-SOP.md)

历史 frozen 不动：
- `docs/changelog.md` / `evolution-log.md` / `claude-code-cleanup-review.md` / `design-*.md`
- `docs-site/docs/changelog.md` / `en/changelog.md`
- `docs-site/docs/v0.8.0/**`
- `docs-site/docs/.vitepress/dist/**` (build output，rebuild 会清)

`README.en.md` 顶部 `## 30-second quickstart` section header (general 名词 "快速入门") 跟 `anet quickstart` CLI 命令**无关**，section 内容是现代命令组合，**保留**。

## How to verify

```bash
# 1. typecheck
cd agent-network && bun install && npm run typecheck   # 应 no error

# 2. 验 deprecation message + exit code
bun bin/cli.ts quickstart; echo "exit=$?"
# 期望:
#   [anet] ⚠ 'anet quickstart' 已删除（per #45）。改用现代命令组合:
#   ...
#   或一键 demo: cd demos/hello-world && docker compose up
#   exit=1

# 3. grep verify 函数完全删除 (除 dispatch deprecation)
grep -nE "quickstartCommand|async function quickstart" bin/cli.ts
# 期望: 空 (function 已删，只剩 dispatch case "quickstart": 输出 message)

# 4. grep verify docs 提及全删 (排除 frozen archive)
grep -rln "quickstart" agent-network/ docs-site/docs/ 2>/dev/null \
  | grep -v ".vitepress/dist" \
  | grep -v "v0.8.0/" \
  | grep -v "changelog.md" \
  | grep -v "evolution-log\|claude-code-cleanup\|design-"
# 期望: agent-network/bin/cli.ts (deprecation message) only

# 5. README.en.md "30-second quickstart" section 保留确认
grep -nE "30-second quickstart" README.en.md
# 期望: L66 + L228 (section header + internal link, 保留 — 跟 CLI 命令无关)
```

## Test evidence

本地全跑通：
- ✅ `bun install` + `npm run typecheck` no error
- ✅ `bun bin/cli.ts quickstart` 输出 deprecation banner + `exit=1`
- ✅ `grep quickstartCommand` 空 (function 完全删)
- ✅ 6 files diff 干净，0 误删 frozen archive，0 误改 unrelated
- ✅ rebased on top of latest `origin/main`

## Checklist

- [x] Relevant tests pass locally (typecheck + cli runtime test)
- [ ] `docs-site/docs/changelog.md` updated — n/a (frozen archive 不动 per RELEASE-SOP.md，新版本发布时通信文档马 R 系列同步 changelog)
- [x] Docs synced (cli.md + getting-started.md ZH/EN 全 sync)
- [x] No secrets / tokens / private IPs / `/home/<user>` paths in the diff
- [x] Conventional Commits message (`chore:`)
- [x] **No `Co-Authored-By: Claude*` footer** (OSS rule)
- [x] **Attribution trailer** (`Author-Agent: 通信工程马` + `Helpers:`)
- [x] Issue linked via `Closes #45`