### PR TITLE
fix(#240): contextual --help routing — restore anet hub --help (and node/project)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -3321,7 +3321,16 @@ async function serverCommand() {
     }
 
   } else {
-    console.log(`
+    printHubHelp();
+  }
+}
+
+// #240 — Extracted from serverCommand's else branch so the #215 universal
+// --help intercept can route `anet hub --help` here instead of bouncing to
+// global printHelp() (which hid stop/status entirely — looked like a
+// regression even though the routes were still wired).
+function printHubHelp() {
+  console.log(`
 anet hub <command>
 
   start [options]    Start CommHub Server (bootstraps admin account; login separately)
@@ -3348,7 +3357,6 @@ Example:
   anet hub start --port 8080         # Custom port
   anet hub config                    # Show config
 `);
-  }
 }
 
 // ── import ──
@@ -8596,10 +8604,27 @@ async function main() {
 // --help` SIGNS a real token, `anet run --help` STARTS a real SSE listener
 // on :9200, `anet hub start --help` STARTS the hub. Convention everywhere
 // else (cargo, git, npm, docker) is "see help, no side effect" — match it.
-// Per-subcommand inline help is polish (tracked in #214 F7-01 follow-ups);
-// here we hard-stop with global help, which is correct minimum.
+//
+// #240 — Original #215 always bounced to global printHelp(), which made
+// `anet hub --help` hide hub/stop/status (regression that read like the
+// routes had been removed even though they were still wired). Route to
+// per-subcommand help printer when one exists; fall back to global for the
+// rest (preserves #215 safety against side-effects in token/run/etc.).
 if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
-  printHelp();
+  switch (command) {
+    case "hub":
+    case "server":
+      printHubHelp();
+      break;
+    case "project":
+      printProjectUsage();
+      break;
+    case "node":
+      console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|migrate-token-to-envref> [name]`);
+      break;
+    default:
+      printHelp();
+  }
   process.exit(0);
 }
 switch (command) {


### PR DESCRIPTION
## Author

Agent: **通信工程马**

## Summary

Closes #240 — P0 regression where `anet hub --help` (and friends) bounced to global `printHelp()` after the #215 universal `--help` intercept (commit `ac96a27`) landed. The hub block listing **stop / status / dashboard / config** disappeared from `--help` output even though the **routes were never removed** (`sub === "stop"` at cli.ts:~3236, `sub === "status"` at ~3269 still work when called directly). Trust killer for any doc that referenced these commands.

## Root cause

`#215` intercept at top of `main()`:
```ts
if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
  printHelp();          // <-- always global
  process.exit(0);
}
```

`anet hub --help` matches (args[1] = `--help`), prints global help, exits — `serverCommand`'s else-branch (which prints the hub-specific block) never runs.

## Fix

1. Extract `serverCommand`'s else-branch into top-level `printHubHelp()` (identical content, no rewording).
2. Replace the `printHelp()` call in the #215 intercept with a `switch(command)` dispatcher:

```ts
case "hub" / "server"   → printHubHelp()
case "project"          → printProjectUsage()
case "node"             → one-line node usage (matches default branch)
default                 → printHelp()   // preserves #215 safety for token/run/etc.
```

The default branch is critical for safety — `anet token create --help` and `anet run --help` still hit `printHelp()` and exit 0, never reaching the body code that would otherwise sign a real token or start a real SSE listener (the entire reason #215 exists).

## Smoke

Docker `node:24-alpine`, install this PR's tarball:

| Command | Expect | Got |
|---|---|---|
| `anet hub --help` | hub block w/ start/stop/status/dashboard/config | ✓ |
| `anet hub -h` | same | ✓ |
| `anet hub start --help` | hub block (NOT "Starting CommHub Server...") | ✓ — #215 safety preserved |
| `anet node --help` | node usage line w/ restart visible | ✓ |
| `anet project --help` | project up/restart/down | ✓ |
| `anet token create --help` | global help, NO token signed | ✓ — #215 safety preserved |
| `anet --help` | top-level help | ✓ |

## Regression guard

Not adding a new test file in this PR. The natural home is the v0.10.16 release-gate Docker matrix (per 通信龙 PR #236/#238/#239 release-gate brief) — should assert that `anet hub --help` output contains the literal tokens `stop` and `status`. 测试马 to add to that matrix.

## Refs

- #240 (this P0)
- #215 / commit `ac96a27` (root cause — universal intercept)
- #214 维度 7 F7-01 (sibling — `anet hub start --help` triggering hub start, solved by #215 + this PR's contextual routing keeps it solved)

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `npm run build` (bun + obfuscator x3) 14s clean
- [x] Docker smoke node:24-alpine: 7 help-context cases all pass; #215 safety regression preserved
- [ ] 测试马 release-gate matrix: `anet hub --help | grep -q stop` + `grep -q status` assertions (v0.10.16 Phase B promote gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
