### PR TITLE
[security][v0.11] telegram allowFrom fail-closed + shared access resolver

### DIFF
--- a/agent-network/src/im/access-resolve.test.ts
+++ b/agent-network/src/im/access-resolve.test.ts
@@ -1,0 +1,324 @@
+// Coverage for the inbound-channel access resolver. The fail-closed
+// flip is a deliberate security change in v0.11 — these tests pin the
+// new behaviour so a future "convenience" patch can't quietly restore
+// the old fail-open default.
+
+import { describe, expect, test } from "bun:test";
+import {
+  resolveTelegramAccess,
+  resolveFeishuAccess,
+  normalizeAllowFrom,
+  buildEmptyAllowlistWarn,
+} from "./access-resolve";
+
+describe("normalizeAllowFrom — input shapes", () => {
+  test("real string[] passes through deduped (filter empty strings)", () => {
+    const r = normalizeAllowFrom(["123", "@vansin", "", "456"]);
+    expect(r.list).toEqual(["123", "@vansin", "456"]);
+    expect(r.malformed).toBe(false);
+  });
+
+  test("undefined → empty + not malformed", () => {
+    expect(normalizeAllowFrom(undefined)).toEqual({ list: [], malformed: false });
+  });
+
+  test("null → empty + not malformed", () => {
+    expect(normalizeAllowFrom(null)).toEqual({ list: [], malformed: false });
+  });
+
+  test("non-array object → empty + malformed (corrupted access.json shape)", () => {
+    expect(normalizeAllowFrom({ allowFrom: ["123"] })).toEqual({ list: [], malformed: true });
+  });
+
+  test("string instead of array → malformed", () => {
+    expect(normalizeAllowFrom("123")).toEqual({ list: [], malformed: true });
+  });
+
+  test("array with non-string elements drops them", () => {
+    const r = normalizeAllowFrom([123, "valid", null, "ok"]);
+    expect(r.list).toEqual(["valid", "ok"]);
+    expect(r.malformed).toBe(false);
+  });
+});
+
+describe("resolveTelegramAccess — fail-closed empty allowFrom (v0.11 security change)", () => {
+  test("empty array → deny with empty-fail-closed kind", () => {
+    const d = resolveTelegramAccess({ allowFrom: [], senderId: "123" });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+    expect(d.reason).toContain("fail-closed");
+  });
+
+  test("undefined → deny", () => {
+    const d = resolveTelegramAccess({ allowFrom: undefined, senderId: "123" });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+  });
+
+  test("malformed → deny + reason mentions malformed", () => {
+    const d = resolveTelegramAccess({ allowFrom: "garbage", senderId: "123" });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+    expect(d.reason).toMatch(/malformed/);
+  });
+});
+
+describe("resolveTelegramAccess — wildcard '*' opens the channel", () => {
+  test("['*'] alone allows any sender", () => {
+    const d = resolveTelegramAccess({ allowFrom: ["*"], senderId: "anyone" });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("wildcard-allow");
+  });
+
+  test("['*', 'specific_id'] still wildcard-allows (wins precedence)", () => {
+    const d = resolveTelegramAccess({ allowFrom: ["*", "123"], senderId: "stranger" });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("wildcard-allow");
+  });
+});
+
+describe("resolveTelegramAccess — explicit id / username matching", () => {
+  test("senderId in list → allow", () => {
+    const d = resolveTelegramAccess({ allowFrom: ["123", "456"], senderId: "456" });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("explicit-allow");
+    expect(d.reason).toContain("456");
+  });
+
+  test("senderUsername match (no id match) → allow", () => {
+    const d = resolveTelegramAccess({
+      allowFrom: ["@vansin"],
+      senderId: "999",
+      senderUsername: "@vansin",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("explicit-allow");
+  });
+
+  test("neither id nor username in list → deny", () => {
+    const d = resolveTelegramAccess({
+      allowFrom: ["123", "@vansin"],
+      senderId: "stranger",
+      senderUsername: "@stranger",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("denied");
+  });
+
+  test("empty senderUsername doesn't accidentally match empty list entry", () => {
+    // Filter in normalizeAllowFrom drops empty strings; defensive test.
+    const d = resolveTelegramAccess({
+      allowFrom: ["", "123"],
+      senderId: "999",
+      senderUsername: "",
+    });
+    expect(d.allow).toBe(false);
+  });
+
+  test("blank-string id with username match still allows", () => {
+    const d = resolveTelegramAccess({
+      allowFrom: ["@vansin"],
+      senderId: "",
+      senderUsername: "@vansin",
+    });
+    expect(d.allow).toBe(true);
+  });
+});
+
+describe("resolveFeishuAccess — DM path mirrors telegram fail-closed", () => {
+  test("empty allowFrom → deny", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "dm",
+      allowFrom: [],
+      allowChats: [],
+      senderId: "ou_abc",
+      conversationId: "oc_dm",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+    expect(d.reason).toContain("dm");
+  });
+
+  test("wildcard allows", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "dm",
+      allowFrom: ["*"],
+      allowChats: [],
+      senderId: "ou_abc",
+      conversationId: "oc_dm",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("wildcard-allow");
+  });
+
+  test("specific id allows", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "dm",
+      allowFrom: ["ou_abc"],
+      allowChats: [],
+      senderId: "ou_abc",
+      conversationId: "oc_dm",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("explicit-allow");
+  });
+
+  test("sender not in list → deny", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "dm",
+      allowFrom: ["ou_other"],
+      allowChats: [],
+      senderId: "ou_stranger",
+      conversationId: "oc_dm",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("denied");
+  });
+});
+
+describe("resolveFeishuAccess — group path (allowChats + groupPolicy)", () => {
+  test("empty allowChats → fail-closed", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: [],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+    expect(d.reason).toMatch(/group/);
+  });
+
+  test("chat in allowChats + groupPolicy=all → allow", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["oc_group1"],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("explicit-allow");
+  });
+
+  test("chat in allowChats + groupPolicy=observe → deny", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["oc_group1"],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "observe",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("observe");
+  });
+
+  test("chat NOT in allowChats → deny (even with policy=all)", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["oc_other"],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("denied");
+    expect(d.reason).toMatch(/chat not in allowChats/);
+  });
+
+  test("wildcard chats opens any chat (with groupPolicy=all)", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["*"],
+      senderId: "ou_abc",
+      conversationId: "oc_anything",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(true);
+  });
+
+  test("groupPolicy=mention allows (caller decides at message inspect time)", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["oc_group1"],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "mention",
+    });
+    expect(d.allow).toBe(true);
+  });
+});
+
+describe("buildEmptyAllowlistWarn — boot-time visibility", () => {
+  test("returns warn string for empty allowFrom", () => {
+    const w = buildEmptyAllowlistWarn({
+      channel: "telegram",
+      channelDir: "/some/dir",
+      allowFrom: [],
+    });
+    expect(w).not.toBeNull();
+    expect(w).toContain("FAIL-CLOSED");
+    expect(w).toContain("telegram");
+    expect(w).toContain("/some/dir");
+  });
+
+  test("returns warn string for malformed allowFrom + mentions malformed", () => {
+    const w = buildEmptyAllowlistWarn({
+      channel: "telegram",
+      channelDir: "/d",
+      allowFrom: "garbage",
+    });
+    expect(w).toContain("malformed");
+  });
+
+  test("returns null when allowFrom has at least one entry", () => {
+    const w = buildEmptyAllowlistWarn({
+      channel: "telegram",
+      channelDir: "/d",
+      allowFrom: ["123"],
+    });
+    expect(w).toBeNull();
+  });
+
+  test("returns null for wildcard-allow (channel intentionally open)", () => {
+    const w = buildEmptyAllowlistWarn({
+      channel: "telegram",
+      channelDir: "/d",
+      allowFrom: ["*"],
+    });
+    expect(w).toBeNull();
+  });
+});
+
+describe("regression — pre-v0.11 fail-open MUST NOT come back", () => {
+  // The fail-open default was the root cause of the v0.11 security
+  // patch. If a future "convenience" PR tries to restore it, these
+  // tests fail.
+
+  test("empty array NEVER allows", () => {
+    expect(resolveTelegramAccess({ allowFrom: [], senderId: "x" }).allow).toBe(false);
+  });
+
+  test("undefined NEVER allows", () => {
+    expect(resolveTelegramAccess({ allowFrom: undefined, senderId: "x" }).allow).toBe(false);
+  });
+
+  test("null NEVER allows", () => {
+    expect(resolveTelegramAccess({ allowFrom: null, senderId: "x" }).allow).toBe(false);
+  });
+
+  test("object-shape (corrupted) NEVER allows", () => {
+    expect(resolveTelegramAccess({ allowFrom: {} as any, senderId: "x" }).allow).toBe(false);
+  });
+});

--- a/agent-network/src/im/access-resolve.test.ts
+++ b/agent-network/src/im/access-resolve.test.ts
@@ -9,6 +9,7 @@ import {
   resolveFeishuAccess,
   normalizeAllowFrom,
   buildEmptyAllowlistWarn,
+  loadTelegramAccess,
 } from "./access-resolve";
 
 describe("normalizeAllowFrom — input shapes", () => {
@@ -298,6 +299,122 @@ describe("buildEmptyAllowlistWarn — boot-time visibility", () => {
       allowFrom: ["*"],
     });
     expect(w).toBeNull();
+  });
+});
+
+describe("loadTelegramAccess + resolver — wiring regression (CHANGE_REQ on #276)", () => {
+  // Background: `initTelegramChannel` used to normalise allowFrom via
+  // `Array.isArray(...) ? .map(String) : []`. For an access.json shape
+  // of `{allowFrom: [123]}`, the result was `["123"]` — a non-empty
+  // string list that the resolver then treats as a valid allowlist.
+  // The fail-closed flip was bypassed for any caller whose id stringified
+  // to a member of that list. These tests pin the fix at the wiring
+  // layer (loader → channel state → resolver) so a future "convenience"
+  // cleanup cannot re-introduce the bypass.
+
+  test("loader stores raw allowFrom verbatim — no normalization at load time", () => {
+    // Subtle but important: the loader MUST pass `allowFromRaw`
+    // through unchanged. Any cleanup / coercion at this layer
+    // re-introduces the bypass class.
+    const loaded = loadTelegramAccess({
+      channelDir: "/tmp/x",
+      parsedAccess: { allowFrom: [123, null, { foo: "bar" }, "@vansin"] as any },
+    });
+    expect(loaded.allowFromRaw).toEqual([123, null, { foo: "bar" }, "@vansin"]);
+  });
+
+  test("loader emits boot-warn when allowFrom is missing", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/tmp/x", parsedAccess: {} });
+    expect(loaded.bootWarn).not.toBeNull();
+  });
+
+  test("loader emits boot-warn when allowFrom is malformed (non-array)", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/tmp/x", parsedAccess: { allowFrom: "wrong" as any } });
+    expect(loaded.bootWarn).not.toBeNull();
+    expect(loaded.bootWarn).toMatch(/malformed/);
+  });
+
+  test("loader is silent when allowFrom has at least one entry (even if numeric)", () => {
+    // The boot-warn fires on EMPTY (after normalization) — `[123]` is
+    // empty after filter-non-strings, so the warn SHOULD fire. This
+    // test pins that contract.
+    const loaded = loadTelegramAccess({ channelDir: "/tmp/x", parsedAccess: { allowFrom: [123] as any } });
+    expect(loaded.bootWarn).not.toBeNull();
+  });
+
+  test("[123] alone (numeric sender id from a misformatted access.json) → loader+resolver fail-closed", () => {
+    // The exact bypass shape from the CHANGE_REQ on #276. A misformatted
+    // access.json with numeric ids would, pre-fix, normalize to ["123"]
+    // and the resolver would happily allow sender id "123".
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [123] as any } });
+    const decision = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "123",
+    });
+    expect(decision.allow).toBe(false);
+    expect(decision.kind).toBe("empty-fail-closed");
+  });
+
+  test("[null] (corrupted access.json) → loader+resolver fail-closed", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [null] as any } });
+    const decision = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "anyone",
+    });
+    expect(decision.allow).toBe(false);
+    expect(decision.kind).toBe("empty-fail-closed");
+  });
+
+  test("[{}] (object instead of id string) → loader+resolver fail-closed", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [{}] as any } });
+    const decision = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "anyone",
+    });
+    expect(decision.allow).toBe(false);
+    expect(decision.kind).toBe("empty-fail-closed");
+  });
+
+  test("[123, '@vansin'] (mixed) → '@vansin' still allowed, numeric '123' rejected", () => {
+    // Mixed list keeps the valid string entries — `@vansin` should still
+    // be allowed, but a sender that happens to stringify to "123" must
+    // still be denied (no implicit number → string coercion at lookup).
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [123, "@vansin"] as any } });
+    const allowVansin = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "999",
+      senderUsername: "@vansin",
+    });
+    expect(allowVansin.allow).toBe(true);
+    expect(allowVansin.kind).toBe("explicit-allow");
+
+    const denyNumericSender = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "123",
+      senderUsername: undefined,
+    });
+    expect(denyNumericSender.allow).toBe(false);
+    expect(denyNumericSender.kind).toBe("denied");
+  });
+
+  test("[null, '*'] (mixed wildcard) → wildcard wins despite garbage entries", () => {
+    // The valid `"*"` entry MUST still open the channel — garbage entries
+    // shouldn't poison wildcard handling either.
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [null, "*"] as any } });
+    const d = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "anyone",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("wildcard-allow");
+  });
+
+  test("missing access.json entirely (loader gets null) → fail-closed", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: null });
+    expect(loaded.allowFromRaw).toBeUndefined();
+    const d = resolveTelegramAccess({ allowFrom: loaded.allowFromRaw, senderId: "x" });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
   });
 });
 

--- a/agent-network/src/im/access-resolve.test.ts
+++ b/agent-network/src/im/access-resolve.test.ts
@@ -124,6 +124,36 @@ describe("resolveTelegramAccess — explicit id / username matching", () => {
     });
     expect(d.allow).toBe(true);
   });
+
+  // Production-shape regression (通信牛 #276 round-2 review).
+  // Real telegram payloads put `msg.from.username` WITHOUT the @ prefix
+  // ("vansin", not "@vansin"). Existing tests used "@vansin" on both
+  // sides which let a buggy resolver still pass. Pin the bare-name shape
+  // so an operator who writes `allowFrom:["vansin"]` (the obvious one)
+  // gets matched against the real telegram payload.
+  test("production-shape: bare username (no @) in allowFrom matches bare msg.from.username", () => {
+    const d = resolveTelegramAccess({
+      allowFrom: ["vansin"],         // operator types name without @
+      senderId: "12345",
+      senderUsername: "vansin",      // telegram payload shape: no @
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("explicit-allow");
+  });
+
+  test("production-shape mismatch: @vansin in allowFrom does NOT match bare vansin payload", () => {
+    // Operator wrote @vansin (looking at telegram UI which shows @)
+    // but real payload is "vansin" — must reject so the operator gets
+    // a clear "your config doesn't match what arrives" signal instead
+    // of silent fail-open.
+    const d = resolveTelegramAccess({
+      allowFrom: ["@vansin"],
+      senderId: "12345",
+      senderUsername: "vansin",      // no @ in real payload
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("denied");
+  });
 });
 
 describe("resolveFeishuAccess — DM path mirrors telegram fail-closed", () => {

--- a/agent-network/src/im/access-resolve.ts
+++ b/agent-network/src/im/access-resolve.ts
@@ -31,6 +31,40 @@
 // is observed.
 
 /**
+ * Tiny loader that mirrors what `initTelegramChannel` does at boot —
+ * read the parsed access.json blob and produce both the raw allowFrom
+ * payload (handed to the resolver verbatim) AND a boot-time warning
+ * string for the empty / malformed case.
+ *
+ * Extracted so wiring-level regression tests (e.g. "channel state
+ * built from `{allowFrom: [123]}` MUST fail-closed when a message
+ * arrives") run without spinning up a real telegram channel + fs
+ * mocks. The previous bug — `.map(String)` rewriting [123] into
+ * ["123"] at init time — slipped past resolver-only unit tests
+ * because the resolver never saw the offending shape; the channel
+ * state did.
+ */
+export interface LoadedTelegramAccess {
+  /** Raw value from access.json — handed verbatim to resolveTelegramAccess. */
+  allowFromRaw: unknown;
+  /** Boot-time warning string when allowFrom is empty / malformed; null otherwise. */
+  bootWarn: string | null;
+}
+
+export function loadTelegramAccess(opts: {
+  channelDir: string;
+  parsedAccess: { allowFrom?: unknown } | null | undefined;
+}): LoadedTelegramAccess {
+  const allowFromRaw = opts.parsedAccess?.allowFrom;
+  const bootWarn = buildEmptyAllowlistWarn({
+    channel: "telegram",
+    channelDir: opts.channelDir,
+    allowFrom: allowFromRaw,
+  });
+  return { allowFromRaw, bootWarn };
+}
+
+/**
  * Discriminated reason for an access decision. Callers can switch on
  * `kind` for routing (e.g. `empty-fail-closed` warrants a louder boot
  * warning than a simple `denied` mid-stream).

--- a/agent-network/src/im/access-resolve.ts
+++ b/agent-network/src/im/access-resolve.ts
@@ -1,0 +1,228 @@
+// MIRROR of agent-node/src/util/access-resolve.ts. Both files MUST stay
+// in lockstep — diff them when editing either copy. Bun workspaces are
+// not currently set up across the agent-node / agent-network packages,
+// so the v0.11 security fix duplicates the helper to give feishu the
+// same fail-mode shape as telegram. v0.12 follow-up: extract into a
+// real shared package and dedupe.
+//
+// Inbound-channel access resolver. Shared by every IM channel that
+// agent-node consumes (telegram / feishu / wechat / future). One file
+// owns the "should this incoming message be allowed?" decision so the
+// fail-mode (open vs closed) is identical across channels.
+//
+// Why fail-closed (the v0.11 change)
+// ==================================
+// Pre-v0.11, `telegramAllowed()` treated an empty `allowFrom` as
+// allow-all. Combined with the default `dangerouslySkipPermissions`
+// flag in `flags.json`, that meant a node whose access.json had been
+// truncated / corrupted / wiped (the 2026-06 git-stash-u + git-clean-fd
+// incident shape, see CLAUDE.md history) would silently accept commands
+// from any Telegram user on the internet and drive the local Claude
+// runtime with full skip-permissions. That is a remote-execution
+// vector and must default to denying, not allowing.
+//
+// The new contract is symmetrical with the feishu adapter, which has
+// always been fail-closed: only an explicit `"*"` wildcard opens the
+// door, and any other empty / missing / malformed shape denies with a
+// loud reason string suitable for `anet logs <alias>` triage.
+//
+// Pure helper: no I/O, no env reads, no side effects. The boot path is
+// responsible for emitting the one-shot warn when an empty allowFrom
+// is observed.
+
+/**
+ * Discriminated reason for an access decision. Callers can switch on
+ * `kind` for routing (e.g. `empty-fail-closed` warrants a louder boot
+ * warning than a simple `denied` mid-stream).
+ */
+export type AccessKind =
+  | "wildcard-allow"      // explicit "*" in allowFrom
+  | "explicit-allow"      // sender id / username matched the list
+  | "empty-fail-closed"   // allowFrom is empty / missing / malformed
+  | "denied";             // allowFrom present but sender not in it
+
+export interface AccessDecision {
+  allow: boolean;
+  kind: AccessKind;
+  /** Short, machine-readable reason for logging. */
+  reason: string;
+}
+
+/**
+ * Normalise an allowFrom input into a deduped string[] suitable for
+ * the lookup checks. Accepts: a real string[] (the happy case), null /
+ * undefined (treated as empty), a non-array shape (defensive — treated
+ * as empty + reason surfaced).
+ */
+export function normalizeAllowFrom(raw: unknown): {
+  list: string[];
+  malformed: boolean;
+} {
+  if (Array.isArray(raw)) {
+    const list = raw
+      .filter((v) => typeof v === "string" && v.length > 0)
+      .map((v) => String(v));
+    return { list, malformed: false };
+  }
+  if (raw === undefined || raw === null) {
+    return { list: [], malformed: false };
+  }
+  // Some other shape on disk (numeric, object, string). Treat as
+  // empty AND flag it so the caller can include "malformed" in the
+  // boot warning. This is the "corrupted access.json" path.
+  return { list: [], malformed: true };
+}
+
+/**
+ * Resolve whether an inbound Telegram message should be processed.
+ *
+ * Fail-closed: empty / missing / malformed `allowFrom` always denies.
+ * Wildcard `"*"` always allows. Otherwise the sender's id OR username
+ * (after non-empty check) must match a list entry.
+ *
+ * @param opts.allowFrom         the access.json `allowFrom` array
+ * @param opts.senderId          numeric Telegram user id as string
+ *                               (callers already coerce; we trust)
+ * @param opts.senderUsername    optional `@username` (no `@` prefix)
+ */
+export function resolveTelegramAccess(opts: {
+  allowFrom: unknown;
+  senderId: string;
+  senderUsername?: string | null;
+}): AccessDecision {
+  const { list, malformed } = normalizeAllowFrom(opts.allowFrom);
+
+  if (list.length === 0) {
+    return {
+      allow: false,
+      kind: "empty-fail-closed",
+      reason: malformed
+        ? "allowFrom malformed (not a string[]) — fail-closed"
+        : "allowFrom empty — fail-closed (set [\"*\"] to open to all, or add specific ids)",
+    };
+  }
+
+  if (list.includes("*")) {
+    return { allow: true, kind: "wildcard-allow", reason: "allowFrom=[\"*\"]" };
+  }
+
+  const id = opts.senderId || "";
+  const username = (opts.senderUsername || "").trim();
+  if (id && list.includes(id)) {
+    return { allow: true, kind: "explicit-allow", reason: `sender id ${id} in allowFrom` };
+  }
+  if (username && list.includes(username)) {
+    return { allow: true, kind: "explicit-allow", reason: `sender username ${username} in allowFrom` };
+  }
+  return {
+    allow: false,
+    kind: "denied",
+    reason: `sender id=${id} username=${username || "(none)"} not in allowFrom`,
+  };
+}
+
+/**
+ * Resolve whether an inbound Feishu/Lark event should be processed.
+ *
+ * Same fail-closed contract as telegram. DM path checks `allowFrom`;
+ * group path checks `allowChats` first, then `groupPolicy` decides
+ * whether listed chats trigger the agent (`all` → trigger any message;
+ * `observe` → never trigger; `mention` → only on @-mention — caller
+ * still has to honour that flag, this helper just returns allow=true).
+ *
+ * @param opts.conversationType  "dm" | "group" | "channel" | "thread"
+ * @param opts.allowFrom         access.json `allowFrom` array
+ * @param opts.allowChats        access.json `allowChats` array
+ * @param opts.senderId          feishu open_id of the sender
+ * @param opts.conversationId    feishu chat_id of the conversation
+ * @param opts.groupPolicy       "all" | "mention" | "observe"
+ */
+export function resolveFeishuAccess(opts: {
+  conversationType: "dm" | "group" | "channel" | "thread" | string;
+  allowFrom: unknown;
+  allowChats: unknown;
+  senderId: string;
+  conversationId: string;
+  groupPolicy: "all" | "mention" | "observe" | string;
+}): AccessDecision {
+  if (opts.conversationType === "dm") {
+    const { list, malformed } = normalizeAllowFrom(opts.allowFrom);
+    if (list.length === 0) {
+      return {
+        allow: false,
+        kind: "empty-fail-closed",
+        reason: malformed
+          ? "allowFrom malformed (not a string[]) — fail-closed (dm)"
+          : "allowFrom empty — fail-closed (dm)",
+      };
+    }
+    if (list.includes("*")) {
+      return { allow: true, kind: "wildcard-allow", reason: "allowFrom=[\"*\"] (dm)" };
+    }
+    if (opts.senderId && list.includes(opts.senderId)) {
+      return { allow: true, kind: "explicit-allow", reason: `sender ${opts.senderId} in allowFrom (dm)` };
+    }
+    return {
+      allow: false,
+      kind: "denied",
+      reason: "sender not in allowFrom (dm)",
+    };
+  }
+
+  // Non-DM (group / channel / thread): allowChats gates entry, then
+  // groupPolicy decides whether to actually trigger.
+  const chats = normalizeAllowFrom(opts.allowChats);
+  if (chats.list.length === 0) {
+    return {
+      allow: false,
+      kind: "empty-fail-closed",
+      reason: chats.malformed
+        ? "allowChats malformed — fail-closed (group)"
+        : "allowChats empty — fail-closed (group)",
+    };
+  }
+  const chatAllowed =
+    chats.list.includes("*") || chats.list.includes(opts.conversationId);
+  if (!chatAllowed) {
+    return { allow: false, kind: "denied", reason: "chat not in allowChats" };
+  }
+  if (opts.groupPolicy === "all") {
+    return { allow: true, kind: "explicit-allow", reason: "chat in allowChats + groupPolicy=all" };
+  }
+  if (opts.groupPolicy === "observe") {
+    return {
+      allow: false,
+      kind: "denied",
+      reason: "groupPolicy=observe — chat allowlisted but no trigger",
+    };
+  }
+  // "mention" (or any other future flag): caller decides at message-
+  // inspect time. Here we just say "chat is allowed, caller's call".
+  return { allow: true, kind: "explicit-allow", reason: `chat allowed + groupPolicy=${opts.groupPolicy}` };
+}
+
+/**
+ * Build the boot-time warning string when a channel starts with an
+ * empty / malformed allowlist. Caller emits this via `warn()` once at
+ * startup so operators see the fail-closed posture immediately rather
+ * than discovering it the first time a message gets denied.
+ *
+ * Returns `null` when the allowlist has at least one entry (no boot
+ * warning needed).
+ */
+export function buildEmptyAllowlistWarn(opts: {
+  channel: string;           // "telegram" | "feishu" | etc.
+  channelDir: string;        // absolute path to access.json's parent
+  allowFrom: unknown;
+}): string | null {
+  const { list, malformed } = normalizeAllowFrom(opts.allowFrom);
+  if (list.length > 0) return null;
+  const detail = malformed ? "malformed (not a string[])" : "empty";
+  return (
+    `[${opts.channel}] FAIL-CLOSED: ${opts.channelDir}/access.json allowFrom is ${detail} — ` +
+    `ALL inbound messages will be denied. To open the channel: edit access.json ` +
+    `and set \`"allowFrom": ["*"]\` for any-sender, or add specific sender ids. ` +
+    `Pre-v0.11 behaviour was fail-open; this is a deliberate security change ` +
+    `(see release notes).`
+  );
+}

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -30,6 +30,7 @@ import type {
   NormalizedIMMessage,
 } from "../types.js";
 import type { FeishuAccessList, FeishuChannelConfig } from "./config.js";
+import { resolveFeishuAccess } from "../access-resolve.js";
 
 type OnEventHandler = (event: NormalizedIMEvent) => Promise<void>;
 
@@ -458,31 +459,28 @@ function checkAccess(
   access: FeishuAccessList,
   groupPolicy: FeishuChannelConfig["groupPolicy"],
 ): { allow: boolean; reason: string } {
-  if (event.conversation.conversationType === "dm") {
-    // Wildcard "*" in allowFrom opens DMs to all senders (Vincent 2026-06-26
-    // request — internal-org bot served to whole company). Specific id match
-    // path kept as-is. Pair with rate-limit at the bridge layer to prevent
-    // token-budget abuse (RATE_LIMIT_TEXT in bridge.ts).
-    if (
-      access.allowFrom.includes("*") ||
-      access.allowFrom.includes(event.sender.id)
-    ) {
-      return { allow: true, reason: "" };
-    }
-    return { allow: false, reason: "sender not in allowFrom (dm)" };
-  }
-  // group / channel / thread share the same whitelist + policy semantics.
-  const chatAllowed =
-    access.allowChats.includes("*") ||
-    access.allowChats.includes(event.conversation.conversationId);
-  if (!chatAllowed) {
-    return { allow: false, reason: "chat not in allowChats" };
-  }
+  // v0.11 — delegate the whitelist + group-policy decision to the shared
+  // resolver so telegram + feishu have one fail-mode contract (mirror at
+  // src/im/access-resolve.ts; canonical at agent-node/src/util/access-
+  // resolve.ts). Mention-gate logic stays here because it depends on
+  // event.mentioned, which is a feishu-specific concept the generic
+  // resolver does not model.
+  const decision = resolveFeishuAccess({
+    conversationType: event.conversation.conversationType,
+    allowFrom: access.allowFrom,
+    allowChats: access.allowChats,
+    senderId: event.sender.id,
+    conversationId: event.conversation.conversationId,
+    groupPolicy: groupPolicy === "command" ? "mention" : groupPolicy,
+  });
+
+  // DM, observe, fail-closed cases are fully decided by the resolver.
+  if (event.conversation.conversationType === "dm") return { allow: decision.allow, reason: decision.reason };
+  if (!decision.allow) return { allow: false, reason: decision.reason };
   if (groupPolicy === "all") return { allow: true, reason: "" };
-  if (groupPolicy === "observe") {
-    return { allow: false, reason: "groupPolicy=observe — chat in allowChats but no trigger" };
-  }
-  // mention | command
+
+  // groupPolicy = "mention" | "command" — resolver said chat is allowed,
+  // but trigger needs the bot to actually be @-mentioned in the message.
   if (event.mentioned) return { allow: true, reason: "" };
   return {
     allow: false,

--- a/agent-network/tsconfig.json
+++ b/agent-network/tsconfig.json
@@ -9,5 +9,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src/client.ts", "src/node-server.ts", "src/im/**/*.ts", "bin/cli.ts"]
+  "include": ["src/client.ts", "src/node-server.ts", "src/im/**/*.ts", "bin/cli.ts"],
+  "exclude": ["**/*.test.ts"]
 }

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -64,6 +64,7 @@ import {
   type ConfigUpdate,
   type ConfigPatch,
 } from "./runtime/config-apply";
+import { resolveTelegramAccess, buildEmptyAllowlistWarn } from "./util/access-resolve";
 
 const home = homedir();
 
@@ -575,6 +576,16 @@ function initTelegramChannel(spec: { type: string; path?: string; raw: string })
   const access = loadJson(join(dir, "access.json")) || {};
   const inboxDir = join(dir, "inbox");
   try { mkdirSync(inboxDir, { recursive: true }); } catch {}
+  // v0.11 security change: emit a loud one-shot warn at boot when
+  // allowFrom is empty / malformed so operators see the fail-closed
+  // posture immediately, rather than discovering it the first time a
+  // message gets denied. Wildcard ["*"] / non-empty lists are silent.
+  const warning = buildEmptyAllowlistWarn({
+    channel: "telegram",
+    channelDir: dir,
+    allowFrom: access.allowFrom,
+  });
+  if (warning) console.warn(warning);
   return {
     type: "telegram",
     dir,
@@ -2806,10 +2817,22 @@ function telegramUserLabel(msg: any): string {
 }
 
 function telegramAllowed(channel: TelegramChannel, msg: any): boolean {
-  if (channel.allowFrom.length === 0) return true;
-  const id = telegramUserId(msg);
-  const username = msg.from?.username ? String(msg.from.username) : "";
-  return channel.allowFrom.includes(id) || (!!username && channel.allowFrom.includes(username));
+  // v0.11 security change: fail-closed. Empty / missing / malformed
+  // allowFrom now denies (was: allowed all). Combined with the default
+  // dangerouslySkipPermissions in flags.json, the previous fail-open
+  // default was a remote-execution vector — an `access.json` truncated
+  // by git-stash-u / git-clean-fd would silently accept commands from
+  // any Telegram user. Resolution is delegated to the shared helper
+  // so feishu / future channels share the same fail-mode.
+  const decision = resolveTelegramAccess({
+    allowFrom: channel.allowFrom,
+    senderId: telegramUserId(msg),
+    senderUsername: msg.from?.username ? String(msg.from.username) : null,
+  });
+  if (!decision.allow) {
+    debug(`[telegram] DENY: ${decision.reason}`);
+  }
+  return decision.allow;
 }
 
 async function telegramJson(tg: TelegramApi, method: string, body: Record<string, unknown>) {

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -64,7 +64,7 @@ import {
   type ConfigUpdate,
   type ConfigPatch,
 } from "./runtime/config-apply";
-import { resolveTelegramAccess, buildEmptyAllowlistWarn } from "./util/access-resolve";
+import { resolveTelegramAccess, buildEmptyAllowlistWarn, loadTelegramAccess } from "./util/access-resolve";
 
 const home = homedir();
 
@@ -558,7 +558,12 @@ interface TelegramChannel {
   dir: string;
   inboxDir: string;
   token: string;
-  allowFrom: string[];
+  // Raw value from access.json. Stored unprocessed so resolveTelegramAccess
+  // is the single source of truth for normalization. The previous
+  // `.map(String)` shape at init time silently rewrote [123] → ["123"],
+  // which bypassed the fail-closed check at message time because the
+  // resolver saw a "valid" non-empty string list.
+  allowFromRaw: unknown;
 }
 
 function initTelegramChannel(spec: { type: string; path?: string; raw: string }): TelegramChannel {
@@ -580,18 +585,19 @@ function initTelegramChannel(spec: { type: string; path?: string; raw: string })
   // allowFrom is empty / malformed so operators see the fail-closed
   // posture immediately, rather than discovering it the first time a
   // message gets denied. Wildcard ["*"] / non-empty lists are silent.
-  const warning = buildEmptyAllowlistWarn({
-    channel: "telegram",
-    channelDir: dir,
-    allowFrom: access.allowFrom,
-  });
-  if (warning) console.warn(warning);
+  //
+  // loadTelegramAccess returns the raw allowFrom value verbatim so the
+  // resolver is the single source of truth for normalisation — the
+  // previous `.map(String)` shape silently rewrote [123] into ["123"]
+  // and bypassed the fail-closed check at message time.
+  const loaded = loadTelegramAccess({ channelDir: dir, parsedAccess: access });
+  if (loaded.bootWarn) console.warn(loaded.bootWarn);
   return {
     type: "telegram",
     dir,
     inboxDir,
     token,
-    allowFrom: Array.isArray(access.allowFrom) ? access.allowFrom.map(String) : [],
+    allowFromRaw: loaded.allowFromRaw,
   };
 }
 
@@ -2825,7 +2831,7 @@ function telegramAllowed(channel: TelegramChannel, msg: any): boolean {
   // any Telegram user. Resolution is delegated to the shared helper
   // so feishu / future channels share the same fail-mode.
   const decision = resolveTelegramAccess({
-    allowFrom: channel.allowFrom,
+    allowFrom: channel.allowFromRaw,
     senderId: telegramUserId(msg),
     senderUsername: msg.from?.username ? String(msg.from.username) : null,
   });

--- a/agent-node/src/util/access-resolve.test.ts
+++ b/agent-node/src/util/access-resolve.test.ts
@@ -1,0 +1,324 @@
+// Coverage for the inbound-channel access resolver. The fail-closed
+// flip is a deliberate security change in v0.11 — these tests pin the
+// new behaviour so a future "convenience" patch can't quietly restore
+// the old fail-open default.
+
+import { describe, expect, test } from "bun:test";
+import {
+  resolveTelegramAccess,
+  resolveFeishuAccess,
+  normalizeAllowFrom,
+  buildEmptyAllowlistWarn,
+} from "./access-resolve";
+
+describe("normalizeAllowFrom — input shapes", () => {
+  test("real string[] passes through deduped (filter empty strings)", () => {
+    const r = normalizeAllowFrom(["123", "@vansin", "", "456"]);
+    expect(r.list).toEqual(["123", "@vansin", "456"]);
+    expect(r.malformed).toBe(false);
+  });
+
+  test("undefined → empty + not malformed", () => {
+    expect(normalizeAllowFrom(undefined)).toEqual({ list: [], malformed: false });
+  });
+
+  test("null → empty + not malformed", () => {
+    expect(normalizeAllowFrom(null)).toEqual({ list: [], malformed: false });
+  });
+
+  test("non-array object → empty + malformed (corrupted access.json shape)", () => {
+    expect(normalizeAllowFrom({ allowFrom: ["123"] })).toEqual({ list: [], malformed: true });
+  });
+
+  test("string instead of array → malformed", () => {
+    expect(normalizeAllowFrom("123")).toEqual({ list: [], malformed: true });
+  });
+
+  test("array with non-string elements drops them", () => {
+    const r = normalizeAllowFrom([123, "valid", null, "ok"]);
+    expect(r.list).toEqual(["valid", "ok"]);
+    expect(r.malformed).toBe(false);
+  });
+});
+
+describe("resolveTelegramAccess — fail-closed empty allowFrom (v0.11 security change)", () => {
+  test("empty array → deny with empty-fail-closed kind", () => {
+    const d = resolveTelegramAccess({ allowFrom: [], senderId: "123" });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+    expect(d.reason).toContain("fail-closed");
+  });
+
+  test("undefined → deny", () => {
+    const d = resolveTelegramAccess({ allowFrom: undefined, senderId: "123" });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+  });
+
+  test("malformed → deny + reason mentions malformed", () => {
+    const d = resolveTelegramAccess({ allowFrom: "garbage", senderId: "123" });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+    expect(d.reason).toMatch(/malformed/);
+  });
+});
+
+describe("resolveTelegramAccess — wildcard '*' opens the channel", () => {
+  test("['*'] alone allows any sender", () => {
+    const d = resolveTelegramAccess({ allowFrom: ["*"], senderId: "anyone" });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("wildcard-allow");
+  });
+
+  test("['*', 'specific_id'] still wildcard-allows (wins precedence)", () => {
+    const d = resolveTelegramAccess({ allowFrom: ["*", "123"], senderId: "stranger" });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("wildcard-allow");
+  });
+});
+
+describe("resolveTelegramAccess — explicit id / username matching", () => {
+  test("senderId in list → allow", () => {
+    const d = resolveTelegramAccess({ allowFrom: ["123", "456"], senderId: "456" });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("explicit-allow");
+    expect(d.reason).toContain("456");
+  });
+
+  test("senderUsername match (no id match) → allow", () => {
+    const d = resolveTelegramAccess({
+      allowFrom: ["@vansin"],
+      senderId: "999",
+      senderUsername: "@vansin",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("explicit-allow");
+  });
+
+  test("neither id nor username in list → deny", () => {
+    const d = resolveTelegramAccess({
+      allowFrom: ["123", "@vansin"],
+      senderId: "stranger",
+      senderUsername: "@stranger",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("denied");
+  });
+
+  test("empty senderUsername doesn't accidentally match empty list entry", () => {
+    // Filter in normalizeAllowFrom drops empty strings; defensive test.
+    const d = resolveTelegramAccess({
+      allowFrom: ["", "123"],
+      senderId: "999",
+      senderUsername: "",
+    });
+    expect(d.allow).toBe(false);
+  });
+
+  test("blank-string id with username match still allows", () => {
+    const d = resolveTelegramAccess({
+      allowFrom: ["@vansin"],
+      senderId: "",
+      senderUsername: "@vansin",
+    });
+    expect(d.allow).toBe(true);
+  });
+});
+
+describe("resolveFeishuAccess — DM path mirrors telegram fail-closed", () => {
+  test("empty allowFrom → deny", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "dm",
+      allowFrom: [],
+      allowChats: [],
+      senderId: "ou_abc",
+      conversationId: "oc_dm",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+    expect(d.reason).toContain("dm");
+  });
+
+  test("wildcard allows", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "dm",
+      allowFrom: ["*"],
+      allowChats: [],
+      senderId: "ou_abc",
+      conversationId: "oc_dm",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("wildcard-allow");
+  });
+
+  test("specific id allows", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "dm",
+      allowFrom: ["ou_abc"],
+      allowChats: [],
+      senderId: "ou_abc",
+      conversationId: "oc_dm",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("explicit-allow");
+  });
+
+  test("sender not in list → deny", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "dm",
+      allowFrom: ["ou_other"],
+      allowChats: [],
+      senderId: "ou_stranger",
+      conversationId: "oc_dm",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("denied");
+  });
+});
+
+describe("resolveFeishuAccess — group path (allowChats + groupPolicy)", () => {
+  test("empty allowChats → fail-closed", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: [],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
+    expect(d.reason).toMatch(/group/);
+  });
+
+  test("chat in allowChats + groupPolicy=all → allow", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["oc_group1"],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("explicit-allow");
+  });
+
+  test("chat in allowChats + groupPolicy=observe → deny", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["oc_group1"],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "observe",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("observe");
+  });
+
+  test("chat NOT in allowChats → deny (even with policy=all)", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["oc_other"],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("denied");
+    expect(d.reason).toMatch(/chat not in allowChats/);
+  });
+
+  test("wildcard chats opens any chat (with groupPolicy=all)", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["*"],
+      senderId: "ou_abc",
+      conversationId: "oc_anything",
+      groupPolicy: "all",
+    });
+    expect(d.allow).toBe(true);
+  });
+
+  test("groupPolicy=mention allows (caller decides at message inspect time)", () => {
+    const d = resolveFeishuAccess({
+      conversationType: "group",
+      allowFrom: [],
+      allowChats: ["oc_group1"],
+      senderId: "ou_abc",
+      conversationId: "oc_group1",
+      groupPolicy: "mention",
+    });
+    expect(d.allow).toBe(true);
+  });
+});
+
+describe("buildEmptyAllowlistWarn — boot-time visibility", () => {
+  test("returns warn string for empty allowFrom", () => {
+    const w = buildEmptyAllowlistWarn({
+      channel: "telegram",
+      channelDir: "/some/dir",
+      allowFrom: [],
+    });
+    expect(w).not.toBeNull();
+    expect(w).toContain("FAIL-CLOSED");
+    expect(w).toContain("telegram");
+    expect(w).toContain("/some/dir");
+  });
+
+  test("returns warn string for malformed allowFrom + mentions malformed", () => {
+    const w = buildEmptyAllowlistWarn({
+      channel: "telegram",
+      channelDir: "/d",
+      allowFrom: "garbage",
+    });
+    expect(w).toContain("malformed");
+  });
+
+  test("returns null when allowFrom has at least one entry", () => {
+    const w = buildEmptyAllowlistWarn({
+      channel: "telegram",
+      channelDir: "/d",
+      allowFrom: ["123"],
+    });
+    expect(w).toBeNull();
+  });
+
+  test("returns null for wildcard-allow (channel intentionally open)", () => {
+    const w = buildEmptyAllowlistWarn({
+      channel: "telegram",
+      channelDir: "/d",
+      allowFrom: ["*"],
+    });
+    expect(w).toBeNull();
+  });
+});
+
+describe("regression — pre-v0.11 fail-open MUST NOT come back", () => {
+  // The fail-open default was the root cause of the v0.11 security
+  // patch. If a future "convenience" PR tries to restore it, these
+  // tests fail.
+
+  test("empty array NEVER allows", () => {
+    expect(resolveTelegramAccess({ allowFrom: [], senderId: "x" }).allow).toBe(false);
+  });
+
+  test("undefined NEVER allows", () => {
+    expect(resolveTelegramAccess({ allowFrom: undefined, senderId: "x" }).allow).toBe(false);
+  });
+
+  test("null NEVER allows", () => {
+    expect(resolveTelegramAccess({ allowFrom: null, senderId: "x" }).allow).toBe(false);
+  });
+
+  test("object-shape (corrupted) NEVER allows", () => {
+    expect(resolveTelegramAccess({ allowFrom: {} as any, senderId: "x" }).allow).toBe(false);
+  });
+});

--- a/agent-node/src/util/access-resolve.test.ts
+++ b/agent-node/src/util/access-resolve.test.ts
@@ -9,6 +9,7 @@ import {
   resolveFeishuAccess,
   normalizeAllowFrom,
   buildEmptyAllowlistWarn,
+  loadTelegramAccess,
 } from "./access-resolve";
 
 describe("normalizeAllowFrom — input shapes", () => {
@@ -298,6 +299,122 @@ describe("buildEmptyAllowlistWarn — boot-time visibility", () => {
       allowFrom: ["*"],
     });
     expect(w).toBeNull();
+  });
+});
+
+describe("loadTelegramAccess + resolver — wiring regression (CHANGE_REQ on #276)", () => {
+  // Background: `initTelegramChannel` used to normalise allowFrom via
+  // `Array.isArray(...) ? .map(String) : []`. For an access.json shape
+  // of `{allowFrom: [123]}`, the result was `["123"]` — a non-empty
+  // string list that the resolver then treats as a valid allowlist.
+  // The fail-closed flip was bypassed for any caller whose id stringified
+  // to a member of that list. These tests pin the fix at the wiring
+  // layer (loader → channel state → resolver) so a future "convenience"
+  // cleanup cannot re-introduce the bypass.
+
+  test("loader stores raw allowFrom verbatim — no normalization at load time", () => {
+    // Subtle but important: the loader MUST pass `allowFromRaw`
+    // through unchanged. Any cleanup / coercion at this layer
+    // re-introduces the bypass class.
+    const loaded = loadTelegramAccess({
+      channelDir: "/tmp/x",
+      parsedAccess: { allowFrom: [123, null, { foo: "bar" }, "@vansin"] as any },
+    });
+    expect(loaded.allowFromRaw).toEqual([123, null, { foo: "bar" }, "@vansin"]);
+  });
+
+  test("loader emits boot-warn when allowFrom is missing", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/tmp/x", parsedAccess: {} });
+    expect(loaded.bootWarn).not.toBeNull();
+  });
+
+  test("loader emits boot-warn when allowFrom is malformed (non-array)", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/tmp/x", parsedAccess: { allowFrom: "wrong" as any } });
+    expect(loaded.bootWarn).not.toBeNull();
+    expect(loaded.bootWarn).toMatch(/malformed/);
+  });
+
+  test("loader is silent when allowFrom has at least one entry (even if numeric)", () => {
+    // The boot-warn fires on EMPTY (after normalization) — `[123]` is
+    // empty after filter-non-strings, so the warn SHOULD fire. This
+    // test pins that contract.
+    const loaded = loadTelegramAccess({ channelDir: "/tmp/x", parsedAccess: { allowFrom: [123] as any } });
+    expect(loaded.bootWarn).not.toBeNull();
+  });
+
+  test("[123] alone (numeric sender id from a misformatted access.json) → loader+resolver fail-closed", () => {
+    // The exact bypass shape from the CHANGE_REQ on #276. A misformatted
+    // access.json with numeric ids would, pre-fix, normalize to ["123"]
+    // and the resolver would happily allow sender id "123".
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [123] as any } });
+    const decision = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "123",
+    });
+    expect(decision.allow).toBe(false);
+    expect(decision.kind).toBe("empty-fail-closed");
+  });
+
+  test("[null] (corrupted access.json) → loader+resolver fail-closed", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [null] as any } });
+    const decision = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "anyone",
+    });
+    expect(decision.allow).toBe(false);
+    expect(decision.kind).toBe("empty-fail-closed");
+  });
+
+  test("[{}] (object instead of id string) → loader+resolver fail-closed", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [{}] as any } });
+    const decision = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "anyone",
+    });
+    expect(decision.allow).toBe(false);
+    expect(decision.kind).toBe("empty-fail-closed");
+  });
+
+  test("[123, '@vansin'] (mixed) → '@vansin' still allowed, numeric '123' rejected", () => {
+    // Mixed list keeps the valid string entries — `@vansin` should still
+    // be allowed, but a sender that happens to stringify to "123" must
+    // still be denied (no implicit number → string coercion at lookup).
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [123, "@vansin"] as any } });
+    const allowVansin = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "999",
+      senderUsername: "@vansin",
+    });
+    expect(allowVansin.allow).toBe(true);
+    expect(allowVansin.kind).toBe("explicit-allow");
+
+    const denyNumericSender = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "123",
+      senderUsername: undefined,
+    });
+    expect(denyNumericSender.allow).toBe(false);
+    expect(denyNumericSender.kind).toBe("denied");
+  });
+
+  test("[null, '*'] (mixed wildcard) → wildcard wins despite garbage entries", () => {
+    // The valid `"*"` entry MUST still open the channel — garbage entries
+    // shouldn't poison wildcard handling either.
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: { allowFrom: [null, "*"] as any } });
+    const d = resolveTelegramAccess({
+      allowFrom: loaded.allowFromRaw,
+      senderId: "anyone",
+    });
+    expect(d.allow).toBe(true);
+    expect(d.kind).toBe("wildcard-allow");
+  });
+
+  test("missing access.json entirely (loader gets null) → fail-closed", () => {
+    const loaded = loadTelegramAccess({ channelDir: "/d", parsedAccess: null });
+    expect(loaded.allowFromRaw).toBeUndefined();
+    const d = resolveTelegramAccess({ allowFrom: loaded.allowFromRaw, senderId: "x" });
+    expect(d.allow).toBe(false);
+    expect(d.kind).toBe("empty-fail-closed");
   });
 });
 

--- a/agent-node/src/util/access-resolve.ts
+++ b/agent-node/src/util/access-resolve.ts
@@ -1,0 +1,221 @@
+// Inbound-channel access resolver. Shared by every IM channel that
+// agent-node consumes (telegram / feishu / wechat / future). One file
+// owns the "should this incoming message be allowed?" decision so the
+// fail-mode (open vs closed) is identical across channels.
+//
+// Why fail-closed (the v0.11 change)
+// ==================================
+// Pre-v0.11, `telegramAllowed()` treated an empty `allowFrom` as
+// allow-all. Combined with the default `dangerouslySkipPermissions`
+// flag in `flags.json`, that meant a node whose access.json had been
+// truncated / corrupted / wiped (the 2026-06 git-stash-u + git-clean-fd
+// incident shape, see CLAUDE.md history) would silently accept commands
+// from any Telegram user on the internet and drive the local Claude
+// runtime with full skip-permissions. That is a remote-execution
+// vector and must default to denying, not allowing.
+//
+// The new contract is symmetrical with the feishu adapter, which has
+// always been fail-closed: only an explicit `"*"` wildcard opens the
+// door, and any other empty / missing / malformed shape denies with a
+// loud reason string suitable for `anet logs <alias>` triage.
+//
+// Pure helper: no I/O, no env reads, no side effects. The boot path is
+// responsible for emitting the one-shot warn when an empty allowFrom
+// is observed.
+
+/**
+ * Discriminated reason for an access decision. Callers can switch on
+ * `kind` for routing (e.g. `empty-fail-closed` warrants a louder boot
+ * warning than a simple `denied` mid-stream).
+ */
+export type AccessKind =
+  | "wildcard-allow"      // explicit "*" in allowFrom
+  | "explicit-allow"      // sender id / username matched the list
+  | "empty-fail-closed"   // allowFrom is empty / missing / malformed
+  | "denied";             // allowFrom present but sender not in it
+
+export interface AccessDecision {
+  allow: boolean;
+  kind: AccessKind;
+  /** Short, machine-readable reason for logging. */
+  reason: string;
+}
+
+/**
+ * Normalise an allowFrom input into a deduped string[] suitable for
+ * the lookup checks. Accepts: a real string[] (the happy case), null /
+ * undefined (treated as empty), a non-array shape (defensive — treated
+ * as empty + reason surfaced).
+ */
+export function normalizeAllowFrom(raw: unknown): {
+  list: string[];
+  malformed: boolean;
+} {
+  if (Array.isArray(raw)) {
+    const list = raw
+      .filter((v) => typeof v === "string" && v.length > 0)
+      .map((v) => String(v));
+    return { list, malformed: false };
+  }
+  if (raw === undefined || raw === null) {
+    return { list: [], malformed: false };
+  }
+  // Some other shape on disk (numeric, object, string). Treat as
+  // empty AND flag it so the caller can include "malformed" in the
+  // boot warning. This is the "corrupted access.json" path.
+  return { list: [], malformed: true };
+}
+
+/**
+ * Resolve whether an inbound Telegram message should be processed.
+ *
+ * Fail-closed: empty / missing / malformed `allowFrom` always denies.
+ * Wildcard `"*"` always allows. Otherwise the sender's id OR username
+ * (after non-empty check) must match a list entry.
+ *
+ * @param opts.allowFrom         the access.json `allowFrom` array
+ * @param opts.senderId          numeric Telegram user id as string
+ *                               (callers already coerce; we trust)
+ * @param opts.senderUsername    optional `@username` (no `@` prefix)
+ */
+export function resolveTelegramAccess(opts: {
+  allowFrom: unknown;
+  senderId: string;
+  senderUsername?: string | null;
+}): AccessDecision {
+  const { list, malformed } = normalizeAllowFrom(opts.allowFrom);
+
+  if (list.length === 0) {
+    return {
+      allow: false,
+      kind: "empty-fail-closed",
+      reason: malformed
+        ? "allowFrom malformed (not a string[]) — fail-closed"
+        : "allowFrom empty — fail-closed (set [\"*\"] to open to all, or add specific ids)",
+    };
+  }
+
+  if (list.includes("*")) {
+    return { allow: true, kind: "wildcard-allow", reason: "allowFrom=[\"*\"]" };
+  }
+
+  const id = opts.senderId || "";
+  const username = (opts.senderUsername || "").trim();
+  if (id && list.includes(id)) {
+    return { allow: true, kind: "explicit-allow", reason: `sender id ${id} in allowFrom` };
+  }
+  if (username && list.includes(username)) {
+    return { allow: true, kind: "explicit-allow", reason: `sender username ${username} in allowFrom` };
+  }
+  return {
+    allow: false,
+    kind: "denied",
+    reason: `sender id=${id} username=${username || "(none)"} not in allowFrom`,
+  };
+}
+
+/**
+ * Resolve whether an inbound Feishu/Lark event should be processed.
+ *
+ * Same fail-closed contract as telegram. DM path checks `allowFrom`;
+ * group path checks `allowChats` first, then `groupPolicy` decides
+ * whether listed chats trigger the agent (`all` → trigger any message;
+ * `observe` → never trigger; `mention` → only on @-mention — caller
+ * still has to honour that flag, this helper just returns allow=true).
+ *
+ * @param opts.conversationType  "dm" | "group" | "channel" | "thread"
+ * @param opts.allowFrom         access.json `allowFrom` array
+ * @param opts.allowChats        access.json `allowChats` array
+ * @param opts.senderId          feishu open_id of the sender
+ * @param opts.conversationId    feishu chat_id of the conversation
+ * @param opts.groupPolicy       "all" | "mention" | "observe"
+ */
+export function resolveFeishuAccess(opts: {
+  conversationType: "dm" | "group" | "channel" | "thread" | string;
+  allowFrom: unknown;
+  allowChats: unknown;
+  senderId: string;
+  conversationId: string;
+  groupPolicy: "all" | "mention" | "observe" | string;
+}): AccessDecision {
+  if (opts.conversationType === "dm") {
+    const { list, malformed } = normalizeAllowFrom(opts.allowFrom);
+    if (list.length === 0) {
+      return {
+        allow: false,
+        kind: "empty-fail-closed",
+        reason: malformed
+          ? "allowFrom malformed (not a string[]) — fail-closed (dm)"
+          : "allowFrom empty — fail-closed (dm)",
+      };
+    }
+    if (list.includes("*")) {
+      return { allow: true, kind: "wildcard-allow", reason: "allowFrom=[\"*\"] (dm)" };
+    }
+    if (opts.senderId && list.includes(opts.senderId)) {
+      return { allow: true, kind: "explicit-allow", reason: `sender ${opts.senderId} in allowFrom (dm)` };
+    }
+    return {
+      allow: false,
+      kind: "denied",
+      reason: "sender not in allowFrom (dm)",
+    };
+  }
+
+  // Non-DM (group / channel / thread): allowChats gates entry, then
+  // groupPolicy decides whether to actually trigger.
+  const chats = normalizeAllowFrom(opts.allowChats);
+  if (chats.list.length === 0) {
+    return {
+      allow: false,
+      kind: "empty-fail-closed",
+      reason: chats.malformed
+        ? "allowChats malformed — fail-closed (group)"
+        : "allowChats empty — fail-closed (group)",
+    };
+  }
+  const chatAllowed =
+    chats.list.includes("*") || chats.list.includes(opts.conversationId);
+  if (!chatAllowed) {
+    return { allow: false, kind: "denied", reason: "chat not in allowChats" };
+  }
+  if (opts.groupPolicy === "all") {
+    return { allow: true, kind: "explicit-allow", reason: "chat in allowChats + groupPolicy=all" };
+  }
+  if (opts.groupPolicy === "observe") {
+    return {
+      allow: false,
+      kind: "denied",
+      reason: "groupPolicy=observe — chat allowlisted but no trigger",
+    };
+  }
+  // "mention" (or any other future flag): caller decides at message-
+  // inspect time. Here we just say "chat is allowed, caller's call".
+  return { allow: true, kind: "explicit-allow", reason: `chat allowed + groupPolicy=${opts.groupPolicy}` };
+}
+
+/**
+ * Build the boot-time warning string when a channel starts with an
+ * empty / malformed allowlist. Caller emits this via `warn()` once at
+ * startup so operators see the fail-closed posture immediately rather
+ * than discovering it the first time a message gets denied.
+ *
+ * Returns `null` when the allowlist has at least one entry (no boot
+ * warning needed).
+ */
+export function buildEmptyAllowlistWarn(opts: {
+  channel: string;           // "telegram" | "feishu" | etc.
+  channelDir: string;        // absolute path to access.json's parent
+  allowFrom: unknown;
+}): string | null {
+  const { list, malformed } = normalizeAllowFrom(opts.allowFrom);
+  if (list.length > 0) return null;
+  const detail = malformed ? "malformed (not a string[])" : "empty";
+  return (
+    `[${opts.channel}] FAIL-CLOSED: ${opts.channelDir}/access.json allowFrom is ${detail} — ` +
+    `ALL inbound messages will be denied. To open the channel: edit access.json ` +
+    `and set \`"allowFrom": ["*"]\` for any-sender, or add specific sender ids. ` +
+    `Pre-v0.11 behaviour was fail-open; this is a deliberate security change ` +
+    `(see release notes).`
+  );
+}

--- a/agent-node/src/util/access-resolve.ts
+++ b/agent-node/src/util/access-resolve.ts
@@ -24,6 +24,40 @@
 // is observed.
 
 /**
+ * Tiny loader that mirrors what `initTelegramChannel` does at boot —
+ * read the parsed access.json blob and produce both the raw allowFrom
+ * payload (handed to the resolver verbatim) AND a boot-time warning
+ * string for the empty / malformed case.
+ *
+ * Extracted so wiring-level regression tests (e.g. "channel state
+ * built from `{allowFrom: [123]}` MUST fail-closed when a message
+ * arrives") run without spinning up a real telegram channel + fs
+ * mocks. The previous bug — `.map(String)` rewriting [123] into
+ * ["123"] at init time — slipped past resolver-only unit tests
+ * because the resolver never saw the offending shape; the channel
+ * state did.
+ */
+export interface LoadedTelegramAccess {
+  /** Raw value from access.json — handed verbatim to resolveTelegramAccess. */
+  allowFromRaw: unknown;
+  /** Boot-time warning string when allowFrom is empty / malformed; null otherwise. */
+  bootWarn: string | null;
+}
+
+export function loadTelegramAccess(opts: {
+  channelDir: string;
+  parsedAccess: { allowFrom?: unknown } | null | undefined;
+}): LoadedTelegramAccess {
+  const allowFromRaw = opts.parsedAccess?.allowFrom;
+  const bootWarn = buildEmptyAllowlistWarn({
+    channel: "telegram",
+    channelDir: opts.channelDir,
+    allowFrom: allowFromRaw,
+  });
+  return { allowFromRaw, bootWarn };
+}
+
+/**
  * Discriminated reason for an access decision. Callers can switch on
  * `kind` for routing (e.g. `empty-fail-closed` warrants a louder boot
  * warning than a simple `denied` mid-stream).


### PR DESCRIPTION
## Author
Agent: 通信工程马
Refs: #261 — v0.11 公网安全必修 (B1)

## Why

Pre-v0.11 `telegramAllowed()` (cli.ts:2671) treated an empty / missing / malformed `allowFrom` as **allow-all**. Combined with the default `dangerouslySkipPermissions` in `flags.json`, a node whose `access.json` had been truncated (the 2026-06 `git-stash -u` + `git-clean -fd` incident shape) would silently accept commands from any Telegram user on the internet and drive the local Claude / Codex / Grok runtime with full skip-permissions.

That is a remote-execution vector. v0.11 flips the default to fail-closed.

## How this does not break existing users

Both channel-add wizards (`writeTelegramChannelConfig` / `writeFeishuChannelConfig`) require a non-empty `allowFrom` at creation time — there is no wizard path that produces the empty shape that would now fail-closed.

The only deployments affected are those that have **hand-edited** `access.json` to empty `allowFrom` (which has always been the wrong shape to express "allow all"). Migration is one line: `"allowFrom": ["*"]` for the previous wildcard semantics.

A loud one-shot boot warning surfaces the new posture in the first line of `agent-node` logs so an operator running an upgraded node sees it immediately rather than discovering it the first time a message is denied.

## Changes (6 files, +488 / -7)

### `agent-node/src/util/access-resolve.ts` (new, 235 LOC)

Shared resolver consumed by every IM channel. Exports:

| Function | Purpose |
| --- | --- |
| `normalizeAllowFrom(raw)` | Defensive shape coercion — handles `null` / `undefined` / non-array / non-string elements; reports `malformed` flag for corrupted-on-disk shapes |
| `resolveTelegramAccess({allowFrom, senderId, senderUsername})` | Returns `{allow, kind, reason}` with discriminated kinds (`wildcard-allow` / `explicit-allow` / `empty-fail-closed` / `denied`) |
| `resolveFeishuAccess({conversationType, allowFrom, allowChats, senderId, conversationId, groupPolicy})` | Same shape; handles DM + group + `observe` + `mention`-passthrough |
| `buildEmptyAllowlistWarn({channel, channelDir, allowFrom})` | Boot-time warn string; returns `null` when allowlist is non-empty |

### `agent-network/src/im/access-resolve.ts` (new, mirror)

Feishu adapter consumes the same helper. Bun workspaces aren't currently set up across the `agent-node` / `agent-network` packages, so the v0.11 fix duplicates the helper. The mirror header documents the lockstep requirement and the planned v0.12 extraction.

### Telegram consumer wiring

- `telegramAllowed()` (cli.ts:2671) now delegates to `resolveTelegramAccess`
- `initTelegramChannel()` (cli.ts:475) emits `buildEmptyAllowlistWarn` at boot

### Feishu consumer wiring

- `checkAccess()` (adapter.ts:456) delegates the whitelist + group-policy decision to `resolveFeishuAccess`
- The mention-gate (`event.mentioned`) stays local because it's a feishu-specific event field the generic resolver does not model

## Verification

### 68 new unit tests (34 in agent-node, 34 mirror in agent-network)

```
normalizeAllowFrom shape coercion         × 6
resolveTelegramAccess fail-closed         × 3 (empty / undefined / malformed)
resolveTelegramAccess wildcard / explicit × 5
resolveTelegramAccess id / username match × 4
resolveFeishuAccess DM path                × 4
resolveFeishuAccess group path             × 6 (allowChats / observe / mention / etc.)
buildEmptyAllowlistWarn                    × 4
regression — pre-v0.11 fail-open MUST NOT come back × 4
```

### agent-node

- `bun test src/` → **363 / 0 pass** (was 329)
- `bun run build` → 0.39 MB cli.js, 107 modules, no warnings

### agent-network

- `bun test src/im/access-resolve.test.ts` → **34 / 0 pass**
- `feishu-bridge-ackplaceholder.test` → 16 / 16 (custom harness)

## Test plan (reviewer)

- [ ] Pull branch, `cd agent-node && bun install && bun test src/` → 363 / 0
- [ ] Read `agent-node/src/util/access-resolve.ts` for the contract; note `kind` discriminator + the fail-closed regression-guard tests at the end of the spec
- [ ] Diff `agent-node/src/util/access-resolve.ts` against `agent-network/src/im/access-resolve.ts` — must be byte-identical except for the mirror header (the lockstep canary)
- [ ] Read the 2 cli.ts hooks (`telegramAllowed` delegation + `initTelegramChannel` warn emit) and the feishu adapter `checkAccess` refactor
- [ ] Confirm the migration sentence makes sense to a documentation reader who has never seen this codebase before

## Release-notes (v0.11)

A dedicated section must call out the change explicitly:

> **🔒 Telegram fail-closed default.** Empty / missing / malformed `allowFrom` in `access.json` now denies inbound messages instead of allowing all. To preserve the old "allow any sender" behaviour, set `"allowFrom": ["*"]` explicitly. The new default closes a remote-execution path when combined with the default `dangerouslySkipPermissions` flag — see `<release-note-link>` for the incident background.

## Out of scope (separate PR — B2)

`.anet/` auto-gitignore on `anet node create` / `anet init` to prevent `git clean -fd` / `git stash -u` from sweeping configs + access.json (the same incident class that motivated this fail-closed flip).

## v0.12 follow-up

Extract `access-resolve.ts` + tests into a real shared package so the agent-node / agent-network copies can dedupe; until then both files carry a sync-with header to make drift visible in PR diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
