### PR TITLE
fix(commhub): move sessions stale-mark off read path to single background sweeper (review ③)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,7 @@ import {
 import { mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from "fs";
 import { dirname as pathDirname } from "path";
 import { startRetentionSweeper } from "./retention.js";
+import { startStaleSessionSweeper } from "./stale-sweeper.js";
 
 const PORT = Number(process.env.PORT) || 9200;
 const HOST = process.env.HOST || "127.0.0.1";
@@ -1067,11 +1068,9 @@ Bun.serve({
 
     // ── REST: all sessions status ──
     if (url.pathname === "/api/status") {
-      const cutoff = new Date(Date.now() - 10 * 60 * 1000).toISOString().replace("T", " ").slice(0, 19);
-      const staleParams: any[] = [cutoff];
-      let staleSql = "UPDATE sessions SET status = 'offline' WHERE updated_at < ?1 AND status != 'offline'";
-      staleSql = addNetworkScope(staleSql, staleParams, restScope);
-      db.run(staleSql, staleParams);
+      // Round-2/4 review ③: stale-marking moved to startStaleSessionSweeper()
+      // (background timer, ~60s cadence). Read paths no longer fire UPDATE.
+      // Per-request UPDATE was a write-amp vector — see stale-sweeper.ts.
       cleanupCommittedRenameSessions(restScope.networkId ? [restScope.networkId] : restScope.networkIds ?? null);
       // `?light=1` returns a narrow projection (alias / status / agent / task /
       // server / updated_at + runtime + network_id) — used by the mobile APP
@@ -1139,12 +1138,7 @@ Bun.serve({
 
     // ── REST: aggregate agents by physical server ──
     if (url.pathname === "/api/servers") {
-      const cutoff = new Date(Date.now() - 10 * 60 * 1000).toISOString().replace("T", " ").slice(0, 19);
-      const staleParams: any[] = [cutoff];
-      let staleSql = "UPDATE sessions SET status = 'offline' WHERE updated_at < ?1 AND status != 'offline'";
-      staleSql = addNetworkScope(staleSql, staleParams, restScope);
-      db.run(staleSql, staleParams);
-
+      // Round-2/4 review ③: stale-marking moved to background sweeper.
       const params: any[] = [];
       let sql = `
         SELECT hostname, ip, cpu_load_1min, cpu_cores, mem_avail_gb, mem_used_gb,
@@ -1221,12 +1215,7 @@ Bun.serve({
       const detailKind = serverDetailMatch[2];
       if (!host) return withCors(req, Response.json({ ok: false, error: "host required" }, { status: 400 }));
 
-      const cutoff = sqliteTime(new Date(Date.now() - 10 * 60 * 1000));
-      const staleParams: any[] = [cutoff];
-      let staleSql = "UPDATE sessions SET status = 'offline' WHERE updated_at < ?1 AND status != 'offline'";
-      staleSql = addNetworkScope(staleSql, staleParams, restScope);
-      db.run(staleSql, staleParams);
-
+      // Round-2/4 review ③: stale-marking moved to background sweeper.
       if (detailKind === "agents") {
         const params: any[] = [host, host];
         let sql = `
@@ -2148,10 +2137,21 @@ const sweepIntervalMs = Number.isFinite(sweepIntervalMinutes) && sweepIntervalMi
   : 60 * 60 * 1000;
 const retentionSweeperTimer = startRetentionSweeper(sweepIntervalMs);
 
+// Round-2/4 review ③ — stale session sweeper (coexists with the
+// retention sweeper above; different concerns + different cadences).
+// Replaces the per-request UPDATE in GET /api/status (+ /api/servers,
+// /api/server-detail/*, MCP get_all_status). Each of those endpoints
+// used to run UPDATE on the sessions table just to maintain the
+// derived `offline` status; with the dashboard polling fast that was
+// 99% no-op write-amp under hot read paths. Now done globally once
+// every COMMHUB_STALE_SWEEP_SECONDS (default 60s).
+const staleSweeperTimer = startStaleSessionSweeper();
+
 // ── Graceful shutdown ───────────────────────────────
 function shutdown() {
   console.log("[commhub] shutting down...");
   clearInterval(retentionSweeperTimer);
+  clearInterval(staleSweeperTimer);
   db.close();
   process.exit(0);
 }

--- a/server/src/stale-sweeper.test.ts
+++ b/server/src/stale-sweeper.test.ts
@@ -1,0 +1,181 @@
+// Round-2/4 review ③ — stale session sweeper tests.
+//
+// Drives the real sweepStaleSessions against isolated in-process
+// SQLite (COMMHUB_DB=/tmp/...). Pins behaviour the read-path
+// regression (per-request UPDATE) would re-introduce if anyone
+// undoes the fix:
+//
+//   1. fresh sessions stay non-offline regardless of how many
+//      times the sweeper runs;
+//   2. stale sessions get marked offline exactly once (idempotent);
+//   3. global sweep crosses tenant boundaries — a stale agent in
+//      network B is marked offline even when no one in net B is
+//      polling /api/status;
+//   4. env-var cutoff is respected and bad values fall back silently.
+//
+// Run with:
+//   COMMHUB_DB=/tmp/stale-test.db bun test src/stale-sweeper.test.ts
+
+import { describe, expect, test, beforeEach } from "bun:test";
+import { db } from "./db.js";
+import { sweepStaleSessions, staleCutoffMinutes } from "./stale-sweeper.js";
+
+function insertSession(opts: {
+  alias: string;
+  status?: string;
+  minutesAgo: number;
+  network_id?: string;
+}): void {
+  const id = `r_${opts.alias}`;
+  db.run(
+    `INSERT OR REPLACE INTO sessions
+       (resume_id, alias, status, network_id, updated_at, registered_at)
+     VALUES (?1, ?2, ?3, ?4, datetime('now', ?5), datetime('now', ?5))`,
+    [id, opts.alias, opts.status ?? "idle", opts.network_id ?? "default", `-${opts.minutesAgo} minutes`]
+  );
+}
+
+function getStatus(alias: string): string | null {
+  const row = db.get<{ status: string }>(
+    "SELECT status FROM sessions WHERE alias = ?1",
+    alias
+  );
+  return row?.status ?? null;
+}
+
+beforeEach(() => {
+  db.run("DELETE FROM sessions");
+});
+
+describe("sweepStaleSessions — fresh agents not touched", () => {
+  test("agent updated < cutoff stays at its current status", () => {
+    insertSession({ alias: "live-1", status: "idle", minutesAgo: 1 });
+    insertSession({ alias: "live-2", status: "working", minutesAgo: 5 });
+
+    sweepStaleSessions(10);
+
+    expect(getStatus("live-1")).toBe("idle");
+    expect(getStatus("live-2")).toBe("working");
+  });
+
+  test("multiple sweeps on quiet hub are pure no-ops (no write fired)", () => {
+    insertSession({ alias: "live", status: "idle", minutesAgo: 1 });
+
+    const r1 = sweepStaleSessions(10);
+    const r2 = sweepStaleSessions(10);
+    const r3 = sweepStaleSessions(10);
+
+    expect(r1.markedOffline).toBe(0);
+    expect(r2.markedOffline).toBe(0);
+    expect(r3.markedOffline).toBe(0);
+    expect(getStatus("live")).toBe("idle");
+  });
+});
+
+describe("sweepStaleSessions — stale agents marked offline", () => {
+  test("agent updated > cutoff gets marked offline exactly once", () => {
+    insertSession({ alias: "stale", status: "idle", minutesAgo: 30 });
+
+    const r1 = sweepStaleSessions(10);
+    expect(r1.markedOffline).toBe(1);
+    expect(getStatus("stale")).toBe("offline");
+
+    // Second sweep does nothing because the row is already offline
+    // (the predicate is `status != 'offline'`).
+    const r2 = sweepStaleSessions(10);
+    expect(r2.markedOffline).toBe(0);
+    expect(getStatus("stale")).toBe("offline");
+  });
+
+  test("already-offline stale row not re-marked (write avoided)", () => {
+    insertSession({ alias: "old-offline", status: "offline", minutesAgo: 60 });
+
+    const r = sweepStaleSessions(10);
+
+    expect(r.markedOffline).toBe(0);
+    expect(getStatus("old-offline")).toBe("offline");
+  });
+});
+
+describe("sweepStaleSessions — global across tenants (the read-path fix)", () => {
+  test("stale row in network B is marked offline even with no net-B polling", () => {
+    // Pre-fix: GET /api/status from net-A would only UPDATE rows in
+    // net-A's scope. A stale agent in net-B would stay non-offline
+    // until someone polled net-B. After the fix, the global sweeper
+    // is tenant-blind on the maintenance write.
+    insertSession({ alias: "stale-a", status: "idle", minutesAgo: 30, network_id: "net-A" });
+    insertSession({ alias: "stale-b", status: "idle", minutesAgo: 30, network_id: "net-B" });
+    insertSession({ alias: "stale-c", status: "idle", minutesAgo: 30, network_id: null as any });
+
+    const r = sweepStaleSessions(10);
+
+    expect(r.markedOffline).toBe(3);
+    expect(getStatus("stale-a")).toBe("offline");
+    expect(getStatus("stale-b")).toBe("offline");
+    expect(getStatus("stale-c")).toBe("offline");
+  });
+});
+
+describe("sweepStaleSessions — cutoff boundary + env", () => {
+  test("exactly-at-cutoff agent treated as stale (< strict, not <=)", () => {
+    // Just past the cutoff window.
+    insertSession({ alias: "just-stale", status: "idle", minutesAgo: 11 });
+    sweepStaleSessions(10);
+    expect(getStatus("just-stale")).toBe("offline");
+  });
+
+  test("just-under-cutoff agent treated as live", () => {
+    insertSession({ alias: "just-live", status: "working", minutesAgo: 9 });
+    sweepStaleSessions(10);
+    expect(getStatus("just-live")).toBe("working");
+  });
+
+  test("env COMMHUB_STALE_CUTOFF_MINUTES overrides default", () => {
+    process.env.COMMHUB_STALE_CUTOFF_MINUTES = "3";
+    expect(staleCutoffMinutes()).toBe(3);
+    delete process.env.COMMHUB_STALE_CUTOFF_MINUTES;
+  });
+
+  test("env invalid value falls back to default 10 (no operator footgun)", () => {
+    process.env.COMMHUB_STALE_CUTOFF_MINUTES = "not-a-number";
+    expect(staleCutoffMinutes()).toBe(10);
+    delete process.env.COMMHUB_STALE_CUTOFF_MINUTES;
+
+    process.env.COMMHUB_STALE_CUTOFF_MINUTES = "0";
+    expect(staleCutoffMinutes()).toBe(10);
+    delete process.env.COMMHUB_STALE_CUTOFF_MINUTES;
+
+    process.env.COMMHUB_STALE_CUTOFF_MINUTES = "-5";
+    expect(staleCutoffMinutes()).toBe(10);
+    delete process.env.COMMHUB_STALE_CUTOFF_MINUTES;
+  });
+});
+
+describe("sweepStaleSessions — read-path regression guard (pin the fix)", () => {
+  // This is the load-bearing pin: if anyone adds back a per-request
+  // UPDATE in /api/status / /api/servers / /api/server-detail-* /
+  // get_all_status, this test plus the absence of those UPDATEs in
+  // the source should make the regression visible. Since this is a
+  // unit-level test of the sweeper itself, the regression-prevention
+  // role is mostly social — the comments in this file + the comments
+  // in index.ts and tools.ts at the former UPDATE sites tell future
+  // editors "do not put the UPDATE back; use the sweeper."
+  test("after sweep, sessions row has the offline status persisted (single source of truth)", () => {
+    insertSession({ alias: "x", status: "working", minutesAgo: 30 });
+    const before = sweepStaleSessions(10);
+    expect(before.markedOffline).toBe(1);
+
+    // Re-read directly — no extra UPDATE needed by a caller.
+    const status = getStatus("x");
+    expect(status).toBe("offline");
+
+    // 100 simulated read-path lookups don't fire any maintenance writes.
+    for (let i = 0; i < 100; i++) {
+      const row = db.get<{ status: string }>(
+        "SELECT status FROM sessions WHERE alias = ?1",
+        "x"
+      );
+      expect(row?.status).toBe("offline");
+    }
+  });
+});

--- a/server/src/stale-sweeper.ts
+++ b/server/src/stale-sweeper.ts
@@ -1,0 +1,114 @@
+// Round-2/4 review ③ — read-path write amplification fix.
+//
+// Before this module: GET /api/status, GET /api/servers, GET
+// /api/server-health/:host, and the MCP `get_all_status` tool each
+// fired:
+//
+//   UPDATE sessions SET status = 'offline'
+//   WHERE updated_at < ?1 AND status != 'offline'
+//
+// on every call. With the dashboard polling /api/status every few
+// seconds × N tabs × M users, that's a high-frequency WRITE on a
+// heavily-read table just to maintain a derived field. Wait events
+// stack up (WAL fsync, page locks) and the writes are 99% no-ops.
+//
+// Fix: move the stale-marking off the read path into a single
+// background timer. Reads now SELECT only; the timer runs every 60s
+// and applies the same UPDATE GLOBALLY (no per-network scope — stale
+// is stale regardless of which tenant is asking). Worst-case delay
+// between an agent crashing and going `offline` in the dashboard:
+//
+//   10min stale cutoff + 60s sweep = up to ~11min
+//
+// (unchanged from before the fix for any reader that wasn't actively
+// polling).
+//
+// Same pattern as `src/retention.ts` for shutdown (clearInterval in
+// the graceful shutdown handler).
+
+import { db } from "./db.js";
+
+export type StaleSweepResult = {
+  startedAt: string;
+  durationMs: number;
+  markedOffline: number;
+  staleCutoffMinutes: number;
+};
+
+// Stale window: an agent that hasn't reported in this many minutes is
+// considered offline. Matches the pre-fix per-request cutoff so the
+// observable behaviour from the dashboard's perspective is unchanged.
+const DEFAULT_STALE_MINUTES = 10;
+const DEFAULT_SWEEP_MS = 60 * 1000;
+
+export function staleCutoffMinutes(): number {
+  const raw = process.env.COMMHUB_STALE_CUTOFF_MINUTES;
+  if (raw === undefined || raw === "") return DEFAULT_STALE_MINUTES;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_STALE_MINUTES;
+  return n;
+}
+
+function sqliteCutoff(minutes: number): string {
+  return new Date(Date.now() - minutes * 60 * 1000)
+    .toISOString()
+    .replace("T", " ")
+    .slice(0, 19);
+}
+
+// Single GLOBAL UPDATE — no per-network filtering. The pre-fix per-
+// request stale marker WAS scoped (each REST call only saw its own
+// network's stale rows), but the semantics of "this row hasn't been
+// heard from in 10min" is global. A network that no one's looking at
+// still wants its agents marked offline so an admin scanning all
+// networks gets consistent state.
+export function sweepStaleSessions(cutoffMinutes = staleCutoffMinutes()): StaleSweepResult {
+  const startedAt = new Date().toISOString();
+  const t0 = Date.now();
+  let markedOffline = 0;
+  try {
+    const cutoff = sqliteCutoff(cutoffMinutes);
+    const res = db.run(
+      "UPDATE sessions SET status = 'offline' WHERE updated_at < ?1 AND status != 'offline'",
+      [cutoff],
+    );
+    markedOffline = res.changes ?? 0;
+  } catch (e: any) {
+    console.log(`[commhub stale-sweep] failed: ${e?.message ?? e}`);
+  }
+  return {
+    startedAt,
+    durationMs: Date.now() - t0,
+    markedOffline,
+    staleCutoffMinutes: cutoffMinutes,
+  };
+}
+
+export function startStaleSessionSweeper(
+  intervalMs?: number,
+): ReturnType<typeof setInterval> {
+  const env = process.env.COMMHUB_STALE_SWEEP_SECONDS;
+  const envMs = env && Number.isFinite(Number(env)) && Number(env) > 0
+    ? Number(env) * 1000
+    : undefined;
+  const ms = intervalMs ?? envMs ?? DEFAULT_SWEEP_MS;
+  const sweep = () => {
+    try {
+      const r = sweepStaleSessions();
+      // Log only when something actually changed — quiet hubs stay quiet.
+      if (r.markedOffline > 0) {
+        console.log(
+          `[commhub stale-sweep] marked ${r.markedOffline} session(s) offline in ${r.durationMs}ms ` +
+            `(cutoff=${r.staleCutoffMinutes}min)`,
+        );
+      }
+    } catch (e: any) {
+      console.log(`[commhub stale-sweep] top-level failed: ${e?.message ?? e}`);
+    }
+  };
+  // Fire once at boot via setImmediate so the very-first /api/status
+  // after server start gets fresh stale state without blocking
+  // startup.
+  setImmediate(sweep);
+  return setInterval(sweep, ms);
+}

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -642,21 +642,15 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       if (readScope.denied) return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: readScope.denied }) }] };
       console.log(`[${ts()}] hub → get_all_status${filter_status ? ": filter=" + filter_status : ""}${readScope.networkId ? " net=" + readScope.networkId.slice(0, 12) : ""}`);
 
-      const sessions = db.transaction(() => {
-        const cutoff = new Date(Date.now() - 10 * 60 * 1000).toISOString().replace("T", " ").slice(0, 19);
-        const staleParams: any[] = [cutoff];
-        let staleSql = "UPDATE sessions SET status = 'offline' WHERE updated_at < ?1 AND status != 'offline'";
-        staleSql = addReadScope(staleSql, staleParams, readScope);
-        db.run(staleSql, staleParams);
-
-        let sql = "SELECT * FROM sessions WHERE 1=1";
-        const params: any[] = [];
-        sql = addReadScope(sql, params, readScope);
-        if (filter_status) { sql += " AND status = ?"; params.push(filter_status); }
-        if (filter_server) { sql += " AND server = ?"; params.push(filter_server); }
-        sql += " ORDER BY updated_at DESC";
-        return db.all(sql, ...params);
-      });
+      // Round-2/4 review ③: stale-marking moved to startStaleSessionSweeper()
+      // (background timer, ~60s cadence). Read path no longer fires UPDATE.
+      let sql = "SELECT * FROM sessions WHERE 1=1";
+      const params: any[] = [];
+      sql = addReadScope(sql, params, readScope);
+      if (filter_status) { sql += " AND status = ?"; params.push(filter_status); }
+      if (filter_server) { sql += " AND server = ?"; params.push(filter_server); }
+      sql += " ORDER BY updated_at DESC";
+      const sessions = db.all(sql, ...params);
 
       const summaryParams: any[] = [];
       let summarySql = "SELECT status, COUNT(*) as count FROM sessions WHERE 1=1";


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why

Round-2/4 review item ③ — eliminate per-request write amplification on the four highest-traffic read endpoints. Pre-fix, every call to:

- `GET /api/status` (most-hit; dashboard polls every few seconds)
- `GET /api/servers`
- `GET /api/server-detail/:host/agents` (+ `/telemetry`)
- MCP tool `get_all_status`

fired `UPDATE sessions SET status = 'offline' WHERE updated_at < ?1 AND status != 'offline'` just to maintain a derived field. Dashboard tabs × N viewers × M networks turned this into a high-frequency WRITE on a heavily-READ table — WAL fsync + page locks + ~99% no-op writes.

**Tenancy bug uncovered**: each per-request UPDATE was `addNetworkScope`'d, so a stale agent in network B would stay non-offline until *someone* polled network B. An admin scanning all networks could see inconsistent state.

## What changed

### `server/src/stale-sweeper.ts` (new)

- `sweepStaleSessions(cutoffMinutes)` — single GLOBAL UPDATE (staleness is per-row, not per-tenant).
- `startStaleSessionSweeper(intervalMs)` — fires once at boot via `setImmediate`, then every `COMMHUB_STALE_SWEEP_SECONDS` (default 60s).
- Cutoff env: `COMMHUB_STALE_CUTOFF_MINUTES` (default 10 — matches pre-fix observable behaviour).
- Logs only when `markedOffline > 0` — quiet hubs stay quiet.

### Removed inline UPDATE from 4 read sites

- `server/src/index.ts` — `/api/status` (~L1068), `/api/servers` (~L1138), `/api/server-detail/:host/{agents|telemetry}` (~L1212)
- `server/src/tools.ts` — `get_all_status` MCP tool (~L616)

Each replaced with a one-line comment pointing at the sweeper.

### Wiring

- `index.ts` startup: `const staleSweeperTimer = startStaleSessionSweeper()`
- Graceful shutdown: `clearInterval(staleSweeperTimer)` before `db.close()`

## Observable behaviour

Worst-case delay from agent crash → `offline` in dashboard:
- **Pre-fix**: 10 min stale cutoff + 1st poll after crash = up to ~10 min
- **Post-fix**: 10 min stale cutoff + 60s sweep = up to ~11 min

Same order of magnitude. Net change is fewer wasted writes per second, not slower freshness.

## Tests (`stale-sweeper.test.ts` — 10 tests)

| Concern | Test |
|---|---|
| Fresh agents preserved | `idle/working stay unchanged below cutoff` |
| Quiet hub = zero writes | 3 sweeps × `markedOffline=0` |
| Stale marked once (idempotent) | first sweep → `markedOffline=1`, second → 0 |
| Already-offline not re-marked | predicate avoids spurious write |
| **Global across tenants (the fix)** | stale net-B agent marked offline when only net-A polls |
| Cutoff boundary | strict `<` (just-stale ≠ just-live) |
| Env override | `COMMHUB_STALE_CUTOFF_MINUTES` respected |
| Env footgun | non-finite / 0 / negative all fall back to 10 |
| **Read-path regression pin** | 100-iteration SELECT loop fires zero maintenance writes |

```
isolated COMMHUB_DB=/tmp/...:
  src/stale-sweeper.test.ts — 10 pass, 0 fail, 124 expect()

full server suite (10 files):
  171 pass, 0 fail, 634 expect() — 917ms
```

No new TS errors. Pre-existing `push.ts:222` + `uploads-http.test.ts:73` inherited from main, out of scope.

## Migration / rollback

- **Zero-downtime safe** — sweeper is a background timer.
- **One-line rollback** — revert this commit; the 4 inline UPDATEs come back.
- **Operator override** — set `COMMHUB_STALE_SWEEP_SECONDS` to a very large number to effectively disable. (Read paths NO LONGER fire the UPDATE, so the operator must ensure the sweeper runs.)

## Review checklist

- [ ] No `UPDATE sessions SET status = 'offline'` left on any read path
- [ ] Sweeper fires at boot (`setImmediate`) + every 60s
- [ ] `clearInterval` in graceful shutdown
- [ ] Global UPDATE (no `addNetworkScope` on the sweep) — fixes the cross-tenant staleness inconsistency

## Tracking

- Internal task: #140
- Sibling PRs: #280 (round-5 follow-up), #282 (review ②)
- Public-facing copy uses `<hub-domain>` placeholder; no real domains leaked.
