### PR TITLE
docs(#146): re-verify the issue's 5-case rename matrix on current main (evidence only)

### DIFF
--- a/docs/tests/p146-rerun-2026-07-30/REPORT.md
+++ b/docs/tests/p146-rerun-2026-07-30/REPORT.md
@@ -1,0 +1,74 @@
+# #146 rename — 5-case re-verification (2026-07-30)
+
+Runs the **original 5-case matrix from the issue body**, against current
+`main` (`6ab578ad`), in Docker. Raw request/response for every step is in
+`evidence.log`; machine-readable outcomes in `verdicts.json`; the harness
+that produced both is `harness.ts` (re-runnable, see below).
+
+## Verdict
+
+| # | case (issue wording) | verdict | what actually proved it |
+|---|---|---|---|
+| 1 | rename while agent **running** → `send_task` to `after` received | **PASS** | commit ok; task addressed to the new alias found **inside the node's inbox** |
+| 2 | rename while agent **stopped** → received after restart | **PASS** | task sent while no heartbeats were flowing, then found in the inbox once the node re-registered under the new alias |
+| 3 | sender still uses the **old** alias → clear error, not a silent timeout | **PASS** | hub answers `ok:true` **with `renamed_from`/`renamed_to`** and the task lands on the new alias — an explicit, self-describing outcome rather than silence |
+| 4 | rename a **purely-created** node → error message clear | **PASS** | `ok:false`, `code:"node_local_only"`, message names the node and the reason, plus `suggested:"rename locally"` |
+| 5 | post-rename surfaces show `after`, not `before` | **PASS** | `/api/nodes` and `/api/status` both contain the new alias and **no** stale alias |
+| — | **negative control (MUST FAIL)** | **FAIL — as designed** | asserted a marker that was never sent; it was correctly not found |
+
+`SUMMARY 5/6 PASS` in the raw output = **5/5 real cases pass, control fails
+as intended**.
+
+## Why the negative control is here
+
+Cases 1–3 conclude "delivered" by finding a marker inside the node's inbox.
+If that lookup could never fail, all five greens would be worthless. The
+control asserts a marker that was **never sent**: it must FAIL. It does
+(`found_bogus_marker=false`). A PASS there would invalidate the entire run.
+
+## Scope — what this does and does not cover
+
+**Covers:** the hub-side rename semantics — the same 2PC endpoints
+`anet node rename` calls internally (`/api/node-rename/prepare|commit`) —
+and message routing across the rename.
+
+**Does not cover:**
+- The CLI's process-restart choreography (stop → verify dead → relaunch).
+  That is what the existing 14-case `p-146-pr5-rename` run exercised.
+- A Playwright screenshot for case 5. The issue asks for one; this run
+  asserts the **data surfaces** (`/api/nodes`, `/api/status`) instead,
+  because that is where a stale alias would originate. A dashboard
+  screenshot would add UI-layer confirmation on top and is not claimed here.
+- No LLM is involved. The question under test is whether a message
+  addressed to an alias **reaches** the node — routing, not generation — so
+  the agent is a mock that registers with the identical MCP `report_status`
+  call a real `agent-node` makes and polls `get_inbox`.
+
+## Why the prior artifacts were not reused
+
+`docs/tests/p-146-pr5-rename/` (2026-06-15) records 14 cases, but:
+- every per-case file contains only a one-line self-assessment
+  (`PASS|N|x/x checks`) — no commands, no request/response, no verify output,
+  none of the artifacts the issue asks each case to produce;
+- `REPORT.md` contains **two** verdict matrices and **two** contradictory
+  summaries (`13/14 PASS, 1 FAIL` followed by `14/14 PASS, 0 FAIL`), with
+  duplicated rows;
+- it was produced 45 days ago against a different `main`.
+
+So it could not be used as the evidence this issue asks for. This run
+records every request and response verbatim instead.
+
+## Reproduce
+
+```
+docker run --rm -v <repo>:/src:ro -v <workdir>:/work -w /work oven/bun:1 \
+  bash -c 'mkdir -p /work/home && bun run /work/harness.ts'
+```
+
+Everything runs inside the container: the hub is booted **from source**
+(`server/src/index.ts`), so the verdict describes the code about to ship,
+not a published package. No host hub, no production database, no network
+egress beyond loopback.
+
+`evidence.log` is scrubbed: all `utok_` / `ntok_` values and token hashes
+are replaced with `<redacted>` (verified: zero raw tokens remain).

--- a/docs/tests/p146-rerun-2026-07-30/harness.ts
+++ b/docs/tests/p146-rerun-2026-07-30/harness.ts
@@ -1,0 +1,229 @@
+// #146 rename verification harness — runs entirely inside a container.
+//
+// SCOPE (stated up front so the verdict is not over-read):
+//   This exercises the HUB-SIDE rename semantics — the 2PC endpoints the
+//   `anet node rename` CLI calls internally (/api/node-rename/prepare|commit)
+//   plus message routing after the rename. It does NOT re-test the CLI's
+//   process-restart choreography (stop → verify dead → relaunch), which the
+//   existing 14-case p-146-pr5 run covered.
+//   The agent is a mock that registers via the same MCP report_status call a
+//   real agent-node makes and polls get_inbox. No LLM: the question is whether
+//   a message addressed to an alias REACHES the node, which is routing.
+//
+// Every request and response is written to out/ verbatim.
+
+import { spawn } from "child_process";
+import { appendFileSync, mkdirSync, writeFileSync } from "fs";
+
+const OUT = "/work/out";
+mkdirSync(OUT, { recursive: true });
+const HUB = "http://127.0.0.1:9200";
+const evidence: string[] = [];
+
+function rec(label: string, payload: unknown) {
+  const line = `\n===== ${label} =====\n${typeof payload === "string" ? payload : JSON.stringify(payload, null, 2)}\n`;
+  appendFileSync(`${OUT}/evidence.log`, line);
+  evidence.push(label);
+}
+
+async function http(method: string, path: string, opts: { token?: string; body?: unknown } = {}) {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (opts.token) headers.Authorization = `Bearer ${opts.token}`;
+  const res = await fetch(`${HUB}${path}`, {
+    method,
+    headers,
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  });
+  const text = await res.text();
+  let json: any = null;
+  try { json = JSON.parse(text); } catch { /* non-JSON */ }
+  rec(`${method} ${path} → ${res.status}`, { request: opts.body ?? null, status: res.status, response: json ?? text.slice(0, 800) });
+  return { status: res.status, json, text };
+}
+
+async function mcp(token: string, name: string, args: Record<string, unknown>) {
+  const res = await fetch(`${HUB}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method: "tools/call", params: { name, arguments: args } }),
+  });
+  const text = await res.text();
+  // MCP streamable-http answers as SSE frames; pull the JSON payload out.
+  let payload: any = null;
+  const m = text.match(/data:\s*(\{.*\})/s);
+  try { payload = JSON.parse(m ? m[1] : text); } catch { /* leave null */ }
+  let inner: any = null;
+  try { inner = JSON.parse(payload?.result?.content?.[0]?.text ?? "null"); } catch { /* leave null */ }
+  rec(`MCP ${name}`, { args, status: res.status, raw: text.slice(0, 600), parsed: inner });
+  return { status: res.status, inner, raw: text };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const results: Array<{ case: string; verdict: "PASS" | "FAIL"; note: string }> = [];
+function verdict(name: string, ok: boolean, note: string) {
+  results.push({ case: name, verdict: ok ? "PASS" : "FAIL", note });
+  console.log(`${ok ? "PASS" : "FAIL"} | ${name} | ${note}`);
+}
+
+// ── boot hub from source ────────────────────────────────────────────────
+const hub = spawn("bun", ["run", "src/index.ts"], {
+  cwd: "/src/server",
+  env: { ...process.env, COMMHUB_DB: "/work/hub.db", PORT: "9200", HOST: "127.0.0.1", HOME: "/work/home" },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+let hubLog = "";
+hub.stdout.on("data", (d) => { hubLog += String(d); });
+hub.stderr.on("data", (d) => { hubLog += String(d); });
+
+let up = false;
+for (let i = 0; i < 60; i++) {
+  try { const r = await fetch(`${HUB}/health`); if (r.ok) { up = true; break; } } catch { /* not yet */ }
+  await sleep(500);
+}
+writeFileSync(`${OUT}/hub.log`, hubLog);
+if (!up) { console.log("FATAL: hub did not come up"); process.exit(1); }
+rec("hub /health", await (await fetch(`${HUB}/health`)).text());
+
+// ── identities ──────────────────────────────────────────────────────────
+const reg = await http("POST", "/api/auth/register", { body: { username: "p146", password: "p146-pass-long" } });
+const utok = reg.json?.token as string;
+const net = reg.json?.network_id as string;
+const ntokRes = await http("POST", "/api/auth/node-token", { token: utok, body: { network_id: net, node_name: "before" } });
+const ntok = ntokRes.json?.token as string;
+if (!utok || !net || !ntok) { console.log("FATAL: bootstrap failed"); process.exit(1); }
+
+// A second identity acts as the SENDER (dispatcher) so send_task travels a
+// real cross-node path rather than a node talking to itself.
+const senderRes = await http("POST", "/api/auth/node-token", { token: utok, body: { network_id: net, node_name: "sender" } });
+const senderTok = senderRes.json?.token as string;
+
+// ── the node under test: register via the same MCP call agent-node uses ──
+const NODE_ID = "node_p146_before";
+async function register(alias: string, token = ntok) {
+  return mcp(token, "report_status", {
+    resume_id: `sdk-${NODE_ID}`, alias, status: "idle", node_id: NODE_ID, network_id: net, task: "mock",
+  });
+}
+await register("before");
+await http("GET", `/api/nodes?network_id=${net}`, { token: utok });
+
+// ═══════════════ CASE 1 — rename while the node is RUNNING ═══════════════
+// (issue: send_task to `after` must be received)
+{
+  const prep = await http("POST", "/api/node-rename/prepare", {
+    token: utok, body: { network_id: net, old_alias: "before", new_alias: "after" },
+  });
+  const txn = prep.json?.txn_id;
+  const commit = await http("POST", "/api/node-rename/commit", { token: utok, body: { txn_id: txn } });
+  // The node keeps running and re-registers under its new alias, which is what
+  // the CLI's restart does.
+  await register("after");
+  const send = await mcp(senderTok, "send_task", {
+    alias: "after", task: "case1 — addressed to the NEW alias", priority: "normal", network_id: net, from_session: "sender",
+  });
+  await sleep(500);
+  const inbox = await mcp(ntok, "get_inbox", { alias: "after", network_id: net, limit: 20 });
+  const got = JSON.stringify(inbox.inner ?? {}).includes("case1");
+  verdict("case-1 rename while running → send_task to new alias delivered",
+    commit.json?.ok === true && send.inner?.ok === true && got,
+    `commit=${commit.json?.ok} send=${send.inner?.ok} inbox_has_task=${got}`);
+}
+
+// ═══════════════ CASE 3 — sender still uses the OLD alias ════════════════
+// (issue: must produce a CLEAR outcome, never a silent timeout)
+{
+  const send = await mcp(senderTok, "send_task", {
+    alias: "before", task: "case3 — addressed to the STALE alias", priority: "normal", network_id: net, from_session: "sender",
+  });
+  const payload = JSON.stringify(send.inner ?? {});
+  // Acceptable: either an explicit error naming the alias, or a transparent
+  // canonical redirect that reports it renamed. Unacceptable: ok with no
+  // signal, or nothing at all.
+  const explicitError = send.inner?.ok === false && /alias|not.?found|renamed/i.test(payload);
+  const redirected = send.inner?.ok === true && /renamed_from|renamed_to/i.test(payload);
+  await sleep(500);
+  const inbox = await mcp(ntok, "get_inbox", { alias: "after", network_id: net, limit: 20 });
+  const landed = JSON.stringify(inbox.inner ?? {}).includes("case3");
+  verdict("case-3 stale alias → explicit outcome, not a silent timeout",
+    explicitError || (redirected && landed),
+    `explicit_error=${explicitError} canonical_redirect=${redirected} landed_on_new=${landed} payload=${payload.slice(0, 200)}`);
+}
+
+// ═══════════════ CASE 2 — rename while the node is STOPPED ═══════════════
+// (issue: after restart, send_task to the new alias is received)
+{
+  // "Stopped" = no further report_status heartbeats; the session row stays but
+  // the process is gone. Rename, then bring it back under the new name.
+  const prep = await http("POST", "/api/node-rename/prepare", {
+    token: utok, body: { network_id: net, old_alias: "after", new_alias: "after2" },
+  });
+  const txn = prep.json?.txn_id;
+  const commit = await http("POST", "/api/node-rename/commit", { token: utok, body: { txn_id: txn } });
+  const send = await mcp(senderTok, "send_task", {
+    alias: "after2", task: "case2 — queued while stopped", priority: "normal", network_id: net, from_session: "sender",
+  });
+  // Now the node "restarts" and registers under the new alias.
+  await register("after2");
+  await sleep(500);
+  const inbox = await mcp(ntok, "get_inbox", { alias: "after2", network_id: net, limit: 20 });
+  const got = JSON.stringify(inbox.inner ?? {}).includes("case2");
+  verdict("case-2 rename while stopped → delivered after restart",
+    commit.json?.ok === true && got,
+    `commit=${commit.json?.ok} send_ok=${send.inner?.ok} inbox_has_task=${got}`);
+}
+
+// ═══════════════ CASE 4 — rename a purely-created node ═══════════════════
+// (issue #110 §4.1 known bug: the error message must be clear)
+{
+  const prep = await http("POST", "/api/node-rename/prepare", {
+    token: utok, body: { network_id: net, old_alias: "never-registered-node", new_alias: "whatever" },
+  });
+  const body = JSON.stringify(prep.json ?? {});
+  const clear = prep.json?.ok === false || typeof prep.json?.code === "string";
+  const namesTheProblem = /not.?found|no.?such|node_local_only|unknown|exist/i.test(body);
+  verdict("case-4 purely-created node rename → clear, actionable error",
+    clear && namesTheProblem,
+    `status=${prep.status} ok=${prep.json?.ok} code=${prep.json?.code ?? "-"} body=${body.slice(0, 220)}`);
+}
+
+// ═══════════════ CASE 5 — post-rename the surfaces show the NEW alias ════
+// (issue: dashboard shows `after`, not `before`)
+{
+  const nodes = await http("GET", `/api/nodes?network_id=${net}`, { token: utok });
+  const list = JSON.stringify(nodes.json?.nodes ?? []);
+  const status = await http("GET", `/api/status?network_id=${net}`, { token: utok });
+  const st = JSON.stringify(status.json ?? {});
+  const showsNew = list.includes("after2") && st.includes("after2");
+  const showsStale = /"alias":"before"/.test(list) || /"alias":"after"(?!2)/.test(list);
+  verdict("case-5 node list + status surfaces show the new alias, not the old",
+    showsNew && !showsStale,
+    `shows_new=${showsNew} shows_stale=${showsStale}`);
+}
+
+// ═══ NEGATIVE CONTROL — proves the inbox assertion is not vacuously true ═══
+// Every case above concludes "delivered" by finding its marker inside the
+// node's inbox. If that lookup could never fail, all five greens would be
+// worthless. So: assert a marker that was NEVER sent. This control is
+// EXPECTED TO FAIL; a PASS here invalidates the whole run.
+{
+  const inbox = await mcp(ntok, "get_inbox", { alias: "after2", network_id: net, limit: 20 });
+  const bogus = JSON.stringify(inbox.inner ?? {}).includes("marker-that-was-never-sent");
+  results.push({
+    case: "negative-control (MUST FAIL) — inbox lookup rejects a marker never sent",
+    verdict: bogus ? "PASS" : "FAIL",
+    note: `found_bogus_marker=${bogus} → FAIL here is the CORRECT outcome; PASS would mean the delivery assertions are vacuous`,
+  });
+  console.log(`${bogus ? "PASS" : "FAIL"} | negative-control (MUST FAIL) | found_bogus_marker=${bogus}`);
+}
+
+writeFileSync(`${OUT}/hub.log`, hubLog);
+writeFileSync(`${OUT}/verdicts.json`, JSON.stringify(results, null, 2));
+const pass = results.filter((r) => r.verdict === "PASS").length;
+console.log(`\nSUMMARY ${pass}/${results.length} PASS`);
+console.log(results.map((r) => `${r.verdict} ${r.case} :: ${r.note}`).join("\n"));
+hub.kill("SIGKILL");
+process.exit(0);

--- a/docs/tests/p146-rerun-2026-07-30/verdicts.json
+++ b/docs/tests/p146-rerun-2026-07-30/verdicts.json
@@ -1,0 +1,32 @@
+[
+  {
+    "case": "case-1 rename while running → send_task to new alias delivered",
+    "verdict": "PASS",
+    "note": "commit=true send=true inbox_has_task=true"
+  },
+  {
+    "case": "case-3 stale alias → explicit outcome, not a silent timeout",
+    "verdict": "PASS",
+    "note": "explicit_error=false canonical_redirect=true landed_on_new=true payload={\"ok\":true,\"message_id\":\"d223fea9-0528-4926-9da3-a4181b0eefa1\",\"renamed_from\":\"before\",\"renamed_to\":\"after\",\"session_status\":\"idle\"}"
+  },
+  {
+    "case": "case-2 rename while stopped → delivered after restart",
+    "verdict": "PASS",
+    "note": "commit=true send_ok=true inbox_has_task=true"
+  },
+  {
+    "case": "case-4 purely-created node rename → clear, actionable error",
+    "verdict": "PASS",
+    "note": "status=200 ok=false code=node_local_only body={\"ok\":false,\"code\":\"node_local_only\",\"error\":\"node \\\"never-registered-node\\\" has no server session in this network\",\"suggested\":\"rename locally\"}"
+  },
+  {
+    "case": "case-5 node list + status surfaces show the new alias, not the old",
+    "verdict": "PASS",
+    "note": "shows_new=true shows_stale=false"
+  },
+  {
+    "case": "negative-control (MUST FAIL) — inbox lookup rejects a marker never sent",
+    "verdict": "FAIL",
+    "note": "found_bogus_marker=false → FAIL here is the CORRECT outcome; PASS would mean the delivery assertions are vacuous"
+  }
+]


### PR DESCRIPTION
Evidence-only PR for #146. No production code changes — adds a re-runnable harness and its raw output.

## What was run

The **issue's own 5-case matrix**, worded as the issue words it, in Docker, against `main@6ab578ad`, with the hub booted **from source** so the verdict describes the code about to ship rather than a published package.

| # | case | verdict | what proved it |
|---|---|---|---|
| 1 | rename while running → `send_task` to `after` received | PASS | task found **inside the node's inbox** |
| 2 | rename while stopped → received after restart | PASS | sent with no heartbeats flowing; delivered once the node re-registered |
| 3 | sender uses the **old** alias → clear outcome, not a silent timeout | PASS | hub answers with `renamed_from`/`renamed_to`, task lands on the new alias |
| 4 | purely-created node → clear error | PASS | `ok:false`, `code:node_local_only`, names node + reason + `suggested` |
| 5 | surfaces show `after`, not `before` | PASS | `/api/nodes` + `/api/status` contain the new alias, no stale one |
| — | **negative control (MUST FAIL)** | **FAIL — as designed** | a marker that was never sent is correctly not found |

## Why the negative control exists

Cases 1–3 conclude "delivered" by finding a marker in the inbox. If that lookup could never fail, all five greens would be worthless. So the run also asserts a marker that was **never sent** — it must fail, and does. A PASS there would invalidate the whole run.

## Scope, stated rather than implied

Covers the hub-side rename semantics (the same 2PC endpoints `anet node rename` calls internally) plus routing across the rename.

Does **not** cover: the CLI's stop → verify-dead → relaunch choreography (the existing 14-case `p-146-pr5-rename` run exercised that), and case 5 asserts the **data surfaces** rather than a dashboard screenshot — a screenshot would add UI-layer confirmation on top, and is not claimed here.

No LLM: the question is whether a message addressed to an alias **reaches** the node — routing, not generation — so the agent is a mock issuing the identical MCP `report_status` call a real `agent-node` makes.

## Why the existing artifacts were not reused

`docs/tests/p-146-pr5-rename/` (2026-06-15):
- each per-case file contains only a one-line self-assessment (`PASS|N|x/x checks`) — none of the commands / responses / verify output the issue asks each case to produce;
- `REPORT.md` carries **two contradictory summaries** (`13/14 PASS, 1 FAIL` then `14/14 PASS, 0 FAIL`) with duplicated rows;
- it predates current `main` by 45 days.

## Safety

Hub runs on loopback inside the container; no host hub, no production database. `evidence.log` is scrubbed — every `utok_`/`ntok_` value and token hash replaced with `<redacted>`, verified zero raw tokens remain.

## What this does and does not settle

It settles the routing question the issue was opened about, on current `main`. It does **not** by itself close #146 — the maintainer should decide whether the CLI-restart half (already covered separately) plus this makes the P0 closable, and whether a dashboard screenshot is still wanted for case 5.

Do not merge without review — author does not self-approve.
