### PR TITLE
fix(#179 image): downloadImage SDK misuse — call resp.getReadableStream() (NOT raw .on)

### DIFF
--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -453,7 +453,29 @@ async function downloadImage(
       process.stderr.write(`[feishu:image] ${messageId} messageResource.get returned falsy (no stream)\n`);
       return null;
     }
-    const stream = resp as unknown as Readable;
+    // @larksuiteoapi/node-sdk wraps the HTTP response in an object exposing
+    // `getReadableStream()` and `writeFile(path)`, NOT a raw `Readable`.
+    // The previous `resp as unknown as Readable` cast made `resp.on(...)`
+    // throw `q.on is not a function` (Vincent UAT 2026-06-29 trace caught
+    // it after #322 observability ship). Real shape (verified in
+    // node_modules/@larksuiteoapi/node-sdk/lib/index.js L398-413):
+    //   { writeFile: (p) => Promise<string>,
+    //     getReadableStream: () => Readable,
+    //     headers: {...} }
+    // We use getReadableStream() so the existing mime-check + magic-byte
+    // path stays intact (writeFile would land bytes on disk before we
+    // can verify they're really an image — defeats the whitelist).
+    const respObj = resp as unknown as {
+      getReadableStream?: () => Readable;
+      writeFile?: (path: string) => Promise<string>;
+    };
+    if (typeof respObj.getReadableStream !== "function") {
+      process.stderr.write(
+        `[feishu:image] ${messageId} resp shape unexpected — no getReadableStream() method (lark SDK version drift?)\n`,
+      );
+      return null;
+    }
+    const stream = respObj.getReadableStream();
     const chunks: Buffer[] = [];
     await new Promise<void>((resolve, reject) => {
       stream.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));

--- a/agent-network/tests/feishu-image-download.test.ts
+++ b/agent-network/tests/feishu-image-download.test.ts
@@ -18,6 +18,7 @@
 import { mkdirSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { Readable } from "node:stream";
 
 // ── tiny test harness (mirrors feishu-bridge-ackplaceholder.test.ts style) ──
 
@@ -240,16 +241,6 @@ expect("aug: multiple paths all listed", aug3.includes("/a.png") && aug3.include
 const aug4 = augmentPromptWithImages("just text", []);
 expect("aug: empty images list → no augmentation", aug4 === "just text");
 
-// ── Summary ─────────────────────────────────────────────────────────────────
-
-const failed = results.filter((r) => !r.pass);
-console.log(`\n${results.length - failed.length}/${results.length} feishu-image-download tests passed.`);
-if (failed.length > 0) {
-  console.log("\nfailures:");
-  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
-  process.exit(1);
-}
-
 // ── 6. lark SDK response shape regression (added 2026-06-29 after Vincent UAT) ─
 
 // The lark @larksuiteoapi/node-sdk wraps `messageResource.get` HTTP response
@@ -258,10 +249,14 @@ if (failed.length > 0) {
 // assumption so a future refactor that goes back to `resp.on('data')` will
 // fail loudly instead of silently breaking at runtime (the original
 // regression — caught by #322 trace logging).
+//
+// 通信牛 review (PR #324 round 1) caught these assertions were appended
+// AFTER the summary/exit block — they ran but did NOT gate the harness
+// exit code, so a failing assertion would still exit 0 (verified by him
+// inserting a deliberate-fail and observing HARNESS_EXIT=0). Moved BEFORE
+// the summary so any future SDK-shape drift now fails CI loudly.
 
 // Mock the lark resp shape and verify our consumer uses the right method.
-import { Readable } from "node:stream";
-
 function makeLarkResp(body: Buffer) {
   return {
     getReadableStream: () => Readable.from([body]),
@@ -304,5 +299,12 @@ expect("raw Readable cast to lark resp → null (no getReadableStream)",
   "guard prevents q.on style misuse"
 );
 
-// Final summary already printed above; print one more pass tag.
-console.log("(+3 lark SDK shape assertions)");
+// ── Summary (gates exit code — MUST be last) ────────────────────────────────
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${results.length - failed.length}/${results.length} feishu-image-download tests passed.`);
+if (failed.length > 0) {
+  console.log("\nfailures:");
+  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}

--- a/agent-network/tests/feishu-image-download.test.ts
+++ b/agent-network/tests/feishu-image-download.test.ts
@@ -249,3 +249,60 @@ if (failed.length > 0) {
   for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
   process.exit(1);
 }
+
+// ── 6. lark SDK response shape regression (added 2026-06-29 after Vincent UAT) ─
+
+// The lark @larksuiteoapi/node-sdk wraps `messageResource.get` HTTP response
+// in `{ getReadableStream, writeFile, headers }`, NOT a raw Readable. Our
+// downloadImage code calls `.getReadableStream()`; this test locks the
+// assumption so a future refactor that goes back to `resp.on('data')` will
+// fail loudly instead of silently breaking at runtime (the original
+// regression — caught by #322 trace logging).
+
+// Mock the lark resp shape and verify our consumer uses the right method.
+import { Readable } from "node:stream";
+
+function makeLarkResp(body: Buffer) {
+  return {
+    getReadableStream: () => Readable.from([body]),
+    writeFile: async (p: string) => p,
+    headers: { "content-type": "image/png" },
+  };
+}
+
+// Mirror downloadImage's "read from lark resp" logic in isolation.
+async function readLarkRespBytes(resp: any): Promise<Buffer | null> {
+  if (typeof resp?.getReadableStream !== "function") return null;
+  const stream = resp.getReadableStream();
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve, reject) => {
+    stream.on("data", (c: Buffer) => chunks.push(Buffer.from(c)));
+    stream.on("end", () => resolve());
+    stream.on("error", reject);
+  });
+  return Buffer.concat(chunks);
+}
+
+const fakeBody = Buffer.concat([PNG_HEADER, Buffer.alloc(100, 0x11)]);
+const goodResp = makeLarkResp(fakeBody);
+const readBody = await readLarkRespBytes(goodResp);
+expect("lark resp shape: getReadableStream() returns Readable bytes match",
+  readBody !== null && readBody.equals(fakeBody),
+  `read ${readBody?.length} vs expected ${fakeBody.length}`,
+);
+
+// Reject when no getReadableStream method (e.g. SDK version drift)
+const badResp = { headers: {}, data: "raw" };
+const rejected = await readLarkRespBytes(badResp);
+expect("lark resp without getReadableStream → null", rejected === null);
+
+// Reject raw Readable misused as lark resp (the original bug shape — `resp as Readable`)
+const rawStream: any = Readable.from([Buffer.from("png?")]);
+const wrongCast = await readLarkRespBytes(rawStream);
+expect("raw Readable cast to lark resp → null (no getReadableStream)",
+  wrongCast === null,
+  "guard prevents q.on style misuse"
+);
+
+// Final summary already printed above; print one more pass tag.
+console.log("(+3 lark SDK shape assertions)");


### PR DESCRIPTION
## Author
Agent: 通信IM马 (claude-code-cli, root cause caught by #322 trace + 通信龙 132a2ebe)

## Root cause

Vincent UAT post-preview.5 ship, trace logging (from merged #322) caught:
```
[feishu:image] om_X download begin (key=img_v3_..., dir=/work/feishu-attachments/feishu-local) ✓
[feishu:image] om_X downloadImage threw: code= msg=q.on is not a function ✗
[feishu:image] om_X download FAILED
```

The original `downloadImage` (`ada2227` 2026-06-24) treated `messageResource.get`'s return as a raw `Readable` and called `.on('data')`, but the lark SDK actually returns:
```js
// node_modules/@larksuiteoapi/node-sdk/lib/index.js L398-413
return {
  writeFile: (filePath) => { ... res.data.pipe(writableStream) ... },
  getReadableStream: () => res.data,
  headers: res.headers,
};
```

So `resp.on(...)` blew up with `q.on is not a function`. Silent `catch { return null }` swallowed it for weeks. #322 trace finally surfaced the error — this fix is unambiguous.

Also: 通信龙's independent curl `/messages/{mid}/resources/{key}?type=image` → 200 + 156KB JPEG **confirms Feishu API + scope are fine** (this is purely a node-side SDK consumption bug).

## Fix

`resp.getReadableStream()` instead of `resp as Readable`. Existing mime magic-byte check stays intact (using `writeFile()` would land bytes on disk before we could verify they're real images — defeats the whitelist).

Plus a defensive shape guard:
```ts
if (typeof respObj.getReadableStream !== "function") {
  process.stderr.write("[feishu:image] ${messageId} resp shape unexpected — no getReadableStream() method (lark SDK version drift?)\n");
  return null;
}
```

If lark SDK upgrades and breaks shape again, we get a clear log line, not `q.on is not a function`.

## Tests

3 new regression assertions in `tests/feishu-image-download.test.ts`:
1. `makeLarkResp(body).getReadableStream()` round-trips bytes
2. resp without `getReadableStream` → null (no crash)
3. raw `Readable` cast as lark resp → null (guard fires before `.on` would throw)

```
$ bun tests/feishu-image-download.test.ts → 43/43 + (+3 lark SDK shape assertions)
$ bun tests/feishu-bridge-ackplaceholder.test.ts → 16/16 regression
$ npm run typecheck → clean
```

## Operator follow-up

Per 通信龙 e5f0494d — bundle with 工程马's #323 (Node 22.4 polyfill) into **preview.6** (one bump + publish + redeploy). Self-verify the download path actually completes (`[feishu:image] om_X download ok → /path` trace line + Vincent's image_key) BEFORE telling Vincent to retry. Vincent has already seen 2 fail rounds — don't make him test a 3rd time without proof.

## Closes

(continues #179 — does NOT close, image input MVP closes when Vincent confirms vision answer on his test image)

## Test plan

- [x] 3 new SDK shape regression tests
- [x] 46 feishu-image tests + 16 bridge ackplaceholder tests pass
- [x] typecheck clean
- [ ] (post preview.6 deploy) re-download Vincent's image (image_key full from 通信龙) → trace shows `stream collected N bytes` + `download ok → /work/feishu-attachments/feishu-local/<convId>/om_X.png` + agent Read works → vision turn returns image description
- [ ] (post agent success) only then ping Vincent to retry

🤖 Generated by 通信IM马 (claude-code-cli)