### PR TITLE
fix(#476): server.ts 模块级 setInterval 移入 startHub 并 unref

### DIFF
--- a/server/src/boot-side-effect.test.ts
+++ b/server/src/boot-side-effect.test.ts
@@ -36,6 +36,54 @@ describe("#438 corrective — importing server.ts is side-effect-free", () => {
   });
 });
 
+describe("#476 — import alone must let the process exit", () => {
+  test("a subprocess that only imports server.js exits by itself (no module-level timers hold the loop)", () => {
+    // Witnessed-red: pre-#476 (main 541a80aa) this child is killed by the
+    // timeout with a non-zero exit — two module-level setIntervals
+    // (rate-limit sweep + DB-writing task patrol) held the event loop
+    // after a bare import. Post-#476 both live inside startHub, so the
+    // child exits 0 on its own. Runs in a subprocess because the parent
+    // test process has its own handles and can't observe loop-emptiness.
+    const child = Bun.spawnSync({
+      cmd: ["bun", "-e", 'await import("./src/server.js");'],
+      cwd: `${import.meta.dir}/..`,
+      env: { ...process.env, COMMHUB_DB: process.env.COMMHUB_DB || "/tmp/anet-476-probe.db" },
+      timeout: 10_000,
+    });
+    expect(child.exitCode).toBe(0);
+  }, 15_000);
+
+  test("the moved task patrol actually FIRES under startHub (not just registered-looking)", () => {
+    // Fake-gate guard for the #476 move: stub patrolExpiredTasks to a
+    // no-op (or forget to register it in startHub) and this goes red.
+    // Runs in a subprocess because startHub is single-shot per process
+    // and the patrol period is shrunk via env for observability.
+    const script = `
+      process.env.COMMHUB_TASK_PATROL_MS = "100";
+      const { startHub } = await import("./src/server.js");
+      const { db } = await import("./src/db.js");
+      const hub = startHub({ port: 0, hostname: "127.0.0.1" });
+      db.run("DELETE FROM tasks WHERE task_id = 't476_patrol'");
+      db.run("INSERT INTO tasks (task_id, from_name, to_name, priority, status, content, created_at, expires_at) " +
+             "VALUES ('t476_patrol', 'a', 'b', 'normal', 'delivered', 'x', datetime('now'), datetime('now', '-1 minute'))");
+      await new Promise((r) => setTimeout(r, 600));
+      const row = db.get("SELECT status FROM tasks WHERE task_id = 't476_patrol'");
+      console.log("PATROL_RESULT:" + (row ? row.status : "missing"));
+      db.run("DELETE FROM tasks WHERE task_id = 't476_patrol'");
+      hub.stop(true);
+      process.exit(0);
+    `;
+    const child = Bun.spawnSync({
+      cmd: ["bun", "-e", script],
+      cwd: `${import.meta.dir}/..`,
+      env: { ...process.env, COMMHUB_DB: process.env.COMMHUB_DB || "/tmp/anet-476-patrol.db" },
+      timeout: 15_000,
+    });
+    const out = new TextDecoder().decode(child.stdout);
+    expect(out).toContain("PATROL_RESULT:expired");
+  }, 20_000);
+});
+
 describe("#438 corrective — startHub is explicit, single-shot, observable", () => {
   test("startHub boots a live hub; second call throws with first boot's coordinates; bootServer stays available", async () => {
     const { startHub, bootServer, getStartedHub } = await import("./server.js") as any;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -99,13 +99,15 @@ function checkRateLimit(ip: string, maxPerMinute = 60): boolean {
   entry.count++;
   return true;
 }
-// Cleanup stale entries every 5 minutes
-setInterval(() => {
+// Cleanup stale entries every 5 minutes. Interval is registered in
+// startHub() (#476) — module scope must stay timer-free so importing
+// this module neither holds the event loop open nor does periodic work.
+function sweepStaleRateLimits(): void {
   const now = Date.now();
   for (const [ip, entry] of rateLimits) {
     if (now > entry.resetAt) rateLimits.delete(ip);
   }
-}, 300000);
+}
 
 // ── Factory: 每个请求创建新的 McpServer（stateless 模式）──
 function createServer(clientIP?: string, enforceNetworkId?: string | null, enforceUserId?: string | null, callerAlias?: string | null, callerTokenIsNetwork = false, callerTokenId?: string | null): McpServer {
@@ -501,7 +503,10 @@ const wsTmuxIntervals = new Map<object, ReturnType<typeof setInterval>>();
 
 
 // ── Task expiration patrol (every 5 minutes) ──
-setInterval(() => {
+// Registered in startHub() (#476): this WRITES the DB, so it must never
+// run as an import side effect — a tool/test importing this module with
+// COMMHUB_DB unset would patrol the production database.
+function patrolExpiredTasks(): void {
   try {
     const result = db.run(
       `UPDATE tasks SET status = 'expired', completed_at = datetime('now')
@@ -516,7 +521,7 @@ setInterval(() => {
       for (const t of expired) logTaskEvent(t.task_id, null, "expired", "patrol");
     }
   } catch {}
-}, 5 * 60 * 1000);
+}
 
 // #434 — test-safety seam, same signature as PR #438 so the two branches
 // merge cleanly. Wraps the sole Bun.serve config in a factory so
@@ -2532,17 +2537,33 @@ export function startHub(opts?: { port?: number; hostname?: string }): ReturnTyp
   // every COMMHUB_STALE_SWEEP_SECONDS (default 60s).
   const staleSweeperTimer = startStaleSessionSweeper();
 
-  // The Bun.serve socket is what keeps the process alive; the sweepers
-  // must not — otherwise a test (or a future caller) that stops the
-  // server would still hang on two live intervals it cannot reach.
+  // #476 — the two legacy module-level intervals, now owned by startHub
+  // like every other periodic job: rate-limit map cleanup (memory only)
+  // and task expiration patrol (writes DB — must never run on import).
+  // Periods env-overridable so tests can observe a real firing without
+  // waiting minutes (mirrors COMMHUB_RETENTION_SWEEP_MINUTES above).
+  const rateLimitSweepMs = Number(process.env.COMMHUB_RATELIMIT_SWEEP_MS) > 0
+    ? Number(process.env.COMMHUB_RATELIMIT_SWEEP_MS) : 300000;
+  const taskPatrolMs = Number(process.env.COMMHUB_TASK_PATROL_MS) > 0
+    ? Number(process.env.COMMHUB_TASK_PATROL_MS) : 5 * 60 * 1000;
+  const rateLimitSweepTimer = setInterval(sweepStaleRateLimits, rateLimitSweepMs);
+  const taskPatrolTimer = setInterval(patrolExpiredTasks, taskPatrolMs);
+
+  // The Bun.serve socket is what keeps the process alive; the periodic
+  // jobs must not — otherwise a test (or a future caller) that stops the
+  // server would still hang on live intervals it cannot reach.
   (retentionSweeperTimer as any)?.unref?.();
   (staleSweeperTimer as any)?.unref?.();
+  (rateLimitSweepTimer as any)?.unref?.();
+  (taskPatrolTimer as any)?.unref?.();
 
   // ── Graceful shutdown ───────────────────────────────
   function shutdown() {
     console.log("[commhub] shutting down...");
     clearInterval(retentionSweeperTimer);
     clearInterval(staleSweeperTimer);
+    clearInterval(rateLimitSweepTimer);
+    clearInterval(taskPatrolTimer);
     db.close();
     process.exit(0);
   }


### PR DESCRIPTION
## 背景

#475 把 hub 改成显式启动函数后，`import` 仍非完全零副作用：`server.ts` 里还剩 2 个模块级 `setInterval`（`:103` rate-limit 清理、`:504` 每 5 分钟写 DB 的过期任务巡逻）。#476 归档了这两处。

## 改动

两个 interval 改为具名函数，注册移进 `startHub()`，与既有 retention / stale sweeper 一致：同样 `unref`、同样在 shutdown 时清理。周期新增 env 覆盖（`COMMHUB_RATELIMIT_SWEEP_MS` / `COMMHUB_TASK_PATROL_MS`，默认值不变），以便测试能观察到真实触发而不是只断言"注册了"。

## 验证

作者给了四项证据，**独立验收方逐条自跑复核，未采信描述**：

1. **witnessed red → green，两个基线各自跑过**：baseline `541a80aa` 上裸 `import server.js` 的子进程被吊住、`rc=124`；候选 `rc=0` 自然退出。已做成常驻回归用例。
2. **防假门是真的**：新增用例断言的是「100ms 周期下，真实 hub 实例里的过期任务行被 interval 真正翻成 `expired`」（断言 DB 状态），而不是「interval 注册了没有」。容器副本里 stub 掉 `patrolExpiredTasks` 该用例如约转红，复原即绿。
3. **合跑 ×2，全仓 559/0**（#475 时 557，净增 2 吻合）。验收方主动披露：首轮曾得 554/5，原因是其 harness 只拷贝了 `server/` 目录，5 个红全是需要兄弟包在位的跨包 drift guard，**同一残缺环境下基线的 fail 集完全相同**，全仓重跑即净 —— 非候选问题。
4. **发布路径**：`npm pack` → 干净目录安装 → 真跑 bin → `/health` 200（2s）→ `SIGTERM` 1s 退出 `rc=0` 带 shutdown 日志。

判据用 **rc + 时序**，未使用 pm2 状态字段 —— 因为实测确认：pm2 一旦设置 `exp_backoff_restart_delay`，就永远不会进入 `errored`，`max_restarts` 实际失效，状态字段不可作为判据。

**finding B 由验收方独立验证**：把 shutdown 的 `process.exit(0)` 换成 `server.stop(true)` 后，`SIGTERM` 触发纯事件循环 2s 自然退出 —— 即「A 已消除，`process.exit` 变成纯双保险」成立。

全程 Docker + 高位端口 + 临时 DB，零生产接触。报告与脚本：`docs/tests/p476-interval-gate/`。

无阻塞项。

Closes #476
