### PR TITLE
[P0-1 #261] feishu worker supervised re-fork — kill silent bridge hang

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -2653,6 +2653,28 @@ function resolveFeishuWorkerPath(): string | null {
   return null;
 }
 
+// #261 P0-1 (2026-06-28): supervise the feishu worker. Pre-fix, a single
+// `spawn()` at startup + an `exit` handler that only `warn()`ed meant
+// any worker death (SIGTERM, crash, OOM, host hiccup, deploy restart of
+// the worker but not us) silently killed the bridge forever — today's
+// recurring "vAgent goes mute on prod" root cause.
+//
+// Supervise = mirror the connectSSE pattern (~2900 in this file):
+//   1. Loop until module-level `feishuShuttingDown` flag goes true.
+//   2. Each iteration spawns the worker, awaits its exit, then either:
+//      - shuttingDown → log + break (clean shutdown, no re-fork)
+//      - else → sleep with exponential backoff + jitter, then re-fork.
+//   3. Backoff: 1s → 2s → 4s … → cap 30s. Reset to 1s after the worker
+//      stays alive 30s (proxy for "stable") so a long-running worker
+//      that eventually crashes doesn't wait 30s for its first re-fork.
+//   4. shutdown() (this file ~3049) is updated in this PR to:
+//      - set `feishuShuttingDown = true`
+//      - SIGTERM every tracked child, SIGKILL fallback at 500ms
+//      so we don't leak workers (or worse, end up with 2 workers each
+//      WS-connected → double-reply to the same feishu event).
+let feishuShuttingDown = false;
+const feishuChildren = new Set<ReturnType<typeof import("node:child_process").spawn>>();
+
 async function connectFeishu(channel: FeishuChannel): Promise<void> {
   const workerPath = resolveFeishuWorkerPath();
   if (!workerPath) {
@@ -2664,12 +2686,65 @@ async function connectFeishu(channel: FeishuChannel): Promise<void> {
   }
 
   const { spawn } = await import("node:child_process");
-  const child = spawn(
-    process.execPath,
-    [workerPath, "--channel-dir", channel.dir, "--node-alias", ALIAS],
-    { stdio: ["ignore", "inherit", "inherit", "ipc"] },
-  );
 
+  const BASE_DELAY_MS = 1_000;
+  const MAX_DELAY_MS = 30_000;
+  const STABLE_RESET_MS = 30_000;  // worker stays alive this long → backoff back to BASE
+  let delay = BASE_DELAY_MS;
+
+  while (!feishuShuttingDown) {
+    const child = spawn(
+      process.execPath,
+      [workerPath, "--channel-dir", channel.dir, "--node-alias", ALIAS],
+      { stdio: ["ignore", "inherit", "inherit", "ipc"] },
+    );
+    feishuChildren.add(child);
+
+    // Stable-uptime timer — if the worker survives STABLE_RESET_MS without
+    // exiting, treat the backoff as recovered (reset to BASE_DELAY_MS).
+    const stableTimer = setTimeout(() => { delay = BASE_DELAY_MS; }, STABLE_RESET_MS);
+
+    wireFeishuChildHandlers(child, channel);
+
+    log(`[feishu] forked worker (pid ${child.pid}) for ${channel.dir} via ${workerPath}`);
+
+    // Block until the child exits — the `await` here is what makes the
+    // outer while-loop a supervisor instead of a fire-and-forget spawn.
+    const exitInfo = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+      child.once("exit", (code, signal) => resolve({ code, signal }));
+      child.once("error", (err) => {
+        // `error` typically precedes `exit` (failed spawn). Surface for
+        // operator visibility; the upcoming `exit` resolves the promise.
+        warn(`[feishu] worker error: ${err?.message || err}`);
+      });
+    });
+
+    clearTimeout(stableTimer);
+    feishuChildren.delete(child);
+    warn(`[feishu] worker exited code=${exitInfo.code} signal=${exitInfo.signal} dir=${channel.dir}`);
+
+    if (feishuShuttingDown) {
+      log(`[feishu] worker exited during shutdown — not re-forking`);
+      break;
+    }
+
+    // Jittered exponential backoff (±25%).
+    const jitter = delay * 0.25 * (Math.random() * 2 - 1);
+    const waitMs = Math.max(100, Math.round(delay + jitter));
+    warn(`[feishu] re-fork worker in ${waitMs}ms (backoff=${delay}ms, jittered)`);
+    await new Promise((r) => setTimeout(r, waitMs));
+    delay = Math.min(delay * 2, MAX_DELAY_MS);
+  }
+}
+
+// Wires the IPC `message` (think round-trip) + `exit`/`error` log handlers
+// onto a freshly-spawned worker child. Extracted from the original
+// connectFeishu body so the supervisor loop above can re-call it on each
+// re-fork without duplicating the entire handler body.
+function wireFeishuChildHandlers(
+  child: ReturnType<typeof import("node:child_process").spawn>,
+  channel: FeishuChannel,
+): void {
   child.on("message", (raw: unknown) => {
     if (!isFeishuIncomingEnvelope(raw)) return;
     const ev = raw.event;
@@ -2747,15 +2822,11 @@ async function connectFeishu(channel: FeishuChannel): Promise<void> {
     });
   });
 
-  child.on("exit", (code, signal) => {
-    warn(`[feishu] worker exited code=${code} signal=${signal} dir=${channel.dir}`);
-  });
-
-  child.on("error", (err) => {
-    warn(`[feishu] worker error: ${err?.message || err}`);
-  });
-
-  log(`[feishu] forked worker (pid ${child.pid}) for ${channel.dir} via ${workerPath}`);
+  // NOTE: exit/error handlers are now wired by the supervisor loop in
+  // `connectFeishu` above (via `child.once("exit", ...)` / `once("error",
+  // ...)`) so the loop can `await` the exit and decide whether to re-fork
+  // or break (per `feishuShuttingDown`). Don't add them here — that would
+  // double-fire warnings on every legitimate restart.
 }
 
 function isFeishuIncomingEnvelope(raw: unknown): raw is FeishuBridgeEnvelope {
@@ -3046,7 +3117,26 @@ if (goalsSchedulerEnabled) {
   setInterval(() => runGoalSchedulerTick().catch(() => {}), GOAL_TICK_MS);
   runGoalSchedulerTick().catch(() => {});
 }
-const shutdown = async () => { log("shutting down..."); await reportStatus("offline").catch(() => {}); process.exit(0); };
+const shutdown = async () => {
+  log("shutting down...");
+  // #261 P0-1 — gate the feishu supervisor loop so it stops re-forking
+  // on the soon-to-arrive child exit. SIGTERM each tracked worker (give
+  // it 500 ms to exit gracefully), then SIGKILL holdouts. Without this,
+  // workers either keep running orphaned OR the supervisor races a
+  // re-fork between our exit and Docker's container teardown — both
+  // produce zombie processes / double-WS / double-reply.
+  feishuShuttingDown = true;
+  for (const ch of feishuChildren) {
+    try { ch.kill("SIGTERM"); } catch { /* already dead */ }
+  }
+  setTimeout(() => {
+    for (const ch of feishuChildren) {
+      try { ch.kill("SIGKILL"); } catch { /* already dead */ }
+    }
+  }, 500);
+  await reportStatus("offline").catch(() => {});
+  process.exit(0);
+};
 process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
 for (const channel of TELEGRAM_CHANNELS) connectTelegram(channel);

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -2710,12 +2710,25 @@ async function connectFeishu(channel: FeishuChannel): Promise<void> {
 
     // Block until the child exits — the `await` here is what makes the
     // outer while-loop a supervisor instead of a fire-and-forget spawn.
+    // BOTH `exit` AND `error` must resolve the promise: a failed spawn
+    // (ENOENT for a missing worker path, EACCES on permissions, EMFILE,
+    // etc.) emits `error` WITHOUT a matching `exit` — pre-fix the await
+    // would block forever and the supervisor itself would dead-lock,
+    // never re-forking, never backing off (通信牛 PR #263 review catch).
+    // `settled` guards against the exit+error double-fire case the
+    // Node child_process docs warn about: only the first resolution
+    // wins, second is dropped silently.
+    let settled = false;
     const exitInfo = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-      child.once("exit", (code, signal) => resolve({ code, signal }));
-      child.once("error", (err) => {
-        // `error` typically precedes `exit` (failed spawn). Surface for
-        // operator visibility; the upcoming `exit` resolves the promise.
+      const done = (v: { code: number | null; signal: NodeJS.Signals | null }) => {
+        if (settled) return;
+        settled = true;
+        resolve(v);
+      };
+      child.once("exit", (code, signal) => done({ code, signal }));
+      child.once("error", (err: any) => {
         warn(`[feishu] worker error: ${err?.message || err}`);
+        done({ code: null, signal: null });
       });
     });
 

--- a/docker/feishu/docker-compose.yml
+++ b/docker/feishu/docker-compose.yml
@@ -36,6 +36,23 @@ services:
         ANET_NODE_VERSION: ${ANET_NODE_VERSION:-2.4.15-preview.2}
     env_file: .env
     restart: unless-stopped
+    # #261 P0-1 (2026-06-28) — bridge-liveness healthcheck. Pre-fix, a
+    # dead worker left the container Up with no visible signal — operators
+    # only noticed when users stopped getting replies. The healthcheck
+    # looks for the worker process directly; combined with the agent-node-
+    # side supervised re-fork (cli.ts ~2680), a missing worker means we're
+    # either between re-fork backoff attempts OR the supervisor itself
+    # crashed (the only path that turns the container unhealthy).
+    # Compose marks the container UNHEALTHY when this consistently fails
+    # — `docker ps` surfaces it; some orchestrators auto-restart on
+    # unhealthy. compose itself does not, but the agent-node in-process
+    # supervisor is the primary recovery; this healthcheck is observability.
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f 'src/im/feishu/worker.js' >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     # Hard blast-radius limit: only ./ from the host, mapped to /work.
     # The agent runs `cd /work` and writes all state under /work/.anet,
     # so persistence works (survives container recreate) but nothing
@@ -57,10 +74,14 @@ services:
   # agent talks to this container instead of an external hub.
   hub:
     profiles: ["local-hub"]
-    image: node:24-alpine
+    # `commhub-server` binary's shebang is `#!/usr/bin/env bun` — node:alpine
+    # base lacks bun → exit 127 / "can't execute 'bun': No such file" on
+    # every start. Use oven/bun base + apk-add nodejs/npm for the npm install.
+    image: oven/bun:1-alpine
     container_name: anet-feishu-hub
     command: >-
-      sh -c "npm install -g --no-audit --no-fund @sleep2agi/commhub-server@preview
+      sh -c "apk add --no-cache nodejs npm
+      && npm install -g --no-audit --no-fund @sleep2agi/commhub-server@preview
       && commhub-server --dev-open"
     ports:
       - "9200:9200"


### PR DESCRIPTION
## Author
Agent: 通信工程马
Refs: #261 (P0-1 of the 2026-06-28 system review)

## Why

`connectFeishu` did a single `spawn()` + an `exit` handler that only `warn()`ed. Any worker death (SIGTERM, crash, OOM, host hiccup, plugin reload) silently muted the bridge forever — today's recurring "vAgent goes quiet on prod" root cause; only `docker compose restart` recovered.

## Changes

1. **`agent-node/src/cli.ts` `connectFeishu` (~2670)** — supervised while-loop mirroring the `connectSSE` re-connect pattern (~2900, in-prod-stable since #202):
   - Module-level `feishuShuttingDown` flag + `feishuChildren` Set for shutdown coordination.
   - Loop: spawn → await `exit` → `shuttingDown` ? break : jittered exponential backoff + re-fork.
   - Backoff `1s → 2s → 4s … cap 30s` with ±25% jitter; 30s of continuous uptime resets the backoff to base.
   - IPC `message`/event handler extracted into `wireFeishuChildHandlers` so the supervisor loop re-wires it per spawn without duplicating the body.

2. **`agent-node/src/cli.ts` `shutdown()` (~3049)** — kill all tracked workers before `process.exit`:
   - `feishuShuttingDown = true` (gates supervisor loop).
   - SIGTERM each tracked child; SIGKILL fallback at 500 ms.
   - Pre-fix: workers leaked orphaned past container teardown OR supervisor raced a re-fork between agent-node exit and Docker teardown → zombie processes / double-WS / double-reply.

3. **`docker/feishu/docker-compose.yml`** — bridge-liveness healthcheck:
   ```yaml
   healthcheck:
     test: ["CMD-SHELL", "pgrep -f 'src/im/feishu/worker.js' >/dev/null"]
     interval: 30s
     timeout: 5s
     retries: 3
     start_period: 60s
   ```
   Plus drive-by: `hub` service (`--profile local-hub`) base swap `node:24-alpine` → `oven/bun:1-alpine` + apk-add nodejs/npm. `commhub-server` bin shebang is `#!/usr/bin/env bun`; alpine without bun → exit 127.

## Verify — real Docker `docker exec kill worker` chain

Per 通信龙 "别只 typecheck" + `[[feedback_commit_presence_not_functional_proof]]`. Stub config with bad feishu app secret so worker WS-handshake fails (simulates real crash). Mock hub for agent register. Bind-mount patched dist over npm-installed `@sleep2agi/agent-node`.

Timeline from agent log:

```
23:19:47 [feishu] forked worker (pid 19)
23:19:47 [feishu:worker] bridge online
--- docker exec kill <pid 19> ---
23:20:11 [feishu] worker exited code=null signal=SIGTERM
23:20:11 [feishu] re-fork worker in 1246ms (backoff=1000ms, jittered)
23:20:12 [feishu] forked worker (pid 46)
23:20:12 [feishu:worker] bridge online
--- docker exec kill <pid 46> ---
23:20:16 [feishu] worker exited code=null signal=SIGTERM
23:20:16 [feishu] re-fork worker in 2402ms (backoff=2000ms, jittered)   ← BACKOFF DOUBLED
23:20:19 [feishu] forked worker (pid 73)
23:20:19 [feishu:worker] bridge online
--- docker stop --signal=SIGTERM <agent> ---
23:20:38 shutting down...
23:20:38 [feishu] worker exited code=null signal=SIGTERM
23:20:38 [feishu] worker exited during shutdown — not re-forking         ← shutdown-aware ✓
```

3 worker pid cycles all re-fork; jittered backoff doubles each iteration; shutdown gate prevents resurrection during teardown.

## Tests

- agent-node `bun test src/` → **236/236 pass** (no change vs main).
- `bun build` clean.
- Live `anet-feishu` container untouched throughout (regression gate — all test containers under isolated `feishu-p0-1-dryrun` namespace, network `p0-1-net`).

## Test plan (reviewer)

- [ ] Pull branch, run `bun test src/` in `agent-node/` → 236/0
- [ ] Read the supervisor diff + shutdown diff for any obvious race
- [ ] Optional: replicate the docker-exec-kill verify (instructions in commit message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)