### PR TITLE
fix(#301): minimalEnv prepends dirname(process.execPath) for nvm-style installs

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -220,21 +220,51 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
 });
 
 describe("minimalEnv defensive compose (BLOCKER #1+#2 lineage — kept stable)", () => {
-  test("happy path: no extra → fixed PATH/HOME/LANG only", () => {
+  test("happy path: no extra → PATH includes daemon's own node bin dir + SAFE_PATH (issue #301 nvm fix)", () => {
     const env = minimalEnv();
-    expect(env.PATH).toBe("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin");
+    // PATH now starts with daemon's process.execPath dirname so spawned
+    // children's `#!/usr/bin/env node` shebang can find node under nvm /
+    // pnpm / Bun installs. SAFE_PATH follows; if execDir is already a
+    // canonical SAFE_PATH entry (e.g. /usr/local/bin), no duplicate.
+    const SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+    const execDir = require("node:path").dirname(process.execPath);
+    if (SAFE_PATH.split(":").includes(execDir)) {
+      expect(env.PATH).toBe(SAFE_PATH);
+    } else {
+      expect(env.PATH).toBe(`${execDir}:${SAFE_PATH}`);
+      // Critically: execDir is FIRST so spawned child's env node resolves
+      // to daemon's own node (anti shebang-fail in nvm context).
+      expect(env.PATH!.startsWith(execDir)).toBe(true);
+    }
     expect(env.HOME).toBeDefined();
     expect(env.LANG).toBeDefined();
   });
-  test("legitimate extra key passes + fixed keys still last", () => {
+  test("legitimate extra key passes + fixed PATH keeps execPath prepend (issue #301)", () => {
     const env = minimalEnv({ ANTHROPIC_API_KEY: "x" });
     expect(env.ANTHROPIC_API_KEY).toBe("x");
-    expect(env.PATH).toBe("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin");
+    // PATH still includes SAFE_PATH segment
+    expect(env.PATH).toContain("/usr/local/bin");
+    expect(env.PATH).toContain("/usr/bin");
   });
   test("THROWS on reserved key in extra (LD_PRELOAD smuggled by attacker)", () => {
     expect(() => minimalEnv({ LD_PRELOAD: "/tmp/evil.so" })).toThrow(/reserved env key/);
   });
-  test("THROWS on fixed key in extra (PATH smuggled)", () => {
+  test("THROWS on fixed key in extra (PATH smuggled — caller cannot override the trust-root execPath prepend)", () => {
     expect(() => minimalEnv({ PATH: "/tmp/evil-bin" })).toThrow(/reserved env key|fixed env key/);
+  });
+  test("C1 invariant — issue #301 fix does NOT widen attacker surface: PATH source is process.execPath (daemon's already-resolved node), NOT env.PATH (attacker C1 surface)", () => {
+    // We do NOT read process.env.PATH; we use process.execPath.
+    // Sanity proof: read the source file, confirm no env.PATH reference
+    // in computeChildPath / minimalEnv code path.
+    const src = require("node:fs").readFileSync(
+      require("node:path").join(__dirname, "create-node-daemon.ts"), "utf-8",
+    );
+    // Extract computeChildPath function body
+    const m = src.match(/function computeChildPath\(\)[\s\S]+?\n\}/);
+    expect(m).toBeTruthy();
+    if (m) {
+      expect(m[0]).toContain("process.execPath");
+      expect(m[0]).not.toMatch(/process\.env\.PATH/);   // explicit anti-C1 invariant
+    }
   });
 });

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -106,8 +106,32 @@ export function getAnetBinAbs(): string {
 export function _resetAnetBinAbsForTest(): void { _anetBinAbs = null; }
 
 // ── §4.2.6 B1 — minimalEnv (filter + fixed-keys-last + throw-on-collision) ──
+import { dirname } from "node:path";
+
 const SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const FIXED_ENV_KEYS = new Set(["PATH", "HOME", "LANG"]);
+
+/** #301 nvm fix (issue: spawned child shebang `#!/usr/bin/env node`
+ *  finds no node when daemon runs under nvm / pnpm / Bun / custom
+ *  installs where node is not in SAFE_PATH). Prepend daemon's own
+ *  node bin dir to PATH for spawned children.
+ *
+ *  Trust root: process.execPath is daemon's own already-resolved
+ *  node binary path (boot-time canonicalize, attacker can't change
+ *  the running process's own argv0 dirname). NOT trusting env.PATH
+ *  (that's C1 attacker surface). So no C1 / PATH-poison regression:
+ *  hub-side validateEnvRefs still rejects env_refs:["PATH"] /
+ *  ["LD_PRELOAD"] (G7/G8 invariant unchanged) — the only thing we
+ *  add is a fixed dir name that the daemon process itself defines.
+ */
+function computeChildPath(): string {
+  const execDir = dirname(process.execPath);
+  // Skip prepend if execDir is already an early SAFE_PATH entry
+  // (avoid duplicate path; canonical SAFE_PATH wins).
+  const safeParts = SAFE_PATH.split(":");
+  if (safeParts.includes(execDir)) return SAFE_PATH;
+  return `${execDir}:${SAFE_PATH}`;
+}
 
 export function minimalEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
   const filtered: Record<string, string> = {};
@@ -122,7 +146,7 @@ export function minimalEnv(extra: Record<string, string> = {}): NodeJS.ProcessEn
   }
   return {
     ...filtered,
-    PATH: SAFE_PATH,
+    PATH: computeChildPath(),
     HOME: process.env.HOME!,
     LANG: process.env.LANG || "C.UTF-8",
   };

--- a/tests/qa-rfc026-create-node/Dockerfile
+++ b/tests/qa-rfc026-create-node/Dockerfile
@@ -25,7 +25,11 @@ COPY agent-node /app/agent-node
 COPY agent-network /app/agent-network
 COPY tests/lib /app/tests/lib
 COPY tests/qa-rfc026-create-node/run.sh /app/tests/qa-rfc026-create-node/run.sh
-RUN chmod +x /app/tests/qa-rfc026-create-node/run.sh
+COPY tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh /app/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh
+COPY tests/qa-rfc026-create-node/test-all.sh /app/tests/qa-rfc026-create-node/test-all.sh
+RUN chmod +x /app/tests/qa-rfc026-create-node/run.sh \
+             /app/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh \
+             /app/tests/qa-rfc026-create-node/test-all.sh
 
 RUN cd /app/server && bun install --silent
 RUN cd /app/agent-node && bun install --silent && bun run build
@@ -40,4 +44,4 @@ RUN cd /app/agent-network \
 
 RUN anet --version && which anet && which agent-node
 
-CMD ["/app/tests/qa-rfc026-create-node/run.sh"]
+CMD ["/app/tests/qa-rfc026-create-node/test-all.sh"]

--- a/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh
+++ b/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Front-row review extension for PR #309 / issue #301.
+# qa-rfc026 A.nvm proves: create → start → register → survive 12s.
+# 通信龙 ask: 「create + start + send-task 三连」— third leg verifies
+# child can真 receive + process a task (inbox path live, not just
+# "process alive idle"). Without real LLM token (M5 territory), we
+# verify the wire: inbox row appears, child consumes it, status
+# transitions or reply attempted.
+
+set -uo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/../lib/safe-rm.sh"
+
+HUB_PORT=9236
+HUB_BASE="http://127.0.0.1:$HUB_PORT"
+HUB_DB=/tmp/qa-309-sendtask.db
+WORK=/tmp/309-sendtask-work
+ADMIN_USER="t309admin"; ADMIN_PW="t309_Pass_1234!"
+DAEMON_NAME="daemon-309"; CHILD_NAME="child-309-nvm"
+
+PASS=0; FAIL=0
+ok()  { printf "  ✓ %s\n" "$*"; PASS=$((PASS+1)); }
+bad() { printf "  ✗ %s\n" "$*"; FAIL=$((FAIL+1)); }
+note(){ printf "\n=== %s ===\n" "$*"; }
+
+cleanup() {
+  [[ -n "${NVM_DAEMON_PID:-}" ]] && kill "$NVM_DAEMON_PID" 2>/dev/null || true
+  [[ -n "${HUB_PID:-}" ]] && kill "$HUB_PID" 2>/dev/null || true
+  # restore node if we moved it
+  [[ -f /opt/anet-nvm-sim/bin/node && -n "${SYS_NODE:-}" && ! -f "$SYS_NODE" ]] && \
+    cp /opt/anet-nvm-sim/bin/node "$SYS_NODE" 2>/dev/null
+  rm -rf /opt/anet-nvm-sim 2>/dev/null
+}
+trap cleanup EXIT
+
+# Resolve binaries
+SYS_NODE=$(realpath -e "$(which node)")
+AGENT_NODE_BIN=$(realpath -e "$(which agent-node)")
+ANET_BIN=$(realpath -e "$(which anet)")
+
+note "Stage 0 — setup isolated hub + register admin user"
+rm -f "$HUB_DB" "${HUB_DB}-wal" "${HUB_DB}-shm" 2>/dev/null
+mkdir -p "$WORK"
+COMMHUB_DB="$HUB_DB" PORT="$HUB_PORT" bun run /app/server/src/index.ts > /tmp/309-hub.log 2>&1 &
+HUB_PID=$!
+sleep 3
+curl -sf "$HUB_BASE/health" > /dev/null || { bad "hub failed"; exit 1; }
+ok "isolated hub :$HUB_PORT up"
+
+R=$(curl -s -X POST "$HUB_BASE/api/auth/register" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PW\",\"display_name\":\"A\"}")
+UTOK=$(echo "$R" | jq -r .token); NTOK=$(echo "$R" | jq -r .network_token); NET_ID=$(echo "$R" | jq -r .network_id)
+[[ "$UTOK" == utok_* ]] && ok "admin registered (net=${NET_ID:0:12})" || { bad "register failed: $R"; exit 1; }
+
+note "Stage 1 — daemon node config (host_supervisor role)"
+mkdir -p "$WORK/.anet/nodes/$DAEMON_NAME"
+DAEMON_NODE_ID="node_d309"
+cat > "$WORK/.anet/nodes/$DAEMON_NAME/config.json" <<EOF
+{
+  "node_id": "$DAEMON_NODE_ID",
+  "alias": "$DAEMON_NAME",
+  "runtime": "claude-agent-sdk",
+  "hub": "$HUB_BASE",
+  "token": "$NTOK",
+  "network_id": "$NET_ID",
+  "role": "host_supervisor",
+  "flags": {"dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000"}
+}
+EOF
+ok "daemon config written"
+
+note "Stage 2 — nvm-sim: MOVE node out of SAFE_PATH"
+mkdir -p /opt/anet-nvm-sim/bin
+mv "$SYS_NODE" /opt/anet-nvm-sim/bin/node
+# Sanity: node should now be unfindable on SAFE_PATH
+for p in /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin; do
+  [[ -x "$p/node" ]] && { bad "node still in SAFE_PATH at $p — nvm-sim not faithful"; exit 1; }
+done
+ok "node MOVED to /opt/anet-nvm-sim/bin/node (faithful nvm-style — SAFE_PATH lookup fails)"
+
+note "Stage 3 — start daemon under nvm-sim node"
+ANET_BIN_ABS="$ANET_BIN" \
+  nohup /opt/anet-nvm-sim/bin/node "$AGENT_NODE_BIN" \
+    --config "$WORK/.anet/nodes/$DAEMON_NAME/config.json" \
+    --alias "$DAEMON_NAME" --runtime claude-agent-sdk \
+    > /tmp/309-daemon.log 2>&1 &
+NVM_DAEMON_PID=$!
+sleep 6
+if ! kill -0 "$NVM_DAEMON_PID" 2>/dev/null; then
+  bad "nvm-sim daemon failed to start"; tail -30 /tmp/309-daemon.log; exit 1
+fi
+ok "nvm-sim daemon alive pid=$NVM_DAEMON_PID (process.execPath=/opt/anet-nvm-sim/bin/node)"
+grep -q "registered\|已注册到 CommHub" /tmp/309-daemon.log && ok "daemon registered with hub" || bad "daemon never registered"
+
+note "Stage 3.5 — pre-dispatch daemon topology snapshot (race audit)"
+# Critical proof for 通信龙: at dispatch time, ONLY the nvm-sim daemon
+# is an active host_supervisor (no leftover from prior runs, no two-
+# daemon race). The earlier qa-rfc026 run.sh踩 this race because it
+# kept the original daemon running while starting nvm-sim daemon.
+HSP_COUNT=$(pgrep -af "agent-node.*--alias $DAEMON_NAME" | grep -v "$$" | grep -v grep | wc -l)
+ALL_AGENT_NODE_PIDS=$(pgrep -af "agent-node " | grep -v grep | awk '{print $1}' | tr '\n' ',' || echo "")
+echo "    nvm-sim daemon PID:        $NVM_DAEMON_PID"
+echo "    pgrep agent-node matches:  $HSP_COUNT"
+echo "    all agent-node PIDs:       [${ALL_AGENT_NODE_PIDS}]"
+if [[ "$HSP_COUNT" -eq 1 ]]; then
+  ok "single-daemon topology — only nvm-sim daemon active (race-free: only it can pull create_request)"
+elif [[ "$HSP_COUNT" -eq 0 ]]; then
+  bad "ZERO daemon processes — pgrep miss?"
+  pgrep -af agent-node || true
+else
+  bad "MULTIPLE daemons ($HSP_COUNT) — race risk! Dispatched create_node could be pulled by stale daemon"
+  pgrep -af agent-node || true
+fi
+
+note "Stage 4 — dispatch create_node via MCP (admin)"
+# Init MCP session
+curl -sS -X POST "$HUB_BASE/mcp" -H "Authorization: Bearer $UTOK" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2025-03-26' \
+  -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"309","version":"0"}}}' > /dev/null 2>&1
+
+REQ_BODY=$(jq -nc --arg dnid "$DAEMON_NODE_ID" --arg cn "$CHILD_NAME" --arg nid "$NET_ID" \
+  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"create_node",arguments:{daemon_node_id:$dnid,node_spec:{name:$cn,runtime:"claude-agent-sdk",model:"claude-opus-309-bogus"},network_id:$nid,env_blob:{ANTHROPIC_API_KEY:"bogus-309"}}}}')
+RESP=$(curl -sS -X POST "$HUB_BASE/mcp" -H "Authorization: Bearer $UTOK" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2025-03-26' -d "$REQ_BODY")
+INNER=$(echo "$RESP" | grep -oP '(?<=data: ).+' | head -1 | jq -r '.result.content[0].text' 2>/dev/null)
+[[ -z "$INNER" || "$INNER" == "null" ]] && INNER=$(echo "$RESP" | jq -r '.result.content[0].text' 2>/dev/null)
+REQ_ID=$(echo "$INNER" | jq -r .request_id 2>/dev/null)
+[[ "$REQ_ID" == cr_* ]] && ok "create_node dispatched request_id=$REQ_ID" || { bad "dispatch failed: $RESP"; exit 1; }
+
+note "Stage 5 — wait for child真 register (this is what #301 fix enables)"
+REG_ITER=""
+for i in $(seq 1 30); do
+  sleep 1
+  R=$(curl -sS "$HUB_BASE/api/nodes?alias=$CHILD_NAME" -H "Authorization: Bearer $UTOK")
+  if echo "$R" | jq -e ".nodes[0].alias == \"$CHILD_NAME\"" >/dev/null 2>&1; then
+    REG_ITER=$i; break
+  fi
+done
+[[ -n "$REG_ITER" ]] && ok "child registered in ${REG_ITER}s (#301 fix真生效 — env node resolved under nvm-style)" \
+  || { bad "child NEVER registered — fix didn't take"; tail -30 /tmp/309-daemon.log; exit 1; }
+
+note "Stage 6 — survive (12s post-register, full loop bar)"
+sleep 12
+CHILD_PID=$(grep -oE "spawned child .$CHILD_NAME. pid=[0-9]+" /tmp/309-daemon.log | tail -1 | grep -oE "[0-9]+$")
+if [[ -n "$CHILD_PID" ]] && kill -0 "$CHILD_PID" 2>/dev/null; then
+  ok "child pid=$CHILD_PID alive after 12s (FULL LOOP — register + survive)"
+else
+  bad "child died within 12s"; exit 1
+fi
+# Find the grandchild agent-node process (the real worker, child of the starter)
+GRANDCHILDREN=$(pgrep -P "$CHILD_PID" 2>/dev/null || echo "")
+if [[ -n "$GRANDCHILDREN" ]]; then
+  ok "child has live grandchild agent-node process(es): $GRANDCHILDREN (full process tree intact)"
+else
+  bad "child has NO grandchild — starter alive but agent-node process missing (the [[feedback_commit_presence_not_functional_proof]] pattern: 'alive' != 'wired')"
+fi
+
+note "Stage 7 — send-task三连 third leg:真 dispatch + verify child processes"
+# Send a task via /api/task (the same path Vincent/agents would use)
+T_RESP=$(curl -sS -X POST "$HUB_BASE/api/task" \
+  -H "Authorization: Bearer $NTOK" -H 'Content-Type: application/json' \
+  -d "{\"alias\":\"$CHILD_NAME\",\"task\":\"ping from 309 review smoke\",\"priority\":\"normal\",\"from\":\"309-smoke\",\"network_id\":\"$NET_ID\"}")
+TASK_OK=$(echo "$T_RESP" | jq -r .ok 2>/dev/null)
+TASK_ID=$(echo "$T_RESP" | jq -r .task_id 2>/dev/null)
+[[ "$TASK_OK" == "true" ]] && ok "send_task accepted by hub: task_id=$TASK_ID" || { bad "send_task failed: $T_RESP"; exit 1; }
+
+# Wait for child's inbox to consume + status change in DB
+INBOX_CONSUMED=""
+DB_STATUS=""
+for i in $(seq 1 25); do
+  sleep 1
+  # The hub DB tracks message.delivered_at on consume by agent
+  STATUS_ROW=$(sqlite3 "$HUB_DB" \
+    "SELECT delivered_at, status FROM tasks WHERE task_id='$TASK_ID' LIMIT 1;" 2>/dev/null || echo "")
+  if [[ -n "$STATUS_ROW" ]] && [[ "$STATUS_ROW" != "|" ]]; then
+    INBOX_CONSUMED=$i
+    DB_STATUS=$STATUS_ROW
+    # If delivered_at is set OR status moved past pending, child真 picked it up
+    DELIVERED=$(echo "$STATUS_ROW" | cut -d'|' -f1)
+    STATUS_VAL=$(echo "$STATUS_ROW" | cut -d'|' -f2)
+    if [[ -n "$DELIVERED" ]] && [[ "$DELIVERED" != "" ]]; then
+      break
+    fi
+    if [[ "$STATUS_VAL" == "delivered" || "$STATUS_VAL" == "replied" || "$STATUS_VAL" == "failed" || "$STATUS_VAL" == "in_progress" ]]; then
+      break
+    fi
+  fi
+done
+if [[ -n "$INBOX_CONSUMED" ]]; then
+  ok "child consumed inbox in ${INBOX_CONSUMED}s — DB row: [$DB_STATUS] (true 'wire is live', child真接到任务)"
+else
+  bad "child NEVER consumed task in 25s — process alive but not wired to inbox (pattern: 'register' != 'functional')"
+  echo "--- child agent-node log (last 30) ---"
+  ls /tmp/309-sendtask-work/.anet/nodes/$CHILD_NAME/logs/ 2>/dev/null && \
+    tail -30 /tmp/309-sendtask-work/.anet/nodes/$CHILD_NAME/logs/*.log 2>/dev/null
+  echo "--- DB task row ---"
+  sqlite3 "$HUB_DB" "SELECT * FROM tasks WHERE task_id='$TASK_ID';" 2>/dev/null
+fi
+
+note "Stage 8 — get_status to see if child has been reporting in"
+SS=$(sqlite3 "$HUB_DB" \
+  "SELECT alias, status FROM sessions WHERE alias='$CHILD_NAME' ORDER BY last_seen_at DESC LIMIT 1;" 2>/dev/null)
+[[ -n "$SS" ]] && ok "child reported status row in DB: [$SS] (heartbeat path真 wired)" \
+  || bad "child has NO status row in DB (report_status path broken — wire incomplete)"
+
+printf "\n────────────────────────────────────────────\n"
+printf "Front-row review extension: PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
+printf "────────────────────────────────────────────\n"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/qa-rfc026-create-node/run.sh
+++ b/tests/qa-rfc026-create-node/run.sh
@@ -370,17 +370,23 @@ RESP=$(mcp_call "$UTOK" "$BODY")
 ERR=$(echo "$RESP" | jq -r .error 2>/dev/null)
 [[ "$ERR" == "channels_not_supported_in_p1" ]] && ok "K channels rejected: $ERR" || bad "K channels NOT rejected: $RESP"
 
-# ── A.nvm — issue #301 minimalEnv PATH fix真验 (after B-K to avoid disturbing existing daemon) ──
-# Simulates nvm-style install: daemon's own node lives OUTSIDE SAFE_PATH
-# (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin).
-# Pre-fix: spawned child's `#!/usr/bin/env node` shebang can't find node
-#         under nvm/Bun/pnpm → insta-die <1s before any register.
-# Post-fix: minimalEnv prepends dirname(process.execPath) so spawned
-#          children can resolve env node → child真 register + survives.
-note "A.nvm — issue #301 PATH fix真验 (nvm-style install + register+survive complete-loop)"
-# Kill the existing daemon-rfc028 daemon (used by A-K).
-kill "$DAEMON_PID" 2>/dev/null || true
-sleep 2
+# ── A.nvm — issue #301 minimalEnv PATH fix真验 ───────────────────
+# Simulates nvm-style install: daemon's own node lives OUTSIDE SAFE_PATH.
+# Pre-fix: spawned child's `#!/usr/bin/env node` shebang fails → insta-die.
+# Post-fix: minimalEnv prepends dirname(process.execPath) → child survives.
+#
+# v2 RACE FIX (Codex catch on commit 84545b4): the prior version killed
+# `$DAEMON_PID` (the `nohup anet node start` wrapper) but left the
+# wrapper-spawned `agent-node` grandchild alive. Two daemons (the
+# survivor + the nvm-sim new daemon) shared the same `daemon_node_id` →
+# raced for the same one-shot `pendingEnvBlobs` consume → POST-FIX
+# outcome non-deterministic (luck-of-the-pull). New design avoids the
+# race entirely by registering the nvm-sim daemon under a DISTINCT
+# identity (own ntok + own node_id + own alias). hub C2 token-bound
+# routing pushes `create_node` only to the target daemon_node_id, so
+# the original `daemon-rfc026` keeps running harmlessly but never
+# receives the nvm probe doorbell.
+note "A.nvm — issue #301 PATH fix真验 (isolated daemon identity, no race; complete-loop register+survive)"
 SYS_NODE=$(realpath -e "$(which node 2>/dev/null)" 2>/dev/null || echo "")
 AGENT_NODE_BIN=$(realpath -e "$(which agent-node 2>/dev/null)" 2>/dev/null || echo "")
 if [[ -z "$SYS_NODE" ]] || ! [[ "$SYS_NODE" =~ ^(/usr/local/sbin|/usr/local/bin|/usr/sbin|/usr/bin|/sbin|/bin)/ ]]; then
@@ -388,36 +394,86 @@ if [[ -z "$SYS_NODE" ]] || ! [[ "$SYS_NODE" =~ ^(/usr/local/sbin|/usr/local/bin|
 elif [[ -z "$AGENT_NODE_BIN" ]]; then
   stub "A.nvm" "agent-node binary missing — skipping"
 else
-  # Stage nvm-sim: MOVE node out of SAFE_PATH so SAFE_PATH lookup fails
-  # (faithful nvm-style — pre-fix child shebang `#!/usr/bin/env node`
-  # cannot resolve node via SAFE_PATH; post-fix the daemon prepends
-  # dirname(process.execPath) which IS where node now lives)
+  # Stage nvm-sim: MOVE node out of SAFE_PATH so SAFE_PATH lookup of
+  # `node` fails (faithful nvm). cleanup trap restores node so any
+  # cleanup steps continue to work.
   mkdir -p /opt/anet-nvm-sim/bin
   mv "$SYS_NODE" /opt/anet-nvm-sim/bin/node
   ok "nvm-sim: MOVED node $SYS_NODE → /opt/anet-nvm-sim/bin/node (SAFE_PATH lookup of node now fails — faithful nvm)"
-  # Cleanup hook restores node so subsequent steps don't break
   trap "cp /opt/anet-nvm-sim/bin/node $SYS_NODE 2>/dev/null; rm -rf /opt/anet-nvm-sim 2>/dev/null" EXIT
-  NVM_CHILD_NAME="demo-nvm-child"
+
+  # Mint NEW daemon identity (isolated from daemon-rfc026 used by B-K)
+  NVM_DAEMON_NAME="daemon-rfc026-nvm"
+  NVM_DAEMON_NTOK_RESP=$(curl -sS -X POST "$HUB_BASE/api/auth/node-token" \
+    -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' \
+    -d "{\"network_id\":\"$NET_ID\",\"node_name\":\"$NVM_DAEMON_NAME\"}")
+  NVM_DAEMON_NTOK=$(echo "$NVM_DAEMON_NTOK_RESP" | jq -r .token)
+  [[ "$NVM_DAEMON_NTOK" == ntok_* ]] && ok "nvm daemon ntok minted (isolated identity)" || { bad "nvm ntok mint: $NVM_DAEMON_NTOK_RESP"; }
+  NVM_DAEMON_NODE_ID="node_daemon_nvm_$(date +%s%N | sha256sum | head -c 12)"
+  mkdir -p "$WORK/.anet/nodes/$NVM_DAEMON_NAME"
+  cat > "$WORK/.anet/nodes/$NVM_DAEMON_NAME/config.json" <<EOF2
+{"node_id":"$NVM_DAEMON_NODE_ID","node_name":"$NVM_DAEMON_NAME","alias":"$NVM_DAEMON_NAME","role":"host_supervisor",
+ "runtime":"claude-agent-sdk","model":"claude-opus-original",
+ "hub":"$HUB_BASE","token":"$NVM_DAEMON_NTOK"}
+EOF2
   cd "$WORK"
-  # Start daemon explicitly under nvm-sim node (process.execPath becomes /opt/anet-nvm-sim/bin/node)
+  # Start nvm daemon under /opt/anet-nvm-sim/bin/node (process.execPath becomes that path)
   ANET_BIN_ABS=$(realpath -e "$(which anet)") \
     nohup /opt/anet-nvm-sim/bin/node "$AGENT_NODE_BIN" \
-      --config "$WORK/.anet/nodes/$DAEMON_NAME/config.json" \
-      --alias "$DAEMON_NAME" --runtime claude-agent-sdk \
+      --config "$WORK/.anet/nodes/$NVM_DAEMON_NAME/config.json" \
+      --alias "$NVM_DAEMON_NAME" --runtime claude-agent-sdk \
       > /tmp/daemon-nvm.log 2>&1 &
   NVM_DAEMON_PID=$!
   sleep 5
   if ! kill -0 "$NVM_DAEMON_PID" 2>/dev/null; then
     bad "nvm-sim daemon failed to start"; tail -30 /tmp/daemon-nvm.log
   else
-    ok "nvm-sim daemon alive pid=$NVM_DAEMON_PID (process.execPath=/opt/anet-nvm-sim/bin/node, NOT in SAFE_PATH)"
-    BODY=$(build_create_node_body "$DAEMON_NODE_ID" "$NVM_CHILD_NAME" "claude-agent-sdk" "claude-opus-nvm-test" "$NET_ID")
+    # Verify execPath真 = nvm-sim path (the daemon's process.execPath
+    # determines what dirname() prepends in computeChildPath; if it
+    # happened to be the original system node, our修 wouldn't be exercising)
+    NVM_EXEC=$(readlink -f /proc/$NVM_DAEMON_PID/exe 2>/dev/null || echo "?")
+    if [[ "$NVM_EXEC" == "/opt/anet-nvm-sim/bin/node" ]]; then
+      ok "nvm-sim daemon execPath=$NVM_EXEC (真 outside SAFE_PATH — fix is exercising)"
+    else
+      bad "nvm-sim daemon execPath=$NVM_EXEC ≠ /opt/anet-nvm-sim/bin/node (fix not exercising)"
+    fi
+
+    # Wait for nvm daemon to register
+    NVM_REG=""
+    for i in $(seq 1 30); do
+      sleep 1
+      R=$(curl -sS "$HUB_BASE/api/nodes?node_id=$NVM_DAEMON_NODE_ID" -H "Authorization: Bearer $UTOK")
+      if echo "$R" | jq -e ".nodes[0].node_id == \"$NVM_DAEMON_NODE_ID\"" >/dev/null 2>&1; then NVM_REG=yes; break; fi
+    done
+    [[ -n "$NVM_REG" ]] && ok "nvm-sim daemon registered ($NVM_DAEMON_NAME / $NVM_DAEMON_NODE_ID)" || { bad "nvm daemon never registered"; tail -20 /tmp/daemon-nvm.log; }
+
+    # Stage 3.5 — pre-dispatch topology audit (race self-guard, mirrors nvm-sendtask-smoke.sh)
+    # If anyone later changes this harness in a way that leaves a stale
+    # daemon for $NVM_DAEMON_NAME running, this assertion catches it on
+    # the spot — race-prevention becomes self-checking, not implicit.
+    HSP_COUNT=$(pgrep -af "agent-node.*--alias $NVM_DAEMON_NAME" | grep -v grep | wc -l)
+    ALL_PIDS=$(pgrep -af "agent-node " | grep -v grep | awk '{print $1}' | tr '\n' ',' || echo "")
+    echo "    nvm-sim daemon PID:        $NVM_DAEMON_PID"
+    echo "    pgrep nvm-daemon matches:  $HSP_COUNT"
+    echo "    all agent-node PIDs:       [${ALL_PIDS}]"
+    if [[ "$HSP_COUNT" -eq 1 ]]; then
+      ok "single-daemon topology — only nvm-sim daemon owns alias=$NVM_DAEMON_NAME (HSP_COUNT=1 ASSERT PASS — race-free hard guard)"
+    else
+      bad "HSP_COUNT=$HSP_COUNT for alias=$NVM_DAEMON_NAME (expected exactly 1) — RACE RISK: harness regression, leftover daemon would steal create_request"
+      pgrep -af agent-node || true
+    fi
+
+    NVM_CHILD_NAME="demo-nvm-child"
+    # Dispatch create_node targeting the NEW daemon_node_id (hub
+    # C2 token-bound routing → only this daemon receives the SSE
+    # doorbell; original daemon-rfc026 keeps running harmlessly).
+    BODY=$(build_create_node_body "$NVM_DAEMON_NODE_ID" "$NVM_CHILD_NAME" "claude-agent-sdk" "claude-opus-nvm-test" "$NET_ID")
     RESP=$(mcp_call "$UTOK" "$BODY")
     NVM_REQ_ID=$(echo "$RESP" | jq -r .request_id 2>/dev/null)
     if [[ "$NVM_REQ_ID" != cr_* ]]; then
       bad "nvm-sim: create_node dispatch failed: $RESP"
     else
-      ok "nvm-sim: create_node dispatched request_id=$NVM_REQ_ID"
+      ok "nvm-sim: create_node dispatched to ISOLATED daemon (request_id=$NVM_REQ_ID, 0 race possible)"
       NVM_REGISTERED=""; NVM_REG_ITER=""
       for i in $(seq 1 30); do
         sleep 1
@@ -427,17 +483,16 @@ else
         fi
       done
       if [[ -z "$NVM_REGISTERED" ]]; then
-        bad "nvm-sim: child NEVER registered — issue #301 fix DIDN'T TAKE (child shebang likely insta-died)"
+        bad "nvm-sim: child NEVER registered — #301 fix DIDN'T TAKE (child shebang likely insta-died)"
         tail -30 /tmp/daemon-nvm.log
       else
-        ok "nvm-sim: child registered in ${NVM_REG_ITER}s (env node resolved via daemon's PATH prepend — #301 修后 register OK)"
-        # Full-loop survival check (register + alive ≥12s — complete loop per 通信龙)
+        ok "nvm-sim: child registered in ${NVM_REG_ITER}s (env node resolved via daemon PATH prepend — #301 修后 register OK)"
         sleep 12
         NVM_CHILD_PID=$(grep -oE "spawned child .$NVM_CHILD_NAME. pid=[0-9]+" /tmp/daemon-nvm.log 2>/dev/null | tail -1 | grep -oE "[0-9]+$")
         if [[ -n "$NVM_CHILD_PID" ]] && kill -0 "$NVM_CHILD_PID" 2>/dev/null; then
-          ok "nvm-sim: child pid=$NVM_CHILD_PID alive after 12s — FULL LOOP (register + survive complete; #301 真 fix landed)"
+          ok "nvm-sim: child pid=$NVM_CHILD_PID alive after 12s — FULL LOOP (register + survive; #301 真 fix landed, isolated daemon, no race)"
         else
-          bad "nvm-sim: child pid=$NVM_CHILD_PID DEAD within 12s — #301 fix incomplete (registered then died)"
+          bad "nvm-sim: child pid=$NVM_CHILD_PID DEAD within 12s — #301 fix incomplete"
         fi
       fi
     fi

--- a/tests/qa-rfc026-create-node/run.sh
+++ b/tests/qa-rfc026-create-node/run.sh
@@ -169,6 +169,8 @@ if [[ -n "$SUCCEEDED" ]]; then
   fi
 fi
 
+# nvm-sim scenario runs at end (after K) — see "A.nvm" block below.
+
 # ── B. role gate ──────────────────────────────────────────────────
 note "B. member/viewer role gate (hub-side)"
 BODY=$(build_create_node_body "$DAEMON_NODE_ID" "b-noop-child" "claude-agent-sdk" "claude-opus-x" "$NET_ID")
@@ -368,8 +370,82 @@ RESP=$(mcp_call "$UTOK" "$BODY")
 ERR=$(echo "$RESP" | jq -r .error 2>/dev/null)
 [[ "$ERR" == "channels_not_supported_in_p1" ]] && ok "K channels rejected: $ERR" || bad "K channels NOT rejected: $RESP"
 
-# ── cleanup ──────────────────────────────────────────────────────
+# ── A.nvm — issue #301 minimalEnv PATH fix真验 (after B-K to avoid disturbing existing daemon) ──
+# Simulates nvm-style install: daemon's own node lives OUTSIDE SAFE_PATH
+# (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin).
+# Pre-fix: spawned child's `#!/usr/bin/env node` shebang can't find node
+#         under nvm/Bun/pnpm → insta-die <1s before any register.
+# Post-fix: minimalEnv prepends dirname(process.execPath) so spawned
+#          children can resolve env node → child真 register + survives.
+note "A.nvm — issue #301 PATH fix真验 (nvm-style install + register+survive complete-loop)"
+# Kill the existing daemon-rfc028 daemon (used by A-K).
 kill "$DAEMON_PID" 2>/dev/null || true
+sleep 2
+SYS_NODE=$(realpath -e "$(which node 2>/dev/null)" 2>/dev/null || echo "")
+AGENT_NODE_BIN=$(realpath -e "$(which agent-node 2>/dev/null)" 2>/dev/null || echo "")
+if [[ -z "$SYS_NODE" ]] || ! [[ "$SYS_NODE" =~ ^(/usr/local/sbin|/usr/local/bin|/usr/sbin|/usr/bin|/sbin|/bin)/ ]]; then
+  stub "A.nvm" "system node not in SAFE_PATH or missing — nvm-sim setup needs repositioning, skipping"
+elif [[ -z "$AGENT_NODE_BIN" ]]; then
+  stub "A.nvm" "agent-node binary missing — skipping"
+else
+  # Stage nvm-sim: MOVE node out of SAFE_PATH so SAFE_PATH lookup fails
+  # (faithful nvm-style — pre-fix child shebang `#!/usr/bin/env node`
+  # cannot resolve node via SAFE_PATH; post-fix the daemon prepends
+  # dirname(process.execPath) which IS where node now lives)
+  mkdir -p /opt/anet-nvm-sim/bin
+  mv "$SYS_NODE" /opt/anet-nvm-sim/bin/node
+  ok "nvm-sim: MOVED node $SYS_NODE → /opt/anet-nvm-sim/bin/node (SAFE_PATH lookup of node now fails — faithful nvm)"
+  # Cleanup hook restores node so subsequent steps don't break
+  trap "cp /opt/anet-nvm-sim/bin/node $SYS_NODE 2>/dev/null; rm -rf /opt/anet-nvm-sim 2>/dev/null" EXIT
+  NVM_CHILD_NAME="demo-nvm-child"
+  cd "$WORK"
+  # Start daemon explicitly under nvm-sim node (process.execPath becomes /opt/anet-nvm-sim/bin/node)
+  ANET_BIN_ABS=$(realpath -e "$(which anet)") \
+    nohup /opt/anet-nvm-sim/bin/node "$AGENT_NODE_BIN" \
+      --config "$WORK/.anet/nodes/$DAEMON_NAME/config.json" \
+      --alias "$DAEMON_NAME" --runtime claude-agent-sdk \
+      > /tmp/daemon-nvm.log 2>&1 &
+  NVM_DAEMON_PID=$!
+  sleep 5
+  if ! kill -0 "$NVM_DAEMON_PID" 2>/dev/null; then
+    bad "nvm-sim daemon failed to start"; tail -30 /tmp/daemon-nvm.log
+  else
+    ok "nvm-sim daemon alive pid=$NVM_DAEMON_PID (process.execPath=/opt/anet-nvm-sim/bin/node, NOT in SAFE_PATH)"
+    BODY=$(build_create_node_body "$DAEMON_NODE_ID" "$NVM_CHILD_NAME" "claude-agent-sdk" "claude-opus-nvm-test" "$NET_ID")
+    RESP=$(mcp_call "$UTOK" "$BODY")
+    NVM_REQ_ID=$(echo "$RESP" | jq -r .request_id 2>/dev/null)
+    if [[ "$NVM_REQ_ID" != cr_* ]]; then
+      bad "nvm-sim: create_node dispatch failed: $RESP"
+    else
+      ok "nvm-sim: create_node dispatched request_id=$NVM_REQ_ID"
+      NVM_REGISTERED=""; NVM_REG_ITER=""
+      for i in $(seq 1 30); do
+        sleep 1
+        R=$(curl -sS "$HUB_BASE/api/nodes?alias=$NVM_CHILD_NAME" -H "Authorization: Bearer $UTOK")
+        if echo "$R" | jq -e ".nodes[0].alias == \"$NVM_CHILD_NAME\"" >/dev/null 2>&1; then
+          NVM_REGISTERED=yes; NVM_REG_ITER=$i; break
+        fi
+      done
+      if [[ -z "$NVM_REGISTERED" ]]; then
+        bad "nvm-sim: child NEVER registered — issue #301 fix DIDN'T TAKE (child shebang likely insta-died)"
+        tail -30 /tmp/daemon-nvm.log
+      else
+        ok "nvm-sim: child registered in ${NVM_REG_ITER}s (env node resolved via daemon's PATH prepend — #301 修后 register OK)"
+        # Full-loop survival check (register + alive ≥12s — complete loop per 通信龙)
+        sleep 12
+        NVM_CHILD_PID=$(grep -oE "spawned child .$NVM_CHILD_NAME. pid=[0-9]+" /tmp/daemon-nvm.log 2>/dev/null | tail -1 | grep -oE "[0-9]+$")
+        if [[ -n "$NVM_CHILD_PID" ]] && kill -0 "$NVM_CHILD_PID" 2>/dev/null; then
+          ok "nvm-sim: child pid=$NVM_CHILD_PID alive after 12s — FULL LOOP (register + survive complete; #301 真 fix landed)"
+        else
+          bad "nvm-sim: child pid=$NVM_CHILD_PID DEAD within 12s — #301 fix incomplete (registered then died)"
+        fi
+      fi
+    fi
+    kill "$NVM_DAEMON_PID" 2>/dev/null || true
+  fi
+fi
+
+# ── cleanup ──────────────────────────────────────────────────────
 kill "$HUB_PID" 2>/dev/null || true
 
 printf "\n────────────────────────────────────────────\n"

--- a/tests/qa-rfc026-create-node/test-all.sh
+++ b/tests/qa-rfc026-create-node/test-all.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# qa-rfc026 master wrapper — runs the full suite + the dedicated
+# nvm send-task race-free smoke. Both scripts use isolated hub ports
+# + isolated COMMHUB_DB, so they coexist in one container.
+#
+# Order matters: run.sh first (it owns ports 9235 + WORK=/tmp/qa-rfc026-work),
+# then nvm-sendtask-smoke.sh (owns port 9236 + WORK=/tmp/309-sendtask-work).
+# A failure in either suite fails the wrapper.
+set -uo pipefail
+TOTAL_FAIL=0
+SUITES=()
+
+echo ""
+echo "============================================================"
+echo " qa-rfc026 master wrapper"
+echo "============================================================"
+
+note() { printf "\n\n=== %s ===\n" "$*"; }
+record() {
+  local name="$1" code="$2"
+  if [[ "$code" -eq 0 ]]; then
+    SUITES+=("✅ $name: PASS")
+  else
+    SUITES+=("❌ $name: FAIL (exit=$code)")
+    TOTAL_FAIL=$((TOTAL_FAIL + 1))
+  fi
+}
+
+note "Suite 1/2 — run.sh (RFC-026 P1 main e2e)"
+/app/tests/qa-rfc026-create-node/run.sh; RC1=$?
+record "RFC-026 P1 e2e (run.sh, includes A.nvm distinct-daemon)" "$RC1"
+
+note "Suite 2/2 — nvm-sendtask-smoke.sh (PR #309 send-task三连)"
+/app/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh; RC2=$?
+record "PR #309 nvm send-task smoke (race-free single-daemon)" "$RC2"
+
+echo ""
+echo "============================================================"
+echo " qa-rfc026 wrapper final"
+echo "============================================================"
+for s in "${SUITES[@]}"; do echo "  $s"; done
+echo "  TOTAL FAILED SUITES: $TOTAL_FAIL"
+echo "============================================================"
+
+[[ "$TOTAL_FAIL" -eq 0 ]]


### PR DESCRIPTION
## Author
Agent: 通信工程马

## Summary

Fix #301 — daemon `minimalEnv()` hardcoded `PATH=SAFE_PATH` made spawned child's `#!/usr/bin/env node` shebang fail on nvm / Bun / pnpm / custom-node installs where node lives outside SAFE_PATH. Symptom (N站马 联调 catch via 通信龙 task `1d1893c0`): child insta-die <1s, daemon's `kill -0` verifies starter alive (briefly), child agent-node grandchild dies before register, hub sweeper later marks request `sweeper_revoked_after_delivery_no_ack`.

**Impact**: any nvm/Bun-hosted hub create-node insta-die (extremely common). **preview2 ship gate** per 通信龙 `b61aad7c`.

## Fix
`agent-node/src/runtime/create-node-daemon.ts`:
- New `computeChildPath()` — prepends `dirname(process.execPath)` to SAFE_PATH; skips if execDir is already in SAFE_PATH (avoid duplicate).
- `minimalEnv()` uses `computeChildPath()` instead of static SAFE_PATH.

## Trust root (anti C1 PATH-poison regression)
- `process.execPath` is daemon's OWN already-resolved node binary absolute path (boot-time canonicalize by Node itself). Attacker cannot change a running process's own argv0 / execPath.
- **NOT** trusting `env.PATH` (that's C1 attacker surface; remains untrusted: `validateEnvRefs` hub-side STILL rejects `env_refs:["PATH"]` / `["LD_PRELOAD"]` — G7/G8 invariant unchanged).
- The only new thing is a fixed directory name the daemon process itself defines. Zero attacker-controlled input enters PATH.

## Real evidence (pre/post numbers measured, not claimed)

Faithful nvm simulation: **MOVE** node out of SAFE_PATH to `/opt/anet-nvm-sim/bin/node`, spawn daemon explicitly under that node binary (`process.execPath = /opt/anet-nvm-sim/bin/node`).

| | child PID | alive @+6s | DB status |
|---|---|---|---|
| **PRE-FIX** | spawned 76 | ✗ DEAD | `delivered` (never reached `succeeded`, register never happened — insta-die) |
| **POST-FIX** | spawned 394 | ✓ ALIVE @+12s | `succeeded` (registered in 1s + survived) |

## Tests
- **server**: `bun test` → 349 pass / 0 fail / 1081 expects (unchanged, no regression)
- **agent-node**: `bun test src/runtime/create-node-daemon.test.ts` → **27 pass / 0 fail / 59 expects** (+1 new C1 invariant assertion: source-file grep confirms `computeChildPath` uses `process.execPath` NOT `process.env.PATH`)
- **docker e2e** (qa-rfc026): `docker run anet-rfc026-nvmfix` → **PASS=35 FAIL=0 SKIP=2** (30 → 35; +5 nvm-sim sub-asserts)
- **C1 invariant**: G7/G8 env_refs `["PATH"]`/`["LD_PRELOAD"]` reject still 真绿 (unchanged)

## Anti-bypass review focus (通信龙 spot-check)
1. `agent-node/src/runtime/create-node-daemon.ts:computeChildPath` — proves `dirname(process.execPath)` is the source, not `process.env.PATH`
2. `tests/qa-rfc026-create-node/run.sh:A.nvm` — scenario MOVES node (not cp) for faithful nvm sim; cleanup trap restores
3. PRE/POST numbers via manual repro under `anet-rfc026-prefix2` image (negative test in /tmp/nvm-prefix-negative.sh — pre-fix child PID 76 DEAD @+6s vs post-fix child PID 394 ALIVE @+12s)
4. C1 invariant pinned by source-file grep test (explicit `not.toMatch(/process\.env\.PATH/)`)

## Refs
- Issue #301
- 通信龙 task `1d1893c0` (N站马 联调 root-cause + fix plan) + `d0183f5d` (plan approval) + `b61aad7c` (preview2 gate)
- Companion: PR #299 (RFC-026 PR B) daemon spawn — this fix complements the spawn hardening for nvm hosts
