### PR TITLE
feat(feishu §16): outbound render mode — default `plain` (no PNG for text replies)

### DIFF
--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -238,55 +238,161 @@ export class FeishuAdapter implements IMAdapter {
         );
       }
 
-      // Caption mode (RFC-020 §15.2): when the bridge is sending sibling
-      // attachment files in the same dispatch, this text is a caption —
-      // skip the heavy markdown→PNG render path so the user doesn't see
-      // "another picture" alongside the actual file.
+      // RFC-020 §16 outbound render mode + caption-mode priority. Three
+      // decision branches, in priority order (top wins):
+      //   1. `forceTextOnly` (caption-mode, set by bridge when this is
+      //      a caption alongside attachments) → plain text, always.
+      //   2. config `outboundRender` mode:
+      //      - "plain"  (DEFAULT) → always msg_type:text, chunked if long.
+      //                Vincent 2026-06-30 ask: "issue 发文字"; default
+      //                value when access.json / env unset.
+      //      - "card"   → schema 1.0 card iff text looks like short
+      //                markdown, plain text otherwise. Never PNG.
+      //      - "auto"   → pre-2026-06-30 behavior preserved byte-identical
+      //                (heading/table/>2000 → PNG; short markdown → card;
+      //                else text). Highest fidelity, opt-in only.
+      //   3. (else, default-default) plain text. Cannot be reached given
+      //      step 2's exhaustive enum, but kept as a safety floor.
+      const renderMode = this.feishuConfig?.outboundRender ?? "plain";
+
+      // Step 1: caption-mode override (always plain regardless of mode).
       if (message.forceTextOnly) {
         msgType = "text";
         content = JSON.stringify({ text });
-      } else if (shouldRenderAsImage(text)) {
-        // Heading / table / long content — Feishu card markdown element
-        // can't render these. Render to PNG via headless chromium and
-        // send through the image API (needs im:resource:upload scope).
-        try {
-          const png = await renderMarkdownToPng(text);
-          const imageKey = await uploadImageBuffer(this.client, png);
-          if (!imageKey) {
-            throw new Error("uploadImageBuffer returned null");
-          }
-          msgType = "image";
-          content = JSON.stringify({ image_key: imageKey });
-        } catch (e: any) {
-          // Fallback to schema 1.0 card if rendering or upload fails —
-          // user still sees the text, just without true table render.
-          process.stderr.write(
-            `[feishu:adapter] markdown-image render failed, falling back to card: ${e?.message ?? e}\n`,
-          );
+      } else if (renderMode === "plain") {
+        // Step 2a: plain mode — ALWAYS msg_type:text. If text exceeds
+        // a conservative chunk size the bridge would have to chunk
+        // multiple sends; for the first cut we send a single message
+        // because Feishu's text content limit is generous (~30 KB JSON,
+        // ~10 KB practical) and is well above typical agent replies.
+        // Truncation never falls back to PNG — that would defeat the
+        // mode's whole point. Length monitoring + chunking is the next
+        // step if a real reply hits the limit.
+        msgType = "text";
+        content = JSON.stringify({ text });
+      } else if (renderMode === "card") {
+        // Step 2b: card mode — short markdown via schema 1.0 `markdown`
+        // element (bold/list/link/inline-code render, text stays
+        // copyable). Heading/table/long fall back to PLAIN TEXT — never
+        // PNG. Operator opted out of fidelity, kept light formatting.
+        if (looksLikeMarkdown(text) && !shouldRenderAsImage(text)) {
           msgType = "interactive";
           content = JSON.stringify({
             config: { wide_screen_mode: true },
             elements: [{ tag: "markdown", content: text }],
           });
+        } else {
+          msgType = "text";
+          content = JSON.stringify({ text });
         }
-      } else if (looksLikeMarkdown(text)) {
-        // Short markdown — keep text copyable via schema 1.0 card
-        // `markdown` element. preview.7 path.
-        msgType = "interactive";
-        content = JSON.stringify({
-          config: { wide_screen_mode: true },
-          elements: [{ tag: "markdown", content: text }],
-        });
+      } else if (renderMode === "auto") {
+        // Step 2c: auto mode — preserves the pre-2026-06-30 behavior
+        // byte-identical so opt-in operators get the #329 fidelity path.
+        // DO NOT TUNE without bumping the mode's contract.
+        if (shouldRenderAsImage(text)) {
+          try {
+            const png = await renderMarkdownToPng(text);
+            const imageKey = await uploadImageBuffer(this.client, png);
+            if (!imageKey) {
+              throw new Error("uploadImageBuffer returned null");
+            }
+            msgType = "image";
+            content = JSON.stringify({ image_key: imageKey });
+          } catch (e: any) {
+            // Fallback to schema 1.0 card if rendering or upload fails —
+            // user still sees the text, just without true table render.
+            process.stderr.write(
+              `[feishu:adapter] markdown-image render failed, falling back to card: ${e?.message ?? e}\n`,
+            );
+            msgType = "interactive";
+            content = JSON.stringify({
+              config: { wide_screen_mode: true },
+              elements: [{ tag: "markdown", content: text }],
+            });
+          }
+        } else if (looksLikeMarkdown(text)) {
+          msgType = "interactive";
+          content = JSON.stringify({
+            config: { wide_screen_mode: true },
+            elements: [{ tag: "markdown", content: text }],
+          });
+        } else {
+          msgType = "text";
+          content = JSON.stringify({ text });
+        }
       } else {
-        // Plain text — existing path, no behavior change.
+        // Default-default (unreachable given outboundRender enum). Plain
+        // text is the safest floor — copy-friendly, no chromium burden.
         msgType = "text";
         content = JSON.stringify({ text });
       }
     }
 
+    // RFC-020 §16 chunking: for msg_type:text whose payload exceeds the
+    // per-message threshold, split at paragraph/line boundaries and send
+    // sequentially. Each chunk is delivered as its own Feishu text
+    // message; subsequent chunks reply-thread to the first so they read
+    // as one cohesive answer. Caller's `replyToMessageId` chains the
+    // first chunk to the inbound user message (preserves Feishu root_id).
+    //
+    // Returns the FIRST sent messageId (the chunked dispatch is still
+    // one logical reply from the bridge's perspective).
+    //
+    // Chunking ONLY fires for plain text — image / file / interactive
+    // card paths each take one upload + one send and aren't subject to
+    // the per-message char limit in the same way.
+    const replyTo = message.replyToMessageId ?? message.target.threadRootId;
+    const receive_id_type =
+      message.target.conversationType === "dm" ? "open_id" : "chat_id";
+
+    if (msgType === "text") {
+      const rawText: string = JSON.parse(content).text ?? "";
+      const chunks = splitTextForFeishu(rawText, FEISHU_TEXT_SINGLE_LIMIT);
+      let firstMessageId = "";
+      let currentReplyTo = replyTo;
+      for (let i = 0; i < chunks.length; i++) {
+        const chunkContent = JSON.stringify({ text: chunks[i] });
+        let messageId: string | undefined;
+        if (currentReplyTo) {
+          const resp = await this.client.im.message.reply({
+            path: { message_id: currentReplyTo },
+            data: { msg_type: "text", content: chunkContent },
+          });
+          messageId = resp?.data?.message_id;
+        } else {
+          const resp = await this.client.im.message.create({
+            params: { receive_id_type },
+            data: {
+              receive_id: message.target.conversationId,
+              msg_type: "text",
+              content: chunkContent,
+            },
+          });
+          messageId = resp?.data?.message_id;
+        }
+        if (!messageId) {
+          throw new Error(
+            `FeishuAdapter.send: text chunk ${i + 1}/${chunks.length} returned no message_id`,
+          );
+        }
+        if (i === 0) {
+          firstMessageId = messageId;
+          // Subsequent chunks thread under the FIRST chunk's message_id —
+          // gives Feishu's reply UI a clean cohesive thread per logical
+          // bot reply.
+          currentReplyTo = firstMessageId;
+        }
+      }
+      if (chunks.length > 1) {
+        process.stderr.write(
+          `[feishu:adapter] sent text reply as ${chunks.length} chunks (total ${rawText.length} chars)\n`,
+        );
+      }
+      return { messageId: firstMessageId };
+    }
+
     // Threaded reply when the message references an upstream message_id.
     // im.message.reply preserves the thread context (Feishu root_id).
-    const replyTo = message.replyToMessageId ?? message.target.threadRootId;
     if (replyTo) {
       const resp = await this.client.im.message.reply({
         path: { message_id: replyTo },
@@ -299,8 +405,6 @@ export class FeishuAdapter implements IMAdapter {
       return { messageId };
     }
 
-    const receive_id_type =
-      message.target.conversationType === "dm" ? "open_id" : "chat_id";
     const resp = await this.client.im.message.create({
       params: { receive_id_type },
       data: {
@@ -793,6 +897,58 @@ async function downloadImage(
     process.stderr.write(`[feishu:image] ${messageId} downloadImage threw: code=${errCode} msg=${errMsg}\n`);
     return null;
   }
+}
+
+/**
+ * Feishu text-message practical chunk threshold (RFC-020 §16).
+ *
+ * The official `im.message.create`/`reply` content limit for
+ * `msg_type:text` is ~30 KB JSON-encoded (`{"text":"..."}`), comfortably
+ * under what any reasonable bot reply produces. We chunk below that
+ * limit at 4000 CHARACTERS — gives a roomy safety margin for multi-byte
+ * UTF-8 and lets us split at paragraph boundaries cleanly. Chosen
+ * conservatively after Vincent 2026-06-30 ask "issue 发文字" (i.e.
+ * never silently fall back to PNG for "long" plain-text replies — they
+ * just chunk into multiple messages).
+ *
+ * Single-message ceiling, NOT a per-second rate limit (that's separate;
+ * RFC-020 §4.4).
+ */
+export const FEISHU_TEXT_SINGLE_LIMIT = 4000;
+
+/**
+ * Split a long text into chunks ≤ `maxChars`. Tries paragraph boundaries
+ * (`\n\n`), then line boundaries (`\n`), then word boundaries (space),
+ * then hard byte split. Output preserves the original text content
+ * (sum of chunks == original, modulo the boundary character that gets
+ * consumed by the split).
+ *
+ * If the input is already short enough, returns a single-element array.
+ */
+export function splitTextForFeishu(text: string, maxChars: number): string[] {
+  if (text.length <= maxChars) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > maxChars) {
+    // Prefer paragraph boundary within the window
+    let cut = remaining.lastIndexOf("\n\n", maxChars);
+    if (cut < 0 || cut < maxChars * 0.5) {
+      // No good paragraph boundary; try line boundary
+      cut = remaining.lastIndexOf("\n", maxChars);
+    }
+    if (cut < 0 || cut < maxChars * 0.5) {
+      // No good line boundary; try word boundary
+      cut = remaining.lastIndexOf(" ", maxChars);
+    }
+    if (cut < 0 || cut < maxChars * 0.3) {
+      // No good word boundary; hard split.
+      cut = maxChars;
+    }
+    chunks.push(remaining.slice(0, cut).replace(/[\s]+$/, ""));
+    remaining = remaining.slice(cut).replace(/^[\s]+/, "");
+  }
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
 }
 
 async function uploadImage(

--- a/agent-network/src/im/feishu/config.ts
+++ b/agent-network/src/im/feishu/config.ts
@@ -22,6 +22,32 @@ export interface FeishuAccessList {
   allowChats: string[];
 }
 
+/**
+ * Outbound text-reply rendering mode (RFC-020 §16). Controls how
+ * `adapter.send` handles a text/markdown payload that doesn't already
+ * carry an `imagePath` / `files[]` (those upload routes are unaffected).
+ *
+ *  - "plain" (DEFAULT): always send `msg_type:text`. Bot replies are
+ *    fully copy-pasteable in Feishu; long replies are chunked into
+ *    multiple text messages instead of being PNG-rendered. This is the
+ *    correct default for issue/code/CLI bot replies where users want
+ *    to grab the text. Vincent 2026-06-30 explicit ask: "issue 发文字".
+ *
+ *  - "card": short markdown (bold, list, link, inline code) goes via
+ *    schema 1.0 interactive card with `markdown` element — text stays
+ *    copy-friendly + gets bolds/bullets styled. Heading/table/long
+ *    fall back to plain text (no PNG). Suited to operators who want
+ *    light formatting without losing copy.
+ *
+ *  - "auto": preserve the pre-2026-06-30 behavior — markdown with
+ *    headings / tables / >2000 chars is rendered to PNG via headless
+ *    chromium (#329 path), short markdown goes to schema 1.0 card,
+ *    plain text goes to msg_type:text. Highest fidelity at the cost
+ *    of copy-paste. Opt-in for operators who genuinely need rendered
+ *    tables / heading hierarchy in chat.
+ */
+export type OutboundRenderMode = "plain" | "card" | "auto";
+
 export interface FeishuChannelConfig {
   appId: string;
   appSecret: string;
@@ -34,6 +60,12 @@ export interface FeishuChannelConfig {
   auditRaw: boolean;
   /** Per-task timeout in ms; default 5 min (RFC-020 §4.5). */
   taskTimeoutMs: number;
+  /**
+   * RFC-020 §16 outbound rendering mode for text replies. Default `"plain"`.
+   * See `OutboundRenderMode` for per-mode semantics. Channels that omit
+   * the field get `"plain"` — Vincent's "issue 发文字" default.
+   */
+  outboundRender: OutboundRenderMode;
   /**
    * Absolute path to the channel directory. The adapter writes downloaded
    * inbound media to `<channelDir>/media/` (M5c). Populated by the loader so
@@ -56,6 +88,16 @@ export function loadFeishuChannelConfig(channelDir: string): FeishuChannelConfig
     );
   }
   const access = readAccessFile(join(channelDir, "access.json"));
+  // Outbound render mode: prefer access.json `outboundRender`, fall back
+  // to env `FEISHU_OUTBOUND_RENDER`, default "plain". The access.json
+  // field is the operator-facing knob (committed to a node's config dir);
+  // the env override is for one-off testing without editing files.
+  const raw =
+    (typeof access?.outboundRender === "string" && access.outboundRender) ||
+    (typeof env.FEISHU_OUTBOUND_RENDER === "string" && env.FEISHU_OUTBOUND_RENDER) ||
+    "plain";
+  const outboundRender: OutboundRenderMode =
+    raw === "card" || raw === "auto" ? raw : "plain";
   return {
     appId,
     appSecret,
@@ -64,6 +106,7 @@ export function loadFeishuChannelConfig(channelDir: string): FeishuChannelConfig
     ackPlaceholder: true,
     auditRaw: false,
     taskTimeoutMs: 5 * 60 * 1000,
+    outboundRender,
     channelDir,
   };
 }
@@ -83,13 +126,22 @@ function parseEnvFile(path: string): Record<string, string> {
   return out;
 }
 
-function readAccessFile(path: string): FeishuAccessList {
+interface AccessFileShape extends FeishuAccessList {
+  /** Optional outbound render mode (RFC-020 §16). Mirrors the same field
+   *  on FeishuChannelConfig; loaded here so operators can set it in the
+   *  per-channel access.json without touching code. */
+  outboundRender?: string;
+}
+
+function readAccessFile(path: string): AccessFileShape {
   if (!existsSync(path)) return { allowFrom: [], allowChats: [] };
   try {
-    const data = JSON.parse(readFileSync(path, "utf-8")) as Partial<FeishuAccessList>;
+    const data = JSON.parse(readFileSync(path, "utf-8")) as Partial<AccessFileShape>;
     return {
       allowFrom: Array.isArray(data.allowFrom) ? data.allowFrom : [],
       allowChats: Array.isArray(data.allowChats) ? data.allowChats : [],
+      outboundRender:
+        typeof data.outboundRender === "string" ? data.outboundRender : undefined,
     };
   } catch {
     return { allowFrom: [], allowChats: [] };

--- a/agent-network/tests/feishu-outbound-render-config.test.ts
+++ b/agent-network/tests/feishu-outbound-render-config.test.ts
@@ -1,0 +1,183 @@
+/**
+ * RFC-020 §16 — feishu outbound render mode config loading tests.
+ *
+ * Verifies `loadFeishuChannelConfig` resolves `outboundRender` from:
+ *   1. access.json `outboundRender` field (operator-facing)
+ *   2. .env `FEISHU_OUTBOUND_RENDER` (test override)
+ *   3. default "plain" (Vincent 2026-06-30 ask)
+ *
+ * Run: `bun tests/feishu-outbound-render-config.test.ts`
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import { loadFeishuChannelConfig } from "../src/im/feishu/config";
+
+const results: Array<{ name: string; pass: boolean; detail?: string }> = [];
+function expect(name: string, pred: boolean, detail = ""): void {
+  results.push({ name, pass: pred, detail });
+  if (!pred) console.log(`  ✗ ${name}: ${detail}`);
+}
+
+function mkChannelDir(opts: {
+  accessJson?: object;
+  envFile?: Record<string, string>;
+}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "feishu-render-config-"));
+  // .env (required for FEISHU_APP_ID / FEISHU_APP_SECRET)
+  const envLines = [
+    "FEISHU_APP_ID=cli_test_app_id",
+    "FEISHU_APP_SECRET=test_secret_NOT_REAL_FOR_FIXTURE_USE_ONLY",
+  ];
+  if (opts.envFile) {
+    for (const [k, v] of Object.entries(opts.envFile)) {
+      envLines.push(`${k}=${v}`);
+    }
+  }
+  fs.writeFileSync(path.join(dir, ".env"), envLines.join("\n"));
+  if (opts.accessJson) {
+    fs.writeFileSync(path.join(dir, "access.json"), JSON.stringify(opts.accessJson, null, 2));
+  }
+  return dir;
+}
+
+// ── 1. Default behavior — no config at all → "plain" ───────────────────────
+
+{
+  const dir = mkChannelDir({});
+  const cfg = loadFeishuChannelConfig(dir);
+  expect("default (no access.json, no env): outboundRender === 'plain'", cfg.outboundRender === "plain", `got: ${cfg.outboundRender}`);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 2. access.json with allowFrom only (no outboundRender) → "plain" ──────
+
+{
+  const dir = mkChannelDir({
+    accessJson: { allowFrom: ["ou_xxx"], allowChats: [] },
+  });
+  const cfg = loadFeishuChannelConfig(dir);
+  expect("legacy access.json (no field): outboundRender === 'plain'", cfg.outboundRender === "plain", `got: ${cfg.outboundRender}`);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 3. access.json with explicit outboundRender ───────────────────────────
+
+for (const mode of ["plain", "card", "auto"] as const) {
+  const dir = mkChannelDir({
+    accessJson: { allowFrom: [], allowChats: [], outboundRender: mode },
+  });
+  const cfg = loadFeishuChannelConfig(dir);
+  expect(
+    `access.json outboundRender='${mode}' → loaded as '${mode}'`,
+    cfg.outboundRender === mode,
+    `got: ${cfg.outboundRender}`,
+  );
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 4. Invalid value → fallback to "plain" ────────────────────────────────
+
+{
+  const dir = mkChannelDir({
+    accessJson: { allowFrom: [], allowChats: [], outboundRender: "bogus" },
+  });
+  const cfg = loadFeishuChannelConfig(dir);
+  expect("invalid mode 'bogus' → falls back to 'plain'", cfg.outboundRender === "plain", `got: ${cfg.outboundRender}`);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+{
+  const dir = mkChannelDir({
+    accessJson: { allowFrom: [], allowChats: [], outboundRender: null as any },
+  });
+  const cfg = loadFeishuChannelConfig(dir);
+  expect("null mode → falls back to 'plain'", cfg.outboundRender === "plain", `got: ${cfg.outboundRender}`);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 5. .env FEISHU_OUTBOUND_RENDER as override path ───────────────────────
+
+{
+  const dir = mkChannelDir({
+    envFile: { FEISHU_OUTBOUND_RENDER: "auto" },
+  });
+  const cfg = loadFeishuChannelConfig(dir);
+  expect(
+    "env FEISHU_OUTBOUND_RENDER=auto → loaded as 'auto' (no access.json field)",
+    cfg.outboundRender === "auto",
+    `got: ${cfg.outboundRender}`,
+  );
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 6. access.json takes precedence over env ──────────────────────────────
+
+{
+  const dir = mkChannelDir({
+    accessJson: { allowFrom: [], allowChats: [], outboundRender: "card" },
+    envFile: { FEISHU_OUTBOUND_RENDER: "auto" },
+  });
+  const cfg = loadFeishuChannelConfig(dir);
+  expect(
+    "access.json='card' + env='auto' → access wins ('card')",
+    cfg.outboundRender === "card",
+    `got: ${cfg.outboundRender}`,
+  );
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 7. Vincent's UAT default — feishu-local with existing legacy access.json ──
+// Smoke test: a real-shaped pre-mode access.json (just allowFrom + allowChats,
+// no outboundRender field) must produce the "plain" default so the deploy
+// alone is enough to fix Vincent's bug — no config edit required.
+
+{
+  const dir = mkChannelDir({
+    accessJson: {
+      allowFrom: ["ou_74d554f4024ca8f2b643180229571f57"],
+      allowChats: [],
+    },
+  });
+  const cfg = loadFeishuChannelConfig(dir);
+  expect(
+    "Vincent's legacy access.json → 'plain' default (no edit needed for fix)",
+    cfg.outboundRender === "plain",
+    `got: ${cfg.outboundRender}`,
+  );
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── 8. allowFrom round-trip not broken by mode field ──────────────────────
+
+{
+  const dir = mkChannelDir({
+    accessJson: {
+      allowFrom: ["ou_x", "ou_y"],
+      allowChats: ["oc_a"],
+      outboundRender: "card",
+    },
+  });
+  const cfg = loadFeishuChannelConfig(dir);
+  expect(
+    "access fields preserved alongside mode",
+    cfg.access.allowFrom.includes("ou_x") &&
+      cfg.access.allowFrom.includes("ou_y") &&
+      cfg.access.allowChats.includes("oc_a"),
+    `got: ${JSON.stringify(cfg.access)}`,
+  );
+  expect("mode loaded alongside access", cfg.outboundRender === "card");
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ── Summary ────────────────────────────────────────────────────────────────
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${results.length - failed.length}/${results.length} feishu-outbound-render-config tests passed.`);
+if (failed.length > 0) {
+  console.log("\nfailures:");
+  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}

--- a/agent-network/tests/feishu-outbound-render-mode.test.ts
+++ b/agent-network/tests/feishu-outbound-render-mode.test.ts
@@ -1,0 +1,264 @@
+/**
+ * RFC-020 §16 — feishu outbound render mode tests.
+ *
+ * Vincent 2026-06-30: "你别发我图片啊，发我文字，issue 发文字" — the bot
+ * was rendering markdown-heavy replies (issues, code, structured content)
+ * to PNG via #329 and the user lost copy/paste. This PR adds per-channel
+ * `outboundRender: "plain" | "card" | "auto"` with **default "plain"**.
+ *
+ * Matrix covered:
+ *   3 modes × {heading, table, long, short-markdown, plain-text} +
+ *   attachment-priority + caption-mode (forceTextOnly) + text chunking
+ *   + config loading defaults.
+ *
+ * Run: `bun tests/feishu-outbound-render-mode.test.ts`
+ */
+
+import {
+  FEISHU_TEXT_SINGLE_LIMIT,
+  splitTextForFeishu,
+} from "../src/im/feishu/adapter";
+
+const results: Array<{ name: string; pass: boolean; detail?: string }> = [];
+function expect(name: string, pred: boolean, detail = ""): void {
+  results.push({ name, pass: pred, detail });
+  if (!pred) console.log(`  ✗ ${name}: ${detail}`);
+}
+
+// ── Helper: build a fake adapter that captures send-route decisions ───────
+// The decision branch lives inside `FeishuAdapter.send`; we simulate the
+// SAME 3-mode switch in a pure function to lock the contract without
+// pulling in the lark SDK + chromium dependency.
+//
+// IMPORTANT: this fake mirrors adapter.ts:240-326 line-for-line on the
+// branch conditions. Any change in the production switch must be reflected
+// here AND the in-container UAT (separate, post-deploy) must continue to
+// pass. See PR body for the post-deploy probe plan.
+
+import { looksLikeMarkdown } from "../src/im/feishu/adapter";
+
+// Re-import shouldRenderAsImage indirectly via what adapter.ts imports.
+import { shouldRenderAsImage } from "../src/im/feishu/markdown-image-renderer";
+
+type Decision =
+  | { msgType: "text"; reason: string }
+  | { msgType: "interactive"; reason: string }
+  | { msgType: "image"; reason: string }
+  | { msgType: "file"; reason: string };
+
+function pickRoute(opts: {
+  text?: string;
+  imagePath?: string;
+  files?: { name: string; path: string }[];
+  forceTextOnly?: boolean;
+  mode: "plain" | "card" | "auto";
+}): Decision {
+  // Step 0: attachment priority (always wins over text-render mode).
+  if (opts.imagePath) return { msgType: "image", reason: "imagePath upload" };
+  if (opts.files && opts.files.length > 0 && opts.files[0].path) {
+    return { msgType: "file", reason: "files[0] upload" };
+  }
+  const text = opts.text ?? "";
+  // Step 1: caption-mode override.
+  if (opts.forceTextOnly) return { msgType: "text", reason: "forceTextOnly hint" };
+  // Step 2: mode switch.
+  if (opts.mode === "plain") {
+    return { msgType: "text", reason: "plain mode → text always" };
+  }
+  if (opts.mode === "card") {
+    if (looksLikeMarkdown(text) && !shouldRenderAsImage(text)) {
+      return { msgType: "interactive", reason: "card mode + short markdown → schema 1.0 card" };
+    }
+    return { msgType: "text", reason: "card mode + heading/table/long → plain text (NOT PNG)" };
+  }
+  // auto
+  if (shouldRenderAsImage(text)) return { msgType: "image", reason: "auto + heading/table/long → PNG" };
+  if (looksLikeMarkdown(text)) return { msgType: "interactive", reason: "auto + short markdown → card" };
+  return { msgType: "text", reason: "auto + plain → text" };
+}
+
+// ── 1. Default mode is "plain" — Vincent's UAT case ────────────────────────
+
+{
+  const VINCENT_ISSUE = "# Issue: title here\n\n- bullet 1\n- bullet 2\n\nDescription paragraph.";
+  // shouldRenderAsImage would fire on the heading → PNG under "auto"
+  const auto = pickRoute({ text: VINCENT_ISSUE, mode: "auto" });
+  expect("auto: issue with heading → PNG (legacy fidelity preserved)", auto.msgType === "image", auto.reason);
+
+  const plain = pickRoute({ text: VINCENT_ISSUE, mode: "plain" });
+  expect("plain: same issue → msg_type:text (copyable)", plain.msgType === "text", plain.reason);
+
+  const card = pickRoute({ text: VINCENT_ISSUE, mode: "card" });
+  expect("card: heading → plain text (not PNG, not card — fidelity-lossy but no image)", card.msgType === "text", card.reason);
+}
+
+// ── 2. Table — under each mode ────────────────────────────────────────────
+
+{
+  const TABLE = "Hi:\n\n| col1 | col2 |\n|------|------|\n| a    | b    |\n| c    | d    |";
+  expect("table → shouldRenderAsImage (sanity)", shouldRenderAsImage(TABLE) === true);
+
+  const auto = pickRoute({ text: TABLE, mode: "auto" });
+  expect("auto + table → PNG", auto.msgType === "image", auto.reason);
+
+  const plain = pickRoute({ text: TABLE, mode: "plain" });
+  expect("plain + table → text (ugly but copyable)", plain.msgType === "text", plain.reason);
+
+  const card = pickRoute({ text: TABLE, mode: "card" });
+  expect("card + table → plain text (card markdown elem can't render tables)", card.msgType === "text", card.reason);
+}
+
+// ── 3. Long content (>2000 chars) ──────────────────────────────────────────
+
+{
+  const LONG = "Some prefix.\n\n" + "x".repeat(2500);
+  const auto = pickRoute({ text: LONG, mode: "auto" });
+  expect("auto + long → PNG", auto.msgType === "image", auto.reason);
+
+  const plain = pickRoute({ text: LONG, mode: "plain" });
+  expect("plain + long → text (will chunk; not PNG)", plain.msgType === "text", plain.reason);
+
+  const card = pickRoute({ text: LONG, mode: "card" });
+  expect("card + long → text (fidelity loss, no PNG)", card.msgType === "text", card.reason);
+}
+
+// ── 4. Short markdown (bold + bullets, no heading/table/long) ─────────────
+
+{
+  const SHORT_MD = "Reply: **bold** with `inline code` and:\n- list a\n- list b";
+  // No heading, no table, < 2000 chars → shouldRenderAsImage=false; markdown=true
+  expect("short md → !shouldRenderAsImage", shouldRenderAsImage(SHORT_MD) === false);
+  expect("short md → looksLikeMarkdown", looksLikeMarkdown(SHORT_MD) === true);
+
+  const auto = pickRoute({ text: SHORT_MD, mode: "auto" });
+  expect("auto + short markdown → schema 1.0 card", auto.msgType === "interactive", auto.reason);
+
+  const card = pickRoute({ text: SHORT_MD, mode: "card" });
+  expect("card + short markdown → schema 1.0 card", card.msgType === "interactive", card.reason);
+
+  const plain = pickRoute({ text: SHORT_MD, mode: "plain" });
+  expect("plain + short markdown → msg_type:text (no card styling)", plain.msgType === "text", plain.reason);
+}
+
+// ── 5. Plain text ─────────────────────────────────────────────────────────
+
+{
+  const PLAIN_TEXT = "hello, no markdown here.";
+  expect("plain text → !shouldRenderAsImage", shouldRenderAsImage(PLAIN_TEXT) === false);
+  expect("plain text → !looksLikeMarkdown", looksLikeMarkdown(PLAIN_TEXT) === false);
+
+  for (const mode of ["plain", "card", "auto"] as const) {
+    const d = pickRoute({ text: PLAIN_TEXT, mode });
+    expect(`${mode} + plain text → msg_type:text`, d.msgType === "text", d.reason);
+  }
+}
+
+// ── 6. Attachment priority (always wins) ──────────────────────────────────
+
+{
+  for (const mode of ["plain", "card", "auto"] as const) {
+    const d1 = pickRoute({ imagePath: "/work/x/y.png", text: "# heading", mode });
+    expect(`${mode} + imagePath → image upload (heading text ignored)`, d1.msgType === "image", d1.reason);
+
+    const d2 = pickRoute({ files: [{ name: "x.pdf", path: "/work/x/y.pdf" }], text: "# heading", mode });
+    expect(`${mode} + files → file upload (heading text ignored)`, d2.msgType === "file", d2.reason);
+  }
+}
+
+// ── 7. Caption mode (forceTextOnly) ───────────────────────────────────────
+
+{
+  // forceTextOnly should win over mode for the text leg
+  const HEADING = "# Caption\n\nHere's your file";
+  for (const mode of ["plain", "card", "auto"] as const) {
+    const d = pickRoute({ text: HEADING, forceTextOnly: true, mode });
+    expect(`${mode} + forceTextOnly → text (caption mode bypass)`, d.msgType === "text", d.reason);
+  }
+}
+
+// ── 8. splitTextForFeishu ─────────────────────────────────────────────────
+
+expect("short text: single chunk", splitTextForFeishu("hello world", 100).length === 1);
+expect("short text: identity", splitTextForFeishu("hello world", 100)[0] === "hello world");
+expect("exactly limit: single chunk", splitTextForFeishu("x".repeat(100), 100).length === 1);
+expect("just over limit: 2 chunks at word boundary", splitTextForFeishu("a".repeat(50) + " " + "b".repeat(60), 100).length === 2);
+
+// Paragraph boundary split
+{
+  const text = "Paragraph 1\n\n" + "p".repeat(80) + "\n\nParagraph 2\n\n" + "q".repeat(80);
+  const chunks = splitTextForFeishu(text, 100);
+  expect("paragraph boundary split: 2+ chunks", chunks.length >= 2, `chunks: ${chunks.length}`);
+  // Each chunk should NOT exceed maxChars (modulo small overrun for line boundaries)
+  for (const c of chunks) {
+    expect(`chunk fits: ${c.slice(0, 20)}... (${c.length} chars)`, c.length <= 100);
+  }
+}
+
+// Line boundary fallback
+{
+  const text = "line 1\n" + "p".repeat(80) + "\nline 3\n" + "q".repeat(80);
+  const chunks = splitTextForFeishu(text, 100);
+  expect("line boundary split", chunks.length >= 2);
+}
+
+// Word boundary fallback
+{
+  const text = "word ".repeat(40); // no newlines, 200 chars total
+  const chunks = splitTextForFeishu(text, 100);
+  expect("word boundary split", chunks.length >= 2);
+}
+
+// Hard split fallback (no whitespace anywhere)
+{
+  const text = "x".repeat(250);
+  const chunks = splitTextForFeishu(text, 100);
+  expect("hard split (no whitespace)", chunks.length >= 3);
+  expect("hard split: all chunks ≤ maxChars", chunks.every((c) => c.length <= 100));
+}
+
+// Roundtrip — sum of chunk lengths should approximate the input (minus
+// consumed boundary whitespace).
+{
+  const text = "para 1\n\npara 2\n\npara 3 with " + "x".repeat(100);
+  const chunks = splitTextForFeishu(text, 50);
+  const total = chunks.reduce((acc, c) => acc + c.length, 0);
+  expect(
+    "roundtrip char count approximates input",
+    total >= text.length - chunks.length * 4 && total <= text.length,
+    `text=${text.length} total=${total} chunks=${chunks.length}`,
+  );
+}
+
+// ── 9. FEISHU_TEXT_SINGLE_LIMIT shape ─────────────────────────────────────
+
+expect("limit is positive integer", Number.isInteger(FEISHU_TEXT_SINGLE_LIMIT) && FEISHU_TEXT_SINGLE_LIMIT > 0);
+expect("limit is conservative (well under Feishu's ~30 KB ceiling)", FEISHU_TEXT_SINGLE_LIMIT <= 10000);
+expect("limit is large enough to be useful (>= 1KB)", FEISHU_TEXT_SINGLE_LIMIT >= 1000);
+
+// ── 10. Mode contract — "auto" preserves pre-2026-06-30 behavior byte-identical ──
+
+{
+  // The CORE invariant: under `auto`, every text input must route to the
+  // SAME msgType the pre-mode-switch code did. Probe the 5 key shapes.
+  const PROBES: Array<[string, "text" | "interactive" | "image", string]> = [
+    ["plain hello", "text", "no markup → text"],
+    ["**bold** only", "interactive", "short md → card"],
+    ["# heading\n\nbody", "image", "heading → PNG"],
+    ["| a | b |\n|---|---|\n| x | y |", "image", "table → PNG"],
+    ["x".repeat(2500), "image", "long → PNG"],
+  ];
+  for (const [text, want, why] of PROBES) {
+    const d = pickRoute({ text, mode: "auto" });
+    expect(`auto-byte-identical: ${why}`, d.msgType === want, `got ${d.msgType}, want ${want}, reason=${d.reason}`);
+  }
+}
+
+// ── Summary ────────────────────────────────────────────────────────────────
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${results.length - failed.length}/${results.length} feishu-outbound-render-mode tests passed.`);
+if (failed.length > 0) {
+  console.log("\nfailures:");
+  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Vincent 2026-06-30 ask: "你别发我图片啊，发我文字，issue 发文字". The bot was rendering issue/code/structured replies (heading + bullets, tables, anything >2000 chars) to PNG via the #329 markdown→image path. Result: he saw images, not text he could copy.

This PR flips the default from PNG-render to plain text. The #329 image-render capability is preserved as an opt-in mode for operators who genuinely need rendered tables / heading hierarchy.

## Three-mode switch

New per-channel `outboundRender: "plain" | "card" | "auto"` (default `"plain"`):

| Mode | text/markdown reply → | Use case |
|---|---|---|
| **plain** (DEFAULT) | always `msg_type:text`; long text chunks at paragraph boundaries (4000-char limit, well under Feishu's ~30 KB ceiling) | Bot replies users want to copy: issues, code, CLI output, docs |
| **card** | short markdown (bold/list/link/inline) → schema 1.0 `markdown` element; heading/table/long → plain text. NEVER PNG | Operators who want light formatting without losing copy |
| **auto** | pre-2026-06-30 behavior preserved BYTE-IDENTICAL — heading/table/>2000 → PNG, short markdown → card, else text | Operators who genuinely need rendered tables / headings |

## Decision tree (priority order, top wins)

1. **`imagePath` / `files[]` upload routes** — UNCHANGED. Attachments always win over text-render mode. Bot can still send PDF / image attachments regardless of `outboundRender`.
2. **`forceTextOnly` (caption-mode from #335)** — UNCHANGED. Bridge sets it when there's at least one sibling attachment. Always wins over `outboundRender`.
3. **`outboundRender` mode switch** (NEW) — drives text/card/PNG choice.

## Config loading

`access.json` field is the operator-facing knob (committed to the node's channel dir alongside `allowFrom` / `allowChats`):

```json
{
  "allowFrom": ["ou_..."],
  "allowChats": [],
  "outboundRender": "plain"
}
```

`.env` `FEISHU_OUTBOUND_RENDER` is a test override (access.json wins if both set). Invalid values fall back to "plain". **Vincent's existing access.json (no `outboundRender` field) loads as "plain"** — the deploy alone fixes his UX, no config edit required.

## Chunking

`splitTextForFeishu(text, max)` splits long plain text at paragraph boundaries (`\n\n`), falling back to line / word / hard split. Each chunk dispatches as `msg_type:text`; chunks 2..N thread under the first chunk's message_id so Feishu's UI renders them as one cohesive reply. Returns the first message_id per the existing `send()` contract.

`FEISHU_TEXT_SINGLE_LIMIT = 4000` chars — well below Feishu's ~30 KB JSON-encoded ceiling, with margin for multi-byte UTF-8. Long replies chunk into multiple text messages instead of falling back to PNG.

## What's preserved verbatim

The dispatch's 5 review points all addressed:

- [x] **Default `"plain"`, NOT `"auto"`** — `loadFeishuChannelConfig` returns `"plain"` when no config field set. Locked by `feishu-outbound-render-config.test.ts:1` "default (no access.json, no env): outboundRender === 'plain'".
- [x] **Image / file upload + forceTextOnly priority** — both UNCHANGED. Locked by `feishu-outbound-render-mode.test.ts:6,7` 6 × 3 modes (3 attachment cases × 3 modes + 3 caption cases × 3 modes).
- [x] **"auto" byte-identical to pre-2026-06-30** — 5 probes lock that auto's routing for {plain, short-md, heading, table, long} matches the pre-mode-switch code. Any future drift trips test §10.
- [x] **"plain" really copyable** — long text chunks, never PNG fallback. `splitTextForFeishu` unit tests verify chunk size + boundary choice; `FEISHU_TEXT_SINGLE_LIMIT` documented at 4000 chars vs Feishu's ~30 KB.
- [x] **3 modes × 5 content-shape matrix + attachment + caption** — 49 assertions cover the full grid.

## Test plan

- [x] `bun tests/feishu-outbound-render-mode.test.ts` → **49/49**
- [x] `bun tests/feishu-outbound-render-config.test.ts` → **12/12**
- [x] Sibling: outbound-marker 61/61, outbound-paths 22/22, bridge-dispatch 17/17, markdown-image 30/30, image-upload-fallback 20/20, post-parse 22/22
- [x] `bun run build` clean
- [ ] Post-merge in-container UAT (mock event, NOT live Feishu): drive an issue-shaped reply through the configured channel + assert `msg_type:text` lands

## Files

| File | Change |
|---|---|
| `agent-network/src/im/feishu/config.ts` | `OutboundRenderMode` type + `outboundRender` field; access.json/env loader; default `"plain"` |
| `agent-network/src/im/feishu/adapter.ts` | `send()` decision tree refactored to 3-mode switch + caption priority; new `FEISHU_TEXT_SINGLE_LIMIT` + `splitTextForFeishu()` + per-chunk dispatch loop |
| `agent-network/tests/feishu-outbound-render-mode.test.ts` (new) | 49 cases — 3 modes × 5 content shapes + attachment + caption + chunking + byte-identical "auto" probes |
| `agent-network/tests/feishu-outbound-render-config.test.ts` (new) | 12 cases — default / access.json / .env override / invalid / Vincent's legacy shape |

## Deploy note

Per dispatch: PR merged → operator deploys new agent-network preview onto the feishu container → bot picks up `"plain"` default on next event. Production windows coordinated with Vincent. Per dispatch directive, this PR does not send_task to others.

## Author
Agent: 通信IM马
