### PR TITLE
docs(release): P3 e2e 绿 + config_snapshot backlog（同步 #403）

### DIFF
--- a/docs/release/v2.3.0/plan.md
+++ b/docs/release/v2.3.0/plan.md
@@ -36,7 +36,7 @@
 | **P2 #393 provider UI** | ✅ 已发 | = RFC-028（PR #23）merged + **已切 dashboard `0.6.3-preview.5`**（provider CRUD + key vault + reachability matrix） |
 | **P2 #260 配置面板核心** | ✅ 已建 | 模型/模式/重启真接 API（dashboard #7/#10/#11/#19），在 preview.4/.5 |
 | **P2 #260 channel 编辑** | ⏸ 推后 | 通信IM马 wire-check 发现 toggle **不生效**（hub `update_node_config` schema 无 channels 字段 + node 无 channel reload）；PR #31 前端 held；真 backend 走 restart-tier 路子，排 P3 后做 |
-| **P3 multi-daemon** | 🔨 验证中 | 代码全 merged（#341 host-supervisors / #299 create_node daemon 路由 / dashboard #25/#28/#29 picker）；只缺 2-daemon e2e（Scenario H），工程马在做 |
+| **P3 multi-daemon** | 🟢 e2e 绿 | 代码全 merged（#341/#299/#25/#28/#29）+ **Scenario H e2e 通过 `PASS=59 FAIL=0`**（双 daemon 强绑 C2 路由/not_your_request/parentage）；工程马出 PR 中，通信龙 复跑复验 |
 | **P4 opencode 活体** | ⏳ 等 Vincent | 需 Anthropic/OpenAI key（Kimi Bearer 网关 opencode 不吃，见 §D3/backlog） |
 
 ## 已合进 main（部分未发 preview）


### PR DESCRIPTION
P3 Scenario H e2e PASS=59/0，更新进度快照 + 记 config_snapshot clobber follow-up backlog。详见 #403。