### PR TITLE
fix(classify): tighten quota-body fallback to 80 chars + update stale test assertion

### DIFF
--- a/agent-node/src/runtime/classify-result.test.ts
+++ b/agent-node/src/runtime/classify-result.test.ts
@@ -167,15 +167,23 @@ describe("classifyRuntimeResult — vendor hint routing via baseUrl", () => {
 });
 
 describe("formatClassificationError — message shape (parsed by IM bridge)", () => {
-  test("soft-fail-quota → 执行出错: <runtime> 限流/配额耗尽", () => {
+  test("soft-fail-quota → 执行出错: [额度用尽][<code>] <runtime>: <body> — <hint>", () => {
+    // #368 replaced the generic `<runtime> 限流/配额耗尽 (<reason>)` copy
+    // with a vendor-phrase-pass-through format prefixed by `[额度用尽]` +
+    // an optional vendor-native code tag (MiniMax 2056 / HTTP 429 / etc.).
+    // This test locks the new format shape — the runtime label, the
+    // vendor URL hint, and the [额度用尽] prefix must all be present.
     const c: ClassificationResult = {
       kind: "soft-fail-quota",
       reason: "HTTP 429",
       hint: "→ 检查 platform.deepseek.com 配额",
     };
     const s = formatClassificationError(c, { runtime: "codex" });
-    expect(s).toMatch(/^执行出错: codex 限流\/配额耗尽/);
+    expect(s).toMatch(/^执行出错: \[额度用尽\]/);
+    expect(s).toContain("codex");
     expect(s).toContain("deepseek");
+    // Code extractor recognises "HTTP 429" — tag should be present.
+    expect(s).toContain("[HTTP 429]");
   });
 
   test("soft-fail-empty → 执行出错: <runtime> 返回空响应 with in/out", () => {

--- a/agent-node/src/runtime/classify-result.ts
+++ b/agent-node/src/runtime/classify-result.ts
@@ -200,7 +200,10 @@ export function formatClassificationForUser(
       const phrase = extractVendorQuotaPhrase(raw);
       const code = extractQuotaCode(raw);
       const codeTag = code ? ` [${code}]` : "";
-      const body = phrase ?? raw.slice(0, 200);
+      // 80-char fallback keeps the IM-facing string comfortably
+      // < 200 total (mirrors ForLog's tightened cap; both call sites
+      // aligned so the user never sees a longer message than the log).
+      const body = phrase ?? raw.slice(0, 80);
       return `[额度用尽]${codeTag} ${body}`.trim();
     }
     case "soft-fail-empty":
@@ -230,11 +233,17 @@ export function formatClassificationForLog(
   const outT = context.usage?.output_tokens ?? 0;
   switch (c.kind) {
     case "soft-fail-quota": {
+      // Bound total ≤ ~200 chars so IM bridges that (still) call this
+      // legacy alias don't wall-of-text the user. Vendor phrase already
+      // capped at 200 by extractVendorQuotaPhrase; the untruncated-raw
+      // fallback path was 200, which pushed total > 200 for long
+      // opaque errors — tightened to 80 (matches the pre-#368
+      // convention this file has always assumed on the quota path).
       const raw = c.reason || "";
       const phrase = extractVendorQuotaPhrase(raw);
       const code = extractQuotaCode(raw);
       const codeTag = code ? ` [${code}]` : "";
-      const body = phrase ?? raw.slice(0, 200);
+      const body = phrase ?? raw.slice(0, 80);
       return `执行出错: [额度用尽]${codeTag} ${context.runtime}: ${body}${c.hint ? ` — ${c.hint}` : ""}`;
     }
     case "soft-fail-empty":


### PR DESCRIPTION
## Summary

pre-check on preview-cut caught 2 fails in `classify-result.test.ts` `formatClassificationError — message shape (parsed by IM bridge)`, soft-fail-quota group. Root cause is downstream of **#368** (quota phrase pass-through): both a **stale test assertion** AND a **real body-cap bug** that would push IM messages past the 200-char ceiling.

## Root cause

#368 upgraded the quota format from generic `执行出错: <runtime> 限流/配额耗尽 (<reason>)` to vendor-native `执行出错: [额度用尽][<code>] <runtime>: <phrase>`. As part of that:

- **Phrase branch** capped at 200 chars via `extractVendorQuotaPhrase` (locked by #368 tests: `phrase pass-through (not truncated 80)`).
- **Fallback branch** silently relaxed from `raw.slice(0, 80)` → `raw.slice(0, 200)` with **no test forcing < 200 total** — the `reason longer than 80 chars is truncated` legacy test was already present but shipped stale (its assertion + the format text weren't updated together).

Consequence: real vendor error with a long opaque body (e.g. a raw JSON envelope) would produce a > 200 char IM message. 通信龙 pre-check spec was `quota 消息截 <200 / reason <80` — the fallback tripped both.

## Fix

`formatClassificationForLog` + `formatClassificationForUser` — same change on both surfaces (user surface should never exceed operator-log surface):

```diff
-const body = phrase ?? raw.slice(0, 200);
+const body = phrase ?? raw.slice(0, 80);
```

Bound check (with 80-char fallback):

```
执行出错: [额度用尽]  (16)
[MiniMax code 2056]  (22)
 claude-agent-sdk:   (20)
<body>               (80)
 — → 检查 platform.…  (~30)
──────────────────
                     ~168 chars < 200 ✓
```

Phrase branch keeps its existing 200-char cap (from `extractVendorQuotaPhrase`) — real vendor phrases in the wild are ~50-80 chars (e.g. `已达到 Token Plan 用量上限：请升级 Token Plan 套餐 (2056)` = ~50 chars).

Test 1 assertion updated to lock the **new** `[额度用尽]`-prefixed format:

```ts
expect(s).toMatch(/^执行出错: \[额度用尽\]/);
expect(s).toContain("codex");
expect(s).toContain("deepseek");   // hint preserved on ForLog path
expect(s).toContain("[HTTP 429]"); // extractQuotaCode result
```

Test 2 (`< 200 chars` from a 200-char raw reason) needs **no assertion change** — it passes now that the fallback cap is correct.

## Verification

| Test | Before | After |
|---|---|---|
| `classify-result.test.ts` | 24/26 (2 fails) | **26/26** |
| `quota-error-passthrough.test.ts` (#368) | 48/48 | **48/48** (no regress) |
| `vendor-error-sanitize.test.ts` | 79/79 | **79/79** (no regress) |
| `outbound-secret-mask.test.ts` | 86/86 | **86/86** (no regress) |
| `claude-error-classify.test.ts` | 38/38 | **38/38** (no regress) |
| `bun run build` | clean | **clean** (0.88 MB cli.js) |

## Files

| File | Change |
|---|---|
| `agent-node/src/runtime/classify-result.ts` | `raw.slice(0, 200) → raw.slice(0, 80)` in both `formatClassificationForLog` + `formatClassificationForUser` soft-fail-quota branches |
| `agent-node/src/runtime/classify-result.test.ts` | Update test 1 assertion for new `[额度用尽]` format; test 2 unchanged |

## Related

- **#368** (quota phrase pass-through — the parent PR that shipped the format change without a fallback-cap test)
- **#383** (ForUser vs ForLog split — didn't touch the fallback cap either)
- Pre-check catch: 通信龙 preview-cut pre-check flagged this before `agent-node preview` publish (`c` request task `141885bf`)

## Author
Agent: 通信IM马
