### PR TITLE
fix(#237 Sub-2): top-level fetch error classify — replace raw Node stack with friendly hub-down / DNS / network message

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -496,6 +496,47 @@ function commandExists(name: string): boolean {
   }
 }
 
+// #237 — Friendly classification of Node `fetch` errors. Node's fetch throws
+// a bare `TypeError: fetch failed` with the real cause hidden in `err.cause`
+// (e.g. `{ code: 'ECONNREFUSED', address: '127.0.0.1', port: 9200 }`). Without
+// classification the user sees only the Node stack and has no idea whether
+// the hub is down, the URL is wrong, the network is broken, or DNS is failing.
+function classifyFetchError(err: any, url?: string): string {
+  const cause = err?.cause;
+  const code = cause?.code || err?.code;
+  const address = cause?.address;
+  const port = cause?.port;
+  const target = url ? `URL: ${url}` : (address ? `${address}:${port}` : "");
+  const isLoopback = url?.includes("127.0.0.1") || url?.includes("localhost") || address === "127.0.0.1" || address === "::1";
+  if (code === "ECONNREFUSED") {
+    if (isLoopback) {
+      return `连不上本地 hub (${target}). 请先在另一终端: anet hub start  然后重试.`;
+    }
+    return `连不上 ${target}. 服务可能未启动 — 检查目标主机/端口, 或网络/代理.`;
+  }
+  if (code === "ENOTFOUND") {
+    return `DNS 解析失败 (${target}). 检查网络/DNS/代理设置.`;
+  }
+  if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT") {
+    return `连接超时 (${target}). 网络不稳定或目标无响应 — 检查防火墙/代理.`;
+  }
+  if (code === "ECONNRESET") {
+    return `连接被对端重置 (${target}). 服务可能在启动中或异常退出.`;
+  }
+  return `fetch 失败: ${err?.message || err}${target ? ` (${target})` : ""}`;
+}
+
+// #237 — Detect whether an arbitrary error came from a fetch call. Used by
+// the top-level FATAL handler so a bare TypeError surfaces as a friendly
+// classified message instead of an undecorated Node stack.
+function isFetchError(err: any): boolean {
+  if (!err) return false;
+  if (err instanceof TypeError && /fetch failed/i.test(err.message || "")) return true;
+  const cause = err?.cause;
+  if (cause && typeof cause === "object" && (cause.code || cause.syscall === "connect")) return true;
+  return false;
+}
+
 // #214 F7-02 / F7-10 / F7-11 — Levenshtein distance for did-you-mean
 // suggestions on typo'd commands. Pure function, ≤30 LOC, no deps.
 function levenshtein(a: string, b: string): number {
@@ -8721,6 +8762,19 @@ switch (command) {
 main().then(
   () => { if (process.env.ANET_INTERNAL_KEEP_PROCESS !== "1") process.exit(0); },
   (err: any) => {
+    // #237 — Friendly classification for unhandled fetch errors. Replaces
+    // the bare "FATAL: TypeError: fetch failed + 10-line Node stack" output
+    // Vincent hit on a clean machine where the hub was unreachable. Falls
+    // through to the legacy FATAL handler for everything else.
+    if (isFetchError(err)) {
+      console.error(`[anet] ❌ ${classifyFetchError(err)}`);
+      if (process.env.DEBUG || process.env.ANET_DEBUG) {
+        console.error(err?.stack || err);
+      } else {
+        console.error(`[anet]    (set ANET_DEBUG=1 to see the underlying Node stack)`);
+      }
+      process.exit(1);
+    }
     console.error("[anet] FATAL:", err?.stack || err?.message || err);
     process.exit(1);
   },


### PR DESCRIPTION
## Author

Agent: **通信工程马**

## Summary

Closes Sub-2 of #237 (anet 首次上手 robustness umbrella). Before this PR, any unwrapped `await fetch(...)` failure surfaced as a bare `[anet] FATAL: TypeError: fetch failed` + 10-line `node:internal/...` stack — what Vincent hit on a clean machine.

## Fix

`agent-network/bin/cli.ts`, +54 lines, 3 surgical edits:

1. **`classifyFetchError(err, url?)`** — pure function reading `err.cause` (where Node fetch stashes the real reason: `ECONNREFUSED`, `ENOTFOUND`, `ETIMEDOUT`, `ECONNRESET`) → Chinese user-facing message:
   - `ECONNREFUSED` + loopback → `连不上本地 hub. 请先在另一终端 anet hub start`
   - `ECONNREFUSED` + external → `连不上 <addr>. 服务可能未启动 — 检查目标主机/端口`
   - `ENOTFOUND` → `DNS 解析失败. 检查网络/DNS/代理`
   - `ETIMEDOUT` / `UND_ERR_CONNECT_TIMEOUT` → `连接超时. 网络不稳定`
   - `ECONNRESET` → `连接被对端重置. 服务可能在启动中或异常退出`
   - fallback → `fetch 失败: <message>`

2. **`isFetchError(err)`** — predicate matching Node's `TypeError: fetch failed` shape and any object with a connect-syscall cause.

3. Top-level `main().then().catch` swaps the bare FATAL log for the classified one when `isFetchError(err)`. Falls through to the legacy FATAL handler for everything else. Stack hidden by default (noise for users) but printed when `ANET_DEBUG=1` / `DEBUG=1` — operators / agents can still get it.

## Why top-level (not per-call wrapping)

97 fetch + spawn call sites in cli.ts. Most user-facing paths already have local try/catch with friendly hints (`cli.ts:2098-2102` is exemplary: `"Could not reach hub: <msg> / Hub: <url> — is it running? Try: anet hub start"`). This PR is the **defensive safety net** for any path that slips through. Per-call retrofitting of all 97 sites is deferred to Sub-3 of #237 if specific naked paths surface.

## Smoke

Docker `node:24-alpine` (no bun, no hub), various scenarios:

| Scenario | Result |
|---|---|
| `anet node create my-node --runtime claude-code-cli` w/ dead hub URL | Existing wrap fires `❌ Could not reach hub: fetch failed / Hub: ... — is it running?` — no Node stack ✓ |
| `anet whoami` w/ dead hub | `friendlyError()` (already in place): `Cannot connect to CommHub server. Is it running? / Start: anet hub start` ✓ |
| `anet network ls` w/ dead hub | Same friendly path ✓ |
| `anet license` w/ dead hub | `(hub unreachable — check 'anet doctor')` per #214 P2.8 ✓ |

The top-level handler is the backstop — anything not covered above gets the classified message instead of a Node stack.

## Out of scope

- Per-call retrofit of all 97 fetch/spawn sites → Sub-3 of #237, separate PR if needed
- Version bump deferred to release-ops commit (per PR-3 SOP)

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `npm run build` (bun + obfuscator x3) 13s clean
- [x] Docker smoke 4 scenarios all pass — existing wraps work, no Node stacks leaked
- [ ] Vincent re-test on his clean machine after v0.10.16 Phase B promote — confirm `anet create` no longer crashes raw

## Refs

- #237 (umbrella, this PR closes Sub-2)
- #235 (Sub-1, PR #236 bunx preflight — separate)
- #214 维度 7 F7-01 (related)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
