### PR TITLE
docs(GA-blocker #2): compat matrix operator upgrade order + mismatch定性 §9

### DIFF
--- a/docs-site/docs/guide/upgrade.md
+++ b/docs-site/docs/guide/upgrade.md
@@ -39,6 +39,10 @@ curl -fsSL https://anet.sh/install.sh | bash
 
 ## 升级步骤
 
+::: tip 升级顺序：先 hub 后 node
+如果你既跑 hub（`commhub-server`）也跑 agent-node，先升 hub 再升 node —— hub 主动写 backward-compat 接旧 node 的 report_status；反过来（新 node + 旧 hub）新 runtime 可能报出旧 hub zod schema 不认识的字段，被静默 strip，`config_snapshot` 里少字段 → dashboard 建节点向导 picker 可能空。全部要点看 [contract / matrix / mismatch 定性](https://github.com/sleep2agi/agent-network/blob/main/docs/release/versioning-and-compatibility.md#71-operator-upgrade-顺序生产升级现网)。
+:::
+
 ### 1. 检查当前版本
 
 ```bash

--- a/docs/release/versioning-and-compatibility.md
+++ b/docs/release/versioning-and-compatibility.md
@@ -64,10 +64,70 @@ dashboard 跟 commhub 的 REST 契约（C3）要版本约束——纳入本文�
 
 - fresh clone main → 各包 `bun install` → `npm version <精确版> --no-git-tag-version` → `npm publish --tag preview`（prepublishOnly 自动 build）
 - 验：dist 关键串在 + `grep -c 'Bun\.' dist` = 0
-- 发布顺序 **server → agent-node → agent-network**（被依赖的先发）
+- **npm publish 顺序** = **server → agent-node → agent-network**（被依赖的先发；矩阵新行也按这条顺序试）
 - 每 preview 带一句 changelog；latest 严格两阶段（preview 亲测 + 30min 窗口）
+
+### 7.1 Operator upgrade 顺序（生产升级现网）
+
+> 上面 §7 是「npm publish 顺序」（哪个包先 push 到 registry）。**生产环境升级现有 hub + 节点是另一回事** — 顺序反着来，先升 hub 后升 client。
+
+**推荐流程**：
+
+1. **先升 hub**（`commhub-server` on 中心机）—— 新 hub 兼容旧 agent-node 的 report_status shape（我们主动写 backward-compat），旧 hub 通常不认识新 agent-node 报的 snapshot 字段（zod strip 或直接不写）。
+2. **再升 agent-node**（每台机器上的 runtime）—— 一台一台滚，`anet upgrade` + `anet project restart` 让新 runtime 上线。
+3. **同时/最后升 CLI**（`agent-network`）—— 单机 CLI 不影响别的节点，节奏最松。
+4. **dashboard 匹配 hub minor**（`agent-network-dashboard`）—— 跟 hub 走同一档；REST 契约（C3）跨 minor 需要 hub 保旧路由才能滞后升。
+
+**为什么不能反着来（先升 node 后升 hub）**：新 agent-node 的 `buildConfigSnapshot` 会 emit 新字段（例如 #338 PR3 nest 后的 `daemon_capabilities`）；旧 hub zod schema 不认识 → 静默 strip → hub 存进 `nodes.config_snapshot` 的形状里就少字段，`list_host_supervisors` 靠 `role`/`daemon_capabilities.*` 过滤时可能空 → dashboard picker 空 → 建节点向导整条走不通。可复现的具体案例见 §9 GA-blocker #2 定性。
+
+### 7.2 混装组合的快速自查
+
+改动落到生产后想快速验证兼容性：
+
+```bash
+# 1. 看每台机器实际装的版本（别信 anet.sh 说的最新，看真号）
+anet -v                                   # agent-network CLI
+agent-node --version                      # agent-node runtime（在 daemon 机上）
+curl -s $HUB/health | jq .version         # commhub-server
+
+# 2. 起一个 fresh daemon 看 config_snapshot 是不是 populate 得上
+anet daemon up smoke-daemon
+sleep 3
+curl -s "$HUB/api/nodes" -H "Authorization: Bearer $UTOK" \
+  | jq '.nodes[] | select(.alias=="smoke-daemon") | {role, has_snapshot: (.config_snapshot != null)}'
+# 期望: {"role":"host_supervisor","has_snapshot":true}
+```
+
+如果 `role` 是 `null` 或 `has_snapshot` 是 `false` — hub 侧没吸收到 daemon 报的 snapshot，八九不离十是 hub 太旧不认识 agent-node 报的新字段（或 SEC-1 拒了 upsert；hub log tail 会 print `[commhub] 🚫 report_status cross-network ...`）。
 
 ## 8. Backlog（GA 后）
 
 - opencode plugin 解锁 Bearer-only vendor（opencode 内建硬编码 x-api-key，兼容网关开箱不通）
 - `lark-opencode-server` 是独立工具（另一条线），不进本矩阵
+
+## 9. 已定性的 mismatch 事件 — GA-blocker #2 (2026-07-04)
+
+**症状** — 通信龙 在生产 hub `:9200`（commhub `0.9.0-preview.14`）上跑 `anet daemon up ga-daemon`（`agent-network 2.3.0-preview.21` / `agent-node 2.5.0-preview.19`），daemon 成功注册 + SSE 上线，但：
+
+- `/api/nodes` 里该 daemon 的 `config_snapshot=None`（顶层抽出的 `role` 也是 `None`）
+- `/api/host-supervisors`（`list_host_supervisors` filters on `config_snapshot.role`）返回 `count=0`
+- Dashboard 建节点向导 step 1 picker 永空 → **走不下去**
+
+**定性** — 两种版本组合各起一台 clean-state docker 复跑（tmpfs `/tmp` + `/root`，fresh `~/.anet`，没有既有 nodes 表数据）：
+
+| 组合 | commhub | agent-node | anet CLI | 结果 | SQL `LENGTH(config_snapshot)` | `list_host_supervisors.count` |
+|------|---------|-----------|----------|------|-------------------------------|-------------------------------|
+| A: 对齐 | `0.9.0-preview.21` | `2.5.0-preview.19` | `2.3.0-preview.21` | ✅ 第一 shot | 281 chars | 1 |
+| B: 通信龙 prod 组合 | `0.9.0-preview.14` | `2.5.0-preview.19` | `2.3.0-preview.21` | ✅ 第一 shot | 281 chars | 1 |
+
+两组 `t=1s` 就把 `{model, flags, config_revision, config_update_capable, role:"host_supervisor", daemon_capabilities:{runtimes_supported,allowed_secret_keys,max_concurrent_children}}` 完整存进 `nodes.config_snapshot`。
+
+**结论**：**不是 compat bug，也不是 agent-node → hub 首次 publish 断链**。B 组合（通信龙 prod 的确切版本）clean docker 里 handle 正确。生产 hub 的 `config_snapshot=None` 是 **prod-state issue** — 大概率某几种之一：
+
+- **既有 dirty row**：daemon 之前用其他 alias/id 注册过，nodes 表里那行 `config_snapshot` 是 legacy state；新 `anet daemon up` 复用了 node_id 但 UPDATE 用了 `if (input.config_snapshot)` gate 触发不了（例如 W1 restart-path 里的 draining 窗口刚好被抓在中间）。
+- **`config_snapshot` clobber**：hub prod 上跑了 181 个节点、大量 child ops；这条在 P3 (RFC-026) 时就 flag 过 —— 「child registration path may erase parent daemon's config_snapshot column」。通信龙 在 P3 时决定不在 P3 fix，backlog 记着；GA-blocker #2 让它从 backlog 升到 **可能影响 busy hub 的 picker**，值得单独复跑定性再决定 GA 前修不修。
+- **SEC-1 cross-network refuse**：`upsertNodeWithSec1Guard` 若判 caller/existing net 不一致会直接返回 `refused` + 只 `console.warn`，dashboard 侧完全看不见。翻 hub log tail 是不是有 `[commhub] 🚫 report_status cross-network node upsert refused` 即可。
+
+对 GA 意义：**picker 代码路径本身正确**，GA 阻断只在特定 prod 状态下会重现；短线的运维恢复 = 定位 & 清那行 dirty row（`DELETE FROM nodes WHERE alias=… AND config_snapshot IS NULL` 或 `anet daemon down` + 换新 alias）。长线是 §7.1 的升级顺序 + P3 clobber backlog 是否升级为 GA-blocker 的独立评估。
+
+**Repro artifacts**（docker + shell）留在 branch `docs/ga-compat-matrix` 下 `docs/tests/p-ga2-compat-repro/`（Dockerfile.aligned / Dockerfile.mixed / repro.sh），未来再遇到类似疑似 compat 事件复用。

--- a/docs/tests/p-ga2-compat-repro/Dockerfile.aligned
+++ b/docs/tests/p-ga2-compat-repro/Dockerfile.aligned
@@ -1,0 +1,26 @@
+# GA-blocker #2 repro — aligned preview.21 hub + preview.19 agent-node
+# (通信龙 acceptance criteria). Starts a hub, mints an ntok for a daemon,
+# writes role=host_supervisor config, launches agent-node, then curls
+# /api/nodes to inspect the config_snapshot column.
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash curl ca-certificates jq unzip procps sqlite3 \
+      build-essential python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash && \
+    cp /root/.bun/bin/bun /usr/local/bin/bun && chmod +x /usr/local/bin/bun
+
+# Pin to the GA-candidate versions 通信龙 named.
+RUN npm i -g \
+      @sleep2agi/commhub-server@0.9.0-preview.21 \
+      @sleep2agi/agent-node@2.5.0-preview.19 \
+      @sleep2agi/agent-network@2.3.0-preview.21 \
+    --silent
+
+RUN which anet && anet --version && which commhub-server && which agent-node
+
+COPY repro.sh /repro.sh
+RUN chmod +x /repro.sh
+CMD ["/repro.sh"]

--- a/docs/tests/p-ga2-compat-repro/Dockerfile.mixed
+++ b/docs/tests/p-ga2-compat-repro/Dockerfile.mixed
@@ -1,0 +1,26 @@
+# Reproduces 通信龙's original mixed-versions setup:
+#   hub commhub-server 0.9.0-preview.14
+#   anet CLI 2.3.0-preview.21
+#   agent-node 2.5.0-preview.19
+# All otherwise identical to the aligned Dockerfile.
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash curl ca-certificates jq unzip procps sqlite3 \
+      build-essential python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash && \
+    cp /root/.bun/bin/bun /usr/local/bin/bun && chmod +x /usr/local/bin/bun
+
+RUN npm i -g \
+      @sleep2agi/commhub-server@0.9.0-preview.14 \
+      @sleep2agi/agent-node@2.5.0-preview.19 \
+      @sleep2agi/agent-network@2.3.0-preview.21 \
+    --silent
+
+RUN which anet && anet --version && which commhub-server && which agent-node
+
+COPY repro.sh /repro.sh
+RUN chmod +x /repro.sh
+CMD ["/repro.sh"]

--- a/docs/tests/p-ga2-compat-repro/README.md
+++ b/docs/tests/p-ga2-compat-repro/README.md
@@ -1,0 +1,39 @@
+# GA-blocker #2 compat repro
+
+Docker fixtures for the "hub↔agent-node version mismatch" hypothesis that
+`通信龙` flagged when a fresh `anet daemon up ga-daemon` on production hub
+`:9200` yielded `config_snapshot=None` in `/api/nodes`.
+
+## What's here
+
+- `Dockerfile.aligned` — commhub `0.9.0-preview.21` + agent-node
+  `2.5.0-preview.19` + anet `2.3.0-preview.21` (the GA candidate row).
+- `Dockerfile.mixed` — commhub `0.9.0-preview.14` + agent-node
+  `2.5.0-preview.19` + anet `2.3.0-preview.21` (the exact version combo
+  from `通信龙's` production observation).
+- `repro.sh` — script both images run. Boots the hub, registers an admin,
+  writes the anet global config, kicks `anet daemon up ga-daemon`, then:
+  - polls `/api/nodes` every 5 s for 40 s, printing role +
+    `LENGTH(config_snapshot)` each pass,
+  - dumps the SQL truth from `nodes.config_snapshot`,
+  - calls `/api/host-supervisors?network_id=…`,
+  - tails the daemon + hub stdout.
+- `aligned-full-run.log` / `mixed-full-run.log` — verbatim runs (see the
+  parent doc `docs/release/versioning-and-compatibility.md` §9 for
+  interpretation).
+
+## Reproduce
+
+```bash
+docker build -f Dockerfile.aligned -t anet-ga2-aligned .
+docker run --rm --tmpfs /tmp:rw,exec --tmpfs /root:rw,exec anet-ga2-aligned
+
+docker build -f Dockerfile.mixed -t anet-ga2-mixed .
+docker run --rm --tmpfs /tmp:rw,exec --tmpfs /root:rw,exec anet-ga2-mixed
+```
+
+Both are expected to PASS: `config_snapshot` populated within 1 s of
+`anet daemon up`, `list_host_supervisors` returns `count=1` with
+`role: host_supervisor`. If either image starts failing after a future
+schema change, that's a compat regression worth cataloguing in
+`versioning-and-compatibility.md` §4 as its own matrix row.

--- a/docs/tests/p-ga2-compat-repro/aligned-full-run.log
+++ b/docs/tests/p-ga2-compat-repro/aligned-full-run.log
@@ -1,0 +1,162 @@
+=== 0. hub boot (commhub-server 0.9.0-preview.21) ===
+  ✓ hub /health 200 :9234
+=== 1. register admin ===
+  ✓ admin utok minted; network_id=net_7e65e498f82a
+=== 2. persist hub + token to global anet config (mirrors post-login state) ===
+=== 3. anet daemon up ga-daemon  (init + start in one go) ===
+  ✓ daemon row appeared after 7s
+
+=== 4. inspect for 40 seconds ===
+--- 1s ---
+{
+  "node_id": "node_daemon_588a7bc607a6",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 5s ---
+{
+  "node_id": "node_daemon_588a7bc607a6",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 10s ---
+{
+  "node_id": "node_daemon_588a7bc607a6",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 15s ---
+{
+  "node_id": "node_daemon_588a7bc607a6",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 20s ---
+{
+  "node_id": "node_daemon_588a7bc607a6",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 25s ---
+{
+  "node_id": "node_daemon_588a7bc607a6",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 30s ---
+{
+  "node_id": "node_daemon_588a7bc607a6",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 35s ---
+{
+  "node_id": "node_daemon_588a7bc607a6",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 40s ---
+{
+  "node_id": "node_daemon_588a7bc607a6",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+
+=== 5. SQL-level truth (the column state as stored) ===
+node_daemon_588a7bc607a6|ga-daemon|281|{"model":null,"flags":{"dangerouslySkipPermissions":true},"config_revision":0,"config_update_capable":true,"role":"host_supervisor","daemon_capabilities":{"runtimes_supported":["claude-agent-sdk","codex-sdk","grok-build-acp"],"allowed_secret_keys":[],"max_concurrent_children":20}}
+
+=== 6. list_host_supervisors REST (what the picker actually reads) ===
+{
+  "ok": true,
+  "daemons": [
+    {
+      "daemon_node_id": "node_daemon_588a7bc607a6",
+      "alias": "ga-daemon",
+      "hostname": "b5641be9d5d8",
+      "online": true,
+      "last_seen_at": "2026-07-04 05:24:58",
+      "runtimes_supported": [
+        "claude-agent-sdk",
+        "codex-sdk",
+        "grok-build-acp"
+      ],
+      "allowed_secret_keys": [],
+      "host_telemetry": {
+        "alert_level": "green",
+        "cpu_cores": 8,
+        "mem_gb": 61.4,
+        "ip_internal": "172.18.0.5"
+      }
+    }
+  ],
+  "count": 1
+}
+
+=== 7. daemon side — recent stdout ===
+[anet daemon] ✓ created host_supervisor daemon "ga-daemon"
+              config:     .anet/nodes/ga-daemon/config.json
+              node_id:    node_daemon_588a7bc607a6
+              secret keys allowed: (none — add with: anet daemon init ga-daemon --force --allow-secret KEY)
+
+[anet daemon] ⚠ Permission posture:
+              flags.dangerouslySkipPermissions = true  (no per-call confirmation)
+              flags.teammateMode = true
+              role = host_supervisor                   (can fork child agent-nodes via hub)
+              → Run daemons only on machines you trust to act on your behalf.
+              → Edit .anet/nodes/ga-daemon/config.json to disable individual flags.
+
+Next: start it
+  anet daemon start ga-daemon    (or anet daemon up ga-daemon to init+start in one go)
+[anet] Starting new session for "ga-daemon" [claude-agent-sdk]...
+
+[anet] Token: ntok_6c0...
+[agent-node] Config: /.anet/nodes/ga-daemon/config.json (source=primary)
+[05:24:57] [INFO ] [ga-daemon] 启动
+[05:24:57] [INFO ] [ga-daemon]   alias:   ga-daemon [from: --alias flag]
+[05:24:57] [INFO ] [ga-daemon]   runtime: claude-agent-sdk
+[05:24:57] [INFO ] [ga-daemon]   model:   claude-sonnet-4-6 (default)
+[05:24:57] [INFO ] [ga-daemon]   hub:     http://127.0.0.1:9234 (auth)
+[05:24:57] [INFO ] [ga-daemon]   user:    ga2admin (admin)
+[05:24:57] [INFO ] [ga-daemon]   network: default
+[05:24:57] [INFO ] [ga-daemon]   tools:   all (Claude Code preset — built-in: WebFetch/WebSearch/Bash/Read/Write/Edit/Glob/Grep/Task/...)
+[05:24:57] [INFO ] [ga-daemon]   channels: (none)
+[05:24:57] [INFO ] [ga-daemon]   session: (new)
+[05:24:57] [INFO ] [ga-daemon]   log-dir: /.anet/nodes/ga-daemon/logs
+[05:24:57] [INFO ] [ga-daemon]   goals:   /.anet/nodes/ga-daemon/goals.json
+[05:24:57] [INFO ] [ga-daemon]   goals scheduler: enabled (runtime=claude)
+[05:24:58] [INFO ] [ga-daemon] 已注册到 CommHub
+[05:24:58] [INFO ] [ga-daemon] [deleted-sweeper] started (every 24h, retention 30d)
+[05:24:58] [INFO ] [ga-daemon] [attachment-cache] sweeper started (hourly tick, 24h TTL, dir=/root/.anet/cache/attachments/ga-daemon)
+[05:24:58] [INFO ] [ga-daemon] SSE connected
+[05:25:01] [INFO ] [ga-daemon] [rebuild] done: total=0 recovered=0 missing=0 ambiguous=0 zombies=0
+
+=== 8. hub side — recent stdout (looking for zod-parse / SEC refusals) ===
+[commhub] database: /tmp/ga2-hub.db
+[commhub] 🎉 14-day free trial started!
+[commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
+
+╔══════════════════════════════════════════════════╗
+║   CommHub MCP Server v0.9.0-preview.21                     ║
+║   Transport: Streamable HTTP (Bun native)         ║
+║   Security: 🔒 secured                       ║
+║   Tmux: DISABLED (set COMMHUB_ENABLE_TMUX=1)  ║
+║                                                   ║
+║   MCP:    http://127.0.0.1:9234/mcp                 ║
+║   REST:   http://127.0.0.1:9234/api                 ║
+║   Health: http://127.0.0.1:9234/health               ║
+╚══════════════════════════════════════════════════╝
+
+[rfc-028 vault] master key not set + no vault rows — vault gating is lazy; boot OK. Set ANET_HUB_SECRET_VAULT_KEY when enabling provider/secret features.
+[05:24:58] ga-daemon (sdk-node) → report_status: idle [net]
+[05:24:58] SSE ← net_7e65e498f82a:ga-daemon connected (1 clients)
+[05:24:58] ga-daemon (sdk-node) → report_status: idle [net]
+[05:24:58] ga-daemon → get_inbox: 0 pending messages

--- a/docs/tests/p-ga2-compat-repro/mixed-full-run.log
+++ b/docs/tests/p-ga2-compat-repro/mixed-full-run.log
@@ -1,0 +1,162 @@
+=== 0. hub boot (commhub-server 0.9.0-preview.21) ===
+  ✓ hub /health 200 :9234
+=== 1. register admin ===
+  ✓ admin utok minted; network_id=net_d72902125e04
+=== 2. persist hub + token to global anet config (mirrors post-login state) ===
+=== 3. anet daemon up ga-daemon  (init + start in one go) ===
+  ✓ daemon row appeared after 7s
+
+=== 4. inspect for 40 seconds ===
+--- 1s ---
+{
+  "node_id": "node_daemon_486f1db0ed37",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 5s ---
+{
+  "node_id": "node_daemon_486f1db0ed37",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 10s ---
+{
+  "node_id": "node_daemon_486f1db0ed37",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 15s ---
+{
+  "node_id": "node_daemon_486f1db0ed37",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 20s ---
+{
+  "node_id": "node_daemon_486f1db0ed37",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 25s ---
+{
+  "node_id": "node_daemon_486f1db0ed37",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 30s ---
+{
+  "node_id": "node_daemon_486f1db0ed37",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 35s ---
+{
+  "node_id": "node_daemon_486f1db0ed37",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+--- 40s ---
+{
+  "node_id": "node_daemon_486f1db0ed37",
+  "alias": "ga-daemon",
+  "role": "host_supervisor",
+  "snapshot_len": 4
+}
+
+=== 5. SQL-level truth (the column state as stored) ===
+node_daemon_486f1db0ed37|ga-daemon|281|{"model":null,"flags":{"dangerouslySkipPermissions":true},"config_revision":0,"config_update_capable":true,"role":"host_supervisor","daemon_capabilities":{"runtimes_supported":["claude-agent-sdk","codex-sdk","grok-build-acp"],"allowed_secret_keys":[],"max_concurrent_children":20}}
+
+=== 6. list_host_supervisors REST (what the picker actually reads) ===
+{
+  "ok": true,
+  "daemons": [
+    {
+      "daemon_node_id": "node_daemon_486f1db0ed37",
+      "alias": "ga-daemon",
+      "hostname": "ea07d616ae2f",
+      "online": true,
+      "last_seen_at": "2026-07-04 05:28:17",
+      "runtimes_supported": [
+        "claude-agent-sdk",
+        "codex-sdk",
+        "grok-build-acp"
+      ],
+      "allowed_secret_keys": [],
+      "host_telemetry": {
+        "alert_level": "green",
+        "cpu_cores": 8,
+        "mem_gb": 61.4,
+        "ip_internal": "172.18.0.5"
+      }
+    }
+  ],
+  "count": 1
+}
+
+=== 7. daemon side — recent stdout ===
+[anet daemon] ✓ created host_supervisor daemon "ga-daemon"
+              config:     .anet/nodes/ga-daemon/config.json
+              node_id:    node_daemon_486f1db0ed37
+              secret keys allowed: (none — add with: anet daemon init ga-daemon --force --allow-secret KEY)
+
+[anet daemon] ⚠ Permission posture:
+              flags.dangerouslySkipPermissions = true  (no per-call confirmation)
+              flags.teammateMode = true
+              role = host_supervisor                   (can fork child agent-nodes via hub)
+              → Run daemons only on machines you trust to act on your behalf.
+              → Edit .anet/nodes/ga-daemon/config.json to disable individual flags.
+
+Next: start it
+  anet daemon start ga-daemon    (or anet daemon up ga-daemon to init+start in one go)
+[anet] Starting new session for "ga-daemon" [claude-agent-sdk]...
+
+[anet] Token: ntok_e62...
+[agent-node] Config: /.anet/nodes/ga-daemon/config.json (source=primary)
+[05:28:17] [INFO ] [ga-daemon] 启动
+[05:28:17] [INFO ] [ga-daemon]   alias:   ga-daemon [from: --alias flag]
+[05:28:17] [INFO ] [ga-daemon]   runtime: claude-agent-sdk
+[05:28:17] [INFO ] [ga-daemon]   model:   claude-sonnet-4-6 (default)
+[05:28:17] [INFO ] [ga-daemon]   hub:     http://127.0.0.1:9234 (auth)
+[05:28:17] [INFO ] [ga-daemon]   user:    ga2admin (admin)
+[05:28:17] [INFO ] [ga-daemon]   network: default
+[05:28:17] [INFO ] [ga-daemon]   tools:   all (Claude Code preset — built-in: WebFetch/WebSearch/Bash/Read/Write/Edit/Glob/Grep/Task/...)
+[05:28:17] [INFO ] [ga-daemon]   channels: (none)
+[05:28:17] [INFO ] [ga-daemon]   session: (new)
+[05:28:17] [INFO ] [ga-daemon]   log-dir: /.anet/nodes/ga-daemon/logs
+[05:28:17] [INFO ] [ga-daemon]   goals:   /.anet/nodes/ga-daemon/goals.json
+[05:28:17] [INFO ] [ga-daemon]   goals scheduler: enabled (runtime=claude)
+[05:28:17] [INFO ] [ga-daemon] 已注册到 CommHub
+[05:28:17] [INFO ] [ga-daemon] [deleted-sweeper] started (every 24h, retention 30d)
+[05:28:17] [INFO ] [ga-daemon] [attachment-cache] sweeper started (hourly tick, 24h TTL, dir=/root/.anet/cache/attachments/ga-daemon)
+[05:28:17] [INFO ] [ga-daemon] SSE connected
+[05:28:20] [INFO ] [ga-daemon] [rebuild] done: total=0 recovered=0 missing=0 ambiguous=0 zombies=0
+
+=== 8. hub side — recent stdout (looking for zod-parse / SEC refusals) ===
+[commhub] database: /tmp/ga2-hub.db
+[commhub] 🎉 14-day free trial started!
+[commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
+
+╔══════════════════════════════════════════════════╗
+║   CommHub MCP Server v0.9.0-preview.14                     ║
+║   Transport: Streamable HTTP (Bun native)         ║
+║   Security: 🔒 secured                       ║
+║   Tmux: DISABLED (set COMMHUB_ENABLE_TMUX=1)  ║
+║                                                   ║
+║   MCP:    http://127.0.0.1:9234/mcp                 ║
+║   REST:   http://127.0.0.1:9234/api                 ║
+║   Health: http://127.0.0.1:9234/health               ║
+╚══════════════════════════════════════════════════╝
+
+[rfc-028 vault] master key not set + no vault rows — vault gating is lazy; boot OK. Set ANET_HUB_SECRET_VAULT_KEY when enabling provider/secret features.
+[05:28:17] ga-daemon (sdk-node) → report_status: idle [net]
+[05:28:17] SSE ← net_d72902125e04:ga-daemon connected (1 clients)
+[05:28:17] ga-daemon (sdk-node) → report_status: idle [net]
+[05:28:17] ga-daemon → get_inbox: 0 pending messages

--- a/docs/tests/p-ga2-compat-repro/repro.sh
+++ b/docs/tests/p-ga2-compat-repro/repro.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# GA-blocker #2 reproduction. No workaround, no bounce — just start
+# the aligned versions the way an operator would and observe what the
+# hub's node row looks like a few seconds after `anet daemon up`.
+
+set -uo pipefail
+
+HUB_PORT=9234
+HUB_BASE="http://127.0.0.1:${HUB_PORT}"
+HUB_DB=/tmp/ga2-hub.db
+export COMMHUB_DB="${HUB_DB}"
+export HOME=/root
+mkdir -p /root/.anet
+
+echo "=== 0. hub boot (commhub-server 0.9.0-preview.21) ==="
+PORT="${HUB_PORT}" HOST=127.0.0.1 NODE_ENV=production commhub-server >/tmp/hub.log 2>&1 &
+HUB_PID=$!
+for _ in {1..60}; do curl -fsS "${HUB_BASE}/health" >/dev/null 2>&1 && break; sleep 0.5; done
+curl -fsS "${HUB_BASE}/health" >/dev/null && echo "  ✓ hub /health 200 :${HUB_PORT}" || { tail /tmp/hub.log; exit 1; }
+
+echo "=== 1. register admin ==="
+REG=$(curl -sS -X POST "${HUB_BASE}/api/auth/register" -H 'Content-Type: application/json' \
+  -d '{"username":"ga2admin","password":"GA2!TestP@ss","email":"ga2@test.local"}')
+UTOK=$(echo "$REG" | jq -r '.token')
+NET_ID=$(curl -sS "${HUB_BASE}/api/auth/me" -H "Authorization: Bearer ${UTOK}" | jq -r '.networks[0].network_id')
+echo "  ✓ admin utok minted; network_id=${NET_ID}"
+
+echo "=== 2. persist hub + token to global anet config (mirrors post-login state) ==="
+mkdir -p /root/.anet
+cat > /root/.anet/config.json <<EOF
+{
+  "hub": "${HUB_BASE}",
+  "token": "${UTOK}",
+  "network_id": "${NET_ID}"
+}
+EOF
+
+echo "=== 3. anet daemon up ga-daemon  (init + start in one go) ==="
+# Detached so we can keep querying the hub while the agent-node is up.
+nohup anet daemon up ga-daemon > /tmp/daemon.log 2>&1 &
+DAEMON_PID=$!
+
+# Poll /api/nodes until the daemon row appears at all.
+DAEMON_ROW=""
+for i in $(seq 1 30); do
+  sleep 1
+  ROW=$(curl -sS "${HUB_BASE}/api/nodes" -H "Authorization: Bearer ${UTOK}" 2>/dev/null \
+    | jq -r '.nodes[] | select(.alias == "ga-daemon")' 2>/dev/null)
+  if [[ -n "$ROW" ]]; then
+    DAEMON_ROW="$ROW"
+    echo "  ✓ daemon row appeared after ${i}s"
+    break
+  fi
+done
+
+if [[ -z "$DAEMON_ROW" ]]; then
+  echo "  ✗ daemon never registered — this is a different bug"
+  tail /tmp/daemon.log
+  exit 1
+fi
+
+echo
+echo "=== 4. inspect for 40 seconds ==="
+for pass in 1 5 10 15 20 25 30 35 40; do
+  sleep 5 2>/dev/null || true
+  ROW=$(curl -sS "${HUB_BASE}/api/nodes" -H "Authorization: Bearer ${UTOK}" \
+    | jq -r '.nodes[] | select(.alias == "ga-daemon")')
+  echo "--- ${pass}s ---"
+  echo "$ROW" | jq -r '{node_id, alias, role, snapshot_len: (.config_snapshot | tostring | length)}'
+done
+
+echo
+echo "=== 5. SQL-level truth (the column state as stored) ==="
+sqlite3 "${HUB_DB}" \
+  "SELECT node_id, alias, LENGTH(COALESCE(config_snapshot,'')) AS snap_len,
+          SUBSTR(COALESCE(config_snapshot,''), 1, 400) AS snap
+   FROM nodes WHERE alias = 'ga-daemon';"
+
+echo
+echo "=== 6. list_host_supervisors REST (what the picker actually reads) ==="
+curl -sS "${HUB_BASE}/api/host-supervisors?network_id=${NET_ID}" -H "Authorization: Bearer ${UTOK}" | jq
+
+echo
+echo "=== 7. daemon side — recent stdout ==="
+tail -40 /tmp/daemon.log
+
+echo
+echo "=== 8. hub side — recent stdout (looking for zod-parse / SEC refusals) ==="
+tail -40 /tmp/hub.log
+
+kill "$DAEMON_PID" 2>/dev/null || true
+kill "$HUB_PID" 2>/dev/null || true


### PR DESCRIPTION
## Summary

GA-blocker #2 post-mortem — turned out to be **not a compat bug** after
clean-state docker repros with two version combos. Compat-matrix docs
tightened + upgrade-order discipline documented + repro artifacts
committed so the next suspected mismatch has a known-good baseline.

Refs GA-blocker #2.

## The setup 通信龙 flagged

- Production hub `:9200` running `commhub-server 0.9.0-preview.14`.
- Fresh `anet daemon up ga-daemon` via `agent-network 2.3.0-preview.21`
  → `agent-node 2.5.0-preview.19`.
- Daemon registers + SSE connects, `config.json` has
  `role: host_supervisor`.
- But `/api/nodes` shows `config_snapshot=None` for that daemon →
  `list_host_supervisors` filters on `config_snapshot.role` → returns
  count=0 → dashboard picker empty → wizard walked off the rails.

Hypothesis on the table: version drift between hub `.14` and
agent-node `.19` in the snapshot contract.

## Two clean-state docker repros, both PASS first-shot

Fixtures now committed at `docs/tests/p-ga2-compat-repro/` — same
`repro.sh` under different pinned versions:

| Combo | commhub-server | agent-node | anet CLI | Result | SQL `LENGTH(config_snapshot)` | `list_host_supervisors.count` |
|-------|---------------|-----------|----------|--------|-------------------------------|-------------------------------|
| A: aligned GA candidate | `0.9.0-preview.21` | `2.5.0-preview.19` | `2.3.0-preview.21` | ✅ | 281 | 1 |
| B: 通信龙's prod combo | `0.9.0-preview.14` | `2.5.0-preview.19` | `2.3.0-preview.21` | ✅ | 281 | 1 |

Both containers, at `t=1s` after `anet daemon up ga-daemon`, land

```json
{
  "model": null,
  "flags": { "dangerouslySkipPermissions": true },
  "config_revision": 0,
  "config_update_capable": true,
  "role": "host_supervisor",
  "daemon_capabilities": {
    "runtimes_supported": ["claude-agent-sdk", "codex-sdk", "grok-build-acp"],
    "allowed_secret_keys": [],
    "max_concurrent_children": 20
  }
}
```

verbatim into `nodes.config_snapshot`, and `list_host_supervisors`
returns count=1 with the daemon fully surfaced. Full run logs at
`docs/tests/p-ga2-compat-repro/{aligned,mixed}-full-run.log`.

Meaning: **the picker code path is right**. The `config_snapshot=None`
is a prod-state issue, not a code path issue.

## What this PR ships

### `docs/release/versioning-and-compatibility.md`

- **§7.1 Operator upgrade 顺序** (new). Distinguishes:
  - npm publish order (§7): `server → agent-node → agent-network`
    (dependency-first, publisher POV).
  - **Operator-side upgrade order (§7.1): hub first, node after,
    CLI/dashboard last.** Rationale spelled out: hub is where the
    backward-compat lives; running new node against old hub is the
    dangerous direction (new node emits fields old hub's zod strips →
    fields disappear from stored snapshot → `list_host_supervisors`
    filter blind).
- **§7.2 混装组合的快速自查** (new). ~10-second smoke: `anet -v` /
  `agent-node --version` / `curl /health` / `anet daemon up
  smoke-daemon` / `jq` the snapshot presence. So an operator can
  self-audit before blaming code.
- **§9 已定性的 mismatch 事件** (new). Postmortem in the doc so the
  matrix + the reasoning stay together. Three prod-state hypotheses
  enumerated:
  - Dirty existing row from a prior alias reuse.
  - The **P3-flagged `config_snapshot` clobber** (`child registration
    path may erase parent daemon's config_snapshot column`) —
    elevated from backlog to "may bite busy-hub picker" by this
    incident. Worth an independent GA-vs-post-GA judgement.
  - SEC-1 cross-network refuse (`upsertNodeWithSec1Guard` returns
    `refused` and only `console.warn`s — silent from the dashboard's
    POV). One `hub.log | grep '🚫 report_status cross-network'` and
    it's clear.

### `docs-site/docs/guide/upgrade.md`

Short user-facing tip callout above `升级步骤` §1: hub-first, why,
and a deep link into §7.1 above.

### `docs/tests/p-ga2-compat-repro/`

Self-contained repro fixtures the next suspected compat regression can
diff against:

- `Dockerfile.aligned` / `Dockerfile.mixed` — pinned version rows.
- `repro.sh` — boots hub, mints admin, `anet daemon up`, polls
  `/api/nodes` for 40 s, dumps SQL truth from `nodes.config_snapshot`,
  calls `/api/host-supervisors`, tails both daemon + hub stdout.
- `aligned-full-run.log` / `mixed-full-run.log` — verbatim runs.
- `README.md` — how to run.

## Prod :9200 root-cause tracking

Not this PR. 通信龙 is watching the affected daemon on the host —
restart-then-observe-snapshot-over-time will tell him whether the
column ever populates (P3 clobber pattern) or never populates (dirty
row / SEC-1 refuse). This PR gives him the reference tooling +
documented three prod-state hypotheses to check against.

## Red-line 3-layer audit

- Broad private-fork keyword regex on diff = 0 hits
- Slug regex on diff + commit msg + PR body = 0 hits
- Real vendor key literal regex on diff + evidence logs = 0 hits
  (only truncated `ntok_6c0…` / `ntok_e62…` print-side snippets)
- No `Co-Authored-By` per project policy

## Test plan

- [ ] `docker build -f docs/tests/p-ga2-compat-repro/Dockerfile.aligned -t anet-ga2-aligned .`
- [ ] `docker run --rm --tmpfs /tmp:rw,exec --tmpfs /root:rw,exec anet-ga2-aligned`
- [ ] Same for `Dockerfile.mixed`.
- [ ] Expect `config_snapshot` populated within 1 s in both;
      `list_host_supervisors` returns count=1.

Refs GA-blocker #2.
