### PR TITLE
test(rfc-025 m4): self-loop tools e2e matrix — 41/41 green across 3 runtimes

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -3744,6 +3744,12 @@ if (RUNTIME === "codex" || RUNTIME === "grok") {
   try {
     const { startLoopsHttpServer } = await import("./goals/loops-http-server");
     const maxGoalsEnv = parseInt(process.env.COMMHUB_MAX_GOALS_PER_NODE || "", 10);
+    // RFC-025 M4 e2e — accept pre-set LOOPS_MCP_TOKEN so test
+    // harness can drive the HTTP MCP without scraping /proc/<pid>/
+    // environ (which only reflects exec-time env, not post-startup
+    // process.env mutations). Production never sets this; left
+    // unset, the server generates its own random token as before.
+    const preSetToken = process.env.LOOPS_MCP_TOKEN || undefined;
     loopsHttpServerHandle = await startLoopsHttpServer({
       ctx: {
         store: goalStore,
@@ -3753,6 +3759,7 @@ if (RUNTIME === "codex" || RUNTIME === "grok") {
         recentCancels: loopsCancelTimestamps,
         pendingConfirmTokens: loopsConfirmTokens,
       },
+      token: preSetToken,
     });
     // Hand token to codex CLI / grok ACP subprocess via env (no log,
     // no disk). buildCodexConfig adds mcp_servers.loops referencing

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -2327,46 +2327,19 @@ async function processWithGrok(task: string, from: string, images?: string[]): P
   // Schema source: @zed-industries/agent-client-protocol@0.4.5
   // schema/schema.json → $defs.McpServer.anyOf[Http]. Required fields:
   // type:"http", name, url, headers ([{name,value}] array).
-  const headers: Array<{ name: string; value: string }> = [];
-  if (AUTH_TOKEN) headers.push({ name: "Authorization", value: `Bearer ${AUTH_TOKEN}` });
-  // Future-proofing: tag the call so commhub-server can log/route ACP-
-  // injected traffic distinctly if needed. Harmless extra header today.
-  headers.push({ name: "X-Commhub-MCP-Transport", value: "acp-http" });
-  if (ALIAS) headers.push({ name: "X-Commhub-Alias-Hint", value: ALIAS });
-  const grokMcpServers: Array<{
-    type: "http";
-    name: string;
-    url: string;
-    headers: Array<{ name: string; value: string }>;
-  }> = [{
-    type: "http",
-    name: "commhub",
-    url: `${COMMHUB_URL}/mcp`,
-    headers,
-  }];
-
-  // RFC-025 M3 — register the loops HTTP MCP server (started at
-  // agent-node boot, see startLoopsHttpServer wire below). Same ACP
-  // schema as commhub: type:"http" + headers array. The bearer token
-  // is read from process.env.LOOPS_MCP_TOKEN (parent process state),
-  // not surfaced in logs/disk per 通信龙 M2 security constraints.
-  //
-  // localhost-bound + per-process random token: a misbehaving peer on
-  // the same machine can't address THIS agent's loops without the
-  // ephemeral token, which only this agent-node process possesses.
-  if (process.env.LOOPS_MCP_URL && process.env.LOOPS_MCP_TOKEN) {
-    const loopHeaders: Array<{ name: string; value: string }> = [
-      { name: "Authorization", value: `Bearer ${process.env.LOOPS_MCP_TOKEN}` },
-      { name: "X-Commhub-MCP-Transport", value: "acp-http-loops" },
-    ];
-    if (ALIAS) loopHeaders.push({ name: "X-Commhub-Alias-Hint", value: ALIAS });
-    grokMcpServers.push({
-      type: "http",
-      name: "loops",
-      url: process.env.LOOPS_MCP_URL,
-      headers: loopHeaders,
-    });
-  }
+  // RFC-025 M3 — grok ACP MCP server list construction extracted to
+  // pure `buildGrokMcpServers` so unit tests in loops-grok-wire.test.ts
+  // assert the REAL export instead of mirroring inline (pre-extraction
+  // a cli.ts edit would silently drift past the wire tests). All env/
+  // ALIAS/AUTH_TOKEN/COMMHUB_URL reads stay here; the helper is pure.
+  const { buildGrokMcpServers } = await import("./goals/loops-grok-wire");
+  const grokMcpServers = buildGrokMcpServers({
+    commhubUrl: COMMHUB_URL,
+    alias: ALIAS,
+    authToken: AUTH_TOKEN || undefined,
+    loopsUrl: process.env.LOOPS_MCP_URL,
+    loopsToken: process.env.LOOPS_MCP_TOKEN,
+  });
 
   // #204 preview.7 — per-node isolated cwd. preview.2 → preview.6 chain
   // showed that even with HTTP MCP injected via ACP, Grok CLI ALSO reads

--- a/agent-node/src/goals/loops-grok-wire.test.ts
+++ b/agent-node/src/goals/loops-grok-wire.test.ts
@@ -1,51 +1,11 @@
 // RFC-025 M3 — grok ACP MCP injection wire tests.
 //
-// The grok injection is a 2-line addition to the existing
-// `grokMcpServers` array in cli.ts (see L2308-ish post-edit). This
-// file pins the SHAPE the array gets when env LOOPS_MCP_URL/TOKEN
-// are set vs absent, so a future refactor that breaks the wire is
-// loudly caught.
-//
-// We don't exercise cli.ts directly (CLI side-effects on load); we
-// inline the same array-building logic and verify the shape.
+// Post-M4-extraction these tests import the REAL `buildGrokMcpServers`
+// export (was pre-extraction an inline mirror of cli.ts logic — which
+// silently drifted any time cli.ts was edited; 通信龙 #306 nit caught).
 
-import { describe, expect, test, beforeEach } from "bun:test";
-
-// Mirror cli.ts's grokMcpServers construction (post-M3 edit).
-function buildGrokMcpServers(opts: {
-  commhubUrl: string;
-  alias: string;
-  authToken?: string;
-  loopsUrl?: string;
-  loopsToken?: string;
-}) {
-  const commhubHeaders: Array<{ name: string; value: string }> = [];
-  if (opts.authToken) commhubHeaders.push({ name: "Authorization", value: `Bearer ${opts.authToken}` });
-  commhubHeaders.push({ name: "X-Commhub-MCP-Transport", value: "acp-http" });
-  if (opts.alias) commhubHeaders.push({ name: "X-Commhub-Alias-Hint", value: opts.alias });
-
-  const servers: Array<{
-    type: "http";
-    name: string;
-    url: string;
-    headers: Array<{ name: string; value: string }>;
-  }> = [{ type: "http", name: "commhub", url: `${opts.commhubUrl}/mcp`, headers: commhubHeaders }];
-
-  if (opts.loopsUrl && opts.loopsToken) {
-    const loopHeaders: Array<{ name: string; value: string }> = [
-      { name: "Authorization", value: `Bearer ${opts.loopsToken}` },
-      { name: "X-Commhub-MCP-Transport", value: "acp-http-loops" },
-    ];
-    if (opts.alias) loopHeaders.push({ name: "X-Commhub-Alias-Hint", value: opts.alias });
-    servers.push({
-      type: "http",
-      name: "loops",
-      url: opts.loopsUrl,
-      headers: loopHeaders,
-    });
-  }
-  return servers;
-}
+import { describe, expect, test } from "bun:test";
+import { buildGrokMcpServers } from "./loops-grok-wire";
 
 describe("grok ACP MCP injection — RFC-025 M3 wire", () => {
   test("when LOOPS env unset, only commhub server (back-compat)", () => {

--- a/agent-node/src/goals/loops-grok-wire.ts
+++ b/agent-node/src/goals/loops-grok-wire.ts
@@ -1,0 +1,67 @@
+// RFC-025 M3 — pure helper that builds the ACP `mcpServers` array
+// injected into Grok via `session/new` (see cli.ts processWithGrok).
+//
+// Extracted from cli.ts so M4 unit tests can assert against the REAL
+// export — pre-extraction the test file mirrored the build logic
+// inline, which silently drifts the day cli.ts changes. Pure function
+// = no env reads, no side effects; caller injects every input.
+//
+// Behavior is byte-identical to the inline pre-extraction version
+// (verified by the existing 6 wire tests still passing after the
+// extraction). Shape pinned by `loops-grok-wire.test.ts`.
+
+export interface GrokMcpHeader {
+  name: string;
+  value: string;
+}
+
+export interface GrokMcpServerEntry {
+  type: "http";
+  name: string;
+  url: string;
+  headers: GrokMcpHeader[];
+}
+
+export interface BuildGrokMcpServersOpts {
+  commhubUrl: string;
+  alias: string;
+  authToken?: string;
+  loopsUrl?: string;
+  loopsToken?: string;
+}
+
+export function buildGrokMcpServers(opts: BuildGrokMcpServersOpts): GrokMcpServerEntry[] {
+  const commhubHeaders: GrokMcpHeader[] = [];
+  if (opts.authToken) {
+    commhubHeaders.push({ name: "Authorization", value: `Bearer ${opts.authToken}` });
+  }
+  commhubHeaders.push({ name: "X-Commhub-MCP-Transport", value: "acp-http" });
+  if (opts.alias) {
+    commhubHeaders.push({ name: "X-Commhub-Alias-Hint", value: opts.alias });
+  }
+
+  const servers: GrokMcpServerEntry[] = [{
+    type: "http",
+    name: "commhub",
+    url: `${opts.commhubUrl}/mcp`,
+    headers: commhubHeaders,
+  }];
+
+  if (opts.loopsUrl && opts.loopsToken) {
+    const loopHeaders: GrokMcpHeader[] = [
+      { name: "Authorization", value: `Bearer ${opts.loopsToken}` },
+      { name: "X-Commhub-MCP-Transport", value: "acp-http-loops" },
+    ];
+    if (opts.alias) {
+      loopHeaders.push({ name: "X-Commhub-Alias-Hint", value: opts.alias });
+    }
+    servers.push({
+      type: "http",
+      name: "loops",
+      url: opts.loopsUrl,
+      headers: loopHeaders,
+    });
+  }
+
+  return servers;
+}

--- a/agent-node/src/goals/loops-http-server.ts
+++ b/agent-node/src/goals/loops-http-server.ts
@@ -19,8 +19,17 @@
 //     never written to disk
 //   - auth no-bypass: missing / wrong token → 401, no fallback
 //   - graceful close on parent shutdown
+//
+// **Runtime portability** (M4 e2e catch): agent-node is bundled with
+// `bun build --target node` and executes under Node.js (npm-linked
+// global bin runs `node dist/cli.js`). `Bun.serve` is undefined at
+// runtime — would throw `Bun is not defined` and the server would
+// silently fail to start. Use `node:http` which is available in both
+// Bun and Node. Unit tests (`bun test`) keep passing; production
+// codex/grok startup now actually binds.
 
 import { randomBytes } from "crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { SELF_LOOP_TOOL_SPECS } from "./self-loop-tools";
 import type { SelfLoopCtx } from "./self-loop-tools";
 
@@ -28,7 +37,7 @@ export interface LoopsHttpServerStarted {
   url: string;        // e.g. "http://127.0.0.1:53412/mcp"
   token: string;      // raw bearer token (only handed to codex subprocess via env)
   port: number;
-  close: () => Promise<void> | void;
+  close: () => Promise<void>;
 }
 
 export interface StartOpts {
@@ -55,8 +64,6 @@ function jsonRpcErr(id: any, code: number, message: string, data?: unknown) {
   return { jsonrpc: "2.0", id, error: { code, message, ...(data !== undefined ? { data } : {}) } };
 }
 
-// Lazy zod schemas pulled from loops-mcp.ts pattern. Inline minimal
-// version here to avoid claude-agent-sdk dependency on codex path.
 function describeTool(spec: typeof SELF_LOOP_TOOL_SPECS[number]) {
   // Build a minimal JSON Schema for inputSchema per MCP spec.
   // Codex CLI is lenient about schema details for streamable HTTP
@@ -108,70 +115,85 @@ async function handleMcpRequest(body: any, ctx: SelfLoopCtx) {
     const spec = SELF_LOOP_TOOL_SPECS.find((s) => s.name === name);
     if (!spec) return jsonRpcErr(id, -32601, `Tool not found: ${name}`);
     const result = await spec.handler(args, ctx);
-    // MCP tools/call response shape — content[]
     return jsonRpcOk(id, {
       content: [{ type: "text", text: JSON.stringify(result) }],
       isError: !result.ok,
     });
   }
-  // Unknown method
   return jsonRpcErr(id, -32601, `Method not found: ${method}`);
+}
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function writeJson(res: ServerResponse, status: number, body: any) {
+  res.statusCode = status;
+  res.setHeader("content-type", "application/json");
+  res.end(JSON.stringify(body));
 }
 
 /**
  * Start a localhost-only HTTP MCP server. Returns the started
  * server's url/token/port + close fn. Caller's responsibility to
  * call close() at parent shutdown.
+ *
+ * Implementation uses node:http for cross-runtime support — agent-node
+ * runs under Node.js in production (bun-built bundle, node-executed).
  */
 export async function startLoopsHttpServer(opts: StartOpts): Promise<LoopsHttpServerStarted> {
   const token = opts.token ?? randomBytes(16).toString("base64url");
-  const handler = async (req: Request): Promise<Response> => {
-    const url = new URL(req.url);
-    if (url.pathname !== "/mcp") {
-      return new Response("not found", { status: 404 });
+
+  const server = createServer(async (req, res) => {
+    if (!req.url || req.method !== "POST" || !req.url.startsWith("/mcp")) {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
     }
     // Auth — bearer no-bypass per 通信龙 hard constraint #4.
-    // No token / wrong token / no Authorization header → 401.
-    const auth = req.headers.get("authorization") || "";
-    if (!auth.startsWith("Bearer ") || auth.slice(7) !== token) {
-      return new Response(JSON.stringify({ error: "unauthorized" }), {
-        status: 401,
-        headers: { "content-type": "application/json" },
-      });
+    const auth = req.headers["authorization"] || "";
+    if (typeof auth !== "string" || !auth.startsWith("Bearer ") || auth.slice(7) !== token) {
+      writeJson(res, 401, { error: "unauthorized" });
+      return;
     }
     let body: any;
     try {
-      body = await req.json();
+      const raw = await readRequestBody(req);
+      body = raw ? JSON.parse(raw) : null;
     } catch {
-      return new Response(JSON.stringify(jsonRpcErr(null, -32700, "Parse error")), {
-        status: 400,
-        headers: { "content-type": "application/json" },
-      });
+      writeJson(res, 400, jsonRpcErr(null, -32700, "Parse error"));
+      return;
     }
     try {
       const result = await handleMcpRequest(body, opts.ctx);
-      return new Response(JSON.stringify(result), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      writeJson(res, 200, result);
     } catch (e: any) {
-      return new Response(
-        JSON.stringify(jsonRpcErr(body?.id ?? null, -32603, `Internal error: ${e?.message ?? e}`)),
-        { status: 500, headers: { "content-type": "application/json" } }
-      );
+      writeJson(res, 500, jsonRpcErr(body?.id ?? null, -32603, `Internal error: ${e?.message ?? e}`));
     }
-  };
-
-  const server = Bun.serve({
-    port: opts.port ?? 0, // 0 = OS picks a random free port
-    hostname: "127.0.0.1", // localhost-bind ONLY — never 0.0.0.0
-    fetch: handler,
   });
 
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts.port ?? 0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+
   return {
-    url: `http://127.0.0.1:${server.port}/mcp`,
+    url: `http://127.0.0.1:${port}/mcp`,
     token,
-    port: server.port,
-    close: () => server.stop(true),
+    port,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      ),
   };
 }

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -27,8 +27,9 @@ COPY tests/docker-e2e-auth.sh /app/test-auth.sh
 COPY tests/docker-e2e-networks.sh /app/test-networks.sh
 COPY tests/docker-e2e-loop-runtime.sh /app/test-loop-runtime.sh
 COPY tests/docker-e2e-loop-npm-pack.sh /app/test-loop-npm-pack.sh
+COPY tests/docker-e2e-loop-self-mgmt.sh /app/test-loop-self-mgmt.sh
 COPY tests/lib /app/lib
-RUN chmod +x /app/test.sh /app/test-codex.sh /app/test-claude.sh /app/test-game.sh /app/test-config.sh /app/test-minimax.sh /app/test-all.sh /app/demo.sh /app/test-auth.sh /app/test-networks.sh /app/test-loop-runtime.sh /app/test-loop-npm-pack.sh
+RUN chmod +x /app/test.sh /app/test-codex.sh /app/test-claude.sh /app/test-game.sh /app/test-config.sh /app/test-minimax.sh /app/test-all.sh /app/demo.sh /app/test-auth.sh /app/test-networks.sh /app/test-loop-runtime.sh /app/test-loop-npm-pack.sh /app/test-loop-self-mgmt.sh
 RUN cd /app/server && bun install
 
 # Install local agent-node globally (build from source)

--- a/tests/docker-e2e-loop-self-mgmt.sh
+++ b/tests/docker-e2e-loop-self-mgmt.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 # RFC-025 M4 — agent loop self-management e2e (Docker isolated).
 #
-# Verifies 通信龙's hard verification line: agent真节点 batch-cancel
-# 真触发 confirm-back + cooldown 真挡 + multi-loop 指代消解 + cron-lite
-# 三模式 + preflight self-lock prevention. Across all 3 in-scope runtimes
-# (claude-agent-sdk / codex-sdk / grok-build-acp).
+# Verifies 通信龙's hard verification line: real agent-nodes prove the
+# 6 self-loop tools + safety防线 cross-runtime, not just unit tests.
 #
 # **Critical isolation** (通信龙 红线):
 #   - COMMHUB_DB=/tmp/commhub-loop-m4-$$.db (per-run isolated)
@@ -12,15 +10,36 @@
 #   - never connects to production hub
 #   - safe_rm_rf for all workdir cleanup
 #
-# What we DO assert: tool-call layer behaviour + parent goalStore state
-#   (cooldown/confirm-token/preflight all enforced WITHOUT real LLM fire)
+# 5 test groups × in-scope runtimes:
+#   1. batch-cancel confirm-back (4th cancel in 30s → confirm_token)
+#   2. cooldown real-block (edit within 30s → rejected; after 31s → ok)
+#   3. multi-loop reference resolution (3 loops, edit by goal_id)
+#   4. cron-lite 3 modes (interval / time_of_day / weekday)
+#   5. preflight self-lock prevention (bad TZ → rejected, store unchanged)
 #
-# What we deliberately DON'T assert: SDK actually completing LLM-driven
-#   task execution after a wake. LLM真 fire 留 M5 single demo run
-#   (省 Vincent's "无 Max 军团" token budget).
+# **Runtime matrix**:
+#   - codex-sdk + grok-build-acp: full 5 groups via HTTP MCP path
+#     (each runtime starts its own loops HTTP server in parent
+#     agent-node; bearer token read from /proc/<pid>/environ — never
+#     logged per 通信龙 security constraints).
+#   - claude-agent-sdk: structural smoke ONLY — the 6 tools live as
+#     in-process SDK MCP that only initializes inside processWithClaude
+#     (per-task), so driving them requires LLM fire. Behavior防线 for
+#     claude is covered by the 199-pass goals/ unit suite (cooldown,
+#     batch-cancel, confirm-token, preflight all unit-tested against
+#     the shared handlers). For claude we verify:
+#       a. node starts + loops SDK MCP wire log line appears
+#       b. addGoalFromSlash path (the LLM-free goal creation pathway)
+#       c. scheduler tick observable (goal next_wake_at advances)
+#
+# What we deliberately DON'T assert: LLM-driven task execution after
+# a wake. Single real-LLM demo run is M5 (separate, per 通信龙).
 
-set -e
-
+# NOTE: deliberately NOT `set -e`. We track failures explicitly via
+# the PASS/FAIL counters + final exit code; set -e would silently
+# abort the whole matrix the moment a single python3/grep returns
+# non-zero, masking which test really failed and skipping later
+# runtimes. Each helper guards its own error paths.
 SAFE_RM_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/safe-rm.sh"
 if [ -f "$SAFE_RM_LIB" ]; then
   source "$SAFE_RM_LIB"
@@ -39,13 +58,12 @@ FAIL=0
 pass() { echo "  ✅ $1"; PASS=$((PASS+1)); }
 fail() { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
 section() { echo ""; echo "━━━ $1 ━━━"; }
+sub() { echo "    — $1"; }
 
 # ────────────────────────────────────────────────────────────────
-# Harness skeleton (per 通信龙 spot-check checkpoint)
+# Harness
 # ────────────────────────────────────────────────────────────────
 
-# Isolated test hub — distinct port from #144's 9210 to avoid
-# collision when both suites run.
 HUB_PORT=9220
 HUB_DB="/tmp/commhub-loop-m4-$$.db"
 
@@ -68,7 +86,6 @@ start_isolated_hub() {
 }
 
 register_test_user() {
-  # Returns user_token + network_token to caller via globals.
   local resp
   resp=$(curl -s -X POST "http://127.0.0.1:$HUB_PORT/api/auth/register" \
     -H "Content-Type: application/json" \
@@ -83,8 +100,6 @@ register_test_user() {
   pass "registered test user (net=${NET_ID:0:12})"
 }
 
-# Per-runtime workdir setup. Writes config.json with the given
-# runtime + auth token, returns workdir path via stdout.
 make_node_workdir() {
   local alias="$1"
   local runtime="$2"
@@ -109,27 +124,32 @@ EOF
   echo "$workdir"
 }
 
-# Start an agent-node in the background and wait for it to register.
-# Bogus API key — we don't need LLM fire for M4 tool-layer checks.
 start_node() {
   local alias="$1"
   local runtime="$2"
   local workdir="$3"
   local logfile="/tmp/m4-${alias}.log"
   > "$logfile"
+  # Pre-generate a per-node loops MCP token so the test harness can
+  # drive the HTTP MCP without scraping /proc/<pid>/environ (which
+  # doesn't reflect post-exec process.env mutations). Production
+  # never pre-sets this; agent-node accepts it as override.
+  local pretoken
+  pretoken=$(head -c 16 /dev/urandom | base64 | tr '/+' '_-' | tr -d '=')
+  echo "$pretoken" > "/tmp/m4-${alias}.loopstoken"
   case "$runtime" in
     claude-agent-sdk)
-      ANTHROPIC_API_KEY="m4-bogus" \
+      ANTHROPIC_API_KEY="m4-bogus" LOOPS_MCP_TOKEN="$pretoken" \
         agent-node --alias "$alias" --config "$workdir/.anet/nodes/$alias/config.json" \
         > "$logfile" 2>&1 &
       ;;
     codex-sdk)
-      OPENAI_API_KEY="m4-bogus" \
+      OPENAI_API_KEY="m4-bogus" LOOPS_MCP_TOKEN="$pretoken" \
         agent-node --alias "$alias" --config "$workdir/.anet/nodes/$alias/config.json" \
         > "$logfile" 2>&1 &
       ;;
     grok-build-acp)
-      XAI_API_KEY="m4-bogus" \
+      XAI_API_KEY="m4-bogus" LOOPS_MCP_TOKEN="$pretoken" \
         agent-node --alias "$alias" --config "$workdir/.anet/nodes/$alias/config.json" \
         > "$logfile" 2>&1 &
       ;;
@@ -140,10 +160,21 @@ start_node() {
   esac
   local pid=$!
   echo "$pid" > "/tmp/m4-${alias}.pid"
-  # Wait up to 20s for "已注册到 CommHub" / "registered"
   for i in $(seq 1 20); do
     if grep -q "已注册到 CommHub\|registered" "$logfile" 2>/dev/null; then
       pass "node $alias ($runtime) registered (PID=$pid)"
+      # For codex/grok also wait for loops HTTP server log line
+      if [ "$runtime" != "claude-agent-sdk" ]; then
+        for j in $(seq 1 10); do
+          if grep -q "HTTP MCP server bound" "$logfile" 2>/dev/null; then
+            pass "loops HTTP MCP server up (${runtime})"
+            return 0
+          fi
+          sleep 1
+        done
+        fail "loops HTTP MCP server didn't bind within 10s (${runtime})"
+        return 1
+      fi
       return 0
     fi
     sleep 1
@@ -165,52 +196,54 @@ stop_node() {
   fi
 }
 
-# Direct tool invocation against parent agent-node — uses the
-# already-running localhost loops HTTP server inside the agent-node
-# process. The LOOPS_MCP_URL + LOOPS_MCP_TOKEN are stamped into the
-# log by startLoopsHttpServer. For claude runtime we don't have an
-# HTTP server (uses in-process SDK MCP) so this helper supports
-# codex/grok only.
 loops_url_for() {
   local logfile="/tmp/m4-${1}.log"
-  grep -oE "http://127.0.0.1:[0-9]+/mcp" "$logfile" | head -1
+  # Extract the full "bound to <url>" URL from the loops log line so
+  # we get the `/mcp` path the server requires (not just host:port).
+  grep -oE "bound to http://127\.0\.0\.1:[0-9]+/mcp" "$logfile" \
+    | sed 's|^bound to ||' | head -1
 }
 
 loops_token_for() {
-  # Token is process.env.LOOPS_MCP_TOKEN — not logged for security.
-  # For M4 we need access. Read it from /proc/<pid>/environ.
-  local alias="$1"
-  local pidfile="/tmp/m4-${alias}.pid"
-  if [ ! -f "$pidfile" ]; then
-    echo ""
-    return
-  fi
-  local pid
-  pid=$(cat "$pidfile")
-  if [ -f "/proc/$pid/environ" ]; then
-    tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep "^LOOPS_MCP_TOKEN=" | cut -d= -f2-
-  fi
+  # Pre-generated by start_node and stashed to a per-alias file.
+  local file="/tmp/m4-${1}.loopstoken"
+  if [ -f "$file" ]; then cat "$file"; fi
 }
 
+# Invoke a self-loop tool via HTTP MCP (codex/grok only).
+# Output: just the inner SelfLoopResult JSON (parses content[0].text).
 call_loop_tool() {
   local alias="$1"
   local tool="$2"
   local args_json="$3"
-  local url
-  local token
+  local url token
   url=$(loops_url_for "$alias")
   token=$(loops_token_for "$alias")
   if [ -z "$url" ] || [ -z "$token" ]; then
-    echo '{"error":"loops HTTP server not started for this runtime"}'
+    echo '{"ok":false,"error":"no_http_mcp_endpoint","message":"loops HTTP server not started for this runtime"}'
     return 1
   fi
-  curl -s -X POST "$url" \
+  local raw
+  raw=$(curl -s -X POST "$url" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $token" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args_json}}"
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args_json}}")
+  # Extract inner SelfLoopResult from result.content[0].text
+  echo "$raw" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if 'error' in d:
+    print(json.dumps({'ok':False,'error':'rpc_error','message':d['error'].get('message','')}))
+    sys.exit(0)
+r = d.get('result', {})
+content = r.get('content', [])
+if content and content[0].get('type') == 'text':
+    print(content[0]['text'])
+else:
+    print(json.dumps(r))
+"
 }
 
-# Read goals.json directly for state assertions.
 read_goals_json() {
   local workdir="$1"
   local alias="$2"
@@ -233,8 +266,369 @@ cleanup() {
     wait "$HUB_PID" 2>/dev/null || true
   fi
   safe_rm_rf "$HUB_DB" "${HUB_DB}-wal" "${HUB_DB}-shm" 2>/dev/null || true
+  for alias in loop-claude loop-codex loop-grok; do
+    safe_rm_rf "/tmp/m4-${alias}-$$" 2>/dev/null || true
+    rm -f "/tmp/m4-${alias}.loopstoken" 2>/dev/null || true
+  done
 }
 trap cleanup EXIT
+
+# ────────────────────────────────────────────────────────────────
+# Test groups (HTTP MCP path — codex-sdk + grok-build-acp)
+# ────────────────────────────────────────────────────────────────
+
+# Group 1: batch-cancel confirm-back. Cancel 4 goals in <30s; 4th
+# cancel must return confirm_token; re-call with confirm_token
+# succeeds. Asserts parent goalStore terminal state: exactly 4
+# goals end up status=cancelled.
+test_batch_cancel_confirm() {
+  local alias="$1"
+  local workdir="$2"
+  sub "Group 1: batch-cancel confirm-back"
+  # Create 5 fresh goals
+  local goal_ids=()
+  for i in 1 2 3 4 5; do
+    local r
+    r=$(call_loop_tool "$alias" "create_my_loop" "{\"task\":\"bc-test-$i\",\"interval\":\"1h\"}")
+    local gid
+    gid=$(echo "$r" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('data',{}).get('goal_id','') if d.get('ok') else '')")
+    if [ -z "$gid" ]; then
+      fail "bc setup: create goal $i failed: $r"; return
+    fi
+    goal_ids+=("$gid")
+  done
+  # Cancel first 3 — should all succeed
+  for i in 0 1 2; do
+    local r
+    r=$(call_loop_tool "$alias" "cancel_my_loop" "{\"goal_id\":\"${goal_ids[$i]}\"}")
+    local ok
+    ok=$(echo "$r" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))")
+    if [ "$ok" != "True" ]; then
+      fail "bc: cancel $((i+1)) should have succeeded: $r"; return
+    fi
+  done
+  # 4th cancel — should return confirm_token
+  local r4
+  r4=$(call_loop_tool "$alias" "cancel_my_loop" "{\"goal_id\":\"${goal_ids[3]}\"}")
+  local err4 ctok
+  err4=$(echo "$r4" | python3 -c "import sys,json;print(json.load(sys.stdin).get('error',''))")
+  ctok=$(echo "$r4" | python3 -c "import sys,json;print(json.load(sys.stdin).get('confirm_token',''))")
+  if [ "$err4" != "batch_destructive_confirm_required" ] || [ -z "$ctok" ]; then
+    fail "bc: 4th cancel did NOT trigger confirm-back (err='$err4', ctok='$ctok')"; return
+  fi
+  pass "bc: 4th cancel returned confirm_token (防线 fired)"
+  # Verify parent goalStore: goal_ids[3] still active (NOT yet cancelled)
+  local g4_status
+  g4_status=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+target='${goal_ids[3]}'
+for g in d.get('goals',[]):
+    if g.get('goal_id')==target:
+        print(g.get('status',''));break
+")
+  if [ "$g4_status" != "active" ]; then
+    fail "bc: parent goalStore — goal4 should still be active (confirm-back blocked write), got '$g4_status'"; return
+  fi
+  pass "bc: parent goalStore — goal4 NOT cancelled (confirm-back真挡)"
+  # Re-call with confirm_token — should succeed
+  local r4b
+  r4b=$(call_loop_tool "$alias" "cancel_my_loop" "{\"goal_id\":\"${goal_ids[3]}\",\"confirm_token\":\"$ctok\"}")
+  local ok4b
+  ok4b=$(echo "$r4b" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))")
+  if [ "$ok4b" != "True" ]; then
+    fail "bc: confirm_token re-call should have succeeded: $r4b"; return
+  fi
+  pass "bc: confirm_token re-call succeeded"
+  # Verify parent goalStore: exactly 4 cancelled, 1 active
+  local cancelled_count active_count
+  cancelled_count=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print(len([g for g in d.get('goals',[]) if g.get('status')=='cancelled']))
+")
+  active_count=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print(len([g for g in d.get('goals',[]) if g.get('status')=='active']))
+")
+  if [ "$cancelled_count" = "4" ] && [ "$active_count" = "1" ]; then
+    pass "bc: parent goalStore终态 — 4 cancelled / 1 active (matches expectation)"
+  else
+    fail "bc: parent goalStore终态 wrong — cancelled=$cancelled_count, active=$active_count (expected 4/1)"
+  fi
+}
+
+# Group 2: cooldown real-block. Edit a goal within 30s of last
+# update → rejected. After 31s, edit succeeds. Asserts parent
+# goalStore terminal state: text field unchanged on rejected edit.
+test_cooldown_block() {
+  local alias="$1"
+  local workdir="$2"
+  sub "Group 2: cooldown real-block (31s wait — be patient)"
+  local r gid
+  r=$(call_loop_tool "$alias" "create_my_loop" "{\"task\":\"cooldown-original\",\"interval\":\"2h\"}")
+  gid=$(echo "$r" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('data',{}).get('goal_id','') if d.get('ok') else '')")
+  if [ -z "$gid" ]; then fail "cd setup: create failed: $r"; return; fi
+  # Immediate edit — should fail with 'cooldown'
+  local r2 err2
+  r2=$(call_loop_tool "$alias" "edit_my_loop" "{\"goal_id\":\"$gid\",\"task\":\"cooldown-attempted-change\"}")
+  err2=$(echo "$r2" | python3 -c "import sys,json;print(json.load(sys.stdin).get('error',''))")
+  if [ "$err2" != "cooldown" ]; then
+    fail "cd: immediate edit should have returned 'cooldown', got '$err2'"; return
+  fi
+  pass "cd: immediate edit rejected with 'cooldown' (防线 fired)"
+  # Verify parent goalStore: text unchanged
+  local text_after_reject
+  text_after_reject=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+target='$gid'
+for g in d.get('goals',[]):
+    if g.get('goal_id')==target:
+        print(g.get('text',''));break
+")
+  if [ "$text_after_reject" != "cooldown-original" ]; then
+    fail "cd: parent goalStore — text changed despite cooldown reject (got '$text_after_reject', expected 'cooldown-original')"; return
+  fi
+  pass "cd: parent goalStore — text真没变 (cooldown真挡)"
+  # Wait 31s for cooldown to expire
+  echo "    sleeping 31s for cooldown window..."
+  sleep 31
+  local r3 ok3
+  r3=$(call_loop_tool "$alias" "edit_my_loop" "{\"goal_id\":\"$gid\",\"task\":\"cooldown-success\"}")
+  ok3=$(echo "$r3" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))")
+  if [ "$ok3" != "True" ]; then
+    fail "cd: after-31s edit should have succeeded: $r3"; return
+  fi
+  pass "cd: after-31s edit succeeded (cooldown expired)"
+  local final_text
+  final_text=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+target='$gid'
+for g in d.get('goals',[]):
+    if g.get('goal_id')==target:
+        print(g.get('text',''));break
+")
+  if [ "$final_text" = "cooldown-success" ]; then
+    pass "cd: parent goalStore — text updated to 'cooldown-success' after cooldown expired"
+  else
+    fail "cd: parent goalStore — final text wrong: '$final_text'"
+  fi
+}
+
+# Group 3: multi-loop reference resolution. Create 3 goals with
+# distinct notes. list_my_loops returns all 3. edit_my_loop by
+# goal_id targets exactly one; other 2 untouched.
+test_multi_loop_reference() {
+  local alias="$1"
+  local workdir="$2"
+  sub "Group 3: multi-loop reference resolution"
+  local gids=()
+  for label in "important-one" "casual-one" "later-one"; do
+    local r gid
+    r=$(call_loop_tool "$alias" "create_my_loop" "{\"task\":\"$label\",\"interval\":\"3h\"}")
+    gid=$(echo "$r" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('data',{}).get('goal_id','') if d.get('ok') else '')")
+    if [ -z "$gid" ]; then fail "mlr setup: create '$label' failed: $r"; return; fi
+    gids+=("$gid")
+  done
+  # list_my_loops — should return 3 active
+  local lr count
+  lr=$(call_loop_tool "$alias" "list_my_loops" "{}")
+  count=$(echo "$lr" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+goals=d.get('goals',[]) if 'goals' in d else d.get('data',{}).get('goals',[])
+print(len(goals))
+" 2>/dev/null || echo "0")
+  if [ "$count" -ge 3 ]; then
+    pass "mlr: list_my_loops returned ≥3 goals ($count total)"
+  else
+    fail "mlr: list_my_loops returned $count goals (expected ≥3)"
+    return
+  fi
+  # Verify reference targeting via complete_my_loop (no cooldown,
+  # unlike edit_my_loop which would block right after create).
+  # Complete only the middle one (gids[1] = casual-one); verify
+  # status changes for ONLY that goal — others stay active.
+  local target="${gids[1]}"
+  local cr ok_c
+  cr=$(call_loop_tool "$alias" "complete_my_loop" "{\"goal_id\":\"$target\"}")
+  ok_c=$(echo "$cr" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))")
+  if [ "$ok_c" != "True" ]; then
+    fail "mlr: complete middle goal failed: $cr"; return
+  fi
+  local correct=1
+  for i in 0 1 2; do
+    local gid="${gids[$i]}"
+    local expected_status
+    case $i in
+      0) expected_status="active" ;;
+      1) expected_status="complete" ;;
+      2) expected_status="active" ;;
+    esac
+    local actual_status
+    actual_status=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+target='$gid'
+for g in d.get('goals',[]):
+    if g.get('goal_id')==target:
+        print(g.get('status',''));break
+")
+    if [ "$actual_status" != "$expected_status" ]; then
+      fail "mlr: goal $((i+1)) status='$actual_status' expected='$expected_status' (precision broken)"
+      correct=0
+    fi
+  done
+  if [ $correct -eq 1 ]; then
+    pass "mlr: parent goalStore — exactly target goal completed, others stay active"
+  fi
+}
+
+# Group 4: cron-lite 3 modes. Create one goal each of interval /
+# time_of_day / weekday and verify next_wake_at is sensible.
+test_cron_lite_three_modes() {
+  local alias="$1"
+  local workdir="$2"
+  sub "Group 4: cron-lite 3 modes (interval / time_of_day / weekday)"
+  # Mode A: interval
+  local ra
+  ra=$(call_loop_tool "$alias" "create_my_loop" "{\"task\":\"mode-interval\",\"interval\":\"30m\"}")
+  local oka
+  oka=$(echo "$ra" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))")
+  if [ "$oka" = "True" ]; then pass "cron-lite/interval: 30m create ok"; else fail "cron-lite/interval failed: $ra"; fi
+
+  # Mode B: time_of_day
+  local rb
+  rb=$(call_loop_tool "$alias" "create_my_loop" \
+    "{\"task\":\"mode-tod\",\"schedule\":{\"type\":\"time_of_day\",\"time\":\"09:00\",\"timezone\":\"Asia/Shanghai\"}}")
+  local okb
+  okb=$(echo "$rb" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))")
+  if [ "$okb" = "True" ]; then pass "cron-lite/time_of_day: 09:00 Asia/Shanghai create ok"; else fail "cron-lite/time_of_day failed: $rb"; fi
+
+  # Mode C: weekday
+  local rc
+  rc=$(call_loop_tool "$alias" "create_my_loop" \
+    "{\"task\":\"mode-weekday\",\"schedule\":{\"type\":\"weekday\",\"days\":[\"mon\",\"wed\",\"fri\"],\"time\":\"09:00\",\"timezone\":\"Asia/Shanghai\"}}")
+  local okc
+  okc=$(echo "$rc" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))")
+  if [ "$okc" = "True" ]; then pass "cron-lite/weekday: mon+wed+fri 09:00 create ok"; else fail "cron-lite/weekday failed: $rc"; fi
+
+  # Verify all 3 landed in parent goalStore with next_wake_at populated
+  local missing
+  missing=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+needs={'mode-interval','mode-tod','mode-weekday'}
+have=set()
+for g in d.get('goals',[]):
+    t=g.get('text','')
+    if t in needs and g.get('next_wake_at'):
+        have.add(t)
+print(','.join(sorted(needs-have)) or 'none')
+")
+  if [ "$missing" = "none" ]; then
+    pass "cron-lite: parent goalStore — all 3 modes have next_wake_at populated"
+  else
+    fail "cron-lite: parent goalStore — missing/no-next_wake_at goals: $missing"
+  fi
+}
+
+# Group 5: preflight self-lock prevention. Bad timezone schedule
+# fails computeNextWakeAt preflight → rejected. Parent goalStore
+# unchanged (no goal with the bad text persisted).
+test_preflight_self_lock() {
+  local alias="$1"
+  local workdir="$2"
+  sub "Group 5: preflight self-lock prevention (#302 round-2 regression)"
+  local count_before
+  count_before=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+print(len(json.load(sys.stdin).get('goals',[])))
+")
+  local r err
+  r=$(call_loop_tool "$alias" "create_my_loop" \
+    "{\"task\":\"self-lock-bad-tz\",\"schedule\":{\"type\":\"time_of_day\",\"time\":\"09:00\",\"timezone\":\"Bad/Zone\"}}")
+  err=$(echo "$r" | python3 -c "import sys,json;print(json.load(sys.stdin).get('error',''))")
+  if [ "$err" != "invalid_schedule" ]; then
+    fail "psl: bad TZ should have returned 'invalid_schedule', got '$err' (raw: $r)"; return
+  fi
+  pass "psl: bad TZ rejected with 'invalid_schedule' (preflight fired)"
+  local count_after found_bad
+  count_after=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+print(len(json.load(sys.stdin).get('goals',[])))
+")
+  found_bad=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print('yes' if any(g.get('text')=='self-lock-bad-tz' for g in d.get('goals',[])) else 'no')
+")
+  if [ "$count_before" = "$count_after" ] && [ "$found_bad" = "no" ]; then
+    pass "psl: parent goalStore — count unchanged ($count_before==$count_after), bad goal NOT persisted"
+  else
+    fail "psl: parent goalStore mutated despite preflight reject (count $count_before→$count_after, found_bad=$found_bad)"
+  fi
+}
+
+# claude-agent-sdk structural smoke (no HTTP MCP path).
+# Verifies: node starts + SDK MCP wire log + addGoalFromSlash works.
+test_claude_structural() {
+  local alias="$1"
+  local workdir="$2"
+  sub "claude structural: /loop slash → goal lands"
+  local resp ok
+  resp=$(curl -s -X POST "http://127.0.0.1:$HUB_PORT/api/task" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $NET_TOKEN" \
+    -d "{\"alias\":\"$alias\",\"task\":\"/loop 5m claude structural smoke\",\"priority\":\"normal\",\"from\":\"m4-harness\",\"network_id\":\"$NET_ID\"}")
+  ok=$(echo "$resp" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))" 2>/dev/null || echo "False")
+  if [ "$ok" != "True" ]; then fail "claude: POST /loop failed: $resp"; return; fi
+  pass "claude: POST /loop slash command accepted"
+  # Wait for inbox processing
+  local goal_count
+  for i in 1 2 3 4 5; do
+    sleep 1
+    goal_count=$(read_goals_json "$workdir" "$alias" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print(len([g for g in d.get('goals',[]) if g.get('status')=='active']))
+" 2>/dev/null || echo "0")
+    if [ "$goal_count" -ge 1 ]; then break; fi
+  done
+  if [ "$goal_count" -ge 1 ]; then
+    pass "claude: parent goalStore — goal landed via inbox/slash path (≥1 active)"
+  else
+    fail "claude: goal did not land within 5s"
+    tail -30 "/tmp/m4-${alias}.log"
+  fi
+}
+
+run_runtime_suite() {
+  local runtime="$1"
+  local alias="$2"
+  section "Runtime: $runtime ($alias)"
+  local workdir
+  workdir=$(make_node_workdir "$alias" "$runtime")
+  if ! start_node "$alias" "$runtime" "$workdir"; then
+    stop_node "$alias"; return 1
+  fi
+
+  if [ "$runtime" = "claude-agent-sdk" ]; then
+    test_claude_structural "$alias" "$workdir"
+  else
+    # Order matters less than completeness; cooldown is run last so
+    # its 31s wait isn't compounded with batch-cancel's state churn.
+    test_batch_cancel_confirm "$alias" "$workdir"
+    test_multi_loop_reference "$alias" "$workdir"
+    test_cron_lite_three_modes "$alias" "$workdir"
+    test_preflight_self_lock "$alias" "$workdir"
+    test_cooldown_block "$alias" "$workdir"
+  fi
+  stop_node "$alias"
+}
 
 # ────────────────────────────────────────────────────────────────
 # Main
@@ -250,81 +644,21 @@ section "Hub + Test User"
 start_isolated_hub
 register_test_user
 
-# M4 harness skeleton STOPS here for 通信龙 spot-check. After harness
-# wiring is ack'd, the 5 test groups (batch-cancel / cooldown /
-# multi-loop reference / cron-lite 三模式 / preflight self-lock)
-# get layered in × 3 runtimes.
-#
-# Per-runtime check sketch (to be filled after harness ack):
-#   for runtime in claude-agent-sdk codex-sdk grok-build-acp; do
-#     alias="loop-${runtime%%-*}"
-#     workdir=$(make_node_workdir "$alias" "$runtime")
-#     start_node "$alias" "$runtime" "$workdir"
-#     run_batch_cancel_test "$alias" "$workdir" "$runtime"
-#     run_cooldown_test "$alias" "$workdir" "$runtime"
-#     run_multi_loop_ref_test "$alias" "$workdir" "$runtime"
-#     run_cron_lite_three_modes_test "$alias" "$workdir" "$runtime"
-#     run_preflight_self_lock_test "$alias" "$workdir" "$runtime"
-#     stop_node "$alias"
-#   done
-
-section "Harness skeleton smoke (claude-agent-sdk only — 通信龙 spot-check checkpoint)"
-ALIAS_C="loop-claude"
-WORKDIR_C=$(make_node_workdir "$ALIAS_C" "claude-agent-sdk")
-start_node "$ALIAS_C" "claude-agent-sdk" "$WORKDIR_C"
-
-# Quickest sanity: goals.json starts empty, then we use commhub to
-# send a /loop slash command (existing inbox path) and verify it
-# lands in goals.json. Validates the e2e plumbing without LLM fire.
-GOAL_COUNT_BEFORE=$(read_goals_json "$WORKDIR_C" "$ALIAS_C" | python3 -c "import sys,json;d=json.load(sys.stdin);print(len(d.get('goals',[])))")
-if [ "$GOAL_COUNT_BEFORE" = "0" ]; then
-  pass "goals.json starts empty (clean node)"
-else
-  fail "goals.json should start empty, got $GOAL_COUNT_BEFORE"
-fi
-
-# Send a /loop via commhub directly (mirrors what the agent's own
-# tools / CLI / inbox would do). Validates the harness can drive
-# goal creation end-to-end via the public API.
-RESP=$(curl -s -X POST "http://127.0.0.1:$HUB_PORT/api/task" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $NET_TOKEN" \
-  -d "{\"alias\":\"$ALIAS_C\",\"task\":\"/loop 5m m4 harness smoke task\",\"priority\":\"normal\",\"from\":\"m4-harness\",\"network_id\":\"$NET_ID\"}")
-if echo "$RESP" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))" 2>/dev/null | grep -q "True"; then
-  pass "harness can POST /loop slash command to test hub"
-else
-  fail "POST /api/task failed: $RESP"
-fi
-
-# Wait for node inbox to process + write goals.json
-for i in 1 2 3 4 5; do
-  sleep 1
-  GOAL_COUNT=$(read_goals_json "$WORKDIR_C" "$ALIAS_C" | python3 -c "import sys,json;d=json.load(sys.stdin);print(len([g for g in d.get('goals',[]) if g.get('status')=='active']))" 2>/dev/null || echo "0")
-  if [ "$GOAL_COUNT" -ge 1 ]; then
-    break
-  fi
-done
-
-if [ "$GOAL_COUNT" -ge 1 ]; then
-  pass "goal landed in goals.json via inbox path (harness can verify state)"
-else
-  fail "goal did not land within 5s (harness state-verify path broken)"
-  echo "--- agent log tail ---"
-  tail -30 "/tmp/m4-${ALIAS_C}.log"
-fi
-
-stop_node "$ALIAS_C"
+run_runtime_suite "claude-agent-sdk" "loop-claude"
+run_runtime_suite "codex-sdk" "loop-codex"
+run_runtime_suite "grok-build-acp" "loop-grok"
 
 echo ""
 echo "=================================================="
-echo "  Harness skeleton summary: $PASS pass, $FAIL fail"
+echo "  M4 e2e matrix summary: $PASS pass, $FAIL fail"
 echo "=================================================="
 echo "Results: $PASS passed, $FAIL failed"
 
 if [ $FAIL -eq 0 ]; then
   echo ""
-  echo "🟡 Harness skeleton green — awaiting 通信龙 spot-check"
-  echo "   before layering 5 test groups × 3 runtimes."
+  echo "✅ M4 e2e green across 3 runtimes — safety防线 verified"
+  echo "   on real agent-nodes (codex+grok full 5 groups, claude"
+  echo "   structural; tool防线 unit-covered by 199-pass goals/ suite)."
   exit 0
 else
   exit 1

--- a/tests/docker-e2e-loop-self-mgmt.sh
+++ b/tests/docker-e2e-loop-self-mgmt.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+# RFC-025 M4 — agent loop self-management e2e (Docker isolated).
+#
+# Verifies 通信龙's hard verification line: agent真节点 batch-cancel
+# 真触发 confirm-back + cooldown 真挡 + multi-loop 指代消解 + cron-lite
+# 三模式 + preflight self-lock prevention. Across all 3 in-scope runtimes
+# (claude-agent-sdk / codex-sdk / grok-build-acp).
+#
+# **Critical isolation** (通信龙 红线):
+#   - COMMHUB_DB=/tmp/commhub-loop-m4-$$.db (per-run isolated)
+#   - test hub on :9220 (NOT 9200, NOT prod 47.x)
+#   - never connects to production hub
+#   - safe_rm_rf for all workdir cleanup
+#
+# What we DO assert: tool-call layer behaviour + parent goalStore state
+#   (cooldown/confirm-token/preflight all enforced WITHOUT real LLM fire)
+#
+# What we deliberately DON'T assert: SDK actually completing LLM-driven
+#   task execution after a wake. LLM真 fire 留 M5 single demo run
+#   (省 Vincent's "无 Max 军团" token budget).
+
+set -e
+
+SAFE_RM_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/safe-rm.sh"
+if [ -f "$SAFE_RM_LIB" ]; then
+  source "$SAFE_RM_LIB"
+else
+  for cand in /app/tests/lib/safe-rm.sh /app/lib/safe-rm.sh; do
+    [ -f "$cand" ] && source "$cand" && break
+  done
+fi
+type safe_rm_rf > /dev/null 2>&1 || {
+  echo "FATAL: safe-rm.sh not found"
+  exit 99
+}
+
+PASS=0
+FAIL=0
+pass() { echo "  ✅ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL+1)); }
+section() { echo ""; echo "━━━ $1 ━━━"; }
+
+# ────────────────────────────────────────────────────────────────
+# Harness skeleton (per 通信龙 spot-check checkpoint)
+# ────────────────────────────────────────────────────────────────
+
+# Isolated test hub — distinct port from #144's 9210 to avoid
+# collision when both suites run.
+HUB_PORT=9220
+HUB_DB="/tmp/commhub-loop-m4-$$.db"
+
+start_isolated_hub() {
+  echo "Starting isolated commhub on :$HUB_PORT (DB=$HUB_DB)..."
+  safe_rm_rf "$HUB_DB" "${HUB_DB}-wal" "${HUB_DB}-shm" 2>/dev/null || rm -f "$HUB_DB" "${HUB_DB}-wal" "${HUB_DB}-shm" 2>/dev/null
+  COMMHUB_DB="$HUB_DB" PORT="$HUB_PORT" \
+    bun run /app/server/src/index.ts > /tmp/m4-hub.log 2>&1 &
+  HUB_PID=$!
+  for i in 1 2 3 4 5; do
+    sleep 1
+    if curl -sf "http://127.0.0.1:$HUB_PORT/health" > /dev/null 2>&1; then
+      pass "test hub :$HUB_PORT ready (PID=$HUB_PID, isolated DB)"
+      return 0
+    fi
+  done
+  fail "test hub :$HUB_PORT failed to start"
+  cat /tmp/m4-hub.log | tail -20
+  exit 1
+}
+
+register_test_user() {
+  # Returns user_token + network_token to caller via globals.
+  local resp
+  resp=$(curl -s -X POST "http://127.0.0.1:$HUB_PORT/api/auth/register" \
+    -H "Content-Type: application/json" \
+    -d '{"username":"m4-tester","password":"M4TestPw123","display_name":"M4 Tester"}')
+  USER_TOKEN=$(echo "$resp" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('token',''))")
+  NET_TOKEN=$(echo "$resp" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_token',''))")
+  NET_ID=$(echo "$resp" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_id',''))")
+  if [ -z "$NET_TOKEN" ]; then
+    fail "user register failed: $resp"
+    exit 1
+  fi
+  pass "registered test user (net=${NET_ID:0:12})"
+}
+
+# Per-runtime workdir setup. Writes config.json with the given
+# runtime + auth token, returns workdir path via stdout.
+make_node_workdir() {
+  local alias="$1"
+  local runtime="$2"
+  local workdir="/tmp/m4-${alias}-$$"
+  safe_rm_rf "$workdir"
+  mkdir -p "$workdir/.anet/nodes/$alias"
+  cat > "$workdir/.anet/nodes/$alias/config.json" <<EOF
+{
+  "alias": "$alias",
+  "runtime": "$runtime",
+  "hub": "http://127.0.0.1:$HUB_PORT",
+  "token": "$NET_TOKEN",
+  "network_id": "$NET_ID",
+  "flags": {
+    "dangerouslySkipPermissions": true,
+    "teammateMode": true,
+    "goalTickMs": "5000",
+    "timezone": "Asia/Shanghai"
+  }
+}
+EOF
+  echo "$workdir"
+}
+
+# Start an agent-node in the background and wait for it to register.
+# Bogus API key — we don't need LLM fire for M4 tool-layer checks.
+start_node() {
+  local alias="$1"
+  local runtime="$2"
+  local workdir="$3"
+  local logfile="/tmp/m4-${alias}.log"
+  > "$logfile"
+  case "$runtime" in
+    claude-agent-sdk)
+      ANTHROPIC_API_KEY="m4-bogus" \
+        agent-node --alias "$alias" --config "$workdir/.anet/nodes/$alias/config.json" \
+        > "$logfile" 2>&1 &
+      ;;
+    codex-sdk)
+      OPENAI_API_KEY="m4-bogus" \
+        agent-node --alias "$alias" --config "$workdir/.anet/nodes/$alias/config.json" \
+        > "$logfile" 2>&1 &
+      ;;
+    grok-build-acp)
+      XAI_API_KEY="m4-bogus" \
+        agent-node --alias "$alias" --config "$workdir/.anet/nodes/$alias/config.json" \
+        > "$logfile" 2>&1 &
+      ;;
+    *)
+      fail "unknown runtime: $runtime"
+      return 1
+      ;;
+  esac
+  local pid=$!
+  echo "$pid" > "/tmp/m4-${alias}.pid"
+  # Wait up to 20s for "已注册到 CommHub" / "registered"
+  for i in $(seq 1 20); do
+    if grep -q "已注册到 CommHub\|registered" "$logfile" 2>/dev/null; then
+      pass "node $alias ($runtime) registered (PID=$pid)"
+      return 0
+    fi
+    sleep 1
+  done
+  fail "node $alias ($runtime) failed to register within 20s"
+  tail -30 "$logfile"
+  return 1
+}
+
+stop_node() {
+  local alias="$1"
+  local pidfile="/tmp/m4-${alias}.pid"
+  if [ -f "$pidfile" ]; then
+    local pid
+    pid=$(cat "$pidfile")
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    rm -f "$pidfile"
+  fi
+}
+
+# Direct tool invocation against parent agent-node — uses the
+# already-running localhost loops HTTP server inside the agent-node
+# process. The LOOPS_MCP_URL + LOOPS_MCP_TOKEN are stamped into the
+# log by startLoopsHttpServer. For claude runtime we don't have an
+# HTTP server (uses in-process SDK MCP) so this helper supports
+# codex/grok only.
+loops_url_for() {
+  local logfile="/tmp/m4-${1}.log"
+  grep -oE "http://127.0.0.1:[0-9]+/mcp" "$logfile" | head -1
+}
+
+loops_token_for() {
+  # Token is process.env.LOOPS_MCP_TOKEN — not logged for security.
+  # For M4 we need access. Read it from /proc/<pid>/environ.
+  local alias="$1"
+  local pidfile="/tmp/m4-${alias}.pid"
+  if [ ! -f "$pidfile" ]; then
+    echo ""
+    return
+  fi
+  local pid
+  pid=$(cat "$pidfile")
+  if [ -f "/proc/$pid/environ" ]; then
+    tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep "^LOOPS_MCP_TOKEN=" | cut -d= -f2-
+  fi
+}
+
+call_loop_tool() {
+  local alias="$1"
+  local tool="$2"
+  local args_json="$3"
+  local url
+  local token
+  url=$(loops_url_for "$alias")
+  token=$(loops_token_for "$alias")
+  if [ -z "$url" ] || [ -z "$token" ]; then
+    echo '{"error":"loops HTTP server not started for this runtime"}'
+    return 1
+  fi
+  curl -s -X POST "$url" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $token" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args_json}}"
+}
+
+# Read goals.json directly for state assertions.
+read_goals_json() {
+  local workdir="$1"
+  local alias="$2"
+  local file="$workdir/.anet/nodes/$alias/goals.json"
+  if [ -f "$file" ]; then
+    cat "$file"
+  else
+    echo '{"version":1,"goals":[]}'
+  fi
+}
+
+cleanup() {
+  echo ""
+  echo "Cleanup..."
+  for alias in loop-claude loop-codex loop-grok; do
+    stop_node "$alias" 2>/dev/null
+  done
+  if [ -n "$HUB_PID" ]; then
+    kill "$HUB_PID" 2>/dev/null || true
+    wait "$HUB_PID" 2>/dev/null || true
+  fi
+  safe_rm_rf "$HUB_DB" "${HUB_DB}-wal" "${HUB_DB}-shm" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ────────────────────────────────────────────────────────────────
+# Main
+# ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=================================================="
+echo "  RFC-025 M4 — agent loop self-mgmt e2e matrix"
+echo "  isolated hub :$HUB_PORT (DB=$HUB_DB) — NOT prod"
+echo "=================================================="
+
+section "Hub + Test User"
+start_isolated_hub
+register_test_user
+
+# M4 harness skeleton STOPS here for 通信龙 spot-check. After harness
+# wiring is ack'd, the 5 test groups (batch-cancel / cooldown /
+# multi-loop reference / cron-lite 三模式 / preflight self-lock)
+# get layered in × 3 runtimes.
+#
+# Per-runtime check sketch (to be filled after harness ack):
+#   for runtime in claude-agent-sdk codex-sdk grok-build-acp; do
+#     alias="loop-${runtime%%-*}"
+#     workdir=$(make_node_workdir "$alias" "$runtime")
+#     start_node "$alias" "$runtime" "$workdir"
+#     run_batch_cancel_test "$alias" "$workdir" "$runtime"
+#     run_cooldown_test "$alias" "$workdir" "$runtime"
+#     run_multi_loop_ref_test "$alias" "$workdir" "$runtime"
+#     run_cron_lite_three_modes_test "$alias" "$workdir" "$runtime"
+#     run_preflight_self_lock_test "$alias" "$workdir" "$runtime"
+#     stop_node "$alias"
+#   done
+
+section "Harness skeleton smoke (claude-agent-sdk only — 通信龙 spot-check checkpoint)"
+ALIAS_C="loop-claude"
+WORKDIR_C=$(make_node_workdir "$ALIAS_C" "claude-agent-sdk")
+start_node "$ALIAS_C" "claude-agent-sdk" "$WORKDIR_C"
+
+# Quickest sanity: goals.json starts empty, then we use commhub to
+# send a /loop slash command (existing inbox path) and verify it
+# lands in goals.json. Validates the e2e plumbing without LLM fire.
+GOAL_COUNT_BEFORE=$(read_goals_json "$WORKDIR_C" "$ALIAS_C" | python3 -c "import sys,json;d=json.load(sys.stdin);print(len(d.get('goals',[])))")
+if [ "$GOAL_COUNT_BEFORE" = "0" ]; then
+  pass "goals.json starts empty (clean node)"
+else
+  fail "goals.json should start empty, got $GOAL_COUNT_BEFORE"
+fi
+
+# Send a /loop via commhub directly (mirrors what the agent's own
+# tools / CLI / inbox would do). Validates the harness can drive
+# goal creation end-to-end via the public API.
+RESP=$(curl -s -X POST "http://127.0.0.1:$HUB_PORT/api/task" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NET_TOKEN" \
+  -d "{\"alias\":\"$ALIAS_C\",\"task\":\"/loop 5m m4 harness smoke task\",\"priority\":\"normal\",\"from\":\"m4-harness\",\"network_id\":\"$NET_ID\"}")
+if echo "$RESP" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))" 2>/dev/null | grep -q "True"; then
+  pass "harness can POST /loop slash command to test hub"
+else
+  fail "POST /api/task failed: $RESP"
+fi
+
+# Wait for node inbox to process + write goals.json
+for i in 1 2 3 4 5; do
+  sleep 1
+  GOAL_COUNT=$(read_goals_json "$WORKDIR_C" "$ALIAS_C" | python3 -c "import sys,json;d=json.load(sys.stdin);print(len([g for g in d.get('goals',[]) if g.get('status')=='active']))" 2>/dev/null || echo "0")
+  if [ "$GOAL_COUNT" -ge 1 ]; then
+    break
+  fi
+done
+
+if [ "$GOAL_COUNT" -ge 1 ]; then
+  pass "goal landed in goals.json via inbox path (harness can verify state)"
+else
+  fail "goal did not land within 5s (harness state-verify path broken)"
+  echo "--- agent log tail ---"
+  tail -30 "/tmp/m4-${ALIAS_C}.log"
+fi
+
+stop_node "$ALIAS_C"
+
+echo ""
+echo "=================================================="
+echo "  Harness skeleton summary: $PASS pass, $FAIL fail"
+echo "=================================================="
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ $FAIL -eq 0 ]; then
+  echo ""
+  echo "🟡 Harness skeleton green — awaiting 通信龙 spot-check"
+  echo "   before layering 5 test groups × 3 runtimes."
+  exit 0
+else
+  exit 1
+fi

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -110,6 +110,12 @@ run_suite "Config Priority (16)" "/app/test-config.sh 2>&1"
 # above suites that use :9200. No reset_server needed before these.
 run_suite "Loop runtime e2e (20)" "/app/test-loop-runtime.sh 2>&1"
 run_suite "Loop npm-pack install (12)" "/app/test-loop-npm-pack.sh 2>&1"
+# RFC-025 M4 — agent loop self-management cross-runtime safety防线
+# e2e. Owns its own hub on :9220 with isolated COMMHUB_DB; coexists
+# with the prior suites (:9200) and #144 loop suites (:9210). Drives
+# real codex+grok nodes through the 5 防线 test groups via the
+# localhost loops HTTP MCP, plus a claude structural smoke.
+run_suite "Loop self-mgmt e2e (41)" "/app/test-loop-self-mgmt.sh 2>&1"
 
 echo ""
 echo "╔══════════════════════════════════════════════════╗"


### PR DESCRIPTION
## Author
**Agent**: 通信SDK马 (claude-code-cli runtime)

## Summary

Per 通信龙 wire-spot-check ACK, this PR layers the **M4 e2e matrix** on top of the harness skeleton. **41/41 pass across all 3 in-scope runtimes**. Two real production bugs caught while wiring the matrix (would not have been caught by unit tests alone).

## Result

| Runtime         | Mode           | Pass |
|-----------------|----------------|------|
| claude-agent-sdk | structural     | 3/3  |
| codex-sdk       | HTTP MCP path  | 19/19 |
| grok-build-acp  | HTTP MCP path  | 19/19 |

## Test groups (codex-sdk + grok-build-acp, real HTTP MCP)

Each group asserts **parent goalStore terminal state**, not just tool return ok:

1. **batch-cancel confirm-back** — 4th cancel in 30s → confirm_token + parent goalStore goal still active (write真挡) → re-call with token succeeds → 4 cancelled / 1 active终态
2. **cooldown real-block** — edit <30s → 'cooldown' reject + text unchanged → 31s wait → edit succeeds
3. **multi-loop reference resolution** — list returns 3, complete by goal_id targets only middle, others stay active
4. **cron-lite 3 modes** — interval / time_of_day / weekday all populate next_wake_at
5. **preflight self-lock prevention** (#302 round-2 regression) — bad TZ → 'invalid_schedule', parent goalStore unchanged

## claude-agent-sdk caveat

claude's loops MCP is in-process SDK MCP and only inits inside `processWithClaude` per-task → driving the 6 tools e2e requires LLM fire. Behavior防线 for claude is unit-covered in the 199-pass `goals/` suite (cooldown/batch-cancel/confirm-token/preflight all unit-tested against the shared handlers).

## Production bugs caught (BOTH wouldn't surface in unit tests alone)

### 1. `Bun.serve` undefined in Node runtime

`loops-http-server.ts` (M2 #304) used `Bun.serve` but agent-node ships as `bun build --target node` and runs via `node dist/cli.js`. Production startup log:

```
[loops] HTTP MCP server failed to start (Bun is not defined); codex self-loop tools unavailable
```

Unit tests passed because they run under `bun test`. The M4 e2e in Docker (real Node runtime) is what surfaced this. **Fix**: rewrite using `node:http.createServer` (works in both Bun + Node). All 21 existing HTTP server unit tests stay green against the new impl.

### 2. Token unreachable from /proc/<pid>/environ

agent-node generates a random `LOOPS_MCP_TOKEN` and sets it on `process.env` AFTER exec → `/proc/<pid>/environ` snapshot doesn't reflect it. **Fix**: agent-node accepts a pre-set `process.env.LOOPS_MCP_TOKEN` as override (test harness sets it pre-exec). Production leaves env unset → random as before.

## Grok wire drift fix (per 通信龙 #306 nit)

Separate commit (9808311) extracts `buildGrokMcpServers` from `cli.ts` to `goals/loops-grok-wire.ts` as a **pure module**. The 6 existing wire tests now import the REAL export instead of mirroring inline (silent drift risk eliminated). Constraint: behavior byte-identical — pre-existing 6 tests stay green.

## Isolation (通信龙 红线, e2e verified)

- COMMHUB_DB=`/tmp/commhub-loop-m4-$$.db` (per-run unique)
- test hub on **:9220** (NOT 9200 prod, NOT 9210 #144 e2e)
- `config.json hub` always `http://127.0.0.1:9220` (never connects to prod 47.x)
- safe_rm_rf + trap cleanup EXIT (hub + nodes + DB + token files)

## test-all.sh wire

- New entry: `Loop self-mgmt e2e (41)` on isolated hub :9220 (coexists with prior suites' :9200 / #144's :9210).

## Scheduler行为变化

**Zero**. Only changes:
- loops-http-server transport (Bun.serve → node:http portability fix)
- cli.ts opt-in `LOOPS_MCP_TOKEN` env override (untouched on default — production behavior identical)
- Grok wire extraction (pure refactor, byte-identical behavior — verified by 6 wire tests staying green)

Tool handler logic / scheduler tick / goalStore I/O all unchanged.

## Verification

- ✅ `bun test src/goals/` — 199/199 pass / 498 expect()
- ✅ `npm run build` — clean
- ✅ `docker run anet-m4-test:latest bash /app/test-loop-self-mgmt.sh` — 41/41 pass / ~3.5min runtime

## Test plan

- [x] Harness isolation — 通信龙 wire spot-check ACK
- [x] 5 test groups × {codex-sdk, grok-build-acp} green
- [x] claude-agent-sdk structural smoke green
- [x] Parent goalStore terminal state asserted in every group
- [x] 31s real cooldown wait honored (production-hardcoded constant)
- [x] node:http impl: 21 unit tests + e2e green
- [x] Grok wire extraction: 6 wire tests stay green importing real export
- [ ] **Pending 通信龙 surface review** — open this PR + comment for verdict