### PR TITLE
fix(server): harden rename alias routing

### DIFF
--- a/docs/tests/report-rename-server-pr1-pr2.txt
+++ b/docs/tests/report-rename-server-pr1-pr2.txt
@@ -1,0 +1,31 @@
+Rename server PR-1+2 verification
+Date: 2026-06-11
+Branch: fix/rename-server-pr1-pr2
+
+Scope:
+- send_message canonical alias routing after rename
+- SSE client map rekey on rename-committed internal event
+- inbox/tasks node_id columns and migration backfill log
+- list_tasks from_node_id filter with from_name compatibility
+- prepareRename node_local_only soft signal
+
+Commands:
+- COMMHUB_DB=/tmp/commhub-rename-push-test.db bun test src/push.test.ts
+- sg docker -c 'docker build -f tests/qa-hub-17-rename-canonicalization/Dockerfile -t anet-qa-hub-17-rename-canonicalization .'
+- sg docker -c 'docker run --rm anet-qa-hub-17-rename-canonicalization'
+- sg docker -c 'docker build -f tests/qa-hub-16-rest-task-api/Dockerfile -t anet-qa-hub-16-rest-task-api .'
+- sg docker -c 'docker run --rm anet-qa-hub-16-rest-task-api'
+- sg docker -c 'docker build -f tests/qa-hub-18-delivery-semantics/Dockerfile -t anet-qa-hub-18-delivery-semantics .'
+- sg docker -c 'docker run --rm anet-qa-hub-18-delivery-semantics'
+
+Results:
+- PASS: src/push.test.ts, 2/2 tests
+- PASS: qa-hub-17-rename-canonicalization
+- PASS: qa-hub-16-rest-task-api
+- PASS: qa-hub-18-delivery-semantics
+
+Notes:
+- Full local `bun test` was not used as the merge gate in this worktree because
+  this isolated worktree does not carry installed server dependencies; Docker
+  fixtures run `bun install` inside containers and are the required validation
+  path for this change.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -123,13 +123,14 @@ db.exec(`
     ON agent_telemetry(network_id, alias, created_at);
 `);
 
-// inbox: add in_reply_to, requires_response, expires_at, scope
+// inbox: add in_reply_to, requires_response, expires_at, scope, node identity
 for (const col of [
   { name: "in_reply_to", def: "TEXT" },
   { name: "requires_response", def: "TEXT DEFAULT 'reply'" },
   { name: "expires_at", def: "TEXT" },
   { name: "scope", def: "TEXT DEFAULT 'single'" },
   { name: "meta_json", def: "TEXT" },
+  { name: "node_id", def: "TEXT" },
 ]) {
   try { db.exec(`ALTER TABLE inbox ADD COLUMN ${col.name} ${col.def}`); } catch {}
 }
@@ -138,6 +139,7 @@ for (const col of [
 try { db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_type ON inbox(type)"); } catch {}
 try { db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_from ON inbox(from_session)"); } catch {}
 try { db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_reply ON inbox(in_reply_to)"); } catch {}
+try { db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_node ON inbox(node_id)"); } catch {}
 try { db.exec("CREATE INDEX IF NOT EXISTS idx_sessions_node ON sessions(node_id)"); } catch {}
 
 // tasks table (V2)
@@ -384,6 +386,185 @@ for (const table of ["sessions", "nodes", "tasks", "inbox", "task_events", "comp
   try { db.exec(`ALTER TABLE ${table} ADD COLUMN network_id TEXT`); } catch {}
 }
 
+// PR-1 (#146): durable node identity on historical inbox/tasks rows. Some
+// existing databases created `tasks` before from_node_id/to_node_id were in the
+// CREATE TABLE statement, so keep these ALTERs explicit and idempotent.
+for (const col of [
+  { table: "tasks", name: "from_node_id", def: "TEXT" },
+  { table: "tasks", name: "to_node_id", def: "TEXT" },
+  { table: "inbox", name: "node_id", def: "TEXT" },
+]) {
+  try { db.exec(`ALTER TABLE ${col.table} ADD COLUMN ${col.name} ${col.def}`); } catch {}
+}
+
+try { db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_from_node ON tasks(from_node_id)"); } catch {}
+try { db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_to_node ON tasks(to_node_id)"); } catch {}
+try { db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_node ON inbox(node_id)"); } catch {}
+
+function backfillMessageNodeIds() {
+  let inboxDirect = 0;
+  let inboxRenamed = 0;
+  let tasksToDirect = 0;
+  let tasksToRenamed = 0;
+  let tasksFromDirect = 0;
+  let tasksFromRenamed = 0;
+
+  try {
+    inboxDirect = db.run(`
+      UPDATE inbox
+      SET node_id = (
+        SELECT s.node_id FROM sessions s
+        WHERE s.node_id IS NOT NULL
+          AND s.alias = inbox.session_name
+          AND COALESCE(s.network_id, 'default') = COALESCE(inbox.network_id, 'default')
+        ORDER BY s.updated_at DESC
+        LIMIT 1
+      )
+      WHERE node_id IS NULL
+        AND EXISTS (
+          SELECT 1 FROM sessions s
+          WHERE s.node_id IS NOT NULL
+            AND s.alias = inbox.session_name
+            AND COALESCE(s.network_id, 'default') = COALESCE(inbox.network_id, 'default')
+        )
+    `).changes;
+  } catch {}
+
+  try {
+    inboxRenamed = db.run(`
+      UPDATE inbox
+      SET node_id = (
+        SELECT s.node_id FROM rename_txn r
+        JOIN sessions s
+          ON s.alias = r.new_alias
+         AND COALESCE(s.network_id, 'default') = COALESCE(r.network_id, 'default')
+        WHERE s.node_id IS NOT NULL
+          AND r.status = 'committed'
+          AND r.old_alias = inbox.session_name
+          AND COALESCE(r.network_id, 'default') = COALESCE(inbox.network_id, 'default')
+        ORDER BY r.committed_at DESC
+        LIMIT 1
+      )
+      WHERE node_id IS NULL
+        AND EXISTS (
+          SELECT 1 FROM rename_txn r
+          JOIN sessions s
+            ON s.alias = r.new_alias
+           AND COALESCE(s.network_id, 'default') = COALESCE(r.network_id, 'default')
+          WHERE s.node_id IS NOT NULL
+            AND r.status = 'committed'
+            AND r.old_alias = inbox.session_name
+            AND COALESCE(r.network_id, 'default') = COALESCE(inbox.network_id, 'default')
+        )
+    `).changes;
+  } catch {}
+
+  try {
+    tasksToDirect = db.run(`
+      UPDATE tasks
+      SET to_node_id = (
+        SELECT s.node_id FROM sessions s
+        WHERE s.node_id IS NOT NULL
+          AND s.alias = tasks.to_name
+          AND COALESCE(s.network_id, 'default') = COALESCE(tasks.network_id, 'default')
+        ORDER BY s.updated_at DESC
+        LIMIT 1
+      )
+      WHERE to_node_id IS NULL
+        AND EXISTS (
+          SELECT 1 FROM sessions s
+          WHERE s.node_id IS NOT NULL
+            AND s.alias = tasks.to_name
+            AND COALESCE(s.network_id, 'default') = COALESCE(tasks.network_id, 'default')
+        )
+    `).changes;
+  } catch {}
+
+  try {
+    tasksToRenamed = db.run(`
+      UPDATE tasks
+      SET to_node_id = (
+        SELECT s.node_id FROM rename_txn r
+        JOIN sessions s
+          ON s.alias = r.new_alias
+         AND COALESCE(s.network_id, 'default') = COALESCE(r.network_id, 'default')
+        WHERE s.node_id IS NOT NULL
+          AND r.status = 'committed'
+          AND r.old_alias = tasks.to_name
+          AND COALESCE(r.network_id, 'default') = COALESCE(tasks.network_id, 'default')
+        ORDER BY r.committed_at DESC
+        LIMIT 1
+      )
+      WHERE to_node_id IS NULL
+        AND EXISTS (
+          SELECT 1 FROM rename_txn r
+          JOIN sessions s
+            ON s.alias = r.new_alias
+           AND COALESCE(s.network_id, 'default') = COALESCE(r.network_id, 'default')
+          WHERE s.node_id IS NOT NULL
+            AND r.status = 'committed'
+            AND r.old_alias = tasks.to_name
+            AND COALESCE(r.network_id, 'default') = COALESCE(tasks.network_id, 'default')
+        )
+    `).changes;
+  } catch {}
+
+  try {
+    tasksFromDirect = db.run(`
+      UPDATE tasks
+      SET from_node_id = (
+        SELECT s.node_id FROM sessions s
+        WHERE s.node_id IS NOT NULL
+          AND s.alias = tasks.from_name
+          AND COALESCE(s.network_id, 'default') = COALESCE(tasks.network_id, 'default')
+        ORDER BY s.updated_at DESC
+        LIMIT 1
+      )
+      WHERE from_node_id IS NULL
+        AND EXISTS (
+          SELECT 1 FROM sessions s
+          WHERE s.node_id IS NOT NULL
+            AND s.alias = tasks.from_name
+            AND COALESCE(s.network_id, 'default') = COALESCE(tasks.network_id, 'default')
+        )
+    `).changes;
+  } catch {}
+
+  try {
+    tasksFromRenamed = db.run(`
+      UPDATE tasks
+      SET from_node_id = (
+        SELECT s.node_id FROM rename_txn r
+        JOIN sessions s
+          ON s.alias = r.new_alias
+         AND COALESCE(s.network_id, 'default') = COALESCE(r.network_id, 'default')
+        WHERE s.node_id IS NOT NULL
+          AND r.status = 'committed'
+          AND r.old_alias = tasks.from_name
+          AND COALESCE(r.network_id, 'default') = COALESCE(tasks.network_id, 'default')
+        ORDER BY r.committed_at DESC
+        LIMIT 1
+      )
+      WHERE from_node_id IS NULL
+        AND EXISTS (
+          SELECT 1 FROM rename_txn r
+          JOIN sessions s
+            ON s.alias = r.new_alias
+           AND COALESCE(s.network_id, 'default') = COALESCE(r.network_id, 'default')
+          WHERE s.node_id IS NOT NULL
+            AND r.status = 'committed'
+            AND r.old_alias = tasks.from_name
+            AND COALESCE(r.network_id, 'default') = COALESCE(tasks.network_id, 'default')
+        )
+    `).changes;
+  } catch {}
+
+  const total = inboxDirect + inboxRenamed + tasksToDirect + tasksToRenamed + tasksFromDirect + tasksFromRenamed;
+  console.log(`[commhub] node_id backfill: inbox=${inboxDirect + inboxRenamed}, tasks.to=${tasksToDirect + tasksToRenamed}, tasks.from=${tasksFromDirect + tasksFromRenamed}, total=${total}`);
+}
+
+backfillMessageNodeIds();
+
 // ── P0: sessions alias uniqueness is network-scoped.
 // Older SQLite databases created `alias TEXT UNIQUE`, which prevents the same
 // agent alias from existing in two networks. SQLite cannot drop a UNIQUE
@@ -588,10 +769,14 @@ export function chainReplyToParent(childTaskId: string, replyText: string, reply
     if (parent.from_name && parent.from_name !== "hub" && parent.from_name !== "api") {
       try {
         const notifyId = `chain_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+        const notifyNode = db.get<{ node_id: string | null }>(
+          "SELECT node_id FROM sessions WHERE alias = ?1 AND COALESCE(network_id, 'default') = COALESCE(?2, 'default') ORDER BY updated_at DESC LIMIT 1",
+          [parent.from_name, parent.network_id ?? null]
+        );
         db.run(
-          `INSERT INTO inbox (id, session_name, type, priority, content, from_session, in_reply_to, requires_response, network_id)
-           VALUES (?1, ?2, 'reply', 'normal', ?3, ?4, ?5, 'none', ?6)`,
-          [notifyId, parent.from_name, `[${childAlias} 子任务完成]\n${currentReply.slice(0, 4000)}`, parent.to_name, parent.task_id, parent.network_id ?? null]
+          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, in_reply_to, requires_response, network_id)
+           VALUES (?1, ?2, ?3, 'reply', 'normal', ?4, ?5, ?6, 'none', ?7)`,
+          [notifyId, parent.from_name, notifyNode?.node_id ?? null, `[${childAlias} 子任务完成]\n${currentReply.slice(0, 4000)}`, parent.to_name, parent.task_id, parent.network_id ?? null]
         );
       } catch {}
     }

--- a/server/src/event_bus.ts
+++ b/server/src/event_bus.ts
@@ -1,0 +1,10 @@
+import { EventEmitter } from "events";
+
+export type RenameCommittedEvent = {
+  networkId: string | null;
+  old_alias: string;
+  new_alias: string;
+  node_id?: string | null;
+};
+
+export const eventBus = new EventEmitter();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -364,7 +364,7 @@ type RestDeliveryTarget =
 
 function resolveRestDeliveryTarget(alias: string, networkId: string | null): RestDeliveryTarget {
   const params: any[] = [alias];
-  let sql = "SELECT status, updated_at, last_seen_at FROM sessions WHERE alias = ?1";
+  let sql = "SELECT status, updated_at, last_seen_at, node_id FROM sessions WHERE alias = ?1";
   if (networkId) {
     sql += " AND network_id = ?2";
     params.push(networkId);
@@ -385,6 +385,13 @@ function resolveRestDeliveryTarget(alias: string, networkId: string | null): Res
     };
   }
   return { state: "online", alias, session };
+}
+
+function resolveRestNodeIdForAlias(alias: string, networkId: string | null): string | null {
+  if (!alias || alias === "hub" || alias === "api") return null;
+  const canonical = resolveCanonicalAlias(networkId, alias);
+  const target = resolveRestDeliveryTarget(canonical.alias, networkId);
+  return target.state === "not_found" ? null : (target.session?.node_id ?? null);
 }
 
 // ── REST input schema ───────────────────────────────
@@ -706,7 +713,7 @@ Bun.serve({
         }
         const result = prepareRename(resolved.user.user_id, body.network_id, body.old_alias, body.new_alias);
         if (result.ok) logAudit(resolved.user.user_id, resolved.user.username, "node_rename_prepared", "node", body.old_alias, body.new_alias);
-        return withCors(req, Response.json(result, { status: result.ok ? 200 : 400 }));
+        return withCors(req, Response.json(result, { status: result.ok || result.code === "node_local_only" ? 200 : 400 }));
       } catch (e: any) {
         return withCors(req, Response.json({ ok: false, error: e.message }, { status: 400 }));
       }
@@ -1486,6 +1493,8 @@ Bun.serve({
       const id = crypto.randomUUID();
       const fromSession = body.from || "api";
       const ttlSeconds = (body as any).ttl_seconds || 3600;
+      const fromNodeId = resolveRestNodeIdForAlias(fromSession, taskNetId);
+      const targetNodeId = target.session?.node_id ?? null;
       // #221 — fold top-level `attachments` into `meta.attachments` so
       // the REST and MCP send_task transports produce identical
       // tasks.meta_json shape downstream. Top-level wins over any
@@ -1525,14 +1534,14 @@ Bun.serve({
       // dispatched via REST (anet demo, dashboard Dispatch button, etc.).
       db.transaction(() => {
         db.run(
-          `INSERT INTO inbox (id, session_name, type, priority, content, from_session, requires_response, network_id, meta_json)
-           VALUES (?1, ?2, 'task', ?3, ?4, ?5, 'reply', ?6, ?7)`,
-          [id, targetAlias, body.priority, body.task, fromSession, taskNetId, metaJson]
+          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, requires_response, network_id, meta_json)
+           VALUES (?1, ?2, ?3, 'task', ?4, ?5, ?6, 'reply', ?7, ?8)`,
+          [id, targetAlias, targetNodeId, body.priority, body.task, fromSession, taskNetId, metaJson]
         );
         db.run(
-          `INSERT INTO tasks (task_id, from_name, to_name, priority, status, content, requires_response, created_at, delivered_at, expires_at, network_id, parent_task_id, meta_json)
-           VALUES (?1, ?2, ?3, ?4, 'delivered', ?5, 'reply', datetime('now'), datetime('now'), datetime('now', ?6), ?7, ?8, ?9)`,
-          [id, fromSession, targetAlias, body.priority, body.task, `+${ttlSeconds} seconds`, taskNetId, body.parent_task_id ?? null, metaJson]
+          `INSERT INTO tasks (task_id, from_node_id, from_name, to_node_id, to_name, priority, status, content, requires_response, created_at, delivered_at, expires_at, network_id, parent_task_id, meta_json)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'delivered', ?7, 'reply', datetime('now'), datetime('now'), datetime('now', ?8), ?9, ?10, ?11)`,
+          [id, fromNodeId, fromSession, targetNodeId, targetAlias, body.priority, body.task, `+${ttlSeconds} seconds`, taskNetId, body.parent_task_id ?? null, metaJson]
         );
         // Touch session row so the dashboard reflects "task in flight"
         // immediately, without waiting for the agent's report_status to
@@ -1590,19 +1599,19 @@ Bun.serve({
       if (!canRestWriteNetwork(restAuth, restScope.networkId, isAdmin)) {
         return withCors(req, Response.json({ ok: false, error: "permission_denied" }, { status: 403 }));
       }
-      let sql = "SELECT alias, network_id FROM sessions WHERE alias IS NOT NULL";
+      let sql = "SELECT alias, node_id, network_id FROM sessions WHERE alias IS NOT NULL";
       const params: any[] = [];
       sql = addNetworkScope(sql, params, restScope);
       if (body.filter_server) { sql += " AND server = ?"; params.push(body.filter_server); }
       if (body.filter_status) { sql += " AND status = ?"; params.push(body.filter_status); }
-      const targets = db.all<{ alias: string; network_id: string | null }>(sql, ...params);
+      const targets = db.all<{ alias: string; node_id: string | null; network_id: string | null }>(sql, ...params);
       const ids: string[] = [];
       for (const t of targets) {
         const id = crypto.randomUUID();
         db.run(
-          `INSERT INTO inbox (id, session_name, type, priority, content, from_session, network_id)
-           VALUES (?1, ?2, 'broadcast', 'normal', ?3, 'api', ?4)`,
-          [id, t.alias, body.message, t.network_id]
+          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, network_id)
+           VALUES (?1, ?2, ?3, 'broadcast', 'normal', ?4, 'api', ?5)`,
+          [id, t.alias, t.node_id ?? null, body.message, t.network_id]
         );
         ids.push(id);
       }

--- a/server/src/push.test.ts
+++ b/server/src/push.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, test } from "bun:test";
+import { eventBus } from "./event_bus";
+import { __resetSSEClientsForTest, createSSEStream, getSSEStats } from "./push";
+
+afterEach(() => {
+  __resetSSEClientsForTest();
+});
+
+test("rename-committed rekeys existing SSE clients from old alias to new alias (case 8)", async () => {
+  const res = createSSEStream("old-agent", "net-rekey-8");
+  const reader = res.body!.getReader();
+
+  expect(getSSEStats().sessions["net-rekey-8:old-agent"]).toBe(1);
+  eventBus.emit("rename-committed", {
+    networkId: "net-rekey-8",
+    old_alias: "old-agent",
+    new_alias: "new-agent",
+    node_id: "node-8",
+  });
+
+  const stats = getSSEStats().sessions;
+  expect(stats["net-rekey-8:old-agent"]).toBeUndefined();
+  expect(stats["net-rekey-8:new-agent"]).toBe(1);
+  await reader.cancel();
+});
+
+test("rename-committed merges old and new SSE client buckets without dropping clients (case 11)", async () => {
+  const oldRes = createSSEStream("old-agent", "net-rekey-11");
+  const newRes = createSSEStream("new-agent", "net-rekey-11");
+  const oldReader = oldRes.body!.getReader();
+  const newReader = newRes.body!.getReader();
+
+  expect(getSSEStats().sessions["net-rekey-11:old-agent"]).toBe(1);
+  expect(getSSEStats().sessions["net-rekey-11:new-agent"]).toBe(1);
+  eventBus.emit("rename-committed", {
+    networkId: "net-rekey-11",
+    old_alias: "old-agent",
+    new_alias: "new-agent",
+    node_id: "node-11",
+  });
+
+  const stats = getSSEStats().sessions;
+  expect(stats["net-rekey-11:old-agent"]).toBeUndefined();
+  expect(stats["net-rekey-11:new-agent"]).toBe(2);
+  await oldReader.cancel();
+  await newReader.cancel();
+});

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -2,6 +2,8 @@
 // Agent 连 GET /events/:session → 保持 SSE 长连接
 // send_task 写 inbox 后 → pushEvent() → 秒达
 
+import { eventBus, type RenameCommittedEvent } from "./event_bus";
+
 type SSEClient = {
   controller: ReadableStreamDefaultController;
   encoder: TextEncoder;
@@ -72,6 +74,28 @@ function clientKey(sessionName: string, networkId?: string | null): string {
   return `${networkId || "global"}:${sessionName}`;
 }
 
+function rekeyClient(oldSessionName: string, newSessionName: string, networkId?: string | null): number {
+  if (!oldSessionName || !newSessionName || oldSessionName === newSessionName) return 0;
+  const oldKey = clientKey(oldSessionName, networkId);
+  const newKey = clientKey(newSessionName, networkId);
+  const oldClients = clients.get(oldKey);
+  if (!oldClients || oldClients.length === 0) return 0;
+
+  const existing = clients.get(newKey) || [];
+  clients.set(newKey, existing.concat(oldClients));
+  clients.delete(oldKey);
+  console.log(`[${ts()}] SSE ↔ rekey ${oldKey} → ${newKey} (${oldClients.length} clients)`);
+  return oldClients.length;
+}
+
+eventBus.on("rename-committed", (event: RenameCommittedEvent) => {
+  try {
+    rekeyClient(event.old_alias, event.new_alias, event.networkId);
+  } catch (e: any) {
+    console.log(`[${ts()}] SSE rekey failed: ${e?.message || e}`);
+  }
+});
+
 /** 推送事件给指定 session 的所有 SSE 连接 */
 export function pushEvent(sessionName: string, event: Record<string, unknown>, networkId?: string | null): void {
   const arr = clients.get(clientKey(sessionName, networkId ?? (event.network_id as string | null | undefined)));
@@ -93,6 +117,10 @@ export function pushEvent(sessionName: string, event: Record<string, unknown>, n
     arr.splice(dead[i], 1);
   }
   if (arr.length === 0) clients.delete(clientKey(sessionName, networkId ?? (event.network_id as string | null | undefined)));
+}
+
+export function __resetSSEClientsForTest(): void {
+  clients.clear();
 }
 
 /** 获取当前 SSE 连接统计 */

--- a/server/src/rename.ts
+++ b/server/src/rename.ts
@@ -16,11 +16,14 @@ import { randomUUID } from "crypto";
 import { db } from "./db";
 import { getUserNetworkRole, getNetworkMembers } from "./auth";
 import { pushEvent } from "./push";
+import { eventBus } from "./event_bus";
 
 export interface RenameResult {
   ok: boolean;
   txn_id?: string;
   error?: string;
+  code?: string;
+  suggested?: string;
 }
 
 export interface CanonicalAlias {
@@ -111,7 +114,14 @@ export function prepareRename(
   // old-alias must exist as a session in this network
   const oldSession = db.get<any>(
     "SELECT 1 FROM sessions WHERE network_id = ?1 AND alias = ?2", networkId, oldAlias);
-  if (!oldSession) return { ok: false, error: `node "${oldAlias}" not found in this network` };
+  if (!oldSession) {
+    return {
+      ok: false,
+      code: "node_local_only",
+      error: `node "${oldAlias}" has no server session in this network`,
+      suggested: "rename locally",
+    };
+  }
 
   // new-alias must not be taken — in sessions OR reserved by another prepared txn
   const newInSessions = db.get<any>(
@@ -147,19 +157,32 @@ export function commitRename(userId: string, txnId: string): RenameResult {
     "SELECT 1 FROM sessions WHERE network_id = ?1 AND alias = ?2", txn.network_id, txn.new_alias);
   if (conflict) return { ok: false, error: `alias "${txn.new_alias}" was taken since prepare` };
 
-  db.run(
-    "UPDATE sessions SET alias = ?1, updated_at = datetime('now') WHERE network_id = ?2 AND alias = ?3",
-    [txn.new_alias, txn.network_id, txn.old_alias]);
-  cleanupRenamedAliasSession(txn.network_id, txn.old_alias, txn.new_alias);
-  db.run(
-    "UPDATE nodes SET alias = ?1, updated_at = datetime('now') WHERE network_id = ?2 AND alias = ?3",
-    [txn.new_alias, txn.network_id, txn.old_alias]);
-  db.run(
-    "UPDATE api_tokens SET name = ?1 WHERE network_id = ?2 AND name = ?3",
-    [`node:${txn.new_alias}`, txn.network_id, `node:${txn.old_alias}`]);
-  db.run(
-    "UPDATE rename_txn SET status = 'committed', committed_at = datetime('now') WHERE txn_id = ?1",
-    [txnId]);
+  const renamedNode = db.transaction(() => {
+    db.run(
+      "UPDATE sessions SET alias = ?1, updated_at = datetime('now') WHERE network_id = ?2 AND alias = ?3",
+      [txn.new_alias, txn.network_id, txn.old_alias]);
+    cleanupRenamedAliasSession(txn.network_id, txn.old_alias, txn.new_alias);
+    db.run(
+      "UPDATE nodes SET alias = ?1, updated_at = datetime('now') WHERE network_id = ?2 AND alias = ?3",
+      [txn.new_alias, txn.network_id, txn.old_alias]);
+    db.run(
+      "UPDATE api_tokens SET name = ?1 WHERE network_id = ?2 AND name = ?3",
+      [`node:${txn.new_alias}`, txn.network_id, `node:${txn.old_alias}`]);
+    db.run(
+      "UPDATE rename_txn SET status = 'committed', committed_at = datetime('now') WHERE txn_id = ?1",
+      [txnId]);
+    const node = db.get<{ node_id: string | null }>(
+      "SELECT node_id FROM sessions WHERE network_id = ?1 AND alias = ?2",
+      [txn.network_id, txn.new_alias]
+    );
+    eventBus.emit("rename-committed", {
+      networkId: txn.network_id,
+      old_alias: txn.old_alias,
+      new_alias: txn.new_alias,
+      node_id: node?.node_id ?? null,
+    });
+    return node;
+  });
 
   // RFC-010 §4.2.1 C4 — broadcast node.renamed SSE. (#84 实施补漏: the Server
   // surface originally missed C4; N站马's dashboard slice needs this event.)
@@ -174,9 +197,11 @@ export function commitRename(userId: string, txnId: string): RenameResult {
     txn_id: txnId,
     alias: txn.new_alias,
     network_id: txn.network_id,
+    node_id: renamedNode?.node_id ?? null,
     data: {
       old_alias: txn.old_alias,
       new_alias: txn.new_alias,
+      node_id: renamedNode?.node_id ?? null,
       surfaces_updated: ["config", "tmux", "commhub", "dashboard", "batch_prefix", "session_resume"],
       history_policy: "preserve",
     },

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -119,9 +119,16 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
   const scopedSessionStatus = (alias: string, networkId?: string | null) => {
     const params: any[] = [alias];
-    let sql = "SELECT status, updated_at, last_seen_at FROM sessions WHERE alias = ?1";
+    let sql = "SELECT status, updated_at, last_seen_at, node_id FROM sessions WHERE alias = ?1";
     sql = addScope(sql, params, networkId);
     return db.get<any>(sql, ...params);
+  };
+
+  const resolveNodeIdForAlias = (alias: string, networkId?: string | null): string | null => {
+    if (!alias || alias === "hub" || alias === "api") return null;
+    const canonical = resolveCanonicalAlias(networkId, alias);
+    const session = scopedSessionStatus(canonical.alias, networkId);
+    return session?.node_id ?? null;
   };
 
   const resolveDeliveryTarget = (alias: string, networkId?: string | null): DeliveryTarget => {
@@ -746,20 +753,22 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
       console.log(`[${ts()}] ${from_session} → send_task → ${targetAlias}: ${task.slice(0, 60)}${priority === "high" ? " [HIGH]" : ""}${canonical.renamed ? ` [renamed from ${alias}]` : ""}`);
       const id = uuidv4();
+      const fromNodeId = resolveNodeIdForAlias(from_session, effectiveNetId);
+      const targetNodeId = target.session?.node_id ?? null;
       // 事务：inbox + tasks 双写 + 触碰目标 session 的 task/updated_at（让
       // dashboard 在派任务一刻就反映出"任务已下发"，不再等 agent 的
       // report_status 心跳；status 字段交给 agent，避免与 working/idle
       // 报告冲突）。
       db.transaction(() => {
         db.run(
-          `INSERT INTO inbox (id, session_name, type, priority, content, context, from_session, requires_response, network_id, meta_json)
-           VALUES (?1, ?2, 'task', ?3, ?4, ?5, ?6, 'reply', ?7, ?8)`,
-          [id, targetAlias, priority, task, context ?? null, from_session, effectiveNetId ?? null, metaJson]
+          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, context, from_session, requires_response, network_id, meta_json)
+           VALUES (?1, ?2, ?3, 'task', ?4, ?5, ?6, ?7, 'reply', ?8, ?9)`,
+          [id, targetAlias, targetNodeId, priority, task, context ?? null, from_session, effectiveNetId ?? null, metaJson]
         );
         db.run(
-          `INSERT INTO tasks (task_id, from_name, to_name, priority, status, content, requires_response, created_at, delivered_at, expires_at, network_id, parent_task_id, meta_json)
-           VALUES (?1, ?2, ?3, ?4, 'delivered', ?5, 'reply', datetime('now'), datetime('now'), datetime('now', ?6), ?7, ?8, ?9)`,
-          [id, from_session, targetAlias, priority, task, `+${ttl_seconds || 3600} seconds`, effectiveNetId ?? null, parentTaskId, metaJson]
+          `INSERT INTO tasks (task_id, from_node_id, from_name, to_node_id, to_name, priority, status, content, requires_response, created_at, delivered_at, expires_at, network_id, parent_task_id, meta_json)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'delivered', ?7, 'reply', datetime('now'), datetime('now'), datetime('now', ?8), ?9, ?10, ?11)`,
+          [id, fromNodeId, from_session, targetNodeId, targetAlias, priority, task, `+${ttl_seconds || 3600} seconds`, effectiveNetId ?? null, parentTaskId, metaJson]
         );
         const touchParams: any[] = [task.slice(0, 200), targetAlias];
         let touchSql = "UPDATE sessions SET task = ?1, updated_at = datetime('now') WHERE alias = ?2";
@@ -833,22 +842,31 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     async ({ alias, message, from_session: _fromIn }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
       const effectiveNetId = getNetworkId(null);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
-      const target = resolveDeliveryTarget(alias, effectiveNetId);
+      const canonical = resolveCanonicalAlias(effectiveNetId, alias);
+      const targetAlias = canonical.alias;
+      const target = resolveDeliveryTarget(targetAlias, effectiveNetId);
       if (target.state === "not_found") return deliveryTargetReply(target)!;
-      console.log(`[${ts()}] ${from_session} → send_message → ${alias}: ${message.slice(0, 60)}`);
+      console.log(`[${ts()}] ${from_session} → send_message → ${targetAlias}: ${message.slice(0, 60)}${canonical.renamed ? ` [renamed from ${alias}]` : ""}`);
       const id = uuidv4();
       db.run(
-        `INSERT INTO inbox (id, session_name, type, priority, content, from_session, network_id)
-         VALUES (?1, ?2, 'message', 'normal', ?3, ?4, ?5)`,
-        [id, alias, message, from_session, effectiveNetId ?? null]
+        `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, network_id)
+         VALUES (?1, ?2, ?3, 'message', 'normal', ?4, ?5, ?6)`,
+        [id, targetAlias, target.session?.node_id ?? null, message, from_session, effectiveNetId ?? null]
       );
 
       if (target.state === "online") {
-        pushEvent(alias, { type: "new_message", from: from_session, message_id: id }, effectiveNetId);
+        pushEvent(targetAlias, { type: "new_message", from: from_session, message_id: id, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
       }
 
       const offlineReply = deliveryTargetReply(target, { message_id: id });
-      if (offlineReply) return offlineReply;
+      if (offlineReply) {
+        const payload = JSON.parse(offlineReply.content[0].text);
+        offlineReply.content[0].text = JSON.stringify({
+          ...payload,
+          ...(canonical.renamed ? { renamed_from: alias, renamed_to: targetAlias } : {}),
+        });
+        return offlineReply;
+      }
 
       return {
         content: [
@@ -857,6 +875,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
             text: JSON.stringify({
               ok: true,
               message_id: id,
+              ...(canonical.renamed ? { renamed_from: alias, renamed_to: targetAlias } : {}),
               session_status: target.session?.status ?? "unknown",
             }),
           },
@@ -917,11 +936,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           };
         }
       }
+      const replyTargetNodeId = resolveNodeIdForAlias(alias, effectiveNetId);
       const replyLogged = db.transaction(() => {
         db.run(
-          `INSERT INTO inbox (id, session_name, type, priority, content, from_session, in_reply_to, requires_response, network_id)
-           VALUES (?1, ?2, 'reply', 'normal', ?3, ?4, ?5, 'none', ?6)`,
-          [id, alias, text, from_session, in_reply_to ?? null, effectiveNetId ?? null]
+          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, in_reply_to, requires_response, network_id)
+           VALUES (?1, ?2, ?3, 'reply', 'normal', ?4, ?5, ?6, 'none', ?7)`,
+          [id, alias, replyTargetNodeId, text, from_session, in_reply_to ?? null, effectiveNetId ?? null]
         );
 
         // 更新 tasks 表
@@ -1053,9 +1073,9 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         // Re-queue in inbox with new ID (original ID may already exist)
         const retryInboxId = uuidv4();
         db.run(
-          `INSERT INTO inbox (id, session_name, type, priority, content, from_session, requires_response, network_id)
-           VALUES (?1, ?2, 'task', ?3, ?4, ?5, 'reply', ?6)`,
-          [retryInboxId, task.to_name, task.priority, task.content, from_session, effectiveNetId ?? task.network_id ?? null]
+          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, requires_response, network_id)
+           VALUES (?1, ?2, ?3, 'task', ?4, ?5, ?6, 'reply', ?7)`,
+          [retryInboxId, task.to_name, task.to_node_id ?? resolveNodeIdForAlias(task.to_name, effectiveNetId ?? task.network_id ?? null), task.priority, task.content, from_session, effectiveNetId ?? task.network_id ?? null]
         );
       });
       logTaskEvent(task_id, task.status, "delivered", from_session, "retry");
@@ -1098,18 +1118,20 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       alias: z.string().max(200).optional().describe("Filter by to_name (target agent)"),
       status: z.string().max(50).optional().describe("Filter by status"),
       from_name: z.string().max(200).optional().describe("Filter by sender"),
+      from_node_id: z.string().max(200).optional().describe("Filter by immutable sender node_id"),
       network_id: z.string().max(200).optional().describe("Filter by network"),
       limit: z.number().min(1).max(100).optional().default(20),
     },
-    async ({ alias, status, from_name, network_id: netId, limit }) => {
+    async ({ alias, status, from_name, from_node_id, network_id: netId, limit }) => {
       const readScope = resolveReadScope(netId);
       if (readScope.denied) return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: readScope.denied }) }] };
-      let sql = "SELECT task_id, from_name, to_name, priority, status, content, result, created_at, completed_at FROM tasks WHERE 1=1";
+      let sql = "SELECT task_id, from_node_id, from_name, to_node_id, to_name, priority, status, content, result, created_at, completed_at FROM tasks WHERE 1=1";
       const params: any[] = [];
       sql = addReadScope(sql, params, readScope);
       if (alias) { sql += ` AND to_name = ?${params.length + 1}`; params.push(alias); }
       if (status) { sql += ` AND status = ?${params.length + 1}`; params.push(status); }
       if (from_name) { sql += ` AND from_name = ?${params.length + 1}`; params.push(from_name); }
+      if (from_node_id) { sql += ` AND from_node_id = ?${params.length + 1}`; params.push(from_node_id); }
       sql += ` ORDER BY created_at DESC LIMIT ?${params.length + 1}`;
       params.push(limit);
       const tasks = db.all(sql, ...params);
@@ -1184,6 +1206,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: `task is terminal (${task.status})` }) }] };
       }
       const oldAlias = task.to_name;
+      const canonical = resolveCanonicalAlias(effectiveNetId ?? task.network_id ?? null, new_alias);
+      const reassignedAlias = canonical.alias;
+      const target = resolveDeliveryTarget(reassignedAlias, effectiveNetId ?? task.network_id ?? null);
+      const newNodeId = target.state === "not_found" ? null : (target.session?.node_id ?? null);
       db.transaction(() => {
         // Ack old inbox to prevent original agent from picking it up
         const inboxParams: any[] = [task_id];
@@ -1191,18 +1217,18 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         inboxSql = addScope(inboxSql, inboxParams, effectiveNetId);
         db.run(inboxSql, inboxParams);
 
-        const updateParams: any[] = [new_alias, task_id];
-        let updateSql = "UPDATE tasks SET to_name = ?1, status = 'delivered', started_at = NULL, delivered_at = datetime('now') WHERE task_id = ?2";
+        const updateParams: any[] = [reassignedAlias, newNodeId, task_id];
+        let updateSql = "UPDATE tasks SET to_name = ?1, to_node_id = ?2, status = 'delivered', started_at = NULL, delivered_at = datetime('now') WHERE task_id = ?3";
         updateSql = addScope(updateSql, updateParams, effectiveNetId);
         db.run(updateSql, updateParams);
 
         const newInboxId = uuidv4();
-        db.run("INSERT INTO inbox (id, session_name, type, priority, content, from_session, requires_response, network_id) VALUES (?1, ?2, 'task', ?3, ?4, ?5, 'reply', ?6)",
-          [newInboxId, new_alias, task.priority, task.content, from_session, effectiveNetId ?? task.network_id ?? null]);
+        db.run("INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, requires_response, network_id) VALUES (?1, ?2, ?3, 'task', ?4, ?5, ?6, 'reply', ?7)",
+          [newInboxId, reassignedAlias, newNodeId, task.priority, task.content, from_session, effectiveNetId ?? task.network_id ?? null]);
       });
-      logTaskEvent(task_id, task.status, "delivered", from_session, `reassign: ${oldAlias} → ${new_alias}`);
-      pushEvent(new_alias, { type: "new_task", inbox_count: 1, priority: task.priority, from: from_session }, effectiveNetId ?? task.network_id ?? null);
-      return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, task_id, reassigned_from: oldAlias, reassigned_to: new_alias }) }] };
+      logTaskEvent(task_id, task.status, "delivered", from_session, `reassign: ${oldAlias} → ${reassignedAlias}`);
+      pushEvent(reassignedAlias, { type: "new_task", inbox_count: 1, priority: task.priority, from: from_session, ...(canonical.renamed ? { renamed_from: new_alias } : {}) }, effectiveNetId ?? task.network_id ?? null);
+      return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, task_id, reassigned_from: oldAlias, reassigned_to: reassignedAlias, ...(canonical.renamed ? { renamed_from: new_alias, renamed_to: reassignedAlias } : {}) }) }] };
     }
   );
 
@@ -1219,21 +1245,21 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const effectiveNetId = getNetworkId(netId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       console.log(`[${ts()}] hub → broadcast: ${message.slice(0, 60)}${effectiveNetId ? " [net=" + effectiveNetId.slice(0, 12) + "]" : ""}`);
-      let sql = "SELECT alias, network_id FROM sessions WHERE alias IS NOT NULL";
+      let sql = "SELECT alias, node_id, network_id FROM sessions WHERE alias IS NOT NULL";
       const params: any[] = [];
       sql = addScope(sql, params, effectiveNetId);
       if (filter_server) { sql += " AND server = ?"; params.push(filter_server); }
       if (filter_status) { sql += " AND status = ?"; params.push(filter_status); }
 
-      const targets = db.all<{ alias: string; network_id: string | null }>(sql, ...params);
+      const targets = db.all<{ alias: string; node_id: string | null; network_id: string | null }>(sql, ...params);
       const ids: string[] = [];
 
       for (const t of targets) {
         const id = uuidv4();
         db.run(
-          `INSERT INTO inbox (id, session_name, type, priority, content, from_session, network_id)
-           VALUES (?1, ?2, 'broadcast', 'normal', ?3, 'hub', ?4)`,
-          [id, t.alias, message, effectiveNetId ?? t.network_id ?? null]
+          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, network_id)
+           VALUES (?1, ?2, ?3, 'broadcast', 'normal', ?4, 'hub', ?5)`,
+          [id, t.alias, t.node_id ?? null, message, effectiveNetId ?? t.network_id ?? null]
         );
         ids.push(id);
       }

--- a/tests/qa-hub-17-rename-canonicalization/run.sh
+++ b/tests/qa-hub-17-rename-canonicalization/run.sh
@@ -83,7 +83,7 @@ NET_ID=$(post_json "/api/networks" "$USER_TOKEN" '{"name":"rename-canon"}' | jso
 NTOK=$(post_json "/api/auth/node-token" "$USER_TOKEN" "{\"network_id\":\"$NET_ID\",\"node_name\":\"old-agent\"}" | json_get token)
 
 echo "1. Old alias reports online"
-mcp_call "$NTOK" "report_status" "{\"resume_id\":\"resume-old\",\"alias\":\"old-agent\",\"status\":\"idle\"}" >/tmp/report-old.json
+mcp_call "$NTOK" "report_status" "{\"resume_id\":\"resume-old\",\"alias\":\"old-agent\",\"status\":\"idle\",\"node_id\":\"node-rename-17\",\"node_name\":\"old-agent\"}" >/tmp/report-old.json
 STATUS=$(curl -fsS -H "Authorization: Bearer $USER_TOKEN" "$BASE/api/status?network_id=$NET_ID")
 assert_contains "$STATUS" '"alias":"old-agent"' "old-agent should exist before rename"
 
@@ -94,7 +94,7 @@ COMMIT=$(post_json "/api/node-rename/commit" "$USER_TOKEN" "{\"txn_id\":\"$TXN_I
 assert_contains "$COMMIT" '"ok":true' "commit rename should succeed"
 
 echo "3. New process reports under new alias"
-mcp_call "$NTOK" "report_status" "{\"resume_id\":\"resume-new\",\"alias\":\"new-agent\",\"status\":\"idle\"}" >/tmp/report-new.json
+mcp_call "$NTOK" "report_status" "{\"resume_id\":\"resume-new\",\"alias\":\"new-agent\",\"status\":\"idle\",\"node_id\":\"node-rename-17\",\"node_name\":\"new-agent\"}" >/tmp/report-new.json
 STATUS=$(curl -fsS -H "Authorization: Bearer $USER_TOKEN" "$BASE/api/status?network_id=$NET_ID")
 assert_contains "$STATUS" '"alias":"new-agent"' "new-agent should exist after rename"
 assert_not_contains "$STATUS" '"alias":"old-agent"' "old-agent should be absent after new report"
@@ -116,13 +116,43 @@ MCP_TASK=$(mcp_call "$USER_TOKEN" "send_task" "{\"alias\":\"old-agent\",\"task\"
 assert_contains "$MCP_TASK" 'renamed_from' "MCP send_task response should include renamed_from"
 assert_contains "$MCP_TASK" 'renamed_to' "MCP send_task response should include renamed_to"
 
-echo "7. Task/inbox rows only target canonical alias"
+echo "7. MCP send_message to old alias redirects to new alias"
+OLD_MSG=$(mcp_call "$NTOK" "send_message" "{\"alias\":\"old-agent\",\"message\":\"old alias message\"}")
+assert_contains "$OLD_MSG" 'renamed_from' "MCP send_message old alias response should include renamed_from"
+assert_contains "$OLD_MSG" 'renamed_to' "MCP send_message old alias response should include renamed_to"
+
+echo "8. MCP send_message to new alias succeeds without redirect"
+NEW_MSG=$(mcp_call "$NTOK" "send_message" "{\"alias\":\"new-agent\",\"message\":\"new alias message\"}")
+assert_contains "$NEW_MSG" 'message_id' "MCP send_message new alias should succeed"
+assert_not_contains "$NEW_MSG" 'renamed_from' "MCP send_message new alias should not redirect"
+
+echo "9. Task/inbox rows only target canonical alias"
 TASKS=$(curl -fsS -H "Authorization: Bearer $USER_TOKEN" "$BASE/api/tasks?network_id=$NET_ID")
 assert_contains "$TASKS" '"to_name":"new-agent"' "tasks should target new-agent"
 assert_not_contains "$TASKS" '"to_name":"old-agent"' "tasks should not target old-agent"
+INBOX=$(mcp_call "$NTOK" "get_inbox" "{\"alias\":\"new-agent\",\"limit\":20}")
+assert_contains "$INBOX" 'old alias message' "old alias send_message should land in new-agent inbox"
+assert_contains "$INBOX" 'new alias message' "new alias send_message should land in new-agent inbox"
+assert_not_contains "$INBOX" '"session_name":"old-agent"' "inbox rows should not target old-agent"
+
+echo "10. list_tasks supports from_node_id while from_name remains compatible"
+FROM_NODE_TASK=$(mcp_call "$NTOK" "send_task" "{\"alias\":\"new-agent\",\"task\":\"from node id probe\"}")
+assert_contains "$FROM_NODE_TASK" 'message_id' "send_task from renamed node should succeed"
+LIST_BY_NODE=$(mcp_call "$NTOK" "list_tasks" "{\"from_node_id\":\"node-rename-17\",\"limit\":20}")
+assert_contains "$LIST_BY_NODE" 'from node id probe' "list_tasks from_node_id should find task"
+assert_contains "$LIST_BY_NODE" 'node-rename-17' "list_tasks should return from_node_id"
+LIST_BY_NAME=$(mcp_call "$NTOK" "list_tasks" "{\"from_name\":\"new-agent\",\"limit\":20}")
+assert_contains "$LIST_BY_NAME" 'from node id probe' "list_tasks from_name compatibility should still work"
+
+echo "11. prepareRename missing sessions row returns node_local_only soft signal"
+LOCAL_ONLY=$(post_json "/api/node-rename/prepare" "$USER_TOKEN" "{\"network_id\":\"$NET_ID\",\"old_alias\":\"never-started\",\"new_alias\":\"never-started-new\"}")
+assert_contains "$LOCAL_ONLY" '"ok":false' "local-only prepare should not succeed server 2PC"
+assert_contains "$LOCAL_ONLY" 'node_local_only' "local-only prepare should return node_local_only code"
+assert_contains "$LOCAL_ONLY" 'rename locally' "local-only prepare should include local rename suggestion"
 
 STATUS=$(curl -fsS -H "Authorization: Bearer $USER_TOKEN" "$BASE/api/status?network_id=$NET_ID")
 assert_contains "$STATUS" '"total":1' "status summary should only include one canonical session"
 assert_not_contains "$STATUS" '"alias":"old-agent"' "final status should not show old-agent"
+assert_contains "$(cat "$LOG")" 'node_id backfill' "migration log should include node_id backfill summary"
 
-echo "PASS: rename canonicalization blocks stale report_status and redirects send_task/REST task"
+echo "PASS: rename canonicalization blocks stale report_status and redirects send_task/send_message/REST task"


### PR DESCRIPTION
## Summary

Implements rename-family server PR-1+2 for #146:

- canonicalizes `send_message` through `resolveCanonicalAlias`, matching the existing `send_task` path
- emits an internal `rename-committed` event from `commitRename` and rekeys existing SSE client map entries from old alias to new alias
- adds durable node identity fields on inbox/tasks rows, with idempotent migrations and startup backfill log
- adds `list_tasks.from_node_id` while keeping `from_name` compatibility
- returns `node_local_only` as a soft prepareRename signal for local-only nodes instead of a hard REST reject

## Verification

- `COMMHUB_DB=/tmp/commhub-rename-push-test.db bun test src/push.test.ts`
- `sg docker -c 'docker build -f tests/qa-hub-17-rename-canonicalization/Dockerfile -t anet-qa-hub-17-rename-canonicalization .'`
- `sg docker -c 'docker run --rm anet-qa-hub-17-rename-canonicalization'`
- `sg docker -c 'docker build -f tests/qa-hub-16-rest-task-api/Dockerfile -t anet-qa-hub-16-rest-task-api .'`
- `sg docker -c 'docker run --rm anet-qa-hub-16-rest-task-api'`
- `sg docker -c 'docker build -f tests/qa-hub-18-delivery-semantics/Dockerfile -t anet-qa-hub-18-delivery-semantics .'`
- `sg docker -c 'docker run --rm anet-qa-hub-18-delivery-semantics'`
- `git diff --check`

Test report: `docs/tests/report-rename-server-pr1-pr2.txt`

## Notes

No npm publish. No production hub access. Server-only PR for review before merge due schema migration.

Author + Agent: 通信牛
