### PR TITLE
fix(#486): refuse claude-code-cli spawn when stdin is not a TTY

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -4220,6 +4220,36 @@ async function launchAgent(id: string, forceNewSession = false) {
       saveProfile(nodeId, profile);
     }
 
+    // #486 P0 — claude CLI 2.1.220+ auto-switches to --print mode when its
+    // stdin is not a TTY, then errors "Input must be provided either through
+    // stdin or as a prompt argument when using --print" AND exits with code
+    // 0 (upstream Anthropic bug). anet spawns with { stdio: "inherit" }, so
+    // any headless caller (CI, systemd unit, docker run without -it, a
+    // watchdog / project-up child, any shell whose stdin is redirected)
+    // inherits a non-TTY stdin and hits this — the agent never comes online
+    // and downstream sees a false-success "session pinned" line. Refuse the
+    // spawn up front with actionable guidance so scripted callers see a
+    // real failure (non-zero exit + clear error), and interactive callers
+    // stay on the happy path.
+    //
+    // The dev-channels warn a few lines above (~L4211) covers the narrower
+    // "dev-channels + no TTY" case (needs Enter to dismiss a prompt). This
+    // gate is broader: NEW claude CLI needs a TTY unconditionally for
+    // interactive mode. Both warn/refuse paths coexist; this one fires
+    // first when it applies.
+    if (!process.stdin.isTTY) {
+      console.error(`[anet] ❌ claude-code-cli requires an interactive TTY on stdin.`);
+      console.error(`[anet]    Current shell's stdin is not a TTY. Claude CLI 2.1.220+`);
+      console.error(`[anet]    auto-switches to --print mode without a TTY and refuses to`);
+      console.error(`[anet]    start its interactive session, so the agent never comes online.`);
+      console.error(`[anet]    Fix:`);
+      console.error(`[anet]      • For headless / CI / systemd / docker without -it:`);
+      console.error(`[anet]        anet node start ${shellQuote(nodeId)} --tmux`);
+      console.error(`[anet]        (anet allocates a real PTY inside a tmux session)`);
+      console.error(`[anet]      • Or re-run this command from an interactive terminal.`);
+      process.exit(1);
+    }
+
     let launchedWithResume = false;
     const supportsSessionId = claudeSupportsSessionId();
     if (!supportsSessionId) {
@@ -4254,10 +4284,20 @@ async function launchAgent(id: string, forceNewSession = false) {
       if (child.pid) writeFileSync(pidFile, String(child.pid));
       child.on("exit", (code) => {
         try { rmSync(pidFile, { force: true }); } catch {}
-        if (forceNewSession) {
-          console.log(`\n[anet] New Claude Code session saved: ${profile.session?.slice(0, 8)}...`);
-        } else if (!launchedWithResume) {
-          console.log(`\n[anet] Claude Code session pinned: ${profile.session?.slice(0, 8)}...`);
+        // #486 P0 — only print the "session pinned / saved" success line
+        // when claude actually exited cleanly. Old behavior printed it
+        // after ANY exit (including error paths where claude died with
+        // an argument-parse error), giving scripted callers a false-
+        // success signal. Non-zero exit propagates via process.exit
+        // below; treating exit 0 as the only success path also protects
+        // against upstream claude bugs that emit an error to stderr but
+        // still exit 0 (rare but observed pre-#486 fix).
+        if ((code ?? 0) === 0) {
+          if (forceNewSession) {
+            console.log(`\n[anet] New Claude Code session saved: ${profile.session?.slice(0, 8)}...`);
+          } else if (!launchedWithResume) {
+            console.log(`\n[anet] Claude Code session pinned: ${profile.session?.slice(0, 8)}...`);
+          }
         }
         // Use the child's exit code as the parent's exit code via the
         // fa08eb4 wrap's natural process.exit(0) path. For non-zero exits,
@@ -4268,7 +4308,9 @@ async function launchAgent(id: string, forceNewSession = false) {
       child.on("error", (err) => {
         try { rmSync(pidFile, { force: true }); } catch {}
         console.error(`[anet] ❌ spawn claude failed: ${err.message || err}`);
-        resolve();
+        // #486 P0 — was `resolve()` → main() natural exit 0 → scripted
+        // callers see spawn ENOENT as success. Propagate as failure.
+        process.exit(1);
       });
     });
   }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -14,7 +14,7 @@ import { chmodSync, readFileSync, writeFileSync, existsSync, mkdirSync, readdirS
 import { dirname, isAbsolute, join } from "path";
 import { fileURLToPath } from "url";
 import { homedir } from "os";
-import { spawn, execSync, execFileSync } from "child_process";
+import { spawn, spawnSync, execSync, execFileSync } from "child_process";
 import { createHash, randomBytes, randomUUID } from "crypto";
 import {
   writeMarker as writeCopresenceMarker,
@@ -4467,15 +4467,89 @@ async function startCommand() {
   }
 
   // `tmux new -As <alias>`:
+  // #486 P0 CR — the previous shape `tmux new -As <alias> … stdio:"inherit"`
+  // is ATTACHED and needs the caller's TTY. That defeated the purpose of
+  // pointing headless callers at `--tmux` as an escape hatch: in a
+  // no-TTY environment `tmux new -As` immediately printed
+  // "open terminal failed: not a terminal" and the parent's spawn +
+  // synchronous `child.on("exit")` returned so fast that the parent
+  // exited 0 — same "假成功" pattern as the mainline #486 bug, sub-path
+  // edition. Two behaviors now:
+  //   TTY present    → keep attached foreground (setRawMode inside claude
+  //                    still needs a real PTY chain; this path is what
+  //                    interactive users have relied on since #122).
+  //   TTY absent     → detached: `tmux new-session -d`, stdio:"ignore",
+  //                    then a bounded `tmux has-session` poll to prove
+  //                    the session actually came up. If it didn't (tmux
+  //                    quick-fail, permissions, no server startup), the
+  //                    captured tmux stderr is surfaced and the parent
+  //                    exits non-zero. Prints the exact attach command
+  //                    for follow-up.
   //   -A  attach if the session already exists (handles the rerun case)
   //   -s  session name (= alias for discoverability)
   //   -c  start in cwd
-  //   <cmd> the agent runtime, foreground (no flag — default is foreground)
-  // stdio: 'inherit' makes the parent terminal a tmux client; setRawMode
-  // sees a real PTY through the tmux client/server pair.
   const inner = forceNewSession
     ? `anet node start ${shellQuote(alias)} --new-session`
     : `anet node start ${shellQuote(alias)}`;
+
+  const headless = !process.stdin.isTTY;
+  if (headless) {
+    // Detached spawn: no stdin inheritance, capture stderr for surfacing
+    // on quick-fail. `new-session -d` returns immediately; we then
+    // verify liveness with `has-session` inside a bounded poll before
+    // reporting success. Any observed failure path exits non-zero.
+    let tmuxStderr = "";
+    try {
+      // Reuse the same argv shape (`-A -s -c <inner>`) but with
+      // `new-session -d`. `-A` still handles the rerun case (attach if
+      // exists) which for detached-startup means "leave existing session
+      // alone and consider it started".
+      const proc = spawnSync(
+        "tmux",
+        ["new-session", "-d", "-A", "-s", alias, "-c", process.cwd(), inner],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+      tmuxStderr = String(proc.stderr || "");
+      if (proc.status !== 0) {
+        console.error(`[anet] ❌ tmux new-session detached failed (exit ${proc.status}).`);
+        if (tmuxStderr.trim()) console.error(`[anet]    tmux stderr: ${tmuxStderr.trim()}`);
+        console.error(`[anet]    Fall back to: anet node start ${shellQuote(alias)}`);
+        process.exit(proc.status ?? 1);
+      }
+    } catch (e: any) {
+      console.error(`[anet] ❌ tmux detached launch failed: ${e?.message || e}`);
+      console.error(`[anet]    Fall back to: anet node start ${shellQuote(alias)}`);
+      process.exit(1);
+    }
+    // Bounded liveness poll — `has-session` returns 0 when the session
+    // exists. Wait up to ~2 s (10 × 200 ms) for the tmux server to
+    // register the new session. If we never see it, the detached spawn
+    // exited cleanly but the session didn't come up (rare — usually
+    // means the inner command quick-failed) → surface non-zero.
+    const started = Date.now();
+    let alive = false;
+    while (Date.now() - started < 2000) {
+      if (tmuxSessionRunning(alias)) { alive = true; break; }
+      // Small blocking wait; keep dependencies minimal (no timers).
+      const s = Date.now(); while (Date.now() - s < 200) { /* busy */ }
+    }
+    if (!alive) {
+      console.error(`[anet] ❌ tmux session "${alias}" did not appear within 2 s of detached spawn.`);
+      console.error(`[anet]    The tmux server accepted the spawn but the session isn't visible; the`);
+      console.error(`[anet]    inner command likely quick-failed. Inspect with:`);
+      console.error(`[anet]      tmux ls`);
+      console.error(`[anet]      tmux new-session -A -s ${alias} -- ${inner}`);
+      process.exit(1);
+    }
+    console.log(`[anet] ✅ tmux session "${alias}" started detached.`);
+    console.log(`[anet]    Attach:   tmux attach -t ${alias}`);
+    console.log(`[anet]    Stop:     anet node stop ${alias}`);
+    return;
+  }
+
+  // TTY-present path: attached foreground (unchanged shape).
+  // stdio: 'inherit' makes the parent terminal a tmux client; setRawMode
+  // sees a real PTY through the tmux client/server pair.
   const tmuxArgs = ["new", "-As", alias, "-c", process.cwd(), inner];
   try {
     const child = spawn("tmux", tmuxArgs, { stdio: "inherit" });

--- a/agent-network/src/claude-code-cli-tty-preflight.test.ts
+++ b/agent-network/src/claude-code-cli-tty-preflight.test.ts
@@ -128,3 +128,115 @@ describe("claude-code-cli spawn preflight (#486 P0 regression gate)", () => {
     expect(errorSlice).toMatch(/process\.exit\(\s*[1-9]\d*\s*\)/);
   });
 });
+
+// #486 P0 CR — --tmux escape hatch regression gate. Prior candidate
+// pointed headless callers at `--tmux`; that path itself was ATTACHED
+// (`tmux new -As … stdio:"inherit"`) so it also needed a TTY, and its
+// synchronous `child.on("exit")` returned so fast that the parent
+// exited 0 even when tmux quick-failed with "open terminal failed: not
+// a terminal". Same "假成功" pattern as the mainline #486 bug, sub-path
+// edition. These assertions catch a regression back to the attached
+// shape or to the silent-exit-0-on-quick-fail behavior.
+//
+// Same source-order + substring style as the block above — cli.ts's
+// startCommand is inside the same ~12k-line entrypoint and cannot be
+// imported; behavioural verification of the headless path is left to
+// independent Docker validation without a Claude subscription
+// requirement (tmux quick-fail is testable without claude).
+describe("--tmux escape-hatch headless (#486 CR regression gate)", () => {
+  const CLI_TEXT = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+
+  /** Body of `startCommand`, up to the next top-level function. */
+  function startCommandBody(): string {
+    const start = CLI_TEXT.indexOf("async function startCommand(");
+    expect(start).toBeGreaterThan(-1);
+    const rest = CLI_TEXT.slice(start + 1);
+    const end = rest.search(/\n(?:export )?(?:async )?function /);
+    return end < 0 ? rest : rest.slice(0, end);
+  }
+
+  const startBody = startCommandBody();
+
+  /**
+   * The `--tmux` branch specifically — anchored on the unique
+   * "// --tmux path:" comment that only appears inside the wantTmux
+   * branch. This deliberately excludes the earlier
+   * `--accept-dev-channels` block (which also spawns `tmux new-session
+   * -d` but for a different feature).
+   */
+  function tmuxBranch(): string {
+    const idx = startBody.indexOf("// --tmux path:");
+    expect(idx).toBeGreaterThan(-1);
+    return startBody.slice(idx);
+  }
+
+  test("body contains the --tmux branch (anchor)", () => {
+    // `wantTmux` is the flag; if the whole branch gets refactored the
+    // gate needs updating too — failing here is that signal.
+    expect(startBody).toContain("wantTmux");
+    expect(startBody).toContain('spawn("tmux"');
+  });
+
+  test("--tmux branch has a headless (no-TTY) codepath (`new-session -d`)", () => {
+    // Prior code only had `["new", "-As", alias …]` with stdio inherit
+    // (attached, needs TTY). The fix adds a headless codepath with
+    // `"new-session", "-d"` inside the wantTmux branch.
+    const branch = tmuxBranch();
+    expect(branch).toMatch(/["']new-session["']\s*,\s*["']-d["']/);
+  });
+
+  test("--tmux headless: does NOT inherit stdin on detached spawn (was `stdio:\"inherit\"`)", () => {
+    // Locate the headless detached call inside wantTmux and ensure
+    // that spawn call does not carry stdio:"inherit". The TTY-present
+    // branch legitimately still uses stdio:"inherit"; the window scope
+    // keeps that from cross-matching.
+    const branch = tmuxBranch();
+    const detachedAt = branch.search(/["']new-session["']\s*,\s*["']-d["']/);
+    expect(detachedAt).toBeGreaterThan(-1);
+    // Look 400 chars before + 400 chars after the detached args.
+    const around = branch.slice(Math.max(0, detachedAt - 400), detachedAt + 400);
+    expect(around).not.toMatch(/stdio\s*:\s*["']inherit["']/);
+    // Positive: some form of stdio suppression / capture (ignore, pipe).
+    expect(around).toMatch(/stdio\s*:\s*(?:["']ignore["']|\[)/);
+  });
+
+  test("--tmux headless: verifies session liveness after detached spawn", () => {
+    // After `new-session -d` the spawn returns without proving the
+    // session came up; must be paired with an actual `tmuxSessionRunning(`
+    // call to prove liveness. If we ever drop this check, tmux quick-fail
+    // becomes silent again. Deliberately requires the FUNCTION CALL, not
+    // mere mention of "has-session" (that string appears in explanatory
+    // comments and would otherwise mask a mutation).
+    const branch = tmuxBranch();
+    const detachedAt = branch.search(/["']new-session["']\s*,\s*["']-d["']/);
+    expect(detachedAt).toBeGreaterThan(-1);
+    // Look ahead up to ~1500 chars for the liveness function call.
+    const after = branch.slice(detachedAt, detachedAt + 1500);
+    expect(after).toMatch(/tmuxSessionRunning\s*\(\s*alias\s*\)/);
+  });
+
+  test("--tmux headless: propagates non-zero exit on failure paths", () => {
+    // Anywhere between the detached-spawn call and the end of the
+    // headless branch, at least one process.exit(<non-zero>) must
+    // exist. Silent exit 0 is the exact regression we're preventing.
+    const branch = tmuxBranch();
+    const detachedAt = branch.search(/["']new-session["']\s*,\s*["']-d["']/);
+    expect(detachedAt).toBeGreaterThan(-1);
+    const after = branch.slice(detachedAt, detachedAt + 2500);
+    // Must contain at least one non-zero exit before the "started
+    // detached" success print. Accept either literal `1` or
+    // `proc.status ?? 1`.
+    expect(after).toMatch(/process\.exit\(\s*(?:proc\.status\s*\?\?\s*1|1)\s*\)/);
+  });
+
+  test("--tmux headless: prints attach hint after successful startup", () => {
+    // Success path must tell the user how to attach — otherwise the
+    // "escape hatch" leaves them stranded with a running but invisible
+    // session. Positive UX assertion.
+    const branch = tmuxBranch();
+    const detachedAt = branch.search(/["']new-session["']\s*,\s*["']-d["']/);
+    expect(detachedAt).toBeGreaterThan(-1);
+    const after = branch.slice(detachedAt, detachedAt + 2500);
+    expect(after).toMatch(/tmux attach -t/);
+  });
+});

--- a/agent-network/src/claude-code-cli-tty-preflight.test.ts
+++ b/agent-network/src/claude-code-cli-tty-preflight.test.ts
@@ -1,0 +1,130 @@
+// #486 P0 regression gate — the claude-code-cli spawn path must refuse
+// to spawn claude when stdin is not a TTY, because claude CLI 2.1.220+
+// auto-switches to --print mode without a TTY and dies with
+// "Input must be provided either through stdin or as a prompt argument
+// when using --print" — then exits with code 0 (upstream Anthropic bug),
+// which anet used to translate into a "Claude Code session pinned:"
+// false-success line. Scripted callers (CI / systemd / docker without
+// -it / watchdog) couldn't tell the agent never came online.
+//
+// HONEST SCOPE NOTE (mirrors copresence-cli-wiring.test.ts): bin/cli.ts
+// is a ~12k-line entrypoint that calls process.exit() and spawns claude;
+// it cannot be imported into a unit test. These are SOURCE-ORDER +
+// SUBSTRING assertions on cli.ts, not behavioural tests. They exist to
+// make a regression in the preflight / exit-code / success-gate turn
+// red. Real behavioural verification is Docker E2E with real anet +
+// claude (Verify 1 in the fork brief); that requires a Claude
+// subscription. This file catches "someone deleted the preflight" or
+// "someone re-added the false-success print" during ordinary edits.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+
+/** Body of `launchAgent`, up to the next top-level function. */
+function launchAgentBody(): string {
+  const start = CLI.indexOf("async function launchAgent(");
+  expect(start).toBeGreaterThan(-1);
+  const rest = CLI.slice(start + 1);
+  const end = rest.search(/\n(?:export )?(?:async )?function /);
+  return end < 0 ? rest : rest.slice(0, end);
+}
+
+describe("claude-code-cli spawn preflight (#486 P0 regression gate)", () => {
+  const body = launchAgentBody();
+
+  test("body contains the claude-code-cli spawn (anchor for the assertions below)", () => {
+    // The claude-code-cli branch is the `else` arm that calls
+    // `spawn("claude", claudeArgs, …)`. If someone refactors this
+    // out into a helper the whole gate needs updating — that is
+    // itself a signal, so failing here is the right outcome.
+    expect(body).toContain('spawn("claude", claudeArgs');
+  });
+
+  test("Refuse: non-TTY stdin preflight fires BEFORE the claude spawn", () => {
+    const preflight = body.indexOf("process.stdin.isTTY");
+    const spawnClaude = body.indexOf('spawn("claude", claudeArgs');
+    expect(preflight).toBeGreaterThan(-1);
+    expect(spawnClaude).toBeGreaterThan(-1);
+    expect(preflight).toBeLessThan(spawnClaude);
+  });
+
+  test("Refuse: non-TTY branch exits non-zero", () => {
+    // Zoom into JUST the #486 preflight block (marker → next blank line
+    // after process.exit). The broader slice from the first `isTTY` hit
+    // would also include the older `--dangerously-load-development-
+    // channels` warn (which does NOT exit) and lots of unrelated code.
+    const marker = "#486 P0 — claude CLI 2.1.220+";
+    const markerIdx = body.indexOf(marker);
+    expect(markerIdx).toBeGreaterThan(-1);
+    // Everything between the marker and the next `let launchedWithResume`.
+    const end = body.indexOf("let launchedWithResume", markerIdx);
+    expect(end).toBeGreaterThan(-1);
+    const slice = body.slice(markerIdx, end);
+    // The #486 refuse block must exit non-zero.
+    expect(slice).toMatch(/process\.exit\(\s*[1-9]\d*\s*\)/);
+    // And must NOT have a bare exit(0) inside the refuse arm.
+    expect(slice).not.toMatch(/process\.exit\(\s*0\s*\)/);
+  });
+
+  test("Refuse: message names claude-code-cli and points at --tmux escape hatch", () => {
+    const preflight = body.indexOf("process.stdin.isTTY");
+    const spawnClaude = body.indexOf('spawn("claude", claudeArgs');
+    const slice = body.slice(preflight, spawnClaude);
+    // Operator needs to know which runtime it is and how to escape.
+    expect(slice).toMatch(/claude-code-cli/);
+    expect(slice).toMatch(/--tmux/);
+    // And it must be an ERROR, not a warn/log (scriptable callers
+    // parse stderr for failures).
+    expect(slice).toMatch(/console\.error/);
+  });
+
+  test("Success gate: 'session pinned' / 'session saved' only fires on exit code 0", () => {
+    // Find the child.on("exit", …) block and confirm the success
+    // log lines are inside a `code === 0` guard, not unconditional.
+    const exitHandler = body.indexOf('child.on("exit"');
+    expect(exitHandler).toBeGreaterThan(-1);
+    const errorHandler = body.indexOf('child.on("error"', exitHandler);
+    const exitSlice = body.slice(exitHandler, errorHandler > 0 ? errorHandler : exitHandler + 2000);
+
+    const pinnedLog = exitSlice.indexOf("Claude Code session pinned");
+    const savedLog = exitSlice.indexOf("New Claude Code session saved");
+    expect(pinnedLog).toBeGreaterThan(-1);
+    expect(savedLog).toBeGreaterThan(-1);
+
+    // The exit-code-0 check must appear BEFORE both success prints,
+    // and wrap them. Accept common forms:
+    //   `(code ?? 0) === 0`
+    //   `code === 0`
+    //   `code == 0`
+    //   `!code`
+    //   `code === undefined || code === 0`
+    // The regex is intentionally lenient — the assertion is "code-0
+    // gate exists BEFORE the success prints", not "gate is written
+    // exactly this way".
+    const guard = exitSlice.search(
+      /(?:code[^;{]*(?:===|==)\s*0|!code\b|code\s*\?\?\s*0[^;{]*===\s*0)/,
+    );
+    expect(guard).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(pinnedLog);
+    expect(guard).toBeLessThan(savedLog);
+  });
+
+  test("Exit-code propagation: non-zero child exit calls process.exit(code)", () => {
+    const exitHandler = body.indexOf('child.on("exit"');
+    const errorHandler = body.indexOf('child.on("error"', exitHandler);
+    const exitSlice = body.slice(exitHandler, errorHandler > 0 ? errorHandler : exitHandler + 2000);
+    expect(exitSlice).toMatch(/process\.exit\(\s*code\s*\)/);
+  });
+
+  test("Spawn-error path: child.on('error') exits non-zero (was silent → false success)", () => {
+    const errorHandler = body.indexOf('child.on("error"', body.indexOf('child.on("exit"'));
+    expect(errorHandler).toBeGreaterThan(-1);
+    // Read a chunk after the error handler start; must contain a
+    // non-zero process.exit before the handler closes.
+    const errorSlice = body.slice(errorHandler, errorHandler + 500);
+    expect(errorSlice).toMatch(/process\.exit\(\s*[1-9]\d*\s*\)/);
+  });
+});


### PR DESCRIPTION
## AWAITING INDEPENDENT VALIDATION — do NOT merge without 通信龙 sign

Refs #486

## Root cause (verified on this host with claude 2.1.220)

Claude CLI 2.1.220+ auto-switches to `--print` mode when its stdin is not a TTY, then errors `Input must be provided either through stdin or as a prompt argument when using --print`. anet spawns claude with `{ stdio: "inherit" }`, so any headless caller (CI, systemd, `docker run` without `-it`, watchdog, project-up child, any shell whose stdin is redirected) inherits a non-TTY stdin and hits this — the agent never comes online, and downstream sees a false-success "Claude Code session pinned:" line.

Direct probe (no claude subscription required) on this host reproduces the exact error signature — see evidence bundle `02-witnessed-red-baseline-probe.log`.

## Fix (agent-network/bin/cli.ts — +47/-5 in the claude-code-cli branch of `launchAgent`)

1. **Pre-spawn TTY preflight**: refuse when `!process.stdin.isTTY`; print a targeted error with the `--tmux` escape hatch and exit `1`. Fires before any claude process is launched, so the operator sees the actual cause instead of an upstream `--print args` surface. Coexists with the narrower dev-channels-non-TTY warn a few lines above.

2. **Success-message gate**: only print `Claude Code session pinned:` / `New Claude Code session saved:` when `(code ?? 0) === 0`. Was unconditional on any child exit → false-success signal for scripted callers.

3. **child.on('error') propagation**: was `resolve()` → natural exit 0. Now `process.exit(1)` so spawn ENOENT (missing binary etc.) surfaces as a real failure.

## Regression gate (agent-network/src/claude-code-cli-tty-preflight.test.ts — NEW +130 lines, 7 tests)

Source-order + substring assertions on cli.ts's `launchAgent` body (same pattern as `copresence-cli-wiring.test.ts`). Verified locally that all three intended mutations turn tests red — evidence `03-mutation-self-check.log`:

| Mutation | Tests turning red |
|---|---|
| Delete the whole preflight block | 2 |
| Revert `child.on('error')` to silent `resolve()` | 1 |
| Remove `code === 0` gate around success prints | 1 |

## Evidence bundle

- Path: `/tmp/p486-evidence-20260729T065832Z.tar.gz`
- Sha256: `79ba4eadbfb23f0d905ae798fbb168edc992c22cf697f6039b2cc3367af9b596`
- Contents: provenance manifest / unit test log / claude-CLI probe reproducing #486 / mutation self-check log / factual summary

## Provenance manifest highlights

- HEAD SHA: `07ed361d…` (this PR's tip)
- Tree hash: `$(cd /tmp/anet-486 && git rev-parse HEAD^{tree})`
- `git status --porcelain`: 0 bytes at push time
- Test switches (`ANET_*_DISABLE|_MUTATE|_BYPASS`): **0 hits in HEAD tree** (DI-free, structurally cannot repeat the 9f2ec282 evidence-integrity failure)
- Sanity greps on the 2 touched files: `[[feedback` / `tmcode` / `/home/vansin` — all 0

## Honest scope note

What **THIS PR verifies**: source-order structural invariants in cli.ts + upstream claude CLI's failure signature on non-TTY stdin (direct probe on real claude 2.1.220 on this host).

What **THIS PR does NOT verify** (out of scope; needs claude subscription): end-to-end `anet node start` in Docker with real hub + real claude, showing (a) baseline red (pre-fix hangs 120s + false success), (b) fixed behavior (either refuses fast when non-TTY, or the agent truly connects when TTY). The走查 report `docs/tests/p-v0110-mainline-e2e/` covers baseline; independent validator should re-run with the fix applied.

**Not merged**: PR opened for independent validation per brief. 通信龙 routes; do NOT self-merge.