### PR TITLE
[P1-① #261] claude-agent-sdk 429/quota fast-fail + empty-result soft-fail (M3 root-cause)

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -42,6 +42,11 @@ import {
 } from "./runtime/grok-build-acp/resume-hint";
 import { CurrentAliasResolver } from "./runtime/current-alias";
 import { delegationTargetExists } from "./runtime/delegation-precheck";
+import {
+  isRateLimitOrQuotaError,
+  isEmptyResultSoftFailure,
+  quotaRemediationHint,
+} from "./runtime/claude-error-classify";
 
 const home = homedir();
 
@@ -1541,9 +1546,25 @@ async function processWithClaude(task: string, from: string, images?: string[]):
           const dt = Date.now() - t0;
           const u = m.usage || {};
           log(`[claude] ${m.subtype} | ${dt}ms | $${m.total_cost_usd?.toFixed(4) || "?"} | in=${u.input_tokens || 0} out=${u.output_tokens || 0} | turns=${m.num_turns}${attempt > 0 ? ` | attempt=${attempt + 1}` : ""}`);
-          result = m.subtype === "success"
-            ? m.result || "任务完成"
-            : `执行出错: ${m.error || m.result || "未知错误"}`;
+          if (m.subtype === "success") {
+            // #261 P1-① (2026-06-28) — empty-result soft-failure gate.
+            // Pre-fix `m.result || "任务完成"` silently rebranded an
+            // empty vendor reply as "task complete" — root cause of the
+            // M3 incident where a silent rate-limit produced 0 output
+            // tokens but the upstream caller saw "任务完成" and moved on.
+            // Now: classifier surfaces the empty reply as a soft fail
+            // with a vendor-specific hint, so the next hop / operator
+            // sees the truth.
+            if (isEmptyResultSoftFailure(m)) {
+              const hint = quotaRemediationHint(process.env.ANTHROPIC_BASE_URL);
+              log(`[claude] ✗ vendor returned EMPTY result despite success subtype (in=${u.input_tokens || 0}, out=${u.output_tokens || 0}, result.len=${String(m.result || "").length}) — treating as soft fail`);
+              result = `执行出错: vendor 返回空响应 (in=${u.input_tokens || 0} out=${u.output_tokens || 0}) — 疑似 vendor 静默限流/配额. ${hint}`;
+            } else {
+              result = m.result;
+            }
+          } else {
+            result = `执行出错: ${m.error || m.result || "未知错误"}`;
+          }
         }
       }
       if (timer) clearTimeout(timer);
@@ -1559,6 +1580,21 @@ async function processWithClaude(task: string, from: string, images?: string[]):
         log(`[anet] FATAL: Vendor API auth failed — ${msg.slice(0, 100)}`);
         log(`[anet]        ${remediationHint(msg)}`);
         return `执行出错: vendor API auth failed (${msg.slice(0, 80)}) — refresh API key and re-export ENV var; see agent-node log for vendor-specific URL`;
+      }
+
+      // #261 P1-① — fast-fail on vendor rate-limit / quota / overload.
+      // Pre-fix these would burn the full retry chain (4s + 8s backoff
+      // each, 3 attempts × per-attempt timeout — up to ~15min of futile
+      // retries before returning the generic "claude-agent-sdk 调用超时"
+      // string). The operator action (raise quota / lower concurrency /
+      // wait for window reset) is unblocked only by an explicit
+      // classifier message; spending 15min on backoff doesn't help.
+      // Mirror the auth-error fast-fail pattern.
+      if (isRateLimitOrQuotaError(msg)) {
+        const hint = quotaRemediationHint(process.env.ANTHROPIC_BASE_URL);
+        log(`[claude] ✗ vendor rate-limit/quota: ${msg.slice(0, 150)}`);
+        log(`[anet]        ${hint}`);
+        return `执行出错: vendor 限流/配额耗尽 (${msg.slice(0, 80)}) — ${hint}`;
       }
 
       lastErr = msg;

--- a/agent-node/src/runtime/claude-error-classify.test.ts
+++ b/agent-node/src/runtime/claude-error-classify.test.ts
@@ -1,0 +1,149 @@
+// Unit coverage for the rate-limit / empty-result classifiers extracted
+// from cli.ts. Each describe block targets one of the failure modes the
+// #261 P1-① review flagged — see claude-error-classify.ts header for
+// the M3 incident reference.
+
+import { describe, expect, test } from "bun:test";
+import {
+  isRateLimitOrQuotaError,
+  isEmptyResultSoftFailure,
+  quotaRemediationHint,
+} from "./claude-error-classify";
+
+describe("isRateLimitOrQuotaError — POSITIVE (must classify as quota/rate-limit)", () => {
+  test("HTTP 429 standalone", () => {
+    expect(isRateLimitOrQuotaError("HTTP 429 from vendor")).toBe(true);
+  });
+  test("HTTP 529 overloaded (Anthropic spec)", () => {
+    expect(isRateLimitOrQuotaError("Got 529 from API")).toBe(true);
+  });
+  test("rate_limit_exceeded (Anthropic / OpenAI shape)", () => {
+    expect(isRateLimitOrQuotaError("error: rate_limit_exceeded")).toBe(true);
+  });
+  test("rate-limit hyphen variant", () => {
+    expect(isRateLimitOrQuotaError("rate-limit hit")).toBe(true);
+  });
+  test("rate limit space variant", () => {
+    expect(isRateLimitOrQuotaError("you have hit your rate limit")).toBe(true);
+  });
+  test("quota exceeded phrase", () => {
+    expect(isRateLimitOrQuotaError("quota exceeded for the day")).toBe(true);
+  });
+  test("quota exhausted phrase", () => {
+    expect(isRateLimitOrQuotaError("monthly quota exhausted")).toBe(true);
+  });
+  test("Anthropic spec overloaded_error", () => {
+    expect(isRateLimitOrQuotaError("API returned overloaded_error")).toBe(true);
+  });
+  test("plain overloaded mention", () => {
+    expect(isRateLimitOrQuotaError("server overloaded, please try later")).toBe(true);
+  });
+  test("too_many_requests OpenAI-compat", () => {
+    expect(isRateLimitOrQuotaError("too_many_requests")).toBe(true);
+  });
+  test("too many requests space form", () => {
+    expect(isRateLimitOrQuotaError("Too Many Requests")).toBe(true);
+  });
+  test("insufficient_quota OpenAI shape", () => {
+    expect(isRateLimitOrQuotaError("error code: insufficient_quota")).toBe(true);
+  });
+  test("usage_limit hit", () => {
+    expect(isRateLimitOrQuotaError("usage_limit reached for free tier")).toBe(true);
+  });
+  test("MiniMax Chinese Token Plan 上限", () => {
+    expect(isRateLimitOrQuotaError("Token Plan 上限 reached")).toBe(true);
+  });
+  test("capacity exceeded vendor message", () => {
+    expect(isRateLimitOrQuotaError("regional capacity-exceeded")).toBe(true);
+  });
+});
+
+describe("isRateLimitOrQuotaError — NEGATIVE (regression gate, must NOT match)", () => {
+  test("401 unauthorized (auth, not quota)", () => {
+    expect(isRateLimitOrQuotaError("HTTP 401 unauthorized")).toBe(false);
+  });
+  test("403 forbidden (auth, not quota)", () => {
+    expect(isRateLimitOrQuotaError("403 forbidden")).toBe(false);
+  });
+  test("plain timeout (not quota)", () => {
+    expect(isRateLimitOrQuotaError("request timed out after 120s")).toBe(false);
+  });
+  test("400 bad request (not quota)", () => {
+    expect(isRateLimitOrQuotaError("400 invalid request body")).toBe(false);
+  });
+  test("499 client closed (not quota)", () => {
+    expect(isRateLimitOrQuotaError("499 client closed request")).toBe(false);
+  });
+  test("ETIMEDOUT network error (not quota)", () => {
+    expect(isRateLimitOrQuotaError("ETIMEDOUT connect")).toBe(false);
+  });
+  test("HTTP 4290 not a real status (avoid false positive on substring)", () => {
+    // Note: this DOES match `\b429\b` if "4290" were tokenized weirdly,
+    // but `\b` enforces word boundary so 4290 won't match. Belt + braces.
+    expect(isRateLimitOrQuotaError("ref token: 4290abc")).toBe(false);
+  });
+  test("empty string", () => {
+    expect(isRateLimitOrQuotaError("")).toBe(false);
+  });
+  test("null / undefined", () => {
+    expect(isRateLimitOrQuotaError(null)).toBe(false);
+    expect(isRateLimitOrQuotaError(undefined)).toBe(false);
+  });
+});
+
+describe("isEmptyResultSoftFailure — POSITIVE (must flag as empty-vendor-reply)", () => {
+  test("result null + output_tokens 0", () => {
+    expect(isEmptyResultSoftFailure({ result: null, usage: { input_tokens: 100, output_tokens: 0 } })).toBe(true);
+  });
+  test("result undefined (M3 incident shape)", () => {
+    expect(isEmptyResultSoftFailure({ usage: { output_tokens: 0 } })).toBe(true);
+  });
+  test("result empty string but usage non-zero", () => {
+    expect(isEmptyResultSoftFailure({ result: "", usage: { output_tokens: 5 } })).toBe(true);
+  });
+  test("result has text but output_tokens 0 (suspicious)", () => {
+    // Vendor returned text but 0 output_tokens reported — flagged because
+    // the consistent-state invariant is broken; the lying-usage case is
+    // also worth surfacing rather than silently shipping.
+    expect(isEmptyResultSoftFailure({ result: "some text", usage: { output_tokens: 0 } })).toBe(true);
+  });
+  test("usage missing entirely (defaulting to 1 = non-zero) but result empty", () => {
+    expect(isEmptyResultSoftFailure({ result: "" })).toBe(true);
+  });
+});
+
+describe("isEmptyResultSoftFailure — NEGATIVE (regression gate, normal success)", () => {
+  test("normal success — result + non-zero tokens", () => {
+    expect(isEmptyResultSoftFailure({ result: "Done.", usage: { input_tokens: 100, output_tokens: 5 } })).toBe(false);
+  });
+  test("short single-char reply still counts as success", () => {
+    expect(isEmptyResultSoftFailure({ result: "0", usage: { output_tokens: 1 } })).toBe(false);
+  });
+  test("usage entirely missing but result non-empty", () => {
+    // We default missing output_tokens to 1 (non-zero) — don't penalise
+    // a vendor that just doesn't report usage.
+    expect(isEmptyResultSoftFailure({ result: "Reply text." })).toBe(false);
+  });
+});
+
+describe("quotaRemediationHint — vendor URL routing", () => {
+  test("intern-ai routing", () => {
+    expect(quotaRemediationHint("https://chat.intern-ai.org.cn")).toMatch(/chat\.intern-ai\.org\.cn/);
+  });
+  test("minimax routing", () => {
+    expect(quotaRemediationHint("https://api.minimaxi.com/anthropic")).toMatch(/platform\.minimaxi\.com/);
+  });
+  test("deepseek routing", () => {
+    expect(quotaRemediationHint("https://api.deepseek.com/anthropic")).toMatch(/platform\.deepseek\.com/);
+  });
+  test("anthropic-native routing", () => {
+    expect(quotaRemediationHint("https://api.anthropic.com")).toMatch(/console\.anthropic\.com/);
+  });
+  test("unknown vendor falls back to generic hint", () => {
+    expect(quotaRemediationHint("https://my-private-llm.example.com")).toMatch(/vendor 配额/);
+  });
+  test("empty / undefined → generic", () => {
+    expect(quotaRemediationHint(undefined)).toMatch(/vendor 配额/);
+    expect(quotaRemediationHint("")).toMatch(/vendor 配额/);
+  });
+});

--- a/agent-node/src/runtime/claude-error-classify.ts
+++ b/agent-node/src/runtime/claude-error-classify.ts
@@ -1,0 +1,92 @@
+// Claude-agent-sdk error & result classifiers, extracted from cli.ts so
+// the patterns can be unit-tested without spinning up the SDK.
+//
+// Two classifiers, both pure:
+//
+//   isRateLimitOrQuotaError(msg)
+//     Detects HTTP 429 / 529, rate_limit / quota / overloaded shapes
+//     across the Anthropic-compat endpoints anet talks to (Anthropic
+//     native, deepseek-v4-pro, MiniMax-M3 / M2.x, intern-s2-preview,
+//     小米 MiMo). Each vendor surfaces rate-limit errors slightly
+//     differently — anet treats them as a single failure class.
+//
+//   isEmptyResultSoftFailure({ result, usage })
+//     SDK can emit `subtype: "success"` with EMPTY content blocks
+//     when the vendor accepts the request but returns no text. M3
+//     incident 2026-06-XX surfaced exactly this — the result block
+//     fell through `m.result || "任务完成"` and got silently
+//     rebranded as "task complete" to the upstream caller. This
+//     classifier promotes that to a soft failure so the user / next
+//     hop sees the empty-vendor-response truth.
+//
+// Both classifiers are pure (no I/O, no globals) — drop them into
+// cli.ts's existing retry/return chain at the matching call sites.
+
+/**
+ * True if `msg` looks like a vendor-side rate-limit / quota / overload
+ * signal. Used to short-circuit the 4s+8s retry chain in cli.ts with
+ * an explicit operator-actionable message — pre-fix, the same generic
+ * "claude-agent-sdk 调用超时" string came back after 15 min of futile
+ * retries.
+ *
+ * Detection strategy: a single regex that matches HTTP status codes
+ * (429/529 as word-boundary integers), the standard `rate_limit` /
+ * `rate limit` / `rate-limit` token, the `quota exceeded` / `quota
+ * exhausted` / `insufficient quota` phrases, the Anthropic-spec
+ * `overloaded` / `overloaded_error` token, and the OpenAI-compat
+ * `too_many_requests` token. Case-insensitive throughout.
+ */
+export function isRateLimitOrQuotaError(msg: string | null | undefined): boolean {
+  if (!msg) return false;
+  return /\b(429|529)\b|rate[_\s-]?limit|quota[_\s-]?(exceeded|exhaust)|overloaded(_error)?|too[_\s-]?many[_\s-]?requests|usage[_\s-]?limit|insufficient[_\s-]?quota|capacity[_\s-]?exceeded|token\s*plan.*(上限|exceeded)/i.test(
+    msg,
+  );
+}
+
+/**
+ * Per-vendor hint mapping ANTHROPIC_BASE_URL → "where to check quota".
+ * Mirrors the auth-error remediationHint shape in cli.ts but pointed at
+ * vendor usage dashboards instead of API-key reissue pages.
+ */
+export function quotaRemediationHint(anthropicBaseUrl: string | null | undefined): string {
+  const base = (anthropicBaseUrl || "").toLowerCase();
+  if (base.includes("intern-ai.org.cn")) return "→ 检查 chat.intern-ai.org.cn 配额/Token Plan 上限/降并发";
+  if (base.includes("minimaxi") || base.includes("minimax")) return "→ 检查 platform.minimaxi.com 配额/Token Plan 上限/降并发";
+  if (base.includes("deepseek")) return "→ 检查 platform.deepseek.com 配额/账户余额/降并发";
+  if (base.includes("anthropic")) return "→ 检查 console.anthropic.com 配额/usage limit/降并发";
+  if (base.includes("xiaomimimo") || base.includes("mimo")) return "→ 检查 platform.xiaomimimo.com 配额/降并发";
+  return "→ 检查 vendor 配额/限流 dashboard / 降并发";
+}
+
+/**
+ * SDK result-message shape the classifier cares about. Mirrors the
+ * fields cli.ts already reads — no need to import the full SDK type
+ * (which is huge and the SDK ships only as a runtime dep).
+ */
+export interface ClaudeResultLike {
+  result?: string | null;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    [k: string]: unknown;
+  } | null;
+}
+
+/**
+ * True when a `subtype: "success"` SDK result is actually an empty
+ * vendor reply — `result` is null/empty AND/OR `usage.output_tokens`
+ * is 0. Either signal alone is enough; both together is the canonical
+ * "vendor accepted, generated nothing" shape we've seen across rate-
+ * limited vendors. Note `result === "0"` (string "0") is non-empty and
+ * NOT a soft failure — only `null` / `undefined` / empty string `""`
+ * count as empty.
+ *
+ * Caller responsibility: only invoke this when SDK already said
+ * `subtype === "success"`. Failures (`error` subtype etc.) have their
+ * own classification path.
+ */
+export function isEmptyResultSoftFailure(m: ClaudeResultLike): boolean {
+  const emptyContent = m.result === null || m.result === undefined || m.result === "";
+  const zeroOut = (m.usage?.output_tokens ?? 1) === 0;
+  return emptyContent || zeroOut;
+}


### PR DESCRIPTION
## Author
Agent: 通信工程马
Refs: #261 (P1-①)

## Why

Two long-standing failure modes in the claude-agent-sdk runtime that produced misleading-success / 15-min wasted-retry outcomes — both root-causes of the M3 incident.

## Changes (3 files, +280/-3 — 2 new helpers + cli.ts glue)

### 1. `isRateLimitOrQuotaError` fast-fail

Pre-fix, `isAuthError` matched 401/403 and short-circuited the retry chain, but 429 / 529 / rate-limit / quota / overloaded errors burned the full backoff (4s + 8s × 3 attempts × per-attempt timeout = up to ~15min) before returning the generic `claude-agent-sdk 调用超时` string. Operator action (raise quota / lower concurrency) is unblocked by an explicit message, NOT by 15min of backoff.

New `isRateLimitOrQuotaError(msg)` classifier matches HTTP 429/529, `rate_limit`/`rate-limit`/`rate limit`, `quota_exceeded`/`exhausted`/`insufficient_quota`, `overloaded`/`overloaded_error`, `too_many_requests`, `usage_limit`, `capacity_exceeded`, and Chinese `Token Plan 上限` (MiniMax-specific). Plus `quotaRemediationHint(ANTHROPIC_BASE_URL)` routes to the vendor dashboard URL.

cli.ts catch block short-circuits AFTER the auth-error check — exact mirror of the auth-error pattern.

### 2. Empty-result soft-failure

Pre-fix: `result = m.subtype === "success" ? m.result || "任务完成" : ...`. If vendor accepts the request but returns empty content blocks AND `usage.output_tokens === 0`, `||` falls through to `"任务完成"` — silently lying about empty vendor reply.

M3 incident shape exactly: silent rate-limit produced 0 output tokens, upstream caller saw "任务完成" and moved on.

New `isEmptyResultSoftFailure({result, usage})`: empty when `result` is null/undefined/`""` OR `usage.output_tokens === 0`. Missing usage entirely is NOT counted (don't penalise vendors that just don't report usage). Returns a soft-fail string with vendor hint so the next hop sees truth.

## Verification — 38 new unit tests

```
isRateLimitOrQuotaError:
  15 POS — 429 / 529 / rate_limit variants / quota_exceeded / overloaded /
           too_many_requests / usage_limit / Token Plan 上限 / capacity_exceeded
  9 NEG — 401 / 403 / timeout / 400 / 499 / ETIMEDOUT / 4290 false-positive guard /
          empty / null

isEmptyResultSoftFailure:
  5 POS — null + 0 tokens / undefined / empty string / suspicious-zero-tokens-with-text /
          missing usage + empty result
  3 NEG — normal success / single-char `"0"` result / missing usage but text present

quotaRemediationHint:
  6 POS — intern-ai / minimaxi / deepseek / anthropic / xiaomimimo / generic fallback
```

All 38 pass. Agent-node `bun test src/` → **236 → 274** (no pre-existing tests broken). `bun build` clean.

**Why pure helpers + unit tests, not E2E**: SDK `query()` needs real claude binary + vendor key + actual vendor 429 (quota state changes between runs — non-reproducible). Pure-helper extraction lets every classification path be deterministically tested + the cli.ts glue is 5-line if/return at each call site, easy to read-review.

## Test plan (reviewer)

- [ ] Pull branch, `cd agent-node && bun test src/runtime/claude-error-classify.test.ts` → 38/0
- [ ] Read `claude-error-classify.ts` for the regex + the two glue call sites in `cli.ts`
- [ ] Confirm short-circuit ordering: auth-error first, then rate-limit/quota, then existing retry-backoff
- [ ] Optional: grep `dist/cli.js` for `vendor 限流` / `EMPTY result despite success` — both present after build

## Lane-serial next

- ② codex-sdk turn timeout (`cli.ts:1375-1483`)
- ③ grok-build-acp handshake 300s decouple (`runtime/grok-build-acp/runtime.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)