### PR TITLE
fix(server): guard public login attempts

### DIFF
--- a/docs/tests/report-226-login-guard.txt
+++ b/docs/tests/report-226-login-guard.txt
@@ -4,14 +4,16 @@ Branch: fix/login-rate-limit
 
 Scope:
 - POST /api/auth/login per-IP 10/min rate limit
+- login IP key uses the last X-Forwarded-For hop so spoofed first hops do not bypass the limit
+- login guard in-memory maps cap at 50k entries and prune expired entries before oldest-entry eviction
 - per-username failure lockout after 5 wrong passwords
 - exponential lockout curve with 30s base and 15min cap
 - successful login clears username failure state
 - bearer token API/MCP/SSE paths are not rate-limited by this guard
 
 Commands:
-- COMMHUB_DB=/tmp/commhub-login-guard-unit.db bun test src/auth_login_guard.test.ts
-- COMMHUB_DB=/tmp/commhub-login-guard-upload-unit.db bun test src/uploads.test.ts src/auth_login_guard.test.ts
+- COMMHUB_DB=/tmp/commhub-login-guard-unit-2.db bun test src/auth_login_guard.test.ts
+- COMMHUB_DB=/tmp/commhub-login-guard-upload-unit-2.db bun test src/uploads.test.ts src/auth_login_guard.test.ts
 - sg docker -c 'docker build -f tests/qa-hub-19-login-guard/Dockerfile -t anet-qa-hub-19-login-guard .'
 - sg docker -c 'docker run --rm anet-qa-hub-19-login-guard'
 - sg docker -c 'docker build -f tests/test5-auth/Dockerfile -t anet-test5-auth-login-guard .'
@@ -23,9 +25,9 @@ Commands:
 - git diff --check
 
 Results:
-- PASS: auth_login_guard unit, 6/6 tests
-- PASS: uploads + auth_login_guard unit, 37/37 tests
-- PASS: qa-hub-19-login-guard
+- PASS: auth_login_guard unit, 12/12 tests
+- PASS: uploads + auth_login_guard unit, 43/43 tests
+- PASS: qa-hub-19-login-guard, including XFF spoof-first / fixed-last-hop login rate-limit coverage
 - PASS: test5-auth, 25/25
 - PASS: qa-dash-07-auth-boundary
 - PASS: qa-hub-18-delivery-semantics

--- a/docs/tests/report-226-login-guard.txt
+++ b/docs/tests/report-226-login-guard.txt
@@ -1,0 +1,31 @@
+Issue #226 login guard verification
+Date: 2026-06-11
+Branch: fix/login-rate-limit
+
+Scope:
+- POST /api/auth/login per-IP 10/min rate limit
+- per-username failure lockout after 5 wrong passwords
+- exponential lockout curve with 30s base and 15min cap
+- successful login clears username failure state
+- bearer token API/MCP/SSE paths are not rate-limited by this guard
+
+Commands:
+- COMMHUB_DB=/tmp/commhub-login-guard-unit.db bun test src/auth_login_guard.test.ts
+- COMMHUB_DB=/tmp/commhub-login-guard-upload-unit.db bun test src/uploads.test.ts src/auth_login_guard.test.ts
+- sg docker -c 'docker build -f tests/qa-hub-19-login-guard/Dockerfile -t anet-qa-hub-19-login-guard .'
+- sg docker -c 'docker run --rm anet-qa-hub-19-login-guard'
+- sg docker -c 'docker build -f tests/test5-auth/Dockerfile -t anet-test5-auth-login-guard .'
+- sg docker -c 'docker run --rm anet-test5-auth-login-guard'
+- sg docker -c 'docker build -f tests/qa-dash-07-auth-boundary/Dockerfile -t anet-qa-dash-07-auth-boundary-login-guard .'
+- sg docker -c 'docker run --rm anet-qa-dash-07-auth-boundary-login-guard'
+- sg docker -c 'docker build -f tests/qa-hub-18-delivery-semantics/Dockerfile -t anet-qa-hub-18-delivery-semantics-login-guard .'
+- sg docker -c 'docker run --rm anet-qa-hub-18-delivery-semantics-login-guard'
+- git diff --check
+
+Results:
+- PASS: auth_login_guard unit, 6/6 tests
+- PASS: uploads + auth_login_guard unit, 37/37 tests
+- PASS: qa-hub-19-login-guard
+- PASS: test5-auth, 25/25
+- PASS: qa-dash-07-auth-boundary
+- PASS: qa-hub-18-delivery-semantics

--- a/server/src/auth_login_guard.test.ts
+++ b/server/src/auth_login_guard.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LOGIN_FAILURE_THRESHOLD,
+  LOGIN_LOCK_BASE_MS,
+  LOGIN_LOCK_MAX_MS,
+  LOGIN_IP_MAX_PER_WINDOW,
+  LOGIN_IP_WINDOW_MS,
+  LoginFailureLockout,
+  LoginIpRateLimiter,
+  normalizeLoginUsername,
+} from "./auth_login_guard";
+
+describe("LoginIpRateLimiter", () => {
+  test("allows the first N attempts and blocks N+1 within the window", () => {
+    const lim = new LoginIpRateLimiter(60_000, 3);
+    expect(lim.check("203.0.113.10", 1000).allowed).toBe(true);
+    expect(lim.check("203.0.113.10", 1001).allowed).toBe(true);
+    expect(lim.check("203.0.113.10", 1002).allowed).toBe(true);
+    const blocked = lim.check("203.0.113.10", 1003);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  test("default public IP limit is 10/min", () => {
+    expect(LOGIN_IP_WINDOW_MS).toBe(60_000);
+    expect(LOGIN_IP_MAX_PER_WINDOW).toBe(10);
+  });
+});
+
+describe("LoginFailureLockout", () => {
+  test("locks on the fifth failure and doubles subsequent lock durations", () => {
+    const lockout = new LoginFailureLockout(5, 30_000, 900_000);
+    const t0 = 1_700_000_000_000;
+    for (let i = 0; i < 4; i++) {
+      const r = lockout.recordFailure("Alice", t0 + i);
+      expect(r.locked).toBe(false);
+      expect(r.failures).toBe(i + 1);
+    }
+
+    const first = lockout.recordFailure(" alice ", t0 + 5);
+    expect(first.locked).toBe(true);
+    expect(first.lockMs).toBe(30_000);
+    expect(lockout.check("ALICE", t0 + 6).locked).toBe(true);
+
+    const second = lockout.recordFailure("alice", t0 + 30_006);
+    expect(second.locked).toBe(true);
+    expect(second.lockMs).toBe(60_000);
+  });
+
+  test("caps exponential lock duration and success clears failure state", () => {
+    const lockout = new LoginFailureLockout(2, 1000, 4000);
+    const t0 = 10_000;
+    expect(lockout.recordFailure("bob", t0).locked).toBe(false);
+    expect(lockout.recordFailure("bob", t0 + 1).lockMs).toBe(1000);
+    expect(lockout.recordFailure("bob", t0 + 1001).lockMs).toBe(2000);
+    expect(lockout.recordFailure("bob", t0 + 3002).lockMs).toBe(4000);
+    expect(lockout.recordFailure("bob", t0 + 7003).lockMs).toBe(4000);
+
+    lockout.recordSuccess("bob");
+    expect(lockout.check("bob", t0 + 7004).locked).toBe(false);
+    expect(lockout.recordFailure("bob", t0 + 7005).locked).toBe(false);
+  });
+
+  test("default failure policy is 5 failures, 30s base, 15min cap", () => {
+    expect(LOGIN_FAILURE_THRESHOLD).toBe(5);
+    expect(LOGIN_LOCK_BASE_MS).toBe(30_000);
+    expect(LOGIN_LOCK_MAX_MS).toBe(15 * 60_000);
+  });
+});
+
+describe("normalizeLoginUsername", () => {
+  test("normalizes for case-insensitive lockout keys", () => {
+    expect(normalizeLoginUsername(" Alice ")).toBe("alice");
+    expect(normalizeLoginUsername(undefined)).toBe("");
+  });
+});

--- a/server/src/auth_login_guard.test.ts
+++ b/server/src/auth_login_guard.test.ts
@@ -5,6 +5,7 @@ import {
   LOGIN_LOCK_MAX_MS,
   LOGIN_IP_MAX_PER_WINDOW,
   LOGIN_IP_WINDOW_MS,
+  getLoginClientIp,
   LoginFailureLockout,
   LoginIpRateLimiter,
   normalizeLoginUsername,
@@ -24,6 +25,24 @@ describe("LoginIpRateLimiter", () => {
   test("default public IP limit is 10/min", () => {
     expect(LOGIN_IP_WINDOW_MS).toBe(60_000);
     expect(LOGIN_IP_MAX_PER_WINDOW).toBe(10);
+  });
+
+  test("evicts expired entries before enforcing the cap", () => {
+    const lim = new LoginIpRateLimiter(100, 10, 2);
+    expect(lim.check("192.0.2.1", 0).allowed).toBe(true);
+    expect(lim.check("192.0.2.2", 0).allowed).toBe(true);
+    expect(lim.check("192.0.2.3", 101).allowed).toBe(true);
+
+    expect(lim.check("192.0.2.1", 102).remaining).toBe(9);
+  });
+
+  test("evicts the oldest active entry when the cap is full", () => {
+    const lim = new LoginIpRateLimiter(60_000, 1, 2);
+    expect(lim.check("192.0.2.1", 0).allowed).toBe(true);
+    expect(lim.check("192.0.2.2", 1).allowed).toBe(true);
+    expect(lim.check("192.0.2.3", 2).allowed).toBe(true);
+
+    expect(lim.check("192.0.2.1", 3).allowed).toBe(true);
   });
 });
 
@@ -66,11 +85,46 @@ describe("LoginFailureLockout", () => {
     expect(LOGIN_LOCK_BASE_MS).toBe(30_000);
     expect(LOGIN_LOCK_MAX_MS).toBe(15 * 60_000);
   });
+
+  test("evicts expired failure entries before enforcing the cap", () => {
+    const lockout = new LoginFailureLockout(2, 100, 1000, 2);
+    expect(lockout.recordFailure("alice", 0).locked).toBe(false);
+    expect(lockout.recordFailure("bob", 0).locked).toBe(false);
+    expect(lockout.recordFailure("carol", 1).locked).toBe(false);
+
+    expect(lockout.recordFailure("alice", 2).locked).toBe(false);
+  });
+
+  test("evicts the oldest active failure entry when the cap is full", () => {
+    const lockout = new LoginFailureLockout(2, 1000, 1000, 2);
+    expect(lockout.recordFailure("alice", 0).locked).toBe(false);
+    expect(lockout.recordFailure("bob", 1).locked).toBe(false);
+    expect(lockout.recordFailure("carol", 2).locked).toBe(false);
+
+    expect(lockout.recordFailure("alice", 3).locked).toBe(false);
+  });
 });
 
 describe("normalizeLoginUsername", () => {
   test("normalizes for case-insensitive lockout keys", () => {
     expect(normalizeLoginUsername(" Alice ")).toBe("alice");
     expect(normalizeLoginUsername(undefined)).toBe("");
+  });
+});
+
+describe("getLoginClientIp", () => {
+  test("uses the last x-forwarded-for hop so spoofed first hops do not bypass login rate limits", () => {
+    const req = new Request("http://127.0.0.1/api/auth/login", {
+      headers: { "x-forwarded-for": "198.51.100.99, 203.0.113.10" },
+    });
+    expect(getLoginClientIp(req)).toBe("203.0.113.10");
+  });
+
+  test("falls back to x-real-ip, then unknown", () => {
+    const withRealIp = new Request("http://127.0.0.1/api/auth/login", {
+      headers: { "x-real-ip": "203.0.113.20" },
+    });
+    expect(getLoginClientIp(withRealIp)).toBe("203.0.113.20");
+    expect(getLoginClientIp(new Request("http://127.0.0.1/api/auth/login"))).toBe("unknown");
   });
 });

--- a/server/src/auth_login_guard.ts
+++ b/server/src/auth_login_guard.ts
@@ -7,6 +7,7 @@ export const LOGIN_IP_MAX_PER_WINDOW = 10;
 export const LOGIN_FAILURE_THRESHOLD = 5;
 export const LOGIN_LOCK_BASE_MS = 30_000;
 export const LOGIN_LOCK_MAX_MS = 15 * 60_000;
+export const LOGIN_GUARD_MAX_ENTRIES = 50_000;
 
 type WindowState = { count: number; resetAt: number };
 
@@ -16,9 +17,14 @@ export class LoginIpRateLimiter {
   constructor(
     private readonly windowMs: number = LOGIN_IP_WINDOW_MS,
     private readonly maxPerWindow: number = LOGIN_IP_MAX_PER_WINDOW,
+    private readonly maxEntries: number = LOGIN_GUARD_MAX_ENTRIES,
   ) {}
 
   check(key: string, nowMs: number = Date.now()): { allowed: boolean; remaining: number; resetAt: number; retryAfterMs?: number } {
+    if (this.state.size >= this.maxEntries && !this.state.has(key)) {
+      pruneExpired(this.state, nowMs, (entry) => nowMs >= entry.resetAt);
+      evictOldestUntilBelowCap(this.state, this.maxEntries);
+    }
     const entry = this.state.get(key);
     if (!entry || nowMs >= entry.resetAt) {
       const resetAt = nowMs + this.windowMs;
@@ -46,6 +52,7 @@ export class LoginFailureLockout {
     private readonly threshold: number = LOGIN_FAILURE_THRESHOLD,
     private readonly baseLockMs: number = LOGIN_LOCK_BASE_MS,
     private readonly maxLockMs: number = LOGIN_LOCK_MAX_MS,
+    private readonly maxEntries: number = LOGIN_GUARD_MAX_ENTRIES,
   ) {}
 
   check(username: string, nowMs: number = Date.now()): { locked: boolean; retryAfterMs?: number; lockedUntil?: number } {
@@ -59,6 +66,10 @@ export class LoginFailureLockout {
   recordFailure(username: string, nowMs: number = Date.now()): { locked: boolean; failures: number; lockMs?: number; lockedUntil?: number } {
     const key = normalizeLoginUsername(username);
     if (!key) return { locked: false, failures: 0 };
+    if (this.state.size >= this.maxEntries && !this.state.has(key)) {
+      pruneExpired(this.state, nowMs, (entry) => !entry.lockedUntil || nowMs >= entry.lockedUntil);
+      evictOldestUntilBelowCap(this.state, this.maxEntries);
+    }
     const current = this.state.get(key);
     const failures = (current?.failures ?? 0) + 1;
     if (failures < this.threshold) {
@@ -87,6 +98,29 @@ export function normalizeLoginUsername(username: unknown): string {
   return typeof username === "string" ? username.trim().toLowerCase() : "";
 }
 
+export function getLoginClientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  if (fwd) {
+    const last = fwd.split(",").map((s) => s.trim()).filter(Boolean).at(-1);
+    if (last) return last;
+  }
+  return req.headers.get("x-real-ip")?.trim() || "unknown";
+}
+
+function pruneExpired<T>(map: Map<string, T>, nowMs: number, expired: (entry: T, nowMs: number) => boolean): void {
+  for (const [key, entry] of map) {
+    if (expired(entry, nowMs)) map.delete(key);
+  }
+}
+
+function evictOldestUntilBelowCap<T>(map: Map<string, T>, maxEntries: number): void {
+  while (map.size >= maxEntries) {
+    const oldest = map.keys().next().value as string | undefined;
+    if (!oldest) return;
+    map.delete(oldest);
+  }
+}
+
 function envInt(name: string, fallback: number): number {
   const raw = process.env[name];
   if (!raw) return fallback;
@@ -97,10 +131,12 @@ function envInt(name: string, fallback: number): number {
 export const sharedLoginIpRateLimiter = new LoginIpRateLimiter(
   envInt("COMMHUB_LOGIN_IP_WINDOW_MS", LOGIN_IP_WINDOW_MS),
   envInt("COMMHUB_LOGIN_IP_MAX", LOGIN_IP_MAX_PER_WINDOW),
+  envInt("COMMHUB_LOGIN_GUARD_MAX_ENTRIES", LOGIN_GUARD_MAX_ENTRIES),
 );
 
 export const sharedLoginFailureLockout = new LoginFailureLockout(
   envInt("COMMHUB_LOGIN_FAILURE_THRESHOLD", LOGIN_FAILURE_THRESHOLD),
   envInt("COMMHUB_LOGIN_LOCK_BASE_MS", LOGIN_LOCK_BASE_MS),
   envInt("COMMHUB_LOGIN_LOCK_MAX_MS", LOGIN_LOCK_MAX_MS),
+  envInt("COMMHUB_LOGIN_GUARD_MAX_ENTRIES", LOGIN_GUARD_MAX_ENTRIES),
 );

--- a/server/src/auth_login_guard.ts
+++ b/server/src/auth_login_guard.ts
@@ -1,0 +1,106 @@
+// #226 — public login brute-force guard.
+// In-memory by design: zero dependency, process-local defence-in-depth for the
+// public /api/auth/login surface. Bearer token auth paths do not use this file.
+
+export const LOGIN_IP_WINDOW_MS = 60_000;
+export const LOGIN_IP_MAX_PER_WINDOW = 10;
+export const LOGIN_FAILURE_THRESHOLD = 5;
+export const LOGIN_LOCK_BASE_MS = 30_000;
+export const LOGIN_LOCK_MAX_MS = 15 * 60_000;
+
+type WindowState = { count: number; resetAt: number };
+
+export class LoginIpRateLimiter {
+  private state = new Map<string, WindowState>();
+
+  constructor(
+    private readonly windowMs: number = LOGIN_IP_WINDOW_MS,
+    private readonly maxPerWindow: number = LOGIN_IP_MAX_PER_WINDOW,
+  ) {}
+
+  check(key: string, nowMs: number = Date.now()): { allowed: boolean; remaining: number; resetAt: number; retryAfterMs?: number } {
+    const entry = this.state.get(key);
+    if (!entry || nowMs >= entry.resetAt) {
+      const resetAt = nowMs + this.windowMs;
+      this.state.set(key, { count: 1, resetAt });
+      return { allowed: true, remaining: this.maxPerWindow - 1, resetAt };
+    }
+    if (entry.count >= this.maxPerWindow) {
+      return { allowed: false, remaining: 0, resetAt: entry.resetAt, retryAfterMs: entry.resetAt - nowMs };
+    }
+    entry.count++;
+    return { allowed: true, remaining: this.maxPerWindow - entry.count, resetAt: entry.resetAt };
+  }
+
+  reset(): void {
+    this.state.clear();
+  }
+}
+
+type FailureState = { failures: number; lockedUntil: number };
+
+export class LoginFailureLockout {
+  private state = new Map<string, FailureState>();
+
+  constructor(
+    private readonly threshold: number = LOGIN_FAILURE_THRESHOLD,
+    private readonly baseLockMs: number = LOGIN_LOCK_BASE_MS,
+    private readonly maxLockMs: number = LOGIN_LOCK_MAX_MS,
+  ) {}
+
+  check(username: string, nowMs: number = Date.now()): { locked: boolean; retryAfterMs?: number; lockedUntil?: number } {
+    const key = normalizeLoginUsername(username);
+    if (!key) return { locked: false };
+    const entry = this.state.get(key);
+    if (!entry || !entry.lockedUntil || nowMs >= entry.lockedUntil) return { locked: false };
+    return { locked: true, retryAfterMs: entry.lockedUntil - nowMs, lockedUntil: entry.lockedUntil };
+  }
+
+  recordFailure(username: string, nowMs: number = Date.now()): { locked: boolean; failures: number; lockMs?: number; lockedUntil?: number } {
+    const key = normalizeLoginUsername(username);
+    if (!key) return { locked: false, failures: 0 };
+    const current = this.state.get(key);
+    const failures = (current?.failures ?? 0) + 1;
+    if (failures < this.threshold) {
+      this.state.set(key, { failures, lockedUntil: 0 });
+      return { locked: false, failures };
+    }
+
+    const exponent = failures - this.threshold;
+    const lockMs = Math.min(this.baseLockMs * Math.pow(2, exponent), this.maxLockMs);
+    const lockedUntil = nowMs + lockMs;
+    this.state.set(key, { failures, lockedUntil });
+    return { locked: true, failures, lockMs, lockedUntil };
+  }
+
+  recordSuccess(username: string): void {
+    const key = normalizeLoginUsername(username);
+    if (key) this.state.delete(key);
+  }
+
+  reset(): void {
+    this.state.clear();
+  }
+}
+
+export function normalizeLoginUsername(username: unknown): string {
+  return typeof username === "string" ? username.trim().toLowerCase() : "";
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export const sharedLoginIpRateLimiter = new LoginIpRateLimiter(
+  envInt("COMMHUB_LOGIN_IP_WINDOW_MS", LOGIN_IP_WINDOW_MS),
+  envInt("COMMHUB_LOGIN_IP_MAX", LOGIN_IP_MAX_PER_WINDOW),
+);
+
+export const sharedLoginFailureLockout = new LoginFailureLockout(
+  envInt("COMMHUB_LOGIN_FAILURE_THRESHOLD", LOGIN_FAILURE_THRESHOLD),
+  envInt("COMMHUB_LOGIN_LOCK_BASE_MS", LOGIN_LOCK_BASE_MS),
+  envInt("COMMHUB_LOGIN_LOCK_MAX_MS", LOGIN_LOCK_MAX_MS),
+);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ import { createSSEStream, pushEvent, getSSEStats } from "./push.js";
 import { register, login, resolveToken, getUserNetworks, getUserAllNetworks, createNetwork, deleteNetwork, renameNetwork, changePassword, issueUserToken, listTokens, createToken, revokeToken, getNetworkMembers, getUserNetworkRole, addNetworkMember, updateMemberRole, removeNetworkMember, createInvite, joinByInvite, createNetworkTokenForNode, type AuthUser } from "./auth.js";
 import { abortRename, cleanupCommittedRenameSessions, commitRename, prepareRename, resolveCanonicalAlias } from "./rename.js";
 import { sharedSendDedup, buildDuplicateSendPayload } from "./send_dedup.js";
+import { sharedLoginFailureLockout, sharedLoginIpRateLimiter } from "./auth_login_guard.js";
 import {
   FILE_ID_REGEX,
   MAX_REQUEST_CONTENT_LENGTH,
@@ -613,15 +614,36 @@ Bun.serve({
 
     if (url.pathname === "/api/auth/login" && req.method === "POST") {
       const clientIP = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
-      if (!checkRateLimit(clientIP, 10)) {
+      const ipRate = sharedLoginIpRateLimiter.check(clientIP || "unknown");
+      if (!ipRate.allowed) {
         logAudit(null, null, "login_rate_limited", "auth", undefined, clientIP);
-        return withCors(req, Response.json({ ok: false, error: "too many attempts, try again later" }, { status: 429 }));
+        return withCors(req, Response.json(
+          { ok: false, error: "rate_limited", message: "Too many login attempts. Try again later.", retry_after_ms: ipRate.retryAfterMs },
+          { status: 429, headers: { "Retry-After": String(Math.ceil((ipRate.retryAfterMs ?? 1000) / 1000)) } }
+        ));
       }
       try {
         const body = await req.json() as any;
+        const lock = sharedLoginFailureLockout.check(body.username);
+        if (lock.locked) {
+          logAudit(null, body.username, "login_locked", "auth", undefined, `retry_after_ms=${lock.retryAfterMs ?? 0}`);
+          return withCors(req, Response.json(
+            { ok: false, error: "login_locked", message: "Too many failed login attempts. Try again later.", retry_after_ms: lock.retryAfterMs },
+            { status: 429, headers: { "Retry-After": String(Math.ceil((lock.retryAfterMs ?? 1000) / 1000)) } }
+          ));
+        }
         const result = login(body.username, body.password);
-        if (result.ok) logAudit(result.user!.user_id, body.username, "login", "user", result.user!.user_id);
-        else logAudit(null, body.username, "login_failed", "user", undefined, "invalid credentials");
+        if (result.ok) {
+          sharedLoginFailureLockout.recordSuccess(body.username);
+          logAudit(result.user!.user_id, body.username, "login", "user", result.user!.user_id);
+        } else {
+          const failure = sharedLoginFailureLockout.recordFailure(body.username);
+          if (failure.locked) {
+            const safeUsername = String(body.username ?? "").replace(/[\r\n\t]/g, " ").slice(0, 80);
+            console.warn(`[auth] login locked for username=${safeUsername} failures=${failure.failures} retry_after_ms=${failure.lockMs}`);
+          }
+          logAudit(null, body.username, "login_failed", "user", undefined, "invalid credentials");
+        }
         return withCors(req, Response.json(result, { status: result.ok ? 200 : 401 }));
       } catch (e: any) {
         return withCors(req, Response.json({ ok: false, error: e.message }, { status: 400 }));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,7 +7,7 @@ import { createSSEStream, pushEvent, getSSEStats } from "./push.js";
 import { register, login, resolveToken, getUserNetworks, getUserAllNetworks, createNetwork, deleteNetwork, renameNetwork, changePassword, issueUserToken, listTokens, createToken, revokeToken, getNetworkMembers, getUserNetworkRole, addNetworkMember, updateMemberRole, removeNetworkMember, createInvite, joinByInvite, createNetworkTokenForNode, type AuthUser } from "./auth.js";
 import { abortRename, cleanupCommittedRenameSessions, commitRename, prepareRename, resolveCanonicalAlias } from "./rename.js";
 import { sharedSendDedup, buildDuplicateSendPayload } from "./send_dedup.js";
-import { sharedLoginFailureLockout, sharedLoginIpRateLimiter } from "./auth_login_guard.js";
+import { getLoginClientIp, sharedLoginFailureLockout, sharedLoginIpRateLimiter } from "./auth_login_guard.js";
 import {
   FILE_ID_REGEX,
   MAX_REQUEST_CONTENT_LENGTH,
@@ -613,7 +613,7 @@ Bun.serve({
     }
 
     if (url.pathname === "/api/auth/login" && req.method === "POST") {
-      const clientIP = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+      const clientIP = getLoginClientIp(req);
       const ipRate = sharedLoginIpRateLimiter.check(clientIP || "unknown");
       if (!ipRate.allowed) {
         logAudit(null, null, "login_rate_limited", "auth", undefined, clientIP);

--- a/tests/qa-hub-19-login-guard/Dockerfile
+++ b/tests/qa-hub-19-login-guard/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-certificates jq unzip && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /app/server
+COPY server/package.json ./
+RUN bun install
+COPY server/src ./src
+
+WORKDIR /app
+COPY tests/qa-hub-19-login-guard/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/qa-hub-19-login-guard/README.md
+++ b/tests/qa-hub-19-login-guard/README.md
@@ -1,0 +1,12 @@
+# qa-hub-19-login-guard
+
+Pins #226 login protection behavior without touching any live hub:
+
+- `POST /api/auth/login` allows 10 attempts/minute per IP and returns 429 on the 11th.
+- Five wrong passwords lock the username; a correct password during the lock still returns 429.
+- After lock expiry, the correct password succeeds and clears the failure state.
+- Bearer-token API traffic remains unaffected by login throttling.
+
+The Docker fixture uses a short lock window via env overrides so the expiry path
+is tested without a 30 second sleep. Production defaults remain 30s/60s/120s...
+up to 15 minutes.

--- a/tests/qa-hub-19-login-guard/run.sh
+++ b/tests/qa-hub-19-login-guard/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT=19319
+BASE="http://127.0.0.1:$PORT"
+DB="/tmp/commhub-login-guard.db"
+LOG="/tmp/commhub-login-guard.log"
+rm -f "$DB" "$LOG"
+
+cleanup() {
+  set +e
+  kill "$SERVER_PID" >/dev/null 2>&1 || true
+  wait "$SERVER_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+post_login() {
+  local ip="$1" username="$2" password="$3" out="$4"
+  curl -sS -o "$out" -D "$out.headers" -w '%{http_code}' \
+    -X POST "$BASE/api/auth/login" \
+    -H "X-Forwarded-For: $ip" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$username\",\"password\":\"$password\"}"
+}
+
+echo "[0] start local hub with short test lock window"
+(
+  cd /app/server
+  PORT="$PORT" HOST=127.0.0.1 COMMHUB_DB="$DB" \
+  COMMHUB_LOGIN_LOCK_BASE_MS=1200 COMMHUB_LOGIN_LOCK_MAX_MS=1200 \
+  bun run src/index.ts
+) >"$LOG" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 60); do
+  curl -fsS "$BASE/health" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+curl -fsS "$BASE/health" >/dev/null
+
+echo "[1] register user"
+curl -fsS -X POST "$BASE/api/auth/register" -H 'Content-Type: application/json' \
+  -d '{"username":"guarduser","password":"StrongPassw0rd"}' >/tmp/register.json
+BOOT_TOKEN=$(jq -r '.token' /tmp/register.json)
+[[ "$BOOT_TOKEN" == utok_* ]] || { echo "FAIL: register token"; cat /tmp/register.json; exit 1; }
+
+echo "[2] IP login rate limit: 10/min allowed, 11th returns 429 + Retry-After"
+for i in $(seq 1 10); do
+  code=$(post_login "198.51.100.10" "guarduser" "StrongPassw0rd" "/tmp/ip-$i.json")
+  [[ "$code" == "200" ]] || { echo "FAIL: login attempt $i expected 200 got $code"; cat "/tmp/ip-$i.json"; exit 1; }
+done
+code=$(post_login "198.51.100.10" "guarduser" "StrongPassw0rd" /tmp/ip-11.json)
+[[ "$code" == "429" ]] || { echo "FAIL: 11th login expected 429 got $code"; cat /tmp/ip-11.json; exit 1; }
+jq -e '.ok == false and .error == "rate_limited" and (.retry_after_ms > 0)' /tmp/ip-11.json >/dev/null
+grep -qi '^Retry-After:' /tmp/ip-11.json.headers || { echo "FAIL: missing Retry-After header"; cat /tmp/ip-11.json.headers; exit 1; }
+
+echo "[3] token-auth endpoint is unaffected by login rate limit"
+status_code=$(curl -sS -o /tmp/status.json -w '%{http_code}' "$BASE/api/status" \
+  -H "Authorization: Bearer $BOOT_TOKEN" \
+  -H "X-Forwarded-For: 198.51.100.10")
+[[ "$status_code" == "200" ]] || { echo "FAIL: /api/status expected 200 got $status_code"; cat /tmp/status.json; exit 1; }
+
+echo "[4] username failure lock: 5 wrong passwords, then correct password is still 429"
+for i in $(seq 1 5); do
+  code=$(post_login "198.51.100.20" "guarduser" "wrong-$i" "/tmp/fail-$i.json")
+  [[ "$code" == "401" ]] || { echo "FAIL: wrong password $i expected 401 got $code"; cat "/tmp/fail-$i.json"; exit 1; }
+done
+code=$(post_login "198.51.100.20" "guarduser" "StrongPassw0rd" /tmp/locked.json)
+[[ "$code" == "429" ]] || { echo "FAIL: locked correct login expected 429 got $code"; cat /tmp/locked.json; exit 1; }
+jq -e '.ok == false and .error == "login_locked" and (.retry_after_ms > 0)' /tmp/locked.json >/dev/null
+grep -qi '^Retry-After:' /tmp/locked.json.headers || { echo "FAIL: missing lock Retry-After header"; cat /tmp/locked.json.headers; exit 1; }
+grep -q 'login locked for username=guarduser' "$LOG" || { echo "FAIL: server log missing lock event"; tail -120 "$LOG"; exit 1; }
+
+echo "[5] after lock expires, correct password succeeds and clears failures"
+sleep 1.5
+code=$(post_login "198.51.100.20" "guarduser" "StrongPassw0rd" /tmp/recovered.json)
+[[ "$code" == "200" ]] || { echo "FAIL: recovered login expected 200 got $code"; cat /tmp/recovered.json; tail -120 "$LOG"; exit 1; }
+jq -e '.ok == true and (.token | startswith("utok_"))' /tmp/recovered.json >/dev/null
+
+echo "PASS qa-hub-19 login guard"

--- a/tests/qa-hub-19-login-guard/run.sh
+++ b/tests/qa-hub-19-login-guard/run.sh
@@ -44,12 +44,12 @@ curl -fsS -X POST "$BASE/api/auth/register" -H 'Content-Type: application/json' 
 BOOT_TOKEN=$(jq -r '.token' /tmp/register.json)
 [[ "$BOOT_TOKEN" == utok_* ]] || { echo "FAIL: register token"; cat /tmp/register.json; exit 1; }
 
-echo "[2] IP login rate limit: 10/min allowed, 11th returns 429 + Retry-After"
+echo "[2] IP login rate limit: 10/min allowed, 11th returns 429 + Retry-After (XFF last-hop keyed)"
 for i in $(seq 1 10); do
-  code=$(post_login "198.51.100.10" "guarduser" "StrongPassw0rd" "/tmp/ip-$i.json")
+  code=$(post_login "198.51.100.$i, 203.0.113.10" "guarduser" "StrongPassw0rd" "/tmp/ip-$i.json")
   [[ "$code" == "200" ]] || { echo "FAIL: login attempt $i expected 200 got $code"; cat "/tmp/ip-$i.json"; exit 1; }
 done
-code=$(post_login "198.51.100.10" "guarduser" "StrongPassw0rd" /tmp/ip-11.json)
+code=$(post_login "198.51.100.99, 203.0.113.10" "guarduser" "StrongPassw0rd" /tmp/ip-11.json)
 [[ "$code" == "429" ]] || { echo "FAIL: 11th login expected 429 got $code"; cat /tmp/ip-11.json; exit 1; }
 jq -e '.ok == false and .error == "rate_limited" and (.retry_after_ms > 0)' /tmp/ip-11.json >/dev/null
 grep -qi '^Retry-After:' /tmp/ip-11.json.headers || { echo "FAIL: missing Retry-After header"; cat /tmp/ip-11.json.headers; exit 1; }


### PR DESCRIPTION
## Summary

Implements #226 login brute-force defence for the public `<hub-domain>` surface:

- adds `/api/auth/login` per-IP limiter: 10 attempts/minute, 429 + `Retry-After`
- adds per-username failed-password lockout: 5 failures, exponential 30s/60s/120s..., capped at 15 minutes
- returns 429 during username lockout before checking the password, so correct passwords do not bypass or reveal timing during lock
- clears username failure state on successful login
- keeps Bearer token auth paths untouched; MCP/SSE/API token traffic does not use the login guard

Defaults match #226. Docker tests use short lock env overrides only to exercise lock expiry without waiting 30 seconds.

## Verification

- `COMMHUB_DB=/tmp/commhub-login-guard-unit.db bun test src/auth_login_guard.test.ts`
- `COMMHUB_DB=/tmp/commhub-login-guard-upload-unit.db bun test src/uploads.test.ts src/auth_login_guard.test.ts`
- `sg docker -c 'docker build -f tests/qa-hub-19-login-guard/Dockerfile -t anet-qa-hub-19-login-guard .'`
- `sg docker -c 'docker run --rm anet-qa-hub-19-login-guard'`
- `sg docker -c 'docker build -f tests/test5-auth/Dockerfile -t anet-test5-auth-login-guard .'`
- `sg docker -c 'docker run --rm anet-test5-auth-login-guard'`
- `sg docker -c 'docker build -f tests/qa-dash-07-auth-boundary/Dockerfile -t anet-qa-dash-07-auth-boundary-login-guard .'`
- `sg docker -c 'docker run --rm anet-qa-dash-07-auth-boundary-login-guard'`
- `sg docker -c 'docker build -f tests/qa-hub-18-delivery-semantics/Dockerfile -t anet-qa-hub-18-delivery-semantics-login-guard .'`
- `sg docker -c 'docker run --rm anet-qa-hub-18-delivery-semantics-login-guard'`
- `git diff --check`

Report: `docs/tests/report-226-login-guard.txt`

## Notes

No npm publish. No live hub access. Server-only security hardening PR.

Author + Agent: 通信牛
