### PR TITLE
fix(loops-http): exact /mcp pathname match (通信牛 hardening nit)

### DIFF
--- a/agent-node/src/goals/loops-http-server.test.ts
+++ b/agent-node/src/goals/loops-http-server.test.ts
@@ -284,3 +284,44 @@ describe("custom token override (for tests)", () => {
     expect(r.status).toBe(200);
   });
 });
+
+describe("path routing — exact pathname (通信牛 hardening nit)", () => {
+  // Prior impl used `req.url.startsWith("/mcp")`, which routed
+  // /mcpXYZ, /mcp.foo, /mcp-anything to the JSON-RPC handler. Bearer
+  // auth still gated execution, but widened surface unnecessarily.
+  // Tightened to exact pathname == "/mcp" (query string OK).
+  const base = () => server.url.replace(/\/mcp$/, "");
+  const authHdr = () => ({ "content-type": "application/json", "authorization": `Bearer ${server.token}` });
+  const initBody = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+  test("/mcp (exact) accepted → 200", async () => {
+    const r = await fetch(`${base()}/mcp`, { method: "POST", headers: authHdr(), body: initBody });
+    expect(r.status).toBe(200);
+  });
+
+  test("/mcp?foo=bar (with query string) accepted → 200", async () => {
+    const r = await fetch(`${base()}/mcp?foo=bar`, { method: "POST", headers: authHdr(), body: initBody });
+    expect(r.status).toBe(200);
+  });
+
+  test("/mcpXYZ (suffix) rejected → 404 (not auth-checked)", async () => {
+    const r = await fetch(`${base()}/mcpXYZ`, { method: "POST", headers: authHdr(), body: initBody });
+    expect(r.status).toBe(404);
+    expect(await r.text()).toBe("not found");
+  });
+
+  test("/mcp/ (trailing slash) rejected → 404", async () => {
+    const r = await fetch(`${base()}/mcp/`, { method: "POST", headers: authHdr(), body: initBody });
+    expect(r.status).toBe(404);
+  });
+
+  test("/mcp-leak (dash suffix) rejected → 404", async () => {
+    const r = await fetch(`${base()}/mcp-leak`, { method: "POST", headers: authHdr(), body: initBody });
+    expect(r.status).toBe(404);
+  });
+
+  test("/ (root) rejected → 404", async () => {
+    const r = await fetch(`${base()}/`, { method: "POST", headers: authHdr(), body: initBody });
+    expect(r.status).toBe(404);
+  });
+});

--- a/agent-node/src/goals/loops-http-server.ts
+++ b/agent-node/src/goals/loops-http-server.ts
@@ -150,7 +150,12 @@ export async function startLoopsHttpServer(opts: StartOpts): Promise<LoopsHttpSe
   const token = opts.token ?? randomBytes(16).toString("base64url");
 
   const server = createServer(async (req, res) => {
-    if (!req.url || req.method !== "POST" || !req.url.startsWith("/mcp")) {
+    // Exact-pathname match. `req.url.startsWith("/mcp")` (prior impl)
+    // accepted "/mcpXYZ", "/mcp-anything", etc. — even with bearer guard
+    // it widens the routable surface unnecessarily. Strip query string
+    // and compare pathname exactly to "/mcp".
+    const pathname = req.url?.split("?")[0];
+    if (!pathname || req.method !== "POST" || pathname !== "/mcp") {
       res.statusCode = 404;
       res.end("not found");
       return;


### PR DESCRIPTION
## Summary

- Tighten \`loops-http-server\` route from \`req.url.startsWith("/mcp")\` to exact pathname \`/mcp\` (query string OK).
- 6 path-routing regression tests covering /mcpXYZ, /mcp/, /mcp-leak, /, plus positive cases /mcp and /mcp?foo=bar.

## Why

\`startsWith("/mcp")\` routes \`/mcpXYZ\`, \`/mcp.foo\`, \`/mcp-anything\` to the JSON-RPC handler. Bearer auth still gates execution downstream, but the routable surface was wider than necessary and weird paths spent CPU on the routing branch before hitting the auth check.

## Test plan

\`bun test src/goals/loops-http-server.test.ts\` → **27 / 27 pass** (was 21, +6 new), 0 fail.

Non-blocking — bearer guard remained the actual auth boundary; this just stops nonsensical paths from reaching it.

cc @vansin

🤖 Generated with [Claude Code](https://claude.com/claude-code)