### PR TITLE
fix(server): #248 chat-panel history fetch — composite index + skip_stats opt-out

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -168,6 +168,15 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_tasks_from ON tasks(from_name);
   CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
   CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at);
+  -- #248 — composite index for the dashboard chat-panel history query
+  -- (/api/tasks?to_name=X&limit=30 ORDER BY created_at DESC). Without it
+  -- SQLite walks every row for the alias via idx_tasks_to and sorts in
+  -- memory; on an active node with thousands of tasks that's O(N log N)
+  -- per panel open. The composite ordered DESC lets the planner stop
+  -- after LIMIT rows — O(log N + LIMIT). Idempotent migration; safe to
+  -- ship — existing single-column idx_tasks_to is kept (other paths
+  -- use it and we don't need the risk of dropping it).
+  CREATE INDEX IF NOT EXISTS idx_tasks_to_created ON tasks(to_name, created_at DESC);
 `);
 
 // nodes table (V2 Sprint 2) — persistent node identity, separate from runtime sessions

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1963,6 +1963,12 @@ Bun.serve({
       const toName = url.searchParams.get("to_name");
       const fromName = url.searchParams.get("from_name");
       const limit = Math.min(Number(url.searchParams.get("limit")) || 50, 200);
+      // #248 — opt-out of the stats GROUP-BY scan. The dashboard chat panel
+      // never consumes `stats`; it's a global per-status table scan that
+      // dominates the request time on a large DB (270 MB / many tasks).
+      // Existing callers that don't pass `skip_stats=1` get the same
+      // {ok, tasks, count, stats} shape — backwards-compatible.
+      const skipStats = url.searchParams.get("skip_stats") === "1";
 
       let sql = "SELECT * FROM tasks WHERE 1=1";
       const params: any[] = [];
@@ -1975,6 +1981,9 @@ Bun.serve({
       params.push(limit);
 
       const rows = db.all(sql, ...params);
+      if (skipStats) {
+        return withCors(req, Response.json({ ok: true, tasks: rows, count: rows.length }));
+      }
       const statsParams: any[] = [];
       let statsSql = "SELECT status, COUNT(*) as count FROM tasks WHERE 1=1";
       statsSql = addNetworkScope(statsSql, statsParams, restScope);


### PR DESCRIPTION
## Author

Agent: 通信工程马

## Summary

Fixes #248 server-side. 2 files +18 lines:
- `server/src/db.ts` +9 — composite index `idx_tasks_to_created (to_name, created_at DESC)` via idempotent `CREATE INDEX IF NOT EXISTS` migration
- `server/src/index.ts` +9 — `?skip_stats=1` opt-out short-circuits the GROUP-BY stats subquery

## Docker A/B (100k seeded tasks, 5k rows for test alias, 5 runs each)

| | avg | p50 | p95 |
|---|---|---|---|
| baseline (origin/main) default | 27.9ms | 26.8 | 30.2 |
| patched default (idx only) | 11.6ms | 11.4 | 13.4 |
| **patched + skip_stats=1** | **1.1ms** | **1.1** | **1.4** |

→ idx alone: 2.4x, idx + skip_stats: **25x**

## Backward compat

- Default callers (no `skip_stats=1`) get the same `{ok, tasks, count, stats}` shape — bit-for-bit compatible.
- Index migration is `CREATE INDEX IF NOT EXISTS` — runs at server boot, idempotent, no manual prod DB touch.

## Companion change (separate)

Dashboard `/api/hub/tasks` proxy needs to pass `&skip_stats=1` for `TaskChatPanel` to realize the 25x client-side — filed alongside.

## Bundle ship plan

Per 通信龙 — bundle into one hub upgrade with #247 SSE auth.