### PR TITLE
fix(commhub): gate SSE push on chain success + close canWrite oracle (#275 follow-up)

### DIFF
--- a/server/src/cross-tenant-injection.test.ts
+++ b/server/src/cross-tenant-injection.test.ts
@@ -64,6 +64,116 @@ beforeEach(() => {
 // fix, the function refuses to traverse and writes nothing.
 // ─────────────────────────────────────────────────────────────────────
 
+// ─────────────────────────────────────────────────────────────────────
+// Round-5 follow-up — chainReplyToParent return value gates SSE push
+//
+// 通信牛 catch on #275: the DB write is refused on cross-network, but
+// the post-call code in tools.ts was still running:
+//
+//   SELECT parent_task_id, from_name FROM tasks WHERE task_id = ?
+//   SELECT from_name, task_id ... WHERE task_id = ?
+//   pushEvent(parent.from_name, { parent_task_id: <netA-id>, ... },
+//             effectiveNetId)
+//
+// That pushEvent leaks the foreign parent's task_id into the caller's
+// network via SSE payload. The fix: chainReplyToParent now returns
+// `{ chained, stoppedReason? }` so callers can skip the follow-up
+// push when the chain didn't actually write. These tests pin the
+// return contract directly. The SSE-gate is exercised at the call
+// sites in tools.ts; pinning the contract here ensures the call-site
+// behaviour can't drift back if someone refactors db.ts.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("chainReplyToParent — return value gates SSE push (round5 follow-up)", () => {
+  test("cross-network refusal returns { chained: false, stoppedReason: 'cross_network' }", () => {
+    const parentA = insertTask({
+      from_name: "admin-a",
+      to_name: "worker-a",
+      network_id: "net-A",
+      status: "delivered",
+    });
+    const childB = insertTask({
+      from_name: "attacker-b",
+      to_name: "victim-b",
+      network_id: "net-B",
+      status: "replied",
+      parent_task_id: parentA,
+    });
+
+    const result = chainReplyToParent(childB, "payload", "replied", 5, "net-B");
+
+    expect(result.chained).toBe(false);
+    expect(result.stoppedReason).toBe("cross_network");
+  });
+
+  test("legitimate same-network chain returns { chained: true } (no stoppedReason)", () => {
+    const parentB = insertTask({
+      from_name: "admin-b",
+      to_name: "worker-b",
+      network_id: "net-B",
+      status: "delivered",
+    });
+    const childB = insertTask({
+      from_name: "child-b",
+      to_name: "leaf-b",
+      network_id: "net-B",
+      status: "replied",
+      parent_task_id: parentB,
+    });
+
+    const result = chainReplyToParent(childB, "ok", "replied", 5, "net-B");
+
+    expect(result.chained).toBe(true);
+    expect(result.stoppedReason).toBeUndefined();
+  });
+
+  test("child with no parent returns { chained: false } (no stoppedReason)", () => {
+    const orphan = insertTask({
+      from_name: "x",
+      to_name: "y",
+      network_id: "net-B",
+      status: "replied",
+    });
+
+    const result = chainReplyToParent(orphan, "ok", "replied", 5, "net-B");
+
+    expect(result.chained).toBe(false);
+    expect(result.stoppedReason).toBeUndefined();
+  });
+
+  test("3-level chain: same-net parent writes, foreign grandparent halts → chained=true, stoppedReason='cross_network'", () => {
+    const grandparent = insertTask({
+      from_name: "gp-admin",
+      to_name: "gp-worker",
+      network_id: "net-A",
+      status: "delivered",
+    });
+    const parent = insertTask({
+      from_name: "p-admin",
+      to_name: "p-worker",
+      network_id: "net-B",
+      status: "delivered",
+      parent_task_id: grandparent,
+    });
+    const child = insertTask({
+      from_name: "c",
+      to_name: "leaf",
+      network_id: "net-B",
+      status: "replied",
+      parent_task_id: parent,
+    });
+
+    const result = chainReplyToParent(child, "ok", "replied", 5, "net-B");
+
+    // We DID write into the same-net parent before the chain halted
+    // at the foreign grandparent. `chained: true` lets callers push
+    // SSE for the legitimate parent; `stoppedReason` makes it visible
+    // in logs/metrics that the chain didn't run to completion.
+    expect(result.chained).toBe(true);
+    expect(result.stoppedReason).toBe("cross_network");
+  });
+});
+
 describe("chainReplyToParent — cross-network rejection (round5 F2 #3)", () => {
   test("blocks chain when parent.network_id != callerNetId", () => {
     // Network A: a task that should NEVER receive a foreign reply.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -762,17 +762,39 @@ export function logAudit(userId: string | null, username: string | null, action:
  * (e.g. server-internal bookkeeping that doesn't have a tenant
  * context) can omit `callerNetId`, but every MCP tool path MUST
  * supply it.
+ *
+ * Returns `{ chained, stoppedReason? }` so the caller can gate its
+ * follow-up SSE push on whether the chain actually wrote (round-2
+ * fix per #275 follow-up, 通信牛 catch): even when the WRITE was
+ * refused, callers were still running `SELECT parent.from_name;
+ * pushEvent(parent.from_name, { parent_task_id }, callerNetId)` —
+ * leaking the foreign parent's task_id into the caller's network
+ * via the SSE payload. Now the caller checks `result.chained` before
+ * pushing the chained_reply event.
  */
+export type ChainReplyResult = {
+  /** True iff this call actually wrote into at least one parent row.
+   *  When false, callers MUST NOT push SSE events for parent
+   *  listeners — the chain would otherwise leak the foreign parent's
+   *  identifiers into the caller's network. */
+  chained: boolean;
+  /** Optional reason the chain stopped short. Today the only enforced
+   *  reason is `cross_network`; future reasons (max-depth, parent-
+   *  archived, etc.) can land here without breaking callers. */
+  stoppedReason?: "cross_network";
+};
+
 export function chainReplyToParent(
   childTaskId: string,
   replyText: string,
   replyStatus: "replied" | "failed" | "cancelled" = "replied",
   maxDepth = 5,
   callerNetId?: string | null,
-): void {
+): ChainReplyResult {
   let currentChildId: string | null = childTaskId;
   let currentReply = replyText;
   let depth = 0;
+  let chained = false;
   // Normalize so undefined ("don't enforce") stays distinct from
   // null ("explicit default network"). Caller passes undefined to
   // opt out of the cross-tenant check; null to require the parent
@@ -788,12 +810,12 @@ export function chainReplyToParent(
       "SELECT parent_task_id, to_name, from_name, content FROM tasks WHERE task_id = ?1",
       currentChildId
     );
-    if (!child?.parent_task_id) return;
+    if (!child?.parent_task_id) return { chained };
     const parent: ParentRow | null = db.get<ParentRow>(
       "SELECT task_id, from_name, to_name, status, result, network_id, parent_task_id FROM tasks WHERE task_id = ?1",
       child.parent_task_id
     );
-    if (!parent) return;
+    if (!parent) return { chained };
 
     // round5 F2 fix: refuse to write into a parent that lives in a
     // different network than the caller. Stops chain-reply being a
@@ -803,7 +825,7 @@ export function chainReplyToParent(
       const parentNet = parent.network_id ?? null;
       if (parentNet !== callerNorm) {
         console.log(`[commhub] 🚫 chainReplyToParent cross-network blocked: parent=${parent.task_id.slice(0, 8)} parent-net=${parentNet ?? "null"} caller-net=${callerNorm ?? "null"}`);
-        return;
+        return { chained, stoppedReason: "cross_network" };
       }
     }
 
@@ -844,10 +866,16 @@ export function chainReplyToParent(
       } catch {}
     }
 
+    // This iteration actually wrote a parent row (and possibly an
+    // inbox notification). Record that so the caller can gate its
+    // SSE push on a real chain.
+    chained = true;
+
     // Recurse up the chain.
     currentChildId = parent.task_id;
     currentReply = newResult;
   }
+  return { chained };
 }
 
 export function logTaskEvent(taskId: string, fromStatus: string | null, toStatus: string, actor: string, detail?: string) {

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -501,20 +501,29 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       // round5 F2: pass caller's effectiveNetId so the chain refuses
       // to write across tenants if some upstream parent links to a
       // foreign network.
+      //
+      // round5 follow-up (通信牛 SSE leak catch): gate the SSE push on
+      // `result.chained` — if the chain refused (cross-network), the
+      // subsequent SELECT of `parent.from_name` + `pushEvent(...,
+      // parent.task_id)` would leak the foreign parent's task_id into
+      // the caller's network via the SSE payload. Skip the push when
+      // the chain didn't actually write.
       if (updatedTaskId) {
         try {
-          chainReplyToParent(updatedTaskId, result, "replied", 5, effectiveNetId);
-          const parentChain = db.get<{ parent_task_id: string | null }>(
-            "SELECT parent_task_id FROM tasks WHERE task_id = ?1",
-            [updatedTaskId]
-          );
-          if (parentChain?.parent_task_id) {
-            const parent = db.get<{ from_name: string; task_id: string }>(
-              "SELECT from_name, task_id FROM tasks WHERE task_id = ?1",
-              [parentChain.parent_task_id]
+          const chainResult = chainReplyToParent(updatedTaskId, result, "replied", 5, effectiveNetId);
+          if (chainResult.chained) {
+            const parentChain = db.get<{ parent_task_id: string | null }>(
+              "SELECT parent_task_id FROM tasks WHERE task_id = ?1",
+              [updatedTaskId]
             );
-            if (parent?.from_name && parent.from_name !== "hub" && parent.from_name !== "api") {
-              pushEvent(parent.from_name, { type: "chained_reply", parent_task_id: parent.task_id, child_task_id: updatedTaskId, child_alias: alias }, effectiveNetId);
+            if (parentChain?.parent_task_id) {
+              const parent = db.get<{ from_name: string; task_id: string }>(
+                "SELECT from_name, task_id FROM tasks WHERE task_id = ?1",
+                [parentChain.parent_task_id]
+              );
+              if (parent?.from_name && parent.from_name !== "hub" && parent.from_name !== "api") {
+                pushEvent(parent.from_name, { type: "chained_reply", parent_task_id: parent.task_id, child_task_id: updatedTaskId, child_alias: alias }, effectiveNetId);
+              }
             }
           }
         } catch (e: any) {
@@ -698,6 +707,18 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     async ({ alias, task, priority, context, from_session: _fromIn, ttl_seconds, network_id: netId, parent_task_id: parentIn, meta }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
       const effectiveNetId = getNetworkId(netId);
       const metaJson = normalizeMetaJson(meta);
+
+      // Role check FIRST — round5 follow-up (通信牛 oracle catch):
+      // the explicit-parent verification below distinguishes
+      // `cross_network_parent` from `permission_denied`. If we ran the
+      // parent lookup before canWrite, a viewer role could probe parent
+      // existence + ownership of foreign parents via the difference in
+      // error codes. Run canWrite first so a viewer ALWAYS gets the
+      // same `permission_denied` regardless of parent state.
+      if (!canWrite(effectiveNetId)) {
+        return writeDeniedReply(effectiveNetId, "send_task");
+      }
+
       // Resolve parent_task_id: explicit > inferred (caller's most recent
       // delivered/started inbox task that's still open). Inference is the
       // safety net for when the LLM forgets to pass parent_task_id.
@@ -741,11 +762,6 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
             message: "parent_task_id belongs to a different network",
           }) }] };
         }
-      }
-
-      // Role check: viewer cannot send tasks
-      if (!canWrite(effectiveNetId)) {
-        return writeDeniedReply(effectiveNetId, "send_task");
       }
 
       // License check
@@ -1017,21 +1033,26 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       // round5 F2: pass caller's effectiveNetId so the chain refuses
       // to write across tenants if some upstream parent links to a
       // foreign network.
+      //
+      // round5 follow-up (通信牛 SSE leak catch): gate the SSE push on
+      // `result.chained`. See report_completion path above for the
+      // full reasoning — same leak, same gate.
       if (replyLogged && in_reply_to) {
         try {
-          chainReplyToParent(in_reply_to, text, replyStatus, 5, effectiveNetId);
-          // Push SSE event for parent originator if there is a chain.
-          const parentChain = db.get<{ parent_task_id: string | null; from_name: string }>(
-            "SELECT parent_task_id, from_name FROM tasks WHERE task_id = ?1",
-            [in_reply_to]
-          );
-          if (parentChain?.parent_task_id) {
-            const parent = db.get<{ from_name: string; task_id: string }>(
-              "SELECT from_name, task_id FROM tasks WHERE task_id = ?1",
-              [parentChain.parent_task_id]
+          const chainResult = chainReplyToParent(in_reply_to, text, replyStatus, 5, effectiveNetId);
+          if (chainResult.chained) {
+            const parentChain = db.get<{ parent_task_id: string | null; from_name: string }>(
+              "SELECT parent_task_id, from_name FROM tasks WHERE task_id = ?1",
+              [in_reply_to]
             );
-            if (parent?.from_name && parent.from_name !== "hub" && parent.from_name !== "api") {
-              pushEvent(parent.from_name, { type: "chained_reply", parent_task_id: parent.task_id, child_task_id: in_reply_to, child_alias: alias }, effectiveNetId);
+            if (parentChain?.parent_task_id) {
+              const parent = db.get<{ from_name: string; task_id: string }>(
+                "SELECT from_name, task_id FROM tasks WHERE task_id = ?1",
+                [parentChain.parent_task_id]
+              );
+              if (parent?.from_name && parent.from_name !== "hub" && parent.from_name !== "api") {
+                pushEvent(parent.from_name, { type: "chained_reply", parent_task_id: parent.task_id, child_task_id: in_reply_to, child_alias: alias }, effectiveNetId);
+              }
             }
           }
         } catch (e: any) {


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why

Round-5 review on PR #275 caught two residual leaks **after** the PR was lead-merged. The DB write defense (F2 #3) was correct, but two adjacent paths still leaked across tenants on the public-facing hub (`<hub-domain>`):

1. **SSE info leak** — `chainReplyToParent` refused to walk into a foreign parent, but the post-call code in `tools.ts` ran unconditionally and pushed a `chained_reply` event carrying the **foreign parent's `task_id`** to a same-aliased session in the caller's network. Visible cross-tenant info leak + a fake notification.
2. **canWrite oracle in `send_task`** — explicit parent verification (F2 #2) distinguishes `cross_network_parent` from `permission_denied`. With `canWrite` running **after** parent verification, a viewer in network B could probe whether a `task_id` exists and which network owns it. Side-channel reconnaissance even though no write succeeds.

## What changed

### `server/src/db.ts` — `chainReplyToParent` return contract

Old: `void`.
New: `{ chained: boolean; stoppedReason?: 'cross_network' }`.

- `chained` becomes `true` only after an iteration actually wrote a parent row.
- `stoppedReason: 'cross_network'` is set when an upstream parent halts the chain.
- A same-net parent that writes and then halts at a foreign grandparent returns `{ chained: true, stoppedReason: 'cross_network' }` — the legitimate `pushEvent` still fires for the same-net parent.

### `server/src/tools.ts` — two SSE gates + canWrite reorder

- `report_completion` (line ~503): capture `chainReplyToParent` result; gate the subsequent `SELECT parent.from_name` + `pushEvent(...)` on `result.chained`.
- `send_reply` (line ~985): same gate.
- `send_task`: move `canWrite(effectiveNetId)` check to the **head** of the handler, before parent inference and before explicit-parent verification. Viewer role always sees `permission_denied` regardless of parent state.

### `server/src/cross-tenant-injection.test.ts` — 4 new tests pin the contract

- cross-network refusal → `{ chained: false, stoppedReason: 'cross_network' }`
- legitimate same-net chain → `{ chained: true }`
- orphan (no parent) → `{ chained: false }`
- 3-level chain (write into same-net parent, halt at foreign grandparent) → `{ chained: true, stoppedReason: 'cross_network' }`

The full-end-to-end SSE-no-push assertion would require a running MCP harness — pinning the contract here ensures the call-site gates in `tools.ts` can't drift back if `db.ts` is refactored.

## Test results

```
src/cross-tenant-injection.test.ts:
 10 pass, 0 fail, 24 expect() calls — 375ms (isolated COMMHUB_DB=/tmp/...)

Full server suite (9 files):
 165 pass, 0 fail, 518 expect() calls — 952ms
```

No new TS errors introduced (the two pre-existing errors in `push.ts:222` and `uploads-http.test.ts:73` are inherited from main, not from this PR).

## Security context

Public-facing hub `<hub-domain>` is multi-tenant. SSE + REST are the only surfaces a foreign network can observe. After this PR:

- The SSE surface no longer leaks foreign `parent_task_id` values on cross-net chain attempts.
- `send_task`'s role check happens before any tenant-scoped lookup, closing the recon oracle.

Combined with #275's DB-write defense, the chain-reply primitive is now safe in all three layers (write / notify / side-channel).

## Review checklist

- [ ] `chainReplyToParent` return-value contract matches both call-site assumptions
- [ ] canWrite ordering correct — viewer cannot probe parent existence/tenant
- [ ] No new TS errors (pre-existing two are out-of-scope)
- [ ] Public-facing copy uses `<hub-domain>` placeholder, not real domain

## Tracking

- Internal task: #142
- Builds on: #275 (round-5 F1+F2 — merged)
- 通信牛 round-5 catch comment on #275
