### PR TITLE
cleanup(agent-node): remove dead LLM-facing send_reply MCP tool

### DIFF
--- a/agent-node/src/commhub-mcp.ts
+++ b/agent-node/src/commhub-mcp.ts
@@ -199,16 +199,26 @@ export async function createCommhubSdkMcpServer(
         },
         fwd("send_message"),
       ),
-      tool(
-        "send_reply",
-        "Send a reply to a task. Linked to task_id via in_reply_to. Does NOT trigger agent re-processing.",
-        {
-          task_id: z.string().describe("Task to reply to"),
-          text: z.string().describe("Reply content"),
-          status: z.enum(["replied", "failed", "cancelled"]).optional(),
-        },
-        fwd("send_reply"),
-      ),
+      // NOTE: `send_reply` tool removed (2026-06-28, 通信龙 dispatch).
+      //
+      // The agent-facing schema declared `{task_id, text, status}` but the
+      // server's send_reply MCP tool expects `{alias, in_reply_to, text,
+      // status}`. The forwarder (`injectAgentFromSession`) only injects
+      // `from_session` — it doesn't remap `task_id → in_reply_to` or
+      // synthesize the required `alias` arg. So every agent invocation
+      // bounced with JSON-RPC -32602 "Invalid arguments" before reaching
+      // any server-side code path. Dead-on-arrival since 2026-05-15.
+      //
+      // The agent does NOT need this tool: every task it receives is
+      // auto-replied via cli.ts:806 `sendReply()` (the runtime calls the
+      // server-side send_reply with the correct shape after `processTask`
+      // returns). For peer-to-peer dispatch chaining the agent uses
+      // `send_task` (which IS wired correctly). CLAUDE.md already
+      // documents this. Keeping the broken tool only confused LLMs into
+      // failing tool calls.
+      //
+      // Server-side send_reply (server/src/tools.ts) is UNCHANGED — the
+      // auto-reply path uses it and works.
       tool(
         "get_all_status",
         "Get status of all sessions in the current network (or globally for admin tokens). Use this to see who is online before send_task.",


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why

Per 通信龙 dispatch (2026-06-28) — `agent-node/src/commhub-mcp.ts:186` agent-callable `send_reply` MCP tool was **dead-on-arrival since 2026-05-15**:

- Tool spec: `{task_id, text, status}`
- Server `send_reply` MCP tool expects: `{alias, in_reply_to, text, status}`
- Forwarder (`injectAgentFromSession`) only injects `from_session` — does NOT remap `task_id → in_reply_to` or synthesize the required `alias` arg
- → Every LLM tool call bounced with JSON-RPC `-32602 Invalid arguments` before reaching any server-side code path

This is the root cause behind CLAUDE.md's note "reply 不推送" + Vincent's observation that LLM-initiated replies "从没生效".

## What changed

Removed only the agent-facing tool spec in `commhub-mcp.ts`. Replaced with an explanatory comment so future readers see why.

## What did NOT change

- **`server/src/tools.ts:send_reply`** — UNCHANGED. The runtime auto-reply path at `cli.ts:806` calls this directly with the correct shape, and it works.
- **`send_message`** — UNCHANGED (实测 works).
- **`cli.ts:806` auto-reply path** — UNCHANGED. After `processTask` returns, the runtime auto-calls server-side send_reply for every received task.
- **`OUTBOUND_FROM_TOOLS` set** containing `"send_reply"` — kept (dead reference, harmless; removing would be out-of-scope cleanup).

## Why agent doesn't need this tool

- Every task it receives is **auto-replied** via `cli.ts:806 sendReply()` — runtime handles it after `processTask` returns
- For peer-to-peer dispatch chaining the agent uses `send_task` (wired correctly)
- CLAUDE.md already documents this: "回复指挥室用 commhub_send_task（不是 commhub_reply，reply 不推送）"

Keeping the broken tool only confused LLMs into making failing tool calls.

## Tracking

- Internal task #148
- 通信龙 dispatch: `agent-node/src/commhub-mcp.ts:186` send_reply schema mismatch + Vincent confirmed scope.
