### PR TITLE
feat(feishu): vendor-error transient retry — 1-2 short backoff before sanitize

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -27,7 +27,12 @@ import { startTelegramWatchdog } from "./telegram-watchdog";
 import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
 import { maskedEnv } from "./secret-mask";
-import { isVendorErrorForUser, VENDOR_ERROR_REPLACEMENT } from "./vendor-error";
+import {
+  isVendorErrorForUser,
+  isTransientVendorError,
+  VENDOR_ERROR_REPLACEMENT,
+  VENDOR_RETRY_PROFILE,
+} from "./vendor-error";
 import {
   CommHubError,
   classifyCommHubResponse,
@@ -2736,6 +2741,54 @@ async function processTask(task: string, from: string, taskId: string | null = n
     failed = true;
   }
 
+  // Vendor-error transient retry (Vincent 2026-06-29 UAT — 通信龙 65e59373):
+  // MiniMax `status_code:1000` / `unknown error` / `choices:null` are
+  // transient; Vincent's logs show the very next turn (72s later) succeeded.
+  // Retry the SAME prompt up to `VENDOR_RETRY_PROFILE.maxRetries` times
+  // with short backoff (1.5s / 3s by default) BEFORE letting the
+  // sanitization layer replace the text. This makes image+text replies
+  // actually answer on transient blip rather than showing "暂时异常"
+  // after one shot.
+  //
+  // `isTransientVendorError` excludes 401/403/quota/429 so we don't waste
+  // round-trips on errors that won't recover. Auth/quota → sanitize
+  // immediately on the existing layer below.
+  for (
+    let retryAttempt = 1;
+    retryAttempt <= VENDOR_RETRY_PROFILE.maxRetries &&
+    text &&
+    isTransientVendorError(text, failed);
+    retryAttempt++
+  ) {
+    const backoff =
+      VENDOR_RETRY_PROFILE.backoffMs[retryAttempt - 1] ??
+      VENDOR_RETRY_PROFILE.backoffMs[VENDOR_RETRY_PROFILE.backoffMs.length - 1] ??
+      1500;
+    warn(
+      `[vendor-retry] transient error detected, retrying in ${backoff}ms (attempt ${retryAttempt}/${VENDOR_RETRY_PROFILE.maxRetries})`,
+    );
+    await new Promise((r) => setTimeout(r, backoff));
+    try {
+      const retried = await think(augmentedTask, from, taskId, images);
+      text = retried;
+      failed = false;
+      // Re-apply the API-error detection on the retry result (consistency
+      // with the first-attempt path; without this a retried "API error"
+      // message would slip through as `failed=false`).
+      if (
+        /(API 错误|API error|需要设置.*KEY|missing.*key|issue with the selected model|may not have access|may not exist|model.+not.+(found|available))/i.test(
+          text,
+        )
+      ) {
+        failed = true;
+      }
+    } catch (err: any) {
+      text = `${RUNTIME} 错误: ${err.message}`;
+      failed = true;
+      warn(`[vendor-retry] retry attempt ${retryAttempt} threw: ${err?.message ?? err}`);
+    }
+  }
+
   // Vendor-response sanitize (Vincent 2026-06-29 catch — MiniMax /anthropic
   // endpoint returned `base_resp:{status_code:1000,"unknown error, 999"}`
   // + `choices:null`; claude-agent-sdk's zod schema rejected it with an
@@ -2747,12 +2800,15 @@ async function processTask(task: string, from: string, taskId: string | null = n
   // terms (e.g. "ZodError 是 Zod 校验库抛出的异常") aren't mis-sanitized.
   // Predicate lives in src/vendor-error.ts so it can be unit-tested
   // without dragging cli.ts's network side-effects into the test bun.
+  // The retry loop above gave us up to N additional attempts for transient
+  // errors; we sanitize here only if those all also failed (or the error
+  // is non-transient like 401/quota).
   if (text && isVendorErrorForUser(text, failed)) {
     const raw = text;
     text = VENDOR_ERROR_REPLACEMENT;
     failed = true;
     process.stderr.write(
-      `[vendor-error] sanitized for user; raw: ${raw.slice(0, 400).replace(/\n/g, " ")}\n`,
+      `[vendor-error] sanitized for user (after retries exhausted); raw: ${raw.slice(0, 400).replace(/\n/g, " ")}\n`,
     );
   }
   return { text, failed };

--- a/agent-node/src/vendor-error.ts
+++ b/agent-node/src/vendor-error.ts
@@ -63,17 +63,38 @@ export const VENDOR_ERROR_REPLACEMENT =
  * Decide whether `text` is the raw bytes of a vendor / SDK failure
  * envelope that must NOT reach the user-facing IM reply.
  *
- * See module docstring for the correlation rules.
+ * Single unified gate (通信牛 #331 round 1):
+ *   sanitize / retry ONLY when BOTH conditions hold:
+ *     (a) `failed === true`  — the SDK threw or processWithClaude already
+ *                              wrapped the result in a `<runtime> 错误:`
+ *                              prefix (real failure context, not just
+ *                              an LLM reply discussing error formats).
+ *     (b) `matchCount >= 2`  — at least two DISTINCT vendor-envelope
+ *                              signals correlate. A single broad pattern
+ *                              like `ZodError` or `base_resp` could
+ *                              appear in a normal Q&A — the signature
+ *                              of a real failure envelope is multiple
+ *                              correlated terms (e.g. zod issue + null
+ *                              choices + status_code != 0).
+ *
+ * Trade-off accepted: a rare SDK-throw whose error text contains only
+ * one signal (e.g. `claude 错误: ZodError: cannot parse`) slips through
+ * un-sanitized. User sees the raw line. Stricter than ideal but
+ * eliminates false-positives on technical discussion that quotes
+ * multiple error terms in success context.
+ *
+ * Both `isVendorErrorForUser` (sanitize gate) and `isTransientVendorError`
+ * (retry gate) use this same predicate as their base — single source of
+ * truth, no drift.
  */
 export function isVendorErrorForUser(
   text: string,
   failed: boolean,
 ): boolean {
   if (!text || typeof text !== "string") return false;
+  if (!failed) return false; // success context: never sanitize
   const matchCount = VENDOR_ERROR_PATTERNS.filter((p) => p.test(text)).length;
-  if (matchCount === 0) return false;
-  if (failed) return true; // failure context + ≥1 signal → sanitize
-  return matchCount >= 2; // success context: need ≥2 correlated signals
+  return matchCount >= 2; // failure + ≥2 distinct signals
 }
 
 /**

--- a/agent-node/src/vendor-error.ts
+++ b/agent-node/src/vendor-error.ts
@@ -75,3 +75,51 @@ export function isVendorErrorForUser(
   if (failed) return true; // failure context + ≥1 signal → sanitize
   return matchCount >= 2; // success context: need ≥2 correlated signals
 }
+
+/**
+ * Vincent UAT 2026-06-29 实测: MiniMax `status_code:1000` / `unknown error`
+ * / `choices:null` are TRANSIENT — the very next turn (72s later) returned
+ * a valid response without operator intervention. Sanitizing on first hit
+ * means a clean retry path goes to waste; the user sees "暂时异常 请重发"
+ * for what should have just been a one-second retry.
+ *
+ * `isTransientVendorError(text, failed)` returns true ONLY when the error
+ * is BOTH (a) a vendor-error per `isVendorErrorForUser` AND (b) reasonably
+ * likely to succeed on retry. Excludes:
+ *   - auth-class errors (401 / 403 / unauthorized / quota / insufficient
+ *     credit) — these won't recover on retry; operator must rotate
+ *     credentials / top up.
+ *   - rate-limit (429, too many requests) — caller might decide to retry
+ *     with longer backoff, but the default short backoff isn't enough.
+ *
+ * 通信龙 65e59373 lock: retry transient 1-2 times with short backoff
+ * BEFORE sanitization, so Vincent's image+text replies don't sanitize on
+ * a single-shot 1000 when the retry would've worked.
+ */
+export function isTransientVendorError(
+  text: string,
+  failed: boolean,
+): boolean {
+  if (!isVendorErrorForUser(text, failed)) return false;
+  // Auth-class errors won't recover on retry — don't waste round-trips.
+  if (/\b401\b|\b403\b|unauthorized|forbidden/i.test(text)) return false;
+  if (/quota|insufficient[_\s]?(credit|balance|funds|tokens?)/i.test(text)) return false;
+  // Explicit rate-limit signal — caller-level backoff needed, not our short retry.
+  if (/\b429\b|too[_\s]?many[_\s]?requests|rate[_\s]?limit/i.test(text)) return false;
+  // Everything else looks transient (vendor 1000 / unknown error / choices null
+  // / SDK zod fail on malformed response / OpenAI-style 5xx envelopes).
+  return true;
+}
+
+/**
+ * Configurable retry profile — exported so callers (cli.ts) and tests can
+ * align without hard-coding magic numbers in two places.
+ */
+export const VENDOR_RETRY_PROFILE = {
+  /** Total retry attempts after the initial think() call. 2 = up to 3
+   *  total attempts (initial + 2 retries). */
+  maxRetries: 2,
+  /** Backoff schedule per retry attempt (ms). Length should match
+   *  maxRetries; missing entries fall back to last entry. */
+  backoffMs: [1500, 3000],
+} as const;

--- a/agent-node/tests/vendor-error-sanitize.test.ts
+++ b/agent-node/tests/vendor-error-sanitize.test.ts
@@ -8,14 +8,26 @@
  * reply. cli.ts now scrubs known vendor-error shapes and replaces with
  * clean Chinese message; raw stays in stderr for operators.
  *
- * 通信牛 #330 round 1 refinement: single-pattern matches like `ZodError`
- * would false-positive on legitimate technical replies discussing error
- * formats. The new `isVendorErrorForUser(text, failed)` predicate combines
- * `failed` context with multi-signal correlation so normal Q&A about
- * Zod / OpenAI errors / base_resp passes through untouched.
+ * 通信牛 #331 round 1 contract — single unified gate:
+ *   sanitize / retry ONLY when BOTH conditions hold:
+ *     (a) `failed === true`  — SDK threw / `<runtime> 错误:` prefix
+ *                              (real failure context, not LLM prose
+ *                              discussing error formats).
+ *     (b) `matchCount >= 2`  — at least two DISTINCT vendor-envelope
+ *                              signals correlate. A single broad term
+ *                              ("ZodError", "base_resp") could appear
+ *                              in a normal reply; correlation is the
+ *                              signature of a real envelope leak.
  *
- * This test imports the SAME `isVendorErrorForUser` production exports —
- * no regex duplication. Any change in cli.ts is visible here.
+ * Trade-off accepted: a rare SDK-throw whose error text has only ONE
+ * signal slips through un-sanitized; user sees raw `claude 错误:
+ * ZodError: ...`. Stricter, but eliminates false-positives on
+ * legitimate technical replies (success context with multi-signal
+ * prose). Operator can still see raw via stderr.
+ *
+ * This test imports the SAME `isVendorErrorForUser` production export —
+ * no regex duplication. Any change in cli.ts is visible here. Both
+ * sanitize and retry gates use a single predicate; no drift between them.
  *
  * Run: `bun tests/vendor-error-sanitize.test.ts`
  */
@@ -34,6 +46,11 @@ function expect(name: string, pred: boolean, detail = ""): void {
 }
 
 // ── 1. Vincent UAT real shape — failed=true + multi-signal → sanitize ────
+//
+// The actual Vincent UAT envelope (MiniMax 1000) contains ZodError +
+// invalid_union + base_resp(non-zero status_code) + "choices":null — at
+// least 4 distinct signals. With failed=true (SDK threw, processWithClaude
+// wrapped in `claude 错误:` prefix), this MUST trigger sanitize.
 
 const VINCENT_UAT_SHAPE = `claude 错误: ZodError: [
   {
@@ -49,17 +66,22 @@ expect(
   "Vincent UAT shape + failed=true → sanitize",
   isVendorErrorForUser(VINCENT_UAT_SHAPE, true),
 );
-// Even if `failed` accidentally false, the multi-signal correlation
-// still catches it.
+
+// Same shape but failed=false (LLM happened to echo this in a reply — eg.
+// "show me what the error looked like"): MUST NOT sanitize. failed-context
+// is the load-bearing signal; raw envelope in a successful think() output
+// is the LLM faithfully quoting an error format the user asked about.
 expect(
-  "Vincent UAT shape + failed=false → still sanitize (multi-signal correlation)",
-  isVendorErrorForUser(VINCENT_UAT_SHAPE, false),
+  "Vincent UAT shape + failed=false → NOT sanitize (no failure context)",
+  !isVendorErrorForUser(VINCENT_UAT_SHAPE, false),
 );
 
-// ── 2. 通信牛 #330 round 1 counterexamples — MUST NOT sanitize ─────────────
+// ── 2. 通信牛 #330+#331 counter-examples — single-signal prose ─────────────
+// These are the false-positives that the OLD `failed=true + ≥1 signal`
+// gate misfired on. Under the new gate, single-signal text in either
+// success or failure context passes through untouched.
 
-// (a) Plain technical discussion of ZodError term (failed=false, single signal)
-const NIU_CASES: Array<[string, string]> = [
+const NIU_COUNTER_CASES: Array<[string, string]> = [
   ["ZodError discussion", "ZodError 是 Zod 校验库抛出的异常，常见于 schema mismatch。"],
   ["invalid_union discussion", "如果 union 不匹配，Zod 可能返回 invalid_union。"],
   [
@@ -71,48 +93,98 @@ const NIU_CASES: Array<[string, string]> = [
     '正常讨论 base_resp：{"base_resp":{"status_code":1001}} 表示上游失败',
   ],
 ];
-for (const [name, text] of NIU_CASES) {
+for (const [name, text] of NIU_COUNTER_CASES) {
+  // success context, single signal — pass through
   expect(
-    `通信牛-counter (failed=false, single signal) NOT sanitized: ${name}`,
+    `counter (failed=false, single signal) → NOT sanitize: ${name}`,
     !isVendorErrorForUser(text, false),
+    `text: ${text.slice(0, 80)}`,
+  );
+  // failure context, single signal — also pass through under the new
+  // gate. The user sees the raw single-signal error line, which is the
+  // accepted trade-off vs misfiring on success-context discussion.
+  expect(
+    `counter (failed=true, single signal) → NOT sanitize: ${name}`,
+    !isVendorErrorForUser(text, true),
     `text: ${text.slice(0, 80)}`,
   );
 }
 
-// But if the LLM REALLY threw on these AND we're in failed=true context,
-// sanitize is correct (operator-visible raw error wrapped in failure path).
-// Pure-prose case is rare enough that failed=true context is itself a
-// strong signal.
-for (const [name, text] of NIU_CASES) {
-  expect(
-    `${name} + failed=true → sanitize (SDK threw, single signal OK in failure context)`,
-    isVendorErrorForUser(text, true),
-  );
-}
+// ── 3. Success-context multi-signal — NOT sanitize (no failure context) ──
+// The OLD gate's `failed=false + ≥2 signals` branch misfired on legit
+// technical replies that happened to discuss multiple error terms (eg.
+// my own gate-verify prompt to feishu-local, which mentioned both
+// ZodError and base_resp in the same prompt — the bot's faithful echo
+// was sanitized in preview.8 prod). Under the new gate, success context
+// never sanitizes regardless of signal count.
 
-// ── 3. Multi-signal correlation cases (failed=false but ≥2 signals) ───────
-
-const MULTI_SIGNAL = [
-  // ZodError + invalid_union — both common in zod error JSON output
-  ['{"name":"ZodError","issues":[{"code":"invalid_union","path":["x"]}]}'],
-  // base_resp + choices:null — MiniMax envelope shape
-  ['{"base_resp":{"status_code":1000},"choices":null}'],
-  // unknown error + choices:null
-  ['Got: unknown error, 999 — "choices":null in response'],
-  // error envelope + choices:null
-  ['{"error":{"message":"bad","type":"x"}} caused "choices":null'],
+const SUCCESS_MULTI_SIGNAL_CASES: Array<[string, string]> = [
+  [
+    "ZodError + invalid_union prose",
+    'ZodError 抛 invalid_union 时，看 union 分支的 issues 数组',
+  ],
+  [
+    "base_resp + choices:null in docs prose",
+    'MiniMax 的 base_resp:{status_code:1} 表示失败；如果 choices:null 通常说明 vendor 拒绝了请求',
+  ],
+  [
+    "unknown error + choices:null docs",
+    'unknown error, 999 是 vendor 内部异常；伴随 "choices":null 时可重试',
+  ],
+  [
+    'OpenAI envelope + "choices":null example',
+    '示例：{"error":{"message":"bad","type":"x"}} 会让 "choices":null',
+  ],
 ];
-for (const [text] of MULTI_SIGNAL) {
+for (const [name, text] of SUCCESS_MULTI_SIGNAL_CASES) {
   expect(
-    `multi-signal (failed=false, ≥2 signals) → sanitize: ${text.slice(0, 60)}`,
-    isVendorErrorForUser(text, false),
+    `success-context multi-signal → NOT sanitize: ${name}`,
+    !isVendorErrorForUser(text, false),
     text,
   );
 }
 
-// ── 4. Single-signal + failed=true → sanitize (SDK-threw context) ─────────
+// ── 4. Failure-context multi-signal — sanitize ───────────────────────────
+// The ONLY combination that triggers sanitize: `failed=true + matchCount ≥ 2`.
 
-const SINGLE_FAILED = [
+const FAILED_MULTI_SIGNAL_CASES: Array<[string, string]> = [
+  [
+    "ZodError + invalid_union after SDK throw",
+    'claude 错误: ZodError: [{"code":"invalid_union","path":["choices"]}]',
+  ],
+  [
+    "base_resp + choices:null after SDK throw",
+    'claude 错误: vendor returned {"base_resp":{"status_code":1000},"choices":null}',
+  ],
+  [
+    "unknown error + ZodError after SDK throw",
+    'agent-node 错误: ZodError on response; vendor said unknown error, 999',
+  ],
+  [
+    "OpenAI envelope + choices:null after SDK throw",
+    'claude 错误: {"error":{"message":"bad","type":"x"}} → "choices":null',
+  ],
+];
+for (const [name, text] of FAILED_MULTI_SIGNAL_CASES) {
+  expect(
+    `failure-context multi-signal → sanitize: ${name}`,
+    isVendorErrorForUser(text, true),
+    text,
+  );
+  // Sanity: same text WITHOUT failure context → NOT sanitize.
+  expect(
+    `same text without failure context → NOT sanitize: ${name}`,
+    !isVendorErrorForUser(text, false),
+    text,
+  );
+}
+
+// ── 5. Single-signal + failed=true — NOT sanitize (new contract) ─────────
+// These were locked in the OLD #330 test as "sanitize=true". Under #331
+// the gate is stricter; user sees raw line in this rare case, operator
+// has stderr trace. Accepted trade-off.
+
+const SINGLE_SIGNAL_FAILED_CASES: Array<[string, string]> = [
   ["only ZodError after SDK throw", "claude 错误: ZodError: cannot parse response"],
   ["only invalid_union after SDK throw", "agent-node 错误: invalid_union at path .choices"],
   [
@@ -124,15 +196,15 @@ const SINGLE_FAILED = [
     'agent-node 错误: parser failed on "choices":null',
   ],
 ];
-for (const [name, text] of SINGLE_FAILED) {
+for (const [name, text] of SINGLE_SIGNAL_FAILED_CASES) {
   expect(
-    `failed=true + single signal → sanitize: ${name}`,
-    isVendorErrorForUser(text, true),
+    `single-signal + failed=true → NOT sanitize (new contract): ${name}`,
+    !isVendorErrorForUser(text, true),
     text,
   );
 }
 
-// ── 5. Zero signals — never sanitize ──────────────────────────────────────
+// ── 6. Zero signals — never sanitize ──────────────────────────────────────
 
 const NO_SIGNAL = [
   ["plain answer", "你好，今天天气很好。"],
@@ -144,18 +216,16 @@ const NO_SIGNAL = [
 ];
 for (const [name, text] of NO_SIGNAL) {
   expect(`zero signals + failed=false: ${name}`, !isVendorErrorForUser(text, false), text);
-  // Even failed=true with zero signals doesn't sanitize — leave operator's
-  // generic error text alone.
   expect(`zero signals + failed=true: ${name}`, !isVendorErrorForUser(text, true), text);
 }
 
-// ── 6. Defensive — bad input ──────────────────────────────────────────────
+// ── 7. Defensive — bad input ──────────────────────────────────────────────
 
 expect("null text", !isVendorErrorForUser(null as any, true));
 expect("undefined text", !isVendorErrorForUser(undefined as any, true));
 expect("non-string", !isVendorErrorForUser(42 as any, true));
 
-// ── 7. Sanitization replacement text (imported from production, regression-locked) ──
+// ── 8. Sanitization replacement text (regression-locked) ──────────────────
 
 const REPLACE = VENDOR_ERROR_REPLACEMENT;
 expect("replacement starts with [模型暂时异常]", REPLACE.startsWith("[模型暂时异常]"));
@@ -164,32 +234,50 @@ expect("replacement does NOT contain base_resp", !REPLACE.includes("base_resp"))
 expect("replacement does NOT contain status_code", !REPLACE.includes("status_code"));
 expect("replacement is Chinese-readable", REPLACE.includes("请稍后重发"));
 
-// ── 8. isTransientVendorError — retry-worthy gate (Vincent UAT 2026-06-29) ──
+// ── 9. isTransientVendorError — retry gate uses SAME base predicate ──────
+// `isTransientVendorError` MUST be a strict subset of `isVendorErrorForUser`:
+// retry only when (a) the predicate fires AND (b) the error isn't auth /
+// quota / 429. No second judgement of its own.
 
-// MiniMax 1000 / unknown error / choices:null — all transient, retry-able
+// Multi-signal + failed=true + no auth-class signal → transient
 const TRANSIENT_CASES: Array<[string, string, boolean]> = [
   [
-    "MiniMax 1000 envelope (Vincent UAT)",
+    "MiniMax 1000 envelope (Vincent UAT real shape)",
     'claude 错误: ZodError [{"code":"invalid_union"}] vendor returned {"base_resp":{"status_code":1000},"choices":null}',
     true,
   ],
-  ["choices:null + ZodError", '{"choices":null,"name":"ZodError"}', false],
-  ["base_resp + unknown error", '{"base_resp":{"status_code":1001}} unknown error, 999', false],
-  ["just unknown error after SDK throw", "claude 错误: unknown error, 200", true],
+  [
+    "ZodError + invalid_union after SDK throw",
+    'claude 错误: ZodError: [{"code":"invalid_union","path":["choices"]}]',
+    true,
+  ],
+  [
+    "base_resp + choices:null after SDK throw",
+    'agent-node 错误: vendor returned {"base_resp":{"status_code":1001},"choices":null}',
+    true,
+  ],
+  [
+    "unknown error + ZodError after SDK throw",
+    'claude 错误: ZodError on response; vendor said unknown error, 999',
+    true,
+  ],
 ];
 for (const [name, text, failed] of TRANSIENT_CASES) {
-  expect(`transient: ${name}`, isTransientVendorError(text, failed), `text: ${text.slice(0, 80)}`);
+  expect(
+    `transient (failure-context multi-signal, no auth): ${name}`,
+    isTransientVendorError(text, failed),
+    `text: ${text.slice(0, 80)}`,
+  );
 }
 
 // NON-transient — auth/quota/rate-limit. These DO trigger sanitize (via
-// isVendorErrorForUser) but should NOT retry.
+// isVendorErrorForUser, since multi-signal + failed=true) but should NOT retry.
 const NON_TRANSIENT_CASES: Array<[string, string, boolean]> = [
-  // Multi-signal vendor error WITH 401 token → not retryable
-  ['401 unauthorized + zod context', 'ZodError invalid_union "choices":null 401 unauthorized', true],
-  ['403 forbidden + base_resp', 'claude 错误: 403 forbidden {"base_resp":{"status_code":1}}', true],
-  ['quota exceeded + zod', 'ZodError invalid_union choices:null insufficient_quota', true],
-  ['rate limit 429', 'claude 错误: ZodError invalid_union choices:null too many requests 429', true],
-  ['rate_limit text', 'ZodError invalid_union "choices":null rate limit hit', true],
+  ['401 unauthorized + zod + choices:null', 'claude 错误: ZodError invalid_union "choices":null 401 unauthorized', true],
+  ['403 forbidden + base_resp + choices:null', 'claude 错误: 403 forbidden {"base_resp":{"status_code":1}} "choices":null', true],
+  ['quota exceeded + zod multi-signal', 'claude 错误: ZodError invalid_union "choices":null insufficient_quota', true],
+  ['rate limit 429 multi-signal', 'claude 错误: ZodError invalid_union "choices":null too many requests 429', true],
+  ['rate_limit prose multi-signal', 'agent-node 错误: ZodError invalid_union "choices":null rate limit hit', true],
 ];
 for (const [name, text, failed] of NON_TRANSIENT_CASES) {
   expect(
@@ -197,19 +285,38 @@ for (const [name, text, failed] of NON_TRANSIENT_CASES) {
     !isTransientVendorError(text, failed),
     `expected !transient. text: ${text.slice(0, 80)}`,
   );
-  // Sanity: these should still be vendor errors (just non-retryable)
+  // Sanity: these still hit the sanitize predicate (multi-signal + failure context).
   expect(
-    `non-transient cases are still vendor errors: ${name}`,
+    `non-transient still triggers sanitize: ${name}`,
     isVendorErrorForUser(text, failed),
     `text: ${text.slice(0, 80)}`,
   );
 }
 
-// NOT a vendor error at all — should NOT be transient either
-for (const [name, text] of NIU_CASES) {
-  // failed=false + single signal: NOT vendor error → NOT transient
+// Single-signal + failed=true → NOT vendor error → NOT transient (new contract)
+const SINGLE_FAILED_NOT_TRANSIENT: Array<[string, string]> = [
+  ["only ZodError after SDK throw", "claude 错误: ZodError: cannot parse response"],
+  ["only unknown error after SDK throw", "claude 错误: unknown error, 200"],
+];
+for (const [name, text] of SINGLE_FAILED_NOT_TRANSIENT) {
   expect(
-    `NIU counter (failed=false, NOT vendor error, NOT transient): ${name}`,
+    `single-signal + failed=true → NOT transient (slips through, no retry): ${name}`,
+    !isTransientVendorError(text, true),
+    text,
+  );
+}
+
+// Success context — never transient
+for (const [name, text] of NIU_COUNTER_CASES) {
+  expect(
+    `counter (failed=false, single signal) → NOT transient: ${name}`,
+    !isTransientVendorError(text, false),
+    text,
+  );
+}
+for (const [name, text] of SUCCESS_MULTI_SIGNAL_CASES) {
+  expect(
+    `success-context multi-signal → NOT transient: ${name}`,
     !isTransientVendorError(text, false),
     text,
   );
@@ -219,14 +326,14 @@ for (const [name, text] of NIU_CASES) {
 expect("plain text not transient", !isTransientVendorError("你好世界", false));
 expect("empty not transient", !isTransientVendorError("", true));
 
-// ── 9. VENDOR_RETRY_PROFILE shape lock ─────────────────────────────────────
+// ── 10. VENDOR_RETRY_PROFILE shape lock ────────────────────────────────────
 
 expect(
   "VENDOR_RETRY_PROFILE.maxRetries >= 1",
   typeof VENDOR_RETRY_PROFILE.maxRetries === "number" && VENDOR_RETRY_PROFILE.maxRetries >= 1,
 );
 expect(
-  "VENDOR_RETRY_PROFILE.maxRetries <= 5 (sanity — runaway retry guard)",
+  "VENDOR_RETRY_PROFILE.maxRetries <= 5 (runaway retry guard)",
   VENDOR_RETRY_PROFILE.maxRetries <= 5,
 );
 expect(
@@ -241,6 +348,30 @@ expect(
   "VENDOR_RETRY_PROFILE backoff total wall-clock ≤ 30s",
   VENDOR_RETRY_PROFILE.backoffMs.reduce((a, b) => a + b, 0) <= 30_000,
 );
+
+// ── 11. Gate symmetry — both helpers share base predicate ─────────────────
+// Every text where isTransientVendorError(t, f) === true MUST also have
+// isVendorErrorForUser(t, f) === true. (Retry without sanitize would mean
+// retry on text that gets through unchanged.) Negative direction is allowed:
+// auth/quota/429 sanitize-but-don't-retry.
+
+const SYMMETRY_PROBES: Array<[string, boolean]> = [
+  [VINCENT_UAT_SHAPE, true],
+  ['claude 错误: ZodError: [{"code":"invalid_union"}] "choices":null', true],
+  ['claude 错误: ZodError: [{"code":"invalid_union"}] "choices":null 401', true],
+  [VINCENT_UAT_SHAPE, false],
+  ["你好世界", true],
+  ["", false],
+  ["only ZodError", true],
+];
+for (const [t, f] of SYMMETRY_PROBES) {
+  if (isTransientVendorError(t, f)) {
+    expect(
+      `symmetry: transient ⊆ sanitize for: ${t.slice(0, 40)}|failed=${f}`,
+      isVendorErrorForUser(t, f),
+    );
+  }
+}
 
 // ── Summary (gates exit — MUST be last) ────────────────────────────────────
 

--- a/agent-node/tests/vendor-error-sanitize.test.ts
+++ b/agent-node/tests/vendor-error-sanitize.test.ts
@@ -20,7 +20,12 @@
  * Run: `bun tests/vendor-error-sanitize.test.ts`
  */
 
-import { isVendorErrorForUser, VENDOR_ERROR_REPLACEMENT } from "../src/vendor-error";
+import {
+  isVendorErrorForUser,
+  isTransientVendorError,
+  VENDOR_ERROR_REPLACEMENT,
+  VENDOR_RETRY_PROFILE,
+} from "../src/vendor-error";
 
 const results: Array<{ name: string; pass: boolean; detail?: string }> = [];
 function expect(name: string, pred: boolean, detail = ""): void {
@@ -158,6 +163,84 @@ expect("replacement does NOT contain ZodError", !REPLACE.includes("ZodError"));
 expect("replacement does NOT contain base_resp", !REPLACE.includes("base_resp"));
 expect("replacement does NOT contain status_code", !REPLACE.includes("status_code"));
 expect("replacement is Chinese-readable", REPLACE.includes("请稍后重发"));
+
+// ── 8. isTransientVendorError — retry-worthy gate (Vincent UAT 2026-06-29) ──
+
+// MiniMax 1000 / unknown error / choices:null — all transient, retry-able
+const TRANSIENT_CASES: Array<[string, string, boolean]> = [
+  [
+    "MiniMax 1000 envelope (Vincent UAT)",
+    'claude 错误: ZodError [{"code":"invalid_union"}] vendor returned {"base_resp":{"status_code":1000},"choices":null}',
+    true,
+  ],
+  ["choices:null + ZodError", '{"choices":null,"name":"ZodError"}', false],
+  ["base_resp + unknown error", '{"base_resp":{"status_code":1001}} unknown error, 999', false],
+  ["just unknown error after SDK throw", "claude 错误: unknown error, 200", true],
+];
+for (const [name, text, failed] of TRANSIENT_CASES) {
+  expect(`transient: ${name}`, isTransientVendorError(text, failed), `text: ${text.slice(0, 80)}`);
+}
+
+// NON-transient — auth/quota/rate-limit. These DO trigger sanitize (via
+// isVendorErrorForUser) but should NOT retry.
+const NON_TRANSIENT_CASES: Array<[string, string, boolean]> = [
+  // Multi-signal vendor error WITH 401 token → not retryable
+  ['401 unauthorized + zod context', 'ZodError invalid_union "choices":null 401 unauthorized', true],
+  ['403 forbidden + base_resp', 'claude 错误: 403 forbidden {"base_resp":{"status_code":1}}', true],
+  ['quota exceeded + zod', 'ZodError invalid_union choices:null insufficient_quota', true],
+  ['rate limit 429', 'claude 错误: ZodError invalid_union choices:null too many requests 429', true],
+  ['rate_limit text', 'ZodError invalid_union "choices":null rate limit hit', true],
+];
+for (const [name, text, failed] of NON_TRANSIENT_CASES) {
+  expect(
+    `non-transient (sanitize but no retry): ${name}`,
+    !isTransientVendorError(text, failed),
+    `expected !transient. text: ${text.slice(0, 80)}`,
+  );
+  // Sanity: these should still be vendor errors (just non-retryable)
+  expect(
+    `non-transient cases are still vendor errors: ${name}`,
+    isVendorErrorForUser(text, failed),
+    `text: ${text.slice(0, 80)}`,
+  );
+}
+
+// NOT a vendor error at all — should NOT be transient either
+for (const [name, text] of NIU_CASES) {
+  // failed=false + single signal: NOT vendor error → NOT transient
+  expect(
+    `NIU counter (failed=false, NOT vendor error, NOT transient): ${name}`,
+    !isTransientVendorError(text, false),
+    text,
+  );
+}
+
+// Plain text — not transient
+expect("plain text not transient", !isTransientVendorError("你好世界", false));
+expect("empty not transient", !isTransientVendorError("", true));
+
+// ── 9. VENDOR_RETRY_PROFILE shape lock ─────────────────────────────────────
+
+expect(
+  "VENDOR_RETRY_PROFILE.maxRetries >= 1",
+  typeof VENDOR_RETRY_PROFILE.maxRetries === "number" && VENDOR_RETRY_PROFILE.maxRetries >= 1,
+);
+expect(
+  "VENDOR_RETRY_PROFILE.maxRetries <= 5 (sanity — runaway retry guard)",
+  VENDOR_RETRY_PROFILE.maxRetries <= 5,
+);
+expect(
+  "VENDOR_RETRY_PROFILE.backoffMs is array",
+  Array.isArray(VENDOR_RETRY_PROFILE.backoffMs) && VENDOR_RETRY_PROFILE.backoffMs.length >= 1,
+);
+expect(
+  "VENDOR_RETRY_PROFILE.backoffMs values are positive ms",
+  VENDOR_RETRY_PROFILE.backoffMs.every((n) => typeof n === "number" && n > 0 && n <= 30_000),
+);
+expect(
+  "VENDOR_RETRY_PROFILE backoff total wall-clock ≤ 30s",
+  VENDOR_RETRY_PROFILE.backoffMs.reduce((a, b) => a + b, 0) <= 30_000,
+);
 
 // ── Summary (gates exit — MUST be last) ────────────────────────────────────
 


### PR DESCRIPTION
## Author
Agent: 通信IM马 (claude-code-cli — per 通信龙 65e59373)

## Summary

Vincent UAT 2026-06-29 实测: preview.8 shipped + post-parse + vendor-sanitize working. **But MiniMax `status_code:1000` was sanitized on first hit — when it's actually transient.** Vincent's log showed the very next turn (72s later) succeeded without any operator intervention. The right fix: retry the same prompt 1-2 times with short backoff BEFORE letting sanitize kick in.

## Vincent's log

```
08:07:02  attempt=1 → 08:07:18  output: "[模型暂时异常] vendor 返回非预期格式，请稍后重发"
08:08:14  attempt=1 → 08:08:31  success ✓ (no change, same prompt)
```

→ The 1000 was a one-shot blip. A 1.5s retry would've answered the user.

## Fix

`processTask` (cli.ts) now retries `think()` up to `VENDOR_RETRY_PROFILE.maxRetries` (2 = up to 3 total attempts) with backoff `[1500ms, 3000ms]` ONLY when `isTransientVendorError(text, failed)` returns true. Excludes auth/quota/rate-limit (those won't recover on a short retry).

Flow:
```
think() → text + failed
  ↓
existing: API-error pattern detection (sets failed=true)
  ↓
NEW: vendor-retry loop
  while isTransientVendorError(text, failed) && retries < 2:
    sleep backoff[i]
    retry think()  ← same prompt, fresh attempt
    update text + failed
  ↓
existing: sanitize layer
  // only fires if retry budget exhausted OR error non-transient
```

Worst-case wall-clock: initial (5-20s) + 1.5s + retry (5-20s) + 3s + retry (5-20s) ≈ 19.5-64s for a double-blip. Much better than seeing "暂时异常" and re-typing.

## `isTransientVendorError(text, failed)`

Retry-worthy gate:
- MUST be `isVendorErrorForUser` (i.e., the existing sanitize would otherwise fire).
- AND NOT auth-class (`401` / `403` / `unauthorized` / `forbidden`).
- AND NOT quota (`quota` / `insufficient_credit|balance|funds|tokens`).
- AND NOT rate-limit (`429` / `too_many_requests` / `rate_limit`) — needs longer backoff than ours.

Everything else (MiniMax 1000 / unknown error / choices:null / SDK zod on malformed response / vendor 5xx envelope) is treated as transient.

## Files

| File | Change | LOC |
|---|---|---|
| `agent-node/src/vendor-error.ts` | + `isTransientVendorError()` + `VENDOR_RETRY_PROFILE` ({maxRetries:2, backoffMs:[1500,3000]}) | +52 |
| `agent-node/src/cli.ts` | Retry loop between API-error detection and sanitize layer; imports new helpers | +47 / -1 |
| `agent-node/tests/vendor-error-sanitize.test.ts` | +25 cases: transient (4) + non-transient (5) + counter-(NIU 4) + plain text (3) + VENDOR_RETRY_PROFILE shape (5) + sanity check that non-transient cases ARE still vendor errors (5) | 63 case total (was 38) |

## Tests

```
$ bun tests/vendor-error-sanitize.test.ts → 63/63 pass, exit 0
$ inject deliberate-fail                  → exit 1  ✓
$ bun build src/cli.ts                    → 1.44 MB clean (no agent-network change)
```

## Deploy plan (lightweight per 通信龙 65e59373)

agent-node only — no agent-network change. dist-replace OK:
- bump `agent-node 2.5.0-preview.6 → preview.7`
- npm publish --tag preview
- `docker exec anet-feishu-local npm install -g @sleep2agi/agent-node@preview`
- explicit kill old pid + truncate + nohup restart
- ~15s downtime, NO container recreate, NO image rebuild

Session resumes (no SDK boundary crossed).

## Closes

(Incremental — Vincent's image+text reply now retries on transient blip rather than sanitizing on first shot. Closes when Vincent UAT confirms the transient case actually answers on retry.)

## Test plan

- [x] 63 unit + typecheck + bun build pass
- [x] Inject deliberate-fail → exit 1 (gating proven)
- [x] Auth/quota/rate-limit excluded from retry (verified)
- [ ] (post-merge + preview.9 ship) Vincent re-sends an image+text that previously sanitized → bot retries → answers (no more "暂时异常" on transient blip)
- [ ] (post-merge) Persistent auth/quota error still sanitizes immediately (no wasted retry round-trips)

🤖 Generated by 通信IM马 (claude-code-cli)