### PR TITLE
fix(#237 P0 #5+#6): codex-sdk lazy-fetch preflight + claude-code-cli dev-channels TTY warn

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -897,10 +897,16 @@ function assertStartCompatibility(runtime: RuntimeName) {
   const requiredAgentNode = parseSemver("1.0.0")!;
   const requiredCommhub = parseSemver("0.4.0")!;
 
+  // #237 P0 #5 — agent-node is intentionally lazy-fetched via npx by the
+  // spawn path in launchAgent (cli.ts:~2417 `npx -y @sleep2agi/agent-node@preview`).
+  // Previously this blocked startup when no global install existed, forcing a
+  // manual `anet upgrade` even though the npx fallback would have pulled and
+  // run the package fine. Treat "not installed globally" as OK and let the
+  // spawn path handle the fetch; only the semver check below fails on a stale
+  // GLOBAL install that would actively shadow / block the runtime.
   if (versions.agentNode.state !== "ok" || !versions.agentNode.version) {
-    console.error(`[anet] agent-node is not installed or cannot report a version.`);
-    console.error(`[anet] Run: anet upgrade`);
-    process.exit(1);
+    console.log(`[anet] note: agent-node not installed globally — will lazy-fetch via npx on spawn (this is normal for fresh installs).`);
+    return;  // skip the semver check; npx will fetch a current version
   }
 
   const agentNodeVersion = parseSemver(versions.agentNode.version);
@@ -2509,9 +2515,11 @@ async function launchAgent(id: string, forceNewSession = false) {
 
     const claudeArgs: string[] = [];
     if (profile.flags.dangerouslySkipPermissions) claudeArgs.push("--dangerously-skip-permissions");
+    let hasDevChannels = false;
     for (const ch of profile.channels) {
       if (ch.startsWith("server:")) {
         claudeArgs.push("--dangerously-load-development-channels", ch);
+        hasDevChannels = true;
       } else if (ch === "telegram") {
         claudeArgs.push("--channels", "plugin:telegram@claude-plugins-official");
       } else {
@@ -2519,6 +2527,22 @@ async function launchAgent(id: string, forceNewSession = false) {
       }
     }
     if (profile.flags.teammateMode) claudeArgs.push("--teammate-mode", profile.flags.teammateMode);
+
+    // #237 P0 #6 — Claude Code's `--dangerously-load-development-channels`
+    // pops an interactive confirm box ("I am using this for local
+    // development / Exit") that needs an Enter keystroke. In tmux/project
+    // batch paths anet auto-confirms via autoConfirmDevChannels() (uses
+    // capture-pane → send-keys). In a plain foreground `anet node start
+    // <alias>` from a non-TTY shell (ssh detached, scripted bootstrap,
+    // systemd unit before user attach), no one types Enter → node hangs
+    // offline indefinitely with no signal that it's waiting on the user.
+    // Friendly preflight: warn loud and suggest the escape hatch.
+    if (hasDevChannels && !process.stdin.isTTY) {
+      console.warn(`[anet] ⚠ claude-code-cli with --dangerously-load-development-channels needs an interactive TTY to confirm Claude Code's dev-channels prompt.`);
+      console.warn(`[anet]   This shell's stdin is not a TTY → the spawned claude process will hang on the confirm box and the node will stay offline.`);
+      console.warn(`[anet]   Fix: re-run with \`anet node start ${shellQuote(nodeId)} --tmux\` (anet auto-confirms in tmux mode via capture-pane).`);
+      console.warn(`[anet]   Or attach a TTY (interactive ssh) and run again, then hit Enter on the prompt.`);
+    }
 
     if (!profile.session) {
       profile.session = randomUUID();


### PR DESCRIPTION
## Author

Agent: **通信工程马**

## Summary

Closes Sub-tasks **#5 and #6** of [#237 umbrella](https://github.com/sleep2agi/agent-network/issues/237) per 通信龙's real-machine retro ([comment-4701482702](https://github.com/sleep2agi/agent-network/issues/237#issuecomment-4701482702)). Both are the same family as Sub-1 (#235 PR #236) and Sub-2 (PR #238): "可预期的环境缺失被裸 throw / 卡死撞穿", just in startCommand / launchAgent paths instead of hub-start / fetch paths.

## Fix #5 — codex-sdk lazy-fetch preflight

`agent-network/bin/cli.ts` `assertStartCompatibility`:

`assertStartCompatibility` failed hard with `Run: anet upgrade` when no GLOBAL agent-node existed, **even though `launchAgent` was designed to lazy-fetch via npx** (`npx -y @sleep2agi/agent-node@preview`, cli.ts:~2417). The assertion conflated "not installed globally" with "broken install" and shut off the lazy-fetch path users were meant to rely on by default.

→ When `versions.agentNode.state !== "ok"`, print a friendly note and `return` (skip the semver check; npx fetches a current version). The semver check still fires when a stale global install exists and would actively shadow the npx-fetched version.

Docker smoke (`node:24-alpine`, no global agent-node, codex-sdk node):
```
[anet] note: agent-node not installed globally — will lazy-fetch via npx on spawn (this is normal for fresh installs).
[anet] Token: ntok_fak...
[agent-node] Config: /work/.anet/nodes/c1/config.json
[10:41:55] [INFO ] [c1] 启动
[10:41:55] [INFO ] [c1]   alias:   c1 [from: --alias flag]
[10:41:55] [INFO ] [c1]   runtime: codex-sdk
```

Runtime now reaches the spawn path. (Token fails fake-validation but the assertion bottleneck is gone.)

## Fix #6 — claude-code-cli dev-channels TTY preflight

`claude --dangerously-load-development-channels server:commhub` pops an interactive confirm box that needs Enter. The batch / project-up paths auto-confirm via `autoConfirmDevChannels()` (tmux capture-pane → send-keys), but foreground `anet node start <alias>` from a non-TTY shell (ssh detached, scripted bootstrap, systemd unit) has no one to press the key — node hangs offline with no signal that it's waiting on the user.

→ In `launchAgent`'s claude-code-cli branch, after building `claudeArgs`, if any channel is `server:*` AND `!process.stdin.isTTY`, emit a 3-line warning **before** the spawn:

```
[anet] ⚠ claude-code-cli with --dangerously-load-development-channels needs an interactive TTY to confirm Claude Code's dev-channels prompt.
[anet]   This shell's stdin is not a TTY → the spawned claude process will hang on the confirm box and the node will stay offline.
[anet]   Fix: re-run with `anet node start 'c2' --tmux` (anet auto-confirms in tmux mode via capture-pane).
[anet]   Or attach a TTY (interactive ssh) and run again, then hit Enter on the prompt.
```

The escape hatch (`--tmux`) already exists and already auto-confirms via `autoConfirmDevChannels()` — this preflight just makes the right action discoverable from the failing context.

Docker smoke (`node:24-alpine`, claude-code-cli + `server:commhub`, no TTY): warning fires cleanly with the correct alias substituted.

## Out of scope

- True auto-answer for the dev-channels prompt WITHOUT tmux (would need expect-style stdin pipe or a Claude Code env-var; not surfaced in current docs). The warning + escape hatch is the elegant minimum that catches Vincent's specific failure (ssh + scripted bootstrap).
- Sub-tasks #3 (runtime default + Ctrl-C rollback), #4 (telegram wizard step), `anet doctor` — separate PRs per 通信龙's split.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `npm run build` (bun + obfuscator x3) 14s clean
- [x] Docker smoke node:24-alpine: P0 #5 codex-sdk reaches spawn (was: hard exit) ✓
- [x] Docker smoke node:24-alpine: P0 #6 dev-channels warning fires with correct --tmux hint ✓
- [ ] Vincent re-test on clean machine after v0.10.16 Phase B promote (manual UAT)

## Refs

- #237 (umbrella, this PR closes Sub-tasks #5 and #6)
- #235 / PR #236 (Sub-1, related)
- PR #238 (Sub-2, related)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
