### PR TITLE
feat(#184 P0): /loop SDK runtime gate — claude hands-off + 4-row switch

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -17,7 +17,7 @@ import { createCommhubSdkMcpServer } from "./commhub-mcp";
 import { getHostTelemetry } from "./host-telemetry";
 import { getProcessTelemetry, incrementInFlight, decrementInFlight } from "./process-telemetry";
 import { parseGoalCommand } from "./goals/parser";
-import { GoalStore, newGoal } from "./goals/store";
+import { GoalStore, newGoal, runtimeBucket, decideStartupAction } from "./goals/store";
 import { startTelegramWatchdog } from "./telegram-watchdog";
 import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
@@ -2152,7 +2152,12 @@ async function processInbox() {
         continue;
       }
 
-      if (isGoalCommand(content)) {
+      // P0 /loop SDK gate (v0.4 §3.4): on claude runtime, anet does NOT
+      // intercept /loop or /goal — let the message flow through to the
+      // claude SDK turn so Claude Code's native /loop skill handles it.
+      // The early-return is the entire hands-off contract; no parse, no
+      // wrap, no forward layer in between.
+      if (RUNTIME !== "claude" && isGoalCommand(content)) {
         let replyText: string;
         let goalFailed = false;
         try {
@@ -2554,14 +2559,49 @@ log(`  log-dir: ${LOG_DIR}`);
 log(`  goals:   ${GOALS_PATH}`);
 const goalsLoad = await goalStore.load();
 if (!goalsLoad.ok) warn(`  goals load recovered: ${goalsLoad.error || "unknown"}${goalsLoad.recovered ? ` (${goalsLoad.recovered})` : ""}`);
-const activeGoals = (await goalStore.list()).filter(g => g.status === "active");
+const allGoals = await goalStore.list();
+const activeGoals = allGoals.filter(g => g.status === "active");
 if (activeGoals.length) log(`  goals active: ${activeGoals.length}`);
+
+// P0 /loop SDK runtime gate (v0.4 §3.4). Decide whether this process can
+// run the anet scheduler at all given the runtime it booted under and the
+// goals already on disk. Pure-function decision; we only act on the
+// verdict here.
+const startupBucket = runtimeBucket(RUNTIME);
+const startupAction = decideStartupAction(startupBucket, allGoals);
+let goalsSchedulerEnabled = startupAction.runScheduler;
+
+switch (startupAction.kind) {
+  case "ok":
+    log(`  goals scheduler: enabled (runtime=${startupBucket})`);
+    break;
+  case "skip":
+    log(`  goals scheduler: skipped — ${startupAction.reason}`);
+    break;
+  case "archive": {
+    warn(`  goals scheduler: ${startupAction.reason}`);
+    const archived = await goalStore.archiveAndClear(startupAction.reason);
+    if (archived) {
+      warn(`  goals archived → ${archived}`);
+    } else {
+      warn(`  goals archive skipped — no file to back up`);
+    }
+    break;
+  }
+  case "fatal":
+    warn(`  goals scheduler: FATAL — ${startupAction.reason}`);
+    warn(`  goals path: ${GOALS_PATH}`);
+    process.exit(1);
+}
+
 await register();
 log("已注册到 CommHub");
 processInbox().catch((e: any) => warn(`initial inbox scan failed: ${e.message}`));
 setInterval(() => reportStatus("idle").catch(() => {}), 3 * 60 * 1000);
-setInterval(() => runGoalSchedulerTick().catch(() => {}), GOAL_TICK_MS);
-runGoalSchedulerTick().catch(() => {});
+if (goalsSchedulerEnabled) {
+  setInterval(() => runGoalSchedulerTick().catch(() => {}), GOAL_TICK_MS);
+  runGoalSchedulerTick().catch(() => {});
+}
 const shutdown = async () => { log("shutting down..."); await reportStatus("offline").catch(() => {}); process.exit(0); };
 process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);

--- a/agent-node/src/goals/store.test.ts
+++ b/agent-node/src/goals/store.test.ts
@@ -6,10 +6,18 @@
 // concurrent upserts (#1+#3).
 
 import { expect, test, describe, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { GoalStore, newGoal } from "./store";
+import {
+  GoalStore,
+  newGoal,
+  assertNonClaudeRuntime,
+  isClaudeRuntime,
+  runtimeBucket,
+  decideStartupAction,
+} from "./store";
+import type { AgentGoal } from "./types";
 
 function tmpPath(): { dir: string; path: string } {
   const dir = mkdtempSync(join(tmpdir(), "anet-goals-test-"));
@@ -164,6 +172,234 @@ describe("GoalStore — corruption recovery (#2)", () => {
     const r = await s.load();
     expect(r.ok).toBe(false);
     expect(r.recovered).toBeDefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// P0 /loop SDK runtime gate (v0.4 §3.4) — the heart of "claude hands-off".
+// ─────────────────────────────────────────────────────────────────────
+
+describe("P0 runtime gate — name resolution", () => {
+  test("isClaudeRuntime accepts every claude alias", () => {
+    for (const name of ["claude", "claude-agent-sdk", "claude-sdk", "agent-sdk"]) {
+      expect(isClaudeRuntime(name)).toBe(true);
+    }
+  });
+
+  test("isClaudeRuntime rejects codex / grok / unknown / empty", () => {
+    for (const name of ["codex", "codex-sdk", "grok", "grok-build-acp", "grok-build", "weird", "", null, undefined]) {
+      expect(isClaudeRuntime(name as any)).toBe(false);
+    }
+  });
+
+  test("runtimeBucket maps to canonical buckets", () => {
+    expect(runtimeBucket("claude-agent-sdk")).toBe("claude");
+    expect(runtimeBucket("claude")).toBe("claude");
+    expect(runtimeBucket("codex-sdk")).toBe("codex");
+    expect(runtimeBucket("codex")).toBe("codex");
+    expect(runtimeBucket("grok-build-acp")).toBe("grok");
+    expect(runtimeBucket("grok-build")).toBe("grok");
+    expect(runtimeBucket("grok")).toBe("grok");
+    expect(runtimeBucket("mystery")).toBe("unknown");
+    expect(runtimeBucket(null)).toBe("unknown");
+    expect(runtimeBucket(undefined)).toBe("unknown");
+    expect(runtimeBucket("")).toBe("unknown");
+  });
+});
+
+describe("P0 runtime gate — assertNonClaudeRuntime", () => {
+  test("throws on every claude alias", () => {
+    for (const name of ["claude", "claude-agent-sdk", "claude-sdk", "agent-sdk"]) {
+      expect(() => assertNonClaudeRuntime(name)).toThrow(/claude runtime/);
+    }
+  });
+
+  test("passes for codex / grok / unknown labels (gate only blocks claude)", () => {
+    for (const name of ["codex-sdk", "codex", "grok-build-acp", "grok", "future-sdk"]) {
+      expect(() => assertNonClaudeRuntime(name)).not.toThrow();
+    }
+  });
+
+  test("newGoal({runtime: 'claude'}) throws — no claude-runtime goal ever lands", () => {
+    expect(() =>
+      newGoal({ text: "should not exist", interval_ms: 60_000, runtime: "claude-agent-sdk" }),
+    ).toThrow(/claude runtime/);
+  });
+
+  test("newGoal succeeds for codex / grok runtimes", () => {
+    const c = newGoal({ text: "codex goal", interval_ms: 60_000, runtime: "codex-sdk" });
+    const g = newGoal({ text: "grok goal", interval_ms: 60_000, runtime: "grok-build-acp" });
+    expect(c.runtime).toBe("codex-sdk");
+    expect(g.runtime).toBe("grok-build-acp");
+  });
+
+  test("GoalStore.upsert refuses claude-runtime goal (defence in depth)", async () => {
+    const { dir, path } = (() => {
+      const d = mkdtempSync(join(tmpdir(), "anet-goals-test-"));
+      return { dir: d, path: join(d, "goals.json") };
+    })();
+    try {
+      const s = new GoalStore(path);
+      await s.load();
+      // Build a goal via the legitimate factory then mutate runtime to
+      // simulate a corrupted on-disk record being re-upserted by some
+      // future code path.
+      const g = newGoal({ text: "smuggle", interval_ms: 60_000, runtime: "codex-sdk" });
+      g.runtime = "claude-agent-sdk";
+      await expect(s.upsert(g)).rejects.toThrow(/claude runtime/);
+      expect(await s.list()).toEqual([]);  // store stayed clean
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("P0 runtime gate — archiveAndClear", () => {
+  let dir: string, path: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "anet-goals-test-"));
+    path = join(dir, "goals.json");
+  });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("with live goals: backup file created, store emptied, reload sees empty", async () => {
+    const s1 = new GoalStore(path);
+    await s1.load();
+    await s1.upsert(newGoal({ text: "a", interval_ms: 60_000, runtime: "codex-sdk" }));
+    await s1.upsert(newGoal({ text: "b", interval_ms: 60_000, runtime: "grok-build-acp" }));
+    expect(await s1.list()).toHaveLength(2);
+
+    const backup = await s1.archiveAndClear("runtime-switched-to-claude");
+    expect(backup).toBeDefined();
+    expect(backup).toMatch(/\.runtime-switched\./);
+    expect(existsSync(backup!)).toBe(true);
+
+    // Backup contents = exactly what was on disk before clear.
+    const backupParsed = JSON.parse(readFileSync(backup!, "utf-8"));
+    expect(backupParsed.goals).toHaveLength(2);
+    expect(backupParsed.goals.map((g: AgentGoal) => g.text).sort()).toEqual(["a", "b"]);
+
+    // Live store now empty in-memory + on-disk.
+    expect(await s1.list()).toEqual([]);
+    const s2 = new GoalStore(path);
+    await s2.load();
+    expect(await s2.list()).toEqual([]);
+  });
+
+  test("with no live file: returns undefined, no throw, store still flushes empty", async () => {
+    const s = new GoalStore(path);
+    await s.load();
+    // No upsert before archive — nothing was ever written.
+    const backup = await s.archiveAndClear("nothing to lose");
+    expect(backup).toBeUndefined();
+    // Post-archive an empty goals.json exists on disk (we always flush).
+    expect(existsSync(path)).toBe(true);
+    expect(await s.list()).toEqual([]);
+  });
+
+  test("backup filenames are unique across rapid calls", async () => {
+    const s = new GoalStore(path);
+    await s.load();
+    await s.upsert(newGoal({ text: "one", interval_ms: 60_000, runtime: "codex-sdk" }));
+    const b1 = await s.archiveAndClear("first");
+    await s.upsert(newGoal({ text: "two", interval_ms: 60_000, runtime: "codex-sdk" }));
+    // Ensure timestamp tick so the second backup filename differs.
+    await new Promise(r => setTimeout(r, 10));
+    const b2 = await s.archiveAndClear("second");
+    expect(b1).toBeDefined();
+    expect(b2).toBeDefined();
+    expect(b1).not.toBe(b2);
+    const archives = readdirSync(dir).filter(f => f.includes("runtime-switched"));
+    expect(archives).toHaveLength(2);
+  });
+});
+
+describe("P0 runtime gate — decideStartupAction (v0.4 §3.4 matrix)", () => {
+  function activeGoal(runtime: string): AgentGoal {
+    return newGoal({ text: "x", interval_ms: 60_000, runtime });
+  }
+  function inactiveGoal(runtime: string, status: AgentGoal["status"]): AgentGoal {
+    const g = newGoal({ text: "x", interval_ms: 60_000, runtime });
+    g.status = status;
+    return g;
+  }
+
+  test("row 1: claude + empty → skip, scheduler off", () => {
+    const a = decideStartupAction("claude", []);
+    expect(a.kind).toBe("skip");
+    expect(a.runScheduler).toBe(false);
+  });
+
+  test("row 2: claude + active codex/grok goals → archive verdict", () => {
+    const a = decideStartupAction("claude", [
+      activeGoal("codex-sdk"),
+      activeGoal("grok-build-acp"),
+    ]);
+    expect(a.kind).toBe("archive");
+    expect(a.runScheduler).toBe(false);
+    if (a.kind === "archive") {
+      expect(a.foreignCount).toBe(2);
+      expect(a.foreignBuckets.sort()).toEqual(["codex", "grok"]);
+    }
+  });
+
+  test("row 2 ignores non-active leftover claude-side (no archive triggered)", () => {
+    const a = decideStartupAction("claude", [
+      inactiveGoal("codex-sdk", "complete"),
+      inactiveGoal("grok-build-acp", "cancelled"),
+    ]);
+    expect(a.kind).toBe("skip");
+  });
+
+  test("row 3a: codex bucket + grok-active leftover → fatal", () => {
+    const a = decideStartupAction("codex", [activeGoal("grok-build-acp")]);
+    expect(a.kind).toBe("fatal");
+    expect(a.runScheduler).toBe(false);
+    if (a.kind === "fatal") {
+      expect(a.foreignCount).toBe(1);
+      expect(a.foreignBuckets).toEqual(["grok"]);
+    }
+  });
+
+  test("row 3b: grok bucket + codex-active leftover → fatal", () => {
+    const a = decideStartupAction("grok", [activeGoal("codex-sdk")]);
+    expect(a.kind).toBe("fatal");
+    if (a.kind === "fatal") expect(a.foreignBuckets).toEqual(["codex"]);
+  });
+
+  test("row 3 ignores non-active foreign goals (resolved/cancelled don't block)", () => {
+    const a = decideStartupAction("codex", [
+      inactiveGoal("grok-build-acp", "complete"),
+      activeGoal("codex-sdk"),
+    ]);
+    expect(a.kind).toBe("ok");
+  });
+
+  test("row 4: codex bucket + only codex goals → ok, scheduler on", () => {
+    const a = decideStartupAction("codex", [
+      activeGoal("codex-sdk"),
+      activeGoal("codex-sdk"),
+    ]);
+    expect(a.kind).toBe("ok");
+    expect(a.runScheduler).toBe(true);
+  });
+
+  test("row 4: grok bucket + only grok goals → ok, scheduler on", () => {
+    const a = decideStartupAction("grok", [activeGoal("grok-build-acp")]);
+    expect(a.kind).toBe("ok");
+    expect(a.runScheduler).toBe(true);
+  });
+
+  test("row 4: codex bucket + empty store → ok (fresh node)", () => {
+    const a = decideStartupAction("codex", []);
+    expect(a.kind).toBe("ok");
+    expect(a.runScheduler).toBe(true);
+  });
+
+  test("unknown bucket → skip with warning text (no scheduler, no auto-archive)", () => {
+    const a = decideStartupAction("unknown", [activeGoal("codex-sdk")]);
+    expect(a.kind).toBe("skip");
+    expect(a.runScheduler).toBe(false);
   });
 });
 

--- a/agent-node/src/goals/store.ts
+++ b/agent-node/src/goals/store.ts
@@ -20,6 +20,59 @@ import { randomUUID } from "crypto";
 import type { AgentGoal, GoalStatus, GoalsFile } from "./types";
 import { GOALS_SCHEMA_VERSION } from "./types";
 
+// P0 of /loop SDK plan v0.4 §3.4 — runtime gate.
+//
+// anet /loop scheduler ONLY serves codex / grok runtimes. claude-agent-sdk
+// agents use Claude Code's native /loop (CronCreate + ScheduleWakeup skill)
+// which the harness handles inside the spawned `claude` binary; anet must
+// stay hands-off there or the two schedulers double-fire the same goal.
+//
+// Any name a user might write in `--runtime` / `RUNTIME` env / config that
+// resolves to the claude runtime is rejected at the schema layer so a stray
+// `newGoal({runtime: "claude"})` or a corrupted on-disk record can't slip
+// through the gate. See cli.ts:244-251 for the canonical name→bucket map.
+const CLAUDE_RUNTIME_NAMES = new Set([
+  "claude",
+  "claude-agent-sdk",
+  "claude-sdk",
+  "agent-sdk",
+]);
+
+const CODEX_RUNTIME_NAMES = new Set([
+  "codex",
+  "codex-sdk",
+]);
+
+const GROK_RUNTIME_NAMES = new Set([
+  "grok",
+  "grok-build-acp",
+  "grok-build",
+]);
+
+export type RuntimeBucket = "claude" | "codex" | "grok" | "unknown";
+
+/** Map any user-facing runtime name to its canonical bucket (mirrors cli.ts RUNTIME_MAP). */
+export function runtimeBucket(rt: string | undefined | null): RuntimeBucket {
+  if (!rt) return "unknown";
+  if (CLAUDE_RUNTIME_NAMES.has(rt)) return "claude";
+  if (CODEX_RUNTIME_NAMES.has(rt)) return "codex";
+  if (GROK_RUNTIME_NAMES.has(rt)) return "grok";
+  return "unknown";
+}
+
+export function isClaudeRuntime(rt: string | undefined | null): boolean {
+  return runtimeBucket(rt) === "claude";
+}
+
+export function assertNonClaudeRuntime(rt: string): void {
+  if (isClaudeRuntime(rt)) {
+    throw new Error(
+      `anet goal scheduler does not serve claude runtime (got "${rt}") — ` +
+      `use Claude Code native /loop (CronCreate / ScheduleWakeup) instead`,
+    );
+  }
+}
+
 // Promise-chain mutex. Every `lock()` waits for the previous one to
 // settle, so callers run strictly in arrival order. Errors thrown inside
 // the critical section release the lock (no deadlock on failure).
@@ -138,12 +191,53 @@ export class GoalStore {
   /**
    * Insert or replace a goal. Bumps `updated_at` and flushes to disk
    * atomically before returning.
+   *
+   * P0 runtime gate: rejects any goal whose `runtime` resolves to the
+   * claude bucket. This catches both fresh `newGoal()` mistakes and
+   * upserts of records re-hydrated from corrupted on-disk state.
    */
   async upsert(goal: AgentGoal): Promise<void> {
+    assertNonClaudeRuntime(goal.runtime);
     return this.mutex.lock(async () => {
       goal.updated_at = new Date().toISOString();
       this.goals.set(goal.goal_id, goal);
       await this._flush();
+    });
+  }
+
+  /**
+   * P0 runtime gate — runtime-switch recovery.
+   *
+   * Used when the host starts under a runtime that's incompatible with the
+   * goals currently persisted (e.g. node was on codex, switched to claude;
+   * claude has its own /loop and anet must stay hands-off). Atomically:
+   *
+   *   1. Copy the live `goals.json` to `<path>.runtime-switched.<iso-ts>`
+   *      so the cancelled goals are recoverable.
+   *   2. Clear the in-memory map.
+   *   3. Flush an empty store so the scheduler tick sees zero work.
+   *
+   * Returns the archive path on success, `undefined` if the live file
+   * doesn't exist (nothing to archive).
+   *
+   * The mutex serialises this against any concurrent upsert/mutate/wake.
+   */
+  async archiveAndClear(reason: string): Promise<string | undefined> {
+    return this.mutex.lock(async () => {
+      if (!this.loaded) throw new Error("GoalStore not loaded — call load() first");
+      let backup: string | undefined;
+      if (existsSync(this.filePath)) {
+        const ts = new Date().toISOString().replace(/[:.]/g, "-");
+        backup = `${this.filePath}.runtime-switched.${ts}`;
+        copyFileSync(this.filePath, backup);
+      }
+      this.goals.clear();
+      await this._flush();
+      // Reason is captured in the backup filename indirectly (timestamp +
+      // suffix); the caller logs the human-readable reason. Touching the
+      // backup with a sibling .reason file is overkill for P0.
+      void reason;
+      return backup;
     });
   }
 
@@ -222,6 +316,10 @@ export class GoalStore {
 /**
  * Build a fresh `AgentGoal` with sane defaults — `goal_id` is a UUID,
  * timestamps are now, status is `active`, `next_wake_at` is now + interval.
+ *
+ * P0 runtime gate: rejects claude-bucket runtime up front so the calling
+ * `/loop` slash handler surfaces a clear "use Claude Code native /loop"
+ * error instead of silently persisting a goal anet won't wake.
  */
 export function newGoal(opts: {
   text: string;
@@ -230,6 +328,7 @@ export function newGoal(opts: {
   parent_task_id?: string;
   report_to?: string;
 }): AgentGoal {
+  assertNonClaudeRuntime(opts.runtime);
   const now = new Date();
   return {
     goal_id: randomUUID(),
@@ -244,4 +343,96 @@ export function newGoal(opts: {
     updated_at: now.toISOString(),
     progress_log: [],
   };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// P0 startup runtime-switch dispatch (v0.4 §3.4 row matrix).
+//
+// At agent-node boot, after `goalStore.load()`, the host inspects which
+// runtime bucket it is starting under and what — if anything — is already
+// in `goals.json`. The result drives one of four actions:
+//
+//   - `ok`           : current runtime matches every persisted goal — boot
+//                      normally, run the scheduler tick.
+//   - `skip`         : claude runtime + empty store — boot normally but
+//                      don't start the scheduler tick (claude uses its
+//                      own /loop).
+//   - `archive`      : claude runtime + non-claude goals leftover (alias
+//                      was previously running under codex/grok and
+//                      switched). Caller archives + clears the store + skips
+//                      the scheduler so the two /loop systems don't double-
+//                      wake. Goals are recoverable from the archive file.
+//   - `fatal`        : codex runtime + grok-leftover goals (or vice versa).
+//                      Mixing thread/session IDs across SDKs is unsafe
+//                      enough that we refuse to boot — the operator must
+//                      cancel or archive the foreign goals first.
+//
+// This is a pure function over (current bucket, goal list) so it has full
+// unit coverage; the cli.ts side just dispatches on the verdict.
+// ─────────────────────────────────────────────────────────────────────
+
+export type StartupAction =
+  | { kind: "ok"; runScheduler: true }
+  | { kind: "skip"; runScheduler: false; reason: string }
+  | { kind: "archive"; runScheduler: false; reason: string; foreignCount: number; foreignBuckets: RuntimeBucket[] }
+  | { kind: "fatal"; runScheduler: false; reason: string; foreignCount: number; foreignBuckets: RuntimeBucket[] };
+
+/**
+ * Decide what to do at startup given the runtime the host is booting under
+ * and the goals currently persisted. Pure; no I/O.
+ */
+export function decideStartupAction(
+  currentBucket: RuntimeBucket,
+  goals: AgentGoal[],
+): StartupAction {
+  // Only `active` goals matter — `complete` / `cancelled` / `failed` /
+  // `paused` will not wake regardless of runtime, so they're not a threat.
+  const activeGoals = goals.filter((g) => g.status === "active");
+
+  if (currentBucket === "claude") {
+    if (activeGoals.length === 0) {
+      return { kind: "skip", runScheduler: false, reason: "claude runtime — native /loop in use" };
+    }
+    const foreignBuckets = uniqueBuckets(activeGoals);
+    return {
+      kind: "archive",
+      runScheduler: false,
+      reason: `claude runtime started with ${activeGoals.length} non-claude goal(s) (${foreignBuckets.join(",")}) — archive + skip scheduler so anet doesn't double-fire alongside Claude Code's native /loop`,
+      foreignCount: activeGoals.length,
+      foreignBuckets,
+    };
+  }
+
+  if (currentBucket === "codex" || currentBucket === "grok") {
+    const wrongBucket = activeGoals.filter((g) => {
+      const b = runtimeBucket(g.runtime);
+      return b !== currentBucket && b !== "unknown";
+    });
+    if (wrongBucket.length > 0) {
+      const foreignBuckets = uniqueBuckets(wrongBucket);
+      return {
+        kind: "fatal",
+        runScheduler: false,
+        reason: `${currentBucket} runtime started but goals.json holds ${wrongBucket.length} ${foreignBuckets.join("/")} goal(s) — thread / session IDs cannot be re-used across SDK runtimes. Cancel or archive the foreign goals before relaunching.`,
+        foreignCount: wrongBucket.length,
+        foreignBuckets,
+      };
+    }
+    return { kind: "ok", runScheduler: true };
+  }
+
+  // unknown bucket — runtime label we don't recognise. Refuse to run the
+  // scheduler rather than guess; do not auto-archive (we don't know what
+  // bucket this even is, so we can't claim leftover goals are "foreign").
+  return {
+    kind: "skip",
+    runScheduler: false,
+    reason: `unknown runtime bucket — anet scheduler refuses to run; check --runtime / RUNTIME env / config.runtime`,
+  };
+}
+
+function uniqueBuckets(goals: AgentGoal[]): RuntimeBucket[] {
+  const out = new Set<RuntimeBucket>();
+  for (const g of goals) out.add(runtimeBucket(g.runtime));
+  return Array.from(out);
 }


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Summary

P0 of [docs/research/codex-sdk-goal-feasibility.md v0.4](https://github.com/sleep2agi/agent-network/blob/main/docs/research/codex-sdk-goal-feasibility.md) §3.4 — the runtime-isolation gate that lets anet's /loop scheduler serve `codex` / `grok` runtimes while staying completely hands-off the `claude` runtime (which uses Claude Code's native `/loop` skill via `CronCreate` / `ScheduleWakeup`).

Without this gate, claude-runtime nodes run the anet scheduler **and** the native /loop skill, double-firing the same goal.

Vincent dispatch via 通信龙 2026-06-23/24: "claude 的都不用系统的 loop" + "不能搞崩现有的"。

## What changed

**`goals/store.ts`**
- `assertNonClaudeRuntime(rt)` — throws on any claude-bucket name.
- `runtimeBucket(rt)` / `isClaudeRuntime(rt)` — pure name → bucket mapping mirroring `cli.ts:244-251`.
- `newGoal()` + `GoalStore.upsert()` call the gate (defence in depth — even a corrupted on-disk record can't smuggle a claude goal in).
- `GoalStore.archiveAndClear(reason)` — atomic backup → clear → empty flush so a node switched from codex back to claude doesn't leave orphan goals.
- `decideStartupAction(bucket, goals)` — pure function returning one of `{ok, skip, archive, fatal}` per the v0.4 §3.4 4-row matrix. Fully unit-tested.

**`cli.ts`**
- Inbox `/loop` `/goal` branch gated `RUNTIME !== "claude"`. anet registers **no interceptor** on claude runtime; the message flows through to the SDK turn so the native /loop skill handles it. This is the entire hands-off contract — no parse, no wrap, no forward.
- Startup wires `goalStore.load()` → `decideStartupAction` → dispatch:
  | verdict   | action                                                    |
  |-----------|-----------------------------------------------------------|
  | `ok`      | log + start scheduler                                     |
  | `skip`    | log reason + skip scheduler (claude empty / unknown bucket)|
  | `archive` | warn + `archiveAndClear` + skip scheduler                 |
  | `fatal`   | warn + `process.exit(1)` (codex↔grok foreign goals)       |
- `setInterval(runGoalSchedulerTick)` + initial kick gated on the verdict.

## Tests

```
$ bun test src/goals/
 58 pass · 0 fail · 161 expect() calls (123ms)
```

35 new tests in `store.test.ts`:
- runtime bucket / name resolution (claude / codex / grok / unknown / null / empty)
- `assertNonClaudeRuntime` — throws on each claude alias; passes for codex / grok / unknown / future-sdk labels
- `newGoal({runtime: "claude"})` throws
- `GoalStore.upsert` with mutated claude-runtime goal throws + store stays clean
- `archiveAndClear`: backup + clear + reload-sees-empty; no-file case; filename uniqueness across rapid calls
- `decideStartupAction` 4-row matrix: claude empty/dirty; codex/grok cross-leftover fatal; matching bucket ok; non-active goals don't trigger archive/fatal; unknown bucket falls to skip

Pre-existing 23 parser tests still pass unchanged.

## Constraint compliance (Vincent / 通信龙)

- [x] Open PR — not pushed to main directly
- [x] Did not touch any `.anet/nodes/<alias>/` real-node state on disk
- [x] No npm publish, no deploy
- [x] No restart of running nodes
- [x] "不能搞崩现有的": `archive` verdict preserves goal data in `<path>.runtime-switched.<ts>` (recoverable); `fatal` aborts with clear error message rather than silent breakage
- [x] Hands-off contract: claude runtime registers zero `/loop` interceptor; no parse-then-forward layer
- [x] P1 (codex driver) and P2 (grok adapter) explicitly out of scope per 通信龙 — separate PRs each with Vincent confirm

## Out of scope (queued)

- P1 codex `GoalScheduler` driver behaviour (already shipped in main; this PR only adds the gate, doesn't change driver loop)
- P2 grok-build-acp adapter (spike landed in v0.4 §2.2)
- P3 commhub-server scheduler (北极星 — agent-node-restart resilient)

## Test plan

- [x] `bun test src/goals/` green (35 new + 23 existing = 58 pass)
- [x] `bun build src/cli.ts` produces a clean 80KB bundle (no syntax/typing breaks)
- [ ] Manual smoke (post-merge): docker codex node creates `/loop ...` goal → wakes on schedule; docker claude node sends `/loop ...` → message lands as normal SDK turn, no anet goal record persisted; codex+grok-leftover docker node → boot fails with the fatal message