### PR TITLE
fix(agent-network): accept Git worktree markers for OpenCode state checks

### DIFF
--- a/agent-network/src/opencode-runtime-binding.test.ts
+++ b/agent-network/src/opencode-runtime-binding.test.ts
@@ -313,6 +313,41 @@ describe("assertOpencodeNodeStateUntracked", () => {
     expect(() => assertOpencodeNodeStateUntracked(node)).not.toThrow();
   });
 
+  test("allows ordinary untracked projects inside a Git worktree checkout", () => {
+    const repo = join(root, "repo");
+    const worktree = join(root, "repo-worktree");
+    execFileSync("git", ["init", "--quiet", repo], { stdio: "pipe", shell: false });
+    execFileSync(
+      "git",
+      [
+        "-C", repo,
+        "-c", "user.name=agent-network-test",
+        "-c", "user.email=agent-network-test@example.invalid",
+        "commit", "--allow-empty", "-m", "init",
+      ],
+      { stdio: "pipe", shell: false },
+    );
+    execFileSync("git", ["-C", repo, "worktree", "add", "--detach", worktree, "HEAD"], {
+      stdio: "pipe",
+      shell: false,
+    });
+
+    const worktreeProject = join(worktree, "project");
+    const worktreeNode = join(worktreeProject, ".anet", "nodes", "node-a");
+    mkdirSync(worktreeNode, { recursive: true, mode: 0o700 });
+    writeFileSync(join(worktreeNode, "config.json"), "{}\n", { mode: 0o600 });
+    writeFileSync(join(worktreeNode, ".env"), "ANET_TOKEN=test\n", { mode: 0o600 });
+
+    expect(readFileSync(join(worktree, ".git"), "utf8")).toMatch(/^gitdir: /);
+    expect(() => assertOpencodeNodeStateUntracked(worktreeNode)).not.toThrow();
+  });
+
+  test("rejects forged Git worktree file markers", () => {
+    writeFileSync(join(project, ".git"), "gitdir: /definitely/not/a/git/dir\n", { mode: 0o600 });
+
+    expect(() => assertOpencodeNodeStateUntracked(node)).toThrow(/Git repository metadata is invalid/);
+  });
+
   test("allows ignored/untracked state but rejects git add -f tracked state", () => {
     execFileSync("git", ["init", "--quiet", project], { stdio: "pipe", shell: false });
     writeFileSync(join(project, ".gitignore"), ".anet/\n", { mode: 0o600 });

--- a/agent-network/src/opencode-runtime-binding.ts
+++ b/agent-network/src/opencode-runtime-binding.ts
@@ -584,10 +584,43 @@ export function assertExactOpencodeRuntimeBinding(
   return binding;
 }
 
-function findGitMarkerRoot(start: string): string | undefined {
+interface GitRepositoryMarker {
+  workTreeRoot: string;
+  gitDir: string;
+}
+
+function readGitFile(markerPath: string, markerRoot: string): string {
+  const stat = lstatSync(markerPath);
+  if (!stat.isFile() || stat.size <= 0 || stat.size > 4096) {
+    throw new Error("invalid Git file marker");
+  }
+  const content = readFileSync(markerPath, "utf8");
+  if (content.includes("\0")) throw new Error("invalid Git file marker");
+  const line = content.endsWith("\n") ? content.slice(0, -1) : content;
+  if (line.includes("\n") || line.includes("\r")) throw new Error("invalid Git file marker");
+  const match = /^gitdir: (.+)$/.exec(line);
+  if (!match) throw new Error("invalid Git file marker");
+  const gitDir = match[1];
+  if (gitDir.trim() !== gitDir || gitDir.length === 0) throw new Error("invalid Git file marker");
+  const resolvedGitDir = realpathSync(isAbsolute(gitDir) ? gitDir : resolve(markerRoot, gitDir));
+  if (!lstatSync(resolvedGitDir).isDirectory()) throw new Error("invalid Git file marker");
+  return resolvedGitDir;
+}
+
+function readGitRepositoryMarker(markerRoot: string): GitRepositoryMarker {
+  const markerPath = join(markerRoot, ".git");
+  const stat = lstatSync(markerPath);
+  const workTreeRoot = realpathSync(markerRoot);
+  if (stat.isDirectory()) {
+    return { workTreeRoot, gitDir: realpathSync(markerPath) };
+  }
+  return { workTreeRoot, gitDir: readGitFile(markerPath, markerRoot) };
+}
+
+function findGitRepositoryMarker(start: string): GitRepositoryMarker | undefined {
   let current = start;
   while (true) {
-    if (lstatIfPresent(join(current, ".git"))) return current;
+    if (lstatIfPresent(join(current, ".git"))) return readGitRepositoryMarker(current);
     const parent = dirname(current);
     if (parent === current) return undefined;
     current = parent;
@@ -624,8 +657,13 @@ function gitPath(path: string): string {
 export function assertOpencodeNodeStateUntracked(nodeWorkDir: string): void {
   const identity = canonicalNodeIdentity(nodeWorkDir);
   const canonicalNode = join(identity.projectRoot, ".anet", "nodes", identity.nodeId);
-  const markerRoot = findGitMarkerRoot(canonicalNode);
-  if (!markerRoot) return;
+  let marker: GitRepositoryMarker | undefined;
+  try {
+    marker = findGitRepositoryMarker(canonicalNode);
+  } catch {
+    throw new Error("OpenCode cannot verify tracked node state: Git repository metadata is invalid");
+  }
+  if (!marker) return;
 
   const common = {
     encoding: "utf8" as const,
@@ -638,7 +676,12 @@ export function assertOpencodeNodeStateUntracked(nodeWorkDir: string): void {
   try {
     const output = execFileSync(
       "git",
-      ["-c", "core.fsmonitor=false", "-C", canonicalNode, "rev-parse", "--show-toplevel"],
+      [
+        "-c", "core.fsmonitor=false",
+        "--git-dir", marker.gitDir,
+        "--work-tree", marker.workTreeRoot,
+        "rev-parse", "--show-toplevel",
+      ],
       common,
     );
     repositoryRoot = realpathSync(stripCommandNewline(output));
@@ -660,7 +703,12 @@ export function assertOpencodeNodeStateUntracked(nodeWorkDir: string): void {
   try {
     tracked = execFileSync(
       "git",
-      ["-c", "core.fsmonitor=false", "-C", repositoryRoot, "ls-files", "-z", "--", ...paths],
+      [
+        "-c", "core.fsmonitor=false",
+        "--git-dir", marker.gitDir,
+        "--work-tree", repositoryRoot,
+        "ls-files", "-z", "--", ...paths,
+      ],
       common,
     );
   } catch {


### PR DESCRIPTION
## Summary

> **修订（通信龙 07-30，据独立复核）**：原文这里有一句指向 #511 的**自动关闭关键字，已去掉**
> （这里刻意不复述那个关键字原文 —— GitHub 会把正文里任何位置的关闭关键字都当真，
> 连引用块里的也算，写上去就等于没删）。
>
> 独立复核在 origin/main + 干净 TMPDIR 下双跑：普通 clone 与 detached worktree
> **都是 3 pass / 0 fail，没有差异** —— #511 描述的"worktree 红"在干净环境下复现不出。
> 真因是宿主 `/tmp/.git`（一个空目录，git 视为无效仓库）污染了默认 TMPDIR，
> 两种检出都会红且报同样的错，看起来像 shape-specific bug。
>
> 本 PR **不解决那个真因**（`/tmp/.git` 比代码早存在，且**不许动** —— TM 系列重度
> 依赖 `/tmp`）。#511 的正确修法是让测试显式指向干净 TMPDIR，已按真因重写。
>
> 本 PR 的价值是**独立的**：为 worktree marker 的合法路径加显式覆盖，并让伪造/损坏的
> marker fail-closed。因此合并本 PR **不应连带关闭** #511（关闭关键字已刻意不写）。
>
> **已知 follow-up（独立复核发现，不阻塞合并）**：`.git` file 的 `gitdir:` 指向**另一个
> 真实合法的 git 目录**时，git 不校验 gitdir 与 work-tree 是否同属一仓，于是该检查会
> 恒定报"未跟踪"。威胁模型上不是安全升级面（能写 markerRoot 的人已能写 nodeWorkDir），
> 但是真实的功能 gap：operator 会看到假阳性。建议校验 `<resolved>/worktrees/<marker
> basename>/gitdir` 是否指回 marker 本身。 by making `assertOpencodeNodeStateUntracked` explicitly understand Git worktree `.git` file markers instead of treating every `.git` marker shape as opaque Git metadata.

The implementation now resolves the nearest `.git` marker before running `git`:

- accepts a normal `.git` directory
- accepts a worktree `.git` regular file only when it is a small single-line `gitdir: <path>` marker
- resolves relative `gitdir:` paths against the marker root
- requires the resolved `gitdir` to be a real directory
- rejects empty, oversized, multi-line, NUL-containing, non-`gitdir:` or dangling file markers as invalid metadata
- invokes Git with explicit `--git-dir` and `--work-tree`, literal pathspecs, no shell

This is intentionally fail-closed: accepting the worktree form does not mean accepting arbitrary `.git` file contents.

## Tests / Evidence

Controlled ordinary clone baseline after fix:

```text
TMPDIR=/tmp/agent-network-511-1785380383 bun test src/opencode-runtime-binding.test.ts --test-name-pattern "assertOpencodeNodeStateUntracked"
5 pass / 0 fail
```

Controlled detached worktree after fix (`.git` is a file):

```text
$ file .git && sed -n '1,3p' .git
.git: ASCII text
gitdir: /tmp/agent-network-511-1785380383/.git/worktrees/agent-network-511-fixed-1785380519

$ TMPDIR=/home/vansin/agent-network-511-fixed-1785380519 bun test src/opencode-runtime-binding.test.ts --test-name-pattern "assertOpencodeNodeStateUntracked"
5 pass / 0 fail
```

Full target file:

```text
TMPDIR=/home/vansin/agent-network-511-fixed-1785380519 bun test src/opencode-runtime-binding.test.ts
18 pass / 0 fail
```

Package regression:

```text
npm run typecheck
# pass

TMPDIR=/tmp/agent-network-511-1785380383 bun test src
301 pass / 0 fail
```

## Witnessed-red note

I could not reproduce the issue description's exact ordinary-clone-vs-worktree split on current `origin/main` (`73ff22d5`) when `TMPDIR` is controlled to live under the checkout roots:

- ordinary clone with `.git` directory: target group passed
- detached worktree with `.git` file: target group also passed

This machine does have an unrelated `/tmp/.git` invalid directory, so default `tmpdir()` runs can fail in both checkout types with the same error. I controlled `TMPDIR` for the evidence above so the test is measuring the checkout marker shape, not host `/tmp` contamination.

Even though the exact red was not reproducible on current `main` here, this PR adds the missing explicit coverage for legal worktree markers and the fail-closed forged-marker case requested by #511.
