### PR TITLE
chore(release): bump agent-network 2.3.0-preview.15 (post-#353 feishu adapter render)

### DIFF
--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.14",
+  "version": "2.3.0-preview.15",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 4 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Grok Build ACP) and 8+ LLM providers (Anthropic / OpenAI / xAI Grok / MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter). Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",


### PR DESCRIPTION
## Why

#353 feishu adapter render mode fix (default plain text, no forced markdown→PNG, long content auto-split). Bumps PINNED so the feishu container build picks up the new adapter on next deploy.

## Already published (real-verified)

| Package | Old @preview | New @preview |
|---|---|---|
| @sleep2agi/agent-network | 2.3.0-preview.14 | **2.3.0-preview.15** |

`npm view @sleep2agi/agent-network dist-tags`:
```
{ latest: '2.2.21', preview: '2.3.0-preview.15' }
```

server + agent-node + dashboard unchanged in #353 → not bumped.

## Test plan

- [x] `npm run build` clean (bun build + javascript-obfuscator chain on bin + client + node-server + feishu/worker)
- [x] `npm publish --tag preview --access public` ✓ — `+ @sleep2agi/agent-network@2.3.0-preview.15`
- [x] `npm view @sleep2agi/agent-network@preview version` → 2.3.0-preview.15 ✓
- [ ] Feishu container re-deploy (production action — 通信龙 owns Vincent window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)