### PR TITLE
feat(rfc-027 PR1.1): rebuildChildrenMapOnBoot + inbox 6-site guard + SF-2 real failure-injection + PG tx

### DIFF
--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.13",
+  "version": "2.5.0-preview.14",
   "description": "AI Agent runtime for CommHub networks. Supports 4 runtimes: Claude Code CLI, Claude Agent SDK, Codex SDK, and Grok Build ACP.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -3956,6 +3956,26 @@ if (fileConfig.role === "host_supervisor") {
     });
     log("[deleted-sweeper] started (every 24h, retention 30d)");
   }).catch((e: any) => warn(`deleted-sweeper import failed: ${e?.message || e}`));
+
+  // RFC-027 PR1.1 — rebuild stop-daemon childrenMap from hub +
+  // pgrep at boot. Without this, daemon restart silently drops every
+  // tracked child and subsequent stop/delete dispatches no-op (same
+  // failure-shape as PR1 BLOCKER-1, but triggered by restart instead
+  // of bad key derivation). Hardening: pgrep + /proc cmdline token-
+  // exact verify + zombie skip + ambiguous-pid skip. Logs warn for
+  // hub-active-but-no-pid (crashed-without-cleanup) — no auto-nudge.
+  // Delay a bit after register so list_my_children sees the daemon
+  // itself as authenticated (resolveCallerDaemonTokenBound uses our
+  // ntok which is hot from register).
+  setTimeout(() => {
+    import("./runtime/stop-daemon.js").then(({ rebuildChildrenMapOnBoot }) => {
+      rebuildChildrenMapOnBoot({
+        callCommHub,
+        log: (m: string) => log(m),
+        warn: (m: string) => warn(m),
+      }).catch((e: any) => warn(`rebuildChildrenMapOnBoot failed: ${e?.message || e}`));
+    }).catch((e: any) => warn(`stop-daemon import for rebuild failed: ${e?.message || e}`));
+  }, 3_000);
 }
 if (goalsSchedulerEnabled) {
   setInterval(() => runGoalSchedulerTick().catch(() => {}), GOAL_TICK_MS);

--- a/agent-node/src/runtime/stop-daemon.test.ts
+++ b/agent-node/src/runtime/stop-daemon.test.ts
@@ -252,3 +252,201 @@ describe("handleStopDoorbell — real subprocess primitive (no mocks)", () => {
     expect(reaped).toBe(true);
   });
 });
+
+// ─── RFC-027 PR1.1 — rebuildChildrenMapOnBoot tests ────────────────
+// Cover: happy recover, alias substring collision rejection (cmdline
+// verify), zombie skip, ambiguous multi-pid skip, missing-pid warn,
+// self-pid exclusion. Plus a "real subprocess primitive" test that
+// spawns a fake child + pgrep + cmdline match exercise on this host
+// (per 通信龙 explicit "真子进程测给 rebuild 上真牙").
+describe("rebuildChildrenMapOnBoot (RFC-027 PR1.1)", () => {
+  test("happy: hub returns 2 children + each has unique matching pid → both recovered", async () => {
+    _resetChildrenMapForTest();
+    const { rebuildChildrenMapOnBoot } = await import("./stop-daemon");
+    const r = await rebuildChildrenMapOnBoot({
+      callCommHub: async (tool) => {
+        if (tool === "list_my_children") return {
+          ok: true, count: 2,
+          children: [
+            { child_node_id: "node_alpha", alias: "alpha", lifecycle_state: "active" },
+            { child_node_id: "node_beta",  alias: "beta",  lifecycle_state: "active" },
+          ],
+        };
+        return { ok: false };
+      },
+      log: () => {}, warn: () => {},
+      pgrepAlias: async (a) => a === "alpha" ? [1001] : a === "beta" ? [2002] : [],
+      readProcCmdline: (pid) =>
+        pid === 1001 ? "agent-node\0--alias\0alpha\0" :
+        pid === 2002 ? "agent-node\0--alias\0beta\0" : null,
+      readProcStatState: () => "S",
+    });
+    expect(r.recovered).toBe(2);
+    expect(r.missing.length).toBe(0);
+    expect(getChildrenSnapshot().map(c => c.alias).sort()).toEqual(["alpha", "beta"]);
+    _resetChildrenMapForTest();
+  });
+
+  test("alias substring collision: pgrep finds 'bot2' for alias 'bot' but cmdline argv exact-match rejects", async () => {
+    _resetChildrenMapForTest();
+    const { rebuildChildrenMapOnBoot, _internals } = await import("./stop-daemon");
+    // Validate the underlying argv check first.
+    expect(_internals.cmdlineMatchesAlias("agent-node\0--alias\0bot2\0", "bot")).toBe(false);
+    expect(_internals.cmdlineMatchesAlias("agent-node\0--alias\0bot\0",  "bot")).toBe(true);
+    expect(_internals.cmdlineMatchesAlias("agent-node\0--alias\0bot",     "bot")).toBe(true);
+    const r = await rebuildChildrenMapOnBoot({
+      callCommHub: async () => ({ ok: true, children: [{ child_node_id: "node_bot", alias: "bot", lifecycle_state: "active" }] }),
+      log: () => {}, warn: () => {},
+      pgrepAlias: async () => [9999],   // candidate pid (e.g. would match "bot2")
+      readProcCmdline: () => "agent-node\0--alias\0bot2\0",  // argv has bot2 not bot
+      readProcStatState: () => "S",
+    });
+    // No verified match — alias goes into missing.
+    expect(r.recovered).toBe(0);
+    expect(r.missing).toContain("bot");
+    expect(getChildrenSnapshot().length).toBe(0);
+    _resetChildrenMapForTest();
+  });
+
+  test("zombie pid skipped (state=Z)", async () => {
+    _resetChildrenMapForTest();
+    const { rebuildChildrenMapOnBoot } = await import("./stop-daemon");
+    const r = await rebuildChildrenMapOnBoot({
+      callCommHub: async () => ({ ok: true, children: [{ child_node_id: "node_z", alias: "zomb", lifecycle_state: "active" }] }),
+      log: () => {}, warn: () => {},
+      pgrepAlias: async () => [4040],
+      readProcCmdline: () => "agent-node\0--alias\0zomb\0",
+      readProcStatState: () => "Z",   // defunct
+    });
+    expect(r.recovered).toBe(0);
+    expect(r.zombies).toContain("zomb");
+    _resetChildrenMapForTest();
+  });
+
+  test("ambiguous: multiple verified pids → skipped (operator intervention)", async () => {
+    _resetChildrenMapForTest();
+    const { rebuildChildrenMapOnBoot } = await import("./stop-daemon");
+    const r = await rebuildChildrenMapOnBoot({
+      callCommHub: async () => ({ ok: true, children: [{ child_node_id: "node_dup", alias: "dup", lifecycle_state: "active" }] }),
+      log: () => {}, warn: () => {},
+      pgrepAlias: async () => [5050, 6060],
+      // Both legit cmdlines — likely operator started a duplicate.
+      readProcCmdline: () => "agent-node\0--alias\0dup\0",
+      readProcStatState: () => "S",
+    });
+    expect(r.recovered).toBe(0);
+    expect(r.ambiguous).toContain("dup");
+    expect(getChildrenSnapshot().length).toBe(0);
+    _resetChildrenMapForTest();
+  });
+
+  test("hub-active but pgrep finds nothing → missing (warn, don't auto-nudge)", async () => {
+    _resetChildrenMapForTest();
+    const warns: string[] = [];
+    const { rebuildChildrenMapOnBoot } = await import("./stop-daemon");
+    const r = await rebuildChildrenMapOnBoot({
+      callCommHub: async () => ({ ok: true, children: [{ child_node_id: "node_g", alias: "ghost", lifecycle_state: "active" }] }),
+      log: () => {}, warn: (m) => warns.push(m),
+      pgrepAlias: async () => [],
+      readProcCmdline: () => null,
+      readProcStatState: () => null,
+    });
+    expect(r.recovered).toBe(0);
+    expect(r.missing).toContain("ghost");
+    expect(warns.some(w => w.includes("ghost"))).toBe(true);
+    _resetChildrenMapForTest();
+  });
+
+  test("daemon's own pid is excluded from candidates", async () => {
+    _resetChildrenMapForTest();
+    const { rebuildChildrenMapOnBoot } = await import("./stop-daemon");
+    const r = await rebuildChildrenMapOnBoot({
+      callCommHub: async () => ({ ok: true, children: [{ child_node_id: "node_self", alias: "myself", lifecycle_state: "active" }] }),
+      log: () => {}, warn: () => {},
+      pgrepAlias: async () => [process.pid],   // collides with daemon itself
+      readProcCmdline: () => "agent-node\0--alias\0myself\0",
+      readProcStatState: () => "S",
+    });
+    expect(r.recovered).toBe(0);
+    expect(r.missing).toContain("myself");
+    _resetChildrenMapForTest();
+  });
+
+  test("list_my_children failure → safe empty result (no throw, no map mutation)", async () => {
+    _resetChildrenMapForTest();
+    recordSpawnedChild("node_preserve", "preserve", 12345);
+    const { rebuildChildrenMapOnBoot } = await import("./stop-daemon");
+    const r = await rebuildChildrenMapOnBoot({
+      callCommHub: async () => ({ ok: false, error: "auth_failed" }),
+      log: () => {}, warn: () => {},
+    });
+    expect(r.recovered).toBe(0);
+    expect(r.total_children_from_hub).toBe(0);
+    // Existing map untouched.
+    expect(getChildrenSnapshot().length).toBe(1);
+    expect(getChildrenSnapshot()[0].alias).toBe("preserve");
+    _resetChildrenMapForTest();
+  });
+});
+
+describe("rebuildChildrenMapOnBoot — real subprocess primitive (no pgrep mocks, no proc mocks)", () => {
+  // Per 通信龙 PR1.1 dispatch + #345 review lesson: "真子进程测给
+  // rebuildOnBoot 上真牙这点尤其对". Spawn a real fake "child" that
+  // sets its argv to look like agent-node + alias, let the real
+  // defaultPgrepAlias + /proc readers find it, verify recovery.
+  // We can't easily fake argv[0] from inside JS so we spawn with
+  // a shell exec that sets the title via process.argv inline.
+  // pgrep -f matches on the full /proc/<pid>/cmdline so we need our
+  // fake to write a cmdline that contains `agent-node` + `--alias <name>`
+  // as adjacent NUL-separated tokens.
+  // Per 通信龙 lesson on label honesty (PR1.1 dispatch + #345 review):
+  // "shape-pin/happy-path 测目前是即使把 fix 回退它们也会过". Calling
+  // this a full "end-to-end rebuild" would oversell.
+  //
+  // What this DOES test: spawn a real subprocess whose argv contains
+  // `--alias <test-alias>`, then drive the real cmdlineMatchesAlias
+  // helper against that pid's real /proc/<pid>/cmdline. Proves the
+  // matcher correctly walks NUL-separated argv from a live kernel.
+  //
+  // What this does NOT test (deferred to PR1.2 Docker e2e):
+  //  - the real pgrep wrapper finding the process by binary name
+  //    (test child runs `node`, not `agent-node`, so the default
+  //    pgrep pattern misses; PR1.2 spawns a real agent-node container
+  //    where the pattern truly matches end-to-end)
+  //  - the recovery decision integrating pgrep + /proc end-to-end
+  test("matcher accepts a real subprocess whose argv contains --alias <token>", async () => {
+    const { spawn } = await import("node:child_process");
+    const { _internals } = await import("./stop-daemon");
+    const { readFileSync } = await import("node:fs");
+    // Spawn `node --title=...` is not portable; instead spawn `bash -c
+    // "exec -a 'agent-node --alias FAKE-PRIM' node -e ...'"` so /proc/
+    // <pid>/cmdline records our pretend argv.
+    // exec -a replaces argv[0]; we still need --alias to appear as a
+    // SEPARATE NUL token, so include it in the exec -a string with
+    // a literal NUL won't work. Workaround: invoke node directly with
+    // sentinel args so /proc/<pid>/cmdline naturally separates.
+    const alias = "FAKE-MATCH-" + Math.floor(Math.random() * 1e6);
+    const child = spawn(
+      process.execPath,
+      ["-e", "setInterval(()=>{},5000)", "--alias", alias],
+      { stdio: ["ignore", "ignore", "ignore"], detached: true },
+    );
+    const pid = child.pid!;
+    expect(pid).toBeGreaterThan(0);
+    child.unref();
+    try {
+      await new Promise(r => setTimeout(r, 200));
+      // Read REAL /proc/<pid>/cmdline from a live process.
+      const realCmdline = readFileSync(`/proc/${pid}/cmdline`, "utf-8");
+      // Real cmdline doesn't contain `agent-node` (we spawned `node`),
+      // so prepend the production binary token to confirm the matcher
+      // walks the real argv data correctly when the binary IS present.
+      const cmdlineWithAgentNode = "agent-node\0" + realCmdline;
+      expect(_internals.cmdlineMatchesAlias(cmdlineWithAgentNode, alias)).toBe(true);
+      // And rejects a collision alias (substring of ours).
+      expect(_internals.cmdlineMatchesAlias(cmdlineWithAgentNode, alias.slice(0, -1))).toBe(false);
+    } finally {
+      try { process.kill(pid, "SIGKILL"); } catch { /* already exited */ }
+    }
+  });
+});

--- a/agent-node/src/runtime/stop-daemon.ts
+++ b/agent-node/src/runtime/stop-daemon.ts
@@ -19,9 +19,13 @@
 //     before rebuildChildrenMapOnBoot lands is the common cause. Hub-side
 //     sweeper / reconciliation picks up the row eventually.
 
-import { chmodSync, mkdirSync, renameSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, renameSync } from "node:fs";
+import { execFile } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileP = promisify(execFile);
 
 // Module-level child map. Filled by recordSpawnedChild when create-node-
 // daemon successfully spawns a child; consumed by handleStopDoorbell to
@@ -227,3 +231,173 @@ export async function handleStopDoorbell(
     deps.warn(`[stop-daemon] ack failed: ${e?.message || e}`);
   });
 }
+
+// ─── RFC-027 PR1.1 — rebuildChildrenMapOnBoot ─────────────────────────
+//
+// On daemon process restart the in-memory childrenMap is empty. Without
+// rebuild, every stop/delete dispatch for a still-running child no-ops
+// with `noop_not_my_child` (same failure shape as PR1's BLOCKER-1) →
+// hub never finalizes → user sees stop hang. The fix:
+//
+// 1. Pull this daemon's owned child aliases from hub via list_my_children
+//    (PR1.1 MCP tool — returns {child_node_id, alias, lifecycle_state}
+//    tuples scoped by the daemon's bound token + network).
+// 2. For each alias, run `pgrep` to find the running process. Hardening
+//    per 通信龙 proactive notes:
+//      a. alias substring collisions ("bot" matching "bot2") — pgrep
+//         pattern uses an explicit boundary (`--alias <alias>` followed
+//         by EOL or whitespace), and we re-check via /proc/<pid>/cmdline
+//         token-exact equality before trusting the match.
+//      b. self-match / other daemon's children — intersect pgrep result
+//         with the hub-supplied alias set; pgrep is the noisy candidate
+//         source, hub is the authority.
+//      c. defunct / zombie pids — /proc/<pid>/stat State=Z gets skipped.
+//      d. hub-says-active but no matching pid → log a warn (operator
+//         signal) but don't try to nudge hub state from here. P3 may add
+//         a "report dead child" tool; PR1.1 just surfaces.
+
+interface MyChild { child_node_id: string; alias: string; lifecycle_state: string; }
+
+export interface RebuildDeps {
+  callCommHub: (tool: string, args: Record<string, unknown>) => Promise<any>;
+  log: (msg: string) => void;
+  warn: (msg: string) => void;
+  // Injectable for tests: returns candidate pids matching the pgrep
+  // pattern for an alias.
+  pgrepAlias?: (alias: string) => Promise<number[]>;
+  // Injectable for tests: returns the /proc/<pid>/cmdline buffer (or
+  // null if the pid disappeared mid-read).
+  readProcCmdline?: (pid: number) => string | null;
+  // Injectable for tests: returns the /proc/<pid>/stat State char
+  // (e.g. "R", "S", "Z"). Null if pid gone.
+  readProcStatState?: (pid: number) => string | null;
+}
+
+/** Default pgrep wrapper. Pattern explicitly boundary-anchored so
+ *  alias "bot" doesn't match "bot2" / "bot-test". */
+async function defaultPgrepAlias(alias: string): Promise<number[]> {
+  const safe = alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = `agent-node.*--alias ${safe}($|[[:space:]])`;
+  try {
+    const { stdout } = await execFileP("pgrep", ["-f", pattern], { timeout: 5000 });
+    return stdout.split(/\s+/).filter(Boolean).map(s => parseInt(s, 10)).filter(n => Number.isFinite(n));
+  } catch (e: any) {
+    // pgrep exits 1 when no match — treat as empty result, not error.
+    if (e?.code === 1) return [];
+    throw e;
+  }
+}
+
+function defaultReadProcCmdline(pid: number): string | null {
+  try {
+    // /proc/<pid>/cmdline is NUL-separated; we want the raw bytes
+    // and will split on NUL to get individual argv tokens.
+    return readFileSync(`/proc/${pid}/cmdline`, "utf-8");
+  } catch { return null; }
+}
+
+function defaultReadProcStatState(pid: number): string | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+    // /proc/<pid>/stat format: "PID (comm) STATE ...". comm may
+    // contain spaces+parens so we slice after the closing paren.
+    const close = stat.lastIndexOf(")");
+    if (close < 0) return null;
+    const tail = stat.slice(close + 1).trim().split(/\s+/);
+    return tail[0] || null;
+  } catch { return null; }
+}
+
+/** Check that a /proc/<pid>/cmdline argv contains BOTH `agent-node`
+ *  AND `--alias <alias>` as adjacent tokens. Defends against
+ *  alias substring collisions (pgrep matches the pattern but the
+ *  actual argv has alias as a suffix of another token). */
+function cmdlineMatchesAlias(cmdline: string | null, alias: string): boolean {
+  if (!cmdline) return false;
+  const argv = cmdline.split("\0").filter(Boolean);
+  const aliasIdx = argv.findIndex((tok, i) => tok === "--alias" && argv[i + 1] === alias);
+  if (aliasIdx < 0) return false;
+  // Belt: ensure agent-node is in argv (process name or path).
+  return argv.some(t => t === "agent-node" || t.endsWith("/agent-node") || t.endsWith("/cli.js"));
+}
+
+export interface RebuildResult {
+  total_children_from_hub: number;
+  recovered: number;        // children whose pid was found and registered
+  missing: string[];        // hub-active alias with no matching live pid (warn-only)
+  ambiguous: string[];      // alias with >1 candidate pid after cmdline verify (skipped)
+  zombies: string[];        // alias whose pid was in defunct state (skipped)
+}
+
+export async function rebuildChildrenMapOnBoot(deps: RebuildDeps): Promise<RebuildResult> {
+  const result: RebuildResult = { total_children_from_hub: 0, recovered: 0, missing: [], ambiguous: [], zombies: [] };
+  const pgrepAlias = deps.pgrepAlias ?? defaultPgrepAlias;
+  const readCmdline = deps.readProcCmdline ?? defaultReadProcCmdline;
+  const readState = deps.readProcStatState ?? defaultReadProcStatState;
+
+  let children: MyChild[];
+  try {
+    const r = await deps.callCommHub("list_my_children", {});
+    if (!r?.ok || !Array.isArray(r.children)) {
+      deps.warn(`[rebuild] list_my_children failed: ${r?.error || "unknown"}`);
+      return result;
+    }
+    children = r.children;
+  } catch (e: any) {
+    deps.warn(`[rebuild] list_my_children threw: ${e?.message || e}`);
+    return result;
+  }
+  result.total_children_from_hub = children.length;
+
+  const selfPid = process.pid;
+
+  for (const c of children) {
+    if (!c.alias || !c.child_node_id) continue;
+    let pids: number[];
+    try {
+      pids = await pgrepAlias(c.alias);
+    } catch (e: any) {
+      deps.warn(`[rebuild] pgrep failed for alias=${c.alias}: ${e?.message || e}`);
+      continue;
+    }
+
+    // Filter out self + non-matching cmdline + defunct zombies.
+    const verified: number[] = [];
+    for (const pid of pids) {
+      if (pid === selfPid) continue;
+      const state = readState(pid);
+      if (state === "Z") {
+        result.zombies.push(c.alias);
+        continue;
+      }
+      const cmd = readCmdline(pid);
+      if (!cmdlineMatchesAlias(cmd, c.alias)) continue;
+      verified.push(pid);
+    }
+
+    if (verified.length === 0) {
+      // Hub says this alias is active but no live process found.
+      // Warn-only per PR1.1 scope; nudging hub state is a follow-up.
+      result.missing.push(c.alias);
+      deps.warn(`[rebuild] hub-active alias=${c.alias} has no matching pid (crashed without cleanup?)`);
+      continue;
+    }
+    if (verified.length > 1) {
+      // Multiple matching pids — refuse to guess, log + skip. Operator
+      // intervention required.
+      result.ambiguous.push(c.alias);
+      deps.warn(`[rebuild] alias=${c.alias} matched ${verified.length} pids ${verified.join(",")} after cmdline filter — skipping`);
+      continue;
+    }
+    recordSpawnedChild(c.child_node_id, c.alias, verified[0]);
+    result.recovered++;
+    deps.log(`[rebuild] recovered alias=${c.alias} → pid=${verified[0]}`);
+  }
+
+  deps.log(`[rebuild] done: total=${result.total_children_from_hub} recovered=${result.recovered} missing=${result.missing.length} ambiguous=${result.ambiguous.length} zombies=${result.zombies.length}`);
+  return result;
+}
+
+// Exported for unit tests so they can exercise cmdlineMatchesAlias
+// without spawning real processes.
+export const _internals = { cmdlineMatchesAlias };

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.9",
+  "version": "0.9.0-preview.10",
   "description": "CommHub Server \u2014 AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and 17 MCP tools.",
   "type": "module",
   "main": "src/index.ts",

--- a/server/src/stop-delete-node.test.ts
+++ b/server/src/stop-delete-node.test.ts
@@ -44,6 +44,12 @@ function cleanup() {
     try { db.run("DELETE FROM network_members WHERE network_id = ?1", [n]); } catch {}
     try { db.run("DELETE FROM networks WHERE network_id = ?1", [n]); } catch {}
   }
+  // SF-5 test plants a NULL-network inbox row keyed by alias — clean
+  // by alias too so it doesn't pollute later tests that use the same
+  // CHILD_A_ALIAS.
+  for (const alias of [CHILD_A_ALIAS, DAEMON_A_ALIAS]) {
+    try { db.run("DELETE FROM inbox WHERE session_name = ?1", [alias]); } catch {}
+  }
   try { db.run("DELETE FROM users WHERE user_id IN (?1, ?2)", [USER_A_ID, USER_B_ID]); } catch {}
 }
 
@@ -532,5 +538,137 @@ describe("SF-5 — in-flight COALESCE for legacy inbox rows", () => {
     expect(r.ok).toBe(false);
     expect(r.error).toBe("node_busy_in_flight");
     expect(r.in_flight_count).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── RFC-027 PR1.1 — D8 atomicity failure-injection (real teeth) ──
+//
+// PR1's SF-2 fix introduced auditCreateNodeStrict (re-throws inside tx
+// callback). The PR1 v3 test only verified happy path: both rows
+// present after success. 通信龙's #345 ack flagged that as a shape-pin
+// — could pass even if the strict variant were silently reverted. This
+// PR1.1 test injects a real failure (monkey-patch db.run to throw at
+// the audit_log INSERT moment) and asserts BOTH rollback halves:
+//   1. nodes.lifecycle_state UNCHANGED (didn't transition to 'stopping')
+//   2. node_stop_requests row absent (INSERT rolled back too)
+describe("SF-2 D8 atomicity — REAL failure injection forces ROLLBACK", () => {
+  test("audit_log table dropped → audit INSERT throws inside tx → ROLLBACK leaves nodes + request untouched", async () => {
+    setupAlphaNetwork();
+    const tools = buildHandlers(USER_A_ID);
+    // Real failure injection: drop audit_log so the strict audit
+    // INSERT inside the tx throws a real SQLite "no such table"
+    // error. The whole tx must roll back per §4.5 D8. (Patching
+    // adapter.db.run via property overwrite proved unreliable under
+    // bun:sqlite's transaction wrapper in earlier draft; dropping
+    // the table is the simplest way to make the failure REAL — the
+    // error originates inside the SQL engine, not a JS mock.)
+    db.exec("DROP TABLE IF EXISTS audit_log_BACKUP");
+    db.exec("ALTER TABLE audit_log RENAME TO audit_log_BACKUP");
+    let r: Reply;
+    try {
+      r = await call(tools.stop_node, {
+        child_node_id: CHILD_A_ID, daemon_node_id: DAEMON_A_ID, network_id: NET_A,
+      });
+    } finally {
+      // Restore so subsequent tests + cleanup work.
+      db.exec("DROP TABLE IF EXISTS audit_log");
+      db.exec("ALTER TABLE audit_log_BACKUP RENAME TO audit_log");
+    }
+    expect(r.ok).toBe(false);
+    // dispatch_tx_failed is the expected error. Print the actual reply
+    // if we got something else so the failure mode is diagnosable.
+    if (r.error !== "dispatch_tx_failed") {
+      console.error("[SF-2 unexpected reply]", JSON.stringify(r));
+    }
+    expect(r.error).toBe("dispatch_tx_failed");
+
+    // ROLLBACK observable:
+    // (a) lifecycle_state did NOT transition out of 'active'
+    expect(readNode(CHILD_A_ID)?.lifecycle_state).toBe("active");
+    // (b) no node_stop_requests row exists for this child
+    const reqs = db.all<{ request_id: string }>(
+      `SELECT request_id FROM node_stop_requests WHERE child_node_id = ?1`, [CHILD_A_ID],
+    );
+    expect(reqs.length).toBe(0);
+    // (c) no audit row was written
+    expect(readAudit("stop_node_dispatched", NET_A).length).toBe(0);
+  });
+});
+
+// ─── RFC-027 PR1.1 — inbox-enqueue lifecycle guard at routing layer ──
+//
+// 6 inbox INSERT sites in tools.ts (send_task / send_message / reply /
+// retry_task / reassign_task / broadcast) now pre-check the target
+// alias's nodes.lifecycle_state. Anything other than `active` refuses
+// with `node_not_active`. Sample the highest-traffic path (send_task)
+// for a stopping target — this catches the routing-after-SIGTERM
+// window that RFC §2.3 explicitly closes.
+describe("inbox-enqueue lifecycle_state guard (RFC-027 §2.3 race-free)", () => {
+  test("send_task to a stopping node → refused with node_not_active", async () => {
+    setupAlphaNetwork();
+    // Caller + target sessions rows (send_task's resolveDeliveryTarget
+    // looks up the target in sessions, not just nodes).
+    db.run(
+      `INSERT INTO sessions (resume_id, alias, network_id, last_seen_at, status, cpu_cores, mem_total_gb, ip)
+       VALUES (?1, ?2, ?3, datetime('now'), 'idle', 4, 8, '10.0.0.99')`,
+      [`s_caller_${Date.now()}`, "sender-x", NET_A],
+    );
+    db.run(
+      `INSERT INTO sessions (resume_id, alias, network_id, last_seen_at, status, cpu_cores, mem_total_gb, ip)
+       VALUES (?1, ?2, ?3, datetime('now'), 'idle', 4, 8, '10.0.0.5')`,
+      [`s_child_${Date.now()}`, CHILD_A_ALIAS, NET_A],
+    );
+    // Move target into stopping (mid-flight stop_node race window).
+    db.run(`UPDATE nodes SET lifecycle_state = 'stopping' WHERE node_id = ?1`, [CHILD_A_ID]);
+
+    const tools = buildHandlers(USER_A_ID);
+    const r = await call(tools.send_task, {
+      alias: CHILD_A_ALIAS,
+      task: "racey post-SIGTERM task",
+      from_session: "sender-x",
+      network_id: NET_A,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("node_not_active");
+    expect(r.lifecycle_state).toBe("stopping");
+    // Inbox unchanged (no row inserted for this alias post-stopping).
+    const inboxRows = db.all<{ id: string }>(
+      `SELECT id FROM inbox WHERE session_name = ?1 AND network_id = ?2`,
+      [CHILD_A_ALIAS, NET_A],
+    );
+    expect(inboxRows.length).toBe(0);
+  });
+});
+
+// ─── list_my_children (PR1.1 hub support for rebuild) ────────────
+describe("list_my_children HANDLER (RFC-027 PR1.1)", () => {
+  test("daemon-bound caller gets its children list", async () => {
+    setupAlphaNetwork();
+    // Plant a create-request row simulating that DAEMON_A has spawned
+    // CHILD_A previously (the daemon's child must be in this table).
+    db.run(
+      `INSERT INTO node_create_requests
+         (request_id, daemon_node_id, child_name, network_id, runtime, model, flags_json, env_keys, status, child_token_id, created_at, created_by_token)
+       VALUES ('cr_lmc_test', ?1, ?2, ?3, 'claude-agent-sdk', 'x', '{}', '[]', 'succeeded', NULL, ?4, 'tok_test')`,
+      [DAEMON_A_ID, CHILD_A_ALIAS, NET_A, Date.now()],
+    );
+    // The child's nodes row must exist (setupAlphaNetwork seeds it),
+    // and the canonical child_node_id needs to match `node_${request_id.slice(3)}`
+    // We update the existing child row's id so the LEFT JOIN matches.
+    db.run(`UPDATE nodes SET node_id = 'node_lmc_test' WHERE alias = ?1 AND network_id = ?2`, [CHILD_A_ALIAS, NET_A]);
+
+    const daemonTools = buildHandlers(USER_A_ID, true, DAEMON_A_TOK, NET_A);
+    const r = await call(daemonTools.list_my_children, {});
+    expect(r.ok).toBe(true);
+    expect(Array.isArray(r.children)).toBe(true);
+    const aliases = (r.children as Array<{ alias: string }>).map(c => c.alias);
+    expect(aliases).toContain(CHILD_A_ALIAS);
+  });
+
+  test("non-daemon caller (utok) refused", async () => {
+    setupAlphaNetwork();
+    const userTools = buildHandlers(USER_A_ID);   // utok, not daemon-bound
+    const r = await call(userTools.list_my_children, {});
+    expect(r.ok).toBe(false);
   });
 });

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -142,6 +142,33 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     return { networkId: null, networkIds: getReadableNetworkIds() };
   };
 
+  // RFC-027 §2.3 race-free invariant — assert target node is `active`
+  // before any inbox INSERT routes to it. Without this, the SIGTERM
+  // is in flight but new tasks keep landing in inbox for a dying
+  // child (and after `stopped`/`deleting` would persist forever).
+  // PR1.1 (#345 follow-up) wires this helper into all 6 inbox-enqueue
+  // sites in this file.
+  //
+  // Returns `{ ok: true }` when the target either (a) has no nodes row
+  // (brand-new alias, allowed), or (b) is in `active` state. Anything
+  // else (`stopping`/`stopped`/`deleting`/`stop_failed`) refuses with
+  // a structured reply the calling handler can return directly.
+  const assertNodeActive = (sessionAlias: string, networkId: string | null):
+    | { ok: true }
+    | { ok: false; error: string; lifecycle_state: string; alias: string } => {
+    if (!sessionAlias) return { ok: true };
+    const row = db.get<{ lifecycle_state: string | null }>(
+      networkId
+        ? `SELECT lifecycle_state FROM nodes WHERE alias = ?1 AND COALESCE(network_id, ?2) = ?2 LIMIT 1`
+        : `SELECT lifecycle_state FROM nodes WHERE alias = ?1 LIMIT 1`,
+      ...(networkId ? [sessionAlias, networkId] : [sessionAlias]),
+    );
+    if (!row) return { ok: true };
+    const st = row.lifecycle_state ?? "active";
+    if (st === "active") return { ok: true };
+    return { ok: false, error: "node_not_active", lifecycle_state: st, alias: sessionAlias };
+  };
+
   const addReadScope = (sql: string, params: any[], scope: ReadScope, column = "network_id"): string => {
     if (scope.networkId) {
       sql += ` AND ${column} = ?${params.length + 1}`;
@@ -868,6 +895,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         return { content: [{ type: "text" as const, text: JSON.stringify(payload) }] };
       }
 
+      // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.1 site 1/6).
+      {
+        const lc = assertNodeActive(targetAlias, effectiveNetId ?? null);
+        if (!lc.ok) return { content: [{ type: "text" as const, text: JSON.stringify(lc) }] };
+      }
+
       console.log(`[${ts()}] ${from_session} → send_task → ${targetAlias}: ${task.slice(0, 60)}${priority === "high" ? " [HIGH]" : ""}${canonical.renamed ? ` [renamed from ${alias}]` : ""}`);
       const id = uuidv4();
       const fromNodeId = resolveNodeIdForAlias(from_session, effectiveNetId);
@@ -963,6 +996,11 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const targetAlias = canonical.alias;
       const target = resolveDeliveryTarget(targetAlias, effectiveNetId);
       if (target.state === "not_found") return deliveryTargetReply(target)!;
+      // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.1 site 2/6).
+      {
+        const lc = assertNodeActive(targetAlias, effectiveNetId ?? null);
+        if (!lc.ok) return { content: [{ type: "text" as const, text: JSON.stringify(lc) }] };
+      }
       console.log(`[${ts()}] ${from_session} → send_message → ${targetAlias}: ${message.slice(0, 60)}${canonical.renamed ? ` [renamed from ${alias}]` : ""}`);
       const id = uuidv4();
       db.run(
@@ -1054,6 +1092,11 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         }
       }
       const replyTargetNodeId = resolveNodeIdForAlias(alias, effectiveNetId);
+      // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.1 site 3/6).
+      {
+        const lc = assertNodeActive(alias, effectiveNetId ?? null);
+        if (!lc.ok) return { content: [{ type: "text" as const, text: JSON.stringify(lc) }] };
+      }
       const replyLogged = db.transaction(() => {
         db.run(
           `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, in_reply_to, requires_response, network_id)
@@ -1187,6 +1230,11 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }
       if (!["failed", "expired", "cancelled"].includes(task.status)) {
         return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: `task status is ${task.status}, not retryable` }) }] };
+      }
+      // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.1 site 4/6).
+      {
+        const lc = assertNodeActive(task.to_name, effectiveNetId ?? task.network_id ?? null);
+        if (!lc.ok) return { content: [{ type: "text" as const, text: JSON.stringify(lc) }] };
       }
       db.transaction(() => {
         // Reset task status
@@ -1335,6 +1383,11 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const reassignedAlias = canonical.alias;
       const target = resolveDeliveryTarget(reassignedAlias, effectiveNetId ?? task.network_id ?? null);
       const newNodeId = target.state === "not_found" ? null : (target.session?.node_id ?? null);
+      // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.1 site 5/6).
+      {
+        const lc = assertNodeActive(reassignedAlias, effectiveNetId ?? task.network_id ?? null);
+        if (!lc.ok) return { content: [{ type: "text" as const, text: JSON.stringify(lc) }] };
+      }
       db.transaction(() => {
         // Ack old inbox to prevent original agent from picking it up
         const inboxParams: any[] = [task_id];
@@ -1380,6 +1433,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const ids: string[] = [];
 
       for (const t of targets) {
+        // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.1 site 6/6).
+        // Broadcast skips non-active recipients silently rather than
+        // failing the entire send — broadcast semantics are best-effort
+        // per-recipient and a stopped node simply gets nothing.
+        const lc = assertNodeActive(t.alias, effectiveNetId ?? t.network_id ?? null);
+        if (!lc.ok) continue;
         const id = uuidv4();
         db.run(
           `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, network_id)
@@ -2487,12 +2546,14 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     const now = Date.now();
     const newState = args.action === "stop" ? "stopping" : "deleting";
 
-    // SQLite tx wraps lifecycle UPDATE + audit INSERT + request INSERT.
-    // Better-sqlite3-style .transaction(...) is not exposed in our
-    // wrapper; emulate via BEGIN..COMMIT around the three writes. On
-    // any failure, ROLLBACK to leave state untouched.
-    db.run("BEGIN");
+    // §4.5 D8 — lifecycle UPDATE + audit INSERTs + request INSERT atomic.
+    // PR1.1: use db.transaction() (SQLiteAdapter wraps better-sqlite3's
+    // native transaction; PgAdapter ships a real BEGIN/COMMIT/ROLLBACK
+    // shim). Lets us drop the open-coded BEGIN/COMMIT + makes the
+    // SF-2 failure-injection test (mock db.run throw inside callback)
+    // reliable across both backends.
     try {
+      db.transaction(() => {
       db.run(
         `INSERT INTO node_stop_requests
            (request_id, network_id, daemon_node_id, child_node_id, child_alias, action,
@@ -2533,9 +2594,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           detail: { in_flight_count: inFlight, child_alias: node.alias },
         });
       }
-      db.run("COMMIT");
+      });   // end db.transaction
     } catch (e: any) {
-      try { db.run("ROLLBACK"); } catch { /* swallow */ }
       return { ok: false, error: "dispatch_tx_failed", message: e?.message || String(e) };
     }
 
@@ -2664,59 +2724,107 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }
       const now = Date.now();
 
-      // tx: per RFC §4.5 D8 — lifecycle UPDATE + request UPDATE + audit INSERT
-      // (+ DELETE for delete action) in one BEGIN..COMMIT.
-      db.run("BEGIN");
+      // §4.5 D8 — lifecycle UPDATE + request UPDATE + audit INSERT
+      // (+ DELETE for delete action) atomic via db.transaction().
+      // PR1.1: replaces hand-rolled BEGIN..COMMIT so PG adapter and
+      // SQLite both get correct rollback semantics from one code path.
       try {
-        db.run(
-          `UPDATE node_stop_requests SET status = ?1, error = ?2, exit_signal = ?3,
-                                          backup_path = ?4, acked_at = ?5
-             WHERE request_id = ?6`,
-          [status, ackError || null, exit_signal || null, backup_path || null, now, request_id],
-        );
-        if (status === "stopped" && row.action === "stop") {
-          db.run(`UPDATE nodes SET lifecycle_state = 'stopped' WHERE node_id = ?1`, [row.child_node_id]);
-          auditCreateNodeStrict({
-            action: "stop_node_completed",
-            user_id: null, network_id: row.network_id, target_id: request_id,
-            detail: {
-              child_node_id: row.child_node_id, child_alias: row.child_alias,
-              exit_signal: exit_signal || null, ts_daemon_ack: now,
-              lifecycle_state_after: "stopped",
-            },
-          });
-        } else if (status === "stopped" && row.action === "delete") {
-          // Revoke the child's ntok (name='node:<alias>') in the daemon's
-          // network, then DELETE the nodes row. Token revoke pattern mirrors
-          // ack_create_request's terminal path.
+        db.transaction(() => {
           db.run(
-            `UPDATE api_tokens SET revoked_at = datetime('now')
-               WHERE network_id = ?1 AND name = ?2 AND revoked_at IS NULL`,
-            [row.network_id, `node:${row.child_alias}`],
+            `UPDATE node_stop_requests SET status = ?1, error = ?2, exit_signal = ?3,
+                                            backup_path = ?4, acked_at = ?5
+               WHERE request_id = ?6`,
+            [status, ackError || null, exit_signal || null, backup_path || null, now, request_id],
           );
-          db.run(`DELETE FROM nodes WHERE node_id = ?1`, [row.child_node_id]);
-          auditCreateNodeStrict({
-            action: "delete_node_completed",
-            user_id: null, network_id: row.network_id, target_id: request_id,
-            detail: {
-              child_node_id: row.child_node_id, child_alias: row.child_alias,
-              exit_signal: exit_signal || null, backup_path: backup_path || null,
-              ts_daemon_ack: now, lifecycle_state_after: "deleted",
-            },
-          });
-        } else if (status === "stop_failed") {
-          db.run(`UPDATE nodes SET lifecycle_state = 'stop_failed' WHERE node_id = ?1`, [row.child_node_id]);
-          // No completion audit; the failure error is on the request row.
-        }
-        // noop_not_my_child: leave lifecycle_state as-is; the hub-side
-        // sweeper / next reconciliation will pick it up. Don't transition.
-        db.run("COMMIT");
+          if (status === "stopped" && row.action === "stop") {
+            db.run(`UPDATE nodes SET lifecycle_state = 'stopped' WHERE node_id = ?1`, [row.child_node_id]);
+            auditCreateNodeStrict({
+              action: "stop_node_completed",
+              user_id: null, network_id: row.network_id, target_id: request_id,
+              detail: {
+                child_node_id: row.child_node_id, child_alias: row.child_alias,
+                exit_signal: exit_signal || null, ts_daemon_ack: now,
+                lifecycle_state_after: "stopped",
+              },
+            });
+          } else if (status === "stopped" && row.action === "delete") {
+            // Revoke the child's ntok (name='node:<alias>') in the daemon's
+            // network, then DELETE the nodes row. Token revoke pattern mirrors
+            // ack_create_request's terminal path.
+            db.run(
+              `UPDATE api_tokens SET revoked_at = datetime('now')
+                 WHERE network_id = ?1 AND name = ?2 AND revoked_at IS NULL`,
+              [row.network_id, `node:${row.child_alias}`],
+            );
+            db.run(`DELETE FROM nodes WHERE node_id = ?1`, [row.child_node_id]);
+            auditCreateNodeStrict({
+              action: "delete_node_completed",
+              user_id: null, network_id: row.network_id, target_id: request_id,
+              detail: {
+                child_node_id: row.child_node_id, child_alias: row.child_alias,
+                exit_signal: exit_signal || null, backup_path: backup_path || null,
+                ts_daemon_ack: now, lifecycle_state_after: "deleted",
+              },
+            });
+          } else if (status === "stop_failed") {
+            db.run(`UPDATE nodes SET lifecycle_state = 'stop_failed' WHERE node_id = ?1`, [row.child_node_id]);
+            // No completion audit; the failure error is on the request row.
+          }
+          // noop_not_my_child: leave lifecycle_state as-is; the hub-side
+          // sweeper / next reconciliation will pick it up. Don't transition.
+        });
       } catch (e: any) {
-        try { db.run("ROLLBACK"); } catch { /* swallow */ }
         return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "finalize_tx_failed", message: e?.message || String(e) }) }] };
       }
 
       return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, status }) }] };
+    },
+  );
+
+  // RFC-027 PR1.1 — list_my_children: daemon-only query. Returns the
+  // {child_node_id, alias, lifecycle_state} tuples for nodes whose
+  // active create-request has this daemon as daemon_node_id. Used at
+  // daemon boot to rebuild the in-memory childrenMap (PR1 dropped
+  // every entry on daemon restart → stop/delete silently no-op'd).
+  //
+  // Network-scope is the daemon's own (resolveCallerDaemonTokenBound
+  // already binds tokenIsNetwork to a single network). No SEC-1 leak:
+  // returns ONLY children whose request landed under this daemon's
+  // token + network.
+  server.tool(
+    "list_my_children",
+    "Daemon pulls the alias + node_id list of children it spawned (for childrenMap rebuild after restart). RFC-027 PR1.1.",
+    {},
+    async () => {
+      const callerDaemon = resolveCallerDaemonTokenBound();
+      if (!callerDaemon.ok) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: callerDaemon.error }) }] };
+      }
+      // node_create_requests carries the canonical authoritative
+      // child→daemon mapping (the row id IS the request, and the
+      // child node_id derives from it deterministically via
+      // `node_${request_id.replace(/^cr_/, "")}`). Filter to children
+      // that completed registration (have a nodes row) so we don't
+      // ask the daemon to pgrep for children that never came up.
+      const rows = db.all<{ request_id: string; child_name: string; child_node_id: string; lifecycle_state: string | null }>(
+        `SELECT ncr.request_id, ncr.child_name,
+                ('node_' || substr(ncr.request_id, 4)) AS child_node_id,
+                n.lifecycle_state
+           FROM node_create_requests ncr
+           LEFT JOIN nodes n ON n.node_id = ('node_' || substr(ncr.request_id, 4))
+          WHERE ncr.daemon_node_id = ?1
+            AND ncr.network_id = ?2
+            AND ncr.status IN ('succeeded', 'delivered')
+            AND n.node_id IS NOT NULL
+            AND COALESCE(n.lifecycle_state, 'active') NOT IN ('stopped', 'stop_failed')`,
+        callerDaemon.daemonNodeId, callerDaemon.networkId,
+      );
+      const children = rows.map(r => ({
+        child_node_id: r.child_node_id,
+        alias: r.child_name,
+        lifecycle_state: r.lifecycle_state ?? "active",
+      }));
+      return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, count: children.length, children }) }] };
     },
   );
 


### PR DESCRIPTION
## Author
Agent: 通信工程马

## Summary
Per 通信龙 dispatch (after #345 squash-merge). 4 deliverables; PR1.1 sits before PR2 (dashboard) per 通信龙 — `rebuildOnBoot` is the real reliability gap (daemon restart silently no-ops stop/delete on existing children, same failure-shape as PR1's BLOCKER-1 but triggered by restart instead of bad key derivation).

## (1) rebuildChildrenMapOnBoot
- **NEW** hub MCP tool `list_my_children` — daemon-bound, returns `{child_node_id, alias, lifecycle_state}` from `node_create_requests` JOIN `nodes`, SEC-1 scoped to daemon's own token+network.
- **NEW** `rebuildChildrenMapOnBoot()` in `stop-daemon.ts`. Hardenings per 通信龙 proactive review (alias substring collision via cmdline token-exact verify; self-pid exclusion; zombie `state='Z'` skip; ambiguous multi-pid skip; hub-active-but-no-pid warn-only).
- `cli.ts` boot schedules rebuild ~3s after register.

## (2) inbox-enqueue 6-site lifecycle guard
RFC §2.3 race-free invariant: post-SIGTERM, no new tasks enqueue to a stopping/stopped/deleting child. `assertNodeActive(alias, networkId)` helper applied at all 6 INSERT INTO inbox sites (send_task / send_message / reply / retry_task / reassign_task / broadcast). broadcast skips silently; the rest return structured `node_not_active` refusal.

## (3) SF-2 REAL failure-injection (PR1 ack required this)
#345's SF-2 test was happy-path. PR1.1 drops `audit_log` table so the audit INSERT inside the tx throws a SQLite "no such table" error. Asserts lifecycle_state UNCHANGED + node_stop_requests row absent + no audit row. The error originates inside the SQL engine — not a JS mock — so the strict variant's re-throw really drives the rollback.

## (4) PG-adapter tx
Hand-rolled `db.run('BEGIN')` / explicit ROLLBACK catch in dispatchStopOrDelete + ack_stop_request → `db.transaction(fn)` (better-sqlite3-style for SQLite; PG adapter ships its own shim). Both backends get the same tx semantics from one code path.

## Test label honesty (per [[feedback_test_label_must_match_coverage_kind]])
- Rebuild unit tests = injected hub + pgrep + /proc. Each hardening branch has a happy/sad pair (alias collision rejected; zombie skipped; ambiguous skipped; missing-pid warn-only; self-pid excluded; list_my_children failure no-op).
- Real-subprocess test is labeled **"primitive: cmdline matcher against real /proc"** — spawns `node` (not `agent-node`), drives `cmdlineMatchesAlias` against the live process's real `/proc/<pid>/cmdline`. Does NOT claim "end-to-end rebuild" — that's PR1.2 docker e2e where a real `agent-node` container child makes the default pgrep pattern fire.

## Verification numbers
- **commhub-server**: 466/466 pass (+4 net: SF-2 real failure-inject + inbox-guard happy + list_my_children daemon-bound happy + non-daemon refuse)
- **agent-node**: 619/619 pass (+8 net: 7 rebuild branch tests + 1 cmdline-matcher real-subprocess primitive)
- `bun test src/` default-timeout: green
- bun build agent-node: clean

## What's NOT in this PR
- Docker e2e scenarios A-K → **PR1.2** (real create→stop→reap via container-spawned agent-node binary; only place where default pgrep pattern fires end-to-end against true `agent-node` argv)
- "hub-says-active but no pid" auto-nudge to hub → **P3** (rebuild surfaces a warn now; auto-reconciliation is separate)
- Dashboard ⋮ menu + modals → **PR2** (next per 通信龙 lane split)

## PINNED chain-bump
- `@sleep2agi/commhub-server` 0.9.0-preview.9 → **0.9.0-preview.10** (list_my_children + assertNodeActive)
- `@sleep2agi/agent-node` 2.5.0-preview.13 → **2.5.0-preview.14** (rebuildOnBoot + boot wire)

Refs RFC-027 §2.3/§2.4/§4.5, follow-up to #345.