### PR TITLE
test(#498): regression coverage for the send_reply warning field + move harness to docs/tests

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2316,7 +2316,7 @@ curl -F "file=@<本地路径>" \\
 ## 规则
 
 - 收到任务必须回应：确认→执行→汇报
-- 回复指挥室用 commhub_send_task（不是 commhub_reply，reply 不推送）
+- **给任何 agent 节点回复都用 commhub_send_task**（不是 commhub_reply）—— commhub_reply 只写库不唤醒对方 agent，对方 next inbox poll 前看不见；只有目标是 Dashboard/UI 时才用 commhub_reply（Vincent 2026-07-28 全网规则）
 - 不要猜 alias，用 get_all_status 查
 - **给用户发文件先 \`curl -F\` 上传 → markdown 引用 \`/api/files/<id>\`，不要发服务器本地路径**
 `);

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -133,7 +133,9 @@ const mcp = new Server(
     instructions: [
       `Messages from CommHub arrive as <channel source="commhub" task_id="..." priority="..." from="...">`,
       `These are tasks dispatched by the hub or other sessions via the CommHub Server.`,
-      `Reply using the commhub_reply tool. IMPORTANT: to make your reply appear in the Dashboard chat and reach the sender in real time, use status="completed" (a terminal status: completed/failed/cancelled) — that routes to send_reply and emits the new_reply SSE event the Dashboard listens for. A non-terminal status (in_progress/blocked/error) only updates your session status via report_status and does NOT show in the Dashboard, even though the call returns ok.`,
+      `Reply routing (IMPORTANT — the tool you pick determines whether the receiver actually gets woken up):`,
+      `  • If the sender is another agent node (from CommHub, from your peer's session alias), reply with commhub_send_task(alias="<their alias>", task="<your reply>"). This creates a new routable task that wakes the peer via new_task SSE so they process it. commhub_reply does NOT wake agent peers — they'd only see it on the next inbox poll (Vincent 2026-07-28 全网规则).`,
+      `  • Only use commhub_reply when the sender is the Dashboard/UI (task_id came from a browser chat). Use status="completed" (terminal) so send_reply routes it, updates the task row (Dashboard displays it), and emits new_reply SSE for the live Dashboard viewer. Non-terminal status (in_progress/blocked/error) just updates your session status and does NOT reach the Dashboard.`,
       `You can also use commhub_report_status to update your session status.`,
       `Session alias: ${ALIAS}`,
     ].join("\n"),
@@ -145,7 +147,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
       name: "commhub_reply",
-      description: "Reply to a CommHub task. Use status=\"completed\" (terminal) to push the reply to the Dashboard/sender in real time (send_reply → new_reply SSE); non-terminal status (in_progress/blocked/error) only updates session status (report_status) and does NOT reach the Dashboard.",
+      description: "Reply to a Dashboard/UI-originated CommHub task. ⚠ For agent-to-agent replies use commhub_send_task instead — commhub_reply does NOT wake agent peers via SSE (Vincent 2026-07-28 全网规则). status=\"completed\" (terminal) routes to send_reply and emits new_reply SSE for the live Dashboard; non-terminal status (in_progress/blocked/error) only updates session status (report_status) and does NOT reach the Dashboard.",
       inputSchema: {
         type: "object" as const,
         properties: {

--- a/docs/tests/p-498-reply-warning/README.md
+++ b/docs/tests/p-498-reply-warning/README.md
@@ -1,0 +1,105 @@
+# #498 hard-gate harness — `send_reply` tool description + warning field
+
+**One-line purpose**: "改了文件" and "LLM 真的看得到" are two different things.
+This harness verifies the *second one*.
+
+## What broke on 2026-07-30 (why this exists)
+
+The rule "回复 agent 之间用 `commhub_send_task`，不用 `commhub_reply`" was
+documented in three places (`agent-network/bin/cli.ts` CLAUDE.md template,
+Vincent's 2026-07-28 全网 broadcast, and prior incident postmortems) —
+**but it was not in the MCP `tools/list` response the LLM reads when it
+decides which tool to call**. Three separate agents in three days picked
+the wrong tool because the rule was documented everywhere except the
+decision point.
+
+PR #502 put the rule into the tool description and added a runtime
+`warning` field on the server response when the target alias resolves to
+a real agent node. This harness locks in that fix at the transport
+layer, complementing the in-tree regression test
+(`server/src/send-reply-agent-warning.test.ts`).
+
+## What this harness verifies (that unit tests do NOT)
+
+| Layer                              | Unit test | This harness |
+|------------------------------------|-----------|--------------|
+| `send_reply` returns `warning` for real agent target | ✅ | ✅ |
+| Description string in `tools.ts` reaches `tools/list` | ❌ | ✅ |
+| MCP Streamable HTTP wire path serves the correct field | ❌ | ✅ |
+| Behavior against a real hub process (not in-process handler) | ❌ | ✅ |
+| Witnessed-red regression coverage | ✅ | ❌ |
+
+**Run both.** The unit test catches "someone deleted the branch"; the
+harness catches "someone rewired MCP transport / initializer / description
+plumbing so the field never leaves the process."
+
+## Run
+
+```bash
+./hardgate.sh
+```
+
+Requirements:
+- `bun`, `python3`, `curl` on PATH
+- Repo layout: harness sits at `docs/tests/p-498-reply-warning/`,
+  the hub source at `server/` (three levels up)
+- Free TCP port (default 9261 via `PORT=…` env)
+
+What it does:
+1. Boots an isolated `bun run server/src/index.ts` on `HOST=127.0.0.1`
+   with its own `COMMHUB_DB`, `COMMHUB_UPLOADS_DIR`, and `HOME` — no
+   touch of `~/.commhub/` production state.
+2. Registers an admin user via `POST /api/auth/register`, captures the
+   returned `network_token` (`ntok_...`).
+3. Seeds a fake agent session + tasks directly into the isolated DB.
+4. Drives an MCP client (`mcp-inspect.ts`) over Streamable HTTP:
+   - `tools/list` → assert `send_reply.description` contains 5 phrases
+   - `tools/call send_reply` → agent alias → assert `warning` field
+     present + contains 5 action-pointing substrings
+   - `tools/call send_reply` → `hub` alias → assert `warning` absent
+
+The trap in `hardgate.sh` kills the hub and removes the isolated
+temp dir on exit; nothing lingers.
+
+## Expected output
+
+```
+=== HARD GATE 1: send_reply description phrases ===
+  ✓ 'NOT for agent-to-agent replies'
+  ✓ 'Use send_task for peer-to-peer replies'
+  ✓ 'RFC-030'
+  ✓ 'response includes a `warning` field'
+  ✓ '全网规则'
+Gate 1: 5 pass / 0 fail
+
+=== HARD GATE 2A: send_reply → live agent alias ===
+response payload: { ..., "warning": "Target \"test-agent-peer\" is an agent node. ..." }
+✓ 'warning' field present
+  ✓ warning contains 'commhub_send_task'
+  ...
+Gate 2A: 6 pass / 0 fail
+
+=== HARD GATE 2B: send_reply → hub (Dashboard alias, no warning expected) ===
+response payload: { "ok": true, "message_id": "...", "session_status": "unknown" }
+✓ no 'warning' field (correct — hub is Dashboard path)
+```
+
+## Witnessed-red evidence
+
+`witnessed-red.txt` — captured on 2026-07-30 when the warning branch was
+temporarily reverted. The regression test `should include \`warning\` field`
+fails at line 147:
+
+```
+error: expect(received).toBeDefined()
+Received: undefined
+```
+
+Confirms the assertions are load-bearing, not shape-only.
+
+## When to update this harness
+
+- Any change to `server/src/tools.ts:send_reply` description
+- Any change to the `warning` field logic in `send_reply`
+- Any change to how MCP tools/list serialises tool descriptions
+- Before landing a release that ships either of the above

--- a/docs/tests/p-498-reply-warning/hardgate.sh
+++ b/docs/tests/p-498-reply-warning/hardgate.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# #498 hard gate — verify the send_reply tool description AND warning
+# field REACH THE LLM, not just "改了文件".
+#
+# Runs against an isolated hub started from ../../../server (fresh
+# COMMHUB_DB + UPLOADS_DIR + HOME, no touch of production). Uses a Bun
+# MCP client (./mcp-inspect.ts) to hit tools/list and tools/call.
+#
+# What this verifies (that unit tests do NOT):
+#   1. The description string in server/src/tools.ts is actually served
+#      via the MCP tools/list response — i.e. the LLM sees it.
+#   2. The warning branch fires for a real agent alias AND stays silent
+#      for hub/api aliases — end-to-end through the MCP transport.
+#
+# What unit tests do that this does NOT: witnessed-red regression
+# coverage (server/src/send-reply-agent-warning.test.ts). Run both.
+set -euo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$HERE/../../.." && pwd)
+ISO="${TMPDIR:-/tmp}/anet-498-hardgate.$$"
+rm -rf "$ISO"; mkdir -p "$ISO/hub-home/.commhub" "$ISO/uploads"
+
+export PORT="${PORT:-9261}"
+export HOST=127.0.0.1
+export COMMHUB_DB="$ISO/hub-home/.commhub/iso.db"
+export COMMHUB_UPLOADS_DIR="$ISO/uploads"
+export HOME="$ISO/hub-home"
+
+echo "=== Boot isolated hub on :$PORT (from $REPO/server) ==="
+cd "$REPO/server"
+nohup bun run src/index.ts >"$ISO/hub.log" 2>&1 &
+HUB_PID=$!
+trap 'kill "$HUB_PID" 2>/dev/null || true; rm -rf "$ISO"' EXIT
+for _ in $(seq 1 20); do
+  sleep 0.5
+  curl -sS --max-time 2 "http://127.0.0.1:$PORT/health" 2>/dev/null | grep -q '"ok":true' && break
+done
+curl -sS "http://127.0.0.1:$PORT/health" | python3 -c 'import sys,json;d=json.load(sys.stdin);print("hub up, version",d.get("version"))'
+
+echo ""
+echo "=== Register admin, capture ntok_ ==="
+REG=$(curl -sS -X POST "http://127.0.0.1:$PORT/api/auth/register" \
+  -H "Content-Type: application/json" -d '{"username":"iso498","password":"IsoTest123!"}')
+UTOK=$(echo "$REG" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))')
+NTOK=$(echo "$REG" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("network_token",""))')
+NETID=$(echo "$REG" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("network_id",""))')
+echo "utok=${UTOK:0:12}...  ntok=${NTOK:0:12}...  netid=$NETID"
+
+echo ""
+echo "=== Seed fake agent session + tasks ==="
+python3 - <<PY
+import sqlite3, uuid, os
+c = sqlite3.connect(os.environ["COMMHUB_DB"])
+cur = c.cursor()
+netid = cur.execute("SELECT network_id FROM networks LIMIT 1").fetchone()[0]
+cur.execute("""INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+               VALUES (?,?,?,?,?,datetime('now'),datetime('now'))""",
+            ("res_peer", "test-agent-peer", "idle", "n_peer", netid))
+cur.execute("""INSERT INTO nodes (node_id, node_name, alias, runtime, network_id, created_at, updated_at)
+               VALUES (?,?,?,?,?,datetime('now'),datetime('now'))""",
+            ("n_peer", "test-agent-peer", "test-agent-peer", "claude", netid))
+for to in ("test-agent-peer", "hub", "api"):
+    tid = "t_" + uuid.uuid4().hex[:12]
+    cur.execute("""INSERT INTO tasks (task_id, from_name, to_name, status, priority, content, network_id, created_at)
+                   VALUES (?,?,?,?,?,?,?,datetime('now'))""",
+                (tid, "dispatcher", to, "delivered", "normal", f"task to {to}", netid))
+    print(f"TID_{to.upper().replace('-','_')}={tid}")
+c.commit(); c.close()
+PY
+
+# Read TIDs from output
+eval "$(python3 - <<PY
+import sqlite3, os
+c = sqlite3.connect(os.environ["COMMHUB_DB"])
+for to in ("test-agent-peer","hub","api"):
+    r = c.execute("SELECT task_id FROM tasks WHERE to_name=? ORDER BY created_at DESC LIMIT 1",(to,)).fetchone()
+    key = to.upper().replace('-','_')
+    print(f"TID_{key}={r[0]}")
+PY
+)"
+echo "TID_TEST_AGENT_PEER=$TID_TEST_AGENT_PEER  TID_HUB=$TID_HUB  TID_API=$TID_API"
+
+echo ""
+echo "=== Drive MCP client ==="
+export HUB="http://127.0.0.1:$PORT" UTOK="$NTOK"
+export AGENT_TASK_ID="$TID_TEST_AGENT_PEER" HUB_TASK_ID="$TID_HUB"
+# ntok is auto-bound to a node whose alias equals the registered username
+# (auto-created "node:<username>" token). Pass that alias so send_reply's
+# from_session identity check passes.
+export FROM_SESSION="iso498"
+bun run "$HERE/mcp-inspect.ts"

--- a/docs/tests/p-498-reply-warning/mcp-inspect.ts
+++ b/docs/tests/p-498-reply-warning/mcp-inspect.ts
@@ -1,0 +1,106 @@
+// MCP inspect v2 — verify send_reply warning field behavior.
+const HUB = process.env.HUB || 'http://127.0.0.1:9251';
+const UTOK = process.env.UTOK || '';
+
+async function mcp(sessionId: string | null, method: string, params: any, id: number) {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json, text/event-stream',
+    'Authorization': `Bearer ${UTOK}`,
+  };
+  if (sessionId) headers['mcp-session-id'] = sessionId;
+  const res = await fetch(`${HUB}/mcp`, {
+    method: 'POST', headers,
+    body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+  });
+  const sid = res.headers.get('mcp-session-id') || sessionId;
+  const text = await res.text();
+  const dataLine = text.split('\n').find((l) => l.startsWith('data: '));
+  const payload = dataLine ? JSON.parse(dataLine.slice(6)) : JSON.parse(text);
+  return { sid, payload };
+}
+
+async function main() {
+  const init = await mcp(null, 'initialize', {
+    protocolVersion: '2024-11-05', capabilities: {},
+    clientInfo: { name: 'inspect', version: '0.0.1' },
+  }, 0);
+  const sid = init.sid;
+
+  // 1) Show send_reply description phrases
+  const list = await mcp(sid, 'tools/list', {}, 1);
+  const t = list.payload?.result?.tools?.find((x: any) => x.name === 'send_reply');
+  console.log('=== HARD GATE 1: send_reply description phrases ===');
+  const phrases = [
+    'NOT for agent-to-agent replies',
+    'Use send_task for peer-to-peer replies',
+    'RFC-030',
+    'response includes a `warning` field',
+    '全网规则',
+  ];
+  let p1 = 0, f1 = 0;
+  for (const p of phrases) {
+    const ok = t?.description?.includes(p);
+    console.log(`  ${ok ? '✓' : '✗'} '${p}'`);
+    ok ? p1++ : f1++;
+  }
+  console.log(`Gate 1: ${p1} pass / ${f1} fail\n`);
+
+  // 2) send_reply → live agent → expect warning
+  const agentTaskId = process.env.AGENT_TASK_ID || 'unset';
+  const r1 = await mcp(sid, 'tools/call', {
+    name: 'send_reply',
+    arguments: {
+      alias: 'test-agent-peer',
+      text: 'test reply body (should trigger warning)',
+      in_reply_to: agentTaskId,
+      status: 'replied',
+      from_session: process.env.FROM_SESSION || '',
+    },
+  }, 2);
+  console.log('=== HARD GATE 2A: send_reply → live agent alias ===');
+  const inner1 = r1.payload?.result?.content?.[0]?.text;
+  if (typeof inner1 === 'string') {
+    const parsed1 = JSON.parse(inner1);
+    console.log('response payload:', JSON.stringify(parsed1, null, 2));
+    let p2 = 0, f2 = 0;
+    if (parsed1.warning) {
+      p2++; console.log("✓ 'warning' field present");
+      const w = parsed1.warning;
+      for (const c of ['commhub_send_task', 'agent peers', 'not see this reply in real time', 'RFC-030', '全网规则']) {
+        const ok = w.includes(c);
+        console.log(`  ${ok ? '✓' : '✗'} warning contains '${c}'`);
+        ok ? p2++ : f2++;
+      }
+    } else {
+      f2++; console.log("✗ 'warning' field ABSENT");
+    }
+    console.log(`Gate 2A: ${p2} pass / ${f2} fail\n`);
+  } else {
+    console.log('parse fail:', r1.payload);
+  }
+
+  // 3) send_reply → hub (Dashboard path) → NO warning
+  const hubTaskId = process.env.HUB_TASK_ID || 'unset';
+  const r2 = await mcp(sid, 'tools/call', {
+    name: 'send_reply',
+    arguments: {
+      alias: 'hub',
+      text: 'test dash reply (should NOT trigger warning)',
+      in_reply_to: hubTaskId,
+      status: 'replied',
+      from_session: process.env.FROM_SESSION || '',
+    },
+  }, 3);
+  console.log('=== HARD GATE 2B: send_reply → hub (Dashboard alias, no warning expected) ===');
+  const inner2 = r2.payload?.result?.content?.[0]?.text;
+  if (typeof inner2 === 'string') {
+    const parsed2 = JSON.parse(inner2);
+    console.log('response payload:', JSON.stringify(parsed2, null, 2));
+    if (parsed2.warning) console.log("✗ 'warning' UNEXPECTEDLY present (target=hub)");
+    else console.log("✓ no 'warning' field (correct — hub is Dashboard path)");
+  } else {
+    console.log('parse fail:', r2.payload);
+  }
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/docs/tests/p-498-reply-warning/witnessed-red.txt
+++ b/docs/tests/p-498-reply-warning/witnessed-red.txt
@@ -1,0 +1,27 @@
+bun test v1.3.14 (0d9b296a)
+
+src/send-reply-agent-warning.test.ts:
+[commhub] database: /tmp/anet-498-warn-test-red.db
+[commhub] 🎉 14-day free trial started!
+[commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
+[17:18:01] peer-agent-498 → send_reply (replied) → peer-agent-498: peer reply (should trigger warning)
+142 |       status: "replied",
+143 |       from_session: AGENT_ALIAS,
+144 |     });
+145 | 
+146 |     expect(reply.ok).toBe(true);
+147 |     expect(reply.warning).toBeDefined();
+                                ^
+error: expect(received).toBeDefined()
+
+Received: undefined
+
+      at <anonymous> (/home/vansin/agent-orchestra-498/server/src/send-reply-agent-warning.test.ts:147:27)
+(fail) send_reply warning field (#498) > target alias resolves to a real agent → response includes `warning` field [65.53ms]
+[17:18:01] peer-agent-498 → send_reply (replied) → hub: dashboard reply
+[17:18:01] peer-agent-498 → send_reply (replied) → api: dashboard reply via api
+
+ 2 pass
+ 1 fail
+ 7 expect() calls
+Ran 3 tests across 1 file. [698.00ms]

--- a/server/src/send-reply-agent-warning.test.ts
+++ b/server/src/send-reply-agent-warning.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { db } from "./db.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "./tools.js";
+
+// #498 regression — the send_reply hub response gains a `warning` field
+// pointing at commhub_send_task ONLY when the target alias resolves to
+// a real agent node (i.e. not hub / not api / not an unbound alias).
+// Silence-affirms the Dashboard path.
+//
+// Why this test exists (通信龙 2026-07-30 裁定): the warning is a pure
+// hint — deleting it doesn't break any behavior, so it's exactly the
+// kind of code a future refactor drops silently. This test is the
+// tripwire: if the branch goes away, this test turns red.
+//
+// witnessed-red methodology (`feedback_witnessed_red_before_witnessed_green`):
+// I confirmed both assertions fail cleanly when the `warning` branch is
+// reverted (see docs/tests/p-498-reply-warning/witnessed-red.txt), so
+// this suite genuinely catches regressions rather than green-when-empty.
+
+const NET_ID = "net_498_warn";
+const USER_ID = "u_498_warn";
+const NODE_ID = "node_498_warn";
+const AGENT_ALIAS = "peer-agent-498";
+const AGENT_TOK_ID = "tok_498_warn";
+
+interface ToolHandler {
+  (args: any, extra?: any): Promise<{ content: Array<{ type: "text"; text: string }> }>;
+}
+interface Reply {
+  ok?: boolean;
+  message_id?: string;
+  session_status?: string;
+  warning?: string;
+  error?: string;
+  [k: string]: unknown;
+}
+
+function cleanup() {
+  try { db.run("DELETE FROM tasks WHERE network_id = ?1", [NET_ID]); } catch {}
+  try { db.run("DELETE FROM inbox WHERE network_id = ?1", [NET_ID]); } catch {}
+  try { db.run("DELETE FROM task_events WHERE network_id = ?1", [NET_ID]); } catch {}
+  try { db.run("DELETE FROM sessions WHERE network_id = ?1", [NET_ID]); } catch {}
+  try { db.run("DELETE FROM nodes WHERE network_id = ?1", [NET_ID]); } catch {}
+  try { db.run("DELETE FROM api_tokens WHERE network_id = ?1", [NET_ID]); } catch {}
+  try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET_ID]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id = ?1", [NET_ID]); } catch {}
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [USER_ID]); } catch {}
+}
+
+beforeEach(cleanup);
+afterAll(cleanup);
+
+function seed() {
+  db.run(
+    `INSERT INTO users (user_id, username, password_hash, role, created_at)
+     VALUES (?1, ?2, 'x', 'user', datetime('now'))`,
+    [USER_ID, USER_ID],
+  );
+  db.run(
+    `INSERT INTO networks (network_id, network_name, owner_id, created_at)
+     VALUES (?1, ?2, ?3, datetime('now'))`,
+    [NET_ID, NET_ID, USER_ID],
+  );
+  db.run(
+    `INSERT INTO network_members (user_id, network_id, role, joined_at)
+     VALUES (?1, ?2, 'owner', datetime('now'))`,
+    [USER_ID, NET_ID],
+  );
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state)
+     VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now'), 'active')`,
+    [NODE_ID, AGENT_ALIAS, AGENT_ALIAS, NET_ID, `host-${AGENT_ALIAS}`],
+  );
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+     VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))`,
+    [`res_${AGENT_ALIAS}`, AGENT_ALIAS, NODE_ID, NET_ID],
+  );
+  db.run(
+    `INSERT INTO api_tokens (token_id, user_id, network_id, scope, name, token_hash, expires_at, revoked_at)
+     VALUES (?1, ?2, ?3, 'network', ?4, ?5, NULL, NULL)`,
+    [AGENT_TOK_ID, USER_ID, NET_ID, `node:${AGENT_ALIAS}`, `hash_${AGENT_TOK_ID}`],
+  );
+}
+
+function makeTask(to: string): string {
+  const id = "t_" + Math.random().toString(36).slice(2, 14);
+  db.run(
+    `INSERT INTO tasks (task_id, from_name, to_name, priority, status, content, requires_response, created_at, network_id)
+     VALUES (?1, ?2, ?3, 'normal', 'delivered', 'test', 'reply', datetime('now'), ?4)`,
+    [id, "dispatcher", to, NET_ID],
+  );
+  return id;
+}
+
+function buildHandlers(): Record<string, ToolHandler> {
+  const server = new McpServer({ name: "test", version: "0" }) as any;
+  const tools: Record<string, ToolHandler> = {};
+  const origTool = server.tool.bind(server);
+  server.tool = (name: string, _desc: string, _schema: any, handler: ToolHandler) => {
+    tools[name] = handler;
+    return origTool(name, _desc, _schema, handler);
+  };
+  const origRegisterTool = server.registerTool?.bind(server);
+  if (origRegisterTool) {
+    server.registerTool = (name: string, _cfg: any, handler: ToolHandler) => {
+      tools[name] = handler;
+      return origRegisterTool(name, _cfg, handler);
+    };
+  }
+  // Bind as a network token whose caller alias is the sender.
+  registerTools(
+    server,
+    undefined,
+    /* enforceNetworkId */ NET_ID,
+    /* enforceUserId */ USER_ID,
+    /* callerAlias */ AGENT_ALIAS,
+    /* callerTokenIsNetwork */ true,
+    /* callerTokenId */ AGENT_TOK_ID,
+  );
+  return tools;
+}
+
+async function call(handler: ToolHandler, args: any): Promise<Reply> {
+  const r = await handler(args);
+  return JSON.parse(r.content[0].text) as Reply;
+}
+
+describe("send_reply warning field (#498)", () => {
+  test("target alias resolves to a real agent → response includes `warning` field", async () => {
+    seed();
+    const tools = buildHandlers();
+    const sendReply = tools["send_reply"];
+    expect(sendReply).toBeDefined();
+
+    const taskId = makeTask(AGENT_ALIAS);
+    const reply = await call(sendReply, {
+      alias: AGENT_ALIAS,
+      text: "peer reply (should trigger warning)",
+      in_reply_to: taskId,
+      status: "replied",
+      from_session: AGENT_ALIAS,
+    });
+
+    expect(reply.ok).toBe(true);
+    expect(reply.warning).toBeDefined();
+    expect(typeof reply.warning).toBe("string");
+    const w = reply.warning as string;
+    // Action-pointing content — witnessed-red methodology means each
+    // assertion here must be one a future revert would break, not a
+    // shape-only check that passes on empty string.
+    expect(w).toContain("commhub_send_task");
+    // Alias value is INLINED (not just "<alias>") so the LLM has a
+    // copy-pasteable next command. This is the specific design 通信龙
+    // called out on 2026-07-30.
+    expect(w).toContain(`alias="${AGENT_ALIAS}"`);
+    expect(w).toContain("agent peers");
+    expect(w).toContain("not see this reply in real time");
+    expect(w).toContain("RFC-030");
+    expect(w).toContain("全网规则");
+  });
+
+  test("target alias is `hub` (Dashboard path) → NO warning field", async () => {
+    seed();
+    const tools = buildHandlers();
+    const sendReply = tools["send_reply"];
+
+    const taskId = makeTask("hub");
+    const reply = await call(sendReply, {
+      alias: "hub",
+      text: "dashboard reply",
+      in_reply_to: taskId,
+      status: "replied",
+      from_session: AGENT_ALIAS,
+    });
+
+    expect(reply.ok).toBe(true);
+    // Silence-affirms the Dashboard path. Every reply carrying a
+    // warning would train the LLM to ignore it, so absence here is
+    // load-bearing.
+    expect(reply.warning).toBeUndefined();
+  });
+
+  test("target alias is `api` (Dashboard path) → NO warning field", async () => {
+    seed();
+    const tools = buildHandlers();
+    const sendReply = tools["send_reply"];
+
+    const taskId = makeTask("api");
+    const reply = await call(sendReply, {
+      alias: "api",
+      text: "dashboard reply via api",
+      in_reply_to: taskId,
+      status: "replied",
+      from_session: AGENT_ALIAS,
+    });
+
+    expect(reply.ok).toBe(true);
+    expect(reply.warning).toBeUndefined();
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1058,7 +1058,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
   // ── V2: send_reply (关联 task_id，不触发 think) ──
   server.tool(
     "send_reply",
-    "Send a reply to a task. Linked to task_id via in_reply_to. Does NOT trigger agent processing.",
+    "Send a reply to a Dashboard/UI-originated task (updates task row, emits new_reply SSE — Dashboard reads it). ⚠ NOT for agent-to-agent replies: agent nodes only log new_reply and do not processInbox on it, so the peer will not see the reply in real time. Use send_task for peer-to-peer replies (RFC-030, Vincent 2026-07-28 全网规则). If the target alias resolves to a live agent node, the response includes a `warning` field pointing to send_task.",
     {
       alias: z.string().min(1).max(200).describe("Target session alias"),
       text: z.string().min(1).max(10000).describe("Reply content"),
@@ -1191,10 +1191,26 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       // #461 network observer summary — ids + routing only, no reply text.
       pushNetworkObserverEvent(effectiveNetId, { type: "new_reply", task_id: in_reply_to ?? null, message_id: id, from: from_session, to: alias, status: replyStatus });
 
+      // #498 — When the reply target is a live agent node (not Dashboard/UI),
+      // warn the caller that agent peers only log new_reply and do not
+      // processInbox on it. Points at the correct next action (send_task)
+      // so a follow-up turn corrects course rather than "why didn't they
+      // respond" spelunking. Absent field when target is Dashboard/hub/api
+      // (the correct path for commhub_reply) — silence is affirmation.
+      const targetIsAgent = replyTargetNodeId !== null && alias !== "hub" && alias !== "api";
+      const warning = targetIsAgent
+        ? `Target "${alias}" is an agent node. commhub_reply/send_reply does NOT wake agent peers (they only log new_reply, they do not processInbox on it) — the peer will not see this reply in real time. For agent-to-agent replies, use commhub_send_task(alias="${alias}", task="<your reply>") so the peer wakes via new_task SSE and processes it. (RFC-030, Vincent 2026-07-28 全网规则.)`
+        : undefined;
+
       return {
         content: [{
           type: "text" as const,
-          text: JSON.stringify({ ok: true, message_id: id, session_status: session?.status ?? "unknown" }),
+          text: JSON.stringify({
+            ok: true,
+            message_id: id,
+            session_status: session?.status ?? "unknown",
+            ...(warning ? { warning } : {}),
+          }),
         }],
       };
     }


### PR DESCRIPTION
Follow-up to #502 (already merged). 通信龙 裁定 both items 要:

- **① In-tree integration test**: guards against "someone silently deletes the warning branch in a future refactor" — a specific concern raised because the warning is a pure hint and its removal breaks nothing at runtime.
- **② Move the one-shot MCP hard-gate harness from `scratchpad/` to a discoverable spot**: the "boot real hub → tools/list → grep new phrases" verification should live where the next person to touch tool descriptions can find it.

## Why both

They cover complementary failure modes:

| Failure mode                                    | Unit test | Harness |
|--------------------------------------------------|-----------|---------|
| Warning branch deleted in `tools.ts`             | ✅ catches | ❌      |
| Description string diverges from LLM-facing text | ❌         | ✅ catches |
| MCP transport / initializer plumbing changes and field never leaves the process | ❌ | ✅ catches |
| Fast, deterministic, runs on every `bun test`    | ✅         | ❌ opt-in |

## `server/src/send-reply-agent-warning.test.ts`

Drives `send_reply` via `registerTools()`'s in-process handler map (same pattern as `stop-delete-node.test.ts` + `list-host-supervisors.test.ts`). Three cases:

- Target alias resolves to a real agent node → response includes `warning` field, and the string contains all six action-pointing substrings including the literal `alias="<the-alias>"` — the copy-pasteable next command 通信龙 called out on 2026-07-30 as the design that separates this warning from the four reverse-pointing error messages we tripped over the same night.
- Target `hub` → no `warning` field. Silence-affirms the Dashboard path (if every reply carried a warning the LLM would learn to ignore it — the assertion is that absence is load-bearing).
- Target `api` → same as `hub`. Both Dashboard-origin sentinels hub-side.

### Witnessed-red methodology

Confirmed the assertions actually catch the regression by temporarily reverting the warning branch in `tools.ts` and re-running the tests. Output captured at `docs/tests/p-498-reply-warning/witnessed-red.txt`:

```
error: expect(received).toBeDefined()
Received: undefined
      at .../send-reply-agent-warning.test.ts:147:27
```

Restoring the branch returns 3/3 pass, 14 expect() calls. This is the pattern from `feedback_witnessed_red_before_witnessed_green` — a "green" test that never went red first is a shape check, not a regression tripwire.

## `docs/tests/p-498-reply-warning/`

- `README.md` — opens with **"改了文件 and LLM 真的看得到 are two different things"** so the next reader immediately knows what problem this exists for. Lays out the coverage matrix vs the unit test.
- `hardgate.sh` — boots an isolated hub from `../../../server` on a configurable port (default 9261). Own `COMMHUB_DB`, `COMMHUB_UPLOADS_DIR`, `HOME`. Trap kills hub + tempdir on exit. Never touches `~/.commhub`.
- `mcp-inspect.ts` — Bun MCP client (fetch + SSE parse) that asserts 5 description phrases + 5 warning substrings + Dashboard-target silence. Reads token / task IDs / from_session alias from env so `hardgate.sh` drives it without rewrites.
- `witnessed-red.txt` — provenance for the "these assertions are load-bearing" claim.

### Harness runs from repo checkout

```bash
cd docs/tests/p-498-reply-warning && ./hardgate.sh
```

Expected tail:
```
Gate 1: 5 pass / 0 fail
Gate 2A: 6 pass / 0 fail
✓ no 'warning' field (correct — hub is Dashboard path)
```

## Test plan

- [x] `bun test src/send-reply-agent-warning.test.ts` → 3 pass, 14 expect
- [x] Witnessed-red: revert warning branch → test fails at line 147 with the expected message; restore → returns green
- [x] `docs/tests/p-498-reply-warning/hardgate.sh` → 12 pass / 0 fail from the harness location (self-contained)
- [ ] (post-merge) On next release, run harness against the built preview to confirm the description survives packaging

## Attribution

Author: 通信demo马
Related: #498 (root incident), #502 (main fix, already merged), RFC-030 (routing intent)