### PR TITLE
chore(release): bump commhub-server preview.13 + agent-node preview.15 (post-#351 cross-host attachment fix)

### DIFF
--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.14",
+  "version": "2.5.0-preview.15",
   "description": "AI Agent runtime for CommHub networks. Supports 4 runtimes: Claude Code CLI, Claude Agent SDK, Codex SDK, and Grok Build ACP.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.12",
-  "description": "CommHub Server \u2014 AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and 17 MCP tools.",
+  "version": "0.9.0-preview.13",
+  "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and 17 MCP tools.",
   "type": "module",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
## Why

#351 cross-host attachment fix touched both server (hub-side path-strip) and agent-node (fetch-attachment module + 2 PR #349 ride-along nits). This PR bumps both packages' PINNED versions so future builds reference the post-#351 sha.

## Already published (real-verified)

| Package | Old @preview | New @preview |
|---|---|---|
| @sleep2agi/commhub-server | 0.9.0-preview.12 | **0.9.0-preview.13** |
| @sleep2agi/agent-node | 2.5.0-preview.14 | **2.5.0-preview.15** |

`npm view ... dist-tags`:
```
@sleep2agi/commhub-server:   { latest: '0.8.8', preview: '0.9.0-preview.13' }
@sleep2agi/agent-node:       { latest: '2.4.13', preview: '2.5.0-preview.15' }
```

## Deploy chain (per 通信龙 dispatch 230fd3e6 — Vincent window-confirmed roll)

To unblock Vincent's TM门户运维@toodadev2 cross-machine attachment scenario:
1. **Hub** (sleep2agi/agent-network production) upgrade to `commhub-server@0.9.0-preview.13` — path-strip applies on outbound `meta_json` so cross-host agents see `file_id` not host-local `path`
2. **Cross-machine agent host** (toodadev2 / 10.110.14.18) upgrade `agent-node@2.5.0-preview.15` — fetch-attachment.ts auto-pulls /api/files/<id> using the agent's own ntok

Both production upgrades; 通信龙 owns Vincent window coordination.

dashboard + agent-network unchanged in #351 → not bumped here.

## Test plan

- [x] `npm run build` clean (agent-node bundles via bun)
- [x] `npm publish --tag preview --access public` for both ✓
- [x] `npm view @sleep2agi/commhub-server@preview version` → 0.9.0-preview.13 ✓
- [x] `npm view @sleep2agi/agent-node@preview version` → 2.5.0-preview.15 ✓
- [ ] Vincent UAT after 通信龙 hands off the install command (in Vincent's window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)