### PR TITLE
fix(#383): rescue thinking-only terminal turns + vendor-agnostic user error

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -62,6 +62,8 @@ import {
 import {
   classifyRuntimeResult,
   formatClassificationError,
+  formatClassificationForUser,
+  formatClassificationForLog,
 } from "./runtime/classify-result";
 import { withTimeout, TimeoutError, resolveTimeoutMs } from "./util/timeout";
 import { superviseChild } from "./util/supervise-child";
@@ -1921,8 +1923,93 @@ async function processWithClaude(task: string, from: string, images?: string[]):
                 if (cls.kind === "success") {
                   inner = m.result;
                 } else {
+                  // #383 — thinking-only terminal turn rescue (fix ①).
+                  //
+                  // Thinking-capable models (Kimi K2, MiniMax-M3, Anthropic
+                  // extended-thinking) sometimes end a tool-heavy turn on a
+                  // `thinking` block only — no `text` block — so the SDK
+                  // aggregates `m.result === ""`. Pre-fix we shipped a
+                  // developer diagnostic ("执行出错: claude-agent-sdk 返回空
+                  // 响应 (in=… out=…). 可能原因: (a) (b) (c). → 检查 <hard-
+                  // coded single vendor console URL>") straight to the IM
+                  // user, which was BOTH confusing AND misleading (the URL
+                  // was one vendor's dashboard even after the runtime moved
+                  // to another vendor).
+                  //
+                  // Rescue precedence (per 通信龙 review):
+                  //   (a) If the terminal turn genuinely has text → SDK's
+                  //       `m.result` already carries it; already handled.
+                  //   (b) `m.result === ""` AND we have an established
+                  //       session AND at least one turn ran → re-prompt
+                  //       ONCE for a plain-text final (session resume,
+                  //       short new prompt). This is the REAL fix — it
+                  //       coaxes the model into writing its final answer
+                  //       out loud.
+                  //   (c) Re-prompt also empty → short vendor-agnostic
+                  //       apology. Do NOT reach back to text blocks from
+                  //       earlier turns (would show the model's "let me
+                  //       check that" mid-thought as the final answer).
+                  //
+                  // Gated to `soft-fail-empty` classifier with the
+                  // "empty vendor result despite success signal" reason —
+                  // the other soft-fail-empty flavor (in=0 out=0 cost=0
+                  // silent reject) means the vendor is broken, not the
+                  // model choosing thinking-only; re-prompt would burn
+                  // tokens for nothing.
+                  const isThinkingOnlyShape = cls.kind === "soft-fail-empty"
+                    && cls.reason === "empty vendor result despite success signal"
+                    && !!claudeSessionId
+                    && (m.num_turns ?? 0) >= 1
+                    && process.env.ANET_DISABLE_383_REPROMPT !== "1";
+
+                  // Operator log (full diagnostic incl. vendor URL hint) —
+                  // regardless of whether we rescue or not.
                   log(`[claude] ✗ ${cls.reason || cls.kind} (in=${u.input_tokens || 0}, out=${u.output_tokens || 0}, cost=${m.total_cost_usd ?? "?"})`);
-                  inner = formatClassificationError(cls, { runtime: "claude-agent-sdk", usage: m.usage });
+                  log(`[claude] ${formatClassificationForLog(cls, { runtime: "claude-agent-sdk", usage: m.usage })}`);
+
+                  if (isThinkingOnlyShape) {
+                    log(`[claude] #383 re-prompting for plain-text final (session=${claudeSessionId?.slice(0, 8)})`);
+                    let rescuedText = "";
+                    try {
+                      const rescueOptions = {
+                        ...options,
+                        resume: claudeSessionId,
+                        abortController: ac,
+                        // A shallow follow-up shouldn't loop back into
+                        // tool-use again; capping turns prevents a
+                        // pathological re-thinking loop from burning
+                        // tokens. If the model *still* only thinks in
+                        // one turn, we fall through to the apology.
+                        maxTurns: 1,
+                      } as any;
+                      const rescuePrompt =
+                        "请用一句面向用户的纯文本给出最终答复（不要用工具，不要 thinking，直接写答案）。";
+                      for await (const rmsg of query({
+                        prompt: rescuePrompt,
+                        options: rescueOptions,
+                      })) {
+                        const rm = rmsg as any;
+                        if (rm.type === "result" && rm.subtype === "success") {
+                          const rusage = rm.usage || {};
+                          log(`[claude] #383 re-prompt result | in=${rusage.input_tokens || 0} out=${rusage.output_tokens || 0} | got=${(rm.result || "").length}ch`);
+                          rescuedText = rm.result || "";
+                          break;
+                        }
+                      }
+                    } catch (e: any) {
+                      log(`[claude] #383 re-prompt failed: ${e?.message || e}`);
+                    }
+                    if (rescuedText && rescuedText.trim()) {
+                      inner = rescuedText;
+                    } else {
+                      inner = formatClassificationForUser(cls, { runtime: "claude-agent-sdk", usage: m.usage });
+                    }
+                  } else {
+                    // Non-thinking-only path (in=0 out=0 cost=0 silent
+                    // reject, or session-less first-turn empty): skip
+                    // re-prompt, show the short user-safe message.
+                    inner = formatClassificationForUser(cls, { runtime: "claude-agent-sdk", usage: m.usage });
+                  }
                 }
               } else {
                 inner = `执行出错: ${m.error || m.result || "未知错误"}`;
@@ -2206,8 +2293,11 @@ async function processWithCodex(task: string, from: string, images?: string[]): 
       { baseUrl: process.env.OPENAI_BASE_URL || process.env.OPENAI_API_BASE },
     );
     if (cls.kind !== "success") {
+      // #383 fix ② — user gets short vendor-agnostic message; operator
+      // log carries the full diagnostic (incl. quota console URL).
       log(`[codex] ✗ ${cls.reason || cls.kind} (in=${inTokens}, out=${outcome.usage?.output_tokens || 0})`);
-      return formatClassificationError(cls, { runtime: "codex-sdk", usage: outcome.usage });
+      log(`[codex] ${formatClassificationForLog(cls, { runtime: "codex-sdk", usage: outcome.usage })}`);
+      return formatClassificationForUser(cls, { runtime: "codex-sdk", usage: outcome.usage });
     }
     return outcome.finalResponse || "（无回复）";
   } catch (e: any) {

--- a/agent-node/src/runtime/classify-result.ts
+++ b/agent-node/src/runtime/classify-result.ts
@@ -164,35 +164,80 @@ export function formatClassificationError(
   c: ClassificationResult,
   context: { runtime: string; usage?: RuntimeResultLike["usage"] },
 ): string {
-  const inT = context.usage?.input_tokens ?? 0;
-  const outT = context.usage?.output_tokens ?? 0;
+  // Legacy alias kept for callers that don't yet distinguish user vs
+  // operator surface. New code should call `formatClassificationForUser`
+  // (short, vendor-agnostic, IM-safe) and `formatClassificationForLog`
+  // (long, includes vendor console URL) explicitly.
+  return formatClassificationForLog(c, context);
+}
+
+/**
+ * #383 — user-facing rendering split (fix ②). The old
+ * `formatClassificationError` shipped a developer diagnostic block plus
+ * a HARDCODED SINGLE VENDOR console URL to end users. Two problems:
+ *   - Users get a technical stack (in= out=, "可能原因 (a) (b) (c)")
+ *     they can't act on.
+ *   - When the runtime is configured against a vendor whose URL is
+ *     NOT hardcoded, the (single vendor) URL is misleading — after
+ *     the Kimi rollover it kept pointing users at MiniMax's dashboard.
+ *
+ * Split: `ForUser` is IM-safe (short, vendor-agnostic, no URL); `ForLog`
+ * keeps the rich diagnostic (with URL) for the operator's log file. IM
+ * bridges / commhub bridges / dashboard chat should call `ForUser` and
+ * let the log-only path keep the actionable-for-operator wording.
+ */
+export function formatClassificationForUser(
+  c: ClassificationResult,
+  context: { runtime: string; usage?: RuntimeResultLike["usage"] },
+): string {
   switch (c.kind) {
     case "soft-fail-quota": {
-      // §20 — friendly Chinese prefix + vendor phrase pass-through +
-      // known code tag. If no vendor phrase is extractable, fall back
-      // to the truncated raw reason.
+      // Users can't fix a vendor quota, but knowing the account is
+      // out-of-quota IS useful (they'll ping their admin). Keep the
+      // vendor-native phrase (already vendor-agnostic — just Chinese
+      // text) and code tag, DROP the URL hint.
       const raw = c.reason || "";
       const phrase = extractVendorQuotaPhrase(raw);
       const code = extractQuotaCode(raw);
       const codeTag = code ? ` [${code}]` : "";
-      const body =
-        phrase ??
-        raw.slice(0, 200); // fall back to raw when no known phrase
+      const body = phrase ?? raw.slice(0, 200);
+      return `[额度用尽]${codeTag} ${body}`.trim();
+    }
+    case "soft-fail-empty":
+      // Reached ONLY when re-prompt (cli.ts follow-up) also failed to
+      // produce text — every earlier layer should have rescued a real
+      // reply already. Short vendor-agnostic apology.
+      return "抱歉，本轮暂时没能给出答复，请再问我一次。";
+    case "error":
+      // Errors get a compact one-liner. Truncate hard so a chatty
+      // vendor error doesn't wall-of-text a user.
+      return `请求出错，请稍后重试。`;
+    case "success":
+      return "";
+  }
+}
+
+/**
+ * #383 — operator-log rendering (fix ②). Keeps the rich diagnostic that
+ * used to leak into user replies. Only the log line at cli.ts /
+ * runtime-wrappers should call this.
+ */
+export function formatClassificationForLog(
+  c: ClassificationResult,
+  context: { runtime: string; usage?: RuntimeResultLike["usage"] },
+): string {
+  const inT = context.usage?.input_tokens ?? 0;
+  const outT = context.usage?.output_tokens ?? 0;
+  switch (c.kind) {
+    case "soft-fail-quota": {
+      const raw = c.reason || "";
+      const phrase = extractVendorQuotaPhrase(raw);
+      const code = extractQuotaCode(raw);
+      const codeTag = code ? ` [${code}]` : "";
+      const body = phrase ?? raw.slice(0, 200);
       return `执行出错: [额度用尽]${codeTag} ${context.runtime}: ${body}${c.hint ? ` — ${c.hint}` : ""}`;
     }
     case "soft-fail-empty":
-      // §20 — soft-fail-empty is subtler: the vendor said "success"
-      // but returned nothing. Common causes (in order):
-      //   1. Content filter fired on a credential literal in the
-      //      request (Vincent PAT case — content filter drops
-      //      response but marks 200 OK).
-      //   2. Silent throttle at the vendor's format-conversion layer
-      //      (MiniMax /anthropic gateway occasionally does this).
-      //   3. Model produced only reasoning/thinking blocks with no
-      //      text content (reasoning-heavy prompt + inadequate
-      //      max_tokens).
-      // We surface all three as hints so operators can triage without
-      // guessing.
       return (
         `执行出错: ${context.runtime} 返回空响应 (in=${inT} out=${outT}). ` +
         `可能原因: (a) vendor 内容过滤 (请求含 credential 字面, 见 [outbound-mask] 日志) ` +
@@ -203,7 +248,6 @@ export function formatClassificationError(
     case "error":
       return `执行出错: ${context.runtime} — ${(c.reason || "未知错误").slice(0, 200)}`;
     case "success":
-      // Caller should only invoke this on non-success; defensive default.
       return "";
   }
 }

--- a/tests/test383-thinking-only-fallback/Dockerfile.harness
+++ b/tests/test383-thinking-only-fallback/Dockerfile.harness
@@ -1,0 +1,34 @@
+# Harness: uses REAL @anthropic-ai/claude-agent-sdk (real vendor client)
+# + agent-node SOURCE (TypeScript, imported directly by the harness via
+# absolute path `/agent-node-src/src/runtime/classify-result`; bun runs
+# TS natively so no build step is required). Isolates the classifier +
+# formatter under review from any npm-published version.
+
+FROM oven/bun:1.3.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl jq ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /harness
+
+# Copy the full agent-node source tree so /agent-node-src/src/... is
+# resolvable. No compile step; bun eats TS directly.
+COPY agent-node /agent-node-src
+COPY tests/test383-thinking-only-fallback/harness.ts /harness/harness.ts
+
+# Minimal package to pull in the SDK version we're testing against.
+RUN cat > /harness/package.json <<'JSON'
+{
+  "name": "test383-harness",
+  "type": "module",
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.141"
+  }
+}
+JSON
+
+COPY tests/test383-thinking-only-fallback/run.sh /harness/run.sh
+RUN chmod +x /harness/run.sh && bun install
+
+CMD ["bash", "-lc", "bash /harness/run.sh"]

--- a/tests/test383-thinking-only-fallback/Dockerfile.mock
+++ b/tests/test383-thinking-only-fallback/Dockerfile.mock
@@ -1,0 +1,9 @@
+FROM oven/bun:1.3.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /mock
+COPY tests/test383-thinking-only-fallback/mock-anthropic.ts /mock/mock-anthropic.ts
+
+CMD ["bun", "run", "/mock/mock-anthropic.ts"]

--- a/tests/test383-thinking-only-fallback/docker-compose.yml
+++ b/tests/test383-thinking-only-fallback/docker-compose.yml
@@ -1,0 +1,58 @@
+# #383 e2e — real @anthropic-ai/claude-agent-sdk + real agent-node
+# classifier/formatter code (source under review) + mocked vendor SSE
+# endpoint. Two harness modes (--pre-fix / --post-fix) demonstrate the
+# fix in the same process — pre-fix reproduces the exact user-visible
+# error the issue quotes; post-fix produces a real rescued reply from
+# the mock model.
+#
+# Both services on an isolated bridge net; no host / fleet touch.
+services:
+  mock-vendor:
+    build:
+      context: ../..
+      dockerfile: tests/test383-thinking-only-fallback/Dockerfile.mock
+    image: anet-test383-mock
+    container_name: p383-mock
+    environment:
+      - PORT=9400
+      - HOST=0.0.0.0
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9400/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+    networks:
+      p383net:
+        # Alias so ANTHROPIC_BASE_URL includes the substring "anthropic",
+        # which triggers `quotaRemediationHint` to return the
+        # console.anthropic.com URL — the exact vendor-console-URL leak
+        # the #383 issue reports. Real prod hits this for minimax /
+        # kimi / deepseek / etc. via their live domain strings.
+        aliases:
+          - anthropic-mock
+
+  harness:
+    build:
+      context: ../..
+      dockerfile: tests/test383-thinking-only-fallback/Dockerfile.harness
+    image: anet-test383-harness
+    container_name: p383-harness
+    depends_on:
+      mock-vendor:
+        condition: service_healthy
+    environment:
+      # Use the "anthropic-mock" alias so the hardcoded vendor URL leak
+      # in quotaRemediationHint fires (base.includes("anthropic") →
+      # console.anthropic.com). Any real vendor domain would fire the
+      # same code path; we choose anthropic here so this test is not
+      # tied to any specific 3rd-party vendor.
+      - ANTHROPIC_BASE_URL=http://anthropic-mock:9400
+      - ANTHROPIC_API_KEY=fake-key-for-test
+    volumes:
+      - /home/vansin/agent-orchestra/docs/tests/p383-thinking-only-fallback:/report
+    networks:
+      - p383net
+
+networks:
+  p383net:
+    driver: bridge

--- a/tests/test383-thinking-only-fallback/harness.ts
+++ b/tests/test383-thinking-only-fallback/harness.ts
@@ -1,0 +1,161 @@
+// #383 e2e harness — real @anthropic-ai/claude-agent-sdk + real classifier
+// against the mock-anthropic SSE endpoint. Two modes replay the SAME walker
+// structure that lives at agent-node/src/cli.ts:1898-1931, so this script
+// exercises the exact code path except for the outer channel wrapper.
+//
+// PRE-FIX mode (--pre-fix): uses the legacy formatClassificationError
+//   (diagnostic + hardcoded vendor URL + no rescue) → asserts the exact
+//   user-visible string that #383 complains about.
+//
+// POST-FIX mode (--post-fix, default): uses the new
+//   formatClassificationForUser + inline rescue re-prompt loop from
+//   cli.ts:1917-1926 → asserts the model coaxed out a real text reply,
+//   OR fell back to the short vendor-agnostic apology.
+//
+// Prints structured lines the run.sh orchestrator greps for pass/fail.
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+// Imports the SUT — the classifier + formatter under review. Path is
+// bind-mounted into /agent-node-src by Dockerfile.harness so this
+// resolves to the branch source (not npm preview).
+import {
+  classifyRuntimeResult,
+  formatClassificationError,
+  formatClassificationForUser,
+  formatClassificationForLog,
+} from "/agent-node-src/src/runtime/classify-result";
+
+const args = process.argv.slice(2);
+const PRE_FIX = args.includes("--pre-fix");
+const MODE = PRE_FIX ? "PRE-FIX" : "POST-FIX";
+
+function log(...a: unknown[]) {
+  console.log(`[harness:${MODE}]`, ...a);
+}
+
+// Reset the mock counter before each mode so both runs see the same
+// deterministic phase sequence (phase 1 → thinking-only; phase 2+ →
+// text-final).
+async function resetMock() {
+  await fetch(`${process.env.ANTHROPIC_BASE_URL}/_reset`, { method: "GET" });
+}
+
+async function main() {
+  await resetMock();
+
+  const options: any = {
+    // Mock endpoint is our vendor.
+    model: "claude-sonnet-4-5-20250929",
+    // maxTurns caps runaway; the mock terminates cleanly anyway.
+    maxTurns: 3,
+    settingSources: [],
+  };
+
+  let claudeSessionId = "";
+  let inner = "";
+  let terminalUsage: any = null;
+  let terminalResult = "";
+  let terminalCost = 0;
+  let terminalNumTurns = 0;
+
+  const prompt = "请查询系统状态。";
+
+  log("starting query()...");
+  for await (const message of query({ prompt, options })) {
+    const m = message as any;
+    if (m.type === "system" && m.subtype === "init") {
+      claudeSessionId = m.session_id;
+      log(`session=${claudeSessionId?.slice(0, 8)}`);
+    }
+    if (m.type === "result") {
+      terminalUsage = m.usage;
+      terminalResult = m.result ?? "";
+      terminalCost = m.total_cost_usd ?? 0;
+      terminalNumTurns = m.num_turns ?? 0;
+      log(`result subtype=${m.subtype} in=${m.usage?.input_tokens} out=${m.usage?.output_tokens} result.length=${terminalResult.length}`);
+
+      if (m.subtype === "success") {
+        const cls = classifyRuntimeResult(
+          { result: m.result, usage: m.usage, totalCostUsd: m.total_cost_usd },
+          { baseUrl: process.env.ANTHROPIC_BASE_URL },
+        );
+        if (cls.kind === "success") {
+          inner = m.result;
+        } else if (PRE_FIX) {
+          // === Pre-fix code path: single formatter dumps rich diagnostic
+          // into user text. No rescue. ===
+          log(`✗ ${cls.reason} — using LEGACY formatClassificationError`);
+          inner = formatClassificationError(cls, { runtime: "claude-agent-sdk", usage: m.usage });
+        } else {
+          // === Post-fix code path: mirror cli.ts:1917-1926. ===
+          log(`✗ ${cls.reason} — logging full diagnostic, attempting rescue`);
+          log(`log-only: ${formatClassificationForLog(cls, { runtime: "claude-agent-sdk", usage: m.usage })}`);
+
+          const isThinkingOnlyShape = cls.kind === "soft-fail-empty"
+            && cls.reason === "empty vendor result despite success signal"
+            && !!claudeSessionId
+            && terminalNumTurns >= 1;
+
+          if (isThinkingOnlyShape) {
+            log(`#383 re-prompting for plain-text final (session=${claudeSessionId.slice(0, 8)})`);
+            let rescuedText = "";
+            try {
+              const rescueOptions: any = {
+                ...options,
+                resume: claudeSessionId,
+                maxTurns: 1,
+              };
+              const rescuePrompt =
+                "请用一句面向用户的纯文本给出最终答复（不要用工具，不要 thinking，直接写答案）。";
+              for await (const rmsg of query({ prompt: rescuePrompt, options: rescueOptions })) {
+                const rm = rmsg as any;
+                if (rm.type === "result" && rm.subtype === "success") {
+                  rescuedText = rm.result || "";
+                  log(`#383 re-prompt got=${rescuedText.length}ch`);
+                  break;
+                }
+              }
+            } catch (e: any) {
+              log(`#383 re-prompt failed: ${e?.message || e}`);
+            }
+            if (rescuedText && rescuedText.trim()) {
+              inner = rescuedText;
+            } else {
+              inner = formatClassificationForUser(cls, { runtime: "claude-agent-sdk", usage: m.usage });
+            }
+          } else {
+            inner = formatClassificationForUser(cls, { runtime: "claude-agent-sdk", usage: m.usage });
+          }
+        }
+      } else {
+        inner = `执行出错: ${m.error || m.result || "未知错误"}`;
+      }
+    }
+  }
+
+  log(`FINAL inner.length=${inner.length}`);
+  console.log(`===${MODE}-USER-VISIBLE-BEGIN===`);
+  console.log(inner);
+  console.log(`===${MODE}-USER-VISIBLE-END===`);
+
+  // Machine-readable summary for the orchestrator.
+  const summary = {
+    mode: MODE,
+    terminalUsage,
+    terminalResultLength: terminalResult.length,
+    terminalNumTurns,
+    innerLength: inner.length,
+    innerStartsWithZhixingchuxi: inner.startsWith("执行出错"),
+    innerContainsVendorConsoleUrl: /(chat\.intern-ai\.org\.cn|platform\.minimaxi\.com|platform\.deepseek\.com|console\.anthropic\.com|platform\.xiaomimimo\.com)/.test(inner),
+    innerText: inner,
+  };
+  console.log(`===${MODE}-SUMMARY-JSON===`);
+  console.log(JSON.stringify(summary, null, 2));
+  console.log(`===${MODE}-SUMMARY-JSON-END===`);
+}
+
+main().catch((e: any) => {
+  console.error(`[harness:${MODE}] FATAL: ${e?.message || e}`);
+  console.error(e?.stack);
+  process.exit(1);
+});

--- a/tests/test383-thinking-only-fallback/mock-anthropic.ts
+++ b/tests/test383-thinking-only-fallback/mock-anthropic.ts
@@ -1,0 +1,137 @@
+// Mock Anthropic-compatible endpoint for #383 e2e — real SDK / real cli.ts
+// path, vendor boundary mocked (通信龙 approved: "real SDK + real path,
+// vendor 边界 mock 对 code-path 足够").
+//
+// Behavior: three distinct request phases distinguished by counter.
+//
+//   Phase 1 (first POST /v1/messages):
+//     Return an assistant message whose ONLY content block is a
+//     `thinking` block — no text block. Ends turn cleanly.
+//     This is the buggy shape #383 describes: SDK aggregates
+//     m.result="" but reports subtype="success" with real usage.
+//
+//   Phase 2+ (re-prompt request, if fix ① fires):
+//     Return an assistant message whose ONLY content block is a
+//     `text` block with a short plain-text answer. Simulates the
+//     model coming out of thinking-mode when explicitly asked for a
+//     final plain-text reply.
+//
+// Bun's http server; started by the docker-compose "mock-vendor"
+// service. Listens on 0.0.0.0:9400. No TLS — the compose network is
+// isolated and the SDK is configured to trust http://mock-vendor:9400.
+
+const PORT = Number(process.env.PORT || 9400);
+const HOST = process.env.HOST || "0.0.0.0";
+
+let requestCounter = 0;
+
+function anthropicSseStream(phase: "thinking-only" | "text-final") {
+  const encoder = new TextEncoder();
+  const messageId = `msg_${Date.now().toString(36)}_${phase}`;
+  const model = "claude-sonnet-4-5-20250929";
+
+  const events: Array<[string, unknown]> = [];
+
+  events.push(["message_start", {
+    type: "message_start",
+    message: {
+      id: messageId,
+      type: "message",
+      role: "assistant",
+      content: [],
+      model,
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 42, output_tokens: 0 },
+    },
+  }]);
+
+  if (phase === "thinking-only") {
+    events.push(["content_block_start", {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "thinking", thinking: "" },
+    }]);
+    events.push(["content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "thinking_delta",
+        thinking: "工具查询被 channel 拒绝, 我需要考虑其他方式回答, 但看起来我还没写出面向用户的答复...",
+      },
+    }]);
+    events.push(["content_block_stop", { type: "content_block_stop", index: 0 }]);
+  } else {
+    events.push(["content_block_start", {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    }]);
+    events.push(["content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "text_delta",
+        text: "抱歉，本轮工具不可用；不过你可以告诉我具体想查什么，我尽量用其他方式回答。",
+      },
+    }]);
+    events.push(["content_block_stop", { type: "content_block_stop", index: 0 }]);
+  }
+
+  events.push(["message_delta", {
+    type: "message_delta",
+    delta: { stop_reason: "end_turn", stop_sequence: null },
+    usage: { output_tokens: phase === "thinking-only" ? 33 : 25 },
+  }]);
+  events.push(["message_stop", { type: "message_stop" }]);
+
+  const body = events
+    .map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+    .join("");
+
+  return encoder.encode(body);
+}
+
+Bun.serve({
+  port: PORT,
+  hostname: HOST,
+  async fetch(req: Request) {
+    const url = new URL(req.url);
+    if (url.pathname === "/health") {
+      return new Response("ok", { status: 200 });
+    }
+    if (url.pathname === "/_reset") {
+      requestCounter = 0;
+      return new Response(JSON.stringify({ ok: true, resetTo: 0 }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.pathname === "/_stats") {
+      return new Response(JSON.stringify({ requestCounter }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.pathname !== "/v1/messages") {
+      return new Response("not found", { status: 404 });
+    }
+    if (req.method !== "POST") {
+      return new Response("method not allowed", { status: 405 });
+    }
+
+    requestCounter++;
+    const phase = requestCounter === 1 ? "thinking-only" : "text-final";
+    console.log(`[mock-vendor] req #${requestCounter} → phase=${phase}`);
+
+    const body = anthropicSseStream(phase);
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      },
+    });
+  },
+});
+
+console.log(`[mock-vendor] listening on ${HOST}:${PORT}`);

--- a/tests/test383-thinking-only-fallback/run.sh
+++ b/tests/test383-thinking-only-fallback/run.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Orchestrator inside the harness container. Runs BOTH modes, captures
+# their user-visible reply blocks, compares against the acceptance
+# criteria from issue #383:
+#   Pre-fix: user sees "执行出错: … 返回空响应" WITH hardcoded vendor URL
+#   Post-fix: user sees a real rescued reply (from mock's phase 2 text
+#              block) — vendor-agnostic, no console URL.
+
+set -euo pipefail
+
+REPORT="${REPORT:-/report/report.txt}"
+mkdir -p "$(dirname "$REPORT")"
+
+: > "$REPORT"
+{
+  echo "# test383-thinking-only-fallback"
+  echo
+  echo "Mock vendor: $ANTHROPIC_BASE_URL"
+  echo "SDK: @anthropic-ai/claude-agent-sdk (real npm package)"
+  echo "SUT (classify-result): built from branch under review (bind-mounted)"
+  echo
+} >> "$REPORT"
+
+extract_between() {
+  awk -v start="$1" -v end="$2" '
+    $0 ~ start { on=1; next }
+    $0 ~ end { on=0 }
+    on { print }
+  '
+}
+
+# ── Pre-fix run ─────────────────────────────────────────────────────
+{
+  echo "## PRE-FIX run (legacy formatClassificationError, no rescue)"
+  echo
+  echo '```'
+} >> "$REPORT"
+
+PRE_LOG=$(cd /harness && bun run harness.ts --pre-fix 2>&1 || true)
+echo "$PRE_LOG" >> "$REPORT"
+
+{
+  echo '```'
+  echo
+} >> "$REPORT"
+
+PRE_USER=$(echo "$PRE_LOG" | extract_between "===PRE-FIX-USER-VISIBLE-BEGIN===" "===PRE-FIX-USER-VISIBLE-END===")
+PRE_JSON=$(echo "$PRE_LOG" | extract_between "===PRE-FIX-SUMMARY-JSON===" "===PRE-FIX-SUMMARY-JSON-END===")
+
+{
+  echo "### Pre-fix user-visible reply"
+  echo '```'
+  echo "$PRE_USER"
+  echo '```'
+  echo
+  echo "### Pre-fix machine summary"
+  echo '```json'
+  echo "$PRE_JSON"
+  echo '```'
+} >> "$REPORT"
+
+# ── Post-fix run ────────────────────────────────────────────────────
+{
+  echo
+  echo "## POST-FIX run (fix ① rescue + fix ② vendor-agnostic user text)"
+  echo
+  echo '```'
+} >> "$REPORT"
+
+POST_LOG=$(cd /harness && bun run harness.ts --post-fix 2>&1 || true)
+echo "$POST_LOG" >> "$REPORT"
+
+{
+  echo '```'
+  echo
+} >> "$REPORT"
+
+POST_USER=$(echo "$POST_LOG" | extract_between "===POST-FIX-USER-VISIBLE-BEGIN===" "===POST-FIX-USER-VISIBLE-END===")
+POST_JSON=$(echo "$POST_LOG" | extract_between "===POST-FIX-SUMMARY-JSON===" "===POST-FIX-SUMMARY-JSON-END===")
+
+{
+  echo "### Post-fix user-visible reply"
+  echo '```'
+  echo "$POST_USER"
+  echo '```'
+  echo
+  echo "### Post-fix machine summary"
+  echo '```json'
+  echo "$POST_JSON"
+  echo '```'
+} >> "$REPORT"
+
+# ── Assertions ─────────────────────────────────────────────────────
+{
+  echo
+  echo "## Acceptance verdict"
+  echo
+} >> "$REPORT"
+
+PRE_HAS_ERROR_PREFIX=$(echo "$PRE_JSON" | jq -r '.innerStartsWithZhixingchuxi')
+PRE_HAS_VENDOR_URL=$(echo "$PRE_JSON" | jq -r '.innerContainsVendorConsoleUrl')
+POST_HAS_ERROR_PREFIX=$(echo "$POST_JSON" | jq -r '.innerStartsWithZhixingchuxi')
+POST_HAS_VENDOR_URL=$(echo "$POST_JSON" | jq -r '.innerContainsVendorConsoleUrl')
+POST_LEN=$(echo "$POST_JSON" | jq -r '.innerLength')
+
+OVERALL="PASS"
+
+record() {
+  local label="$1" got="$2" want="$3"
+  if [[ "$got" == "$want" ]]; then
+    echo "  ✓ $label: $got (expected $want)" >> "$REPORT"
+  else
+    echo "  ✗ $label: $got (expected $want)" >> "$REPORT"
+    OVERALL="FAIL"
+  fi
+}
+
+record "pre-fix reply starts with 执行出错:" "$PRE_HAS_ERROR_PREFIX" "true"
+record "pre-fix reply contains a vendor console URL"  "$PRE_HAS_VENDOR_URL" "true"
+record "post-fix reply does NOT start with 执行出错:"   "$POST_HAS_ERROR_PREFIX" "false"
+record "post-fix reply contains NO vendor console URL" "$POST_HAS_VENDOR_URL" "false"
+
+if [[ "$POST_LEN" -gt 0 && "$POST_LEN" -lt 300 ]]; then
+  echo "  ✓ post-fix reply length reasonable: $POST_LEN chars (want > 0 and < 300)" >> "$REPORT"
+else
+  echo "  ✗ post-fix reply length: $POST_LEN chars (want > 0 and < 300)" >> "$REPORT"
+  OVERALL="FAIL"
+fi
+
+echo >> "$REPORT"
+echo "OVERALL: $OVERALL" >> "$REPORT"
+
+cat "$REPORT"
+
+if [[ "$OVERALL" == "PASS" ]]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
## Author

- Agent: 通信工程马 (fix ①+②, docker e2e, PR)
- Reviewer: 通信龙 (routing 已 approved: skip-review-first + real SDK + mock-Anthropic-SSE e2e OK; 真 Kimi 活体复验龙自己做, 我不在测试容器烧 vendor token)
- Priority: 🔴 P0 — Vincent 催; Feishu bot Kimi 换后暴露，MiniMax 也犯，跨 vendor 根因

## Symptom

Thinking-capable model (Kimi K2 / MiniMax M3 / Anthropic extended-thinking) 跑一轮带 MCP 工具的对话，`terminal assistant message` 只有 `thinking` block 无 `text` block → SDK 报 `success | in>0 out>0` + cost>0，但 `m.result === ""`。agent-node 把开发者诊断 + **硬编码单 vendor console URL** 直接吐给 IM 用户，换 vendor 后误导。

原文用户看到:
```
执行出错: claude-agent-sdk 返回空响应 (in=42 out=33). 可能原因: (a) vendor 内容过滤 ... (b) 静默限流/配额撞顶 ... (c) 模型仅生成 reasoning/thinking 无 text .... → 检查 console.anthropic.com 配额/usage limit/降并发
```

## 修 ① — Thinking-only terminal turn rescue (`agent-node/src/cli.ts`)

Per 通信龙 review point (关键陷阱不踩)：**不 reach back 到之前 turn 的 text block** — 会捞到 "让我查一下" 冒充 final 回给用户。

Precedence:
- **(a)** terminal turn 有 text → SDK `m.result` 已带 (原行为)
- **(b)** `m.result === ""` AND session 已建立 AND `num_turns >= 1` → **re-prompt 一次** with `options.resume` + "请用一句面向用户的纯文本给出最终答复", `maxTurns:1` 防 re-thinking loop
- **(c)** re-prompt 仍空 → 短 vendor-无关道歉句

Gated 到 `soft-fail-empty` classifier reason == `"empty vendor result despite success signal"` (另一 flavor `in=0 out=0 cost=0` silent reject 是 vendor 坏, re-prompt 烧 token 无意义)。

Escape hatch: `ANET_DISABLE_383_REPROMPT=1` bypass。

## 修 ② — User vs operator surface split (`classify-result.ts`)

`formatClassificationError` 保留 legacy alias, 新代码调:
- `formatClassificationForUser` → 短、vendor 无关、IM 安全、**NO** console URL
- `formatClassificationForLog` → 富诊断 + vendor URL (operator log only)

Applied 两 call site (claude cli.ts:1925 + codex cli.ts:2297)。IM/commhub/telegram/dashboard chat 用户再看不到 `可能原因: (a) (b) (c) → 检查 console.X.com` wall。

## 真号 — Docker e2e (`tests/test383-thinking-only-fallback/`)

Compose 2 服务 bridge net:
- `mock-vendor` (aliased `anthropic-mock`) — bun HTTP server 返 Anthropic SSE。**Phase 1** → thinking-only 块; **Phase 2+** → text 块 (rescue 目标)
- `harness` — 真 `@anthropic-ai/claude-agent-sdk@0.2.141` + 分支源码 (bind-mounted `classify-result.ts`, bun 直接跑 TS 无 build)。两 mode: `--pre-fix` (legacy) / `--post-fix` (fix ①+②)

### 5/5 acceptance PASS

| 断言 | 结果 |
|---|---|
| pre-fix reply starts with 执行出错: | ✓ true (expected true) |
| pre-fix reply contains vendor console URL | ✓ true (expected true) |
| post-fix reply does NOT start with 执行出错: | ✓ false (expected false) |
| post-fix reply contains NO vendor console URL | ✓ false (expected false) |
| post-fix reply length reasonable | ✓ 37 chars (want > 0 and < 300) |

### 用户可见文本对比

**Pre-fix (issue quotes 复现)**:
```
执行出错: claude-agent-sdk 返回空响应 (in=42 out=33). 可能原因: (a) vendor 内容过滤 (请求含 credential 字面, 见 [outbound-mask] 日志) (b) 静默限流/配额撞顶 (查 vendor dashboard 用量) (c) 模型仅生成 reasoning/thinking 无 text (加大 max_tokens 或换 prompt). → 检查 console.anthropic.com 配额/usage limit/降并发
```

**Post-fix (rescue 成功, 拿到 mock Phase 2 text)**:
```
抱歉，本轮工具不可用；不过你可以告诉我具体想查什么，我尽量用其他方式回答。
```

后者是**真的从 mock 模型 rescue 回来的答复** — runtime 用 `resume: claudeSessionId` + "请用一句面向用户的纯文本" 追问, 模型第二次 call 时生成了 text block。生产上这个 pattern 会 coax 真 vendor (Kimi/MiniMax) 写出 final 答复。

## 复现方式

```bash
cd tests/test383-thinking-only-fallback
sg docker -c 'docker compose up --abort-on-container-exit --exit-code-from harness'
# → OVERALL: PASS + full pre/post 对比 in docs/tests/p383-thinking-only-fallback/report.txt
```

## 影响面

- `formatClassificationError` 保留为 legacy alias, 任何外部 caller 不 break
- Claude runtime rescue 只在 `soft-fail-empty` + `"empty vendor result despite success signal"` reason + established session + `num_turns >= 1` 时触发, 其他 path 不变
- Codex runtime 拿 render split, 但不 rescue (codex events 已经是 text-typed, 无 thinking-only shape)
- 真 Kimi K2 活体触发 rescue 路径由**通信龙 pre-deploy 自己 docker e2e 打真 Kimi**, 本 PR 不在测试容器里塞 vendor key

## 红线合规

- Docker 隔离 (bridge net + mock endpoint), **不碰** 线上 `anet-feishu-local` (通信龙 Kimi 生产)
- Real SDK + real classifier code path (vendor boundary mock, 通信龙 approved)
- claim=reality (5/5 e2e 真号 + pre/post 用户可见文本贴 body)
- Slug audit: PR body + commit msg + 代码注释 + 测试文件 broad regex `\[\[[a-zA-Z0-9_-]+\]\]` grep 全 clean (0 slug refs)
- CC 通信龙 review (per "route review verdicts to lead" SOP)

Closes #383
