### PR TITLE
docs(#144): document anet node loop + universal /loop scheduler (ZH + EN parity)

### DIFF
--- a/docs-site/docs/en/guide/agent-node.md
+++ b/docs-site/docs/en/guide/agent-node.md
@@ -311,6 +311,62 @@ stateDiagram-v2
     GoOffline --> [*]: report_status(offline)
 ```
 
+### Recurring tasks / the `/loop` scheduler
+
+Starting with v0.11, **every runtime** (claude-agent-sdk / codex-sdk / grok-build-acp) supports anet's built-in /loop scheduler. Send an agent a `/loop <interval> <task>` message and the node persists it to its own `goals.json`; the scheduler then wakes the agent on the chosen interval, asks for an incremental advance, and reports progress.
+
+#### One-liner CLI (recommended)
+
+```bash
+# Check on PR #271 every 5 minutes
+anet node loop my-codex "monitor PR #271" --every 5m
+
+# Sweep Twitter every 30 minutes
+anet node loop researcher "scan twitter for grok updates" --every 30m
+
+# Post a morning summary every 2 hours
+anet node loop daily-bot "post the morning summary" --every 2h
+```
+
+Interval format: `30s` / `5m` / `2h` / `1d` (unit suffix required). `--every` defaults to `5m` when omitted.
+
+#### Or send a `/loop` message directly
+
+You can equivalently use `commhub_send_task` or the Dashboard to send a message that starts with `/loop`:
+
+```
+/loop 5m monitor PR #271
+/loop 30s check if the feishu bot is alive
+/loop 1d wrap up yesterday's release work
+```
+
+`/goal` is an alias of `/loop` and behaves identically.
+
+#### claude-agent-sdk can loop too (since v0.11)
+
+Between v0.4 and v0.10 the claude-agent-sdk runtime [could not /loop](#144) because of an incorrect design assumption (the gate assumed the SDK-spawned `claude` subprocess had its own native /loop; in fact the SDK is a one-shot `query()` Promise — the process exits after each call). v0.11 (#144) makes every runtime use anet's own scheduler:
+
+```bash
+# claude-agent-sdk nodes can now loop (v0.11+)
+anet node loop my-claude "check ANTHROPIC quota once a day" --every 1d
+```
+
+#### Inspect / cancel
+
+```bash
+# List loops on a node (drop the alias to list all nodes)
+anet goal list my-codex
+
+# Cancel by goal id (first 8 chars are enough — auto-unique-matched)
+anet goal cancel my-codex 3f8a2b1c
+```
+
+Goals are persisted in `~/.anet/nodes/<alias>/goals.json` and restored automatically after a restart.
+
+#### Tick interval
+
+Scheduler tick frequency is controlled by `ANET_GOAL_TICK_MS` (env) or `flags.goalTickMs` in config.json, default 30 seconds. A goal's `interval_ms` can never be more precise than the tick — a 5-second interval still effectively wakes every 30s. Lower the tick if you need finer granularity.
+
 ### Message Type Filtering
 
 Agent Node only triggers AI processing for `task` type messages:

--- a/docs-site/docs/guide/agent-node.md
+++ b/docs-site/docs/guide/agent-node.md
@@ -311,6 +311,62 @@ stateDiagram-v2
     下线 --> [*]: report_status(offline)
 ```
 
+### 循环任务 / `/loop` 调度器
+
+从 v0.11 起，**所有 runtime**（claude-agent-sdk / codex-sdk / grok-build-acp）都支持 anet 内置的 /loop 调度器。给 agent 发一个 `/loop <间隔> <任务>` 消息，节点会持久化到自己的 `goals.json`，按间隔自动唤醒、做一次增量推进、汇报进度。
+
+#### 一行命令调度（推荐）
+
+```bash
+# 每 5 分钟监控一次 PR #271
+anet node loop my-codex "监控 PR #271 进展" --every 5m
+
+# 每 30 分钟扫一次 Twitter
+anet node loop researcher "扫一遍 twitter 上 grok 的最新进展" --every 30m
+
+# 每 2 小时发一次晨报
+anet node loop daily-bot "发布今日早报" --every 2h
+```
+
+间隔格式：`30s` / `5m` / `2h` / `1d`（必须带单位）。命令在 `--every` 省略时默认 `5m`。
+
+#### 直接发 /loop 消息
+
+也可以用 `commhub_send_task` 或 dashboard 发一条以 `/loop` 开头的消息，效果等价：
+
+```
+/loop 5m 监控 #271 PR 进展
+/loop 30s 检查飞书 bot 是否在线
+/loop 1d 整理昨天的发布工作
+```
+
+`/goal` 是 `/loop` 的别名，效果一样。
+
+#### claude-agent-sdk 也能 loop（v0.11 起）
+
+v0.4–v0.10 期间 claude-agent-sdk runtime 因为 [设计前提错](#144) 不能 /loop（错误假设 SDK spawn 的 claude 子进程有自带 native /loop；实际 SDK 是单次 `query()` Promise，进程发完即退）。v0.11 (#144) 起所有 runtime 都走 anet 自己的调度器：
+
+```bash
+# claude-agent-sdk 节点也能 loop（v0.11+）
+anet node loop my-claude "每天检查一次 ANTHROPIC quota 余额" --every 1d
+```
+
+#### 查看 / 取消 loop
+
+```bash
+# 列出某节点所有 loop（也可以 anet goal ls 看全部节点）
+anet goal list my-codex
+
+# 按 goal id 取消（id 用前 8 位即可，会自动唯一匹配）
+anet goal cancel my-codex 3f8a2b1c
+```
+
+持久化文件在 `~/.anet/nodes/<alias>/goals.json`，节点重启自动恢复。
+
+#### 间隔 + 频率
+
+调度器 tick 间隔由 `ANET_GOAL_TICK_MS` 环境变量或 config.json `flags.goalTickMs` 控制，默认 30 秒。任何 goal 的 `interval_ms` 不会比 tick 间隔更精确——一个 5 秒间隔的 goal 实际上还是按 30 秒 tick 唤醒，按需调小 tick。
+
 ### 消息类型过滤
 
 Agent Node 只对 `task` 类型消息触发 AI 处理：


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why

Per 通信龙 dispatch — preview2 needs user docs for the new universal /loop scheduler that landed in #144 (`fix(agent-node): anet /loop universal across all runtimes`). Low-risk docs PR that doesn't add to the security-review queue (4 PRs already pending 通信牛).

## What changed

Added a **"循环任务 / /loop 调度器"** section to `docs-site/docs/guide/agent-node.md` (+ same-commit EN parity in `docs-site/docs/en/guide/agent-node.md`).

Content covers:

| Topic | Coverage |
|---|---|
| One-liner CLI | `anet node loop <alias> "<task>" --every 5m` with 3 examples (codex / researcher / daily-bot) |
| Inbox message form | `/loop <interval> <task>` (and `/goal` alias) |
| **claude-agent-sdk** specifically | Vincent's personally-tested runtime — explains v0.11+ now supports it, links back to #144 for design rationale |
| Interval format | `30s` / `5m` / `2h` / `1d` (unit suffix required) |
| Inspect / cancel | `anet goal list` / `anet goal cancel` |
| Tick interval | `ANET_GOAL_TICK_MS` / `flags.goalTickMs` (default 30s) |

## ZH + EN parity

Both files updated in the same commit per [[feedback_docs_zh_en_parity]]. EN translation preserves the same anchor structure (section headers, code-block ordering) so cross-language links don't drift.

## Test plan

- [ ] Local vitepress build green (`cd docs-site && bun run build`)
- [ ] ZH page renders without broken links
- [ ] EN page renders without broken links
- [ ] Cross-language anchors line up (both have `循环任务 / /loop 调度器` and `Recurring tasks / the /loop scheduler` at the same parent level)

## Tracking

- Internal task: #145
- Documents the user-facing surface of #144 (PR #288)
- Lands ahead of preview2 release per 通信龙 schedule
