### PR TITLE
fix(anet): flip normalizeRuntime fallback to claude-agent-sdk (Vincent no-Max directive)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -312,23 +312,10 @@ interface Profile {
   role?: "leader" | "worker";
 }
 
-type RuntimeName = "claude-code-cli" | "codex-sdk" | "claude-agent-sdk" | "grok-build-acp";
-
-function normalizeRuntime(profileOrRuntime?: Profile | string): RuntimeName {
-  if (typeof profileOrRuntime === "string") {
-    if (profileOrRuntime === "codex" || profileOrRuntime === "codex-sdk") return "codex-sdk";
-    if (profileOrRuntime === "grok" || profileOrRuntime === "grok-build" || profileOrRuntime === "grok-build-acp") return "grok-build-acp";
-    if (profileOrRuntime === "claude" || profileOrRuntime === "claude-sdk" || profileOrRuntime === "claude-agent-sdk") return "claude-agent-sdk";
-    if (profileOrRuntime === "agent-sdk") return "claude-agent-sdk";
-    return "claude-code-cli";
-  }
-  const p = profileOrRuntime;
-  if (!p) return "claude-code-cli";
-  if (p.runtime === "agent-sdk") {
-    return p.codexRuntime === "codex" ? "codex-sdk" : "claude-agent-sdk";
-  }
-  return normalizeRuntime(p.runtime || "claude-code-cli");
-}
+// Re-export from the pure helper module (src/normalize-runtime.ts) so
+// unit tests can import without dragging in CLI side-effects.
+import { normalizeRuntime, type RuntimeName } from "../src/normalize-runtime";
+export { normalizeRuntime, type RuntimeName };
 
 function nodeDisplayName(id: string, profile?: Profile | null): string {
   return profile?.node_name || profile?.name || profile?.alias || id;
@@ -3185,7 +3172,7 @@ async function resumeCommand() {
 
   if (!resolved) validateNodeName(nodeId);
   if (!profile) {
-    const createOpts = { ...opts, session: sessionId, runtime: opts.runtime || "claude-code-cli" } as unknown as ReturnType<typeof parseOpts>;
+    const createOpts = { ...opts, session: sessionId, runtime: opts.runtime || "claude-agent-sdk" } as unknown as ReturnType<typeof parseOpts>;
     profile = await ensureNodeToken(createProfileFromOpts(nodeId, createOpts), nodeId);
     saveProfile(nodeId, profile);
     console.log(`[anet] Created node "${nodeId}"`);

--- a/agent-network/src/normalize-runtime.test.ts
+++ b/agent-network/src/normalize-runtime.test.ts
@@ -1,0 +1,91 @@
+// Pin the runtime fallback default — `claude-agent-sdk`, not the
+// legacy `claude-code-cli` which was a poor default that left non-
+// subscribers with broken nodes (Max/Pro-bound).
+//
+// Per Vincent's "无 Max 军团" directive (2026-06-28, 通信龙 dispatch):
+// the entire surface where a user-facing runtime can default — empty,
+// unknown, missing profile — must fall through to `claude-agent-sdk`.
+// Explicit `claude-code-cli` choice still works.
+
+import { describe, expect, test } from "bun:test";
+import { normalizeRuntime } from "./normalize-runtime";
+
+describe("normalizeRuntime — fallback default is claude-agent-sdk (Vincent no-Max)", () => {
+  test("unknown string → claude-agent-sdk (was claude-code-cli pre-2026-06-28)", () => {
+    expect(normalizeRuntime("totally-unknown-runtime")).toBe("claude-agent-sdk");
+  });
+
+  test("empty string → claude-agent-sdk", () => {
+    expect(normalizeRuntime("")).toBe("claude-agent-sdk");
+  });
+
+  test("undefined (no arg) → claude-agent-sdk", () => {
+    expect(normalizeRuntime()).toBe("claude-agent-sdk");
+  });
+
+  test("undefined profile arg → claude-agent-sdk", () => {
+    expect(normalizeRuntime(undefined)).toBe("claude-agent-sdk");
+  });
+
+  test("profile with missing runtime field → claude-agent-sdk", () => {
+    expect(normalizeRuntime({ alias: "x" } as any)).toBe("claude-agent-sdk");
+  });
+
+  test("profile with empty-string runtime field → claude-agent-sdk", () => {
+    expect(normalizeRuntime({ alias: "x", runtime: "" } as any)).toBe("claude-agent-sdk");
+  });
+});
+
+describe("normalizeRuntime — explicit choices are preserved", () => {
+  // Operators who actually want a specific runtime still get it. The
+  // fallback flip ONLY affects missing/unknown cases.
+
+  test("explicit 'claude-code-cli' → claude-code-cli (operator opt-in still works)", () => {
+    expect(normalizeRuntime("claude-code-cli")).toBe("claude-code-cli");
+  });
+
+  test("explicit 'claude-agent-sdk' → claude-agent-sdk", () => {
+    expect(normalizeRuntime("claude-agent-sdk")).toBe("claude-agent-sdk");
+  });
+
+  test("alias 'claude' → claude-agent-sdk (existing canonicalization)", () => {
+    expect(normalizeRuntime("claude")).toBe("claude-agent-sdk");
+  });
+
+  test("alias 'claude-sdk' → claude-agent-sdk", () => {
+    expect(normalizeRuntime("claude-sdk")).toBe("claude-agent-sdk");
+  });
+
+  test("alias 'agent-sdk' (string form) → claude-agent-sdk", () => {
+    expect(normalizeRuntime("agent-sdk")).toBe("claude-agent-sdk");
+  });
+
+  test("'codex' / 'codex-sdk' → codex-sdk", () => {
+    expect(normalizeRuntime("codex")).toBe("codex-sdk");
+    expect(normalizeRuntime("codex-sdk")).toBe("codex-sdk");
+  });
+
+  test("'grok' / 'grok-build' / 'grok-build-acp' → grok-build-acp", () => {
+    expect(normalizeRuntime("grok")).toBe("grok-build-acp");
+    expect(normalizeRuntime("grok-build")).toBe("grok-build-acp");
+    expect(normalizeRuntime("grok-build-acp")).toBe("grok-build-acp");
+  });
+});
+
+describe("normalizeRuntime — profile object paths", () => {
+  test("profile with runtime='claude-code-cli' → claude-code-cli (explicit, preserved)", () => {
+    expect(normalizeRuntime({ runtime: "claude-code-cli" } as any)).toBe("claude-code-cli");
+  });
+
+  test("profile with runtime='agent-sdk' + codexRuntime='codex' → codex-sdk (legacy hybrid)", () => {
+    expect(normalizeRuntime({ runtime: "agent-sdk", codexRuntime: "codex" } as any)).toBe("codex-sdk");
+  });
+
+  test("profile with runtime='agent-sdk' + no codexRuntime → claude-agent-sdk", () => {
+    expect(normalizeRuntime({ runtime: "agent-sdk" } as any)).toBe("claude-agent-sdk");
+  });
+
+  test("profile with unknown runtime string → claude-agent-sdk (fallback)", () => {
+    expect(normalizeRuntime({ runtime: "bogus-runtime-name" } as any)).toBe("claude-agent-sdk");
+  });
+});

--- a/agent-network/src/normalize-runtime.ts
+++ b/agent-network/src/normalize-runtime.ts
@@ -1,0 +1,57 @@
+// Pure helper — runtime name canonicalization for `anet node` flows.
+//
+// Extracted from bin/cli.ts so it can be imported by unit tests without
+// triggering the CLI side-effects (top-level argv parsing, prompt
+// dispatch, etc.).
+//
+// Per Vincent's "无 Max 军团" directive (2026-06-28): fallback default
+// is `claude-agent-sdk` (vendor-neutral, works without Anthropic Max),
+// NOT the legacy `claude-code-cli` (Max/Pro-bound, leaves non-
+// subscribers with broken nodes). Explicit `claude-code-cli` operator
+// choice is preserved — only unknown/empty/missing input falls through
+// to the safe default.
+
+export type RuntimeName =
+  | "claude-code-cli"
+  | "codex-sdk"
+  | "claude-agent-sdk"
+  | "grok-build-acp";
+
+/** Operator-facing default for any runtime slot that comes in empty / missing / unrecognized. */
+export const DEFAULT_RUNTIME: RuntimeName = "claude-agent-sdk";
+
+// Subset of Profile fields this helper inspects. Keeping it narrow so
+// the test fixture doesn't need the full Profile shape and so callers
+// (bin/cli.ts uses the full Profile) can pass anything structurally
+// compatible.
+type ProfileLike = {
+  runtime?: string;
+  codexRuntime?: string;
+};
+
+export function normalizeRuntime(profileOrRuntime?: ProfileLike | string): RuntimeName {
+  if (typeof profileOrRuntime === "string") {
+    if (profileOrRuntime === "codex" || profileOrRuntime === "codex-sdk") return "codex-sdk";
+    if (
+      profileOrRuntime === "grok" ||
+      profileOrRuntime === "grok-build" ||
+      profileOrRuntime === "grok-build-acp"
+    ) return "grok-build-acp";
+    if (
+      profileOrRuntime === "claude" ||
+      profileOrRuntime === "claude-sdk" ||
+      profileOrRuntime === "claude-agent-sdk"
+    ) return "claude-agent-sdk";
+    if (profileOrRuntime === "agent-sdk") return "claude-agent-sdk";
+    // Preserve EXPLICIT `claude-code-cli` choice — operators who
+    // actually want CC-CLI still get it.
+    if (profileOrRuntime === "claude-code-cli") return "claude-code-cli";
+    return DEFAULT_RUNTIME;
+  }
+  const p = profileOrRuntime;
+  if (!p) return DEFAULT_RUNTIME;
+  if (p.runtime === "agent-sdk") {
+    return p.codexRuntime === "codex" ? "codex-sdk" : "claude-agent-sdk";
+  }
+  return normalizeRuntime(p.runtime || DEFAULT_RUNTIME);
+}


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why

Per 通信龙 dispatch (Vincent "无 Max 军团" directive): legacy stale default in `agent-network/bin/cli.ts:normalizeRuntime` falls back to `claude-code-cli` on missing/unknown input. `claude-code-cli` is bound to Anthropic Max/Pro subscription — leaving non-subscribers with broken nodes. Main `anet node create` already explicit-defaults to `claude-agent-sdk` (cli.ts:1309 comment notes CC-CLI "was a poor default"). This patch aligns the edge fallback paths.

## What changed

### Fallback paths flipped (claude-code-cli → claude-agent-sdk)

| Path | Before | After |
|---|---|---|
| `normalizeRuntime(<unknown-string>)` | claude-code-cli | claude-agent-sdk |
| `normalizeRuntime(undefined / null)` | claude-code-cli | claude-agent-sdk |
| `normalizeRuntime(profile)` with missing/empty `runtime` field | claude-code-cli | claude-agent-sdk |
| `cli.ts:3188` createOpts `opts.runtime \|\| 'claude-code-cli'` | claude-code-cli | claude-agent-sdk |

### Explicit operator choice preserved

- `normalizeRuntime('claude-code-cli')` still returns `'claude-code-cli'`
- `anet import` from existing CC sessions still writes `runtime: 'claude-code-cli'` (intentional — those ARE CC users)
- Capability tables / picker options unchanged

### Refactor side-effect

Extracted `normalizeRuntime` + `RuntimeName` + `DEFAULT_RUNTIME` to `agent-network/src/normalize-runtime.ts` (pure module, no CLI side-effects). `bin/cli.ts` re-exports for back-compat. This lets the unit test import directly without dragging in argv parsing / inquirer.

## Why `claude-agent-sdk` is the safe default

Vendor-neutral — works with:
- Anthropic API
- MiniMax (via Claude API shape)
- DeepSeek, GLM, Kimi (via Claude API shape)
- Anthropic subscription (when set)

No Max/Pro subscription required. Matches main `anet node create` default per cli.ts:1309 comment.

## Tests

`agent-network/src/normalize-runtime.test.ts` — 17 pass, 0 fail, 20 expect()

| Group | Coverage |
|---|---|
| **Fallback default** | unknown string / empty / undefined / no-arg / missing profile / empty-string profile.runtime — all 6 → `claude-agent-sdk` |
| **Explicit choice preserved** | `claude-code-cli` / `claude-agent-sdk` / `claude` / `claude-sdk` / `agent-sdk` / `codex` / `codex-sdk` / `grok` / `grok-build` / `grok-build-acp` — 10 cases |
| **Profile object paths** | explicit CC-CLI / legacy `agent-sdk` + `codexRuntime` hybrid / `agent-sdk` alone / unknown runtime in profile — 4 cases |

`tsc --noEmit` on agent-network: clean.

## Verify (per 通信龙 dispatch checklist)

- [x] Read full `normalizeRuntime` — L317-331 in main, three fallback sites identified
- [x] Grep all repo for `claude-code-cli` defaults — found L3188 createOpts (flipped). L3989 `anet import` is INTENTIONAL (importing CC sessions), kept. L839/L1964/L2156 picker options (user choices), kept. L1782 capability table, kept.
- [x] Unit test runtime missing / unknown → claude-agent-sdk
- [x] Explicit `claude-code-cli` choice preserved

Non-security, non-destructive, behavior tightened on edge fallback only.

## Tracking

- Internal task #151
- 通信龙 dispatch: Vincent "无 Max 军团" directive
