### PR TITLE
feat(#461,#462): hub 观察者事件流 + 节点头像（含授权修复与 aggregate 隔离）

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -52,7 +52,9 @@ L0_TESTS=(
   "auth-validate:server/src/auth-validate.test.ts"
   "observer-push:server/src/observer-push.test.ts"
   "avatar-validate:server/src/avatar-validate.test.ts"
-  "observer-avatar-http:server/src/observer-avatar-http.test.ts"
+  # observer-avatar-http.test.ts 不进 L0：它启真 HTTP server，import 链需要
+  # MCP SDK，而 CI 的 L0 层按设计不跑 bun install（ms 级零依赖预算）。
+  # 它的 CI 归属是会安装依赖的层级；本地跑法见该文件头注释的门禁命令。
 )
 L1_TESTS=(
   "qa-cli-01-hub-start"

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -50,6 +50,9 @@ L0_TESTS=(
   "password-dict:server/src/password-dict.test.ts"
   "auth-tokens:server/src/auth-tokens.test.ts"
   "auth-validate:server/src/auth-validate.test.ts"
+  "observer-push:server/src/observer-push.test.ts"
+  "avatar-validate:server/src/avatar-validate.test.ts"
+  "observer-avatar-http:server/src/observer-avatar-http.test.ts"
 )
 L1_TESTS=(
   "qa-cli-01-hub-start"

--- a/server/src/avatar-validate.test.ts
+++ b/server/src/avatar-validate.test.ts
@@ -98,6 +98,12 @@ describe("#462 validateAvatarUrl", () => {
     if (q.ok) expect(q.value).not.toContain("'");
   });
 
+  test("rejects URLs with embedded credentials (userinfo)", () => {
+    expect(validateAvatarUrl("https://user:pass@example.com/a.png").ok).toBe(false);
+    expect(validateAvatarUrl("https://user@example.com/a.png").ok).toBe(false);
+    expect(validateAvatarUrl("http://:secret@example.com/a.png").ok).toBe(false);
+  });
+
   test("enforces the length cap", () => {
     const base = "https://example.com/";
     const ok = base + "a".repeat(MAX_AVATAR_URL_LENGTH - base.length);

--- a/server/src/avatar-validate.test.ts
+++ b/server/src/avatar-validate.test.ts
@@ -1,0 +1,82 @@
+// #462 — unit tests for the avatar_url XSS boundary (avatar-validate.ts).
+//
+// The validator's whole job is to keep hostile values out of a dashboard
+// <img src>; every rejection case here is a concrete injection shape.
+// Live-gate check: replace validateAvatarUrl with `return { ok: true,
+// value: String(raw) }` and the javascript:/data:/control-char tests go
+// red.
+
+import { describe, expect, test } from "bun:test";
+import { MAX_AVATAR_URL_LENGTH, validateAvatarUrl } from "./avatar-validate";
+
+describe("#462 validateAvatarUrl", () => {
+  test("accepts plain https URL", () => {
+    const r = validateAvatarUrl("https://cdn.example.com/a/b.png");
+    expect(r).toEqual({ ok: true, value: "https://cdn.example.com/a/b.png" });
+  });
+
+  test("accepts http URL and trims surrounding whitespace", () => {
+    const r = validateAvatarUrl("  http://example.com/x.jpg  ");
+    expect(r).toEqual({ ok: true, value: "http://example.com/x.jpg" });
+  });
+
+  test("accepts URL with query string", () => {
+    const r = validateAvatarUrl("https://example.com/img?size=64&v=2");
+    expect(r.ok).toBe(true);
+  });
+
+  test("null / undefined / empty / whitespace-only → clear (value null)", () => {
+    expect(validateAvatarUrl(null)).toEqual({ ok: true, value: null });
+    expect(validateAvatarUrl(undefined)).toEqual({ ok: true, value: null });
+    expect(validateAvatarUrl("")).toEqual({ ok: true, value: null });
+    expect(validateAvatarUrl("   ")).toEqual({ ok: true, value: null });
+  });
+
+  test("rejects non-string types", () => {
+    expect(validateAvatarUrl(42).ok).toBe(false);
+    expect(validateAvatarUrl({ url: "https://x" }).ok).toBe(false);
+    expect(validateAvatarUrl(["https://x"]).ok).toBe(false);
+    expect(validateAvatarUrl(true).ok).toBe(false);
+  });
+
+  test("rejects javascript: pseudo-protocol", () => {
+    expect(validateAvatarUrl("javascript:alert(1)").ok).toBe(false);
+    expect(validateAvatarUrl("JavaScript:alert(1)").ok).toBe(false);
+    expect(validateAvatarUrl("JAVASCRIPT:alert(document.cookie)").ok).toBe(false);
+  });
+
+  test("rejects javascript: smuggled via embedded tab/newline (URL() would strip them)", () => {
+    expect(validateAvatarUrl("java\tscript:alert(1)").ok).toBe(false);
+    expect(validateAvatarUrl("java\nscript:alert(1)").ok).toBe(false);
+    expect(validateAvatarUrl("java\rscript:alert(1)").ok).toBe(false);
+  });
+
+  test("rejects data: / vbscript: / file: / blob: and other non-http protocols", () => {
+    expect(validateAvatarUrl("data:text/html,<script>alert(1)</script>").ok).toBe(false);
+    expect(validateAvatarUrl("data:image/png;base64,iVBORw0KGgo=").ok).toBe(false);
+    expect(validateAvatarUrl("vbscript:msgbox(1)").ok).toBe(false);
+    expect(validateAvatarUrl("file:///etc/passwd").ok).toBe(false);
+    expect(validateAvatarUrl("blob:https://example.com/uuid").ok).toBe(false);
+    expect(validateAvatarUrl("ftp://example.com/a.png").ok).toBe(false);
+  });
+
+  test("rejects relative / protocol-relative / non-URL strings", () => {
+    expect(validateAvatarUrl("/avatars/1.png").ok).toBe(false);
+    expect(validateAvatarUrl("//cdn.example.com/1.png").ok).toBe(false);
+    expect(validateAvatarUrl("not a url").ok).toBe(false);
+    expect(validateAvatarUrl("example.com/x.png").ok).toBe(false);
+  });
+
+  test("rejects embedded whitespace and control characters", () => {
+    expect(validateAvatarUrl("https://example.com/a b.png").ok).toBe(false);
+    expect(validateAvatarUrl("https://example.com/a\u0000.png").ok).toBe(false);
+    expect(validateAvatarUrl("https://example.com/a\u009f.png").ok).toBe(false);
+  });
+
+  test("enforces the length cap", () => {
+    const base = "https://example.com/";
+    const ok = base + "a".repeat(MAX_AVATAR_URL_LENGTH - base.length);
+    expect(validateAvatarUrl(ok).ok).toBe(true);
+    expect(validateAvatarUrl(ok + "a").ok).toBe(false);
+  });
+});

--- a/server/src/avatar-validate.test.ts
+++ b/server/src/avatar-validate.test.ts
@@ -73,6 +73,31 @@ describe("#462 validateAvatarUrl", () => {
     expect(validateAvatarUrl("https://example.com/a\u009f.png").ok).toBe(false);
   });
 
+  test("normalizes to parsed.href: markup-hostile chars come out percent-encoded (finding 3)", () => {
+    const r1 = validateAvatarUrl('https://example.com/a"b.png');
+    expect(r1).toEqual({ ok: true, value: "https://example.com/a%22b.png" });
+    const r2 = validateAvatarUrl("https://example.com/</script><script>.png");
+    expect(r2.ok).toBe(true);
+    if (r2.ok) {
+      expect(r2.value).not.toContain("<");
+      expect(r2.value).not.toContain(">");
+    }
+    const r3 = validateAvatarUrl("https://example.com/a`b.png");
+    expect(r3.ok).toBe(true);
+    if (r3.ok) expect(r3.value).not.toContain("`");
+  });
+
+  test("rejects values whose href still carries attribute-breaking chars (single quote)", () => {
+    // WHATWG URL leaves ' un-encoded in the PATH component — href alone
+    // doesn't neutralize it there, so the validator must refuse.
+    expect(validateAvatarUrl("https://example.com/a'b.png").ok).toBe(false);
+    // In the QUERY component ' IS percent-encoded by href → accepted,
+    // but the stored value must carry no raw quote.
+    const q = validateAvatarUrl("https://example.com/x.png?a='1'");
+    expect(q.ok).toBe(true);
+    if (q.ok) expect(q.value).not.toContain("'");
+  });
+
   test("enforces the length cap", () => {
     const base = "https://example.com/";
     const ok = base + "a".repeat(MAX_AVATAR_URL_LENGTH - base.length);

--- a/server/src/avatar-validate.ts
+++ b/server/src/avatar-validate.ts
@@ -44,6 +44,14 @@ export function validateAvatarUrl(raw: unknown): AvatarValidation {
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     return { ok: false, reason: "avatar_url protocol must be http or https" };
   }
+  // Embedded credentials (https://user:pass@host/…) would be persisted,
+  // leaked to the avatar host on every render, and can spoof the visible
+  // origin in UIs. Reject outright rather than silently stripping — the
+  // caller should know their input carried secrets (通信龙 review round-2
+  // follow-up).
+  if (parsed.username || parsed.password) {
+    return { ok: false, reason: "avatar_url must not contain credentials (userinfo)" };
+  }
   // Persist the NORMALIZED href, not the raw input: href percent-encodes
   // markup-hostile characters (" < > ` → %22 %3C %3E %60), so what lands
   // in the DB is already safe to interpolate into an <img src> attribute.

--- a/server/src/avatar-validate.ts
+++ b/server/src/avatar-validate.ts
@@ -1,0 +1,48 @@
+// #462 — validator for the user-set custom avatar URL (nodes.avatar_url).
+//
+// The value ends up in an <img src> on every dashboard client, so this is
+// an XSS trust boundary: protocol MUST be http/https (rejects javascript:,
+// data:, vbscript:, file:, blob:, …), no whitespace/control characters,
+// bounded length. Pure function, unit-tested in avatar-validate.test.ts.
+
+export const MAX_AVATAR_URL_LENGTH = 2048;
+
+export type AvatarValidation =
+  | { ok: true; value: string | null }
+  | { ok: false; reason: string };
+
+/**
+ * Normalize + validate an untrusted avatar_url patch value.
+ *
+ *   null / undefined / "" / whitespace-only  → { ok, value: null }  (clear)
+ *   valid absolute http(s) URL               → { ok, value: trimmed }
+ *   anything else                            → { ok: false, reason }
+ */
+export function validateAvatarUrl(raw: unknown): AvatarValidation {
+  if (raw === null || raw === undefined) return { ok: true, value: null };
+  if (typeof raw !== "string") {
+    return { ok: false, reason: "avatar_url must be a string or null" };
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return { ok: true, value: null };
+  if (trimmed.length > MAX_AVATAR_URL_LENGTH) {
+    return { ok: false, reason: `avatar_url must be ≤ ${MAX_AVATAR_URL_LENGTH} chars` };
+  }
+  // Reject embedded whitespace + C0/C1 control chars outright. URL()
+  // silently strips some of these (e.g. tabs/newlines), which would let
+  // "java\tscript:" style payloads normalize into a hostile protocol —
+  // so this check must run BEFORE parsing, on the raw trimmed string.
+  if (/[\u0000-\u001f\u007f-\u009f\s]/.test(trimmed)) {
+    return { ok: false, reason: "avatar_url must not contain whitespace or control characters" };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { ok: false, reason: "avatar_url must be an absolute URL" };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, reason: "avatar_url protocol must be http or https" };
+  }
+  return { ok: true, value: trimmed };
+}

--- a/server/src/avatar-validate.ts
+++ b/server/src/avatar-validate.ts
@@ -44,5 +44,18 @@ export function validateAvatarUrl(raw: unknown): AvatarValidation {
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     return { ok: false, reason: "avatar_url protocol must be http or https" };
   }
-  return { ok: true, value: trimmed };
+  // Persist the NORMALIZED href, not the raw input: href percent-encodes
+  // markup-hostile characters (" < > ` → %22 %3C %3E %60), so what lands
+  // in the DB is already safe to interpolate into an <img src> attribute.
+  // The dashboard renderer lives in a different package this repo cannot
+  // audit — the server must not bet on it escaping (审查修复 per 通信龙
+  // #461/#462 review, finding 3).
+  const normalized = parsed.href;
+  // Belt-and-braces: reject anything href does NOT encode that could
+  // still break out of an attribute context (WHATWG URL leaves ' and \
+  // untouched in some positions).
+  if (/["'<>\\`]/.test(normalized)) {
+    return { ok: false, reason: "avatar_url contains characters not allowed in a URL" };
+  }
+  return { ok: true, value: normalized };
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -338,6 +338,16 @@ try {
   if (!/duplicate column|already exists/i.test(e?.message || "")) throw e;
 }
 
+// #462 — user-set custom avatar (nullable http/https image URL). Pure
+// display attribute: deliberately NOT part of the RFC-024 config-apply
+// pipeline (nothing for agent-node to consume, no revision/ack). Written
+// only via PUT /api/nodes/:ref/avatar which validates the URL shape.
+try {
+  db.exec(`ALTER TABLE nodes ADD COLUMN avatar_url TEXT`);
+} catch (e: any) {
+  if (!/duplicate column|already exists/i.test(e?.message || "")) throw e;
+}
+
 // RFC-027 §2 — stop/delete request envelope. Mirrors
 // node_create_requests structure so the daemon-side pull/ack pattern
 // is symmetric with create_node. action='stop'|'delete' picks which

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -518,9 +518,25 @@ setInterval(() => {
   } catch {}
 }, 5 * 60 * 1000);
 
-Bun.serve({
-  port: PORT,
-  hostname: HOST,
+// #434 — test-safety seam, same signature as PR #438 so the two branches
+// merge cleanly. Wraps the sole Bun.serve config in a factory so
+// integration tests can request an OS-assigned ephemeral port
+// (`bootServer({ port: 0 })`) and read the actual bound port back from
+// the returned server. In an aggregate `bun test` run only the FIRST test
+// file's import boots the default server (module cache) — later files'
+// PORT env is ignored, so a suite that hard-codes its own port gets
+// ConnectionRefused on every fetch while still "running" (审查修复 per
+// 通信龙 #461 review, finding 2). Suites boot a private instance via this
+// seam instead. #438 additionally moves the default boot below under
+// `import.meta.main`; until that lands, import keeps booting (pre-#434
+// behavior) so the not-yet-migrated suites stay green.
+//
+// Note: `opts.port ?? PORT` uses nullish-coalescing on purpose — `||`
+// would swallow a legitimate `0`. Same for hostname.
+export function bootServer(opts?: { port?: number; hostname?: string }): ReturnType<typeof Bun.serve> {
+return Bun.serve({
+  port: opts?.port ?? PORT,
+  hostname: opts?.hostname ?? HOST,
   idleTimeout: 255, // max value: keep SSE connections alive (seconds)
   // #221 — defense-in-depth cap on the raw request body. The /api/upload
   // handler also pre-checks Content-Length and post-checks parsed size
@@ -592,8 +608,13 @@ Bun.serve({
     //
     // Auth mirrors /events/:session's three paths:
     //   1. legacy AUTH_TOKEN (master) → any network
-    //   2/3. ntok_ / utok_ → must be a member of the requested network
-    //        (ntok_ additionally passes if the token is bound to it)
+    //   2/3. ntok_ / utok_ → must CURRENTLY be a member of the requested
+    //        network. Membership is checked unconditionally — there is NO
+    //        token-bound-network shortcut. removeNetworkMember deletes the
+    //        membership row but does NOT revoke the user's ntok, so the
+    //        network_members lookup IS the revocation mechanism: an ntok
+    //        bound to this network whose owner was removed must lose the
+    //        stream (审查修复 per 通信龙 #461 review, finding 1).
     const netEventsMatch = url.pathname.match(/^\/events\/network\/(.+)$/);
     if (netEventsMatch && req.method === "GET") {
       const authErr = requireAuth(req);
@@ -607,7 +628,7 @@ Bun.serve({
         return withCors(req, Response.json({ ok: false, error: "auth required" }, { status: 403 }));
       }
       const observerRole = getUserNetworkRole(authCtx.userId, observedNetId);
-      if (!observerRole && authCtx.networkId !== observedNetId) {
+      if (!observerRole) {
         return withCors(req, Response.json({ ok: false, error: "not a member of this network" }, { status: 403 }));
       }
       return createNetworkObserverStream(observedNetId);
@@ -1756,7 +1777,7 @@ Bun.serve({
       }
       // #461 network observer summary — unconditional (the task row
       // exists even when the target is offline/queued), metadata only.
-      pushNetworkObserverEvent(taskNetId, { type: "new_task", task_id: id, from: fromSession, to: targetAlias, status: "delivered", priority: body.priority });
+      pushNetworkObserverEvent(taskNetId, { type: "new_task", task_id: id, from: fromSession, to: targetAlias, status: target.state === "online" ? "delivered" : "queued", priority: body.priority });
       // #212 — stamp the dedup index only after the inbox/tasks insert
       // succeeds. Mirrors the MCP `send_task` path so a failed write
       // never shadows a legitimate retry.
@@ -2447,6 +2468,11 @@ Security: ${SECURITY_LABEL}
     },
   },
 });
+} // end bootServer
+
+// Boot the default server at import (pre-#434 behavior — #438 moves this
+// under `import.meta.main`). Exported so callers can read the bound port.
+export const server = bootServer();
 
 // Round-2/4 review ② — periodic retention sweep + incremental VACUUM.
 // Sweeps every hour by default. Operators can disable any single table

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,8 +3,9 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { z } from "zod/v4";
 import { registerTools } from "./tools.js";
 import { db, logTaskEvent, logAudit } from "./db.js";
-import { createSSEStream, pushEvent, getSSEStats } from "./push.js";
+import { createSSEStream, createNetworkObserverStream, pushEvent, pushNetworkObserverEvent, getSSEStats } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
+import { validateAvatarUrl } from "./avatar-validate.js";
 import { register, login, resolveToken, getUserNetworks, getUserAllNetworks, createNetwork, deleteNetwork, renameNetwork, changePassword, issueUserToken, listTokens, createToken, revokeToken, getNetworkMembers, getUserNetworkRole, addNetworkMember, updateMemberRole, removeNetworkMember, createInvite, joinByInvite, createNetworkTokenForNode, type AuthUser } from "./auth.js";
 import { abortRename, cleanupCommittedRenameSessions, commitRename, prepareRename, resolveCanonicalAlias } from "./rename.js";
 import { sharedSendDedup, buildDuplicateSendPayload } from "./send_dedup.js";
@@ -581,6 +582,35 @@ Bun.serve({
       // rewrite the header. Streamed bodies (SSE) pass through untouched
       // because Response takes the original ReadableStream verbatim.
       return withUtf8CharsetContentType(response);
+    }
+
+    // ── #461 SSE network observer stream ──
+    // GET /events/network/:network_id → 网络级摘要事件（new_task / new_reply
+    // routing metadata only, no content）。Dashboard 用它实时感知第三方流量,
+    // 退役 15s 软轮询。MUST be matched before the generic /events/(.+) route
+    // below, which would otherwise swallow the path as a session name.
+    //
+    // Auth mirrors /events/:session's three paths:
+    //   1. legacy AUTH_TOKEN (master) → any network
+    //   2/3. ntok_ / utok_ → must be a member of the requested network
+    //        (ntok_ additionally passes if the token is bound to it)
+    const netEventsMatch = url.pathname.match(/^\/events\/network\/(.+)$/);
+    if (netEventsMatch && req.method === "GET") {
+      const authErr = requireAuth(req);
+      if (authErr) return authErr;
+      const observedNetId = decodeURIComponent(netEventsMatch[1]);
+      const authCtx = resolveRequestAuth(req);
+      if (!authCtx && isLegacyAuthToken(req)) {
+        return createNetworkObserverStream(observedNetId);
+      }
+      if (!authCtx) {
+        return withCors(req, Response.json({ ok: false, error: "auth required" }, { status: 403 }));
+      }
+      const observerRole = getUserNetworkRole(authCtx.userId, observedNetId);
+      if (!observerRole && authCtx.networkId !== observedNetId) {
+        return withCors(req, Response.json({ ok: false, error: "not a member of this network" }, { status: 403 }));
+      }
+      return createNetworkObserverStream(observedNetId);
     }
 
     // ── SSE push: Agent 实时接收任务推送 ──
@@ -1724,6 +1754,9 @@ Bun.serve({
       if (target.state === "online") {
         pushEvent(targetAlias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority: body.priority, from: fromSession, ...(canonical.renamed ? { renamed_from: body.alias } : {}) }, taskNetId);
       }
+      // #461 network observer summary — unconditional (the task row
+      // exists even when the target is offline/queued), metadata only.
+      pushNetworkObserverEvent(taskNetId, { type: "new_task", task_id: id, from: fromSession, to: targetAlias, status: "delivered", priority: body.priority });
       // #212 — stamp the dedup index only after the inbox/tasks insert
       // succeeds. Mirrors the MCP `send_task` path so a failed write
       // never shadows a legitimate retry.
@@ -2025,6 +2058,51 @@ Bun.serve({
       }));
     }
 
+    // ── #462 REST: set / clear a node's custom avatar ──
+    // PUT /api/nodes/:ref/avatar  body: { "avatar_url": "https://…" | null }
+    //
+    // Deliberately NOT part of the RFC-024 config-apply pipeline: avatar
+    // is a pure display attribute — nothing for agent-node to consume, no
+    // config_revision / ack round-trip, no restart tier. Persisted on the
+    // nodes row and served back via GET /api/nodes (cross-device).
+    //
+    // Auth: same write gate as node delete above — network-scoped lookup
+    // + canRestWriteNetwork (member with role above viewer, or admin, or
+    // legacy master token). Value passes validateAvatarUrl (http/https
+    // only, ≤ 2048 chars, no control chars — XSS boundary, see
+    // avatar-validate.ts).
+    const nodeAvatarMatch = url.pathname.match(/^\/api\/nodes\/([^/]+)\/avatar$/);
+    if (nodeAvatarMatch && req.method === "PUT") {
+      let avatarBody: any;
+      try {
+        avatarBody = await req.json();
+      } catch {
+        return withCors(req, Response.json({ ok: false, error: "invalid JSON" }, { status: 400 }));
+      }
+      const validated = validateAvatarUrl(avatarBody?.avatar_url);
+      if (!validated.ok) {
+        return withCors(req, Response.json({ ok: false, error: "invalid_avatar_url", reason: validated.reason }, { status: 400 }));
+      }
+      const ref = decodeURIComponent(nodeAvatarMatch[1]);
+      const params: any[] = [ref, ref, ref];
+      let sql = "SELECT node_id, alias, network_id FROM nodes WHERE (node_id = ?1 OR node_name = ?2 OR alias = ?3)";
+      sql = addNetworkScope(sql, params, restScope);
+      sql += " ORDER BY updated_at DESC LIMIT 1";
+      const node = db.get<any>(sql, ...params);
+      if (!node) return withCors(req, Response.json({ ok: false, error: "node not found" }, { status: 404 }));
+
+      const nodeNetId = node.network_id ?? singleNetworkId(restScope);
+      if (!canRestWriteNetwork(restAuth, nodeNetId, isAdmin)) {
+        return withCors(req, Response.json({ ok: false, error: "permission_denied" }, { status: 403 }));
+      }
+
+      db.run(
+        "UPDATE nodes SET avatar_url = ?1, updated_at = datetime('now') WHERE node_id = ?2",
+        [validated.value, node.node_id]
+      );
+      return withCors(req, Response.json({ ok: true, node_id: node.node_id, alias: node.alias, avatar_url: validated.value }));
+    }
+
     // ── REST: nodes table (V2 Sprint 2) ──
     // Explicit column list — NOT `SELECT *`. Two reasons:
     //   1. `SELECT *` silently broadcasts any column added later to the
@@ -2173,10 +2251,13 @@ Bun.serve({
       // (#345) but /api/nodes never SELECTed it. Following #312
       // "explicit SELECT" discipline — extend the projection here,
       // do NOT switch to SELECT *.
+      // #462: avatar_url added to the projection so custom avatars are
+      // cross-device (dashboard hydrates from here; localStorage was the
+      // only store before). Nullable — null means "use default set".
       let sql = `SELECT node_id, node_name, alias, runtime, model,
                         config_path, channels, server, hostname,
                         network_id, created_at, updated_at,
-                        config_snapshot, lifecycle_state
+                        config_snapshot, lifecycle_state, avatar_url
                  FROM nodes WHERE 1=1`;
       const params: any[] = [];
       sql = addNetworkScope(sql, params, restScope);

--- a/server/src/observer-avatar-http.test.ts
+++ b/server/src/observer-avatar-http.test.ts
@@ -1,42 +1,60 @@
 // #461 + #462 — HTTP integration tests against the real Bun.serve hub.
 //
-// Pattern mirrors uploads-http.test.ts / api-host-supervisors-fallback:
-// temp DB + ephemeral port, `import("./index.js")` side effect boots the
-// server, real fetch() against the production code path (auth included).
+// Boots a PRIVATE server instance via the #434 seam (`bootServer({ port: 0 })`,
+// same signature as PR #438) and derives BASE from the actual bound port.
+// This keeps the suite alive in aggregate runs: `await import("./index.js")`
+// is a module-cache no-op when another file booted first, so relying on the
+// import side effect + own PORT env leaves every fetch ConnectionRefused
+// while the tests still "run" (通信龙 #461 review, finding 2). Gate:
+//   bun test src/uploads-http.test.ts src/observer-avatar-http.test.ts → 0 fail
 //
-// #461: GET /events/network/:id observer stream — membership auth, summary
-//       events for third-party REST dispatches, no content leakage.
+// #461: GET /events/network/:id observer stream — membership auth incl.
+//       member-removal revocation, summary events for third-party traffic
+//       (REST dispatch + MCP send_reply), no content leakage.
 // #462: PUT /api/nodes/:ref/avatar + GET /api/nodes round trip — persistence,
-//       XSS-shaped rejects, clear semantics, write-permission gate.
+//       href normalization, XSS-shaped rejects, clear semantics, write gate.
 
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import { mkdtempSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { register, login } from "./auth.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { register, login, addNetworkMember, removeNetworkMember, createNetworkTokenForNode } from "./auth.js";
+import { registerTools } from "./tools.js";
 import { db } from "./db.js";
 
 const SERVER_DB = mkdtempSync(join(tmpdir(), "anet-obs-avatar-db-")) + "/commhub.db";
-const PORT = 17000 + Math.floor(Math.random() * 1000);
-const BASE = `http://127.0.0.1:${PORT}`;
+
+let BASE = "";
+let privateServer: any = null;
 
 let memberToken = "";
 let memberNetworkId = "";
+let memberUserId = "";
 let outsiderToken = "";
+let outsiderUserId = "";
 const TARGET_ALIAS = "obs-target-agent";
 const AVATAR_NODE_ID = "node_avatar_test_1";
 
 beforeAll(async () => {
-  process.env.COMMHUB_DB = SERVER_DB;
-  process.env.PORT = String(PORT);
+  // Kept for per-file runs launched without an external COMMHUB_DB (the
+  // documented contract still is to set it externally; see db-adapter.ts).
+  process.env.COMMHUB_DB = process.env.COMMHUB_DB || SERVER_DB;
   process.env.HOST = "127.0.0.1";
+  // The default import-boot instance (pre-#434 behavior) must not fight
+  // over a fixed port — 9200 may be a real hub on the dev box. (PORT=0
+  // won't do: index.ts parses `Number(process.env.PORT) || 9200`, which
+  // swallows 0.) Our assertions run against the private bootServer
+  // instance below either way.
+  process.env.PORT = process.env.PORT || String(16000 + Math.floor(Math.random() * 1000));
 
   const suffix = `${Date.now()}_${Math.floor(Math.random() * 1000)}`;
   const pw = "BootstrapPw123Aa!";
 
-  let r = register(`obs_member_${suffix}`, pw, undefined, "seed");
+  const memberName = `obs_member_${suffix}`;
+  let r = register(memberName, pw, undefined, "seed");
   if (!r.ok || !r.token) {
-    const lr = login(`obs_member_${suffix}`, pw);
+    const lr = login(memberName, pw);
     if (lr.token) { memberToken = lr.token; memberNetworkId = lr.network_id ?? ""; }
   } else {
     memberToken = r.token;
@@ -44,10 +62,15 @@ beforeAll(async () => {
   }
   expect(memberToken).toBeTruthy();
   expect(memberNetworkId).toBeTruthy();
+  memberUserId = db.get<any>("SELECT user_id FROM users WHERE username = ?1", memberName)?.user_id ?? "";
+  expect(memberUserId).toBeTruthy();
 
-  const r2 = register(`obs_outsider_${suffix}`, pw, undefined, "seed");
+  const outsiderName = `obs_outsider_${suffix}`;
+  const r2 = register(outsiderName, pw, undefined, "seed");
   if (r2.ok && r2.token) outsiderToken = r2.token;
   expect(outsiderToken).toBeTruthy();
+  outsiderUserId = db.get<any>("SELECT user_id FROM users WHERE username = ?1", outsiderName)?.user_id ?? "";
+  expect(outsiderUserId).toBeTruthy();
 
   // Target agent session in the member's network, freshly seen → online.
   db.run(
@@ -63,11 +86,15 @@ beforeAll(async () => {
     [AVATAR_NODE_ID, TARGET_ALIAS, memberNetworkId]
   );
 
-  await import("./index.js");
-  await new Promise((r) => setTimeout(r, 100));
+  // Private instance on an OS-assigned port — never collides with the
+  // default import-boot instance another test file may own.
+  const mod: any = await import("./index.js");
+  privateServer = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  BASE = `http://127.0.0.1:${privateServer.port}`;
 });
 
 afterAll(() => {
+  try { privateServer?.stop?.(true); } catch {}
   try { rmSync(SERVER_DB, { recursive: true, force: true }); } catch {}
 });
 
@@ -127,9 +154,43 @@ describe("#461 GET /events/network/:id — auth", () => {
     expect(connected.network_id).toBe(memberNetworkId);
     await reader.cancel();
   });
+
+  test("membership removal revokes observer access — ntok exploit repro (通信龙 review finding 1)", async () => {
+    // Exact repro of the review's exploit: add user C to network A, mint
+    // an ntok BOUND to A, remove C from A — the same live ntok must lose
+    // the stream. network_members IS the revocation mechanism because
+    // removeNetworkMember does not revoke the user's tokens; the old
+    // `!role && authCtx.networkId !== observedNetId` OR-form let the
+    // token's network binding bypass the membership check (utok would
+    // not catch this: its authCtx.networkId is null, so only ntok
+    // exercises the vulnerable branch — verified by stubbing the OR
+    // back in: THIS test goes red, the utok variants stay green).
+    const added = addNetworkMember(memberNetworkId, outsiderUserId, "member");
+    expect(added.ok).toBe(true);
+    const minted = createNetworkTokenForNode(outsiderUserId, memberNetworkId, "revocation-probe");
+    expect(minted.ok).toBe(true);
+    const ntok = minted.token!;
+    expect(ntok.startsWith("ntok_")).toBe(true);
+
+    const whileMember = await fetch(`${BASE}/events/network/${memberNetworkId}`, { headers: auth(ntok) });
+    expect(whileMember.status).toBe(200);
+    const reader = whileMember.body!.getReader();
+    expect((await readFrame(reader)).type).toBe("connected");
+    await reader.cancel();
+
+    const removed = removeNetworkMember(memberNetworkId, outsiderUserId);
+    expect(removed.ok).toBe(true);
+    // The review's failing probe: /events/network/A with the still-live
+    // network-bound token → must now be 403, not 200.
+    const afterRemoval = await fetch(`${BASE}/events/network/${memberNetworkId}`, { headers: auth(ntok) });
+    expect(afterRemoval.status).toBe(403);
+    // utok of the removed user is denied too.
+    const utokAfter = await fetch(`${BASE}/events/network/${memberNetworkId}`, { headers: auth(outsiderToken) });
+    expect(utokAfter.status).toBe(403);
+  });
 });
 
-describe("#461 observer receives third-party dispatch summaries", () => {
+describe("#461 observer receives third-party traffic summaries", () => {
   test("REST /api/task dispatch → observer gets new_task summary, no content", async () => {
     const res = await fetch(`${BASE}/events/network/${memberNetworkId}`, { headers: auth(memberToken) });
     const reader = res.body!.getReader();
@@ -150,11 +211,47 @@ describe("#461 observer receives third-party dispatch summaries", () => {
     expect(evt.task_id).toBe(dispatched.task_id);
     expect(evt.from).toBe("third-party-sender");
     expect(evt.to).toBe(TARGET_ALIAS);
+    // Online session was seeded → delivered; offline would report queued.
     expect(evt.status).toBe("delivered");
     expect(evt.priority).toBe("high");
     expect(evt.network_id).toBe(memberNetworkId);
     expect(evt.scope).toBe("network");
     // The acceptance line: summary must NOT leak the task body.
+    expect(JSON.stringify(evt)).not.toContain(secret);
+    await reader.cancel();
+  });
+
+  test("MCP send_reply → observer gets new_reply summary, reply text NOT in frame", async () => {
+    // Drive the REAL registered MCP handler (same interception pattern as
+    // ack-create-request.test.ts) with the member's network enforced, and
+    // read the observer stream over real HTTP.
+    const res = await fetch(`${BASE}/events/network/${memberNetworkId}`, { headers: auth(memberToken) });
+    const reader = res.body!.getReader();
+    await readFrame(reader); // connected
+
+    const tools: Record<string, (args: any) => Promise<any>> = {};
+    const mcp = new McpServer({ name: "test", version: "0" }) as any;
+    mcp.tool = (name: string, _desc: string, _schema: any, handler: any) => { tools[name] = handler; };
+    registerTools(mcp, undefined, memberNetworkId, memberUserId);
+    expect(typeof tools["send_reply"]).toBe("function");
+
+    const secret = `SECRET-REPLY-TEXT-${Date.now()}`;
+    const result = await tools["send_reply"]({
+      alias: TARGET_ALIAS,
+      text: secret,
+      status: "replied",
+      from_session: "reply-worker",
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(true);
+
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("new_reply");
+    expect(evt.from).toBe("reply-worker");
+    expect(evt.to).toBe(TARGET_ALIAS);
+    expect(evt.status).toBe("replied");
+    expect(evt.message_id).toBe(parsed.message_id);
+    expect(evt.network_id).toBe(memberNetworkId);
     expect(JSON.stringify(evt)).not.toContain(secret);
     await reader.cancel();
   });
@@ -182,6 +279,20 @@ describe("#462 PUT /api/nodes/:ref/avatar + GET /api/nodes", () => {
     expect(row.avatar_url).toBe(avatarUrl);
     // #312 discipline still holds — internals must not leak.
     expect("config_snapshot" in row).toBe(false);
+  });
+
+  test("markup-hostile chars are stored NORMALIZED (href), not raw (通信龙 review finding 3)", async () => {
+    const put = await fetch(`${BASE}/api/nodes/${AVATAR_NODE_ID}/avatar`, {
+      method: "PUT",
+      headers: { ...auth(memberToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar_url: 'https://cdn.example.com/a"b.png' }),
+    });
+    expect(put.status).toBe(200);
+    const putBody = await put.json() as any;
+    expect(putBody.avatar_url).toBe("https://cdn.example.com/a%22b.png");
+    const row = db.get<any>("SELECT avatar_url FROM nodes WHERE node_id = ?1", AVATAR_NODE_ID);
+    expect(row.avatar_url).toBe("https://cdn.example.com/a%22b.png");
+    expect(row.avatar_url).not.toContain('"');
   });
 
   test("clear avatar with null → avatar_url null in list", async () => {

--- a/server/src/observer-avatar-http.test.ts
+++ b/server/src/observer-avatar-http.test.ts
@@ -1,0 +1,241 @@
+// #461 + #462 — HTTP integration tests against the real Bun.serve hub.
+//
+// Pattern mirrors uploads-http.test.ts / api-host-supervisors-fallback:
+// temp DB + ephemeral port, `import("./index.js")` side effect boots the
+// server, real fetch() against the production code path (auth included).
+//
+// #461: GET /events/network/:id observer stream — membership auth, summary
+//       events for third-party REST dispatches, no content leakage.
+// #462: PUT /api/nodes/:ref/avatar + GET /api/nodes round trip — persistence,
+//       XSS-shaped rejects, clear semantics, write-permission gate.
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { register, login } from "./auth.js";
+import { db } from "./db.js";
+
+const SERVER_DB = mkdtempSync(join(tmpdir(), "anet-obs-avatar-db-")) + "/commhub.db";
+const PORT = 17000 + Math.floor(Math.random() * 1000);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+let memberToken = "";
+let memberNetworkId = "";
+let outsiderToken = "";
+const TARGET_ALIAS = "obs-target-agent";
+const AVATAR_NODE_ID = "node_avatar_test_1";
+
+beforeAll(async () => {
+  process.env.COMMHUB_DB = SERVER_DB;
+  process.env.PORT = String(PORT);
+  process.env.HOST = "127.0.0.1";
+
+  const suffix = `${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+  const pw = "BootstrapPw123Aa!";
+
+  let r = register(`obs_member_${suffix}`, pw, undefined, "seed");
+  if (!r.ok || !r.token) {
+    const lr = login(`obs_member_${suffix}`, pw);
+    if (lr.token) { memberToken = lr.token; memberNetworkId = lr.network_id ?? ""; }
+  } else {
+    memberToken = r.token;
+    memberNetworkId = r.network_id ?? "";
+  }
+  expect(memberToken).toBeTruthy();
+  expect(memberNetworkId).toBeTruthy();
+
+  const r2 = register(`obs_outsider_${suffix}`, pw, undefined, "seed");
+  if (r2.ok && r2.token) outsiderToken = r2.token;
+  expect(outsiderToken).toBeTruthy();
+
+  // Target agent session in the member's network, freshly seen → online.
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, network_id, updated_at, last_seen_at)
+     VALUES (?1, ?2, 'idle', ?3, datetime('now'), datetime('now'))`,
+    [`resume_${suffix}`, TARGET_ALIAS, memberNetworkId]
+  );
+
+  // Node row for the avatar round trip.
+  db.run(
+    `INSERT OR REPLACE INTO nodes (node_id, node_name, alias, network_id, created_at, updated_at)
+     VALUES (?1, 'avatar-test-node', ?2, ?3, datetime('now'), datetime('now'))`,
+    [AVATAR_NODE_ID, TARGET_ALIAS, memberNetworkId]
+  );
+
+  await import("./index.js");
+  await new Promise((r) => setTimeout(r, 100));
+});
+
+afterAll(() => {
+  try { rmSync(SERVER_DB, { recursive: true, force: true }); } catch {}
+});
+
+function auth(token: string): Record<string, string> {
+  return { "Authorization": `Bearer ${token}` };
+}
+
+/** Read the next SSE data frame from a fetch Response, with timeout. */
+async function readFrame(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs = 3_000,
+): Promise<Record<string, any>> {
+  const decoder = new TextDecoder();
+  let buf = "";
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, rej) =>
+        setTimeout(() => rej(new Error(`no SSE frame within ${timeoutMs}ms`)), deadline - Date.now()),
+      ),
+    ]);
+    if (result.done) throw new Error("SSE stream ended unexpectedly");
+    buf += decoder.decode(result.value, { stream: true });
+    const sep = buf.indexOf("\n\n");
+    if (sep === -1) continue;
+    const rawFrame = buf.slice(0, sep);
+    buf = buf.slice(sep + 2);
+    const dataLine = rawFrame.split("\n").find((l) => l.startsWith("data: "));
+    if (!dataLine) continue;
+    return JSON.parse(dataLine.slice(6));
+  }
+  throw new Error(`no SSE frame within ${timeoutMs}ms`);
+}
+
+describe("#461 GET /events/network/:id — auth", () => {
+  test("anonymous → 401", async () => {
+    const res = await fetch(`${BASE}/events/network/${memberNetworkId}`);
+    expect(res.status).toBe(401);
+  });
+
+  test("non-member user token → 403", async () => {
+    const res = await fetch(`${BASE}/events/network/${memberNetworkId}`, { headers: auth(outsiderToken) });
+    expect(res.status).toBe(403);
+    const body = await res.json() as any;
+    expect(body.ok).toBe(false);
+  });
+
+  test("member user token → SSE stream with observer connected frame", async () => {
+    const res = await fetch(`${BASE}/events/network/${memberNetworkId}`, { headers: auth(memberToken) });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") || "").toContain("text/event-stream");
+    const reader = res.body!.getReader();
+    const connected = await readFrame(reader);
+    expect(connected.type).toBe("connected");
+    expect(connected.observer).toBe(true);
+    expect(connected.network_id).toBe(memberNetworkId);
+    await reader.cancel();
+  });
+});
+
+describe("#461 observer receives third-party dispatch summaries", () => {
+  test("REST /api/task dispatch → observer gets new_task summary, no content", async () => {
+    const res = await fetch(`${BASE}/events/network/${memberNetworkId}`, { headers: auth(memberToken) });
+    const reader = res.body!.getReader();
+    await readFrame(reader); // connected
+
+    const secret = `SECRET-TASK-CONTENT-${Date.now()}`;
+    const dispatch = await fetch(`${BASE}/api/task`, {
+      method: "POST",
+      headers: { ...auth(memberToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ alias: TARGET_ALIAS, task: secret, priority: "high", from: "third-party-sender", network_id: memberNetworkId }),
+    });
+    expect([200, 202]).toContain(dispatch.status);
+    const dispatched = await dispatch.json() as any;
+    expect(dispatched.task_id).toBeTruthy();
+
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("new_task");
+    expect(evt.task_id).toBe(dispatched.task_id);
+    expect(evt.from).toBe("third-party-sender");
+    expect(evt.to).toBe(TARGET_ALIAS);
+    expect(evt.status).toBe("delivered");
+    expect(evt.priority).toBe("high");
+    expect(evt.network_id).toBe(memberNetworkId);
+    expect(evt.scope).toBe("network");
+    // The acceptance line: summary must NOT leak the task body.
+    expect(JSON.stringify(evt)).not.toContain(secret);
+    await reader.cancel();
+  });
+});
+
+describe("#462 PUT /api/nodes/:ref/avatar + GET /api/nodes", () => {
+  test("set avatar → 200, GET /api/nodes returns it (cross-device persistence)", async () => {
+    const avatarUrl = "https://cdn.example.com/avatars/custom-1.png";
+    const put = await fetch(`${BASE}/api/nodes/${AVATAR_NODE_ID}/avatar`, {
+      method: "PUT",
+      headers: { ...auth(memberToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar_url: avatarUrl }),
+    });
+    expect(put.status).toBe(200);
+    const putBody = await put.json() as any;
+    expect(putBody.ok).toBe(true);
+    expect(putBody.avatar_url).toBe(avatarUrl);
+
+    const list = await fetch(`${BASE}/api/nodes?node_id=${AVATAR_NODE_ID}`, { headers: auth(memberToken) });
+    expect(list.status).toBe(200);
+    const listBody = await list.json() as any;
+    expect(listBody.ok).toBe(true);
+    const row = listBody.nodes.find((n: any) => n.node_id === AVATAR_NODE_ID);
+    expect(row).toBeTruthy();
+    expect(row.avatar_url).toBe(avatarUrl);
+    // #312 discipline still holds — internals must not leak.
+    expect("config_snapshot" in row).toBe(false);
+  });
+
+  test("clear avatar with null → avatar_url null in list", async () => {
+    const put = await fetch(`${BASE}/api/nodes/${AVATAR_NODE_ID}/avatar`, {
+      method: "PUT",
+      headers: { ...auth(memberToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar_url: null }),
+    });
+    expect(put.status).toBe(200);
+    const list = await fetch(`${BASE}/api/nodes?node_id=${AVATAR_NODE_ID}`, { headers: auth(memberToken) });
+    const listBody = await list.json() as any;
+    const row = listBody.nodes.find((n: any) => n.node_id === AVATAR_NODE_ID);
+    expect(row.avatar_url).toBeNull();
+  });
+
+  test("javascript: URL → 400 invalid_avatar_url, value NOT persisted", async () => {
+    const put = await fetch(`${BASE}/api/nodes/${AVATAR_NODE_ID}/avatar`, {
+      method: "PUT",
+      headers: { ...auth(memberToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar_url: "javascript:alert(1)" }),
+    });
+    expect(put.status).toBe(400);
+    const body = await put.json() as any;
+    expect(body.error).toBe("invalid_avatar_url");
+    const row = db.get<any>("SELECT avatar_url FROM nodes WHERE node_id = ?1", AVATAR_NODE_ID);
+    expect(row.avatar_url ?? null).toBeNull();
+  });
+
+  test("data: URL → 400", async () => {
+    const put = await fetch(`${BASE}/api/nodes/${AVATAR_NODE_ID}/avatar`, {
+      method: "PUT",
+      headers: { ...auth(memberToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar_url: "data:text/html,<script>alert(1)</script>" }),
+    });
+    expect(put.status).toBe(400);
+  });
+
+  test("anonymous → 401; non-member → 404/403 (network-scoped lookup)", async () => {
+    const anon = await fetch(`${BASE}/api/nodes/${AVATAR_NODE_ID}/avatar`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar_url: "https://example.com/x.png" }),
+    });
+    expect(anon.status).toBe(401);
+
+    // Outsider's network scope can't even see the node → 404 (or 403 if
+    // visibility rules change later; both deny the write).
+    const outsider = await fetch(`${BASE}/api/nodes/${AVATAR_NODE_ID}/avatar`, {
+      method: "PUT",
+      headers: { ...auth(outsiderToken), "Content-Type": "application/json" },
+      body: JSON.stringify({ avatar_url: "https://example.com/x.png" }),
+    });
+    expect([403, 404]).toContain(outsider.status);
+    const row = db.get<any>("SELECT avatar_url FROM nodes WHERE node_id = ?1", AVATAR_NODE_ID);
+    expect(row.avatar_url ?? null).toBeNull();
+  });
+});

--- a/server/src/observer-push.test.ts
+++ b/server/src/observer-push.test.ts
@@ -1,0 +1,176 @@
+// #461 — unit tests for the network observer SSE channel (push.ts).
+//
+// These tests read REAL bytes off the observer stream, so they are a
+// live gate: stub pushNetworkObserverEvent out to a no-op and every
+// "receives …" test below times out red. (Per 通信龙 2026-07-28 rule:
+// a test that stays green when the core function is emptied is a fake
+// gate.)
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  __resetSSEClientsForTest,
+  createNetworkObserverStream,
+  createSSEStream,
+  pushEvent,
+  pushNetworkObserverEvent,
+} from "./push";
+
+afterEach(() => {
+  __resetSSEClientsForTest();
+});
+
+type Frame = Record<string, any>;
+
+/** Read the next SSE data frame (skipping keepalive comments), with a
+ *  hard timeout so a silent stream fails the test instead of hanging. */
+async function readFrame(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs = 2_000,
+): Promise<Frame> {
+  const decoder = new TextDecoder();
+  let buf = "";
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    const result = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, rej) =>
+        setTimeout(() => rej(new Error(`no SSE frame within ${timeoutMs}ms`)), remaining),
+      ),
+    ]);
+    if (result.done) throw new Error("stream ended before a data frame arrived");
+    buf += decoder.decode(result.value, { stream: true });
+    const sep = buf.indexOf("\n\n");
+    if (sep === -1) continue;
+    const rawFrame = buf.slice(0, sep);
+    buf = buf.slice(sep + 2);
+    const dataLine = rawFrame.split("\n").find((l) => l.startsWith("data: "));
+    if (!dataLine) continue; // keepalive comment frame — keep reading
+    return JSON.parse(dataLine.slice(6));
+  }
+  throw new Error(`no SSE frame within ${timeoutMs}ms`);
+}
+
+describe("#461 network observer stream", () => {
+  test("observer receives connected frame, then new_task summary with metadata only", async () => {
+    const res = createNetworkObserverStream("net_obs_a");
+    const reader = res.body!.getReader();
+
+    const connected = await readFrame(reader);
+    expect(connected.type).toBe("connected");
+    expect(connected.observer).toBe(true);
+    expect(connected.network_id).toBe("net_obs_a");
+
+    pushNetworkObserverEvent("net_obs_a", {
+      type: "new_task",
+      task_id: "task-123",
+      from: "sender-agent",
+      to: "receiver-agent",
+      status: "delivered",
+      priority: "high",
+    });
+
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("new_task");
+    expect(evt.task_id).toBe("task-123");
+    expect(evt.from).toBe("sender-agent");
+    expect(evt.to).toBe("receiver-agent");
+    expect(evt.status).toBe("delivered");
+    expect(evt.priority).toBe("high");
+    expect(evt.network_id).toBe("net_obs_a");
+    expect(evt.scope).toBe("network");
+    // Summary contract: NO content field, ever.
+    expect("content" in evt).toBe(false);
+    expect("task" in evt).toBe(false);
+    await reader.cancel();
+  });
+
+  test("observer receives new_reply summary", async () => {
+    const res = createNetworkObserverStream("net_obs_reply");
+    const reader = res.body!.getReader();
+    await readFrame(reader); // connected
+
+    pushNetworkObserverEvent("net_obs_reply", {
+      type: "new_reply",
+      task_id: "parent-task",
+      message_id: "msg-9",
+      from: "worker",
+      to: "boss",
+      status: "completed",
+    });
+
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("new_reply");
+    expect(evt.task_id).toBe("parent-task");
+    expect(evt.message_id).toBe("msg-9");
+    expect(evt.status).toBe("completed");
+    expect("content" in evt).toBe(false);
+    expect("text" in evt).toBe(false);
+    await reader.cancel();
+  });
+
+  test("events are network-isolated: observer on net B never sees net A traffic", async () => {
+    const resB = createNetworkObserverStream("net_obs_b");
+    const readerB = resB.body!.getReader();
+    await readFrame(readerB); // connected
+
+    // Push to A first, then a marker to B. Delivery per key is
+    // synchronous and ordered, so if B's next frame is the marker,
+    // the A event provably never reached B.
+    pushNetworkObserverEvent("net_obs_a2", { type: "new_task", task_id: "leaked" });
+    pushNetworkObserverEvent("net_obs_b", { type: "new_task", task_id: "marker-b" });
+
+    const evt = await readFrame(readerB);
+    expect(evt.task_id).toBe("marker-b");
+    await readerB.cancel();
+  });
+
+  test("observer stream is isolated from session channels (both directions)", async () => {
+    const sessionRes = createSSEStream("agent-x", "net_obs_c");
+    const sessionReader = sessionRes.body!.getReader();
+    await readFrame(sessionReader); // connected
+
+    const obsRes = createNetworkObserverStream("net_obs_c");
+    const obsReader = obsRes.body!.getReader();
+    await readFrame(obsReader); // connected
+
+    // Session push must NOT hit the observer; observer push must NOT
+    // hit the session. Marker technique as above.
+    pushEvent("agent-x", { type: "new_task", inbox_count: 1, marker: "to-session" }, "net_obs_c");
+    pushNetworkObserverEvent("net_obs_c", { type: "new_task", task_id: "to-observer" });
+
+    const sessionEvt = await readFrame(sessionReader);
+    expect(sessionEvt.marker).toBe("to-session");
+    expect("task_id" in sessionEvt).toBe(false);
+
+    const obsEvt = await readFrame(obsReader);
+    expect(obsEvt.task_id).toBe("to-observer");
+    expect("marker" in obsEvt).toBe(false);
+
+    await sessionReader.cancel();
+    await obsReader.cancel();
+  });
+
+  test("null / undefined networkId is a silent no-op", () => {
+    // Must not throw — legacy null-network traffic has no observer
+    // stream by design (documented in #461 / the PR).
+    expect(() => pushNetworkObserverEvent(null, { type: "new_task" })).not.toThrow();
+    expect(() => pushNetworkObserverEvent(undefined, { type: "new_task" })).not.toThrow();
+  });
+
+  test("multiple observers on the same network all receive the event", async () => {
+    const r1 = createNetworkObserverStream("net_obs_multi");
+    const r2 = createNetworkObserverStream("net_obs_multi");
+    const reader1 = r1.body!.getReader();
+    const reader2 = r2.body!.getReader();
+    await readFrame(reader1);
+    await readFrame(reader2);
+
+    pushNetworkObserverEvent("net_obs_multi", { type: "new_task", task_id: "fanout" });
+
+    expect((await readFrame(reader1)).task_id).toBe("fanout");
+    expect((await readFrame(reader2)).task_id).toBe("fanout");
+    await reader1.cancel();
+    await reader2.cancel();
+  });
+});

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -97,6 +97,23 @@ function clientKey(sessionName: string, networkId?: string | null): string {
   return `${networkId || "global"}:${sessionName}`;
 }
 
+// ── #461 network observer channels ───────────────────────────────────
+// Dashboard (or any network member) subscribes GET /events/network/:id
+// and receives SUMMARY events for ALL new_task / new_reply traffic in
+// that network — not just tasks it sent/received. Summary events carry
+// ids + routing metadata only, never task/reply content.
+//
+// Key scheme: leading NUL byte makes an observer key impossible to
+// forge from the session scheme above (`${networkId}:${sessionName}`)
+// for any networkId the hub itself issues (net_* / "global"). Only a
+// master-token caller could even inject a NUL into network_id via the
+// legacy ?network_id= path, and master token is root already.
+const OBSERVER_KEY_PREFIX = "\u0000netobs:";
+
+function observerKey(networkId: string): string {
+  return `${OBSERVER_KEY_PREFIX}${networkId}`;
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Close + dispatch helpers
 // ─────────────────────────────────────────────────────────────────────
@@ -215,8 +232,24 @@ function ensureLivenessSweep(): void {
 
 /** 创建 SSE Response 并注册到 clients map */
 export function createSSEStream(sessionName: string, networkId?: string | null): Response {
+  return createStreamForKey(
+    clientKey(sessionName, networkId),
+    { type: "connected", session: sessionName, network_id: networkId ?? null },
+  );
+}
+
+/** #461 — 创建网络级观察者 SSE Response（dashboard 观察第三方流量）。
+ *  Shares the exact same registration / backpressure / liveness
+ *  machinery as session streams; only the key scheme differs. */
+export function createNetworkObserverStream(networkId: string): Response {
+  return createStreamForKey(
+    observerKey(networkId),
+    { type: "connected", observer: true, network_id: networkId },
+  );
+}
+
+function createStreamForKey(key: string, initialEvent: Record<string, unknown>): Response {
   const encoder = new TextEncoder();
-  const key = clientKey(sessionName, networkId);
   let client: SSEClient;
 
   const stream = new ReadableStream<Uint8Array>({
@@ -237,7 +270,7 @@ export function createSSEStream(sessionName: string, networkId?: string | null):
       // even the first byte respects the contract.
       tryEnqueueBytes(
         client,
-        encoder.encode(`data: ${JSON.stringify({ type: "connected", session: sessionName, network_id: networkId ?? null })}\n\n`),
+        encoder.encode(`data: ${JSON.stringify(initialEvent)}\n\n`),
       );
 
       // Periodic keepalive doubles as a half-open probe — if the
@@ -338,6 +371,40 @@ export function pushEvent(sessionName: string, event: Record<string, unknown>, n
   if (!arr || arr.length === 0) return;
 
   const data = `data: ${JSON.stringify(event)}\n\n`;
+  let needPrune = false;
+
+  for (const c of arr) {
+    if (c.closed) {
+      needPrune = true;
+      continue;
+    }
+    const result = tryEnqueueBytes(c, c.encoder.encode(data));
+    if (result === "dead") needPrune = true;
+  }
+
+  if (needPrune) pruneClosed(key);
+}
+
+/** #461 — 推送网络级摘要事件给该网络的所有观察者连接。
+ *
+ *  Callers pass ROUTING METADATA ONLY (task_id / from / to / status /
+ *  priority / message_id) — never task or reply content. The event is
+ *  stamped with `network_id` + `scope: "network"` here so observers can
+ *  always tell which network the event belongs to and that it came from
+ *  the observer stream rather than their personal channel.
+ *
+ *  No-op when networkId is falsy: legacy null-network traffic has no
+ *  observer stream (the route requires an explicit network id). */
+export function pushNetworkObserverEvent(
+  networkId: string | null | undefined,
+  event: Record<string, unknown>,
+): void {
+  if (!networkId) return;
+  const key = observerKey(networkId);
+  const arr = clients.get(key);
+  if (!arr || arr.length === 0) return;
+
+  const data = `data: ${JSON.stringify({ ...event, network_id: networkId, scope: "network" })}\n\n`;
   let needPrune = false;
 
   for (const c of arr) {

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -114,6 +114,14 @@ function observerKey(networkId: string): string {
   return `${OBSERVER_KEY_PREFIX}${networkId}`;
 }
 
+/** Render a client key for logs / stats. Observer keys embed a raw NUL
+ *  byte (collision guard above); printing that verbatim makes grep treat
+ *  hub logs as binary and breaks log shippers, and getSSEStats feeds
+ *  /health. Display as a visible "\\0" escape instead. */
+function printableKey(key: string): string {
+  return key.split("\u0000").join("\\0");
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Close + dispatch helpers
 // ─────────────────────────────────────────────────────────────────────
@@ -131,7 +139,7 @@ function closeClient(client: SSEClient, reason: string): void {
     // Already closed by the runtime, or controller errored. Either way
     // we're done with it.
   }
-  console.log(`[${ts()}] SSE ✕ ${client.key} closed (reason=${reason})`);
+  console.log(`[${ts()}] SSE ✕ ${printableKey(client.key)} closed (reason=${reason})`);
 }
 
 /** Best-effort enqueue with backpressure guard. Returns:
@@ -264,7 +272,7 @@ function createStreamForKey(key: string, initialEvent: Record<string, unknown>):
 
       if (!clients.has(key)) clients.set(key, []);
       clients.get(key)!.push(client);
-      console.log(`[${ts()}] SSE ← ${key} connected (${clients.get(key)!.length} clients)`);
+      console.log(`[${ts()}] SSE ← ${printableKey(key)} connected (${clients.get(key)!.length} clients)`);
 
       // Send initial connected frame through the backpressure guard so
       // even the first byte respects the contract.
@@ -332,7 +340,7 @@ function pruneClosed(key: string): void {
   const alive = arr.filter((c) => !c.closed);
   if (alive.length === 0) {
     clients.delete(key);
-    console.log(`[${ts()}] SSE ✕ ${key} disconnected (0 remaining)`);
+    console.log(`[${ts()}] SSE ✕ ${printableKey(key)} disconnected (0 remaining)`);
   } else if (alive.length !== arr.length) {
     clients.set(key, alive);
   }
@@ -437,7 +445,7 @@ export function getSSEStats(): { total: number; sessions: Record<string, number>
   for (const [name, arr] of clients) {
     const alive = arr.filter((c) => !c.closed);
     if (alive.length === 0) continue;
-    sessions[name] = alive.length;
+    sessions[printableKey(name)] = alive.length;
     total += alive.length;
   }
   return { total, sessions };

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
 import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken } from "./db.js";
-import { pushEvent } from "./push.js";
+import { pushEvent, pushNetworkObserverEvent } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { getUserNetworkRole, createNetworkTokenForNode } from "./auth.js";
 import {
@@ -958,6 +958,9 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       if (target.state === "online") {
         pushEvent(targetAlias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority, from: from_session, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
       }
+      // #461 network observer summary — unconditional (task row exists
+      // even when the target is offline/queued), metadata only.
+      pushNetworkObserverEvent(effectiveNetId, { type: "new_task", task_id: id, from: from_session, to: targetAlias, status: "delivered", priority });
 
       if (target.state === "offline") {
         return {
@@ -1185,6 +1188,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
       const session = scopedSessionStatus(alias, effectiveNetId);
       pushEvent(alias, { type: "new_reply", from: from_session, message_id: id, in_reply_to, status: replyStatus }, effectiveNetId);
+      // #461 network observer summary — ids + routing only, no reply text.
+      pushNetworkObserverEvent(effectiveNetId, { type: "new_reply", task_id: in_reply_to ?? null, message_id: id, from: from_session, to: alias, status: replyStatus });
 
       return {
         content: [{
@@ -1267,6 +1272,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       logTaskEvent(task_id, task.status, "delivered", from_session, "retry");
       // SSE push (unconditional — channel is keyed by alias, not network)
       pushEvent(task.to_name, { type: "new_task", inbox_count: 1, priority: task.priority, from: from_session }, effectiveNetId ?? task.network_id ?? null);
+      pushNetworkObserverEvent(effectiveNetId ?? task.network_id ?? null, { type: "new_task", task_id, from: from_session, to: task.to_name, status: "delivered", priority: task.priority });
       return {
         content: [{ type: "text" as const, text: JSON.stringify({ ok: true, task_id, retried_to: task.to_name }) }],
       };
@@ -1419,6 +1425,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       });
       logTaskEvent(task_id, task.status, "delivered", from_session, `reassign: ${oldAlias} → ${reassignedAlias}`);
       pushEvent(reassignedAlias, { type: "new_task", inbox_count: 1, priority: task.priority, from: from_session, ...(canonical.renamed ? { renamed_from: new_alias } : {}) }, effectiveNetId ?? task.network_id ?? null);
+      pushNetworkObserverEvent(effectiveNetId ?? task.network_id ?? null, { type: "new_task", task_id, from: from_session, to: reassignedAlias, status: "delivered", priority: task.priority });
       return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, task_id, reassigned_from: oldAlias, reassigned_to: reassignedAlias, ...(canonical.renamed ? { renamed_from: new_alias, renamed_to: reassignedAlias } : {}) }) }] };
     }
   );

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -960,7 +960,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }
       // #461 network observer summary — unconditional (task row exists
       // even when the target is offline/queued), metadata only.
-      pushNetworkObserverEvent(effectiveNetId, { type: "new_task", task_id: id, from: from_session, to: targetAlias, status: "delivered", priority });
+      pushNetworkObserverEvent(effectiveNetId, { type: "new_task", task_id: id, from: from_session, to: targetAlias, status: target.state === "online" ? "delivered" : "queued", priority });
 
       if (target.state === "offline") {
         return {


### PR DESCRIPTION
Closes #461, closes #462.

Hub 观察者事件流（#461）+ 节点头像（#462）。**已通过通信龙独立复审（第二轮）。**

## 复审结论：PASS

复审方式：detached worktree，`COMMHUB_DB` 全程指向 scratch 路径（未触碰生产库），主工作树未改动，测试端口跑完全部释放（按精确 PID 清理）。**复审者亲自重跑，非采信作者自述。**

### 硬门 1 — observer 授权（第一轮 blocker）

第一轮的守卫是「或」：`if (!observerRole && authCtx.networkId !== observedNetId)`，而既有 `/events/:session` 的 ntok 路径是「与」。成员关系正是吊销机制——`removeNetworkMember` 删成员行但**不吊销该用户的 ntok**。实测证伪：用户加入网络 A → 发 ntok → 移出网络 A → 同一活 token 打两个端点，旧端点 403、**新端点仍 200**，被移出者保住整网实时流。

现已改为无条件成员校验，networkId 逃生通道删除。

**witnessed-red**：把守卫改回旧「或」写法，精确命中一条红——
`(fail) #461 GET /events/network/:id — auth > membership removal revokes observer access — ntok exploit repro` → 11 pass / 1 fail；还原后 12 pass / 0 fail。**该用例能红且红在正确位置，不是假门。**

### 硬门 2 — aggregate 隔离（第一轮 blocker）

第一轮 9 个 HTTP 安全测试在 aggregate 跑法下**完全不执行**（`await import("./index.js")` 在别的文件先启过 server 时是模块缓存 no-op，所有 fetch ConnectionRefused），死掉的正是本 PR 的整个 HTTP 层安全面。

现引入 `bootServer({port:0})` seam，测试用私有实例并读回实际端口。双向验证：

```
正序 bun test src/uploads-http.test.ts src/observer-avatar-http.test.ts → 22 pass / 0 fail
反序 bun test src/observer-avatar-http.test.ts src/uploads-http.test.ts → 22 pass / 0 fail
```
（第一轮为 10 pass / 9 fail。）

**关键：本 PR 刻意不使用 `import.meta.main` 守卫。** 该守卫会让已发布包完全不监听端口——`package.json` 的 `bin` 指向 `bin/commhub.ts`，它通过 `import("../src/index.js")` **动态加载** `src/index.ts`，因此那里的 `import.meta.main` 恒为 false。复审独立重做打包验收：

```
npm pack → 干净目录安装 → 真跑 node_modules/.bin/commhub-server → curl /health = 200
```

### 硬门 3 — avatar 规范化存储

第一轮校验通过后存的是原始串而非 `parsed.href`，`https://e.com/a".png` 原样落库。现返回规范化值并拒绝残留危险字符。复审独立喂 12 个恶意 URL：

| 输入 | 结果 |
|---|---|
| `a".png` | 落库 `a%22.png` |
| `<img>` | 落库 `%3Cimg%3E` |
| `</script><script>…` | 全部百分号编码 |
| 反引号 | 落库 `%60…%60` |
| `javascript:` / `java\tscript:` / `java\nscript:` | 拒绝 |
| `data:` / `vbscript:` / `file:` | 拒绝 |
| `user:pass@` / `user@` | 拒绝（本 PR 追加） |

落库值中 `" ' < > 反引号` 零残留。

### 回归：零新增失败

两棵树以完全相同方式跑 aggregate：

```
基线 origin/main : 515 pass / 8 fail
本 PR            : 546 pass / 8 fail
本 PR 独有的失败  : 0 条
```

两边 8 条同名，均为既有的 `#380 /api/host-supervisors`（属 #434 范围，不在本 PR）。净增 31 个通过用例，**无任何既有测试因本 PR 改变状态**。

### 其他

- observer 事件仅含路由元数据，零内容字段；e2e 断言任务正文与回复正文均不出现在观察帧中。
- observer key 中的裸 NUL 已净化：日志裸 NUL 字节数 **0**（第一轮为 17），`file` 判定 UTF-8 text 而非二进制。
- `send_task` 按目标在线与否给 `delivered`/`queued`，不再无条件 `delivered`。
- `/health` 未鉴权暴露 observer key 的既有问题另开 #473 跟踪。

## 后续（不阻塞本 PR）

`export const server = bootServer()` 为模块级副作用——import 即绑端口。它正确避开了 `import.meta.main` 的坑，但更干净的终态是**导出显式启动函数、由 bin 入口显式调用**，两个坑都不踩。已与 #438 corrective 约定一起收敛，避免测试基础设施分叉。
