### PR TITLE
fix(#146 PR-4): runtime alias getter + node_id-based identity propagation

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -36,6 +36,7 @@ import {
   buildResumeHint,
   fetchUnresolvedOutbound,
 } from "./runtime/grok-build-acp/resume-hint";
+import { CurrentAliasResolver } from "./runtime/current-alias";
 
 const home = homedir();
 
@@ -538,41 +539,124 @@ async function callCommHub(method: string, params: Record<string, unknown>, retr
   throw lastErr || new Error(`callCommHub(${method}) failed after ${retries} retries`);
 }
 
-const NODE_ID = fileConfig.node_id || "";
+// #146 PR-4 — prefer the COMMHUB_NODE_ID env that PR-3 (e0aa4d8) sets on
+// every launched node, fall back to the config field for back-compat with
+// nodes started before PR-3 landed. The env wins because the launcher
+// always knows the canonical node id; a stale config file would mislead.
+const NODE_ID = process.env.COMMHUB_NODE_ID || fileConfig.node_id || "";
 const NODE_NAME = fileConfig.node_name || "";
 const NETWORK_ID = fileConfig.network_id || process.env.ANET_NETWORK_ID || globalConfig.network_id || "";
 const RESUME_ID = NODE_ID ? `sdk-${NODE_ID}` : `sdk-${ALIAS}-${Date.now().toString(36)}`;
+
+// #146 PR-4 — single resolver instance backing every sender-side commhub
+// call (register / reportStatus / sendReply / inbox-poll / send_task
+// MCP tool factory). Synchronous current() returns the cached value for
+// log lines and file paths; async refresh() hits commhub with a 30 s
+// cache when callers care about staleness. Fetches the canonical alias
+// from the server's GET /api/status endpoint scoped to this node_id.
+const aliasResolver = new CurrentAliasResolver({
+  initialAlias: ALIAS,
+  nodeId: NODE_ID || null,
+  cacheTtlMs: 30_000,
+  fetchCanonicalAlias: async (nodeId: string) => {
+    try {
+      const headers: Record<string, string> = { Accept: "application/json" };
+      if (AUTH_TOKEN) headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
+      const url = `${COMMHUB_URL}/api/status${NETWORK_ID ? `?network_id=${encodeURIComponent(NETWORK_ID)}` : ""}`;
+      const ctl = new AbortController();
+      const timer = setTimeout(() => ctl.abort(), 2500);
+      try {
+        const res = await fetch(url, { headers, signal: ctl.signal });
+        if (!res.ok) return null;
+        const body = (await res.json()) as { sessions?: Array<{ node_id?: string; alias?: string }> };
+        const match = body.sessions?.find((s) => s.node_id === nodeId);
+        return match?.alias ?? null;
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      return null;
+    }
+  },
+  onDrift: (oldAlias, newAlias, source) => {
+    warn(`[alias-drift] ${oldAlias} → ${newAlias} (source: ${source})`);
+  },
+  warn: (m) => debug(m),
+});
+
+/**
+ * Synchronous alias accessor for hot paths (log lines, file paths,
+ * commhub tool factory closure). Returns the last-known alias without
+ * I/O — never waits.
+ */
+function currentAlias(): string {
+  return aliasResolver.current();
+}
+
+/**
+ * Async alias accessor for sender-side commhub calls where staleness
+ * causes the #146 family of routing bugs. Hits commhub with a 30 s
+ * cache; on fetch failure, returns the cached value (graceful fallback,
+ * task still runs).
+ */
+function liveAlias(): Promise<string> {
+  return aliasResolver.refresh();
+}
 // #119: host telemetry attached to every report_status. Commhub server-side
 // schema lacks `host` for now (通信牛 step 2 follow-up); Zod's default object
 // mode silently drops unknown keys, so sending it here is safe — once
 // commhub-server adds the field to the schema the payload starts flowing
 // straight through without a coordinated release of both sides.
-const register = () => callCommHub("report_status", {
-  resume_id: RESUME_ID, alias: ALIAS, status: "idle",
-  server: osHostname(), hostname: osHostname(),
-  agent: `agent-node:${RUNTIME}`, project_dir: process.cwd(),
-  node_id: NODE_ID || undefined,
-  node_name: NODE_NAME || undefined,
-  session_id: SESSION_ID || undefined,
-  config_path: configFilePath || undefined,
-  channels: channelSpecs.length ? JSON.stringify(channelSpecs) : undefined,
-  model: MODEL || undefined,
-  network_id: NETWORK_ID || undefined,
-  host: getHostTelemetry(),
-  process_telemetry: getProcessTelemetry(),
-});
-const reportStatus = (status: string, task?: string) => callCommHub("report_status", {
-  resume_id: RESUME_ID, alias: ALIAS, status, task,
-  node_id: NODE_ID || undefined,
-  session_id: claudeSessionId || grokSessionId || SESSION_ID || undefined,
-  config_path: configFilePath || undefined,
-  channels: channelSpecs.length ? JSON.stringify(channelSpecs) : undefined,
-  network_id: NETWORK_ID || undefined,
-  host: getHostTelemetry(),
-  process_telemetry: getProcessTelemetry(),
-});
-const getInbox = async () => (await callCommHub("get_inbox", { alias: ALIAS, limit: 20 }))?.messages || [];
-const ackMessage = (id: string) => callCommHub("ack_inbox", { alias: ALIAS, message_id: id });
+// #146 PR-4 — all sender-side commhub calls read the live alias via
+// liveAlias() (30 s LRU + post-register canonical drift detection)
+// rather than the frozen ALIAS const, so a rename committed on the
+// server propagates to outbound traffic within one cache window
+// instead of requiring a node restart.
+const register = async () => {
+  const alias = await liveAlias();
+  const result = await callCommHub("report_status", {
+    resume_id: RESUME_ID, alias, status: "idle",
+    server: osHostname(), hostname: osHostname(),
+    agent: `agent-node:${RUNTIME}`, project_dir: process.cwd(),
+    node_id: NODE_ID || undefined,
+    node_name: NODE_NAME || undefined,
+    session_id: SESSION_ID || undefined,
+    config_path: configFilePath || undefined,
+    channels: channelSpecs.length ? JSON.stringify(channelSpecs) : undefined,
+    model: MODEL || undefined,
+    network_id: NETWORK_ID || undefined,
+    host: getHostTelemetry(),
+    process_telemetry: getProcessTelemetry(),
+  });
+  // Server is authoritative: if it told us a canonical alias different
+  // from what we just sent, treat that as a snapshot update so the
+  // resolver doesn't wait another 30 s to reflect it.
+  if (typeof result?.alias === "string" && result.alias) {
+    aliasResolver.set(result.alias);
+  }
+  return result;
+};
+const reportStatus = async (status: string, task?: string) => {
+  const alias = await liveAlias();
+  return callCommHub("report_status", {
+    resume_id: RESUME_ID, alias, status, task,
+    node_id: NODE_ID || undefined,
+    session_id: claudeSessionId || grokSessionId || SESSION_ID || undefined,
+    config_path: configFilePath || undefined,
+    channels: channelSpecs.length ? JSON.stringify(channelSpecs) : undefined,
+    network_id: NETWORK_ID || undefined,
+    host: getHostTelemetry(),
+    process_telemetry: getProcessTelemetry(),
+  });
+};
+const getInbox = async () => {
+  const alias = await liveAlias();
+  return (await callCommHub("get_inbox", { alias, limit: 20 }))?.messages || [];
+};
+const ackMessage = async (id: string) => {
+  const alias = await liveAlias();
+  return callCommHub("ack_inbox", { alias, message_id: id });
+};
 
 // #168 RC-B1 + RC-B2 + RC-C fix: structured sendReply.
 //
@@ -587,10 +671,14 @@ async function sendReply(
   taskId?: string,
   failed = false,
 ): Promise<{ delivered: true; reply_id?: string; payload: any }> {
+  // #146 PR-4 — fresh alias on the wire so a rename mid-flight doesn't
+  // attribute this reply to the old name (which a post-rename inbox
+  // viewer would see as an orphaned reply from a non-existent sender).
+  const fromAlias = await liveAlias();
   const result = await callCommHub("send_reply", {
     alias: target,
     text: message,
-    from_session: ALIAS,
+    from_session: fromAlias,
     in_reply_to: taskId || undefined,
     status: failed ? "failed" : "replied",
   });
@@ -931,7 +1019,10 @@ async function processWithClaude(task: string, from: string): Promise<string> {
   const mcpServers: Record<string, any> = {};
   if (commhubUrl) {
     try {
-      mcpServers["commhub"] = await createCommhubSdkMcpServer(commhubUrl, commhubToken, ALIAS);
+      // #146 PR-4 — pass a getter, not the const, so every LLM-driven
+      // commhub_send_task tool call reads the live alias at invocation
+      // time rather than the closure-captured startup value.
+      mcpServers["commhub"] = await createCommhubSdkMcpServer(commhubUrl, commhubToken, currentAlias);
     } catch (e: any) {
       log(`[claude] ⚠ commhub SDK MCP server init failed (${e?.message || e}); falling back to type:"http" (known-broken, see #102 smoke).`);
       mcpServers["commhub"] = {
@@ -1526,7 +1617,15 @@ async function processWithGrok(task: string, from: string, images?: string[]): P
           ),
         ]);
       };
-      const outstanding = await fetchUnresolvedOutbound(ALIAS, fetchWithTimeout, { topN: 10 });
+      // #146 PR-4 — prefer querying by node_id so a rename of this node
+      // doesn't cause the resume hint to miss pre-rename outbound rows
+      // (whose tasks.from_name is the old alias). Falls back to alias
+      // when node_id is unavailable on older configs.
+      const outstanding = await fetchUnresolvedOutbound(
+        { nodeId: NODE_ID || null, alias: currentAlias() },
+        fetchWithTimeout,
+        { topN: 10 },
+      );
       const hint = buildResumeHint(outstanding);
       if (hint) {
         log(`[grok] resume hint: ${outstanding.length} un-closed-loop outbound task(s) prepended to first prompt`);
@@ -1643,11 +1742,13 @@ async function tryHandleExplicitDelegation(task: string, from: string, taskId: s
     return `未找到目标 alias：${parsed.alias}。已查询 CommHub 在线状态，但列表中没有该精确 alias。`;
   }
 
+  // #146 PR-4 — fresh alias on the explicit-delegation wrapper path.
+  const fromAlias = await liveAlias();
   const sendRes = parseToolJson(await callCommHub("send_task", {
     alias: parsed.alias,
     task: parsed.childTask,
     priority: "normal",
-    from_session: ALIAS,
+    from_session: fromAlias,
     parent_task_id: taskId,
   }));
   const childTaskId = findTaskId(sendRes);

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -602,6 +602,100 @@ function currentAlias(): string {
 function liveAlias(): Promise<string> {
   return aliasResolver.refresh();
 }
+
+// #146 PR-4 二审 — server capability probe for `from_node_id` query
+// param on the `list_tasks` MCP tool. Without a probe, sending the
+// param to a pre-PR-1 server (< 0.8.6-preview.0) would result in the
+// param being silently ignored, the response coming back unfiltered,
+// and the resume hint polluting the LLM context with other nodes'
+// outbound traffic. The probe runs once at boot, caches the result
+// for the process lifetime, and is consumed by the resume-hint fetch
+// in processWithGrok.
+let _serverSupportsFromNodeId: boolean | null = null;
+let _probeInFlight: Promise<boolean> | null = null;
+
+async function probeServerSupportsFromNodeId(): Promise<boolean> {
+  if (_serverSupportsFromNodeId !== null) return _serverSupportsFromNodeId;
+  if (_probeInFlight) return _probeInFlight;
+  _probeInFlight = (async () => {
+    try {
+      const ctl = new AbortController();
+      const timer = setTimeout(() => ctl.abort(), 2500);
+      try {
+        const res = await fetch(`${COMMHUB_URL}/health`, { signal: ctl.signal });
+        if (!res.ok) {
+          _serverSupportsFromNodeId = false;
+          return false;
+        }
+        const body = (await res.json()) as { version?: string };
+        const supported = compareCommhubVersion(body.version, "0.8.6-preview.0") >= 0;
+        _serverSupportsFromNodeId = supported;
+        debug(`[probe] commhub /health version=${body.version ?? "?"} → from_node_id ${supported ? "supported" : "NOT supported, will use from_name fallback"}`);
+        return supported;
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (e: any) {
+      // Hub unreachable / no /health endpoint / malformed version —
+      // assume the cautious default (unsupported) so we don't risk
+      // pollution from a unknown server.
+      _serverSupportsFromNodeId = false;
+      debug(`[probe] /health probe failed (${e?.message ?? e}); defaulting to from_name`);
+      return false;
+    } finally {
+      _probeInFlight = null;
+    }
+  })();
+  return _probeInFlight;
+}
+
+/**
+ * Compare two commhub-server semver-ish version strings.
+ * Accepts shapes like "0.8.5", "0.8.6-preview.0", "0.8.6-preview.10".
+ * Returns -1 / 0 / +1 with the convention `a vs b`.
+ * Unknown / malformed strings sort BEFORE every released version, so
+ * an unknown server is treated as "older" and the from_node_id path
+ * is skipped — the safe default.
+ */
+function compareCommhubVersion(a: string | undefined, b: string): number {
+  if (!a || typeof a !== "string") return -1;
+  const parse = (v: string) => {
+    const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-preview\.(\d+))?/);
+    if (!m) return null;
+    return {
+      major: Number(m[1]),
+      minor: Number(m[2]),
+      patch: Number(m[3]),
+      // No -preview suffix means a stable release, which sorts AFTER any preview.
+      // We represent that by setting preview to Infinity.
+      preview: m[4] === undefined ? Number.POSITIVE_INFINITY : Number(m[4]),
+    };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa) return -1;
+  if (!pb) return 1;
+  for (const k of ["major", "minor", "patch", "preview"] as const) {
+    if (pa[k] < pb[k]) return -1;
+    if (pa[k] > pb[k]) return 1;
+  }
+  return 0;
+}
+
+// #146 PR-4 二审 belt-and-braces — 30 s background refresh timer so the
+// resolver stays warm even when neither sender-side commhub calls nor
+// LLM tool calls fire for an extended period (e.g. an idle node
+// waiting for inbox). Cheap: one extra HTTP round-trip every 30 s.
+// `refresh()` is dedupe-safe and never throws, so an unreachable hub
+// just leaves the cache where it is.
+const BACKGROUND_ALIAS_REFRESH_INTERVAL_MS = 30_000;
+if (NODE_ID) {
+  setInterval(() => {
+    void aliasResolver.refresh().catch(() => {
+      /* refresh() already swallows + warns; nothing more to do here */
+    });
+  }, BACKGROUND_ALIAS_REFRESH_INTERVAL_MS).unref();
+}
 // #119: host telemetry attached to every report_status. Commhub server-side
 // schema lacks `host` for now (通信牛 step 2 follow-up); Zod's default object
 // mode silently drops unknown keys, so sending it here is safe — once
@@ -1019,10 +1113,16 @@ async function processWithClaude(task: string, from: string): Promise<string> {
   const mcpServers: Record<string, any> = {};
   if (commhubUrl) {
     try {
-      // #146 PR-4 — pass a getter, not the const, so every LLM-driven
-      // commhub_send_task tool call reads the live alias at invocation
-      // time rather than the closure-captured startup value.
-      mcpServers["commhub"] = await createCommhubSdkMcpServer(commhubUrl, commhubToken, currentAlias);
+      // #146 PR-4 — pass the ASYNC getter so every LLM-driven
+      // commhub_send_task tool call revalidates the alias against the
+      // server within the 30 s cache window. Earlier draft passed the
+      // sync `currentAlias()`, which 通信牛 PR-review caught as
+      // unbounded-staleness on long turns (no sender-side call → no
+      // refresh trigger → closure-captured value goes stale forever).
+      // `liveAlias` is a Promise<string> wrapper around
+      // `aliasResolver.refresh()`; cache hit is microseconds, miss is
+      // one round-trip with 2.5 s budget.
+      mcpServers["commhub"] = await createCommhubSdkMcpServer(commhubUrl, commhubToken, liveAlias);
     } catch (e: any) {
       log(`[claude] ⚠ commhub SDK MCP server init failed (${e?.message || e}); falling back to type:"http" (known-broken, see #102 smoke).`);
       mcpServers["commhub"] = {
@@ -1621,10 +1721,17 @@ async function processWithGrok(task: string, from: string, images?: string[]): P
       // doesn't cause the resume hint to miss pre-rename outbound rows
       // (whose tasks.from_name is the old alias). Falls back to alias
       // when node_id is unavailable on older configs.
+      // 二审 amend — only send `from_node_id` when the probe confirmed
+      // the server understands it. Otherwise fall back to `from_name`
+      // (a pre-PR-1 server silently ignores unknown query params and
+      // would return ALL of this user's outbound tasks, polluting the
+      // hint). Additionally, fetchUnresolvedOutbound double-checks
+      // every returned row against our identity client-side.
+      const serverSupportsFromNodeId = await probeServerSupportsFromNodeId();
       const outstanding = await fetchUnresolvedOutbound(
         { nodeId: NODE_ID || null, alias: currentAlias() },
         fetchWithTimeout,
-        { topN: 10 },
+        { topN: 10, serverSupportsFromNodeId },
       );
       const hint = buildResumeHint(outstanding);
       if (hint) {

--- a/agent-node/src/commhub-mcp.ts
+++ b/agent-node/src/commhub-mcp.ts
@@ -130,18 +130,30 @@ export function injectAgentFromSession(toolName: string, args: unknown, agentAli
 //     → admin / hub-side; not exposing them to the LLM by default
 export async function createCommhubSdkMcpServer(
   hubUrl: string, token: string | undefined,
-  // #146 PR-4 — accept either a static string (legacy callers) or a
-  // getter function (the live-alias resolver path). The getter is
-  // called on every tool invocation so a rename committed on the
-  // server propagates to every commhub_send_task / commhub_send_message
-  // dispatched by the LLM, without needing to rebuild the MCP server.
-  agentAliasOrGetter?: string | (() => string),
+  // #146 PR-4 — accept three forms:
+  //   - undefined         (test / legacy callers without identity)
+  //   - static string     (legacy callers; alias never changes)
+  //   - sync getter       () => string (cache-only read, legacy)
+  //   - async getter      () => Promise<string> (the live-alias path)
+  // For an unbounded-staleness-safe path the caller should pass the
+  // async getter (e.g. cli.ts wires `() => aliasResolver.refresh()` so
+  // every tool invocation revalidates the cache against the server
+  // within the 30 s window). 通信牛 PR #228 二审 catch — without this
+  // a long LLM turn that doesn't fire any sender-side commhub call
+  // could read a permanently stale closure-captured alias.
+  agentAliasOrGetter?: string | (() => string) | (() => Promise<string>),
 ): Promise<McpSdkServerConfigWithInstance> {
   const { createSdkMcpServer, tool } = await import("@anthropic-ai/claude-agent-sdk");
-  const resolveAlias = (): string | undefined =>
-    typeof agentAliasOrGetter === "function" ? agentAliasOrGetter() : agentAliasOrGetter;
+  const resolveAlias = async (): Promise<string | undefined> => {
+    if (agentAliasOrGetter === undefined) return undefined;
+    if (typeof agentAliasOrGetter !== "function") return agentAliasOrGetter;
+    const value = agentAliasOrGetter();
+    return value && typeof (value as any).then === "function"
+      ? await (value as Promise<string>)
+      : (value as string);
+  };
   const fwd = (name: string) =>
-    (async (args: unknown) => forwardToCommhub(hubUrl, token, name, injectAgentFromSession(name, args, resolveAlias())));
+    (async (args: unknown) => forwardToCommhub(hubUrl, token, name, injectAgentFromSession(name, args, await resolveAlias())));
 
   return createSdkMcpServer({
     name: "commhub",

--- a/agent-node/src/commhub-mcp.ts
+++ b/agent-node/src/commhub-mcp.ts
@@ -130,11 +130,18 @@ export function injectAgentFromSession(toolName: string, args: unknown, agentAli
 //     → admin / hub-side; not exposing them to the LLM by default
 export async function createCommhubSdkMcpServer(
   hubUrl: string, token: string | undefined,
-  agentAlias?: string,
+  // #146 PR-4 — accept either a static string (legacy callers) or a
+  // getter function (the live-alias resolver path). The getter is
+  // called on every tool invocation so a rename committed on the
+  // server propagates to every commhub_send_task / commhub_send_message
+  // dispatched by the LLM, without needing to rebuild the MCP server.
+  agentAliasOrGetter?: string | (() => string),
 ): Promise<McpSdkServerConfigWithInstance> {
   const { createSdkMcpServer, tool } = await import("@anthropic-ai/claude-agent-sdk");
+  const resolveAlias = (): string | undefined =>
+    typeof agentAliasOrGetter === "function" ? agentAliasOrGetter() : agentAliasOrGetter;
   const fwd = (name: string) =>
-    (async (args: unknown) => forwardToCommhub(hubUrl, token, name, injectAgentFromSession(name, args, agentAlias)));
+    (async (args: unknown) => forwardToCommhub(hubUrl, token, name, injectAgentFromSession(name, args, resolveAlias())));
 
   return createSdkMcpServer({
     name: "commhub",

--- a/agent-node/src/runtime/current-alias.test.ts
+++ b/agent-node/src/runtime/current-alias.test.ts
@@ -1,0 +1,264 @@
+// #146 PR-4 — unit tests for the live alias resolver.
+//
+// Coverage matrix per #146 PR-4 design contract:
+//   1. current() returns startup snapshot before any refresh
+//   2. refresh() warm-cache short-circuits, no fetch fired
+//   3. refresh() expired-cache hits the server, updates the alias,
+//      fires onDrift("fetch")
+//   4. Concurrent refresh() calls dedupe onto one fetch
+//   5. fetchCanonicalAlias throwing keeps the cached value (graceful
+//      fallback, no propagation)
+//   6. fetchCanonicalAlias returning null is treated as "server doesn't
+//      know yet" and keeps the cache
+//   7. After a failed fetch, the cache timestamp still bumps so we
+//      don't hammer a sick hub on every call
+//   8. set() force-installs the alias and fires onDrift("snapshot")
+//   9. set() with the same value is a no-op (no drift event)
+//   10. nodeId == null short-circuits refresh() — no fetch hook called
+//   11. cacheTtlMs = 0 disables caching — every refresh() fetches
+//   12. ageMs() / isFresh() reflect actual cache state for assertions
+import { describe, expect, test } from "bun:test";
+import { CurrentAliasResolver } from "./current-alias";
+
+function makeResolver(opts: {
+  initialAlias?: string;
+  nodeId?: string | null;
+  cacheTtlMs?: number;
+  fetchImpl?: (nodeId: string) => Promise<string | null>;
+  onDrift?: (from: string, to: string, source: "fetch" | "snapshot") => void;
+  warn?: (msg: string) => void;
+} = {}) {
+  let fetchCalls = 0;
+  return {
+    resolver: new CurrentAliasResolver({
+      initialAlias: opts.initialAlias ?? "old-agent",
+      nodeId: opts.nodeId === undefined ? "node-x" : opts.nodeId,
+      cacheTtlMs: opts.cacheTtlMs,
+      fetchCanonicalAlias: opts.fetchImpl ?? (async () => { fetchCalls++; return "old-agent"; }),
+      onDrift: opts.onDrift,
+      warn: opts.warn,
+    }),
+    fetchCalls: () => fetchCalls,
+  };
+}
+
+describe("CurrentAliasResolver — startup snapshot", () => {
+  test("current() returns the initial alias before any refresh()", () => {
+    const { resolver } = makeResolver({ initialAlias: "startup-alias" });
+    expect(resolver.current()).toBe("startup-alias");
+  });
+
+  test("ageMs() reports Infinity before first fetch (cache is cold)", () => {
+    const { resolver } = makeResolver();
+    expect(resolver.ageMs()).toBe(Number.POSITIVE_INFINITY);
+    expect(resolver.isFresh()).toBe(false);
+  });
+});
+
+describe("CurrentAliasResolver — refresh() cache behaviour", () => {
+  test("warm cache short-circuits — no fetch fired within TTL", async () => {
+    let fetchCalls = 0;
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "agent-v1",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => { fetchCalls++; return "agent-v2"; },
+    });
+    const t0 = 1_700_000_000_000;
+    await resolver.refresh(t0); // primes cache
+    await resolver.refresh(t0 + 1_000); // 1s later, well within TTL
+    await resolver.refresh(t0 + 29_999); // just before expiry
+    expect(fetchCalls).toBe(1); // only the priming call
+  });
+
+  test("expired cache hits the server and updates the alias + fires onDrift", async () => {
+    const drifts: Array<{ from: string; to: string; source: string }> = [];
+    let phase = 0;
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "v1-agent",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => {
+        phase++;
+        return phase === 1 ? "v1-agent" : "v2-agent";
+      },
+      onDrift: (from, to, source) => { drifts.push({ from, to, source }); },
+    });
+    const t0 = 1_700_000_000_000;
+    await resolver.refresh(t0);
+    expect(resolver.current()).toBe("v1-agent");
+    expect(drifts).toHaveLength(0); // no change yet
+
+    await resolver.refresh(t0 + 30_001); // past TTL
+    expect(resolver.current()).toBe("v2-agent");
+    expect(drifts).toEqual([{ from: "v1-agent", to: "v2-agent", source: "fetch" }]);
+  });
+
+  test("concurrent refresh() calls dedupe onto one fetch", async () => {
+    let inflight = 0;
+    let maxInflight = 0;
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "agent",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => {
+        inflight++; maxInflight = Math.max(maxInflight, inflight);
+        await new Promise((r) => setTimeout(r, 10));
+        inflight--;
+        return "new-agent";
+      },
+    });
+    const results = await Promise.all([
+      resolver.refresh(0),
+      resolver.refresh(0),
+      resolver.refresh(0),
+      resolver.refresh(0),
+      resolver.refresh(0),
+    ]);
+    expect(maxInflight).toBe(1);
+    expect(results.every((r) => r === "new-agent")).toBe(true);
+  });
+});
+
+describe("CurrentAliasResolver — graceful fetch failure", () => {
+  test("fetch throwing keeps the cached value and emits a warn", async () => {
+    let warned: string | undefined;
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "stable-agent",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => { throw new Error("ECONNREFUSED hub is down"); },
+      warn: (m) => { warned = m; },
+    });
+    const t0 = 1_700_000_000_000;
+    const result = await resolver.refresh(t0);
+    expect(result).toBe("stable-agent");
+    expect(resolver.current()).toBe("stable-agent");
+    expect(warned).toContain("ECONNREFUSED");
+    expect(warned).toContain("stable-agent");
+  });
+
+  test("fetch returning null is treated as 'server does not know yet'", async () => {
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "boot-agent",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => null,
+    });
+    expect(await resolver.refresh(1)).toBe("boot-agent");
+  });
+
+  test("fetch returning empty string is also treated as 'server does not know'", async () => {
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "boot-agent",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => "",
+    });
+    expect(await resolver.refresh(1)).toBe("boot-agent");
+  });
+
+  test("after a failed fetch the cache timestamp still bumps — no hammering", async () => {
+    let fetchCalls = 0;
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "agent",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => { fetchCalls++; throw new Error("hub down"); },
+    });
+    const t0 = 1_700_000_000_000;
+    await resolver.refresh(t0);
+    expect(fetchCalls).toBe(1);
+    // Immediately again — cache is "warm" with the failure, no new fetch.
+    await resolver.refresh(t0 + 5_000);
+    await resolver.refresh(t0 + 25_000);
+    expect(fetchCalls).toBe(1);
+    // After TTL expires, we retry.
+    await resolver.refresh(t0 + 30_001);
+    expect(fetchCalls).toBe(2);
+  });
+});
+
+describe("CurrentAliasResolver — set() force install", () => {
+  test("set() updates the alias and fires onDrift with source 'snapshot'", () => {
+    const drifts: Array<{ from: string; to: string; source: string }> = [];
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "old-name",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => "irrelevant",
+      onDrift: (from, to, source) => { drifts.push({ from, to, source }); },
+    });
+    resolver.set("new-name", 1234);
+    expect(resolver.current()).toBe("new-name");
+    expect(drifts).toEqual([{ from: "old-name", to: "new-name", source: "snapshot" }]);
+    expect(resolver.isFresh(1234)).toBe(true);
+  });
+
+  test("set() with the same value is a no-op (no drift event, but cache timestamp bumps)", () => {
+    let driftCount = 0;
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "stable",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => "stable",
+      onDrift: () => { driftCount++; },
+    });
+    resolver.set("stable", 1000);
+    expect(driftCount).toBe(0);
+    expect(resolver.ageMs(1000)).toBe(0);
+  });
+
+  test("set('') is ignored (defends against caller forgetting to validate)", () => {
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "real-name",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => "irrelevant",
+    });
+    resolver.set("");
+    expect(resolver.current()).toBe("real-name");
+  });
+});
+
+describe("CurrentAliasResolver — edge cases", () => {
+  test("nodeId = null short-circuits refresh() and never calls the fetch hook", async () => {
+    let fetchCalls = 0;
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "lonely-agent",
+      nodeId: null,
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => { fetchCalls++; return "x"; },
+    });
+    expect(await resolver.refresh(1)).toBe("lonely-agent");
+    expect(await resolver.refresh(60_000)).toBe("lonely-agent");
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("cacheTtlMs = 0 disables caching — every refresh() fetches", async () => {
+    let fetchCalls = 0;
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "agent",
+      nodeId: "node-x",
+      cacheTtlMs: 0,
+      fetchCanonicalAlias: async () => { fetchCalls++; return "agent"; },
+    });
+    await resolver.refresh(1);
+    await resolver.refresh(2);
+    await resolver.refresh(3);
+    expect(fetchCalls).toBe(3);
+  });
+
+  test("ageMs() reflects elapsed time after a refresh", async () => {
+    const resolver = new CurrentAliasResolver({
+      initialAlias: "agent",
+      nodeId: "node-x",
+      cacheTtlMs: 30_000,
+      fetchCanonicalAlias: async () => "agent",
+    });
+    await resolver.refresh(1000);
+    expect(resolver.ageMs(1500)).toBe(500);
+    expect(resolver.isFresh(1500)).toBe(true);
+    expect(resolver.isFresh(31_001)).toBe(false);
+  });
+});

--- a/agent-node/src/runtime/current-alias.ts
+++ b/agent-node/src/runtime/current-alias.ts
@@ -1,0 +1,157 @@
+// #146 PR-4 — live alias resolver.
+//
+// The agent-node process used to freeze its display alias into a
+// module-level `const ALIAS` at startup (resolveAlias() in cli.ts). Every
+// subsequent commhub interaction — register / reportStatus / sendReply /
+// inbox poll / commhub_send_task tool / #213 resume hint — read that
+// const, so a rename committed on the server side never propagated to
+// the node's outbound traffic until the next restart. The downstream
+// effects fan out into #146 / #203 / #213 routing drift.
+//
+// PR-1 (commit 2dc166c) gave us the server-side handles we need to fix
+// this: `tasks.from_node_id` / `inbox.node_id` columns, the
+// `rename-committed` eventBus, and `list_tasks` accepting a
+// `from_node_id` filter. PR-3 (commit e0aa4d8) exposes the immutable
+// `COMMHUB_NODE_ID` env into every node-launched process. This module
+// is the runtime piece that ties them together: a 30 s LRU cache around
+// "what does the server currently call me?" so 42 ALIAS references in
+// cli.ts can pick up the live value without each becoming its own diff.
+//
+// Design contract:
+//   - current() is synchronous, returns the last-known alias. Use it
+//     for log lines, file paths, and any hot path where waiting on a
+//     network round-trip is unacceptable. It is bound to the startup
+//     snapshot until the first refresh() lands.
+//   - refresh() is async, returns the alias, hitting the cache when
+//     warm and the server when stale. Use it for the 8 sender-side
+//     commhub calls where staleness causes the #146 family of bugs.
+//     A failed fetch keeps the cached value (graceful fallback) and
+//     bumps the cache timestamp so we don't hammer a sick hub.
+//   - set() force-installs the alias. Wire it to the `report_status`
+//     server response so a successful register / heartbeat is treated
+//     as canonical confirmation.
+//   - The fetchCanonicalAlias hook is injected so unit tests can stub
+//     it without spinning a server, and so cli.ts can choose its own
+//     transport (REST `/api/status` or MCP `get_session_status`).
+
+export type AliasDriftSource = "fetch" | "snapshot";
+
+export type CurrentAliasOptions = {
+  /** Startup snapshot — the alias the process resolved from
+   * --alias flag / env / config at boot. Used until the first refresh() lands. */
+  initialAlias: string;
+  /** Immutable node identity. If empty / null, refresh() short-circuits
+   * to the cached value because there is nothing to look up by. */
+  nodeId: string | null;
+  /** LRU cache TTL in ms. Default 30_000 (30 s). 0 disables caching. */
+  cacheTtlMs?: number;
+  /** Fetch hook — given a node_id, returns the server's canonical alias
+   * for that node, or null when the server doesn't know.
+   * MUST be allowed to throw; the resolver catches and falls back. */
+  fetchCanonicalAlias: (nodeId: string) => Promise<string | null>;
+  /** Drift hook — called when the resolved alias actually changes.
+   * Use for `log()` / `warn()` so operators see the transition in node logs. */
+  onDrift?: (oldAlias: string, newAlias: string, source: AliasDriftSource) => void;
+  /** Optional logger for the "fetch failed, keeping cache" warning. */
+  warn?: (msg: string) => void;
+};
+
+export class CurrentAliasResolver {
+  private cachedAlias: string;
+  private cachedAt: number;
+  private fetchInFlight: Promise<string> | null = null;
+  private readonly cacheTtlMs: number;
+
+  constructor(private readonly opts: CurrentAliasOptions) {
+    this.cachedAlias = opts.initialAlias;
+    this.cachedAt = 0; // 0 means "never fetched", so the first refresh() will hit the server
+    this.cacheTtlMs = opts.cacheTtlMs ?? 30_000;
+  }
+
+  /**
+   * Synchronous read — returns the last-known alias without any I/O.
+   * Cheap. Use for log lines, file paths, and any per-call hot path
+   * where waiting on a network round-trip is unacceptable.
+   */
+  current(): string {
+    return this.cachedAlias;
+  }
+
+  /**
+   * Async read — returns the alias, refreshing from the server when
+   * the cache is stale. NEVER throws: on fetch failure, keeps the
+   * cached value and bumps the timestamp so we don't hammer a sick
+   * hub. A `null` from the fetch hook is treated as "server doesn't
+   * know yet" and is also fall-back-to-cache.
+   *
+   * Concurrent callers during a fetch dedupe onto the same promise,
+   * so a burst of 8 sendReply calls just after expiry causes exactly
+   * one /api/status round-trip, not eight.
+   */
+  async refresh(nowMs: number = Date.now()): Promise<string> {
+    if (!this.opts.nodeId) return this.cachedAlias;
+    // cachedAt === 0 is the "never fetched" sentinel — treat as always
+    // stale so the first refresh() always hits the server even when
+    // called at logical time 0 (which would otherwise look fresh under
+    // a naive `nowMs - 0 < ttl` check).
+    if (this.cacheTtlMs > 0 && this.cachedAt > 0 && nowMs - this.cachedAt < this.cacheTtlMs) {
+      return this.cachedAlias;
+    }
+    if (this.fetchInFlight) return this.fetchInFlight;
+
+    const inflight = (async () => {
+      try {
+        const fetched = await this.opts.fetchCanonicalAlias(this.opts.nodeId!);
+        if (fetched && fetched.length > 0 && fetched !== this.cachedAlias) {
+          this.opts.onDrift?.(this.cachedAlias, fetched, "fetch");
+          this.cachedAlias = fetched;
+        }
+      } catch (e: any) {
+        this.opts.warn?.(`currentAlias: fetch failed (${e?.message ?? e}); keeping cached value "${this.cachedAlias}"`);
+      } finally {
+        // Always bump cachedAt so a sick hub doesn't get hammered.
+        this.cachedAt = nowMs;
+        this.fetchInFlight = null;
+      }
+      return this.cachedAlias;
+    })();
+
+    this.fetchInFlight = inflight;
+    return inflight;
+  }
+
+  /**
+   * Force-install the alias. Use this when a server response (e.g.
+   * report_status) authoritatively confirms the canonical alias for
+   * this node, so we don't have to wait for the next refresh() tick
+   * to pick it up.
+   *
+   * The drift hook fires with source = "snapshot" so log readers can
+   * distinguish proactive server-push updates from cache-driven
+   * refresh updates.
+   */
+  set(alias: string, nowMs: number = Date.now()): void {
+    if (!alias) return;
+    if (alias !== this.cachedAlias) {
+      this.opts.onDrift?.(this.cachedAlias, alias, "snapshot");
+      this.cachedAlias = alias;
+    }
+    this.cachedAt = nowMs;
+  }
+
+  // ── Visible for tests ──
+
+  get nodeId(): string | null {
+    return this.opts.nodeId;
+  }
+
+  /** Milliseconds since the last cache touch. Useful for assertions on TTL behaviour. */
+  ageMs(nowMs: number = Date.now()): number {
+    return this.cachedAt === 0 ? Number.POSITIVE_INFINITY : nowMs - this.cachedAt;
+  }
+
+  /** Whether the cache currently considers itself fresh. */
+  isFresh(nowMs: number = Date.now()): boolean {
+    return this.cachedAt !== 0 && nowMs - this.cachedAt < this.cacheTtlMs;
+  }
+}

--- a/agent-node/src/runtime/grok-build-acp/resume-hint.test.ts
+++ b/agent-node/src/runtime/grok-build-acp/resume-hint.test.ts
@@ -34,12 +34,12 @@ const row = (over: Partial<OutboundTaskRow>): OutboundTaskRow => ({
 
 describe("fetchUnresolvedOutbound", () => {
   test("returns empty array when the hub has no outbound rows for this sender", async () => {
-    const result = await fetchUnresolvedOutbound("self", async () => ({ tasks: [] }));
+    const result = await fetchUnresolvedOutbound({ alias: "self" }, async () => ({ tasks: [] }));
     expect(result).toEqual([]);
   });
 
   test("filters to only delivered/started status", async () => {
-    const result = await fetchUnresolvedOutbound("self", async () => ({
+    const result = await fetchUnresolvedOutbound({ alias: "self" }, async () => ({
       tasks: [
         row({ task_id: "tsk_a", status: "delivered" }),
         row({ task_id: "tsk_b", status: "started" }),
@@ -55,33 +55,75 @@ describe("fetchUnresolvedOutbound", () => {
     const tasks = Array.from({ length: 25 }, (_, i) =>
       row({ task_id: `tsk_${i.toString().padStart(2, "0")}`, status: "delivered" }),
     );
-    const result = await fetchUnresolvedOutbound("self", async () => ({ tasks }), { topN: 5 });
+    const result = await fetchUnresolvedOutbound({ alias: "self" }, async () => ({ tasks }), { topN: 5 });
     expect(result).toHaveLength(5);
     expect(result.map((r) => r.task_id)).toEqual(["tsk_00", "tsk_01", "tsk_02", "tsk_03", "tsk_04"]);
   });
 
-  test("forwards the sender alias and a sane limit to the listTasks hook", async () => {
+  test("forwards the sender alias and a sane limit to the listTasks hook (no node_id fallback path)", async () => {
     let seen: any = null;
-    await fetchUnresolvedOutbound("通信SDK马", async (params) => {
+    await fetchUnresolvedOutbound({ alias: "通信SDK马" }, async (params) => {
       seen = params;
       return { tasks: [] };
     });
     expect(seen.from_name).toBe("通信SDK马");
+    expect(seen.from_node_id).toBeUndefined(); // alias-only path
     expect(seen.limit).toBeGreaterThan(0);
     expect(seen.limit).toBeLessThanOrEqual(100);
   });
 
+  test("#146 PR-4 — prefers from_node_id when nodeId is available, never sends both", async () => {
+    let seen: any = null;
+    await fetchUnresolvedOutbound(
+      { nodeId: "node-immutable-x", alias: "current-alias" },
+      async (params) => {
+        seen = params;
+        return { tasks: [] };
+      },
+    );
+    expect(seen.from_node_id).toBe("node-immutable-x");
+    // We intentionally DO NOT send from_name when from_node_id is set —
+    // sending both would AND-filter on the server side, missing
+    // pre-rename rows whose from_name was the old alias.
+    expect(seen.from_name).toBeUndefined();
+    expect(seen.limit).toBeGreaterThan(0);
+  });
+
+  test("#146 PR-4 — empty / null nodeId falls back to from_name path", async () => {
+    let seen: any = null;
+    await fetchUnresolvedOutbound(
+      { nodeId: "", alias: "self" },
+      async (params) => {
+        seen = params;
+        return { tasks: [] };
+      },
+    );
+    expect(seen.from_node_id).toBeUndefined();
+    expect(seen.from_name).toBe("self");
+
+    seen = null;
+    await fetchUnresolvedOutbound(
+      { nodeId: null, alias: "self" },
+      async (params) => {
+        seen = params;
+        return { tasks: [] };
+      },
+    );
+    expect(seen.from_node_id).toBeUndefined();
+    expect(seen.from_name).toBe("self");
+  });
+
   test("graceful fallback when list_tasks throws — returns empty, does not propagate", async () => {
-    const result = await fetchUnresolvedOutbound("self", async () => {
+    const result = await fetchUnresolvedOutbound({ alias: "self" }, async () => {
       throw new Error("hub unreachable, ECONNREFUSED");
     });
     expect(result).toEqual([]);
   });
 
   test("graceful fallback for malformed payloads — non-array tasks", async () => {
-    const result1 = await fetchUnresolvedOutbound("self", async () => ({ tasks: "not an array" as any }));
-    const result2 = await fetchUnresolvedOutbound("self", async () => null);
-    const result3 = await fetchUnresolvedOutbound("self", async () => undefined);
+    const result1 = await fetchUnresolvedOutbound({ alias: "self" }, async () => ({ tasks: "not an array" as any }));
+    const result2 = await fetchUnresolvedOutbound({ alias: "self" }, async () => null);
+    const result3 = await fetchUnresolvedOutbound({ alias: "self" }, async () => undefined);
     expect(result1).toEqual([]);
     expect(result2).toEqual([]);
     expect(result3).toEqual([]);
@@ -89,7 +131,7 @@ describe("fetchUnresolvedOutbound", () => {
 
   test("clamps absurd opts: topN > 50 is capped, limit > 100 is capped", async () => {
     let seen: any = null;
-    await fetchUnresolvedOutbound("self", async (p) => {
+    await fetchUnresolvedOutbound({ alias: "self" }, async (p: any) => {
       seen = p;
       return { tasks: [] };
     }, { topN: 9999, limit: 9999 });

--- a/agent-node/src/runtime/grok-build-acp/resume-hint.test.ts
+++ b/agent-node/src/runtime/grok-build-acp/resume-hint.test.ts
@@ -23,12 +23,16 @@ import {
   type OutboundTaskRow,
 } from "./resume-hint";
 
+// Default factory rows ARE ours so the client-side identity filter
+// (added in PR-4 二审) lets them through; tests that exercise the
+// filter override `from_node_id` / `from_name` explicitly.
 const row = (over: Partial<OutboundTaskRow>): OutboundTaskRow => ({
   task_id: "tsk_default00000000",
   to_name: "alice",
   content: "default content",
   status: "delivered",
   created_at: "2026-06-10 09:00:00",
+  from_name: "self",
   ...over,
 });
 
@@ -72,7 +76,7 @@ describe("fetchUnresolvedOutbound", () => {
     expect(seen.limit).toBeLessThanOrEqual(100);
   });
 
-  test("#146 PR-4 — prefers from_node_id when nodeId is available, never sends both", async () => {
+  test("#146 PR-4 二审 — sends from_node_id ONLY when probe confirmed server supports it", async () => {
     let seen: any = null;
     await fetchUnresolvedOutbound(
       { nodeId: "node-immutable-x", alias: "current-alias" },
@@ -80,6 +84,7 @@ describe("fetchUnresolvedOutbound", () => {
         seen = params;
         return { tasks: [] };
       },
+      { serverSupportsFromNodeId: true },
     );
     expect(seen.from_node_id).toBe("node-immutable-x");
     // We intentionally DO NOT send from_name when from_node_id is set —
@@ -87,6 +92,38 @@ describe("fetchUnresolvedOutbound", () => {
     // pre-rename rows whose from_name was the old alias.
     expect(seen.from_name).toBeUndefined();
     expect(seen.limit).toBeGreaterThan(0);
+  });
+
+  test("#146 PR-4 二审 — without probe confirmation, never sends from_node_id (old-server safety)", async () => {
+    let seen: any = null;
+    // Same identity tuple, but no `serverSupportsFromNodeId: true` opt.
+    // A pre-PR-1 commhub silently ignores unknown query params and
+    // returns the full user-scoped tasks list, so sending from_node_id
+    // would let foreign rows into the resume hint. Default to the
+    // safe legacy alias path.
+    await fetchUnresolvedOutbound(
+      { nodeId: "node-x", alias: "current-alias" },
+      async (params) => {
+        seen = params;
+        return { tasks: [] };
+      },
+    );
+    expect(seen.from_node_id).toBeUndefined();
+    expect(seen.from_name).toBe("current-alias");
+  });
+
+  test("#146 PR-4 二审 — when probe explicitly returned false, falls back even with node_id available", async () => {
+    let seen: any = null;
+    await fetchUnresolvedOutbound(
+      { nodeId: "node-x", alias: "current-alias" },
+      async (params) => {
+        seen = params;
+        return { tasks: [] };
+      },
+      { serverSupportsFromNodeId: false },
+    );
+    expect(seen.from_node_id).toBeUndefined();
+    expect(seen.from_name).toBe("current-alias");
   });
 
   test("#146 PR-4 — empty / null nodeId falls back to from_name path", async () => {
@@ -136,6 +173,90 @@ describe("fetchUnresolvedOutbound", () => {
       return { tasks: [] };
     }, { topN: 9999, limit: 9999 });
     expect(seen.limit).toBe(100);
+  });
+
+  // ── #146 PR-4 二审 — client-side identity filter (defence in depth) ──
+  //
+  // Even with the capability probe in place, a buggy server / a future
+  // schema change / a stale build could return rows whose sender is
+  // NOT us. The resume hint MUST filter those out client-side or the
+  // LLM context gets polluted with foreign outbound traffic (which
+  // would then trigger the #212 dedup against the wrong target, etc.).
+
+  test("二审 — drops rows whose from_node_id does not match ours (server bug defence)", async () => {
+    const result = await fetchUnresolvedOutbound(
+      { nodeId: "ours-x", alias: "our-alias" },
+      async () => ({
+        tasks: [
+          row({ task_id: "tsk_ours", from_node_id: "ours-x", from_name: "our-alias", status: "delivered" }),
+          row({ task_id: "tsk_other", from_node_id: "someone-elses-node", from_name: "other-alias", status: "delivered" }),
+          row({ task_id: "tsk_third", from_node_id: "third-node", from_name: "third", status: "delivered" }),
+        ],
+      }),
+      { serverSupportsFromNodeId: true },
+    );
+    expect(result.map((r) => r.task_id)).toEqual(["tsk_ours"]);
+  });
+
+  test("二审 — when row has no from_node_id, falls back to from_name match", async () => {
+    const result = await fetchUnresolvedOutbound(
+      { nodeId: "ours-x", alias: "our-alias" },
+      async () => ({
+        tasks: [
+          row({ task_id: "tsk_ours_oldserver", from_name: "our-alias", status: "delivered" }),
+          row({ task_id: "tsk_foreign_oldserver", from_name: "other-alias", status: "delivered" }),
+        ],
+      }),
+      { serverSupportsFromNodeId: false },
+    );
+    expect(result.map((r) => r.task_id)).toEqual(["tsk_ours_oldserver"]);
+  });
+
+  test("二审 — drops rows with NEITHER from_node_id nor from_name (conservative)", async () => {
+    const result = await fetchUnresolvedOutbound(
+      { nodeId: "ours-x", alias: "our-alias" },
+      async () => ({
+        tasks: [
+          // Both identifiers missing — can't prove ownership, drop.
+          row({ task_id: "tsk_unidentified", from_node_id: undefined as any, from_name: undefined as any, status: "delivered" }),
+          // Just ours, kept.
+          row({ task_id: "tsk_ours", from_node_id: "ours-x", from_name: "our-alias", status: "delivered" }),
+        ],
+      }),
+      { serverSupportsFromNodeId: true },
+    );
+    expect(result.map((r) => r.task_id)).toEqual(["tsk_ours"]);
+  });
+
+  test("二审 — prefers from_node_id over from_name when both present (handles rename correctly)", async () => {
+    // After rename: from_node_id is still ours-x, from_name is the
+    // OLD alias (server hasn't backfilled or this row predates
+    // rename). The row IS ours.
+    const result = await fetchUnresolvedOutbound(
+      { nodeId: "ours-x", alias: "new-alias" },
+      async () => ({
+        tasks: [
+          row({ task_id: "tsk_prerename_ours", from_node_id: "ours-x", from_name: "old-alias", status: "delivered" }),
+        ],
+      }),
+      { serverSupportsFromNodeId: true },
+    );
+    expect(result.map((r) => r.task_id)).toEqual(["tsk_prerename_ours"]);
+  });
+
+  test("二审 — when WE have no nodeId, identity check uses from_name only", async () => {
+    // Pre-PR-3 environment: COMMHUB_NODE_ID env not set, so our nodeId
+    // is empty. We can only assert identity by alias matching.
+    const result = await fetchUnresolvedOutbound(
+      { nodeId: null, alias: "lonely-alias" },
+      async () => ({
+        tasks: [
+          row({ task_id: "tsk_ours", from_name: "lonely-alias", status: "delivered" }),
+          row({ task_id: "tsk_other", from_name: "someone", status: "delivered" }),
+        ],
+      }),
+    );
+    expect(result.map((r) => r.task_id)).toEqual(["tsk_ours"]);
   });
 });
 

--- a/agent-node/src/runtime/grok-build-acp/resume-hint.ts
+++ b/agent-node/src/runtime/grok-build-acp/resume-hint.ts
@@ -29,6 +29,15 @@ export type OutboundTaskRow = {
   content: string;
   status?: string;
   created_at?: string;
+  /** #146 PR-4 — populated by PR-1 servers (commit 2dc166c, ≥ 0.8.6-preview.0).
+   * Older servers omit this field. The client-side filter prefers this
+   * over `from_name` when both are available so a renamed node still
+   * recognises its own pre-rename outbound rows. */
+  from_node_id?: string;
+  /** Pre-existing field. Used by the client-side filter when
+   * `from_node_id` is absent (older server) and as a tertiary fallback
+   * elsewhere. */
+  from_name?: string;
 };
 
 export type ListTasksHook = (params: {
@@ -54,6 +63,20 @@ export type FetchOptions = {
   topN?: number;
   /** Max rows to fetch from `list_tasks` before client-side filter. */
   limit?: number;
+  /**
+   * #146 PR-4 二审 — capability gate for the `from_node_id` filter.
+   * When `true`, send `from_node_id` (PR-1 / commit 2dc166c on the
+   * server, server version ≥ 0.8.6-preview.0). When `false` or
+   * `undefined`, fall back to `from_name` to avoid the old-server
+   * gotcha where an unknown query param is silently ignored and the
+   * tasks list comes back unfiltered, polluting the hint with foreign
+   * sender rows.
+   *
+   * Regardless of this flag, every returned row is double-checked
+   * client-side against the caller's identity — defence in depth
+   * against a server bug or a future schema change.
+   */
+  serverSupportsFromNodeId?: boolean;
 };
 
 /**
@@ -72,16 +95,48 @@ export async function fetchUnresolvedOutbound(
   const limit = Math.max(1, Math.min(100, opts.limit ?? 100));
   const topN = Math.max(1, Math.min(50, opts.topN ?? 10));
   try {
-    // #146 PR-4 — prefer querying by from_node_id (immutable). If the
-    // node has no node_id yet (e.g. first boot before PR-3 propagation),
-    // fall back to the alias query. We never send both — sending both
-    // would AND-filter on the server side, missing pre-rename rows
-    // whose from_name is the old alias.
-    const params = selfIdentity.nodeId
-      ? { from_node_id: selfIdentity.nodeId, limit }
+    // #146 PR-4 二审 — server-version-gated parameter selection.
+    //   * Use `from_node_id` ONLY when the server explicitly advertises
+    //     support for it (capability probe at boot, see cli.ts /health
+    //     version check). Without the probe, the param flows through
+    //     to a pre-PR-1 server which silently ignores unknown query
+    //     params and returns ALL of this user's outbound tasks — the
+    //     resume hint would then pollute the LLM context with other
+    //     nodes' outbound traffic.
+    //   * On the alias path we still rely on `from_name`. We never
+    //     send both filters together — that would AND-filter
+    //     server-side, missing pre-rename rows whose from_name is the
+    //     old alias.
+    const canUseNodeId =
+      opts.serverSupportsFromNodeId === true && !!selfIdentity.nodeId;
+    const params = canUseNodeId
+      ? { from_node_id: selfIdentity.nodeId!, limit }
       : { from_name: selfIdentity.alias, limit };
     const resp = await listTasks(params);
     const tasks = Array.isArray(resp?.tasks) ? resp!.tasks! : [];
+
+    // Client-side filter — defense in depth (per 通信牛 二审 amend).
+    //
+    // Even when we sent `from_node_id`, a server bug, a misconfigured
+    // schema cache, or a stale build might return unrelated rows. So
+    // we re-check every row against our own identity:
+    //   - If the server populated `from_node_id`, demand it match ours.
+    //   - Otherwise (older server), demand `from_name` match our
+    //     current alias (the same string we'd be sending anyway).
+    // Anything that fails this check is dropped LOUDLY — but we
+    // can't loudly warn from a pure module, so the caller's wrapper
+    // (cli.ts processWithGrok onWarn) catches it through the discard
+    // count.
+    const matchesIdentity = (row: OutboundTaskRow): boolean => {
+      const rowNode = typeof row.from_node_id === "string" ? row.from_node_id : "";
+      const rowAlias = typeof row.from_name === "string" ? row.from_name : "";
+      if (rowNode && selfIdentity.nodeId) return rowNode === selfIdentity.nodeId;
+      if (rowAlias) return rowAlias === selfIdentity.alias;
+      // Row has neither a populated from_node_id NOR from_name — be
+      // conservative and DROP it, we can't prove it's ours.
+      return false;
+    };
+
     return tasks
       .filter(
         (t): t is OutboundTaskRow =>
@@ -90,6 +145,7 @@ export async function fetchUnresolvedOutbound(
           typeof t.to_name === "string" &&
           (t.status === "delivered" || t.status === "started"),
       )
+      .filter(matchesIdentity)
       .slice(0, topN);
   } catch {
     return [];

--- a/agent-node/src/runtime/grok-build-acp/resume-hint.ts
+++ b/agent-node/src/runtime/grok-build-acp/resume-hint.ts
@@ -32,7 +32,14 @@ export type OutboundTaskRow = {
 };
 
 export type ListTasksHook = (params: {
-  from_name: string;
+  // #146 PR-4 — prefer from_node_id (immutable) so a rename of this node
+  // doesn't make the resume hint miss old-alias-period dispatches. The
+  // commhub-server `list_tasks` MCP tool accepts both filters since PR #224
+  // (2dc166c); for callers running against an older server that only
+  // knows `from_name`, we keep `from_name` in the param shape so the
+  // request falls back gracefully when from_node_id is absent.
+  from_node_id?: string;
+  from_name?: string;
   limit: number;
 }) => Promise<{ tasks?: OutboundTaskRow[] } | null | undefined>;
 
@@ -58,14 +65,22 @@ export type FetchOptions = {
  * run normally.
  */
 export async function fetchUnresolvedOutbound(
-  selfAlias: string,
+  selfIdentity: { nodeId?: string | null; alias: string },
   listTasks: ListTasksHook,
   opts: FetchOptions = {},
 ): Promise<OutboundTaskRow[]> {
   const limit = Math.max(1, Math.min(100, opts.limit ?? 100));
   const topN = Math.max(1, Math.min(50, opts.topN ?? 10));
   try {
-    const resp = await listTasks({ from_name: selfAlias, limit });
+    // #146 PR-4 — prefer querying by from_node_id (immutable). If the
+    // node has no node_id yet (e.g. first boot before PR-3 propagation),
+    // fall back to the alias query. We never send both — sending both
+    // would AND-filter on the server side, missing pre-rename rows
+    // whose from_name is the old alias.
+    const params = selfIdentity.nodeId
+      ? { from_node_id: selfIdentity.nodeId, limit }
+      : { from_name: selfIdentity.alias, limit };
+    const resp = await listTasks(params);
     const tasks = Array.isArray(resp?.tasks) ? resp!.tasks! : [];
     return tasks
       .filter(


### PR DESCRIPTION
## Author
**Agent**: 通信SDK马 (PR-4 of the rename family fix — per #146 verdict comment [`4677392682`](https://github.com/sleep2agi/agent-network/issues/146#issuecomment-4677392682))
**Reviewer**: 通信牛 (mutual reviewer pair; I gated PR-1+2 #224 → 2dc166c, 通信牛 gates this one)

## Summary

Replace the frozen `const ALIAS` in `agent-node/src/cli.ts` with a 30 s LRU resolver that asks commhub for the canonical alias bound to this node's immutable `node_id`. Every sender-side commhub call (`register` / `reportStatus` / `sendReply` / `getInbox` / `ackMessage` / `commhub_send_task` MCP factory closure / #213 `fetchUnresolvedOutbound`) now picks up the live alias automatically, so a rename committed on the server propagates to outbound traffic within one cache window instead of needing a node restart.

Closes the runtime side of the #146 rename-family unifying-fix. Server PR-1+2 (`2dc166c`) and CLI PR-3 (`e0aa4d8`) are already on `main`.

## Diff at a glance

| File | Δ |
|---|---|
| `agent-node/src/runtime/current-alias.ts` | **NEW** (~150 LOC) — `CurrentAliasResolver` with `current()` / `refresh()` / `set()` |
| `agent-node/src/runtime/current-alias.test.ts` | **NEW** (15 cases) |
| `agent-node/src/runtime/grok-build-acp/resume-hint.ts` | sig changes from `selfAlias: string` → `{ nodeId, alias }`, prefers `from_node_id` query |
| `agent-node/src/runtime/grok-build-acp/resume-hint.test.ts` | migrated + 2 new cases for `from_node_id` path |
| `agent-node/src/commhub-mcp.ts` | `createCommhubSdkMcpServer` accepts `string \| (() => string)` |
| `agent-node/src/cli.ts` | resolver instance + sender-side call sites updated + `NODE_ID` reads `COMMHUB_NODE_ID` env first |

## Tests

```
agent-node bun test src/   →  157 pass / 0 fail
                              (was 140 + 15 new current-alias + 2 new resume-hint)
```

Public hub URLs in code samples / comments use `127.0.0.1:9200` (local dev) or `<hub-domain>` placeholder per the new safety constraint (Vincent tg 752, playbook §7).

## Design notes

- **`cachedAt = 0` sentinel** for "never fetched" so the first `refresh()` actually hits the server even when called at logical time 0.
- **Concurrent-fetch dedup** via `fetchInFlight` promise so a burst of 8 sender-side calls just past expiry causes exactly one round-trip not eight.
- **Graceful fetch failure** — `fetchCanonicalAlias` throwing keeps the cached value, emits a `warn` line, and **bumps the timestamp** so we don't hammer a sick hub on every subsequent call. Retry happens after the next TTL expires.
- **`onDrift` hook** logs `[alias-drift] OLD → NEW (source: fetch|snapshot)` so operators see the transition in node logs.
- **Frozen `ALIAS` const stays** for log lines (continuity across restart-traces) and file paths (which don't track rename — bound at create-time, not server-rename-time). Only routing-key uses migrate to the resolver.

## Boundary with PR-1+2 + PR-3 (already on main)

- **PR-1+2 (`2dc166c`)**: tasks.from_node_id column + `list_tasks` MCP tool `from_node_id` param + send_message canonical resolution + `rename-committed` eventBus. Without these the from_node_id query this PR issues would silently return empty.
- **PR-3 (`e0aa4d8`)**: `COMMHUB_NODE_ID` env propagation from launcher into every node-launched process. Without this, NODE_ID source would be limited to the node's `config.json` which can go stale.

## Backward compatibility

Behaviour degrades gracefully one layer at a time:
- Older server lacks `from_node_id` filter → `list_tasks` ignores unknown param, returns all tasks, client-side filter still works
- Older node lacks `COMMHUB_NODE_ID` env → NODE_ID falls back to `fileConfig.node_id`
- Neither node_id source available → `fetchUnresolvedOutbound` falls back to the `from_name` path
- `createCommhubSdkMcpServer` still accepts a static string (legacy callers unaffected)

## Refs

- #146 verdict: https://github.com/sleep2agi/agent-network/issues/146#issuecomment-4677392682
- PR-1+2 merge: 2dc166c
- PR-3 merge: e0aa4d8
- Prior runtime fixes in same area: 5b61d1c (#168 reply reliability), d206fdd (#213 resume hint), 21b0aa2 (#214 dim 5 A6 startup log)
