### PR TITLE
fix(#380): /api/host-supervisors fallback for single-network utok users

### DIFF
--- a/server/src/api-host-supervisors-fallback.test.ts
+++ b/server/src/api-host-supervisors-fallback.test.ts
@@ -1,0 +1,155 @@
+// #380 fix — REST /api/host-supervisors utok→default-network fallback.
+//
+// Before this patch the endpoint hard-4xxed when the client omitted the
+// `network_id` query param. The dashboard's create-node wizard was
+// reported as "hub 400" against a prod hub that had zero daemons AND was
+// being polled without the query — the frontend read that as "no
+// available servers" and blocked the wizard.
+//
+// Post-fix contract:
+//   - ntok caller                                → uses bound network (existing)
+//   - utok caller + `?network_id=...` verified   → uses that (existing)
+//   - utok caller + NO query + 1 accessible net  → fallback to that net (200)
+//   - utok caller + NO query + 2+ accessible net → 400, error=network_id_required_multi
+//   - utok caller + NO query + 0 accessible net  → 400, error=missing_network_id
+//
+// The multi-network case is the authz boundary — we refuse to guess
+// which network to list from (per 通信龙 spec "别 fallback 到错 network").
+//
+// Test pattern mirrors uploads-http.test.ts: bind the real Bun.serve
+// server on an ephemeral port with a temp DB, hit it with fetch().
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { register, login, createNetwork } from "./auth.js";
+import { db } from "./db.js";
+
+const SERVER_DB = mkdtempSync(join(tmpdir(), "anet-hs-fallback-db-")) + "/commhub.db";
+const PORT = 18000 + Math.floor(Math.random() * 1000);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+// Three users:
+//   soloUser    — single accessible network (fallback should work)
+//   multiUser   — two accessible networks (fallback should refuse)
+//   orphanUser  — zero networks (fallback has nothing to derive)
+let soloToken = "", multiToken = "", orphanToken = "";
+let soloNetworkId = "";
+let multiNetworkA = "", multiNetworkB = "";
+
+beforeAll(async () => {
+  process.env.COMMHUB_DB = SERVER_DB;
+  process.env.PORT = String(PORT);
+  process.env.HOST = "127.0.0.1";
+
+  const suffix = `${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+  const password = "BootstrapPw123Aa!";
+
+  // Pre-register a first user so subsequent test users are NOT auto-admin.
+  // resolveRestNetworkScope's admin branch bypasses fallback (admin can
+  // legitimately query any network), which would make solo's no-query
+  // case a false-negative for our fix contract.
+  const seed = register(`seed_admin_${suffix}`, password, undefined, "seed");
+  if (!seed.ok) throw new Error("seed admin failed: " + JSON.stringify(seed));
+
+  // Solo user — register() auto-creates a default network; nothing to add.
+  const solo = register(`solo_${suffix}`, password, undefined, "seed");
+  if (!solo.ok || !solo.token) throw new Error("solo register failed: " + JSON.stringify(solo));
+  soloToken = solo.token;
+  soloNetworkId = solo.network_id ?? "";
+  if (!soloNetworkId) throw new Error("solo default network missing");
+
+  // Multi user — register + create a second owned network.
+  const multi = register(`multi_${suffix}`, password, undefined, "seed");
+  if (!multi.ok || !multi.token) throw new Error("multi register failed: " + JSON.stringify(multi));
+  multiToken = multi.token;
+  multiNetworkA = multi.network_id ?? "";
+  if (!multiNetworkA) throw new Error("multi default network missing");
+  const authCtx = login(`multi_${suffix}`, password);
+  const secondNet: any = createNetwork(authCtx.user!.user_id, `multi_second_${suffix}`);
+  if (!secondNet.ok || !secondNet.network_id) throw new Error("multi second-net create failed: " + JSON.stringify(secondNet));
+  multiNetworkB = secondNet.network_id;
+
+  // Orphan user — register then delete membership in the default net so
+  // the user has zero networks. Direct DB manipulation is fine here;
+  // we're modeling an edge case the production API would never let a
+  // normal user hit (they'd always keep at least their default), but
+  // the endpoint contract still needs to be locked.
+  const orphan = register(`orphan_${suffix}`, password, undefined, "seed");
+  if (!orphan.ok || !orphan.token) throw new Error("orphan register failed: " + JSON.stringify(orphan));
+  orphanToken = orphan.token;
+  const orphanUserId = login(`orphan_${suffix}`, password).user!.user_id;
+  db.run("DELETE FROM network_members WHERE user_id = ?1", [orphanUserId]);
+
+  // Import triggers Bun.serve at module load — this IS the server start.
+  await import("./index.js");
+  await new Promise((r) => setTimeout(r, 100));
+});
+
+afterAll(() => {
+  try { rmSync(SERVER_DB, { recursive: true, force: true }); } catch {}
+});
+
+async function get(path: string, token: string): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { "Authorization": `Bearer ${token}` },
+  });
+  const body = await res.json().catch(() => null);
+  return { status: res.status, body };
+}
+
+describe("#380 — /api/host-supervisors utok→default-network fallback", () => {
+  test("path 1 — utok with 1 network, WITH ?network_id → 200 (existing behavior)", async () => {
+    const r = await get(`/api/host-supervisors?network_id=${soloNetworkId}`, soloToken);
+    expect(r.status).toBe(200);
+    expect(r.body?.ok).toBe(true);
+    expect(Array.isArray(r.body?.daemons)).toBe(true);
+    expect(typeof r.body?.count).toBe("number");
+  });
+
+  test("path 2 — utok with 1 network, NO ?network_id → 200 (fallback lands)", async () => {
+    // This is the core #380 fix: dashboard forgot the query but the user
+    // only has one network anyway, so we can safely fall back to it.
+    const r = await get(`/api/host-supervisors`, soloToken);
+    expect(r.status).toBe(200);
+    expect(r.body?.ok).toBe(true);
+    expect(Array.isArray(r.body?.daemons)).toBe(true);
+  });
+
+  test("path 3 — utok with 2 networks, NO ?network_id → 400 network_id_required_multi", async () => {
+    // Authz boundary: refuse to guess which network to list. Distinguishing
+    // error field lets the client tell the user "pick a network" vs
+    // "you're not in any networks".
+    const r = await get(`/api/host-supervisors`, multiToken);
+    expect(r.status).toBe(400);
+    expect(r.body?.ok).toBe(false);
+    expect(r.body?.error).toBe("network_id_required_multi");
+    expect(r.body?.memberships).toBe(2);
+  });
+
+  test("path 4 — utok with 2 networks, WITH ?network_id → 200 (explicit choice honored)", async () => {
+    const r = await get(`/api/host-supervisors?network_id=${multiNetworkA}`, multiToken);
+    expect(r.status).toBe(200);
+    expect(r.body?.ok).toBe(true);
+    const r2 = await get(`/api/host-supervisors?network_id=${multiNetworkB}`, multiToken);
+    expect(r2.status).toBe(200);
+    expect(r2.body?.ok).toBe(true);
+  });
+
+  test("path 5 — utok with 2 networks, WITH ?network_id (not a member) → denied by scope layer", async () => {
+    // Requesting a network the user isn't in must never leak — this is
+    // enforced upstream at resolveRestNetworkScope, but re-lock here.
+    const foreignNet = "net_absolutely_not_a_member";
+    const r = await get(`/api/host-supervisors?network_id=${foreignNet}`, multiToken);
+    expect(r.status).toBe(403);
+  });
+
+  test("path 6 — utok with 0 networks, NO ?network_id → 400 missing_network_id (memberships=0)", async () => {
+    const r = await get(`/api/host-supervisors`, orphanToken);
+    expect(r.status).toBe(400);
+    expect(r.body?.ok).toBe(false);
+    expect(r.body?.error).toBe("missing_network_id");
+    expect(r.body?.memberships).toBe(0);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1992,10 +1992,28 @@ Bun.serve({
     // Same SQL + role-extract + member-脱敏 logic; SEC-1 scoped via REST
     // auth pipeline (restScope). Returns {ok, daemons:[...], count}.
     if (url.pathname === "/api/host-supervisors") {
-      const netParam = url.searchParams.get("network_id");
-      const effectiveNetId = restScope.networkId ?? netParam ?? null;
+      // #380 — utok callers with exactly one accessible network get a
+      // safe fallback so the create-node wizard doesn't have to bake
+      // network_id into every request (it was hard-4xxing when the
+      // dashboard omitted the query param — that's what "hub 400" was).
+      // `singleNetworkId` returns:
+      //   - scope.networkId when it's set (ntok binding, or an
+      //     explicitly-requested network the user has verified access to)
+      //   - the sole member of scope.networkIds when the utok user
+      //     belongs to exactly one network (safe unambiguous fallback)
+      //   - null when the user belongs to 0 or 2+ networks (authz
+      //     boundary — refuse to guess which one, mirrors 通信龙 spec
+      //     "别 fallback 到错 network")
+      // The 400 branch is retained for the ambiguous / no-access cases
+      // and distinguishes them in the error message so the client can
+      // recover (send network_id explicitly).
+      const effectiveNetId = singleNetworkId(restScope);
       if (!effectiveNetId) {
-        return withCors(req, Response.json({ ok: false, error: "missing_network_id" }, { status: 400 }));
+        const memberships = restScope.networkIds?.length ?? 0;
+        const error = memberships > 1
+          ? "network_id_required_multi"
+          : "missing_network_id";
+        return withCors(req, Response.json({ ok: false, error, memberships }, { status: 400 }));
       }
       // Role for member-脱敏 (admin/owner = full host_telemetry, others = masked)
       let isPrivileged = false;

--- a/tests/test380-daemon-telemetry-probe/Dockerfile
+++ b/tests/test380-daemon-telemetry-probe/Dockerfile
@@ -1,0 +1,31 @@
+# Mirror 通信龙's environment: node:22-bookworm-slim + npm-install
+# @sleep2agi/agent-network@preview + @sleep2agi/agent-node@preview
+# (currently preview.17 per `npm view @sleep2agi/agent-node@preview version`).
+#
+# The probe runs BOTH the isolated hub AND the daemon inside this container,
+# talking to 127.0.0.1:9310. Different from 通信龙's gateway topology, but
+# functionally identical for the "what does the daemon send" question — the
+# payload shape and DB writes are what we're after, not network routing.
+
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash curl jq ca-certificates sqlite3 procps unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install bun for running the hub from source (we bind-mount main).
+RUN curl -fsSL https://bun.sh/install | bash && \
+    ln -s /root/.bun/bin/bun /usr/local/bin/bun
+
+# npm-install the same preview versions 通信龙 used, so we probe the
+# ACTUAL published tarballs (not the /repo main source). This is what
+# `anet daemon up` spawns in production when agent-node isn't in PATH.
+RUN npm i -g @sleep2agi/agent-network@preview @sleep2agi/agent-node@preview
+
+WORKDIR /repo
+COPY . .
+WORKDIR /repo/server
+RUN bun install
+
+WORKDIR /repo
+CMD ["bash", "tests/test380-daemon-telemetry-probe/run.sh"]

--- a/tests/test380-daemon-telemetry-probe/run.sh
+++ b/tests/test380-daemon-telemetry-probe/run.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# P0/P1 #380 daemon telemetry probe — mirror 通信龙's environment, capture
+# the ACTUAL heartbeat payload + DB state so we can tell A (version drift) /
+# B (host: field null) / C (config_snapshot slow) apart with real numbers.
+#
+# Not testing dashboard directly here; probing the raw wire so a fix can be
+# scoped without guessing.
+
+set -euo pipefail
+
+export HOME=/tmp/anethome
+export COMMHUB_DB=/tmp/qa-380-hub.db
+export PORT=9310
+BASE="http://127.0.0.1:${PORT}"
+REPORT="/repo/docs/tests/p380-daemon-telemetry-probe/report.txt"
+LOGFILE="/tmp/hub.log"
+DAEMON_LOG="/tmp/daemon.log"
+mkdir -p "$(dirname "$REPORT")" "$HOME/.anet"
+
+cleanup() {
+  { kill "${DAEMON_PID:-0}" 2>/dev/null || true; } &
+  { kill "${HUB_PID:-0}" 2>/dev/null || true; } &
+  wait 2>/dev/null || true
+}
+trap cleanup EXIT
+
+rec() { printf '  %s = %s\n' "$1" "$2" >> "$REPORT"; }
+sec() { printf '\n## %s\n\n' "$1" >> "$REPORT"; }
+raw() { printf '%s\n' "$*" >> "$REPORT"; }
+
+json_post() {
+  local path="$1" token="$2" body="$3"
+  curl -sS -X POST "$BASE$path" \
+    ${token:+-H "Authorization: Bearer $token"} \
+    -H "Content-Type: application/json" \
+    -d "$body"
+}
+
+: > "$REPORT"
+cat >> "$REPORT" <<HDR
+# test380-daemon-telemetry-probe
+
+Environment mirror of 通信龙's #380 repro (with local-container topology).
+- OS: node:22-bookworm-slim (Linux)
+- agent-network + agent-node: installed via npm from @preview tag
+- Hub: /repo/server bun-run on port $PORT, isolated DB $COMMHUB_DB
+- No connection to production or fleet :9200.
+
+HDR
+
+# ── Step 0: baseline environment probe ──────────────────────────────────
+sec "S0 environment"
+rec "linux kernel" "$(uname -a)"
+rec "node" "$(node --version)"
+rec "bun" "$(bun --version)"
+rec "installed agent-network" "$(anet --version 2>/dev/null || echo '(missing)')"
+rec "installed agent-node" "$(agent-node --version 2>/dev/null || echo '(missing)')"
+rec "which agent-node" "$(command -v agent-node || echo '(none)')"
+rec "PATH" "$PATH"
+
+# The critical A-hypothesis probe: is the binary that DAEMON will spawn
+# actually preview.17 (or later)?
+NPM_PREVIEW_VER=$(npm view @sleep2agi/agent-node@preview version 2>&1 | tail -1)
+NPM_PREVIEW_LATEST=$(npm view @sleep2agi/agent-node@latest version 2>&1 | tail -1)
+rec "@sleep2agi/agent-node@preview (npm)" "$NPM_PREVIEW_VER"
+rec "@sleep2agi/agent-node@latest (npm)" "$NPM_PREVIEW_LATEST"
+
+# The B-hypothesis pre-check: are /proc/loadavg and /proc/meminfo readable,
+# does df -k / return sane values? host-telemetry.ts:61-138 depends on these.
+sec "S0b B-hypothesis pre-check — /proc + df access from slim image"
+if [[ -r /proc/loadavg ]]; then
+  raw "/proc/loadavg:"; cat /proc/loadavg | head -1 >> "$REPORT"
+else
+  raw "/proc/loadavg: NOT READABLE"
+fi
+if [[ -r /proc/meminfo ]]; then
+  raw ""; raw "/proc/meminfo head:"; grep -E "^(MemTotal|MemAvailable|MemFree):" /proc/meminfo >> "$REPORT"
+else
+  raw "/proc/meminfo: NOT READABLE"
+fi
+raw ""; raw "df -k / output:"
+df -k / >> "$REPORT" 2>&1 || raw "  df failed"
+
+# ── Step 1: start isolated hub ───────────────────────────────────────────
+sec "S1 start isolated hub on :$PORT"
+rm -f "$COMMHUB_DB"
+bun run server/src/index.ts >"$LOGFILE" 2>&1 &
+HUB_PID=$!
+for _ in {1..80}; do curl -fsS "$BASE/health" >/dev/null 2>&1 && break; sleep 0.25; done
+curl -fsS "$BASE/health" >/dev/null || { rec "hub health" "TIMEOUT"; tail -80 "$LOGFILE" >> "$REPORT"; exit 1; }
+rec "hub pid" "$HUB_PID"
+rec "hub health" "OK"
+
+# ── Step 2: bootstrap admin + network + mint ntok for demo-host ─────────
+ADMIN=$(json_post "/api/auth/register" "" '{"username":"admin","password":"anethub"}')
+UTOK=$(echo "$ADMIN" | jq -r '.token // empty')
+[[ "$UTOK" == utok_* ]] || { echo "register failed: $ADMIN" | tee -a "$REPORT"; exit 1; }
+
+NET=$(json_post "/api/networks" "$UTOK" '{"name":"n-380"}')
+NET_ID=$(echo "$NET" | jq -r '.network.network_id // .network_id // empty')
+[[ -n "$NET_ID" ]] || { echo "network failed: $NET" | tee -a "$REPORT"; exit 1; }
+
+DEMO_HOST_TOK=$(json_post "/api/auth/node-token" "$UTOK" \
+  "{\"network_id\":\"$NET_ID\",\"node_name\":\"demo-host\"}" | jq -r '.token // empty')
+[[ "$DEMO_HOST_TOK" == ntok_* ]] || { echo "mint failed"; exit 1; }
+
+sec "S2 setup"
+rec "network_id" "$NET_ID"
+rec "demo-host ntok prefix" "${DEMO_HOST_TOK:0:12}..."
+
+# ── Step 3: write a daemon config that mirrors `anet daemon init` output ─
+sec "S3 write config.json for daemon (matches anet daemon init at bin/cli.ts:4098-4117)"
+
+DAEMON_DIR="$HOME/.anet/nodes/demo-host"
+mkdir -p "$DAEMON_DIR"
+NODE_ID="n_$(head -c 8 /dev/urandom | od -An -txC | tr -d ' \n')"
+cat > "$DAEMON_DIR/config.json" <<CFG
+{
+  "anet_version": "test-probe",
+  "node_id": "$NODE_ID",
+  "node_name": "demo-host",
+  "alias": "demo-host",
+  "runtime": "claude-agent-sdk",
+  "role": "host_supervisor",
+  "runtimes_supported": ["claude-agent-sdk", "codex-sdk", "grok-build-acp"],
+  "allowed_secret_keys": [],
+  "max_concurrent_children": 20,
+  "network_id": "$NET_ID",
+  "hub": "$BASE",
+  "token": "$DEMO_HOST_TOK",
+  "model": "claude-sonnet-4-5",
+  "channels": [],
+  "env": {},
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true },
+  "session": null
+}
+CFG
+rec "config path" "$DAEMON_DIR/config.json"
+rec "config role" "$(jq -r .role "$DAEMON_DIR/config.json")"
+
+# ── Step 4: spawn the daemon exactly as anet daemon start would ─────────
+# From bin/cli.ts:2701-2785 (spawn args for claude-agent-sdk runtime).
+# We call agent-node directly with the same argv the launcher would use.
+sec "S4 spawn daemon (mirror agent-network launcher: --config --alias --runtime)"
+
+if ! command -v agent-node >/dev/null; then
+  rec "spawn" "agent-node not on PATH — cannot proceed"
+  exit 1
+fi
+
+DAEMON_ARGS=(
+  --config "$DAEMON_DIR/config.json"
+  --alias  demo-host
+  --runtime claude-agent-sdk
+)
+
+env_common=(
+  "COMMHUB_ALIAS=demo-host"
+  "COMMHUB_NODE_ID=$NODE_ID"
+  "COMMHUB_TOKEN=$DEMO_HOST_TOK"
+  "COMMHUB_URL=$BASE"
+  "ANET_CONFIG_UPDATE_CAPABLE=1"
+  "PATH=$PATH"
+  "HOME=$HOME"
+)
+
+# Fire in background; daemon may exit if runtime init fails (no anthropic
+# key), but register() and immediate reportStatus() run BEFORE runtime
+# engagement. So the payload should land regardless.
+( env "${env_common[@]}" agent-node "${DAEMON_ARGS[@]}" >"$DAEMON_LOG" 2>&1 ) &
+DAEMON_PID=$!
+rec "daemon spawn pid" "$DAEMON_PID"
+
+# Wait for register + immediate reportStatus to land. From cli.ts:4085-4096
+# these fire on boot within a few seconds — 8s is a generous ceiling.
+sleep 8
+
+# ── Step 5: capture evidence ─────────────────────────────────────────────
+sec "S5 hub log — report_status accepted lines (tools.ts:391 print format)"
+
+# Line format is: "[hh:mm:ss] <alias> (<resume8>) → report_status: <status>"
+grep -E "→ report_status:" "$LOGFILE" | head -20 >> "$REPORT" || raw "  (no report_status lines yet)"
+
+sec "S5b daemon log head (last 60 lines)"
+tail -60 "$DAEMON_LOG" >> "$REPORT" 2>&1
+
+sec "S6 SQL dump — sessions row for demo-host (register()'s target)"
+sqlite3 -header -column "$COMMHUB_DB" \
+  "SELECT alias, node_id, hostname, ip, status,
+          cpu_load_1min, cpu_cores,
+          mem_total_gb, mem_used_gb, mem_avail_gb,
+          disk_total_gb, disk_used_gb, disk_avail_gb,
+          last_seen_at, updated_at
+     FROM sessions WHERE alias='demo-host'" >> "$REPORT" 2>&1
+
+sec "S6b SQL dump — nodes row for demo-host (config_snapshot's target)"
+sqlite3 -header -column "$COMMHUB_DB" \
+  "SELECT alias, node_id, runtime, model, hostname,
+          CASE WHEN config_snapshot IS NULL THEN 'NULL'
+               WHEN config_snapshot='' THEN 'EMPTY'
+               ELSE 'HAS_VALUE ('||length(config_snapshot)||' bytes)' END AS snapshot_status,
+          runtimes_supported, allowed_secret_keys,
+          updated_at
+     FROM nodes WHERE alias='demo-host'" >> "$REPORT" 2>&1
+# Note: max_concurrent_children is NOT a column in nodes; it lives inside
+# the config_snapshot JSON blob only (PR3 nit didn't promote it, see
+# tools.ts:320 comment). We probe the JSON body separately at S6c.
+
+# If snapshot has value, extract the interesting bits
+sec "S6c nodes.config_snapshot content (if any)"
+SNAPSHOT=$(sqlite3 "$COMMHUB_DB" "SELECT config_snapshot FROM nodes WHERE alias='demo-host'")
+if [[ -n "$SNAPSHOT" && "$SNAPSHOT" != "NULL" ]]; then
+  echo "$SNAPSHOT" | jq '.' >> "$REPORT" 2>>"$REPORT" || echo "$SNAPSHOT" >> "$REPORT"
+else
+  raw "  (empty / NULL — config_snapshot never landed)"
+fi
+
+sec "S6d agent_telemetry insert count for demo-host"
+sqlite3 -header -column "$COMMHUB_DB" \
+  "SELECT COUNT(*) AS n, MIN(created_at) AS first, MAX(created_at) AS last
+     FROM agent_telemetry WHERE alias='demo-host'" >> "$REPORT" 2>&1
+
+# ── Step 7: the /api/servers view (dashboard sees this) ──────────────────
+sec "S7 /api/servers response (what Servers page reads)"
+curl -sS "$BASE/api/servers" -H "Authorization: Bearer $UTOK" | jq '.' >> "$REPORT" 2>&1
+
+sec "S7b /api/host-supervisors response (create-node wizard reads this)"
+curl -sS "$BASE/api/host-supervisors?network_id=$NET_ID" -H "Authorization: Bearer $UTOK" | jq '.' >> "$REPORT" 2>&1
+
+# ── Step 8: verdict — which of A/B/C fired? ─────────────────────────────
+sec "S8 verdict — A/B/C classification"
+
+CPU_LOAD=$(sqlite3 "$COMMHUB_DB" "SELECT cpu_load_1min FROM sessions WHERE alias='demo-host'" 2>/dev/null || echo "")
+MEM_TOTAL=$(sqlite3 "$COMMHUB_DB" "SELECT mem_total_gb FROM sessions WHERE alias='demo-host'" 2>/dev/null || echo "")
+SESSION_LAST_SEEN=$(sqlite3 "$COMMHUB_DB" "SELECT last_seen_at FROM sessions WHERE alias='demo-host'" 2>/dev/null || echo "")
+SNAPSHOT_SET=$(sqlite3 "$COMMHUB_DB" "SELECT CASE WHEN config_snapshot IS NULL OR config_snapshot='' THEN 'NO' ELSE 'YES' END FROM nodes WHERE alias='demo-host'" 2>/dev/null || echo "NO_ROW")
+HB_LINES=$(grep -c "→ report_status" "$LOGFILE" 2>/dev/null || echo 0)
+
+rec "cpu_load_1min in sessions" "${CPU_LOAD:-<null>}"
+rec "mem_total_gb in sessions"  "${MEM_TOTAL:-<null>}"
+rec "sessions.last_seen_at"     "${SESSION_LAST_SEEN:-<empty>}"
+rec "nodes.config_snapshot"     "$SNAPSHOT_SET"
+rec "report_status accepted lines in hub log" "$HB_LINES"
+
+raw ""
+raw "Hypothesis classification:"
+if [[ "$HB_LINES" -eq 0 ]]; then
+  raw "  ▶ heartbeat never reached hub — check auth / URL / network"
+elif [[ -z "$CPU_LOAD" || "$CPU_LOAD" == "" ]]; then
+  raw "  ▶ heartbeat reached hub, but host telemetry columns are null → B (or A: agent-node was older)."
+  raw "    Combined with agent-node --version above, determines A vs B."
+  raw "    B: /proc access above shows whether host-telemetry.ts would have gotten values."
+else
+  raw "  ▶ heartbeat reached hub and cpu/mem are present → register()'s host: payload lands."
+  raw "    If config_snapshot=NO the wizard fails while Servers page shows online — that's C."
+fi
+
+if [[ "$SNAPSHOT_SET" == "NO" ]]; then
+  raw ""
+  raw "  ▶ nodes.config_snapshot is unset even after 8s wait."
+  raw "    Immediate reportStatus() at cli.ts:4095 either failed silently or hasn't fired yet."
+  raw "    This directly explains list_host_supervisors returning 0 → create-node wizard 'hub 400'."
+fi
+
+raw ""
+raw "Boot log first 5 hub log lines for context:"
+head -5 "$LOGFILE" | sed 's/^/  /' >> "$REPORT"
+
+echo
+echo "===== REPORT ====="
+cat "$REPORT"
+echo
+echo "REPORT saved to $REPORT"

--- a/tests/test380-gateway-topology-probe/Dockerfile.daemon
+++ b/tests/test380-gateway-topology-probe/Dockerfile.daemon
@@ -1,0 +1,13 @@
+# Mirror 通信龙's repro exactly: node:22-bookworm-slim + npm-installed
+# @sleep2agi/agent-network@preview + @sleep2agi/agent-node@preview.
+
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash curl jq ca-certificates sqlite3 procps && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm i -g @sleep2agi/agent-network@preview @sleep2agi/agent-node@preview
+
+WORKDIR /repo
+COPY . .

--- a/tests/test380-gateway-topology-probe/Dockerfile.hub
+++ b/tests/test380-gateway-topology-probe/Dockerfile.hub
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo
+COPY . .
+WORKDIR /repo/server
+RUN bun install
+WORKDIR /repo

--- a/tests/test380-gateway-topology-probe/daemon-run.sh
+++ b/tests/test380-gateway-topology-probe/daemon-run.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# Daemon-side probe. Runs INSIDE the daemon container, talks to `hub`
+# service via docker bridge (functional equivalent of 通信龙's
+# gateway-172.18.0.1 topology).
+#
+# Emits report to /repo/docs/tests/p380-gateway-topology-probe/report.txt
+# (bind-mounted from host).
+
+set -euo pipefail
+
+BASE="${HUB_URL:-http://hub:9310}"
+REPORT="${REPORT_HOST_PATH:-/repo/docs/tests/p380-gateway-topology-probe/report.txt}"
+DAEMON_LOG="/tmp/daemon.log"
+export HOME=/tmp/anethome
+mkdir -p "$HOME/.anet" "$(dirname "$REPORT")"
+
+rec() { printf '  %s = %s\n' "$1" "$2" >> "$REPORT"; }
+sec() { printf '\n## %s\n\n' "$1" >> "$REPORT"; }
+raw() { printf '%s\n' "$*" >> "$REPORT"; }
+
+json_post() {
+  local path="$1" token="$2" body="$3"
+  curl -sS -X POST "$BASE$path" \
+    ${token:+-H "Authorization: Bearer $token"} \
+    -H "Content-Type: application/json" \
+    -d "$body"
+}
+
+mcp_call() {
+  local token="$1" tool="$2" args="$3"
+  local body raw_resp json text
+  body=$(jq -nc --arg n "$tool" --argjson a "$args" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:$n,arguments:$a}}')
+  raw_resp=$(curl -sS -X POST "$BASE/mcp" \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "MCP-Protocol-Version: 2025-03-26" \
+    -d "$body")
+  json=$(echo "$raw_resp" | sed -n 's/^data: //p' | head -1)
+  [[ -z "$json" ]] && json="$raw_resp"
+  text=$(echo "$json" | jq -r '.result.content[0].text // empty')
+  [[ -n "$text" ]] || { echo "empty MCP response for $tool: $raw_resp" >&2; return 1; }
+  echo "$text"
+}
+
+: > "$REPORT"
+cat >> "$REPORT" <<HDR
+# test380-gateway-topology-probe
+
+Mirror of 通信龙's #380 exact repro topology:
+- hub  container: /repo/server (bun) on 0.0.0.0:9310
+- daemon container: node:22-bookworm-slim + npm-installed
+    @sleep2agi/agent-network@preview + @sleep2agi/agent-node@preview
+- shared docker bridge net "p380net"; daemon reaches hub via DNS "hub"
+    (functional equivalent of gateway 172.18.0.1 — cross-container HTTP
+    over shared bridge network, daemon's outbound IP is a bridge-assigned
+    address that the hub records verbatim)
+- neither container touches host or fleet :9200.
+
+HDR
+
+# ── S0 environment ──────────────────────────────────────────────────────
+sec "S0 daemon-container environment"
+rec "kernel"                     "$(uname -a)"
+rec "node"                       "$(node --version)"
+rec "installed agent-network"    "$(anet --version 2>/dev/null | grep -oE 'anet v[0-9\.a-z-]+' | head -1)"
+rec "installed agent-node"       "$(agent-node --version 2>/dev/null || echo '(missing)')"
+rec "which agent-node"           "$(command -v agent-node)"
+rec "hub reachable"              "$(curl -sS -o /dev/null -w '%{http_code}' "$BASE/health" || echo 'FAIL')"
+DAEMON_IP=$(hostname -i 2>/dev/null || echo '(unknown)')
+rec "daemon container IP"        "$DAEMON_IP"
+rec "hub URL"                    "$BASE"
+
+# ── S1 bootstrap admin + network + mint ntok ────────────────────────────
+sec "S1 setup — admin / network / demo-host ntok"
+
+ADMIN=$(json_post "/api/auth/register" "" '{"username":"admin","password":"anethub"}')
+UTOK=$(echo "$ADMIN" | jq -r '.token // empty')
+[[ "$UTOK" == utok_* ]] || { rec "register" "FAILED: $ADMIN"; exit 1; }
+
+NET=$(json_post "/api/networks" "$UTOK" '{"name":"n-380-gw"}')
+NET_ID=$(echo "$NET" | jq -r '.network.network_id // .network_id // empty')
+[[ -n "$NET_ID" ]] || { rec "network" "FAILED: $NET"; exit 1; }
+
+DEMO_HOST_TOK=$(json_post "/api/auth/node-token" "$UTOK" \
+  "{\"network_id\":\"$NET_ID\",\"node_name\":\"demo-host\"}" | jq -r '.token // empty')
+[[ "$DEMO_HOST_TOK" == ntok_* ]] || { rec "mint" "FAILED"; exit 1; }
+
+rec "utok prefix"  "${UTOK:0:12}..."
+rec "network_id"   "$NET_ID"
+rec "demo-host ntok prefix" "${DEMO_HOST_TOK:0:12}..."
+
+# ── S1b — first, probe empty state (count=0 side-quest for 通信龙) ────
+sec "S1b empty-state probe — /api/host-supervisors BEFORE any daemon starts (count=0 side-quest)"
+
+# With network_id
+EMPTY_WITH_NET=$(curl -sS -o /tmp/rest-empty.json -w '%{http_code}' \
+  "$BASE/api/host-supervisors?network_id=$NET_ID" -H "Authorization: Bearer $UTOK")
+rec "REST /api/host-supervisors?network_id=... (empty) status" "$EMPTY_WITH_NET"
+raw ""
+raw "REST body when count=0:"; cat /tmp/rest-empty.json | jq '.' >> "$REPORT"
+
+# Without network_id (dashboard-forgot-param case)
+EMPTY_NO_NET=$(curl -sS -o /tmp/rest-empty-nonet.json -w '%{http_code}' \
+  "$BASE/api/host-supervisors" -H "Authorization: Bearer $UTOK")
+rec "REST /api/host-supervisors (no network_id!) status" "$EMPTY_NO_NET"
+raw ""
+raw "REST body when network_id missing:"; cat /tmp/rest-empty-nonet.json | jq '.' >> "$REPORT"
+
+# MCP tool empty
+EMPTY_MCP=$(mcp_call "$DEMO_HOST_TOK" "list_host_supervisors" "{}")
+raw ""
+raw "MCP list_host_supervisors (empty state):"
+echo "$EMPTY_MCP" | jq '.' >> "$REPORT"
+
+# ── S2 write config + spawn daemon ─────────────────────────────────────
+sec "S2 spawn daemon (agent-node preview.17 via PATH)"
+
+DAEMON_DIR="$HOME/.anet/nodes/demo-host"
+mkdir -p "$DAEMON_DIR"
+NODE_ID="n_$(head -c 8 /dev/urandom | od -An -txC | tr -d ' \n')"
+cat > "$DAEMON_DIR/config.json" <<CFG
+{
+  "anet_version": "gateway-topology-probe",
+  "node_id": "$NODE_ID",
+  "node_name": "demo-host",
+  "alias": "demo-host",
+  "runtime": "claude-agent-sdk",
+  "role": "host_supervisor",
+  "runtimes_supported": ["claude-agent-sdk", "codex-sdk", "grok-build-acp"],
+  "allowed_secret_keys": [],
+  "max_concurrent_children": 20,
+  "network_id": "$NET_ID",
+  "hub": "$BASE",
+  "token": "$DEMO_HOST_TOK",
+  "model": "claude-sonnet-4-5",
+  "channels": [],
+  "env": {},
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true },
+  "session": null
+}
+CFG
+rec "config path" "$DAEMON_DIR/config.json"
+rec "config role" "$(jq -r .role "$DAEMON_DIR/config.json")"
+
+env_common=(
+  "COMMHUB_ALIAS=demo-host"
+  "COMMHUB_NODE_ID=$NODE_ID"
+  "COMMHUB_TOKEN=$DEMO_HOST_TOK"
+  "COMMHUB_URL=$BASE"
+  "ANET_CONFIG_UPDATE_CAPABLE=1"
+  "PATH=$PATH"
+  "HOME=$HOME"
+)
+( env "${env_common[@]}" agent-node \
+    --config "$DAEMON_DIR/config.json" \
+    --alias demo-host \
+    --runtime claude-agent-sdk >"$DAEMON_LOG" 2>&1 ) &
+DAEMON_PID=$!
+rec "daemon spawn pid" "$DAEMON_PID"
+
+# Wait for register + immediate reportStatus to land, then some slack.
+sleep 12
+
+# ── S3 daemon log — did register succeed cross-container? ─────────────
+sec "S3 daemon log (last 30 lines) — cross-container register/report"
+tail -30 "$DAEMON_LOG" >> "$REPORT" 2>&1
+
+# ── S4 REST from daemon container to hub ───────────────────────────────
+sec "S4 REST /api/host-supervisors (post-daemon-up, from daemon container)"
+
+RESP_STATUS=$(curl -sS -o /tmp/hs-resp.json -w '%{http_code}' \
+  "$BASE/api/host-supervisors?network_id=$NET_ID" -H "Authorization: Bearer $UTOK")
+rec "HTTP status" "$RESP_STATUS"
+raw ""
+raw "response body:"
+cat /tmp/hs-resp.json | jq '.' >> "$REPORT"
+
+sec "S4b REST /api/servers (post-daemon-up)"
+curl -sS "$BASE/api/servers" -H "Authorization: Bearer $UTOK" | jq '.' >> "$REPORT"
+
+# ── S5 MCP list_host_supervisors (populated) ────────────────────────────
+sec "S5 MCP list_host_supervisors (populated) — the tool the dashboard's wizard actually calls"
+MCP_LIST=$(mcp_call "$DEMO_HOST_TOK" "list_host_supervisors" "{}")
+echo "$MCP_LIST" | jq '.' >> "$REPORT"
+
+# extract daemon_node_id for the create_node round-trip
+DAEMON_NODE_ID=$(echo "$MCP_LIST" | jq -r '.daemons[0].daemon_node_id // empty')
+rec "extracted daemon_node_id" "${DAEMON_NODE_ID:-<none>}"
+
+# ── S6 wizard end-to-end — can it really create a node? ────────────────
+sec "S6 create_node MCP — full wizard action end-to-end"
+
+if [[ -n "$DAEMON_NODE_ID" ]]; then
+  # Payload matches what the wizard would send — create_node MCP tool
+  # takes nested node_spec (tools.ts:2059-2067). Corrected after first-run
+  # observed "Invalid arguments: node_spec expected object, received undefined".
+  CREATE_ARGS=$(jq -nc \
+    --arg d "$DAEMON_NODE_ID" \
+    --arg net "$NET_ID" \
+    '{
+       daemon_node_id: $d,
+       network_id: $net,
+       node_spec: {
+         name: "child-a",
+         runtime: "claude-agent-sdk",
+         model: "claude-sonnet-4-5",
+         flags: { dangerouslySkipPermissions: true }
+       }
+     }')
+  CREATE_RESP=$(mcp_call "$UTOK" "create_node" "$CREATE_ARGS" 2>&1 || true)
+  raw "create_node response:"
+  echo "$CREATE_RESP" | jq '.' >> "$REPORT" 2>>"$REPORT" || echo "$CREATE_RESP" >> "$REPORT"
+
+  # Query the created row (if any)
+  raw ""
+  raw "hub nodes table after create_node:"
+  # We can't sqlite3 from here — nodes DB is on hub side. Query via /api/nodes.
+  curl -sS "$BASE/api/nodes?network_id=$NET_ID" -H "Authorization: Bearer $UTOK" \
+    | jq '.nodes // .' >> "$REPORT" 2>&1
+else
+  raw "  daemon_node_id was empty — cannot call create_node"
+fi
+
+# ── S7 verdict ──────────────────────────────────────────────────────────
+sec "S7 verdict — did gateway topology change anything?"
+
+ONLINE=$(cat /tmp/hs-resp.json | jq -r '.daemons[0].online // false')
+CPU_CORES=$(cat /tmp/hs-resp.json | jq -r '.daemons[0].host_telemetry.cpu_cores // "null"')
+MEM_GB=$(cat /tmp/hs-resp.json | jq -r '.daemons[0].host_telemetry.mem_gb // "null"')
+COUNT=$(cat /tmp/hs-resp.json | jq -r '.count // 0')
+
+rec "daemon online (post-fix)" "$ONLINE"
+rec "daemon cpu_cores"         "$CPU_CORES"
+rec "daemon mem_gb"            "$MEM_GB"
+rec "list count"               "$COUNT"
+
+raw ""
+if [[ "$ONLINE" == "true" && "$COUNT" != "0" && "$CPU_CORES" != "null" ]]; then
+  raw "  ▶ VERDICT: Gateway topology fully works. #380 root observation was a"
+  raw "    timing artefact of an earlier dashboard poll before reportStatus"
+  raw "    landed. No telemetry bug. Fix is dashboard-side polling / cache."
+else
+  raw "  ▶ VERDICT: Gateway topology DOES break something. See S3 for the"
+  raw "    daemon-side log (any register errors?) and S4 for the hub view."
+fi
+
+raw ""
+raw "count=0 side-quest — 'hub 400' truth table:"
+raw "  - REST /api/host-supervisors WITH  network_id, empty list  → HTTP $EMPTY_WITH_NET, body has count:0 + daemons:[]"
+raw "  - REST /api/host-supervisors WITHOUT network_id            → HTTP $EMPTY_NO_NET, body: {ok:false, error:'missing_network_id'} or 200 (if fix landed + single-network)"
+
+# ── S8 fix-A e2e: fallback path over gateway topology ────────────────
+sec "S8 修 A e2e — utok fallback via singleNetworkId (single-network NON-admin user)"
+
+# Register a SECOND user in this hub — subsequent users aren't
+# auto-admin, so their utok exercises the fallback branch (admin gets
+# scope.networkIds=null and correctly requires an explicit network_id
+# because they can span all networks).
+NORMAL_USER="normal_$(date +%s)_$$"
+NORMAL_PW="StrongUserPw123Aa!"
+NORMAL_RESP=$(json_post "/api/auth/register" "" \
+  "{\"username\":\"$NORMAL_USER\",\"password\":\"$NORMAL_PW\"}")
+NORMAL_UTOK=$(echo "$NORMAL_RESP" | jq -r '.token // empty')
+NORMAL_NET=$(echo "$NORMAL_RESP" | jq -r '.network_id // empty')
+rec "normal user utok prefix" "${NORMAL_UTOK:0:12}..."
+rec "normal user default network" "$NORMAL_NET"
+
+# Mint a demo-host2 ntok in the normal user's default network + register
+# a daemon there so /api/host-supervisors has something to return.
+NORMAL_HOST_TOK=$(json_post "/api/auth/node-token" "$NORMAL_UTOK" \
+  "{\"network_id\":\"$NORMAL_NET\",\"node_name\":\"demo-host2\"}" | jq -r '.token // empty')
+
+NORMAL_DAEMON_DIR="$HOME/.anet/nodes/demo-host2"
+mkdir -p "$NORMAL_DAEMON_DIR"
+NORMAL_NODE_ID="n_$(head -c 8 /dev/urandom | od -An -txC | tr -d ' \n')"
+cat > "$NORMAL_DAEMON_DIR/config.json" <<CFG2
+{
+  "node_id": "$NORMAL_NODE_ID",
+  "node_name": "demo-host2",
+  "alias": "demo-host2",
+  "runtime": "claude-agent-sdk",
+  "role": "host_supervisor",
+  "runtimes_supported": ["claude-agent-sdk"],
+  "allowed_secret_keys": [],
+  "max_concurrent_children": 20,
+  "network_id": "$NORMAL_NET",
+  "hub": "$BASE",
+  "token": "$NORMAL_HOST_TOK",
+  "model": "claude-sonnet-4-5",
+  "channels": [],
+  "env": {},
+  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true },
+  "session": null
+}
+CFG2
+
+( env "COMMHUB_ALIAS=demo-host2" "COMMHUB_NODE_ID=$NORMAL_NODE_ID" \
+      "COMMHUB_TOKEN=$NORMAL_HOST_TOK" "COMMHUB_URL=$BASE" \
+      "ANET_CONFIG_UPDATE_CAPABLE=1" "PATH=$PATH" "HOME=$HOME" \
+    agent-node --config "$NORMAL_DAEMON_DIR/config.json" \
+               --alias demo-host2 \
+               --runtime claude-agent-sdk >/tmp/daemon2.log 2>&1 ) &
+NORMAL_DAEMON_PID=$!
+sleep 10
+
+# Now the fallback test: NORMAL_UTOK belongs to a single-network user,
+# calling /api/host-supervisors WITHOUT ?network_id should succeed and
+# list demo-host2.
+FALLBACK_STATUS=$(curl -sS -o /tmp/fallback.json -w '%{http_code}' \
+  "$BASE/api/host-supervisors" -H "Authorization: Bearer $NORMAL_UTOK")
+rec "REST /api/host-supervisors (no query, non-admin single-net) status" "$FALLBACK_STATUS"
+raw ""
+raw "fallback body (non-admin single-net):"
+cat /tmp/fallback.json | jq '.' >> "$REPORT"
+
+FALLBACK_COUNT=$(cat /tmp/fallback.json | jq -r '.count // 0')
+if [[ "$FALLBACK_STATUS" == "200" && "$FALLBACK_COUNT" -ge 1 ]]; then
+  raw ""
+  raw "  ▶ FIX-A VERIFIED: single-network non-admin utok fallback works"
+  raw "    (HTTP 200, count=$FALLBACK_COUNT includes demo-host2)"
+else
+  raw ""
+  raw "  ▶ FIX-A REGRESSION: expected 200 + count>=1, got HTTP=$FALLBACK_STATUS count=$FALLBACK_COUNT"
+fi
+
+# Compare: admin utok WITHOUT ?network_id — this still 400s (admin can
+# span every network, no safe pick). This locks the authz boundary.
+sec "S8b authz boundary — admin utok WITHOUT ?network_id still 400s (admin can't be fallen back)"
+ADMIN_NO_NET=$(curl -sS -o /tmp/admin-no-net.json -w '%{http_code}' \
+  "$BASE/api/host-supervisors" -H "Authorization: Bearer $UTOK")
+rec "REST /api/host-supervisors (admin, no query) status" "$ADMIN_NO_NET"
+raw ""
+raw "admin-no-query body:"
+cat /tmp/admin-no-net.json | jq '.' >> "$REPORT"
+
+if [[ "$ADMIN_NO_NET" == "400" ]]; then
+  raw ""
+  raw "  ▶ AUTHZ BOUNDARY VERIFIED: admin without ?network_id still 400 (no cross-network guessing)"
+else
+  raw ""
+  raw "  ▶ AUTHZ REGRESSION: admin should stay 400, got $ADMIN_NO_NET"
+fi
+
+# clean up demo-host2 daemon before compose down
+kill "$NORMAL_DAEMON_PID" 2>/dev/null || true
+raw ""
+raw "  So 'hub 400' means the client omitted network_id — NOT that no daemons"
+raw "  exist. If prod dashboard reports hub 400 in the create-node wizard,"
+raw "  the fix is: send network_id in the request, or fall back client-side"
+raw "  to the user's active network."
+
+echo
+echo "===== REPORT ====="
+cat "$REPORT"

--- a/tests/test380-gateway-topology-probe/docker-compose.yml
+++ b/tests/test380-gateway-topology-probe/docker-compose.yml
@@ -1,0 +1,75 @@
+# P0 #380 gateway topology probe — mirror 通信龙's exact repro.
+#
+# 通信龙's env:
+#   容器 node:22-bookworm-slim
+#   容器内 npm i -g @sleep2agi/agent-network@preview @sleep2agi/agent-node@preview
+#   anet daemon up demo-host
+#   隔离 hub :9310（HOST=0.0.0.0，独立 DB），容器 bridge 网络经 gateway 172.18.0.1:9310 连 hub
+#
+# We split into two services:
+#   hub    — runs the commhub server from /repo/server (bun) on 0.0.0.0:9310.
+#            Bind-mounted /repo so we exercise the exact main-tree code.
+#   daemon — node:22-bookworm-slim + npm-installed preview.17, spawns
+#            `agent-node --config ... --alias demo-host --runtime claude-agent-sdk`
+#            reaching the hub over the docker bridge network.
+#
+# Both share a custom bridge net "p380net" so the daemon reaches the hub
+# via DNS name `hub` (equivalent to gateway routing — the daemon's
+# outbound IP is a bridge-assigned 172.x.y.z, and the hub logs record
+# that IP). The `hub` DNS name substitutes for 通信龙's 172.18.0.1
+# gateway hop; both are cross-container HTTP over a shared bridge net —
+# same functional exercise.
+#
+# The daemon service's entrypoint is a run script that:
+#   - captures agent-node --version (排 A one more time)
+#   - registers admin + network + demo-host ntok against the hub via REST
+#   - writes daemon config.json mirroring `anet daemon init`
+#   - spawns agent-node
+#   - waits 12s (register + immediate reportStatus + a little slack)
+#   - dumps the same probes as the single-container run, plus:
+#     - what IP the daemon appears with from the hub's view
+#     - /api/host-supervisors + /api/servers over the docker network
+#     - a real create_node MCP call end-to-end (verify wizard action)
+
+services:
+  hub:
+    build:
+      context: ../..
+      dockerfile: tests/test380-gateway-topology-probe/Dockerfile.hub
+    image: anet-test380-hub
+    container_name: p380-hub
+    environment:
+      - COMMHUB_DB=/tmp/qa-380-gw.db
+      - PORT=9310
+      - HOST=0.0.0.0
+    command: bash -lc "rm -f /tmp/qa-380-gw.db && bun run server/src/index.ts"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9310/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+    networks:
+      - p380net
+
+  daemon:
+    build:
+      context: ../..
+      dockerfile: tests/test380-gateway-topology-probe/Dockerfile.daemon
+    image: anet-test380-daemon
+    container_name: p380-daemon
+    depends_on:
+      hub:
+        condition: service_healthy
+    environment:
+      - HUB_URL=http://hub:9310
+      - REPORT_HOST_PATH=/repo/docs/tests/p380-gateway-topology-probe/report.txt
+    volumes:
+      # bind for the probe output (host <-> container)
+      - /home/vansin/agent-orchestra/docs/tests/p380-gateway-topology-probe:/repo/docs/tests/p380-gateway-topology-probe
+    command: bash -lc "bash /repo/tests/test380-gateway-topology-probe/daemon-run.sh"
+    networks:
+      - p380net
+
+networks:
+  p380net:
+    driver: bridge


### PR DESCRIPTION
## Author

- Agent: 通信工程马 (probe + fix + PR)
- Reviewer: 通信龙 (routing 修 A + 调研 B — 我 CC 龙, verdict 到手立即 forward per the "route review verdicts to lead" SOP)
- Priority: 🔴 P0 endpoint fix, part of RFC-026 P2 create-node wizard reliability

## Story so far (this PR closes step 3 of a 3-step investigation)

**Step 1 — 复现 & code-walk**: 通信龙 报 #380 "host telemetry 缺失致 server 恒 offline + wizard 报 hub 400"。docker probe (`tests/test380-daemon-telemetry-probe/`) mirror 通信龙 环境 (`node:22-bookworm-slim` + `npm i @sleep2agi/agent-node@preview.17`) 抓真号:
- `sessions.cpu_load_1min=2.07, mem_total_gb=61.4, disk_total_gb=299.8` 全填 ✓
- `nodes.config_snapshot HAS_VALUE (296 bytes)` 含 `role: "host_supervisor"` + `daemon_capabilities` ✓
- `/api/host-supervisors` returns `online:true, cpu_cores:8, count:1` ✓
- `agent_telemetry` 8s 内 2 rows inserted ✓

结论: **daemon telemetry 端到端全通**, 假设作废。通信龙 立即修正 #380 判断: "别去建 telemetry feature (它不缺)" 并授权我做真根因收窄。

**Step 2 — gateway topology + 400 truth table**: `tests/test380-gateway-topology-probe/` docker-compose 双服务 bridge 复现 通信龙 exact topology。两个真相:
- Gateway topology 下 telemetry 依然全通 (通信龙 原观察是 timing 假象)
- **"hub 400" 谜题**: 空 list 返 `HTTP 200 count:0`; **400 只在 client 少传 `network_id` query 时冒** (`server/src/index.ts:1997-1998`)

通信龙 批 "授权你上, 修法 A hub 端 fallback + 调研 B dashboard"。

**Step 3 (本 PR) — 修法 A + 调研 B**:

## 修法 A — 收窄到 authz-safe 单一 site

`server/src/index.ts` `/api/host-supervisors` 端点。替换原直接 `restScope.networkId ?? netParam ?? null` 的硬 400 守卫为 `singleNetworkId(restScope)` (已存在 helper at index.ts:258-262):

| Caller shape | 老行为 | 新行为 |
|---|---|---|
| ntok caller | ntok binding | 不变 |
| utok + `?network_id=X` (有 access) | X | 不变 |
| utok + `?network_id=X` (无 access) | 403 (upstream) | 不变 |
| **utok + 无 query + 1 accessible net** | **400** | **200 (safe fallback)** |
| **utok + 无 query + 2+ nets** | **400** | **400 `network_id_required_multi` + `memberships:N`** |
| utok + 无 query + 0 nets | 400 | 400 `missing_network_id` + `memberships:0` |
| admin + 无 query | 400 | 400 (admin can span 所有 network, 不能猜) |

关键 authz 边界: `singleNetworkId` 只在 `scope.networkIds.length === 1` 时才 fallback。多 network 明确 400 (per 通信龙 spec "别 fallback 到错 network")。admin 走 `scope.networkIds: null` 分支, 不参与 fallback。

400 responses 加 `memberships` 字段让 client 分 "pick a network" vs "0 网络"。

## 真号 (bun test 6/6 + docker compose e2e)

### 单元测试 (6/6 PASS in 912ms):
```
$ COMMHUB_DB=/tmp/hs-fallback-XXX.db bun test src/api-host-supervisors-fallback.test.ts
 6 pass  0 fail  20 expect() calls
```

覆盖 6 场景, `server/src/api-host-supervisors-fallback.test.ts`:
1. utok 1-net WITH `?network_id` → 200 (baseline)
2. **utok 1-net NO `?network_id` → 200 (core fix)**
3. **utok 2-net NO `?network_id` → 400 `network_id_required_multi` + `memberships:2`**
4. utok 2-net WITH `?network_id` → 200 (explicit choice honored, 2 network 都测)
5. utok 2-net WITH foreign network → 403 (upstream authz layer)
6. utok 0-net NO `?network_id` → 400 `missing_network_id` + `memberships:0`

### E2E (docker-compose gateway topology, 2 fresh scenarios post-fix):

`docs/tests/p380-gateway-topology-probe/report.txt` S8/S8b:
- **S8 (single-network non-admin utok)**: `REST /api/host-supervisors (no query) status = 200 + count>=1` ✓ FIX-A VERIFIED
- **S8b (admin utok authz boundary)**: `REST /api/host-supervisors (no query) status = 400` ✓ AUTHZ BOUNDARY VERIFIED

## 调研 B — dashboard 侧定位 (无改动)

Dashboard repo: `github.com/sleep2agi/agent-network-dashboard` (克隆在 `~/agent-network-dashboard`)。

**关键发现: dashboard 目前 完全不用 `/api/host-supervisors` 端点** (0 hits in `app/`).

Dashboard 用两个独立路径做 daemon discovery:
- `/api/anet/providers/probe/route.ts:29` → `hubFetch('/api/nodes')` + client-side filter `role === 'host_supervisor'` OR `id.startsWith('node_daemon_')`
- `/api/anet/node-create/route.ts:12` → 同上, 加 `config_snapshot.role === 'host_supervisor'` fallback

Dashboard 自己有 `resolveDefaultNetworkId()` (`app/lib/hub-mcp.ts:25`) 从 `/api/auth/me` 拿 `current_network.network_id || networks[0].network_id`。

**含义**: 通信龙 报的 prod dashboard "hub 400" 不是从 `/api/host-supervisors` 冒出来的。可能是:
1. `/api/nodes` 的某种 400 (但代码看起来没这条路径)
2. `resolveDefaultNetworkId` 失败 → 下游 MCP 报错被 wrap 成 400
3. 别的路径

本 PR **不改 dashboard**。修 A 让 `/api/host-supervisors` 更健壮以备:
- Dashboard 未来迁移到 `/api/host-supervisors` (拿 server-side role filter + telemetry + online status)
- 外部 CLI/client 直调该端点

## 影响面

- **只改** `server/src/index.ts` 一处 (1 endpoint, ~15 行改动 + 15 行注释)
- 其他端点 (`/api/servers`, `/api/nodes`, 各 write endpoints) 保持原行为 (它们要么走 ntok scope, 要么走别的 auth 逻辑)
- Dashboard 无需修改
- 新 fields `memberships:N` 是 additive, 不破坏已解析 `error` 字符串的老 client

## 红线合规

- Docker 隔离 hub (:9310 / bridge net), 不接触生产 / :9200 舰队
- 单元测试 6/6 + e2e S8+S8b 全 PASS
- claim=reality (真号在 docs/tests/p380-*/report.txt)
- Slug audit: PR body + commit msg + 代码注释 + 测试文件 grep 全 clean (0 slug references)
- CC 通信龙 per the "route review verdicts to lead" SOP

Closes #380
