### PR TITLE
feat(RFC-029 PR②): opencode-cli ACP shim (events + client + runtime) + processTask wire

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1381,6 +1381,16 @@ async function runGoalSchedulerTick() {
 // ══════════════════════════════════════
 let claudeSessionId: string | undefined = SESSION_ID || undefined;
 let grokSessionId: string | undefined = RUNTIME === "grok" ? (SESSION_ID || undefined) : undefined;
+// RFC-029 PR② — opencode-cli session state.
+// `opencodeSessionId` is persisted across turns; on a supervisor-driven
+// restart runtime.ts will try `session/load` with it before falling
+// back to session/new. Long-running architecture: one child process
+// handles every turn; `opencodeRuntimeSession` is lazily opened on
+// the first turn and reused for the whole node lifetime unless the
+// subprocess exits (crash-restart path handled by resetting the
+// holder — the next turn spawns fresh).
+let opencodeSessionId: string | undefined = RUNTIME === "opencode" ? (SESSION_ID || undefined) : undefined;
+let opencodeRuntimeSession: import("./runtime/opencode-acp/runtime").OpencodeRuntimeSession | null = null;
 
 // #213 — track whether the current process resumed a pre-existing grok
 // session (truthy SESSION_ID at boot) so we can prepend the un-closed-loop
@@ -2495,6 +2505,71 @@ function sanitizeGrokCommhubLeak(text: string): string {
   return cleaned || text.trim() || "（无回复）";
 }
 
+// RFC-029 PR② — opencode-cli ACP runtime think() entry.
+//
+// Long-running architecture: `opencodeRuntimeSession` is opened lazily
+// on the first turn and reused for every subsequent turn (no cold-
+// start per turn, matching the "常驻 B1'" spirit).
+//
+// Crash-restart correctness (通信龙 PR② flag catch): when the child
+// process exits (crash, killed by supervisor, whatever), we detect the
+// stale handle on the next turn and re-open with the persisted
+// sessionId; runtime.openOpencodeRuntime tries `session/load` first
+// and falls back to `session/new` with an explicit "session lost on
+// restart" log line — no silent history loss.
+//
+// #383 thinking-only rescue is inherited from the runtime layer (see
+// opencodeThink). Toggle via ANET_DISABLE_383_REPROMPT env, shared
+// with the claude runtime for uniform operator override.
+async function processWithOpencode(task: string, _from: string, _images?: string[]): Promise<string> {
+  const { openOpencodeRuntime, opencodeThink } =
+    await import("./runtime/opencode-acp/runtime");
+
+  // Reset the holder if the child has already exited — the next call
+  // will re-open with session/load per the persisted sessionId.
+  if (opencodeRuntimeSession && !opencodeRuntimeSession.client.isRunning) {
+    log(`[opencode] previous child exited — reopening on this turn`);
+    opencodeRuntimeSession = null;
+  }
+
+  if (!opencodeRuntimeSession) {
+    opencodeRuntimeSession = await openOpencodeRuntime({
+      cwd: process.cwd(),
+      workDir: process.cwd(),  // §8 D5: HOME isolation lands here
+      sessionId: opencodeSessionId,
+      onSession: async (id: string) => {
+        opencodeSessionId = id;
+        writebackSession(id);
+      },
+      onExit: (info) => {
+        warn(`[opencode] child exited code=${info.code} signal=${info.signal}; next turn will reopen`);
+        opencodeRuntimeSession = null;
+      },
+      log,
+      warn,
+    });
+  }
+
+  const outcome = await opencodeThink(opencodeRuntimeSession, {
+    prompt: task,
+    cwd: process.cwd(),
+    workDir: process.cwd(),
+    sessionId: opencodeRuntimeSession.sessionId,
+    log,
+    warn,
+  });
+
+  const u = outcome.state.usage;
+  log(
+    `[opencode] turn done | reply=${outcome.replyText.length}ch ` +
+    `thought=${outcome.thoughtText.length}ch chunks=${outcome.state.chunks} ` +
+    `stopReason=${outcome.state.lastStopReason ?? "?"} rescued=${outcome.rescued} ` +
+    `in=${u?.inputTokens ?? "?"} out=${u?.outputTokens ?? "?"} thought=${u?.thoughtTokens ?? "?"}`,
+  );
+
+  return outcome.replyText || "（无回复）";
+}
+
 async function processWithGrok(task: string, from: string, images?: string[]): Promise<string> {
   if (images?.length) {
     warn(`[grok] image attachments received but Grok ACP fixture reports promptCapabilities.image=false; sending text-only prompt`);
@@ -2881,18 +2956,7 @@ function think(task: string, from: string, taskId: string | null, images?: strin
         return await processWithGrok(task, from, images);
       }
       if (RUNTIME === "opencode") {
-        // RFC-029 PR① — runtime is registered end-to-end (config,
-        // wizard, CLI, launcher) so operators can create and start
-        // opencode-cli nodes today; the ACP think() shim itself lands
-        // in PR② (agent-node/src/runtime/opencode-acp/{events,client,
-        // runtime}.ts, ~15-25 LOC per Phase 0b probe). Fail loudly
-        // with a clear pointer so a first-turn attempt doesn't look
-        // like a mysterious hang or fall through to another runtime's
-        // path.
-        return (
-          "执行出错: opencode-cli runtime 尚未实现 think() (RFC-029 PR②). " +
-          "PR① 已 wire runtime 注册路径; PR② 会加 agent-node/src/runtime/opencode-acp/ ACP shim (~15-25 LOC)."
-        );
+        return await processWithOpencode(task, from, images);
       }
       return await processWithClaude(task, from, images);
     } finally {

--- a/agent-node/src/runtime/opencode-acp/client.test.ts
+++ b/agent-node/src/runtime/opencode-acp/client.test.ts
@@ -1,0 +1,148 @@
+// RFC-029 PR② — client tests. Uses a tiny bun helper subprocess that
+// emits deterministic JSON-RPC frames to exercise:
+//   - request/response id correlation
+//   - notification event emission
+//   - exit → pending-request rejection
+//   - stdout parse error surface
+//
+// We DON'T install a real opencode here — the transport layer is
+// opencode-agnostic. Runtime-integration tests live in the mock e2e
+// (tests/test-rfc029-pr2-acp-shim/).
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { OpencodeAcpClient } from "./client";
+
+function makeStubBinary(script: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "opencode-stub-"));
+  const jsPath = join(dir, "stub.mjs");
+  const shPath = join(dir, "opencode-stub.sh");
+  // Write the JS body to a file and wrap in a bash launcher. This
+  // avoids the shell-quoting minefield of `bun run -e '<inline>'` and
+  // keeps newlines / regex escapes intact inside the script.
+  writeFileSync(jsPath, script);
+  writeFileSync(shPath, `#!/usr/bin/env bash\nexec bun run ${JSON.stringify(jsPath)}\n`, { mode: 0o755 });
+  return shPath;
+}
+
+describe("OpencodeAcpClient — request/response correlation", () => {
+  test("request() resolves with the matching response's result", async () => {
+    const stub = makeStubBinary(`
+      let buf = "";
+      process.stdin.on("data", (chunk) => {
+        buf += chunk;
+        while (buf.includes("\\n")) {
+          const idx = buf.indexOf("\\n");
+          const line = buf.slice(0, idx).trim();
+          buf = buf.slice(idx + 1);
+          if (!line) continue;
+          const req = JSON.parse(line);
+          process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: req.id, result: { echoed: req.method } }) + "\\n");
+        }
+      });
+    `);
+    const c = new OpencodeAcpClient();
+    c.start({ binary: stub });
+    try {
+      const r = await c.request<{ echoed: string }>("initialize", { protocolVersion: 1 }, 5000);
+      expect(r.echoed).toBe("initialize");
+    } finally { await c.stop(); }
+  });
+
+  test("error response rejects the promise with a shaped message", async () => {
+    const stub = makeStubBinary(`
+      let buf = "";
+      process.stdin.on("data", (chunk) => {
+        buf += chunk;
+        while (buf.includes("\\n")) {
+          const idx = buf.indexOf("\\n");
+          const line = buf.slice(0, idx).trim();
+          buf = buf.slice(idx + 1);
+          if (!line) continue;
+          const req = JSON.parse(line);
+          process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: req.id, error: { code: -32600, message: "bad request" }}) + "\\n");
+        }
+      });
+    `);
+    const c = new OpencodeAcpClient();
+    c.start({ binary: stub });
+    try {
+      let thrown: Error | null = null;
+      try { await c.request("session/new", {}, 3000); }
+      catch (e: any) { thrown = e; }
+      expect(thrown).not.toBeNull();
+      expect(thrown!.message).toContain("-32600");
+      expect(thrown!.message).toContain("bad request");
+    } finally { await c.stop(); }
+  });
+});
+
+describe("OpencodeAcpClient — streaming notifications", () => {
+  test("emits 'notification' for every session/update frame", async () => {
+    const stub = makeStubBinary(`
+      let buf = "";
+      process.stdin.on("data", (chunk) => {
+        buf += chunk;
+        while (buf.includes("\\n")) {
+          const idx = buf.indexOf("\\n");
+          const line = buf.slice(0, idx).trim();
+          buf = buf.slice(idx + 1);
+          if (!line) continue;
+          const req = JSON.parse(line);
+          // Stream two session/update notifications, then the response.
+          process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "hi" }}}}) + "\\n");
+          process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "there" }}}}) + "\\n");
+          process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: req.id, result: { stopReason: "end_turn" }}) + "\\n");
+        }
+      });
+    `);
+    const c = new OpencodeAcpClient();
+    const notifications: any[] = [];
+    c.on("notification", (n) => notifications.push(n));
+    c.start({ binary: stub });
+    try {
+      const result = await c.request<{ stopReason: string }>("session/prompt", {}, 5000);
+      expect(result.stopReason).toBe("end_turn");
+      expect(notifications).toHaveLength(2);
+      expect(notifications[0].params.update.sessionUpdate).toBe("agent_thought_chunk");
+      expect(notifications[1].params.update.sessionUpdate).toBe("agent_message_chunk");
+    } finally { await c.stop(); }
+  });
+});
+
+describe("OpencodeAcpClient — process lifecycle", () => {
+  test("child exit rejects all pending requests", async () => {
+    // Stub that reads one line then exits without responding.
+    const stub = makeStubBinary(`
+      let buf = "";
+      process.stdin.on("data", (chunk) => {
+        buf += chunk;
+        if (buf.includes("\\n")) {
+          process.exit(0);  // die mid-request
+        }
+      });
+    `);
+    const c = new OpencodeAcpClient();
+    c.start({ binary: stub });
+    let thrown: Error | null = null;
+    try {
+      await c.request("session/prompt", {}, 5000);
+    } catch (e: any) { thrown = e; }
+    expect(thrown).not.toBeNull();
+    expect(thrown!.message).toContain("opencode acp exited");
+  });
+
+  test("isRunning flips false after stop()", async () => {
+    const stub = makeStubBinary(`
+      // A stub that just reads and never writes.
+      process.stdin.resume();
+    `);
+    const c = new OpencodeAcpClient();
+    c.start({ binary: stub });
+    expect(c.isRunning).toBe(true);
+    await c.stop();
+    expect(c.isRunning).toBe(false);
+  });
+});

--- a/agent-node/src/runtime/opencode-acp/client.ts
+++ b/agent-node/src/runtime/opencode-acp/client.ts
@@ -1,0 +1,242 @@
+// RFC-029 PR② — opencode ACP stdio JSON-RPC client.
+//
+// Transport layer for `spawn('opencode', ['acp'])`. Mirrors the
+// grok-build-acp/client.ts skeleton because Phase 0b (U8) confirmed
+// the wire framing is identical JSON-RPC 2.0 over newline-delimited
+// stdio. Kept in-tree (not a shared abstraction with Grok) so
+// upstream churn on either side can be absorbed without cross-
+// runtime blast radius.
+//
+// What lives here:
+//   - subprocess spawn + stdio pump
+//   - newline-delimited JSON-RPC framing (in + out)
+//   - id-correlated request/response with per-request timeout
+//   - streaming notifications surface via `on("notification", ...)`
+//   - HOME env isolation is the caller's job (env passed through
+//     verbatim — runtime.ts sets `HOME=<node workdir>` per §8 D5)
+//
+// What lives in runtime.ts:
+//   - session/new vs session/load restart policy (crash-preservation
+//     per 通信龙 review-point on PR② flag)
+//   - state machine driving initialize → session/{new,load} →
+//     session/prompt in the long-running process
+//   - sessionId persistence (writebackSession) for restart
+
+import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
+import { EventEmitter } from "events";
+
+export interface JsonRpcRequest<P = unknown> {
+  jsonrpc: "2.0";
+  id: number | string;
+  method: string;
+  params?: P;
+}
+
+export interface JsonRpcSuccess<R = unknown> {
+  jsonrpc?: "2.0";
+  id: number | string;
+  result: R;
+}
+
+export interface JsonRpcError {
+  jsonrpc?: "2.0";
+  id: number | string;
+  error: { code: number; message: string; data?: unknown };
+}
+
+export interface JsonRpcNotification<P = unknown> {
+  jsonrpc?: "2.0";
+  method: string;
+  params?: P;
+}
+
+export type JsonRpcMessage =
+  | JsonRpcRequest
+  | JsonRpcSuccess
+  | JsonRpcError
+  | JsonRpcNotification;
+
+export interface OpencodeAcpClientOptions {
+  /** cwd for the spawned opencode process. Not the anet cwd — per §8
+   *  D5 this should be the per-node work dir so opencode's own
+   *  `--cwd` file resolution stays scoped. */
+  cwd?: string;
+  /** Full env for the child. Callers MUST set `HOME=<node workdir>`
+   *  here to isolate opencode's auth.json + opencode.json + session
+   *  cache per anet node (§8 D5). */
+  env?: NodeJS.ProcessEnv;
+  /** Binary name / path. Defaults to `"opencode"` (found via $PATH). */
+  binary?: string;
+}
+
+export class OpencodeAcpClient extends EventEmitter {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private nextId = 1;
+  private pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  private rxBuffer = "";
+  private closed = false;
+  private lastIncomingAt = Date.now();
+
+  /** Timestamp (ms since epoch) of the last JSON-RPC frame received
+   *  from the agent. Runtime.ts uses this to distinguish a wedged
+   *  agent from a long-running streaming turn. */
+  get lastActivityAt(): number {
+    return this.lastIncomingAt;
+  }
+
+  start(opts: OpencodeAcpClientOptions = {}): void {
+    if (this.child) throw new Error("OpencodeAcpClient already started");
+    const bin = opts.binary ?? "opencode";
+    // NOTE: `opencode acp` v1.17.13 IGNORES --port/--hostname (see
+    // Phase 0b U8 finding — flags are accepted for CLI parsing but
+    // the server binds to stdio only). Do not pass them here.
+    this.child = spawn(bin, ["acp"], {
+      cwd: opts.cwd ?? process.cwd(),
+      env: { ...process.env, ...opts.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    this.child.stdout.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk: string) => this.onStdout(chunk));
+    this.child.stderr.setEncoding("utf8");
+    this.child.stderr.on("data", (chunk: string) => this.emit("stderr", chunk));
+    this.child.on("exit", (code, signal) => {
+      this.closed = true;
+      this.emit("exit", { code, signal });
+      const errMsg = `opencode acp exited (code=${code} signal=${signal})`;
+      for (const [, p] of this.pending) p.reject(new Error(errMsg));
+      this.pending.clear();
+    });
+    this.child.on("error", (err) => this.emit("error", err));
+  }
+
+  async request<R = unknown, P = unknown>(method: string, params?: P, timeoutMs = 30_000): Promise<R> {
+    if (!this.child || this.closed) throw new Error("OpencodeAcpClient not started or already exited");
+    const id = this.nextId++;
+    const payload: JsonRpcRequest<P> = {
+      jsonrpc: "2.0", id, method,
+      ...(params !== undefined ? { params } : {}),
+    };
+    return new Promise<R>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`opencode ACP request '${method}' (id=${id}) timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (v) => { clearTimeout(timer); resolve(v as R); },
+        reject: (e) => { clearTimeout(timer); reject(e); },
+      });
+      this.child!.stdin.write(JSON.stringify(payload) + "\n", (err) => {
+        if (err) {
+          this.pending.delete(id);
+          clearTimeout(timer);
+          reject(err);
+        }
+      });
+    });
+  }
+
+  /**
+   * Idle-threshold variant of `request()` for `session/prompt`, which
+   * streams `session/update` chunks for the entire LLM turn. Mirrors
+   * grok-build-acp/client.ts:requestWithIdleTimeout — any incoming
+   * frame resets the timer so a genuinely long-running turn isn't
+   * killed while frames are actively flowing.
+   */
+  async requestWithIdleTimeout<R = unknown, P = unknown>(
+    method: string,
+    params: P,
+    idleTimeoutMs: number,
+  ): Promise<R> {
+    if (!this.child || this.closed) throw new Error("OpencodeAcpClient not started or already exited");
+    const id = this.nextId++;
+    const payload: JsonRpcRequest<P> = { jsonrpc: "2.0", id, method, params };
+    const sentAt = Date.now();
+    return new Promise<R>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const check = () => {
+        const idleFor = Date.now() - Math.max(sentAt, this.lastIncomingAt);
+        if (idleFor >= idleTimeoutMs) {
+          this.pending.delete(id);
+          reject(new Error(
+            `opencode ACP request '${method}' (id=${id}) idle for ${idleFor}ms ` +
+            `(threshold ${idleTimeoutMs}ms); background work may still be running.`,
+          ));
+        } else {
+          timer = setTimeout(check, Math.max(500, idleTimeoutMs - idleFor));
+        }
+      };
+      timer = setTimeout(check, idleTimeoutMs);
+      this.pending.set(id, {
+        resolve: (v) => { if (timer) clearTimeout(timer); resolve(v as R); },
+        reject:  (e) => { if (timer) clearTimeout(timer); reject(e); },
+      });
+      this.child!.stdin.write(JSON.stringify(payload) + "\n", (err) => {
+        if (err) {
+          this.pending.delete(id);
+          if (timer) clearTimeout(timer);
+          reject(err);
+        }
+      });
+    });
+  }
+
+  /** Terminate the child and refuse further requests. Idempotent. */
+  async stop(signal: NodeJS.Signals = "SIGTERM"): Promise<void> {
+    if (!this.child || this.closed) return;
+    try { this.child.kill(signal); } catch { /* already gone */ }
+    // Await the exit handler which sets `closed = true` and clears pending.
+    if (!this.closed) await new Promise<void>((r) => this.once("exit", () => r()));
+  }
+
+  /**
+   * Whether the child process is alive AND still accepting requests.
+   * Used by runtime.ts's crash-restart detector.
+   */
+  get isRunning(): boolean {
+    return this.child !== null && !this.closed;
+  }
+
+  private onStdout(chunk: string): void {
+    this.rxBuffer += chunk;
+    while (this.rxBuffer.includes("\n")) {
+      const idx = this.rxBuffer.indexOf("\n");
+      const line = this.rxBuffer.slice(0, idx).trim();
+      this.rxBuffer = this.rxBuffer.slice(idx + 1);
+      if (!line) continue;
+      let msg: JsonRpcMessage;
+      try { msg = JSON.parse(line) as JsonRpcMessage; }
+      catch { this.emit("parseError", line); continue; }
+      this.lastIncomingAt = Date.now();
+      this.dispatch(msg);
+    }
+  }
+
+  private dispatch(msg: JsonRpcMessage): void {
+    // Response frame (has `id` AND either `result` or `error`, no `method`).
+    if ("id" in msg && !("method" in msg && (msg as any).method)) {
+      const id = Number((msg as any).id);
+      const p = this.pending.get(id);
+      if (p) {
+        this.pending.delete(id);
+        if ("error" in msg && (msg as JsonRpcError).error) {
+          const e = (msg as JsonRpcError).error;
+          p.reject(new Error(`opencode ACP error id=${id}: ${e.code} ${e.message}`));
+        } else {
+          // Emit the WHOLE response so callers that need `stopReason`
+          // from the `result` field can also see it via listeners
+          // (in addition to the resolved promise result).
+          this.emit("response", msg);
+          p.resolve((msg as JsonRpcSuccess).result);
+        }
+      } else {
+        this.emit("orphanResponse", msg);
+      }
+      return;
+    }
+    // Notification frame (has `method`, no correlating `id`).
+    if ("method" in msg && (msg as any).method) {
+      this.emit("notification", msg as JsonRpcNotification);
+    }
+  }
+}

--- a/agent-node/src/runtime/opencode-acp/events.test.ts
+++ b/agent-node/src/runtime/opencode-acp/events.test.ts
@@ -1,0 +1,214 @@
+// RFC-029 PR② — opencode ACP events reducer tests.
+//
+// Locks the byte-shape opencode-ai@1.17.13 emits over `opencode acp`
+// stdio, as captured by Phase 0b probes in
+// `docs/analysis/rfc029-opencode-probe/u8-acp.txt`. The reducer
+// treats each notification and each response independently; wire-
+// level ordering is enforced by client.ts, not this file.
+
+import { describe, expect, test } from "bun:test";
+import {
+  newOpencodeTurnState,
+  reduceOpencodeAcpNotification,
+  reduceOpencodeAcpResponse,
+  reduceOpencodeAcpFrames,
+} from "./events";
+
+describe("reduceOpencodeAcpNotification — session/update dispatch", () => {
+  test("agent_message_chunk with text content → replyText += content.text", () => {
+    const state = newOpencodeTurnState("ses_abc");
+    const r = reduceOpencodeAcpNotification(state, {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "ses_abc",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          messageId: "msg_1",
+          content: { type: "text", text: "Okay" },
+        },
+      },
+    });
+    expect(r.kind).toBe("reply_chunk");
+    expect(r.consumed).toBe(true);
+    expect(state.replyText).toBe("Okay");
+    expect(state.chunks).toBe(1);
+    expect(state.warnings).toHaveLength(0);
+  });
+
+  test("agent_thought_chunk with text → thoughtText, NOT replyText (grok discipline)", () => {
+    const state = newOpencodeTurnState();
+    reduceOpencodeAcpNotification(state, {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "The user " },
+        },
+      },
+    });
+    reduceOpencodeAcpNotification(state, {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "wants one word." },
+        },
+      },
+    });
+    expect(state.thoughtText).toBe("The user wants one word.");
+    expect(state.thoughtChunks).toBe(2);
+    expect(state.replyText).toBe("");
+    expect(state.chunks).toBe(0);
+  });
+
+  test("tool_call and tool_call_update both bump toolCalls", () => {
+    const state = newOpencodeTurnState();
+    reduceOpencodeAcpNotification(state, {
+      method: "session/update",
+      params: { update: { sessionUpdate: "tool_call" } },
+    });
+    reduceOpencodeAcpNotification(state, {
+      method: "session/update",
+      params: { update: { sessionUpdate: "tool_call_update" } },
+    });
+    expect(state.toolCalls).toBe(2);
+  });
+
+  test("usage_update snaps totalTokens into state.usage", () => {
+    const state = newOpencodeTurnState();
+    const r = reduceOpencodeAcpNotification(state, {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "usage_update",
+          used: 7687,
+          size: 200000,
+          cost: { amount: 0, currency: "USD" },
+        },
+      },
+    });
+    expect(r.kind).toBe("usage_update");
+    expect(state.usage?.totalTokens).toBe(7687);
+  });
+
+  test("available_commands_update consumed silently (session-init only)", () => {
+    const state = newOpencodeTurnState();
+    const r = reduceOpencodeAcpNotification(state, {
+      method: "session/update",
+      params: { update: { sessionUpdate: "available_commands_update", availableCommands: [] } },
+    });
+    expect(r.kind).toBe("available_commands");
+    expect(state.replyText).toBe("");
+  });
+
+  test("agent_message_chunk without text content adds a warning", () => {
+    const state = newOpencodeTurnState();
+    const r = reduceOpencodeAcpNotification(state, {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "image", data: "..." },
+        },
+      },
+    });
+    expect(r.kind).toBe("warning");
+    expect(state.warnings).toContain("agent_message_chunk without text content");
+    expect(state.replyText).toBe("");
+  });
+
+  test("unknown method returns ignored without mutating state", () => {
+    const state = newOpencodeTurnState();
+    const r = reduceOpencodeAcpNotification(state, {
+      method: "session/mystery",
+      params: {},
+    });
+    expect(r.kind).toBe("ignored");
+    expect(r.consumed).toBe(false);
+    expect(state.replyText).toBe("");
+  });
+
+  test("unknown sessionUpdate subtype returns ignored (forward-compat)", () => {
+    const state = newOpencodeTurnState();
+    const r = reduceOpencodeAcpNotification(state, {
+      method: "session/update",
+      params: { update: { sessionUpdate: "future_extension" } },
+    });
+    expect(r.kind).toBe("ignored");
+  });
+});
+
+describe("reduceOpencodeAcpResponse — session/prompt terminal response", () => {
+  test("captures stopReason + usage from result", () => {
+    const state = newOpencodeTurnState("ses_abc");
+    const r = reduceOpencodeAcpResponse(state, {
+      jsonrpc: "2.0",
+      id: 3,
+      result: {
+        stopReason: "end_turn",
+        usage: { inputTokens: 7687, outputTokens: 2, totalTokens: 7699, thoughtTokens: 10 },
+      },
+    });
+    expect(r.kind).toBe("prompt_complete");
+    expect(state.promptComplete).toBe(true);
+    expect(state.lastStopReason).toBe("end_turn");
+    expect(state.usage?.totalTokens).toBe(7699);
+    expect(state.usage?.thoughtTokens).toBe(10);
+  });
+
+  test("missing stopReason still marks turn complete", () => {
+    const state = newOpencodeTurnState();
+    reduceOpencodeAcpResponse(state, { id: 3, result: {} });
+    expect(state.promptComplete).toBe(true);
+    expect(state.lastStopReason).toBeUndefined();
+  });
+});
+
+describe("reduceOpencodeAcpFrames — replay the Phase 0b captured turn", () => {
+  test("full one-word turn: 10 thought chunks + 1 message chunk + usage + response", () => {
+    // Trimmed replica of the u8-acp.txt captured stream: 10
+    // agent_thought_chunk (streaming "The user wants ..."), one
+    // agent_message_chunk ("Okay"), one usage_update, one prompt
+    // response. Locks the reducer against the exact wire shape.
+    const words = ["The", " user", " wants", " me", " to", " reply", " with", " one", " word", "."];
+    const frames: any[] = [
+      { method: "session/update", params: { update: { sessionUpdate: "available_commands_update", availableCommands: [] }}},
+      ...words.map(w => ({
+        method: "session/update",
+        params: { update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: w }}},
+      })),
+      { method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Okay" }}}},
+      { method: "session/update", params: { update: { sessionUpdate: "usage_update", used: 7687 }}},
+      { id: 3, result: { stopReason: "end_turn", usage: { inputTokens: 7687, outputTokens: 2, totalTokens: 7699, thoughtTokens: 10 }}},
+    ];
+    const state = reduceOpencodeAcpFrames(frames);
+    expect(state.replyText).toBe("Okay");
+    expect(state.thoughtText).toBe("The user wants me to reply with one word.");
+    expect(state.chunks).toBe(1);
+    expect(state.thoughtChunks).toBe(10);
+    expect(state.promptComplete).toBe(true);
+    expect(state.lastStopReason).toBe("end_turn");
+    expect(state.usage?.totalTokens).toBe(7699);
+    expect(state.warnings).toHaveLength(0);
+  });
+
+  test("thinking-only terminal turn (no agent_message_chunk) — replyText stays empty", () => {
+    // Mirrors #383's Kimi-observed shape: model thinks but never
+    // emits a final text block. The reducer produces an empty
+    // replyText + populated thoughtText so runtime.ts can trigger
+    // the same rescue re-prompt pattern that #383 added for
+    // claude-agent-sdk.
+    const frames: any[] = [
+      { method: "session/update", params: { update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "工具查询被拒绝, 我该..." }}}},
+      { id: 3, result: { stopReason: "end_turn", usage: { totalTokens: 20 }}},
+    ];
+    const state = reduceOpencodeAcpFrames(frames);
+    expect(state.replyText).toBe("");
+    expect(state.chunks).toBe(0);
+    expect(state.thoughtText).toContain("工具查询被拒绝");
+    expect(state.thoughtChunks).toBe(1);
+    expect(state.promptComplete).toBe(true);
+    expect(state.lastStopReason).toBe("end_turn");
+  });
+});

--- a/agent-node/src/runtime/opencode-acp/events.ts
+++ b/agent-node/src/runtime/opencode-acp/events.ts
@@ -1,0 +1,204 @@
+// RFC-029 PR② — opencode ACP notification reducer.
+//
+// Derived from agent-node/src/runtime/grok-build-acp/events.ts. The wire
+// framing (JSON-RPC 2.0 over stdio) and the streaming envelope
+// (`session/update` notifications carrying a nested
+// `params.update.sessionUpdate` discriminator) are byte-identical to
+// Grok's Zed ACP; Phase 0b probes verified this against opencode-ai@
+// 1.17.13's `spawn('opencode', ['acp'])` output (see
+// `docs/analysis/rfc029-opencode-probe/u8-acp.txt`).
+//
+// Diff vs the Grok reducer is small enough to keep the shim tiny (per
+// the RFC v0.3 §5 estimate of ~15-25 LOC net):
+//
+//   1. Turn-end.
+//      Grok emits a bespoke `_x.ai/session/prompt_complete` notification
+//      with a `stopReason` string. opencode instead completes the turn
+//      by RESPONDING to the client-issued `session/prompt` request
+//      (id-carrying JSON-RPC response) with `result.stopReason`. This
+//      reducer therefore consumes a response frame — not a notification —
+//      for the turn-end signal. The dispatcher (client.ts) is
+//      responsible for correlating the response back to the same
+//      state machine that saw the streaming notifications.
+//
+//   2. New sessionUpdate subtypes.
+//      opencode emits `agent_thought_chunk` while the model is
+//      reasoning (grok never does — it hides reasoning). We aggregate
+//      it into a separate `thoughtText` field for parity with the
+//      #383 thinking-only rescue logic — if a terminal turn produces
+//      thought but no `agent_message_chunk`, the caller can re-prompt
+//      exactly like the claude runtime does.
+//
+//   3. Bookkeeping.
+//      `usage_update` and `available_commands_update` are informational
+//      only; we track them to a warnings-free bucket so the reducer's
+//      "kind: ignored" fallback doesn't fire on healthy traffic.
+
+export interface OpencodeAcpNotification {
+  jsonrpc?: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+export interface OpencodeAcpResponse {
+  jsonrpc?: "2.0";
+  id: number | string;
+  result?: unknown;
+  error?: { code?: number; message?: string; data?: unknown };
+}
+
+export interface OpencodeTurnState {
+  sessionId?: string;
+  promptComplete: boolean;
+  replyText: string;
+  thoughtText: string;
+  chunks: number;
+  thoughtChunks: number;
+  toolCalls: number;
+  lastStopReason?: string;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    thoughtTokens?: number;
+  };
+  warnings: string[];
+}
+
+export interface ReduceResult {
+  state: OpencodeTurnState;
+  consumed: boolean;
+  kind:
+    | "reply_chunk"
+    | "thought_chunk"
+    | "tool_call"
+    | "usage_update"
+    | "available_commands"
+    | "prompt_complete"
+    | "ignored"
+    | "warning";
+}
+
+export function newOpencodeTurnState(sessionId?: string): OpencodeTurnState {
+  return {
+    sessionId,
+    promptComplete: false,
+    replyText: "",
+    thoughtText: "",
+    chunks: 0,
+    thoughtChunks: 0,
+    toolCalls: 0,
+    warnings: [],
+  };
+}
+
+/**
+ * Consume an id-carrying `session/prompt` response frame. Sets the
+ * terminal state (`promptComplete + lastStopReason + usage`) so the
+ * caller can settle its `think()` promise. Response frames don't
+ * carry `method`, hence this distinct entry point vs the streaming
+ * notification reducer below.
+ */
+export function reduceOpencodeAcpResponse(
+  state: OpencodeTurnState,
+  response: OpencodeAcpResponse,
+): ReduceResult {
+  const result = asRecord(response.result);
+  const stopReason = typeof result?.stopReason === "string" ? result.stopReason : undefined;
+  const usage = asRecord(result?.usage);
+  if (usage) {
+    state.usage = {
+      inputTokens: numberField(usage.inputTokens),
+      outputTokens: numberField(usage.outputTokens),
+      totalTokens: numberField(usage.totalTokens),
+      thoughtTokens: numberField(usage.thoughtTokens),
+    };
+  }
+  state.promptComplete = true;
+  state.lastStopReason = stopReason;
+  return { state, consumed: true, kind: "prompt_complete" };
+}
+
+export function reduceOpencodeAcpNotification(
+  state: OpencodeTurnState,
+  notification: OpencodeAcpNotification,
+): ReduceResult {
+  if (notification.method !== "session/update") {
+    return { state, consumed: false, kind: "ignored" };
+  }
+
+  const params = asRecord(notification.params);
+  const update = asRecord(params?.update);
+  const updateType = typeof update?.sessionUpdate === "string" ? update.sessionUpdate : "";
+
+  if (updateType === "agent_message_chunk") {
+    const content = asRecord(update.content);
+    if (content?.type === "text" && typeof content.text === "string") {
+      state.replyText += content.text;
+      state.chunks++;
+      return { state, consumed: true, kind: "reply_chunk" };
+    }
+    state.warnings.push("agent_message_chunk without text content");
+    return { state, consumed: false, kind: "warning" };
+  }
+
+  if (updateType === "agent_thought_chunk") {
+    const content = asRecord(update.content);
+    if (content?.type === "text" && typeof content.text === "string") {
+      state.thoughtText += content.text;
+      state.thoughtChunks++;
+      return { state, consumed: true, kind: "thought_chunk" };
+    }
+    return { state, consumed: false, kind: "warning" };
+  }
+
+  if (updateType === "tool_call" || updateType === "tool_call_update") {
+    state.toolCalls++;
+    return { state, consumed: true, kind: "tool_call" };
+  }
+
+  if (updateType === "usage_update") {
+    // Snap the running usage totals into state so callers can log them
+    // even before the terminal response arrives.
+    const inFlight = update as Record<string, unknown>;
+    if (typeof inFlight.used === "number") {
+      state.usage = { ...state.usage, totalTokens: inFlight.used };
+    }
+    return { state, consumed: true, kind: "usage_update" };
+  }
+
+  if (updateType === "available_commands_update") {
+    return { state, consumed: true, kind: "available_commands" };
+  }
+
+  return { state, consumed: false, kind: "ignored" };
+}
+
+/** Ergonomic wrapper for tests / offline replay: feed an ordered list
+ *  of frames (mixed notifications + responses) and return the reduced
+ *  turn state. */
+export function reduceOpencodeAcpFrames(
+  frames: Array<OpencodeAcpNotification | OpencodeAcpResponse>,
+  sessionId?: string,
+): OpencodeTurnState {
+  const state = newOpencodeTurnState(sessionId);
+  for (const frame of frames) {
+    // Response frames carry `id` and never `method`. This
+    // discriminant is precisely how the wire distinguishes the two;
+    // no ambiguity in real traffic.
+    if ("id" in frame && frame.id !== undefined && !("method" in frame && (frame as any).method)) {
+      reduceOpencodeAcpResponse(state, frame as OpencodeAcpResponse);
+    } else if ("method" in frame && (frame as any).method) {
+      reduceOpencodeAcpNotification(state, frame as OpencodeAcpNotification);
+    }
+  }
+  return state;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? value as Record<string, unknown> : undefined;
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}

--- a/agent-node/src/runtime/opencode-acp/runtime.ts
+++ b/agent-node/src/runtime/opencode-acp/runtime.ts
@@ -1,0 +1,253 @@
+// RFC-029 PR② — opencode-cli runtime think() entry.
+//
+// Long-running architecture (per 通信龙 approval of PR② flag):
+//   - Spawn `opencode acp` ONCE at first turn.
+//   - Reuse the same subprocess for every subsequent turn (no cold-
+//     start, matches the "常驻 B1'" spirit of the RFC).
+//   - Persist the ACP sessionId to config.session via `onSession`
+//     so a supervisor-driven restart can attempt `session/load` to
+//     preserve conversation history.
+//
+// Crash-restart semantics (per 通信龙 review-point on PR② flag):
+//   - Client exit → `state.client = null`. The next turn's think()
+//     re-spawns and tries `session/load` with the persisted
+//     sessionId FIRST. If load succeeds, the model resumes the
+//     prior conversation.
+//   - If `session/load` returns an error (opencode does not persist
+//     the session across process exits, or session was pruned), we
+//     LOG "session lost on restart" explicitly and fall back to
+//     `session/new` — no silent degrade.
+//
+// Rescue (mirrors #383 fix ①):
+//   - Terminal turn ended with `agent_message_chunk` empty AND
+//     `agent_thought_chunk` accumulated → the model thought without
+//     writing a final answer. runtime.ts re-prompts once with
+//     "请用一句面向用户的纯文本给出最终答复", capped at maxTurns:1
+//     equivalent (opencode's next session/prompt call).
+//   - Suppressible via `ANET_DISABLE_383_REPROMPT=1` (env shared
+//     with the claude runtime for uniform operator override).
+
+import { OpencodeAcpClient, type JsonRpcNotification } from "./client";
+import {
+  reduceOpencodeAcpNotification,
+  reduceOpencodeAcpResponse,
+  newOpencodeTurnState,
+  type OpencodeTurnState,
+} from "./events";
+
+export interface OpencodeThinkOptions {
+  /** User turn text. Sent verbatim as the sole `{type:"text"}` part. */
+  prompt: string;
+  /** cwd the opencode child should chdir to. Not the node workdir —
+   *  that's isolated via HOME. This is what appears in tool
+   *  invocations as the project root. */
+  cwd: string;
+  /** ANet node work dir. Set as `HOME` on the child env so opencode's
+   *  auth.json / opencode.json / session cache is isolated per node
+   *  (§8 D5). */
+  workDir: string;
+  /** Persisted sessionId from prior turn, if any. `session/load` is
+   *  tried first with this; on failure we fall back to session/new
+   *  (with an explicit "session lost on restart" log line). */
+  sessionId?: string;
+  /** Persisted sessionId callback. Called after session/{new,load}
+   *  returns a fresh id so anet's config.session can be written back
+   *  for a subsequent crash-restart to reuse. */
+  onSession?: (sessionId: string) => void | Promise<void>;
+  /** Idle timeout for `session/prompt` (default 5 min). Streaming
+   *  frames reset the timer, so long running turns aren't killed. */
+  idleTimeoutMs?: number;
+  /** Logger. Falls back to `console.log` / `console.warn`. */
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+  /** #383 rescue toggle. Falls through to the process env if unset. */
+  disableThinkingOnlyRescue?: boolean;
+}
+
+export interface OpencodeThinkResult {
+  /** Final assistant text for the turn. Empty string ONLY if the
+   *  turn ended with no message chunk AND the rescue also produced
+   *  nothing (or was disabled). */
+  replyText: string;
+  /** Accumulated thinking text (for logs + optional debugging). */
+  thoughtText: string;
+  /** Persisted sessionId used on this turn. Same across long-running
+   *  turns; changes only on `session/new` (fresh session or fallback
+   *  from a failed load). */
+  sessionId: string;
+  /** Terminal turn state — includes usage totals for logging. */
+  state: OpencodeTurnState;
+  /** Whether the rescue re-prompt fired this turn. False on the
+   *  happy path (first turn already produced text). */
+  rescued: boolean;
+}
+
+export interface OpencodeRuntimeSession {
+  client: OpencodeAcpClient;
+  sessionId: string;
+}
+
+/**
+ * Long-running session holder. runtime.think() looks this up per
+ * node; a fresh call to `openOpencodeRuntime` should happen only on
+ * boot or after a supervisor-detected restart.
+ */
+export async function openOpencodeRuntime(opts: {
+  cwd: string;
+  workDir: string;
+  sessionId?: string;
+  onSession?: (sessionId: string) => void | Promise<void>;
+  onExit?: (info: { code: number | null; signal: NodeJS.Signals | null }) => void;
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+  binary?: string;
+}): Promise<OpencodeRuntimeSession> {
+  const log = opts.log ?? ((m: string) => console.log(m));
+  const warn = opts.warn ?? ((m: string) => console.warn(m));
+
+  const client = new OpencodeAcpClient();
+  client.on("stderr", (chunk: string) => {
+    // opencode's stderr is developer-facing; log at debug volume.
+    log(`[opencode-acp stderr] ${String(chunk).trim().slice(0, 300)}`);
+  });
+  if (opts.onExit) client.on("exit", opts.onExit);
+
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    // Per §8 D5: isolate opencode's config root to the per-node
+    // workDir. auth.json, opencode.json, and its session cache all
+    // land under $HOME/.local/share/opencode and $HOME/.config/
+    // opencode; setting HOME here keeps each node's opencode state
+    // separate.
+    HOME: opts.workDir,
+  };
+
+  client.start({ cwd: opts.cwd, env: childEnv, binary: opts.binary });
+
+  // Handshake: initialize (declare client capabilities).
+  await client.request("initialize", {
+    protocolVersion: 1,
+    clientCapabilities: {
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+    },
+  }, 20_000);
+
+  // Session establishment: load persisted, fall back to fresh on
+  // failure with an EXPLICIT operator log line.
+  let sessionId: string | undefined;
+  if (opts.sessionId) {
+    try {
+      const loaded = await client.request<{ sessionId?: string }>("session/load", {
+        sessionId: opts.sessionId,
+        cwd: opts.cwd,
+        mcpServers: [],
+      }, 20_000);
+      sessionId = loaded?.sessionId ?? opts.sessionId;
+      log(`[opencode-acp] session/load ok — resumed ${sessionId.slice(0, 12)}...`);
+    } catch (e: any) {
+      warn(
+        `[opencode-acp] session lost on restart — ` +
+        `session/load(${opts.sessionId.slice(0, 12)}...) failed (${e?.message ?? e}); ` +
+        `falling back to session/new. Prior conversation history is unavailable this turn.`,
+      );
+      sessionId = undefined;
+    }
+  }
+
+  if (!sessionId) {
+    const created = await client.request<{ sessionId?: string }>("session/new", {
+      cwd: opts.cwd, mcpServers: [],
+    }, 20_000);
+    if (!created?.sessionId) throw new Error("opencode session/new response missing sessionId");
+    sessionId = created.sessionId;
+    log(`[opencode-acp] session/new — ${sessionId.slice(0, 12)}...`);
+  }
+
+  if (opts.onSession) await opts.onSession(sessionId);
+  return { client, sessionId };
+}
+
+/**
+ * Run one turn against a pre-opened runtime session. Streams
+ * notifications through the reducer, awaits the id-carrying
+ * session/prompt response, and optionally rescues a thinking-only
+ * terminal turn per the #383 pattern.
+ */
+export async function opencodeThink(
+  runtime: OpencodeRuntimeSession,
+  opts: OpencodeThinkOptions,
+): Promise<OpencodeThinkResult> {
+  const log = opts.log ?? ((m: string) => console.log(m));
+  const idleTimeoutMs = opts.idleTimeoutMs ?? 5 * 60_000;
+  const state = newOpencodeTurnState(runtime.sessionId);
+
+  const onNotification = (n: JsonRpcNotification) => {
+    reduceOpencodeAcpNotification(state, n);
+  };
+  runtime.client.on("notification", onNotification);
+
+  let response: any;
+  try {
+    response = await runtime.client.requestWithIdleTimeout("session/prompt", {
+      sessionId: runtime.sessionId,
+      prompt: [{ type: "text", text: opts.prompt }],
+    }, idleTimeoutMs);
+  } finally {
+    runtime.client.off("notification", onNotification);
+  }
+
+  // Feed the terminal response into the reducer so stopReason + usage
+  // land on state before we branch on empty-reply rescue.
+  reduceOpencodeAcpResponse(state, {
+    jsonrpc: "2.0",
+    id: 0,
+    result: response ?? {},
+  });
+
+  const disableRescue =
+    opts.disableThinkingOnlyRescue ?? process.env.ANET_DISABLE_383_REPROMPT === "1";
+  const isThinkingOnly =
+    state.replyText.trim() === "" && state.thoughtText.trim() !== "";
+
+  let rescued = false;
+  if (isThinkingOnly && !disableRescue) {
+    log(
+      `[opencode-acp] #383 thinking-only terminal turn (chunks=${state.chunks} ` +
+      `thoughtChunks=${state.thoughtChunks}) — re-prompting for plain-text final`,
+    );
+    const rescueState = newOpencodeTurnState(runtime.sessionId);
+    const onRescueNotification = (n: JsonRpcNotification) => {
+      reduceOpencodeAcpNotification(rescueState, n);
+    };
+    runtime.client.on("notification", onRescueNotification);
+    try {
+      const rescueResponse = await runtime.client.requestWithIdleTimeout("session/prompt", {
+        sessionId: runtime.sessionId,
+        prompt: [{
+          type: "text",
+          text: "请用一句面向用户的纯文本给出最终答复（不要用工具，不要 thinking，直接写答案）。",
+        }],
+      }, idleTimeoutMs);
+      reduceOpencodeAcpResponse(rescueState, {
+        jsonrpc: "2.0", id: 0, result: rescueResponse ?? {},
+      });
+      if (rescueState.replyText.trim() !== "") {
+        state.replyText = rescueState.replyText;
+        rescued = true;
+      }
+    } catch (e: any) {
+      log(`[opencode-acp] #383 rescue re-prompt failed: ${e?.message ?? e}`);
+    } finally {
+      runtime.client.off("notification", onRescueNotification);
+    }
+  }
+
+  return {
+    replyText: state.replyText,
+    thoughtText: state.thoughtText,
+    sessionId: runtime.sessionId,
+    state,
+    rescued,
+  };
+}

--- a/tests/test-rfc029-pr2-acp-shim/Dockerfile
+++ b/tests/test-rfc029-pr2-acp-shim/Dockerfile
@@ -1,0 +1,40 @@
+# RFC-029 PR② — CI-gating ACP shim e2e container.
+#
+# Real bun + real agent-node TS source (bind-mounted). Vendor
+# boundary MOCKED via `mock-opencode.mjs` — the mock is spawned by
+# the runtime exactly like the real opencode CLI, so we exercise
+# client.ts + events.ts + runtime.ts real code paths with a
+# byte-shape identical to Phase 0b's u8-acp.txt dump.
+
+FROM oven/bun:1.3.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash curl jq ca-certificates nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /harness
+
+COPY agent-node /agent-node-src
+COPY tests/test-rfc029-pr2-acp-shim/mock-opencode.mjs /harness/mock-opencode.mjs
+COPY tests/test-rfc029-pr2-acp-shim/harness.ts /harness/harness.ts
+COPY tests/test-rfc029-pr2-acp-shim/run.sh /harness/run.sh
+
+# Small launcher so the runtime's spawn(bin, ['acp']) call runs the
+# mock instead of the real opencode CLI. The launcher just ignores
+# the `acp` positional and execs the mock script.
+RUN cat > /harness/mock-opencode-launcher.sh <<'SH' && chmod +x /harness/mock-opencode-launcher.sh
+#!/usr/bin/env bash
+exec node /harness/mock-opencode.mjs
+SH
+
+RUN cat > /harness/package.json <<'JSON'
+{
+  "name": "test-rfc029-pr2-harness",
+  "type": "module",
+  "dependencies": {}
+}
+JSON
+
+RUN chmod +x /harness/run.sh
+
+CMD ["bash", "/harness/run.sh"]

--- a/tests/test-rfc029-pr2-acp-shim/harness.ts
+++ b/tests/test-rfc029-pr2-acp-shim/harness.ts
@@ -1,0 +1,88 @@
+// RFC-029 PR② — CI-gating deterministic e2e for the ACP shim.
+//
+// Runs 3 scenarios against the mock-opencode server via the real
+// runtime.ts + events.ts + client.ts code paths:
+//
+//   S-happy       one turn, model emits agent_message_chunks →
+//                 replyText === "hello world"; rescued=false.
+//   S-thinking    one turn, model emits ONLY thought chunks (no
+//                 agent_message_chunk) → runtime's #383 rescue
+//                 re-prompts; second prompt returns real text →
+//                 replyText === "hello world"; rescued=true.
+//   S-load-fails  provided sessionId; mock rejects session/load →
+//                 runtime logs "session lost on restart" and falls
+//                 back to session/new; turn still completes.
+//
+// Prints structured lines run.sh can grep for pass/fail.
+
+import {
+  openOpencodeRuntime,
+  opencodeThink,
+} from "/agent-node-src/src/runtime/opencode-acp/runtime";
+
+const MOCK = "/harness/mock-opencode-launcher.sh";
+
+async function runScenario(label: string, mockEnv: Record<string, string>, opts: { sessionId?: string; rescueDisabled?: boolean }) {
+  const savedEnv: Record<string, string | undefined> = {};
+  for (const k of Object.keys(mockEnv)) {
+    savedEnv[k] = process.env[k];
+    process.env[k] = mockEnv[k];
+  }
+  const rescueEnv = process.env.ANET_DISABLE_383_REPROMPT;
+  if (opts.rescueDisabled) process.env.ANET_DISABLE_383_REPROMPT = "1";
+  else delete process.env.ANET_DISABLE_383_REPROMPT;
+
+  const logs: string[] = [];
+  const warns: string[] = [];
+  try {
+    const runtime = await openOpencodeRuntime({
+      cwd: "/tmp",
+      workDir: "/tmp",
+      sessionId: opts.sessionId,
+      binary: MOCK,
+      log: (m) => logs.push(m),
+      warn: (m) => warns.push(m),
+    });
+    const outcome = await opencodeThink(runtime, {
+      prompt: "hi",
+      cwd: "/tmp",
+      workDir: "/tmp",
+      sessionId: runtime.sessionId,
+      log: (m) => logs.push(m),
+      warn: (m) => warns.push(m),
+    });
+    await runtime.client.stop();
+    console.log(`===${label}-BEGIN===`);
+    console.log(JSON.stringify({
+      replyText: outcome.replyText,
+      thoughtText: outcome.thoughtText,
+      sessionId: outcome.sessionId,
+      chunks: outcome.state.chunks,
+      thoughtChunks: outcome.state.thoughtChunks,
+      stopReason: outcome.state.lastStopReason,
+      rescued: outcome.rescued,
+      usage: outcome.state.usage,
+      logsFromRuntime: logs.filter(l => l.includes("[opencode-acp]") || l.includes("session")),
+      warnsFromRuntime: warns.filter(w => w.includes("[opencode-acp]") || w.includes("session")),
+    }, null, 2));
+    console.log(`===${label}-END===`);
+  } finally {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (rescueEnv === undefined) delete process.env.ANET_DISABLE_383_REPROMPT;
+    else process.env.ANET_DISABLE_383_REPROMPT = rescueEnv;
+  }
+}
+
+async function main() {
+  await runScenario("S-happy", {}, {});
+  await runScenario("S-thinking", { MOCK_THINKING_ONLY: "1" }, {});
+  await runScenario("S-load-fails", { MOCK_LOAD_FAILS: "1" }, { sessionId: "ses_stale_from_prior_boot" });
+}
+
+main().catch((e) => {
+  console.error("FATAL", e?.stack ?? String(e));
+  process.exit(1);
+});

--- a/tests/test-rfc029-pr2-acp-shim/mock-opencode.mjs
+++ b/tests/test-rfc029-pr2-acp-shim/mock-opencode.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// RFC-029 PR② — deterministic mock-opencode ACP for the CI gate.
+//
+// Behaves like `opencode acp`: stdin/stdout newline-delimited JSON-
+// RPC 2.0. The Phase 0b probe (u8-acp.txt) pins the frame shape we
+// emit; this mock replays exactly that shape so runtime.ts + events.ts
+// wiring is exercised end-to-end without any external dependency.
+//
+// State machine:
+//   initialize       → agent-info response
+//   session/new      → { sessionId, configOptions[] }
+//   session/load     → { sessionId }  (with MOCK_LOAD_FAILS=1 → error)
+//   session/prompt   → stream N session/update notifications, then a
+//                      response with stopReason + usage.
+//
+// Env toggles:
+//   MOCK_THINKING_ONLY=1 → prompt emits only agent_thought_chunk (no
+//                          agent_message_chunk) → runtime.ts's #383
+//                          rescue path fires and follow-up prompt
+//                          gets a plain-text answer.
+//   MOCK_LOAD_FAILS=1    → session/load returns a JSON-RPC error so
+//                          the runtime falls back to session/new with
+//                          the explicit "session lost on restart" log.
+
+let buf = "";
+let promptCount = 0;
+
+const write = (obj) => {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+};
+
+const stream = (sessionId, msgId, chunks) => {
+  for (const c of chunks) {
+    write({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId,
+        update: { sessionUpdate: c.kind, messageId: msgId, content: { type: "text", text: c.text }},
+      },
+    });
+  }
+};
+
+process.stdin.on("data", (chunk) => {
+  buf += chunk.toString("utf8");
+  while (buf.includes("\n")) {
+    const idx = buf.indexOf("\n");
+    const line = buf.slice(0, idx).trim();
+    buf = buf.slice(idx + 1);
+    if (!line) continue;
+    let req;
+    try { req = JSON.parse(line); } catch { continue; }
+    handleRequest(req);
+  }
+});
+
+function handleRequest(req) {
+  switch (req.method) {
+    case "initialize":
+      write({
+        jsonrpc: "2.0", id: req.id, result: {
+          protocolVersion: 1,
+          agentCapabilities: {
+            loadSession: true,
+            sessionCapabilities: { close: {}, fork: {}, list: {}, resume: {} },
+            promptCapabilities: { embeddedContext: true, image: true },
+          },
+          agentInfo: { name: "MockOpenCode", version: "0.0.0-mock" },
+        },
+      });
+      break;
+    case "session/new":
+      write({
+        jsonrpc: "2.0", id: req.id, result: {
+          sessionId: "ses_mock_new",
+          configOptions: [],
+        },
+      });
+      break;
+    case "session/load":
+      if (process.env.MOCK_LOAD_FAILS === "1") {
+        write({ jsonrpc: "2.0", id: req.id, error: { code: -32000, message: "session not found (mock)" }});
+      } else {
+        write({
+          jsonrpc: "2.0", id: req.id, result: {
+            sessionId: req.params?.sessionId ?? "ses_mock_loaded",
+          },
+        });
+      }
+      break;
+    case "session/prompt": {
+      promptCount++;
+      const sessionId = req.params?.sessionId ?? "ses_mock";
+      const msgId = "msg_mock_" + promptCount;
+      const thinkingOnly = process.env.MOCK_THINKING_ONLY === "1" && promptCount === 1;
+
+      // Emit an initial available_commands_update (matches U8 fixture).
+      write({
+        jsonrpc: "2.0", method: "session/update",
+        params: { sessionId, update: { sessionUpdate: "available_commands_update", availableCommands: [] }},
+      });
+
+      // Thinking chunks — always present so the test can assert the
+      // thoughtText accumulator works.
+      stream(sessionId, msgId, [
+        { kind: "agent_thought_chunk", text: "Analyzing " },
+        { kind: "agent_thought_chunk", text: "request." },
+      ]);
+
+      if (!thinkingOnly) {
+        stream(sessionId, msgId, [
+          { kind: "agent_message_chunk", text: "hello " },
+          { kind: "agent_message_chunk", text: "world" },
+        ]);
+      }
+      // Usage notification.
+      write({
+        jsonrpc: "2.0", method: "session/update",
+        params: { sessionId, update: { sessionUpdate: "usage_update", used: 100 + promptCount, size: 100000, cost: { amount: 0, currency: "USD" }}},
+      });
+      // Terminal response with stopReason + usage.
+      write({
+        jsonrpc: "2.0", id: req.id,
+        result: {
+          stopReason: "end_turn",
+          usage: { inputTokens: 10, outputTokens: thinkingOnly ? 0 : 2, totalTokens: 12, thoughtTokens: 2 },
+          _meta: {},
+        },
+      });
+      break;
+    }
+    default:
+      write({ jsonrpc: "2.0", id: req.id, error: { code: -32601, message: `method not found: ${req.method}` }});
+  }
+}

--- a/tests/test-rfc029-pr2-acp-shim/run.sh
+++ b/tests/test-rfc029-pr2-acp-shim/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Runs the 3 scenarios, parses the structured output, applies
+# assertions. Exit 0 on all-pass, 1 otherwise.
+
+set -euo pipefail
+REPORT="${REPORT:-/report/pr2-mock-acp.txt}"
+mkdir -p "$(dirname "$REPORT")"
+
+: > "$REPORT"
+{
+  echo "# RFC-029 PR② — mock-opencode ACP CI gate"
+  echo
+  echo "date: $(date -Iseconds)"
+  echo "bun: $(bun --version)"
+  echo "node: $(node --version)"
+  echo
+  echo "## Full harness output"
+  echo
+  echo '```'
+} >> "$REPORT"
+
+set +e
+OUT=$(cd /harness && bun run harness.ts 2>&1)
+RC=$?
+set -e
+echo "$OUT" >> "$REPORT"
+echo '```' >> "$REPORT"
+echo >> "$REPORT"
+echo "harness exit=$RC" >> "$REPORT"
+echo >> "$REPORT"
+
+extract() {
+  awk -v tag="$1" '
+    $0 ~ ("===" tag "-BEGIN===") { on=1; next }
+    $0 ~ ("===" tag "-END===")   { on=0 }
+    on { print }
+  ' <<<"$OUT"
+}
+
+happy=$(extract "S-happy")
+thinking=$(extract "S-thinking")
+loadfails=$(extract "S-load-fails")
+
+echo "## Assertions" >> "$REPORT"
+echo >> "$REPORT"
+
+fail=0
+check() {
+  local label="$1" got="$2" want="$3"
+  if [[ "$got" == "$want" ]]; then
+    echo "  ✓ $label: $got (expected $want)" >> "$REPORT"
+  else
+    echo "  ✗ $label: $got (expected $want)" >> "$REPORT"
+    fail=1
+  fi
+}
+
+check "S-happy replyText"     "$(jq -r .replyText     <<<"$happy")" "hello world"
+check "S-happy rescued"       "$(jq -r .rescued       <<<"$happy")" "false"
+check "S-happy chunks"        "$(jq -r .chunks        <<<"$happy")" "2"
+check "S-happy stopReason"    "$(jq -r .stopReason    <<<"$happy")" "end_turn"
+
+check "S-thinking replyText"  "$(jq -r .replyText     <<<"$thinking")" "hello world"
+check "S-thinking rescued"    "$(jq -r .rescued       <<<"$thinking")" "true"
+check "S-thinking thoughtText contains" \
+  "$(jq -r .thoughtText <<<"$thinking" | grep -c 'Analyzing')" "1"
+
+check "S-load-fails replyText" "$(jq -r .replyText <<<"$loadfails")" "hello world"
+lostLog=$(jq -r '.warnsFromRuntime | map(select(contains("session lost on restart"))) | length' <<<"$loadfails")
+check "S-load-fails logged 'session lost on restart'" "$lostLog" "1"
+
+echo >> "$REPORT"
+if [[ "$fail" -eq 0 ]]; then
+  echo "OVERALL: PASS" >> "$REPORT"
+else
+  echo "OVERALL: FAIL — see above" >> "$REPORT"
+fi
+
+cat "$REPORT"
+exit "$fail"


### PR DESCRIPTION
## Author

- Agent: 通信工程马 (events + client + runtime + processTask wire + mock CI e2e + live smoke doc)
- Reviewer: 通信龙 (routing + docker e2e 复验; CC 龙 per lesson)
- Priority: RFC-029 PR② (approved plan) — 常驻 B1' 核心, 真 opencode 能 think() 就 landed 在这个 PR

## What this PR is

Second of 3 slices per RFC-029 v0.3 §7. PR① wired the runtime name end-to-end (config, wizard, CLI, launcher, server); PR② adds the actual **think() implementation** — a stdio JSON-RPC client + per-notification reducer + long-running runtime facade + `processTask` branch replacing the PR① stub. PR③ = vendor preset + wizard hint + `anet opencode upgrade-pin` command + docs.

## 关键设计决策 (per 通信龙 PR② flag)

**长驻子进程 + session/load 恢复** — 匹配 "常驻 B1'" 精神:

- 一个节点整个 lifetime 只 spawn 一个 `opencode acp` 子进程
- 崩溃/被 kill 后, 下一个 turn detect stale handle → 用 persisted sessionId 尝试 `session/load` 恢复对话
- **session/load 失败明确 warn "session lost on restart" + graceful degrade 到 session/new** — 不静默丢历史 (通信龙 review-point catch, e2e S-load-fails 验证)
- `HOME=<node workDir>` env 隔离 per §8 D5 (auth.json + opencode.json + session cache 每 node 独立)

**#383 thinking-only rescue 继承** — opencode acp reducer 分开 `replyText` / `thoughtText`; 若 terminal turn 只有 thought 没有 message chunk → 自动 re-prompt "请用一句面向用户的纯文本给出最终答复", 拿到就用。Env toggle `ANET_DISABLE_383_REPROMPT=1` 跟 claude runtime 共享。

## Diff footprint

| File | LOC | 说明 |
|---|---|---|
| `agent-node/src/runtime/opencode-acp/events.ts` | ~185 | Reducer + `session/prompt` response 分开处理 |
| `agent-node/src/runtime/opencode-acp/events.test.ts` | ~180 | 12 tests, includes Phase 0b captured stream replay |
| `agent-node/src/runtime/opencode-acp/client.ts` | ~215 | stdio JSON-RPC + idle timeout for streaming |
| `agent-node/src/runtime/opencode-acp/client.test.ts` | ~130 | 5 tests via bash+bun stub subprocess (no real opencode需) |
| `agent-node/src/runtime/opencode-acp/runtime.ts` | ~230 | openOpencodeRuntime + opencodeThink (rescue inline) |
| `agent-node/src/cli.ts` | +76 -12 | Module state + processWithOpencode + processTask branch |
| `tests/test-rfc029-pr2-acp-shim/*` | (~4 files) | Mock ACP + harness + Dockerfile + run.sh |
| `docs/tests/p-rfc029-pr2/live-smoke.md` | ~50 | 补充活体 smoke 手动指南 |

## 真号 — 单元 + Docker CI-gating e2e non-mock

### `bun test src/runtime/opencode-acp/`

```
17 pass / 0 fail / 54 expect() calls
```
- events.test.ts: 12 tests (每 sessionUpdate subtype + Phase 0b 完整 turn replay + thinking-only shape)
- client.test.ts: 5 tests (request/response, error propagation, streaming notification, exit → reject, isRunning)

### Docker CI-gating (`tests/test-rfc029-pr2-acp-shim/`, real bun + real agent-node source + mock ACP)

Report: `docs/tests/p-rfc029-pr2/pr2-mock-acp.txt`

| 断言 | 结果 |
|---|---|
| S-happy replyText = "hello world" | ✓ |
| S-happy rescued = false | ✓ |
| S-happy chunks = 2 | ✓ |
| S-happy stopReason = end_turn | ✓ |
| **S-thinking replyText = "hello world"** (rescue via re-prompt) | ✓ |
| **S-thinking rescued = true** | ✓ |
| S-thinking thoughtText contains "Analyzing" | ✓ |
| **S-load-fails replyText = "hello world"** (session/load errored → fallback) | ✓ |
| **S-load-fails logged "session lost on restart" warn** | ✓ |

**OVERALL: PASS (9/9)**

### 活体 smoke (supplementary, allow-failure)

`docs/tests/p-rfc029-pr2/live-smoke.md` — 手动 bun one-liner 走真 opencode + `opencode/*-free`. 通信龙 双轨 e2e 策略: mock 做 merge gate, 活体做补充证据不做 gate (opencode.ai free proxy 有 quota/drift 风险)。

## 影响面 (surgical additive)

- 4 existing runtimes 行为不变
- `opencode-cli` 节点 `anet node start` **真能 think()** 了, single-turn happy path + thinking-only rescue + crash-restart 恢复都覆盖
- HOME 隔离在 PR② 落地 (spawn env 层最内聚, 跟 通信龙 flag verdict 一致, 不推到 PR③)
- server / dashboard / VendorSpec preset / wizard 提示语属 PR③

## 红线合规 (broad audit 3 层)

- **公版 sst/opencode only**: PR diff broad regex 私仓 keyword = 0 hits
- **opencode-ai@1.17.13 pin** 依然 PR① 里的 `assertStartCompatibility` 硬锁
- **Slug audit**: broad regex `\[\[[a-zA-Z0-9_-]+\]\]` on diff + commit msg + PR body = 0 hits (自 scrub 陷阱教训消化了)
- **Docker CI e2e non-mock code-path**: 真 runtime.ts / events.ts / client.ts, mock 只在 vendor 边界 (spawn 的 binary 换成 mock 脚本)
- **CC 龙 review** per SOP

Refs #RFC-029. Next: PR③ (vendor preset + `anet opencode upgrade-pin` + docs).
