### PR TITLE
fix(#491): startup banner reports the effective runtime (+ fail-closed regression lock)

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -4432,7 +4432,13 @@ async function connectSSE() {
 // ── 启动 ──
 log(`启动`);
 log(`  alias:   ${ALIAS || "(none!)"} [from: ${ALIAS_SOURCE}]`);  // #203 traceability
-log(`  runtime: ${RUNTIME_LABEL}`);
+// #491 — report the runtime that is ACTUALLY in effect, not just what the
+// operator typed. `--runtime codex-tui` runs the `codex-app-server`
+// implementation; echoing only the input hid which code path was live and
+// sent one investigation down the wrong track ("wrong model" instead of
+// "wrong runtime"). The raw input is kept alongside so the line still
+// answers "did my flag land?".
+log(`  runtime: ${RUNTIME}${RUNTIME_LABEL === RUNTIME ? "" : ` (input: ${RUNTIME_LABEL})`}`);
 log(`  model:   ${MODEL || (RUNTIME === "codex" || RUNTIME === "codex-app-server" ? "gpt-5.5" : RUNTIME === "grok" ? "grok-build" : "claude-sonnet-4-6")} ${MODEL ? "" : "(default)"}`);
 log(`  hub:     ${COMMHUB_URL}${AUTH_TOKEN ? " (auth)" : " (no auth!)"}`);
 // #214 维度 5 A6 — surface the grok ACP idle-timeout resolution so the

--- a/agent-node/src/runtime-effective-label.test.ts
+++ b/agent-node/src/runtime-effective-label.test.ts
@@ -1,0 +1,120 @@
+// #491 — the startup banner must report the runtime that is ACTUALLY in
+// effect, and an unknown runtime must fail closed.
+//
+// Both assertions drive the REAL CLI entrypoint (spawned `src/cli.ts`),
+// not a helper: the reported bug was that the banner echoed the user's
+// input verbatim while a different implementation bucket was running, so
+// a helper-level test would not have caught it.
+//
+// Isolation: every spawn runs in a fresh empty cwd with a fake HOME and a
+// hub URL pointing at a closed loopback port, so no real `.anet/nodes`
+// profile is read and no live hub is contacted.
+
+import { describe, expect, test } from "bun:test";
+import { spawn } from "child_process";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "cli.ts");
+/** Loopback port nothing listens on — the node's connect attempt fails
+ *  harmlessly AFTER the startup banner has already been printed. */
+const DEAD_HUB = "http://127.0.0.1:9";
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+}
+
+/**
+ * Spawn the real CLI in isolation and collect output until either the
+ * process exits or the banner is complete (whichever comes first).
+ */
+function runCli(args: string[], timeoutMs = 15_000): Promise<RunResult> {
+  const sandbox = mkdtempSync(join(tmpdir(), "anet-491-"));
+  const home = mkdtempSync(join(tmpdir(), "anet-491-home-"));
+  return new Promise<RunResult>((resolve) => {
+    const child = spawn("bun", [CLI, ...args], {
+      cwd: sandbox,
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: home,
+        COMMHUB_URL: DEAD_HUB,
+        // Keep the environment from contributing a runtime of its own.
+        RUNTIME: "",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const finish = (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+      rmSync(sandbox, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+      resolve({ stdout, stderr, code });
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    child.stdout.on("data", (d) => {
+      stdout += String(d);
+      // The banner ends with the `hub:` line; once seen we have all we
+      // need and can stop the reconnect loop early.
+      if (/\n\s*hub:/.test(stdout)) finish(null);
+    });
+    child.stderr.on("data", (d) => {
+      stderr += String(d);
+    });
+    child.on("exit", (code) => finish(code));
+    child.on("error", () => finish(null));
+  });
+}
+
+/** The `runtime:` line of the startup banner, without the log prefix. */
+function bannerRuntimeLine(stdout: string): string | null {
+  const m = stdout.match(/^.*\bruntime:\s*(.+)$/m);
+  return m ? m[1].trim() : null;
+}
+
+describe("#491 startup banner reports the EFFECTIVE runtime", () => {
+  test("alias input 'codex-tui' → banner names the effective runtime (codex-app-server), not just the raw input", async () => {
+    const r = await runCli(["--alias", "p491-node", "--runtime", "codex-tui"]);
+    const line = bannerRuntimeLine(r.stdout);
+    expect(line).not.toBeNull();
+    // The whole point of the bug: the operator must be able to tell WHICH
+    // implementation is running. Echoing only the alias hides it.
+    expect(line!).toContain("codex-app-server");
+  }, 30_000);
+
+  test("canonical input stays readable (no regression for the common case)", async () => {
+    const r = await runCli(["--alias", "p491-node", "--runtime", "claude-agent-sdk"]);
+    const line = bannerRuntimeLine(r.stdout);
+    expect(line).not.toBeNull();
+    expect(line!).toContain("claude-agent-sdk");
+  }, 30_000);
+});
+
+describe("#491 regression lock — unknown runtime fails closed", () => {
+  // NOTE: this behaviour already exists on main (added before this issue);
+  // the lock exists so it cannot silently regress back to the
+  // `RUNTIME_MAP[raw] || "claude"` fallback that shipped in 2.4.13.
+  test("unknown runtime → non-zero exit, error names the value AND the supported list", async () => {
+    const r = await runCli(["--alias", "p491-node", "--runtime", "totally-bogus-runtime"]);
+    const out = r.stdout + r.stderr;
+    expect(r.code).not.toBe(0);
+    expect(out).toContain("totally-bogus-runtime");
+    // Supported list is generated from the live RUNTIME_MAP, so assert on
+    // entries that must be present in ANY version that has the map.
+    expect(out).toMatch(/claude-agent-sdk/);
+    expect(out).toMatch(/codex-sdk/);
+    // …and it must NOT have silently started as claude.
+    expect(bannerRuntimeLine(r.stdout) ?? "").not.toContain("claude-agent-sdk");
+  }, 30_000);
+});


### PR DESCRIPTION
Fixes the second requirement of #491 (effective-runtime logging) and adds a regression lock for the first.

## What changed

`agent-node/src/cli.ts` — the startup banner now prints the runtime bucket that is **actually in effect**, keeping the raw input alongside:

```
runtime: codex-app-server (input: codex-tui)
runtime: claude (input: claude-agent-sdk)
runtime: claude                                  # input == bucket, no suffix
```

**Scope boundary:** the `runtime` value **reported to the hub** (config/status payloads) is deliberately unchanged — it feeds dashboard compatibility and is outside this issue.

## Tests — real CLI entry, red first

`agent-node/src/runtime-effective-label.test.ts` spawns the **real** `src/cli.ts` (isolated cwd + fake HOME + dead loopback hub so no real node profile is read and no live hub is contacted). A helper-level test could not have caught a banner-formatting bug.

| test | on unmodified main | after fix |
|---|---|---|
| `codex-tui` → banner names `codex-app-server` | **RED** (`Expected to contain: "codex-app-server"` / `Received: "codex-tui"`) | pass |
| canonical input stays readable | pass | pass |
| unknown runtime → non-zero exit + value + supported list | pass | pass |

The third row is an explicit **do-not-regress lock, not a new fix** — that fail-closed behaviour already exists on `main`. It is labelled as such in the test file so it is never counted as newly-earned coverage.

## Premise correction

The issue quoted `RUNTIME_MAP[rawRuntime] || "claude"`. That line **no longer exists on `main`** — `main` already fails closed with a dynamically generated supported list. The quote came from a stale tree (issue author has corrected this publicly in the issue thread).

Verified against the published channels instead:

| package | silent `|| "claude"` fallback | fail-closed | `codex-app-server` registered |
|---|---|---|---|
| `agent-node@2.4.13` (latest) | present | **absent** | absent |
| `agent-node@2.5.0-preview.4` | present | **absent** | absent |
| `agent-node@2.5.0-preview.27` | gone | present | present |

So the unknown-runtime hole is a **release gap on `latest`**, not a code gap on `main`. Shipping it is a separate action (reported as blocked behind #490) and is **not** part of this PR.

## Regression

`bun test src/` → 802 pass / 0 fail (44 files).

Honest disclosure: two of four runs showed one failure in `resolveAttachmentToLocalPath — cache hit > same file_id + different size`, which is unrelated to this change (attachment cache, filesystem-timing flake) and reproduces independently of it.

Do not merge without review — author does not self-approve.
