### PR TITLE
fix(agent-node): #144 — anet /loop universal across all runtimes (remove claude bucket skip)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -4919,6 +4919,101 @@ async function projectDown() {
   console.log(`\n  ${stopped}/${nodes.length} stopped${alreadyDown ? ` · ${alreadyDown} were not running` : ""}\n`);
 }
 
+// ── loop ── (#144 round-6)
+//
+// `anet node loop <alias> "<task>" --every 5m`
+//
+// One-liner UX wrapper for the inbox `/loop <interval> <task>` slash
+// command. POSTs a task to commhub via /api/task; the receiving node's
+// inbox handler parses the `/loop` prefix and calls createScheduledGoal,
+// which persists the goal in goals.json + the scheduler tick fires it.
+//
+// Why a CLI wrapper instead of just "send the slash text directly"?
+// Vincent's "使用简单" priority — a non-interactive node operator
+// shouldn't need to memorize slash-command syntax or run a separate
+// `send_task` call. One line, one verb, one task.
+
+async function nodeLoopCommand() {
+  const aliasRef = args[1];
+  const taskText = args[2];
+  if (!aliasRef || !taskText) {
+    console.log(`
+anet node loop <alias> "<task>" --every <interval>
+
+  Schedule a recurring task on a running node. The node will be woken at
+  the chosen interval and asked to make an incremental advance on the
+  task, reporting back each cycle.
+
+Examples:
+  anet node loop my-codex "monitor #271 PR" --every 5m
+  anet node loop researcher "scan twitter for grok updates" --every 30m
+  anet node loop daily-bot "post the morning summary" --every 2h
+
+Interval format: 30s / 5m / 2h / 1d (s/m/h/d suffix required).
+Use 'anet goal list <alias>' to see scheduled loops; 'anet goal cancel'
+to stop one.
+`);
+    process.exit(aliasRef ? 1 : 0);
+  }
+
+  // Default 5m if --every omitted (matches Vincent's example cadence
+  // and is the most common cron-style "check periodically" interval).
+  const everyIdx = args.indexOf("--every");
+  const everyRaw = everyIdx >= 0 ? args[everyIdx + 1] : "5m";
+  if (!everyRaw || !/^\d+[smhd]$/.test(everyRaw)) {
+    console.error(`Invalid --every value "${everyRaw}". Use formats like 30s, 5m, 2h, 1d.`);
+    process.exit(1);
+  }
+
+  const resolved = resolveNodeRef(aliasRef);
+  if (!resolved) {
+    console.error(`Node "${aliasRef}" not found. Run 'anet node ls' to see registered nodes.`);
+    process.exit(1);
+  }
+
+  const profile = resolved.profile;
+  const displayName = nodeDisplayName(resolved.id, profile);
+  const gc = loadGlobal();
+  const hub = profile.hub || gc.hub || "http://127.0.0.1:9200";
+  const networkId = profile.network_id || gc.network_id || null;
+
+  // The inbox parser at agent-node/src/goals/parser.ts accepts
+  // `/loop <interval> <text>` (and `/goal` as an alias). We assemble
+  // the slash form and POST it as a normal task — the node's inbox
+  // handler routes /loop tasks to createScheduledGoal regardless of
+  // runtime (post-#144 the claude-bucket carve-out is gone).
+  const slashCmd = `/loop ${everyRaw} ${taskText}`;
+  const body = JSON.stringify({
+    alias: displayName,
+    task: slashCmd,
+    priority: "normal",
+    from: "api",
+    network_id: networkId || undefined,
+  });
+
+  try {
+    const res = await fetch(`${hub}/api/task`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body,
+    });
+    const j: any = await res.json();
+    if (!j?.ok) {
+      console.error(`Failed to schedule loop: ${JSON.stringify(j)}`);
+      process.exit(1);
+    }
+    console.log(`✅ Scheduled loop on ${displayName}`);
+    console.log(`   every: ${everyRaw}`);
+    console.log(`   task:  ${taskText}`);
+    console.log(`   sent as: ${slashCmd}`);
+    console.log(`\nUse 'anet goal list ${displayName}' to inspect; 'anet goal cancel ${displayName} <goal-id>' to stop.`);
+  } catch (e: any) {
+    console.error(`Failed to reach hub ${hub}: ${e?.message ?? e}`);
+    console.error(`Is the hub running? Try: anet hub start`);
+    process.exit(1);
+  }
+}
+
 // ── delete ──
 
 async function deleteCommand() {
@@ -9438,6 +9533,7 @@ switch (command) {
       case "resume": args.splice(0, 1); await resumeCommand(); break;
       case "delete": args.splice(0, 1); await deleteCommand(); break;
       case "rename": args.splice(0, 1); await renameCommand(); break;
+      case "loop": args.splice(0, 1); await nodeLoopCommand(); break;
       case "ls": case "list": await lsCommand(); break;
       case "restart": {
         // #173 / F7-03 — node restart = stop + start, alias for symmetry
@@ -9452,10 +9548,10 @@ switch (command) {
       default: {
         const sub = args[1];
         if (sub) {
-          const suggestion = suggestSimilar(sub, ["create", "start", "stop", "restart", "resume", "delete", "ls", "rename"]);
+          const suggestion = suggestSimilar(sub, ["create", "start", "stop", "restart", "resume", "delete", "ls", "rename", "loop"]);
           if (suggestion) console.log(`Unknown node subcommand "${sub}". Did you mean: anet node ${suggestion}?`);
         }
-        console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|migrate-token-to-envref> [name]`);
+        console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|loop|migrate-token-to-envref> [name]`);
         break;
       }
     }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -4948,8 +4948,13 @@ Examples:
   anet node loop my-codex "monitor #271 PR" --every 5m
   anet node loop researcher "scan twitter for grok updates" --every 30m
   anet node loop daily-bot "post the morning summary" --every 2h
+  anet node loop nightly-bot "rotate logs"                  --every 1d
 
-Interval format: 30s / 5m / 2h / 1d (s/m/h/d suffix required).
+Interval format: 5m / 2h / 1d (m/h/d suffix required, integer ≥ 1).
+Sub-minute intervals (e.g. 30s) are not accepted — the scheduler tick
+runs at ~30s cadence so a sub-minute goal would not actually fire any
+faster and risks wake-storm load on the runtime.
+
 Use 'anet goal list <alias>' to see scheduled loops; 'anet goal cancel'
 to stop one.
 `);
@@ -4960,8 +4965,14 @@ to stop one.
   // and is the most common cron-style "check periodically" interval).
   const everyIdx = args.indexOf("--every");
   const everyRaw = everyIdx >= 0 ? args[everyIdx + 1] : "5m";
-  if (!everyRaw || !/^\d+[smhd]$/.test(everyRaw)) {
-    console.error(`Invalid --every value "${everyRaw}". Use formats like 30s, 5m, 2h, 1d.`);
+  // CLI mirrors agent-node/src/goals/parser.ts: single-letter m/h/d only,
+  // integer ≥ 1. Sub-minute is rejected by both layers (MIN_INTERVAL_MS
+  // = 60s in the parser); reject here too so the user sees the error
+  // before we POST a doomed task. The previous /^\d+[smhd]$/ pattern
+  // accepted `30s` at the CLI layer but the parser rejected it server-
+  // side → silent fail (CLI printed "Scheduled" but no goal was created).
+  if (!everyRaw || !/^[1-9]\d*[mhd]$/.test(everyRaw)) {
+    console.error(`Invalid --every value "${everyRaw}". Use formats like 5m, 30m, 2h, 1d (sub-minute not allowed).`);
     process.exit(1);
   }
 
@@ -4991,6 +5002,7 @@ to stop one.
     network_id: networkId || undefined,
   });
 
+  let taskId: string;
   try {
     const res = await fetch(`${hub}/api/task`, {
       method: "POST",
@@ -4999,19 +5011,73 @@ to stop one.
     });
     const j: any = await res.json();
     if (!j?.ok) {
-      console.error(`Failed to schedule loop: ${JSON.stringify(j)}`);
+      console.error(`Failed to enqueue /loop task: ${JSON.stringify(j)}`);
       process.exit(1);
     }
-    console.log(`✅ Scheduled loop on ${displayName}`);
-    console.log(`   every: ${everyRaw}`);
-    console.log(`   task:  ${taskText}`);
-    console.log(`   sent as: ${slashCmd}`);
-    console.log(`\nUse 'anet goal list ${displayName}' to inspect; 'anet goal cancel ${displayName} <goal-id>' to stop.`);
+    taskId = j.message_id;
   } catch (e: any) {
     console.error(`Failed to reach hub ${hub}: ${e?.message ?? e}`);
     console.error(`Is the hub running? Try: anet hub start`);
     process.exit(1);
   }
+
+  // #144 round-6 hardening — don't claim success until the node has
+  // ACTUALLY created the goal. Previously the CLI printed "✅ Scheduled
+  // loop" the instant /api/task enqueued the task; if the parser
+  // downstream rejected it (e.g. `5m` not matching the old word-only
+  // patterns) the failure reply went back to `from:"api"` and was
+  // invisible to the user — silent fail. Now we poll for the node's
+  // reply and surface what actually happened.
+  console.log(`→ Sent /loop to ${displayName} (task ${taskId.slice(0, 8)}); waiting for node confirmation...`);
+
+  const POLL_DEADLINE_MS = 15_000;
+  const POLL_INTERVAL_MS = 1_000;
+  const started = Date.now();
+  let taskRow: any = null;
+  // Poll `/api/tasks?task_id=<id>` for the task row. After the node
+  // handles the /loop slash command it writes the reply text into
+  // tasks.result + sets status='replied' (or 'failed'). This is the
+  // robust signal — /api/messages doesn't carry in_reply_to in its
+  // SELECT (existing comment at cli.ts:7053), so we can't reliably
+  // match a reply back to our task there.
+  while (Date.now() - started < POLL_DEADLINE_MS) {
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+    try {
+      const r: any = await fetch(`${hub}/api/tasks?task_id=${encodeURIComponent(taskId)}`, { headers: authHeaders() }).then(x => x.json());
+      const t = (r?.tasks || [])[0];
+      if (t && (t.status === "replied" || t.status === "failed" || t.status === "cancelled") && t.result) {
+        taskRow = t;
+        break;
+      }
+    } catch {
+      // network blip; keep polling
+    }
+  }
+
+  if (!taskRow) {
+    console.error(`⚠ Node ${displayName} did not confirm goal creation within 15s.`);
+    console.error(`  Possible causes: node offline / agent crashed / parser rejected the interval.`);
+    console.error(`  Verify with: anet goal list ${displayName}`);
+    console.error(`  Or inspect node logs at ~/.anet/nodes/${resolved.id}/logs/`);
+    process.exit(1);
+  }
+
+  const replyText = String(taskRow.result || "");
+  // The node's reply text is set by agent-node/src/cli.ts:createScheduledGoal
+  // wrapping success as "已创建 loop 目标 <id>..." or, on failure,
+  // "/loop 创建失败：<reason>".
+  if (taskRow.status === "failed" || (/创建失败|failed/i.test(replyText) && !/已创建 loop 目标/.test(replyText))) {
+    console.error(`❌ Node rejected the /loop command:`);
+    console.error(`   ${replyText.replace(/^\[[^\]]+\]\s*/, "").trim()}`);
+    process.exit(1);
+  }
+
+  console.log(`✅ Scheduled loop on ${displayName}`);
+  console.log(`   every: ${everyRaw}`);
+  console.log(`   task:  ${taskText}`);
+  console.log(`   sent as: ${slashCmd}`);
+  console.log(`\n${replyText.replace(/^\[[^\]]+\]\s*/, "").trim()}`);
+  console.log(`\nUse 'anet goal list ${displayName}' to inspect; 'anet goal cancel ${displayName} <goal-id>' to stop.`);
 }
 
 // ── delete ──
@@ -9509,7 +9575,22 @@ if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
       printProjectUsage();
       break;
     case "node":
-      console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|migrate-token-to-envref> [name]`);
+      // #144 — if it's `anet node loop --help` specifically, delegate
+      // to nodeLoopCommand so the user sees the loop-specific help
+      // (examples + interval format) rather than the generic node
+      // subcommand list. Other `anet node <sub> --help` calls still
+      // get the generic node usage.
+      if (args[1] === "loop") {
+        args.splice(0, 1); // drop "node" so nodeLoopCommand sees args[1] as alias slot (no alias → prints loop help)
+        // strip --help so it's not treated as an alias literal
+        const hi = args.indexOf("--help");
+        if (hi >= 0) args.splice(hi, 1);
+        const hi2 = args.indexOf("-h");
+        if (hi2 >= 0) args.splice(hi2, 1);
+        await nodeLoopCommand();
+        process.exit(0);
+      }
+      console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|loop|migrate-token-to-envref> [name]`);
       break;
     default:
       printHelp();

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -2576,12 +2576,14 @@ async function processInbox() {
         continue;
       }
 
-      // P0 /loop SDK gate (v0.4 §3.4): on claude runtime, anet does NOT
-      // intercept /loop or /goal — let the message flow through to the
-      // claude SDK turn so Claude Code's native /loop skill handles it.
-      // The early-return is the entire hands-off contract; no parse, no
-      // wrap, no forward layer in between.
-      if (RUNTIME !== "claude" && isGoalCommand(content)) {
+      // #144 round-6: anet /loop is universal — all recognized runtimes
+      // (claude / codex / grok) route /loop and /goal commands to the
+      // scheduler. The pre-#144 `RUNTIME !== "claude"` carve-out was
+      // removed because the underlying premise (claude-agent-sdk has a
+      // native /loop) was false: the SDK is one-shot per-task, no
+      // persistent CC REPL to fire CronCreate/ScheduleWakeup from. See
+      // goals/store.ts runtimeBucket comment for full rationale.
+      if (isGoalCommand(content)) {
         let replyText: string;
         let goalFailed = false;
         try {
@@ -3240,10 +3242,12 @@ const allGoals = await goalStore.list();
 const activeGoals = allGoals.filter(g => g.status === "active");
 if (activeGoals.length) log(`  goals active: ${activeGoals.length}`);
 
-// P0 /loop SDK runtime gate (v0.4 §3.4). Decide whether this process can
-// run the anet scheduler at all given the runtime it booted under and the
-// goals already on disk. Pure-function decision; we only act on the
-// verdict here.
+// #144 round-6 — startup runtime dispatch. Pure-function decision over
+// (current runtime bucket, persisted goals); we just act on the verdict.
+// "archive" no longer crashes — pre-#144 the codex↔grok cross-bucket
+// case did `exit(1)` which was hostile UX (silently killing the user's
+// node without recovery guidance). It now archives + clears + continues
+// so the scheduler runs against an empty store.
 const startupBucket = runtimeBucket(RUNTIME);
 const startupAction = decideStartupAction(startupBucket, allGoals);
 let goalsSchedulerEnabled = startupAction.runScheduler;
@@ -3263,12 +3267,9 @@ switch (startupAction.kind) {
     } else {
       warn(`  goals archive skipped — no file to back up`);
     }
+    log(`  goals scheduler: enabled (runtime=${startupBucket}, fresh store)`);
     break;
   }
-  case "fatal":
-    warn(`  goals scheduler: FATAL — ${startupAction.reason}`);
-    warn(`  goals path: ${GOALS_PATH}`);
-    process.exit(1);
 }
 
 await register();

--- a/agent-node/src/goals/parser.test.ts
+++ b/agent-node/src/goals/parser.test.ts
@@ -164,3 +164,80 @@ describe("parseGoalCommand — defence-in-depth", () => {
     if (r.ok) expect(r.goal.interval_ms).toBe(60_000);
   });
 });
+
+describe("parseGoalCommand — #144 round-6 single-letter units (CLI parity)", () => {
+  // `anet node loop <alias> "<task>" --every 5m` emits a slash command
+  // shaped exactly like the strings below. Pre-fix the parser ONLY
+  // matched word-form ("min/minute/hour/day"), so `5m` / `2h` / `1d`
+  // all fell through to "no recognised interval" and the CLI silently
+  // succeeded at /api/task enqueue while the goal never landed. These
+  // tests pin parity with the CLI's `--every` format.
+
+  test("`5m` parses to 5 × 60_000 ms (the canonical CLI emission)", () => {
+    const r = parseGoalCommand("/loop 5m monitor PR #271");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.goal.interval_ms).toBe(5 * 60_000);
+      expect(r.goal.text).toBe("monitor PR #271");
+    }
+  });
+
+  test("`30m` / `90m` arbitrary minutes parse correctly", () => {
+    const a = parseGoalCommand("/loop 30m scan twitter");
+    const b = parseGoalCommand("/loop 90m long task");
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    if (a.ok) expect(a.goal.interval_ms).toBe(30 * 60_000);
+    if (b.ok) expect(b.goal.interval_ms).toBe(90 * 60_000);
+  });
+
+  test("`2h` parses to 2 hours", () => {
+    const r = parseGoalCommand("/loop 2h morning sync");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.goal.interval_ms).toBe(2 * 60 * 60_000);
+  });
+
+  test("`1d` parses to 24 hours", () => {
+    const r = parseGoalCommand("/loop 1d nightly cleanup");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.goal.interval_ms).toBe(24 * 60 * 60_000);
+  });
+
+  test("single-letter and word-form yield the same interval (no semantic drift)", () => {
+    const single = parseGoalCommand("/loop 5m do thing");
+    const word = parseGoalCommand("/loop 5min do thing");
+    expect(single.ok).toBe(true);
+    expect(word.ok).toBe(true);
+    if (single.ok && word.ok) {
+      expect(single.goal.interval_ms).toBe(word.goal.interval_ms);
+      expect(single.goal.text).toBe(word.goal.text);
+    }
+  });
+
+  test("`5min` still wins over `5m` (longest-prefix declaration order)", () => {
+    // Pre-fix `5min` was the only thing that worked; ensure we don't
+    // regress that by accidentally matching `5m` first and treating
+    // `in` as leftover goal text.
+    const r = parseGoalCommand("/loop 5min check the deploy");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.goal.interval_ms).toBe(5 * 60_000);
+      expect(r.goal.text).toBe("check the deploy"); // NOT "in check the deploy"
+    }
+  });
+
+  test("single-letter inside a larger word is NOT swallowed (lookahead guard)", () => {
+    // `5min` should match the word-form rule, not the single-letter
+    // rule with `in` as leftover. Pinned above. Conversely, a stray
+    // `2m2` in the text should not be picked up — there's no clean
+    // single-letter form here, so it must NOT parse.
+    const r = parseGoalCommand("/loop check status 5MOM"); // looks suggestive
+    expect(r.ok).toBe(false); // no valid interval
+  });
+
+  test("`30s` is rejected with sub-minute error (parser + CLI aligned)", () => {
+    const r = parseGoalCommand("/loop 30s ping");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/shorter than 60s|seconds/i);
+  });
+});

--- a/agent-node/src/goals/parser.ts
+++ b/agent-node/src/goals/parser.ts
@@ -7,12 +7,20 @@
 // post-parse as a defence-in-depth check.
 //
 // Accepted forms (case-insensitive on ASCII; locale-sensitive on CJK):
-//   English: `5min`, `5 min`, `5 minute`, `5 minutes`, `1h`, `1 hour`,
-//            `2 hours`, `hourly`, `daily`, `1 day`
-//   Chinese: `5分钟`, `每5分钟`, `1小时`, `每小时`, `每天`
+//   Single-letter: `5m`, `2h`, `1d` (matches what `anet node loop --every`
+//                  emits — keep parser and CLI in lockstep).
+//   English:       `5min`, `5 min`, `5 minute`, `5 minutes`,
+//                  `1h`, `1 hour`, `2 hours`, `hourly`, `daily`, `1 day`
+//   Chinese:       `5分钟`, `每5分钟`, `1小时`, `每小时`, `每天`
 //
 // Rejected: sub-minute units (`5s`, `30秒`), no interval at all, bare
 // numbers without units (`/goal 5 check` — unit-free 5 is ambiguous).
+//
+// #144 round-6 (this fix): added single-letter `m`/`h`/`d` so that
+// `anet node loop <alias> "<task>" --every 5m` actually creates a goal
+// instead of silent-failing. The CLI emits `5m` / `30s` / `2h` / `1d`
+// straight from `--every` and previously the parser rejected all of them
+// because INTERVAL_PATTERNS only matched word-form unit names.
 
 export const MIN_INTERVAL_MS = 60_000;
 
@@ -56,6 +64,17 @@ const INTERVAL_PATTERNS: Array<{
   { re: /(\d+)\s*(?:minutes|minute|mins|min)\b/i, toMs: (m) => parseInt(m[1], 10) * 60_000 },
   { re: /(\d+)\s*(?:hours|hour|hrs|hr)\b/i, toMs: (m) => parseInt(m[1], 10) * 60 * 60_000 },
   { re: /(\d+)\s*(?:days|day)\b/i, toMs: (m) => parseInt(m[1], 10) * 24 * 60 * 60_000 },
+
+  // Single-letter units — matches `anet node loop --every 5m` shape.
+  // Anchored so `5m` isn't accidentally swallowed by `5min` / `5mins`
+  // (those patterns above run FIRST per declaration order and use
+  // `\b` to terminate, so `5m` here only matches when not part of a
+  // word like `5min`). Lookahead `(?![a-zA-Z])` prevents `5min` from
+  // matching the `5m` rule. Lookbehind `(?<!\w)` prevents `pm5h`-like
+  // surprises (no digit/letter immediately before the number).
+  { re: /(?<!\w)(\d+)m(?![a-zA-Z])/i,   toMs: (m) => parseInt(m[1], 10) * 60_000 },
+  { re: /(?<!\w)(\d+)h(?![a-zA-Z])/i,   toMs: (m) => parseInt(m[1], 10) * 60 * 60_000 },
+  { re: /(?<!\w)(\d+)d(?![a-zA-Z])/i,   toMs: (m) => parseInt(m[1], 10) * 24 * 60 * 60_000 },
 ];
 
 // Patterns we recognise as *invalid* (sub-minute units) — surface a clear

--- a/agent-node/src/goals/store.test.ts
+++ b/agent-node/src/goals/store.test.ts
@@ -12,7 +12,6 @@ import { tmpdir } from "os";
 import {
   GoalStore,
   newGoal,
-  assertNonClaudeRuntime,
   isClaudeRuntime,
   runtimeBucket,
   decideStartupAction,
@@ -207,50 +206,50 @@ describe("P0 runtime gate — name resolution", () => {
   });
 });
 
-describe("P0 runtime gate — assertNonClaudeRuntime", () => {
-  test("throws on every claude alias", () => {
-    for (const name of ["claude", "claude-agent-sdk", "claude-sdk", "agent-sdk"]) {
-      expect(() => assertNonClaudeRuntime(name)).toThrow(/claude runtime/);
+describe("#144 round-6 — claude runtime gate REMOVED, scheduler is universal", () => {
+  // History: pre-#144 a `assertNonClaudeRuntime` gate threw on any
+  // claude alias. The premise (claude-agent-sdk has a native /loop) was
+  // false — SDK is one-shot query(), no persistent CC REPL to host
+  // CronCreate/ScheduleWakeup. Loop silently didn't fire for claude
+  // users. These tests pin the post-#144 universal behaviour: every
+  // recognized runtime (incl. claude) creates + persists goals.
+
+  test("newGoal({runtime: 'claude-agent-sdk'}) succeeds (was the load-bearing bug)", () => {
+    const g = newGoal({ text: "claude loop", interval_ms: 60_000, runtime: "claude-agent-sdk" });
+    expect(g.runtime).toBe("claude-agent-sdk");
+    expect(g.status).toBe("active");
+  });
+
+  test("newGoal succeeds for every recognized runtime alias (no per-bucket carve-out)", () => {
+    for (const rt of [
+      "claude", "claude-agent-sdk", "claude-sdk", "agent-sdk",
+      "codex", "codex-sdk",
+      "grok", "grok-build", "grok-build-acp",
+    ]) {
+      const g = newGoal({ text: "x", interval_ms: 60_000, runtime: rt });
+      expect(g.runtime).toBe(rt);
     }
   });
 
-  test("passes for codex / grok / unknown labels (gate only blocks claude)", () => {
-    for (const name of ["codex-sdk", "codex", "grok-build-acp", "grok", "future-sdk"]) {
-      expect(() => assertNonClaudeRuntime(name)).not.toThrow();
-    }
-  });
-
-  test("newGoal({runtime: 'claude'}) throws — no claude-runtime goal ever lands", () => {
-    expect(() =>
-      newGoal({ text: "should not exist", interval_ms: 60_000, runtime: "claude-agent-sdk" }),
-    ).toThrow(/claude runtime/);
-  });
-
-  test("newGoal succeeds for codex / grok runtimes", () => {
-    const c = newGoal({ text: "codex goal", interval_ms: 60_000, runtime: "codex-sdk" });
-    const g = newGoal({ text: "grok goal", interval_ms: 60_000, runtime: "grok-build-acp" });
-    expect(c.runtime).toBe("codex-sdk");
-    expect(g.runtime).toBe("grok-build-acp");
-  });
-
-  test("GoalStore.upsert refuses claude-runtime goal (defence in depth)", async () => {
-    const { dir, path } = (() => {
-      const d = mkdtempSync(join(tmpdir(), "anet-goals-test-"));
-      return { dir: d, path: join(d, "goals.json") };
-    })();
+  test("GoalStore.upsert accepts a claude-runtime goal end-to-end", async () => {
+    const d = mkdtempSync(join(tmpdir(), "anet-goals-test-"));
+    const path = join(d, "goals.json");
     try {
       const s = new GoalStore(path);
       await s.load();
-      // Build a goal via the legitimate factory then mutate runtime to
-      // simulate a corrupted on-disk record being re-upserted by some
-      // future code path.
-      const g = newGoal({ text: "smuggle", interval_ms: 60_000, runtime: "codex-sdk" });
-      g.runtime = "claude-agent-sdk";
-      await expect(s.upsert(g)).rejects.toThrow(/claude runtime/);
-      expect(await s.list()).toEqual([]);  // store stayed clean
+      const g = newGoal({ text: "claude e2e", interval_ms: 60_000, runtime: "claude-agent-sdk" });
+      await s.upsert(g);
+      expect(await s.list()).toHaveLength(1);
+      const loaded = (await s.list())[0];
+      expect(loaded.runtime).toBe("claude-agent-sdk");
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      rmSync(d, { recursive: true, force: true });
     }
+  });
+
+  test("isClaudeRuntime still classifies (kept for cross-bucket detection, not gating)", () => {
+    expect(isClaudeRuntime("claude-agent-sdk")).toBe(true);
+    expect(isClaudeRuntime("codex-sdk")).toBe(false);
   });
 });
 
@@ -314,7 +313,7 @@ describe("P0 runtime gate — archiveAndClear", () => {
   });
 });
 
-describe("P0 runtime gate — decideStartupAction (v0.4 §3.4 matrix)", () => {
+describe("#144 round-6 — decideStartupAction (refined-B matrix)", () => {
   function activeGoal(runtime: string): AgentGoal {
     return newGoal({ text: "x", interval_ms: 60_000, runtime });
   }
@@ -324,50 +323,75 @@ describe("P0 runtime gate — decideStartupAction (v0.4 §3.4 matrix)", () => {
     return g;
   }
 
-  test("row 1: claude + empty → skip, scheduler off", () => {
+  // ── claude bucket: no longer a special case ──
+
+  test("claude + empty → ok (scheduler runs; was 'skip' pre-#144)", () => {
     const a = decideStartupAction("claude", []);
-    expect(a.kind).toBe("skip");
-    expect(a.runScheduler).toBe(false);
+    expect(a.kind).toBe("ok");
+    expect(a.runScheduler).toBe(true);
   });
 
-  test("row 2: claude + active codex/grok goals → archive verdict", () => {
+  test("claude + only claude-active goals → ok (scheduler runs)", () => {
+    const a = decideStartupAction("claude", [
+      activeGoal("claude-agent-sdk"),
+      activeGoal("claude-agent-sdk"),
+    ]);
+    expect(a.kind).toBe("ok");
+    expect(a.runScheduler).toBe(true);
+  });
+
+  // ── codex / grok: same-bucket happy path ──
+
+  test("codex + empty → ok", () => {
+    const a = decideStartupAction("codex", []);
+    expect(a.kind).toBe("ok");
+    expect(a.runScheduler).toBe(true);
+  });
+
+  test("codex + only codex goals → ok", () => {
+    const a = decideStartupAction("codex", [activeGoal("codex-sdk")]);
+    expect(a.kind).toBe("ok");
+  });
+
+  test("grok + only grok goals → ok", () => {
+    const a = decideStartupAction("grok", [activeGoal("grok-build-acp")]);
+    expect(a.kind).toBe("ok");
+  });
+
+  // ── cross-bucket: archive (NOT fatal) ──
+
+  test("claude + active codex/grok goals → archive + runScheduler=true (recover after archive)", () => {
     const a = decideStartupAction("claude", [
       activeGoal("codex-sdk"),
       activeGoal("grok-build-acp"),
     ]);
     expect(a.kind).toBe("archive");
-    expect(a.runScheduler).toBe(false);
+    expect(a.runScheduler).toBe(true); // ← new: was false pre-#144
     if (a.kind === "archive") {
       expect(a.foreignCount).toBe(2);
       expect(a.foreignBuckets.sort()).toEqual(["codex", "grok"]);
     }
   });
 
-  test("row 2 ignores non-active leftover claude-side (no archive triggered)", () => {
-    const a = decideStartupAction("claude", [
-      inactiveGoal("codex-sdk", "complete"),
-      inactiveGoal("grok-build-acp", "cancelled"),
-    ]);
-    expect(a.kind).toBe("skip");
-  });
-
-  test("row 3a: codex bucket + grok-active leftover → fatal", () => {
+  test("codex + grok-active leftover → archive (NOT fatal exit anymore)", () => {
     const a = decideStartupAction("codex", [activeGoal("grok-build-acp")]);
-    expect(a.kind).toBe("fatal");
-    expect(a.runScheduler).toBe(false);
-    if (a.kind === "fatal") {
+    expect(a.kind).toBe("archive");
+    expect(a.runScheduler).toBe(true); // ← was kind=fatal, runScheduler=false pre-#144
+    if (a.kind === "archive") {
       expect(a.foreignCount).toBe(1);
       expect(a.foreignBuckets).toEqual(["grok"]);
     }
   });
 
-  test("row 3b: grok bucket + codex-active leftover → fatal", () => {
+  test("grok + codex-active leftover → archive", () => {
     const a = decideStartupAction("grok", [activeGoal("codex-sdk")]);
-    expect(a.kind).toBe("fatal");
-    if (a.kind === "fatal") expect(a.foreignBuckets).toEqual(["codex"]);
+    expect(a.kind).toBe("archive");
+    expect(a.runScheduler).toBe(true);
   });
 
-  test("row 3 ignores non-active foreign goals (resolved/cancelled don't block)", () => {
+  // ── non-active foreign goals don't trigger archive ──
+
+  test("inactive foreign-bucket goals do NOT trigger archive (only `active` counts)", () => {
     const a = decideStartupAction("codex", [
       inactiveGoal("grok-build-acp", "complete"),
       activeGoal("codex-sdk"),
@@ -375,28 +399,17 @@ describe("P0 runtime gate — decideStartupAction (v0.4 §3.4 matrix)", () => {
     expect(a.kind).toBe("ok");
   });
 
-  test("row 4: codex bucket + only codex goals → ok, scheduler on", () => {
-    const a = decideStartupAction("codex", [
-      activeGoal("codex-sdk"),
-      activeGoal("codex-sdk"),
+  test("claude with only inactive foreign leftover → ok (just cleanup pending)", () => {
+    const a = decideStartupAction("claude", [
+      inactiveGoal("codex-sdk", "complete"),
+      inactiveGoal("grok-build-acp", "cancelled"),
     ]);
     expect(a.kind).toBe("ok");
-    expect(a.runScheduler).toBe(true);
   });
 
-  test("row 4: grok bucket + only grok goals → ok, scheduler on", () => {
-    const a = decideStartupAction("grok", [activeGoal("grok-build-acp")]);
-    expect(a.kind).toBe("ok");
-    expect(a.runScheduler).toBe(true);
-  });
+  // ── unknown bucket: still skip (defensive) ──
 
-  test("row 4: codex bucket + empty store → ok (fresh node)", () => {
-    const a = decideStartupAction("codex", []);
-    expect(a.kind).toBe("ok");
-    expect(a.runScheduler).toBe(true);
-  });
-
-  test("unknown bucket → skip with warning text (no scheduler, no auto-archive)", () => {
+  test("unknown bucket → skip (no scheduler, no auto-archive)", () => {
     const a = decideStartupAction("unknown", [activeGoal("codex-sdk")]);
     expect(a.kind).toBe("skip");
     expect(a.runScheduler).toBe(false);

--- a/agent-node/src/goals/store.ts
+++ b/agent-node/src/goals/store.ts
@@ -20,17 +20,29 @@ import { randomUUID } from "crypto";
 import type { AgentGoal, GoalStatus, GoalsFile } from "./types";
 import { GOALS_SCHEMA_VERSION } from "./types";
 
-// P0 of /loop SDK plan v0.4 §3.4 — runtime gate.
+// #144 round-6 — runtime bucket mapping (no more "claude is special" gate).
 //
-// anet /loop scheduler ONLY serves codex / grok runtimes. claude-agent-sdk
-// agents use Claude Code's native /loop (CronCreate + ScheduleWakeup skill)
-// which the harness handles inside the spawned `claude` binary; anet must
-// stay hands-off there or the two schedulers double-fire the same goal.
+// History: v0.4 §3.4 P0 (#184 commit 45c7909) introduced a runtime gate
+// that rejected the claude bucket entirely, on the assumption that
+// claude-agent-sdk agents use Claude Code's native /loop (CronCreate +
+// ScheduleWakeup skill). That assumption is FALSE for SDK-spawned claude:
+// `processWithClaude` invokes `query()` from @anthropic-ai/claude-agent-sdk
+// which is a one-shot Promise — not a long-running interactive REPL — so
+// the native /loop machinery (which requires a persistent CC session) has
+// no host to fire from. The result was: claude-agent-sdk users sent /loop
+// commands that were silently rejected at the inbox gate and never wired
+// to anything; "loop doesn't fire" for that runtime.
 //
-// Any name a user might write in `--runtime` / `RUNTIME` env / config that
-// resolves to the claude runtime is rejected at the schema layer so a stray
-// `newGoal({runtime: "claude"})` or a corrupted on-disk record can't slip
-// through the gate. See cli.ts:244-251 for the canonical name→bucket map.
+// Refined-B (this PR): no per-bucket scheduler skip. ALL recognized
+// runtimes get the anet scheduler. The bucket helpers stay for the
+// remaining concern that's still real — codex thread IDs are NOT
+// translatable to grok and vice versa, so a node that switches SDK
+// runtime mid-life shouldn't silently re-feed old thread IDs across
+// SDK boundaries. The cross-bucket recovery is now "archive + skip"
+// (formerly hostile-UX `fatal exit(1)` that crashed the node without
+// guidance).
+//
+// Recognized names mirror cli.ts:280 RUNTIME_MAP.
 const CLAUDE_RUNTIME_NAMES = new Set([
   "claude",
   "claude-agent-sdk",
@@ -62,15 +74,6 @@ export function runtimeBucket(rt: string | undefined | null): RuntimeBucket {
 
 export function isClaudeRuntime(rt: string | undefined | null): boolean {
   return runtimeBucket(rt) === "claude";
-}
-
-export function assertNonClaudeRuntime(rt: string): void {
-  if (isClaudeRuntime(rt)) {
-    throw new Error(
-      `anet goal scheduler does not serve claude runtime (got "${rt}") — ` +
-      `use Claude Code native /loop (CronCreate / ScheduleWakeup) instead`,
-    );
-  }
 }
 
 // Promise-chain mutex. Every `lock()` waits for the previous one to
@@ -192,12 +195,12 @@ export class GoalStore {
    * Insert or replace a goal. Bumps `updated_at` and flushes to disk
    * atomically before returning.
    *
-   * P0 runtime gate: rejects any goal whose `runtime` resolves to the
-   * claude bucket. This catches both fresh `newGoal()` mistakes and
-   * upserts of records re-hydrated from corrupted on-disk state.
+   * #144: no runtime gate. The pre-#144 `assertNonClaudeRuntime(goal.runtime)`
+   * check was removed because the claude-bucket "skip" premise was false
+   * (SDK-spawned claude has no native /loop host — see runtimeBucket
+   * comment above for the full rationale).
    */
   async upsert(goal: AgentGoal): Promise<void> {
-    assertNonClaudeRuntime(goal.runtime);
     return this.mutex.lock(async () => {
       goal.updated_at = new Date().toISOString();
       this.goals.set(goal.goal_id, goal);
@@ -328,7 +331,8 @@ export function newGoal(opts: {
   parent_task_id?: string;
   report_to?: string;
 }): AgentGoal {
-  assertNonClaudeRuntime(opts.runtime);
+  // #144: no runtime gate. Pre-#144 this asserted the runtime was non-claude
+  // on the (incorrect) premise that claude-agent-sdk had a native /loop.
   const now = new Date();
   return {
     goal_id: randomUUID(),
@@ -346,36 +350,38 @@ export function newGoal(opts: {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// P0 startup runtime-switch dispatch (v0.4 §3.4 row matrix).
+// #144 round-6 — startup runtime dispatch (refined-B matrix).
 //
 // At agent-node boot, after `goalStore.load()`, the host inspects which
-// runtime bucket it is starting under and what — if anything — is already
-// in `goals.json`. The result drives one of four actions:
+// runtime bucket it is starting under and what — if anything — is in
+// `goals.json`. The result drives one of three actions:
 //
-//   - `ok`           : current runtime matches every persisted goal — boot
-//                      normally, run the scheduler tick.
-//   - `skip`         : claude runtime + empty store — boot normally but
-//                      don't start the scheduler tick (claude uses its
-//                      own /loop).
-//   - `archive`      : claude runtime + non-claude goals leftover (alias
-//                      was previously running under codex/grok and
-//                      switched). Caller archives + clears the store + skips
-//                      the scheduler so the two /loop systems don't double-
-//                      wake. Goals are recoverable from the archive file.
-//   - `fatal`        : codex runtime + grok-leftover goals (or vice versa).
-//                      Mixing thread/session IDs across SDKs is unsafe
-//                      enough that we refuse to boot — the operator must
-//                      cancel or archive the foreign goals first.
+//   - `ok`      : current runtime matches every persisted goal (or the
+//                 store is empty). Boot normally, run the scheduler.
+//                 This is the new claude-bucket behaviour too — see
+//                 runtimeBucket comment above for why removing the
+//                 claude skip is safe (SDK-spawned claude has no native
+//                 /loop host).
+//   - `archive` : current bucket can run, but goals.json holds goals
+//                 for a DIFFERENT bucket (the alias was previously
+//                 running under another SDK runtime). Caller archives +
+//                 clears the store + boots clean, so we don't try to
+//                 reuse thread/session IDs across incompatible SDKs.
+//                 (Pre-#144 this was `fatal exit(1)` for codex↔grok,
+//                 which crashed the user's node without guidance —
+//                 hostile UX. Now: log + archive + continue.)
+//   - `skip`    : unknown runtime bucket — refuse to schedule without
+//                 a clear name → bucket mapping. Operator should check
+//                 --runtime / RUNTIME env / config.runtime.
 //
-// This is a pure function over (current bucket, goal list) so it has full
-// unit coverage; the cli.ts side just dispatches on the verdict.
+// This is a pure function over (current bucket, goal list); cli.ts
+// dispatches on the verdict. Fully unit-covered.
 // ─────────────────────────────────────────────────────────────────────
 
 export type StartupAction =
   | { kind: "ok"; runScheduler: true }
   | { kind: "skip"; runScheduler: false; reason: string }
-  | { kind: "archive"; runScheduler: false; reason: string; foreignCount: number; foreignBuckets: RuntimeBucket[] }
-  | { kind: "fatal"; runScheduler: false; reason: string; foreignCount: number; foreignBuckets: RuntimeBucket[] };
+  | { kind: "archive"; runScheduler: true; reason: string; foreignCount: number; foreignBuckets: RuntimeBucket[] };
 
 /**
  * Decide what to do at startup given the runtime the host is booting under
@@ -385,50 +391,44 @@ export function decideStartupAction(
   currentBucket: RuntimeBucket,
   goals: AgentGoal[],
 ): StartupAction {
+  // Unknown runtime label — refuse to schedule. Don't auto-archive
+  // either; we don't know what bucket this is, so we can't safely
+  // judge what's "foreign".
+  if (currentBucket === "unknown") {
+    return {
+      kind: "skip",
+      runScheduler: false,
+      reason: `unknown runtime bucket — anet scheduler refuses to run; check --runtime / RUNTIME env / config.runtime`,
+    };
+  }
+
   // Only `active` goals matter — `complete` / `cancelled` / `failed` /
-  // `paused` will not wake regardless of runtime, so they're not a threat.
+  // `paused` will not wake regardless of runtime, so they're not a
+  // foreign-bucket concern.
   const activeGoals = goals.filter((g) => g.status === "active");
 
-  if (currentBucket === "claude") {
-    if (activeGoals.length === 0) {
-      return { kind: "skip", runScheduler: false, reason: "claude runtime — native /loop in use" };
-    }
-    const foreignBuckets = uniqueBuckets(activeGoals);
+  // Any active goal whose runtime resolves to a DIFFERENT recognized
+  // bucket is "foreign". An unknown-bucket goal (legacy / future SDK
+  // label) is left alone — we already refuse to schedule unknown
+  // buckets above, and an unknown-bucket goal in a known-bucket store
+  // is harmless (it just won't have a matching runtime to dispatch).
+  const foreign = activeGoals.filter((g) => {
+    const b = runtimeBucket(g.runtime);
+    return b !== currentBucket && b !== "unknown";
+  });
+
+  if (foreign.length > 0) {
+    const foreignBuckets = uniqueBuckets(foreign);
     return {
       kind: "archive",
-      runScheduler: false,
-      reason: `claude runtime started with ${activeGoals.length} non-claude goal(s) (${foreignBuckets.join(",")}) — archive + skip scheduler so anet doesn't double-fire alongside Claude Code's native /loop`,
-      foreignCount: activeGoals.length,
+      runScheduler: true,
+      reason: `${currentBucket} runtime started but goals.json holds ${foreign.length} ${foreignBuckets.join("/")} goal(s) — archiving + clearing so we don't reuse thread/session IDs across SDK boundaries. Backup recoverable on disk.`,
+      foreignCount: foreign.length,
       foreignBuckets,
     };
   }
 
-  if (currentBucket === "codex" || currentBucket === "grok") {
-    const wrongBucket = activeGoals.filter((g) => {
-      const b = runtimeBucket(g.runtime);
-      return b !== currentBucket && b !== "unknown";
-    });
-    if (wrongBucket.length > 0) {
-      const foreignBuckets = uniqueBuckets(wrongBucket);
-      return {
-        kind: "fatal",
-        runScheduler: false,
-        reason: `${currentBucket} runtime started but goals.json holds ${wrongBucket.length} ${foreignBuckets.join("/")} goal(s) — thread / session IDs cannot be re-used across SDK runtimes. Cancel or archive the foreign goals before relaunching.`,
-        foreignCount: wrongBucket.length,
-        foreignBuckets,
-      };
-    }
-    return { kind: "ok", runScheduler: true };
-  }
-
-  // unknown bucket — runtime label we don't recognise. Refuse to run the
-  // scheduler rather than guess; do not auto-archive (we don't know what
-  // bucket this even is, so we can't claim leftover goals are "foreign").
-  return {
-    kind: "skip",
-    runScheduler: false,
-    reason: `unknown runtime bucket — anet scheduler refuses to run; check --runtime / RUNTIME env / config.runtime`,
-  };
+  return { kind: "ok", runScheduler: true };
 }
 
 function uniqueBuckets(goals: AgentGoal[]): RuntimeBucket[] {

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -25,7 +25,10 @@ COPY tests/docker-config-priority.sh /app/test-config.sh
 COPY tests/demo-quickstart.sh /app/demo.sh
 COPY tests/docker-e2e-auth.sh /app/test-auth.sh
 COPY tests/docker-e2e-networks.sh /app/test-networks.sh
-RUN chmod +x /app/test.sh /app/test-codex.sh /app/test-claude.sh /app/test-game.sh /app/test-config.sh /app/test-minimax.sh /app/test-all.sh /app/demo.sh /app/test-auth.sh /app/test-networks.sh
+COPY tests/docker-e2e-loop-runtime.sh /app/test-loop-runtime.sh
+COPY tests/docker-e2e-loop-npm-pack.sh /app/test-loop-npm-pack.sh
+COPY tests/lib /app/lib
+RUN chmod +x /app/test.sh /app/test-codex.sh /app/test-claude.sh /app/test-game.sh /app/test-config.sh /app/test-minimax.sh /app/test-all.sh /app/demo.sh /app/test-auth.sh /app/test-networks.sh /app/test-loop-runtime.sh /app/test-loop-npm-pack.sh
 RUN cd /app/server && bun install
 
 # Install local agent-node globally (build from source)

--- a/tests/docker-e2e-loop-npm-pack.sh
+++ b/tests/docker-e2e-loop-npm-pack.sh
@@ -17,6 +17,21 @@
 #      end-to-end against a freshly-installed-from-tgz environment
 
 set -e
+
+# Safe-rm guardrail per the 2026-06-16 incident. lint guard enforces.
+SAFE_RM_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/safe-rm.sh"
+if [ -f "$SAFE_RM_LIB" ]; then
+  source "$SAFE_RM_LIB"
+else
+  for cand in /app/tests/lib/safe-rm.sh /app/lib/safe-rm.sh; do
+    [ -f "$cand" ] && source "$cand" && break
+  done
+fi
+type safe_rm_rf > /dev/null 2>&1 || {
+  echo "FATAL: safe-rm.sh not found — refusing to run with bare rm -rf"
+  exit 99
+}
+
 PASS=0
 FAIL=0
 
@@ -104,7 +119,7 @@ NET_ID=$(echo "$REG" | python3 -c "import sys,json;print(json.load(sys.stdin).ge
 
 ALIAS="pack-test-claude"
 WORKDIR="/tmp/pack-test-claude"
-rm -rf "$WORKDIR"
+safe_rm_rf "$WORKDIR"
 mkdir -p "$WORKDIR/.anet/nodes/$ALIAS"
 cat > "$WORKDIR/.anet/nodes/$ALIAS/config.json" <<EOF
 {
@@ -170,6 +185,8 @@ echo ""
 echo "========================================="
 echo "  npm-pack smoke: $PASS pass, $FAIL fail"
 echo "========================================="
+# Format for test-all.sh's run_suite regex.
+echo "Results: $PASS passed, $FAIL failed"
 
 if [ $FAIL -eq 0 ]; then
   echo "🎉 npm-pack install path verified — user install will work"

--- a/tests/docker-e2e-loop-npm-pack.sh
+++ b/tests/docker-e2e-loop-npm-pack.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# #144 round-6 — npm-pack install smoke for the `anet node loop` path.
+#
+# Per 通信龙 "用 npm pack 本地 tarball" — `npm pack` produces the same
+# .tgz artifact that `npm publish` uploads, so installing from .tgz
+# proves the user-install path WITHOUT needing to actually publish to
+# the registry. This catches "source builds work but the user's npm
+# install is broken" regressions (per [[feedback_docker_smoke_gate_before_ship]]
+# / [[feedback_anet_node_behavior_stale_install]]).
+#
+# Pass criteria:
+#   1. npm pack succeeds for agent-network, agent-node, server
+#   2. Global install from .tgz succeeds — `anet` binary on PATH,
+#      `agent-node` binary on PATH, `commhub-server` available
+#   3. `anet node loop --help` prints the new help text
+#   4. `anet node loop <alias> "<task>" --every 5m` creates the goal
+#      end-to-end against a freshly-installed-from-tgz environment
+
+set -e
+PASS=0
+FAIL=0
+
+pass() { echo "  ✅ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+
+echo ""
+echo "========================================="
+echo "  #144 — npm-pack install smoke (user install path)"
+echo "========================================="
+echo ""
+
+# 1. npm pack each package — produces the EXACT artifact npm publish uploads
+echo "1. Running npm pack on each package..."
+cd /app/agent-node && npm pack --silent > /tmp/pack-node.log 2>&1 \
+  && NODE_TGZ=$(ls -1 /app/agent-node/*.tgz | head -1) \
+  && pass "agent-node: packed → $(basename $NODE_TGZ)" \
+  || { fail "agent-node npm pack failed"; cat /tmp/pack-node.log; exit 1; }
+
+cd /app/agent-network && npm pack --silent > /tmp/pack-net.log 2>&1 \
+  && NET_TGZ=$(ls -1 /app/agent-network/*.tgz | head -1) \
+  && pass "agent-network: packed → $(basename $NET_TGZ)" \
+  || { fail "agent-network npm pack failed"; cat /tmp/pack-net.log; exit 1; }
+
+cd /app/server && npm pack --silent > /tmp/pack-server.log 2>&1 \
+  && SERVER_TGZ=$(ls -1 /app/server/*.tgz | head -1) \
+  && pass "commhub-server: packed → $(basename $SERVER_TGZ)" \
+  || { fail "commhub-server npm pack failed"; cat /tmp/pack-server.log; exit 1; }
+
+# 2. Uninstall the source-installed versions first (we need a CLEAN
+# state to confirm the .tgz install actually wires the binaries)
+echo ""
+echo "2. Uninstalling source-installed versions to get clean state..."
+npm uninstall -g @sleep2agi/agent-network @sleep2agi/agent-node @sleep2agi/commhub-server --silent 2>/dev/null || true
+# Source-install path used `npm link` + `npm install -g .` which may
+# leave binaries; double-check `anet` is gone or about to be
+# overwritten.
+pass "removed source-installed @sleep2agi/* packages"
+
+# 3. Install from the .tgz artifacts (this is what `npm publish`
+#    followed by `npm install -g @sleep2agi/...` produces on a user's
+#    machine — modulo registry round-trip).
+echo ""
+echo "3. Installing from .tgz tarballs (user install simulation)..."
+npm install -g "$NODE_TGZ" "$NET_TGZ" "$SERVER_TGZ" --silent > /tmp/install.log 2>&1 \
+  && pass "npm install -g <tgz> succeeded for all 3 packages" \
+  || { fail "npm install -g <tgz> failed"; cat /tmp/install.log; exit 1; }
+
+# 4. Verify binaries land on PATH
+echo ""
+echo "4. Verifying binaries are on PATH..."
+command -v anet > /dev/null && pass "anet binary present at $(which anet)" || fail "anet missing from PATH"
+command -v agent-node > /dev/null && pass "agent-node binary present at $(which agent-node)" || fail "agent-node missing from PATH"
+command -v commhub-server > /dev/null && pass "commhub-server binary present at $(which commhub-server)" || fail "commhub-server missing from PATH"
+
+# 5. `anet node loop --help` should show the new help text
+echo ""
+echo "5. Verifying 'anet node loop --help' shows the new command..."
+HELP_OUT=$(anet node loop --help 2>&1 || true)
+if echo "$HELP_OUT" | grep -q "anet node loop"; then
+  pass "anet node loop --help shows command usage"
+else
+  fail "anet node loop --help missing — command not wired in installed package"
+  echo "$HELP_OUT" | head -10
+fi
+
+# 6. Full e2e: hub + node + CLI loop creation, using ONLY the installed
+#    binaries (no /app/ source paths in the run)
+echo ""
+echo "6. Full e2e using installed binaries..."
+rm -f /tmp/commhub-pack.db /tmp/commhub-pack.db-wal /tmp/commhub-pack.db-shm
+COMMHUB_DB=/tmp/commhub-pack.db PORT=9211 \
+  commhub-server > /tmp/pack-hub.log 2>&1 &
+HUB_PID=$!
+sleep 4
+curl -s http://127.0.0.1:9211/health | grep -q '"ok":true' \
+  && pass "commhub-server (from .tgz) started on :9211" \
+  || { fail "commhub-server failed"; cat /tmp/pack-hub.log | tail -20; exit 1; }
+
+REG=$(curl -s -X POST http://127.0.0.1:9211/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username":"pack-test","password":"PackTestPw123","display_name":"pack test"}')
+NET_TOKEN=$(echo "$REG" | python3 -c "import sys,json;print(json.load(sys.stdin).get('network_token',''))")
+NET_ID=$(echo "$REG" | python3 -c "import sys,json;print(json.load(sys.stdin).get('network_id',''))")
+
+ALIAS="pack-test-claude"
+WORKDIR="/tmp/pack-test-claude"
+rm -rf "$WORKDIR"
+mkdir -p "$WORKDIR/.anet/nodes/$ALIAS"
+cat > "$WORKDIR/.anet/nodes/$ALIAS/config.json" <<EOF
+{
+  "alias": "$ALIAS",
+  "runtime": "claude-agent-sdk",
+  "hub": "http://127.0.0.1:9211",
+  "model": "claude-sonnet-4-6",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+}
+EOF
+
+cd "$WORKDIR"
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS" \
+  --config "$WORKDIR/.anet/nodes/$ALIAS/config.json" \
+  > /tmp/pack-agent.log 2>&1 &
+AGENT_PID=$!
+
+DEADLINE=$(($(date +%s) + 12))
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "已注册到 CommHub" /tmp/pack-agent.log && break
+  sleep 1
+done
+
+# THE LOAD-BEARING CHECK: real installed `anet` binary on real
+# installed agent-node, real user CLI flow.
+COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9211" \
+  anet node loop "$ALIAS" "pack-install probe" --every 5m \
+  > /tmp/pack-cli.log 2>&1 || true
+
+if grep -q "✅ Scheduled loop" /tmp/pack-cli.log; then
+  pass "anet node loop (from .tgz install) → goal created end-to-end"
+elif grep -q "❌ Node rejected" /tmp/pack-cli.log; then
+  fail "installed anet rejected /loop — parser/CLI not wired same in .tgz"
+  cat /tmp/pack-cli.log
+elif grep -q "did not confirm" /tmp/pack-cli.log; then
+  fail "installed anet did not get reply — install path silent-fail"
+  cat /tmp/pack-cli.log
+  echo "--- agent log ---"
+  tail -20 /tmp/pack-agent.log
+else
+  fail "unexpected CLI output:"
+  cat /tmp/pack-cli.log
+fi
+
+# Verify goal landed in the workdir's goals.json
+GOAL_COUNT=$(python3 -c "import json,os;p='$WORKDIR/.anet/nodes/$ALIAS/goals.json';d=json.load(open(p)) if os.path.exists(p) else {};print(len([g for g in d.get('goals',[]) if g.get('status')=='active']))" 2>/dev/null)
+if [ "$GOAL_COUNT" -ge 1 ]; then
+  pass "goals.json: $GOAL_COUNT active goal(s) — full install→CLI→parser→goal path verified"
+else
+  fail "goals.json: no active goal after install path"
+fi
+
+# Cleanup
+kill $AGENT_PID 2>/dev/null || true
+kill $HUB_PID 2>/dev/null || true
+wait $AGENT_PID $HUB_PID 2>/dev/null || true
+
+echo ""
+echo "========================================="
+echo "  npm-pack smoke: $PASS pass, $FAIL fail"
+echo "========================================="
+
+if [ $FAIL -eq 0 ]; then
+  echo "🎉 npm-pack install path verified — user install will work"
+  exit 0
+else
+  echo "❌ npm-pack install regression — user install would break"
+  exit 1
+fi

--- a/tests/docker-e2e-loop-runtime.sh
+++ b/tests/docker-e2e-loop-runtime.sh
@@ -61,8 +61,22 @@ NET_ID=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(
   || { fail "user registration failed: $REG"; exit 1; }
 
 # 2. Test claude-agent-sdk runtime — the load-bearing one
+#
+# This test exercises the FULL user path:
+#
+#   1. Start the node (no pre-injected goals.json)
+#   2. Run the real `anet node loop` CLI command (the one Vincent will type)
+#   3. CLI emits `/loop 5m <task>` via /api/task
+#   4. Node inbox handler routes through parser.parseGoalCommand
+#   5. Goal lands in goals.json
+#   6. Scheduler tick fires [goal] wake
+#
+# Previous e2e iteration wrote goals.json directly, bypassing the
+# parser — that hid the silent-fail bug independent-reviewer caught
+# on round 6 (`5m` was not in parser's word-only INTERVAL_PATTERNS).
+
 echo ""
-echo "2. claude-agent-sdk runtime — scheduler enable + wake fire..."
+echo "2. claude-agent-sdk runtime — full CLI → parser → goal → wake fire..."
 
 ALIAS_CLAUDE="loop-test-claude"
 WORKDIR_CLAUDE="/tmp/loop-test-claude"
@@ -76,79 +90,145 @@ cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" <<EOF
   "model": "claude-sonnet-4-6",
   "token": "$NET_TOKEN",
   "network_id": "$NET_ID",
-  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000", "goalAcceptSubMinute": true }
 }
 EOF
-
-# Pre-inject a claude-runtime goal with 5s interval, next_wake_at = now
-# so the very first tick after startup fires it.
-NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
-PAST_ISO=$(date -u -d "1 minute ago" +%Y-%m-%dT%H:%M:%S.000Z)
-GOAL_ID="goal-claude-e2e-${RANDOM}"
-cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json" <<EOF
-{
-  "version": 1,
-  "goals": [
-    {
-      "goal_id": "$GOAL_ID",
-      "text": "e2e probe: confirm scheduler fires this wake",
-      "status": "active",
-      "interval_ms": 5000,
-      "next_wake_at": "$PAST_ISO",
-      "runtime": "claude-agent-sdk",
-      "created_at": "$NOW_ISO",
-      "updated_at": "$NOW_ISO",
-      "progress_log": []
-    }
-  ]
-}
-EOF
-pass "pre-injected claude-runtime goal (id=${GOAL_ID:0:8}, interval=5s, next_wake_at in past)"
+# NOTE: the test uses interval `5m` which the parser enforces as
+# 60_000 ms minimum. Real wake firing in 25s requires interval >= tick
+# (default 30s, here 5s) AND >= MIN_INTERVAL (60s). To make the wake
+# fire FAST without weakening MIN_INTERVAL in the parser, we register
+# the goal via CLI with --every 5m (parser accepts) then BEFORE the
+# first tick we hand-set next_wake_at into the past by editing
+# goals.json. This proves: (a) CLI→parser→goal landed (real path),
+# (b) the wake actually fires. We need NO mock for parser/CLI.
 
 cd "$WORKDIR_CLAUDE"
-# Use a bogus API key — the SDK call inside processTask WILL fail at
-# the LLM layer, but we observe the wake log which fires BEFORE the
-# call. Captures stdout+stderr to /tmp/claude-agent.log.
+# Bogus key — SDK call inside wake will fail at LLM layer; the wake
+# log fires BEFORE that, which is what we assert.
 ANTHROPIC_API_KEY="test-no-real-call" \
-  timeout 30 agent-node \
+  timeout 60 agent-node \
   --alias "$ALIAS_CLAUDE" \
   --config "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" \
   > /tmp/claude-agent.log 2>&1 &
 CLAUDE_PID=$!
 
-# Wait up to 25s for both expected log lines to appear.
-DEADLINE=$(($(date +%s) + 25))
+# Wait for the node to register before sending the CLI command.
+DEADLINE=$(($(date +%s) + 15))
 SAW_ENABLE=0
-SAW_WAKE=0
+SAW_REGISTERED=0
 while [ $(date +%s) -lt $DEADLINE ]; do
   grep -q "goals scheduler: enabled (runtime=claude" /tmp/claude-agent.log && SAW_ENABLE=1
-  grep -q "\[goal\] wake ${GOAL_ID:0:8}" /tmp/claude-agent.log && SAW_WAKE=1
-  if [ $SAW_ENABLE -eq 1 ] && [ $SAW_WAKE -eq 1 ]; then break; fi
+  grep -q "已注册到 CommHub" /tmp/claude-agent.log && SAW_REGISTERED=1
+  if [ $SAW_ENABLE -eq 1 ] && [ $SAW_REGISTERED -eq 1 ]; then break; fi
   sleep 1
 done
-
-kill $CLAUDE_PID 2>/dev/null || true
-wait $CLAUDE_PID 2>/dev/null || true
 
 if [ $SAW_ENABLE -eq 1 ]; then
   pass "claude-agent-sdk: 'goals scheduler: enabled (runtime=claude...)' (gate removed ✓)"
 else
   fail "claude-agent-sdk: scheduler NOT enabled — gate still blocking"
-  echo "  --- tail of /tmp/claude-agent.log ---"
   tail -30 /tmp/claude-agent.log
+  exit 1
 fi
+
+# Now run the REAL CLI command users will type. This exercises:
+# CLI → /api/task → node inbox → parseGoalCommand → createScheduledGoal
+# → goals.json upsert. The CLI itself polls for the node's reply so
+# we get "node confirmed" or "node rejected" surfacing.
+echo "  Running: anet node loop $ALIAS_CLAUDE \"e2e probe\" --every 5m"
+# CLI reads --token / COMMHUB_TOKEN / loadGlobal().token. Use env so
+# we don't need to write a config file.
+COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CLAUDE" "e2e probe — please ack" --every 5m \
+  > /tmp/cli-loop.log 2>&1 || true
+
+if grep -q "✅ Scheduled loop" /tmp/cli-loop.log; then
+  pass "anet node loop: CLI confirmed goal creation (real user path ✓)"
+elif grep -q "❌ Node rejected" /tmp/cli-loop.log; then
+  fail "anet node loop: node REJECTED the /loop (parser regression?)"
+  cat /tmp/cli-loop.log
+  exit 1
+elif grep -q "did not confirm goal creation" /tmp/cli-loop.log; then
+  fail "anet node loop: node did not reply within 15s (might be silent-fail or slow node)"
+  cat /tmp/cli-loop.log
+  echo "--- agent log tail ---"
+  tail -30 /tmp/claude-agent.log
+  exit 1
+else
+  fail "anet node loop: unexpected CLI output"
+  cat /tmp/cli-loop.log
+  exit 1
+fi
+
+# Verify the goal landed in goals.json (filesystem confirmation)
+if [ -f "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json" ]; then
+  GOAL_COUNT=$(python3 -c "import json;d=json.load(open('$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json'));print(len([g for g in d.get('goals',[]) if g.get('status')=='active']))" 2>/dev/null)
+  if [ "$GOAL_COUNT" -ge 1 ]; then
+    pass "goals.json: $GOAL_COUNT active goal(s) persisted (parser → upsert path ✓)"
+  else
+    fail "goals.json: no active goals (CLI reported success but parser may have rejected)"
+    cat "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json"
+    exit 1
+  fi
+else
+  fail "goals.json does not exist after CLI succeeded — silent-fail regression"
+  exit 1
+fi
+
+# To observe a real fire within the test deadline, we restart the node
+# after editing next_wake_at into the past. (The node holds goals in
+# memory; an external file edit doesn't re-trigger load. Restart is a
+# realistic user flow — nodes restart routinely, see scheduler picks
+# up persisted past-due goals on next boot.)
+GOAL_ID=$(python3 -c "import json;d=json.load(open('$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json'));print(d['goals'][0]['goal_id'])")
+
+# Stop the live node first
+kill $CLAUDE_PID 2>/dev/null || true
+wait $CLAUDE_PID 2>/dev/null || true
+
+# Edit goals.json: next_wake_at into the past
+python3 <<PY
+import json, datetime
+p = "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json"
+d = json.load(open(p))
+past = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+for g in d["goals"]:
+    g["next_wake_at"] = past
+json.dump(d, open(p, "w"))
+PY
+
+# Restart and watch for wake fire
+> /tmp/claude-agent2.log
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS_CLAUDE" \
+  --config "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" \
+  > /tmp/claude-agent2.log 2>&1 &
+CLAUDE_PID2=$!
+
+DEADLINE=$(($(date +%s) + 20))
+SAW_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "\[goal\] wake ${GOAL_ID:0:8}" /tmp/claude-agent2.log && SAW_WAKE=1
+  if [ $SAW_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $CLAUDE_PID2 2>/dev/null || true
+wait $CLAUDE_PID2 2>/dev/null || true
 
 if [ $SAW_WAKE -eq 1 ]; then
-  pass "claude-agent-sdk: '[goal] wake ${GOAL_ID:0:8}' fired (tick reaches goal ✓)"
+  pass "claude-agent-sdk: '[goal] wake ${GOAL_ID:0:8}' fired after restart (full CLI→parser→goal→wake path ✓)"
 else
-  fail "claude-agent-sdk: scheduler enabled but tick did NOT fire wake"
-  echo "  --- tail of /tmp/claude-agent.log ---"
-  tail -40 /tmp/claude-agent.log
+  fail "claude-agent-sdk: wake did NOT fire even after restart with past next_wake_at"
+  echo "--- agent2 log tail ---"
+  tail -30 /tmp/claude-agent2.log
+  exit 1
 fi
 
-# 3. Test codex-sdk runtime — light-touch (just the enable log)
+# 3. Test codex-sdk runtime — same full path, light-touch
 echo ""
-echo "3. codex-sdk runtime — startup enable log..."
+echo "3. codex-sdk runtime — startup enable + CLI loop + wake fire..."
 
 ALIAS_CODEX="loop-test-codex"
 WORKDIR_CODEX="/tmp/loop-test-codex"
@@ -166,29 +246,9 @@ cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" <<EOF
 }
 EOF
 
-CODEX_GOAL_ID="goal-codex-e2e-${RANDOM}"
-cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/goals.json" <<EOF
-{
-  "version": 1,
-  "goals": [
-    {
-      "goal_id": "$CODEX_GOAL_ID",
-      "text": "e2e probe codex",
-      "status": "active",
-      "interval_ms": 5000,
-      "next_wake_at": "$PAST_ISO",
-      "runtime": "codex-sdk",
-      "created_at": "$NOW_ISO",
-      "updated_at": "$NOW_ISO",
-      "progress_log": []
-    }
-  ]
-}
-EOF
-
 cd "$WORKDIR_CODEX"
 OPENAI_API_KEY="test-no-real-call" \
-  timeout 20 agent-node \
+  timeout 60 agent-node \
   --alias "$ALIAS_CODEX" \
   --config "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" \
   > /tmp/codex-agent.log 2>&1 &
@@ -196,16 +256,13 @@ CODEX_PID=$!
 
 DEADLINE=$(($(date +%s) + 15))
 SAW_CODEX_ENABLE=0
-SAW_CODEX_WAKE=0
+SAW_CODEX_REGISTERED=0
 while [ $(date +%s) -lt $DEADLINE ]; do
   grep -q "goals scheduler: enabled (runtime=codex" /tmp/codex-agent.log && SAW_CODEX_ENABLE=1
-  grep -q "\[goal\] wake ${CODEX_GOAL_ID:0:8}" /tmp/codex-agent.log && SAW_CODEX_WAKE=1
-  if [ $SAW_CODEX_ENABLE -eq 1 ] && [ $SAW_CODEX_WAKE -eq 1 ]; then break; fi
+  grep -q "已注册到 CommHub" /tmp/codex-agent.log && SAW_CODEX_REGISTERED=1
+  if [ $SAW_CODEX_ENABLE -eq 1 ] && [ $SAW_CODEX_REGISTERED -eq 1 ]; then break; fi
   sleep 1
 done
-
-kill $CODEX_PID 2>/dev/null || true
-wait $CODEX_PID 2>/dev/null || true
 
 if [ $SAW_CODEX_ENABLE -eq 1 ]; then
   pass "codex-sdk: 'goals scheduler: enabled (runtime=codex)' ✓"
@@ -214,13 +271,352 @@ else
   tail -20 /tmp/codex-agent.log
 fi
 
+# Real CLI path for codex too — covers `2h` single-letter variant.
+COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CODEX" "e2e probe codex" --every 2h \
+  > /tmp/cli-codex.log 2>&1 || true
+
+if grep -q "✅ Scheduled loop" /tmp/cli-codex.log; then
+  pass "codex-sdk: 'anet node loop --every 2h' confirmed by node (CLI path ✓)"
+else
+  fail "codex-sdk: CLI loop creation did not confirm"
+  cat /tmp/cli-codex.log
+  exit 1
+fi
+
+CODEX_GOAL_ID=$(python3 -c "import json;d=json.load(open('$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/goals.json'));print(d['goals'][0]['goal_id'])")
+
+# Same restart pattern as claude
+kill $CODEX_PID 2>/dev/null || true
+wait $CODEX_PID 2>/dev/null || true
+
+python3 <<PY
+import json, datetime
+p = "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/goals.json"
+d = json.load(open(p))
+past = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+for g in d["goals"]:
+    g["next_wake_at"] = past
+json.dump(d, open(p, "w"))
+PY
+
+> /tmp/codex-agent2.log
+OPENAI_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS_CODEX" \
+  --config "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" \
+  > /tmp/codex-agent2.log 2>&1 &
+CODEX_PID2=$!
+
+DEADLINE=$(($(date +%s) + 20))
+SAW_CODEX_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "\[goal\] wake ${CODEX_GOAL_ID:0:8}" /tmp/codex-agent2.log && SAW_CODEX_WAKE=1
+  if [ $SAW_CODEX_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $CODEX_PID2 2>/dev/null || true
+wait $CODEX_PID2 2>/dev/null || true
+
 if [ $SAW_CODEX_WAKE -eq 1 ]; then
-  pass "codex-sdk: '[goal] wake ${CODEX_GOAL_ID:0:8}' fired ✓"
+  pass "codex-sdk: '[goal] wake ${CODEX_GOAL_ID:0:8}' fired after CLI→parser→goal landed ✓"
 else
   fail "codex-sdk: tick did NOT fire wake"
 fi
 
-# 4. Cleanup
+# 4. Channel /loop path (commhub_send_task with /loop slash — same
+#    user entry that a chatting user / another agent uses)
+echo ""
+echo "4. Channel /loop slash path (commhub_send_task)..."
+
+ALIAS_CH="loop-test-channel"
+WORKDIR_CH="/tmp/loop-test-channel"
+rm -rf "$WORKDIR_CH"
+mkdir -p "$WORKDIR_CH/.anet/nodes/$ALIAS_CH"
+cat > "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/config.json" <<EOF
+{
+  "alias": "$ALIAS_CH",
+  "runtime": "claude-agent-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "claude-sonnet-4-6",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+}
+EOF
+
+cd "$WORKDIR_CH"
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS_CH" \
+  --config "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/config.json" \
+  > /tmp/channel-agent.log 2>&1 &
+CH_PID=$!
+
+DEADLINE=$(($(date +%s) + 10))
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "已注册到 CommHub" /tmp/channel-agent.log && break
+  sleep 1
+done
+
+# Send a /loop via /api/task directly (same shape as commhub_send_task MCP tool)
+CH_RESP=$(curl -s -X POST http://127.0.0.1:9210/api/task \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NET_TOKEN" \
+  -d "{\"alias\":\"$ALIAS_CH\",\"task\":\"/loop 1d nightly cleanup\",\"priority\":\"normal\",\"from\":\"channel-test\",\"network_id\":\"$NET_ID\"}")
+CH_TASK_ID=$(echo "$CH_RESP" | python3 -c "import sys,json;print(json.load(sys.stdin).get('task_id',''))" 2>/dev/null)
+sleep 3
+
+# Verify goals.json has it
+if [ -f "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/goals.json" ]; then
+  CH_GOAL_COUNT=$(python3 -c "import json;d=json.load(open('$WORKDIR_CH/.anet/nodes/$ALIAS_CH/goals.json'));print(len([g for g in d.get('goals',[]) if g.get('status')=='active' and g.get('interval_ms')==86400000]))" 2>/dev/null)
+  if [ "$CH_GOAL_COUNT" -ge 1 ]; then
+    pass "channel /loop: 1d goal created via raw /api/task (interval=86400000ms)"
+  else
+    fail "channel /loop: goal not persisted"
+    cat "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/goals.json"
+  fi
+else
+  fail "channel /loop: goals.json missing"
+fi
+kill $CH_PID 2>/dev/null || true
+wait $CH_PID 2>/dev/null || true
+
+# 5. Interval format edge cases (CLI argv validation)
+echo ""
+echo "5. Interval format edge cases (CLI argv validation)..."
+
+# 5a. Sub-minute MUST be rejected at CLI layer (no silent success)
+SUB_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CLAUDE" "x" --every 30s 2>&1 || true)
+if echo "$SUB_OUT" | grep -q "Invalid --every"; then
+  pass "interval 30s: CLI rejects with clear error (no silent ✓ success)"
+else
+  fail "interval 30s: CLI did not reject"
+  echo "$SUB_OUT" | head -5
+fi
+
+# 5b. Bogus format
+BOG_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CLAUDE" "x" --every 5x 2>&1 || true)
+if echo "$BOG_OUT" | grep -q "Invalid --every"; then
+  pass "interval 5x: CLI rejects with clear error"
+else
+  fail "interval 5x: CLI did not reject"
+fi
+
+# 5c. Empty --every
+EMP_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CLAUDE" "x" --every "" 2>&1 || true)
+if echo "$EMP_OUT" | grep -q "Invalid --every"; then
+  pass "interval empty: CLI rejects with clear error"
+else
+  fail "interval empty: CLI did not reject"
+fi
+
+# 6. anet goal list + cancel
+echo ""
+echo "6. anet goal list + cancel..."
+
+# anet goal resolves nodes via $cwd/.anet/nodes — must cd into the
+# workdir that has the node profile (created by the agent's
+# --config write at startup).
+cd "$WORKDIR_CLAUDE"
+LIST_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet goal list "$ALIAS_CLAUDE" 2>&1 || true)
+if echo "$LIST_OUT" | grep -q "$GOAL_ID\|5min\|active"; then
+  pass "anet goal list: shows the created goal"
+else
+  fail "anet goal list: goal not visible"
+  echo "  --- list output ---"
+  echo "$LIST_OUT" | head -10
+fi
+
+CANCEL_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet goal cancel "$ALIAS_CLAUDE" "${GOAL_ID:0:8}" 2>&1 || true)
+if echo "$CANCEL_OUT" | grep -qi "cancelled\|已取消\|status.*cancelled"; then
+  pass "anet goal cancel: goal cancelled"
+else
+  fail "anet goal cancel: did not confirm cancellation"
+  echo "  --- cancel output ---"
+  echo "$CANCEL_OUT" | head -5
+fi
+
+# Verify cancel landed in goals.json
+CANCELLED_COUNT=$(python3 -c "import json;d=json.load(open('$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json'));print(len([g for g in d.get('goals',[]) if g.get('status')=='cancelled']))" 2>/dev/null)
+if [ "$CANCELLED_COUNT" -ge 1 ]; then
+  pass "goals.json: goal status flipped to 'cancelled' (no longer active)"
+else
+  fail "goals.json: cancel didn't persist"
+fi
+cd - > /dev/null
+
+# 6b. grok-build-acp runtime — startup enable + scheduler picks goal
+echo ""
+echo "6b. grok-build-acp runtime — startup enable + goal fire..."
+
+ALIAS_GROK="loop-test-grok"
+WORKDIR_GROK="/tmp/loop-test-grok"
+rm -rf "$WORKDIR_GROK"
+mkdir -p "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK"
+cat > "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK/config.json" <<EOF
+{
+  "alias": "$ALIAS_GROK",
+  "runtime": "grok-build-acp",
+  "hub": "http://127.0.0.1:9210",
+  "model": "grok-build",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "goalTickMs": "5000" }
+}
+EOF
+
+# Pre-create a grok-runtime goal (no real grok binary needed for the
+# scheduler-tick observation; SDK call inside processTask will fail
+# but the wake log fires BEFORE that — matches the claude pattern).
+GROK_GOAL="$(python3 -c "import uuid;print(uuid.uuid4())")"
+PAST=$(python3 -c "import datetime;print((datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z'))")
+NOW=$(python3 -c "import datetime;print(datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%dT%H:%M:%S.000Z'))")
+cat > "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$GROK_GOAL",
+      "text": "grok smoke probe",
+      "status": "active",
+      "interval_ms": 60000,
+      "next_wake_at": "$PAST",
+      "runtime": "grok-build-acp",
+      "created_at": "$NOW",
+      "updated_at": "$NOW",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+
+cd "$WORKDIR_GROK"
+timeout 20 agent-node \
+  --alias "$ALIAS_GROK" \
+  --config "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK/config.json" \
+  > /tmp/grok-agent.log 2>&1 &
+GROK_PID=$!
+
+DEADLINE=$(($(date +%s) + 15))
+SAW_GROK_ENABLE=0
+SAW_GROK_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "goals scheduler: enabled (runtime=grok" /tmp/grok-agent.log && SAW_GROK_ENABLE=1
+  grep -q "\[goal\] wake ${GROK_GOAL:0:8}" /tmp/grok-agent.log && SAW_GROK_WAKE=1
+  if [ $SAW_GROK_ENABLE -eq 1 ] && [ $SAW_GROK_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $GROK_PID 2>/dev/null || true
+wait $GROK_PID 2>/dev/null || true
+
+if [ $SAW_GROK_ENABLE -eq 1 ]; then
+  pass "grok-build-acp: 'goals scheduler: enabled (runtime=grok)' ✓"
+else
+  fail "grok-build-acp: scheduler NOT enabled"
+  tail -20 /tmp/grok-agent.log
+fi
+
+if [ $SAW_GROK_WAKE -eq 1 ]; then
+  pass "grok-build-acp: '[goal] wake ${GROK_GOAL:0:8}' fired ✓"
+else
+  fail "grok-build-acp: tick did NOT fire wake"
+fi
+
+# 6c. Multi-cycle wake — confirm scheduler fires REPEATEDLY (not just once)
+echo ""
+echo "6c. Multi-cycle wake — verify the scheduler fires the SAME goal repeatedly..."
+
+ALIAS_MULTI="loop-test-multi"
+WORKDIR_MULTI="/tmp/loop-test-multi"
+rm -rf "$WORKDIR_MULTI"
+mkdir -p "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI"
+cat > "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI/config.json" <<EOF
+{
+  "alias": "$ALIAS_MULTI",
+  "runtime": "codex-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "gpt-5.5",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "goalTickMs": "5000" }
+}
+EOF
+
+MULTI_GOAL="$(python3 -c "import uuid;print(uuid.uuid4())")"
+# 60s interval (parser min) + 5s tick. Past next_wake_at so first
+# fire is immediate; second fire ~60s later; third ~120s.
+cat > "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$MULTI_GOAL",
+      "text": "multi-cycle probe",
+      "status": "active",
+      "interval_ms": 60000,
+      "next_wake_at": "$PAST",
+      "runtime": "codex-sdk",
+      "created_at": "$NOW",
+      "updated_at": "$NOW",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+
+cd "$WORKDIR_MULTI"
+OPENAI_API_KEY="test-no-real-call" \
+  timeout 140 agent-node \
+  --alias "$ALIAS_MULTI" \
+  --config "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI/config.json" \
+  > /tmp/multi-agent.log 2>&1 &
+MULTI_PID=$!
+
+# Wait for 2 wakes minimum (first fires immediately, second after
+# ~60s interval). 130s window gives generous margin.
+DEADLINE=$(($(date +%s) + 130))
+while [ $(date +%s) -lt $DEADLINE ]; do
+  WAKE_COUNT=$(grep -c "\[goal\] wake ${MULTI_GOAL:0:8}" /tmp/multi-agent.log 2>/dev/null || echo 0)
+  if [ "$WAKE_COUNT" -ge 2 ]; then break; fi
+  sleep 5
+done
+
+kill $MULTI_PID 2>/dev/null || true
+wait $MULTI_PID 2>/dev/null || true
+
+WAKE_COUNT=$(grep -c "\[goal\] wake ${MULTI_GOAL:0:8}" /tmp/multi-agent.log 2>/dev/null || echo 0)
+if [ "$WAKE_COUNT" -ge 2 ]; then
+  pass "multi-cycle: scheduler fired the same goal $WAKE_COUNT times (proves not one-shot)"
+else
+  fail "multi-cycle: only $WAKE_COUNT wake(s) observed in 130s window (expected ≥2)"
+  echo "  --- multi-agent log tail ---"
+  tail -25 /tmp/multi-agent.log
+fi
+
+# 7. Offline node behavior — CLI polls + times out cleanly
+echo ""
+echo "7. Offline node behavior (CLI must fail clearly, not silent ✅)..."
+
+OFF_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  timeout 25 anet node loop "$ALIAS_CLAUDE" "this node is dead" --every 5m 2>&1 || true)
+if echo "$OFF_OUT" | grep -q "did not confirm\|node offline"; then
+  pass "offline node: CLI reports timeout (does NOT print false ✅)"
+elif echo "$OFF_OUT" | grep -q "✅ Scheduled"; then
+  fail "offline node: CLI printed false success ✓ — silent-fail regression"
+  echo "$OFF_OUT" | head -10
+else
+  pass "offline node: CLI did not print ✅ (alternative non-success output OK)"
+fi
+
+# 8. Cleanup
 kill $HUB_PID 2>/dev/null || true
 
 echo ""

--- a/tests/docker-e2e-loop-runtime.sh
+++ b/tests/docker-e2e-loop-runtime.sh
@@ -22,6 +22,25 @@
 #     avoid). The wake log fires BEFORE the SDK call.
 
 set -e
+
+# Safe-rm guardrail per the 2026-06-16 incident — refuses to `rm -rf`
+# anything outside /tmp/*. Drop-in `safe_rm_rf` replaces every bare
+# `rm -rf "$VAR"` in this script. lint guard enforces this on PR.
+SAFE_RM_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/safe-rm.sh"
+if [ -f "$SAFE_RM_LIB" ]; then
+  source "$SAFE_RM_LIB"
+else
+  # Fallback for Docker runs where the script is mounted standalone
+  # (the lib lives at /app/tests/lib/ when copied via Dockerfile).
+  for cand in /app/tests/lib/safe-rm.sh /app/lib/safe-rm.sh; do
+    [ -f "$cand" ] && source "$cand" && break
+  done
+fi
+type safe_rm_rf > /dev/null 2>&1 || {
+  echo "FATAL: safe-rm.sh not found — refusing to run with bare rm -rf"
+  exit 99
+}
+
 PASS=0
 FAIL=0
 
@@ -80,7 +99,7 @@ echo "2. claude-agent-sdk runtime — full CLI → parser → goal → wake fire
 
 ALIAS_CLAUDE="loop-test-claude"
 WORKDIR_CLAUDE="/tmp/loop-test-claude"
-rm -rf "$WORKDIR_CLAUDE"
+safe_rm_rf "$WORKDIR_CLAUDE"
 mkdir -p "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE"
 cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" <<EOF
 {
@@ -232,7 +251,7 @@ echo "3. codex-sdk runtime — startup enable + CLI loop + wake fire..."
 
 ALIAS_CODEX="loop-test-codex"
 WORKDIR_CODEX="/tmp/loop-test-codex"
-rm -rf "$WORKDIR_CODEX"
+safe_rm_rf "$WORKDIR_CODEX"
 mkdir -p "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX"
 cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" <<EOF
 {
@@ -332,7 +351,7 @@ echo "4. Channel /loop slash path (commhub_send_task)..."
 
 ALIAS_CH="loop-test-channel"
 WORKDIR_CH="/tmp/loop-test-channel"
-rm -rf "$WORKDIR_CH"
+safe_rm_rf "$WORKDIR_CH"
 mkdir -p "$WORKDIR_CH/.anet/nodes/$ALIAS_CH"
 cat > "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/config.json" <<EOF
 {
@@ -458,7 +477,7 @@ echo "6b. grok-build-acp runtime — startup enable + goal fire..."
 
 ALIAS_GROK="loop-test-grok"
 WORKDIR_GROK="/tmp/loop-test-grok"
-rm -rf "$WORKDIR_GROK"
+safe_rm_rf "$WORKDIR_GROK"
 mkdir -p "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK"
 cat > "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK/config.json" <<EOF
 {
@@ -536,7 +555,7 @@ echo "6c. Multi-cycle wake — verify the scheduler fires the SAME goal repeated
 
 ALIAS_MULTI="loop-test-multi"
 WORKDIR_MULTI="/tmp/loop-test-multi"
-rm -rf "$WORKDIR_MULTI"
+safe_rm_rf "$WORKDIR_MULTI"
 mkdir -p "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI"
 cat > "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI/config.json" <<EOF
 {
@@ -584,7 +603,8 @@ MULTI_PID=$!
 # ~60s interval). 130s window gives generous margin.
 DEADLINE=$(($(date +%s) + 130))
 while [ $(date +%s) -lt $DEADLINE ]; do
-  WAKE_COUNT=$(grep -c "\[goal\] wake ${MULTI_GOAL:0:8}" /tmp/multi-agent.log 2>/dev/null || echo 0)
+  WAKE_COUNT=$( { grep -c "\[goal\] wake ${MULTI_GOAL:0:8}" /tmp/multi-agent.log 2>/dev/null || true; } | head -1)
+  WAKE_COUNT=${WAKE_COUNT:-0}
   if [ "$WAKE_COUNT" -ge 2 ]; then break; fi
   sleep 5
 done
@@ -599,6 +619,81 @@ else
   fail "multi-cycle: only $WAKE_COUNT wake(s) observed in 130s window (expected ≥2)"
   echo "  --- multi-agent log tail ---"
   tail -25 /tmp/multi-agent.log
+fi
+
+# 6d. Multi-cycle wake on **claude-agent-sdk** specifically
+#
+# 通信龙 spot-check tighten: the existing multi-cycle test (6c) ran
+# on codex. Scheduler is runtime-agnostic shared code, but claude
+# is Vincent's personally-tested runtime — pin its multi-cycle
+# behaviour rather than relying on transitive inference from codex.
+echo ""
+echo "6d. Multi-cycle wake — claude-agent-sdk (Vincent's runtime)..."
+
+ALIAS_CMULTI="loop-test-claude-multi"
+WORKDIR_CMULTI="/tmp/loop-test-claude-multi"
+safe_rm_rf "$WORKDIR_CMULTI"
+mkdir -p "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI"
+cat > "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI/config.json" <<EOF
+{
+  "alias": "$ALIAS_CMULTI",
+  "runtime": "claude-agent-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "claude-sonnet-4-6",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+}
+EOF
+
+CMULTI_GOAL="$(python3 -c "import uuid;print(uuid.uuid4())")"
+cat > "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$CMULTI_GOAL",
+      "text": "claude multi-cycle probe",
+      "status": "active",
+      "interval_ms": 60000,
+      "next_wake_at": "$PAST",
+      "runtime": "claude-agent-sdk",
+      "created_at": "$NOW",
+      "updated_at": "$NOW",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+
+cd "$WORKDIR_CMULTI"
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 140 agent-node \
+  --alias "$ALIAS_CMULTI" \
+  --config "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI/config.json" \
+  > /tmp/cmulti-agent.log 2>&1 &
+CMULTI_PID=$!
+
+# Same 130s window as 6c codex test.
+DEADLINE=$(($(date +%s) + 130))
+while [ $(date +%s) -lt $DEADLINE ]; do
+  CMULTI_WAKE_COUNT=$( { grep -c "\[goal\] wake ${CMULTI_GOAL:0:8}" /tmp/cmulti-agent.log 2>/dev/null || true; } | head -1)
+  CMULTI_WAKE_COUNT=${CMULTI_WAKE_COUNT:-0}
+  if [ "$CMULTI_WAKE_COUNT" -ge 2 ]; then break; fi
+  sleep 5
+done
+
+kill $CMULTI_PID 2>/dev/null || true
+wait $CMULTI_PID 2>/dev/null || true
+
+CMULTI_WAKE_COUNT=$( { grep -c "\[goal\] wake ${CMULTI_GOAL:0:8}" /tmp/cmulti-agent.log 2>/dev/null || true; } | head -1)
+CMULTI_WAKE_COUNT=${CMULTI_WAKE_COUNT:-0}
+if [ "$CMULTI_WAKE_COUNT" -ge 2 ]; then
+  pass "claude multi-cycle: scheduler fired same goal $CMULTI_WAKE_COUNT times (Vincent's runtime ✓ not inference)"
+else
+  fail "claude multi-cycle: only $CMULTI_WAKE_COUNT wake(s) observed in 130s window (expected ≥2)"
+  echo "  --- claude-multi log tail ---"
+  tail -25 /tmp/cmulti-agent.log
 fi
 
 # 7. Offline node behavior — CLI polls + times out cleanly
@@ -623,6 +718,9 @@ echo ""
 echo "========================================="
 echo "  Summary: $PASS pass, $FAIL fail"
 echo "========================================="
+# Also emit the format test-all.sh's run_suite parses
+# (`\d+(?= passed)` and `\d+(?= failed)`).
+echo "Results: $PASS passed, $FAIL failed"
 
 if [ $FAIL -eq 0 ]; then
   echo "🎉 All loop-runtime checks pass"

--- a/tests/docker-e2e-loop-runtime.sh
+++ b/tests/docker-e2e-loop-runtime.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# #144 round-6 — loop runtime gate end-to-end verification.
+#
+# Hard requirement from 通信龙: prove that after removing the claude
+# bucket skip, the scheduler ACTUALLY FIRES for claude-agent-sdk (the
+# runtime Vincent will personally test). Also light-touch confirm for
+# codex-sdk that startup-enables the scheduler.
+#
+# This test does NOT need a real Anthropic / OpenAI API key. We assert
+# the SCHEDULER FIRES (anet's responsibility) — not that the LLM call
+# inside the wake succeeds (vendor responsibility, out of scope).
+#
+# Pass criteria per runtime:
+#   1. Startup log shows `goals scheduler: enabled (runtime=<bucket>)`
+#   2. Within 30s a `[goal] wake <id>:` line appears for the pre-injected
+#      goal (proves the tick fires AND finds the goal AND begins
+#      processing it).
+#
+# What's deliberately NOT asserted:
+#   - That the LLM SDK call inside processTask succeeds (needs vendor
+#     auth + network; would re-introduce flakiness the test should
+#     avoid). The wake log fires BEFORE the SDK call.
+
+set -e
+PASS=0
+FAIL=0
+
+pass() { echo "  ✅ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+
+echo ""
+echo "========================================="
+echo "  #144 — Loop runtime gate E2E"
+echo "  Proves: scheduler fires for claude-agent-sdk + codex-sdk"
+echo "========================================="
+echo ""
+
+# 1. Start hub on isolated DB (COMMHUB_DB to /tmp/commhub-loop-test.db)
+echo "1. Starting CommHub (isolated DB)..."
+rm -f /tmp/commhub-loop-test.db /tmp/commhub-loop-test.db-wal /tmp/commhub-loop-test.db-shm
+COMMHUB_DB=/tmp/commhub-loop-test.db PORT=9210 \
+  bun run /app/server/src/index.ts > /tmp/hub.log 2>&1 &
+HUB_PID=$!
+sleep 3
+curl -s http://127.0.0.1:9210/health | grep -q '"ok":true' \
+  && pass "CommHub started on :9210" \
+  || { fail "CommHub failed to start"; cat /tmp/hub.log | tail -30; exit 1; }
+
+# Register a test user + grab a network token. report_status MCP tool
+# requires callerTokenIsNetwork (network-scoped token, not user token);
+# without it every status report 401s and the agent crashes before the
+# first scheduler tick.
+echo "  Registering test user..."
+REG=$(curl -s -X POST http://127.0.0.1:9210/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username":"loop-test","password":"LoopTestPw123","display_name":"loop test"}')
+USER_TOKEN=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('token',''))" 2>/dev/null)
+NET_TOKEN=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_token',''))" 2>/dev/null)
+NET_ID=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_id',''))" 2>/dev/null)
+[ -n "$NET_TOKEN" ] && pass "test user registered, network token issued (net=${NET_ID:0:12})" \
+  || { fail "user registration failed: $REG"; exit 1; }
+
+# 2. Test claude-agent-sdk runtime — the load-bearing one
+echo ""
+echo "2. claude-agent-sdk runtime — scheduler enable + wake fire..."
+
+ALIAS_CLAUDE="loop-test-claude"
+WORKDIR_CLAUDE="/tmp/loop-test-claude"
+rm -rf "$WORKDIR_CLAUDE"
+mkdir -p "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE"
+cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" <<EOF
+{
+  "alias": "$ALIAS_CLAUDE",
+  "runtime": "claude-agent-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "claude-sonnet-4-6",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+}
+EOF
+
+# Pre-inject a claude-runtime goal with 5s interval, next_wake_at = now
+# so the very first tick after startup fires it.
+NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+PAST_ISO=$(date -u -d "1 minute ago" +%Y-%m-%dT%H:%M:%S.000Z)
+GOAL_ID="goal-claude-e2e-${RANDOM}"
+cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$GOAL_ID",
+      "text": "e2e probe: confirm scheduler fires this wake",
+      "status": "active",
+      "interval_ms": 5000,
+      "next_wake_at": "$PAST_ISO",
+      "runtime": "claude-agent-sdk",
+      "created_at": "$NOW_ISO",
+      "updated_at": "$NOW_ISO",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+pass "pre-injected claude-runtime goal (id=${GOAL_ID:0:8}, interval=5s, next_wake_at in past)"
+
+cd "$WORKDIR_CLAUDE"
+# Use a bogus API key — the SDK call inside processTask WILL fail at
+# the LLM layer, but we observe the wake log which fires BEFORE the
+# call. Captures stdout+stderr to /tmp/claude-agent.log.
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS_CLAUDE" \
+  --config "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" \
+  > /tmp/claude-agent.log 2>&1 &
+CLAUDE_PID=$!
+
+# Wait up to 25s for both expected log lines to appear.
+DEADLINE=$(($(date +%s) + 25))
+SAW_ENABLE=0
+SAW_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "goals scheduler: enabled (runtime=claude" /tmp/claude-agent.log && SAW_ENABLE=1
+  grep -q "\[goal\] wake ${GOAL_ID:0:8}" /tmp/claude-agent.log && SAW_WAKE=1
+  if [ $SAW_ENABLE -eq 1 ] && [ $SAW_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $CLAUDE_PID 2>/dev/null || true
+wait $CLAUDE_PID 2>/dev/null || true
+
+if [ $SAW_ENABLE -eq 1 ]; then
+  pass "claude-agent-sdk: 'goals scheduler: enabled (runtime=claude...)' (gate removed ✓)"
+else
+  fail "claude-agent-sdk: scheduler NOT enabled — gate still blocking"
+  echo "  --- tail of /tmp/claude-agent.log ---"
+  tail -30 /tmp/claude-agent.log
+fi
+
+if [ $SAW_WAKE -eq 1 ]; then
+  pass "claude-agent-sdk: '[goal] wake ${GOAL_ID:0:8}' fired (tick reaches goal ✓)"
+else
+  fail "claude-agent-sdk: scheduler enabled but tick did NOT fire wake"
+  echo "  --- tail of /tmp/claude-agent.log ---"
+  tail -40 /tmp/claude-agent.log
+fi
+
+# 3. Test codex-sdk runtime — light-touch (just the enable log)
+echo ""
+echo "3. codex-sdk runtime — startup enable log..."
+
+ALIAS_CODEX="loop-test-codex"
+WORKDIR_CODEX="/tmp/loop-test-codex"
+rm -rf "$WORKDIR_CODEX"
+mkdir -p "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX"
+cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" <<EOF
+{
+  "alias": "$ALIAS_CODEX",
+  "runtime": "codex-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "gpt-5.5",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "goalTickMs": "5000" }
+}
+EOF
+
+CODEX_GOAL_ID="goal-codex-e2e-${RANDOM}"
+cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$CODEX_GOAL_ID",
+      "text": "e2e probe codex",
+      "status": "active",
+      "interval_ms": 5000,
+      "next_wake_at": "$PAST_ISO",
+      "runtime": "codex-sdk",
+      "created_at": "$NOW_ISO",
+      "updated_at": "$NOW_ISO",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+
+cd "$WORKDIR_CODEX"
+OPENAI_API_KEY="test-no-real-call" \
+  timeout 20 agent-node \
+  --alias "$ALIAS_CODEX" \
+  --config "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" \
+  > /tmp/codex-agent.log 2>&1 &
+CODEX_PID=$!
+
+DEADLINE=$(($(date +%s) + 15))
+SAW_CODEX_ENABLE=0
+SAW_CODEX_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "goals scheduler: enabled (runtime=codex" /tmp/codex-agent.log && SAW_CODEX_ENABLE=1
+  grep -q "\[goal\] wake ${CODEX_GOAL_ID:0:8}" /tmp/codex-agent.log && SAW_CODEX_WAKE=1
+  if [ $SAW_CODEX_ENABLE -eq 1 ] && [ $SAW_CODEX_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $CODEX_PID 2>/dev/null || true
+wait $CODEX_PID 2>/dev/null || true
+
+if [ $SAW_CODEX_ENABLE -eq 1 ]; then
+  pass "codex-sdk: 'goals scheduler: enabled (runtime=codex)' ✓"
+else
+  fail "codex-sdk: scheduler NOT enabled"
+  tail -20 /tmp/codex-agent.log
+fi
+
+if [ $SAW_CODEX_WAKE -eq 1 ]; then
+  pass "codex-sdk: '[goal] wake ${CODEX_GOAL_ID:0:8}' fired ✓"
+else
+  fail "codex-sdk: tick did NOT fire wake"
+fi
+
+# 4. Cleanup
+kill $HUB_PID 2>/dev/null || true
+
+echo ""
+echo "========================================="
+echo "  Summary: $PASS pass, $FAIL fail"
+echo "========================================="
+
+if [ $FAIL -eq 0 ]; then
+  echo "🎉 All loop-runtime checks pass"
+  exit 0
+else
+  echo "❌ Loop-runtime regression"
+  exit 1
+fi

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -77,6 +77,13 @@ run_suite "V3 Networks (22)" "/app/test-networks.sh 2>&1"
 reset_server
 run_suite "Config Priority (16)" "/app/test-config.sh 2>&1"
 
+# #144 round-6 — loop runtime gate + universal /loop scheduler
+# regression coverage. Each suite spins its OWN hub on a non-standard
+# port (9210, 9211) with isolated COMMHUB_DB, so they coexist with the
+# above suites that use :9200. No reset_server needed before these.
+run_suite "Loop runtime e2e (20)" "/app/test-loop-runtime.sh 2>&1"
+run_suite "Loop npm-pack install (12)" "/app/test-loop-npm-pack.sh 2>&1"
+
 echo ""
 echo "╔══════════════════════════════════════════════════╗"
 echo "║   Final Report                                    ║"


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why

Vincent priority: "除 Claude Code CLI 外其他 runtime loop 不起来". Real user-facing symptom: when you send `/loop ...` to a claude-agent-sdk node, the inbox gate silently drops the command. The LLM may say "I created a loop", but nothing is actually wired — `goals.json` stays empty, the scheduler stays asleep.

## Corrected root cause

The dispatch's initial audit claimed claude-agent-sdk was "mistakenly grouped with claude-code-cli". On design-first investigation (code reading + pure-function probe at every `runtime × goal` combination), the gate turned out to be **by design** per v0.4 §3.4 (commit `45c7909`), on the premise:

> "claude-agent-sdk agents use Claude Code's native /loop (CronCreate + ScheduleWakeup) inside the spawned `claude` binary"

This premise is **false** for SDK-spawned claude:

- `processWithClaude` calls `query()` from `@anthropic-ai/claude-agent-sdk` — a one-shot Promise per task
- Each query() spawns a short-lived child process that exits when the response resolves
- Native /loop (`CronCreate`/`ScheduleWakeup`) needs a long-running interactive CC REPL to host its callbacks
- Net result: the gate blocked anet /loop on the (incorrect) assumption there was a native /loop to defer to; in fact there was no /loop at all for claude-bucket runtimes

A pure-function probe established ground truth before any change:

| Runtime | Probe verdict |
|---|---|
| claude-agent-sdk + empty | skip ("native /loop in use") — wrong premise |
| claude bucket + any goal | throws via `assertNonClaudeRuntime` |
| codex-sdk + same-bucket | ok (worked) |
| grok-build-acp + same-bucket | ok (worked) |
| codex-sdk + grok goal | **fatal exit(1)** — hostile UX, separate bug |

## Refined-B fix (5 pieces, all in this PR)

### 1. Remove claude-bucket skip + `assertNonClaudeRuntime`

`goals/store.ts`:
- `CLAUDE_RUNTIME_NAMES` kept as a CLASSIFIER (for cross-bucket detection) but no longer load-bearing for any reject/throw
- `assertNonClaudeRuntime` removed entirely
- `newGoal({runtime: "claude-agent-sdk"})` now succeeds
- `GoalStore.upsert` accepts claude-bucket goals

### 2. Remove inbox `RUNTIME !== "claude"` carve-out

`agent-node/src/cli.ts:2584`:
- Pre-#144: `if (RUNTIME !== "claude" && isGoalCommand(content))` — claude /loop fell through to LLM as plain text
- Now: `if (isGoalCommand(content))` — all recognized runtimes route to `createScheduledGoal`

### 3. unknown bucket still skips (defensive)

If `--runtime <typo>` resolves to unknown, scheduler refuses to start. No name-bucket guess.

### 4. Cross-bucket: `fatal exit(1)` → `archive + continue` (hostile-UX fix)

Pre-#144 the codex↔grok cross-bucket case did `process.exit(1)`, silently killing the user's node with no recovery guidance. Now: archives the foreign goals to `<path>.runtime-switched.<ts>` (recoverable) + boots the scheduler against a clean store. No process exit. `StartupAction.fatal` variant removed from the type.

### 5. UX — `anet node loop` one-liner

```
anet node loop <alias> "<task>" --every 5m
```

Wraps the inbox `/loop <interval> <task>` slash command and POSTs as a normal task via `/api/task`. Default `--every` = 5m. Validates interval format (`Ns` / `Nm` / `Nh` / `Nd`). Surfaces hub-down errors clearly.

Matches Vincent's "使用简单" priority: one command, one verb, one recurring task.

## Tests

### Unit (agent-node)

```
src/goals/store.test.ts:   35 pass, 0 fail
src/ full suite:           329 pass, 0 fail, 686 expect()  — 2.84s
```

- claude runtime `newGoal/upsert` smoke (was throwing pre-#144)
- `decideStartupAction` matrix incl. **claude=ok**, **cross-bucket=archive+runScheduler=true** (regression pin vs old fatal-exit)
- unknown bucket still skips
- inactive foreign goals don't trigger archive

### Docker e2e — the load-bearing capability proof per 通信龙

`tests/docker-e2e-loop-runtime.sh`:
- Hub on :9210 with isolated `COMMHUB_DB`
- Registers test user → grabs network token (`report_status` needs network-scoped token)
- **claude-agent-sdk node**: pre-injected 5s-interval goal with `next_wake_at = past`. Asserts within 25s:
  - ✅ `goals scheduler: enabled (runtime=claude)` (gate gone)
  - ✅ `[goal] wake <id>` (tick fires)
- **codex-sdk node**: same shape, 15s deadline:
  - ✅ `goals scheduler: enabled (runtime=codex)`
  - ✅ `[goal] wake <id>`

**Result: 7 pass, 0 fail.** Both runtimes' schedulers verifiably FIRE the wake on the pre-injected goal — not just an architecture inference, an observed runtime event.

```
Summary: 7 pass, 0 fail
🎉 All loop-runtime checks pass
```

What's deliberately NOT asserted in e2e: that the LLM SDK call inside the wake succeeds end-to-end (needs vendor auth + network; would re-introduce flakiness). The wake log fires BEFORE the SDK call — gate-removal proof is what matters.

## Migration / rollback

| Scenario | Behaviour |
|---|---|
| Claude-bucket node + empty goals | Continues working; scheduler now enabled+idle instead of disabled |
| Claude-bucket node + codex/grok leftover | Foreign goals archived to `.runtime-switched.<ts>`; scheduler runs against clean store |
| Codex-bucket node + grok leftover | Same: archive + continue (was `exit(1)` pre-#144) |
| Existing valid goals | Untouched |

**Zero data loss.** The archive path preserves everything that gets moved.

**Rollback**: revert this commit; the gate comes back. Anyone who created claude-bucket goals post-deploy would have them archived next start under the restored gate (since the gate would archive them on claude-bucket boot).

## Review checklist

- [ ] `assertNonClaudeRuntime` removed (no throw on claude-bucket newGoal/upsert)
- [ ] inbox `/loop` accepts on all runtimes (no `RUNTIME !== "claude"` carve-out)
- [ ] decideStartupAction returns `archive` (not `fatal`) on cross-bucket
- [ ] No `process.exit(1)` left on any runtime-mismatch path
- [ ] Docker e2e green (claude scheduler-enable + wake fire / codex same)
- [ ] `anet node loop` CLI works end-to-end (build + dispatch verified)
- [ ] No real domains in commit/PR body (placeholder convention)

## Tracking

- Internal task: #144
- Sibling round-6: #285 (A1 KDF — auth)
- This is a **runtime behavior change** — 通信龙 will surface Vincent before merge per dispatch protocol.
