### PR TITLE
feat(cli): batch create primitive — anet create --batch + anet batch <verb> (refs #55)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -65,6 +65,8 @@
 
 ## 30-second quickstart
 
+> **Prereq:** Node.js ≥ 22.13.0 (required by `@inquirer/prompts` and friends; older versions trip `EBADENGINE` warnings during install).
+
 ```bash
 # Install one global package
 npm install -g @sleep2agi/agent-network

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@
 
 ## 30 秒上手
 
+> **前置**：Node.js ≥ 22.13.0（`@inquirer/prompts` 等依赖要求；老版本会触发 `EBADENGINE` warnings）。
+
 ```bash
 # 装一个全局包
 npm install -g @sleep2agi/agent-network

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1217,6 +1217,12 @@ Telegram setup:
 }
 
 async function createCommand(idOverride?: string) {
+  // Batch mode: `anet create --batch` enters the multi-node wizard
+  // (issue #55, Vincent 4335). All other create flows fall through to the
+  // existing single-node create path below.
+  if (!idOverride && args.includes("--batch")) {
+    return await createBatchWizardCommand();
+  }
   const id = idOverride || args[1];
   if (!id) return createInteractiveCommand();
   if (id.startsWith("--")) {
@@ -4837,6 +4843,9 @@ async function demoSciTeamCommand() {
   const isCleanup = args.includes("--cleanup");
   const lifecycleDir = opts.dir || join(home, "intern-s");
   if (isStop || isRestart || isCleanup) {
+    const flag = isStop ? "--stop" : isRestart ? "--restart" : "--cleanup";
+    const verb = isStop ? "stop" : isRestart ? "restart" : "cleanup";
+    console.warn(`[deprecated] 'anet demo sci-team ${flag}' is deprecated; use 'anet batch ${verb} sci-team' (will remove in next major).`);
     return sciTeamLifecycle({ dir: lifecycleDir, restart: isRestart, cleanup: isCleanup });
   }
 
@@ -4902,106 +4911,278 @@ async function demoSciTeamCommand() {
   console.log(`        综述方向:  ${direction}`);
   console.log(`        Runtime:   claude-agent-sdk + intern-s1-pro\n`);
 
-  mkdirSync(targetDir, { recursive: true });
-  const origCwd = process.cwd();
-  const createdAliases: string[] = [];
+  // sci-team is now a preset wrapper over the generic batch primitive
+  // (issue #55). The Intern URL + model + active-fan-out sciTeamPrompt
+  // template all stay locked here; createBatch handles the per-node
+  // mkdir + ensureNodeToken + saveProfile + tmux launch loop.
+  const result = await createBatch({
+    prefix: "研究员",
+    count,
+    workdir: targetDir,
+    workdirMode: "separate",
+    runtime: "claude-agent-sdk",
+    model: "intern-s1-pro",
+    baseUrl: "https://chat.intern-ai.org.cn",
+    apiKey: internApiKey,
+    systemPrompt: (role, index, total) => sciTeamPrompt(role, index, total, direction),
+    team: "sci-team",
+    leaderAlias: "研究Leader",
+  });
 
-  try {
-    for (let i = 1; i <= count; i++) {
-      const role: "leader" | "worker" = i === 1 ? "leader" : "worker";
-      const alias = role === "leader" ? "研究Leader" : `研究员${i - 1}号`;
-      const nodeDir = join(targetDir, `node${i}`);
-      mkdirSync(nodeDir, { recursive: true });
-      process.chdir(nodeDir);
-
-      // Build profile manually (skip createCommand to avoid interactive prompts
-      // and to thread sci-team metadata + Intern preset cleanly).
-      const profile: Profile = {
-        anet_version: "0.1.0",
-        node_id: generateNodeId(),
-        node_name: alias,
-        alias,
-        runtime: "claude-agent-sdk",
-        model: "intern-s1-pro",
-        ...(gc.network_id ? { network_id: gc.network_id } : {}),
-        channels: ["server:commhub"],
-        env: {
-          ANTHROPIC_BASE_URL: "https://chat.intern-ai.org.cn",
-          ANTHROPIC_AUTH_TOKEN: internApiKey,
-        },
-        flags: { dangerouslySkipPermissions: true },
-        systemPrompt: sciTeamPrompt(role, i - 1, count, direction),
-        team: "sci-team",
-        role,
-      };
-
-      try {
-        await ensureNodeToken(profile, alias);
-      } catch (e: any) {
-        console.error(`        ❌ ${alias.padEnd(14)} ntok_ 请求失败: ${e.message}`);
-        continue;
-      }
-      saveProfile(alias, profile);
-      createdAliases.push(alias);
-      console.log(`        ✓ ${alias.padEnd(14)} (${role.padEnd(7)})  ${nodeDir}`);
-    }
-  } finally {
-    process.chdir(origCwd);
-  }
-
-  if (createdAliases.length === 0) {
+  if (result.createdAliases.length === 0) {
     console.error("\n[anet] 没有任何 node 创建成功，退出。");
     return;
-  }
-
-  // ── Launch via tmux ──
-  console.log(`\n[anet] 启动 ${createdAliases.length} 个 tmux session...`);
-  try {
-    for (let i = 0; i < createdAliases.length; i++) {
-      const alias = createdAliases[i];
-      const nodeDir = join(targetDir, `node${i + 1}`);
-      const sessName = `sci-team-${alias}`;
-      killTmuxSession(sessName);
-      try {
-        process.chdir(nodeDir);
-        startNodeTmuxSession(sessName, alias);
-        console.log(`        ✓ ${sessName}`);
-      } catch (e: any) {
-        console.error(`        ❌ tmux ${alias}: ${e.message}`);
-      }
-    }
-  } finally {
-    process.chdir(origCwd);
   }
 
   console.log(`\n[anet] 🏁 科研军团 ready.`);
   console.log(`        Dashboard:    anet hub dashboard  (or open ${gc.hub.replace(":9200", ":3000")})`);
   console.log(`        派任务:       commhub_send_task --alias 研究Leader --task "<研究 prompt>"`);
   console.log(`        Phase 1 note: leader 只是 placeholder echo, RFC-008 Phase 2 接入智能 fan-out`);
-  console.log(`        Cleanup:      anet demo sci-team --cleanup --dir ${targetDir}`);
+  console.log(`        Stop:         anet batch stop sci-team`);
+  console.log(`        Cleanup:      anet batch cleanup sci-team --workdir ${targetDir}`);
   console.log();
 }
 
+// Wrapper preserved for the `anet demo sci-team --stop|--restart|--cleanup`
+// flag path (deprecated, see warning in demoSciTeamCommand). New users should
+// use `anet batch <verb> sci-team` (the canonical lifecycle command). The
+// implementation now delegates to batchLifecycle() so behavior stays in sync.
 function sciTeamLifecycle(opts: { dir: string; restart: boolean; cleanup: boolean }) {
   const { dir, restart, cleanup } = opts;
-  if (!existsSync(dir)) {
-    console.error(`[anet] 工作目录不存在: ${dir}`);
+  if (restart) {
+    return batchLifecycle({ prefix: "sci-team", verb: "restart", workdir: dir });
+  }
+  if (cleanup) {
+    return batchLifecycle({ prefix: "sci-team", verb: "cleanup", workdir: dir });
+  }
+  return batchLifecycle({ prefix: "sci-team", verb: "stop", workdir: dir });
+}
+
+// ── Batch primitive (issue #55) ──
+//
+// `createBatch` is the generic N-node spawn primitive that both
+// `anet create --batch` (user-facing wizard) and `anet demo sci-team`
+// (preset wrapper) call into. It abstracts the pattern PR #53 first wired
+// up for sci-team: per-node mkdir + Profile build + ensureNodeToken +
+// saveProfile + tmux session launch, with the original cwd restored in a
+// finally block.
+//
+// Vendor presets must stay in sync with the Vincent-verified list at
+// cli.ts L1116+ (1bc03c0 chain): adding a new preset here requires
+// per-vendor verify-with-real-call, not byte-copy (see
+// [[feedback_vendor_verify_before_hardcode]]).
+
+interface BatchOptions {
+  prefix: string;                // alias 前缀, e.g. "工程师" → 工程师1号..工程师N号
+  count: number;                 // node 数 (caller pre-clamps to spec range)
+  workdir: string;               // 父目录 (absolute path), e.g. /home/u/anet-team
+  workdirMode: "separate" | "shared";  // separate: workdir/node{i}/.anet/nodes/<alias>  | shared: workdir/.anet/nodes/<alias>
+  runtime: string;               // claude-agent-sdk / codex-sdk / claude-code-cli / http-api
+  model?: string;                // e.g. intern-s1-pro / MiniMax-M2.7 / claude-sonnet-4-6
+  baseUrl?: string;              // ANTHROPIC_BASE_URL value (omit for Anthropic native)
+  apiKey?: string;               // ANTHROPIC_AUTH_TOKEN value (or runtime-specific token)
+  authTokenEnvName?: string;     // env var name for the auth token (default ANTHROPIC_AUTH_TOKEN)
+  systemPrompt?: string | ((role: "leader" | "worker", index: number, total: number) => string);
+  team?: string;                 // profile.team field + tmux session prefix (defaults to prefix)
+  leaderAlias?: string;          // 设了 → i=1 = leader role with this alias; i>1 = `${prefix}${i-1}号` worker. 没设 → all i = `${prefix}${i}号` workers.
+  printSummary?: boolean;        // default true
+}
+
+interface BatchResult {
+  workdir: string;
+  createdAliases: string[];
+  failedAliases: string[];
+  tmuxPrefix: string;            // for downstream lifecycle ops
+}
+
+function batchAliasFor(opts: BatchOptions, i: number): { alias: string; role: "leader" | "worker"; workerIndex: number } {
+  if (opts.leaderAlias && i === 1) {
+    return { alias: opts.leaderAlias, role: "leader", workerIndex: 0 };
+  }
+  const workerIndex = opts.leaderAlias ? i - 1 : i;
+  return { alias: `${opts.prefix}${workerIndex}号`, role: "worker", workerIndex };
+}
+
+function batchNodeDirFor(opts: BatchOptions, i: number): string {
+  return opts.workdirMode === "separate" ? join(opts.workdir, `node${i}`) : opts.workdir;
+}
+
+async function createBatch(opts: BatchOptions): Promise<BatchResult> {
+  // Validate every user-controllable string that lands in a filesystem path
+  // or a tmux session name. Single-node createCommand calls validateNodeName
+  // for the same reason (cli.ts:1233, also :1079); without it here a
+  // `--prefix '../bad'` would escape `.anet/nodes/` via saveProfile()'s
+  // `join(nodesDir(), id, "config.json")` write — caught by 通信牛 review of PR #60.
+  if (!opts.prefix || opts.prefix.length === 0) {
+    console.error("Error: batch prefix is required (got empty).");
+    process.exit(1);
+  }
+  validateNodeName(opts.prefix);
+  if (opts.team) validateNodeName(opts.team);
+  if (opts.leaderAlias) {
+    if (opts.leaderAlias.length === 0) {
+      console.error("Error: --leader-alias is empty; pass a name or drop the flag.");
+      process.exit(1);
+    }
+    validateNodeName(opts.leaderAlias);
+  }
+
+  const tmuxPrefix = opts.team || opts.prefix;
+  const gc = loadGlobal();
+  mkdirSync(opts.workdir, { recursive: true });
+  const origCwd = process.cwd();
+  const created: string[] = [];
+  const failed: string[] = [];
+
+  try {
+    for (let i = 1; i <= opts.count; i++) {
+      const { alias, role, workerIndex } = batchAliasFor(opts, i);
+      // Defense-in-depth: the prefix/leaderAlias entry-level validation above
+      // should already guarantee a safe alias here, but re-check so a bug in
+      // batchAliasFor() can never silently escape `.anet/nodes/`.
+      validateNodeName(alias);
+      const nodeDir = batchNodeDirFor(opts, i);
+      mkdirSync(nodeDir, { recursive: true });
+      process.chdir(nodeDir);
+
+      const envMap: Record<string, string> = {};
+      if (opts.baseUrl) envMap.ANTHROPIC_BASE_URL = opts.baseUrl;
+      if (opts.apiKey) envMap[opts.authTokenEnvName || "ANTHROPIC_AUTH_TOKEN"] = opts.apiKey;
+
+      const promptText = typeof opts.systemPrompt === "function"
+        ? opts.systemPrompt(role, workerIndex, opts.count)
+        : opts.systemPrompt;
+
+      const profile: Profile = {
+        anet_version: "0.1.0",
+        node_id: generateNodeId(),
+        node_name: alias,
+        alias,
+        runtime: opts.runtime,
+        ...(opts.model ? { model: opts.model } : {}),
+        ...(gc.network_id ? { network_id: gc.network_id } : {}),
+        channels: ["server:commhub"],
+        env: envMap,
+        flags: { dangerouslySkipPermissions: true },
+        ...(promptText ? { systemPrompt: promptText } : {}),
+        ...(opts.team ? { team: opts.team } : {}),
+        ...(opts.leaderAlias ? { role } : {}),
+      };
+
+      try {
+        await ensureNodeToken(profile, alias);
+      } catch (e: any) {
+        console.error(`        ❌ ${alias.padEnd(14)} ntok_ 请求失败: ${e.message}`);
+        failed.push(alias);
+        continue;
+      }
+      saveProfile(alias, profile);
+      created.push(alias);
+      if (opts.printSummary !== false) {
+        const roleTag = opts.leaderAlias ? ` (${role.padEnd(7)})` : "";
+        console.log(`        ✓ ${alias.padEnd(14)}${roleTag}  ${nodeDir}`);
+      }
+    }
+  } finally {
+    process.chdir(origCwd);
+  }
+
+  // Launch via tmux. We launch in a second pass so a partial config failure
+  // doesn't leave half-started tmux sessions running with no config.
+  if (created.length > 0) {
+    if (opts.printSummary !== false) {
+      console.log(`\n[anet] 启动 ${created.length} 个 tmux session...`);
+    }
+    try {
+      for (let idx = 0; idx < created.length; idx++) {
+        const alias = created[idx];
+        // Map created[idx] back to its original i — index in `created` may be
+        // gappy if some entries went into `failed`. We track that by scanning.
+        // For workdir-separate mode we need the matching nodeK dir.
+        let nodeI = -1;
+        for (let i = 1; i <= opts.count; i++) {
+          if (batchAliasFor(opts, i).alias === alias) { nodeI = i; break; }
+        }
+        const nodeDir = nodeI > 0 ? batchNodeDirFor(opts, nodeI) : opts.workdir;
+        const sessName = `${tmuxPrefix}-${alias}`;
+        killTmuxSession(sessName);
+        try {
+          process.chdir(nodeDir);
+          startNodeTmuxSession(sessName, alias);
+          if (opts.printSummary !== false) console.log(`        ✓ ${sessName}`);
+        } catch (e: any) {
+          console.error(`        ❌ tmux ${alias}: ${e.message}`);
+        }
+      }
+    } finally {
+      process.chdir(origCwd);
+    }
+  }
+
+  return { workdir: opts.workdir, createdAliases: created, failedAliases: failed, tmuxPrefix };
+}
+
+// Batch lifecycle (issue #55 #6 "能够 restart all" + extended verbs):
+//   - start    re-launch tmux for all `${prefix}-*` configs (skips already-running)
+//   - stop     kill any tmux session matching `${prefix}-*`
+//   - restart  stop + start (best-effort; relies on saved .anet/nodes/ configs)
+//   - cleanup  stop + rm -rf <workdir>/node*  + remove empty <workdir>
+//   - list     enumerate distinct `<prefix>` groups currently active in tmux
+
+function batchLifecycle(opts: { prefix: string; verb: "start" | "stop" | "restart" | "cleanup" | "list"; workdir?: string }) {
+  const { prefix, verb, workdir } = opts;
+
+  if (verb === "list") {
+    let sessions: string[] = [];
+    try {
+      const out = execSync("tmux list-sessions -F '#{session_name}' 2>/dev/null || true", { encoding: "utf-8" });
+      sessions = out.split("\n").filter(s => s && s.includes("-"));
+    } catch {}
+    const groups = new Map<string, string[]>();
+    for (const sess of sessions) {
+      const idx = sess.indexOf("-");
+      const p = sess.slice(0, idx);
+      const alias = sess.slice(idx + 1);
+      if (!groups.has(p)) groups.set(p, []);
+      groups.get(p)!.push(alias);
+    }
+    if (groups.size === 0) {
+      console.log("[anet] No batch tmux sessions found.");
+      return;
+    }
+    console.log(`[anet] Active batch groups (${groups.size}):`);
+    for (const [p, aliases] of groups) {
+      console.log(`  ${p.padEnd(20)} (${aliases.length} node)`);
+      for (const a of aliases.slice(0, 5)) console.log(`    - ${a}`);
+      if (aliases.length > 5) console.log(`    ... +${aliases.length - 5} more`);
+    }
     return;
   }
 
-  // Kill any tmux session matching the sci-team-* prefix.
+  // stop/restart/cleanup share a "kill matching tmux sessions" pass.
   let killedCount = 0;
   try {
     const out = execSync("tmux list-sessions -F '#{session_name}' 2>/dev/null || true", { encoding: "utf-8" });
-    const sessions = out.split("\n").filter(s => s.startsWith("sci-team-"));
+    const sessions = out.split("\n").filter(s => s.startsWith(`${prefix}-`));
     for (const sess of sessions) {
       killTmuxSession(sess);
       killedCount++;
     }
   } catch {}
-  console.log(`[anet] killed ${killedCount} tmux session(s) matching sci-team-*`);
+  console.log(`[anet] killed ${killedCount} tmux session(s) matching ${prefix}-*`);
 
-  if (cleanup) {
+  if (verb === "stop") return;
+
+  if (verb === "cleanup") {
+    const dir = workdir;
+    if (!dir) {
+      console.error("[anet] cleanup 需要 --workdir <path> 指明清理目录。");
+      return;
+    }
+    if (!existsSync(dir)) {
+      console.error(`[anet] 工作目录不存在: ${dir}`);
+      return;
+    }
     const subdirs = readdirSync(dir).filter(name => name.startsWith("node") && statSync(join(dir, name)).isDirectory());
     for (const sub of subdirs) {
       rmSync(join(dir, sub), { recursive: true, force: true });
@@ -5011,13 +5192,268 @@ function sciTeamLifecycle(opts: { dir: string; restart: boolean; cleanup: boolea
       if (remaining.length === 0) rmSync(dir, { recursive: true, force: true });
     } catch {}
     console.log(`[anet] 清理完成: ${dir}`);
+    // Phase 1 limitation: cleanup only handles `--workdir-mode separate` (each
+    // node has its own `<workdir>/node{i}/.anet/nodes/...` tree). For
+    // `--workdir-mode shared`, configs live under `<workdir>/.anet/nodes/${prefix}*号`
+    // and need a manual `rm -rf` (no registry yet to know which aliases this
+    // batch owns vs. other batches that may share the same dir). Phase 2 will
+    // add a `~/.anet/batches.json` marker registry to make shared-mode cleanup
+    // safe; until then surfacing the gap loudly per 通信牛 PR #60 review.
+    if (subdirs.length === 0 && existsSync(join(dir, ".anet", "nodes"))) {
+      console.warn(`[anet] ⚠ shared workdir-mode 限制: no node*/ subdirs to remove. Configs under`);
+      console.warn(`        ${join(dir, ".anet", "nodes")}/${prefix}*号/  remain on disk. Phase 1 cleanup`);
+      console.warn(`        only handles separate workdir-mode. Manual: rm -rf '${join(dir, ".anet", "nodes")}'/${prefix}*号`);
+    }
     return;
   }
 
-  if (restart) {
-    console.log(`[anet] --restart: 重新启动需要重跑 'anet demo sci-team' (Phase 1 scaffold 暂不支持 in-place relaunch — 完整 supervisor 留 Phase 2)`);
+  if (verb === "restart" || verb === "start") {
+    // Phase 1: restart/start in-place is not yet wired (would need to walk
+    // saved .anet/nodes/<alias>/config.json under <workdir>/node*/ and
+    // re-launch tmux). For now, hint the user to re-run the create wizard.
+    console.log(`[anet] '${verb}' in-place not yet implemented (Phase 1 scaffold). Re-run:`);
+    console.log(`         anet create --batch    # generic`);
+    console.log(`         anet demo sci-team     # sci-team preset`);
     return;
   }
+}
+
+// ── batch wizard (anet create --batch) ──
+//
+// Verified preset list — must stay in sync with the auth-fail flow (cli.ts
+// L1116+) and the `anet demo sci-team` preset (Vincent commit 1bc03c0 chain).
+// New presets only after per-vendor verify-with-real-call (per
+// [[feedback_vendor_verify_before_hardcode]]).
+
+const BATCH_PRESETS: Array<{
+  value: string;
+  label: string;
+  runtime: string;
+  model?: string;
+  baseUrl?: string;
+}> = [
+  { value: "intern-s1-pro",      label: "claude-agent-sdk + intern-s1-pro (书生 Intern, https://chat.intern-ai.org.cn)",
+    runtime: "claude-agent-sdk", model: "intern-s1-pro",     baseUrl: "https://chat.intern-ai.org.cn" },
+  { value: "MiniMax-M2.7",       label: "claude-agent-sdk + MiniMax-M2.7 (https://api.minimaxi.com/anthropic)",
+    runtime: "claude-agent-sdk", model: "MiniMax-M2.7",      baseUrl: "https://api.minimaxi.com/anthropic" },
+  { value: "claude-sonnet-4-6",  label: "claude-agent-sdk + claude-sonnet-4-6 (Anthropic default)",
+    runtime: "claude-agent-sdk", model: "claude-sonnet-4-6" },
+  { value: "claude-opus-4-6",    label: "claude-agent-sdk + claude-opus-4-6 (Anthropic default)",
+    runtime: "claude-agent-sdk", model: "claude-opus-4-6" },
+  { value: "claude-haiku-4-5",   label: "claude-agent-sdk + claude-haiku-4-5 (Anthropic default)",
+    runtime: "claude-agent-sdk", model: "claude-haiku-4-5" },
+  { value: "__custom__",         label: "Custom — 自行输入 runtime / base URL / model",
+    runtime: "" },
+];
+
+async function createBatchWizardCommand() {
+  const opts = parseOpts();
+  const help = args.includes("--help") || args.includes("-h");
+  if (help) {
+    console.log(`
+  anet create --batch — 批量创建 N 个 agent (issue #55)
+
+  Usage:
+    anet create --batch [--preset <key>] [--api-key <key>] [--workdir <path>]
+                        [--workdir-mode separate|shared] [--prefix <name>]
+                        [--count <N>] [--description <text>]
+                        [--leader-alias <name>]
+
+  Wizard fields (任一可用 --flag 跳过):
+    --preset <key>        intern-s1-pro / MiniMax-M2.7 / claude-sonnet-4-6 /
+                          claude-opus-4-6 / claude-haiku-4-5 / __custom__
+    --api-key <key>       runtime auth token (ANTHROPIC_AUTH_TOKEN or 等价)
+    --workdir <path>      父目录, default ~/anet-team
+    --workdir-mode        separate (default, <workdir>/node{i}) | shared (单 dir)
+    --prefix <name>       alias 前缀, e.g. 工程师 → 工程师1号..工程师N号
+    --count <N>           1-50
+    --description <text>  systemPrompt 内容 (空 → no systemPrompt)
+    --leader-alias <name> 设了 → i=1 = leader with this alias, i>1 workers
+
+  Lifecycle (issue #55 #6 "能够 restart all"):
+    anet batch start  <prefix>   # launch (Phase 1: hint re-run create)
+    anet batch stop   <prefix>   # kill all matching tmux
+    anet batch list              # all active batch groups
+    anet batch cleanup <prefix> [--workdir <path>]   # stop + rm -rf <workdir>/node*/
+    anet batch restart <prefix>  # stop + start (Phase 1 hint)
+
+  Phase 1 cleanup limitation: only --workdir-mode separate is fully cleaned
+  (rm <workdir>/node*). For --workdir-mode shared, configs at
+  <workdir>/.anet/nodes/<prefix>*号/ stay on disk — manual rm needed
+  (registry-based safe cleanup is Phase 2).
+
+  Vendor presets are Vincent-verified (commit 1bc03c0). For codex / other
+  vendors not yet verified, use --preset __custom__ and paste your own
+  runtime / baseUrl / model values.
+
+  Spec: issue #55 / RFC-008 (multi-agent team convention)
+`);
+    return;
+  }
+
+  const gc = loadGlobal();
+  if (!gc.hub) {
+    console.error("[anet] 未找到 CommHub Server。先运行 'anet hub start' 或 'anet init --hub <url>'");
+    return;
+  }
+
+  // 1. Preset
+  let presetKey = opts.preset || "";
+  if (!presetKey) {
+    presetKey = await askChoice("Model preset", BATCH_PRESETS.map(p => ({ label: p.label, value: p.value })));
+  }
+  const preset = BATCH_PRESETS.find(p => p.value === presetKey);
+  if (!preset) {
+    closeRL();
+    console.error(`[anet] Unknown preset: ${presetKey}. Use --help to see verified list.`);
+    return;
+  }
+
+  let runtime = preset.runtime;
+  let model = preset.model;
+  let baseUrl = preset.baseUrl;
+  if (preset.value === "__custom__") {
+    const customRuntime = await ask("Runtime (claude-agent-sdk / codex-sdk / claude-code-cli / http-api)", "claude-agent-sdk");
+    runtime = normalizeRuntime(customRuntime);
+    const customBase = await ask("ANTHROPIC_BASE_URL (空白=Anthropic default)", "");
+    if (customBase) baseUrl = customBase;
+    const customModel = await ask("Model id", "");
+    if (customModel) model = customModel;
+  }
+
+  // 2. API key
+  const apiKey = opts["api-key"] || opts.key || process.env.ANET_BATCH_API_KEY || await ask("API key (ANTHROPIC_AUTH_TOKEN)");
+  if (!apiKey) {
+    closeRL();
+    console.error("[anet] API key required.");
+    return;
+  }
+
+  // 3. Workdir
+  const workdir = opts.workdir || await ask("Workdir", join(home, "anet-team"));
+  const workdirMode = (opts["workdir-mode"] || "separate") as "separate" | "shared";
+  if (workdirMode !== "separate" && workdirMode !== "shared") {
+    closeRL();
+    console.error(`[anet] --workdir-mode must be 'separate' or 'shared', got: ${workdirMode}`);
+    return;
+  }
+
+  // 4. Prefix + count
+  const prefix = opts.prefix || await ask("Node prefix (e.g. 工程师)", "工程师");
+  const countRaw = parseInt(opts.count || await ask("Count (1-50)", "5"), 10);
+  const count = Math.max(1, Math.min(50, Number.isFinite(countRaw) ? countRaw : 5));
+  if (count !== countRaw) {
+    console.log(`  [anet] Count ${countRaw} → clamped to [1,50] = ${count}`);
+  }
+  if (count > 20) {
+    console.warn(`  [anet] Warning: count=${count} > 20 may exceed memory/ulimit on a developer laptop. Recommended ≤ 20 unless tested.`);
+  }
+
+  // 5. Description (systemPrompt)
+  const description = opts.description || await ask("Description / system prompt (空 → no prompt)", "");
+
+  const leaderAlias = opts["leader-alias"] || "";
+  closeRL();
+
+  // Auto-login if no user token (same admin/anethub pattern as demo sci-team)
+  if (!gc.token || !gc.user) {
+    console.log(`\n[anet] 没有 user token，自动用 default admin/anethub 登录...`);
+    const loginRes = await fetch(`${gc.hub}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "admin", password: "anethub" }),
+    }).then(r => r.json() as any).catch(() => null);
+    if (!loginRes?.ok) {
+      console.error(`[anet] 自动登录失败: ${loginRes?.error || "unknown"}. 先 'anet register' 创账号。`);
+      return;
+    }
+    gc.token = loginRes.token;
+    gc.user = loginRes.user;
+    const nets = await fetch(`${gc.hub}/api/networks`, { headers: { Authorization: `Bearer ${loginRes.token}` } }).then(r => r.json() as any).catch(() => ({ networks: [] }));
+    if (nets.networks?.length > 0) {
+      gc.network_id = nets.networks[0].network_id;
+      gc.network_name = nets.networks[0].network_name;
+    }
+    saveGlobal(gc);
+    console.log(`        ✓ 登录: ${loginRes.user.username}`);
+  }
+
+  console.log(`\n[anet] Creating batch '${prefix}' × ${count} in ${workdir}/...`);
+  console.log(`        Preset:        ${preset.label}`);
+  console.log(`        Workdir mode:  ${workdirMode}`);
+  if (leaderAlias) console.log(`        Leader alias:  ${leaderAlias}`);
+  console.log();
+
+  const result = await createBatch({
+    prefix,
+    count,
+    workdir,
+    workdirMode,
+    runtime,
+    model,
+    baseUrl,
+    apiKey,
+    systemPrompt: description || undefined,
+    leaderAlias: leaderAlias || undefined,
+  });
+
+  if (result.createdAliases.length === 0) {
+    console.error(`\n[anet] No nodes created.`);
+    return;
+  }
+  console.log(`\n[anet] 🏁 Batch '${prefix}' ready. ${result.createdAliases.length} node launched.`);
+  if (result.failedAliases.length > 0) {
+    console.log(`        ⚠ ${result.failedAliases.length} 失败: ${result.failedAliases.join(", ")}`);
+  }
+  console.log(`        Stop:    anet batch stop ${result.tmuxPrefix}`);
+  console.log(`        List:    anet batch list`);
+  console.log(`        Cleanup: anet batch cleanup ${result.tmuxPrefix} --workdir ${workdir}`);
+  console.log();
+}
+
+// ── batch top-level subcommand: anet batch <verb> ──
+
+async function batchCommand() {
+  const sub = args[1];
+  if (!sub || sub === "-h" || sub === "--help" || sub.startsWith("-")) {
+    console.log(`
+  anet batch <verb> <prefix>   # batch lifecycle ops (issue #55)
+
+  Verbs:
+    start <prefix>                        re-launch (Phase 1: hint re-run create)
+    stop <prefix>                         kill all tmux matching <prefix>-*
+    restart <prefix>                      stop + start
+    cleanup <prefix> --workdir <path>     stop + rm -rf <workdir>/node*/
+                                          (shared workdir-mode leaves configs
+                                          under <workdir>/.anet/nodes/; needs
+                                          manual rm — registry is Phase 2)
+    list                                  list all active batch groups
+                                          (Phase 1: also catches non-anet tmux
+                                          sessions whose names contain '-')
+
+  See also: anet create --batch  (batch create wizard)
+`);
+    return;
+  }
+  const verb = sub;
+  const validVerbs = ["start", "stop", "restart", "cleanup", "list"] as const;
+  if (!(validVerbs as readonly string[]).includes(verb)) {
+    console.error(`[anet] Unknown batch verb '${verb}'. Valid: ${validVerbs.join(" / ")}`);
+    return;
+  }
+
+  if (verb === "list") {
+    return batchLifecycle({ prefix: "", verb: "list" });
+  }
+
+  const prefix = args[2];
+  if (!prefix) {
+    console.error(`[anet] Usage: anet batch ${verb} <prefix>`);
+    return;
+  }
+  const opts = parseOpts();
+  const workdir = opts.workdir;
+  return batchLifecycle({ prefix, verb: verb as "start" | "stop" | "restart" | "cleanup", workdir });
 }
 
 
@@ -5477,6 +5913,7 @@ switch (command) {
   case "passwd": await passwdCommand(); break;
   case "token": await tokenCommand(); break;
   case "demo": await demoCommand(); break;
+  case "batch": await batchCommand(); break;
   case "logs": logsCommand(); break;
   case "info": await infoCommand(); break;
   case "config": configShowCommand(); break;

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.1.7-preview.2",
+  "version": "2.1.8-preview.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.1.7-preview.2",
+      "version": "2.1.8-preview.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@inquirer/prompts": "^7.10.1"
+        "@inquirer/prompts": "^8.4.3"
       },
       "bin": {
         "anet": "dist/bin/cli.js"
@@ -22,7 +22,8 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "bun": ">=1.2.0"
+        "bun": ">=1.2.0",
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -39,24 +40,27 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.3.2",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.5.tgz",
+      "integrity": "sha512-Jmf9tgBHIEK5SAOB7swYfStqmtkZb00xOTpSQmkoGEpdxOTpJi9RS0A8bkfDPHTTItZRJrRdZrEMu25wyj0VfQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -68,14 +72,16 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.13.tgz",
+      "integrity": "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -87,20 +93,21 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.3.2",
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.10.tgz",
+      "integrity": "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
         "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -112,15 +119,17 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.23",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.2.tgz",
+      "integrity": "sha512-Y3Nor7S/DhIPo+8Ym/dSY4efwKI4BsflKDwXh0jNeXJsSF3dteS/3Yf+z4wkibVZDvYMyCgknSTQlNahfunGHg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/external-editor": "^3.0.0",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -132,15 +141,16 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.23",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.14.tgz",
+      "integrity": "sha512-qyY9zcIX2eKYwaAUiQo9zORd61Lc3sXeM72fVbeHkYnDkqfr8/armcRbmVAIrExeJhI2puk+uomeKtWrpUVUmQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -152,14 +162,16 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.3",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
+      "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
+        "iconv-lite": "^0.7.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -171,21 +183,25 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.3.1",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.13.tgz",
+      "integrity": "sha512-0l0jCHlJnXIV8CTxwQC0C+5Ziq8WP22edWgmciW2xYvoeoSck4v5FvCS1ctKdqLLR0dUo93uAHgWHywgBSoRyw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -197,14 +213,16 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.23",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.13.tgz",
+      "integrity": "sha512-WHmkYnnJAou5gx7RgcvAfUggnHNM1zWfoh0dFPl3dxVssuqt+dK5rIbaOYQXNyOegvFnopbKupjnhw2O8gANNg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -216,15 +234,17 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.23",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.13.tgz",
+      "integrity": "sha512-XDGu64ROHZjOOXLAANvJN7iIxWKhOSCG5VakrZ5kaScVR+snVJCFglD/hL3/677awtWcu4pXoWa280CDIYcBeg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -236,22 +256,24 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.10.1",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.3.tgz",
+      "integrity": "sha512-ai5LseTw9HhegupIgmo4cn7RpnCGznjjXu4OI+7jMR8vu7T1ZCCNMzFFAovUCjL1fl0cceksIN1++yQE59SmZw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
+        "@inquirer/checkbox": "^5.1.5",
+        "@inquirer/confirm": "^6.0.13",
+        "@inquirer/editor": "^5.1.2",
+        "@inquirer/expand": "^5.0.14",
+        "@inquirer/input": "^5.0.13",
+        "@inquirer/number": "^4.0.13",
+        "@inquirer/password": "^5.0.13",
+        "@inquirer/rawlist": "^5.2.9",
+        "@inquirer/search": "^4.1.9",
+        "@inquirer/select": "^5.1.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -263,15 +285,16 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.11",
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.9.tgz",
+      "integrity": "sha512-a1ErXEfgjfPYpyQ89dp+7n2IISjH9oQg3ygvF5adz8B7aHn4n2PjEgu1wpVTp69K3bj3lVLxP0qJ2b1clk1Whw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -283,16 +306,17 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.2.2",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.9.tgz",
+      "integrity": "sha512-ZlbM28Q9lmLkFPNAIv+ZuY530n5Km8U1WW48oYEvDhe9yc2uL3m3t+JSdRUkQlk5fuIuskgiIVjcb7czFzQpuA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -304,17 +328,18 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.4.2",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.5.tgz",
+      "integrity": "sha512-6SRg6kHfK/sjLXOsuqNebuir+sjwrf/iWuRUnXgB2slzEewppI1WfzeS16XxDcOQmXBruMmmB9Cgrz7wsAxqMg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -326,10 +351,12 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.10",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -549,15 +576,9 @@
         }
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -778,6 +799,8 @@
     },
     "node_modules/chardet": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
     },
     "node_modules/charenc": {
@@ -804,6 +827,8 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -811,6 +836,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -821,6 +847,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -1018,10 +1045,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1277,6 +1300,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -1293,6 +1331,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1626,13 +1673,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -1952,10 +1992,12 @@
       }
     },
     "node_modules/mute-stream": {
-      "version": "2.0.0",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/negotiator": {
@@ -2463,6 +2505,8 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2499,18 +2543,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/stringz": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/stringz/-/stringz-2.1.0.tgz",
@@ -2519,16 +2551,6 @@
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -2721,34 +2743,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -52,7 +52,8 @@
     "url": "https://github.com/sleep2agi/agent-network/issues"
   },
   "engines": {
-    "bun": ">=1.2.0"
+    "bun": ">=1.2.0",
+    "node": ">=22.13.0"
   },
   "dependencies": {
     "@inquirer/prompts": "^8.4.3"

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -1,0 +1,152 @@
+# `anet create --batch` + `anet batch <verb>` — 批量 agent 工作流
+
+> Phase 1 scaffold per issue [#55](https://github.com/sleep2agi/agent-network/issues/55).
+> 该文档跟 cli `--help` 同步，是 user-facing surface 的 source of truth；
+> 命令实现见 `agent-network/bin/cli.ts` `createBatch` / `batchLifecycle`。
+
+## 一句话
+
+`anet create --batch` 批量起 N 个 agent，prefix 自动编号，每个 agent 一个独立工作目录 + config + tmux session；之后用 `anet batch <verb> <prefix>` 统一管 lifecycle。
+
+## Quick start
+
+```bash
+# 一行起 5 个工程师 agent，用 Claude Haiku
+anet create --batch \
+  --preset claude-haiku-4-5 \
+  --api-key sk-ant-... \
+  --prefix 工程师 \
+  --count 5
+
+# 看现在跑着哪些 batch
+anet batch list
+
+# 全部停下
+anet batch stop 工程师
+
+# 彻底删（停 + rm -rf 工作目录）
+anet batch cleanup 工程师 --workdir ~/anet-team
+```
+
+不带 flag 直接跑 `anet create --batch` 进 wizard 一项项问。
+
+## Wizard 字段
+
+| 字段 | flag | 默认 | 说明 |
+|------|------|------|------|
+| Model preset | `--preset <key>` | (prompt) | 见下方 verified 列表，未列入的走 `__custom__` 自己填 |
+| API key | `--api-key <key>` | (prompt) | `ANTHROPIC_AUTH_TOKEN` 写入每个 node 的 `env` |
+| Workdir | `--workdir <path>` | `~/anet-team` | 父目录 |
+| Workdir mode | `--workdir-mode <mode>` | `separate` | `separate` = `<workdir>/node{i}/.anet/nodes/<alias>` 每 node 一个子目录；`shared` = 全部 N 个 node 写同一个 `<workdir>/.anet/nodes/<alias>` |
+| Prefix | `--prefix <name>` | (prompt) | alias 前缀，e.g. `工程师` → `工程师1号`, `工程师2号`, ..., `工程师N号` |
+| Count | `--count <N>` | (prompt) | `1-50`；超过 20 会 stderr 警告 memory/ulimit 风险 |
+| Description | `--description <text>` | (prompt) | `systemPrompt` 内容；空串则不写 systemPrompt |
+| Leader alias | `--leader-alias <name>` | (off) | 可选；设了→ `i=1` 用这个 alias 标 `role: "leader"`，剩下 `count-1` 个走 `${prefix}{1..N-1}号` 当 worker |
+
+env vars 也认 `ANET_BATCH_API_KEY` 当 fallback。
+
+## Vendor preset 列表（Vincent 已 verify）
+
+| Preset | Runtime | Model | baseUrl |
+|--------|---------|-------|---------|
+| `intern-s1-pro` | `claude-agent-sdk` | `intern-s1-pro` | `https://chat.intern-ai.org.cn` |
+| `MiniMax-M2.7` | `claude-agent-sdk` | `MiniMax-M2.7` | `https://api.minimaxi.com/anthropic` |
+| `claude-sonnet-4-6` | `claude-agent-sdk` | `claude-sonnet-4-6` | (Anthropic default) |
+| `claude-opus-4-6` | `claude-agent-sdk` | `claude-opus-4-6` | (Anthropic default) |
+| `claude-haiku-4-5` | `claude-agent-sdk` | `claude-haiku-4-5` | (Anthropic default) |
+| `__custom__` | (输入) | (输入) | (输入) |
+
+字段值跟 `anet login` auth-fail guidance 列表 *same verified value set*（per commit 1bc03c0）—— preset 排序在 batch 这里把 `intern-s1-pro` 提到首位（用户用 batch 多半冲着 sci-team 这路），跟 cli.ts L1122+ 的顺序不严格一致，但 runtime / model / baseUrl 各值是 same source。codex-sdk preset **暂时不在列表里**——`__custom__` 自己填 runtime / model 仍可用，但默认 codex preset 还在 verify 中（follow-up issue 跟踪）。
+
+## Lifecycle — `anet batch <verb>`
+
+```bash
+anet batch <verb> [<prefix>] [--workdir <path>]
+```
+
+| Verb | 作用 | Phase 1 状态 |
+|------|------|---------------|
+| `list` | 列所有 tmux session group by 第一个 `-` 分隔 | ✅ 跑得起；**已知噪声**：会把 host 上任何 `${something}-${rest}` 形式的 tmux session 都算成一个 group。Phase 2 计划加 `~/.anet/batches.json` marker registry 后过滤干净 |
+| `stop <prefix>` | kill 所有 `${prefix}-*` tmux session | ✅ 干净 |
+| `cleanup <prefix> --workdir <path>` | `stop` + `rm -rf <workdir>/node*` + 删空 `<workdir>` | ✅ 干净 |
+| `start <prefix>` | re-launch | ⚠️ Phase 1 是 hint-only：提示重跑 `anet create --batch`。in-place supervisor 留 Phase 2 |
+| `restart <prefix>` | `stop` + `start` | ⚠️ 同上，`stop` 走完 `start` 是 hint-only |
+
+> 想"重启所有节点"目前的可靠做法：`anet batch stop <prefix>` → `anet batch cleanup <prefix> --workdir <path>` → 重新跑 `anet create --batch`。Phase 2 会让 `restart` 直接复活已存在的 config，不需重跑 wizard。
+
+## Output 结构
+
+`workdir-mode=separate` (默认)：
+
+```
+<workdir>/
+├── node1/
+│   └── .anet/nodes/<alias-1>/
+│       └── config.json     # runtime / model / token / env / systemPrompt / team? / role?
+├── node2/
+│   └── .anet/nodes/<alias-2>/...
+└── node{N}/...
+```
+
+`workdir-mode=shared`：
+
+```
+<workdir>/
+└── .anet/nodes/
+    ├── <alias-1>/config.json
+    ├── <alias-2>/config.json
+    └── ...
+```
+
+tmux session 命名是 `${team || prefix}-${alias}`：
+
+```
+$ tmux ls
+工程师-工程师1号
+工程师-工程师2号
+工程师-工程师3号
+sci-team-研究Leader     # `anet demo sci-team` 走的同款 batch primitive
+sci-team-研究员1号
+...
+```
+
+## `anet demo sci-team` — preset wrapper 示例
+
+`anet demo sci-team` 现在是 batch primitive 的一个 *preset wrapper*，user-facing surface 跟 PR #53 preview.7 保持 bit-identical：
+
+```bash
+anet demo sci-team --count 10 --intern-api $INTERN_API_KEY --dir ~/intern-s
+```
+
+内部相当于：
+
+```bash
+anet create --batch \
+  --preset intern-s1-pro \
+  --api-key $INTERN_API_KEY \
+  --workdir ~/intern-s --workdir-mode separate \
+  --prefix 研究员 --leader-alias 研究Leader \
+  --count 10 \
+  --description '<sciTeamPrompt active fan-out template>'
+```
+
+差别是 sci-team 自带 `team="sci-team"` 标签 + `role="leader|worker"` 字段 + `sciTeamPrompt` 主动 fan-out 模板（详见 RFC-008）。通用 batch 不带这些字段，systemPrompt 走用户 `--description` 输入。
+
+> 老的 `anet demo sci-team --stop|--restart|--cleanup` 仍然能跑，但会 stderr 一条 deprecation 警告，指向新的 `anet batch <verb> sci-team`。下一个 major 会移除 legacy flag。
+
+## Phase 1 限制 + Phase 2 路线
+
+| 限制 | 现在表现 | Phase 2 计划 |
+|------|----------|---------------|
+| `anet batch list` 噪声 | 群组 host 上**所有** `${a}-${b}` tmux session，包括非 anet | `~/.anet/batches.json` marker registry 写入 `createBatch` 时，list 时过滤 |
+| `restart` / `start` in-place | hint-only：提示重跑 wizard | 走 `<workdir>/node*/.anet/nodes/<alias>/config.json` 重新 spawn tmux |
+| Codex preset | 不在 verified 列表 | 单独 issue 跟 Vincent verify codex base URL + model id 后加 preset |
+| 多 prefix list 过滤 | 全部 group 一起返 | `anet batch list <prefix>` filter |
+| Cross-batch 任务路由 | 不做 | RFC-008 Phase 3+ |
+
+## 关联
+
+- 上游 issue：[#55](https://github.com/sleep2agi/agent-network/issues/55)
+- 同源 primitive 来历：[#51 科研军团 demo PR #53](https://github.com/sleep2agi/agent-network/pull/53)（generalized）
+- 长程协调协议：[RFC-008 multi-agent team convention](rfcs/RFC-008-multi-agent-team-convention.md)
+- Vendor preset 真值锚：[commit 1bc03c0](https://github.com/sleep2agi/agent-network/commit/1bc03c0)


### PR DESCRIPTION
## Author & Helpers

**Author (Primary)**: 通信工程马 (cli.ts implementation + amend chain)

**Helpers**:
- 通信龙: Option C 分层 propose (issue #55 comment 4439171170) + dispatch + 7 implementer-decision review + 2 nit (drop unverified codex preset / count>20 stderr warning) + Tier review + Vincent 4380 preview-only gate + lockfile fix dispatch
- Vincent: issue #55 raise (telegram 4335 lifted hold from 4300) + 4378 push-ship signal + 4380 preview-only gate
- 通信SDK马: RFC-008 multi-agent team convention spec author
- 通信测试马: PR #53 sci-team scaffold E2E audit (pattern this PR generalizes) + 84-fail regression triage 4-bucket verdict ([detail](https://github.com/sleep2agi/agent-network/pull/60#issuecomment-4443545297)) → 🚦 GO
- 通信牛: review chain — first/second/third pass catches (path traversal in `--prefix`, `git add` miss on `package.json`, docs/batch.md wording polish, "byte-identical" → "same verified value set")

**Tier review gate**: 通信龙 (Lead) + 通信牛 (cross-review per big-feature multi-cmd guideline) + 通信测试马 (regression-suite verdict)

## Why

Refs #55 — Vincent 4335 lifted the earlier hold on the batch-create feature. This PR is the *generic primitive* that the existing `anet demo sci-team` (PR #53) had baked into one specific preset; it lifts the batch pattern up so any team prefix / model preset can use it, and refactors sci-team into a preset wrapper. Issue body asked for:

1. 选模型 + 输入 key → covered by `--preset` + `--api-key`
2. 选 workdir (1 dir vs N dir) → `--workdir-mode separate|shared`
3. 节点前缀 (e.g. 工程师 → 工程师1号..) → `--prefix`
4. 个数 → `--count` (1-50, stderr warning >20)
5. 描述定位 → `--description` (systemPrompt)
6. **能够 restart all** → `anet batch <verb> <prefix>` lifecycle (start/stop/restart/cleanup/list)

## What

Files touched (6, +801 -207):
- `agent-network/bin/cli.ts` — createBatch helper + batchLifecycle helper + `anet create --batch` wizard + `anet batch <verb>` top-level + sci-team refactor + deprecation warning
- `agent-network/package.json` — engines `+ "node": ">=22.13.0"`
- `agent-network/package-lock.json` — npm install regen sync with engines bump (npm format lockfile, bun.lockb gitignored)
- `docs/batch.md` (new, 152 lines) — user-facing reference
- `README.md` + `README.en.md` — 30-second-quickstart 顶 Prereq line Node.js ≥ 22.13.0

### `createBatch(options)` helper (~150 LOC)

Generic N-node spawn primitive. Two-pass loop: configs first (mkdir + Profile build + `ensureNodeToken` + `saveProfile`), then tmux sessions (so a partial config failure doesn't leave half-started tmux). `process.chdir` restored in `finally` block.

**Path traversal defense** (per 通信牛 first-pass catch): `validateNodeName(prefix / team / leaderAlias)` at entry, then `validateNodeName(alias)` defense-in-depth per generated alias. Verified: `--prefix '../bad'` / `--prefix '/etc/passwd'` / `--leader-alias '..'` all reject with `Error: invalid node-name` and exit 1 before any saveProfile / mkdir / tmux side effect.

### `batchLifecycle({ prefix, verb, workdir? })` helper (~80 LOC)

- `stop` — kill tmux matching `${prefix}-*`
- `cleanup` — `stop` + `rm -rf <workdir>/node*` + remove empty `<workdir>` (separate workdir-mode only; shared-mode emits stderr warning + manual `rm` guidance)
- `restart` / `start` — Phase 1 scaffold hint (re-run create wizard); in-place supervisor deferred to Phase 2
- `list` — group all tmux sessions by first `-` separator. Phase 1 known limitation: catches non-anet sessions whose names contain `-`. Future: `~/.anet/batches.json` marker registry, deferred.

### CLI surfaces (3 new entry points)

1. **`anet create --batch`** wizard — Vincent-verified preset list (intern-s1-pro / MiniMax-M2.7 / claude-sonnet-4-6 / claude-opus-4-6 / claude-haiku-4-5 / `__custom__`). Codex preset deliberately excluded — not yet verified end-to-end. Follow-up issue planned.

2. **`anet batch <verb> <prefix>`** top-level lifecycle (mirrors `anet hub` / `anet node` / `anet network` pattern).

3. **`anet demo sci-team`** refactored to internally call `createBatch` with the sci-team preset (`team="sci-team"`, `leaderAlias="研究Leader"`, intern URL/model, `sciTeamPrompt` active fan-out template). **User-facing wizard surface bit-identical to preview.7** — backward compat for docs / demo recordings.

### Deprecation

`anet demo sci-team --stop|--restart|--cleanup` now prints a stderr deprecation warning pointing at the canonical `anet batch <verb> sci-team`. One-release-cycle grace.

## CI status — pre-existing test infra debt (NOT introduced by this PR)

PR #60's lockfile fix (commit 0440c55 — `npm install` regen of `package-lock.json` to sync with `engines.node` bump) **exposed regression suite silently failing since preview.5**. All 5 most recent main runs died at `bun install --frozen-lockfile` step in 13-19s; the 186-test regression never actually ran:

| Commit | E2E run | Time | Result |
|--------|---------|------|--------|
| `039c2a4` preview.7 | [25811359270](https://github.com/sleep2agi/agent-network/actions/runs/25811359270) | 19s | died at install |
| `a451899` #58 cli fix | 25811139718 | 15s | died at install |
| `8dd1d18` preview.6 | 25792030112 | 16s | died at install |
| `9e206aa` sci systemPrompt | 25791869367 | 13s | died at install |
| `e4507e4` preview.5 | 25791425357 | 13s | died at install |

After the lockfile fix the install step passes and the suite actually runs. 通信测试马 triage ([detail comment](https://github.com/sleep2agi/agent-network/pull/60#issuecomment-4443545297)):

| Bucket | Count | Note |
|--------|-------|------|
| 🔒 Security | 0 | none |
| 🔴 Functional regression | 0 | none |
| 🟡 Flaky (Config Priority `set -e` + mkdir crash, silent-skip) | 16 | runner crash, not real fail |
| ⚪ Obsolete (V3 auth + RFC-001 deprecation lag) | 84 | 80 Base E2E (anonymous MCP/REST → 401) + 4 V3 Networks (master-token write → RFC-001 rejection) |

**Supporting evidence — user-facing flows verified healthy**:
- V3 Auth (25/25) ✅
- sci-team E2E full-chain on preview.6 ✅ (per #51)
- #52 Dashboard + V3 Networks utok/ntok audit 4 layers all ✅

**Follow-up issues** (NOT blocking this PR per 测试马 verdict + 通信龙 dispatch):
- [#63](https://github.com/sleep2agi/agent-network/issues/63) P1 — Base E2E 80 fail: V3 utok/ntok auth migration
- [#64](https://github.com/sleep2agi/agent-network/issues/64) P2 — V3 Networks 4 fail: master-token write deprecation per RFC-001
- [#65](https://github.com/sleep2agi/agent-network/issues/65) P2 — Config Priority 16 silent skip: `set -e` + mkdir crash

## Vendor preset list (Vincent-verified per 1bc03c0 / issue #48 chain)

| Preset | Runtime | Model | baseUrl |
|--------|---------|-------|---------|
| `intern-s1-pro` | claude-agent-sdk | intern-s1-pro | `https://chat.intern-ai.org.cn` |
| `MiniMax-M2.7` | claude-agent-sdk | MiniMax-M2.7 | `https://api.minimaxi.com/anthropic` |
| `claude-sonnet-4-6` | claude-agent-sdk | claude-sonnet-4-6 | (Anthropic default) |
| `claude-opus-4-6` | claude-agent-sdk | claude-opus-4-6 | (Anthropic default) |
| `claude-haiku-4-5` | claude-agent-sdk | claude-haiku-4-5 | (Anthropic default) |
| `__custom__` | (user input) | (user input) | (user input) |

No fabricated values added (per [[feedback_vendor_verify_before_hardcode]] SOP).

## How to verify (post-merge functional gate)

```bash
cd agent-network && bun install && npm run typecheck    # no errors

# Help banners
bun bin/cli.ts create --batch --help
bun bin/cli.ts batch
bun bin/cli.ts demo sci-team --help                     # unchanged (backward compat)

# Lifecycle (no fresh hub required)
bun bin/cli.ts batch list
bun bin/cli.ts batch stop somePrefix
bun bin/cli.ts demo sci-team --stop --dir /tmp/nodir   # → deprecation warning + delegated

# Path traversal defense (BLOCKER fixed)
bun bin/cli.ts create --batch --prefix '../bad' --count 2 --api-key fake --preset claude-haiku-4-5 --workdir /tmp/bad
# expect: "Error: invalid node-name '../bad'" + exit 1, no escaped writes

# End-to-end (needs running hub)
bunx -y @sleep2agi/commhub-server --port 9897 &
HOME=/tmp/p55-test bun bin/cli.ts register --hub http://127.0.0.1:9897 --username admin --password anethub --display-name admin --email admin@local
HOME=/tmp/p55-test bun bin/cli.ts create --batch \
  --preset claude-haiku-4-5 --api-key fake-test-key \
  --workdir /tmp/p55-test/team --workdir-mode separate \
  --prefix 工程师 --count 3 --description "你是软件工程师"
HOME=/tmp/p55-test bun bin/cli.ts batch list | grep 工程师
HOME=/tmp/p55-test bun bin/cli.ts batch stop 工程师
```

## Out of scope for this PR

- ❌ Codex preset (un-verified — follow-up issue planned)
- ❌ In-place `anet batch restart` / `start` supervisor (Phase 2)
- ❌ Multi-prefix protected lifecycle filtering (Phase 2)
- ❌ `~/.anet/batches.json` marker registry (Phase 2 cleanup of `batch list` noise)
- ❌ Cross-batch task routing (Phase 3+, RFC-008 future)
- ❌ Fix test infra debt #63 #64 #65 (separate scope per 测试马 triage)

## Scope creep defenses

- ✅ cli.ts + docs/batch.md + README + package.json/lock (touch list aligned with delta summary)
- ✅ No new vendor / runtime / endpoint introduced
- ✅ No new scaffold mode (tmux only, per Vincent 4303)
- ✅ commhub-server / agent-node / demos / docs-site untouched
- ✅ Vincent-verified preset list only (no fabrications)

## Checklist

- [x] Relevant tests pass locally (typecheck + 6 smoke + 1 end-to-end + 4 path traversal reject)
- [ ] `docs-site/docs/changelog.md` updated — n/a (frozen archive; release commit will sync after merge)
- [x] Docs synced — `--help` banners + `docs/batch.md` cover the new surface; demo sci-team `--help` unchanged
- [x] No secrets / tokens / private IPs / `/home/<user>` paths in the diff
- [x] Conventional Commits message (`feat(cli):`)
- [x] **No `Co-Authored-By: Claude*` footer** (OSS rule)
- [x] **Attribution trailer** in commit footer (Author-Agent + Helpers + Refs #55 + Refs #63 #64 #65)
- [x] Issue linked via `Refs #55`

## Release plan post-merge

Per [[project_release_ops_owner]] (boundary shift since preview.7): 通信工程马 (me) runs the full publish chain — `git pull` + `rm -rf dist && npm run build` + functional verify on the obfuscated dist + `npm publish --tag preview` (Vincent 4380 hard rule: preview only, never latest) + docker `--no-cache` E2E + release commit + close #55. preview.8 is the **second** release-ops boundary transition test under the new ownership; passing it confirms reliability cap 8.5.
