### PR TITLE
docs(rfc-025): agent loop self-awareness + self-management (design-first)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -4919,6 +4919,101 @@ async function projectDown() {
   console.log(`\n  ${stopped}/${nodes.length} stopped${alreadyDown ? ` · ${alreadyDown} were not running` : ""}\n`);
 }
 
+// ── loop ── (#144 round-6)
+//
+// `anet node loop <alias> "<task>" --every 5m`
+//
+// One-liner UX wrapper for the inbox `/loop <interval> <task>` slash
+// command. POSTs a task to commhub via /api/task; the receiving node's
+// inbox handler parses the `/loop` prefix and calls createScheduledGoal,
+// which persists the goal in goals.json + the scheduler tick fires it.
+//
+// Why a CLI wrapper instead of just "send the slash text directly"?
+// Vincent's "使用简单" priority — a non-interactive node operator
+// shouldn't need to memorize slash-command syntax or run a separate
+// `send_task` call. One line, one verb, one task.
+
+async function nodeLoopCommand() {
+  const aliasRef = args[1];
+  const taskText = args[2];
+  if (!aliasRef || !taskText) {
+    console.log(`
+anet node loop <alias> "<task>" --every <interval>
+
+  Schedule a recurring task on a running node. The node will be woken at
+  the chosen interval and asked to make an incremental advance on the
+  task, reporting back each cycle.
+
+Examples:
+  anet node loop my-codex "monitor #271 PR" --every 5m
+  anet node loop researcher "scan twitter for grok updates" --every 30m
+  anet node loop daily-bot "post the morning summary" --every 2h
+
+Interval format: 30s / 5m / 2h / 1d (s/m/h/d suffix required).
+Use 'anet goal list <alias>' to see scheduled loops; 'anet goal cancel'
+to stop one.
+`);
+    process.exit(aliasRef ? 1 : 0);
+  }
+
+  // Default 5m if --every omitted (matches Vincent's example cadence
+  // and is the most common cron-style "check periodically" interval).
+  const everyIdx = args.indexOf("--every");
+  const everyRaw = everyIdx >= 0 ? args[everyIdx + 1] : "5m";
+  if (!everyRaw || !/^\d+[smhd]$/.test(everyRaw)) {
+    console.error(`Invalid --every value "${everyRaw}". Use formats like 30s, 5m, 2h, 1d.`);
+    process.exit(1);
+  }
+
+  const resolved = resolveNodeRef(aliasRef);
+  if (!resolved) {
+    console.error(`Node "${aliasRef}" not found. Run 'anet node ls' to see registered nodes.`);
+    process.exit(1);
+  }
+
+  const profile = resolved.profile;
+  const displayName = nodeDisplayName(resolved.id, profile);
+  const gc = loadGlobal();
+  const hub = profile.hub || gc.hub || "http://127.0.0.1:9200";
+  const networkId = profile.network_id || gc.network_id || null;
+
+  // The inbox parser at agent-node/src/goals/parser.ts accepts
+  // `/loop <interval> <text>` (and `/goal` as an alias). We assemble
+  // the slash form and POST it as a normal task — the node's inbox
+  // handler routes /loop tasks to createScheduledGoal regardless of
+  // runtime (post-#144 the claude-bucket carve-out is gone).
+  const slashCmd = `/loop ${everyRaw} ${taskText}`;
+  const body = JSON.stringify({
+    alias: displayName,
+    task: slashCmd,
+    priority: "normal",
+    from: "api",
+    network_id: networkId || undefined,
+  });
+
+  try {
+    const res = await fetch(`${hub}/api/task`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body,
+    });
+    const j: any = await res.json();
+    if (!j?.ok) {
+      console.error(`Failed to schedule loop: ${JSON.stringify(j)}`);
+      process.exit(1);
+    }
+    console.log(`✅ Scheduled loop on ${displayName}`);
+    console.log(`   every: ${everyRaw}`);
+    console.log(`   task:  ${taskText}`);
+    console.log(`   sent as: ${slashCmd}`);
+    console.log(`\nUse 'anet goal list ${displayName}' to inspect; 'anet goal cancel ${displayName} <goal-id>' to stop.`);
+  } catch (e: any) {
+    console.error(`Failed to reach hub ${hub}: ${e?.message ?? e}`);
+    console.error(`Is the hub running? Try: anet hub start`);
+    process.exit(1);
+  }
+}
+
 // ── delete ──
 
 async function deleteCommand() {
@@ -9438,6 +9533,7 @@ switch (command) {
       case "resume": args.splice(0, 1); await resumeCommand(); break;
       case "delete": args.splice(0, 1); await deleteCommand(); break;
       case "rename": args.splice(0, 1); await renameCommand(); break;
+      case "loop": args.splice(0, 1); await nodeLoopCommand(); break;
       case "ls": case "list": await lsCommand(); break;
       case "restart": {
         // #173 / F7-03 — node restart = stop + start, alias for symmetry
@@ -9452,10 +9548,10 @@ switch (command) {
       default: {
         const sub = args[1];
         if (sub) {
-          const suggestion = suggestSimilar(sub, ["create", "start", "stop", "restart", "resume", "delete", "ls", "rename"]);
+          const suggestion = suggestSimilar(sub, ["create", "start", "stop", "restart", "resume", "delete", "ls", "rename", "loop"]);
           if (suggestion) console.log(`Unknown node subcommand "${sub}". Did you mean: anet node ${suggestion}?`);
         }
-        console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|migrate-token-to-envref> [name]`);
+        console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|loop|migrate-token-to-envref> [name]`);
         break;
       }
     }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -4948,8 +4948,13 @@ Examples:
   anet node loop my-codex "monitor #271 PR" --every 5m
   anet node loop researcher "scan twitter for grok updates" --every 30m
   anet node loop daily-bot "post the morning summary" --every 2h
+  anet node loop nightly-bot "rotate logs"                  --every 1d
 
-Interval format: 30s / 5m / 2h / 1d (s/m/h/d suffix required).
+Interval format: 5m / 2h / 1d (m/h/d suffix required, integer ≥ 1).
+Sub-minute intervals (e.g. 30s) are not accepted — the scheduler tick
+runs at ~30s cadence so a sub-minute goal would not actually fire any
+faster and risks wake-storm load on the runtime.
+
 Use 'anet goal list <alias>' to see scheduled loops; 'anet goal cancel'
 to stop one.
 `);
@@ -4960,8 +4965,14 @@ to stop one.
   // and is the most common cron-style "check periodically" interval).
   const everyIdx = args.indexOf("--every");
   const everyRaw = everyIdx >= 0 ? args[everyIdx + 1] : "5m";
-  if (!everyRaw || !/^\d+[smhd]$/.test(everyRaw)) {
-    console.error(`Invalid --every value "${everyRaw}". Use formats like 30s, 5m, 2h, 1d.`);
+  // CLI mirrors agent-node/src/goals/parser.ts: single-letter m/h/d only,
+  // integer ≥ 1. Sub-minute is rejected by both layers (MIN_INTERVAL_MS
+  // = 60s in the parser); reject here too so the user sees the error
+  // before we POST a doomed task. The previous /^\d+[smhd]$/ pattern
+  // accepted `30s` at the CLI layer but the parser rejected it server-
+  // side → silent fail (CLI printed "Scheduled" but no goal was created).
+  if (!everyRaw || !/^[1-9]\d*[mhd]$/.test(everyRaw)) {
+    console.error(`Invalid --every value "${everyRaw}". Use formats like 5m, 30m, 2h, 1d (sub-minute not allowed).`);
     process.exit(1);
   }
 
@@ -4991,6 +5002,7 @@ to stop one.
     network_id: networkId || undefined,
   });
 
+  let taskId: string;
   try {
     const res = await fetch(`${hub}/api/task`, {
       method: "POST",
@@ -4999,19 +5011,73 @@ to stop one.
     });
     const j: any = await res.json();
     if (!j?.ok) {
-      console.error(`Failed to schedule loop: ${JSON.stringify(j)}`);
+      console.error(`Failed to enqueue /loop task: ${JSON.stringify(j)}`);
       process.exit(1);
     }
-    console.log(`✅ Scheduled loop on ${displayName}`);
-    console.log(`   every: ${everyRaw}`);
-    console.log(`   task:  ${taskText}`);
-    console.log(`   sent as: ${slashCmd}`);
-    console.log(`\nUse 'anet goal list ${displayName}' to inspect; 'anet goal cancel ${displayName} <goal-id>' to stop.`);
+    taskId = j.message_id;
   } catch (e: any) {
     console.error(`Failed to reach hub ${hub}: ${e?.message ?? e}`);
     console.error(`Is the hub running? Try: anet hub start`);
     process.exit(1);
   }
+
+  // #144 round-6 hardening — don't claim success until the node has
+  // ACTUALLY created the goal. Previously the CLI printed "✅ Scheduled
+  // loop" the instant /api/task enqueued the task; if the parser
+  // downstream rejected it (e.g. `5m` not matching the old word-only
+  // patterns) the failure reply went back to `from:"api"` and was
+  // invisible to the user — silent fail. Now we poll for the node's
+  // reply and surface what actually happened.
+  console.log(`→ Sent /loop to ${displayName} (task ${taskId.slice(0, 8)}); waiting for node confirmation...`);
+
+  const POLL_DEADLINE_MS = 15_000;
+  const POLL_INTERVAL_MS = 1_000;
+  const started = Date.now();
+  let taskRow: any = null;
+  // Poll `/api/tasks?task_id=<id>` for the task row. After the node
+  // handles the /loop slash command it writes the reply text into
+  // tasks.result + sets status='replied' (or 'failed'). This is the
+  // robust signal — /api/messages doesn't carry in_reply_to in its
+  // SELECT (existing comment at cli.ts:7053), so we can't reliably
+  // match a reply back to our task there.
+  while (Date.now() - started < POLL_DEADLINE_MS) {
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+    try {
+      const r: any = await fetch(`${hub}/api/tasks?task_id=${encodeURIComponent(taskId)}`, { headers: authHeaders() }).then(x => x.json());
+      const t = (r?.tasks || [])[0];
+      if (t && (t.status === "replied" || t.status === "failed" || t.status === "cancelled") && t.result) {
+        taskRow = t;
+        break;
+      }
+    } catch {
+      // network blip; keep polling
+    }
+  }
+
+  if (!taskRow) {
+    console.error(`⚠ Node ${displayName} did not confirm goal creation within 15s.`);
+    console.error(`  Possible causes: node offline / agent crashed / parser rejected the interval.`);
+    console.error(`  Verify with: anet goal list ${displayName}`);
+    console.error(`  Or inspect node logs at ~/.anet/nodes/${resolved.id}/logs/`);
+    process.exit(1);
+  }
+
+  const replyText = String(taskRow.result || "");
+  // The node's reply text is set by agent-node/src/cli.ts:createScheduledGoal
+  // wrapping success as "已创建 loop 目标 <id>..." or, on failure,
+  // "/loop 创建失败：<reason>".
+  if (taskRow.status === "failed" || (/创建失败|failed/i.test(replyText) && !/已创建 loop 目标/.test(replyText))) {
+    console.error(`❌ Node rejected the /loop command:`);
+    console.error(`   ${replyText.replace(/^\[[^\]]+\]\s*/, "").trim()}`);
+    process.exit(1);
+  }
+
+  console.log(`✅ Scheduled loop on ${displayName}`);
+  console.log(`   every: ${everyRaw}`);
+  console.log(`   task:  ${taskText}`);
+  console.log(`   sent as: ${slashCmd}`);
+  console.log(`\n${replyText.replace(/^\[[^\]]+\]\s*/, "").trim()}`);
+  console.log(`\nUse 'anet goal list ${displayName}' to inspect; 'anet goal cancel ${displayName} <goal-id>' to stop.`);
 }
 
 // ── delete ──
@@ -9509,7 +9575,22 @@ if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
       printProjectUsage();
       break;
     case "node":
-      console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|migrate-token-to-envref> [name]`);
+      // #144 — if it's `anet node loop --help` specifically, delegate
+      // to nodeLoopCommand so the user sees the loop-specific help
+      // (examples + interval format) rather than the generic node
+      // subcommand list. Other `anet node <sub> --help` calls still
+      // get the generic node usage.
+      if (args[1] === "loop") {
+        args.splice(0, 1); // drop "node" so nodeLoopCommand sees args[1] as alias slot (no alias → prints loop help)
+        // strip --help so it's not treated as an alias literal
+        const hi = args.indexOf("--help");
+        if (hi >= 0) args.splice(hi, 1);
+        const hi2 = args.indexOf("-h");
+        if (hi2 >= 0) args.splice(hi2, 1);
+        await nodeLoopCommand();
+        process.exit(0);
+      }
+      console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|loop|migrate-token-to-envref> [name]`);
       break;
     default:
       printHelp();

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -2576,12 +2576,14 @@ async function processInbox() {
         continue;
       }
 
-      // P0 /loop SDK gate (v0.4 §3.4): on claude runtime, anet does NOT
-      // intercept /loop or /goal — let the message flow through to the
-      // claude SDK turn so Claude Code's native /loop skill handles it.
-      // The early-return is the entire hands-off contract; no parse, no
-      // wrap, no forward layer in between.
-      if (RUNTIME !== "claude" && isGoalCommand(content)) {
+      // #144 round-6: anet /loop is universal — all recognized runtimes
+      // (claude / codex / grok) route /loop and /goal commands to the
+      // scheduler. The pre-#144 `RUNTIME !== "claude"` carve-out was
+      // removed because the underlying premise (claude-agent-sdk has a
+      // native /loop) was false: the SDK is one-shot per-task, no
+      // persistent CC REPL to fire CronCreate/ScheduleWakeup from. See
+      // goals/store.ts runtimeBucket comment for full rationale.
+      if (isGoalCommand(content)) {
         let replyText: string;
         let goalFailed = false;
         try {
@@ -3240,10 +3242,12 @@ const allGoals = await goalStore.list();
 const activeGoals = allGoals.filter(g => g.status === "active");
 if (activeGoals.length) log(`  goals active: ${activeGoals.length}`);
 
-// P0 /loop SDK runtime gate (v0.4 §3.4). Decide whether this process can
-// run the anet scheduler at all given the runtime it booted under and the
-// goals already on disk. Pure-function decision; we only act on the
-// verdict here.
+// #144 round-6 — startup runtime dispatch. Pure-function decision over
+// (current runtime bucket, persisted goals); we just act on the verdict.
+// "archive" no longer crashes — pre-#144 the codex↔grok cross-bucket
+// case did `exit(1)` which was hostile UX (silently killing the user's
+// node without recovery guidance). It now archives + clears + continues
+// so the scheduler runs against an empty store.
 const startupBucket = runtimeBucket(RUNTIME);
 const startupAction = decideStartupAction(startupBucket, allGoals);
 let goalsSchedulerEnabled = startupAction.runScheduler;
@@ -3263,12 +3267,9 @@ switch (startupAction.kind) {
     } else {
       warn(`  goals archive skipped — no file to back up`);
     }
+    log(`  goals scheduler: enabled (runtime=${startupBucket}, fresh store)`);
     break;
   }
-  case "fatal":
-    warn(`  goals scheduler: FATAL — ${startupAction.reason}`);
-    warn(`  goals path: ${GOALS_PATH}`);
-    process.exit(1);
 }
 
 await register();

--- a/agent-node/src/goals/parser.test.ts
+++ b/agent-node/src/goals/parser.test.ts
@@ -164,3 +164,80 @@ describe("parseGoalCommand — defence-in-depth", () => {
     if (r.ok) expect(r.goal.interval_ms).toBe(60_000);
   });
 });
+
+describe("parseGoalCommand — #144 round-6 single-letter units (CLI parity)", () => {
+  // `anet node loop <alias> "<task>" --every 5m` emits a slash command
+  // shaped exactly like the strings below. Pre-fix the parser ONLY
+  // matched word-form ("min/minute/hour/day"), so `5m` / `2h` / `1d`
+  // all fell through to "no recognised interval" and the CLI silently
+  // succeeded at /api/task enqueue while the goal never landed. These
+  // tests pin parity with the CLI's `--every` format.
+
+  test("`5m` parses to 5 × 60_000 ms (the canonical CLI emission)", () => {
+    const r = parseGoalCommand("/loop 5m monitor PR #271");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.goal.interval_ms).toBe(5 * 60_000);
+      expect(r.goal.text).toBe("monitor PR #271");
+    }
+  });
+
+  test("`30m` / `90m` arbitrary minutes parse correctly", () => {
+    const a = parseGoalCommand("/loop 30m scan twitter");
+    const b = parseGoalCommand("/loop 90m long task");
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    if (a.ok) expect(a.goal.interval_ms).toBe(30 * 60_000);
+    if (b.ok) expect(b.goal.interval_ms).toBe(90 * 60_000);
+  });
+
+  test("`2h` parses to 2 hours", () => {
+    const r = parseGoalCommand("/loop 2h morning sync");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.goal.interval_ms).toBe(2 * 60 * 60_000);
+  });
+
+  test("`1d` parses to 24 hours", () => {
+    const r = parseGoalCommand("/loop 1d nightly cleanup");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.goal.interval_ms).toBe(24 * 60 * 60_000);
+  });
+
+  test("single-letter and word-form yield the same interval (no semantic drift)", () => {
+    const single = parseGoalCommand("/loop 5m do thing");
+    const word = parseGoalCommand("/loop 5min do thing");
+    expect(single.ok).toBe(true);
+    expect(word.ok).toBe(true);
+    if (single.ok && word.ok) {
+      expect(single.goal.interval_ms).toBe(word.goal.interval_ms);
+      expect(single.goal.text).toBe(word.goal.text);
+    }
+  });
+
+  test("`5min` still wins over `5m` (longest-prefix declaration order)", () => {
+    // Pre-fix `5min` was the only thing that worked; ensure we don't
+    // regress that by accidentally matching `5m` first and treating
+    // `in` as leftover goal text.
+    const r = parseGoalCommand("/loop 5min check the deploy");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.goal.interval_ms).toBe(5 * 60_000);
+      expect(r.goal.text).toBe("check the deploy"); // NOT "in check the deploy"
+    }
+  });
+
+  test("single-letter inside a larger word is NOT swallowed (lookahead guard)", () => {
+    // `5min` should match the word-form rule, not the single-letter
+    // rule with `in` as leftover. Pinned above. Conversely, a stray
+    // `2m2` in the text should not be picked up — there's no clean
+    // single-letter form here, so it must NOT parse.
+    const r = parseGoalCommand("/loop check status 5MOM"); // looks suggestive
+    expect(r.ok).toBe(false); // no valid interval
+  });
+
+  test("`30s` is rejected with sub-minute error (parser + CLI aligned)", () => {
+    const r = parseGoalCommand("/loop 30s ping");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/shorter than 60s|seconds/i);
+  });
+});

--- a/agent-node/src/goals/parser.ts
+++ b/agent-node/src/goals/parser.ts
@@ -7,12 +7,20 @@
 // post-parse as a defence-in-depth check.
 //
 // Accepted forms (case-insensitive on ASCII; locale-sensitive on CJK):
-//   English: `5min`, `5 min`, `5 minute`, `5 minutes`, `1h`, `1 hour`,
-//            `2 hours`, `hourly`, `daily`, `1 day`
-//   Chinese: `5分钟`, `每5分钟`, `1小时`, `每小时`, `每天`
+//   Single-letter: `5m`, `2h`, `1d` (matches what `anet node loop --every`
+//                  emits — keep parser and CLI in lockstep).
+//   English:       `5min`, `5 min`, `5 minute`, `5 minutes`,
+//                  `1h`, `1 hour`, `2 hours`, `hourly`, `daily`, `1 day`
+//   Chinese:       `5分钟`, `每5分钟`, `1小时`, `每小时`, `每天`
 //
 // Rejected: sub-minute units (`5s`, `30秒`), no interval at all, bare
 // numbers without units (`/goal 5 check` — unit-free 5 is ambiguous).
+//
+// #144 round-6 (this fix): added single-letter `m`/`h`/`d` so that
+// `anet node loop <alias> "<task>" --every 5m` actually creates a goal
+// instead of silent-failing. The CLI emits `5m` / `30s` / `2h` / `1d`
+// straight from `--every` and previously the parser rejected all of them
+// because INTERVAL_PATTERNS only matched word-form unit names.
 
 export const MIN_INTERVAL_MS = 60_000;
 
@@ -56,6 +64,17 @@ const INTERVAL_PATTERNS: Array<{
   { re: /(\d+)\s*(?:minutes|minute|mins|min)\b/i, toMs: (m) => parseInt(m[1], 10) * 60_000 },
   { re: /(\d+)\s*(?:hours|hour|hrs|hr)\b/i, toMs: (m) => parseInt(m[1], 10) * 60 * 60_000 },
   { re: /(\d+)\s*(?:days|day)\b/i, toMs: (m) => parseInt(m[1], 10) * 24 * 60 * 60_000 },
+
+  // Single-letter units — matches `anet node loop --every 5m` shape.
+  // Anchored so `5m` isn't accidentally swallowed by `5min` / `5mins`
+  // (those patterns above run FIRST per declaration order and use
+  // `\b` to terminate, so `5m` here only matches when not part of a
+  // word like `5min`). Lookahead `(?![a-zA-Z])` prevents `5min` from
+  // matching the `5m` rule. Lookbehind `(?<!\w)` prevents `pm5h`-like
+  // surprises (no digit/letter immediately before the number).
+  { re: /(?<!\w)(\d+)m(?![a-zA-Z])/i,   toMs: (m) => parseInt(m[1], 10) * 60_000 },
+  { re: /(?<!\w)(\d+)h(?![a-zA-Z])/i,   toMs: (m) => parseInt(m[1], 10) * 60 * 60_000 },
+  { re: /(?<!\w)(\d+)d(?![a-zA-Z])/i,   toMs: (m) => parseInt(m[1], 10) * 24 * 60 * 60_000 },
 ];
 
 // Patterns we recognise as *invalid* (sub-minute units) — surface a clear

--- a/agent-node/src/goals/store.test.ts
+++ b/agent-node/src/goals/store.test.ts
@@ -12,7 +12,6 @@ import { tmpdir } from "os";
 import {
   GoalStore,
   newGoal,
-  assertNonClaudeRuntime,
   isClaudeRuntime,
   runtimeBucket,
   decideStartupAction,
@@ -207,50 +206,50 @@ describe("P0 runtime gate — name resolution", () => {
   });
 });
 
-describe("P0 runtime gate — assertNonClaudeRuntime", () => {
-  test("throws on every claude alias", () => {
-    for (const name of ["claude", "claude-agent-sdk", "claude-sdk", "agent-sdk"]) {
-      expect(() => assertNonClaudeRuntime(name)).toThrow(/claude runtime/);
+describe("#144 round-6 — claude runtime gate REMOVED, scheduler is universal", () => {
+  // History: pre-#144 a `assertNonClaudeRuntime` gate threw on any
+  // claude alias. The premise (claude-agent-sdk has a native /loop) was
+  // false — SDK is one-shot query(), no persistent CC REPL to host
+  // CronCreate/ScheduleWakeup. Loop silently didn't fire for claude
+  // users. These tests pin the post-#144 universal behaviour: every
+  // recognized runtime (incl. claude) creates + persists goals.
+
+  test("newGoal({runtime: 'claude-agent-sdk'}) succeeds (was the load-bearing bug)", () => {
+    const g = newGoal({ text: "claude loop", interval_ms: 60_000, runtime: "claude-agent-sdk" });
+    expect(g.runtime).toBe("claude-agent-sdk");
+    expect(g.status).toBe("active");
+  });
+
+  test("newGoal succeeds for every recognized runtime alias (no per-bucket carve-out)", () => {
+    for (const rt of [
+      "claude", "claude-agent-sdk", "claude-sdk", "agent-sdk",
+      "codex", "codex-sdk",
+      "grok", "grok-build", "grok-build-acp",
+    ]) {
+      const g = newGoal({ text: "x", interval_ms: 60_000, runtime: rt });
+      expect(g.runtime).toBe(rt);
     }
   });
 
-  test("passes for codex / grok / unknown labels (gate only blocks claude)", () => {
-    for (const name of ["codex-sdk", "codex", "grok-build-acp", "grok", "future-sdk"]) {
-      expect(() => assertNonClaudeRuntime(name)).not.toThrow();
-    }
-  });
-
-  test("newGoal({runtime: 'claude'}) throws — no claude-runtime goal ever lands", () => {
-    expect(() =>
-      newGoal({ text: "should not exist", interval_ms: 60_000, runtime: "claude-agent-sdk" }),
-    ).toThrow(/claude runtime/);
-  });
-
-  test("newGoal succeeds for codex / grok runtimes", () => {
-    const c = newGoal({ text: "codex goal", interval_ms: 60_000, runtime: "codex-sdk" });
-    const g = newGoal({ text: "grok goal", interval_ms: 60_000, runtime: "grok-build-acp" });
-    expect(c.runtime).toBe("codex-sdk");
-    expect(g.runtime).toBe("grok-build-acp");
-  });
-
-  test("GoalStore.upsert refuses claude-runtime goal (defence in depth)", async () => {
-    const { dir, path } = (() => {
-      const d = mkdtempSync(join(tmpdir(), "anet-goals-test-"));
-      return { dir: d, path: join(d, "goals.json") };
-    })();
+  test("GoalStore.upsert accepts a claude-runtime goal end-to-end", async () => {
+    const d = mkdtempSync(join(tmpdir(), "anet-goals-test-"));
+    const path = join(d, "goals.json");
     try {
       const s = new GoalStore(path);
       await s.load();
-      // Build a goal via the legitimate factory then mutate runtime to
-      // simulate a corrupted on-disk record being re-upserted by some
-      // future code path.
-      const g = newGoal({ text: "smuggle", interval_ms: 60_000, runtime: "codex-sdk" });
-      g.runtime = "claude-agent-sdk";
-      await expect(s.upsert(g)).rejects.toThrow(/claude runtime/);
-      expect(await s.list()).toEqual([]);  // store stayed clean
+      const g = newGoal({ text: "claude e2e", interval_ms: 60_000, runtime: "claude-agent-sdk" });
+      await s.upsert(g);
+      expect(await s.list()).toHaveLength(1);
+      const loaded = (await s.list())[0];
+      expect(loaded.runtime).toBe("claude-agent-sdk");
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      rmSync(d, { recursive: true, force: true });
     }
+  });
+
+  test("isClaudeRuntime still classifies (kept for cross-bucket detection, not gating)", () => {
+    expect(isClaudeRuntime("claude-agent-sdk")).toBe(true);
+    expect(isClaudeRuntime("codex-sdk")).toBe(false);
   });
 });
 
@@ -314,7 +313,7 @@ describe("P0 runtime gate — archiveAndClear", () => {
   });
 });
 
-describe("P0 runtime gate — decideStartupAction (v0.4 §3.4 matrix)", () => {
+describe("#144 round-6 — decideStartupAction (refined-B matrix)", () => {
   function activeGoal(runtime: string): AgentGoal {
     return newGoal({ text: "x", interval_ms: 60_000, runtime });
   }
@@ -324,50 +323,75 @@ describe("P0 runtime gate — decideStartupAction (v0.4 §3.4 matrix)", () => {
     return g;
   }
 
-  test("row 1: claude + empty → skip, scheduler off", () => {
+  // ── claude bucket: no longer a special case ──
+
+  test("claude + empty → ok (scheduler runs; was 'skip' pre-#144)", () => {
     const a = decideStartupAction("claude", []);
-    expect(a.kind).toBe("skip");
-    expect(a.runScheduler).toBe(false);
+    expect(a.kind).toBe("ok");
+    expect(a.runScheduler).toBe(true);
   });
 
-  test("row 2: claude + active codex/grok goals → archive verdict", () => {
+  test("claude + only claude-active goals → ok (scheduler runs)", () => {
+    const a = decideStartupAction("claude", [
+      activeGoal("claude-agent-sdk"),
+      activeGoal("claude-agent-sdk"),
+    ]);
+    expect(a.kind).toBe("ok");
+    expect(a.runScheduler).toBe(true);
+  });
+
+  // ── codex / grok: same-bucket happy path ──
+
+  test("codex + empty → ok", () => {
+    const a = decideStartupAction("codex", []);
+    expect(a.kind).toBe("ok");
+    expect(a.runScheduler).toBe(true);
+  });
+
+  test("codex + only codex goals → ok", () => {
+    const a = decideStartupAction("codex", [activeGoal("codex-sdk")]);
+    expect(a.kind).toBe("ok");
+  });
+
+  test("grok + only grok goals → ok", () => {
+    const a = decideStartupAction("grok", [activeGoal("grok-build-acp")]);
+    expect(a.kind).toBe("ok");
+  });
+
+  // ── cross-bucket: archive (NOT fatal) ──
+
+  test("claude + active codex/grok goals → archive + runScheduler=true (recover after archive)", () => {
     const a = decideStartupAction("claude", [
       activeGoal("codex-sdk"),
       activeGoal("grok-build-acp"),
     ]);
     expect(a.kind).toBe("archive");
-    expect(a.runScheduler).toBe(false);
+    expect(a.runScheduler).toBe(true); // ← new: was false pre-#144
     if (a.kind === "archive") {
       expect(a.foreignCount).toBe(2);
       expect(a.foreignBuckets.sort()).toEqual(["codex", "grok"]);
     }
   });
 
-  test("row 2 ignores non-active leftover claude-side (no archive triggered)", () => {
-    const a = decideStartupAction("claude", [
-      inactiveGoal("codex-sdk", "complete"),
-      inactiveGoal("grok-build-acp", "cancelled"),
-    ]);
-    expect(a.kind).toBe("skip");
-  });
-
-  test("row 3a: codex bucket + grok-active leftover → fatal", () => {
+  test("codex + grok-active leftover → archive (NOT fatal exit anymore)", () => {
     const a = decideStartupAction("codex", [activeGoal("grok-build-acp")]);
-    expect(a.kind).toBe("fatal");
-    expect(a.runScheduler).toBe(false);
-    if (a.kind === "fatal") {
+    expect(a.kind).toBe("archive");
+    expect(a.runScheduler).toBe(true); // ← was kind=fatal, runScheduler=false pre-#144
+    if (a.kind === "archive") {
       expect(a.foreignCount).toBe(1);
       expect(a.foreignBuckets).toEqual(["grok"]);
     }
   });
 
-  test("row 3b: grok bucket + codex-active leftover → fatal", () => {
+  test("grok + codex-active leftover → archive", () => {
     const a = decideStartupAction("grok", [activeGoal("codex-sdk")]);
-    expect(a.kind).toBe("fatal");
-    if (a.kind === "fatal") expect(a.foreignBuckets).toEqual(["codex"]);
+    expect(a.kind).toBe("archive");
+    expect(a.runScheduler).toBe(true);
   });
 
-  test("row 3 ignores non-active foreign goals (resolved/cancelled don't block)", () => {
+  // ── non-active foreign goals don't trigger archive ──
+
+  test("inactive foreign-bucket goals do NOT trigger archive (only `active` counts)", () => {
     const a = decideStartupAction("codex", [
       inactiveGoal("grok-build-acp", "complete"),
       activeGoal("codex-sdk"),
@@ -375,28 +399,17 @@ describe("P0 runtime gate — decideStartupAction (v0.4 §3.4 matrix)", () => {
     expect(a.kind).toBe("ok");
   });
 
-  test("row 4: codex bucket + only codex goals → ok, scheduler on", () => {
-    const a = decideStartupAction("codex", [
-      activeGoal("codex-sdk"),
-      activeGoal("codex-sdk"),
+  test("claude with only inactive foreign leftover → ok (just cleanup pending)", () => {
+    const a = decideStartupAction("claude", [
+      inactiveGoal("codex-sdk", "complete"),
+      inactiveGoal("grok-build-acp", "cancelled"),
     ]);
     expect(a.kind).toBe("ok");
-    expect(a.runScheduler).toBe(true);
   });
 
-  test("row 4: grok bucket + only grok goals → ok, scheduler on", () => {
-    const a = decideStartupAction("grok", [activeGoal("grok-build-acp")]);
-    expect(a.kind).toBe("ok");
-    expect(a.runScheduler).toBe(true);
-  });
+  // ── unknown bucket: still skip (defensive) ──
 
-  test("row 4: codex bucket + empty store → ok (fresh node)", () => {
-    const a = decideStartupAction("codex", []);
-    expect(a.kind).toBe("ok");
-    expect(a.runScheduler).toBe(true);
-  });
-
-  test("unknown bucket → skip with warning text (no scheduler, no auto-archive)", () => {
+  test("unknown bucket → skip (no scheduler, no auto-archive)", () => {
     const a = decideStartupAction("unknown", [activeGoal("codex-sdk")]);
     expect(a.kind).toBe("skip");
     expect(a.runScheduler).toBe(false);

--- a/agent-node/src/goals/store.ts
+++ b/agent-node/src/goals/store.ts
@@ -20,17 +20,29 @@ import { randomUUID } from "crypto";
 import type { AgentGoal, GoalStatus, GoalsFile } from "./types";
 import { GOALS_SCHEMA_VERSION } from "./types";
 
-// P0 of /loop SDK plan v0.4 §3.4 — runtime gate.
+// #144 round-6 — runtime bucket mapping (no more "claude is special" gate).
 //
-// anet /loop scheduler ONLY serves codex / grok runtimes. claude-agent-sdk
-// agents use Claude Code's native /loop (CronCreate + ScheduleWakeup skill)
-// which the harness handles inside the spawned `claude` binary; anet must
-// stay hands-off there or the two schedulers double-fire the same goal.
+// History: v0.4 §3.4 P0 (#184 commit 45c7909) introduced a runtime gate
+// that rejected the claude bucket entirely, on the assumption that
+// claude-agent-sdk agents use Claude Code's native /loop (CronCreate +
+// ScheduleWakeup skill). That assumption is FALSE for SDK-spawned claude:
+// `processWithClaude` invokes `query()` from @anthropic-ai/claude-agent-sdk
+// which is a one-shot Promise — not a long-running interactive REPL — so
+// the native /loop machinery (which requires a persistent CC session) has
+// no host to fire from. The result was: claude-agent-sdk users sent /loop
+// commands that were silently rejected at the inbox gate and never wired
+// to anything; "loop doesn't fire" for that runtime.
 //
-// Any name a user might write in `--runtime` / `RUNTIME` env / config that
-// resolves to the claude runtime is rejected at the schema layer so a stray
-// `newGoal({runtime: "claude"})` or a corrupted on-disk record can't slip
-// through the gate. See cli.ts:244-251 for the canonical name→bucket map.
+// Refined-B (this PR): no per-bucket scheduler skip. ALL recognized
+// runtimes get the anet scheduler. The bucket helpers stay for the
+// remaining concern that's still real — codex thread IDs are NOT
+// translatable to grok and vice versa, so a node that switches SDK
+// runtime mid-life shouldn't silently re-feed old thread IDs across
+// SDK boundaries. The cross-bucket recovery is now "archive + skip"
+// (formerly hostile-UX `fatal exit(1)` that crashed the node without
+// guidance).
+//
+// Recognized names mirror cli.ts:280 RUNTIME_MAP.
 const CLAUDE_RUNTIME_NAMES = new Set([
   "claude",
   "claude-agent-sdk",
@@ -62,15 +74,6 @@ export function runtimeBucket(rt: string | undefined | null): RuntimeBucket {
 
 export function isClaudeRuntime(rt: string | undefined | null): boolean {
   return runtimeBucket(rt) === "claude";
-}
-
-export function assertNonClaudeRuntime(rt: string): void {
-  if (isClaudeRuntime(rt)) {
-    throw new Error(
-      `anet goal scheduler does not serve claude runtime (got "${rt}") — ` +
-      `use Claude Code native /loop (CronCreate / ScheduleWakeup) instead`,
-    );
-  }
 }
 
 // Promise-chain mutex. Every `lock()` waits for the previous one to
@@ -192,12 +195,12 @@ export class GoalStore {
    * Insert or replace a goal. Bumps `updated_at` and flushes to disk
    * atomically before returning.
    *
-   * P0 runtime gate: rejects any goal whose `runtime` resolves to the
-   * claude bucket. This catches both fresh `newGoal()` mistakes and
-   * upserts of records re-hydrated from corrupted on-disk state.
+   * #144: no runtime gate. The pre-#144 `assertNonClaudeRuntime(goal.runtime)`
+   * check was removed because the claude-bucket "skip" premise was false
+   * (SDK-spawned claude has no native /loop host — see runtimeBucket
+   * comment above for the full rationale).
    */
   async upsert(goal: AgentGoal): Promise<void> {
-    assertNonClaudeRuntime(goal.runtime);
     return this.mutex.lock(async () => {
       goal.updated_at = new Date().toISOString();
       this.goals.set(goal.goal_id, goal);
@@ -328,7 +331,8 @@ export function newGoal(opts: {
   parent_task_id?: string;
   report_to?: string;
 }): AgentGoal {
-  assertNonClaudeRuntime(opts.runtime);
+  // #144: no runtime gate. Pre-#144 this asserted the runtime was non-claude
+  // on the (incorrect) premise that claude-agent-sdk had a native /loop.
   const now = new Date();
   return {
     goal_id: randomUUID(),
@@ -346,36 +350,38 @@ export function newGoal(opts: {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// P0 startup runtime-switch dispatch (v0.4 §3.4 row matrix).
+// #144 round-6 — startup runtime dispatch (refined-B matrix).
 //
 // At agent-node boot, after `goalStore.load()`, the host inspects which
-// runtime bucket it is starting under and what — if anything — is already
-// in `goals.json`. The result drives one of four actions:
+// runtime bucket it is starting under and what — if anything — is in
+// `goals.json`. The result drives one of three actions:
 //
-//   - `ok`           : current runtime matches every persisted goal — boot
-//                      normally, run the scheduler tick.
-//   - `skip`         : claude runtime + empty store — boot normally but
-//                      don't start the scheduler tick (claude uses its
-//                      own /loop).
-//   - `archive`      : claude runtime + non-claude goals leftover (alias
-//                      was previously running under codex/grok and
-//                      switched). Caller archives + clears the store + skips
-//                      the scheduler so the two /loop systems don't double-
-//                      wake. Goals are recoverable from the archive file.
-//   - `fatal`        : codex runtime + grok-leftover goals (or vice versa).
-//                      Mixing thread/session IDs across SDKs is unsafe
-//                      enough that we refuse to boot — the operator must
-//                      cancel or archive the foreign goals first.
+//   - `ok`      : current runtime matches every persisted goal (or the
+//                 store is empty). Boot normally, run the scheduler.
+//                 This is the new claude-bucket behaviour too — see
+//                 runtimeBucket comment above for why removing the
+//                 claude skip is safe (SDK-spawned claude has no native
+//                 /loop host).
+//   - `archive` : current bucket can run, but goals.json holds goals
+//                 for a DIFFERENT bucket (the alias was previously
+//                 running under another SDK runtime). Caller archives +
+//                 clears the store + boots clean, so we don't try to
+//                 reuse thread/session IDs across incompatible SDKs.
+//                 (Pre-#144 this was `fatal exit(1)` for codex↔grok,
+//                 which crashed the user's node without guidance —
+//                 hostile UX. Now: log + archive + continue.)
+//   - `skip`    : unknown runtime bucket — refuse to schedule without
+//                 a clear name → bucket mapping. Operator should check
+//                 --runtime / RUNTIME env / config.runtime.
 //
-// This is a pure function over (current bucket, goal list) so it has full
-// unit coverage; the cli.ts side just dispatches on the verdict.
+// This is a pure function over (current bucket, goal list); cli.ts
+// dispatches on the verdict. Fully unit-covered.
 // ─────────────────────────────────────────────────────────────────────
 
 export type StartupAction =
   | { kind: "ok"; runScheduler: true }
   | { kind: "skip"; runScheduler: false; reason: string }
-  | { kind: "archive"; runScheduler: false; reason: string; foreignCount: number; foreignBuckets: RuntimeBucket[] }
-  | { kind: "fatal"; runScheduler: false; reason: string; foreignCount: number; foreignBuckets: RuntimeBucket[] };
+  | { kind: "archive"; runScheduler: true; reason: string; foreignCount: number; foreignBuckets: RuntimeBucket[] };
 
 /**
  * Decide what to do at startup given the runtime the host is booting under
@@ -385,50 +391,44 @@ export function decideStartupAction(
   currentBucket: RuntimeBucket,
   goals: AgentGoal[],
 ): StartupAction {
+  // Unknown runtime label — refuse to schedule. Don't auto-archive
+  // either; we don't know what bucket this is, so we can't safely
+  // judge what's "foreign".
+  if (currentBucket === "unknown") {
+    return {
+      kind: "skip",
+      runScheduler: false,
+      reason: `unknown runtime bucket — anet scheduler refuses to run; check --runtime / RUNTIME env / config.runtime`,
+    };
+  }
+
   // Only `active` goals matter — `complete` / `cancelled` / `failed` /
-  // `paused` will not wake regardless of runtime, so they're not a threat.
+  // `paused` will not wake regardless of runtime, so they're not a
+  // foreign-bucket concern.
   const activeGoals = goals.filter((g) => g.status === "active");
 
-  if (currentBucket === "claude") {
-    if (activeGoals.length === 0) {
-      return { kind: "skip", runScheduler: false, reason: "claude runtime — native /loop in use" };
-    }
-    const foreignBuckets = uniqueBuckets(activeGoals);
+  // Any active goal whose runtime resolves to a DIFFERENT recognized
+  // bucket is "foreign". An unknown-bucket goal (legacy / future SDK
+  // label) is left alone — we already refuse to schedule unknown
+  // buckets above, and an unknown-bucket goal in a known-bucket store
+  // is harmless (it just won't have a matching runtime to dispatch).
+  const foreign = activeGoals.filter((g) => {
+    const b = runtimeBucket(g.runtime);
+    return b !== currentBucket && b !== "unknown";
+  });
+
+  if (foreign.length > 0) {
+    const foreignBuckets = uniqueBuckets(foreign);
     return {
       kind: "archive",
-      runScheduler: false,
-      reason: `claude runtime started with ${activeGoals.length} non-claude goal(s) (${foreignBuckets.join(",")}) — archive + skip scheduler so anet doesn't double-fire alongside Claude Code's native /loop`,
-      foreignCount: activeGoals.length,
+      runScheduler: true,
+      reason: `${currentBucket} runtime started but goals.json holds ${foreign.length} ${foreignBuckets.join("/")} goal(s) — archiving + clearing so we don't reuse thread/session IDs across SDK boundaries. Backup recoverable on disk.`,
+      foreignCount: foreign.length,
       foreignBuckets,
     };
   }
 
-  if (currentBucket === "codex" || currentBucket === "grok") {
-    const wrongBucket = activeGoals.filter((g) => {
-      const b = runtimeBucket(g.runtime);
-      return b !== currentBucket && b !== "unknown";
-    });
-    if (wrongBucket.length > 0) {
-      const foreignBuckets = uniqueBuckets(wrongBucket);
-      return {
-        kind: "fatal",
-        runScheduler: false,
-        reason: `${currentBucket} runtime started but goals.json holds ${wrongBucket.length} ${foreignBuckets.join("/")} goal(s) — thread / session IDs cannot be re-used across SDK runtimes. Cancel or archive the foreign goals before relaunching.`,
-        foreignCount: wrongBucket.length,
-        foreignBuckets,
-      };
-    }
-    return { kind: "ok", runScheduler: true };
-  }
-
-  // unknown bucket — runtime label we don't recognise. Refuse to run the
-  // scheduler rather than guess; do not auto-archive (we don't know what
-  // bucket this even is, so we can't claim leftover goals are "foreign").
-  return {
-    kind: "skip",
-    runScheduler: false,
-    reason: `unknown runtime bucket — anet scheduler refuses to run; check --runtime / RUNTIME env / config.runtime`,
-  };
+  return { kind: "ok", runScheduler: true };
 }
 
 function uniqueBuckets(goals: AgentGoal[]): RuntimeBucket[] {

--- a/docs/rfcs/RFC-024-agent-loop-self-management.md
+++ b/docs/rfcs/RFC-024-agent-loop-self-management.md
@@ -1,0 +1,304 @@
+# RFC-024 — Agent Loop 自感知 + 自管理
+
+> 状态: 草稿 (design-first, 待 通信龙 + Vincent review)
+> 作者: 通信SDK马
+> 关联: #144 (anet /loop universal), #184 (goals scheduler), #288 (loop-runtime-gate)
+> 日期: 2026-06-28
+
+## 1. 背景与动机
+
+#144 把 anet `/loop` 调度器统一到所有 runtime（claude-agent-sdk / codex / grok），用户现在可以用 `anet node loop <alias> "<task>" --every 5m` 给任意节点排循环任务。但 agent 自身**对自己的循环是"无感"的**：
+
+- 不知道当前在循环哪几件事
+- 没法自主调整（要用户从外部 CLI 改 / 用 `anet goal cancel` 停）
+- 不能根据任务推进情况自适应节奏（重要的事多盯、稳定的事少跑）
+
+Vincent 强需求："**agent 要自己理解 loop**" —— 不只被动执行，而是感知 + 通过自然语言对话调整管理自己的 loop。
+
+参照 Claude Code `/loop` 动态模式（本会话即跑在这套上）：agent 用 `ScheduleWakeup(delaySeconds, prompt)` **自主决定下次唤醒时刻 + 下次执行什么**。anet 要给本体 agent 等价能力。
+
+## 2. 设计目标 & 评判维度
+
+通信龙 review 卡这 5 条：
+
+| # | 维度 | 含义 |
+|---|------|------|
+| ① | **自调** | agent 能 list/edit/cancel/create/reschedule 自己的 loop |
+| ② | **智能** | LLM 自己理解意图（"太频繁了" / "重要的事多盯"），不写 NLU 规则 |
+| ③ | **Claude Code 范式** | 自调度: agent 用工具决定下次唤醒，不只固定 interval |
+| ④ | **🔴 防双调度** | anet goals scheduler 是**唯一**调度源；SDK query() 只是单次任务执行 |
+| ⑤ | **优雅** | 复用 (goals store + parser + commhub-mcp pattern) / 最小新增面 / 干净抽象 / per-runtime 共享一层 |
+
+## 3. 核心模型: 两层调度严格分离
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ 外层 (Outer): anet goals scheduler                              │
+│   ★ 唯一调度源                                                  │
+│   - runGoalSchedulerTick (cli.ts:1131) — 每 30s tick            │
+│   - 读 goals.json, 找 next_wake_at ≤ now 的 active goal         │
+│   - 决定何时唤醒 agent + 喂什么 prompt                            │
+│   - agent 用 4 个 self-loop tools 管理这一层的 goals             │
+└────────────────────────────────────────────────────────────────┘
+                          │ 唤醒
+                          ▼
+┌────────────────────────────────────────────────────────────────┐
+│ 内层 (Inner): SDK 单次任务执行                                   │
+│   - claude-agent-sdk: query() 返单次 Promise                    │
+│   - codex-sdk: thread.runStreamed() 单次返完                    │
+│   - grok-build-acp: 单次 prompt → response                      │
+│   ★ 内部 agentic-turn loop ≠ 循环, 是单次任务的执行细节            │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**防双调度的硬不变式** (#288 教训延伸):
+
+- ❌ 不允许 SDK 内部触发 anet goals 之外的"循环"——比如 SDK 未来加 self-scheduling，anet 要明确禁用或不接入。
+- ❌ 不允许 self-loop tools 在**当前 wake 的 agentic turn 内立即触发下次 wake**（防递归暴走）——cooldown 防线见 §6。
+- ✅ 一个 goal 一次 wake 一次 SDK call；SDK 内部 turn loop 是任务执行细节，不计入循环计数。
+
+## 4. Loop 自感知 (context injection)
+
+### 4.1 注入位置
+
+每次 agent 被唤醒执行 task 时（包括 `processTask` 的 inbox-任务路径 + scheduler-wake 路径），prompt 拼接前注入一段 **`【你的当前循环任务】`** 块。
+
+```
+【你的当前循环任务】 (anet goals — 你能用 manage_my_loop 工具管理这些)
+
+3f8a2b1c  active   每 5min     下次: 2026-06-28T15:35:00Z
+   监控 PR #271 进展
+
+a2b3c4d5  active   每 1d       下次: 2026-06-29T00:00:00Z
+   每天早上整理昨天的发布工作
+
+7e8f9012  paused   每 30m      暂停于: 2026-06-28T12:00:00Z
+   扫一遍 twitter 上 grok 的最新进展
+```
+
+最小实现：
+- `cli.ts:processTask` 在调 think() / 各 runtime 入口前，从 `goalStore.list()` 拉 active+paused goals
+- 用辅助函数 `formatSelfLoopsBlock(goals): string` 渲染（提取到 `goals/format.ts`）
+- 注入到 system prompt 或 user prompt preamble（claude-agent-sdk 走 systemPrompt option, codex/grok 走 prefix）
+
+### 4.2 刷新策略
+
+每次 task 执行前都重新读 `goalStore.list()`，**不缓存**。理由：
+- goalStore 已有 in-memory map + mutex，读是 O(N goals) 微秒级
+- agent 可能在上一次 turn 里调了 edit/cancel/create_my_loop，下一次 turn 必须看最新状态
+- 不缓存 = 不引入"陈旧视图"bug 类
+
+### 4.3 token 成本
+
+active goals 通常 <10 条。每条 ~80 tokens 渲染。总 <1k tokens / turn — 可接受。
+
+## 5. Loop 自管理工具
+
+### 5.1 工具集 (6 个, self-scoped)
+
+| 工具 | 用途 | 关键参数 | 语义类 |
+|------|------|---------|--------|
+| `list_my_loops` | 看自己当前所有 loops | (none) | 读 |
+| `create_my_loop` | 新建一个 loop | `task: string`, `interval: string` (parser 复用, 如 "5m"/"2h") | 写 |
+| `edit_my_loop` | 改 task/interval/状态(paused) | `goal_id`, `task?`, `interval?`, `paused?: boolean` | 写 |
+| `reschedule_my_loop` | ★ **动态自调度** — 不改 interval, 只改本轮 next_wake | `goal_id`, `next_wake_in: string` (e.g. "30m") | 写 |
+| `complete_my_loop` | ★ **达标即停** — 任务目标已实现, 主动收 | `goal_id` | 写 (终态) |
+| `cancel_my_loop` | **放弃** — 不再做了 (非达标) | `goal_id` | 写 (终态) |
+
+★ = 本设计的优雅核心 (通信龙 review 强调):
+
+**`reschedule_my_loop`** — 是 Claude Code `/loop` `ScheduleWakeup(delaySeconds, prompt)` 范式的核心抽象。agent 在执行一次 wake 时可以说"这次任务有进展但不急，下次 1h 后再看"，调 `reschedule_my_loop(goal_id, "1h")`，**本次 cycle** 的 `next_wake_at` 推迟到 1h 后但不改 interval 本身。下下次依然按原 interval 跑。比"只改 interval"高一层：agent 像 Claude Code 那样**自主决定下次什么时候醒**，而不是被动等固定周期。
+
+**`complete_my_loop`** vs `cancel_my_loop` — 语义类分清:
+- `complete`: "我把这件事做完了/达标了" → goal.status = `complete`. 用于"监控 PR 直到 merge" 这种**有明确成功条件**的循环。agent 自决任务实现即收，**防死循环**核心防线。
+- `cancel`: "不做了/不重要了/用户让停" → goal.status = `cancelled`. 用于明确放弃。
+
+两者都终态，但语义对 LLM 不同：`complete` 暗示成就，`cancel` 暗示放弃。让 agent 选对的那个，user / 审计回看时也清楚发生了什么。
+
+### 5.2 Self-scoped 不变式 (④ 安全)
+
+所有 5 个工具：
+
+```ts
+// Pseudo-impl
+async function list_my_loops(args, ctx) {
+  const myAlias = ctx.agentAlias;  // from runtime caller-binding
+  return goalStore.list();  // already file-scoped to THIS node's goals.json
+                            // — goals.json sits at .anet/nodes/<myAlias>/goals.json
+}
+
+async function edit_my_loop(args, ctx) {
+  // goal_id MUST resolve to a goal in MY goals.json (impossible to
+  // address another node's goal because goalStore is per-node-file
+  // bound). No alias arg accepted in the tool surface.
+  const g = await goalStore.get(args.goal_id);
+  if (!g) return { ok: false, error: "goal not found in your loops" };
+  // ...apply edit via goalStore.mutate()...
+}
+```
+
+**关键设计**: tools 不接受 `alias` 参数。`goalStore` 实例化时绑死本节点的 `goals.json`（已有的 P184 设计），所以 agent **物理上无法**访问别节点的 goals — 安全 by-construction，不靠 runtime check。
+
+### 5.3 共享接口 + per-runtime adapter (⑤ 优雅)
+
+定义共享接口 `agent-node/src/goals/self-loop-tools.ts`：
+
+```ts
+// 通用工具定义 — runtime-agnostic
+export const SELF_LOOP_TOOL_SPECS: Array<{
+  name: string;
+  description: string;
+  schema: ZodSchema;
+  handler: (args: any, ctx: SelfLoopCtx) => Promise<SelfLoopResult>;
+}> = [...];
+```
+
+每个 runtime adapter 把这 5 个 spec 翻译成自己的工具形式：
+
+- **claude-agent-sdk**: 在 `commhub-mcp.ts` 同款 `createSdkMcpServer({name: "loops", tools: [...]})` 里注册 → tool names `mcp__loops__list_my_loops` 等
+- **codex-sdk**: 复用 commhub MCP server 同款 stdio 通道（写一个新的 `loops-mcp.ts`），通过 codex 的 mcp_servers 配置暴露
+- **grok-build-acp**: ACP 协议的 tool 注入（参照现有 grok runtime 的 commhub 工具注入）
+
+共享 specs 一处定义，三处 adapter 各 ~20 行翻译。新增工具时改一处。
+
+## 6. Per-runtime 可行性 + 实现路径
+
+| Runtime | 工具暴露通道 | 可行性 | 实施量 |
+|---------|---------|---------|---------|
+| **claude-agent-sdk** | `createSdkMcpServer` (已有 commhub-mcp.ts 模式) | ✅ 现成路径 | ~50 行 (新 file + 注册到 query options.mcpServers) |
+| **codex-sdk** | `~/.codex/config.toml` mcp_servers 或 SDK API | ⚠ 需调研: codex SDK 是否支持运行时注入 in-process MCP, 还是必须走 config.toml + stdio subprocess | 调研 + ~80 行 (若 stdio 则起 mini server) |
+| **grok-build-acp** | ACP `McpServer` 配置 (现有 commhub 用同一模式) | ✅ 同 commhub MCP 注入路径 | ~50 行 |
+
+**Fallback**: 若某 runtime 实在塞不进 in-process MCP，**仍可让 agent 通过现有的 commhub `send_task` 给自己发 `/loop <interval> <task>` 形式的消息**。等价于 agent 用现成的 inbox `/loop` 入口 — 兜底可用，但不够优雅（要绕一圈 commhub）。
+
+## 7. 安全 & 边界
+
+### 7.1 防递归暴走
+
+agent 在 `edit_my_loop` 把 interval 改成 60s 后立即 schedule 又改… 可能写入风暴。防线：
+
+1. **Per-goal cooldown**: `edit_my_loop` / `reschedule_my_loop` 对同一 `goal_id` 在 30s 内只允许 1 次。第二次 NOP + 返 `cooldown` 信息（不报错, 不让 LLM 重试）。
+2. **`updated_at` 已是 GoalStore 现成字段**: cooldown 直接查 `now - g.updated_at < 30s`，无需新字段。
+
+### 7.2 防无限新建
+
+`create_my_loop` 在节点已有 **N=20** 个 active goals 时拒绝（返 `max_active_goals_reached`）。20 是 Vincent 实际用法的 4x 安全 margin。
+
+### 7.3 Interval 校验复用
+
+`create_my_loop` / `edit_my_loop` 的 `interval` 参数直接喂给 `parseGoalCommand("/loop " + interval + " x")`，复用 #288 的所有校验（60s floor / m/h/d / 拒 30s 等）。**parser 是唯一 interval 真理源**。
+
+### 7.4 防双调度 (④ 核心)
+
+- 所有 self-loop tools 写入只动 `goalStore`
+- **agent 不能拿到 SDK 内部 turn loop 的把柄**（claude-agent-sdk SDK 的 `query()` 不暴露 turn-level control 给我们的 tool 层）
+- 即使未来 SDK 提供 in-task self-scheduling，anet runtime 层**不接入**（防线: 不导入相关 SDK 接口）
+- 文档明写: "**一切循环 = anet goals**; SDK call 是单次任务的执行"
+
+## 8. UX 示例
+
+### 8.1 智能意图理解 (②)
+
+```
+User: 这个查邮件循环太频繁了，烦
+Agent (内部推理): 
+  - 用户对哪个 loop 不满? list_my_loops →
+    [check-mail (每 5min), pr-monitor (每 5min), ...]
+  - "查邮件" 关键词 → 锁定 check-mail
+  - "太频繁" → 调成保守一点, 30m 或 1h 合理
+  - LLM 选 30m
+Agent → edit_my_loop(goal_id="check-mail", interval="30m")
+Agent → User: "好的，已经把查邮件改成每 30 分钟一次了。如果还嫌频繁可以再说。"
+```
+
+```
+User: 那个 PR 监控的事重要，再多盯着点
+Agent → list_my_loops → 找 pr-monitor
+Agent → edit_my_loop(goal_id="pr-monitor", interval="2m")
+Agent → User: "✓ PR 监控调成每 2 分钟看一次了。"
+```
+
+### 8.2 reschedule 范式 (③)
+
+```
+[scheduler wakes agent for goal pr-monitor]
+Agent: 看 PR #271 状态... 还在 CI, 30min 后再看就够了, 不用 5min 那么紧
+Agent → reschedule_my_loop(goal_id="pr-monitor", next_wake_in="30m")
+Agent reply: "PR 在跑 CI，30min 后回看（本次推迟）"
+```
+
+下次 wake 是 30min 后；再下次回到原 5min interval 节奏。
+
+### 8.3 自决达标即停 (`complete_my_loop` 防死循环)
+
+```
+[scheduler wakes for goal monitor-pr-271]
+Agent: 看 PR #271 状态 — 已 merged! 任务达标了
+Agent → complete_my_loop(goal_id="monitor-pr-271")
+Agent reply: "✓ PR #271 已 merge, 监控循环达标完成。"
+```
+
+vs 主动放弃:
+
+```
+User: 不用监控 PR 了, 切别的优先级了
+Agent → cancel_my_loop(goal_id="monitor-pr-271")
+Agent reply: "✓ PR 监控已取消（未完成，用户切走）。"
+```
+
+两者在 goals.json 留 `status: complete` vs `status: cancelled`, 审计回看清楚分得清。
+
+## 9. 与现有入口共存
+
+三入口 (用户视角):
+
+| 入口 | 谁用 | 何时用 |
+|------|------|------|
+| `anet node loop <alias> "<task>" --every 5m` (CLI) | 外部操作员 | 批量起 / 脚本化 |
+| `/loop <interval> <task>` (inbox slash) | 在 IM / Dashboard 跟 agent 对话的用户 | 显式命令 |
+| `create_my_loop` / `edit_my_loop` (self-tool) | agent 自己 | 自然语言对话理解意图后自调 |
+
+三入口最终都写同一个 `goals.json` 通过同一个 `goalStore.upsert()`，**parser 是唯一 interval 校验**，无冲突。
+
+CLI / inbox 的 spec 文字（`docs-site/docs/guide/agent-node.md` 已写）补充: "**agent 也可以自己用工具管理自己的循环**" 一段。
+
+## 10. 实施 phases (待 review 后 impl)
+
+| Phase | 内容 | LOC 估 |
+|-------|------|--------|
+| P0 | `goals/format.ts` (formatSelfLoopsBlock) + processTask 注入 — 自感知 only | ~80 |
+| P1 | `goals/self-loop-tools.ts` 共享 specs + claude-agent-sdk adapter — 6 tools (含 ★reschedule + ★complete) | ~150 |
+| P2 | codex-sdk adapter (调研后) | ~80-150 |
+| P3 | grok-build-acp adapter | ~50 |
+| P4 | 安全防线 (cooldown / max-goals / parser 复用 wiring) + 单测 | ~100 |
+| P5 | 端到端 Docker e2e (各 runtime 实测「agent 改自己 loop」流) | ~150 |
+
+Total: ~600 LOC, 4-6 working hours impl + 2-3h 测.
+
+## 11. Open questions (等 review 拍)
+
+1. **`list_my_loops` 返结构 vs 字符串?** 倾向: 返结构化 `{goals: [...]}`, 让 LLM 自己渲染给 user 看。
+2. **`reschedule_my_loop` 跟 `edit_my_loop(interval)` 是否合并?** 倾向: 分开 — `reschedule` 不改 interval 只改 next_wake (一次性 skip-ahead/delay), `edit` 改 interval (周期性). 语义清晰。
+3. **paused → active 是否需要重新校验 interval?** 倾向: 不需要, paused 时 interval 没变, 直接复活。
+4. **context-injection block 放 system prompt 还是 user-message preamble?** 倾向: system prompt (agent 把它当"我自身状态"而非"用户告诉我"). claude-agent-sdk 走 `systemPrompt` option, codex/grok 各 adapter 自己拼。
+5. **20 个 goals 上限是否需 env 可调?** 倾向: 加 `COMMHUB_MAX_GOALS_PER_NODE` env, 默认 20。
+
+## 12. Non-goals (本 RFC 不涵盖, 留 follow-up)
+
+- 跨节点 loops 管理 (agent 帮另一个 agent 管 loop) — 复杂权限模型, 留 v0.13+
+- Goals 历史/审计可视化 (Dashboard view) — Dashboard team 单独 RFC
+- Loop 执行结果归档/检索 (LLM 看过去 N 轮的输出) — `progress_log` 已存, 但访问工具是另一个面
+- Multi-agent collaborative loops (一组 agents 共享一个 goal) — 太重, 暂不接
+
+---
+
+**Review checkpoints** (通信龙 + Vincent):
+- [ ] ② 智能 — 工具描述足够引导 LLM 做意图理解吗?
+- [ ] ③ Claude Code 范式 — `reschedule_my_loop` 抽象抓住 ScheduleWakeup 精髓吗?
+- [ ] ④ 防双调度 — 文档/不变式够明确吗? 有 SDK side-channel 风险吗?
+- [ ] ⑤ 优雅 — 复用够多吗? 抽象够干净吗?
+- [ ] Per-runtime 估工量合理吗? codex 那块需要先 spike?
+
+**ETA**:
+- P0 + P1 ship preview3 候选 (4-5h)
+- P2-P5 跟 v0.12 一起 (1-2 day)

--- a/docs/rfcs/RFC-025-agent-loop-self-management.md
+++ b/docs/rfcs/RFC-025-agent-loop-self-management.md
@@ -1,4 +1,4 @@
-# RFC-024 — Agent Loop 自感知 + 自管理
+# RFC-025 — Agent Loop 自感知 + 自管理
 
 > 状态: 草稿 (design-first, 待 通信龙 + Vincent review)
 > 作者: 通信SDK马
@@ -57,6 +57,64 @@ Vincent 强需求："**agent 要自己理解 loop**" —— 不只被动执行�
 - ❌ 不允许 self-loop tools 在**当前 wake 的 agentic turn 内立即触发下次 wake**（防递归暴走）——cooldown 防线见 §6。
 - ✅ 一个 goal 一次 wake 一次 SDK call；SDK 内部 turn loop 是任务执行细节，不计入循环计数。
 
+### 3.1 `claude-code-cli` — 范围外 (用原生 CC /loop)
+
+Per Vincent: `claude-code-cli` 一直用 Claude Code 原生 /loop 自管, 不接 anet scheduler / self-loop tools. 本 RFC 范围 = **claude-agent-sdk / codex / grok 三个 agent-node runtime**. 双触发风险已 ruled out (claude-code-cli 是独立 CC session, 不经 agent-node, 不碰 anet goals.json). 见 §6 per-runtime 表 + §12 non-goals.
+
+### 3.2 设计缺口 (独立 LLM-validation review 抓到, 折进本 RFC)
+
+通信龙 起独立 agent 用 3 个 LLM context 跑 8 句自然语言测「LLM 能否从工具 description 解析意图 + 调对工具」, **工具选择 100% 一致** — 核心 premise (②智能) 成立. 但抓到 **5 个真设计缺口**, 全部折进本 RFC:
+
+#### 🔴 #1 时间点 / cron-lite 调度缺口 (最重要)
+
+interval 模型只表达 **「每隔多久」** (5m/2h/1d), 但**「每天早上9点」「每周一」「工作日」「每月1号」**这种 **wall-clock** 表达不了. **Vincent 自己举的例子** ("每天早上9点发摘要") 不在当前数据模型覆盖范围.
+
+LLM-validation 实测: 3 个 LLM 都硬凑 `create(1d) + reschedule "算到下个9点几小时"` —— 都自标"只是近似" + LLM 时钟运算易飘 + DST/相位漂移 + 「每周一/工作日」完全没法映射. **且 LLM 倾向静默近似而不报"做不到" = 危险**.
+
+**修法 (二选一, 待 review 拍)**:
+- **(A) 加 cron-lite 调度字段** — `AgentGoal` 增加 `schedule?: { type: 'interval' | 'time_of_day' | 'weekday', value: string }` 联合类型:
+  - `{type:'interval', value:'5m'}` (现状)
+  - `{type:'time_of_day', value:'09:00'}` — 每天该时刻 (含时区)
+  - `{type:'weekday', value:'mon 09:00'}` — 每周指定
+  - 复用现有 `next_wake_at` 字段, 调度器 tick 时计算下一个匹配 wall-clock
+- **(B) parser/工具显式拒 wall-clock 请求** — 让 agent 如实告诉用户「目前只支持间隔不支持指定时间点, 你想要 24h 间隔还是其他?」, 不静默凑
+
+**倾向 (A)**: 「每天早上9点」是最常见用户说法 + Vincent 例子 + cron-lite 加 80 行调度代码可解决, 价值高. (B) 太将就.
+
+新数据字段 + 调度器 wake 决策更新 + 工具 `create_my_loop` / `edit_my_loop` 新增 `schedule` 参数 (跟旧 `interval` 互斥) — 列入 §10 P0/P1.
+
+#### #2 防误删 — 批量 / destructive 操作要 confirm-back
+
+`cancel_my_loop` 现在立即执行无确认. LLM-validation 测「把所有循环停了」3 个 LLM 都选了**可逆的 `edit(paused=true)` + 先 list-first** (好直觉), 但**设计没强制** — 换个措辞「全删了」就一次性 cancel 光. 不能依赖 LLM 直觉.
+
+**修**: destructive / 批量 loop 操作走 **confirm-back 模式** (符合 anet [RFC-023 destructive-command-guardrail](./RFC-023-destructive-command-guardrail.md) 规范):
+- 单 `cancel_my_loop` ok 直接执行
+- N 个连续 `cancel_my_loop` 在短时间窗 (3 次/30s) 触发批量警告: 工具 return `{ok:false, error:'batch_destructive_confirm_required', message:'用户是否确认要取消这些 goals?<list>'}` agent 必须问用户再 retry
+
+实现成本: ~30 LOC counter + return-shape 约定. 列入 §7 安全防线扩展.
+
+#### #3 编造的参数值要回报给用户
+
+LLM-validation #1 「太频繁」无具体数字, 3 个 LLM 都猜 30m. **一致 ≠ 对** — 用户可能想 1h 或 15m. 工具选对了但**量级是猜的**.
+
+**修**: agent 调 `edit_my_loop` / `create_my_loop` 改 / 设 interval 后, **回报给用户具体新值** ("已改成 30 分钟一次, 这个频率合适吗?") — 静默猜错变廉价纠正. 不需工具改, 用 tool description 提示:
+
+> `edit_my_loop` description 加: "用户没给具体数字时, 选合理值后**回报新值**给用户(中文/英文)让用户能纠正. 例: 用户说'太频繁了' → 改成 30m → 回'好的, 改成每 30 分钟一次了'"
+
+#### #4 pause / cancel / complete 描述拉开语义
+
+三个语义相邻 (都是「停」). 干净措辞下 3/3 区分对, 但糊措辞「这个别跑了」掷硬币. tool descriptions 必须明示对比:
+
+- `pause` (edit_my_loop 的 paused=true) = **临时**, 可 resume, goal 保留 active 概念但不 fire
+- `cancel_my_loop` = **永久放弃**, status 改 `cancelled`, 用于不再做这件事
+- `complete_my_loop` = **达标归档**, status 改 `complete`, 用于"已完成"
+
+每个工具 description 含一句对比性提示防混淆. 列入 §5 工具表更新.
+
+#### #5 多 loop 状态再测 — 指代消解
+
+LLM-validation 测试都在 **单/少 loop** 状态. 「这个/重要的那个/查邮件那个」指代消解的难度被掩盖. **ship 前必跑 3-5 个 loop 状态的指代/批量歧义测**. 列入 §10 P5 e2e 矩阵.
+
 ## 4. Loop 自感知 (context injection)
 
 ### 4.1 注入位置
@@ -96,14 +154,14 @@ active goals 通常 <10 条。每条 ~80 tokens 渲染。总 <1k tokens / turn �
 
 ### 5.1 工具集 (6 个, self-scoped)
 
-| 工具 | 用途 | 关键参数 | 语义类 |
-|------|------|---------|--------|
-| `list_my_loops` | 看自己当前所有 loops | (none) | 读 |
-| `create_my_loop` | 新建一个 loop | `task: string`, `interval: string` (parser 复用, 如 "5m"/"2h") | 写 |
-| `edit_my_loop` | 改 task/interval/状态(paused) | `goal_id`, `task?`, `interval?`, `paused?: boolean` | 写 |
-| `reschedule_my_loop` | ★ **动态自调度** — 不改 interval, 只改本轮 next_wake | `goal_id`, `next_wake_in: string` (e.g. "30m") | 写 |
-| `complete_my_loop` | ★ **达标即停** — 任务目标已实现, 主动收 | `goal_id` | 写 (终态) |
-| `cancel_my_loop` | **放弃** — 不再做了 (非达标) | `goal_id` | 写 (终态) |
+| 工具 | 用途 + tool description 提示 (LLM 引导关键) | 关键参数 | 语义类 |
+|------|----------|---------|--------|
+| `list_my_loops` | 看自己当前所有 loops. **用户提到「这个/那个」时先 list 再确认指代** | (none) | 读 |
+| `create_my_loop` | 新建一个 loop. 用户没给具体数字时选合理值后**回报新值** ("已设成每 X 分钟一次") 让用户纠正 (per §3.2 #3) | `task: string`, `schedule: ...` (含 interval / time_of_day / weekday, 见 §3.2 #1) | 写 |
+| `edit_my_loop` | 改 task / interval / 暂停 (`paused=true` **临时**, 可后续 resume). 改 interval 后必**回报新值**给用户 | `goal_id`, `task?`, `interval?`, `paused?: boolean` | 写 |
+| `reschedule_my_loop` | ★ **动态自调度** — 不改 interval, 只跳过本轮把 next_wake 推到指定时刻. 任务"这次有进展但不急, 下次 1h 后再看"专用 | `goal_id`, `next_wake_in: string` (e.g. "30m") | 写 |
+| `complete_my_loop` | ★ **达标归档** — 任务目标已实现 (e.g. PR merged / 报告交付). status=`complete`. **不同于 cancel**: 这是成就, 不是放弃 | `goal_id` | 写 (终态) |
+| `cancel_my_loop` | **永久放弃** — 不再做这件事 (非达标). status=`cancelled`. **不同于 pause/complete**: 这是放弃, 不可恢复. **批量取消 (3 次/30s 窗) 触发 confirm-back, 工具拒绝直接执行, 让 agent 回问用户确认** (per §3.2 #2) | `goal_id` | 写 (终态) |
 
 ★ = 本设计的优雅核心 (通信龙 review 强调):
 
@@ -163,11 +221,12 @@ export const SELF_LOOP_TOOL_SPECS: Array<{
 
 ## 6. Per-runtime 可行性 + 实现路径
 
-| Runtime | 工具暴露通道 | 可行性 | 实施量 |
-|---------|---------|---------|---------|
-| **claude-agent-sdk** | `createSdkMcpServer` (已有 commhub-mcp.ts 模式) | ✅ 现成路径 | ~50 行 (新 file + 注册到 query options.mcpServers) |
-| **codex-sdk** | `~/.codex/config.toml` mcp_servers 或 SDK API | ⚠ 需调研: codex SDK 是否支持运行时注入 in-process MCP, 还是必须走 config.toml + stdio subprocess | 调研 + ~80 行 (若 stdio 则起 mini server) |
-| **grok-build-acp** | ACP `McpServer` 配置 (现有 commhub 用同一模式) | ✅ 同 commhub MCP 注入路径 | ~50 行 |
+| Runtime | 范围 | 工具暴露通道 | 可行性 | 实施量 |
+|---------|---------|---------|---------|---------|
+| **claude-agent-sdk** | ✅ 本 RFC 覆盖 | `createSdkMcpServer` (已有 commhub-mcp.ts 模式) | ✅ 现成路径 | ~50 行 (新 file + 注册到 query options.mcpServers) |
+| **codex-sdk** | ✅ 本 RFC 覆盖 | `~/.codex/config.toml` mcp_servers 或 SDK API | ⚠ 需调研: codex SDK 是否支持运行时注入 in-process MCP, 还是必须走 config.toml + stdio subprocess | 调研 + ~80 行 (若 stdio 则起 mini server) |
+| **grok-build-acp** | ✅ 本 RFC 覆盖 | ACP `McpServer` 配置 (现有 commhub 用同一模式) | ✅ 同 commhub MCP 注入路径 | ~50 行 |
+| **claude-code-cli** | ❌ **范围外** (per Vincent) | (N/A — 用 CC 原生 /loop + CronCreate / ScheduleWakeup, 独立 CC session, 不接 anet) | — | 0 (不实施) |
 
 **Fallback**: 若某 runtime 实在塞不进 in-process MCP，**仍可让 agent 通过现有的 commhub `send_task` 给自己发 `/loop <interval> <task>` 形式的消息**。等价于 agent 用现成的 inbox `/loop` 入口 — 兜底可用，但不够优雅（要绕一圈 commhub）。
 
@@ -266,14 +325,15 @@ CLI / inbox 的 spec 文字（`docs-site/docs/guide/agent-node.md` 已写）补�
 
 | Phase | 内容 | LOC 估 |
 |-------|------|--------|
-| P0 | `goals/format.ts` (formatSelfLoopsBlock) + processTask 注入 — 自感知 only | ~80 |
-| P1 | `goals/self-loop-tools.ts` 共享 specs + claude-agent-sdk adapter — 6 tools (含 ★reschedule + ★complete) | ~150 |
+| P0a | **§3.2 #1 cron-lite schedule field** — AgentGoal 增 `schedule?` 联合类型 (interval/time_of_day/weekday) + scheduler tick 计算 next_wake_at 改造 + parser 扩展接受 wall-clock 表达 | ~120 |
+| P0b | `goals/format.ts` (formatSelfLoopsBlock) + processTask 注入 — 自感知 only | ~80 |
+| P1 | `goals/self-loop-tools.ts` 共享 specs + claude-agent-sdk adapter — 6 tools (含 ★reschedule + ★complete, 含 §3.2 #2 confirm-back batch guard, 含 §3.2 #4 description 反差措辞) | ~180 |
 | P2 | codex-sdk adapter (调研后) | ~80-150 |
 | P3 | grok-build-acp adapter | ~50 |
 | P4 | 安全防线 (cooldown / max-goals / parser 复用 wiring) + 单测 | ~100 |
-| P5 | 端到端 Docker e2e (各 runtime 实测「agent 改自己 loop」流) | ~150 |
+| P5 | 端到端 Docker e2e (各 runtime 实测「agent 改自己 loop」流) + **§3.2 #5 多 loop 指代消解 e2e** (3-5 个 loop 状态下「这个/那个/重要的」歧义测) | ~180 |
 
-Total: ~600 LOC, 4-6 working hours impl + 2-3h 测.
+Total: ~720 LOC, 5-7 working hours impl + 3-4h 测. (上调 from 600 LOC: cron-lite 加 120 + confirm-back 加 30 + multi-loop e2e 加 30)
 
 ## 11. Open questions (等 review 拍)
 
@@ -282,9 +342,13 @@ Total: ~600 LOC, 4-6 working hours impl + 2-3h 测.
 3. **paused → active 是否需要重新校验 interval?** 倾向: 不需要, paused 时 interval 没变, 直接复活。
 4. **context-injection block 放 system prompt 还是 user-message preamble?** 倾向: system prompt (agent 把它当"我自身状态"而非"用户告诉我"). claude-agent-sdk 走 `systemPrompt` option, codex/grok 各 adapter 自己拼。
 5. **20 个 goals 上限是否需 env 可调?** 倾向: 加 `COMMHUB_MAX_GOALS_PER_NODE` env, 默认 20。
+6. **§3.2 #1 cron-lite (A) vs 显式拒 (B)?** 倾向 (A) — Vincent 例子「每天9点」太常见, 静默近似太危险, 加 cron-lite 80 LOC 解决一类需求。需 review 拍 (A 增数据模型字段 + scheduler 改, 但收益高).
+7. **§3.2 #2 confirm-back 阈值** — 3 次/30s 窗口合理吗? 太严会卡正常批量管理, 太松失去防线意义。
+8. **时区处理** — `time_of_day '09:00'` 跟哪个时区对齐? 服务器 TZ / 节点 config 显式声明 / 用户首次设时让 agent 问? 倾向: 节点 config 加 `flags.timezone`, agent create 时落, 工具用此. 默认 `Asia/Shanghai` (Vincent / 团队主时区).
 
 ## 12. Non-goals (本 RFC 不涵盖, 留 follow-up)
 
+- **`claude-code-cli` runtime** — 用 CC 原生 /loop (CronCreate / ScheduleWakeup) 自管, 独立 session, 不接 anet self-loop tools (per Vincent §3.1)
 - 跨节点 loops 管理 (agent 帮另一个 agent 管 loop) — 复杂权限模型, 留 v0.13+
 - Goals 历史/审计可视化 (Dashboard view) — Dashboard team 单独 RFC
 - Loop 执行结果归档/检索 (LLM 看过去 N 轮的输出) — `progress_log` 已存, 但访问工具是另一个面

--- a/docs/rfcs/RFC-025-agent-loop-self-management.md
+++ b/docs/rfcs/RFC-025-agent-loop-self-management.md
@@ -335,16 +335,20 @@ CLI / inbox 的 spec 文字（`docs-site/docs/guide/agent-node.md` 已写）补�
 
 Total: ~720 LOC, 5-7 working hours impl + 3-4h 测. (上调 from 600 LOC: cron-lite 加 120 + confirm-back 加 30 + multi-loop e2e 加 30)
 
-## 11. Open questions (等 review 拍)
+## 11. Resolved decisions (通信龙 lead-level 裁定 2026-06-28, 待 Vincent 产品级拍)
 
-1. **`list_my_loops` 返结构 vs 字符串?** 倾向: 返结构化 `{goals: [...]}`, 让 LLM 自己渲染给 user 看。
-2. **`reschedule_my_loop` 跟 `edit_my_loop(interval)` 是否合并?** 倾向: 分开 — `reschedule` 不改 interval 只改 next_wake (一次性 skip-ahead/delay), `edit` 改 interval (周期性). 语义清晰。
-3. **paused → active 是否需要重新校验 interval?** 倾向: 不需要, paused 时 interval 没变, 直接复活。
-4. **context-injection block 放 system prompt 还是 user-message preamble?** 倾向: system prompt (agent 把它当"我自身状态"而非"用户告诉我"). claude-agent-sdk 走 `systemPrompt` option, codex/grok 各 adapter 自己拼。
-5. **20 个 goals 上限是否需 env 可调?** 倾向: 加 `COMMHUB_MAX_GOALS_PER_NODE` env, 默认 20。
-6. **§3.2 #1 cron-lite (A) vs 显式拒 (B)?** 倾向 (A) — Vincent 例子「每天9点」太常见, 静默近似太危险, 加 cron-lite 80 LOC 解决一类需求。需 review 拍 (A 增数据模型字段 + scheduler 改, 但收益高).
-7. **§3.2 #2 confirm-back 阈值** — 3 次/30s 窗口合理吗? 太严会卡正常批量管理, 太松失去防线意义。
-8. **时区处理** — `time_of_day '09:00'` 跟哪个时区对齐? 服务器 TZ / 节点 config 显式声明 / 用户首次设时让 agent 问? 倾向: 节点 config 加 `flags.timezone`, agent create 时落, 工具用此. 默认 `Asia/Shanghai` (Vincent / 团队主时区).
+| # | Question | Resolution | Rationale |
+|---|----------|-----------|-----------|
+| 1 | `list_my_loops` 返结构 vs 字符串 | **结构化 `{goals: [...]}`** | agent + dashboard 都能渲染 + 程序可读 |
+| 2 | `reschedule_my_loop` vs `edit_my_loop(interval)` 合并/分? | **分开** | 语义不同: reschedule=一次性下次唤醒 (ScheduleWakeup 范式动态自调度), edit(interval)=改循环周期. 分开是优雅核心. |
+| 3 | paused→active 是否重新校验 interval? | **重新校验** | resume 时重验 interval/schedule 仍合法 (防 paused 期间 cap/规则变了) |
+| 4 | context-injection 放 system 还是 user prompt? | **system prompt** | agent 当前 loop 状态属"它自己配置/状态", 不放 user prompt |
+| 5 | 20 cap env 可调? | **`COMMHUB_MAX_GOALS_PER_NODE` env + 默认 20** | env 配置 + sane default |
+| 6 | §3.2 #1 cron-lite (A) vs 显式拒 (B)? | **(A) 加 schedule field union** | Vincent「每天9点」必须支持, B 会阉割功能. schedule = interval \| time_of_day \| weekday 联合类型, 干净 |
+| 7 | §3.2 #2 confirm-back 阈值? | **3 cancels/30s 作默认 + env 可调** | 不太严不太松, 操作员能调 |
+| 8 | 时区处理? | **节点 config `flags.timezone`, 默认 `Asia/Shanghai`** | 尊重节点配置, fallback 用 Vincent/团队主时区. `time_of_day` 调度按节点时区算 |
+
+**全部 resolved**. Vincent 产品级 review 通过后接 impl P0a-P5.
 
 ## 12. Non-goals (本 RFC 不涵盖, 留 follow-up)
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -25,7 +25,10 @@ COPY tests/docker-config-priority.sh /app/test-config.sh
 COPY tests/demo-quickstart.sh /app/demo.sh
 COPY tests/docker-e2e-auth.sh /app/test-auth.sh
 COPY tests/docker-e2e-networks.sh /app/test-networks.sh
-RUN chmod +x /app/test.sh /app/test-codex.sh /app/test-claude.sh /app/test-game.sh /app/test-config.sh /app/test-minimax.sh /app/test-all.sh /app/demo.sh /app/test-auth.sh /app/test-networks.sh
+COPY tests/docker-e2e-loop-runtime.sh /app/test-loop-runtime.sh
+COPY tests/docker-e2e-loop-npm-pack.sh /app/test-loop-npm-pack.sh
+COPY tests/lib /app/lib
+RUN chmod +x /app/test.sh /app/test-codex.sh /app/test-claude.sh /app/test-game.sh /app/test-config.sh /app/test-minimax.sh /app/test-all.sh /app/demo.sh /app/test-auth.sh /app/test-networks.sh /app/test-loop-runtime.sh /app/test-loop-npm-pack.sh
 RUN cd /app/server && bun install
 
 # Install local agent-node globally (build from source)

--- a/tests/docker-e2e-loop-npm-pack.sh
+++ b/tests/docker-e2e-loop-npm-pack.sh
@@ -17,6 +17,21 @@
 #      end-to-end against a freshly-installed-from-tgz environment
 
 set -e
+
+# Safe-rm guardrail per the 2026-06-16 incident. lint guard enforces.
+SAFE_RM_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/safe-rm.sh"
+if [ -f "$SAFE_RM_LIB" ]; then
+  source "$SAFE_RM_LIB"
+else
+  for cand in /app/tests/lib/safe-rm.sh /app/lib/safe-rm.sh; do
+    [ -f "$cand" ] && source "$cand" && break
+  done
+fi
+type safe_rm_rf > /dev/null 2>&1 || {
+  echo "FATAL: safe-rm.sh not found — refusing to run with bare rm -rf"
+  exit 99
+}
+
 PASS=0
 FAIL=0
 
@@ -104,7 +119,7 @@ NET_ID=$(echo "$REG" | python3 -c "import sys,json;print(json.load(sys.stdin).ge
 
 ALIAS="pack-test-claude"
 WORKDIR="/tmp/pack-test-claude"
-rm -rf "$WORKDIR"
+safe_rm_rf "$WORKDIR"
 mkdir -p "$WORKDIR/.anet/nodes/$ALIAS"
 cat > "$WORKDIR/.anet/nodes/$ALIAS/config.json" <<EOF
 {
@@ -170,6 +185,8 @@ echo ""
 echo "========================================="
 echo "  npm-pack smoke: $PASS pass, $FAIL fail"
 echo "========================================="
+# Format for test-all.sh's run_suite regex.
+echo "Results: $PASS passed, $FAIL failed"
 
 if [ $FAIL -eq 0 ]; then
   echo "🎉 npm-pack install path verified — user install will work"

--- a/tests/docker-e2e-loop-npm-pack.sh
+++ b/tests/docker-e2e-loop-npm-pack.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# #144 round-6 — npm-pack install smoke for the `anet node loop` path.
+#
+# Per 通信龙 "用 npm pack 本地 tarball" — `npm pack` produces the same
+# .tgz artifact that `npm publish` uploads, so installing from .tgz
+# proves the user-install path WITHOUT needing to actually publish to
+# the registry. This catches "source builds work but the user's npm
+# install is broken" regressions (per [[feedback_docker_smoke_gate_before_ship]]
+# / [[feedback_anet_node_behavior_stale_install]]).
+#
+# Pass criteria:
+#   1. npm pack succeeds for agent-network, agent-node, server
+#   2. Global install from .tgz succeeds — `anet` binary on PATH,
+#      `agent-node` binary on PATH, `commhub-server` available
+#   3. `anet node loop --help` prints the new help text
+#   4. `anet node loop <alias> "<task>" --every 5m` creates the goal
+#      end-to-end against a freshly-installed-from-tgz environment
+
+set -e
+PASS=0
+FAIL=0
+
+pass() { echo "  ✅ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+
+echo ""
+echo "========================================="
+echo "  #144 — npm-pack install smoke (user install path)"
+echo "========================================="
+echo ""
+
+# 1. npm pack each package — produces the EXACT artifact npm publish uploads
+echo "1. Running npm pack on each package..."
+cd /app/agent-node && npm pack --silent > /tmp/pack-node.log 2>&1 \
+  && NODE_TGZ=$(ls -1 /app/agent-node/*.tgz | head -1) \
+  && pass "agent-node: packed → $(basename $NODE_TGZ)" \
+  || { fail "agent-node npm pack failed"; cat /tmp/pack-node.log; exit 1; }
+
+cd /app/agent-network && npm pack --silent > /tmp/pack-net.log 2>&1 \
+  && NET_TGZ=$(ls -1 /app/agent-network/*.tgz | head -1) \
+  && pass "agent-network: packed → $(basename $NET_TGZ)" \
+  || { fail "agent-network npm pack failed"; cat /tmp/pack-net.log; exit 1; }
+
+cd /app/server && npm pack --silent > /tmp/pack-server.log 2>&1 \
+  && SERVER_TGZ=$(ls -1 /app/server/*.tgz | head -1) \
+  && pass "commhub-server: packed → $(basename $SERVER_TGZ)" \
+  || { fail "commhub-server npm pack failed"; cat /tmp/pack-server.log; exit 1; }
+
+# 2. Uninstall the source-installed versions first (we need a CLEAN
+# state to confirm the .tgz install actually wires the binaries)
+echo ""
+echo "2. Uninstalling source-installed versions to get clean state..."
+npm uninstall -g @sleep2agi/agent-network @sleep2agi/agent-node @sleep2agi/commhub-server --silent 2>/dev/null || true
+# Source-install path used `npm link` + `npm install -g .` which may
+# leave binaries; double-check `anet` is gone or about to be
+# overwritten.
+pass "removed source-installed @sleep2agi/* packages"
+
+# 3. Install from the .tgz artifacts (this is what `npm publish`
+#    followed by `npm install -g @sleep2agi/...` produces on a user's
+#    machine — modulo registry round-trip).
+echo ""
+echo "3. Installing from .tgz tarballs (user install simulation)..."
+npm install -g "$NODE_TGZ" "$NET_TGZ" "$SERVER_TGZ" --silent > /tmp/install.log 2>&1 \
+  && pass "npm install -g <tgz> succeeded for all 3 packages" \
+  || { fail "npm install -g <tgz> failed"; cat /tmp/install.log; exit 1; }
+
+# 4. Verify binaries land on PATH
+echo ""
+echo "4. Verifying binaries are on PATH..."
+command -v anet > /dev/null && pass "anet binary present at $(which anet)" || fail "anet missing from PATH"
+command -v agent-node > /dev/null && pass "agent-node binary present at $(which agent-node)" || fail "agent-node missing from PATH"
+command -v commhub-server > /dev/null && pass "commhub-server binary present at $(which commhub-server)" || fail "commhub-server missing from PATH"
+
+# 5. `anet node loop --help` should show the new help text
+echo ""
+echo "5. Verifying 'anet node loop --help' shows the new command..."
+HELP_OUT=$(anet node loop --help 2>&1 || true)
+if echo "$HELP_OUT" | grep -q "anet node loop"; then
+  pass "anet node loop --help shows command usage"
+else
+  fail "anet node loop --help missing — command not wired in installed package"
+  echo "$HELP_OUT" | head -10
+fi
+
+# 6. Full e2e: hub + node + CLI loop creation, using ONLY the installed
+#    binaries (no /app/ source paths in the run)
+echo ""
+echo "6. Full e2e using installed binaries..."
+rm -f /tmp/commhub-pack.db /tmp/commhub-pack.db-wal /tmp/commhub-pack.db-shm
+COMMHUB_DB=/tmp/commhub-pack.db PORT=9211 \
+  commhub-server > /tmp/pack-hub.log 2>&1 &
+HUB_PID=$!
+sleep 4
+curl -s http://127.0.0.1:9211/health | grep -q '"ok":true' \
+  && pass "commhub-server (from .tgz) started on :9211" \
+  || { fail "commhub-server failed"; cat /tmp/pack-hub.log | tail -20; exit 1; }
+
+REG=$(curl -s -X POST http://127.0.0.1:9211/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username":"pack-test","password":"PackTestPw123","display_name":"pack test"}')
+NET_TOKEN=$(echo "$REG" | python3 -c "import sys,json;print(json.load(sys.stdin).get('network_token',''))")
+NET_ID=$(echo "$REG" | python3 -c "import sys,json;print(json.load(sys.stdin).get('network_id',''))")
+
+ALIAS="pack-test-claude"
+WORKDIR="/tmp/pack-test-claude"
+rm -rf "$WORKDIR"
+mkdir -p "$WORKDIR/.anet/nodes/$ALIAS"
+cat > "$WORKDIR/.anet/nodes/$ALIAS/config.json" <<EOF
+{
+  "alias": "$ALIAS",
+  "runtime": "claude-agent-sdk",
+  "hub": "http://127.0.0.1:9211",
+  "model": "claude-sonnet-4-6",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+}
+EOF
+
+cd "$WORKDIR"
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS" \
+  --config "$WORKDIR/.anet/nodes/$ALIAS/config.json" \
+  > /tmp/pack-agent.log 2>&1 &
+AGENT_PID=$!
+
+DEADLINE=$(($(date +%s) + 12))
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "已注册到 CommHub" /tmp/pack-agent.log && break
+  sleep 1
+done
+
+# THE LOAD-BEARING CHECK: real installed `anet` binary on real
+# installed agent-node, real user CLI flow.
+COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9211" \
+  anet node loop "$ALIAS" "pack-install probe" --every 5m \
+  > /tmp/pack-cli.log 2>&1 || true
+
+if grep -q "✅ Scheduled loop" /tmp/pack-cli.log; then
+  pass "anet node loop (from .tgz install) → goal created end-to-end"
+elif grep -q "❌ Node rejected" /tmp/pack-cli.log; then
+  fail "installed anet rejected /loop — parser/CLI not wired same in .tgz"
+  cat /tmp/pack-cli.log
+elif grep -q "did not confirm" /tmp/pack-cli.log; then
+  fail "installed anet did not get reply — install path silent-fail"
+  cat /tmp/pack-cli.log
+  echo "--- agent log ---"
+  tail -20 /tmp/pack-agent.log
+else
+  fail "unexpected CLI output:"
+  cat /tmp/pack-cli.log
+fi
+
+# Verify goal landed in the workdir's goals.json
+GOAL_COUNT=$(python3 -c "import json,os;p='$WORKDIR/.anet/nodes/$ALIAS/goals.json';d=json.load(open(p)) if os.path.exists(p) else {};print(len([g for g in d.get('goals',[]) if g.get('status')=='active']))" 2>/dev/null)
+if [ "$GOAL_COUNT" -ge 1 ]; then
+  pass "goals.json: $GOAL_COUNT active goal(s) — full install→CLI→parser→goal path verified"
+else
+  fail "goals.json: no active goal after install path"
+fi
+
+# Cleanup
+kill $AGENT_PID 2>/dev/null || true
+kill $HUB_PID 2>/dev/null || true
+wait $AGENT_PID $HUB_PID 2>/dev/null || true
+
+echo ""
+echo "========================================="
+echo "  npm-pack smoke: $PASS pass, $FAIL fail"
+echo "========================================="
+
+if [ $FAIL -eq 0 ]; then
+  echo "🎉 npm-pack install path verified — user install will work"
+  exit 0
+else
+  echo "❌ npm-pack install regression — user install would break"
+  exit 1
+fi

--- a/tests/docker-e2e-loop-runtime.sh
+++ b/tests/docker-e2e-loop-runtime.sh
@@ -61,8 +61,22 @@ NET_ID=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(
   || { fail "user registration failed: $REG"; exit 1; }
 
 # 2. Test claude-agent-sdk runtime — the load-bearing one
+#
+# This test exercises the FULL user path:
+#
+#   1. Start the node (no pre-injected goals.json)
+#   2. Run the real `anet node loop` CLI command (the one Vincent will type)
+#   3. CLI emits `/loop 5m <task>` via /api/task
+#   4. Node inbox handler routes through parser.parseGoalCommand
+#   5. Goal lands in goals.json
+#   6. Scheduler tick fires [goal] wake
+#
+# Previous e2e iteration wrote goals.json directly, bypassing the
+# parser — that hid the silent-fail bug independent-reviewer caught
+# on round 6 (`5m` was not in parser's word-only INTERVAL_PATTERNS).
+
 echo ""
-echo "2. claude-agent-sdk runtime — scheduler enable + wake fire..."
+echo "2. claude-agent-sdk runtime — full CLI → parser → goal → wake fire..."
 
 ALIAS_CLAUDE="loop-test-claude"
 WORKDIR_CLAUDE="/tmp/loop-test-claude"
@@ -76,79 +90,145 @@ cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" <<EOF
   "model": "claude-sonnet-4-6",
   "token": "$NET_TOKEN",
   "network_id": "$NET_ID",
-  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000", "goalAcceptSubMinute": true }
 }
 EOF
-
-# Pre-inject a claude-runtime goal with 5s interval, next_wake_at = now
-# so the very first tick after startup fires it.
-NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
-PAST_ISO=$(date -u -d "1 minute ago" +%Y-%m-%dT%H:%M:%S.000Z)
-GOAL_ID="goal-claude-e2e-${RANDOM}"
-cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json" <<EOF
-{
-  "version": 1,
-  "goals": [
-    {
-      "goal_id": "$GOAL_ID",
-      "text": "e2e probe: confirm scheduler fires this wake",
-      "status": "active",
-      "interval_ms": 5000,
-      "next_wake_at": "$PAST_ISO",
-      "runtime": "claude-agent-sdk",
-      "created_at": "$NOW_ISO",
-      "updated_at": "$NOW_ISO",
-      "progress_log": []
-    }
-  ]
-}
-EOF
-pass "pre-injected claude-runtime goal (id=${GOAL_ID:0:8}, interval=5s, next_wake_at in past)"
+# NOTE: the test uses interval `5m` which the parser enforces as
+# 60_000 ms minimum. Real wake firing in 25s requires interval >= tick
+# (default 30s, here 5s) AND >= MIN_INTERVAL (60s). To make the wake
+# fire FAST without weakening MIN_INTERVAL in the parser, we register
+# the goal via CLI with --every 5m (parser accepts) then BEFORE the
+# first tick we hand-set next_wake_at into the past by editing
+# goals.json. This proves: (a) CLI→parser→goal landed (real path),
+# (b) the wake actually fires. We need NO mock for parser/CLI.
 
 cd "$WORKDIR_CLAUDE"
-# Use a bogus API key — the SDK call inside processTask WILL fail at
-# the LLM layer, but we observe the wake log which fires BEFORE the
-# call. Captures stdout+stderr to /tmp/claude-agent.log.
+# Bogus key — SDK call inside wake will fail at LLM layer; the wake
+# log fires BEFORE that, which is what we assert.
 ANTHROPIC_API_KEY="test-no-real-call" \
-  timeout 30 agent-node \
+  timeout 60 agent-node \
   --alias "$ALIAS_CLAUDE" \
   --config "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" \
   > /tmp/claude-agent.log 2>&1 &
 CLAUDE_PID=$!
 
-# Wait up to 25s for both expected log lines to appear.
-DEADLINE=$(($(date +%s) + 25))
+# Wait for the node to register before sending the CLI command.
+DEADLINE=$(($(date +%s) + 15))
 SAW_ENABLE=0
-SAW_WAKE=0
+SAW_REGISTERED=0
 while [ $(date +%s) -lt $DEADLINE ]; do
   grep -q "goals scheduler: enabled (runtime=claude" /tmp/claude-agent.log && SAW_ENABLE=1
-  grep -q "\[goal\] wake ${GOAL_ID:0:8}" /tmp/claude-agent.log && SAW_WAKE=1
-  if [ $SAW_ENABLE -eq 1 ] && [ $SAW_WAKE -eq 1 ]; then break; fi
+  grep -q "已注册到 CommHub" /tmp/claude-agent.log && SAW_REGISTERED=1
+  if [ $SAW_ENABLE -eq 1 ] && [ $SAW_REGISTERED -eq 1 ]; then break; fi
   sleep 1
 done
-
-kill $CLAUDE_PID 2>/dev/null || true
-wait $CLAUDE_PID 2>/dev/null || true
 
 if [ $SAW_ENABLE -eq 1 ]; then
   pass "claude-agent-sdk: 'goals scheduler: enabled (runtime=claude...)' (gate removed ✓)"
 else
   fail "claude-agent-sdk: scheduler NOT enabled — gate still blocking"
-  echo "  --- tail of /tmp/claude-agent.log ---"
   tail -30 /tmp/claude-agent.log
+  exit 1
 fi
+
+# Now run the REAL CLI command users will type. This exercises:
+# CLI → /api/task → node inbox → parseGoalCommand → createScheduledGoal
+# → goals.json upsert. The CLI itself polls for the node's reply so
+# we get "node confirmed" or "node rejected" surfacing.
+echo "  Running: anet node loop $ALIAS_CLAUDE \"e2e probe\" --every 5m"
+# CLI reads --token / COMMHUB_TOKEN / loadGlobal().token. Use env so
+# we don't need to write a config file.
+COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CLAUDE" "e2e probe — please ack" --every 5m \
+  > /tmp/cli-loop.log 2>&1 || true
+
+if grep -q "✅ Scheduled loop" /tmp/cli-loop.log; then
+  pass "anet node loop: CLI confirmed goal creation (real user path ✓)"
+elif grep -q "❌ Node rejected" /tmp/cli-loop.log; then
+  fail "anet node loop: node REJECTED the /loop (parser regression?)"
+  cat /tmp/cli-loop.log
+  exit 1
+elif grep -q "did not confirm goal creation" /tmp/cli-loop.log; then
+  fail "anet node loop: node did not reply within 15s (might be silent-fail or slow node)"
+  cat /tmp/cli-loop.log
+  echo "--- agent log tail ---"
+  tail -30 /tmp/claude-agent.log
+  exit 1
+else
+  fail "anet node loop: unexpected CLI output"
+  cat /tmp/cli-loop.log
+  exit 1
+fi
+
+# Verify the goal landed in goals.json (filesystem confirmation)
+if [ -f "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json" ]; then
+  GOAL_COUNT=$(python3 -c "import json;d=json.load(open('$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json'));print(len([g for g in d.get('goals',[]) if g.get('status')=='active']))" 2>/dev/null)
+  if [ "$GOAL_COUNT" -ge 1 ]; then
+    pass "goals.json: $GOAL_COUNT active goal(s) persisted (parser → upsert path ✓)"
+  else
+    fail "goals.json: no active goals (CLI reported success but parser may have rejected)"
+    cat "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json"
+    exit 1
+  fi
+else
+  fail "goals.json does not exist after CLI succeeded — silent-fail regression"
+  exit 1
+fi
+
+# To observe a real fire within the test deadline, we restart the node
+# after editing next_wake_at into the past. (The node holds goals in
+# memory; an external file edit doesn't re-trigger load. Restart is a
+# realistic user flow — nodes restart routinely, see scheduler picks
+# up persisted past-due goals on next boot.)
+GOAL_ID=$(python3 -c "import json;d=json.load(open('$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json'));print(d['goals'][0]['goal_id'])")
+
+# Stop the live node first
+kill $CLAUDE_PID 2>/dev/null || true
+wait $CLAUDE_PID 2>/dev/null || true
+
+# Edit goals.json: next_wake_at into the past
+python3 <<PY
+import json, datetime
+p = "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json"
+d = json.load(open(p))
+past = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+for g in d["goals"]:
+    g["next_wake_at"] = past
+json.dump(d, open(p, "w"))
+PY
+
+# Restart and watch for wake fire
+> /tmp/claude-agent2.log
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS_CLAUDE" \
+  --config "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" \
+  > /tmp/claude-agent2.log 2>&1 &
+CLAUDE_PID2=$!
+
+DEADLINE=$(($(date +%s) + 20))
+SAW_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "\[goal\] wake ${GOAL_ID:0:8}" /tmp/claude-agent2.log && SAW_WAKE=1
+  if [ $SAW_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $CLAUDE_PID2 2>/dev/null || true
+wait $CLAUDE_PID2 2>/dev/null || true
 
 if [ $SAW_WAKE -eq 1 ]; then
-  pass "claude-agent-sdk: '[goal] wake ${GOAL_ID:0:8}' fired (tick reaches goal ✓)"
+  pass "claude-agent-sdk: '[goal] wake ${GOAL_ID:0:8}' fired after restart (full CLI→parser→goal→wake path ✓)"
 else
-  fail "claude-agent-sdk: scheduler enabled but tick did NOT fire wake"
-  echo "  --- tail of /tmp/claude-agent.log ---"
-  tail -40 /tmp/claude-agent.log
+  fail "claude-agent-sdk: wake did NOT fire even after restart with past next_wake_at"
+  echo "--- agent2 log tail ---"
+  tail -30 /tmp/claude-agent2.log
+  exit 1
 fi
 
-# 3. Test codex-sdk runtime — light-touch (just the enable log)
+# 3. Test codex-sdk runtime — same full path, light-touch
 echo ""
-echo "3. codex-sdk runtime — startup enable log..."
+echo "3. codex-sdk runtime — startup enable + CLI loop + wake fire..."
 
 ALIAS_CODEX="loop-test-codex"
 WORKDIR_CODEX="/tmp/loop-test-codex"
@@ -166,29 +246,9 @@ cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" <<EOF
 }
 EOF
 
-CODEX_GOAL_ID="goal-codex-e2e-${RANDOM}"
-cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/goals.json" <<EOF
-{
-  "version": 1,
-  "goals": [
-    {
-      "goal_id": "$CODEX_GOAL_ID",
-      "text": "e2e probe codex",
-      "status": "active",
-      "interval_ms": 5000,
-      "next_wake_at": "$PAST_ISO",
-      "runtime": "codex-sdk",
-      "created_at": "$NOW_ISO",
-      "updated_at": "$NOW_ISO",
-      "progress_log": []
-    }
-  ]
-}
-EOF
-
 cd "$WORKDIR_CODEX"
 OPENAI_API_KEY="test-no-real-call" \
-  timeout 20 agent-node \
+  timeout 60 agent-node \
   --alias "$ALIAS_CODEX" \
   --config "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" \
   > /tmp/codex-agent.log 2>&1 &
@@ -196,16 +256,13 @@ CODEX_PID=$!
 
 DEADLINE=$(($(date +%s) + 15))
 SAW_CODEX_ENABLE=0
-SAW_CODEX_WAKE=0
+SAW_CODEX_REGISTERED=0
 while [ $(date +%s) -lt $DEADLINE ]; do
   grep -q "goals scheduler: enabled (runtime=codex" /tmp/codex-agent.log && SAW_CODEX_ENABLE=1
-  grep -q "\[goal\] wake ${CODEX_GOAL_ID:0:8}" /tmp/codex-agent.log && SAW_CODEX_WAKE=1
-  if [ $SAW_CODEX_ENABLE -eq 1 ] && [ $SAW_CODEX_WAKE -eq 1 ]; then break; fi
+  grep -q "已注册到 CommHub" /tmp/codex-agent.log && SAW_CODEX_REGISTERED=1
+  if [ $SAW_CODEX_ENABLE -eq 1 ] && [ $SAW_CODEX_REGISTERED -eq 1 ]; then break; fi
   sleep 1
 done
-
-kill $CODEX_PID 2>/dev/null || true
-wait $CODEX_PID 2>/dev/null || true
 
 if [ $SAW_CODEX_ENABLE -eq 1 ]; then
   pass "codex-sdk: 'goals scheduler: enabled (runtime=codex)' ✓"
@@ -214,13 +271,352 @@ else
   tail -20 /tmp/codex-agent.log
 fi
 
+# Real CLI path for codex too — covers `2h` single-letter variant.
+COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CODEX" "e2e probe codex" --every 2h \
+  > /tmp/cli-codex.log 2>&1 || true
+
+if grep -q "✅ Scheduled loop" /tmp/cli-codex.log; then
+  pass "codex-sdk: 'anet node loop --every 2h' confirmed by node (CLI path ✓)"
+else
+  fail "codex-sdk: CLI loop creation did not confirm"
+  cat /tmp/cli-codex.log
+  exit 1
+fi
+
+CODEX_GOAL_ID=$(python3 -c "import json;d=json.load(open('$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/goals.json'));print(d['goals'][0]['goal_id'])")
+
+# Same restart pattern as claude
+kill $CODEX_PID 2>/dev/null || true
+wait $CODEX_PID 2>/dev/null || true
+
+python3 <<PY
+import json, datetime
+p = "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/goals.json"
+d = json.load(open(p))
+past = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+for g in d["goals"]:
+    g["next_wake_at"] = past
+json.dump(d, open(p, "w"))
+PY
+
+> /tmp/codex-agent2.log
+OPENAI_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS_CODEX" \
+  --config "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" \
+  > /tmp/codex-agent2.log 2>&1 &
+CODEX_PID2=$!
+
+DEADLINE=$(($(date +%s) + 20))
+SAW_CODEX_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "\[goal\] wake ${CODEX_GOAL_ID:0:8}" /tmp/codex-agent2.log && SAW_CODEX_WAKE=1
+  if [ $SAW_CODEX_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $CODEX_PID2 2>/dev/null || true
+wait $CODEX_PID2 2>/dev/null || true
+
 if [ $SAW_CODEX_WAKE -eq 1 ]; then
-  pass "codex-sdk: '[goal] wake ${CODEX_GOAL_ID:0:8}' fired ✓"
+  pass "codex-sdk: '[goal] wake ${CODEX_GOAL_ID:0:8}' fired after CLI→parser→goal landed ✓"
 else
   fail "codex-sdk: tick did NOT fire wake"
 fi
 
-# 4. Cleanup
+# 4. Channel /loop path (commhub_send_task with /loop slash — same
+#    user entry that a chatting user / another agent uses)
+echo ""
+echo "4. Channel /loop slash path (commhub_send_task)..."
+
+ALIAS_CH="loop-test-channel"
+WORKDIR_CH="/tmp/loop-test-channel"
+rm -rf "$WORKDIR_CH"
+mkdir -p "$WORKDIR_CH/.anet/nodes/$ALIAS_CH"
+cat > "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/config.json" <<EOF
+{
+  "alias": "$ALIAS_CH",
+  "runtime": "claude-agent-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "claude-sonnet-4-6",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+}
+EOF
+
+cd "$WORKDIR_CH"
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS_CH" \
+  --config "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/config.json" \
+  > /tmp/channel-agent.log 2>&1 &
+CH_PID=$!
+
+DEADLINE=$(($(date +%s) + 10))
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "已注册到 CommHub" /tmp/channel-agent.log && break
+  sleep 1
+done
+
+# Send a /loop via /api/task directly (same shape as commhub_send_task MCP tool)
+CH_RESP=$(curl -s -X POST http://127.0.0.1:9210/api/task \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NET_TOKEN" \
+  -d "{\"alias\":\"$ALIAS_CH\",\"task\":\"/loop 1d nightly cleanup\",\"priority\":\"normal\",\"from\":\"channel-test\",\"network_id\":\"$NET_ID\"}")
+CH_TASK_ID=$(echo "$CH_RESP" | python3 -c "import sys,json;print(json.load(sys.stdin).get('task_id',''))" 2>/dev/null)
+sleep 3
+
+# Verify goals.json has it
+if [ -f "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/goals.json" ]; then
+  CH_GOAL_COUNT=$(python3 -c "import json;d=json.load(open('$WORKDIR_CH/.anet/nodes/$ALIAS_CH/goals.json'));print(len([g for g in d.get('goals',[]) if g.get('status')=='active' and g.get('interval_ms')==86400000]))" 2>/dev/null)
+  if [ "$CH_GOAL_COUNT" -ge 1 ]; then
+    pass "channel /loop: 1d goal created via raw /api/task (interval=86400000ms)"
+  else
+    fail "channel /loop: goal not persisted"
+    cat "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/goals.json"
+  fi
+else
+  fail "channel /loop: goals.json missing"
+fi
+kill $CH_PID 2>/dev/null || true
+wait $CH_PID 2>/dev/null || true
+
+# 5. Interval format edge cases (CLI argv validation)
+echo ""
+echo "5. Interval format edge cases (CLI argv validation)..."
+
+# 5a. Sub-minute MUST be rejected at CLI layer (no silent success)
+SUB_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CLAUDE" "x" --every 30s 2>&1 || true)
+if echo "$SUB_OUT" | grep -q "Invalid --every"; then
+  pass "interval 30s: CLI rejects with clear error (no silent ✓ success)"
+else
+  fail "interval 30s: CLI did not reject"
+  echo "$SUB_OUT" | head -5
+fi
+
+# 5b. Bogus format
+BOG_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CLAUDE" "x" --every 5x 2>&1 || true)
+if echo "$BOG_OUT" | grep -q "Invalid --every"; then
+  pass "interval 5x: CLI rejects with clear error"
+else
+  fail "interval 5x: CLI did not reject"
+fi
+
+# 5c. Empty --every
+EMP_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet node loop "$ALIAS_CLAUDE" "x" --every "" 2>&1 || true)
+if echo "$EMP_OUT" | grep -q "Invalid --every"; then
+  pass "interval empty: CLI rejects with clear error"
+else
+  fail "interval empty: CLI did not reject"
+fi
+
+# 6. anet goal list + cancel
+echo ""
+echo "6. anet goal list + cancel..."
+
+# anet goal resolves nodes via $cwd/.anet/nodes — must cd into the
+# workdir that has the node profile (created by the agent's
+# --config write at startup).
+cd "$WORKDIR_CLAUDE"
+LIST_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet goal list "$ALIAS_CLAUDE" 2>&1 || true)
+if echo "$LIST_OUT" | grep -q "$GOAL_ID\|5min\|active"; then
+  pass "anet goal list: shows the created goal"
+else
+  fail "anet goal list: goal not visible"
+  echo "  --- list output ---"
+  echo "$LIST_OUT" | head -10
+fi
+
+CANCEL_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  anet goal cancel "$ALIAS_CLAUDE" "${GOAL_ID:0:8}" 2>&1 || true)
+if echo "$CANCEL_OUT" | grep -qi "cancelled\|已取消\|status.*cancelled"; then
+  pass "anet goal cancel: goal cancelled"
+else
+  fail "anet goal cancel: did not confirm cancellation"
+  echo "  --- cancel output ---"
+  echo "$CANCEL_OUT" | head -5
+fi
+
+# Verify cancel landed in goals.json
+CANCELLED_COUNT=$(python3 -c "import json;d=json.load(open('$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json'));print(len([g for g in d.get('goals',[]) if g.get('status')=='cancelled']))" 2>/dev/null)
+if [ "$CANCELLED_COUNT" -ge 1 ]; then
+  pass "goals.json: goal status flipped to 'cancelled' (no longer active)"
+else
+  fail "goals.json: cancel didn't persist"
+fi
+cd - > /dev/null
+
+# 6b. grok-build-acp runtime — startup enable + scheduler picks goal
+echo ""
+echo "6b. grok-build-acp runtime — startup enable + goal fire..."
+
+ALIAS_GROK="loop-test-grok"
+WORKDIR_GROK="/tmp/loop-test-grok"
+rm -rf "$WORKDIR_GROK"
+mkdir -p "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK"
+cat > "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK/config.json" <<EOF
+{
+  "alias": "$ALIAS_GROK",
+  "runtime": "grok-build-acp",
+  "hub": "http://127.0.0.1:9210",
+  "model": "grok-build",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "goalTickMs": "5000" }
+}
+EOF
+
+# Pre-create a grok-runtime goal (no real grok binary needed for the
+# scheduler-tick observation; SDK call inside processTask will fail
+# but the wake log fires BEFORE that — matches the claude pattern).
+GROK_GOAL="$(python3 -c "import uuid;print(uuid.uuid4())")"
+PAST=$(python3 -c "import datetime;print((datetime.datetime.now(datetime.UTC) - datetime.timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M:%S.000Z'))")
+NOW=$(python3 -c "import datetime;print(datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%dT%H:%M:%S.000Z'))")
+cat > "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$GROK_GOAL",
+      "text": "grok smoke probe",
+      "status": "active",
+      "interval_ms": 60000,
+      "next_wake_at": "$PAST",
+      "runtime": "grok-build-acp",
+      "created_at": "$NOW",
+      "updated_at": "$NOW",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+
+cd "$WORKDIR_GROK"
+timeout 20 agent-node \
+  --alias "$ALIAS_GROK" \
+  --config "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK/config.json" \
+  > /tmp/grok-agent.log 2>&1 &
+GROK_PID=$!
+
+DEADLINE=$(($(date +%s) + 15))
+SAW_GROK_ENABLE=0
+SAW_GROK_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "goals scheduler: enabled (runtime=grok" /tmp/grok-agent.log && SAW_GROK_ENABLE=1
+  grep -q "\[goal\] wake ${GROK_GOAL:0:8}" /tmp/grok-agent.log && SAW_GROK_WAKE=1
+  if [ $SAW_GROK_ENABLE -eq 1 ] && [ $SAW_GROK_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $GROK_PID 2>/dev/null || true
+wait $GROK_PID 2>/dev/null || true
+
+if [ $SAW_GROK_ENABLE -eq 1 ]; then
+  pass "grok-build-acp: 'goals scheduler: enabled (runtime=grok)' ✓"
+else
+  fail "grok-build-acp: scheduler NOT enabled"
+  tail -20 /tmp/grok-agent.log
+fi
+
+if [ $SAW_GROK_WAKE -eq 1 ]; then
+  pass "grok-build-acp: '[goal] wake ${GROK_GOAL:0:8}' fired ✓"
+else
+  fail "grok-build-acp: tick did NOT fire wake"
+fi
+
+# 6c. Multi-cycle wake — confirm scheduler fires REPEATEDLY (not just once)
+echo ""
+echo "6c. Multi-cycle wake — verify the scheduler fires the SAME goal repeatedly..."
+
+ALIAS_MULTI="loop-test-multi"
+WORKDIR_MULTI="/tmp/loop-test-multi"
+rm -rf "$WORKDIR_MULTI"
+mkdir -p "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI"
+cat > "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI/config.json" <<EOF
+{
+  "alias": "$ALIAS_MULTI",
+  "runtime": "codex-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "gpt-5.5",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "goalTickMs": "5000" }
+}
+EOF
+
+MULTI_GOAL="$(python3 -c "import uuid;print(uuid.uuid4())")"
+# 60s interval (parser min) + 5s tick. Past next_wake_at so first
+# fire is immediate; second fire ~60s later; third ~120s.
+cat > "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$MULTI_GOAL",
+      "text": "multi-cycle probe",
+      "status": "active",
+      "interval_ms": 60000,
+      "next_wake_at": "$PAST",
+      "runtime": "codex-sdk",
+      "created_at": "$NOW",
+      "updated_at": "$NOW",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+
+cd "$WORKDIR_MULTI"
+OPENAI_API_KEY="test-no-real-call" \
+  timeout 140 agent-node \
+  --alias "$ALIAS_MULTI" \
+  --config "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI/config.json" \
+  > /tmp/multi-agent.log 2>&1 &
+MULTI_PID=$!
+
+# Wait for 2 wakes minimum (first fires immediately, second after
+# ~60s interval). 130s window gives generous margin.
+DEADLINE=$(($(date +%s) + 130))
+while [ $(date +%s) -lt $DEADLINE ]; do
+  WAKE_COUNT=$(grep -c "\[goal\] wake ${MULTI_GOAL:0:8}" /tmp/multi-agent.log 2>/dev/null || echo 0)
+  if [ "$WAKE_COUNT" -ge 2 ]; then break; fi
+  sleep 5
+done
+
+kill $MULTI_PID 2>/dev/null || true
+wait $MULTI_PID 2>/dev/null || true
+
+WAKE_COUNT=$(grep -c "\[goal\] wake ${MULTI_GOAL:0:8}" /tmp/multi-agent.log 2>/dev/null || echo 0)
+if [ "$WAKE_COUNT" -ge 2 ]; then
+  pass "multi-cycle: scheduler fired the same goal $WAKE_COUNT times (proves not one-shot)"
+else
+  fail "multi-cycle: only $WAKE_COUNT wake(s) observed in 130s window (expected ≥2)"
+  echo "  --- multi-agent log tail ---"
+  tail -25 /tmp/multi-agent.log
+fi
+
+# 7. Offline node behavior — CLI polls + times out cleanly
+echo ""
+echo "7. Offline node behavior (CLI must fail clearly, not silent ✅)..."
+
+OFF_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+  timeout 25 anet node loop "$ALIAS_CLAUDE" "this node is dead" --every 5m 2>&1 || true)
+if echo "$OFF_OUT" | grep -q "did not confirm\|node offline"; then
+  pass "offline node: CLI reports timeout (does NOT print false ✅)"
+elif echo "$OFF_OUT" | grep -q "✅ Scheduled"; then
+  fail "offline node: CLI printed false success ✓ — silent-fail regression"
+  echo "$OFF_OUT" | head -10
+else
+  pass "offline node: CLI did not print ✅ (alternative non-success output OK)"
+fi
+
+# 8. Cleanup
 kill $HUB_PID 2>/dev/null || true
 
 echo ""

--- a/tests/docker-e2e-loop-runtime.sh
+++ b/tests/docker-e2e-loop-runtime.sh
@@ -22,6 +22,25 @@
 #     avoid). The wake log fires BEFORE the SDK call.
 
 set -e
+
+# Safe-rm guardrail per the 2026-06-16 incident — refuses to `rm -rf`
+# anything outside /tmp/*. Drop-in `safe_rm_rf` replaces every bare
+# `rm -rf "$VAR"` in this script. lint guard enforces this on PR.
+SAFE_RM_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/safe-rm.sh"
+if [ -f "$SAFE_RM_LIB" ]; then
+  source "$SAFE_RM_LIB"
+else
+  # Fallback for Docker runs where the script is mounted standalone
+  # (the lib lives at /app/tests/lib/ when copied via Dockerfile).
+  for cand in /app/tests/lib/safe-rm.sh /app/lib/safe-rm.sh; do
+    [ -f "$cand" ] && source "$cand" && break
+  done
+fi
+type safe_rm_rf > /dev/null 2>&1 || {
+  echo "FATAL: safe-rm.sh not found — refusing to run with bare rm -rf"
+  exit 99
+}
+
 PASS=0
 FAIL=0
 
@@ -80,7 +99,7 @@ echo "2. claude-agent-sdk runtime — full CLI → parser → goal → wake fire
 
 ALIAS_CLAUDE="loop-test-claude"
 WORKDIR_CLAUDE="/tmp/loop-test-claude"
-rm -rf "$WORKDIR_CLAUDE"
+safe_rm_rf "$WORKDIR_CLAUDE"
 mkdir -p "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE"
 cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" <<EOF
 {
@@ -232,7 +251,7 @@ echo "3. codex-sdk runtime — startup enable + CLI loop + wake fire..."
 
 ALIAS_CODEX="loop-test-codex"
 WORKDIR_CODEX="/tmp/loop-test-codex"
-rm -rf "$WORKDIR_CODEX"
+safe_rm_rf "$WORKDIR_CODEX"
 mkdir -p "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX"
 cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" <<EOF
 {
@@ -332,7 +351,7 @@ echo "4. Channel /loop slash path (commhub_send_task)..."
 
 ALIAS_CH="loop-test-channel"
 WORKDIR_CH="/tmp/loop-test-channel"
-rm -rf "$WORKDIR_CH"
+safe_rm_rf "$WORKDIR_CH"
 mkdir -p "$WORKDIR_CH/.anet/nodes/$ALIAS_CH"
 cat > "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/config.json" <<EOF
 {
@@ -458,7 +477,7 @@ echo "6b. grok-build-acp runtime — startup enable + goal fire..."
 
 ALIAS_GROK="loop-test-grok"
 WORKDIR_GROK="/tmp/loop-test-grok"
-rm -rf "$WORKDIR_GROK"
+safe_rm_rf "$WORKDIR_GROK"
 mkdir -p "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK"
 cat > "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK/config.json" <<EOF
 {
@@ -536,7 +555,7 @@ echo "6c. Multi-cycle wake — verify the scheduler fires the SAME goal repeated
 
 ALIAS_MULTI="loop-test-multi"
 WORKDIR_MULTI="/tmp/loop-test-multi"
-rm -rf "$WORKDIR_MULTI"
+safe_rm_rf "$WORKDIR_MULTI"
 mkdir -p "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI"
 cat > "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI/config.json" <<EOF
 {
@@ -584,7 +603,8 @@ MULTI_PID=$!
 # ~60s interval). 130s window gives generous margin.
 DEADLINE=$(($(date +%s) + 130))
 while [ $(date +%s) -lt $DEADLINE ]; do
-  WAKE_COUNT=$(grep -c "\[goal\] wake ${MULTI_GOAL:0:8}" /tmp/multi-agent.log 2>/dev/null || echo 0)
+  WAKE_COUNT=$( { grep -c "\[goal\] wake ${MULTI_GOAL:0:8}" /tmp/multi-agent.log 2>/dev/null || true; } | head -1)
+  WAKE_COUNT=${WAKE_COUNT:-0}
   if [ "$WAKE_COUNT" -ge 2 ]; then break; fi
   sleep 5
 done
@@ -599,6 +619,81 @@ else
   fail "multi-cycle: only $WAKE_COUNT wake(s) observed in 130s window (expected ≥2)"
   echo "  --- multi-agent log tail ---"
   tail -25 /tmp/multi-agent.log
+fi
+
+# 6d. Multi-cycle wake on **claude-agent-sdk** specifically
+#
+# 通信龙 spot-check tighten: the existing multi-cycle test (6c) ran
+# on codex. Scheduler is runtime-agnostic shared code, but claude
+# is Vincent's personally-tested runtime — pin its multi-cycle
+# behaviour rather than relying on transitive inference from codex.
+echo ""
+echo "6d. Multi-cycle wake — claude-agent-sdk (Vincent's runtime)..."
+
+ALIAS_CMULTI="loop-test-claude-multi"
+WORKDIR_CMULTI="/tmp/loop-test-claude-multi"
+safe_rm_rf "$WORKDIR_CMULTI"
+mkdir -p "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI"
+cat > "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI/config.json" <<EOF
+{
+  "alias": "$ALIAS_CMULTI",
+  "runtime": "claude-agent-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "claude-sonnet-4-6",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+}
+EOF
+
+CMULTI_GOAL="$(python3 -c "import uuid;print(uuid.uuid4())")"
+cat > "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$CMULTI_GOAL",
+      "text": "claude multi-cycle probe",
+      "status": "active",
+      "interval_ms": 60000,
+      "next_wake_at": "$PAST",
+      "runtime": "claude-agent-sdk",
+      "created_at": "$NOW",
+      "updated_at": "$NOW",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+
+cd "$WORKDIR_CMULTI"
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 140 agent-node \
+  --alias "$ALIAS_CMULTI" \
+  --config "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI/config.json" \
+  > /tmp/cmulti-agent.log 2>&1 &
+CMULTI_PID=$!
+
+# Same 130s window as 6c codex test.
+DEADLINE=$(($(date +%s) + 130))
+while [ $(date +%s) -lt $DEADLINE ]; do
+  CMULTI_WAKE_COUNT=$( { grep -c "\[goal\] wake ${CMULTI_GOAL:0:8}" /tmp/cmulti-agent.log 2>/dev/null || true; } | head -1)
+  CMULTI_WAKE_COUNT=${CMULTI_WAKE_COUNT:-0}
+  if [ "$CMULTI_WAKE_COUNT" -ge 2 ]; then break; fi
+  sleep 5
+done
+
+kill $CMULTI_PID 2>/dev/null || true
+wait $CMULTI_PID 2>/dev/null || true
+
+CMULTI_WAKE_COUNT=$( { grep -c "\[goal\] wake ${CMULTI_GOAL:0:8}" /tmp/cmulti-agent.log 2>/dev/null || true; } | head -1)
+CMULTI_WAKE_COUNT=${CMULTI_WAKE_COUNT:-0}
+if [ "$CMULTI_WAKE_COUNT" -ge 2 ]; then
+  pass "claude multi-cycle: scheduler fired same goal $CMULTI_WAKE_COUNT times (Vincent's runtime ✓ not inference)"
+else
+  fail "claude multi-cycle: only $CMULTI_WAKE_COUNT wake(s) observed in 130s window (expected ≥2)"
+  echo "  --- claude-multi log tail ---"
+  tail -25 /tmp/cmulti-agent.log
 fi
 
 # 7. Offline node behavior — CLI polls + times out cleanly
@@ -623,6 +718,9 @@ echo ""
 echo "========================================="
 echo "  Summary: $PASS pass, $FAIL fail"
 echo "========================================="
+# Also emit the format test-all.sh's run_suite parses
+# (`\d+(?= passed)` and `\d+(?= failed)`).
+echo "Results: $PASS passed, $FAIL failed"
 
 if [ $FAIL -eq 0 ]; then
   echo "🎉 All loop-runtime checks pass"

--- a/tests/docker-e2e-loop-runtime.sh
+++ b/tests/docker-e2e-loop-runtime.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# #144 round-6 — loop runtime gate end-to-end verification.
+#
+# Hard requirement from 通信龙: prove that after removing the claude
+# bucket skip, the scheduler ACTUALLY FIRES for claude-agent-sdk (the
+# runtime Vincent will personally test). Also light-touch confirm for
+# codex-sdk that startup-enables the scheduler.
+#
+# This test does NOT need a real Anthropic / OpenAI API key. We assert
+# the SCHEDULER FIRES (anet's responsibility) — not that the LLM call
+# inside the wake succeeds (vendor responsibility, out of scope).
+#
+# Pass criteria per runtime:
+#   1. Startup log shows `goals scheduler: enabled (runtime=<bucket>)`
+#   2. Within 30s a `[goal] wake <id>:` line appears for the pre-injected
+#      goal (proves the tick fires AND finds the goal AND begins
+#      processing it).
+#
+# What's deliberately NOT asserted:
+#   - That the LLM SDK call inside processTask succeeds (needs vendor
+#     auth + network; would re-introduce flakiness the test should
+#     avoid). The wake log fires BEFORE the SDK call.
+
+set -e
+PASS=0
+FAIL=0
+
+pass() { echo "  ✅ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+
+echo ""
+echo "========================================="
+echo "  #144 — Loop runtime gate E2E"
+echo "  Proves: scheduler fires for claude-agent-sdk + codex-sdk"
+echo "========================================="
+echo ""
+
+# 1. Start hub on isolated DB (COMMHUB_DB to /tmp/commhub-loop-test.db)
+echo "1. Starting CommHub (isolated DB)..."
+rm -f /tmp/commhub-loop-test.db /tmp/commhub-loop-test.db-wal /tmp/commhub-loop-test.db-shm
+COMMHUB_DB=/tmp/commhub-loop-test.db PORT=9210 \
+  bun run /app/server/src/index.ts > /tmp/hub.log 2>&1 &
+HUB_PID=$!
+sleep 3
+curl -s http://127.0.0.1:9210/health | grep -q '"ok":true' \
+  && pass "CommHub started on :9210" \
+  || { fail "CommHub failed to start"; cat /tmp/hub.log | tail -30; exit 1; }
+
+# Register a test user + grab a network token. report_status MCP tool
+# requires callerTokenIsNetwork (network-scoped token, not user token);
+# without it every status report 401s and the agent crashes before the
+# first scheduler tick.
+echo "  Registering test user..."
+REG=$(curl -s -X POST http://127.0.0.1:9210/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username":"loop-test","password":"LoopTestPw123","display_name":"loop test"}')
+USER_TOKEN=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('token',''))" 2>/dev/null)
+NET_TOKEN=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_token',''))" 2>/dev/null)
+NET_ID=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_id',''))" 2>/dev/null)
+[ -n "$NET_TOKEN" ] && pass "test user registered, network token issued (net=${NET_ID:0:12})" \
+  || { fail "user registration failed: $REG"; exit 1; }
+
+# 2. Test claude-agent-sdk runtime — the load-bearing one
+echo ""
+echo "2. claude-agent-sdk runtime — scheduler enable + wake fire..."
+
+ALIAS_CLAUDE="loop-test-claude"
+WORKDIR_CLAUDE="/tmp/loop-test-claude"
+rm -rf "$WORKDIR_CLAUDE"
+mkdir -p "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE"
+cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" <<EOF
+{
+  "alias": "$ALIAS_CLAUDE",
+  "runtime": "claude-agent-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "claude-sonnet-4-6",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
+}
+EOF
+
+# Pre-inject a claude-runtime goal with 5s interval, next_wake_at = now
+# so the very first tick after startup fires it.
+NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+PAST_ISO=$(date -u -d "1 minute ago" +%Y-%m-%dT%H:%M:%S.000Z)
+GOAL_ID="goal-claude-e2e-${RANDOM}"
+cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$GOAL_ID",
+      "text": "e2e probe: confirm scheduler fires this wake",
+      "status": "active",
+      "interval_ms": 5000,
+      "next_wake_at": "$PAST_ISO",
+      "runtime": "claude-agent-sdk",
+      "created_at": "$NOW_ISO",
+      "updated_at": "$NOW_ISO",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+pass "pre-injected claude-runtime goal (id=${GOAL_ID:0:8}, interval=5s, next_wake_at in past)"
+
+cd "$WORKDIR_CLAUDE"
+# Use a bogus API key — the SDK call inside processTask WILL fail at
+# the LLM layer, but we observe the wake log which fires BEFORE the
+# call. Captures stdout+stderr to /tmp/claude-agent.log.
+ANTHROPIC_API_KEY="test-no-real-call" \
+  timeout 30 agent-node \
+  --alias "$ALIAS_CLAUDE" \
+  --config "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" \
+  > /tmp/claude-agent.log 2>&1 &
+CLAUDE_PID=$!
+
+# Wait up to 25s for both expected log lines to appear.
+DEADLINE=$(($(date +%s) + 25))
+SAW_ENABLE=0
+SAW_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "goals scheduler: enabled (runtime=claude" /tmp/claude-agent.log && SAW_ENABLE=1
+  grep -q "\[goal\] wake ${GOAL_ID:0:8}" /tmp/claude-agent.log && SAW_WAKE=1
+  if [ $SAW_ENABLE -eq 1 ] && [ $SAW_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $CLAUDE_PID 2>/dev/null || true
+wait $CLAUDE_PID 2>/dev/null || true
+
+if [ $SAW_ENABLE -eq 1 ]; then
+  pass "claude-agent-sdk: 'goals scheduler: enabled (runtime=claude...)' (gate removed ✓)"
+else
+  fail "claude-agent-sdk: scheduler NOT enabled — gate still blocking"
+  echo "  --- tail of /tmp/claude-agent.log ---"
+  tail -30 /tmp/claude-agent.log
+fi
+
+if [ $SAW_WAKE -eq 1 ]; then
+  pass "claude-agent-sdk: '[goal] wake ${GOAL_ID:0:8}' fired (tick reaches goal ✓)"
+else
+  fail "claude-agent-sdk: scheduler enabled but tick did NOT fire wake"
+  echo "  --- tail of /tmp/claude-agent.log ---"
+  tail -40 /tmp/claude-agent.log
+fi
+
+# 3. Test codex-sdk runtime — light-touch (just the enable log)
+echo ""
+echo "3. codex-sdk runtime — startup enable log..."
+
+ALIAS_CODEX="loop-test-codex"
+WORKDIR_CODEX="/tmp/loop-test-codex"
+rm -rf "$WORKDIR_CODEX"
+mkdir -p "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX"
+cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" <<EOF
+{
+  "alias": "$ALIAS_CODEX",
+  "runtime": "codex-sdk",
+  "hub": "http://127.0.0.1:9210",
+  "model": "gpt-5.5",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": { "goalTickMs": "5000" }
+}
+EOF
+
+CODEX_GOAL_ID="goal-codex-e2e-${RANDOM}"
+cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/goals.json" <<EOF
+{
+  "version": 1,
+  "goals": [
+    {
+      "goal_id": "$CODEX_GOAL_ID",
+      "text": "e2e probe codex",
+      "status": "active",
+      "interval_ms": 5000,
+      "next_wake_at": "$PAST_ISO",
+      "runtime": "codex-sdk",
+      "created_at": "$NOW_ISO",
+      "updated_at": "$NOW_ISO",
+      "progress_log": []
+    }
+  ]
+}
+EOF
+
+cd "$WORKDIR_CODEX"
+OPENAI_API_KEY="test-no-real-call" \
+  timeout 20 agent-node \
+  --alias "$ALIAS_CODEX" \
+  --config "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" \
+  > /tmp/codex-agent.log 2>&1 &
+CODEX_PID=$!
+
+DEADLINE=$(($(date +%s) + 15))
+SAW_CODEX_ENABLE=0
+SAW_CODEX_WAKE=0
+while [ $(date +%s) -lt $DEADLINE ]; do
+  grep -q "goals scheduler: enabled (runtime=codex" /tmp/codex-agent.log && SAW_CODEX_ENABLE=1
+  grep -q "\[goal\] wake ${CODEX_GOAL_ID:0:8}" /tmp/codex-agent.log && SAW_CODEX_WAKE=1
+  if [ $SAW_CODEX_ENABLE -eq 1 ] && [ $SAW_CODEX_WAKE -eq 1 ]; then break; fi
+  sleep 1
+done
+
+kill $CODEX_PID 2>/dev/null || true
+wait $CODEX_PID 2>/dev/null || true
+
+if [ $SAW_CODEX_ENABLE -eq 1 ]; then
+  pass "codex-sdk: 'goals scheduler: enabled (runtime=codex)' ✓"
+else
+  fail "codex-sdk: scheduler NOT enabled"
+  tail -20 /tmp/codex-agent.log
+fi
+
+if [ $SAW_CODEX_WAKE -eq 1 ]; then
+  pass "codex-sdk: '[goal] wake ${CODEX_GOAL_ID:0:8}' fired ✓"
+else
+  fail "codex-sdk: tick did NOT fire wake"
+fi
+
+# 4. Cleanup
+kill $HUB_PID 2>/dev/null || true
+
+echo ""
+echo "========================================="
+echo "  Summary: $PASS pass, $FAIL fail"
+echo "========================================="
+
+if [ $FAIL -eq 0 ]; then
+  echo "🎉 All loop-runtime checks pass"
+  exit 0
+else
+  echo "❌ Loop-runtime regression"
+  exit 1
+fi

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -77,6 +77,13 @@ run_suite "V3 Networks (22)" "/app/test-networks.sh 2>&1"
 reset_server
 run_suite "Config Priority (16)" "/app/test-config.sh 2>&1"
 
+# #144 round-6 — loop runtime gate + universal /loop scheduler
+# regression coverage. Each suite spins its OWN hub on a non-standard
+# port (9210, 9211) with isolated COMMHUB_DB, so they coexist with the
+# above suites that use :9200. No reset_server needed before these.
+run_suite "Loop runtime e2e (20)" "/app/test-loop-runtime.sh 2>&1"
+run_suite "Loop npm-pack install (12)" "/app/test-loop-npm-pack.sh 2>&1"
+
 echo ""
 echo "╔══════════════════════════════════════════════════╗"
 echo "║   Final Report                                    ║"


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why

Vincent priority — "agent 要自己理解 loop"：感知 + 自然语言对话调整管理. design-first per 通信龙, **no impl**.

> ⚠️ **Renumbered** RFC-024 → RFC-025 (RFC-024 already taken by dashboard config-apply, #287/#290/#294).

## Scope

**In**: agent-node runtimes — `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`
**Out** (per Vincent §3.1, §12 non-goals): `claude-code-cli` (用 CC 原生 /loop 自管, 独立 session 不接 anet)

## Highlights

- **6 self-scoped tools** (no `alias` arg — physically can't address another node)
  - `list_my_loops` / `create_my_loop` / `edit_my_loop` / `cancel_my_loop`
  - **★ `reschedule_my_loop`** — Claude Code `/loop` ScheduleWakeup 范式: agent 自决下次唤醒
  - **★ `complete_my_loop`** — 达标即停, 防死循环, 跟 `cancel` 语义分清
- **Two-layer scheduling separated** (#288 lesson 延伸): outer anet goals = unique source; inner SDK `query()` = single-task exec
- **Context injection**: `【你的当前循环任务】` block injected before each think
- **Per-runtime adapter shared layer**: `SELF_LOOP_TOOL_SPECS` 一处定义, 各 runtime ~20 行翻译
- **Safety**: 30s per-goal cooldown + max_goals_per_node cap + parser reuse

## Independent LLM-validation (通信龙 起独立 agent 验)

3 LLM contexts × 8 natural-language sentences → **100% tool-choice agreement** (②智能 premise 实证). But caught **5 design gaps**, all folded into the RFC:

| # | Gap | Fix landed in RFC |
|---|---|---|
| 🔴 1 | Time-of-day / cron-lite gap (Vincent's own "每天9点" example doesn't fit interval model — LLM silently fakes it) | §3.2 #1 + P0a phase (~120 LOC) — cron-lite schedule field |
| 2 | Destructive batch (3 cancels/30s) needs confirm-back, not silent execute | §3.2 #2 + tool table |
| 3 | Agent fabricates numbers ("太频繁" → 30m猜), must report new value back | §3.2 #3 + tool description hint |
| 4 | pause/cancel/complete semantics adjacent, descriptions need contrastive phrasing | §3.2 #4 + tool table rows |
| 5 | Multi-loop reference resolution ("这个/那个") untested with 3-5 loops | §3.2 #5 + P5 e2e |

## 8 open questions (待 review 拍)

See §11. New since v1: **#6 cron-lite A/B**, **#7 confirm-back threshold**, **#8 timezone handling** (倾向 `Asia/Shanghai` default via node config `flags.timezone`).

## ETA (impl phase, post-review) — ~720 LOC

| Phase | LOC |
|---|---|
| P0a — cron-lite schedule field | ~120 |
| P0b — context injection | ~80 |
| P1 — self-loop tools + claude-agent-sdk adapter | ~180 |
| P2 — codex-sdk adapter | ~80-150 |
| P3 — grok-build-acp adapter | ~50 |
| P4 — safety防线 + 单测 | ~100 |
| P5 — Docker e2e (含 multi-loop 指代消解) | ~180 |

5-7h impl + 3-4h 测.

## Tracking

- Internal task #147
- Builds on #144 (universal /loop) + #288 (parser + CLI)
- Vincent priority — design-first per 通信龙 dispatch; await Vincent + 通信龙 verdict before impl
