### PR TITLE
fix(#268): align qa-* test from_session with ntok-bound alias — restore 13/13 L1 green

### DIFF
--- a/tests/qa-dash-08-cross-account-views/run.sh
+++ b/tests/qa-dash-08-cross-account-views/run.sh
@@ -86,9 +86,9 @@ mcp_call "$ALICE_NTOK" "report_status" "$ARG" | jq -e '.ok == true' >/dev/null \
   || { echo "FAIL: alice report_status"; exit 1; }
 # dispatch + reply (so /api/completions gets a row)
 ARG=$(jq -nc --arg net "$ALICE_NET" \
-  '{alias:"alice-secret-agent",task:"alice-confidential-task",priority:"normal",network_id:$net,from_session:"alice"}')
+  '{alias:"alice-secret-agent",task:"alice-confidential-task",priority:"normal",network_id:$net,from_session:"alice-secret-agent"}')
 TASK_ID=$(mcp_call "$ALICE_NTOK" "send_task" "$ARG" | jq -r '.message_id')
-[[ -n "$TASK_ID" ]] || { echo "FAIL: no task id"; exit 1; }
+[[ -n "$TASK_ID" && "$TASK_ID" != "null" ]] || { echo "FAIL: no task id"; exit 1; }
 ARG=$(jq -nc --arg t "$TASK_ID" \
   '{alias:"alice",text:"alice-private-reply-text",in_reply_to:$t,status:"replied",from_session:"alice-secret-agent"}')
 mcp_call "$ALICE_NTOK" "send_reply" "$ARG" | jq -e '.ok == true' >/dev/null \

--- a/tests/qa-dash-10-incremental-poll/run.sh
+++ b/tests/qa-dash-10-incremental-poll/run.sh
@@ -79,7 +79,7 @@ mcp_call "$NTOK" "report_status" "$ARG" | jq -e '.ok == true' >/dev/null \
 do_send() {
   local text="$1"
   ARG=$(jq -nc --arg net "$NET_ID" --arg t "$text" \
-    '{alias:"dash10-agent",task:$t,priority:"normal",network_id:$net,from_session:"admin"}')
+    '{alias:"dash10-agent",task:$t,priority:"normal",network_id:$net,from_session:"dash10-agent"}')
   mcp_call "$NTOK" "send_task" "$ARG" | jq -r '.message_id'
 }
 

--- a/tests/qa-hub-06b-cross-user-isolation/run.sh
+++ b/tests/qa-hub-06b-cross-user-isolation/run.sh
@@ -94,7 +94,7 @@ mcp_call "$ALICE_NTOK" "report_status" "$ARG" | jq -e '.ok == true' >/dev/null \
 
 echo "[3] alice sends a 'top-secret-alice' task to alice-agent"
 ARG=$(jq -nc --arg a "alice-agent" --arg t "top-secret-alice-payload" --arg net "$ALICE_NET" \
-  '{alias:$a,task:$t,priority:"normal",network_id:$net,from_session:"alice"}')
+  '{alias:$a,task:$t,priority:"normal",network_id:$net,from_session:"alice-agent"}')
 mcp_call "$ALICE_NTOK" "send_task" "$ARG" | jq -e '.message_id' >/dev/null \
   || { echo "FAIL: alice send_task"; exit 1; }
 

--- a/tests/qa-hub-09-task-state-machine/run.sh
+++ b/tests/qa-hub-09-task-state-machine/run.sh
@@ -128,7 +128,7 @@ echo "[5] BRANCH cancelled: send → cancel_task"
 T_CXL=$(send_task "$UTOK" "$NET_ID" "agent-09" "task-cancelled")
 [[ "$(task_field "$UTOK" "$NET_ID" "$T_CXL" status)" == "delivered" ]] || \
   { echo "FAIL: cancel PRE != delivered"; exit 1; }
-ARG=$(jq -nc --arg t "$T_CXL" '{task_id:$t,reason:"user changed mind",from_session:"admin"}')
+ARG=$(jq -nc --arg t "$T_CXL" '{task_id:$t,reason:"user changed mind",from_session:"agent-09"}')
 # cancel_task needs a network-scoped writer (canWrite). Use NTOK (which is
 # bound to NET_ID) — agent-09 cancelling a task targeted at itself.
 CXL_RESP=$(mcp_call "$NTOK" "cancel_task" "$ARG")
@@ -163,7 +163,7 @@ sleep 0.2
   { echo "FAIL: terminal task.status changed on second send_reply"; exit 1; }
 
 echo "[8] PIN: cancel_task on already-cancelled task returns ok:false"
-ARG=$(jq -nc --arg t "$T_CXL" '{task_id:$t,reason:"again",from_session:"admin"}')
+ARG=$(jq -nc --arg t "$T_CXL" '{task_id:$t,reason:"again",from_session:"agent-09"}')
 CXL2=$(mcp_call "$NTOK" "cancel_task" "$ARG")
 # cancel_task's WHERE excludes terminal states → changes=0 → ok:false
 echo "$CXL2" | jq -e '.ok == false' >/dev/null \


### PR DESCRIPTION
## Author
Agent: 通信测试马 (claude-code-cli)
Dispatch: 通信龙 task 0d89d6f2 → push directly (mechanical low-risk, same pattern as #265)
Refs: #268 (4 L1 fails), #265 (cascade fix), #257

## Summary

#265 cleared the L1 cascade; the next QA run showed **9/13 PASS, 4 fail** — all 4 with the same `from_session_identity_mismatch` signature. This PR fixes the 4 test scripts.

## Root cause

`bf564fb` (#203 fix, 2026-05-28) tightened a server-side check: an NTOK request's `from_session` must match the alias the NTOK is bound to. Four `qa-*` tests pre-date that fix and still send the wrong value, so the server (correctly) rejects them.

| test | NTOK bound to | was | now |
|---|---|---|---|
| qa-hub-09-task-state-machine | `agent-09` | `"admin"` | `"agent-09"` |
| qa-hub-06b-cross-user-isolation | `alice-agent` | `"alice"` | `"alice-agent"` |
| qa-dash-08-cross-account-views | `alice-secret-agent` | `"alice"` | `"alice-secret-agent"` |
| qa-dash-10-incremental-poll | `dash10-agent` | `"admin"` | `"dash10-agent"` |

## Real isolation contract VERIFIED INTACT (not a security bug)

The biggest risk if this had been a real bug: cross-user isolation broken. I patched only `qa-hub-06b`'s `from_session` and re-ran — **all 11 isolation PINs PASS**, including:

```
[4] PIN: bob's /api/networks does NOT include alice-private    ✓
[5] PIN: bob's /api/tasks does NOT include alice's task        ✓
[6] PIN: bob's /api/status does NOT include alice-agent        ✓
[7] PIN: bob's /api/messages does NOT contain alice's secret   ✓
[8] PIN: bob DIRECT IDOR — query alice's network_id            ✓ (HTTP 403)
[9] PIN: bob CANNOT POST /api/task to alice-agent              ✓ (HTTP 403)
[10] PIN: bob CANNOT mint ntok for alice's network             ✓ (HTTP 400)
```

The `#203` check has silently been doing its job all along — these tests were just sending nonsense values that the safe-rm cascade was hiding.

## Bonus null-guard fix (qa-dash-08)

`jq -r .message_id` emits the literal string `"null"` when the field is missing, so `[[ -n "$TASK_ID" ]]` is true for `TASK_ID="null"`. The test proceeded with garbage and mis-attributed the failure to `send_reply`. Tightened to `[[ -n "$TASK_ID" && "$TASK_ID" != "null" ]]` so the assertion fails at the actual point of breakage.

A wider null-guard hygiene sweep is **out of scope** for this PR — noted in #268 as a follow-up.

## Test plan
- [x] Local Docker build + run all 4 cases → PASS
  - `qa-hub-09-task-state-machine` → PASS (replied/failed/cancelled + terminal no-op)
  - `qa-hub-06b-cross-user-isolation` → PASS (11 isolation PINs incl. IDOR/inject/mint)
  - `qa-dash-08-cross-account-views` → PASS (nodes/stats/completions/tasks/tokens/task_events)
  - `qa-dash-10-incremental-poll` → PASS (since= filter on both endpoints + format gap)
- [ ] `anet QA (v0)` on this PR returns green
- [ ] After merge: `anet QA (v0)` on main returns **13/13 PASS** for the first time since `826c8a7`

## Out of scope
- Docker E2E (`Base E2E` 45 fail) — tracked in #266, independent harness.
- Broader null-guard sweep — tracked against #268 as hygiene follow-up.