### PR TITLE
RFC-030 Phase 0A: codex-app-server runtime (codex TUI bridge, direct-client preview)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ agent-network/tests/docker-e2e/results/
 # Dashboard screenshots hosted via Release assets
 docs/dashboard-screenshots/
 .qa-status-history
+
+# RFC-030 live demo (hub db + node config w/ ntok — never commit)
+.demo/

--- a/agent-network/.gitignore
+++ b/agent-network/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 bun.lock
 .npmrc
+.anet/

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1064,6 +1064,14 @@ function checkRuntimeDependency(runtime: RuntimeName, phase: "create" | "start")
     console.warn(`[anet] Warning: opencode CLI not found in PATH.`);
     console.warn(`[anet] Install (exact): npm install -g opencode-ai@${OPENCODE_PINNED_VERSION}`);
   }
+  // RFC-030 — codex-app-server (codex TUI bridge) runs a standalone
+  // `codex app-server`, so it needs the `codex` CLI on PATH (same binary
+  // as codex-sdk, but the app-server subcommand). agent-node itself is
+  // lazy-fetched via npx like the other runtimes.
+  if (runtime === "codex-app-server" && !commandExists("codex")) {
+    console.warn(`[anet] Warning: codex CLI not found in PATH.`);
+    console.warn(`[anet] Install/login codex first: https://developers.openai.com/codex/cli`);
+  }
 }
 
 // ── Help ──
@@ -1373,7 +1381,8 @@ function createProfileFromOpts(id: string, opts: ReturnType<typeof parseOpts>): 
   // (MiniMax/DeepSeek/GLM/Kimi/Anthropic). claude-code-cli only works for Max/Pro
   // subscribers and was a poor default that left non-subscribers with broken nodes.
   const runtime = normalizeRuntime(opts.runtime || "claude-agent-sdk");
-  const defaultModel = runtime === "codex-sdk" ? "gpt-5.5" : undefined;
+  const defaultModel =
+    runtime === "codex-sdk" || runtime === "codex-app-server" ? "gpt-5.5" : undefined;
 
   const profile: Profile = {
     anet_version: "0.1.0",
@@ -2068,6 +2077,7 @@ This wizard creates one agent node for this project:
         { value: "claude-agent-sdk", name: "claude-agent-sdk — 任意 OpenAI/Anthropic-compat vendor (intern / MiniMax / Claude / GLM / ...)" },
         { value: "claude-code-cli",  name: "claude-code-cli  — Anthropic Claude (Max/Pro plan), 复用 `claude` CLI 登录态" },
         { value: "codex-sdk",        name: "codex-sdk        — OpenAI Codex, 复用 `codex auth login` 登录态" },
+        { value: "codex-app-server", name: "codex-app-server — OpenAI Codex TUI 桥 (RFC-030), 独立 `codex app-server`, 可接管已有 codex 会话" },
         { value: "grok-build-acp",   name: "grok-build-acp   — Grok Build ACP, 复用 `grok` CLI 登录态" },
         // RFC-029 — public sst/opencode CLI (multi-vendor front-end
         // with unified session + auth abstraction). Runtime not yet
@@ -2087,6 +2097,10 @@ This wizard creates one agent node for this project:
   } else if (pickedRuntime === "codex-sdk") {
     opts.runtime = "codex-sdk";
     console.log(`[anet] 请确保已执行: codex auth login`);
+  } else if (pickedRuntime === "codex-app-server") {
+    opts.runtime = "codex-app-server";
+    console.log(`[anet] 请确保已执行: codex auth login （codex-app-server 需要 codex CLI）`);
+    console.log(`[anet] 接管已有 codex 会话：在 config.json 里设 codexAppServerUrl + codexThreadId`);
   } else if (pickedRuntime === "grok-build-acp") {
     opts.runtime = "grok-build-acp";
     console.log(`[anet] 请确保已安装并登录 Grok Build CLI: grok auth login`);

--- a/agent-network/src/normalize-runtime.test.ts
+++ b/agent-network/src/normalize-runtime.test.ts
@@ -91,6 +91,33 @@ describe("normalizeRuntime — explicit choices are preserved", () => {
   test("profile with runtime='opencode' → opencode-cli", () => {
     expect(normalizeRuntime({ runtime: "opencode" } as any)).toBe("opencode-cli");
   });
+
+  // RFC-030 — codex TUI bridge (standalone `codex app-server`). Canonical
+  // `codex-app-server` plus aliases `codex-tui` / `codex-appserver`. These
+  // must NOT collapse into `codex-sdk` (a different runtime).
+  test("explicit 'codex-app-server' → codex-app-server", () => {
+    expect(normalizeRuntime("codex-app-server")).toBe("codex-app-server");
+  });
+
+  test("alias 'codex-tui' → codex-app-server", () => {
+    expect(normalizeRuntime("codex-tui")).toBe("codex-app-server");
+  });
+
+  test("alias 'codex-appserver' → codex-app-server", () => {
+    expect(normalizeRuntime("codex-appserver")).toBe("codex-app-server");
+  });
+
+  test("'codex-sdk' still → codex-sdk (not shadowed by the app-server branch)", () => {
+    expect(normalizeRuntime("codex-sdk")).toBe("codex-sdk");
+  });
+
+  test("'codex' still → codex-sdk (legacy short alias unchanged)", () => {
+    expect(normalizeRuntime("codex")).toBe("codex-sdk");
+  });
+
+  test("profile with runtime='codex-app-server' → codex-app-server", () => {
+    expect(normalizeRuntime({ runtime: "codex-app-server" } as any)).toBe("codex-app-server");
+  });
 });
 
 describe("normalizeRuntime — profile object paths", () => {

--- a/agent-network/src/normalize-runtime.ts
+++ b/agent-network/src/normalize-runtime.ts
@@ -16,7 +16,8 @@ export type RuntimeName =
   | "codex-sdk"
   | "claude-agent-sdk"
   | "grok-build-acp"
-  | "opencode-cli";
+  | "opencode-cli"
+  | "codex-app-server";
 
 /** Operator-facing default for any runtime slot that comes in empty / missing / unrecognized. */
 export const DEFAULT_RUNTIME: RuntimeName = "claude-agent-sdk";
@@ -32,6 +33,14 @@ type ProfileLike = {
 
 export function normalizeRuntime(profileOrRuntime?: ProfileLike | string): RuntimeName {
   if (typeof profileOrRuntime === "string") {
+    // RFC-030 — codex TUI bridge (standalone `codex app-server`). Aliases:
+    // `codex-tui` / `codex-app-server` / `codex-appserver`. Checked BEFORE
+    // the `codex`/`codex-sdk` branch so the more specific names win.
+    if (
+      profileOrRuntime === "codex-app-server" ||
+      profileOrRuntime === "codex-appserver" ||
+      profileOrRuntime === "codex-tui"
+    ) return "codex-app-server";
     if (profileOrRuntime === "codex" || profileOrRuntime === "codex-sdk") return "codex-sdk";
     if (
       profileOrRuntime === "grok" ||

--- a/agent-node/.gitignore
+++ b/agent-node/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 
 # packaging
 *.tgz
+
+# RFC-030 real-node e2e runtime dir (contains ntok — never commit)
+.e2e-run/

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -339,6 +339,12 @@ const RUNTIME_MAP: Record<string, string> = {
 const RUNTIME = (RUNTIME_MAP[rawRuntime] || "claude") as "claude" | "codex" | "grok" | "opencode" | "codex-app-server";
 const RUNTIME_LABEL = rawRuntime; // 日志用原始名
 
+// RFC-030 — codex-app-server nodes reply to dispatched tasks with send_task
+// (immediate SSE wake + actionable) instead of send_reply (inbox-only, no
+// wake for the immediate originator). See sendReply() for the empirical
+// rationale. Other runtimes keep the send_reply task-lifecycle-close path.
+const REPLY_VIA_SEND_TASK = RUNTIME === "codex-app-server";
+
 const COMMHUB_URL = opts.url || opts.hub || process.env.COMMHUB_URL || fileConfig.hub || "http://127.0.0.1:9200";
 const MODEL = opts.model || process.env.MODEL || fileConfig.model;
 // #101 fix: when config.tools is absent the agent must still get the full
@@ -1057,6 +1063,24 @@ async function sendReply(
   // attribute this reply to the old name (which a post-rename inbox
   // viewer would see as an orphaned reply from a non-existent sender).
   const fromAlias = await liveAlias();
+
+  // RFC-030 — codex-app-server replies via send_task, NOT send_reply.
+  // Empirically (isolated-hub e2e), send_reply enqueues to the originator's
+  // inbox as type='reply' but does NOT SSE-wake the immediate originator
+  // (only a chained-to-parent push fires) — an agent peer would only see it
+  // on its next poll. send_task fires a `new_task` SSE wake so the peer acts
+  // immediately, matching the network's "回复用 send_task" convention
+  // (Vincent, 2026-07-09). Failures are prefixed so the peer sees the error.
+  if (REPLY_VIA_SEND_TASK) {
+    const taskResult = await callCommHub("send_task", {
+      alias: target,
+      task: failed ? `⚠️ ${message}` : message,
+      priority: failed ? "high" : "normal",
+      parent_task_id: taskId || undefined,
+    });
+    return { delivered: true, reply_id: taskResult?.message_id ?? taskResult?.task_id, payload: taskResult };
+  }
+
   const result = await callCommHub("send_reply", {
     alias: target,
     text: message,

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -331,8 +331,12 @@ const RUNTIME_MAP: Record<string, string> = {
   // launcher name (matches claude-code-cli precedent); `opencode` is
   // the short alias. Internal bucket is `"opencode"`.
   "opencode-cli": "opencode", "opencode": "opencode",
+  // RFC-030 — codex TUI bridge (standalone `codex app-server`). Distinct
+  // bucket from `codex` (that's the @openai/codex-sdk transport). Aliases:
+  // `codex-app-server` (canonical) / `codex-tui` / `codex-appserver`.
+  "codex-app-server": "codex-app-server", "codex-appserver": "codex-app-server", "codex-tui": "codex-app-server",
 };
-const RUNTIME = (RUNTIME_MAP[rawRuntime] || "claude") as "claude" | "codex" | "grok" | "opencode";
+const RUNTIME = (RUNTIME_MAP[rawRuntime] || "claude") as "claude" | "codex" | "grok" | "opencode" | "codex-app-server";
 const RUNTIME_LABEL = rawRuntime; // 日志用原始名
 
 const COMMHUB_URL = opts.url || opts.hub || process.env.COMMHUB_URL || fileConfig.hub || "http://127.0.0.1:9200";
@@ -559,6 +563,23 @@ function writebackGrokSession(sessionId: string) {
   }
 }
 
+// RFC-030 — persist the codex-app-server thread id into a dedicated
+// `codexThreadId` config field (NOT the generic `session`, which other
+// runtimes use) so a restart resumes the same codex conversation.
+function writebackCodexThread(threadId: string) {
+  codexAppServerThreadId = threadId;
+  if (!configFilePath || !threadId) return;
+  try {
+    const cfg = JSON.parse(readFileSync(configFilePath, "utf-8"));
+    if (cfg.codexThreadId === threadId) return;
+    cfg.codexThreadId = threadId;
+    writeFileSync(configFilePath, JSON.stringify(cfg, null, 2) + "\n");
+    debug(`codexThreadId 写回: ${configFilePath} → ${threadId.slice(0, 8)}...`);
+  } catch (e: any) {
+    warn(`writebackCodexThread failed: ${e.message}`);
+  }
+}
+
 function clearGrokSession(reason: string) {
   grokSessionId = undefined;
   if (!configFilePath) return;
@@ -680,7 +701,7 @@ if (UNSUPPORTED_CHANNEL) {
 // #101 fix: TOOLS may now be the preset sentinel (no array methods) — preset
 // already includes Read, so we only need to inject when TOOLS is an explicit
 // allowlist that doesn't already have Read.
-if (TELEGRAM_CHANNELS.length > 0 && RUNTIME !== "codex" && Array.isArray(TOOLS) && !TOOLS.includes("Read")) {
+if (TELEGRAM_CHANNELS.length > 0 && RUNTIME !== "codex" && RUNTIME !== "codex-app-server" && Array.isArray(TOOLS) && !TOOLS.includes("Read")) {
   TOOLS.push("Read");
 }
 
@@ -1401,6 +1422,28 @@ let grokSessionId: string | undefined = RUNTIME === "grok" ? (SESSION_ID || unde
 // holder — the next turn spawns fresh).
 let opencodeSessionId: string | undefined = RUNTIME === "opencode" ? (SESSION_ID || undefined) : undefined;
 let opencodeRuntimeSession: import("./runtime/opencode-acp/runtime").OpencodeRuntimeSession | null = null;
+
+// RFC-030 — codex-app-server runtime state.
+// `codexAppServerThreadId` is the persisted codex thread this node binds
+// to (config `codexThreadId`, or the generic `session` field as a
+// fallback). Empty → the bridge creates a fresh thread on first turn and
+// we write the adopted id back. `codexAppServerUrl` (config
+// `codexAppServerUrl` / env ANET_CODEX_APP_SERVER_URL) opts into the
+// shared-server topology: attach to an already-running `codex app-server`
+// (e.g. a human `codex --remote` TUI's) instead of spawning our own —
+// this is how an EXISTING codex session becomes a network node. The
+// runtime session is opened lazily and reused for the node lifetime; a
+// child-exit resets the holder so the next turn respawns.
+let codexAppServerThreadId: string | undefined =
+  RUNTIME === "codex-app-server"
+    ? ((fileConfig as { codexThreadId?: string }).codexThreadId || SESSION_ID || undefined)
+    : undefined;
+const codexAppServerUrl: string | undefined =
+  (fileConfig as { codexAppServerUrl?: string }).codexAppServerUrl ||
+  process.env.ANET_CODEX_APP_SERVER_URL ||
+  undefined;
+let codexAppServerRuntimeSession:
+  import("./runtime/codex-app-server/runtime").CodexAppServerRuntimeSession | null = null;
 
 // #213 — track whether the current process resumed a pre-existing grok
 // session (truthy SESSION_ID at boot) so we can prepend the un-closed-loop
@@ -2580,6 +2623,57 @@ async function processWithOpencode(task: string, _from: string, _images?: string
   return outcome.replyText || "（无回复）";
 }
 
+// RFC-030 — codex-app-server runtime turn.
+//
+// Inbound task → bridge.submitTask → one codex turn on the bound thread →
+// final answer returned here. The reply then goes back out through the
+// node's normal CommHub `sendReply`/`send_task` path (cli.ts inbox handler),
+// exactly like every other runtime — the bridge only wraps "run one turn".
+// A second concurrent task queues FIFO inside the bridge and is drained when
+// the in-flight turn (ours OR a human TUI's) completes.
+async function processWithCodexAppServer(task: string, _from: string, taskId: string | null): Promise<string> {
+  const { openCodexAppServerRuntime, codexAppServerThink } =
+    await import("./runtime/codex-app-server/runtime");
+
+  // Reset the holder if the app-server child has exited — the next call
+  // reopens (spawns fresh / re-attaches) and resumes the persisted thread.
+  if (codexAppServerRuntimeSession && !codexAppServerRuntimeSession.isRunning) {
+    log(`[codex-app-server] previous session not running — reopening on this turn`);
+    codexAppServerRuntimeSession = null;
+  }
+
+  if (!codexAppServerRuntimeSession) {
+    codexAppServerRuntimeSession = await openCodexAppServerRuntime({
+      serverUrl: codexAppServerUrl,
+      threadId: codexAppServerThreadId,
+      onThread: (threadId) => writebackCodexThread(threadId),
+      onExit: (info) => {
+        warn(`[codex-app-server] app-server exited code=${info.code} signal=${info.signal}; next turn will reopen`);
+        codexAppServerRuntimeSession = null;
+      },
+      log,
+      warn,
+    });
+    // A freshly-created thread is written back via onThread; make sure the
+    // in-memory var tracks it even when resuming (idempotent).
+    writebackCodexThread(codexAppServerRuntimeSession.threadId);
+  }
+
+  const outcome = await codexAppServerThink(codexAppServerRuntimeSession, {
+    taskId: taskId || `local-${Date.now()}`,
+    text: task,
+    from: _from,
+    log,
+  });
+
+  if (outcome.failed) {
+    // Surface as a runtime error string; processTask's failure detector
+    // treats the "错误:" marker as failed=true (dashboard shows real fail).
+    return outcome.replyText;
+  }
+  return outcome.replyText || "（无回复）";
+}
+
 async function processWithGrok(task: string, from: string, images?: string[]): Promise<string> {
   if (images?.length) {
     warn(`[grok] image attachments received but Grok ACP fixture reports promptCapabilities.image=false; sending text-only prompt`);
@@ -2967,6 +3061,9 @@ function think(task: string, from: string, taskId: string | null, images?: strin
       }
       if (RUNTIME === "opencode") {
         return await processWithOpencode(task, from, images);
+      }
+      if (RUNTIME === "codex-app-server") {
+        return await processWithCodexAppServer(task, from, taskId);
       }
       return await processWithClaude(task, from, images);
     } finally {
@@ -4164,7 +4261,7 @@ async function connectSSE() {
 log(`启动`);
 log(`  alias:   ${ALIAS || "(none!)"} [from: ${ALIAS_SOURCE}]`);  // #203 traceability
 log(`  runtime: ${RUNTIME_LABEL}`);
-log(`  model:   ${MODEL || (RUNTIME === "codex" ? "gpt-5.5" : RUNTIME === "grok" ? "grok-build" : "claude-sonnet-4-6")} ${MODEL ? "" : "(default)"}`);
+log(`  model:   ${MODEL || (RUNTIME === "codex" || RUNTIME === "codex-app-server" ? "gpt-5.5" : RUNTIME === "grok" ? "grok-build" : "claude-sonnet-4-6")} ${MODEL ? "" : "(default)"}`);
 log(`  hub:     ${COMMHUB_URL}${AUTH_TOKEN ? " (auth)" : " (no auth!)"}`);
 // #214 维度 5 A6 — surface the grok ACP idle-timeout resolution so the
 // operator can see at a glance whether their `flags.grokAcpTimeoutMs`
@@ -4342,7 +4439,7 @@ if (goalsSchedulerEnabled) {
 //     process, only handed to subprocess via env var (no log, no disk)
 //   - auth no-bypass — wrong/missing token → 401
 let loopsHttpServerHandle: import("./goals/loops-http-server").LoopsHttpServerStarted | null = null;
-if (RUNTIME === "codex" || RUNTIME === "grok") {
+if (RUNTIME === "codex" || RUNTIME === "grok" || RUNTIME === "codex-app-server") {
   try {
     const { startLoopsHttpServer } = await import("./goals/loops-http-server");
     const maxGoalsEnv = parseInt(process.env.COMMHUB_MAX_GOALS_PER_NODE || "", 10);

--- a/agent-node/src/goals/store.ts
+++ b/agent-node/src/goals/store.ts
@@ -53,6 +53,12 @@ const CLAUDE_RUNTIME_NAMES = new Set([
 const CODEX_RUNTIME_NAMES = new Set([
   "codex",
   "codex-sdk",
+  // RFC-030 — codex TUI bridge (standalone `codex app-server`). Same
+  // non-claude bucket as codex-sdk: it has a native host process, so
+  // self-loop management is host-driven (not the SDK-spawned claude path).
+  "codex-app-server",
+  "codex-appserver",
+  "codex-tui",
 ]);
 
 const GROK_RUNTIME_NAMES = new Set([

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -1,0 +1,415 @@
+// RFC-030 Phase 0 — bridge behaviour tests for CodexAppServerBridge.
+//
+// Uses a real WS server as the fake `codex app-server` and drives it by hand
+// to reproduce the scenarios that matter:
+//   - bootstrap: initialize → initialized → thread/resume
+//   - turn/start returns turnId, bridge tracks pending
+//   - turn/completed on OUR turn triggers task_reply
+//   - turn/completed on a HUMAN-TUI turn (unknown turnId) is dropped
+//   - cross-thread events are dropped
+//   - reverse request (approval) → waiting_human, NO response sent
+//   - serverRequest/resolved clears waiting_human; status recovers
+//   - two bridges pointed at the same fake server race for `idle` — only one
+//     wins turn/start; the other observes the winner's turn and does not
+//     produce a task_reply.
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { CodexAppServerClient } from "./codex-app-server-client";
+import { CodexAppServerBridge } from "./codex-app-server-bridge";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fake app-server that autoreplies to initialize / thread/resume / turn/start.
+// ────────────────────────────────────────────────────────────────────────────
+
+interface FakeApp {
+  url: string;
+  received: object[];
+  connections: Set<{ send: (s: string) => void }>;
+  broadcast: (obj: object) => void;
+  /** Send only to the client that most recently sent a request. */
+  respondLast: (result: object | { error: object }) => void;
+  /** Send to the client whose sequence number is offered. */
+  connectionCount: () => number;
+  stop: () => Promise<void>;
+}
+
+async function startFakeApp(config?: {
+  onRequest?: (
+    msg: { id: number; method: string; params?: unknown },
+    respond: (r: { result?: unknown; error?: { code: number; message: string } }) => void,
+    broadcast: (obj: object) => void,
+  ) => void;
+}): Promise<FakeApp> {
+  const received: object[] = [];
+  const connections = new Set<{ send: (s: string) => void }>();
+  let lastResponder: ((s: string) => void) | null = null;
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, srv) {
+      if (srv.upgrade(req)) return undefined;
+      return new Response("upgrade required", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        const handle = { send: (s: string) => ws.send(s) };
+        connections.add(handle);
+        (ws as unknown as { data: { handle: { send: (s: string) => void } } }).data = { handle };
+      },
+      message(ws, raw) {
+        const line = typeof raw === "string" ? raw : String(raw);
+        const parsed = JSON.parse(line);
+        received.push(parsed);
+        const handle = (ws as unknown as { data: { handle: { send: (s: string) => void } } }).data.handle;
+        lastResponder = handle.send;
+        if (typeof parsed.id === "number" && typeof parsed.method === "string") {
+          const respond = (r: { result?: unknown; error?: { code: number; message: string } }) => {
+            handle.send(JSON.stringify({ jsonrpc: "2.0", id: parsed.id, ...r }));
+          };
+          const broadcast = (obj: object) => {
+            const line = JSON.stringify(obj);
+            for (const c of connections) c.send(line);
+          };
+          if (config?.onRequest) {
+            config.onRequest(parsed, respond, broadcast);
+          } else {
+            // Default: auto-ok initialize / thread/resume; assign turnId to turn/start.
+            if (parsed.method === "initialize") {
+              respond({ result: { serverInfo: { name: "fake-codex" } } });
+            } else if (parsed.method === "thread/resume") {
+              respond({ result: {} });
+            } else if (parsed.method === "turn/start") {
+              respond({ result: { turnId: `turn_${received.length}` } });
+            }
+          }
+        }
+      },
+      close(ws) {
+        const handle = (ws as unknown as { data?: { handle?: { send: (s: string) => void } } }).data?.handle;
+        if (handle) connections.delete(handle);
+      },
+    },
+  });
+  return {
+    url: `ws://127.0.0.1:${server.port}`,
+    received,
+    connections,
+    broadcast: (obj: object) => {
+      const line = JSON.stringify(obj);
+      for (const c of connections) c.send(line);
+    },
+    respondLast: (r) => {
+      if (lastResponder) lastResponder(JSON.stringify({ jsonrpc: "2.0", ...r }));
+    },
+    connectionCount: () => connections.size,
+    stop: async () => {
+      server.stop(true);
+    },
+  };
+}
+
+const THREAD = "thread_abc";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Bootstrap + happy path
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CodexAppServerBridge — bootstrap + task mapping", () => {
+  let app: FakeApp;
+  let client: CodexAppServerClient;
+  let bridge: CodexAppServerBridge;
+
+  beforeEach(async () => {
+    app = await startFakeApp();
+    client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+  });
+  afterEach(async () => {
+    await client.close().catch(() => undefined);
+    await app.stop();
+  });
+
+  test("bootstrap sends initialize + initialized + thread/resume in order", () => {
+    const methods = app.received
+      .map((m) => (m as { method?: string }).method)
+      .filter(Boolean);
+    expect(methods).toEqual(["initialize", "initialized", "thread/resume"]);
+    expect(bridge.currentStatus()).toBe("idle");
+  });
+
+  test("startTaskTurn returns the server-assigned turnId and marks bridge working", async () => {
+    const turnId = await bridge.startTaskTurn({ taskId: "task_1", text: "please help" });
+    expect(turnId).toBeTypeOf("string");
+    expect(bridge.currentStatus()).toBe("working");
+    expect(bridge.activeTurn()).toBe(turnId);
+    expect(bridge.pendingTurnCount()).toBe(1);
+  });
+
+  test("turn/completed for OUR turn fires task_reply mapped back to the task_id", async () => {
+    const turnId = await bridge.startTaskTurn({ taskId: "task_1", text: "hello" });
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (r) => replies.push(r as never));
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turnId, finalText: "done!" },
+    });
+    await tick(10);
+    expect(replies).toEqual([{ taskId: "task_1", text: "done!" }]);
+    expect(bridge.currentStatus()).toBe("idle");
+    expect(bridge.activeTurn()).toBeNull();
+  });
+
+  test("agentMessage/delta accumulates when server omits finalText", async () => {
+    const turnId = await bridge.startTaskTurn({ taskId: "task_1", text: "hi" });
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (r) => replies.push(r as never));
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { threadId: THREAD, turnId, delta: { text: "hello " } },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { threadId: THREAD, turnId, delta: { text: "world" } },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turnId /* no finalText */ },
+    });
+    await tick(10);
+    expect(replies).toEqual([{ taskId: "task_1", text: "hello world" }]);
+  });
+
+  test("turn/completed for a HUMAN-TUI-initiated turn is dropped (§7.5)", async () => {
+    // No startTaskTurn — bridge has no pending turns.
+    const replies: unknown[] = [];
+    const drops: unknown[] = [];
+    bridge.on("task_reply", (r) => replies.push(r));
+    bridge.on("unowned_turn_drop", (d) => drops.push(d));
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turnId: "turn_human_only", finalText: "human turn text" },
+    });
+    await tick(10);
+    expect(replies).toHaveLength(0);
+    expect(drops).toHaveLength(1);
+  });
+
+  test("events for a DIFFERENT thread are dropped (defense in depth)", async () => {
+    const drops: unknown[] = [];
+    bridge.on("cross_thread_drop", (d) => drops.push(d));
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: "OTHER_THREAD", turnId: "whatever", finalText: "nope" },
+    });
+    await tick(10);
+    expect(drops).toHaveLength(1);
+  });
+
+  test("startTaskTurn refuses a second task while one is active", async () => {
+    await bridge.startTaskTurn({ taskId: "task_a", text: "first" });
+    let caught: Error | null = null;
+    try {
+      await bridge.startTaskTurn({ taskId: "task_b", text: "second" });
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).toContain("active");
+  });
+
+  test("turn/completed with an error field fires task_error, NOT task_reply", async () => {
+    const turnId = await bridge.startTaskTurn({ taskId: "task_1", text: "hi" });
+    const replies: unknown[] = [];
+    const errors: Array<{ taskId: string; error: string }> = [];
+    bridge.on("task_reply", (r) => replies.push(r));
+    bridge.on("task_error", (e) => errors.push(e as never));
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turnId, error: { message: "model unavailable" } },
+    });
+    await tick(10);
+    expect(replies).toHaveLength(0);
+    expect(errors).toEqual([{ taskId: "task_1", error: "model unavailable" }]);
+    expect(bridge.currentStatus()).toBe("idle");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Approval / waiting_human (§7.6)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CodexAppServerBridge — approvals (waiting_human) §7.6", () => {
+  let app: FakeApp;
+  let client: CodexAppServerClient;
+  let bridge: CodexAppServerBridge;
+
+  beforeEach(async () => {
+    app = await startFakeApp();
+    client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+  });
+  afterEach(async () => {
+    await client.close().catch(() => undefined);
+    await app.stop();
+  });
+
+  test("reverse-request approval records waiting_human and sends NO response", async () => {
+    await bridge.startTaskTurn({ taskId: "task_1", text: "run tests" });
+    const initialSentCount = app.received.length;
+    const waits: unknown[] = [];
+    bridge.on("waiting_human", (w) => waits.push(w));
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      id: 501,
+      method: "item/tool/requestApproval",
+      params: { toolName: "shell", command: "rm -rf /" },
+    });
+    await tick(10);
+
+    // Bridge records
+    expect(waits).toHaveLength(1);
+    expect(bridge.isWaitingHuman()).toBe(true);
+    expect(bridge.currentStatus()).toBe("waiting_human");
+
+    // The critical anti-regression: bridge sent NOTHING back to the server
+    // during the approval window. That is what routes the decision to the
+    // human TUI (which is the second client).
+    expect(app.received.length).toBe(initialSentCount);
+  });
+
+  test("serverRequest/resolved clears waiting_human and status recovers", async () => {
+    await bridge.startTaskTurn({ taskId: "task_1", text: "…" });
+    app.broadcast({
+      jsonrpc: "2.0",
+      id: 700,
+      method: "item/tool/requestApproval",
+      params: {},
+    });
+    await tick(10);
+    expect(bridge.currentStatus()).toBe("waiting_human");
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "serverRequest/resolved",
+      params: { reverseRequestId: 700 },
+    });
+    await tick(10);
+    expect(bridge.isWaitingHuman()).toBe(false);
+    expect(bridge.currentStatus()).toBe("working");
+  });
+
+  test("multiple concurrent approvals: bridge stays waiting_human until all resolve", async () => {
+    await bridge.startTaskTurn({ taskId: "task_1", text: "…" });
+    app.broadcast({ jsonrpc: "2.0", id: 800, method: "item/tool/requestApproval", params: {} });
+    app.broadcast({ jsonrpc: "2.0", id: 801, method: "item/tool/requestUserInput", params: {} });
+    await tick(10);
+    expect(bridge.currentStatus()).toBe("waiting_human");
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "serverRequest/resolved",
+      params: { reverseRequestId: 800 },
+    });
+    await tick(10);
+    expect(bridge.currentStatus()).toBe("waiting_human"); // still one open
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "serverRequest/resolved",
+      params: { reverseRequestId: 801 },
+    });
+    await tick(10);
+    expect(bridge.currentStatus()).toBe("working");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Race: two bridges (or a bridge + a TUI) sharing one server (§6.1, §6.3)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CodexAppServerBridge — two-client race for idle", () => {
+  test("only one bridge wins turn/start; the other observes and does not reply", async () => {
+    let firstStartAnswered = false;
+    // Server policy: only one turn per thread at a time. Second concurrent
+    // turn/start gets an error until the first turn/completed is broadcast.
+    let activeTurn: string | null = null;
+    const app = await startFakeApp({
+      onRequest: (msg, respond, _broadcast) => {
+        if (msg.method === "initialize") return respond({ result: {} });
+        if (msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/start") {
+          if (activeTurn) {
+            return respond({
+              error: { code: -32010, message: "thread busy" },
+            });
+          }
+          const turnId = `turn_${msg.id}`;
+          activeTurn = turnId;
+          firstStartAnswered = true;
+          return respond({ result: { turnId } });
+        }
+      },
+    });
+
+    const clientA = new CodexAppServerClient({ url: app.url });
+    const clientB = new CodexAppServerClient({ url: app.url });
+    await clientA.connect();
+    await clientB.connect();
+    const bridgeA = new CodexAppServerBridge({ client: clientA, threadId: THREAD, bridgeLabel: "A" });
+    const bridgeB = new CodexAppServerBridge({ client: clientB, threadId: THREAD, bridgeLabel: "B" });
+    await bridgeA.bootstrap();
+    await bridgeB.bootstrap();
+
+    // Both bridges try to grab the thread at the same time.
+    const results = await Promise.allSettled([
+      bridgeA.startTaskTurn({ taskId: "task_A", text: "A" }),
+      bridgeB.startTaskTurn({ taskId: "task_B", text: "B" }),
+    ]);
+    const wins = results.filter((r) => r.status === "fulfilled").length;
+    const losses = results.filter((r) => r.status === "rejected").length;
+    expect(wins).toBe(1);
+    expect(losses).toBe(1);
+    expect(firstStartAnswered).toBe(true);
+
+    // Now broadcast completion for whichever turn the server assigned.
+    const winningTurnId = activeTurn!;
+    const repliesA: Array<{ taskId: string }> = [];
+    const repliesB: Array<{ taskId: string }> = [];
+    bridgeA.on("task_reply", (r) => repliesA.push(r as never));
+    bridgeB.on("task_reply", (r) => repliesB.push(r as never));
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turnId: winningTurnId, finalText: "shared reply" },
+    });
+    await tick(15);
+
+    // Exactly one bridge should attribute the reply to its own task.
+    const totalReplies = repliesA.length + repliesB.length;
+    expect(totalReplies).toBe(1);
+
+    await clientA.close();
+    await clientB.close();
+    await app.stop();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function tick(ms = 5): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -413,3 +413,154 @@ describe("CodexAppServerBridge — two-client race for idle", () => {
 function tick(ms = 5): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// 通信龙 additions — synchronous claim race fix + submitTask FIFO queue.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
+  test("concurrent startTaskTurn: exactly ONE turn/start reaches the server even with a slow response", async () => {
+    let turnStartCount = 0;
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize") return respond({ result: {} });
+        if (msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/start") {
+          turnStartCount++;
+          // Slow server: respond after 50ms so the pre-response race window
+          // (the original bug) is wide open.
+          setTimeout(() => respond({ result: { turnId: "turn_slow_1" } }), 50);
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+
+    const results = await Promise.allSettled([
+      bridge.startTaskTurn({ taskId: "t-race-1", text: "one" }),
+      bridge.startTaskTurn({ taskId: "t-race-2", text: "two" }),
+    ]);
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled.length).toBe(1);
+    expect(rejected.length).toBe(1);
+    expect(turnStartCount).toBe(1); // the load-bearing assertion: server saw ONE start
+    await client.close();
+    await app.stop();
+  });
+
+  test("submitTask queues the second task and drains it after turn/completed (order preserved)", async () => {
+    let seq = 0;
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize") return respond({ result: {} });
+        if (msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/start") {
+          seq++;
+          respond({ result: { turnId: `turn_q_${seq}` } });
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (r) => replies.push(r as { taskId: string; text: string }));
+    const queued: string[] = [];
+    bridge.on("task_queued", (q) => queued.push((q as { taskId: string }).taskId));
+
+    const r1 = await bridge.submitTask({ taskId: "t-q-1", text: "first" });
+    const r2 = await bridge.submitTask({ taskId: "t-q-2", text: "second" });
+    expect(r1.started).toBe(true);
+    expect(r2.started).toBe(false);
+    expect(queued).toEqual(["t-q-2"]);
+    expect(bridge.queueDepth()).toBe(1);
+
+    // Complete turn 1 → bridge should auto-drain and start turn 2.
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turnId: "turn_q_1", finalText: "answer-1" },
+    });
+    // Wait for the drain's turn/start round-trip.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(bridge.queueDepth()).toBe(0);
+    expect(bridge.activeTurn()).toBe("turn_q_2");
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turnId: "turn_q_2", finalText: "answer-2" },
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(replies.map((r) => r.taskId)).toEqual(["t-q-1", "t-q-2"]);
+    expect(replies.map((r) => r.text)).toEqual(["answer-1", "answer-2"]);
+    expect(bridge.currentStatus()).toBe("idle");
+    await client.close();
+    await app.stop();
+  });
+
+  test("drain losing the idle race requeues at the FRONT and retries on next idle", async () => {
+    let denials = 0;
+    let seq = 0;
+    let denyNext = false;
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize") return respond({ result: {} });
+        if (msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/start") {
+          if (denyNext) {
+            denyNext = false;
+            denials++;
+            return respond({ error: { code: -32009, message: "turn already active" } });
+          }
+          seq++;
+          respond({ result: { turnId: `turn_d_${seq}` } });
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    const deferred: string[] = [];
+    bridge.on("drain_deferred", (d) => deferred.push((d as { taskId: string }).taskId));
+
+    await bridge.submitTask({ taskId: "t-d-1", text: "first" });
+    await bridge.submitTask({ taskId: "t-d-2", text: "second" }); // queued
+    // Human TUI "wins" the next idle: server denies our drain's turn/start.
+    denyNext = true;
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turnId: "turn_d_1", finalText: "a1" },
+    });
+    await new Promise((r) => setTimeout(r, 80));
+    expect(denials).toBe(1);
+    expect(deferred).toEqual(["t-d-2"]); // requeued, not lost
+    expect(bridge.queueDepth()).toBe(1);
+
+    // Simulate the human's turn finishing: we only observe idle again via our
+    // own accounting when OUR turn completes — Phase 0 drains retry on the
+    // next completion event we own. Trigger with a fresh submit+complete.
+    const r3 = await bridge.submitTask({ taskId: "t-d-3", text: "third" });
+    expect(r3.started).toBe(false); // goes behind t-d-2 in FIFO? No — unshift kept t-d-2 first
+    expect(bridge.queueDepth()).toBe(2);
+    // Free the thread: drain starts t-d-2 FIRST (order preserved).
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turnId: "turn_d_999_unknown", finalText: "human turn done" },
+    });
+    // Human turn completed → thread idle → drain starts t-d-2 FIRST (order kept).
+    await new Promise((r) => setTimeout(r, 80));
+    expect(bridge.queueDepth()).toBe(1); // t-d-3 still waiting
+    expect(bridge.activeTurn()).toBe("turn_d_2");
+    await client.close();
+    await app.stop();
+  });
+});

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -78,7 +78,7 @@ async function startFakeApp(config?: {
             } else if (parsed.method === "thread/resume") {
               respond({ result: {} });
             } else if (parsed.method === "turn/start") {
-              respond({ result: { turnId: `turn_${received.length}` } });
+              respond({ result: { turn: { id: `turn_${received.length}` } } });
             }
           }
         }
@@ -150,10 +150,11 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     const turnId = await bridge.startTaskTurn({ taskId: "task_1", text: "hello" });
     const replies: Array<{ taskId: string; text: string }> = [];
     bridge.on("task_reply", (r) => replies.push(r as never));
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId, item: { type: "agentMessage", phase: "final_answer", text: "done!" } } });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: THREAD, turnId, finalText: "done!" },
+      params: { threadId: THREAD, turn: { id: turnId } },
     });
     await tick(10);
     expect(replies).toEqual([{ taskId: "task_1", text: "done!" }]);
@@ -168,17 +169,17 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     app.broadcast({
       jsonrpc: "2.0",
       method: "item/agentMessage/delta",
-      params: { threadId: THREAD, turnId, delta: { text: "hello " } },
+      params: { threadId: THREAD, turnId, delta: "hello " },
     });
     app.broadcast({
       jsonrpc: "2.0",
       method: "item/agentMessage/delta",
-      params: { threadId: THREAD, turnId, delta: { text: "world" } },
+      params: { threadId: THREAD, turnId, delta: "world" },
     });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: THREAD, turnId /* no finalText */ },
+      params: { threadId: THREAD, turn: { id: turnId } },
     });
     await tick(10);
     expect(replies).toEqual([{ taskId: "task_1", text: "hello world" }]);
@@ -190,10 +191,11 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     const drops: unknown[] = [];
     bridge.on("task_reply", (r) => replies.push(r));
     bridge.on("unowned_turn_drop", (d) => drops.push(d));
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_human_only", item: { type: "agentMessage", phase: "final_answer", text: "human turn text" } } });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: THREAD, turnId: "turn_human_only", finalText: "human turn text" },
+      params: { threadId: THREAD, turn: { id: "turn_human_only" } },
     });
     await tick(10);
     expect(replies).toHaveLength(0);
@@ -203,10 +205,11 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
   test("events for a DIFFERENT thread are dropped (defense in depth)", async () => {
     const drops: unknown[] = [];
     bridge.on("cross_thread_drop", (d) => drops.push(d));
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: "OTHER_THREAD", turnId: "whatever", item: { type: "agentMessage", phase: "final_answer", text: "nope" } } });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: "OTHER_THREAD", turnId: "whatever", finalText: "nope" },
+      params: { threadId: "OTHER_THREAD", turn: { id: "whatever" } },
     });
     await tick(10);
     expect(drops).toHaveLength(1);
@@ -233,7 +236,7 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: THREAD, turnId, error: { message: "model unavailable" } },
+      params: { threadId: THREAD, turn: { id: turnId, error: { message: "model unavailable" } } },
     });
     await tick(10);
     expect(replies).toHaveLength(0);
@@ -389,10 +392,11 @@ describe("CodexAppServerBridge — two-client race for idle", () => {
     bridgeA.on("task_reply", (r) => repliesA.push(r as never));
     bridgeB.on("task_reply", (r) => repliesB.push(r as never));
 
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: winningTurnId, item: { type: "agentMessage", phase: "final_answer", text: "shared reply" } } });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: THREAD, turnId: winningTurnId, finalText: "shared reply" },
+      params: { threadId: THREAD, turn: { id: winningTurnId } },
     });
     await tick(15);
 
@@ -429,7 +433,7 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
           turnStartCount++;
           // Slow server: respond after 50ms so the pre-response race window
           // (the original bug) is wide open.
-          setTimeout(() => respond({ result: { turnId: "turn_slow_1" } }), 50);
+          setTimeout(() => respond({ result: { turn: { id: "turn_slow_1" } } }), 50);
         }
       },
     });
@@ -459,7 +463,7 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
         if (msg.method === "thread/resume") return respond({ result: {} });
         if (msg.method === "turn/start") {
           seq++;
-          respond({ result: { turnId: `turn_q_${seq}` } });
+          respond({ result: { turn: { id: `turn_q_${seq}` } } });
         }
       },
     });
@@ -481,20 +485,22 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     expect(bridge.queueDepth()).toBe(1);
 
     // Complete turn 1 → bridge should auto-drain and start turn 2.
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_q_1", item: { type: "agentMessage", phase: "final_answer", text: "answer-1" } } });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: THREAD, turnId: "turn_q_1", finalText: "answer-1" },
+      params: { threadId: THREAD, turn: { id: "turn_q_1" } },
     });
     // Wait for the drain's turn/start round-trip.
     await new Promise((r) => setTimeout(r, 80));
     expect(bridge.queueDepth()).toBe(0);
     expect(bridge.activeTurn()).toBe("turn_q_2");
 
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_q_2", item: { type: "agentMessage", phase: "final_answer", text: "answer-2" } } });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: THREAD, turnId: "turn_q_2", finalText: "answer-2" },
+      params: { threadId: THREAD, turn: { id: "turn_q_2" } },
     });
     await new Promise((r) => setTimeout(r, 30));
     expect(replies.map((r) => r.taskId)).toEqual(["t-q-1", "t-q-2"]);
@@ -519,7 +525,7 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
             return respond({ error: { code: -32009, message: "turn already active" } });
           }
           seq++;
-          respond({ result: { turnId: `turn_d_${seq}` } });
+          respond({ result: { turn: { id: `turn_d_${seq}` } } });
         }
       },
     });
@@ -534,10 +540,11 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     await bridge.submitTask({ taskId: "t-d-2", text: "second" }); // queued
     // Human TUI "wins" the next idle: server denies our drain's turn/start.
     denyNext = true;
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_d_1", item: { type: "agentMessage", phase: "final_answer", text: "a1" } } });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: THREAD, turnId: "turn_d_1", finalText: "a1" },
+      params: { threadId: THREAD, turn: { id: "turn_d_1" } },
     });
     await new Promise((r) => setTimeout(r, 80));
     expect(denials).toBe(1);
@@ -551,10 +558,11 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     expect(r3.started).toBe(false); // goes behind t-d-2 in FIFO? No — unshift kept t-d-2 first
     expect(bridge.queueDepth()).toBe(2);
     // Free the thread: drain starts t-d-2 FIRST (order preserved).
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_d_999_unknown", item: { type: "agentMessage", phase: "final_answer", text: "human turn done" } } });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
-      params: { threadId: THREAD, turnId: "turn_d_999_unknown", finalText: "human turn done" },
+      params: { threadId: THREAD, turn: { id: "turn_d_999_unknown" } },
     });
     // Human turn completed → thread idle → drain starts t-d-2 FIRST (order kept).
     await new Promise((r) => setTimeout(r, 80));

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -77,6 +77,8 @@ async function startFakeApp(config?: {
               respond({ result: { serverInfo: { name: "fake-codex" } } });
             } else if (parsed.method === "thread/resume") {
               respond({ result: {} });
+            } else if (parsed.method === "thread/start") {
+              respond({ result: { threadId: "thread_new_xyz" } });
             } else if (parsed.method === "turn/start") {
               respond({ result: { turn: { id: `turn_${received.length}` } } });
             }
@@ -136,6 +138,45 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
       .filter(Boolean);
     expect(methods).toEqual(["initialize", "initialized", "thread/resume"]);
     expect(bridge.currentStatus()).toBe("idle");
+  });
+
+  test("empty threadId → bootstrap creates a thread (thread/start) and adopts its id", async () => {
+    const app2 = await startFakeApp();
+    const client2 = new CodexAppServerClient({ url: app2.url });
+    await client2.connect();
+    const bridge2 = new CodexAppServerBridge({ client: client2 }); // no threadId
+    const ready: Array<{ threadId: string; created: boolean }> = [];
+    bridge2.on("thread_ready", (e) => ready.push(e as never));
+    await bridge2.bootstrap();
+    const methods = app2.received.map((m) => (m as { method?: string }).method).filter(Boolean);
+    expect(methods).toEqual(["initialize", "initialized", "thread/start"]);
+    expect(bridge2.getThreadId()).toBe("thread_new_xyz");
+    expect(ready).toEqual([{ threadId: "thread_new_xyz", created: true }]);
+    expect(bridge2.currentStatus()).toBe("idle");
+    await client2.close().catch(() => undefined);
+    await app2.stop();
+  });
+
+  test("stale threadId with no rollout → resume fails, bootstrap falls back to thread/start", async () => {
+    const app2 = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize") return respond({ result: {} });
+        if (msg.method === "thread/resume")
+          return respond({ error: { code: -32600, message: "no rollout found for thread id stale_id" } });
+        if (msg.method === "thread/start") return respond({ result: { threadId: "thread_fresh" } });
+      },
+    });
+    const client2 = new CodexAppServerClient({ url: app2.url });
+    await client2.connect();
+    const bridge2 = new CodexAppServerBridge({ client: client2, threadId: "stale_id" });
+    const ready: Array<{ threadId: string; created: boolean }> = [];
+    bridge2.on("thread_ready", (e) => ready.push(e as never));
+    await bridge2.bootstrap();
+    expect(bridge2.getThreadId()).toBe("thread_fresh");
+    expect(ready).toEqual([{ threadId: "thread_fresh", created: true }]);
+    expect(bridge2.currentStatus()).toBe("idle");
+    await client2.close().catch(() => undefined);
+    await app2.stop();
   });
 
   test("startTaskTurn returns the server-assigned turnId and marks bridge working", async () => {

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -1,0 +1,328 @@
+// RFC-030 Phase 0 — Minimal bridge for the shared-thread PoC.
+//
+// The bridge:
+//   - Owns a single CodexAppServerClient connection.
+//   - Binds one persistent thread (via `thread/resume`).
+//   - Maps each Agent Network task_id ↔ one Codex `turnId`.
+//   - Filters incoming events to the configured thread and `pendingTurns`
+//     the bridge itself created (per RFC §7.5).
+//   - Records `waiting_human` when a reverse request arrives, WITHOUT
+//     responding — approvals belong to the human TUI (§7.6).
+//   - Emits `task_reply` with the final agent text mapped back to the
+//     originating `task_id` when its turn completes.
+//
+// Scope discipline (通信龙): Phase 0 is a PoC only. This bridge deliberately
+// does NOT:
+//   - Persist a durable ledger (§9 is Phase 2).
+//   - Reconnect on transport loss (Phase 1 will add `thread/resume` retry).
+//   - Wire into CommHub / cli.ts (§8.4 is Phase 1).
+//   - Steer / cancel / interrupt (§7.4 is future scope).
+//   - Run a tool proxy (§8.6 later).
+
+import { EventEmitter } from "events";
+import { CodexAppServerClient } from "./codex-app-server-client";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Public shapes
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface CodexAppServerBridgeOptions {
+  client: CodexAppServerClient;
+  /** Persistent thread ID this bridge binds to (from node config). */
+  threadId: string;
+  /** Optional label for logs. */
+  bridgeLabel?: string;
+}
+
+export type BridgeStatus =
+  | "connecting"
+  | "idle"
+  | "working"
+  | "waiting_human"
+  | "offline";
+
+export interface PendingTurn {
+  taskId: string;
+  clientUserMessageId: string;
+  submittedAt: number;
+  turnId?: string;
+  agentTextChunks: string[];
+}
+
+export interface WaitingApproval {
+  reverseRequestId: number;
+  method: string;
+  params: unknown;
+  observedAt: number;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Bridge
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Events:
+ *   - "status_changed"    → { previous, current }
+ *   - "waiting_human"     → WaitingApproval (bridge did not respond)
+ *   - "approval_resolved" → { reverseRequestId } — from serverRequest/resolved
+ *   - "task_reply"        → { taskId, text }  — final agent message
+ *   - "task_error"        → { taskId, error }
+ *   - "cross_thread_drop" → { event } — event for a thread we don't own
+ *   - "unowned_turn_drop" → { turnId, event } — turn started outside this bridge
+ */
+export class CodexAppServerBridge extends EventEmitter {
+  private client: CodexAppServerClient;
+  private readonly threadId: string;
+  private readonly label: string;
+  private status: BridgeStatus = "connecting";
+  private activeTurnId: string | null = null;
+  private pendingTurns = new Map<string, PendingTurn>();
+  /** Reverse-request ids we've observed but not resolved (bridge policy). */
+  private waitingApprovals = new Map<number, WaitingApproval>();
+
+  constructor(opts: CodexAppServerBridgeOptions) {
+    super();
+    this.client = opts.client;
+    this.threadId = opts.threadId;
+    this.label = opts.bridgeLabel ?? `bridge:${this.threadId.slice(0, 8)}`;
+    this.attachClientListeners();
+  }
+
+  /** Perform initialize → initialized → thread/resume. */
+  async bootstrap(): Promise<void> {
+    // Initialize handshake per RFC §7.2. The response is not used here beyond
+    // ensuring the server accepted us.
+    await this.client.request("initialize", {
+      clientInfo: {
+        name: "anet_codex_bridge",
+        title: "Agent Network Codex Bridge",
+        version: "0.1.0",
+      },
+    });
+    this.client.notify("initialized", {});
+    await this.client.request("thread/resume", { threadId: this.threadId });
+    this.setStatus("idle");
+  }
+
+  /**
+   * Start a turn for an Agent Network task. Returns the turnId the server
+   * assigned. The final agent reply is delivered later via `task_reply`.
+   */
+  async startTaskTurn(input: {
+    taskId: string;
+    text: string;
+    from?: string;
+  }): Promise<string> {
+    // Bridge discipline: one active turn at a time. Phase 0 queueing lives in
+    // the caller (per RFC §6.3 — scheduling is bridge-external for now). If
+    // callers race we surface it as an error rather than pretending to queue.
+    if (this.activeTurnId) {
+      throw new Error(
+        `${this.label}: refusing to start turn for task=${input.taskId} while turn=${this.activeTurnId} active`,
+      );
+    }
+    const clientUserMessageId = `anet:${input.taskId}`;
+    const promptPrefix = input.from ? `[Agent Network/from=${input.from}/task=${input.taskId}] ` : `[Agent Network/task=${input.taskId}] `;
+    const pending: PendingTurn = {
+      taskId: input.taskId,
+      clientUserMessageId,
+      submittedAt: Date.now(),
+      agentTextChunks: [],
+    };
+    // Optimistically claim active so a concurrent call races cleanly.
+    this.setStatus("working");
+
+    let resp: unknown;
+    try {
+      resp = await this.client.request("turn/start", {
+        threadId: this.threadId,
+        clientUserMessageId,
+        input: [{ type: "text", text: promptPrefix + input.text }],
+      });
+    } catch (e) {
+      this.setStatus("idle");
+      throw e;
+    }
+    const turnId = extractTurnId(resp);
+    if (!turnId) {
+      this.setStatus("idle");
+      throw new Error(
+        `${this.label}: turn/start response did not include a turnId (task=${input.taskId})`,
+      );
+    }
+    pending.turnId = turnId;
+    this.pendingTurns.set(turnId, pending);
+    this.activeTurnId = turnId;
+    return turnId;
+  }
+
+  /** Read-only accessors (for testing / observability). */
+  currentStatus(): BridgeStatus {
+    return this.status;
+  }
+  activeTurn(): string | null {
+    return this.activeTurnId;
+  }
+  pendingTurnCount(): number {
+    return this.pendingTurns.size;
+  }
+  isWaitingHuman(): boolean {
+    return this.waitingApprovals.size > 0;
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Internals
+  // ──────────────────────────────────────────────────────────────────────
+
+  private attachClientListeners(): void {
+    // Notifications we care about (§7.5). We use `.on(method)` rather than
+    // parsing a single "notification" stream because the client dispatches
+    // notifications on their method name.
+    this.client.on("thread/status/changed", (params) => this.onStatusChanged(params));
+    this.client.on("turn/started", (params) => this.onTurnStarted(params));
+    this.client.on("item/started", (params) => this.onItemStarted(params));
+    this.client.on("item/agentMessage/delta", (params) => this.onAgentDelta(params));
+    this.client.on("item/completed", (params) => this.onItemCompleted(params));
+    this.client.on("turn/completed", (params) => this.onTurnCompleted(params));
+    this.client.on("error", (err) => this.emit("client_error", err));
+    this.client.on("serverRequest/resolved", (params) => this.onApprovalResolved(params));
+
+    // Reverse requests: approvals must NOT be answered by this bridge.
+    this.client.on("reverse_request", (rr: { id: number; method: string; params: unknown }) =>
+      this.onReverseRequest(rr),
+    );
+
+    this.client.on("close", () => this.setStatus("offline"));
+  }
+
+  private onReverseRequest(rr: { id: number; method: string; params: unknown }): void {
+    // The set of methods that indicate a human decision. We deliberately
+    // widen this to anything that looks like an approval or user-input
+    // request, per §7.6. Non-matching reverse requests are still recorded
+    // (Phase 0 policy: don't respond to *anything* until a later phase
+    // gates specific tool methods through a proxy).
+    const waiting: WaitingApproval = {
+      reverseRequestId: rr.id,
+      method: rr.method,
+      params: rr.params,
+      observedAt: Date.now(),
+    };
+    this.waitingApprovals.set(rr.id, waiting);
+    this.setStatus("waiting_human");
+    this.emit("waiting_human", waiting);
+  }
+
+  private onApprovalResolved(params: unknown): void {
+    // Server broadcasts `serverRequest/resolved` once *any* subscriber
+    // responded. We just clean up our tracking and (if no more approvals
+    // are outstanding, and a turn is active) return to working.
+    const resolvedId = extractReverseRequestId(params);
+    if (resolvedId === null) return;
+    if (!this.waitingApprovals.delete(resolvedId)) return;
+    this.emit("approval_resolved", { reverseRequestId: resolvedId });
+    if (this.waitingApprovals.size === 0) {
+      if (this.activeTurnId) this.setStatus("working");
+      else this.setStatus("idle");
+    }
+  }
+
+  private onStatusChanged(_params: unknown): void {
+    // Phase 0 relies on the bridge's own accounting (activeTurnId +
+    // waitingApprovals) rather than trusting server-reported status. But
+    // we still forward as an event for observability.
+    this.emit("status_notification", _params);
+  }
+
+  private onTurnStarted(params: unknown): void {
+    // Filter: turns started by other subscribers (the human TUI) must not
+    // touch bridge accounting.
+    const p = params as { threadId?: string; turnId?: string };
+    if (!p || p.threadId !== this.threadId) {
+      this.emit("cross_thread_drop", { event: "turn/started", params });
+      return;
+    }
+    if (!p.turnId) return;
+    if (!this.pendingTurns.has(p.turnId)) {
+      // A turn we didn't start (§7.5 rule). Emit for observability, but
+      // do not touch status or claim ownership.
+      this.emit("unowned_turn_drop", { turnId: p.turnId, event: "turn/started" });
+      return;
+    }
+  }
+
+  private onItemStarted(_params: unknown): void {
+    // No-op in Phase 0. Real bridge will use item ids to gate approval
+    // acceptance in later phases.
+  }
+
+  private onAgentDelta(params: unknown): void {
+    const p = params as { threadId?: string; turnId?: string; delta?: { text?: string } };
+    if (!p || p.threadId !== this.threadId) return;
+    if (!p.turnId) return;
+    const pending = this.pendingTurns.get(p.turnId);
+    if (!pending) return; // Not our turn — human TUI is receiving deltas too.
+    if (typeof p.delta?.text === "string") pending.agentTextChunks.push(p.delta.text);
+  }
+
+  private onItemCompleted(_params: unknown): void {
+    // No-op in Phase 0.
+  }
+
+  private onTurnCompleted(params: unknown): void {
+    const p = params as {
+      threadId?: string;
+      turnId?: string;
+      finalText?: string;
+      error?: { message?: string };
+    };
+    if (!p || p.threadId !== this.threadId) {
+      this.emit("cross_thread_drop", { event: "turn/completed", params });
+      return;
+    }
+    if (!p.turnId) return;
+    const pending = this.pendingTurns.get(p.turnId);
+    if (!pending) {
+      // Human-TUI-initiated turn completed. Absolutely no reply mapping.
+      this.emit("unowned_turn_drop", { turnId: p.turnId, event: "turn/completed" });
+      return;
+    }
+    this.pendingTurns.delete(p.turnId);
+    if (this.activeTurnId === p.turnId) {
+      this.activeTurnId = null;
+      this.setStatus(this.waitingApprovals.size > 0 ? "waiting_human" : "idle");
+    }
+    if (p.error?.message) {
+      this.emit("task_error", { taskId: pending.taskId, error: p.error.message });
+      return;
+    }
+    const text = typeof p.finalText === "string" && p.finalText.length > 0
+      ? p.finalText
+      : pending.agentTextChunks.join("");
+    this.emit("task_reply", { taskId: pending.taskId, text });
+  }
+
+  private setStatus(next: BridgeStatus): void {
+    if (this.status === next) return;
+    const previous = this.status;
+    this.status = next;
+    this.emit("status_changed", { previous, current: next });
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Field extractors — defensive against schema drift.
+// ────────────────────────────────────────────────────────────────────────────
+
+function extractTurnId(resp: unknown): string | null {
+  if (!resp || typeof resp !== "object") return null;
+  const r = resp as { turnId?: unknown };
+  return typeof r.turnId === "string" ? r.turnId : null;
+}
+
+function extractReverseRequestId(params: unknown): number | null {
+  if (!params || typeof params !== "object") return null;
+  const p = params as { reverseRequestId?: unknown; requestId?: unknown };
+  if (typeof p.reverseRequestId === "number") return p.reverseRequestId;
+  if (typeof p.requestId === "number") return p.requestId;
+  return null;
+}

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -76,9 +76,24 @@ export class CodexAppServerBridge extends EventEmitter {
   private readonly label: string;
   private status: BridgeStatus = "connecting";
   private activeTurnId: string | null = null;
+  /**
+   * Synchronous claim taken BEFORE the `turn/start` RPC round-trip.
+   * `activeTurnId` alone is insufficient as a mutual-exclusion guard: it is
+   * only assigned after the server responds, so two concurrent
+   * `startTaskTurn` calls could both pass the `activeTurnId === null` check
+   * and double-start (通信龙 review finding #1).
+   */
+  private turnClaimed = false;
   private pendingTurns = new Map<string, PendingTurn>();
   /** Reverse-request ids we've observed but not resolved (bridge policy). */
   private waitingApprovals = new Map<number, WaitingApproval>();
+  /**
+   * FIFO of tasks waiting for the thread to go idle (通信龙 review finding #2;
+   * RFC §6.3 — Phase 0 gate requires the second concurrent task to queue
+   * stably rather than error). Drained on turn completion/error.
+   */
+  private taskQueue: Array<{ taskId: string; text: string; from?: string }> = [];
+  private draining = false;
 
   constructor(opts: CodexAppServerBridgeOptions) {
     super();
@@ -113,14 +128,16 @@ export class CodexAppServerBridge extends EventEmitter {
     text: string;
     from?: string;
   }): Promise<string> {
-    // Bridge discipline: one active turn at a time. Phase 0 queueing lives in
-    // the caller (per RFC §6.3 — scheduling is bridge-external for now). If
-    // callers race we surface it as an error rather than pretending to queue.
-    if (this.activeTurnId) {
+    // Bridge discipline: one active turn at a time. The claim is taken
+    // SYNCHRONOUSLY (before any await) so concurrent callers race cleanly:
+    // exactly one proceeds, the rest throw. Queueing callers should use
+    // `submitTask()` instead of this low-level primitive.
+    if (this.turnClaimed || this.activeTurnId) {
       throw new Error(
-        `${this.label}: refusing to start turn for task=${input.taskId} while turn=${this.activeTurnId} active`,
+        `${this.label}: refusing to start turn for task=${input.taskId} while turn=${this.activeTurnId ?? "(starting)"} active`,
       );
     }
+    this.turnClaimed = true;
     const clientUserMessageId = `anet:${input.taskId}`;
     const promptPrefix = input.from ? `[Agent Network/from=${input.from}/task=${input.taskId}] ` : `[Agent Network/task=${input.taskId}] `;
     const pending: PendingTurn = {
@@ -140,11 +157,13 @@ export class CodexAppServerBridge extends EventEmitter {
         input: [{ type: "text", text: promptPrefix + input.text }],
       });
     } catch (e) {
+      this.turnClaimed = false;
       this.setStatus("idle");
       throw e;
     }
     const turnId = extractTurnId(resp);
     if (!turnId) {
+      this.turnClaimed = false;
       this.setStatus("idle");
       throw new Error(
         `${this.label}: turn/start response did not include a turnId (task=${input.taskId})`,
@@ -154,6 +173,51 @@ export class CodexAppServerBridge extends EventEmitter {
     this.pendingTurns.set(turnId, pending);
     this.activeTurnId = turnId;
     return turnId;
+  }
+
+  /**
+   * Queueing entry point (Phase 0 gate: "两个 Agent 同时派 task，只创建一个
+   * active turn，另一个稳定排队"). If the thread is free the task starts
+   * immediately; otherwise it joins a FIFO drained on turn completion/error.
+   *
+   * Human-priority note (§6.1): the bridge only ever starts a turn when the
+   * shared thread is idle from ITS point of view; if the human TUI wins the
+   * idle race, `turn/start` fails with an active-turn error and the task is
+   * requeued at the FRONT (original order preserved) — the app-server is the
+   * authority (§6.3).
+   */
+  async submitTask(input: { taskId: string; text: string; from?: string }): Promise<
+    { started: true; turnId: string } | { started: false; queuedAt: number }
+  > {
+    if (this.turnClaimed || this.activeTurnId || this.taskQueue.length > 0) {
+      this.taskQueue.push(input);
+      this.emit("task_queued", { taskId: input.taskId, depth: this.taskQueue.length });
+      return { started: false, queuedAt: this.taskQueue.length };
+    }
+    const turnId = await this.startTaskTurn(input);
+    return { started: true, turnId };
+  }
+
+  /** Drain the FIFO after a turn finishes. One task per idle transition. */
+  private async drainQueue(): Promise<void> {
+    if (this.draining) return;
+    if (this.turnClaimed || this.activeTurnId) return;
+    const next = this.taskQueue.shift();
+    if (!next) return;
+    this.draining = true;
+    try {
+      await this.startTaskTurn(next);
+    } catch (e) {
+      // Lost the idle race to the human TUI (or transport error). Requeue at
+      // the FRONT to preserve order; retry on the next idle transition.
+      this.taskQueue.unshift(next);
+      this.emit("drain_deferred", {
+        taskId: next.taskId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      this.draining = false;
+    }
   }
 
   /** Read-only accessors (for testing / observability). */
@@ -192,7 +256,13 @@ export class CodexAppServerBridge extends EventEmitter {
       this.onReverseRequest(rr),
     );
 
-    this.client.on("close", () => this.setStatus("offline"));
+    this.client.on("close", () => {
+      // Transport gone: release the claim so a future reconnect (Phase 1)
+      // can restart cleanly. Queue is intentionally preserved — those tasks
+      // were never accepted by the server.
+      this.turnClaimed = false;
+      this.setStatus("offline");
+    });
   }
 
   private onReverseRequest(rr: { id: number; method: string; params: unknown }): void {
@@ -282,23 +352,34 @@ export class CodexAppServerBridge extends EventEmitter {
     if (!p.turnId) return;
     const pending = this.pendingTurns.get(p.turnId);
     if (!pending) {
-      // Human-TUI-initiated turn completed. Absolutely no reply mapping.
+      // Human-TUI-initiated turn completed. Absolutely no reply mapping —
+      // but the thread just went idle, so queued Agent tasks may proceed
+      // (§6.1: human input had its priority; FIFO resumes after).
       this.emit("unowned_turn_drop", { turnId: p.turnId, event: "turn/completed" });
+      void this.drainQueue();
       return;
     }
     this.pendingTurns.delete(p.turnId);
     if (this.activeTurnId === p.turnId) {
       this.activeTurnId = null;
+      this.turnClaimed = false;
       this.setStatus(this.waitingApprovals.size > 0 ? "waiting_human" : "idle");
     }
     if (p.error?.message) {
       this.emit("task_error", { taskId: pending.taskId, error: p.error.message });
-      return;
+    } else {
+      const text = typeof p.finalText === "string" && p.finalText.length > 0
+        ? p.finalText
+        : pending.agentTextChunks.join("");
+      this.emit("task_reply", { taskId: pending.taskId, text });
     }
-    const text = typeof p.finalText === "string" && p.finalText.length > 0
-      ? p.finalText
-      : pending.agentTextChunks.join("");
-    this.emit("task_reply", { taskId: pending.taskId, text });
+    // Either way the thread just went idle from our perspective → drain FIFO.
+    void this.drainQueue();
+  }
+
+  /** Read-only queue depth (for tests / observability). */
+  queueDepth(): number {
+    return this.taskQueue.length;
   }
 
   private setStatus(next: BridgeStatus): void {

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -103,18 +103,32 @@ export class CodexAppServerBridge extends EventEmitter {
     this.attachClientListeners();
   }
 
-  /** Perform initialize → initialized → thread/resume. */
+  /**
+   * Perform initialize → initialized → thread/resume.
+   *
+   * REAL-WIRE CORRECTION (通信龙, verified against codex-cli 0.144.0 live
+   * two-client PoC): `initialize` is scoped to the **app-server**, NOT to
+   * each connection. When the human TUI (`codex --remote`) has already
+   * initialized the shared server, a second client's `initialize` returns
+   * `-32600: Already initialized`. RFC §7.2's "每个连接必须单独初始化" is
+   * wrong for the shared-server topology — the bridge tolerates an
+   * already-initialized server and proceeds straight to `thread/resume`.
+   */
   async bootstrap(): Promise<void> {
-    // Initialize handshake per RFC §7.2. The response is not used here beyond
-    // ensuring the server accepted us.
-    await this.client.request("initialize", {
-      clientInfo: {
-        name: "anet_codex_bridge",
-        title: "Agent Network Codex Bridge",
-        version: "0.1.0",
-      },
-    });
-    this.client.notify("initialized", {});
+    try {
+      await this.client.request("initialize", {
+        clientInfo: {
+          name: "anet_codex_bridge",
+          title: "Agent Network Codex Bridge",
+          version: "0.1.0",
+        },
+      });
+      this.client.notify("initialized", {});
+    } catch (e) {
+      if (!isAlreadyInitialized(e)) throw e;
+      // Shared server already initialized by the human TUI — expected in the
+      // second-client bridge role. Do NOT re-send `initialized`.
+    }
     await this.client.request("thread/resume", { threadId: this.threadId });
     this.setStatus("idle");
   }
@@ -398,6 +412,14 @@ function extractTurnId(resp: unknown): string | null {
   if (!resp || typeof resp !== "object") return null;
   const r = resp as { turnId?: unknown };
   return typeof r.turnId === "string" ? r.turnId : null;
+}
+
+/** Recognise the app-server's "already initialized" rejection (shared server). */
+function isAlreadyInitialized(e: unknown): boolean {
+  const code = (e as { code?: unknown })?.code;
+  const msg = (e as { message?: unknown })?.message;
+  if (code === -32600) return true;
+  return typeof msg === "string" && /already initialized/i.test(msg);
 }
 
 function extractReverseRequestId(params: unknown): number | null {

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -318,18 +318,17 @@ export class CodexAppServerBridge extends EventEmitter {
   }
 
   private onTurnStarted(params: unknown): void {
-    // Filter: turns started by other subscribers (the human TUI) must not
-    // touch bridge accounting.
-    const p = params as { threadId?: string; turnId?: string };
+    // REAL-WIRE: turn/started params = { threadId, turn: { id, status, … } }.
+    const p = params as { threadId?: string };
     if (!p || p.threadId !== this.threadId) {
       this.emit("cross_thread_drop", { event: "turn/started", params });
       return;
     }
-    if (!p.turnId) return;
-    if (!this.pendingTurns.has(p.turnId)) {
-      // A turn we didn't start (§7.5 rule). Emit for observability, but
-      // do not touch status or claim ownership.
-      this.emit("unowned_turn_drop", { turnId: p.turnId, event: "turn/started" });
+    const turnId = extractTurnId(params);
+    if (!turnId) return;
+    if (!this.pendingTurns.has(turnId)) {
+      // A turn we didn't start (§7.5 rule) — e.g. the human TUI. Observe only.
+      this.emit("unowned_turn_drop", { turnId, event: "turn/started" });
       return;
     }
   }
@@ -340,50 +339,72 @@ export class CodexAppServerBridge extends EventEmitter {
   }
 
   private onAgentDelta(params: unknown): void {
-    const p = params as { threadId?: string; turnId?: string; delta?: { text?: string } };
+    // REAL-WIRE: item/agentMessage/delta = { threadId, turnId, itemId, delta }
+    // where `delta` is a plain string (NOT { text }).
+    const p = params as { threadId?: string; turnId?: string; delta?: unknown };
     if (!p || p.threadId !== this.threadId) return;
-    if (!p.turnId) return;
+    if (typeof p.turnId !== "string") return;
     const pending = this.pendingTurns.get(p.turnId);
     if (!pending) return; // Not our turn — human TUI is receiving deltas too.
-    if (typeof p.delta?.text === "string") pending.agentTextChunks.push(p.delta.text);
+    if (typeof p.delta === "string") pending.agentTextChunks.push(p.delta);
   }
 
-  private onItemCompleted(_params: unknown): void {
-    // No-op in Phase 0.
-  }
-
-  private onTurnCompleted(params: unknown): void {
+  private onItemCompleted(params: unknown): void {
+    // REAL-WIRE: item/completed = { item: { type, text, phase, … }, threadId,
+    // turnId }. The final agent answer is the agentMessage item with
+    // phase === "final_answer". Capture it as the authoritative reply text.
     const p = params as {
       threadId?: string;
       turnId?: string;
-      finalText?: string;
-      error?: { message?: string };
+      item?: { type?: string; text?: string; phase?: string };
+    };
+    if (!p || p.threadId !== this.threadId) return;
+    if (typeof p.turnId !== "string") return;
+    const pending = this.pendingTurns.get(p.turnId);
+    if (!pending) return;
+    if (
+      p.item?.type === "agentMessage" &&
+      p.item.phase === "final_answer" &&
+      typeof p.item.text === "string"
+    ) {
+      pending.finalText = p.item.text;
+    }
+  }
+
+  private onTurnCompleted(params: unknown): void {
+    // REAL-WIRE: turn/completed = { threadId, turn: { id, status, error, … } }.
+    const p = params as {
+      threadId?: string;
+      turn?: { id?: string; status?: string; error?: { message?: string } | null };
     };
     if (!p || p.threadId !== this.threadId) {
       this.emit("cross_thread_drop", { event: "turn/completed", params });
       return;
     }
-    if (!p.turnId) return;
-    const pending = this.pendingTurns.get(p.turnId);
+    const turnId = extractTurnId(params);
+    if (!turnId) return;
+    const pending = this.pendingTurns.get(turnId);
     if (!pending) {
       // Human-TUI-initiated turn completed. Absolutely no reply mapping —
       // but the thread just went idle, so queued Agent tasks may proceed
       // (§6.1: human input had its priority; FIFO resumes after).
-      this.emit("unowned_turn_drop", { turnId: p.turnId, event: "turn/completed" });
+      this.emit("unowned_turn_drop", { turnId, event: "turn/completed" });
       void this.drainQueue();
       return;
     }
-    this.pendingTurns.delete(p.turnId);
-    if (this.activeTurnId === p.turnId) {
+    this.pendingTurns.delete(turnId);
+    if (this.activeTurnId === turnId) {
       this.activeTurnId = null;
       this.turnClaimed = false;
       this.setStatus(this.waitingApprovals.size > 0 ? "waiting_human" : "idle");
     }
-    if (p.error?.message) {
-      this.emit("task_error", { taskId: pending.taskId, error: p.error.message });
+    const turnErr = p.turn?.error?.message;
+    if (turnErr) {
+      this.emit("task_error", { taskId: pending.taskId, error: turnErr });
     } else {
-      const text = typeof p.finalText === "string" && p.finalText.length > 0
-        ? p.finalText
+      // Prefer the captured final_answer item; fall back to accumulated deltas.
+      const text = pending.finalText && pending.finalText.length > 0
+        ? pending.finalText
         : pending.agentTextChunks.join("");
       this.emit("task_reply", { taskId: pending.taskId, text });
     }
@@ -408,10 +429,15 @@ export class CodexAppServerBridge extends EventEmitter {
 // Field extractors — defensive against schema drift.
 // ────────────────────────────────────────────────────────────────────────────
 
-function extractTurnId(resp: unknown): string | null {
-  if (!resp || typeof resp !== "object") return null;
-  const r = resp as { turnId?: unknown };
-  return typeof r.turnId === "string" ? r.turnId : null;
+// REAL-WIRE (codex-cli 0.144.0): turn/start response and turn/{started,completed}
+// events nest the id under `turn.id`; only item-level events use a flat
+// `turnId`. Accept both so this survives either surface.
+function extractTurnId(v: unknown): string | null {
+  if (!v || typeof v !== "object") return null;
+  const o = v as { turn?: { id?: unknown }; turnId?: unknown };
+  if (o.turn && typeof o.turn === "object" && typeof o.turn.id === "string") return o.turn.id;
+  if (typeof o.turnId === "string") return o.turnId;
+  return null;
 }
 
 /** Recognise the app-server's "already initialized" rejection (shared server). */

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -28,8 +28,14 @@ import { CodexAppServerClient } from "./codex-app-server-client";
 
 export interface CodexAppServerBridgeOptions {
   client: CodexAppServerClient;
-  /** Persistent thread ID this bridge binds to (from node config). */
-  threadId: string;
+  /**
+   * Persistent thread ID this bridge binds to (from node config). Leave
+   * empty/undefined to have `bootstrap()` create a fresh thread and adopt
+   * its id (network-runtime mode, where the bridge owns the thread). A
+   * non-empty id is resumed; if the resume fails because the thread has no
+   * persisted rollout yet, bootstrap falls back to creating a new one.
+   */
+  threadId?: string;
   /** Optional label for logs. */
   bridgeLabel?: string;
 }
@@ -72,7 +78,7 @@ export interface WaitingApproval {
  */
 export class CodexAppServerBridge extends EventEmitter {
   private client: CodexAppServerClient;
-  private readonly threadId: string;
+  private threadId: string;
   private readonly label: string;
   private status: BridgeStatus = "connecting";
   private activeTurnId: string | null = null;
@@ -98,13 +104,18 @@ export class CodexAppServerBridge extends EventEmitter {
   constructor(opts: CodexAppServerBridgeOptions) {
     super();
     this.client = opts.client;
-    this.threadId = opts.threadId;
-    this.label = opts.bridgeLabel ?? `bridge:${this.threadId.slice(0, 8)}`;
+    this.threadId = opts.threadId ?? "";
+    this.label = opts.bridgeLabel ?? `bridge:${(this.threadId || "new").slice(0, 8)}`;
     this.attachClientListeners();
   }
 
+  /** The thread this bridge is bound to (final id after bootstrap adoption). */
+  getThreadId(): string {
+    return this.threadId;
+  }
+
   /**
-   * Perform initialize → initialized → thread/resume.
+   * Perform initialize → initialized → (thread/resume | thread/start).
    *
    * REAL-WIRE CORRECTION (通信龙, verified against codex-cli 0.144.0 live
    * two-client PoC): `initialize` is scoped to the **app-server**, NOT to
@@ -112,7 +123,17 @@ export class CodexAppServerBridge extends EventEmitter {
    * initialized the shared server, a second client's `initialize` returns
    * `-32600: Already initialized`. RFC §7.2's "每个连接必须单独初始化" is
    * wrong for the shared-server topology — the bridge tolerates an
-   * already-initialized server and proceeds straight to `thread/resume`.
+   * already-initialized server and proceeds straight to thread binding.
+   *
+   * Thread binding is create-or-resume (mirrors the opencode runtime's
+   * session/load-else-new):
+   *   - empty threadId → thread/start, adopt the returned id.
+   *   - non-empty threadId → thread/resume; if that fails because the
+   *     thread has no persisted rollout yet ("no rollout found"), fall
+   *     back to thread/start so a stale/never-persisted id can't wedge
+   *     the node at boot.
+   * Emits "thread_ready" { threadId, created } so the runtime can persist
+   * a freshly-created id back to node config.
    */
   async bootstrap(): Promise<void> {
     try {
@@ -129,8 +150,39 @@ export class CodexAppServerBridge extends EventEmitter {
       // Shared server already initialized by the human TUI — expected in the
       // second-client bridge role. Do NOT re-send `initialized`.
     }
-    await this.client.request("thread/resume", { threadId: this.threadId });
+
+    let created = false;
+    if (this.threadId) {
+      try {
+        await this.client.request("thread/resume", { threadId: this.threadId });
+      } catch (e) {
+        if (!isNoRollout(e)) throw e;
+        // Persisted id never got a rollout (e.g. node created but never ran
+        // a turn) — create a fresh thread rather than wedging at boot.
+        this.threadId = await this.startNewThread();
+        created = true;
+      }
+    } else {
+      this.threadId = await this.startNewThread();
+      created = true;
+    }
+
+    this.emit("thread_ready", { threadId: this.threadId, created });
     this.setStatus("idle");
+  }
+
+  private async startNewThread(): Promise<string> {
+    const started = await this.client.request<{
+      threadId?: string;
+      thread?: { id?: string };
+    }>("thread/start", {});
+    const id = started?.threadId ?? started?.thread?.id;
+    if (!id) {
+      throw new Error(
+        "thread/start returned no threadId: " + JSON.stringify(started).slice(0, 200),
+      );
+    }
+    return id;
   }
 
   /**
@@ -446,6 +498,12 @@ function isAlreadyInitialized(e: unknown): boolean {
   const msg = (e as { message?: unknown })?.message;
   if (code === -32600) return true;
   return typeof msg === "string" && /already initialized/i.test(msg);
+}
+
+/** thread/resume against an id the app-server has no persisted rollout for. */
+function isNoRollout(e: unknown): boolean {
+  const msg = (e as { message?: unknown })?.message;
+  return typeof msg === "string" && /no rollout found|thread not found|unknown thread/i.test(msg);
 }
 
 function extractReverseRequestId(params: unknown): number | null {

--- a/agent-node/src/runtime/codex-app-server-client.test.ts
+++ b/agent-node/src/runtime/codex-app-server-client.test.ts
@@ -1,0 +1,241 @@
+// RFC-030 Phase 0 — dispatch correctness tests for CodexAppServerClient.
+//
+// The load-bearing question: does the client route a message that carries
+// BOTH `method` and `id` (a reverse request) to the `reverse_request` path
+// instead of the response/orphan path? That's the bug in codex-stdio-client.ts
+// (line ~145) that we must not repeat.
+//
+// These tests exercise the client's internal dispatch via a fake WS. We do
+// not spawn a real `codex app-server` here — that lives in the docker smoke.
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { CodexAppServerClient } from "./codex-app-server-client";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fake WebSocket server on loopback. Small helper to avoid pulling in `ws`.
+// ────────────────────────────────────────────────────────────────────────────
+
+interface FakeServer {
+  url: string;
+  connections: Set<{ send: (s: string) => void }>;
+  received: string[];
+  broadcast: (msg: object) => void;
+  stop: () => Promise<void>;
+}
+
+async function startFakeServer(): Promise<FakeServer> {
+  const received: string[] = [];
+  const connections = new Set<{ send: (s: string) => void }>();
+  // Use Bun.serve — matches the agent-node runtime.
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, srv) {
+      if (srv.upgrade(req)) return undefined;
+      return new Response("upgrade required", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        const handle = { send: (s: string) => ws.send(s) };
+        connections.add(handle);
+        (ws as unknown as { data: { handle: { send: (s: string) => void } } }).data = { handle };
+      },
+      message(_ws, msg) {
+        received.push(typeof msg === "string" ? msg : String(msg));
+      },
+      close(ws) {
+        const handle = (ws as unknown as { data?: { handle?: { send: (s: string) => void } } }).data?.handle;
+        if (handle) connections.delete(handle);
+      },
+    },
+  });
+  return {
+    url: `ws://127.0.0.1:${server.port}`,
+    connections,
+    received,
+    broadcast: (obj: object) => {
+      const line = JSON.stringify(obj);
+      for (const c of connections) c.send(line);
+    },
+    stop: async () => {
+      server.stop(true);
+    },
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CodexAppServerClient — dispatch correctness (RFC-030 §7 + bug fix)", () => {
+  let server: FakeServer;
+  let client: CodexAppServerClient;
+
+  beforeEach(async () => {
+    server = await startFakeServer();
+    client = new CodexAppServerClient({ url: server.url });
+    await client.connect();
+  });
+  afterEach(async () => {
+    await client.close().catch(() => undefined);
+    await server.stop();
+  });
+
+  test("reverse request (method + id) routes to `reverse_request`, NOT orphan_response", async () => {
+    // This is the exact bug pattern the RFC calls out: codex-stdio-client.ts
+    // checks id first and would treat this as an orphan response.
+    const rrEvents: Array<{ id: number; method: string; params: unknown }> = [];
+    const orphans: unknown[] = [];
+    client.on("reverse_request", (rr) => rrEvents.push(rr as never));
+    client.on("orphan_response", (msg) => orphans.push(msg));
+
+    server.broadcast({
+      jsonrpc: "2.0",
+      id: 999,
+      method: "item/tool/requestApproval",
+      params: { toolName: "shell", command: "rm -rf /" },
+    });
+    await tick();
+
+    expect(rrEvents).toHaveLength(1);
+    expect(rrEvents[0].id).toBe(999);
+    expect(rrEvents[0].method).toBe("item/tool/requestApproval");
+    expect((rrEvents[0].params as { toolName: string }).toolName).toBe("shell");
+    expect(orphans).toHaveLength(0);
+  });
+
+  test("reverse request also fires `reverse:<method>` targeted event", async () => {
+    const hit: Array<{ id: number; params: unknown }> = [];
+    client.on("reverse:item/tool/requestApproval", (ev) => hit.push(ev as never));
+    server.broadcast({ jsonrpc: "2.0", id: 42, method: "item/tool/requestApproval", params: {} });
+    await tick();
+    expect(hit).toHaveLength(1);
+    expect(hit[0].id).toBe(42);
+  });
+
+  test("notification (method + no id) routes to method-keyed event", async () => {
+    const deltas: Array<{ text: string }> = [];
+    const generic: unknown[] = [];
+    client.on("item/agentMessage/delta", (p) => deltas.push(p as { text: string }));
+    client.on("notification", (n) => generic.push(n));
+    server.broadcast({ jsonrpc: "2.0", method: "item/agentMessage/delta", params: { text: "hi" } });
+    await tick();
+    expect(deltas).toEqual([{ text: "hi" }]);
+    expect(generic).toHaveLength(1);
+  });
+
+  test("response (id + result) resolves the matching pending request", async () => {
+    // Route: client sends a request; server replies with matching id.
+    const respPromise = client.request<{ ok: true }>("initialize", { clientInfo: {} });
+    await tick();
+    expect(server.received.length).toBeGreaterThan(0);
+    const req = JSON.parse(server.received[0]);
+    expect(req.method).toBe("initialize");
+    expect(req.id).toBeTypeOf("number");
+    server.broadcast({ jsonrpc: "2.0", id: req.id, result: { ok: true } });
+    const resp = await respPromise;
+    expect(resp).toEqual({ ok: true });
+  });
+
+  test("response (id + error) rejects with codex-formatted Error", async () => {
+    const respPromise = client.request("thread/resume", { threadId: "not-real" });
+    await tick();
+    const req = JSON.parse(server.received[0]);
+    server.broadcast({
+      jsonrpc: "2.0",
+      id: req.id,
+      error: { code: -32001, message: "unknown thread" },
+    });
+    let caught: Error | null = null;
+    try {
+      await respPromise;
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).toContain("-32001");
+    expect(caught!.message).toContain("unknown thread");
+    // The pending method name should be included so callers can grep by call site.
+    expect(caught!.message).toContain("thread/resume");
+  });
+
+  test("orphan response (id present, no matching pending) fires `orphan_response`", async () => {
+    const orphans: unknown[] = [];
+    client.on("orphan_response", (m) => orphans.push(m));
+    server.broadcast({ jsonrpc: "2.0", id: 99999, result: { unrelated: true } });
+    await tick();
+    expect(orphans).toHaveLength(1);
+  });
+
+  test("malformed messages fire `malformed`", async () => {
+    const bad: unknown[] = [];
+    client.on("malformed", (m) => bad.push(m));
+    // No id, no method — nothing dispatchable.
+    server.broadcast({ jsonrpc: "2.0", garbage: true });
+    await tick();
+    expect(bad).toHaveLength(1);
+  });
+
+  test("parse errors on non-JSON payload fire `parse_error`", async () => {
+    // We need the server to send raw non-JSON. Reach into a connection.
+    const errors: Array<{ line: string; error: unknown }> = [];
+    client.on("parse_error", (e) => errors.push(e as never));
+    for (const c of server.connections) c.send("this is not json {[");
+    await tick();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].line).toContain("not json");
+  });
+
+  test("request timeout rejects the pending promise and cleans up the entry", async () => {
+    const p = client.request("thread/resume", { threadId: "never-answered" }, 40);
+    let caught: Error | null = null;
+    try {
+      await p;
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).toContain("timed out");
+  });
+
+  test("close rejects any in-flight request cleanly (no unhandled rejection)", async () => {
+    const p = client.request("thread/resume", { threadId: "will-be-cut-off" }, 5_000);
+    // Server never answers; we close.
+    await client.close();
+    let caught: Error | null = null;
+    try {
+      await p;
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).toContain("closed");
+  });
+
+  test("respondToReverseRequest emits a well-formed response envelope", async () => {
+    // The bridge policy is to NOT respond in Phase 0, but the primitive
+    // still has to exist for later phases and must round-trip cleanly.
+    server.broadcast({ jsonrpc: "2.0", id: 7, method: "tool/proxy/invoke", params: {} });
+    await tick();
+    client.respondToReverseRequest(7, { ok: true, output: "done" });
+    await tick();
+    const last = server.received[server.received.length - 1];
+    const parsed = JSON.parse(last);
+    expect(parsed).toEqual({ jsonrpc: "2.0", id: 7, result: { ok: true, output: "done" } });
+  });
+
+  test("errorReverseRequest emits a JSON-RPC error envelope", async () => {
+    client.errorReverseRequest(8, -32000, "not permitted", { hint: "no perms" });
+    await tick();
+    const last = server.received[server.received.length - 1];
+    const parsed = JSON.parse(last);
+    expect(parsed.error.code).toBe(-32000);
+    expect(parsed.error.message).toBe("not permitted");
+    expect(parsed.error.data.hint).toBe("no perms");
+  });
+});
+
+// A tiny helper — Bun's WebSocket delivers on the next microtask. We yield
+// two macrotasks to be safe on slower CI runners.
+function tick(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 5));
+}

--- a/agent-node/src/runtime/codex-app-server-client.ts
+++ b/agent-node/src/runtime/codex-app-server-client.ts
@@ -1,0 +1,356 @@
+// RFC-030 Phase 0 — WebSocket JSON-RPC client for `codex app-server`.
+//
+// Independent runtime for the shared-thread bridge (human TUI + agent both
+// connected to the same `codex app-server`). Not a codex-sdk transport wrapper;
+// agent-node is the second app-server client alongside `codex --remote`.
+//
+// Why this exists (not a fork of codex-stdio-client.ts): `app-server` sends
+// **reverse requests** — JSON-RPC calls FROM the server TO the client, most
+// notably approval prompts. Those messages carry BOTH `method` AND `id`. The
+// existing stdio client's `dispatch()` (codex-stdio-client.ts around line 145)
+// tests `id !== undefined && id !== null` first, tries to look the id up in
+// its own pending map, misses, and emits `orphan_response` — silently
+// dropping the reverse request. That path is fine for stdio (which the RFC
+// notes doesn't use reverse requests today) but wrong for app-server.
+//
+// Dispatch order in this client:
+//   1. `method` string present + `id` present → reverse request from server.
+//      Emit `reverse_request` with { id, method, params }. The bridge decides
+//      whether/how to respond. Phase 0 bridge NEVER responds (approvals must
+//      come from the human TUI); it just records `waiting_human`.
+//   2. `method` string present + `id` absent → notification. Emit on the
+//      method name + a generic `notification` event.
+//   3. `id` present with `result` or `error` → response. Match against pending.
+//   4. Anything else → `malformed`.
+//
+// Global `WebSocket` (Node 20+, Bun). No `ws` dependency added.
+
+import { EventEmitter } from "events";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Wire types (subset). Field names camelCase per Codex serde convention.
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface JsonRpcRequest<P = unknown> {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: P;
+}
+
+export interface JsonRpcSuccess<R = unknown> {
+  jsonrpc?: "2.0";
+  id: number;
+  result: R;
+}
+
+export interface JsonRpcErrorMsg {
+  jsonrpc?: "2.0";
+  id: number;
+  error: { code: number; message: string; data?: unknown };
+}
+
+export interface JsonRpcNotification<P = unknown> {
+  jsonrpc?: "2.0";
+  method: string;
+  params?: P;
+}
+
+/** Server-initiated request (a JSON-RPC "call" from server to client). */
+export interface JsonRpcReverseRequest<P = unknown> {
+  jsonrpc?: "2.0";
+  id: number;
+  method: string;
+  params?: P;
+}
+
+type IncomingMsg =
+  | JsonRpcSuccess
+  | JsonRpcErrorMsg
+  | JsonRpcNotification
+  | JsonRpcReverseRequest;
+
+export interface CodexAppServerClientOptions {
+  /** Full URL: `ws://127.0.0.1:4500` or `wss://…`. Loopback only in Phase 0. */
+  url: string;
+  /** Optional bearer / capability token; sent as `Authorization: Bearer …`. */
+  authToken?: string;
+  /** Default per-request timeout (ms). */
+  defaultTimeoutMs?: number;
+  /** Debug label for logs / errors. */
+  clientLabel?: string;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Client
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Events emitted:
+ *   - "open"                        → WS connection established
+ *   - "close"                       → { code, reason }
+ *   - "error"                       → Error (transport-level)
+ *   - "parse_error"                 → { line, error }
+ *   - "malformed"                   → raw message that didn't fit any shape
+ *   - "orphan_response"             → response with no matching pending id
+ *   - "notification"                → raw notification envelope
+ *   - <method>                      → notification's params, keyed by method
+ *   - "reverse_request"             → { id, method, params } — server called us
+ *
+ * The bridge listens for `reverse_request`, records `waiting_human` on
+ * approval methods, and does NOT call `respondToReverseRequest` in Phase 0.
+ * A helper is provided for later phases when we do want to answer
+ * (`tool/*` for the local tool proxy, once that exists).
+ */
+export class CodexAppServerClient extends EventEmitter {
+  private ws: WebSocket | null = null;
+  private nextId = 1;
+  private pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void; method: string }
+  >();
+  private closed = false;
+  private readonly opts: CodexAppServerClientOptions;
+  private readonly defaultTimeoutMs: number;
+
+  constructor(opts: CodexAppServerClientOptions) {
+    super();
+    this.opts = opts;
+    this.defaultTimeoutMs = opts.defaultTimeoutMs ?? 30_000;
+  }
+
+  /** Open the WebSocket. Resolves on `open`; rejects on first `error`. */
+  async connect(): Promise<void> {
+    if (this.ws) throw new Error("CodexAppServerClient already connected");
+    const headers: Record<string, string> = {};
+    if (this.opts.authToken) headers.Authorization = `Bearer ${this.opts.authToken}`;
+    // The global WebSocket ctor supports (url) or (url, protocols). Header
+    // injection isn't standardized on the browser API; we rely on Node/Bun's
+    // WebSocket, which accepts an options bag as the third argument. If the
+    // runtime doesn't, callers should embed the token in the URL query.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const WS: any = (globalThis as any).WebSocket;
+    if (typeof WS !== "function") {
+      throw new Error(
+        "global WebSocket is not available — need Node 20+ or Bun",
+      );
+    }
+    this.ws = new WS(this.opts.url, undefined, headers.Authorization ? { headers } : undefined);
+
+    return new Promise<void>((resolve, reject) => {
+      const onOpen = () => {
+        this.ws!.removeEventListener("error", onErrorInit);
+        this.emit("open");
+        resolve();
+      };
+      const onErrorInit = (ev: Event) => {
+        // Extract a useful message from the DOM event when possible.
+        const err = extractError(ev, `connect ${this.opts.url}`);
+        this.ws!.removeEventListener("open", onOpen);
+        reject(err);
+      };
+      this.ws!.addEventListener("open", onOpen, { once: true });
+      this.ws!.addEventListener("error", onErrorInit, { once: true });
+
+      // Steady-state handlers (installed regardless of connect outcome).
+      this.ws!.addEventListener("message", (ev: MessageEvent) => {
+        this.onMessage(String(ev.data));
+      });
+      this.ws!.addEventListener("close", (ev: CloseEvent) => {
+        this.closed = true;
+        this.emit("close", { code: ev.code, reason: ev.reason });
+        for (const [, p] of this.pending) {
+          p.reject(new Error(`codex app-server closed (code=${ev.code} reason=${ev.reason})`));
+        }
+        this.pending.clear();
+      });
+      this.ws!.addEventListener("error", (ev: Event) => {
+        this.emit("error", extractError(ev, "ws steady-state"));
+      });
+    });
+  }
+
+  /** Send a JSON-RPC request and await response. */
+  async request<R = unknown, P = unknown>(
+    method: string,
+    params?: P,
+    timeoutMs?: number,
+  ): Promise<R> {
+    if (!this.ws || this.closed) {
+      throw new Error("CodexAppServerClient not connected or already closed");
+    }
+    const id = this.nextId++;
+    const payload: JsonRpcRequest<P> = {
+      jsonrpc: "2.0",
+      id,
+      method,
+      ...(params !== undefined ? { params } : {}),
+    };
+    const to = timeoutMs ?? this.defaultTimeoutMs;
+    return new Promise<R>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`codex request '${method}' (id=${id}) timed out after ${to}ms`));
+      }, to);
+      this.pending.set(id, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolve(v as R);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+        method,
+      });
+      try {
+        this.ws!.send(JSON.stringify(payload));
+      } catch (e) {
+        this.pending.delete(id);
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+  }
+
+  /** Send a JSON-RPC notification (no response expected). */
+  notify<P = unknown>(method: string, params?: P): void {
+    if (!this.ws || this.closed) {
+      throw new Error("CodexAppServerClient not connected or already closed");
+    }
+    const payload: JsonRpcNotification<P> = {
+      jsonrpc: "2.0",
+      method,
+      ...(params !== undefined ? { params } : {}),
+    };
+    this.ws.send(JSON.stringify(payload));
+  }
+
+  /**
+   * Respond to a **reverse request** from the server. Phase 0 bridge MUST
+   * NOT call this for approvals — the human TUI is the sole approver. It is
+   * exposed here for later phases (tool proxy, etc.). Refusing to expose the
+   * primitive would just push callers to reach into `ws.send` themselves.
+   */
+  respondToReverseRequest<R = unknown>(id: number, result: R): void {
+    if (!this.ws || this.closed) {
+      throw new Error("CodexAppServerClient not connected or already closed");
+    }
+    this.ws.send(JSON.stringify({ jsonrpc: "2.0", id, result }));
+  }
+
+  /** Error-form response to a reverse request (also gated to bridge policy). */
+  errorReverseRequest(id: number, code: number, message: string, data?: unknown): void {
+    if (!this.ws || this.closed) {
+      throw new Error("CodexAppServerClient not connected or already closed");
+    }
+    this.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        error: { code, message, ...(data !== undefined ? { data } : {}) },
+      }),
+    );
+  }
+
+  /** Graceful close. Any in-flight requests reject with a close error. */
+  async close(code?: number, reason?: string): Promise<void> {
+    if (!this.ws || this.closed) return;
+    return new Promise<void>((resolve) => {
+      this.ws!.addEventListener("close", () => resolve(), { once: true });
+      try {
+        this.ws!.close(code, reason);
+      } catch {
+        resolve();
+      }
+    });
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Wire handling
+  // ──────────────────────────────────────────────────────────────────────
+
+  private onMessage(raw: string): void {
+    let msg: IncomingMsg;
+    try {
+      msg = JSON.parse(raw) as IncomingMsg;
+    } catch (e) {
+      this.emit("parse_error", { line: raw, error: e });
+      return;
+    }
+    this.dispatch(msg);
+  }
+
+  /**
+   * See the file header for the full ordering rationale. Summary:
+   *   method + id → reverse request
+   *   method     → notification
+   *   id (+ result | error) → response
+   */
+  private dispatch(msg: IncomingMsg): void {
+    const hasMethod = "method" in msg && typeof (msg as { method: unknown }).method === "string";
+    const idField = "id" in msg ? (msg as { id: unknown }).id : undefined;
+    const hasId = idField !== undefined && idField !== null;
+
+    if (hasMethod && hasId) {
+      // Reverse request from server.
+      const rr = msg as JsonRpcReverseRequest;
+      this.emit("reverse_request", { id: rr.id, method: rr.method, params: rr.params });
+      // Also emit on the method name for method-specific listeners.
+      this.emit(`reverse:${rr.method}`, { id: rr.id, params: rr.params });
+      return;
+    }
+
+    if (hasMethod && !hasId) {
+      // Notification.
+      const n = msg as JsonRpcNotification;
+      this.emit(n.method, n.params);
+      this.emit("notification", n);
+      return;
+    }
+
+    if (hasId) {
+      // Response.
+      const id = idField as number;
+      const pending = this.pending.get(id);
+      if (!pending) {
+        this.emit("orphan_response", msg);
+        return;
+      }
+      this.pending.delete(id);
+      if ("error" in msg && (msg as JsonRpcErrorMsg).error) {
+        const err = msg as JsonRpcErrorMsg;
+        const e = new Error(
+          `codex JSON-RPC error ${err.error.code}: ${err.error.message} (method=${pending.method})`,
+        );
+        (e as Error & { code?: number; data?: unknown }).code = err.error.code;
+        (e as Error & { code?: number; data?: unknown }).data = err.error.data;
+        pending.reject(e);
+      } else if ("result" in msg) {
+        pending.resolve((msg as JsonRpcSuccess).result);
+      } else {
+        pending.reject(
+          new Error(
+            `codex JSON-RPC response (id=${id}, method=${pending.method}) missing both result and error`,
+          ),
+        );
+      }
+      return;
+    }
+
+    this.emit("malformed", msg);
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function extractError(ev: Event, context: string): Error {
+  // Node/Bun WebSocket often surface the underlying error via `.error`
+  // property on the event; browser API doesn't.
+  const anyEv = ev as unknown as { error?: unknown; message?: unknown };
+  if (anyEv.error instanceof Error) return anyEv.error;
+  if (typeof anyEv.message === "string") return new Error(`${context}: ${anyEv.message}`);
+  return new Error(`${context}: WebSocket error`);
+}

--- a/agent-node/src/runtime/codex-app-server-client.ts
+++ b/agent-node/src/runtime/codex-app-server-client.ts
@@ -119,6 +119,11 @@ export class CodexAppServerClient extends EventEmitter {
     this.defaultTimeoutMs = opts.defaultTimeoutMs ?? 30_000;
   }
 
+  /** True while the socket is open (constructed and not yet closed). */
+  get isConnected(): boolean {
+    return !!this.ws && !this.closed;
+  }
+
   /** Open the WebSocket. Resolves on `open`; rejects on first `error`. */
   async connect(): Promise<void> {
     if (this.ws) throw new Error("CodexAppServerClient already connected");

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -1,0 +1,187 @@
+// RFC-030 — codex-app-server runtime.
+//
+// Long-running session holder that owns (or attaches to) a `codex
+// app-server` and drives turns through the CodexAppServerBridge. Mirrors
+// the opencode-acp runtime's lifecycle contract (open once on boot / after
+// a supervisor restart; `think` per turn).
+//
+// Two topologies:
+//   1. Owned server (default). We spawn `codex app-server --listen ws://…`
+//      on an ephemeral localhost port and the bridge owns a fresh thread.
+//   2. Shared server (ANET_CODEX_APP_SERVER_URL set). We connect to an
+//      already-running app-server — e.g. one a human `codex --remote` TUI
+//      is also attached to — and resume the configured thread. The bridge
+//      is the SECOND client; it never answers approvals (human TUI only).
+//
+// The bridge only wraps "run one codex turn". Inbound tasks arrive via the
+// normal CommHub inbox (cli.ts), and replies go back out via the normal
+// CommHub `send_task` — the runtime just returns the final text.
+
+import { spawn, type ChildProcess } from "child_process";
+import { CodexAppServerClient } from "../codex-app-server-client";
+import { CodexAppServerBridge } from "../codex-app-server-bridge";
+
+export interface CodexAppServerRuntimeSession {
+  client: CodexAppServerClient;
+  bridge: CodexAppServerBridge;
+  /** The child app-server we spawned, or null when attached to a shared one. */
+  proc: ChildProcess | null;
+  /** The thread the bridge is bound to (final id after create-or-resume). */
+  threadId: string;
+  get isRunning(): boolean;
+}
+
+function randomPort(): number {
+  // Ephemeral-ish localhost range; collisions are retried by the caller.
+  return 24000 + Math.floor(Math.random() * 4000);
+}
+
+async function waitWs(url: string, tries = 60, gapMs = 300): Promise<void> {
+  for (let i = 0; i < tries; i++) {
+    try {
+      const c = new WebSocket(url);
+      await new Promise<void>((res, rej) => {
+        c.onopen = () => res();
+        c.onerror = (e) => rej(e);
+      });
+      c.close();
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, gapMs));
+    }
+  }
+  throw new Error(`codex app-server WS never came up: ${url}`);
+}
+
+/**
+ * Open (or attach to) a codex app-server and bind a bridge to a thread.
+ * Persisted threadId is resumed; empty/stale falls back to a fresh thread
+ * (see CodexAppServerBridge.bootstrap). `onThread` fires with a
+ * freshly-created id so the caller can persist it back to node config.
+ */
+export async function openCodexAppServerRuntime(opts: {
+  /** Attach to this app-server instead of spawning one (shared-TUI mode). */
+  serverUrl?: string;
+  /** Persisted thread id from node config; empty → create a fresh thread. */
+  threadId?: string;
+  /** codex binary (default "codex"); honored only when we spawn. */
+  binary?: string;
+  onThread?: (threadId: string, created: boolean) => void | Promise<void>;
+  onExit?: (info: { code: number | null; signal: NodeJS.Signals | null }) => void;
+  log?: (msg: string) => void;
+  warn?: (msg: string) => void;
+}): Promise<CodexAppServerRuntimeSession> {
+  const log = opts.log ?? ((m: string) => console.log(m));
+  const warn = opts.warn ?? ((m: string) => console.warn(m));
+
+  let proc: ChildProcess | null = null;
+  let url = opts.serverUrl;
+
+  if (!url) {
+    // Owned-server topology: spawn `codex app-server --listen ws://…`.
+    const port = randomPort();
+    url = `ws://127.0.0.1:${port}`;
+    const binary = opts.binary ?? "codex";
+    log(`[codex-app-server] spawning ${binary} app-server --listen ${url}`);
+    proc = spawn(binary, ["app-server", "--listen", url], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    proc.stderr?.on("data", (d) =>
+      log(`[codex-app-server stderr] ${String(d).trim().slice(0, 300)}`),
+    );
+    if (opts.onExit) proc.on("exit", (code, signal) => opts.onExit!({ code, signal }));
+    await waitWs(url);
+  } else {
+    log(`[codex-app-server] attaching to shared server ${url}`);
+  }
+
+  const client = new CodexAppServerClient({ url, clientLabel: "anet_codex_bridge" });
+  client.on("error", (e) => warn(`[codex-app-server] client error: ${String(e).slice(0, 200)}`));
+  await client.connect();
+
+  const bridge = new CodexAppServerBridge({ client, threadId: opts.threadId });
+  bridge.on("thread_ready", (e: { threadId: string; created: boolean }) => {
+    if (e.created) {
+      log(`[codex-app-server] created thread ${e.threadId.slice(0, 12)}…`);
+    } else {
+      log(`[codex-app-server] resumed thread ${e.threadId.slice(0, 12)}…`);
+    }
+    if (opts.onThread) void opts.onThread(e.threadId, e.created);
+  });
+  bridge.on("waiting_human", () =>
+    warn(`[codex-app-server] turn is waiting on a human approval — bridge will NOT answer`),
+  );
+  await bridge.bootstrap();
+
+  return {
+    client,
+    bridge,
+    proc,
+    threadId: bridge.getThreadId(),
+    get isRunning() {
+      // Owned server: the child must be alive. Shared server: rely on the
+      // ws client's connection state.
+      if (proc) return proc.exitCode === null && !proc.killed;
+      return client.isConnected;
+    },
+  };
+}
+
+export interface CodexAppServerThinkResult {
+  replyText: string;
+  failed: boolean;
+  queued: boolean;
+}
+
+/**
+ * Run one Agent Network task through the bridge. Submits the task (which
+ * queues FIFO if a turn is already in flight) and resolves when THIS task's
+ * final answer (task_reply) or error (task_error) arrives.
+ */
+export function codexAppServerThink(
+  session: CodexAppServerRuntimeSession,
+  opts: { taskId: string; text: string; from?: string; timeoutMs?: number; log?: (m: string) => void },
+): Promise<CodexAppServerThinkResult> {
+  const timeoutMs = opts.timeoutMs ?? 10 * 60_000;
+  const log = opts.log ?? (() => {});
+  const { bridge } = session;
+
+  return new Promise<CodexAppServerThinkResult>((resolve) => {
+    let settled = false;
+    const finish = (r: CodexAppServerThinkResult) => {
+      if (settled) return;
+      settled = true;
+      bridge.off("task_reply", onReply);
+      bridge.off("task_error", onError);
+      clearTimeout(timer);
+      resolve(r);
+    };
+    const onReply = (ev: { taskId: string; text: string }) => {
+      if (ev.taskId !== opts.taskId) return;
+      log(`[codex-app-server] task_reply ${ev.taskId} (${ev.text.length}ch)`);
+      finish({ replyText: ev.text, failed: false, queued: false });
+    };
+    const onError = (ev: { taskId: string; error: string }) => {
+      if (ev.taskId !== opts.taskId) return;
+      log(`[codex-app-server] task_error ${ev.taskId}: ${ev.error}`);
+      finish({ replyText: `codex-app-server 错误: ${ev.error}`, failed: true, queued: false });
+    };
+    const timer = setTimeout(() => {
+      finish({
+        replyText: `codex-app-server 错误: 任务 ${opts.taskId} 超时（${Math.round(timeoutMs / 1000)}s 内无最终回复）`,
+        failed: true,
+        queued: false,
+      });
+    }, timeoutMs);
+
+    bridge.on("task_reply", onReply);
+    bridge.on("task_error", onError);
+
+    bridge
+      .submitTask({ taskId: opts.taskId, text: opts.text, from: opts.from })
+      .then((r) => {
+        if (!r.started) log(`[codex-app-server] task ${opts.taskId} queued (a turn is in flight)`);
+      })
+      .catch((e) => finish({ replyText: `codex-app-server 错误: ${e?.message ?? e}`, failed: true, queued: false }));
+  });
+}

--- a/agent-node/tests/rfc-030-commhub-e2e.ts
+++ b/agent-node/tests/rfc-030-commhub-e2e.ts
@@ -1,0 +1,218 @@
+// RFC-030 — CommHub network closed-loop e2e (Vincent's #1 demand).
+//
+// Proves the REAL network loop end-to-end, all against an ISOLATED hub
+// (never production):
+//
+//   [测试派单 node] --send_task--> hub --inbox--> [codex桥 node]
+//        └── bridge.submitTask ─> codex app-server turn ─> final answer
+//        └── send_task(reply) --> hub --inbox--> [测试派单 node] ✅
+//
+// Vincent constraint: BOTH directions use `send_task` (not send_reply) so
+// the reply lands as a pushed, visible task the originator actually receives.
+//
+// Isolation: fresh `codex app-server` on a random port + fresh commhub-server
+// on a random port + throwaway SQLite in /tmp. Two node identities minted via
+// real register→login→network→node-token. Nothing touches dm.vansin.top / :9200.
+//
+// Run: bun tests/rfc-030-commhub-e2e.ts        (time-boxed 150s, hard exit)
+
+import { spawn, type ChildProcess } from "child_process";
+import { mkdirSync } from "fs";
+import { CodexAppServerClient } from "../src/runtime/codex-app-server-client";
+import { CodexAppServerBridge } from "../src/runtime/codex-app-server-bridge";
+
+const rnd = (lo: number, hi: number) => lo + Math.floor(Math.random() * (hi - lo));
+const HUB_PORT = rnd(29300, 29900);
+const WS_PORT = rnd(24300, 24900);
+const HUB = `http://127.0.0.1:${HUB_PORT}`;
+const WS = `ws://127.0.0.1:${WS_PORT}`;
+const DB_DIR = `/tmp/rfc030-e2e-${HUB_PORT}`;
+mkdirSync(DB_DIR, { recursive: true });
+const DB = `${DB_DIR}/hub.db`;
+const REPO = new URL("../../", import.meta.url).pathname; // .../rfc030-work/
+
+const BRIDGE_ALIAS = "codex桥";
+const SENDER_ALIAS = "测试派单";
+
+const kids: ChildProcess[] = [];
+function die(code: number, msg: string): never {
+  console.log(msg);
+  for (const k of kids) { try { k.kill("SIGKILL"); } catch {} }
+  process.exit(code);
+}
+const T = setTimeout(() => die(1, "E2E TIMEOUT 150s"), 150_000);
+const dbg = (...a: unknown[]) => process.env.E2E_DEBUG && console.log(...a);
+
+// ── REST / MCP helpers ──────────────────────────────────────────────────────
+async function rest(path: string, method: string, body?: unknown, token?: string) {
+  const res = await fetch(`${HUB}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, json: json as any };
+}
+
+async function mcp(token: string, name: string, args: Record<string, unknown>) {
+  const res = await fetch(`${HUB}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: Date.now(),
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+  const raw = await res.text();
+  const m = raw.match(/data: (.+)/);
+  const data = m ? JSON.parse(m[1]) : JSON.parse(raw || "{}");
+  // Unwrap MCP tool result → the JSON the tool returned.
+  const txt = data?.result?.content?.[0]?.text;
+  let payload: any = data?.result ?? data;
+  if (typeof txt === "string") { try { payload = JSON.parse(txt); } catch { payload = txt; } }
+  if (data?.error) throw new Error(`mcp ${name}: ${JSON.stringify(data.error)}`);
+  return payload;
+}
+
+async function waitHttp(url: string, ok: (s: number) => boolean) {
+  for (let i = 0; i < 60; i++) {
+    try { const r = await fetch(url); if (ok(r.status)) return; } catch {}
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`never healthy: ${url}`);
+}
+async function waitWs(url: string) {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const c = new WebSocket(url);
+      await new Promise((res, rej) => { c.onopen = res; c.onerror = rej; });
+      c.close(); return;
+    } catch { await new Promise((r) => setTimeout(r, 300)); }
+  }
+  throw new Error(`app-server WS never up: ${url}`);
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+(async () => {
+  // 1. Boot isolated hub + isolated codex app-server.
+  const hub = spawn("bun", [`${REPO}server/bin/commhub.ts`, "--port", String(HUB_PORT), "--db", DB], {
+    stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, PORT: String(HUB_PORT), COMMHUB_DB: DB },
+  });
+  kids.push(hub);
+  hub.stderr!.on("data", (d) => dbg("[hub!]", String(d).trim().slice(0, 200)));
+
+  const appsrv = spawn("codex", ["app-server", "--listen", WS], { stdio: ["ignore", "pipe", "pipe"] });
+  kids.push(appsrv);
+  appsrv.stderr!.on("data", (d) => dbg("[appsrv!]", String(d).trim().slice(0, 160)));
+
+  await waitHttp(`${HUB}/health`, (s) => s === 200);
+  await waitWs(WS);
+  console.log(`hub :${HUB_PORT}  app-server ${WS}  (isolated)`);
+
+  // 2. Bootstrap identities: register → login → network → 2 node tokens.
+  const uname = `e2e_${HUB_PORT}`;
+  await rest("/api/auth/register", "POST", { username: uname, password: "pw-e2e-throwaway-123", email: `${uname}@t.local`, display_name: "E2E" });
+  const login = await rest("/api/auth/login", "POST", { username: uname, password: "pw-e2e-throwaway-123" });
+  const utok = login.json.token || login.json.utok || login.json.user?.token;
+  if (!utok) die(1, "FAIL: login returned no token: " + JSON.stringify(login.json).slice(0, 200));
+  const net = await rest("/api/networks", "POST", { name: "e2e-net", description: "rfc030" }, utok);
+  const networkId = net.json.network_id || net.json.network?.network_id || net.json.id;
+  if (!networkId) die(1, "FAIL: create network returned no id: " + JSON.stringify(net.json).slice(0, 200));
+
+  const brTokRes = await rest("/api/auth/node-token", "POST", { network_id: networkId, node_name: BRIDGE_ALIAS }, utok);
+  const senderTokRes = await rest("/api/auth/node-token", "POST", { network_id: networkId, node_name: SENDER_ALIAS }, utok);
+  const brToken = brTokRes.json.token || brTokRes.json.node_token;
+  const senderToken = senderTokRes.json.token || senderTokRes.json.node_token;
+  if (!brToken || !senderToken) die(1, "FAIL: node-token mint failed: " + JSON.stringify({ brTokRes: brTokRes.json, senderTokRes: senderTokRes.json }).slice(0, 300));
+  console.log(`network ${networkId}  tokens minted for ${BRIDGE_ALIAS} + ${SENDER_ALIAS}`);
+
+  // 3. Both nodes report online (upsert into active node list so send_task routes).
+  await mcp(brToken, "report_status", { resume_id: `e2e-${BRIDGE_ALIAS}-${HUB_PORT}`, alias: BRIDGE_ALIAS, status: "idle", task: "codex bridge ready", agent: "codex" });
+  await mcp(senderToken, "report_status", { resume_id: `e2e-${SENDER_ALIAS}-${HUB_PORT}`, alias: SENDER_ALIAS, status: "idle", task: "sender ready" });
+
+  // 4. Codex app-server: bridge OWNS its thread (network-runtime mode —
+  //    empty threadId → bootstrap creates one and adopts the id).
+  const bridgeClient = new CodexAppServerClient({ url: WS, clientLabel: "anet_codex_bridge" });
+  await bridgeClient.connect();
+  const bridge = new CodexAppServerBridge({ client: bridgeClient });
+  await bridge.bootstrap();
+  console.log(`bridge owns thread ${bridge.getThreadId().slice(0, 12)}…`);
+
+  // taskId → originating alias (so the reply routes back to the sender).
+  const originOf = new Map<string, string>();
+
+  // 5a. Bridge reply → send_task back to originator (Vincent: use send_task).
+  bridge.on("task_reply", async (ev: { taskId: string; text: string }) => {
+    const to = originOf.get(ev.taskId) || SENDER_ALIAS;
+    console.log(`[bridge] task_reply ${ev.taskId} → send_task ${to}: ${ev.text.slice(0, 60)}`);
+    await mcp(brToken, "send_task", { alias: to, task: `[codex回复] ${ev.text}`, priority: "normal" }).catch((e) => dbg("reply send_task err", e));
+  });
+  bridge.on("task_error", async (ev: { taskId: string; error: string }) => {
+    const to = originOf.get(ev.taskId) || SENDER_ALIAS;
+    await mcp(brToken, "send_task", { alias: to, task: `[codex错误] ${ev.error}`, priority: "high" }).catch(() => {});
+  });
+
+  // 5b. Bridge inbox pump: poll get_inbox → submitTask for each fresh new_task.
+  const acked = new Set<string>();
+  let bridgePumps = 0;
+  const bridgePump = setInterval(async () => {
+    if (bridgePumps++ > 120) return;
+    try {
+      const inbox = await mcp(brToken, "get_inbox", { alias: BRIDGE_ALIAS, limit: 20 });
+      const msgs: any[] = inbox?.messages || [];
+      for (const m of msgs) {
+        const id = m.id || m.message_id;
+        if (!id || acked.has(id)) continue;
+        acked.add(id);
+        if (m.type && m.type !== "task") continue; // only real dispatched tasks
+        const taskId = m.meta?.task_id || m.task_id || id; // message id doubles as correlation
+        const from = m.from_session || m.from || m.sender || SENDER_ALIAS;
+        const body = m.content || m.task || m.message || m.text || "";
+        originOf.set(taskId, from);
+        console.log(`[bridge] new_task ${taskId} from ${from}: ${String(body).slice(0, 60)}`);
+        await bridge.submitTask({ taskId, text: String(body), from });
+        await mcp(brToken, "ack_inbox", { alias: BRIDGE_ALIAS, message_id: id }).catch(() => {});
+      }
+    } catch (e) { dbg("bridge pump err", e); }
+  }, 1000);
+
+  // 6. Sender dispatches a REAL send_task to the codex bridge.
+  const PROBE = "只回复这四个字，不要多说：网络闭环";
+  const send = await mcp(senderToken, "send_task", { alias: BRIDGE_ALIAS, task: PROBE, priority: "normal" });
+  const dispatchedTaskId = send?.message_id || send?.task_id || send?.id;
+  console.log(`[sender] send_task → ${BRIDGE_ALIAS}  task_id=${dispatchedTaskId}`);
+
+  // 7. Sender waits for the reply to arrive as a pushed task in ITS inbox.
+  const deadline = Date.now() + 130_000;
+  const senderAcked = new Set<string>();
+  while (Date.now() < deadline) {
+    const inbox = await mcp(senderToken, "get_inbox", { alias: SENDER_ALIAS, limit: 20 }).catch(() => ({ messages: [] }));
+    for (const m of (inbox?.messages || []) as any[]) {
+      const id = m.id || m.message_id;
+      if (!id || senderAcked.has(id)) continue;
+      senderAcked.add(id);
+      const body = String(m.content || m.task || m.message || m.text || "");
+      if (body.includes("[codex回复]") || body.includes("网络闭环")) {
+        clearInterval(bridgePump);
+        console.log("\n════════════════════════════════════════════");
+        console.log("GATE PASS ✅  send_task → codex → send_task closed loop");
+        console.log(`  sender dispatched: "${PROBE}"`);
+        console.log(`  sender received  : "${body.slice(0, 120)}"`);
+        console.log("════════════════════════════════════════════");
+        clearTimeout(T);
+        die(0, "");
+      }
+    }
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  clearInterval(bridgePump);
+  die(1, "FAIL: sender never received the codex reply as a pushed task within 130s");
+})().catch((e) => die(1, "FAIL (exception): " + (e?.stack || e)));

--- a/agent-node/tests/rfc-030-poc-2client.ts
+++ b/agent-node/tests/rfc-030-poc-2client.ts
@@ -1,0 +1,33 @@
+// RFC-030 Phase 0 GATE — two-client end-to-end driver (bridge = 2nd client).
+// The human TUI (codex --remote in tmux) is client #1 on the SAME app-server.
+import { CodexAppServerClient } from "../src/runtime/codex-app-server-client";
+import { CodexAppServerBridge } from "../src/runtime/codex-app-server-bridge";
+const url = process.argv[2] || "ws://127.0.0.1:24777";
+const die = (c: number, m: string) => { console.log(m); process.exit(c); };
+setTimeout(() => die(1, "TIMEOUT 120s"), 120_000);
+(async () => {
+  const client = new CodexAppServerClient({ url, clientLabel: "anet-bridge" });
+  await client.connect();
+  await client.request("initialize", { clientInfo: { name: "anet_codex_bridge", title: "Agent Network Codex Bridge", version: "0.1.0" } }, 8000);
+  client.notify("initialized", {});
+  const threads: any = await client.request("thread/loaded/list", {}, 6000);
+  console.log("LOADED THREADS:", JSON.stringify(threads).slice(0, 300));
+  const tid = threads?.data?.[0]?.threadId || threads?.data?.[0]?.id || threads?.data?.[0];
+  if (!tid) die(1, "no persistent thread to resume — human TUI must send one msg first");
+  console.log("RESUMING thread:", tid);
+
+  const bridge = new CodexAppServerBridge({ client, threadId: tid, bridgeLabel: "poc" });
+  // log every event for observability
+  for (const ev of ["status_changed","waiting_human","task_reply","task_error","cross_thread_drop","unowned_turn_drop","task_queued"]) {
+    bridge.on(ev, (p) => console.log(`[bridge:${ev}]`, JSON.stringify(p).slice(0, 200)));
+  }
+  client.on("reverse_request", (rr) => console.log("[reverse_request — NOT answering]", JSON.stringify(rr).slice(0,160)));
+  await bridge.bootstrap();
+  console.log("BRIDGE bootstrapped, status:", bridge.currentStatus());
+
+  const taskId = "poc-task-001";
+  bridge.on("task_reply", (r: any) => { console.log("✅ TASK_REPLY mapped back:", JSON.stringify(r)); die(0, "GATE PASS ✓ — agent task ran on shared thread + reply mapped to task_id"); });
+  bridge.on("task_error", (r: any) => die(1, "TASK_ERROR: " + JSON.stringify(r)));
+  const sub = await bridge.submitTask({ taskId, text: "只回复两个字：收到" });
+  console.log("SUBMITTED:", JSON.stringify(sub));
+})().catch((e) => die(1, "DRIVER FAIL: " + (e as Error).message));

--- a/agent-node/tests/rfc-030-real-appserver-smoke.ts
+++ b/agent-node/tests/rfc-030-real-appserver-smoke.ts
@@ -1,0 +1,126 @@
+// RFC-030 Phase 0 — real `codex app-server` smoke.
+//
+// Sanity-check that our client+bridge parse the actual 0.144.0 wire without
+// relying on schema fixtures. This is NOT the full PoC gate (that needs a
+// human TUI via `codex --remote`); it just:
+//   1. spawns `codex app-server --listen ws://127.0.0.1:PORT`
+//   2. waits for readyz
+//   3. connects the client, runs `initialize`
+//   4. logs the initialize response so schema drift shows up early
+//
+// Runs standalone: `bun tests/rfc-030-real-appserver-smoke.ts`
+// Exit code 0 on success, 1 on failure. Time-boxed to 10s total.
+
+import { spawn } from "child_process";
+import { CodexAppServerClient } from "../src/runtime/codex-app-server-client";
+
+async function main() {
+  const port = 24500 + Math.floor(Math.random() * 200);
+  const url = `ws://127.0.0.1:${port}`;
+  console.log(`[smoke] starting codex app-server on ${url}`);
+
+  const proc = spawn("codex", ["app-server", "--listen", url], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env },
+  });
+  proc.stdout?.setEncoding("utf8");
+  proc.stderr?.setEncoding("utf8");
+  proc.stdout?.on("data", (d) => process.stdout.write(`[app-server stdout] ${d}`));
+  proc.stderr?.on("data", (d) => process.stderr.write(`[app-server stderr] ${d}`));
+
+  try {
+    // Poll readyz for up to 5s.
+    const readyzUrl = `http://127.0.0.1:${port}/readyz`;
+    const deadline = Date.now() + 5_000;
+    let ready = false;
+    while (Date.now() < deadline) {
+      try {
+        const r = await fetch(readyzUrl);
+        if (r.ok) {
+          ready = true;
+          break;
+        }
+      } catch {
+        // not yet
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    if (!ready) throw new Error(`app-server /readyz not reachable after 5s`);
+    console.log("[smoke] app-server ready");
+
+    const client = new CodexAppServerClient({ url });
+    await client.connect();
+    console.log("[smoke] client connected");
+
+    // The bridge policy is to never respond to reverse requests. Attach a
+    // watcher so if the server somehow sends one during initialize we log it
+    // rather than silently drop.
+    client.on("reverse_request", (rr) => {
+      console.log("[smoke] observed reverse_request during handshake:", rr);
+    });
+
+    const resp = await client.request<Record<string, unknown>>(
+      "initialize",
+      {
+        clientInfo: {
+          name: "anet_codex_bridge",
+          title: "Agent Network Codex Bridge",
+          version: "0.1.0-phase0-smoke",
+        },
+      },
+      3_000,
+    );
+    console.log("[smoke] initialize response:", JSON.stringify(resp, null, 2));
+
+    // Best-effort: fire `initialized` notification (per RFC §7.2 handshake).
+    client.notify("initialized", {});
+    console.log("[smoke] initialized notification sent");
+
+    // Try a thread/resume for a synthetic threadId — the server will likely
+    // reject (unknown thread), and that's OK for smoke; we just need to see
+    // that the error envelope round-trips.
+    let threadResumeErrorSeen = false;
+    try {
+      const r = await client.request(
+        "thread/resume",
+        { threadId: "thr_smoke_nonexistent" },
+        3_000,
+      );
+      console.log("[smoke] thread/resume ok (unexpected but harmless):", r);
+    } catch (e) {
+      threadResumeErrorSeen = true;
+      const msg = (e as Error).message;
+      console.log("[smoke] thread/resume error (expected):", msg);
+      if (!msg.includes("thread/resume")) {
+        throw new Error(`error envelope missing method context: ${msg}`);
+      }
+    }
+
+    await client.close();
+    console.log("[smoke] client closed");
+
+    if (threadResumeErrorSeen) {
+      console.log("[smoke] PASS — dispatch handled error envelope correctly");
+    } else {
+      console.log("[smoke] PASS — handshake completed");
+    }
+  } finally {
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      // already exited
+    }
+    // Give it 500ms to clean up, then hard-kill.
+    await new Promise((r) => setTimeout(r, 500));
+    try {
+      proc.kill("SIGKILL");
+    } catch {
+      // already gone
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error("[smoke] FAIL:", e);
+  process.exit(1);
+});

--- a/agent-node/tests/rfc-030-real-appserver-smoke.ts
+++ b/agent-node/tests/rfc-030-real-appserver-smoke.ts
@@ -4,123 +4,38 @@
 // relying on schema fixtures. This is NOT the full PoC gate (that needs a
 // human TUI via `codex --remote`); it just:
 //   1. spawns `codex app-server --listen ws://127.0.0.1:PORT`
-//   2. waits for readyz
-//   3. connects the client, runs `initialize`
-//   4. logs the initialize response so schema drift shows up early
+//   2. waits for the WS to accept
+//   3. connects the client, runs initialize → initialized → thread/loaded/list
+//   4. logs responses so schema drift shows up early, then HARD-exits
+//      (the spawned child otherwise keeps the event loop alive — 通信龙 fix).
 //
 // Runs standalone: `bun tests/rfc-030-real-appserver-smoke.ts`
-// Exit code 0 on success, 1 on failure. Time-boxed to 10s total.
-
+// Exit 0 on success, 1 on failure. Time-boxed to 20s. No model turn → no tokens.
 import { spawn } from "child_process";
 import { CodexAppServerClient } from "../src/runtime/codex-app-server-client";
-
-async function main() {
-  const port = 24500 + Math.floor(Math.random() * 200);
-  const url = `ws://127.0.0.1:${port}`;
-  console.log(`[smoke] starting codex app-server on ${url}`);
-
-  const proc = spawn("codex", ["app-server", "--listen", url], {
-    stdio: ["ignore", "pipe", "pipe"],
-    env: { ...process.env },
-  });
-  proc.stdout?.setEncoding("utf8");
-  proc.stderr?.setEncoding("utf8");
-  proc.stdout?.on("data", (d) => process.stdout.write(`[app-server stdout] ${d}`));
-  proc.stderr?.on("data", (d) => process.stderr.write(`[app-server stderr] ${d}`));
-
-  try {
-    // Poll readyz for up to 5s.
-    const readyzUrl = `http://127.0.0.1:${port}/readyz`;
-    const deadline = Date.now() + 5_000;
-    let ready = false;
-    while (Date.now() < deadline) {
-      try {
-        const r = await fetch(readyzUrl);
-        if (r.ok) {
-          ready = true;
-          break;
-        }
-      } catch {
-        // not yet
-      }
-      await new Promise((r) => setTimeout(r, 100));
-    }
-    if (!ready) throw new Error(`app-server /readyz not reachable after 5s`);
-    console.log("[smoke] app-server ready");
-
-    const client = new CodexAppServerClient({ url });
-    await client.connect();
-    console.log("[smoke] client connected");
-
-    // The bridge policy is to never respond to reverse requests. Attach a
-    // watcher so if the server somehow sends one during initialize we log it
-    // rather than silently drop.
-    client.on("reverse_request", (rr) => {
-      console.log("[smoke] observed reverse_request during handshake:", rr);
-    });
-
-    const resp = await client.request<Record<string, unknown>>(
-      "initialize",
-      {
-        clientInfo: {
-          name: "anet_codex_bridge",
-          title: "Agent Network Codex Bridge",
-          version: "0.1.0-phase0-smoke",
-        },
-      },
-      3_000,
-    );
-    console.log("[smoke] initialize response:", JSON.stringify(resp, null, 2));
-
-    // Best-effort: fire `initialized` notification (per RFC §7.2 handshake).
-    client.notify("initialized", {});
-    console.log("[smoke] initialized notification sent");
-
-    // Try a thread/resume for a synthetic threadId — the server will likely
-    // reject (unknown thread), and that's OK for smoke; we just need to see
-    // that the error envelope round-trips.
-    let threadResumeErrorSeen = false;
-    try {
-      const r = await client.request(
-        "thread/resume",
-        { threadId: "thr_smoke_nonexistent" },
-        3_000,
-      );
-      console.log("[smoke] thread/resume ok (unexpected but harmless):", r);
-    } catch (e) {
-      threadResumeErrorSeen = true;
-      const msg = (e as Error).message;
-      console.log("[smoke] thread/resume error (expected):", msg);
-      if (!msg.includes("thread/resume")) {
-        throw new Error(`error envelope missing method context: ${msg}`);
-      }
-    }
-
-    await client.close();
-    console.log("[smoke] client closed");
-
-    if (threadResumeErrorSeen) {
-      console.log("[smoke] PASS — dispatch handled error envelope correctly");
-    } else {
-      console.log("[smoke] PASS — handshake completed");
-    }
-  } finally {
-    try {
-      proc.kill("SIGTERM");
-    } catch {
-      // already exited
-    }
-    // Give it 500ms to clean up, then hard-kill.
-    await new Promise((r) => setTimeout(r, 500));
-    try {
-      proc.kill("SIGKILL");
-    } catch {
-      // already gone
-    }
+const port = 24500 + Math.floor(Math.random() * 400);
+const url = `ws://127.0.0.1:${port}`;
+const proc = spawn("codex", ["app-server", "--listen", url], { stdio: ["ignore", "pipe", "pipe"] });
+proc.stdout.on("data", (d) => console.log("[srv]", String(d).trim().slice(0, 200)));
+proc.stderr.on("data", (d) => console.log("[srv!]", String(d).trim().slice(0, 200)));
+const die = (code: number, msg: string) => { console.log(msg); try { proc.kill("SIGKILL"); } catch {} ; process.exit(code); };
+setTimeout(() => die(1, "TIMEOUT 20s"), 20_000);
+(async () => {
+  // wait for ws to accept
+  for (let i = 0; i < 40; i++) {
+    try { const c = new WebSocket(url); await new Promise((res, rej) => { c.onopen = res; c.onerror = rej; }); c.close(); break; }
+    catch { await new Promise((r) => setTimeout(r, 250)); }
   }
-}
-
-main().catch((e) => {
-  console.error("[smoke] FAIL:", e);
-  process.exit(1);
-});
+  const client = new CodexAppServerClient({ url, clientLabel: "dragon-probe" });
+  await client.connect();
+  const init = await client.request("initialize", { clientInfo: { name: "dragon_probe", title: "Dragon Probe", version: "0.0.1" } }, 8000);
+  console.log("INIT OK:", JSON.stringify(init).slice(0, 300));
+  client.notify("initialized", {});
+  // list persistent threads (read-only, no model turn, no token burn)
+  try {
+    const threads = await client.request("thread/loaded/list", {}, 5000);
+    console.log("THREADS:", JSON.stringify(threads).slice(0, 200));
+  } catch (e) { console.log("thread/loaded/list:", (e as Error).message.slice(0, 160)); }
+  await client.close();
+  die(0, "PROBE PASS ✓");
+})().catch((e) => die(1, "PROBE FAIL: " + (e as Error).message));

--- a/agent-node/tests/rfc-030-real-node-e2e.ts
+++ b/agent-node/tests/rfc-030-real-node-e2e.ts
@@ -1,0 +1,165 @@
+// RFC-030 — REAL agent-node node e2e (not a test-script bridge).
+//
+// Boots an actual `bun src/cli.ts --config … --runtime codex-app-server`
+// node against an isolated hub, then dispatches a real `send_task` from a
+// separate sender identity and asserts the node's reply comes back. This
+// exercises the FULL production path: cli.ts inbox poll → think() →
+// processWithCodexAppServer → bridge → real codex turn → runtime reply.
+//
+// Also records HOW the reply is delivered (send_reply type='reply' vs a
+// fresh send_task) so we can confirm the loop closes for a real originator.
+//
+// Isolation: isolated hub (throwaway sqlite in /tmp), isolated codex
+// app-server spawned by the node itself. Node config + ntok live under
+// agent-node/.e2e-run (gitignored). Nothing touches production.
+//
+// Run: bun tests/rfc-030-real-node-e2e.ts        (time-boxed 180s, hard exit)
+
+import { spawn, type ChildProcess } from "child_process";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+
+const rnd = (lo: number, hi: number) => lo + Math.floor(Math.random() * (hi - lo));
+const HUB_PORT = rnd(29300, 29900);
+const HUB = `http://127.0.0.1:${HUB_PORT}`;
+const DB_DIR = `/tmp/rfc030-realnode-${HUB_PORT}`;
+mkdirSync(DB_DIR, { recursive: true });
+const DB = `${DB_DIR}/hub.db`;
+const REPO = new URL("../../", import.meta.url).pathname; // .../rfc030-work/
+const RUN_DIR = `${REPO}agent-node/.e2e-run/${HUB_PORT}`;
+mkdirSync(RUN_DIR, { recursive: true });
+
+const NODE_ALIAS = "codex真节点";
+const SENDER_ALIAS = "派单真测";
+
+const kids: ChildProcess[] = [];
+function die(code: number, msg: string): never {
+  console.log(msg);
+  for (const k of kids) { try { k.kill("SIGKILL"); } catch {} }
+  try { rmSync(RUN_DIR, { recursive: true, force: true }); } catch {}
+  process.exit(code);
+}
+const T = setTimeout(() => die(1, "REAL-NODE E2E TIMEOUT 180s"), 180_000);
+const dbg = (...a: unknown[]) => process.env.E2E_DEBUG && console.log(...a);
+
+async function rest(path: string, method: string, body?: unknown, token?: string) {
+  const res = await fetch(`${HUB}${path}`, {
+    method,
+    headers: { "Content-Type": "application/json", ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: res.status, json: (await res.json().catch(() => ({}))) as any };
+}
+async function mcp(token: string, name: string, args: Record<string, unknown>) {
+  const res = await fetch(`${HUB}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method: "tools/call", params: { name, arguments: args } }),
+  });
+  const raw = await res.text();
+  const m = raw.match(/data: (.+)/);
+  const data = m ? JSON.parse(m[1]) : JSON.parse(raw || "{}");
+  const txt = data?.result?.content?.[0]?.text;
+  if (data?.error) throw new Error(`mcp ${name}: ${JSON.stringify(data.error)}`);
+  return typeof txt === "string" ? (() => { try { return JSON.parse(txt); } catch { return txt; } })() : data?.result;
+}
+async function waitHttp(url: string, ok: (s: number) => boolean) {
+  for (let i = 0; i < 60; i++) { try { const r = await fetch(url); if (ok(r.status)) return; } catch {} await new Promise((r) => setTimeout(r, 300)); }
+  throw new Error(`never healthy: ${url}`);
+}
+
+(async () => {
+  // 1. Isolated hub.
+  const hub = spawn("bun", [`${REPO}server/bin/commhub.ts`, "--port", String(HUB_PORT), "--db", DB], {
+    stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, PORT: String(HUB_PORT), COMMHUB_DB: DB },
+  });
+  kids.push(hub);
+  hub.stderr!.on("data", (d) => dbg("[hub!]", String(d).trim().slice(0, 200)));
+  await waitHttp(`${HUB}/health`, (s) => s === 200);
+
+  // 2. Bootstrap identities.
+  const uname = `rn_${HUB_PORT}`;
+  await rest("/api/auth/register", "POST", { username: uname, password: "pw-throwaway-123", email: `${uname}@t.local`, display_name: "RN" });
+  const login = await rest("/api/auth/login", "POST", { username: uname, password: "pw-throwaway-123" });
+  const utok = login.json.token;
+  const net = await rest("/api/networks", "POST", { name: "rn-net", description: "rfc030" }, utok);
+  const networkId = net.json.network_id || net.json.network?.network_id;
+  const nodeTok = (await rest("/api/auth/node-token", "POST", { network_id: networkId, node_name: NODE_ALIAS }, utok)).json.token;
+  const senderTok = (await rest("/api/auth/node-token", "POST", { network_id: networkId, node_name: SENDER_ALIAS }, utok)).json.token;
+  if (!nodeTok || !senderTok) die(1, "FAIL: node-token mint failed");
+  console.log(`hub :${HUB_PORT}  network ${networkId}  (isolated)`);
+
+  // 3. Write the REAL node's config + launch `bun src/cli.ts`.
+  const cfgPath = `${RUN_DIR}/config.json`;
+  writeFileSync(cfgPath, JSON.stringify({
+    node_name: NODE_ALIAS,
+    alias: NODE_ALIAS,
+    hub: HUB,
+    token: nodeTok,
+    network_id: networkId,
+    runtime: "codex-app-server",
+    flags: { dangerouslySkipPermissions: true, teammateMode: true, approvalPolicy: "never", sandboxMode: "danger-full-access" },
+  }, null, 2));
+
+  const node = spawn("bun", [`${REPO}agent-node/src/cli.ts`, "--config", cfgPath], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, COMMHUB_URL: HUB, COMMHUB_TOKEN: nodeTok, COMMHUB_ALIAS: NODE_ALIAS },
+  });
+  kids.push(node);
+  let nodeReady = false;
+  const onNodeLine = (d: Buffer) => {
+    const s = String(d);
+    for (const line of s.split("\n")) {
+      if (!line.trim()) continue;
+      dbg("[node]", line.slice(0, 200));
+      if (/inbox|report_status|listening|codex-app-server|连接|已连接|ready|轮询|poll/i.test(line)) nodeReady = true;
+    }
+  };
+  node.stdout!.on("data", onNodeLine);
+  node.stderr!.on("data", onNodeLine);
+
+  // 4. Sender comes online; wait for the node to be routable, then send_task.
+  await mcp(senderTok, "report_status", { resume_id: `rn-${SENDER_ALIAS}`, alias: SENDER_ALIAS, status: "idle", task: "sender" });
+  // Wait until the node has registered (appears active) so send_task routes.
+  let routable = false;
+  for (let i = 0; i < 60 && !routable; i++) {
+    await new Promise((r) => setTimeout(r, 1000));
+    try {
+      const st = await mcp(senderTok, "get_all_status", {});
+      const list: any[] = st?.sessions || st?.statuses || (Array.isArray(st) ? st : []);
+      routable = list.some((a) => (a.session_name || a.alias || a.name) === NODE_ALIAS);
+    } catch (e) { dbg("status err", e); }
+  }
+  if (!routable) die(1, `FAIL: node ${NODE_ALIAS} never registered/active within 60s (nodeReady=${nodeReady})`);
+  console.log(`node ${NODE_ALIAS} is active — dispatching real send_task`);
+
+  const PROBE = "只回复这四个字，不要任何多余内容：网络闭环";
+  const send = await mcp(senderTok, "send_task", { alias: NODE_ALIAS, task: PROBE, priority: "normal" });
+  console.log(`[sender] send_task → ${NODE_ALIAS}  message_id=${send?.message_id}`);
+
+  // 5. Poll sender inbox for the node's reply (any type: reply or task).
+  const deadline = Date.now() + 160_000;
+  const seen = new Set<string>();
+  while (Date.now() < deadline) {
+    const inbox = await mcp(senderTok, "get_inbox", { alias: SENDER_ALIAS, limit: 20 }).catch(() => ({ messages: [] }));
+    for (const m of (inbox?.messages || []) as any[]) {
+      const id = m.id || m.message_id;
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      const body = String(m.content || m.task || m.message || m.text || "");
+      dbg(`[sender inbox] type=${m.type} from=${m.from_session} body=${body.slice(0, 80)}`);
+      if (body.includes("网络闭环")) {
+        console.log("\n════════════════════════════════════════════");
+        console.log("REAL-NODE GATE PASS ✅");
+        console.log(`  real agent-node (--runtime codex-app-server) executed a dispatched send_task`);
+        console.log(`  reply delivery type: '${m.type}'  from: ${m.from_session}`);
+        console.log(`  dispatched: "${PROBE}"`);
+        console.log(`  received  : "${body.slice(0, 120)}"`);
+        console.log("════════════════════════════════════════════");
+        clearTimeout(T);
+        die(0, "");
+      }
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  die(1, "FAIL: sender never received the real node's reply within 160s");
+})().catch((e) => die(1, "FAIL (exception): " + (e?.stack || e)));

--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -397,8 +397,8 @@ Measured: the hub's `send_reply` enqueues the reply into the originator's inbox 
 - You want **multiple independent codex nodes**
 - You want the standard `codex app-server` protocol rather than the SDK wrapper
 
-::: warning Verification status
-Phase 0/1 is shipped and self-verified against a live codex: bridge 17 + client 12 unit tests, 741 full-suite tests with zero regression, and an isolated-hub **real-node e2e** (`send_task` → codex → `send_task` closed loop PASS). Approvals are human-only by design; the adopt topology's `codexAppServerUrl`/`codexThreadId` are set manually in config for now. See [RFC-030 §18 Implementation Status](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md).
+::: warning Verification status (Phase 0A / preview only)
+This is the **direct dual-client** design — self-verified against a live codex (bridge 17 + client 12 unit tests, 741 full-suite zero regression, isolated-hub **real-node e2e** `send_task`→codex→`send_task` closed loop PASS), suitable for a **single trusted machine preview**. It is **not yet production-hardened**: the human TUI and the bridge connect directly to codex and can race on an active turn, "approvals are human-only" is code discipline rather than a permission boundary, and the bridge holds the raw app-server control plane. The production shape is a **single upstream Policy Gateway** (serialized arbitration + approvals routed only to the human + a minimal typed enqueue surface). See [RFC-030 §18 + §8 gates](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md).
 :::
 
 ---

--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -326,6 +326,83 @@ When enabled, agent-node runs `spawn('codex', ['app-server'])` and talks the ful
 
 ---
 
+## codex-app-server (Codex TUI bridge, RFC-030)
+
+Attach a **codex CLI TUI session** to the network as a node. The node spawns its own standalone `codex app-server` and a bridge subscribes to the same codex thread as a client. Key difference vs `codex-sdk`: `codex-sdk` embeds the SDK and exclusively owns the codex thread, whereas **`codex-app-server` speaks the standard `codex app-server` protocol, where one thread can be subscribed by multiple clients** — so **a codex session you're typing into in the TUI can simultaneously become a network node**.
+
+### Prerequisites
+
+Install the `codex` CLI and log in (same as codex-sdk):
+
+```bash
+npm install -g @openai/codex
+codex auth login       # or export OPENAI_API_KEY=sk-xxx
+codex --version        # expect codex 0.144.0+ (app-server protocol baseline)
+```
+
+### How it works
+
+```
+anet node start  →  spawn agent-node child (runtime=codex-app-server)
+                 ↓
+   on a dispatched task: spawn `codex app-server --listen ws://127.0.0.1:<ephemeral>`
+                 ↓
+   bridge connects → thread/start creates and owns a thread
+                 ↓
+   inbound send_task → bridge.submitTask → one codex turn → final answer
+                 ↓
+   reply goes back via a plain CommHub send_task (see "Reply via send_task")
+```
+
+- **Receive** (inbound): network `send_task` → node inbox → **through the bridge** → codex runs a turn
+- **Send** (outbound): codex answer → **plain CommHub `send_task`** back to the sender (the bridge only wraps "run one codex turn")
+- One active turn per thread; a second task **queues FIFO** in the bridge and drains when the in-flight turn (yours or the human TUI's) completes
+- **Approvals are human-only**: the bridge never answers an approval; a turn needing approval parks as `waiting_human` for the human TUI
+
+### Two topologies
+
+**① Owned (default)** — the node spawns its own app-server and creates a fresh thread. Multiple codex-app-server nodes are fully independent:
+
+```bash
+codex auth login
+anet node create codexbridge --runtime codex-app-server
+anet node start codexbridge
+```
+
+```jsonc
+// config.json
+{ "runtime": "codex-app-server", "model": "gpt-5.5" }
+```
+
+**② Adopt an existing codex session** — make a running codex session a node too. Run a shared app-server + a human `codex --remote` TUI, then point the node config at it:
+
+```jsonc
+// config.json
+{
+  "runtime": "codex-app-server",
+  "codexAppServerUrl": "ws://127.0.0.1:24777",  // a running codex app-server
+  "codexThreadId": "019f…"                       // the existing thread to adopt
+}
+```
+
+The bridge attaches as a **second client** and `thread/resume`s that thread. You keep typing in the TUI while the network dispatches tasks into the same thread. `codexThreadId` is written back after first bind, so a restart resumes the same session.
+
+### Reply via send_task (not send_reply)
+
+Measured: the hub's `send_reply` enqueues the reply into the originator's inbox but does **not** SSE-wake the immediate originator — an agent peer only sees it on its next poll. `send_task` fires an immediate `new_task` wake. So **codex-app-server nodes reply to dispatched tasks via `send_task`** (this runtime only; other runtimes are unchanged). Both directions are `send_task`.
+
+### When to use
+
+- You want a **human codex TUI session to also be on the network** (human + agent share one thread)
+- You want **multiple independent codex nodes**
+- You want the standard `codex app-server` protocol rather than the SDK wrapper
+
+::: warning Verification status
+Phase 0/1 is shipped and self-verified against a live codex: bridge 17 + client 12 unit tests, 741 full-suite tests with zero regression, and an isolated-hub **real-node e2e** (`send_task` → codex → `send_task` closed loop PASS). Approvals are human-only by design; the adopt topology's `codexAppServerUrl`/`codexThreadId` are set manually in config for now. See [RFC-030 §18 Implementation Status](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md).
+:::
+
+---
+
 ## grok-build-acp
 
 Run agents via [xAI Grok Build](https://x.ai/grok)'s local CLI — the node spawns a local `grok agent stdio` process and talks the Agent Client Protocol (ACP), reusing your host's Grok login. **Formally onboarded in v0.10.8**; v0.10.11 [#204](https://github.com/sleep2agi/agent-network/issues/204) adds per-node isolated cwd to eliminate multi-node identity pollution (already in npm `latest`).

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -417,8 +417,8 @@ anet node start codexbridge
 - 想开**多个独立 codex 节点**各干各的
 - 想要标准 `codex app-server` 协议而非 SDK 封装
 
-::: warning 验证状态
-Phase 0/1 已落地并真机自验：桥 17 + client 12 单测、741 全量测试零回归、隔离 hub **真节点 e2e**（`send_task` → codex → `send_task` 闭环 PASS）。审批流为设计上「只归人类」；接管拓扑的 `codexAppServerUrl`/`codexThreadId` 目前手工写 config。详见 [RFC-030 §18 实现现状](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md)。
+::: warning 验证状态（Phase 0A / preview 形态）
+当前是**方案 A 直接双客户端**——已真机自验（桥 17 + client 12 单测、741 全量零回归、隔离 hub **真节点 e2e** `send_task`→codex→`send_task` 闭环 PASS），适用于**单机可信 preview**。**尚未**做生产加固：人类 TUI 与桥直连 codex 会在 active turn 争抢、审批「只归人类」目前是代码纪律非权限边界、桥持有 app-server 原始控制面。生产形态是**方案 B 单 upstream Policy Gateway**（排队仲裁 + 审批只递人类 + 最小权限投递口），见 [RFC-030 §18 实现现状 + §8 硬门](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md)。
 :::
 
 ---

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -346,6 +346,83 @@ ANET_CODEX_STDIO_DIRECT=1 anet node start <codex-node>
 
 ---
 
+## codex-app-server（Codex TUI 桥, RFC-030）
+
+把一个 **codex CLI 的 TUI 会话**接进网络当节点 —— 节点自己起一个独立的 `codex app-server`，桥（bridge）作为客户端订阅同一条 codex thread。跟 `codex-sdk` 的关键区别：`codex-sdk` 是 agent-node 内嵌 SDK 独占管理 codex thread；**`codex-app-server` 用的是标准 `codex app-server` 协议，一条 thread 可以被多个客户端订阅**——于是**你在 codex TUI 里手打的那个会话，可以同时变成网络节点**。
+
+### 前置
+
+装 `codex` CLI 并登录（跟 codex-sdk 一样）：
+
+```bash
+npm install -g @openai/codex
+codex auth login       # 或 export OPENAI_API_KEY=sk-xxx
+codex --version        # 期望 codex 0.144.0 及以上（app-server 协议以此为准）
+```
+
+### 工作原理
+
+```
+anet node start  →  spawn agent-node 子进程（runtime=codex-app-server）
+                 ↓
+      收到派工时: spawn `codex app-server --listen ws://127.0.0.1:<临时端口>`
+                 ↓
+      bridge 连上 app-server → thread/start 新建并拥有一条 thread
+                 ↓
+      入站 send_task → bridge.submitTask → 一次 codex turn → 最终答案
+                 ↓
+      结果用 send_task 回派单方（见下方「回复用 send_task」）
+```
+
+- **收**（入站）：网络 `send_task` → 节点 inbox → **走桥** → codex 执行一轮
+- **发**（出站）：codex 出答案 → **普通 CommHub `send_task`** 回发起方（桥只包住「让 codex 跑一轮」）
+- 单条 thread 同一时刻只有一个 active turn；第二个任务在桥里 **FIFO 排队**，等当前 turn（自己的或人类 TUI 的）结束再跑
+- **审批只归人类**：桥永不代答 approval，需要审批的 turn 会挂起等人类在 TUI 里处理
+
+### 两种拓扑
+
+**① 独占（默认）** —— 节点自己起 app-server + 新建 thread。多个 codex-app-server 节点互不干扰：
+
+```bash
+codex auth login
+anet node create codexbridge --runtime codex-app-server
+anet node start codexbridge
+```
+
+```jsonc
+// config.json
+{ "runtime": "codex-app-server", "model": "gpt-5.5" }
+```
+
+**② 接管已有 codex 会话** —— 让一个正在运行的 codex 会话同时变成节点。先跑一个共享 app-server + 人类 `codex --remote` TUI，然后在节点 config 里指过去：
+
+```jsonc
+// config.json
+{
+  "runtime": "codex-app-server",
+  "codexAppServerUrl": "ws://127.0.0.1:24777",  // 指向正在运行的 codex app-server
+  "codexThreadId": "019f…"                       // 要接管的已有 thread
+}
+```
+
+桥作为**第二个客户端** `thread/resume` 复用该线程。你继续在 TUI 里打字，网络也能派任务进同一条 thread。`codexThreadId` 会在首次落地后自动写回，重启 resume 同一会话。
+
+### 回复用 send_task（不是 send_reply）
+
+实测：hub 的 `send_reply` 会把回复塞进发起方收件箱，但**不会 SSE 唤醒直接发起方**——对端 agent 只能等下次轮询才看到。`send_task` 会立刻 `new_task` 唤醒。所以 **`codex-app-server` 节点回复派工统一走 `send_task`**（只对该 runtime 生效，不改其他 runtime 的行为）。收发两个方向都是 `send_task`。
+
+### 适用场景
+
+- 想让**人类的 codex TUI 会话同时接入网络**（人机共用一条 thread）
+- 想开**多个独立 codex 节点**各干各的
+- 想要标准 `codex app-server` 协议而非 SDK 封装
+
+::: warning 验证状态
+Phase 0/1 已落地并真机自验：桥 17 + client 12 单测、741 全量测试零回归、隔离 hub **真节点 e2e**（`send_task` → codex → `send_task` 闭环 PASS）。审批流为设计上「只归人类」；接管拓扑的 `codexAppServerUrl`/`codexThreadId` 目前手工写 config。详见 [RFC-030 §18 实现现状](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md)。
+:::
+
+---
+
 ## grok-build-acp
 
 用 [xAI Grok Build](https://x.ai/grok) 本地 CLI 跑 agent —— 节点 spawn 本地 `grok agent stdio` 进程 + Agent Client Protocol (ACP) 协议交互，复用本机 Grok 登录态。**v0.10.8 起正式接入**；v0.10.11 [#204](https://github.com/sleep2agi/agent-network/issues/204) 加 per-node isolated cwd 解决多节点身份污染（已在 npm `latest`）。

--- a/docs/rfcs/RFC-030-codex-tui-bridge.md
+++ b/docs/rfcs/RFC-030-codex-tui-bridge.md
@@ -1,7 +1,8 @@
 # RFC-030：Codex TUI 人类与 Agent 共用会话桥接（app-server transport）
 
-> 状态：**已落地 Phase 0/1（Implemented, 2026-07-10）** · 通信龙实现 + 真机 e2e 自验 · Vincent 授权
-> 分支：`rfc030-phase0` · 落地实现的权威说明见下方 **§18 实现现状**（本节推翻了原始设计正文里若干猜测字段, 以真机 codex-cli 0.144.0 为准）。
+> 状态：**Accepted for Phase 0A（直接链路已验证）; 生产上线被 §8 硬门 blocked**（2026-07-10）
+> ⚠️ 已落地的是**方案 A 直接双客户端**（Phase 0A 验证形态, 仅单机可信 preview）; **生产形态是方案 B「单 upstream Policy Gateway」, 尚未实现**。详见配套设计文档 `agent-network-codex-tui-bridge-design.md`（§2.3 三个硬问题 / §3.2 gateway / §8 验收门 / §9 本 RFC 必改清单）。
+> 分支：`rfc030-phase0` · 已落地实现的权威说明见下方 **§18 实现现状**（以真机 codex-cli 0.144.0 为准）。
 > 关联 tracking issue 见下; 原始设计正文（§1–§17）保留作为设计背景。
 
 
@@ -853,20 +854,28 @@ codex app-server generate-json-schema --out ./schemas
 
 ---
 
-## 18. 实现现状（Implemented 2026-07-10, 权威）
+## 18. 实现现状（Phase 0A 已验证, 2026-07-10）
 
-> 本节记录**已落地并真机自验**的实现。凡与 §1–§17 设计正文冲突处, **以本节为准**——设计正文写作时 codex app-server 协议字段是推测的, 落地时以真机 `codex-cli 0.144.0` 抓包为准做了修正。
-> 分支 `rfc030-phase0`; 关键 commit 见 tracking issue。
+> ⚠️ **定位**：本节记录的是**方案 A 直接双客户端**的落地——对应配套设计文档 `agent-network-codex-tui-bridge-design.md` 的 **Phase 0A「直接链路验证」（该文档标记为已完成）**。它**证明了产品方向且能真机 demo, 但不是生产形态**：设计文档明确「不批准直接双客户端上线」, 生产必须走 **方案 B 单 upstream Policy Gateway**（见该文档 §3.2 / §4）。本节所述能力在**单机可信 preview** 语义下为真; 生产上线被设计文档 §8 硬门 blocked。
+> 凡协议字段与 §1–§17 设计正文冲突处, **以本节为准**（真机 `codex-cli 0.144.0` 抓包修正）。分支 `rfc030-phase0`; 关键 commit 见 tracking issue。
 
-### 18.1 落地了什么
+### 18.1 落地了什么（Phase 0A + 运行时/CLI/文档管道）
 
 | 能力 | 状态 | 验证方式 |
 |---|---|---|
 | App Server JSON-RPC client (`codex-app-server-client.ts`) | ✅ | 12 单测 + 真机 |
-| Bridge（create-or-resume thread / 单活跃 turn / FIFO 队列 / 审批只归人类）(`codex-app-server-bridge.ts`) | ✅ | 17 单测 + 真机 2-client gate |
-| `codex-app-server` runtime（`codex-app-server/runtime.ts` + `cli.ts` 接线）| ✅ | 741 全量测试 + 真节点 e2e |
+| Bridge（create-or-resume thread / 单活跃 turn / FIFO 队列）(`codex-app-server-bridge.ts`) | ✅ Phase 0A | 17 单测 + 真机 2-client gate |
+| `codex-app-server` runtime（`runtime.ts` + `cli.ts` 接线）| ✅ Phase 0A | 741 全量测试 + 真节点 e2e |
 | 网络闭环：`send_task` → 桥 → 真 codex → `send_task` 回 | ✅ | 隔离 hub 真节点 e2e PASS |
 | `anet node create --runtime codex-app-server` | ✅ | 隔离 hub 真建节点，config 写 `runtime:"codex-app-server"` |
+
+### 18.1b 明确**未**落地（生产前置, 设计文档 §3.2/§4/§8）
+
+- ❌ **Policy Gateway（方案 B）**：唯一 upstream app-server 连接、TUI 经 gateway UDS、request-id 双向重写、事件转发。当前是 TUI 与桥**直接双连接**。
+- ❌ **原子 reservation 跨 gateway**：当前桥的 FIFO 只协调桥自己, **不能阻止人类 TUI 与桥在 app-server 上争抢 `turn/start`**（设计文档 §2.3-A：active turn 下可能隐式 steer）。
+- ⚠️ **审批边界**：桥「不答审批」是**代码纪律, 不是权限边界**（§2.3-B：审批是多订阅者第一响应者）。
+- ⚠️ **控制面最小权限**：桥持有 app-server 原始 endpoint（§2.3-C：含 sandbox 外 `thread/shellCommand`）。
+- ❌ WS 仅 loopback PoC; 产品路径应为 UDS。
 
 ### 18.2 真机协议修正（推翻设计正文的猜测）
 

--- a/docs/rfcs/RFC-030-codex-tui-bridge.md
+++ b/docs/rfcs/RFC-030-codex-tui-bridge.md
@@ -1,13 +1,13 @@
 # RFC-030：Codex TUI 人类与 Agent 共用会话桥接（app-server transport）
 
-> 状态：**Accepted（通信龙 review 通过, Vincent 授权实施 2026-07-10）** · 先做 Phase 0/1, 保守边界
-> 关联 tracking issue 见下; 原始设计正文如下。
+> 状态：**已落地 Phase 0/1（Implemented, 2026-07-10）** · 通信龙实现 + 真机 e2e 自验 · Vincent 授权
+> 分支：`rfc030-phase0` · 落地实现的权威说明见下方 **§18 实现现状**（本节推翻了原始设计正文里若干猜测字段, 以真机 codex-cli 0.144.0 为准）。
+> 关联 tracking issue 见下; 原始设计正文（§1–§17）保留作为设计背景。
 
 
-> 状态：设计提案，尚未在 Agent Network 主干实现  
-> 评审基线：`sleep2agi/agent-network@84136dc`（2026-07-09）  
+> 原始设计基线（历史）：`sleep2agi/agent-network@84136dc`（2026-07-09）  
 > Codex 验证基线：`codex-cli 0.144.0`（2026-07-10）  
-> 建议落点：先作为 `codex-sdk` 的 `app-server` transport 预览开关验证，再决定是否提升为独立 runtime
+> 原始设计正文（§1–§17）落点建议为「先作为 `codex-sdk` 的 app-server transport」；**实际落地采用独立 `codex-app-server` runtime**（Vincent 定「用 codex-cli TUI 模式、别用 codex-sdk」），详见 §18。
 
 ## 1. 摘要
 
@@ -850,3 +850,62 @@ codex app-server generate-json-schema --out ./schemas
 - [RFC-006：旧 remote-control 路线](https://github.com/sleep2agi/agent-network/blob/84136dc25e2e1a06b2af984aaf8fa0ce49cdace4/docs/rfcs/RFC-006-codex-code-cli-mcp-server.md)
 - [RFC-007：mcp-server 路线](https://github.com/sleep2agi/agent-network/blob/84136dc25e2e1a06b2af984aaf8fa0ce49cdace4/docs/rfcs/RFC-007-codex-code-cli-mcp.md)
 - [RFC-012：Codex 与 CommHub MCP 桥接](https://github.com/sleep2agi/agent-network/blob/84136dc25e2e1a06b2af984aaf8fa0ce49cdace4/docs/rfcs/RFC-012-codex-mobile-bridge.md)
+
+---
+
+## 18. 实现现状（Implemented 2026-07-10, 权威）
+
+> 本节记录**已落地并真机自验**的实现。凡与 §1–§17 设计正文冲突处, **以本节为准**——设计正文写作时 codex app-server 协议字段是推测的, 落地时以真机 `codex-cli 0.144.0` 抓包为准做了修正。
+> 分支 `rfc030-phase0`; 关键 commit 见 tracking issue。
+
+### 18.1 落地了什么
+
+| 能力 | 状态 | 验证方式 |
+|---|---|---|
+| App Server JSON-RPC client (`codex-app-server-client.ts`) | ✅ | 12 单测 + 真机 |
+| Bridge（create-or-resume thread / 单活跃 turn / FIFO 队列 / 审批只归人类）(`codex-app-server-bridge.ts`) | ✅ | 17 单测 + 真机 2-client gate |
+| `codex-app-server` runtime（`codex-app-server/runtime.ts` + `cli.ts` 接线）| ✅ | 741 全量测试 + 真节点 e2e |
+| 网络闭环：`send_task` → 桥 → 真 codex → `send_task` 回 | ✅ | 隔离 hub 真节点 e2e PASS |
+| `anet node create --runtime codex-app-server` | ✅ | 隔离 hub 真建节点，config 写 `runtime:"codex-app-server"` |
+
+### 18.2 真机协议修正（推翻设计正文的猜测）
+
+以 `codex-cli 0.144.0` 真机为准, 落地时修正了以下字段（原 §7 是推测）：
+
+1. **`initialize` 是 per-app-server, 不是 per-connection**。共享 server 上第二个 client 再发 `initialize` 会收到 `-32600 Already initialized`——桥容错并直接进入 thread 绑定。（§7.2「每个连接必须单独初始化」是**错的**。）
+2. **`turnId` 嵌套在 `turn.id`**：`turn/start` 响应与 `turn/{started,completed}` 事件都用 `turn.id`；item 级事件（delta / `item/completed`）用扁平 `turnId`。
+3. **`item/agentMessage/delta.delta` 是纯字符串**, 不是 `{ text }`。
+4. **最终答案在 `item/completed`**（`item.type=agentMessage, phase=final_answer, item.text`）, **`turn/completed` 里没有 finalText**。桥在 `item/completed` 抓最终文本, 累积 deltas 作兜底。
+5. **反向请求（审批）同时带 `method` 和 `id`**；client dispatch 必须先判 `method` 再判 `id`, 否则审批被误判成孤儿响应。
+
+### 18.3 两种拓扑
+
+- **独占（owned, 默认）**：节点自己 `spawn codex app-server --listen ws://127.0.0.1:<临时端口>`, 桥 `thread/start` 新建并拥有一条 thread。多个节点互不干扰（各自 app-server + thread）。
+- **接管已有会话（shared / adopt）**：config 设 `codexAppServerUrl`（指向正在运行的 `codex app-server`）+ `codexThreadId`（已有线程）→ 桥作为**第二个 client** 接入、`thread/resume` 复用该线程。于是一个正在被人类 `codex --remote` TUI 使用的会话**同时变成网络节点**。桥**永不代答审批**（审批只归人类 TUI）。
+- 若 `thread/resume` 因线程从未持久化 rollout 而失败（`no rollout found`）, 桥回退到 `thread/start` 新建, 不让陈旧 id 卡死开机。
+
+### 18.4 回复走 send_task（实测决策）
+
+实测（隔离 hub e2e）：hub 的 `send_reply` 会把回复塞进发起方收件箱（`type='reply'`）, **但不会 SSE 唤醒直接发起方**（只有 chain 到 parent 才 push）——对端 agent 只能等下一次轮询才看到。而 `send_task` 会立刻发 `new_task` SSE 唤醒。
+
+因此 **`codex-app-server` 节点回复派工用 `send_task`**（`REPLY_VIA_SEND_TASK`, 仅对该 runtime 生效, 不改其他 runtime 的 `send_reply` 任务生命周期语义）。这与全网「回复指挥室用 `commhub_send_task`」的约定一致。收发两个方向都是 `send_task`。
+
+### 18.5 配置字段
+
+```jsonc
+{
+  "runtime": "codex-app-server",
+  "codexThreadId": "019f…",          // 可选; 落地后自动写回, 重启 resume 同一会话
+  "codexAppServerUrl": "ws://127.0.0.1:24777", // 可选; 设了就接管该共享 server（否则自己 spawn）
+  "model": "gpt-5.5",
+  "flags": { "dangerouslySkipPermissions": true, "approvalPolicy": "never" }
+}
+```
+- `codexThreadId` 存放于**专属字段**（不占用通用 `session` 字段, 避免与其他 runtime 冲突）; 首次落地由 `onThread` 自动写回。
+- 前置：本机装 `codex` CLI 并 `codex auth login`。
+
+### 18.6 已知边界 / 后续
+
+- 审批（approval）流：桥永不代答, 纯文本 turn 不触发审批; 需要审批的 turn 会 `waiting_human` 挂起, 由人类 TUI 处理（设计如此）。
+- 接管拓扑的 `codexAppServerUrl`/`codexThreadId` 目前靠手工写 config; `anet node create` 交互向导已给提示, 后续可加专属 flag。
+- codex-app-server 内层 codex 的 loops MCP（自管 /loop 工具）接线为后续增强; 派工闭环不依赖它。


### PR DESCRIPTION
## What

Lands the **codex-app-server** runtime (RFC-030 codex TUI bridge) as the **Phase 0A direct-client preview** — a new opt-in agent-node runtime that runs a standalone \`codex app-server\` and bridges CommHub tasks into codex turns.

**Scope / honesty:** this is METHOD A (direct dual-client), i.e. the design's **Phase 0A "direct-link validation"** — proven and demoable, suitable for a **single-trusted-machine preview**. It is **not** production-hardened; the production shape is a single-upstream Policy Gateway (METHOD B), parked for later. See `docs/rfcs/RFC-030 §18.1b` for what is explicitly NOT done (gateway, cross-client atomic reservation, approval as a real boundary, control-plane least-privilege, UDS) and the three hard problems.

## Changes
- `codex-app-server-client.ts` + `codex-app-server-bridge.ts` — JSON-RPC client + bridge (create-or-resume thread, single active turn, FIFO queue). Real codex-cli 0.144.0 wire.
- `codex-app-server/runtime.ts` + `cli.ts` wiring — new runtime, lazy session holder, thread persistence (`codexThreadId`), owned + adopt-existing-session topologies.
- codex-app-server replies via `send_task` (empirically `send_reply` doesn't SSE-wake the immediate originator); gated `REPLY_VIA_SEND_TASK`, other runtimes unchanged.
- `anet node create --runtime codex-app-server` (normalize-runtime + dep check + wizard).
- Docs: RFC-030 §18 implementation status + bilingual runtimes.md guide.

## Testing
- Unit: bridge 17 + client 12 + normalize-runtime +6; **741 agent-node full suite, zero regression**.
- **Real-node e2e** (isolated hub, real `bun cli.ts --runtime codex-app-server` node): dispatched `send_task` → node spawns its own app-server → real codex turn → `send_task` reply — **PASS, reproduced 5×**.
- Public-repo audit: no slugs / no secrets / no stray runtime dirs committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)