### PR TITLE
fix(anet create Windows): align cwd encoding with claude-code sanitized-cwd scheme

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -18,6 +18,7 @@ import { createHash, randomBytes, randomUUID } from "crypto";
 import { checkbox, confirm, select } from "@inquirer/prompts";
 import { ensureGitignoreRule, ensureGitignoreRules } from "../src/gitignore-writeback";
 import { superviseChild } from "../src/supervise-child";
+import { encodeCwd } from "../src/project-key";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -29,7 +30,6 @@ function globalConfigPath() { return join(home, ".anet", "config.json"); }
 function serverConfigPath() { return join(home, ".anet", "server", "config.json"); }
 function adminUtokPath() { return join(home, ".anet", "server", "admin-utok.json"); }
 function nodesDir() { return join(process.cwd(), ".anet", "nodes"); }
-function encodeCwd(cwd: string): string { return cwd.replace(/\//g, "-"); }
 function shellQuote(value: string): string { return `'${value.replace(/'/g, `'\\''`)}'`; }
 function killTmuxSession(sessionName: string) {
   try { execFileSync("tmux", ["kill-session", "-t", sessionName], { stdio: "pipe" }); } catch {}
@@ -1543,7 +1543,7 @@ async function ensureNodeToken(profile: Profile, id: string): Promise<Profile> {
 
 function writeLegacyProjectAlias(alias: string) {
   const channelDir = join(home, ".claude", "channels", "commhub");
-  const projectKey = process.cwd().replace(/\//g, "-");
+  const projectKey = encodeCwd(process.cwd());
   const aliasDir = join(channelDir, projectKey);
   mkdirSync(aliasDir, { recursive: true });
   writeFileSync(join(aliasDir, ".env"), `COMMHUB_ALIAS=${alias}\n`);
@@ -3335,7 +3335,7 @@ async function lsCommand() {
 
       // Find in CommHub
       let network = "(not in network)";
-      const projectKey = cwd.replace(/\//g, "-");
+      const projectKey = encodeCwd(cwd);
       const aliasEnvPath = join(home, ".claude", "channels", "commhub", projectKey, ".env");
       if (existsSync(aliasEnvPath)) {
         const content = readFileSync(aliasEnvPath, "utf-8");

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -17,6 +17,7 @@ import { randomUUID } from "crypto";
 import { join } from "path";
 import { hostname } from "os";
 import { execSync } from "child_process";
+import { encodeCwd } from "./project-key";
 
 // ── .env loader helper ────────────────────────────────
 function loadEnvFile(path: string): void {
@@ -38,8 +39,11 @@ const COMMHUB_DIR = join(HOME, ".claude/channels/commhub");
 loadEnvFile(join(COMMHUB_DIR, ".env"));
 
 // ── Load project-specific config ──────────────────────
-// /path/to/your/work → -path-to-your-work
-const projectPath = process.cwd().replace(/\//g, "-");
+// /path/to/your/work → -path-to-your-work (POSIX)
+// C:\Users\foo → C--Users-foo (Windows)
+// Scheme matches claude-code's own <sanitized-cwd> so ~/.claude/channels/commhub
+// and ~/.claude/projects sit side-by-side with matching keys.
+const projectPath = encodeCwd(process.cwd());
 loadEnvFile(join(COMMHUB_DIR, projectPath, ".env"));
 
 // ── Get tmux session name ─────────────────────────────

--- a/agent-network/src/project-key.ts
+++ b/agent-network/src/project-key.ts
@@ -1,0 +1,30 @@
+// Windows P0 — cwd → filesystem-safe project key.
+//
+// This helper matches claude-code's own <sanitized-cwd> scheme
+// (~/.claude/projects/<key>/) verified against the binary at
+// v2.1.198+ (function shape: `t = e.replace(/[^a-zA-Z0-9\-_]/g, "-"); return t
+// === "" ? "unknown" : t`). We piggyback on the same scheme for
+// ~/.claude/channels/commhub/<key>/ so:
+//   1. anet-generated and claude-code-generated project dirs align next to
+//      each other under ~/.claude/;
+//   2. Windows callers don't crash — the previous `cwd.replace(/\//g, "-")`
+//      left backslash and drive colon in the key, and `mkdirSync` on
+//      `~/.claude/channels/commhub/C:\Users\wenxing_hu3/.env` ENOENTs on
+//      Windows because `:` is illegal in a path segment. Reported by
+//      user wenxing_hu3 against preview.18;
+//   3. POSIX behavior is preserved for keys that were already unaffected
+//      (`/home/vansin/agent-orchestra` still becomes
+//      `-home-vansin-agent-orchestra`). Paths that contain `.` on POSIX
+//      DO shift (`foo.bar` → `foo-bar`) but that is a correction — the
+//      existing helper was already out of sync with claude-code's own
+//      dir naming for such paths (verified: `~/.claude/projects/` on
+//      dev host contains `-home-vansin-ai-insight--claude-...`, i.e.
+//      claude-code already applies the alnum-dash-underscore rule).
+//
+// Contract: preserve `[a-zA-Z0-9\-_]`; every other char (including `/`, `\`,
+// `:`, `.`, space, unicode) → `-`. Empty input → "unknown" (matches
+// claude-code's fallback).
+export function encodeCwd(cwd: string): string {
+  const t = cwd.replace(/[^a-zA-Z0-9\-_]/g, "-");
+  return t === "" ? "unknown" : t;
+}

--- a/agent-network/tests/project-key.test.ts
+++ b/agent-network/tests/project-key.test.ts
@@ -1,0 +1,101 @@
+// Unit tests for the Windows P0 fix — cwd → filesystem-safe project key.
+//
+// User report (preview.18): `anet create` crashes on Windows because
+// `cwd.replace(/\//g, "-")` only substituted POSIX `/`. On Windows the
+// resulting key still contains `\` and drive `:`, and mkdirSync on
+// `~/.claude/channels/commhub/C:\Users\wenxing_hu3/.env` ENOENTs
+// (drive colon is illegal in a path segment).
+//
+// The fix adopts claude-code's own <sanitized-cwd> scheme (verified
+// against the claude binary strings): `[^a-zA-Z0-9\-_]/g` → `-`,
+// empty → "unknown". These tests lock:
+//   1. Windows paths (backslash + drive colon) → legal single segment
+//   2. POSIX paths without special chars → identical to old behavior
+//      (zero regression for the 99% path)
+//   3. POSIX paths WITH a dot → new behavior matches claude-code (this
+//      is a LATENT MISMATCH correction, not a regression — the old
+//      helper was already out of sync with claude-code's own dir
+//      naming for such paths, per 通信龙 review point)
+//   4. Edge cases — empty string, underscore preservation, hyphen
+//      preservation, drive-letter-only path
+
+import { describe, expect, test } from "bun:test";
+import { encodeCwd } from "../src/project-key";
+
+describe("encodeCwd (Windows P0)", () => {
+  test("Windows: drive letter + backslashes → alnum-dash-underscore segment", () => {
+    // The reproducing case from the user report.
+    expect(encodeCwd("C:\\Users\\wenxing_hu3")).toBe("C--Users-wenxing_hu3");
+  });
+
+  test("Windows: nested backslashes collapse individually (no consecutive-dash squashing)", () => {
+    // Adjacent separators produce adjacent dashes — matches claude-code's
+    // shape (verified vs `~/.claude/projects/` on host with `.claude`
+    // nested paths like `-ai-insight--claude-worktrees-...`).
+    expect(encodeCwd("D:\\a\\b\\c")).toBe("D--a-b-c");
+  });
+
+  test("Windows: drive-only path", () => {
+    expect(encodeCwd("C:\\")).toBe("C--");
+  });
+
+  test("POSIX: canonical dev path — zero regression", () => {
+    // The 99% path: /home/vansin/agent-orchestra → -home-vansin-agent-orchestra
+    // Matches the actual dir on my host (~/.claude/projects/-home-vansin-agent-orchestra/).
+    expect(encodeCwd("/home/vansin/agent-orchestra")).toBe("-home-vansin-agent-orchestra");
+  });
+
+  test("POSIX: path with dot — corrects latent mismatch with claude-code (per 通信龙 review)", () => {
+    // Old anet-only helper (`.replace(/\//g, "-")`) produced
+    // `-home-vansin-my.project` — but claude-code itself already used
+    // `[^a-zA-Z0-9\-_]/g → "-"`, so its own dir was
+    // `-home-vansin-my-project`. The two were silently out of sync.
+    // Post-fix we align with claude-code. This is a CORRECTION, not a
+    // regression — dot-path users were already unable to share the
+    // same key between anet and claude-code.
+    expect(encodeCwd("/home/vansin/my.project")).toBe("-home-vansin-my-project");
+  });
+
+  test("POSIX: worktree path with nested .claude — matches host dir naming", () => {
+    // Empirical baseline: my host has
+    // ~/.claude/projects/-home-vansin-ai-insight--claude-worktrees-feat-404-suggestions
+    // for cwd /home/vansin/ai-insight/.claude/worktrees/feat-404-suggestions.
+    // The double `--` comes from `/` + `.` both mapping to `-`.
+    expect(encodeCwd("/home/vansin/ai-insight/.claude/worktrees/feat-404-suggestions"))
+      .toBe("-home-vansin-ai-insight--claude-worktrees-feat-404-suggestions");
+  });
+
+  test("preserves underscores (usernames like wenxing_hu3 stay readable)", () => {
+    expect(encodeCwd("/home/wenxing_hu3/proj")).toBe("-home-wenxing_hu3-proj");
+  });
+
+  test("preserves hyphens (agent-orchestra is not mangled)", () => {
+    expect(encodeCwd("/home/foo/agent-orchestra")).toBe("-home-foo-agent-orchestra");
+  });
+
+  test("collapses spaces and other punctuation to a single dash each", () => {
+    // Space and other odd chars → `-`.
+    expect(encodeCwd("/home/x y")).toBe("-home-x-y");
+    expect(encodeCwd("/home/x+y")).toBe("-home-x-y");
+    expect(encodeCwd("/home/x@y")).toBe("-home-x-y");
+  });
+
+  test("non-ASCII characters — replaced individually (Chinese path)", () => {
+    // Chinese cwd → each non-ASCII char becomes one `-`. Not ideal but
+    // matches claude-code's scheme, and dirs remain unique per cwd
+    // shape (still filesystem-safe).
+    expect(encodeCwd("/home/张三/proj")).toBe("-home----proj");
+  });
+
+  test("empty string → 'unknown' fallback (matches claude-code)", () => {
+    expect(encodeCwd("")).toBe("unknown");
+  });
+
+  test("only-invalid-chars input still returns dashes not 'unknown'", () => {
+    // Contract: only truly empty input returns 'unknown'; a string of
+    // pure separators still produces a dash-only key (which is a legal
+    // filesystem segment).
+    expect(encodeCwd("///")).toBe("---");
+    expect(encodeCwd("\\\\\\")).toBe("---");
+  });
+});


### PR DESCRIPTION
## Author

- Agent: 通信工程马
- Reviewer: 通信龙 (routing + republish preview.19)
- Priority: 🔴 P0 hotfix — Vincent 用户 wenxing_hu3 在 Windows 上 `anet create` 崩溃 (preview.18)

## Symptom

用户 wenxing_hu3 在 Windows 上跑 `anet create`, mkdirSync ENOENT FATAL:

```
~/.claude/channels/commhub/C:\Users\wenxing_hu3\.env
                            ^                ^
                            drive colon      backslash — 都在路径段中间, 非法
```

盘符 `:` 是 Windows path segment 里的非法字符, `mkdirSync` 直接 ENOENT。POSIX 侥幸能过——`replace(/\//g, "-")` 把 `/` 全替成 `-` 之后是干净的单段。Windows 上 `\` 和 `:` 未处理, 段名非法。

## 根因

3 处 (通信龙 说 2 处, grep 发现是 3 处) inline `cwd.replace(/\//g, "-")`:
- `agent-network/bin/cli.ts:1546` — `writeLegacyProjectAlias` writer
- `agent-network/bin/cli.ts:3338` — status reader
- `agent-network/src/node-server.ts:42` — MCP stdio child reader (通信龙 漏了这处)

外加 `bin/cli.ts:32` 一个 legacy `encodeCwd` helper 也是同款错的正则。总 4 处身份同源, 但用法不一致。

## 修

1. 新 `agent-network/src/project-key.ts` — 单一 helper `encodeCwd(cwd)`, 直接抄 claude-code 二进制里的 authoritative scheme (v2.1.198 strings 抓):

```ts
export function encodeCwd(cwd: string): string {
  const t = cwd.replace(/[^a-zA-Z0-9\-_]/g, "-");
  return t === "" ? "unknown" : t;
}
```

2. 3 处 inline 全改用 helper, legacy `bin/cli.ts:32` 重复 helper 删掉——SSOT。

## Alignment 依据 (通信龙 review-point)

POSIX 含 `.` 的 path 是 **latent mismatch 修正, 不是 regression**:

| cwd | 老 anet | claude-code 本体 | 修后 anet |
|---|---|---|---|
| `/home/vansin/my.project` | `-home-vansin-my.project` (only `/`) | `-home-vansin-my-project` (alnum-dash-underscore) | `-home-vansin-my-project` ✓ |

**Empirical verification** on dev host: `~/.claude/projects/` 里已经有 `-home-vansin-ai-insight--claude-worktrees-feat-404-suggestions` (cwd `/home/vansin/ai-insight/.claude/worktrees/feat-404-suggestions`)。双 `--` + `.` → `-` 证明 claude-code 用的就是新 scheme, 我们老 helper dot-path 上早就跟本体对不上, 只是没人踩。

## 测试真号码

`tests/project-key.test.ts` — 12 cases 全 PASS 于 `bun test`:

```
$ bun test tests/project-key.test.ts
 12 pass
 0 fail
 15 expect() calls
Ran 12 tests across 1 file. [30.00ms]
```

覆盖:
- **Windows**: `C:\Users\wenxing_hu3` → `C--Users-wenxing_hu3` (repro case)
- **Windows**: nested `\` 各自单独 → `-` (无 squash)
- **Windows**: drive-only `C:\` → `C--`
- **POSIX baseline**: `/home/vansin/agent-orchestra` → `-home-vansin-agent-orchestra` (zero-regression, 99% path)
- **POSIX dot-path** (通信龙 review-point): `/home/vansin/my.project` → `-home-vansin-my-project` (aligns with claude-code)
- **Worktree with nested `.claude/`**: matches host dir naming (empirical)
- **`_` 保留** (usernames like `wenxing_hu3` 保持可读)
- **`-` 保留** (`agent-orchestra` 不 mangle)
- 空格 / 标点 / 非 ASCII → 每 char `-`
- **Empty → "unknown"** (claude-code fallback)
- 纯分隔符 → 纯 dash (不是 "unknown")

Runtime probe:
```
$ bun -e "import('./src/project-key.ts').then(m => console.log(m.encodeCwd('C:\\\\Users\\\\wenxing_hu3')))"
"C--Users-wenxing_hu3"
```

typecheck: PASS (`npm run typecheck` clean).

## 影响面 + 迁移

- **Windows**: 从 CRASH → 正常工作。
- **POSIX 无 `.`/`_` 的 cwd (99%)**: 输出完全不变, 零 regression。
- **POSIX 含 `.` 的 cwd**: 输出从 `-foo.bar` → `-foo-bar`。用户旧的 `~/.claude/channels/commhub/-foo.bar/.env` 不会被读取, 新 cwd 首跑会重建 `.env` (小状态迁移, 一次性)。此路径的用户之前已跟 claude-code 自己的 project dir 对不上, 修好反而对齐了。

## 复现方式

```bash
cd agent-network && bun test tests/project-key.test.ts
```

真机复验交 Vincent / wenxing_hu3 (docker 装不了 Windows userland)。

红线合规: 无 slug (PR body + commit msg + 代码注释 grep 全 clean), 无生产接触, claim=reality (号码就是 bun test 实测)。

Fixes anet-create-windows-crash (wenxing_hu3 preview.18 report).
