### PR TITLE
feat(#184 P1b): /loop per-goal codex thread — resumeThread + startThread fallback

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -19,6 +19,7 @@ import { getProcessTelemetry, incrementInFlight, decrementInFlight } from "./pro
 import { parseGoalCommand } from "./goals/parser";
 import { GoalStore, newGoal, runtimeBucket, decideStartupAction } from "./goals/store";
 import { decideTickWork } from "./goals/scheduler";
+import { runCodexWakeForGoal, type CodexWakeDeps } from "./goals/codex-wake";
 import { startTelegramWatchdog } from "./telegram-watchdog";
 import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
@@ -922,7 +923,35 @@ async function runOneGoalWake(goal: AgentGoal): Promise<void> {
     return;
   }
 
-  const { text, failed } = await processTask(prompt, `goal:${idShort}`, goal.parent_task_id || null);
+  // P1b /loop SDK — per-goal codex thread isolation.
+  //
+  // codex runtime: spawn / resume a goal-owned thread via the codex
+  // wake helper so multiple goals don't pollute each other's working
+  // context. The wake prompt (buildGoalWakePrompt) already embeds the
+  // goal text + last 5 progress entries, so a rebuilt thread (after
+  // resume-fail) can pick up from `progress_log` without depending on
+  // the LLM-side thread history we just lost.
+  //
+  // grok / claude runtimes: fall through to processTask (claude is
+  // already blocked at scheduler-startup via the P0 runtime gate;
+  // grok wake gets its own per-goal isolation in P2).
+  let text: string;
+  let failed: boolean;
+  let codexThreadIdCaptured: string | undefined;
+  let codexThreadRebuilt = false;
+  let codexRebuildReason: string | undefined;
+  if (RUNTIME === "codex") {
+    const result = await runCodexWakeForGoal(goal, prompt, buildCodexWakeDeps());
+    text = result.text;
+    failed = result.failed;
+    codexThreadIdCaptured = result.threadId;
+    codexThreadRebuilt = result.threadRebuilt;
+    codexRebuildReason = result.rebuildReason;
+  } else {
+    const r = await processTask(prompt, `goal:${idShort}`, goal.parent_task_id || null);
+    text = r.text;
+    failed = r.failed;
+  }
   const summary = text.replace(/\s+/g, " ").slice(0, 500);
   const completed = /目标已完成|goal completed|completed/i.test(text);
   const nextWakeAt = new Date(Date.now() + goal.interval_ms).toISOString();
@@ -936,6 +965,20 @@ async function runOneGoalWake(goal: AgentGoal): Promise<void> {
       g.last_report_at = new Date().toISOString();
       g.next_wake_at = nextWakeAt;
       if (completed) g.status = "complete";
+      // Persist (possibly rotated) codex thread id so the next wake
+      // resumes the right thread. Only write when the helper actually
+      // produced one — undefined means the SDK didn't expose it yet.
+      if (codexThreadIdCaptured && g.codex_thread_id !== codexThreadIdCaptured) {
+        g.codex_thread_id = codexThreadIdCaptured;
+      }
+      if (codexThreadRebuilt) {
+        g.progress_log.push({
+          ts: new Date().toISOString(),
+          status: "thread-rebuilt",
+          summary: `codex thread rebuilt — ${codexRebuildReason ?? "resume failed"}`,
+          task_id: g.parent_task_id,
+        });
+      }
       g.progress_log.push({
         ts: new Date().toISOString(),
         status: failed ? "error" : completed ? "complete" : "report",
@@ -959,6 +1002,51 @@ async function runOneGoalWake(goal: AgentGoal): Promise<void> {
       warn(`[goal] report send failed for ${idShort}: ${e.message}`);
     }
   }
+}
+
+// P1b — Codex wake deps factory. Lazy-loads the codex SDK once (same
+// path processWithCodex uses for normal tasks), then builds a fresh
+// Codex client per wake so per-goal threads stay isolated. The SDK
+// module is module-level cached after first wake; subsequent wakes
+// hit the cache without re-walking the npm-install fallback path.
+let _codexSdkModuleCache: any | null = null;
+async function loadCodexSdkModule(): Promise<any> {
+  if (_codexSdkModuleCache) return _codexSdkModuleCache;
+  const { execSync } = await import("child_process");
+  const { module: sdkMod } = await loadCodexSdk(
+    {
+      importCodexSdk: () => import("@openai/codex-sdk"),
+      npmInstall: defaultNpmInstall(execSync),
+      log,
+      warn,
+    },
+    resolveAgentNodeDir(__dirname),
+  );
+  _codexSdkModuleCache = sdkMod;
+  return sdkMod;
+}
+
+function buildCodexWakeDeps(): CodexWakeDeps {
+  return {
+    newCodex: async () => {
+      const sdkMod = await loadCodexSdkModule();
+      return new sdkMod.Codex({ config: CODEX_CONFIG });
+    },
+    buildOpts: () => {
+      // Mirror cli.ts:1417-1424 normal-task codex opts so wake behavior
+      // matches the operator's runtime config (yolo flags, model, etc.).
+      const cfgFlags = (fileConfig?.flags || {}) as Record<string, unknown>;
+      return {
+        skipGitRepoCheck: cfgFlags.skipGitRepoCheck === false ? false : true,
+        approvalPolicy: typeof cfgFlags.approvalPolicy === "string" ? cfgFlags.approvalPolicy : "never",
+        model: MODEL || "gpt-5.5",
+        sandboxMode: typeof cfgFlags.sandboxMode === "string" ? cfgFlags.sandboxMode : "danger-full-access",
+        modelReasoningEffort: "low" as const,
+      };
+    },
+    log,
+    warn,
+  };
 }
 
 async function runGoalSchedulerTick() {

--- a/agent-node/src/goals/codex-wake.test.ts
+++ b/agent-node/src/goals/codex-wake.test.ts
@@ -1,0 +1,280 @@
+// P1b unit tests for per-goal codex wake.
+//
+// The Codex SDK is injected via `CodexWakeDeps.newCodex`, so every test
+// passes a hand-rolled fake that yields exactly the events / errors the
+// branch under test needs. Zero real-LLM dependency.
+
+import { expect, test, describe } from "bun:test";
+import type { AgentGoal } from "./types";
+import {
+  runCodexWakeForGoal,
+  type CodexClientFake,
+  type CodexThreadFake,
+  type CodexEventFake,
+  type CodexWakeDeps,
+} from "./codex-wake";
+
+function makeGoal(opts: { codex_thread_id?: string } = {}): AgentGoal {
+  const now = new Date();
+  return {
+    goal_id: "test-goal-abcdef12",
+    text: "test goal",
+    status: "active",
+    interval_ms: 60_000,
+    next_wake_at: now.toISOString(),
+    runtime: "codex-sdk",
+    created_at: now.toISOString(),
+    updated_at: now.toISOString(),
+    progress_log: [],
+    codex_thread_id: opts.codex_thread_id,
+  };
+}
+
+async function* streamEvents(events: CodexEventFake[]): AsyncIterable<CodexEventFake> {
+  for (const ev of events) yield ev;
+}
+
+function agentMessageEvent(text: string): CodexEventFake {
+  return { type: "item.completed", item: { type: "agent_message", text } };
+}
+
+function fakeThread(opts: {
+  id?: string;
+  events?: CodexEventFake[];
+  runThrows?: Error;
+}): CodexThreadFake {
+  return {
+    id: opts.id ?? null,
+    runStreamed: async (_input: unknown) => {
+      if (opts.runThrows) throw opts.runThrows;
+      return { events: streamEvents(opts.events ?? [agentMessageEvent("ok")]) };
+    },
+  };
+}
+
+interface ClientFakeOpts {
+  startThreadResult?: CodexThreadFake | (() => CodexThreadFake);
+  resumeThreadResult?: CodexThreadFake | ((id: string) => CodexThreadFake);
+  startThreadThrows?: Error;
+  resumeThreadThrows?: Error;
+}
+
+function fakeClient(opts: ClientFakeOpts): CodexClientFake {
+  return {
+    startThread: (_o: unknown) => {
+      if (opts.startThreadThrows) throw opts.startThreadThrows;
+      const r = opts.startThreadResult;
+      if (typeof r === "function") return r();
+      return r ?? fakeThread({ id: "new-thread-id" });
+    },
+    resumeThread: (id: string, _o: unknown) => {
+      if (opts.resumeThreadThrows) throw opts.resumeThreadThrows;
+      const r = opts.resumeThreadResult;
+      if (typeof r === "function") return r(id);
+      return r ?? fakeThread({ id });
+    },
+  };
+}
+
+function deps(client: CodexClientFake): CodexWakeDeps {
+  return {
+    newCodex: () => client,
+    buildOpts: () => ({ model: "test", approvalPolicy: "never" }),
+    // Silent log/warn so test output stays clean.
+    log: () => {},
+    warn: () => {},
+  };
+}
+
+describe("runCodexWakeForGoal — first wake (no codex_thread_id)", () => {
+  test("startThread path → captures threadId, returns text + failed=false", async () => {
+    const client = fakeClient({
+      startThreadResult: fakeThread({ id: "fresh-thread-1", events: [agentMessageEvent("hello world")] }),
+    });
+    const r = await runCodexWakeForGoal(makeGoal(), "wake prompt", deps(client));
+    expect(r.failed).toBe(false);
+    expect(r.text).toBe("hello world");
+    expect(r.threadId).toBe("fresh-thread-1");
+    expect(r.threadRebuilt).toBe(false);
+    expect(r.rebuildReason).toBeUndefined();
+  });
+
+  test("startThread with thread.id still null → threadId undefined (SDK didn't expose id yet)", async () => {
+    const client = fakeClient({
+      startThreadResult: fakeThread({ id: null, events: [agentMessageEvent("nothing")] }) as any,
+    });
+    // Force id to null (simulates SDK pre-thread.started). Cast via any
+    // because the type allows string | null at the thread shape.
+    const r = await runCodexWakeForGoal(makeGoal(), "wake", deps(client));
+    expect(r.threadId).toBeUndefined();
+    expect(r.failed).toBe(false);
+  });
+
+  test("empty agent_message stream → returns '(无回复)' fallback", async () => {
+    const client = fakeClient({
+      startThreadResult: fakeThread({ id: "id-1", events: [] }),
+    });
+    const r = await runCodexWakeForGoal(makeGoal(), "wake", deps(client));
+    expect(r.text).toBe("（无回复）");
+    expect(r.failed).toBe(false);
+  });
+});
+
+describe("runCodexWakeForGoal — subsequent wake (has codex_thread_id)", () => {
+  test("resumeThread succeeds → captures (possibly updated) threadId", async () => {
+    const client = fakeClient({
+      resumeThreadResult: (id) => fakeThread({ id, events: [agentMessageEvent("resumed-ok")] }),
+    });
+    const goal = makeGoal({ codex_thread_id: "existing-thread-xyz" });
+    const r = await runCodexWakeForGoal(goal, "wake", deps(client));
+    expect(r.failed).toBe(false);
+    expect(r.text).toBe("resumed-ok");
+    expect(r.threadId).toBe("existing-thread-xyz");
+    expect(r.threadRebuilt).toBe(false);
+    expect(r.rebuildReason).toBeUndefined();
+  });
+
+  test("resume returns thread whose .id was updated by SDK → reflects new id", async () => {
+    const client = fakeClient({
+      resumeThreadResult: () => fakeThread({ id: "new-rotated-id", events: [agentMessageEvent("ok")] }),
+    });
+    const goal = makeGoal({ codex_thread_id: "old-id" });
+    const r = await runCodexWakeForGoal(goal, "wake", deps(client));
+    expect(r.threadId).toBe("new-rotated-id");
+  });
+});
+
+describe("runCodexWakeForGoal — resume-fail fallback (the critical path)", () => {
+  test("resumeThread throws → startThread fallback, threadRebuilt=true, rebuildReason populated", async () => {
+    const client = fakeClient({
+      resumeThreadThrows: new Error("thread not found"),
+      startThreadResult: fakeThread({ id: "rebuilt-thread-id", events: [agentMessageEvent("after rebuild")] }),
+    });
+    const goal = makeGoal({ codex_thread_id: "expired-id" });
+    const r = await runCodexWakeForGoal(goal, "wake prompt with goal text", deps(client));
+    expect(r.failed).toBe(false);
+    expect(r.text).toBe("after rebuild");
+    expect(r.threadId).toBe("rebuilt-thread-id");
+    expect(r.threadRebuilt).toBe(true);
+    expect(r.rebuildReason).toMatch(/resumeThread failed/);
+    expect(r.rebuildReason).toMatch(/thread not found/);
+  });
+
+  test("startThread fallback also throws → failed=true with both errors surfaced", async () => {
+    const client = fakeClient({
+      resumeThreadThrows: new Error("thread expired"),
+      startThreadThrows: new Error("codex binary missing"),
+    });
+    const goal = makeGoal({ codex_thread_id: "expired-id" });
+    const r = await runCodexWakeForGoal(goal, "wake", deps(client));
+    expect(r.failed).toBe(true);
+    expect(r.text).toMatch(/startThread failed/);
+    expect(r.text).toMatch(/codex binary missing/);
+    expect(r.threadRebuilt).toBe(true);
+    expect(r.rebuildReason).toMatch(/thread expired/);
+  });
+
+  test("first wake + startThread throws → failed=true, threadRebuilt=false", async () => {
+    const client = fakeClient({
+      startThreadThrows: new Error("codex not installed"),
+    });
+    const r = await runCodexWakeForGoal(makeGoal(), "wake", deps(client));
+    expect(r.failed).toBe(true);
+    expect(r.text).toMatch(/codex not installed/);
+    expect(r.threadRebuilt).toBe(false);
+    expect(r.rebuildReason).toBeUndefined();
+  });
+});
+
+describe("runCodexWakeForGoal — run-time error after thread obtained", () => {
+  test("runStreamed throws on first wake → failed=true, threadId still captured if SDK set it", async () => {
+    const client = fakeClient({
+      startThreadResult: fakeThread({ id: "obtained", runThrows: new Error("network reset mid-stream") }),
+    });
+    const r = await runCodexWakeForGoal(makeGoal(), "wake", deps(client));
+    expect(r.failed).toBe(true);
+    expect(r.text).toMatch(/network reset/);
+    expect(r.threadId).toBe("obtained");
+    expect(r.threadRebuilt).toBe(false);
+  });
+
+  test("runStreamed throws on resume → failed=true, threadRebuilt=false (resume itself worked)", async () => {
+    const client = fakeClient({
+      resumeThreadResult: (id) => fakeThread({ id, runThrows: new Error("LLM 5xx") }),
+    });
+    const goal = makeGoal({ codex_thread_id: "good-id" });
+    const r = await runCodexWakeForGoal(goal, "wake", deps(client));
+    expect(r.failed).toBe(true);
+    expect(r.text).toMatch(/LLM 5xx/);
+    expect(r.threadId).toBe("good-id");
+    expect(r.threadRebuilt).toBe(false);
+    expect(r.rebuildReason).toBeUndefined();
+  });
+});
+
+describe("runCodexWakeForGoal — DI plumbing", () => {
+  test("newCodex called per wake (not cached across wakes — fresh client each time)", async () => {
+    let calls = 0;
+    const deps2: CodexWakeDeps = {
+      newCodex: () => {
+        calls++;
+        return fakeClient({}) ;
+      },
+      buildOpts: () => ({}),
+    };
+    await runCodexWakeForGoal(makeGoal(), "wake1", deps2);
+    expect(calls).toBe(1);
+    await runCodexWakeForGoal(makeGoal(), "wake2", deps2);
+    expect(calls).toBe(2);
+  });
+
+  test("buildOpts passed verbatim to start/resume Thread", async () => {
+    const seen: unknown[] = [];
+    const sentinel = { I_AM: "the opts", model: "codex-test" };
+    const client: CodexClientFake = {
+      startThread: (o) => { seen.push(o); return fakeThread({ id: "x" }); },
+      resumeThread: (_id, o) => { seen.push(o); return fakeThread({ id: "x" }); },
+    };
+    const d: CodexWakeDeps = {
+      newCodex: () => client,
+      buildOpts: () => sentinel,
+    };
+    // First wake: startThread receives opts
+    await runCodexWakeForGoal(makeGoal(), "w", d);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBe(sentinel);
+    // Resume: resumeThread receives opts
+    await runCodexWakeForGoal(makeGoal({ codex_thread_id: "id" }), "w", d);
+    expect(seen).toHaveLength(2);
+    expect(seen[1]).toBe(sentinel);
+  });
+
+  test("warn callback fires on resume-fail; log callback fires on success", async () => {
+    const warns: string[] = [];
+    const logs: string[] = [];
+    const client = fakeClient({
+      resumeThreadThrows: new Error("bad"),
+      startThreadResult: fakeThread({ id: "rebuilt", events: [agentMessageEvent("ok")] }),
+    });
+    const d: CodexWakeDeps = {
+      newCodex: () => client,
+      buildOpts: () => ({}),
+      log: (m) => { logs.push(m); },
+      warn: (m) => { warns.push(m); },
+    };
+    await runCodexWakeForGoal(makeGoal({ codex_thread_id: "x" }), "w", d);
+    expect(warns.some((m) => /resumeThread failed/.test(m))).toBe(true);
+    expect(logs.some((m) => /startThread/.test(m))).toBe(true);
+  });
+
+  test("missing log/warn deps → no throw (defaults are noops)", async () => {
+    const client = fakeClient({});
+    const d: CodexWakeDeps = {
+      newCodex: () => client,
+      buildOpts: () => ({}),
+      // no log, no warn
+    };
+    const r = await runCodexWakeForGoal(makeGoal(), "w", d);
+    expect(r.failed).toBe(false);
+  });
+});

--- a/agent-node/src/goals/codex-wake.ts
+++ b/agent-node/src/goals/codex-wake.ts
@@ -1,0 +1,159 @@
+// P1b of /loop SDK plan v0.4 — per-goal codex thread wake handler.
+//
+// Each AgentGoal owns its own codex thread so multiple parallel goals
+// don't pollute each other's working context. The first wake spawns a
+// new thread (no LLM waste at goal creation — codex SDK's startThread
+// returns thread.id === null until the first run, so capturing it
+// eagerly would require a no-op turn). Subsequent wakes resume that
+// thread by id. If resume fails (thread expired, deleted by the user,
+// codex SDK rebuilt their session store), we rebuild a fresh thread,
+// flag the goal so the wake handler logs a "thread-rebuilt" entry,
+// and move on — the goal continues to make progress instead of
+// stalling on an unrecoverable session reference.
+//
+// All side effects (Codex SDK construction, thread instantiation,
+// logging) flow through the injected `CodexWakeDeps` so tests can
+// drop in a fake Codex class and exercise every branch deterministically
+// without touching the real LLM.
+
+import type { AgentGoal } from "./types";
+
+/**
+ * Minimal codex SDK shape we depend on. The real `Codex` class from
+ * `@openai/codex-sdk` matches this — we accept `unknown` so tests can
+ * pass any object that exposes `startThread` / `resumeThread` returning
+ * a thing with `runStreamed` / `id`.
+ */
+export interface CodexClientFake {
+  startThread: (opts: unknown) => CodexThreadFake;
+  resumeThread: (id: string, opts: unknown) => CodexThreadFake;
+}
+
+export interface CodexThreadFake {
+  id: string | null;
+  runStreamed: (input: unknown) => Promise<{ events: AsyncIterable<CodexEventFake> }>;
+}
+
+export interface CodexEventFake {
+  type: string;
+  item?: { type: string; text?: string; [k: string]: unknown };
+  usage?: unknown;
+}
+
+export interface CodexWakeDeps {
+  /** Build a fresh Codex client. Called per wake so transient SDK state
+   * (the long-lived ambient `codexThread` in cli.ts) isn't shared.
+   * Async because production loads the codex SDK lazily (npm-install on
+   * miss); tests can return a sync `Promise.resolve(fake)`. */
+  newCodex: () => Promise<CodexClientFake> | CodexClientFake;
+  /** Build the options object passed to startThread/resumeThread.
+   * Same shape as cli.ts:1417-1424 — extracted to deps so tests can
+   * skip the codex-specific flag matrix. */
+  buildOpts: () => unknown;
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+}
+
+export interface CodexWakeResult {
+  /** LLM final response text (or empty / error string on failure). */
+  text: string;
+  /** True when the wake didn't reach the LLM successfully — caller
+   * surfaces this in progress_log + sendReply.failed. */
+  failed: boolean;
+  /** Thread id captured AFTER the run (may differ from the input
+   * `goal.codex_thread_id` when we had to rebuild). Caller writes it
+   * back via goalStore.mutate so subsequent wakes resume correctly. */
+  threadId?: string;
+  /** True when resumeThread(goal.codex_thread_id) threw and we fell
+   * back to startThread. Caller logs a `thread-rebuilt` progress
+   * entry so operators can spot codex-session churn. */
+  threadRebuilt: boolean;
+  /** Human-readable description of any non-fatal failure that DIDN'T
+   * stop the wake (e.g. resume rebuild reason). undefined on the
+   * fully clean path. */
+  rebuildReason?: string;
+}
+
+/**
+ * Run a single codex wake for the given goal. Pure-ish: no module-level
+ * mutable state, all I/O through `deps`. Caller is responsible for
+ * persisting `result.threadId` back to the goal record.
+ */
+export async function runCodexWakeForGoal(
+  goal: AgentGoal,
+  prompt: string,
+  deps: CodexWakeDeps,
+): Promise<CodexWakeResult> {
+  const idShort = goal.goal_id.slice(0, 8);
+  const log = deps.log ?? noop;
+  const warn = deps.warn ?? noop;
+
+  let thread: CodexThreadFake | undefined;
+  let threadRebuilt = false;
+  let rebuildReason: string | undefined;
+
+  // 1. Try resume first if the goal already owns a thread.
+  if (goal.codex_thread_id) {
+    try {
+      const codex = await deps.newCodex();
+      thread = codex.resumeThread(goal.codex_thread_id, deps.buildOpts());
+      log(`[goal-codex] ${idShort} resumed thread ${goal.codex_thread_id}`);
+    } catch (e: any) {
+      const msg = (e?.message || String(e)).slice(0, 200);
+      rebuildReason = `resumeThread failed: ${msg}`;
+      warn(`[goal-codex] ${idShort} ${rebuildReason} — rebuilding`);
+      thread = undefined;
+      threadRebuilt = true;
+    }
+  }
+
+  // 2. Fall back to a fresh thread (first wake or post-rebuild).
+  if (!thread) {
+    try {
+      const codex = await deps.newCodex();
+      thread = codex.startThread(deps.buildOpts());
+      log(`[goal-codex] ${idShort} startThread (fresh${threadRebuilt ? " — rebuilt" : ""})`);
+    } catch (e: any) {
+      const msg = (e?.message || String(e)).slice(0, 200);
+      warn(`[goal-codex] ${idShort} startThread failed: ${msg}`);
+      return {
+        text: `执行出错: codex startThread failed — ${msg}`,
+        failed: true,
+        threadRebuilt,
+        rebuildReason,
+      };
+    }
+  }
+
+  // 3. Run the wake prompt.
+  let finalResponse = "";
+  try {
+    const { events } = await thread.runStreamed(prompt);
+    for await (const ev of events) {
+      if (ev.type === "item.completed" && ev.item?.type === "agent_message") {
+        finalResponse = (ev.item.text as string | undefined) ?? "";
+      }
+    }
+  } catch (e: any) {
+    const msg = (e?.message || String(e)).slice(0, 200);
+    warn(`[goal-codex] ${idShort} run failed: ${msg}`);
+    return {
+      text: `执行出错: ${msg}`,
+      failed: true,
+      threadId: typeof thread.id === "string" ? thread.id : undefined,
+      threadRebuilt,
+      rebuildReason,
+    };
+  }
+
+  const threadId = typeof thread.id === "string" ? thread.id : undefined;
+  return {
+    text: finalResponse || "（无回复）",
+    failed: false,
+    threadId,
+    threadRebuilt,
+    rebuildReason,
+  };
+}
+
+function noop(): void {}


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Summary

P1b of [docs/research/codex-sdk-goal-feasibility.md v0.4](https://github.com/sleep2agi/agent-network/blob/main/docs/research/codex-sdk-goal-feasibility.md) §3.5 — each `AgentGoal` owns its own codex thread so multiple parallel goals don't pollute each other's working context. First wake spawns the thread (no LLM waste at goal creation — codex SDK's `startThread` returns `thread.id === null` until the first run, so capturing it eagerly would require a no-op turn). Subsequent wakes resume by id. Resume fails → rebuild fresh thread, flag `thread-rebuilt`, continue.

通信龙 dispatch 2026-06-24: P1b green after P1a review pass. Vincent ship-gate after focused review.

## Stack base

**Base = `feat/loop-p1a-tick-hardening` (PR #255)** — this PR stacks on P1a so the diff against #255's base is exactly the P1b delta. Merge P1a first, then this PR rebases trivially onto main.

## What changed

**`agent-node/src/goals/codex-wake.ts` (new)**
- `runCodexWakeForGoal(goal, prompt, deps)` — per-wake helper with DI `CodexWakeDeps`. Branches:
  1. `goal.codex_thread_id` set → try `resumeThread(id)`
  2. resume throws OR first wake → `startThread()` fallback (`threadRebuilt=true` when post-resume-fail)
  3. start also throws → return `{failed: true, threadRebuilt: <preserved>}`
  4. Stream events, extract `agent_message.text`, return `{text, failed, threadId, threadRebuilt, rebuildReason}`
- Async `newCodex` so production lazy-loads the codex SDK; tests pass sync fakes.

**`agent-node/src/cli.ts`**
- `runOneGoalWake` dispatches by `RUNTIME`:
  - `codex` → `runCodexWakeForGoal(goal, prompt, buildCodexWakeDeps())`
  - else → `processTask` (grok unchanged — P2; claude already blocked at scheduler-startup via P0 runtime gate)
- Post-wake `goalStore.mutate` writes captured `codex_thread_id` when it differs from stored value; appends a `thread-rebuilt` `progress_log` entry when the helper rebuilt.
- `buildCodexWakeDeps()` builds `CodexWakeDeps`:
  - `newCodex`: lazy-loads codex SDK module once (cached), returns `new Codex({ config: CODEX_CONFIG })` per call
  - `buildOpts`: mirrors `processWithCodex` opts shape (`skipGitRepoCheck` / `approvalPolicy` / `sandboxMode` / `modelReasoningEffort`) so wake behaviour matches operator runtime config

## Review focus (per 通信龙)

**Rebuild context is self-contained** — when resume fails and we rebuild a fresh thread, the new thread has no LLM history. The wake prompt `buildGoalWakePrompt()` (cli.ts:875-894, unchanged) already embeds:
- `goal_id` + `goal.text` (the full goal description)
- `goal.last_wake_at` (continuity marker)
- Last 5 `progress_log` entries (recent history)

So the rebuilt thread picks up from `progress_log` and keeps working without depending on the LLM-side history that just got dropped. The `thread-rebuilt` progress entry surfaces the rebuild for operator visibility.

## Tests

```
$ bun test src/goals/
 65 pass · 0 fail · 177 expect() calls (124ms)
```

14 new tests in `codex-wake.test.ts`:
- First wake (no `codex_thread_id`): `startThread` path, null-id handling, empty stream fallback
- Subsequent wake (has `codex_thread_id`): `resumeThread` succeeds, captures rotated id
- **Resume-fail rebuild path** (the critical edge case): resume throws → `startThread` fallback + `threadRebuilt=true` + `rebuildReason` populated; start also throws → `failed=true` with both errors surfaced
- Runtime errors: `runStreamed` throws on first wake / on resume → `failed=true` with correct `threadRebuilt` state
- DI plumbing: `newCodex` called per wake (fresh client each time, no caching across wakes); `buildOpts` passed verbatim; `log` / `warn` callbacks fire on expected paths; missing `log` / `warn` deps don't throw (noop default)

Pre-existing 51 goal / scheduler / parser tests still pass unchanged.

## Constraint compliance (Vincent / 通信龙)

- [x] Open PR, not pushed to main directly
- [x] Did not touch any `.anet/nodes/<alias>/` real-node state on disk
- [x] No npm publish, no deploy
- [x] No restart of running nodes
- [x] Hands-off contract from P0 untouched (`RUNTIME !== "claude"` slash gate / `decideStartupAction` startup matrix unchanged)
- [x] Happy-path behaviour change is **codex runtime only**: instead of using the ambient `codexThread` (cli.ts:1337 — still used for non-goal tasks), goal wakes now use per-goal threads via the helper. Operator-visible signal: `thread-rebuilt` progress entries on resume-fail.
- [x] DI testable end-to-end (Codex SDK fully mockable)
- [x] **Capture-rollback no-leak**: codex threads land in `~/.codex/sessions` on disk (durable, not in-memory). A goalStore.mutate failure after wake doesn't "leak" a thread — it stays in the codex session store and can be re-resumed later or pruned by codex itself.
- [x] **Rebuild context-safe**: wake prompt embeds goal text + last 5 progress entries so rebuilt threads continue from `progress_log`, no LLM-history dependency.

## Out of scope (queued)

- **P2**: grok-build-acp per-goal wake (same per-goal isolation pattern, different ACP protocol — grok currently still uses `processTask` for goal wakes; this preserves behaviour while P2 is designed)
- **P3**: commhub-server-side scheduler (北极星 — agent-node-restart resilient)

## Test plan

- [x] `bun test src/goals/` green (65 pass: 14 codex-wake + 28 scheduler + 23 parser)
- [x] `bun build src/cli.ts` produces a clean 82KB bundle
- [ ] Manual smoke (post-merge): docker codex node creates `/loop 每5分钟 ...`; observe first wake writes `codex_thread_id`; subsequent wakes resume same thread (`thread=<id>` log line stable); kill the underlying codex session out-of-band → next wake logs `thread-rebuilt` + writes new `codex_thread_id`; goal continues to make progress