### PR TITLE
chore(release): bump agent-network 2.3.0-preview.16 (post-#355 feishu bridge file_id)

### DIFF
--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.15",
+  "version": "2.3.0-preview.16",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 4 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Grok Build ACP) and 8+ LLM providers (Anthropic / OpenAI / xAI Grok / MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter). Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",


### PR DESCRIPTION
## Why

#355 feishu bridge file_id rolling (cross-machine attachment fix — feishu side, closes #222 loop). Bumps PINNED so the feishu container build picks up the bridge + adapter changes on next deploy.

## Already published (real-verified)

| Package | Old @preview | New @preview |
|---|---|---|
| @sleep2agi/agent-network | 2.3.0-preview.15 | **2.3.0-preview.16** |

`npm view @sleep2agi/agent-network dist-tags`:
```
{ latest: '2.2.21', preview: '2.3.0-preview.16' }
```

Bundles #353 (render-mode plain default) + #355 (bridge POST /api/upload → file_id). server/agent-node/dashboard not bumped (not changed).

## Test plan

- [x] `npm run build` clean (bun build + javascript-obfuscator on 4 entries)
- [x] `npm publish --tag preview --access public` ✓ — `+ @sleep2agi/agent-network@2.3.0-preview.16`
- [x] `npm view @sleep2agi/agent-network@preview version` → 2.3.0-preview.16 ✓
- [ ] Feishu container re-deploy (production — 通信龙 owns Vincent window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)