### PR TITLE
fix(cli): 把 anet daemon 补进 --help（命令早已存在但不可发现）

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1950,6 +1950,12 @@ Setup:
   anet upgrade                  Upgrade all anet packages (channel-aware)
   anet upgrade --channel preview|latest --dry-run --self  (see flags)
 
+Daemon (host_supervisor — required by the dashboard's node-creation wizard):
+  anet daemon up [name]         Create + start a daemon (one-shot, default: "daemon")
+  anet daemon init <name>       Create a host_supervisor node config
+  anet daemon start <name>      Start an existing daemon
+  anet daemon list              List locally-configured daemons
+
 Other:
   anet import [alias]           Import sessions from CommHub
   anet register                  Create new account


### PR DESCRIPTION
## 问题

`anet daemon`（RFC-026 起就有：`init` / `start` / `up` / `list`）**从未出现在 `--help` 里**，用户无从发现它的存在。

而 dashboard 的「新建节点」向导依赖 host_supervisor daemon——用户从 dashboard 撞到 `no_host_supervisor_daemon` 之后，`anet --help` 里找不到任何相关命令，等于没有可见的解决路径。

## 改动

在 `--help` 的 `Setup:` 与 `Other:` 之间新增一个 `Daemon:` 段，列出四个子命令。**仅新增帮助文本，无任何行为变更**（+6 行）。

## 措辞依据

四条子命令与描述**逐条对照已发布构建自身的 `anet daemon` usage 输出**核对过，不是照着源码或记忆写的：

```
$ node dist/bin/cli.js daemon
Subcommands:
  init <name>          Create a host_supervisor daemon node (role + defaults)
  start <name>         Start a daemon (delegates to anet node start; verifies role)
  up [<name>]          init + start one-shot (default name: "daemon")
  list                 List locally-configured daemon nodes
```

所以帮助文本不会宣称任何实际不存在的能力。
