### PR TITLE
[RFC-024 follow-up] hub-side restart-finalize via report_status content-match (Option A)

### DIFF
--- a/server/src/config-apply-sec1.test.ts
+++ b/server/src/config-apply-sec1.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, expect, test, beforeEach } from "bun:test";
 import { db, uuidv4 } from "./db.js";
-import { upsertNodeWithSec1Guard } from "./tools.js";
+import { upsertNodeWithSec1Guard, finalizePendingMatchingUpdates } from "./tools.js";
 
 function insertNode(opts: { node_id?: string; alias: string; network_id: string | null }): string {
   const id = opts.node_id ?? uuidv4();
@@ -442,6 +442,168 @@ describe("SEC trust-root — REAL driver via upsertNodeWithSec1Guard (catches gu
     const post = db.get<any>("SELECT network_id, alias FROM nodes WHERE node_id = ?1", nid);
     expect(post.network_id).toBe("netA");
     expect(post.alias).toBe("named-only");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// finalizePendingMatchingUpdates — Option A restart-finalize matcher
+// (通信牛 #290 final CHANGE_REQ 2026-06-28). Real-driver tests: drive
+// the helper that production report_status delegates to + assert on
+// the persisted state. Same single-source-of-truth pattern as
+// upsertNodeWithSec1Guard (prevents inline-mirror test drift).
+// ─────────────────────────────────────────────────────────────────────
+describe("finalizePendingMatchingUpdates — Option A restart-finalize via content match", () => {
+  function insertPendingUpdate(opts: {
+    update_id?: string;
+    node_id: string;
+    network_id: string;
+    patch: any;
+    apply_mode: "hot" | "restart" | "restart_only";
+    status?: "pending" | "restarting";
+  }): string {
+    const id = opts.update_id ?? `cu_${uuidv4()}`;
+    db.run(
+      `INSERT INTO node_config_updates (update_id, node_id, network_id, patch_json, apply_mode, base_revision, status, created_at, created_by_token) VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?7, 'test')`,
+      [id, opts.node_id, opts.network_id, JSON.stringify(opts.patch), opts.apply_mode, opts.status ?? "pending", Date.now()],
+    );
+    return id;
+  }
+
+  test("empty patch (restart_only) → finalizes on ANY snapshot (restart itself = goal)", () => {
+    const nid = insertNode({ alias: "n1", network_id: "netA" });
+    const uid = insertPendingUpdate({
+      node_id: nid, network_id: "netA", patch: {}, apply_mode: "restart_only", status: "restarting",
+    });
+    const r = finalizePendingMatchingUpdates(nid, { model: "any", flags: {} });
+    expect(r.finalizedCount).toBe(1);
+    expect(r.finalizedIds).toContain(uid);
+    const row = db.get<any>("SELECT status, new_revision FROM node_config_updates WHERE update_id = ?1", uid);
+    expect(row.status).toBe("applied");
+    expect(row.new_revision).toBe(1);
+    const node = db.get<any>("SELECT config_revision FROM nodes WHERE node_id = ?1", nid);
+    expect(node.config_revision).toBe(1);
+  });
+
+  test("model patch + snapshot.model matches → finalized", () => {
+    const nid = insertNode({ alias: "n2", network_id: "netA" });
+    const uid = insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { model: "claude-opus-4-new", flags: {} },
+      apply_mode: "restart",
+    });
+    const r = finalizePendingMatchingUpdates(nid, {
+      model: "claude-opus-4-new", flags: { maxTurns: 50 },
+    });
+    expect(r.finalizedCount).toBe(1);
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uid).status).toBe("applied");
+  });
+
+  test("model patch + snapshot.model DIFFERENT → NOT finalized (left pending)", () => {
+    const nid = insertNode({ alias: "n3", network_id: "netA" });
+    const uid = insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { model: "claude-opus-4-new", flags: {} },
+      apply_mode: "restart",
+    });
+    const r = finalizePendingMatchingUpdates(nid, {
+      model: "claude-sonnet-3-old", flags: {},
+    });
+    expect(r.finalizedCount).toBe(0);
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uid).status).toBe("pending");
+  });
+
+  test("flags patch + every flag matches snapshot → finalized", () => {
+    const nid = insertNode({ alias: "n4", network_id: "netA" });
+    const uid = insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { flags: { maxTurns: 99, budget: 500 } },
+      apply_mode: "hot",
+    });
+    const r = finalizePendingMatchingUpdates(nid, {
+      flags: { maxTurns: 99, budget: 500, dangerouslySkipPermissions: true },
+    });
+    expect(r.finalizedCount).toBe(1);
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uid).status).toBe("applied");
+  });
+
+  test("flags patch + ONE flag mismatch → NOT finalized (any field absent = no match)", () => {
+    const nid = insertNode({ alias: "n5", network_id: "netA" });
+    const uid = insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { flags: { maxTurns: 99, budget: 500 } },
+      apply_mode: "hot",
+    });
+    const r = finalizePendingMatchingUpdates(nid, {
+      flags: { maxTurns: 99, budget: 999 },  // budget wrong
+    });
+    expect(r.finalizedCount).toBe(0);
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uid).status).toBe("pending");
+  });
+
+  test("flags patch + flag absent from snapshot → NOT finalized", () => {
+    const nid = insertNode({ alias: "n6", network_id: "netA" });
+    const uid = insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { flags: { permissionMode: "auto" } },
+      apply_mode: "restart",
+    });
+    const r = finalizePendingMatchingUpdates(nid, {
+      flags: { maxTurns: 50 },  // permissionMode missing entirely
+    });
+    expect(r.finalizedCount).toBe(0);
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uid).status).toBe("pending");
+  });
+
+  test("no pending update → no-op (idempotent on routine heartbeats)", () => {
+    const nid = insertNode({ alias: "n7", network_id: "netA" });
+    const r = finalizePendingMatchingUpdates(nid, { model: "x", flags: { maxTurns: 50 } });
+    expect(r.finalizedCount).toBe(0);
+  });
+
+  test("restarting status finalizes too (not just pending)", () => {
+    const nid = insertNode({ alias: "n8", network_id: "netA" });
+    const uid = insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { model: "new" },
+      apply_mode: "restart",
+      status: "restarting",
+    });
+    const r = finalizePendingMatchingUpdates(nid, { model: "new", flags: {} });
+    expect(r.finalizedCount).toBe(1);
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uid).status).toBe("applied");
+  });
+
+  test("two nodes with separate pending updates → finalize only matching one", () => {
+    const nidA = insertNode({ alias: "match-this", network_id: "netA" });
+    const nidB = insertNode({ alias: "leave-alone", network_id: "netA" });
+    const uidA = insertPendingUpdate({
+      node_id: nidA, network_id: "netA",
+      patch: { model: "matched-model" },
+      apply_mode: "restart",
+    });
+    const uidB = insertPendingUpdate({
+      node_id: nidB, network_id: "netA",
+      patch: { model: "different-model" },
+      apply_mode: "restart",
+    });
+    finalizePendingMatchingUpdates(nidA, { model: "matched-model", flags: {} });
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uidA).status).toBe("applied");
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uidB).status).toBe("pending");
+  });
+
+  test("config_revision bumps to base+1 for single finalize (multi-pending blocked by F-C index)", () => {
+    // F-C partial unique index (db.ts) prevents two non-terminal updates
+    // for the same node, so the multi-finalize scenario is unreachable
+    // at the DB layer. This test pins that ONE pending finalize → revision = base + 1.
+    const nid = insertNode({ alias: "n10", network_id: "netA" });
+    insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { model: "v1" },
+      apply_mode: "restart",
+    });
+    const r = finalizePendingMatchingUpdates(nid, { model: "v1", flags: {} });
+    expect(r.finalizedCount).toBe(1);
+    expect(db.get<any>("SELECT config_revision FROM nodes WHERE node_id = ?1", nid).config_revision).toBe(1);
   });
 });
 

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1843,6 +1843,101 @@ export function upsertNodeWithSec1Guard(input: UpsertNodeWithSec1GuardInput): Up
       `UPDATE nodes SET config_snapshot = ?1 WHERE node_id = ?2`,
       [JSON.stringify(input.config_snapshot), input.node_id],
     );
+    // RFC-024 — finalize any pending/restarting update whose target
+    // patch is now reflected in the snapshot. Closes the
+    // restart-required-never-reaches-applied gap that 通信牛 caught:
+    // the old child acks `restarting` + exits 75; the new child boots,
+    // reads the new config, reports status — but never had the
+    // update_id to call ack_config_update(applied) itself. Hub does
+    // it on the new child's behalf by content-matching the patch
+    // against the reported snapshot.
+    finalizePendingMatchingUpdates(input.node_id, input.config_snapshot);
   }
   return { result: existing ? "updated" : "inserted", node_id: input.node_id };
+}
+
+/**
+ * RFC-024 restart-finalize (Option A per 通信牛 final review).
+ *
+ * Called from `upsertNodeWithSec1Guard` after writing a fresh
+ * `config_snapshot` for the node. For each pending/restarting update
+ * row, parse the patch and compare every field against the snapshot.
+ * If everything in the patch is now reflected in the live snapshot,
+ * mark the update applied + bump `nodes.config_revision`. The new
+ * child doesn't need to know the update_id — content-matching against
+ * the live state IS the proof that the apply landed.
+ *
+ * Edge cases:
+ *   - Empty patch (apply_mode=restart_only from `restart_node` tool) →
+ *     ANY snapshot matches (the restart itself was the goal).
+ *   - Patch field absent from snapshot → not a match (snapshot
+ *     post-dates the apply only when every requested field shows up).
+ *   - Multiple concurrent pending rows → impossible by single-flight,
+ *     but defensive: finalize OLDEST first so the chain stays linear.
+ *
+ * Pure-ish: takes a snapshot blob (TS shape, see config-snapshot type)
+ * and runs only db.run / db.get. No external IO.
+ */
+export function finalizePendingMatchingUpdates(
+  nodeId: string,
+  snapshot: any,
+): { finalizedCount: number; finalizedIds: string[] } {
+  const pending = db.all<{
+    update_id: string;
+    patch_json: string;
+    apply_mode: string;
+    base_revision: number;
+  }>(
+    "SELECT update_id, patch_json, apply_mode, base_revision FROM node_config_updates WHERE node_id = ?1 AND status IN ('pending', 'restarting') ORDER BY created_at ASC",
+    nodeId,
+  );
+  if (pending.length === 0) return { finalizedCount: 0, finalizedIds: [] };
+
+  const snapModel: string | null | undefined = snapshot?.model;
+  const snapFlags: Record<string, unknown> = (snapshot?.flags && typeof snapshot.flags === "object") ? snapshot.flags : {};
+
+  const finalizedIds: string[] = [];
+
+  for (const row of pending) {
+    let patch: any = {};
+    try { patch = JSON.parse(row.patch_json); } catch { continue; }
+
+    let matches = true;
+    // restart_only / empty patch → any snapshot proves the restart
+    // happened, finalize unconditionally.
+    if (row.apply_mode !== "restart_only") {
+      if (patch.model !== undefined) {
+        if (snapModel !== patch.model) { matches = false; }
+      }
+      if (matches && patch.flags && typeof patch.flags === "object") {
+        for (const [k, v] of Object.entries(patch.flags as Record<string, unknown>)) {
+          // Canonical-key fallback for legacy aliases. The dashboard
+          // schema uses `budget` and `timeout`; node-side config may
+          // also carry the older `maxBudgetUsd` / `claudeTimeoutMs` /
+          // `codexTimeoutMs` keys. agent-node's buildConfigSnapshot
+          // only reports the canonical key, so we just compare on `k`.
+          if (snapFlags[k] !== v) { matches = false; break; }
+        }
+      }
+    }
+
+    if (!matches) continue;
+
+    // Promote nodes.config_revision atomically with the update row.
+    const nextRev = (db.get<{ config_revision: number }>(
+      "SELECT config_revision FROM nodes WHERE node_id = ?1",
+      nodeId,
+    )?.config_revision || 0) + 1;
+    db.run(
+      "UPDATE node_config_updates SET status = 'applied', acked_at = ?1, new_revision = ?2 WHERE update_id = ?3 AND status IN ('pending', 'restarting')",
+      [Date.now(), nextRev, row.update_id],
+    );
+    db.run("UPDATE nodes SET config_revision = ?1 WHERE node_id = ?2", [nextRev, nodeId]);
+    finalizedIds.push(row.update_id);
+    console.log(
+      `[commhub] ✓ finalize update ${row.update_id} via report_status content-match: node=${nodeId} new_revision=${nextRev} apply_mode=${row.apply_mode}`,
+    );
+  }
+
+  return { finalizedCount: finalizedIds.length, finalizedIds };
 }


### PR DESCRIPTION
## Author
Agent: 通信工程马
Refs: #290 (PR B 通信牛 final CHANGE_REQ) · RFC-024 #286

## What this fixes

Closes the **restart-required apply never reaches \`applied\`** gap from 通信牛's final review on PR #290. Old child acks \`restarting\` + exits 75 → new child boots reading new config + reports status — but **never had the update_id to ack(applied) itself**. Without this fix, every restart-required patch (model / permissionMode / DSP / timeout / restart_node) stays in \`restarting\` until the reaper TTL marks it timeout. Dashboard never shows ✓.

## Option A — hub-side finalize-on-report_status

Match the pending update's \`patch_json\` content against the new \`config_snapshot\` reported by the node. If every field in the patch is present in the snapshot → finalize:
- \`node_config_updates.status = 'applied'\`
- \`node_config_updates.new_revision = nodes.config_revision + 1\`
- \`nodes.config_revision\` bumped atomically

**Content-match (not revision-match)** because node-side \`currentConfigRevision\` resets to 0 on each process boot (per PR B impl) — patch field values are the only stable signal.

## Premature-finalize guard

Critical edge 通信龙 caught: during the drain window (up to 60s after \`ack restarting\`), the old child could still send periodic heartbeats. Its \`buildConfigSnapshot\` reads the file (already new) → hub content-matches → false-finalize while the new child hasn't even spawned.

**Companion fix in PR B branch (separate commit)**: agent-node \`reportStatus\` skips the \`config_snapshot\` field while \`configApplyDraining\` is true. Heartbeats still fire (so the node doesn't look offline), they just don't carry the snapshot until the new child takes over.

The same guard naturally covers boot-failure rollback: a corrupted config triggers \`loadConfigWithSelfHeal\` → new child boots with \`.prev\` → reports the OLD snapshot → content-match fails → update stays pending → reaper marks timeout → dashboard shows timeout (NOT false ✓).

## 10 new real-driver tests (\`config-apply-sec1.test.ts\`)

```
- empty patch (restart_only) → finalize on ANY snapshot
- model patch + matching snapshot.model → finalize
- model patch + DIFFERENT snapshot.model → NOT finalize
- flags patch + every flag matches → finalize
- flags patch + ONE flag mismatch → NOT finalize
- flags patch + flag absent from snapshot → NOT finalize
- no pending update → no-op (routine heartbeats don't false-fire)
- 'restarting' status also finalizes (not just 'pending')
- two nodes with separate pending updates → finalize only the matching one
- single-flight (F-C partial unique index) prevents multi-pending — regression pin
```

All call \`finalizePendingMatchingUpdates\` directly + assert on persisted DB state. Same single-source-of-truth pattern as \`upsertNodeWithSec1Guard\` — guard drift breaks the test.

## Server suite

\`COMMHUB_DB=/tmp/x.db bun test src/\` → **289 → 299 pass, 0 fail.**

## Companion changes (separate, on PR #290 branch)

- agent-node \`reportStatus\` omits \`config_snapshot\` during \`configApplyDraining\` (premature-finalize guard)
- Real-driver Docker e2e in \`qa-rfc024-config-apply\`: positive (anet node start + restart patch + finalize within window) + negative (kill mid-restart + assert reaper timeout NOT false applied)
- Pinning unit test that \`reportStatus\` payload during drain omits the snapshot

## Slug guard

Commit body + PR body 0 internal references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)