### PR TITLE
feat(#179): Feishu channel for claude-agent-sdk runtime — RFC-020 first-cut [WIP]

### DIFF
--- a/agent-network/README.md
+++ b/agent-network/README.md
@@ -252,6 +252,7 @@ anet session ls
 
 # Channels and upgrades
 anet channel add telegram <name> --bot-token <tok> --allow <uid>
+anet channel add feishu   <name> --app-id <id> --app-secret <secret> --allow <open-id>   # see docs/feishu-quickstart.md
 anet channel ls
 anet upgrade
 anet upgrade --channel preview --dry-run

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1492,6 +1492,33 @@ function writeTelegramChannelConfig(nodeId: string, botToken: string, allowId: s
   return channelDir;
 }
 
+/**
+ * Feishu channel config writer (RFC-020 §5.2 — #179 M4).
+ * Mirrors writeTelegramChannelConfig but with the Feishu schema:
+ *   - .env: FEISHU_APP_ID + FEISHU_APP_SECRET (chmod 600, .gitignore'd)
+ *   - access.json: { allowFrom: [open_id, ...], allowChats: [chat_id, ...] }
+ */
+function writeFeishuChannelConfig(
+  nodeId: string,
+  appId: string,
+  appSecret: string,
+  allowOpenId: string,
+  allowChatId?: string,
+): string {
+  const channelDir = join(nodesDir(), nodeId, "channels", "feishu");
+  mkdirSync(channelDir, { recursive: true });
+
+  const envPath = join(channelDir, ".env");
+  writeFileSync(envPath, `FEISHU_APP_ID=${appId}\nFEISHU_APP_SECRET=${appSecret}\n`);
+  try { chmodSync(envPath, 0o600); } catch {}
+
+  writeFileSync(join(channelDir, "access.json"), JSON.stringify({
+    allowFrom: allowOpenId ? [allowOpenId] : [],
+    allowChats: allowChatId ? [allowChatId] : [],
+  }, null, 2) + "\n");
+  return channelDir;
+}
+
 async function askChoice<T extends string>(title: string, choices: { label: string; value: T; description?: string }[]): Promise<T> {
   closeRL();
   return await select<T>({
@@ -4690,27 +4717,34 @@ async function channelCommand() {
   const opts = parseOpts();
 
   if (sub === "add") {
-    const type = args[2]; // P0: telegram
+    const type = args[2];
     const nodeRef = args[3];
 
     if (!type || !nodeRef) {
       console.log(`
 anet channel add <type> <node-id> [options]
 
-Types:  telegram
+Types:  telegram, feishu
 
-Options:
-  --bot-token <token>   Bot token
-  --allow <user-id>     Allow user ID
+Options (telegram):
+  --bot-token <token>     Bot token
+  --allow <user-id>       Allow user ID
 
-Example:
+Options (feishu, RFC-020 #179):
+  --app-id <id>           Feishu app ID
+  --app-secret <secret>   Feishu app secret
+  --allow <open-id>       Allow Feishu open_id (DM)
+  --allow-chat <chat-id>  Allow Feishu chat_id (group, optional)
+
+Examples:
   anet channel add telegram 指挥室 --bot-token 123:ABC --allow <your-numeric-uid>
-  anet channel add telegram 指挥室     # 交互式
+  anet channel add feishu  指挥室 --app-id cli_xxx --app-secret yyy --allow ou_zzz
+  anet channel add feishu  指挥室                # 交互式
 `);
       return;
     }
-    if (type !== "telegram") {
-      console.error(`P0 only supports telegram channels. Unsupported type: ${type}`);
+    if (type !== "telegram" && type !== "feishu") {
+      console.error(`Unsupported channel type: ${type}. Supported: telegram, feishu`);
       process.exit(1);
     }
 
@@ -4723,20 +4757,47 @@ Example:
     }
     const storedProfile = loadStoredProfile(nodeId) || profile;
 
-    let botToken = opts["bot-token"];
-    let allowId = opts.allow;
-    if (!botToken) botToken = await ask(`${type} Bot Token`);
-    if (!allowId) allowId = await ask("Allow User ID (发 @userinfobot 获取数字ID)", "");
-    closeRL();
+    let channelDir: string;
 
-    if (!botToken || !allowId) {
-      console.error("Error: bot-token and allow required");
-      process.exit(1);
+    if (type === "telegram") {
+      let botToken = opts["bot-token"];
+      let allowId = opts.allow;
+      if (!botToken) botToken = await ask(`${type} Bot Token`);
+      if (!allowId) allowId = await ask("Allow User ID (发 @userinfobot 获取数字ID)", "");
+      closeRL();
+
+      if (!botToken || !allowId) {
+        console.error("Error: bot-token and allow required");
+        process.exit(1);
+      }
+
+      channelDir = writeTelegramChannelConfig(nodeId, botToken, allowId);
+      attachChannel(storedProfile, "telegram");
+    } else {
+      // type === "feishu" — RFC-020 §3.1 / §5.1 (#179)
+      let appId = opts["app-id"];
+      let appSecret = opts["app-secret"];
+      let allowOpenId = opts.allow;
+      const allowChatId = opts["allow-chat"] || "";
+
+      if (!appId) appId = await ask("Feishu App ID (开放平台「企业自建应用」凭证)");
+      if (!appSecret) appSecret = await ask("Feishu App Secret");
+      if (!allowOpenId) allowOpenId = await ask("Allow Feishu open_id (DM 白名单，可空)", "");
+      closeRL();
+
+      if (!appId || !appSecret) {
+        console.error("Error: --app-id and --app-secret required");
+        process.exit(1);
+      }
+      if (!allowOpenId && !allowChatId) {
+        console.error("Error: at least one of --allow <open-id> or --allow-chat <chat-id> required");
+        process.exit(1);
+      }
+
+      channelDir = writeFeishuChannelConfig(nodeId, appId, appSecret, allowOpenId, allowChatId);
+      attachChannel(storedProfile, "feishu");
     }
 
-    const channelDir = writeTelegramChannelConfig(nodeId, botToken, allowId);
-
-    attachChannel(storedProfile, "telegram");
     await ensureNodeToken(storedProfile, nodeId);
     saveProfile(nodeId, storedProfile);
 

--- a/agent-network/docs/feishu-quickstart.md
+++ b/agent-network/docs/feishu-quickstart.md
@@ -1,0 +1,118 @@
+# 飞书 channel quickstart（claude-agent-sdk runtime）
+
+把 anet 节点接上飞书，让飞书用户跟 agent 直接对话。对应 [RFC-020](../../docs/rfcs/RFC-020-im-platform-integration.md) 的第一刀 / GitHub issue [#179](https://github.com/sleep2agi/agent-network/issues/179)。
+
+> **状态（v0.13 alpha）**：claude-agent-sdk runtime 私聊 + 群 @bot 收发文本与图片可用。完整 commhub-gateway / Dashboard 透传是后续 PR。
+
+## 前置
+
+1. **飞书自建应用**：在 [开放平台](https://open.feishu.cn) 建一个「企业自建应用」，启用机器人能力。
+2. **权限**（应用能力 → 权限管理）：`im:message:send_as_bot`、`im:message`、`im:resource`。
+3. **事件订阅**：选 **WebSocket 模式**，订阅 `im.message.receive_v1`（仅此一个）。
+4. **发布版本** + 等管理员 approve。无需公网 IP、无需 webhook URL、无需 Encrypt Key。
+5. 复制 **App ID** + **App Secret**（凭证 & 基本信息页）。
+
+## 安装 + 绑定
+
+需要 anet 节点已存在；如未创建：
+
+```bash
+anet node create <node-name> --runtime claude-agent-sdk
+```
+
+绑定飞书 channel：
+
+```bash
+anet channel add feishu <node-name> \
+  --app-id   cli_xxxxxxxxxxxxxx \
+  --app-secret yyyyyyyyyyyyyyyyy \
+  --allow    ou_<your-open-id>            # 允许私聊的 open_id
+  --allow-chat oc_<group-chat-id>         # 可选：允许群聊的 chat_id
+```
+
+不带 flags 进交互模式：
+
+```bash
+anet channel add feishu <node-name>
+```
+
+写入 `.anet/nodes/<node-name>/channels/feishu/`：
+
+| 文件 | 内容 |
+|---|---|
+| `.env` (chmod 600) | `FEISHU_APP_ID` + `FEISHU_APP_SECRET` |
+| `access.json` | `{allowFrom: [open_id], allowChats: [chat_id]}` |
+
+## 启动
+
+```bash
+anet node start <node-name>
+```
+
+agent-node 启动时检测 `channels: ["feishu", ...]` → fork 飞书 bridge worker（独立子进程，通过 IPC 跟 agent-node 通信）→ bridge 跟飞书建 WebSocket 长连接。
+
+确认 worker 路径：默认走 `dist/src/im/feishu/worker.js`（agent-network 安装后即有）。如需覆盖：
+
+```bash
+export ANET_FEISHU_WORKER_PATH=/path/to/your/worker.js
+```
+
+启动 log 应出现：
+
+```
+[agent-node] channels: feishu(/path/.anet/nodes/<node-name>/channels/feishu)
+[agent-node] [feishu] forked worker (pid 12345) for ... via ...
+[feishu:worker] bridge online — node=<node-name> dir=... ipc=yes
+```
+
+## 触发策略
+
+- **私聊**：`sender.open_id ∈ allowFrom` → 触发。
+- **群聊**：默认 `groupPolicy: mention` —— 只有 **@bot** 才触发，普通群消息忽略（防群噪音）。`@bot` 通过比对 `mentions[].id.open_id` 与 bot 自己的 `open_id`（init 时通过 `/open-apis/bot/v3/info` 拉取）。
+- **线程**：bot 回复跟着 `root_id` 进原线程，不污染主频道。
+
+## 出站
+
+- 文本：`adapter.send` 调 `im.message.create`（DM 用 `open_id`，群用 `chat_id`）；存在 `replyToMessageId` / `threadRootId` 则走 `im.message.reply` 保留线程上下文。
+- 编辑：`adapter.edit` 调 `im.message.update`（飞书单条消息可编辑 ≤20 次，用于把"⏳ 处理中…"占位提升为正式回复）。
+- 图片：传 `imagePath` → 先 `im.image.create` 上传拿 `image_key` → `msg_type: "image"` 发送。
+
+## 故障排查
+
+| 现象 | 排查 |
+|---|---|
+| 节点启动报 `unsupported channel: feishu` | agent-node 版本太老，升级到含本 PR 的版本 |
+| `[feishu] worker path not found` warn | 设 `ANET_FEISHU_WORKER_PATH`，或确认 `@sleep2agi/agent-network` 已安装 + 编译 |
+| WSClient 连不上飞书 | App 未 approve / 凭证写错 / 网络问题 — bridge 会自动重连，看 stderr |
+| 群里 @bot 不响应 | 1) bot 已加群且有发言权限 2) `access.json` `allowChats` 含目标 chat_id 3) `/open-apis/bot/v3/info` 是否返回有效 open_id |
+| 收到回复是 "agent-node M5a placeholder…" | 当前 v0.13 alpha 是 M5a 占位；M5b 替换为真 think() 集成（未 ship 时） |
+
+## 已知限制（第一刀 scope）
+
+- **不进 Dashboard 拓扑** —— 飞书消息不走 commhub task 路径，Dashboard 看不见。完整 commhub-gateway（RFC-020 §2.9 schema 增量）是收尾 PR。
+- **agent 不能任意主动推飞书** —— 仅响应入站消息。主动推（`anet im send`）排在 P1.5（RFC §12.9）。
+- **仅 claude-agent-sdk runtime** —— claude-code-cli 仍用社区 plugin；codex-sdk / grok-build-acp 后续。
+
+## E2E smoke checklist（测试派单用）
+
+> 测试一律 Docker mock + 派测试号（[[feedback_no_host_test_nodes]] / [[feedback_delegate_testing]]），不连本机 hub、不碰生产 db。Vincent 凭证活体 E2E 由通信龙调度。
+
+- [ ] **L0 环境** — Docker 容器内安装 `@sleep2agi/agent-network` + `@sleep2agi/agent-node`；mock 飞书 WSClient server 可达。
+- [ ] **L1 配置** — `anet channel add feishu <test-node>` 落盘 `.env` + `access.json`，`.env` 权限 = 600，`config.json` `channels` 含 `"feishu"`。
+- [ ] **L2 启动** — `anet node start <test-node>`，log 出现 `[feishu] forked worker (pid …)` + `bridge online`。
+- [ ] **L3 入站文本（DM 白名单内）** — mock 发 `im.message.receive_v1` 私聊文本 → bridge log 收到事件 → agent-node parent log 收到 IPC envelope → 占位回复（M5a 占位 / M5b real reply）回到 mock 发送侧。
+- [ ] **L4 入站群 @bot** — mock 发群消息含 mentions[].id.open_id = bot 自身 → 触发；群消息**不** @ bot → ignore。
+- [ ] **L5 入站图片** — mock 发 image 消息 → `<channel-dir>/media/img_*.png` 落盘 → `event.content.images = [path]`。
+- [ ] **L6 白名单拒绝** — 非白名单 open_id 私聊 → bridge stderr 出 `[feishu:audit] deny from=... — not in allowFrom / allowChats`，不派 IPC。
+- [ ] **L7 重连** — mock 断开 WebSocket → bridge 报错 + 自动重连（lark SDK 内置）。
+- [ ] **L8 worker 崩溃** — kill bridge worker 进程 → agent-node `[feishu] worker exited code=...` warn，不影响其它 channel。
+- [ ] **L9 出站文本** — agent-node 通过 IPC 发 reply → bridge `adapter.send` → mock 收到 `im.message.create` 调用。
+- [ ] **L10 出站图片** — agent-node 派带 imagePath 的 reply → bridge upload → `im.message.create` 用 `msg_type: image`。
+
+## 参考
+
+- [RFC-020 IM 兼容层](../../docs/rfcs/RFC-020-im-platform-integration.md)
+- [RFC-002 channel-bind-cli](../../docs/rfcs/RFC-002-channel-bind-cli.md)（telegram-bridge 模式前身）
+- [issue #179](https://github.com/sleep2agi/agent-network/issues/179)（父 RFC）
+- [issue #182](https://github.com/sleep2agi/agent-network/issues/182)（P0 tracker / 后续 commhub schema 增量）
+- 社区 [`vansin/claude-code-feishu-channel`](https://github.com/vansin/claude-code-feishu-channel)（SDK 调用层 prior art，RFC §12.6 决策复用）

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.2.12",
+  "version": "2.2.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.2.12",
+      "version": "2.2.21",
       "license": "Apache-2.0",
       "dependencies": {
-        "@inquirer/prompts": "^8.4.3"
+        "@inquirer/prompts": "^8.4.3",
+        "@larksuiteoapi/node-sdk": "^1.42.0"
       },
       "bin": {
         "anet": "dist/bin/cli.js"
@@ -424,6 +425,21 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/@larksuiteoapi/node-sdk": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.67.0.tgz",
+      "integrity": "sha512-pr3iZbK+CkwgwIhUzt86mZGP/wLCzBDRmCy+Vt+/UAWx/KjwxwrRpfAKm4eOmd0uUd8AcG2mWC/ZSUMu7lZIqg==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "~1.13.3",
+        "lodash.identity": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.pickby": "^4.6.0",
+        "protobufjs": "^7.2.6",
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -465,6 +481,63 @@
         }
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -474,7 +547,6 @@
     },
     "node_modules/@types/node": {
       "version": "25.5.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -644,6 +716,12 @@
         "retry": "0.13.1"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -658,6 +736,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -736,7 +825,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -750,7 +838,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -849,6 +936,18 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -1015,6 +1114,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1029,7 +1137,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -1077,7 +1184,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1087,7 +1193,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1097,10 +1202,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1363,6 +1482,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -1377,6 +1516,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -1403,7 +1591,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1423,7 +1610,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -1448,7 +1634,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -1462,7 +1647,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1498,7 +1682,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1511,7 +1694,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -1527,7 +1709,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1872,11 +2053,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.identity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2042,7 +2246,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2210,6 +2413,29 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2224,11 +2450,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2431,7 +2662,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2451,7 +2681,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2468,7 +2697,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -2487,7 +2715,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -2648,7 +2875,6 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -2749,6 +2975,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -63,7 +63,8 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@inquirer/prompts": "^8.4.3"
+    "@inquirer/prompts": "^8.4.3",
+    "@larksuiteoapi/node-sdk": "^1.42.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "bun build src/client.ts --outdir dist/src --target node --minify && bun build bin/cli.ts --outdir dist/bin --target node --minify --external @sleep2agi/commhub-server --external bun:sqlite --external '../../server/*' && bun build src/node-server.ts --outdir dist/src --target node --minify --external @modelcontextprotocol/sdk && tsc --emitDeclarationOnly --declaration --outDir dist && npx javascript-obfuscator dist/bin/cli.js --output dist/bin/cli.js --compact true --string-array true --string-array-encoding base64 && npx javascript-obfuscator dist/src/client.js --output dist/src/client.js --compact true --string-array true && npx javascript-obfuscator dist/src/node-server.js --output dist/src/node-server.js --compact true --string-array true",
+    "build": "bun build src/client.ts --outdir dist/src --target node --minify && bun build bin/cli.ts --outdir dist/bin --target node --minify --external @sleep2agi/commhub-server --external bun:sqlite --external '../../server/*' && bun build src/node-server.ts --outdir dist/src --target node --minify --external @modelcontextprotocol/sdk && bun build src/im/feishu/worker.ts --outdir dist/src/im/feishu --target node --minify --external @larksuiteoapi/node-sdk && tsc --emitDeclarationOnly --declaration --outDir dist && npx javascript-obfuscator dist/bin/cli.js --output dist/bin/cli.js --compact true --string-array true --string-array-encoding base64 && npx javascript-obfuscator dist/src/client.js --output dist/src/client.js --compact true --string-array true && npx javascript-obfuscator dist/src/node-server.js --output dist/src/node-server.js --compact true --string-array true",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -7,14 +7,15 @@
  * not in WSClient mode.
  *
  * Milestones:
- *   M1 (this file): contract scaffold — implements IMAdapter signature with
- *                   TODO stubs so subsequent milestones can fill behavior.
- *   M2:  WSClient init + EventDispatcher for `im.message.receive_v1` +
- *        normalize raw events to NormalizedIMEvent + access whitelist gate.
- *   M3:  outbound `im.message.create` (text), edit support (≤20/msg), think()
- *        bridge handoff.
- *   M5:  image upload/download (`im.image.create` / `im.messageResource.get`).
+ *   M1: contract scaffold.
+ *   M2 (this file): WSClient init + EventDispatcher for `im.message.receive_v1`
+ *                   + event normalization + access whitelist gate + audit log.
+ *   M3: outbound `im.message.create` (text), edit support (≤20/msg).
+ *   M5: image upload / download (`im.image.create` / `im.messageResource.get`)
+ *       + group @bot detection refined to match the bot's own open_id.
  */
+import * as lark from "@larksuiteoapi/node-sdk";
+
 import type {
   IMAdapter,
   IMAdapterHealth,
@@ -24,47 +25,96 @@ import type {
   NormalizedIMEvent,
   NormalizedIMMessage,
 } from "../types.js";
-import type { FeishuChannelConfig } from "./config.js";
+import type { FeishuAccessList, FeishuChannelConfig } from "./config.js";
+
+type OnEventHandler = (event: NormalizedIMEvent) => Promise<void>;
 
 export class FeishuAdapter implements IMAdapter {
   readonly platform = "feishu";
   readonly ingressMode: IMIngressMode = "socket";
 
   private feishuConfig: FeishuChannelConfig | null = null;
+  private connectionName = "";
+  private client: lark.Client | null = null;
+  private wsClient: lark.WSClient | null = null;
+
   private health_: IMAdapterHealth = {
     connected: false,
     lastEventAt: null,
     lastError: null,
   };
 
-  async init(_config: IMChannelConfig): Promise<void> {
-    // M2: extract FeishuChannelConfig from _config.platformConfig
-    // M2: const client = new lark.Client({ appId, appSecret, disableTokenCache: false })
-    throw new Error("FeishuAdapter.init: pending M2 (WSClient wiring)");
+  async init(config: IMChannelConfig): Promise<void> {
+    if (config.platform !== "feishu") {
+      throw new Error(
+        `FeishuAdapter.init: expected platform "feishu", got "${config.platform}"`,
+      );
+    }
+    const fc = config.platformConfig as Partial<FeishuChannelConfig> | undefined;
+    if (!fc?.appId || !fc?.appSecret) {
+      throw new Error(
+        "FeishuAdapter.init: appId / appSecret missing in platformConfig",
+      );
+    }
+    this.feishuConfig = fc as FeishuChannelConfig;
+    this.connectionName = config.connectionName;
+    this.client = new lark.Client({
+      appId: fc.appId,
+      appSecret: fc.appSecret,
+      disableTokenCache: false,
+    });
   }
 
-  async start(
-    _onEvent: (event: NormalizedIMEvent) => Promise<void>,
-  ): Promise<void> {
-    // M2: const ws = new lark.WSClient({ appId, appSecret, loggerLevel: WARN })
-    // M2: const dispatcher = new lark.EventDispatcher({}).register({
-    //       "im.message.receive_v1": handler that normalizes → access-check → onEvent
-    //     })
-    // M2: await ws.start({ eventDispatcher: dispatcher })
-    throw new Error("FeishuAdapter.start: pending M2 (WSClient + EventDispatcher)");
+  async start(onEvent: OnEventHandler): Promise<void> {
+    if (!this.feishuConfig || !this.client) {
+      throw new Error("FeishuAdapter.start: call init() first");
+    }
+    const { appId, appSecret, access } = this.feishuConfig;
+    const connectionName = this.connectionName;
+
+    const dispatcher = new lark.EventDispatcher({});
+    dispatcher.register({
+      "im.message.receive_v1": async (rawEvent: unknown): Promise<unknown> => {
+        try {
+          this.health_ = { ...this.health_, lastEventAt: Date.now() };
+          const normalized = normalizeMessageEvent(rawEvent, connectionName);
+          if (!normalized) return; // unsupported message_type
+          if (!isAccessAllowed(normalized, access)) {
+            auditLog("deny", normalized, "not in allowFrom / allowChats");
+            return;
+          }
+          await onEvent(normalized);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.health_ = { ...this.health_, lastError: msg };
+          auditLog("error", null, msg);
+        }
+      },
+    });
+
+    this.wsClient = new lark.WSClient({
+      appId,
+      appSecret,
+      loggerLevel: lark.LoggerLevel.warn,
+    });
+
+    await this.wsClient.start({ eventDispatcher: dispatcher });
+    this.health_ = { ...this.health_, connected: true, lastError: null };
   }
 
   async stop(): Promise<void> {
-    // M2: graceful WSClient teardown.
+    // Lark SDK does not expose a public close on WSClient (as of 1.42); allow
+    // GC + mark health for callers. Worker process exit drops the connection.
     this.health_ = { ...this.health_, connected: false };
+    this.wsClient = null;
+    this.client = null;
+    this.feishuConfig = null;
   }
 
-  async send(
-    _message: NormalizedIMMessage,
-  ): Promise<{ messageId: string }> {
+  async send(_message: NormalizedIMMessage): Promise<{ messageId: string }> {
     // M3: client.im.message.create({
     //       params: { receive_id_type: dm ? "open_id" : "chat_id" },
-    //       data: { receive_id, msg_type: "text"|"image"|..., content: JSON.stringify({...}) }
+    //       data: { receive_id, msg_type, content }
     //     })
     throw new Error("FeishuAdapter.send: pending M3 (im.message.create wiring)");
   }
@@ -82,4 +132,127 @@ export class FeishuAdapter implements IMAdapter {
   health(): IMAdapterHealth {
     return { ...this.health_ };
   }
+}
+
+// ── Internals: event normalization (RFC-020 §2.3) ────────────────────────
+
+interface FeishuRawMessage {
+  message_id: string;
+  message_type: string;
+  content: string;
+  chat_id: string;
+  chat_type: "p2p" | "group";
+  mentions?: Array<{ key: string; id: { open_id: string }; name: string }>;
+  root_id?: string;
+  create_time?: string;
+}
+
+interface FeishuRawSender {
+  sender_id?: { open_id?: string; union_id?: string; user_id?: string };
+  sender_type?: string;
+  tenant_key?: string;
+}
+
+interface FeishuRawEvent {
+  message?: FeishuRawMessage;
+  sender?: FeishuRawSender;
+}
+
+/**
+ * Translate raw `im.message.receive_v1` payload into NormalizedIMEvent.
+ * Returns null for unsupported message types so the caller skips them.
+ *
+ * `mentioned` is detected naively in M2 as `mentions.length > 0`. M5 refines
+ * by comparing each mention's `id.open_id` against the bot's own open_id
+ * (requires an API round-trip at init time to resolve the bot identity).
+ */
+function normalizeMessageEvent(
+  raw: unknown,
+  connectionName: string,
+): NormalizedIMEvent | null {
+  const event = raw as FeishuRawEvent | undefined;
+  const message = event?.message;
+  const sender = event?.sender;
+  const openId = sender?.sender_id?.open_id;
+  if (!message || !openId) return null;
+
+  let text: string | undefined;
+  if (message.message_type === "text") {
+    try {
+      text = (JSON.parse(message.content) as { text?: string }).text;
+    } catch {
+      text = message.content;
+    }
+  } else if (message.message_type === "file") {
+    try {
+      const parsed = JSON.parse(message.content) as { file_name?: string };
+      text = `[文件: ${parsed.file_name ?? "unknown"}]`;
+    } catch {
+      text = "[文件]";
+    }
+  } else if (message.message_type === "sticker") {
+    text = "[表情]";
+  } else if (message.message_type === "image") {
+    // M5: download via im.messageResource.get + populate content.images.
+    text = undefined;
+  } else {
+    // unsupported types (audio / video / post / share_chat / ...) — skip
+    return null;
+  }
+
+  const conversationType: "dm" | "group" =
+    message.chat_type === "group" ? "group" : "dm";
+  const mentioned =
+    Array.isArray(message.mentions) && message.mentions.length > 0;
+  const connectionId = `${connectionName}#feishu`;
+
+  return {
+    platform: "feishu",
+    connectionId,
+    tenantId: sender?.tenant_key,
+    conversation: {
+      platform: "feishu",
+      conversationId: message.chat_id,
+      conversationType,
+      threadRootId: message.root_id,
+    },
+    sender: { id: openId },
+    messageId: message.message_id,
+    mentioned,
+    content: text ? { text } : {},
+    receivedAt: Date.now(),
+    // RFC-020 §4.4: `${platform}:${connectionId}:${messageId}`
+    idempotencyKey: `feishu:${connectionId}:${message.message_id}`,
+  };
+}
+
+// ── Internals: access whitelist (RFC-020 §4.1 / §5.1) ────────────────────
+
+function isAccessAllowed(
+  event: NormalizedIMEvent,
+  access: FeishuAccessList,
+): boolean {
+  if (access.allowFrom.includes(event.sender.id)) return true;
+  if (
+    event.conversation.conversationType === "group" &&
+    access.allowChats.includes(event.conversation.conversationId)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function auditLog(
+  verdict: "allow" | "deny" | "error",
+  event: NormalizedIMEvent | null,
+  reason: string,
+): void {
+  const ts = new Date().toISOString();
+  const conv = event
+    ? `${event.conversation.conversationType}:${event.conversation.conversationId}`
+    : "?";
+  const from = event ? event.sender.id : "?";
+  process.stderr.write(
+    `[${ts}] [feishu:audit] ${verdict} from=${from} conv=${conv} — ${reason}\n`,
+  );
 }

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -15,6 +15,10 @@
  *       + group @bot detection refined to match the bot's own open_id.
  */
 import * as lark from "@larksuiteoapi/node-sdk";
+import crypto from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Readable } from "node:stream";
 
 import type {
   IMAdapter,
@@ -44,6 +48,8 @@ export class FeishuAdapter implements IMAdapter {
    * naive `mentions.length > 0` check.
    */
   private botOpenId: string | null = null;
+  /** Where to persist downloaded inbound media (M5c). */
+  private mediaDir: string | null = null;
 
   private health_: IMAdapterHealth = {
     connected: false,
@@ -74,6 +80,10 @@ export class FeishuAdapter implements IMAdapter {
     // open_id. Failure degrades the check to naive `mentions.length > 0`
     // — we still want the bridge to start.
     this.botOpenId = await fetchBotOpenId(this.client);
+    // Configure the media drop-zone for inbound image downloads. If the
+    // config did not carry a channelDir, image downloads are disabled but
+    // text flow is unaffected.
+    this.mediaDir = fc.channelDir ? join(fc.channelDir, "media") : null;
   }
 
   async start(onEvent: OnEventHandler): Promise<void> {
@@ -83,6 +93,8 @@ export class FeishuAdapter implements IMAdapter {
     const { appId, appSecret, access } = this.feishuConfig;
     const connectionName = this.connectionName;
     const botOpenId = this.botOpenId;
+    const mediaDir = this.mediaDir;
+    const client = this.client;
 
     const dispatcher = new lark.EventDispatcher({});
     dispatcher.register({
@@ -91,6 +103,11 @@ export class FeishuAdapter implements IMAdapter {
           this.health_ = { ...this.health_, lastEventAt: Date.now() };
           const normalized = normalizeMessageEvent(rawEvent, connectionName, botOpenId);
           if (!normalized) return; // unsupported message_type
+
+          // M5c: attach downloaded image paths for image-type messages.
+          // Failure-tolerant — text flow proceeds even when download fails.
+          await maybeAttachImages(rawEvent, normalized, client, mediaDir);
+
           if (!isAccessAllowed(normalized, access)) {
             auditLog("deny", normalized, "not in allowFrom / allowChats");
             return;
@@ -127,14 +144,30 @@ export class FeishuAdapter implements IMAdapter {
     if (!this.client) {
       throw new Error("FeishuAdapter.send: call init() first");
     }
-    const text = message.text ?? message.markdown;
-    if (!text) {
-      // M5 will add image / file / card variants.
-      throw new Error(
-        "FeishuAdapter.send: M3 supports text only (image/card land in M5)",
-      );
+
+    // Decide payload — image takes precedence when imagePath is provided
+    // (caller's choice), otherwise text/markdown.
+    let msgType: "text" | "image";
+    let content: string;
+    if (message.imagePath) {
+      const imageKey = await uploadImage(this.client, message.imagePath);
+      if (!imageKey) {
+        throw new Error(
+          `FeishuAdapter.send: image upload failed for ${message.imagePath}`,
+        );
+      }
+      msgType = "image";
+      content = JSON.stringify({ image_key: imageKey });
+    } else {
+      const text = message.text ?? message.markdown;
+      if (!text) {
+        throw new Error(
+          "FeishuAdapter.send: requires text, markdown, or imagePath",
+        );
+      }
+      msgType = "text";
+      content = JSON.stringify({ text });
     }
-    const content = JSON.stringify({ text });
 
     // Threaded reply when the message references an upstream message_id.
     // im.message.reply preserves the thread context (Feishu root_id).
@@ -142,7 +175,7 @@ export class FeishuAdapter implements IMAdapter {
     if (replyTo) {
       const resp = await this.client.im.message.reply({
         path: { message_id: replyTo },
-        data: { msg_type: "text", content },
+        data: { msg_type: msgType, content },
       });
       const messageId = resp?.data?.message_id;
       if (!messageId) {
@@ -157,7 +190,7 @@ export class FeishuAdapter implements IMAdapter {
       params: { receive_id_type },
       data: {
         receive_id: message.target.conversationId,
-        msg_type: "text",
+        msg_type: msgType,
         content,
       },
     });
@@ -290,6 +323,95 @@ function normalizeMessageEvent(
     // RFC-020 §4.4: `${platform}:${connectionId}:${messageId}`
     idempotencyKey: `feishu:${connectionId}:${message.message_id}`,
   };
+}
+
+// ── Internals: image up/down (RFC-020 §3.1 / #179 M5c) ──────────────────
+
+/**
+ * Best-effort: when the inbound message is an image, download it via
+ * `im.messageResource.get` and attach the local file path to `event.content
+ * .images`. Failure is non-fatal — the text flow proceeds and the event
+ * carries an empty images array.
+ *
+ * `mediaDir` of null disables downloads (e.g. when the channel config didn't
+ * carry a channelDir). `client` of null does the same.
+ */
+async function maybeAttachImages(
+  rawEvent: unknown,
+  normalized: NormalizedIMEvent,
+  client: lark.Client | null,
+  mediaDir: string | null,
+): Promise<void> {
+  if (!client || !mediaDir) return;
+  const raw = rawEvent as FeishuRawEvent | undefined;
+  const message = raw?.message;
+  if (!message || message.message_type !== "image") return;
+  let imageKey: string | undefined;
+  try {
+    imageKey = (JSON.parse(message.content) as { image_key?: string }).image_key;
+  } catch {
+    return;
+  }
+  if (!imageKey || !message.message_id) return;
+  const localPath = await downloadImage(
+    client,
+    message.message_id,
+    imageKey,
+    mediaDir,
+  );
+  if (localPath) {
+    normalized.content = { ...normalized.content, images: [localPath] };
+  }
+}
+
+async function downloadImage(
+  client: lark.Client,
+  messageId: string,
+  imageKey: string,
+  mediaDir: string,
+): Promise<string | null> {
+  try {
+    const resp = await client.im.messageResource.get({
+      path: { message_id: messageId, file_key: imageKey },
+      params: { type: "image" },
+    });
+    if (!resp) return null;
+    const stream = resp as unknown as Readable;
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+      stream.on("end", () => resolve());
+      stream.on("error", (err: Error) => reject(err));
+    });
+    mkdirSync(mediaDir, { recursive: true });
+    const filename = `img_${Date.now()}_${crypto.randomBytes(4).toString("hex")}.png`;
+    const filepath = join(mediaDir, filename);
+    writeFileSync(filepath, Buffer.concat(chunks));
+    return filepath;
+  } catch {
+    return null;
+  }
+}
+
+async function uploadImage(
+  client: lark.Client,
+  imagePath: string,
+): Promise<string | null> {
+  try {
+    if (!existsSync(imagePath)) return null;
+    const buf = readFileSync(imagePath);
+    const stream = Readable.from(buf);
+    const resp = await client.im.image.create({
+      data: {
+        image_type: "message",
+        // lark's typing wants a Readable but the runtime accepts any Readable.
+        image: stream as unknown as never,
+      },
+    });
+    return resp?.image_key ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // ── Internals: bot identity resolution (RFC-020 §4.3 / #179 M5b) ────────

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -37,6 +37,13 @@ export class FeishuAdapter implements IMAdapter {
   private connectionName = "";
   private client: lark.Client | null = null;
   private wsClient: lark.WSClient | null = null;
+  /**
+   * The bot's own open_id, resolved at init() via /open-apis/bot/v3/info.
+   * Used to detect real @bot mentions (vs any mention) in group messages.
+   * Falls back to null on lookup failure — `mentioned` then degrades to the
+   * naive `mentions.length > 0` check.
+   */
+  private botOpenId: string | null = null;
 
   private health_: IMAdapterHealth = {
     connected: false,
@@ -63,6 +70,10 @@ export class FeishuAdapter implements IMAdapter {
       appSecret: fc.appSecret,
       disableTokenCache: false,
     });
+    // Resolve bot identity so group @ detection compares against the real
+    // open_id. Failure degrades the check to naive `mentions.length > 0`
+    // — we still want the bridge to start.
+    this.botOpenId = await fetchBotOpenId(this.client);
   }
 
   async start(onEvent: OnEventHandler): Promise<void> {
@@ -71,13 +82,14 @@ export class FeishuAdapter implements IMAdapter {
     }
     const { appId, appSecret, access } = this.feishuConfig;
     const connectionName = this.connectionName;
+    const botOpenId = this.botOpenId;
 
     const dispatcher = new lark.EventDispatcher({});
     dispatcher.register({
       "im.message.receive_v1": async (rawEvent: unknown): Promise<unknown> => {
         try {
           this.health_ = { ...this.health_, lastEventAt: Date.now() };
-          const normalized = normalizeMessageEvent(rawEvent, connectionName);
+          const normalized = normalizeMessageEvent(rawEvent, connectionName, botOpenId);
           if (!normalized) return; // unsupported message_type
           if (!isAccessAllowed(normalized, access)) {
             auditLog("deny", normalized, "not in allowFrom / allowChats");
@@ -212,13 +224,15 @@ interface FeishuRawEvent {
  * Translate raw `im.message.receive_v1` payload into NormalizedIMEvent.
  * Returns null for unsupported message types so the caller skips them.
  *
- * `mentioned` is detected naively in M2 as `mentions.length > 0`. M5 refines
- * by comparing each mention's `id.open_id` against the bot's own open_id
- * (requires an API round-trip at init time to resolve the bot identity).
+ * `mentioned` precision: when `botOpenId` is non-null (resolved at init via
+ * /open-apis/bot/v3/info, M5b) the function compares mentions[].id.open_id
+ * to the bot's actual open_id. When null (init lookup failed), it falls back
+ * to the M2 naive check `mentions.length > 0` so the bridge still functions.
  */
 function normalizeMessageEvent(
   raw: unknown,
   connectionName: string,
+  botOpenId: string | null,
 ): NormalizedIMEvent | null {
   const event = raw as FeishuRawEvent | undefined;
   const message = event?.message;
@@ -252,8 +266,10 @@ function normalizeMessageEvent(
 
   const conversationType: "dm" | "group" =
     message.chat_type === "group" ? "group" : "dm";
-  const mentioned =
-    Array.isArray(message.mentions) && message.mentions.length > 0;
+  const mentions = Array.isArray(message.mentions) ? message.mentions : [];
+  const mentioned = botOpenId
+    ? mentions.some((m) => m?.id?.open_id === botOpenId)
+    : mentions.length > 0;
   const connectionId = `${connectionName}#feishu`;
 
   return {
@@ -274,6 +290,27 @@ function normalizeMessageEvent(
     // RFC-020 §4.4: `${platform}:${connectionId}:${messageId}`
     idempotencyKey: `feishu:${connectionId}:${message.message_id}`,
   };
+}
+
+// ── Internals: bot identity resolution (RFC-020 §4.3 / #179 M5b) ────────
+
+/**
+ * Resolve the bot's own open_id via the Feishu /open-apis/bot/v3/info endpoint.
+ * Returns null on failure so the adapter can degrade to naive mention
+ * detection rather than refusing to start.
+ */
+async function fetchBotOpenId(client: lark.Client): Promise<string | null> {
+  try {
+    const resp = (await client.request({
+      method: "GET",
+      url: "/open-apis/bot/v3/info",
+    })) as unknown;
+    // Lark's untyped request envelope; bot info lives at .bot.open_id.
+    const r = resp as { bot?: { open_id?: string }; data?: { bot?: { open_id?: string } } };
+    return r?.bot?.open_id ?? r?.data?.bot?.open_id ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // ── Internals: access whitelist (RFC-020 §4.1 / §5.1) ────────────────────

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -90,7 +90,7 @@ export class FeishuAdapter implements IMAdapter {
     if (!this.feishuConfig || !this.client) {
       throw new Error("FeishuAdapter.start: call init() first");
     }
-    const { appId, appSecret, access } = this.feishuConfig;
+    const { appId, appSecret, access, groupPolicy } = this.feishuConfig;
     const connectionName = this.connectionName;
     const botOpenId = this.botOpenId;
     const mediaDir = this.mediaDir;
@@ -108,8 +108,9 @@ export class FeishuAdapter implements IMAdapter {
           // Failure-tolerant — text flow proceeds even when download fails.
           await maybeAttachImages(rawEvent, normalized, client, mediaDir);
 
-          if (!isAccessAllowed(normalized, access)) {
-            auditLog("deny", normalized, "not in allowFrom / allowChats");
+          const verdict = checkAccess(normalized, access, groupPolicy);
+          if (!verdict.allow) {
+            auditLog("deny", normalized, verdict.reason);
             return;
           }
           await onEvent(normalized);
@@ -435,20 +436,47 @@ async function fetchBotOpenId(client: lark.Client): Promise<string | null> {
   }
 }
 
-// ── Internals: access whitelist (RFC-020 §4.1 / §5.1) ────────────────────
+// ── Internals: access whitelist (RFC-020 §4.1 / §4.3 / §5.1) ─────────────
 
-function isAccessAllowed(
+/**
+ * Two-stage access check (RFC-020 §4.3 — 通信牛 review 必改1):
+ *   1. Whitelist gate: sender or chat must be in the configured allowlist.
+ *   2. Group policy gate: in non-DM conversations, the configured groupPolicy
+ *      decides whether to trigger even when whitelisted.
+ *        - "all"      → trigger on every whitelisted-chat message
+ *        - "mention"  → require event.mentioned (default; M5b real bot open_id match)
+ *        - "command"  → reserved for slash-prefix triggers; behaves as "mention"
+ *                       until a command parser lands. TODO post-M5.
+ *        - "observe"  → never trigger (chat is whitelisted for sidecar visibility
+ *                       only — keeps the door open for future audit / Dashboard)
+ *
+ * Returns { allow, reason } so the audit log surfaces *why* a message was denied
+ * (helps Vincent triage "I sent a message and got nothing" cases).
+ */
+function checkAccess(
   event: NormalizedIMEvent,
   access: FeishuAccessList,
-): boolean {
-  if (access.allowFrom.includes(event.sender.id)) return true;
-  if (
-    event.conversation.conversationType === "group" &&
-    access.allowChats.includes(event.conversation.conversationId)
-  ) {
-    return true;
+  groupPolicy: FeishuChannelConfig["groupPolicy"],
+): { allow: boolean; reason: string } {
+  if (event.conversation.conversationType === "dm") {
+    return access.allowFrom.includes(event.sender.id)
+      ? { allow: true, reason: "" }
+      : { allow: false, reason: "sender not in allowFrom (dm)" };
   }
-  return false;
+  // group / channel / thread share the same whitelist + policy semantics.
+  if (!access.allowChats.includes(event.conversation.conversationId)) {
+    return { allow: false, reason: "chat not in allowChats" };
+  }
+  if (groupPolicy === "all") return { allow: true, reason: "" };
+  if (groupPolicy === "observe") {
+    return { allow: false, reason: "groupPolicy=observe — chat in allowChats but no trigger" };
+  }
+  // mention | command
+  if (event.mentioned) return { allow: true, reason: "" };
+  return {
+    allow: false,
+    reason: `groupPolicy=${groupPolicy} requires @bot mention (not mentioned)`,
+  };
 }
 
 function auditLog(

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -111,22 +111,72 @@ export class FeishuAdapter implements IMAdapter {
     this.feishuConfig = null;
   }
 
-  async send(_message: NormalizedIMMessage): Promise<{ messageId: string }> {
-    // M3: client.im.message.create({
-    //       params: { receive_id_type: dm ? "open_id" : "chat_id" },
-    //       data: { receive_id, msg_type, content }
-    //     })
-    throw new Error("FeishuAdapter.send: pending M3 (im.message.create wiring)");
+  async send(message: NormalizedIMMessage): Promise<{ messageId: string }> {
+    if (!this.client) {
+      throw new Error("FeishuAdapter.send: call init() first");
+    }
+    const text = message.text ?? message.markdown;
+    if (!text) {
+      // M5 will add image / file / card variants.
+      throw new Error(
+        "FeishuAdapter.send: M3 supports text only (image/card land in M5)",
+      );
+    }
+    const content = JSON.stringify({ text });
+
+    // Threaded reply when the message references an upstream message_id.
+    // im.message.reply preserves the thread context (Feishu root_id).
+    const replyTo = message.replyToMessageId ?? message.target.threadRootId;
+    if (replyTo) {
+      const resp = await this.client.im.message.reply({
+        path: { message_id: replyTo },
+        data: { msg_type: "text", content },
+      });
+      const messageId = resp?.data?.message_id;
+      if (!messageId) {
+        throw new Error("FeishuAdapter.send: reply returned no message_id");
+      }
+      return { messageId };
+    }
+
+    const receive_id_type =
+      message.target.conversationType === "dm" ? "open_id" : "chat_id";
+    const resp = await this.client.im.message.create({
+      params: { receive_id_type },
+      data: {
+        receive_id: message.target.conversationId,
+        msg_type: "text",
+        content,
+      },
+    });
+    const messageId = resp?.data?.message_id;
+    if (!messageId) {
+      throw new Error("FeishuAdapter.send: create returned no message_id");
+    }
+    return { messageId };
   }
 
   async edit(
     _target: IMConversationRef,
-    _messageId: string,
-    _message: NormalizedIMMessage,
+    messageId: string,
+    message: NormalizedIMMessage,
   ): Promise<void> {
-    // M3+: client.im.message.update — Feishu supports edit up to 20 times per msg.
-    // Used to promote the "⏳ 处理中…" placeholder into the final reply.
-    throw new Error("FeishuAdapter.edit: pending M3+ (im.message.update wiring)");
+    if (!this.client) {
+      throw new Error("FeishuAdapter.edit: call init() first");
+    }
+    const text = message.text ?? message.markdown;
+    if (!text) {
+      throw new Error("FeishuAdapter.edit: M3 supports text only");
+    }
+    // Feishu allows up to 20 edits per message — caller is responsible for
+    // budgeting. Used to promote a "⏳ 处理中…" placeholder into the final reply.
+    await this.client.im.message.update({
+      path: { message_id: messageId },
+      data: {
+        msg_type: "text",
+        content: JSON.stringify({ text }),
+      },
+    });
   }
 
   health(): IMAdapterHealth {

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -1,0 +1,85 @@
+/**
+ * RFC-020 §3.1 — Feishu (Lark) adapter for the IM compatibility layer.
+ *
+ * Uses `@larksuiteoapi/node-sdk` in WebSocket long-connection mode (WSClient).
+ * No public IP / no domain verification / no webhook signature decryption —
+ * the three biggest 飞书 接入 risks all live in the HTTP event-callback path,
+ * not in WSClient mode.
+ *
+ * Milestones:
+ *   M1 (this file): contract scaffold — implements IMAdapter signature with
+ *                   TODO stubs so subsequent milestones can fill behavior.
+ *   M2:  WSClient init + EventDispatcher for `im.message.receive_v1` +
+ *        normalize raw events to NormalizedIMEvent + access whitelist gate.
+ *   M3:  outbound `im.message.create` (text), edit support (≤20/msg), think()
+ *        bridge handoff.
+ *   M5:  image upload/download (`im.image.create` / `im.messageResource.get`).
+ */
+import type {
+  IMAdapter,
+  IMAdapterHealth,
+  IMChannelConfig,
+  IMConversationRef,
+  IMIngressMode,
+  NormalizedIMEvent,
+  NormalizedIMMessage,
+} from "../types.js";
+import type { FeishuChannelConfig } from "./config.js";
+
+export class FeishuAdapter implements IMAdapter {
+  readonly platform = "feishu";
+  readonly ingressMode: IMIngressMode = "socket";
+
+  private feishuConfig: FeishuChannelConfig | null = null;
+  private health_: IMAdapterHealth = {
+    connected: false,
+    lastEventAt: null,
+    lastError: null,
+  };
+
+  async init(_config: IMChannelConfig): Promise<void> {
+    // M2: extract FeishuChannelConfig from _config.platformConfig
+    // M2: const client = new lark.Client({ appId, appSecret, disableTokenCache: false })
+    throw new Error("FeishuAdapter.init: pending M2 (WSClient wiring)");
+  }
+
+  async start(
+    _onEvent: (event: NormalizedIMEvent) => Promise<void>,
+  ): Promise<void> {
+    // M2: const ws = new lark.WSClient({ appId, appSecret, loggerLevel: WARN })
+    // M2: const dispatcher = new lark.EventDispatcher({}).register({
+    //       "im.message.receive_v1": handler that normalizes → access-check → onEvent
+    //     })
+    // M2: await ws.start({ eventDispatcher: dispatcher })
+    throw new Error("FeishuAdapter.start: pending M2 (WSClient + EventDispatcher)");
+  }
+
+  async stop(): Promise<void> {
+    // M2: graceful WSClient teardown.
+    this.health_ = { ...this.health_, connected: false };
+  }
+
+  async send(
+    _message: NormalizedIMMessage,
+  ): Promise<{ messageId: string }> {
+    // M3: client.im.message.create({
+    //       params: { receive_id_type: dm ? "open_id" : "chat_id" },
+    //       data: { receive_id, msg_type: "text"|"image"|..., content: JSON.stringify({...}) }
+    //     })
+    throw new Error("FeishuAdapter.send: pending M3 (im.message.create wiring)");
+  }
+
+  async edit(
+    _target: IMConversationRef,
+    _messageId: string,
+    _message: NormalizedIMMessage,
+  ): Promise<void> {
+    // M3+: client.im.message.update — Feishu supports edit up to 20 times per msg.
+    // Used to promote the "⏳ 处理中…" placeholder into the final reply.
+    throw new Error("FeishuAdapter.edit: pending M3+ (im.message.update wiring)");
+  }
+
+  health(): IMAdapterHealth {
+    return { ...this.health_ };
+  }
+}

--- a/agent-network/src/im/feishu/bridge.ts
+++ b/agent-network/src/im/feishu/bridge.ts
@@ -64,7 +64,14 @@ export interface BridgeReplyEnvelope {
   text: string;
 }
 
-const REPLY_PENDING_TTL_MS = 5 * 60 * 1000;
+/** Default outbound-correlation TTL when channelConfig.taskTimeoutMs is unset.
+ *  Bumped to 15min per 通信牛 review 必改3 — covers 95% of real think durations.
+ *  Override via .anet/nodes/<n>/channels/feishu/config.json `taskTimeoutMs`. */
+const DEFAULT_REPLY_PENDING_TTL_MS = 15 * 60 * 1000;
+
+/** Idempotency dedup window — drop repeat events that arrive within this
+ *  span (socket-reconnect replay). Independent of the outbound TTL above. */
+const DEDUP_WINDOW_MS = 2 * 60 * 1000;
 
 /**
  * Wire and start the Feishu bridge. Resolves once the underlying WSClient is
@@ -87,16 +94,48 @@ export async function startFeishuBridge(
     platformConfig: channelConfig as unknown as Record<string, unknown>,
   });
 
-  const onEvent = opts.onEvent ?? selectDefaultEventHandler(adapter);
-  await adapter.start(onEvent);
+  const ttlMs = channelConfig.taskTimeoutMs || DEFAULT_REPLY_PENDING_TTL_MS;
+  const onEvent =
+    opts.onEvent ?? selectDefaultEventHandler(adapter, ttlMs);
+  await adapter.start(withDedup(onEvent));
   return adapter;
+}
+
+/**
+ * Dedup wrapper — drops repeat events that arrive within DEDUP_WINDOW_MS
+ * (RFC-020 §4.4 / 通信牛 review). Protects against socket-reconnect replay.
+ * Sits in front of any other handler so the dropped event never reaches
+ * IPC / think / send.
+ */
+function withDedup(
+  inner: (event: NormalizedIMEvent) => Promise<void>,
+): (event: NormalizedIMEvent) => Promise<void> {
+  const seen = new Map<string, number>();
+  return async (event: NormalizedIMEvent) => {
+    const now = Date.now();
+    // Lightweight GC — only when the map grows, sweep stale entries.
+    if (seen.size > 200) {
+      for (const [k, ts] of seen) {
+        if (now - ts > DEDUP_WINDOW_MS) seen.delete(k);
+      }
+    }
+    if (seen.has(event.idempotencyKey)) {
+      process.stderr.write(
+        `[feishu:bridge] dedup drop ${event.idempotencyKey}\n`,
+      );
+      return;
+    }
+    seen.set(event.idempotencyKey, now);
+    await inner(event);
+  };
 }
 
 function selectDefaultEventHandler(
   adapter: FeishuAdapter,
+  ttlMs: number,
 ): (event: NormalizedIMEvent) => Promise<void> {
   if (typeof process.send === "function") {
-    return createIPCEventHandler(adapter);
+    return createIPCEventHandler(adapter, ttlMs);
   }
   return defaultEventLogger;
 }
@@ -105,9 +144,16 @@ function selectDefaultEventHandler(
  * IPC handler — forwards inbound events to the parent agent-node and routes
  * the parent's reply back to Feishu via the adapter. The parent contract is
  * a single round-trip per event keyed on `idempotencyKey`.
+ *
+ * On TTL expiry without reply (per 通信牛 review 必改3-b — never silent-drop)
+ * the bridge sends a user-visible "[处理超时]" notice into the originating
+ * conversation before evicting the pending entry. If the agent's real reply
+ * arrives later, bridge's reply-envelope lookup will miss (entry already
+ * evicted) and the late reply is dropped — the user already knows.
  */
 function createIPCEventHandler(
   adapter: FeishuAdapter,
+  ttlMs: number,
 ): (event: NormalizedIMEvent) => Promise<void> {
   if (typeof process.send !== "function") {
     throw new Error(
@@ -142,7 +188,30 @@ function createIPCEventHandler(
 
   return async (event: NormalizedIMEvent) => {
     pending.set(event.idempotencyKey, event);
-    setTimeout(() => pending.delete(event.idempotencyKey), REPLY_PENDING_TTL_MS);
+    setTimeout(() => {
+      // If pending entry still here, parent never sent a reply within ttl.
+      // Surface a user-visible timeout instead of silently evicting.
+      if (!pending.has(event.idempotencyKey)) return;
+      pending.delete(event.idempotencyKey);
+      void (async () => {
+        try {
+          await adapter.send({
+            target: event.conversation,
+            text: "[处理超时，任务可能仍在后台运行]",
+            replyToMessageId: event.messageId,
+            correlation: { taskId: event.idempotencyKey },
+          });
+          process.stderr.write(
+            `[feishu:bridge] timeout-notify sent for ${event.idempotencyKey} after ${ttlMs}ms\n`,
+          );
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          process.stderr.write(
+            `[feishu:bridge] timeout-notify send failed: ${msg}\n`,
+          );
+        }
+      })();
+    }, ttlMs);
     const envelope: BridgeIncomingEnvelope = { type: "event", event };
     process.send!(envelope);
   };

--- a/agent-network/src/im/feishu/bridge.ts
+++ b/agent-network/src/im/feishu/bridge.ts
@@ -20,12 +20,15 @@
  * — tracked in #182.
  *
  * Milestones:
- *   M1 (this file): worker entry scaffold.
- *   M2: load config + instantiate adapter + WSClient.
+ *   M1: worker entry scaffold.
+ *   M2 (this file): adapter + WSClient wiring with a noop event handler that
+ *                   logs received events. Useful by itself for debugging the
+ *                   inbound path without an agent attached.
  *   M3: parent-IPC contract for think() round-trip, outbound send.
  *   M4: agent-node spawn integration (fork(this) wired by agent-node).
- *   M5: group @bot trigger, image up/down, Docker smoke.
+ *   M5: group @bot trigger refinement, image up/down, Docker smoke.
  */
+import type { NormalizedIMEvent } from "../types.js";
 import { FeishuAdapter } from "./adapter.js";
 import { loadFeishuChannelConfig } from "./config.js";
 
@@ -34,33 +37,54 @@ export interface FeishuBridgeOptions {
   channelDir: string;
   /** Node alias — used for audit log + IPC framing. */
   nodeAlias: string;
+  /**
+   * Optional inbound event sink for tests and the M3 think() bridge. Defaults
+   * to a stderr logger so a bare bridge process can be observed end-to-end.
+   */
+  onEvent?: (event: NormalizedIMEvent) => Promise<void>;
 }
 
 /**
  * Wire and start the Feishu bridge. Resolves once the underlying WSClient is
  * connected and the EventDispatcher is registered.
  *
- * Intended to be the worker's `main()` — agent-node will spawn this file as a
- * child process and pass `FeishuBridgeOptions` through CLI args or env.
+ * Intended to be the worker's `main()` — agent-node spawns this file as a
+ * child process and passes `FeishuBridgeOptions` through CLI args or env.
  */
 export async function startFeishuBridge(
-  _opts: FeishuBridgeOptions,
-): Promise<void> {
-  // M2 outline:
-  //   const config = loadFeishuChannelConfig(_opts.channelDir);
-  //   const adapter = new FeishuAdapter();
-  //   await adapter.init({ platform: "feishu", connectionName: _opts.nodeAlias,
-  //                        ingressMode: "socket", platformConfig: config });
-  //   await adapter.start(async (event) => {
-  //     if (!isAllowed(event, config.access)) return;            // §4.1 access gate
-  //     const reply = await thinkViaParent(event);                // M3 IPC
-  //     await adapter.send(buildReply(event, reply));             // §4.2 outbound
-  //   });
-  void FeishuAdapter; // keep import live until M2 wires it
-  void loadFeishuChannelConfig;
-  throw new Error("startFeishuBridge: pending M2 (adapter + WSClient wiring)");
+  opts: FeishuBridgeOptions,
+): Promise<FeishuAdapter> {
+  const channelConfig = loadFeishuChannelConfig(opts.channelDir);
+
+  const adapter = new FeishuAdapter();
+  await adapter.init({
+    platform: "feishu",
+    connectionName: opts.nodeAlias,
+    ingressMode: "socket",
+    groupPolicy: channelConfig.groupPolicy,
+    ackPlaceholder: channelConfig.ackPlaceholder,
+    auditRaw: channelConfig.auditRaw,
+    taskTimeoutMs: channelConfig.taskTimeoutMs,
+    platformConfig: channelConfig as unknown as Record<string, unknown>,
+  });
+
+  const onEvent = opts.onEvent ?? defaultEventLogger;
+  await adapter.start(onEvent);
+  return adapter;
+}
+
+async function defaultEventLogger(event: NormalizedIMEvent): Promise<void> {
+  process.stderr.write(
+    `[feishu:bridge] event from=${event.sender.id} ` +
+      `conv=${event.conversation.conversationType}:${event.conversation.conversationId} ` +
+      `mentioned=${event.mentioned} text=${(event.content.text ?? "").slice(0, 80)}\n`,
+  );
 }
 
 export { FeishuAdapter } from "./adapter.js";
 export { loadFeishuChannelConfig } from "./config.js";
-export type { FeishuAccessList, FeishuChannelConfig, FeishuChannelEnv } from "./config.js";
+export type {
+  FeishuAccessList,
+  FeishuChannelConfig,
+  FeishuChannelEnv,
+} from "./config.js";

--- a/agent-network/src/im/feishu/bridge.ts
+++ b/agent-network/src/im/feishu/bridge.ts
@@ -21,10 +21,11 @@
  *
  * Milestones:
  *   M1: worker entry scaffold.
- *   M2 (this file): adapter + WSClient wiring with a noop event handler that
- *                   logs received events. Useful by itself for debugging the
- *                   inbound path without an agent attached.
- *   M3: parent-IPC contract for think() round-trip, outbound send.
+ *   M2: adapter + WSClient wiring with a noop event handler.
+ *   M3 (this file): IPC contract for the think() round-trip — when running
+ *                   as a forked child the bridge auto-uses `process.send` /
+ *                   `process.on("message")`; standalone, it falls back to a
+ *                   stderr logger so the inbound path stays observable.
  *   M4: agent-node spawn integration (fork(this) wired by agent-node).
  *   M5: group @bot trigger refinement, image up/down, Docker smoke.
  */
@@ -38,18 +39,36 @@ export interface FeishuBridgeOptions {
   /** Node alias — used for audit log + IPC framing. */
   nodeAlias: string;
   /**
-   * Optional inbound event sink for tests and the M3 think() bridge. Defaults
-   * to a stderr logger so a bare bridge process can be observed end-to-end.
+   * Optional inbound event sink for tests or custom integrations. When omitted
+   * the bridge picks an automatic strategy:
+   *   - IPC handler when `process.send` exists (i.e. running as a forked
+   *     child of agent-node).
+   *   - stderr logger otherwise (standalone smoke debugging).
    */
   onEvent?: (event: NormalizedIMEvent) => Promise<void>;
 }
 
+// ── IPC contract with the agent-node parent (M3) ─────────────────────────
+
+/** Bridge → parent: inbound IM event ready for think(). */
+export interface BridgeIncomingEnvelope {
+  type: "event";
+  event: NormalizedIMEvent;
+}
+
+/** Parent → bridge: agent reply text for a previously-forwarded event. */
+export interface BridgeReplyEnvelope {
+  type: "reply";
+  /** Echoes the originating event's idempotencyKey. */
+  eventKey: string;
+  text: string;
+}
+
+const REPLY_PENDING_TTL_MS = 5 * 60 * 1000;
+
 /**
  * Wire and start the Feishu bridge. Resolves once the underlying WSClient is
  * connected and the EventDispatcher is registered.
- *
- * Intended to be the worker's `main()` — agent-node spawns this file as a
- * child process and passes `FeishuBridgeOptions` through CLI args or env.
  */
 export async function startFeishuBridge(
   opts: FeishuBridgeOptions,
@@ -68,9 +87,75 @@ export async function startFeishuBridge(
     platformConfig: channelConfig as unknown as Record<string, unknown>,
   });
 
-  const onEvent = opts.onEvent ?? defaultEventLogger;
+  const onEvent = opts.onEvent ?? selectDefaultEventHandler(adapter);
   await adapter.start(onEvent);
   return adapter;
+}
+
+function selectDefaultEventHandler(
+  adapter: FeishuAdapter,
+): (event: NormalizedIMEvent) => Promise<void> {
+  if (typeof process.send === "function") {
+    return createIPCEventHandler(adapter);
+  }
+  return defaultEventLogger;
+}
+
+/**
+ * IPC handler — forwards inbound events to the parent agent-node and routes
+ * the parent's reply back to Feishu via the adapter. The parent contract is
+ * a single round-trip per event keyed on `idempotencyKey`.
+ */
+function createIPCEventHandler(
+  adapter: FeishuAdapter,
+): (event: NormalizedIMEvent) => Promise<void> {
+  if (typeof process.send !== "function") {
+    throw new Error(
+      "createIPCEventHandler: parent process.send unavailable (not forked)",
+    );
+  }
+
+  const pending = new Map<string, NormalizedIMEvent>();
+
+  process.on("message", (raw: unknown) => {
+    if (!isReplyEnvelope(raw)) return;
+    const event = pending.get(raw.eventKey);
+    if (!event) return;
+    pending.delete(raw.eventKey);
+
+    const replyText = raw.text;
+    const eventKey = raw.eventKey;
+    void (async () => {
+      try {
+        await adapter.send({
+          target: event.conversation,
+          text: replyText,
+          replyToMessageId: event.messageId,
+          correlation: { taskId: eventKey },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`[feishu:bridge] reply send failed: ${msg}\n`);
+      }
+    })();
+  });
+
+  return async (event: NormalizedIMEvent) => {
+    pending.set(event.idempotencyKey, event);
+    setTimeout(() => pending.delete(event.idempotencyKey), REPLY_PENDING_TTL_MS);
+    const envelope: BridgeIncomingEnvelope = { type: "event", event };
+    process.send!(envelope);
+  };
+}
+
+function isReplyEnvelope(raw: unknown): raw is BridgeReplyEnvelope {
+  if (!raw || typeof raw !== "object") return false;
+  const r = raw as Record<string, unknown>;
+  return (
+    r["type"] === "reply" &&
+    typeof r["eventKey"] === "string" &&
+    typeof r["text"] === "string"
+  );
 }
 
 async function defaultEventLogger(event: NormalizedIMEvent): Promise<void> {

--- a/agent-network/src/im/feishu/bridge.ts
+++ b/agent-network/src/im/feishu/bridge.ts
@@ -1,0 +1,66 @@
+/**
+ * RFC-020 §2.5 / RFC-002 §2.2 — Feishu bridge worker.
+ *
+ * Entry point spawned by agent-node when a node profile has `channels.feishu`
+ * enabled. Per Vincent 2026-06-24 decision, the first-cut is the simplified
+ * "agent-node direct bridge" model, not the full commhub-gateway:
+ *
+ *   - This worker owns the FeishuAdapter and its WSClient connection.
+ *   - Inbound IM event → access whitelist gate → forward to agent-node's main
+ *     `think()` via parent IPC.
+ *   - think() result → adapter.send() back to the originating conversation.
+ *
+ * Differences vs RFC-020 §2.5 full commhub-gateway path:
+ *   - No separate gateway ntok_ / dedicated commhub alias.
+ *   - IM messages do NOT pass through commhub task dispatch.
+ *   - Feishu messages do NOT appear in Dashboard topology / Chat.
+ *
+ * The full §2.9 path (meta_json columns, SSE passthrough, persisted
+ * IMCorrelationStore) lands as the follow-up PR after this demo ships
+ * — tracked in #182.
+ *
+ * Milestones:
+ *   M1 (this file): worker entry scaffold.
+ *   M2: load config + instantiate adapter + WSClient.
+ *   M3: parent-IPC contract for think() round-trip, outbound send.
+ *   M4: agent-node spawn integration (fork(this) wired by agent-node).
+ *   M5: group @bot trigger, image up/down, Docker smoke.
+ */
+import { FeishuAdapter } from "./adapter.js";
+import { loadFeishuChannelConfig } from "./config.js";
+
+export interface FeishuBridgeOptions {
+  /** Absolute path to `.anet/nodes/<node>/channels/feishu/`. */
+  channelDir: string;
+  /** Node alias — used for audit log + IPC framing. */
+  nodeAlias: string;
+}
+
+/**
+ * Wire and start the Feishu bridge. Resolves once the underlying WSClient is
+ * connected and the EventDispatcher is registered.
+ *
+ * Intended to be the worker's `main()` — agent-node will spawn this file as a
+ * child process and pass `FeishuBridgeOptions` through CLI args or env.
+ */
+export async function startFeishuBridge(
+  _opts: FeishuBridgeOptions,
+): Promise<void> {
+  // M2 outline:
+  //   const config = loadFeishuChannelConfig(_opts.channelDir);
+  //   const adapter = new FeishuAdapter();
+  //   await adapter.init({ platform: "feishu", connectionName: _opts.nodeAlias,
+  //                        ingressMode: "socket", platformConfig: config });
+  //   await adapter.start(async (event) => {
+  //     if (!isAllowed(event, config.access)) return;            // §4.1 access gate
+  //     const reply = await thinkViaParent(event);                // M3 IPC
+  //     await adapter.send(buildReply(event, reply));             // §4.2 outbound
+  //   });
+  void FeishuAdapter; // keep import live until M2 wires it
+  void loadFeishuChannelConfig;
+  throw new Error("startFeishuBridge: pending M2 (adapter + WSClient wiring)");
+}
+
+export { FeishuAdapter } from "./adapter.js";
+export { loadFeishuChannelConfig } from "./config.js";
+export type { FeishuAccessList, FeishuChannelConfig, FeishuChannelEnv } from "./config.js";

--- a/agent-network/src/im/feishu/config.ts
+++ b/agent-network/src/im/feishu/config.ts
@@ -1,0 +1,90 @@
+/**
+ * RFC-020 §3.1 / §5.2 — Feishu channel config loader.
+ *
+ * Reads `.anet/nodes/<node>/channels/feishu/`:
+ *   - `.env`         FEISHU_APP_ID + FEISHU_APP_SECRET (chmod 600, not in git)
+ *   - `access.json`  { allowFrom: [open_id, ...], allowChats: [chat_id, ...] }
+ *
+ * Secrets stay agent-local; never uploaded to the hub (RFC-020 §5.3).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface FeishuChannelEnv {
+  FEISHU_APP_ID: string;
+  FEISHU_APP_SECRET: string;
+}
+
+export interface FeishuAccessList {
+  /** Feishu open_ids permitted to DM the bot. */
+  allowFrom: string[];
+  /** Feishu chat_ids the bot is permitted to listen in. */
+  allowChats: string[];
+}
+
+export interface FeishuChannelConfig {
+  appId: string;
+  appSecret: string;
+  access: FeishuAccessList;
+  /** RFC-020 §4.3 group trigger policy. Default `mention`. */
+  groupPolicy: "mention" | "command" | "all" | "observe";
+  /** Send a "⏳ 处理中…" placeholder before agent reply (RFC-020 §4.2). */
+  ackPlaceholder: boolean;
+  /** Persist redacted raw payload to local audit log (RFC-020 §2.3 / §12.10). */
+  auditRaw: boolean;
+  /** Per-task timeout in ms; default 5 min (RFC-020 §4.5). */
+  taskTimeoutMs: number;
+}
+
+/**
+ * Load Feishu channel config from a node's channels/feishu directory.
+ * Throws if required secrets are missing.
+ */
+export function loadFeishuChannelConfig(channelDir: string): FeishuChannelConfig {
+  const env = parseEnvFile(join(channelDir, ".env"));
+  const appId = env.FEISHU_APP_ID;
+  const appSecret = env.FEISHU_APP_SECRET;
+  if (!appId || !appSecret) {
+    throw new Error(
+      `feishu channel: FEISHU_APP_ID / FEISHU_APP_SECRET missing in ${channelDir}/.env`,
+    );
+  }
+  const access = readAccessFile(join(channelDir, "access.json"));
+  return {
+    appId,
+    appSecret,
+    access,
+    groupPolicy: "mention",
+    ackPlaceholder: true,
+    auditRaw: false,
+    taskTimeoutMs: 5 * 60 * 1000,
+  };
+}
+
+function parseEnvFile(path: string): Record<string, string> {
+  if (!existsSync(path)) return {};
+  const out: Record<string, string> = {};
+  for (const line of readFileSync(path, "utf-8").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 0) continue;
+    const k = trimmed.slice(0, eq).trim();
+    const v = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+    out[k] = v;
+  }
+  return out;
+}
+
+function readAccessFile(path: string): FeishuAccessList {
+  if (!existsSync(path)) return { allowFrom: [], allowChats: [] };
+  try {
+    const data = JSON.parse(readFileSync(path, "utf-8")) as Partial<FeishuAccessList>;
+    return {
+      allowFrom: Array.isArray(data.allowFrom) ? data.allowFrom : [],
+      allowChats: Array.isArray(data.allowChats) ? data.allowChats : [],
+    };
+  } catch {
+    return { allowFrom: [], allowChats: [] };
+  }
+}

--- a/agent-network/src/im/feishu/config.ts
+++ b/agent-network/src/im/feishu/config.ts
@@ -34,6 +34,12 @@ export interface FeishuChannelConfig {
   auditRaw: boolean;
   /** Per-task timeout in ms; default 5 min (RFC-020 §4.5). */
   taskTimeoutMs: number;
+  /**
+   * Absolute path to the channel directory. The adapter writes downloaded
+   * inbound media to `<channelDir>/media/` (M5c). Populated by the loader so
+   * callers do not have to thread it separately.
+   */
+  channelDir: string;
 }
 
 /**
@@ -58,6 +64,7 @@ export function loadFeishuChannelConfig(channelDir: string): FeishuChannelConfig
     ackPlaceholder: true,
     auditRaw: false,
     taskTimeoutMs: 5 * 60 * 1000,
+    channelDir,
   };
 }
 

--- a/agent-network/src/im/feishu/index.ts
+++ b/agent-network/src/im/feishu/index.ts
@@ -1,0 +1,18 @@
+/**
+ * RFC-020 §3.1 — Feishu (Lark) IM channel public surface.
+ *
+ * - `FeishuAdapter`         — IMAdapter implementation backed by `@larksuiteoapi/node-sdk` WSClient.
+ * - `startFeishuBridge`     — entry point spawned by agent-node for SDK runtimes.
+ * - `loadFeishuChannelConfig` — loader for `.anet/nodes/<node>/channels/feishu/`.
+ *
+ * Tracking: issues #179 (parent RFC), #182 (P0 tracker).
+ */
+export { FeishuAdapter } from "./adapter.js";
+export { startFeishuBridge } from "./bridge.js";
+export type { FeishuBridgeOptions } from "./bridge.js";
+export { loadFeishuChannelConfig } from "./config.js";
+export type {
+  FeishuAccessList,
+  FeishuChannelConfig,
+  FeishuChannelEnv,
+} from "./config.js";

--- a/agent-network/src/im/feishu/worker.ts
+++ b/agent-network/src/im/feishu/worker.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * RFC-020 §2.5 — Feishu bridge standalone worker entry (#179 M4).
+ *
+ * This file is the script that agent-node forks to run the Feishu bridge in
+ * a child process. It is also usable standalone for debugging the inbound
+ * path without an agent attached.
+ *
+ * Usage (standalone, no parent IPC — falls back to stderr logger):
+ *   node dist/src/im/feishu/worker.js \
+ *     --channel-dir /path/to/.anet/nodes/<node>/channels/feishu \
+ *     --node-alias  <alias>
+ *
+ * Usage (forked by agent-node with IPC):
+ *   child_process.fork(workerPath, [
+ *     "--channel-dir", channelDir,
+ *     "--node-alias",  nodeAlias,
+ *   ], { stdio: ["inherit", "inherit", "inherit", "ipc"] });
+ *
+ *   When `process.send` is available (IPC mode), the bridge auto-switches to
+ *   forwarding inbound events to the parent and routing parent's reply text
+ *   back to Feishu (see BridgeIncomingEnvelope / BridgeReplyEnvelope in
+ *   ./bridge.ts).
+ *
+ * Milestone status:
+ *   M4 (this file): standalone + IPC entry.
+ *   M5: agent-node spawn site that forks this worker (see agent-node/cli.ts).
+ */
+import { startFeishuBridge } from "./bridge.js";
+
+interface ParsedArgs {
+  channelDir?: string;
+  nodeAlias?: string;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === "--channel-dir" && value) {
+      out.channelDir = value;
+      i++;
+    } else if (flag === "--node-alias" && value) {
+      out.nodeAlias = value;
+      i++;
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.channelDir || !args.nodeAlias) {
+    process.stderr.write(
+      "usage: feishu-worker --channel-dir <path> --node-alias <alias>\n",
+    );
+    process.exit(2);
+  }
+
+  try {
+    await startFeishuBridge({
+      channelDir: args.channelDir,
+      nodeAlias: args.nodeAlias,
+    });
+    process.stderr.write(
+      `[feishu:worker] bridge online — node=${args.nodeAlias} dir=${args.channelDir}` +
+        ` ipc=${typeof process.send === "function" ? "yes" : "no"}\n`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.stack ?? err.message : String(err);
+    process.stderr.write(`[feishu:worker] startup failed: ${msg}\n`);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -2597,27 +2597,78 @@ async function connectFeishu(channel: FeishuChannel): Promise<void> {
   child.on("message", (raw: unknown) => {
     if (!isFeishuIncomingEnvelope(raw)) return;
     const ev = raw.event;
+    const convId = ev.conversation?.conversationId ?? "?";
     log(
       `[feishu] event from=${ev.sender?.id ?? "?"} ` +
-        `conv=${ev.conversation?.conversationType ?? "?"}:${ev.conversation?.conversationId ?? "?"} ` +
+        `conv=${ev.conversation?.conversationType ?? "?"}:${convId} ` +
         `mentioned=${ev.mentioned ?? false} text="${(ev.content?.text ?? "").slice(0, 80)}"`,
     );
 
-    // M5a: placeholder reply so the full inbound→IPC→outbound round-trip is
-    // exercisable end-to-end before think() integration lands in M5b.
-    // M5b will replace this with claude-agent-sdk query() invocation routing
-    // (or the project's existing inbox → think → reply pipeline).
-    if (typeof child.send === "function") {
+    // M5b (2026-06-24): real think() integration via the existing
+    // processTask → think() → thinkQueue pipeline. The placeholder reply
+    // M5a shipped is replaced; this path now drives the same LLM turn
+    // commhub-inbox messages and /loop wakes run through.
+    //
+    // Concurrency: `thinkQueue` (cli.ts ~2189) process-wide-serialises
+    // every think() call. Feishu inbound thus serialises with commhub
+    // SSE inbox + /loop wakes — strictly stronger than IM马's per-
+    // conversation ordering requirement (per-conv ⊆ process-wide).
+    // Cross-conversation parallelism is a #182 / RFC-020 §4.4 follow-up;
+    // the first-cut bottleneck is acceptable + avoids unverified
+    // concurrent-SDK behaviour.
+    //
+    // 5-min TTL: the bridge drops the reply if think() exceeds
+    // REPLY_PENDING_TTL_MS (5 min, src/im/feishu/bridge.ts). Long-task
+    // (>5 min) reply DROP is a known M5b limitation; progress-ack via
+    // adapter.edit OR a bumped TTL is the M5c follow-up choice (per
+    // 通信龙 ack). Vincent's M5b UAT is bounded to simple tasks <5min.
+    //
+    // Error handling (per IM马 #5 — never silent-drop):
+    //   - think success         → reply with raw text
+    //   - think failed=true     → reply with "[agent-node 处理失败]" prefix
+    //   - think threw           → reply with "[agent-node 异常]" + message
+    // Same-eventKey-second-reply is ignored by the bridge per IM马 #6;
+    // the try/catch around each branch guarantees exactly-one outbound.
+    (async () => {
+      const content = ev.content?.text ?? "";
+      const images = Array.isArray(ev.content?.images) ? ev.content?.images : undefined;
+      const from = `feishu:${convId}`;
+
+      let replyText: string;
+      if (!content.trim() && !(images && images.length > 0)) {
+        // Bridge would have filtered most empty events, but defend
+        // against zero-content + no-image edge (sticker / unsupported
+        // message kind) — send a brief reply so the user sees that we
+        // heard them but had nothing actionable.
+        replyText = "[agent-node] 收到事件但没有可处理的文本/图片内容。";
+      } else {
+        try {
+          const result = await processTask(content, from, null, images);
+          replyText = result.failed
+            ? `[agent-node 处理失败] ${result.text}`
+            : result.text;
+        } catch (e: any) {
+          warn(`[feishu] think() threw: ${e?.message ?? e}`);
+          replyText = `[agent-node 异常] ${e?.message ?? String(e)}`;
+        }
+      }
+
+      if (typeof child.send !== "function") return;
       try {
         child.send({
           type: "reply",
           eventKey: ev.idempotencyKey,
-          text: "[agent-node M5a placeholder — think() integration follows in M5b]",
+          text: replyText,
         });
       } catch (e: any) {
         warn(`[feishu] reply send failed: ${e?.message || e}`);
       }
-    }
+    })().catch((e: any) => {
+      // Belt-and-braces — the inner try/catch already swallows think()
+      // errors, but if something between them (e.g. JSON.stringify) throws,
+      // log it instead of crashing the IPC handler.
+      warn(`[feishu] message handler outer error: ${e?.message ?? e}`);
+    });
   });
 
   child.on("exit", (code, signal) => {

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -447,7 +447,37 @@ function initTelegramChannel(spec: { type: string; path?: string; raw: string })
 }
 
 const TELEGRAM_CHANNELS = CHANNELS.filter(ch => ch.type === "telegram").map(initTelegramChannel);
-const UNSUPPORTED_CHANNEL = CHANNELS.find(ch => ch.type !== "telegram");
+
+// ── Feishu channel (RFC-020 §3.1 / #179 M5a) ─────────────────────────────
+// Feishu bridge runs in a forked worker (src/im/feishu/worker.ts from the
+// agent-network package). agent-node owns the IPC parent side: receives
+// inbound events from the bridge and routes replies back. think() integration
+// lands in M5b — M5a sends a clear placeholder reply so the full round-trip
+// is demoable end-to-end.
+
+interface FeishuChannel {
+  type: "feishu";
+  dir: string;
+}
+
+function initFeishuChannel(spec: { type: string; path?: string; raw: string }): FeishuChannel {
+  const dir = spec.path || defaultChannelDir("feishu");
+  if (!existsSync(join(dir, ".env"))) {
+    console.error(`[agent-node] feishu channel needs .env with FEISHU_APP_ID + FEISHU_APP_SECRET in ${dir}`);
+    process.exit(1);
+  }
+  if (!existsSync(join(dir, "access.json"))) {
+    console.error(`[agent-node] feishu channel needs access.json in ${dir}`);
+    process.exit(1);
+  }
+  // .env 权限加固
+  try { chmodSync(join(dir, ".env"), 0o600); } catch {}
+  return { type: "feishu", dir };
+}
+
+const FEISHU_CHANNELS = CHANNELS.filter(ch => ch.type === "feishu").map(initFeishuChannel);
+
+const UNSUPPORTED_CHANNEL = CHANNELS.find(ch => ch.type !== "telegram" && ch.type !== "feishu");
 if (UNSUPPORTED_CHANNEL) {
   console.error(`[agent-node] unsupported channel: ${UNSUPPORTED_CHANNEL.raw}`);
   process.exit(1);
@@ -2507,6 +2537,112 @@ async function handleTelegramMessage(tg: TelegramApi, msg: any) {
   }
 }
 
+// ── Feishu bridge worker fork + IPC handler (#179 M5a) ──────────────────────
+
+interface FeishuBridgeEnvelope {
+  type: "event";
+  event: {
+    idempotencyKey: string;
+    sender?: { id?: string };
+    conversation?: { conversationType?: string; conversationId?: string };
+    content?: { text?: string };
+    mentioned?: boolean;
+  };
+}
+
+/**
+ * Locate the agent-network feishu worker script. Search order:
+ *   1. `ANET_FEISHU_WORKER_PATH` env override (explicit).
+ *   2. Dev sibling checkout: agent-node and agent-network laid out as siblings.
+ *   3. Installed npm package layout (worker lives in @sleep2agi/agent-network).
+ */
+function resolveFeishuWorkerPath(): string | null {
+  const candidates: string[] = [];
+  if (process.env.ANET_FEISHU_WORKER_PATH) {
+    candidates.push(process.env.ANET_FEISHU_WORKER_PATH);
+  }
+  const here = new URL(".", import.meta.url).pathname;
+  candidates.push(
+    // dev sibling: ../../agent-network/{dist|src}/src/im/feishu/worker.{js|ts}
+    join(here, "..", "..", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
+    join(here, "..", "..", "agent-network", "src", "im", "feishu", "worker.ts"),
+    // installed npm package (agent-network and agent-node share node_modules root)
+    join(here, "..", "..", "..", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
+    // global npm prefix layout
+    join(here, "..", "..", "..", "..", "@sleep2agi", "agent-network", "dist", "src", "im", "feishu", "worker.js"),
+  );
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return null;
+}
+
+async function connectFeishu(channel: FeishuChannel): Promise<void> {
+  const workerPath = resolveFeishuWorkerPath();
+  if (!workerPath) {
+    warn(
+      `[feishu] worker path not found — skipping feishu channel setup. ` +
+        `Override with ANET_FEISHU_WORKER_PATH, or install @sleep2agi/agent-network so dist/src/im/feishu/worker.js is reachable.`,
+    );
+    return;
+  }
+
+  const { spawn } = await import("node:child_process");
+  const child = spawn(
+    process.execPath,
+    [workerPath, "--channel-dir", channel.dir, "--node-alias", ALIAS],
+    { stdio: ["ignore", "inherit", "inherit", "ipc"] },
+  );
+
+  child.on("message", (raw: unknown) => {
+    if (!isFeishuIncomingEnvelope(raw)) return;
+    const ev = raw.event;
+    log(
+      `[feishu] event from=${ev.sender?.id ?? "?"} ` +
+        `conv=${ev.conversation?.conversationType ?? "?"}:${ev.conversation?.conversationId ?? "?"} ` +
+        `mentioned=${ev.mentioned ?? false} text="${(ev.content?.text ?? "").slice(0, 80)}"`,
+    );
+
+    // M5a: placeholder reply so the full inbound→IPC→outbound round-trip is
+    // exercisable end-to-end before think() integration lands in M5b.
+    // M5b will replace this with claude-agent-sdk query() invocation routing
+    // (or the project's existing inbox → think → reply pipeline).
+    if (typeof child.send === "function") {
+      try {
+        child.send({
+          type: "reply",
+          eventKey: ev.idempotencyKey,
+          text: "[agent-node M5a placeholder — think() integration follows in M5b]",
+        });
+      } catch (e: any) {
+        warn(`[feishu] reply send failed: ${e?.message || e}`);
+      }
+    }
+  });
+
+  child.on("exit", (code, signal) => {
+    warn(`[feishu] worker exited code=${code} signal=${signal} dir=${channel.dir}`);
+  });
+
+  child.on("error", (err) => {
+    warn(`[feishu] worker error: ${err?.message || err}`);
+  });
+
+  log(`[feishu] forked worker (pid ${child.pid}) for ${channel.dir} via ${workerPath}`);
+}
+
+function isFeishuIncomingEnvelope(raw: unknown): raw is FeishuBridgeEnvelope {
+  if (!raw || typeof raw !== "object") return false;
+  const r = raw as Record<string, unknown>;
+  if (r["type"] !== "event") return false;
+  const ev = r["event"];
+  return (
+    !!ev &&
+    typeof ev === "object" &&
+    typeof (ev as Record<string, unknown>)["idempotencyKey"] === "string"
+  );
+}
+
 async function connectTelegram(channel: TelegramChannel) {
   const tg: TelegramApi = {
     channel,
@@ -2731,7 +2867,10 @@ log(`  tools:   ${
     ? (TOOLS.length ? `[${TOOLS.join(",")}]` : "(none)")
     : "all (Claude Code preset — built-in: WebFetch/WebSearch/Bash/Read/Write/Edit/Glob/Grep/Task/...)"
 }`);
-log(`  channels:${TELEGRAM_CHANNELS.length ? ` telegram(${TELEGRAM_CHANNELS.map(ch => ch.dir).join(",")})` : " (none)"}`);
+log(`  channels:${[
+  TELEGRAM_CHANNELS.length ? `telegram(${TELEGRAM_CHANNELS.map(ch => ch.dir).join(",")})` : "",
+  FEISHU_CHANNELS.length ? `feishu(${FEISHU_CHANNELS.map(ch => ch.dir).join(",")})` : "",
+].filter(s => s).join(" ") || " (none)"}`);
 log(`  session: ${SESSION_ID || "(new)"}`);
 log(`  log-dir: ${LOG_DIR}`);
 log(`  goals:   ${GOALS_PATH}`);
@@ -2784,6 +2923,7 @@ const shutdown = async () => { log("shutting down..."); await reportStatus("offl
 process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
 for (const channel of TELEGRAM_CHANNELS) connectTelegram(channel);
+for (const channel of FEISHU_CHANNELS) void connectFeishu(channel);
 connectSSE();
 
 // #246 — opt-in telegram plugin watchdog. Reads

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1134,7 +1134,24 @@ let grokSessionId: string | undefined = RUNTIME === "grok" ? (SESSION_ID || unde
 const HAD_GROK_SESSION_AT_BOOT = RUNTIME === "grok" && !!SESSION_ID;
 let grokResumeHintFired = false;
 
-async function processWithClaude(task: string, from: string): Promise<string> {
+async function processWithClaude(task: string, from: string, images?: string[]): Promise<string> {
+  // #179 M5b 必改2-C (2026-06-24, 通信龙 ack): mirror the Grok runtime
+  // pattern — accept images in the signature so callers (commhub-inbox
+  // attachments, feishu channel content.images, /loop wakes carrying
+  // images, etc.) pass them through symmetrically, but for now emit a
+  // single warn line and downgrade to text-only.
+  //
+  // Real multimodal wiring (build AsyncIterable<SDKUserMessage> with
+  // {type:"image", source:{type:"base64",...}} content blocks) is a
+  // follow-up: blast radius is all claude-agent-sdk callers (not just
+  // feishu) and would need a cross-runtime regression + verification
+  // that the configured vendor's Anthropic-compat endpoint (e.g.
+  // deepseek-v4-pro via /anthropic) actually accepts image blocks.
+  // Track in the per-runtime multimodal issue.
+  if (images?.length) {
+    warn(`[claude] image attachments (${images.length}) received but claude-agent-sdk runtime currently sends text-only prompts; images remain on disk for future runs. Real multimodal wiring is tracked in a follow-up issue.`);
+  }
+
   // Pre-flight: if no Claude binary is resolvable, on-the-fly install the
   // glibc one. SDK ships musl-only by default on Linux x64 which fails on
   // Debian/Ubuntu/RHEL hosts. Auto-install means the user doesn't need to
@@ -2215,7 +2232,7 @@ function think(task: string, from: string, taskId: string | null, images?: strin
       if (RUNTIME === "grok") {
         return await processWithGrok(task, from, images);
       }
-      return await processWithClaude(task, from);
+      return await processWithClaude(task, from, images);
     } finally {
       if (prev !== undefined) process.env.CURRENT_TASK_ID = prev; else delete process.env.CURRENT_TASK_ID;
       decrementInFlight();


### PR DESCRIPTION
## Author

Agent: 通信IM马 (claude-code-cli runtime, RFC-020 主笔)
Co-owner: 通信IM牛 (codex runtime, peer review)

## Scope (per Vincent 2026-06-24 decision)

`claude-agent-sdk` runtime + 飞书 + 私聊 + 群 @bot + 文本 + 图片. ETA ~9-13 工程小时 (see milestones below).

**第一刀路径** = agent-node 直 bridge + WSClient 长连接. 完整 RFC-020 §2.9 commhub-gateway schema 增量 **deferred** to follow-up PR after demo ships.

Vincent decisions on the 5 unknowns from the eval (relayed via 通信龙):

| Q | Decision |
|---|---|
| Q1 群聊 @bot | 含 (+1h) |
| Q2 飞书消息进 Dashboard | 第一刀不做; 走完整 §2.9 收尾 PR |
| Q3 群聊触发策略 | mention (RFC §12.4 默认) |
| Q4 图片上下行 | 含 (+1h, 社区 SDK 已有) |
| Q5 飞书 App ID/Secret | Vincent 那侧出, 工程并行不等 |

## Milestones

- [x] **M1 — Adapter + Bridge scaffold** (~30min actual, commit `45819dc`)
      4 files, ~260 lines, `tsc --noEmit` clean.
      `src/im/feishu/{config,adapter,bridge,index}.ts`
- [ ] **M2 — WSClient + EventDispatcher + access whitelist + audit log** (~2-3h)
      `@larksuiteoapi/node-sdk` dep + `adapter.init`/`adapter.start` 实装 +
      `im.message.receive_v1` normalize → `NormalizedIMEvent` + access gate
- [ ] **M3 — `think()` bridge + outbound send + edit** (~1-2h)
      `adapter.send` / `adapter.edit` + bridge ↔ agent-node IPC for think round-trip
- [ ] **M4 — `anet channel add feishu` CLI + agent-node fork integration** (~2-3h)
      `bin/cli.ts:4492` switch over `type` + agent-node spawn bridge worker on node start
- [ ] **M5 — Group @bot + image up/down + Docker smoke + docs** (~2-3h)
      `message.mentions` parse + `im.image.create` / `im.messageResource.get` +
      docker mock smoke (派测试号) + README 片段

## Refs

- Parent RFC issue: #179
- P0 tracker: #182 (full commhub-gateway 抽象层 — 本 PR 第一刀完后续 schema 增量 PR)
- RFC: `docs/rfcs/RFC-020-im-platform-integration.md` (commit `5216370`, v3.1 Final)
- Per RFC §12.6: porting [`vansin/claude-code-feishu-channel`](https://github.com/vansin/claude-code-feishu-channel) SDK layer (validated)

## Test plan

- Docker mock + 派测试号 (不在本机起测试节点; 不连生产 hub)
- WSClient unit + 集成 (mock 飞书事件) at M5
- 活体 E2E 等 Vincent 凭证 (不阻塞 M1-M5 工程)

## Out of scope

- WhatsApp / 企微 / Slack (post-MVP)
- 飞书消息进 Dashboard 拓扑 (走完整 §2.9 收尾 PR)
- agent 主动推 IM (RFC §12.9: P1 不做, P1.5 加 `anet im send` 新工具)
- 富交互卡片 (post-MVP)

## Branch policy

从 `origin/main` (8afe9f6) 切出 fresh feature branch. PR 标 Draft 至 M5 完, 期间每 milestone 一个 commit + commhub 进度 ping. Promote latest 前 Vincent confirm (runtime 级).
