### PR TITLE
feat(RFC-025 P1.1): `anet goal wake-log <node> <goal-id>` CLI — export progress_log

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -6359,12 +6359,19 @@ function printGoalShow(goal: LocalGoal, displayName: string, path: string) {
   console.log("");
 }
 
+// RFC-025 P1.1 — wake-log renderers live in a separate pure module
+// (bin/goal-wake-log-render.ts) so unit tests can import them without
+// triggering cli.ts's top-level command dispatch (which prints help
+// on any load with no argv). Command handler below wraps + console.logs.
+import { renderWakeLogJson, renderWakeLogText } from "./goal-wake-log-render";
+
 function printGoalUsage() {
   console.log(`
 anet goal <command>
 
   list [node]                  List scheduled goals for one node, or all nodes
   show <node> <goal-id>        Show one goal in detail (including progress log)
+  wake-log <node> <goal-id>    Export progress_log (wake history) — supports --json / --tail N
   edit <node> <goal-id> ...    Edit a goal's interval / text / status
   cancel <node> <goal-id>      Mark a goal cancelled in that node's goals.json
 
@@ -6373,10 +6380,17 @@ Edit flags (at least one required):
   --text "<new goal description>"
   --status active|paused|completed|cancelled
 
+Wake-log flags:
+  --json                       Output raw JSON (goal_id + entries[])
+  --tail N                     Only show the last N entries (default: all)
+
 Examples:
   anet goal list
   anet goal list 通信牛
   anet goal show 通信牛 abcd1234
+  anet goal wake-log 通信牛 abcd1234
+  anet goal wake-log 通信牛 abcd1234 --tail 5
+  anet goal wake-log 通信牛 abcd1234 --json
   anet goal edit 通信牛 abcd1234 --interval 10min
   anet goal edit 通信牛 abcd1234 --status paused
   anet goal cancel 通信牛 abcd1234
@@ -6503,6 +6517,54 @@ async function goalCommand() {
       process.exit(1);
     }
     printGoalShow(matches[0], nodeDisplayName(resolved.id, resolved.profile), path);
+    return;
+  }
+
+  // RFC-025 P1.1 — `anet goal wake-log <node> <goal-id> [--json] [--tail N]`:
+  // export progress_log (wake history). Complements `anet goal show`
+  // (which caps at 10 entries) by giving full access + machine-readable
+  // JSON for scripting. Read-only, no state changes.
+  if (sub === "wake-log" || sub === "wakelog") {
+    const nodeRef = args[2];
+    const goalRef = args[3];
+    if (!nodeRef || !goalRef) {
+      console.error("Usage: anet goal wake-log <node> <goal-id> [--json] [--tail N]");
+      process.exit(1);
+    }
+    const opts = parseOpts();
+    const resolved = resolveNodeRef(nodeRef);
+    if (!resolved) {
+      console.error(`Node "${nodeRef}" not found.`);
+      process.exit(1);
+    }
+    const { path, file } = loadGoalsFile(resolved.id);
+    const matches = file.goals.filter(g => g.goal_id === goalRef || g.goal_id.startsWith(goalRef));
+    if (matches.length === 0) {
+      console.error(`Goal "${goalRef}" not found in ${path}`);
+      process.exit(1);
+    }
+    if (matches.length > 1) {
+      console.error(`Goal prefix "${goalRef}" is ambiguous (${matches.length} matches). Use a longer id.`);
+      process.exit(1);
+    }
+    // --tail parsing. Reject NaN / <=0 / non-integer. Missing = all.
+    let tailN: number | undefined;
+    if (typeof opts.tail === "string" && opts.tail.length > 0) {
+      const n = parseInt(opts.tail, 10);
+      if (!Number.isFinite(n) || n < 1 || !Number.isInteger(n)) {
+        console.error(`--tail must be a positive integer, got "${opts.tail}"`);
+        process.exit(1);
+      }
+      tailN = n;
+    }
+    // parseOpts declares Record<string, string>: bare `--json` lands
+    // as the sentinel string "true"; `--json=false` opts out.
+    const asJson = typeof opts.json === "string" && opts.json !== "false";
+    if (asJson) {
+      console.log(JSON.stringify(renderWakeLogJson(matches[0], { tail: tailN }), null, 2));
+    } else {
+      console.log(renderWakeLogText(matches[0], { tail: tailN }));
+    }
     return;
   }
 

--- a/agent-network/bin/goal-wake-log-render.ts
+++ b/agent-network/bin/goal-wake-log-render.ts
@@ -1,0 +1,75 @@
+// RFC-025 P1.1 — pure renderers for `anet goal wake-log`.
+//
+// Extracted from cli.ts so unit tests can import these functions
+// without triggering cli.ts's top-level command dispatch (which
+// prints help text on any load with no args). Zero I/O, zero
+// state; just goal shape → string/object shape.
+
+export interface WakeLogEntryShape {
+  ts?: string;
+  status?: string;
+  summary?: string;
+  task_id?: string;
+}
+
+export interface WakeLogGoalShape {
+  goal_id: string;
+  progress_log?: WakeLogEntryShape[];
+}
+
+export interface WakeLogRenderOpts {
+  /** Trim to the last N entries. undefined = all. */
+  tail?: number;
+}
+
+/**
+ * Format progress_log as a JSON object suitable for `--json` output.
+ * Pure. Never reads/writes filesystem. Legacy goals without
+ * progress_log render as empty array (not error).
+ */
+export function renderWakeLogJson(
+  goal: WakeLogGoalShape,
+  opts: WakeLogRenderOpts = {},
+): { goal_id: string; total: number; returned: number; entries: WakeLogEntryShape[] } {
+  const all = Array.isArray(goal.progress_log) ? goal.progress_log : [];
+  const entries = typeof opts.tail === "number" && opts.tail > 0 ? all.slice(-opts.tail) : all;
+  return {
+    goal_id: goal.goal_id,
+    total: all.length,
+    returned: entries.length,
+    entries,
+  };
+}
+
+/**
+ * Format progress_log as a table for human console output.
+ * Column layout mirrors printGoalShow so the two commands read
+ * consistently. Empty log renders a single "(none)" line, not an error.
+ */
+export function renderWakeLogText(
+  goal: WakeLogGoalShape,
+  opts: WakeLogRenderOpts = {},
+): string {
+  const all = Array.isArray(goal.progress_log) ? goal.progress_log : [];
+  const entries = typeof opts.tail === "number" && opts.tail > 0 ? all.slice(-opts.tail) : all;
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`  Goal:     ${goal.goal_id}`);
+  if (all.length === 0) {
+    lines.push("  Progress: (none)");
+    lines.push("");
+    return lines.join("\n");
+  }
+  const suffix = entries.length < all.length
+    ? ` (showing last ${entries.length} of ${all.length})`
+    : ` (${all.length} total)`;
+  lines.push(`  Progress${suffix}:`);
+  for (const entry of entries) {
+    const ts = (entry.ts || "").slice(0, 19).padEnd(19);
+    const st = (entry.status || "").padEnd(13);
+    const sm = (entry.summary || "").replace(/\s+/g, " ").slice(0, 100);
+    lines.push(`    ${ts}  ${st}  ${sm}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}

--- a/agent-network/tests/goal-wake-log-render.test.ts
+++ b/agent-network/tests/goal-wake-log-render.test.ts
@@ -1,0 +1,185 @@
+// RFC-025 P1.1 — anet goal wake-log render helpers.
+//
+// The CLI wiring reads from filesystem and calls process.exit, which
+// makes it painful to unit-test. The interesting logic — how a goal's
+// progress_log is shaped into JSON or text — is broken out into two
+// pure functions (`renderWakeLogJson`, `renderWakeLogText`) so tests
+// can feed shaped inputs and check outputs directly.
+
+import { describe, expect, test } from "bun:test";
+import {
+  renderWakeLogJson,
+  renderWakeLogText,
+  type WakeLogEntryShape,
+  type WakeLogGoalShape,
+} from "../bin/goal-wake-log-render";
+
+function mkEntry(overrides: Partial<WakeLogEntryShape> = {}): WakeLogEntryShape {
+  return {
+    ts: "2026-07-02T00:00:00Z",
+    status: "wake",
+    summary: "scheduler tick started",
+    ...overrides,
+  };
+}
+
+function mkGoal(entries: WakeLogEntryShape[] = []): WakeLogGoalShape {
+  return { goal_id: "abcdef01-2345-6789-abcd-ef0123456789", progress_log: entries };
+}
+
+describe("renderWakeLogJson — pure shape", () => {
+  test("legacy goal with no progress_log field → entries=[], total=0", () => {
+    const goal: WakeLogGoalShape = { goal_id: "legacy-goal" };
+    const r = renderWakeLogJson(goal);
+    expect(r.goal_id).toBe("legacy-goal");
+    expect(r.total).toBe(0);
+    expect(r.returned).toBe(0);
+    expect(r.entries).toEqual([]);
+  });
+
+  test("goal with explicit empty progress_log → same shape as legacy", () => {
+    const r = renderWakeLogJson(mkGoal([]));
+    expect(r.total).toBe(0);
+    expect(r.returned).toBe(0);
+    expect(r.entries).toEqual([]);
+  });
+
+  test("goal with 3 entries + no --tail → returns all 3", () => {
+    const entries = [mkEntry({ status: "wake" }), mkEntry({ status: "report" }), mkEntry({ status: "wake" })];
+    const r = renderWakeLogJson(mkGoal(entries));
+    expect(r.total).toBe(3);
+    expect(r.returned).toBe(3);
+    expect(r.entries).toEqual(entries);
+  });
+
+  test("goal with 10 entries + --tail 5 → returns LAST 5", () => {
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      mkEntry({ ts: `2026-07-02T00:00:${String(i).padStart(2, "0")}Z`, summary: `entry ${i}` }),
+    );
+    const r = renderWakeLogJson(mkGoal(entries), { tail: 5 });
+    expect(r.total).toBe(10);
+    expect(r.returned).toBe(5);
+    expect(r.entries.map((e) => e.summary)).toEqual(["entry 5", "entry 6", "entry 7", "entry 8", "entry 9"]);
+  });
+
+  test("--tail N > total → returns all (no crash, no padding)", () => {
+    const entries = [mkEntry(), mkEntry()];
+    const r = renderWakeLogJson(mkGoal(entries), { tail: 999 });
+    expect(r.total).toBe(2);
+    expect(r.returned).toBe(2);
+    expect(r.entries).toEqual(entries);
+  });
+
+  test("--tail 0 or negative → treated as no tail (all entries) — filters at handler layer", () => {
+    // The render function doc says tail > 0 activates the slice. Zero/
+    // negative → fall through to all-entries. The CLI parseInt guard
+    // rejects <1 earlier, but the helper stays permissive for library use.
+    const entries = [mkEntry(), mkEntry(), mkEntry()];
+    expect(renderWakeLogJson(mkGoal(entries), { tail: 0 }).entries).toEqual(entries);
+    expect(renderWakeLogJson(mkGoal(entries), { tail: -5 }).entries).toEqual(entries);
+  });
+
+  test("goal_id preserved verbatim in JSON output", () => {
+    const goal: WakeLogGoalShape = { goal_id: "unique-goal-xyz", progress_log: [] };
+    expect(renderWakeLogJson(goal).goal_id).toBe("unique-goal-xyz");
+  });
+
+  test("does not mutate input goal or entries", () => {
+    const entries = [mkEntry({ summary: "original" })];
+    const goal = mkGoal(entries);
+    const before = JSON.stringify(goal);
+    renderWakeLogJson(goal, { tail: 1 });
+    expect(JSON.stringify(goal)).toBe(before);
+  });
+});
+
+describe("renderWakeLogText — human console output", () => {
+  test("legacy goal (no progress_log) → '(none)' marker + goal_id header", () => {
+    const r = renderWakeLogText({ goal_id: "legacy" });
+    expect(r).toContain("Goal:     legacy");
+    expect(r).toContain("Progress: (none)");
+  });
+
+  test("empty progress_log → '(none)' marker (same as legacy)", () => {
+    const r = renderWakeLogText(mkGoal([]));
+    expect(r).toContain("Progress: (none)");
+  });
+
+  test("3 entries no tail → header shows '3 total' + all 3 lines present", () => {
+    const entries = [
+      mkEntry({ status: "wake", summary: "s1" }),
+      mkEntry({ status: "report", summary: "s2" }),
+      mkEntry({ status: "complete", summary: "s3" }),
+    ];
+    const r = renderWakeLogText(mkGoal(entries));
+    expect(r).toContain("(3 total)");
+    expect(r).toContain("s1");
+    expect(r).toContain("s2");
+    expect(r).toContain("s3");
+    expect(r).toContain("wake");
+    expect(r).toContain("report");
+    expect(r).toContain("complete");
+  });
+
+  test("--tail N < total → header notes 'showing last N of TOTAL'", () => {
+    const entries = Array.from({ length: 10 }, (_, i) => mkEntry({ summary: `e${i}` }));
+    const r = renderWakeLogText(mkGoal(entries), { tail: 3 });
+    expect(r).toContain("showing last 3 of 10");
+    expect(r).toContain("e7");
+    expect(r).toContain("e8");
+    expect(r).toContain("e9");
+    expect(r).not.toContain("e0 ");  // e0 should NOT appear
+  });
+
+  test("--tail N == total → still says 'N total' not 'showing last N of N'", () => {
+    const entries = [mkEntry({ summary: "only-one" })];
+    const r = renderWakeLogText(mkGoal(entries), { tail: 5 });
+    expect(r).toContain("(1 total)");
+    expect(r).not.toContain("showing last");
+  });
+
+  test("long summary is truncated to 100 chars", () => {
+    const long = "x".repeat(200);
+    const entries = [mkEntry({ summary: long })];
+    const r = renderWakeLogText(mkGoal(entries));
+    // The truncated segment should be present but not the full string
+    expect(r).toContain("x".repeat(100));
+    expect(r).not.toContain("x".repeat(101));
+  });
+
+  test("multi-line summary is flattened (whitespace collapsed)", () => {
+    const messy = "line1\n  line2\t\tline3";
+    const entries = [mkEntry({ summary: messy })];
+    const r = renderWakeLogText(mkGoal(entries));
+    expect(r).toContain("line1 line2 line3");
+    // The original newline must not survive inside the entry row
+    expect(r.split("\n").filter((l) => l.includes("line1 line2 line3"))).toHaveLength(1);
+  });
+
+  test("timestamp truncated to first 19 chars (YYYY-MM-DDTHH:MM:SS)", () => {
+    const entries = [mkEntry({ ts: "2026-07-02T15:30:45.123Z" })];
+    const r = renderWakeLogText(mkGoal(entries));
+    expect(r).toContain("2026-07-02T15:30:45");
+    expect(r).not.toContain("2026-07-02T15:30:45.123Z");
+  });
+
+  test("empty status / missing ts / missing summary render without crash", () => {
+    const entries = [
+      {},
+      { status: "wake" },
+      { ts: "2026-07-02T00:00:00Z", summary: "hi" },
+    ] as WakeLogEntryShape[];
+    const r = renderWakeLogText(mkGoal(entries));
+    expect(r).toContain("(3 total)");
+    // must not throw; must contain the one entry with actual content
+    expect(r).toContain("hi");
+  });
+
+  test("does not mutate input goal or entries", () => {
+    const entries = [mkEntry({ summary: "original" })];
+    const goal = mkGoal(entries);
+    const before = JSON.stringify(goal);
+    renderWakeLogText(goal, { tail: 1 });
+    expect(JSON.stringify(goal)).toBe(before);
+  });
+});


### PR DESCRIPTION
## Author
**Agent**: 通信SDK马 (claude-code-cli runtime)

## Summary

Per Vincent 2.3 iteration 主线④ + 通信龙 approved (P1.1 from anet loop assessment report).

Loop assessment §2.7 flagged `progress_log` as write-only — operators had to `grep goals.json` to see a goal's wake history. `anet goal show` caps at the last 10 entries. This adds a dedicated command with full log + `--json` for scripting.

## Usage

```
anet goal wake-log <node> <goal-id> [--json] [--tail N]
```

- **Bare form** → tabular text (timestamp / status / summary), full log
- **`--tail 5`** → only the last N entries (header shows `showing last N of TOTAL`)
- **`--json`** → `{goal_id, total, returned, entries[]}` for scripting/dashboard consumption

## Design

Renderers extracted to a **pure module** `bin/goal-wake-log-render.ts` so tests import them without triggering `cli.ts`'s top-level command dispatch (which prints help on any load without argv). The command handler in `cli.ts` is a thin filesystem + argv wrapper.

## Files

| File | Lines |
|---|---|
| `bin/goal-wake-log-render.ts` (new) | +75 |
| `bin/cli.ts` (handler + usage) | +62 |
| `tests/goal-wake-log-render.test.ts` (new) | +185 |

## Verification

- **`bun test tests/goal-wake-log-render.test.ts`** → **18 pass / 46 expect**
- **`bun run build`** → clean (0 TS errors)
- **Smoke**:
  - `anet goal --help` shows the new command
  - `anet goal wake-log` (missing args) prints usage line

## Test coverage (18 tests / 46 expect)

**JSON shape** (8):
- legacy no-`progress_log` field → empty entries + total=0
- explicit empty → same shape as legacy
- 3 entries no tail → all 3 returned in order
- 10 entries `--tail 5` → LAST 5 by content (verified by summary text)
- `--tail 999` (> total) → all, no crash, no padding
- `--tail 0 / -N` → permissive fall-through to all (CLI guard rejects earlier)
- `goal_id` preserved verbatim
- **input goal + entries NOT mutated** (before/after JSON string equality)

**Text shape** (10):
- legacy `(none)` marker + goal_id header
- empty `progress_log` → same `(none)` marker
- 3 entries → header `(3 total)`, all summaries + statuses appear
- `--tail 3 of 10` → header `showing last 3 of 10`, verifies specific entries
- `--tail N == total` → still `(N total)`, NOT `showing last`
- summary > 100 chars → truncated to 100
- multi-line summary → flattened (whitespace collapsed to single space)
- timestamp truncated to first 19 chars (`YYYY-MM-DDTHH:MM:SS`)
- edge entries (missing ts/status/summary) render without crash
- **input goal + entries NOT mutated**

## Not doing here

- No dashboard integration (separate P1 item, ~4-6h per assessment)
- No metrics endpoint (P1.5, separate ETA)
- No `--follow` (tail -f style) — non-goal per scope

## Scheduler / runtime行为变化

**Zero**. Read-only command. No changes to `goalStore`, tick, handlers, agent-node, or any wire.

## Test plan

- [x] 18/18 unit tests pass
- [x] `bun run build` clean
- [x] Manual smoke: `--help` documents / missing-args error correct
- [x] Only 3 files touched (pure module + handler + tests); zero staged leftovers
- [ ] Pending 通信龙 review + PR merge

## Refs

- Loop assessment: `/tmp/anet-loop-support-report.md` §2.3 + §3 P1.1
- Sibling P0.2a docs: #370 ✅ merged
- Sibling P0.3 poison-goal: #372 ✅ merged