### PR TITLE
fix(server): surface failed delivery and reply errors

### DIFF
--- a/docs/qa/test-matrix.md
+++ b/docs/qa/test-matrix.md
@@ -31,7 +31,8 @@
 | HUB-06b | utok 跨用户隔离 / IDOR 边界 | ✅ | [qa-hub-06b](../../tests/qa-hub-06b-cross-user-isolation/) R17 PASS（~10s）— bob 偷不到 alice 的 network/task/status/messages，显式 IDOR + cross-tenant inject + mint 全拒 |
 | HUB-07 | SSE 断线后重连不丢消息 | ✅ | [qa-hub-07](../../tests/qa-hub-07-sse-reconnect/) R9 PASS（~12s）— pin fire-and-forget + get_inbox backlog 契约 |
 | HUB-08 | hub 重启不丢状态（sessions + tasks + ntok + SSE 重订） | ✅ | [qa-hub-08](../../tests/qa-hub-08-restart-persistence/) R11 PASS（~10s）— NODE-04 的 hub-side 半边 |
-| HUB-09 | task 状态机 delivered→replied/failed/cancelled + terminal no-op | ✅ | [qa-hub-09](../../tests/qa-hub-09-task-state-machine/) R14 PASS（~12s）— 3 分支 + cancelled inbox auto-ack + send_reply terminal silent no-op + cancel_task terminal ok:false |
+| HUB-09 | task 状态机 delivered→replied/failed/cancelled + terminal reply hard reject | ✅ | [qa-hub-09](../../tests/qa-hub-09-task-state-machine/) — 3 分支 + cancelled inbox auto-ack + send_reply terminal structured error + cancel_task terminal ok:false |
+| HUB-18 | send/reply delivery semantics: missing alias vs offline queue vs bad reply | ✅ | [qa-hub-18](../../tests/qa-hub-18-delivery-semantics/) Wave 1 PASS — `alias_not_found` 不入库，`alias_offline` 入 inbox/tasks 但明确 queued，bad `send_reply` 返回结构化错误 |
 
 ## agent-node 矩阵（persona: runtime adapter）
 

--- a/docs/qa/v0-summary.md
+++ b/docs/qa/v0-summary.md
@@ -82,7 +82,7 @@ CI 真实抓 race ≥4 次（每次都是新 hub-bootstrap 后 auth race，固�
 | 1 | R5 (HUB-06) | utok reset-user **不级联** ntok（`auth.ts L267` 只 DELETE network_id IS NULL）| 设计还是 bug 待 Vincent 评 |
 | 2 | R6 (NODE-02) | `/api/networks` POST 响应 shape 因 caller 异（admin top-level vs 普通 nested）| 统一 shape |
 | 3 | R6 (NODE-02) | admin login 在 /health 200 后短暂 401（bootstrap race）| doc + retry 写进 SDK examples |
-| 4 | R14 (HUB-09) | send_reply terminal silent no-op vs cancel_task terminal ok:false（不一致）| 一致化（都 silent 或都 hard reject）|
+| 4 | R14 (HUB-09) | send_reply terminal silent no-op vs cancel_task terminal ok:false（不一致）| Wave 1 改为 send_reply terminal structured error；cancel_task 保持 ok:false |
 | 5 | R5 (HUB-06) | POST `/api/auth/node-token` 响应缺 `token_id`，SDK 撤销自己 mint 的 ntok 要绕路 | 加 token_id 字段 |
 | 6 | R5 (HUB-06) | `register()` 自动建 default network + ntok，新用户有 3 token 不是 2 | doc 明确 |
 | 7 | R14 (HUB-09) | `cancel_task` 需 NTOK，admin UTOK 无干净取消路径 | hub 加 UTOK + network_id 路径 |

--- a/docs/tests/report-qa-hub-09.txt
+++ b/docs/tests/report-qa-hub-09.txt
@@ -22,10 +22,10 @@ Contracts pinned:
    cancel_task always writes 'cancelled'
    Future new terminal (e.g. 'timeout') needs enum + state-machine update.
 
-2. Terminal-state non-reversibility (with quirk):
-   - send_reply on terminal: silent no-op (response.ok=true, task unchanged)
+2. Terminal-state non-reversibility:
+   - send_reply on terminal: structured error (response.ok=false,
+     error=reply_task_terminal), task unchanged
    - cancel_task on terminal: ok:false (changes=0 path)
-   Inconsistent behavior pinned for maintainer to decide later.
 
 3. Cancelled inbox auto-acked:
    cancel_task also runs `UPDATE inbox SET acked=1 WHERE id=task_id`

--- a/docs/tests/report-qa-hub-18-delivery-semantics.md
+++ b/docs/tests/report-qa-hub-18-delivery-semantics.md
@@ -1,0 +1,28 @@
+# qa-hub-18-delivery-semantics
+
+Status: PASS
+
+Date: 2026-06-10
+
+Scope:
+
+- #214 Wave 1 server delivery semantics.
+- #168 server-side bad reply visibility.
+- #172 missing/dead alias dispatch visibility.
+
+Docker:
+
+```bash
+sg docker -c 'docker build -f tests/qa-hub-18-delivery-semantics/Dockerfile -t anet-qa-hub-18-delivery-semantics .'
+sg docker -c 'docker run --rm anet-qa-hub-18-delivery-semantics'
+```
+
+Verified:
+
+- REST `/api/task` to missing alias returns HTTP 404 with `alias_not_found` and does not queue.
+- MCP `send_task` to missing alias returns `alias_not_found` and does not queue.
+- REST `/api/task` to offline alias returns HTTP 202 with `alias_offline`, `queued:true`, and `task_id/message_id`.
+- MCP `send_task` to offline alias returns `alias_offline`, `queued:true`, and writes task.
+- MCP `send_message` separates missing alias from offline queued alias.
+- `send_reply` with missing `in_reply_to` returns `reply_task_not_found`.
+- `send_reply` on terminal task returns `reply_task_terminal` and does not overwrite task result.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -341,6 +341,36 @@ function canRestWriteNetwork(authCtx: { userId: string; networkId: string | null
   return !!role && role !== "viewer";
 }
 
+type RestDeliveryTarget =
+  | { state: "online"; alias: string; session: any }
+  | { state: "offline"; alias: string; session: any; message: string }
+  | { state: "not_found"; alias: string; message: string };
+
+function resolveRestDeliveryTarget(alias: string, networkId: string | null): RestDeliveryTarget {
+  const params: any[] = [alias];
+  let sql = "SELECT status, updated_at, last_seen_at FROM sessions WHERE alias = ?1";
+  if (networkId) {
+    sql += " AND network_id = ?2";
+    params.push(networkId);
+  }
+  const session = db.get<any>(sql, ...params);
+  if (!session) {
+    return { state: "not_found", alias, message: `alias not found: ${alias}` };
+  }
+  const lastSeen = session.last_seen_at || session.updated_at;
+  const lastSeenAt = lastSeen ? new Date(String(lastSeen).replace(" ", "T") + "Z").getTime() : 0;
+  const stale = !lastSeenAt || Date.now() - lastSeenAt > 5 * 60 * 1000;
+  if (String(session.status || "").toLowerCase() === "offline" || stale) {
+    return {
+      state: "offline",
+      alias,
+      session,
+      message: `alias is offline; task queued in inbox: ${alias}`,
+    };
+  }
+  return { state: "online", alias, session };
+}
+
 // ── REST input schema ───────────────────────────────
 const TaskSchema = z.object({
   alias: z.string().min(1).max(200),
@@ -1199,6 +1229,17 @@ Bun.serve({
       }
       const canonical = resolveCanonicalAlias(taskNetId, body.alias);
       const targetAlias = canonical.alias;
+      const target = resolveRestDeliveryTarget(targetAlias, taskNetId);
+      if (target.state === "not_found") {
+        return withCors(req, Response.json({
+          ok: false,
+          error: "alias_not_found",
+          message: target.message,
+          alias: targetAlias,
+          queued: false,
+          ...(canonical.renamed ? { renamed_from: body.alias, renamed_to: targetAlias } : {}),
+        }, { status: 404 }));
+      }
       const id = crypto.randomUUID();
       const fromSession = body.from || "api";
       const ttlSeconds = (body as any).ttl_seconds || 3600;
@@ -1251,15 +1292,26 @@ Bun.serve({
       let pendingSql = "SELECT COUNT(*) as cnt FROM inbox WHERE session_name = ?1 AND acked = 0";
       if (taskNetId) { pendingSql += " AND network_id = ?2"; pendingParams.push(taskNetId); }
       const pending = db.get<{ cnt: number }>(pendingSql, ...pendingParams);
-      const sessionParams: any[] = [targetAlias];
-      let sessionSql = "SELECT 1 FROM sessions WHERE alias = ?1";
-      if (taskNetId) { sessionSql += " AND network_id = ?2"; sessionParams.push(taskNetId); }
-      const targetSession = db.get<any>(sessionSql, ...sessionParams);
-      if (targetSession) pushEvent(targetAlias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority: body.priority, from: fromSession, ...(canonical.renamed ? { renamed_from: body.alias } : {}) }, taskNetId);
+      if (target.state === "online") {
+        pushEvent(targetAlias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority: body.priority, from: fromSession, ...(canonical.renamed ? { renamed_from: body.alias } : {}) }, taskNetId);
+      }
       // #212 — stamp the dedup index only after the inbox/tasks insert
       // succeeds. Mirrors the MCP `send_task` path so a failed write
       // never shadows a legitimate retry.
       sharedSendDedup.record(fromSession, targetAlias, body.task);
+      if (target.state === "offline") {
+        return withCors(req, Response.json({
+          ok: false,
+          error: "alias_offline",
+          message: target.message,
+          alias: targetAlias,
+          queued: true,
+          task_id: id,
+          message_id: id,
+          session_status: target.session.status ?? "offline",
+          ...(canonical.renamed ? { renamed_from: body.alias, renamed_to: targetAlias } : {}),
+        }, { status: 202 }));
+      }
       return withCors(req, Response.json({ ok: true, task_id: id, message_id: id, ...(canonical.renamed ? { renamed_from: body.alias, renamed_to: targetAlias } : {}) }));
     }
 

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -112,11 +112,74 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     return sql;
   };
 
+  type DeliveryTarget =
+    | { state: "online"; alias: string; session: any }
+    | { state: "offline"; alias: string; session: any; message: string }
+    | { state: "not_found"; alias: string; message: string };
+
   const scopedSessionStatus = (alias: string, networkId?: string | null) => {
     const params: any[] = [alias];
-    let sql = "SELECT status FROM sessions WHERE alias = ?1";
+    let sql = "SELECT status, updated_at, last_seen_at FROM sessions WHERE alias = ?1";
     sql = addScope(sql, params, networkId);
     return db.get<any>(sql, ...params);
+  };
+
+  const resolveDeliveryTarget = (alias: string, networkId?: string | null): DeliveryTarget => {
+    const session = scopedSessionStatus(alias, networkId);
+    if (!session) {
+      return {
+        state: "not_found",
+        alias,
+        message: `alias not found: ${alias}`,
+      };
+    }
+    const lastSeen = session.last_seen_at || session.updated_at;
+    const lastSeenAt = lastSeen ? new Date(String(lastSeen).replace(" ", "T") + "Z").getTime() : 0;
+    const stale = !lastSeenAt || Date.now() - lastSeenAt > 5 * 60 * 1000;
+    if (String(session.status || "").toLowerCase() === "offline" || stale) {
+      return {
+        state: "offline",
+        alias,
+        session,
+        message: `alias is offline; message queued in inbox: ${alias}`,
+      };
+    }
+    return { state: "online", alias, session };
+  };
+
+  const deliveryTargetReply = (target: DeliveryTarget, ids: Record<string, string> = {}) => {
+    if (target.state === "not_found") {
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify({
+            ok: false,
+            error: "alias_not_found",
+            message: target.message,
+            alias: target.alias,
+            queued: false,
+            ...ids,
+          }),
+        }],
+      };
+    }
+    if (target.state === "offline") {
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify({
+            ok: false,
+            error: "alias_offline",
+            message: target.message,
+            alias: target.alias,
+            queued: true,
+            session_status: target.session.status ?? "offline",
+            ...ids,
+          }),
+        }],
+      };
+    }
+    return null;
   };
   // ═══════════════════════════════════════════
   //  Child Agent Tools (4)
@@ -658,6 +721,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
       const canonical = resolveCanonicalAlias(effectiveNetId, alias);
       const targetAlias = canonical.alias;
+      const target = resolveDeliveryTarget(targetAlias, effectiveNetId);
+      if (target.state === "not_found") return deliveryTargetReply(target)!;
 
       // #212 dedup guardrail. If this exact (from, to, content) has already
       // been delivered within COMMHUB_SEND_DEDUP_WINDOW_MS (default 5 min)
@@ -707,8 +772,6 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       // retry.
       sharedSendDedup.record(from_session, targetAlias, task);
 
-      const session = scopedSessionStatus(targetAlias, effectiveNetId);
-
       // SSE push by alias.
       // The SSE channel is keyed by alias (subscribers connected to /events/<alias>),
       // not by network_id. Earlier we gated the push on a network-scoped session
@@ -720,7 +783,28 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       let pendingSql = "SELECT COUNT(*) as cnt FROM inbox WHERE session_name = ?1 AND acked = 0";
       pendingSql = addScope(pendingSql, pendingParams, effectiveNetId);
       const pending = db.get<{ cnt: number }>(pendingSql, ...pendingParams);
-      pushEvent(targetAlias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority, from: from_session, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
+      if (target.state === "online") {
+        pushEvent(targetAlias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority, from: from_session, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
+      }
+
+      if (target.state === "offline") {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              ok: false,
+              error: "alias_offline",
+              message: target.message,
+              alias: targetAlias,
+              queued: true,
+              task_id: id,
+              message_id: id,
+              session_status: target.session.status ?? "offline",
+              ...(canonical.renamed ? { renamed_from: alias, renamed_to: targetAlias } : {}),
+            }),
+          }],
+        };
+      }
 
       return {
         content: [
@@ -730,7 +814,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
               ok: true,
               message_id: id,
               ...(canonical.renamed ? { renamed_from: alias, renamed_to: targetAlias } : {}),
-              session_status: session?.status ?? "unknown",
+              session_status: target.session?.status ?? "unknown",
             }),
           },
         ],
@@ -749,6 +833,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     async ({ alias, message, from_session: _fromIn }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
       const effectiveNetId = getNetworkId(null);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
+      const target = resolveDeliveryTarget(alias, effectiveNetId);
+      if (target.state === "not_found") return deliveryTargetReply(target)!;
       console.log(`[${ts()}] ${from_session} → send_message → ${alias}: ${message.slice(0, 60)}`);
       const id = uuidv4();
       db.run(
@@ -757,9 +843,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         [id, alias, message, from_session, effectiveNetId ?? null]
       );
 
-      const session = scopedSessionStatus(alias, effectiveNetId);
+      if (target.state === "online") {
+        pushEvent(alias, { type: "new_message", from: from_session, message_id: id }, effectiveNetId);
+      }
 
-      pushEvent(alias, { type: "new_message", from: from_session, message_id: id }, effectiveNetId);
+      const offlineReply = deliveryTargetReply(target, { message_id: id });
+      if (offlineReply) return offlineReply;
 
       return {
         content: [
@@ -768,7 +857,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
             text: JSON.stringify({
               ok: true,
               message_id: id,
-              session_status: session?.status ?? "unknown",
+              session_status: target.session?.status ?? "unknown",
             }),
           },
         ],
@@ -792,6 +881,42 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       console.log(`[${ts()}] ${from_session} → send_reply (${replyStatus}) → ${alias}: ${text.slice(0, 60)}`);
       const id = uuidv4();
+      let taskBefore: { status: string } | null = null;
+      if (in_reply_to) {
+        const taskParams: any[] = [in_reply_to];
+        let taskSql = "SELECT status FROM tasks WHERE task_id = ?1";
+        taskSql = addScope(taskSql, taskParams, effectiveNetId);
+        taskBefore = db.get<{ status: string }>(taskSql, ...taskParams) ?? null;
+        if (!taskBefore) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: false,
+                error: "reply_task_not_found",
+                message: `cannot apply reply: task not found (${in_reply_to})`,
+                in_reply_to,
+                reply_queued: false,
+              }),
+            }],
+          };
+        }
+        if (!["created", "delivered", "acked", "running"].includes(taskBefore.status)) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: false,
+                error: "reply_task_terminal",
+                message: `cannot apply reply: task is already terminal (${taskBefore.status})`,
+                in_reply_to,
+                task_status: taskBefore.status,
+                reply_queued: false,
+              }),
+            }],
+          };
+        }
+      }
       const replyLogged = db.transaction(() => {
         db.run(
           `INSERT INTO inbox (id, session_name, type, priority, content, from_session, in_reply_to, requires_response, network_id)
@@ -814,6 +939,21 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         }
         return false;
       });
+
+      if (in_reply_to && !replyLogged) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              ok: false,
+              error: "reply_not_applied",
+              message: "reply was not applied to task",
+              in_reply_to,
+              reply_queued: false,
+            }),
+          }],
+        };
+      }
 
       // Log event after commit (outside transaction)
       if (replyLogged && in_reply_to) logTaskEvent(in_reply_to, null, replyStatus, from_session, text.slice(0, 200));

--- a/tests/docker-e2e.sh
+++ b/tests/docker-e2e.sh
@@ -285,7 +285,8 @@ echo ""
 # 20. send_reply to non-existent task (graceful)
 echo "20. Testing reply to non-existent task..."
 GHOST_REPLY=$(mcp_call "send_reply" '{"alias":"e2e-agent","text":"ghost reply","in_reply_to":"non-existent-id","from_session":"tester"}')
-echo "$GHOST_REPLY" | grep -q 'ok' && pass "reply to non-existent task (graceful)" || fail "ghost reply crashed"
+echo "$GHOST_REPLY" | jq -e '.ok == false and .error == "reply_task_not_found"' >/dev/null \
+  && pass "reply to non-existent task returns structured error" || fail "ghost reply contract broken"
 echo ""
 
 # 21. tasks REST with multiple filters

--- a/tests/qa-hub-09-task-state-machine/run.sh
+++ b/tests/qa-hub-09-task-state-machine/run.sh
@@ -142,15 +142,14 @@ INBOX=$(mcp_call "$NTOK" "get_inbox" "$ARG")
 LEAK=$(echo "$INBOX" | jq -r '[.messages[] | select(.content=="task-cancelled")] | length')
 [[ "$LEAK" -eq 0 ]] || { echo "FAIL: cancelled task still in inbox (count=$LEAK)"; echo "$INBOX" | head -20; exit 1; }
 
-# ─────────────── TERMINAL-STATE NO-OP CONTRACT ───────────────
-echo "[7] PIN: send_reply on already-replied task is SILENT no-op"
+# ─────────────── TERMINAL-STATE REJECT CONTRACT ───────────────
+echo "[7] PIN: send_reply on already-replied task returns structured error"
 # R6 抠出的 contract：tools.ts L613-614 WHERE status IN ('created','delivered','acked','running')
-# 终态再来 send_reply：response.ok=false 但 DB 不变
+# 终态再来 send_reply：response.ok=false 且 DB 不变
 ARG=$(jq -nc --arg t "$T_REP" '{alias:"admin",text:"NEW reply trying to overwrite",in_reply_to:$t,status:"replied",from_session:"agent-09"}')
 SR2=$(mcp_call "$NTOK" "send_reply" "$ARG")
-# send_reply doesn't error visibly — it just inserts inbox row and returns... let's check
-# Actually looking at the tool code, it does still log + insert reply inbox row.
-# The KEY assertion is that the TASK row's result/status didn't change.
+echo "$SR2" | jq -e '.ok == false and .error == "reply_task_terminal" and .reply_queued == false' >/dev/null \
+  || { echo "FAIL: terminal send_reply should return structured error, got: $SR2"; exit 1; }
 sleep 0.2
 [[ "$(task_field "$UTOK" "$NET_ID" "$T_REP" result)" == "OK reply" ]] || \
   { echo "FAIL: terminal task.result was overwritten on second send_reply!"; exit 1; }

--- a/tests/qa-hub-16-rest-task-api/run.sh
+++ b/tests/qa-hub-16-rest-task-api/run.sh
@@ -34,6 +34,20 @@ TOKEN=$(echo "$RESP" | jq -r '.token // empty')
 NET=$(echo "$RESP" | jq -r '.network_id // empty')
 [[ "$TOKEN" == utok_* && -n "$NET" ]] || { echo "FAIL: registration did not return token/network"; echo "$RESP"; exit 1; }
 
+echo "[1b] register target-agent session"
+NTOK=$(curl -fsS -X POST "$HUB_BASE/api/auth/node-token" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"network_id\":\"$NET\",\"node_name\":\"target-agent\"}" | jq -r '.token // empty')
+[[ "$NTOK" == ntok_* ]] || { echo "FAIL: node-token"; exit 1; }
+BODY=$(jq -nc --arg net "$NET" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"report_status",arguments:{resume_id:"qa16-target-agent",alias:"target-agent",status:"idle",network_id:$net}}}')
+RS=$(curl -fsS -X POST "$HUB_BASE/mcp" \
+  -H "Authorization: Bearer $NTOK" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2025-03-26' \
+  -d "$BODY" | sed -n 's/^data: //p' | head -1 | jq -r '.result.content[0].text // empty')
+echo "$RS" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status target-agent: $RS"; exit 1; }
+
 echo "[2] send REST task with parent_task_id"
 PARENT_ID="parent-probe-001"
 SEND=$(jq -n --arg alias "target-agent" --arg task "rest fallback probe" --arg from "qa-probe" --arg net "$NET" --arg parent "$PARENT_ID" \

--- a/tests/qa-hub-18-delivery-semantics/Dockerfile
+++ b/tests/qa-hub-18-delivery-semantics/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-certificates jq unzip && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /app/server
+COPY server/package.json ./
+RUN bun install
+COPY server/src ./src
+
+WORKDIR /app
+COPY tests/qa-hub-18-delivery-semantics/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/qa-hub-18-delivery-semantics/run.sh
+++ b/tests/qa-hub-18-delivery-semantics/run.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export HOME=/tmp/anethome
+export COMMHUB_DB=/tmp/commhub-qa18.db
+HUB_PORT=9218
+HUB_BASE="http://127.0.0.1:$HUB_PORT"
+REPORT="/app/docs/tests/report-qa-hub-18-delivery-semantics.md"
+
+cleanup() {
+  [[ -n "${HUB_PID:-}" ]] && kill "$HUB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$REPORT")"
+cat > "$REPORT" <<'REPORT'
+# qa-hub-18-delivery-semantics
+
+Status: RUNNING
+REPORT
+
+mcp_call() {
+  local tok="$1" name="$2" args="$3"
+  local body
+  body=$(jq -nc --arg n "$name" --argjson a "$args" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:$n,arguments:$a}}')
+  curl -sS -X POST "$HUB_BASE/mcp" \
+    -H "Authorization: Bearer $tok" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -H 'MCP-Protocol-Version: 2025-03-26' \
+    -d "$body" \
+    | sed -n 's/^data: //p' | head -1 \
+    | jq -r '.result.content[0].text // empty'
+}
+
+register_node() {
+  local alias="$1" resume="$2"
+  local ntok
+  ntok=$(curl -fsS -X POST "$HUB_BASE/api/auth/node-token" \
+    -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' \
+    -d "{\"network_id\":\"$NET_ID\",\"node_name\":\"$alias\"}" | jq -r '.token')
+  local arg
+  arg=$(jq -nc --arg net "$NET_ID" --arg alias "$alias" --arg resume "$resume" \
+    '{resume_id:$resume,alias:$alias,status:"idle",network_id:$net}')
+  mcp_call "$ntok" "report_status" "$arg" | jq -e '.ok == true' >/dev/null
+  echo "$ntok"
+}
+
+task_status() {
+  local tid="$1"
+  curl -fsS "$HUB_BASE/api/tasks?task_id=$tid&network_id=$NET_ID" \
+    -H "Authorization: Bearer $UTOK" | jq -r '.tasks[0].status // empty'
+}
+
+task_result() {
+  local tid="$1"
+  curl -fsS "$HUB_BASE/api/tasks?task_id=$tid&network_id=$NET_ID" \
+    -H "Authorization: Bearer $UTOK" | jq -r '.tasks[0].result // empty'
+}
+
+echo "[0] start local hub"
+rm -rf "$HOME/.commhub" "$HOME/.anet/server" "$COMMHUB_DB"
+cd /app/server
+HOST=127.0.0.1 PORT="$HUB_PORT" bun run src/index.ts >/tmp/hub.log 2>&1 &
+HUB_PID=$!
+for _ in {1..60}; do curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && break; sleep 0.5; done
+curl -fsS "$HUB_BASE/health" >/dev/null || { echo "FAIL: hub did not start"; cat /tmp/hub.log; exit 1; }
+
+echo "[1] register user and nodes"
+RESP=$(curl -fsS -X POST "$HUB_BASE/api/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"qa18","password":"StrongPassw0rd!"}')
+UTOK=$(echo "$RESP" | jq -r '.token // empty')
+NET_ID=$(echo "$RESP" | jq -r '.network_id // empty')
+[[ "$UTOK" == utok_* && -n "$NET_ID" ]] || { echo "FAIL: registration"; echo "$RESP"; exit 1; }
+
+LIVE_NTOK=$(register_node "agent-live" "qa18-live")
+OFF_NTOK=$(register_node "agent-offline" "qa18-offline")
+OFF_ARG=$(jq -nc --arg net "$NET_ID" '{resume_id:"qa18-offline",alias:"agent-offline",status:"offline",network_id:$net}')
+mcp_call "$OFF_NTOK" "report_status" "$OFF_ARG" | jq -e '.ok == true' >/dev/null
+
+echo "[2] REST /api/task missing alias returns 404 and no queue"
+HTTP_CODE=$(jq -n --arg net "$NET_ID" '{alias:"ghost-rest",task:"missing rest",network_id:$net}' \
+  | curl -sS -o /tmp/rest-missing.json -w "%{http_code}" -X POST "$HUB_BASE/api/task" \
+      -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' --data-binary @-)
+[[ "$HTTP_CODE" == "404" ]] || { echo "FAIL: missing REST code $HTTP_CODE"; cat /tmp/rest-missing.json; exit 1; }
+jq -e '.ok == false and .error == "alias_not_found" and .queued == false' /tmp/rest-missing.json >/dev/null
+
+echo "[3] MCP send_task missing alias returns alias_not_found"
+ARG=$(jq -nc --arg net "$NET_ID" '{alias:"ghost-mcp",task:"missing mcp",network_id:$net,from_session:"agent-live"}')
+MISSING_TASK=$(mcp_call "$LIVE_NTOK" "send_task" "$ARG")
+echo "$MISSING_TASK" | jq -e '.ok == false and .error == "alias_not_found" and .queued == false' >/dev/null
+
+echo "[4] REST /api/task offline alias queues but reports alias_offline"
+HTTP_CODE=$(jq -n --arg net "$NET_ID" '{alias:"agent-offline",task:"offline rest",network_id:$net}' \
+  | curl -sS -o /tmp/rest-offline.json -w "%{http_code}" -X POST "$HUB_BASE/api/task" \
+      -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' --data-binary @-)
+[[ "$HTTP_CODE" == "202" ]] || { echo "FAIL: offline REST code $HTTP_CODE"; cat /tmp/rest-offline.json; exit 1; }
+REST_OFF_ID=$(jq -r '.task_id // empty' /tmp/rest-offline.json)
+jq -e '.ok == false and .error == "alias_offline" and .queued == true and (.task_id == .message_id)' /tmp/rest-offline.json >/dev/null
+[[ "$(task_status "$REST_OFF_ID")" == "delivered" ]] || { echo "FAIL: offline REST task not queued"; exit 1; }
+
+echo "[5] MCP send_task offline alias queues but reports alias_offline"
+ARG=$(jq -nc --arg net "$NET_ID" '{alias:"agent-offline",task:"offline mcp",network_id:$net,from_session:"agent-live"}')
+OFF_TASK=$(mcp_call "$LIVE_NTOK" "send_task" "$ARG")
+echo "$OFF_TASK" | jq -e '.ok == false and .error == "alias_offline" and .queued == true and .message_id' >/dev/null
+OFF_TASK_ID=$(echo "$OFF_TASK" | jq -r '.message_id')
+[[ "$(task_status "$OFF_TASK_ID")" == "delivered" ]] || { echo "FAIL: offline MCP task not queued"; exit 1; }
+
+echo "[6] MCP send_message missing/offline semantics"
+ARG=$(jq -nc '{alias:"ghost-msg",message:"hello",from_session:"agent-live"}')
+mcp_call "$LIVE_NTOK" "send_message" "$ARG" | jq -e '.ok == false and .error == "alias_not_found" and .queued == false' >/dev/null
+ARG=$(jq -nc '{alias:"agent-offline",message:"queued hello",from_session:"agent-live"}')
+OFF_MSG=$(mcp_call "$LIVE_NTOK" "send_message" "$ARG")
+echo "$OFF_MSG" | jq -e '.ok == false and .error == "alias_offline" and .queued == true and .message_id' >/dev/null
+ARG=$(jq -nc '{alias:"agent-offline",limit:20}')
+mcp_call "$OFF_NTOK" "get_inbox" "$ARG" | jq -e '[.messages[] | select(.content=="queued hello")] | length == 1' >/dev/null
+
+echo "[7] send_reply missing task is structured error"
+ARG=$(jq -nc '{alias:"agent-live",text:"ghost reply",in_reply_to:"missing-task-id",status:"replied",from_session:"agent-live"}')
+mcp_call "$LIVE_NTOK" "send_reply" "$ARG" | jq -e '.ok == false and .error == "reply_task_not_found" and .reply_queued == false' >/dev/null
+
+echo "[8] send_reply terminal task is structured error and does not overwrite"
+LIVE_SEND=$(jq -n --arg net "$NET_ID" '{alias:"agent-live",task:"reply once",network_id:$net}' \
+  | curl -fsS -X POST "$HUB_BASE/api/task" \
+      -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' --data-binary @-)
+LIVE_TASK_ID=$(echo "$LIVE_SEND" | jq -r '.task_id')
+ARG=$(jq -nc --arg tid "$LIVE_TASK_ID" '{alias:"qa18",text:"first",in_reply_to:$tid,status:"replied",from_session:"agent-live"}')
+mcp_call "$LIVE_NTOK" "send_reply" "$ARG" | jq -e '.ok == true' >/dev/null
+[[ "$(task_result "$LIVE_TASK_ID")" == "first" ]] || { echo "FAIL: first reply not applied"; exit 1; }
+ARG=$(jq -nc --arg tid "$LIVE_TASK_ID" '{alias:"qa18",text:"second",in_reply_to:$tid,status:"replied",from_session:"agent-live"}')
+TERM_REPLY=$(mcp_call "$LIVE_NTOK" "send_reply" "$ARG")
+echo "$TERM_REPLY" | jq -e '.ok == false and .error == "reply_task_terminal" and .reply_queued == false and .task_status == "replied"' >/dev/null
+[[ "$(task_result "$LIVE_TASK_ID")" == "first" ]] || { echo "FAIL: terminal reply overwrote result"; exit 1; }
+
+cat > "$REPORT" <<REPORT
+# qa-hub-18-delivery-semantics
+
+Status: PASS
+
+Verified:
+
+- REST /api/task missing alias returns 404 alias_not_found and does not queue.
+- MCP send_task missing alias returns alias_not_found and does not queue.
+- REST /api/task offline alias returns 202 alias_offline with queued=true and task_id/message_id.
+- MCP send_task offline alias returns alias_offline with queued=true and writes task.
+- MCP send_message missing/offline aliases report alias_not_found vs alias_offline.
+- send_reply missing task returns reply_task_not_found.
+- send_reply terminal task returns reply_task_terminal and does not overwrite result.
+REPORT
+
+echo "PASS qa-hub-18-delivery-semantics"

--- a/tests/test4-base/run.sh
+++ b/tests/test4-base/run.sh
@@ -292,7 +292,8 @@ echo ""
 # 20. send_reply to non-existent task (graceful)
 echo "20. Testing reply to non-existent task..."
 GHOST_REPLY=$(mcp_call "send_reply" '{"alias":"e2e-agent","text":"ghost reply","in_reply_to":"non-existent-id","from_session":"tester"}')
-echo "$GHOST_REPLY" | grep -q 'ok' && pass "reply to non-existent task (graceful)" || fail "ghost reply crashed"
+echo "$GHOST_REPLY" | jq -e '.ok == false and .error == "reply_task_not_found"' >/dev/null \
+  && pass "reply to non-existent task returns structured error" || fail "ghost reply contract broken"
 echo ""
 
 # 21. tasks REST with multiple filters


### PR DESCRIPTION
## Summary

Wave 1 server-side fixes from #214 dimension 4:

- return structured `reply_task_not_found` / `reply_task_terminal` errors when `send_reply` cannot apply to `in_reply_to`
- return `alias_not_found` for missing REST `/api/task`, MCP `send_task`, and MCP `send_message` targets without queuing orphan rows
- return explicit `alias_offline` with `queued:true` for offline targets while still writing inbox/tasks
- add Docker regression suite `qa-hub-18-delivery-semantics`
- update stale test/docs references for terminal `send_reply` behavior

## Verification

- `COMMHUB_DB=/tmp/commhub-wave1-bun-test-2.db bun test` in `server/` -> 74 pass
- `sg docker -c 'docker build -f tests/qa-hub-18-delivery-semantics/Dockerfile -t anet-qa-hub-18-delivery-semantics . && docker run --rm anet-qa-hub-18-delivery-semantics'` -> PASS
- `sg docker -c 'docker build -f tests/qa-hub-16-rest-task-api/Dockerfile -t anet-qa-hub-16-rest-task-api . && docker run --rm anet-qa-hub-16-rest-task-api'` -> PASS

Fixes server-side half of #168 and #172.

Issue: #214
