### PR TITLE
feat(rfc-025 m2): codex-sdk MCP adapter via localhost-bound HTTP server (shared parent state)

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1921,23 +1921,51 @@ const CODEX_INSTRUCTIONS = SYSTEM_PROMPT || [
 // correct per-node identity.
 function buildCodexConfig(workdir: string): Record<string, any> {
   const nodeServerPath = join(workdir, ".anet", "node-server.js");
+  const mcp_servers: Record<string, any> = {
+    commhub: {
+      command: "bun",
+      args: [nodeServerPath],
+      // env intentionally omitted: codex CLI subprocess inherits this
+      // agent-node parent process's env, which includes the per-node
+      // COMMHUB_ALIAS / COMMHUB_TOKEN / COMMHUB_URL that anet's
+      // launchAgent already sets. Hard-coding env here would re-introduce
+      // the global-alias bug the 06-17 incident exposed.
+    },
+  };
+  // RFC-025 M2 — loops MCP server (streamable HTTP, localhost-bound,
+  // bearer-token-protected). Wired in only when the parent agent-node
+  // has actually started the HTTP server (env LOOPS_MCP_URL set by
+  // startup). codex CLI reads bearer from env LOOPS_MCP_TOKEN. The
+  // token is generated fresh per agent-node process and never leaves
+  // env (no log, no disk). Codex CLI's MCP "Bearer token" shape was
+  // verified 2026-06-29 via `codex mcp add --url ... --bearer-token-env-var`.
+  if (process.env.LOOPS_MCP_URL && process.env.LOOPS_MCP_TOKEN) {
+    mcp_servers.loops = {
+      url: process.env.LOOPS_MCP_URL,
+      bearer_token_env_var: "LOOPS_MCP_TOKEN",
+    };
+  }
   return {
     model_auto_compact_token_limit: 200000,
     developer_instructions: CODEX_INSTRUCTIONS,
-    mcp_servers: {
-      commhub: {
-        command: "bun",
-        args: [nodeServerPath],
-        // env intentionally omitted: codex CLI subprocess inherits this
-        // agent-node parent process's env, which includes the per-node
-        // COMMHUB_ALIAS / COMMHUB_TOKEN / COMMHUB_URL that anet's
-        // launchAgent already sets. Hard-coding env here would re-introduce
-        // the global-alias bug the 06-17 incident exposed.
-      },
-    },
+    mcp_servers,
   };
 }
-const CODEX_CONFIG = buildCodexConfig(process.cwd());
+// Defer CODEX_CONFIG materialization to first use so the loops MCP
+// startup (which sets LOOPS_MCP_URL/TOKEN in env) has a chance to run.
+let CODEX_CONFIG_CACHED: Record<string, any> | null = null;
+function getCodexConfig(): Record<string, any> {
+  if (!CODEX_CONFIG_CACHED) CODEX_CONFIG_CACHED = buildCodexConfig(process.cwd());
+  return CODEX_CONFIG_CACHED;
+}
+// Preserve the original eager binding for callers that still want a
+// static reference (read at first Codex new(); the loops env vars
+// are set before the first task arrives).
+const CODEX_CONFIG = new Proxy({} as Record<string, any>, {
+  get: (_t, prop) => (getCodexConfig() as any)[prop],
+  ownKeys: () => Reflect.ownKeys(getCodexConfig()),
+  getOwnPropertyDescriptor: (_t, prop) => Object.getOwnPropertyDescriptor(getCodexConfig(), prop),
+});
 
 async function processWithCodex(task: string, from: string, images?: string[]): Promise<string> {
   // Ensure system-installed codex binary is found (npm global bin)
@@ -3698,6 +3726,40 @@ if (goalsSchedulerEnabled) {
   setInterval(() => runGoalSchedulerTick().catch(() => {}), GOAL_TICK_MS);
   runGoalSchedulerTick().catch(() => {});
 }
+
+// RFC-025 M2 — loops HTTP MCP server for codex-sdk runtime.
+// Always start (independent of runtime) so the SAME goalStore +
+// cooldown + confirm-token state is shared with codex tools. claude
+// path uses in-process SDK McpServer; this HTTP server is the codex
+// equivalent. localhost-bound + random bearer token (only handed to
+// codex subprocess via env). For non-codex runtimes the server runs
+// but is unused — no security exposure since 127.0.0.1 + bearer.
+let loopsHttpServerHandle: import("./goals/loops-http-server").LoopsHttpServerStarted | null = null;
+if (RUNTIME === "codex") {
+  try {
+    const { startLoopsHttpServer } = await import("./goals/loops-http-server");
+    const maxGoalsEnv = parseInt(process.env.COMMHUB_MAX_GOALS_PER_NODE || "", 10);
+    loopsHttpServerHandle = await startLoopsHttpServer({
+      ctx: {
+        store: goalStore,
+        runtime: RUNTIME_LABEL,
+        defaultTz: (fileConfig?.flags?.timezone as string) || "Asia/Shanghai",
+        maxActiveGoals: Number.isFinite(maxGoalsEnv) && maxGoalsEnv > 0 ? maxGoalsEnv : undefined,
+        recentCancels: loopsCancelTimestamps,
+        pendingConfirmTokens: loopsConfirmTokens,
+      },
+    });
+    // Hand token to codex CLI subprocess via env (no log, no disk).
+    // The buildCodexConfig adds mcp_servers.loops referencing this
+    // URL + bearer-token-env-var = LOOPS_MCP_TOKEN.
+    process.env.LOOPS_MCP_TOKEN = loopsHttpServerHandle.token;
+    process.env.LOOPS_MCP_URL = loopsHttpServerHandle.url;
+    log(`[loops] HTTP MCP server bound to ${loopsHttpServerHandle.url} (codex self-loop tools)`);
+  } catch (e: any) {
+    warn(`[loops] HTTP MCP server failed to start (${e?.message ?? e}); codex self-loop tools unavailable`);
+  }
+}
+
 const shutdown = async () => {
   log("shutting down...");
   // #261 P0-1 — gate the feishu supervisor loop so it stops re-forking
@@ -3715,6 +3777,9 @@ const shutdown = async () => {
       try { ch.kill("SIGKILL"); } catch { /* already dead */ }
     }
   }, 500);
+  // M2 — close loops HTTP MCP server (release port + token state).
+  // Synchronous; fast.
+  try { await loopsHttpServerHandle?.close(); } catch { /* already closed */ }
   await reportStatus("offline").catch(() => {});
   process.exit(0);
 };

--- a/agent-node/src/goals/loops-http-server.test.ts
+++ b/agent-node/src/goals/loops-http-server.test.ts
@@ -1,0 +1,286 @@
+// RFC-025 M2 — loops-http-server tests.
+//
+// Pins: localhost-only bind, bearer auth no-bypass, JSON-RPC routing
+// (initialize / tools/list / tools/call), handler dispatch carries
+// safety防线 (cooldown / max / batch-cancel) across HTTP boundary.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { GoalStore, newGoal } from "./store";
+import { startLoopsHttpServer, type LoopsHttpServerStarted } from "./loops-http-server";
+import type { SelfLoopCtx } from "./self-loop-tools";
+
+let dir: string;
+let store: GoalStore;
+let server: LoopsHttpServerStarted;
+let ctx: SelfLoopCtx;
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), "loops-http-"));
+  store = new GoalStore(join(dir, "goals.json"));
+  await store.load();
+  ctx = {
+    store,
+    runtime: "codex-sdk",
+    defaultTz: "Asia/Shanghai",
+    recentCancels: [],
+    pendingConfirmTokens: new Set(),
+  };
+  server = await startLoopsHttpServer({ ctx });
+});
+
+afterEach(async () => {
+  await server.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function rpc(method: string, params: any = {}, token?: string) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (token !== null) headers["authorization"] = `Bearer ${token ?? server.token}`;
+  return fetch(server.url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+}
+
+describe("localhost binding (通信龙 hard constraint #1+#2)", () => {
+  test("server bound to 127.0.0.1, not 0.0.0.0", () => {
+    expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+  });
+
+  test("port is reachable", async () => {
+    const r = await rpc("initialize");
+    expect(r.status).toBe(200);
+  });
+
+  test("random port (different runs get different ports)", async () => {
+    // Default port 0 = OS picks. Verify we got a real ephemeral.
+    expect(server.port).toBeGreaterThan(1024);
+    expect(server.port).toBeLessThan(65536);
+  });
+});
+
+describe("bearer auth no-bypass (通信龙 hard constraint #4)", () => {
+  test("missing Authorization header → 401", async () => {
+    const r = await fetch(server.url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+    });
+    expect(r.status).toBe(401);
+    const j: any = await r.json();
+    expect(j.error).toBe("unauthorized");
+  });
+
+  test("wrong token → 401", async () => {
+    const r = await rpc("initialize", {}, "totally-wrong-token");
+    expect(r.status).toBe(401);
+  });
+
+  test("non-Bearer scheme → 401", async () => {
+    const r = await fetch(server.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "authorization": `Basic ${server.token}`,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+    });
+    expect(r.status).toBe(401);
+  });
+
+  test("correct Bearer → 200", async () => {
+    const r = await rpc("initialize");
+    expect(r.status).toBe(200);
+  });
+
+  test("path other than /mcp → 404", async () => {
+    const r = await fetch(`http://127.0.0.1:${server.port}/anything`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${server.token}` },
+    });
+    expect(r.status).toBe(404);
+  });
+});
+
+describe("MCP protocol — initialize / tools/list / tools/call", () => {
+  test("initialize returns serverInfo + tools capability", async () => {
+    const r = await rpc("initialize");
+    const j: any = await r.json();
+    expect(j.jsonrpc).toBe("2.0");
+    expect(j.result.serverInfo.name).toBe("loops");
+    expect(j.result.capabilities.tools).toBeDefined();
+  });
+
+  test("tools/list returns all 6 self-loop tools", async () => {
+    const r = await rpc("tools/list");
+    const j: any = await r.json();
+    expect(j.result.tools).toHaveLength(6);
+    const names = j.result.tools.map((t: any) => t.name).sort();
+    expect(names).toEqual([
+      "cancel_my_loop",
+      "complete_my_loop",
+      "create_my_loop",
+      "edit_my_loop",
+      "list_my_loops",
+      "reschedule_my_loop",
+    ]);
+  });
+
+  test("tools/list each tool has description + inputSchema", async () => {
+    const r = await rpc("tools/list");
+    const j: any = await r.json();
+    for (const t of j.result.tools) {
+      expect(t.description.length).toBeGreaterThan(30);
+      expect(t.inputSchema.type).toBe("object");
+    }
+  });
+
+  test("unknown method → JSON-RPC -32601", async () => {
+    const r = await rpc("totally/bogus");
+    const j: any = await r.json();
+    expect(j.error.code).toBe(-32601);
+  });
+
+  test("malformed JSON → -32700", async () => {
+    const r = await fetch(server.url, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+      body: "{ not json",
+    });
+    expect(r.status).toBe(400);
+    const j: any = await r.json();
+    expect(j.error.code).toBe(-32700);
+  });
+});
+
+describe("tools/call — handler dispatch into parent ctx", () => {
+  test("list_my_loops on empty store", async () => {
+    const r = await rpc("tools/call", { name: "list_my_loops", arguments: {} });
+    const j: any = await r.json();
+    expect(j.result.isError).toBe(false);
+    const payload = JSON.parse(j.result.content[0].text);
+    expect(payload.ok).toBe(true);
+    expect(payload.data.total).toBe(0);
+  });
+
+  test("create_my_loop with interval string writes to parent goalStore", async () => {
+    const r = await rpc("tools/call", {
+      name: "create_my_loop",
+      arguments: { task: "via http", interval: "5m" },
+    });
+    const j: any = await r.json();
+    expect(j.result.isError).toBe(false);
+    // Verify parent goalStore really has it (same ctx, same in-memory map)
+    expect((await store.list())).toHaveLength(1);
+  });
+
+  test("unknown tool name → JSON-RPC -32601", async () => {
+    const r = await rpc("tools/call", { name: "bogus_tool", arguments: {} });
+    const j: any = await r.json();
+    expect(j.error.code).toBe(-32601);
+  });
+});
+
+describe("safety防线 cross-HTTP boundary (M2 verification line)", () => {
+  // 通信龙 hard verification line: codex 节点上 batch-cancel 真触发
+  // confirm-back + cooldown 真挡 — proves the防线 is NOT a per-process
+  // no-op in the codex path.
+
+  test("batch-cancel via HTTP triggers confirm-back on 4th call", async () => {
+    // Seed 4 active goals
+    for (let i = 0; i < 4; i++) {
+      await store.upsert(newGoal({ text: `g${i}`, interval_ms: 5 * 60_000, runtime: "codex-sdk" }));
+    }
+    const goals = await store.list();
+    // First 3 cancels succeed (sharing parent's recentCancels via ctx)
+    for (let i = 0; i < 3; i++) {
+      const r = await rpc("tools/call", {
+        name: "cancel_my_loop",
+        arguments: { goal_id: goals[i].goal_id },
+      });
+      const j: any = await r.json();
+      const payload = JSON.parse(j.result.content[0].text);
+      expect(payload.ok).toBe(true);
+    }
+    // 4th triggers confirm-back
+    const r4 = await rpc("tools/call", {
+      name: "cancel_my_loop",
+      arguments: { goal_id: goals[3].goal_id },
+    });
+    const j4: any = await r4.json();
+    const payload4 = JSON.parse(j4.result.content[0].text);
+    expect(payload4.ok).toBe(false);
+    expect(payload4.error).toBe("batch_destructive_confirm_required");
+    expect(payload4.confirm_token).toBeTruthy();
+    // The 4th goal is NOT cancelled
+    expect((await store.get(goals[3].goal_id))!.status).toBe("active");
+  });
+
+  test("cooldown via HTTP — edit within 30s of upsert rejected", async () => {
+    const g = newGoal({ text: "x", interval_ms: 5 * 60_000, runtime: "codex-sdk" });
+    await store.upsert(g);
+    // Edit immediately — well within cooldown
+    const r = await rpc("tools/call", {
+      name: "edit_my_loop",
+      arguments: { goal_id: g.goal_id, interval: "10m" },
+    });
+    const j: any = await r.json();
+    const payload = JSON.parse(j.result.content[0].text);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe("cooldown");
+  });
+
+  test("max-active-goals cap honored across HTTP", async () => {
+    // Recreate ctx with low cap
+    await server.close();
+    ctx = { ...ctx, maxActiveGoals: 2 };
+    server = await startLoopsHttpServer({ ctx });
+    for (let i = 0; i < 2; i++) {
+      const r = await rpc("tools/call", {
+        name: "create_my_loop",
+        arguments: { task: `g${i}`, interval: "5m" },
+      });
+      const j: any = await r.json();
+      const payload = JSON.parse(j.result.content[0].text);
+      expect(payload.ok).toBe(true);
+    }
+    const r3 = await rpc("tools/call", {
+      name: "create_my_loop",
+      arguments: { task: "g3", interval: "5m" },
+    });
+    const j3: any = await r3.json();
+    const payload3 = JSON.parse(j3.result.content[0].text);
+    expect(payload3.ok).toBe(false);
+    expect(payload3.error).toBe("max_active_goals_reached");
+  });
+
+  test("preflight invalid timezone rejected via HTTP (M1 #302 round-2 still works)", async () => {
+    const r = await rpc("tools/call", {
+      name: "create_my_loop",
+      arguments: {
+        task: "bad tz",
+        schedule: { type: "time_of_day", time: "09:00", timezone: "Bad/Zone" },
+      },
+    });
+    const j: any = await r.json();
+    const payload = JSON.parse(j.result.content[0].text);
+    expect(payload.ok).toBe(false);
+    expect(payload.error).toBe("invalid_schedule");
+    // Goal NOT written
+    expect((await store.list())).toHaveLength(0);
+  });
+});
+
+describe("custom token override (for tests)", () => {
+  test("explicit token honored", async () => {
+    await server.close();
+    server = await startLoopsHttpServer({ ctx, token: "test-fixed-token" });
+    expect(server.token).toBe("test-fixed-token");
+    const r = await rpc("initialize");
+    expect(r.status).toBe(200);
+  });
+});

--- a/agent-node/src/goals/loops-http-server.ts
+++ b/agent-node/src/goals/loops-http-server.ts
@@ -1,0 +1,177 @@
+// RFC-025 M2 — in-process HTTP MCP server for codex-sdk runtime.
+//
+// Codex CLI's MCP support accepts streamable HTTP servers
+// (`codex mcp add --url ... --bearer-token-env-var ...`, verified
+// 2026-06-29). Unlike claude-agent-sdk's in-process SDK McpServer,
+// codex spawns the agent CLI as a child process which then calls
+// out to this URL — but since the URL is `127.0.0.1:<random>`, we
+// stay inside the parent process boundary for the actual handler
+// execution, so the 6 self-loop handlers run against the SAME
+// `goalStore` + `loopsCancelTimestamps` + `loopsConfirmTokens` as
+// the claude path. Safety防线 (cooldown / max / batch-cancel
+// confirm-back) preserved cross-runtime — they're not per-process
+// counters that reset between codex turns.
+//
+// Security (通信龙 hard constraints):
+//   - localhost-bind ONLY (127.0.0.1) — never 0.0.0.0
+//   - random bearer token (crypto.randomBytes 16B) — only handed to
+//     codex subprocess via env var `LOOPS_MCP_TOKEN`, never logged,
+//     never written to disk
+//   - auth no-bypass: missing / wrong token → 401, no fallback
+//   - graceful close on parent shutdown
+
+import { randomBytes } from "crypto";
+import { SELF_LOOP_TOOL_SPECS } from "./self-loop-tools";
+import type { SelfLoopCtx } from "./self-loop-tools";
+
+export interface LoopsHttpServerStarted {
+  url: string;        // e.g. "http://127.0.0.1:53412/mcp"
+  token: string;      // raw bearer token (only handed to codex subprocess via env)
+  port: number;
+  close: () => Promise<void> | void;
+}
+
+export interface StartOpts {
+  ctx: SelfLoopCtx;
+  /** Override port. Default 0 = OS picks (random). */
+  port?: number;
+  /** Override token. Default random 16B base64. */
+  token?: string;
+}
+
+// MCP JSON-RPC protocol implementation — just enough surface for
+// `initialize` / `tools/list` / `tools/call` (the 3 verbs codex CLI
+// uses against an MCP server).
+//
+// We don't pull in the full @modelcontextprotocol/sdk just for this
+// shim — the protocol is small enough to inline cleanly and avoids
+// dragging another transport layer into agent-node.
+
+function jsonRpcOk(id: any, result: unknown) {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function jsonRpcErr(id: any, code: number, message: string, data?: unknown) {
+  return { jsonrpc: "2.0", id, error: { code, message, ...(data !== undefined ? { data } : {}) } };
+}
+
+// Lazy zod schemas pulled from loops-mcp.ts pattern. Inline minimal
+// version here to avoid claude-agent-sdk dependency on codex path.
+function describeTool(spec: typeof SELF_LOOP_TOOL_SPECS[number]) {
+  // Build a minimal JSON Schema for inputSchema per MCP spec.
+  // Codex CLI is lenient about schema details for streamable HTTP
+  // (it relays the call regardless), so we hand-roll a relaxed shape.
+  const props: Record<string, any> = {};
+  if (spec.name === "create_my_loop") {
+    props.task = { type: "string" };
+    props.interval = { type: "string" };
+    props.schedule = { type: "object" };
+  } else if (spec.name === "edit_my_loop") {
+    props.goal_id = { type: "string" };
+    props.task = { type: "string" };
+    props.interval = { type: "string" };
+    props.schedule = { type: "object" };
+    props.paused = { type: "boolean" };
+  } else if (spec.name === "reschedule_my_loop") {
+    props.goal_id = { type: "string" };
+    props.next_wake_in = { type: "string" };
+  } else if (spec.name === "complete_my_loop" || spec.name === "cancel_my_loop") {
+    props.goal_id = { type: "string" };
+    if (spec.name === "cancel_my_loop") props.confirm_token = { type: "string" };
+  }
+  return {
+    name: spec.name,
+    description: spec.description,
+    inputSchema: {
+      type: "object",
+      properties: props,
+      required: spec.name === "list_my_loops" ? [] : ["goal_id"].filter((k) => k in props),
+    },
+  };
+}
+
+async function handleMcpRequest(body: any, ctx: SelfLoopCtx) {
+  const { id, method, params } = body || {};
+  if (method === "initialize") {
+    return jsonRpcOk(id, {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: { listChanged: false } },
+      serverInfo: { name: "loops", version: "0.1.0" },
+    });
+  }
+  if (method === "tools/list") {
+    return jsonRpcOk(id, { tools: SELF_LOOP_TOOL_SPECS.map(describeTool) });
+  }
+  if (method === "tools/call") {
+    const name = params?.name;
+    const args = params?.arguments ?? {};
+    const spec = SELF_LOOP_TOOL_SPECS.find((s) => s.name === name);
+    if (!spec) return jsonRpcErr(id, -32601, `Tool not found: ${name}`);
+    const result = await spec.handler(args, ctx);
+    // MCP tools/call response shape — content[]
+    return jsonRpcOk(id, {
+      content: [{ type: "text", text: JSON.stringify(result) }],
+      isError: !result.ok,
+    });
+  }
+  // Unknown method
+  return jsonRpcErr(id, -32601, `Method not found: ${method}`);
+}
+
+/**
+ * Start a localhost-only HTTP MCP server. Returns the started
+ * server's url/token/port + close fn. Caller's responsibility to
+ * call close() at parent shutdown.
+ */
+export async function startLoopsHttpServer(opts: StartOpts): Promise<LoopsHttpServerStarted> {
+  const token = opts.token ?? randomBytes(16).toString("base64url");
+  const handler = async (req: Request): Promise<Response> => {
+    const url = new URL(req.url);
+    if (url.pathname !== "/mcp") {
+      return new Response("not found", { status: 404 });
+    }
+    // Auth — bearer no-bypass per 通信龙 hard constraint #4.
+    // No token / wrong token / no Authorization header → 401.
+    const auth = req.headers.get("authorization") || "";
+    if (!auth.startsWith("Bearer ") || auth.slice(7) !== token) {
+      return new Response(JSON.stringify({ error: "unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    let body: any;
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(JSON.stringify(jsonRpcErr(null, -32700, "Parse error")), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    try {
+      const result = await handleMcpRequest(body, opts.ctx);
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    } catch (e: any) {
+      return new Response(
+        JSON.stringify(jsonRpcErr(body?.id ?? null, -32603, `Internal error: ${e?.message ?? e}`)),
+        { status: 500, headers: { "content-type": "application/json" } }
+      );
+    }
+  };
+
+  const server = Bun.serve({
+    port: opts.port ?? 0, // 0 = OS picks a random free port
+    hostname: "127.0.0.1", // localhost-bind ONLY — never 0.0.0.0
+    fetch: handler,
+  });
+
+  return {
+    url: `http://127.0.0.1:${server.port}/mcp`,
+    token,
+    port: server.port,
+    close: () => server.stop(true),
+  };
+}


### PR DESCRIPTION
## Author
Agent: 通信SDK马

## Why

RFC-025 M2: codex-sdk runtime needs the 6 self-loop tools too. Per 通信龙 dispatch — verified (`codex mcp add --url ... --bearer-token-env-var`) that codex CLI supports streamable HTTP MCP with bearer auth. Chose **Option C** (in-process HTTP MCP server in parent agent-node, codex subprocess HTTPs back in) over options A (stdio shim + HTTP back-channel) and B (rejected — stdio direct file mutation defeats safety防线).

## Critical: shared parent state preserved

The 6 self-loop tools' safety防线 (cooldown / max-cap / batch-cancel confirm-back) are **per-process state** in the parent agent-node. Option B (codex stdio subprocess directly writing goals.json) would race against the parent's in-memory map → cooldown/confirm-token entirely no-op. Per 通信龙 hard verification line: M4 e2e must prove batch-cancel on a codex node really triggers confirm-back.

## Security (4 hard constraints all enforced + tested)

| # | Constraint | Implementation | Test |
|---|---|---|---|
| 1 | localhost-only bind | `Bun.serve({hostname: "127.0.0.1"})` (never 0.0.0.0) | pinned: server.url matches `/^http:\/\/127\.0\.0\.1:\d+\/mcp$/` |
| 2 | Random port + bearer | `port: 0` (OS-picked) + `crypto.randomBytes(16).toString("base64url")` per agent-node process | port in ephemeral range (1024-65535) |
| 3 | Token only in env | `process.env.LOOPS_MCP_TOKEN` (consumed by codex via `bearer_token_env_var`). No log, no disk. | (code review) |
| 4 | Auth no-bypass | 401 on missing/wrong/non-Bearer headers | 5 auth tests cover all paths |

## What landed

- `agent-node/src/goals/loops-http-server.ts` (~180 LOC) — Bun.serve + JSON-RPC + bearer + dispatch to SELF_LOOP_TOOL_SPECS handlers
- `agent-node/src/cli.ts` wire (~50 LOC) — startup spawn when RUNTIME=='codex', env vars for codex subprocess, shutdown close
- `agent-node/src/goals/loops-http-server.test.ts` — 21 new tests

## Tests

| Group | Cases | Notable |
|---|---|---|
| localhost binding | 3 | hostname 127.0.0.1, random port reachable |
| bearer no-bypass | 5 | missing/wrong/non-Bearer all → 401, correct → 200, /404 path |
| MCP protocol | 5 | initialize, tools/list (6 names), tools/list schema valid, -32601 unknown method, -32700 malformed JSON |
| tools/call dispatch | 3 | list/create writes parent goalStore (same in-memory map), unknown tool -32601 |
| **safety防线 cross-HTTP** (M2 verification line) | 4 | batch-cancel 4th triggers confirm_token, cooldown rejects edit, max-cap honored, preflight bad TZ rejected |
| custom token | 1 | injectable for tests |

agent-node/src/goals/ full suite: **193 pass / 0 fail / 483 expect()** (was 172, +21).

## Scheduler行为变化点

**Zero**. M2 adds new MCP server only. Scheduler tick / newGoal / processTask unchanged.

## What's NOT in M2

- **M3** grok-build-acp MCP adapter (~50 LOC analogous to claude path)
- **M4** Docker e2e — codex node真用工具 + 通信龙 hard verification: batch-cancel real-fire on codex node + cooldown real-block (NOT unit, real codex run)

## Surface checklist

- 通信龙: localhost-bound + bearer-auth + shared parent state (verified design)
- 通信牛: localhost endpoint + auth安全审

## Tracking

- Internal task #154
- Builds on #302 (M1, merged)
- Design RFC #295 (RFC-025)
