### PR TITLE
fix(#494): headless 报错改推 --accept-dev-channels；--tmux 语义写清 + dev-channels 检测告警

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -4268,7 +4268,12 @@ async function launchAgent(id: string, forceNewSession = false) {
     if (hasDevChannels && !process.stdin.isTTY) {
       console.warn(`[anet] ⚠ claude-code-cli with --dangerously-load-development-channels needs an interactive TTY to confirm Claude Code's dev-channels prompt.`);
       console.warn(`[anet]   This shell's stdin is not a TTY → the spawned claude process will hang on the confirm box and the node will stay offline.`);
-      console.warn(`[anet]   Fix: re-run with \`anet node start ${shellQuote(nodeId)} --tmux\` (anet auto-confirms in tmux mode via capture-pane).`);
+      // #494 — this used to point at `--tmux` and claim anet auto-confirms
+      // there. The single-node `--tmux` path never ran the capture-pane
+      // watcher (only `project up` and `--accept-dev-channels` do), so a
+      // headless dev-channels node started via `--tmux` sat on the confirm
+      // box forever. Point at the flag that actually dismisses the prompt.
+      console.warn(`[anet]   Fix: re-run with \`anet node start ${shellQuote(nodeId)} --accept-dev-channels\` (detached tmux + anet auto-confirms the prompt via capture-pane).`);
       console.warn(`[anet]   Or attach a TTY (interactive ssh) and run again, then hit Enter on the prompt.`);
     }
 
@@ -4300,9 +4305,20 @@ async function launchAgent(id: string, forceNewSession = false) {
       console.error(`[anet]    auto-switches to --print mode without a TTY and refuses to`);
       console.error(`[anet]    start its interactive session, so the agent never comes online.`);
       console.error(`[anet]    Fix:`);
+      // #494 — recommend the purpose-built headless path FIRST.
+      // `--accept-dev-channels` always spawns DETACHED (works with no TTY
+      // anywhere) and additionally auto-confirms Claude's dev-channels
+      // prompt if one appears (a `--tmux` detached session leaves that
+      // prompt waiting until someone attaches). `--tmux` stays listed with
+      // its precondition spelled out so nobody is pointed back at a wall.
       console.error(`[anet]      • For headless / CI / systemd / docker without -it:`);
-      console.error(`[anet]        anet node start ${shellQuote(nodeId)} --tmux`);
-      console.error(`[anet]        (anet allocates a real PTY inside a tmux session)`);
+      console.error(`[anet]        anet node start ${shellQuote(nodeId)} --accept-dev-channels`);
+      console.error(`[anet]        (detached tmux session with a real PTY; auto-confirms the`);
+      console.error(`[anet]         dev-channels prompt if the node uses server: channels)`);
+      console.error(`[anet]      • anet node start ${shellQuote(nodeId)} --tmux`);
+      console.error(`[anet]        (attached when run from a terminal; detached when headless —`);
+      console.error(`[anet]         note: does NOT auto-confirm a dev-channels prompt; attach`);
+      console.error(`[anet]         with \`tmux attach -t <alias>\` if the node waits on one)`);
       console.error(`[anet]      • Or re-run this command from an interactive terminal.`);
       process.exit(1);
     }
@@ -4442,8 +4458,12 @@ async function startCommand() {
   const wantTmux = opts.tmux === "true";
 
   // #176 — headless / no-TTY start with automatic dev-channels prompt
-  // dismissal. Default `startCommand` and `--tmux` both assume an attached
-  // TTY: claude-code-cli pops "WARNING: Loading development channels …
+  // dismissal. Default `startCommand` assumes an attached TTY, and `--tmux`
+  // did too until #486-CR/#494 (it now falls back to a detached session
+  // when stdin is not a TTY — see the `headless` branch below — but it
+  // still does NOT dismiss the dev-channels prompt; only this flag and
+  // `project up` run the capture-pane watcher).
+  // claude-code-cli pops "WARNING: Loading development channels …
   // (Enter to confirm)" on every launch and waits for keyboard input. From
   // a watchdog / cron / CI / `setsid`-detached caller there is no TTY to
   // press Enter, so the process hangs forever and the node never comes up
@@ -4601,6 +4621,15 @@ async function startCommand() {
     console.log(`[anet] ✅ tmux session "${alias}" started detached.`);
     console.log(`[anet]    Attach:   tmux attach -t ${alias}`);
     console.log(`[anet]    Stop:     anet node stop ${alias}`);
+    // #494 — a detached `--tmux` start does not run the dev-channels
+    // prompt watcher; a claude node with server: channels will sit on the
+    // confirm box until a human attaches. Don't let that read as success
+    // silently — say so and point at the flag that handles it.
+    if ((resolved.profile.channels ?? []).some(ch => typeof ch === "string" && ch.startsWith("server:"))) {
+      console.warn(`[anet] ⚠ this node loads dev channels (server:*): Claude will wait on its`);
+      console.warn(`[anet]   confirm prompt inside the detached session. Attach and hit Enter,`);
+      console.warn(`[anet]   or use \`anet node start ${shellQuote(alias)} --accept-dev-channels\` which auto-confirms.`);
+    }
     return;
   }
 

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2080,7 +2080,7 @@ Session:
   anet node create <name> --resume <id>  Bind an existing Claude session
   anet node create <name> --resume-latest  Bind the latest Claude session
   anet node start <name>                 Start in this terminal (foreground, default)
-  anet node start <name> --tmux          Start in a new tmux session + attach
+  anet node start <name> --tmux          Start in a tmux session (attach with a terminal; detached when headless)
   anet node start <name> --new-session   Start with fresh Claude session
   anet node resume <name> --session <id> Resume specific session
   anet session ls               List Claude Code sessions
@@ -4258,13 +4258,16 @@ async function launchAgent(id: string, forceNewSession = false) {
 
     // #237 P0 #6 — Claude Code's `--dangerously-load-development-channels`
     // pops an interactive confirm box ("I am using this for local
-    // development / Exit") that needs an Enter keystroke. In tmux/project
-    // batch paths anet auto-confirms via autoConfirmDevChannels() (uses
-    // capture-pane → send-keys). In a plain foreground `anet node start
-    // <alias>` from a non-TTY shell (ssh detached, scripted bootstrap,
-    // systemd unit before user attach), no one types Enter → node hangs
-    // offline indefinitely with no signal that it's waiting on the user.
-    // Friendly preflight: warn loud and suggest the escape hatch.
+    // development / Exit") that needs an Enter keystroke. anet auto-confirms
+    // it via autoConfirmDevChannels() (capture-pane → send-keys) ONLY on the
+    // `project up`/`project restart` batch paths and the single-node
+    // `--accept-dev-channels` flag — NOT on plain `node start` and NOT on
+    // `--tmux` (#494 clarified this; the warn below points accordingly).
+    // In a plain foreground `anet node start <alias>` from a non-TTY shell
+    // (ssh detached, scripted bootstrap, systemd unit before user attach),
+    // no one types Enter → node hangs offline indefinitely with no signal
+    // that it's waiting on the user. Friendly preflight: warn loud and
+    // suggest the escape hatch that actually dismisses the prompt.
     if (hasDevChannels && !process.stdin.isTTY) {
       console.warn(`[anet] ⚠ claude-code-cli with --dangerously-load-development-channels needs an interactive TTY to confirm Claude Code's dev-channels prompt.`);
       console.warn(`[anet]   This shell's stdin is not a TTY → the spawned claude process will hang on the confirm box and the node will stay offline.`);

--- a/agent-network/src/claude-code-cli-tty-preflight.test.ts
+++ b/agent-network/src/claude-code-cli-tty-preflight.test.ts
@@ -69,13 +69,25 @@ describe("claude-code-cli spawn preflight (#486 P0 regression gate)", () => {
     expect(slice).not.toMatch(/process\.exit\(\s*0\s*\)/);
   });
 
-  test("Refuse: message names claude-code-cli and points at --tmux escape hatch", () => {
+  test("Refuse: message names claude-code-cli and recommends --accept-dev-channels first (--tmux listed with its precondition)", () => {
     const preflight = body.indexOf("process.stdin.isTTY");
     const spawnClaude = body.indexOf('spawn("claude", claudeArgs');
     const slice = body.slice(preflight, spawnClaude);
     // Operator needs to know which runtime it is and how to escape.
     expect(slice).toMatch(/claude-code-cli/);
+    // #494 — the primary headless recommendation is --accept-dev-channels
+    // (always detached + auto-confirms the dev-channels prompt); --tmux
+    // stays listed but must come after it and carry the "does NOT
+    // auto-confirm" caveat so nobody is pointed back at a wall.
+    expect(slice).toMatch(/--accept-dev-channels/);
     expect(slice).toMatch(/--tmux/);
+    // Ordering is asserted inside the refusal's Fix section (comments
+    // earlier in the function legitimately mention --tmux first).
+    const fixIdx = slice.indexOf("For headless / CI / systemd");
+    expect(fixIdx).toBeGreaterThan(-1);
+    const fixSlice = slice.slice(fixIdx);
+    expect(fixSlice.indexOf("--accept-dev-channels")).toBeLessThan(fixSlice.indexOf("--tmux"));
+    expect(fixSlice).toMatch(/does NOT auto-confirm/);
     // And it must be an ERROR, not a warn/log (scriptable callers
     // parse stderr for failures).
     expect(slice).toMatch(/console\.error/);

--- a/docs-site/docs/en/guide/cli.md
+++ b/docs-site/docs/en/guide/cli.md
@@ -365,14 +365,14 @@ Cross-machine deploy is still supported: the wizard still prints the export comm
 
 > [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)
 
-Start an agent node. **Default is foreground** (stdio inherits the current terminal); pass `--tmux` to launch the node inside a new tmux session and attach.
+Start an agent node. **Default is foreground** (stdio inherits the current terminal); pass `--tmux` to launch the node inside a tmux session (attaches when run from a terminal; automatically **detached** when headless / stdin is not a TTY — see below).
 
-> v0.9.0 briefly introduced an "auto-wrap into detached tmux" default ([#122](https://github.com/sleep2agi/agent-network/issues/122)). v0.9.2 reverts it via [#136](https://github.com/sleep2agi/agent-network/issues/136) — detached tmux triggered `setRawMode errno 5` on macOS bun (the detached child's stdio isn't a real PTY, claude-code-cli's setRawMode call failed). The new `--tmux` path is **attached** (`tmux new -As`), keeping the PTY chain intact so setRawMode works everywhere.
+> v0.9.0 briefly introduced an "auto-wrap into detached tmux" default ([#122](https://github.com/sleep2agi/agent-network/issues/122)). v0.9.2 reverts it via [#136](https://github.com/sleep2agi/agent-network/issues/136) — detached tmux triggered `setRawMode errno 5` on macOS bun (the detached child's stdio isn't a real PTY, claude-code-cli's setRawMode call failed). The `--tmux` path is **attached when a terminal is present** (`tmux new -As`, keeping the PTY chain intact so setRawMode works); since [#486](https://github.com/sleep2agi/agent-network/issues/486)/[#494](https://github.com/sleep2agi/agent-network/issues/494) it **falls back to detached** (`tmux new-session -d` + liveness check, non-zero exit on failure) when stdin is not a TTY, so headless / CI / systemd callers no longer hit "open terminal failed".
 
 ::: tip Want to re-attach to a running tmux node?
 There is no generic top-level `anet attach <alias>` subcommand today ([#121](https://github.com/sleep2agi/agent-network/issues/121) is planned, not yet implemented). To re-attach:
 - `tmux a -t <alias>` — direct tmux command
-- or `anet node start <alias> --tmux` — the `--tmux` flag uses `tmux new -As`, which attaches if the session already exists
+- or `anet node start <alias> --tmux` — from a terminal it uses `tmux new -As`, which attaches if the session already exists
 
 **Exception: Grok co-presence** (`--runtime grok-build-cli`) has a dedicated `anet grok attach <alias>` that attaches you to the real Grok TUI held by the agent-node, sharing one session with network tasks. See [Grok Co-presence TUI](./grok-copresence.md).
 :::
@@ -383,7 +383,7 @@ anet node start <name> [options]
 
 | Parameter | Default | Description |
 |------|--------|------|
-| `--tmux` | false | Start in a new tmux session and attach (session name = alias; `-A` attaches if it already exists). Detach with `Ctrl-B D`. |
+| `--tmux` | false | Start in a tmux session (session name = alias; `-A` attaches if it already exists). From a terminal it attaches — detach with `Ctrl-B D`; **headless (stdin not a TTY) it starts detached** — re-join with `tmux attach -t <alias>`. Note: it does NOT auto-confirm the dev-channels prompt; use `--accept-dev-channels` for that. |
 | `--new-session` | false | Ignore previous Claude session, create a new one (the "start over" path on the `--resume` chain) |
 
 **Default (no flag)**:
@@ -398,12 +398,14 @@ anet node start <name>
 anet node start <name> --tmux
 ```
 
-**`--tmux` semantics**: internally runs `tmux new -As <alias> -c <cwd> "anet node start <alias>"`:
+**`--tmux` semantics (terminal present)**: internally runs `tmux new -As <alias> -c <cwd> "anet node start <alias>"`:
 - `-A` — if a same-name session already exists, attach to it instead of erroring (rerun-friendly)
 - `-s` — session name = alias (discoverability)
 - `-c` — start in the current cwd
 - the inner command does **not** carry `--tmux`, so the inner `anet node start` runs foreground — no recursion
 - the parent terminal becomes a tmux client, keeping the PTY chain intact: `claude-code-cli` setRawMode, `Ctrl-C`, raw input all work normally
+
+**`--tmux` semantics (headless, stdin not a TTY)**: automatically switches to `tmux new-session -d` (detached), then polls `tmux has-session` for up to 2 s to prove the session actually came up; a tmux failure or a missing session **exits non-zero** with tmux's stderr surfaced. Detached mode does **not** auto-confirm claude's dev-channels prompt — for nodes with `server:*` channels use `--accept-dev-channels` (detached + capture-pane auto-confirm) instead.
 
 **`--tmux` fallback**: if tmux isn't installed, the command errors out and suggests installing tmux or dropping the flag to run foreground.
 

--- a/docs-site/docs/guide/cli.md
+++ b/docs-site/docs/guide/cli.md
@@ -371,14 +371,14 @@ anet node create 翻译官 --runtime claude-agent-sdk --model <minimax-model-id>
 
 > [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)
 
-启动 Agent 节点。**默认前台运行**（stdio 接当前终端）；想后台跑或想用 tmux 管理，加 `--tmux` 开 tmux session 并 attach。
+启动 Agent 节点。**默认前台运行**（stdio 接当前终端）；想后台跑或想用 tmux 管理，加 `--tmux` 开 tmux session（从终端跑会 attach 进入；headless/无 TTY 时自动转 **detached** 后台起，见下）。
 
-> v0.9.0 短暂引入过「默认 detached tmux」行为（[#122](https://github.com/sleep2agi/agent-network/issues/122)），v0.9.2 通过 [#136](https://github.com/sleep2agi/agent-network/issues/136) 回退 —— detached tmux 触发了 macOS bun `setRawMode errno 5`（detached child 的 stdio 不是 real PTY，claude-code-cli setRawMode 调用失败）。现在的 `--tmux` 走 **attached** 模式（`tmux new -As`），PTY chain 保持完整不再触发 bug。
+> v0.9.0 短暂引入过「默认 detached tmux」行为（[#122](https://github.com/sleep2agi/agent-network/issues/122)），v0.9.2 通过 [#136](https://github.com/sleep2agi/agent-network/issues/136) 回退 —— detached tmux 触发了 macOS bun `setRawMode errno 5`（detached child 的 stdio 不是 real PTY，claude-code-cli setRawMode 调用失败）。现在的 `--tmux` 在**有终端时走 attached** 模式（`tmux new -As`，PTY chain 完整不触发该 bug）；[#486](https://github.com/sleep2agi/agent-network/issues/486)/[#494](https://github.com/sleep2agi/agent-network/issues/494) 起 **stdin 不是 TTY 时自动转 detached**（`tmux new-session -d` + session 存活校验，失败非零退出），headless/CI/systemd 场景不再撞「open terminal failed」。
 
 ::: tip 想 re-attach 到已跑的 tmux 节点？
 当前没有通用的顶层 `anet attach <alias>` 子命令（[#121](https://github.com/sleep2agi/agent-network/issues/121) 计划中, 未实施）。re-attach 用：
 - `tmux a -t <alias>` —— 直接 tmux 命令
-- 或 `anet node start <alias> --tmux` —— `--tmux` flag 用 `tmux new -As`, session 已存在直接 attach
+- 或 `anet node start <alias> --tmux` —— 从终端跑用 `tmux new -As`, session 已存在直接 attach
 
 **例外：Grok 人机共存**（`--runtime grok-build-cli`）有专用的 `anet grok attach <alias>`，可 attach 到 agent-node 持有的真实 Grok TUI，与网络任务同处一个会话。详见 [Grok 人机共存 TUI](./grok-copresence.md)。
 :::
@@ -389,7 +389,7 @@ anet node start <name> [options]
 
 | 参数 | 默认值 | 说明 |
 |------|--------|------|
-| `--tmux` | false | 在新 tmux session 里跑并 attach 进入（session 名 = alias；`-A` 已存在则 attach）；按 `Ctrl-B D` detach |
+| `--tmux` | false | 在 tmux session 里跑（session 名 = alias；`-A` 已存在则 attach）。从终端跑 = attach 进入，按 `Ctrl-B D` detach；**headless（stdin 非 TTY）= 自动 detached 起**，之后 `tmux attach -t <alias>`。注意：不会自动确认 dev-channels 弹窗，那个用 `--accept-dev-channels` |
 | `--new-session` | false | 忽略旧 Claude session，创建新的（同 `--resume` chain 的「重新开始」） |
 
 **默认（无 flag）**：
@@ -404,12 +404,14 @@ anet node start <name>
 anet node start <name> --tmux
 ```
 
-**`--tmux` 行为**：内部执行 `tmux new -As <alias> -c <cwd> "anet node start <alias>"`：
+**`--tmux` 行为（有终端时）**：内部执行 `tmux new -As <alias> -c <cwd> "anet node start <alias>"`：
 - `-A` —— alias 已有同名 session 直接 attach（rerun 友好）
 - `-s` —— session 名 = alias（discoverability）
 - `-c` —— start 在当前 cwd
 - inner cmd 不带 `--tmux`，所以内层就是 foreground 跑，没有递归
 - 终端是 tmux client，PTY chain 完整：claude-code-cli 的 setRawMode、`Ctrl-C`/raw input 都正常工作
+
+**`--tmux` 行为（headless，stdin 非 TTY）**：自动转 `tmux new-session -d`（detached），随后做最长 2s 的 `tmux has-session` 存活校验；tmux 失败或 session 未出现都**非零退出**并透传 tmux stderr。detached 模式**不会**自动确认 claude 的 dev-channels 弹窗 —— 带 `server:*` channel 的节点请改用 `--accept-dev-channels`（detached + capture-pane 自动确认）。
 
 **`--tmux` 失败回退**：如果 tmux 未装，命令拒绝 + 提示装 tmux 或回退默认前台。
 


### PR DESCRIPTION
Closes #494

## 结论先行

**议题两问的现状（针对 main HEAD 73ff22d5 实测）**：
1. ❌ headless 报错**只推 `--tmux`、一字不提 `--accept-dev-channels`** → 本 PR 修
2. ✅ `--tmux` 失败退出 0 **已在 #489 squash（494e7f6d）里修掉**——headless 走 detached spawn + has-session liveness 轮询 + 非零退出。issue 里 `open terminal failed + exit 0` 的实测应来自**已发布的 npm v2.3.0-preview.35（pre-#489，连 refusal 都没有）**，main 上复现不出（证据见下）。**要用户真正受益需要 cut 一个新 release。**

另修两处 main 上确实存在的残余：
- **dev-channels headless 警告谎称 `--tmux` 会 auto-confirm**——单节点 `--tmux` 路径从未跑 capture-pane watcher（只有 `project up` 和 `--accept-dev-channels` 跑）。dev-channels 节点照它做 = detached session 里 claude 卡确认框直到有人 attach。改推 `--accept-dev-channels`。
- **陈旧注释**（#176 块）仍写 `--tmux both assume an attached TTY`——正是 issue 引用的自相矛盾，已更新为现状描述。
- 新增：detached `--tmux` 成功输出在节点带 server:* channels 时打点名警告（防静默假成功观感）。

改动 = 文案 + 注释 + 1 个 headless-only 警告；**不动任何行为路径**，tsc --noEmit 0 error。

## witnessed-red（沙箱：HOME/cwd 均 scratch、伪造本地 profile、不触生产 hub）

**已发布 npm v2.3.0-preview.35**（用户实际拿到的）headless 起 claude 节点：
```
[anet] Token: ntok_fak...
Error: Input must be provided either through stdin or as a prompt argument when using --print
[anet] Claude Code session pinned: 007cbe17...
```
（#486 原始形态：假成功文案；refusal/--tmux 提示都不存在）

**main pre-patch** headless 起 claude 节点 → refusal 只推 --tmux：
```
[anet]      • For headless / CI / systemd / docker without -it:
[anet]        anet node start 'demo494' --tmux
[anet]        (anet allocates a real PTY inside a tmux session)
```
**main pre-patch** 照提示 headless 跑 `--tmux` → detached 成功（机制已好，issue 该项在 main 不再红）：
```
[anet] ✅ tmux session "demo494" started detached.   # exit 0, tmux ls 可见 session
```

## witnessed-green（本 PR 后，同沙箱）

- **a. headless refusal 新文案**：--accept-dev-channels 列首位（含语义说明），--tmux 前置条件写清 → exit 1
- **b. 照首选提示做**：`--accept-dev-channels` headless → `✅ node "demo494" started detached (tmux session live; dev-channels prompt did not appear within 45 s)`，exit 0，session 实际存活
- **c. `--tmux` headless 回归**：行为与 main 相同（detached，exit 0）
- **d. dev-channels 节点 `--tmux` headless**：成功输出后新增点名警告（Attach and hit Enter / 或用 --accept-dev-channels）
- **e. 退出码故障注入（tmux shim）**：
  - new-session 失败（`open terminal failed` stderr）→ `❌ tmux new-session detached failed (exit 1)` + stderr 透传，**exit 1**
  - tmux 假成功（exit 0 但无 session）→ liveness 轮询 2s 后 `❌ ... did not appear`，**exit 1**
  - tmux 未安装 → 既有分支 exit 1
- **f. 交互回归（script 伪 TTY）**：attached 分支代码零改动；伪 TTY + 无 tmux → 既有 not-installed 提示 exit 1

原始输出留存于执行机 `/tmp/claude-1000/-home-vansin-agent-network-dashboard/d99c5b97-60df-4566-a9f2-fb02b9df761a/scratchpad/494-sandbox/{plain,main-plain,main-tmux,green-*}.out`，需要我可整段贴进评论。

## 建议 follow-up（不在本 PR）
- cut release：v2.3.0-preview.35 用户拿不到 #489 与本修复
- 可选：--tmux headless 分支直接复用 dismissDevChannelPrompt，让两条路径行为收敛（行为变更，留给独立决策）

🤖 Generated with [Claude Code](https://claude.com/claude-code)