### PR TITLE
chore(release): bump agent-network 2.3.0-preview.14 (RFC-027 GA snapshot)

### DIFF
--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.13",
+  "version": "2.3.0-preview.14",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 4 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Grok Build ACP) and 8+ LLM providers (Anthropic / OpenAI / xAI Grok / MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter). Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",


### PR DESCRIPTION
## Why

RFC-027 节点管理 GA 4-pack preview rollout per 通信龙 dispatch 6d59bf12. Bumps agent-network so Vincent's `npm i -g @sleep2agi/agent-network@preview` pulls the post-#349 sha along with the other 3 packages.

## Verified published

```
@sleep2agi/commhub-server@preview        = 0.9.0-preview.12  (BUG-A SSE alias fix)
@sleep2agi/agent-node@preview            = 2.5.0-preview.14  (BUG-B pgid kill fix)
@sleep2agi/agent-network@preview         = 2.3.0-preview.14  (this PR — version bump only, no CLI changes)
@sleep2agi/agent-network-dashboard@preview = 0.6.3-preview.4   (PR #30 stop/delete UI)
```

All four `npm view ... dist-tags` confirmed `preview:` matches PINNED.

## Test plan

- [x] `npm run build` clean (per [[feedback_npm_pack_skips_prepublishOnly]] — explicit build, not via pack)
- [x] `npm publish --tag preview --access public` ✓
- [x] `npm view @sleep2agi/agent-network@preview version` → 2.3.0-preview.14 ✓
- [ ] Vincent UAT after 通信龙 hands off the install command

🤖 Generated with [Claude Code](https://claude.com/claude-code)