### PR TITLE
[security][v0.11] auto-ignore .anet/ in project-root .gitignore

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -16,6 +16,7 @@ import { homedir } from "os";
 import { spawn, execSync, execFileSync } from "child_process";
 import { createHash, randomBytes, randomUUID } from "crypto";
 import { checkbox, confirm, select } from "@inquirer/prompts";
+import { ensureGitignoreRule, ensureGitignoreRules } from "../src/gitignore-writeback";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -1148,6 +1149,11 @@ async function initProject() {
   const anetDir = join(process.cwd(), ".anet");
   mkdirSync(anetDir, { recursive: true });
 
+  // v0.11 security — first action after creating .anet/ is to make
+  // sure git won't sweep it. See ensureAnetInRootGitignore() for the
+  // incident background.
+  ensureAnetInRootGitignore();
+
   // 1. Write node-server.ts (uses shared resolver below)
   const serverTs = join(anetDir, "node-server.js");
   const refreshed = refreshNodeServerJsAt(serverTs, { overwrite: false });
@@ -1408,23 +1414,46 @@ function loadNodeDotenv(nodeId: string): Record<string, string> {
 }
 
 // #193 envRef Option A — ensure the user's project-level `.anet/.gitignore`
-// covers per-node .env secret stores. Idempotent: appends the rule only when
-// missing; never touches existing rules.
+// covers per-node .env secret stores. Idempotent.
 function ensureNodeDotenvGitignore(): void {
   try {
     const anetDir = join(process.cwd(), ".anet");
     if (!existsSync(anetDir)) return;  // no .anet/ yet — nothing to protect
-    const gi = join(anetDir, ".gitignore");
-    const rule = "nodes/*/.env";
-    let content = "";
-    if (existsSync(gi)) content = readFileSync(gi, "utf-8");
-    if (content.split("\n").some(l => l.trim() === rule)) return;
-    const sep = content && !content.endsWith("\n") ? "\n" : "";
-    writeFileSync(gi, content + sep + rule + "\n");
+    ensureGitignoreRule(join(anetDir, ".gitignore"), "nodes/*/.env");
   } catch {}
 }
 
+// v0.11 security — ensure the *project-root* .gitignore ignores the whole
+// `.anet/` tree. Without this, `git stash -u` or `git clean -fd` in the
+// project root sweeps the untracked `.anet/` directory and silently
+// destroys configs + access.json + per-node secret stores (the 2026-06
+// incident shape that motivated the v0.11 security pass). Idempotent.
+function ensureAnetInRootGitignore(): void {
+  try {
+    const gitignorePath = join(process.cwd(), ".gitignore");
+    const outcome = ensureGitignoreRule(gitignorePath, ".anet/");
+    if (outcome === "created") {
+      console.log(`[anet] 🔒 Created ./.gitignore and added '.anet/' rule (protects against \`git stash -u\` / \`git clean -fd\`).`);
+    } else if (outcome === "appended") {
+      console.log(`[anet] 🔒 Added '.anet/' to ./.gitignore (protects against \`git stash -u\` / \`git clean -fd\`).`);
+    }
+    // 'already-present' is silent — the rule was already there, nothing to surface.
+  } catch (e: any) {
+    // Non-fatal: a CI runner may have a read-only fs, or there's no
+    // .gitignore-writable parent. Surface as a warn so the operator can
+    // add the rule manually but don't block create / init.
+    console.warn(`[anet] ⚠ could not update ./.gitignore with '.anet/' rule: ${e?.message || e}`);
+    console.warn(`[anet]    Add '.anet/' to your project's .gitignore manually to avoid \`git clean\` sweeping configs+access.json.`);
+  }
+}
+
 function saveCreatedNode(id: string, profile: Profile) {
+  // v0.11 security — node create writes to .anet/nodes/<id>/ which carries
+  // access.json + per-node tokens. Make sure project-root .gitignore covers
+  // .anet/ before we drop any secret state into it. Idempotent; silent
+  // when already present.
+  ensureAnetInRootGitignore();
+
   // #125 fix: rewrite plain-secret env values to the envRef shape **at create
   // time**, before the config first hits disk. Keeps secrets out of git
   // history, dashboard, anet ls -v, etc. User sees a banner with `export …`

--- a/agent-network/src/gitignore-writeback.test.ts
+++ b/agent-network/src/gitignore-writeback.test.ts
@@ -1,0 +1,166 @@
+// Coverage for the idempotent .gitignore writeback helper.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureGitignoreRule, ensureGitignoreRules } from "./gitignore-writeback";
+
+let scratch = "";
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "anet-gi-"));
+});
+
+afterEach(() => {
+  if (scratch) rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("ensureGitignoreRule — file does not exist", () => {
+  test("creates file with the rule + trailing newline", () => {
+    const path = join(scratch, ".gitignore");
+    const out = ensureGitignoreRule(path, ".anet/");
+    expect(out).toBe("created");
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path, "utf-8")).toBe(".anet/\n");
+  });
+
+  test("trims surrounding whitespace from the rule before writing", () => {
+    const path = join(scratch, ".gitignore");
+    ensureGitignoreRule(path, "   .anet/   ");
+    expect(readFileSync(path, "utf-8")).toBe(".anet/\n");
+  });
+});
+
+describe("ensureGitignoreRule — file exists, rule absent", () => {
+  test("appends rule and reports 'appended'", () => {
+    const path = join(scratch, ".gitignore");
+    Bun.write(path, "node_modules/\n.env\n");
+    // Force sync read after async Bun.write
+    Bun.file(path);
+    const out = ensureGitignoreRule(path, ".anet/");
+    expect(out).toBe("appended");
+    expect(readFileSync(path, "utf-8")).toBe("node_modules/\n.env\n.anet/\n");
+  });
+
+  test("adds missing trailing newline before appending", () => {
+    const path = join(scratch, ".gitignore");
+    writeFileSyncRaw(path, "node_modules"); // no trailing newline
+    const out = ensureGitignoreRule(path, ".anet/");
+    expect(out).toBe("appended");
+    expect(readFileSync(path, "utf-8")).toBe("node_modules\n.anet/\n");
+  });
+
+  test("empty file → appended, not created", () => {
+    const path = join(scratch, ".gitignore");
+    writeFileSyncRaw(path, "");
+    const out = ensureGitignoreRule(path, ".anet/");
+    expect(out).toBe("appended");
+    expect(readFileSync(path, "utf-8")).toBe(".anet/\n");
+  });
+});
+
+describe("ensureGitignoreRule — rule already present (idempotent)", () => {
+  test("exact match returns already-present + does not modify file", () => {
+    const path = join(scratch, ".gitignore");
+    writeFileSyncRaw(path, "node_modules/\n.anet/\n.env\n");
+    const before = readFileSync(path, "utf-8");
+    const out = ensureGitignoreRule(path, ".anet/");
+    expect(out).toBe("already-present");
+    expect(readFileSync(path, "utf-8")).toBe(before);
+  });
+
+  test("trimmed match (rule with surrounding whitespace) treats as present", () => {
+    const path = join(scratch, ".gitignore");
+    writeFileSyncRaw(path, "  .anet/  \n");
+    const out = ensureGitignoreRule(path, ".anet/");
+    expect(out).toBe("already-present");
+  });
+
+  test("commented-out rule does NOT count as present", () => {
+    // `# .anet/` is a comment, not an active rule. We must still
+    // append the actual rule below it.
+    const path = join(scratch, ".gitignore");
+    writeFileSyncRaw(path, "# .anet/\nnode_modules/\n");
+    const out = ensureGitignoreRule(path, ".anet/");
+    expect(out).toBe("appended");
+    expect(readFileSync(path, "utf-8")).toBe("# .anet/\nnode_modules/\n.anet/\n");
+  });
+
+  test("multiple invocations are idempotent (call 3 times)", () => {
+    const path = join(scratch, ".gitignore");
+    ensureGitignoreRule(path, ".anet/");
+    const after1 = readFileSync(path, "utf-8");
+    expect(ensureGitignoreRule(path, ".anet/")).toBe("already-present");
+    expect(ensureGitignoreRule(path, ".anet/")).toBe("already-present");
+    expect(readFileSync(path, "utf-8")).toBe(after1);
+  });
+});
+
+describe("ensureGitignoreRule — multiple distinct rules don't collide", () => {
+  test("two different rules go to two different lines", () => {
+    const path = join(scratch, ".gitignore");
+    ensureGitignoreRule(path, ".anet/");
+    ensureGitignoreRule(path, "nodes/*/.env");
+    const body = readFileSync(path, "utf-8");
+    expect(body).toContain(".anet/\n");
+    expect(body).toContain("nodes/*/.env\n");
+  });
+
+  test("similar-but-different rules don't false-match (`.anet/` vs `.anet/foo`)", () => {
+    const path = join(scratch, ".gitignore");
+    ensureGitignoreRule(path, ".anet/");
+    const out = ensureGitignoreRule(path, ".anet/foo");
+    expect(out).toBe("appended");
+    expect(readFileSync(path, "utf-8")).toBe(".anet/\n.anet/foo\n");
+  });
+});
+
+describe("ensureGitignoreRules — batch", () => {
+  test("empty rules list is a no-op", () => {
+    const path = join(scratch, ".gitignore");
+    const result = ensureGitignoreRules(path, []);
+    expect(result).toEqual([]);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("creates file with all rules on first call", () => {
+    const path = join(scratch, ".gitignore");
+    const result = ensureGitignoreRules(path, [".anet/", "nodes/*/.env"]);
+    expect(result).toEqual(["created", "appended"]);
+    expect(readFileSync(path, "utf-8")).toBe(".anet/\nnodes/*/.env\n");
+  });
+
+  test("second batch call is fully idempotent", () => {
+    const path = join(scratch, ".gitignore");
+    ensureGitignoreRules(path, [".anet/", "nodes/*/.env"]);
+    const result = ensureGitignoreRules(path, [".anet/", "nodes/*/.env"]);
+    expect(result).toEqual(["already-present", "already-present"]);
+  });
+
+  test("partial overlap — only new rules appended", () => {
+    const path = join(scratch, ".gitignore");
+    writeFileSyncRaw(path, ".env\n.anet/\n");
+    const result = ensureGitignoreRules(path, [".anet/", "nodes/*/.env"]);
+    expect(result).toEqual(["already-present", "appended"]);
+    expect(readFileSync(path, "utf-8")).toBe(".env\n.anet/\nnodes/*/.env\n");
+  });
+});
+
+describe("ensureGitignoreRule — defensive", () => {
+  test("empty rule throws", () => {
+    const path = join(scratch, ".gitignore");
+    expect(() => ensureGitignoreRule(path, "")).toThrow(/non-empty/);
+  });
+
+  test("whitespace-only rule throws", () => {
+    const path = join(scratch, ".gitignore");
+    expect(() => ensureGitignoreRule(path, "   ")).toThrow(/non-empty/);
+  });
+});
+
+// Helper for sync raw write so tests don't fight Bun.write's async.
+function writeFileSyncRaw(path: string, content: string) {
+  const { writeFileSync } = require("node:fs");
+  writeFileSync(path, content);
+}

--- a/agent-network/src/gitignore-writeback.ts
+++ b/agent-network/src/gitignore-writeback.ts
@@ -1,0 +1,73 @@
+// Idempotent .gitignore writeback. Used by `anet init project` and
+// `anet node create` to make sure `.anet/` plus its mode-600 secret
+// stores never accidentally land in `git status` (and therefore never
+// get swept by `git clean -fd` / `git stash -u`, which is the exact
+// shape of the 2026-06 incident that lost a node's access.json +
+// flags.json + per-node tokens).
+//
+// Pure helper: takes the file path and the rule, returns a value
+// describing whether the file was touched. No process.cwd reads, no
+// console.log — caller decides logging.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+/**
+ * Outcome of one rule check against one `.gitignore` file.
+ */
+export type EnsureRuleOutcome =
+  | "already-present"  // line already in file (idempotent no-op)
+  | "appended"         // file existed, we appended the rule
+  | "created"          // file did not exist, we created it with the rule
+  | "skipped-no-anet"; // file's parent .anet dir does not exist — we don't materialise it just to write a gitignore
+
+/**
+ * Append `rule` to `gitignorePath` unless an exactly-matching line
+ * already exists. Returns the outcome. Never throws on missing parent
+ * directory — caller is expected to have created it (or wants the
+ * gitignore skipped, per the `.anet`-scoped writer below).
+ *
+ * The rule comparison is line-exact after `trim()`. Rules with leading
+ * `#` (comment lines in the same file) are ignored for the duplicate
+ * check, so an end-user can leave commented-out variants in place
+ * without confusing the idempotent guard.
+ */
+export function ensureGitignoreRule(
+  gitignorePath: string,
+  rule: string,
+): EnsureRuleOutcome {
+  const target = rule.trim();
+  if (!target) throw new Error("ensureGitignoreRule: rule must be non-empty");
+
+  if (!existsSync(gitignorePath)) {
+    writeFileSync(gitignorePath, target + "\n");
+    return "created";
+  }
+
+  const content = readFileSync(gitignorePath, "utf-8");
+  const present = content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith("#"))
+    .some((l) => l === target);
+  if (present) return "already-present";
+
+  const sep = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+  writeFileSync(gitignorePath, content + sep + target + "\n");
+  return "appended";
+}
+
+/**
+ * Convenience: append multiple rules to one `.gitignore` file with one
+ * read/write pair. Returns the outcome per rule, in input order.
+ */
+export function ensureGitignoreRules(
+  gitignorePath: string,
+  rules: string[],
+): EnsureRuleOutcome[] {
+  if (rules.length === 0) return [];
+  // For correctness under repeated rules, we still call the single-
+  // rule writer per entry. Disk IO is small (writeFileSync rewrites
+  // the whole file) and the per-rule loop keeps the contract trivial
+  // to reason about.
+  return rules.map((r) => ensureGitignoreRule(gitignorePath, r));
+}


### PR DESCRIPTION
## Author
Agent: 通信工程马
Refs: #261 — v0.11 公网安全必修 (B2)

## Why

`.anet/` carries `access.json`, per-node `ntok_*`, channel secrets, and bridge state — the entire runtime identity of a node. Pre-v0.11 it was untracked but **not** covered by the project-root `.gitignore`, so `git stash -u` / `git clean -fd` run from the project root would silently sweep the whole tree. The 2026-06 incident that lost a live node's telegram allowlist + feishu config + per-node tokens reproduced exactly this shape — state lived only on disk and was not recoverable from git history.

The existing #193 writeback (`ensureNodeDotenvGitignore`) only covered `nodes/*/.env` *inside* `.anet/.gitignore`. That governs sub-tracking but doesn't prevent git from seeing the `.anet/` directory as untracked at the project root in the first place, which is what `git clean -fd` walks.

v0.11 fix: project-root `.gitignore` now contains `.anet/` after `anet init project` AND after every `anet node create`.

## Changes (3 files, +277 / -9)

### `agent-network/src/gitignore-writeback.ts` (new, 78 LOC)

Pure idempotent helper. Exports:

| Function | Behaviour |
| --- | --- |
| `ensureGitignoreRule(filePath, rule)` | Returns `"created"` / `"appended"` / `"already-present"`. Handles missing file, missing trailing newline, commented-out rule (does NOT count as present), exact-match dedup |
| `ensureGitignoreRules(filePath, rules[])` | Batch; returns outcome[] in input order |

Both pure — no `process.cwd()` reads, no `console.log`. Caller decides logging. Defensive: empty / whitespace-only `rule` throws so a mis-wired call site fails loudly instead of silently no-op'ing.

### Wiring in `agent-network/bin/cli.ts`

- `initProject()` — calls `ensureAnetInRootGitignore()` immediately after `mkdirSync(.anet/)` so a fresh project is protected before any state lands
- `saveCreatedNode()` — calls `ensureAnetInRootGitignore()` on every node create (no-op if `.gitignore` already has it; safe to re-fire for legacy projects that pre-date this PR)
- Existing `ensureNodeDotenvGitignore()` simplified to use the new helper (inline dedup loop removed)

The `ensureAnetInRootGitignore()` wrapper logs once on `created` / `appended` (silent on `already-present`) so an operator sees the protection go in. On failure (read-only fs / unwritable parent), surfaces a warn with manual-action guidance — does not block create / init.

## Verification

### 17 new unit tests (`gitignore-writeback.test.ts`)

```
- create from scratch / trim whitespace                   × 2
- append to existing / missing trailing nl / empty file   × 3
- idempotent (exact / trimmed / commented-out / 3-call)   × 4
- multiple distinct rules don't collide (.anet/ vs .anet/foo) × 2
- batch ensureGitignoreRules (empty / fresh / idempotent / partial) × 4
- defensive (empty / whitespace-only throws)              × 2
```

### 5 functional smoke cases (real tmp-dir, no mocks)

```
1. fresh        → "created"        | ".anet/\n"
2. idempotent   → "already-present"
3. append       → "appended"        | "node_modules/\n.env\n.anet/\n"
4. commented    → "appended"        (comment line doesn't count)
5. no-trailing  → "appended"        | "node_modules\n.anet/\n"
ALL B2 SMOKES PASS
```

### Build

- `bun build bin/cli.ts` → 0.33 MB cli.js, clean

## Test plan (reviewer)

- [ ] Pull branch, `cd agent-network && bun test src/gitignore-writeback.test.ts` → 17 / 0
- [ ] Read `gitignore-writeback.ts` for the contract; especially the comment-line behaviour (commented-out rule MUST NOT short-circuit the writer)
- [ ] Read the 3 `ensureAnetInRootGitignore()` call sites — both new + the simplified `ensureNodeDotenvGitignore()`
- [ ] Manual smoke: fresh project dir, run `anet init project` against a mock hub URL, confirm `.gitignore` is created with `.anet/`; then `anet node create` and confirm idempotent log line

## Out of scope (separate PR — B1)

`telegramAllowed` fail-closed flip + shared access resolver — that's the matching B1 in PR #276.

## v0.12 follow-up

For legacy projects that already have `.anet/` populated but no project-root `.gitignore` entry, the next `anet node create` will retroactively add the rule. No migration script needed; the idempotent helper makes the rule-add safe to fire on every create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
