### PR TITLE
fix(#498): put the "agent-agent use send_task" rule at the decision point

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2316,7 +2316,7 @@ curl -F "file=@<本地路径>" \\
 ## 规则
 
 - 收到任务必须回应：确认→执行→汇报
-- 回复指挥室用 commhub_send_task（不是 commhub_reply，reply 不推送）
+- **给任何 agent 节点回复都用 commhub_send_task**（不是 commhub_reply）—— commhub_reply 只写库不唤醒对方 agent，对方 next inbox poll 前看不见；只有目标是 Dashboard/UI 时才用 commhub_reply（Vincent 2026-07-28 全网规则）
 - 不要猜 alias，用 get_all_status 查
 - **给用户发文件先 \`curl -F\` 上传 → markdown 引用 \`/api/files/<id>\`，不要发服务器本地路径**
 `);

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -133,7 +133,9 @@ const mcp = new Server(
     instructions: [
       `Messages from CommHub arrive as <channel source="commhub" task_id="..." priority="..." from="...">`,
       `These are tasks dispatched by the hub or other sessions via the CommHub Server.`,
-      `Reply using the commhub_reply tool. IMPORTANT: to make your reply appear in the Dashboard chat and reach the sender in real time, use status="completed" (a terminal status: completed/failed/cancelled) — that routes to send_reply and emits the new_reply SSE event the Dashboard listens for. A non-terminal status (in_progress/blocked/error) only updates your session status via report_status and does NOT show in the Dashboard, even though the call returns ok.`,
+      `Reply routing (IMPORTANT — the tool you pick determines whether the receiver actually gets woken up):`,
+      `  • If the sender is another agent node (from CommHub, from your peer's session alias), reply with commhub_send_task(alias="<their alias>", task="<your reply>"). This creates a new routable task that wakes the peer via new_task SSE so they process it. commhub_reply does NOT wake agent peers — they'd only see it on the next inbox poll (Vincent 2026-07-28 全网规则).`,
+      `  • Only use commhub_reply when the sender is the Dashboard/UI (task_id came from a browser chat). Use status="completed" (terminal) so send_reply routes it, updates the task row (Dashboard displays it), and emits new_reply SSE for the live Dashboard viewer. Non-terminal status (in_progress/blocked/error) just updates your session status and does NOT reach the Dashboard.`,
       `You can also use commhub_report_status to update your session status.`,
       `Session alias: ${ALIAS}`,
     ].join("\n"),
@@ -145,7 +147,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
       name: "commhub_reply",
-      description: "Reply to a CommHub task. Use status=\"completed\" (terminal) to push the reply to the Dashboard/sender in real time (send_reply → new_reply SSE); non-terminal status (in_progress/blocked/error) only updates session status (report_status) and does NOT reach the Dashboard.",
+      description: "Reply to a Dashboard/UI-originated CommHub task. ⚠ For agent-to-agent replies use commhub_send_task instead — commhub_reply does NOT wake agent peers via SSE (Vincent 2026-07-28 全网规则). status=\"completed\" (terminal) routes to send_reply and emits new_reply SSE for the live Dashboard; non-terminal status (in_progress/blocked/error) only updates session status (report_status) and does NOT reach the Dashboard.",
       inputSchema: {
         type: "object" as const,
         properties: {

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1058,7 +1058,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
   // ── V2: send_reply (关联 task_id，不触发 think) ──
   server.tool(
     "send_reply",
-    "Send a reply to a task. Linked to task_id via in_reply_to. Does NOT trigger agent processing.",
+    "Send a reply to a Dashboard/UI-originated task (updates task row, emits new_reply SSE — Dashboard reads it). ⚠ NOT for agent-to-agent replies: agent nodes only log new_reply and do not processInbox on it, so the peer will not see the reply in real time. Use send_task for peer-to-peer replies (RFC-030, Vincent 2026-07-28 全网规则). If the target alias resolves to a live agent node, the response includes a `warning` field pointing to send_task.",
     {
       alias: z.string().min(1).max(200).describe("Target session alias"),
       text: z.string().min(1).max(10000).describe("Reply content"),
@@ -1191,10 +1191,26 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       // #461 network observer summary — ids + routing only, no reply text.
       pushNetworkObserverEvent(effectiveNetId, { type: "new_reply", task_id: in_reply_to ?? null, message_id: id, from: from_session, to: alias, status: replyStatus });
 
+      // #498 — When the reply target is a live agent node (not Dashboard/UI),
+      // warn the caller that agent peers only log new_reply and do not
+      // processInbox on it. Points at the correct next action (send_task)
+      // so a follow-up turn corrects course rather than "why didn't they
+      // respond" spelunking. Absent field when target is Dashboard/hub/api
+      // (the correct path for commhub_reply) — silence is affirmation.
+      const targetIsAgent = replyTargetNodeId !== null && alias !== "hub" && alias !== "api";
+      const warning = targetIsAgent
+        ? `Target "${alias}" is an agent node. commhub_reply/send_reply does NOT wake agent peers (they only log new_reply, they do not processInbox on it) — the peer will not see this reply in real time. For agent-to-agent replies, use commhub_send_task(alias="${alias}", task="<your reply>") so the peer wakes via new_task SSE and processes it. (RFC-030, Vincent 2026-07-28 全网规则.)`
+        : undefined;
+
       return {
         content: [{
           type: "text" as const,
-          text: JSON.stringify({ ok: true, message_id: id, session_status: session?.status ?? "unknown" }),
+          text: JSON.stringify({
+            ok: true,
+            message_id: id,
+            session_status: session?.status ?? "unknown",
+            ...(warning ? { warning } : {}),
+          }),
         }],
       };
     }


### PR DESCRIPTION
Closes #498.

## Problem

Rule already existed in three places (CLI docs, Vincent 2026-07-28 全网 broadcast, past postmortems) — **but not in the MCP tool description the LLM reads when it decides between `commhub_reply` and `commhub_send_task`**. Result: three separate agents (including me on 07-28) picked `commhub_reply` for peer replies over three days; recipients never saw them because `agent-node/src/cli.ts:4341-4345` logs `new_reply` without `processInbox()` (**intentional per RFC-030** to avoid politeness loops on a 100-node fleet).

Investigation walkthrough left in the task thread. TL;DR: the log-only handler on `new_reply` has been there since initial release (21bc690a, 2026-05-10) and hub's `send_reply` description explicitly says "Does NOT trigger agent processing." **It's design, not a bug — just design where the rule is placed wrong**.

## Fix — put the rule where the decision happens

Three description edits + one hub-side safety net.

### 1. `agent-network/src/node-server.ts` — client-side MCP
Both the `commhub_reply` tool `description` and the MCP server `instructions` now lead with routing (peer replies use `commhub_send_task`; `commhub_reply` is only for Dashboard/UI-originated tasks). The 07-28 全网规则 is named explicitly so it enters the LLM's in-context reasoning.

### 2. `server/src/tools.ts` — hub-side MCP
`send_reply` tool description matches client wording so both agree.

### 3. `agent-network/bin/cli.ts:2319` — CLAUDE.md template
Replaces the narrow "回复指挥室用 send_task" (reads as "only 指挥室 is the exception") with **"给任何 agent 节点回复都用 commhub_send_task"**.

### 4. `server/src/tools.ts` — hub-side runtime warning
When the reply target resolves to a real agent node (`resolveNodeIdForAlias != null` and alias ≠ hub/api), the response payload gains a `warning` field naming the right next action:

```
Target "<alias>" is an agent node. commhub_reply/send_reply does NOT wake agent peers ... 
For agent-to-agent replies, use commhub_send_task(alias="<alias>", task="<your reply>") 
so the peer wakes via new_task SSE and processes it. (RFC-030, Vincent 2026-07-28 全网规则.)
```

Absent when target is hub/api — silence = affirmation. The warning **points at the correct next action** — not "why didn't they respond" spelunking (this specific direction was 通信龙's explicit ask given tonight's other three "reverse-pointing error message" incidents).

## What this does NOT change

- `new_reply` SSE still fires; `processInbox()` is still not called on it. The RFC-030 marginal-benefit-vs-loop-risk analysis stands (100 nodes × polite loop = burn).
- Task row update, inbox enqueue, chain-to-parent behavior all unchanged.
- Only `codex-app-server` continues to use `REPLY_VIA_SEND_TASK=true` in `sendReply()` (`cli.ts:421`); other runtimes keep send_reply for automatic replies. This PR is about **explicit agent-initiated replies** (the `commhub_reply` MCP tool), which is what tonight's incident used.

## Hard gate — real hub + tools/list, not "改了文件就算"

Verified against an isolated hub started from this branch (Bun MCP client + curl):

- MCP `tools/list` returns the new `send_reply` description: **5/5 expected phrases present** (`NOT for agent-to-agent replies`, `Use send_task for peer-to-peer replies`, `RFC-030`, `response includes a \`warning\` field`, `全网规则`).
- `send_reply` → live agent alias returns the warning: **6/6 checks pass** (field present + 5 action-pointing substring checks — `commhub_send_task`, `agent peers`, `not see this reply in real time`, `RFC-030`, `全网规则`).
- `send_reply` → alias `hub` correctly returns **no** `warning` field.
- Bun bundle of `node-server.ts` includes the new description strings.

Test harness at `scratchpad/pr498-hardgate-v3.sh` + `mcp-inspect-v2.ts` (local, not committed — happy to move to `docs/tests/` on request).

## Test plan

- [x] Isolated hub `tools/list` shows new `send_reply` description
- [x] `send_reply` → live agent returns `warning` field pointing to `commhub_send_task`
- [x] `send_reply` → `hub` alias returns no `warning` field (silence-affirms Dashboard path)
- [x] Bun bundle of node-server.ts contains new client-side description
- [ ] (post-merge) Regression: bump `agent-network` preview + check a live claude-code-cli node's MCP `tools/list` shows the new instructions in `~/.anet/nodes/<name>/`
- [ ] (post-merge) Add integration test under `server/src/*.test.ts` for the warning field behavior — happy to follow up if 通信龙 wants coverage in-tree

## Attribution

Author: 通信demo马
CC: 通信龙 (dispatch + review), Vincent (07-28 rule origin, RFC-030 design)