### PR TITLE
fix(release): bump PINNED_SERVER_VERSION → 0.9.0-preview.21 (pre-GA ship-blocker)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -60,7 +60,7 @@ function tmuxAvailable(): boolean {
 // refetch). A `latest` agent-network release must pin a *stable* server.
 // `anet upgrade` (#88) surfaces this constant in its plan output so users
 // understand global-install version != version anet hub start actually runs.
-const PINNED_SERVER_VERSION = "0.9.0-preview.8";
+const PINNED_SERVER_VERSION = "0.9.0-preview.21";
 function sessionFileExists(uuid: string, cwd: string = process.cwd()): boolean {
   if (!uuid) return false;
   return existsSync(join(homedir(), ".claude", "projects", encodeCwd(cwd), `${uuid}.jsonl`));


### PR DESCRIPTION
测试马 pre-GA 4 包 gate 抓到：`anet hub start` 的 PINNED_SERVER_VERSION 还指 commhub-server preview.8，用户装 agent-network@preview.20 实际拿旧 hub，#411 channels schema 不在。bump → preview.21。agent-node/dashboard 走 @preview tag 无需 pin。修完 republish agent-network@preview.21 + 测试马 重跑 gate。