### PR TITLE
docs(feishu): 接入指南补「换 App open_id 白名单坑」+ 诊断口诀 (ZH+EN)

### DIFF
--- a/docs-site/docs/en/guide/feishu.md
+++ b/docs-site/docs/en/guide/feishu.md
@@ -173,6 +173,14 @@ anet channel ls
 `access.json` is **not hot-reloaded** — after every edit you must `anet node stop <node>` + `anet node start <node>` (for the Docker path, `docker compose restart <node-service>`). The bridge reads `access.json` into memory once at startup.
 :::
 
+::: danger Switching Feishu apps — a guaranteed trap: open_id / chat_id are per-app
+Feishu's `open_id` (user identity) and `chat_id` (conversation) are **scoped per app** — **the same person has a completely different `open_id` under a different app.** So after switching apps, the old IDs in `access.json` **all become invalid**, and every message hits "sender not in allowlist" and is silently denied.
+
+When switching apps, update **all three** places: ① `FEISHU_APP_ID` / `FEISHU_APP_SECRET` in the node env / deployment ② the channel `.env` ③ **`allowFrom` / `allowChats` in `access.json`** (most often missed).
+
+Classic symptom of missing the third: **`client ready` is fine, events arrive, yet the user's messages get "no reaction."** Full post-mortem → [Case Study: Feishu Silent Deny](/en/troubleshooting/case-feishu-silent-deny).
+:::
+
 ## 6. Group `@bot` mechanics
 
 Two steps for the bot to work in a group:
@@ -287,7 +295,10 @@ export ANET_FEISHU_WORKER_PATH=/path/to/your/worker.js
 | WSClient can't connect to Feishu | App not approved / wrong credentials / network issue — the bridge auto-reconnects; check stderr |
 | Bot doesn't reply in a group | 1) Bot is added to the group with send permissions 2) `access.json` `allowChats` includes the target `chat_id` 3) `/open-apis/bot/v3/info` is returning a valid `open_id` 4) After editing `access.json`, did you restart the node? (Not hot-reloaded — see §5) |
 | Bot doesn't reply in a DM | Verify the sender's `open_id` is in `allowFrom` (run `anet channel ls`) |
+| **Connected, events arrive, but messages get "no reaction"** | **grep the bridge stderr for `deny` / `allowFrom`**: message received but sender not in allowlist. **Most common after switching apps** (`open_id` changed per app — see the §5 danger note) |
 | Bot replies seem wrong / errors out on an image | The backend isn't vision-capable (§4) — switch to a vision-capable model |
+
+Diagnostic mnemonic (narrow by layer): ① no `client ready` in the log = can't reach the Feishu long-connection domain → change network; ② `client ready` but zero events = console event subscription not wired (missing `im.message.receive_v1` / not long-connection mode / version not published); ③ `client ready`, events arrive, but no reply = denied at the application layer, grep `deny` / `allowFrom`. Full post-mortem → [Case Study: Feishu Silent Deny](/en/troubleshooting/case-feishu-silent-deny).
 
 ## 10. Known limitations (preview scope)
 

--- a/docs-site/docs/guide/feishu.md
+++ b/docs-site/docs/guide/feishu.md
@@ -173,6 +173,14 @@ anet channel ls
 `access.json` **不热加载**——改完一定要 `anet node stop <node>` + `anet node start <node>`（Docker 路径下 `docker compose restart <node-service>`）。bridge 启动时一次性把 access.json 读进内存。
 :::
 
+::: danger 换飞书 App 必踩：open_id / chat_id 按 App 隔离
+飞书的 `open_id`（用户身份）和 `chat_id`（会话）都是**按 App 隔离**的——**同一个人，在不同 App 下 `open_id` 完全不同**。所以换 App 后，`access.json` 里存的旧 ID **全部失效**，每条消息都会命中「发件人不在白名单」被静默拒收。
+
+换 App 时**三处**都要同步改：① 节点环境 / 部署里的 `FEISHU_APP_ID` / `FEISHU_APP_SECRET` ② channel 的 `.env` ③ **`access.json` 的 `allowFrom` / `allowChats`**（最容易漏）。
+
+漏第三处的典型症状：**`client ready` 正常、能看到事件、但用户消息「毫无反应」**。完整复盘见 → [经典案例：飞书 Bot 静默拒收](/troubleshooting/case-feishu-silent-deny)。
+:::
+
 ## 6. 群 @ 机制
 
 bot 要在群里能用，**两步**：
@@ -287,7 +295,10 @@ export ANET_FEISHU_WORKER_PATH=/path/to/your/worker.js
 | WSClient 连不上飞书 | App 未 approve / 凭证写错 / 网络问题 — bridge 会自动重连，看 stderr |
 | 群里 @bot 不响应 | 1) bot 已加群且有发言权限 2) `access.json` `allowChats` 含目标 `chat_id` 3) `/open-apis/bot/v3/info` 是否返回有效 `open_id` 4) 改完 `access.json` 是否 restart 过节点（不热加载，见 §5） |
 | 私聊不响应 | `open_id` 是否在 `allowFrom` 内（`anet channel ls` 看一下） |
+| **连上了、有事件、但消息「没反应」** | bridge stderr **grep `deny` / `allowFrom`**：消息收到了但发件人不在白名单。**换 App 后最常见**（`open_id` 按 App 变了，见 §5 危险提示） |
 | 收到图片 bot 答非所问 / 报错 | 后端不是 vision-capable（见 §4）—— 切到支持 vision 的 model |
+
+诊断口诀（按层收窄）：① 日志无 `client ready` = 网络连不上飞书长连接域名 → 换网络；② 有 `client ready` 但零事件 = 飞书后台事件订阅没配对（漏 `im.message.receive_v1` / 没设长连接 / 没发布版本）；③ 有 `client ready`、有事件、但不回 = 应用层拒了，grep `deny` / `allowFrom`。完整复盘 → [经典案例：飞书 Bot 静默拒收](/troubleshooting/case-feishu-silent-deny)。
 
 ## 10. 已知限制（preview scope）
 


### PR DESCRIPTION
## Author
Agent: 通信龙

## 背景
Vincent 要求更新飞书 channel 使用文档。现有 `/guide/feishu` 接入指南已较完整，本 PR 做**针对性补强**：把刚刚实战踩到、且最隐蔽的坑写进去。

## 改动（仅 2 文件，ZH+EN）
- **§5 访问白名单** 加 `danger` 提示：飞书 `open_id`/`chat_id` 按 App 隔离，**换 App 后 `access.json` 旧 ID 全部失效 → 消息被静默拒收**；换 App 三处同步改（env / `.env` / `access.json`）。
- **§9 故障排查** 加一行「连上了、有事件、但消息没反应 → grep `deny`/`allowFrom`」+ 三层诊断口诀（网络/订阅/访问控制），链到 [经典案例：飞书静默拒收](/troubleshooting/case-feishu-silent-deny)（#358）。

## 说明
- 基于对 installed 包（`agent-network@2.3.0-preview.4` worker/CLI bundle）的代码核实，未臆测。
- 在干净 worktree（off origin/main）上做，未夹带工作树里其它 docs-loop 的未提交改动。
- 全文脱敏，无真实 app_id/open_id/token。

🤖 Generated with [Claude Code](https://claude.com/claude-code)