### PR TITLE
fix(server): #247 accept utok_ for SSE subscribe with 4-gate auth-scoping

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -533,6 +533,8 @@ Bun.serve({
       const token = requestToken(req);
       const authCtx = resolveRequestAuth(req);
       const scopedNetId = authCtx?.networkId || url.searchParams.get("network_id");
+
+      // ── Path 1: legacy AUTH_TOKEN (master token) — unchanged ──
       if (!authCtx && isLegacyAuthToken(req)) {
         if (scopedNetId) {
           const session = db.get<any>(
@@ -543,17 +545,74 @@ Bun.serve({
         }
         return createSSEStream(sessionName, scopedNetId);
       }
-      if (!token?.startsWith("ntok_") || !authCtx || !scopedNetId) {
-        return withCors(req, Response.json({ ok: false, error: "network-scoped token required for SSE" }, { status: 403 }));
+
+      // ── Path 2: ntok_ (network-bound agent token) — pre-#247 behavior preserved ──
+      if (token?.startsWith("ntok_")) {
+        if (!authCtx || !scopedNetId) {
+          return withCors(req, Response.json({ ok: false, error: "network-scoped token required for SSE" }, { status: 403 }));
+        }
+        const role = getUserNetworkRole(authCtx.userId, scopedNetId);
+        if (!role) return withCors(req, Response.json({ ok: false, error: "not a member of this network" }, { status: 403 }));
+        const session = db.get<any>(
+          "SELECT 1 FROM sessions WHERE alias = ?1 AND network_id = ?2",
+          sessionName, scopedNetId
+        );
+        if (!session && authCtx.networkId !== scopedNetId) {
+          return withCors(req, Response.json({ ok: false, error: "session not in requested network" }, { status: 403 }));
+        }
+        return createSSEStream(sessionName, scopedNetId);
       }
-      const role = getUserNetworkRole(authCtx.userId, scopedNetId);
-      if (!role) return withCors(req, Response.json({ ok: false, error: "not a member of this network" }, { status: 403 }));
-      const session = db.get<any>(
+
+      // ── Path 3 (#247): utok_ (user token, dashboard SSE path) — 4 gates ──
+      //
+      // Pre-#247 the only V3 path required `ntok_` and rejected `utok_` outright,
+      // which locked the dashboard out of SSE (the dashboard proxy authenticates
+      // with the user's `utok_`). That broke real-time chat updates — replies
+      // were persisted but never live-pushed to the UI.
+      //
+      // Auth-scoping rules (all four must pass — see #247 design):
+      //   gate 1: token resolves to a valid user context (authCtx non-null)
+      //   gate 2: network scope is explicit — `utok_` has no implicit network,
+      //           so the caller must pass `?network_id=<id>`
+      //   gate 3: user is a member of that network (any role: owner / admin / member)
+      //   gate 4: channel-ownership — one of:
+      //           (a) sessionName === own username (the dashboard's default channel —
+      //               `send_reply` pushes to the original sender's alias which equals
+      //               the dashboard user's username; NO `sessions` row required for
+      //               this branch since the dashboard user is not a registered agent)
+      //           (b) sessionName is an existing agent alias in `scopedNetId`
+      //               (lets members monitor agents within their network)
+      //
+      // Security: rule 4(a) uses strict equality, so a `utok_` user cannot subscribe
+      // to another user's username channel (no cross-user eavesdrop). Rule 4(b) is
+      // scoped to `scopedNetId` + gate 3 membership, so cross-network eavesdrop is
+      // blocked too. There is intentionally NO org-admin bypass — even users with
+      // global `admin` role must be a member of the network they want to listen on.
+      if (!authCtx) {
+        return withCors(req, Response.json({ ok: false, error: "auth required" }, { status: 403 }));
+      }
+      if (!scopedNetId) {
+        return withCors(req, Response.json({
+          ok: false,
+          error: "network_id required (utok has no implicit network; pass ?network_id=<id>)"
+        }, { status: 403 }));
+      }
+      const utokRole = getUserNetworkRole(authCtx.userId, scopedNetId);
+      if (!utokRole) {
+        return withCors(req, Response.json({ ok: false, error: "not a member of this network" }, { status: 403 }));
+      }
+      if (sessionName === authCtx.username) {
+        return createSSEStream(sessionName, scopedNetId);
+      }
+      const utokSession = db.get<any>(
         "SELECT 1 FROM sessions WHERE alias = ?1 AND network_id = ?2",
         sessionName, scopedNetId
       );
-      if (!session && authCtx.networkId !== scopedNetId) {
-        return withCors(req, Response.json({ ok: false, error: "session not in requested network" }, { status: 403 }));
+      if (!utokSession) {
+        return withCors(req, Response.json({
+          ok: false,
+          error: "channel not allowed: must be your username or an existing agent in your network"
+        }, { status: 403 }));
       }
       return createSSEStream(sessionName, scopedNetId);
     }


### PR DESCRIPTION
## Author

Agent: 通信工程马

## Summary

Fixes #247 hub-side. Adds a third auth path to the `/events/<alias>` SSE handler so dashboard `utok_` callers can subscribe, with 4-gate auth-scoping (per the design approved in commhub conversation):

1. Token resolves to a valid user context (authCtx non-null)
2. Network scope is explicit — `utok_` has no implicit network binding, so caller must pass `?network_id=<id>`
3. User is a member of that network (any role: owner / admin / member)
4. Channel-ownership — either:
   - (a) `sessionName === own username` — the dashboard's default channel; `send_reply` pushes to the original sender's alias which equals the dashboard user's username. NO `sessions` row required for this branch.
   - (b) `sessionName` is an existing agent alias in `scopedNetId` — lets members monitor agents in their network.

Pre-#247 the V3 path was strict `ntok_`-only, which locked dashboards out → 403 → 502 → EventSource error → no live chat updates. The reply IS persisted (`tasks.result` + `inbox`) but never live-pushed.

## Security boundary

- **No cross-user eavesdrop**: rule 4(a) uses strict equality. A `utok_` user cannot subscribe to another user's username channel.
- **No cross-network eavesdrop**: rule 4(b) is scoped to `scopedNetId` + gate 3 membership.
- **No org-admin bypass**: even users with global `admin` role must be a member of the network they want to listen on.

## Backward compat

- Legacy `AUTH_TOKEN` path — unchanged.
- `ntok_` path — unchanged (cross-network bypass preserved).
- `pushEvent` — unchanged.
- Existing agent SSE subscriptions continue to work.

## Verification (Docker, node:24-alpine + patched server, 2 users + 2 networks + 1 session)

| # | scenario | expected | actual |
|---|---|---|---|
| C1 | `utok_alice` + `?network_id=NetX` + `/events/alice` (own username) | 200 SSE | ✅ 200 |
| C2 | `utok_alice` + `?network_id=NetX` + `/events/agent1` (own-network agent) | 200 SSE | ✅ 200 |
| C3 | `utok_alice` + `?network_id=NetX` + `/events/bob` (other user's username) | 403 | ✅ 403 |
| C4 | `utok_alice` + (no `network_id`) + `/events/alice` | 403 | ✅ 403 |
| C5 | `utok_alice` + `?network_id=NetY` (not member) + `/events/alice` | 403 | ✅ 403 |
| C6 | `utok_bob` + `?network_id=NetX` + `/events/agent1` (cross-network) | 403 | ✅ 403 |
| C7 | `ntok_` + `?network_id=NetX` + `/events/agent1` (backward compat) | 200 SSE | ✅ 200 |

7/7 pass. Server log confirms C1/C2/C7 actually opened SSE streams; C3-C6 silently 403'd at the right gate.

## Companion PR

Dashboard side: https://github.com/sleep2agi/agent-network-dashboard/pull/5 — must land together (hub change alone is insufficient because the dashboard proxy doesn't pass `?network_id`).

## Test plan checklist (for reviewers)

- [ ] Review auth-scoping logic against the security boundary above (especially rule 4(a) strict equality, rule 4(b) scopedNetId enforcement, no admin bypass).
- [ ] Confirm `ntok_` and legacy paths are byte-equivalent to pre-PR semantics (`git diff main -- server/src/index.ts`).
- [ ] Run `bun pm install && bun run src/index.ts --dev-open` locally; reproduce a 4-gate failure (e.g. omit `?network_id`).
