### PR TITLE
docs(research): opencode 会话忙闲信号实测 — 修正此前「无状态端点」的假阴性结论

### DIFF
--- a/docs/research/opencode-session-status-signal.md
+++ b/docs/research/opencode-session-status-signal.md
@@ -1,0 +1,61 @@
+# opencode 会话忙闲信号 — 实测记录
+
+日期：2026-07-29
+环境：独立服务器（4 核 / 14G，专用于该实验），opencode-ai 1.17.13，免费模型 `opencode/deepseek-v4-flash-free`
+
+## 背景
+
+opencode 人机共存的拓扑决策卡在一个前提上：**外部能否知道某个会话正在生成中**。
+此前的探测结论是"没有可用的状态端点"，据此倾向于选择成本较高的方案（自建一层终端仲裁）。
+
+## 实测结论：信号存在，之前的探测方式错过了它
+
+`/event` 是一条 **SSE 推送流**，其中 `session.status` 事件带 **per-session 的忙闲状态**：
+
+```json
+{"type":"session.status","properties":{"sessionID":"ses_…","status":{"type":"busy"}}}
+{"type":"session.status","properties":{"sessionID":"ses_…","status":{"type":"idle"}}}
+```
+
+单次生成期间共捕获 224 条事件，类型分布（节选）：
+
+| 事件类型 | 条数 |
+|---|---|
+| `message.part.delta` | 68 |
+| `message.part.updated` | 14 |
+| `message.updated` | 10 |
+| `session.status` | 6 |
+| `step-start` / `step-finish` | 2 / 2 |
+
+`session.status` 完整覆盖了 **busy → idle** 的转换。
+
+## 之前为什么判成"没有"
+
+1. 只探测了**主动查询**类端点（`/session/:id/state`、`/status` 等），这些确实不存在；
+2. 唯一探到 `/event` 的那次，**读取超时设为 2 秒，仅收到 89 字节即断开**，没有读到流内容。
+
+**信号是推送式的，不是拉取式的**——探测方法与信号形态不匹配，因此得出了假阴性。
+
+## 对共存设计的影响
+
+- 外部程序**可以**订阅 `/event`、按 `sessionID` 跟踪忙闲，从而在会话忙时不发送自己的消息；
+- 这使"轻量方案（订阅事件 + 自我串行）"重新可行，无需自建终端仲裁层。
+
+## 必须同时记住的边界
+
+该信号**只能约束我们自己**，**约束不了人**。
+
+同一环境下已复现：当第二条消息真正落在第一条的生成窗口内（以时间戳证明重叠），两条消息会被**合并为同一条回复**（相同 message id、同时返回）。人类随时可能手动输入，不受程序协调。
+
+因此订阅事件的真实价值是：
+
+1. 我们自己**永远不制造冲突**；
+2. 检测到忙时可以**提示或排队**，而不是无声合并。
+
+## 复现方法
+
+1. `opencode serve --hostname 127.0.0.1 --port <port>`
+2. 订阅：`curl -sN -H 'Accept: text/event-stream' http://127.0.0.1:<port>/event`
+3. 另一路发送一次会话消息，观察 `session.status` 的 busy/idle 转换
+
+**合并现象的复现要点**：必须先用时间戳证明第二条消息确实落在第一条的生成窗口内。若第一条已结束才发第二条，两条会得到不同的 message id，从而得出"不会合并"的错误结论。


### PR DESCRIPTION
## 为什么提这个

opencode 人机共存的拓扑决策一直卡在一个前提上：**外部能否知道某个会话正在生成中**。
此前探测得出的结论是"没有可用的状态端点"，据此倾向选择成本较高的方案（自建一层终端仲裁，估 14-20h）。

实测发现**这个结论是假阴性，信号一直都在**。

## 结论

`/event` 是一条 SSE 推送流，`session.status` 事件带 per-session 的 `busy` / `idle` 状态。单次生成期间捕获 224 条事件，busy→idle 转换完整。

之前判成"没有"的原因有两条，都属探测方法问题：
1. 只探了**主动查询**类端点（这些确实不存在）；
2. 唯一探到 `/event` 的那次**读取超时 2 秒、仅收到 89 字节即断开**，没读到流内容。

信号是**推送式**的，而探测方式是**拉取式**的，形态不匹配。

## 同时记录了边界（避免下一个人过度乐观）

该信号只能约束程序自身，**约束不了人**。同环境下已复现：当第二条消息真正落在第一条的生成窗口内时，两条会被**合并为同一条回复**（相同 message id、同时返回）。

所以订阅事件的真实价值是"我们自己不制造冲突 + 检测到忙时可提示"，而不是"冲突问题解决了"。

## 复现要点

文档里写了完整复现步骤。其中一条值得强调：**验证合并现象时必须先用时间戳证明第二条消息确实落在第一条的生成窗口内**——若第一条已结束才发第二条，会得到不同的 message id，从而得出"不会合并"的错误结论（我第一次跑就踩了这个坑）。

纯文档，无代码改动。
