### PR TITLE
feat: node display attributes (display_name / team / tags) with an independent CAS

### DIFF
--- a/server/src/api-nodes-shape.test.ts
+++ b/server/src/api-nodes-shape.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { db } from "./db.js";
+import { parseStoredTags } from "./node-attrs-validate.js";
 
 // Regression test for SELECT * fragility on GET /api/nodes.
 //
@@ -41,7 +42,12 @@ function mapRow(r: Record<string, unknown>): Record<string, unknown> {
     catch { /* malformed */ }
   }
   const { config_snapshot, ...rest } = r;
-  return { ...rest, role };
+  return {
+    ...rest,
+    tags: parseStoredTags(r.tags),
+    attrs_revision: Number(r.attrs_revision ?? 0),
+    role,
+  };
 }
 
 describe("RFC-024 regression — GET /api/nodes response shape (no SELECT *)", () => {
@@ -66,7 +72,7 @@ describe("RFC-024 regression — GET /api/nodes response shape (no SELECT *)", (
       `SELECT node_id, node_name, alias, runtime, model,
               config_path, channels, server, hostname,
               network_id, created_at, updated_at,
-              config_snapshot
+              config_snapshot, display_name, team, tags, attrs_revision
        FROM nodes WHERE node_id = ?1`,
       TEST_NODE,
     );
@@ -85,11 +91,17 @@ describe("RFC-024 regression — GET /api/nodes response shape (no SELECT *)", (
     expect(row).not.toHaveProperty("config_snapshot");
     // role is EXTRACTED from config_snapshot JSON, not the raw blob
     expect(row.role).toBe("host_supervisor");
-    // Belt: full key set is exactly the 13 contract fields
+    // Belt: the key set is exactly the dashboard-facing contract.
+    // NOTE: this file MIRRORS the handler's SQL rather than calling it, so
+    // it can drift — it already lagged behind `lifecycle_state` /
+    // `avatar_url`, which the handler selects but this mirror does not.
+    // Treat a diff here as "re-read the handler", not as proof of the wire
+    // shape; node-attrs.test.ts asserts the real HTTP response.
     expect(Object.keys(row).sort()).toEqual([
-      "alias", "channels", "config_path", "created_at", "hostname",
-      "model", "network_id", "node_id", "node_name", "role", "runtime",
-      "server", "updated_at",
+      "alias", "attrs_revision", "channels", "config_path", "created_at",
+      "display_name", "hostname", "model", "network_id", "node_id",
+      "node_name", "role", "runtime", "server", "tags", "team",
+      "updated_at",
     ]);
   });
 
@@ -102,7 +114,8 @@ describe("RFC-024 regression — GET /api/nodes response shape (no SELECT *)", (
     );
     let row = mapRow(db.get<Record<string, unknown>>(
       `SELECT node_id, node_name, alias, runtime, model, config_path, channels,
-              server, hostname, network_id, created_at, updated_at, config_snapshot
+              server, hostname, network_id, created_at, updated_at, config_snapshot,
+              display_name, team, tags, attrs_revision
        FROM nodes WHERE node_id = ?1`,
       TEST_NODE,
     )!);
@@ -113,7 +126,8 @@ describe("RFC-024 regression — GET /api/nodes response shape (no SELECT *)", (
     db.run(`UPDATE nodes SET config_snapshot = ?1 WHERE node_id = ?2`, ["not-json{", TEST_NODE]);
     row = mapRow(db.get<Record<string, unknown>>(
       `SELECT node_id, node_name, alias, runtime, model, config_path, channels,
-              server, hostname, network_id, created_at, updated_at, config_snapshot
+              server, hostname, network_id, created_at, updated_at, config_snapshot,
+              display_name, team, tags, attrs_revision
        FROM nodes WHERE node_id = ?1`,
       TEST_NODE,
     )!);
@@ -124,7 +138,8 @@ describe("RFC-024 regression — GET /api/nodes response shape (no SELECT *)", (
            [JSON.stringify({ model: "x", flags: {} }), TEST_NODE]);
     row = mapRow(db.get<Record<string, unknown>>(
       `SELECT node_id, node_name, alias, runtime, model, config_path, channels,
-              server, hostname, network_id, created_at, updated_at, config_snapshot
+              server, hostname, network_id, created_at, updated_at, config_snapshot,
+              display_name, team, tags, attrs_revision
        FROM nodes WHERE node_id = ?1`,
       TEST_NODE,
     )!);
@@ -141,7 +156,8 @@ describe("RFC-024 regression — GET /api/nodes response shape (no SELECT *)", (
     );
     const rows = db.all<Record<string, unknown>>(
       `SELECT node_id, node_name, alias, runtime, model, config_path, channels,
-              server, hostname, network_id, created_at, updated_at, config_snapshot
+              server, hostname, network_id, created_at, updated_at, config_snapshot,
+              display_name, team, tags, attrs_revision
        FROM nodes WHERE network_id = ?1`,
       TEST_NETWORK,
     ).map(mapRow);

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -348,6 +348,38 @@ try {
   if (!/duplicate column|already exists/i.test(e?.message || "")) throw e;
 }
 
+// Node DISPLAY attributes (Vincent 目标第 3 条 — dashboard/app 多维度编辑).
+// Same posture as avatar_url above: hub-side presentation only, NOT part of
+// the RFC-024 config-apply pipeline (agent-node consumes none of them, so a
+// doorbell/ack round-trip would be meaningless and could wedge the config
+// revision). Written only via PUT /api/nodes/:ref/attrs.
+//
+//   display_name   — human label shown in the UI. Distinct from `alias`,
+//                    which is the ROUTING key (messages address the alias)
+//                    and from `node_name`, which is an addressing key
+//                    (`WHERE node_id OR node_name OR alias`). Renaming
+//                    either of those must go through the rename 2PC
+//                    (/api/node-rename/*), never through an attrs write.
+//   team, tags     — organisation metadata; tags stored as JSON array text.
+//   attrs_revision — optimistic-lock counter for these display fields ONLY.
+//                    Deliberately separate from config_revision so that
+//                    editing a tag never bumps the node's *config* revision
+//                    (which would perturb the config ack protocol).
+//
+// All nullable / defaulted so the ~100 rows already in flight keep reading.
+for (const ddl of [
+  `ALTER TABLE nodes ADD COLUMN display_name TEXT`,
+  `ALTER TABLE nodes ADD COLUMN team TEXT`,
+  `ALTER TABLE nodes ADD COLUMN tags TEXT`,
+  `ALTER TABLE nodes ADD COLUMN attrs_revision INTEGER NOT NULL DEFAULT 0`,
+]) {
+  try {
+    db.exec(ddl);
+  } catch (e: any) {
+    if (!/duplicate column|already exists/i.test(e?.message || "")) throw e;
+  }
+}
+
 // RFC-027 §2 — stop/delete request envelope. Mirrors
 // node_create_requests structure so the daemon-side pull/ack pattern
 // is symmetric with create_node. action='stop'|'delete' picks which

--- a/server/src/node-attrs-validate.ts
+++ b/server/src/node-attrs-validate.ts
@@ -1,0 +1,88 @@
+// Boundary validation for node DISPLAY attributes (display_name / team /
+// tags). Mirrors `avatar-validate.ts` in spirit: this is the only place
+// that decides what a client is allowed to store, and it trusts nothing.
+//
+// Two different postures on purpose:
+//
+//   display_name / team — SCALAR fields the user typed. A wrong TYPE here
+//     is a client bug, so it is REJECTED (400) rather than coerced: silently
+//     turning `{}` into "[object Object]" would persist garbage the user
+//     never typed and can't explain.
+//
+//   tags — a LIST. Same reasoning as the `channels` patch in tools.ts: the
+//     wire contract wants junk dropped instead of failing the whole request,
+//     so one fat-fingered entry from a dashboard doesn't 400 the save. Each
+//     element is narrowed independently (typeof → trim → length cap →
+//     dedup), so nothing non-string can reach the database.
+
+/** Max stored length of display_name / team. */
+export const MAX_ATTR_LEN = 120;
+/** Max stored length of a single tag. */
+export const MAX_TAG_LEN = 64;
+/** Max number of tags kept per node. */
+export const MAX_TAGS = 16;
+
+export type ScalarAttrResult =
+  | { ok: true; value: string | null }
+  | { ok: false; reason: string };
+
+/**
+ * Narrow an optional scalar display attribute.
+ *   undefined      → not part of this patch (caller leaves the column alone)
+ *   null / ""      → explicit clear
+ *   non-string     → rejected (never coerced)
+ *   over-long      → rejected (the user should see it, not silently lose text)
+ */
+export function validateScalarAttr(raw: unknown, field: string): ScalarAttrResult {
+  if (raw === undefined) return { ok: true, value: null };
+  if (raw === null) return { ok: true, value: null };
+  if (typeof raw !== "string") {
+    return { ok: false, reason: `${field} must be a string or null` };
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return { ok: true, value: null };
+  if (trimmed.length > MAX_ATTR_LEN) {
+    return { ok: false, reason: `${field} exceeds ${MAX_ATTR_LEN} characters` };
+  }
+  // Control characters would corrupt any log line / table cell that renders
+  // the value; strip rather than reject (they are almost always a paste
+  // artefact, not user intent).
+  // eslint-disable-next-line no-control-regex
+  const clean = trimmed.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
+  return { ok: true, value: clean.length > 0 ? clean : null };
+}
+
+/**
+ * Narrow an untrusted tags array. NEVER throws, never rejects the request:
+ * unusable entries are dropped. Returns the canonical list to store.
+ */
+export function narrowTags(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (typeof item !== "string") continue; // numbers/objects/arrays/null
+    // eslint-disable-next-line no-control-regex
+    const t = item.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
+    if (t.length === 0) continue;
+    if (t.length > MAX_TAG_LEN) continue; // absurd entry — drop, don't truncate
+    const key = t.toLowerCase(); // case-fold for dedup, keep first spelling
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+    if (out.length >= MAX_TAGS) break;
+  }
+  return out;
+}
+
+/** Parse the stored tags column back into an array. Storage is JSON text;
+ *  anything unparseable (hand-edited DB, older format) reads as empty so a
+ *  dashboard can always `.map()` without a guard. */
+export function parseStoredTags(stored: unknown): string[] {
+  if (typeof stored !== "string" || stored.length === 0) return [];
+  try {
+    return narrowTags(JSON.parse(stored));
+  } catch {
+    return [];
+  }
+}

--- a/server/src/node-attrs.test.ts
+++ b/server/src/node-attrs.test.ts
@@ -1,0 +1,213 @@
+// Node display attributes — team / tags / display_name (Vincent 目标第 3 条).
+//
+// These are HUB-SIDE DISPLAY attributes. Following the `avatar_url` (#462)
+// precedent they are deliberately NOT part of the RFC-024 config-apply
+// pipeline: agent-node has nothing to consume, so pushing them through
+// config revision/ack would ring a doorbell for a field the node does not
+// understand and could wedge the config revision.
+//
+// They DO need concurrency protection (two dashboards editing the same
+// node), which `avatar_url` lacks. Hence a dedicated `attrs_revision` CAS
+// that is independent of `config_revision` — editing a tag must never bump
+// the node's *config* revision.
+//
+// Every test drives the REAL HTTP endpoint against a booted server, not a
+// helper: the contract under test is the wire shape + status codes.
+//
+// NOTE (test isolation): this file boots its own Bun.serve, same pattern as
+// uploads-http.test.ts / api-host-supervisors-fallback.test.ts. Those files
+// are per-file runs by design (single-process module-singleton conflict,
+// tracked in #434) — run this file on its own.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const tmpDb = join(mkdtempSync(join(tmpdir(), "anet-attrs-")), "commhub.db");
+process.env.COMMHUB_DB = tmpDb;
+const PORT = 23000 + Math.floor(Math.random() * 1500);
+process.env.PORT = String(PORT);
+process.env.HOST = "127.0.0.1";
+
+const { db } = await import("./db.js");
+const { issueUserToken } = await import("./auth.js");
+const { bootServer } = await import("./server.js");
+
+const BASE = `http://127.0.0.1:${PORT}`;
+const NET = "net_attrs";
+const USER = "u_attrs";
+/** A node row seeded the way a PRE-MIGRATION row looks: none of the new
+ *  columns are written, so they are NULL / default at read time. */
+const LEGACY_NODE = "node_attrs_legacy";
+const LEGACY_ALIAS = "attrs-legacy-node";
+
+let token = "";
+let server: { stop: (force?: boolean) => void } | null = null;
+
+beforeAll(async () => {
+  db.run(`INSERT INTO users (user_id, username, password_hash, role) VALUES (?1, 'attrs-user', 'x', 'user')`, [USER]);
+  db.run(`INSERT INTO networks (network_id, network_name, owner_id) VALUES (?1, 'attrs-net', ?2)`, [NET, USER]);
+  db.run(`INSERT INTO network_members (network_id, user_id, role) VALUES (?1, ?2, 'owner')`, [NET, USER]);
+  // Legacy row: only the columns that existed before this change.
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, runtime, model, network_id)
+     VALUES (?1, 'attrs-legacy', ?2, 'claude-agent-sdk', 'claude-sonnet-4-6', ?3)`,
+    [LEGACY_NODE, LEGACY_ALIAS, NET],
+  );
+  token = issueUserToken(USER, "attrs-test").token;
+  server = bootServer({ port: PORT, hostname: "127.0.0.1" }) as never;
+  await new Promise((r) => setTimeout(r, 120));
+});
+
+afterAll(() => {
+  try { server?.stop(true); } catch { /* already down */ }
+});
+
+async function putAttrs(ref: string, body: unknown) {
+  const res = await fetch(`${BASE}/api/nodes/${encodeURIComponent(ref)}/attrs?network_id=${NET}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+async function listNodes() {
+  const res = await fetch(`${BASE}/api/nodes?network_id=${NET}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const j = (await res.json()) as { nodes?: Array<Record<string, unknown>> };
+  return j.nodes ?? [];
+}
+
+describe("node display attrs — backward compatibility with existing rows", () => {
+  test("a pre-migration node row still lists fine; new fields read as empty, not missing/throwing", async () => {
+    const rows = await listNodes();
+    const row = rows.find((r) => r.node_id === LEGACY_NODE);
+    expect(row).toBeDefined();
+    // Must not blow up and must not omit the keys — the dashboard reads
+    // them unconditionally.
+    expect(row!).toHaveProperty("display_name");
+    expect(row!).toHaveProperty("team");
+    expect(row!).toHaveProperty("tags");
+    expect(row!.display_name ?? null).toBeNull();
+    expect(row!.team ?? null).toBeNull();
+    // tags normalises to an empty array rather than null/undefined so the
+    // dashboard can `.map()` without a guard.
+    expect(row!.tags).toEqual([]);
+    expect(row!.attrs_revision).toBe(0);
+  });
+});
+
+describe("node display attrs — write then read back", () => {
+  test("PUT sets display_name/team/tags, bumps attrs_revision, and GET /api/nodes reflects it", async () => {
+    const w = await putAttrs(LEGACY_ALIAS, {
+      base_attrs_revision: 0,
+      display_name: "研发一号机",
+      team: "platform",
+      tags: ["prod", "gpu"],
+    });
+    expect(w.status).toBe(200);
+    expect(w.json.ok).toBe(true);
+    expect(w.json.attrs_revision).toBe(1);
+
+    const row = (await listNodes()).find((r) => r.node_id === LEGACY_NODE)!;
+    expect(row.display_name).toBe("研发一号机");
+    expect(row.team).toBe("platform");
+    expect(row.tags).toEqual(["prod", "gpu"]);
+    expect(row.attrs_revision).toBe(1);
+  });
+
+  test("editing attrs does NOT touch config_revision (display vs config are separate revisions)", async () => {
+    const before = db.get<{ config_revision: number }>(
+      "SELECT config_revision FROM nodes WHERE node_id = ?1", LEGACY_NODE)!.config_revision ?? 0;
+    const w = await putAttrs(LEGACY_ALIAS, { base_attrs_revision: 1, team: "infra" });
+    expect(w.status).toBe(200);
+    const after = db.get<{ config_revision: number }>(
+      "SELECT config_revision FROM nodes WHERE node_id = ?1", LEGACY_NODE)!.config_revision ?? 0;
+    expect(after).toBe(before);
+  });
+
+  test("partial patch leaves untouched fields alone", async () => {
+    const row = (await listNodes()).find((r) => r.node_id === LEGACY_NODE)!;
+    // team was just changed to 'infra'; display_name/tags must survive.
+    expect(row.team).toBe("infra");
+    expect(row.display_name).toBe("研发一号机");
+    expect(row.tags).toEqual(["prod", "gpu"]);
+  });
+});
+
+describe("node display attrs — CAS concurrency guard", () => {
+  test("stale base_attrs_revision → 409 with the current revision, and NO write happens", async () => {
+    const before = (await listNodes()).find((r) => r.node_id === LEGACY_NODE)!;
+    const stale = await putAttrs(LEGACY_ALIAS, {
+      base_attrs_revision: 0, // deliberately stale
+      team: "should-not-land",
+    });
+    expect(stale.status).toBe(409);
+    expect(stale.json.ok).toBe(false);
+    expect(stale.json.error).toBe("attrs_revision_conflict");
+    expect(stale.json.current_attrs_revision).toBe(before.attrs_revision);
+
+    const after = (await listNodes()).find((r) => r.node_id === LEGACY_NODE)!;
+    expect(after.team).toBe(before.team); // unchanged
+    expect(after.attrs_revision).toBe(before.attrs_revision);
+  });
+});
+
+describe("node display attrs — untrusted input is narrowed at the boundary", () => {
+  test("tags: non-strings dropped, blanks dropped, duplicates folded, count + length capped", async () => {
+    const cur = (await listNodes()).find((r) => r.node_id === LEGACY_NODE)!.attrs_revision as number;
+    const w = await putAttrs(LEGACY_ALIAS, {
+      base_attrs_revision: cur,
+      tags: [
+        "keep",
+        "keep", // duplicate
+        "  spaced  ", // trimmed
+        "",
+        "   ",
+        42,
+        null,
+        { evil: true },
+        ["nested"],
+        "x".repeat(200), // over-long → dropped or truncated, never stored raw
+      ],
+    });
+    expect(w.status).toBe(200);
+    const tags = (await listNodes()).find((r) => r.node_id === LEGACY_NODE)!.tags as string[];
+    expect(Array.isArray(tags)).toBe(true);
+    expect(tags).toContain("keep");
+    expect(tags).toContain("spaced");
+    // one "keep", no junk, nothing absurdly long
+    expect(tags.filter((t) => t === "keep")).toHaveLength(1);
+    expect(tags.every((t) => typeof t === "string" && t.length > 0 && t.length <= 64)).toBe(true);
+    expect(tags.some((t) => t.includes("evil") || t.includes("nested"))).toBe(false);
+  });
+
+  test("display_name/team: non-string values are rejected, not coerced", async () => {
+    const cur = (await listNodes()).find((r) => r.node_id === LEGACY_NODE)!.attrs_revision as number;
+    const bad = await putAttrs(LEGACY_ALIAS, { base_attrs_revision: cur, team: { not: "a string" } });
+    expect(bad.status).toBe(400);
+    expect(bad.json.ok).toBe(false);
+  });
+});
+
+describe("node display attrs — auth + scope", () => {
+  test("no token → 401, and the row is untouched", async () => {
+    const before = (await listNodes()).find((r) => r.node_id === LEGACY_NODE)!;
+    const res = await fetch(`${BASE}/api/nodes/${LEGACY_ALIAS}/attrs?network_id=${NET}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ base_attrs_revision: before.attrs_revision, team: "hijack" }),
+    });
+    expect(res.status).toBe(401);
+    const after = (await listNodes()).find((r) => r.node_id === LEGACY_NODE)!;
+    expect(after.team).toBe(before.team);
+  });
+
+  test("unknown node ref → 404", async () => {
+    const r = await putAttrs("no-such-node-ref", { base_attrs_revision: 0, team: "x" });
+    expect(r.status).toBe(404);
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -6,6 +6,7 @@ import { db, logTaskEvent, logAudit } from "./db.js";
 import { createSSEStream, createNetworkObserverStream, pushEvent, pushNetworkObserverEvent, getSSEStats } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { validateAvatarUrl } from "./avatar-validate.js";
+import { narrowTags, parseStoredTags, validateScalarAttr } from "./node-attrs-validate.js";
 import { register, login, resolveToken, getUserNetworks, getUserAllNetworks, createNetwork, deleteNetwork, renameNetwork, changePassword, issueUserToken, listTokens, createToken, revokeToken, getNetworkMembers, getUserNetworkRole, addNetworkMember, updateMemberRole, removeNetworkMember, createInvite, joinByInvite, createNetworkTokenForNode, type AuthUser } from "./auth.js";
 import { abortRename, cleanupCommittedRenameSessions, commitRename, prepareRename, resolveCanonicalAlias } from "./rename.js";
 import { sharedSendDedup, buildDuplicateSendPayload } from "./send_dedup.js";
@@ -2129,6 +2130,115 @@ return Bun.serve({
     // legacy master token). Value passes validateAvatarUrl (http/https
     // only, ≤ 2048 chars, no control chars — XSS boundary, see
     // avatar-validate.ts).
+    // ── REST: node DISPLAY attributes (display_name / team / tags) ──
+    // Companion to the avatar route below: hub-side presentation fields that
+    // agent-node does not consume, so they deliberately bypass the RFC-024
+    // config-apply pipeline (no doorbell, no ack, no config_revision bump).
+    //
+    // Unlike avatar, these are multi-field and multi-editor, so they carry
+    // their OWN optimistic lock (`attrs_revision`). A stale base revision is
+    // a 409 with the current value, mirroring update_node_config's contract
+    // so the dashboard can reuse its conflict-resolution UX.
+    //
+    // NOT editable here: `alias` (message-routing key) and `node_name`
+    // (addressing key). Renaming those must go through the rename 2PC at
+    // /api/node-rename/* which cascades sessions + api_tokens + SSE cleanup;
+    // a single-table UPDATE would strand the node (see #146).
+    const nodeAttrsMatch = url.pathname.match(/^\/api\/nodes\/([^/]+)\/attrs$/);
+    if (nodeAttrsMatch && req.method === "PUT") {
+      let attrsBody: any;
+      try {
+        attrsBody = await req.json();
+      } catch {
+        return withCors(req, Response.json({ ok: false, error: "invalid JSON" }, { status: 400 }));
+      }
+      const ref = decodeURIComponent(nodeAttrsMatch[1]);
+      const params: any[] = [ref, ref, ref];
+      let sql = "SELECT node_id, alias, network_id, display_name, team, tags, attrs_revision FROM nodes WHERE (node_id = ?1 OR node_name = ?2 OR alias = ?3)";
+      sql = addNetworkScope(sql, params, restScope);
+      sql += " ORDER BY updated_at DESC LIMIT 1";
+      const node = db.get<any>(sql, ...params);
+      if (!node) return withCors(req, Response.json({ ok: false, error: "node not found" }, { status: 404 }));
+
+      const nodeNetId = node.network_id ?? singleNetworkId(restScope);
+      if (!canRestWriteNetwork(restAuth, nodeNetId, isAdmin)) {
+        return withCors(req, Response.json({ ok: false, error: "permission_denied" }, { status: 403 }));
+      }
+
+      // Optimistic lock BEFORE any narrowing work, so a losing writer never
+      // has side effects.
+      const currentRev = Number(node.attrs_revision ?? 0);
+      const baseRev = attrsBody?.base_attrs_revision;
+      if (typeof baseRev !== "number" || !Number.isInteger(baseRev) || baseRev < 0) {
+        return withCors(req, Response.json({
+          ok: false, error: "base_attrs_revision required (integer >= 0)",
+        }, { status: 400 }));
+      }
+      if (baseRev !== currentRev) {
+        return withCors(req, Response.json({
+          ok: false,
+          error: "attrs_revision_conflict",
+          current_attrs_revision: currentRev,
+          message: "another editor changed this node's attributes; re-read and retry",
+        }, { status: 409 }));
+      }
+
+      // Scalars reject on wrong type (never coerce); tags drop junk per item.
+      const nextDisplay = "display_name" in attrsBody
+        ? validateScalarAttr(attrsBody.display_name, "display_name")
+        : null;
+      if (nextDisplay && !nextDisplay.ok) {
+        return withCors(req, Response.json({ ok: false, error: "invalid_display_name", reason: nextDisplay.reason }, { status: 400 }));
+      }
+      const nextTeam = "team" in attrsBody ? validateScalarAttr(attrsBody.team, "team") : null;
+      if (nextTeam && !nextTeam.ok) {
+        return withCors(req, Response.json({ ok: false, error: "invalid_team", reason: nextTeam.reason }, { status: 400 }));
+      }
+      const nextTags = "tags" in attrsBody ? narrowTags(attrsBody.tags) : null;
+
+      // Only the supplied fields move; the rest keep their stored value.
+      const sets: string[] = [];
+      const vals: any[] = [];
+      if (nextDisplay) { sets.push(`display_name = ?${vals.length + 1}`); vals.push(nextDisplay.value); }
+      if (nextTeam) { sets.push(`team = ?${vals.length + 1}`); vals.push(nextTeam.value); }
+      if (nextTags) { sets.push(`tags = ?${vals.length + 1}`); vals.push(JSON.stringify(nextTags)); }
+      // A no-op patch still bumps the revision: the caller observed a state
+      // and asserted it, so honouring the CAS keeps client counters in step.
+      sets.push(`attrs_revision = ?${vals.length + 1}`); vals.push(currentRev + 1);
+      sets.push(`updated_at = datetime('now')`);
+      vals.push(node.node_id);
+      // Guard the UPDATE with the same revision so two concurrent writers
+      // that both passed the read above cannot both land.
+      vals.push(currentRev);
+      const res = db.run(
+        `UPDATE nodes SET ${sets.join(", ")} WHERE node_id = ?${vals.length - 1} AND attrs_revision = ?${vals.length}`,
+        vals,
+      );
+      if (!res.changes) {
+        const fresh = db.get<any>("SELECT attrs_revision FROM nodes WHERE node_id = ?1", node.node_id);
+        return withCors(req, Response.json({
+          ok: false,
+          error: "attrs_revision_conflict",
+          current_attrs_revision: Number(fresh?.attrs_revision ?? currentRev),
+          message: "another editor changed this node's attributes; re-read and retry",
+        }, { status: 409 }));
+      }
+      logAudit(restAuth?.userId ?? null, restAuth?.username ?? null, "node_attrs_updated", "node", node.node_id,
+        JSON.stringify({ display_name: nextDisplay?.value ?? undefined, team: nextTeam?.value ?? undefined, tags: nextTags ?? undefined }),
+        undefined, nodeNetId ?? undefined);
+      const after = db.get<any>(
+        "SELECT display_name, team, tags, attrs_revision FROM nodes WHERE node_id = ?1", node.node_id);
+      return withCors(req, Response.json({
+        ok: true,
+        node_id: node.node_id,
+        alias: node.alias,
+        display_name: after?.display_name ?? null,
+        team: after?.team ?? null,
+        tags: parseStoredTags(after?.tags),
+        attrs_revision: Number(after?.attrs_revision ?? currentRev + 1),
+      }));
+    }
+
     const nodeAvatarMatch = url.pathname.match(/^\/api\/nodes\/([^/]+)\/avatar$/);
     if (nodeAvatarMatch && req.method === "PUT") {
       let avatarBody: any;
@@ -2315,7 +2425,8 @@ return Bun.serve({
       let sql = `SELECT node_id, node_name, alias, runtime, model,
                         config_path, channels, server, hostname,
                         network_id, created_at, updated_at,
-                        config_snapshot, lifecycle_state, avatar_url
+                        config_snapshot, lifecycle_state, avatar_url,
+                        display_name, team, tags, attrs_revision
                  FROM nodes WHERE 1=1`;
       const params: any[] = [];
       sql = addNetworkScope(sql, params, restScope);
@@ -2337,7 +2448,16 @@ return Bun.serve({
           catch { /* malformed snapshot — leave role null */ }
         }
         const { config_snapshot, ...rest } = r;
-        return { ...rest, role };
+        // `tags` is stored as JSON text; hand the dashboard a real array so
+        // it can map() without a guard, and normalise legacy/absent values
+        // to [] rather than null. attrs_revision is normalised to a number
+        // so pre-migration rows (NULL) read as 0.
+        return {
+          ...rest,
+          tags: parseStoredTags(r.tags),
+          attrs_revision: Number(r.attrs_revision ?? 0),
+          role,
+        };
       });
       return withCors(req, Response.json({ ok: true, nodes: rows, count: rows.length }));
     }


### PR DESCRIPTION
Step 1 of Vincent 目标第 3 条 (dashboard/app 多维度编辑): the **display-side** attributes — `display_name`, `team`, `tags`.

## Design decisions worth reviewing

**1. Deliberately NOT in the RFC-024 config-apply pipeline.** Follows the `avatar_url` (#462) precedent: agent-node consumes none of these fields, so pushing them through config revision/ack would ring a doorbell for a field the node cannot interpret — the ack never comes back and the config revision can wedge. These are hub-side presentation only.

**2. Its own optimistic lock, separate from `config_revision`.** `avatar_url` has *no* concurrency protection, which is the wrong half of that precedent to copy — two dashboards editing one node would silently clobber each other. So attrs writes carry `base_attrs_revision` and return **409** on a stale value (mirroring `update_node_config`'s conflict contract, so the dashboard can reuse its resolution UX). Keeping the counter separate means **editing a tag never bumps the node's config revision**. The UPDATE is additionally guarded by `AND attrs_revision = <base>`, so two writers that both passed the read cannot both land.

**3. `alias` and `node_name` are NOT editable here — on purpose.**
- `alias` is the **message-routing key**.
- `node_name` is an **addressing key** (`WHERE node_id OR node_name OR alias`).

Renaming either must go through the existing rename 2PC (`/api/node-rename/*`), which cascades `sessions.alias` + `nodes.alias` + `api_tokens.name` + SSE session cleanup + a `node.renamed` broadcast. A single-table UPDATE would strand the node — precisely the failure #146 describes. `display_name` exists so the UI can offer a safe "edit the label" today while true rename stays behind the 2PC path. **These must be visually distinct in the UI** so a user never thinks editing the label changed the name others @ them by.

## Boundary validation

Two deliberately different postures in `node-attrs-validate.ts`:
- **scalars** (`display_name`, `team`) — a wrong TYPE is **rejected (400)**, never coerced; silently storing `"[object Object]"` would persist garbage the user never typed.
- **tags** (list) — junk dropped **per element** (`typeof` → control-char strip → trim → length cap → case-folded dedup → count cap), so one fat-fingered entry doesn't 400 the whole save. Same reasoning as the `channels` patch in `tools.ts`.

## Tests — real HTTP entry, red first

`node-attrs.test.ts` (9 tests) drives the **real endpoint on a booted server**. All nine were **RED** before this change (8 assertion failures + 1 shape gap):

| behaviour | assertion |
|---|---|
| legacy row (pre-migration) | lists cleanly; new fields present-but-empty, `tags: []`, `attrs_revision: 0` |
| write → read back | GET reflects all three fields, revision bumped |
| **isolation** | attrs write leaves `config_revision` untouched |
| partial patch | untouched fields survive |
| **CAS** | stale base → 409 + `current_attrs_revision`, **and no write happens** |
| tags narrowing | non-strings/blanks/dupes dropped, length + count capped |
| scalar type | wrong type → 400, not coerced |
| auth | no token → 401, row untouched; unknown ref → 404 |

`api-nodes-shape.test.ts` updated. Note for reviewers: that file **mirrors** the handler's SQL rather than calling it, and had **already drifted** — it never picked up `lifecycle_state` / `avatar_url`. I widened and annotated it so the next reader treats a diff there as "re-read the handler", with `node-attrs.test.ts` being what actually asserts the wire shape.

## Migration verified against a POPULATED database, in Docker

Not an empty-file check:

1. Seeded **120 node rows** using the **pre-change** code (columns genuinely absent — verified via `PRAGMA table_info`).
2. Reopened the same file with **this** code.

Result: 4 columns added in place · **120/120 rows preserved and readable** · every `attrs_revision` defaults to 0 · a CAS write on a legacy row succeeds · `config_revision` untouched → `MIGRATION_VERDICT=PASS`.

**No production database was touched at any point.**

## Regression

Full server suite: **575 pass / 0 fail** (35 files).

Isolation note: `node-attrs.test.ts` boots its own `Bun.serve`, same pattern as `uploads-http.test.ts` / `api-host-supervisors-fallback.test.ts`, which are per-file runs by design (single-process module-singleton conflict, tracked in #434).

Do not merge without review — author does not self-approve.
