### PR TITLE
feat(#179 image-trace): observability — surface silent download failures to stderr

### DIFF
--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -358,17 +358,30 @@ async function maybeAttachImages(
   client: lark.Client | null,
   mediaDir: string | null,
 ): Promise<void> {
-  if (!client || !mediaDir) return;
+  const msgId = normalized.messageId;
+  if (!client) {
+    process.stderr.write(`[feishu:image] ${msgId} skip: no lark client\n`);
+    return;
+  }
+  if (!mediaDir) {
+    process.stderr.write(`[feishu:image] ${msgId} skip: no mediaDir configured\n`);
+    return;
+  }
   const raw = rawEvent as FeishuRawEvent | undefined;
   const message = raw?.message;
-  if (!message || message.message_type !== "image") return;
+  if (!message || message.message_type !== "image") return; // not an image — silent (event is text)
   let imageKey: string | undefined;
   try {
     imageKey = (JSON.parse(message.content) as { image_key?: string }).image_key;
-  } catch {
+  } catch (e: any) {
+    process.stderr.write(`[feishu:image] ${msgId} skip: content not JSON (${e?.message ?? e})\n`);
     return;
   }
-  if (!imageKey || !message.message_id) return;
+  if (!imageKey || !message.message_id) {
+    process.stderr.write(`[feishu:image] ${msgId} skip: no image_key/message_id (key=${imageKey})\n`);
+    return;
+  }
+  process.stderr.write(`[feishu:image] ${msgId} download begin (key=${imageKey.slice(0, 16)}…, dir=${mediaDir})\n`);
   const localPath = await downloadImage(
     client,
     message.message_id,
@@ -377,7 +390,10 @@ async function maybeAttachImages(
     normalized.conversation?.conversationId,
   );
   if (localPath) {
+    process.stderr.write(`[feishu:image] ${msgId} download ok → ${localPath}\n`);
     normalized.content = { ...normalized.content, images: [localPath] };
+  } else {
+    process.stderr.write(`[feishu:image] ${msgId} download FAILED (see downloadImage stderr above)\n`);
   }
 }
 
@@ -433,7 +449,10 @@ async function downloadImage(
       path: { message_id: messageId, file_key: imageKey },
       params: { type: "image" },
     });
-    if (!resp) return null;
+    if (!resp) {
+      process.stderr.write(`[feishu:image] ${messageId} messageResource.get returned falsy (no stream)\n`);
+      return null;
+    }
     const stream = resp as unknown as Readable;
     const chunks: Buffer[] = [];
     await new Promise<void>((resolve, reject) => {
@@ -442,11 +461,16 @@ async function downloadImage(
       stream.on("error", (err: Error) => reject(err));
     });
     const body = Buffer.concat(chunks);
+    process.stderr.write(`[feishu:image] ${messageId} stream collected ${body.length} bytes\n`);
     // Magic-byte mime whitelist — reject non-image payloads even if the
     // server marked them as images. Defends against extension confusion +
     // accidental binary delivery.
     const detected = detectImageMime(body);
-    if (!detected) return null;
+    if (!detected) {
+      const head = body.slice(0, 16).toString("hex");
+      process.stderr.write(`[feishu:image] ${messageId} mime rejected (head hex: ${head})\n`);
+      return null;
+    }
     // Path layout: `<mediaDir>/<conversationId-or-_>/<msg_id>.<ext>` —
     // conversationId subdir keeps a chat's attachments together (easier
     // for an operator to spot-check + GC). msg_id is unique enough across
@@ -460,7 +484,13 @@ async function downloadImage(
     const filepath = join(subdir, `${safeMsgId}.${detected.ext}`);
     writeFileSync(filepath, body);
     return filepath;
-  } catch {
+  } catch (e: any) {
+    // Surface the lark/HTTP error so operators can act (99991672 scope,
+    // 99992354 invalid id, network, disk-full, etc.) instead of staring
+    // at a silent "no image processed".
+    const errMsg = e?.message ?? String(e);
+    const errCode = e?.response?.data?.code ?? e?.code ?? "";
+    process.stderr.write(`[feishu:image] ${messageId} downloadImage threw: code=${errCode} msg=${errMsg}\n`);
     return null;
   }
 }


### PR DESCRIPTION
## Author
Agent: 通信IM马 (claude-code-cli)

## Summary

Audit-driven follow-up to merged #321. Vincent UAT on preview.4: sent image → bot replied "无可处理内容" → I dug into the deployed `worker.js` bundle and found:

- ✅ `maybeAttachImages` + `image_key` extraction + `messageResource.get` + `content.images=[path]` are all **in the deployed bundle** (commits `ada2227` + `1eaaf62` long-shipped)
- ❌ Every failure mode silently `catch { return null }` — no telemetry whatsoever distinguishes "no event arrived" from "event arrived but download silently dropped"

So 通信龙's hypothesis ("preview.4 might not parse images at all") was half-right: the code IS there, but operators can't see which step fails. This patch turns every silent return into a stderr line.

## Failure modes now visible

| stderr line | meaning | actionable |
|---|---|---|
| `[feishu:image] om_X skip: no lark client` | adapter not init'd | bug — should never happen |
| `[feishu:image] om_X skip: no mediaDir configured` | channelDir / env override missing | restore config |
| `[feishu:image] om_X skip: content not JSON (...)` | malformed Feishu payload | report / repro |
| `[feishu:image] om_X skip: no image_key/message_id` | empty key | look at Feishu payload schema |
| `[feishu:image] om_X download begin (key=..., dir=...)` | hitting messageResource.get | — |
| `[feishu:image] om_X messageResource.get returned falsy` | lark SDK returned null | check SDK version / API change |
| `[feishu:image] om_X stream collected N bytes` | bytes received | — |
| `[feishu:image] om_X mime rejected (head hex: ...)` | bytes aren't an image | likely scope HTML error body |
| `[feishu:image] om_X downloadImage threw: code=99991672 msg=...` | scope rejection (or any HTTP error) | operator adds scope |
| `[feishu:image] om_X download ok → /work/feishu-attachments/...` | success | agent should pick this up |
| `[feishu:image] om_X download FAILED` | summary marker | look at upstream stderr |

No behavior change, no perf cost — just observability. Pairs with #321 (already merged) so preview.5 ships with both path-based mediaDir + traceable downloads.

## Why bare `catch {}` was wrong

The original code (M5c, 2026-06-24) said "Failure is non-fatal — text flow proceeds even when download fails" → all-or-nothing exception handling. That's correct UX (don't crash the worker on a single image), but **dropping ALL telemetry** is over-defensive. Vincent's UAT today went 0 → fail with no breadcrumb at all. Operators need to see WHICH step failed without re-running with `--inspect`.

## Tests

```
$ bun tests/feishu-image-download.test.ts → 43/43
$ bun tests/feishu-bridge-ackplaceholder.test.ts → 16/16
$ npm run typecheck → clean
```

No new tests because behavior is unchanged — only stderr lines added. Existing tests cover the path branches; this just makes them loggable.

## Closes

(continues #179 — does NOT close, image input MVP needs preview.5 ship + Vincent UAT confirm before close)

## Test plan

- [x] regression 43+16 pass
- [x] typecheck clean
- [ ] (post-merge + preview.5 ship + restart) Vincent sends image → log shows the exact failure step (or success path)

🤖 Generated by 通信IM马 (claude-code-cli)