### PR TITLE
chore(release): bump previews after #339 (agent-network 2.3.0-preview.11 / agent-node 2.5.0-preview.10 / commhub-server 0.9.0-preview.6)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -60,7 +60,7 @@ function tmuxAvailable(): boolean {
 // refetch). A `latest` agent-network release must pin a *stable* server.
 // `anet upgrade` (#88) surfaces this constant in its plan output so users
 // understand global-install version != version anet hub start actually runs.
-const PINNED_SERVER_VERSION = "0.9.0-preview.4";
+const PINNED_SERVER_VERSION = "0.9.0-preview.6";
 function sessionFileExists(uuid: string, cwd: string = process.cwd()): boolean {
   if (!uuid) return false;
   return existsSync(join(homedir(), ".claude", "projects", encodeCwd(cwd), `${uuid}.jsonl`));

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.10",
+  "version": "2.3.0-preview.11",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 4 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Grok Build ACP) and 8+ LLM providers (Anthropic / OpenAI / xAI Grok / MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter). Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.9",
+  "version": "2.5.0-preview.10",
   "description": "AI Agent runtime for CommHub networks. Supports 4 runtimes: Claude Code CLI, Claude Agent SDK, Codex SDK, and Grok Build ACP.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.4",
+  "version": "0.9.0-preview.6",
   "description": "CommHub Server \u2014 AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and 17 MCP tools.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

- Published 3 previews after #339 (anet daemon CLI lane PR1) merge.
- `--tag preview` only; @latest unchanged.
- PINNED_SERVER_VERSION chain-bumped to keep `anet hub start` users coherent with the new role-aware schema.

## Versions (raw registry truth)

| Package | Version | @latest |
|:---|:---|:---|
| `@sleep2agi/agent-network` | **2.3.0-preview.11** | 2.2.21 (unchanged) |
| `@sleep2agi/agent-node` | **2.5.0-preview.10** | 2.4.13 (unchanged) |
| `@sleep2agi/commhub-server` | **0.9.0-preview.6** | 0.8.8 (unchanged) |

## Prod hub restart status

**NOT scheduled here.** Per 通信龙 directive after PR #339 merge: batch the prod hub restart with PR2/PR3 (also touch hub) → one restart instead of three to minimize live network disturbance.

The `anet daemon` CLI in agent-network 2.3.0-preview.11 is **independently usable today** without the prod hub restart — local users running `anet hub start` get PINNED 0.9.0-preview.6 (chain-bumped) which has the role-aware schema.

## Verification

- server `bun test src/`: 423/423 pass
- daemon e2e (`tests/qa-anet-daemon-cmd/`): 25/25 PASS (in PR #339, unchanged)
- raw registry: all 3 versions live, @latest untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)