### PR TITLE
fix(#257): COPY tests/lib/safe-rm.sh into qa-* containers — restore main CI green

### DIFF
--- a/tests/qa-cli-01-hub-start/Dockerfile
+++ b/tests/qa-cli-01-hub-start/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-cli-01-hub-start/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-cli-02-network-create/Dockerfile
+++ b/tests/qa-cli-02-network-create/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-cli-02-network-create/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-dash-07-auth-boundary/Dockerfile
+++ b/tests/qa-dash-07-auth-boundary/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-dash-07-auth-boundary/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-dash-08-cross-account-views/Dockerfile
+++ b/tests/qa-dash-08-cross-account-views/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-dash-08-cross-account-views/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-dash-10-incremental-poll/Dockerfile
+++ b/tests/qa-dash-10-incremental-poll/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-dash-10-incremental-poll/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-05-roundtrip/Dockerfile
+++ b/tests/qa-hub-05-roundtrip/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-hub-05-roundtrip/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-06-token-revoke/Dockerfile
+++ b/tests/qa-hub-06-token-revoke/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-hub-06-token-revoke/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-06b-cross-user-isolation/Dockerfile
+++ b/tests/qa-hub-06b-cross-user-isolation/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-hub-06b-cross-user-isolation/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-07-sse-reconnect/Dockerfile
+++ b/tests/qa-hub-07-sse-reconnect/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-hub-07-sse-reconnect/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-08-restart-persistence/Dockerfile
+++ b/tests/qa-hub-08-restart-persistence/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-hub-08-restart-persistence/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-09-task-state-machine/Dockerfile
+++ b/tests/qa-hub-09-task-state-machine/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-hub-09-task-state-machine/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-10-network-scope-regressions/Dockerfile
+++ b/tests/qa-hub-10-network-scope-regressions/Dockerfile
@@ -11,6 +11,7 @@ COPY server/src ./src
 
 WORKDIR /app
 COPY tests/qa-hub-10-network-scope-regressions/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-11-node-delete-sse/Dockerfile
+++ b/tests/qa-hub-11-node-delete-sse/Dockerfile
@@ -11,6 +11,7 @@ COPY server/src ./src
 
 WORKDIR /app
 COPY tests/qa-hub-11-node-delete-sse/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-12-servers-endpoint/Dockerfile
+++ b/tests/qa-hub-12-servers-endpoint/Dockerfile
@@ -11,6 +11,7 @@ COPY server/src ./src
 
 WORKDIR /app
 COPY tests/qa-hub-12-servers-endpoint/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-13-server-health-agents/Dockerfile
+++ b/tests/qa-hub-13-server-health-agents/Dockerfile
@@ -11,6 +11,7 @@ COPY server/src ./src
 
 WORKDIR /app
 COPY tests/qa-hub-13-server-health-agents/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-16-rest-task-api/Dockerfile
+++ b/tests/qa-hub-16-rest-task-api/Dockerfile
@@ -11,6 +11,7 @@ COPY server/src ./src
 
 WORKDIR /app
 COPY tests/qa-hub-16-rest-task-api/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-18-delivery-semantics/Dockerfile
+++ b/tests/qa-hub-18-delivery-semantics/Dockerfile
@@ -11,6 +11,7 @@ COPY server/src ./src
 
 WORKDIR /app
 COPY tests/qa-hub-18-delivery-semantics/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-node-02-success-reply/Dockerfile
+++ b/tests/qa-node-02-success-reply/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-node-02-success-reply/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-node-03b-task-events/Dockerfile
+++ b/tests/qa-node-03b-task-events/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
 COPY tests/qa-node-03b-task-events/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]


### PR DESCRIPTION
## Author
Agent: 通信测试马 (claude-code-cli)
Dispatch: 通信龙 task 791d2afe → #257 lane
Origin: v0.11 onboarding 5-PR batch smoke (#236/#239/#241/#238/#244) discovered main CI red baseline → root-cause traced to one missing COPY.

## Summary

Main CI has been **red for 12 days / 133 commits** since `826c8a7` (P0 incident #2 sweep, 2026-06-16). All 13 L1 contract tests in `anet QA (v0)` cascade-fail with one identical signature:

```
✗ L1 qa-cli-01-hub-start — see /tmp/qa-l1-...-run.log
    /app/run.sh: line 20: /app/../lib/safe-rm.sh: No such file or directory
```

### Root cause

- `826c8a7` added `source ../lib/safe-rm.sh` to 19 `tests/qa-*/run.sh` scripts (destructive-rm guardrail wired into every test)
- It committed `tests/lib/safe-rm.sh` ✅
- It did **not** update the corresponding `Dockerfile`s — they still only `COPY tests/qa-X/run.sh /app/run.sh`
- Inside container: `${BASH_SOURCE[0]}` = `/app/run.sh`, so `$(dirname)/../lib/safe-rm.sh` = `/lib/safe-rm.sh` → `No such file`
- Every L1 test exits 1 at line ~20 before doing anything → 13/13 cascade red

The 5 PRs merged in this batch (#236/#239/#241/#238/#244) do **not** touch `tests/qa-*/Dockerfile` or `tests/lib/`, so they were correctly admin-merged ahead of this fix.

### Fix

One line added per Dockerfile (right after the `COPY ... run.sh` line):

```dockerfile
COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
```

This resolves the `/app/../lib/...` path the existing `run.sh` source statement expects, with zero run.sh changes.

19 Dockerfiles patched:
- `tests/qa-cli-{01,02}/Dockerfile`
- `tests/qa-dash-{07,08,10}/Dockerfile`
- `tests/qa-hub-{05,06,06b,07,08,09,10,11,12,13,16,18}/Dockerfile`
- `tests/qa-node-{02,03b}/Dockerfile`

**Not touched**: `qa-hub-{17,19}` (their `run.sh` doesn't source safe-rm.sh) and `qa-ut-*` (unit-test images, no `run.sh`).

## Verification

Rebuilt + ran one case locally on the patched branch:

```
$ docker build -t anet-qa-cli-01-fix -f tests/qa-cli-01-hub-start/Dockerfile .
... (no error)
$ docker run --rm anet-qa-cli-01-fix
[0] fresh state — no ~/.anet, no ~/.commhub
[1] start hub in background, capture banner
[2] /health 200
[3] PIN: banner content — header + starting line + URL
  ✓ banner shows header + 'Starting CommHub Server' + 127.0.0.1
[4] PIN: ~/.anet/server/admin-utok.json落地，mode 600
  ✓ admin-utok.json mode 600 + utok_ inside
[5] admin utok actually works for /api/auth/me
  ✓ admin-utok auths as admin role
[6] port 9200 bound — direct TCP check
[7] PIN: re-run 'anet hub start' detects already-running, doesn't double-start
  ✓ idempotent: second run says 'already running'
  ✓ admin-utok.json preserved (no re-bootstrap)
[8] anet -v matches the binary that started the hub
  anet v2.2.22-preview.4
rc=0
```

The `source ../lib/safe-rm.sh` now succeeds (would have died at line ~20 otherwise) and the full test reaches PIN 8 cleanly.

## Test plan
- [x] Local Docker build of `qa-cli-01-hub-start` succeeds with patched Dockerfile
- [x] Local Docker run reaches PIN 8 with rc=0 (proves `source ../lib/safe-rm.sh` resolves)
- [ ] CI `anet QA (v0)` workflow returns green on this PR
- [ ] After merge: `anet QA (v0)` on next main push returns green for the first time since 826c8a7

## Out of scope (separate follow-up)

`Docker E2E Tests` workflow also red on main (Base E2E: 90 pass / 45 fail). Different failure signature — not part of this L1 cascade. I'll open a follow-up issue to scope it independently.

Refs: #257 (CI red baseline), #261 (P1 — no release CI gate, related context)