### PR TITLE
fix(RFC-030 P3-A): 把 teardown 的 fail-closed 范围收窄到自身进程树，并让真实代码真正被测到

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -24,8 +24,11 @@ import {
   realKiller,
   callerCarriesMarker,
   reapMarkerGroups,
+  prepareIdentityForStart,
+  anchorsFromMarker,
   type SessionInfo,
 } from "../src/copresence-identity";
+import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
 import { createServer as netCreateServer } from "net";
 import { checkbox, confirm, select } from "@inquirer/prompts";
 import { ensureGitignoreRule, ensureGitignoreRules } from "../src/gitignore-writeback";
@@ -420,6 +423,46 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   // code reported success). See docs of writeMarker() in copresence-identity.ts.
   const identityMarker = randomUUID();
 
+  // #P3fix必修12 — tmux capability preflight. `new-session -e KEY=VALUE`
+  // (how the marker gets injected) needs tmux 3.2+; Ubuntu 20.04 ships
+  // 3.0a. Without this check the very first new-session below dies with
+  // tmux's raw usage dump and the operator has nothing to act on.
+  assertTmuxSupportsSessionEnv(
+    () => execFileSync("tmux", ["-V"], { stdio: ["ignore", "pipe", "pipe"] }).toString(),
+    (m) => console.error(m),
+    (m) => { console.error(m); process.exit(1); },
+  );
+
+  // #P3fix必修5+6 — everything identity-related happens BEFORE the first
+  // marker-carrying tmux session exists.
+  //   5: the marker file is written now, not after the app-server binds.
+  //      v2 wrote it after a 25s wait and after several exit(1) paths, so a
+  //      start that died in that window left a live marker-carrying session
+  //      with no marker file on disk — an unreclaimable ghost, the exact
+  //      failure this feature exists to prevent.
+  //   6: if a marker from a previous generation is still on disk (a stop
+  //      that failed deliberately preserves it), its processes are reaped
+  //      by identity FIRST. v2 overwrote the file with a fresh uuid while
+  //      only killing tmux sessions by NAME, permanently losing the handle
+  //      on any surviving subprocess of the old generation.
+  const identityPrep = await prepareIdentityForStart(identityMarker, {
+    readMarker: () => readCopresenceMarker(nodesDir(), resolved.id),
+    reap: (uuid, anchors) => reapMarkerGroups(realEnumerator(), realKiller(), uuid, {
+      graceMs: 3000,
+      logger: (m) => console.log(`[anet] ${m}`),
+      anchors,
+    }),
+    removeMarker: () => removeCopresenceMarker(nodesDir(), resolved.id),
+    writeMarker: (uuid, sessions) => { writeCopresenceMarker(nodesDir(), resolved.id, uuid, sessions); },
+    logger: (m) => console.log(`[anet] ${m}`),
+  });
+  if (identityPrep.kind === "blocked") {
+    console.error(`[anet] ❌ refusing to start ${displayName}: ${identityPrep.detail}`);
+    console.error(`[anet]    ${identityPrep.remedy}`);
+    process.exit(1);
+  }
+  console.log(`[anet] identity marker written (uuid=${identityMarker.slice(0, 8)}… — on disk before any session starts)`);
+
   // Kill any prior instances so this is idempotent.
   for (const s of [appsrvSession, bridgeSession, tuiSession]) {
     if (tmuxSessionRunning(s)) {
@@ -482,15 +525,12 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   }
   console.log(`[anet] ① app-server READY on ${wsUrl}`);
 
-  // #P3fix复审 finding #5 — write the identity marker file NOW, as soon as
-  // the FIRST session with ANET_NODE_MARKER injected is running. If any of
-  // the 6 downstream early-exit paths (thread/start, SAFE_THREAD_ID reject,
-  // bridge/tui tmux new-session, etc.) fires, the identity flow can still
-  // reap appsrv on the next `anet node stop`. Prior placement (after all 3
-  // sessions up) left orphans-with-no-marker-file for partial failures.
-  //
-  // Sessions object is best-effort observability only (all fields optional
-  // per finding #4) — reap identity is /proc/*/environ scan for the uuid.
+  // #P3fix必修5 — the marker file itself was already written before the
+  // first tmux session (see prepareIdentityForStart above); everything from
+  // here on is a best-effort refresh that adds pane-pid hints. Those hints
+  // are observability plus invariant-11 scope anchors — they are NOT the
+  // reap identity (that is always the environ uuid), so a failed refresh
+  // degrades post-mortem detail, never reclaimability.
   const harvestSession = (session: string): SessionInfo | undefined => {
     try {
       const panePid = Number(execFileSync("tmux", ["display-message", "-p", "-t", session, "#{pane_pid}"], { stdio: ["ignore", "pipe", "ignore"] }).toString().trim());
@@ -505,10 +545,10 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     writeCopresenceMarker(nodesDir(), resolved.id, identityMarker, {
       appsrv: harvestSession(appsrvSession),
     });
-    console.log(`[anet] identity marker written (uuid=${identityMarker.slice(0, 8)}… — appsrv up, bridge/tui pending)`);
+    console.log(`[anet] identity marker refreshed with appsrv pane hint (bridge/tui pending)`);
   } catch (e: any) {
-    console.error(`[anet] ⚠ could not persist identity marker: ${e?.message || e}`);
-    console.error(`[anet]    Stop will fall back to legacy tmux-name teardown (subprocess-orphan risk).`);
+    console.error(`[anet] ⚠ could not refresh identity marker hints: ${e?.message || e}`);
+    console.error(`[anet]    Teardown still works — the marker uuid written before startup governs reap.`);
   }
 
   // ── create fresh thread + persist config ──────────────────────────────
@@ -6275,6 +6315,12 @@ Stop a running agent node.
       const reapResult = await reapMarkerGroups(enumer, killer, uuid, {
         graceMs: 3000,
         logger: (m) => console.log(`[anet] ${m}`),
+        // #P3fix必修1+2 — the recorded pane pids anchor the invariant-11
+        // scope test, so a marker-carrying descendant whose environ we
+        // cannot read (non-dumpable) is still accounted for instead of
+        // being dropped. Each anchor is re-validated (alive + matching
+        // starttime) inside the scan before it may widen scope.
+        anchors: anchorsFromMarker(markerResult.marker),
       });
       if (reapResult.kind === "success") {
         removeCopresenceMarker(nodesDir(), resolved.id);

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -16,6 +16,15 @@ import { fileURLToPath } from "url";
 import { homedir } from "os";
 import { spawn, execSync, execFileSync } from "child_process";
 import { createHash, randomBytes, randomUUID } from "crypto";
+import {
+  writeMarker as writeCopresenceMarker,
+  readMarker as readCopresenceMarker,
+  removeMarker as removeCopresenceMarker,
+  realEnumerator,
+  realKiller,
+  callerCarriesMarker,
+  reapMarkerGroups,
+} from "../src/copresence-identity";
 import { createServer as netCreateServer } from "net";
 import { checkbox, confirm, select } from "@inquirer/prompts";
 import { ensureGitignoreRule, ensureGitignoreRules } from "../src/gitignore-writeback";
@@ -402,6 +411,14 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   const { appsrv: appsrvSession, bridge: bridgeSession, tui: tuiSession } =
     copresenceTmuxSessions(displayName);
 
+  // #P3fix必修1 — generate the identity marker uuid ONCE. Same uuid is
+  // injected into every tmux session's ANET_NODE_MARKER env AND persisted
+  // to the marker file. Single source of truth defeats Blocker 1 (9f2ec282
+  // generated it twice — cli-side vs helper-side — so environ scan at stop
+  // never matched what was on disk, and nothing was ever killed while the
+  // code reported success). See docs of writeMarker() in copresence-identity.ts.
+  const identityMarker = randomUUID();
+
   // Kill any prior instances so this is idempotent.
   for (const s of [appsrvSession, bridgeSession, tuiSession]) {
     if (tmuxSessionRunning(s)) {
@@ -442,6 +459,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   try {
     execFileSync("tmux", [
       "new-session", "-d", "-s", appsrvSession, "-c", process.cwd(),
+      "-e", `ANET_NODE_MARKER=${identityMarker}`,
       "bash", "-lc", appsrvCmd,
     ], { stdio: "pipe" });
   } catch (e: any) {
@@ -504,6 +522,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   try {
     execFileSync("tmux", [
       "new-session", "-d", "-s", bridgeSession, "-c", process.cwd(),
+      "-e", `ANET_NODE_MARKER=${identityMarker}`,
       "bash", "-lc", bridgeCmd,
     ], { stdio: "pipe" });
   } catch (e: any) {
@@ -524,6 +543,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   try {
     execFileSync("tmux", [
       "new-session", "-d", "-s", tuiSession, "-c", process.cwd(),
+      "-e", `ANET_NODE_MARKER=${identityMarker}`,
       "bash", "-lc", tuiCmd,
     ], { stdio: "pipe" });
   } catch (e: any) {
@@ -532,6 +552,47 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     process.exit(1);
   }
   console.log(`[anet] ③ TUI tmux=${tuiSession} ready to attach`);
+
+  // #P3fix必修1 — persist identity marker AFTER all 3 tmux sessions are up.
+  // The `identityMarker` uuid was already injected via -e into every session
+  // (single source of truth). We record the tmux pane bash pid + its pgid +
+  // starttime as best-effort observability hints; the stop-time reap uses
+  // /proc/*/environ scan as the authoritative identity source, NOT these hints.
+  //
+  // Marker write follows the fix-fork architecture: fail-closed 0600 atomic
+  // write with pre-unlink + wx flag (see copresence-identity.ts writeMarker).
+  //
+  // If marker write fails, we log-only and continue — the node is running,
+  // stop will fall through to the legacy tmux-name teardown path (imperfect
+  // but non-fatal). We do NOT tear down the 3-piece just because bookkeeping
+  // failed; that would penalize the user for a metadata glitch.
+  try {
+    const harvest = (session: string): { tmux: string; pid: number; pgid: number; starttime_jiffies: number } | null => {
+      try {
+        const panePid = Number(execFileSync("tmux", ["display-message", "-p", "-t", session, "#{pane_pid}"], { stdio: ["ignore", "pipe", "ignore"] }).toString().trim());
+        if (!Number.isInteger(panePid) || panePid <= 0) return null;
+        const enumer = realEnumerator();
+        const stat = enumer.readStat(panePid);
+        if (!stat) return null;
+        return { tmux: session, pid: panePid, pgid: stat.pgid, starttime_jiffies: stat.starttime_jiffies };
+      } catch { return null; }
+    };
+    const appsrvMk = harvest(appsrvSession);
+    const bridgeMk = harvest(bridgeSession);
+    const tuiMk    = harvest(tuiSession);
+    if (appsrvMk && bridgeMk && tuiMk) {
+      writeCopresenceMarker(nodesDir(), resolved.id, identityMarker, {
+        appsrv: appsrvMk, bridge: bridgeMk, tui: tuiMk,
+      });
+      console.log(`[anet] identity marker written (uuid=${identityMarker.slice(0, 8)}…)`);
+    } else {
+      console.error(`[anet] ⚠ pane pid harvest incomplete; skipping identity marker write.`);
+      console.error(`[anet]    Stop will fall back to legacy tmux-name teardown (subprocess-orphan risk).`);
+    }
+  } catch (e: any) {
+    console.error(`[anet] ⚠ could not persist identity marker: ${e?.message || e}`);
+    console.error(`[anet]    Stop will fall back to legacy tmux-name teardown (subprocess-orphan risk).`);
+  }
 
   const hubBase = opts.hub.replace(/\/+$/, "");
   console.log("");
@@ -6179,6 +6240,62 @@ Stop a running agent node.
   // any child processes too, which makes `stopNode` mostly a defensive op
   // when the PID file is stale.
   //
+  // RFC-030 P3 — identity-gated teardown, BEFORE the legacy tmux-name sweep.
+  //
+  // For copresence nodes (marker file present), run the identity flow:
+  // scan /proc/*/environ for ANET_NODE_MARKER=<uuid>, group by current PGID,
+  // fail-closed homogeneity per group, TERM→grace→KILL. This reaps codex
+  // subprocesses that survived tmux kill-session in P2 (see #466 blockers).
+  //
+  // For non-copresence nodes (marker file MISSING — the case for every
+  // ordinary node including runtime=codex-app-server started WITHOUT
+  // --copresence), this block is a silent no-op and the legacy sweep runs
+  // unchanged. Gate keys on marker EXISTENCE, not on runtime string, so
+  // ordinary codex-app-server nodes take the legacy path (zero-diff).
+  try {
+    const markerResult = readCopresenceMarker(nodesDir(), resolved.id);
+    if (markerResult.kind === "ok") {
+      const uuid = markerResult.marker.marker;
+      console.log(`[anet] copresence node — identity-gated teardown (uuid=${uuid.slice(0, 8)}…)`);
+      const enumer = realEnumerator();
+      const killer = realKiller();
+      // Self-context check: refuse if caller ancestry carries the marker
+      // (else stop would kill the shell we're running in).
+      const selfCheck = callerCarriesMarker(enumer, uuid);
+      if (selfCheck.self || selfCheck.ancestorPid) {
+        console.error(`[anet] ❌ this stop command's ancestry includes a marker-carrying pid (${selfCheck.ancestorPid}).`);
+        console.error(`[anet]    Running stop from inside the copresence tree would kill your own shell.`);
+        console.error(`[anet]    Detach from the tmux session (Ctrl-b d) and run stop from an outside shell.`);
+        process.exit(2);
+      }
+      const reapResult = reapMarkerGroups(enumer, killer, uuid, {
+        graceMs: 3000,
+        logger: (m) => console.log(`[anet] ${m}`),
+      });
+      if (reapResult.kind === "success") {
+        removeCopresenceMarker(nodesDir(), resolved.id);
+        console.log(`[anet] identity teardown OK (killed ${reapResult.killedPgids.length} pgroup(s))`);
+      } else {
+        console.error(`[anet] ⚠ identity teardown incomplete: ${reapResult.detail}`);
+        console.error(`[anet]    marker preserved for idempotent retry; ${reapResult.residualPids.length} marker-bearing pid(s) may still be alive`);
+        if (reapResult.skippedGroups.length > 0) {
+          for (const s of reapResult.skippedGroups) {
+            console.error(`[anet]    SKIPPED pgid=${s.pgid} — ${s.reason}`);
+          }
+        }
+      }
+    } else if (markerResult.cause !== "MISSING") {
+      console.error(`[anet] ⚠ copresence marker present but refused (${markerResult.cause}): ${markerResult.detail}`);
+      console.error(`[anet]    Falling through to legacy tmux-name sweep. Investigate the marker file for corruption.`);
+    }
+    // markerResult.cause === "MISSING" is the ordinary-node path: silent
+    // fall-through to legacy sweep (zero-diff for every runtime that never
+    // ran --copresence).
+  } catch (e: any) {
+    console.error(`[anet] ⚠ identity gate check crashed: ${e?.message || e}`);
+    console.error(`[anet]    Falling through to legacy tmux-name sweep.`);
+  }
+
   // RFC-030 P2 — co-presence nodes own three tmux sessions
   // (`<alias>`, `<alias>-appsrv`, `<alias>-桥`). Sweep all three
   // unconditionally: has-session guards make the extra kills no-op for

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -24,6 +24,7 @@ import {
   realKiller,
   callerCarriesMarker,
   reapMarkerGroups,
+  type SessionInfo,
 } from "../src/copresence-identity";
 import { createServer as netCreateServer } from "net";
 import { checkbox, confirm, select } from "@inquirer/prompts";
@@ -481,6 +482,35 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   }
   console.log(`[anet] ① app-server READY on ${wsUrl}`);
 
+  // #P3fix复审 finding #5 — write the identity marker file NOW, as soon as
+  // the FIRST session with ANET_NODE_MARKER injected is running. If any of
+  // the 6 downstream early-exit paths (thread/start, SAFE_THREAD_ID reject,
+  // bridge/tui tmux new-session, etc.) fires, the identity flow can still
+  // reap appsrv on the next `anet node stop`. Prior placement (after all 3
+  // sessions up) left orphans-with-no-marker-file for partial failures.
+  //
+  // Sessions object is best-effort observability only (all fields optional
+  // per finding #4) — reap identity is /proc/*/environ scan for the uuid.
+  const harvestSession = (session: string): SessionInfo | undefined => {
+    try {
+      const panePid = Number(execFileSync("tmux", ["display-message", "-p", "-t", session, "#{pane_pid}"], { stdio: ["ignore", "pipe", "ignore"] }).toString().trim());
+      if (!Number.isInteger(panePid) || panePid <= 0) return undefined;
+      const enumer = realEnumerator();
+      const stat = enumer.readStat(panePid);
+      if (!stat) return undefined;
+      return { tmux: session, pid: panePid, pgid: stat.pgid, starttime_jiffies: stat.starttime_jiffies };
+    } catch { return undefined; }
+  };
+  try {
+    writeCopresenceMarker(nodesDir(), resolved.id, identityMarker, {
+      appsrv: harvestSession(appsrvSession),
+    });
+    console.log(`[anet] identity marker written (uuid=${identityMarker.slice(0, 8)}… — appsrv up, bridge/tui pending)`);
+  } catch (e: any) {
+    console.error(`[anet] ⚠ could not persist identity marker: ${e?.message || e}`);
+    console.error(`[anet]    Stop will fall back to legacy tmux-name teardown (subprocess-orphan risk).`);
+  }
+
   // ── create fresh thread + persist config ──────────────────────────────
   let threadId: string;
   try {
@@ -553,46 +583,20 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   }
   console.log(`[anet] ③ TUI tmux=${tuiSession} ready to attach`);
 
-  // #P3fix必修1 — persist identity marker AFTER all 3 tmux sessions are up.
-  // The `identityMarker` uuid was already injected via -e into every session
-  // (single source of truth). We record the tmux pane bash pid + its pgid +
-  // starttime as best-effort observability hints; the stop-time reap uses
-  // /proc/*/environ scan as the authoritative identity source, NOT these hints.
-  //
-  // Marker write follows the fix-fork architecture: fail-closed 0600 atomic
-  // write with pre-unlink + wx flag (see copresence-identity.ts writeMarker).
-  //
-  // If marker write fails, we log-only and continue — the node is running,
-  // stop will fall through to the legacy tmux-name teardown path (imperfect
-  // but non-fatal). We do NOT tear down the 3-piece just because bookkeeping
-  // failed; that would penalize the user for a metadata glitch.
+  // #P3fix复审 finding #5 — best-effort marker-file update with bridge/tui
+  // observability hints now that both sessions are up. Marker file was
+  // already written after appsrv (see above) with just appsrv's hint —
+  // reap identity is unchanged (still environ scan for uuid). This write
+  // is purely for post-mortem debugging so operators can `cat` the marker
+  // file and see all three pane pids. Best-effort: if the rewrite fails,
+  // the appsrv-only marker still works for reap.
   try {
-    const harvest = (session: string): { tmux: string; pid: number; pgid: number; starttime_jiffies: number } | null => {
-      try {
-        const panePid = Number(execFileSync("tmux", ["display-message", "-p", "-t", session, "#{pane_pid}"], { stdio: ["ignore", "pipe", "ignore"] }).toString().trim());
-        if (!Number.isInteger(panePid) || panePid <= 0) return null;
-        const enumer = realEnumerator();
-        const stat = enumer.readStat(panePid);
-        if (!stat) return null;
-        return { tmux: session, pid: panePid, pgid: stat.pgid, starttime_jiffies: stat.starttime_jiffies };
-      } catch { return null; }
-    };
-    const appsrvMk = harvest(appsrvSession);
-    const bridgeMk = harvest(bridgeSession);
-    const tuiMk    = harvest(tuiSession);
-    if (appsrvMk && bridgeMk && tuiMk) {
-      writeCopresenceMarker(nodesDir(), resolved.id, identityMarker, {
-        appsrv: appsrvMk, bridge: bridgeMk, tui: tuiMk,
-      });
-      console.log(`[anet] identity marker written (uuid=${identityMarker.slice(0, 8)}…)`);
-    } else {
-      console.error(`[anet] ⚠ pane pid harvest incomplete; skipping identity marker write.`);
-      console.error(`[anet]    Stop will fall back to legacy tmux-name teardown (subprocess-orphan risk).`);
-    }
-  } catch (e: any) {
-    console.error(`[anet] ⚠ could not persist identity marker: ${e?.message || e}`);
-    console.error(`[anet]    Stop will fall back to legacy tmux-name teardown (subprocess-orphan risk).`);
-  }
+    writeCopresenceMarker(nodesDir(), resolved.id, identityMarker, {
+      appsrv: harvestSession(appsrvSession),
+      bridge: harvestSession(bridgeSession),
+      tui:    harvestSession(tuiSession),
+    });
+  } catch { /* best-effort observability update; appsrv-only marker still governs reap */ }
 
   const hubBase = opts.hub.replace(/\/+$/, "");
   console.log("");
@@ -6268,7 +6272,7 @@ Stop a running agent node.
         console.error(`[anet]    Detach from the tmux session (Ctrl-b d) and run stop from an outside shell.`);
         process.exit(2);
       }
-      const reapResult = reapMarkerGroups(enumer, killer, uuid, {
+      const reapResult = await reapMarkerGroups(enumer, killer, uuid, {
         graceMs: 3000,
         logger: (m) => console.log(`[anet] ${m}`),
       });

--- a/agent-network/src/copresence-cli-wiring.test.ts
+++ b/agent-network/src/copresence-cli-wiring.test.ts
@@ -1,0 +1,101 @@
+// RFC-030 P3-A — structural gates on the cli.ts copresence seam.
+//
+// HONEST SCOPE NOTE: these are SOURCE-ORDER assertions, not behavioural
+// tests. bin/cli.ts is a 12k-line entrypoint that calls process.exit() and
+// spawns tmux; it cannot be imported into a unit test. The decision logic
+// that CAN be tested behaviourally was extracted out of it —
+// prepareIdentityForStart (blockers 5+6) and checkTmuxCapability (blocker
+// 12) both have real unit tests in their own modules. What remains
+// untestable-by-import is whether cli.ts CALLS them, and in the right
+// ORDER — and order is precisely what both blockers are about:
+//
+//   Blocker 5: the marker must reach disk BEFORE the first marker-carrying
+//              tmux session exists. A call in the right place but after the
+//              first `new-session` re-opens the ghost window exactly as v2
+//              had it (marker was written after a 25s bind wait and after
+//              several process.exit(1) paths).
+//   Blocker 12: the tmux version preflight must run before the first
+//              `new-session`, or the operator gets tmux's raw usage dump.
+//
+// So these tests exist to make a REGRESSION IN CALL ORDER turn red. They
+// cannot prove the calls behave correctly at runtime — the real-/proc suite
+// and the module unit tests do that.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+
+/** Body of `startCopresenceOrchestration`, up to the next top-level function. */
+function copresenceStartBody(): string {
+  const start = CLI.indexOf("async function startCopresenceOrchestration(");
+  expect(start).toBeGreaterThan(-1);
+  const rest = CLI.slice(start + 1);
+  const end = rest.search(/\n(?:export )?(?:async )?function /);
+  return end < 0 ? rest : rest.slice(0, end);
+}
+
+describe("cli.ts copresence start ordering (structural gate)", () => {
+  const body = copresenceStartBody();
+  const firstNewSession = body.indexOf('"new-session"');
+
+  test("the copresence start path really does create tmux sessions with -e (anchor for the tests below)", () => {
+    expect(firstNewSession).toBeGreaterThan(-1);
+    expect(body).toContain('"-e", `ANET_NODE_MARKER=${identityMarker}`');
+  });
+
+  test("Blocker 5: prepareIdentityForStart runs BEFORE the first tmux new-session", () => {
+    const prep = body.indexOf("prepareIdentityForStart(");
+    expect(prep).toBeGreaterThan(-1);
+    expect(prep).toBeLessThan(firstNewSession);
+  });
+
+  test("Blocker 5: no marker write happens before the identity preparation call", () => {
+    // Any earlier writeCopresenceMarker would mean a second source of truth
+    // for the marker file, which is how blocker 1 of the previous round
+    // (two uuids) happened in the first place.
+    const prep = body.indexOf("prepareIdentityForStart(");
+    const firstWrite = body.indexOf("writeCopresenceMarker(");
+    expect(firstWrite).toBeGreaterThan(prep);
+  });
+
+  test("Blocker 6: a blocked preparation aborts the start (never falls through to session creation)", () => {
+    const prep = body.indexOf("prepareIdentityForStart(");
+    const guard = body.indexOf('identityPrep.kind === "blocked"', prep);
+    expect(guard).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(firstNewSession);
+    // and the guard actually exits rather than logging and continuing
+    const exitAfterGuard = body.indexOf("process.exit(1)", guard);
+    expect(exitAfterGuard).toBeGreaterThan(-1);
+    expect(exitAfterGuard).toBeLessThan(firstNewSession);
+  });
+
+  test("Blocker 12: the tmux capability preflight runs BEFORE the first tmux new-session", () => {
+    const check = body.indexOf("assertTmuxSupportsSessionEnv(");
+    expect(check).toBeGreaterThan(-1);
+    expect(check).toBeLessThan(firstNewSession);
+  });
+});
+
+describe("cli.ts copresence stop wiring (structural gate)", () => {
+  test("Blockers 1+2: the stop-time reap is given the marker's recorded pids as scope anchors", () => {
+    // Without anchors, a marker-carrying process we cannot READ (non-dumpable)
+    // has nothing to be in scope of once its readable siblings are gone, and
+    // is dropped instead of preserving the marker.
+    const reapCall = CLI.indexOf("reapMarkerGroups(enumer, killer, uuid, {");
+    expect(reapCall).toBeGreaterThan(-1);
+    const optsBlock = CLI.slice(reapCall, CLI.indexOf("});", reapCall));
+    expect(optsBlock).toContain("anchors: anchorsFromMarker(markerResult.marker)");
+  });
+
+  test("marker removal happens only on a successful reap", () => {
+    const successBranch = CLI.indexOf('reapResult.kind === "success"');
+    expect(successBranch).toBeGreaterThan(-1);
+    const removal = CLI.indexOf("removeCopresenceMarker(nodesDir(), resolved.id)", successBranch);
+    expect(removal).toBeGreaterThan(successBranch);
+    // ...and it is inside the success branch, i.e. before the else.
+    const elseBranch = CLI.indexOf("} else {", successBranch);
+    expect(removal).toBeLessThan(elseBranch);
+  });
+});

--- a/agent-network/src/copresence-identity.real.test.ts
+++ b/agent-network/src/copresence-identity.real.test.ts
@@ -1,0 +1,226 @@
+// RFC-030 P3-A v2 — REAL /proc integration tests.
+//
+// These tests are the answer to independent-audit finding 92d53c8f: the
+// pure-mock unit test suite proved "mock and implementation self-consistent"
+// but did not prove "real code works on real Linux". The audit reproduced
+// scanEnvironForMarker throwing EACCES on /proc/1/environ in ~150ms, and
+// verified verifyGroupHomogeneity would permanently skip a group with a
+// same-uid zombie member. Neither behavior was covered by any mock test
+// because MockEnumer's readEnviron only throws when the test asks it to.
+//
+// The rule this file enforces (meta-lesson added 2026-07-29 after
+// independent audit found the mock-only invariant break):
+//   "Every module that touches OS/filesystem/process/network state must have
+//    AT LEAST ONE test that calls the real implementation, not the mock,
+//    even if only to assert 'does not throw'."
+//
+// Test coverage here:
+//   test A  — scanEnvironForMarker on real /proc (no target uuid) does NOT
+//             throw and returns length === 0. This is the EACCES-on-pid-1
+//             regression check for Blocker 1.
+//   test B  — real zombie fixture: spawn short-lived child, poll until
+//             State: Z, verifyGroupHomogeneity does NOT return ENUM_ERROR
+//             for the zombie's pgid. Regression check for Blocker 2.
+//   test C  — realEnumerator().readEnviron(1) on real /proc (pid 1 = root)
+//             actually throws EACCES — verifies the discriminator is what
+//             wraps that throw for us at the higher level.
+//   test D  — POSITIVE: spawn child with marker uuid, scan finds it. Answers
+//             "扫描器真能找到目标" (通信龙 33dfeea0 补充). Without this,
+//             tests A/B/C together only prove the scanner doesn't crash;
+//             they don't prove it actually finds anything.
+//   test E  — END-TO-END: spawn child with marker → readStat for its pgid →
+//             verifyGroupHomogeneity(that pgid, uuid) returns ok:true with
+//             child pid in members. Proves the full identity chain (scan
+//             → group → homogeneity) works on real /proc.
+//
+// Tests skip cleanly on non-Linux — the whole feature is Linux-only.
+
+import { describe, test, expect } from "bun:test";
+import { spawn, execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import {
+  realEnumerator,
+  scanEnvironForMarker,
+  verifyGroupHomogeneity,
+} from "./copresence-identity";
+
+const IS_LINUX = process.platform === "linux";
+
+function waitFor(predicate: () => boolean, timeoutMs = 500, intervalMs = 10): boolean {
+  const end = Date.now() + timeoutMs;
+  while (Date.now() < end) {
+    if (predicate()) return true;
+    // Busy-wait only for fixture setup (tiny window, ~500ms max).
+    const wait = Date.now() + intervalMs;
+    while (Date.now() < wait) { /* short spin */ }
+  }
+  return predicate();
+}
+
+function readState(pid: number): string | null {
+  try {
+    const raw = readFileSync(`/proc/${pid}/status`, "utf8");
+    const m = raw.match(/^State:\s*(\S)/m);
+    return m ? m[1] : null;
+  } catch { return null; }
+}
+
+function pgidOf(pid: number): number | null {
+  try {
+    const raw = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const lastParen = raw.lastIndexOf(")");
+    if (lastParen < 0) return null;
+    const rest = raw.slice(lastParen + 1).trim().split(/\s+/);
+    const pgrp = Number(rest[2]);
+    return Number.isFinite(pgrp) ? pgrp : null;
+  } catch { return null; }
+}
+
+describe("REAL /proc integration (Linux only)", () => {
+  test("A: realEnumerator.scanEnvironForMarker on nonexistent uuid does NOT throw on real /proc (Blocker 1 regression)", () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    const enumer = realEnumerator();
+    // If Blocker 1 is un-fixed, this throws EACCES on /proc/1/environ (systemd).
+    // We look for a uuid that certainly doesn't exist anywhere.
+    const nonce = `no-such-uuid-${randomUUID()}`;
+    let result: number[] = [];
+    let threw: unknown = null;
+    try { result = scanEnvironForMarker(enumer, nonce); } catch (e) { threw = e; }
+    expect(threw).toBeNull();
+    expect(result.length).toBe(0);
+  });
+
+  test("B: real zombie fixture — verifyGroupHomogeneity does NOT ENUM_ERROR on a zombie in the group (Blocker 2 regression)", () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    // Spawn a child that will exit immediately; without parent wait, it becomes a zombie.
+    const uuid = `zombie-fixture-uuid-${randomUUID()}`;
+    // detached + no waitpid → zombie once child exits.
+    const child = spawn("bash", ["-c", "true"], {
+      detached: true,
+      env: { ...process.env, ANET_NODE_MARKER: uuid },
+      stdio: "ignore",
+    });
+    child.unref();
+    if (!child.pid) { console.log("[skip] spawn failed to yield pid"); return; }
+    const childPid = child.pid;
+    // Wait until child hits State=Z (zombie).
+    const becameZombie = waitFor(() => readState(childPid) === "Z", 500);
+    if (!becameZombie) {
+      // Sometimes bun reaps children we spawned; in that case /proc/PID vanishes
+      // and this test can't run. Not a fix defect, just fixture unavailable.
+      console.log(`[skip] child pid ${childPid} did not reach zombie state (state=${readState(childPid)})`);
+      return;
+    }
+    const pgid = pgidOf(childPid);
+    if (pgid == null) {
+      console.log(`[skip] could not read pgid of zombie ${childPid}`);
+      return;
+    }
+    const enumer = realEnumerator();
+    // The zombie is in `pgid`; verifyGroupHomogeneity should NOT crash / ENUM_ERROR
+    // because of the zombie's unreadable environ.
+    const result = verifyGroupHomogeneity(enumer, pgid, `unrelated-${randomUUID()}`);
+    // The important thing: result.cause !== "ENUM_ERROR" (zombie shouldn't trigger it).
+    // With no marker-carrying members in this pgid, expect EMPTY_GROUP or FOREIGN_MEMBER.
+    if (!result.ok) {
+      expect(result.cause).not.toBe("ENUM_ERROR");
+    }
+    // Cleanup: allow child to be reaped.
+    try { execSync(`wait ${childPid} 2>/dev/null || true`); } catch {}
+  });
+
+  test("C: realEnumerator.readEnviron(1) throws EACCES (systemd is root-owned, discriminator handles it)", () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    const enumer = realEnumerator();
+    let threw: any = null;
+    try { enumer.readEnviron(1); } catch (e) { threw = e; }
+    // pid 1 is systemd owned by root → we don't own it → EACCES is expected.
+    // scanEnvironForMarker's owner-uid discriminator turns this into a skip
+    // (see test A which does NOT throw despite this being what would throw).
+    expect(threw).not.toBeNull();
+    expect(threw?.code).toBe("EACCES");
+    // Discriminator sanity: verify readOwnerUid(1) returns 0 (root).
+    const uid = enumer.readOwnerUid(1);
+    expect(uid).toBe(0);
+    expect(uid).not.toBe(process.getuid?.() ?? -1);
+  });
+
+  test("D: POSITIVE — spawn child carrying our marker, scan finds it (通信龙 33dfeea0 补充)", () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    // The critical positive test: prove the scanner actually finds a marker-
+    // carrying process. Tests A/B/C together only prove "doesn't crash";
+    // this proves "does find". Without this, a broken impl that returned []
+    // would still pass A/B/C.
+    const uuid = randomUUID();
+    const child = spawn("bash", ["-c", "sleep 5"], {
+      detached: true,
+      env: { ...process.env, ANET_NODE_MARKER: uuid },
+      stdio: "ignore",
+    });
+    child.unref();
+    if (!child.pid) {
+      throw new Error("Test D fixture setup failed: spawn returned no pid");
+    }
+    const childPid = child.pid;
+    try {
+      // Wait for /proc/<pid>/environ to be populated with our marker.
+      const ready = waitFor(() => {
+        try {
+          const env = readFileSync(`/proc/${childPid}/environ`, "utf8");
+          return env.split("\0").includes(`ANET_NODE_MARKER=${uuid}`);
+        } catch { return false; }
+      }, 1000);
+      expect(ready).toBe(true);
+      const enumer = realEnumerator();
+      const found = scanEnvironForMarker(enumer, uuid);
+      expect(found.length).toBeGreaterThanOrEqual(1);
+      expect(found).toContain(childPid);
+    } finally {
+      try { process.kill(childPid, "SIGTERM"); } catch {}
+      try { process.kill(childPid, "SIGKILL"); } catch {}
+    }
+  });
+
+  test("E: END-TO-END — spawn child with marker → scan + verifyGroupHomogeneity → ok with child in members", () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    // The end-to-end test: not only does scan find the process, but the full
+    // downstream chain (group by pgid, verify homogeneity) also succeeds on
+    // real /proc. This is what actually runs at stop time.
+    const uuid = randomUUID();
+    const child = spawn("bash", ["-c", "sleep 5"], {
+      detached: true,
+      env: { ...process.env, ANET_NODE_MARKER: uuid },
+      stdio: "ignore",
+    });
+    child.unref();
+    if (!child.pid) {
+      throw new Error("Test E fixture setup failed: spawn returned no pid");
+    }
+    const childPid = child.pid;
+    try {
+      const ready = waitFor(() => {
+        try {
+          const env = readFileSync(`/proc/${childPid}/environ`, "utf8");
+          return env.split("\0").includes(`ANET_NODE_MARKER=${uuid}`);
+        } catch { return false; }
+      }, 1000);
+      expect(ready).toBe(true);
+      const enumer = realEnumerator();
+      const found = scanEnvironForMarker(enumer, uuid);
+      expect(found).toContain(childPid);
+      // Group and verify
+      const pgid = pgidOf(childPid);
+      expect(pgid).not.toBeNull();
+      if (pgid == null) return;
+      const check = verifyGroupHomogeneity(enumer, pgid, uuid);
+      expect(check.ok).toBe(true);
+      if (check.ok) {
+        expect(check.members).toContain(childPid);
+      }
+    } finally {
+      try { process.kill(childPid, "SIGTERM"); } catch {}
+      try { process.kill(childPid, "SIGKILL"); } catch {}
+    }
+  });
+});

--- a/agent-network/src/copresence-identity.real.test.ts
+++ b/agent-network/src/copresence-identity.real.test.ts
@@ -1,59 +1,100 @@
-// RFC-030 P3-A v2 — REAL /proc integration tests.
+// RFC-030 P3-A — REAL /proc integration tests.
 //
-// These tests are the answer to independent-audit finding 92d53c8f: the
-// pure-mock unit test suite proved "mock and implementation self-consistent"
-// but did not prove "real code works on real Linux". The audit reproduced
-// scanEnvironForMarker throwing EACCES on /proc/1/environ in ~150ms, and
-// verified verifyGroupHomogeneity would permanently skip a group with a
-// same-uid zombie member. Neither behavior was covered by any mock test
-// because MockEnumer's readEnviron only throws when the test asks it to.
+// These tests are the answer to the repeated independent-audit finding that
+// the pure-mock suite proved "mock and implementation are self-consistent"
+// but not "the real code works on real Linux". Three candidate rounds passed
+// 52/52 mock tests while the feature was 100% non-functional on this host.
 //
-// The rule this file enforces (meta-lesson added 2026-07-29 after
-// independent audit found the mock-only invariant break):
-//   "Every module that touches OS/filesystem/process/network state must have
-//    AT LEAST ONE test that calls the real implementation, not the mock,
-//    even if only to assert 'does not throw'."
+// The rule this file enforces:
+//   "Every module that touches OS/filesystem/process state must have AT
+//    LEAST ONE test that drives the REAL implementation (realEnumerator /
+//    realKiller), not a mock — including at least one that proves the happy
+//    path actually succeeds, not merely that nothing throws."
 //
-// Test coverage here:
-//   test A  — scanEnvironForMarker on real /proc (no target uuid) does NOT
-//             throw and returns length === 0. This is the EACCES-on-pid-1
-//             regression check for Blocker 1.
-//   test B  — real zombie fixture: spawn short-lived child, poll until
-//             State: Z, verifyGroupHomogeneity does NOT return ENUM_ERROR
-//             for the zombie's pgid. Regression check for Blocker 2.
-//   test C  — realEnumerator().readEnviron(1) on real /proc (pid 1 = root)
-//             actually throws EACCES — verifies the discriminator is what
-//             wraps that throw for us at the higher level.
-//   test D  — POSITIVE: spawn child with marker uuid, scan finds it. Answers
-//             "扫描器真能找到目标" (通信龙 33dfeea0 补充). Without this,
-//             tests A/B/C together only prove the scanner doesn't crash;
-//             they don't prove it actually finds anything.
-//   test E  — END-TO-END: spawn child with marker → readStat for its pgid →
-//             verifyGroupHomogeneity(that pgid, uuid) returns ok:true with
-//             child pid in members. Proves the full identity chain (scan
-//             → group → homogeneity) works on real /proc.
+// Fixture policy (audit blocker 9): a test whose fixture cannot be built
+// FAILS. It never `return`s early and reports green — that is how a whole
+// test can go from "covers a regression" to "asserts nothing" without
+// anyone noticing.
+//
+// Coverage map:
+//   A — scan on real /proc with a nonce uuid does not throw, finds nothing.
+//   B — live marker member + REAL zombie sibling in the same pgroup →
+//       verifyGroupHomogeneity returns ok:true so escalation to SIGKILL is
+//       still possible. (v2's zombie test asserted `cause !== ENUM_ERROR`
+//       against an EMPTY_GROUP result — vacuously true, covered nothing.)
+//   C — readEnviron(1) EACCESes and readOwnerUid(1) is root. Skipped when
+//       running as root, where pid 1's environ is readable and both
+//       assertions would be false.
+//   D — POSITIVE: a spawned marker carrier is found by the scan.
+//   E — END-TO-END: scan → group → homogeneity on real /proc.
+//   F — REAL REAP: reapMarkerGroups with realEnumerator + realKiller
+//       actually kills a real marker-carrying process tree and returns
+//       kind:"success". Blocker 1 regression: on this host v2 returned
+//       "failed" 100% of the time.
+//   G — CLEAN-HOST REAP: nothing carries the uuid → success, so the caller
+//       removes the marker. This is the exact case v2 could never reach on
+//       any host running a same-uid/different-gid process.
+//   H — NON-DUMPABLE: a marker-carrying, prctl(PR_SET_DUMPABLE,0) child of
+//       a marker carrier is accounted for (in-scope unreadable) instead of
+//       silently dropped. Blocker 2 regression.
+//   I — readOwnerUid reports the REAL uid of a non-dumpable process, where
+//       the /proc/PID/environ inode owner lies and says root. Blocker 2 unit.
+//   J — REAL START SEAM: prepareIdentityForStart against real marker files
+//       and real processes reclaims the previous generation, then installs
+//       the new identity. Blockers 5+6.
+//   K — REAL START SEAM: a previous generation that genuinely cannot be
+//       reaped (foreign member in its pgroup) blocks the start and its
+//       marker survives untouched. Blocker 6.
+//   L — anchorsFromMarker + starttime validation against real /proc.
 //
 // Tests skip cleanly on non-Linux — the whole feature is Linux-only.
 
 import { describe, test, expect } from "bun:test";
-import { spawn, execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { readFileSync, statSync, writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import {
   realEnumerator,
+  realKiller,
   scanEnvironForMarker,
+  scanEnvironForMarkerFull,
   verifyGroupHomogeneity,
+  reapMarkerGroups,
+  prepareIdentityForStart,
+  writeMarker,
+  readMarker,
+  removeMarker,
+  anchorsFromMarker,
 } from "./copresence-identity";
 
 const IS_LINUX = process.platform === "linux";
+const IS_ROOT = (process.getuid?.() ?? -1) === 0;
 
-function waitFor(predicate: () => boolean, timeoutMs = 500, intervalMs = 10): boolean {
+/** python3 is the fixture interpreter: it survives PR_SET_DUMPABLE=0 (bun
+ *  does not — it dies within ~2s) and it never reaps its children, which is
+ *  what makes a stable zombie. Absence is a hard failure, never a skip. */
+const PYTHON = "python3";
+function requirePython(): void {
+  const probe = spawnSync(PYTHON, ["-c", "import ctypes"], { stdio: "ignore" });
+  if (probe.error || probe.status !== 0) {
+    throw new Error(
+      `real-/proc fixtures require \`${PYTHON}\` with ctypes (needed for a stable zombie and for prctl(PR_SET_DUMPABLE,0)). ` +
+      `Install python3 in the test environment — skipping would let blockers 2 and 9 regress unnoticed.`,
+    );
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000, intervalMs = 20): Promise<boolean> {
   const end = Date.now() + timeoutMs;
   while (Date.now() < end) {
     if (predicate()) return true;
-    // Busy-wait only for fixture setup (tiny window, ~500ms max).
-    const wait = Date.now() + intervalMs;
-    while (Date.now() < wait) { /* short spin */ }
+    await sleep(intervalMs);
   }
   return predicate();
 }
@@ -77,12 +118,30 @@ function pgidOf(pid: number): number | null {
   } catch { return null; }
 }
 
+function alive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+function killTree(pids: number[]): void {
+  for (const p of pids) { try { process.kill(p, "SIGKILL"); } catch { /* already gone */ } }
+}
+
+/** Marker-carrying, detached (own pgroup) child that stays alive. */
+function spawnCarrier(uuid: string, script: string): number {
+  const child = spawn(PYTHON, ["-c", script], {
+    detached: true,
+    env: { ...process.env, ANET_NODE_MARKER: uuid },
+    stdio: "ignore",
+  });
+  child.unref();
+  if (!child.pid) throw new Error("fixture setup failed: spawn returned no pid");
+  return child.pid;
+}
+
 describe("REAL /proc integration (Linux only)", () => {
-  test("A: realEnumerator.scanEnvironForMarker on nonexistent uuid does NOT throw on real /proc (Blocker 1 regression)", () => {
+  test("A: scan on real /proc with a nonce uuid does not throw and finds nothing", () => {
     if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
     const enumer = realEnumerator();
-    // If Blocker 1 is un-fixed, this throws EACCES on /proc/1/environ (systemd).
-    // We look for a uuid that certainly doesn't exist anywhere.
     const nonce = `no-such-uuid-${randomUUID()}`;
     let result: number[] = [];
     let threw: unknown = null;
@@ -91,136 +150,370 @@ describe("REAL /proc integration (Linux only)", () => {
     expect(result.length).toBe(0);
   });
 
-  test("B: real zombie fixture — verifyGroupHomogeneity does NOT ENUM_ERROR on a zombie in the group (Blocker 2 regression)", () => {
+  test("B: live marker member + REAL zombie sibling in the same pgroup → homogeneity ok:true (escalation stays possible)", async () => {
     if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
-    // Spawn a child that will exit immediately; without parent wait, it becomes a zombie.
-    const uuid = `zombie-fixture-uuid-${randomUUID()}`;
-    // detached + no waitpid → zombie once child exits.
-    const child = spawn("bash", ["-c", "true"], {
-      detached: true,
-      env: { ...process.env, ANET_NODE_MARKER: uuid },
-      stdio: "ignore",
-    });
-    child.unref();
-    if (!child.pid) { console.log("[skip] spawn failed to yield pid"); return; }
-    const childPid = child.pid;
-    // Wait until child hits State=Z (zombie).
-    const becameZombie = waitFor(() => readState(childPid) === "Z", 500);
-    if (!becameZombie) {
-      // Sometimes bun reaps children we spawned; in that case /proc/PID vanishes
-      // and this test can't run. Not a fix defect, just fixture unavailable.
-      console.log(`[skip] child pid ${childPid} did not reach zombie state (state=${readState(childPid)})`);
-      return;
+    requirePython();
+    const uuid = randomUUID();
+    // Parent stays alive and NEVER waits, so the /bin/true child stays a
+    // zombie for the whole test. Both inherit the marker; both share the
+    // parent's pgroup (no setsid in the child).
+    const parentPid = spawnCarrier(uuid, [
+      "import subprocess, time",
+      "p = subprocess.Popen(['/bin/true'])",
+      "print(p.pid, flush=True)",
+      "time.sleep(30)",
+    ].join("\n"));
+    const spawned: number[] = [parentPid];
+    try {
+      // Find the zombie by scanning the parent's children.
+      const pgid = await waitFor(() => pgidOf(parentPid) != null) ? pgidOf(parentPid)! : null;
+      expect(pgid).not.toBeNull();
+      const zombieFound = await waitFor(() => {
+        const kids = readFileSync(`/proc/${parentPid}/task/${parentPid}/children`, "utf8").trim();
+        if (!kids) return false;
+        return kids.split(/\s+/).map(Number).some((p) => readState(p) === "Z");
+      }, 5000);
+      // Blocker 9: fixture failure is a test failure, never a silent return.
+      expect(zombieFound).toBe(true);
+      const zombiePid = readFileSync(`/proc/${parentPid}/task/${parentPid}/children`, "utf8")
+        .trim().split(/\s+/).map(Number).find((p) => readState(p) === "Z")!;
+      spawned.push(zombiePid);
+      expect(pgidOf(zombiePid)).toBe(pgid!);
+
+      const enumer = realEnumerator();
+      // The parent is a live marker carrier; the zombie is a same-pgroup,
+      // same-uid member whose environ EACCESes because its mm is gone. The
+      // group MUST still verify, otherwise teardown can never escalate to
+      // SIGKILL — and post-SIGTERM is exactly when zombies are everywhere.
+      const result = verifyGroupHomogeneity(enumer, pgid!, uuid);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.members).toContain(parentPid);
+    } finally {
+      killTree(spawned);
     }
-    const pgid = pgidOf(childPid);
-    if (pgid == null) {
-      console.log(`[skip] could not read pgid of zombie ${childPid}`);
-      return;
-    }
-    const enumer = realEnumerator();
-    // The zombie is in `pgid`; verifyGroupHomogeneity should NOT crash / ENUM_ERROR
-    // because of the zombie's unreadable environ.
-    const result = verifyGroupHomogeneity(enumer, pgid, `unrelated-${randomUUID()}`);
-    // The important thing: result.cause !== "ENUM_ERROR" (zombie shouldn't trigger it).
-    // With no marker-carrying members in this pgid, expect EMPTY_GROUP or FOREIGN_MEMBER.
-    if (!result.ok) {
-      expect(result.cause).not.toBe("ENUM_ERROR");
-    }
-    // Cleanup: allow child to be reaped.
-    try { execSync(`wait ${childPid} 2>/dev/null || true`); } catch {}
   });
 
-  test("C: realEnumerator.readEnviron(1) throws EACCES (systemd is root-owned, discriminator handles it)", () => {
+  test("C: readEnviron(1) EACCESes and readOwnerUid(1) is root (non-root only)", () => {
     if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    // Blocker 10: as root, /proc/1/environ IS readable and readOwnerUid(1)
+    // equals our own uid, so both assertions below would be false. Many anet
+    // container images run as root — asserting them there is a guaranteed
+    // false red, not a real signal.
+    if (IS_ROOT) { console.log("[skip] running as root — pid 1 is readable to us, assertions do not apply"); return; }
     const enumer = realEnumerator();
     let threw: any = null;
     try { enumer.readEnviron(1); } catch (e) { threw = e; }
-    // pid 1 is systemd owned by root → we don't own it → EACCES is expected.
-    // scanEnvironForMarker's owner-uid discriminator turns this into a skip
-    // (see test A which does NOT throw despite this being what would throw).
     expect(threw).not.toBeNull();
     expect(threw?.code).toBe("EACCES");
-    // Discriminator sanity: verify readOwnerUid(1) returns 0 (root).
     const uid = enumer.readOwnerUid(1);
     expect(uid).toBe(0);
     expect(uid).not.toBe(process.getuid?.() ?? -1);
   });
 
-  test("D: POSITIVE — spawn child carrying our marker, scan finds it (通信龙 33dfeea0 补充)", () => {
+  test("D: POSITIVE — spawned marker carrier is found by the scan", async () => {
     if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
-    // The critical positive test: prove the scanner actually finds a marker-
-    // carrying process. Tests A/B/C together only prove "doesn't crash";
-    // this proves "does find". Without this, a broken impl that returned []
-    // would still pass A/B/C.
+    requirePython();
     const uuid = randomUUID();
-    const child = spawn("bash", ["-c", "sleep 5"], {
-      detached: true,
-      env: { ...process.env, ANET_NODE_MARKER: uuid },
-      stdio: "ignore",
-    });
-    child.unref();
-    if (!child.pid) {
-      throw new Error("Test D fixture setup failed: spawn returned no pid");
-    }
-    const childPid = child.pid;
+    const childPid = spawnCarrier(uuid, "import time; time.sleep(30)");
     try {
-      // Wait for /proc/<pid>/environ to be populated with our marker.
-      const ready = waitFor(() => {
+      const ready = await waitFor(() => {
         try {
-          const env = readFileSync(`/proc/${childPid}/environ`, "utf8");
-          return env.split("\0").includes(`ANET_NODE_MARKER=${uuid}`);
+          return readFileSync(`/proc/${childPid}/environ`, "utf8").split("\0").includes(`ANET_NODE_MARKER=${uuid}`);
         } catch { return false; }
-      }, 1000);
+      });
       expect(ready).toBe(true);
-      const enumer = realEnumerator();
-      const found = scanEnvironForMarker(enumer, uuid);
-      expect(found.length).toBeGreaterThanOrEqual(1);
+      const found = scanEnvironForMarker(realEnumerator(), uuid);
       expect(found).toContain(childPid);
     } finally {
-      try { process.kill(childPid, "SIGTERM"); } catch {}
-      try { process.kill(childPid, "SIGKILL"); } catch {}
+      killTree([childPid]);
     }
   });
 
-  test("E: END-TO-END — spawn child with marker → scan + verifyGroupHomogeneity → ok with child in members", () => {
+  test("E: END-TO-END — scan → group → homogeneity all succeed on real /proc", async () => {
     if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
-    // The end-to-end test: not only does scan find the process, but the full
-    // downstream chain (group by pgid, verify homogeneity) also succeeds on
-    // real /proc. This is what actually runs at stop time.
+    requirePython();
     const uuid = randomUUID();
-    const child = spawn("bash", ["-c", "sleep 5"], {
-      detached: true,
-      env: { ...process.env, ANET_NODE_MARKER: uuid },
-      stdio: "ignore",
-    });
-    child.unref();
-    if (!child.pid) {
-      throw new Error("Test E fixture setup failed: spawn returned no pid");
-    }
-    const childPid = child.pid;
+    const childPid = spawnCarrier(uuid, "import time; time.sleep(30)");
     try {
-      const ready = waitFor(() => {
-        try {
-          const env = readFileSync(`/proc/${childPid}/environ`, "utf8");
-          return env.split("\0").includes(`ANET_NODE_MARKER=${uuid}`);
-        } catch { return false; }
-      }, 1000);
-      expect(ready).toBe(true);
       const enumer = realEnumerator();
-      const found = scanEnvironForMarker(enumer, uuid);
-      expect(found).toContain(childPid);
-      // Group and verify
+      const ready = await waitFor(() => scanEnvironForMarker(enumer, uuid).includes(childPid));
+      expect(ready).toBe(true);
       const pgid = pgidOf(childPid);
       expect(pgid).not.toBeNull();
-      if (pgid == null) return;
-      const check = verifyGroupHomogeneity(enumer, pgid, uuid);
+      const check = verifyGroupHomogeneity(enumer, pgid!, uuid);
       expect(check.ok).toBe(true);
-      if (check.ok) {
-        expect(check.members).toContain(childPid);
-      }
+      if (check.ok) expect(check.members).toContain(childPid);
     } finally {
-      try { process.kill(childPid, "SIGTERM"); } catch {}
-      try { process.kill(childPid, "SIGKILL"); } catch {}
+      killTree([childPid]);
+    }
+  });
+
+  test("F: REAL REAP — reapMarkerGroups(realEnumerator, realKiller) kills a real carrier and returns success", async () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    requirePython();
+    const uuid = randomUUID();
+    // Two processes in one detached pgroup: parent + a marker-carrying child
+    // that is NOT setsid'd. This is the copresence shape (pane process plus
+    // its subprocess) and it is what P2 could not reap.
+    const parentPid = spawnCarrier(uuid, [
+      "import subprocess, time, sys",
+      "p = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])",
+      "print(p.pid, flush=True)",
+      "time.sleep(30)",
+    ].join("\n"));
+    const spawned = [parentPid];
+    try {
+      const enumer = realEnumerator();
+      const bothUp = await waitFor(() => scanEnvironForMarker(enumer, uuid).length >= 2, 5000);
+      expect(bothUp).toBe(true);
+      const carriers = scanEnvironForMarker(enumer, uuid);
+      spawned.push(...carriers);
+      expect(carriers).toContain(parentPid);
+
+      const logs: string[] = [];
+      const res = await reapMarkerGroups(enumer, realKiller(), uuid, {
+        graceMs: 300,
+        logger: (m) => logs.push(m),
+      });
+      if (res.kind !== "success") console.log("[F] reap logs:\n" + logs.join("\n") + "\ndetail=" + res.detail);
+      expect(res.kind).toBe("success");
+      // And the processes are actually gone — "success" must mean reality.
+      const gone = await waitFor(() => carriers.every((p) => !alive(p)), 3000);
+      expect(gone).toBe(true);
+      expect(scanEnvironForMarker(enumer, uuid)).toEqual([]);
+    } finally {
+      killTree(spawned);
+    }
+  });
+
+  test("G: CLEAN-HOST REAP — nothing carries the uuid → success on THIS host (blocker 1 regression)", async () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    // v2 returned kind:"failed" here on any host running a same-uid process
+    // whose primary GID differs from ours (docker desktop, systemd user
+    // units, anything started under a supplementary group). That made the
+    // caller print "identity teardown incomplete" and keep the marker
+    // FOREVER on such hosts — teardown could never complete even when the
+    // tree was perfectly clean.
+    const enumer = realEnumerator();
+    const nonce = `clean-host-${randomUUID()}`;
+    const scan = scanEnvironForMarkerFull(enumer, nonce);
+    expect(scan.hits).toEqual([]);
+    // Whatever machine-wide unreadable processes exist, none of them may be
+    // in scope for a uuid nothing carries: with no hits and no anchors there
+    // is no anchor to be in scope of.
+    expect(scan.unreadableOwnUid).toEqual([]);
+    const res = await reapMarkerGroups(enumer, realKiller(), nonce, {
+      graceMs: 0,
+      logger: () => {},
+    });
+    expect(res.kind).toBe("success");
+  });
+
+  test("H: NON-DUMPABLE — marker-carrying non-dumpable child of a carrier is accounted for, not dropped (blocker 2)", async () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    requirePython();
+    const uuid = randomUUID();
+    const dir = mkdtempSync(join(tmpdir(), "anet-nd-"));
+    const ndScript = join(dir, "nd.py");
+    writeFileSync(ndScript, [
+      "import ctypes, os, sys, time",
+      "libc = ctypes.CDLL('libc.so.6', use_errno=True)",
+      "libc.prctl(4, 0, 0, 0, 0)  # PR_SET_DUMPABLE = 4",
+      "print(os.getpid(), flush=True)",
+      "time.sleep(30)",
+    ].join("\n"));
+    // Parent is a readable marker carrier; the non-dumpable child shares its
+    // pgroup, so the invariant-11 scope test reaches it through the parent.
+    const parentPid = spawnCarrier(uuid, [
+      "import subprocess, time, sys",
+      `p = subprocess.Popen([sys.executable, ${JSON.stringify(ndScript)}])`,
+      "time.sleep(30)",
+    ].join("\n"));
+    const spawned = [parentPid];
+    try {
+      const enumer = realEnumerator();
+      const ndFound = await waitFor(() => {
+        try {
+          const kids = readFileSync(`/proc/${parentPid}/task/${parentPid}/children`, "utf8").trim();
+          if (!kids) return false;
+          return kids.split(/\s+/).map(Number).some((p) => {
+            try { statSync(`/proc/${p}/environ`); } catch { return false; }
+            return statSync(`/proc/${p}/environ`).uid !== (process.getuid?.() ?? -1);
+          });
+        } catch { return false; }
+      }, 8000);
+      expect(ndFound).toBe(true);
+      const ndPid = readFileSync(`/proc/${parentPid}/task/${parentPid}/children`, "utf8")
+        .trim().split(/\s+/).map(Number)
+        .find((p) => { try { return statSync(`/proc/${p}/environ`).uid !== (process.getuid?.() ?? -1); } catch { return false; } })!;
+      spawned.push(ndPid);
+
+      // Ground truth: the inode owner LIES (says root), the process is ours.
+      expect(statSync(`/proc/${ndPid}/environ`).uid).toBe(0);
+      expect(readFileSync(`/proc/${ndPid}/status`, "utf8")).toMatch(/^Uid:\s*1?\d+/m);
+
+      const scan = scanEnvironForMarkerFull(enumer, uuid);
+      // It cannot be a hit — its environ is unreadable by anyone but root.
+      expect(scan.hits).not.toContain(ndPid);
+      // But it MUST be accounted for. v2 dropped it entirely (uid read from
+      // the environ inode said root → "not ours" → skip), so teardown
+      // reported success and deleted the marker while it lived on.
+      expect(scan.unreadableOwnUid).toContain(ndPid);
+      expect(scan.unreadableOutOfScope).not.toContain(ndPid);
+
+      // Consequence: reap refuses to report success, so the caller keeps the
+      // marker and the process stays reclaimable.
+      const res = await reapMarkerGroups(enumer, realKiller(), uuid, {
+        graceMs: 200,
+        logger: () => {},
+      });
+      expect(res.kind).toBe("failed");
+    } finally {
+      killTree(spawned);
+    }
+  });
+
+  test("I: readOwnerUid reports the REAL uid of a non-dumpable process (environ inode owner lies)", async () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    requirePython();
+    const dir = mkdtempSync(join(tmpdir(), "anet-nd2-"));
+    const ndScript = join(dir, "nd.py");
+    writeFileSync(ndScript, [
+      "import ctypes, os, time",
+      "libc = ctypes.CDLL('libc.so.6', use_errno=True)",
+      "libc.prctl(4, 0, 0, 0, 0)",
+      "time.sleep(30)",
+    ].join("\n"));
+    const child = spawn(PYTHON, [ndScript], { detached: true, stdio: "ignore" });
+    child.unref();
+    const pid = child.pid!;
+    try {
+      const ready = await waitFor(() => {
+        try { return statSync(`/proc/${pid}/environ`).uid === 0; } catch { return false; }
+      }, 8000);
+      expect(ready).toBe(true);
+      const ourUid = process.getuid?.() ?? -1;
+      // The v2 implementation was `statSync('/proc/PID/environ').uid`, which
+      // returns 0 here and made our own child look like somebody else's.
+      expect(statSync(`/proc/${pid}/environ`).uid).toBe(0);
+      expect(realEnumerator().readOwnerUid(pid)).toBe(ourUid);
+    } finally {
+      killTree([pid]);
+    }
+  });
+
+  test("J: REAL START SEAM — prepareIdentityForStart reclaims a live previous generation and installs the new marker", async () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    requirePython();
+    // Everything real: real marker file, real /proc scan, real signals.
+    const nodesDir = mkdtempSync(join(tmpdir(), "anet-start-seam-"));
+    const nodeId = "seam-node";
+    const oldUuid = randomUUID();
+    const newUuid = randomUUID();
+    const carrier = spawnCarrier(oldUuid, "import time; time.sleep(30)");
+    const spawned = [carrier];
+    try {
+      const enumer = realEnumerator();
+      expect(await waitFor(() => scanEnvironForMarker(enumer, oldUuid).includes(carrier))).toBe(true);
+      writeMarker(nodesDir, nodeId, oldUuid, {});
+
+      const result = await prepareIdentityForStart(newUuid, {
+        readMarker: () => readMarker(nodesDir, nodeId),
+        reap: (uuid, anchors) => reapMarkerGroups(realEnumerator(), realKiller(), uuid, { graceMs: 300, logger: () => {}, anchors }),
+        removeMarker: () => removeMarker(nodesDir, nodeId),
+        writeMarker: (uuid, sessions) => { writeMarker(nodesDir, nodeId, uuid, sessions); },
+        logger: () => {},
+      });
+
+      expect(result.kind).toBe("ok");
+      if (result.kind === "ok") expect(result.reclaimedUuid).toBe(oldUuid);
+      // The previous generation is really dead...
+      expect(await waitFor(() => !alive(carrier), 3000)).toBe(true);
+      // ...and the marker on disk is the NEW identity.
+      const after = readMarker(nodesDir, nodeId);
+      expect(after.kind).toBe("ok");
+      if (after.kind === "ok") expect(after.marker.marker).toBe(newUuid);
+    } finally {
+      killTree(spawned);
+    }
+  });
+
+  test("K: REAL START SEAM — a previous generation that cannot be reaped BLOCKS the start and its marker survives", async () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    requirePython();
+    // Real un-reapable shape: a marker carrier sharing its pgroup with a
+    // process that does NOT carry the marker. Homogeneity refuses
+    // FOREIGN_MEMBER, the group is never signalled, and the reap fails —
+    // exactly the state a failed stop leaves behind.
+    const nodesDir = mkdtempSync(join(tmpdir(), "anet-start-seam2-"));
+    const nodeId = "seam-node";
+    const oldUuid = randomUUID();
+    const newUuid = randomUUID();
+    const carrier = spawnCarrier(oldUuid, [
+      "import subprocess, os, sys, time",
+      "env = dict(os.environ); env.pop('ANET_NODE_MARKER', None)",
+      "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'], env=env)",
+      "time.sleep(30)",
+    ].join("\n"));
+    const spawned = [carrier];
+    try {
+      const enumer = realEnumerator();
+      expect(await waitFor(() => scanEnvironForMarker(enumer, oldUuid).includes(carrier))).toBe(true);
+      // Wait for the foreign sibling to actually exist in the pgroup.
+      expect(await waitFor(() => {
+        const kids = readFileSync(`/proc/${carrier}/task/${carrier}/children`, "utf8").trim();
+        return kids.length > 0;
+      }, 5000)).toBe(true);
+      for (const k of readFileSync(`/proc/${carrier}/task/${carrier}/children`, "utf8").trim().split(/\s+/).map(Number)) spawned.push(k);
+      writeMarker(nodesDir, nodeId, oldUuid, {});
+
+      const result = await prepareIdentityForStart(newUuid, {
+        readMarker: () => readMarker(nodesDir, nodeId),
+        reap: (uuid, anchors) => reapMarkerGroups(realEnumerator(), realKiller(), uuid, { graceMs: 300, logger: () => {}, anchors }),
+        removeMarker: () => removeMarker(nodesDir, nodeId),
+        writeMarker: (uuid, sessions) => { writeMarker(nodesDir, nodeId, uuid, sessions); },
+        logger: () => {},
+      });
+
+      expect(result.kind).toBe("blocked");
+      if (result.kind === "blocked") expect(result.cause).toBe("STALE_TREE_ALIVE");
+      // The old identity is STILL the one on disk — losing it would strand
+      // the surviving processes forever.
+      const after = readMarker(nodesDir, nodeId);
+      expect(after.kind).toBe("ok");
+      if (after.kind === "ok") expect(after.marker.marker).toBe(oldUuid);
+      expect(alive(carrier)).toBe(true);
+    } finally {
+      killTree(spawned);
+    }
+  });
+
+  test("L: anchorsFromMarker feeds real recorded pane pids into the scope test", async () => {
+    if (!IS_LINUX) { console.log("[skip] not Linux"); return; }
+    requirePython();
+    // A recorded session pid is only allowed to widen scope while it is the
+    // SAME process. Real /proc, real starttime.
+    const uuid = randomUUID();
+    const pid = spawnCarrier(uuid, "import time; time.sleep(30)");
+    try {
+      const enumer = realEnumerator();
+      expect(await waitFor(() => enumer.readStat(pid) != null)).toBe(true);
+      const stat = enumer.readStat(pid)!;
+      const good = anchorsFromMarker({
+        marker: uuid, boot_id: "b", started_at_epoch_ms: 1, owner_uid: process.getuid?.() ?? -1,
+        sessions: { appsrv: { tmux: "t", pid, pgid: stat.pgid, starttime_jiffies: stat.starttime_jiffies } },
+      });
+      expect(good.sessions).toEqual([{ pid, starttime_jiffies: stat.starttime_jiffies }]);
+      // A stale record for the same pid must not anchor: prove it by asking
+      // the scan with a uuid nothing carries — the anchor is the only thing
+      // that could widen scope, and a mismatched starttime must drop it.
+      const nonce = `anchor-check-${randomUUID()}`;
+      const staleScan = scanEnvironForMarkerFull(enumer, nonce, {
+        sessions: [{ pid, starttime_jiffies: stat.starttime_jiffies + 1 }],
+      });
+      expect(staleScan.unreadableOwnUid).toEqual([]);
+    } finally {
+      killTree([pid]);
     }
   });
 });

--- a/agent-network/src/copresence-identity.test.ts
+++ b/agent-network/src/copresence-identity.test.ts
@@ -396,6 +396,133 @@ describe("Test 8: malformed marker → structured refuse (never throws)", () => 
   });
 });
 
+// ─── Test 8b: filesystem/environment refuse guards ──────────────────────
+//
+// These target the three refuses that had no test coverage in the initial
+// v2 candidate (通信龙 mutation复核 task fb363cf7). Each fixture is
+// carefully constructed so that ONLY the target guard fires — all earlier
+// guards in readMarker (SYMLINK → NOT_REGULAR → WRONG_MODE → OWNER_MISMATCH
+// → PARSE_ERROR → SCHEMA_INVALID → STALE_BOOT_ID) pass, so the specific
+// refuse is uniquely observable.
+//
+// If a fixture triggered an earlier guard by accident, disabling the target
+// guard wouldn't be observable — the earlier guard would mask it. Every
+// test below is designed so that removing the target guard changes the
+// return value from `refuse:<TARGET>` to something else observable
+// (typically `ok`, or a subsequent-guard refuse, or a thrown error).
+describe("Test 8b: filesystem/environment refuse guards (mutation-sensitive)", () => {
+  // MUTATION CASES (for 通信龙's automated mutation复核):
+  //   - Comment `if (!lstat.isFile())` → NOT_REGULAR test RED
+  //     (readMarker falls to readFileSync which throws EISDIR on a directory)
+  //   - Comment `if (lstat.uid !== ownUid)` → OWNER_MISMATCH test RED
+  //     (returns ok:{marker} because our fixture is otherwise valid)
+  //   - Comment `if (parsed.boot_id !== currentBoot)` → STALE_BOOT_ID test RED
+  //     (returns ok:{marker} because everything else is valid)
+
+  test("NOT_REGULAR: directory at marker path with mode 0600 (skips SYMLINK+WRONG_MODE)", () => {
+    // Fixture: create a *directory* at the exact path where the marker file
+    // would live. Directory bits 0o600 pass WRONG_MODE. isSymbolicLink=false
+    // passes SYMLINK. So NOT_REGULAR is the only fireable guard.
+    const nodeDir = join(tmpNodesDir, "notreg-node");
+    mkdirSync(nodeDir, { recursive: true, mode: 0o700 });
+    // Create the marker "file" as a directory.
+    const markerPath = join(nodeDir, "copresence-identity.json");
+    mkdirSync(markerPath, { mode: 0o600 });
+    // Force mode to 0o600 (mkdir + umask may not honor 0o600 exactly).
+    chmodSync(markerPath, 0o600);
+    // Sanity check the fixture: lstat sees a directory with mode 0o600.
+    const st = statSync(markerPath);
+    expect(st.isDirectory()).toBe(true);
+    expect(st.mode & 0o777).toBe(0o600);
+    const r = readMarker(tmpNodesDir, "notreg-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("NOT_REGULAR");
+    // Note: if NOT_REGULAR guard is removed, readFileSync throws EISDIR
+    // and readMarker itself throws. Bun's `expect(fn).toBe(...)` on the
+    // thrown result reports failure — test correctly turns RED.
+  });
+
+  test("OWNER_MISMATCH: valid marker file whose lstat.uid differs from process.getuid() (SECURITY CRITICAL)", () => {
+    // We cannot chown as non-root, so this test overrides process.getuid
+    // for its duration. This is the *only* way to construct the mismatch
+    // without helper-side DI (which we chose to avoid — see fork brief).
+    //
+    // The marker file is otherwise fully valid: correct mode, correct
+    // schema, matching boot_id. So the ONLY guard that fires is
+    // OWNER_MISMATCH. If that guard is removed, readMarker returns
+    // { kind: "ok", ... } and the test's `expect(r.kind).toBe("refuse")`
+    // assertion fails → test correctly turns RED.
+    const uuid = "owner-mismatch-uuid-1234";
+    // Write a fully valid marker (uses real process.getuid for owner_uid).
+    writeMarker(tmpNodesDir, "owner-mismatch-node", uuid, makeSessions());
+    // Now spoof process.getuid to return a different uid.
+    const realGetuid = process.getuid;
+    const spoofedUid = ((realGetuid ? realGetuid.call(process) : 0) + 424242) >>> 0;
+    // Use Object.defineProperty because process.getuid may be non-writable on
+    // some Node builds; defineProperty forces the replacement.
+    Object.defineProperty(process, "getuid", {
+      value: () => spoofedUid,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const r = readMarker(tmpNodesDir, "owner-mismatch-node");
+      expect(r.kind).toBe("refuse");
+      if (r.kind === "refuse") {
+        expect(r.cause).toBe("OWNER_MISMATCH");
+        // Also assert the detail message references BOTH uids to catch
+        // regressions where the message accidentally uses ownUid in place
+        // of lstat.uid or vice versa.
+        expect(r.detail).toContain(String(spoofedUid));
+      }
+    } finally {
+      // Restore. Use defineProperty again to reinstall the real fn.
+      Object.defineProperty(process, "getuid", {
+        value: realGetuid,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  test("STALE_BOOT_ID: valid schema but boot_id differs from current /proc boot_id", () => {
+    // Bypass writeMarker (which stamps current boot_id) and hand-write a
+    // marker JSON with a deliberately-wrong boot_id. Everything else is
+    // valid: mode 0o600, owner=us, schema OK. So the ONLY guard that fires
+    // is STALE_BOOT_ID. Removing that guard returns `ok` and the assertion
+    // `r.cause === "STALE_BOOT_ID"` fails → test correctly turns RED.
+    const nodeDir = join(tmpNodesDir, "stale-boot-node");
+    mkdirSync(nodeDir, { recursive: true, mode: 0o700 });
+    const path = join(nodeDir, "copresence-identity.json");
+    const stale = {
+      marker: "stale-boot-uuid-9999",
+      // A boot_id that cannot possibly match: fixed sentinel unrelated to
+      // any real /proc value. If /proc/sys/kernel/random/boot_id ever
+      // returned this literal string, we would need to update — but the
+      // sentinel is chosen to be visibly not-a-UUID to make that impossible
+      // by design.
+      boot_id: "0000ffff-stale-boot-id-for-mutation-test-fixture",
+      started_at_epoch_ms: 1,
+      owner_uid: process.getuid ? process.getuid() : -1,
+      sessions: {
+        appsrv: { tmux: "a-appsrv", pid: 100, pgid: 100, starttime_jiffies: 500 },
+        bridge: { tmux: "a-bridge", pid: 200, pgid: 200, starttime_jiffies: 600 },
+        tui: { tmux: "a-tui", pid: 300, pgid: 300, starttime_jiffies: 700 },
+      },
+    };
+    writeFileSync(path, JSON.stringify(stale, null, 2) + "\n", { mode: 0o600 });
+    chmodSync(path, 0o600);
+    const r = readMarker(tmpNodesDir, "stale-boot-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") {
+      expect(r.cause).toBe("STALE_BOOT_ID");
+      // Detail must mention the stale boot_id in the marker (this catches
+      // a mutation where the message would use `currentBoot` twice).
+      expect(r.detail).toContain(stale.boot_id);
+    }
+  });
+});
+
 // ─── Test 9: self-context ───────────────────────────────────────────────
 
 describe("Test 9: self-context refuses stop from within the tree", () => {

--- a/agent-network/src/copresence-identity.test.ts
+++ b/agent-network/src/copresence-identity.test.ts
@@ -1,0 +1,561 @@
+// RFC-030 P3-A v2 — unit tests for copresence identity/reap module.
+//
+// Each `describe` block covers one of the 11 scenarios listed in the
+// 副指挥 GO (7a9c99df, 2026-07-29). Every assertion is designed to
+// TURN RED under a specific mutation of the production code — see the
+// `MUTATION CASES` comments for what 通信龙 will attempt.
+//
+// FIRST PRINCIPLE (fork brief verbatim):
+//   This restart's lesson is NOT "code has bugs" — it's "three gates all
+//   looked present, none actually worked, and evidence looked green". So
+//   every gate here MUST first prove it CAN turn red. Mutation testing
+//   (通信龙 will actively break tests to verify they turn red) is the
+//   acceptance criterion.
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, symlinkSync, statSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  writeMarker,
+  readMarker,
+  removeMarker,
+  markerFilePath,
+  scanEnvironForMarker,
+  groupPidsByPgid,
+  verifyGroupHomogeneity,
+  callerCarriesMarker,
+  sessionStillFresh,
+  reapMarkerGroups,
+  type ProcessEnumerator,
+  type KillPrimitive,
+  type CopresenceMarker,
+  type SessionInfo,
+} from "./copresence-identity";
+
+// ─── Test fixtures ──────────────────────────────────────────────────────
+
+let tmpNodesDir: string;
+
+beforeEach(() => {
+  tmpNodesDir = mkdtempSync(join(tmpdir(), "p3-v2-test-"));
+  chmodSync(tmpNodesDir, 0o700);
+});
+
+afterEach(() => {
+  try { rmSync(tmpNodesDir, { recursive: true, force: true }); } catch {}
+});
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    tmux: "test-alias-appsrv",
+    pid: 1000,
+    pgid: 1000,
+    starttime_jiffies: 500,
+    ...overrides,
+  };
+}
+
+function makeSessions(): CopresenceMarker["sessions"] {
+  return {
+    appsrv: makeSession({ tmux: "a-appsrv", pid: 100, pgid: 100, starttime_jiffies: 500 }),
+    bridge: makeSession({ tmux: "a-bridge", pid: 200, pgid: 200, starttime_jiffies: 600 }),
+    tui: makeSession({ tmux: "a-tui", pid: 300, pgid: 300, starttime_jiffies: 700 }),
+  };
+}
+
+/** In-memory ProcessEnumerator for tests. */
+class MockEnumer implements ProcessEnumerator {
+  procs = new Map<number, { environ: string; stat: { pgid: number; starttime_jiffies: number; ppid: number } }>();
+  listErr: Error | null = null;
+  environErrs = new Map<number, Error>();
+  statErrs = new Map<number, Error>();
+
+  listAllPids(): number[] {
+    if (this.listErr) throw this.listErr;
+    return [...this.procs.keys()];
+  }
+  readEnviron(pid: number): string | null {
+    const err = this.environErrs.get(pid);
+    if (err) throw err;
+    const p = this.procs.get(pid);
+    return p ? p.environ : null;
+  }
+  readStat(pid: number) {
+    const err = this.statErrs.get(pid);
+    if (err) throw err;
+    const p = this.procs.get(pid);
+    return p ? { ...p.stat } : null;
+  }
+  add(pid: number, environ: string, pgid: number, starttime = 0, ppid = 1) {
+    this.procs.set(pid, { environ, stat: { pgid, starttime_jiffies: starttime, ppid } });
+  }
+}
+
+class MockKiller implements KillPrimitive {
+  signals: Array<{ pgid: number; signal: "TERM" | "KILL" }> = [];
+  aliveMap = new Map<number, boolean>();
+  killPgroup(pgid: number, signal: "TERM" | "KILL"): void {
+    this.signals.push({ pgid, signal });
+  }
+  pgroupAlive(pgid: number): boolean {
+    return this.aliveMap.get(pgid) ?? false;
+  }
+}
+
+// ─── Test 1: UUID round-trip (MUST catch Blocker 1) ─────────────────────
+
+describe("Test 1: UUID round-trip", () => {
+  // MUTATION CASES (通信龙 will attempt these to verify test turns RED):
+  //   - Change writeMarker to generate its own uuid internally, ignoring
+  //     the `uuid` parameter → this test MUST RED (marker.marker !== provided)
+  //   - Remove the uuid parameter guard, accept "" or number → this test
+  //     MUST RED (empty-string or wrong-type must throw)
+  //   - cli.ts wiring: any caller that generates a second uuid to inject
+  //     into tmux env instead of using the returned marker.marker → the
+  //     invariant is tested here at the API level.
+  test("writeMarker persists exactly the provided uuid (single source of truth)", () => {
+    const uuid = "11111111-2222-3333-4444-555555555555";
+    const written = writeMarker(tmpNodesDir, "n1", uuid, makeSessions());
+    expect(written.marker).toBe(uuid);
+    const read = readMarker(tmpNodesDir, "n1");
+    expect(read.kind).toBe("ok");
+    if (read.kind === "ok") {
+      expect(read.marker.marker).toBe(uuid);
+      // The same uuid MUST be what cli.ts injects into tmux env vars.
+      // If the helper had generated its own uuid, this equality would fail
+      // — that was Blocker 1 in 9f2ec282.
+    }
+  });
+
+  test("writeMarker refuses empty uuid (guard against silent regeneration)", () => {
+    expect(() => writeMarker(tmpNodesDir, "n2", "", makeSessions())).toThrow(/non-empty/i);
+  });
+
+  test("writeMarker refuses non-string uuid", () => {
+    // @ts-expect-error deliberate type violation
+    expect(() => writeMarker(tmpNodesDir, "n3", 42, makeSessions())).toThrow(/non-empty/i);
+    // @ts-expect-error deliberate type violation
+    expect(() => writeMarker(tmpNodesDir, "n4", null, makeSessions())).toThrow(/non-empty/i);
+  });
+});
+
+// ─── Test 2: enumeration failure (MUST catch Blocker 2) ─────────────────
+
+describe("Test 2: enumeration failure is loud (fail-closed)", () => {
+  // MUTATION CASES:
+  //   - Wrap listAllPids/readStat/readEnviron in `catch { return [] }` in
+  //     the real /proc-based ProcessEnumerator → verifyGroupHomogeneity
+  //     would judge empty-list as "no foreign members, ok:true" → this
+  //     test MUST RED
+  //   - Silent swallow of listAllPids error → verifyGroupHomogeneity must
+  //     surface ENUM_ERROR, not judge ok
+  test("verifyGroupHomogeneity fails-closed when listAllPids throws", () => {
+    const enumer = new MockEnumer();
+    enumer.listErr = new Error("ps: unknown gnu long option");
+    const result = verifyGroupHomogeneity(enumer, 999, "some-uuid");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.cause).toBe("ENUM_ERROR");
+      expect(result.detail).toMatch(/listAllPids failed/);
+    }
+  });
+
+  test("verifyGroupHomogeneity fails-closed when a member's environ read throws", () => {
+    const enumer = new MockEnumer();
+    // pid 100 is in the group and has the marker
+    enumer.add(100, "ANET_NODE_MARKER=u1\0PATH=/\0", 500);
+    // pid 200 is in the group; environ read fails (permission denied)
+    enumer.add(200, "x", 500);
+    enumer.environErrs.set(200, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const result = verifyGroupHomogeneity(enumer, 500, "u1");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.cause).toBe("ENUM_ERROR");
+      expect(result.unreadablePids).toContain(200);
+    }
+  });
+
+  test("verifyGroupHomogeneity fails-closed when a stat read throws", () => {
+    const enumer = new MockEnumer();
+    enumer.add(100, "ANET_NODE_MARKER=u1\0PATH=/\0", 500);
+    // synthesize a pid whose stat throws (permission oddity)
+    enumer.procs.set(200, { environ: "PATH=/\0", stat: { pgid: 500, starttime_jiffies: 1, ppid: 1 } });
+    enumer.statErrs.set(200, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const result = verifyGroupHomogeneity(enumer, 500, "u1");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.cause).toBe("ENUM_ERROR");
+    }
+  });
+});
+
+// ─── Test 3: foreign member in PGID ─────────────────────────────────────
+
+describe("Test 3: foreign member in PGID → SKIP", () => {
+  // MUTATION CASES:
+  //   - Skipping the loop over all group pids (only checking the initial
+  //     scan result) → test MUST RED
+  //   - Trusting only the primary pid's environ → test MUST RED
+  //   - Treating "0 foreign" as ok:true when actually enumeration failed →
+  //     covered by Test 2
+  test("group with unmarked co-resident refuses homogeneity", () => {
+    const enumer = new MockEnumer();
+    // Two marker-carrying + one foreign pid, all in pgid=500
+    enumer.add(100, "ANET_NODE_MARKER=u1\0", 500);
+    enumer.add(200, "ANET_NODE_MARKER=u1\0", 500);
+    enumer.add(300, "PATH=/\0", 500); // foreign — no marker
+    const result = verifyGroupHomogeneity(enumer, 500, "u1");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.cause).toBe("FOREIGN_MEMBER");
+      expect(result.foreignPids).toContain(300);
+    }
+  });
+
+  test("group where every member carries the marker is ok", () => {
+    const enumer = new MockEnumer();
+    enumer.add(100, "ANET_NODE_MARKER=u1\0", 500);
+    enumer.add(200, "ANET_NODE_MARKER=u1\0", 500);
+    const result = verifyGroupHomogeneity(enumer, 500, "u1");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.members.sort()).toEqual([100, 200]);
+  });
+});
+
+// ─── Test 4: main dead, child alive ─────────────────────────────────────
+
+describe("Test 4: main-dead-child-alive (environ scan is authority)", () => {
+  // MUTATION CASES:
+  //   - If reap flow trusted marker.sessions.*.pid instead of environ scan
+  //     for identity, main-dead scenario would leave workers un-reaped.
+  //     scanEnvironForMarker MUST find the surviving worker regardless of
+  //     the marker file's stored pids.
+  test("scan finds workers even when marker's stored pids are gone", () => {
+    const enumer = new MockEnumer();
+    // Marker file (hypothetically) recorded pid=100 as main; main died.
+    // Only pid=200 (worker) survives, still carrying the marker.
+    enumer.add(200, "ANET_NODE_MARKER=u1\0OTHER=x\0", 750);
+    // Marker's stored pid=100 does NOT exist in enumer; we don't add it.
+    const found = scanEnvironForMarker(enumer, "u1");
+    expect(found).toEqual([200]);
+    // Grouping uses the worker's CURRENT pgid, not the marker file's hint.
+    const groups = groupPidsByPgid(enumer, found);
+    expect(groups.get(750)).toEqual([200]);
+    expect(groups.has(100)).toBe(false);
+  });
+});
+
+// ─── Test 5: setsid / new PGID ──────────────────────────────────────────
+
+describe("Test 5: child setsid → new PGID", () => {
+  // MUTATION CASES:
+  //   - If groupPidsByPgid used the marker.sessions.*.pgid instead of the
+  //     current /proc/PID/stat pgid, the detached child would land under
+  //     the wrong (dead) pgid and never be reaped.
+  test("detached child grouped under its current pgid, not marker's stored pgid", () => {
+    const enumer = new MockEnumer();
+    // Worker was born under pgid=500 (per marker), but did setsid → now pgid=200.
+    enumer.add(200, "ANET_NODE_MARKER=u1\0", 200 /* new pgid */, 1234);
+    const found = scanEnvironForMarker(enumer, "u1");
+    expect(found).toEqual([200]);
+    const groups = groupPidsByPgid(enumer, found);
+    expect(groups.get(200)).toEqual([200]); // grouped by current pgid
+    expect(groups.has(500)).toBe(false);
+  });
+});
+
+// ─── Test 6: PID reuse ──────────────────────────────────────────────────
+
+describe("Test 6: PID reuse via starttime mismatch", () => {
+  // MUTATION CASES:
+  //   - Skipping the starttime check → stale marker pid would match a
+  //     recycled unrelated pid → this test MUST RED
+  //   - Also see boot_id check in Test 8 (readMarker's STALE_BOOT_ID path)
+  test("sessionStillFresh returns false when starttime doesn't match", () => {
+    const enumer = new MockEnumer();
+    // Marker recorded pid=100 starttime=500. Current /proc/100 has different starttime.
+    enumer.add(100, "PATH=/\0", 100, /* starttime */ 999);
+    const session: SessionInfo = { tmux: "t", pid: 100, pgid: 100, starttime_jiffies: 500 };
+    expect(sessionStillFresh(enumer, session)).toBe(false);
+  });
+
+  test("sessionStillFresh returns true when starttime matches", () => {
+    const enumer = new MockEnumer();
+    enumer.add(100, "PATH=/\0", 100, 500);
+    const session: SessionInfo = { tmux: "t", pid: 100, pgid: 100, starttime_jiffies: 500 };
+    expect(sessionStillFresh(enumer, session)).toBe(true);
+  });
+
+  test("sessionStillFresh returns false when pid gone (ENOENT)", () => {
+    const enumer = new MockEnumer();
+    const session: SessionInfo = { tmux: "t", pid: 100, pgid: 100, starttime_jiffies: 500 };
+    expect(sessionStillFresh(enumer, session)).toBe(false);
+  });
+});
+
+// ─── Test 7: partial-start rollback ─────────────────────────────────────
+
+describe("Test 7: partial-start rollback (marker gate)", () => {
+  // The invariant tested here is: if writeMarker was never called (partial
+  // start), then readMarker returns MISSING and the stop caller must treat
+  // that as "not our node, don't touch anything" — never blind-kill.
+  //
+  // MUTATION CASES:
+  //   - Any code path that assumes MISSING marker means "clean up by name"
+  //     → violates the invariant.
+  //   - Any rollback that shells out to `pkill -f <alias>` when marker is
+  //     absent → violates the invariant.
+  test("MISSING marker after partial start prevents any process action", () => {
+    // No marker file exists at all (start failed before writeMarker)
+    const r = readMarker(tmpNodesDir, "partial-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("MISSING");
+    // The reap flow is not invoked because caller sees MISSING.
+    // (Invariant: caller MUST honor MISSING as no-op; verified in cli.ts
+    // integration by Test 10's zero-diff check on the legacy path.)
+  });
+});
+
+// ─── Test 8: malformed marker ───────────────────────────────────────────
+
+describe("Test 8: malformed marker → structured refuse (never throws)", () => {
+  // MUTATION CASES:
+  //   - Using `"marker" in obj` on a null-body → TypeError, test MUST RED
+  //   - Trusting Array/number bodies → schema check catches, MUST RED
+  //   - Missing null-check in isPlainObject → MUST RED
+  const write = (body: string, mode = 0o600) => {
+    const nodeDir = join(tmpNodesDir, "malformed-node");
+    mkdirSync(nodeDir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(nodeDir, "copresence-identity.json"), body, { mode });
+    chmodSync(join(nodeDir, "copresence-identity.json"), mode);
+  };
+
+  test("null body → SCHEMA_INVALID (no TypeError from `in` operator)", () => {
+    write("null");
+    const r = readMarker(tmpNodesDir, "malformed-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("SCHEMA_INVALID");
+  });
+
+  test("bare number → SCHEMA_INVALID", () => {
+    write("42");
+    const r = readMarker(tmpNodesDir, "malformed-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("SCHEMA_INVALID");
+  });
+
+  test("empty array → SCHEMA_INVALID", () => {
+    write("[]");
+    const r = readMarker(tmpNodesDir, "malformed-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("SCHEMA_INVALID");
+  });
+
+  test("empty object → SCHEMA_INVALID (missing required fields)", () => {
+    write("{}");
+    const r = readMarker(tmpNodesDir, "malformed-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("SCHEMA_INVALID");
+  });
+
+  test("wrong types in schema → SCHEMA_INVALID", () => {
+    write(JSON.stringify({ marker: 42, boot_id: "x", started_at_epoch_ms: 1, owner_uid: 1, sessions: { appsrv: {}, bridge: {}, tui: {} } }));
+    const r = readMarker(tmpNodesDir, "malformed-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("SCHEMA_INVALID");
+  });
+
+  test("syntactically invalid JSON → PARSE_ERROR", () => {
+    write("{not json");
+    const r = readMarker(tmpNodesDir, "malformed-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("PARSE_ERROR");
+  });
+
+  test("wrong mode → WRONG_MODE (even with valid JSON)", () => {
+    write(JSON.stringify({
+      marker: "u1", boot_id: "b1", started_at_epoch_ms: 1, owner_uid: process.getuid?.() ?? -1,
+      sessions: { appsrv: makeSession(), bridge: makeSession(), tui: makeSession() },
+    }), 0o644);
+    const r = readMarker(tmpNodesDir, "malformed-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("WRONG_MODE");
+  });
+
+  test("symlink → SYMLINK (refuses to follow)", () => {
+    const nodeDir = join(tmpNodesDir, "symlink-node");
+    mkdirSync(nodeDir, { recursive: true, mode: 0o700 });
+    // Create a target file, then symlink the marker path to it.
+    const target = join(tmpNodesDir, "target.json");
+    writeFileSync(target, "irrelevant", { mode: 0o600 });
+    symlinkSync(target, join(nodeDir, "copresence-identity.json"));
+    const r = readMarker(tmpNodesDir, "symlink-node");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("SYMLINK");
+  });
+});
+
+// ─── Test 9: self-context ───────────────────────────────────────────────
+
+describe("Test 9: self-context refuses stop from within the tree", () => {
+  // MUTATION CASES:
+  //   - Any code that excludes caller pid then continues to kill → MUST RED
+  //   - Skipping ancestry walk (only checking self pid) → RED for the
+  //     "ancestor carries marker" case
+  test("caller's own environ carrying the marker is detected", () => {
+    const enumer = new MockEnumer();
+    // Simulate current pid carrying the marker (in reality process.pid is
+    // read; we override the enumer to return the marker for process.pid).
+    enumer.add(process.pid, `ANET_NODE_MARKER=u1\0PATH=/\0`, 500, 0, 1);
+    const r = callerCarriesMarker(enumer, "u1");
+    expect(r.self).toBe(true);
+    expect(r.ancestorPid).toBe(process.pid);
+  });
+
+  test("ancestor carrying the marker is detected via PPID walk", () => {
+    const enumer = new MockEnumer();
+    // Chain: self (no marker) → parent 9999 → grandparent 8888 (has marker)
+    enumer.add(process.pid, "PATH=/\0", 500, 0, 9999);
+    enumer.add(9999, "PATH=/\0", 500, 0, 8888);
+    enumer.add(8888, "ANET_NODE_MARKER=u1\0PATH=/\0", 500, 0, 1);
+    const r = callerCarriesMarker(enumer, "u1");
+    expect(r.self).toBe(false);
+    expect(r.ancestorPid).toBe(8888);
+  });
+
+  test("clean caller (no marker in ancestry) returns self=false", () => {
+    const enumer = new MockEnumer();
+    enumer.add(process.pid, "PATH=/\0", 500, 0, 1);
+    const r = callerCarriesMarker(enumer, "u1");
+    expect(r.self).toBe(false);
+    expect(r.ancestorPid).toBeUndefined();
+  });
+});
+
+// ─── Test 10: ordinary codex-app-server zero-diff ────────────────────────
+
+describe("Test 10: non-copresence codex-app-server → legacy path (zero diff)", () => {
+  // The invariant tested here is: the stop gate keys on MARKER FILE
+  // EXISTENCE (a persistent side-effect of `anet node start --copresence`),
+  // NOT on the runtime string. An ordinary codex-app-server node has NO
+  // marker file → readMarker → MISSING → caller falls through to legacy.
+  //
+  // MUTATION CASES:
+  //   - Any gate that keys on `runtime === "codex-app-server"` and forces
+  //     the new P3 path for ordinary nodes → RED (breaks ordinary stop)
+  //   - Any gate that ignores marker MISSING and proceeds with identity
+  //     flow → RED (ordinary node has no marker; nothing would be killed)
+  test("readMarker returns MISSING for an ordinary codex-app-server node dir", () => {
+    // Simulate: a node exists (as a directory in nodesDir), but was NOT
+    // started with --copresence, so writeMarker was never called.
+    const nodeDir = join(tmpNodesDir, "ordinary-codex");
+    mkdirSync(nodeDir, { recursive: true, mode: 0o700 });
+    // Other node config files may exist here, but not copresence-identity.json.
+    writeFileSync(join(nodeDir, "config.json"), JSON.stringify({ runtime: "codex-app-server", copresence: false }), { mode: 0o600 });
+    const r = readMarker(tmpNodesDir, "ordinary-codex");
+    expect(r.kind).toBe("refuse");
+    if (r.kind === "refuse") expect(r.cause).toBe("MISSING");
+    // The stop-command gate MUST short-circuit here to the legacy path.
+    // Any code that reads the config's `runtime` field and forces the
+    // new path for `codex-app-server` breaks the zero-diff invariant.
+  });
+});
+
+// ─── Test 11: idempotent 二次 stop ──────────────────────────────────────
+
+describe("Test 11: 二次 stop is idempotent (MISSING = already stopped)", () => {
+  // MUTATION CASES:
+  //   - Any 2nd-stop path that tries to "clean up residuals" on missing
+  //     marker → RED (must be a no-op)
+  //   - Any 2nd stop that emits a warning implying failure → RED (caller
+  //     must treat MISSING as clean state)
+  test("2nd read after successful removeMarker returns MISSING (no side effects)", () => {
+    const uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    writeMarker(tmpNodesDir, "n1", uuid, makeSessions());
+    // Simulate a successful stop path: caller removes the marker.
+    removeMarker(tmpNodesDir, "n1");
+    // 2nd stop attempt reads → MISSING.
+    const r1 = readMarker(tmpNodesDir, "n1");
+    expect(r1.kind).toBe("refuse");
+    if (r1.kind === "refuse") expect(r1.cause).toBe("MISSING");
+    // 3rd, 4th ... all identical.
+    const r2 = readMarker(tmpNodesDir, "n1");
+    expect(r2.kind).toBe("refuse");
+    if (r2.kind === "refuse") expect(r2.cause).toBe("MISSING");
+  });
+
+  test("removeMarker on already-missing marker does not throw", () => {
+    // Idempotency at the primitive level.
+    expect(() => removeMarker(tmpNodesDir, "never-existed")).not.toThrow();
+  });
+});
+
+// ─── Reap orchestration integration (glue test for the reap flow) ────────
+
+describe("reapMarkerGroups: end-to-end (mocked /proc + kill)", () => {
+  test("verified groups get SIGTERM, still-alive groups then get SIGKILL", () => {
+    const enumer = new MockEnumer();
+    const killer = new MockKiller();
+    // Two groups, all homogeneous with marker
+    enumer.add(100, "ANET_NODE_MARKER=u1\0", 100);
+    enumer.add(200, "ANET_NODE_MARKER=u1\0", 200);
+    // First group exits on TERM; second doesn't (needs KILL)
+    killer.aliveMap.set(100, false); // exited after TERM
+    killer.aliveMap.set(200, true);  // still alive after TERM
+    const logs: string[] = [];
+    // After we escalate, simulate that group 200 also dies.
+    // But before SIGKILL, re-verify happens; group must still be homogeneous.
+    // (Post-KILL scan sees no residual because we clear procs.)
+    const originalTerm = killer.killPgroup.bind(killer);
+    killer.killPgroup = (pgid, sig) => {
+      originalTerm(pgid, sig);
+      if (sig === "KILL") {
+        // Simulate everyone dying on KILL.
+        enumer.procs.delete(100); enumer.procs.delete(200);
+      }
+    };
+    const result = reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: (m) => logs.push(m) });
+    // SIGTERM sent to both, SIGKILL sent to 200 only.
+    const sigs = killer.signals;
+    expect(sigs.some(s => s.pgid === 100 && s.signal === "TERM")).toBe(true);
+    expect(sigs.some(s => s.pgid === 200 && s.signal === "TERM")).toBe(true);
+    expect(sigs.some(s => s.pgid === 200 && s.signal === "KILL")).toBe(true);
+    // 100 should NOT get KILL (it exited on TERM).
+    expect(sigs.some(s => s.pgid === 100 && s.signal === "KILL")).toBe(false);
+    expect(result.kind).toBe("success");
+  });
+
+  test("groups with foreign members are SKIPPED, never signaled", () => {
+    const enumer = new MockEnumer();
+    const killer = new MockKiller();
+    // Marker in pgid=100, plus a foreign process also in pgid=100
+    enumer.add(100, "ANET_NODE_MARKER=u1\0", 100);
+    enumer.add(101, "PATH=/\0", 100); // foreign co-resident
+    // Clean group in pgid=200
+    enumer.add(200, "ANET_NODE_MARKER=u1\0", 200);
+    killer.aliveMap.set(200, false);
+    const originalKill = killer.killPgroup.bind(killer);
+    killer.killPgroup = (pgid, sig) => { originalKill(pgid, sig); };
+    const logs: string[] = [];
+    const result = reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: (m) => logs.push(m) });
+    // No signal EVER to pgid 100 (it had a foreign member).
+    expect(killer.signals.some(s => s.pgid === 100)).toBe(false);
+    // Signal(s) to pgid 200 (clean group).
+    expect(killer.signals.some(s => s.pgid === 200 && s.signal === "TERM")).toBe(true);
+    // Result records that some was skipped and pid 100 is residual.
+    expect(result.kind).toBe("failed");
+    if (result.kind === "failed") {
+      expect(result.skippedGroups.some(g => g.pgid === 100)).toBe(true);
+      expect(result.residualPids).toContain(100);
+    }
+  });
+
+  test("no marker-carrying pids anywhere → immediate success (idempotent)", () => {
+    const enumer = new MockEnumer();
+    const killer = new MockKiller();
+    const result = reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: () => {} });
+    expect(result.kind).toBe("success");
+    expect(killer.signals.length).toBe(0);
+  });
+});

--- a/agent-network/src/copresence-identity.test.ts
+++ b/agent-network/src/copresence-identity.test.ts
@@ -28,6 +28,11 @@ import {
   callerCarriesMarker,
   reapMarkerGroups,
   realKiller,
+  prepareIdentityForStart,
+  type PrepareStartDeps,
+  type ReadMarkerResult,
+  type ReapResult,
+  type ScanAnchors,
   type ProcessEnumerator,
   type KillPrimitive,
   type CopresenceMarker,
@@ -716,30 +721,135 @@ describe("Blocker 1: scanEnvironForMarker EACCES discrimination", () => {
     expect(result).toEqual([9999]);
   });
 
-  test("Defect A defense: own-uid running EACCES records unreadable pid → reap refuses to delete marker", async () => {
-    // Real-world calibration (audit + practical Linux behavior 2026-07-29):
+  test("Defect A defense: own-uid EACCES pid IN SCOPE (anchored) → reap refuses to delete marker", async () => {
     // Rather than throwing (which crashed the whole scan on random system
     // processes like sd-pam, docker daemons, systemd-oomd), scan RECORDS
-    // the pid as "unreadable own-uid" and continues. reapMarkerGroups treats
-    // ANY unreadable-own-uid pid as "cannot prove teardown succeeded" and
-    // returns kind:"failed" (preserving the marker file for retry). This
-    // maintains Defect A defense WITHOUT crashing on unrelated system procs.
+    // the pid as unreadable and continues. reapMarkerGroups treats an
+    // IN-SCOPE unreadable pid as "cannot prove teardown succeeded" and
+    // returns kind:"failed" (preserving the marker file for retry).
+    //
+    // Blocker 1 refinement: "in scope" is now load-bearing. Here the
+    // unreadable pid is a child of a validated marker-file session pid, so
+    // it is plausibly part of our tree and MUST fail closed. The companion
+    // test below covers the same pid with no anchor — that one must NOT
+    // block teardown, which is what made v2 unusable on real hosts.
     const enumer = new MockEnumer();
     const killer = new MockKiller();
-    // A process that: is ours, is running, but its environ returns EACCES.
-    // With NO marker-carrying pids visible, scan would return hits=0 but
-    // unreadableOwnUid=[500] — reap must NOT report success.
-    enumer.add(500, "ANET_NODE_MARKER=u1\0", 500, 0, 1, { ownerUid: process.getuid?.() ?? -1, state: "S" });
+    const ourUid = process.getuid?.() ?? -1;
+    // 400 = recorded appsrv pane pid, still alive with the recorded starttime.
+    enumer.add(400, "ANET_NODE_MARKER=u1\0", 400, 777, 1, { ownerUid: ourUid, state: "S" });
+    enumer.environErrs.set(400, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    // 500 = its child; own uid, running, environ unreadable.
+    enumer.add(500, "ANET_NODE_MARKER=u1\0", 500, 0, 400, { ownerUid: ourUid, state: "S" });
     enumer.environErrs.set(500, Object.assign(new Error("EACCES"), { code: "EACCES" }));
-    // Sanity: scan sees the unreadable
-    const scan = scanEnvironForMarkerFull(enumer, "u1");
+    const anchors = { sessions: [{ pid: 400, starttime_jiffies: 777 }] };
+    const scan = scanEnvironForMarkerFull(enumer, "u1", anchors);
     expect(scan.hits.length).toBe(0);
-    expect(scan.unreadableOwnUid).toEqual([500]);
+    expect(scan.unreadableOwnUid.sort()).toEqual([400, 500]);
+    expect(scan.unreadableOutOfScope).toEqual([]);
     // Reap must refuse:
-    const result = await reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: () => {} });
+    const result = await reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: () => {}, anchors });
     expect(result.kind).toBe("failed");
     if (result.kind === "failed") {
-      expect(result.unreadableOwnUid).toEqual([500]);
+      expect(result.unreadableOwnUid?.sort()).toEqual([400, 500]);
+    }
+  });
+
+  test("Blocker 1: own-uid EACCES pid OUT OF SCOPE → informational only, teardown still succeeds", async () => {
+    // This is the defect that made v2 100% non-functional on a normal Linux
+    // host: a same-uid process whose PRIMARY GID differs from ours fails the
+    // kernel's __ptrace_may_access gid check, so its environ EACCESes even
+    // though its real uid matches. v2 put it on the fail-closed list, so
+    // reapMarkerGroups could never return success, the marker was never
+    // removed, and every single stop printed "teardown incomplete" — even
+    // when the copresence tree was already perfectly clean.
+    const enumer = new MockEnumer();
+    const killer = new MockKiller();
+    const ourUid = process.getuid?.() ?? -1;
+    // Unrelated same-uid process: own pgroup, ppid=1, no anchor above it.
+    enumer.add(8888, "SOMETHING_ELSE=1\0", 8888, 0, 1, { ownerUid: ourUid, state: "S" });
+    enumer.environErrs.set(8888, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const scan = scanEnvironForMarkerFull(enumer, "u1");
+    expect(scan.hits).toEqual([]);
+    expect(scan.unreadableOwnUid).toEqual([]);
+    expect(scan.unreadableOutOfScope).toEqual([8888]);
+    const result = await reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: () => {} });
+    expect(result.kind).toBe("success");
+  });
+
+  test("Blocker 1: unreadable pid sharing a marker carrier's PGROUP is in scope (no anchors needed)", () => {
+    const enumer = new MockEnumer();
+    const ourUid = process.getuid?.() ?? -1;
+    // 700 carries the marker and is readable → a hit, pgid 700.
+    enumer.add(700, "ANET_NODE_MARKER=u1\0", 700, 0, 1, { ownerUid: ourUid, state: "S" });
+    // 701 shares pgid 700 but its environ is unreadable → in scope via pgid.
+    enumer.add(701, "ANET_NODE_MARKER=u1\0", 700, 0, 700, { ownerUid: ourUid, state: "S" });
+    enumer.environErrs.set(701, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    // 900 is unrelated and unreadable → out of scope.
+    enumer.add(900, "OTHER=1\0", 900, 0, 1, { ownerUid: ourUid, state: "S" });
+    enumer.environErrs.set(900, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const scan = scanEnvironForMarkerFull(enumer, "u1");
+    expect(scan.hits).toEqual([700]);
+    expect(scan.unreadableOwnUid).toEqual([701]);
+    expect(scan.unreadableOutOfScope).toEqual([900]);
+  });
+
+  test("Blocker 8/invariant 5: an anchor whose starttime no longer matches is REJECTED (pid reuse)", () => {
+    // The header promised a starttime re-verification for years and the code
+    // never did one — SessionInfo.starttime_jiffies was written and never
+    // read. It is now the gate that stops a stale marker from widening the
+    // fail-closed scope onto whatever unrelated process inherited the pid.
+    const enumer = new MockEnumer();
+    const ourUid = process.getuid?.() ?? -1;
+    // pid 400 exists but with a DIFFERENT starttime than the marker recorded
+    // → recycled pid → must not anchor anything.
+    enumer.add(400, "SOMETHING_ELSE=1\0", 400, /* starttime */ 999, 1, { ownerUid: ourUid, state: "S" });
+    enumer.add(500, "ANET_NODE_MARKER=u1\0", 500, 0, 400, { ownerUid: ourUid, state: "S" });
+    enumer.environErrs.set(500, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const stale = { sessions: [{ pid: 400, starttime_jiffies: 777 }] };
+    const withStale = scanEnvironForMarkerFull(enumer, "u1", stale);
+    expect(withStale.unreadableOwnUid).toEqual([]);
+    expect(withStale.unreadableOutOfScope).toEqual([500]);
+    // Same anchor pid, matching starttime → accepted, 500 becomes in-scope.
+    const fresh = { sessions: [{ pid: 400, starttime_jiffies: 999 }] };
+    const withFresh = scanEnvironForMarkerFull(enumer, "u1", fresh);
+    expect(withFresh.unreadableOwnUid).toEqual([500]);
+    expect(withFresh.unreadableOutOfScope).toEqual([]);
+  });
+
+  test("Blocker 7: post-kill RESCAN unreadable half also preserves the marker", async () => {
+    // reapMarkerGroups' final gate is
+    //   `residual.length > 0 || rescan.unreadableOwnUid.length > 0`
+    // and the audit proved the second half was dead: rewriting it to
+    // `residual.length > 0` left 52/52 tests green. This test covers it.
+    const enumer = new MockEnumer();
+    const killer = new MockKiller();
+    const ourUid = process.getuid?.() ?? -1;
+    // 400 = live anchor (recorded pane pid, matching starttime).
+    enumer.add(400, "ANET_NODE_MARKER=u1\0", 400, 777, 1, { ownerUid: ourUid, state: "S" });
+    // 500 = readable marker carrier in its own pgroup — this one gets killed.
+    enumer.add(500, "ANET_NODE_MARKER=u1\0", 500, 0, 400, { ownerUid: ourUid, state: "S" });
+    const anchors = { sessions: [{ pid: 400, starttime_jiffies: 777 }] };
+    killer.aliveMap.set(500, false); // exits on SIGTERM
+    const logs: string[] = [];
+    const result = await reapMarkerGroups(enumer, killer, "u1", {
+      graceMs: 0,
+      logger: (m) => logs.push(m),
+      anchors,
+      // Between the kill and the post-rescan, pid 400 (still alive, still an
+      // anchor) becomes environ-unreadable — e.g. it re-execs into a
+      // non-dumpable state. residual hits are 0, so ONLY the rescan's
+      // unreadable half can catch it.
+      sleep: async () => {
+        enumer.procs.delete(500);
+        enumer.environErrs.set(400, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+      },
+    });
+    expect(result.kind).toBe("failed");
+    if (result.kind === "failed") {
+      expect(result.residualPids).toEqual([]);
+      expect(result.unreadableOwnUid).toEqual([400]);
+      expect(result.detail).toContain("unreadable");
     }
   });
 
@@ -908,5 +1018,225 @@ describe("Finding #4: writeMarker accepts partial sessions object", () => {
     const r = readMarker(tmpNodesDir, "no-sessions-node");
     expect(r.kind).toBe("ok");
     if (r.kind === "ok") expect(r.marker.marker).toBe(uuid);
+  });
+});
+
+// ─── Blocker 3: group-level unreadable must not couple to the whole box ───
+
+describe("Blocker 3: verifyGroupHomogeneity stat-unreadable pids are bounded by ownership", () => {
+  // v2 pushed EVERY pid whose /proc/PID/stat read threw onto the `unreadable`
+  // list BEFORE applying the pgid filter. One unrelated process anywhere on
+  // the machine with a hidden stat (hidepid, LSM, container policy) therefore
+  // turned EVERY group into ENUM_ERROR — nothing was ever killed, on any
+  // node, for as long as that process lived.
+
+  test("an unrelated OTHER-uid pid whose stat is unreadable does NOT poison the group", () => {
+    const enumer = new MockEnumer();
+    const ourUid = process.getuid?.() ?? -1;
+    enumer.add(700, "ANET_NODE_MARKER=u1\0", 700, 0, 1, { ownerUid: ourUid, state: "S" });
+    // Unrelated root process hidden from us: stat read throws, uid is not ours.
+    enumer.add(31337, "OTHER=1\0", 31337, 0, 1, { ownerUid: 0, state: "S" });
+    enumer.statErrs.set(31337, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const result = verifyGroupHomogeneity(enumer, 700, "u1");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.members).toEqual([700]);
+  });
+
+  test("a pid hidden so thoroughly that even its uid is unknown does NOT poison the group", () => {
+    const enumer = new MockEnumer();
+    const ourUid = process.getuid?.() ?? -1;
+    enumer.add(700, "ANET_NODE_MARKER=u1\0", 700, 0, 1, { ownerUid: ourUid, state: "S" });
+    // listAllPids reports it, but nothing about it is readable (hidepid=2).
+    const base = enumer.listAllPids.bind(enumer);
+    enumer.listAllPids = () => [...base(), 41337];
+    enumer.statErrs.set(41337, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const result = verifyGroupHomogeneity(enumer, 700, "u1");
+    expect(result.ok).toBe(true);
+  });
+
+  test("an OWN-uid pid whose stat is unreadable still fails closed (we cannot rule out membership)", () => {
+    const enumer = new MockEnumer();
+    const ourUid = process.getuid?.() ?? -1;
+    enumer.add(700, "ANET_NODE_MARKER=u1\0", 700, 0, 1, { ownerUid: ourUid, state: "S" });
+    enumer.add(701, "ANET_NODE_MARKER=u1\0", 700, 0, 700, { ownerUid: ourUid, state: "S" });
+    enumer.statErrs.set(701, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const result = verifyGroupHomogeneity(enumer, 700, "u1");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.cause).toBe("ENUM_ERROR");
+      expect(result.unreadablePids).toEqual([701]);
+    }
+  });
+});
+
+// ─── Blocker 4: MISSING wins over PLATFORM_UNSUPPORTED ───────────────────
+
+describe("Blocker 4: readMarker checks MISSING before PLATFORM_UNSUPPORTED", () => {
+  // The stop caller treats every cause except MISSING as "a marker exists
+  // but we refused it" and prints a loud corruption warning. v2 returned
+  // PLATFORM_UNSUPPORTED before touching the filesystem, so on macOS and
+  // Windows EVERY node of EVERY runtime — none of which have ever had a
+  // marker file — printed that warning on `anet node stop`. A user-visible
+  // regression against the pre-P3 baseline for people who never used
+  // copresence at all.
+  const withPlatform = <T,>(platform: string, fn: () => T): T => {
+    const original = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    try { return fn(); } finally { Object.defineProperty(process, "platform", original); }
+  };
+
+  test("non-Linux + NO marker file → MISSING (silent legacy fall-through, no scary warning)", () => {
+    for (const platform of ["darwin", "win32"]) {
+      const r = withPlatform(platform, () => readMarker(tmpNodesDir, "node-without-marker"));
+      expect(r.kind).toBe("refuse");
+      if (r.kind === "refuse") expect(r.cause).toBe("MISSING");
+    }
+  });
+
+  test("non-Linux + marker file present → PLATFORM_UNSUPPORTED (we genuinely cannot act on it)", () => {
+    writeMarker(tmpNodesDir, "node-with-marker", "some-uuid", {});
+    for (const platform of ["darwin", "win32"]) {
+      const r = withPlatform(platform, () => readMarker(tmpNodesDir, "node-with-marker"));
+      expect(r.kind).toBe("refuse");
+      if (r.kind === "refuse") expect(r.cause).toBe("PLATFORM_UNSUPPORTED");
+    }
+  });
+});
+
+// ─── Blockers 5 + 6: start-side identity preparation ─────────────────────
+
+describe("Blockers 5+6: prepareIdentityForStart", () => {
+  const ourUid = process.getuid?.() ?? -1;
+
+  interface Recorder {
+    deps: PrepareStartDeps;
+    written: Array<{ uuid: string; sessions: CopresenceMarker["sessions"] }>;
+    removed: number;
+    reaped: Array<{ uuid: string; anchors: ScanAnchors }>;
+    log: string[];
+  }
+
+  function recorder(opts: {
+    read: () => ReadMarkerResult;
+    reapResult?: ReapResult;
+  }): Recorder {
+    const written: Recorder["written"] = [];
+    const reaped: Recorder["reaped"] = [];
+    const log: string[] = [];
+    let removed = 0;
+    const rec = {
+      written, reaped, log,
+      get removed() { return removed; },
+      deps: {
+        readMarker: opts.read,
+        reap: async (uuid: string, anchors: ScanAnchors) => {
+          reaped.push({ uuid, anchors });
+          return opts.reapResult ?? { kind: "success", killedPgids: [], residualPids: [] };
+        },
+        removeMarker: () => { removed++; },
+        writeMarker: (uuid: string, sessions: CopresenceMarker["sessions"]) => { written.push({ uuid, sessions }); },
+        logger: (m: string) => log.push(m),
+      } as PrepareStartDeps,
+    };
+    return rec as Recorder;
+  }
+
+  test("no marker on disk → writes the new marker, reaps nothing", async () => {
+    const rec = recorder({ read: () => ({ kind: "refuse", cause: "MISSING", detail: "none" }) });
+    const result = await prepareIdentityForStart("new-uuid", rec.deps);
+    expect(result.kind).toBe("ok");
+    expect(rec.reaped).toEqual([]);
+    expect(rec.written.length).toBe(1);
+    expect(rec.written[0].uuid).toBe("new-uuid");
+  });
+
+  test("Blocker 6: a PRESERVED marker is reaped by its OWN uuid before the new one is written", async () => {
+    // The stop path deliberately preserves the marker when teardown could not
+    // be proven complete. v2's start then overwrote it with a fresh uuid
+    // while killing only tmux sessions BY NAME — the surviving subprocesses
+    // of the old generation kept running with an environ uuid that no longer
+    // existed anywhere on disk. Permanently unreclaimable.
+    const marker: CopresenceMarker = {
+      marker: "old-uuid",
+      boot_id: "b",
+      started_at_epoch_ms: 1,
+      owner_uid: ourUid,
+      sessions: { appsrv: makeSession({ pid: 4242, starttime_jiffies: 777 }) },
+    };
+    const rec = recorder({ read: () => ({ kind: "ok", marker }) });
+    const result = await prepareIdentityForStart("new-uuid", rec.deps);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") expect(result.reclaimedUuid).toBe("old-uuid");
+    // Reaped the OLD uuid, with the marker's recorded pane pid as scope anchor.
+    expect(rec.reaped.length).toBe(1);
+    expect(rec.reaped[0].uuid).toBe("old-uuid");
+    expect(rec.reaped[0].anchors.sessions).toEqual([{ pid: 4242, starttime_jiffies: 777 }]);
+    expect(rec.removed).toBe(1);
+    expect(rec.written.map((w) => w.uuid)).toEqual(["new-uuid"]);
+  });
+
+  test("Blocker 6: if the old generation cannot be reaped, start is BLOCKED and nothing is overwritten", async () => {
+    const marker: CopresenceMarker = {
+      marker: "old-uuid",
+      boot_id: "b",
+      started_at_epoch_ms: 1,
+      owner_uid: ourUid,
+      sessions: {},
+    };
+    const rec = recorder({
+      read: () => ({ kind: "ok", marker }),
+      reapResult: {
+        kind: "failed",
+        killedPgids: [],
+        residualPids: [4242],
+        skippedGroups: [],
+        detail: "1 marker-carrying pid(s) still alive",
+      },
+    });
+    const result = await prepareIdentityForStart("new-uuid", rec.deps);
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") {
+      expect(result.cause).toBe("STALE_TREE_ALIVE");
+      expect(result.detail).toContain("old-uuid".slice(0, 8));
+    }
+    // The critical assertion: the old identity is still the one on disk.
+    expect(rec.written).toEqual([]);
+    expect(rec.removed).toBe(0);
+  });
+
+  test("a marker from a previous BOOT is discarded without a reap (its pids cannot exist)", async () => {
+    const rec = recorder({ read: () => ({ kind: "refuse", cause: "STALE_BOOT_ID", detail: "rebooted" }) });
+    const result = await prepareIdentityForStart("new-uuid", rec.deps);
+    expect(result.kind).toBe("ok");
+    expect(rec.reaped).toEqual([]);
+    expect(rec.removed).toBe(1);
+    expect(rec.written.map((w) => w.uuid)).toEqual(["new-uuid"]);
+  });
+
+  test("an unreadable/suspicious marker BLOCKS start rather than overwriting it", async () => {
+    for (const cause of ["SYMLINK", "NOT_REGULAR", "WRONG_MODE", "OWNER_MISMATCH", "PARSE_ERROR", "SCHEMA_INVALID", "PLATFORM_UNSUPPORTED"] as const) {
+      const rec = recorder({ read: () => ({ kind: "refuse", cause, detail: `d-${cause}` }) });
+      const result = await prepareIdentityForStart("new-uuid", rec.deps);
+      expect(result.kind).toBe("blocked");
+      if (result.kind === "blocked") expect(result.cause).toBe("UNUSABLE_MARKER");
+      expect(rec.written).toEqual([]);
+      expect(rec.removed).toBe(0);
+    }
+  });
+
+  test("Blocker 5: the marker is written with an EMPTY sessions object (before any session exists)", async () => {
+    // Ordering is the whole point: the file must be on disk before the first
+    // marker-carrying tmux session is created, so there is no window in which
+    // a live carrier exists with no marker file. That means there are no pane
+    // pids to record yet — and there must not need to be, because identity is
+    // the uuid alone.
+    const rec = recorder({ read: () => ({ kind: "refuse", cause: "MISSING", detail: "none" }) });
+    await prepareIdentityForStart("new-uuid", rec.deps);
+    expect(rec.written[0].sessions).toEqual({});
+  });
+
+  test("refuses an empty uuid (guards against a silently regenerated identity)", async () => {
+    const rec = recorder({ read: () => ({ kind: "refuse", cause: "MISSING", detail: "none" }) });
+    await expect(prepareIdentityForStart("", rec.deps)).rejects.toThrow();
   });
 });

--- a/agent-network/src/copresence-identity.test.ts
+++ b/agent-network/src/copresence-identity.test.ts
@@ -22,11 +22,12 @@ import {
   removeMarker,
   markerFilePath,
   scanEnvironForMarker,
+  scanEnvironForMarkerFull,
   groupPidsByPgid,
   verifyGroupHomogeneity,
   callerCarriesMarker,
-  sessionStillFresh,
   reapMarkerGroups,
+  realKiller,
   type ProcessEnumerator,
   type KillPrimitive,
   type CopresenceMarker,
@@ -66,10 +67,11 @@ function makeSessions(): CopresenceMarker["sessions"] {
 
 /** In-memory ProcessEnumerator for tests. */
 class MockEnumer implements ProcessEnumerator {
-  procs = new Map<number, { environ: string; stat: { pgid: number; starttime_jiffies: number; ppid: number } }>();
+  procs = new Map<number, { environ: string; stat: { pgid: number; starttime_jiffies: number; ppid: number }; ownerUid?: number; state?: string }>();
   listErr: Error | null = null;
   environErrs = new Map<number, Error>();
   statErrs = new Map<number, Error>();
+  defaultOwnerUid: number = process.getuid ? process.getuid()! : -1;
 
   listAllPids(): number[] {
     if (this.listErr) throw this.listErr;
@@ -87,8 +89,23 @@ class MockEnumer implements ProcessEnumerator {
     const p = this.procs.get(pid);
     return p ? { ...p.stat } : null;
   }
-  add(pid: number, environ: string, pgid: number, starttime = 0, ppid = 1) {
-    this.procs.set(pid, { environ, stat: { pgid, starttime_jiffies: starttime, ppid } });
+  readOwnerUid(pid: number): number | null {
+    const p = this.procs.get(pid);
+    if (!p) return null;
+    return p.ownerUid ?? this.defaultOwnerUid;
+  }
+  readState(pid: number): string | null {
+    const p = this.procs.get(pid);
+    if (!p) return null;
+    return p.state ?? "S"; // default = sleeping (normal running)
+  }
+  add(pid: number, environ: string, pgid: number, starttime = 0, ppid = 1, opts: { ownerUid?: number; state?: string } = {}) {
+    this.procs.set(pid, {
+      environ,
+      stat: { pgid, starttime_jiffies: starttime, ppid },
+      ownerUid: opts.ownerUid,
+      state: opts.state,
+    });
   }
 }
 
@@ -265,32 +282,30 @@ describe("Test 5: child setsid → new PGID", () => {
   });
 });
 
-// ─── Test 6: PID reuse ──────────────────────────────────────────────────
-
-describe("Test 6: PID reuse via starttime mismatch", () => {
-  // MUTATION CASES:
-  //   - Skipping the starttime check → stale marker pid would match a
-  //     recycled unrelated pid → this test MUST RED
-  //   - Also see boot_id check in Test 8 (readMarker's STALE_BOOT_ID path)
-  test("sessionStillFresh returns false when starttime doesn't match", () => {
+// ─── Test 6: PID reuse (boot_id defense via readMarker) ─────────────────
+//
+// Original Test 6 covered `sessionStillFresh` — that function was deleted
+// per audit 92d53c8f finding #1 (zero production call sites, gave the tests
+// false coverage). PID-reuse defense in practice is:
+//   - The boot_id check in readMarker (STALE_BOOT_ID refuse) — after host
+//     reboot, every stale marker's pids are unrelated → readMarker refuses
+//     the whole thing before reap even starts. Covered by Test 8b's
+//     STALE_BOOT_ID test.
+//   - The environ-scan-is-truth rule — reap NEVER looks at marker.sessions.*
+//     .pid to decide what to kill. Only /proc/*/environ matching the uuid.
+//     A stale recycled pid can't carry our uuid (it's a fresh process's
+//     environ). Covered by Test 4 (main-dead-child-alive) which proves
+//     the reap flow doesn't trust marker's stored pids at all.
+describe("Test 6: PID-reuse defense is the boot_id + environ-scan invariant", () => {
+  test("environ scan only returns pids whose current environ carries the uuid", () => {
+    // Simulate: marker file previously recorded pid=100 as a session pid.
+    // Now pid=100 has been recycled to an unrelated process (different environ).
     const enumer = new MockEnumer();
-    // Marker recorded pid=100 starttime=500. Current /proc/100 has different starttime.
-    enumer.add(100, "PATH=/\0", 100, /* starttime */ 999);
-    const session: SessionInfo = { tmux: "t", pid: 100, pgid: 100, starttime_jiffies: 500 };
-    expect(sessionStillFresh(enumer, session)).toBe(false);
-  });
-
-  test("sessionStillFresh returns true when starttime matches", () => {
-    const enumer = new MockEnumer();
-    enumer.add(100, "PATH=/\0", 100, 500);
-    const session: SessionInfo = { tmux: "t", pid: 100, pgid: 100, starttime_jiffies: 500 };
-    expect(sessionStillFresh(enumer, session)).toBe(true);
-  });
-
-  test("sessionStillFresh returns false when pid gone (ENOENT)", () => {
-    const enumer = new MockEnumer();
-    const session: SessionInfo = { tmux: "t", pid: 100, pgid: 100, starttime_jiffies: 500 };
-    expect(sessionStillFresh(enumer, session)).toBe(false);
+    enumer.add(100, "PATH=/\0OLDER_PROC=1\0", 500);
+    // No marker anywhere → scan returns nothing. Recycled pid is never
+    // touched by the reap flow because it doesn't carry our uuid.
+    const found = scanEnvironForMarker(enumer, "u1-that-does-not-exist-anywhere");
+    expect(found).toEqual([]);
   });
 });
 
@@ -621,56 +636,43 @@ describe("Test 11: 二次 stop is idempotent (MISSING = already stopped)", () =>
 // ─── Reap orchestration integration (glue test for the reap flow) ────────
 
 describe("reapMarkerGroups: end-to-end (mocked /proc + kill)", () => {
-  test("verified groups get SIGTERM, still-alive groups then get SIGKILL", () => {
+  test("verified groups get SIGTERM, still-alive groups then get SIGKILL", async () => {
     const enumer = new MockEnumer();
     const killer = new MockKiller();
-    // Two groups, all homogeneous with marker
     enumer.add(100, "ANET_NODE_MARKER=u1\0", 100);
     enumer.add(200, "ANET_NODE_MARKER=u1\0", 200);
-    // First group exits on TERM; second doesn't (needs KILL)
     killer.aliveMap.set(100, false); // exited after TERM
     killer.aliveMap.set(200, true);  // still alive after TERM
     const logs: string[] = [];
-    // After we escalate, simulate that group 200 also dies.
-    // But before SIGKILL, re-verify happens; group must still be homogeneous.
-    // (Post-KILL scan sees no residual because we clear procs.)
     const originalTerm = killer.killPgroup.bind(killer);
     killer.killPgroup = (pgid, sig) => {
       originalTerm(pgid, sig);
       if (sig === "KILL") {
-        // Simulate everyone dying on KILL.
         enumer.procs.delete(100); enumer.procs.delete(200);
       }
     };
-    const result = reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: (m) => logs.push(m) });
-    // SIGTERM sent to both, SIGKILL sent to 200 only.
+    const result = await reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: (m) => logs.push(m) });
     const sigs = killer.signals;
     expect(sigs.some(s => s.pgid === 100 && s.signal === "TERM")).toBe(true);
     expect(sigs.some(s => s.pgid === 200 && s.signal === "TERM")).toBe(true);
     expect(sigs.some(s => s.pgid === 200 && s.signal === "KILL")).toBe(true);
-    // 100 should NOT get KILL (it exited on TERM).
     expect(sigs.some(s => s.pgid === 100 && s.signal === "KILL")).toBe(false);
     expect(result.kind).toBe("success");
   });
 
-  test("groups with foreign members are SKIPPED, never signaled", () => {
+  test("groups with foreign members are SKIPPED, never signaled", async () => {
     const enumer = new MockEnumer();
     const killer = new MockKiller();
-    // Marker in pgid=100, plus a foreign process also in pgid=100
     enumer.add(100, "ANET_NODE_MARKER=u1\0", 100);
     enumer.add(101, "PATH=/\0", 100); // foreign co-resident
-    // Clean group in pgid=200
     enumer.add(200, "ANET_NODE_MARKER=u1\0", 200);
     killer.aliveMap.set(200, false);
     const originalKill = killer.killPgroup.bind(killer);
     killer.killPgroup = (pgid, sig) => { originalKill(pgid, sig); };
     const logs: string[] = [];
-    const result = reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: (m) => logs.push(m) });
-    // No signal EVER to pgid 100 (it had a foreign member).
+    const result = await reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: (m) => logs.push(m) });
     expect(killer.signals.some(s => s.pgid === 100)).toBe(false);
-    // Signal(s) to pgid 200 (clean group).
     expect(killer.signals.some(s => s.pgid === 200 && s.signal === "TERM")).toBe(true);
-    // Result records that some was skipped and pid 100 is residual.
     expect(result.kind).toBe("failed");
     if (result.kind === "failed") {
       expect(result.skippedGroups.some(g => g.pgid === 100)).toBe(true);
@@ -678,11 +680,233 @@ describe("reapMarkerGroups: end-to-end (mocked /proc + kill)", () => {
     }
   });
 
-  test("no marker-carrying pids anywhere → immediate success (idempotent)", () => {
+  test("no marker-carrying pids anywhere → immediate success (idempotent)", async () => {
     const enumer = new MockEnumer();
     const killer = new MockKiller();
-    const result = reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: () => {} });
+    const result = await reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: () => {} });
     expect(result.kind).toBe("success");
     expect(killer.signals.length).toBe(0);
+  });
+});
+
+// ─── Finding tests (audit 92d53c8f 2 blockers + 9 finds) ────────────────
+
+describe("Blocker 1: scanEnvironForMarker EACCES discrimination", () => {
+  // Root cause of the审 blocker: /proc/1/environ (root pid=1) is 0400 → EACCES.
+  // Without discrimination, scanEnvironForMarker crashes on the first
+  // non-own-uid process it hits and the whole identity flow falls back to
+  // the legacy tmux-name sweep (i.e. this whole feature never actually runs).
+  //
+  // MUTATION CASES (通信龙 will attempt):
+  //   - Change `if (ownerUid !== ownUid) continue` → `throw err` : test #1 RED
+  //   - Change `if (state === "Z") continue` → `throw err` : test #3 RED
+  //   - Remove the discriminator entirely (revert to naive `throw err`) : both RED
+  //   - Change to blind `catch { continue }` (recreates Defect A) : test #4 RED
+  //     (marker-carrying own-uid live proc with unexplained EACCES must NOT
+  //     be silently missed)
+
+  test("other-user EACCES on environ → skip that pid (expected, not fail)", () => {
+    const enumer = new MockEnumer();
+    // pid 1 = systemd/root; own-uid discriminator says "not ours, skip"
+    enumer.add(1, "IGNORED\0", 1, 0, 0, { ownerUid: 0, state: "S" });
+    enumer.environErrs.set(1, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    // Our own pid carrying the marker
+    enumer.add(9999, "ANET_NODE_MARKER=u1\0", 999);
+    const result = scanEnvironForMarker(enumer, "u1");
+    expect(result).toEqual([9999]);
+  });
+
+  test("Defect A defense: own-uid running EACCES records unreadable pid → reap refuses to delete marker", async () => {
+    // Real-world calibration (audit + practical Linux behavior 2026-07-29):
+    // Rather than throwing (which crashed the whole scan on random system
+    // processes like sd-pam, docker daemons, systemd-oomd), scan RECORDS
+    // the pid as "unreadable own-uid" and continues. reapMarkerGroups treats
+    // ANY unreadable-own-uid pid as "cannot prove teardown succeeded" and
+    // returns kind:"failed" (preserving the marker file for retry). This
+    // maintains Defect A defense WITHOUT crashing on unrelated system procs.
+    const enumer = new MockEnumer();
+    const killer = new MockKiller();
+    // A process that: is ours, is running, but its environ returns EACCES.
+    // With NO marker-carrying pids visible, scan would return hits=0 but
+    // unreadableOwnUid=[500] — reap must NOT report success.
+    enumer.add(500, "ANET_NODE_MARKER=u1\0", 500, 0, 1, { ownerUid: process.getuid?.() ?? -1, state: "S" });
+    enumer.environErrs.set(500, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    // Sanity: scan sees the unreadable
+    const scan = scanEnvironForMarkerFull(enumer, "u1");
+    expect(scan.hits.length).toBe(0);
+    expect(scan.unreadableOwnUid).toEqual([500]);
+    // Reap must refuse:
+    const result = await reapMarkerGroups(enumer, killer, "u1", { graceMs: 0, logger: () => {} });
+    expect(result.kind).toBe("failed");
+    if (result.kind === "failed") {
+      expect(result.unreadableOwnUid).toEqual([500]);
+    }
+  });
+
+  test("zombie process environ EACCES → skip (mm freed, expected)", () => {
+    const enumer = new MockEnumer();
+    // Our own uid, but state=Z means zombie — mm freed, environ unreadable
+    enumer.add(500, "IGNORED\0", 500, 0, 1, { ownerUid: process.getuid?.() ?? -1, state: "Z" });
+    enumer.environErrs.set(500, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    // And a live one carrying the marker
+    enumer.add(600, "ANET_NODE_MARKER=u1\0", 600);
+    const result = scanEnvironForMarker(enumer, "u1");
+    expect(result).toEqual([600]);
+  });
+
+  test("EACCES-carrying process that vanishes during discrimination → skip", () => {
+    const enumer = new MockEnumer();
+    // The pid's ownerUid check returns null (pid gone between listAllPids and readOwnerUid)
+    // Simulated by not adding it to procs but having listAllPids return it.
+    const bumperPids = [1234];
+    const originalList = enumer.listAllPids.bind(enumer);
+    enumer.listAllPids = () => [...bumperPids, ...originalList()];
+    enumer.environErrs.set(1234, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    // readOwnerUid(1234) returns null because not in procs — treat as vanished, skip
+    const result = scanEnvironForMarker(enumer, "u1");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("Blocker 2: verifyGroupHomogeneity zombie discrimination + EMPTY_GROUP", () => {
+  // If verifyGroupHomogeneity treats a zombie same-uid member as "unreadable
+  // → ENUM_ERROR", the whole group gets skipped even though the zombie is
+  // dying and irrelevant. Post-SIGTERM re-verify is when zombies are most
+  // numerous → teardown never escalates → residual reported forever.
+
+  test("group containing a zombie same-uid member still verifies OK for the live marker members", () => {
+    const enumer = new MockEnumer();
+    // Live marker member
+    enumer.add(100, "ANET_NODE_MARKER=u1\0", 500, 0, 1, { ownerUid: process.getuid?.() ?? -1, state: "S" });
+    // Same-uid zombie in the same pgid — environ read returns EACCES
+    enumer.add(101, "IGNORED\0", 500, 0, 1, { ownerUid: process.getuid?.() ?? -1, state: "Z" });
+    enumer.environErrs.set(101, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const result = verifyGroupHomogeneity(enumer, 500, "u1");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.members).toEqual([100]);
+  });
+
+  test("group containing an other-user EACCES member still verifies OK for our members", () => {
+    const enumer = new MockEnumer();
+    enumer.add(100, "ANET_NODE_MARKER=u1\0", 500, 0, 1, { ownerUid: process.getuid?.() ?? -1 });
+    enumer.add(101, "IGNORED\0", 500, 0, 1, { ownerUid: 0 }); // root process co-resident
+    enumer.environErrs.set(101, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const result = verifyGroupHomogeneity(enumer, 500, "u1");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.members).toEqual([100]);
+  });
+
+  test("empty group (no live marker members) → EMPTY_GROUP refuse (never ok:true)", () => {
+    // Finding #6: empty-members judged ok:true was Defect B's shape.
+    const enumer = new MockEnumer();
+    // No processes at all in pgid=999
+    const result = verifyGroupHomogeneity(enumer, 999, "u1");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.cause).toBe("EMPTY_GROUP");
+  });
+
+  test("own-uid non-zombie unreadable → ENUM_ERROR (fail-closed)", () => {
+    const enumer = new MockEnumer();
+    enumer.add(100, "ANET_NODE_MARKER=u1\0", 500, 0, 1, { ownerUid: process.getuid?.() ?? -1 });
+    // Same-uid live process in group, environ unreadable for real reason
+    enumer.add(101, "IGNORED\0", 500, 0, 1, { ownerUid: process.getuid?.() ?? -1, state: "S" });
+    enumer.environErrs.set(101, Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    const result = verifyGroupHomogeneity(enumer, 500, "u1");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.cause).toBe("ENUM_ERROR");
+  });
+});
+
+describe("Finding #2: killPgroup pgid<=0 guard", () => {
+  test("realKiller().killPgroup(0, TERM) throws — kill(-0) would target caller's own pgroup", () => {
+    const kk = realKiller();
+    expect(() => kk.killPgroup(0, "TERM")).toThrow(/pgid must be > 0/);
+    expect(() => kk.killPgroup(-1, "TERM")).toThrow(/pgid must be > 0/);
+  });
+  test("realKiller().pgroupAlive(0) throws", () => {
+    const kk = realKiller();
+    expect(() => kk.pgroupAlive(0)).toThrow(/pgid must be > 0/);
+  });
+});
+
+describe("Finding #3: reapMarkerGroups uses async sleep (not busy-wait)", () => {
+  test("grace period is truly asynchronous — event loop ticks during it", async () => {
+    const enumer = new MockEnumer();
+    const killer = new MockKiller();
+    // Set up a group so we hit the sleep path.
+    enumer.add(100, "ANET_NODE_MARKER=u1\0", 100);
+    killer.aliveMap.set(100, false); // exits on TERM, so no KILL escalation
+    // Prove the event loop can process a setImmediate during the grace window.
+    // Busy-wait would block the loop and setImmediate would never fire.
+    let loopTicked = false;
+    const graceMs = 100;
+    const reapP = reapMarkerGroups(enumer, killer, "u1", { graceMs, logger: () => {} });
+    // Kick a microtask that requires event-loop turns.
+    setImmediate(() => { loopTicked = true; });
+    await reapP;
+    expect(loopTicked).toBe(true);
+  });
+
+  test("injected sleep function is used (tests can override with fast/deterministic version)", async () => {
+    const enumer = new MockEnumer();
+    const killer = new MockKiller();
+    enumer.add(100, "ANET_NODE_MARKER=u1\0", 100);
+    killer.aliveMap.set(100, false);
+    let sleepCalledWith = -1;
+    await reapMarkerGroups(enumer, killer, "u1", {
+      graceMs: 999,
+      logger: () => {},
+      sleep: async (ms) => { sleepCalledWith = ms; }, // completes immediately
+    });
+    expect(sleepCalledWith).toBe(999);
+  });
+});
+
+describe("Finding #7: readMarker PLATFORM_UNSUPPORTED on non-Linux", () => {
+  // On Linux the marker file path works as-designed; on Darwin/Windows the
+  // whole /proc-based identity flow is fundamentally not applicable. Rather
+  // than misreporting corruption on those platforms, refuse with clarity.
+  test("on non-Linux, readMarker refuses cleanly regardless of on-disk state", () => {
+    // Verify the behavior by checking the guard directly:
+    if (process.platform !== "linux") {
+      const r = readMarker(tmpNodesDir, "any-node");
+      expect(r.kind).toBe("refuse");
+      if (r.kind === "refuse") expect(r.cause).toBe("PLATFORM_UNSUPPORTED");
+    } else {
+      // On Linux the guard should NOT fire — writing then reading should work.
+      const uuid = "linux-platform-uuid";
+      writeMarker(tmpNodesDir, "linux-node", uuid, { appsrv: makeSession() });
+      const r = readMarker(tmpNodesDir, "linux-node");
+      expect(r.kind).toBe("ok");
+      // Guard code has been read/kept even on Linux; this test asserts the
+      // sibling code path (non-Linux) exists by symmetry.
+    }
+  });
+});
+
+describe("Finding #4: writeMarker accepts partial sessions object", () => {
+  // Prior gated on `if (appsrvMk && bridgeMk && tuiMk)`; one flaky tmux
+  // display-message → whole marker file skipped → node permanently loses
+  // identity teardown ability. Sessions are observability, marker uuid is
+  // identity truth. Fix: all sessions optional; only uuid + boot_id matter.
+  test("writeMarker with only appsrv session succeeds and readMarker returns ok", () => {
+    const uuid = "partial-sessions-uuid";
+    writeMarker(tmpNodesDir, "partial-node", uuid, { appsrv: makeSession() });
+    const r = readMarker(tmpNodesDir, "partial-node");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.marker.marker).toBe(uuid);
+      expect(r.marker.sessions.appsrv).toBeDefined();
+      expect(r.marker.sessions.bridge).toBeUndefined();
+      expect(r.marker.sessions.tui).toBeUndefined();
+    }
+  });
+
+  test("writeMarker with empty sessions object still succeeds (uuid is what matters)", () => {
+    const uuid = "no-sessions-uuid";
+    writeMarker(tmpNodesDir, "no-sessions-node", uuid, {});
+    const r = readMarker(tmpNodesDir, "no-sessions-node");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.marker.marker).toBe(uuid);
   });
 });

--- a/agent-network/src/copresence-identity.ts
+++ b/agent-network/src/copresence-identity.ts
@@ -1,0 +1,635 @@
+// RFC-030 P3-A v2 — managed identity + group reap for copresence teardown.
+//
+// Restart of the earlier P3-A candidate (9f2ec282, invalidated 2026-07-29
+// after 独立安全审 caught 3 blockers). Written from scratch to correct:
+//   - Blocker 1: uuid was generated twice (start-side vs write-side) so the
+//     tmux env uuid never matched the disk uuid → environ scan always 0 hits
+//     → nothing was ever killed while the code reported success. Fix here:
+//     writeMarker takes uuid as a parameter, single source of truth.
+//   - Blocker 2: `ps -o pid= --pgid N` is not portable (procps-ng rejects it
+//     with "unknown gnu long option"); the old catch-all swallowed the error
+//     and returned [] which was judged "no foreign members, ok:true". Fix
+//     here: enumeration uses direct /proc/*/stat reads via the injected
+//     ProcessEnumerator (no ps at all); any read failure throws, callers
+//     surface it as a fail-closed refuse.
+//   - 副指挥 8 追加 + 通信龙 13 findings folded into structure below.
+//
+// Design invariants (each is unit-test-covered with mutation-red potential):
+//   1. UUID round-trip: cli.ts generates uuid once, passes to writeMarker
+//      AND to the tmux `-e ANET_NODE_MARKER=` inject. writeMarker persists
+//      exactly that uuid. Any code path that generates a second uuid → red.
+//   2. Enumeration is portable + errors are loud. On ENOENT for /proc/PID
+//      the pid is simply gone (return null, that's normal); on any other
+//      error the enumerator throws and the reap flow refuses.
+//   3. Group homogeneity fail-closed: every live member of a PGID must
+//      carry the marker; any foreign member (marker absent) OR any
+//      unreadable member (permission / race) → SKIP the group, log detail.
+//      Never assume "empty foreign list == safe" from a swallowed error.
+//   4. Marker file safety: 0600 mode enforced at read; symlinks refused
+//      (lstat + regular-file check); owner uid verified; malformed JSON
+//      / wrong schema / non-object bodies return structured refuse (never
+//      TypeError from `in` operator on null/number/array/etc.).
+//   5. PID reuse: at reap time re-verify marker starttime + current
+//      boot_id vs the marker file. If mismatch, that pid is a stale
+//      recycled pid — skip.
+//   6. TOCTOU: before each kill() call, re-run environ scan + homogeneity.
+//      Do not act on a 3-second-old snapshot.
+//   7. Self-context: caller ancestry is walked (getpid + PPID walk); if
+//      any ancestor carries the target marker, refuse the stop with
+//      "run from external shell", never "exclude caller and continue".
+//   8. Copresence gating: the stop-time gate keys on a persistent
+//      config-level flag (marker file EXISTS), not on runtime string.
+//      Ordinary codex-app-server nodes without --copresence do not have
+//      a marker file → readMarker returns MISSING → caller falls through
+//      to the pre-P3 legacy stop path (zero diff).
+//   9. Partial-start rollback: if start fails before writeMarker is called,
+//      NO marker file exists → subsequent stop uses legacy path (safe).
+//      If start fails AFTER writeMarker, marker exists → stop uses the
+//      identity flow. Never blind pkill on partial state.
+//  10. Idempotent: readMarker returning MISSING is a "clean, already stopped"
+//      signal — not a warning. The stop caller prints one informational line
+//      and exits 0.
+
+import {
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  statSync,
+  lstatSync,
+  chmodSync,
+  renameSync,
+  readdirSync,
+  mkdirSync,
+  fsyncSync,
+  openSync,
+  closeSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface SessionInfo {
+  tmux: string;
+  pid: number;
+  pgid: number;
+  starttime_jiffies: number;
+}
+
+export interface CopresenceMarker {
+  marker: string; // uuid v4
+  boot_id: string;
+  started_at_epoch_ms: number;
+  owner_uid: number;
+  sessions: {
+    appsrv: SessionInfo;
+    bridge: SessionInfo;
+    tui: SessionInfo;
+  };
+}
+
+export type RefuseCause =
+  | "MISSING"
+  | "SYMLINK"
+  | "NOT_REGULAR"
+  | "WRONG_MODE"
+  | "OWNER_MISMATCH"
+  | "PARSE_ERROR"
+  | "SCHEMA_INVALID"
+  | "STALE_BOOT_ID";
+
+export type ReadMarkerResult =
+  | { kind: "ok"; marker: CopresenceMarker }
+  | { kind: "refuse"; cause: RefuseCause; detail: string };
+
+export interface ProcStat {
+  pgid: number;
+  starttime_jiffies: number;
+  ppid: number;
+}
+
+/**
+ * Injectable primitive for /proc access. Real impl reads the filesystem;
+ * unit tests inject a mock so /proc-based logic is deterministically testable.
+ *
+ * Contract:
+ *   - listAllPids: read /proc directory and return numeric-name entries.
+ *     Throws on unrecoverable errors (permission denied on /proc itself).
+ *   - readEnviron: read /proc/<pid>/environ as a raw string. Returns null
+ *     if the pid has vanished (ENOENT) — that's a normal race, not a failure.
+ *     Throws for permission errors etc.
+ *   - readStat: read /proc/<pid>/stat and extract (pgid, starttime, ppid).
+ *     Returns null on ENOENT (pid gone). Throws on other errors.
+ */
+export interface ProcessEnumerator {
+  listAllPids(): number[];
+  readEnviron(pid: number): string | null;
+  readStat(pid: number): ProcStat | null;
+}
+
+/**
+ * Injectable primitive for sending signals. Real impl uses process.kill;
+ * tests inject a mock.
+ */
+export interface KillPrimitive {
+  killPgroup(pgid: number, signal: "TERM" | "KILL"): void;
+  /** Returns true if ANY process in the pgroup is still alive. */
+  pgroupAlive(pgid: number): boolean;
+}
+
+// ─── Paths ────────────────────────────────────────────────────────────────
+
+export function markerFilePath(nodesDir: string, nodeId: string): string {
+  return join(nodesDir, nodeId, "copresence-identity.json");
+}
+
+// ─── Boot ID (host identity for PID-reuse detection) ─────────────────────
+
+export function readBootId(): string {
+  try {
+    return readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+  } catch {
+    // No /proc/... (mac/win dev). Return a per-process synthetic so
+    // cross-machine marker use always fails STALE_BOOT_ID rather than
+    // matching a wildcard.
+    return `no-boot-id-${process.pid}-${Date.now()}`;
+  }
+}
+
+// ─── Marker file: write ──────────────────────────────────────────────────
+
+function assertParentDir(nodesDir: string, nodeId: string): void {
+  const dir = join(nodesDir, nodeId);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+}
+
+/**
+ * Write the marker file atomically.
+ *
+ * IMPORTANT (Blocker 1 fix): the uuid parameter is the SINGLE SOURCE OF
+ * TRUTH. Caller is expected to inject this same uuid into every tmux
+ * session's ANET_NODE_MARKER env var. writeMarker does NOT generate its
+ * own uuid — that was the exact bug in 9f2ec282.
+ */
+export function writeMarker(
+  nodesDir: string,
+  nodeId: string,
+  uuid: string,
+  sessions: CopresenceMarker["sessions"],
+): CopresenceMarker {
+  if (typeof uuid !== "string" || uuid.length === 0) {
+    throw new Error("writeMarker: uuid must be a non-empty string (caller-provided single source of truth)");
+  }
+  assertParentDir(nodesDir, nodeId);
+  const marker: CopresenceMarker = {
+    marker: uuid,
+    boot_id: readBootId(),
+    started_at_epoch_ms: Date.now(),
+    owner_uid: process.getuid ? process.getuid()! : -1,
+    sessions,
+  };
+  const finalPath = markerFilePath(nodesDir, nodeId);
+  const tmpPath = `${finalPath}.tmp-${process.pid}`;
+  // Pre-unlink defeats symlink-follow (same idiom as P2 env-file fix).
+  try { unlinkSync(tmpPath); } catch (err: any) { if (err?.code !== "ENOENT") throw err; }
+  const body = JSON.stringify(marker, null, 2) + "\n";
+  // wx flag = exclusive create (belt-and-suspenders after pre-unlink).
+  writeFileSync(tmpPath, body, { mode: 0o600, flag: "wx" });
+  chmodSync(tmpPath, 0o600); // belt-and-suspenders (umask may have masked mode)
+  const fd = openSync(tmpPath, "r");
+  try { fsyncSync(fd); } finally { closeSync(fd); }
+  renameSync(tmpPath, finalPath);
+  return marker;
+}
+
+// ─── Marker file: read (with all fail-closed refuses) ────────────────────
+
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function validateSchema(obj: unknown): obj is CopresenceMarker {
+  if (!isPlainObject(obj)) return false;
+  if (typeof obj.marker !== "string" || obj.marker.length === 0) return false;
+  if (typeof obj.boot_id !== "string") return false;
+  if (typeof obj.started_at_epoch_ms !== "number") return false;
+  if (typeof obj.owner_uid !== "number") return false;
+  if (!isPlainObject(obj.sessions)) return false;
+  const s = obj.sessions;
+  for (const key of ["appsrv", "bridge", "tui"] as const) {
+    const sess = s[key];
+    if (!isPlainObject(sess)) return false;
+    if (typeof sess.tmux !== "string") return false;
+    if (typeof sess.pid !== "number") return false;
+    if (typeof sess.pgid !== "number") return false;
+    if (typeof sess.starttime_jiffies !== "number") return false;
+  }
+  return true;
+}
+
+/**
+ * Read the marker file with structured fail-closed refuses.
+ *
+ * Never throws for expected refuse causes. Only throws if the OS itself
+ * is broken (e.g. EIO). Malformed JSON, wrong types, null bodies etc.
+ * all return { kind: "refuse", cause, detail }.
+ */
+export function readMarker(nodesDir: string, nodeId: string): ReadMarkerResult {
+  const path = markerFilePath(nodesDir, nodeId);
+  // Use lstat to catch symlinks (statSync would follow).
+  let lstat;
+  try {
+    lstat = lstatSync(path);
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return { kind: "refuse", cause: "MISSING", detail: `no marker at ${path}` };
+    throw err;
+  }
+  if (lstat.isSymbolicLink()) {
+    return { kind: "refuse", cause: "SYMLINK", detail: `marker at ${path} is a symlink; refusing to follow` };
+  }
+  if (!lstat.isFile()) {
+    return { kind: "refuse", cause: "NOT_REGULAR", detail: `marker at ${path} is not a regular file (mode=${lstat.mode.toString(8)})` };
+  }
+  if ((lstat.mode & 0o777) !== 0o600) {
+    return { kind: "refuse", cause: "WRONG_MODE", detail: `marker at ${path} has mode ${(lstat.mode & 0o777).toString(8)}, expected 600` };
+  }
+  const ownUid = process.getuid ? process.getuid()! : -1;
+  if (lstat.uid !== ownUid) {
+    return { kind: "refuse", cause: "OWNER_MISMATCH", detail: `marker at ${path} owned by uid ${lstat.uid}, we are uid ${ownUid}` };
+  }
+  let body: string;
+  try {
+    body = readFileSync(path, "utf8");
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return { kind: "refuse", cause: "MISSING", detail: `marker vanished between lstat and read: ${path}` };
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch (err: any) {
+    return { kind: "refuse", cause: "PARSE_ERROR", detail: `marker JSON parse failed: ${err?.message || err}` };
+  }
+  if (!validateSchema(parsed)) {
+    return { kind: "refuse", cause: "SCHEMA_INVALID", detail: `marker schema invalid (body type=${typeof parsed}, isArray=${Array.isArray(parsed)}, isNull=${parsed === null})` };
+  }
+  const currentBoot = readBootId();
+  if (parsed.boot_id !== currentBoot) {
+    return { kind: "refuse", cause: "STALE_BOOT_ID", detail: `marker boot_id=${parsed.boot_id} but current=${currentBoot} (host restarted since marker was written)` };
+  }
+  return { kind: "ok", marker: parsed };
+}
+
+export function removeMarker(nodesDir: string, nodeId: string): void {
+  try { unlinkSync(markerFilePath(nodesDir, nodeId)); } catch (err: any) { if (err?.code !== "ENOENT") throw err; }
+}
+
+// ─── Enumeration (real /proc-based implementation) ───────────────────────
+
+export function realEnumerator(): ProcessEnumerator {
+  return {
+    listAllPids(): number[] {
+      const entries = readdirSync("/proc");
+      const pids: number[] = [];
+      for (const e of entries) {
+        const n = Number(e);
+        if (Number.isInteger(n) && n > 0) pids.push(n);
+      }
+      return pids;
+    },
+    readEnviron(pid: number): string | null {
+      try {
+        return readFileSync(`/proc/${pid}/environ`, "utf8");
+      } catch (err: any) {
+        if (err?.code === "ENOENT" || err?.code === "ESRCH") return null;
+        // Permission-denied etc — surface it, do NOT silently return null.
+        throw err;
+      }
+    },
+    readStat(pid: number): ProcStat | null {
+      let raw: string;
+      try {
+        raw = readFileSync(`/proc/${pid}/stat`, "utf8");
+      } catch (err: any) {
+        if (err?.code === "ENOENT" || err?.code === "ESRCH") return null;
+        throw err;
+      }
+      // /proc/PID/stat format: pid (comm) state ppid pgrp ...
+      // comm can contain spaces or parens; find the LAST ')' to split.
+      const lastParen = raw.lastIndexOf(")");
+      if (lastParen < 0) throw new Error(`malformed /proc/${pid}/stat: no ')'`);
+      const rest = raw.slice(lastParen + 1).trim().split(/\s+/);
+      // rest[0] = state, rest[1] = ppid, rest[2] = pgrp, ..., rest[19] = starttime (jiffies since boot)
+      // Field indices per proc(5) after we've stripped pid + (comm):
+      //   0 state, 1 ppid, 2 pgrp, ..., 19 starttime
+      if (rest.length < 20) throw new Error(`malformed /proc/${pid}/stat: only ${rest.length} fields after comm`);
+      const ppid = Number(rest[1]);
+      const pgrp = Number(rest[2]);
+      const starttime = Number(rest[19]);
+      if (!Number.isFinite(ppid) || !Number.isFinite(pgrp) || !Number.isFinite(starttime)) {
+        throw new Error(`malformed /proc/${pid}/stat: non-numeric fields`);
+      }
+      return { pgid: pgrp, starttime_jiffies: starttime, ppid };
+    },
+  };
+}
+
+export function realKiller(): KillPrimitive {
+  return {
+    killPgroup(pgid: number, signal: "TERM" | "KILL"): void {
+      // Negative pid → group signal. process.kill accepts string signal.
+      process.kill(-pgid, signal === "TERM" ? "SIGTERM" : "SIGKILL");
+    },
+    pgroupAlive(pgid: number): boolean {
+      try {
+        process.kill(-pgid, 0);
+        return true;
+      } catch (err: any) {
+        if (err?.code === "ESRCH") return false;
+        if (err?.code === "EPERM") return true; // exists but not ours; treat as alive
+        throw err;
+      }
+    },
+  };
+}
+
+// ─── Environ scan (identity truth) ───────────────────────────────────────
+
+/**
+ * Scan /proc for all pids whose environ contains ANET_NODE_MARKER=<uuid>.
+ * This is the authoritative identity source — NOT the marker file's stored
+ * pids, which may be stale (main died, workers survived under new pgids).
+ *
+ * Bytes format of /proc/PID/environ: NUL-separated key=value pairs.
+ */
+export function scanEnvironForMarker(enumer: ProcessEnumerator, markerUuid: string): number[] {
+  if (typeof markerUuid !== "string" || markerUuid.length === 0) {
+    throw new Error("scanEnvironForMarker: markerUuid must be a non-empty string");
+  }
+  const needle = `ANET_NODE_MARKER=${markerUuid}`;
+  const pids = enumer.listAllPids();
+  const hits: number[] = [];
+  for (const pid of pids) {
+    const env = enumer.readEnviron(pid);
+    if (env == null) continue; // pid raced away, normal
+    const parts = env.split("\0");
+    if (parts.indexOf(needle) >= 0) hits.push(pid);
+  }
+  return hits;
+}
+
+export function groupPidsByPgid(enumer: ProcessEnumerator, pids: number[]): Map<number, number[]> {
+  const groups = new Map<number, number[]>();
+  for (const pid of pids) {
+    const stat = enumer.readStat(pid);
+    if (stat == null) continue; // pid gone
+    const arr = groups.get(stat.pgid) || [];
+    arr.push(pid);
+    groups.set(stat.pgid, arr);
+  }
+  return groups;
+}
+
+// ─── Group homogeneity (fail-closed) ─────────────────────────────────────
+
+export type HomogeneityResult =
+  | { ok: true; members: number[] }
+  | { ok: false; cause: "FOREIGN_MEMBER" | "ENUM_ERROR"; foreignPids: number[]; unreadablePids: number[]; detail: string };
+
+/**
+ * Verify that EVERY live member of `pgid` carries the marker.
+ *
+ * Blocker 2 fix: enumeration errors surface as ENUM_ERROR (fail-closed),
+ * never as an empty-list judged "safe". Any unreadable member also
+ * fails-closed.
+ *
+ * Algorithm:
+ *   1. Enumerate all pids on the system.
+ *   2. Filter to pids whose /proc/PID/stat pgid == target pgid.
+ *   3. For each such pid, check its environ. If pid can't be read → fail-closed.
+ *      If pid lacks marker → foreign member → fail-closed.
+ */
+export function verifyGroupHomogeneity(
+  enumer: ProcessEnumerator,
+  pgid: number,
+  markerUuid: string,
+): HomogeneityResult {
+  const needle = `ANET_NODE_MARKER=${markerUuid}`;
+  let allPids: number[];
+  try {
+    allPids = enumer.listAllPids();
+  } catch (err: any) {
+    return { ok: false, cause: "ENUM_ERROR", foreignPids: [], unreadablePids: [], detail: `listAllPids failed: ${err?.message || err}` };
+  }
+  const groupMembers: number[] = [];
+  const unreadable: number[] = [];
+  for (const pid of allPids) {
+    let stat: ProcStat | null;
+    try {
+      stat = enumer.readStat(pid);
+    } catch (err: any) {
+      // A process in the enumeration list whose stat we can't read is suspicious;
+      // fail-closed rather than assume it's not in the group.
+      unreadable.push(pid);
+      continue;
+    }
+    if (stat == null) continue; // process gone, normal race
+    if (stat.pgid !== pgid) continue;
+    groupMembers.push(pid);
+  }
+  const foreign: number[] = [];
+  for (const pid of groupMembers) {
+    let env: string | null;
+    try {
+      env = enumer.readEnviron(pid);
+    } catch (err: any) {
+      unreadable.push(pid);
+      continue;
+    }
+    if (env == null) continue; // pid gone between stat and environ, normal race
+    const parts = env.split("\0");
+    if (parts.indexOf(needle) < 0) foreign.push(pid);
+  }
+  if (unreadable.length > 0) {
+    return { ok: false, cause: "ENUM_ERROR", foreignPids: foreign, unreadablePids: unreadable, detail: `${unreadable.length} member(s) unreadable — cannot prove homogeneity` };
+  }
+  if (foreign.length > 0) {
+    return { ok: false, cause: "FOREIGN_MEMBER", foreignPids: foreign, unreadablePids: [], detail: `${foreign.length} member(s) do not carry the marker` };
+  }
+  return { ok: true, members: groupMembers };
+}
+
+// ─── Self-context check ─────────────────────────────────────────────────
+
+/**
+ * Walk the caller's ancestry (self → PPID → grandparent → ...) and check
+ * whether any ancestor carries the target marker. If yes → caller is
+ * running inside the copresence tree we're about to kill, and would take
+ * itself down.
+ */
+export function callerCarriesMarker(enumer: ProcessEnumerator, markerUuid: string): { self: boolean; ancestorPid?: number } {
+  const needle = `ANET_NODE_MARKER=${markerUuid}`;
+  let pid = process.pid;
+  const seen = new Set<number>();
+  while (pid > 0 && !seen.has(pid)) {
+    seen.add(pid);
+    let env: string | null;
+    try {
+      env = enumer.readEnviron(pid);
+    } catch {
+      env = null;
+    }
+    if (env != null) {
+      const parts = env.split("\0");
+      if (parts.indexOf(needle) >= 0) {
+        return { self: pid === process.pid, ancestorPid: pid };
+      }
+    }
+    let stat: ProcStat | null;
+    try {
+      stat = enumer.readStat(pid);
+    } catch {
+      break;
+    }
+    if (stat == null) break;
+    if (stat.ppid === pid) break; // safety
+    pid = stat.ppid;
+  }
+  return { self: false };
+}
+
+// ─── PID reuse verification ─────────────────────────────────────────────
+
+/**
+ * For each session recorded in the marker file, check whether the recorded
+ * pid still refers to that specific process (starttime_jiffies match) and
+ * whether the host has restarted (boot_id already checked by readMarker,
+ * this is the per-session pid re-verification for stale hint detection).
+ *
+ * A session whose current /proc/PID/stat starttime differs from the marker's
+ * stored starttime is a stale PID — the OS recycled it to an unrelated proc.
+ * Skip that session, do NOT signal.
+ */
+export function sessionStillFresh(enumer: ProcessEnumerator, session: SessionInfo): boolean {
+  let stat: ProcStat | null;
+  try {
+    stat = enumer.readStat(session.pid);
+  } catch {
+    return false; // fail-closed
+  }
+  if (stat == null) return false; // process gone
+  return stat.starttime_jiffies === session.starttime_jiffies;
+}
+
+// ─── Reap orchestration ─────────────────────────────────────────────────
+
+export type ReapResult =
+  | { kind: "success"; killedPgids: number[]; residualPids: number[] }
+  | { kind: "failed"; killedPgids: number[]; residualPids: number[]; skippedGroups: Array<{ pgid: number; reason: string }>; detail: string };
+
+export interface ReapOptions {
+  graceMs: number;
+  logger: (msg: string) => void;
+}
+
+/**
+ * Full reap flow with TOCTOU re-verification.
+ *
+ * Sequence:
+ *   1. Environ scan for marker → get all live pids carrying it.
+ *   2. Group by current PGID.
+ *   3. For each group: verify homogeneity. Skip on foreign/unreadable.
+ *   4. For each verified group: send SIGTERM to pgroup.
+ *   5. Wait grace.
+ *   6. Re-verify each group (marker still there, no new foreign) before SIGKILL.
+ *   7. Send SIGKILL to any group still alive.
+ *   8. Post-rescan: if any marker-carrying pid alive → preserve marker.
+ */
+export function reapMarkerGroups(
+  enumer: ProcessEnumerator,
+  killer: KillPrimitive,
+  markerUuid: string,
+  opts: ReapOptions,
+): ReapResult {
+  const skippedGroups: Array<{ pgid: number; reason: string }> = [];
+  const killedPgids: number[] = [];
+
+  // Step 1-2: discover + group
+  const pids = scanEnvironForMarker(enumer, markerUuid);
+  opts.logger(`[identity] environ scan found ${pids.length} marker-carrying pid(s)`);
+  if (pids.length === 0) {
+    return { kind: "success", killedPgids: [], residualPids: [] };
+  }
+  const groups = groupPidsByPgid(enumer, pids);
+  opts.logger(`[identity] grouped into ${groups.size} pgroup(s): ${[...groups.keys()].join(",")}`);
+
+  // Step 3-4: verify + SIGTERM per verified group
+  const verifiedGroups: number[] = [];
+  for (const pgid of groups.keys()) {
+    const check = verifyGroupHomogeneity(enumer, pgid, markerUuid);
+    if (!check.ok) {
+      const reason = `${check.cause}: ${check.detail} (foreign=[${check.foreignPids.join(",")}] unreadable=[${check.unreadablePids.join(",")}])`;
+      skippedGroups.push({ pgid, reason });
+      opts.logger(`[identity] SKIP pgid=${pgid} — ${reason}`);
+      continue;
+    }
+    verifiedGroups.push(pgid);
+    opts.logger(`[identity] verified pgid=${pgid} members=${check.members.join(",")}; sending SIGTERM`);
+    try { killer.killPgroup(pgid, "TERM"); } catch (err: any) {
+      opts.logger(`[identity] SIGTERM pgid=${pgid} failed: ${err?.message || err}`);
+    }
+  }
+
+  if (verifiedGroups.length === 0) {
+    return {
+      kind: "failed",
+      killedPgids: [],
+      residualPids: pids,
+      skippedGroups,
+      detail: "no groups passed homogeneity — nothing killed",
+    };
+  }
+
+  // Step 5: grace
+  const sleep = (ms: number) => {
+    const end = Date.now() + ms;
+    while (Date.now() < end) { /* busy-wait so we don't need an async layer here */ }
+  };
+  sleep(opts.graceMs);
+
+  // Step 6-7: re-verify then SIGKILL as needed
+  for (const pgid of verifiedGroups) {
+    if (!killer.pgroupAlive(pgid)) {
+      killedPgids.push(pgid);
+      opts.logger(`[identity] pgid=${pgid} exited after SIGTERM`);
+      continue;
+    }
+    // TOCTOU re-verify before escalating
+    const recheck = verifyGroupHomogeneity(enumer, pgid, markerUuid);
+    if (!recheck.ok) {
+      const reason = `re-verify after grace: ${recheck.cause}: ${recheck.detail}`;
+      skippedGroups.push({ pgid, reason });
+      opts.logger(`[identity] SKIP escalation pgid=${pgid} — ${reason}`);
+      continue;
+    }
+    opts.logger(`[identity] pgid=${pgid} still alive after grace; sending SIGKILL`);
+    try { killer.killPgroup(pgid, "KILL"); killedPgids.push(pgid); } catch (err: any) {
+      opts.logger(`[identity] SIGKILL pgid=${pgid} failed: ${err?.message || err}`);
+    }
+  }
+
+  // Step 8: post-rescan
+  const residual = scanEnvironForMarker(enumer, markerUuid);
+  if (residual.length > 0) {
+    return {
+      kind: "failed",
+      killedPgids,
+      residualPids: residual,
+      skippedGroups,
+      detail: `${residual.length} marker-carrying pid(s) still alive after grace+KILL`,
+    };
+  }
+  return { kind: "success", killedPgids, residualPids: [] };
+}

--- a/agent-network/src/copresence-identity.ts
+++ b/agent-network/src/copresence-identity.ts
@@ -81,10 +81,20 @@ export interface CopresenceMarker {
   boot_id: string;
   started_at_epoch_ms: number;
   owner_uid: number;
+  // Best-effort observability hints (which tmux session each pid came from,
+  // pgid/starttime at harvest time). NOT the identity source — reap uses
+  // /proc/PID/environ scan for the marker uuid, which stays valid even when
+  // the recorded pids die or spawn workers under different pgids.
+  //
+  // Finding #4 (audit 92d53c8f): every field here is OPTIONAL. If pane pid
+  // harvest fails for any session (or all), the marker file still gets
+  // written — the identity uuid is what matters. Prior all-or-nothing gate
+  // meant one flaky tmux display-message call destroyed the node's ability
+  // to be identity-reaped forever.
   sessions: {
-    appsrv: SessionInfo;
-    bridge: SessionInfo;
-    tui: SessionInfo;
+    appsrv?: SessionInfo;
+    bridge?: SessionInfo;
+    tui?: SessionInfo;
   };
 }
 
@@ -96,7 +106,8 @@ export type RefuseCause =
   | "OWNER_MISMATCH"
   | "PARSE_ERROR"
   | "SCHEMA_INVALID"
-  | "STALE_BOOT_ID";
+  | "STALE_BOOT_ID"
+  | "PLATFORM_UNSUPPORTED";
 
 export type ReadMarkerResult =
   | { kind: "ok"; marker: CopresenceMarker }
@@ -125,6 +136,20 @@ export interface ProcessEnumerator {
   listAllPids(): number[];
   readEnviron(pid: number): string | null;
   readStat(pid: number): ProcStat | null;
+  /**
+   * Owner uid of /proc/<pid>. Used by scanEnvironForMarker to discriminate
+   * "other-user process (expected EACCES)" from "our own process with weird
+   * EACCES (real problem, must fail closed)".
+   * Returns null if the pid is gone (ENOENT).
+   */
+  readOwnerUid(pid: number): number | null;
+  /**
+   * Single-character process state from /proc/<pid>/status (R/S/D/Z/T/...).
+   * `Z` means zombie — mm freed, environ returns EACCES even to owner, but
+   * the pid is going away shortly. Skip zombies during environ scan.
+   * Returns null if the pid is gone (ENOENT).
+   */
+  readState(pid: number): string | null;
 }
 
 /**
@@ -220,6 +245,7 @@ function validateSchema(obj: unknown): obj is CopresenceMarker {
   const s = obj.sessions;
   for (const key of ["appsrv", "bridge", "tui"] as const) {
     const sess = s[key];
+    if (sess === undefined) continue; // optional per finding #4
     if (!isPlainObject(sess)) return false;
     if (typeof sess.tmux !== "string") return false;
     if (typeof sess.pid !== "number") return false;
@@ -237,6 +263,18 @@ function validateSchema(obj: unknown): obj is CopresenceMarker {
  * all return { kind: "refuse", cause, detail }.
  */
 export function readMarker(nodesDir: string, nodeId: string): ReadMarkerResult {
+  // Finding #7 (audit 92d53c8f): P3 identity teardown depends on /proc/*
+  // which only exists on Linux. On Darwin/Windows dev machines every stop
+  // used to misreport marker corruption (or crash reading /proc/…). Refuse
+  // cleanly with a clear cause so the cli falls through to the legacy sweep
+  // without alarming the operator.
+  if (process.platform !== "linux") {
+    return {
+      kind: "refuse",
+      cause: "PLATFORM_UNSUPPORTED",
+      detail: `P3 identity teardown requires Linux /proc; platform=${process.platform}; falling through to legacy sweep`,
+    };
+  }
   const path = markerFilePath(nodesDir, nodeId);
   // Use lstat to catch symlinks (statSync would follow).
   let lstat;
@@ -333,16 +371,72 @@ export function realEnumerator(): ProcessEnumerator {
       }
       return { pgid: pgrp, starttime_jiffies: starttime, ppid };
     },
+    readOwnerUid(pid: number): number | null {
+      // IMPORTANT: check /proc/PID/environ's OWN owner, not /proc/PID directory.
+      // Some special processes (systemd sd-pam, setuid children, root
+      // sub-daemons launched via user session) have /proc/PID owned by the
+      // real user uid but /proc/PID/environ owned by root with mode 0400.
+      // We're testing whether we CAN read environ; the environ file's owner
+      // is what actually matters for that.
+      //
+      // If /proc/PID/environ specifically can't be stat'd, the pid is either
+      // gone or the container/policy layer blocks even the metadata; return
+      // null (skip) — safer to not treat as "ours" than to fail-closed and
+      // block stops for irrelevant system processes.
+      try {
+        return statSync(`/proc/${pid}/environ`).uid;
+      } catch (err: any) {
+        if (err?.code === "ENOENT" || err?.code === "ESRCH") return null;
+        if (err?.code === "EACCES") return null; // metadata itself blocked, treat as not-ours
+        throw err;
+      }
+    },
+    readState(pid: number): string | null {
+      // /proc/<pid>/stat field-after-comm[0] is state. We already have readStat
+      // above but that throws on malformed; here we want a lighter/silent read
+      // that returns just the state char (used to detect zombies during environ
+      // EACCES discrimination). Prefer /proc/<pid>/status (line-oriented, more
+      // stable to parse than the space-packed stat).
+      //
+      // We combine State + TracerPid into a single call for callers that need
+      // both. When TracerPid != 0, the task's mm is locked by the tracer and
+      // readEnviron will EACCES even for the owner — treat that as an
+      // expected "mm-locked" state (returned as "t" per convention).
+      let raw: string;
+      try {
+        raw = readFileSync(`/proc/${pid}/status`, "utf8");
+      } catch (err: any) {
+        if (err?.code === "ENOENT" || err?.code === "ESRCH") return null;
+        throw err;
+      }
+      const tracerMatch = raw.match(/^TracerPid:\s*(\d+)/m);
+      if (tracerMatch && Number(tracerMatch[1]) > 0) {
+        return "t"; // ptrace-stopped: mm-locked, environ unreadable, expected
+      }
+      // Line format: `State:\tZ (zombie)` — take the first non-whitespace char
+      // after `State:`.
+      const m = raw.match(/^State:\s*(\S)/m);
+      return m ? m[1] : null;
+    },
   };
 }
 
 export function realKiller(): KillPrimitive {
   return {
     killPgroup(pgid: number, signal: "TERM" | "KILL"): void {
+      // Finding #2 (audit 92d53c8f): kill(-0) targets the CALLER's own
+      // process group — kernel threads have pgrp=0. Any code path that
+      // arrived here with pgid<=0 has a bug upstream; refuse to signal.
+      if (pgid <= 0) {
+        throw new Error(`killPgroup refused: pgid must be > 0 (got ${pgid}); kill(-0) or kill(-negative) would target caller's own pgroup`);
+      }
       // Negative pid → group signal. process.kill accepts string signal.
       process.kill(-pgid, signal === "TERM" ? "SIGTERM" : "SIGKILL");
     },
     pgroupAlive(pgid: number): boolean {
+      if (pgid <= 0) {
+        throw new Error(`pgroupAlive refused: pgid must be > 0 (got ${pgid})`);
+      }
       try {
         process.kill(-pgid, 0);
         return true;
@@ -363,21 +457,89 @@ export function realKiller(): KillPrimitive {
  * pids, which may be stale (main died, workers survived under new pgids).
  *
  * Bytes format of /proc/PID/environ: NUL-separated key=value pairs.
+ *
+ * Blocker 1 fix (independent audit 92d53c8f, 2026-07-29): /proc/<pid>/environ
+ * is 0400 owner-only. Blindly reading it will hit EACCES on every other-user
+ * process (pid 1 is systemd/root → guaranteed EACCES). The naive fix — wrap
+ * in try/catch and continue — would silently miss marker-carrying processes
+ * whose environ we can't read for some other reason, recreating Defect A
+ * ("nothing killed but report success"). Right fix:
+ *
+ *   1. Try readEnviron.
+ *   2. On EACCES, discriminate via readOwnerUid + readState:
+ *      - Owner uid != ours     → EXPECTED skip (can't be one of our procs).
+ *      - Own uid, state = Z    → EXPECTED skip (zombie, mm freed).
+ *      - Own uid, not zombie   → FAIL-CLOSED (unexplained EACCES on our own
+ *                                live process is a real problem, must throw).
  */
+export interface ScanResult {
+  /** Pids whose environ we successfully read and matched the marker uuid. */
+  hits: number[];
+  /**
+   * Pids we had to SKIP due to EACCES on own-uid running-state process.
+   * These pids MIGHT be marker-carrying but we couldn't verify. Reap flow
+   * uses this to REFUSE marker removal even when hits=0 (defense against
+   * Defect A: silently missing a marker-carrying process, then deleting
+   * the marker as if teardown succeeded).
+   */
+  unreadableOwnUid: number[];
+}
+
 export function scanEnvironForMarker(enumer: ProcessEnumerator, markerUuid: string): number[] {
+  return scanEnvironForMarkerFull(enumer, markerUuid).hits;
+}
+
+export function scanEnvironForMarkerFull(enumer: ProcessEnumerator, markerUuid: string): ScanResult {
+  if (typeof markerUuid !== "string" || markerUuid.length === 0) {
+    throw new Error("scanEnvironForMarker: markerUuid must be a non-empty string");
+  }
   if (typeof markerUuid !== "string" || markerUuid.length === 0) {
     throw new Error("scanEnvironForMarker: markerUuid must be a non-empty string");
   }
   const needle = `ANET_NODE_MARKER=${markerUuid}`;
+  const ownUid = process.getuid ? process.getuid()! : -1;
   const pids = enumer.listAllPids();
   const hits: number[] = [];
+  const unreadableOwnUid: number[] = [];
   for (const pid of pids) {
-    const env = enumer.readEnviron(pid);
+    let env: string | null;
+    try {
+      env = enumer.readEnviron(pid);
+    } catch (err: any) {
+      // Blocker 1 fix (audit 92d53c8f + practical Linux calibration).
+      //
+      // Real /proc has many pids where readEnviron EACCES even when the pid
+      // "appears" ours by directory stat: sd-pam (env owned by root),
+      // docker/podman daemons (dumpable=0), systemd session leaders,
+      // ptrace-locked, exec2-transitioning, etc.
+      //
+      // Discrimination:
+      //   - Non-EACCES error → throw (real problem, not a permission thing)
+      //   - env-file uid != ours → skip (not ours)
+      //   - state Z/X/T/t or other non-R/S/D → skip (mm-locked/dying)
+      //   - Otherwise (own-uid, running state, still EACCES) →
+      //     record in unreadableOwnUid list. Caller uses this to refuse
+      //     removing the marker file (defense against Defect A: if we
+      //     silently skipped and reported hits=0, marker would be deleted
+      //     as if teardown succeeded, but a real marker-carrying process
+      //     might have been in the unreadable set).
+      if (err?.code !== "EACCES") throw err;
+      let envOwnerUid: number | null;
+      try { envOwnerUid = enumer.readOwnerUid(pid); } catch { continue; }
+      if (envOwnerUid == null) continue;
+      if (envOwnerUid !== ownUid) continue;
+      let state: string | null;
+      try { state = enumer.readState(pid); } catch { continue; }
+      if (state == null) continue;
+      if (state !== "R" && state !== "S" && state !== "D") continue;
+      unreadableOwnUid.push(pid);
+      continue;
+    }
     if (env == null) continue; // pid raced away, normal
     const parts = env.split("\0");
     if (parts.indexOf(needle) >= 0) hits.push(pid);
   }
-  return hits;
+  return { hits, unreadableOwnUid };
 }
 
 export function groupPidsByPgid(enumer: ProcessEnumerator, pids: number[]): Map<number, number[]> {
@@ -396,20 +558,33 @@ export function groupPidsByPgid(enumer: ProcessEnumerator, pids: number[]): Map<
 
 export type HomogeneityResult =
   | { ok: true; members: number[] }
-  | { ok: false; cause: "FOREIGN_MEMBER" | "ENUM_ERROR"; foreignPids: number[]; unreadablePids: number[]; detail: string };
+  | { ok: false; cause: "FOREIGN_MEMBER" | "ENUM_ERROR" | "EMPTY_GROUP"; foreignPids: number[]; unreadablePids: number[]; detail: string };
 
 /**
  * Verify that EVERY live member of `pgid` carries the marker.
  *
  * Blocker 2 fix: enumeration errors surface as ENUM_ERROR (fail-closed),
  * never as an empty-list judged "safe". Any unreadable member also
- * fails-closed.
+ * fails-closed. Empty group (no live members at all) also refuses — killing
+ * an empty pgroup can't be right and empty-list judged "ok" recreates the
+ * exact defect shape (independent audit 92d53c8f finding #6).
+ *
+ * Blocker 2 second half (zombie): a zombie same-uid process's environ
+ * returns EACCES even to owner (mm freed), but stat still exists with
+ * original pgid. Without discrimination, the zombie would be treated as
+ * "unreadable member" → ENUM_ERROR → entire group SKIPPED. Since re-verify
+ * happens post-SIGTERM (when zombies are most numerous), teardown would
+ * never escalate. Fix: apply the same owner-uid + state=Z discriminator as
+ * scanEnvironForMarker.
  *
  * Algorithm:
  *   1. Enumerate all pids on the system.
  *   2. Filter to pids whose /proc/PID/stat pgid == target pgid.
- *   3. For each such pid, check its environ. If pid can't be read → fail-closed.
- *      If pid lacks marker → foreign member → fail-closed.
+ *   3. For each such pid, check its environ with EACCES discrimination:
+ *      - Other-user EACCES  → skip (can't be ours anyway).
+ *      - Own-uid zombie     → skip (expected, dying).
+ *      - Own-uid live EACCES → truly unreadable → fail-closed.
+ *      - Missing marker     → foreign member → fail-closed.
  */
 export function verifyGroupHomogeneity(
   enumer: ProcessEnumerator,
@@ -417,6 +592,7 @@ export function verifyGroupHomogeneity(
   markerUuid: string,
 ): HomogeneityResult {
   const needle = `ANET_NODE_MARKER=${markerUuid}`;
+  const ownUid = process.getuid ? process.getuid()! : -1;
   let allPids: number[];
   try {
     allPids = enumer.listAllPids();
@@ -440,15 +616,34 @@ export function verifyGroupHomogeneity(
     groupMembers.push(pid);
   }
   const foreign: number[] = [];
+  const liveMembers: number[] = [];
   for (const pid of groupMembers) {
     let env: string | null;
     try {
       env = enumer.readEnviron(pid);
     } catch (err: any) {
+      if (err?.code === "EACCES") {
+        // Discriminator (see scanEnvironForMarker for full rationale). At
+        // the group level, we're stricter than at scan level: if a member's
+        // environ is unreadable AND we can't rule out its ownership OR its
+        // dumpable=0 state, we mark it unreadable and let the group refuse
+        // ENUM_ERROR. Marker-carrying-member-not-verifiable → don't kill.
+        let envOwnerUid: number | null;
+        try { envOwnerUid = enumer.readOwnerUid(pid); } catch { continue; }
+        if (envOwnerUid == null) continue;
+        if (envOwnerUid !== ownUid) continue;
+        let state: string | null;
+        try { state = enumer.readState(pid); } catch { continue; }
+        if (state == null) continue;
+        if (state !== "R" && state !== "S" && state !== "D") continue;
+        unreadable.push(pid);
+        continue;
+      }
       unreadable.push(pid);
       continue;
     }
     if (env == null) continue; // pid gone between stat and environ, normal race
+    liveMembers.push(pid);
     const parts = env.split("\0");
     if (parts.indexOf(needle) < 0) foreign.push(pid);
   }
@@ -458,7 +653,14 @@ export function verifyGroupHomogeneity(
   if (foreign.length > 0) {
     return { ok: false, cause: "FOREIGN_MEMBER", foreignPids: foreign, unreadablePids: [], detail: `${foreign.length} member(s) do not carry the marker` };
   }
-  return { ok: true, members: groupMembers };
+  if (liveMembers.length === 0) {
+    // Finding #6 (audit 92d53c8f): empty-group judged ok:true is defect
+    // shape B. If nothing was found in the pgid, don't signal (empty
+    // pgroup = pgroup dissolved; kill(-pgid) would be a no-op at best and
+    // potentially catch a stray pgid re-assigned to something else).
+    return { ok: false, cause: "EMPTY_GROUP", foreignPids: [], unreadablePids: [], detail: `pgid=${pgid} has no live marker-carrying members` };
+  }
+  return { ok: true, members: liveMembers };
 }
 
 // ─── Self-context check ─────────────────────────────────────────────────
@@ -500,38 +702,29 @@ export function callerCarriesMarker(enumer: ProcessEnumerator, markerUuid: strin
   return { self: false };
 }
 
-// ─── PID reuse verification ─────────────────────────────────────────────
-
-/**
- * For each session recorded in the marker file, check whether the recorded
- * pid still refers to that specific process (starttime_jiffies match) and
- * whether the host has restarted (boot_id already checked by readMarker,
- * this is the per-session pid re-verification for stale hint detection).
- *
- * A session whose current /proc/PID/stat starttime differs from the marker's
- * stored starttime is a stale PID — the OS recycled it to an unrelated proc.
- * Skip that session, do NOT signal.
- */
-export function sessionStillFresh(enumer: ProcessEnumerator, session: SessionInfo): boolean {
-  let stat: ProcStat | null;
-  try {
-    stat = enumer.readStat(session.pid);
-  } catch {
-    return false; // fail-closed
-  }
-  if (stat == null) return false; // process gone
-  return stat.starttime_jiffies === session.starttime_jiffies;
-}
-
 // ─── Reap orchestration ─────────────────────────────────────────────────
+// (sessionStillFresh removed 2026-07-29 per audit 92d53c8f finding #1 — it
+// had zero production call sites and gave Test 6 false coverage. PID-reuse
+// defense in practice comes from the boot_id check inside readMarker plus
+// the environ-scan-is-truth rule that ignores the marker file's stored pids
+// entirely at reap time. If a future need re-introduces per-session stale-
+// pid detection, wire it into reapMarkerGroups before adding tests.)
 
 export type ReapResult =
-  | { kind: "success"; killedPgids: number[]; residualPids: number[] }
-  | { kind: "failed"; killedPgids: number[]; residualPids: number[]; skippedGroups: Array<{ pgid: number; reason: string }>; detail: string };
+  | { kind: "success"; killedPgids: number[]; residualPids: number[]; unreadableOwnUid?: number[] }
+  | { kind: "failed"; killedPgids: number[]; residualPids: number[]; skippedGroups: Array<{ pgid: number; reason: string }>; detail: string; unreadableOwnUid?: number[] };
 
 export interface ReapOptions {
   graceMs: number;
   logger: (msg: string) => void;
+  /**
+   * Sleep primitive (grace period). Real code uses setTimeout; tests inject
+   * a fast/deterministic sleep so grace paths are actually covered. Prior
+   * impl was a busy-wait `while (Date.now() < end) {}` — audit 92d53c8f
+   * finding #3 flagged that as pinning one CPU core for graceMs and blocking
+   * the event loop; test coverage missed it because tests passed graceMs=0.
+   */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 /**
@@ -547,20 +740,36 @@ export interface ReapOptions {
  *   7. Send SIGKILL to any group still alive.
  *   8. Post-rescan: if any marker-carrying pid alive → preserve marker.
  */
-export function reapMarkerGroups(
+export async function reapMarkerGroups(
   enumer: ProcessEnumerator,
   killer: KillPrimitive,
   markerUuid: string,
   opts: ReapOptions,
-): ReapResult {
+): Promise<ReapResult> {
   const skippedGroups: Array<{ pgid: number; reason: string }> = [];
   const killedPgids: number[] = [];
 
-  // Step 1-2: discover + group
-  const pids = scanEnvironForMarker(enumer, markerUuid);
-  opts.logger(`[identity] environ scan found ${pids.length} marker-carrying pid(s)`);
-  if (pids.length === 0) {
+  // Step 1-2: discover + group. Use ..Full form so we can retain the list
+  // of pids we had to SKIP due to EACCES on own-uid running processes.
+  // Those unreadable pids might have been marker-carrying; treating hits=0
+  // as "success + delete marker" when the unreadable list is non-empty
+  // recreates Defect A. Instead we return kind:"failed" and preserve the
+  // marker for retry.
+  const scan = scanEnvironForMarkerFull(enumer, markerUuid);
+  const pids = scan.hits;
+  opts.logger(`[identity] environ scan found ${pids.length} marker-carrying pid(s), ${scan.unreadableOwnUid.length} own-uid unreadable`);
+  if (pids.length === 0 && scan.unreadableOwnUid.length === 0) {
     return { kind: "success", killedPgids: [], residualPids: [] };
+  }
+  if (pids.length === 0 && scan.unreadableOwnUid.length > 0) {
+    return {
+      kind: "failed",
+      killedPgids: [],
+      residualPids: [],
+      skippedGroups: [],
+      detail: `no marker-carrying pids found, but ${scan.unreadableOwnUid.length} own-uid running process(es) had unreadable environ — cannot prove marker-bearing processes don't exist; preserve marker for retry`,
+      unreadableOwnUid: scan.unreadableOwnUid,
+    };
   }
   const groups = groupPidsByPgid(enumer, pids);
   opts.logger(`[identity] grouped into ${groups.size} pgroup(s): ${[...groups.keys()].join(",")}`);
@@ -592,12 +801,9 @@ export function reapMarkerGroups(
     };
   }
 
-  // Step 5: grace
-  const sleep = (ms: number) => {
-    const end = Date.now() + ms;
-    while (Date.now() < end) { /* busy-wait so we don't need an async layer here */ }
-  };
-  sleep(opts.graceMs);
+  // Step 5: grace — real setTimeout, NOT busy-wait (finding #3).
+  const sleep = opts.sleep || ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  await sleep(opts.graceMs);
 
   // Step 6-7: re-verify then SIGKILL as needed
   for (const pgid of verifiedGroups) {
@@ -621,14 +827,18 @@ export function reapMarkerGroups(
   }
 
   // Step 8: post-rescan
-  const residual = scanEnvironForMarker(enumer, markerUuid);
-  if (residual.length > 0) {
+  const rescan = scanEnvironForMarkerFull(enumer, markerUuid);
+  const residual = rescan.hits;
+  if (residual.length > 0 || rescan.unreadableOwnUid.length > 0) {
     return {
       kind: "failed",
       killedPgids,
       residualPids: residual,
       skippedGroups,
-      detail: `${residual.length} marker-carrying pid(s) still alive after grace+KILL`,
+      detail: residual.length > 0
+        ? `${residual.length} marker-carrying pid(s) still alive after grace+KILL`
+        : `no marker-carrying residual but ${rescan.unreadableOwnUid.length} own-uid unreadable — preserve marker for retry`,
+      unreadableOwnUid: rescan.unreadableOwnUid.length > 0 ? rescan.unreadableOwnUid : undefined,
     };
   }
   return { kind: "success", killedPgids, residualPids: [] };

--- a/agent-network/src/copresence-identity.ts
+++ b/agent-network/src/copresence-identity.ts
@@ -1,4 +1,35 @@
-// RFC-030 P3-A v2 — managed identity + group reap for copresence teardown.
+// RFC-030 P3-A v3 — managed identity + group reap for copresence teardown.
+//
+// v3 (2026-07-29) exists because an independent audit did what three
+// previous review rounds did not: it ran the code on a real Linux box. The
+// mock suite was 52/52 green while the feature was 100% non-functional
+// here, because EVERY unit test injected MockEnumer/MockKiller and the real
+// implementations had literally zero test references. Mutation testing on
+// that suite proved only that the mock and the implementation agreed with
+// each other. The v3 corrections and the real-/proc suite that guards them:
+//
+//   - Blocker 1: the fail-closed "unreadable" list was machine-wide, so any
+//     same-uid/different-gid process on the host (a docker helper, here)
+//     made reapMarkerGroups return "failed" forever — the marker was never
+//     removed and every stop printed "teardown incomplete" even when the
+//     tree was clean. Scope is now bounded to our own process tree
+//     (invariant 11).
+//   - Blocker 2: process ownership was read from the /proc/PID/environ
+//     INODE owner, which reports root for our own non-dumpable children
+//     (prctl(PR_SET_DUMPABLE,0)). Those carriers were invisible: not a hit,
+//     not unreadable, so teardown "succeeded" and deleted the marker while
+//     the orphan lived on. Ownership now comes from /proc/PID/status Uid:.
+//   - Blocker 3: group-level stat-unreadable pids were collected before the
+//     pgid filter — one hidden process anywhere blocked every group.
+//   - Blocker 4: PLATFORM_UNSUPPORTED preceded the MISSING check, so every
+//     node on macOS/Windows warned about a marker file that never existed.
+//   - Blockers 5+6: start-side ordering and stale-marker reclaim, now in
+//     prepareIdentityForStart (bottom of this file) so they are testable.
+//   - Blocker 7: the post-rescan unreadable branch had no coverage.
+//   - Blocker 8: invariant 5 promised a starttime re-verification that no
+//     code performed; validateAnchors now performs it.
+//
+// Original v2 header follows.
 //
 // Restart of the earlier P3-A candidate (9f2ec282, invalidated 2026-07-29
 // after 独立安全审 caught 3 blockers). Written from scratch to correct:
@@ -29,9 +60,15 @@
 //      (lstat + regular-file check); owner uid verified; malformed JSON
 //      / wrong schema / non-object bodies return structured refuse (never
 //      TypeError from `in` operator on null/number/array/etc.).
-//   5. PID reuse: at reap time re-verify marker starttime + current
-//      boot_id vs the marker file. If mismatch, that pid is a stale
-//      recycled pid — skip.
+//   5. PID reuse: the marker file's recorded session pids are NOT a kill
+//      list — identity is always the environ uuid. They are used for one
+//      thing only: anchoring the "is this unreadable process plausibly
+//      part of our tree" scope check (invariant 11). Before a recorded pid
+//      may act as an anchor it must still be the SAME process, proven by
+//      comparing SessionInfo.starttime_jiffies against the live
+//      /proc/PID/stat starttime (see validateAnchors). A recycled pid has
+//      a different starttime and is dropped. Host-level reuse across a
+//      reboot is caught earlier by the boot_id check in readMarker.
 //   6. TOCTOU: before each kill() call, re-run environ scan + homogeneity.
 //      Do not act on a 3-second-old snapshot.
 //   7. Self-context: caller ancestry is walked (getpid + PPID walk); if
@@ -49,6 +86,17 @@
 //  10. Idempotent: readMarker returning MISSING is a "clean, already stopped"
 //      signal — not a warning. The stop caller prints one informational line
 //      and exits 0.
+//  11. Fail-closed scope is BOUNDED to our own process tree. Every
+//      fail-closed signal derived from "a process we could not inspect"
+//      must first prove that process is plausibly ours: its pgid belongs to
+//      a marker-carrying group, or its ppid chain reaches a marker carrier
+//      or a validated marker-file session pid. An unrelated process
+//      elsewhere on the machine that we merely cannot read (different
+//      primary gid, hidepid, LSM, container policy) must NEVER be able to
+//      block teardown. v2 violated this: a machine-wide unreadable list
+//      meant reapMarkerGroups could never return success on a host that
+//      happened to run any same-uid/different-gid process, so the marker
+//      was never removed and every stop printed "teardown incomplete".
 
 import {
   readFileSync,
@@ -137,10 +185,23 @@ export interface ProcessEnumerator {
   readEnviron(pid: number): string | null;
   readStat(pid: number): ProcStat | null;
   /**
-   * Owner uid of /proc/<pid>. Used by scanEnvironForMarker to discriminate
-   * "other-user process (expected EACCES)" from "our own process with weird
-   * EACCES (real problem, must fail closed)".
-   * Returns null if the pid is gone (ENOENT).
+   * REAL uid of the process itself (`Uid:` line of /proc/<pid>/status,
+   * field 0). Used by the environ-EACCES discriminator to tell
+   * "other-user process (expected EACCES)" from "our own process we could
+   * not inspect (must be accounted for)".
+   *
+   * MUST NOT be implemented as `statSync('/proc/<pid>/environ').uid`.
+   * A process that called prctl(PR_SET_DUMPABLE, 0) keeps its real uid but
+   * its /proc/<pid>/{environ,mem,...} nodes flip to root:root 0400 (see
+   * proc(5) / kernel `task_dump_owner`). Deriving ownership from the
+   * environ inode therefore reports uid 0 for our OWN non-dumpable
+   * children, which made them invisible to the scan: not in `hits`, not in
+   * the unreadable list, so teardown reported success and deleted the
+   * marker while the orphan lived on (Defect A).
+   *
+   * Returns null if the pid is gone (ENOENT) or if even /proc/<pid>/status
+   * is blocked (hidepid / LSM) — in that case the process cannot be ours
+   * to reason about and is skipped.
    */
   readOwnerUid(pid: number): number | null;
   /**
@@ -263,26 +324,35 @@ function validateSchema(obj: unknown): obj is CopresenceMarker {
  * all return { kind: "refuse", cause, detail }.
  */
 export function readMarker(nodesDir: string, nodeId: string): ReadMarkerResult {
-  // Finding #7 (audit 92d53c8f): P3 identity teardown depends on /proc/*
-  // which only exists on Linux. On Darwin/Windows dev machines every stop
-  // used to misreport marker corruption (or crash reading /proc/…). Refuse
-  // cleanly with a clear cause so the cli falls through to the legacy sweep
-  // without alarming the operator.
-  if (process.platform !== "linux") {
-    return {
-      kind: "refuse",
-      cause: "PLATFORM_UNSUPPORTED",
-      detail: `P3 identity teardown requires Linux /proc; platform=${process.platform}; falling through to legacy sweep`,
-    };
-  }
   const path = markerFilePath(nodesDir, nodeId);
   // Use lstat to catch symlinks (statSync would follow).
+  //
+  // Blocker 4 fix: the MISSING check runs FIRST, before the platform check.
+  // The caller treats every cause except MISSING as "a marker exists but we
+  // refused it" and prints a loud "investigate the marker file for
+  // corruption" warning. v2 returned PLATFORM_UNSUPPORTED before ever
+  // touching the filesystem, so on macOS/Windows EVERY node of EVERY runtime
+  // — none of which have ever had a marker file — printed that warning on
+  // `anet node stop`. A no-marker node must be indistinguishable from the
+  // pre-P3 baseline on every platform, so absence of the file wins.
   let lstat;
   try {
     lstat = lstatSync(path);
   } catch (err: any) {
     if (err?.code === "ENOENT") return { kind: "refuse", cause: "MISSING", detail: `no marker at ${path}` };
     throw err;
+  }
+  // Finding #7 (audit 92d53c8f): P3 identity teardown depends on /proc/*
+  // which only exists on Linux. A marker file DOES exist here (copied dev
+  // tree, shared home dir, cross-platform sync) but we cannot act on it —
+  // refuse cleanly with a clear cause so the cli falls through to the legacy
+  // sweep.
+  if (process.platform !== "linux") {
+    return {
+      kind: "refuse",
+      cause: "PLATFORM_UNSUPPORTED",
+      detail: `P3 identity teardown requires Linux /proc; platform=${process.platform}; falling through to legacy sweep`,
+    };
   }
   if (lstat.isSymbolicLink()) {
     return { kind: "refuse", cause: "SYMLINK", detail: `marker at ${path} is a symlink; refusing to follow` };
@@ -372,24 +442,33 @@ export function realEnumerator(): ProcessEnumerator {
       return { pgid: pgrp, starttime_jiffies: starttime, ppid };
     },
     readOwnerUid(pid: number): number | null {
-      // IMPORTANT: check /proc/PID/environ's OWN owner, not /proc/PID directory.
-      // Some special processes (systemd sd-pam, setuid children, root
-      // sub-daemons launched via user session) have /proc/PID owned by the
-      // real user uid but /proc/PID/environ owned by root with mode 0400.
-      // We're testing whether we CAN read environ; the environ file's owner
-      // is what actually matters for that.
+      // Read the process's REAL uid from /proc/<pid>/status, NOT the owner
+      // of the /proc/<pid>/environ inode. See the interface doc: a
+      // non-dumpable process (prctl(PR_SET_DUMPABLE, 0)) keeps real uid
+      // 1000 while its environ inode is reported as root:root 0400, so the
+      // inode-owner reading silently classified our own children as
+      // "somebody else's process".
       //
-      // If /proc/PID/environ specifically can't be stat'd, the pid is either
-      // gone or the container/policy layer blocks even the metadata; return
-      // null (skip) — safer to not treat as "ours" than to fail-closed and
-      // block stops for irrelevant system processes.
+      // Verified on Linux 6.8 with a uid-1000 child that called
+      // prctl(PR_SET_DUMPABLE, 0):
+      //   stat /proc/<pid>/environ  -> uid=0 gid=0 mode=400   (misleading)
+      //   /proc/<pid>/status Uid:   -> 1000 1000 1000 1000    (correct)
+      let raw: string;
       try {
-        return statSync(`/proc/${pid}/environ`).uid;
+        raw = readFileSync(`/proc/${pid}/status`, "utf8");
       } catch (err: any) {
         if (err?.code === "ENOENT" || err?.code === "ESRCH") return null;
-        if (err?.code === "EACCES") return null; // metadata itself blocked, treat as not-ours
+        // hidepid / LSM blocks even the metadata: we cannot reason about
+        // this pid at all, and it cannot be a process we spawned and can
+        // still see. Skip rather than throw.
+        if (err?.code === "EACCES" || err?.code === "EPERM") return null;
         throw err;
       }
+      // `Uid:\t<real>\t<effective>\t<saved>\t<fs>` — field 0 is the real uid.
+      const m = raw.match(/^Uid:\s*(\d+)/m);
+      if (!m) return null;
+      const uid = Number(m[1]);
+      return Number.isFinite(uid) ? uid : null;
     },
     readState(pid: number): string | null {
       // /proc/<pid>/stat field-after-comm[0] is state. We already have readStat
@@ -476,23 +555,132 @@ export interface ScanResult {
   /** Pids whose environ we successfully read and matched the marker uuid. */
   hits: number[];
   /**
-   * Pids we had to SKIP due to EACCES on own-uid running-state process.
-   * These pids MIGHT be marker-carrying but we couldn't verify. Reap flow
-   * uses this to REFUSE marker removal even when hits=0 (defense against
-   * Defect A: silently missing a marker-carrying process, then deleting
-   * the marker as if teardown succeeded).
+   * Own-uid, live, environ-unreadable pids that are PLAUSIBLY PART OF THE
+   * COPRESENCE TREE (invariant 11 scope test). These might be marker-
+   * carrying without us being able to prove it, so the reap flow REFUSES
+   * marker removal while this list is non-empty — defense against Defect A
+   * (silently missing a marker-carrying process, then deleting the marker
+   * as if teardown had succeeded).
    */
   unreadableOwnUid: number[];
+  /**
+   * Own-uid, live, environ-unreadable pids that failed the scope test:
+   * their pgid belongs to no marker-carrying group and their ppid chain
+   * reaches no marker carrier / validated marker-file session pid.
+   *
+   * INFORMATIONAL ONLY — never fail-closed. A machine routinely has such
+   * processes (a same-uid process whose primary GID differs from ours fails
+   * the kernel's __ptrace_may_access gid check and EACCESes on environ even
+   * though its real uid matches). v2 lumped these into unreadableOwnUid,
+   * which made reapMarkerGroups structurally unable to return success on
+   * any such host.
+   *
+   * KNOWN RESIDUAL GAP (stated rather than papered over): a marker-carrying
+   * process that is BOTH non-dumpable (environ unreadable) AND fully
+   * detached (setsid'd into its own pgroup with ppid=1, no live recorded
+   * session pid above it) lands here and is therefore not reaped and does
+   * not block marker removal. Nothing in /proc exposes the environment of a
+   * non-dumpable task to a non-root reader, so no scope widening can
+   * recover it — only running teardown as root could. Widening scope to
+   * "every same-uid unreadable process" is NOT an acceptable trade: that is
+   * exactly the v2 behaviour that made teardown never succeed. The
+   * realistic copresence shape (child of a recorded pane pid, or sharing a
+   * marker carrier's pgroup) IS covered — see the real-/proc test.
+   */
+  unreadableOutOfScope: number[];
+}
+
+/**
+ * Marker-file session records used to anchor the invariant-11 scope test.
+ * Each entry must be re-validated (pid alive AND same starttime) before it
+ * is trusted — see validateAnchors.
+ */
+export interface ScanAnchors {
+  sessions?: Array<{ pid: number; starttime_jiffies: number }>;
+}
+
+export function anchorsFromMarker(marker: CopresenceMarker): ScanAnchors {
+  const sessions: Array<{ pid: number; starttime_jiffies: number }> = [];
+  for (const key of ["appsrv", "bridge", "tui"] as const) {
+    const s = marker.sessions?.[key];
+    if (!s) continue;
+    if (!Number.isInteger(s.pid) || s.pid <= 0) continue;
+    sessions.push({ pid: s.pid, starttime_jiffies: s.starttime_jiffies });
+  }
+  return { sessions };
+}
+
+/**
+ * Invariant 5 in force: a recorded session pid may anchor the scope test
+ * only if the pid is still alive AND its /proc/PID/stat starttime matches
+ * what was recorded when the marker was written. A recycled pid has a
+ * different starttime and is dropped, so a stale marker can never widen the
+ * scope onto an unrelated process that happens to have inherited the pid.
+ */
+function validateAnchors(
+  enumer: ProcessEnumerator,
+  anchors: ScanAnchors | undefined,
+): { pids: Set<number>; pgids: Set<number> } {
+  const pids = new Set<number>();
+  const pgids = new Set<number>();
+  for (const s of anchors?.sessions || []) {
+    let stat: ProcStat | null;
+    try { stat = enumer.readStat(s.pid); } catch { continue; }
+    if (stat == null) continue; // recorded pid is gone
+    if (stat.starttime_jiffies !== s.starttime_jiffies) continue; // pid recycled
+    pids.add(s.pid);
+    if (stat.pgid > 0) pgids.add(stat.pgid);
+  }
+  return { pids, pgids };
+}
+
+const SCOPE_ANCESTRY_MAX_DEPTH = 64;
+
+/**
+ * Invariant 11 scope test: is `pid` plausibly part of the copresence tree?
+ *
+ * True when the pid IS an anchor, when its pgid belongs to a marker-carrying
+ * group (or a validated anchor's group), or when walking its ppid chain
+ * reaches an anchor / marker carrier / a pid inside a relevant pgroup.
+ *
+ * Everything else is out of scope and must not participate in a fail-closed
+ * decision, no matter how unreadable it is.
+ */
+export function isInCopresenceScope(
+  enumer: ProcessEnumerator,
+  pid: number,
+  relevantPids: Set<number>,
+  relevantPgids: Set<number>,
+): boolean {
+  if (relevantPids.has(pid)) return true;
+  let stat: ProcStat | null;
+  try { stat = enumer.readStat(pid); } catch { return false; }
+  if (stat == null) return false;
+  if (relevantPgids.has(stat.pgid)) return true;
+  let cur = stat.ppid;
+  const seen = new Set<number>([pid]);
+  for (let depth = 0; depth < SCOPE_ANCESTRY_MAX_DEPTH; depth++) {
+    if (cur <= 1 || seen.has(cur)) break;
+    seen.add(cur);
+    if (relevantPids.has(cur)) return true;
+    let up: ProcStat | null;
+    try { up = enumer.readStat(cur); } catch { break; }
+    if (up == null) break;
+    if (relevantPgids.has(up.pgid)) return true;
+    cur = up.ppid;
+  }
+  return false;
 }
 
 export function scanEnvironForMarker(enumer: ProcessEnumerator, markerUuid: string): number[] {
   return scanEnvironForMarkerFull(enumer, markerUuid).hits;
 }
 
-export function scanEnvironForMarkerFull(enumer: ProcessEnumerator, markerUuid: string): ScanResult {
-  if (typeof markerUuid !== "string" || markerUuid.length === 0) {
-    throw new Error("scanEnvironForMarker: markerUuid must be a non-empty string");
-  }
+export function scanEnvironForMarkerFull(
+  enumer: ProcessEnumerator,
+  markerUuid: string,
+  anchors?: ScanAnchors,
+): ScanResult {
   if (typeof markerUuid !== "string" || markerUuid.length === 0) {
     throw new Error("scanEnvironForMarker: markerUuid must be a non-empty string");
   }
@@ -500,46 +688,65 @@ export function scanEnvironForMarkerFull(enumer: ProcessEnumerator, markerUuid: 
   const ownUid = process.getuid ? process.getuid()! : -1;
   const pids = enumer.listAllPids();
   const hits: number[] = [];
-  const unreadableOwnUid: number[] = [];
+  // Own-uid, live pids whose environ we could not read. Scope is applied in
+  // a SECOND pass, because the scope anchors include the hit set itself and
+  // that is not known until the first pass finishes.
+  const unreadableCandidates: number[] = [];
   for (const pid of pids) {
     let env: string | null;
     try {
       env = enumer.readEnviron(pid);
     } catch (err: any) {
-      // Blocker 1 fix (audit 92d53c8f + practical Linux calibration).
-      //
-      // Real /proc has many pids where readEnviron EACCES even when the pid
-      // "appears" ours by directory stat: sd-pam (env owned by root),
-      // docker/podman daemons (dumpable=0), systemd session leaders,
-      // ptrace-locked, exec2-transitioning, etc.
+      // Real /proc has many pids where readEnviron EACCESes:
+      //   - other users' processes (uid mismatch)
+      //   - same uid but different primary gid (kernel __ptrace_may_access
+      //     checks BOTH uid and gid — e.g. a process whose primary group is
+      //     `docker` while ours is our own login group)
+      //   - non-dumpable processes (prctl(PR_SET_DUMPABLE, 0))
+      //   - ptrace-stopped, zombie, execve-transitioning
       //
       // Discrimination:
-      //   - Non-EACCES error → throw (real problem, not a permission thing)
-      //   - env-file uid != ours → skip (not ours)
-      //   - state Z/X/T/t or other non-R/S/D → skip (mm-locked/dying)
-      //   - Otherwise (own-uid, running state, still EACCES) →
-      //     record in unreadableOwnUid list. Caller uses this to refuse
-      //     removing the marker file (defense against Defect A: if we
-      //     silently skipped and reported hits=0, marker would be deleted
-      //     as if teardown succeeded, but a real marker-carrying process
-      //     might have been in the unreadable set).
+      //   - Non-EACCES error   → throw (real problem, not a permission thing)
+      //   - real uid != ours   → skip (cannot be one of our processes)
+      //   - state not R/S/D    → skip (zombie / mm-locked / dying)
+      //   - otherwise          → candidate; the scope test below decides
+      //     whether it is fail-closed material or informational noise.
       if (err?.code !== "EACCES") throw err;
-      let envOwnerUid: number | null;
-      try { envOwnerUid = enumer.readOwnerUid(pid); } catch { continue; }
-      if (envOwnerUid == null) continue;
-      if (envOwnerUid !== ownUid) continue;
+      let procUid: number | null;
+      try { procUid = enumer.readOwnerUid(pid); } catch { continue; }
+      if (procUid == null) continue;
+      if (procUid !== ownUid) continue;
       let state: string | null;
       try { state = enumer.readState(pid); } catch { continue; }
       if (state == null) continue;
       if (state !== "R" && state !== "S" && state !== "D") continue;
-      unreadableOwnUid.push(pid);
+      unreadableCandidates.push(pid);
       continue;
     }
     if (env == null) continue; // pid raced away, normal
     const parts = env.split("\0");
     if (parts.indexOf(needle) >= 0) hits.push(pid);
   }
-  return { hits, unreadableOwnUid };
+
+  // Second pass — invariant 11. Anchors are (a) validated marker-file
+  // session pids and their live pgroups, plus (b) every marker carrier we
+  // just found and its pgroup.
+  const validated = validateAnchors(enumer, anchors);
+  const relevantPids = new Set<number>(validated.pids);
+  const relevantPgids = new Set<number>(validated.pgids);
+  for (const hit of hits) {
+    relevantPids.add(hit);
+    let stat: ProcStat | null;
+    try { stat = enumer.readStat(hit); } catch { continue; }
+    if (stat != null && stat.pgid > 0) relevantPgids.add(stat.pgid);
+  }
+  const unreadableOwnUid: number[] = [];
+  const unreadableOutOfScope: number[] = [];
+  for (const pid of unreadableCandidates) {
+    if (isInCopresenceScope(enumer, pid, relevantPids, relevantPgids)) unreadableOwnUid.push(pid);
+    else unreadableOutOfScope.push(pid);
+  }
+  return { hits, unreadableOwnUid, unreadableOutOfScope };
 }
 
 export function groupPidsByPgid(enumer: ProcessEnumerator, pids: number[]): Map<number, number[]> {
@@ -606,8 +813,28 @@ export function verifyGroupHomogeneity(
     try {
       stat = enumer.readStat(pid);
     } catch (err: any) {
-      // A process in the enumeration list whose stat we can't read is suspicious;
-      // fail-closed rather than assume it's not in the group.
+      // Blocker 3 fix (invariant 11 at the group level). v2 pushed EVERY
+      // stat-unreadable pid onto the global `unreadable` list BEFORE the
+      // pgid filter, so one unrelated process anywhere on the machine whose
+      // /proc/PID/stat could not be read (hidepid, LSM, container policy,
+      // exotic namespace) turned EVERY group into ENUM_ERROR and nothing was
+      // ever killed. Machine-wide coupling, same defect family as the
+      // machine-wide unreadable scan list.
+      //
+      // We cannot apply the pgid filter to a pid whose stat we could not
+      // read — the pgid is exactly what we failed to learn. So we bound the
+      // fail-closed signal by ownership instead: /proc/PID/stat is 0444 on
+      // Linux, so a read failure means a policy layer is hiding that task
+      // from us entirely. If we cannot even establish its real uid
+      // (readOwnerUid → null, i.e. /proc/PID/status is hidden too), or the
+      // uid is not ours, the task lives outside our reach and provably
+      // cannot be a member of a pgroup we created — informational skip.
+      // Only an OWN-uid task we somehow cannot stat is genuinely alarming,
+      // and that keeps the fail-closed trigger inside our own uid.
+      let procUid: number | null;
+      try { procUid = enumer.readOwnerUid(pid); } catch { continue; }
+      if (procUid == null) continue;
+      if (procUid !== ownUid) continue;
       unreadable.push(pid);
       continue;
     }
@@ -725,6 +952,17 @@ export interface ReapOptions {
    * the event loop; test coverage missed it because tests passed graceMs=0.
    */
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * Invariant-11 scope anchors, normally `anchorsFromMarker(marker)`.
+   *
+   * Without them the only anchors are the marker carriers the scan itself
+   * found, so a marker-carrying process we cannot READ (non-dumpable) but
+   * whose parent IS a recorded session pid would be judged out of scope and
+   * silently dropped. Passing the marker's recorded session pids closes that
+   * hole; each one is re-validated (alive + same starttime) before it can
+   * widen scope, so a stale/recycled pid cannot.
+   */
+  anchors?: ScanAnchors;
 }
 
 /**
@@ -755,9 +993,9 @@ export async function reapMarkerGroups(
   // as "success + delete marker" when the unreadable list is non-empty
   // recreates Defect A. Instead we return kind:"failed" and preserve the
   // marker for retry.
-  const scan = scanEnvironForMarkerFull(enumer, markerUuid);
+  const scan = scanEnvironForMarkerFull(enumer, markerUuid, opts.anchors);
   const pids = scan.hits;
-  opts.logger(`[identity] environ scan found ${pids.length} marker-carrying pid(s), ${scan.unreadableOwnUid.length} own-uid unreadable`);
+  opts.logger(`[identity] environ scan found ${pids.length} marker-carrying pid(s), ${scan.unreadableOwnUid.length} in-scope unreadable, ${scan.unreadableOutOfScope.length} out-of-scope unreadable (informational)`);
   if (pids.length === 0 && scan.unreadableOwnUid.length === 0) {
     return { kind: "success", killedPgids: [], residualPids: [] };
   }
@@ -827,7 +1065,7 @@ export async function reapMarkerGroups(
   }
 
   // Step 8: post-rescan
-  const rescan = scanEnvironForMarkerFull(enumer, markerUuid);
+  const rescan = scanEnvironForMarkerFull(enumer, markerUuid, opts.anchors);
   const residual = rescan.hits;
   if (residual.length > 0 || rescan.unreadableOwnUid.length > 0) {
     return {
@@ -842,4 +1080,110 @@ export async function reapMarkerGroups(
     };
   }
   return { kind: "success", killedPgids, residualPids: [] };
+}
+
+// ─── Start-side identity preparation (blockers 5 + 6) ────────────────────
+
+export interface PrepareStartDeps {
+  /** Usually () => readMarker(nodesDir, nodeId). */
+  readMarker(): ReadMarkerResult;
+  /** Usually (uuid, anchors) => reapMarkerGroups(realEnumerator(), realKiller(), uuid, {...anchors}). */
+  reap(uuid: string, anchors: ScanAnchors): Promise<ReapResult>;
+  /** Usually () => removeMarker(nodesDir, nodeId). */
+  removeMarker(): void;
+  /** Usually (uuid, sessions) => writeMarker(nodesDir, nodeId, uuid, sessions). */
+  writeMarker(uuid: string, sessions: CopresenceMarker["sessions"]): void;
+  logger(msg: string): void;
+}
+
+export type PrepareStartResult =
+  | { kind: "ok"; reclaimedUuid?: string }
+  | { kind: "blocked"; cause: "STALE_TREE_ALIVE" | "UNUSABLE_MARKER"; detail: string; remedy: string };
+
+/**
+ * Everything that must happen BEFORE the first `tmux new-session` of a
+ * copresence start. Extracted out of cli.ts so both blockers below are
+ * actually reachable by tests — the audit's point that the two fatal
+ * defects of the previous rounds both lived in an untested cli.ts seam.
+ *
+ * Blocker 5 — marker-before-tmux ordering.
+ *   v2 wrote the marker only after the app-server had bound its port, i.e.
+ *   after a 25s wait and after several `process.exit(1)` paths. A start that
+ *   died in that window left a live, marker-carrying tmux session behind
+ *   with NO marker file on disk: the exact unreclaimable-ghost this feature
+ *   exists to prevent. The marker is now written here, before any session is
+ *   created, with an empty `sessions` object — reap identity has always been
+ *   the environ uuid, never the recorded pids, so an empty sessions object
+ *   loses nothing but observability hints (which the start path fills in
+ *   later, best-effort).
+ *
+ * Blocker 6 — never overwrite a preserved marker.
+ *   A failed stop deliberately PRESERVES the marker so the next stop can
+ *   retry idempotently. v2's start then overwrote it with a fresh uuid while
+ *   only killing tmux sessions BY NAME, so the still-running subprocesses of
+ *   the previous instance became permanently unreclaimable: their uuid was
+ *   gone from disk forever. Now the old identity is reaped FIRST; if that
+ *   reap does not fully succeed we refuse to start rather than destroy the
+ *   only handle on those processes.
+ */
+export async function prepareIdentityForStart(
+  newUuid: string,
+  deps: PrepareStartDeps,
+): Promise<PrepareStartResult> {
+  if (typeof newUuid !== "string" || newUuid.length === 0) {
+    throw new Error("prepareIdentityForStart: newUuid must be a non-empty string");
+  }
+  const existing = deps.readMarker();
+  let reclaimedUuid: string | undefined;
+
+  if (existing.kind === "ok") {
+    const oldUuid = existing.marker.marker;
+    if (oldUuid === newUuid) {
+      // Caller reused a uuid — that can only be a bug (randomUUID collision
+      // is not a thing). Refuse rather than conflate two generations.
+      return {
+        kind: "blocked",
+        cause: "UNUSABLE_MARKER",
+        detail: `refusing to start: the new identity uuid equals the existing marker's uuid`,
+        remedy: `This is an internal error — the start path must generate a fresh uuid per start.`,
+      };
+    }
+    deps.logger(`existing identity marker found (uuid=${oldUuid.slice(0, 8)}…) — reclaiming its processes before starting a new generation`);
+    const result = await deps.reap(oldUuid, anchorsFromMarker(existing.marker));
+    if (result.kind !== "success") {
+      return {
+        kind: "blocked",
+        cause: "STALE_TREE_ALIVE",
+        detail: `previous copresence generation (uuid=${oldUuid.slice(0, 8)}…) could not be fully reclaimed: ${result.detail}`,
+        remedy: `Run \`anet node stop\` for this node again (the marker is preserved, retry is idempotent). Overwriting the marker now would lose the only handle on ${result.residualPids.length} surviving process(es) forever.`,
+      };
+    }
+    deps.removeMarker();
+    reclaimedUuid = oldUuid;
+    deps.logger(`previous generation reclaimed (${result.killedPgids.length} pgroup(s) killed)`);
+  } else if (existing.cause === "STALE_BOOT_ID") {
+    // The host rebooted since the marker was written, so every process it
+    // could possibly refer to is gone by definition. Safe to discard.
+    deps.logger(`stale marker from a previous boot discarded (${existing.detail})`);
+    deps.removeMarker();
+  } else if (existing.cause !== "MISSING") {
+    // SYMLINK / NOT_REGULAR / WRONG_MODE / OWNER_MISMATCH / PARSE_ERROR /
+    // SCHEMA_INVALID / PLATFORM_UNSUPPORTED. In every one of these we cannot
+    // learn the previous uuid, so we cannot reclaim the previous generation.
+    // Overwriting would be exactly the blocker-6 data loss, and for the
+    // security-shaped causes (symlink / foreign owner / wrong mode) writing
+    // through would also mean writing into something an attacker planted.
+    return {
+      kind: "blocked",
+      cause: "UNUSABLE_MARKER",
+      detail: `an identity marker exists but cannot be read (${existing.cause}): ${existing.detail}`,
+      remedy: `Inspect the marker file. If no copresence processes from a previous run survive, delete it and start again.`,
+    };
+  }
+
+  // Blocker 5: marker on disk BEFORE any marker-carrying session exists.
+  // `sessions` is intentionally empty — observability hints get filled in
+  // later, best-effort; identity is the uuid alone.
+  deps.writeMarker(newUuid, {});
+  return { kind: "ok", reclaimedUuid };
 }

--- a/agent-network/src/tmux-capability.test.ts
+++ b/agent-network/src/tmux-capability.test.ts
@@ -1,0 +1,111 @@
+// RFC-030 P3-A blocker 12 — tmux capability preflight.
+
+import { describe, expect, test } from "bun:test";
+import {
+  parseTmuxVersion,
+  tmuxSupportsSessionEnv,
+  checkTmuxCapability,
+  assertTmuxSupportsSessionEnv,
+} from "./tmux-capability";
+
+describe("parseTmuxVersion", () => {
+  test("parses the shapes real tmux builds print", () => {
+    expect(parseTmuxVersion("tmux 3.2a")).toMatchObject({ major: 3, minor: 2, suffix: "a" });
+    expect(parseTmuxVersion("tmux 3.0a\n")).toMatchObject({ major: 3, minor: 0, suffix: "a" });
+    expect(parseTmuxVersion("tmux 3.4")).toMatchObject({ major: 3, minor: 4, suffix: "" });
+    expect(parseTmuxVersion("tmux next-3.4")).toMatchObject({ major: 3, minor: 4 });
+    expect(parseTmuxVersion("tmux 2.9")).toMatchObject({ major: 2, minor: 9 });
+    expect(parseTmuxVersion("tmux 1.10")).toMatchObject({ major: 1, minor: 10 });
+  });
+
+  test("returns null when there is no version to find", () => {
+    expect(parseTmuxVersion("tmux master")).toBeNull();
+    expect(parseTmuxVersion("")).toBeNull();
+    expect(parseTmuxVersion(undefined as unknown as string)).toBeNull();
+  });
+});
+
+describe("tmuxSupportsSessionEnv", () => {
+  test("3.2 is the floor; the letter suffix is a patch marker and never lifts a version over it", () => {
+    // Ubuntu 20.04 LTS ships 3.0a and Debian bullseye 3.1c. Both LOOK like
+    // "3.x with a letter" and both reject `new-session -e`.
+    expect(tmuxSupportsSessionEnv(parseTmuxVersion("tmux 3.0a")!)).toBe(false);
+    expect(tmuxSupportsSessionEnv(parseTmuxVersion("tmux 3.1c")!)).toBe(false);
+    expect(tmuxSupportsSessionEnv(parseTmuxVersion("tmux 3.2")!)).toBe(true);
+    expect(tmuxSupportsSessionEnv(parseTmuxVersion("tmux 3.2a")!)).toBe(true);
+    expect(tmuxSupportsSessionEnv(parseTmuxVersion("tmux 3.5a")!)).toBe(true);
+  });
+
+  test("major version dominates the minor comparison", () => {
+    expect(tmuxSupportsSessionEnv(parseTmuxVersion("tmux 2.9")!)).toBe(false);
+    expect(tmuxSupportsSessionEnv(parseTmuxVersion("tmux 2.99")!)).toBe(false);
+    expect(tmuxSupportsSessionEnv(parseTmuxVersion("tmux 4.0")!)).toBe(true);
+  });
+});
+
+describe("checkTmuxCapability", () => {
+  test("too old → actionable verdict naming the required version", () => {
+    const v = checkTmuxCapability(() => "tmux 3.0a");
+    expect(v.kind).toBe("too_old");
+    if (v.kind === "too_old") {
+      expect(v.detail).toContain("3.2");
+      expect(v.remedy.join(" ")).toContain("Upgrade tmux");
+    }
+  });
+
+  test("tmux absent → missing verdict, not a crash", () => {
+    const v = checkTmuxCapability(() => { throw Object.assign(new Error("spawn tmux ENOENT"), { code: "ENOENT" }); });
+    expect(v.kind).toBe("missing");
+  });
+
+  test("unparseable version → unknown (permissive: never refuse a tmux that may be fine)", () => {
+    expect(checkTmuxCapability(() => "tmux master").kind).toBe("unknown");
+  });
+
+  test("modern tmux → ok", () => {
+    expect(checkTmuxCapability(() => "tmux 3.4").kind).toBe("ok");
+  });
+});
+
+describe("assertTmuxSupportsSessionEnv (cli wrapper)", () => {
+  function run(out: string | (() => never)) {
+    const logs: string[] = [];
+    let failed: string | null = null;
+    const fail = ((m: string) => { failed = m; throw new Error("__exit__"); }) as (m: string) => never;
+    try {
+      assertTmuxSupportsSessionEnv(
+        typeof out === "string" ? () => out : out,
+        (m) => logs.push(m),
+        fail,
+      );
+    } catch (e: any) {
+      if (e?.message !== "__exit__") throw e;
+    }
+    return { logs, failed: failed as string | null };
+  }
+
+  test("old tmux aborts the start with an explanation", () => {
+    const r = run("tmux 3.0a");
+    expect(r.failed).not.toBeNull();
+    expect(r.failed).toContain("3.2");
+    expect(r.failed).toContain("Upgrade tmux");
+  });
+
+  test("missing tmux aborts the start", () => {
+    const r = run((() => { throw new Error("ENOENT"); }) as () => never);
+    expect(r.failed).not.toBeNull();
+  });
+
+  test("modern tmux is silent and does not abort", () => {
+    const r = run("tmux 3.4");
+    expect(r.failed).toBeNull();
+    expect(r.logs).toEqual([]);
+  });
+
+  test("unknown version warns but does NOT abort", () => {
+    const r = run("tmux master");
+    expect(r.failed).toBeNull();
+    expect(r.logs.length).toBe(1);
+    expect(r.logs[0]).toContain("3.2");
+  });
+});

--- a/agent-network/src/tmux-capability.ts
+++ b/agent-network/src/tmux-capability.ts
@@ -1,0 +1,125 @@
+// RFC-030 P3 blocker 12 — tmux capability preflight for copresence start.
+//
+// The copresence start path injects the identity marker with
+// `tmux new-session -e KEY=VALUE`. The `-e` flag on `new-session` was added
+// in tmux 3.2; before that, `new-session` accepts no `-e` and tmux exits
+// with a raw usage error. Ubuntu 20.04 LTS still ships 3.0a, Debian
+// bullseye ships 3.1c — both fail. Without a preflight the operator sees
+// tmux's own "usage: new-session ..." dump from the FIRST session creation
+// and the whole start dies with no explanation, which is a regression in
+// the start path relative to the pre-identity baseline (which used no -e).
+//
+// Kept in its own module with a pure parser so the version comparison is
+// unit-testable without a tmux binary.
+
+/** Lowest tmux version whose `new-session` understands `-e KEY=VALUE`. */
+export const MIN_TMUX_MAJOR = 3;
+export const MIN_TMUX_MINOR = 2;
+
+export interface TmuxVersion {
+  major: number;
+  minor: number;
+  /** Trailing letter suffix, e.g. the "a" of "3.0a". Not used for ordering. */
+  suffix: string;
+  raw: string;
+}
+
+/**
+ * Parse the output of `tmux -V`, e.g.:
+ *   "tmux 3.2a"        → { major: 3, minor: 2,  suffix: "a" }
+ *   "tmux 3.0a"        → { major: 3, minor: 0,  suffix: "a" }
+ *   "tmux 3.4"         → { major: 3, minor: 4,  suffix: ""  }
+ *   "tmux next-3.4"    → { major: 3, minor: 4,  suffix: ""  }
+ *   "tmux 2.9"         → { major: 2, minor: 9,  suffix: ""  }
+ *
+ * Returns null when no version can be extracted (unknown build, empty
+ * output, `tmux master` with no numbers). Callers must treat null as
+ * "unknown" and NOT as "too old" — refusing to start on an unparseable
+ * version string would break hosts whose tmux is perfectly capable.
+ */
+export function parseTmuxVersion(raw: string): TmuxVersion | null {
+  if (typeof raw !== "string") return null;
+  const m = raw.match(/(\d+)\.(\d+)([a-z]*)/i);
+  if (!m) return null;
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) return null;
+  return { major, minor, suffix: (m[3] || "").toLowerCase(), raw: raw.trim() };
+}
+
+/**
+ * True when this version's `new-session` supports `-e KEY=VALUE` (>= 3.2).
+ * Note 3.0a / 3.1c sort BELOW 3.2 — the letter suffix is a patch marker,
+ * never a minor bump, so it must not participate in the comparison.
+ */
+export function tmuxSupportsSessionEnv(v: TmuxVersion): boolean {
+  if (v.major !== MIN_TMUX_MAJOR) return v.major > MIN_TMUX_MAJOR;
+  return v.minor >= MIN_TMUX_MINOR;
+}
+
+export type TmuxCapabilityVerdict =
+  | { kind: "ok"; version: TmuxVersion }
+  | { kind: "unknown"; detail: string }
+  | { kind: "too_old"; version: TmuxVersion; detail: string; remedy: string[] }
+  | { kind: "missing"; detail: string; remedy: string[] };
+
+/**
+ * Pure decision function — `runVersionCmd` returns `tmux -V` output, or
+ * throws if tmux is absent/unrunnable. Split from the printing/exiting
+ * wrapper so tests drive every branch without a tmux binary.
+ */
+export function checkTmuxCapability(runVersionCmd: () => string): TmuxCapabilityVerdict {
+  let raw: string;
+  try {
+    raw = runVersionCmd();
+  } catch (e: any) {
+    return {
+      kind: "missing",
+      detail: `could not run \`tmux -V\`: ${e?.message || e}`,
+      remedy: [
+        "Copresence mode runs its three pieces inside tmux sessions.",
+        "Install tmux 3.2 or newer, then start the node again.",
+      ],
+    };
+  }
+  const version = parseTmuxVersion(raw);
+  if (!version) {
+    return { kind: "unknown", detail: `could not parse a version out of \`tmux -V\` output: ${JSON.stringify(raw)}` };
+  }
+  if (!tmuxSupportsSessionEnv(version)) {
+    return {
+      kind: "too_old",
+      version,
+      detail: `tmux ${version.major}.${version.minor}${version.suffix} is too old: \`new-session -e KEY=VALUE\` requires tmux ${MIN_TMUX_MAJOR}.${MIN_TMUX_MINOR}+`,
+      remedy: [
+        "Copresence start injects the teardown identity marker into every tmux",
+        "session with `new-session -e`. Without it a stopped node can leave",
+        "unreclaimable subprocesses behind, so this is not optional.",
+        "Upgrade tmux to 3.2 or newer (Ubuntu 20.04 ships 3.0a — the tmux",
+        "package from a newer release, a distro backport, or a source build",
+        "all work), then start the node again.",
+      ],
+    };
+  }
+  return { kind: "ok", version };
+}
+
+/**
+ * cli.ts wrapper: run the check, print an actionable message, and exit
+ * non-zero when tmux cannot carry the marker. `unknown` is deliberately
+ * permissive — we log and continue.
+ */
+export function assertTmuxSupportsSessionEnv(
+  runVersionCmd: () => string,
+  log: (msg: string) => void,
+  fail: (msg: string) => never,
+): void {
+  const verdict = checkTmuxCapability(runVersionCmd);
+  if (verdict.kind === "ok") return;
+  if (verdict.kind === "unknown") {
+    log(`[anet] ⚠ ${verdict.detail} — continuing; if session creation fails with a tmux usage error, upgrade to tmux ${MIN_TMUX_MAJOR}.${MIN_TMUX_MINOR}+`);
+    return;
+  }
+  const lines = [`[anet] ❌ ${verdict.detail}`, ...verdict.remedy.map((r) => `[anet]    ${r}`)];
+  fail(lines.join("\n"));
+}


### PR DESCRIPTION
RFC-030 P3-A 第 4 轮候选。前三轮均因「单测全绿但真实 Linux 上 100% 不工作」被独立审查打回。

**下列数字与行为均为通信龙亲自重跑，非采信作者自述。**

## 结构性根因（前三轮真正的病灶）

所有单测都注入 mock（`MockEnumer`/`MockKiller`），`realEnumerator`/`realKiller` 在测试文件里**零引用**。因此 mutation testing 全红也只证明「mock 与实现自洽」，打的是 mock 那一侧，**真实代码从未被执行过**。

复审判据：「把真实实现整个删掉换成空函数，有没有测试会红？」

```
v2：realEnumerator 在测试中出现 0 次   → 真实实现零覆盖
v3：realEnumerator 18 次 / realKiller 14 次
    把 realEnumerator 换成空实现 → 10 个测试转红
    （含 B/C/D/E 与 F: REAL REAP — reapMarkerGroups(realEnumerator, realKiller)
      真杀一个真实携带者并返回 success）
```

## 决定性验证：v2 的致命缺陷是否真的消除

v2 被打回的**唯一决定性判据**是「`reapMarkerGroups` 在真实主机上永远不可能返回 success」——fail-closed 集合取全机器范围，一个同 uid 不同主 GID 的进程（本机确实存在）就会让每次共存停止都打印 `⚠ identity teardown incomplete` 并留下 marker，即使 teardown 完全干净。

在真实 `/proc` 上用 `realEnumerator()` 只读扫描（未杀任何进程）：

```
hits                 = 0
unreadableOwnUid     = 0     ← 范围内、会 fail-closed 的集合为空
unreadableOutOfScope = 7     ← 仅信息性
```

**这 7 个正是 v2 会计入 fail-closed 而导致永久失败的进程。** 死结解除。

## 非 dumpable 携带者（Defect A 的另一条路径）

v2 用 `/proc/PID/environ` 的 **inode 属主**判进程归属，而 `prctl(PR_SET_DUMPABLE,0)` 会让我们自己子进程的 environ inode 报 uid 0 → 该 marker 携带者**既不在 hits 也不在 unreadable** → reap 返回 success → marker 被删 → 孤儿永久无法回收。

v3 改用 `/proc/PID/status` 的 `Uid:` 行。复审实测（真实 fork + `PR_SET_DUMPABLE=0`，**fixture 先自检再断言**）：

```
FIXTURE OK: leader=<pid> 非dumpable子=<pid> 同 pgid, 子 environ inode 属主 uid=0
hits             = [leader]
unreadableOwnUid = [非dumpable子]        ← 进入 fail-closed，阻止误删 marker
```

## 存活变异体已消除

v2 中把 `residual.length > 0 || rescan.unreadableOwnUid.length > 0` 改成 `residual.length > 0`，**52/52 仍全绿**（rescan 后那半边防线零覆盖）。

v3 同一变异 → `285 pass / 1 fail`，红在 `Blocker 7: post-kill RESCAN unreadable half also preserves the marker`。

## 其余各项（均含 witnessed-red）

| 项 | 验证 |
|---|---|
| 4 — `readMarker` 先查 MISSING 再查 PLATFORM_UNSUPPORTED | 代码确认；否则 macOS/Windows 上**每个节点**（含 claude-code-cli / codex-sdk）`anet node stop` 都会误报「marker 存在但被拒 / 疑似损坏」，而根本没有 marker |
| 5 — marker 在第一个 `tmux new-session` 之前落盘 | 移除 `prepareIdentityForStart` 调用 → 红在 `Blocker 5: prepareIdentityForStart runs BEFORE the first tmux new-session` |
| 11 — 重复守卫已删 | 确认 |
| 12 — tmux ≥ 3.2 前置检查 | 移除 `assertTmuxSupportsSessionEnv` → 红在 `Blocker 12: the tmux capability preflight runs BEFORE the first tmux new-session` |
| 8 — 过时不变量 | 未删注释了事，而是**真的实现**了 `validateAnchors`（starttime 比对） |

全量：`286 pass / 0 fail`。

## 诚实记录的限制（作者自陈，复审核实属实）

1. **`bin/cli.ts` 的调用顺序是结构性门（源码顺序断言），不是行为测试。** 该文件 12k 行、调用 `process.exit()`、spawn tmux，无法 import 进单测。可行为化的决策逻辑**已被抽出**成独立模块（`prepareIdentityForStart`、`checkTmuxCapability`）并有真实单测；结构门只覆盖「cli.ts 是否调用它们、顺序对不对」这一残余面。测试文件头部对此有明确说明，未粉饰。
2. **已知残余缺口**：同时满足「非 dumpable」**且**「完全脱离进程树（setsid 自成 pgroup、ppid=1、其上无存活的已记录 session pid）」的 marker 携带者会落进 out-of-scope，因而不被回收、也不阻止 marker 删除。非 root 读不到非 dumpable 任务的环境，无法通过扩大范围解决——而扩大到「所有同 uid 不可读进程」正是 v2 那个让 teardown 永不成功的做法。代码中对此有显式记述。

## 尚未验证 / 不随本 PR 放行

**真实 codex 三件套的端到端 teardown 未跑**（TERM→grace→KILL 全链、真实 codex 子进程回收、tmux 会话消解后 legacy sweep 确为 no-op、从 TUI 内部触发的自杀拒绝）。

因此：**本 PR 只合入代码修复（相对 v2 的坏状态是严格改进），不构成发版许可。** 发 npm 前仍需真实 codex E2E，并按既定边界先经 Vincent 确认。
