### PR TITLE
fix(#517): MCP write path — single-network utok auto-resolve via shared REST scope helpers

### DIFF
--- a/docs-site/docs/api/mcp-tools.md
+++ b/docs-site/docs/api/mcp-tools.md
@@ -189,6 +189,7 @@ report_completion({
 | `alias` | string | &check; | Session 别名 |
 | `message_id` | string | &check; | 消息 ID |
 | `response` | string | | **当前 no-op**：handler 接受这个参数但不写库（[`tools.ts:337-360`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L337) 整段没有引用 `response`）。schema 保留是为了 forward-compat / 不破坏现有调用方；想真正回复用 [`send_reply`](#send-reply) |
+| `network_id` | string | | Network 范围。utok_ 恰好 1 个成员网络时自动解析，可省略；跨多网络必须显式传（#517） |
 
 **返回值**：
 
@@ -268,6 +269,7 @@ send_task({
 | `alias` | string | &check; | 目标 Agent 别名 |
 | `message` | string | &check; | 消息内容（最大 10000 字符） |
 | `from_session` | string | | 发送者标识（默认 "hub"） |
+| `network_id` | string | | Network 范围。utok_ 恰好 1 个成员网络时自动解析，可省略；跨多网络必须显式传（#517） |
 
 **返回值**：
 
@@ -296,6 +298,7 @@ send_task({
 | `in_reply_to` | string | | 原始 task/message ID |
 | `status` | enum | | `replied`（默认）/ `failed` / `cancelled` |
 | `from_session` | string | | 发送者标识（默认 "hub"） |
+| `network_id` | string | | Network 范围。utok_ 恰好 1 个成员网络时自动解析，可省略；跨多网络必须显式传（#517） |
 
 **返回值**：
 
@@ -321,6 +324,7 @@ send_task({
 |------|------|:----:|------|
 | `task_id` | string | &check; | 任务 ID |
 | `from_session` | string | | 发送者标识（默认 "hub"） |
+| `network_id` | string | | Network 范围。utok_ 恰好 1 个成员网络时自动解析，可省略；跨多网络必须显式传（#517） |
 
 **返回值**：
 
@@ -346,6 +350,7 @@ send_task({
 |------|------|:----:|------|
 | `task_id` | string | &check; | 任务 ID |
 | `from_session` | string | | 发送者标识 |
+| `network_id` | string | | Network 范围。utok_ 恰好 1 个成员网络时自动解析，可省略；跨多网络必须显式传（#517） |
 
 **返回值**：
 
@@ -378,6 +383,7 @@ send_task({
 | `task_id` | string | &check; | 任务 ID |
 | `reason` | string | | 取消原因（最大 1000 字符） |
 | `from_session` | string | | 发送者标识 |
+| `network_id` | string | | Network 范围。utok_ 恰好 1 个成员网络时自动解析，可省略；跨多网络必须显式传（#517） |
 
 **返回值**：
 
@@ -410,6 +416,7 @@ send_task({
 | `task_id` | string | &check; | 任务 ID |
 | `new_alias` | string | &check; | 新目标 Agent 别名 |
 | `from_session` | string | | 发送者标识 |
+| `network_id` | string | | Network 范围。utok_ 恰好 1 个成员网络时自动解析，可省略；跨多网络必须显式传（#517） |
 
 **返回值**：
 
@@ -707,7 +714,9 @@ send_task({
 
 | 错误 | 含义 |
 |------|------|
-| `permission_denied` | 权限不足（viewer 写、缺少可写 network 绑定等） |
+| `network_id_required` | 写操作无法确定目标 network：utok_ 调用方有 **0 个或 ≥2 个** network 成员身份，且未显式传 `network_id`。恰好 1 个成员身份时 hub 会**自动解析**，无需传。`message` 会区分是「无成员身份」还是「跨多个 network 需显式指定」 |
+| `access_denied` | 显式传入的 `network_id` 指向一个调用方**不是成员**的 network |
+| `permission_denied` | **viewer 角色**尝试写操作（viewer 只能读；owner/admin/member 可写） |
 | `license_expired` | 试用期过期（v0.6 legacy 路径，Apache 2.0 OSS 后不再需要；命中后照 [troubleshooting `license_expired` 段](/troubleshooting) 清 SQLite `licenses` 表即可） |
 | `message not found or not yours` | 消息不存在或不属于该 Agent |
 | `task not found` | 任务不存在 |

--- a/docs-site/docs/en/api/mcp-tools.md
+++ b/docs-site/docs/en/api/mcp-tools.md
@@ -189,6 +189,7 @@ Acknowledge message receipt. After ACK, the message won't be returned by `get_in
 | `alias` | string | &check; | Session alias |
 | `message_id` | string | &check; | Message ID |
 | `response` | string | | **Currently a no-op**: the handler accepts this parameter but never writes it to the database ([`tools.ts:337-360`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L337) never references `response`). The schema is kept for forward-compat / to avoid breaking existing callers; if you want to actually reply, use [`send_reply`](#send-reply). |
+| `network_id` | string | | Network scope. Auto-resolved for utok_ callers with exactly one membership — optional then; required when the caller spans multiple networks (#517) |
 
 **Response**:
 
@@ -268,6 +269,7 @@ Send a message (does not trigger AI processing, display only).
 | `alias` | string | &check; | Target agent alias |
 | `message` | string | &check; | Message content (max 10000 chars) |
 | `from_session` | string | | Sender identifier (default "hub") |
+| `network_id` | string | | Network scope. Auto-resolved for utok_ callers with exactly one membership — optional then; required when the caller spans multiple networks (#517) |
 
 **Response**:
 
@@ -296,6 +298,7 @@ Reply to a task. Links to the original task_id and does not trigger the recipien
 | `in_reply_to` | string | | Original task/message ID |
 | `status` | enum | | `replied` (default) / `failed` / `cancelled` |
 | `from_session` | string | | Sender identifier (default "hub") |
+| `network_id` | string | | Network scope. Auto-resolved for utok_ callers with exactly one membership — optional then; required when the caller spans multiple networks (#517) |
 
 **Response**:
 
@@ -321,6 +324,7 @@ Acknowledge task receipt (lightweight, does not enter inbox).
 |------|------|:----:|------|
 | `task_id` | string | &check; | Task ID |
 | `from_session` | string | | Sender identifier (default "hub") |
+| `network_id` | string | | Network scope. Auto-resolved for utok_ callers with exactly one membership — optional then; required when the caller spans multiple networks (#517) |
 
 **Response**:
 
@@ -346,6 +350,7 @@ Retry a failed/cancelled/expired task.
 |------|------|:----:|------|
 | `task_id` | string | &check; | Task ID |
 | `from_session` | string | | Sender identifier |
+| `network_id` | string | | Network scope. Auto-resolved for utok_ callers with exactly one membership — optional then; required when the caller spans multiple networks (#517) |
 
 **Response**:
 
@@ -378,6 +383,7 @@ Cancel a pending task.
 | `task_id` | string | &check; | Task ID |
 | `reason` | string | | Cancellation reason (max 1000 chars) |
 | `from_session` | string | | Sender identifier |
+| `network_id` | string | | Network scope. Auto-resolved for utok_ callers with exactly one membership — optional then; required when the caller spans multiple networks (#517) |
 
 **Response**:
 
@@ -410,6 +416,7 @@ Reassign a task to another agent.
 | `task_id` | string | &check; | Task ID |
 | `new_alias` | string | &check; | New target agent alias |
 | `from_session` | string | | Sender identifier |
+| `network_id` | string | | Network scope. Auto-resolved for utok_ callers with exactly one membership — optional then; required when the caller spans multiple networks (#517) |
 
 **Response**:
 
@@ -707,7 +714,9 @@ The `text` field is a JSON string that needs to be parsed.
 
 | Error | Meaning |
 |------|------|
-| `permission_denied` | Insufficient permissions (viewer writing, missing writable network binding, etc.) |
+| `network_id_required` | The write could not be scoped to a network: the utok_ caller has **0 or ≥2** network memberships and passed no explicit `network_id`. With exactly 1 membership the hub **auto-resolves** — no parameter needed. The `message` states which case applies (no memberships vs. multiple networks) |
+| `access_denied` | The explicitly supplied `network_id` names a network the caller is **not a member of** |
+| `permission_denied` | A **viewer role** attempted a write (viewers are read-only; owner/admin/member can write) |
 | `license_expired` | Trial period expired (v0.6 legacy path; not needed after Apache 2.0 OSS — when hit, follow the `license_expired` section in [troubleshooting](/en/troubleshooting) to clear the SQLite `licenses` table) |
 | `message not found or not yours` | Message doesn't exist or doesn't belong to this agent |
 | `task not found` | Task doesn't exist |

--- a/docs-site/docs/en/troubleshooting.md
+++ b/docs-site/docs/en/troubleshooting.md
@@ -191,27 +191,29 @@ cat ~/.anet/config.json
 
 ---
 
-### `permission_denied` -- Insufficient Permissions
+### MCP write rejected — `network_id_required` / `access_denied` / `permission_denied`
 
-```json
-{"ok": false, "error": "permission_denied"}
-```
+When a write tool (send_task / send_message / send_reply / ack_inbox / send_ack / retry_task / cancel_task / reassign_task …) is rejected, the `error` code distinguishes **three different real causes** — don't treat them all as a permissions problem (that misdirection is exactly what #517 fixed):
 
-**Cause**:
+| `error` | Real cause | Fix |
+|---|---|---|
+| `network_id_required`<br>(message says "no network memberships") | The user belongs to no network | Create a network or join one via invite code |
+| `network_id_required`<br>(message says "spans N networks") | The utok_ spans multiple networks — the write target is ambiguous | Pass `network_id` explicitly (from `networks[].network_id` in `/api/auth/me`) |
+| `access_denied` | The `network_id` you passed names a network you are not a member of | Use the right network_id, or have the owner invite you |
+| `permission_denied` | You are a **viewer** (read-only) in that network | Have the owner promote your role (below) |
 
-1. **utok_ used for MCP write operations**: utok_ has no network binding and cannot call MCP write operations
-2. **viewer role attempting write operations**: viewers are read-only
+> **A utok_ caller with exactly one network does NOT need to pass `network_id`** — the hub auto-resolves to the single membership (same rule as REST `POST /api/task`, #517). Hubs from before the #517 fix answered ALL of the above with `permission_denied` and a "utok current_network is null" hint: if you see that old text, upgrade the hub first.
 
 **Solution**:
 
 ```bash
-# Case 1: Use ntok_ instead of utok_
+# Promote a viewer / or switch to ntok_
 # Agent Nodes must connect using ntok_. The token lives in
 # .anet/nodes/<name>/config.json — agent-node CLI does NOT accept a --token flag.
 # If your current node config still has utok_/atok_, doctor migrates it:
 anet doctor --fix
 
-# Case 2: Upgrade your role
+# viewer → member role promotion
 # Have the owner (not admin — admin can't change roles; PUT members is an owner-only gate)
 # call REST to promote you (v0.10.x stable still does not expose a CLI promote subcommand — the v0.9.x and v0.10.x scopes did not touch member-role management; queued for v0.11+ / unscheduled):
 NET=$(jq -r .network_id ~/.anet/config.json)

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -190,27 +190,29 @@ cat ~/.anet/config.json
 
 ---
 
-### `permission_denied` -- 权限不足
+### MCP 写操作被拒 — `network_id_required` / `access_denied` / `permission_denied`
 
-```json
-{"ok": false, "error": "permission_denied"}
-```
+写工具（send_task / send_message / send_reply / ack_inbox / send_ack / retry_task / cancel_task / reassign_task …）被拒时，`error` 码区分**三种不同的真实原因**——别一律当权限问题查（那正是 #517 修掉的误导）：
 
-**原因**：
+| `error` | 真实原因 | 解决 |
+|---|---|---|
+| `network_id_required`<br>（message 含 "no network memberships"） | 该用户不属于任何 network | 先创建或通过邀请码加入一个 network |
+| `network_id_required`<br>（message 含 "spans N networks"） | utok_ 跨多个 network，写目标有歧义 | 显式传 `network_id`（从 `/api/auth/me` 的 `networks[].network_id` 取） |
+| `access_denied` | 显式传的 `network_id` 你不是其成员 | 换正确的 network_id，或让 owner 邀请你加入 |
+| `permission_denied` | 你在该 network 是 **viewer**（只读） | 让 owner 提升角色（见下） |
 
-1. **utok_ 调用 MCP 写操作**：utok_ 没有网络绑定，不能调 MCP 写操作
-2. **viewer 角色尝试写操作**：viewer 只能读
+> **恰好属于 1 个 network 的 utok_ 调用方无需传 `network_id`** —— hub 自动解析到唯一成员网络（与 REST `POST /api/task` 同一规则，#517）。修复 #517 之前的 hub 对上述所有情况一律报 `permission_denied` 并提示 "utok current_network is null"：如果你看到那个旧文案，先升级 hub。
 
 **解决**：
 
 ```bash
-# 情况 1：使用 ntok_ 而非 utok_
+# viewer 提升角色 / 或改用 ntok_
 # Agent Node 必须使用 ntok_，token 来自 .anet/nodes/<name>/config.json 文件
 # （agent-node CLI 不接受 --token flag；token 由 config.json 提供）
 # 如果当前 node 的 token 是 utok_/atok_，跑 doctor 自动修：
 anet doctor --fix
 
-# 情况 2：提升角色
+# viewer → member 提升角色
 # 让 owner（不是 admin —— admin 改不了角色，PUT members 是 owner-only gate）
 # 通过 REST 调用提升角色（CLI promote 子命令 v0.10.x 仍未提供 —— v0.9.x / v0.10.x scope chain 都未动 member role 管理；排到 v0.11+ / 未排期）：
 NET=$(jq -r .network_id ~/.anet/config.json)

--- a/docs/tests/p-517-mcp-write-scope/witnessed-green.txt
+++ b/docs/tests/p-517-mcp-write-scope/witnessed-green.txt
@@ -1,0 +1,29 @@
+bun test v1.3.14 (0d9b296a)
+
+src/mcp-write-network-resolution.test.ts:
+[commhub] database: /tmp/517-net-scope-green.db
+[commhub] 🎉 14-day free trial started!
+[commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
+[08:55:41] u517_single → send_task → peer-517-a1: x517 g1 send_task
+[08:55:41] u517_single → send_message → peer-517-a1: x517 g1 send_message
+[08:55:41] u517_single → send_reply (replied) → peer-517-a1: x517 g1 send_reply
+[08:55:41] peer-517-a1 → ack_inbox: 21552091
+[08:55:41] u517_single → send_ack → task 2588b431
+[08:55:42] u517_single → retry_task → 338562f6
+[08:55:42] u517_single → cancel_task → 7e030ce4
+[08:55:42] u517_single → reassign_task → 781463ae → peer-517-a2
+[08:55:42] u517_multi → send_message → peer-517-a1: x517 g2 send_message
+[08:55:42] u517_multi → send_reply (replied) → peer-517-a1: x517 g2 send_reply
+[08:55:42] peer-517-a1 → ack_inbox: 30eb6543
+[08:55:42] u517_multi → send_ack → task 3feb824a
+[08:55:42] u517_multi → retry_task → 7259c101
+[08:55:42] u517_multi → cancel_task → c14533d1
+[08:55:42] u517_multi → reassign_task → c2e95212 → peer-517-a2
+[08:55:43] peer-517-a1 → send_task → peer-517-a2: x517 g4 ntok plain
+[08:55:43] peer-517-a1 → send_task → peer-517-a2: x517 g4 ntok override
+[08:55:43] hub → send_message → peer-517-a1: x517 g5 legacy
+
+ 24 pass
+ 0 fail
+ 50 expect() calls
+Ran 24 tests across 1 file. [2.15s]

--- a/docs/tests/p-517-mcp-write-scope/witnessed-red-p2-ghost.txt
+++ b/docs/tests/p-517-mcp-write-scope/witnessed-red-p2-ghost.txt
@@ -1,0 +1,81 @@
+bun test v1.3.14 (0d9b296a)
+
+src/mcp-write-network-resolution.test.ts:
+[commhub] database: /tmp/517-p2-red.db
+[commhub] 🎉 14-day free trial started!
+[commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
+[10:03:37] u517_single → send_task → peer-517-a1: x517 g1 send_task
+[10:03:37] u517_single → send_message → peer-517-a1: x517 g1 send_message
+[10:03:37] u517_single → send_reply (replied) → peer-517-a1: x517 g1 send_reply
+[10:03:37] peer-517-a1 → ack_inbox: 8d000361
+[10:03:37] u517_single → send_ack → task 74de77bf
+[10:03:37] u517_single → retry_task → b49a67cc
+[10:03:37] u517_single → cancel_task → 8be68c81
+[10:03:37] u517_single → reassign_task → 1a95b180 → peer-517-a2
+[10:03:37] u517_multi → send_message → peer-517-a1: x517 g2 send_message
+[10:03:38] u517_multi → send_reply (replied) → peer-517-a1: x517 g2 send_reply
+[10:03:38] peer-517-a1 → ack_inbox: 47e8d3cc
+[10:03:38] u517_multi → send_ack → task 539a4a0b
+[10:03:38] u517_multi → retry_task → 3b4b4427
+[10:03:38] u517_multi → cancel_task → 3fc86f5c
+[10:03:38] u517_multi → reassign_task → 664b4be6 → peer-517-a2
+365 |   test("membership to a deleted network does not break single-network auto-resolve", async () => {
+366 |     // stale row: membership exists, networks row does not
+367 |     db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))`, [U_SINGLE, GHOST]);
+368 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+369 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 ghost still-single", priority: "normal" });
+370 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:370:18)
+(fail) ghost memberships (deleted networks) > membership to a deleted network does not break single-network auto-resolve [62.37ms]
+374 | 
+375 |   test("sole membership pointing at a deleted network → no-membership error, no orphaned write", async () => {
+376 |     db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))`, [U_NONE, GHOST]);
+377 |     const { tools } = buildHandlers({ userId: U_NONE });
+378 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 ghost orphan", priority: "normal" });
+379 |     expect(r).toEqual({
+                    ^
+error: expect(received).toEqual(expected)
+
+  {
+-   "error": "network_id_required",
+-   "message": "user token has no network memberships; join or create a network first",
++   "alias": "peer-517-a1",
++   "error": "alias_not_found",
++   "message": "alias not found: peer-517-a1",
+    "ok": false,
++   "queued": false,
+  }
+
+- Expected  - 2
++ Received  + 4
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:379:15)
+(fail) ghost memberships (deleted networks) > sole membership pointing at a deleted network → no-membership error, no orphaned write [54.64ms]
+390 |     db.run(`INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))`, [NET_DEL, U_SINGLE]);
+391 |     db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))`, [U_SINGLE, NET_DEL]);
+392 |     const res = deleteNetwork(U_SINGLE, NET_DEL);
+393 |     expect(res.ok).toBe(true);
+394 |     const left = db.get<{ cnt: number }>("SELECT COUNT(*) as cnt FROM network_members WHERE network_id = ?1", NET_DEL);
+395 |     expect(left?.cnt).toBe(0);
+                            ^
+error: expect(received).toBe(expected)
+
+Expected: 0
+Received: 1
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:395:23)
+(fail) ghost memberships (deleted networks) > deleteNetwork removes the network's membership rows (root cause) [52.47ms]
+[10:03:38] peer-517-a1 → send_task → peer-517-a2: x517 g4 ntok plain
+[10:03:38] peer-517-a1 → send_task → peer-517-a2: x517 g4 ntok override
+[10:03:39] hub → send_message → peer-517-a1: x517 g5 legacy
+
+ 24 pass
+ 3 fail
+ 54 expect() calls
+Ran 27 tests across 1 file. [2.30s]

--- a/docs/tests/p-517-mcp-write-scope/witnessed-red-pins-sabotage.txt
+++ b/docs/tests/p-517-mcp-write-scope/witnessed-red-pins-sabotage.txt
@@ -1,0 +1,331 @@
+bun test v1.3.14 (0d9b296a)
+
+src/mcp-write-network-resolution.test.ts:
+[commhub] database: /tmp/517-net-scope-sabotage.db
+[commhub] 🎉 14-day free trial started!
+[commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
+160 | // ─────────────────────────────────────────────────────────────────────
+161 | describe("utok single-network auto-resolve (no network_id argument)", () => {
+162 |   test("send_task resolves to the only membership", async () => {
+163 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+164 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 g1 send_task", priority: "normal" });
+165 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:165:18)
+(fail) utok single-network auto-resolve (no network_id argument) > send_task resolves to the only membership [73.87ms]
+167 |   });
+168 | 
+169 |   test("send_message resolves to the only membership", async () => {
+170 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+171 |     const r = await call(tools["send_message"], { alias: A1, message: "x517 g1 send_message" });
+172 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:172:18)
+(fail) utok single-network auto-resolve (no network_id argument) > send_message resolves to the only membership [65.90ms]
+175 | 
+176 |   test("send_reply resolves to the only membership", async () => {
+177 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+178 |     const t = makeTask(A1, "delivered", "x517 g1 send_reply parent");
+179 |     const r = await call(tools["send_reply"], { alias: A1, text: "x517 g1 send_reply", in_reply_to: t, status: "replied" });
+180 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:180:18)
+(fail) utok single-network auto-resolve (no network_id argument) > send_reply resolves to the only membership [75.42ms]
+183 | 
+184 |   test("ack_inbox resolves to the only membership", async () => {
+185 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+186 |     const ib = makeInbox(A1, "x517 g1 ack_inbox");
+187 |     const r = await call(tools["ack_inbox"], { alias: A1, message_id: ib });
+188 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:188:18)
+(fail) utok single-network auto-resolve (no network_id argument) > ack_inbox resolves to the only membership [76.31ms]
+191 | 
+192 |   test("send_ack resolves to the only membership", async () => {
+193 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+194 |     const t = makeTask(A1, "delivered", "x517 g1 send_ack");
+195 |     const r = await call(tools["send_ack"], { task_id: t });
+196 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:196:18)
+(fail) utok single-network auto-resolve (no network_id argument) > send_ack resolves to the only membership [74.06ms]
+199 | 
+200 |   test("retry_task resolves to the only membership", async () => {
+201 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+202 |     const t = makeTask(A1, "failed", "x517 g1 retry_task");
+203 |     const r = await call(tools["retry_task"], { task_id: t });
+204 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:204:18)
+(fail) utok single-network auto-resolve (no network_id argument) > retry_task resolves to the only membership [88.04ms]
+207 | 
+208 |   test("cancel_task resolves to the only membership", async () => {
+209 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+210 |     const t = makeTask(A1, "delivered", "x517 g1 cancel_task");
+211 |     const r = await call(tools["cancel_task"], { task_id: t });
+212 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:212:18)
+(fail) utok single-network auto-resolve (no network_id argument) > cancel_task resolves to the only membership [63.18ms]
+215 | 
+216 |   test("reassign_task resolves to the only membership", async () => {
+217 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+218 |     const t = makeTask(A1, "delivered", "x517 g1 reassign_task");
+219 |     const r = await call(tools["reassign_task"], { task_id: t, new_alias: A2 });
+220 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:220:18)
+(fail) utok single-network auto-resolve (no network_id argument) > reassign_task resolves to the only membership [63.52ms]
+242 |   });
+243 | 
+244 |   test("send_message threads explicit network_id", async () => {
+245 |     const { tools } = buildHandlers({ userId: U_MULTI });
+246 |     const r = await call(tools["send_message"], { alias: A1, message: "x517 g2 send_message", network_id: NET_A });
+247 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:247:18)
+(fail) utok multi-network > send_message threads explicit network_id [59.15ms]
+250 | 
+251 |   test("send_reply threads explicit network_id", async () => {
+252 |     const { tools } = buildHandlers({ userId: U_MULTI });
+253 |     const t = makeTask(A1, "delivered", "x517 g2 send_reply parent");
+254 |     const r = await call(tools["send_reply"], { alias: A1, text: "x517 g2 send_reply", in_reply_to: t, status: "replied", network_id: NET_A });
+255 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:255:18)
+(fail) utok multi-network > send_reply threads explicit network_id [69.18ms]
+258 | 
+259 |   test("ack_inbox threads explicit network_id", async () => {
+260 |     const { tools } = buildHandlers({ userId: U_MULTI });
+261 |     const ib = makeInbox(A1, "x517 g2 ack_inbox");
+262 |     const r = await call(tools["ack_inbox"], { alias: A1, message_id: ib, network_id: NET_A });
+263 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:263:18)
+(fail) utok multi-network > ack_inbox threads explicit network_id [65.78ms]
+266 | 
+267 |   test("send_ack threads explicit network_id", async () => {
+268 |     const { tools } = buildHandlers({ userId: U_MULTI });
+269 |     const t = makeTask(A1, "delivered", "x517 g2 send_ack");
+270 |     const r = await call(tools["send_ack"], { task_id: t, network_id: NET_A });
+271 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:271:18)
+(fail) utok multi-network > send_ack threads explicit network_id [82.21ms]
+274 | 
+275 |   test("retry_task threads explicit network_id", async () => {
+276 |     const { tools } = buildHandlers({ userId: U_MULTI });
+277 |     const t = makeTask(A1, "failed", "x517 g2 retry_task");
+278 |     const r = await call(tools["retry_task"], { task_id: t, network_id: NET_A });
+279 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:279:18)
+(fail) utok multi-network > retry_task threads explicit network_id [64.65ms]
+282 | 
+283 |   test("cancel_task threads explicit network_id", async () => {
+284 |     const { tools } = buildHandlers({ userId: U_MULTI });
+285 |     const t = makeTask(A1, "delivered", "x517 g2 cancel_task");
+286 |     const r = await call(tools["cancel_task"], { task_id: t, network_id: NET_A });
+287 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:287:18)
+(fail) utok multi-network > cancel_task threads explicit network_id [67.04ms]
+290 | 
+291 |   test("reassign_task threads explicit network_id", async () => {
+292 |     const { tools } = buildHandlers({ userId: U_MULTI });
+293 |     const t = makeTask(A1, "delivered", "x517 g2 reassign_task");
+294 |     const r = await call(tools["reassign_task"], { task_id: t, new_alias: A2, network_id: NET_A });
+295 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:295:18)
+(fail) utok multi-network > reassign_task threads explicit network_id [65.19ms]
+319 |   });
+320 | 
+321 |   test("utok explicitly targeting a network it is not a member of → access_denied", async () => {
+322 |     const { tools } = buildHandlers({ userId: U_OUTSIDER });
+323 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 g3 outsider", priority: "normal", network_id: NET_A });
+324 |     expect(r).toEqual({
+                    ^
+error: expect(received).toEqual(expected)
+
+@@ -1,4 +1,4 @@
+  {
+-   "error": "access_denied",
+-   "message": "access denied to requested network (not a member)",
++   "error": "network_id_required",
++   "message": "user token spans 1 networks; pass network_id explicitly (see /api/auth/me networks[].network_id)",
+    "ok": false,
+
+- Expected  - 2
++ Received  + 2
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:324:15)
+(fail) precise denial causes > utok explicitly targeting a network it is not a member of → access_denied [62.83ms]
+330 |   });
+331 | 
+332 |   test("viewer in a single network → permission_denied (send_task wording)", async () => {
+333 |     const { tools } = buildHandlers({ userId: U_VIEWER });
+334 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 g3 viewer task", priority: "normal" });
+335 |     expect(r).toEqual({
+                    ^
+error: expect(received).toEqual(expected)
+
+@@ -1,4 +1,4 @@
+  {
+-   "error": "permission_denied",
+-   "message": "Viewer role cannot send tasks",
++   "error": "network_id_required",
++   "message": "user token spans 1 networks; pass network_id explicitly (see /api/auth/me networks[].network_id)",
+    "ok": false,
+
+- Expected  - 2
++ Received  + 2
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:335:15)
+(fail) precise denial causes > viewer in a single network → permission_denied (send_task wording) [64.50ms]
+340 |   });
+341 | 
+342 |   test("viewer in a single network → permission_denied (generic write wording)", async () => {
+343 |     const { tools } = buildHandlers({ userId: U_VIEWER });
+344 |     const r = await call(tools["send_message"], { alias: A1, message: "x517 g3 viewer msg" });
+345 |     expect(r).toEqual({
+                    ^
+error: expect(received).toEqual(expected)
+
+@@ -1,4 +1,4 @@
+  {
+-   "error": "permission_denied",
+-   "message": "Viewer role cannot write to this network",
++   "error": "network_id_required",
++   "message": "user token spans 1 networks; pass network_id explicitly (see /api/auth/me networks[].network_id)",
+    "ok": false,
+
+- Expected  - 2
++ Received  + 2
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:345:15)
+(fail) precise denial causes > viewer in a single network → permission_denied (generic write wording) [50.45ms]
+[08:56:31] peer-517-a1 → send_task → peer-517-a2: x517 g4 ntok plain
+356 | describe("ntok behavior pinned (zero change)", () => {
+357 |   test("ntok send_task without network_id stays bound to token network", async () => {
+358 |     const { tools } = buildHandlers({ netId: NET_A, userId: U_SINGLE, alias: A1, isNetwork: true });
+359 |     const r = await call(tools["send_task"], { alias: A2, task: "x517 g4 ntok plain", priority: "normal" });
+360 |     expect(r.ok).toBe(true);
+361 |     expect(taskRow("x517 g4 ntok plain")?.network_id).toBe(NET_A);
+                                                            ^
+error: expect(received).toBe(expected)
+
+Expected: "net_517_a"
+Received: null
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:361:55)
+(fail) ntok behavior pinned (zero change) > ntok send_task without network_id stays bound to token network [64.34ms]
+[08:56:32] peer-517-a1 → send_task → peer-517-a2: x517 g4 ntok override
+363 | 
+364 |   test("ntok send_task ignores a client-supplied foreign network_id (enforced binding wins)", async () => {
+365 |     const { tools } = buildHandlers({ netId: NET_A, userId: U_MULTI, alias: A1, isNetwork: true });
+366 |     const r = await call(tools["send_task"], { alias: A2, task: "x517 g4 ntok override", priority: "normal", network_id: NET_B });
+367 |     expect(r.ok).toBe(true);
+368 |     expect(taskRow("x517 g4 ntok override")?.network_id).toBe(NET_A);
+                                                               ^
+error: expect(received).toBe(expected)
+
+Expected: "net_517_a"
+Received: null
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:368:58)
+(fail) ntok behavior pinned (zero change) > ntok send_task ignores a client-supplied foreign network_id (enforced binding wins) [75.24ms]
+375 | // ─────────────────────────────────────────────────────────────────────
+376 | describe("legacy global-token mode pinned", () => {
+377 |   test("send_message without auth context stays network-unscoped", async () => {
+378 |     const { tools } = buildHandlers({ userId: null });
+379 |     const r = await call(tools["send_message"], { alias: A1, message: "x517 g5 legacy" });
+380 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:380:18)
+(fail) legacy global-token mode pinned > send_message without auth context stays network-unscoped [57.36ms]
+
+ 3 pass
+ 21 fail
+ 33 expect() calls
+Ran 24 tests across 1 file. [2.06s]

--- a/docs/tests/p-517-mcp-write-scope/witnessed-red.txt
+++ b/docs/tests/p-517-mcp-write-scope/witnessed-red.txt
@@ -1,0 +1,343 @@
+bun test v1.3.14 (0d9b296a)
+
+src/mcp-write-network-resolution.test.ts:
+[commhub] database: /tmp/517-net-scope-red.db
+[commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
+160 | // ─────────────────────────────────────────────────────────────────────
+161 | describe("utok single-network auto-resolve (no network_id argument)", () => {
+162 |   test("send_task resolves to the only membership", async () => {
+163 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+164 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 g1 send_task", priority: "normal" });
+165 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:165:18)
+(fail) utok single-network auto-resolve (no network_id argument) > send_task resolves to the only membership [76.90ms]
+167 |   });
+168 | 
+169 |   test("send_message resolves to the only membership", async () => {
+170 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+171 |     const r = await call(tools["send_message"], { alias: A1, message: "x517 g1 send_message" });
+172 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:172:18)
+(fail) utok single-network auto-resolve (no network_id argument) > send_message resolves to the only membership [66.48ms]
+175 | 
+176 |   test("send_reply resolves to the only membership", async () => {
+177 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+178 |     const t = makeTask(A1, "delivered", "x517 g1 send_reply parent");
+179 |     const r = await call(tools["send_reply"], { alias: A1, text: "x517 g1 send_reply", in_reply_to: t, status: "replied" });
+180 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:180:18)
+(fail) utok single-network auto-resolve (no network_id argument) > send_reply resolves to the only membership [71.64ms]
+183 | 
+184 |   test("ack_inbox resolves to the only membership", async () => {
+185 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+186 |     const ib = makeInbox(A1, "x517 g1 ack_inbox");
+187 |     const r = await call(tools["ack_inbox"], { alias: A1, message_id: ib });
+188 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:188:18)
+(fail) utok single-network auto-resolve (no network_id argument) > ack_inbox resolves to the only membership [78.47ms]
+191 | 
+192 |   test("send_ack resolves to the only membership", async () => {
+193 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+194 |     const t = makeTask(A1, "delivered", "x517 g1 send_ack");
+195 |     const r = await call(tools["send_ack"], { task_id: t });
+196 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:196:18)
+(fail) utok single-network auto-resolve (no network_id argument) > send_ack resolves to the only membership [71.62ms]
+199 | 
+200 |   test("retry_task resolves to the only membership", async () => {
+201 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+202 |     const t = makeTask(A1, "failed", "x517 g1 retry_task");
+203 |     const r = await call(tools["retry_task"], { task_id: t });
+204 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:204:18)
+(fail) utok single-network auto-resolve (no network_id argument) > retry_task resolves to the only membership [66.72ms]
+207 | 
+208 |   test("cancel_task resolves to the only membership", async () => {
+209 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+210 |     const t = makeTask(A1, "delivered", "x517 g1 cancel_task");
+211 |     const r = await call(tools["cancel_task"], { task_id: t });
+212 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:212:18)
+(fail) utok single-network auto-resolve (no network_id argument) > cancel_task resolves to the only membership [75.25ms]
+215 | 
+216 |   test("reassign_task resolves to the only membership", async () => {
+217 |     const { tools } = buildHandlers({ userId: U_SINGLE });
+218 |     const t = makeTask(A1, "delivered", "x517 g1 reassign_task");
+219 |     const r = await call(tools["reassign_task"], { task_id: t, new_alias: A2 });
+220 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:220:18)
+(fail) utok single-network auto-resolve (no network_id argument) > reassign_task resolves to the only membership [66.84ms]
+231 | // ─────────────────────────────────────────────────────────────────────
+232 | describe("utok multi-network", () => {
+233 |   test("send_task without network_id → exact network_id_required error", async () => {
+234 |     const { tools } = buildHandlers({ userId: U_MULTI });
+235 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 g2 ambiguous", priority: "normal" });
+236 |     expect(r).toEqual({
+                    ^
+error: expect(received).toEqual(expected)
+
+@@ -1,4 +1,4 @@
+  {
+-   "error": "network_id_required",
+-   "message": "user token spans 2 networks; pass network_id explicitly (see /api/auth/me networks[].network_id)",
++   "error": "permission_denied",
++   "message": "network_id required (utok current_network is null; pass explicit network_id from /api/auth/me networks[0].network_id)",
+    "ok": false,
+
+- Expected  - 2
++ Received  + 2
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:236:15)
+(fail) utok multi-network > send_task without network_id → exact network_id_required error [64.80ms]
+242 |   });
+243 | 
+244 |   test("send_message threads explicit network_id", async () => {
+245 |     const { tools } = buildHandlers({ userId: U_MULTI });
+246 |     const r = await call(tools["send_message"], { alias: A1, message: "x517 g2 send_message", network_id: NET_A });
+247 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:247:18)
+(fail) utok multi-network > send_message threads explicit network_id [58.95ms]
+250 | 
+251 |   test("send_reply threads explicit network_id", async () => {
+252 |     const { tools } = buildHandlers({ userId: U_MULTI });
+253 |     const t = makeTask(A1, "delivered", "x517 g2 send_reply parent");
+254 |     const r = await call(tools["send_reply"], { alias: A1, text: "x517 g2 send_reply", in_reply_to: t, status: "replied", network_id: NET_A });
+255 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:255:18)
+(fail) utok multi-network > send_reply threads explicit network_id [56.59ms]
+258 | 
+259 |   test("ack_inbox threads explicit network_id", async () => {
+260 |     const { tools } = buildHandlers({ userId: U_MULTI });
+261 |     const ib = makeInbox(A1, "x517 g2 ack_inbox");
+262 |     const r = await call(tools["ack_inbox"], { alias: A1, message_id: ib, network_id: NET_A });
+263 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:263:18)
+(fail) utok multi-network > ack_inbox threads explicit network_id [61.30ms]
+266 | 
+267 |   test("send_ack threads explicit network_id", async () => {
+268 |     const { tools } = buildHandlers({ userId: U_MULTI });
+269 |     const t = makeTask(A1, "delivered", "x517 g2 send_ack");
+270 |     const r = await call(tools["send_ack"], { task_id: t, network_id: NET_A });
+271 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:271:18)
+(fail) utok multi-network > send_ack threads explicit network_id [69.47ms]
+274 | 
+275 |   test("retry_task threads explicit network_id", async () => {
+276 |     const { tools } = buildHandlers({ userId: U_MULTI });
+277 |     const t = makeTask(A1, "failed", "x517 g2 retry_task");
+278 |     const r = await call(tools["retry_task"], { task_id: t, network_id: NET_A });
+279 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:279:18)
+(fail) utok multi-network > retry_task threads explicit network_id [105.94ms]
+282 | 
+283 |   test("cancel_task threads explicit network_id", async () => {
+284 |     const { tools } = buildHandlers({ userId: U_MULTI });
+285 |     const t = makeTask(A1, "delivered", "x517 g2 cancel_task");
+286 |     const r = await call(tools["cancel_task"], { task_id: t, network_id: NET_A });
+287 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:287:18)
+(fail) utok multi-network > cancel_task threads explicit network_id [75.31ms]
+290 | 
+291 |   test("reassign_task threads explicit network_id", async () => {
+292 |     const { tools } = buildHandlers({ userId: U_MULTI });
+293 |     const t = makeTask(A1, "delivered", "x517 g2 reassign_task");
+294 |     const r = await call(tools["reassign_task"], { task_id: t, new_alias: A2, network_id: NET_A });
+295 |     expect(r.ok).toBe(true);
+                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:295:18)
+(fail) utok multi-network > reassign_task threads explicit network_id [90.83ms]
+297 |   });
+298 | 
+299 |   test("all 7 formerly param-less write tools expose network_id in their input schema", () => {
+300 |     const { schemas } = buildHandlers({ userId: U_MULTI });
+301 |     for (const name of ["send_message", "send_reply", "ack_inbox", "send_ack", "retry_task", "cancel_task", "reassign_task"]) {
+302 |       expect(Object.keys(schemas[name] ?? {})).toContain("network_id");
+                                                     ^
+error: expect(received).toContain(expected)
+
+Expected to contain: "network_id"
+Received: [ "alias", "message", "from_session" ]
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:302:48)
+(fail) utok multi-network > all 7 formerly param-less write tools expose network_id in their input schema [70.48ms]
+309 | // ─────────────────────────────────────────────────────────────────────
+310 | describe("precise denial causes", () => {
+311 |   test("utok with zero memberships → network_id_required naming the real cause", async () => {
+312 |     const { tools } = buildHandlers({ userId: U_NONE });
+313 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 g3 none", priority: "normal" });
+314 |     expect(r).toEqual({
+                    ^
+error: expect(received).toEqual(expected)
+
+@@ -1,4 +1,4 @@
+  {
+-   "error": "network_id_required",
+-   "message": "user token has no network memberships; join or create a network first",
++   "error": "permission_denied",
++   "message": "network_id required (utok current_network is null; pass explicit network_id from /api/auth/me networks[0].network_id)",
+    "ok": false,
+
+- Expected  - 2
++ Received  + 2
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:314:15)
+(fail) precise denial causes > utok with zero memberships → network_id_required naming the real cause [72.82ms]
+319 |   });
+320 | 
+321 |   test("utok explicitly targeting a network it is not a member of → access_denied", async () => {
+322 |     const { tools } = buildHandlers({ userId: U_OUTSIDER });
+323 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 g3 outsider", priority: "normal", network_id: NET_A });
+324 |     expect(r).toEqual({
+                    ^
+error: expect(received).toEqual(expected)
+
+@@ -1,4 +1,4 @@
+  {
+-   "error": "access_denied",
+-   "message": "access denied to requested network (not a member)",
++   "error": "permission_denied",
++   "message": "Viewer role cannot send tasks",
+    "ok": false,
+
+- Expected  - 2
++ Received  + 2
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:324:15)
+(fail) precise denial causes > utok explicitly targeting a network it is not a member of → access_denied [69.98ms]
+330 |   });
+331 | 
+332 |   test("viewer in a single network → permission_denied (send_task wording)", async () => {
+333 |     const { tools } = buildHandlers({ userId: U_VIEWER });
+334 |     const r = await call(tools["send_task"], { alias: A1, task: "x517 g3 viewer task", priority: "normal" });
+335 |     expect(r).toEqual({
+                    ^
+error: expect(received).toEqual(expected)
+
+@@ -2,3 +2,3 @@
+    "error": "permission_denied",
+-   "message": "Viewer role cannot send tasks",
++   "message": "network_id required (utok current_network is null; pass explicit network_id from /api/auth/me networks[0].network_id)",
+    "ok": false,
+
+- Expected  - 1
++ Received  + 1
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:335:15)
+(fail) precise denial causes > viewer in a single network → permission_denied (send_task wording) [75.32ms]
+340 |   });
+341 | 
+342 |   test("viewer in a single network → permission_denied (generic write wording)", async () => {
+343 |     const { tools } = buildHandlers({ userId: U_VIEWER });
+344 |     const r = await call(tools["send_message"], { alias: A1, message: "x517 g3 viewer msg" });
+345 |     expect(r).toEqual({
+                    ^
+error: expect(received).toEqual(expected)
+
+@@ -2,3 +2,3 @@
+    "error": "permission_denied",
+-   "message": "Viewer role cannot write to this network",
++   "message": "network_id required (utok current_network is null; pass explicit network_id from /api/auth/me networks[0].network_id)",
+    "ok": false,
+
+- Expected  - 1
++ Received  + 1
+
+      at <anonymous> (/home/vansin/anet-work/fix-517-net-scope/server/src/mcp-write-network-resolution.test.ts:345:15)
+(fail) precise denial causes > viewer in a single network → permission_denied (generic write wording) [57.21ms]
+[08:51:05] peer-517-a1 → send_task → peer-517-a2: x517 g4 ntok plain
+[08:51:05] peer-517-a1 → send_task → peer-517-a2: x517 g4 ntok override
+[08:51:05] hub → send_message → peer-517-a1: x517 g5 legacy
+
+ 3 pass
+ 21 fail
+ 27 expect() calls
+Ran 24 tests across 1 file. [1.93s]

--- a/docs/tests/report-qa-517-red-baseline.txt
+++ b/docs/tests/report-qa-517-red-baseline.txt
@@ -1,0 +1,45 @@
+
+=== L0 env — hub boot ===
+  ✓ hub /health 200 :9251
+
+=== L1 auth — utok with current_network=null (the #517 precondition) ===
+  ✓ login issues utok_ token
+  ✓ register auto-created default network (net_3e288131b42a)
+  ✓ utok current_network is null (issue precondition)
+
+=== L2 seed — target agent session inside net_3e288131b42a (direct sqlite, no prod) ===
+  ✓ seeded node+session peer-517-e2e in net_3e288131b42a
+
+=== L3 single-network utok writes WITHOUT network_id (the fix) ===
+  ✗ S1 send_task ok — got [false] want [true]
+  ✗ S2 task row scoped to net_3e288131b42a — got [] want [net_3e288131b42a]
+  ✗ S3 send_message ok (tool previously had NO network_id input) — got [false] want [true]
+
+=== L4 multi-network utok — ambiguous without, explicit works ===
+  ✓ created second network (net_ad52ecfb3ba5)
+  ✗ S4 error — got [permission_denied] want [network_id_required]
+  ✗ S4 message — got [network_id required (utok current_network is null; pass explicit network_id from /api/auth/me networks[0].network_id)] want [user token spans 2 networks; pass network_id explicitly (see /api/auth/me networks[].network_id)]
+  ✓ S5 explicit network_id ok
+
+=== L5 deleted network — membership cleanup restores auto-resolve ===
+  ✓ delete second network
+  ✗ S6 auto-resolve works again after delete (no ghost membership) — got [false] want [true]
+
+=== L6 viewer role — resolves, then role-denied with viewer wording ===
+  ✓ viewer joined net_3e288131b42a via invite
+  ✓ S7 error
+  ✗ S7 message — got [network_id required (utok current_network is null; pass explicit network_id from /api/auth/me networks[0].network_id)] want [Viewer role cannot send tasks]
+
+=== L7 outsider — explicit foreign network_id ===
+  ✗ S8 error — got [permission_denied] want [access_denied]
+  ✗ S8 message — got [Viewer role cannot send tasks] want [access denied to requested network (not a member)]
+
+=== L8 zero memberships — after deleting own default network ===
+  ✗ S9 error — got [permission_denied] want [network_id_required]
+  ✗ S9 message — got [network_id required (utok current_network is null; pass explicit network_id from /api/auth/me networks[0].network_id)] want [user token has no network memberships; join or create a network first]
+  ✓ S9 no orphaned task row written
+
+=== result ===
+
+PASS=11 FAIL=11
+QA-517 FAILED

--- a/docs/tests/report-qa-517.txt
+++ b/docs/tests/report-qa-517.txt
@@ -1,0 +1,45 @@
+
+=== L0 env — hub boot ===
+  ✓ hub /health 200 :9251
+
+=== L1 auth — utok with current_network=null (the #517 precondition) ===
+  ✓ login issues utok_ token
+  ✓ register auto-created default network (net_b2dbc90b54d0)
+  ✓ utok current_network is null (issue precondition)
+
+=== L2 seed — target agent session inside net_b2dbc90b54d0 (direct sqlite, no prod) ===
+  ✓ seeded node+session peer-517-e2e in net_b2dbc90b54d0
+
+=== L3 single-network utok writes WITHOUT network_id (the fix) ===
+  ✓ S1 send_task ok
+  ✓ S2 task row scoped to net_b2dbc90b54d0
+  ✓ S3 send_message ok (tool previously had NO network_id input)
+
+=== L4 multi-network utok — ambiguous without, explicit works ===
+  ✓ created second network (net_2ae8961d54a5)
+  ✓ S4 error
+  ✓ S4 message
+  ✓ S5 explicit network_id ok
+
+=== L5 deleted network — membership cleanup restores auto-resolve ===
+  ✓ delete second network
+  ✓ S6 auto-resolve works again after delete (no ghost membership)
+
+=== L6 viewer role — resolves, then role-denied with viewer wording ===
+  ✓ viewer joined net_b2dbc90b54d0 via invite
+  ✓ S7 error
+  ✓ S7 message
+
+=== L7 outsider — explicit foreign network_id ===
+  ✓ S8 error
+  ✓ S8 message
+
+=== L8 zero memberships — after deleting own default network ===
+  ✓ S9 error
+  ✓ S9 message
+  ✓ S9 no orphaned task row written
+
+=== result ===
+
+PASS=22 FAIL=0
+QA-517 ALL PASS

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -297,6 +297,11 @@ export function deleteNetwork(userId: string, networkId: string): { ok: boolean;
   const sessions = db.get<{ cnt: number }>("SELECT COUNT(*) as cnt FROM sessions WHERE network_id = ?1", networkId);
   if (sessions && sessions.cnt > 0) return { ok: false, error: `network has ${sessions.cnt} active session(s) — stop them first` };
   db.run("DELETE FROM networks WHERE network_id = ?1 AND owner_id = ?2", [networkId, userId]);
+  // PR #519 codex catch: leaving membership rows behind made deleted
+  // networks count toward getUserNetworkIds — a stale row could flip a
+  // single-network user to "ambiguous" or auto-resolve writes INTO the
+  // deleted network. Remove memberships with the network.
+  db.run("DELETE FROM network_members WHERE network_id = ?1", [networkId]);
   return { ok: true };
 }
 

--- a/server/src/mcp-write-network-resolution.test.ts
+++ b/server/src/mcp-write-network-resolution.test.ts
@@ -1,0 +1,383 @@
+// #517 — MCP write-path network resolution (utok single-network fallback).
+//
+// Root cause (issue #517): utok_ token rows are created with network_id=null
+// BY DESIGN (auth.ts login), and the MCP write path (tools.ts canWrite) had
+// no single-network fallback — unlike REST POST /api/task (server.ts), which
+// auto-resolves via singleNetworkId(restScope) when the user belongs to
+// exactly one network. Result: a utok node could READ everything
+// (resolveReadScope falls back to all memberships) but could not WRITE
+// anything, and the error mislabeled the failure as permission_denied.
+//
+// Fix under test:
+//  - getNetworkId falls back to the user's single membership via the SAME
+//    shared singleNetworkId/getUserNetworkIds used by REST (network-scope.ts)
+//  - canWrite delegates to the shared canRestWriteNetwork
+//  - the 7 write tools that had NO network_id input gain an optional one:
+//    send_message / send_reply / ack_inbox / send_ack / retry_task /
+//    cancel_task / reassign_task
+//  - writeDeniedReply names the REAL cause: network_id_required (0 or ≥2
+//    memberships) / access_denied (not a member of the requested network) /
+//    permission_denied (viewer role)
+//  - ntok_ (network-bound) behavior: ZERO change — pinned below
+//
+// Assertion discipline: error replies are asserted with toEqual (accepted
+// set == spec-allowed set, no not.toBe / toContain wideners).
+//
+// Run: COMMHUB_DB=/tmp/517-net-scope-test.db bun test src/mcp-write-network-resolution.test.ts
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { db, uuidv4 } from "./db.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "./tools.js";
+
+const NET_A = "net_517_a";
+const NET_B = "net_517_b";
+const U_SINGLE = "u517_single";    // owner of NET_A only → fallback resolves
+const U_MULTI = "u517_multi";      // member of NET_A + NET_B → ambiguous
+const U_VIEWER = "u517_viewer";    // viewer of NET_A only → resolves, then role-denied
+const U_NONE = "u517_none";        // no memberships
+const U_OUTSIDER = "u517_outsider"; // member of NET_B only, targets NET_A
+const A1 = "peer-517-a1";
+const A2 = "peer-517-a2";
+const ALL_USERS = [U_SINGLE, U_MULTI, U_VIEWER, U_NONE, U_OUTSIDER];
+
+interface ToolHandler {
+  (args: any, extra?: any): Promise<{ content: Array<{ type: "text"; text: string }> }>;
+}
+interface Reply { ok?: boolean; error?: string; message?: string; [k: string]: unknown }
+
+function cleanup() {
+  for (const t of ["tasks", "inbox", "task_events"]) {
+    try { db.run(`DELETE FROM ${t} WHERE network_id IN (?1, ?2)`, [NET_A, NET_B]); } catch {}
+    try { db.run(`DELETE FROM ${t} WHERE content LIKE 'x517%'`); } catch {}
+  }
+  try { db.run("DELETE FROM sessions WHERE network_id IN (?1, ?2)", [NET_A, NET_B]); } catch {}
+  try { db.run("DELETE FROM nodes WHERE network_id IN (?1, ?2)", [NET_A, NET_B]); } catch {}
+  try { db.run("DELETE FROM network_members WHERE network_id IN (?1, ?2)", [NET_A, NET_B]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id IN (?1, ?2)", [NET_A, NET_B]); } catch {}
+  for (const u of ALL_USERS) {
+    try { db.run("DELETE FROM users WHERE user_id = ?1", [u]); } catch {}
+  }
+}
+
+function seed() {
+  for (const u of ALL_USERS) {
+    db.run(
+      `INSERT INTO users (user_id, username, password_hash, role, created_at)
+       VALUES (?1, ?2, 'x', 'user', datetime('now'))`,
+      [u, u],
+    );
+  }
+  db.run(`INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))`, [NET_A, U_SINGLE]);
+  db.run(`INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))`, [NET_B, U_MULTI]);
+  const member = (u: string, net: string, role: string) =>
+    db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, ?3, datetime('now'))`, [u, net, role]);
+  member(U_SINGLE, NET_A, "owner");
+  member(U_MULTI, NET_A, "member");
+  member(U_MULTI, NET_B, "owner");
+  member(U_VIEWER, NET_A, "viewer");
+  member(U_OUTSIDER, NET_B, "member");
+  for (const alias of [A1, A2]) {
+    db.run(
+      `INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state)
+       VALUES (?1, ?2, ?2, ?3, ?4, datetime('now'), datetime('now'), 'active')`,
+      [`node_${alias}`, alias, NET_A, `host-${alias}`],
+    );
+    db.run(
+      `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+       VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))`,
+      [`res_${alias}`, alias, `node_${alias}`, NET_A],
+    );
+  }
+}
+
+beforeEach(() => { cleanup(); seed(); });
+afterAll(cleanup);
+
+type HandlerMap = { tools: Record<string, ToolHandler>; schemas: Record<string, Record<string, unknown>> };
+
+function buildHandlers(opts: { netId?: string | null; userId?: string | null; alias?: string | null; isNetwork?: boolean }): HandlerMap {
+  const server = new McpServer({ name: "test", version: "0" }) as any;
+  const tools: Record<string, ToolHandler> = {};
+  const schemas: Record<string, Record<string, unknown>> = {};
+  const origTool = server.tool.bind(server);
+  server.tool = (name: string, _desc: string, schema: any, handler: ToolHandler) => {
+    tools[name] = handler;
+    schemas[name] = schema;
+    return origTool(name, _desc, schema, handler);
+  };
+  registerTools(
+    server,
+    undefined,
+    opts.netId ?? null,
+    opts.userId ?? null,
+    opts.alias ?? opts.userId ?? null,
+    opts.isNetwork ?? false,
+    null,
+  );
+  return { tools, schemas };
+}
+
+async function call(handler: ToolHandler, args: any): Promise<Reply> {
+  const r = await handler(args);
+  return JSON.parse(r.content[0].text) as Reply;
+}
+
+function makeTask(to: string, status: string, content: string, net: string | null = NET_A): string {
+  const id = uuidv4();
+  db.run(
+    `INSERT INTO tasks (task_id, from_name, to_name, priority, status, content, requires_response, created_at, network_id)
+     VALUES (?1, 'dispatcher', ?2, 'normal', ?3, ?4, 'reply', datetime('now'), ?5)`,
+    [id, to, status, content, net],
+  );
+  return id;
+}
+
+function makeInbox(to: string, content: string, net: string | null = NET_A): string {
+  const id = uuidv4();
+  db.run(
+    `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, network_id)
+     VALUES (?1, ?2, ?3, 'message', 'normal', ?4, 'dispatcher', ?5)`,
+    [id, to, `node_${to}`, content, net],
+  );
+  return id;
+}
+
+const taskRow = (content: string) =>
+  db.get<{ task_id: string; status: string; to_name: string; network_id: string | null }>(
+    "SELECT task_id, status, to_name, network_id FROM tasks WHERE content = ?1", content);
+const taskById = (id: string) =>
+  db.get<{ status: string; to_name: string; network_id: string | null }>(
+    "SELECT status, to_name, network_id FROM tasks WHERE task_id = ?1", id);
+const inboxRow = (content: string) =>
+  db.get<{ id: string; acked: number; network_id: string | null }>(
+    "SELECT id, acked, network_id FROM inbox WHERE content = ?1", content);
+
+// ─────────────────────────────────────────────────────────────────────
+// Group 1 — utok, single network, NO network_id argument anywhere.
+// The hub must auto-resolve to the user's only membership (REST parity
+// with server.ts POST /api/task → singleNetworkId fallback).
+// ─────────────────────────────────────────────────────────────────────
+describe("utok single-network auto-resolve (no network_id argument)", () => {
+  test("send_task resolves to the only membership", async () => {
+    const { tools } = buildHandlers({ userId: U_SINGLE });
+    const r = await call(tools["send_task"], { alias: A1, task: "x517 g1 send_task", priority: "normal" });
+    expect(r.ok).toBe(true);
+    expect(taskRow("x517 g1 send_task")?.network_id).toBe(NET_A);
+  });
+
+  test("send_message resolves to the only membership", async () => {
+    const { tools } = buildHandlers({ userId: U_SINGLE });
+    const r = await call(tools["send_message"], { alias: A1, message: "x517 g1 send_message" });
+    expect(r.ok).toBe(true);
+    expect(inboxRow("x517 g1 send_message")?.network_id).toBe(NET_A);
+  });
+
+  test("send_reply resolves to the only membership", async () => {
+    const { tools } = buildHandlers({ userId: U_SINGLE });
+    const t = makeTask(A1, "delivered", "x517 g1 send_reply parent");
+    const r = await call(tools["send_reply"], { alias: A1, text: "x517 g1 send_reply", in_reply_to: t, status: "replied" });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.status).toBe("replied");
+  });
+
+  test("ack_inbox resolves to the only membership", async () => {
+    const { tools } = buildHandlers({ userId: U_SINGLE });
+    const ib = makeInbox(A1, "x517 g1 ack_inbox");
+    const r = await call(tools["ack_inbox"], { alias: A1, message_id: ib });
+    expect(r.ok).toBe(true);
+    expect(inboxRow("x517 g1 ack_inbox")?.acked).toBe(1);
+  });
+
+  test("send_ack resolves to the only membership", async () => {
+    const { tools } = buildHandlers({ userId: U_SINGLE });
+    const t = makeTask(A1, "delivered", "x517 g1 send_ack");
+    const r = await call(tools["send_ack"], { task_id: t });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.status).toBe("acked");
+  });
+
+  test("retry_task resolves to the only membership", async () => {
+    const { tools } = buildHandlers({ userId: U_SINGLE });
+    const t = makeTask(A1, "failed", "x517 g1 retry_task");
+    const r = await call(tools["retry_task"], { task_id: t });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.status).toBe("delivered");
+  });
+
+  test("cancel_task resolves to the only membership", async () => {
+    const { tools } = buildHandlers({ userId: U_SINGLE });
+    const t = makeTask(A1, "delivered", "x517 g1 cancel_task");
+    const r = await call(tools["cancel_task"], { task_id: t });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.status).toBe("cancelled");
+  });
+
+  test("reassign_task resolves to the only membership", async () => {
+    const { tools } = buildHandlers({ userId: U_SINGLE });
+    const t = makeTask(A1, "delivered", "x517 g1 reassign_task");
+    const r = await call(tools["reassign_task"], { task_id: t, new_alias: A2 });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.to_name).toBe(A2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Group 2 — utok, MULTI network. Without network_id: precise
+// network_id_required error (not permission_denied). With explicit
+// network_id: every formerly param-less tool must thread it through.
+// One case per changed tool (通信龙 acceptance rule: 改了三个只测一个,
+// 剩下两个等于没验).
+// ─────────────────────────────────────────────────────────────────────
+describe("utok multi-network", () => {
+  test("send_task without network_id → exact network_id_required error", async () => {
+    const { tools } = buildHandlers({ userId: U_MULTI });
+    const r = await call(tools["send_task"], { alias: A1, task: "x517 g2 ambiguous", priority: "normal" });
+    expect(r).toEqual({
+      ok: false,
+      error: "network_id_required",
+      message: "user token spans 2 networks; pass network_id explicitly (see /api/auth/me networks[].network_id)",
+    });
+    expect(taskRow("x517 g2 ambiguous")).toBeNull();
+  });
+
+  test("send_message threads explicit network_id", async () => {
+    const { tools } = buildHandlers({ userId: U_MULTI });
+    const r = await call(tools["send_message"], { alias: A1, message: "x517 g2 send_message", network_id: NET_A });
+    expect(r.ok).toBe(true);
+    expect(inboxRow("x517 g2 send_message")?.network_id).toBe(NET_A);
+  });
+
+  test("send_reply threads explicit network_id", async () => {
+    const { tools } = buildHandlers({ userId: U_MULTI });
+    const t = makeTask(A1, "delivered", "x517 g2 send_reply parent");
+    const r = await call(tools["send_reply"], { alias: A1, text: "x517 g2 send_reply", in_reply_to: t, status: "replied", network_id: NET_A });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.status).toBe("replied");
+  });
+
+  test("ack_inbox threads explicit network_id", async () => {
+    const { tools } = buildHandlers({ userId: U_MULTI });
+    const ib = makeInbox(A1, "x517 g2 ack_inbox");
+    const r = await call(tools["ack_inbox"], { alias: A1, message_id: ib, network_id: NET_A });
+    expect(r.ok).toBe(true);
+    expect(inboxRow("x517 g2 ack_inbox")?.acked).toBe(1);
+  });
+
+  test("send_ack threads explicit network_id", async () => {
+    const { tools } = buildHandlers({ userId: U_MULTI });
+    const t = makeTask(A1, "delivered", "x517 g2 send_ack");
+    const r = await call(tools["send_ack"], { task_id: t, network_id: NET_A });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.status).toBe("acked");
+  });
+
+  test("retry_task threads explicit network_id", async () => {
+    const { tools } = buildHandlers({ userId: U_MULTI });
+    const t = makeTask(A1, "failed", "x517 g2 retry_task");
+    const r = await call(tools["retry_task"], { task_id: t, network_id: NET_A });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.status).toBe("delivered");
+  });
+
+  test("cancel_task threads explicit network_id", async () => {
+    const { tools } = buildHandlers({ userId: U_MULTI });
+    const t = makeTask(A1, "delivered", "x517 g2 cancel_task");
+    const r = await call(tools["cancel_task"], { task_id: t, network_id: NET_A });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.status).toBe("cancelled");
+  });
+
+  test("reassign_task threads explicit network_id", async () => {
+    const { tools } = buildHandlers({ userId: U_MULTI });
+    const t = makeTask(A1, "delivered", "x517 g2 reassign_task");
+    const r = await call(tools["reassign_task"], { task_id: t, new_alias: A2, network_id: NET_A });
+    expect(r.ok).toBe(true);
+    expect(taskById(t)?.to_name).toBe(A2);
+  });
+
+  test("all 7 formerly param-less write tools expose network_id in their input schema", () => {
+    const { schemas } = buildHandlers({ userId: U_MULTI });
+    for (const name of ["send_message", "send_reply", "ack_inbox", "send_ack", "retry_task", "cancel_task", "reassign_task"]) {
+      expect(Object.keys(schemas[name] ?? {})).toContain("network_id");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Group 3 — precise causes replace the old catch-all message.
+// ─────────────────────────────────────────────────────────────────────
+describe("precise denial causes", () => {
+  test("utok with zero memberships → network_id_required naming the real cause", async () => {
+    const { tools } = buildHandlers({ userId: U_NONE });
+    const r = await call(tools["send_task"], { alias: A1, task: "x517 g3 none", priority: "normal" });
+    expect(r).toEqual({
+      ok: false,
+      error: "network_id_required",
+      message: "user token has no network memberships; join or create a network first",
+    });
+  });
+
+  test("utok explicitly targeting a network it is not a member of → access_denied", async () => {
+    const { tools } = buildHandlers({ userId: U_OUTSIDER });
+    const r = await call(tools["send_task"], { alias: A1, task: "x517 g3 outsider", priority: "normal", network_id: NET_A });
+    expect(r).toEqual({
+      ok: false,
+      error: "access_denied",
+      message: "access denied to requested network (not a member)",
+    });
+    expect(taskRow("x517 g3 outsider")).toBeNull();
+  });
+
+  test("viewer in a single network → permission_denied (send_task wording)", async () => {
+    const { tools } = buildHandlers({ userId: U_VIEWER });
+    const r = await call(tools["send_task"], { alias: A1, task: "x517 g3 viewer task", priority: "normal" });
+    expect(r).toEqual({
+      ok: false,
+      error: "permission_denied",
+      message: "Viewer role cannot send tasks",
+    });
+  });
+
+  test("viewer in a single network → permission_denied (generic write wording)", async () => {
+    const { tools } = buildHandlers({ userId: U_VIEWER });
+    const r = await call(tools["send_message"], { alias: A1, message: "x517 g3 viewer msg" });
+    expect(r).toEqual({
+      ok: false,
+      error: "permission_denied",
+      message: "Viewer role cannot write to this network",
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Group 4 — ntok_ pins: network-bound tokens must see ZERO change.
+// ─────────────────────────────────────────────────────────────────────
+describe("ntok behavior pinned (zero change)", () => {
+  test("ntok send_task without network_id stays bound to token network", async () => {
+    const { tools } = buildHandlers({ netId: NET_A, userId: U_SINGLE, alias: A1, isNetwork: true });
+    const r = await call(tools["send_task"], { alias: A2, task: "x517 g4 ntok plain", priority: "normal" });
+    expect(r.ok).toBe(true);
+    expect(taskRow("x517 g4 ntok plain")?.network_id).toBe(NET_A);
+  });
+
+  test("ntok send_task ignores a client-supplied foreign network_id (enforced binding wins)", async () => {
+    const { tools } = buildHandlers({ netId: NET_A, userId: U_MULTI, alias: A1, isNetwork: true });
+    const r = await call(tools["send_task"], { alias: A2, task: "x517 g4 ntok override", priority: "normal", network_id: NET_B });
+    expect(r.ok).toBe(true);
+    expect(taskRow("x517 g4 ntok override")?.network_id).toBe(NET_A);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Group 5 — legacy global-token mode (no enforceUserId): the fallback
+// must NOT kick in; writes stay unscoped exactly as before.
+// ─────────────────────────────────────────────────────────────────────
+describe("legacy global-token mode pinned", () => {
+  test("send_message without auth context stays network-unscoped", async () => {
+    const { tools } = buildHandlers({ userId: null });
+    const r = await call(tools["send_message"], { alias: A1, message: "x517 g5 legacy" });
+    expect(r.ok).toBe(true);
+    expect(inboxRow("x517 g5 legacy")?.network_id).toBeNull();
+  });
+});

--- a/server/src/mcp-write-network-resolution.test.ts
+++ b/server/src/mcp-write-network-resolution.test.ts
@@ -27,6 +27,7 @@
 
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { db, uuidv4 } from "./db.js";
+import { deleteNetwork } from "./auth.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerTools } from "./tools.js";
 
@@ -347,6 +348,51 @@ describe("precise denial causes", () => {
       error: "permission_denied",
       message: "Viewer role cannot write to this network",
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Group 3b — ghost memberships (PR #519 codex P2): deleteNetwork used to
+// leave network_members rows behind, so a stale membership to a deleted
+// network could (a) make a single-network user look multi-network, or
+// (b) auto-resolve a write INTO the deleted network, creating orphaned
+// rows. getUserNetworkIds now joins networks; deleteNetwork now removes
+// its membership rows.
+// ─────────────────────────────────────────────────────────────────────
+describe("ghost memberships (deleted networks)", () => {
+  const GHOST = "net_517_ghost";
+
+  test("membership to a deleted network does not break single-network auto-resolve", async () => {
+    // stale row: membership exists, networks row does not
+    db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))`, [U_SINGLE, GHOST]);
+    const { tools } = buildHandlers({ userId: U_SINGLE });
+    const r = await call(tools["send_task"], { alias: A1, task: "x517 ghost still-single", priority: "normal" });
+    expect(r.ok).toBe(true);
+    expect(taskRow("x517 ghost still-single")?.network_id).toBe(NET_A);
+    db.run("DELETE FROM network_members WHERE network_id = ?1", [GHOST]);
+  });
+
+  test("sole membership pointing at a deleted network → no-membership error, no orphaned write", async () => {
+    db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))`, [U_NONE, GHOST]);
+    const { tools } = buildHandlers({ userId: U_NONE });
+    const r = await call(tools["send_task"], { alias: A1, task: "x517 ghost orphan", priority: "normal" });
+    expect(r).toEqual({
+      ok: false,
+      error: "network_id_required",
+      message: "user token has no network memberships; join or create a network first",
+    });
+    expect(taskRow("x517 ghost orphan")).toBeNull();
+    db.run("DELETE FROM network_members WHERE network_id = ?1", [GHOST]);
+  });
+
+  test("deleteNetwork removes the network's membership rows (root cause)", () => {
+    const NET_DEL = "net_517_del";
+    db.run(`INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))`, [NET_DEL, U_SINGLE]);
+    db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))`, [U_SINGLE, NET_DEL]);
+    const res = deleteNetwork(U_SINGLE, NET_DEL);
+    expect(res.ok).toBe(true);
+    const left = db.get<{ cnt: number }>("SELECT COUNT(*) as cnt FROM network_members WHERE network_id = ?1", NET_DEL);
+    expect(left?.cnt).toBe(0);
   });
 });
 

--- a/server/src/network-scope.ts
+++ b/server/src/network-scope.ts
@@ -19,8 +19,14 @@ export type RestNetworkScope = {
 };
 
 export function getUserNetworkIds(userId: string): string[] {
+  // JOIN networks: deleteNetwork historically left network_members rows
+  // behind (fixed alongside PR #519, but legacy DBs still carry strays).
+  // A ghost membership must neither make a single-network user look
+  // ambiguous nor let the write fallback resolve INTO a deleted network.
   return db.all<{ network_id: string }>(
-    "SELECT network_id FROM network_members WHERE user_id = ?1",
+    `SELECT m.network_id FROM network_members m
+     JOIN networks n ON n.network_id = m.network_id
+     WHERE m.user_id = ?1`,
     userId
   ).map((row) => row.network_id);
 }

--- a/server/src/network-scope.ts
+++ b/server/src/network-scope.ts
@@ -1,0 +1,75 @@
+// Network-scope resolution shared by BOTH transports.
+//
+// #517: REST (server.ts) and MCP (tools.ts) each carried their own copy of
+// the "which network does this caller write to" rule. REST grew a
+// single-network fallback (POST /api/task); MCP never did — so a utok_
+// caller could read everything but write nothing, with a misleading
+// permission_denied. Extracted here (same pattern as lifecycle-guard.ts)
+// so the rule has exactly ONE implementation. If you change write-scope
+// semantics, this module is the only place — do NOT re-inline a copy in
+// server.ts or tools.ts.
+
+import { db } from "./db.js";
+import { getUserNetworkRole } from "./auth.js";
+
+export type RestNetworkScope = {
+  networkId: string | null;
+  networkIds: string[] | null;
+  denied?: string;
+};
+
+export function getUserNetworkIds(userId: string): string[] {
+  return db.all<{ network_id: string }>(
+    "SELECT network_id FROM network_members WHERE user_id = ?1",
+    userId
+  ).map((row) => row.network_id);
+}
+
+export function resolveRestNetworkScope(requested: string | null, authCtx: { userId: string; networkId: string | null } | null, isAdmin: boolean): RestNetworkScope {
+  // Legacy global token or open dev mode keeps the old global behavior.
+  if (!authCtx) return { networkId: requested || null, networkIds: null };
+
+  // Network tokens are forcibly scoped to their bound network.
+  if (authCtx.networkId) return { networkId: authCtx.networkId, networkIds: null };
+
+  // System admins may intentionally inspect all networks.
+  if (isAdmin) return { networkId: requested || null, networkIds: null };
+
+  if (requested) {
+    const role = getUserNetworkRole(authCtx.userId, requested);
+    if (!role) return { networkId: null, networkIds: [], denied: "access denied to requested network" };
+    return { networkId: requested, networkIds: null };
+  }
+
+  return { networkId: null, networkIds: getUserNetworkIds(authCtx.userId) };
+}
+
+export function addNetworkScope(sql: string, params: any[], scope: RestNetworkScope, column = "network_id"): string {
+  if (scope.networkId) {
+    sql += ` AND ${column} = ?${params.length + 1}`;
+    params.push(scope.networkId);
+  } else if (scope.networkIds) {
+    if (scope.networkIds.length === 0) {
+      sql += " AND 1=0";
+    } else {
+      const placeholders = scope.networkIds.map((_, i) => `?${params.length + i + 1}`).join(", ");
+      sql += ` AND ${column} IN (${placeholders})`;
+      params.push(...scope.networkIds);
+    }
+  }
+  return sql;
+}
+
+export function singleNetworkId(scope: RestNetworkScope): string | null {
+  if (scope.networkId) return scope.networkId;
+  if (scope.networkIds?.length === 1) return scope.networkIds[0];
+  return null;
+}
+
+export function canRestWriteNetwork(authCtx: { userId: string; networkId: string | null } | null, networkId: string | null, isAdmin: boolean): boolean {
+  if (!authCtx) return true; // legacy global token or open dev mode
+  if (isAdmin) return true;
+  if (!networkId) return false;
+  const role = getUserNetworkRole(authCtx.userId, networkId);
+  return !!role && role !== "viewer";
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,6 +5,7 @@ import { registerTools } from "./tools.js";
 import { db, logTaskEvent, logAudit } from "./db.js";
 import { createSSEStream, createNetworkObserverStream, pushEvent, pushNetworkObserverEvent, getSSEStats, PRINTABLE_OBSERVER_KEY_PREFIX } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
+import { addNetworkScope, canRestWriteNetwork, getUserNetworkIds, resolveRestNetworkScope, singleNetworkId, type RestNetworkScope } from "./network-scope.js";
 import { validateAvatarUrl } from "./avatar-validate.js";
 import { narrowTags, parseStoredTags, validateScalarAttr } from "./node-attrs-validate.js";
 import { register, login, resolveToken, getUserNetworks, getUserAllNetworks, createNetwork, deleteNetwork, renameNetwork, changePassword, issueUserToken, listTokens, createToken, revokeToken, getNetworkMembers, getUserNetworkRole, addNetworkMember, updateMemberRole, removeNetworkMember, createInvite, joinByInvite, createNetworkTokenForNode, type AuthUser } from "./auth.js";
@@ -291,62 +292,6 @@ function parseSingleByteRange(rangeHeader: string | null, size: number): ByteRan
   return { ok: true, start, end, length: end - start + 1 };
 }
 
-type RestNetworkScope = {
-  networkId: string | null;
-  networkIds: string[] | null;
-  denied?: string;
-};
-
-function getUserNetworkIds(userId: string): string[] {
-  return db.all<{ network_id: string }>(
-    "SELECT network_id FROM network_members WHERE user_id = ?1",
-    userId
-  ).map((row) => row.network_id);
-}
-
-function resolveRestNetworkScope(url: URL, authCtx: { userId: string; networkId: string | null } | null, isAdmin: boolean): RestNetworkScope {
-  const requested = url.searchParams.get("network_id");
-
-  // Legacy global token or open dev mode keeps the old global behavior.
-  if (!authCtx) return { networkId: requested || null, networkIds: null };
-
-  // Network tokens are forcibly scoped to their bound network.
-  if (authCtx.networkId) return { networkId: authCtx.networkId, networkIds: null };
-
-  // System admins may intentionally inspect all networks.
-  if (isAdmin) return { networkId: requested || null, networkIds: null };
-
-  if (requested) {
-    const role = getUserNetworkRole(authCtx.userId, requested);
-    if (!role) return { networkId: null, networkIds: [], denied: "access denied to requested network" };
-    return { networkId: requested, networkIds: null };
-  }
-
-  return { networkId: null, networkIds: getUserNetworkIds(authCtx.userId) };
-}
-
-function addNetworkScope(sql: string, params: any[], scope: RestNetworkScope, column = "network_id"): string {
-  if (scope.networkId) {
-    sql += ` AND ${column} = ?${params.length + 1}`;
-    params.push(scope.networkId);
-  } else if (scope.networkIds) {
-    if (scope.networkIds.length === 0) {
-      sql += " AND 1=0";
-    } else {
-      const placeholders = scope.networkIds.map((_, i) => `?${params.length + i + 1}`).join(", ");
-      sql += ` AND ${column} IN (${placeholders})`;
-      params.push(...scope.networkIds);
-    }
-  }
-  return sql;
-}
-
-function singleNetworkId(scope: RestNetworkScope): string | null {
-  if (scope.networkId) return scope.networkId;
-  if (scope.networkIds?.length === 1) return scope.networkIds[0];
-  return null;
-}
-
 function sqliteTime(date: Date): string {
   return date.toISOString().replace("T", " ").slice(0, 19);
 }
@@ -445,13 +390,6 @@ function bucketTelemetry(rows: any[], fromMs: number, bucketMs: number) {
     }));
 }
 
-function canRestWriteNetwork(authCtx: { userId: string; networkId: string | null } | null, networkId: string | null, isAdmin: boolean): boolean {
-  if (!authCtx) return true; // legacy global token or open dev mode
-  if (isAdmin) return true;
-  if (!networkId) return false;
-  const role = getUserNetworkRole(authCtx.userId, networkId);
-  return !!role && role !== "viewer";
-}
 
 type RestDeliveryTarget =
   | { state: "online"; alias: string; session: any }
@@ -1341,7 +1279,7 @@ return Bun.serve({
     // Token-bound networkId takes precedence (ntok_ → forced), then query param
     const restAuth = resolveRequestAuth(req);
     const isAdmin = !!(restAuth?.username && db.get<any>("SELECT role FROM users WHERE username = ?1", restAuth.username)?.role === "admin");
-    const restScope = resolveRestNetworkScope(url, restAuth, isAdmin);
+    const restScope = resolveRestNetworkScope(url.searchParams.get("network_id"), restAuth, isAdmin);
     if (restScope.denied) {
       return withCors(req, Response.json({ ok: false, error: restScope.denied }, { status: 403 }));
     }

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -4,6 +4,7 @@ import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, ge
 import { pushEvent, pushNetworkObserverEvent } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { getUserNetworkRole, createNetworkTokenForNode } from "./auth.js";
+import { canRestWriteNetwork, getUserNetworkIds, singleNetworkId } from "./network-scope.js";
 import {
   buildAnetArgs as _unused_buildAnetArgs,           // ensure module is loaded
   validateName as validateChildName,
@@ -97,28 +98,54 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }],
     };
   };
-  // If enforceNetworkId is set, override any client-supplied network_id
-  const getNetworkId = (clientNetId?: string | null) => enforceNetworkId ?? clientNetId ?? null;
+  // MCP-side auth context in the shape network-scope.ts helpers take.
+  // null = legacy global-token / open-dev mode (unscoped, allow-all).
+  const mcpAuthCtx = enforceUserId ? { userId: enforceUserId, networkId: enforceNetworkId ?? null } : null;
 
-  // Check write access. For ntok_ the network is enforced by the token.
-  // For utok_ (no enforced network) we accept the network_id supplied in the
-  // request and verify the user has a write role on it.
-  const canWrite = (effectiveNetworkId?: string | null): boolean => {
-    if (!enforceUserId) return true; // legacy global token mode, allow
-    const netId = enforceNetworkId ?? effectiveNetworkId ?? null;
-    if (!netId) return false; // no network resolvable
-    const role = getUserNetworkRole(enforceUserId, netId);
-    return !!role && role !== "viewer"; // owner/admin/member can write
+  // If enforceNetworkId is set (ntok_), override any client-supplied
+  // network_id. #517: for utok_ with no explicit network_id, fall back to
+  // the user's single membership via the SAME singleNetworkId used by REST
+  // POST /api/task (network-scope.ts) — utok_ rows carry network_id=null by
+  // design, so without this fallback single-network nodes could read
+  // everything but write nothing. Multi-network stays null (ambiguous) and
+  // canWrite rejects with network_id_required.
+  const getNetworkId = (clientNetId?: string | null) => {
+    const explicit = enforceNetworkId ?? clientNetId ?? null;
+    if (explicit !== null || !enforceUserId) return explicit;
+    return singleNetworkId({ networkId: null, networkIds: getUserNetworkIds(enforceUserId) });
   };
 
+  // Check write access — delegates to the shared canRestWriteNetwork so MCP
+  // and REST cannot drift again (#517). isAdmin=false: MCP has no admin
+  // bypass today; keep behavior identical to before the extraction.
+  const canWrite = (effectiveNetworkId?: string | null): boolean => {
+    const netId = enforceNetworkId ?? effectiveNetworkId ?? null;
+    return canRestWriteNetwork(mcpAuthCtx, netId, false);
+  };
+
+  // #517: name the REAL cause. The old catch-all blamed permissions for
+  // what was actually an unresolvable network, sending operators down the
+  // wrong debugging path (roles/membership) for hours.
   const writeDeniedReply = (effectiveNetworkId?: string | null, action = "write") => {
     const netId = enforceNetworkId ?? effectiveNetworkId ?? null;
-    const message = !netId
-      ? "network_id required (utok current_network is null; pass explicit network_id from /api/auth/me networks[0].network_id)"
-      : action === "send_task"
+    let error: string;
+    let message: string;
+    if (!netId) {
+      const memberships = enforceUserId ? getUserNetworkIds(enforceUserId) : [];
+      error = "network_id_required";
+      message = memberships.length === 0
+        ? "user token has no network memberships; join or create a network first"
+        : `user token spans ${memberships.length} networks; pass network_id explicitly (see /api/auth/me networks[].network_id)`;
+    } else if (enforceUserId && !getUserNetworkRole(enforceUserId, netId)) {
+      error = "access_denied";
+      message = "access denied to requested network (not a member)";
+    } else {
+      error = "permission_denied";
+      message = action === "send_task"
         ? "Viewer role cannot send tasks"
         : "Viewer role cannot write to this network";
-    return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "permission_denied", message }) }] };
+    }
+    return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error, message }) }] };
   };
 
   const addScope = (sql: string, params: any[], networkId?: string | null, column = "network_id"): string => {
@@ -130,13 +157,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
   type ReadScope = { networkId?: string | null; networkIds?: string[] | null; denied?: string };
 
-  const getReadableNetworkIds = (): string[] => {
-    if (!enforceUserId) return [];
-    return db.all<{ network_id: string }>(
-      "SELECT network_id FROM network_members WHERE user_id = ?1",
-      enforceUserId
-    ).map((row) => row.network_id);
-  };
+  // Delegates to the shared membership query (network-scope.ts) — was a
+  // byte-for-byte duplicate of getUserNetworkIds before #517.
+  const getReadableNetworkIds = (): string[] =>
+    enforceUserId ? getUserNetworkIds(enforceUserId) : [];
 
   const resolveReadScope = (clientNetId?: string | null): ReadScope => {
     if (!enforceUserId) return { networkId: clientNetId ?? null, networkIds: null };
@@ -690,9 +714,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       alias: z.string().min(1).max(200).describe("Session alias"),
       message_id: z.string().min(1).max(200),
       response: z.string().max(10000).optional(),
+      network_id: z.string().max(200).optional().describe("Network scope (auto-resolved for single-network user tokens)"),
     },
-    async ({ alias, message_id, response }) => {
-      const effectiveNetId = getNetworkId(null);
+    async ({ alias, message_id, response, network_id: netId }) => {
+      const effectiveNetId = getNetworkId(netId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       console.log(`[${ts()}] ${alias} → ack_inbox: ${message_id.slice(0, 8)}`);
       const ackParams: any[] = [message_id, alias];
@@ -1004,9 +1029,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       alias: z.string().min(1).max(200).describe("Target session alias"),
       message: z.string().min(1).max(10000).describe("Message content"),
       from_session: z.string().max(200).optional(),
+      network_id: z.string().max(200).optional().describe("Network scope (auto-resolved for single-network user tokens)"),
     },
-    async ({ alias, message, from_session: _fromIn }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
-      const effectiveNetId = getNetworkId(null);
+    async ({ alias, message, from_session: _fromIn, network_id: netId }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
+      const effectiveNetId = getNetworkId(netId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       const canonical = resolveCanonicalAlias(effectiveNetId, alias);
       const targetAlias = canonical.alias;
@@ -1065,9 +1091,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       in_reply_to: z.string().max(200).optional().describe("Original task/message ID"),
       status: z.enum(["replied", "failed", "cancelled"]).optional().default("replied").describe("Task outcome"),
       from_session: z.string().max(200).optional(),
+      network_id: z.string().max(200).optional().describe("Network scope (auto-resolved for single-network user tokens)"),
     },
-    async ({ alias, text, in_reply_to, status: replyStatus, from_session: _fromIn }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
-      const effectiveNetId = getNetworkId(null);
+    async ({ alias, text, in_reply_to, status: replyStatus, from_session: _fromIn, network_id: netId }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
+      const effectiveNetId = getNetworkId(netId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       console.log(`[${ts()}] ${from_session} → send_reply (${replyStatus}) → ${alias}: ${text.slice(0, 60)}`);
       const id = uuidv4();
@@ -1223,9 +1250,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     {
       task_id: z.string().min(1).max(200).describe("Task ID to acknowledge"),
       from_session: z.string().max(200).optional(),
+      network_id: z.string().max(200).optional().describe("Network scope (auto-resolved for single-network user tokens)"),
     },
-    async ({ task_id, from_session: _fromIn }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
-      const effectiveNetId = getNetworkId(null);
+    async ({ task_id, from_session: _fromIn, network_id: netId }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
+      const effectiveNetId = getNetworkId(netId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       console.log(`[${ts()}] ${from_session} → send_ack → task ${task_id.slice(0, 8)}`);
       const updateParams: any[] = [task_id];
@@ -1249,9 +1277,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     {
       task_id: z.string().min(1).max(200).describe("Task ID to retry"),
       from_session: z.string().max(200).optional(),
+      network_id: z.string().max(200).optional().describe("Network scope (auto-resolved for single-network user tokens)"),
     },
-    async ({ task_id, from_session: _fromIn }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
-      const effectiveNetId = getNetworkId(null);
+    async ({ task_id, from_session: _fromIn, network_id: netId }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
+      const effectiveNetId = getNetworkId(netId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       console.log(`[${ts()}] ${from_session} → retry_task → ${task_id.slice(0, 8)}`);
       // Find the original task
@@ -1368,9 +1397,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       task_id: z.string().min(1).max(200).describe("Task ID to cancel"),
       reason: z.string().max(1000).optional().describe("Cancellation reason"),
       from_session: z.string().max(200).optional(),
+      network_id: z.string().max(200).optional().describe("Network scope (auto-resolved for single-network user tokens)"),
     },
-    async ({ task_id, reason, from_session: _fromIn }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
-      const effectiveNetId = getNetworkId(null);
+    async ({ task_id, reason, from_session: _fromIn, network_id: netId }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
+      const effectiveNetId = getNetworkId(netId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       console.log(`[${ts()}] ${from_session} → cancel_task → ${task_id.slice(0, 8)}`);
       const updateParams: any[] = [reason || "cancelled by " + from_session, task_id];
@@ -1400,9 +1430,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       task_id: z.string().min(1).max(200).describe("Task ID to reassign"),
       new_alias: z.string().min(1).max(200).describe("Target agent alias"),
       from_session: z.string().max(200).optional(),
+      network_id: z.string().max(200).optional().describe("Network scope (auto-resolved for single-network user tokens)"),
     },
-    async ({ task_id, new_alias, from_session: _fromIn }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
-      const effectiveNetId = getNetworkId(null);
+    async ({ task_id, new_alias, from_session: _fromIn, network_id: netId }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
+      const effectiveNetId = getNetworkId(netId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       console.log(`[${ts()}] ${from_session} → reassign_task → ${task_id.slice(0, 8)} → ${new_alias}`);
       const taskParams: any[] = [task_id];

--- a/tests/qa-517-mcp-write-scope/Dockerfile
+++ b/tests/qa-517-mcp-write-scope/Dockerfile
@@ -1,0 +1,27 @@
+# #517 / PR #519 — MCP write-path network resolution Docker e2e.
+#
+# Unlike the unit suite (server/src/mcp-write-network-resolution.test.ts,
+# which injects enforceUserId/enforceNetworkId straight into registerTools),
+# this suite drives the REAL authenticated chain the codex review demanded:
+#   /api/auth/register → /api/auth/login (utok_, current_network=null)
+#   → POST /mcp (requireAuth → resolveRequestAuth → createServer)
+# and asserts the single-network fallback, the precise denial taxonomy,
+# and the deleted-network membership cleanup end-to-end.
+#
+# Server-only image: no agent-node/agent-network build needed — every
+# scenario is curl against the hub. Base oven/bun:1 (cached locally).
+FROM oven/bun:1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl jq sqlite3 ca-certificates procps \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY server /app/server
+COPY tests/qa-517-mcp-write-scope/run.sh /app/tests/qa-517-mcp-write-scope/run.sh
+RUN chmod +x /app/tests/qa-517-mcp-write-scope/run.sh
+
+RUN cd /app/server && bun install --silent
+
+CMD ["/app/tests/qa-517-mcp-write-scope/run.sh"]

--- a/tests/qa-517-mcp-write-scope/README.md
+++ b/tests/qa-517-mcp-write-scope/README.md
@@ -1,0 +1,40 @@
+# qa-517-mcp-write-scope
+
+Docker e2e for #517 / PR #519 — MCP write-path network resolution,
+exercised through the **real authenticated chain** (the unit suite in
+`server/src/mcp-write-network-resolution.test.ts` injects auth context
+directly into `registerTools`; this suite does not):
+
+```
+/api/auth/register → /api/auth/login (utok_, current_network=null)
+  → POST /mcp  (requireAuth → resolveRequestAuth → createServer)
+```
+
+Layers (env → auth → single write → multi-network → deleted-network → roles):
+
+| layer | asserts |
+|---|---|
+| L1 | login yields `utok_` with `current_network=null` — the exact #517 precondition |
+| L3 | single-network utok `send_task`/`send_message` succeed **without** `network_id`; task row lands in the right network |
+| L4 | 2 networks → exact `network_id_required` + "spans 2 networks" message; explicit `network_id` works |
+| L5 | deleting a network removes its memberships — auto-resolve works again (codex P2) |
+| L6 | viewer (sole membership via invite) → exact `permission_denied` viewer wording |
+| L7 | explicit foreign `network_id` → exact `access_denied` |
+| L8 | zero memberships → exact `network_id_required` no-membership wording; no orphaned rows |
+
+All error assertions match **both** `error` and `message` exactly.
+
+Run:
+
+```bash
+sg docker -c 'docker build -f tests/qa-517-mcp-write-scope/Dockerfile -t qa-517-mcp-write-scope .'
+sg docker -c 'docker run --rm qa-517-mcp-write-scope'
+```
+
+Reports: `docs/tests/report-qa-517.txt` (fix branch, 22/22 PASS) and
+`docs/tests/report-qa-517-red-baseline.txt` (same suite against
+origin/main's server: 11 FAIL — proves the suite detects the pre-fix
+behavior, including the old misleading error text).
+
+ntok_ zero-change pins are covered in the unit suite (they need a minted
+network token; unit layer injects it, keeping this suite server-API-only).

--- a/tests/qa-517-mcp-write-scope/README.md
+++ b/tests/qa-517-mcp-write-scope/README.md
@@ -33,8 +33,11 @@ sg docker -c 'docker run --rm qa-517-mcp-write-scope'
 
 Reports: `docs/tests/report-qa-517.txt` (fix branch, 22/22 PASS) and
 `docs/tests/report-qa-517-red-baseline.txt` (same suite against
-origin/main's server: 11 FAIL — proves the suite detects the pre-fix
-behavior, including the old misleading error text).
+origin/main's server: 11 assertions turn red, including the old
+misleading error text — note some are derived assertions of the same
+underlying operation, e.g. S1 send_task failing implies S2's task-row
+lookup finds nothing; the baseline proves the suite detects pre-fix
+behavior, not that there are 11 independent root causes).
 
 ntok_ zero-change pins are covered in the unit suite (they need a minted
 network token; unit layer injects it, keeping this suite server-API-only).

--- a/tests/qa-517-mcp-write-scope/run.sh
+++ b/tests/qa-517-mcp-write-scope/run.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# #517 / PR #519 — MCP write-path network resolution e2e, through the REAL
+# auth chain: register → login utok_ (current_network=null) → POST /mcp.
+# Layered per AGENTS.md: env → auth → single write → multi-network →
+# deleted-network → roles. Exact-match assertions on error AND message
+# (accepted set == spec-allowed set).
+
+set -uo pipefail
+
+HUB_PORT=9251
+HUB_BASE="http://127.0.0.1:$HUB_PORT"
+HUB_DB=/tmp/qa517-hub.db
+U1=qa517owner;  P1='Qa517_Owner_Pass_1!'
+U2=qa517viewer; P2='Qa517_Viewer_Pass_2!'
+U3=qa517outsider; P3='Qa517_Outsider_Pass_3!'
+TARGET=peer-517-e2e
+
+PASS=0; FAIL=0
+note() { printf "\n=== %s ===\n" "$*"; }
+ok()   { printf "  ✓ %s\n" "$*"; PASS=$((PASS+1)); }
+bad()  { printf "  ✗ %s\n" "$*"; FAIL=$((FAIL+1)); }
+
+# expect_exact <label> <actual> <expected>
+expect_exact() {
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 — got [$2] want [$3]"; fi
+}
+
+mcp_init_once() {
+  curl -sS -X POST "$HUB_BASE/mcp" \
+    -H "Authorization: Bearer $1" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -H 'MCP-Protocol-Version: 2025-03-26' \
+    -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"qa517","version":"0"}}}' >/dev/null 2>&1 || true
+}
+# mcp_call <token> <tool> <arguments-json> → inner tool reply JSON
+mcp_call() {
+  local tok="$1" tool="$2" args="$3"
+  local body="{\"jsonrpc\":\"2.0\",\"id\":$RANDOM,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}"
+  local resp; resp=$(curl -sS -X POST "$HUB_BASE/mcp" \
+    -H "Authorization: Bearer $tok" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -H 'MCP-Protocol-Version: 2025-03-26' \
+    -d "$body")
+  local inner; inner=$(echo "$resp" | grep -oP '(?<=data: ).+' | head -1 | jq -r '.result.content[0].text' 2>/dev/null)
+  if [[ -z "$inner" || "$inner" == "null" ]]; then
+    inner=$(echo "$resp" | jq -r '.result.content[0].text' 2>/dev/null)
+  fi
+  [[ -z "$inner" || "$inner" == "null" ]] && echo "$resp" || echo "$inner"
+}
+
+register_and_login() { # <user> <pass> → token on stdout
+  curl -sS -X POST "$HUB_BASE/api/auth/register" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$1\",\"password\":\"$2\"}" >/dev/null
+  curl -sS -X POST "$HUB_BASE/api/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$1\",\"password\":\"$2\"}" | jq -r .token
+}
+me_json() { curl -sS "$HUB_BASE/api/auth/me" -H "Authorization: Bearer $1"; }
+
+note "L0 env — hub boot"
+rm -f "$HUB_DB" "$HUB_DB-wal" "$HUB_DB-shm"
+( cd /app/server && PORT="$HUB_PORT" HOST=127.0.0.1 NODE_ENV=test COMMHUB_DB="$HUB_DB" bun run src/index.ts >/tmp/qa517-hub.log 2>&1 & )
+for i in $(seq 1 30); do curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && break; sleep 0.5; done
+curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && ok "hub /health 200 :$HUB_PORT" \
+  || { bad "hub did not start"; tail -40 /tmp/qa517-hub.log; exit 1; }
+
+note "L1 auth — utok with current_network=null (the #517 precondition)"
+TOK1=$(register_and_login "$U1" "$P1")
+[[ "$TOK1" == utok_* ]] && ok "login issues utok_ token" || bad "expected utok_, got: ${TOK1:0:12}"
+ME1=$(me_json "$TOK1")
+NET1=$(echo "$ME1" | jq -r '.networks[0].network_id')
+[[ -n "$NET1" && "$NET1" != "null" ]] && ok "register auto-created default network ($NET1)" || bad "no default network"
+CURNET=$(echo "$ME1" | jq -r '.current_network')
+expect_exact "utok current_network is null (issue precondition)" "$CURNET" "null"
+mcp_init_once "$TOK1"
+
+note "L2 seed — target agent session inside $NET1 (direct sqlite, no prod)"
+sqlite3 "$HUB_DB" "INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state) VALUES ('node_qa517','$TARGET','$TARGET','$NET1','qa517-host',datetime('now'),datetime('now'),'active');"
+sqlite3 "$HUB_DB" "INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at) VALUES ('res_qa517','$TARGET','idle','node_qa517','$NET1',datetime('now'),datetime('now'));"
+ok "seeded node+session $TARGET in $NET1"
+
+note "L3 single-network utok writes WITHOUT network_id (the fix)"
+R=$(mcp_call "$TOK1" send_task "{\"alias\":\"$TARGET\",\"task\":\"qa517 S1 single-net send_task\"}")
+expect_exact "S1 send_task ok" "$(echo "$R" | jq -r .ok)" "true"
+ROWNET=$(sqlite3 "$HUB_DB" "SELECT network_id FROM tasks WHERE content='qa517 S1 single-net send_task';")
+expect_exact "S2 task row scoped to $NET1" "$ROWNET" "$NET1"
+R=$(mcp_call "$TOK1" send_message "{\"alias\":\"$TARGET\",\"message\":\"qa517 S3 single-net send_message\"}")
+expect_exact "S3 send_message ok (tool previously had NO network_id input)" "$(echo "$R" | jq -r .ok)" "true"
+
+note "L4 multi-network utok — ambiguous without, explicit works"
+NET2=$(curl -sS -X POST "$HUB_BASE/api/networks" -H "Authorization: Bearer $TOK1" -H 'Content-Type: application/json' \
+  -d '{"name":"qa517-net2"}' | jq -r .network_id)
+[[ -n "$NET2" && "$NET2" != "null" ]] && ok "created second network ($NET2)" || bad "network create failed"
+R=$(mcp_call "$TOK1" send_task "{\"alias\":\"$TARGET\",\"task\":\"qa517 S4 ambiguous\"}")
+expect_exact "S4 error" "$(echo "$R" | jq -r .error)" "network_id_required"
+expect_exact "S4 message" "$(echo "$R" | jq -r .message)" "user token spans 2 networks; pass network_id explicitly (see /api/auth/me networks[].network_id)"
+R=$(mcp_call "$TOK1" send_task "{\"alias\":\"$TARGET\",\"task\":\"qa517 S5 explicit\",\"network_id\":\"$NET1\"}")
+expect_exact "S5 explicit network_id ok" "$(echo "$R" | jq -r .ok)" "true"
+
+note "L5 deleted network — membership cleanup restores auto-resolve"
+DEL=$(curl -sS -X DELETE "$HUB_BASE/api/networks/$NET2" -H "Authorization: Bearer $TOK1" | jq -r .ok)
+expect_exact "delete second network" "$DEL" "true"
+R=$(mcp_call "$TOK1" send_task "{\"alias\":\"$TARGET\",\"task\":\"qa517 S6 post-delete\"}")
+expect_exact "S6 auto-resolve works again after delete (no ghost membership)" "$(echo "$R" | jq -r .ok)" "true"
+
+note "L6 viewer role — resolves, then role-denied with viewer wording"
+TOK2=$(register_and_login "$U2" "$P2")
+NET2OWN=$(me_json "$TOK2" | jq -r '.networks[0].network_id')
+curl -sS -X DELETE "$HUB_BASE/api/networks/$NET2OWN" -H "Authorization: Bearer $TOK2" >/dev/null
+INV=$(curl -sS -X POST "$HUB_BASE/api/networks/$NET1/invite" -H "Authorization: Bearer $TOK1" -H 'Content-Type: application/json' \
+  -d '{"role":"viewer"}' | jq -r .invite_code)
+JOINED=$(curl -sS -X POST "$HUB_BASE/api/networks/join" -H "Authorization: Bearer $TOK2" -H 'Content-Type: application/json' \
+  -d "{\"invite_code\":\"$INV\"}" | jq -r .ok)
+expect_exact "viewer joined $NET1 via invite" "$JOINED" "true"
+mcp_init_once "$TOK2"
+R=$(mcp_call "$TOK2" send_task "{\"alias\":\"$TARGET\",\"task\":\"qa517 S7 viewer\"}")
+expect_exact "S7 error" "$(echo "$R" | jq -r .error)" "permission_denied"
+expect_exact "S7 message" "$(echo "$R" | jq -r .message)" "Viewer role cannot send tasks"
+
+note "L7 outsider — explicit foreign network_id"
+TOK3=$(register_and_login "$U3" "$P3")
+NET3=$(me_json "$TOK3" | jq -r '.networks[0].network_id')
+mcp_init_once "$TOK3"
+R=$(mcp_call "$TOK3" send_task "{\"alias\":\"$TARGET\",\"task\":\"qa517 S8 outsider\",\"network_id\":\"$NET1\"}")
+expect_exact "S8 error" "$(echo "$R" | jq -r .error)" "access_denied"
+expect_exact "S8 message" "$(echo "$R" | jq -r .message)" "access denied to requested network (not a member)"
+
+note "L8 zero memberships — after deleting own default network"
+curl -sS -X DELETE "$HUB_BASE/api/networks/$NET3" -H "Authorization: Bearer $TOK3" >/dev/null
+R=$(mcp_call "$TOK3" send_task "{\"alias\":\"$TARGET\",\"task\":\"qa517 S9 none\"}")
+expect_exact "S9 error" "$(echo "$R" | jq -r .error)" "network_id_required"
+expect_exact "S9 message" "$(echo "$R" | jq -r .message)" "user token has no network memberships; join or create a network first"
+ORPHANS=$(sqlite3 "$HUB_DB" "SELECT COUNT(*) FROM tasks WHERE content LIKE 'qa517 S9%';")
+expect_exact "S9 no orphaned task row written" "$ORPHANS" "0"
+
+note "result"
+printf "\nPASS=%d FAIL=%d\n" "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]] && echo "QA-517 ALL PASS" || echo "QA-517 FAILED"
+exit $(( FAIL > 0 ))

--- a/tests/qa-hub-09-task-state-machine/README.md
+++ b/tests/qa-hub-09-task-state-machine/README.md
@@ -36,19 +36,9 @@ sg docker -c 'docker run --rm anet-qa-hub-09'
 
 ## 抠出的额外契约（R14 实测发现）
 
-**cancel_task 需要 network-scoped writer（NTOK）**，UTOK 直接调返回 `{"ok":false,"error":"permission_denied"}`。
+**cancel_task 的调用方网络解析（#517 之后的语义）**：UTOK 恰好属于 1 个 network 时 hub 自动解析、直接成功；跨多个 network 时须显式传 `network_id`，否则返回 `{"ok":false,"error":"network_id_required"}`（不再是旧的 `permission_denied`）。`network_id` 已是 cancel_task 的 optional 参数。
 
-[tools.ts L812](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L812)：
-```ts
-const effectiveNetId = getNetworkId(null);
-if (!canWrite(effectiveNetId)) return { ... "permission_denied" };
-```
-
-UTOK 没有 inherent network，`getNetworkId(null)` 拿不到 network，`canWrite(null)` false。
-**SDK 含义**：admin / dashboard 想取消任务，要么用 NTOK，要么通过 REST 端点（不存在）。
-要么 hub 加 UTOK + 显式 network_id 支持。
-
-(这是测试逼出来的真 SDK 设计 gap。)
+> 历史注（R14 实测，#517 修复前）：当时 UTOK 调 cancel_task 一律 `permission_denied` —— `getNetworkId(null)` 拿不到 network、`canWrite(null)` false，本 README 曾在此记下根因与修法（"hub 加 UTOK + 显式 network_id 支持"）。该 gap 由 [#517](https://github.com/sleep2agi/agent-network/issues/517) / PR #519 落实：单网络自动解析（与 REST `POST /api/task` 同规则）+ 全部写工具补 optional `network_id` + 错误码分三真因（`network_id_required` / `access_denied` / `permission_denied`=仅 viewer）。详见 [troubleshooting 分诊表](../../docs-site/docs/troubleshooting.md)。
 
 ## 锁住的契约
 


### PR DESCRIPTION
Closes #517.

## ①② judgment (confirmed by 通信龙 before implementation)

**① network_id is not truly required — and "registration gap" is disproved.** `utok_` token rows are created with `network_id=null` by design (`auth.ts` login inserts `network_id=null, name='user-login'`); there is no missing field to backfill. REST `POST /api/task` already auto-resolves via `singleNetworkId(restScope)` when the user belongs to exactly one network — the MCP write path simply never got that fallback.

**② Read/write asymmetry**: `resolveReadScope` falls back to `getReadableNetworkIds()` (all memberships → reads work); `canWrite` required a single resolvable netId (null → deny), mislabeled `permission_denied`. Hence "进得来出不去".

## The hard constraint: one implementation, not a synced copy

`server.ts` imports `registerTools` from `tools.ts`, so `tools.ts` importing from `server.ts` would be a **circular import** — direct import is out. Per the approved fallback, the scope-rule family is **extracted to `server/src/network-scope.ts`** (same precedent as `lifecycle-guard.ts`, which was extracted for exactly this REST/MCP dual-transport reason):

- `RestNetworkScope`, `getUserNetworkIds`, `resolveRestNetworkScope` (signature: takes `requested: string | null` instead of `URL` so both transports can call it), `addNetworkScope`, `singleNetworkId`, `canRestWriteNetwork`
- `server.ts` now imports these; its local copies are deleted
- `tools.ts` `canWrite` **delegates to `canRestWriteNetwork`** — the viewer exclusion exists in exactly one place. `isAdmin=false` is passed because MCP has no admin bypass today; behavior preserved, noted in a comment
- `tools.ts` `getReadableNetworkIds` was a byte-for-byte duplicate of `getUserNetworkIds` — now delegates
- Not deduplicated (out of scope, flagged for a follow-up): `resolveReadScope`/`addReadScope` in tools.ts overlap `resolveRestNetworkScope`/`addNetworkScope` but differ semantically on the enforced-network membership check; merging them changes read-path behavior and deserves its own reviewed change

## Error taxonomy — the 🔴 point

| situation | before | after |
|---|---|---|
| utok, 1 membership, no network_id | `permission_denied` "network_id required (utok current_network is null…)" | **works** (auto-resolve) |
| utok, ≥2 memberships, no network_id | same misleading text | `network_id_required` "user token spans N networks; pass network_id explicitly (see /api/auth/me networks[].network_id)" |
| utok, 0 memberships | same misleading text | `network_id_required` "user token has no network memberships; join or create a network first" |
| explicit network_id, not a member | `permission_denied` "Viewer role cannot…" (wrong) | `access_denied` "access denied to requested network (not a member)" |
| viewer role | (only reachable with explicit param) | `permission_denied`, unchanged wording — now also reachable via auto-resolve |

## ⚠️ Breaking-ish: error-code contract change (approved by 通信龙)

The unresolvable/not-a-member denial cases change their `error` code: `permission_denied` → `network_id_required` / `access_denied` (semantic correction — the old code blamed the wrong layer). Caller impact audit:
- **Code**: repo-wide grep finds no code string-matching the old error code or message for these paths; docker-e2e injects explicit `network_id` everywhere and is unaffected.
- **Docs**: synced in this PR (cce1a335) — `api/mcp-tools.md` zh+en (error-code taxonomy + `network_id` param rows for the 7 formerly param-less write tools), `troubleshooting.md` zh+en (three-cause triage table replacing the now-false "utok_ cannot call MCP write operations" guidance). `api/rest.md` untouched: REST error strings did not change.
- **Old-hub tell**: clients seeing the old "utok current_network is null" text are talking to a pre-#517 hub; troubleshooting now says exactly that.

Note: the unresolvable/not-a-member cases change `error` code (`permission_denied` → `network_id_required`/`access_denied`). Grepped the repo — nothing string-matches the old message; docker-e2e injects explicit network_id everywhere and is unaffected.

## 7 formerly param-less write tools

`send_message`, `send_reply`, `ack_inbox`, `send_ack`, `retry_task`, `cancel_task`, `reassign_task` — utok callers previously **could not even work around** the bug on these (no `network_id` input existed). All gain `network_id: z.string().max(200).optional()`.

## Tests — 24 cases, every one with witnessed-red evidence

**Red baseline** (`docs/tests/report-qa-517-red-baseline.txt`): the Docker suite run against origin/main's server turns 11 assertions red, including the old misleading error text. Several of those are derived assertions of one underlying operation (e.g. S1 send_task failing implies S2's task-row lookup finds nothing) — the baseline demonstrates the suite detects pre-fix behavior, not 11 independent root causes.

`server/src/mcp-write-network-resolution.test.ts`, isolated hub DB (`COMMHUB_DB=/tmp/...`), error replies asserted with `toEqual` (accepted set == allowed set, no wideners):

- **G1** utok single-network auto-resolve — one case per write tool (8)
- **G2** utok multi-network — exact `network_id_required` error; explicit `network_id` threaded **per changed tool** (7); schema exposure for all 7
- **G3** precise denial causes — 0 memberships / outsider / viewer ×2 wordings
- **G4** ntok pinned zero-change — no-param stays bound; foreign client network_id ignored (enforced binding wins)
- **G5** legacy global-token pinned — fallback must NOT kick in, writes stay unscoped

Evidence in `docs/tests/p-517-mcp-write-scope/`: `witnessed-red.txt` (21 red pre-fix, old misleading message visible in the diffs), `witnessed-red-pins-sabotage.txt` (the 3 pin tests proven able to fail via a temporary sabotage of `getNetworkId`/`mcpAuthCtx`, then restored), `witnessed-green.txt` (24/24).

Full suite: **662 pass / 0 fail** (`npm run test`). `tsc --noEmit` error list diffed against base: **zero new** (11 pre-existing, line shifts only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

