### PR TITLE
feat: #246 telegram plugin watchdog (agent-node) + #176 single-node --accept-dev-channels flag

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2759,9 +2759,70 @@ async function startCommand() {
   // detach with `Ctrl-B D` per normal tmux behavior.
   const wantTmux = opts.tmux === "true";
 
-  if (!wantTmux) {
+  // #176 — headless / no-TTY start with automatic dev-channels prompt
+  // dismissal. Default `startCommand` and `--tmux` both assume an attached
+  // TTY: claude-code-cli pops "WARNING: Loading development channels …
+  // (Enter to confirm)" on every launch and waits for keyboard input. From
+  // a watchdog / cron / CI / `setsid`-detached caller there is no TTY to
+  // press Enter, so the process hangs forever and the node never comes up
+  // (broken telegram → broken whole node — strictly worse than the
+  // problem any auto-restart is trying to solve, per 通信龙 a4d1836b).
+  //
+  // `--accept-dev-channels` spawns the node in a DETACHED tmux session
+  // (so claude gets a real PTY from the tmux client/server pair) and runs
+  // the existing `dismissDevChannelPrompt` watcher in parallel to confirm
+  // the prompt the moment it appears. Same mechanism that `anet project
+  // up` already uses (autoConfirmDevChannels at line ~4220) — just made
+  // available to single-node `anet node start` for the watchdog +
+  // headless re-attach use cases. Closes #176 for the single-node path.
+  const wantAcceptDevChannels = opts["accept-dev-channels"] === "true";
+
+  if (!wantTmux && !wantAcceptDevChannels) {
     // Default: spawn the agent runtime in this terminal.
     await launchAgent(id, forceNewSession);
+    return;
+  }
+
+  if (wantAcceptDevChannels) {
+    const resolved = resolveNodeRef(id);
+    if (!resolved) {
+      console.error(`Node "${id}" not found. Create it first: anet node create ${id}`);
+      process.exit(1);
+    }
+    const alias = nodeDisplayName(resolved.id, resolved.profile);
+    if (!tmuxAvailable()) {
+      console.error(`[anet] ❌ --accept-dev-channels requires tmux (used for PTY + prompt-dismiss side-channel).`);
+      process.exit(1);
+    }
+    // tmux already running for this alias — assume it's the live session,
+    // do NOT re-spawn (would `-As` attach and confuse callers expecting a
+    // fresh start).
+    if (tmuxSessionRunning(alias)) {
+      console.log(`[anet] tmux session "${alias}" already running — skipping spawn (use \`anet node stop\` first if you intended a fresh start).`);
+      return;
+    }
+    const inner = forceNewSession
+      ? `anet node start ${shellQuote(alias)} --new-session`
+      : `anet node start ${shellQuote(alias)}`;
+    try {
+      execFileSync(
+        "tmux",
+        ["new-session", "-d", "-s", alias, "-c", process.cwd(), inner],
+        { stdio: "ignore" },
+      );
+    } catch (e: any) {
+      console.error(`[anet] ❌ tmux detached spawn failed: ${e?.message || e}`);
+      process.exit(1);
+    }
+    // Concurrently watch the new tmux pane and send Enter when the
+    // dev-channels prompt appears. Returns false if the prompt never
+    // shows within the window — that's a non-claude node or a node that
+    // came up past the prompt already; either way we're done.
+    const dismissed = await dismissDevChannelPrompt(alias, 45_000);
+    console.log(
+      `[anet] ✅ node "${alias}" started detached (tmux session live; ` +
+        `dev-channels prompt ${dismissed ? "auto-confirmed" : "did not appear within 45 s"}).`,
+    );
     return;
   }
 

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -2566,3 +2566,37 @@ process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
 for (const channel of TELEGRAM_CHANNELS) connectTelegram(channel);
 connectSSE();
+
+// #246 — opt-in telegram plugin watchdog. Reads
+// `fileConfig.telegram.watchdog === true` (default false). When enabled,
+// monitors the plugin's `bot.pid` under TELEGRAM_STATE_DIR; if the poller
+// dies, gates on (a) agent idle long enough, OR (b) dead-for-20-min force
+// fallback, then fires `anet node stop && anet node start` via a detached
+// helper so a node-side restart can survive killing this very process.
+// Thrash-capped to 1 restart per 30 min. See
+// `agent-node/src/telegram-watchdog.ts` for the full contract.
+if (fileConfig.telegram?.watchdog === true) {
+  const stateDir = fileConfig.env?.TELEGRAM_STATE_DIR;
+  if (!stateDir) {
+    warn(
+      "telegram.watchdog enabled but TELEGRAM_STATE_DIR not set in config.env — " +
+        "watchdog cannot locate bot.pid. Either unset telegram.watchdog or add env.TELEGRAM_STATE_DIR.",
+    );
+  } else {
+    import("./telegram-watchdog.js")
+      .then((mod) => {
+        mod.startTelegramWatchdog(
+          {
+            stateDir,
+            alias: ALIAS,
+            commhubUrl: COMMHUB_URL,
+            commhubToken: AUTH_TOKEN,
+          },
+          (msg: string) => log(`[telegram-watchdog] ${msg}`),
+        );
+      })
+      .catch((e: any) => {
+        warn(`telegram-watchdog start failed: ${e?.message ?? String(e)}`);
+      });
+  }
+}

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -18,6 +18,7 @@ import { getHostTelemetry } from "./host-telemetry";
 import { getProcessTelemetry, incrementInFlight, decrementInFlight } from "./process-telemetry";
 import { parseGoalCommand } from "./goals/parser";
 import { GoalStore, newGoal } from "./goals/store";
+import { startTelegramWatchdog } from "./telegram-watchdog";
 import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
 import {
@@ -2583,20 +2584,23 @@ if (fileConfig.telegram?.watchdog === true) {
         "watchdog cannot locate bot.pid. Either unset telegram.watchdog or add env.TELEGRAM_STATE_DIR.",
     );
   } else {
-    import("./telegram-watchdog.js")
-      .then((mod) => {
-        mod.startTelegramWatchdog(
-          {
-            stateDir,
-            alias: ALIAS,
-            commhubUrl: COMMHUB_URL,
-            commhubToken: AUTH_TOKEN,
-          },
-          (msg: string) => log(`[telegram-watchdog] ${msg}`),
-        );
-      })
-      .catch((e: any) => {
-        warn(`telegram-watchdog start failed: ${e?.message ?? String(e)}`);
-      });
+    try {
+      // Static import (top of file) so bun build bundles the module into
+      // dist/cli.js — dynamic import('./telegram-watchdog.js') would not be
+      // resolvable post-bundle. Opt-in flag still gates runtime startup,
+      // so non-telegram nodes pay only the bundle-size cost (~few KB),
+      // not any runtime cost.
+      startTelegramWatchdog(
+        {
+          stateDir,
+          alias: ALIAS,
+          commhubUrl: COMMHUB_URL,
+          commhubToken: AUTH_TOKEN,
+        },
+        (msg: string) => log(`[telegram-watchdog] ${msg}`),
+      );
+    } catch (e: any) {
+      warn(`telegram-watchdog start failed: ${e?.message ?? String(e)}`);
+    }
   }
 }

--- a/agent-node/src/telegram-watchdog.ts
+++ b/agent-node/src/telegram-watchdog.ts
@@ -86,6 +86,10 @@ export function startTelegramWatchdog(
 
   let deadSinceMs = 0;
   let lastRestartMs = 0;
+  // Re-entrancy guard — if a previous tick is still awaiting the
+  // 10 s pre-restart grace, skip this tick to avoid overlapping
+  // restart fires (defensive; timing makes it unlikely but cheap).
+  let ticking = false;
 
   const pollerAlive = (): boolean => {
     if (!existsSync(PID_FILE)) return false;
@@ -160,11 +164,20 @@ export function startTelegramWatchdog(
     // `setsid` puts the helper in its own session so the parent kill chain
     // can't reach it. `nohup` would also work but `setsid` is cleaner about
     // tty detachment and matches the pattern used for other anet helpers.
+    //
+    // `--accept-dev-channels` is REQUIRED here (#176). Default `anet node
+    // start` runs claude in foreground and hangs on the dev-channels
+    // confirmation prompt waiting for an Enter that nobody can press in
+    // this detached/headless context. The flag spawns claude in a detached
+    // tmux session (so it gets a PTY) and auto-confirms the prompt via
+    // the same side-channel that `anet project up` uses. Without it the
+    // restart would deadlock and the watchdog would make the outage
+    // worse, not better — per 通信龙 a4d1836b code-review catch.
     const cmd =
       `setsid sh -c 'sleep 5 && ` +
       `anet node stop ${JSON.stringify(cfg.alias)} >> /tmp/telegram-watchdog-${cfg.alias}.log 2>&1 && ` +
       `sleep 2 && ` +
-      `anet node start ${JSON.stringify(cfg.alias)} >> /tmp/telegram-watchdog-${cfg.alias}.log 2>&1` +
+      `anet node start ${JSON.stringify(cfg.alias)} --accept-dev-channels >> /tmp/telegram-watchdog-${cfg.alias}.log 2>&1` +
       `' >> /tmp/telegram-watchdog-${cfg.alias}.log 2>&1 < /dev/null &`;
 
     const child = spawn("bash", ["-c", cmd], {
@@ -180,6 +193,19 @@ export function startTelegramWatchdog(
   };
 
   const tick = async (): Promise<void> => {
+    if (ticking) {
+      log("tick skipped — previous tick still in flight (pre-restart grace)");
+      return;
+    }
+    ticking = true;
+    try {
+      await tickInner();
+    } finally {
+      ticking = false;
+    }
+  };
+
+  const tickInner = async (): Promise<void> => {
     const now = Date.now();
 
     if (pollerAlive()) {

--- a/agent-node/src/telegram-watchdog.ts
+++ b/agent-node/src/telegram-watchdog.ts
@@ -1,0 +1,252 @@
+// Telegram plugin watchdog (#246).
+//
+// Background — see RFC-024 reframe + commhub conversation b7d6f516.
+//
+// The official `claude-plugins-official/telegram` plugin sometimes dies
+// without auto-respawn (root cause still pending — intermittent). When it
+// does, the node loses its bot.pid and Vincent's primary channel goes
+// silent until a human restarts the node. This module watches for that
+// failure mode and triggers a node restart, gated to avoid disrupting an
+// actively-working agent or thrashing on a misconfigured node.
+//
+// Wired into `agent-node` only when `config.json` contains
+// `telegram: { watchdog: true }` — opt-in, default off. Existing nodes
+// see zero behavior change.
+
+import { existsSync, readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+
+export interface TelegramWatchdogConfig {
+  /** Plugin state directory containing `bot.pid` (from config.env.TELEGRAM_STATE_DIR). */
+  stateDir: string;
+  /** Own alias (so we can query our own commhub session and notify admin). */
+  alias: string;
+  /** CommHub base URL — same one the rest of agent-node uses. */
+  commhubUrl: string;
+  /** CommHub token (ntok_) — for /api/status query and send_message MCP. */
+  commhubToken: string;
+
+  /** Knobs — all default to the values reviewed with 通信龙. */
+  /** How often to check poller liveness. Default 60 s. */
+  pollIntervalMs?: number;
+  /** Agent must be idle AND last-active-longer-than this before we'd restart
+   *  on the idle path. Default 5 min — gives a buffer past brief lulls. */
+  idleThresholdMs?: number;
+  /** If poller has been dead this long, restart regardless of agent activity
+   *  (fallback so a persistently-busy agent doesn't stay broken forever).
+   *  Default 20 min — matches the observed pre-fix outage tolerance. */
+  forceRestartAfterDeadMs?: number;
+  /** Minimum gap between two consecutive restart fires. Default 30 min —
+   *  caps thrash on misconfigured tokens / broken plugin. */
+  thrashWindowMs?: number;
+  /** Admin alias to notify before restarting. Default `通信龙`. */
+  adminAlias?: string;
+}
+
+export interface TelegramWatchdogHandle {
+  /** setInterval handle — call `clearInterval` to stop. Mostly for tests. */
+  timer: NodeJS.Timeout;
+}
+
+const DEFAULTS = {
+  pollIntervalMs: 60_000,
+  idleThresholdMs: 5 * 60 * 1_000,
+  forceRestartAfterDeadMs: 20 * 60 * 1_000,
+  thrashWindowMs: 30 * 60 * 1_000,
+  adminAlias: "通信龙",
+};
+
+function expandHome(p: string): string {
+  if (!p) return p;
+  return p.startsWith("~") ? p.replace(/^~/, homedir()) : p;
+}
+
+function parseSqliteIsoTimestamp(ts: string | undefined | null): number | null {
+  // commhub `updated_at` is `'YYYY-MM-DD HH:MM:SS'` (UTC, no tz suffix).
+  // `Date.parse` is permissive enough but unreliable on the space-as-separator
+  // form across engines; do it explicitly.
+  if (!ts) return null;
+  const fixed = ts.includes("T") ? ts : ts.replace(" ", "T") + "Z";
+  const ms = Date.parse(fixed);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function startTelegramWatchdog(
+  cfg: TelegramWatchdogConfig,
+  log: (msg: string) => void,
+): TelegramWatchdogHandle {
+  const POLL = cfg.pollIntervalMs ?? DEFAULTS.pollIntervalMs;
+  const IDLE = cfg.idleThresholdMs ?? DEFAULTS.idleThresholdMs;
+  const FORCE_AFTER = cfg.forceRestartAfterDeadMs ?? DEFAULTS.forceRestartAfterDeadMs;
+  const THRASH = cfg.thrashWindowMs ?? DEFAULTS.thrashWindowMs;
+  const ADMIN = cfg.adminAlias ?? DEFAULTS.adminAlias;
+
+  const PID_FILE = `${expandHome(cfg.stateDir)}/bot.pid`;
+
+  let deadSinceMs = 0;
+  let lastRestartMs = 0;
+
+  const pollerAlive = (): boolean => {
+    if (!existsSync(PID_FILE)) return false;
+    try {
+      const pid = parseInt(readFileSync(PID_FILE, "utf8"), 10);
+      if (!Number.isFinite(pid) || pid <= 1) return false;
+      // signal 0 = existence check, doesn't actually deliver a signal
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const queryOwnSessionStatus = async (): Promise<{
+    status: string;
+    lastSeenMs: number | null;
+  } | null> => {
+    try {
+      const res = await fetch(`${cfg.commhubUrl}/api/status?light=1`, {
+        headers: { Authorization: `Bearer ${cfg.commhubToken}` },
+      });
+      if (!res.ok) return null;
+      const data = (await res.json()) as {
+        sessions?: Array<{ alias: string; status: string; updated_at?: string }>;
+      };
+      const own = (data.sessions ?? []).find((s) => s.alias === cfg.alias);
+      if (!own) return null;
+      return {
+        status: own.status ?? "unknown",
+        lastSeenMs: parseSqliteIsoTimestamp(own.updated_at),
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  const sendAdminMessage = async (text: string): Promise<void> => {
+    try {
+      await fetch(`${cfg.commhubUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${cfg.commhubToken}`,
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: Date.now(),
+          method: "tools/call",
+          params: {
+            name: "send_message",
+            arguments: {
+              alias: ADMIN,
+              message: `[telegram-watchdog] ${cfg.alias}: ${text}`,
+            },
+          },
+        }),
+      });
+    } catch (e: any) {
+      log(`admin notify failed: ${e?.message ?? String(e)}`);
+    }
+  };
+
+  const fireRestart = async (reason: string): Promise<void> => {
+    log(`triggering restart — reason: ${reason}`);
+    await sendAdminMessage(`telegram poller down, restarting in 10s (${reason})`);
+    // Give downstream a beat to notice the notification, then detach a child
+    // session that will outlive the imminent `anet node stop` of ourselves.
+    await new Promise((r) => setTimeout(r, 10_000));
+
+    // `setsid` puts the helper in its own session so the parent kill chain
+    // can't reach it. `nohup` would also work but `setsid` is cleaner about
+    // tty detachment and matches the pattern used for other anet helpers.
+    const cmd =
+      `setsid sh -c 'sleep 5 && ` +
+      `anet node stop ${JSON.stringify(cfg.alias)} >> /tmp/telegram-watchdog-${cfg.alias}.log 2>&1 && ` +
+      `sleep 2 && ` +
+      `anet node start ${JSON.stringify(cfg.alias)} >> /tmp/telegram-watchdog-${cfg.alias}.log 2>&1` +
+      `' >> /tmp/telegram-watchdog-${cfg.alias}.log 2>&1 < /dev/null &`;
+
+    const child = spawn("bash", ["-c", cmd], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+
+    lastRestartMs = Date.now();
+    // Reset death tracker so a slow-to-fire restart doesn't double-trigger
+    // before this agent-node is actually killed.
+    deadSinceMs = 0;
+  };
+
+  const tick = async (): Promise<void> => {
+    const now = Date.now();
+
+    if (pollerAlive()) {
+      if (deadSinceMs > 0) {
+        log(`poller back alive (was down ${Math.round((now - deadSinceMs) / 1_000)}s)`);
+      }
+      deadSinceMs = 0;
+      return;
+    }
+
+    // poller dead
+    if (!deadSinceMs) {
+      deadSinceMs = now;
+      log(`poller DEAD detected (bot.pid missing or pid not alive)`);
+      return;
+    }
+
+    // thrash cap — don't fire another restart inside the window
+    if (lastRestartMs && now - lastRestartMs < THRASH) {
+      const waitMin = Math.round((THRASH - (now - lastRestartMs)) / 60_000);
+      log(`thrash cap held — next restart allowed in ${waitMin} min`);
+      return;
+    }
+
+    const deadFor = now - deadSinceMs;
+    const own = await queryOwnSessionStatus();
+
+    // Idle-gate path: agent is idle AND was idle long enough that we're not
+    // interrupting a mid-task pause.
+    const isIdle = own?.status === "idle";
+    const idleLongEnough = own?.lastSeenMs ? now - own.lastSeenMs > IDLE : false;
+
+    if (isIdle && idleLongEnough) {
+      const idleMin = own?.lastSeenMs
+        ? Math.round((now - own.lastSeenMs) / 60_000)
+        : null;
+      await fireRestart(
+        `idle path (status=idle, last activity ~${idleMin ?? "?"} min ago)`,
+      );
+      return;
+    }
+
+    // Fallback path: dead long enough that even an actively-working agent
+    // is better off with telegram restored. Agents typically have natural
+    // turn boundaries; restart pain (~30 s) is better than indefinitely
+    // dead telegram on an active node.
+    if (deadFor > FORCE_AFTER) {
+      const deadMin = Math.round(deadFor / 60_000);
+      await fireRestart(`force path (dead ${deadMin} min, agent active or status unknown)`);
+      return;
+    }
+
+    log(
+      `waiting — dead for ${Math.round(deadFor / 60_000)} min, ` +
+        `status=${own?.status ?? "unknown"}, ` +
+        `last_seen=${own?.lastSeenMs ? Math.round((now - own.lastSeenMs) / 60_000) + "min ago" : "?"}`,
+    );
+  };
+
+  log(
+    `started — poll=${POLL / 1_000}s, idle_threshold=${IDLE / 60_000}min, ` +
+      `force_after=${FORCE_AFTER / 60_000}min, thrash_cap=${THRASH / 60_000}min, ` +
+      `state_dir=${cfg.stateDir}`,
+  );
+
+  const timer = setInterval(() => {
+    tick().catch((e) => log(`tick error: ${e?.message ?? String(e)}`));
+  }, POLL);
+  return { timer };
+}


### PR DESCRIPTION
## Author

Agent: 通信工程马

## Summary

Two connected fixes that solve #246 watchdog + #176 single-node-start-hangs-on-prompt as one ship:

### `agent-node/src/telegram-watchdog.ts` (NEW, 280 LOC) — opt-in plugin watchdog

Death-detect (`bot.pid` exists + pid alive) → idle-gate (status=idle + last_seen>5 min) OR force fallback (dead>20 min) → 10 s admin notify grace → `setsid sh -c '... anet node stop && start --accept-dev-channels'` detached restart. Thrash-capped 1 / 30 min. Re-entrancy guard on `tick()` (defensive). `health.json` planned for the broader #246 supervisor scope; this is the narrow 2a slice.

Opt-in via `config.json` `telegram: { watchdog: true }`. Default off — zero behavior change for unaffected nodes.

### `agent-network/bin/cli.ts` — single-node `anet node start <alias> --accept-dev-channels` flag

Closes #176 for the single-node path. Default `startCommand` runs claude in foreground via `launchAgent` and deadlocks on Claude Code's "WARNING: Loading development channels … (Enter to confirm)" prompt in any no-TTY context (watchdog `setsid`, cron, CI). The new flag spawns the node in a DETACHED tmux session (so claude gets a real PTY from the tmux client/server) and runs the existing `dismissDevChannelPrompt` watcher in parallel — same proven helper `anet project up` uses (autoConfirmDevChannels). Single-node now has explicit opt-in to the same flow.

## Docker E2E

A stub `claude` script printing the exact dev-channels detection strings was used to verify the full chain end-to-end:
- tmux session spawned (detached) ✅
- stub prints prompt ✅
- `dismissDevChannelPrompt` detects + sends Enter ✅
- stub echoes "DEV CHANNELS CONFIRMED" (proves Enter went through) ✅
- `anet node start --accept-dev-channels` exits 0 (no hang) ✅
- watchdog module bundled into `dist/cli.js` ✅ (grep 2 hits — verified after switch from dynamic to static import; dynamic was a real bundling trap caught by this same Docker run)

## Static import + re-entrancy guard

Two refinements during 通信龙 re-review (a4d1836b):
- `import('./telegram-watchdog.js')` → top-level static import. `bun build` doesn't bundle dynamic-imported relative modules into `dist/cli.js`; would fail at runtime in production. Opt-in flag still gates startup, so non-telegram nodes pay ~few KB bundle cost and zero runtime cost.
- `tick()` wrapped in a `ticking` guard so the 10 s pre-restart grace cannot overlap with the next 60 s poll.

## Backward compat / safety

- Watchdog: opt-in (default off). Existing nodes unchanged.
- `--accept-dev-channels`: explicit flag, not a default behavior change.
- Restart command is `setsid` detached + thrash-capped + admin pre-notify — defensive layers stack.
- `--accept-dev-channels` reuses the proven `dismissDevChannelPrompt` helper that ships in production today for `anet project up`.

## Sequencing (per 通信龙)

- Merge this PR to main → ship as separate preview bump (NOT bundled with the current #247+#248 hub upgrade which is already preview-ready).
- `--accept-dev-channels` flag ships as a general improvement (also closes #176) and can be used independently of watchdog enable.
- Watchdog `enable` on A站 requires Vincent's explicit confirmation (node-level auto-restart is a runtime behavior change per `[[feedback_confirm_before_push_on_vincent_arch_decisions]]`).

Related: #246, #176.