### PR TITLE
fix(#426): declare charset=utf-8 on all text-y hub responses

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -459,6 +459,42 @@ function withCors(req: Request, res: Response): Response {
   return res;
 }
 
+/**
+ * #426 — append `charset=utf-8` to text-y Content-Type headers that
+ * omit it. Legacy Windows clients (PowerShell 5.1 Invoke-RestMethod /
+ * Invoke-WebRequest) default to ISO-8859-1 when the charset is
+ * unspecified, which double-encodes our clean UTF-8 payloads on the
+ * way in.
+ *
+ * Applied to Responses whose Content-Type header we can't influence at
+ * construction time — notably the MCP SDK transport, which builds its
+ * own `text/event-stream` / `application/json` reply. Response headers
+ * from `fetch` are mutable, so this rewrites in place rather than
+ * reconstructing the Response (which would break streamed bodies).
+ *
+ * No-ops when: charset is already set, the type is binary
+ * (application/octet-stream, image/*, video/*, application/pdf, etc.),
+ * or the header is missing entirely.
+ */
+function withUtf8CharsetContentType(res: Response): Response {
+  const ct = res.headers.get("content-type");
+  if (!ct) return res;
+  if (/;\s*charset=/i.test(ct)) return res;
+  const trimmed = ct.trim();
+  // Text-y types that legacy clients decode via charset. Everything
+  // else (binary, opaque) is left alone.
+  if (
+    trimmed === "application/json" ||
+    trimmed.startsWith("text/") ||
+    trimmed.startsWith("application/json;") ||
+    trimmed === "application/ld+json" ||
+    trimmed === "application/xml"
+  ) {
+    res.headers.set("content-type", `${trimmed}; charset=utf-8`);
+  }
+  return res;
+}
+
 // ── WebSocket tmux sessions ────────────────────────
 const wsTmuxIntervals = new Map<object, ReturnType<typeof setInterval>>();
 
@@ -534,7 +570,17 @@ Bun.serve({
       const response = await transport.handleRequest(req);
       // Disconnect after response to prevent McpServer leak
       setImmediate(() => mcpServer.close().catch(() => {}));
-      return response;
+      // #426: the MCP SDK's WebStandardStreamableHTTPServerTransport builds
+      // its own Response with `Content-Type: text/event-stream` (or
+      // `application/json` for JSON-mode) but WITHOUT charset. Legacy
+      // Windows clients (PowerShell 5.1 Invoke-WebRequest / RestMethod)
+      // default to ISO-8859-1 when the charset is unspecified and 双重-
+      // 编码 our clean UTF-8 payload on the way in — the reported
+      // mojibake is client-side, but the header is what tells them to
+      // guess. We can't tell the SDK to add it, so wrap the response and
+      // rewrite the header. Streamed bodies (SSE) pass through untouched
+      // because Response takes the original ReadableStream verbatim.
+      return withUtf8CharsetContentType(response);
     }
 
     // ── SSE push: Agent 实时接收任务推送 ──
@@ -1365,7 +1411,7 @@ Bun.serve({
         if (rate.retryAfterMs) headers["Retry-After"] = String(Math.ceil(rate.retryAfterMs / 1000));
         return withCors(req, new Response(
           JSON.stringify({ ok: false, error: "rate_limited", message: "Upload rate limit exceeded (60/hour). Try again later.", retry_after_ms: rate.retryAfterMs }),
-          { status: 429, headers: { ...headers, "Content-Type": "application/json" } },
+          { status: 429, headers: { ...headers, "Content-Type": "application/json; charset=utf-8" } },   // #426 — legacy clients default to ISO-8859-1 without charset
         ));
       }
 
@@ -2235,7 +2281,7 @@ Endpoints:
 
 Security: ${SECURITY_LABEL}
 `,
-      { status: 200, headers: { "Content-Type": "text/plain" } }
+      { status: 200, headers: { "Content-Type": "text/plain; charset=utf-8" } }   // #426
     ));
   },
 

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -280,7 +280,12 @@ export function createSSEStream(sessionName: string, networkId?: string | null):
 
   return new Response(stream, {
     headers: {
-      "Content-Type": "text/event-stream",
+      // #426: explicit charset so legacy Windows clients (PowerShell 5.1's
+      // Invoke-RestMethod / Invoke-WebRequest default to ISO-8859-1 when
+      // Content-Type omits the charset) decode UTF-8 payloads correctly.
+      // Hub itself was already writing clean UTF-8 bytes; the client-side
+      // 双重编码样式 mojibake was the header telling the client to guess.
+      "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache, no-transform",
       "Connection": "keep-alive",
     },

--- a/server/src/response-charset.test.ts
+++ b/server/src/response-charset.test.ts
@@ -1,0 +1,130 @@
+// #426 unit tests for the withUtf8CharsetContentType helper — the
+// piece that rewrites text-y Content-Type headers to include
+// charset=utf-8 so legacy Windows clients don't fall back to
+// ISO-8859-1 decoding. The helper lives in server/src/index.ts;
+// to keep the test standalone we re-implement its pure semantics here
+// and assert those. Any drift between this pure copy and the
+// production helper is caught by the "identical semantics" test at
+// the bottom via a source grep.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Pure re-implementation — MUST match server/src/index.ts:withUtf8CharsetContentType.
+function withUtf8CharsetContentType(res: Response): Response {
+  const ct = res.headers.get("content-type");
+  if (!ct) return res;
+  if (/;\s*charset=/i.test(ct)) return res;
+  const trimmed = ct.trim();
+  if (
+    trimmed === "application/json" ||
+    trimmed.startsWith("text/") ||
+    trimmed.startsWith("application/json;") ||
+    trimmed === "application/ld+json" ||
+    trimmed === "application/xml"
+  ) {
+    res.headers.set("content-type", `${trimmed}; charset=utf-8`);
+  }
+  return res;
+}
+
+function makeRes(contentType: string | null, body = ""): Response {
+  return new Response(body, { headers: contentType ? { "content-type": contentType } : {} });
+}
+
+describe("withUtf8CharsetContentType — #426", () => {
+  test("appends charset to text/event-stream", () => {
+    const res = withUtf8CharsetContentType(makeRes("text/event-stream"));
+    expect(res.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+  });
+
+  test("appends charset to application/json (bare)", () => {
+    const res = withUtf8CharsetContentType(makeRes("application/json"));
+    expect(res.headers.get("content-type")).toBe("application/json; charset=utf-8");
+  });
+
+  test("appends charset to text/plain", () => {
+    const res = withUtf8CharsetContentType(makeRes("text/plain"));
+    expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+  });
+
+  test("appends charset to text/html", () => {
+    const res = withUtf8CharsetContentType(makeRes("text/html"));
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+  });
+
+  test("no-op when charset already present (case-insensitive)", () => {
+    for (const ct of [
+      "application/json; charset=utf-8",
+      "application/json;charset=UTF-8",
+      "text/event-stream;Charset=us-ascii",
+      "text/plain; CHARSET=iso-8859-1",
+    ]) {
+      const res = withUtf8CharsetContentType(makeRes(ct));
+      expect(res.headers.get("content-type")).toBe(ct);
+    }
+  });
+
+  test("no-op on binary types (opaque)", () => {
+    for (const ct of [
+      "application/octet-stream",
+      "image/png",
+      "image/jpeg",
+      "video/mp4",
+      "application/pdf",
+      "font/woff2",
+    ]) {
+      const res = withUtf8CharsetContentType(makeRes(ct));
+      expect(res.headers.get("content-type")).toBe(ct);
+    }
+  });
+
+  test("no-op when Content-Type header is absent entirely (returns as-is)", () => {
+    const res = withUtf8CharsetContentType(makeRes(null));
+    expect(res.headers.get("content-type")).toBeNull();
+  });
+
+  test("handles application/ld+json / application/xml", () => {
+    expect(withUtf8CharsetContentType(makeRes("application/ld+json")).headers.get("content-type"))
+      .toBe("application/ld+json; charset=utf-8");
+    expect(withUtf8CharsetContentType(makeRes("application/xml")).headers.get("content-type"))
+      .toBe("application/xml; charset=utf-8");
+  });
+
+  test("preserves non-charset parameters and appends charset (application/json; boundary=…)", () => {
+    // Bun's Response.json emits `application/json;charset=utf-8`; the test
+    // above covers that no-op path. When a caller sends a parametrised
+    // header like `application/json; profile=…`, the helper still recognises
+    // it via the `application/json;` prefix and appends the charset.
+    const res = withUtf8CharsetContentType(makeRes("application/json; profile=example"));
+    expect(res.headers.get("content-type")).toBe("application/json; profile=example; charset=utf-8");
+  });
+
+  test("returns the same Response instance (mutates in place)", () => {
+    const input = makeRes("text/event-stream");
+    const output = withUtf8CharsetContentType(input);
+    expect(output).toBe(input);
+  });
+
+  // Drift guard: the pure copy in this file MUST match the production
+  // helper's branching set. If someone edits one without touching the
+  // other, this test fails visibly instead of the helper going silently
+  // out of sync. Kept as fragment-level greps (not whole-body match) so
+  // added comments don't break the assertion.
+  test("production helper covers the same content-type branches", () => {
+    const src = readFileSync(join(import.meta.dir, "index.ts"), "utf-8");
+    expect(src).toContain("function withUtf8CharsetContentType(res: Response): Response {");
+    expect(src).toContain("if (/;\\s*charset=/i.test(ct)) return res;");
+    for (const branch of [
+      'trimmed === "application/json"',
+      'trimmed.startsWith("text/")',
+      'trimmed.startsWith("application/json;")',
+      'trimmed === "application/ld+json"',
+      'trimmed === "application/xml"',
+    ]) {
+      expect(src).toContain(branch);
+    }
+    expect(src).toContain('res.headers.set("content-type", `${trimmed}; charset=utf-8`);');
+  });
+});


### PR DESCRIPTION
## Summary

External Windows MCP clients (PowerShell 5.1 Invoke-WebRequest /
Invoke-RestMethod) 双重-编码-looked our clean UTF-8 payloads because
their default decoding for a `Content-Type` without an explicit
charset is ISO-8859-1. Reporter's isolated-docker repro confirmed the
hub stored and returned bytes clean (`E7 9C 9F` verbatim on `真`) —
the mojibake was the client guessing.

Fix per 通信龙 verdict: every text-y hub response now advertises
`; charset=utf-8` on its `Content-Type` header. Small change, no
protocol semantics touched, no standalone release — bundle into the
next preview.

Closes #426.

Author: 通信工程马

## Real-run proof (verbatim `curl -D -` on a booted hub off this branch)

```
=== /health ===
Content-Type: application/json;charset=utf-8
=== / (banner) ===
Content-Type: text/plain; charset=utf-8
=== /api/nodes ===
Content-Type: application/json;charset=utf-8
=== /mcp POST (SDK transport) ===
Content-Type: text/event-stream; charset=utf-8
=== /events/<self> (SSE) ===
Content-Type: text/event-stream; charset=utf-8
```

Before this branch, `/mcp POST` and `/events/*` responded with
`Content-Type: text/event-stream` bare — no charset.

## Coverage

| Site | Before | After |
|------|--------|-------|
| `server/src/push.ts` — SSE stream builder (`createSSEStream`) | `text/event-stream` | `text/event-stream; charset=utf-8` |
| `server/src/index.ts` — banner `/` | `text/plain` | `text/plain; charset=utf-8` |
| `server/src/index.ts` — upload rate-limit 429 | `application/json` | `application/json; charset=utf-8` |
| `server/src/index.ts` — MCP SDK transport `WebStandardStreamableHTTPServerTransport.handleRequest` | `text/event-stream` / `application/json` bare | rewritten in place via `withUtf8CharsetContentType(res)` |
| All `Response.json(...)` sites | `application/json;charset=utf-8` (Bun default) | unchanged — Bun already emits it |
| `application/octet-stream` file downloads | binary — no charset applicable | unchanged |
| 204 preflights, `new Response(proc.stdout)` utilities | no user-facing Content-Type | unchanged |

The MCP SDK transport builds its own Response without exposing a
header knob at construction time; rather than reconstruct a fresh
Response (which would break the streaming body handoff) the fix
rewrites the returned Response's Content-Type in place. Response
headers from `fetch` are mutable, so this is legal + the streamed
body passes through untouched. The helper is factored out to
`withUtf8CharsetContentType(res)` next to `withCors(req, res)` so
future call sites have one obvious place to reach for.

Bun's own `Response.json(...)` already emits
`application/json;charset=utf-8` (empirically verified with
`bun -e 'const r = Response.json({a:1});
console.log(r.headers.get("content-type"))'`), so those sites are
untouched.

## Unit tests

`server/src/response-charset.test.ts` — **11 pass / 0 fail**. Covers:

- Appends charset to `text/event-stream` / `application/json` /
  `text/plain` / `text/html`.
- No-op when charset already set (case-insensitive across
  `charset=UTF-8` / `Charset=us-ascii` / `CHARSET=iso-8859-1`).
- No-op on binary types (`application/octet-stream`, `image/png`,
  `video/mp4`, `application/pdf`, `font/woff2`).
- No-op when Content-Type header is absent entirely.
- Handles `application/ld+json` / `application/xml`.
- Handles parametrised header (`application/json; profile=example`
  → `application/json; profile=example; charset=utf-8`).
- Returns the same Response instance (mutates in place).
- **Drift guard**: greps the production `index.ts` for each branch
  keyword, so an edit to one copy without the other fails visibly.

Full server suite: 515 pass / 8 fail on this branch. Baseline
`origin/main` before the fix: 504 pass / 8 fail — same 8 pre-existing
failures (all pass when the file runs standalone; test-file
interaction pollution unrelated to this change). +11 = the new tests.

## Red-line 3-layer audit

- Broad private-fork keyword regex on diff = 0 hits
- Slug regex on diff + commit msg + PR body = 0 hits
- Real vendor key literal regex on diff + curl trace = 0 hits
- No `Co-Authored-By` per project policy

## Release note

Per 通信龙 verdict on #426: **no standalone release**. This lands on
main and rides the next preview bundle.

## Test plan

- [ ] `bun test src/response-charset.test.ts` from `server/` → 11
      pass / 0 fail.
- [ ] Boot hub locally (`PORT=… bun run src/index.ts`), `curl -D -`
      each of the five endpoints above — every Content-Type carries
      `; charset=utf-8`.
- [ ] Optional: PowerShell 5.1 client that reported #426 confirms
      no more Latin-1→UTF-8 double-encoding on read.

Refs #426.
