### PR TITLE
chore: strip 9 internal memory-slug refs from public code (guard compliance)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -3976,7 +3976,7 @@ Example:
 //     (fail-closed; operator adds via `anet daemon init --allow-secret KEY`
 //     or by hand-editing — strict-by-default per RFC-026 §9.7)
 //   flags: { dangerouslySkipPermissions: true, teammateMode: true }
-//     (standard daemon flags, same defaults [[feedback_default_flags]])
+//     (standard daemon flags, same defaults — dangerouslySkipPermissions + teammateMode on by default)
 //   node_id prefix `node_daemon_` preserved for backwards-compat with
 //   pre-#337 dashboard discovery heuristic (no-op cost on post-#337 hubs).
 

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -271,7 +271,7 @@ export function buildConfigSnapshot(
   };
   // Self-declare nested under daemon_capabilities — only emit fields
   // when valid (typeof + Array.isArray narrow per
-  // [[feedback_typeof_narrow_extracted_fields]]; don't trust user JSON).
+  // per team rule: any typed scalar extracted from untrusted JSON must be typeof-narrowed at the boundary; don't trust user JSON).
   const caps: DaemonCapabilities = {};
   const rt = fileConfig?.runtimes_supported;
   if (Array.isArray(rt) && rt.every((s: unknown) => typeof s === "string")) {

--- a/agent-node/src/runtime/fetch-attachment.test.ts
+++ b/agent-node/src/runtime/fetch-attachment.test.ts
@@ -10,7 +10,7 @@
 //   - hub 401 → auth_failed
 //   - 🔴 Content-Length > cap → size_exceeded BEFORE consuming bytes
 //   - 🔴 stream byte counter > cap → size_exceeded MID-FLIGHT (Content-Length lied)
-//     [[feedback_assume_unit_before_threshold]] — verifies cap unit is BYTES
+//     per team rule: assume-unit-before-threshold — verifies cap unit is BYTES
 //     not chunks, and the abort point is mid-stream not after-read.
 //   - cache hit (file exists + size matches) → no HTTP call, cached:true
 //   - sweeper purges files older than TTL, keeps fresh

--- a/agent-node/src/runtime/fetch-attachment.ts
+++ b/agent-node/src/runtime/fetch-attachment.ts
@@ -24,7 +24,7 @@
 // existing single-host behaviour without forcing every sender to
 // upload through /api/upload.
 //
-// Size safety per [[feedback_assume_unit_before_threshold]]: cap is in
+// Size safety per team rule (assume-unit-before-threshold): cap is in
 // BYTES, not chunks or kb. Pre-check Content-Length header; if absent
 // or > cap, refuse before consuming. During stream, byte counter as a
 // belt — Content-Length can lie. Default 50 MiB (configurable via env

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -78,7 +78,7 @@ function normalizeMetaJson(meta: unknown): string | null {
   // #222 cross-host safety — same sanitization as tools.ts so REST
   // /api/task and MCP send_task produce identical meta_json shapes.
   // Conditional: only strips `path` when `file_id` is also present
-  // (preserves single-host feishu fallback per [[feedback_assume_unit_before_threshold]]
+  // (preserves single-host feishu fallback per team rule — assume-unit-before-threshold: cap is in bytes
   // discipline of not breaking other call sites).
   try { return JSON.stringify(stripHostLocalPathsForCrossHostSafe(meta)); } catch { return null; }
 }

--- a/server/src/lifecycle-guard.ts
+++ b/server/src/lifecycle-guard.ts
@@ -12,7 +12,7 @@
 //
 // PR1.2a (#346 follow-up) extracts the helper to this module so both
 // the MCP tools and the REST handlers can import the same code path,
-// per [[feedback_grep_all_sites_before_apply_guard]]: any SQL-level
+// per team rule (grep every write site before adding a guard): any SQL-level
 // guard's helper lives at module scope so every write site
 // (MCP + REST + internal db.ts helpers) can use it.
 //

--- a/server/src/stop-delete-node.test.ts
+++ b/server/src/stop-delete-node.test.ts
@@ -7,7 +7,7 @@ import { registerTools } from "./tools.js";
 // get_stop_request, ack_stop_request. Drives the MCP handlers via
 // registerTools() so the wired auth context is real (not the
 // mirror-SQL pattern that PR2 v1 used and which let SEC-1 leak slip
-// through, per [[feedback_parallel_fork_review_catches_wired_wrong]]).
+// through — per team rule: independent fork-review catches wired-wrong even when unit tests pass).
 //
 // Covers RFC-027 P1 e2e plan §5.2 scenarios A/B/C/D/E/F at the
 // handler layer:

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -155,7 +155,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
   // (#346 review catch) extracted because the closure scope made it
   // unreachable from REST and left the §2.3 race open on dashboard
   // Dispatch (POST /api/task + /api/broadcast). Per
-  // [[feedback_grep_all_sites_before_apply_guard]].
+  // per team rule: grep every write site (MCP tools.ts AND REST index.ts) before adding a guard, and extract the helper into a shared module so both transports import it.
 
   const addReadScope = (sql: string, params: any[], scope: ReadScope, column = "network_id"): string => {
     if (scope.networkId) {
@@ -3464,7 +3464,7 @@ export function upsertNodeWithSec1Guard(input: UpsertNodeWithSec1GuardInput): Up
     // The snapshot stays the source of truth for non-list reads; the
     // columns exist so `list_host_supervisors` doesn't JSON.parse on
     // every call. typeof-narrow per
-    // [[feedback_typeof_narrow_extracted_fields]] — zod narrowed but
+    // per team rule (typeof-narrow extracted JSON fields at the boundary) — zod narrowed but
     // input.config_snapshot is typed `unknown` here.
     //
     // PR3 nit ①: read from nested `daemon_capabilities.*` (canonical


### PR DESCRIPTION
Slug guard (`.github/scripts/check-no-memory-slugs.py`) landed after 9 pre-existing `[[feedback_*]]` refs had already merged into main. CI now fails on every PR touching main until these are cleaned.

Fixed 9 refs in 8 files via semantic-equivalent rewrites (intent preserved inline, no behavior change):

| File | Slug removed | Inline replacement |
|---|---|---|
| `agent-network/bin/cli.ts` | `[[feedback_default_flags]]` | "dangerouslySkipPermissions + teammateMode on by default" |
| `agent-node/src/runtime/config-apply.ts` | `[[feedback_typeof_narrow_extracted_fields]]` | "any typed scalar extracted from untrusted JSON must be typeof-narrowed at the boundary" |
| `agent-node/src/runtime/fetch-attachment.test.ts` | `[[feedback_assume_unit_before_threshold]]` | "assume-unit-before-threshold — verifies cap unit is BYTES" |
| `agent-node/src/runtime/fetch-attachment.ts` | `[[feedback_assume_unit_before_threshold]]` | "assume-unit-before-threshold" |
| `server/src/tools.ts` × 2 | `[[feedback_grep_all_sites_before_apply_guard]]` + `[[feedback_typeof_narrow_extracted_fields]]` | "grep every write site before adding a guard" + "typeof-narrow extracted JSON fields" |
| `server/src/stop-delete-node.test.ts` | `[[feedback_parallel_fork_review_catches_wired_wrong]]` | "independent fork-review catches wired-wrong even when unit tests pass" |
| `server/src/lifecycle-guard.ts` | `[[feedback_grep_all_sites_before_apply_guard]]` | "grep every write site before adding a guard" |
| `server/src/index.ts` | `[[feedback_assume_unit_before_threshold]]` | "assume-unit-before-threshold: cap is in bytes" |

Post-fix: `grep -rn '\[\[(feedback|project|reference)_' ` those 8 files → 0 hits.

Unblocks PR #366 (runbook rename) + any subsequent PR that touched-but-didn't-cause the slug leaks.

**No behavior change** — pure comment rewrites.

## Author
Agent: 通信IM马