### PR TITLE
fix(server): implement deterministic file range downloads

### DIFF
--- a/server/src/file-download-date-bucket.test.ts
+++ b/server/src/file-download-date-bucket.test.ts
@@ -263,35 +263,17 @@ describe.skipIf(!isProdMode)("#509 — download uses index date_bucket, not toda
       dateBucket: BUCKET_YESTERDAY,
       content,
     });
-    // Whether Range is honoured is orthogonal to #509 and NOT decided by
-    // this codebase: the handler is `new Response(Bun.file(path), {status:200})`
-    // with no Range handling anywhere, so 200-vs-206 is decided purely by the
-    // Bun runtime. Measured 2026-07-30 with byte-identical code:
-    //   bun 1.2.22 → 200 + full body     bun 1.3.14 → 206 + correct slice
-    // So both statuses are legitimate and this test must pass on both.
-    //
-    // 🔴 But "accept either status" must NOT mean "assert nothing". The first
-    // version guarded the body check with `if (status === 200)`, so on the
-    // runtime production actually runs (206) the body assertion never
-    // executed — the test claimed to prove the blob path resolved correctly
-    // while only ever checking a status code. Each branch asserts its own
-    // bytes, and an unrecognised status fails loudly rather than silently
-    // skipping.
+    // #514: Range is now handled in application code, not delegated to Bun.
+    // That makes 206 the only valid result across Bun versions; accepting 200
+    // here would re-open the runtime-dependent behavior this test guards.
     const res = await fetch(`${BASE}/api/files/${fileId}`, {
       method: "GET",
       headers: { Authorization: `Bearer ${userAToken}`, Range: "bytes=0-4" },
     });
-    expect([200, 206]).toContain(res.status);
-    if (res.status === 206) {
-      // Runtime honoured Range: body must be exactly the requested slice,
-      // and the slice must come from THIS file (total length 20 proves the
-      // resolved blob is the planted one, not some other bucket's file).
-      expect(await res.text()).toBe("01234");
-      expect(res.headers.get("content-range")).toBe(`bytes 0-4/${content.byteLength}`);
-    } else {
-      // Runtime ignored Range: body must be the complete planted blob.
-      expect(await res.text()).toBe("0123456789ABCDEFGHIJ");
-    }
+    expect(res.status).toBe(206);
+    expect(await res.text()).toBe("01234");
+    expect(res.headers.get("content-range")).toBe(`bytes 0-4/${content.byteLength}`);
+    expect(res.headers.get("content-length")).toBe("5");
   });
 
   test("Door 3 conditional: yesterday's file with If-None-Match → served or 304, never 404", async () => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -255,6 +255,42 @@ export function authorizeFileDownload(req: Request, entry: { owner_id?: unknown 
   return false;
 }
 
+type ByteRange =
+  | { ok: true; start: number; end: number; length: number }
+  | { ok: false };
+
+function parseSingleByteRange(rangeHeader: string | null, size: number): ByteRange | null {
+  if (rangeHeader === null) return null;
+  if (!Number.isSafeInteger(size) || size < 0) return { ok: false };
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+  if (!match) return { ok: false };
+  const [, rawStart, rawEnd] = match;
+  if (rawStart === "" && rawEnd === "") return { ok: false };
+
+  let start: number;
+  let end: number;
+  if (rawStart === "") {
+    const suffixLength = Number(rawEnd);
+    if (!Number.isSafeInteger(suffixLength) || suffixLength <= 0) return { ok: false };
+    if (size === 0) return { ok: false };
+    start = Math.max(0, size - suffixLength);
+    end = size - 1;
+  } else {
+    start = Number(rawStart);
+    if (!Number.isSafeInteger(start) || start < 0) return { ok: false };
+    if (start >= size) return { ok: false };
+    if (rawEnd === "") {
+      end = size - 1;
+    } else {
+      end = Number(rawEnd);
+      if (!Number.isSafeInteger(end) || end < start) return { ok: false };
+      end = Math.min(end, size - 1);
+    }
+  }
+
+  return { ok: true, start, end, length: end - start + 1 };
+}
+
 type RestNetworkScope = {
   networkId: string | null;
   networkIds: string[] | null;
@@ -1847,7 +1883,31 @@ return Bun.serve({
         "Content-Disposition": `attachment; filename="${safeFilename.replace(/"/g, "")}"`,
         "X-Content-Type-Options": "nosniff",
         "Cache-Control": "private, no-store",
+        "Accept-Ranges": "bytes",
       };
+      const range = parseSingleByteRange(req.headers.get("Range"), entry.size);
+      if (range && !range.ok) {
+        return new Response(null, {
+          status: 416,
+          headers: {
+            ...responseHeaders,
+            "Content-Length": "0",
+            "Content-Range": `bytes */${entry.size}`,
+          },
+        });
+      }
+      if (range?.ok) {
+        const headers = {
+          ...responseHeaders,
+          "Content-Length": String(range.length),
+          "Content-Range": `bytes ${range.start}-${range.end}/${entry.size}`,
+        };
+        if (req.method === "HEAD") {
+          return new Response(null, { status: 206, headers });
+        }
+        const blob = Bun.file(storage.absolutePath).slice(range.start, range.end + 1);
+        return new Response(blob, { status: 206, headers });
+      }
       // HEAD: return the same status and headers as GET, but no body,
       // per RFC 9110 §9.3.2. This ensures HEAD passes through the same
       // authorization helper — a cross-owner HEAD is 404 (same as GET),

--- a/server/src/uploads-http.test.ts
+++ b/server/src/uploads-http.test.ts
@@ -164,12 +164,18 @@ describe("POST /api/upload — 6-item security checklist (HTTP integration)", ()
 
 describe("GET /api/files/:file_id — download safety", () => {
   let fileId = "";
+  let rangeFileId = "";
+  const rangeContent = Uint8Array.from({ length: 64 }, (_, i) => i);
 
   beforeAll(async () => {
     const content = new TextEncoder().encode("hello-world-from-#221-integration-test");
     const res = await uploadFile(content, "greeting.txt", "text/plain");
     const body = await res.json() as any;
     fileId = body.file_id;
+
+    const rangeRes = await uploadFile(rangeContent, "range.bin", "application/octet-stream");
+    const rangeBody = await rangeRes.json() as any;
+    rangeFileId = rangeBody.file_id;
   });
 
   test("(item 3) download returns the blob with Content-Disposition: attachment + X-Content-Type-Options: nosniff", async () => {
@@ -178,8 +184,70 @@ describe("GET /api/files/:file_id — download safety", () => {
     expect(res.headers.get("Content-Disposition") ?? "").toMatch(/^attachment(;|$)/i);
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
     const text = await res.text();
     expect(text).toBe("hello-world-from-#221-integration-test");
+  });
+
+  test("#514 Range bytes=a-b returns exact 206 partial content, not a tolerant 200/full body", async () => {
+    const res = await fetch(`${BASE}/api/files/${rangeFileId}`, {
+      headers: { ...authHeaders(), Range: "bytes=3-8" },
+    });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 3-8/64");
+    expect(res.headers.get("Content-Length")).toBe("6");
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+    const body = new Uint8Array(await res.arrayBuffer());
+    expect(body.length).toBe(6);
+    expect([...body]).toEqual([...rangeContent.slice(3, 9)]);
+  });
+
+  test("#514 Range bytes=N- returns the exact open-ended tail", async () => {
+    const res = await fetch(`${BASE}/api/files/${rangeFileId}`, {
+      headers: { ...authHeaders(), Range: "bytes=60-" },
+    });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 60-63/64");
+    expect(res.headers.get("Content-Length")).toBe("4");
+    const body = new Uint8Array(await res.arrayBuffer());
+    expect(body.length).toBe(4);
+    expect([...body]).toEqual([...rangeContent.slice(60)]);
+  });
+
+  test("#514 Range bytes=-N returns the exact suffix", async () => {
+    const res = await fetch(`${BASE}/api/files/${rangeFileId}`, {
+      headers: { ...authHeaders(), Range: "bytes=-7" },
+    });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 57-63/64");
+    expect(res.headers.get("Content-Length")).toBe("7");
+    const body = new Uint8Array(await res.arrayBuffer());
+    expect(body.length).toBe(7);
+    expect([...body]).toEqual([...rangeContent.slice(57)]);
+  });
+
+  test("#514 unsatisfiable Range returns 416 with concrete Content-Range size", async () => {
+    const res = await fetch(`${BASE}/api/files/${rangeFileId}`, {
+      headers: { ...authHeaders(), Range: "bytes=64-70" },
+    });
+    expect(res.status).toBe(416);
+    expect(res.headers.get("Content-Range")).toBe("bytes */64");
+    expect(res.headers.get("Content-Length")).toBe("0");
+    const body = new Uint8Array(await res.arrayBuffer());
+    expect(body.length).toBe(0);
+  });
+
+  test("#514 HEAD Range mirrors GET status and range headers without a body", async () => {
+    const res = await fetch(`${BASE}/api/files/${rangeFileId}`, {
+      method: "HEAD",
+      headers: { ...authHeaders(), Range: "bytes=3-8" },
+    });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 3-8/64");
+    expect(res.headers.get("Content-Length")).toBe("6");
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+    const body = new Uint8Array(await res.arrayBuffer());
+    expect(body.length).toBe(0);
   });
 
   test("anonymous download is 401", async () => {


### PR DESCRIPTION
## Summary

Fixes #514 by moving `/api/files/:file_id` Range handling into the CommHub application layer instead of relying on Bun runtime behavior.

The download handler now:

- advertises `Accept-Ranges: bytes`
- parses a single `bytes=` range explicitly
- returns `206` with exact `Content-Range` and fragment `Content-Length`
- supports `bytes=a-b`, `bytes=N-`, and `bytes=-N`
- returns `416` with `Content-Range: bytes */<size>` for malformed or unsatisfiable ranges
- keeps `HEAD` aligned with `GET` for status and headers while omitting the body

This keeps authz and path validation unchanged: Range requests still go through the existing `/api/files/:file_id` ownership gate before any blob bytes are served.

## Why

Previously the code returned `new Response(Bun.file(path), { status: 200, ... })` and delegated Range behavior to Bun. That makes media seeking and resumable downloads depend on the deployed Bun version: newer Bun may synthesize `206`, older Bun may return `200` plus the full file.

## Tests

Targeted green:

```text
COMMHUB_DB=/tmp/anet-514-target-green-$$.db bun test src/uploads-http.test.ts
15 pass / 0 fail
```

Aggregate green, using the repo script rather than bare `bun test src`:

```text
npm run test
638 pass / 3 skip / 0 fail
```

Witnessed-red for the new #514 tests: I temporarily changed each new Range test's status expectation to `200`. The same target file then failed exactly on the 5 new Range cases:

```text
10 pass / 5 fail
Expected: 200 Received: 206  # bytes=3-8
Expected: 200 Received: 206  # bytes=60-
Expected: 200 Received: 206  # bytes=-7
Expected: 200 Received: 416  # bytes=64-70
Expected: 200 Received: 206  # HEAD bytes=3-8
```

The tests assert concrete `206` / `416`, exact `Content-Range`, exact `Content-Length`, actual received byte length, and byte-for-byte slice content. There is no tolerant `[200, 206]` assertion.
