### PR TITLE
fix(commhub): salted scrypt password hash + lazy migration from legacy SHA-256 (round-6 A1)

### DIFF
--- a/server/src/auth-kdf-migration.test.ts
+++ b/server/src/auth-kdf-migration.test.ts
@@ -275,6 +275,87 @@ describe("login — username enumeration timing-oracle close (round-6 A1 hardeni
   });
 });
 
+describe("login — timing parity across all 3 failure paths (round-6 round-2)", () => {
+  // Independent reviewer's round-2 catch on #285: the round-1 dummy-
+  // scrypt fix only equalized the !user (missing) path. legacy-user-
+  // wrong-password still ran SHA-256 only (sub-ms) while new-format-
+  // user-wrong-password ran scrypt (~50ms). That ~50x gap let an
+  // attacker distinguish "this username exists on a legacy hash" from
+  // "this username has been migrated" or "doesn't exist". Fix: burn
+  // an equal-time scrypt on the legacy-wrong-password path so all
+  // three failure paths cost SHA-256 + 1 scrypt.
+  //
+  // The test asserts ORDER-OF-MAGNITUDE timing parity (max/min ratio
+  // < 5x) — generous to avoid CI flake but pre-fix would be 50x+.
+  test("all 3 wrong-password paths take comparable scrypt-class time", () => {
+    // Setup: one user with new-format hash, one with legacy SHA-256
+    // seeded directly.
+    register("new-user", "NewUserP@ss1");
+
+    const legacyUserId = "usr_legacy_oracle";
+    const legacyHashed = new Bun.CryptoHasher("sha256").update("anet:LegacyP@ss1").digest("hex");
+    db.run(
+      `INSERT INTO users (user_id, username, password_hash, role) VALUES (?1, ?2, ?3, 'user')`,
+      [legacyUserId, "legacy-user", legacyHashed]
+    );
+
+    // Warm JIT + scrypt code paths
+    login("new-user", "wrong");
+    login("legacy-user", "wrong");
+    login("nobody-here-warmup", "wrong");
+
+    const sample = (fn: () => void): number => {
+      const N = 5;
+      const xs: number[] = [];
+      for (let i = 0; i < N; i++) {
+        const start = performance.now();
+        fn();
+        xs.push(performance.now() - start);
+      }
+      xs.sort((a, b) => a - b);
+      return xs[Math.floor(N / 2)];
+    };
+
+    const tNewWrong = sample(() => { login("new-user", "wrong"); });
+    const tLegacyWrong = sample(() => { login("legacy-user", "wrong"); });
+    const tMissing = sample(() => { login("nobody-here-" + Math.random(), "wrong"); });
+
+    // All three must run scrypt (> 1ms floor — early returns are sub-ms)
+    expect(tNewWrong).toBeGreaterThan(1);
+    expect(tLegacyWrong).toBeGreaterThan(1);
+    expect(tMissing).toBeGreaterThan(1);
+
+    // Order-of-magnitude parity. Pre-fix tLegacyWrong vs tNewWrong
+    // would be 50x+. Generous 5x cap absorbs CI scheduling jitter.
+    const maxT = Math.max(tNewWrong, tLegacyWrong, tMissing);
+    const minT = Math.max(0.1, Math.min(tNewWrong, tLegacyWrong, tMissing));
+    expect(maxT / minT).toBeLessThan(5);
+  });
+
+  test("legacy-wrong-password returns the same generic error string as the other paths", () => {
+    const legacyUserId = "usr_legacy_str";
+    const legacyHashed = new Bun.CryptoHasher("sha256").update("anet:Pw1").digest("hex");
+    db.run(
+      `INSERT INTO users (user_id, username, password_hash, role) VALUES (?1, ?2, ?3, 'user')`,
+      [legacyUserId, "legacy-str", legacyHashed]
+    );
+    register("new-str", "NewP@ss1");
+
+    const a = login("legacy-str", "wrong");
+    const b = login("new-str", "wrong");
+    const c = login("does-not-exist", "wrong");
+
+    expect(a.ok).toBe(false);
+    expect(b.ok).toBe(false);
+    expect(c.ok).toBe(false);
+    // All three must say EXACTLY the same thing or the oracle reopens
+    // at the response-body layer.
+    expect(a.error).toBe("invalid username or password");
+    expect(b.error).toBe(a.error);
+    expect(c.error).toBe(a.error);
+  });
+});
+
 describe("ordering invariant — single login transition (round-6 spec)", () => {
   // The dispatch's load-bearing post-condition: "post-upgrade 旧串
   // 不再存在 in DB". One concise pin.

--- a/server/src/auth-kdf-migration.test.ts
+++ b/server/src/auth-kdf-migration.test.ts
@@ -1,0 +1,228 @@
+// Round-6 A1 — salted KDF password hash + lazy migration.
+//
+// Pins the 5 behaviours called out in the dispatch:
+//   1. old-format hash verifies + auto-rehashes to new on login
+//   2. new-format hash round-trips
+//   3. wrong password rejected (both old and new format paths)
+//   4. after a successful login against a legacy hash, the legacy
+//      hash NO LONGER EXISTS in the DB (single source of truth)
+//   5. bootstrap admin (register flow) writes new format from row 1
+//
+// Plus regression pins:
+//   - timing-safe verify path doesn't throw on adversarial input
+//   - malformed new-format string is rejected (not silently accepted)
+//
+// All COMMHUB_SCRYPT_N=10 to keep the suite fast (~5ms/scrypt vs
+// 50ms at production N=14).
+
+import { describe, expect, test, beforeAll, beforeEach } from "bun:test";
+import { db, hashPassword, verifyPassword } from "./db.js";
+import { register, login } from "./auth.js";
+
+// Fast scrypt for tests — 2^10 = 1024 iter is ~5ms. Production stays at N=14.
+beforeAll(() => {
+  process.env.COMMHUB_SCRYPT_N = "10";
+});
+
+beforeEach(() => {
+  db.run("DELETE FROM users");
+  db.run("DELETE FROM api_tokens");
+  db.run("DELETE FROM network_members");
+  db.run("DELETE FROM networks");
+  db.run("DELETE FROM audit_log");
+});
+
+// Mimic the pre-A1 unsalted SHA-256 path. Used to seed legacy rows.
+function legacyHash(plain: string): string {
+  return new Bun.CryptoHasher("sha256").update(`anet:${plain}`).digest("hex");
+}
+
+function getStoredHash(username: string): string | null {
+  const row = db.get<{ password_hash: string }>(
+    "SELECT password_hash FROM users WHERE username = ?1",
+    username
+  );
+  return row?.password_hash ?? null;
+}
+
+function insertLegacyUser(username: string, plain: string): string {
+  const userId = `usr_${username}`;
+  db.run(
+    `INSERT INTO users (user_id, username, password_hash, role)
+     VALUES (?1, ?2, ?3, 'user')`,
+    [userId, username, legacyHash(plain)]
+  );
+  return userId;
+}
+
+describe("hashPassword — new format shape", () => {
+  test("produces scrypt$N$salt$hash with non-zero salt and hash", () => {
+    const stored = hashPassword("PasswordWith8+");
+    const parts = stored.split("$");
+    expect(parts.length).toBe(4);
+    expect(parts[0]).toBe("scrypt");
+    const N = parseInt(parts[1], 10);
+    expect(N).toBeGreaterThanOrEqual(8);
+    expect(N).toBeLessThanOrEqual(20);
+    expect(Buffer.from(parts[2], "base64").length).toBeGreaterThan(0);
+    expect(Buffer.from(parts[3], "base64").length).toBe(64); // SCRYPT_KEYLEN
+  });
+
+  test("salt + hash differ on every call (no static derivation)", () => {
+    const a = hashPassword("same");
+    const b = hashPassword("same");
+    const c = hashPassword("same");
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+    expect(a).not.toBe(c);
+  });
+});
+
+describe("verifyPassword — new format round-trip", () => {
+  test("hashPassword + verifyPassword round-trips, needsRehash=false", () => {
+    const stored = hashPassword("MyPassw0rd!");
+    const v = verifyPassword("MyPassw0rd!", stored);
+    expect(v.ok).toBe(true);
+    expect(v.needsRehash).toBe(false);
+  });
+
+  test("wrong password rejected, needsRehash=false", () => {
+    const stored = hashPassword("MyPassw0rd!");
+    const v = verifyPassword("wrong", stored);
+    expect(v.ok).toBe(false);
+    expect(v.needsRehash).toBe(false);
+  });
+
+  test("malformed new-format strings rejected (not silently passed)", () => {
+    // Each of these tries to abuse the parser. None should yield ok=true.
+    const bad = [
+      "scrypt$$salt$hash",                       // missing N
+      "scrypt$14$$hash",                         // empty salt
+      "scrypt$14$c2FsdA==$",                     // empty hash
+      "scrypt$abc$c2FsdA==$aGFzaA==",            // non-numeric N
+      "scrypt$14$c2FsdA==$aGFzaA==$extra",       // 5 parts
+      "scrypt$14$c2FsdA==",                      // 3 parts
+      "argon2$1$c2FsdA==$aGFzaA==",              // unknown scheme
+      "scrypt$5$c2FsdA==$aGFzaA==",              // N below floor (8)
+      "scrypt$30$c2FsdA==$aGFzaA==",             // N above ceiling (20)
+    ];
+    for (const s of bad) {
+      const v = verifyPassword("anything", s);
+      expect(v.ok).toBe(false);
+    }
+  });
+});
+
+describe("verifyPassword — legacy format compatibility (A1's load-bearing claim)", () => {
+  test("legacy unsalted SHA-256 hash verifies", () => {
+    const plain = "OldUserPassw0rd";
+    const stored = legacyHash(plain);
+    const v = verifyPassword(plain, stored);
+    expect(v.ok).toBe(true);
+    expect(v.needsRehash).toBe(true); // ← KEY: caller MUST rehash
+  });
+
+  test("legacy wrong-password rejected, needsRehash=false", () => {
+    const stored = legacyHash("OldUserPassw0rd");
+    const v = verifyPassword("wrong", stored);
+    expect(v.ok).toBe(false);
+    expect(v.needsRehash).toBe(false);
+  });
+
+  test("legacy hash with wrong length rejected (not crash)", () => {
+    const v = verifyPassword("anything", "deadbeef"); // 8 hex chars, not 64
+    expect(v.ok).toBe(false);
+    expect(v.needsRehash).toBe(false);
+  });
+});
+
+describe("login() — lazy migration on success", () => {
+  test("legacy user logs in successfully AND is auto-upgraded to new format", () => {
+    insertLegacyUser("legacy-alice", "AliceP@ss123");
+
+    // Sanity: the seeded hash IS bare-hex sha256 (no $).
+    const before = getStoredHash("legacy-alice")!;
+    expect(before).not.toContain("$");
+    expect(before).toHaveLength(64);
+
+    const result = login("legacy-alice", "AliceP@ss123");
+    expect(result.ok).toBe(true);
+
+    // The load-bearing assertion: after login, the legacy hash is GONE.
+    const after = getStoredHash("legacy-alice")!;
+    expect(after).toContain("$");
+    expect(after.startsWith("scrypt$")).toBe(true);
+    expect(after).not.toBe(before);
+  });
+
+  test("legacy user wrong-password fails AND legacy hash is preserved", () => {
+    insertLegacyUser("legacy-bob", "BobP@ss123");
+    const before = getStoredHash("legacy-bob")!;
+
+    const result = login("legacy-bob", "wrong");
+    expect(result.ok).toBe(false);
+
+    // Failed login MUST NOT rehash (would leak info about format).
+    const after = getStoredHash("legacy-bob")!;
+    expect(after).toBe(before);
+    expect(after).not.toContain("$");
+  });
+
+  test("new-format user logs in without rehash (already current)", () => {
+    // First login auto-migrates; second login should not rewrite again.
+    insertLegacyUser("legacy-charlie", "CharlieP@ss");
+    const r1 = login("legacy-charlie", "CharlieP@ss");
+    expect(r1.ok).toBe(true);
+    const afterFirst = getStoredHash("legacy-charlie")!;
+
+    const r2 = login("legacy-charlie", "CharlieP@ss");
+    expect(r2.ok).toBe(true);
+    const afterSecond = getStoredHash("legacy-charlie")!;
+
+    // Same hash on consecutive logins — no spurious rewrites.
+    expect(afterSecond).toBe(afterFirst);
+  });
+});
+
+describe("register() — new users always start in new format (bootstrap admin)", () => {
+  test("freshly-registered user has scrypt$ format from row 1", () => {
+    const r = register("dave", "DaveBootstr@p", "dave@example.com", "Dave");
+    expect(r.ok).toBe(true);
+
+    const stored = getStoredHash("dave")!;
+    expect(stored.startsWith("scrypt$")).toBe(true);
+  });
+
+  test("registered user can log in (smoke for the whole pipeline)", () => {
+    register("eve", "EveP@ssword99", undefined, "Eve");
+    const login_r = login("eve", "EveP@ssword99");
+    expect(login_r.ok).toBe(true);
+  });
+
+  test("registered user wrong-password fails (smoke for new-format reject)", () => {
+    register("frank", "FrankP@ssword99", undefined, "Frank");
+    const login_r = login("frank", "wrong");
+    expect(login_r.ok).toBe(false);
+  });
+});
+
+describe("ordering invariant — single login transition (round-6 spec)", () => {
+  // The dispatch's load-bearing post-condition: "post-upgrade 旧串
+  // 不再存在 in DB". One concise pin.
+  test("after first login, legacy hash is provably absent from the row", () => {
+    const plain = "TransitionPw1";
+    insertLegacyUser("legacy-tx", plain);
+    const legacy = legacyHash(plain);
+
+    login("legacy-tx", plain);
+
+    const after = getStoredHash("legacy-tx")!;
+    expect(after).not.toBe(legacy);          // not the same string
+    expect(after.startsWith("scrypt$")).toBe(true);
+    // The legacy string is exactly 64 hex chars. The new string is
+    // markedly longer (scrypt$N$salt$hash). Verify length disjoint
+    // so any future regression that re-stores a 64-char bare hex
+    // would be caught.
+    expect(after.length).toBeGreaterThan(64);
+  });
+});

--- a/server/src/auth-kdf-migration.test.ts
+++ b/server/src/auth-kdf-migration.test.ts
@@ -206,6 +206,75 @@ describe("register() — new users always start in new format (bootstrap admin)"
   });
 });
 
+describe("login — username enumeration timing-oracle close (round-6 A1 hardening)", () => {
+  // Independent pre-review on #285: post-A1 the user-exists +
+  // wrong-password path runs ~50ms scrypt, the user-not-found path
+  // returns sub-ms — that's a web-measurable oracle for "is this
+  // username registered". Fix: run a throwaway verifyPassword
+  // against a module-constant dummy hash on the not-found branch
+  // so wall-clock cost is comparable on both paths.
+  //
+  // The test asserts ORDER-OF-MAGNITUDE timing parity, not exact
+  // equality — scrypt timings have natural jitter and we don't
+  // want a flaky test that hammers CI on busy hosts. The check
+  // is "both paths are slow" (both > some floor), proving the
+  // dummy-verify codepath actually runs on the not-found branch.
+  test("not-found user takes scrypt-class time (not sub-ms early-return)", () => {
+    register("real-user-z", "RealUserZ123");
+
+    // Warm the JIT + paging on both paths so the first call's
+    // amortized cost doesn't skew the comparison.
+    login("real-user-z", "wrong");
+    login("does-not-exist-warmup", "wrong");
+
+    // Sample multiple times and take the median so single-call
+    // jitter doesn't dominate.
+    const sample = (fn: () => void): number => {
+      const N = 5;
+      const xs: number[] = [];
+      for (let i = 0; i < N; i++) {
+        const start = performance.now();
+        fn();
+        xs.push(performance.now() - start);
+      }
+      xs.sort((a, b) => a - b);
+      return xs[Math.floor(N / 2)];
+    };
+
+    const tExists = sample(() => { login("real-user-z", "wrong"); });
+    const tMissing = sample(() => { login("nobody-here-" + Math.random(), "wrong"); });
+
+    // The fix's load-bearing claim: BOTH paths run scrypt. At test
+    // N=10 (~5ms per scrypt), an early-return path would be < 1ms.
+    // Loose lower bound of 1ms catches an "early return" regression
+    // without being flaky on slow CI runners.
+    expect(tExists).toBeGreaterThan(1);
+    expect(tMissing).toBeGreaterThan(1);
+
+    // Ratio: both paths should be the same order of magnitude.
+    // 5x is a generous bound to avoid CI flakiness from
+    // co-scheduled scrypt workloads or paging. Pre-fix this would
+    // be 50x+ trivially.
+    const ratio = Math.max(tExists, tMissing) / Math.max(0.1, Math.min(tExists, tMissing));
+    expect(ratio).toBeLessThan(5);
+  });
+
+  test("not-found user still returns the generic error string (no info leak)", () => {
+    register("user-exists", "ExistsP@ss1");
+
+    const a = login("user-exists", "wrong");
+    const b = login("user-does-not-exist", "wrong");
+
+    expect(a.ok).toBe(false);
+    expect(b.ok).toBe(false);
+    // Both must return EXACTLY the same error string. If they
+    // diverge, the username-enumeration oracle reopens at the
+    // string-comparison layer regardless of timing.
+    expect(a.error).toBe(b.error);
+    expect(a.error).toBe("invalid username or password");
+  });
+});
+
 describe("ordering invariant — single login transition (round-6 spec)", () => {
   // The dispatch's load-bearing post-condition: "post-upgrade 旧串
   // 不再存在 in DB". One concise pin.

--- a/server/src/auth-tokens.test.ts
+++ b/server/src/auth-tokens.test.ts
@@ -104,18 +104,27 @@ describe("hashToken — deterministic sha256", () => {
   });
 });
 
-describe("hashPassword — sha256('anet:' + password)", () => {
-  it("returns 64-char lowercase hex", () => {
-    expect(hashPassword("StrongPassw0rd")).toMatch(HEX_RE(64));
+describe("hashPassword — salted scrypt (round-6 A1)", () => {
+  it("returns scrypt$N$salt$hash self-describing format", () => {
+    const stored = hashPassword("StrongPassw0rd");
+    expect(stored).toMatch(/^scrypt\$\d+\$[A-Za-z0-9+/=]+\$[A-Za-z0-9+/=]+$/);
   });
-  it("deterministic", () => {
-    expect(hashPassword("foo")).toBe(hashPassword("foo"));
+
+  it("NON-deterministic — same password produces different salts (the whole point)", () => {
+    // The pre-A1 hashPassword was deterministic SHA-256 — rainbow-
+    // table vulnerable. Salted scrypt MUST produce different output
+    // for repeated calls. If this fails, the salt isn't random.
+    const a = hashPassword("foo");
+    const b = hashPassword("foo");
+    expect(a).not.toBe(b);
   });
-  it("uses 'anet:' salt → different from hashToken on same input", () => {
-    // This pins the 'anet:' prefix — if someone drops it, this fails,
-    // and existing user password hashes will silently stop matching.
+
+  it("does not collide with hashToken's surface (separate concerns)", () => {
+    // Pin the separation. Pre-A1 had hashPassword("foo") === hashToken("anet:foo"),
+    // which was an accidental coincidence of unsalted hashes; post-A1 the
+    // password hash carries randomness and never equals a token hash.
     expect(hashPassword("foo")).not.toBe(hashToken("foo"));
-    expect(hashPassword("foo")).toBe(hashToken("anet:foo"));
+    expect(hashPassword("foo")).not.toBe(hashToken("anet:foo"));
   });
 });
 

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -1,7 +1,7 @@
 /**
  * V3 Auth module — user registration, login, token management
  */
-import { db, generateId, hashPassword, hashToken, generateToken, generateUserToken, generateNetworkToken, uuidv4 } from "./db.js";
+import { db, generateId, hashPassword, verifyPassword, hashToken, generateToken, generateUserToken, generateNetworkToken, uuidv4 } from "./db.js";
 import { WEAK_PASSWORDS } from "./password-dict.js";
 
 export interface AuthUser {
@@ -105,7 +105,24 @@ export function login(username: string, password: string): AuthResult {
     username);
 
   if (!user) return { ok: false, error: "invalid username or password" };
-  if (user.password_hash !== hashPassword(password)) return { ok: false, error: "invalid username or password" };
+  // Round-6 A1: verifyPassword accepts both new scrypt format and
+  // legacy bare-sha256. On successful legacy verify, lazy-upgrade the
+  // stored hash in place (zero downtime, no forced password change).
+  const verify = verifyPassword(password, user.password_hash);
+  if (!verify.ok) return { ok: false, error: "invalid username or password" };
+  if (verify.needsRehash) {
+    try {
+      const upgraded = hashPassword(password);
+      db.run(
+        "UPDATE users SET password_hash = ?1, updated_at = datetime('now') WHERE user_id = ?2",
+        [upgraded, user.user_id]
+      );
+    } catch (e: any) {
+      // Don't fail the login if the rehash write hits a transient
+      // error — the user authenticated, we'll try again next login.
+      console.log(`[commhub auth] lazy-rehash failed for user ${user.user_id}: ${e?.message ?? e}`);
+    }
+  }
 
   // Issue a NEW user token — do NOT rotate/invalidate existing ones. Each
   // login (cli, dashboard, second machine) gets its own row so they don't
@@ -287,7 +304,11 @@ export function changePassword(userId: string, oldPassword: string, newPassword:
   if (passwordError) return { ok: false, error: passwordError };
   const user = db.get<any>("SELECT password_hash FROM users WHERE user_id = ?1", userId);
   if (!user) return { ok: false, error: "user not found" };
-  if (user.password_hash !== hashPassword(oldPassword)) return { ok: false, error: "incorrect current password" };
+  // Round-6 A1: verifyPassword accepts both formats. No need to
+  // lazy-rehash here separately because we're about to overwrite
+  // password_hash with the new password's scrypt hash below anyway.
+  const verify = verifyPassword(oldPassword, user.password_hash);
+  if (!verify.ok) return { ok: false, error: "incorrect current password" };
   // #261 P0-2 — clearing must_change_password as a side-effect of a real
   // password change. If the user changes via `anet passwd`, the bootstrap
   // nudge goes away on next login. SET to 0 explicitly (rather than skip)

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -4,6 +4,30 @@
 import { db, generateId, hashPassword, verifyPassword, hashToken, generateToken, generateUserToken, generateNetworkToken, uuidv4 } from "./db.js";
 import { WEAK_PASSWORDS } from "./password-dict.js";
 
+// Round-6 A1 hardening — dummy hash for username-enumeration timing
+// close. We compute ONE scrypt hash of a throwaway password and reuse
+// it on every `!user` branch in login. The verify call against this
+// dummy always fails the timingSafeEqual (the candidate password is
+// unrelated), but the wall-clock cost of the scrypt() invocation is
+// identical to the user-exists path — closing the ~50ms username-
+// exists oracle that opened up when we moved off SHA-256 to scrypt.
+//
+// **Lazy** (memoized) rather than module-load constant: COMMHUB_SCRYPT_N
+// may be set after this module loads (tests do this), and the dummy
+// MUST match the current N so its scrypt cost matches the cost of
+// verifying a real stored hash. Computing on first use captures the
+// env-current N. After that it's a single fixed string for the
+// process lifetime — one scrypt per process, not per request.
+let _enumerationDummyHash: string | null = null;
+function getEnumerationDummyHash(): string {
+  if (_enumerationDummyHash === null) {
+    _enumerationDummyHash = hashPassword(
+      "agent-network::enumeration-oracle-close::do-not-match"
+    );
+  }
+  return _enumerationDummyHash;
+}
+
 export interface AuthUser {
   user_id: string;
   username: string;
@@ -104,7 +128,20 @@ export function login(username: string, password: string): AuthResult {
     "SELECT user_id, username, password_hash, display_name, email, role, must_change_password FROM users WHERE username = ?1",
     username);
 
-  if (!user) return { ok: false, error: "invalid username or password" };
+  if (!user) {
+    // Round-6 A1 hardening (timing-oracle close): pre-A1 the user-
+    // exists vs user-doesn't-exist branches both ran a µs-scale
+    // SHA-256, so wall-clock difference was lost in noise. Post-A1
+    // the user-exists path runs ~50ms scrypt while user-doesn't
+    // returns sub-ms — that ~50ms gap is web-measurable and turns
+    // login into a username-enumeration oracle (rate limiter only
+    // partially mitigates). Equalize by running scrypt against a
+    // module-constant dummy hash on the not-found path. Dummy is
+    // pre-generated at module load (not per call) so we don't burn
+    // a fresh scryptSync on every miss.
+    verifyPassword(password, getEnumerationDummyHash());
+    return { ok: false, error: "invalid username or password" };
+  }
   // Round-6 A1: verifyPassword accepts both new scrypt format and
   // legacy bare-sha256. On successful legacy verify, lazy-upgrade the
   // stored hash in place (zero downtime, no forced password change).

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -831,14 +831,55 @@ export function verifyPassword(plain: string, stored: string): { ok: boolean; ne
   // compared via JS === which is variable-time on first-differing
   // char — the timing leak is tiny for fixed-format hex but pin the
   // habit). Both are exactly 64 hex chars when sha256 produced.
-  if (stored.length !== legacy.length) return { ok: false, needsRehash: false };
+  if (stored.length !== legacy.length) {
+    // Length mismatch is itself indistinguishable from a parse miss
+    // — but we still pay the scrypt to keep this branch's timing
+    // peer to the verify branches below.
+    burnEqualTimeScrypt(plain);
+    return { ok: false, needsRehash: false };
+  }
   let ok = false;
   try {
     ok = timingSafeEqual(Buffer.from(stored, "hex"), Buffer.from(legacy, "hex"));
   } catch {
+    burnEqualTimeScrypt(plain);
     return { ok: false, needsRehash: false };
   }
+  // Timing-oracle close (round-6 round-2 — independent reviewer flag):
+  // legacy-OK   path callers (auth.ts:login) do `hashPassword(password)`
+  //             immediately after to rehash → one scrypt cost on top of
+  //             this function's return. ~50ms.
+  // legacy-WRONG path callers reject and return → ZERO additional cost.
+  //
+  // That asymmetry leaks "is this user on the legacy hash" via wall-
+  // clock difference (sub-ms wrong vs ~50ms ok). To close it, burn an
+  // equal-time scrypt on the wrong-password branch too. Now both
+  // legacy paths cost SHA-256 + one scrypt, matching new-format paths
+  // and the missing-user dummy-scrypt path.
+  if (!ok) {
+    burnEqualTimeScrypt(plain);
+  }
   return { ok, needsRehash: ok };
+}
+
+// Round-6 round-2 hardening — throwaway scrypt to equalize timing on
+// failure paths. Burns the same wall-clock cost as a real
+// hashPassword() call. Result discarded; salt is a fresh random so
+// the work is real (not optimised away). Cost ~N=14 → 50ms,
+// COMMHUB_SCRYPT_N controlled like the real path.
+function burnEqualTimeScrypt(plain: string): void {
+  try {
+    const N = getScryptN();
+    scryptSync(plain, randomBytes(SCRYPT_SALT_BYTES), SCRYPT_KEYLEN, {
+      N: 1 << N,
+      r: SCRYPT_R,
+      p: SCRYPT_P,
+      maxmem: SCRYPT_MAXMEM,
+    });
+  } catch {
+    // Even on failure to scrypt (shouldn't happen), don't surface —
+    // this is a timing pacer, not a correctness path.
+  }
 }
 
 export function hashToken(token: string): string {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -707,8 +707,138 @@ export function generateId(prefix: string): string {
   return `${prefix}_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
 }
 
-export function hashPassword(password: string): string {
-  return new Bun.CryptoHasher("sha256").update(`anet:${password}`).digest("hex");
+// ──────────────────────────────────────────────────────────────────
+// Round-6 A1 — Password hashing: salted scrypt with lazy migration
+//
+// Format: `scrypt$<N>$<salt-b64>$<hash-b64>`
+//   N        = log2(cost). E.g. 14 → 2^14 = 16384 (~50ms on modern hw).
+//   salt-b64 = base64 of 16 random bytes.
+//   hash-b64 = base64 of 64-byte scrypt output.
+//
+// Why scrypt: Node built-in crypto.scryptSync — zero new deps.
+//   Memory-hard, ASIC-resistant. Better than bcrypt under modern GPU
+//   attack. argon2id would be marginally better but pulls a native
+//   dep (argon2 npm package) we don't want on the hub.
+//
+// Why "$" delimiter: legacy hashes are bare hex (0-9a-f only). Any
+//   "$" in stored hash means new format. Trivial detect with zero
+//   false-positives.
+//
+// Lazy migration:
+//   - register/bootstrap/changePassword/resetUserPassword always
+//     write the new format.
+//   - login + changePassword (old-verify) accept BOTH formats.
+//   - on successful login against a legacy hash, the caller rehashes
+//     in place. Zero downtime, no forced password change.
+//
+// See feedback_assume_unit_before_threshold.md: explicit-set
+// crypto parameters; don't rely on library defaults.
+// ──────────────────────────────────────────────────────────────────
+
+import { scryptSync, randomBytes, timingSafeEqual } from "node:crypto";
+
+// Default cost parameter (N = 2^14 = 16384). Tunable via env for
+// test suites that don't want to spend ~50ms per scrypt call.
+//   N=10 → 2^10 = 1024 iter, ~5ms (test-only)
+//   N=14 → 2^14 = 16384 iter, ~50ms (production)
+//   N=15 → 2^15 = 32768 iter, ~100ms (if hw improves and ops want headroom)
+const DEFAULT_SCRYPT_N = 14;
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const SCRYPT_KEYLEN = 64;
+const SCRYPT_SALT_BYTES = 16;
+// Bun's scrypt defaults maxmem to ~32 MiB which is too tight for
+// N ≥ 14 (128 * r * 2^N = ~16 MiB at r=8, N=14; default has no
+// headroom for the internal buffers). Set explicitly so a higher-N
+// upgrade later doesn't suddenly throw at runtime.
+const SCRYPT_MAXMEM = 128 * 1024 * 1024; // 128 MiB
+
+function getScryptN(): number {
+  const raw = process.env.COMMHUB_SCRYPT_N;
+  if (!raw) return DEFAULT_SCRYPT_N;
+  const n = parseInt(raw, 10);
+  // Bound: 8 (way-too-weak, only for unit tests) — 20 (DoS risk).
+  if (!Number.isFinite(n) || n < 8 || n > 20) return DEFAULT_SCRYPT_N;
+  return n;
+}
+
+export function hashPassword(plain: string): string {
+  const N = getScryptN();
+  const salt = randomBytes(SCRYPT_SALT_BYTES);
+  const hash = scryptSync(plain, salt, SCRYPT_KEYLEN, {
+    N: 1 << N,
+    r: SCRYPT_R,
+    p: SCRYPT_P,
+    maxmem: SCRYPT_MAXMEM,
+  });
+  return `scrypt$${N}$${salt.toString("base64")}$${hash.toString("base64")}`;
+}
+
+/**
+ * Verify a plaintext password against the stored hash. Accepts BOTH
+ * the new scrypt format and the legacy bare-hex SHA-256 format
+ * (back-compat for pre-A1 deployments).
+ *
+ * Returns:
+ *   ok           — true iff the password matches.
+ *   needsRehash  — true iff the stored hash was legacy format AND the
+ *                  password matched. The caller MUST rehash and write
+ *                  the new format back to disk so the legacy hash
+ *                  stops existing. Returned false for already-new
+ *                  hashes (no rehash needed even on N upgrade —
+ *                  follow-up if/when we bump default N).
+ */
+export function verifyPassword(plain: string, stored: string): { ok: boolean; needsRehash: boolean } {
+  // Format detection: new format always contains "$". Legacy bare
+  // sha256 hex never does (0-9a-f only).
+  if (stored.includes("$")) {
+    const parts = stored.split("$");
+    if (parts.length !== 4 || parts[0] !== "scrypt") {
+      // Unknown new-style scheme — be conservative, reject.
+      return { ok: false, needsRehash: false };
+    }
+    const N = parseInt(parts[1], 10);
+    if (!Number.isFinite(N) || N < 8 || N > 20) return { ok: false, needsRehash: false };
+    let saltBuf: Buffer;
+    let expectedBuf: Buffer;
+    try {
+      saltBuf = Buffer.from(parts[2], "base64");
+      expectedBuf = Buffer.from(parts[3], "base64");
+    } catch {
+      return { ok: false, needsRehash: false };
+    }
+    if (expectedBuf.length === 0) return { ok: false, needsRehash: false };
+    let actualBuf: Buffer;
+    try {
+      actualBuf = scryptSync(plain, saltBuf, expectedBuf.length, {
+        N: 1 << N,
+        r: SCRYPT_R,
+        p: SCRYPT_P,
+        maxmem: SCRYPT_MAXMEM,
+      });
+    } catch {
+      return { ok: false, needsRehash: false };
+    }
+    // timingSafeEqual requires equal-length buffers; we sized actual
+    // to expected.length above so this is safe.
+    const ok = timingSafeEqual(actualBuf, expectedBuf);
+    return { ok, needsRehash: false };
+  }
+
+  // Legacy bare-hex SHA-256 format (pre-A1).
+  const legacy = new Bun.CryptoHasher("sha256").update(`anet:${plain}`).digest("hex");
+  // Use timingSafeEqual on byte buffers (hex strings would be
+  // compared via JS === which is variable-time on first-differing
+  // char — the timing leak is tiny for fixed-format hex but pin the
+  // habit). Both are exactly 64 hex chars when sha256 produced.
+  if (stored.length !== legacy.length) return { ok: false, needsRehash: false };
+  let ok = false;
+  try {
+    ok = timingSafeEqual(Buffer.from(stored, "hex"), Buffer.from(legacy, "hex"));
+  } catch {
+    return { ok: false, needsRehash: false };
+  }
+  return { ok, needsRehash: ok };
 }
 
 export function hashToken(token: string): string {


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why (round-6 A1 — public-facing hub security)

The current `hashPassword` returns unsalted `sha256("anet:" + password)`:
- Rainbow-table vulnerable (same password → same hash across all users)
- Batch brute-force friendly (modern GPUs do ~10⁹ sha256/sec; a 6M-rockyou crack is seconds)
- The `"anet:"` prefix is a pepper, not a salt — uniform for every user, doesn't slow brute force

On a public-facing hub (`<hub-domain>`) where the user table is online, this is the standout DB-dump risk.

## Design (the load-bearing pieces)

### Format: `scrypt$<N>$<salt-b64>$<hash-b64>`

| Field | Meaning |
|---|---|
| `scrypt` | scheme name (extensible for argon2id / future schemes) |
| `N` | log2(cost). `14` → 2^14 = 16384 iter (~50ms modern hw) |
| `salt` | 16 random bytes, base64 |
| `hash` | 64-byte scrypt output, base64 |

Self-describing → future N upgrades / scheme changes don't require a schema migration.

### Format detection (zero-false-positive)

```
stored.includes("$") → new format (parse + scrypt verify)
else                  → legacy bare-hex sha256 (verify + needsRehash)
```

Legacy bare-hex is exactly 64 lowercase hex chars (0-9a-f). The `"$"` delimiter is impossible in hex → trivial detect, no ambiguity.

### API surface

```ts
hashPassword(plain): string                                  // always new format
verifyPassword(plain, stored): { ok: boolean; needsRehash: boolean }
```

`verifyPassword` accepts **both** formats:
- New scrypt: parse, scrypt(plain, salt) → timingSafeEqual → `needsRehash = false`
- Legacy bare-hex: sha256("anet:"+plain) → timingSafeEqual → `needsRehash = ok` (caller rehashes only on success)

### Lazy migration timing (proof of non-disruption)

```
                 Pre-A1                         Post-A1
─────────────────────────────────────────────────────────────────
register   → users.password_hash = sha256()  → users.password_hash = scrypt$
login      → if hash == sha256(input) ok     → verifyPassword(input, hash)
                                                if ok && needsRehash:
                                                  UPDATE users SET password_hash = hashPassword(input)
changePw   → verify old + write new          → same, verifyPassword on old + always-new on write
reset      → write new                       → same, always-new
bootstrap  → register() → sha256             → register() → scrypt$
```

**Proof**: a user whose row is `sha256(...)` on day N
1. Logs in on day N+1 with their unchanged password → `verifyPassword` returns `ok=true, needsRehash=true` → row becomes `scrypt$...`
2. Wrong password on day N+1 → `verifyPassword` returns `ok=false` → row untouched (no info leak)
3. Never logs in again → row stays legacy until admin reset (acceptable; the dump risk only matters if someone exfils ALL hashes anyway)

After the first successful login, the legacy hash is **provably absent** from the row. Pinned by:

```ts
const after = getStoredHash("legacy-tx")!;
expect(after).not.toBe(legacy);              // not the same string
expect(after.startsWith("scrypt$")).toBe(true);
expect(after.length).toBeGreaterThan(64);    // length-disjoint from sha256 hex
```

### Sync vs async (与 通信龙 dispatch 讨论项)

Chose `crypto.scryptSync`. Rationale:
- Login is human-driven (< 1/sec typical), 50ms event-loop block × 1/sec = ~5% occupancy
- Per-IP rate limiter already caps burst (`sharedLoginIpRateLimiter`)
- Async would propagate `await` through 5+ call sites in `index.ts` — separate refactor scope

Async (`crypto.scrypt` callback) is **documented as a follow-up** if hub telemetry ever shows event-loop blocking under login storms. Single-file swap when needed.

### Crypto params SET explicitly (per `feedback_assume_unit_before_threshold`)

```ts
const N      = 1 << 14   // 16384 (env COMMHUB_SCRYPT_N override for tests)
const r      = 8
const p      = 1
const keylen = 64
const maxmem = 128 MiB   // node default ~32 MiB would throw at N >= 14
```

`COMMHUB_SCRYPT_N` env override, bounded [8, 20]. Below 8 → DOS-weak (only for unit tests). Above 20 → DOS-loud.

## What changed

| File | Change |
|---|---|
| `server/src/db.ts` | `hashPassword` returns scrypt format; new `verifyPassword`; `hashToken` unchanged |
| `server/src/auth.ts` | `login` uses `verifyPassword` + lazy rehash on success; `changePassword` uses `verifyPassword` on old; register/reset paths unchanged (inherit new format) |
| `server/src/auth-tokens.test.ts` | drop equality assertion that pinned the unsalted coincidence (`hashPassword("foo") === hashToken("anet:foo")`); add salt-randomness + format-shape pins |
| `server/src/auth-kdf-migration.test.ts` | new, 17 tests |

## Tests

`auth-kdf-migration.test.ts` (17 tests, `COMMHUB_SCRYPT_N=10` fast):

| Concern | Test |
|---|---|
| Format shape | scrypt$N$salt$hash with valid base64 + 64-byte hash |
| Salt randomness | 3 calls × same password → 3 different strings |
| New roundtrip | hash + verify ok, needsRehash=false |
| New wrong | reject, needsRehash=false |
| Parser robustness | 9 malformed inputs (missing N, empty parts, unknown scheme, N out of bounds) all rejected |
| **Legacy verify + flag** | sha256 hash → ok=true, **needsRehash=true** |
| Legacy wrong | reject, needsRehash=false |
| Legacy bad length | not crash |
| **Login lazy upgrade** | legacy user logs in → hash silently becomes scrypt$ |
| Login wrong preserves | failed login does NOT mutate legacy hash (info-leak guard) |
| Idempotent upgrade | 2nd login on already-upgraded row does not rewrite |
| **Bootstrap admin format** | register() new user → scrypt$ from row 1 |
| Register + login smoke | end-to-end pipeline |
| Register + wrong smoke | new-format reject |
| **Post-condition pin** | after first login, legacy hash is provably absent (length-disjoint) |

Results:
```
kdf migration + tokens: 34 pass, 0 fail, 123 expect()
full server suite:      180 pass, 0 fail, 565 expect() — 1343ms
```

No new TS errors. Pre-existing `push.ts:222` + `uploads-http.test.ts:73` out-of-scope.

## Migration / rollback

| Scenario | Behaviour |
|---|---|
| Existing users | Unchanged. Hash silently upgrades on next successful login. |
| New users (post-deploy) | New format from row 1 |
| Bootstrap admin (`anet hub start`) | Goes through `register` → new format |
| Hub restart mid-upgrade | Idempotent. Already-upgraded rows stay upgraded; not-yet-logged-in users still match legacy verify. |
| Rollback | Possible **only if** no users have logged in post-deploy. After lazy-upgrades fire, those users would not be able to log in against an old hashPassword. So rollback is one-way after rollout. |
| Operator can pin N via | `COMMHUB_SCRYPT_N=12` (faster on weaker hosts) — bounded [8, 20] |

## Review checklist

- [ ] Format detection robust (parser rejects 9 malformed inputs)
- [ ] Lazy upgrade ONLY on successful verify (not on wrong-password)
- [ ] Timing-safe equal on both paths
- [ ] crypto params SET explicitly (no library defaults)
- [ ] `register` / `bootstrap admin` / `resetUserPassword` all write new format
- [ ] No real domain in body / commit / code (uses `<hub-domain>` placeholder)
- [ ] **auth-sensitive PR** — 通信龙 will surface Vincent before merge

## Tracking

- Internal task: #143
- Sibling PRs: #282 (review ②), #283 (review ③) — both also awaiting 通信牛
- Builds on: #275 + #280 (cross-tenant write defense)
- Follow-up considered: async scrypt if login storms appear in telemetry
