### PR TITLE
fix(rfc-028): SSRF allowlist extend — add DeepSeek + MiniMax to anthropic vendor (curated)

### DIFF
--- a/agent-node/src/shared/probe-host-allowlist.ts
+++ b/agent-node/src/shared/probe-host-allowlist.ts
@@ -24,17 +24,33 @@ export class ProbeValidationError extends Error {
   }
 }
 
-// ── §4.4.1 per-vendor host allowlist (P1: anthropic only) ─────────
-// P2 will extend: openai/zai/openrouter/deepseek/qwen. Each vendor
-// has ONE OR MORE allowed hostnames (regex anchored). custom vendor
-// requires admin to explicitly allowlist per-host (P3).
+// ── §4.4.1 per-vendor host allowlist ──────────────────────────────
+// `anthropic` vendor accepts Anthropic + curated 3rd-party Anthropic-
+// compatible endpoints that Vincent / N站马 ship live providers
+// against (DeepSeek + MiniMax both expose `/v1/messages` with the
+// Anthropic protocol surface). Whitelist semantics preserved — NOT
+// allow-any. New entries land here via PR with security review
+// (network-admin-configurable allowlist is backlog: needs strong
+// IP-range / shape guard before admins can edit).
+//
+// Per 通信龙 (RFC-028 P1.5+): the host whitelist is defense layer 1;
+// layer 2 is the DNS-resolved IP block (FORBIDDEN_IPV{4,6}_RE below),
+// applied AFTER allowlist passes. Any new host gets BOTH layers
+// automatically — host in allowlist + DNS resolves to private/metadata
+// IP still surfaces `probe_resolve_unsafe_ip`.
+//
+// P2 will add vendors (openai/zai/openrouter/qwen) as separate keys.
 export const VENDOR_HOST_ALLOWLIST: Record<string, ReadonlyArray<RegExp>> = {
-  anthropic:  [/^api\.anthropic\.com$/],
+  anthropic:  [
+    /^api\.anthropic\.com$/,
+    /^api\.deepseek\.com$/,     // Anthropic-compatible /v1/messages
+    /^api\.minimax\.chat$/,     // MiniMax legacy domain
+    /^api\.minimax\.io$/,       // MiniMax new domain (Vincent live use)
+  ],
   // P2:
   // openai:     [/^api\.openai\.com$/],
   // zai:        [/^api\.z\.ai$/, /^open\.bigmodel\.cn$/],
   // openrouter: [/^openrouter\.ai$/],
-  // deepseek:   [/^api\.deepseek\.com$/],
   // qwen:       [/^dashscope(-intl)?\.aliyuncs\.com$/],
 };
 export const SUPPORTED_VENDORS = Object.keys(VENDOR_HOST_ALLOWLIST);

--- a/server/src/probe-validate.test.ts
+++ b/server/src/probe-validate.test.ts
@@ -33,6 +33,40 @@ describe("validateBaseUrl (§4.4.1 vendor host allowlist)", () => {
   test("P1 SUPPORTED_VENDORS only contains anthropic", () => {
     expect(SUPPORTED_VENDORS).toEqual(["anthropic"]);
   });
+
+  // ── RFC-028 P1.5+ — Anthropic-compatible 3rd-party hosts on `anthropic` vendor.
+  // Whitelist semantics preserved; new entries require PR + security review.
+  // Host allowlist passes here; IP-level guard still fires at fetch time
+  // (covered by safelyFetchProbe + docker scenarios qa-rfc028 F + M.ssrf).
+  test("anthropic + api.deepseek.com → ok (Anthropic-compatible /v1/messages)", () => {
+    expect(() => validateBaseUrl("anthropic", "https://api.deepseek.com/v1")).not.toThrow();
+  });
+  test("anthropic + api.minimax.chat → ok (MiniMax legacy domain)", () => {
+    expect(() => validateBaseUrl("anthropic", "https://api.minimax.chat/v1")).not.toThrow();
+  });
+  test("anthropic + api.minimax.io → ok (MiniMax new domain, Vincent live)", () => {
+    expect(() => validateBaseUrl("anthropic", "https://api.minimax.io/v1")).not.toThrow();
+  });
+  test("subdomain of allowed host NOT accepted (regex anchored)", () => {
+    expect(() => validateBaseUrl("anthropic", "https://attacker.api.deepseek.com/v1")).toThrow(/probe_target_forbidden/);
+    expect(() => validateBaseUrl("anthropic", "https://api.minimax.io.attacker.example/v1")).toThrow(/probe_target_forbidden/);
+  });
+  test("homograph / look-alike host rejected (regex anchored)", () => {
+    expect(() => validateBaseUrl("anthropic", "https://api.deepseek.com.attacker/v1")).toThrow(/probe_target_forbidden/);
+    expect(() => validateBaseUrl("anthropic", "https://api-deepseek.com/v1")).toThrow(/probe_target_forbidden/);
+  });
+  test("VENDOR_HOST_ALLOWLIST.anthropic curated list = exactly 4 entries", () => {
+    // Lock the curated set — adding a 5th host MUST go through a PR
+    // bump this assertion (forces conscious security review).
+    expect(VENDOR_HOST_ALLOWLIST.anthropic.length).toBe(4);
+    const sources = VENDOR_HOST_ALLOWLIST.anthropic.map(r => r.source).sort();
+    expect(sources).toEqual([
+      "^api\\.anthropic\\.com$",
+      "^api\\.deepseek\\.com$",
+      "^api\\.minimax\\.chat$",
+      "^api\\.minimax\\.io$",
+    ]);
+  });
 });
 
 describe("isForbiddenIp (§4.4.2 private/reserved IP block — anti SSRF)", () => {

--- a/server/src/shared/probe-host-allowlist.ts
+++ b/server/src/shared/probe-host-allowlist.ts
@@ -24,17 +24,33 @@ export class ProbeValidationError extends Error {
   }
 }
 
-// ── §4.4.1 per-vendor host allowlist (P1: anthropic only) ─────────
-// P2 will extend: openai/zai/openrouter/deepseek/qwen. Each vendor
-// has ONE OR MORE allowed hostnames (regex anchored). custom vendor
-// requires admin to explicitly allowlist per-host (P3).
+// ── §4.4.1 per-vendor host allowlist ──────────────────────────────
+// `anthropic` vendor accepts Anthropic + curated 3rd-party Anthropic-
+// compatible endpoints that Vincent / N站马 ship live providers
+// against (DeepSeek + MiniMax both expose `/v1/messages` with the
+// Anthropic protocol surface). Whitelist semantics preserved — NOT
+// allow-any. New entries land here via PR with security review
+// (network-admin-configurable allowlist is backlog: needs strong
+// IP-range / shape guard before admins can edit).
+//
+// Per 通信龙 (RFC-028 P1.5+): the host whitelist is defense layer 1;
+// layer 2 is the DNS-resolved IP block (FORBIDDEN_IPV{4,6}_RE below),
+// applied AFTER allowlist passes. Any new host gets BOTH layers
+// automatically — host in allowlist + DNS resolves to private/metadata
+// IP still surfaces `probe_resolve_unsafe_ip`.
+//
+// P2 will add vendors (openai/zai/openrouter/qwen) as separate keys.
 export const VENDOR_HOST_ALLOWLIST: Record<string, ReadonlyArray<RegExp>> = {
-  anthropic:  [/^api\.anthropic\.com$/],
+  anthropic:  [
+    /^api\.anthropic\.com$/,
+    /^api\.deepseek\.com$/,     // Anthropic-compatible /v1/messages
+    /^api\.minimax\.chat$/,     // MiniMax legacy domain
+    /^api\.minimax\.io$/,       // MiniMax new domain (Vincent live use)
+  ],
   // P2:
   // openai:     [/^api\.openai\.com$/],
   // zai:        [/^api\.z\.ai$/, /^open\.bigmodel\.cn$/],
   // openrouter: [/^openrouter\.ai$/],
-  // deepseek:   [/^api\.deepseek\.com$/],
   // qwen:       [/^dashscope(-intl)?\.aliyuncs\.com$/],
 };
 export const SUPPORTED_VENDORS = Object.keys(VENDOR_HOST_ALLOWLIST);

--- a/tests/qa-rfc028-provider-probe/run.sh
+++ b/tests/qa-rfc028-provider-probe/run.sh
@@ -311,8 +311,44 @@ else
   echo "--- daemon-f.log tail ---"; tail -20 /tmp/daemon-f.log 2>/dev/null
 fi
 
-# Restore /etc/hosts + cleanup F daemon (don't disturb subsequent scenarios)
-cp /tmp/hosts.bak /etc/hosts && rm -f /tmp/hosts.bak && ok "F /etc/hosts restored"
+# Restore /etc/hosts before staging the DeepSeek DNS-attack variant
+cp /tmp/hosts.bak /etc/hosts && ok "F /etc/hosts restored after anthropic variant"
+
+# ── Scenario F.deepseek — verify IP-block fires for newly-allowlisted host ──
+# RFC-028 SSRF allowlist extension (PR following N站马 e2e): anthropic
+# vendor now also accepts api.deepseek.com / api.minimax.{chat,io}.
+# Critical security invariant per 通信龙: host whitelist is layer 1,
+# DNS-resolved IP block is layer 2 — both MUST fire for every host on
+# the list. F (above) proves it for api.anthropic.com; this variant
+# proves it for api.deepseek.com (same code path, but locks the new
+# host gets BOTH guards).
+note "F.deepseek — IP-block真 fires for api.deepseek.com (extended allowlist)"
+
+# Insert a provider on the SAME isolated F daemon (no need to restart it),
+# now with host=api.deepseek.com (which passes hub validateBaseUrl after
+# the allowlist extension)
+sqlite3 "$HUB_DB" "INSERT INTO providers (provider_id, network_id, name, vendor, base_url, secret_key_ref, created_at, created_by, enabled) VALUES ('prov_ds_attack', '$NET_ID', 'DeepSeek DNS Attack', 'anthropic', 'https://api.deepseek.com/v1', 'ANTHROPIC_API_KEY', $(date +%s%N | head -c 13), '$ADMIN_USER', 1);"
+sqlite3 "$HUB_DB" "INSERT INTO provider_models (model_id, provider_id, model_name, enabled, created_at) VALUES ('pm_ds_attack', 'prov_ds_attack', 'claude-x', 1, $(date +%s%N | head -c 13));"
+ok "F.deepseek provider inserted (host=api.deepseek.com, passes new allowlist)"
+
+# /etc/hosts override: point api.deepseek.com → 169.254.169.254
+echo "169.254.169.254 api.deepseek.com" >> /etc/hosts
+ok "F.deepseek /etc/hosts override: api.deepseek.com → 169.254.169.254"
+
+BODY='{"jsonrpc":"2.0","id":15,"method":"tools/call","params":{"name":"probe_provider_model","arguments":{
+  "provider_id":"prov_ds_attack","model_name":"claude-x","daemon_node_id":"'$F_DAEMON_NODE_ID'","network_id":"'$NET_ID'"}}}'
+RESP=$(mcp_call "$UTOK" "$BODY")
+PROBE_ID_FDS=$(echo "$RESP" | jq -r .probe_id 2>/dev/null)
+for i in {1..20}; do sleep 1; ST=$(sqlite3 "$HUB_DB" "SELECT status FROM probe_results WHERE probe_id='$PROBE_ID_FDS';" 2>/dev/null); [[ "$ST" != "pending" && -n "$ST" ]] && break; done
+
+if [[ "$ST" == "probe_resolve_unsafe_ip" ]]; then
+  ok "F.deepseek STRICT: ack.status == probe_resolve_unsafe_ip (allowlist passes host; IP-guard still rejects metadata IP — both layers active for extended hosts)"
+else
+  bad "F.deepseek STRICT FAIL: ack.status='$ST' expected exactly 'probe_resolve_unsafe_ip' — IP guard miss for new allowlist host (SSRF regression)"
+fi
+
+# Restore /etc/hosts + cleanup F daemon
+cp /tmp/hosts.bak /etc/hosts && rm -f /tmp/hosts.bak && ok "F.deepseek /etc/hosts restored"
 kill "$F_DAEMON_PID" 2>/dev/null || true
 
 # ── Scenario G — secret-no-leak (zod .strict() via JSON-parsed error code) ──


### PR DESCRIPTION
## Summary

- Extend \`VENDOR_HOST_ALLOWLIST.anthropic\` from 1 host (\`api.anthropic.com\`) to 4 curated Anthropic-compatible hosts.
- New entries: \`api.deepseek.com\`, \`api.minimax.chat\`, \`api.minimax.io\` (Vincent live use).
- Both SSRF defense layers preserved: host whitelist + IP-level block. F.deepseek scenario proves layer 2 still fires for newly-allowlisted host.
- Curated count locked at 4 in unit test — any 5th host requires conscious PR bump.

## Why

N站马 e2e hit \`probe_target_forbidden\` when building DeepSeek/MiniMax providers. These are legitimate Anthropic-compatible \`/v1/messages\` endpoints already running in production. Multi-provider was名存实亡 without this extension.

## Security invariants (per 通信龙 hard constraint)

| Layer | Mechanism | Still active after this PR? |
|:---|:---|:---:|
| 1 — host whitelist | regex-anchored allowlist, NOT allow-any | ✅ Yes (locked at 4 entries) |
| 2 — IP-level block | \`isForbiddenIp\` in \`safelyFetchProbe\` after \`dns.lookup\` | ✅ Yes (F.deepseek scenario verifies) |

**F.deepseek scenario** (\`tests/qa-rfc028-provider-probe/run.sh\`):
- Insert provider \`https://api.deepseek.com/v1\` — passes new host allowlist
- /etc/hosts override: \`api.deepseek.com → 169.254.169.254\` (cloud metadata)
- Probe dispatch → daemon's DNS resolves to forbidden IP → \`ack.status == "probe_resolve_unsafe_ip"\` STRICT
- Proves: allowlist passes the host, IP-guard still fires. Both layers active.

## Verification

| Suite | Result |
|:---|:---|
| \`bun test src/\` server suite | **421/421 pass** (was 415, +6) |
| Docker e2e qa-rfc028 | **51/51 PASS, exit=0** (was 47, +4 F.deepseek) |

**New unit tests** (\`server/src/probe-validate.test.ts\`):
- \`api.deepseek.com / api.minimax.chat / api.minimax.io\` accepted
- Subdomain (\`attacker.api.deepseek.com\`) rejected — regex anchored
- Look-alike (\`api.deepseek.com.attacker\`, \`api-deepseek.com\`) rejected
- Curated count locked at exactly 4 entries with sorted source list (forces PR bump for any 5th host → conscious security review)

**G9 drift guard**: byte-identical mirror to \`agent-node/src/shared/probe-host-allowlist.ts\` — drift test asserts source-set equality across hub + daemon, still passes.

## Backlog (out of scope here)

- Network-admin-configurable allowlist (needs strong IP-range / shape guard before admins can edit, otherwise admin误配 = SSRF). 通信龙: backlog.

## Test plan

- [ ] 通信牛 review — host whitelist + IP-guard both verified active for extended hosts
- [ ] N站马 flip DeepSeek / MiniMax providers \`enabled: true\` via dashboard

cc @vansin

🤖 Generated with [Claude Code](https://claude.com/claude-code)