### PR TITLE
chore(release): bump previews after #341 (agent-node 2.5.0-preview.11 / commhub-server 0.9.0-preview.7)

### DIFF
--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.10",
+  "version": "2.5.0-preview.11",
   "description": "AI Agent runtime for CommHub networks. Supports 4 runtimes: Claude Code CLI, Claude Agent SDK, Codex SDK, and Grok Build ACP.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.6",
+  "version": "0.9.0-preview.7",
   "description": "CommHub Server \u2014 AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and 17 MCP tools.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

Bump 2 previews after #341 merge (PR2 list_host_supervisors).

| Package | Version | @latest |
|:---|:---|:---|
| `@sleep2agi/agent-node` | **2.5.0-preview.11** | 2.4.13 (unchanged) |
| `@sleep2agi/commhub-server` | **0.9.0-preview.7** | 0.8.8 (unchanged) |

`agent-network` not bumped — its only delta would be a PINNED chain-bump; folded into PR3 ship cycle. Prod hub restart batched with PR3 (per 通信龙 directive).

Pre-publish: server 432/432 pass, agent-node build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)