### PR TITLE
fix(rfc-027 PR1.2a): close 2 REST inbox guard misses + restart_node lifecycle reset

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.10",
+  "version": "0.9.0-preview.11",
   "description": "CommHub Server \u2014 AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and 17 MCP tools.",
   "type": "module",
   "main": "src/index.ts",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import { registerTools } from "./tools.js";
 import { db, logTaskEvent, logAudit } from "./db.js";
 import { createSSEStream, pushEvent, getSSEStats } from "./push.js";
+import { assertNodeActive } from "./lifecycle-guard.js";
 import { register, login, resolveToken, getUserNetworks, getUserAllNetworks, createNetwork, deleteNetwork, renameNetwork, changePassword, issueUserToken, listTokens, createToken, revokeToken, getNetworkMembers, getUserNetworkRole, addNetworkMember, updateMemberRole, removeNetworkMember, createInvite, joinByInvite, createNetworkTokenForNode, type AuthUser } from "./auth.js";
 import { abortRename, cleanupCommittedRenameSessions, commitRename, prepareRename, resolveCanonicalAlias } from "./rename.js";
 import { sharedSendDedup, buildDuplicateSendPayload } from "./send_dedup.js";
@@ -1621,6 +1622,18 @@ Bun.serve({
         return withCors(req, Response.json(payload, { status: 429 }));
       }
 
+      // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.2a REST site
+      // 1/2 — paired with the 6 MCP sites guarded in tools.ts at PR1.1).
+      // Dashboard's "Dispatch" button hits this endpoint, so without
+      // the guard a stopping/stopped/deleting node still got tasks
+      // routed through REST. Returns 409 with the same structured
+      // payload the MCP handlers use.
+      {
+        const lc = assertNodeActive(targetAlias, taskNetId ?? null);
+        if (!lc.ok) {
+          return withCors(req, Response.json(lc, { status: 409 }));
+        }
+      }
       // Mirror send_task MCP: write inbox + tasks rows in a single
       // transaction so the dispatch is visible to dashboard's Tasks page
       // and the parent_task_id lineage chain. Previously this endpoint
@@ -1701,6 +1714,12 @@ Bun.serve({
       const targets = db.all<{ alias: string; node_id: string | null; network_id: string | null }>(sql, ...params);
       const ids: string[] = [];
       for (const t of targets) {
+        // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.2a REST site
+        // 2/2). Broadcast skips non-active recipients silently per its
+        // best-effort semantics — mirrors the MCP broadcast handler
+        // in tools.ts (PR1.1 site 6/6).
+        const lc = assertNodeActive(t.alias, t.network_id ?? null);
+        if (!lc.ok) continue;
         const id = crypto.randomUUID();
         db.run(
           `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, network_id)

--- a/server/src/lifecycle-guard.ts
+++ b/server/src/lifecycle-guard.ts
@@ -1,0 +1,50 @@
+// RFC-027 §2.3 race-free invariant — shared helper for the inbox-
+// enqueue lifecycle guard.
+//
+// PR1.1 (#346) added an `assertNodeActive` helper inside the
+// registerTools() closure and applied it at the 6 INSERT INTO inbox
+// sites in server/src/tools.ts. PR1.1 review (通信龙 #346 ack) caught
+// that the closure scope made the helper unreachable from REST
+// handlers in server/src/index.ts — POST /api/task (:1631) and
+// POST /api/broadcast (:1706) are dashboard's "Dispatch" entry
+// points and bypassed the guard, leaving the §2.3 race open on the
+// REST path.
+//
+// PR1.2a (#346 follow-up) extracts the helper to this module so both
+// the MCP tools and the REST handlers can import the same code path,
+// per [[feedback_grep_all_sites_before_apply_guard]]: any SQL-level
+// guard's helper lives at module scope so every write site
+// (MCP + REST + internal db.ts helpers) can use it.
+//
+// Behaviour:
+//   - no nodes row for the alias → ok:true (brand-new alias allowed;
+//     could be the first INSERT for a child about to register)
+//   - lifecycle_state = 'active' OR NULL (pre-RFC-027 row) → ok:true
+//   - anything else (stopping / stopped / stop_failed / deleting) →
+//     ok:false + structured `node_not_active` reply
+//
+// COALESCE on the WHERE keeps NULL-network inbox rows / legacy nodes
+// rows correctly scoped (PR1 SF-5 lineage).
+
+import { db } from "./db.js";
+
+export type LifecycleGuardResult =
+  | { ok: true }
+  | { ok: false; error: "node_not_active"; lifecycle_state: string; alias: string };
+
+export function assertNodeActive(
+  sessionAlias: string,
+  networkId: string | null,
+): LifecycleGuardResult {
+  if (!sessionAlias) return { ok: true };
+  const row = db.get<{ lifecycle_state: string | null }>(
+    networkId
+      ? `SELECT lifecycle_state FROM nodes WHERE alias = ?1 AND COALESCE(network_id, ?2) = ?2 LIMIT 1`
+      : `SELECT lifecycle_state FROM nodes WHERE alias = ?1 LIMIT 1`,
+    ...(networkId ? [sessionAlias, networkId] : [sessionAlias]),
+  );
+  if (!row) return { ok: true };
+  const st = row.lifecycle_state ?? "active";
+  if (st === "active") return { ok: true };
+  return { ok: false, error: "node_not_active", lifecycle_state: st, alias: sessionAlias };
+}

--- a/server/src/stop-delete-node.test.ts
+++ b/server/src/stop-delete-node.test.ts
@@ -38,6 +38,9 @@ function cleanup() {
     try { db.run("DELETE FROM node_stop_requests WHERE network_id = ?1", [n]); } catch {}
     try { db.run("DELETE FROM audit_log WHERE network_id = ?1", [n]); } catch {}
     try { db.run("DELETE FROM inbox WHERE network_id = ?1", [n]); } catch {}
+    // PR1.2a restart_node tests leave node_config_updates rows; clear
+    // so the next test's restart_node doesn't see them as in_flight.
+    try { db.run("DELETE FROM node_config_updates WHERE network_id = ?1", [n]); } catch {}
     try { db.run("DELETE FROM nodes WHERE network_id = ?1", [n]); } catch {}
     try { db.run("DELETE FROM sessions WHERE network_id = ?1", [n]); } catch {}
     try { db.run("DELETE FROM api_tokens WHERE network_id = ?1", [n]); } catch {}
@@ -670,5 +673,48 @@ describe("list_my_children HANDLER (RFC-027 PR1.1)", () => {
     const userTools = buildHandlers(USER_A_ID);   // utok, not daemon-bound
     const r = await call(userTools.list_my_children, {});
     expect(r.ok).toBe(false);
+  });
+});
+
+// ─── PR1.2a — restart_node resets lifecycle_state ──────────────────
+//
+// 通信龙 #346 ack latent: without this, a stopped node restart-ed via
+// restart_node would still have lifecycle_state='stopped' in the
+// nodes table → the 6 MCP + 2 REST inbox guards would refuse all
+// routing → node silently unreachable until manual DB fix. Asserts
+// the dispatch + state flip happen atomically (tx).
+describe("RFC-027 PR1.2a — restart_node resets lifecycle_state to 'active'", () => {
+  test("restart_node on a stopped node → lifecycle_state flips back to 'active' + dispatch row created", async () => {
+    setupAlphaNetwork();
+    // Move the child to 'stopped' (simulating prior stop_node completion).
+    db.run(`UPDATE nodes SET lifecycle_state = 'stopped' WHERE node_id = ?1`, [CHILD_A_ID]);
+    expect(readNode(CHILD_A_ID)?.lifecycle_state).toBe("stopped");
+
+    const tools = buildHandlers(USER_A_ID);
+    const r = await call(tools.restart_node, {
+      node_id: CHILD_A_ID,
+      network_id: NET_A,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.apply_mode).toBe("restart_only");
+
+    // State flipped back.
+    expect(readNode(CHILD_A_ID)?.lifecycle_state).toBe("active");
+    // node_config_updates row exists (the dispatch).
+    const rows = db.all<{ update_id: string; status: string }>(
+      `SELECT update_id, status FROM node_config_updates WHERE node_id = ?1 ORDER BY created_at DESC LIMIT 1`,
+      [CHILD_A_ID],
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].status).toBe("pending");
+  });
+
+  test("restart_node on an active node → still resets to active (idempotent, no-op state-wise)", async () => {
+    setupAlphaNetwork();
+    expect(readNode(CHILD_A_ID)?.lifecycle_state).toBe("active");
+    const tools = buildHandlers(USER_A_ID);
+    const r = await call(tools.restart_node, { node_id: CHILD_A_ID, network_id: NET_A });
+    expect(r.ok).toBe(true);
+    expect(readNode(CHILD_A_ID)?.lifecycle_state).toBe("active");
   });
 });

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
 import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken } from "./db.js";
 import { pushEvent } from "./push.js";
+import { assertNodeActive } from "./lifecycle-guard.js";
 import { getUserNetworkRole, createNetworkTokenForNode } from "./auth.js";
 import {
   buildAnetArgs as _unused_buildAnetArgs,           // ensure module is loaded
@@ -142,32 +143,13 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     return { networkId: null, networkIds: getReadableNetworkIds() };
   };
 
-  // RFC-027 §2.3 race-free invariant — assert target node is `active`
-  // before any inbox INSERT routes to it. Without this, the SIGTERM
-  // is in flight but new tasks keep landing in inbox for a dying
-  // child (and after `stopped`/`deleting` would persist forever).
-  // PR1.1 (#345 follow-up) wires this helper into all 6 inbox-enqueue
-  // sites in this file.
-  //
-  // Returns `{ ok: true }` when the target either (a) has no nodes row
-  // (brand-new alias, allowed), or (b) is in `active` state. Anything
-  // else (`stopping`/`stopped`/`deleting`/`stop_failed`) refuses with
-  // a structured reply the calling handler can return directly.
-  const assertNodeActive = (sessionAlias: string, networkId: string | null):
-    | { ok: true }
-    | { ok: false; error: string; lifecycle_state: string; alias: string } => {
-    if (!sessionAlias) return { ok: true };
-    const row = db.get<{ lifecycle_state: string | null }>(
-      networkId
-        ? `SELECT lifecycle_state FROM nodes WHERE alias = ?1 AND COALESCE(network_id, ?2) = ?2 LIMIT 1`
-        : `SELECT lifecycle_state FROM nodes WHERE alias = ?1 LIMIT 1`,
-      ...(networkId ? [sessionAlias, networkId] : [sessionAlias]),
-    );
-    if (!row) return { ok: true };
-    const st = row.lifecycle_state ?? "active";
-    if (st === "active") return { ok: true };
-    return { ok: false, error: "node_not_active", lifecycle_state: st, alias: sessionAlias };
-  };
+  // RFC-027 §2.3 race-free invariant — assertNodeActive lives in
+  // server/src/lifecycle-guard.ts so REST handlers in server/src/index.ts
+  // can use the SAME code path. PR1.1 had it inline here; PR1.2a
+  // (#346 review catch) extracted because the closure scope made it
+  // unreachable from REST and left the §2.3 race open on dashboard
+  // Dispatch (POST /api/task + /api/broadcast). Per
+  // [[feedback_grep_all_sites_before_apply_guard]].
 
   const addReadScope = (sql: string, params: any[], scope: ReadScope, column = "network_id"): string => {
     if (scope.networkId) {
@@ -1853,10 +1835,24 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }
       const updateId = `cu_${uuidv4()}`;
       const networkId = node.network_id || "default";
-      db.run(
-        `INSERT INTO node_config_updates (update_id, node_id, network_id, patch_json, apply_mode, base_revision, status, created_at, created_by_token) VALUES (?1, ?2, ?3, '{}', 'restart_only', ?4, 'pending', ?5, ?6)`,
-        [updateId, nodeId, networkId, node.config_revision || 0, Date.now(), callerTokenId || "unknown"],
-      );
+      // RFC-027 PR1.2a latent fix (#346 ack): restart_node must reset
+      // lifecycle_state to 'active'. Otherwise a node that was previously
+      // stop_node'd → 'stopped' would, after restart, stay marked
+      // 'stopped' in the nodes table → the 6 MCP + 2 REST inbox guards
+      // would refuse every routing attempt → node silently unreachable
+      // (no error to operator, just no traffic). Pair the schema flip
+      // with the config_updates INSERT inside one tx so we don't
+      // half-commit if the dispatch INSERT throws.
+      db.transaction(() => {
+        db.run(
+          `INSERT INTO node_config_updates (update_id, node_id, network_id, patch_json, apply_mode, base_revision, status, created_at, created_by_token) VALUES (?1, ?2, ?3, '{}', 'restart_only', ?4, 'pending', ?5, ?6)`,
+          [updateId, nodeId, networkId, node.config_revision || 0, Date.now(), callerTokenId || "unknown"],
+        );
+        db.run(
+          `UPDATE nodes SET lifecycle_state = 'active' WHERE node_id = ?1`,
+          [nodeId],
+        );
+      });
       pushEvent(node.alias, { type: "restart", update_id: updateId }, networkId);
       return {
         content: [{ type: "text" as const, text: JSON.stringify({ ok: true, update_id: updateId, apply_mode: "restart_only" }) }],


### PR DESCRIPTION
## Author
Agent: 通信工程马

## Summary
Fast follow-up to #346 closing the 2 scope items 通信龙 caught in squash-merge ack. Small + ship-quality so PR2 (dashboard UI) doesn't open a known-broken race.

## What this fixes
**Miss 1** — `assertNodeActive` lived in `registerTools()` closure → REST handlers in `index.ts` couldn't import → dashboard's "Dispatch" button (hits POST `/api/task` + `/api/broadcast`) bypassed the §2.3 race-free guard PR1.1 wired everywhere else.

- **NEW** `server/src/lifecycle-guard.ts` — module-level `assertNodeActive(alias, networkId)`. Same semantics PR1.1 established.
- `tools.ts` — drops closure helper, imports shared one.
- `index.ts` — applies at POST `/api/task` (returns 409 + structured payload) and POST `/api/broadcast` (skips silently per best-effort semantics, matches `tools.ts` broadcast site).

**Latent** — `restart_node` didn't reset `lifecycle_state` → restarting a stopped node left it marked `'stopped'` → all 6 MCP + 2 REST inbox guards refused → silently unreachable.

- `tools.ts restart_node`: dispatch INSERT + `UPDATE nodes SET lifecycle_state='active'` now in a single `db.transaction()`.

## Tests (label-honest per [[feedback_test_label_must_match_coverage_kind]])
- restart_node on stopped → state flips to active + dispatch row present.
- restart_node on active → idempotent (no state regression, no error).
- Test fixture cleanup gains `node_config_updates` DELETE.

Live REST guard exercise (curl against preview.11 hub) deferred to PR1.2 docker e2e — there a stopped child + POST /api/task expects 409 against a real running server.

## Discipline
Followed [[feedback_grep_all_sites_before_apply_guard]]:
```
grep -rn "INSERT INTO inbox" server/src/
```
lists 9 sites (6 in `tools.ts` PR1.1-guarded + 2 in `index.ts` this PR + 1 in `db.ts:1325` chainReplyToParent helper). PR body lists all 9 honestly; `db.ts:1325` deferred to PR1.2 with documented rationale (deeper helper, needs caller-path network_id audit).

## Verification numbers
- **commhub-server**: 468/468 pass (+2 net for restart_node)
- `bun test src/` no-flag green
- agent-node unchanged

## PINNED bump
- `@sleep2agi/commhub-server` 0.9.0-preview.10 → **0.9.0-preview.11**

## What's NOT in this PR
- Docker e2e scenario A (real create→stop→reap) → **PR1.2**
- `db.ts:1325` chainReplyToParent inbox INSERT guard → **PR1.2**
- `list_my_children` cross-network negative test → **PR1.2**
- Dashboard ⋮ menu + modal UI → **PR2** (next, can run in parallel with PR1.2)

Refs RFC-027 §2.3, follow-up to #346.