### PR TITLE
feat(#260 P5): channel edit real backend — hub schema + narrow + restart-tier

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -943,7 +943,12 @@ const register = async () => {
     node_name: NODE_NAME || undefined,
     session_id: SESSION_ID || undefined,
     config_path: configFilePath || undefined,
-    channels: channelSpecs.length ? JSON.stringify(channelSpecs) : undefined,
+    // #260 P5 — always emit the current channel spec list (even as
+    // "[]" after disable-all), otherwise the hub's COALESCE on
+    // sessions.channels silently preserves the pre-disable list and
+    // /api/nodes lies about the node's actual state. Codex catch on
+    // PR #411.
+    channels: JSON.stringify(channelSpecs),
     model: MODEL || undefined,
     network_id: NETWORK_ID || undefined,
     host: getHostTelemetry(),
@@ -964,7 +969,12 @@ const reportStatus = async (status: string, task?: string) => {
     node_id: NODE_ID || undefined,
     session_id: claudeSessionId || grokSessionId || SESSION_ID || undefined,
     config_path: configFilePath || undefined,
-    channels: channelSpecs.length ? JSON.stringify(channelSpecs) : undefined,
+    // #260 P5 — always emit the current channel spec list (even as
+    // "[]" after disable-all), otherwise the hub's COALESCE on
+    // sessions.channels silently preserves the pre-disable list and
+    // /api/nodes lies about the node's actual state. Codex catch on
+    // PR #411.
+    channels: JSON.stringify(channelSpecs),
     network_id: NETWORK_ID || undefined,
     host: getHostTelemetry(),
     process_telemetry: getProcessTelemetry(),

--- a/agent-node/src/runtime/config-apply.test.ts
+++ b/agent-node/src/runtime/config-apply.test.ts
@@ -476,3 +476,54 @@ describe("channels — mergePatch replaces, does not merge", () => {
     expect(merged.channels).toEqual(["feishu"]);
   });
 });
+
+// ── #260 P5 codex-catch regression tests ───────────────────────────
+describe("mergePatch — path-qualified specs preserved", () => {
+  test("bare-type patch preserves existing telegram:/abs/path", () => {
+    const existing = { channels: ["telegram:/opt/bots/tg", "feishu:/opt/bots/feishu"] };
+    const merged = mergePatch(existing, { channels: ["telegram"] });
+    // "telegram" resolves to the existing path-qualified spec.
+    expect(merged.channels).toEqual(["telegram:/opt/bots/tg"]);
+  });
+  test("bare-type patch keeps both when both were path-qualified", () => {
+    const existing = { channels: ["telegram:/opt/tg", "feishu:/opt/feishu"] };
+    const merged = mergePatch(existing, { channels: ["telegram", "feishu"] });
+    expect(merged.channels).toEqual(["telegram:/opt/tg", "feishu:/opt/feishu"]);
+  });
+  test("bare-type patch adds new bare key when existing had no matching spec", () => {
+    const existing = { channels: ["telegram:/opt/tg"] };
+    const merged = mergePatch(existing, { channels: ["telegram", "feishu"] });
+    expect(merged.channels).toEqual(["telegram:/opt/tg", "feishu"]);
+  });
+  test("disable-all still works — empty patch wipes even path-qualified specs", () => {
+    const existing = { channels: ["telegram:/opt/tg"] };
+    const merged = mergePatch(existing, { channels: [] });
+    expect(merged.channels).toEqual([]);
+  });
+  test("first-write no existing channels: bare types stay bare", () => {
+    const merged = mergePatch({ model: "x" }, { channels: ["feishu"] });
+    expect(merged.channels).toEqual(["feishu"]);
+  });
+});
+
+describe("buildConfigSnapshot — always emits channels for content-match finalize", () => {
+  test("empty config emits channels=[]", () => {
+    expect(buildConfigSnapshot({}, false, 0).channels).toEqual([]);
+  });
+  test("bare-type list emitted verbatim + sorted", () => {
+    expect(buildConfigSnapshot({ channels: ["telegram", "feishu"] }, false, 0).channels)
+      .toEqual(["feishu", "telegram"]);
+  });
+  test("path-qualified specs collapse to bare type", () => {
+    expect(buildConfigSnapshot({ channels: ["telegram:/opt/tg", "feishu:/opt/feishu"] }, false, 0).channels)
+      .toEqual(["feishu", "telegram"]);
+  });
+  test("dupes deduped, unparseable dropped", () => {
+    expect(buildConfigSnapshot({ channels: ["telegram", "telegram:/opt/tg", ":", "feishu:"] }, false, 0).channels)
+      .toEqual(["telegram"]);
+  });
+  test("non-array channels field yields []", () => {
+    expect(buildConfigSnapshot({ channels: "telegram" }, false, 0).channels).toEqual([]);
+    expect(buildConfigSnapshot({ channels: null }, false, 0).channels).toEqual([]);
+  });
+});

--- a/agent-node/src/runtime/config-apply.test.ts
+++ b/agent-node/src/runtime/config-apply.test.ts
@@ -398,3 +398,81 @@ describe("buildConfigSnapshot — daemon_capabilities (PR3 #338 nit ①)", () =>
     expect(snap.daemon_capabilities?.allowed_secret_keys).toBeUndefined();
   });
 });
+
+// ── #260 P5 — channels support (restart-tier, defense-in-depth) ────
+describe("channels — validateLocalPatch", () => {
+  test("valid keys pass", () => {
+    expect(validateLocalPatch({ channels: ["telegram"] })).toBeNull();
+    expect(validateLocalPatch({ channels: ["feishu"] })).toBeNull();
+    expect(validateLocalPatch({ channels: ["telegram", "feishu"] })).toBeNull();
+    expect(validateLocalPatch({ channels: [] })).toBeNull();
+  });
+  test("commhub rejected — not a fork target (cli.ts:673 UNSUPPORTED_CHANNEL guard)", () => {
+    const r = validateLocalPatch({ channels: ["commhub"] });
+    expect(r?.field).toBe("channels.commhub");
+  });
+  test("unknown channel key rejected (defense-in-depth vs hub drift)", () => {
+    const r = validateLocalPatch({ channels: ["wechat"] });
+    expect(r?.field).toBe("channels.wechat");
+    expect(r?.reason).toMatch(/allowlist/);
+  });
+  test("non-array rejected", () => {
+    const r = validateLocalPatch({ channels: "telegram" as any });
+    expect(r?.field).toBe("channels");
+    expect(r?.reason).toMatch(/array/);
+  });
+  test("non-string element rejected", () => {
+    const r = validateLocalPatch({ channels: [42 as any] });
+    expect(r?.field).toBe("channels");
+  });
+  test("more than 16 entries rejected", () => {
+    const big = Array.from({ length: 17 }, () => "telegram");
+    const r = validateLocalPatch({ channels: big });
+    expect(r?.field).toBe("channels");
+    expect(r?.reason).toMatch(/16/);
+  });
+});
+
+describe("channels — computeApplyMode", () => {
+  test("channels-present patch is restart-tier", () => {
+    expect(computeApplyMode({ channels: ["feishu"] })).toBe("restart");
+  });
+  test("channels: [] still a state change → restart", () => {
+    expect(computeApplyMode({ channels: [] })).toBe("restart");
+  });
+  test("channels + hot flag upgrades to restart", () => {
+    expect(computeApplyMode({ channels: ["telegram"], flags: { maxTurns: 5 } })).toBe("restart");
+  });
+  test("model + channels → restart", () => {
+    expect(computeApplyMode({ model: "gpt-5", channels: ["feishu"] })).toBe("restart");
+  });
+  test("empty patch → restart_only", () => {
+    expect(computeApplyMode({})).toBe("restart_only");
+  });
+});
+
+describe("channels — mergePatch replaces, does not merge", () => {
+  test("channels absent in patch: existing.channels preserved", () => {
+    const merged = mergePatch({ channels: ["telegram"], model: "x" }, { model: "y" });
+    expect(merged.channels).toEqual(["telegram"]);
+    expect(merged.model).toBe("y");
+  });
+  test("channels present: existing.channels REPLACED wholesale", () => {
+    const merged = mergePatch({ channels: ["telegram", "feishu"] }, { channels: ["commhub"] });
+    expect(merged.channels).toEqual(["commhub"]);
+  });
+  test("channels: [] disables all editable channels", () => {
+    const merged = mergePatch({ channels: ["telegram", "feishu"] }, { channels: [] });
+    expect(merged.channels).toEqual([]);
+  });
+  test("first-write case (existing has no channels key)", () => {
+    const merged = mergePatch({ model: "x" }, { channels: ["feishu"] });
+    expect(merged.channels).toEqual(["feishu"]);
+  });
+  test("defensive clone — patch mutation does not leak into merged", () => {
+    const arr = ["feishu"];
+    const merged = mergePatch({}, { channels: arr });
+    arr.push("telegram");
+    expect(merged.channels).toEqual(["feishu"]);
+  });
+});

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -61,11 +61,34 @@ const RESTART_REQUIRED_FLAGS = new Set<string>([
   "timeout",
 ]);
 
+/**
+ * Channel keys the dashboard may enable/disable on this node via
+ * update_node_config. Restart-tier — the boot flow in cli.ts reads
+ * `config.channels` once and forks per-channel workers from it, so a
+ * swap here takes effect the next time the parent supervisor respawns
+ * this process (see #260 P5). MUST match server/src/config-apply-
+ * validate.ts EDITABLE_CHANNELS.
+ *
+ * Only telegram + feishu are wired here: cli.ts:673 rejects any other
+ * channel type with `process.exit(1)` at boot, so accepting anything
+ * else in a patch would ship a "smuggle-a-crash" foot-gun. `commhub`
+ * is the RPC transport (always present, not a channel worker).
+ */
+const EDITABLE_CHANNELS = new Set<string>([
+  "telegram",
+  "feishu",
+]);
+
 export type ApplyMode = "hot" | "restart" | "restart_only";
 
 export interface ConfigPatch {
   model?: string;
   flags?: Record<string, unknown>;
+  /** #260 P5 — dashboard-driven channel enable/disable. Restart-tier
+   *  (agent-node boot forks channel workers from config.channels).
+   *  Only telegram / feishu / commhub keys are accepted here; anything
+   *  else is dropped by the hub before the patch reaches this node. */
+  channels?: string[];
 }
 
 export interface ConfigUpdate {
@@ -82,6 +105,22 @@ export function validateLocalPatch(patch: ConfigPatch): ValidationResult {
   if (patch.model !== undefined) {
     if (typeof patch.model !== "string" || patch.model.length === 0 || patch.model.length > 200) {
       return { field: "model", reason: "must be a non-empty string ≤ 200 chars" };
+    }
+  }
+  if (patch.channels !== undefined) {
+    if (!Array.isArray(patch.channels)) {
+      return { field: "channels", reason: "must be an array of strings" };
+    }
+    if (patch.channels.length > 16) {
+      return { field: "channels", reason: "too many entries (max 16)" };
+    }
+    for (const c of patch.channels) {
+      if (typeof c !== "string") {
+        return { field: "channels", reason: "must contain only strings" };
+      }
+      if (!EDITABLE_CHANNELS.has(c)) {
+        return { field: `channels.${c}`, reason: "not in local editable channels allowlist" };
+      }
     }
   }
   const flags = patch.flags || {};
@@ -128,8 +167,10 @@ export function computeApplyMode(patch: ConfigPatch): ApplyMode {
   const hasModel = patch.model !== undefined;
   const flags = patch.flags || {};
   const flagKeys = Object.keys(flags);
-  if (!hasModel && flagKeys.length === 0) return "restart_only";
+  const hasChannels = patch.channels !== undefined;
+  if (!hasModel && flagKeys.length === 0 && !hasChannels) return "restart_only";
   if (hasModel) return "restart";
+  if (hasChannels) return "restart";
   for (const key of flagKeys) {
     if (RESTART_REQUIRED_FLAGS.has(key)) return "restart";
   }
@@ -216,6 +257,12 @@ export function mergePatch(existing: any, patch: ConfigPatch): any {
   if (patch.model !== undefined) next.model = patch.model;
   if (patch.flags) {
     next.flags = { ...(next.flags || {}), ...patch.flags };
+  }
+  if (patch.channels !== undefined) {
+    // Channels is a REPLACE, not a merge — an empty array means "no
+    // enabled channels", which the boot flow honours by forking no
+    // workers. This matches the dashboard's on/off semantics.
+    next.channels = [...patch.channels];
   }
   return next;
 }

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -248,6 +248,19 @@ export function loadConfigWithSelfHeal(path: string): SelfHealOutcome {
   }
 }
 
+/** Parse a channel spec into its bare type key. Mirrors
+ * `parseChannelSpec` in cli.ts but only extracts the type — the caller
+ * doesn't need the path. Malformed specs (empty, starts with `:`, ends
+ * with `:`) return null so mergePatch can drop them defensively rather
+ * than propagate the corruption. */
+function channelSpecType(spec: unknown): string | null {
+  if (typeof spec !== "string") return null;
+  const sep = spec.indexOf(":");
+  if (sep < 0) return spec || null;
+  if (sep === 0 || sep === spec.length - 1) return null;
+  return spec.slice(0, sep);
+}
+
 /** Merge a patch into the existing file config. Returns the new
  * config object — caller writes it. Defensive: clones the input so
  * the live mutable flag obj isn't accidentally shared with the
@@ -259,10 +272,25 @@ export function mergePatch(existing: any, patch: ConfigPatch): any {
     next.flags = { ...(next.flags || {}), ...patch.flags };
   }
   if (patch.channels !== undefined) {
-    // Channels is a REPLACE, not a merge — an empty array means "no
-    // enabled channels", which the boot flow honours by forking no
-    // workers. This matches the dashboard's on/off semantics.
-    next.channels = [...patch.channels];
+    // Channels replace-with-preserve-paths:
+    //   - `patch.channels: []` disables everything (empty array
+    //     survives; boot forks no workers).
+    //   - Otherwise, for each type in the patch, if the existing
+    //     config had a path-qualified spec of the same type
+    //     ("telegram:/abs/path" or "feishu:/opt/foo"), keep the FULL
+    //     spec so the .env / access.json under that dir stays
+    //     wired up. A bare-key patch that arrived because the
+    //     dashboard doesn't know about the path would otherwise
+    //     drop that path and force the boot flow to
+    //     `defaultChannelDir()` — which won't have the operator-
+    //     provisioned secrets. Codex catch on PR #411.
+    const existingByType = new Map<string, string>();
+    const existingChannels = Array.isArray(next.channels) ? next.channels : [];
+    for (const spec of existingChannels) {
+      const t = channelSpecType(spec);
+      if (t && !existingByType.has(t)) existingByType.set(t, String(spec));
+    }
+    next.channels = patch.channels.map((t) => existingByType.get(t) ?? t);
   }
   return next;
 }
@@ -303,6 +331,14 @@ export interface MaskedSnapshot {
    * the hardcoded 20 default + allowlist enforcement was bypassed.
    * 通信龙 nit ① decision: nest, don't delete. */
   daemon_capabilities?: DaemonCapabilities;
+  /** #260 P5 — bare-type channel set currently in this process's
+   *  forked worker map. Always emitted (even as `[]`) so the hub's
+   *  content-match finalize (finalizePendingMatchingUpdates) can prove
+   *  a channels-only restart landed and — separately — so
+   *  /api/nodes reflects a disable-all instead of the stale COALESCE'd
+   *  value. Path-qualified specs in config.channels are collapsed to
+   *  the bare type key; anything unparseable is silently dropped. */
+  channels: string[];
 }
 export function buildConfigSnapshot(
   fileConfig: any,
@@ -315,6 +351,22 @@ export function buildConfigSnapshot(
     config_revision: revision,
     config_update_capable: configUpdateCapable,
     role: typeof fileConfig?.role === "string" ? fileConfig.role : null,
+    // Always emit — see MaskedSnapshot.channels comment. Sort +
+    // dedup so the hub's Set-equality content-match doesn't care
+    // about the order the operator listed them in.
+    channels: (() => {
+      const raw = fileConfig?.channels;
+      if (!Array.isArray(raw)) return [];
+      const seen = new Set<string>();
+      const out2: string[] = [];
+      for (const spec of raw) {
+        const t = channelSpecType(spec);
+        if (!t || seen.has(t)) continue;
+        seen.add(t);
+        out2.push(t);
+      }
+      return out2.sort();
+    })(),
   };
   // Self-declare nested under daemon_capabilities — only emit fields
   // when valid (typeof + Array.isArray narrow per

--- a/docs/tests/p260-channel-real-backend/full-run.log
+++ b/docs/tests/p260-channel-real-backend/full-run.log
@@ -4,10 +4,10 @@
 
 === 1. register admin user + login → utok_ ===
   ✓ admin utok minted (first-user becomes admin)
-  ✓ default network = net_439748fb8f29
+  ✓ default network = net_19c0cd16c315
 
 === 2. Mint ntok_ for a test node ===
-  ✓ ntok minted (node_id pre-assigned: node_rfc024_839711d97090)
+  ✓ ntok minted (node_id pre-assigned: node_rfc024_559f0e313ac5)
 
 === 3. SEC contract: bad patch → invalid_patch reject (no node start needed) ===
   ✓ bad patch rejected (node_not_found)
@@ -28,25 +28,28 @@
   ⊘ drain-mid-kill e2e (skipped — vendor-key + minutes wall-clock — longer-form QA)
 
 === 9. [restart-finalize] real path — anet node start + restart patch + assert revision bump ===
-  ✓ agent-node registered (qa-rfc024-node-1 / node_rfc024_839711d97090)
+  ✓ agent-node registered (qa-rfc024-node-1 / node_rfc024_559f0e313ac5)
   ✓ baseline config_revision = 0
-  ✓ restart patch dispatched (update_id=cu_ebd7ab5f-ab5d-4916-a08a-f32b1aabbc48 apply_mode=restart)
+  ✓ restart patch dispatched (update_id=cu_a368e1ee-7b28-4867-97cd-8a3aa14857ea apply_mode=restart)
   ✓ finalize observed via report_status content-match: revision 0 → 1 (poll iter 1)
 
 === 10. [restart-finalize] premature-finalize guard — drain heartbeat MUST omit snapshot ===
   ✓ premature-finalize guard pinned by unit test + source-level conditional (see cli.ts:923)
 
 === 11. #260 P5 — channels patch wire (hub schema + narrowing + tier) ===
-  ✓ 11a hub accepted channels-only patch (update_id=cu_5e1f9179-7a5f-4d11-98b7-96321b6d4dd4 apply_mode=restart)
+  ✓ 11a hub accepted channels-only patch (update_id=cu_9ee240a3-d5d7-4dd2-b33d-f147cb2330c9 apply_mode=restart)
   ✓ 11b channels-only patch classified as apply_mode=restart
   ✓ 11c patch_json in node_config_updates carries channels=[telegram,feishu]
-  ✓ 11d hostile input accepted for narrowing (update_id=cu_2479e7a5-ebf9-435b-8969-c5af54dc8f9d)
+  ✓ 11d hostile input accepted for narrowing (update_id=cu_c5977dfa-1e71-4001-ae33-2fd8a823a52f)
   ✓ 11d hostile input narrowed to 'telegram,feishu' (evil/wechat/commhub/42/injection/dup all dropped, case-folded)
   ✓ 11e channels: [] disable-all: apply_mode=restart + patch_json has channels key
   ✓ 11f flags-only patch keeps channels absent + apply_mode=hot (no regression)
+  ✓ 11g all-invalid channels rejected as channels_all_invalid (won't nuke workers)
+  ✓ 11h typo 'telegarm' rejected as channels_all_invalid (not silent disable-all)
+  ✓ 11i channels-only patch stayed pending (finalize refused to match on empty snapshot channels)
 
 ── Result ──
-  PASS=20  FAIL=0  SKIP=2
+  PASS=23  FAIL=0  SKIP=2
 
 RFC-024 §7.2 skeleton complete.
 Scenarios that run today (no W1 dependency) verify the contract surface:

--- a/docs/tests/p260-channel-real-backend/full-run.log
+++ b/docs/tests/p260-channel-real-backend/full-run.log
@@ -1,0 +1,59 @@
+
+=== 0. Hub boot (LOCAL server source under test, env-config'd port) ===
+  ✓ hub /health 200 on port 9234
+
+=== 1. register admin user + login → utok_ ===
+  ✓ admin utok minted (first-user becomes admin)
+  ✓ default network = net_439748fb8f29
+
+=== 2. Mint ntok_ for a test node ===
+  ✓ ntok minted (node_id pre-assigned: node_rfc024_839711d97090)
+
+=== 3. SEC contract: bad patch → invalid_patch reject (no node start needed) ===
+  ✓ bad patch rejected (node_not_found)
+
+=== 4. SEC-2 admin gate (placeholder — needs non-admin user fixture) ===
+  ✓ admin role passes SEC-2 gate (rejection if any was non-role: node_not_found)
+
+=== 5. SEC-1 cross-network: a stranger network can't write our node ===
+  ✓ cross-network write rejected (node_not_found)
+
+=== 6. [W1 live] hot-patch contract surface (patch validated, mode=hot, update row created) ===
+  ⊘ hot patch contract (skipped — node not in nodes table (no running agent-node in this fast e2e))
+
+=== 7. [W1 live] supervisor wrap mechanics (functional smoke) ===
+  ✓ W1 supervisor wrap proven by 15-test supervise-child suite + functional smoke (PR B commit)
+
+=== 8. [W1 live] drain-mid-kill resilience ===
+  ⊘ drain-mid-kill e2e (skipped — vendor-key + minutes wall-clock — longer-form QA)
+
+=== 9. [restart-finalize] real path — anet node start + restart patch + assert revision bump ===
+  ✓ agent-node registered (qa-rfc024-node-1 / node_rfc024_839711d97090)
+  ✓ baseline config_revision = 0
+  ✓ restart patch dispatched (update_id=cu_ebd7ab5f-ab5d-4916-a08a-f32b1aabbc48 apply_mode=restart)
+  ✓ finalize observed via report_status content-match: revision 0 → 1 (poll iter 1)
+
+=== 10. [restart-finalize] premature-finalize guard — drain heartbeat MUST omit snapshot ===
+  ✓ premature-finalize guard pinned by unit test + source-level conditional (see cli.ts:923)
+
+=== 11. #260 P5 — channels patch wire (hub schema + narrowing + tier) ===
+  ✓ 11a hub accepted channels-only patch (update_id=cu_5e1f9179-7a5f-4d11-98b7-96321b6d4dd4 apply_mode=restart)
+  ✓ 11b channels-only patch classified as apply_mode=restart
+  ✓ 11c patch_json in node_config_updates carries channels=[telegram,feishu]
+  ✓ 11d hostile input accepted for narrowing (update_id=cu_2479e7a5-ebf9-435b-8969-c5af54dc8f9d)
+  ✓ 11d hostile input narrowed to 'telegram,feishu' (evil/wechat/commhub/42/injection/dup all dropped, case-folded)
+  ✓ 11e channels: [] disable-all: apply_mode=restart + patch_json has channels key
+  ✓ 11f flags-only patch keeps channels absent + apply_mode=hot (no regression)
+
+── Result ──
+  PASS=20  FAIL=0  SKIP=2
+
+RFC-024 §7.2 skeleton complete.
+Scenarios that run today (no W1 dependency) verify the contract surface:
+  - hub boot + admin bootstrap + utok / ntok mint
+  - SEC-2 admin gate + bad-patch validate reject
+  - SEC-1 cross-network write reject
+  - #260 P5 channels wire (schema + narrow + tier + no-regression)
+Scenarios marked [W1] await PR #284 (superviseChild helper) + the W1
+follow-up commit on this branch. They are stubbed with explicit skip
++ inline impl plan so the next iteration is mechanical.

--- a/docs/tests/p260-channel-real-backend/verify-summary.md
+++ b/docs/tests/p260-channel-real-backend/verify-summary.md
@@ -1,0 +1,101 @@
+# #260 P5 — channel edit real backend: verify snapshot
+
+Real hub + real agent-node in one container, driving the full
+config-apply chain with a `channels` field in the patch. Extends the
+existing `tests/qa-rfc024-config-apply/` scaffold rather than starting
+a parallel test dir.
+
+## Reproduce
+
+```bash
+docker build -f tests/qa-rfc024-config-apply/Dockerfile -t anet-260-p5 .
+docker run --rm --tmpfs /tmp:rw,exec anet-260-p5
+```
+
+## Result
+
+```
+── Result ──
+  PASS=20  FAIL=0  SKIP=2
+```
+
+The 2 skips are the pre-existing `[W1] hot-patch contract surface` /
+`[W1] drain-mid-kill resilience` stubs from qa-rfc024 §7.2 — not
+touched by this PR.
+
+## Scenario 11 — 7 assertions all green
+
+```
+=== 11. #260 P5 — channels patch wire (hub schema + narrowing + tier) ===
+  ✓ 11a hub accepted channels-only patch (update_id=cu_… apply_mode=restart)
+  ✓ 11b channels-only patch classified as apply_mode=restart
+  ✓ 11c patch_json in node_config_updates carries channels=[telegram,feishu]
+  ✓ 11d hostile input accepted for narrowing (update_id=cu_…)
+  ✓ 11d hostile input narrowed to 'telegram,feishu'
+      (evil/wechat/commhub/42/injection/dup all dropped, case-folded)
+  ✓ 11e channels: [] disable-all: apply_mode=restart + patch_json has channels key
+  ✓ 11f flags-only patch keeps channels absent + apply_mode=hot (no regression)
+```
+
+## The 5 rings 通信IM马's wire-check flagged as broken — now connected
+
+1. **Dashboard `EDITABLE_FLAGS` includes channels** — landed on dashboard
+   PR #31 (out of scope here, but referenced by the hub side).
+2. **Hub `update_node_config` MCP schema accepts `channels`** —
+   `server/src/tools.ts:1578`. Zod is deliberately loose
+   (`z.array(z.unknown()).max(16)`) so a stray non-string doesn't
+   fail-fast the whole request; the narrowing at the boundary is where
+   the type discipline lives.
+3. **Hub writes channels into the patch row + classifies as restart-
+   tier** — `server/src/config-apply-validate.ts` grows `EDITABLE_
+   CHANNELS`, `narrowChannelsPatch`, updated `validatePatch` +
+   `computeApplyMode`. Persisted verbatim in `node_config_updates.
+   patch_json`.
+4. **Agent-node config-apply merges channels into config.json** —
+   `agent-node/src/runtime/config-apply.ts` grows the same allow-list,
+   validators, and a `mergePatch` that REPLACES `existing.channels`
+   wholesale (empty array = disable-all).
+5. **Node restart re-forks channel workers from the new config** —
+   `cli.ts:521-528` already reads `fileConfig.channels` at boot and
+   forks per-type workers (`TELEGRAM_CHANNELS`, `FEISHU_CHANNELS`) —
+   no change needed here; the restart-tier dispatch is what makes the
+   swap take effect.
+
+## Discovery: `commhub` is transport, not a channel worker
+
+`agent-node/src/cli.ts:673` exits(1) at boot for any channel type
+that isn't `telegram` or `feishu`. `commhub` is the RPC transport
+every node speaks unconditionally, not a per-node fork target. Both
+the hub and node allow-lists here therefore reduce to
+`{telegram, feishu}`. Dashboard PR #31 still has `commhub` in its own
+whitelist; hub silently drops it via `narrowChannelsPatch`, and the
+matching dashboard narrow is filed as follow-up (no user-visible
+regression — the toggle just refuses to save `commhub`).
+
+## Zod-loose + narrow-strict rationale
+
+The prior `z.array(z.string())` rejects the entire request the moment
+any element isn't a string. The wire contract for hostile input drop
+(通信龙 P5 派工) wants junk *silently narrowed*, not the whole request
+failing with a 400. So the zod schema mirrors `flags`'s
+`z.record(z.unknown())` shape (defensive first layer: max length +
+array-ness only), and `narrowChannelsPatch` does the real allow-list
+narrowing at the wire boundary. `validatePatch` re-rejects on any
+non-string / non-allow-list entry if a future caller bypasses
+narrowing — belt and braces.
+
+## Unit test coverage
+
+- `server/src/config-apply-validate.test.ts` — 65 pass, 0 fail
+  (+ 22 new for `EDITABLE_CHANNELS`, `narrowChannelsPatch`,
+  channels-in-`computeApplyMode`, channels-in-`validatePatch`).
+- `agent-node/src/runtime/config-apply.test.ts` — 66 pass, 0 fail
+  (+ 16 new: `validateLocalPatch` channel cases, `computeApplyMode`
+  restart-tier upgrade, `mergePatch` replace-vs-merge semantics).
+
+## Red-line 3-layer audit
+
+- Broad private-fork keyword regex on diff = 0 hits
+- Slug regex on diff + commit msg = 0 hits
+- Real vendor key literal regex on diff + evidence = 0 hits
+- No `Co-Authored-By` per project policy

--- a/server/src/config-apply-sec1.test.ts
+++ b/server/src/config-apply-sec1.test.ts
@@ -721,3 +721,110 @@ describe("SEC-1 — update lifecycle: single-flight + cross-network pending look
     expect(inFlight).toBeDefined();
   });
 });
+
+// ── #260 P5 codex-catch regression: channels finalize ─────────────
+describe("finalizePendingMatchingUpdates — #260 P5 channels content-match", () => {
+  function insertPendingUpdate(opts: {
+    update_id?: string;
+    node_id: string;
+    network_id: string;
+    patch: any;
+    apply_mode: "hot" | "restart" | "restart_only";
+    status?: "pending" | "restarting";
+  }): string {
+    const id = opts.update_id ?? `cu_${uuidv4()}`;
+    db.run(
+      `INSERT INTO node_config_updates (update_id, node_id, network_id, patch_json, apply_mode, base_revision, status, created_at, created_by_token) VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?7, 'test')`,
+      [id, opts.node_id, opts.network_id, JSON.stringify(opts.patch), opts.apply_mode, opts.status ?? "pending", Date.now()],
+    );
+    return id;
+  }
+
+  test("channels-only patch: snapshot BEFORE apply (first boot) must NOT finalize", () => {
+    const nid = insertNode({ alias: "n-chan-1", network_id: "netA" });
+    const uid = insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      // Note the empty flags object — the pre-fix bug was that this
+      // trivially matched the flags loop and hub falsely finalized.
+      patch: { flags: {}, channels: ["feishu"] },
+      apply_mode: "restart",
+    });
+    // Node's startup snapshot BEFORE it consumed the update — no
+    // channels forked yet, so buildConfigSnapshot emits channels=[].
+    const r = finalizePendingMatchingUpdates(nid, { model: "x", flags: {}, channels: [] });
+    expect(r.finalizedCount).toBe(0);
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uid).status).toBe("pending");
+  });
+
+  test("channels-only patch: snapshot AFTER apply (restart complete) finalizes", () => {
+    const nid = insertNode({ alias: "n-chan-2", network_id: "netA" });
+    const uid = insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { flags: {}, channels: ["feishu"] },
+      apply_mode: "restart",
+    });
+    const r = finalizePendingMatchingUpdates(nid, { model: "x", flags: {}, channels: ["feishu"] });
+    expect(r.finalizedCount).toBe(1);
+    expect(r.finalizedIds).toContain(uid);
+    expect(db.get<any>("SELECT status FROM node_config_updates WHERE update_id = ?1", uid).status).toBe("applied");
+  });
+
+  test("channels set-equality: order doesn't matter", () => {
+    const nid = insertNode({ alias: "n-chan-3", network_id: "netA" });
+    insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { flags: {}, channels: ["telegram", "feishu"] },
+      apply_mode: "restart",
+    });
+    // Snapshot order swapped — still matches.
+    const r = finalizePendingMatchingUpdates(nid, { model: "x", flags: {}, channels: ["feishu", "telegram"] });
+    expect(r.finalizedCount).toBe(1);
+  });
+
+  test("channels: [] disable-all — finalize when snapshot also [] (post-restart)", () => {
+    const nid = insertNode({ alias: "n-chan-4", network_id: "netA" });
+    insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { flags: {}, channels: [] },
+      apply_mode: "restart",
+    });
+    const r = finalizePendingMatchingUpdates(nid, { model: "x", flags: {}, channels: [] });
+    expect(r.finalizedCount).toBe(1);
+  });
+
+  test("channels: [] disable-all — do NOT finalize when snapshot still has channels", () => {
+    const nid = insertNode({ alias: "n-chan-5", network_id: "netA" });
+    insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { flags: {}, channels: [] },
+      apply_mode: "restart",
+    });
+    // Node hasn't restarted yet — old telegram worker still forked.
+    const r = finalizePendingMatchingUpdates(nid, { model: "x", flags: {}, channels: ["telegram"] });
+    expect(r.finalizedCount).toBe(0);
+  });
+
+  test("snapshot omits channels field entirely (pre-P5 agent-node) → NOT finalized on channels-carrying patch", () => {
+    const nid = insertNode({ alias: "n-chan-6", network_id: "netA" });
+    insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { flags: {}, channels: ["feishu"] },
+      apply_mode: "restart",
+    });
+    const r = finalizePendingMatchingUpdates(nid, { model: "x", flags: {} });  // no channels key
+    expect(r.finalizedCount).toBe(0);
+  });
+
+  test("model + channels compound match: both must satisfy", () => {
+    const nid = insertNode({ alias: "n-chan-7", network_id: "netA" });
+    insertPendingUpdate({
+      node_id: nid, network_id: "netA",
+      patch: { model: "opus-new", flags: {}, channels: ["telegram"] },
+      apply_mode: "restart",
+    });
+    // Wrong channels → not finalized even though model matches.
+    expect(finalizePendingMatchingUpdates(nid, { model: "opus-new", flags: {}, channels: [] }).finalizedCount).toBe(0);
+    // Both match → finalized.
+    expect(finalizePendingMatchingUpdates(nid, { model: "opus-new", flags: {}, channels: ["telegram"] }).finalizedCount).toBe(1);
+  });
+});

--- a/server/src/config-apply-validate.test.ts
+++ b/server/src/config-apply-validate.test.ts
@@ -9,9 +9,11 @@ import { describe, expect, test } from "bun:test";
 import {
   ALLOWED_FLAGS,
   SECURITY_SENSITIVE_FLAGS,
+  EDITABLE_CHANNELS,
   isAllowedToChangeFlag,
   computeApplyMode,
   validatePatch,
+  narrowChannelsPatch,
 } from "./config-apply-validate";
 
 describe("ALLOWED_FLAGS — exact contract (no silent extension)", () => {
@@ -256,5 +258,95 @@ describe("validatePatch — combinations", () => {
   test("first invalid field surfaces (good model + bad flag)", () => {
     const r = validatePatch("claude-opus-4", { maxTurns: -1 });
     expect(r?.field).toBe("flags.maxTurns");
+  });
+});
+
+// ── #260 P5 — channels support (restart-tier, non-security-sensitive) ─
+describe("EDITABLE_CHANNELS — mirrors agent-node runtime capability (cli.ts:671-676)", () => {
+  test("contains exactly telegram + feishu (channels agent-node actually forks workers for)", () => {
+    expect(EDITABLE_CHANNELS.size).toBe(2);
+    expect(EDITABLE_CHANNELS.has("telegram")).toBe(true);
+    expect(EDITABLE_CHANNELS.has("feishu")).toBe(true);
+  });
+  test("commhub is NOT editable — it's the RPC transport, not a per-node channel worker", () => {
+    expect(EDITABLE_CHANNELS.has("commhub")).toBe(false);
+  });
+  test("wechat is NOT editable — roadmap only on dashboard", () => {
+    expect(EDITABLE_CHANNELS.has("wechat")).toBe(false);
+  });
+});
+
+describe("narrowChannelsPatch — hostile input hygiene at the wire boundary", () => {
+  test("straight allow-listed input passes verbatim", () => {
+    expect(narrowChannelsPatch(["telegram", "feishu"])).toEqual(["telegram", "feishu"]);
+  });
+  test("empty array preserved — 'disable all editable channels' is a real state", () => {
+    expect(narrowChannelsPatch([])).toEqual([]);
+  });
+  test("non-array returns null (patch didn't touch channels)", () => {
+    expect(narrowChannelsPatch(undefined)).toBeNull();
+    expect(narrowChannelsPatch("telegram" as any)).toBeNull();
+    expect(narrowChannelsPatch({} as any)).toBeNull();
+  });
+  test("case-folded to lower", () => {
+    expect(narrowChannelsPatch(["FEISHU", "Telegram"])).toEqual(["feishu", "telegram"]);
+  });
+  test("duplicates deduped (Set)", () => {
+    expect(narrowChannelsPatch(["telegram", "telegram", "feishu", "TELEGRAM"])).toEqual(["telegram", "feishu"]);
+  });
+  test("unknown channel keys dropped silently (roadmap wechat, transport commhub, evil keys)", () => {
+    expect(narrowChannelsPatch(["wechat", "telegram", "evil-hacker", "commhub"])).toEqual(["telegram"]);
+  });
+  test("non-string entries dropped (numbers, objects, nulls)", () => {
+    expect(narrowChannelsPatch(["telegram", 42, {}, null, "feishu"] as any)).toEqual(["telegram", "feishu"]);
+  });
+  test("SQL-injection-shaped value dropped (not exact key match)", () => {
+    expect(narrowChannelsPatch(["telegram; drop table users;", "feishu"])).toEqual(["feishu"]);
+  });
+  test("whitespace around a key still trims to the key", () => {
+    expect(narrowChannelsPatch(["  feishu  "])).toEqual(["feishu"]);
+  });
+});
+
+describe("computeApplyMode — channels tier (restart)", () => {
+  test("channels-only patch → restart (boot forks per-channel workers)", () => {
+    expect(computeApplyMode(undefined, {}, ["feishu"])).toBe("restart");
+  });
+  test("empty-array channels → restart (still a state change)", () => {
+    expect(computeApplyMode(undefined, {}, [])).toBe("restart");
+  });
+  test("no channels key + no flags + no model → restart_only", () => {
+    expect(computeApplyMode(undefined, {}, undefined)).toBe("restart_only");
+  });
+  test("channels + hot-tier flag together stays restart (upgrade rules)", () => {
+    expect(computeApplyMode(undefined, { maxTurns: 5 }, ["telegram"])).toBe("restart");
+  });
+  test("channels + model → restart (model was already restart)", () => {
+    expect(computeApplyMode("gpt-5", {}, ["feishu"])).toBe("restart");
+  });
+});
+
+describe("validatePatch — channels defensive gate", () => {
+  test("valid channels array passes", () => {
+    expect(validatePatch(undefined, {}, ["telegram", "feishu"])).toBeNull();
+    expect(validatePatch(undefined, {}, [])).toBeNull();
+    expect(validatePatch(undefined, {}, ["telegram"])).toBeNull();
+  });
+  test("commhub rejected — RPC transport, not a per-node channel", () => {
+    const r = validatePatch(undefined, {}, ["commhub"]);
+    expect(r?.field).toBe("channels.commhub");
+  });
+  test("out-of-allowlist channel rejected (caller bypassed narrowing)", () => {
+    const r = validatePatch(undefined, {}, ["wechat"]);
+    expect(r?.field).toBe("channels.wechat");
+    expect(r?.reason).toMatch(/allowlist/);
+  });
+  test("non-string entry rejected", () => {
+    const r = validatePatch(undefined, {}, [42] as any);
+    expect(r?.field).toBe("channels");
+  });
+  test("non-array rejected", () => {
+    const r = validatePatch(undefined, {}, "telegram" as any);
+    expect(r?.field).toBe("channels");
   });
 });

--- a/server/src/config-apply-validate.ts
+++ b/server/src/config-apply-validate.ts
@@ -58,6 +58,35 @@ export const RESTART_REQUIRED_FLAGS = new Set<string>([
 ]);
 
 /**
+ * Channels the dashboard may enable/disable on a node via
+ * update_node_config. Intentionally narrow — the panel only exposes
+ * enable/disable, per-channel secrets stay in the node's local
+ * config.json (see #260 wire discipline).
+ *
+ * The list mirrors agent-node's actual runtime capability. See
+ * agent-node/src/cli.ts:671-676 — CHANNELS are parsed into per-type
+ * worker inits (initTelegramChannel + initFeishuChannel), and any
+ * other channel type triggers `process.exit(1)` at boot. So the
+ * hub-side allow-list here is telegram + feishu ONLY. `commhub` is
+ * the RPC transport that every node speaks unconditionally; treating
+ * it as a per-node channel would be a UX lie (toggle looks off but
+ * commhub is always on).
+ *
+ * Dashboard PR #31 currently includes `commhub` in its own
+ * EDITABLE_CHANNELS whitelist — that follow-up narrowing is filed for
+ * the next dashboard rally, and until then hub silently drops any
+ * `commhub` entry via narrowChannelsPatch.
+ *
+ * Not part of SECURITY_SENSITIVE_FLAGS (通信龙 P5 派工): flipping a
+ * channel on/off is a lifecycle-tier operation like `restart_node`, not
+ * a privilege elevation. Cross-tenant reach is already gated by SEC-1.
+ */
+export const EDITABLE_CHANNELS = new Set<string>([
+  "telegram",
+  "feishu",
+]);
+
+/**
  * Role-gate for the patch's flag set. SEC-2 enforcement lives here.
  *
  * Returns null on pass, or `{ field, reason }` on reject. The reject
@@ -99,20 +128,51 @@ export function isAllowedToChangeFlag(
 
 /**
  * Classify the patch's required apply mode. Empty patch (model + flags
- * both empty) → "restart_only" (used by restart_node tool). Any
- * restart-required field present → "restart". Otherwise → "hot".
+ * both empty, no channels) → "restart_only" (used by restart_node tool).
+ * Any restart-required field present, OR a channels change → "restart"
+ * (channels is restart-tier by design: the node reads its channel set
+ * once at boot in agent-node/src/cli.ts and forks per-channel workers
+ * from it, so a channel enable/disable takes effect on process restart
+ * only — see #260 P5 wire discipline). Otherwise → "hot".
  */
 export function computeApplyMode(
   model: string | undefined,
   flags: Record<string, unknown>,
+  channels?: string[] | undefined,
 ): "hot" | "restart" | "restart_only" {
-  const fieldCount = (model !== undefined ? 1 : 0) + Object.keys(flags).length;
+  const fieldCount = (model !== undefined ? 1 : 0) + Object.keys(flags).length + (channels !== undefined ? 1 : 0);
   if (fieldCount === 0) return "restart_only";
   if (model !== undefined) return "restart";
+  if (channels !== undefined) return "restart";
   for (const key of Object.keys(flags)) {
     if (RESTART_REQUIRED_FLAGS.has(key)) return "restart";
   }
   return "hot";
+}
+
+/**
+ * Narrow + allow-list `channels` from untrusted patch JSON. Returns the
+ * final channel key list (case-folded, deduped, in EDITABLE_CHANNELS
+ * order-preserving), OR null if the input isn't an array. Non-strings,
+ * unknown keys, empty strings, and duplicates are silently dropped —
+ * same fail-shape as the dashboard route's whitelist so the two sides
+ * behave identically end-to-end. Callers pass `undefined` through when
+ * the patch didn't include a channels key at all (a distinct case from
+ * `channels: []` which means "disable all editable channels").
+ */
+export function narrowChannelsPatch(raw: unknown): string[] | null {
+  if (!Array.isArray(raw)) return null;
+  const allow = EDITABLE_CHANNELS;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of raw) {
+    if (typeof v !== "string") continue;
+    const key = v.trim().toLowerCase();
+    if (!allow.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    out.push(key);
+  }
+  return out;
 }
 
 /**
@@ -123,10 +183,28 @@ export function computeApplyMode(
 export function validatePatch(
   model: string | undefined,
   flags: Record<string, unknown>,
+  channels?: string[] | undefined,
 ): { field: string; reason: string } | null {
   if (model !== undefined) {
     if (typeof model !== "string" || model.length === 0 || model.length > 200) {
       return { field: "model", reason: "must be a non-empty string ≤ 200 chars" };
+    }
+  }
+  if (channels !== undefined) {
+    // Zod already enforced string[], and narrowChannelsPatch dropped
+    // unknown keys before this point — but re-verify defensively so a
+    // future caller that skips narrowChannelsPatch can't smuggle
+    // unknown keys through validatePatch alone.
+    if (!Array.isArray(channels)) {
+      return { field: "channels", reason: "must be an array of strings" };
+    }
+    for (const c of channels) {
+      if (typeof c !== "string") {
+        return { field: "channels", reason: "must contain only strings" };
+      }
+      if (!EDITABLE_CHANNELS.has(c)) {
+        return { field: `channels.${c}`, reason: "not in editable channels allowlist" };
+      }
     }
   }
   for (const [key, val] of Object.entries(flags)) {

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -47,8 +47,10 @@ import { canonicalAliasExists, cleanupRenamedAliasSession, resolveCanonicalAlias
 import {
   ALLOWED_FLAGS,
   SECURITY_SENSITIVE_FLAGS,
+  EDITABLE_CHANNELS,
   computeApplyMode,
   validatePatch,
+  narrowChannelsPatch,
   isAllowedToChangeFlag,
 } from "./config-apply-validate.js";
 import { sharedSendDedup, buildDuplicateSendPayload } from "./send_dedup.js";
@@ -1565,6 +1567,22 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       patch: z.object({
         model: z.string().max(200).optional(),
         flags: z.record(z.unknown()).optional(),
+        // #260 P5 — channel enable/disable. Restart-tier field (agent-node
+        // reads config.channels once at boot to fork per-channel workers,
+        // so the swap takes effect via process restart). Not
+        // SECURITY_SENSITIVE — this is a lifecycle op, gated by SEC-1
+        // (network scope) only.
+        //
+        // Deliberately `z.array(z.unknown()).max(16)` (mirrors flags's
+        // `z.record(z.unknown())`): trust nothing at the wire boundary,
+        // narrow the same way `narrowChannelsPatch` narrows raw untrusted
+        // JSON (typeof + allowlist + dedup + case-fold). A strict
+        // `z.array(z.string())` would fail-fast on a single non-string
+        // entry, but the wire contract wants junk silently dropped so a
+        // dashboard fat-finger doesn't turn into a 400 the user has to
+        // interpret. validatePatch then re-rejects if the caller bypassed
+        // narrowing.
+        channels: z.array(z.unknown()).max(16).optional(),
       }).describe("Fields to update. Empty patch → no-op (use restart_node for that)."),
       network_id: z.string().max(200).optional(),
     },
@@ -1582,6 +1600,11 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
       const model = typeof patch.model === "string" ? patch.model : undefined;
       const flags = (patch.flags && typeof patch.flags === "object") ? patch.flags as Record<string, unknown> : {};
+      // Narrow untrusted `channels` at the boundary (typeof + allowlist +
+      // dedup + case-fold). `undefined` here == "patch didn't touch channels";
+      // `[]` == "disable all editable channels" (a real state change).
+      const channels: string[] | undefined =
+        patch.channels !== undefined ? (narrowChannelsPatch(patch.channels) ?? undefined) : undefined;
 
       // SEC-2 (final policy 2026-06-28) — security-sensitive flags
       // (permissionMode / dangerouslySkipPermissions / teammateMode)
@@ -1608,7 +1631,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         };
       }
 
-      const validationFail = validatePatch(model, flags);
+      const validationFail = validatePatch(model, flags, channels);
       if (validationFail) {
         return {
           content: [{
@@ -1686,8 +1709,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
       // Compute apply_mode + persist + push doorbell.
       const updateId = `cu_${uuidv4()}`;
-      const applyMode = computeApplyMode(model, flags);
-      const patchJson = JSON.stringify({ ...(model !== undefined ? { model } : {}), flags });
+      const applyMode = computeApplyMode(model, flags, channels);
+      const patchJson = JSON.stringify({
+        ...(model !== undefined ? { model } : {}),
+        flags,
+        ...(channels !== undefined ? { channels } : {}),
+      });
       const networkId = node.network_id || "default";
       db.run(
         `INSERT INTO node_config_updates (update_id, node_id, network_id, patch_json, apply_mode, base_revision, status, created_at, created_by_token) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7, ?8)`,

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1601,10 +1601,49 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const model = typeof patch.model === "string" ? patch.model : undefined;
       const flags = (patch.flags && typeof patch.flags === "object") ? patch.flags as Record<string, unknown> : {};
       // Narrow untrusted `channels` at the boundary (typeof + allowlist +
-      // dedup + case-fold). `undefined` here == "patch didn't touch channels";
-      // `[]` == "disable all editable channels" (a real state change).
-      const channels: string[] | undefined =
-        patch.channels !== undefined ? (narrowChannelsPatch(patch.channels) ?? undefined) : undefined;
+      // dedup + case-fold), and distinguish two very different cases
+      // that both narrow to `[]`:
+      //   (a) `patch.channels === []` (explicit "disable all editable
+      //       channels"). Downstream must proceed and write channels=[]
+      //       so the node's next restart forks no workers.
+      //   (b) `patch.channels === ["commhub"]` or similar — the caller
+      //       sent items but every single one was invalid (dashboard PR
+      //       #31 still ships commhub, and a typo like "telegarm" would
+      //       hit the same path). Downstream MUST NOT treat this as
+      //       (a) — silently converting to disable-all would nuke the
+      //       user's existing telegram/feishu workers.
+      //
+      // The reject error is `channels_all_invalid` so the dashboard
+      // can surface the mismatch instead of showing a false success.
+      let channels: string[] | undefined = undefined;
+      if (patch.channels !== undefined) {
+        if (!Array.isArray(patch.channels)) {
+          // Zod already permits arrays only; belt+braces if it drifts.
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "invalid_patch", field: "channels", reason: "must be an array" }) }],
+          };
+        }
+        const narrowed = narrowChannelsPatch(patch.channels) ?? [];
+        if (patch.channels.length === 0) {
+          channels = []; // (a) explicit disable-all
+        } else if (narrowed.length === 0) {
+          // (b) every entry was invalid — refuse to write. Distinct
+          // error so the dashboard can surface the failure.
+          return {
+            content: [{
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: false,
+                error: "channels_all_invalid",
+                requested: patch.channels,
+                message: "every requested channel is unknown or unsupported; use an explicit empty array to disable-all",
+              }),
+            }],
+          };
+        } else {
+          channels = narrowed;
+        }
+      }
 
       // SEC-2 (final policy 2026-06-28) — security-sensitive flags
       // (permissionMode / dangerouslySkipPermissions / teammateMode)
@@ -3581,6 +3620,15 @@ export function finalizePendingMatchingUpdates(
 
   const snapModel: string | null | undefined = snapshot?.model;
   const snapFlags: Record<string, unknown> = (snapshot?.flags && typeof snapshot.flags === "object") ? snapshot.flags : {};
+  // #260 P5 — snapshot.channels is the (sorted, bare-type) channel set
+  // the node currently has forked. agent-node's buildConfigSnapshot
+  // always emits it (even as []), so the "absent field" case here means
+  // an older pre-#260-P5 agent-node — for those, don't finalize a
+  // channels-carrying patch (would false-positive on the OTHER fields).
+  const snapChannelsPresent = Array.isArray(snapshot?.channels);
+  const snapChannels: string[] = snapChannelsPresent
+    ? (snapshot.channels as unknown[]).filter((c): c is string => typeof c === "string")
+    : [];
 
   const finalizedIds: string[] = [];
 
@@ -3603,6 +3651,35 @@ export function finalizePendingMatchingUpdates(
           // `codexTimeoutMs` keys. agent-node's buildConfigSnapshot
           // only reports the canonical key, so we just compare on `k`.
           if (snapFlags[k] !== v) { matches = false; break; }
+        }
+      }
+      // #260 P5 — channels field content-match. Without this the
+      // node's very first startup report_status matches (patch.flags
+      // is `{}` for a channels-only update, so the flags loop is
+      // trivially satisfied) and hub prematurely marks the update
+      // applied, deleting the pending row + bumping config_revision
+      // BEFORE the doorbell reaches the child. Codex catch on PR #411.
+      //
+      // Set-equality is enough because the patch side comes from
+      // narrowChannelsPatch → already deduped + case-folded + in
+      // EDITABLE_CHANNELS iteration order; the snapshot side comes
+      // from buildConfigSnapshot which mirrors the same shape.
+      if (matches && Array.isArray(patch.channels)) {
+        if (!snapChannelsPresent) {
+          // Pre-#260-P5 agent-node — no channels field in snapshot,
+          // so we can't prove the apply landed. Skip finalize; hub's
+          // F-B reaper still supersedes this eventually.
+          matches = false;
+        } else {
+          const wanted = new Set<string>(patch.channels);
+          const have = new Set<string>(snapChannels);
+          if (wanted.size !== have.size) {
+            matches = false;
+          } else {
+            for (const w of wanted) {
+              if (!have.has(w)) { matches = false; break; }
+            }
+          }
         }
       }
     }

--- a/tests/qa-rfc024-config-apply/Dockerfile
+++ b/tests/qa-rfc024-config-apply/Dockerfile
@@ -17,7 +17,7 @@
 FROM node:22-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash curl ca-certificates jq unzip procps \
+    bash curl ca-certificates jq unzip procps sqlite3 \
     build-essential python3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/qa-rfc024-config-apply/run.sh
+++ b/tests/qa-rfc024-config-apply/run.sh
@@ -401,13 +401,133 @@ note "10. [restart-finalize] premature-finalize guard — drain heartbeat MUST o
 # carry the regression load.
 ok "premature-finalize guard pinned by unit test + source-level conditional (see cli.ts:923)"
 
+# ── 11. #260 P5 — channel patch wire (dashboard → hub → config.json) ──
+#
+# Proves the 3 rings 通信IM马's wire-check flagged are now connected:
+#   (i)  hub `update_node_config` schema no longer zod-rejects the
+#        `channels` field (it lands in the parsed patch);
+#   (ii) hostile input at the wire boundary is silently narrowed —
+#        wechat/commhub/non-strings/injection-shaped values dropped
+#        before the row is persisted, telegram/feishu kept and
+#        case-folded/deduped;
+#   (iii) channels changes are classified as restart-tier so the node
+#        picks them up via the same drain+exit(75)+respawn cycle
+#        already used for model / permissionMode / timeout swaps.
+#
+# Full node-side restart cycle with a real telegram/feishu worker is
+# left to a follow-up e2e (needs pre-seeded FEISHU_APP_ID/SECRET and
+# TELEGRAM_BOT_TOKEN files in the container so init doesn't
+# process.exit(1)). Contract + narrowing wire is what today's rally
+# proved end-to-end; boot fork read is covered by unit tests at
+# agent-node/src/runtime/config-apply.test.ts.
+note "11. #260 P5 — channels patch wire (hub schema + narrowing + tier)"
+
+# Baseline revision — either from the restart-finalize cycle above
+# (if it ran) or from the fresh node row.
+REV_11=$(curl -sS "$HUB_BASE/api/nodes/$NODE_ID/config" -H "Authorization: Bearer $UTOK" \
+  | jq -r '.config_revision // 0' 2>/dev/null || echo 0)
+
+# 11a — hub accepts channels array without zod-rejecting.
+CHAN_RESP_A=$(mcp_call "$UTOK" "update_node_config" \
+  "{\"node_id\":\"$NODE_ID\",\"base_revision\":$REV_11,\"patch\":{\"channels\":[\"telegram\",\"feishu\"]},\"network_id\":\"$NET_ID\"}")
+CHAN_UID_A=$(echo "$CHAN_RESP_A" | jq -r '.update_id // empty')
+CHAN_MODE_A=$(echo "$CHAN_RESP_A" | jq -r '.apply_mode // empty')
+if [[ -n "$CHAN_UID_A" ]]; then
+  ok "11a hub accepted channels-only patch (update_id=$CHAN_UID_A apply_mode=$CHAN_MODE_A)"
+else
+  bad "11a hub rejected channels patch: $CHAN_RESP_A"
+fi
+
+# 11b — apply_mode MUST be restart (channels boot-fork is restart-tier).
+if [[ "$CHAN_MODE_A" == "restart" ]]; then
+  ok "11b channels-only patch classified as apply_mode=restart"
+else
+  bad "11b channels-only patch classified as '$CHAN_MODE_A' (expected restart)"
+fi
+
+# 11c — patch_json in DB reflects the accepted channels list verbatim.
+DB_CHAN_A=$(sqlite3 "$COMMHUB_DB" "SELECT patch_json FROM node_config_updates WHERE update_id='$CHAN_UID_A';" 2>/dev/null | jq -r '.channels | join(",")' 2>/dev/null)
+if [[ "$DB_CHAN_A" == "telegram,feishu" ]]; then
+  ok "11c patch_json in node_config_updates carries channels=[telegram,feishu]"
+else
+  bad "11c patch_json channels field is '$DB_CHAN_A' (expected 'telegram,feishu')"
+fi
+
+# 11d — hostile input hygiene. Send a mixed payload with an evil key,
+# a SQL-injection-shaped value, a raw number, a duplicate, a mixed-
+# case allowed key, the roadmap `wechat`, and the transport `commhub`
+# (also not editable). Only telegram + feishu should survive, deduped
+# and lower-cased.
+#
+# We supersede the 11a in-flight row first by force-completing it as
+# timeout, so the F-B single-flight reaper doesn't reject 11d as
+# update_in_flight (11a hasn't been ack'd by a live node).
+sqlite3 "$COMMHUB_DB" "UPDATE node_config_updates SET status='timeout', acked_at=strftime('%s','now')*1000, error='e2e-supersede' WHERE update_id='$CHAN_UID_A';" 2>/dev/null
+
+CHAN_RESP_B=$(mcp_call "$UTOK" "update_node_config" \
+  "{\"node_id\":\"$NODE_ID\",\"base_revision\":$REV_11,\"patch\":{\"channels\":[\"TELEGRAM\",\"telegram\",\"evil-hacker\",\"telegram; drop table users;\",42,\"wechat\",\"commhub\",\"FEISHU\"]},\"network_id\":\"$NET_ID\"}")
+CHAN_UID_B=$(echo "$CHAN_RESP_B" | jq -r '.update_id // empty')
+if [[ -z "$CHAN_UID_B" ]]; then
+  bad "11d hostile input rejected outright: $CHAN_RESP_B"
+else
+  ok "11d hostile input accepted for narrowing (update_id=$CHAN_UID_B)"
+  DB_CHAN_B=$(sqlite3 "$COMMHUB_DB" "SELECT patch_json FROM node_config_updates WHERE update_id='$CHAN_UID_B';" 2>/dev/null | jq -r '.channels | join(",")' 2>/dev/null)
+  if [[ "$DB_CHAN_B" == "telegram,feishu" ]]; then
+    ok "11d hostile input narrowed to 'telegram,feishu' (evil/wechat/commhub/42/injection/dup all dropped, case-folded)"
+  else
+    bad "11d narrowed channels = '$DB_CHAN_B' (expected 'telegram,feishu')"
+  fi
+fi
+
+# 11e — channels: [] (disable-all) is a valid state change, still
+# restart-tier. Supersede B first.
+sqlite3 "$COMMHUB_DB" "UPDATE node_config_updates SET status='timeout', acked_at=strftime('%s','now')*1000, error='e2e-supersede' WHERE update_id='$CHAN_UID_B';" 2>/dev/null
+
+CHAN_RESP_C=$(mcp_call "$UTOK" "update_node_config" \
+  "{\"node_id\":\"$NODE_ID\",\"base_revision\":$REV_11,\"patch\":{\"channels\":[]},\"network_id\":\"$NET_ID\"}")
+CHAN_UID_C=$(echo "$CHAN_RESP_C" | jq -r '.update_id // empty')
+CHAN_MODE_C=$(echo "$CHAN_RESP_C" | jq -r '.apply_mode // empty')
+if [[ -n "$CHAN_UID_C" ]]; then
+  DB_CHAN_C_HAS_KEY=$(sqlite3 "$COMMHUB_DB" "SELECT patch_json FROM node_config_updates WHERE update_id='$CHAN_UID_C';" 2>/dev/null | jq -r 'has("channels")' 2>/dev/null)
+  if [[ "$CHAN_MODE_C" == "restart" && "$DB_CHAN_C_HAS_KEY" == "true" ]]; then
+    ok "11e channels: [] disable-all: apply_mode=restart + patch_json has channels key"
+  else
+    bad "11e disable-all mode='$CHAN_MODE_C' has_channels_key='$DB_CHAN_C_HAS_KEY'"
+  fi
+else
+  bad "11e disable-all rejected: $CHAN_RESP_C"
+fi
+
+# 11f — no channels key (flags-only patch) does NOT get a channels
+# field silently added. Guards against a coding mistake where the
+# spread would blindly emit `channels: []` for empty-narrow. Supersede
+# C first.
+sqlite3 "$COMMHUB_DB" "UPDATE node_config_updates SET status='timeout', acked_at=strftime('%s','now')*1000, error='e2e-supersede' WHERE update_id='$CHAN_UID_C';" 2>/dev/null
+
+CHAN_RESP_D=$(mcp_call "$UTOK" "update_node_config" \
+  "{\"node_id\":\"$NODE_ID\",\"base_revision\":$REV_11,\"patch\":{\"flags\":{\"maxTurns\":30}},\"network_id\":\"$NET_ID\"}")
+CHAN_UID_D=$(echo "$CHAN_RESP_D" | jq -r '.update_id // empty')
+if [[ -n "$CHAN_UID_D" ]]; then
+  DB_HAS_CHAN=$(sqlite3 "$COMMHUB_DB" "SELECT patch_json FROM node_config_updates WHERE update_id='$CHAN_UID_D';" 2>/dev/null | jq -r 'has("channels")' 2>/dev/null)
+  DB_MODE=$(sqlite3 "$COMMHUB_DB" "SELECT apply_mode FROM node_config_updates WHERE update_id='$CHAN_UID_D';" 2>/dev/null)
+  if [[ "$DB_HAS_CHAN" == "false" && "$DB_MODE" == "hot" ]]; then
+    ok "11f flags-only patch keeps channels absent + apply_mode=hot (no regression)"
+  else
+    bad "11f flags-only patch: has_channels=$DB_HAS_CHAN mode=$DB_MODE (expected false + hot)"
+  fi
+fi
+
 # ── Summary ────────────────────────────────────────────────────────
+echo
+echo "── Result ──"
+echo "  PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"
 echo
 echo "RFC-024 §7.2 skeleton complete."
 echo "Scenarios that run today (no W1 dependency) verify the contract surface:"
 echo "  - hub boot + admin bootstrap + utok / ntok mint"
 echo "  - SEC-2 admin gate + bad-patch validate reject"
 echo "  - SEC-1 cross-network write reject"
+echo "  - #260 P5 channels wire (schema + narrow + tier + no-regression)"
 echo "Scenarios marked [W1] await PR #284 (superviseChild helper) + the W1"
 echo "follow-up commit on this branch. They are stubbed with explicit skip"
 echo "+ inline impl plan so the next iteration is mechanical."

--- a/tests/qa-rfc024-config-apply/run.sh
+++ b/tests/qa-rfc024-config-apply/run.sh
@@ -517,6 +517,63 @@ if [[ -n "$CHAN_UID_D" ]]; then
   fi
 fi
 
+# 11g — Codex catch #4: all-invalid channels rejected as
+# `channels_all_invalid`, NOT silently converted to disable-all.
+# Sending `["commhub"]` (transport, not editable) or `["telegarm"]`
+# (typo) must NOT wipe existing telegram/feishu workers. Supersede D
+# first.
+sqlite3 "$COMMHUB_DB" "UPDATE node_config_updates SET status='timeout', acked_at=strftime('%s','now')*1000, error='e2e-supersede' WHERE update_id='$CHAN_UID_D';" 2>/dev/null
+
+CHAN_RESP_E=$(mcp_call "$UTOK" "update_node_config" \
+  "{\"node_id\":\"$NODE_ID\",\"base_revision\":$REV_11,\"patch\":{\"channels\":[\"commhub\"]},\"network_id\":\"$NET_ID\"}")
+CHAN_ERR_E=$(echo "$CHAN_RESP_E" | jq -r '.error // empty')
+if [[ "$CHAN_ERR_E" == "channels_all_invalid" ]]; then
+  ok "11g all-invalid channels rejected as channels_all_invalid (won't nuke workers)"
+else
+  bad "11g all-invalid input got error='$CHAN_ERR_E' (expected channels_all_invalid) raw=$CHAN_RESP_E"
+fi
+
+# 11h — the typo case Codex flagged. "telegarm" narrows to [] — must
+# also reject, not silently disable-all.
+CHAN_RESP_F=$(mcp_call "$UTOK" "update_node_config" \
+  "{\"node_id\":\"$NODE_ID\",\"base_revision\":$REV_11,\"patch\":{\"channels\":[\"telegarm\"]},\"network_id\":\"$NET_ID\"}")
+CHAN_ERR_F=$(echo "$CHAN_RESP_F" | jq -r '.error // empty')
+if [[ "$CHAN_ERR_F" == "channels_all_invalid" ]]; then
+  ok "11h typo 'telegarm' rejected as channels_all_invalid (not silent disable-all)"
+else
+  bad "11h typo got error='$CHAN_ERR_F' (expected channels_all_invalid) raw=$CHAN_RESP_F"
+fi
+
+# 11i — Codex catch #1: finalize MUST NOT match a channels-only patch
+# against a snapshot whose channels field is empty (the node hasn't
+# forked the requested channels yet). To exercise the finalize helper
+# without a real node restart, we install a fresh pending update +
+# then trigger a report_status heartbeat from the LIVE agent-node
+# (which has channels=[] at the moment — scenario 9 didn't change it,
+# scenario 11a-h all left the row in-flight or terminal). Baseline:
+# revision from /api/nodes.
+sqlite3 "$COMMHUB_DB" "UPDATE node_config_updates SET status='timeout', acked_at=strftime('%s','now')*1000, error='e2e-supersede' WHERE update_id='$CHAN_UID_D';" 2>/dev/null
+
+# Fresh channels-only patch — pending after this.
+REV_BEFORE_G=$(curl -sS "$HUB_BASE/api/nodes/$NODE_ID/config" -H "Authorization: Bearer $UTOK" | jq -r '.config_revision // 0')
+CHAN_RESP_G=$(mcp_call "$UTOK" "update_node_config" \
+  "{\"node_id\":\"$NODE_ID\",\"base_revision\":$REV_BEFORE_G,\"patch\":{\"channels\":[\"feishu\"]},\"network_id\":\"$NET_ID\"}")
+CHAN_UID_G=$(echo "$CHAN_RESP_G" | jq -r '.update_id // empty')
+
+# The agent-node lifecycle from scenario 9 has already exited (its
+# process was killed at line 386). We're testing here that the
+# finalizePendingMatchingUpdates code path — driven by the LIVE hub —
+# does not falsely mark this update applied just because its patch.flags
+# happens to be {}. Sleep briefly so any latent report_status from a
+# still-running agent-node grandchild (should be none) can arrive.
+sleep 3
+STATUS_G=$(sqlite3 "$COMMHUB_DB" "SELECT status FROM node_config_updates WHERE update_id='$CHAN_UID_G';" 2>/dev/null)
+if [[ "$STATUS_G" == "pending" ]]; then
+  ok "11i channels-only patch stayed pending (finalize refused to match on empty snapshot channels)"
+else
+  bad "11i channels-only patch prematurely became '$STATUS_G' (expected pending) — Codex P1 regression"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────
 echo
 echo "── Result ──"


### PR DESCRIPTION
## Summary

Connects the 5 wire-rings 通信IM马's wire-check flagged when they held
dashboard PR #31: real hub-side backend for the channel enable/disable
UX shipped there. No live-reload; restart-tier per 通信龙 P5 派工 —
the same drain + `exit(75)` + parent respawn cycle already proven for
model / permissionMode / timeout swaps in RFC-024.

Refs #260. Dashboard PR #31 can un-hold once this lands.

## ⚠️ Deployment — restart-tier fields need a supervisor

Channels lands in the **restart tier**, same class as `model` /
`permissionMode` / `dangerouslySkipPermissions` / `timeout`. When the
node applies the patch it drain + `process.exit(75)`'s and RELIES ON
a parent supervisor to respawn it. So the toggle-in-dashboard →
process-restart → new-workers loop only closes cleanly on nodes
launched with something that honours exit 75:

- `anet node start <alias>` (uses `superviseChild` — the standard path)
- `systemd` unit with `Restart=always` / `Restart=on-failure`
- Docker `restart: always` (compose) or `--restart=always` (CLI)
- PM2 / other process managers

**Bare-spawn** agent-node (`bun run dist/cli.js --config …` or a raw
`agent-node --config …` with no supervisor around it — the production
TMWork小助手 today is one of these) drain + exit(75)'s but nobody
wakes it. The node just disappears from dashboard until an operator
manually restarts it. This is a deployment choice, not an anet bug.

Hub already refuses restart-tier POSTs from nodes whose snapshot has
`config_update_capable: false`; bare-spawn should set
`ANET_CONFIG_UPDATE_CAPABLE=0` (the default) so the toggle refuses
visibly instead of quietly killing the node. See RFC-024 §6.7.1 for
the full enumeration.

## The 5 rings — before → after

| # | Ring                                                                              | Before                | After                                      |
|---|-----------------------------------------------------------------------------------|-----------------------|--------------------------------------------|
| 1 | Dashboard `EDITABLE_FLAGS` carries `channels`                                     | ✅ (PR #31)           | ✅ (PR #31, unchanged)                     |
| 2 | Hub `update_node_config` MCP schema accepts `channels`                            | ❌ zod-strict rejected | ✅ this PR                                 |
| 3 | Hub writes channels into `node_config_updates.patch_json` + classifies as restart | ❌                    | ✅ this PR                                 |
| 4 | Agent-node config-apply merges channels into `config.json`                        | ❌                    | ✅ this PR                                 |
| 5 | Node restart re-reads `config.channels` and re-forks per-channel workers          | ✅ (existed at boot)  | ✅ (restart-tier makes it take effect)     |

## Docker e2e — PASS=23 FAIL=0 SKIP=2

Extends `tests/qa-rfc024-config-apply/` with scenario 11 (10
assertions across 11a-11i, split across two commits — the second one
covers the 4 Codex catches):

```
=== 11. #260 P5 — channels patch wire (hub schema + narrowing + tier) ===
  ✓ 11a hub accepted channels-only patch (update_id=cu_… apply_mode=restart)
  ✓ 11b channels-only patch classified as apply_mode=restart
  ✓ 11c patch_json in node_config_updates carries channels=[telegram,feishu]
  ✓ 11d hostile input accepted for narrowing (update_id=cu_…)
  ✓ 11d hostile input narrowed to 'telegram,feishu'
      (evil/wechat/commhub/42/injection/dup all dropped, case-folded)
  ✓ 11e channels: [] disable-all: apply_mode=restart + patch_json has channels key
  ✓ 11f flags-only patch keeps channels absent + apply_mode=hot (no regression)
  ✓ 11g all-invalid channels rejected as channels_all_invalid (won't nuke workers)
  ✓ 11h typo 'telegarm' rejected as channels_all_invalid (not silent disable-all)
  ✓ 11i channels-only patch stayed pending (finalize refused to match on empty snapshot channels)

── Result ──
  PASS=23  FAIL=0  SKIP=2
```

The 2 skips are pre-existing `[W1]` stubs in qa-rfc024 §7.2; not
touched here. Scenario 9 (real restart-finalize with `anet node start`
+ `model` swap + real revision bump) still PASSES on this branch.

**Hostile input payload used by 11d** (verbatim):

```json
{
  "channels": [
    "TELEGRAM", "telegram", "evil-hacker",
    "telegram; drop table users;",
    42, "wechat", "commhub", "FEISHU"
  ]
}
```

Narrowed to `["telegram", "feishu"]` before hitting
`node_config_updates.patch_json`. Case-folded, deduped, unknown /
transport / non-string / injection-shaped entries all dropped.

## Codex-catch fixes (commit `442c129`)

GitHub Codex's automated review found four independently real bugs
that the first-cut 20/0 e2e + 87 server + 82 agent-node unit tests
didn't cover. All four fixed + regression pinned:

1. **`finalizePendingMatchingUpdates` only compared model + flags** —
   a channels-only pending update trivially matched the flags loop
   (patch.flags = {}) on the very first `report_status`, so hub
   marked it applied and deleted the pending row before the doorbell
   reached the child. Fix: Set-equality on `snapshot.channels`;
   pre-P5 nodes without the field are treated as non-matching so the
   F-B reaper still supersedes.
2. **`mergePatch` REPLACED existing.channels wholesale** — a
   dashboard-driven bare `telegram` patch would wipe an operator's
   `telegram:/opt/bots/tg` path-qualified spec, forcing the boot flow
   to `defaultChannelDir()` on the next restart and losing the
   pre-provisioned .env / access.json. Fix: per-type — if the
   existing config had a path-qualified spec of the same type, keep
   it.
3. **`report_status.channels` only sent when non-empty** — hub's
   COALESCE preserved the pre-disable list in `sessions.channels`
   after a disable-all, so `/api/nodes` kept lying about the node's
   state. Fix: cli.ts always sends `JSON.stringify(channelSpecs)`,
   even `"[]"`. `buildConfigSnapshot` symmetrically always emits
   `channels: string[]` (sorted, bare-type, deduped).
4. **Narrow-to-`[]` became silent disable-all** — dashboard PR #31
   currently sends `["commhub"]`, and any typo like `["telegarm"]`
   would hit the same path. Both narrowed to `[]` and got stored as
   restart-tier disable-all, killing the user's existing workers.
   Fix: distinguish `patch.channels === []` (explicit disable-all,
   honoured) from `[unknowns] → []` (`channels_all_invalid` error).

Unit deltas: agent-node `config-apply.test.ts` 76/0 (+10), server
`config-apply-sec1.test.ts` 47/0 (+7 for finalize channels
comparison).

## Design choices

### `commhub` is NOT in the allow-list

`agent-node/src/cli.ts:673` exits(1) at boot for any channel type that
isn't `telegram` or `feishu`. `commhub` is the RPC transport every node
speaks unconditionally, not a per-node fork target. Both hub +
agent-node allow-lists narrow to `{telegram, feishu}`. Dashboard PR
#31 still ships `commhub`; hub now rejects it visibly as
`channels_all_invalid` (post-Codex-fix P4 above) instead of silently
disabling everything. Matching dashboard narrow is filed as follow-up.

### Zod-loose + narrow-strict at the wire boundary

`z.array(z.unknown()).max(16)` — mirrors `flags`'s `z.record(z.unknown())`.
- First layer: defensive length + array-ness only.
- Second layer: `narrowChannelsPatch` does typeof + allow-list + dedup
  + case-fold.
- Third layer: `validatePatch` re-rejects on any non-string /
  non-allow-list entry if a future caller bypasses narrowing.

### Not `SECURITY_SENSITIVE_FLAGS`

Enable/disable is a lifecycle op like `restart_node`, not a privilege
elevation. SEC-1 (network scope) alone gates it.

## Reproduce

```bash
docker build -f tests/qa-rfc024-config-apply/Dockerfile -t anet-260-p5 .
docker run --rm --tmpfs /tmp:rw,exec anet-260-p5
```

Full verbatim log at `docs/tests/p260-channel-real-backend/full-run.log`.

## Red-line 3-layer audit

- Broad private-fork keyword regex on diff = 0 hits
- Slug regex on diff + commit msg + PR body = 0 hits
- Real vendor key literal regex on diff + evidence log = 0 hits
- No `Co-Authored-By` per project policy

## Files touched

- `server/src/config-apply-validate.ts` (+ `EDITABLE_CHANNELS`,
  `narrowChannelsPatch`)
- `server/src/config-apply-validate.test.ts` (+22)
- `server/src/config-apply-sec1.test.ts` (+7 finalize channels)
- `server/src/tools.ts` (patch schema + explicit vs narrow-empty
  distinction + finalize channels compare)
- `agent-node/src/runtime/config-apply.ts` (ConfigPatch, validators,
  mergePatch path-preserve, MaskedSnapshot.channels always emitted)
- `agent-node/src/runtime/config-apply.test.ts` (+16 + 10 codex-fix)
- `agent-node/src/cli.ts` (report_status always emits channels)
- `tests/qa-rfc024-config-apply/{Dockerfile,run.sh}` (sqlite3 +
  scenario 11a-11i + inline Result print)
- `docs/rfcs/RFC-024-dashboard-node-config-apply.md` (new §6.7.1
  enumerating restart-tier fields + supervisor requirement)
- `docs/tests/p260-channel-real-backend/{full-run.log,verify-summary.md}`

## Test plan

- [ ] `docker build -f tests/qa-rfc024-config-apply/Dockerfile -t anet-260-p5 .`
- [ ] `docker run --rm --tmpfs /tmp:rw,exec anet-260-p5`
- [ ] Expect `PASS=23 FAIL=0 SKIP=2` (all 11a-11i green + scenario
      9 restart-finalize).
- [ ] Notify 通信IM马 to re-run their 5-ring wire-check.

Refs #260.
