### PR TITLE
fix(#457): opencode rename pre-create newDir at 0700 before cpSync (close umask 022 timing window)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -5908,6 +5908,14 @@ anet node rename <node-id|node-name> <new-node-name> [--force]
   let txnId: string | null = "";
   try {
     // P2: copy (not move) old → new + update config.alias
+    // #457 — pre-create newDir with 0700 so cpSync preserves target dir mode.
+    // Node fs.cp does NOT overwrite an existing dest dir's mode; if we let
+    // cpSync create newDir, it defaults to umask (0755 under umask 022) and
+    // then fails opencode-preset's 0700 predjection at PHASE-3 wiring. Verified
+    // Node 20.20.0: `mkdirSync(dst,{mode:0o700})` + `cpSync(src,dst)` leaves
+    // dst at 0700 even when src is 0755. Structural fix, no post-cpSync chmod
+    // (would be TOCTOU vs the预检's own identity-bound fchmod branch).
+    mkdirSync(newDir, { mode: 0o700, recursive: false });
     cpSync(oldDir, newDir, { recursive: true });
     const newLock = join(newDir, "rename.lock");
     if (existsSync(newLock)) rmSync(newLock, { force: true });  // lock belongs to oldDir only


### PR DESCRIPTION
## Summary

Fixes #457 — under standard umask 022 (Docker/CI/most shells), `anet node rename` on any opencode-cli node fails PHASE 1 with:

```
rename PHASE 1 failed: OpenCode preset refuses node workDir at .../<new-alias>:
directory mode must be 0700 — rolling back
```

**Root cause** (`agent-network/bin/cli.ts:5911`): `cpSync(oldDir, newDir, {recursive:true})` creates the top-level `newDir` with default umask permissions (0755 under umask 022). The subsequent opencode-preset predjection (`assertPrivateDirectory` at `opencode-preset.ts:190-191`) rejects any mode other than 0o700 — throw and rollback.

**Fix** (`+8/-0` lines, one-hunk): pre-create `newDir` with `mkdirSync(newDir, {mode:0o700, recursive:false})` **before** `cpSync`. Node 20/22 `fs.cp` preserves the mode of an existing dest directory (validated empirically; see evidence). No post-cpSync chmod (that pattern would be TOCTOU-flavored and defeat the预检's purpose).

## Test plan

**Verify 1 — witnessed_red → green (cpSync semantics)**
- BASELINE `cpSync(0755-src, dst_not_exist)` → dst = 0755 (repros #457)
- FIXED `mkdirSync(dst,{mode:0o700})` + `cpSync(0755-src, dst_existing)` → dst = 0700 ✓

**Verify 2 — 5 fast + 5 slow (bash -x) iterations**
- BASELINE: 0/5 fast pass_700, 0/5 slow pass_700 (all 0755, consistent, no timing window)
- FIXED: 5/5 fast pass_700, 5/5 slow pass_700 (all 0700, deterministic)

**Verify 6 — 0755 source directory (real-world scenario for pre-fix nodes)**
- Src=0755 + fix → dst=0700 across 5 iterations ✓
- Sub-file modes (config.json 0600, session.jsonl 0644) preserved
- Src unchanged (0755)

**Verify — rollback safety (`mkdirSync` EEXIST)**
- Pre-plant stale newDir → mkdirSync throws EEXIST → PHASE 1 try/catch rolls back
- Src untouched, stale dst preserved for operator inspection

**Verify — non-opencode regression** (analytical + semantic)
- `grep -rn 0o755` on agent-network src returns only descriptive comments (no code path asserts newDir mode == 0755)
- Sub-file/subdir modes byte-identical to baseline for any runtime
- 0700 = owner rwx (same anet-managed daemon owner) — functionally equivalent for claude-code-cli / codex-sdk / codex-app-server / grok-build-acp
- Security-positive change (tighter perms), not regression

**Verify 3 — test384 full L8** ⚠️ NOT ATTEMPTED
- test384 has a pre-existing L5 orphan cleanup failure that blocks reaching L8 (unrelated to #457). Independent validator with a working test384 flow can verify L8 directly.

**Verify 4 — Docker only** ✓
- All evidence generated inside `p457-baseline:test` (test384 Dockerfile), never touched host. Umask 022 explicitly printed in evidence.

## Evidence

Evidence tar.gz: `/tmp/p457-evidence-20260729T131528Z.tar.gz`
sha256: `668e7fa3fc8a45824e8e2f758f0a3cb3a6a78758b056df5f9bfb998f806f7ffb`

Contents:
- `00-provenance-manifest.md` — HEAD SHA, tree hash, status--porcelain=0, image sha256, test switches (none)
- `cpsync-semantics.log` — direct Node fs.cpSync mode preservation proof
- `iterations-fast-slow.log` — 5+5 iteration matrix baseline vs fixed
- `rollback-test.log` — EEXIST rollback safety
- `regression-non-opencode.log` — non-opencode paths unaffected
- `rename-repro.sh` / `rename-repro-with-hub.sh` — full-flow repros (hub setup flake noted)

## Timing window note

The issue reports "run1/run3 fail, run2 (bash -x) pass" — my BASELINE cpSync repro shows deterministic 0755 (5/5 fast + 5/5 slow all fail same way). The reported inconsistency was likely anet-side (a race between the failed rename and OTHER chmod code paths); my structural fix eliminates any race by making the dir 0o700 at creation atomically. Fix is race-free by design.

## AWAITING INDEPENDENT VALIDATION

**Do NOT merge without 通信龙 sign.** Fork does not have merge authority. Independent validator (通信龙 route, ~30min turnaround per commitment) will run full E2E in their environment; PR merges only after their PASS + coordinator co-sign.

Closes #457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)