### PR TITLE
docs(release): GA-gate GREEN 23/23 — v2.3.0 GA-ready

### DIFF
--- a/docs/release/v2.3.0/plan.md
+++ b/docs/release/v2.3.0/plan.md
@@ -27,7 +27,7 @@
 
 ## 进度快照（自主推进中 · 每步滚动更新）
 
-> 最后更新：2026-07-04（北京）· **全 4 包 v2.3.0 preview 齐（pre-GA）**: agent-network 2.3.0-preview.20 / agent-node 2.5.0-preview.19 / commhub-server 0.9.0-preview.21 / dashboard 0.6.3-preview.6· Vincent msg9799 自主执行模式。
+> 最后更新：2026-07-04（北京）· **🟢 GA-gate GREEN (23/23) — GA-ready, 等 Vincent 拍 latest**: agent-network 2.3.0-preview.20 / agent-node 2.5.0-preview.19 / commhub-server 0.9.0-preview.21 / dashboard 0.6.3-preview.6· Vincent msg9799 自主执行模式。
 > **📌 详细滚动进度追踪 → [tracking issue #403](https://github.com/sleep2agi/agent-network/issues/403)**（本 plan 是总文档/spec，详细每步日志记在 issue，二者互链）。
 
 | 线 | 状态 | 细节 |


### PR DESCRIPTION
测试马 4 包整行 pre-GA gate 23/23 PASS（PIN 修验证 /health=preview.21 + channel-edit 端到端 + hostile drop）。v2.3.0 GA-ready，等 Vincent 拍 latest。同步 #403。