### PR TITLE
feat(#146 PR-3): CLI rename lane — local-only / codex+grok pid match / NODE_ID env

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2390,9 +2390,14 @@ async function launchAgent(id: string, forceNewSession = false) {
     // outbound send_task/send_message to attribute to the wrong alias.
     // `displayName` is the same value we pass as --alias above, so the two
     // sources agree.
+    // PR-3 (#146 family) — also propagate COMMHUB_NODE_ID so PR-4's identity
+    // getter can resolve `node_id → canonical alias` server-side without
+    // relying on the mutable COMMHUB_ALIAS. The runtime can fall back to
+    // COMMHUB_ALIAS today; once PR-4 lands, the getter prefers NODE_ID.
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       COMMHUB_ALIAS: displayName,
+      ...(profile.node_id ? { COMMHUB_NODE_ID: profile.node_id } : {}),
       ...(token ? { COMMHUB_TOKEN: token } : {}),
       ...(hub ? { COMMHUB_URL: hub } : {}),
     };
@@ -2437,9 +2442,16 @@ async function launchAgent(id: string, forceNewSession = false) {
     });
   } else {
     // spawn claude CLI
+    // PR-3 (#146 family) — single-source on displayName (was profile.alias).
+    // displayName falls through node_name → name → alias → nodeId, matching
+    // the agent-node branch above and the `-n` flag below; using
+    // profile.alias here could diverge if the config is hand-edited or if
+    // a rename only updated node_name without alias. Also propagate
+    // COMMHUB_NODE_ID for PR-4's identity getter.
     const env: NodeJS.ProcessEnv = {
       ...process.env,
-      COMMHUB_ALIAS: profile.alias,
+      COMMHUB_ALIAS: displayName,
+      ...(profile.node_id ? { COMMHUB_NODE_ID: profile.node_id } : {}),
       // #115 — suppress Claude Code's "Resume from summary / full session"
       // interactive prompt so restarting a batch of nodes is zero-interaction.
       // The prompt is gated by a session-age threshold (default 70min); a very
@@ -3490,10 +3502,17 @@ function findNodeProcessesByAlias(...aliases: string[]): number[] | null {
     // executable itself (basename claude / agent-node) or its package path —
     // NOT a mere substring of the whole command line, which an unrelated
     // process could carry in a path/arg and then be wrongly killed.
+    // PR-3 (#146 family) — also recognise codex / grok standalone CLIs so a
+    // rename on a node started via those binaries can match its real process.
+    // Without this gap-fill, rename --force on a codex-sdk or grok-build-acp
+    // node that was launched via the standalone CLI (not the agent-node
+    // bridge) would silently fail to find the old process.
     const isAgentProc = tok.some(x => {
       const base = x.split("/").pop() || x;
       return base === "claude" || base === "agent-node"
-        || x.includes("@anthropic-ai/claude-code") || x.includes("@sleep2agi/agent-node");
+        || base === "codex" || base === "grok"
+        || x.includes("@anthropic-ai/claude-code") || x.includes("@sleep2agi/agent-node")
+        || x.includes("@openai/codex") || x.includes("@openai/codex-sdk");
     });
     if (!isAgentProc) continue;
     for (let i = 0; i < tok.length - 1; i++) {
@@ -3671,7 +3690,7 @@ anet node rename <node-id|node-name> <new-node-name> [--force]
 
   // ── PHASE 1: PREPARE (copy/prepare, old node untouched — fully rollbackable) ──
   writeFileSync(lockPath, JSON.stringify({ old: oldId, new: newName, phase: "prepare", ts: Date.now() }) + "\n");
-  let txnId = "";
+  let txnId: string | null = "";
   try {
     // P2: copy (not move) old → new + update config.alias
     cpSync(oldDir, newDir, { recursive: true });
@@ -3693,12 +3712,42 @@ anet node rename <node-id|node-name> <new-node-name> [--force]
       headers: { "Content-Type": "application/json", ...authHeaders(token) },
       body: JSON.stringify({ network_id: networkId, old_alias: oldId, new_alias: newName }),
     }).then(r => r.json() as any);
-    if (!prep.ok) throw new Error(`commhub prepare-rename: ${prep.error}`);
-    txnId = prep.txn_id;
+    if (!prep.ok) {
+      // PR-3 (#110) — purely-created nodes (`anet node create` without ever
+      // running `anet node start`) have no commhub `sessions` row, so
+      // server-side prepareRename rejects with "node not found in this
+      // network". RFC-010 §4.1 lists `created` as a recommended rename path,
+      // so falling out here contradicts the spec. Detect this case and fall
+      // back to a local-only rename: the local config dir + alias rename
+      // happens, and there's nothing on the server to coordinate yet.
+      //
+      // Two error shapes are tolerated:
+      //   1. PR-2 (server-side) future contract: `error: "node_local_only"`
+      //   2. Current main: `error` string contains "not found in this network"
+      const errStr = String(prep.error || "");
+      const isLocalOnly = prep.error === "node_local_only"
+        || /not found in this network/i.test(errStr)
+        || /node .* not found/i.test(errStr);
+      if (isLocalOnly) {
+        console.log(`[anet] note: "${oldId}" has no server registration yet (never started). Performing local-only rename — no commhub 2PC needed.`);
+        // Strip lock + drop the local-only flag for PHASE 2 commit path
+        if (existsSync(lockPath)) {
+          const lockData = JSON.parse(readFileSync(lockPath, "utf-8"));
+          lockData.local_only = true;
+          writeFileSync(lockPath, JSON.stringify(lockData));
+        }
+        txnId = null;  // signal no server txn to PHASE 2 commit / rollback
+      } else {
+        throw new Error(`commhub prepare-rename: ${prep.error}`);
+      }
+    } else {
+      txnId = prep.txn_id;
+    }
   } catch (e: any) {
     // ── PHASE 1 失败回滚: old 原封不动 ──
     console.error(`[anet] rename PHASE 1 failed: ${e.message} — rolling back`);
     if (existsSync(newDir)) rmSync(newDir, { recursive: true, force: true });
+    // PR-3 (#110) — txnId is null for local-only renames; no server abort needed.
     if (txnId) {
       await fetch(`${hub}/api/node-rename/abort`, {
         method: "POST", headers: { "Content-Type": "application/json", ...authHeaders(token) },
@@ -3711,19 +3760,27 @@ anet node rename <node-id|node-name> <new-node-name> [--force]
   }
 
   // ── PHASE 2: COMMIT (顺序敏感: commhub 路由 → tmux → 删 old) ──
-  // C1: commhub commit-rename — C1 之前仍可回滚, C1 之后转 forward-fix
-  const commit = await fetch(`${hub}/api/node-rename/commit`, {
-    method: "POST", headers: { "Content-Type": "application/json", ...authHeaders(token) },
-    body: JSON.stringify({ txn_id: txnId }),
-  }).then(r => r.json() as any).catch((e: any) => ({ ok: false, error: String(e?.message || e) }));
+  // PR-3 (#110) — local-only rename skips server C1 (no txn to commit; the
+  // purely-created node had no commhub side to coordinate). Fall through
+  // directly to the local cutover (kill old / tmux / dir delete / restart).
+  const localOnly = txnId === null;
+  const commit = localOnly
+    ? { ok: true }
+    : await fetch(`${hub}/api/node-rename/commit`, {
+        method: "POST", headers: { "Content-Type": "application/json", ...authHeaders(token) },
+        body: JSON.stringify({ txn_id: txnId }),
+      }).then(r => r.json() as any).catch((e: any) => ({ ok: false, error: String(e?.message || e) }));
   if (!commit.ok) {
     // C1 失败: commhub 路由未切, 仍可干净回滚
     console.error(`[anet] rename PHASE 2 C1 (commhub commit) failed: ${commit.error} — rolling back`);
     if (existsSync(newDir)) rmSync(newDir, { recursive: true, force: true });
-    await fetch(`${hub}/api/node-rename/abort`, {
-      method: "POST", headers: { "Content-Type": "application/json", ...authHeaders(token) },
-      body: JSON.stringify({ txn_id: txnId }),
-    }).catch(() => {});
+    // PR-3 (#110) — txnId is null for local-only path; nothing to abort server-side.
+    if (txnId) {
+      await fetch(`${hub}/api/node-rename/abort`, {
+        method: "POST", headers: { "Content-Type": "application/json", ...authHeaders(token) },
+        body: JSON.stringify({ txn_id: txnId }),
+      }).catch(() => {});
+    }
     if (existsSync(lockPath)) rmSync(lockPath, { force: true });
     console.error(`[anet] rollback complete — "${oldId}" unchanged.`);
     process.exit(1);

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.2.13-preview.0",
+  "version": "2.2.12",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 4 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Grok Build ACP) and 8+ LLM providers (Anthropic / OpenAI / xAI Grok / MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter). Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.2.12",
+  "version": "2.2.13-preview.0",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 4 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Grok Build ACP) and 8+ LLM providers (Anthropic / OpenAI / xAI Grok / MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter). Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",


### PR DESCRIPTION
## Author

Agent: **通信工程马** (release-ops + CLI lane PR-3 per [#146 review staffing](https://github.com/sleep2agi/agent-network/issues/146#issuecomment-4677399510))

## Summary

PR-3 of the `#146 / #110 / #180 / #203` rename/identity family unifying fix. Per the [umbrella analysis](https://github.com/sleep2agi/agent-network/issues/146#issuecomment-4677324351), `alias` is currently both a *mutable display label* and an *immutable routing key* — RFC-010 §4 made the server schema rename atomic, but several client-side surfaces still cache alias independently or assume the existence of server state RFC-010 §4.1 explicitly said is optional.

This PR is the **CLI lane** — 5 surgical edits to `agent-network/bin/cli.ts` that don't introduce the full `node_id` contract (that's PR-4 / SDK马 lane) but make every PR-3-touched code path forward-compatible with it.

## Changes

### 1. `#110` — Local-only rename for purely-created nodes (`renameCommand`)

`prepareRename` returning either:
- `error: "node_local_only"` (PR-2 / 通信牛 future contract), OR
- error string matching `/not found in this network/i` (current main)

now triggers a local-only path: dir rename + config update only, no `commit`/`abort` round-trip with the server. `txnId` is now `string | null`; null encodes "no server txn".

Aligns with [RFC-010 §4.1](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-010-node-lifecycle.md) which lists `created` as the recommended rename path.

### 2. `#180` — `findNodeProcessesByAlias` adds `codex` / `grok` basenames

The existing pid scanner only recognised `claude` / `agent-node` / Anthropic / Sleep2AGI package paths. A node started via the standalone `codex` or `grok` CLI would have its argv classified as "not an agent process" and the `--force` rename would silently not find it (regressing `f74c04c`'s reuse-proof guarantee for those runtimes).

Added: `base === "codex" || base === "grok"` + `@openai/codex` / `@openai/codex-sdk` package paths.

### 3. PR-4 prep — `COMMHUB_NODE_ID` env on both launch branches

Both the `agent-node` spawn env (cli.ts:~2395) and the `claude-code-cli` spawn env (cli.ts:~2442) now include `COMMHUB_NODE_ID: profile.node_id`. PR-4 (SDK马 / runtime lane) introduces a `currentAlias()` getter that prefers immutable `node_id`; this PR pre-propagates the var so PR-4 can land independently of any agent-network bump.

### 4. `#203` — `claude-code-cli` branch alias single-source

`launchAgent` claude-code-cli branch was setting `COMMHUB_ALIAS = profile.alias`, which can diverge from `displayName` (used both in the `-n` flag and in the `agent-node` branch's env) if the config was hand-edited or partially renamed. Both branches now use `displayName`, matching the umbrella audit's single-source requirement.

### 5. Type widening for the local-only path

`let txnId: string | null = ""` — encodes the absence of a server txn for the local-only path. PHASE 2 commit / PHASE 1 + 2 rollback all check `if (txnId)` before issuing the abort call.

## Out of scope for PR-3

Documented in [#146 reply](https://github.com/sleep2agi/agent-network/issues/146#issuecomment-4677409623):

- `runCommand` cli.ts:2809 `process.env.COMMHUB_ALIAS` fallback — the umbrella analysis cited this line inside `lsCommand`, but the actual function at 2809 is `runCommand` (standalone SSE agent, user-driven invocation). Not a silent fallback path; leaving as-is.
- `legacyNodeId(id)` SHA1 fallback removal — deferred to PR-4 since it touches the identity contract that PR-4 introduces.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `npm run build` (bun bundle + javascript-obfuscator x3) clean — 14s
- [x] Docker smoke node:20-alpine: obfuscated bundle contains markers for `codex/grok` / `COMMHUB_NODE_ID` / `node_local_only` — confirmed
- [ ] Runtime exercise of `#110` local-only path requires a working hub mock — deferred to PR-5 (通信测试马 Docker harness, 14-case matrix from [#146 SDK马 verdict](https://github.com/sleep2agi/agent-network/issues/146#issuecomment-4677392682))
- [ ] Cross-runtime `#180` pid-match (codex/grok standalone) — same PR-5

## Review

- **Reviewer**: 通信龙 (PR-3 owner gate)
- **Gates**: PR-3 is the CLI lane; PR-1+2 (server) and PR-4 (runtime) land independently and converge in v0.10.17 batch ship (not v0.10.16 / 0.8.6 clean promote car per [dispatch dfa14138](https://github.com/sleep2agi/agent-network/issues/146)).

## Refs

- #146 (umbrella), #110, #180, #203
- RFC-010 §4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
