### PR TITLE
fix(#235): preflight bun/bunx + spawn error handler — anet hub start friendly missing-bun UX

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2919,6 +2919,27 @@ async function serverCommand() {
     } catch {}
 
     if (!serverAlreadyRunning) {
+      // #235 — Preflight bun/bunx presence BEFORE spawn. commhub-server is
+      // bun-only (Bun.serve + bun:sqlite, no Node equivalent), so a missing
+      // bunx in PATH is a hard prerequisite failure, not a recoverable
+      // runtime hiccup. Without this check, `spawn("bunx", ...)` emits an
+      // ENOENT 'error' event with no listener → Node crashes with an
+      // unhandled exception and a 10-line internal stack — user-hostile and
+      // misdirects troubleshooting toward Node internals instead of the
+      // actual missing dependency.
+      //
+      // The post-spawn 15s /health poll then a Bun-missing check (see
+      // ~30 lines down) cannot rescue this — spawn ENOENT throws before
+      // the poll loop ever runs.
+      if (!commandExists("bunx") && !commandExists("bun")) {
+        console.error(`\n  ❌ anet hub start requires the Bun runtime (commhub-server is bun-only — uses Bun.serve + bun:sqlite, no Node fallback).`);
+        console.error(`\n     Install Bun first:`);
+        console.error(`       curl -fsSL https://bun.sh/install | bash`);
+        console.error(`       # restart your shell so PATH picks up ~/.bun/bin`);
+        console.error(`\n     Then re-run: anet hub start`);
+        console.error(`\n     More info: https://bun.sh/install\n`);
+        process.exit(1);
+      }
       console.log(`  Starting CommHub Server on port ${port} (bind ${host})...`);
       const env: Record<string, string> = {
         ...process.env as any,
@@ -2930,6 +2951,21 @@ async function serverCommand() {
       const serverArgs = ["--bun", `@sleep2agi/commhub-server@${PINNED_SERVER_VERSION}`];
       if (devOpen) serverArgs.push("--dev-open");
       child = spawn("bunx", serverArgs, { env, stdio: "inherit" });
+      // #235 — Belt-and-braces: even with the preflight above, race
+      // conditions (PATH being modified mid-process, partial install) can
+      // still produce an async ENOENT 'error' event. Without this handler
+      // Node would crash with "Unhandled 'error' event" — defeat the
+      // preflight's UX promise. Log + exit gracefully.
+      child.on("error", (err: any) => {
+        if (err?.code === "ENOENT") {
+          console.error(`\n  ❌ Failed to spawn bunx — it disappeared from PATH after the preflight check.`);
+          console.error(`     This usually means Bun was uninstalled or PATH changed mid-process.`);
+          console.error(`     Try: which bunx && bunx --version`);
+        } else {
+          console.error(`\n  ❌ commhub-server spawn error: ${err?.message || err}`);
+        }
+        process.exit(1);
+      });
 
       // Wait for server with polling
       let ready = false;


### PR DESCRIPTION
## Author

Agent: **通信工程马**

## Summary

Closes #235. `anet hub start` on a no-bun machine used to crash with Node's "Unhandled 'error' event" + 10-line `node:internal/child_process` stack — user-hostile and misdirects toward Node internals instead of the actual missing dep.

## Fix

`agent-network/bin/cli.ts:~2932` (server spawn path):

1. **Preflight** before `spawn("bunx", ...)`: `commandExists("bunx") || commandExists("bun")` — missing → friendly multi-line message + `exit 1`. The existing post-poll Bun-missing handler at cli.ts:~2947 could never rescue this (`spawn` ENOENT throws synchronously, before the 15s `/health` poll loop even starts).
2. **`child.on("error", ...)` handler**: belt-and-braces for race conditions (PATH modified mid-process, partial install) that can still produce async ENOENT.
3. **Dashboard spawn** at cli.ts:~3228 already has an error handler — unchanged.

## Why no npx fallback

commhub-server uses `Bun.serve` (not Node `http`) + `bun:sqlite` (not `better-sqlite3`) + Bun-specific runtime APIs. Strict bun-only; preflight + docs link is the only correct path.

## Docker smoke

- `node:24-alpine` (no bun) — friendly preflight: `❌ anet hub start requires the Bun runtime ... Install Bun first: curl -fsSL https://bun.sh/install | bash ...` + exit 1. **No node stack.**
- `oven/bun:1` (bun present, +nodejs added) — preflight bypassed, hub actually starts (`admin bootstrapped`, `Server running on http://127.0.0.1:9200`) + exit 0. **No regression.**

## Out of scope

- Version bump: deferred to release-ops commit per [PR-3 review feedback](https://github.com/sleep2agi/agent-network/pull/225). v0.10.16 Phase B ship commit batches this fix + PR-3 + #229 + #223 into one agent-network bump.
- `--help` UX regression on same spawn path (#214 维度 7 F7-01) is solved by this preflight as a free side-effect.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `npm run build` (bun + obfuscator x3) 13.5s clean
- [x] Docker smoke node:24-alpine — friendly exit, no crash
- [x] Docker smoke oven/bun:1 — normal startup, no regression
- [ ] Vincent re-test on his machine after deploy (manual UAT, post-v0.10.16 Phase B promote)

## Refs

- #235 (this issue)
- #199 (related but different — PINNED 404, not PATH-missing)
- #214 维度 7 F7-01 (--help variant of same spawn — preflight side-solves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
