### PR TITLE
security(#473): /health 移除 SSE 会话键明细，明细移入需鉴权端点

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -801,19 +801,52 @@ function authHeaders(token?: string): Record<string, string> {
 // moved OFF the anonymous /health body (it leaked the whole agent
 // topology) and behind auth at GET /api/stats/sse. Returns the SAME
 // `sessions` map getSSEStats() always produced, so downstream key lookups
-// are unchanged. Degrades gracefully: non-admin (403), unreachable, or
-// any parse error → {} (empty detail), NEVER a throw and NEVER a fake 0
-// masquerading as "hub is dead". Callers that only need the COUNT should
-// read health.sse_connections (an aggregate that stayed on /health).
-async function fetchSseSessions(hub: string): Promise<Record<string, number>> {
+// are unchanged.
+//
+// TRISTATE by design (审查 round-2, 通信龙): the map alone can't tell
+// "genuinely 0 connections" from "I'm not allowed to see" — a non-admin
+// user gets 403 here, and rendering that as "0 connected" is a LIE that
+// reads as "hub is dead". So `ok` distinguishes them: ok=false means the
+// detail is unavailable (403 / unreachable / bad JSON), and callers must
+// then show "unknown" or fall back to the anonymous aggregate
+// health.sse_connections — never 0. Never throws.
+type SseDetail = { ok: boolean; sessions: Record<string, number> };
+async function fetchSseSessions(hub: string): Promise<SseDetail> {
   try {
     const res = await fetch(`${hub}/api/stats/sse`, { headers: authHeaders() });
-    if (!res.ok) return {};
+    if (!res.ok) return { ok: false, sessions: {} };
     const body = await res.json() as any;
-    return (body && typeof body.sessions === "object" && body.sessions) || {};
+    const sessions = (body && typeof body.sessions === "object" && body.sessions) || {};
+    return { ok: true, sessions };
   } catch {
-    return {};
+    return { ok: false, sessions: {} };
   }
+}
+
+// #473 — anonymous aggregate connection count from /health (never gated,
+// every user can read it). The reliable source for "how many SSE
+// connections" when the per-alias detail is unavailable.
+async function fetchSseConnectionCount(hub: string): Promise<number | null> {
+  try {
+    const res = await fetch(`${hub}/health`, { headers: authHeaders() });
+    if (!res.ok) return null;
+    const body = await res.json() as any;
+    return typeof body.sse_connections === "number" ? body.sse_connections : null;
+  } catch {
+    return null;
+  }
+}
+
+// #473 — "are all these aliases SSE-connected?" for the orchestration
+// wait-loops. Prefers precise per-alias detail; when that's unavailable
+// (non-admin 403) falls back to the aggregate count so a non-admin
+// operator doesn't sit through the full 60s empty wait while the agents
+// are actually already up (审查 round-2 non-blocking item).
+async function sseAllConnected(hub: string, aliases: string[]): Promise<boolean> {
+  const detail = await fetchSseSessions(hub);
+  if (detail.ok) return aliases.every(a => (detail.sessions[a] || 0) >= 1);
+  const count = await fetchSseConnectionCount(hub);
+  return count !== null && count >= aliases.length;
 }
 
 function loadGlobal(): Record<string, any> {
@@ -4539,7 +4572,9 @@ async function lsCommand() {
   // Fetch CommHub status first
   const gc = loadGlobal();
   let networkSessions: any[] = [];
-  let sseSessions: Record<string, number> = {};
+  // #473 tristate: sseDetail.ok=false → detail unavailable (non-admin/403),
+  // per-node column shows "?" not a false "not connected".
+  let sseDetail: SseDetail = { ok: false, sessions: {} };
 
   if (gc.hub) {
     try {
@@ -4548,7 +4583,7 @@ async function lsCommand() {
         fetchSseSessions(gc.hub), // #473: was /health.sse_sessions (now auth-gated)
       ]);
       networkSessions = statusRes.sessions || [];
-      sseSessions = sseRes;
+      sseDetail = sseRes;
     } catch {}
   }
 
@@ -4574,7 +4609,7 @@ async function lsCommand() {
       // Match with CommHub
       const ns: any = networkSessions.find((n: any) => n.alias === displayName || n.node_id === p?.node_id);
       const serverStatus = ns ? ns.status : (localAlive ? "starting" : "offline");
-      const sseConnected = sseSessions[displayName] ? "●" : "○";
+      const sseConnected = !sseDetail.ok ? "?" : (sseDetail.sessions[displayName] ? "●" : "○");
 
       const statusIcon = serverStatus === "idle" ? "idle" :
                          serverStatus === "working" ? "working" :
@@ -4635,7 +4670,7 @@ async function lsCommand() {
         if (match) {
           const alias = match[1].trim();
           const ns: any = networkSessions.find((n: any) => n.alias === alias);
-          const sse = sseSessions[alias] ? "●" : "○";
+          const sse = !sseDetail.ok ? "?" : (sseDetail.sessions[alias] ? "●" : "○");
           network = ns ? `${alias} ${ns.status} ${sse}` : `${alias} (not registered)`;
         }
       }
@@ -8087,9 +8122,13 @@ async function statusCommand() {
   if (!hub) { console.log("No hub configured. Run: anet init"); return; }
 
   try {
-    const [statusRes, sse, tasksRes] = await Promise.all([
+    // #473: this summary line needs only the COUNT, so read the anonymous
+    // aggregate health.sse_connections — every user can read it. Using the
+    // per-alias detail's key-count here was the regression that showed
+    // non-admins "0 connected" (detail 403 → {} → 0) on a live hub.
+    const [statusRes, sseCount, tasksRes] = await Promise.all([
       fetch(`${hub}/api/status`, { headers: authHeaders() }).then(r => r.json() as any).catch(() => ({ sessions: [] })),
-      fetchSseSessions(hub), // #473: was /health.sse_sessions (now auth-gated)
+      fetchSseConnectionCount(hub),
       fetch(`${hub}/api/tasks?limit=10`, { headers: authHeaders() }).then(r => r.json() as any).catch(() => ({ tasks: [] })),
     ]);
 
@@ -8113,7 +8152,7 @@ async function statusCommand() {
 
     console.log(`\n  CommHub: ${hub}`);
     console.log(`  Agents: ${summary.idle || 0} idle, ${summary.working || 0} working, ${summary.offline || 0} offline`);
-    console.log(`  SSE:    ${Object.keys(sse).length} connected`);
+    console.log(`  SSE:    ${sseCount === null ? "unknown" : `${sseCount} connected`}`);
     console.log(`  Tasks:  ${tasks.length} recent\n`);
 
     if (working.length > 0) {
@@ -9521,8 +9560,10 @@ async function demoDebateCommand() {
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 2000));
     try {
-      const sse = await fetchSseSessions(hub); // #473: detail auth-gated off /health
-      const allUp = DEBATE_ROLES.every(r => sse[roleAliases[r]] >= 1);
+      // #473: sseAllConnected prefers per-alias detail, falls back to
+      // the aggregate count when detail is 403'd (non-admin) — no 60s
+      // empty wait, no false "not connected".
+      const allUp = await sseAllConnected(hub, DEBATE_ROLES.map(r => roleAliases[r]));
       if (allUp) { console.log(`        ✓ 6 agent 全部 SSE connected`); break; }
     } catch {}
   }
@@ -9907,8 +9948,7 @@ async function demoSocialMediaCommand() {
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 2000));
     try {
-      const sse = await fetchSseSessions(hub); // #473: detail auth-gated off /health
-      const allUp = SOCIAL_ROLES.every(r => sse[roleAliases[r]] >= 1);
+      const allUp = await sseAllConnected(hub, SOCIAL_ROLES.map(r => roleAliases[r]));
       if (allUp) { console.log(`        ✓ 4 agent 全部 SSE connected`); break; }
     } catch {}
   }
@@ -10330,8 +10370,7 @@ async function demoPrReviewCommand() {
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 2000));
     try {
-      const sse = await fetchSseSessions(hub); // #473: detail auth-gated off /health
-      const allUp = PR_REVIEW_ROLES.every(r => sse[roleAliases[r]] >= 1);
+      const allUp = await sseAllConnected(hub, PR_REVIEW_ROLES.map(r => roleAliases[r]));
       if (allUp) { console.log(`        ✓ 4 agent 全部 SSE connected`); break; }
     } catch {}
   }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -797,6 +797,25 @@ function authHeaders(token?: string): Record<string, string> {
   return t ? { Authorization: `Bearer ${t}` } : {};
 }
 
+// #473 — the per-connection SSE breakdown (`{networkId}:{alias}` → count)
+// moved OFF the anonymous /health body (it leaked the whole agent
+// topology) and behind auth at GET /api/stats/sse. Returns the SAME
+// `sessions` map getSSEStats() always produced, so downstream key lookups
+// are unchanged. Degrades gracefully: non-admin (403), unreachable, or
+// any parse error → {} (empty detail), NEVER a throw and NEVER a fake 0
+// masquerading as "hub is dead". Callers that only need the COUNT should
+// read health.sse_connections (an aggregate that stayed on /health).
+async function fetchSseSessions(hub: string): Promise<Record<string, number>> {
+  try {
+    const res = await fetch(`${hub}/api/stats/sse`, { headers: authHeaders() });
+    if (!res.ok) return {};
+    const body = await res.json() as any;
+    return (body && typeof body.sessions === "object" && body.sessions) || {};
+  } catch {
+    return {};
+  }
+}
+
 function loadGlobal(): Record<string, any> {
   const p = globalConfigPath();
   if (existsSync(p)) try { return JSON.parse(readFileSync(p, "utf-8")); } catch {}
@@ -4524,12 +4543,12 @@ async function lsCommand() {
 
   if (gc.hub) {
     try {
-      const [statusRes, healthRes] = await Promise.all([
+      const [statusRes, sseRes] = await Promise.all([
         fetch(`${gc.hub}/api/status`, { headers: authHeaders() }).then(r => r.json() as any),
-        fetch(`${gc.hub}/health`, { headers: authHeaders() }).then(r => r.json() as any),
+        fetchSseSessions(gc.hub), // #473: was /health.sse_sessions (now auth-gated)
       ]);
       networkSessions = statusRes.sessions || [];
-      sseSessions = healthRes.sse_sessions || {};
+      sseSessions = sseRes;
     } catch {}
   }
 
@@ -8068,14 +8087,13 @@ async function statusCommand() {
   if (!hub) { console.log("No hub configured. Run: anet init"); return; }
 
   try {
-    const [statusRes, healthRes, tasksRes] = await Promise.all([
+    const [statusRes, sse, tasksRes] = await Promise.all([
       fetch(`${hub}/api/status`, { headers: authHeaders() }).then(r => r.json() as any).catch(() => ({ sessions: [] })),
-      fetch(`${hub}/health`, { headers: authHeaders() }).then(r => r.json() as any).catch(() => ({})),
+      fetchSseSessions(hub), // #473: was /health.sse_sessions (now auth-gated)
       fetch(`${hub}/api/tasks?limit=10`, { headers: authHeaders() }).then(r => r.json() as any).catch(() => ({ tasks: [] })),
     ]);
 
     const sessions = statusRes.sessions || [];
-    const sse = healthRes.sse_sessions || {};
     const tasks = tasksRes.tasks || [];
 
     const classifyStatus = (s: any) => {
@@ -9503,8 +9521,7 @@ async function demoDebateCommand() {
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 2000));
     try {
-      const h = await fetch(`${hub}/health`).then(r => r.json() as any);
-      const sse = h?.sse_sessions || {};
+      const sse = await fetchSseSessions(hub); // #473: detail auth-gated off /health
       const allUp = DEBATE_ROLES.every(r => sse[roleAliases[r]] >= 1);
       if (allUp) { console.log(`        ✓ 6 agent 全部 SSE connected`); break; }
     } catch {}
@@ -9890,8 +9907,7 @@ async function demoSocialMediaCommand() {
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 2000));
     try {
-      const h = await fetch(`${hub}/health`).then(r => r.json() as any);
-      const sse = h?.sse_sessions || {};
+      const sse = await fetchSseSessions(hub); // #473: detail auth-gated off /health
       const allUp = SOCIAL_ROLES.every(r => sse[roleAliases[r]] >= 1);
       if (allUp) { console.log(`        ✓ 4 agent 全部 SSE connected`); break; }
     } catch {}
@@ -10314,8 +10330,7 @@ async function demoPrReviewCommand() {
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 2000));
     try {
-      const h = await fetch(`${hub}/health`).then(r => r.json() as any);
-      const sse = h?.sse_sessions || {};
+      const sse = await fetchSseSessions(hub); // #473: detail auth-gated off /health
       const allUp = PR_REVIEW_ROLES.every(r => sse[roleAliases[r]] >= 1);
       if (allUp) { console.log(`        ✓ 4 agent 全部 SSE connected`); break; }
     } catch {}
@@ -11659,7 +11674,7 @@ async function doctorCommand() {
       check("CommHub reachable", health.ok === true, `${gc.hub} v${health.version || "?"}`);
       if (health.api_version) info("API version", health.api_version);
       info("Sessions", `${health.sessions_count || health.sessions || 0} registered`);
-      info("SSE connections", `${Object.keys(health.sse_sessions || {}).length} active`);
+      info("SSE connections", `${health.sse_connections ?? 0} active`); // #473: aggregate stayed on /health
       if (health.license) info("License", health.license);
       if (health.multi_network) check("Multi-network", true);
     } catch (e: any) {

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -837,16 +837,21 @@ async function fetchSseConnectionCount(hub: string): Promise<number | null> {
   }
 }
 
-// #473 — "are all these aliases SSE-connected?" for the orchestration
-// wait-loops. Prefers precise per-alias detail; when that's unavailable
-// (non-admin 403) falls back to the aggregate count so a non-admin
-// operator doesn't sit through the full 60s empty wait while the agents
-// are actually already up (审查 round-2 non-blocking item).
-async function sseAllConnected(hub: string, aliases: string[]): Promise<boolean> {
+// #473 — "are all these SPECIFIC aliases SSE-connected?" for the
+// orchestration wait-loops. TRISTATE (审查 round-2b, 通信龙): the aggregate
+// count CANNOT answer this — `sse_connections >= aliases.length` is true
+// whenever N unrelated nodes are connected, which would falsely claim
+// "all connected" while a/b/c/d are all down. That's the same class of
+// lie as the fake 0, just inverted. So when the per-alias detail is
+// unavailable (non-admin 403 / unreachable), we return "unknown" and the
+// caller must say so honestly rather than guess from the count.
+//   "yes"     — every alias has ≥1 connection (verified)
+//   "no"      — detail readable, at least one alias not yet connected
+//   "unknown" — detail not readable; cannot assert either way
+async function sseAllConnected(hub: string, aliases: string[]): Promise<"yes" | "no" | "unknown"> {
   const detail = await fetchSseSessions(hub);
-  if (detail.ok) return aliases.every(a => (detail.sessions[a] || 0) >= 1);
-  const count = await fetchSseConnectionCount(hub);
-  return count !== null && count >= aliases.length;
+  if (!detail.ok) return "unknown";
+  return aliases.every(a => (detail.sessions[a] || 0) >= 1) ? "yes" : "no";
 }
 
 function loadGlobal(): Record<string, any> {
@@ -9560,11 +9565,12 @@ async function demoDebateCommand() {
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 2000));
     try {
-      // #473: sseAllConnected prefers per-alias detail, falls back to
-      // the aggregate count when detail is 403'd (non-admin) — no 60s
-      // empty wait, no false "not connected".
-      const allUp = await sseAllConnected(hub, DEBATE_ROLES.map(r => roleAliases[r]));
-      if (allUp) { console.log(`        ✓ 6 agent 全部 SSE connected`); break; }
+      // #473: tristate — never GUESS from the aggregate count that these
+      // specific aliases are up. "unknown" (non-admin/unreachable) → say
+      // so and proceed, don't claim connected and don't burn the full 60s.
+      const state = await sseAllConnected(hub, DEBATE_ROLES.map(r => roleAliases[r]));
+      if (state === "yes") { console.log(`        ✓ 6 agent 全部 SSE connected`); break; }
+      if (state === "unknown") { console.log(`        ⚠ 无法确认 6 个 agent 的 SSE 连接状态（需 admin 权限查看明细），继续执行`); break; }
     } catch {}
   }
 
@@ -9948,8 +9954,9 @@ async function demoSocialMediaCommand() {
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 2000));
     try {
-      const allUp = await sseAllConnected(hub, SOCIAL_ROLES.map(r => roleAliases[r]));
-      if (allUp) { console.log(`        ✓ 4 agent 全部 SSE connected`); break; }
+      const state = await sseAllConnected(hub, SOCIAL_ROLES.map(r => roleAliases[r]));
+      if (state === "yes") { console.log(`        ✓ 4 agent 全部 SSE connected`); break; }
+      if (state === "unknown") { console.log(`        ⚠ 无法确认 4 个 agent 的 SSE 连接状态（需 admin 权限查看明细），继续执行`); break; }
     } catch {}
   }
 
@@ -10370,8 +10377,9 @@ async function demoPrReviewCommand() {
   for (let i = 0; i < 30; i++) {
     await new Promise(r => setTimeout(r, 2000));
     try {
-      const allUp = await sseAllConnected(hub, PR_REVIEW_ROLES.map(r => roleAliases[r]));
-      if (allUp) { console.log(`        ✓ 4 agent 全部 SSE connected`); break; }
+      const state = await sseAllConnected(hub, PR_REVIEW_ROLES.map(r => roleAliases[r]));
+      if (state === "yes") { console.log(`        ✓ 4 agent 全部 SSE connected`); break; }
+      if (state === "unknown") { console.log(`        ⚠ 无法确认 4 个 agent 的 SSE 连接状态（需 admin 权限查看明细），继续执行`); break; }
     } catch {}
   }
 

--- a/server/src/health-redaction.test.ts
+++ b/server/src/health-redaction.test.ts
@@ -91,6 +91,18 @@ describe("#473 anonymous /health — watchdog contract intact, no topology leak"
     expect(body.sse_connections).toBeGreaterThanOrEqual(1);
   });
 
+  test("CLI count source stays truthful: health.sse_connections == /api/stats/sse total (no fake 0)", async () => {
+    // The CLI's `anet doctor` line reads health.sse_connections now
+    // (was Object.keys(sse_sessions).length). This pins that aggregate to
+    // the same number the auth-gated detail endpoint reports — so a live
+    // hub with N connections shows N, never the "0 active" regression the
+    // review caught. There is exactly one live SSE connection in setup.
+    const health = await (await fetch(`${BASE}/health`)).json() as any;
+    const detail = await (await fetch(`${BASE}/api/stats/sse`, { headers: { Authorization: `Bearer ${adminToken}` } })).json() as any;
+    expect(health.sse_connections).toBe(detail.total);
+    expect(health.sse_connections).toBeGreaterThanOrEqual(1);
+  });
+
   test("does NOT expose SSE key detail: no sse_sessions field, no alias, no network id", async () => {
     const res = await fetch(`${BASE}/health`);
     const text = await res.text();
@@ -122,4 +134,43 @@ describe("#473 GET /api/stats/sse — detail survives, behind ops auth", () => {
     expect(typeof body.total).toBe("number");
     expect(body.sessions[`${userNetworkId}:${userName}`]).toBeGreaterThanOrEqual(1);
   });
+
+  test("legacy master token → 200 (ops path — restAuth null, isLegacyAuthToken)", () => {
+    // COMMHUB_AUTH_TOKEN is captured at module import, so this path needs
+    // a fresh process with the env set before boot (aggregate order can't
+    // guarantee this file imports server.ts first). Subprocess, like the
+    // patrol test. Reviewer flagged this path had code but no test.
+    const script = `
+      process.env.COMMHUB_AUTH_TOKEN = "master-secret-xyz";
+      const { startHub } = await import("./src/server.js");
+      const hub = startHub({ port: 0, hostname: "127.0.0.1" });
+      const base = "http://127.0.0.1:" + hub.port;
+      const anon = await fetch(base + "/api/stats/sse");
+      const master = await fetch(base + "/api/stats/sse", { headers: { Authorization: "Bearer master-secret-xyz" } });
+      const health = await fetch(base + "/health");
+      const hb = await health.json();
+      console.log("RESULT:" + JSON.stringify({
+        anon: anon.status,
+        master: master.status,
+        masterOk: (await master.json()).ok,
+        healthHasSseSessions: "sse_sessions" in hb,
+      }));
+      hub.stop(true);
+      process.exit(0);
+    `;
+    const child = Bun.spawnSync({
+      cmd: ["bun", "-e", script],
+      cwd: `${import.meta.dir}/..`,
+      env: { ...process.env, COMMHUB_DB: process.env.COMMHUB_DB || "/tmp/anet-473-master.db" },
+      timeout: 15_000,
+    });
+    const out = new TextDecoder().decode(child.stdout);
+    const m = out.match(/RESULT:(\{.*\})/);
+    expect(m).not.toBeNull();
+    const r = JSON.parse(m![1]);
+    expect(r.anon).toBe(401);        // token configured → anonymous rejected
+    expect(r.master).toBe(200);      // legacy master token → ops access
+    expect(r.masterOk).toBe(true);
+    expect(r.healthHasSseSessions).toBe(false); // /health still redacted with a token set
+  }, 20_000);
 });

--- a/server/src/health-redaction.test.ts
+++ b/server/src/health-redaction.test.ts
@@ -1,0 +1,125 @@
+// #473 — /health information-leak redaction.
+//
+// Public-hub audit (通信龙, 2026-07-30) showed anonymous GET /health
+// returning the full SSE key breakdown: `{networkId}:{alias}` for every
+// live connection — network id + all 95 agent aliases on the audited
+// hub. The fix keeps /health anonymous (HARD CONSTRAINT: the central
+// watchdog curls it every minute; auth here would blind it) but strips
+// the per-key detail down to aggregate counts; the detail moved behind
+// auth at GET /api/stats/sse (master token or admin only).
+//
+// Witnessed-red: on pre-fix main (8c11edf5) the "no leak" test below is
+// red — the /health body contains the connected alias and network id.
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { register } from "./auth.js";
+import { db } from "./db.js";
+
+const SERVER_DB = mkdtempSync(join(tmpdir(), "anet-health-red-db-")) + "/commhub.db";
+
+let BASE = "";
+let server: any = null;
+let sseReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+let userToken = "";
+let userNetworkId = "";
+let userName = "";
+let adminToken = "";
+
+beforeAll(async () => {
+  process.env.COMMHUB_DB = process.env.COMMHUB_DB || SERVER_DB;
+  process.env.HOST = "127.0.0.1";
+
+  const suffix = `${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+  const pw = "BootstrapPw123Aa!";
+
+  // Burn a seed registration first so our member is NOT auto-admin (the
+  // "first registered user → admin" rule only bites when this suite owns
+  // the DB; per-file runs need this guard). We set roles explicitly below.
+  register(`health_seed_${suffix}`, pw, undefined, "seed");
+
+  userName = `health_user_${suffix}`;
+  const r = register(userName, pw, undefined, "seed");
+  if (!r.ok || !r.token) throw new Error("register failed: " + JSON.stringify(r));
+  userToken = r.token;
+  userNetworkId = r.network_id ?? "";
+  if (!userNetworkId) throw new Error("no network for user");
+  // Pin to plain member — defend against any residual auto-admin.
+  db.run("UPDATE users SET role = 'user' WHERE username = ?1", [userName]);
+
+  const adminName = `health_admin_${suffix}`;
+  const a = register(adminName, pw, undefined, "seed");
+  if (!a.ok || !a.token) throw new Error("admin register failed: " + JSON.stringify(a));
+  adminToken = a.token;
+  // Explicit promotion — "first registered user is auto-admin" does not
+  // hold in aggregate runs (see api-host-supervisors-fallback.test.ts).
+  db.run("UPDATE users SET role = 'admin' WHERE username = ?1", [adminName]);
+
+  const { bootServer } = await import("./server.js");
+  server = bootServer({ port: 0, hostname: "127.0.0.1" });
+  BASE = `http://127.0.0.1:${server.port}`;
+
+  // Open a real SSE connection so the stats have a key that WOULD leak:
+  // the dashboard-user channel (sessionName === own username, Path 3
+  // gate 4a) registers `${networkId}:${username}` in the clients map.
+  const res = await fetch(`${BASE}/events/${encodeURIComponent(userName)}?network_id=${userNetworkId}`, {
+    headers: { Authorization: `Bearer ${userToken}` },
+  });
+  if (res.status !== 200) throw new Error("SSE subscribe failed: " + res.status);
+  sseReader = res.body!.getReader();
+  await sseReader.read(); // consume the connected frame → registration done
+});
+
+afterAll(() => {
+  try { sseReader?.cancel(); } catch {}
+  try { server?.stop?.(true); } catch {}
+  try { rmSync(SERVER_DB, { recursive: true, force: true }); } catch {}
+});
+
+describe("#473 anonymous /health — watchdog contract intact, no topology leak", () => {
+  test("stays anonymous 200 with parseable aggregates (watchdog judge: curl -sf gets 2xx)", async () => {
+    const res = await fetch(`${BASE}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.ok).toBe(true);
+    expect(typeof body.version).toBe("string");
+    expect(typeof body.sessions_count).toBe("number");
+    expect(typeof body.sse_connections).toBe("number");
+    expect(body.sse_connections).toBeGreaterThanOrEqual(1);
+  });
+
+  test("does NOT expose SSE key detail: no sse_sessions field, no alias, no network id", async () => {
+    const res = await fetch(`${BASE}/health`);
+    const text = await res.text();
+    const body = JSON.parse(text);
+    expect("sse_sessions" in body).toBe(false);
+    // The live connection's identifying strings must not appear anywhere
+    // in the anonymous body.
+    expect(text).not.toContain(userName);
+    expect(text).not.toContain(userNetworkId);
+  });
+});
+
+describe("#473 GET /api/stats/sse — detail survives, behind ops auth", () => {
+  test("anonymous → 401", async () => {
+    const res = await fetch(`${BASE}/api/stats/sse`);
+    expect(res.status).toBe(401);
+  });
+
+  test("regular member token → 403 (detail spans every network)", async () => {
+    const res = await fetch(`${BASE}/api/stats/sse`, { headers: { Authorization: `Bearer ${userToken}` } });
+    expect(res.status).toBe(403);
+  });
+
+  test("admin → 200 with the full key breakdown (ops capability preserved)", async () => {
+    const res = await fetch(`${BASE}/api/stats/sse`, { headers: { Authorization: `Bearer ${adminToken}` } });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.ok).toBe(true);
+    expect(typeof body.total).toBe("number");
+    expect(body.sessions[`${userNetworkId}:${userName}`]).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1199,6 +1199,12 @@ return Bun.serve({
     // network, so per-network filtering would be required to open it
     // wider; no consumer needs that today.
     if (url.pathname === "/api/stats/sse") {
+      // restAuth === null here means the caller passed the legacy master
+      // token (requireAuth already accepted it above) OR the hub runs in
+      // DEV_OPEN mode. Both are treated as ops: master token is root, and
+      // under DEV_OPEN this endpoint is anonymously readable BY DESIGN
+      // (dev convenience — production never sets COMMHUB_DEV_OPEN, so the
+      // topology detail stays gated in every real deployment).
       if (restAuth && !isAdmin) {
         return withCors(req, Response.json({ ok: false, error: "admin or master token required" }, { status: 403 }));
       }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1146,6 +1146,17 @@ return Bun.serve({
 
     // ── REST: health (public, no auth) ──
     if (url.pathname === "/health") {
+      // #473 — /health is ANONYMOUS BY CONTRACT (the central watchdog
+      // cron curls it every minute to decide dead-or-alive; adding auth
+      // here would blind it — do NOT add requireAuth, do NOT change the
+      // 200-with-JSON shape without telling the watchdog owner first).
+      // Anonymous callers get AGGREGATES ONLY. The per-key SSE detail
+      // (`{networkId}:{alias}` + observer keys) used to be inlined here,
+      // which handed any internet stranger the full network id + all
+      // agent aliases (95 on the public hub when audited) — that detail
+      // now lives behind auth at GET /api/stats/sse.
+      // `version` stays: it does help fingerprinting, but ops needs it
+      // to verify deploys land, and the tradeoff was accepted in review.
       const count = db.get<{ cnt: number }>("SELECT COUNT(*) as cnt FROM sessions");
       const sse = getSSEStats();
       const license = db.get<any>("SELECT type, expires_at FROM licenses LIMIT 1");
@@ -1156,7 +1167,6 @@ return Bun.serve({
         transport: "streamable-http",
         sessions_count: count?.cnt ?? 0,
         sse_connections: sse.total,
-        sse_sessions: sse.sessions,
         auth: DEV_OPEN ? "dev-open" : "user-token",
         security: DEV_OPEN ? "dev-open" : "secured",
         tmux: TMUX_ENABLED ? "enabled" : "disabled",
@@ -1178,6 +1188,22 @@ return Bun.serve({
     const restScope = resolveRestNetworkScope(url, restAuth, isAdmin);
     if (restScope.denied) {
       return withCors(req, Response.json({ ok: false, error: restScope.denied }, { status: 403 }));
+    }
+
+    // ── #473 REST: SSE connection detail (ops-only) ──
+    // The per-key breakdown /health used to expose anonymously: keys are
+    // `{networkId}:{alias}` (+ `\0netobs:{networkId}` observer keys via
+    // printableKey), i.e. the full network/agent topology. Ops-scoped:
+    // legacy master token (restAuth null once requireAuth passed) or an
+    // admin user. Regular members get 403 — the detail spans EVERY
+    // network, so per-network filtering would be required to open it
+    // wider; no consumer needs that today.
+    if (url.pathname === "/api/stats/sse") {
+      if (restAuth && !isAdmin) {
+        return withCors(req, Response.json({ ok: false, error: "admin or master token required" }, { status: 403 }));
+      }
+      const sse = getSSEStats();
+      return withCors(req, Response.json({ ok: true, total: sse.total, sessions: sse.sessions }));
     }
 
     // ── REST: all sessions status ──


### PR DESCRIPTION
## 背景

`/health` 匿名可读，且返回体里带 `sse_sessions` 的**键明细**（`{networkId}:{alias}`）。

**这不是理论风险，线上实测可复现**：公网 `http://<hub-host>:9200/health` 匿名 HTTP 200，返回内容包含网络 ID、**全部在线节点别名**（等于把团队与项目结构摊开）、会话数、hub 版本号、license 状态。端口直接 bind `0.0.0.0`，不在反代之后。

**爆炸半径是收敛的**：扫描确认只有 `/health` 匿名可读；`/api/nodes`、`/api/tasks`、`/api/servers`、`/api/networks`、`/mcp` 全部正确返回 401。所以定性为**单点信息泄露**，不是鉴权体系失效。

## 改动

- `/health` **保持匿名、保持 200、保持 JSON 可解析、未加任何鉴权、未改成 204**
- 仅移除 `sse_sessions` 的键明细；保留聚合 `sse_connections` / `sessions_count` / `version`
- 键明细移至新端点 `GET /api/stats/sse`（ops 作用域：master token 或 admin 可读，普通成员 403，匿名 401）

`version` 保留的权衡已在代码注释中写明（便于运维核对部署落地）。

## 为什么不能给 /health 加鉴权

hub 的 cron 看门狗靠**匿名** `curl -sf /health` 判断存活。加鉴权会让看门狗永远判定 hub 已死 —— 虽然它有"端口二次确认"兜底不会误起第二个实例，但会持续刷告警日志，并在真出事时失去自愈能力。

因此本 PR 的硬约束是：**匿名 `/health` 必须继续返回可解析的 2xx**。

## 验证

1. **witnessed red → green**：pre-fix 基线上匿名 `/health` body 含真实别名与网络 ID（泄露用例转红）；候选上转绿
2. **看门狗判据未破**：真跑发布 bin，匿名 `curl -sf /health` exit 0、body 可解析、聚合计数在位
3. **鉴权后明细完整**：admin 可取到完整 `{networkId}:{alias}`，运维能力未被削减
4. 全量 `bun test src/` 564/0 ×2；打包验收：干净装真跑 bin，`/api/stats/sse` 匿名 401 / master 200 实测通过
5. 测试用高位端口 + 临时 DB，未接触生产

## 合入后待办

线上泄露需**合入 + 重新部署**才真正消除。合入后需跟一次线上复验，确认公网返回体不再包含别名。

Closes #473
