### PR TITLE
fix(#110 follow-up): align CLI to PR-2 server schema — read prep.code, widen regex

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -3748,11 +3748,27 @@ anet node rename <node-id|node-name> <new-node-name> [--force]
       // back to a local-only rename: the local config dir + alias rename
       // happens, and there's nothing on the server to coordinate yet.
       //
-      // Two error shapes are tolerated:
-      //   1. PR-2 (server-side) future contract: `error: "node_local_only"`
-      //   2. Current main: `error` string contains "not found in this network"
+      // Three error shapes are tolerated:
+      //   1. PR-2 (server-side, landed): `{ ok:false, code:"node_local_only",
+      //      error:"node 'X' has no server session in this network", suggested:"rename locally" }`
+      //      — `code` field carries the type; `error` is the human-readable msg.
+      //   2. Legacy `error` field containing the literal "node_local_only" string
+      //      (kept for any older server build that conflated the two fields).
+      //   3. Pre-PR-2 servers: `error` substring match on whatever wording the
+      //      server used ("has no server session" or "not found in this network").
+      //
+      // The original PR-3 (#225 / commit f28ffd9) only checked shapes 2+3 with
+      // a regex that didn't match server's actual wording — 测试马's PR-5
+      // Case 2 caught it: server returned the new shape (1), CLI fell through
+      // to throw, rename hard-failed for purely-created nodes (regressing the
+      // exact case #110 was meant to fix). Switch to checking `prep.code` as
+      // the primary signal (matches the server contract) and widen the regex
+      // fallback to include the server's actual "has no server session" phrase.
       const errStr = String(prep.error || "");
-      const isLocalOnly = prep.error === "node_local_only"
+      const isLocalOnly = prep.code === "node_local_only"
+        || prep.error === "node_local_only"
+        || /node_local_only/i.test(errStr)
+        || /has no server session/i.test(errStr)
         || /not found in this network/i.test(errStr)
         || /node .* not found/i.test(errStr);
       if (isLocalOnly) {


### PR DESCRIPTION
## Author

Agent: **通信工程马**

## Summary

测试马 PR-5 Case 2 caught a schema mismatch between PR-2 (server, landed) and PR-3 (my CLI in #225 / commit `f28ffd9`). `anet node rename node-c node-d --force` on a purely-created node — exactly the case #110 was meant to fix — still hard-rolled-back with rc=1 instead of doing the local-only rename.

## Root cause

Server PR-2 (`server/src/rename.ts:117-124`) ships:

```json
{
  "ok": false,
  "code": "node_local_only",
  "error": "node 'X' has no server session in this network",
  "suggested": "rename locally"
}
```

My PR-3 (this file, pre-fix) checked:

```ts
prep.error === "node_local_only"                  // wrong field — error is the message
|| /not found in this network/i.test(errStr)       // wrong wording
|| /node .* not found/i.test(errStr)               // generic
```

→ `isLocalOnly = false` → `throw` → PHASE 1 rollback → rc=1.

## Fix

Switch to `prep.code` as the primary signal (matches PR-2 contract), keep `prep.error` checks as belt-and-braces, widen the regex to include the server's actual wording:

```ts
isLocalOnly =
    prep.code === "node_local_only"            // PR-2 contract (primary)
 || prep.error === "node_local_only"           // legacy / older builds
 || /node_local_only/i.test(errStr)            // belt-and-braces
 || /has no server session/i.test(errStr)      // server's actual phrase
 || /not found in this network/i.test(errStr)  // pre-PR-2 wording
 || /node .* not found/i.test(errStr)          // generic fallback
```

## Smoke

Bundle marker verification (post `npm run build` w/ javascript-obfuscator):

| String | Count | Source |
|---|---|---|
| `node_local_only` | 2 | new `prep.code` check + regex literal |
| `has no server session` | 1 | new regex literal (matches server's actual phrase) |
| `not found in this network` | 1 | legacy regex retained |

Full integration verify deferred to 测试马 PR-5 Case 2 rerun (their harness has the live commhub-server + the create→rename sequence).

## Refs

- #110 (the RFC-010 §4.1 "created is recommended rename path" follow-up that this is supposed to honor)
- #146 PR-3 (#225 / commit `f28ffd9` — root cause)
- 测试马 PR-5 Case 2 (the regression detector)

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `npm run build` (bun + obfuscator x3) 14s clean
- [x] Bundle marker grep — all 4 schema strings present
- [ ] 测试马 PR-5 Case 2 rerun: `anet node create node-c` (no start) → `anet node rename node-c node-d --force` → expect rc=0, `.anet/nodes/node-d` exists, `.anet/nodes/node-c` gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
