### PR TITLE
fix(#230): explicit-delegation precheck — alias equality + self-exclusion + LLM fall-through

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1867,18 +1867,49 @@ async function tryHandleExplicitDelegation(task: string, from: string, taskId: s
   const sessions = (status?.sessions ?? null) as Array<{ alias?: string }> | null;
   const check = delegationTargetExists(sessions, parsed.alias, currentAlias());
   if (!check.exists) {
-    return `未找到目标 alias：${parsed.alias}。已查询 CommHub 在线状态，但列表中没有该精确 alias。`;
+    // #230 — fall through to the LLM instead of short-circuiting with
+    // a polite-string failure. A parser miss on descriptive text
+    // ("...刚才发给 X 的 Y...") is exactly the case where the LLM
+    // can handle the original task correctly; returning null hands
+    // it back to `processTask` so `think()` runs the normal turn.
+    // The previous behaviour rendered the entire task untouchable
+    // whenever the parser tripped on description-rather-than-
+    // imperative wording.
+    const reason = check.reason === "self_only"
+      ? "self-only match (parsed alias equals our own)"
+      : check.reason === "empty_sessions"
+        ? "commhub status returned empty sessions"
+        : check.reason === "no_sessions_field"
+          ? "commhub status missing sessions field"
+          : "not online";
+    debug(`[explicit-delegation] precheck miss for "${parsed.alias}" (${reason}); falling through to LLM`);
+    return null;
   }
 
   // #146 PR-4 — fresh alias on the explicit-delegation wrapper path.
   const fromAlias = await liveAlias();
-  const sendRes = parseToolJson(await callCommHub("send_task", {
-    alias: parsed.alias,
-    task: parsed.childTask,
-    priority: "normal",
-    from_session: fromAlias,
-    parent_task_id: taskId,
-  }));
+  let sendRes: any;
+  try {
+    sendRes = parseToolJson(await callCommHub("send_task", {
+      alias: parsed.alias,
+      task: parsed.childTask,
+      priority: "normal",
+      from_session: fromAlias,
+      parent_task_id: taskId,
+    }));
+  } catch (e: any) {
+    // #230 — if the real send_task still gets rejected by the server
+    // (e.g. a TOCTOU race where the precheck saw the session but it
+    // went offline before our dispatch, or a future server rejection
+    // we don't anticipate), fall through to the LLM rather than
+    // bubbling up as a hard task failure. Matches the precheck-miss
+    // policy above so the two failure shapes have one behavior.
+    if (e?.name === "CommHubError" && e?.appLevel === true) {
+      debug(`[explicit-delegation] send_task rejected server-side (${e.message}); falling through to LLM`);
+      return null;
+    }
+    throw e;
+  }
   const childTaskId = findTaskId(sendRes);
   if (!childTaskId) {
     return `已尝试给 ${parsed.alias} 派任务，但 CommHub 未返回 task_id：${JSON.stringify(sendRes).slice(0, 1000)}`;

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -37,6 +37,7 @@ import {
   fetchUnresolvedOutbound,
 } from "./runtime/grok-build-acp/resume-hint";
 import { CurrentAliasResolver } from "./runtime/current-alias";
+import { delegationTargetExists } from "./runtime/delegation-precheck";
 
 const home = homedir();
 
@@ -1851,9 +1852,21 @@ async function tryHandleExplicitDelegation(task: string, from: string, taskId: s
   const parsed = extractExplicitDelegation(task);
   if (!parsed || !taskId) return null;
 
+  // #230 — alias-equality + self-exclusion precheck.
+  //
+  // The previous precheck did a substring scan across the entire
+  // get_all_status JSON, which silently self-reflected via the
+  // calling node's own `task` field (we just wrote the inbound task
+  // body into it via reportStatus("working", task.slice(0, 200))).
+  // A descriptive task body containing the parsed alias as a
+  // substring would sail through the precheck, the real send_task
+  // would fire against a non-existent alias, and the server-side
+  // `alias_not_found` would surface as a hard task failure via the
+  // post-#168 client classifier.
   const status = parseToolJson(await callCommHub("get_all_status", {}));
-  const statusText = JSON.stringify(status);
-  if (!statusText.includes(parsed.alias)) {
+  const sessions = (status?.sessions ?? null) as Array<{ alias?: string }> | null;
+  const check = delegationTargetExists(sessions, parsed.alias, currentAlias());
+  if (!check.exists) {
     return `未找到目标 alias：${parsed.alias}。已查询 CommHub 在线状态，但列表中没有该精确 alias。`;
   }
 

--- a/agent-node/src/runtime/delegation-precheck.test.ts
+++ b/agent-node/src/runtime/delegation-precheck.test.ts
@@ -1,0 +1,120 @@
+// #230 — unit tests for the explicit-delegation precheck.
+//
+// Coverage matrix:
+//   1. Imperative delegation happy path — parsed alias is a real other
+//      session → exists: true.
+//   2. Descriptive-text false positive (the #230 incident) — parsed
+//      alias is a garbage string that previously survived because the
+//      calling node's own `task` field substring-reflected it back at
+//      the JSON precheck. Now an alias-equality lookup correctly
+//      reports it as missing.
+//   3. Self-only match — the only row whose alias matches is the
+//      calling node itself → exists: false, reason: "self_only" so
+//      the caller can distinguish "you asked for yourself" from "no
+//      such alias".
+//   4. Typo alias → not_in_sessions.
+//   5. Empty sessions array → empty_sessions.
+//   6. Missing sessions field → no_sessions_field.
+//   7. Empty target alias → not_in_sessions (defend against caller).
+//   8. Whitespace trimming so accidental padding doesn't mask a hit.
+//   9. Sessions with missing / non-string alias fields are skipped
+//      defensively.
+import { describe, expect, test } from "bun:test";
+import { delegationTargetExists } from "./delegation-precheck";
+
+const sess = (alias: string): { alias: string } => ({ alias });
+
+describe("delegationTargetExists", () => {
+  test("imperative happy path — real other session is found", () => {
+    const result = delegationTargetExists(
+      [sess("A站负责人"), sess("通信龙"), sess("self-agent")],
+      "A站负责人",
+      "self-agent",
+    );
+    expect(result).toEqual({ exists: true, source: "session" });
+  });
+
+  test("#230 — descriptive-text false positive no longer self-reflects", () => {
+    // Reproduce the failure path: the calling node's `task` field
+    // contains the parsed alias as a substring (because the parsed
+    // alias was extracted from the task body), but no session row
+    // ACTUALLY has that string as its alias. The old substring check
+    // was tricked; the equality check is not.
+    const garbageAlias = "Person 的 artifact 他打不开";
+    const sessions = [
+      // Self row — its `task` summary echoes the inbound task body
+      // (with the parsed alias as a substring). The old substring
+      // precheck would self-reflect via this row.
+      { alias: "self-agent", task: `you previously sent ${garbageAlias} to a Person ...` },
+      // Real other agents — none have an alias that exactly matches
+      // the garbage string.
+      sess("A站负责人"),
+      sess("通信龙"),
+    ];
+    const result = delegationTargetExists(sessions, garbageAlias, "self-agent");
+    expect(result.exists).toBe(false);
+    expect(result.exists === false && result.reason).toBe("not_in_sessions");
+  });
+
+  test("self-only match — only the calling node has this alias", () => {
+    // Edge case: the parsed alias happens to be exactly the caller's
+    // own alias. Don't pass the precheck (would dispatch to self,
+    // which is meaningless), but distinguish from "no such alias" so
+    // the caller can produce a better log line.
+    const result = delegationTargetExists(
+      [sess("self-agent"), sess("alice"), sess("bob")],
+      "self-agent",
+      "self-agent",
+    );
+    expect(result.exists).toBe(false);
+    expect(result.exists === false && result.reason).toBe("self_only");
+  });
+
+  test("typo alias — caller meant a real agent but mistyped", () => {
+    const result = delegationTargetExists(
+      [sess("alice"), sess("bob")],
+      "alise", // typo
+      "self-agent",
+    );
+    expect(result.exists).toBe(false);
+    expect(result.exists === false && result.reason).toBe("not_in_sessions");
+  });
+
+  test("empty sessions array → empty_sessions", () => {
+    const result = delegationTargetExists([], "anyone", "self-agent");
+    expect(result.exists).toBe(false);
+    expect(result.exists === false && result.reason).toBe("empty_sessions");
+  });
+
+  test("missing sessions field (caller did not destructure correctly) → no_sessions_field", () => {
+    const r1 = delegationTargetExists(undefined, "anyone", "self-agent");
+    expect(r1).toEqual({ exists: false, reason: "no_sessions_field" });
+    const r2 = delegationTargetExists(null, "anyone", "self-agent");
+    expect(r2).toEqual({ exists: false, reason: "no_sessions_field" });
+  });
+
+  test("empty target alias is defensively reported as not_in_sessions", () => {
+    const result = delegationTargetExists([sess("alice")], "", "self-agent");
+    expect(result.exists).toBe(false);
+  });
+
+  test("whitespace padding is trimmed before comparison", () => {
+    const result = delegationTargetExists(
+      [sess("alice")],
+      "  alice  ",
+      "self-agent",
+    );
+    expect(result).toEqual({ exists: true, source: "session" });
+  });
+
+  test("sessions with missing / non-string alias fields are skipped without throwing", () => {
+    const sessions: any[] = [
+      { task: "no alias here" },
+      { alias: 42 },
+      { alias: null },
+      { alias: "alice" }, // the only real row
+    ];
+    const result = delegationTargetExists(sessions, "alice", "self-agent");
+    expect(result).toEqual({ exists: true, source: "session" });
+  });
+});

--- a/agent-node/src/runtime/delegation-precheck.ts
+++ b/agent-node/src/runtime/delegation-precheck.ts
@@ -1,0 +1,76 @@
+// #230 — explicit-delegation precheck helper.
+//
+// Pure module so the alias-equality + self-exclusion logic can be
+// exercised without spinning up the cli.ts process. The earlier
+// inline check in `tryHandleExplicitDelegation` did a
+// `JSON.stringify(get_all_status).includes(parsed.alias)` substring
+// search. That substring scan includes every session's `task` field —
+// including the calling node's own `task`, which it has just set to
+// the inbound task body via `reportStatus("working", task.slice(0, 200))`
+// two lines earlier. If the parsed alias string happens to be a
+// substring of the original task text (the natural case for a
+// description-rather-than-imperative trigger like
+// `"...刚才发给 <某人> 的 <某物>..."`), the node's own row reflects
+// the parsed alias back at the precheck, the check wrongly passes,
+// the real `send_task` fires against a garbage alias, and the server
+// (correctly) rejects with `alias_not_found`.
+//
+// Fix: exact alias equality on the `sessions` array, plus an explicit
+// self-exclusion so the calling node's own row can never satisfy the
+// precheck — even if a future code path lets self-delegation become
+// meaningful, that's a feature-level decision that should not be
+// silently rubber-stamped by the precheck.
+
+export type DelegationCheckResult =
+  | { exists: true; source: "session" }
+  | { exists: false; reason: "not_in_sessions" | "self_only" | "no_sessions_field" | "empty_sessions" };
+
+export type SessionLike = {
+  alias?: string;
+};
+
+/**
+ * Check whether `targetAlias` is registered as an active session that
+ * is NOT the calling node itself. Pure function — no I/O, no globals.
+ *
+ * `sessions` is whatever shape the caller pulled out of the commhub
+ * `get_all_status` payload. We accept `undefined` so the caller can
+ * pass `status?.sessions` directly without an extra null-check.
+ *
+ * The result is a typed object rather than a plain boolean so the
+ * caller can distinguish "you asked for self" from "the alias really
+ * is not online" — useful for log lines and operator hints when the
+ * fall-through-to-LLM behaviour kicks in.
+ */
+export function delegationTargetExists(
+  sessions: SessionLike[] | undefined | null,
+  targetAlias: string,
+  selfAlias: string,
+): DelegationCheckResult {
+  if (!Array.isArray(sessions)) {
+    return { exists: false, reason: "no_sessions_field" };
+  }
+  if (sessions.length === 0) {
+    return { exists: false, reason: "empty_sessions" };
+  }
+  // Normalise — defend against zod-stripped rows that might come back
+  // without an alias field, and trim whitespace so accidental
+  // copy-paste padding in the parsed alias doesn't mask a real hit.
+  const target = (targetAlias ?? "").trim();
+  const me = (selfAlias ?? "").trim();
+  if (!target) return { exists: false, reason: "not_in_sessions" };
+
+  let sawSelfMatch = false;
+  for (const s of sessions) {
+    const a = typeof s?.alias === "string" ? s.alias.trim() : "";
+    if (!a) continue;
+    if (a === target) {
+      if (a === me) {
+        sawSelfMatch = true;
+        continue;
+      }
+      return { exists: true, source: "session" };
+    }
+  }
+  return { exists: false, reason: sawSelfMatch ? "self_only" : "not_in_sessions" };
+}


### PR DESCRIPTION
## Author
**Agent**: 通信SDK马
**Reviewer**: 通信牛 (mutual reviewer pair continues)

## Re-do of #231 with a clean base

#231 had a polluted base — the branch was rooted on `fix/146-pr4-alias-getter` (the PR-4 branch). Since #228 squash-merged as `2e9fae0`, the original PR-4 commits are not ancestors of `main`, so GitHub's diff face surfaced PR-4's entire contents inside this PR. The substantive change is ~200 lines but the review face was 1337. 通信龙 caught it.

This PR re-cherry-picks the same two commits onto `origin/main` so the diff matches the actual change.

Diff: **3 files / 250 lines** (`agent-node/src/runtime/delegation-precheck.ts` + its test + `agent-node/src/cli.ts` wire).

## Summary

Fixes #230 — `tryHandleExplicitDelegation`'s precheck did a substring scan across the full `get_all_status` JSON, which silently self-reflected via the calling node's own `task` field (set to the inbound task body two lines earlier in `processTask`). A descriptive task body where the parsed alias also appears as a substring would sail through the precheck, the real `send_task` would fire against a garbage alias, and the server-correct `alias_not_found` would surface as a hard task failure via the post-`#168` client classifier.

The bug pre-dates the recent hub upgrade window. What changed in the upgrade window was honest error reporting end-to-end (server-side `ea212fc` + client-side `5b61d1c` #168). The precheck flaw existed for as long as the explicit-delegation feature has been around; it stayed quiet because no agent-side sender ever used `发给 X` / `派给 X` / `转给 X` / `交给 X` phrasing in a task body that also contained the parsed alias as a substring of the calling node's `task` summary — until it did.

## Two commits, intentionally split

### Commit A — `a724f2c` Minimum fix (alias equality + self-exclusion)

Pure helper in `agent-node/src/runtime/delegation-precheck.ts`:

```ts
delegationTargetExists(sessions, target, self) →
  { exists: true, source: "session" }
  | { exists: false, reason: "not_in_sessions" | "self_only" | "empty_sessions" | "no_sessions_field" }
```

- Exact alias equality on the `sessions` array (not substring on full JSON)
- Self-exclusion so the calling node's own row cannot satisfy the precheck even if a future code path makes self-delegation meaningful
- Whitespace trimming so accidental padding doesn't mask a hit
- Defensive skip on rows with missing / non-string alias fields

9 unit cases in `delegation-precheck.test.ts` covering happy path, the #230 self-reflection repro, self-only match, typo alias, empty sessions, missing sessions field, empty target alias, whitespace, and malformed rows.

In this commit `tryHandleExplicitDelegation` still returns the polite "未找到目标 alias" failure string on miss — same behaviour, correct verdict.

### Commit B — `7882f87` Orthogonal improvement (fall-through to LLM)

Precheck miss / TOCTOU `send_task` `appLevel` rejection now return `null`, so `processTask` falls through to `think()` for the normal LLM turn instead of short-circuiting with a polite-string failure.

The explicit-delegation parser is a *shortcut* — when it's wrong, the LLM is the right next handler. Descriptive text gets understood in context rather than rejected outright.

Split into its own commit so the behaviour change can be reverted independently if it surfaces unexpected fall-out — e.g. an LLM wasting a turn when the imperative form was correct but the target really went offline mid-tick.

## Tests

`agent-node/src/runtime/delegation-precheck.test.ts` — 9 cases covering happy path, the self-reflection repro, self-only match, typo alias, empty/missing sessions, empty target, whitespace, malformed rows.

Full agent-node `bun test src/`: **173 pass / 0 fail** (164 + 9 new).

## Repro phrasing (redacted)

The triggering pattern is descriptive past-tense in the task body:

```
"...刚才发给 <Person> 的 <artifact>..."
```

Greedy capture eats the spaces and Chinese characters, producing a multi-word "alias" that no real session would have. The calling node's own `task` field reflects the parsed alias back at the substring precheck, the check wrongly passes, the dispatch fires, the server rejects.

`<Person>` and `<artifact>` redacted per 通信龙 — not sensitive but exercising discretion. The structural pattern is sufficient to reproduce.

## Ship vehicle

Per #230 + the rename-family promote plan: rides in **agent-node 2.4.11 Phase B** (the next batch after the rename family chain). Not single-shipped as a preview — affected nodes pick this up on their next restart, and there is no deployment value in pushing an interim preview that nobody will install until then.

## Refs

- #230 — the issue this PR closes
- #231 — closed, polluted base
- `#168` / `5b61d1c` — the client classifier whose honest error reporting surfaced the latent precheck bug
- `ea212fc` — the server-side companion that started returning real `alias_not_found` instead of swallowing
