### PR TITLE
refactor(feishu): extract route + envelope helpers — test-teeth bind real code

### DIFF
--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -41,6 +41,7 @@ import {
   uploadFilesToHubConcurrent,
   type HubUploadResult,
 } from "./hub-upload.js";
+import { resolveOutboundRoute } from "./outbound-route.js";
 
 type OnEventHandler = (event: NormalizedIMEvent) => Promise<void>;
 
@@ -205,9 +206,29 @@ export class FeishuAdapter implements IMAdapter {
     let msgType: "text" | "image" | "interactive" | "file";
     let content: string;
 
-    if (message.imagePath) {
+    // RFC-020 §16.1 — decision tree extracted into `resolveOutboundRoute`
+    // (pure helper). Single source of truth for choosing image_upload /
+    // file_upload / text / card_short_md / image_render. The route is
+    // decided here; the side-effects (lark uploads / chromium render /
+    // JSON shape) live below, keyed on the route.
+    //
+    // CALLER CONTRACT: any change to the decision tree goes in
+    // `outbound-route.ts`. The unit tests bind against that helper
+    // directly (no more mirror copy in the test file — they'd drift
+    // silently).
+    const renderMode = this.feishuConfig?.outboundRender ?? "plain";
+    const candidateText = message.text ?? message.markdown ?? "";
+    const decision = resolveOutboundRoute({
+      text: candidateText,
+      imagePath: message.imagePath,
+      files: message.files,
+      forceTextOnly: message.forceTextOnly,
+      mode: renderMode,
+    });
+
+    if (decision.route === "image_upload") {
       // Caller-supplied image path takes precedence over text/markdown.
-      const imageKey = await uploadImage(this.client, message.imagePath);
+      const imageKey = await uploadImage(this.client, message.imagePath!);
       if (!imageKey) {
         throw new Error(
           `FeishuAdapter.send: image upload failed for ${message.imagePath}`,
@@ -215,18 +236,9 @@ export class FeishuAdapter implements IMAdapter {
       }
       msgType = "image";
       content = JSON.stringify({ image_key: imageKey });
-    } else if (
-      message.files &&
-      message.files.length > 0 &&
-      message.files[0]?.path
-    ) {
-      // Caller-supplied file path → upload + send msg_type:file
-      // (Vincent "给用户发文件" use case, 通信龙 3f70044c).
-      const file = message.files[0];
-      if (!file.path) {
-        throw new Error("FeishuAdapter.send: files[0].path required");
-      }
-      const fileKey = await uploadFile(this.client, file.path, file.name);
+    } else if (decision.route === "file_upload") {
+      const file = message.files![0];
+      const fileKey = await uploadFile(this.client, file.path!, file.name);
       if (!fileKey) {
         throw new Error(
           `FeishuAdapter.send: file upload failed for ${file.path}`,
@@ -235,100 +247,50 @@ export class FeishuAdapter implements IMAdapter {
       msgType = "file";
       content = JSON.stringify({ file_key: fileKey });
     } else {
-      const text = message.text ?? message.markdown;
-      if (!text) {
+      // Text-derived routes (text / card_short_md / image_render) all
+      // require `candidateText` to be non-empty.
+      if (!candidateText) {
         throw new Error(
           "FeishuAdapter.send: requires text, markdown, imagePath, or files",
         );
       }
-
-      // RFC-020 §16 outbound render mode + caption-mode priority. Three
-      // decision branches, in priority order (top wins):
-      //   1. `forceTextOnly` (caption-mode, set by bridge when this is
-      //      a caption alongside attachments) → plain text, always.
-      //   2. config `outboundRender` mode:
-      //      - "plain"  (DEFAULT) → always msg_type:text, chunked if long.
-      //                Vincent 2026-06-30 ask: "issue 发文字"; default
-      //                value when access.json / env unset.
-      //      - "card"   → schema 1.0 card iff text looks like short
-      //                markdown, plain text otherwise. Never PNG.
-      //      - "auto"   → pre-2026-06-30 behavior preserved byte-identical
-      //                (heading/table/>2000 → PNG; short markdown → card;
-      //                else text). Highest fidelity, opt-in only.
-      //   3. (else, default-default) plain text. Cannot be reached given
-      //      step 2's exhaustive enum, but kept as a safety floor.
-      const renderMode = this.feishuConfig?.outboundRender ?? "plain";
-
-      // Step 1: caption-mode override (always plain regardless of mode).
-      if (message.forceTextOnly) {
+      if (decision.route === "text") {
         msgType = "text";
-        content = JSON.stringify({ text });
-      } else if (renderMode === "plain") {
-        // Step 2a: plain mode — ALWAYS msg_type:text. If text exceeds
-        // a conservative chunk size the bridge would have to chunk
-        // multiple sends; for the first cut we send a single message
-        // because Feishu's text content limit is generous (~30 KB JSON,
-        // ~10 KB practical) and is well above typical agent replies.
-        // Truncation never falls back to PNG — that would defeat the
-        // mode's whole point. Length monitoring + chunking is the next
-        // step if a real reply hits the limit.
-        msgType = "text";
-        content = JSON.stringify({ text });
-      } else if (renderMode === "card") {
-        // Step 2b: card mode — short markdown via schema 1.0 `markdown`
-        // element (bold/list/link/inline-code render, text stays
-        // copyable). Heading/table/long fall back to PLAIN TEXT — never
-        // PNG. Operator opted out of fidelity, kept light formatting.
-        if (looksLikeMarkdown(text) && !shouldRenderAsImage(text)) {
-          msgType = "interactive";
-          content = JSON.stringify({
-            config: { wide_screen_mode: true },
-            elements: [{ tag: "markdown", content: text }],
-          });
-        } else {
-          msgType = "text";
-          content = JSON.stringify({ text });
-        }
-      } else if (renderMode === "auto") {
-        // Step 2c: auto mode — preserves the pre-2026-06-30 behavior
-        // byte-identical so opt-in operators get the #329 fidelity path.
-        // DO NOT TUNE without bumping the mode's contract.
-        if (shouldRenderAsImage(text)) {
-          try {
-            const png = await renderMarkdownToPng(text);
-            const imageKey = await uploadImageBuffer(this.client, png);
-            if (!imageKey) {
-              throw new Error("uploadImageBuffer returned null");
-            }
-            msgType = "image";
-            content = JSON.stringify({ image_key: imageKey });
-          } catch (e: any) {
-            // Fallback to schema 1.0 card if rendering or upload fails —
-            // user still sees the text, just without true table render.
-            process.stderr.write(
-              `[feishu:adapter] markdown-image render failed, falling back to card: ${e?.message ?? e}\n`,
-            );
-            msgType = "interactive";
-            content = JSON.stringify({
-              config: { wide_screen_mode: true },
-              elements: [{ tag: "markdown", content: text }],
-            });
+        content = JSON.stringify({ text: candidateText });
+      } else if (decision.route === "card_short_md") {
+        msgType = "interactive";
+        content = JSON.stringify({
+          config: { wide_screen_mode: true },
+          elements: [{ tag: "markdown", content: candidateText }],
+        });
+      } else if (decision.route === "image_render") {
+        // #329 fidelity path — render markdown to PNG via headless
+        // chromium and send through Feishu's image API. Fallback to
+        // schema 1.0 card on render / upload failure so the user
+        // still sees the text just without true table render.
+        try {
+          const png = await renderMarkdownToPng(candidateText);
+          const imageKey = await uploadImageBuffer(this.client, png);
+          if (!imageKey) {
+            throw new Error("uploadImageBuffer returned null");
           }
-        } else if (looksLikeMarkdown(text)) {
+          msgType = "image";
+          content = JSON.stringify({ image_key: imageKey });
+        } catch (e: any) {
+          process.stderr.write(
+            `[feishu:adapter] markdown-image render failed, falling back to card: ${e?.message ?? e}\n`,
+          );
           msgType = "interactive";
           content = JSON.stringify({
             config: { wide_screen_mode: true },
-            elements: [{ tag: "markdown", content: text }],
+            elements: [{ tag: "markdown", content: candidateText }],
           });
-        } else {
-          msgType = "text";
-          content = JSON.stringify({ text });
         }
       } else {
-        // Default-default (unreachable given outboundRender enum). Plain
-        // text is the safest floor — copy-friendly, no chromium burden.
+        // Defensive — resolveOutboundRoute's enum is exhaustive but
+        // a future addition that isn't wired here would land in `text`.
         msgType = "text";
-        content = JSON.stringify({ text });
+        content = JSON.stringify({ text: candidateText });
       }
     }
 

--- a/agent-network/src/im/feishu/outbound-route.ts
+++ b/agent-network/src/im/feishu/outbound-route.ts
@@ -1,0 +1,117 @@
+/**
+ * RFC-020 §16.1 — feishu outbound route decision (pure helper).
+ *
+ * Single source of truth for the `adapter.send` decision tree that
+ * picks among text / interactive card / image (rendered PNG) / file /
+ * imagePath outputs. Extracted into a pure module so the production
+ * call site AND the unit tests can bind the same function — previously
+ * the test mirrored the decision tree in a sibling `pickRoute` helper,
+ * which would drift silently if the production tree changed.
+ *
+ * Inputs are the minimal data the decision needs:
+ *
+ *   - `text` / `imagePath` / `files` — payload from `NormalizedIMMessage`
+ *   - `forceTextOnly` — caption-mode hint (RFC-020 §15.2)
+ *   - `mode` — channel-config `outboundRender` (`"plain"` / `"card"` /
+ *     `"auto"`, RFC-020 §16)
+ *
+ * Outputs the chosen `route` plus a short `reason` string for log /
+ * debug. The CALLER (adapter.send) actually performs the upload /
+ * render side-effects keyed on the route — this function does no I/O.
+ *
+ * Behavior contract (mirrors adapter.send line-for-line, locked by
+ * `feishu-outbound-render-mode.test.ts`):
+ *
+ *   1. `imagePath` set → `image_upload`
+ *   2. `files[0].path` set → `file_upload`
+ *   3. `forceTextOnly` true → `text`
+ *   4. mode "plain" → `text` (always)
+ *   5. mode "card" → `card_short_md` iff `looksLikeMarkdown(text)` AND
+ *      NOT `shouldRenderAsImage(text)`; else `text`
+ *   6. mode "auto" → `image_render` iff `shouldRenderAsImage(text)`;
+ *      else `card_short_md` iff `looksLikeMarkdown(text)`; else `text`
+ *   7. unknown mode (defensive default-default) → `text`
+ *
+ * The production switch in adapter.send may add the actual upload /
+ * render / lark API calls keyed on the route, but the route itself
+ * is decided HERE. To change the decision, change this file.
+ */
+
+import { looksLikeMarkdown } from "./adapter.js";
+import { shouldRenderAsImage } from "./markdown-image-renderer.js";
+
+export type OutboundRoute =
+  | "image_upload"     // imagePath upload — message.imagePath set
+  | "file_upload"      // file_key upload — message.files[0].path set
+  | "text"             // msg_type:text (plain or short-text fall-through)
+  | "card_short_md"    // schema 1.0 interactive card, markdown element
+  | "image_render";    // markdown → PNG → image_key upload (#329 fidelity)
+
+export interface RouteInput {
+  text?: string;
+  imagePath?: string;
+  files?: { name: string; path?: string }[];
+  forceTextOnly?: boolean;
+  /** `outboundRender` from the channel config. Defaults to "plain" when
+   *  absent so a caller that doesn't read the config still gets the
+   *  "Vincent default" behavior. */
+  mode?: "plain" | "card" | "auto";
+}
+
+export interface RouteDecision {
+  route: OutboundRoute;
+  reason: string;
+}
+
+/**
+ * Decide the outbound route for a `NormalizedIMMessage` (or a subset
+ * of its fields). Pure — no I/O, no SDK calls; safe to call from tests
+ * directly.
+ */
+export function resolveOutboundRoute(input: RouteInput): RouteDecision {
+  // 1. Attachment priority — always wins.
+  if (input.imagePath) {
+    return { route: "image_upload", reason: "imagePath upload" };
+  }
+  if (input.files && input.files.length > 0 && input.files[0]?.path) {
+    return { route: "file_upload", reason: "files[0] upload" };
+  }
+
+  const text = input.text ?? "";
+
+  // 2. Caption-mode override (RFC-020 §15.2) — always plain when set.
+  if (input.forceTextOnly) {
+    return { route: "text", reason: "forceTextOnly hint" };
+  }
+
+  // 3. Mode switch.
+  const mode = input.mode ?? "plain";
+
+  if (mode === "plain") {
+    return { route: "text", reason: "plain mode → text always" };
+  }
+  if (mode === "card") {
+    if (looksLikeMarkdown(text) && !shouldRenderAsImage(text)) {
+      return {
+        route: "card_short_md",
+        reason: "card mode + short markdown → schema 1.0 card",
+      };
+    }
+    return {
+      route: "text",
+      reason: "card mode + heading/table/long → plain text (NOT PNG)",
+    };
+  }
+  if (mode === "auto") {
+    if (shouldRenderAsImage(text)) {
+      return { route: "image_render", reason: "auto + heading/table/long → PNG" };
+    }
+    if (looksLikeMarkdown(text)) {
+      return { route: "card_short_md", reason: "auto + short markdown → card" };
+    }
+    return { route: "text", reason: "auto + plain → text" };
+  }
+
+  // Defensive default-default — unreachable given the mode enum.
+  return { route: "text", reason: "unknown mode → text floor" };
+}

--- a/agent-network/tests/feishu-bridge-ackplaceholder.test.ts
+++ b/agent-network/tests/feishu-bridge-ackplaceholder.test.ts
@@ -189,8 +189,11 @@ await test("1. happy path: placeholder send → reply IPC → reply send (new me
   assert.equal((adapter.sendCalls[1] as { text: string }).text, "real reply");
   const log = stderrLog.join("");
   assert.ok(log.includes("placeholder sent (messageId=mock-send-1)"));
+  // PR #335 introduced multi-message dispatch (text + attachments); the
+  // text-leg log line now reads "reply text sent" (vs the original
+  // "reply sent") to disambiguate from attachment-side outbound logs.
   assert.ok(
-    log.includes("reply sent (messageId=mock-send-2) (after placeholder=mock-send-1)"),
+    log.includes("reply text sent (messageId=mock-send-2) (after placeholder=mock-send-1)"),
     "reply log must include 'after placeholder' note",
   );
 });

--- a/agent-network/tests/feishu-envelope-compat.test.ts
+++ b/agent-network/tests/feishu-envelope-compat.test.ts
@@ -31,9 +31,19 @@ function expect(name: string, pred: boolean, detail = ""): void {
   if (!pred) console.log(`  ✗ ${name}: ${detail}`);
 }
 
-// Mirror the parsing logic in agent-node/src/cli.ts feishu IPC handler.
-// Any change to that logic MUST be reflected here AND the live in-container
-// probe (post-deploy). Keep these two in lockstep.
+// RFC-020 §17.1 test-teeth: bind the REAL helper extracted from
+// agent-node/src/cli.ts. The function lives at
+// `agent-node/src/runtime/feishu-envelope.ts` and is shared by the
+// production IPC handler. A test reaching across the package boundary
+// is a pragmatic choice — the alternative (publishing
+// agent-node/runtime as a separate subpackage just for tests) is
+// over-engineered for one helper. The dev-time monorepo layout makes
+// the import path stable.
+import { buildAttachmentDescriptors } from "../../agent-node/src/runtime/feishu-envelope";
+
+// `IncomingEnvelopeShape` matches the wire shape the helper accepts.
+// Kept here in test-only form so callers don't need to import the
+// envelope type AND the helper.
 interface IncomingEnvelopeShape {
   content?: {
     text?: string;
@@ -49,29 +59,10 @@ interface IncomingEnvelopeShape {
   };
 }
 
-function buildAttachmentDescriptors(ev: IncomingEnvelopeShape): Array<{
-  path: string;
-  file_id?: string;
-  mime?: string;
-  name?: string;
-  size?: number;
-}> {
-  const fromAttachments = Array.isArray(ev.content?.attachments)
-    ? ev.content.attachments
-        .filter((a: any) => a && typeof a.path === "string" && a.path.length > 0)
-        .map((a: any) => ({
-          path: a.path as string,
-          file_id: typeof a.file_id === "string" ? a.file_id : undefined,
-          mime: typeof a.mime === "string" ? a.mime : undefined,
-          name: typeof a.name === "string" ? a.name : undefined,
-          size: typeof a.size === "number" ? a.size : undefined,
-        }))
-    : [];
-  if (fromAttachments.length > 0) return fromAttachments;
-  const legacy = Array.isArray(ev.content?.images) ? ev.content.images : [];
-  return legacy
-    .filter((p: any): p is string => typeof p === "string" && p.length > 0)
-    .map((p: string) => ({ path: p }));
+// Adapter to keep the existing test shape — helper now accepts the
+// `content` object directly, so unwrap `ev.content` for callers.
+function buildAttachmentDescriptorsFromEvent(ev: IncomingEnvelopeShape) {
+  return buildAttachmentDescriptors(ev.content);
 }
 
 // ── 1. Legacy envelope (old bridge): `images: string[]` only ──────────────
@@ -84,7 +75,7 @@ function buildAttachmentDescriptors(ev: IncomingEnvelopeShape): Array<{
       images: ["/work/feishu-attachments/feishu-local/oc_x/y.jpg"],
     },
   };
-  const desc = buildAttachmentDescriptors(env);
+  const desc = buildAttachmentDescriptorsFromEvent(env);
   expect("legacy: 1 descriptor", desc.length === 1);
   expect("legacy: path preserved", desc[0].path === "/work/feishu-attachments/feishu-local/oc_x/y.jpg");
   expect("legacy: no file_id (older worker can't compute it)", desc[0].file_id === undefined);
@@ -110,7 +101,7 @@ function buildAttachmentDescriptors(ev: IncomingEnvelopeShape): Array<{
       ],
     },
   };
-  const desc = buildAttachmentDescriptors(env);
+  const desc = buildAttachmentDescriptorsFromEvent(env);
   expect("new-only: 1 descriptor", desc.length === 1);
   expect("new-only: file_id present", desc[0].file_id === "abc123def456");
   expect("new-only: mime present", desc[0].mime === "image/jpeg");
@@ -138,7 +129,7 @@ function buildAttachmentDescriptors(ev: IncomingEnvelopeShape): Array<{
       ],
     },
   };
-  const desc = buildAttachmentDescriptors(env);
+  const desc = buildAttachmentDescriptorsFromEvent(env);
   expect("both: 1 descriptor (from attachments, not duplicated)", desc.length === 1);
   expect("both: file_id from attachments takes precedence", desc[0].file_id === "abc123def456");
   expect("both: mime from attachments", desc[0].mime === "image/jpeg");
@@ -168,7 +159,7 @@ function buildAttachmentDescriptors(ev: IncomingEnvelopeShape): Array<{
       ],
     },
   };
-  const desc = buildAttachmentDescriptors(env);
+  const desc = buildAttachmentDescriptorsFromEvent(env);
   expect("partial: 2 descriptors", desc.length === 2);
   expect("partial: first has file_id", desc[0].file_id === "good1");
   expect("partial: second missing file_id (graceful)", desc[1].file_id === undefined);
@@ -179,13 +170,13 @@ function buildAttachmentDescriptors(ev: IncomingEnvelopeShape): Array<{
 
 {
   const env: IncomingEnvelopeShape = { content: { text: "hi" } };
-  const desc = buildAttachmentDescriptors(env);
+  const desc = buildAttachmentDescriptorsFromEvent(env);
   expect("empty content: 0 descriptors", desc.length === 0);
 }
 
 {
   const env: IncomingEnvelopeShape = {};
-  const desc = buildAttachmentDescriptors(env);
+  const desc = buildAttachmentDescriptorsFromEvent(env);
   expect("missing content: 0 descriptors", desc.length === 0);
 }
 
@@ -204,7 +195,7 @@ function buildAttachmentDescriptors(ev: IncomingEnvelopeShape): Array<{
       ],
     },
   };
-  const desc = buildAttachmentDescriptors(env);
+  const desc = buildAttachmentDescriptorsFromEvent(env);
   expect("malformed-filter: 2 valid descriptors", desc.length === 2);
   expect("malformed-filter: first /valid/path", desc[0].path === "/valid/path");
   expect("malformed-filter: second /valid/another with file_id", desc[1].file_id === "ok123abc");
@@ -218,7 +209,7 @@ function buildAttachmentDescriptors(ev: IncomingEnvelopeShape): Array<{
       images: ["/valid/path", null as any, "" as any, 42 as any, "/other/path"],
     },
   };
-  const desc = buildAttachmentDescriptors(env);
+  const desc = buildAttachmentDescriptorsFromEvent(env);
   expect("legacy-filter: 2 valid", desc.length === 2);
   expect("legacy-filter: order preserved", desc[0].path === "/valid/path" && desc[1].path === "/other/path");
 }
@@ -234,7 +225,7 @@ function buildAttachmentDescriptors(ev: IncomingEnvelopeShape): Array<{
       ],
     },
   };
-  const desc = buildAttachmentDescriptors(env);
+  const desc = buildAttachmentDescriptorsFromEvent(env);
   expect("mixed types: 2 descriptors (file + image)", desc.length === 2);
   expect("mixed types: file_id preserved on both", desc[0].file_id === "i1234567" && desc[1].file_id === "f1234567");
 }
@@ -279,7 +270,7 @@ const SCENARIOS = [
 ];
 
 for (const s of SCENARIOS) {
-  const desc = buildAttachmentDescriptors(s.env);
+  const desc = buildAttachmentDescriptorsFromEvent(s.env);
   expect(
     `${s.label}: path resolved`,
     JSON.stringify(desc.map((d) => d.path)) === JSON.stringify(s.expectPaths),

--- a/agent-network/tests/feishu-outbound-render-mode.test.ts
+++ b/agent-network/tests/feishu-outbound-render-mode.test.ts
@@ -17,7 +17,10 @@
 import {
   FEISHU_TEXT_SINGLE_LIMIT,
   splitTextForFeishu,
+  looksLikeMarkdown,
 } from "../src/im/feishu/adapter";
+import { resolveOutboundRoute } from "../src/im/feishu/outbound-route";
+import { shouldRenderAsImage } from "../src/im/feishu/markdown-image-renderer";
 
 const results: Array<{ name: string; pass: boolean; detail?: string }> = [];
 function expect(name: string, pred: boolean, detail = ""): void {
@@ -25,21 +28,14 @@ function expect(name: string, pred: boolean, detail = ""): void {
   if (!pred) console.log(`  ✗ ${name}: ${detail}`);
 }
 
-// ── Helper: build a fake adapter that captures send-route decisions ───────
-// The decision branch lives inside `FeishuAdapter.send`; we simulate the
-// SAME 3-mode switch in a pure function to lock the contract without
-// pulling in the lark SDK + chromium dependency.
+// RFC-020 §16.1 test-teeth hardening: bind the REAL `resolveOutboundRoute`
+// helper (extracted from adapter.ts). The pre-extraction version of this
+// test had a sibling `pickRoute` copy that would silently drift if the
+// production decision tree changed — bind to the real one so changes
+// trip a red test.
 //
-// IMPORTANT: this fake mirrors adapter.ts:240-326 line-for-line on the
-// branch conditions. Any change in the production switch must be reflected
-// here AND the in-container UAT (separate, post-deploy) must continue to
-// pass. See PR body for the post-deploy probe plan.
-
-import { looksLikeMarkdown } from "../src/im/feishu/adapter";
-
-// Re-import shouldRenderAsImage indirectly via what adapter.ts imports.
-import { shouldRenderAsImage } from "../src/im/feishu/markdown-image-renderer";
-
+// `pickRoute` is now a thin adapter that maps the real helper's route
+// enum to the legacy `msgType` shape the test assertions key on.
 type Decision =
   | { msgType: "text"; reason: string }
   | { msgType: "interactive"; reason: string }
@@ -53,28 +49,28 @@ function pickRoute(opts: {
   forceTextOnly?: boolean;
   mode: "plain" | "card" | "auto";
 }): Decision {
-  // Step 0: attachment priority (always wins over text-render mode).
-  if (opts.imagePath) return { msgType: "image", reason: "imagePath upload" };
-  if (opts.files && opts.files.length > 0 && opts.files[0].path) {
-    return { msgType: "file", reason: "files[0] upload" };
+  const d = resolveOutboundRoute({
+    text: opts.text,
+    imagePath: opts.imagePath,
+    files: opts.files,
+    forceTextOnly: opts.forceTextOnly,
+    mode: opts.mode,
+  });
+  // Map the route enum to the msgType the existing assertions use.
+  // image_upload → "image", file_upload → "file", text → "text",
+  // card_short_md → "interactive", image_render → "image" (PNG path
+  // still produces msg_type:image at the API level).
+  switch (d.route) {
+    case "image_upload":
+    case "image_render":
+      return { msgType: "image", reason: d.reason };
+    case "file_upload":
+      return { msgType: "file", reason: d.reason };
+    case "card_short_md":
+      return { msgType: "interactive", reason: d.reason };
+    case "text":
+      return { msgType: "text", reason: d.reason };
   }
-  const text = opts.text ?? "";
-  // Step 1: caption-mode override.
-  if (opts.forceTextOnly) return { msgType: "text", reason: "forceTextOnly hint" };
-  // Step 2: mode switch.
-  if (opts.mode === "plain") {
-    return { msgType: "text", reason: "plain mode → text always" };
-  }
-  if (opts.mode === "card") {
-    if (looksLikeMarkdown(text) && !shouldRenderAsImage(text)) {
-      return { msgType: "interactive", reason: "card mode + short markdown → schema 1.0 card" };
-    }
-    return { msgType: "text", reason: "card mode + heading/table/long → plain text (NOT PNG)" };
-  }
-  // auto
-  if (shouldRenderAsImage(text)) return { msgType: "image", reason: "auto + heading/table/long → PNG" };
-  if (looksLikeMarkdown(text)) return { msgType: "interactive", reason: "auto + short markdown → card" };
-  return { msgType: "text", reason: "auto + plain → text" };
 }
 
 // ── 1. Default mode is "plain" — Vincent's UAT case ────────────────────────

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -28,6 +28,7 @@ import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
 import { maskedEnv } from "./secret-mask";
 import { checkFeishuToolDeny, isFeishuChannelTurn } from "./feishu-tool-deny";
+import { buildAttachmentDescriptors } from "./runtime/feishu-envelope";
 import {
   isVendorErrorForUser,
   isTransientVendorError,
@@ -3393,36 +3394,13 @@ function wireFeishuChildHandlers(
     // the try/catch around each branch guarantees exactly-one outbound.
     (async () => {
       const baseContent = ev.content?.text ?? "";
-      // RFC-020 §17 — prefer the new `attachments` field (carries file_id
-      // for cross-machine delegation) over the legacy `images` field.
-      // Both are populated by current bridges; older bridges only ship
-      // `images` (string[] of paths). Build a unified descriptor list
-      // here so the prompt builder is single-shape.
-      const attachmentDescriptors: Array<{
-        path: string;
-        file_id?: string;
-        mime?: string;
-        name?: string;
-        size?: number;
-      }> = (() => {
-        const fromAttachments = Array.isArray(ev.content?.attachments)
-          ? ev.content.attachments
-              .filter((a: any) => a && typeof a.path === "string" && a.path.length > 0)
-              .map((a: any) => ({
-                path: a.path as string,
-                file_id: typeof a.file_id === "string" ? a.file_id : undefined,
-                mime: typeof a.mime === "string" ? a.mime : undefined,
-                name: typeof a.name === "string" ? a.name : undefined,
-                size: typeof a.size === "number" ? a.size : undefined,
-              }))
-          : [];
-        if (fromAttachments.length > 0) return fromAttachments;
-        // Older bridge (legacy worker): fall back to `images: string[]`.
-        const legacy = Array.isArray(ev.content?.images) ? ev.content.images : [];
-        return legacy
-          .filter((p: any): p is string => typeof p === "string" && p.length > 0)
-          .map((p: string) => ({ path: p }));
-      })();
+      // RFC-020 §17.1 test-teeth extract: single source of truth in
+      // `runtime/feishu-envelope.ts`. The helper prefers the new
+      // `attachments[]` shape (carries file_id) over legacy
+      // `images: string[]` and filters malformed entries defensively.
+      // Unit test binds the same function — change the helper, the
+      // test runs against the change.
+      const attachmentDescriptors = buildAttachmentDescriptors(ev.content);
       const images = attachmentDescriptors.length > 0
         ? attachmentDescriptors.map((a) => a.path)
         : undefined;

--- a/agent-node/src/runtime/feishu-envelope.ts
+++ b/agent-node/src/runtime/feishu-envelope.ts
@@ -1,0 +1,101 @@
+/**
+ * RFC-020 §17.1 — feishu IPC envelope parsing (pure helper).
+ *
+ * Single source of truth for resolving the inbound attachment list
+ * from a `FeishuBridgeEnvelope.event.content`. Old bridges ship just
+ * `content.images: string[]` (legacy); newer bridges add
+ * `content.attachments[]` carrying `file_id` for cross-machine
+ * delegation (RFC-020 §17). This helper:
+ *
+ *   - prefers `attachments[]` when populated (carries the richer
+ *     metadata + file_id)
+ *   - falls back to `images: string[]` from older bridges (rolling
+ *     upgrade safety)
+ *   - drops malformed entries (non-string path, empty path, null,
+ *     etc.) defensively so a hostile envelope can't crash the
+ *     handler
+ *
+ * Extracted from the cli.ts IPC handler so unit tests bind the real
+ * function instead of mirroring it. Pre-extraction the test
+ * `feishu-envelope-compat.test.ts` had a sibling
+ * `buildAttachmentDescriptors` that would silently drift if the
+ * production logic changed — bind to the real one so a change in
+ * cli.ts trips a red test.
+ */
+
+export interface FeishuInboundContent {
+  text?: string;
+  /** Legacy string[] of paths (RFC-020 pre-§17). Populated by all
+   *  bridges for rolling-upgrade safety. */
+  images?: string[];
+  /** RFC-020 §17 attachment descriptors carrying file_id for
+   *  cross-machine delegation. Populated by newer bridges after
+   *  uploading inbound files to `/api/upload`. */
+  attachments?: Array<{
+    type?: "image" | "file";
+    path?: string;
+    file_id?: string;
+    mime?: string;
+    name?: string;
+    size?: number;
+  }>;
+}
+
+/** One inbound attachment as resolved from the envelope, ready to be
+ *  surfaced into the agent's prompt and (optionally) re-stamped onto
+ *  outbound `commhub_send_task(meta.attachments)`. */
+export interface InboundAttachmentDescriptor {
+  path: string;
+  file_id?: string;
+  mime?: string;
+  name?: string;
+  size?: number;
+}
+
+/**
+ * Resolve the unified attachment descriptor list from the envelope's
+ * `content` field, preferring the new `attachments[]` shape over the
+ * legacy `images: string[]` for rolling-upgrade safety.
+ *
+ * Behavior contract (locked by `feishu-envelope-compat.test.ts`):
+ *
+ *   1. `content` is null / undefined → return `[]`.
+ *   2. `content.attachments[]` non-empty → use it; filter entries
+ *      that aren't `{ path: string, length > 0 }`.
+ *   3. else `content.images[]` non-empty → use it as path-only
+ *      descriptors; filter non-string / empty entries.
+ *   4. else → return `[]`.
+ *
+ * No I/O. No SDK calls. Pure function — safe to call from tests.
+ */
+export function buildAttachmentDescriptors(
+  content: FeishuInboundContent | null | undefined,
+): InboundAttachmentDescriptor[] {
+  if (!content || typeof content !== "object") return [];
+
+  const fromAttachments = Array.isArray(content.attachments)
+    ? content.attachments
+        .filter(
+          (a: any): a is FeishuInboundContent["attachments"] extends Array<infer T> ? T : never =>
+            a !== null &&
+            typeof a === "object" &&
+            typeof a.path === "string" &&
+            a.path.length > 0,
+        )
+        .map((a) => ({
+          path: a.path as string,
+          file_id: typeof a.file_id === "string" ? a.file_id : undefined,
+          mime: typeof a.mime === "string" ? a.mime : undefined,
+          name: typeof a.name === "string" ? a.name : undefined,
+          size: typeof a.size === "number" ? a.size : undefined,
+        }))
+    : [];
+
+  if (fromAttachments.length > 0) return fromAttachments;
+
+  // Older bridge (legacy worker): fall back to `images: string[]`.
+  const legacy = Array.isArray(content.images) ? content.images : [];
+  return legacy
+    .filter((p): p is string => typeof p === "string" && p.length > 0)
+    .map((p) => ({ path: p }));
+}


### PR DESCRIPTION
## Summary

Low-priority test-teeth hardening. Pre-review on #353 and #355 surfaced the same gap:

| Test | Was mirroring | Now binds |
|---|---|---|
| `feishu-outbound-render-mode.test.ts` | sibling `pickRoute` copy of `adapter.send` decision tree | real `resolveOutboundRoute` helper |
| `feishu-envelope-compat.test.ts` | sibling `buildAttachmentDescriptors` copy of `cli.ts` inline IIFE | real `buildAttachmentDescriptors` helper |

Plus a stale-test ride-along: `feishu-bridge-ackplaceholder.test.ts` was at 19/20 since PR #335 changed the bridge log string from `reply sent` → `reply text sent` (multi-message dispatch disambiguation). 1-line fix → 20/20 again.

## Two extracts

### `agent-network/src/im/feishu/outbound-route.ts` (NEW)

```ts
resolveOutboundRoute({text, imagePath, files, forceTextOnly, mode})
  → {route: "image_upload" | "file_upload" | "text" | "card_short_md" | "image_render", reason}
```

Pure helper. `adapter.send` switches on the route; side-effects (lark uploads, chromium render) live there. The test imports this directly.

### `agent-node/src/runtime/feishu-envelope.ts` (NEW)

```ts
buildAttachmentDescriptors(content)
  → InboundAttachmentDescriptor[]
```

Prefers new `attachments[]` (carries `file_id`), falls back to legacy `images: string[]`, drops malformed entries. `cli.ts` IPC handler now calls this; envelope-compat test imports it across the package boundary (pragmatic monorepo choice — alternative of publishing a separate subpackage for one helper is over-engineered).

## Stale-test fix

PR #335 introduced multi-message dispatch (caption text + attachment files); bridge log changed:

```
- "reply sent (messageId=X) (after placeholder=Y)"
+ "reply text sent (messageId=X) (after placeholder=Y)"
```

ackplaceholder test still asserted the old string → 19/20. 1-line update → 20/20.

## Behavior change: NONE

Pure refactor. The route logic in `outbound-route.ts` is line-for-line equivalent to the inline switch it replaces (mode + caption-mode priorities preserved; `image_render` only on `auto`; `card_short_md` only when `looksLikeMarkdown && !shouldRenderAsImage`). The envelope helper preserves the IIFE's filter rules verbatim (path must be non-empty string).

## Test-teeth proof

Sanity-injected a regression — forced `resolveOutboundRoute` to always return `{route: "image_render"}` — and observed **20 of 49 render-mode tests turn red** as expected (including the explicit `auto-byte-identical: no markup → text` lock). Restored helper → 49/49 green. Tests now catch any future drift in `adapter.send` routing logic.

## Test plan

- [x] `bun tests/feishu-outbound-render-mode.test.ts` → **49/49** (real helper bound)
- [x] `bun tests/feishu-envelope-compat.test.ts` → **30/30** (real helper bound)
- [x] `bun tests/feishu-bridge-ackplaceholder.test.ts` → **20/20** (was 19/20)
- [x] Sanity-inject confirms test-teeth catch regression (20 of 49 fail when route helper is broken)
- [x] Sibling no-regress (7 suites): hub-upload 42/42, outbound-marker 61/61, outbound-paths 22/22, bridge-dispatch 17/17, render-config 12/12, markdown-image 30/30, post-parse 22/22
- [x] `bun run build` (agent-network + agent-node) → clean
- Total: **305/305** feishu test cases green

## Files

| File | Change |
|---|---|
| `agent-network/src/im/feishu/outbound-route.ts` (new) | `resolveOutboundRoute` pure helper |
| `agent-network/src/im/feishu/adapter.ts` | `send()` switches on extracted route |
| `agent-node/src/runtime/feishu-envelope.ts` (new) | `buildAttachmentDescriptors` pure helper |
| `agent-node/src/cli.ts` | IPC handler calls extracted helper instead of inline IIFE |
| `agent-network/tests/feishu-outbound-render-mode.test.ts` | imports real helper; `pickRoute` is now a 3-line adapter shim |
| `agent-network/tests/feishu-envelope-compat.test.ts` | imports real helper across package boundary |
| `agent-network/tests/feishu-bridge-ackplaceholder.test.ts` | 1-line log-string update |

## Author
Agent: 通信IM马
