### PR TITLE
feat(feishu docker): 持久化 session 跨容器重建 (./claude 挂载 + 文档)

### DIFF
--- a/docker/feishu/README.md
+++ b/docker/feishu/README.md
@@ -48,7 +48,12 @@ See `.env.example` for the full annotated list (verified vendor + model combos, 
 
 ## Where state lives
 
-Only the `./data/` subdirectory is mounted into the container (hard volume constraint per agent-network maintainers — limits the agent's blast radius to that subdir). The agent writes its node config, logs, goals, and per-channel `.env` / `access.json` under `./data/.anet/`. Everything else on your host is unreachable from inside the agent.
+Two subdirectories of cwd are mounted (still a hard blast-radius limit — the agent cannot reach anywhere else on the host):
+
+- **`./data/` → `/work`** — node config, logs, goals, and per-channel `.env` / `access.json` under `./data/.anet/`.
+- **`./claude/` → `/root/.claude`** — the claude-agent-sdk **conversation history** (`projects/-work/<session>.jsonl`). The resume id is in `config.json` under `./data/`, but the actual transcript lives here. Without this mount, recreating the container loses the transcript and the bot can't resume prior context ("No conversation found").
+
+Everything else on your host is unreachable from inside the agent. Both dirs are auto-created on first `up`.
 
 ## Versions
 

--- a/docker/feishu/docker-compose.yml
+++ b/docker/feishu/docker-compose.yml
@@ -63,6 +63,15 @@ services:
       # Tighter than `./:/work` — even the compose file and .env stay
       # outside the agent's reach. Auto-created on first up.
       - ./data:/work
+      # `./claude/` persists the claude-agent-sdk conversation history
+      # (~/.claude/projects/-work/<session>.jsonl). The node's resume id
+      # lives in /work/.anet/.../config.json (persisted above), but the
+      # actual conversation transcript lives under /root/.claude — NOT
+      # under /work. Without this mount, recreating the container loses
+      # the transcript: the SDK can't resume → "No conversation found" and
+      # the bot forgets prior context. Sibling subdir of cwd, so the
+      # blast-radius limit still holds (no host escape). Auto-created.
+      - ./claude:/root/.claude
     # No `ports:` by default — the agent connects OUTBOUND to HUB_URL,
     # nothing inbound is needed. (If you enable the local-hub profile
     # below and want to reach the hub from your host, that service

--- a/docs-site/docs/en/guide/feishu.md
+++ b/docs-site/docs/en/guide/feishu.md
@@ -87,9 +87,16 @@ The `.env.example` file ships annotated comments with verified vendor + model co
 
 > 🧪 **`--profile local-hub` is self-test only.** It runs a throwaway local hub container alongside the agent for an isolated smoke test. **Off by default** — you have to explicitly `docker compose --profile local-hub up -d` and set `HUB_URL=http://hub:9200` in `.env`. Ignore it for daily use.
 
-### Safety boundary (volume mount is `./data` only)
+### Volume mapping + safety boundary (two subdirectories)
 
-`docker-compose.yml` mounts **only the `./data` subdirectory** of cwd into the container's `/work` (not the entire cwd). The agent's Bash / full tool capabilities **can only write under `./data/`** — the compose file itself, the `.env` file, and sibling directories on the host are all unreachable. Blast radius is strictly bounded. The node config, logs, goals, and per-channel `.env` / `access.json` all live under `./data/.anet/`, so persistence survives container recreate but the agent cannot escape.
+`docker-compose.yml` mounts **only two subdirectories** of cwd (not the entire cwd), so the blast radius stays strictly bounded — the agent's Bash / full tools cannot reach the compose file, the `.env`, or any other host directory:
+
+| Host (cwd subdir) | Container | What's stored |
+|---|---|---|
+| `./data` | `/work` | Node config, channels (`.env` + `access.json`), logs, SQLite — all under `./data/.anet/` |
+| `./claude` | `/root/.claude` | claude-agent-sdk **conversation history** `projects/-work/<session>.jsonl` |
+
+Both matter: the `session` field in `config.json` is only the **resume id** (under `./data`); the actual **conversation transcript** lives under `/root/.claude` (not `/work`). **Without the `./claude` mount, recreating the container loses the transcript → the SDK can't resume → "No conversation found" and the bot forgets prior context.** With it, the bot keeps its memory across container recreate / upgrade. Both dirs are auto-created on first `up`.
 
 ### Pinned versions + upgrades
 

--- a/docs-site/docs/guide/feishu.md
+++ b/docs-site/docs/guide/feishu.md
@@ -87,9 +87,16 @@ docker compose logs -f feishu-agent         # 跟启动 + 运行日志
 
 > 🧪 **`--profile local-hub` 是自测用**，跑一个一次性本地 hub 容器配合 agent，做隔离 smoke。**默认不启用**，需要时显式 `docker compose --profile local-hub up -d` 且把 `.env` 里 `HUB_URL=http://hub:9200`。日常忽略即可。
 
-### 安全边界（卷只挂 `./data`）
+### 卷映射 + 安全边界（两个子目录）
 
-`docker-compose.yml` 只把 cwd 的 `./data` 子目录映射进容器的 `/work`（而不是整个 cwd）。agent 的 Bash / 完整工具能力**只能写 `./data/` 里**，碰不到主机上的 compose 文件、`.env`、或同级别其他目录——blast radius 严格限定。`.anet/`、节点 channels、SQLite 全部落在 `./data/.anet/`，重建容器状态不丢。
+`docker-compose.yml` 只映射 cwd 的**两个子目录**（不是整个 cwd），blast radius 严格限定——agent 的 Bash / 完整工具碰不到主机上的 compose 文件、`.env`、或其他目录：
+
+| 宿主（cwd 子目录） | 容器 | 装什么 |
+|---|---|---|
+| `./data` | `/work` | 节点配置、channels（`.env` + `access.json`）、logs、SQLite，全在 `./data/.anet/` |
+| `./claude` | `/root/.claude` | claude-agent-sdk **对话历史** `projects/-work/<session>.jsonl` |
+
+两个都重要：`config.json` 里的 `session` 只是 **resume id**（在 `./data`），真正的**对话记录**在 `/root/.claude`（不在 `/work`）。**不挂 `./claude` 的话，重建容器对话历史就丢了 → SDK 没法 resume，报「No conversation found」、bot 忘记之前上下文。** 挂上后，重建 / 升级容器 bot 都能接着之前的记忆聊。两个目录首次 `up` 自动创建。
 
 ### 版本钉死 + 升级
 


### PR DESCRIPTION
## Author
Agent: 通信龙

## 背景
Vincent 要求：飞书 bot 容器重启/重建后能 resume 之前对话记忆（像 Claude Code 接着上次 session），并更新文案/教程方便以后部署。已在生产容器实测验证（session c14f65da resume 成功，in=25439 真加载了历史）。

## 根因
claude-agent-sdk session 双依赖：① `config.json` 的 `session=<id>`（resume id，在 `/work` 已持久）② 真正对话历史 `/root/.claude/projects/-work/<id>.jsonl`（**不在 /work**，重建容器即丢 → resume 失败报 `No conversation found`、bot 忘上下文）。

## 改动
- `docker/feishu/docker-compose.yml`：加 `- ./claude:/root/.claude` 卷（沿用 cwd 子目录约束，blast radius 不变）
- `docker/feishu/README.md`：state 章节更新为两挂载
- `docs-site/.../guide/feishu.md` §3（ZH+EN）：「卷映射 + 安全边界」改成两子目录表 + session 持久化说明

## 验证
- compose YAML 解析 OK，两挂载在位
- 生产容器已按此 3 挂载重建并验证 session resume + 真实 MiniMax-M3 推理成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)