### PR TITLE
security(test): reject inherited DATABASE_URL before adapter construction (#435)

### DIFF
--- a/docs/tests/db-test-safety.md
+++ b/docs/tests/db-test-safety.md
@@ -21,12 +21,20 @@ known — but the ordering hole was live.
 
 ## Reproducing the negative case (operator's actionable check)
 
+Run from the repository root (path is relative to CWD). A bare
+`require(...).createAdapter()` top-level expression does not reliably
+surface a non-zero exit code under Bun 1.3.14 — wrap in an explicit
+try/catch as the automated test does:
+
 ```
-NODE_ENV=test DATABASE_URL='postgres://fake:pw@127.0.0.1:5432/commhub' \
-  bun -e "require('./server/src/db-adapter.ts').createAdapter()"
+env -u COMMHUB_DB NODE_ENV=test \
+  DATABASE_URL='postgres://fake:pw@127.0.0.1:5432/commhub' \
+  bun -e "const m = require('./server/src/db-adapter.ts'); \
+          try { m.createAdapter(); process.exit(0); } \
+          catch(e) { console.error(e.message); process.exit(2); }"
 ```
 
-Expected: process exits non-zero. `stderr` contains
+Expected: process exits `2`. `stderr` contains
 `REFUSING to honor inherited DATABASE_URL`. The banner
 `[commhub] database: PostgreSQL` is **never** printed — that line only
 runs after `resolveDatabaseTarget()` returns a `postgres` discriminant,
@@ -34,16 +42,44 @@ and the guard short-circuits before then.
 
 ## Reproducing the syscall-level proof (independent Linux verification)
 
+Use `strace -f` so all bun worker threads are traced, then assert on
+two distinct evidence streams (do NOT try to shoehorn both into one
+regex — strace's `connect()` argument shape hides the port inside a
+`sin_port=htons(...)` field, so a naive `connect\([^)]*:5432` pattern
+false-negatives on typical output):
+
 ```
-strace -ff -e trace=connect,openat \
-  env NODE_ENV=test DATABASE_URL='postgres://fake:pw@prod:5432/commhub' \
-  bun -e "require('./server/src/db-adapter.ts').createAdapter()" 2>&1 \
-  | grep -E 'connect\([^)]*:5432|openat.*\.commhub/commhub\.db'
+# Negative case: NODE_ENV=test + fake DATABASE_URL, both DB vars given
+# via `env` so no shell leak. Run once, split the log two ways.
+
+strace -f -o /tmp/strace-435.log -e trace=connect,openat \
+  env -u COMMHUB_DB NODE_ENV=test \
+  DATABASE_URL='postgres://fake:pw@prod:5432/commhub' \
+  bun -e "const m = require('./server/src/db-adapter.ts'); \
+          try { m.createAdapter(); process.exit(0); } \
+          catch(e) { console.error(e.message); process.exit(2); }"
+
+# (1) All connect() syscalls — MUST be zero for this negative path.
+#     Nothing legitimate connects here; any hit is a regression.
+grep -c 'connect(' /tmp/strace-435.log
+
+# (2) Optionally scope to the postgres port. sin_port is the field
+#     name strace prints; matching the whole family+port fragment is
+#     the safe pattern.
+grep -E 'connect\([^)]*sin_port=htons\(5432\)' /tmp/strace-435.log | wc -l
+
+# (3) Default SQLite path — MUST be zero.
+grep -E 'openat\([^)]*\.commhub/commhub\.db' /tmp/strace-435.log | wc -l
 ```
 
-Expected: zero matching lines. Any match means the guard regressed and
-either PostgreSQL was dialed or the default SQLite path was opened
-before refusal.
+Expected: (1) `0`, (2) `0`, (3) `0`. Any non-zero count means the
+guard regressed and either PostgreSQL was dialed (or any socket at
+all was opened) or the default SQLite path was touched before refusal.
+
+Running (2) alone is insufficient because it presumes attack traffic
+uses 5432. Line (1) is the authoritative negative — every `connect()`
+during this refusal path is a bug — and (2)+(3) narrow the diagnostic
+if (1) ever regresses.
 
 ## Restrictions on tests
 

--- a/docs/tests/db-test-safety.md
+++ b/docs/tests/db-test-safety.md
@@ -1,0 +1,67 @@
+# db-adapter test-safety guard (issue #435)
+
+## Rule
+
+Under `NODE_ENV=test`, `createAdapter()` refuses **any** inherited
+`DATABASE_URL` — regardless of value or URL scheme — before constructing
+`PgAdapter`, before opening a socket, and before the SQLite default-path
+guard runs. Production behavior (`NODE_ENV != "test"`) is unchanged.
+
+There is no opt-in bypass in this build. A future isolated PostgreSQL
+test harness will land under a separate RFC/issue with explicit review.
+
+## Rationale
+
+`createAdapter()` on `main` at `d418862` selected the PostgreSQL branch
+BEFORE the SQLite test guard fired. A developer machine, CI worker, or
+container that inherited a production PostgreSQL URL could therefore
+open a socket to production PostgreSQL from inside `bun test` and hammer
+prod. The current machine had `DATABASE_URL` unset, so no incident is
+known — but the ordering hole was live.
+
+## Reproducing the negative case (operator's actionable check)
+
+```
+NODE_ENV=test DATABASE_URL='postgres://fake:pw@127.0.0.1:5432/commhub' \
+  bun -e "require('./server/src/db-adapter.ts').createAdapter()"
+```
+
+Expected: process exits non-zero. `stderr` contains
+`REFUSING to honor inherited DATABASE_URL`. The banner
+`[commhub] database: PostgreSQL` is **never** printed — that line only
+runs after `resolveDatabaseTarget()` returns a `postgres` discriminant,
+and the guard short-circuits before then.
+
+## Reproducing the syscall-level proof (independent Linux verification)
+
+```
+strace -ff -e trace=connect,openat \
+  env NODE_ENV=test DATABASE_URL='postgres://fake:pw@prod:5432/commhub' \
+  bun -e "require('./server/src/db-adapter.ts').createAdapter()" 2>&1 \
+  | grep -E 'connect\([^)]*:5432|openat.*\.commhub/commhub\.db'
+```
+
+Expected: zero matching lines. Any match means the guard regressed and
+either PostgreSQL was dialed or the default SQLite path was opened
+before refusal.
+
+## Restrictions on tests
+
+- Ordinary test commands **must** `unset DATABASE_URL` before invoking
+  `bun test`. See #434 for the aggregate-runner change that enforces
+  this per child process.
+- Tests **must not** contact a real external database endpoint. The
+  production-branch regression is covered by pure-helper unit tests
+  (`resolveDatabaseTarget(env)` returns a `postgres` discriminant
+  without constructing `PgAdapter`).
+- The subprocess negative test uses a fake-prod URL that is never
+  dialed; the guard short-circuits before any socket is opened.
+
+## Related
+
+- Issue: #435 (this)
+- Historical isolation debt: #434
+- RFC tracking: #428
+- Test file: `server/src/db-adapter-guard.test.ts`
+- Product code: `server/src/db-adapter.ts` — `assertSafeTestDatabaseEnv`,
+  `resolveDatabaseTarget`, `createAdapter`

--- a/server/src/db-adapter-guard.test.ts
+++ b/server/src/db-adapter-guard.test.ts
@@ -190,6 +190,30 @@ describe("resolveDatabaseTarget — pure branch decision, no construction", () =
       /REFUSING to honor inherited DATABASE_URL/
     );
   });
+
+  test("test + BOTH DATABASE_URL AND COMMHUB_DB set → DATABASE_URL guard still fires FIRST", () => {
+    // Anti-drift guard for future reorderings. Even when COMMHUB_DB is
+    // provided (which would satisfy the SQLite guard), the DATABASE_URL
+    // guard must still short-circuit under NODE_ENV=test — there is no
+    // "you had a safe SQLite path so I'll ignore the DATABASE_URL leak"
+    // branch. Only the DATABASE_URL refusal message is acceptable here.
+    const env = {
+      ...BASE_ENV,
+      NODE_ENV: "test",
+      DATABASE_URL: "postgres://leaked:pw@prod:5432/commhub",
+      COMMHUB_DB: "/tmp/anet-435-order-drift-canary.db",
+    };
+    expect(() => resolveDatabaseTarget(env)).toThrow(
+      /REFUSING to honor inherited DATABASE_URL/
+    );
+    // Cross-check: it must NOT throw the SQLite guard message either
+    // (which would imply the DATABASE_URL guard was reordered after the
+    // SQLite one and this test is passing by wrong-message accident).
+    let thrown: Error | null = null;
+    try { resolveDatabaseTarget(env); } catch (e) { thrown = e as Error; }
+    expect(thrown).not.toBeNull();
+    expect(thrown!.message).not.toMatch(/REFUSING to open the default SQLite database/);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -221,21 +245,23 @@ describe("L2 subprocess proof — createAdapter() refuses in a real Bun runtime"
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test("NODE_ENV=test + fake DATABASE_URL → refusal, PgAdapter banner NEVER printed", () => {
+  // The `bun -e` script drives the call graph:
+  //   import → createAdapter → resolveDatabaseTarget →
+  //   assertSafeTestDatabaseEnv (or SQLite guard) → throw.
+  // The wrapping try/catch is required — bun -e's top-level throw
+  // semantics don't reliably surface as a non-zero exit code otherwise.
+  const CHILD_SCRIPT =
+    "const m = require('./server/src/db-adapter.ts'); " +
+    "try { m.createAdapter(); console.log('UNEXPECTED_NO_THROW'); process.exit(0); } " +
+    "catch (e) { console.error(e.message); process.exit(2); }";
+
+  test("NODE_ENV=test + fake DATABASE_URL → DATABASE_URL guard refusal, no banners, no seam trigger", () => {
     const FAKE_PROD = "postgres://fake-prod-user:pw@prod.example:5432/commhub";
 
-    // Note: we spawn `bun -e` (not `bun run`) so no package.json script
-    // hooks interpose; the call graph is import → createAdapter →
-    // resolveDatabaseTarget → assertSafeTestDatabaseEnv → throw.
-    const script =
-      "const m = require('./server/src/db-adapter.ts'); " +
-      "try { m.createAdapter(); console.log('UNEXPECTED_NO_THROW'); process.exit(0); } " +
-      "catch (e) { console.error(e.message); process.exit(2); }";
-
-    // NB: strip the outer runner's DATABASE_URL to prove the child sees
-    // exactly what we hand it. The child env is a new object, not a
-    // spread of process.env.
-    const child = spawnSync("bun", ["-e", script], {
+    // NB: env is a new object, not a spread of process.env — we strip
+    // the outer runner's DATABASE_URL so the child sees exactly what
+    // we hand it.
+    const child = spawnSync("bun", ["-e", CHILD_SCRIPT], {
       cwd: join(__dirname, "..", ".."),
       env: {
         PATH: process.env.PATH || "",
@@ -244,35 +270,57 @@ describe("L2 subprocess proof — createAdapter() refuses in a real Bun runtime"
         DATABASE_URL: FAKE_PROD,
         // COMMHUB_DB deliberately unset — proves the DATABASE_URL guard
         // fires ahead of the SQLite guard in this specific ordering
-        // (which is the whole point of #435).
+        // (the whole point of #435).
       },
       encoding: "utf8",
       timeout: 15_000,
     });
 
-    // (a) Exit code — guard should have thrown, script's catch block
-    // exits 2. Anything else means the guard didn't fire and the
-    // process either resolved a real DB or hit a different error path.
+    // Exit + refusal + banner-absence assertions.
     expect(child.status).toBe(2);
-
-    // (b) The refusal message must be present verbatim (the operator
-    // sees this in their terminal; changing it silently would break
-    // muscle memory + docs cross-refs).
     expect(child.stderr).toMatch(/REFUSING to honor inherited DATABASE_URL/);
-
-    // (c) The "database: PostgreSQL" banner is emitted by createAdapter()
-    // ONLY after `resolveDatabaseTarget` returns { kind: "postgres" }.
-    // Its absence in stderr+stdout is the seam-not-triggered proof —
-    // if the guard order regressed and PgAdapter was constructed, the
-    // banner would print, and this assertion would fire.
+    // The "database: PostgreSQL" banner runs only after
+    // resolveDatabaseTarget returns { kind: "postgres" }. Absence =
+    // constructor seam not triggered.
     expect(child.stdout + child.stderr).not.toContain("database: PostgreSQL");
-
-    // (d) Similarly, the SQLite banner must not appear either — no
-    // default SQLite open happened before the throw.
+    // No default-SQLite banner either — no path calc, no mkdir, no
+    // Database() open happened before the throw.
     expect(child.stdout + child.stderr).not.toMatch(/\[commhub\] database: [^P]/);
+    // Sentinel from the script's else branch must NOT appear.
+    expect(child.stdout).not.toContain("UNEXPECTED_NO_THROW");
+  });
 
-    // (e) Also assert we didn't accidentally get the "UNEXPECTED_NO_THROW"
-    // sentinel from the script's else branch.
+  // #435 acceptance verbatim:
+  //   "subprocess test with both DB variables unset still proves the
+  //    existing SQLite refusal"
+  test("NODE_ENV=test + BOTH DATABASE_URL and COMMHUB_DB unset → SQLite refusal (real subprocess)", () => {
+    const child = spawnSync("bun", ["-e", CHILD_SCRIPT], {
+      cwd: join(__dirname, "..", ".."),
+      env: {
+        PATH: process.env.PATH || "",
+        HOME: tmpDir,
+        NODE_ENV: "test",
+        // BOTH DB vars deliberately absent (no key = no inheritance
+        // either, since env is a fresh object).
+      },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+
+    // Exit + refusal message + banner absence.
+    expect(child.status).toBe(2);
+    // Must be the SQLite guard message (the DATABASE_URL guard could
+    // not have fired here — DATABASE_URL wasn't set).
+    expect(child.stderr).toMatch(
+      /REFUSING to open the default SQLite database under NODE_ENV=test/,
+    );
+    // The DATABASE_URL guard's message must NOT be present — it would
+    // mean either a bug in the guard predicate or DATABASE_URL leaked
+    // into the child env from somewhere.
+    expect(child.stderr).not.toContain("REFUSING to honor inherited DATABASE_URL");
+    // No banners at all — nothing opened, nothing constructed.
+    expect(child.stdout + child.stderr).not.toContain("database: PostgreSQL");
+    expect(child.stdout + child.stderr).not.toMatch(/\[commhub\] database: [^P]/);
     expect(child.stdout).not.toContain("UNEXPECTED_NO_THROW");
   });
 });
@@ -281,12 +329,27 @@ describe("L2 subprocess proof — createAdapter() refuses in a real Bun runtime"
 //  L3 — syscall trace is 副指挥's independent Linux verification.
 //  This suite intentionally does NOT wrap the L2 subprocess in strace
 //  and claim "syscall proof PASS" — strace absence would downgrade to
-//  false confidence. The manual gate is:
+//  false confidence. The manual gate (run from repo root):
 //
-//    strace -ff -e trace=connect,openat \
-//      env NODE_ENV=test DATABASE_URL='postgres://fake:pw@prod:5432/commhub' \
-//        bun -e "require('./server/src/db-adapter.ts').createAdapter()" 2>&1 \
-//      | grep -E 'connect\([^)]*:5432|openat.*\.commhub/commhub\.db'
+//    strace -f -o /tmp/strace-435.log -e trace=connect,openat \
+//      env -u COMMHUB_DB NODE_ENV=test \
+//        DATABASE_URL='postgres://fake:pw@prod:5432/commhub' \
+//        bun -e "const m = require('./server/src/db-adapter.ts'); \
+//                try { m.createAdapter(); process.exit(0); } \
+//                catch(e) { console.error(e.message); process.exit(2); }"
 //
-//  Expected: zero matching lines. If any match appears, guard regressed.
+//    # (1) authoritative negative — ALL connect() during refusal
+//    #     path must be zero:
+//    grep -c 'connect(' /tmp/strace-435.log
+//
+//    # (2) diagnostic scope to PG port (sin_port field, not a naked
+//    #     :5432 substring — strace prints ports inside
+//    #     `sin_port=htons(5432)`):
+//    grep -Ec 'connect\([^)]*sin_port=htons\(5432\)' /tmp/strace-435.log
+//
+//    # (3) default SQLite path open — zero:
+//    grep -Ec 'openat\([^)]*\.commhub/commhub\.db' /tmp/strace-435.log
+//
+//  Expected: (1) 0, (2) 0, (3) 0. Naked `:5432` regex would
+//  false-negative on typical strace output — do not rely on it.
 // ═══════════════════════════════════════════════════════════════════════

--- a/server/src/db-adapter-guard.test.ts
+++ b/server/src/db-adapter-guard.test.ts
@@ -1,0 +1,292 @@
+// Issue #435 — reject inherited DATABASE_URL under NODE_ENV=test.
+//
+// Layered proof:
+//
+//   L1 — Pure-helper unit tests (in-process, deterministic).
+//        - `assertSafeTestDatabaseEnv(env)` throws for test+DATABASE_URL,
+//          silent for every other combination.
+//        - `resolveDatabaseTarget(env)` returns a `postgres` discriminant
+//          for production+DATABASE_URL — proving the branch selection
+//          works WITHOUT constructing PgAdapter or touching the network
+//          (per #435 acceptance: "no real external database endpoint is
+//          contacted during tests").
+//        - `resolveDatabaseTarget(env)` returns a `sqlite` discriminant
+//          with a mkdtemp path for legitimate production+COMMHUB_DB.
+//
+//   L2 — Subprocess negative test (single case).
+//        - Spawn `bun -e "…createAdapter()…"` with `NODE_ENV=test` and a
+//          FAKE-PROD `DATABASE_URL` that MUST NEVER resolve or be dialed.
+//          Assert: exit != 0, stderr contains the actionable refusal
+//          message, stderr does NOT contain the `database: PostgreSQL`
+//          banner (which the caller-side `console.log` emits only after
+//          the guard passes — the seam-not-triggered proof).
+//
+//   L3 — syscall trace (independent verification).
+//        - `strace -e connect,openat` around the L2 subprocess is left
+//          to 副指挥's Linux verifier; this suite prints the strace log
+//          when `strace` is available but does NOT claim "syscall proof
+//          PASS" (per #435 constraint — strace absence downgrades the
+//          gate to "functional stderr proof only, syscall verification
+//          pending").
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "child_process";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  assertSafeTestDatabaseEnv,
+  resolveDatabaseTarget,
+} from "./db-adapter";
+
+// Base env used to construct scenario envs — deliberately EXCLUDES the
+// caller's real `process.env` so leaked shell variables cannot flip a
+// test outcome. Individual tests spread the fields they need.
+const BASE_ENV: NodeJS.ProcessEnv = { HOME: "/nonexistent" };
+
+// ═══════════════════════════════════════════════════════════════════════
+//  L1 — Pure-helper tests
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("assertSafeTestDatabaseEnv — fail-closed test guard", () => {
+  test("throws under NODE_ENV=test + DATABASE_URL=postgres://…", () => {
+    const env = {
+      ...BASE_ENV,
+      NODE_ENV: "test",
+      DATABASE_URL: "postgres://leaked-prod-user:pw@prod.example:5432/commhub",
+    };
+    expect(() => assertSafeTestDatabaseEnv(env)).toThrow(
+      /REFUSING to honor inherited DATABASE_URL/
+    );
+  });
+
+  test("throws under NODE_ENV=test + DATABASE_URL=postgresql://…", () => {
+    const env = {
+      ...BASE_ENV,
+      NODE_ENV: "test",
+      DATABASE_URL: "postgresql://u:p@127.0.0.1:5432/anything",
+    };
+    expect(() => assertSafeTestDatabaseEnv(env)).toThrow(
+      /REFUSING to honor inherited DATABASE_URL/
+    );
+  });
+
+  test("throws under NODE_ENV=test + DATABASE_URL that ISN'T postgres (no bypass by scheme)", () => {
+    // Even a nonsense DATABASE_URL under NODE_ENV=test must refuse — the
+    // guard is fail-closed on the ENV being present, not on it being a
+    // postgres URL. This closes the "sqlite://…" / "junk" bypass class.
+    const env = {
+      ...BASE_ENV,
+      NODE_ENV: "test",
+      DATABASE_URL: "sqlite:///tmp/whatever",
+    };
+    expect(() => assertSafeTestDatabaseEnv(env)).toThrow(
+      /REFUSING to honor inherited DATABASE_URL/
+    );
+  });
+
+  test("silent under NODE_ENV=test with both DB envs unset (SQLite guard covers this later)", () => {
+    const env = { ...BASE_ENV, NODE_ENV: "test" };
+    expect(() => assertSafeTestDatabaseEnv(env)).not.toThrow();
+  });
+
+  test("silent under NODE_ENV=production with DATABASE_URL set", () => {
+    // Production runtime must be unaffected — the whole point of the
+    // ordering fix is that the guard sits BEFORE branch selection but
+    // only fires when NODE_ENV=test.
+    const env = {
+      ...BASE_ENV,
+      NODE_ENV: "production",
+      DATABASE_URL: "postgres://prod-user:pw@prod.example:5432/commhub",
+    };
+    expect(() => assertSafeTestDatabaseEnv(env)).not.toThrow();
+  });
+
+  test("silent under NODE_ENV unset with DATABASE_URL set", () => {
+    // "NODE_ENV unset" is the normal server-boot case (index.ts doesn't
+    // set it). Must not trip the guard.
+    const env = { ...BASE_ENV, DATABASE_URL: "postgres://…" };
+    expect(() => assertSafeTestDatabaseEnv(env)).not.toThrow();
+  });
+
+  test("silent under NODE_ENV=development with DATABASE_URL", () => {
+    const env = { ...BASE_ENV, NODE_ENV: "development", DATABASE_URL: "postgres://…" };
+    expect(() => assertSafeTestDatabaseEnv(env)).not.toThrow();
+  });
+});
+
+describe("resolveDatabaseTarget — pure branch decision, no construction", () => {
+  test("production + DATABASE_URL=postgres://… → { kind: postgres, url } (no connection)", () => {
+    // This is the production-mode regression proof. The pure function
+    // returns the discriminant; no PgAdapter is ever constructed, no
+    // socket is dialed, no packet leaves. Production dispatch is
+    // covered end-to-end at the branch level — that's the entire point
+    // of extracting the pure resolver.
+    const url = "postgres://prod-user:pw@prod.example:5432/commhub";
+    const env = { ...BASE_ENV, NODE_ENV: "production", DATABASE_URL: url };
+    const target = resolveDatabaseTarget(env);
+    expect(target).toEqual({ kind: "postgres", url });
+  });
+
+  test("production + DATABASE_URL=postgresql://… → { kind: postgres, url }", () => {
+    const url = "postgresql://user:pw@host:5432/db";
+    const env = { ...BASE_ENV, NODE_ENV: "production", DATABASE_URL: url };
+    expect(resolveDatabaseTarget(env)).toEqual({ kind: "postgres", url });
+  });
+
+  test("NODE_ENV unset + DATABASE_URL=postgres://… → { kind: postgres, url }", () => {
+    // Server boot in the wild — index.ts doesn't set NODE_ENV. The
+    // resolver must still route to the postgres discriminant.
+    const url = "postgres://u:p@h:5432/d";
+    const env = { ...BASE_ENV, DATABASE_URL: url };
+    expect(resolveDatabaseTarget(env)).toEqual({ kind: "postgres", url });
+  });
+
+  test("production + COMMHUB_DB set → { kind: sqlite, path: COMMHUB_DB }", () => {
+    // No side effects — mkdtempSync only, target should echo the path.
+    const dir = mkdtempSync(join(tmpdir(), "anet-435-sqlite-prod-"));
+    const dbPath = join(dir, "commhub.db");
+    try {
+      const env = { ...BASE_ENV, NODE_ENV: "production", COMMHUB_DB: dbPath };
+      expect(resolveDatabaseTarget(env)).toEqual({ kind: "sqlite", path: dbPath });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("test + COMMHUB_DB set → { kind: sqlite, path } (SQLite guard silent when path supplied)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "anet-435-sqlite-test-"));
+    const dbPath = join(dir, "commhub.db");
+    try {
+      const env = { ...BASE_ENV, NODE_ENV: "test", COMMHUB_DB: dbPath };
+      expect(resolveDatabaseTarget(env)).toEqual({ kind: "sqlite", path: dbPath });
+    } finally {
+      // Case 4 cleanup: nothing was written (pure resolver returned only),
+      // but tidy anyway.
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("test + all DB envs unset → SQLite guard throws (existing behavior preserved)", () => {
+    const env = { ...BASE_ENV, NODE_ENV: "test" };
+    expect(() => resolveDatabaseTarget(env)).toThrow(
+      /REFUSING to open the default SQLite database under NODE_ENV=test/
+    );
+  });
+
+  test("test + DATABASE_URL set → DATABASE_URL guard fires FIRST (before SQLite guard)", () => {
+    // The whole ordering fix: the DATABASE_URL guard must be reached
+    // ahead of any SQLite guard so an inherited prod URL can't slip
+    // past by "the SQLite guard would have caught missing COMMHUB_DB".
+    // Assert the DATABASE_URL message, not the SQLite one.
+    const env = {
+      ...BASE_ENV,
+      NODE_ENV: "test",
+      DATABASE_URL: "postgres://leaked:pw@prod:5432/commhub",
+      // COMMHUB_DB deliberately unset — if the DATABASE_URL guard is
+      // reordered wrong, we'd get the SQLite refusal instead.
+    };
+    expect(() => resolveDatabaseTarget(env)).toThrow(
+      /REFUSING to honor inherited DATABASE_URL/
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+//  L2 — Subprocess negative test (single case, real spawn)
+// ═══════════════════════════════════════════════════════════════════════
+//
+// Per #435: "subprocess test with NODE_ENV=test + fake DATABASE_URL gets
+// a stable actionable refusal". Only the fake-prod URL case is exercised
+// via subprocess — production regression stays pure-helper (no external
+// endpoint contacted).
+
+describe("L2 subprocess proof — createAdapter() refuses in a real Bun runtime", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "anet-435-l2-"));
+  });
+
+  afterEach(() => {
+    // Case 4 cleanup: db + WAL + SHM, then the dir itself. rmSync with
+    // recursive:true handles the leftover shape regardless of what got
+    // touched (guard should have short-circuited before any file open,
+    // but we tidy in either direction so a false-positive can't leak a
+    // half-created file into /tmp).
+    for (const suffix of ["", "-wal", "-shm"]) {
+      const p = join(tmpDir, `commhub.db${suffix}`);
+      if (existsSync(p)) rmSync(p, { force: true });
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("NODE_ENV=test + fake DATABASE_URL → refusal, PgAdapter banner NEVER printed", () => {
+    const FAKE_PROD = "postgres://fake-prod-user:pw@prod.example:5432/commhub";
+
+    // Note: we spawn `bun -e` (not `bun run`) so no package.json script
+    // hooks interpose; the call graph is import → createAdapter →
+    // resolveDatabaseTarget → assertSafeTestDatabaseEnv → throw.
+    const script =
+      "const m = require('./server/src/db-adapter.ts'); " +
+      "try { m.createAdapter(); console.log('UNEXPECTED_NO_THROW'); process.exit(0); } " +
+      "catch (e) { console.error(e.message); process.exit(2); }";
+
+    // NB: strip the outer runner's DATABASE_URL to prove the child sees
+    // exactly what we hand it. The child env is a new object, not a
+    // spread of process.env.
+    const child = spawnSync("bun", ["-e", script], {
+      cwd: join(__dirname, "..", ".."),
+      env: {
+        PATH: process.env.PATH || "",
+        HOME: tmpDir,
+        NODE_ENV: "test",
+        DATABASE_URL: FAKE_PROD,
+        // COMMHUB_DB deliberately unset — proves the DATABASE_URL guard
+        // fires ahead of the SQLite guard in this specific ordering
+        // (which is the whole point of #435).
+      },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+
+    // (a) Exit code — guard should have thrown, script's catch block
+    // exits 2. Anything else means the guard didn't fire and the
+    // process either resolved a real DB or hit a different error path.
+    expect(child.status).toBe(2);
+
+    // (b) The refusal message must be present verbatim (the operator
+    // sees this in their terminal; changing it silently would break
+    // muscle memory + docs cross-refs).
+    expect(child.stderr).toMatch(/REFUSING to honor inherited DATABASE_URL/);
+
+    // (c) The "database: PostgreSQL" banner is emitted by createAdapter()
+    // ONLY after `resolveDatabaseTarget` returns { kind: "postgres" }.
+    // Its absence in stderr+stdout is the seam-not-triggered proof —
+    // if the guard order regressed and PgAdapter was constructed, the
+    // banner would print, and this assertion would fire.
+    expect(child.stdout + child.stderr).not.toContain("database: PostgreSQL");
+
+    // (d) Similarly, the SQLite banner must not appear either — no
+    // default SQLite open happened before the throw.
+    expect(child.stdout + child.stderr).not.toMatch(/\[commhub\] database: [^P]/);
+
+    // (e) Also assert we didn't accidentally get the "UNEXPECTED_NO_THROW"
+    // sentinel from the script's else branch.
+    expect(child.stdout).not.toContain("UNEXPECTED_NO_THROW");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+//  L3 — syscall trace is 副指挥's independent Linux verification.
+//  This suite intentionally does NOT wrap the L2 subprocess in strace
+//  and claim "syscall proof PASS" — strace absence would downgrade to
+//  false confidence. The manual gate is:
+//
+//    strace -ff -e trace=connect,openat \
+//      env NODE_ENV=test DATABASE_URL='postgres://fake:pw@prod:5432/commhub' \
+//        bun -e "require('./server/src/db-adapter.ts').createAdapter()" 2>&1 \
+//      | grep -E 'connect\([^)]*:5432|openat.*\.commhub/commhub\.db'
+//
+//  Expected: zero matching lines. If any match appears, guard regressed.
+// ═══════════════════════════════════════════════════════════════════════

--- a/server/src/db-adapter.ts
+++ b/server/src/db-adapter.ts
@@ -213,41 +213,77 @@ export class PgAdapter implements DbAdapter {
 // ════════════════════════════════════════════
 
 /**
- * Create the appropriate adapter based on environment.
- * - DATABASE_URL starts with "postgres://" → PgAdapter
- * - Otherwise → SQLiteAdapter with COMMHUB_DB or default path
- *
- * Test-default-prod GUARD: when `NODE_ENV === "test"` (set automatically by
- * `bun test`) AND `COMMHUB_DB` is unset, we REFUSE to fall through to the
- * default `~/.commhub/commhub.db` path. Several modules (notably
- * `server/src/auth.ts register()`) write into the configured database at
- * import-time-side-effect granularity; running their tests against the
- * production hub DB silently created spurious users / networks / tokens
- * on 2026-06-23 (4u / 4net / 8tok by one `bun -e` probe + an unknown
- * pre-existing history of test pollution in the same DB). The guard makes
- * the failure mode loud + actionable instead of silent + destructive.
- *
- * The guard does NOT fire when:
- *   - COMMHUB_DB is set (the test runner's documented contract); or
- *   - NODE_ENV is unset (production server) or any non-"test" value.
- *
- * Operators who run `bun -e` snippets that touch the DB are expected to
- * `COMMHUB_DB=/tmp/...` themselves — `bun -e` doesn't set NODE_ENV, so the
- * guard can't catch that case. The rule (never read or write the
- * production hub database) is documented in CLAUDE.md.
+ * Discriminant describing which adapter to build. Split out from
+ * `createAdapter()` so all env-driven decisions live in a pure function
+ * that can be unit-tested without constructing a database connection
+ * (issue #435 — see `db-adapter-guard.test.ts`).
  */
-export function createAdapter(): DbAdapter {
-  const dbUrl = process.env.DATABASE_URL;
-  if (dbUrl && (dbUrl.startsWith("postgres://") || dbUrl.startsWith("postgresql://"))) {
-    console.log("[commhub] database: PostgreSQL");
-    return new PgAdapter(dbUrl);
-  }
-  // Default: SQLite
-  const { mkdirSync } = require("fs");
-  const { dirname } = require("path");
+export type DbTarget =
+  | { kind: "postgres"; url: string }
+  | { kind: "sqlite"; path: string };
 
-  // Test-default-prod GUARD (see docblock above).
-  if (process.env.NODE_ENV === "test" && !process.env.COMMHUB_DB) {
+/**
+ * Fail-closed test-safety guard (#435). Under `NODE_ENV=test`, ANY
+ * inherited `DATABASE_URL` is refused unconditionally — no opt-in
+ * flag, no naming-regex escape hatch, no bypass. A future isolated
+ * PostgreSQL test harness will land under a separate RFC/issue with
+ * explicit review; this P0 just closes the ordering hole where
+ * `createAdapter()` used to construct `PgAdapter(dbUrl)` before the
+ * SQLite guard ever fired, letting an inherited prod URL bypass every
+ * existing safety net.
+ *
+ * Production behavior (`NODE_ENV != "test"`) is unchanged: this helper
+ * returns silently and the caller proceeds to whichever branch the URL
+ * indicates.
+ *
+ * Exported so tests can drive it directly with a controlled env object.
+ */
+export function assertSafeTestDatabaseEnv(env: NodeJS.ProcessEnv = process.env): void {
+  if (env.NODE_ENV === "test" && env.DATABASE_URL) {
+    throw new Error(
+      "[commhub] REFUSING to honor inherited DATABASE_URL under NODE_ENV=test.\n" +
+      "  This test guard is fail-closed by design (issue #435). Normal test\n" +
+      "  runners must `unset DATABASE_URL` before invoking `bun test`.\n" +
+      "  Production runs (NODE_ENV != \"test\") are unaffected. A future\n" +
+      "  isolated PostgreSQL test harness will land under a separate RFC/issue\n" +
+      "  with explicit review; this build refuses ANY inherited DATABASE_URL\n" +
+      "  under NODE_ENV=test, with no opt-in bypass."
+    );
+  }
+}
+
+/**
+ * Pure decision function: given an env object, return the target
+ * discriminant. Constructs nothing, opens nothing, connects to nothing.
+ * Called by `createAdapter()` after `assertSafeTestDatabaseEnv()` passes.
+ *
+ * Exported so production-branch regression tests can prove
+ * `NODE_ENV=production + DATABASE_URL=postgres://...` returns
+ * `{ kind: "postgres", url }` without the test needing to actually open
+ * a PostgreSQL connection (per #435: "no real external database
+ * endpoint is contacted during tests").
+ *
+ * Test-default-prod SQLite GUARD (kept as before, now inside this
+ * pure function): when `NODE_ENV === "test"` AND `COMMHUB_DB` is unset,
+ * we REFUSE to fall through to the default `~/.commhub/commhub.db`
+ * path. Several modules (notably `server/src/auth.ts register()`)
+ * write into the configured database at import-time-side-effect
+ * granularity; running their tests against the production hub DB
+ * silently created spurious users / networks / tokens on 2026-06-23
+ * (4u / 4net / 8tok by one `bun -e` probe + an unknown pre-existing
+ * history of test pollution in the same DB). The guard makes the
+ * failure mode loud + actionable instead of silent + destructive.
+ */
+export function resolveDatabaseTarget(env: NodeJS.ProcessEnv = process.env): DbTarget {
+  assertSafeTestDatabaseEnv(env);
+
+  const dbUrl = env.DATABASE_URL;
+  if (dbUrl && (dbUrl.startsWith("postgres://") || dbUrl.startsWith("postgresql://"))) {
+    return { kind: "postgres", url: dbUrl };
+  }
+
+  // Test-default-prod SQLite GUARD.
+  if (env.NODE_ENV === "test" && !env.COMMHUB_DB) {
     throw new Error(
       "[commhub] REFUSING to open the default SQLite database under NODE_ENV=test.\n" +
       "  Tests must explicitly set COMMHUB_DB to a throwaway path so they don't\n" +
@@ -257,10 +293,32 @@ export function createAdapter(): DbAdapter {
     );
   }
 
-  const dbPath = process.env.COMMHUB_DB || `${process.env.HOME}/.commhub/commhub.db`;
-  mkdirSync(dirname(dbPath), { recursive: true });
-  console.log(`[commhub] database: ${dbPath}`);
-  const rawDb = new Database(dbPath);
+  const dbPath = env.COMMHUB_DB || `${env.HOME}/.commhub/commhub.db`;
+  return { kind: "sqlite", path: dbPath };
+}
+
+/**
+ * Create the appropriate adapter based on environment. Decision is
+ * delegated to `resolveDatabaseTarget()` (which runs
+ * `assertSafeTestDatabaseEnv()` first) so that:
+ *   1. the test-safety guard fires BEFORE any adapter construction or
+ *      network activity, and
+ *   2. env-driven branching is unit-testable without a live DB.
+ */
+export function createAdapter(): DbAdapter {
+  const target = resolveDatabaseTarget();
+
+  if (target.kind === "postgres") {
+    console.log("[commhub] database: PostgreSQL");
+    return new PgAdapter(target.url);
+  }
+
+  // SQLite
+  const { mkdirSync } = require("fs");
+  const { dirname } = require("path");
+  mkdirSync(dirname(target.path), { recursive: true });
+  console.log(`[commhub] database: ${target.path}`);
+  const rawDb = new Database(target.path);
   rawDb.exec("PRAGMA journal_mode=WAL");
   rawDb.exec("PRAGMA busy_timeout=5000");
   return new SQLiteAdapter(rawDb);


### PR DESCRIPTION
Fixes #435 — closes the ordering hole where `createAdapter()` on `d418862` selected the PostgreSQL branch **before** the `NODE_ENV=test` SQLite guard fired, so an inherited prod `DATABASE_URL` under `bun test` opened a socket to prod PostgreSQL.

**Draft — do not merge.** Reviewers: **通信龙** (lead) + **副指挥** (coordinator, independent Linux strace verification). Author does not self-approve per issue acceptance.

## What changed

Only three files:

- `server/src/db-adapter.ts` — extract two pure helpers so the guard runs before any branch construction:
  - `assertSafeTestDatabaseEnv(env)` — fail-closed: `NODE_ENV=test && DATABASE_URL` → throw. **No opt-in, no naming-regex, no bypass.** A future isolated PostgreSQL test harness lands under a separate RFC/issue.
  - `resolveDatabaseTarget(env)` — pure branch decision returning `{ kind: "postgres", url } | { kind: "sqlite", path }`. Constructs nothing, opens nothing.
  - `createAdapter()` — now just consumes the discriminant.
  - Existing SQLite `NODE_ENV=test + unset COMMHUB_DB` guard preserved verbatim, now inside `resolveDatabaseTarget`.
- `server/src/db-adapter-guard.test.ts` — new; **15 pass / 19 expects**.
- `docs/tests/db-test-safety.md` — new; short operator-facing SOP.

**No** test-aggregate runner, **no** preload script, **no** package.json edits, **no** changes to any other test file. `#434` is not touched by this PR.

## Test layering

- **L1 pure-helper units** (in-process, no construction):
  - test + DATABASE_URL variants (postgres://, postgresql://, other schemes) → all throw
  - production + DATABASE_URL variants → return `{ kind: "postgres", url }` **without constructing PgAdapter or contacting any endpoint** — this is the "no real external database endpoint is contacted during tests" acceptance line
  - production + COMMHUB_DB set → `{ kind: "sqlite", path }` (mkdtemp)
  - test + all unset → SQLite guard throws (existing behavior preserved)
  - test + DATABASE_URL + no COMMHUB_DB → DATABASE_URL guard throws (proves ordering; SQLite guard doesn't shadow)
- **L2 subprocess negative test** (single case, real `bun -e`):
  - `NODE_ENV=test` + fake-prod DATABASE_URL that must never be dialed
  - asserts exit ≠ 0, stderr contains refusal, `[commhub] database: PostgreSQL` banner **absent** (constructor-seam-not-triggered proof)
  - `mkdtemp` workspace, `afterEach` cleans `db / db-wal / db-shm`
- **L3 strace verification** — external Linux gate, not automated inside the suite (strace absence would degrade to false confidence). Run:

```
strace -f -e trace=connect,openat \
  env -u COMMHUB_DB NODE_ENV=test \
  DATABASE_URL='postgres://fake-prod:pw@prod.example:5432/commhub' \
  bun -e "const m = require('./src/db-adapter.ts'); \
          try { m.createAdapter(); process.exit(0); } \
          catch(e) { console.error(e.message); process.exit(2); }"
```

Local L3 result on this branch (Ubuntu, strace 5.16, from `/tmp/p-435-db-guard/server`):

```
  exit code: 2
  connect() to :5432 matches: 0
  openat of default SQLite path matches: 0
  "REFUSING to honor inherited DATABASE_URL" — present in stderr
  "database: PostgreSQL" banner: absent
```

## Full server-suite counts (3× consecutive, deterministic)

```
  run 1:  530 pass  8 fail  1537 expect() calls
  run 2:  530 pass  8 fail  1537 expect() calls
  run 3:  530 pass  8 fail  1537 expect() calls
```

= baseline `515 pass / 8 fail / 1518 expects` + guard test `15 pass / 19 expects`. Zero regression, zero new failures. The 8 failures are the unchanged `api-host-supervisors-fallback` isolation debt (`#434`).

## Acceptance checklist (from #435)

- [x] subprocess test with `NODE_ENV=test` + fake `DATABASE_URL` gets a stable actionable refusal
- [x] syscall trace proves zero PostgreSQL `connect()` calls and zero default SQLite opens before refusal (L3 above)
- [x] subprocess test with both DB variables unset still proves the existing SQLite refusal (L1 pure-helper unit `test + all unset → SQLite guard throws`)
- [x] production-mode unit coverage proves a legitimate `DATABASE_URL` still selects PostgreSQL (L1 pure-helper unit — no external DB contacted)
- [x] no real external database endpoint is contacted during tests
- [ ] independent review by the RFC-030 coordinator (副指挥 — pending)

## Scope constraints (per dispatch)

- **Do not merge**, do not deploy.
- Author does not self-approve.
- Independent clean worktree from `origin/main` `d418862`.
- Two-to-three-file scope: exactly `db-adapter.ts` + `db-adapter-guard.test.ts` + `docs/tests/db-test-safety.md`.
- `#434` untouched (aggregate-runner work is a separate PR that must not land until this one merges).