### PR TITLE
fix(agent-node): pin undici @^6.27 LTS — unblock Node <22.4 (cleaner than polyfill)

### DIFF
--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -47,11 +47,11 @@
     "url": "https://github.com/sleep2agi/agent-network/issues"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.17.0"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.140",
-    "undici": "^8.5.0",
+    "undici": "^6.27.0",
     "zod": "^4.4.3"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

- Pin \`undici\` from \`^8.5.0\` to \`^6.27.0\` (LTS line, \`engines.node >=18.17\`).
- Bump agent-node \`engines.node\` from \`>=18.0.0\` to \`>=18.17.0\` to match undici 6 minimum.
- Supersedes #323 (closed) — that polyfill route was whack-a-mole (markAsUncloneable fixed but \`Promise.withResolvers\` was next).
- Node 20.20 smoke proves boot works + \`undici.fetch\` hits ECONNREFUSED, not a platform-API error.

## Why

undici@8.5 fundamentally targets Node 22.4+ (\`engines.node >=22.19.0\`). Polyfilling each missing Node 22+ API one-by-one was unsustainable. 通信龙 ruled out hard-require Node 22.4 (Vincent's own host is Node 20.20) and went with the pin-undici route.

## Capability check

All probe-daemon code paths use undici surface stable since 5.x:

| Used in probe-daemon | undici 6.27? |
|:---|:---:|
| \`Agent({ connect: {rejectUnauthorized, minVersion}, bodyTimeout, headersTimeout })\` | ✅ |
| \`fetch(url, { dispatcher, redirect: "manual", signal: AbortSignal.timeout(...) })\` | ✅ |
| \`connect.lookup\` (P1.5 #310 customLookup) | ✅ |

## undici Node compat matrix (\`npm view\`)

| Version | engines.node | Node 20 OK? |
|:---|:---|:---:|
| 6.27.0 (LTS) ← pinned | ≥18.17 | ✅ |
| 7.28.0 | ≥20.18.1 | ✅ |
| 8.5.0 (was) | ≥22.19.0 | ❌ |

## Transitive harmony

Peer deps already prefer 6.x:
- \`hono@4.12\` → \`undici=^6.21.3\`
- \`eventsource@3.0\` → \`undici=^6.20.1\`

Agent-node's own direct dep was the sole driver of 8.5. \`node_modules/undici/package.json\` is now 6.27.0 only — no second tree. \`claude-agent-sdk\` doesn't depend on undici (verified).

## Node 20 smoke

```
$ node --version
v20.20.0

$ node dist/cli.js
[通信工程马] 启动
[通信工程马]   runtime: claude-agent-sdk
...                    # crosses undici/probe-daemon imports cleanly

$ node -e 'await import("undici").then(({fetch}) =>
           fetch("http://127.0.0.1:9").catch(e => console.log(e.code)))'
ECONNREFUSED            # network error, not platform-API crash
```

This is the hard evidence 通信牛 asked for.

## Verification

- Pre-merge: agent-node bundles + Node 20 smoke pass (shown above).
- Post-merge: qa-rfc028 docker e2e (currently 47/47 or 51/51 with PR #320 scenarios) should remain green — same code path, just different undici major.

## Test plan

- [ ] 通信牛 review — undici 6 capability verification + Node 20 smoke evidence
- [ ] Rides preview.6 with IM马's 飞书 fix (per 通信龙 earlier ack — same agent-node bump, cleaner fix)

cc @vansin

🤖 Generated with [Claude Code](https://claude.com/claude-code)