### PR TITLE
docs(troubleshooting): 远程建节点 CLI 登录态不跨机复用

### DIFF
--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -119,6 +119,7 @@ export default withMermaid(defineConfig({
               { text: '故障排查', link: '/troubleshooting' },
               { text: '连接 / Channel / MCP 排障', link: '/troubleshooting/connectivity-channels-mcp' },
               { text: '经典案例：飞书静默拒收', link: '/troubleshooting/case-feishu-silent-deny' },
+              { text: '远程建节点：CLI 登录态不跨机', link: '/troubleshooting/remote-node-cli-login' },
               { text: 'FAQ', link: '/faq' },
               { text: '更新日志', link: '/changelog' },
             ]
@@ -212,6 +213,7 @@ export default withMermaid(defineConfig({
               { text: 'Troubleshooting', link: '/en/troubleshooting' },
               { text: 'Connectivity / Channels / MCP', link: '/en/troubleshooting/connectivity-channels-mcp' },
               { text: 'Case Study: Feishu Silent Deny', link: '/en/troubleshooting/case-feishu-silent-deny' },
+              { text: 'Remote Nodes: CLI Login Not Portable', link: '/en/troubleshooting/remote-node-cli-login' },
               { text: 'FAQ', link: '/en/faq' },
               { text: 'Changelog', link: '/en/changelog' },
             ]

--- a/docs-site/docs/en/troubleshooting/remote-node-cli-login.md
+++ b/docs-site/docs/en/troubleshooting/remote-node-cli-login.md
@@ -1,0 +1,30 @@
+# Creating nodes on a remote daemon: Claude Code CLI login state is not portable
+
+> When you pick a remote host (a host_supervisor daemon) in the dashboard to create a node, some work and some fail to start. Usually this is not a bug — the agent's **auth method decides whether it can cross machines**.
+
+## Two auth methods, two fates
+
+An anet node needs vendor auth to run. There are two paths, and they behave very differently across machines:
+
+| Auth method | Stored where | Portable across hosts |
+|-------------|--------------|-----------------------|
+| **API key** (DeepSeek / MiniMax / Anthropic API key, etc.) | node config + hub secret vault | ✅ travels with the node, works on any host |
+| **Claude Code CLI subscription login** (`claude login` OAuth) | that machine's `~/.claude` | ❌ machine-bound, not in config, not shipped to remote |
+
+- API-key nodes → run on any daemon (the key travels with config / vault). This is exactly what the dashboard "provider preset store" solves.
+- claude-code-cli subscription-login nodes → only run on a host that has already run `claude login`. A remote daemon with no login state → the node won't start.
+
+## Symptoms
+
+- Node creation works locally; the same node on a remote daemon won't start / is unresponsive.
+- The node uses the `claude-code-cli` runtime with subscription login (not an API key).
+
+## What to do
+
+1. **Prefer the API-key route for multi-host / remote setups**: configure vendor + model + key in the dashboard provider store (the key goes write-only into the vault and travels with the node), then select that preset when creating the node. Zero friction across hosts.
+2. **If you must use claude-code-cli subscription login**: SSH into that remote host and run `claude login` once there, so the login state lands in that machine's `~/.claude`. Only then can claude-code-cli nodes run on that host.
+3. Login state is a sensitive credential and Claude CLI is designed to be machine-bound; anet does **not** ship your `~/.claude` to remote hosts (by design).
+
+## Why this is not a bug
+
+Claude Code CLI's subscription login state is machine-bound and non-portable by Claude CLI's design (credential safety). What anet can do is make **API-key** auth travel with the node (provider store + vault); claude-code-cli subscription login stays with already-logged-in machines.

--- a/docs-site/docs/troubleshooting/remote-node-cli-login.md
+++ b/docs-site/docs/troubleshooting/remote-node-cli-login.md
@@ -1,0 +1,30 @@
+# 远程 daemon 建节点：Claude Code CLI 登录态不能跨机复用
+
+> 从 dashboard 选一台远程 host（host_supervisor daemon）建节点时，有的能跑、有的起不来。多半不是 bug，而是 **agent 的 auth 方式决定了它能不能跨机**。
+
+## 两种 auth，命运不同
+
+anet 节点跑起来需要 vendor 认证。认证有两条路，跨机行为完全不同：
+
+| auth 方式 | 存在哪 | 跨机复用 |
+|-----------|--------|----------|
+| **API key**（DeepSeek / MiniMax / Anthropic API key 等） | 节点 config + hub secret vault | ✅ 跟着节点走，远程 host 直接能用 |
+| **Claude Code CLI 订阅登录**（`claude login` 的 OAuth） | 该机器的 `~/.claude` | ❌ 机器绑定，不进 config，不传远程 |
+
+- 用 **API key** 的节点 → 在任意 daemon 上建都能跑（key 跟着 config / vault 走）。这正是 dashboard「供应商预配置库」要解决的。
+- 用 **claude-code-cli 订阅登录** 的节点 → 只有**那台机器已经 `claude login` 过**才能跑。远程 daemon 没登录态 → 节点起不来。
+
+## 症状
+
+- 本机建节点正常；选远程 daemon 建同款节点，节点起不来 / 无响应。
+- 节点用的是 `claude-code-cli` runtime + 订阅登录（不是 API key）。
+
+## 怎么办
+
+1. **多机 / 远程场景，优先走 API key 路线**：在 dashboard 供应商库里配好 vendor + model + key（key 写入即进 vault，跟着节点走），建节点时选这个 preset。跨机零门槛。
+2. **一定要用 claude-code-cli 订阅登录**：先 SSH 到那台远程 host，在该 host 上 `claude login` 一次，登录态落到该机 `~/.claude`，之后该 host 上的 claude-code-cli 节点才能跑。
+3. 登录态是敏感凭据、Claude CLI 本就设计成机器绑定，anet **不会**替你把 `~/.claude` 传到远程 host（安全考量）。
+
+## 为什么不是 bug
+
+Claude Code CLI 的订阅登录态机器绑定、不可移植，是 Claude CLI 的设计（凭据安全）。anet 能做的是把 **API key 类**认证做成跟着节点走（provider 库 + vault），claude-code-cli 订阅登录留给已登录的机器。


### PR DESCRIPTION
Vincent 反馈：claude-code-cli 登录态不能跨机复用。写清两种 auth 命运（API key 跟节点走 vs claude-code-cli 订阅登录机器绑定）+ 多机优先 API key 路线 + 远程 host 需 `claude login`。zh + en + vitepress sidebar。