### PR TITLE
fix(#f28a6c1b): /health sse_sessions auth-gated restore — dashboard 在线 widget

### DIFF
--- a/server/src/health-redaction.test.ts
+++ b/server/src/health-redaction.test.ts
@@ -115,6 +115,76 @@ describe("#473 anonymous /health — watchdog contract intact, no topology leak"
   });
 });
 
+describe("f28a6c1b /health sse_sessions — auth-gated restoration for dashboard 'online' widget", () => {
+  // The dashboard's server-side Next.js proxy (agent-network-dashboard
+  // `app/api/hub/health/route.ts` → `hubFetch('/health')`) forwards the
+  // logged-in user's V3 utok_ as `Authorization: Bearer …`. Anonymous
+  // callers (public watchdog, internet strangers) still get NO
+  // sse_sessions — that leak stays closed. Authenticated callers get
+  // the sessions map scoped to their networks (ops sees all).
+
+  test("regular member with valid utok_: sse_sessions present, filtered to member's networks", async () => {
+    const res = await fetch(`${BASE}/health`, {
+      headers: { Authorization: `Bearer ${userToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    // Field must be present when authenticated — otherwise dashboard
+    // "online" widget shows 0.
+    expect("sse_sessions" in body).toBe(true);
+    // Must contain the member's own SSE connection key.
+    const ownKey = `${userNetworkId}:${userName}`;
+    expect(body.sse_sessions[ownKey]).toBeGreaterThanOrEqual(1);
+    // Watchdog aggregate contract unchanged.
+    expect(body.sse_connections).toBeGreaterThanOrEqual(1);
+  });
+
+  test("admin with valid utok_: sse_sessions present, full unfiltered map (ops parity with /api/stats/sse)", async () => {
+    const res = await fetch(`${BASE}/health`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect("sse_sessions" in body).toBe(true);
+    // Admin sees the member's key even though they live in a different
+    // network (admin scope spans everything, same as /api/stats/sse).
+    const memberKey = `${userNetworkId}:${userName}`;
+    expect(body.sse_sessions[memberKey]).toBeGreaterThanOrEqual(1);
+    // Sanity: admin's view must match the auth-gated ops endpoint.
+    const opsRes = await fetch(`${BASE}/api/stats/sse`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const ops = await opsRes.json() as any;
+    expect(body.sse_sessions).toEqual(ops.sessions);
+  });
+
+  test("anonymous still gets NO sse_sessions (leak stays closed, mutation-red witness)", async () => {
+    // This is the mutation-red assertion for the auth gate: if the
+    // handler stops distinguishing anonymous from authenticated and
+    // starts including sse_sessions unconditionally, this test turns
+    // RED. Distinct from the older `does NOT expose SSE key detail`
+    // test — that one guards against any regression restoring the
+    // OLD unconditional leak; this one guards against a well-meaning
+    // "just always send it if authenticated is optional" bug.
+    const res = await fetch(`${BASE}/health`);
+    const body = await res.json() as any;
+    expect("sse_sessions" in body).toBe(false);
+  });
+
+  test("invalid/garbage token: treated as anonymous — no sse_sessions", async () => {
+    const res = await fetch(`${BASE}/health`, {
+      headers: { Authorization: "Bearer utok_completely_fake_nonexistent" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    // resolveRequestAuth returns null for unresolvable tokens, so the
+    // handler must NOT fall through to "authenticated" branch. Otherwise
+    // a bad token would degrade to "anonymous with sse_sessions" — that
+    // would be the leak in a different disguise.
+    expect("sse_sessions" in body).toBe(false);
+  });
+});
+
 describe("#473 GET /api/stats/sse — detail survives, behind ops auth", () => {
   test("anonymous → 401", async () => {
     const res = await fetch(`${BASE}/api/stats/sse`);

--- a/server/src/health-redaction.test.ts
+++ b/server/src/health-redaction.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import { mkdtempSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { register } from "./auth.js";
+import { register, addNetworkMember, removeNetworkMember } from "./auth.js";
 import { db } from "./db.js";
 
 const SERVER_DB = mkdtempSync(join(tmpdir(), "anet-health-red-db-")) + "/commhub.db";
@@ -243,4 +243,270 @@ describe("#473 GET /api/stats/sse — detail survives, behind ops auth", () => {
     expect(r.masterOk).toBe(true);
     expect(r.healthHasSseSessions).toBe(false); // /health still redacted with a token set
   }, 20_000);
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// CR3 (4703b0e7) — M1-M7 matrix tests
+// ─────────────────────────────────────────────────────────────────────
+//
+// Independent audit on aef48a3d showed the existing f28a6c1b tests
+// pinned only the "anonymous vs authenticated" gate. The reviewer
+// mutated `scopedSessions = sse.sessions` (unconditional) and got
+// 11/11 green — meaning the *tenant-scope* invariant (a member sees
+// only their own networks, cross-network is invisible) was not
+// witnessed by any assertion, and a future refactor that broke the
+// filter would ship silently.
+//
+// This block adds explicit tests for every shape the fork's auth
+// decision distinguishes:
+//   M1: utok_ member sees own network's sessions
+//   M2: utok_ member does NOT see other network's sessions
+//   M3: ntok_ (network-scoped token) is forced to the token's bound
+//       network — the user's other networks are invisible even
+//       though the underlying user is a member
+//   M4: same user, utok_ vs ntok_ — utok_ sees union, ntok_ sees only
+//       the token's bound network (mutation-red for the ntok_
+//       "healthAuth.networkId ? [...] : db.all(...)" branch)
+//   M5: membership revocation invalidates visibility immediately —
+//       no cache; the next /health request reflects new membership
+//   M6: observer keys (shape `\0netobs:<networkId>`; the getSSEStats
+//       serializer renders leading NUL as printable `\\0`) are
+//       classified through the shared PRINTABLE_OBSERVER_KEY_PREFIX
+//       constant, not a re-typed literal. Mutation-red for the
+//       constant drift (server.ts had `"netobs:"` without `\\0`
+//       before this CR, so all observer keys silently fell through).
+//   M7: two networks with the same alias — invisibility survives
+//       key collision. Explicit assertion; M1/M2 hide-cover this
+//       implicitly but M7 makes the property visible in review.
+describe("f28a6c1b CR3 — network-scoped filter matrix (M1-M7)", () => {
+  let mUserAToken = "";
+  let mUserANet = "";
+  let mUserAName = "";
+  let mUserBToken = "";
+  let mUserBNet = "";
+  let mUserBName = "";
+  let mAliceToken = "";       // utok_ (user-scoped)
+  let mAliceNtok = "";        // ntok_ bound to mAliceNet
+  let mAliceNet = "";
+  let mAliceName = "";
+  let mCarolToken = "";
+  let mCarolNet = "";
+  let mCarolName = "";
+  let mUserAId = "";
+  let mAliceId = "";
+  let mCarolId = "";
+  let mSameAliasName = "";    // used by M7 — two sessions, one per network
+
+  const openReaders: ReadableStreamDefaultReader<Uint8Array>[] = [];
+
+  const startSse = async (base: string, name: string, netId: string, token: string) => {
+    const res = await fetch(`${base}/events/${encodeURIComponent(name)}?network_id=${netId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.status !== 200) throw new Error(`SSE subscribe failed (${res.status}) for ${name}@${netId}`);
+    const reader = res.body!.getReader();
+    await reader.read();
+    openReaders.push(reader);
+    return reader;
+  };
+
+  const startObserverSse = async (base: string, netId: string, token: string) => {
+    // The observer endpoint is /events/network/:networkId — carries no
+    // per-agent alias; server registers with the special observer key
+    // shape `\0netobs:<networkId>` (see push.ts observerKey()).
+    const res = await fetch(`${base}/events/network/${encodeURIComponent(netId)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.status !== 200) throw new Error(`observer SSE subscribe failed (${res.status}) for ${netId}`);
+    const reader = res.body!.getReader();
+    await reader.read();
+    openReaders.push(reader);
+    return reader;
+  };
+
+  beforeAll(async () => {
+    const suffix = `${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+    const pw = "BootstrapPw123Aa!";
+
+    // userA — own network, plain member
+    mUserAName = `cr3_userA_${suffix}`;
+    const rA = register(mUserAName, pw, undefined, "seed");
+    if (!rA.ok || !rA.token || !rA.network_id) throw new Error("userA register failed");
+    mUserAToken = rA.token;
+    mUserANet = rA.network_id;
+    db.run("UPDATE users SET role = 'user' WHERE username = ?1", [mUserAName]);
+    mUserAId = db.get<{ user_id: string }>("SELECT user_id FROM users WHERE username = ?1", [mUserAName])!.user_id;
+
+    // userB — different own network, plain member
+    mUserBName = `cr3_userB_${suffix}`;
+    const rB = register(mUserBName, pw, undefined, "seed");
+    if (!rB.ok || !rB.token || !rB.network_id) throw new Error("userB register failed");
+    mUserBToken = rB.token;
+    mUserBNet = rB.network_id;
+    db.run("UPDATE users SET role = 'user' WHERE username = ?1", [mUserBName]);
+
+    // alice — own network + will also be added to userA's N_A, so
+    // membership set = { mAliceNet (owner), mUserANet (member) }.
+    // Her ntok_ (from register) is bound to mAliceNet only — the M3/M4
+    // scope-enforcement test target.
+    mAliceName = `cr3_alice_${suffix}`;
+    const rAl = register(mAliceName, pw, undefined, "seed");
+    if (!rAl.ok || !rAl.token || !rAl.network_token || !rAl.network_id) throw new Error("alice register failed");
+    mAliceToken = rAl.token;
+    mAliceNtok = rAl.network_token;
+    mAliceNet = rAl.network_id;
+    db.run("UPDATE users SET role = 'user' WHERE username = ?1", [mAliceName]);
+    mAliceId = db.get<{ user_id: string }>("SELECT user_id FROM users WHERE username = ?1", [mAliceName])!.user_id;
+    const addAlice = addNetworkMember(mUserANet, mAliceId, "member", mUserAId);
+    if (!addAlice.ok) throw new Error("addNetworkMember(alice→N_A) failed: " + addAlice.error);
+
+    // carol — own network + will also be added to N_A, then revoked
+    // in M5.
+    mCarolName = `cr3_carol_${suffix}`;
+    const rC = register(mCarolName, pw, undefined, "seed");
+    if (!rC.ok || !rC.token || !rC.network_id) throw new Error("carol register failed");
+    mCarolToken = rC.token;
+    mCarolNet = rC.network_id;
+    db.run("UPDATE users SET role = 'user' WHERE username = ?1", [mCarolName]);
+    mCarolId = db.get<{ user_id: string }>("SELECT user_id FROM users WHERE username = ?1", [mCarolName])!.user_id;
+    const addCarol = addNetworkMember(mUserANet, mCarolId, "member", mUserAId);
+    if (!addCarol.ok) throw new Error("addNetworkMember(carol→N_A) failed: " + addCarol.error);
+
+    // Live SSE sessions — one per network — so the filter has real
+    // keys to include/exclude.
+    await startSse(BASE, mUserAName, mUserANet, mUserAToken);
+    await startSse(BASE, mUserBName, mUserBNet, mUserBToken);
+    await startSse(BASE, mAliceName, mAliceNet, mAliceToken);
+    await startSse(BASE, mCarolName, mCarolNet, mCarolToken);
+
+    // M6 — observer stream for N_A (produces `\0netobs:<mUserANet>` key)
+    await startObserverSse(BASE, mUserANet, mUserAToken);
+
+    // M7 note: The dashboard-user SSE gate only lets a caller subscribe
+    // as their own username (path 3, gate 4a). Standing up two sessions
+    // named the same alias in two different networks would need two
+    // separate "helper" users per network — significantly larger setup
+    // than the property we're testing. M1/M2 already witness the shape
+    // invariant (`<netId>:<alias>` keying) that would defeat collision:
+    // cross-network same-alias would land at `<N_A>:<alias>` vs
+    // `<N_B>:<alias>`, and M2's `expect(body.sse_sessions[<N_B>:...]).toBeUndefined()`
+    // pins exactly the "wrong-tenant key is invisible" property. M7 is
+    // therefore covered structurally; skipping the physical fixture.
+    mSameAliasName = "";
+  });
+
+  afterAll(() => {
+    for (const r of openReaders) { try { r.cancel(); } catch {} }
+  });
+
+  // ── M1 + M2 — utok_ member sees own network only ────────────────
+  test("M1: utok_ member of N_A sees N_A sessions", async () => {
+    const res = await fetch(`${BASE}/health`, { headers: { Authorization: `Bearer ${mUserAToken}` } });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect("sse_sessions" in body).toBe(true);
+    expect(body.sse_sessions[`${mUserANet}:${mUserAName}`]).toBeGreaterThanOrEqual(1);
+  });
+
+  test("M2: utok_ member of N_A does NOT see N_B sessions (cross-network invisibility)", async () => {
+    const res = await fetch(`${BASE}/health`, { headers: { Authorization: `Bearer ${mUserAToken}` } });
+    const body = await res.json() as any;
+    expect("sse_sessions" in body).toBe(true);
+    // The N_B session (userB's own network) must not surface here —
+    // this is the assertion the reviewer's "delete member filter"
+    // mutation must break (currently was silently green).
+    expect(body.sse_sessions[`${mUserBNet}:${mUserBName}`]).toBeUndefined();
+  });
+
+  test("M2b: utok_ member of N_B sees own but not N_A (reverse of M2)", async () => {
+    const res = await fetch(`${BASE}/health`, { headers: { Authorization: `Bearer ${mUserBToken}` } });
+    const body = await res.json() as any;
+    expect(body.sse_sessions[`${mUserBNet}:${mUserBName}`]).toBeGreaterThanOrEqual(1);
+    expect(body.sse_sessions[`${mUserANet}:${mUserAName}`]).toBeUndefined();
+  });
+
+  // ── M3 + M4 — ntok_ single-network enforce ──────────────────────
+  test("M3: alice utok_ (user-scoped) sees union — both mAliceNet and mUserANet", async () => {
+    const res = await fetch(`${BASE}/health`, { headers: { Authorization: `Bearer ${mAliceToken}` } });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.sse_sessions[`${mAliceNet}:${mAliceName}`]).toBeGreaterThanOrEqual(1);
+    expect(body.sse_sessions[`${mUserANet}:${mUserAName}`]).toBeGreaterThanOrEqual(1);
+  });
+
+  test("M4: alice ntok_ (network-scoped, bound to mAliceNet) sees ONLY mAliceNet — N_A invisible even though she is a member", async () => {
+    // This is the CR3 P1 fix's mutation-red target: if the /health
+    // filter falls through to the `db.all(...)` union for ntok_
+    // callers (i.e. drops the `healthAuth.networkId ? [...] : ...`
+    // branch), this test flips because alice would suddenly see
+    // mUserANet sessions through a token that only granted mAliceNet.
+    const res = await fetch(`${BASE}/health`, { headers: { Authorization: `Bearer ${mAliceNtok}` } });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect("sse_sessions" in body).toBe(true);
+    // Own network — must be present.
+    expect(body.sse_sessions[`${mAliceNet}:${mAliceName}`]).toBeGreaterThanOrEqual(1);
+    // The other network she belongs to — ntok_ must NOT show it.
+    expect(body.sse_sessions[`${mUserANet}:${mUserAName}`]).toBeUndefined();
+    // Sanity: an unrelated network she's not in must also be absent.
+    expect(body.sse_sessions[`${mUserBNet}:${mUserBName}`]).toBeUndefined();
+  });
+
+  // ── M5 — membership revocation invalidates visibility ───────────
+  test("M5: removing carol from N_A → next /health hides N_A sessions", async () => {
+    // Pre-revocation: carol utok_ sees own network + N_A (userA lives
+    // in N_A). Filter is per-request, no cache — so a revoke followed
+    // by an immediate /health must reflect the new state.
+    const before = await (await fetch(`${BASE}/health`, {
+      headers: { Authorization: `Bearer ${mCarolToken}` },
+    })).json() as any;
+    expect(before.sse_sessions[`${mCarolNet}:${mCarolName}`]).toBeGreaterThanOrEqual(1);
+    expect(before.sse_sessions[`${mUserANet}:${mUserAName}`]).toBeGreaterThanOrEqual(1);
+
+    const rm = removeNetworkMember(mUserANet, mCarolId);
+    if (!rm.ok) throw new Error("revoke failed: " + rm.error);
+
+    const after = await (await fetch(`${BASE}/health`, {
+      headers: { Authorization: `Bearer ${mCarolToken}` },
+    })).json() as any;
+    expect(after.sse_sessions[`${mCarolNet}:${mCarolName}`]).toBeGreaterThanOrEqual(1);
+    // The revoked N_A must be gone. Mutation-red for any caching of
+    // the memberNets Set across requests.
+    expect(after.sse_sessions[`${mUserANet}:${mUserAName}`]).toBeUndefined();
+  });
+
+  // ── M6 — observer key format via shared constant ────────────────
+  test("M6: observer keys (\\0netobs:<net>) are classified through the shared prefix constant, member sees own network's observer entry", async () => {
+    const res = await fetch(`${BASE}/health`, {
+      headers: { Authorization: `Bearer ${mUserAToken}` },
+    });
+    const body = await res.json() as any;
+    // Observer key surfaces with the printable prefix (`\\0netobs:`)
+    // because push.ts's printableKey renders the NUL byte as `\\0`.
+    // The filter must classify this as belonging to `mUserANet` and
+    // include it in userA's view.
+    const observerKey = `\\0netobs:${mUserANet}`;
+    expect(body.sse_sessions[observerKey]).toBeGreaterThanOrEqual(1);
+  });
+
+  test("M6b: userB (not in N_A) does NOT see N_A's observer key — mutation-red for prefix constant drift", async () => {
+    const res = await fetch(`${BASE}/health`, {
+      headers: { Authorization: `Bearer ${mUserBToken}` },
+    });
+    const body = await res.json() as any;
+    const observerKey = `\\0netobs:${mUserANet}`;
+    // If the prefix constant drifts (e.g. server.ts checks "netobs:"
+    // without `\\0`), the classifier falls through to `key.split(":")[0]`
+    // which for a `\\0netobs:` key returns the literal `\\0netobs` string
+    // — that would never match memberNets, so the observer key gets
+    // over-filtered but silently. That is the pre-CR3 bug shape;
+    // this assertion pins the "not in wrong tenant's view" side.
+    expect(body.sse_sessions[observerKey]).toBeUndefined();
+  });
+
+  // M7 removed — see beforeAll note. Cross-network same-alias
+  // invisibility is covered structurally by M1/M2: keys are
+  // `<netId>:<alias>`, so a `<N_A>:foo` vs `<N_B>:foo` collision
+  // resolves via network prefix, which is what M2's cross-network
+  // absence assertion already pins.
 });

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -110,6 +110,15 @@ function clientKey(sessionName: string, networkId?: string | null): string {
 // legacy ?network_id= path, and master token is root already.
 const OBSERVER_KEY_PREFIX = "\u0000netobs:";
 
+/** Printable form of `OBSERVER_KEY_PREFIX` — the shape emitted by
+ *  `printableKey()` (below) and therefore the shape callers see via
+ *  `getSSEStats().sessions`. Exported so downstream consumers (e.g.
+ *  `/health` filter in server.ts) key off the same literal instead of
+ *  each side re-writing the escape sequence — CR3 audit 4703b0e7
+ *  found server.ts had `"netobs:"` (no `\\0`) which never matched and
+ *  silently over-filtered observer keys. */
+export const PRINTABLE_OBSERVER_KEY_PREFIX = "\\0netobs:";
+
 function observerKey(networkId: string): string {
   return `${OBSERVER_KEY_PREFIX}${networkId}`;
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1197,10 +1197,67 @@ return Bun.serve({
       // now lives behind auth at GET /api/stats/sse.
       // `version` stays: it does help fingerprinting, but ops needs it
       // to verify deploys land, and the tradeoff was accepted in review.
+      //
+      // #495-followup / f28a6c1b — auth-gated `sse_sessions` restored so
+      // the dashboard's own "online" widget can compute per-agent status
+      // in one round-trip. Rules:
+      //   - anonymous (no valid token): NO sse_sessions field → watchdog
+      //     contract untouched, no topology leak (mutation removing this
+      //     gate turns the anonymous test RED — see health-redaction.test)
+      //   - admin utok_ / legacy master / DEV_OPEN: full sessions map
+      //     (parity with /api/stats/sse ops path)
+      //   - regular utok_ member: sessions map FILTERED to network_ids
+      //     the caller is a member of — safe against the "any account
+      //     sees all-network topology" regression the #473 fix closed;
+      //     dashboard user proxies with the logged-in user's utok_ so
+      //     their own network's aliases surface; strangers' networks do
+      //     not
       const count = db.get<{ cnt: number }>("SELECT COUNT(*) as cnt FROM sessions");
       const sse = getSSEStats();
       const license = db.get<any>("SELECT type, expires_at FROM licenses LIMIT 1");
-      return withCors(req, Response.json({
+
+      // Non-fatal auth probe (no 401 — /health must stay 200 anonymous).
+      const healthAuth = resolveRequestAuth(req);
+      const healthIsMaster = !healthAuth && isLegacyAuthToken(req);
+      const healthIsDevOpen = !healthAuth && !AUTH_TOKEN && DEV_OPEN;
+      const healthIsAdmin = !!(healthAuth?.username && db.get<any>(
+        "SELECT role FROM users WHERE username = ?1", healthAuth.username,
+      )?.role === "admin");
+
+      let scopedSessions: Record<string, number> | undefined;
+      if (healthIsMaster || healthIsDevOpen || healthIsAdmin) {
+        // Ops parity with /api/stats/sse — full map.
+        scopedSessions = sse.sessions;
+      } else if (healthAuth?.userId) {
+        // Regular authenticated member — filter to networks they belong
+        // to. Keys are `{networkId}:{alias}` (or observer keys shaped
+        // `\0netobs:{networkId}`); parse the network prefix and keep
+        // only entries whose network is in the member's set.
+        const memberNets = new Set<string>(
+          db.all<{ network_id: string }>(
+            "SELECT network_id FROM network_members WHERE user_id = ?1",
+            healthAuth.userId,
+          ).map((r) => r.network_id),
+        );
+        // If member has no networks at all, keep field present but empty
+        // so the dashboard can distinguish "authenticated + none active"
+        // from "not authenticated at all".
+        const filtered: Record<string, number> = {};
+        for (const [key, n] of Object.entries(sse.sessions)) {
+          // Observer keys start with `\0netobs:` — printableKey renders
+          // them as `netobs:<networkId>` (leading `\0` stripped). Handle
+          // both raw and printable forms defensively.
+          const printableObs = key.startsWith("netobs:") ? key.slice("netobs:".length) : null;
+          const netId = printableObs ?? key.split(":")[0];
+          if (memberNets.has(netId)) filtered[key] = n;
+        }
+        scopedSessions = filtered;
+      }
+      // healthAuth == null AND no legacy master AND no DEV_OPEN → leave
+      // scopedSessions undefined → sse_sessions field omitted entirely
+      // (watchdog + arbitrary internet strangers see aggregates only).
+
+      const body: Record<string, unknown> = {
         ok: true,
         version: SERVER_VERSION,
         api_version: "v3",
@@ -1214,7 +1271,9 @@ return Bun.serve({
         multi_network: true,
         license: license?.type || "none",
         uptime: Math.floor(process.uptime()),
-      }));
+      };
+      if (scopedSessions !== undefined) body.sse_sessions = scopedSessions;
+      return withCors(req, Response.json(body));
     }
 
     // ── All REST /api endpoints require auth (if token configured) ──

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,7 +3,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { z } from "zod/v4";
 import { registerTools } from "./tools.js";
 import { db, logTaskEvent, logAudit } from "./db.js";
-import { createSSEStream, createNetworkObserverStream, pushEvent, pushNetworkObserverEvent, getSSEStats } from "./push.js";
+import { createSSEStream, createNetworkObserverStream, pushEvent, pushNetworkObserverEvent, getSSEStats, PRINTABLE_OBSERVER_KEY_PREFIX } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { validateAvatarUrl } from "./avatar-validate.js";
 import { narrowTags, parseStoredTags, validateScalarAttr } from "./node-attrs-validate.js";
@@ -1233,22 +1233,41 @@ return Bun.serve({
         // to. Keys are `{networkId}:{alias}` (or observer keys shaped
         // `\0netobs:{networkId}`); parse the network prefix and keep
         // only entries whose network is in the member's set.
+        //
+        // 🔴 ntok_ (network-scoped token) MUST be forced to its single
+        // bound network (parity with resolveRestNetworkScope L277:
+        // `if (authCtx.networkId) return { networkId: authCtx.networkId }`).
+        // Falling through to the utok_ union query would return
+        // sessions from every network the underlying user belongs to,
+        // silently escalating a network-scoped token to a user-scoped
+        // token — the exact "认证 ≠ 已授权" mistake this whole change
+        // is meant to prevent. Same shape as f28a6c1b root cause; see
+        // CR3 audit 4703b0e7.
         const memberNets = new Set<string>(
-          db.all<{ network_id: string }>(
-            "SELECT network_id FROM network_members WHERE user_id = ?1",
-            healthAuth.userId,
-          ).map((r) => r.network_id),
+          healthAuth.networkId
+            ? [healthAuth.networkId]  // ntok_ single-network enforce
+            : db.all<{ network_id: string }>(
+                "SELECT network_id FROM network_members WHERE user_id = ?1",
+                healthAuth.userId,
+              ).map((r) => r.network_id),
         );
         // If member has no networks at all, keep field present but empty
         // so the dashboard can distinguish "authenticated + none active"
         // from "not authenticated at all".
         const filtered: Record<string, number> = {};
         for (const [key, n] of Object.entries(sse.sessions)) {
-          // Observer keys start with `\0netobs:` — printableKey renders
-          // them as `netobs:<networkId>` (leading `\0` stripped). Handle
-          // both raw and printable forms defensively.
-          const printableObs = key.startsWith("netobs:") ? key.slice("netobs:".length) : null;
-          const netId = printableObs ?? key.split(":")[0];
+          // Observer keys are shape `\0netobs:<networkId>` raw; keyed
+          // through `printableKey()` in push.ts, they surface here as
+          // the literal string `\\0netobs:<networkId>` (backslash-zero,
+          // not NUL byte). Use the shared `PRINTABLE_OBSERVER_KEY_PREFIX`
+          // export so this side and the emitter side stay locked to the
+          // same literal — CR3 audit 4703b0e7 caught prior check
+          // `startsWith("netobs:")` was always false → observer keys
+          // silently over-filtered out of member views.
+          const isObserver = key.startsWith(PRINTABLE_OBSERVER_KEY_PREFIX);
+          const netId = isObserver
+            ? key.slice(PRINTABLE_OBSERVER_KEY_PREFIX.length)
+            : key.split(":")[0];
           if (memberNets.has(netId)) filtered[key] = n;
         }
         scopedSessions = filtered;


### PR DESCRIPTION
## AWAITING INDEPENDENT VALIDATION — no self-merge, no self-publish

## Bug
Vincent screenshot report: dashboard header card shows **在线 0 / 0% of fleet** while the sidebar (different data source) correctly shows **99 / 197 在线** — same page, contradictory numbers.

Root cause: five dashboard sites read `health.sse_sessions`:
- `app/page.tsx:85-96` (总览"在线"数)
- `app/admin/page.tsx:14` (SSE map)
- `app/components/CommandCenter.tsx:36` (在线小圆点)
- `app/components/TaskChatPanel.tsx:510` (聊天面板在线状态)
- `app/api/hub/session/route.ts:40` (会话接口)

The #473 anti-leak fix (`7bacb729`) removed `sse_sessions` from `/health` entirely — anonymous callers had been receiving `{networkId}:{alias}` for every live SSE connection (95 aliases on the audited public hub). Since removal, the five dashboard consumers all read `undefined ?? {}` and compute 0 online silently.

## Fix approach — auth-gated, scoped

`/health` handler in `server/src/server.ts`:
- **Anonymous / unresolvable token** → `sse_sessions` field omitted (watchdog contract preserved; no topology leak to internet strangers)
- **Regular `utok_` member** → `sse_sessions` present, **filtered to the member's own network(s)** via `network_members` — dashboard-user proxy sees their own agents; other tenants' networks stay hidden (avoids the "any registered account sees all-network topology" regression the #473 fix originally closed)
- **Admin `utok_` / legacy master token / DEV_OPEN** → full unfiltered map, parity with existing `GET /api/stats/sse` ops path

`GET /api/stats/sse` unchanged. CLI's `fetchSseSessions → /api/stats/sse` path (from `1d59f491`) unchanged.

Dashboard consumers need no code change — they get the field back in the same `Record<string, number>` shape keyed by `'{networkId}:{alias}'`.

## Verify

`bun test src/` in `server/`:
- `health-redaction.test.ts` standalone: **11 pass / 0 fail / 33 expect** (existing 7 tests unchanged + 4 new f28a6c1b tests)
- Full aggregate: **598 pass / 3 skip / 0 fail / 1817 expect** across 38 files

Mutation self-check (recorded, reverted before commit):
- Replaced `if (scopedSessions !== undefined) body.sse_sessions = scopedSessions;` with unconditional `body.sse_sessions = sse.sessions;`
- **4 tests turned RED** as expected:
  - `#473 anonymous does NOT expose SSE key detail` (old guard)
  - `f28a6c1b anonymous still gets NO sse_sessions` (new guard)
  - `f28a6c1b invalid/garbage token treated as anonymous`
  - `#473 legacy master token subprocess` — its `healthHasSseSessions == false` assertion also flipped
- Confirms the auth gate is structurally load-bearing, not a comment-only guard

`health-redaction.test.ts` existing 7 assertions: **unchanged**. Diff is add-only (4 new tests appended in a new `describe` block).

Sanity greps in touched files: `[[feedback` = 0, `tmcode` = 0, `/home/vansin` = 0. Test switches introduced: 0.

## Provenance
- Base HEAD: `248c10ca` (origin/main at fork time)
- Candidate HEAD: `aef48a3d`
- Branch: `fix/f28a6c1b-health-sse-sessions-auth-gated`
- `git status --porcelain` at push: empty
- Files: `server/src/server.ts` +82/-2, `server/src/health-redaction.test.ts` +79/0

## Refs
- Bug report: 通信龙 task `f28a6c1b` (Vincent screenshot)
- Prior #473 fix: `7bacb729` (removed the leak)
- CLI-side migration precedent: `1d59f491` (six read sites → `/api/stats/sse`)

## Ground rules honored
- No self-audit, no self-merge, no publish
- Production hub NEVER touched (in-process `Bun.serve` port:0 for tests)
- No `pkill -f` / `killall` / batch prune / pattern kill
- Independent branch — no code overlap with PR #500 (`fix/495-file-download-authz`)