### PR TITLE
docs(#260 P5): restart-tier supervisor 依赖 warning（补 #411 merge 后遗漏）

### DIFF
--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -337,7 +337,16 @@ export interface MaskedSnapshot {
    *  a channels-only restart landed and — separately — so
    *  /api/nodes reflects a disable-all instead of the stale COALESCE'd
    *  value. Path-qualified specs in config.channels are collapsed to
-   *  the bare type key; anything unparseable is silently dropped. */
+   *  the bare type key; anything unparseable is silently dropped.
+   *
+   *  Deployment: a channels update is restart-tier — the process
+   *  drain + exit(75)'s and RELIES ON a supervisor to respawn it.
+   *  Bare-spawn `agent-node ...` (no `anet node start` / systemd
+   *  Restart / docker restart-policy) can't restart itself, so the
+   *  node just disappears until an operator brings it back. RFC-024
+   *  §6.7.1. Hub gates this via config_update_capable — bare-spawn
+   *  should set ANET_CONFIG_UPDATE_CAPABLE=0 (default) so restart-
+   *  tier POSTs are refused instead of quietly killing the node. */
   channels: string[];
 }
 export function buildConfigSnapshot(

--- a/docs/rfcs/RFC-024-dashboard-node-config-apply.md
+++ b/docs/rfcs/RFC-024-dashboard-node-config-apply.md
@@ -313,6 +313,16 @@ Ctrl-C / 磁盘满 / 并发写都不会留半 config.
 
 无 supervisor wrapper 跑的 bare agent-node (用户直接 `bun run agent-node ...` 而不是 `anet node start`): config_snapshot 上报 `config_update_capable: false`, dashboard 显示"该节点不支持远程重启 — 用 anet node start 启动"提示, POST 时 hub 直接 reject.
 
+### 6.7.1 ⚠️ Restart-tier fields (channels included) 需要 supervisor
+
+所有 apply_mode=restart 的字段都走同一条 exit(75) → parent 重 spawn 通路:
+
+- **model** (常改)
+- **permissionMode** / **dangerouslySkipPermissions** / **timeout** (RESTART_REQUIRED_FLAGS)
+- **channels** (#260 P5) — 通过 `anet node start` (含 `superviseChild`) 或系统 supervisor (systemd `Restart=always`, docker `restart: always`, PM2 等) 启动的节点自动生效。
+
+**手动直起** (`bun run dist/cli.js --config ...` / `agent-node --config ...` / IM馬 生产 TMWork小助手 早期跑法) 的 bare 进程收到 restart-tier update: drain + exit(75), 但 nobody 拉起 → 节点消失, dashboard 显示 offline, 手动重启才能起来。这属于运维部署选择, 不是 anet bug; 但生产运维请一律用 `anet node start` (或包 systemd/docker restart-policy) 挂 supervisor. Bare-spawn 应设 `ANET_CONFIG_UPDATE_CAPABLE=0` (默认 false) 让 hub 直接 reject restart-tier POST, 避免误关。
+
 ---
 
 ## 7. 测试计划


### PR DESCRIPTION
#411 merge 时我 squash 早于 工程马 的 supervisor-warning commit（9e47c52），导致这段 docs 漏进 main。cherry-pick 补回：
- RFC-024 §6.7.1：restart-tier 字段（model + RESTART_REQUIRED_FLAGS + channels）需 supervisor（anet node start / systemd / docker restart:always / PM2）；bare-spawn 节点 exit(75) 不回来
- config-apply.ts channels docstring 引用 §6.7.1

IM马 wire-check 提的运维 nit。无代码行为变更，纯 docs + docstring。