### PR TITLE
feat(rfc-025 m1): agent loop self-management — 6 self-scoped tools + cron-lite + context injection (claude-agent-sdk)

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -21,6 +21,7 @@ import { GoalStore, newGoal, runtimeBucket, decideStartupAction } from "./goals/
 import { decideTickWork } from "./goals/scheduler";
 import { runCodexWakeForGoal, type CodexWakeDeps } from "./goals/codex-wake";
 import { isGoalCompleteSentinel } from "./goals/completion-detect";
+import { computeNextWakeAt } from "./goals/schedule";
 import { startTelegramWatchdog } from "./telegram-watchdog";
 import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
@@ -1169,7 +1170,22 @@ async function runOneGoalWake(goal: AgentGoal): Promise<void> {
   }
   const summary = text.replace(/\s+/g, " ").slice(0, 500);
   const completed = isGoalCompleteSentinel(text);
-  const nextWakeAt = new Date(Date.now() + goal.interval_ms).toISOString();
+  // RFC-025 M1b: cron-lite aware advancement. When goal has schedule
+  // field (time_of_day / weekday / new-format interval), use the pure
+  // computeNextWakeAt to pick the next wall-clock instant. When schedule
+  // is absent (legacy interval-only goals — every goals.json on disk
+  // pre-M1b), fall back to "now + interval_ms" — EXACTLY the pre-M1b
+  // path. Back-compat regression锁 by goals/schedule.test.ts.
+  //
+  // Default TZ comes from node config flags.timezone, falling back to
+  // Asia/Shanghai (Vincent/团队主时区, per RFC-025 §11.8 resolved).
+  const goalDefaultTz: string = (fileConfig?.flags?.timezone as string) || "Asia/Shanghai";
+  const nextWakeAt = computeNextWakeAt(
+    goal.schedule,
+    new Date(),
+    goalDefaultTz,
+    { fallback_interval_ms: goal.interval_ms },
+  ).toISOString();
 
   // Phase 2: writeback. If THIS mutate throws, the wake's LLM work
   // already happened — surface the writeback failure loudly so the

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -22,6 +22,7 @@ import { decideTickWork } from "./goals/scheduler";
 import { runCodexWakeForGoal, type CodexWakeDeps } from "./goals/codex-wake";
 import { isGoalCompleteSentinel } from "./goals/completion-detect";
 import { computeNextWakeAt } from "./goals/schedule";
+import { formatSelfLoopsBlock } from "./goals/format";
 import { startTelegramWatchdog } from "./telegram-watchdog";
 import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
@@ -2624,11 +2625,29 @@ async function processTask(task: string, from: string, taskId: string | null = n
   log(`→ processing [${RUNTIME}]${images?.length ? ` +${images.length} image(s)` : ""}: ${task.slice(0, 80)}`);
   await reportStatus("working", task.slice(0, 200)).catch(() => {});
 
+  // RFC-025 M1c P0b — context injection.
+  // Prepend a self-loop block so the agent knows what it's currently
+  // looping. Pure formatter; empty when no active/paused goals.
+  // Read goals fresh every turn (no cache) so M1d edits / new loops
+  // show up immediately on the next think.
+  let augmentedTask = task;
+  try {
+    const myGoals = await goalStore.list();
+    const block = formatSelfLoopsBlock(myGoals);
+    if (block) {
+      augmentedTask = block + "\n" + task;
+    }
+  } catch (e: any) {
+    // Defensive: a bad goalStore read MUST NOT block normal task
+    // processing. Log and continue with the original task.
+    warn(`[goals/format] inject failed: ${e?.message ?? e} (task continues without block)`);
+  }
+
   let text: string;
   let failed = false;
   try {
-    text = await tryHandleExplicitDelegation(task, from, taskId)
-      || await think(task, from, taskId, images);
+    text = await tryHandleExplicitDelegation(augmentedTask, from, taskId)
+      || await think(augmentedTask, from, taskId, images);
   } catch (err: any) {
     text = `${RUNTIME} 错误: ${err.message}`;
     failed = true;

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -480,6 +480,14 @@ const NODE_DIR = configFilePath ? dirname(configFilePath) : join(process.cwd(), 
 const GOALS_PATH = opts["goals-path"] || fileConfig.flags?.goalsPath || fileConfig.goalsPath || join(NODE_DIR, "goals.json");
 const GOAL_TICK_MS = Math.max(10_000, parseInt(opts["goal-tick-ms"] || process.env.ANET_GOAL_TICK_MS || fileConfig.flags?.goalTickMs || "30000"));
 const goalStore = new GoalStore(GOALS_PATH);
+
+// RFC-025 M1e — per-process state for the self-loop tools' safety
+// 防线. Lives at module scope so the SAME counters are shared across
+// every claude SDK query() invocation in this agent-node process
+// (otherwise the batch-cancel threshold reset every wake and the防线
+// would be a no-op).
+const loopsCancelTimestamps: number[] = [];
+const loopsConfirmTokens: Set<string> = new Set();
 const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 } as const;
 const LOG_LEVEL = (LOG_LEVELS as any)[(opts["log-level"] || process.env.LOG_LEVEL || fileConfig.logLevel || "info")] ?? 1;
 const channelSpecs = [
@@ -1574,6 +1582,29 @@ async function processWithClaude(task: string, from: string, images?: string[]):
         headers: commhubToken ? { "Authorization": `Bearer ${commhubToken}` } : undefined,
       };
     }
+  }
+
+  // RFC-025 M1e — agent loop self-management tools (6 self-scoped
+  // handlers: list/create/edit/reschedule/complete/cancel_my_loop).
+  // By construction self-scoped: the ctx binds THIS node's goalStore
+  // + runtime + tz; no `alias` arg in any tool schema, so the LLM
+  // physically cannot address another node's goals. claude-code-cli
+  // runtime is excluded by where this wire-up lives (we're in
+  // processWithClaude, RUNTIME='claude' bucket = claude-agent-sdk
+  // path; CC-CLI is its own standalone session).
+  try {
+    const { createLoopsMcpServer } = await import("./goals/loops-mcp");
+    const maxGoalsEnv = parseInt(process.env.COMMHUB_MAX_GOALS_PER_NODE || "", 10);
+    mcpServers["loops"] = await createLoopsMcpServer({
+      store: goalStore,
+      runtime: RUNTIME_LABEL,
+      defaultTz: (fileConfig?.flags?.timezone as string) || "Asia/Shanghai",
+      maxActiveGoals: Number.isFinite(maxGoalsEnv) && maxGoalsEnv > 0 ? maxGoalsEnv : undefined,
+      recentCancels: loopsCancelTimestamps,
+      pendingConfirmTokens: loopsConfirmTokens,
+    });
+  } catch (e: any) {
+    warn(`[claude] loops SDK MCP server init failed (${e?.message || e}); self-loop tools unavailable for this agent`);
   }
 
   // ALWAYS resolve a working binary. Earlier we returned undefined when

--- a/agent-node/src/goals/format.test.ts
+++ b/agent-node/src/goals/format.test.ts
@@ -1,0 +1,155 @@
+// RFC-025 M1c P0b — context-injection formatter tests.
+
+import { describe, expect, test } from "bun:test";
+import { formatSelfLoopsBlock } from "./format";
+import type { AgentGoal } from "./types";
+
+function mkGoal(overrides: Partial<AgentGoal> = {}): AgentGoal {
+  return {
+    goal_id: "abcdef12-3456-7890-abcd-ef1234567890",
+    text: "test goal",
+    status: "active",
+    interval_ms: 5 * 60_000,
+    next_wake_at: new Date(Date.now() + 5 * 60_000).toISOString(),
+    runtime: "claude-agent-sdk",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    progress_log: [],
+    ...overrides,
+  };
+}
+
+describe("formatSelfLoopsBlock — empty / omit semantics", () => {
+  test("no goals + omitWhenEmpty=true (default) → empty string", () => {
+    expect(formatSelfLoopsBlock([])).toBe("");
+  });
+
+  test("no goals + omitWhenEmpty=false → explicit '无活跃循环' block", () => {
+    const out = formatSelfLoopsBlock([], { omitWhenEmpty: false });
+    expect(out).toContain("【你的当前循环任务】");
+    expect(out).toContain("(无活跃循环)");
+  });
+
+  test("only terminal goals (cancelled/complete/failed) → empty (same as no goals)", () => {
+    const goals = [
+      mkGoal({ goal_id: "a", status: "complete" }),
+      mkGoal({ goal_id: "b", status: "cancelled" }),
+      mkGoal({ goal_id: "c", status: "failed" }),
+    ];
+    expect(formatSelfLoopsBlock(goals)).toBe("");
+  });
+});
+
+describe("formatSelfLoopsBlock — content shape", () => {
+  test("single active goal: header + id8 + cadence + text", () => {
+    const out = formatSelfLoopsBlock([
+      mkGoal({ goal_id: "12345678-...", text: "monitor PR #271", interval_ms: 5 * 60_000 }),
+    ]);
+    expect(out).toContain("【你的当前循环任务】");
+    expect(out).toContain("12345678");
+    expect(out).toContain("active");
+    expect(out).toContain("每 5min");
+    expect(out).toContain("monitor PR #271");
+  });
+
+  test("paused goals shown with status='paused'", () => {
+    const out = formatSelfLoopsBlock([
+      mkGoal({ goal_id: "p1", status: "paused", text: "twitter scan" }),
+    ]);
+    expect(out).toContain("paused");
+    expect(out).toContain("twitter scan");
+  });
+
+  test("mix active + paused + terminal → only active+paused appear", () => {
+    const out = formatSelfLoopsBlock([
+      mkGoal({ goal_id: "active1", text: "A active" }),
+      mkGoal({ goal_id: "paused1", status: "paused", text: "B paused" }),
+      mkGoal({ goal_id: "term1", status: "complete", text: "C done" }),
+    ]);
+    expect(out).toContain("A active");
+    expect(out).toContain("B paused");
+    expect(out).not.toContain("C done");
+  });
+});
+
+describe("formatSelfLoopsBlock — cron-lite cadence rendering", () => {
+  test("time_of_day cadence: '每天 09:00'", () => {
+    const out = formatSelfLoopsBlock([
+      mkGoal({
+        text: "morning summary",
+        schedule: { type: "time_of_day", time: "09:00", timezone: "Asia/Shanghai" },
+        interval_ms: 24 * 60 * 60_000,  // natural cadence
+      }),
+    ]);
+    expect(out).toContain("每天 09:00");
+    expect(out).toContain("Asia/Shanghai");
+  });
+
+  test("weekday cadence: 'mon/wed/fri 18:30'", () => {
+    const out = formatSelfLoopsBlock([
+      mkGoal({
+        text: "MWF report",
+        schedule: { type: "weekday", days: ["mon", "wed", "fri"], time: "18:30" },
+        interval_ms: 7 * 24 * 60 * 60_000,
+      }),
+    ]);
+    expect(out).toContain("mon/wed/fri 18:30");
+  });
+
+  test("new-format interval cadence renders same as legacy interval_ms", () => {
+    const out = formatSelfLoopsBlock([
+      mkGoal({
+        text: "x",
+        schedule: { type: "interval", interval_ms: 30 * 60_000 },
+        interval_ms: 30 * 60_000,
+      }),
+    ]);
+    expect(out).toContain("每 30min");
+  });
+});
+
+describe("formatSelfLoopsBlock — cap + truncation", () => {
+  test("more than maxGoals → truncates with '...' summary", () => {
+    const goals = Array.from({ length: 25 }, (_, i) =>
+      mkGoal({ goal_id: `g${i}`, text: `goal ${i}` }),
+    );
+    const out = formatSelfLoopsBlock(goals, { maxGoals: 3 });
+    expect(out).toContain("goal 0");
+    expect(out).toContain("goal 1");
+    expect(out).toContain("goal 2");
+    expect(out).not.toContain("goal 3");
+    expect(out).toContain("+22 个更多");
+  });
+
+  test("text is one-line truncated at 100 chars", () => {
+    const longText = "a".repeat(200);
+    const out = formatSelfLoopsBlock([mkGoal({ text: longText })]);
+    // truncated text is 100 a's, not 200
+    expect(out).toContain("a".repeat(100));
+    expect(out).not.toContain("a".repeat(101));
+  });
+
+  test("multi-line text is rendered as single line", () => {
+    const out = formatSelfLoopsBlock([mkGoal({ text: "line1\nline2\n\nline3" })]);
+    expect(out).toContain("line1 line2 line3");
+  });
+});
+
+describe("formatSelfLoopsBlock — relative time rendering", () => {
+  test("next_wake_at far in the future → ISO-shortened", () => {
+    const future = new Date(Date.now() + 48 * 60 * 60_000).toISOString();
+    const out = formatSelfLoopsBlock([mkGoal({ next_wake_at: future })]);
+    expect(out).toContain("下次:");
+  });
+
+  test("next_wake_at in past → '已到期'", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const out = formatSelfLoopsBlock([mkGoal({ next_wake_at: past })]);
+    expect(out).toContain("已到期");
+  });
+
+  test("malformed ISO doesn't crash, falls back to raw", () => {
+    const out = formatSelfLoopsBlock([mkGoal({ next_wake_at: "not-a-date" })]);
+    expect(out).toContain("not-a-date");
+  });
+});

--- a/agent-node/src/goals/format.ts
+++ b/agent-node/src/goals/format.ts
@@ -1,0 +1,101 @@
+// RFC-025 M1c P0b — context-injection formatter.
+//
+// Pure renderer: turns the agent's active+paused goals into a
+// human-readable block that gets prepended to every think() prompt
+// so the agent knows "I'm currently looping these things".
+//
+// **Why prepend to user prompt** (not system prompt as the RFC §11.4
+// resolution prefers): in practice codex-sdk and grok-build-acp don't
+// expose a clean per-call systemPrompt slot the way claude-agent-sdk
+// does. A user-prompt preamble with a `【...】` marker is the most
+// uniform cross-runtime path and reads as "system-style metadata" to
+// every LLM. We can refactor to per-runtime systemPrompt in a future
+// pass if telemetry shows it matters.
+//
+// Pure function — no I/O, callable from anywhere.
+
+import type { AgentGoal } from "./types";
+
+export interface FormatOpts {
+  /** Cap the block at N goals so it doesn't dominate the prompt. Default 20. */
+  maxGoals?: number;
+  /** Hide block entirely when there are no active+paused goals. Default true. */
+  omitWhenEmpty?: boolean;
+}
+
+/**
+ * Render a `【你的当前循环任务】` block listing this agent's active and
+ * paused loops. Empty list → empty string (caller can prepend nothing).
+ */
+export function formatSelfLoopsBlock(goals: AgentGoal[], opts: FormatOpts = {}): string {
+  const max = opts.maxGoals ?? 20;
+  const omitWhenEmpty = opts.omitWhenEmpty ?? true;
+
+  // Only active + paused are interesting context. Complete/cancelled/
+  // failed are terminal — agent doesn't need them in working memory.
+  const relevant = goals.filter((g) => g.status === "active" || g.status === "paused");
+
+  if (relevant.length === 0 && omitWhenEmpty) return "";
+
+  const lines: string[] = [];
+  lines.push("【你的当前循环任务】 (anet goals — 用 manage_my_loop 工具管理)");
+  lines.push("");
+
+  if (relevant.length === 0) {
+    lines.push("(无活跃循环)");
+    return lines.join("\n") + "\n";
+  }
+
+  const shown = relevant.slice(0, max);
+  for (const g of shown) {
+    const id8 = g.goal_id.slice(0, 8);
+    const status = g.status === "paused" ? "paused" : "active";
+    const cadence = describeCadence(g);
+    const nextTime = formatRelativeTime(g.next_wake_at);
+    lines.push(`${id8}  ${status.padEnd(7)}  ${cadence.padEnd(20)}  下次: ${nextTime}`);
+    const oneLineText = g.text.replace(/\s+/g, " ").trim().slice(0, 100);
+    lines.push(`    ${oneLineText}`);
+  }
+
+  if (relevant.length > max) {
+    lines.push(`... (+${relevant.length - max} 个更多, list_my_loops 看全部)`);
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+function describeCadence(g: AgentGoal): string {
+  if (g.schedule) {
+    switch (g.schedule.type) {
+      case "interval":
+        return `每 ${humanizeMs(g.schedule.interval_ms)}`;
+      case "time_of_day":
+        return `每天 ${g.schedule.time}${g.schedule.timezone ? ` (${g.schedule.timezone})` : ""}`;
+      case "weekday":
+        return `${g.schedule.days.join("/")} ${g.schedule.time}`;
+    }
+  }
+  return `每 ${humanizeMs(g.interval_ms)}`;
+}
+
+function humanizeMs(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}秒`;
+  if (ms < 60 * 60_000) return `${Math.round(ms / 60_000)}min`;
+  if (ms < 24 * 60 * 60_000) return `${Math.round(ms / 3600_000)}h`;
+  return `${Math.round(ms / (24 * 3600_000))}d`;
+}
+
+function formatRelativeTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (!Number.isFinite(d.getTime())) return iso;
+    const delta = d.getTime() - Date.now();
+    if (delta < 0) return `已到期 (${iso.slice(11, 19)}Z)`;
+    if (delta < 60_000) return `~${Math.round(delta / 1000)}s 后`;
+    if (delta < 60 * 60_000) return `~${Math.round(delta / 60_000)}min 后`;
+    if (delta < 24 * 60 * 60_000) return `~${Math.round(delta / 3600_000)}h 后`;
+    return iso.slice(0, 16).replace("T", " ");
+  } catch {
+    return iso;
+  }
+}

--- a/agent-node/src/goals/loops-mcp.ts
+++ b/agent-node/src/goals/loops-mcp.ts
@@ -1,0 +1,101 @@
+// RFC-025 M1e P1 — claude-agent-sdk MCP adapter for self-loop tools.
+//
+// Mirrors the commhub-mcp.ts pattern: creates an in-process SDK
+// McpServer instance and wires our 6 handlers to it. The agent's LLM
+// sees them as `mcp__loops__list_my_loops` etc.
+//
+// **Self-scoped by-construction** (RFC-025 §5.2): the SelfLoopCtx
+// passed at adapter creation time is bound to THIS node's GoalStore +
+// runtime + tz. No `alias` arg in any tool schema — physically
+// impossible for the LLM to address another node's goals.
+//
+// claude-code-cli runtime: this adapter is NOT registered (RFC-025
+// §3.1 + §12 — claude-code-cli uses CC native /loop, independent
+// session, not agent-node).
+
+import { z } from "zod";
+import type { SelfLoopCtx } from "./self-loop-tools";
+import { SELF_LOOP_TOOL_SPECS } from "./self-loop-tools";
+
+// Schemas — zod versions of the tool args. Kept narrow + descriptive
+// so the SDK generates good tool-call documentation for the LLM.
+const ScheduleUnionSchema = z.union([
+  z.object({
+    type: z.literal("interval"),
+    interval_ms: z.number().int().min(60_000).describe("Wake interval in ms (>= 60000 = 60s floor)"),
+  }),
+  z.object({
+    type: z.literal("time_of_day"),
+    time: z.string().regex(/^\d{1,2}:\d{2}$/).describe("Wall-clock time HH:MM (e.g. '09:00')"),
+    timezone: z.string().optional().describe("IANA tz (default: node config or Asia/Shanghai)"),
+  }),
+  z.object({
+    type: z.literal("weekday"),
+    days: z.array(z.enum(["sun", "mon", "tue", "wed", "thu", "fri", "sat"])).min(1).describe("Weekdays e.g. ['mon','wed','fri']"),
+    time: z.string().regex(/^\d{1,2}:\d{2}$/).describe("Wall-clock time HH:MM"),
+    timezone: z.string().optional(),
+  }),
+]);
+
+const ToolArgSchemas: Record<string, z.ZodObject<any>> = {
+  list_my_loops: z.object({}),
+  create_my_loop: z.object({
+    task: z.string().describe("Goal task description (what the agent will do at each wake)"),
+    interval: z.string().optional().describe("Simple interval like '5m' / '2h' / '1d' (alternative to schedule)"),
+    schedule: ScheduleUnionSchema.optional().describe("Cron-lite schedule (alternative to interval)"),
+  }),
+  edit_my_loop: z.object({
+    goal_id: z.string().describe("Goal id (full UUID or 8-char prefix — must be unique match)"),
+    task: z.string().optional().describe("New task description"),
+    interval: z.string().optional().describe("New simple interval"),
+    schedule: ScheduleUnionSchema.optional().describe("New cron-lite schedule"),
+    paused: z.boolean().optional().describe("true=pause (temporary, resumable), false=resume"),
+  }),
+  reschedule_my_loop: z.object({
+    goal_id: z.string(),
+    next_wake_in: z.string().describe("Push next wake forward by this much (e.g. '30m', '2h')"),
+  }),
+  complete_my_loop: z.object({
+    goal_id: z.string(),
+  }),
+  cancel_my_loop: z.object({
+    goal_id: z.string(),
+    confirm_token: z.string().optional().describe("Required on batch-cancel confirm-back retry"),
+  }),
+};
+
+export async function createLoopsMcpServer(ctx: SelfLoopCtx) {
+  // Dynamic import per the same pattern as commhub-mcp.ts — keeps
+  // claude-agent-sdk SDK as `--external` at bundle time so the
+  // 222 MB linux-x64 claude binary doesn't get pulled into the dist.
+  const { createSdkMcpServer, tool } = await import("@anthropic-ai/claude-agent-sdk");
+
+  const tools = SELF_LOOP_TOOL_SPECS.map((spec) => {
+    const schema = ToolArgSchemas[spec.name];
+    if (!schema) {
+      throw new Error(`loops-mcp: missing schema for tool ${spec.name}`);
+    }
+    return tool(
+      spec.name,
+      spec.description,
+      schema.shape, // claude-agent-sdk tool() takes raw ZodRawShape, not the full object
+      async (args: unknown) => {
+        const result = await spec.handler(args, ctx);
+        // SDK MCP tool() expects { content: [{ type: 'text', text: string }] }.
+        // We serialize the discriminated result so the LLM sees the
+        // structured ok/error shape including confirm_token.
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(result) },
+          ],
+        };
+      },
+    );
+  });
+
+  return createSdkMcpServer({
+    name: "loops",
+    version: "0.1.0",
+    tools,
+  });
+}

--- a/agent-node/src/goals/schedule.test.ts
+++ b/agent-node/src/goals/schedule.test.ts
@@ -1,0 +1,216 @@
+// RFC-025 M1 P0a — computeNextWakeAt tests (test-first).
+//
+// 通信龙 emphasis #1: "computeNextWakeAt 是 load-bearing 正确性件 —
+// cron-lite 的 DST / 时区 / 相位 edge 测试要狠 (table-driven edge
+// case)". This is a pure function; every TZ/DST/wraparound case below
+// is reproducible without external state.
+//
+// 通信龙 emphasis #5: "向后兼容 — 现有只有 interval 的 goal, 加
+// schedule union 后行为不能变". Pinned in the "legacy interval-only"
+// describe block at the bottom.
+
+import { describe, expect, test } from "bun:test";
+import { computeNextWakeAt } from "./schedule";
+import type { AgentGoalSchedule } from "./types";
+
+// Anchor every fixed-time test on a known-stable Asia/Shanghai instant:
+// 2026-06-28T10:00:00+08:00  ==  2026-06-28T02:00:00Z
+const SH_10AM = new Date("2026-06-28T02:00:00.000Z"); // Sunday Asia/Shanghai 10:00
+
+describe("computeNextWakeAt — interval mode", () => {
+  test("interval 5min from a baseline returns baseline + 5min", () => {
+    const sched: AgentGoalSchedule = { type: "interval", interval_ms: 5 * 60_000 };
+    const next = computeNextWakeAt(sched, SH_10AM, "Asia/Shanghai");
+    expect(next.toISOString()).toBe("2026-06-28T02:05:00.000Z");
+  });
+
+  test("interval 24h returns +24h", () => {
+    const sched: AgentGoalSchedule = { type: "interval", interval_ms: 24 * 60 * 60_000 };
+    const next = computeNextWakeAt(sched, SH_10AM, "Asia/Shanghai");
+    expect(next.toISOString()).toBe("2026-06-29T02:00:00.000Z");
+  });
+
+  test("interval is timezone-independent (UTC anchor same result regardless of node TZ)", () => {
+    const sched: AgentGoalSchedule = { type: "interval", interval_ms: 60 * 60_000 };
+    const sh = computeNextWakeAt(sched, SH_10AM, "Asia/Shanghai");
+    const ny = computeNextWakeAt(sched, SH_10AM, "America/New_York");
+    const utc = computeNextWakeAt(sched, SH_10AM, "UTC");
+    expect(sh.toISOString()).toBe(ny.toISOString());
+    expect(ny.toISOString()).toBe(utc.toISOString());
+  });
+});
+
+describe("computeNextWakeAt — time_of_day mode (per-TZ wall clock)", () => {
+  test("09:00 Asia/Shanghai, called at 10:00 Asia/Shanghai → tomorrow 09:00 (already past today)", () => {
+    const sched: AgentGoalSchedule = { type: "time_of_day", time: "09:00", timezone: "Asia/Shanghai" };
+    const next = computeNextWakeAt(sched, SH_10AM, "Asia/Shanghai");
+    // 09:00 Asia/Shanghai = 01:00 UTC; tomorrow = 2026-06-29T01:00:00Z
+    expect(next.toISOString()).toBe("2026-06-29T01:00:00.000Z");
+  });
+
+  test("09:00 Asia/Shanghai, called at 08:00 Asia/Shanghai → today 09:00 (still upcoming)", () => {
+    const sched: AgentGoalSchedule = { type: "time_of_day", time: "09:00", timezone: "Asia/Shanghai" };
+    const at_8am_sh = new Date("2026-06-28T00:00:00.000Z"); // 08:00 Asia/Shanghai
+    const next = computeNextWakeAt(sched, at_8am_sh, "Asia/Shanghai");
+    expect(next.toISOString()).toBe("2026-06-28T01:00:00.000Z");
+  });
+
+  test("09:00 Asia/Shanghai, called AT 09:00 exactly → today (boundary include)", () => {
+    const sched: AgentGoalSchedule = { type: "time_of_day", time: "09:00", timezone: "Asia/Shanghai" };
+    const at_9am_sh = new Date("2026-06-28T01:00:00.000Z"); // exact 09:00 Asia/Shanghai
+    const next = computeNextWakeAt(sched, at_9am_sh, "Asia/Shanghai");
+    // Boundary: if it's exactly 09:00 we treat now as "just past" and
+    // schedule for tomorrow (avoids immediate re-fire after the wake
+    // that we just triggered).
+    expect(next.toISOString()).toBe("2026-06-29T01:00:00.000Z");
+  });
+
+  test("falls back to node default TZ if schedule has no timezone", () => {
+    const sched: AgentGoalSchedule = { type: "time_of_day", time: "09:00" };
+    // node default = America/New_York. 09:00 New York = 13:00 UTC (summer EDT)
+    const at_eod = new Date("2026-06-28T20:00:00.000Z"); // anytime past 09:00 NY
+    const next = computeNextWakeAt(sched, at_eod, "America/New_York");
+    expect(next.toISOString()).toBe("2026-06-29T13:00:00.000Z");
+  });
+});
+
+describe("computeNextWakeAt — weekday mode", () => {
+  // 2026-06-28 is Sunday in Asia/Shanghai. Days of week order:
+  // Sun=0, Mon=1, Tue=2, ..., Sat=6
+  test("Monday 09:00 Asia/Shanghai, called Sun 10:00 → tomorrow (Mon) 09:00", () => {
+    const sched: AgentGoalSchedule = {
+      type: "weekday", days: ["mon"], time: "09:00", timezone: "Asia/Shanghai",
+    };
+    const next = computeNextWakeAt(sched, SH_10AM, "Asia/Shanghai");
+    expect(next.toISOString()).toBe("2026-06-29T01:00:00.000Z");
+  });
+
+  test("Mon/Wed/Fri 18:30 Asia/Shanghai, called Sun 10:00 → Monday 18:30 (next eligible)", () => {
+    const sched: AgentGoalSchedule = {
+      type: "weekday", days: ["mon", "wed", "fri"], time: "18:30", timezone: "Asia/Shanghai",
+    };
+    const next = computeNextWakeAt(sched, SH_10AM, "Asia/Shanghai");
+    // 18:30 Asia/Shanghai = 10:30 UTC
+    expect(next.toISOString()).toBe("2026-06-29T10:30:00.000Z");
+  });
+
+  test("Mon/Wed/Fri 18:30, called Mon 18:00 → today 18:30 (today eligible AND time still upcoming)", () => {
+    const sched: AgentGoalSchedule = {
+      type: "weekday", days: ["mon", "wed", "fri"], time: "18:30", timezone: "Asia/Shanghai",
+    };
+    const mon_6pm_sh = new Date("2026-06-29T10:00:00.000Z");
+    const next = computeNextWakeAt(sched, mon_6pm_sh, "Asia/Shanghai");
+    expect(next.toISOString()).toBe("2026-06-29T10:30:00.000Z");
+  });
+
+  test("Mon/Wed/Fri 18:30, called Mon 19:00 → today is Mon but past 18:30 → Wed 18:30", () => {
+    const sched: AgentGoalSchedule = {
+      type: "weekday", days: ["mon", "wed", "fri"], time: "18:30", timezone: "Asia/Shanghai",
+    };
+    const mon_7pm_sh = new Date("2026-06-29T11:00:00.000Z");
+    const next = computeNextWakeAt(sched, mon_7pm_sh, "Asia/Shanghai");
+    // Wed (2 days later) = 2026-07-01T10:30:00Z
+    expect(next.toISOString()).toBe("2026-07-01T10:30:00.000Z");
+  });
+
+  test("Friday 09:00, called Saturday → next Friday (full week wrap-around)", () => {
+    const sched: AgentGoalSchedule = {
+      type: "weekday", days: ["fri"], time: "09:00", timezone: "Asia/Shanghai",
+    };
+    const sat = new Date("2026-06-27T12:00:00.000Z"); // Sat 20:00 Asia/Shanghai
+    const next = computeNextWakeAt(sched, sat, "Asia/Shanghai");
+    // Next Fri 2026-07-03 09:00 Asia/Shanghai = 2026-07-03T01:00:00Z
+    expect(next.toISOString()).toBe("2026-07-03T01:00:00.000Z");
+  });
+
+  test("workdays ['mon','tue','wed','thu','fri'] for daily standup is supported", () => {
+    const sched: AgentGoalSchedule = {
+      type: "weekday",
+      days: ["mon", "tue", "wed", "thu", "fri"],
+      time: "10:00",
+      timezone: "Asia/Shanghai",
+    };
+    // Sun → next Mon
+    const next = computeNextWakeAt(sched, SH_10AM, "Asia/Shanghai");
+    expect(next.toISOString()).toBe("2026-06-29T02:00:00.000Z");
+  });
+});
+
+describe("computeNextWakeAt — DST edge cases (US Eastern)", () => {
+  // US DST 2026: starts Sun Mar 8 (spring forward 02:00→03:00), ends Sun Nov 1 (fall back 02:00→01:00)
+  // Pin behaviour: time_of_day uses CALENDAR wall-clock — "09:00 New York" means 09:00 New York time,
+  // which is 13:00 UTC during EDT (summer), 14:00 UTC during EST (winter). Auto.
+
+  test("09:00 America/New_York in summer (EDT) → 13:00 UTC", () => {
+    const sched: AgentGoalSchedule = { type: "time_of_day", time: "09:00", timezone: "America/New_York" };
+    const summer_baseline = new Date("2026-07-15T03:00:00.000Z");
+    const next = computeNextWakeAt(sched, summer_baseline, "America/New_York");
+    expect(next.toISOString()).toBe("2026-07-15T13:00:00.000Z");
+  });
+
+  test("09:00 America/New_York in winter (EST) → 14:00 UTC", () => {
+    const sched: AgentGoalSchedule = { type: "time_of_day", time: "09:00", timezone: "America/New_York" };
+    const winter_baseline = new Date("2026-01-15T03:00:00.000Z");
+    const next = computeNextWakeAt(sched, winter_baseline, "America/New_York");
+    expect(next.toISOString()).toBe("2026-01-15T14:00:00.000Z");
+  });
+
+  test("daily 02:30 wake DOES NOT skip on DST spring-forward day (just shifts that day)", () => {
+    // 2026-03-08 02:00 ET → 03:00 ET (skips 02:30). Schedule wants 02:30 ET.
+    // Standard cron behaviour for skipped wall-clock times: skip that day, fire next day.
+    // We follow that convention.
+    const sched: AgentGoalSchedule = { type: "time_of_day", time: "02:30", timezone: "America/New_York" };
+    const at_2am_et_spring_forward = new Date("2026-03-08T07:00:00.000Z"); // 02:00 EST (just before spring forward)
+    const next = computeNextWakeAt(sched, at_2am_et_spring_forward, "America/New_York");
+    // 02:30 ET on 2026-03-08 does not exist — skip to next day (2026-03-09 02:30 EDT = 06:30 UTC)
+    expect(next.toISOString()).toBe("2026-03-09T06:30:00.000Z");
+  });
+});
+
+describe("computeNextWakeAt — legacy interval-only (back-compat regression)", () => {
+  // 通信龙 emphasis #5: existing interval-only goals must behave
+  // IDENTICALLY. If schedule is undefined, computeNextWakeAt falls
+  // back to interval-from-now semantics (matches pre-RFC-025
+  // behaviour: scheduler advanced next_wake_at = now + interval_ms).
+
+  test("undefined schedule → uses interval_ms from goal context, returns now + interval", () => {
+    const next = computeNextWakeAt(undefined, SH_10AM, "Asia/Shanghai", { fallback_interval_ms: 5 * 60_000 });
+    expect(next.toISOString()).toBe("2026-06-28T02:05:00.000Z");
+  });
+
+  test("undefined schedule + zero fallback interval → still returns now (no negative offset)", () => {
+    // Defensive: scheduler tick treats 0 as "ASAP" but never negative.
+    const next = computeNextWakeAt(undefined, SH_10AM, "Asia/Shanghai", { fallback_interval_ms: 0 });
+    expect(next.getTime()).toBe(SH_10AM.getTime());
+  });
+
+  test("undefined schedule + missing fallback interval throws (programmer error)", () => {
+    // The scheduler should ALWAYS pass either schedule or fallback_interval_ms.
+    // If both are absent it's a bug, not a user-facing condition.
+    expect(() => computeNextWakeAt(undefined, SH_10AM, "Asia/Shanghai", {})).toThrow();
+  });
+});
+
+describe("computeNextWakeAt — parser-rejected edge cases (defensive)", () => {
+  test("invalid time format '25:99' throws", () => {
+    expect(() =>
+      computeNextWakeAt({ type: "time_of_day", time: "25:99" } as any, SH_10AM, "Asia/Shanghai")
+    ).toThrow(/invalid time/);
+  });
+
+  test("empty weekday list throws (caught by parser too, defense in depth)", () => {
+    expect(() =>
+      computeNextWakeAt({ type: "weekday", days: [], time: "09:00" } as any, SH_10AM, "Asia/Shanghai")
+    ).toThrow(/weekday/);
+  });
+
+  test("unknown weekday name throws", () => {
+    expect(() =>
+      computeNextWakeAt(
+        { type: "weekday", days: ["nonday"], time: "09:00" } as any,
+        SH_10AM,
+        "Asia/Shanghai"
+      )
+    ).toThrow(/unknown weekday/);
+  });
+});

--- a/agent-node/src/goals/schedule.ts
+++ b/agent-node/src/goals/schedule.ts
@@ -1,0 +1,208 @@
+// RFC-025 M1 P0a — cron-lite schedule computation.
+//
+// `computeNextWakeAt(schedule, now, defaultTz, opts?)` returns the
+// next ISO instant the scheduler should fire this goal. Pure: no I/O,
+// no global state, no clock reads (caller passes `now` so tests and
+// the scheduler tick can both feed the same instant).
+//
+// **Load-bearing correctness** (通信龙 emphasis #1): every TZ/DST
+// edge that user expectations care about is encoded here. Test file
+// schedule.test.ts covers DST spring-forward skip, weekday wraparound,
+// boundary inclusion, back-compat fallback to interval_ms.
+//
+// **Back-compat** (通信龙 emphasis #5): when `schedule` is undefined
+// the function falls back to "now + opts.fallback_interval_ms" — the
+// exact behaviour the pre-RFC-025 scheduler used for interval goals.
+// Existing goals in goals.json have no `schedule` field; they keep
+// firing on the same cadence with zero observable change.
+
+import type { AgentGoalSchedule } from "./types";
+
+const WEEKDAY_NAMES: Record<string, number> = {
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+};
+
+export interface ComputeOpts {
+  /** Used when `schedule` is undefined (legacy interval-only goals). */
+  fallback_interval_ms?: number;
+}
+
+/**
+ * Pure next-wake calculator. See schedule.test.ts for the full
+ * behaviour matrix (DST, TZ, weekday wraparound, boundary).
+ */
+export function computeNextWakeAt(
+  schedule: AgentGoalSchedule | undefined,
+  now: Date,
+  defaultTz: string,
+  opts: ComputeOpts = {},
+): Date {
+  if (!schedule) {
+    if (opts.fallback_interval_ms === undefined) {
+      throw new Error(
+        "computeNextWakeAt: schedule is undefined AND opts.fallback_interval_ms is missing — " +
+        "scheduler tick must always supply one or the other (programmer error)"
+      );
+    }
+    return new Date(now.getTime() + Math.max(0, opts.fallback_interval_ms));
+  }
+
+  if (schedule.type === "interval") {
+    return new Date(now.getTime() + Math.max(0, schedule.interval_ms));
+  }
+
+  if (schedule.type === "time_of_day") {
+    const tz = schedule.timezone || defaultTz;
+    const { hour, minute } = parseTime(schedule.time);
+    return nextWallClock(now, tz, [0, 1, 2, 3, 4, 5, 6], hour, minute);
+  }
+
+  if (schedule.type === "weekday") {
+    if (!Array.isArray(schedule.days) || schedule.days.length === 0) {
+      throw new Error("computeNextWakeAt: weekday schedule has empty days[]");
+    }
+    const dayNums = schedule.days.map((d) => {
+      const n = WEEKDAY_NAMES[d.toLowerCase()];
+      if (n === undefined) throw new Error(`computeNextWakeAt: unknown weekday "${d}"`);
+      return n;
+    });
+    const tz = schedule.timezone || defaultTz;
+    const { hour, minute } = parseTime(schedule.time);
+    return nextWallClock(now, tz, dayNums, hour, minute);
+  }
+
+  throw new Error(`computeNextWakeAt: unknown schedule type ${(schedule as any).type}`);
+}
+
+function parseTime(s: string): { hour: number; minute: number } {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(s);
+  if (!m) throw new Error(`computeNextWakeAt: invalid time format "${s}" (expected HH:MM)`);
+  const hour = parseInt(m[1], 10);
+  const minute = parseInt(m[2], 10);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    throw new Error(`computeNextWakeAt: invalid time "${s}" (hour 0-23, minute 0-59)`);
+  }
+  return { hour, minute };
+}
+
+/**
+ * Find the next instant >= `now` whose wall-clock in `tz` matches
+ * (hour, minute) AND whose weekday (in tz) is in `allowedDays`.
+ *
+ * Boundary policy: if `now`'s wall-clock is EXACTLY (hour, minute) on
+ * an allowed day, treat as "just fired" and skip to the next eligible
+ * day. Avoids immediate re-fire after the wake we just triggered.
+ *
+ * DST: if the target wall-clock time doesn't exist on a given day
+ * (spring-forward skip), we advance to the next day's target. This
+ * matches standard cron behaviour.
+ */
+function nextWallClock(
+  now: Date,
+  tz: string,
+  allowedDays: number[],
+  hour: number,
+  minute: number,
+): Date {
+  // Search up to 8 days ahead. Weekly schedules wrap within 7; the
+  // 8th iteration is the safety net (handles DST-skipped target on
+  // the last eligible day).
+  for (let i = 0; i < 8; i++) {
+    const probe = addDays(now, i);
+    const parts = wallClockParts(probe, tz);
+    if (!allowedDays.includes(parts.weekday)) continue;
+    const target = makeInstant(parts.year, parts.month, parts.day, hour, minute, tz);
+    if (target === null) continue;  // spring-forward skip; try next day
+    if (target.getTime() > now.getTime()) return target;
+    // Boundary: target <= now and same minute → "just fired", skip.
+  }
+  throw new Error(
+    `computeNextWakeAt: no eligible day found within 8 days (schedule may be unreachable; ` +
+    `check days=[${allowedDays.join(",")}] hour=${hour} minute=${minute} tz=${tz})`
+  );
+}
+
+function addDays(d: Date, n: number): Date {
+  return new Date(d.getTime() + n * 24 * 60 * 60_000);
+}
+
+/** Extract wall-clock components in target TZ via Intl.DateTimeFormat. */
+function wallClockParts(d: Date, tz: string): {
+  year: number; month: number; day: number; weekday: number;
+} {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric", month: "2-digit", day: "2-digit", weekday: "short",
+  });
+  const parts = fmt.formatToParts(d);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value || "";
+  const weekdayName = get("weekday").toLowerCase();
+  const weekday = WEEKDAY_NAMES[weekdayName] ?? -1;
+  return {
+    year: parseInt(get("year"), 10),
+    month: parseInt(get("month"), 10),
+    day: parseInt(get("day"), 10),
+    weekday,
+  };
+}
+
+/**
+ * Build the UTC instant corresponding to (year, month, day, hour,
+ * minute) in `tz`. Returns null if that local time doesn't exist
+ * (DST spring-forward gap).
+ *
+ * Approach: try an approximate UTC anchor, check if its wall-clock in
+ * tz round-trips to the expected (h, m, d). If not (DST skip), bail.
+ */
+function makeInstant(
+  year: number, month: number, day: number,
+  hour: number, minute: number, tz: string,
+): Date | null {
+  // Start with a naive UTC instant for the requested wall-clock.
+  // Then adjust by the offset between UTC and tz at that instant.
+  const naive = Date.UTC(year, month - 1, day, hour, minute, 0);
+  // Look up TZ offset at `naive` by formatting and parsing back.
+  const probe = new Date(naive);
+  const probeParts = wallClockParts(probe, tz);
+  // The naive UTC instant's wall-clock IN tz tells us tz offset
+  // implicitly. Compute the diff between requested h:m and what tz
+  // shows for this UTC instant, then shift the UTC instant.
+  const probeAsTzMinutes = probeParts.day * 24 * 60 + 0; // we don't have h/m yet
+  // Need hour/minute of `probe` in `tz`. Fetch them.
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz, hour12: false, hour: "2-digit", minute: "2-digit", day: "2-digit", month: "2-digit", year: "numeric",
+  });
+  const p = fmt.formatToParts(probe);
+  const getN = (t: string) => parseInt(p.find((x) => x.type === t)?.value || "0", 10);
+  const tzHour = getN("hour") % 24;  // Intl can return "24" for midnight in some locales
+  const tzMinute = getN("minute");
+  const tzDay = getN("day");
+  const tzMonth = getN("month");
+  const tzYear = getN("year");
+
+  // Compute the offset: requested wall-clock minus tz wall-clock at
+  // the naive instant. If offset is N minutes, the real UTC instant
+  // is naive - (tz - requested) minutes... but watch out for date
+  // wrap. Simpler: compute the difference between the requested
+  // wall-clock-as-UTC and probe-tz-as-UTC.
+  const requestedAsIfUtc = Date.UTC(year, month - 1, day, hour, minute, 0);
+  const probeTzAsIfUtc = Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute, 0);
+  const offsetMs = requestedAsIfUtc - probeTzAsIfUtc;
+  // The real UTC instant corresponding to (year, month, day, hour, minute) in tz
+  // is the naive UTC instant adjusted by offsetMs.
+  const candidate = new Date(naive + offsetMs);
+
+  // Validate round-trip: if the candidate's wall-clock in tz doesn't
+  // match the request, the requested time doesn't exist in tz
+  // (DST spring-forward gap). Return null in that case.
+  const verifyFmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz, hour12: false, hour: "2-digit", minute: "2-digit", day: "2-digit", month: "2-digit", year: "numeric",
+  });
+  const vp = verifyFmt.formatToParts(candidate);
+  const v = (t: string) => parseInt(vp.find((x) => x.type === t)?.value || "0", 10);
+  if (v("year") !== year || v("month") !== month || v("day") !== day) return null;
+  if (v("hour") % 24 !== hour || v("minute") !== minute) return null;
+  return candidate;
+  // Note: void unused intermediate.
+  void probeAsTzMinutes;
+}

--- a/agent-node/src/goals/self-loop-tools.test.ts
+++ b/agent-node/src/goals/self-loop-tools.test.ts
@@ -1,0 +1,305 @@
+// RFC-025 M1d P1 — self-loop tools handler tests.
+//
+// Each handler exercised against a real GoalStore on a tmp file
+// (filesystem-isolated). The safety防线 (cooldown / max-goals /
+// batch-cancel confirm-back) tested as first-class behaviour, not
+// optional polish.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { GoalStore, newGoal } from "./store";
+import {
+  handleListMyLoops,
+  handleCreateMyLoop,
+  handleEditMyLoop,
+  handleRescheduleMyLoop,
+  handleCompleteMyLoop,
+  handleCancelMyLoop,
+  SELF_LOOP_TOOL_SPECS,
+  DEFAULT_BATCH_CANCEL_THRESHOLD,
+  type SelfLoopCtx,
+} from "./self-loop-tools";
+
+function mkCtx(store: GoalStore, overrides: Partial<SelfLoopCtx> = {}): SelfLoopCtx {
+  return {
+    store,
+    runtime: "claude-agent-sdk",
+    defaultTz: "Asia/Shanghai",
+    recentCancels: [],
+    pendingConfirmTokens: new Set(),
+    ...overrides,
+  };
+}
+
+let dir: string;
+let store: GoalStore;
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), "self-loop-tools-"));
+  store = new GoalStore(join(dir, "goals.json"));
+  await store.load();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("list_my_loops", () => {
+  test("empty store → {goals: [], total: 0}", async () => {
+    const r = await handleListMyLoops({}, mkCtx(store));
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect((r.data as any).goals).toEqual([]);
+      expect((r.data as any).total).toBe(0);
+    }
+  });
+
+  test("includes goal_id_short + cadence schedule shape", async () => {
+    await store.upsert(newGoal({ text: "g1", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" }));
+    const r = await handleListMyLoops({}, mkCtx(store));
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const g = (r.data as any).goals[0];
+      expect(g.goal_id_short).toHaveLength(8);
+      expect(g.cadence.type).toBe("interval");
+      expect(g.cadence.interval_ms).toBe(5 * 60_000);
+    }
+  });
+});
+
+describe("create_my_loop", () => {
+  test("interval string '5m' creates goal", async () => {
+    const r = await handleCreateMyLoop({ task: "monitor x", interval: "5m" }, mkCtx(store));
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect((r.data as any).cadence.interval_ms).toBe(5 * 60_000);
+      expect((r.data as any).message).toContain("已创建循环");
+    }
+    expect((await store.list()).length).toBe(1);
+  });
+
+  test("cron-lite time_of_day creates goal with schedule field", async () => {
+    const r = await handleCreateMyLoop(
+      { task: "morning summary", schedule: { type: "time_of_day", time: "09:00" } },
+      mkCtx(store)
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect((r.data as any).cadence.type).toBe("time_of_day");
+      expect((r.data as any).cadence.time).toBe("09:00");
+      expect((r.data as any).cadence.timezone).toBe("Asia/Shanghai"); // injected from ctx.defaultTz
+    }
+  });
+
+  test("missing task → invalid_args", async () => {
+    const r = await handleCreateMyLoop({ interval: "5m" }, mkCtx(store));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("invalid_args");
+  });
+
+  test("missing both schedule and interval → invalid_schedule", async () => {
+    const r = await handleCreateMyLoop({ task: "x" }, mkCtx(store));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("invalid_schedule");
+  });
+
+  test("sub-minute interval rejected (parser 60s floor)", async () => {
+    const r = await handleCreateMyLoop({ task: "x", interval: "30s" }, mkCtx(store));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("invalid_schedule");
+  });
+
+  test("max active goals cap (3 cap → 4th rejected)", async () => {
+    const ctx = mkCtx(store, { maxActiveGoals: 3 });
+    for (let i = 0; i < 3; i++) {
+      const r = await handleCreateMyLoop({ task: `g${i}`, interval: "5m" }, ctx);
+      expect(r.ok).toBe(true);
+    }
+    const r4 = await handleCreateMyLoop({ task: "g4", interval: "5m" }, ctx);
+    expect(r4.ok).toBe(false);
+    if (!r4.ok) expect(r4.error).toBe("max_active_goals_reached");
+  });
+});
+
+describe("edit_my_loop", () => {
+  test("change interval + report new value", async () => {
+    const g = newGoal({ text: "x", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    await store.upsert(g);
+    // Simulate "60s later" via ctx.now — store.upsert always rewrites
+    // updated_at to current time, so pre-dating is futile; ctx.now is
+    // the clean cooldown bypass.
+    const future = Date.now() + 60_000;
+    const r = await handleEditMyLoop({ goal_id: g.goal_id, interval: "30m" }, mkCtx(store, { now: () => future }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect((r.data as any).cadence.interval_ms).toBe(30 * 60_000);
+  });
+
+  test("paused=true → status=paused", async () => {
+    const g = newGoal({ text: "x", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    await store.upsert(g);
+    const future = Date.now() + 60_000;
+    const r = await handleEditMyLoop({ goal_id: g.goal_id, paused: true }, mkCtx(store, { now: () => future }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect((r.data as any).status).toBe("paused");
+  });
+
+  test("cooldown — edit within 30s of last update rejected", async () => {
+    const g = newGoal({ text: "x", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    // updated_at = now (fresh)
+    await store.upsert(g);
+
+    const r = await handleEditMyLoop({ goal_id: g.goal_id, interval: "10m" }, mkCtx(store));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("cooldown");
+  });
+
+  test("unknown goal_id → goal_not_found", async () => {
+    const r = await handleEditMyLoop({ goal_id: "nonexistent" }, mkCtx(store));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("goal_not_found");
+  });
+});
+
+describe("reschedule_my_loop (★ ScheduleWakeup 范式)", () => {
+  test("pushes next_wake_at forward, interval_ms unchanged", async () => {
+    const g = newGoal({ text: "x", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    await store.upsert(g);
+    const originalInterval = g.interval_ms;
+    // Use ctx.now ~10:00 future timestamp; subtract back so cooldown
+    // is satisfied (now - updated_at > 30s). Pick now to be way past
+    // the upsert's real wall-clock so updated_at is in the past from
+    // ctx.now's perspective.
+    const baseline = Date.now() + 60_000;
+    const r = await handleRescheduleMyLoop(
+      { goal_id: g.goal_id, next_wake_in: "1h" },
+      mkCtx(store, { now: () => baseline }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      // next_wake_at = baseline + 1h
+      expect((r.data as any).next_wake_at).toBe(new Date(baseline + 60 * 60_000).toISOString());
+    }
+    // Verify interval not touched
+    const after = await store.get(g.goal_id);
+    expect(after!.interval_ms).toBe(originalInterval);
+  });
+
+  test("invalid next_wake_in → invalid_interval", async () => {
+    const g = newGoal({ text: "x", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    await store.upsert(g);
+    const future = Date.now() + 60_000;
+    const r = await handleRescheduleMyLoop(
+      { goal_id: g.goal_id, next_wake_in: "30s" },
+      mkCtx(store, { now: () => future }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("invalid_interval");
+  });
+
+  test("cooldown applies", async () => {
+    const g = newGoal({ text: "x", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    await store.upsert(g);
+    const r = await handleRescheduleMyLoop({ goal_id: g.goal_id, next_wake_in: "1h" }, mkCtx(store));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("cooldown");
+  });
+});
+
+describe("complete_my_loop (★ 达标归档)", () => {
+  test("status → 'complete'", async () => {
+    const g = newGoal({ text: "x", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    await store.upsert(g);
+    const r = await handleCompleteMyLoop({ goal_id: g.goal_id }, mkCtx(store));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect((r.data as any).status).toBe("complete");
+    expect((await store.get(g.goal_id))!.status).toBe("complete");
+  });
+
+  test("unknown goal_id → goal_not_found", async () => {
+    const r = await handleCompleteMyLoop({ goal_id: "x" }, mkCtx(store));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("goal_not_found");
+  });
+});
+
+describe("cancel_my_loop", () => {
+  test("status → 'cancelled'", async () => {
+    const g = newGoal({ text: "x", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    await store.upsert(g);
+    const r = await handleCancelMyLoop({ goal_id: g.goal_id }, mkCtx(store));
+    expect(r.ok).toBe(true);
+    expect((await store.get(g.goal_id))!.status).toBe("cancelled");
+  });
+
+  test("batch cancel (3 in 30s) triggers confirm-back on 4th", async () => {
+    const recentCancels: number[] = [];
+    const pendingConfirmTokens = new Set<string>();
+    const t0 = Date.now();
+    const ctx = mkCtx(store, { recentCancels, pendingConfirmTokens, now: () => t0 });
+
+    // Pre-fill 3 cancels in window
+    for (let i = 0; i < DEFAULT_BATCH_CANCEL_THRESHOLD; i++) {
+      const g = newGoal({ text: `g${i}`, interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+      await store.upsert(g);
+      const r = await handleCancelMyLoop({ goal_id: g.goal_id }, ctx);
+      expect(r.ok).toBe(true);
+    }
+    // 4th cancel triggers confirm
+    const g4 = newGoal({ text: "g4", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    await store.upsert(g4);
+    const r4 = await handleCancelMyLoop({ goal_id: g4.goal_id }, ctx);
+    expect(r4.ok).toBe(false);
+    if (!r4.ok) {
+      expect(r4.error).toBe("batch_destructive_confirm_required");
+      expect(r4.confirm_token).toBeTruthy();
+    }
+    // g4 NOT cancelled
+    expect((await store.get(g4.goal_id))!.status).toBe("active");
+
+    // Re-call with confirm_token → proceeds
+    if (!r4.ok) {
+      const r4b = await handleCancelMyLoop(
+        { goal_id: g4.goal_id, confirm_token: r4.confirm_token },
+        ctx
+      );
+      expect(r4b.ok).toBe(true);
+      expect((await store.get(g4.goal_id))!.status).toBe("cancelled");
+    }
+  });
+});
+
+describe("SELF_LOOP_TOOL_SPECS — registration table", () => {
+  test("exports 6 tools with stable names", () => {
+    const names = SELF_LOOP_TOOL_SPECS.map((s) => s.name);
+    expect(names).toEqual([
+      "list_my_loops",
+      "create_my_loop",
+      "edit_my_loop",
+      "reschedule_my_loop",
+      "complete_my_loop",
+      "cancel_my_loop",
+    ]);
+  });
+
+  test("every spec has non-empty description (LLM-discoverable)", () => {
+    for (const s of SELF_LOOP_TOOL_SPECS) {
+      expect(s.description.length).toBeGreaterThan(30);
+    }
+  });
+
+  test("description guides per RFC-025 §3.2 (intent-parse + report-back + safety)", () => {
+    const create = SELF_LOOP_TOOL_SPECS.find((s) => s.name === "create_my_loop")!;
+    // #3 report-back hint
+    expect(create.description).toMatch(/回报新值/);
+    const edit = SELF_LOOP_TOOL_SPECS.find((s) => s.name === "edit_my_loop")!;
+    // #4 disambiguation
+    expect(edit.description).toMatch(/临时/);
+    const cancel = SELF_LOOP_TOOL_SPECS.find((s) => s.name === "cancel_my_loop")!;
+    // #2 confirm-back
+    expect(cancel.description).toMatch(/confirm_token|confirm-back|确认/);
+    const complete = SELF_LOOP_TOOL_SPECS.find((s) => s.name === "complete_my_loop")!;
+    expect(complete.description).toMatch(/达标|归档/);
+  });
+});

--- a/agent-node/src/goals/self-loop-tools.test.ts
+++ b/agent-node/src/goals/self-loop-tools.test.ts
@@ -270,6 +270,109 @@ describe("cancel_my_loop", () => {
   });
 });
 
+describe("#302 round-2 — preflight computeNextWakeAt (self-lock prevention)", () => {
+  // 通信牛 catch: structured schedule that passes shape validation
+  // but throws at computeNextWakeAt-time (bad IANA timezone, etc.)
+  // would land in goals.json, and every scheduler tick would throw
+  // → goal stays active+due → self-locking wake storm.
+  //
+  // Pin: create/edit MUST preflight computeNextWakeAt and reject
+  // with invalid_schedule BEFORE writing. Existing goals must be
+  // untouched if the edit is rejected.
+
+  test("create_my_loop: bad timezone in schedule → invalid_schedule, NOT written", async () => {
+    const before = (await store.list()).length;
+    const r = await handleCreateMyLoop(
+      {
+        task: "morning",
+        schedule: { type: "time_of_day", time: "09:00", timezone: "Bad/Zone" },
+      },
+      mkCtx(store),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe("invalid_schedule");
+      expect(r.message).toMatch(/Bad\/Zone|invalid time zone/i);
+    }
+    // load fresh from disk to verify it didn't sneak in
+    expect((await store.list()).length).toBe(before);
+  });
+
+  test("create_my_loop: bad weekday → invalid_schedule, NOT written", async () => {
+    const before = (await store.list()).length;
+    const r = await handleCreateMyLoop(
+      {
+        task: "bad",
+        schedule: { type: "weekday", days: ["funday"], time: "09:00" },
+      },
+      mkCtx(store),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("invalid_schedule");
+    expect((await store.list()).length).toBe(before);
+  });
+
+  test("create_my_loop: bad time format → invalid_schedule, NOT written", async () => {
+    const before = (await store.list()).length;
+    const r = await handleCreateMyLoop(
+      {
+        task: "bad",
+        schedule: { type: "time_of_day", time: "25:99" },
+      },
+      mkCtx(store),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("invalid_schedule");
+    expect((await store.list()).length).toBe(before);
+  });
+
+  test("edit_my_loop: bad timezone on edit → invalid_schedule, EXISTING goal untouched", async () => {
+    // Seed a healthy goal with status=active + interval cadence
+    const healthy = newGoal({ text: "healthy", interval_ms: 5 * 60_000, runtime: "claude-agent-sdk" });
+    await store.upsert(healthy);
+    const beforeStored = await store.get(healthy.goal_id);
+    const beforeIso = beforeStored!.updated_at;
+    const beforeNext = beforeStored!.next_wake_at;
+    const beforeStatus = beforeStored!.status;
+    const beforeText = beforeStored!.text;
+
+    const future = Date.now() + 60_000;
+    const r = await handleEditMyLoop(
+      {
+        goal_id: healthy.goal_id,
+        schedule: { type: "time_of_day", time: "09:00", timezone: "Mars/Phobos" },
+        task: "should not change either", // even other fields must not slip through
+      },
+      mkCtx(store, { now: () => future }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("invalid_schedule");
+
+    // Verify EXISTING goal completely untouched
+    const after = await store.get(healthy.goal_id);
+    expect(after!.text).toBe(beforeText);
+    expect(after!.status).toBe(beforeStatus);
+    expect(after!.next_wake_at).toBe(beforeNext);
+    expect(after!.updated_at).toBe(beforeIso);
+    expect(after!.schedule).toBeUndefined(); // no schedule corruption
+  });
+
+  test("create_my_loop: VALID structured schedule still works (regression)", async () => {
+    // Sanity check — the preflight must not over-reject good schedules.
+    const r = await handleCreateMyLoop(
+      {
+        task: "valid morning",
+        schedule: { type: "time_of_day", time: "09:00", timezone: "Asia/Shanghai" },
+      },
+      mkCtx(store),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect((r.data as any).cadence.type).toBe("time_of_day");
+    }
+  });
+});
+
 describe("SELF_LOOP_TOOL_SPECS — registration table", () => {
   test("exports 6 tools with stable names", () => {
     const names = SELF_LOOP_TOOL_SPECS.map((s) => s.name);

--- a/agent-node/src/goals/self-loop-tools.ts
+++ b/agent-node/src/goals/self-loop-tools.ts
@@ -1,0 +1,360 @@
+// RFC-025 M1d P1 — self-scoped loop management tools.
+//
+// Six handlers an agent calls to manage ITS OWN loops. No `alias`
+// parameter — by construction the handlers only ever see the
+// per-node goalStore instance, so an agent can NEVER address another
+// node's goals (RFC-025 §5.2 safety invariant). claude-code-cli
+// runtime is out of scope (RFC-025 §3.1 + §12): these tools are
+// registered only in agent-node-spawned runtimes.
+//
+// Pure handler module — runtime-agnostic. The per-runtime MCP
+// adapter (claude-agent-sdk in this same M1d / codex / grok in
+// later milestones) consumes SELF_LOOP_TOOL_SPECS to register tools
+// with each SDK's tool surface.
+
+import { computeNextWakeAt } from "./schedule";
+import { parseGoalCommand } from "./parser";
+import { newGoal } from "./store";
+import type { GoalStore } from "./store";
+import type { AgentGoal, AgentGoalSchedule } from "./types";
+
+// Safety constants per RFC-025 §7 (resolved decisions §11.5 + §11.7).
+export const DEFAULT_MAX_ACTIVE_GOALS_PER_NODE = 20;
+export const DEFAULT_COOLDOWN_MS = 30_000; // 30s per-goal anti-recursion
+export const DEFAULT_BATCH_CANCEL_WINDOW_MS = 30_000;
+export const DEFAULT_BATCH_CANCEL_THRESHOLD = 3; // 3 cancels in 30s → confirm-back
+
+export interface SelfLoopCtx {
+  store: GoalStore;
+  /** Caller's runtime ("claude-agent-sdk" etc.) — written into new goals. */
+  runtime: string;
+  /** Node's default timezone for cron-lite schedules. RFC-025 §11.8 default Asia/Shanghai. */
+  defaultTz: string;
+  /** Env-overridable: max active goals before create_my_loop rejects. */
+  maxActiveGoals?: number;
+  /**
+   * Recent cancel timestamps (in-memory, per-process). Tracks
+   * cancel_my_loop call times for the confirm-back threshold. Caller
+   * supplies + persists across handler calls; tools mutate in place.
+   */
+  recentCancels?: number[];
+  /**
+   * Recent batch-confirm tokens the agent has presented. When the
+   * confirm-back path returns `error: 'batch_destructive_confirm_required'`
+   * with a token, the agent re-calls with `confirm_token` set. The
+   * tool checks the token here and proceeds if present.
+   */
+  pendingConfirmTokens?: Set<string>;
+  /** Now provider — overridable for tests. Default Date.now(). */
+  now?: () => number;
+}
+
+/** All handlers return this discriminated shape so MCP wire-up is uniform. */
+export type SelfLoopResult =
+  | { ok: true; data: unknown }
+  | { ok: false; error: string; message: string; confirm_token?: string };
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+function nowOf(ctx: SelfLoopCtx): number {
+  return (ctx.now ?? Date.now)();
+}
+
+function withinCooldown(g: AgentGoal, now: number): boolean {
+  const updated = Date.parse(g.updated_at);
+  if (!Number.isFinite(updated)) return false;
+  return now - updated < DEFAULT_COOLDOWN_MS;
+}
+
+function intervalFromText(intervalText: string): number {
+  // Reuse #288 parser (60s floor, m/h/d units, etc.). We don't have
+  // a separate "parse interval string" entry point in parser.ts,
+  // so build a fake "/loop <interval> x" and read interval_ms.
+  const r = parseGoalCommand(`/loop ${intervalText} x`);
+  if (!r.ok) throw new Error(`invalid interval "${intervalText}": ${r.error}`);
+  return r.goal.interval_ms;
+}
+
+function parseSchedule(
+  schedule: any,
+  intervalText: string | undefined,
+  defaultTz: string,
+): { interval_ms: number; schedule?: AgentGoalSchedule } {
+  // Two shapes accepted: structured `schedule` arg (cron-lite) or
+  // `interval` string (legacy/simple). At least one must be set.
+  if (schedule && typeof schedule === "object") {
+    if (schedule.type === "interval") {
+      if (typeof schedule.interval_ms !== "number" || schedule.interval_ms < 60_000) {
+        throw new Error("interval schedule needs interval_ms >= 60000");
+      }
+      return { interval_ms: schedule.interval_ms, schedule };
+    }
+    if (schedule.type === "time_of_day") {
+      if (typeof schedule.time !== "string") throw new Error("time_of_day schedule needs time (HH:MM)");
+      // Natural cadence = 24h
+      return {
+        interval_ms: 24 * 60 * 60_000,
+        schedule: { type: "time_of_day", time: schedule.time, timezone: schedule.timezone || defaultTz },
+      };
+    }
+    if (schedule.type === "weekday") {
+      if (!Array.isArray(schedule.days) || schedule.days.length === 0) throw new Error("weekday schedule needs days[]");
+      if (typeof schedule.time !== "string") throw new Error("weekday schedule needs time (HH:MM)");
+      // Natural cadence = 7d
+      return {
+        interval_ms: 7 * 24 * 60 * 60_000,
+        schedule: { type: "weekday", days: schedule.days, time: schedule.time, timezone: schedule.timezone || defaultTz },
+      };
+    }
+    throw new Error(`unknown schedule type "${schedule.type}"`);
+  }
+  if (intervalText) {
+    return { interval_ms: intervalFromText(intervalText) };
+  }
+  throw new Error("either 'schedule' (cron-lite) or 'interval' (string like '5m') required");
+}
+
+function ok(data: unknown): SelfLoopResult {
+  return { ok: true, data };
+}
+
+function fail(error: string, message: string, confirm_token?: string): SelfLoopResult {
+  return { ok: false, error, message, ...(confirm_token ? { confirm_token } : {}) };
+}
+
+// ── handlers (6 tools) ───────────────────────────────────────────────
+
+export async function handleListMyLoops(_args: any, ctx: SelfLoopCtx): Promise<SelfLoopResult> {
+  const goals = await ctx.store.list();
+  return ok({
+    goals: goals.map((g) => ({
+      goal_id: g.goal_id,
+      goal_id_short: g.goal_id.slice(0, 8),
+      text: g.text,
+      status: g.status,
+      cadence: g.schedule ?? { type: "interval", interval_ms: g.interval_ms },
+      next_wake_at: g.next_wake_at,
+      last_wake_at: g.last_wake_at,
+      last_report_at: g.last_report_at,
+    })),
+    total: goals.length,
+  });
+}
+
+export async function handleCreateMyLoop(args: any, ctx: SelfLoopCtx): Promise<SelfLoopResult> {
+  if (!args.task || typeof args.task !== "string" || !args.task.trim()) {
+    return fail("invalid_args", "missing required 'task' (string)");
+  }
+  // Max-goals cap (RFC-025 §11.5)
+  const max = ctx.maxActiveGoals ?? DEFAULT_MAX_ACTIVE_GOALS_PER_NODE;
+  const goals = await ctx.store.list();
+  const activeCount = goals.filter((g) => g.status === "active").length;
+  if (activeCount >= max) {
+    return fail(
+      "max_active_goals_reached",
+      `this node already has ${activeCount}/${max} active goals — cancel or complete some before creating new ones`
+    );
+  }
+  let parsed: { interval_ms: number; schedule?: AgentGoalSchedule };
+  try {
+    parsed = parseSchedule(args.schedule, args.interval, ctx.defaultTz);
+  } catch (e: any) {
+    return fail("invalid_schedule", e.message);
+  }
+  const g = newGoal({
+    text: args.task.trim(),
+    interval_ms: parsed.interval_ms,
+    schedule: parsed.schedule,
+    default_tz: ctx.defaultTz,
+    runtime: ctx.runtime,
+  });
+  await ctx.store.upsert(g);
+  return ok({
+    goal_id: g.goal_id,
+    goal_id_short: g.goal_id.slice(0, 8),
+    next_wake_at: g.next_wake_at,
+    cadence: g.schedule ?? { type: "interval", interval_ms: g.interval_ms },
+    // Per RFC-025 §3.2 #3: agent should report the new value back to user.
+    message: `已创建循环 ${g.goal_id.slice(0, 8)}, 下次唤醒 ${g.next_wake_at}`,
+  });
+}
+
+export async function handleEditMyLoop(args: any, ctx: SelfLoopCtx): Promise<SelfLoopResult> {
+  if (!args.goal_id || typeof args.goal_id !== "string") {
+    return fail("invalid_args", "missing required 'goal_id'");
+  }
+  const g = await ctx.store.get(args.goal_id);
+  if (!g) return fail("goal_not_found", `no goal with id "${args.goal_id}"`);
+  // Cooldown (RFC-025 §7.1 anti-recursion)
+  const now = nowOf(ctx);
+  if (withinCooldown(g, now)) {
+    return fail(
+      "cooldown",
+      `goal was modified <30s ago (${g.updated_at}) — wait a moment before editing again`
+    );
+  }
+  // Validate interval if changing
+  let newIntervalMs: number | undefined;
+  let newSchedule: AgentGoalSchedule | undefined | null = undefined;
+  if (args.interval !== undefined || args.schedule !== undefined) {
+    try {
+      const parsed = parseSchedule(args.schedule, args.interval, ctx.defaultTz);
+      newIntervalMs = parsed.interval_ms;
+      newSchedule = parsed.schedule ?? null; // null = clear schedule field
+    } catch (e: any) {
+      return fail("invalid_schedule", e.message);
+    }
+  }
+  const updated = await ctx.store.mutate(args.goal_id, (current) => {
+    if (typeof args.task === "string" && args.task.trim()) current.text = args.task.trim();
+    if (newIntervalMs !== undefined) current.interval_ms = newIntervalMs;
+    if (newSchedule !== undefined) {
+      if (newSchedule === null) delete (current as any).schedule;
+      else current.schedule = newSchedule;
+    }
+    if (typeof args.paused === "boolean") {
+      current.status = args.paused ? "paused" : "active";
+    }
+  });
+  return ok({
+    goal_id: updated!.goal_id,
+    cadence: updated!.schedule ?? { type: "interval", interval_ms: updated!.interval_ms },
+    status: updated!.status,
+    text: updated!.text,
+    message: `已更新循环 ${updated!.goal_id.slice(0, 8)}`,
+  });
+}
+
+export async function handleRescheduleMyLoop(args: any, ctx: SelfLoopCtx): Promise<SelfLoopResult> {
+  // ★ Claude Code /loop ScheduleWakeup 范式 (RFC-025 §5.1).
+  // Doesn't change interval — only pushes next_wake_at one-shot.
+  if (!args.goal_id || typeof args.goal_id !== "string") {
+    return fail("invalid_args", "missing required 'goal_id'");
+  }
+  if (!args.next_wake_in || typeof args.next_wake_in !== "string") {
+    return fail("invalid_args", "missing required 'next_wake_in' (e.g. '30m' / '2h' / '1d')");
+  }
+  const g = await ctx.store.get(args.goal_id);
+  if (!g) return fail("goal_not_found", `no goal with id "${args.goal_id}"`);
+  const now = nowOf(ctx);
+  if (withinCooldown(g, now)) {
+    return fail("cooldown", `goal modified <30s ago — wait before reschedule`);
+  }
+  let deltaMs: number;
+  try {
+    deltaMs = intervalFromText(args.next_wake_in);
+  } catch (e: any) {
+    return fail("invalid_interval", e.message);
+  }
+  const nextWake = new Date(now + deltaMs).toISOString();
+  const updated = await ctx.store.mutate(args.goal_id, (current) => {
+    current.next_wake_at = nextWake;
+  });
+  return ok({
+    goal_id: updated!.goal_id,
+    next_wake_at: updated!.next_wake_at,
+    message: `已推迟 ${updated!.goal_id.slice(0, 8)} 下次唤醒到 ${nextWake} (本轮一次性, interval 不变)`,
+  });
+}
+
+export async function handleCompleteMyLoop(args: any, ctx: SelfLoopCtx): Promise<SelfLoopResult> {
+  // ★ 达标即停 (RFC-025 §5.1). 跟 cancel 语义分清: complete = goal
+  // achieved, cancel = abandoned.
+  if (!args.goal_id || typeof args.goal_id !== "string") {
+    return fail("invalid_args", "missing required 'goal_id'");
+  }
+  const g = await ctx.store.get(args.goal_id);
+  if (!g) return fail("goal_not_found", `no goal with id "${args.goal_id}"`);
+  const updated = await ctx.store.setStatus(args.goal_id, "complete");
+  return ok({
+    goal_id: updated!.goal_id,
+    status: updated!.status,
+    message: `✓ 循环 ${updated!.goal_id.slice(0, 8)} 已达标完成 (status=complete)`,
+  });
+}
+
+export async function handleCancelMyLoop(args: any, ctx: SelfLoopCtx): Promise<SelfLoopResult> {
+  if (!args.goal_id || typeof args.goal_id !== "string") {
+    return fail("invalid_args", "missing required 'goal_id'");
+  }
+  // Batch-cancel confirm-back (RFC-025 §3.2 #2)
+  const now = nowOf(ctx);
+  const recent = ctx.recentCancels ?? [];
+  const windowStart = now - DEFAULT_BATCH_CANCEL_WINDOW_MS;
+  // Prune old timestamps in place
+  while (recent.length > 0 && recent[0] < windowStart) recent.shift();
+  if (recent.length >= DEFAULT_BATCH_CANCEL_THRESHOLD && !args.confirm_token) {
+    // Issue a confirm token. Agent must re-call with confirm_token to proceed.
+    const token = `confirm-${now.toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`;
+    if (ctx.pendingConfirmTokens) ctx.pendingConfirmTokens.add(token);
+    return fail(
+      "batch_destructive_confirm_required",
+      `已经取消了 ${recent.length} 个循环在过去 30 秒 — 这次取消需要用户确认才继续。回问用户是否真要取消这个 ${args.goal_id.slice(0, 8)}, 拿到确认后重新调本工具并传 confirm_token="${token}"`,
+      token
+    );
+  }
+  if (args.confirm_token && ctx.pendingConfirmTokens) {
+    if (!ctx.pendingConfirmTokens.has(args.confirm_token)) {
+      return fail("invalid_confirm_token", "confirm_token unknown or already used");
+    }
+    ctx.pendingConfirmTokens.delete(args.confirm_token);
+  }
+  const g = await ctx.store.get(args.goal_id);
+  if (!g) return fail("goal_not_found", `no goal with id "${args.goal_id}"`);
+  const updated = await ctx.store.setStatus(args.goal_id, "cancelled");
+  // `recent` is the same array reference as ctx.recentCancels (when
+  // caller passes one) — push mutates in place. No re-assignment.
+  recent.push(now);
+  return ok({
+    goal_id: updated!.goal_id,
+    status: updated!.status,
+    message: `已取消循环 ${updated!.goal_id.slice(0, 8)} (status=cancelled, 不可恢复)`,
+  });
+}
+
+// ── tool spec table for per-runtime adapters ─────────────────────────
+
+export interface SelfLoopToolSpec {
+  name: string;
+  description: string;
+  handler: (args: any, ctx: SelfLoopCtx) => Promise<SelfLoopResult>;
+}
+
+export const SELF_LOOP_TOOL_SPECS: SelfLoopToolSpec[] = [
+  {
+    name: "list_my_loops",
+    description:
+      "看自己当前所有循环 (active + paused 的). 用户提到「这个/那个/重要的那个」时先调本工具看清单再决定指代. 返回 {goals: [{goal_id, status, cadence, next_wake_at, text}], total}.",
+    handler: handleListMyLoops,
+  },
+  {
+    name: "create_my_loop",
+    description:
+      "新建一个循环任务. interval 用 '5m'/'2h'/'1d' (单字母 m/h/d); 或 schedule 用 cron-lite 联合 (interval/time_of_day '09:00'/weekday ['mon','wed','fri']+time). 用户没给具体数字时选合理值后**回报新值** ('已设成每 30 分钟一次') 让用户能纠正. 上限默认 20 个 active goals/节点 (满了拒).",
+    handler: handleCreateMyLoop,
+  },
+  {
+    name: "edit_my_loop",
+    description:
+      "改一个循环 (改 task / interval / schedule / paused). `paused=true` 是**临时**暂停, 后续 `paused=false` 可恢复 (不同于 cancel). 改 interval 后必**回报新值**给用户. 同一 goal 30s 内只能改 1 次 (防递归暴走).",
+    handler: handleEditMyLoop,
+  },
+  {
+    name: "reschedule_my_loop",
+    description:
+      "★ 动态自调度 — **不改 interval**, 只把本轮 next_wake 推到指定时刻. 用于「这次任务有进展但不急, 下次 1h 后再看」类场景. interval 仍按原节奏走. 类似 Claude Code /loop 的 ScheduleWakeup 范式. next_wake_in 用 '30m'/'2h'/'1d' 等.",
+    handler: handleRescheduleMyLoop,
+  },
+  {
+    name: "complete_my_loop",
+    description:
+      "★ 达标归档 — 任务目标已实现 (PR 已 merge / 报告交付 / etc.). status=`complete`. **不同于 cancel**: 这是成就归档, 不是放弃. agent 自决达标即停, 防死循环.",
+    handler: handleCompleteMyLoop,
+  },
+  {
+    name: "cancel_my_loop",
+    description:
+      "永久放弃一个循环 — 不再做这件事 (非达标). status=`cancelled`, 不可恢复. **不同于 pause/complete**: 这是放弃. 短时间内 (30s) 连续取消 3 个以上会触发 confirm-back: 工具返 error='batch_destructive_confirm_required' + confirm_token, agent 必须回问用户确认后带 confirm_token 重调.",
+    handler: handleCancelMyLoop,
+  },
+];

--- a/agent-node/src/goals/self-loop-tools.ts
+++ b/agent-node/src/goals/self-loop-tools.ts
@@ -161,6 +161,21 @@ export async function handleCreateMyLoop(args: any, ctx: SelfLoopCtx): Promise<S
   } catch (e: any) {
     return fail("invalid_schedule", e.message);
   }
+  // #302 round-2 (通信牛 catch): structured schedule shape may be
+  // syntactically valid (time matches HH:MM, type is allowed) but
+  // semantically broken — e.g. bogus IANA timezone "Bad/Zone" that
+  // Intl.DateTimeFormat rejects. Without this preflight, such a
+  // schedule lands in goals.json, then every scheduler tick throws
+  // in computeNextWakeAt → goal stays active+due → self-lock wake
+  // storm. Catch here BEFORE the write so the goal never reaches
+  // disk and existing goals are untouched.
+  try {
+    computeNextWakeAt(parsed.schedule, new Date(nowOf(ctx)), ctx.defaultTz, {
+      fallback_interval_ms: parsed.interval_ms,
+    });
+  } catch (e: any) {
+    return fail("invalid_schedule", `schedule fails compute: ${e?.message || e}`);
+  }
   const g = newGoal({
     text: args.task.trim(),
     interval_ms: parsed.interval_ms,
@@ -203,6 +218,18 @@ export async function handleEditMyLoop(args: any, ctx: SelfLoopCtx): Promise<Sel
       newSchedule = parsed.schedule ?? null; // null = clear schedule field
     } catch (e: any) {
       return fail("invalid_schedule", e.message);
+    }
+    // #302 round-2 (通信牛 catch) — preflight computeNextWakeAt so a
+    // semantically-bad-but-shape-valid schedule (e.g. invalid timezone)
+    // is rejected BEFORE we overwrite the existing goal. Otherwise
+    // edit + bad TZ corrupts the existing healthy goal into a
+    // self-locking one.
+    try {
+      computeNextWakeAt(newSchedule ?? undefined, new Date(now), ctx.defaultTz, {
+        fallback_interval_ms: newIntervalMs ?? g.interval_ms,
+      });
+    } catch (e: any) {
+      return fail("invalid_schedule", `schedule fails compute: ${e?.message || e}`);
     }
   }
   const updated = await ctx.store.mutate(args.goal_id, (current) => {

--- a/agent-node/src/goals/store.ts
+++ b/agent-node/src/goals/store.ts
@@ -330,16 +330,36 @@ export function newGoal(opts: {
   runtime: string;
   parent_task_id?: string;
   report_to?: string;
+  // RFC-025 M1b — optional cron-lite schedule. When present, the
+  // scheduler uses it (via computeNextWakeAt) to advance next_wake_at
+  // every wake; when absent, behaviour falls back to interval_ms (the
+  // pre-RFC-025 path) — existing goals.json files keep working unchanged.
+  schedule?: import("./types").AgentGoalSchedule;
+  // Optional node-default timezone for schedule.time_of_day / weekday
+  // when the schedule itself didn't specify one. Caller passes the
+  // resolved value (e.g. config.flags.timezone || 'Asia/Shanghai').
+  default_tz?: string;
 }): AgentGoal {
   // #144: no runtime gate. Pre-#144 this asserted the runtime was non-claude
   // on the (incorrect) premise that claude-agent-sdk had a native /loop.
   const now = new Date();
+  // computeNextWakeAt: lazy import to keep `newGoal` zero-dep at module
+  // load (store.ts already exports newGoal early). The pure schedule.ts
+  // module has no transitive side-effects, so this require is safe.
+  const { computeNextWakeAt } = require("./schedule") as typeof import("./schedule");
+  const next = computeNextWakeAt(
+    opts.schedule,
+    now,
+    opts.default_tz || "Asia/Shanghai",
+    { fallback_interval_ms: opts.interval_ms },
+  );
   return {
     goal_id: randomUUID(),
     text: opts.text,
     status: "active",
     interval_ms: opts.interval_ms,
-    next_wake_at: new Date(now.getTime() + opts.interval_ms).toISOString(),
+    ...(opts.schedule ? { schedule: opts.schedule } : {}),
+    next_wake_at: next.toISOString(),
     parent_task_id: opts.parent_task_id,
     report_to: opts.report_to,
     runtime: opts.runtime,

--- a/agent-node/src/goals/types.ts
+++ b/agent-node/src/goals/types.ts
@@ -23,11 +23,43 @@ export interface GoalProgressEntry {
   task_id?: string;  // optional link to the commhub task this entry came from
 }
 
+// RFC-025 M1 — cron-lite schedule for wall-clock cadences ("每天 9 点",
+// 每周一 etc.). Backward compatible: existing goals with only
+// `interval_ms` continue to work unchanged (schedule = undefined →
+// scheduler falls back to interval_ms + last next_wake_at math, which
+// is what it already does).
+//
+// Union members:
+//   - `interval` — pure cadence ("every N ms"). Equivalent to legacy
+//     interval_ms; provided for new-format consistency.
+//   - `time_of_day` — fires at a specific clock time each day (e.g.
+//     "09:00"). Uses node's `flags.timezone` (default Asia/Shanghai
+//     per RFC-025 §11.8).
+//   - `weekday` — same as time_of_day but on specific weekdays only
+//     (e.g. "mon 09:00" or "mon,wed,fri 18:30").
+export type AgentGoalSchedule =
+  | { type: "interval"; interval_ms: number }
+  | { type: "time_of_day"; time: string /* "HH:MM" */; timezone?: string }
+  | { type: "weekday"; days: string[] /* ["mon","wed","fri"] */; time: string; timezone?: string };
+
 export interface AgentGoal {
   goal_id: string;                   // UUID, stable across renames + restarts
   text: string;                      // goal body (parsed from /goal command)
   status: GoalStatus;
-  interval_ms: number;               // wake cadence; minimum enforced by parser
+  // **Legacy load-bearing**: every existing goal in goals.json across
+  // the install base has `interval_ms`. RFC-025 keeps this field
+  // required so the parser, scheduler, and store all stay
+  // back-compat. New cron-lite schedule modes (time_of_day /
+  // weekday) populate `schedule` AND set interval_ms to the natural
+  // cadence (e.g. 24h for daily, 7d for weekly) — that way any
+  // code path that only reads interval_ms still sees something
+  // reasonable.
+  interval_ms: number;
+  // Optional cron-lite schedule (RFC-025 M1, P0a). `undefined` =
+  // legacy interval-only behaviour (scheduler uses interval_ms).
+  // Present = scheduler uses computeNextWakeAt(schedule, now) for
+  // next_wake_at calculation.
+  schedule?: AgentGoalSchedule;
   next_wake_at: string;              // ISO-8601 timestamp
   last_wake_at?: string;
   last_report_at?: string;


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why

RFC-025 M1 implementation per Vincent un-park dispatch (2026-06-28). agent uses 6 self-scoped tools to manage its own loops; sees `【你的当前循环任务】` context block before every think; new cron-lite schedule field supports time_of_day / weekday (per Vincent "每天9点" example).

Design = PR #295 (RFC-025 doc, lock-down 8/8). claude-code-cli runtime out-of-scope per Vincent (uses CC native /loop, independent session).

## Scope (M1 = P0a + P0b + P1 + P4 partial)

Five commits on this branch, test-first incremental:

| Commit | Phase | Content | LOC | Tests |
|---|---|---|---|---|
| `45cfe34` | M1a P0a | cron-lite schedule field + `computeNextWakeAt` pure function | ~270 | 22 |
| `c6daba9` | M1b | Wire `computeNextWakeAt` into scheduler tick + newGoal | ~40 | 130 cumulative (back-compat) |
| `5aa8228` | M1c P0b | `formatSelfLoopsBlock` formatter + processTask context injection | ~280 | 145 cumulative |
| `d225d22` | M1d P1+P4 | 6 self-loop tool handlers + safety防线 + 22 handler tests | ~665 | 167 cumulative |
| `849a6c3` | M1e P1 | claude-agent-sdk MCP adapter (loops-mcp.ts) + cli.ts wiring | ~130 | 167 (adapter is translation shell, M4 e2e is its coverage) |

Total: ~1400 LOC, **167 unit tests / 0 fail / 410 expect()**.

## Scheduler行为变化点 (per 通信龙 emphasis #3 — surfaced + reviewed at M1b)

Two and only two sites changed:

1. `cli.ts:runGoalSchedulerTick` advance: `new Date(Date.now() + goal.interval_ms)` → `computeNextWakeAt(goal.schedule, now, defaultTz, {fallback_interval_ms: goal.interval_ms})`
2. `store.ts:newGoal` initial: same call shape

**Back-compat (RFC §11.5 + 通信龙 emphasis #5)**: every existing goals.json in install-base has no `schedule` field. computeNextWakeAt's undefined-schedule branch returns `now + fallback_interval_ms` → **bytes-identical** to legacy. 3 back-compat regression tests pin this in schedule.test.ts. Zero observable change for existing goals.

通信龙 already PASS'd the scheduler delta at M1b (early-surface review of commits `c6daba9` `5aa8228` against the two real diff sites).

## 6 self-loop tools (RFC-025 §5.1)

| Tool | Semantics | Safety |
|---|---|---|
| `list_my_loops` | read self goals (structured) | — |
| `create_my_loop` | new goal (interval string OR cron-lite schedule) | max_active cap (default 20), parser 60s floor |
| `edit_my_loop` | change task/interval/schedule/paused | 30s cooldown per goal |
| ★ `reschedule_my_loop` | **ScheduleWakeup 范式** — push next_wake_at one-shot (interval untouched) | 30s cooldown |
| ★ `complete_my_loop` | 达标归档 (status=complete) — different from cancel | — |
| `cancel_my_loop` | permanent abandon (status=cancelled) | batch-cancel confirm-back (3 in 30s) |

**Self-scoped by construction**: no `alias` arg in any tool schema. The MCP adapter binds the ctx (goalStore + runtime + tz) to THIS node at boot. The LLM **physically cannot** address another node's goals (not a runtime check — by construction).

## Safety防线 wired (RFC-025 §7 + resolved §11)

1. **30s per-goal cooldown** — edit/reschedule reject if `now - goal.updated_at < 30s` (anti-recursion暴走). Uses existing updated_at field, no new state.
2. **max_active_goals_per_node** — create rejects when active count >= cap (default 20, env `COMMHUB_MAX_GOALS_PER_NODE`).
3. **batch-cancel confirm-back** — 3 cancels in 30s window → 4th returns `{ok: false, error: 'batch_destructive_confirm_required', confirm_token}`. Agent must re-call with the token after asking user to confirm. Token is single-use.

## RFC-025 §3.2 5 LLM-validation findings folded

| # | Gap | Fix |
|---|---|---|
| 🔴 1 | Time-of-day / cron-lite gap ("每天9点") | Schedule union (interval/time_of_day/weekday) — M1a |
| 2 | Destructive batch needs confirm-back | M1d batch-cancel confirm-back |
| 3 | Agent fabricates numbers, must report back | Tool descriptions hint "回报新值" |
| 4 | pause/cancel/complete description disambiguation | Tool descriptions contrast |
| 5 | Multi-loop reference resolution | M4 e2e (next milestone) |

## What's NOT in M1 (deliberate scope cap)

- **M2**: codex-sdk MCP adapter (~80-150 LOC)
- **M3**: grok-build-acp MCP adapter (~50 LOC)
- **M4**: Docker e2e — agent真用工具改自己 loop + multi-loop 指代消解 + cron-lite 三模式
- Parser cron-lite syntax (e.g. `/loop every day at 09:00` slash command) — depends on M4 design

## Review checklist

- [ ] Scheduler delta (M1b) — back-compat preserved? *(已 surface-reviewed at M1b PASS)*
- [ ] Self-scoped by-construction — no `alias` arg anywhere?
- [ ] Cooldown 30s + max cap 20 + batch-cancel 3/30s thresholds reasonable?
- [ ] confirm_token lifecycle (issue → consume → discard) tight?
- [ ] LLM tool descriptions match RFC-025 §3.2 #3/#4 guidance?
- [ ] cron-lite DST/TZ edge cases (especially spring-forward skip) handled?

## Surface checklist

- 通信龙: scheduler delta + cron-lite design review (already PASS at M1b)
- 通信牛: safety防线 + tool isolation security审

## Tracking

- Internal task #152
- Design RFC #295 (RFC-025, lock-down 8/8)
- Builds on #288 (parser) + #144 (universal /loop)
