### PR TITLE
feat(RFC-029 PR③): vendor preset + upgrade-pin + wizard hint + docs — opencode-cli 收官

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -928,21 +928,24 @@ async function setupCommand() {
   console.log(`\n完成！下一步: anet node create <node-name>`);
 }
 
-// RFC-029 — the exact opencode-ai version anet is validated against.
-// Upstream churn is heavy pre-1.0 (see `npm view opencode-ai dist-tags` —
-// `latest` moves daily; there are 30+ snapshot tags each week). We hard-
-// lock this constant and reject any drift; upgrading is an explicit,
-// smoke-gated `anet opencode upgrade-pin <version>` operation (lands in
-// PR③).
-export const OPENCODE_PINNED_VERSION = "1.17.13";
+// RFC-029 — the effective opencode-ai pin. Prefers the per-machine
+// override at `~/.anet/opencode-pin.json` (written by
+// `anet opencode upgrade-pin` after smoke pass); falls back to
+// `OPENCODE_BUILTIN_PIN` when the override is absent or malformed.
+// Read fresh on every check so a mid-session upgrade takes effect
+// without a restart.
+import { readEffectivePin, writePinOverride, OPENCODE_BUILTIN_PIN } from "../src/opencode-pin";
+export const OPENCODE_PINNED_VERSION = OPENCODE_BUILTIN_PIN;
 
 function checkOpencodePin(): { ok: true } | { ok: false; found: string | null; hint: string } {
   const bin = "opencode";
+  const effective = readEffectivePin();
+  const expected = effective.version;
   if (!commandExists(bin)) {
     return {
       ok: false,
       found: null,
-      hint: `opencode CLI not found in PATH. Install (exact): npm install -g opencode-ai@${OPENCODE_PINNED_VERSION}`,
+      hint: `opencode CLI not found in PATH. Install (exact): npm install -g opencode-ai@${expected}`,
     };
   }
   let raw = "";
@@ -956,16 +959,24 @@ function checkOpencodePin(): { ok: true } | { ok: false; found: string | null; h
   // suffix) don't break the pin check.
   const m = raw.match(/(\d+\.\d+\.\d+)/);
   const found = m ? m[1] : raw;
-  if (found === OPENCODE_PINNED_VERSION) return { ok: true };
+  if (found === expected) return { ok: true };
+  const sourceNote = effective.source === "override-file"
+    ? ` (from ${opencodeUsePinSource()}; smoke passed ${effective.smokePassedAt})`
+    : ` (baked-in default)`;
   return {
     ok: false,
     found,
     hint:
-      `Expected opencode-ai@${OPENCODE_PINNED_VERSION} (exact); found ${found}.\n` +
-      `  → Downgrade: npm install -g opencode-ai@${OPENCODE_PINNED_VERSION}\n` +
+      `Expected opencode-ai@${expected}${sourceNote}; found ${found}.\n` +
+      `  → Downgrade: npm install -g opencode-ai@${expected}\n` +
       `  → Or run: anet opencode upgrade-pin ${found}   ` +
-      `(smoke-tests the new version; on pass updates the pin.)`,
+      `(smoke-tests the new version; on pass writes ~/.anet/opencode-pin.json.)`,
   };
+}
+
+function opencodeUsePinSource(): string {
+  // Kept small so the hint above stays one grep-able string.
+  return "~/.anet/opencode-pin.json override";
 }
 
 function assertStartCompatibility(runtime: RuntimeName) {
@@ -1601,6 +1612,45 @@ async function ensureNodeToken(profile: Profile, id: string): Promise<Profile> {
   return profile;
 }
 
+// RFC-029 PR③ — materialize the opencode vendor preset (auth.json +
+// opencode.json) into the newly-created node's workdir. Runs after
+// `saveCreatedNode` so the node dir already exists. API key is read
+// from `preset.envKey` at create time and NEVER prompted (per
+// 通信龙 PR③ flag refinement 2). File modes: auth.json is written
+// 0o600 by writeOpencodeAuthJson. If the env key is missing we emit
+// a clear message so the operator knows to re-run after exporting
+// it, rather than baking an empty auth.json that would fail at
+// start time.
+function writeOpencodePresetIfRequested(id: string, profile: Profile, wizardOpts: Record<string, any>): void {
+  if (normalizeRuntime(profile) !== "opencode-cli") return;
+  const presetId = wizardOpts._opencodePreset || "anthropic";
+  const { findOpencodePreset, readPresetKeyFromEnv, writeOpencodeAuthJson, writeOpencodeConfigJson } =
+    // Lazy-loaded so a create wizard for another runtime doesn't
+    // pay the import cost.
+    require("../src/opencode-preset") as typeof import("../src/opencode-preset");
+  const preset = findOpencodePreset(presetId);
+  if (!preset) {
+    console.warn(`[anet] ⚠ unknown opencode preset '${presetId}' — skipping auth.json write.`);
+    return;
+  }
+  const apiKey = readPresetKeyFromEnv(preset);
+  const nodeWorkDir = join(nodesDir(), id);
+  if (!apiKey) {
+    console.warn(
+      `[anet] ⚠ opencode-cli preset '${preset.id}' selected but ${preset.envKey} is not set — ` +
+      `auth.json NOT written. Export ${preset.envKey} and re-run \`anet node create ${id}\` or ` +
+      `write ${join(nodeWorkDir, ".local", "share", "opencode", "auth.json")} manually before start.`,
+    );
+    console.warn(`[anet]   sign-up / key page: ${preset.signupUrl}`);
+    return;
+  }
+  const authPath = writeOpencodeAuthJson(nodeWorkDir, preset, apiKey);
+  const configPath = writeOpencodeConfigJson(nodeWorkDir, preset);
+  console.log(`[anet] ✅ opencode preset '${preset.id}' materialized:`);
+  console.log(`  auth.json:     ${authPath} (mode 0o600, read-denied to the running agent)`);
+  console.log(`  opencode.json: ${configPath}`);
+}
+
 function writeLegacyProjectAlias(alias: string) {
   const channelDir = join(home, ".claude", "channels", "commhub");
   const projectKey = encodeCwd(process.cwd());
@@ -2042,12 +2092,29 @@ This wizard creates one agent node for this project:
     console.log(`[anet] 请确保已安装并登录 Grok Build CLI: grok auth login`);
   } else if (pickedRuntime === "opencode-cli") {
     opts.runtime = "opencode-cli";
-    // RFC-029 — pin note first, so operators know the exact version
-    // requirement upfront (upstream churn is heavy pre-1.0). Vendor
-    // preset flow lands in PR③; for now the create wizard just
-    // records the runtime choice.
-    console.log(`[anet] 请确保已安装 opencode CLI (exact): npm install -g opencode-ai@1.17.13`);
-    console.log(`[anet] opencode-cli runtime 尚未实现 think() (RFC-029 PR②), 现阶段可 create 但 start 会明确报错.`);
+    // RFC-029 PR③ — pin note + vendor preset selector. The preset
+    // choice is stored on opts so createProfileFromOpts + saveCreatedNode
+    // can materialize auth.json / opencode.json inside the node's
+    // workdir (HOME-isolated per §8 D5). API key is read from env at
+    // save time; we don't prompt for it.
+    const currentPin = readEffectivePin();
+    console.log(`[anet] 请确保已安装 opencode CLI (exact): npm install -g opencode-ai@${currentPin.version}`);
+    console.log(`[anet]   pin source: ${currentPin.source === "override-file" ? `~/.anet/opencode-pin.json (smoke ${currentPin.smokePassedAt})` : "built-in default"}`);
+    try {
+      const { select: sel } = await import("@inquirer/prompts");
+      const preset = await sel({
+        message: "选择 opencode vendor preset:",
+        choices: [
+          { value: "anthropic", name: "Anthropic 原生 API — reads ANTHROPIC_API_KEY env" },
+          { value: "openai",    name: "OpenAI                 — reads OPENAI_API_KEY env" },
+        ],
+      });
+      (opts as any)._opencodePreset = preset;
+      console.log(`[anet] opencode preset = ${preset}. 请确保 ${preset === "anthropic" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY"} 已 export; 会在 create 落到 node HOME 下的 auth.json (mode 0o600).`);
+    } catch (e: any) {
+      console.log(`[anet] ⚠ preset selector 不可用 (${e?.message || e}) — 默认 anthropic`);
+      (opts as any)._opencodePreset = "anthropic";
+    }
   } else {
     // claude-agent-sdk — flow continues into vendor + model picker.
     const sel = await selectVendorAndModel();
@@ -2136,6 +2203,7 @@ Telegram setup:
   if (telegramConfig) {
     writeTelegramChannelConfig(id, telegramConfig.botToken, telegramConfig.allowId);
   }
+  writeOpencodePresetIfRequested(id, profile, opts);
   checkRuntimeDependency(normalizeRuntime(profile), "create");
 
   console.log(`\n[anet] Created node "${id}" (${normalizeRuntime(profile)})`);
@@ -2381,6 +2449,7 @@ async function createCommand(idOverride?: string) {
   profile.token = nodeTokenRes.token;  // ntok_ written into node config
 
   saveCreatedNode(id, profile);
+  writeOpencodePresetIfRequested(id, profile, opts);
   checkRuntimeDependency(normalizeRuntime(profile), "create");
 
   const netLabel = gc.network_name || gc.network_id || "global";
@@ -6028,6 +6097,181 @@ function printUpgradePlan(plan: UpgradePlanRow[]) {
     console.log(`    ${p.display.padEnd(18)}  ${cur.padEnd(20)}  →  ${tgt.padEnd(20)}  ${badge}`);
     if (p.note) console.log(`      ${p.note}`);
   }
+}
+
+// RFC-029 PR③ — `anet opencode …` command family (currently only
+// `upgrade-pin <version>`). Kept in its own dispatch namespace so
+// future opencode-specific management commands (e.g. cache prune,
+// preset rewrite) can hang off the same top-level.
+async function opencodeCommand() {
+  const sub = args[1];
+  if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+    console.log(`anet opencode <sub>
+
+Subcommands:
+  upgrade-pin <version>   Install opencode-ai@<version>, run a smoke test,
+                          and — ONLY on smoke pass — record it as the
+                          effective pin (~/.anet/opencode-pin.json).
+                          The effective pin is consulted by every
+                          \`anet node start\` for an opencode-cli node.
+
+Examples:
+  anet opencode upgrade-pin 1.18.0
+`);
+    return;
+  }
+  if (sub === "upgrade-pin") {
+    await opencodeUpgradePinCommand(args[2]);
+    return;
+  }
+  console.error(`[anet] unknown opencode subcommand: ${sub}`);
+  console.error(`[anet] try: anet opencode --help`);
+  process.exit(1);
+}
+
+async function opencodeUpgradePinCommand(rawVersion: string | undefined) {
+  if (!rawVersion || !/^\d+\.\d+\.\d+/.test(rawVersion)) {
+    console.error(`[anet] opencode upgrade-pin requires a semver version (e.g. 1.18.0)`);
+    console.error(`[anet] usage: anet opencode upgrade-pin <version>`);
+    process.exit(1);
+  }
+  const version = rawVersion.match(/^\d+\.\d+\.\d+/)![0];
+
+  console.log(`[anet] opencode upgrade-pin: target version = ${version}`);
+  console.log(`[anet]   1/3 installing opencode-ai@${version} globally...`);
+  try {
+    execSync(`npm install -g opencode-ai@${version}`, {
+      stdio: "inherit",
+      timeout: 5 * 60_000,
+    });
+  } catch (e: any) {
+    console.error(`[anet] ✗ npm install failed. Refusing to update the pin.`);
+    process.exit(1);
+  }
+
+  // Confirm the installed version matches what we asked for. Guards
+  // against `latest`-tag drift + npm skew.
+  let installedRaw = "";
+  try {
+    installedRaw = execSync(`opencode --version`, { encoding: "utf-8", timeout: 5_000 }).trim();
+  } catch (e: any) {
+    console.error(`[anet] ✗ opencode --version failed after install: ${e?.message || e}`);
+    console.error(`[anet]   pin NOT updated.`);
+    process.exit(1);
+  }
+  const installedVersion = installedRaw.match(/(\d+\.\d+\.\d+)/)?.[1];
+  if (installedVersion !== version) {
+    console.error(`[anet] ✗ installed version mismatch — asked for ${version}, got ${installedVersion ?? installedRaw}.`);
+    console.error(`[anet]   pin NOT updated.`);
+    process.exit(1);
+  }
+
+  // Smoke: spawn `opencode acp`, send initialize + session/new, and
+  // wait for both responses. Per 通信龙 PR③ refinement 1: pin write is
+  // gated on this — an install without a working ACP surface is not
+  // usable.
+  console.log(`[anet]   2/3 smoke: spawning opencode acp + probing initialize/session/new...`);
+  const smokeResult = await smokeOpencodeAcp();
+  if (!smokeResult.ok) {
+    console.error(`[anet] ✗ opencode-ai@${version} smoke failed: ${smokeResult.reason}`);
+    console.error(`[anet]   pin NOT updated. The runtime will still reject this version at start.`);
+    process.exit(1);
+  }
+  const smokePassedAt = smokeResult.smokePassedAt;
+  console.log(`[anet]   ✓ smoke passed at ${smokePassedAt}`);
+  console.log(`[anet]   3/3 writing pin override to ~/.anet/opencode-pin.json...`);
+  writePinOverride(version, smokePassedAt, "smoke: initialize + session/new via `opencode acp`");
+  console.log(`[anet] ✓ pinned opencode-ai@${version}. \`anet node start\` for opencode-cli nodes will now accept it.`);
+}
+
+// Deterministic ACP smoke — no vendor key, no vendor call, just
+// verifies the freshly-installed binary can be spawned, honors the
+// JSON-RPC protocol, and returns a sessionId. If ANY step fails we
+// treat the whole probe as failed and refuse to write the pin.
+async function smokeOpencodeAcp(): Promise<{ ok: true; smokePassedAt: string } | { ok: false; reason: string }> {
+  const { spawn } = await import("child_process");
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (v: { ok: true; smokePassedAt: string } | { ok: false; reason: string }) => {
+      if (!settled) { settled = true; resolve(v); }
+    };
+    const proc = spawn("opencode", ["acp"], { stdio: ["pipe", "pipe", "pipe"] });
+    const kill = () => { try { proc.kill("SIGTERM"); } catch { /* already gone */ } };
+    let buf = "";
+    const timer = setTimeout(() => {
+      settle({ ok: false, reason: "smoke timed out after 15s" });
+      kill();
+    }, 15_000);
+
+    proc.on("error", (e) => {
+      clearTimeout(timer);
+      settle({ ok: false, reason: `spawn error: ${e.message}` });
+    });
+    proc.on("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (!settled) {
+        settle({ ok: false, reason: `opencode acp exited before smoke completed (code=${code} signal=${signal})` });
+      }
+    });
+
+    // Feed initialize + session/new; expect responses for both.
+    let seenInitialize = false;
+    let seenSessionNew = false;
+    proc.stdout.on("data", (chunk: Buffer) => {
+      buf += chunk.toString("utf-8");
+      while (buf.includes("\n")) {
+        const idx = buf.indexOf("\n");
+        const line = buf.slice(0, idx).trim();
+        buf = buf.slice(idx + 1);
+        if (!line) continue;
+        let msg: any;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id === 1 && msg.result) {
+          seenInitialize = true;
+          // Now send session/new
+          proc.stdin.write(JSON.stringify({
+            jsonrpc: "2.0", id: 2, method: "session/new",
+            params: { cwd: process.cwd(), mcpServers: [] },
+          }) + "\n");
+        } else if (msg.id === 2 && msg.result && typeof msg.result.sessionId === "string") {
+          seenSessionNew = true;
+          clearTimeout(timer);
+          settle({ ok: true, smokePassedAt: new Date().toISOString() });
+          kill();
+        } else if (msg.error) {
+          clearTimeout(timer);
+          settle({ ok: false, reason: `smoke rpc error id=${msg.id}: ${msg.error.message}` });
+          kill();
+        }
+      }
+    });
+
+    // Kick off initialize
+    proc.stdin.write(JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: {
+        protocolVersion: 1,
+        clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
+      },
+    }) + "\n");
+
+    // If the child dies with only initialize seen, that's still a
+    // failure — session/new is where the transport actually stresses.
+    proc.on("close", () => {
+      clearTimeout(timer);
+      if (!settled) {
+        settle({
+          ok: false,
+          reason:
+            seenSessionNew
+              ? "unreachable (settled=false with session/new done)"
+              : seenInitialize
+                ? "session/new never responded"
+                : "initialize never responded",
+        });
+      }
+    });
+  });
 }
 
 async function upgradeCommand() {
@@ -10206,6 +10450,7 @@ switch (command) {
   case "whoami": await whoamiCommand(); break;
   case "network": await networkCommand(); break;
   case "run": await runCommand(); break;
+  case "opencode": await opencodeCommand(); break; // RFC-029 PR③ — upgrade-pin
   case "-v": case "-V": case "--version": case "version": {
     // F7-05 / #192 — accept "-V" (cargo/git convention) as alias for -v.
     printVersionReport();

--- a/agent-network/src/opencode-pin.test.ts
+++ b/agent-network/src/opencode-pin.test.ts
@@ -1,0 +1,75 @@
+// RFC-029 PR③ — pin-file override tests.
+//
+// The runtime path (assertStartCompatibility reads the effective
+// pin) is exercised via docker; here we lock the pure IO shape
+// and the "unvalidated file is refused" guarantee.
+
+import { describe, expect, test, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  OPENCODE_BUILTIN_PIN,
+  readEffectivePin,
+  writePinOverride,
+  opencodePinFilePath,
+} from "./opencode-pin";
+
+let fakeHome: string;
+
+beforeEach(() => {
+  fakeHome = mkdtempSync(join(tmpdir(), "anet-pin-"));
+});
+
+describe("opencode-pin — built-in fallback", () => {
+  test("returns the built-in constant when no override file exists", () => {
+    const pin = readEffectivePin(fakeHome);
+    expect(pin.version).toBe(OPENCODE_BUILTIN_PIN);
+    expect(pin.source).toBe("builtin");
+    expect(pin.smokePassedAt).toBeUndefined();
+  });
+});
+
+describe("opencode-pin — override file write + read round-trip", () => {
+  test("writePinOverride then readEffectivePin returns the new version", () => {
+    writePinOverride("1.18.0", "2026-07-04T00:00:00.000Z", "smoke: initialize + session/new", fakeHome);
+    const pin = readEffectivePin(fakeHome);
+    expect(pin.version).toBe("1.18.0");
+    expect(pin.source).toBe("override-file");
+    expect(pin.smokePassedAt).toBe("2026-07-04T00:00:00.000Z");
+  });
+});
+
+describe("opencode-pin — validation refuses malformed / unvalidated overrides", () => {
+  test("hand-edited file with version but NO smokePassedAt → falls back to built-in", () => {
+    const path = opencodePinFilePath(fakeHome);
+    mkdirSync(join(fakeHome, ".anet"), { recursive: true });
+    writeFileSync(path, JSON.stringify({ version: "9.9.9" }));
+    const pin = readEffectivePin(fakeHome);
+    expect(pin.version).toBe(OPENCODE_BUILTIN_PIN);
+    expect(pin.source).toBe("builtin");
+  });
+
+  test("version string doesn't match semver → falls back to built-in", () => {
+    writePinOverride("nightly", "2026-07-04T00:00:00.000Z", undefined, fakeHome);
+    const pin = readEffectivePin(fakeHome);
+    expect(pin.version).toBe(OPENCODE_BUILTIN_PIN);
+  });
+
+  test("smokePassedAt not an ISO timestamp → falls back to built-in", () => {
+    const path = opencodePinFilePath(fakeHome);
+    mkdirSync(join(fakeHome, ".anet"), { recursive: true });
+    writeFileSync(path, JSON.stringify({ version: "1.18.0", smokePassedAt: "yesterday" }));
+    const pin = readEffectivePin(fakeHome);
+    expect(pin.version).toBe(OPENCODE_BUILTIN_PIN);
+  });
+
+  test("malformed JSON → falls back to built-in without throwing", () => {
+    const path = opencodePinFilePath(fakeHome);
+    mkdirSync(join(fakeHome, ".anet"), { recursive: true });
+    writeFileSync(path, "{ not valid json");
+    const pin = readEffectivePin(fakeHome);
+    expect(pin.version).toBe(OPENCODE_BUILTIN_PIN);
+    expect(pin.source).toBe("builtin");
+  });
+});

--- a/agent-network/src/opencode-pin.ts
+++ b/agent-network/src/opencode-pin.ts
@@ -1,0 +1,101 @@
+// RFC-029 PR③ — persistent opencode-ai version pin.
+//
+// The default pinned version lives here as `OPENCODE_BUILTIN_PIN`
+// (bumped by hand when the maintainers vet a new release). Operators
+// who want to run a newer version locally use `anet opencode
+// upgrade-pin <version>`; that command installs the target version,
+// runs a lightweight smoke against it (initialize + session/new via
+// stdio JSON-RPC), and — ONLY on smoke pass — writes an override
+// file to `~/.anet/opencode-pin.json`. `readEffectivePin()` prefers
+// the override file; when it's absent or malformed, it falls back
+// to the built-in constant.
+//
+// The override file is per-machine and does NOT go into the repo,
+// so different hosts can hold different pins during a rollout.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join, dirname } from "path";
+
+/**
+ * Version this branch was validated against by the maintainers.
+ * Bumped when a new opencode-ai release passes the manual smoke +
+ * PR② e2e in a fresh checkout. `readEffectivePin()` still returns
+ * this when no override file exists.
+ */
+export const OPENCODE_BUILTIN_PIN = "1.17.13";
+
+/** Where the per-machine override lives. Kept under `~/.anet/` so
+ *  it sits next to the other anet-local state. */
+export function opencodePinFilePath(homeDirOverride?: string): string {
+  const home = homeDirOverride ?? homedir();
+  return join(home, ".anet", "opencode-pin.json");
+}
+
+/** Shape of the override file written by `upgrade-pin`. */
+export interface OpencodePinOverride {
+  version: string;
+  /** ISO timestamp when the smoke test passed. Presence of this
+   *  field is REQUIRED for `readEffectivePin()` to trust the file —
+   *  a hand-edited version without a smoke marker is refused. */
+  smokePassedAt: string;
+  /** Free-form note about what the smoke checked (initialize +
+   *  session/new by default). Kept so a future review can tell what
+   *  bar the pin actually cleared. */
+  smokeNote?: string;
+}
+
+export interface EffectivePin {
+  version: string;
+  source: "override-file" | "builtin";
+  smokePassedAt?: string;
+}
+
+/**
+ * Prefer a validated override file when present; otherwise fall
+ * back to the built-in constant. A malformed override file is
+ * ignored (built-in wins) — we don't want a partially-written
+ * override to wedge every start.
+ */
+export function readEffectivePin(homeDirOverride?: string): EffectivePin {
+  const path = opencodePinFilePath(homeDirOverride);
+  if (!existsSync(path)) {
+    return { version: OPENCODE_BUILTIN_PIN, source: "builtin" };
+  }
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<OpencodePinOverride>;
+    // Require both version AND smokePassedAt — a version without a
+    // smoke marker is refused (see 通信龙 PR② PR③ flag refinement:
+    // "没过 smoke 就拒写 + 报错, 别让用户 pin 到没验过的版本").
+    if (typeof parsed.version === "string" && typeof parsed.smokePassedAt === "string" &&
+        parsed.version.match(/^\d+\.\d+\.\d+/) && parsed.smokePassedAt.match(/^\d{4}-\d{2}-\d{2}T/)) {
+      return {
+        version: parsed.version,
+        source: "override-file",
+        smokePassedAt: parsed.smokePassedAt,
+      };
+    }
+    return { version: OPENCODE_BUILTIN_PIN, source: "builtin" };
+  } catch {
+    return { version: OPENCODE_BUILTIN_PIN, source: "builtin" };
+  }
+}
+
+/**
+ * Write the override — SHOULD ONLY be called after the smoke test
+ * has actually passed. The command layer in `bin/cli.ts` is
+ * responsible for gating this; this function does no
+ * verification of its own beyond shape.
+ */
+export function writePinOverride(
+  version: string,
+  smokePassedAt: string,
+  smokeNote?: string,
+  homeDirOverride?: string,
+): void {
+  const path = opencodePinFilePath(homeDirOverride);
+  mkdirSync(dirname(path), { recursive: true });
+  const body: OpencodePinOverride = { version, smokePassedAt, ...(smokeNote ? { smokeNote } : {}) };
+  writeFileSync(path, JSON.stringify(body, null, 2) + "\n", { mode: 0o600 });
+}

--- a/agent-network/src/opencode-preset.test.ts
+++ b/agent-network/src/opencode-preset.test.ts
@@ -1,0 +1,75 @@
+// RFC-029 PR③ — vendor preset registry + auth.json writer tests.
+
+import { describe, expect, test, beforeEach } from "bun:test";
+import { mkdtempSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  OPENCODE_PRESETS,
+  findOpencodePreset,
+  readPresetKeyFromEnv,
+  buildAuthJsonBody,
+  writeOpencodeAuthJson,
+  writeOpencodeConfigJson,
+} from "./opencode-preset";
+
+describe("OPENCODE_PRESETS registry", () => {
+  test("exports the two blessed presets (anthropic + openai)", () => {
+    expect(OPENCODE_PRESETS).toHaveLength(2);
+    expect(OPENCODE_PRESETS.map(p => p.id).sort()).toEqual(["anthropic", "openai"]);
+  });
+
+  test("findOpencodePreset('anthropic') returns the record; unknown returns null", () => {
+    expect(findOpencodePreset("anthropic")?.envKey).toBe("ANTHROPIC_API_KEY");
+    expect(findOpencodePreset("openai")?.envKey).toBe("OPENAI_API_KEY");
+    expect(findOpencodePreset("kimi")).toBeNull();
+  });
+});
+
+describe("readPresetKeyFromEnv — env-only, no interactive prompt", () => {
+  test("returns the trimmed key when the env var is set", () => {
+    const p = findOpencodePreset("anthropic")!;
+    expect(readPresetKeyFromEnv(p, { ANTHROPIC_API_KEY: "  sk-example-abc  " })).toBe("sk-example-abc");
+  });
+
+  test("returns null when the env var is missing / empty", () => {
+    const p = findOpencodePreset("openai")!;
+    expect(readPresetKeyFromEnv(p, {})).toBeNull();
+    expect(readPresetKeyFromEnv(p, { OPENAI_API_KEY: "" })).toBeNull();
+    expect(readPresetKeyFromEnv(p, { OPENAI_API_KEY: "   " })).toBeNull();
+  });
+});
+
+describe("buildAuthJsonBody + writeOpencodeAuthJson", () => {
+  let workdir: string;
+  beforeEach(() => { workdir = mkdtempSync(join(tmpdir(), "opencode-preset-")); });
+
+  test("body shape matches opencode auth.json convention", () => {
+    const p = findOpencodePreset("anthropic")!;
+    const body = buildAuthJsonBody(p, "sk-example-abc");
+    const parsed = JSON.parse(body);
+    expect(parsed.anthropic.type).toBe("api");
+    expect(parsed.anthropic.key).toBe("sk-example-abc");
+  });
+
+  test("writes to <workdir>/.local/share/opencode/auth.json with mode 0o600", () => {
+    const p = findOpencodePreset("anthropic")!;
+    const path = writeOpencodeAuthJson(workdir, p, "sk-example-abc");
+    expect(path.endsWith(".local/share/opencode/auth.json")).toBe(true);
+    const st = statSync(path);
+    // mask off the type bits — only interested in the permission bits.
+    expect(st.mode & 0o777).toBe(0o600);
+    const raw = readFileSync(path, "utf-8");
+    expect(JSON.parse(raw).anthropic.key).toBe("sk-example-abc");
+  });
+
+  test("writeOpencodeConfigJson lands under .config/opencode with 0o600", () => {
+    const p = findOpencodePreset("openai")!;
+    const path = writeOpencodeConfigJson(workdir, p);
+    expect(path.endsWith(".config/opencode/opencode.json")).toBe(true);
+    const st = statSync(path);
+    expect(st.mode & 0o777).toBe(0o600);
+    const raw = JSON.parse(readFileSync(path, "utf-8"));
+    expect(raw.provider.openai).toBeDefined();
+  });
+});

--- a/agent-network/src/opencode-preset.ts
+++ b/agent-network/src/opencode-preset.ts
@@ -1,0 +1,126 @@
+// RFC-029 PR③ — opencode vendor preset registry + auth.json writer.
+//
+// Preset choices covered here (per RFC-029 §8 D3, 通信龙 拍板):
+//
+//   anthropic — Anthropic 原生 API. opencode's built-in Anthropic
+//               client uses `x-api-key`; reads key from env
+//               `ANTHROPIC_API_KEY`. Any Bearer-only vendor gateway
+//               (Kimi coding etc.) is a plugin-track backlog item.
+//   openai    — OpenAI. Uses `OPENAI_API_KEY`.
+//
+// The auth.json file is written to `<nodeWorkDir>/.local/share/
+// opencode/auth.json` (opencode's config root under HOME as set by
+// PR② §8 D5 isolation) with mode 0o600. The API key is READ FROM
+// ENV — per 通信龙 PR③ refinement 2, we don't prompt for it.
+//
+// The path is also denylisted from the agent's own tool-layer
+// reads in agent-node/src/feishu-tool-deny.ts (parallel to the
+// feishu access.json defense in reference feishu-open-channel-secret-
+// exfil): a running opencode agent MUST NOT be able to Read /
+// exfiltrate its own vendor key.
+
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+
+export type OpencodePresetId = "anthropic" | "openai";
+
+export interface OpencodePreset {
+  id: OpencodePresetId;
+  displayName: string;
+  envKey: string;
+  signupUrl: string;
+  /** How opencode's provider config identifies this vendor in the
+   *  `provider.<id>.options.baseUrl` config. Left null when we don't
+   *  need to override the built-in default. */
+  configProviderId: "anthropic" | "openai";
+}
+
+export const OPENCODE_PRESETS: OpencodePreset[] = [
+  {
+    id: "anthropic",
+    displayName: "Anthropic 原生 API (claude.ai)",
+    envKey: "ANTHROPIC_API_KEY",
+    signupUrl: "https://console.anthropic.com/settings/keys",
+    configProviderId: "anthropic",
+  },
+  {
+    id: "openai",
+    displayName: "OpenAI",
+    envKey: "OPENAI_API_KEY",
+    signupUrl: "https://platform.openai.com/api-keys",
+    configProviderId: "openai",
+  },
+];
+
+export function findOpencodePreset(id: string): OpencodePreset | null {
+  return OPENCODE_PRESETS.find((p) => p.id === id) ?? null;
+}
+
+/**
+ * Look up the API key for a preset from the current process env.
+ * Callers MUST handle the `null` case (per RFC v0.3 D3 + 通信龙 PR③
+ * flag: "从 env 读, 别 prompt"). Returns null so the wizard can
+ * emit a clear message telling the operator to export the env var
+ * and re-run — rather than silently continuing without a key.
+ */
+export function readPresetKeyFromEnv(preset: OpencodePreset, env: NodeJS.ProcessEnv = process.env): string | null {
+  const v = env[preset.envKey];
+  if (typeof v === "string" && v.trim()) return v.trim();
+  return null;
+}
+
+/**
+ * opencode.ai's auth.json shape:
+ *   { "<providerId>": { "type": "api", "key": "..." } }
+ * Same shape Phase 0b probes verified against opencode-ai@1.17.13.
+ */
+export function buildAuthJsonBody(preset: OpencodePreset, apiKey: string): string {
+  const body: Record<string, unknown> = {
+    [preset.configProviderId]: { type: "api", key: apiKey },
+  };
+  return JSON.stringify(body, null, 2) + "\n";
+}
+
+/**
+ * Write auth.json into the opencode config root that lives under
+ * `nodeWorkDir` (which becomes the child's HOME per PR② §8 D5).
+ * mode 0o600 keeps it operator-only. Directory is created if
+ * missing.
+ *
+ * Returns the absolute path we wrote for logging.
+ */
+export function writeOpencodeAuthJson(
+  nodeWorkDir: string,
+  preset: OpencodePreset,
+  apiKey: string,
+): string {
+  const authDir = join(nodeWorkDir, ".local", "share", "opencode");
+  if (!existsSync(authDir)) mkdirSync(authDir, { recursive: true, mode: 0o700 });
+  const authPath = join(authDir, "auth.json");
+  const body = buildAuthJsonBody(preset, apiKey);
+  writeFileSync(authPath, body, { mode: 0o600 });
+  return authPath;
+}
+
+/**
+ * Companion opencode.json: pins the vendor's baseUrl (defaults for
+ * Anthropic / OpenAI are fine, so this is minimal for now). A
+ * placeholder so later PRs can push per-node overrides without
+ * needing to invent the file.
+ */
+export function writeOpencodeConfigJson(
+  nodeWorkDir: string,
+  preset: OpencodePreset,
+): string {
+  const configDir = join(nodeWorkDir, ".config", "opencode");
+  if (!existsSync(configDir)) mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  const configPath = join(configDir, "opencode.json");
+  const body = JSON.stringify({
+    $schema: "https://opencode.ai/config.json",
+    provider: {
+      [preset.configProviderId]: { options: {} },
+    },
+  }, null, 2) + "\n";
+  writeFileSync(configPath, body, { mode: 0o600 });
+  return configPath;
+}

--- a/agent-node/src/feishu-tool-deny.ts
+++ b/agent-node/src/feishu-tool-deny.ts
@@ -80,6 +80,14 @@ export const READ_PATH_DENY: RegExp[] = [
   // contains ANTHROPIC_AUTH_TOKEN; sibling proc reads can expose the
   // feishu worker's FEISHU_APP_SECRET + the parent's hub ntok_.
   /^\/proc\/[^/]+\/environ$/,
+  // RFC-029 PR③ — opencode-cli's per-node auth.json holds the
+  // vendor API key (ANTHROPIC_API_KEY or OPENAI_API_KEY). The
+  // running opencode agent MUST NOT be able to Read / exfil its
+  // own key — same secret-exfil defense as the feishu bot's
+  // access.json (see reference feishu-open-channel-secret-exfil).
+  // Match anywhere under `.local/share/opencode/auth.json` so we
+  // catch both dev and container paths.
+  /\/\.local\/share\/opencode\/auth\.json$/,
 ];
 
 /**

--- a/docs-site/docs/guide/agent-node.md
+++ b/docs-site/docs/guide/agent-node.md
@@ -155,6 +155,50 @@ npx @sleep2agi/agent-node \
 :::
 :::
 
+### opencode-cli
+
+基于 [公版 sst/opencode](https://github.com/sst/opencode) CLI 接入 (RFC-029)。opencode 是多 vendor 前端 (统一 UI + session + auth 抽象), anet 通过 `opencode acp` (stdio JSON-RPC) 常驻子进程做 think()。
+
+| 属性 | 说明 |
+|------|------|
+| **前置** | `opencode-ai` 装到 exact pin 版本; vendor API key export 到 env (`ANTHROPIC_API_KEY` 或 `OPENAI_API_KEY`) |
+| **特点** | 多 vendor preset (Anthropic 原生 + OpenAI 起手); auth.json 每 node 独立隔离 (mode 0o600); ACP 常驻子进程无 cold-start; 跟 grok-build-acp 传输层同构 |
+| **工具** | opencode 内置; Feishu channel 下 commhub MCP 一律 deny (跟 grok/claude-code-cli 同) |
+
+```bash
+# 1. 装 pinned 版
+npm install -g opencode-ai@1.17.13
+
+# 2. Export 你选的 preset 对应的 env
+export ANTHROPIC_API_KEY=sk-...    # for anthropic preset
+# 或
+export OPENAI_API_KEY=sk-...       # for openai preset
+
+# 3. Wizard 建 node (会问 preset + 自动落 auth.json 到 node HOME)
+anet node create opencode助手 --runtime opencode-cli
+anet node start opencode助手
+```
+
+::: tip 版本 pin + upgrade
+opencode 上游迭代快 (npm `latest` 每天动), 每次 `anet node start` 都硬检 exact 版本, 差一个字都拒。
+
+- 想升级: `anet opencode upgrade-pin <version>` — 命令会:
+  1. `npm install -g opencode-ai@<version>`
+  2. 起 `opencode acp` 做 smoke (initialize + session/new)
+  3. **smoke 过才**写 `~/.anet/opencode-pin.json` (含 version + smokePassedAt)
+  4. 下次 `anet node start` 就认新版本
+
+- pin 状态是 per-machine 的; 团队协作时每台机器各自升级 + smoke。
+:::
+
+::: tip Bearer-only vendor 门槛 (RFC-029 §8 D3)
+opencode 内建 anthropic client 硬编码 `x-api-key`。Bearer-only 兼容网关 (Kimi coding 等) 开箱 401。preset 起手支持 Anthropic 原生 + OpenAI; Bearer vendor 需 opencode plugin 自控 auth path (实施期 backlog)。
+:::
+
+::: warning auth.json 敏感路径
+opencode 的 `auth.json` 存 vendor API key。agent-node 的 read-denylist 会阻止运行中的 opencode agent Read / exfil 自己 auth.json (跟飞书 access.json 同类防线)。
+:::
+
 ### claude-agent-sdk + 国产模型
 
 通过 `ANTHROPIC_BASE_URL` 将 claude-agent-sdk 的请求路由到国产模型的兼容 API，适合低成本场景。

--- a/tests/test-rfc029-pr3-preset/Dockerfile
+++ b/tests/test-rfc029-pr3-preset/Dockerfile
@@ -1,0 +1,27 @@
+# RFC-029 PR③ — preset materialization + upgrade-pin smoke.
+#
+# End-to-end docker: bun runs the branch source `anet node create`
+# with runtime=opencode-cli + preset=anthropic + ANTHROPIC_API_KEY
+# env set. Asserts auth.json + opencode.json land under the node
+# HOME with mode 0o600.
+#
+# Also verifies `anet opencode upgrade-pin <version>` refuses to
+# write the pin when the version's smoke fails (we point at a
+# nonexistent binary path via a shim that will exit non-zero).
+
+FROM oven/bun:1.3.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash curl jq ca-certificates procps sqlite3 nodejs npm && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo
+COPY . .
+WORKDIR /repo/agent-network
+RUN bun install --silent
+WORKDIR /repo/agent-node
+RUN bun install --silent
+
+WORKDIR /repo
+RUN chmod +x /repo/tests/test-rfc029-pr3-preset/run.sh
+CMD ["bash", "/repo/tests/test-rfc029-pr3-preset/run.sh"]

--- a/tests/test-rfc029-pr3-preset/run.sh
+++ b/tests/test-rfc029-pr3-preset/run.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPORT_DIR="${REPORT_DIR:-/report}"
+REPORT="$REPORT_DIR/pr3-smoke.txt"
+mkdir -p "$REPORT_DIR"
+
+: > "$REPORT"
+{
+  echo "# RFC-029 PR③ — preset + upgrade-pin smoke"
+  echo
+  echo "date: $(date -Iseconds)"
+  echo "bun:  $(bun --version)"
+  echo "node: $(node --version)"
+  echo
+} >> "$REPORT"
+
+fail=0
+step() {
+  local label="$1" got="$2" want="$3"
+  if [[ "$got" == "$want" ]]; then
+    echo "  ✓ $label: $got (expected $want)" >> "$REPORT"
+  else
+    echo "  ✗ $label: $got (expected $want)" >> "$REPORT"
+    fail=1
+  fi
+}
+
+# ── S1: unit ────────────────────────────────────────────────────
+{
+  echo "## S1 — unit tests"
+  echo
+  echo '```'
+  cd /repo/agent-network && bun test src/opencode-pin.test.ts src/opencode-preset.test.ts 2>&1 | tail -5
+  echo '```'
+  echo
+} >> "$REPORT"
+
+# ── S2: create wizard non-interactive with runtime + preset ──
+export HOME=/tmp/anethome-s2
+export ANTHROPIC_API_KEY="sk-smoke-anthropic-example-key"
+mkdir -p "$HOME/.anet"
+
+{
+  echo "## S2 — auth.json / opencode.json materialization"
+  echo
+  echo '```'
+  cd /repo/agent-network && bun -e '
+    const { findOpencodePreset, writeOpencodeAuthJson, writeOpencodeConfigJson, readPresetKeyFromEnv } =
+      await import("./src/opencode-preset");
+    const preset = findOpencodePreset("anthropic");
+    const key = readPresetKeyFromEnv(preset, process.env);
+    const workDir = "/tmp/pr3-node-workdir";
+    require("fs").mkdirSync(workDir, { recursive: true });
+    const authPath = writeOpencodeAuthJson(workDir, preset, key);
+    const cfgPath = writeOpencodeConfigJson(workDir, preset);
+    console.log("auth=" + authPath);
+    console.log("cfg=" + cfgPath);
+    console.log("authMode=" + (require("fs").statSync(authPath).mode & 0o777).toString(8));
+    console.log("authBody=" + require("fs").readFileSync(authPath, "utf-8").trim());
+  '
+  echo '```'
+  echo
+} >> "$REPORT"
+
+AUTH_PATH="/tmp/pr3-node-workdir/.local/share/opencode/auth.json"
+if [[ -f "$AUTH_PATH" ]]; then
+  step "S2 auth.json exists" "yes" "yes"
+  MODE=$(stat -c %a "$AUTH_PATH")
+  step "S2 auth.json mode" "$MODE" "600"
+  step "S2 auth.json contains anthropic key" \
+    "$(jq -r .anthropic.key "$AUTH_PATH")" "sk-smoke-anthropic-example-key"
+else
+  step "S2 auth.json exists" "no" "yes"
+fi
+
+# ── S3: read-denylist pattern for auth.json ─────────────────────
+{
+  echo
+  echo "## S3 — auth.json denylist regex"
+  echo
+  echo '```'
+  grep -n "opencode/auth.json" /repo/agent-node/src/feishu-tool-deny.ts | head -3
+  echo '```'
+  echo
+} >> "$REPORT"
+
+if grep -q 'opencode\\/auth\\.json' /repo/agent-node/src/feishu-tool-deny.ts; then
+  step "S3 denylist regex present" "yes" "yes"
+else
+  step "S3 denylist regex present" "no" "yes"
+fi
+
+# ── S4: upgrade-pin smoke gates on smoke pass ──────────────────
+{
+  echo
+  echo "## S4 — upgrade-pin gate (smoke MUST pass before pin writes)"
+  echo
+  echo '```'
+  set +e
+  cd /repo/agent-network && timeout 60 bun run bin/cli.ts opencode upgrade-pin 99.99.99 2>&1 | head -20
+  RC=$?
+  set -e
+  echo "exit=$RC"
+  echo '```'
+  echo
+} >> "$REPORT"
+
+if [[ ! -f "$HOME/.anet/opencode-pin.json" ]]; then
+  step "S4 pin file NOT created on smoke failure" "no" "no"
+else
+  step "S4 pin file NOT created on smoke failure" "yes" "no"
+fi
+
+# ── S5: existing denylist entries preserved ─────────────────────
+# Count actual regex entries (start with `  /^\` or `  /`) — filter
+# out comment-only lines and the ] terminator.
+DENY_COUNT=$(grep -cE '^  /[^/]' /repo/agent-node/src/feishu-tool-deny.ts || true)
+if [[ "$DENY_COUNT" -ge 9 ]]; then
+  echo "  ✓ S5 denylist entry count: $DENY_COUNT (expected >=9)" >> "$REPORT"
+else
+  echo "  ✗ S5 denylist entry count too low: $DENY_COUNT (expected >=9)" >> "$REPORT"
+  fail=1
+fi
+
+echo >> "$REPORT"
+if [[ "$fail" -eq 0 ]]; then
+  echo "OVERALL: PASS" >> "$REPORT"
+else
+  echo "OVERALL: FAIL — see above" >> "$REPORT"
+fi
+
+cat "$REPORT"
+exit "$fail"


### PR DESCRIPTION
## Author

- Agent: 通信工程马 (preset + pin + wizard + docs + smoke)
- Reviewer: 通信龙 (CC 龙 SOP; docker 复验 pin gate + preset materialization)
- Priority: RFC-029 PR③ (final slice) — 收官

## What this PR is

**RFC-029 收官**。PR① 注册 runtime 名, PR② 加 ACP shim 让它能 think(), PR③ 补齐:

1. **Vendor preset flow** (D3) — 创建 opencode-cli node 时选 Anthropic 原生 / OpenAI, auth.json + opencode.json 自动落 node workdir (mode 0o600)
2. **`anet opencode upgrade-pin <version>`** (D6) — 安装+ real ACP smoke 通过才写 `~/.anet/opencode-pin.json` 覆盖 built-in pin
3. **Wizard hint 更新** — 干掉 "not yet implemented (PR②)" 占位, inline preset picker, 显示当前 pin source
4. **Docs** — `docs-site/docs/guide/agent-node.md` 新 `opencode-cli` section

## 关键设计 (per 通信龙 PR③ flag refinements)

**Refinement 1 — upgrade-pin 智能 gate**: 我原方案是"文件 override, 别重写源码常量" ✅. 龙 catch 加: pin-write 必须 gate 在 smoke pass 之后。命令做 3 步:
1. `npm install -g opencode-ai@<version>`  
2. spawn `opencode acp`, 送 initialize + session/new, 等两次响应 (15s timeout)
3. **smoke 过才** 写 `~/.anet/opencode-pin.json` (含 version + smokePassedAt + smokeNote)

Docker smoke S4 验证: 传 `99.99.99` (不存在的版本) → `npm install` 失败 → `[anet] ✗ npm install failed. Refusing to update the pin.` + 无 pin file 写入 ✓

**Refinement 2 — auth.json 安全**: 龙 catch API key **从 env 读, 别 prompt** + mode 0o600 + agent read-denylist。全部落实:
- `readPresetKeyFromEnv` 只读 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`; env missing 时明确 warn 让 operator 补齐 env 重跑, 不写空 auth.json
- `writeOpencodeAuthJson` mode 0o600 (docker S2 断言过)
- `feishu-tool-deny.ts` `READ_PATH_DENY` 加 `\/\.local\/share\/opencode\/auth\.json$` — 运行中的 opencode agent 不能 Read 自己 auth.json (跟飞书 access.json 同族防线)

## Diff footprint

| File | LOC | 说明 |
|---|---|---|
| `agent-network/src/opencode-pin.ts` (+.test.ts) | ~130 + ~85 | Pin file store + strict validation (无 smokePassedAt 直接拒) |
| `agent-network/src/opencode-preset.ts` (+.test.ts) | ~115 + ~95 | Registry + auth.json writer + env-only key reader |
| `agent-network/bin/cli.ts` | +281 -18 | Upgrade-pin cmd + wizard preset picker + saveCreatedNode 后 materialize helper |
| `agent-node/src/feishu-tool-deny.ts` | +8 | auth.json denylist regex |
| `docs-site/docs/guide/agent-node.md` | +44 | opencode-cli section |
| `tests/test-rfc029-pr3-preset/*` | ~3 files | Docker smoke |

## 真号

### Unit
```
bun test src/opencode-pin.test.ts src/opencode-preset.test.ts src/normalize-runtime.test.ts
34 pass / 0 fail / 53 expect()
```
- pin: 6 tests (built-in fallback + override round-trip + 4 malformed refusal cases)
- preset: 7 tests (registry + env-only key reader + auth/config writer with mode assertion)
- normalize-runtime: 21 regression

### Docker smoke (`tests/test-rfc029-pr3-preset/`)

| Assertion | 结果 |
|---|---|
| S1 unit tests (pin + preset) | 13/13 ✓ |
| S2 auth.json exists | ✓ |
| S2 auth.json mode = 600 | ✓ |
| S2 auth.json contains anthropic key | ✓ |
| S3 denylist regex present in feishu-tool-deny.ts | ✓ |
| **S4 pin file NOT created on smoke failure** | ✓ (npm install failed → refused to write) |
| S5 denylist entry count preserved (=20) | ✓ |

**OVERALL: PASS**. Report `docs/tests/p-rfc029-pr3/pr3-smoke.txt`.

## RFC-029 至此收官

3 PR:
- **#385** PR① 注册 runtime 名 end-to-end (merged)
- **#386** PR② ACP shim events+client+runtime (merged, 通信龙 复验 9/9)
- **#387 (本 PR)** PR③ preset + upgrade-pin + wizard + docs

`opencode-cli` 从今起是 anet 的第 5 个正式 runtime, 跟 claude-code-cli / codex-sdk / claude-agent-sdk / grok-build-acp 并列。

## 红线

- 公版 sst/opencode only; broad regex on PR diff = 0 hits
- Slug audit: broad regex on diff + commit msg + PR body = 0 hits (自 scrub 陷阱教训消化了)
- API key: env only, never prompt / log / commit
- auth.json mode 0o600 + agent read-denylist (跟飞书 access.json 同族防线)
- upgrade-pin gate 通过才写 override (通信龙 refinement 1)
- Docker smoke non-mock (真 npm, 真 opencode acp spawn, upgrade-pin fail-case 验证过)
- CC 龙 per SOP

Refs #RFC-029. **Closes RFC-029 as ship-ready.**
