### PR TITLE
docs(RFC-025): claude runtime 6-tool per-task lifecycle (P0.2a from loop assessment)

### DIFF
--- a/docs-site/docs/en/guide/agent-node.md
+++ b/docs-site/docs/en/guide/agent-node.md
@@ -372,6 +372,41 @@ Goals are persisted in `~/.anet/nodes/<alias>/goals.json` and restored automatic
 
 Scheduler tick frequency is controlled by `ANET_GOAL_TICK_MS` (env) or `flags.goalTickMs` in config.json, default 30 seconds. A goal's `interval_ms` can never be more precise than the tick — a 5-second interval still effectively wakes every 30s. Lower the tick if you need finer granularity.
 
+#### Agent self-management: 6 self-scoped tools (RFC-025)
+
+In addition to external `anet node loop` / `/loop`, an agent can call 6 self-scoped tools during a task response to manage **its own** loops without human intervention:
+
+| Tool | Meaning |
+|---|---|
+| `list_my_loops` | List all of the agent's active/paused loops |
+| `create_my_loop` | Create a new loop |
+| `edit_my_loop` | Change task / interval / schedule / paused |
+| `reschedule_my_loop` | One-shot push next_wake_at (interval unchanged) |
+| `complete_my_loop` | Archive as achieved (`status=complete`) |
+| `cancel_my_loop` | Permanent abandon (`status=cancelled`) |
+
+None of the 6 tools take an `alias` argument — by construction they are physically isolated to the per-node `goalStore`, so an agent can never address another node's loops.
+
+**Runtime tool availability** — this is a key claude vs. codex/grok difference:
+
+- **codex-sdk / grok-build-acp**: agent-node exposes the tools on a localhost HTTP MCP server (bearer-token-protected) at startup. **Tools are callable at any time** — during task response, during a loop wake, at any turn of the subprocess.
+- **claude-agent-sdk**: tools are attached to `processWithClaude`'s tool surface via an in-process SDK MCP server. They are **only callable within a task response lifecycle** (i.e. during `processTask`).
+
+What this means for claude users:
+
+> **A loop wake triggers `processTask` → the tools become available immediately → the agent can call `create_my_loop("next step")` or `complete_my_loop(this)` in the same response** — the loop is closed-loop, because loop wakes themselves flow through `processTask`.
+>
+> But when the agent is **completely idle** (not processing any task), claude has **no tool context**. So you cannot externally trigger a "let the agent decide autonomously whether to create a loop" scenario the way you can with codex/grok — you need to first send a task (via `anet node loop` or a direct `send_task`) to wake the agent up.
+
+**codex/grok are always-on** — the tools are callable by the subprocess whenever the LLM decides to reference them, from any turn onwards, right after agent-node starts. This is a natural consequence of the architectural choice: codex/grok use out-of-process HTTP MCP, claude uses in-process SDK MCP. It's not a gap or a bug.
+
+**Safety guardrails** are consistent across runtimes (all three runtimes share the same `goalStore` + counter state):
+
+- Default **20 active goals per node** cap (override with `COMMHUB_MAX_GOALS_PER_NODE`)
+- Same goal can only be edited **once per 30-second cooldown** (anti-recursion)
+- ≥ 3 cancels within 30s → the 4th triggers confirm-back; the agent must ask the user and re-call with a `confirm_token`
+- On create/edit: **preflight** the cron-lite schedule — semantically invalid schedules (bad timezone, etc.) are rejected before write to prevent self-lock
+
 ### Message Type Filtering
 
 Agent Node only triggers AI processing for `task` type messages:

--- a/docs-site/docs/guide/agent-node.md
+++ b/docs-site/docs/guide/agent-node.md
@@ -372,6 +372,41 @@ anet goal cancel my-codex 3f8a2b1c
 
 调度器 tick 间隔由 `ANET_GOAL_TICK_MS` 环境变量或 config.json `flags.goalTickMs` 控制，默认 30 秒。任何 goal 的 `interval_ms` 不会比 tick 间隔更精确——一个 5 秒间隔的 goal 实际上还是按 30 秒 tick 唤醒，按需调小 tick。
 
+#### Agent 自管 loop：6 个 self-scoped 工具（RFC-025）
+
+除了外部 `anet node loop` / `/loop` 之外，agent 在响应任务时也可以调用 6 个 self-scoped 工具管理**自己**的循环，无需人工介入：
+
+| 工具 | 语义 |
+|---|---|
+| `list_my_loops` | 看自己当前所有 loop |
+| `create_my_loop` | 新建一个 loop |
+| `edit_my_loop` | 改 task / interval / schedule / paused |
+| `reschedule_my_loop` | 一次性推下次唤醒（不改 interval） |
+| `complete_my_loop` | 达标归档（`status=complete`） |
+| `cancel_my_loop` | 永久放弃（`status=cancelled`） |
+
+6 个工具都**没有 `alias` 参数**——从架构上就物理隔离，agent 无法操作其他节点的 loop。
+
+**runtime 工具可用时段**——这是 claude 和 codex/grok 的一个关键差异：
+
+- **codex-sdk / grok-build-acp**：agent-node 启动就把工具挂在一个 localhost HTTP MCP server 上（带 bearer token），**全时段可调**。agent 在处理任务时、在 loop 被唤醒时，都可以调这 6 个工具。
+- **claude-agent-sdk**：工具通过 in-process SDK MCP server 挂在 `processWithClaude` 的 tool surface 上，**只在 agent 响应某任务的生命周期内可调**（`processTask` 期间）。
+
+对 claude 用户来说这意味着什么：
+
+> **loop 被唤醒 → 触发 processTask → 工具立即可用 → agent 可以在同一个响应里 `create_my_loop("下一步")` 或 `complete_my_loop(this)`**——闭环没问题，因为 loop 唤醒本身就走 processTask 路径。
+>
+> 但**在 agent 完全 idle 时**（没有正在处理任何任务），claude 内部**没有 tool 上下文**。所以你不能像 codex/grok 那样在外部触发一个「让 agent 自主决定要不要建 loop」的场景——需要先发一个任务（`anet node loop` 或直接 `send_task`）把 agent 唤起。
+
+**codex/grok 是常驻的**——工具从 agent-node 启动那一刻起就可以被随时触发的进程调用（LLM 在任意 turn 内都能引用）。这是 codex/grok 选择 out-of-process HTTP MCP、而 claude 选择 in-process SDK MCP 的架构决定带来的天然差异，不是 gap 也不是 bug。
+
+**安全防线** 是跨 runtime 一致的（三 runtime 共享同一份 `goalStore` + 计数器状态）：
+
+- 单节点默认 **20 个 active goal** 上限（`COMMHUB_MAX_GOALS_PER_NODE` 可覆盖）
+- 同一个 goal **30 秒 cooldown** 内只能改一次（防递归暴走）
+- 30 秒内连续 cancel ≥ 3 个 → 第 4 次触发 confirm-back，agent 必须回问用户，拿到确认后带 `confirm_token` 重调
+- 创建/编辑时**preflight**：cron-lite schedule 语义不合法（如时区错）直接拒，绝不入库自锁
+
 ### 消息类型过滤
 
 Agent Node 只对 `task` 类型消息触发 AI 处理：


### PR DESCRIPTION
## Author
**Agent**: 通信SDK马 (claude-code-cli runtime)

## Summary

Per Vincent 2.3 iteration 主线④ + 通信龙 approved (P0.2a from the anet loop 支持程度 assessment report).

Adds a new sub-section 「**Agent 自管 loop：6 个 self-scoped 工具**」 to the loop scheduler chapter of `docs-site/docs/guide/agent-node.md` (ZH) and `docs-site/docs/en/guide/agent-node.md` (EN).

## Content covered

- Listed the 6 self-scoped tools (list/create/edit/reschedule/complete/cancel_my_loop) with brief semantics
- By-construction safety invariant: no `alias` arg → per-node physical isolation
- **The load-bearing claude vs codex/grok runtime lifecycle difference** — the point users need to understand:
  - **codex-sdk / grok-build-acp**: always-on HTTP MCP → tools callable at any time
  - **claude-agent-sdk**: in-process SDK MCP → tools callable only during `processTask` lifecycle
- Explanation of why this is architecture, not a gap:
  - Loop wakes flow through `processTask` → closed-loop scenario works on all 3 runtimes
  - Only 「fully idle → agent decides autonomously」 differs between claude and codex/grok — and even then, first-touch task wakes the agent up
- Safety guardrails cross-runtime (all 3 share `goalStore` + counter state):
  - 20 active goals/node cap (`COMMHUB_MAX_GOALS_PER_NODE`)
  - 30s per-goal cooldown on edit
  - 3-in-30s cancels → 4th triggers confirm-back
  - Create/edit preflight rejects semantically-invalid schedules (invalid TZ etc.)

## Why now

The RFC-025 loop assessment report (Vincent 2.3 主线④) identified this as a user-facing clarification gap. Without docs, users may expect claude tools to be always-on like codex/grok and hit surprising behavior when trying to self-schedule from a fully idle state. Not a code bug — just missing documentation.

## Changes

- `docs-site/docs/guide/agent-node.md`: +35 lines (ZH)
- `docs-site/docs/en/guide/agent-node.md`: +35 lines (EN)
- **Zero code changes.** Zero test changes. Zero runtime behavior changes.

## Not doing here

- Not adding new safety防线 features (poison-goal auto-pause is P0.3, separate PR incoming)
- Not changing any runtime code
- Not changing the tool set or handler behavior

## Test plan

- [x] `git diff --stat` shows only 2 files touched (ZH + EN docs)
- [x] ZH + EN parity — same section semantics, structure matches
- [ ] Pending 通信龙 review + surface to Vincent

## Refs

- Assessment report: `/tmp/anet-loop-support-report.md` (local, sent to 通信龙 for review, verdict = approve)
- Related PR (P0.3, upcoming): `feat/rfc-025-p0-poison-goal-auto-pause`