### PR TITLE
feat(rfc-030): anet node start --copresence — codex 人机共存一等公民命令

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -10,7 +10,7 @@
  * anet run                     独立 SSE Agent
  */
 
-import { chmodSync, readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync, renameSync, rmSync, cpSync } from "fs";
+import { chmodSync, readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync, renameSync, rmSync, cpSync, unlinkSync } from "fs";
 import { dirname, isAbsolute, join } from "path";
 import { fileURLToPath } from "url";
 import { homedir } from "os";
@@ -183,8 +183,14 @@ async function createCodexCopresenceThread(ws: string, timeoutMs = 60_000): Prom
       const p = pending.get(msg.id);
       if (!p) return;
       pending.delete(msg.id);
-      if (msg.error) p.reject(new Error(`${msg.error.code}: ${msg.error.message}`));
-      else p.resolve(msg.result);
+      if (msg.error) {
+        // #P2fix复审顺手4 — attach .code so isAlreadyInitializedError's
+        // code-based branch is live (mirrors codex-app-server-client.ts
+        // where the shared client attaches err.error.code).
+        const rpcErr = new Error(`${msg.error.code}: ${msg.error.message}`);
+        (rpcErr as Error & { code?: number }).code = msg.error.code;
+        p.reject(rpcErr);
+      } else p.resolve(msg.result);
     }
   });
   const request = (method: string, params: any, timeoutMsInner: number) => new Promise<any>((resolve, reject) => {
@@ -267,8 +273,15 @@ function assertSafeHubUrl(hub: string): void {
 // `tmux send-keys` (writes into pane history).
 function writeCodexCopresenceEnvFile(codexHome: string, token: string): string {
   const envPath = join(codexHome, ".anet-copresence.env");
-  writeFileSync(envPath, `export ANET_CODEX_COMMHUB_TOKEN=${shellQuote(token)}\n`);
-  chmodSync(envPath, 0o600);
+  // #P2fix复审必修 — TOCTOU + symlink-follow attack surface.
+  // Without pre-unlink, a pre-existing symlink at envPath would be followed
+  // by writeFileSync and write the token to the link target (rm -f later only
+  // removes the link, not the target). Without flag:"wx", writeFileSync creates
+  // the file at umask default (typically 0644) and the chmod-to-0600 race is
+  // observable to any world-readable scan.
+  try { unlinkSync(envPath); } catch (err: any) { if (err?.code !== "ENOENT") throw err; }
+  writeFileSync(envPath, `export ANET_CODEX_COMMHUB_TOKEN=${shellQuote(token)}\n`, { mode: 0o600, flag: "wx" });
+  chmodSync(envPath, 0o600);  // belt-and-suspenders in case older node ignores mode option
   return envPath;
 }
 
@@ -374,7 +387,17 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   }
 
   mkdirSync(opts.codexHome, { recursive: true });
-  try { chmodSync(opts.codexHome, 0o700); } catch { /* best-effort */ }
+  // #P2fix复审顺手2 — 0700 on the parent is a load-bearing invariant for the
+  // 0600 env file inside; if we can't enforce it, refuse to start rather than
+  // silently degrade to whatever perms already exist.
+  try {
+    chmodSync(opts.codexHome, 0o700);
+  } catch (e: any) {
+    console.error(`[anet] ❌ cannot set 0700 on CODEX_HOME (${opts.codexHome}): ${e?.message || e}`);
+    console.error(`[anet]    The token env file requires a 0700 parent directory.`);
+    console.error(`[anet]    Fix perms manually (chmod 700 ${shellQuote(opts.codexHome)}) or point --codex-home elsewhere.`);
+    process.exit(1);
+  }
 
   const { appsrv: appsrvSession, bridge: bridgeSession, tui: tuiSession } =
     copresenceTmuxSessions(displayName);
@@ -432,6 +455,10 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     console.error(`[anet] ❌ app-server did not bind ${wsUrl} within 25s.`);
     console.error(`[anet]    Debug:   tmux attach -t ${appsrvSession}`);
     console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
+    // #P2fix复审顺手3 — env file was source-then-rm'd by the tmux child on
+    // the happy path, but if the bash chain crashed before reaching `rm -f`
+    // (e.g. the `.` failed) the token file could linger. Defense-in-depth.
+    try { rmSync(envFilePath, { force: true }); } catch { /* best-effort */ }
     process.exit(1);
   }
   console.log(`[anet] ① app-server READY on ${wsUrl}`);
@@ -444,6 +471,8 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     console.error(`[anet] ❌ thread/start failed: ${e?.message || e}`);
     console.error(`[anet]    Debug:   tmux attach -t ${appsrvSession}`);
     console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
+    // #P2fix复审顺手3 — defense-in-depth env-file cleanup (see :431).
+    try { rmSync(envFilePath, { force: true }); } catch { /* best-effort */ }
     process.exit(1);
   }
   // #P2fix顺手3 — defense-in-depth shape check before threadId flows into
@@ -452,6 +481,8 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   if (!SAFE_THREAD_ID.test(threadId)) {
     console.error(`[anet] internal error: unexpected threadId shape (rejected before shell interpolation)`);
     console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
+    // #P2fix复审顺手3 — defense-in-depth env-file cleanup (see :431).
+    try { rmSync(envFilePath, { force: true }); } catch { /* best-effort */ }
     process.exit(1);
   }
   console.log(`[anet] thread: ${threadId}`);

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -204,7 +204,11 @@ async function createCodexCopresenceThread(ws: string, timeoutMs = 60_000): Prom
         clientInfo: { name: "anet-copresence-creator", title: "creator", version: "0.0.1" },
       }, 10_000);
       notify("initialized", {});
-    } catch { /* already initialized on shared server */ }
+    } catch (e) {
+      // #P2fix顺手4 — only swallow "already initialized" on the shared
+      // server path; every other initialize failure is real.
+      if (!isAlreadyInitializedError(e)) throw e;
+    }
     const started: any = await request("thread/start", {}, 15_000);
     const threadId: string | undefined = started?.threadId ?? started?.thread?.id;
     if (!threadId) throw new Error("thread/start returned no threadId");
@@ -232,12 +236,66 @@ function copresenceTmuxSessions(displayName: string): { appsrv: string; bridge: 
   return { appsrv: `${displayName}-appsrv`, bridge: `${displayName}-桥`, tui: displayName };
 }
 
+// #P2fix必修2 — validate hub URL for the --copresence codepath before it
+// interpolates into a bash -c argument. `hub` comes from the project-local
+// `.anet/nodes/<id>/config.json`, so a hostile checkout could plant a URL
+// containing shell metacharacters. URL parsing catches most junk; the
+// explicit-char reject is defense-in-depth (backtick / dollar / quote would
+// break out of the outer single-quoted wrapper even if URL.parse accepted).
+const UNSAFE_HUB_CHARS = /['"`$;|&\r\n\t\\]/;
+function assertSafeHubUrl(hub: string): void {
+  if (typeof hub !== "string" || !hub) {
+    throw new Error("hub URL is empty");
+  }
+  if (UNSAFE_HUB_CHARS.test(hub)) {
+    const printable = hub.replace(/[^\x20-\x7e]/g, "?");
+    throw new Error(`invalid hub URL (contains disallowed character): ${printable}`);
+  }
+  let parsed: URL;
+  try { parsed = new URL(hub); }
+  catch { throw new Error(`invalid hub URL (not parseable): ${hub}`); }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`invalid hub URL (scheme must be http/https): ${hub}`);
+  }
+}
+
+// #P2fix必修1 — token must NOT appear in argv or tmux pane_start_command.
+// Writes ANET_CODEX_COMMHUB_TOKEN to a 0600 file inside <codexHome> (0700);
+// the tmux child sources then removes it before exec'ing codex, so the
+// value never reaches /proc/*/cmdline nor tmux's pane_start_command.
+// Do NOT use `tmux new-session -e KEY=VAL` (env pairs are argv) or
+// `tmux send-keys` (writes into pane history).
+function writeCodexCopresenceEnvFile(codexHome: string, token: string): string {
+  const envPath = join(codexHome, ".anet-copresence.env");
+  writeFileSync(envPath, `export ANET_CODEX_COMMHUB_TOKEN=${shellQuote(token)}\n`);
+  chmodSync(envPath, 0o600);
+  return envPath;
+}
+
+// #P2fix顺手3 — threadId comes from our own JSON-RPC thread/start response
+// (server-generated UUID / ULID / opaque token), but we interpolate it into
+// a bash string, so a strict-shape check is cheap defense-in-depth against
+// a protocol change or a compromised app-server.
+const SAFE_THREAD_ID = /^[A-Za-z0-9_-]+$/;
+
+// #P2fix顺手4 — mirrors codex-app-server-bridge.ts:isAlreadyInitialized.
+// Only "already initialized" (code -32600 or matching message) is expected
+// on the shared-server bootstrap path; every other initialize failure is
+// real and must re-throw. Inline copy — cli.ts stays package-boundary-free.
+function isAlreadyInitializedError(e: unknown): boolean {
+  const code = (e as { code?: unknown })?.code;
+  if (code === -32600) return true;
+  const msg = (e as { message?: unknown })?.message;
+  return typeof msg === "string" && /already initialized/i.test(msg);
+}
+
 interface CopresenceOptions {
   codexBin: string;
   codexHome: string;
   model?: string;
   port?: number;
   dangerFullAccess: boolean;
+  yesDangerFullAccess: boolean;
   hub: string;
   token: string;
 }
@@ -272,22 +330,44 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     process.exit(1);
   }
 
+  // #P2fix必修2 — hub URL sanity before any interpolation into bash -c.
+  // Rejects bad schemes, empty, and shell-metacharacter contamination.
+  try { assertSafeHubUrl(opts.hub); }
+  catch (e: any) {
+    console.error(`[anet] ❌ ${e?.message || String(e)}`);
+    console.error(`[anet]    Fix: correct the hub URL in ${join(nodesDir(), resolved.id, "config.json")} (or global .anet/config.json).`);
+    process.exit(1);
+  }
+
   // Risk C double safeguard — dangerous sandbox is never the default.
   // Requires: explicit CLI flag (opts.dangerFullAccess) + typed 'yes' at
-  // start + stderr banner every launch.
+  // start (TTY caller) OR a second explicit --yes-danger-full-access flag
+  // (non-TTY caller) — the two-flag non-TTY path blocks a piped-yes bypass
+  // (`printf 'yes\n' | anet node start …`) while giving CI/Docker E2E an
+  // opt-in route. Stderr banner fires either way.
   if (opts.dangerFullAccess) {
     console.error("");
     console.error(`⚠  --dangerously-allow-full-access ENABLED for ${displayName}`);
     console.error("   This grants the codex session unrestricted filesystem/network access.");
     console.error("   Read-only default is safer; only enable if you understand the risk.");
     console.error("");
-    const ok = await askTypedConfirmation(
-      "   Type 'yes' to confirm (any other input aborts): ",
-      "yes",
-    );
-    if (!ok) {
-      console.error("[anet] aborted (danger-full-access not confirmed).");
-      process.exit(1);
+    if (process.stdin.isTTY) {
+      const ok = await askTypedConfirmation(
+        "   Type 'yes' to confirm (any other input aborts): ",
+        "yes",
+      );
+      if (!ok) {
+        console.error("[anet] aborted (danger-full-access not confirmed).");
+        process.exit(1);
+      }
+    } else {
+      if (!opts.yesDangerFullAccess) {
+        console.error("[anet] aborted: danger-full-access needs an interactive TTY, or");
+        console.error("       both --dangerously-allow-full-access AND --yes-danger-full-access");
+        console.error("       (second explicit flag prevents `printf 'yes\\n' |` bypass in scripts).");
+        process.exit(1);
+      }
+      console.error("[anet] non-TTY danger opt-in via --yes-danger-full-access — proceeding");
     }
     console.error(`[anet] ⚠ codex 共存节点 ${displayName} 以 danger-full-access 模式运行`);
     console.error(`[anet] ⚠ (no filesystem or network sandbox; codex may write/delete freely)`);
@@ -315,16 +395,25 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   const model = opts.model || "gpt-5.5";
 
   // ── piece ① codex app-server (loopback WS + commhub MCP) ──────────────
+  // #P2fix必修1 — token to 0600 file, sourced-then-removed inside the tmux
+  // child. Never appears in argv / /proc/*/cmdline / tmux pane_start_command.
+  const envFilePath = writeCodexCopresenceEnvFile(opts.codexHome, opts.token);
+  // #P2fix必修2 — shellQuote every `-c` TOML fragment (including the hub
+  // URL fragment). assertSafeHubUrl was called above; shellQuote guards
+  // even in the face of a validator regression.
+  const hubMcpUrlToml = `mcp_servers.commhub.url="${opts.hub}/mcp"`;
+  const bearerTomlLiteral = `mcp_servers.commhub.bearer_token_env_var="ANET_CODEX_COMMHUB_TOKEN"`;
   const appsrvCmd = [
     `export CODEX_HOME=${shellQuote(opts.codexHome)}`,
-    `export ANET_CODEX_COMMHUB_TOKEN=${shellQuote(opts.token)}`,
+    `. ${shellQuote(envFilePath)}`,
+    `rm -f ${shellQuote(envFilePath)}`,
     `clear`,
     `exec ${shellQuote(opts.codexBin)} app-server`
       + ` -c approval_policy=${approvalPolicy}`
       + ` -c sandbox_mode=${sandboxMode}`
       + ` -c model=${shellQuote(model)}`
-      + ` -c 'mcp_servers.commhub.url="${opts.hub}/mcp"'`
-      + ` -c 'mcp_servers.commhub.bearer_token_env_var="ANET_CODEX_COMMHUB_TOKEN"'`
+      + ` -c ${shellQuote(hubMcpUrlToml)}`
+      + ` -c ${shellQuote(bearerTomlLiteral)}`
       + ` --listen ${wsUrl}`,
   ].join(" ; ");
   try {
@@ -334,13 +423,15 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     ], { stdio: "pipe" });
   } catch (e: any) {
     console.error(`[anet] ❌ tmux new-session ${appsrvSession} failed: ${e?.message || e}`);
+    try { rmSync(envFilePath, { force: true }); } catch { /* best-effort */ }
     process.exit(1);
   }
   console.log(`[anet] ① app-server tmux=${appsrvSession} listening ${wsUrl} (sandbox=${sandboxMode})…`);
   const bound = await waitForTmuxPaneText(appsrvSession, `listening on: ${wsUrl}`, 25_000);
   if (!bound) {
     console.error(`[anet] ❌ app-server did not bind ${wsUrl} within 25s.`);
-    console.error(`[anet]    Debug: tmux attach -t ${appsrvSession}`);
+    console.error(`[anet]    Debug:   tmux attach -t ${appsrvSession}`);
+    console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
     process.exit(1);
   }
   console.log(`[anet] ① app-server READY on ${wsUrl}`);
@@ -351,7 +442,16 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     threadId = await createCodexCopresenceThread(wsUrl);
   } catch (e: any) {
     console.error(`[anet] ❌ thread/start failed: ${e?.message || e}`);
-    console.error(`[anet]    Debug: tmux attach -t ${appsrvSession}`);
+    console.error(`[anet]    Debug:   tmux attach -t ${appsrvSession}`);
+    console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
+    process.exit(1);
+  }
+  // #P2fix顺手3 — defense-in-depth shape check before threadId flows into
+  // a bash-string interpolation. Server-generated ids match; anything else
+  // means either a protocol drift or a compromised app-server.
+  if (!SAFE_THREAD_ID.test(threadId)) {
+    console.error(`[anet] internal error: unexpected threadId shape (rejected before shell interpolation)`);
+    console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
     process.exit(1);
   }
   console.log(`[anet] thread: ${threadId}`);
@@ -377,6 +477,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     ], { stdio: "pipe" });
   } catch (e: any) {
     console.error(`[anet] ❌ tmux new-session ${bridgeSession} failed: ${e?.message || e}`);
+    console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
     process.exit(1);
   }
   console.log(`[anet] ② bridge tmux=${bridgeSession} starting…`);
@@ -396,6 +497,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     ], { stdio: "pipe" });
   } catch (e: any) {
     console.error(`[anet] ❌ tmux new-session ${tuiSession} failed: ${e?.message || e}`);
+    console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
     process.exit(1);
   }
   console.log(`[anet] ③ TUI tmux=${tuiSession} ready to attach`);
@@ -893,7 +995,11 @@ function parseOpts(): Record<string, string> & { _channels: string[]; _envs: str
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--channel" && args[i + 1]) { r._channels.push(args[++i]); continue; }
     if (args[i] === "--env" && args[i + 1]) { r._envs.push(args[++i]); continue; }
-    if (args[i].startsWith("--") && args[i + 1] && !args[i + 1].startsWith("--")) {
+    // #P2fix设计裁6 — boolean flags must not swallow the next positional as a
+    // value; `--copresence <alias>` previously assigned `copresence=<alias>`
+    // and callers checking `=== "true"` silently lost the feature. Mirrors
+    // the BOOLEAN_FLAGS handling in positionalArgs() below.
+    if (args[i].startsWith("--") && !BOOLEAN_FLAGS.has(args[i]) && args[i + 1] && !args[i + 1].startsWith("--")) {
       r[args[i].slice(2)] = args[++i];
     } else if (args[i].startsWith("--")) {
       r[args[i].slice(2)] = "true";
@@ -912,6 +1018,10 @@ const BOOLEAN_FLAGS = new Set([
   // RFC-030 P2 — co-presence orchestration flags.
   "--copresence",
   "--dangerously-allow-full-access",
+  // #P2fix设计裁5 — non-TTY confirmation of danger-full-access requires this
+  // second explicit flag alongside --dangerously-allow-full-access. TTY
+  // callers still use the typed 'yes' prompt.
+  "--yes-danger-full-access",
 ]);
 
 // #173 — extract the bare positional operands from an argv slice, mirroring
@@ -1789,7 +1899,10 @@ Co-presence (codex TUI + agent share one thread, RFC-030):
       Attach with: tmux attach -t <name>. Stop with: anet node stop <name>.
       Requires runtime=codex-app-server on the node.
       Default sandbox is read-only. To grant full FS/network access, add
-      --dangerously-allow-full-access (requires typed 'yes' confirmation).
+      --dangerously-allow-full-access. In an interactive TTY this prompts for
+      a typed 'yes'; in a non-TTY caller (script / CI / Docker) you must ALSO
+      pass --yes-danger-full-access to confirm — the second explicit flag
+      prevents \`printf 'yes\\n' |\` from bypassing the prompt.
       Optional: --codex-bin <path> --codex-home <dir> --model <id> --port <p>
 
 Channel:
@@ -4039,7 +4152,11 @@ async function startCommand() {
     return;
   }
 
-  const id = args[1];
+  // #P2fix设计裁6 — extract alias via positionalArgs so `--copresence <alias>`
+  // is not treated as `id=--copresence`. positionalArgs is already boolean-
+  // aware; parseOpts is now too (see BOOLEAN_FLAGS check above).
+  const startPositionals = positionalArgs(args.slice(1));
+  const id = startPositionals[0];
   if (!id) { showProfiles("start"); return; }
   const opts = parseOpts();
   const forceNewSession = !!opts["new-session"];
@@ -4065,6 +4182,7 @@ async function startCommand() {
       model: opts.model,
       port: opts.port ? Number(opts.port) : undefined,
       dangerFullAccess: opts["dangerously-allow-full-access"] === "true",
+      yesDangerFullAccess: opts["yes-danger-full-access"] === "true",
       hub: profileHub,
       token: profileTok,
     });

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from "url";
 import { homedir } from "os";
 import { spawn, execSync, execFileSync } from "child_process";
 import { createHash, randomBytes, randomUUID } from "crypto";
+import { createServer as netCreateServer } from "net";
 import { checkbox, confirm, select } from "@inquirer/prompts";
 import { ensureGitignoreRule, ensureGitignoreRules } from "../src/gitignore-writeback";
 import { superviseChild } from "../src/supervise-child";
@@ -95,6 +96,317 @@ function tmuxAvailable(): boolean {
   try { execFileSync("tmux", ["-V"], { stdio: "pipe" }); tmuxAvailableCache = true; }
   catch { tmuxAvailableCache = false; }
   return tmuxAvailableCache;
+}
+
+// ── RFC-030 co-presence orchestration helpers ────────────────────────────
+//
+// `anet node start <alias> --copresence` spawns 3 tmux sessions:
+//   ① <alias>-appsrv : codex app-server (loopback WS + commhub MCP)
+//   ② <alias>-桥      : agent-node bridge (adopt-mode, connects to hub)
+//   ③ <alias>         : codex resume --remote (human-attachable TUI)
+// Replaces the .demo/setup-copresence.sh bash dance with a first-class
+// command. Preserves the RFC-030 MVP posture: loopback-only bind, ntok-only
+// auth, per-node CODEX_HOME isolation. Risk C (dangerous sandbox) requires
+// an explicit flag + typed confirmation + stderr banner — never silent.
+
+const COPRESENCE_PORT_RANGE_START = 24700;
+const COPRESENCE_PORT_RANGE_END = 24799;
+
+async function findFreeLoopbackPort(preferred?: number): Promise<number> {
+  const tryOne = (port: number) => new Promise<number | null>((resolve) => {
+    const s = netCreateServer();
+    s.once("error", () => resolve(null));
+    s.listen(port, "127.0.0.1", () => {
+      const addr = s.address();
+      const chosen = typeof addr === "object" && addr ? addr.port : null;
+      s.close(() => resolve(chosen));
+    });
+  });
+  if (preferred !== undefined) {
+    const got = await tryOne(preferred);
+    if (got !== null) return got;
+  }
+  for (let p = COPRESENCE_PORT_RANGE_START; p <= COPRESENCE_PORT_RANGE_END; p++) {
+    const got = await tryOne(p);
+    if (got !== null) return got;
+  }
+  throw new Error(`no free port in ${COPRESENCE_PORT_RANGE_START}-${COPRESENCE_PORT_RANGE_END}`);
+}
+
+function waitForTmuxPaneText(sessionName: string, needle: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve) => {
+    const poll = () => {
+      try {
+        const out = execFileSync("tmux", ["capture-pane", "-t", sessionName, "-p"], {
+          stdio: ["ignore", "pipe", "pipe"], encoding: "utf8",
+        });
+        if (out.includes(needle)) { resolve(true); return; }
+      } catch { /* session may still be spinning up */ }
+      if (Date.now() >= deadline) { resolve(false); return; }
+      setTimeout(poll, 400);
+    };
+    poll();
+  });
+}
+
+async function resolveCopresenceWebSocketCtor(): Promise<any> {
+  const g = (globalThis as any).WebSocket;
+  if (typeof g === "function") return g;
+  try {
+    const undici = await import("undici");
+    if (typeof (undici as any).WebSocket === "function") return (undici as any).WebSocket;
+  } catch { /* fall through */ }
+  throw new Error(
+    "no WebSocket available — need Bun / Node 22+ (global WebSocket) or `undici` in node_modules",
+  );
+}
+
+// Minimal WebSocket JSON-RPC thread creator against a running `codex
+// app-server`. Mirrors agent-node/tests/rfc-030-create-thread.ts but inlined
+// so the shipped CLI can call it (tests/ is not published).
+async function createCodexCopresenceThread(ws: string, timeoutMs = 60_000): Promise<string> {
+  const WsCtor = await resolveCopresenceWebSocketCtor();
+  const socket = new WsCtor(ws);
+  const deadline = Date.now() + timeoutMs;
+  await new Promise<void>((resolve, reject) => {
+    const to = setTimeout(() => reject(new Error(`ws open timeout on ${ws}`)), Math.max(1000, deadline - Date.now()));
+    socket.addEventListener("open", () => { clearTimeout(to); resolve(); }, { once: true });
+    socket.addEventListener("error", (e: any) => { clearTimeout(to); reject(new Error(`ws error: ${e?.message || e}`)); }, { once: true });
+  });
+  let nextId = 1;
+  const pending = new Map<number, { resolve: (v: any) => void; reject: (e: any) => void }>();
+  socket.addEventListener("message", (ev: any) => {
+    let msg: any;
+    try { msg = JSON.parse(typeof ev.data === "string" ? ev.data : ev.data.toString()); } catch { return; }
+    if (typeof msg?.id === "number" && !msg.method) {
+      const p = pending.get(msg.id);
+      if (!p) return;
+      pending.delete(msg.id);
+      if (msg.error) p.reject(new Error(`${msg.error.code}: ${msg.error.message}`));
+      else p.resolve(msg.result);
+    }
+  });
+  const request = (method: string, params: any, timeoutMsInner: number) => new Promise<any>((resolve, reject) => {
+    const id = nextId++;
+    const to = setTimeout(() => { pending.delete(id); reject(new Error(`request ${method} timeout`)); }, timeoutMsInner);
+    pending.set(id, {
+      resolve: (v) => { clearTimeout(to); resolve(v); },
+      reject: (e) => { clearTimeout(to); reject(e); },
+    });
+    socket.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+  });
+  const notify = (method: string, params: any) =>
+    socket.send(JSON.stringify({ jsonrpc: "2.0", method, params }));
+  try {
+    try {
+      await request("initialize", {
+        clientInfo: { name: "anet-copresence-creator", title: "creator", version: "0.0.1" },
+      }, 10_000);
+      notify("initialized", {});
+    } catch { /* already initialized on shared server */ }
+    const started: any = await request("thread/start", {}, 15_000);
+    const threadId: string | undefined = started?.threadId ?? started?.thread?.id;
+    if (!threadId) throw new Error("thread/start returned no threadId");
+    // Tiny turn persists the rollout so `codex resume --remote` can adopt.
+    await request("turn/start", {
+      threadId,
+      clientUserMessageId: "anet-copresence:bootstrap",
+      input: [{ type: "text", text: "只回复一个词：READY" }],
+    }, 45_000);
+    await new Promise((r) => setTimeout(r, 3000));
+    return threadId;
+  } finally {
+    try { socket.close(); } catch { /* ignore */ }
+  }
+}
+
+async function askTypedConfirmation(prompt: string, expected: string): Promise<boolean> {
+  const rl = getRL();
+  const answer = await new Promise<string>((resolve) => rl.question(prompt, (s) => resolve(s)));
+  closeRL();
+  return answer.trim() === expected;
+}
+
+function copresenceTmuxSessions(displayName: string): { appsrv: string; bridge: string; tui: string } {
+  return { appsrv: `${displayName}-appsrv`, bridge: `${displayName}-桥`, tui: displayName };
+}
+
+interface CopresenceOptions {
+  codexBin: string;
+  codexHome: string;
+  model?: string;
+  port?: number;
+  dangerFullAccess: boolean;
+  hub: string;
+  token: string;
+}
+
+async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOptions): Promise<void> {
+  const resolved = resolveNodeRef(nodeId);
+  if (!resolved) {
+    console.error(`Node "${nodeId}" not found. Create it first: anet node create ${nodeId}`);
+    process.exit(1);
+  }
+  const displayName = nodeDisplayName(resolved.id, resolved.profile);
+  const profile = resolved.profile;
+  if (profile.runtime !== "codex-app-server") {
+    console.error(`[anet] ❌ --copresence requires runtime=codex-app-server (node "${displayName}" is runtime=${profile.runtime}).`);
+    console.error(`[anet]    Create a copresence-capable node with:`);
+    console.error(`[anet]      anet node create ${shellQuote(displayName)} --runtime codex-app-server`);
+    process.exit(1);
+  }
+  if (!tmuxAvailable()) {
+    console.error(`[anet] ❌ --copresence requires tmux (used to isolate the 3-piece dance).`);
+    console.error(`[anet]    Install tmux (e.g. \`brew install tmux\` / \`apt-get install tmux\`) and retry.`);
+    process.exit(1);
+  }
+  if (!commandExists(opts.codexBin)) {
+    console.error(`[anet] ❌ codex binary "${opts.codexBin}" not found in PATH.`);
+    console.error(`[anet]    Install codex CLI (e.g. \`npm install -g @openai/codex\`) or pass --codex-bin <path>.`);
+    process.exit(1);
+  }
+  if (!opts.token || !opts.token.startsWith("ntok_")) {
+    console.error(`[anet] ❌ node token is missing or not an ntok_ (co-presence bridge requires network-scoped ntok_).`);
+    console.error(`[anet]    Run \`anet doctor --fix\` to repair, or recreate the node.`);
+    process.exit(1);
+  }
+
+  // Risk C double safeguard — dangerous sandbox is never the default.
+  // Requires: explicit CLI flag (opts.dangerFullAccess) + typed 'yes' at
+  // start + stderr banner every launch.
+  if (opts.dangerFullAccess) {
+    console.error("");
+    console.error(`⚠  --dangerously-allow-full-access ENABLED for ${displayName}`);
+    console.error("   This grants the codex session unrestricted filesystem/network access.");
+    console.error("   Read-only default is safer; only enable if you understand the risk.");
+    console.error("");
+    const ok = await askTypedConfirmation(
+      "   Type 'yes' to confirm (any other input aborts): ",
+      "yes",
+    );
+    if (!ok) {
+      console.error("[anet] aborted (danger-full-access not confirmed).");
+      process.exit(1);
+    }
+    console.error(`[anet] ⚠ codex 共存节点 ${displayName} 以 danger-full-access 模式运行`);
+    console.error(`[anet] ⚠ (no filesystem or network sandbox; codex may write/delete freely)`);
+  }
+
+  mkdirSync(opts.codexHome, { recursive: true });
+  try { chmodSync(opts.codexHome, 0o700); } catch { /* best-effort */ }
+
+  const { appsrv: appsrvSession, bridge: bridgeSession, tui: tuiSession } =
+    copresenceTmuxSessions(displayName);
+
+  // Kill any prior instances so this is idempotent.
+  for (const s of [appsrvSession, bridgeSession, tuiSession]) {
+    if (tmuxSessionRunning(s)) {
+      console.log(`[anet] killing prior tmux session ${s}`);
+      killTmuxSession(s);
+    }
+  }
+  await new Promise((r) => setTimeout(r, 500));
+
+  const port = await findFreeLoopbackPort(opts.port);
+  const wsUrl = `ws://127.0.0.1:${port}`;
+  const approvalPolicy = opts.dangerFullAccess ? "never" : "on-request";
+  const sandboxMode = opts.dangerFullAccess ? "danger-full-access" : "read-only";
+  const model = opts.model || "gpt-5.5";
+
+  // ── piece ① codex app-server (loopback WS + commhub MCP) ──────────────
+  const appsrvCmd = [
+    `export CODEX_HOME=${shellQuote(opts.codexHome)}`,
+    `export ANET_CODEX_COMMHUB_TOKEN=${shellQuote(opts.token)}`,
+    `clear`,
+    `exec ${shellQuote(opts.codexBin)} app-server`
+      + ` -c approval_policy=${approvalPolicy}`
+      + ` -c sandbox_mode=${sandboxMode}`
+      + ` -c model=${shellQuote(model)}`
+      + ` -c 'mcp_servers.commhub.url="${opts.hub}/mcp"'`
+      + ` -c 'mcp_servers.commhub.bearer_token_env_var="ANET_CODEX_COMMHUB_TOKEN"'`
+      + ` --listen ${wsUrl}`,
+  ].join(" ; ");
+  try {
+    execFileSync("tmux", [
+      "new-session", "-d", "-s", appsrvSession, "-c", process.cwd(),
+      "bash", "-lc", appsrvCmd,
+    ], { stdio: "pipe" });
+  } catch (e: any) {
+    console.error(`[anet] ❌ tmux new-session ${appsrvSession} failed: ${e?.message || e}`);
+    process.exit(1);
+  }
+  console.log(`[anet] ① app-server tmux=${appsrvSession} listening ${wsUrl} (sandbox=${sandboxMode})…`);
+  const bound = await waitForTmuxPaneText(appsrvSession, `listening on: ${wsUrl}`, 25_000);
+  if (!bound) {
+    console.error(`[anet] ❌ app-server did not bind ${wsUrl} within 25s.`);
+    console.error(`[anet]    Debug: tmux attach -t ${appsrvSession}`);
+    process.exit(1);
+  }
+  console.log(`[anet] ① app-server READY on ${wsUrl}`);
+
+  // ── create fresh thread + persist config ──────────────────────────────
+  let threadId: string;
+  try {
+    threadId = await createCodexCopresenceThread(wsUrl);
+  } catch (e: any) {
+    console.error(`[anet] ❌ thread/start failed: ${e?.message || e}`);
+    console.error(`[anet]    Debug: tmux attach -t ${appsrvSession}`);
+    process.exit(1);
+  }
+  console.log(`[anet] thread: ${threadId}`);
+
+  const rawCfgPath = join(nodesDir(), resolved.id, "config.json");
+  const rawCfg = JSON.parse(readFileSync(rawCfgPath, "utf-8"));
+  rawCfg.codexAppServerPort = port;
+  rawCfg.codexAppServerUrl = wsUrl;
+  rawCfg.codexThreadId = threadId;
+  delete rawCfg.session;
+  writeFileSync(rawCfgPath, JSON.stringify(rawCfg, null, 2) + "\n");
+
+  // ── piece ② bridge (agent-node adopt mode) ────────────────────────────
+  // The bridge re-invokes `anet node start` in foreground under tmux; that
+  // path reads codexAppServerUrl / codexThreadId from the config we just
+  // wrote and spawns agent-node in adopt mode. Same launchAgent()
+  // codepath as the non-copresence case — no fork of the bridge dispatch.
+  const bridgeCmd = `unset COMMHUB_TOKEN ANET_CODEX_COMMHUB_TOKEN && exec anet node start ${shellQuote(displayName)}`;
+  try {
+    execFileSync("tmux", [
+      "new-session", "-d", "-s", bridgeSession, "-c", process.cwd(),
+      "bash", "-lc", bridgeCmd,
+    ], { stdio: "pipe" });
+  } catch (e: any) {
+    console.error(`[anet] ❌ tmux new-session ${bridgeSession} failed: ${e?.message || e}`);
+    process.exit(1);
+  }
+  console.log(`[anet] ② bridge tmux=${bridgeSession} starting…`);
+  await new Promise((r) => setTimeout(r, 3000));
+
+  // ── piece ③ codex TUI (attachable, resumes same thread) ───────────────
+  const tuiFlags: string[] = [];
+  if (opts.dangerFullAccess) tuiFlags.push("--dangerously-bypass-approvals-and-sandbox");
+  const tuiCmd = [
+    `export CODEX_HOME=${shellQuote(opts.codexHome)}`,
+    `exec ${shellQuote(opts.codexBin)} resume --remote ${wsUrl} ${threadId} ${tuiFlags.join(" ")}`.trim(),
+  ].join(" ; ");
+  try {
+    execFileSync("tmux", [
+      "new-session", "-d", "-s", tuiSession, "-c", process.cwd(),
+      "bash", "-lc", tuiCmd,
+    ], { stdio: "pipe" });
+  } catch (e: any) {
+    console.error(`[anet] ❌ tmux new-session ${tuiSession} failed: ${e?.message || e}`);
+    process.exit(1);
+  }
+  console.log(`[anet] ③ TUI tmux=${tuiSession} ready to attach`);
+
+  const hubBase = opts.hub.replace(/\/+$/, "");
+  console.log("");
+  console.log(`[anet] ✅ 共存节点 ${displayName} 就绪`);
+  console.log(`[anet]    attach:    tmux attach -t ${shellQuote(displayName)}`);
+  console.log(`[anet]    stop:      anet node stop ${shellQuote(displayName)}`);
+  console.log(`[anet]    dashboard: ${hubBase}/nodes/${encodeURIComponent(displayName)}`);
+  console.log(`[anet]    runtime:   codex-app-server @ ${wsUrl}  (sandbox=${sandboxMode})`);
 }
 
 // Pin commhub-server to a specific version to defeat bunx caching of older
@@ -593,7 +905,14 @@ function parseOpts(): Record<string, string> & { _channels: string[]; _envs: str
 // #173 — boolean (no-value) flags must NOT swallow the following token as a
 // value. parseOpts's heuristic ("--flag" + non-"--" token → that token is the
 // value) would otherwise read `anet node start --all foo` as all="foo".
-const BOOLEAN_FLAGS = new Set(["--all", "--tmux", "--new-session"]);
+const BOOLEAN_FLAGS = new Set([
+  "--all",
+  "--tmux",
+  "--new-session",
+  // RFC-030 P2 — co-presence orchestration flags.
+  "--copresence",
+  "--dangerously-allow-full-access",
+]);
 
 // #173 — extract the bare positional operands from an argv slice, mirroring
 // parseOpts's flag/value consumption, so `--all`'s mutual exclusion with a
@@ -1462,6 +1781,16 @@ Session:
   anet node start <name> --new-session   Start with fresh Claude session
   anet node resume <name> --session <id> Resume specific session
   anet session ls               List Claude Code sessions
+
+Co-presence (codex TUI + agent share one thread, RFC-030):
+  anet node start <name> --copresence
+      Spawn 3-piece dance: codex app-server (loopback WS) + agent-node bridge
+      + attachable codex TUI. All 3 in tmux (<name>, <name>-appsrv, <name>-桥).
+      Attach with: tmux attach -t <name>. Stop with: anet node stop <name>.
+      Requires runtime=codex-app-server on the node.
+      Default sandbox is read-only. To grant full FS/network access, add
+      --dangerously-allow-full-access (requires typed 'yes' confirmation).
+      Optional: --codex-bin <path> --codex-home <dir> --model <id> --port <p>
 
 Channel:
   anet channel add telegram <name> --bot-token <tok> --allow <uid>
@@ -3715,6 +4044,33 @@ async function startCommand() {
   const opts = parseOpts();
   const forceNewSession = !!opts["new-session"];
 
+  // RFC-030 P2 — `anet node start <alias> --copresence` spawns the 3-piece
+  // codex co-presence dance (app-server + bridge + attachable TUI).
+  // Replaces .demo/setup-copresence.sh. See startCopresenceOrchestration
+  // for the Risk C double-safeguard (default read-only; danger requires
+  // explicit flag + typed confirm + stderr banner) and the per-node
+  // CODEX_HOME isolation.
+  if (opts.copresence === "true") {
+    const resolvedForCopresence = resolveNodeRef(id);
+    if (!resolvedForCopresence) {
+      console.error(`Node "${id}" not found. Create it first: anet node create ${id}`);
+      process.exit(1);
+    }
+    const codexHomeDefault = join(nodesDir(), resolvedForCopresence.id, "codex-home");
+    const profileHub = (resolvedForCopresence.profile as any).hub || getHub();
+    const profileTok = resolvedForCopresence.profile.token || "";
+    await startCopresenceOrchestration(id, {
+      codexBin: opts["codex-bin"] || "codex",
+      codexHome: opts["codex-home"] || codexHomeDefault,
+      model: opts.model,
+      port: opts.port ? Number(opts.port) : undefined,
+      dangerFullAccess: opts["dangerously-allow-full-access"] === "true",
+      hub: profileHub,
+      token: profileTok,
+    });
+    return;
+  }
+
   // #136 (Vincent telegram 5158/5159/5161) — revert #122 default auto-wrap.
   // The detached-tmux-by-default path triggered `setRawMode errno 5` on
   // macOS bun (bun's claude-code-cli wants to call setRawMode on a real PTY
@@ -5673,13 +6029,31 @@ Stop a running agent node.
   // the recorded PID and notify the hub. Order matters: killing tmux kills
   // any child processes too, which makes `stopNode` mostly a defensive op
   // when the PID file is stale.
-  const tmuxKilled = tmuxSessionRunning(displayName);
-  if (tmuxKilled) killTmuxSession(displayName);
+  //
+  // RFC-030 P2 — co-presence nodes own three tmux sessions
+  // (`<alias>`, `<alias>-appsrv`, `<alias>-桥`). Sweep all three
+  // unconditionally: has-session guards make the extra kills no-op for
+  // non-copresence nodes, so this stays safe for every runtime.
+  const copresenceSessions = copresenceTmuxSessions(displayName);
+  const tmuxTuiKilled = tmuxSessionRunning(copresenceSessions.tui);
+  const tmuxAppsrvKilled = tmuxSessionRunning(copresenceSessions.appsrv);
+  const tmuxBridgeKilled = tmuxSessionRunning(copresenceSessions.bridge);
+  if (tmuxTuiKilled) killTmuxSession(copresenceSessions.tui);
+  if (tmuxAppsrvKilled) killTmuxSession(copresenceSessions.appsrv);
+  if (tmuxBridgeKilled) killTmuxSession(copresenceSessions.bridge);
+  const tmuxKilled = tmuxTuiKilled || tmuxAppsrvKilled || tmuxBridgeKilled;
   const killed = stopNode(resolved.id);
   // Always notify server — even if PID file missing, server may have stale session
   await notifyServerOffline(resolved.profile, resolved.id);
   if (killed || tmuxKilled) {
-    const what = [tmuxKilled ? "tmux" : null, killed ? "process" : null].filter(Boolean).join(" + ");
+    const tmuxLabels: string[] = [];
+    if (tmuxTuiKilled) tmuxLabels.push("tui");
+    if (tmuxAppsrvKilled) tmuxLabels.push("appsrv");
+    if (tmuxBridgeKilled) tmuxLabels.push("bridge");
+    const what = [
+      tmuxLabels.length ? `tmux(${tmuxLabels.join("+")})` : null,
+      killed ? "process" : null,
+    ].filter(Boolean).join(" + ");
     console.log(`[anet] Stopped "${displayName}" (${what} killed, server notified)`);
   } else {
     console.log(`[anet] "${displayName}" is not running locally (server notified offline)`);

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -205,7 +205,8 @@ export class CodexAppServerBridge extends EventEmitter {
     }
     this.turnClaimed = true;
     const clientUserMessageId = `anet:${input.taskId}`;
-    const promptPrefix = input.from ? `[Agent Network/from=${input.from}/task=${input.taskId}] ` : `[Agent Network/task=${input.taskId}] `;
+    const fromLabel = displaySender(input.from);
+    const promptPrefix = fromLabel ? `[Agent Network/from=${fromLabel}/task=${input.taskId}] ` : `[Agent Network/task=${input.taskId}] `;
     const pending: PendingTurn = {
       taskId: input.taskId,
       clientUserMessageId,
@@ -504,6 +505,19 @@ function isAlreadyInitialized(e: unknown): boolean {
 function isNoRollout(e: unknown): boolean {
   const msg = (e as { message?: unknown })?.message;
   return typeof msg === "string" && /no rollout found|thread not found|unknown thread/i.test(msg);
+}
+
+/**
+ * Human-readable sender label for the codex prompt prefix. The hub defaults
+ * `from_session` to "api" for dashboard/REST-originated tasks (server/src/
+ * index.ts), which reads as opaque "from=api" in the TUI — map it to a clear
+ * "控制台(dashboard)" so a human at the TUI knows it came from the panel.
+ * Everything else (agent aliases, "hub") passes through unchanged.
+ */
+function displaySender(from?: string): string | undefined {
+  if (!from) return undefined;
+  if (from === "api") return "控制台(dashboard)";
+  return from;
 }
 
 function extractReverseRequestId(params: unknown): number | null {


### PR DESCRIPTION
## 做了什么

给 codex 人机共存节点加一个一等公民启动命令：`anet node start <alias> --copresence`。

在此之前，起一个 codex 共存节点要手工跑 demo 目录里的 bash 脚本。本 PR 让 CLI 直接编排完整三件套（codex app-server + bridge + 可 attach 的 TUI），并打印 attach / stop 指引。

- `agent-network/bin/cli.ts` — `--copresence` flag + 编排 + 向导
- `agent-node/src/runtime/codex-app-server-bridge.ts` — displaySender UX（`from=api` → `from=控制台(dashboard)`，+14 行，纯展示层）

## 安全门（两轮独立审查 + 复核）

作者不自审。三轮把关：

**第一轮** → CHANGES_REQUIRED，两个真实缺陷：
1. **节点 token 落到 argv**：token 被烤进 tmux 命令串，会出现在 `/proc/*/cmdline`（全局可读）以及 tmux `pane_start_command`（整个 session 生命周期驻留）。改为写入 `<codexHome>/.anet-copresence.env`（0600，父目录 0700），tmux 侧 `. file && rm -f file && exec`。
2. **hub 参数 shell 注入**：`opts.hub` 未转义拼进 `bash -lc`，而 hub 可来自项目本地 node config —— 克隆一个植入恶意 hub 的仓库并启用共存即可任意命令执行。改为 URL 解析 + scheme 白名单 + 危险字符拒绝 + 整段 `shellQuote`。

同轮另修：threadId 形状校验、initialize 错误吞噬收窄、**非 TTY 下启用 danger 模式必须两个显式 flag**（堵掉 `printf 'yes' |` 绕过）、`parseOpts` 认 BOOLEAN_FLAGS（此前 flag 写在位置参数前会被静默吞掉）。

**第二轮** → PASS-WITH-CONDITIONS。`parseOpts` 改动是最高回归风险（约 40 个调用点），审查以枚举全部调用点 + 17 条命令行差分执行 + 全仓 grep 确认无任何调用点依赖旧行为。余一条必修：env 文件为「先写后 chmod」，存在权限窗口，且预置符号链接会被跟随（token 写到链接目标，`rm -f` 只删链接）。

**第三轮（本次收口）** → 预删除（ENOENT 安全）+ `writeFileSync(..., { mode: 0o600, flag: "wx" })`，`O_EXCL` 使得符号链接被重建时创建直接失败（fail-closed）；另修 codexHome 权限设置失败改为拒绝启动（该 0700 是 0600 env 文件的承重不变量，不能静默降级）、三条失败路径补 env 文件清理、修活 `-32600` 死分支。

## 边界

- 未纳入：Policy Gateway（Method B，RFC §18.1b 明确延后）
- 未纳入：PGID 身份 teardown —— `anet node stop` 目前仍可能残留 node 进程，属 P3，**已知且未掩盖**
- 遗留同类问题（9 个 boolean flag 仍会吞位置参数、`parseOpts` 零单测）单独立项 #464，未在本 PR 扩 scope

## 验证

三件套真实拉起：token 在 `ps` 与 tmux `pane_start_command` 中均零命中、env 文件 source 后即消失；4 个恶意 hub URL 全部拒绝、正常 URL 放行；非 TTY 单 flag 中止 / 双 flag 放行 / 管道 yes 仍中止。
