### PR TITLE
feat(#338 PR1): anet daemon CLI — zero-config-edit host_supervisor registration

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -3920,6 +3920,241 @@ Example:
 `);
 }
 
+// ── daemon (RFC-026 P2 / issue #338 lane①) ──
+//
+// `anet daemon` = zero-config-edit `host_supervisor` node provisioning.
+// The Vincent friction this kills: pre-RFC-026 P2, registering a machine
+// as a schedulable host_supervisor required manually editing
+// `.anet/nodes/<name>/config.json` to add `"role": "host_supervisor"`.
+// `anet node create` had no role concept; users hit `no_host_supervisor_daemon`
+// from dashboard with no path forward except vim-and-restart.
+//
+// Surface:
+//   anet daemon init <name>   create config.json with role + defaults
+//   anet daemon start <name>  start daemon (delegates to startCommand)
+//   anet daemon up [<name>]   init+start one-shot (default name: "daemon")
+//   anet daemon list          list locally-configured daemons
+//
+// Idempotence (init):
+//   - profile exists with role=host_supervisor → no-op + success log
+//   - profile exists with different/no role → REFUSE unless --force
+//   - profile absent → mint ntok + write config + log next step
+//
+// Defaults (matching RFC-026 §9.3 daemon-self-declare scaffolding —
+// PR3 will land the schema for `runtimes_supported` / `allowed_secret_keys`
+// to be reported via report_status; we already write the fields so
+// the daemon ships ready for the next PR's hub-side wiring):
+//   role: "host_supervisor"
+//   runtime: "claude-agent-sdk"  (lightest, just the SSE doorbell loop)
+//   runtimes_supported: [claude-agent-sdk, codex-sdk, grok-build-acp]
+//     (declares; PR3 daemon-side fail-fast catches binary-missing at spawn)
+//   allowed_secret_keys: []
+//     (fail-closed; operator adds via `anet daemon init --allow-secret KEY`
+//     or by hand-editing — strict-by-default per RFC-026 §9.7)
+//   flags: { dangerouslySkipPermissions: true, teammateMode: true }
+//     (standard daemon flags, same defaults [[feedback_default_flags]])
+//   node_id prefix `node_daemon_` preserved for backwards-compat with
+//   pre-#337 dashboard discovery heuristic (no-op cost on post-#337 hubs).
+
+const DAEMON_DEFAULT_NAME = "daemon";
+
+async function daemonCommand() {
+  const sub = args[1];
+  if (!sub || sub === "help" || sub === "-h" || sub === "--help") {
+    console.log(`Usage: anet daemon <subcommand> [name] [options]
+
+Subcommands:
+  init <name>          Create a host_supervisor daemon node (role + defaults)
+  start <name>         Start a daemon (delegates to anet node start; verifies role)
+  up [<name>]          init + start one-shot (default name: "${DAEMON_DEFAULT_NAME}")
+  list                 List locally-configured daemon nodes
+
+Options:
+  --force              Overwrite an existing non-daemon config (init only)
+  --allow-secret KEY   Pre-populate allowed_secret_keys (repeatable; init only)
+
+A "daemon" is an agent-node with role:host_supervisor — receives create_node
+dispatches from the hub/dashboard and forks child agent-nodes on demand.
+Run \`anet hub start\` first if you don't yet have a CommHub.`);
+    return;
+  }
+  switch (sub) {
+    case "init":  args.splice(0, 1); await daemonInitCommand(); break;
+    case "start": args.splice(0, 1); await daemonStartCommand(); break;
+    case "up":    args.splice(0, 1); await daemonUpCommand(); break;
+    case "list": case "ls": await daemonListCommand(); break;
+    default: {
+      const suggestion = suggestSimilar(sub, ["init", "start", "up", "list"]);
+      if (suggestion) console.log(`Unknown daemon subcommand "${sub}". Did you mean: anet daemon ${suggestion}?`);
+      console.log(`Usage: anet daemon <init|start|up|list> [name]`);
+      process.exit(1);
+    }
+  }
+}
+
+async function daemonInitCommand() {
+  const opts = parseOpts();
+  const id = args[1] && !args[1].startsWith("--") ? args[1] : DAEMON_DEFAULT_NAME;
+  validateNodeName(id);
+
+  // Idempotence — preserve existing token/node_id when re-running init on a
+  // healthy daemon; surface conflict when the profile exists with a non-
+  // daemon role unless --force.
+  const existing = loadProfile(id);
+  if (existing) {
+    if ((existing as any).role === "host_supervisor" && !opts.force) {
+      console.log(`[anet daemon] ✓ "${id}" already a host_supervisor daemon`);
+      console.log(`              config: .anet/nodes/${id}/config.json`);
+      console.log(`              start:  anet daemon start ${id}`);
+      return;
+    }
+    if ((existing as any).role !== "host_supervisor" && !opts.force) {
+      console.error(`Error: node "${id}" exists with role="${(existing as any).role || "(none)"}", not "host_supervisor".`);
+      console.error(`Use --force to overwrite (re-mints token, keeps node_id), or pick a different name.`);
+      process.exit(1);
+    }
+    // --force: fall through; we'll overwrite below, preserving node_id when present
+  }
+
+  // Hub gate (mirrors createCommand)
+  const gc = loadGlobal();
+  if (!gc.hub) {
+    try {
+      const h = await fetch("http://127.0.0.1:9200/health").then(r => r.json() as any);
+      if (h.ok) { gc.hub = "http://127.0.0.1:9200"; saveGlobal(gc); console.log(`[anet] 检测到本地 CommHub: ${gc.hub}`); }
+    } catch { /* not reachable */ }
+  }
+  if (!gc.hub) {
+    console.error("未找到 CommHub Server。请先运行:\n  anet hub start\n\n或手动配置:\n  anet init --hub http://YOUR_IP:9200");
+    process.exit(1);
+  }
+  if (!gc.token || !gc.network_id) {
+    console.error("未登录或缺少 network_id。请运行:\n  anet login");
+    process.exit(1);
+  }
+
+  // Collect --allow-secret repeatables (parseOpts only knows --channel/--env;
+  // walk argv manually for --allow-secret to avoid touching the shared parser).
+  const allowedSecretKeys: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--allow-secret" && args[i + 1]) {
+      const k = args[++i];
+      if (!/^[A-Z][A-Z0-9_]{0,63}$/.test(k)) {
+        console.error(`Error: --allow-secret value "${k}" must match ^[A-Z][A-Z0-9_]{0,63}$ (uppercase env-var name)`);
+        process.exit(1);
+      }
+      allowedSecretKeys.push(k);
+    }
+  }
+
+  // Mint a network token via existing helper. Preserve node_id when re-init
+  // with --force on an existing daemon (avoid orphaning child references).
+  const preservedNodeId = existing && (existing as any).node_id;
+  const nodeIdToUse = preservedNodeId || `node_daemon_${randomBytes(6).toString("hex")}`;
+  const stubProfile: any = {
+    node_id: nodeIdToUse,
+    node_name: id,
+    hub: gc.hub,
+    network_id: gc.network_id,
+  };
+  let mintedToken: string;
+  try {
+    mintedToken = await requestNodeToken(stubProfile as any, id);
+  } catch (e: any) {
+    console.error(`Failed to mint node-token from hub ${gc.hub}: ${e?.message || e}`);
+    process.exit(1);
+  }
+
+  // Write config.json directly (not via saveProfile) — saveProfile's
+  // normalize+whitelist pipeline strips the RFC-026 §9.3 daemon-self-declare
+  // fields (runtimes_supported / allowed_secret_keys / max_concurrent_children).
+  // The daemon config shape is small + explicit; direct write keeps all the
+  // fields on disk so agent-node's report_status can include them in its
+  // config_snapshot for the post-#337 hub role extraction to pick up.
+  const daemonConfig = {
+    anet_version: 1,
+    node_id: nodeIdToUse,
+    node_name: id,
+    alias: id,
+    runtime: "claude-agent-sdk",
+    role: "host_supervisor",
+    hub: gc.hub,
+    token: mintedToken,
+    network_id: gc.network_id,
+    runtimes_supported: ["claude-agent-sdk", "codex-sdk", "grok-build-acp"],
+    allowed_secret_keys: allowedSecretKeys,
+    max_concurrent_children: 20,
+    channels: [],
+    env: {},
+    flags: { dangerouslySkipPermissions: true, teammateMode: true },
+  };
+  const dir = join(nodesDir(), id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.json"), JSON.stringify(daemonConfig, null, 2) + "\n");
+
+  console.log(`[anet daemon] ✓ ${existing ? "re-initialized" : "created"} host_supervisor daemon "${id}"`);
+  console.log(`              config:     .anet/nodes/${id}/config.json`);
+  console.log(`              node_id:    ${nodeIdToUse}`);
+  if (allowedSecretKeys.length) {
+    console.log(`              secret keys allowed: ${allowedSecretKeys.join(", ")}`);
+  } else {
+    console.log(`              secret keys allowed: (none — add with: anet daemon init ${id} --force --allow-secret KEY)`);
+  }
+  console.log(``);
+  console.log(`Next: start it`);
+  console.log(`  anet daemon start ${id}    (or anet daemon up ${id} to init+start in one go)`);
+}
+
+async function daemonStartCommand() {
+  const id = args[1];
+  if (!id || id.startsWith("--")) {
+    console.error("Usage: anet daemon start <name>");
+    process.exit(1);
+  }
+  const profile = loadProfile(id);
+  if (!profile) {
+    console.error(`Daemon "${id}" not found. Create it first:`);
+    console.error(`  anet daemon init ${id}`);
+    process.exit(1);
+  }
+  if ((profile as any).role !== "host_supervisor") {
+    console.error(`Error: node "${id}" exists but role="${(profile as any).role || "(none)"}", not "host_supervisor".`);
+    console.error(`Re-init as daemon: anet daemon init ${id} --force`);
+    process.exit(1);
+  }
+  // Delegate to existing startCommand — it reads args[1] for the node name,
+  // which is what we have after the `daemon start` splice in daemonCommand.
+  await startCommand();
+}
+
+async function daemonUpCommand() {
+  // Inject default name into args if user said `anet daemon up` with no name
+  if (!args[1] || args[1].startsWith("--")) {
+    args.splice(1, 0, DAEMON_DEFAULT_NAME);
+  }
+  await daemonInitCommand();
+  // After init, args[1] is still the name; startCommand reads args[1].
+  await startCommand();
+}
+
+async function daemonListCommand() {
+  const ids = listProfileIds();
+  const daemons = ids
+    .map(id => ({ id, profile: loadProfile(id) }))
+    .filter(({ profile }) => profile && (profile as any).role === "host_supervisor");
+  if (daemons.length === 0) {
+    console.log("No host_supervisor daemons configured locally.");
+    console.log("Create one: anet daemon init <name>");
+    return;
+  }
+  console.log(`Local host_supervisor daemons (${daemons.length}):`);
+  for (const { id, profile } of daemons) {
+    const nid = (profile as any)?.node_id || "(missing)";
+    const runtimes = ((profile as any)?.runtimes_supported || []).join(",") || "(default)";
+    console.log(`  ${id.padEnd(24)} node_id=${nid}  runtimes=[${runtimes}]`);
+  }
+}
+
 // ── import ──
 
 async function importCommand() {
@@ -9689,6 +9924,7 @@ switch (command) {
       }
     }
     break;
+  case "daemon": await daemonCommand(); break; // RFC-026 P2 / #338 — host_supervisor one-cmd
   case "project": await projectCommand(); break;  // #117 — cwd-wide orchestration
   case "start": await startCommand(); break;   // backward compat
   case "resume": await resumeCommand(); break; // backward compat

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -223,12 +223,18 @@ export function mergePatch(existing: any, patch: ConfigPatch): any {
 /** Build the masked config snapshot the node reports via
  * report_status's `config_snapshot` field. Strips secrets — env
  * `_envRef` placeholders stay opaque; nothing from `env` block at all
- * is included. Only model + the 6 dashboard-editable flags. */
+ * is included. Only model + the 6 dashboard-editable flags + role
+ * (daemon discovery, see issue #338 / RFC-026 P2). */
 export interface MaskedSnapshot {
   model?: string | null;
   flags: Record<string, unknown>;
   config_revision?: number;
   config_update_capable: boolean;
+  /** Node role surfaced to hub /api/nodes for daemon discovery (#337).
+   * "host_supervisor" = anet daemon (receives create_node dispatches);
+   * undefined / other values = regular agent-node. Read from config.json's
+   * `role` field, narrow-typed (only string passes). */
+  role?: string | null;
 }
 export function buildConfigSnapshot(
   fileConfig: any,
@@ -240,6 +246,7 @@ export function buildConfigSnapshot(
     flags: {},
     config_revision: revision,
     config_update_capable: configUpdateCapable,
+    role: typeof fileConfig?.role === "string" ? fileConfig.role : null,
   };
   const f = (fileConfig?.flags || {}) as Record<string, unknown>;
   for (const k of ALLOWED_FLAGS) {

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -294,6 +294,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         flags: z.record(z.unknown()).optional(),
         config_revision: z.number().int().min(0).optional(),
         config_update_capable: z.boolean().optional(),
+        // RFC-026 P2 / #338 — daemon role surfaced for hub /api/nodes
+        // discovery (#337 extracts this field). "host_supervisor" =
+        // anet daemon. Default-stripping zod would drop this otherwise.
+        role: z.string().max(64).optional().nullable(),
       }).optional().describe("RFC-024 — masked node config snapshot"),
     },
     async ({ resume_id, alias, status, task, output, score, progress, server: srv, hostname: hn, agent: ag, project_dir: pd, version: ver, tmux_name: tmux, node_id, session_id, config_path, channels, model: mdl, node_name: nn, network_id: netId, host, process_telemetry: proc, config_snapshot: cfgSnap }) => {

--- a/tests/qa-anet-daemon-cmd/Dockerfile
+++ b/tests/qa-anet-daemon-cmd/Dockerfile
@@ -1,0 +1,38 @@
+# `anet daemon` CLI end-to-end (issue #338 / RFC-026 P2 PR1).
+# Mirrors qa-rfc026-create-node install pattern: glibc base + bun +
+# build-essential + python3 + LOCAL source via `npm install -g`. Tests
+# that a user can go from zero to a registered host_supervisor daemon
+# WITHOUT manually editing any config.json.
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash curl ca-certificates jq unzip procps \
+    build-essential python3 sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /app
+
+COPY server /app/server
+COPY agent-node /app/agent-node
+COPY agent-network /app/agent-network
+COPY tests/lib /app/tests/lib
+COPY tests/qa-anet-daemon-cmd/run.sh /app/tests/qa-anet-daemon-cmd/run.sh
+RUN chmod +x /app/tests/qa-anet-daemon-cmd/run.sh
+
+RUN cd /app/server && bun install --silent
+RUN cd /app/agent-node && bun install --silent && bun run build
+RUN cd /app/agent-network && bun install --silent && bun run build
+
+RUN cd /app/agent-node \
+    && npm pack \
+    && npm install -g ./sleep2agi-agent-node-*.tgz
+RUN cd /app/agent-network \
+    && npm pack \
+    && npm install -g ./sleep2agi-agent-network-*.tgz
+
+RUN anet --version && which anet && which agent-node
+
+CMD ["/app/tests/qa-anet-daemon-cmd/run.sh"]

--- a/tests/qa-anet-daemon-cmd/run.sh
+++ b/tests/qa-anet-daemon-cmd/run.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# RFC-026 P2 PR1 (#338) — `anet daemon` CLI e2e.
+# Proves: from zero, a user runs `anet daemon init` → config.json gets
+# role=host_supervisor + defaults (NO manual edit) → `anet daemon start`
+# registers → hub /api/nodes returns role=host_supervisor → dashboard
+# can discover it via the post-#337 role-based path.
+
+set -uo pipefail
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/safe-rm.sh"
+
+HUB_PORT=9244
+HUB_BASE="http://127.0.0.1:$HUB_PORT"
+HUB_DB=/tmp/qa-anet-daemon.db
+WORK=/tmp/qa-anet-daemon-work
+ADMIN_USER="anetdmnadmin"
+ADMIN_PW="anetdmn_TestPass_1234!"
+DAEMON_NAME="my-daemon"
+
+PASS=0; FAIL=0
+note(){ printf "\n=== %s ===\n" "$*"; }
+ok()  { printf "  ✓ %s\n" "$*"; PASS=$((PASS+1)); }
+bad() { printf "  ✗ %s\n" "$*"; FAIL=$((FAIL+1)); }
+
+cleanup() {
+  [[ -n "${DAEMON_PID:-}" ]] && kill "$DAEMON_PID" 2>/dev/null || true
+  [[ -n "${HUB_PID:-}" ]] && kill "$HUB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ── Stage 0 — hub + admin user
+note "Stage 0 — isolated hub :$HUB_PORT + admin user"
+safe_rm_rf "$WORK" 2>/dev/null || true
+rm -f "$HUB_DB" "${HUB_DB}-wal" "${HUB_DB}-shm" 2>/dev/null
+mkdir -p "$WORK"
+COMMHUB_DB="$HUB_DB" PORT="$HUB_PORT" HOST=127.0.0.1 NODE_ENV=test \
+  bun run /app/server/src/index.ts >/tmp/hub.log 2>&1 &
+HUB_PID=$!
+for i in {1..30}; do sleep 0.5; curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && break; done
+curl -fsS "$HUB_BASE/health" >/dev/null && ok "hub /health 200" || { bad "hub failed to start"; tail -20 /tmp/hub.log; exit 1; }
+
+R=$(curl -sS -X POST "$HUB_BASE/api/auth/register" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PW\",\"display_name\":\"A\"}")
+UTOK=$(echo "$R" | jq -r .token); NET=$(echo "$R" | jq -r .network_id)
+[[ "$UTOK" == utok_* ]] && ok "admin utok minted (net=${NET:0:12})" || { bad "register: $R"; exit 1; }
+
+# Point anet CLI at this hub for the duration of the test (writes ~/.anet/config.json)
+cd "$WORK"
+mkdir -p "$HOME/.anet"
+cat > "$HOME/.anet/config.json" <<EOF
+{
+  "hub": "$HUB_BASE",
+  "token": "$UTOK",
+  "network_id": "$NET"
+}
+EOF
+ok "~/.anet/config.json wired to test hub"
+
+# ── A — anet daemon list (empty) on fresh install
+note "A. anet daemon list on fresh install"
+OUT=$(anet daemon list 2>&1)
+echo "$OUT" | grep -q "No host_supervisor daemons" && ok "empty list reports no daemons" || bad "unexpected list output: $OUT"
+
+# ── B — anet daemon init <name> creates config WITHOUT manual edit
+note "B. anet daemon init $DAEMON_NAME — zero manual config.json edit"
+anet daemon init "$DAEMON_NAME" 2>&1 | tee /tmp/init.log >/dev/null
+[[ -f "$WORK/.anet/nodes/$DAEMON_NAME/config.json" ]] && ok "config.json materialized" || { bad "config.json missing"; tail /tmp/init.log; exit 1; }
+
+# Assert the new config has role=host_supervisor + defaults (the actual unblocker)
+ROLE=$(jq -r '.role' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
+[[ "$ROLE" == "host_supervisor" ]] && ok "config.role == host_supervisor (no vim required)" || bad "role='$ROLE' expected host_supervisor"
+
+RUNTIMES=$(jq -r '.runtimes_supported | join(",")' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
+[[ "$RUNTIMES" == "claude-agent-sdk,codex-sdk,grok-build-acp" ]] && ok "runtimes_supported defaults set" || bad "runtimes_supported='$RUNTIMES'"
+
+ALLOWED=$(jq -r '.allowed_secret_keys | length' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
+[[ "$ALLOWED" == "0" ]] && ok "allowed_secret_keys fail-closed (empty by default per §9.7)" || bad "allowed_secret_keys length=$ALLOWED expected 0"
+
+NODE_ID=$(jq -r '.node_id' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
+[[ "$NODE_ID" == node_daemon_* ]] && ok "node_id prefix node_daemon_ (P1 #24 fallback compat)" || bad "node_id='$NODE_ID' not prefixed"
+
+TOK=$(jq -r '.token' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
+[[ "$TOK" == ntok_* ]] && ok "ntok minted + persisted" || bad "token='$TOK' not ntok_"
+
+# ── C — re-init same daemon is idempotent (no destructive)
+note "C. re-init idempotence"
+TOK_BEFORE="$TOK"
+NID_BEFORE="$NODE_ID"
+OUT=$(anet daemon init "$DAEMON_NAME" 2>&1)
+echo "$OUT" | grep -q "already a host_supervisor" && ok "init reports 'already a daemon' on second run" || bad "re-init didn't surface idempotence: $OUT"
+TOK_AFTER=$(jq -r '.token' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
+NID_AFTER=$(jq -r '.node_id' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
+[[ "$TOK_BEFORE" == "$TOK_AFTER" ]] && ok "token NOT re-minted on idempotent init (no churn)" || bad "token churned despite idempotence"
+[[ "$NID_BEFORE" == "$NID_AFTER" ]] && ok "node_id preserved on idempotent init" || bad "node_id churned"
+
+# ── D — refuse to overwrite non-daemon node without --force
+note "D. refuse to overwrite non-daemon node without --force"
+mkdir -p "$WORK/.anet/nodes/regular-node"
+echo '{"node_id":"node_regular","node_name":"regular-node","runtime":"claude-agent-sdk","role":"member"}' \
+  > "$WORK/.anet/nodes/regular-node/config.json"
+OUT=$(anet daemon init "regular-node" 2>&1)
+RC=$?
+[[ "$RC" -ne 0 ]] && ok "exit code non-zero on conflict (was $RC)" || bad "exited 0 despite role conflict"
+echo "$OUT" | grep -q '"member"' && ok "error names the conflicting role" || bad "error missing role mention: $OUT"
+# Verify the regular-node config WAS NOT overwritten
+EXISTING_ROLE=$(jq -r '.role' "$WORK/.anet/nodes/regular-node/config.json")
+[[ "$EXISTING_ROLE" == "member" ]] && ok "regular-node config untouched (no destructive write)" || bad "regular-node role mutated to '$EXISTING_ROLE'"
+
+# ── E — --force overwrite mints new token but PRESERVES node_id
+note "E. --force overwrite preserves node_id, re-mints token"
+NID_REGULAR=$(jq -r '.node_id' "$WORK/.anet/nodes/regular-node/config.json")
+anet daemon init "regular-node" --force 2>&1 >/tmp/force.log
+NEW_ROLE=$(jq -r '.role' "$WORK/.anet/nodes/regular-node/config.json")
+NEW_NID=$(jq -r '.node_id' "$WORK/.anet/nodes/regular-node/config.json")
+[[ "$NEW_ROLE" == "host_supervisor" ]] && ok "--force flipped role to host_supervisor" || bad "--force didn't flip role (got '$NEW_ROLE')"
+[[ "$NEW_NID" == "$NID_REGULAR" ]] && ok "--force preserved node_id ($NID_REGULAR)" || bad "node_id changed (was $NID_REGULAR, now $NEW_NID)"
+
+# ── F — anet daemon list shows the daemons
+note "F. anet daemon list shows the 2 daemons"
+LIST=$(anet daemon list 2>&1)
+echo "$LIST" | grep -q "$DAEMON_NAME" && ok "list shows '$DAEMON_NAME'" || bad "list missing '$DAEMON_NAME'"
+echo "$LIST" | grep -q "regular-node" && ok "list shows 'regular-node' (newly --force'd into daemon)" || bad "list missing 'regular-node'"
+COUNT=$(echo "$LIST" | grep -E "node_id=" | wc -l)
+[[ "$COUNT" -ge 2 ]] && ok "list count >= 2 ($COUNT)" || bad "list count $COUNT expected >=2"
+
+# ── G — anet daemon start + register + hub /api/nodes returns role
+note "G. anet daemon start → register → hub /api/nodes returns role=host_supervisor"
+# Use the original daemon (not the --force'd one)
+nohup anet daemon start "$DAEMON_NAME" > /tmp/daemon.log 2>&1 &
+DAEMON_PID=$!
+REG=""
+for i in {1..30}; do
+  sleep 1
+  R=$(curl -sS "$HUB_BASE/api/nodes?node_id=$NID_AFTER" -H "Authorization: Bearer $UTOK")
+  if echo "$R" | jq -e ".nodes[0].node_id == \"$NID_AFTER\"" >/dev/null 2>&1; then REG=yes; break; fi
+done
+[[ -n "$REG" ]] && ok "daemon registered with hub (node_id=$NID_AFTER)" || { bad "daemon never registered"; tail -30 /tmp/daemon.log; exit 1; }
+
+# CRITICAL: post-#337, hub /api/nodes returns role field extracted from config_snapshot.
+# This is the integration that unblocks the dashboard's role-based daemon discovery (#24).
+HUB_ROLE=$(curl -sS "$HUB_BASE/api/nodes?node_id=$NID_AFTER" -H "Authorization: Bearer $UTOK" | jq -r '.nodes[0].role')
+[[ "$HUB_ROLE" == "host_supervisor" ]] && ok "hub /api/nodes returns role=host_supervisor (post-#337 integration真)" || bad "hub role='$HUB_ROLE' expected host_supervisor"
+
+# Dashboard-style discovery: rows.find(r => r.role === 'host_supervisor') succeeds
+DASHBOARD_FOUND=$(curl -sS "$HUB_BASE/api/nodes" -H "Authorization: Bearer $UTOK" | jq -r '[.nodes[] | select(.role=="host_supervisor")] | length')
+[[ "$DASHBOARD_FOUND" -ge 1 ]] && ok "dashboard-style discovery succeeds (≥1 daemon found)" || bad "dashboard discovery would still fail"
+
+# ── H — daemon up (init+start one-shot) works on a fresh name
+note "H. anet daemon up oneshot — init+start in single command"
+kill "$DAEMON_PID" 2>/dev/null
+sleep 1
+nohup anet daemon up "oneshot-daemon" > /tmp/oneshot.log 2>&1 &
+DAEMON_PID=$!
+ONESHOT_REG=""
+for i in {1..30}; do
+  sleep 1
+  R=$(curl -sS "$HUB_BASE/api/nodes?alias=oneshot-daemon" -H "Authorization: Bearer $UTOK")
+  if echo "$R" | jq -e '.nodes[0].alias == "oneshot-daemon"' >/dev/null 2>&1; then ONESHOT_REG=yes; break; fi
+done
+[[ -n "$ONESHOT_REG" ]] && ok "daemon up registered 'oneshot-daemon' end-to-end" || { bad "oneshot never registered"; tail -30 /tmp/oneshot.log; }
+
+printf "\n────────────────────────────────────────────\n"
+printf "anet daemon CLI e2e — PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
+printf "────────────────────────────────────────────\n"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- New `anet daemon` CLI subcommand (init/start/up/list) — register a machine as a host_supervisor daemon with **zero manual config.json edit**.
- Closes the friction Vincent hit this AM: pre-PR, registering a daemon required `vim ~/.anet/nodes/<name>/config.json` to add `"role": "host_supervisor"` by hand. After PR, `anet daemon up` does the whole thing.
- Spans 3 packages (agent-network + agent-node + server) — all needed to close the integration loop with #337/#24.
- **25/25 e2e PASS** in fresh Docker container, **423/423 server unit pass**.

## Surface

```
anet daemon init <name> [--force] [--allow-secret KEY]...
anet daemon start <name>
anet daemon up [<name>]    # init+start one-shot, default name "daemon"
anet daemon list
```

## Why 3 packages

Closing the integration loop ("daemon → register → dashboard discovers via #24 role-based lookup") requires `role` to flow from disk config through every hop:

| package | change |
|:---|:---|
| `agent-network` (CLI) | new `daemonCommand` writes config with `role: "host_supervisor"` + RFC-026 §9.3 defaults via `writeFileSync` (saveProfile's whitelist would strip §9.3 fields) |
| `agent-node` (runtime) | `buildConfigSnapshot()` includes `role` (typeof-narrowed per [[feedback_typeof_narrow_extracted_fields]]) |
| `commhub-server` (hub) | `report_status` zod schema adds `role: z.string().max(64).optional().nullable()` — default zod strips unknown keys (caught mid-impl by my e2e scenario G failure) |

Without all three, the dashboard discovery loop stays broken at the silently-stripped hop. PR2-4 in the lane will land separately and don't depend on this PR.

## Idempotence + safety

- `init` on existing host_supervisor daemon → no-op + log, no token re-mint
- `init` on existing non-daemon node → REFUSE (exit !=0, no destructive write, error names the conflicting role)
- `init --force` → overwrites, **preserves `node_id`** (child references intact), re-mints token
- node_id keeps `node_daemon_` prefix for backwards-compat with pre-#337 dashboard prefix heuristic fallback
- Hub gate same as `anet node create` (refuses if no hub configured)

## Verification

| Suite | Result |
|:---|:---|
| server `bun test src/` | **423/423 pass, 0 fail** |
| daemon e2e (`tests/qa-anet-daemon-cmd/`, 25 scenarios A-H, fresh `node:22-bookworm-slim`) | **25/25 PASS, exit=0** |

Key e2e closures:
- B: 6 sub-asserts on `init`-generated config (role, runtimes_supported, allowed_secret_keys, node_id prefix, ntok)
- C: re-init idempotence (token + node_id NOT churned)
- D: refuse to overwrite non-daemon node (`role="member"` → error names it + no write)
- E: `--force` flips role, preserves node_id
- G: **the actual unblock** — daemon start → register → `/api/nodes` returns `role=host_supervisor` → dashboard-style `rows.find(r => r.role === "host_supervisor")` finds it (≥1 daemon)
- H: `anet daemon up` init+start one-shot end-to-end registration

## Out of scope (later PRs in #338 lane)

- **PR2** (hub): `list_host_supervisors` MCP tool + REST + nodes schema ALTERs for self-declared `runtimes_supported`/`allowed_secret_keys` columns (today those values live in `config_snapshot` blob; PR2 promotes to first-class columns)
- **PR3** (agent-node): D2 spawn fail-fast for "declared but binary missing" runtimes
- **PR4** (dashboard): RFC-026 §9.4 responsive wizard server-picker UI

## Test plan (review)

- [ ] 通信龙 claude-agent pre-review — focus on config write idempotence + `--force` preserves node_id + cross-package integration (the 3 hops where `role` could be silently stripped)
- [ ] Preview ship per-package after merge (agent-network preview.X / agent-node preview.X / commhub-server preview.X — publish-only, prod restart surface 通信龙)
- [ ] Progress tracked in #338

cc @vansin

🤖 Generated with [Claude Code](https://claude.com/claude-code)