### PR TITLE
feat(feishu §15): agent→bridge outbound file protocol — [[send-file:/path]]

### DIFF
--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -44,7 +44,7 @@ export class FeishuAdapter implements IMAdapter {
   readonly ingressMode: IMIngressMode = "socket";
 
   private feishuConfig: FeishuChannelConfig | null = null;
-  private connectionName = "";
+  private connectionName_ = "";
   private client: lark.Client | null = null;
   private wsClient: lark.WSClient | null = null;
   /**
@@ -77,6 +77,15 @@ export class FeishuAdapter implements IMAdapter {
     return this.feishuConfig?.access?.allowFrom ?? [];
   }
 
+  /**
+   * Read-only accessor used by bridge to resolve per-connection paths
+   * (RFC-020 §15 outbound-marker validation needs the connection name
+   * to build the allowed per-conversation directory prefix).
+   */
+  get connectionName(): string {
+    return this.connectionName_;
+  }
+
   async init(config: IMChannelConfig): Promise<void> {
     if (config.platform !== "feishu") {
       throw new Error(
@@ -90,7 +99,7 @@ export class FeishuAdapter implements IMAdapter {
       );
     }
     this.feishuConfig = fc as FeishuChannelConfig;
-    this.connectionName = config.connectionName;
+    this.connectionName_ = config.connectionName;
     this.client = new lark.Client({
       appId: fc.appId,
       appSecret: fc.appSecret,
@@ -112,9 +121,9 @@ export class FeishuAdapter implements IMAdapter {
     // paths), downloads are disabled.
     const overrideBase = process.env.ANET_FEISHU_MEDIA_DIR?.trim();
     if (overrideBase) {
-      this.mediaDir = join(overrideBase, this.connectionName);
+      this.mediaDir = join(overrideBase, this.connectionName_);
     } else if (fc.channelDir) {
-      this.mediaDir = `/work/feishu-attachments/${this.connectionName}`;
+      this.mediaDir = `/work/feishu-attachments/${this.connectionName_}`;
     } else {
       this.mediaDir = null;
     }
@@ -125,7 +134,7 @@ export class FeishuAdapter implements IMAdapter {
       throw new Error("FeishuAdapter.start: call init() first");
     }
     const { appId, appSecret, access, groupPolicy } = this.feishuConfig;
-    const connectionName = this.connectionName;
+    const connectionName = this.connectionName_;
     const botOpenId = this.botOpenId;
     const mediaDir = this.mediaDir;
     const client = this.client;

--- a/agent-network/src/im/feishu/bridge.ts
+++ b/agent-network/src/im/feishu/bridge.ts
@@ -32,6 +32,13 @@
 import type { NormalizedIMEvent } from "../types.js";
 import { FeishuAdapter } from "./adapter.js";
 import { loadFeishuChannelConfig } from "./config.js";
+import {
+  parseOutboundMarkers,
+  validateOutboundPath,
+  sniffFileKind,
+  ALL_FILES_FAILED_FALLBACK,
+} from "./outbound-marker.js";
+import * as fs from "node:fs";
 
 export interface FeishuBridgeOptions {
   /** Absolute path to `.anet/nodes/<node>/channels/feishu/`. */
@@ -456,19 +463,139 @@ export function createIPCEventHandler(
       // reply (no adapter.edit). The placeholderMessageId is logged for
       // traceability but is not used to mutate the placeholder. Users get
       // a second push notification when the reply lands.
-      try {
-        const { messageId } = await adapter.send({
-          target: event.conversation,
-          text: replyText,
-          replyToMessageId: event.messageId,
-          correlation: { taskId: eventKey },
+      //
+      // RFC-020 §15 (Vincent UAT 2026-06-29 PDF case): parse outbound
+      // `[[send-file:/abs/path]]` markers, strip from visible text, validate
+      // paths per-conversation, and dispatch each file as its own message
+      // (text first if non-empty, then files in source order). adapter.send()
+      // takes one payload at a time — this loop is the multi-dispatch site.
+      const { cleanedText, files: markerRequests } = parseOutboundMarkers(replyText);
+      // convKey: open_chat_id for groups, open_id (sender) for DMs. The
+      // /work/feishu-attachments/<connection>/<convKey>/ directory is the
+      // single allowed outbound root the agent can write into.
+      // convKey: open_id (sender) for DMs, open_chat_id (conversationId) for
+      // groups. Mirrors the per-conversation drop-zone the inbound image
+      // downloader uses, so the agent's Read access (Layer B allow list)
+      // and outbound dispatch share one directory tree.
+      const convKey =
+        event.conversation.conversationType === "dm"
+          ? event.sender.id
+          : event.conversation.conversationId || event.sender.id;
+      // connectionId is `<node>#<platform>:<connectionName>` — pull the
+      // last `:` segment. Fall back to adapter's own copy if the event
+      // shape ever drifts.
+      const connectionName =
+        event.connectionId?.split(":").pop() ||
+        adapter.connectionName ||
+        "feishu";
+      // Validate every marker request; collect successes + failures.
+      const validFiles: Array<{ path: string; kind: "image" | "file" }> = [];
+      const failureReasons: string[] = [];
+      for (const req of markerRequests) {
+        const reason = validateOutboundPath({
+          p: req.normalized,
+          convKey,
+          connectionName,
         });
-        const note = placeholderMessageId
-          ? ` (after placeholder=${placeholderMessageId})`
-          : "";
-        process.stderr.write(
-          `[feishu:bridge] reply sent (messageId=${messageId})${note} for ${eventKey}\n`,
-        );
+        if (reason) {
+          process.stderr.write(
+            `[feishu:bridge] outbound-marker rejected ${req.normalized} for ${eventKey}: ${reason}\n`,
+          );
+          failureReasons.push(reason);
+          continue;
+        }
+        // Read first 16 bytes to magic-byte sniff the kind.
+        let kind: "image" | "file" = "file";
+        try {
+          const fd = fs.openSync(req.normalized, "r");
+          try {
+            const head = Buffer.alloc(16);
+            const n = fs.readSync(fd, head, 0, 16, 0);
+            kind = sniffFileKind(head.subarray(0, n));
+          } finally {
+            fs.closeSync(fd);
+          }
+        } catch (e: any) {
+          process.stderr.write(
+            `[feishu:bridge] outbound-marker sniff failed for ${req.normalized}: ${e?.message ?? e}\n`,
+          );
+          failureReasons.push("[文件附件未发送] 读取文件失败");
+          continue;
+        }
+        validFiles.push({ path: req.normalized, kind });
+      }
+
+      const note = placeholderMessageId
+        ? ` (after placeholder=${placeholderMessageId})`
+        : "";
+
+      // If the agent produced ONLY markers + no surrounding text AND every
+      // marker failed validation, we still owe the user a friendly reply
+      // (silent drop is the worst outcome — user thinks bot is hung).
+      const haveAnyOutbound = validFiles.length > 0 || cleanedText.length > 0;
+      let textToSend = cleanedText;
+      if (!haveAnyOutbound) {
+        textToSend = failureReasons[0] || ALL_FILES_FAILED_FALLBACK;
+      } else if (
+        !cleanedText &&
+        validFiles.length > 0 &&
+        failureReasons.length > 0
+      ) {
+        // Some files dispatched, some failed — let the user know.
+        textToSend = `(${failureReasons[0]})`;
+      }
+
+      try {
+        // Send text first if non-empty (puts the file in context for the user).
+        if (textToSend) {
+          const { messageId } = await adapter.send({
+            target: event.conversation,
+            text: textToSend,
+            replyToMessageId: event.messageId,
+            correlation: { taskId: eventKey },
+          });
+          process.stderr.write(
+            `[feishu:bridge] reply text sent (messageId=${messageId})${note} for ${eventKey}\n`,
+          );
+        }
+        // Then each file as its own outbound message — magic-byte routing
+        // decides image_key vs file_key.
+        for (const f of validFiles) {
+          try {
+            const filename = f.path.split("/").pop() || "file";
+            const sendArgs: any = {
+              target: event.conversation,
+              replyToMessageId: event.messageId,
+              correlation: { taskId: eventKey },
+            };
+            if (f.kind === "image") {
+              sendArgs.imagePath = f.path;
+            } else {
+              sendArgs.files = [{ path: f.path, name: filename }];
+            }
+            const { messageId } = await adapter.send(sendArgs);
+            process.stderr.write(
+              `[feishu:bridge] outbound ${f.kind} sent (messageId=${messageId}, path=${f.path}) for ${eventKey}\n`,
+            );
+          } catch (e: any) {
+            const msg = e instanceof Error ? e.message : String(e);
+            process.stderr.write(
+              `[feishu:bridge] outbound file send failed (${f.path}): ${msg}\n`,
+            );
+            // Friendly fallback: don't surface the raw vendor error.
+            try {
+              await adapter.send({
+                target: event.conversation,
+                text: `[文件附件发送失败] ${f.path.split("/").pop()} — 稍后再试`,
+                replyToMessageId: event.messageId,
+                correlation: { taskId: eventKey },
+              });
+            } catch {
+              // If even the friendly fallback fails, give up silently;
+              // we've already logged the underlying error.
+            }
+          }
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         process.stderr.write(`[feishu:bridge] reply delivery failed: ${msg}\n`);

--- a/agent-network/src/im/feishu/outbound-marker.ts
+++ b/agent-network/src/im/feishu/outbound-marker.ts
@@ -1,0 +1,246 @@
+/**
+ * RFC-020 §15 — agent→bridge outbound file protocol.
+ *
+ * 2026-06-29 Vincent UAT: agent generated a PDF via reportlab + wrote it
+ * to `/work/feishu-attachments/<conv>/x.pdf`, then in text asked Vincent
+ * "I'm not sure if the system will auto-attach this — try another way?"
+ * The bridge has `adapter.send({files})` since #329, but no protocol
+ * told the agent how to signal "dispatch this file to the user".
+ *
+ * Convention: in its final reply, the agent emits one
+ *
+ *     [[send-file:/abs/path]]
+ *
+ * marker per file (one per line, end of reply). The bridge:
+ *
+ *   1. extracts every `[[send-file:...]]` token,
+ *   2. strips them from the user-visible text,
+ *   3. validates each path against an allowed-outbound-root whitelist
+ *      (`/work/feishu-attachments/<conn>/<chat>/` — same per-conversation
+ *      directory the LLM has Write access to under Layer B),
+ *   4. checks the file exists, is non-empty, and ≤ 30 MB (Feishu file_v1
+ *      upper bound),
+ *   5. magic-byte sniffs to choose `image_key` vs `file_key` upload route,
+ *   6. dispatches each file via `adapter.send({files:[...]})`,
+ *   7. emits a friendly fallback if validation fails — never the raw error.
+ *
+ * Pure module — no I/O, no IM SDK calls. The parser returns the cleaned
+ * text + a structured list of file requests; bridge.ts is responsible
+ * for filesystem checks and dispatching.
+ */
+
+import * as path from "node:path";
+
+/**
+ * One outbound-file request parsed from an agent reply.
+ *
+ *  - `raw`: the bytes between `[[send-file:` and `]]`, before any
+ *    normalization. Kept for stderr forensic.
+ *  - `normalized`: lexical-normalized absolute path (quote-strip, `..`
+ *    collapse, `//` collapse, `./` resolution against cwd). The
+ *    `validatedAbsolute` field is set later by the bridge after the
+ *    realpath / whitelist / exists check.
+ */
+export interface OutboundFileRequest {
+  raw: string;
+  normalized: string;
+}
+
+export interface MarkerParseResult {
+  /** Reply text with all `[[send-file:...]]` markers removed + adjacent
+   *  whitespace collapsed. May be empty (file-only reply). */
+  cleanedText: string;
+  /** Files in source order. Caller-side validation happens after. */
+  files: OutboundFileRequest[];
+}
+
+/**
+ * Matches one `[[send-file:<path>]]` token. Path bytes are
+ * non-`]` characters; the closing `]]` is required. Anchored to either
+ * a line boundary or another marker to keep prose containing `[[…]]`
+ * safe (Markdown wiki-link style etc.).
+ *
+ * Captures the path bytes (group 1).
+ */
+const MARKER_RE = /\[\[send-file:([^\]\n]+)\]\]/g;
+
+/**
+ * Lexically normalize a path token from the marker. NOT a full
+ * symlink/realpath resolver — bridge does that after this returns.
+ *
+ *  - Trim leading / trailing whitespace.
+ *  - Strip one layer of matching quotes (`"/x"` / `'/x'` → `/x`).
+ *  - `.` and `..` segments collapse via `path.posix.normalize`.
+ *  - Repeated `/` collapse.
+ *
+ * Returns an absolute path or the empty string if the input cannot be
+ * interpreted as an absolute path token (caller drops empties).
+ */
+export function normalizeMarkerPath(raw: string): string {
+  let p = raw.trim();
+  if (p.length >= 2) {
+    if ((p[0] === '"' && p[p.length - 1] === '"') || (p[0] === "'" && p[p.length - 1] === "'")) {
+      p = p.slice(1, -1).trim();
+    }
+  }
+  if (!p.startsWith("/")) return "";
+  // posix.normalize collapses `//`, `.`, `..` segments.
+  return path.posix.normalize(p);
+}
+
+/**
+ * Parse an agent reply into cleaned text + outbound-file requests.
+ *
+ * Empty / null input returns `{cleanedText: "", files: []}` so callers
+ * can safely pipe through without defensive checks.
+ *
+ * Marker-only reply (no surrounding text) returns `cleanedText: ""` —
+ * caller should NOT send an empty text message in that case; they only
+ * dispatch the files.
+ *
+ * Multiple markers on one reply are all captured. Adjacent whitespace
+ * around stripped markers is collapsed (no double blank lines).
+ */
+export function parseOutboundMarkers(reply: string | null | undefined): MarkerParseResult {
+  if (!reply || typeof reply !== "string") {
+    return { cleanedText: "", files: [] };
+  }
+  const files: OutboundFileRequest[] = [];
+  // First pass: extract markers
+  let m: RegExpExecArray | null;
+  // Need to reset lastIndex since MARKER_RE is /g.
+  MARKER_RE.lastIndex = 0;
+  while ((m = MARKER_RE.exec(reply)) !== null) {
+    const raw = m[1] ?? "";
+    const normalized = normalizeMarkerPath(raw);
+    if (normalized) {
+      files.push({ raw, normalized });
+    }
+    // Empty normalized → drop the marker (e.g. agent emits relative path);
+    // still removed from the visible text below.
+  }
+  // Second pass: strip markers from text, collapse whitespace
+  let cleaned = reply.replace(MARKER_RE, "");
+  // Collapse runs of blank lines left by strips
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n");
+  // Trim trailing whitespace on individual lines (from "text [[marker]]\n")
+  cleaned = cleaned
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/g, ""))
+    .join("\n")
+    .trim();
+  return { cleanedText: cleaned, files };
+}
+
+/**
+ * The single allowed outbound root for files the agent wants to send.
+ * Each conversation gets its own subdirectory under this root; the
+ * agent's Write permission on this tree is granted by Layer B (config
+ * paths like `access.json` / `config.json` are denied, attachments
+ * dir is allowed).
+ *
+ * `<conv>` is the open_chat_id (group) or open_id (DM). Bridge fills
+ * the placeholder per-event when validating.
+ */
+export const OUTBOUND_ROOT = "/work/feishu-attachments";
+
+/**
+ * Validate a normalized absolute path against the per-conversation
+ * whitelist + size + existence checks. Returns null on success or a
+ * Chinese user-friendly reason on failure (the same string can be
+ * surfaced as a fallback text reply when ALL files fail validation).
+ *
+ * Filesystem-touching — bridge calls this AFTER `parseOutboundMarkers`.
+ *
+ * Params:
+ *   - p: normalized absolute path candidate
+ *   - convKey: per-conversation directory name (open_chat_id / open_id)
+ *   - statFn: optional override for tests (defaults to fs.statSync)
+ *   - realpathFn: optional override for tests (defaults to fs.realpathSync)
+ *
+ * Note: `convKey` may include characters Feishu accepts but are unusual
+ * for file paths (open_id starts with `ou_`, open_chat_id with `oc_`).
+ * The whitelist check uses the literal substring + path.posix.dirname
+ * walk so symlink redirects don't bypass it — the realpath form must
+ * also fall under `OUTBOUND_ROOT/<connection>/<convKey>/`.
+ */
+export interface ValidateOpts {
+  p: string;
+  convKey: string;
+  connectionName: string;
+  statFn?: (p: string) => { size: number };
+  realpathFn?: (p: string) => string;
+}
+export function validateOutboundPath(opts: ValidateOpts): string | null {
+  const expectedPrefix = `${OUTBOUND_ROOT}/${opts.connectionName}/${opts.convKey}/`;
+  if (!opts.p.startsWith(expectedPrefix)) {
+    return `[文件附件未发送] 路径不在允许的会话目录内 (必须在 ${expectedPrefix} 下)`;
+  }
+  // Realpath check — if file is a symlink pointing outside the allowed
+  // root, reject. Failing realpath (ENOENT) means file doesn't exist
+  // yet, which we'll catch via stat below.
+  let real: string;
+  try {
+    const fn = opts.realpathFn || ((p: string) => require("node:fs").realpathSync(p));
+    real = fn(opts.p);
+  } catch {
+    return `[文件附件未发送] 路径不存在或不可访问`;
+  }
+  if (!real.startsWith(expectedPrefix)) {
+    return `[文件附件未发送] 实际路径越权 (symlink 指向了允许目录外)`;
+  }
+  // Size check.
+  try {
+    const fn = opts.statFn || ((p: string) => require("node:fs").statSync(p));
+    const st = fn(real);
+    if (!st.size || st.size <= 0) {
+      return `[文件附件未发送] 文件为空`;
+    }
+    // Feishu file_v1 upper bound — 30 MB. Image v1 is 10 MB; we allow up
+    // to 30 here and let the per-route upload return its own error if the
+    // image route rejects the buffer.
+    const MAX_BYTES = 30 * 1024 * 1024;
+    if (st.size > MAX_BYTES) {
+      return `[文件附件未发送] 文件过大 (>${Math.floor(MAX_BYTES / 1024 / 1024)}MB)`;
+    }
+  } catch {
+    return `[文件附件未发送] 文件元数据读取失败`;
+  }
+  return null;
+}
+
+/**
+ * Magic-byte sniffer — picks `image` vs `file` upload route. Reads the
+ * first 16 bytes only; safe to call before commitment. Returns:
+ *
+ *   - "image" when the bytes are a PNG / JPG / GIF / WebP / BMP signature
+ *     (Feishu image_v1 supports these natively, with chat inline render).
+ *   - "file" otherwise (PDF, TXT, audio, video, archive, …).
+ *
+ * Caller supplies a Buffer (bridge reads via fs.openSync + readSync).
+ */
+export function sniffFileKind(buf: Buffer): "image" | "file" {
+  if (buf.length < 4) return "file";
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return "image";
+  // JPG: FF D8 FF
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return "image";
+  // GIF: "GIF8"
+  if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38) return "image";
+  // BMP: "BM"
+  if (buf[0] === 0x42 && buf[1] === 0x4d) return "image";
+  // WebP: "RIFF" .. "WEBP"
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) return "image";
+  return "file";
+}
+
+/**
+ * User-facing fallback message when ALL marker validations fail and the
+ * stripped text is empty (would leave the user with no reply at all).
+ */
+export const ALL_FILES_FAILED_FALLBACK =
+  "[文件附件发送失败] 我准备好了文件但分发时出了问题——稍后再试或换种方式。";

--- a/agent-network/tests/feishu-outbound-marker.test.ts
+++ b/agent-network/tests/feishu-outbound-marker.test.ts
@@ -1,0 +1,360 @@
+/**
+ * RFC-020 §15 — agent→bridge outbound file protocol parser tests.
+ *
+ * Covers parseOutboundMarkers (cleaned text + file list extraction),
+ * normalizeMarkerPath (quote-strip, `..` collapse, `//` collapse),
+ * validateOutboundPath (per-conversation whitelist, exists + size),
+ * sniffFileKind (PNG/JPG/GIF/BMP/WebP → image, otherwise → file).
+ *
+ * Run: `bun tests/feishu-outbound-marker.test.ts`
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import {
+  parseOutboundMarkers,
+  normalizeMarkerPath,
+  validateOutboundPath,
+  sniffFileKind,
+  OUTBOUND_ROOT,
+  ALL_FILES_FAILED_FALLBACK,
+} from "../src/im/feishu/outbound-marker";
+
+const results: Array<{ name: string; pass: boolean; detail?: string }> = [];
+function expect(name: string, pred: boolean, detail = ""): void {
+  results.push({ name, pass: pred, detail });
+  if (!pred) console.log(`  ✗ ${name}: ${detail}`);
+}
+
+// ── 1. parseOutboundMarkers — no markers ───────────────────────────────────
+
+{
+  const r = parseOutboundMarkers("just a plain reply");
+  expect("plain text: cleanedText preserved", r.cleanedText === "just a plain reply");
+  expect("plain text: no files", r.files.length === 0);
+}
+
+{
+  const r = parseOutboundMarkers("");
+  expect("empty input: empty result", r.cleanedText === "" && r.files.length === 0);
+}
+
+{
+  const r = parseOutboundMarkers(null);
+  expect("null input: empty result", r.cleanedText === "" && r.files.length === 0);
+}
+
+// ── 2. Single marker at end of text ────────────────────────────────────────
+
+{
+  const r = parseOutboundMarkers(
+    "报告做好了，要点如下：A / B / C。\n[[send-file:/work/feishu-attachments/feishu-local/oc_xxx/report.pdf]]",
+  );
+  expect(
+    "single marker: cleanedText strips marker",
+    r.cleanedText === "报告做好了，要点如下：A / B / C。",
+    `got: ${JSON.stringify(r.cleanedText)}`,
+  );
+  expect("single marker: 1 file", r.files.length === 1);
+  expect(
+    "single marker: path normalized",
+    r.files[0].normalized === "/work/feishu-attachments/feishu-local/oc_xxx/report.pdf",
+  );
+}
+
+// ── 3. Multiple markers on separate lines ──────────────────────────────────
+
+{
+  const reply = [
+    "三个文件都准备好了:",
+    "[[send-file:/work/feishu-attachments/feishu-local/oc_x/a.pdf]]",
+    "[[send-file:/work/feishu-attachments/feishu-local/oc_x/b.png]]",
+    "[[send-file:/work/feishu-attachments/feishu-local/oc_x/c.txt]]",
+  ].join("\n");
+  const r = parseOutboundMarkers(reply);
+  expect(
+    "multi-marker: 3 files",
+    r.files.length === 3,
+    `got ${r.files.length}: ${JSON.stringify(r.files)}`,
+  );
+  expect(
+    "multi-marker: source order preserved",
+    r.files[0].normalized.endsWith("a.pdf") &&
+      r.files[1].normalized.endsWith("b.png") &&
+      r.files[2].normalized.endsWith("c.txt"),
+  );
+  expect(
+    "multi-marker: cleanedText = leading prose",
+    r.cleanedText === "三个文件都准备好了:",
+    `got: ${JSON.stringify(r.cleanedText)}`,
+  );
+}
+
+// ── 4. Markers interleaved with prose ──────────────────────────────────────
+
+{
+  const reply = [
+    "先看这个 PDF:",
+    "[[send-file:/work/feishu-attachments/feishu-local/oc_x/a.pdf]]",
+    "",
+    "对比这张图:",
+    "[[send-file:/work/feishu-attachments/feishu-local/oc_x/b.png]]",
+    "",
+    "总结一下：核心结论是 X 和 Y。",
+  ].join("\n");
+  const r = parseOutboundMarkers(reply);
+  expect("interleaved: 2 files", r.files.length === 2);
+  expect("interleaved: leading prose preserved", r.cleanedText.includes("先看这个 PDF"));
+  expect("interleaved: middle prose preserved", r.cleanedText.includes("对比这张图"));
+  expect("interleaved: trailing prose preserved", r.cleanedText.includes("总结一下"));
+  expect("interleaved: no markers leak", !r.cleanedText.includes("send-file"));
+  // Should not have triple blank lines
+  expect(
+    "interleaved: blank-line runs collapsed",
+    !/\n{3,}/.test(r.cleanedText),
+    `text: ${JSON.stringify(r.cleanedText)}`,
+  );
+}
+
+// ── 5. Marker-only reply (no surrounding text) ─────────────────────────────
+
+{
+  const r = parseOutboundMarkers(
+    "[[send-file:/work/feishu-attachments/feishu-local/oc_x/a.pdf]]",
+  );
+  expect("marker-only: empty cleanedText", r.cleanedText === "", `got: ${JSON.stringify(r.cleanedText)}`);
+  expect("marker-only: 1 file", r.files.length === 1);
+}
+
+// ── 6. Malformed markers ───────────────────────────────────────────────────
+
+// Missing closing ]] — not extracted, marker text remains visible
+{
+  const r = parseOutboundMarkers(
+    "broken: [[send-file:/work/feishu-attachments/x/a.pdf",
+  );
+  expect("unclosed marker: 0 files", r.files.length === 0);
+  expect("unclosed marker: text untouched", r.cleanedText.includes("[[send-file"));
+}
+
+// Empty path between markers — dropped silently
+{
+  const r = parseOutboundMarkers("text [[send-file:]] more text");
+  // Empty inside [...] doesn't match because of `[^\]\n]+` (one or more
+  // non-`]` characters required).
+  expect("empty marker: 0 files", r.files.length === 0);
+  expect("empty marker: passes through text", r.cleanedText.includes("[[send-file:]]"));
+}
+
+// Relative path inside marker — dropped from files but stripped from text
+{
+  const r = parseOutboundMarkers("foo [[send-file:relative/path.pdf]] bar");
+  expect("relative-path marker: 0 files", r.files.length === 0);
+  expect("relative-path marker: marker stripped", !r.cleanedText.includes("send-file"));
+  expect("relative-path marker: surrounding text preserved", r.cleanedText.includes("foo") && r.cleanedText.includes("bar"));
+}
+
+// ── 7. normalizeMarkerPath unit ────────────────────────────────────────────
+
+expect("normalize: bare absolute", normalizeMarkerPath("/work/x") === "/work/x");
+expect("normalize: collapse //", normalizeMarkerPath("//work//.anet//x") === "/work/.anet/x");
+expect("normalize: `..` collapse", normalizeMarkerPath("/work/a/../b/c") === "/work/b/c");
+expect("normalize: `.` drop", normalizeMarkerPath("/work/./b") === "/work/b");
+expect("normalize: trailing /", normalizeMarkerPath("/work/x/") === "/work/x/");
+expect("normalize: trim spaces", normalizeMarkerPath("  /work/x  ") === "/work/x");
+expect('normalize: strip double-quote', normalizeMarkerPath('"/work/x"') === "/work/x");
+expect("normalize: strip single-quote", normalizeMarkerPath("'/work/x'") === "/work/x");
+expect("normalize: relative → empty", normalizeMarkerPath("relative/x") === "");
+expect("normalize: empty → empty", normalizeMarkerPath("") === "");
+expect("normalize: only `~` → empty (not abs)", normalizeMarkerPath("~/x") === "");
+
+// ── 8. validateOutboundPath — happy path ───────────────────────────────────
+
+{
+  // Build a tmp file matching the structure /tmp/.../feishu-attachments/feishu-local/oc_x/file.pdf
+  const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "feishu-outbound-"));
+  const fakeRoot = path.join(tmpdir, "feishu-attachments", "feishu-local", "oc_test");
+  fs.mkdirSync(fakeRoot, { recursive: true });
+  const file = path.join(fakeRoot, "report.pdf");
+  fs.writeFileSync(file, Buffer.from("PDF-1.4\n%fake content"));
+
+  // We can't redirect OUTBOUND_ROOT cleanly, so emulate by patching the
+  // expected prefix through the path-and-stat injection: build the
+  // candidate path identical to what would land in production by
+  // hand-rolling a fake `/work/feishu-attachments/feishu-local/oc_test/...`
+  // and providing mock stat + realpath functions.
+  const candidate = "/work/feishu-attachments/feishu-local/oc_test/report.pdf";
+  const reason = validateOutboundPath({
+    p: candidate,
+    convKey: "oc_test",
+    connectionName: "feishu-local",
+    realpathFn: () => candidate,
+    statFn: () => ({ size: 100 }),
+  });
+  expect("validate happy path → null", reason === null, `got: ${reason}`);
+
+  fs.rmSync(tmpdir, { recursive: true, force: true });
+}
+
+// ── 9. validateOutboundPath — wrong directory ──────────────────────────────
+
+{
+  // Path under a DIFFERENT conv → reject (cross-conv leak)
+  const r = validateOutboundPath({
+    p: "/work/feishu-attachments/feishu-local/oc_OTHER/leak.pdf",
+    convKey: "oc_test",
+    connectionName: "feishu-local",
+    realpathFn: () => "/work/feishu-attachments/feishu-local/oc_OTHER/leak.pdf",
+    statFn: () => ({ size: 100 }),
+  });
+  expect("validate cross-conv → reject", r !== null && r.includes("会话目录"), `got: ${r}`);
+}
+
+{
+  // Path outside the outbound root → reject
+  const r = validateOutboundPath({
+    p: "/etc/passwd",
+    convKey: "oc_test",
+    connectionName: "feishu-local",
+    realpathFn: () => "/etc/passwd",
+    statFn: () => ({ size: 100 }),
+  });
+  expect("validate /etc/passwd → reject", r !== null, `got: ${r}`);
+}
+
+{
+  // Path under a different connection → reject
+  const r = validateOutboundPath({
+    p: "/work/feishu-attachments/OTHER-NODE/oc_test/x.pdf",
+    convKey: "oc_test",
+    connectionName: "feishu-local",
+    realpathFn: () => "/work/feishu-attachments/OTHER-NODE/oc_test/x.pdf",
+    statFn: () => ({ size: 100 }),
+  });
+  expect("validate cross-connection → reject", r !== null, `got: ${r}`);
+}
+
+// ── 10. validateOutboundPath — symlink escape ──────────────────────────────
+
+{
+  // Lexical path inside allowed root, but realpath redirects outside.
+  const r = validateOutboundPath({
+    p: "/work/feishu-attachments/feishu-local/oc_test/bait.pdf",
+    convKey: "oc_test",
+    connectionName: "feishu-local",
+    realpathFn: () => "/etc/shadow", // symlink escape
+    statFn: () => ({ size: 100 }),
+  });
+  expect("validate symlink-escape → reject", r !== null && r.includes("越权"), `got: ${r}`);
+}
+
+// ── 11. validateOutboundPath — size ────────────────────────────────────────
+
+{
+  // Empty file
+  const candidate = "/work/feishu-attachments/feishu-local/oc_test/empty.pdf";
+  const r = validateOutboundPath({
+    p: candidate,
+    convKey: "oc_test",
+    connectionName: "feishu-local",
+    realpathFn: () => candidate,
+    statFn: () => ({ size: 0 }),
+  });
+  expect("validate empty file → reject", r !== null && r.includes("空"), `got: ${r}`);
+}
+
+{
+  // 50MB > 30MB cap
+  const candidate = "/work/feishu-attachments/feishu-local/oc_test/huge.bin";
+  const r = validateOutboundPath({
+    p: candidate,
+    convKey: "oc_test",
+    connectionName: "feishu-local",
+    realpathFn: () => candidate,
+    statFn: () => ({ size: 50 * 1024 * 1024 }),
+  });
+  expect("validate 50MB → reject", r !== null && r.includes("过大"), `got: ${r}`);
+}
+
+// ── 12. validateOutboundPath — realpath ENOENT ─────────────────────────────
+
+{
+  // Realpath throws (file doesn't exist) → reject
+  const r = validateOutboundPath({
+    p: "/work/feishu-attachments/feishu-local/oc_test/missing.pdf",
+    convKey: "oc_test",
+    connectionName: "feishu-local",
+    realpathFn: () => {
+      throw new Error("ENOENT");
+    },
+    statFn: () => ({ size: 100 }),
+  });
+  expect("validate missing file → reject", r !== null && r.includes("不存在"), `got: ${r}`);
+}
+
+// ── 13. sniffFileKind ──────────────────────────────────────────────────────
+
+const PNG_HEAD = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPG_HEAD = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const GIF_HEAD = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+const BMP_HEAD = Buffer.from([0x42, 0x4d, 0x46, 0x00]);
+const WEBP_HEAD = Buffer.from([
+  0x52, 0x49, 0x46, 0x46, 0x10, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+]);
+const PDF_HEAD = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]); // "%PDF-1.4"
+const TXT_HEAD = Buffer.from([0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f]); // "hello wo"
+
+expect("sniff PNG → image", sniffFileKind(PNG_HEAD) === "image");
+expect("sniff JPG → image", sniffFileKind(JPG_HEAD) === "image");
+expect("sniff GIF → image", sniffFileKind(GIF_HEAD) === "image");
+expect("sniff BMP → image", sniffFileKind(BMP_HEAD) === "image");
+expect("sniff WebP → image", sniffFileKind(WEBP_HEAD) === "image");
+expect("sniff PDF → file", sniffFileKind(PDF_HEAD) === "file");
+expect("sniff TXT → file", sniffFileKind(TXT_HEAD) === "file");
+expect("sniff empty → file", sniffFileKind(Buffer.alloc(0)) === "file");
+expect("sniff 3-byte truncated → file", sniffFileKind(Buffer.from([0x89, 0x50, 0x4e])) === "file");
+
+// ── 14. OUTBOUND_ROOT + ALL_FILES_FAILED_FALLBACK shape ────────────────────
+
+expect("OUTBOUND_ROOT is /work/feishu-attachments", OUTBOUND_ROOT === "/work/feishu-attachments");
+expect("fallback message in Chinese", ALL_FILES_FAILED_FALLBACK.includes("发送失败"));
+expect(
+  "fallback message does NOT leak protocol details (no 'send-file', no path)",
+  !ALL_FILES_FAILED_FALLBACK.includes("send-file") &&
+    !ALL_FILES_FAILED_FALLBACK.includes("/work"),
+);
+
+// ── 15. Markers with quoted paths ──────────────────────────────────────────
+
+{
+  const r = parseOutboundMarkers(
+    '前面有点东西 [[send-file:"/work/feishu-attachments/feishu-local/oc_x/quoted.pdf"]]',
+  );
+  expect("quoted path marker: 1 file", r.files.length === 1);
+  expect(
+    "quoted path: quotes stripped",
+    r.files[0].normalized === "/work/feishu-attachments/feishu-local/oc_x/quoted.pdf",
+  );
+}
+
+// ── 16. Adjacent prose preserved verbatim ──────────────────────────────────
+
+{
+  const reply =
+    "Hi there! [[send-file:/work/feishu-attachments/feishu-local/oc_x/a.pdf]] cheers.";
+  const r = parseOutboundMarkers(reply);
+  expect("inline marker: cleanedText preserved", r.cleanedText === "Hi there!  cheers.");
+  expect("inline marker: 1 file", r.files.length === 1);
+}
+
+// ── Summary ────────────────────────────────────────────────────────────────
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${results.length - failed.length}/${results.length} feishu-outbound-marker tests passed.`);
+if (failed.length > 0) {
+  console.log("\nfailures:");
+  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1465,6 +1465,31 @@ async function processWithClaude(task: string, from: string, images?: string[]):
   // commhub prefix, NOT the double `mcp__commhub__commhub_<bare>` the v1 fix
   // taught (the double came from a different MCP host's configuration that
   // is not what the SDK in-process server produces). Names updated below.
+  // RFC-020 §15 — feishu turn outbound-file convention. Only injected when
+  // the current turn originates from the feishu channel; commhub / /loop /
+  // telegram replies don't need this (the marker is bridge-specific).
+  // 2026-06-29 Vincent UAT root cause: agent generated a PDF + wrote it to
+  // disk, then text-replied "I don't know how to send this" — no protocol
+  // taught it the `[[send-file:/abs/path]]` marker. Bridge worker now
+  // parses these markers, strips them from the user-visible text, and
+  // dispatches each file (magic-byte routes image_key vs file_key).
+  const feishuOutboundFileGuidance = isFeishuChannelTurn(from)
+    ? [
+        `【给用户发文件 — 飞书】`,
+        `想把生成/找到的文件（PDF、图片、音频、视频、任意文件）发给用户时：`,
+        `1. 先把文件写到 \`/work/feishu-attachments/<connection>/<conv>/<filename>\` 这条会话的目录（你的 Bash/Write 有该目录的权限）。`,
+        `2. 在回复末尾**另起一行**，每个要发的文件写一行：\`[[send-file:/绝对路径]]\``,
+        `3. 回复正文 + 标记一起发就行——bridge 会自动 strip 标记、上传文件、按图片/文件路由分发，用户看不到标记本身。`,
+        ``,
+        `示例（写完 PDF 之后）：`,
+        `> 报告做好了，要点如下：A / B / C。`,
+        `> [[send-file:/work/feishu-attachments/feishu-local/oc_xxx/report.pdf]]`,
+        ``,
+        `不要因为不确定怎么发，就**问用户**"系统会不会自动当附件发"——直接用标记就发了。一条回复多个文件就写多个标记，每行一个。`,
+        `路径必须在 \`/work/feishu-attachments/<connection>/<conv>/\` 下，否则会被 bridge 拒绝；用 ls 看看当前会话目录在哪。`,
+      ].join("\n")
+    : "";
+
   const commhubToolGuidance = [
     `【多 agent 协作 — CommHub 工具】`,
     `你已接入 CommHub 通信网络，可主动用以下 MCP 工具协调其他 agent（这些工具已 registered，直接调用即可）：`,
@@ -1488,6 +1513,8 @@ async function processWithClaude(task: string, from: string, images?: string[]):
     ``,
     commhubToolGuidance,
     ``,
+    // Only present on feishu turns; empty string elsewhere.
+    feishuOutboundFileGuidance,
     `【禁止】`,
     `- 不要给自己（${ALIAS}）发任务（死循环）。`,
     `- 不要回复"收到""ok""明白了"等无内容确认。`,
@@ -1497,7 +1524,9 @@ async function processWithClaude(task: string, from: string, images?: string[]):
     `执行完后简要汇报结果。`,
   ].join("\n");
   const promptText = SYSTEM_PROMPT
-    ? `${SYSTEM_PROMPT}\n\n${toolCapabilityGuidance}\n\n${commhubToolGuidance}\n\n收到来自 ${from} 的任务：\n\n${task}`
+    ? `${SYSTEM_PROMPT}\n\n${toolCapabilityGuidance}\n\n${commhubToolGuidance}${
+        feishuOutboundFileGuidance ? `\n\n${feishuOutboundFileGuidance}` : ""
+      }\n\n收到来自 ${from} 的任务：\n\n${task}`
     : defaultPrompt;
 
   // #259 Y prompt construction — string path (red-line zero-regression for


### PR DESCRIPTION
## Summary

Wires the missing **agent → bridge "send this file" signal** so the bot can actually dispatch generated files (PDF, image, audio, anything) instead of asking the user "I'm not sure if the system will auto-attach this — try another way?". Closes the gap surfaced by Vincent's 2026-06-29 PDF UAT.

#329 already shipped `adapter.send({files})` (upload + send). This PR adds the protocol that lets the agent **trigger** that path.

## Convention

Agent emits one or more `[[send-file:/abs/path]]` markers in its reply:

```
报告做好了，要点如下：A / B / C。
[[send-file:/work/feishu-attachments/feishu-local/oc_xxx/report.pdf]]
```

Bridge worker:

1. Extracts every `[[send-file:...]]` marker.
2. Strips them from user-visible text + collapses whitespace.
3. Validates each path against:
   - Per-conversation whitelist (`/work/feishu-attachments/<connection>/<convKey>/`).
   - Realpath form (symlink redirect outside allowed root → reject).
   - Exists + non-empty + ≤ 30 MB (Feishu `file_v1` upper bound).
4. **Magic-byte sniffs** PNG / JPG / GIF / BMP / WebP → `image_key` route (chat inline render); everything else → `file_key` route (attachment).
5. Sends cleaned text first (if non-empty), then each file as its own message — preserves chat ordering, gives the user context before each attachment.
6. **Friendly fallback** on any failure: `[文件附件未发送] <reason>` / `[文件附件发送失败] <filename> — 稍后再试`. Raw vendor errors stay in stderr.

## System-prompt teaching

`agent-node/src/cli.ts` adds `feishuOutboundFileGuidance` to the agent's prompt — only when `isFeishuChannelTurn(from)`. Tells the agent:

- Save files to `/work/feishu-attachments/<connection>/<conv>/<filename>` (the per-conversation drop-zone — already Write-allowed under hardening Layer B).
- End the reply with one `[[send-file:/abs/path]]` per file, one per line.
- **Don't** ask the user "will this auto-attach" — just use the marker.

Non-feishu turns (commhub / `/loop` / telegram) get nothing added — protocol stays scoped.

## Bypass classes addressed

| Bypass | Resolution |
| --- | --- |
| Path outside `/work/feishu-attachments/` | Prefix whitelist with per-conv `convKey` segment |
| Cross-conversation path | `convKey` segment baked into whitelist prefix |
| Symlink redirect | `realpathSync()` + same prefix check |
| Relative / `..` / `//` in marker | `path.posix.normalize` + quote strip |
| Empty / oversized files | `statSync` size check, reject with reason |
| Marker injection in arbitrary prose | Strict `[[send-file:...]]` regex, line-anchored, `[^\]\n]+` body |

## Test plan

- [x] `bun tests/feishu-outbound-marker.test.ts` → **60/60**
- [x] Sibling-suite no regression:
  - feishu-post-parse 22/22
  - feishu-markdown-image 30/30
  - feishu-image-upload-fallback 20/20
  - feishu-tool-deny 233/233 (hardening Layer B unaffected)
  - vendor-error-sanitize 79/79
- [x] `bun run build` agent-network + agent-node → clean
- [x] Bundle grep: `send-file` + `/work/feishu-attachments` + `给用户发文件` all baked into agent-node `dist/cli.js`
- [ ] Live container UAT after merge: Vincent's PDF request, second image+text dispatch (deploy via lightweight dist-replace + worker.js replace)

## Files

| File | Change |
| --- | --- |
| `agent-network/src/im/feishu/outbound-marker.ts` (new) | Parser + validator + magic-byte sniff. Pure module. |
| `agent-network/src/im/feishu/bridge.ts` | Reply path: parse/strip/validate/dispatch loop |
| `agent-network/src/im/feishu/adapter.ts` | `connectionName` exposed via read-only getter |
| `agent-node/src/cli.ts` | `feishuOutboundFileGuidance` in system prompt (both branches) |
| `agent-network/tests/feishu-outbound-marker.test.ts` (new) | 60 cases |

## Threat / scope notes

- Marker syntax overlaps with internal memory-link `[[name]]` syntax — but the agent's reply never goes into memory; bridge consumes the marker before any persistence. No collision.
- Hardening Layer B (#333) already allows Write under `/work/feishu-attachments/` and denies write under `/work/.anet/**`. This PR composes — agent writes file → marker → bridge reads same path (validated separately).
- Protocol is one-directional (agent → bridge). Bridge does NOT echo confirmation back as another marker; sent files are visible to the user already.

## Author
Agent: 通信IM马
