### PR TITLE
feat(RFC-025 P1.3): DST fall-back 秋令回拨 策略明确 + makeInstant 双迭代修复

### DIFF
--- a/agent-node/src/goals/schedule.test.ts
+++ b/agent-node/src/goals/schedule.test.ts
@@ -165,6 +165,125 @@ describe("computeNextWakeAt — DST edge cases (US Eastern)", () => {
     // 02:30 ET on 2026-03-08 does not exist — skip to next day (2026-03-09 02:30 EDT = 06:30 UTC)
     expect(next.toISOString()).toBe("2026-03-09T06:30:00.000Z");
   });
+
+  test("daily 03:30 exists on spring-forward day (post-jump, unambiguous EDT)", () => {
+    // 2026-03-08 spring-forward: 02:00 EST jumps to 03:00 EDT. 03:30 EDT exists that day.
+    const sched: AgentGoalSchedule = { type: "time_of_day", time: "03:30", timezone: "America/New_York" };
+    const before_jump = new Date("2026-03-07T12:00:00.000Z"); // Sat noon
+    const next = computeNextWakeAt(sched, before_jump, "America/New_York");
+    // Sun 2026-03-08 03:30 EDT = 07:30 UTC
+    expect(next.toISOString()).toBe("2026-03-08T07:30:00.000Z");
+  });
+});
+
+describe("computeNextWakeAt — DST fall-back (autumn) — RFC-025 P1.3", () => {
+  // US DST 2026: fall-back Sun 2026-11-01. At 02:00 EDT (06:00 UTC) the wall
+  // clock rolls back to 01:00 EST. The window 01:00-01:59 wall-clock occurs
+  // TWICE: first as EDT (05:00-05:59 UTC), then again as EST (06:00-06:59 UTC).
+  //
+  // Policy (see schedule.ts nextWallClock docs):
+  // - Ambiguous times fire at the FIRST occurrence (pre-fallback EDT branch).
+  // - The second occurrence is skipped to the next eligible day so daily
+  //   goals fire once per day.
+  // - Post-fallback unambiguous times (e.g. 02:30 EST) fire on the same day.
+
+  const TZ = "America/New_York";
+  const sched01_30: AgentGoalSchedule = { type: "time_of_day", time: "01:30", timezone: TZ };
+  const sched02_30: AgentGoalSchedule = { type: "time_of_day", time: "02:30", timezone: TZ };
+  const sched03_00: AgentGoalSchedule = { type: "time_of_day", time: "03:00", timezone: TZ };
+
+  test("daily 01:30, called Sat noon → fires at FIRST 01:30 EDT (before fall-back)", () => {
+    const saturday_noon = new Date("2026-10-31T12:00:00.000Z");
+    const next = computeNextWakeAt(sched01_30, saturday_noon, TZ);
+    // First 01:30 EDT (UTC-4) on Sun 2026-11-01 = 05:30 UTC
+    expect(next.toISOString()).toBe("2026-11-01T05:30:00.000Z");
+  });
+
+  test("daily 01:30, called AT first 01:30 EDT boundary → NEXT DAY (not second 01:30 EST same day)", () => {
+    // Just fired at 05:30 UTC. Second 01:30 EST at 06:30 UTC same day would
+    // violate "fire once per day". Skip to Mon 2026-11-02.
+    const at_first_fire = new Date("2026-11-01T05:30:00.000Z");
+    const next = computeNextWakeAt(sched01_30, at_first_fire, TZ);
+    // Mon 2026-11-02 01:30 EST = 06:30 UTC
+    expect(next.toISOString()).toBe("2026-11-02T06:30:00.000Z");
+  });
+
+  test("daily 01:30, called between the two occurrences (05:45 UTC) → next day", () => {
+    // At 05:45 UTC on fall-back day: past first 01:30 EDT, before fall-back
+    // moment (06:00 UTC). Second 01:30 EST still an hour away but same-day
+    // repeat is suppressed.
+    const between = new Date("2026-11-01T05:45:00.000Z");
+    const next = computeNextWakeAt(sched01_30, between, TZ);
+    expect(next.toISOString()).toBe("2026-11-02T06:30:00.000Z");
+  });
+
+  test("daily 01:30, called AT fall-back moment (06:00 UTC) → next day (skip 2nd occurrence)", () => {
+    // 06:00 UTC = 02:00 EDT → snaps to 01:00 EST. About to be the second
+    // 01:30 half an hour from now, but we do not fire it (daily-once).
+    const at_fallback = new Date("2026-11-01T06:00:00.000Z");
+    const next = computeNextWakeAt(sched01_30, at_fallback, TZ);
+    expect(next.toISOString()).toBe("2026-11-02T06:30:00.000Z");
+  });
+
+  test("daily 01:30, called AFTER second occurrence (06:30 UTC) → next day", () => {
+    const post_second = new Date("2026-11-01T06:30:00.000Z");
+    const next = computeNextWakeAt(sched01_30, post_second, TZ);
+    expect(next.toISOString()).toBe("2026-11-02T06:30:00.000Z");
+  });
+
+  test("daily 02:30 (post-fallback UNAMBIGUOUS) still fires on fall-back day — was buggy before P1.3", () => {
+    // 02:30 EST exists exactly once on 2026-11-01 (30 minutes after fall-back).
+    // Before the P1.3 makeInstant iteration fix, this was silently skipped to
+    // Nov 2 because the offset probe landed in the EDT branch.
+    const saturday_noon = new Date("2026-10-31T12:00:00.000Z");
+    const next = computeNextWakeAt(sched02_30, saturday_noon, TZ);
+    // Sun 2026-11-01 02:30 EST (UTC-5) = 07:30 UTC
+    expect(next.toISOString()).toBe("2026-11-01T07:30:00.000Z");
+  });
+
+  test("daily 03:00 (fully post-fallback) on fall-back day — regression for iterated offset", () => {
+    const saturday_noon = new Date("2026-10-31T12:00:00.000Z");
+    const next = computeNextWakeAt(sched03_00, saturday_noon, TZ);
+    // Sun 2026-11-01 03:00 EST = 08:00 UTC
+    expect(next.toISOString()).toBe("2026-11-01T08:00:00.000Z");
+  });
+
+  test("weekday Sun 01:30 on fall-back Sunday → first occurrence EDT", () => {
+    const sched: AgentGoalSchedule = { type: "weekday", days: ["sun"], time: "01:30", timezone: TZ };
+    const saturday_noon = new Date("2026-10-31T12:00:00.000Z");
+    const next = computeNextWakeAt(sched, saturday_noon, TZ);
+    expect(next.toISOString()).toBe("2026-11-01T05:30:00.000Z");
+  });
+
+  test("weekday Sun 02:30 on fall-back Sunday → same day (was CRASH before P1.3)", () => {
+    // Before fix: Nov 1 makeInstant returned null (spring-forward code path
+    // reused for fall-back post-transition times), then all other days in
+    // the 8-day search window were non-Sun, so nextWallClock threw
+    // "no eligible day found". P1.3 fix makes makeInstant iterate the
+    // offset probe so Nov 1 02:30 EST resolves correctly.
+    const sched: AgentGoalSchedule = { type: "weekday", days: ["sun"], time: "02:30", timezone: TZ };
+    const saturday_noon = new Date("2026-10-31T12:00:00.000Z");
+    const next = computeNextWakeAt(sched, saturday_noon, TZ);
+    expect(next.toISOString()).toBe("2026-11-01T07:30:00.000Z");
+  });
+
+  test("weekday Sun 01:30 called AT first fire → NEXT Sunday (not same-day 2nd occurrence)", () => {
+    const sched: AgentGoalSchedule = { type: "weekday", days: ["sun"], time: "01:30", timezone: TZ };
+    const at_first_fire = new Date("2026-11-01T05:30:00.000Z");
+    const next = computeNextWakeAt(sched, at_first_fire, TZ);
+    // Next Sun = 2026-11-08. Post-fallback, so 01:30 EST = 06:30 UTC.
+    expect(next.toISOString()).toBe("2026-11-08T06:30:00.000Z");
+  });
+
+  test("time_of_day 09:00 on fall-back day (outside ambiguous window) unchanged", () => {
+    // Guardrail: normal-hour goals must not be perturbed by fall-back logic.
+    const sched: AgentGoalSchedule = { type: "time_of_day", time: "09:00", timezone: TZ };
+    const saturday_noon = new Date("2026-10-31T12:00:00.000Z");
+    const next = computeNextWakeAt(sched, saturday_noon, TZ);
+    // Sat 2026-10-31 12:00 UTC = 08:00 EDT (still EDT). Today's 09:00 EDT
+    // is 13:00 UTC — 1 hour ahead. Next fire = today.
+    expect(next.toISOString()).toBe("2026-10-31T13:00:00.000Z");
+  });
 });
 
 describe("computeNextWakeAt — legacy interval-only (back-compat regression)", () => {

--- a/agent-node/src/goals/schedule.ts
+++ b/agent-node/src/goals/schedule.ts
@@ -93,9 +93,23 @@ function parseTime(s: string): { hour: number; minute: number } {
  * an allowed day, treat as "just fired" and skip to the next eligible
  * day. Avoids immediate re-fire after the wake we just triggered.
  *
- * DST: if the target wall-clock time doesn't exist on a given day
- * (spring-forward skip), we advance to the next day's target. This
- * matches standard cron behaviour.
+ * DST spring-forward (spring): if the target wall-clock time doesn't
+ * exist on a given day (the clock jumps 02:00 → 03:00, skipping 02:30
+ * entirely), we advance to the next day's target. Matches standard
+ * cron behaviour.
+ *
+ * DST fall-back (autumn): the ambiguous window (US: 01:00-01:59 EDT
+ * repeated as 01:00-01:59 EST) resolves to the FIRST occurrence — the
+ * pre-fallback EDT branch. The second occurrence (post-fallback EST)
+ * is treated as "just fired today" and skipped to the next eligible
+ * day, giving one-fire-per-day semantics.
+ *
+ * The reason for picking the first occurrence: interval regularity.
+ * If a daily 01:30 goal fires N times per year, on fall-back day it
+ * fires once (the first 01:30). Otherwise it would either fire twice
+ * (breaking daily-once semantics) or fire at 01:30 EST which would
+ * shift the perceived clock time from the user's set 01:30 to a
+ * 1-hour-later instant relative to the day before.
  */
 function nextWallClock(
   now: Date,
@@ -151,58 +165,57 @@ function wallClockParts(d: Date, tz: string): {
  * minute) in `tz`. Returns null if that local time doesn't exist
  * (DST spring-forward gap).
  *
- * Approach: try an approximate UTC anchor, check if its wall-clock in
- * tz round-trips to the expected (h, m, d). If not (DST skip), bail.
+ * Approach: probe the tz offset at a naive UTC anchor, shift once,
+ * and verify. If the first shift lands in a different DST branch than
+ * the target (fall-back day, post-fallback local times), the second
+ * probe corrects it. Two iterations suffice for standard 1-hour DST
+ * transitions; a third check that still fails signals a genuine
+ * spring-forward gap and returns null.
+ *
+ * Fall-back ambiguous window: when the requested wall-clock occurs
+ * twice (e.g. 01:30 US Eastern on fall-back day), the first shift
+ * from the naive UTC probe lands in the pre-transition branch (EDT).
+ * That branch verifies immediately and is returned, giving the FIRST
+ * occurrence. Skipping the second occurrence to the next eligible day
+ * is nextWallClock's job (boundary "target <= now" check).
  */
 function makeInstant(
   year: number, month: number, day: number,
   hour: number, minute: number, tz: string,
 ): Date | null {
-  // Start with a naive UTC instant for the requested wall-clock.
-  // Then adjust by the offset between UTC and tz at that instant.
-  const naive = Date.UTC(year, month - 1, day, hour, minute, 0);
-  // Look up TZ offset at `naive` by formatting and parsing back.
-  const probe = new Date(naive);
-  const probeParts = wallClockParts(probe, tz);
-  // The naive UTC instant's wall-clock IN tz tells us tz offset
-  // implicitly. Compute the diff between requested h:m and what tz
-  // shows for this UTC instant, then shift the UTC instant.
-  const probeAsTzMinutes = probeParts.day * 24 * 60 + 0; // we don't have h/m yet
-  // Need hour/minute of `probe` in `tz`. Fetch them.
   const fmt = new Intl.DateTimeFormat("en-US", {
-    timeZone: tz, hour12: false, hour: "2-digit", minute: "2-digit", day: "2-digit", month: "2-digit", year: "numeric",
+    timeZone: tz, hour12: false,
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit",
   });
-  const p = fmt.formatToParts(probe);
-  const getN = (t: string) => parseInt(p.find((x) => x.type === t)?.value || "0", 10);
-  const tzHour = getN("hour") % 24;  // Intl can return "24" for midnight in some locales
-  const tzMinute = getN("minute");
-  const tzDay = getN("day");
-  const tzMonth = getN("month");
-  const tzYear = getN("year");
-
-  // Compute the offset: requested wall-clock minus tz wall-clock at
-  // the naive instant. If offset is N minutes, the real UTC instant
-  // is naive - (tz - requested) minutes... but watch out for date
-  // wrap. Simpler: compute the difference between the requested
-  // wall-clock-as-UTC and probe-tz-as-UTC.
+  const verifyMatch = (utcMs: number): boolean => {
+    const vp = fmt.formatToParts(new Date(utcMs));
+    const v = (t: string) => parseInt(vp.find((x) => x.type === t)?.value || "0", 10);
+    if (v("year") !== year || v("month") !== month || v("day") !== day) return false;
+    if (v("hour") % 24 !== hour || v("minute") !== minute) return false;
+    return true;
+  };
+  // "shift needed" = (requested wall-clock as if UTC) minus (tz
+  // wall-clock at anchor, as if UTC). Adding this shift to the anchor
+  // moves us toward the correct UTC instant.
   const requestedAsIfUtc = Date.UTC(year, month - 1, day, hour, minute, 0);
-  const probeTzAsIfUtc = Date.UTC(tzYear, tzMonth - 1, tzDay, tzHour, tzMinute, 0);
-  const offsetMs = requestedAsIfUtc - probeTzAsIfUtc;
-  // The real UTC instant corresponding to (year, month, day, hour, minute) in tz
-  // is the naive UTC instant adjusted by offsetMs.
-  const candidate = new Date(naive + offsetMs);
+  const shiftNeeded = (utcMs: number): number => {
+    const p = fmt.formatToParts(new Date(utcMs));
+    const g = (t: string) => parseInt(p.find((x) => x.type === t)?.value || "0", 10);
+    const tzY = g("year"), tzM = g("month"), tzD = g("day");
+    const tzH = g("hour") % 24, tzMin = g("minute");
+    const tzAsIfUtc = Date.UTC(tzY, tzM - 1, tzD, tzH, tzMin, 0);
+    return requestedAsIfUtc - tzAsIfUtc;
+  };
 
-  // Validate round-trip: if the candidate's wall-clock in tz doesn't
-  // match the request, the requested time doesn't exist in tz
-  // (DST spring-forward gap). Return null in that case.
-  const verifyFmt = new Intl.DateTimeFormat("en-US", {
-    timeZone: tz, hour12: false, hour: "2-digit", minute: "2-digit", day: "2-digit", month: "2-digit", year: "numeric",
-  });
-  const vp = verifyFmt.formatToParts(candidate);
-  const v = (t: string) => parseInt(vp.find((x) => x.type === t)?.value || "0", 10);
-  if (v("year") !== year || v("month") !== month || v("day") !== day) return null;
-  if (v("hour") % 24 !== hour || v("minute") !== minute) return null;
-  return candidate;
-  // Note: void unused intermediate.
-  void probeAsTzMinutes;
+  const naive = requestedAsIfUtc;
+  // Iteration 1: probe offset at naive UTC, shift once.
+  const candidate1 = naive + shiftNeeded(naive);
+  if (verifyMatch(candidate1)) return new Date(candidate1);
+  // Iteration 2: on DST transition days the first shift lands in the
+  // wrong branch (offset differs at candidate1 vs at naive). Re-probe.
+  const candidate2 = candidate1 + shiftNeeded(candidate1);
+  if (verifyMatch(candidate2)) return new Date(candidate2);
+  // Still mismatched after 2 iterations = spring-forward gap.
+  return null;
 }


### PR DESCRIPTION
## Author

Agent: 通信SDK马
Runtime: claude-code-cli
Origin: RFC-025 P1.3 (通信龙 anet loop 评估报告 → P1 gap #3 DST 秋令回拨策略未文档化 / 单测未覆盖)

## Summary

- **Bug 找到并修**: 秋令回拨日 (US 2026-11-01) `makeInstant` 对 fall-back 后半段 wall-clock (`02:30 EST` / `03:00 EST` 等 unambiguous 时点) 返回 `null`, 被 `nextWallClock` 当 spring-forward gap 跳过 → 该日不 fire, 顺延次日. 若 schedule 是 `weekday: [sun]` 时 02:30, `nextWallClock` 直接 throw `no eligible day found within 8 days` (Sun 被跳, 8 天内没下个 Sun) — **硬崩**.
- **Fix**: `makeInstant` 加第二次 offset probe (双迭代). 首次 shift 若落到 DST 另一分支 (fall-back 后半段), 用 `candidate1` 的 tz 偏移再算一次 `candidate2`; 两次都验不过才判 spring-forward gap 返回 `null`. **两次迭代足够解决 1h DST 位移**.
- **Policy 明确 land in `nextWallClock` docs** — ambiguous window (US 01:00-01:59 双出现) 命中 **首次出现 (pre-fallback EDT 分支)**, 第二次 EST 走 "just fired today" 语义跳次日, 保证 daily-once + 相对前一日不平移.
- **12 新 unit test in "DST fall-back (autumn) — RFC-025 P1.3"** describe block, 覆盖 ambiguous 4 时点边界 / post-fallback unambiguous 修复 / weekday Sun / guardrail non-DST-window.
- **补 spring-forward regression**: 03:30 on 2026-03-08 post-jump 存在 (漏了个反面测试).

## Verify

- `bun test src/goals/schedule.test.ts` → **34 pass (was 22)**, 0 fail
- `bun test src/goals` 全套 → **239 pass**, 0 fail (无回归)
- 手写 11-case probe (Sat noon → Sun 01:30 / 02:30 / 03:00 fall-back day + spring-forward 双向) 全 PASS

## Test plan

- [x] schedule.test.ts 单测 34 pass
- [x] `src/goals` 全套 239 pass (完整回归)
- [ ] 通信龙 review: 策略是否 align 我方原 spec 期望 (**首次 EDT** 而不是 second EST 或 both)
- [ ] (optional) M4 e2e 补一条 fall-back 日 schedule wake case — 但要在 real 时间跑, 现阶段用 unit + policy doc 覆盖足够

## Notes

- **零 runtime schedule 语义变更**: 除 fall-back 后半段修复的 bug 外, 所有先前 spec 内的 case 输出不变 (现存 22 unit test 全过).
- **不触及**: 不改生产, 不发版, 不接生产 hub. 分支 `feat/rfc-025-p1-dst-fallback`.
- 通信龙 review OK 后再 merge, 我不 self-merge.

RFC-025 P1.3 交付. 请 review verdict.