### PR TITLE
chore(release): bump preview2 → -preview.4 (3 packages published)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -60,7 +60,7 @@ function tmuxAvailable(): boolean {
 // refetch). A `latest` agent-network release must pin a *stable* server.
 // `anet upgrade` (#88) surfaces this constant in its plan output so users
 // understand global-install version != version anet hub start actually runs.
-const PINNED_SERVER_VERSION = "0.9.0-preview.1";
+const PINNED_SERVER_VERSION = "0.9.0-preview.4";
 function sessionFileExists(uuid: string, cwd: string = process.cwd()): boolean {
   if (!uuid) return false;
   return existsSync(join(homedir(), ".claude", "projects", encodeCwd(cwd), `${uuid}.jsonl`));

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.1",
+  "version": "2.3.0-preview.4",
   "description": "AI Agent Network CLI \u2014 Local-first multi-agent orchestration across 4 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Grok Build ACP) and 8+ LLM providers (Anthropic / OpenAI / xAI Grok / MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter). Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.1",
+  "version": "2.5.0-preview.4",
   "description": "AI Agent runtime for CommHub networks. Supports 4 runtimes: Claude Code CLI, Claude Agent SDK, Codex SDK, and Grok Build ACP.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.1",
+  "version": "0.9.0-preview.4",
   "description": "CommHub Server \u2014 AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and 17 MCP tools.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

- npm publish complete for three packages on \`@preview\` tag (NOT latest).
- PINNED_SERVER_VERSION chain-bumped to match published commhub-server.
- Tag: \`v0.11-preview2.4\`.

## Published versions (raw registry truth)

| Package | @preview | @latest |
|:---|:---|:---|
| \`@sleep2agi/agent-network\` | **2.3.0-preview.4** | 2.2.21 (unchanged) |
| \`@sleep2agi/agent-node\` | **2.5.0-preview.4** | 2.4.13 (unchanged) |
| \`@sleep2agi/commhub-server\` | **0.9.0-preview.4** | 0.8.8 (unchanged) |

## Verification

- \`npm whoami\` = vansin ✓
- Docker smoke (node:22-bookworm-slim + glibc base + bun + build-essential): install path works for all three .tgzs, \`anet --version\` + \`agent-node --version\` succeed, PINNED string \`0.9.0-preview.4\` surfaced in upgrade plan output ✓
- PINNED_SERVER_VERSION (cli.ts:63) matches published commhub-server preview.4 — avoids #194 ship-blocker class
- Three package.json bumps mirror PINNED chain, no preview.3 re-publish risk

## Cut headline

- V3 Networks 2-fail root caused by ea212fc (2026-06-10, "surface failed delivery") — 3 weeks before preview2 batch, test infra lag not regression
- #312 \`/api/nodes\` explicit columns landed (separate SELECT * fix; backlog #311 for remaining)
- 45 Base E2E confirmed = #292 pre-existing class + Config Priority infra (not blocking preview2)
- #160 / #161 RFC-026 P1 create-node green
- #309 nvm PATH fix (race-free harness) green

## Test plan

- [ ] User-side smoke per upgrade command (separate Vincent dispatch)
- [ ] UAT phase begins on \`@preview\` install

🤖 Generated with [Claude Code](https://claude.com/claude-code)