### PR TITLE
docs: Bun 前置提到快速上手代码块之前（新人第一步就崩）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -40,6 +40,14 @@
 
 ## 30-second quickstart
 
+> **Install these two first, or step one crashes.**
+> **Node.js ≥ 22.13.0** + **Bun ≥ 1.2.0** — `anet hub start` uses `bunx` under the hood to launch
+> `commhub-server`; without Bun it fails immediately with `spawn bunx ENOENT`.
+>
+> ```bash
+> npm i -g bun
+> ```
+
 ```bash
 # Install one global package
 npm install -g @sleep2agi/agent-network
@@ -69,8 +77,6 @@ anet project restart    # restart cwd nodes against the new version
 ```
 
 Full cross-version migration reference: [Upgrade Guide](https://anet.sh/en/guide/upgrade).
-
-<sub>Prereqs: **Node.js ≥ 22.13.0** + **Bun ≥ 1.2.0** (install Bun: `npm i -g bun`). `anet hub start` launches `commhub-server` via `bunx`, so **without Bun the very first step crashes with `spawn bunx ENOENT`**.</sub>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@
 
 ## 30 秒上手
 
+> **先装这两个，否则第一步就崩。**
+> **Node.js ≥ 22.13.0** + **Bun ≥ 1.2.0** —— `anet hub start` 底层用 `bunx` 起 `commhub-server`，
+> 没装 Bun 会直接报 `spawn bunx ENOENT`。
+>
+> ```bash
+> npm i -g bun
+> ```
+
 ```bash
 # 装一个全局包
 npm install -g @sleep2agi/agent-network
@@ -69,8 +77,6 @@ anet project restart    # 重启 cwd 节点接新版
 ```
 
 完整跨版本迁移参考 [升级指南](https://anet.sh/guide/upgrade)。
-
-<sub>前置：**Node.js ≥ 22.13.0** + **Bun ≥ 1.2.0**（装 Bun：`npm i -g bun`）。`anet hub start` 底层用 `bunx` 起 `commhub-server`，**没装 Bun 第一步就会崩 `spawn bunx ENOENT`**。</sub>
 
 ---
 

--- a/docs-site/docs/en/index.md
+++ b/docs-site/docs/en/index.md
@@ -35,6 +35,15 @@ features:
 
 ## 30-second quickstart
 
+::: warning Install these two first, or step one crashes
+**Node.js ≥ 22.13.0** + **Bun ≥ 1.2.0**. `anet hub start` uses `bunx` under the hood to launch
+`commhub-server`; without Bun it fails immediately with `spawn bunx ENOENT`.
+
+```bash
+npm i -g bun
+```
+:::
+
 ```bash
 # Install one global package
 npm install -g @sleep2agi/agent-network

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -35,6 +35,15 @@ features:
 
 ## 30 秒上手
 
+::: warning 先装这两个，否则第一步就崩
+**Node.js ≥ 22.13.0** + **Bun ≥ 1.2.0**。`anet hub start` 底层用 `bunx` 起 `commhub-server`，
+没装 Bun 会直接报 `spawn bunx ENOENT`。
+
+```bash
+npm i -g bun
+```
+:::
+
 ```bash
 # 装一个全局包
 npm install -g @sleep2agi/agent-network


### PR DESCRIPTION
## 来源

v0.11.0 主线**新人视角**走查的第一个字面卡点，走查开始 19 秒就撞上。

新人照 README「30 秒上手」把代码块复制下来跑，第一条 `anet hub start` 直接崩：

```
spawn bunx ENOENT
```

## 问题不是"没写"，是"写在看不到的地方"

Bun 前置**写了**，但位置在代码块**之后**（README 第 73 行）、并且用 `<sub>` 小字：

> `<sub>前置：Node.js ≥ 22.13.0 + Bun ≥ 1.2.0（装 Bun：npm i -g bun）。anet hub start 底层用 bunx 起 commhub-server，**没装 Bun 第一步就会崩 spawn bunx ENOENT**。</sub>`

也就是说：**文档明确知道这个失败会发生，却把警告放在用户已经踩坑之后才会读到的位置。** 复制粘贴的人不会先往下翻小字。

docs-site 两个首页更直接 —— **完全没提 Bun**。

## 改动

把前置移到「30 秒上手」标题之后、代码块之前，改用醒目样式，并直接给出安装命令。

覆盖四个入口（用户可能从任一处开始）：

| 文件 | 原状态 | 现状态 |
|---|---|---|
| `README.md` | 小字，在代码块后 | 醒目块，在代码块前 |
| `README.en.md` | 小字，在代码块后 | 醒目块，在代码块前 |
| `docs-site/docs/index.md` | **完全没提** | 醒目块，在代码块前 |
| `docs-site/docs/en/index.md` | **完全没提** | 醒目块，在代码块前 |

README 里原来的 `<sub>` 行已删除，不重复（`spawn bunx ENOENT` 在每个文件中仅出现 1 次）。

## 验证

- 文档站 `npm run build` 通过
- 四文件 diff 扫描：无家目录绝对路径、无内部链接

## 为什么值得单独一个 PR

这条直接卡住「零配置 5 分钟上手」这个主线宣传口径的**第一步**。装包 4 秒就成功了，然后第二条命令崩掉 —— 对新人来说这就是"这东西跑不起来"。

---

Author: 通信龙
