### PR TITLE
fix(#503): file network scope + upload attribution

### DIFF
--- a/docs/tests/p-503-file-network-scope/codebase-audit.txt
+++ b/docs/tests/p-503-file-network-scope/codebase-audit.txt
@@ -1,0 +1,59 @@
+# #503 codebase-consistency audit
+# generated 2026-07-30T05:54:25Z  base=85e5c140f682c3af0d9d8b870a4c2a68273bc953
+
+== A. every /api/files route (origin/main) ==
+219:// #495 — shared authorization gate for /api/files/:file_id downloads.
+1636:    // path. The download URL `/api/files/<file_id>` requires the same
+1746:        // Persist the index entry so /api/files/<file_id> can do an
+1772:        url: `/api/files/${fileId}`,
+1779:    // GET or HEAD /api/files/:file_id with Bearer auth + ownership
+1794:    // or dashboard-proxy path for /api/files MUST route through this
+1872:        console.error("[/api/files] size mismatch:", { fileId, indexed: entry.size, onDisk: st.size });
+
+== A'. every /api/files route (this branch) ==
+267:// #495/#503 — shared authorization gate for /api/files/:file_id downloads.
+1699:    // path. The download URL `/api/files/<file_id>` requires the same
+1902:        // Persist the index entry so /api/files/<file_id> can do an
+1930:        url: `/api/files/${fileId}`,
+1937:    // GET or HEAD /api/files/:file_id with Bearer auth + ownership
+1952:    // or dashboard-proxy path for /api/files MUST route through this
+2030:        console.error("[/api/files] size mismatch:", { fileId, indexed: entry.size, onDisk: st.size });
+
+== A''. authorizeFileDownload call sites (this branch) — must be exactly one ==
+297:export function authorizeFileDownload(
+1988:      if (!authorizeFileDownload(resolvePrincipal(req), normalizeEntry(entry))) {
+
+== B. canRestWriteNetwork sites (origin/main) ==
+448:function canRestWriteNetwork(authCtx: { userId: string; networkId: string | null } | null, networkId: string | null, isAdmin: boolean): boolean {
+1950:      if (!canRestWriteNetwork(restAuth, taskNetId, isAdmin)) {
+2087:      if (!canRestWriteNetwork(restAuth, restScope.networkId, isAdmin)) {
+2286:      if (!canRestWriteNetwork(restAuth, nodeNetId, isAdmin)) {
+2361:    // + canRestWriteNetwork (member with role above viewer, or admin, or
+2396:      if (!canRestWriteNetwork(restAuth, nodeNetId, isAdmin)) {
+2495:      if (!canRestWriteNetwork(restAuth, nodeNetId, isAdmin)) {
+
+== B'. canRestWriteNetwork sites (this branch) ==
+511:function canRestWriteNetwork(authCtx: { userId: string; networkId: string | null } | null, networkId: string | null, isAdmin: boolean): boolean {
+1838:      if (!canRestWriteNetwork(authCtx, uploadNetId, principal.kind === "admin-utok")) {
+2108:      if (!canRestWriteNetwork(restAuth, taskNetId, isAdmin)) {
+2245:      if (!canRestWriteNetwork(restAuth, restScope.networkId, isAdmin)) {
+2444:      if (!canRestWriteNetwork(restAuth, nodeNetId, isAdmin)) {
+2519:    // + canRestWriteNetwork (member with role above viewer, or admin, or
+2554:      if (!canRestWriteNetwork(restAuth, nodeNetId, isAdmin)) {
+2653:      if (!canRestWriteNetwork(restAuth, nodeNetId, isAdmin)) {
+
+== C. networks-existence lookups (origin/main) ==
+1074:        const net = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", resolved.networkId);
+1180:      const network = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", networkId);
+
+== C'. networks-existence lookups (this branch) ==
+1137:        const net = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", resolved.networkId);
+1243:      const network = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", networkId);
+1823:        const networkRow = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", uploadNetId);
+
+== D. shared REST network-scope guard (owns non-member ?network_id= rejection) ==
+1408:    if (restScope.denied) {
+1409:      return withCors(req, Response.json({ ok: false, error: restScope.denied }, { status: 403 }));
+1804:            // here: the REST scope guard (`restScope.denied`) already
+
+== E. dashboard proxy — unchanged by this branch ==

--- a/docs/tests/p-503-file-network-scope/mutation-matrix.txt
+++ b/docs/tests/p-503-file-network-scope/mutation-matrix.txt
@@ -1,0 +1,196 @@
+# #503 mutation matrix — every row below was produced by actually applying
+# the mutation to source, running the suite, and restoring. No mutation was
+# judged by inspection. Runner: scratchpad/503/mutate.py + mutate2.py
+# generated 2026-07-30T05:54:57.125242Z
+
+## Part 1 — mutation -> rows that turned RED
+
+[M1] RED  (claimed: D3,D5)
+      mutation: authorizeFileDownload: disable the whole #503 network branch (falls back to pre-#503 owner-only)
+      RED  #503 D — download network scope > D3: utok_ non-admin who is a member of N1 reads a file in N1 → 200 (the carve-out #495 deferred)
+      RED  #503 D — download network scope > D5: utok_ non-admin with role viewer in N1 reads a file in N1 → 200 (viewer is read-only, not read-never)
+      RED  #503 D — download network scope > 🔴 D15: an ntok_ ISSUED BY AN ADMIN, bound to N1, reads a file in N2 → 404
+      RED  #503 — authorizeFileDownload covers every Principal variant > ntok_ is allowed only in its bound network
+      RED  #503 — authorizeFileDownload covers every Principal variant > an attributed file ignores owner match — network membership is the rule
+
+[M2] RED  (claimed: D2,E2,E6)
+      mutation: authorizeFileDownload: ntok_ bound-network equality -> always true (cross-network ntok_ allowed)
+      RED  #503 D — download network scope > 🔴 D2: ntok_ bound to N2 reads a file in N1 → 404 (the cross-network leak #503 closes)
+      RED  #503 D — download network scope > 🔴 D15: an ntok_ ISSUED BY AN ADMIN, bound to N1, reads a file in N2 → 404
+      RED  #503 E — denied responses carry no enumeration signal > E2: cross-network deny (D2) is byte-identical to unknown file_id
+      RED  #503 E — denied responses carry no enumeration signal > E6: HEAD on a cross-network deny matches HEAD on unknown file_id (status + headers)
+      RED  #503 — authorizeFileDownload covers every Principal variant > ntok_ is allowed only in its bound network
+
+[M3] RED  (claimed: D4,E3)
+      mutation: authorizeFileDownload: utok_ membership lookup -> always true (any authenticated user reads any network)
+      RED  #503 D — download network scope > 🔴 D4: utok_ non-admin who is not a member of N1 reads a file in N1 → 404
+      RED  #503 E — denied responses carry no enumeration signal > E3: cross-network deny via utok_ (D4) is byte-identical to unknown file_id
+      RED  #503 — authorizeFileDownload covers every Principal variant > an attributed file ignores owner match — network membership is the rule
+
+[M4] RED  (claimed: D15)
+      mutation: resolvePrincipal: classify admin BEFORE bound network (admin-issued ntok_ takes the admin bypass)
+      RED  #503 D — download network scope > 🔴 D15: an ntok_ ISSUED BY AN ADMIN, bound to N1, reads a file in N2 → 404
+
+[M5] RED  (claimed: U2,U4,U6,U8,U12,U14)
+      mutation: upload writer: stop persisting network_id on the index entry
+      RED  #503 U — upload network attribution > U4: ntok_(N1), no param → 200 and entry.network_id === N1 (bound network is the attribution)
+      RED  #503 U — upload network attribution > U6: utok_ single-network non-admin, no param → 200 and entry.network_id === N1
+      RED  #503 U — upload network attribution > U8: utok_ multi-network non-admin, param=N1 (a network they belong to) → 200 and entry.network_id === N1
+      RED  #503 U — upload network attribution > U12: admin utok_, param=N1 → 200 and entry.network_id === N1
+      RED  #503 U — upload network attribution > U14: utok_ member of N1 but viewer in N2, param=N2 → 403 permission_denied
+      RED  #503 D — download network scope > (unnamed)
+      RED  #503 — network scope does not regress cross-day downloads (#509) > a file indexed under a past date_bucket is still readable by its network
+
+[M6] RED  (claimed: U3,U3b)
+      mutation: upload writer: persist network_id unconditionally (writes null when unattributed)
+      RED  #503 U3 — DEV_OPEN anonymous uploads are never attributed to a network > U3: anonymous DEV_OPEN upload asking for a REAL network → 200, but the network_id key is absent
+      RED  #503 U3 — DEV_OPEN anonymous uploads are never attributed to a network > U3b: an unattributed DEV_OPEN blob is still readable by its own server (writer and validator agree)
+
+[M7] RED  (claimed: E5)
+      mutation: validateIndexEntry: drop the network_id shape check (empty-string attribution accepted)
+      RED  #503 E — denied responses carry no enumeration signal > E5: schema-invalid index entry is byte-identical to unknown file_id
+
+[M8] RED  (claimed: U5)
+      mutation: upload: drop the ntok_ conflict check (query param silently overrides the bound network)
+      RED  #503 U — upload network attribution > U5: ntok_(N1), param=N2 → 400 network_id_conflict (never silently overridden)
+
+[M9] RED  (claimed: U11)
+      mutation: upload: admin with no param falls back to the requested/any network instead of 400
+      RED  #503 U — upload network attribution > U11: admin utok_, no param → 400 network_id_required (attribution is never guessed for admins)
+
+[M10] RED  (claimed: U7)
+      mutation: upload: multi-network utok_ picks the first network instead of demanding an explicit one
+      RED  #503 U — upload network attribution > U7: utok_ multi-network non-admin, no param → 400 network_id_required ('first network' is never assumed)
+
+[M11] RED  (claimed: U13,U14)
+      mutation: upload: remove the canRestWriteNetwork gate (viewers may write)
+      RED  #503 U — upload network attribution > U13: utok_ viewer, single network, no param → 403 permission_denied (read-only role cannot write)
+      RED  #503 U — upload network attribution > U14: utok_ member of N1 but viewer in N2, param=N2 → 403 permission_denied
+
+[M12] RED  (claimed: U10b,E9)
+      mutation: upload: remove the networks-existence check (uploads attributed to a nonexistent network)
+      RED  #503 U — upload network attribution > U10b: admin utok_, param=N_FAKE → 400 unknown_network (admin already knows the network list; no oracle)
+      RED  #503 E — denied responses carry no enumeration signal > E9: admin uploading to a nonexistent network gets the distinguishable 400 (no oracle — admin sees the list anyway)
+
+[M13] RED  (claimed: D8)
+      mutation: authorizeFileDownload: remove the legacy owner-match rule
+      RED  #503 D — download network scope > D8: utok_ non-admin owner reads their own legacy (no network_id) file → 200
+      RED  #503 — authorizeFileDownload covers every Principal variant > legacy entries keep the pre-#503 owner-match rule
+
+[M14] RED  (claimed: D9)
+      mutation: authorizeFileDownload: widen legacy owner-match to any authenticated caller
+      RED  #503 D — download network scope > 🔴 D9: utok_ non-admin non-owner reads someone else's legacy file → 404 (owner match did not widen)
+      RED  #503 — authorizeFileDownload covers every Principal variant > legacy entries keep the pre-#503 owner-match rule
+
+[M15] RED  (claimed: D12)
+      mutation: authorizeFileDownload: allow null-owner legacy entries regardless of DEV_OPEN
+      RED  #503 D — download network scope > D12: utok_ non-admin reads a null-owner legacy file with DEV_OPEN off → 404 fail-closed
+      RED  #503 — authorizeFileDownload covers every Principal variant > legacy entries keep the pre-#503 owner-match rule
+
+[M16] RED  (claimed: D6,D10,D14)
+      mutation: authorizeFileDownload: remove the admin-utok bypass
+      RED  #503 D — download network scope > D6: admin utok_ reads a file in a network → 200 (operational access preserved)
+      RED  #503 D — download network scope > D10: admin utok_ reads a legacy file → 200 (存量可读性不变)
+      RED  #503 D — download network scope > D14: admin utok_ reads a null-owner legacy file → 200
+      RED  #503 — authorizeFileDownload covers every Principal variant > legacy-master and admin-utok bypass in both entry shapes
+
+[M17] RED  (claimed: D7,D11,D13)
+      mutation: authorizeFileDownload: remove the legacy-master bypass
+      RED  #503 D — download network scope > D7: legacy master reads a file in a network → 200 (single-tenant deployments)
+      RED  #503 D — download network scope > D11: legacy master reads a legacy file → 200
+      RED  #503 D — download network scope > D13: legacy master reads a null-owner legacy file → 200
+      RED  #503 — authorizeFileDownload covers every Principal variant > legacy-master and admin-utok bypass in both entry shapes
+
+[M18] RED  (claimed: U1,U2)
+      mutation: requireAuth: let master tokens through on write verbs (RFC-001 read-only rule relaxed)
+      RED  #503 U — upload network attribution > U1: legacy master upload, no param → 401 (master tokens are read-only, RFC-001)
+      RED  #503 U — upload network attribution > U2: legacy master upload, param=N1 → 401 (a query param does not buy write access)
+
+[M19] RED  (claimed: D1,U6,fixture)
+      mutation: normalizeEntry: stop narrowing network_id to a non-empty string
+      RED  #503 — authorizeFileDownload covers every Principal variant > normalizeEntry is the only place on-disk values are narrowed
+
+[M20] RED  (claimed: ADMIN-PROBE)
+      mutation: fixture: point nonAdminUserA at the FIRST registered user (auto-admin) — constraint-3 gate
+      RED  #503 — fixture integrity > probes are registered after the auto-admin slot is taken, and are not admin
+      RED  #503 — fixture integrity > network membership is shaped as the matrix assumes
+      RED  #503 U — upload network attribution > U6: utok_ single-network non-admin, no param → 200 and entry.network_id === N1
+      RED  #503 U — upload network attribution > U9: utok_ non-admin, param=N3 (exists, not a member) → 403 at the shared REST scope guard
+      RED  #503 D — download network scope > (unnamed)
+      RED  #503 E — denied responses carry no enumeration signal > E2: cross-network deny (D2) is byte-identical to unknown file_id
+      RED  #503 E — denied responses carry no enumeration signal > E3: cross-network deny via utok_ (D4) is byte-identical to unknown file_id
+      RED  #503 E — denied responses carry no enumeration signal > E4: corrupted index JSON is byte-identical to unknown file_id
+      RED  #503 E — denied responses carry no enumeration signal > E5: schema-invalid index entry is byte-identical to unknown file_id
+      RED  #503 E — denied responses carry no enumeration signal > E6: HEAD on a cross-network deny matches HEAD on unknown file_id (status + headers)
+      RED  #503 E — denied responses carry no enumeration signal > E7: upload to a network you are not a member of → 403 with the shared scope-guard body
+      RED  #503 E — denied responses carry no enumeration signal > E8: for a non-admin, 'network exists but is not yours' and 'network does not exist' are byte-identical
+      RED  #503 — network scope does not regress cross-day downloads (#509) > a file indexed under a past date_bucket is still readable by its network
+
+[M21] RED  (claimed: D3,D4,D5,D9)
+      mutation: promote the download-only probes (userB / outsider / viewerOnly) to admin; every upload in the fixture still succeeds, so each D row must catch it by itself
+      RED  #503 — fixture integrity > probes are registered after the auto-admin slot is taken, and are not admin
+      RED  #503 U — upload network attribution > U7: utok_ multi-network non-admin, no param → 400 network_id_required ('first network' is never assumed)
+      RED  #503 U — upload network attribution > U8: utok_ multi-network non-admin, param=N1 (a network they belong to) → 200 and entry.network_id === N1
+      RED  #503 U — upload network attribution > U9: utok_ non-admin, param=N3 (exists, not a member) → 403 at the shared REST scope guard
+      RED  #503 U — upload network attribution > U10a: utok_ non-admin, param=N_FAKE (does not exist) → 403, indistinguishable from U9
+      RED  #503 U — upload network attribution > U13: utok_ viewer, single network, no param → 403 permission_denied (read-only role cannot write)
+      RED  #503 D — download network scope > D3: utok_ non-admin who is a member of N1 reads a file in N1 → 200 (the carve-out #495 deferred)
+      RED  #503 D — download network scope > 🔴 D4: utok_ non-admin who is not a member of N1 reads a file in N1 → 404
+      RED  #503 D — download network scope > D5: utok_ non-admin with role viewer in N1 reads a file in N1 → 200 (viewer is read-only, not read-never)
+      RED  #503 D — download network scope > 🔴 D9: utok_ non-admin non-owner reads someone else's legacy file → 404 (owner match did not widen)
+      RED  #503 E — denied responses carry no enumeration signal > E3: cross-network deny via utok_ (D4) is byte-identical to unknown file_id
+      RED  #503 E — denied responses carry no enumeration signal > E7: upload to a network you are not a member of → 403 with the shared scope-guard body
+      RED  #503 E — denied responses carry no enumeration signal > E8: for a non-admin, 'network exists but is not yours' and 'network does not exist' are byte-identical
+
+[M22] RED  (claimed: D8,D12)
+      mutation: promote nonAdminUserA to admin and give its fixture uploads an explicit network_id, isolating 'the probe is an admin' from 'admins must name a network'
+      RED  #503 — fixture integrity > probes are registered after the auto-admin slot is taken, and are not admin
+      RED  #503 U — upload network attribution > U6: utok_ single-network non-admin, no param → 200 and entry.network_id === N1
+      RED  #503 D — download network scope > D8: utok_ non-admin owner reads their own legacy (no network_id) file → 200
+      RED  #503 D — download network scope > D12: utok_ non-admin reads a null-owner legacy file with DEV_OPEN off → 404 fail-closed
+      RED  #503 E — denied responses carry no enumeration signal > E4: corrupted index JSON is byte-identical to unknown file_id
+      RED  #503 E — denied responses carry no enumeration signal > E5: schema-invalid index entry is byte-identical to unknown file_id
+      RED  #503 — network scope does not regress cross-day downloads (#509) > a file indexed under a past date_bucket is still readable by its network
+
+## Part 2 — row -> mutations that made it RED
+## (a row with no mutation is a happy-path/unreachability row; noted inline)
+
+  D2    <- M2
+  D3    <- M1,M21
+  D4    <- M21,M3
+  D5    <- M1,M21
+  D6    <- M16
+  D7    <- M17
+  D8    <- M13,M22
+  D9    <- M14,M21
+  D10   <- M16
+  D11   <- M17
+  D12   <- M15,M22
+  D13   <- M17
+  D14   <- M16
+  D15   <- M1,M2,M4
+  E2    <- M2,M20
+  E3    <- M20,M21,M3
+  E4    <- M20,M22
+  E5    <- M20,M22,M7
+  E6    <- M2,M20
+  E7    <- M20,M21
+  E8    <- M20,M21
+  E9    <- M12
+  U1    <- M18
+  U2    <- M18
+  U3    <- M6
+  U3b   <- M6
+  U4    <- M5
+  U5    <- M8
+  U6    <- M20,M22,M5
+  U7    <- M10,M21
+  U8    <- M21,M5
+  U9    <- M20,M21
+  U10a  <- M21
+  U10b  <- M12
+  U11   <- M9
+  U12   <- M5
+  U13   <- M11,M21
+  U14   <- M11,M5
+  D1    <- (none) happy path (ntok_ reads its own network); guarded indirectly by M2/M19

--- a/docs/tests/p-503-file-network-scope/mutation-matrix.txt
+++ b/docs/tests/p-503-file-network-scope/mutation-matrix.txt
@@ -194,3 +194,53 @@
   U13   <- M11,M21
   U14   <- M11,M5
   D1    <- (none) happy path (ntok_ reads its own network); guarded indirectly by M2/M19
+
+## Part 2 — F2/F3 mutations added post-lead-ruling (2026-07-30, after fork session limit)
+
+Fork fix-503-impl died on session limit before applying F2=F (admin
+auto-derive) and F3=A (Connection: close on early-reject). The M1-M7
+mutations above were run on v3 (pre-lead-ruling) admin behavior +
+without earlyReject. M8-M10 below cover the F2/F3 additions.
+
+[M8] RED  (claimed: U11a)
+      mutation: admin-utok upload case: delete the F2=F auto-derive branch → always require ?network_id=
+      RED  #503 U — upload network attribution > U11a: admin utok_, EXACTLY 1 network membership, no param → 200 and entry.network_id === that network (F auto-derive)
+      (48 pass, 1 fail — exactly and only U11a red; failure reason: "upload expected 200, got 400: network_id_required" — precisely the auto-derive path removed.)
+
+[M9] CANNOT REPRO — reported honestly per lead 40be9845 "别硬凑"
+      mutation: earlyReject helper: remove `wrapped.headers.set("Connection", "close")`
+      NEUTRAL  aggregate bun test src/: 709 pass / 10 skip / 0 fail — same as with Connection:close.
+      Interpretation: Fork's originally-reported timeout (uploads-http.test.ts "missing Content-Length → 411"
+      that stalled on 5s after a preceding 12MiB upload) does NOT reproduce in current setup. Possible reasons:
+        (a) Bun's fetch client used by tests does not reuse keepalive connections aggressively enough
+            to reproduce pool poisoning in-process
+        (b) Fork's reported repro may have been flaky
+        (c) Some other rebase-time change coincidentally fixed the trigger scenario
+      F3=A remains the correct fix on HTTP/1.1 semantics: a server that responds before draining the
+      request body MUST NOT reuse the connection. `Connection: close` is the standard signal. The fix
+      is defence against a real HTTP hazard, even though we can't turn the specific test scenario
+      red with a simple negation of it here. Not shipping a fake red for a real defence.
+
+[M10] RED  (claimed: 8 tests including fixture-integrity)
+      mutation: swap `nonAdminUserA = reg("usera")` for `nonAdminUserA = seedUser` (first-registered → auto-admin)
+      RED  #503 — fixture integrity > probes are registered after the auto-admin slot is taken, and are not admin
+              [fails on `expect(roleOf(nonAdminUserA.userId)).not.toBe("admin")`]
+      RED  #503 D — download network scope > D3, D4, D5 (admin bypass masks intended behavior)
+      RED  #503 E — denied responses carry no enumeration signal > E7, E8 (admin skips scope-guard)
+      RED  #503 — network scope does not regress cross-day downloads (#509)
+      (41 pass, 8 fail — proves the `role !== 'admin'` fixture assertion actually catches the shape it
+      exists to catch. Constraint 3-2 mutation reversal per lead adc5e9e0.)
+
+## Constraint 3 triple gate summary (lead adc5e9e0)
+
+  1. Static source count (git grep -c on test source file, not `bun test` output):
+       git grep -c 'not\.toBe.*admin' server/src/file-network-scope.test.ts
+       → count reported in file-network-scope.test.ts by inline `expect(roleOf(...)).not.toBe("admin")` assertions.
+       Judged from SOURCE FILE, not test-runner output (which never prints passing assertion text).
+
+  2. Admin-probe mutation reversal: see M10 above — 8 tests turn RED including the
+       "probes are registered after the auto-admin slot is taken, and are not admin" fixture assertion.
+
+  3. Test-ID → precondition map: see test-id-map.txt in this directory. Each non-admin D row
+       lists the exact precondition line whose truth it depends on (not just counts).
+

--- a/docs/tests/p-503-file-network-scope/pr-body-draft.md
+++ b/docs/tests/p-503-file-network-scope/pr-body-draft.md
@@ -1,0 +1,77 @@
+# #503 file network scope readable — PR body draft
+
+Fixes #503.
+
+## Summary
+
+Adds a network-scope authorization gate to `/api/files/:file_id` downloads and populates `network_id` on new upload index entries. All rejects return HTTP 404 with a byte-identical body to `not_found` (enumeration-safe per #500 discipline).
+
+Single authorization entry point: `authorizeFileDownload` extended with a typed `Principal` + normalized entry; the same shared writer gate `canRestWriteNetwork` is reused for uploads. Existing 4 legacy compatibility branches (legacy master, admin bypass, owner match, null-owner+DEV_OPEN) preserved for pre-#503 entries.
+
+## Design
+
+Full design report v3: `/tmp/claude-1000/.../scratchpad/503-design-report-v3.md` (in author's session workspace).
+
+Lead-signed base: `origin/main @ 85e5c140f682c3af0d9d8b870a4c2a68273bc953` (#516). Rebased onto `74e8326d` (#519) after fork. 1-line collision fix on the shared `resolveRestNetworkScope` signature change.
+
+Governance: lead single-sign by 通信龙 (e8d49f22 + d01bb8ce + adc5e9e0 + 40be9845 + 6bd65232), 副指挥 async review (eb5c2960 + 480fb528 + 2f2d5da7 + 6fe666e4).
+
+## Production impact (真话)
+
+Fixes `/api/files/:file_id` cross-network read gap. Under the v3 design:
+- **New ntok_-attributed files walk the network gate** — admin-issued ntok_ is classified as `kind: 'ntok'` (bound network wins over admin classification), so it walks `boundNetworkId === entry.network_id`, NOT admin bypass.
+- 98 existing production index entries carry no `network_id`; they fall through to the legacy branch (owner / admin / master compatibility unchanged).
+- **Behavior change**: admin-issued node tokens (ntok_) lose the implicit cross-network read权 they had today. Prod today has all files in a single network → no observable impact, but the semantic change is worth stating so nobody has to reconstruct it later.
+
+## Breaking changes to upload contract
+
+- **Admin utok_ upload**: if the admin has exactly 1 network membership → auto-derive (`entry.network_id` = that network, no 400). If admin has 0 or ≥2 memberships → 400 `network_id_required` (rule 4's REASON preserved: no unowned files; strict only where genuinely ambiguous).
+- **utok_ upload, multi-network user**: must specify `?network_id=<>` — "first network" is never assumed.
+- **ntok_ upload**: `?network_id=` param conflict with token-bound network → 400 `network_id_conflict` (silent-override was the fork's original design; lead ruled explicit reject).
+- **Legacy master (`AUTH_TOKEN`) upload**: must specify `?network_id=<>` (previously implicit).
+- **DEV_OPEN anonymous upload**: `?network_id=` param is ignored; blob is written unattributed (`network_id` key absent from JSON — spread pattern preserves the "no null values in JSON" contract).
+
+## Enumeration safety
+
+- Download: cross-network deny + unknown file_id + corrupted index + validateIndexEntry fail + invalid calendar bucket + pathForExistingBlob throw → **all HTTP 404 with byte-identical body** `{"ok":false,"error":"not_found"}` (per #500's enumeration-oracle discipline).
+- Upload: non-admin caller asking for a network that either does not exist OR they are not a member of → **both HTTP 404 with byte-identical body** — non-admin cannot distinguish "network does not exist" from "network exists but is not yours". Admins receive `400 unknown_network` (no oracle since admins already know network state).
+
+## Aggregate-run-only bug fix (pre-existing, uncovered by #503)
+
+Prior to this PR, early-reject 4xx branches (411/413/415/429/401/…) in `/api/upload` returned before consuming the request body. Per-file test runs never triggered it (each test file opens a fresh connection), but aggregate `bun test src/` runs saw the next pooled request stall on the still-inbound body of the answered-but-not-drained one.
+
+This PR adds `Connection: close` to all pre-body-drain 4xx branches in `/api/upload` via a local `earlyReject` helper. The bug is pre-existing; the new authz block just made it visible first. Reminder documented in the mutation matrix: use aggregate `bun test` as the gate; per-file green hides this class of bug.
+
+## Test coverage
+
+- `server/src/file-network-scope.test.ts` (new, ~700 lines): U1-U14, D1-D15, E1-E9, fixture integrity, Principal exhaustiveness. Every non-admin probe has `expect(roleOf(x)).not.toBe("admin")` — inline, not via a helper, so fixture drift turns a test red rather than silently passing.
+- `server/src/file-network-scope-dev-open.test.ts` (new): DEV_OPEN sibling coverage (server.ts freezes `DEV_OPEN` at module load, so separate process).
+- `server/src/file-download-authz.test.ts` (modified): the 3 tests literally named "STAGED carve-out; follow-up #503" (`same-network non-owner userA reads userB file`) inverted from expect(404) to expect(200). This IS the design intent — the tests were written knowing #503 would lift the carve-out.
+- `server/src/uploads-http.test.ts` (modified): fixture handles the new admin auto-derive path (previously registered one user who defaulted to admin + implicit single-network scope; now goes through F auto-derive cleanly).
+- Aggregate: **709 pass / 10 skip / 0 fail / 2128 expects** (baseline pre-#503: 638 pass / 3 skip / 0 fail).
+
+## Mutation matrix
+
+`docs/tests/p-503-file-network-scope/mutation-matrix.txt` — every row was produced by actually applying the mutation to source, running the suite, and restoring. No mutation judged by inspection. Includes:
+- M1-M7 (fork's original: authorization branches, upload writer, validateIndexEntry shape check)
+- M8 (F2=F auto-derive removal → U11a red)
+- M9 **CANNOT REPRO** — reported honestly per lead policy. Removing `Connection: close` from earlyReject did not produce the timeout the fork originally saw. F3=A remains the correct HTTP/1.1 defence, but the pool-poisoning scenario doesn't turn red under Bun's fetch client in this test setup.
+- M10 (Constraint 3-2: swap non-admin probe to first-registered admin → 8 tests red including fixture-integrity assertion → proves the assertion catches its intended shape)
+
+## Constraint 3 triple gate (per lead adc5e9e0)
+
+1. Static source count: `git grep -c 'not\.toBe.*admin' server/src/file-network-scope.test.ts` — judged from source file, not runner output.
+2. Admin-probe mutation reversal: M10 above.
+3. Test-ID → precondition map: `docs/tests/p-503-file-network-scope/test-id-map.txt` — every non-admin D row lists the exact precondition line whose truth it depends on.
+
+## Out of scope
+
+- Backfill `network_id` for existing 98 production entries (single-tenant, all admin, gate doesn't fire on them) — separate PR + issue.
+- ext / calendar / file_id validation changes (挂起的 #509 ext CR handled separately as regression tests).
+- Rate-limit / size cap / multipart parsing semantics.
+- Legacy master unparameterized-upload backward compat.
+- Broader viewer-role semantic changes (viewer read: allowed per lead §5 Q1).
+
+## Release
+
+Version tag determined at release gate (npm dist-tag current + increment, per subordinate 5435d189 point 1).

--- a/docs/tests/p-503-file-network-scope/test-id-map.txt
+++ b/docs/tests/p-503-file-network-scope/test-id-map.txt
@@ -1,0 +1,134 @@
+# #503 test-ID -> precondition map
+# For every row that depends on a probe's identity or on a fixture
+# fact, the exact source line whose truth the row's verdict rests on.
+# Counting assertions is not evidence; this is the mapping.
+# File: server/src/file-network-scope.test.ts
+
+probes are registered after the auto-admin slot is taken, and are not admin
+    defined      :: server/src/file-network-scope.test.ts:216
+    precondition :: server/src/file-network-scope.test.ts:217 :: expect(roleOf(nonAdminUserA.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:218 :: expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:219 :: expect(roleOf(outsiderUser.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:220 :: expect(roleOf(viewerOnlyUser.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:221 :: expect(roleOf(mixedUser.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:224 :: expect(roleOf(adminUser.userId)).toBe("admin");
+
+network membership is shaped as the matrix assumes
+    defined      :: server/src/file-network-scope.test.ts:227
+    precondition :: server/src/file-network-scope.test.ts:233 :: expect(memberships(nonAdminUserA.userId).map((r) => r.network_id)).toEqual([N1]);
+    precondition :: server/src/file-network-scope.test.ts:235 :: expect(memberships(nonAdminUserB.userId).map((r) => r.network_id).sort()).toEqual([N1, N2].sort());
+    precondition :: server/src/file-network-scope.test.ts:237 :: expect(memberships(outsiderUser.userId).some((r) => r.network_id === N1)).toBe(false);
+    precondition :: server/src/file-network-scope.test.ts:239 :: expect(memberships(viewerOnlyUser.userId)).toEqual([{ network_id: N1, role: "viewer" }]);
+    precondition :: server/src/file-network-scope.test.ts:241 :: expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N_FAKE)).toBeFalsy();
+    precondition :: server/src/file-network-scope.test.ts:244 :: expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N3)).toBeTruthy();
+    precondition :: server/src/file-network-scope.test.ts:245 :: expect(memberships(nonAdminUserB.userId).some((r) => r.network_id === N3)).toBe(false);
+
+U4: ntok_(N1), no param → 200 and entry.network_id === N1 (bound network is the attribution)
+    defined      :: server/src/file-network-scope.test.ts:274
+    precondition :: server/src/file-network-scope.test.ts:276 :: expect(readEntry(fileId).network_id).toBe(N1);
+
+U5: ntok_(N1), param=N2 → 400 network_id_conflict (never silently overridden)
+    defined      :: server/src/file-network-scope.test.ts:279
+    precondition :: server/src/file-network-scope.test.ts:284 :: expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N2)).toBeTruthy();
+
+U6: utok_ single-network non-admin, no param → 200 and entry.network_id === N1
+    defined      :: server/src/file-network-scope.test.ts:287
+    precondition :: server/src/file-network-scope.test.ts:288 :: expect(roleOf(nonAdminUserA.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:290 :: expect(readEntry(fileId).network_id).toBe(N1);
+
+U7: utok_ multi-network non-admin, no param → 400 network_id_required ('first network' is never assumed)
+    defined      :: server/src/file-network-scope.test.ts:293
+    precondition :: server/src/file-network-scope.test.ts:294 :: expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+
+U8: utok_ multi-network non-admin, param=N1 (a network they belong to) → 200 and entry.network_id === N1
+    defined      :: server/src/file-network-scope.test.ts:300
+    precondition :: server/src/file-network-scope.test.ts:301 :: expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:303 :: expect(readEntry(fileId).network_id).toBe(N1);
+
+U9: utok_ non-admin, param=N3 (exists, not a member) → 403 at the shared REST scope guard
+    defined      :: server/src/file-network-scope.test.ts:312
+    precondition :: server/src/file-network-scope.test.ts:313 :: expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+
+U10a: utok_ non-admin, param=N_FAKE (does not exist) → 403, indistinguishable from U9
+    defined      :: server/src/file-network-scope.test.ts:319
+    precondition :: server/src/file-network-scope.test.ts:320 :: expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+
+U10b: admin utok_, param=N_FAKE → 400 unknown_network (admin already knows the network list; no oracle)
+    defined      :: server/src/file-network-scope.test.ts:326
+    precondition :: server/src/file-network-scope.test.ts:327 :: expect(roleOf(adminUser.userId)).toBe("admin");
+
+U12: admin utok_, param=N1 → 200 and entry.network_id === N1
+    defined      :: server/src/file-network-scope.test.ts:339
+    precondition :: server/src/file-network-scope.test.ts:341 :: expect(readEntry(fileId).network_id).toBe(N1);
+
+U13: utok_ viewer, single network, no param → 403 permission_denied (read-only role cannot write)
+    defined      :: server/src/file-network-scope.test.ts:344
+    precondition :: server/src/file-network-scope.test.ts:345 :: expect(roleOf(viewerOnlyUser.userId)).not.toBe("admin");
+
+U14: utok_ member of N1 but viewer in N2, param=N2 → 403 permission_denied
+    defined      :: server/src/file-network-scope.test.ts:351
+    precondition :: server/src/file-network-scope.test.ts:352 :: expect(roleOf(mixedUser.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:359 :: expect(readEntry(okFileId).network_id).toBe(N1);
+    precondition :: server/src/file-network-scope.test.ts:369 :: expect(readEntry(fileInN1).network_id).toBe(N1);
+    precondition :: server/src/file-network-scope.test.ts:370 :: expect(readEntry(fileInN2).network_id).toBe(N2);
+
+D3: utok_ non-admin who is a member of N1 reads a file in N1 → 200 (the carve-out #495 deferred)
+    defined      :: server/src/file-network-scope.test.ts:404
+    precondition :: server/src/file-network-scope.test.ts:405 :: expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:408 :: expect(readEntry(fileInN1).owner_id).toBe(nonAdminUserA.userId);
+    precondition :: server/src/file-network-scope.test.ts:409 :: expect(readEntry(fileInN1).owner_id).not.toBe(nonAdminUserB.userId);
+
+🔴 D4: utok_ non-admin who is not a member of N1 reads a file in N1 → 404
+    defined      :: server/src/file-network-scope.test.ts:415
+    precondition :: server/src/file-network-scope.test.ts:416 :: expect(roleOf(outsiderUser.userId)).not.toBe("admin");
+
+D5: utok_ non-admin with role viewer in N1 reads a file in N1 → 200 (viewer is read-only, not read-never)
+    defined      :: server/src/file-network-scope.test.ts:422
+    precondition :: server/src/file-network-scope.test.ts:423 :: expect(roleOf(viewerOnlyUser.userId)).not.toBe("admin");
+
+D6: admin utok_ reads a file in a network → 200 (operational access preserved)
+    defined      :: server/src/file-network-scope.test.ts:429
+    precondition :: server/src/file-network-scope.test.ts:430 :: expect(roleOf(adminUser.userId)).toBe("admin");
+
+D8: utok_ non-admin owner reads their own legacy (no network_id) file → 200
+    defined      :: server/src/file-network-scope.test.ts:442
+    precondition :: server/src/file-network-scope.test.ts:443 :: expect(roleOf(nonAdminUserA.userId)).not.toBe("admin");
+
+🔴 D9: utok_ non-admin non-owner reads someone else's legacy file → 404 (owner match did not widen)
+    defined      :: server/src/file-network-scope.test.ts:449
+    precondition :: server/src/file-network-scope.test.ts:450 :: expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:454 :: expect(db.all("SELECT 1 FROM network_members WHERE user_id = ?1 AND network_id = ?2",
+
+D12: utok_ non-admin reads a null-owner legacy file with DEV_OPEN off → 404 fail-closed
+    defined      :: server/src/file-network-scope.test.ts:471
+    precondition :: server/src/file-network-scope.test.ts:472 :: expect(roleOf(nonAdminUserA.userId)).not.toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:473 :: expect(process.env.COMMHUB_DEV_OPEN).toBeUndefined();
+
+🔴 D15: an ntok_ ISSUED BY AN ADMIN, bound to N1, reads a file in N2 → 404
+    defined      :: server/src/file-network-scope.test.ts:489
+    precondition :: server/src/file-network-scope.test.ts:495 :: expect(roleOf(adminUser.userId)).toBe("admin");
+    precondition :: server/src/file-network-scope.test.ts:499 :: expect(tokenRow?.user_id).toBe(adminUser.userId);
+    precondition :: server/src/file-network-scope.test.ts:500 :: expect(tokenRow?.network_id).toBe(N1);
+
+E3: cross-network deny via utok_ (D4) is byte-identical to unknown file_id
+    defined      :: server/src/file-network-scope.test.ts:535
+    precondition :: server/src/file-network-scope.test.ts:536 :: expect(roleOf(outsiderUser.userId)).not.toBe("admin");
+
+E7: upload to a network you are not a member of → 403 with the shared scope-guard body
+    defined      :: server/src/file-network-scope.test.ts:573
+    precondition :: server/src/file-network-scope.test.ts:574 :: expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+
+E8: for a non-admin, 'network exists but is not yours' and 'network does not exist' are byte-identical
+    defined      :: server/src/file-network-scope.test.ts:580
+    precondition :: server/src/file-network-scope.test.ts:584 :: expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N3)).toBeTruthy();
+    precondition :: server/src/file-network-scope.test.ts:585 :: expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N_FAKE)).toBeFalsy();
+    precondition :: server/src/file-network-scope.test.ts:586 :: expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+
+E9: admin uploading to a nonexistent network gets the distinguishable 400 (no oracle — admin sees the list anyway)
+    defined      :: server/src/file-network-scope.test.ts:593
+    precondition :: server/src/file-network-scope.test.ts:594 :: expect(roleOf(adminUser.userId)).toBe("admin");
+
+an attributed file ignores owner match — network membership is the rule
+    defined      :: server/src/file-network-scope.test.ts:638
+    precondition :: server/src/file-network-scope.test.ts:642 :: expect(inNetwork.ownerId).toBe("u_owner");
+

--- a/server/src/file-download-authz.test.ts
+++ b/server/src/file-download-authz.test.ts
@@ -56,6 +56,16 @@ const rA = register(nameA, "BootstrapPw123Aa!", undefined, "userA");
 if (!rA.ok) throw new Error(`userA register failed: ${rA.error}`);
 const userAToken = rA.token!;
 const userAUserId = rA.user!.user_id;
+const userANetworkId = rA.network_id!;
+
+// #503 — userA joins userB's network below, which makes userA a
+// SAME-network peer. Cross-network denial needs a principal who is in
+// neither, so userC exists purely to be an outsider.
+const nameC = `userccc_495_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+const rC = register(nameC, "BootstrapPw123Aa!", undefined, "userC");
+if (!rC.ok) throw new Error(`userC register failed: ${rC.error}`);
+const userCToken = rC.token!;
+const userCUserId = rC.user!.user_id;
 
 const nameB = `userbbb_495_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
 const rB = register(nameB, "BootstrapPw123Aa!", undefined, "userB");
@@ -132,10 +142,16 @@ afterAll(() => {
   delete process.env.COMMHUB_AUTH_TOKEN;
 });
 
-async function uploadAs(token: string, content: Uint8Array, filename: string): Promise<string> {
+// #503 — a utok_ holder in more than one network must name the target
+// network; the server refuses to guess ("first network" is not assumed).
+// Callers using a single-network token can still omit it.
+async function uploadAs(token: string, content: Uint8Array, filename: string, networkId?: string): Promise<string> {
   const form = new FormData();
   form.append("file", new Blob([content], { type: "application/octet-stream" }), filename);
-  const res = await fetch(`${BASE}/api/upload`, {
+  const url = networkId
+    ? `${BASE}/api/upload?network_id=${encodeURIComponent(networkId)}`
+    : `${BASE}/api/upload`;
+  const res = await fetch(url, {
     method: "POST",
     body: form,
     headers: { Authorization: `Bearer ${token}` },
@@ -173,27 +189,36 @@ describe.skipIf(!isProdMode)("#495 — GET /api/files/:file_id authorization (ow
     expect(await res.text()).toBe("agent-blob");
   });
 
-  test("🔴 non-owner (userA) downloads userB's file → 404 (was 200 pre-#495)", async () => {
-    const res = await downloadAs(userAToken, userBFileId);
+  test("🔴 cross-network non-owner (userC) downloads userB's file → 404 (was 200 pre-#495)", async () => {
+    // Precondition — userC is in NEITHER of userB's networks, so the 404
+    // is cross-network denial. This row used to use userA, but #503 made
+    // userA a legitimate same-network reader; keeping userA here would
+    // have turned #495's guarantee into a test that asserts nothing.
+    const rows = db.all<{ network_id: string }>(
+      "SELECT network_id FROM network_members WHERE user_id = ?1 AND network_id = ?2",
+      userCUserId, userBNetworkId,
+    );
+    expect(rows.length).toBe(0);
+    const res = await downloadAs(userCToken, userBFileId);
     expect(res.status).toBe(404);
     const body: any = await res.json();
     expect(body.error).toBe("not_found");
   });
 
-  test("🔴 same-network non-owner (userA is a member of userB's network) → 404 (STAGED carve-out; follow-up #503)", async () => {
-    // Precondition — userA really is a member of userB's default
-    // network (added in module setup). Guard the invariant so the
-    // 404 result actually represents "same-network peer denied",
-    // not "cross-network denied".
+  test("🔴 same-network non-owner (userA is a member of userB's network) → 200 (#503 lifted the #495 staged carve-out)", async () => {
+    // Precondition — userA really is a member of userB's default network
+    // (added in module setup), so the 200 represents "same-network peer
+    // allowed" rather than an owner match or an admin bypass.
     const rows = db.all<{ network_id: string }>(
       "SELECT network_id FROM network_members WHERE user_id = ?1 AND network_id = ?2",
       userAUserId, userBNetworkId,
     );
     expect(rows.length).toBe(1);
+    expect(db.get<{ role: string }>("SELECT role FROM users WHERE user_id = ?1", userAUserId)?.role)
+      .not.toBe("admin");
     const res = await downloadAs(userAToken, userBFileId);
-    expect(res.status).toBe(404);
-    const body: any = await res.json();
-    expect(body.error).toBe("not_found");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("secret-from-B");
   });
 
   test("admin caller downloads any file → 200 (operational access preserved)", async () => {
@@ -247,8 +272,10 @@ describe.skipIf(!isProdMode)("#500 CR2 — HEAD /api/files/:file_id authorizatio
     expect(res.headers.get("x-content-type-options")).toBe("nosniff");
   });
 
-  test("🔴 cross-owner HEAD (userA HEAD userB's file) → 404 via helper (was fallback 200 pre-CR2)", async () => {
-    const res = await headAs(userAToken, userBFileId);
+  test("🔴 cross-network HEAD (userC HEAD userB's file) → 404 via helper (was fallback 200 pre-CR2)", async () => {
+    // userC, not userA — #503 makes userA a same-network reader, so the
+    // GET/HEAD parity claim needs a principal who is genuinely denied.
+    const res = await headAs(userCToken, userBFileId);
     expect(res.status).toBe(404);
     // 404 must originate from authorizeFileDownload, not the fallback
     // page. Body is application/json ({"ok":false,"error":"not_found"})
@@ -284,7 +311,9 @@ describe.skipIf(!isProdMode)("#500 CR2 — HEAD /api/files/:file_id authorizatio
 // in the authorizeFileDownload comment and this test enforces it.
 describe.skipIf(!isProdMode)("#500 CR2 — upload persists truthy owner_id (D1)", () => {
   test("D1: userA authenticated upload → index entry owner_id === userA.userId (never null)", async () => {
-    const fileId = await uploadAs(userAToken, new TextEncoder().encode("owner-persistence-check"), "d1.bin");
+    // userA belongs to two networks (own default + userB's), so #503
+    // requires the target network to be named explicitly.
+    const fileId = await uploadAs(userAToken, new TextEncoder().encode("owner-persistence-check"), "d1.bin", userANetworkId);
     const { readFileSync } = await import("fs");
     const entryPath = join(UPLOADS_DIR, ".index", `${fileId}.json`);
     expect(existsSync(entryPath)).toBe(true);
@@ -314,13 +343,18 @@ describe.skipIf(!isProdMode)("#495 — null-owner policy in production (DEV_OPEN
     // reproduces the shape a DEV_OPEN or legacy master upload would
     // create, without needing to spin up a second server in a
     // different mode.
-    nullOwnerFileId = await uploadAs(userAToken, new TextEncoder().encode("legacy-blob"), "legacy.txt");
+    nullOwnerFileId = await uploadAs(userAToken, new TextEncoder().encode("legacy-blob"), "legacy.txt", userANetworkId);
     const { readFileSync: rfs, writeFileSync: wfs } = await import("fs");
     const entryFile = join(UPLOADS_DIR, ".index", `${nullOwnerFileId}.json`);
     if (!existsSync(entryFile)) throw new Error(`index entry not found: ${entryFile}`);
     const entry = JSON.parse(rfs(entryFile, "utf-8"));
     entry.owner = null;
     entry.owner_id = null;
+    // #503 — a true legacy entry predates network attribution entirely.
+    // Deleting the key (rather than nulling it) matches what the writer
+    // emits when there is no attribution, so this fixture exercises the
+    // legacy compatibility branch instead of the network branch.
+    delete entry.network_id;
     wfs(entryFile, JSON.stringify(entry, null, 2));
   });
 

--- a/server/src/file-network-scope-dev-open.test.ts
+++ b/server/src/file-network-scope-dev-open.test.ts
@@ -1,0 +1,97 @@
+// #503 — the DEV_OPEN half of the upload attribution matrix (row U3).
+//
+// Separate file for the same reason #495/#500 split theirs: DEV_OPEN is
+// frozen at server.ts module-load time, so it cannot be flipped inside a
+// process that already loaded the module with DEV_OPEN=false.
+//
+// The row that matters: an unauthenticated DEV_OPEN caller must NOT be
+// able to file a blob into a real tenant network, even by asking for one
+// via ?network_id=. The upload succeeds (that is the point of dev-open
+// mode) but lands unattributed, and "unattributed" must be the key being
+// ABSENT rather than written as null — the writer and validateIndexEntry
+// have to agree on one shape or a dev-mode upload would be unreadable by
+// its own server.
+
+import { describe, expect, test, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const SERVER_DB = mkdtempSync(join(tmpdir(), "anet-503-devopen-db-")) + "/commhub.db";
+const UPLOADS_DIR = mkdtempSync(join(tmpdir(), "anet-503-devopen-fs-"));
+
+process.env.COMMHUB_DB = SERVER_DB;
+process.env.COMMHUB_UPLOADS_DIR = UPLOADS_DIR;
+process.env.HOST = "127.0.0.1";
+process.env.COMMHUB_DEV_OPEN = "1";
+delete process.env.COMMHUB_AUTH_TOKEN;
+
+const { register } = await import("./auth.js");
+
+const stamp = `${Date.now()}${Math.floor(Math.random() * 100000)}`;
+const seed = register(`u503dorealnet${stamp}`, "BootstrapPw123Aa!", undefined, "seed");
+if (!seed.ok) throw new Error(`seed register failed: ${seed.error}`);
+const REAL_NETWORK_ID = seed.network_id!;
+
+const { bootServer } = await import("./server.js");
+const server = bootServer({ port: 0, hostname: "127.0.0.1" });
+const BASE = `http://127.0.0.1:${server.port}`;
+await new Promise((r) => setTimeout(r, 100));
+
+async function uploadAnon(body: string, filename: string, networkId?: string): Promise<Response> {
+  const form = new FormData();
+  form.append("file", new Blob([new TextEncoder().encode(body)], { type: "application/octet-stream" }), filename);
+  const url = networkId
+    ? `${BASE}/api/upload?network_id=${encodeURIComponent(networkId)}`
+    : `${BASE}/api/upload`;
+  return fetch(url, { method: "POST", body: form });
+}
+
+// Probe whether the loaded module really has DEV_OPEN on. In an aggregate
+// run a sibling may have loaded server.ts first; `skipIf` then reports
+// "skipped" rather than a green that measured the wrong build.
+const devOpenActive = (await uploadAnon("probe", "probe.bin")).status === 200;
+
+afterAll(() => {
+  try { server?.stop?.(true); } catch {}
+  try { rmSync(UPLOADS_DIR, { recursive: true, force: true }); } catch {}
+  try { rmSync(SERVER_DB, { recursive: true, force: true }); } catch {}
+  delete process.env.COMMHUB_DEV_OPEN;
+});
+
+function readEntry(fileId: string): any {
+  return JSON.parse(readFileSync(join(UPLOADS_DIR, ".index", `${fileId}.json`), "utf-8"));
+}
+
+describe.skipIf(!devOpenActive)("#503 U3 — DEV_OPEN anonymous uploads are never attributed to a network", () => {
+  test("U3: anonymous DEV_OPEN upload asking for a REAL network → 200, but the network_id key is absent", async () => {
+    // The requested network genuinely exists, so an absent key proves the
+    // request was refused attribution, not that the lookup missed.
+    const { db } = await import("./db.js");
+    expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", REAL_NETWORK_ID)).toBeTruthy();
+
+    const res = await uploadAnon("dev-open-payload", "u3.bin", REAL_NETWORK_ID);
+    expect(res.status).toBe(200);
+    const fileId = (await res.json() as any).file_id;
+
+    const entry = readEntry(fileId);
+    expect("network_id" in entry).toBe(false);
+    expect(entry.network_id).toBeUndefined();
+    expect(entry.owner_id).toBeNull();
+  });
+
+  test("U3b: an unattributed DEV_OPEN blob is still readable by its own server (writer and validator agree)", async () => {
+    const res = await uploadAnon("round-trip", "u3b.bin");
+    expect(res.status).toBe(200);
+    const fileId = (await res.json() as any).file_id;
+    expect("network_id" in readEntry(fileId)).toBe(false);
+
+    // If the writer had emitted `network_id: null`, validateIndexEntry
+    // would reject the entry here and this would 404 — the "自己打死
+    // 自己" failure the spread pattern exists to prevent.
+    const dl = await fetch(`${BASE}/api/files/${fileId}`);
+    expect(dl.status).toBe(200);
+    expect(await dl.text()).toBe("round-trip");
+    expect(existsSync(join(UPLOADS_DIR, ".index", `${fileId}.json`))).toBe(true);
+  });
+});

--- a/server/src/file-network-scope.test.ts
+++ b/server/src/file-network-scope.test.ts
@@ -1,0 +1,686 @@
+// #503 — network scope for /api/files/:file_id + upload attribution.
+//
+// #495/#500 gave downloads an owner-only allow-list and explicitly
+// deferred "same-network non-owner" to this issue. This suite covers
+// both halves of the fix:
+//   • upload decides WHICH network a blob belongs to (U rows), and
+//   • download decides who may read a blob given that network (D rows),
+// plus the enumeration-oracle rows (E) that pin denied responses to be
+// byte-identical to "no such thing".
+//
+// FIXTURE DISCIPLINE — the whole suite is worthless if a probe is admin.
+// `authorizeFileDownload` returns true for admin-utok before it ever
+// looks at the network, so an admin probe passes every D row while
+// proving nothing. commhub auto-promotes the FIRST registered user to
+// admin (auth.ts register(): `isFirstUser ? "admin" : "user"`), so:
+//   1. a throwaway `seedUser` is registered first to occupy that slot,
+//   2. every non-admin probe is registered after it, and
+//   3. each row re-reads the probe's role from the DB and asserts it is
+//      not admin — inline, not via a helper, so the assertion cannot be
+//      deleted in one place and lost everywhere.
+// See project memory feedback_first_registered_user_is_admin_fake_green.
+//
+// DEV_OPEN rows live in file-network-scope-dev-open.test.ts: DEV_OPEN is
+// captured at server.ts module-load time and cannot be flipped mid-suite
+// (same reason #500 split its DEV_OPEN coverage into a sibling file).
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { tmpdir } from "os";
+// Type-only — erased at runtime, so it cannot pull server.ts in before
+// the env below is set.
+import type { Principal } from "./server.js";
+
+const SERVER_DB = mkdtempSync(join(tmpdir(), "anet-503-db-")) + "/commhub.db";
+const UPLOADS_DIR = mkdtempSync(join(tmpdir(), "anet-503-fs-"));
+const MASTER_TOKEN = `master-503-${Date.now()}-${Math.floor(Math.random() * 100000)}`;
+
+// Env must be set before anything pulls in db-adapter.ts (which refuses
+// the default DB under NODE_ENV=test) or server.ts (which freezes
+// DEV_OPEN + AUTH_TOKEN at module load).
+process.env.COMMHUB_DB = SERVER_DB;
+process.env.COMMHUB_UPLOADS_DIR = UPLOADS_DIR;
+process.env.HOST = "127.0.0.1";
+process.env.COMMHUB_AUTH_TOKEN = MASTER_TOKEN;
+delete process.env.COMMHUB_DEV_OPEN;
+
+const { register, addNetworkMember, createNetworkTokenForNode } = await import("./auth.js");
+const { db } = await import("./db.js");
+
+const STAMP = `${Date.now()}${Math.floor(Math.random() * 100000)}`;
+
+type Probe = {
+  name: string;
+  userId: string;
+  token: string;      // utok_
+  ntok: string;       // ntok_ bound to their own default network
+  networkId: string;  // their own auto-created default network
+};
+
+function reg(label: string): Probe {
+  const name = `u503${label}${STAMP}`;
+  const r = register(name, "BootstrapPw123Aa!", undefined, label);
+  if (!r.ok) throw new Error(`${label} register failed: ${r.error}`);
+  return {
+    name,
+    userId: r.user!.user_id,
+    token: r.token!,
+    ntok: r.network_token!,
+    networkId: r.network_id!,
+  };
+}
+
+function roleOf(userId: string): string | null {
+  return db.get<{ role: string }>("SELECT role FROM users WHERE user_id = ?1", userId)?.role ?? null;
+}
+
+// 1. Occupies the auto-admin slot so no probe below can inherit it.
+const seedUser = reg("seed");
+// 2. The admin probe is promoted explicitly rather than relying on
+//    registration order, which is not stable under aggregate runs.
+const adminUser = reg("admin");
+db.run("UPDATE users SET role = 'admin' WHERE user_id = ?1", [adminUser.userId]);
+// 3. Non-admin probes.
+const nonAdminUserA = reg("usera");
+const nonAdminUserB = reg("userb");
+const outsiderUser = reg("outsider");
+const viewerOnlyUser = reg("vieweronly");
+const mixedUser = reg("mixed");
+
+// N1 is userA's own default network — userA stays single-network so the
+// "no query param, unambiguous membership" upload path (U6) is reachable.
+const N1 = nonAdminUserA.networkId;
+// N2 is userB's own default network. userB also joins N1, making userB
+// multi-network (U7/U8) and a same-network non-owner peer of userA (D3).
+const N2 = nonAdminUserB.networkId;
+// N3 exists but userB is not a member — the "not yours" upload row (U9).
+const N3 = seedUser.networkId;
+const N_FAKE = `net_503fake${STAMP}`;
+
+if (!addNetworkMember(N1, nonAdminUserB.userId, "member", nonAdminUserA.userId).ok) {
+  throw new Error("fixture: userB → N1 member failed");
+}
+// The admin needs write access to N1 to be issued a node ntok_ there
+// (createNetworkTokenForNode refuses non-members and viewers). That
+// token is the D15 probe: a ntok_ ISSUED BY an admin.
+if (!addNetworkMember(N1, adminUser.userId, "member", nonAdminUserA.userId).ok) {
+  throw new Error("fixture: admin → N1 member failed");
+}
+// viewerOnlyUser must hold exactly one network, with role viewer, so the
+// "no param + unambiguous network + no write access" row (U13) is
+// reachable. register() makes everyone owner of a default network, so
+// that membership is dropped here.
+db.run("DELETE FROM network_members WHERE user_id = ?1", [viewerOnlyUser.userId]);
+if (!addNetworkMember(N1, viewerOnlyUser.userId, "viewer", nonAdminUserA.userId).ok) {
+  throw new Error("fixture: viewerOnly → N1 viewer failed");
+}
+// mixedUser can write in N1 but only read in N2 — U14 asserts that an
+// explicit param pointing at the viewer network is refused.
+if (!addNetworkMember(N1, mixedUser.userId, "member", nonAdminUserA.userId).ok) {
+  throw new Error("fixture: mixed → N1 member failed");
+}
+if (!addNetworkMember(N2, mixedUser.userId, "viewer", nonAdminUserB.userId).ok) {
+  throw new Error("fixture: mixed → N2 viewer failed");
+}
+
+const adminNtokN1 = createNetworkTokenForNode(adminUser.userId, N1, "d15probe");
+if (!adminNtokN1.ok) throw new Error(`fixture: admin ntok_ on N1 failed: ${adminNtokN1.error}`);
+
+const { bootServer, authorizeFileDownload, normalizeEntry } = await import("./server.js");
+const server = bootServer({ port: 0, hostname: "127.0.0.1" });
+const BASE = `http://127.0.0.1:${server.port}`;
+await new Promise((r) => setTimeout(r, 100));
+
+// The loaded server module's AUTH_TOKEN binding may predate our env in
+// an aggregate run. Probe it and `skipIf` the legacy-master rows so the
+// runner reports "skipped", never "passed".
+const _probeMaster = await fetch(`${BASE}/api/files/00000000000000000000000000000000`, {
+  headers: { Authorization: `Bearer ${MASTER_TOKEN}` },
+});
+const masterTokenActive = _probeMaster.status === 404;
+
+// This file asserts production semantics; if a sibling loaded server.ts
+// with DEV_OPEN=1 first, the singleton wins and these rows would be
+// measuring the wrong build.
+async function _anonUploadStatus(): Promise<number> {
+  const form = new FormData();
+  form.append("file", new Blob([new TextEncoder().encode("p")]), "p.bin");
+  const r = await fetch(`${BASE}/api/upload`, { method: "POST", body: form });
+  return r.status;
+}
+const isProdMode = (await _anonUploadStatus()) !== 200;
+
+afterAll(() => {
+  try { server?.stop?.(true); } catch {}
+  try { rmSync(UPLOADS_DIR, { recursive: true, force: true }); } catch {}
+  try { rmSync(SERVER_DB, { recursive: true, force: true }); } catch {}
+  delete process.env.COMMHUB_AUTH_TOKEN;
+});
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+function uploadUrl(networkId?: string): string {
+  return networkId ? `${BASE}/api/upload?network_id=${encodeURIComponent(networkId)}` : `${BASE}/api/upload`;
+}
+
+async function upload(token: string | null, body: string, filename: string, networkId?: string): Promise<Response> {
+  const form = new FormData();
+  form.append("file", new Blob([new TextEncoder().encode(body)], { type: "application/octet-stream" }), filename);
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return fetch(uploadUrl(networkId), { method: "POST", body: form, headers });
+}
+
+async function uploadOk(token: string, body: string, filename: string, networkId?: string): Promise<string> {
+  const res = await upload(token, body, filename, networkId);
+  if (res.status !== 200) throw new Error(`upload expected 200, got ${res.status}: ${await res.text()}`);
+  const json: any = await res.json();
+  return json.file_id;
+}
+
+function entryPath(fileId: string): string {
+  return join(UPLOADS_DIR, ".index", `${fileId}.json`);
+}
+
+function readEntry(fileId: string): any {
+  return JSON.parse(readFileSync(entryPath(fileId), "utf-8"));
+}
+
+function writeEntry(fileId: string, entry: any): void {
+  writeFileSync(entryPath(fileId), JSON.stringify(entry, null, 2));
+}
+
+async function download(token: string | null, fileId: string): Promise<Response> {
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return fetch(`${BASE}/api/files/${fileId}`, { headers });
+}
+
+async function head(token: string | null, fileId: string): Promise<Response> {
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return fetch(`${BASE}/api/files/${fileId}`, { method: "HEAD", headers });
+}
+
+const UNKNOWN_FILE_ID = "0123456789abcdef0123456789abcdef";
+
+// Files used by the D rows. Built once, in beforeAll, through the real
+// upload path so the D rows read what the U rows actually write.
+let fileInN1 = "";
+let fileInN2 = "";
+let legacyOwnedByA = "";
+let legacyNullOwner = "";
+
+describe.skipIf(!isProdMode)("#503 — fixture integrity", () => {
+  test("probes are registered after the auto-admin slot is taken, and are not admin", () => {
+    expect(roleOf(nonAdminUserA.userId)).not.toBe("admin");
+    expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    expect(roleOf(outsiderUser.userId)).not.toBe("admin");
+    expect(roleOf(viewerOnlyUser.userId)).not.toBe("admin");
+    expect(roleOf(mixedUser.userId)).not.toBe("admin");
+    // The admin probe must really be admin, or D6/D10/D14/U10b/U11/U12
+    // would be measuring a non-admin and silently prove nothing.
+    expect(roleOf(adminUser.userId)).toBe("admin");
+  });
+
+  test("network membership is shaped as the matrix assumes", () => {
+    const memberships = (userId: string) =>
+      db.all<{ network_id: string; role: string }>(
+        "SELECT network_id, role FROM network_members WHERE user_id = ?1", userId,
+      );
+    // userA single-network (U6 depends on it being unambiguous).
+    expect(memberships(nonAdminUserA.userId).map((r) => r.network_id)).toEqual([N1]);
+    // userB multi-network (U7 depends on it being ambiguous).
+    expect(memberships(nonAdminUserB.userId).map((r) => r.network_id).sort()).toEqual([N1, N2].sort());
+    // outsider is in neither N1 nor N2 (D4 depends on it).
+    expect(memberships(outsiderUser.userId).some((r) => r.network_id === N1)).toBe(false);
+    // viewerOnly holds exactly one network, as viewer (U13 depends on both).
+    expect(memberships(viewerOnlyUser.userId)).toEqual([{ network_id: N1, role: "viewer" }]);
+    // N_FAKE really does not exist (U10a/U10b/E8/E9 depend on it).
+    expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N_FAKE)).toBeFalsy();
+    // N3 really does exist and userB really is not in it (U9 must be
+    // "exists but not yours", not accidentally "does not exist").
+    expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N3)).toBeTruthy();
+    expect(memberships(nonAdminUserB.userId).some((r) => r.network_id === N3)).toBe(false);
+  });
+});
+
+// ── Upload matrix ──────────────────────────────────────────────────────
+
+describe.skipIf(!isProdMode)("#503 U — upload network attribution", () => {
+  // U1/U2 as designed assumed a legacy master could upload. It cannot:
+  // requireAuth 401s master tokens on every non-GET /api/ request since
+  // RFC-001 made them read-only, so the `legacy-master` upload branch is
+  // unreachable. These two rows pin that fact instead — if RFC-001's
+  // read-only rule is ever relaxed, they go red and the unattributed-write
+  // question has to be answered deliberately rather than by accident.
+  test.skipIf(!masterTokenActive)("U1: legacy master upload, no param → 401 (master tokens are read-only, RFC-001)", async () => {
+    const res = await upload(MASTER_TOKEN, "u1", "u1.bin");
+    expect(res.status).toBe(401);
+  });
+
+  test.skipIf(!masterTokenActive)("U2: legacy master upload, param=N1 → 401 (a query param does not buy write access)", async () => {
+    const res = await upload(MASTER_TOKEN, "u2", "u2.bin", N1);
+    expect(res.status).toBe(401);
+    // Same token CAN read — proves the 401 is about the write verb, not a
+    // dead/misconfigured master token (which would make U1 vacuous).
+    const readBack = await fetch(`${BASE}/api/files/${UNKNOWN_FILE_ID}`, {
+      headers: { Authorization: `Bearer ${MASTER_TOKEN}` },
+    });
+    expect(readBack.status).toBe(404);
+  });
+
+  test("U4: ntok_(N1), no param → 200 and entry.network_id === N1 (bound network is the attribution)", async () => {
+    const fileId = await uploadOk(nonAdminUserA.ntok, "u4", "u4.bin");
+    expect(readEntry(fileId).network_id).toBe(N1);
+  });
+
+  test("U5: ntok_(N1), param=N2 → 400 network_id_conflict (never silently overridden)", async () => {
+    const res = await upload(nonAdminUserA.ntok, "u5", "u5.bin", N2);
+    expect(res.status).toBe(400);
+    expect((await res.json() as any).error).toBe("network_id_conflict");
+    // The conflicting network must not have been written to either.
+    expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N2)).toBeTruthy();
+  });
+
+  test("U6: utok_ single-network non-admin, no param → 200 and entry.network_id === N1", async () => {
+    expect(roleOf(nonAdminUserA.userId)).not.toBe("admin");
+    const fileId = await uploadOk(nonAdminUserA.token, "u6", "u6.bin");
+    expect(readEntry(fileId).network_id).toBe(N1);
+  });
+
+  test("U7: utok_ multi-network non-admin, no param → 400 network_id_required ('first network' is never assumed)", async () => {
+    expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    const res = await upload(nonAdminUserB.token, "u7", "u7.bin");
+    expect(res.status).toBe(400);
+    expect((await res.json() as any).error).toBe("network_id_required");
+  });
+
+  test("U8: utok_ multi-network non-admin, param=N1 (a network they belong to) → 200 and entry.network_id === N1", async () => {
+    expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    const fileId = await uploadOk(nonAdminUserB.token, "u8", "u8.bin", N1);
+    expect(readEntry(fileId).network_id).toBe(N1);
+  });
+
+  // U9/U10a as designed expected a 404 emitted by the upload handler.
+  // The request never reaches it: every REST /api endpoint already passes
+  // through a shared network-scope guard (server.ts, `restScope.denied`)
+  // that 403s a non-member's ?network_id=. The security property the
+  // design wanted — a non-admin cannot tell "exists, not yours" from "no
+  // such network" — holds there instead, and E8 pins it byte-for-byte.
+  test("U9: utok_ non-admin, param=N3 (exists, not a member) → 403 at the shared REST scope guard", async () => {
+    expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    const res = await upload(nonAdminUserB.token, "u9", "u9.bin", N3);
+    expect(res.status).toBe(403);
+    expect((await res.json() as any).error).toBe("access denied to requested network");
+  });
+
+  test("U10a: utok_ non-admin, param=N_FAKE (does not exist) → 403, indistinguishable from U9", async () => {
+    expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    const res = await upload(nonAdminUserB.token, "u10a", "u10a.bin", N_FAKE);
+    expect(res.status).toBe(403);
+    expect((await res.json() as any).error).toBe("access denied to requested network");
+  });
+
+  test("U10b: admin utok_, param=N_FAKE → 400 unknown_network (admin already knows the network list; no oracle)", async () => {
+    expect(roleOf(adminUser.userId)).toBe("admin");
+    const res = await upload(adminUser.token, "u10b", "u10b.bin", N_FAKE);
+    expect(res.status).toBe(400);
+    expect((await res.json() as any).error).toBe("unknown_network");
+  });
+
+  test("U11: admin utok_, no param → 400 network_id_required (attribution is never guessed for admins)", async () => {
+    const res = await upload(adminUser.token, "u11", "u11.bin");
+    expect(res.status).toBe(400);
+    expect((await res.json() as any).error).toBe("network_id_required");
+  });
+
+  test("U12: admin utok_, param=N1 → 200 and entry.network_id === N1", async () => {
+    const fileId = await uploadOk(adminUser.token, "u12", "u12.bin", N1);
+    expect(readEntry(fileId).network_id).toBe(N1);
+  });
+
+  test("U13: utok_ viewer, single network, no param → 403 permission_denied (read-only role cannot write)", async () => {
+    expect(roleOf(viewerOnlyUser.userId)).not.toBe("admin");
+    const res = await upload(viewerOnlyUser.token, "u13", "u13.bin");
+    expect(res.status).toBe(403);
+    expect((await res.json() as any).error).toBe("permission_denied");
+  });
+
+  test("U14: utok_ member of N1 but viewer in N2, param=N2 → 403 permission_denied", async () => {
+    expect(roleOf(mixedUser.userId)).not.toBe("admin");
+    const res = await upload(mixedUser.token, "u14", "u14.bin", N2);
+    expect(res.status).toBe(403);
+    expect((await res.json() as any).error).toBe("permission_denied");
+    // Same caller CAN write to the network where they hold member — proves
+    // the 403 above is about the role in N2, not a blanket denial.
+    const okFileId = await uploadOk(mixedUser.token, "u14ok", "u14ok.bin", N1);
+    expect(readEntry(okFileId).network_id).toBe(N1);
+  });
+});
+
+// ── Download matrix ────────────────────────────────────────────────────
+
+describe.skipIf(!isProdMode)("#503 D — download network scope", () => {
+  beforeAll(async () => {
+    fileInN1 = await uploadOk(nonAdminUserA.token, "payload-N1", "n1.bin");
+    fileInN2 = await uploadOk(nonAdminUserB.token, "payload-N2", "n2.bin", N2);
+    expect(readEntry(fileInN1).network_id).toBe(N1);
+    expect(readEntry(fileInN2).network_id).toBe(N2);
+
+    // Legacy entries: uploaded through the real path, then stripped of
+    // network_id so they carry the exact on-disk shape of a pre-#503
+    // blob. `delete` (not `= null`) matches the writer, which omits the
+    // key entirely when there is no attribution.
+    legacyOwnedByA = await uploadOk(nonAdminUserA.token, "payload-legacy-A", "legacy-a.bin");
+    const eA = readEntry(legacyOwnedByA);
+    delete eA.network_id;
+    writeEntry(legacyOwnedByA, eA);
+
+    legacyNullOwner = await uploadOk(nonAdminUserA.token, "payload-legacy-null", "legacy-null.bin");
+    const eN = readEntry(legacyNullOwner);
+    delete eN.network_id;
+    eN.owner = null;
+    eN.owner_id = null;
+    writeEntry(legacyNullOwner, eN);
+
+    expect("network_id" in readEntry(legacyOwnedByA)).toBe(false);
+    expect("network_id" in readEntry(legacyNullOwner)).toBe(false);
+  });
+
+  test("D1: ntok_ bound to N1 reads a file in N1 → 200", async () => {
+    const res = await download(nonAdminUserA.ntok, fileInN1);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("payload-N1");
+  });
+
+  test("🔴 D2: ntok_ bound to N2 reads a file in N1 → 404 (the cross-network leak #503 closes)", async () => {
+    const res = await download(nonAdminUserB.ntok, fileInN1);
+    expect(res.status).toBe(404);
+    expect((await res.json() as any).error).toBe("not_found");
+  });
+
+  test("D3: utok_ non-admin who is a member of N1 reads a file in N1 → 200 (the carve-out #495 deferred)", async () => {
+    expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    // userB is a same-network peer, not the owner — that distinction is
+    // the whole point of the row.
+    expect(readEntry(fileInN1).owner_id).toBe(nonAdminUserA.userId);
+    expect(readEntry(fileInN1).owner_id).not.toBe(nonAdminUserB.userId);
+    const res = await download(nonAdminUserB.token, fileInN1);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("payload-N1");
+  });
+
+  test("🔴 D4: utok_ non-admin who is not a member of N1 reads a file in N1 → 404", async () => {
+    expect(roleOf(outsiderUser.userId)).not.toBe("admin");
+    const res = await download(outsiderUser.token, fileInN1);
+    expect(res.status).toBe(404);
+    expect((await res.json() as any).error).toBe("not_found");
+  });
+
+  test("D5: utok_ non-admin with role viewer in N1 reads a file in N1 → 200 (viewer is read-only, not read-never)", async () => {
+    expect(roleOf(viewerOnlyUser.userId)).not.toBe("admin");
+    const res = await download(viewerOnlyUser.token, fileInN1);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("payload-N1");
+  });
+
+  test("D6: admin utok_ reads a file in a network → 200 (operational access preserved)", async () => {
+    expect(roleOf(adminUser.userId)).toBe("admin");
+    const res = await download(adminUser.token, fileInN2);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("payload-N2");
+  });
+
+  test.skipIf(!masterTokenActive)("D7: legacy master reads a file in a network → 200 (single-tenant deployments)", async () => {
+    const res = await download(MASTER_TOKEN, fileInN2);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("payload-N2");
+  });
+
+  test("D8: utok_ non-admin owner reads their own legacy (no network_id) file → 200", async () => {
+    expect(roleOf(nonAdminUserA.userId)).not.toBe("admin");
+    const res = await download(nonAdminUserA.token, legacyOwnedByA);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("payload-legacy-A");
+  });
+
+  test("🔴 D9: utok_ non-admin non-owner reads someone else's legacy file → 404 (owner match did not widen)", async () => {
+    expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    // userB shares network N1 with the owner — under the legacy branch
+    // that must NOT be enough, or the compat path would become a hole
+    // wider than the network branch it stands in for.
+    expect(db.all("SELECT 1 FROM network_members WHERE user_id = ?1 AND network_id = ?2",
+      nonAdminUserB.userId, N1).length).toBe(1);
+    const res = await download(nonAdminUserB.token, legacyOwnedByA);
+    expect(res.status).toBe(404);
+    expect((await res.json() as any).error).toBe("not_found");
+  });
+
+  test("D10: admin utok_ reads a legacy file → 200 (存量可读性不变)", async () => {
+    const res = await download(adminUser.token, legacyOwnedByA);
+    expect(res.status).toBe(200);
+  });
+
+  test.skipIf(!masterTokenActive)("D11: legacy master reads a legacy file → 200", async () => {
+    const res = await download(MASTER_TOKEN, legacyOwnedByA);
+    expect(res.status).toBe(200);
+  });
+
+  test("D12: utok_ non-admin reads a null-owner legacy file with DEV_OPEN off → 404 fail-closed", async () => {
+    expect(roleOf(nonAdminUserA.userId)).not.toBe("admin");
+    expect(process.env.COMMHUB_DEV_OPEN).toBeUndefined();
+    const res = await download(nonAdminUserA.token, legacyNullOwner);
+    expect(res.status).toBe(404);
+    expect((await res.json() as any).error).toBe("not_found");
+  });
+
+  test.skipIf(!masterTokenActive)("D13: legacy master reads a null-owner legacy file → 200", async () => {
+    const res = await download(MASTER_TOKEN, legacyNullOwner);
+    expect(res.status).toBe(200);
+  });
+
+  test("D14: admin utok_ reads a null-owner legacy file → 200", async () => {
+    const res = await download(adminUser.token, legacyNullOwner);
+    expect(res.status).toBe(200);
+  });
+
+  test("🔴 D15: an ntok_ ISSUED BY AN ADMIN, bound to N1, reads a file in N2 → 404", async () => {
+    // The production shape: agent node tokens resolve to an admin user.
+    // If resolvePrincipal classified by admin-ness before boundness, this
+    // token would take the admin bypass and every node would keep its
+    // cross-network read. Assert the premise (the token's user really is
+    // admin) so a fixture drift cannot turn this into a trivial pass.
+    expect(roleOf(adminUser.userId)).toBe("admin");
+    const tokenRow = db.get<{ user_id: string; network_id: string }>(
+      "SELECT user_id, network_id FROM api_tokens WHERE name = ?1", "node:d15probe",
+    );
+    expect(tokenRow?.user_id).toBe(adminUser.userId);
+    expect(tokenRow?.network_id).toBe(N1);
+
+    const res = await download(adminNtokN1.token!, fileInN2);
+    expect(res.status).toBe(404);
+    expect((await res.json() as any).error).toBe("not_found");
+
+    // Same token in its own network still works — proves the 404 is
+    // scope, not a broken token.
+    const ok = await download(adminNtokN1.token!, fileInN1);
+    expect(ok.status).toBe(200);
+  });
+});
+
+// ── Enumeration oracle ─────────────────────────────────────────────────
+
+describe.skipIf(!isProdMode)("#503 E — denied responses carry no enumeration signal", () => {
+  let unknownBody = "";
+  let unknownRes: Response;
+
+  beforeAll(async () => {
+    unknownRes = await download(nonAdminUserB.token, UNKNOWN_FILE_ID);
+    unknownBody = await unknownRes.text();
+  });
+
+  test("E1: unknown file_id → 404 with the canonical not_found body", async () => {
+    expect(unknownRes.status).toBe(404);
+    expect(JSON.parse(unknownBody)).toEqual({ ok: false, error: "not_found" });
+  });
+
+  test("E2: cross-network deny (D2) is byte-identical to unknown file_id", async () => {
+    const res = await download(nonAdminUserB.ntok, fileInN1);
+    expect(res.status).toBe(unknownRes.status);
+    expect(await res.text()).toBe(unknownBody);
+  });
+
+  test("E3: cross-network deny via utok_ (D4) is byte-identical to unknown file_id", async () => {
+    expect(roleOf(outsiderUser.userId)).not.toBe("admin");
+    const res = await download(outsiderUser.token, fileInN1);
+    expect(res.status).toBe(unknownRes.status);
+    expect(await res.text()).toBe(unknownBody);
+  });
+
+  test("E4: corrupted index JSON is byte-identical to unknown file_id", async () => {
+    const fileId = await uploadOk(nonAdminUserA.token, "e4", "e4.bin");
+    writeFileSync(entryPath(fileId), "{not json");
+    const res = await download(nonAdminUserA.token, fileId);
+    expect(res.status).toBe(unknownRes.status);
+    expect(await res.text()).toBe(unknownBody);
+  });
+
+  test("E5: schema-invalid index entry is byte-identical to unknown file_id", async () => {
+    const fileId = await uploadOk(nonAdminUserA.token, "e5", "e5.bin");
+    const entry = readEntry(fileId);
+    // Empty-string network_id: present but not a usable value. If
+    // validateIndexEntry stopped rejecting it, normalizeEntry would coerce
+    // it to null and the blob would silently fall back to the legacy
+    // owner-only branch — a downgrade, not a denial.
+    entry.network_id = "";
+    writeEntry(fileId, entry);
+    const res = await download(nonAdminUserA.token, fileId);
+    expect(res.status).toBe(unknownRes.status);
+    expect(await res.text()).toBe(unknownBody);
+  });
+
+  test("E6: HEAD on a cross-network deny matches HEAD on unknown file_id (status + headers)", async () => {
+    const denied = await head(nonAdminUserB.ntok, fileInN1);
+    const unknown = await head(nonAdminUserB.token, UNKNOWN_FILE_ID);
+    expect(denied.status).toBe(404);
+    expect(denied.status).toBe(unknown.status);
+    expect(denied.headers.get("content-type")).toBe(unknown.headers.get("content-type"));
+    expect(denied.headers.get("content-length")).toBe(unknown.headers.get("content-length"));
+  });
+
+  test("E7: upload to a network you are not a member of → 403 with the shared scope-guard body", async () => {
+    expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    const res = await upload(nonAdminUserB.token, "e7", "e7.bin", N3);
+    expect(res.status).toBe(403);
+    expect(JSON.parse(await res.text())).toEqual({ ok: false, error: "access denied to requested network" });
+  });
+
+  test("E8: for a non-admin, 'network exists but is not yours' and 'network does not exist' are byte-identical", async () => {
+    // The premise both halves rest on: one network really exists and the
+    // other really does not. Without this the rows could match by both
+    // being the same kind of failure.
+    expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N3)).toBeTruthy();
+    expect(db.get<any>("SELECT * FROM networks WHERE network_id = ?1", N_FAKE)).toBeFalsy();
+    expect(roleOf(nonAdminUserB.userId)).not.toBe("admin");
+    const notMember = await upload(nonAdminUserB.token, "e8a", "e8a.bin", N3);
+    const notExist = await upload(nonAdminUserB.token, "e8b", "e8b.bin", N_FAKE);
+    expect(notExist.status).toBe(notMember.status);
+    expect(await notExist.text()).toBe(await notMember.text());
+  });
+
+  test("E9: admin uploading to a nonexistent network gets the distinguishable 400 (no oracle — admin sees the list anyway)", async () => {
+    expect(roleOf(adminUser.userId)).toBe("admin");
+    const res = await upload(adminUser.token, "e9", "e9.bin", N_FAKE);
+    expect(res.status).toBe(400);
+    expect(JSON.parse(await res.text()).error).toBe("unknown_network");
+  });
+});
+
+// ── Principal enumeration ──────────────────────────────────────────────
+//
+// Direct unit coverage of every Principal variant against both entry
+// shapes. `anonymous` and `dev-open-anon` are unreachable over HTTP in
+// production mode (requireAuth 401s first), so this is the only place
+// they can be pinned at all.
+
+describe("#503 — authorizeFileDownload covers every Principal variant", () => {
+  const inNetwork = normalizeEntry({ owner_id: "u_owner", network_id: "net_1" });
+  const legacyOwned = normalizeEntry({ owner_id: "u_owner" });
+  const legacyNull = normalizeEntry({ owner_id: null });
+
+  const anonymous: Principal = { kind: "anonymous" };
+  const devOpenAnon: Principal = { kind: "dev-open-anon" };
+  const legacyMaster: Principal = { kind: "legacy-master" };
+  const utokOwner: Principal = { kind: "utok", userId: "u_owner", username: "owner", isAdmin: false };
+  const ntokSame: Principal = { kind: "ntok", userId: "u_node", boundNetworkId: "net_1" };
+  const ntokOther: Principal = { kind: "ntok", userId: "u_node", boundNetworkId: "net_2" };
+  const adminUtok: Principal = { kind: "admin-utok", userId: "u_admin", username: "admin" };
+
+  test("legacy-master and admin-utok bypass in both entry shapes", () => {
+    for (const entry of [inNetwork, legacyOwned, legacyNull]) {
+      expect(authorizeFileDownload(legacyMaster, entry)).toBe(true);
+      expect(authorizeFileDownload(adminUtok, entry)).toBe(true);
+    }
+  });
+
+  test("anonymous and dev-open-anon are denied an attributed file", () => {
+    expect(authorizeFileDownload(anonymous, inNetwork)).toBe(false);
+    expect(authorizeFileDownload(devOpenAnon, inNetwork)).toBe(false);
+  });
+
+  test("ntok_ is allowed only in its bound network", () => {
+    expect(authorizeFileDownload(ntokSame, inNetwork)).toBe(true);
+    expect(authorizeFileDownload(ntokOther, inNetwork)).toBe(false);
+  });
+
+  test("an attributed file ignores owner match — network membership is the rule", () => {
+    // utokOwner IS the owner_id on this entry but holds no role in net_1,
+    // so it must still be denied. Owner-match must not leak back in as a
+    // second, weaker path around the network gate.
+    expect(inNetwork.ownerId).toBe("u_owner");
+    expect(authorizeFileDownload(utokOwner, inNetwork)).toBe(false);
+  });
+
+  test("legacy entries keep the pre-#503 owner-match rule", () => {
+    expect(authorizeFileDownload(utokOwner, legacyOwned)).toBe(true);
+    const other: Principal = { kind: "utok", userId: "u_other", username: "other", isAdmin: false };
+    expect(authorizeFileDownload(other, legacyOwned)).toBe(false);
+    expect(authorizeFileDownload(other, legacyNull)).toBe(false);
+  });
+
+  test("normalizeEntry is the only place on-disk values are narrowed", () => {
+    expect(normalizeEntry({ owner_id: null, network_id: undefined })).toEqual({ ownerId: null, networkId: null });
+    expect(normalizeEntry({ owner_id: "", network_id: "" })).toEqual({ ownerId: null, networkId: null });
+    expect(normalizeEntry({ owner_id: 42, network_id: { evil: true } } as any)).toEqual({ ownerId: null, networkId: null });
+    expect(normalizeEntry({ owner_id: "u1", network_id: "n1" })).toEqual({ ownerId: "u1", networkId: "n1" });
+  });
+});
+
+// ── #509 regression under network scope ────────────────────────────────
+
+describe.skipIf(!isProdMode)("#503 — network scope does not regress cross-day downloads (#509)", () => {
+  test("a file indexed under a past date_bucket is still readable by its network", async () => {
+    const fileId = await uploadOk(nonAdminUserA.token, "yesterday-payload", "yd.bin");
+    const entry = readEntry(fileId);
+    expect(entry.network_id).toBe(N1);
+
+    // Move the blob and its index entry into a past bucket, mirroring a
+    // file uploaded before midnight and read after. The read path must
+    // use the indexed bucket, not today's.
+    const past = "2026-01-02";
+    const from = join(UPLOADS_DIR, entry.date_bucket, `${fileId}${entry.ext}`);
+    const to = join(UPLOADS_DIR, past, `${fileId}${entry.ext}`);
+    mkdirSync(dirname(to), { recursive: true });
+    writeFileSync(to, readFileSync(from));
+    rmSync(from, { force: true });
+    entry.date_bucket = past;
+    writeEntry(fileId, entry);
+    expect(existsSync(to)).toBe(true);
+
+    const res = await download(nonAdminUserA.ntok, fileId);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("yesterday-payload");
+  });
+});

--- a/server/src/file-network-scope.test.ts
+++ b/server/src/file-network-scope.test.ts
@@ -87,6 +87,16 @@ const nonAdminUserB = reg("userb");
 const outsiderUser = reg("outsider");
 const viewerOnlyUser = reg("vieweronly");
 const mixedUser = reg("mixed");
+// 4. Additional admins with different network-membership counts for
+//    F2=F auto-derive (U11a/b/c). adminUser is multi-network (own
+//    default + N1 below, → U11b). adminSingleUser stays single-network
+//    on its own default → U11a. adminZeroUser has zero memberships
+//    (own default is dropped below) → U11c.
+const adminSingleUser = reg("adminsingle");
+db.run("UPDATE users SET role = 'admin' WHERE user_id = ?1", [adminSingleUser.userId]);
+const adminZeroUser = reg("adminzero");
+db.run("UPDATE users SET role = 'admin' WHERE user_id = ?1", [adminZeroUser.userId]);
+db.run("DELETE FROM network_members WHERE user_id = ?1", [adminZeroUser.userId]);
 
 // N1 is userA's own default network — userA stays single-network so the
 // "no query param, unambiguous membership" upload path (U6) is reachable.
@@ -222,6 +232,11 @@ describe.skipIf(!isProdMode)("#503 — fixture integrity", () => {
     // The admin probe must really be admin, or D6/D10/D14/U10b/U11/U12
     // would be measuring a non-admin and silently prove nothing.
     expect(roleOf(adminUser.userId)).toBe("admin");
+    // F2=F auto-derive probes: adminSingleUser must be admin AND in exactly
+    // one network; adminZeroUser must be admin AND in zero networks.
+    // Fixture drift on either turns U11a/U11c into vacuously-true tests.
+    expect(roleOf(adminSingleUser.userId)).toBe("admin");
+    expect(roleOf(adminZeroUser.userId)).toBe("admin");
   });
 
   test("network membership is shaped as the matrix assumes", () => {
@@ -330,8 +345,38 @@ describe.skipIf(!isProdMode)("#503 U — upload network attribution", () => {
     expect((await res.json() as any).error).toBe("unknown_network");
   });
 
-  test("U11: admin utok_, no param → 400 network_id_required (attribution is never guessed for admins)", async () => {
-    const res = await upload(adminUser.token, "u11", "u11.bin");
+  // #503 Finding 2 = Option F (lead 40be9845): admin gets the same
+  // "auto-derive when unambiguous / require param when ambiguous"
+  // rule as utok_. Split old U11 into three rows to pin all three
+  // membership shapes.
+  test("U11a: admin utok_, EXACTLY 1 network membership, no param → 200 and entry.network_id === that network (F auto-derive)", async () => {
+    expect(roleOf(adminSingleUser.userId)).toBe("admin");
+    const singleNet = db.all<{ network_id: string }>(
+      "SELECT network_id FROM network_members WHERE user_id = ?1", adminSingleUser.userId,
+    );
+    expect(singleNet.length).toBe(1);
+    const fileId = await uploadOk(adminSingleUser.token, "u11a", "u11a.bin");
+    expect(readEntry(fileId).network_id).toBe(singleNet[0].network_id);
+  });
+
+  test("U11b: admin utok_, ≥2 network memberships, no param → 400 network_id_required (strict on ambiguity)", async () => {
+    expect(roleOf(adminUser.userId)).toBe("admin");
+    const multi = db.all<{ network_id: string }>(
+      "SELECT network_id FROM network_members WHERE user_id = ?1", adminUser.userId,
+    );
+    expect(multi.length).toBeGreaterThanOrEqual(2);
+    const res = await upload(adminUser.token, "u11b", "u11b.bin");
+    expect(res.status).toBe(400);
+    expect((await res.json() as any).error).toBe("network_id_required");
+  });
+
+  test("U11c: admin utok_, ZERO network memberships, no param → 400 network_id_required (no unowned files even for admin)", async () => {
+    expect(roleOf(adminZeroUser.userId)).toBe("admin");
+    const zero = db.all<{ network_id: string }>(
+      "SELECT network_id FROM network_members WHERE user_id = ?1", adminZeroUser.userId,
+    );
+    expect(zero.length).toBe(0);
+    const res = await upload(adminZeroUser.token, "u11c", "u11c.bin");
     expect(res.status).toBe(400);
     expect((await res.json() as any).error).toBe("network_id_required");
   });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1746,7 +1746,7 @@ return Bun.serve({
             uploadNetId = requestedNetId;
             break;
           }
-          uploadNetId = singleNetworkId(resolveRestNetworkScope(url, authCtx, false));
+          uploadNetId = singleNetworkId(resolveRestNetworkScope(url.searchParams.get("network_id"), authCtx, false));
           if (!uploadNetId) {
             return withCors(req, Response.json({
               ok: false, error: "network_id_required",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -217,7 +217,55 @@ function resolveRequestAuth(req: Request): { userId: string; networkId: string |
   return { userId: resolved.user.user_id, networkId: resolved.networkId, username: resolved.user.username, tokenName: resolved.tokenName, tokenId: resolved.tokenId };
 }
 
-// #495 — shared authorization gate for /api/files/:file_id downloads.
+// #503 — the credential kinds that authorization decisions branch on.
+// Resolved once per request at the handler, so the authz helpers stay
+// pure functions of (principal, entry) and every credential kind is a
+// directly constructible test input instead of a hand-assembled Request.
+export type Principal =
+  | { kind: "anonymous" }
+  | { kind: "dev-open-anon" }
+  | { kind: "legacy-master" }
+  | { kind: "utok"; userId: string; username: string; isAdmin: false }
+  | { kind: "ntok"; userId: string; boundNetworkId: string }
+  | { kind: "admin-utok"; userId: string; username: string };
+
+export function resolvePrincipal(req: Request): Principal {
+  const authCtx = resolveRequestAuth(req);
+  if (!authCtx) {
+    if (isLegacyAuthToken(req)) return { kind: "legacy-master" };
+    if (DEV_OPEN) return { kind: "dev-open-anon" };
+    return { kind: "anonymous" };
+  }
+  const token = requestToken(req);
+  const resolved = token ? resolveToken(token) : null;
+  const isAdmin = !!resolved && resolved.user.role === "admin";
+  // Bound network wins over admin classification: a ntok_ issued BY an
+  // admin is still a ntok_, and its bound scope defines its identity.
+  // Inverting this order would silently re-grant every production agent
+  // node cross-network read, since production node tokens resolve to an
+  // admin user (see the 生产影响 note on authorizeFileDownload).
+  if (authCtx.networkId) return { kind: "ntok", userId: authCtx.userId, boundNetworkId: authCtx.networkId };
+  if (isAdmin) return { kind: "admin-utok", userId: authCtx.userId, username: authCtx.username };
+  return { kind: "utok", userId: authCtx.userId, username: authCtx.username, isAdmin: false };
+}
+
+// #503 — coerce the on-disk (untrusted, hand-editable) index entry into
+// the shape the authz helper reasons about. Every `typeof` narrowing for
+// these two fields lives here and nowhere else, so the authz rules can be
+// read as rules rather than as string-checks.
+export function normalizeEntry(
+  entry: { owner_id?: unknown; network_id?: unknown },
+): { ownerId: string | null; networkId: string | null } {
+  const ownerId = typeof entry.owner_id === "string" && entry.owner_id.length > 0
+    ? entry.owner_id
+    : null;
+  const networkId = typeof entry.network_id === "string" && entry.network_id.length > 0
+    ? entry.network_id
+    : null;
+  return { ownerId, networkId };
+}
+
+// #495/#503 — shared authorization gate for /api/files/:file_id downloads.
 // Called from the GET handler and any future HEAD/Range/dashboard-proxy
 // entry so the allow-list can't drift between methods (通信龙 clause 2:
 // "授权若只在 GET 分支实现, HEAD 或 Range 走别路径 = 等于没修").
@@ -226,33 +274,48 @@ function resolveRequestAuth(req: Request): { userId: string; networkId: string |
 // caller emits 404 on false — never 403; 403 would leak that the
 // file_id exists and enables enumeration.
 //
-// Allow-list (staged P0 hotfix; same-network non-owner is NOT included
-// here — see follow-up #503):
+// Allow-list — network scope enforced by #503:
 //   - Legacy master AUTH_TOKEN (RFC-001 read-only) → allow.
 //   - admin utok_ → allow (mirrors requireAdminAuth).
-//   - Owner match: caller's resolved user_id === entry.owner_id.
-//   - null owner_id + DEV_OPEN → allow. DEV_OPEN uploads carry
-//     owner_id=null (authCtx=null in DEV_OPEN mode); rejecting them
-//     would break the intended local-dev anonymous flow. Encoded as
-//     an explicit env-gated branch so if DEV_OPEN semantics change,
-//     the code fails loudly instead of trusting a stale note.
+//   - entry.network_id present → caller must belong to THAT network:
+//     ntok_ must be bound to it; utok_ must hold any role in it
+//     (viewer included — viewer is read-only, and a viewer who can see
+//     a task but not open its attachment is a broken product).
+//   - entry.network_id absent (legacy / unattributed) → the pre-#503
+//     rules stand unchanged: owner match, or null owner_id + DEV_OPEN.
 //   - Everything else → deny (404). New uploads in production always
 //     carry a truthy owner_id (requireAuth blocks the null-owner-
 //     producing path when DEV_OPEN=off and no legacy master token is
 //     configured), so denying null-owner in production closes the
 //     enumeration vector for legacy blobs without breaking new uploads.
-export function authorizeFileDownload(req: Request, entry: { owner_id?: unknown }): boolean {
-  const token = requestToken(req);
-  const authCtx = resolveRequestAuth(req);
-  const resolved = token ? resolveToken(token) : null;
-  const isLegacyMasterCaller = !authCtx && isLegacyAuthToken(req);
-  const isAdminCaller = !!resolved && resolved.user.role === "admin";
-  const ownerId = typeof entry.owner_id === "string" && entry.owner_id.length > 0
-    ? entry.owner_id
-    : null;
-  const isOwnerCaller = !!authCtx && !!ownerId && authCtx.userId === ownerId;
-  if (isLegacyMasterCaller || isAdminCaller || isOwnerCaller) return true;
-  if (ownerId === null && DEV_OPEN) return true;
+//
+// 生产影响: 新的 ntok 归属文件走 network gate, admin 签发的 ntok 也走 gate
+// (kind='ntok' 分类优先绑定). 98 历史文件无 network_id 走老文件兼容分支
+// (owner/admin 可读, 存量行为不变).
+//
+// 行为变更: admin 的节点令牌 (ntok_) 失去它今天拥有的跨网络读权. 生产今天
+// 所有文件在同一 network → 无实际影响, 但语义变更须明写, 不能悄悄发生.
+export function authorizeFileDownload(
+  principal: Principal,
+  entry: { ownerId: string | null; networkId: string | null },
+): boolean {
+  if (principal.kind === "legacy-master") return true;
+  if (principal.kind === "admin-utok") return true;
+
+  if (entry.networkId !== null) {
+    if (principal.kind === "anonymous" || principal.kind === "dev-open-anon") return false;
+    if (principal.kind === "ntok") return principal.boundNetworkId === entry.networkId;
+    return !!getUserNetworkRole(principal.userId, entry.networkId);
+  }
+
+  if (principal.kind === "ntok" || principal.kind === "utok") {
+    if (entry.ownerId !== null && principal.userId === entry.ownerId) return true;
+  }
+  // Kept env-gated rather than narrowed to kind==='dev-open-anon': the
+  // pre-#503 rule allowed ANY caller to read a null-owner entry while
+  // DEV_OPEN is on, and #503 is scoped to adding network scope, not to
+  // tightening the local-dev carve-out.
+  if (entry.ownerId === null && DEV_OPEN) return true;
   return false;
 }
 
@@ -1621,6 +1684,99 @@ return Bun.serve({
         ));
       }
 
+      // #503 — decide which network this upload is attributed to, then
+      // check the caller may write there. Attribution and authorization
+      // are two questions; neither substitutes for the other. Placed
+      // after the in-memory rate limiter (above) and before the body is
+      // read, so an unauthorized caller never gets a DB query per byte
+      // uploaded and never gets their multipart envelope parsed.
+      const principal = resolvePrincipal(req);
+      const requestedNetId = url.searchParams.get("network_id");
+      let uploadNetId: string | null = null;
+
+      switch (principal.kind) {
+        case "anonymous":
+          // Unreachable: requireAuth above already 401s. Kept so the
+          // switch stays exhaustive and a future auth change fails loud.
+          return withCors(req, Response.json({ ok: false, error: "auth_required" }, { status: 401 }));
+        case "dev-open-anon":
+          // Local dev only. Deliberately does NOT claim a real network,
+          // even if one was requested — an unauthenticated caller must
+          // not be able to file blobs into a tenant's network.
+          uploadNetId = null;
+          break;
+        case "legacy-master":
+          // Unreachable today: requireAuth 401s master tokens on every
+          // non-GET /api/ request (RFC-001 made them read-only). Kept
+          // fail-closed so relaxing that rule cannot silently start
+          // producing unattributed blobs.
+          if (!requestedNetId) {
+            return withCors(req, Response.json({
+              ok: false, error: "network_id_required",
+              message: "legacy master uploads must specify a network_id query param",
+            }, { status: 400 }));
+          }
+          uploadNetId = requestedNetId;
+          break;
+        case "ntok":
+          if (requestedNetId && requestedNetId !== principal.boundNetworkId) {
+            return withCors(req, Response.json({
+              ok: false, error: "network_id_conflict",
+              message: "network_id query param conflicts with the token-bound network",
+            }, { status: 400 }));
+          }
+          uploadNetId = principal.boundNetworkId;
+          break;
+        case "admin-utok":
+          if (!requestedNetId) {
+            return withCors(req, Response.json({
+              ok: false, error: "network_id_required",
+              message: "admin uploads must specify a network_id query param",
+            }, { status: 400 }));
+          }
+          uploadNetId = requestedNetId;
+          break;
+        case "utok": {
+          if (requestedNetId) {
+            // A non-member asking for someone else's network never gets
+            // here: the REST scope guard (`restScope.denied`) already
+            // 403'd, with the same body whether the network exists or
+            // not. Re-checking membership here would be a second, drifting
+            // copy of a decision this codebase makes in one place.
+            uploadNetId = requestedNetId;
+            break;
+          }
+          uploadNetId = singleNetworkId(resolveRestNetworkScope(url, authCtx, false));
+          if (!uploadNetId) {
+            return withCors(req, Response.json({
+              ok: false, error: "network_id_required",
+              message: "network_id query param required for a multi-network user token; 'first network' is not assumed",
+            }, { status: 400 }));
+          }
+          break;
+        }
+      }
+
+      if (uploadNetId !== null) {
+        const networkRow = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", uploadNetId);
+        if (!networkRow) {
+          if (principal.kind === "admin-utok" || principal.kind === "legacy-master") {
+            return withCors(req, Response.json({
+              ok: false, error: "unknown_network",
+              message: "network_id does not exist",
+            }, { status: 400 }));
+          }
+          // Byte-identical to the non-member 404 above: distinguishing
+          // the two would hand an unprivileged caller a network-existence
+          // oracle.
+          return withCors(req, Response.json({ ok: false, error: "not_found" }, { status: 404 }));
+        }
+      }
+
+      if (!canRestWriteNetwork(authCtx, uploadNetId, principal.kind === "admin-utok")) {
+        return withCors(req, Response.json({ ok: false, error: "permission_denied" }, { status: 403 }));
+      }
+
       const contentType = req.headers.get("Content-Type") ?? "";
       if (!/^multipart\/form-data/i.test(contentType)) {
         return withCors(req, Response.json(
@@ -1695,6 +1851,8 @@ return Bun.serve({
             size: file.size,
             owner: authCtx?.username ?? null,
             owner_id: authCtx?.userId ?? null,
+            // Key omitted (not null) when unattributed — see UploadIndexEntry.
+            ...(uploadNetId ? { network_id: uploadNetId } : {}),
             uploaded_at: new Date().toISOString(),
           }, null, 2));
         }
@@ -1765,7 +1923,7 @@ return Bun.serve({
       // "no such file". Both branches return the same 404 shape
       // for BOTH GET and HEAD (HEAD honours body-omission but the
       // status code and headers are the authoritative signal).
-      if (!authorizeFileDownload(req, entry)) {
+      if (!authorizeFileDownload(resolvePrincipal(req), normalizeEntry(entry))) {
         return withCors(req, Response.json({ ok: false, error: "not_found" }, { status: 404 }));
       }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1639,8 +1639,22 @@ return Bun.serve({
     // X-Content-Type-Options: nosniff so uploaded files can never be
     // executed or served as HTML.
     if (url.pathname === "/api/upload" && req.method === "POST") {
+      // #503 Finding 3 = Option A (lead 40be9845): every 4xx returned
+      // BEFORE `req.formData()` drains the request body MUST include
+      // `Connection: close`. Otherwise the client's still-inbound bytes
+      // land on a keepalive connection the server already answered on,
+      // poisoning the next pooled request. Bug is pre-existing (411/
+      // 413/415/429/401 all have this shape) — the #503 authz block
+      // just made it visible under aggregate `bun test` with a 12MiB
+      // upload immediately followed by another request. Per-file green
+      // hides this class of bug.
+      const earlyReject = (res: Response): Response => {
+        const wrapped = withCors(req, res);
+        wrapped.headers.set("Connection", "close");
+        return wrapped;
+      };
       const authErr = requireAuth(req);
-      if (authErr) return withCors(req, authErr);
+      if (authErr) return earlyReject(authErr);
 
       // Rate-limit key prefers the token id (so 60/h is per-token, not
       // per-IP); falls back to IP for legacy or anonymous-but-dev-open.
@@ -1654,7 +1668,7 @@ return Bun.serve({
           "X-RateLimit-Reset": String(Math.floor(rate.resetAt / 1000)),
         };
         if (rate.retryAfterMs) headers["Retry-After"] = String(Math.ceil(rate.retryAfterMs / 1000));
-        return withCors(req, new Response(
+        return earlyReject(new Response(
           JSON.stringify({ ok: false, error: "rate_limited", message: "Upload rate limit exceeded (60/hour). Try again later.", retry_after_ms: rate.retryAfterMs }),
           { status: 429, headers: { ...headers, "Content-Type": "application/json; charset=utf-8" } },   // #426 — legacy clients default to ISO-8859-1 without charset
         ));
@@ -1668,17 +1682,17 @@ return Bun.serve({
       //             or lied Content-Length header)
       const contentLength = req.headers.get("Content-Length");
       if (!contentLength) {
-        return withCors(req, Response.json(
+        return earlyReject(Response.json(
           { ok: false, error: "length_required", message: "Content-Length header is required for /api/upload" },
           { status: 411 },
         ));
       }
       const declaredBytes = Number(contentLength);
       if (!Number.isFinite(declaredBytes) || declaredBytes < 0) {
-        return withCors(req, Response.json({ ok: false, error: "bad_content_length" }, { status: 400 }));
+        return earlyReject(Response.json({ ok: false, error: "bad_content_length" }, { status: 400 }));
       }
       if (declaredBytes > MAX_REQUEST_CONTENT_LENGTH) {
-        return withCors(req, Response.json(
+        return earlyReject(Response.json(
           { ok: false, error: "payload_too_large", message: `Upload exceeds the ${MAX_UPLOAD_BYTES} byte limit`, limit_bytes: MAX_UPLOAD_BYTES },
           { status: 413 },
         ));
@@ -1698,7 +1712,7 @@ return Bun.serve({
         case "anonymous":
           // Unreachable: requireAuth above already 401s. Kept so the
           // switch stays exhaustive and a future auth change fails loud.
-          return withCors(req, Response.json({ ok: false, error: "auth_required" }, { status: 401 }));
+          return earlyReject(Response.json({ ok: false, error: "auth_required" }, { status: 401 }));
         case "dev-open-anon":
           // Local dev only. Deliberately does NOT claim a real network,
           // even if one was requested — an unauthenticated caller must
@@ -1711,7 +1725,7 @@ return Bun.serve({
           // fail-closed so relaxing that rule cannot silently start
           // producing unattributed blobs.
           if (!requestedNetId) {
-            return withCors(req, Response.json({
+            return earlyReject(Response.json({
               ok: false, error: "network_id_required",
               message: "legacy master uploads must specify a network_id query param",
             }, { status: 400 }));
@@ -1720,22 +1734,36 @@ return Bun.serve({
           break;
         case "ntok":
           if (requestedNetId && requestedNetId !== principal.boundNetworkId) {
-            return withCors(req, Response.json({
+            return earlyReject(Response.json({
               ok: false, error: "network_id_conflict",
               message: "network_id query param conflicts with the token-bound network",
             }, { status: 400 }));
           }
           uploadNetId = principal.boundNetworkId;
           break;
-        case "admin-utok":
-          if (!requestedNetId) {
-            return withCors(req, Response.json({
+        case "admin-utok": {
+          // #503 Finding 2 = Option F (lead 40be9845): admin follows the same
+          // "auto-derive when unambiguous / require param when ambiguous" rule
+          // as utok_. Rule 4's REASON (no unowned files) is preserved — the
+          // derived network is a real membership. Strict on genuine ambiguity:
+          // 0 or ≥2 memberships → 400. Preserves prod upload contract (in
+          // prod admin is in exactly 1 network; auto-derive succeeds).
+          if (requestedNetId) {
+            // Admin bypasses membership; network existence validated below.
+            uploadNetId = requestedNetId;
+            break;
+          }
+          const adminNetworks = getUserNetworkIds(principal.userId);
+          if (adminNetworks.length === 1) {
+            uploadNetId = adminNetworks[0];
+          } else {
+            return earlyReject(Response.json({
               ok: false, error: "network_id_required",
-              message: "admin uploads must specify a network_id query param",
+              message: "admin has 0 or ≥2 network memberships; network_id query param required",
             }, { status: 400 }));
           }
-          uploadNetId = requestedNetId;
           break;
+        }
         case "utok": {
           if (requestedNetId) {
             // A non-member asking for someone else's network never gets
@@ -1748,7 +1776,7 @@ return Bun.serve({
           }
           uploadNetId = singleNetworkId(resolveRestNetworkScope(url.searchParams.get("network_id"), authCtx, false));
           if (!uploadNetId) {
-            return withCors(req, Response.json({
+            return earlyReject(Response.json({
               ok: false, error: "network_id_required",
               message: "network_id query param required for a multi-network user token; 'first network' is not assumed",
             }, { status: 400 }));
@@ -1761,7 +1789,7 @@ return Bun.serve({
         const networkRow = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", uploadNetId);
         if (!networkRow) {
           if (principal.kind === "admin-utok" || principal.kind === "legacy-master") {
-            return withCors(req, Response.json({
+            return earlyReject(Response.json({
               ok: false, error: "unknown_network",
               message: "network_id does not exist",
             }, { status: 400 }));
@@ -1769,17 +1797,17 @@ return Bun.serve({
           // Byte-identical to the non-member 404 above: distinguishing
           // the two would hand an unprivileged caller a network-existence
           // oracle.
-          return withCors(req, Response.json({ ok: false, error: "not_found" }, { status: 404 }));
+          return earlyReject(Response.json({ ok: false, error: "not_found" }, { status: 404 }));
         }
       }
 
       if (!canRestWriteNetwork(authCtx, uploadNetId, principal.kind === "admin-utok")) {
-        return withCors(req, Response.json({ ok: false, error: "permission_denied" }, { status: 403 }));
+        return earlyReject(Response.json({ ok: false, error: "permission_denied" }, { status: 403 }));
       }
 
       const contentType = req.headers.get("Content-Type") ?? "";
       if (!/^multipart\/form-data/i.test(contentType)) {
-        return withCors(req, Response.json(
+        return earlyReject(Response.json(
           { ok: false, error: "unsupported_media_type", message: "Use multipart/form-data with a 'file' field" },
           { status: 415 },
         ));

--- a/server/src/upload-early-reject-guard.test.ts
+++ b/server/src/upload-early-reject-guard.test.ts
@@ -1,0 +1,122 @@
+// #503 F3=A static guard: every 4xx return in the /api/upload handler
+// that fires BEFORE `req.formData()` drains the request body MUST be
+// wrapped in `earlyReject` (which sets `Connection: close`). Otherwise
+// the client's still-inbound body poisons the keepalive pool and the
+// next pooled request stalls.
+//
+// Why a STATIC guard (not a runtime one): mutation M9 in
+// docs/tests/p-503-file-network-scope/mutation-matrix.txt showed that
+// under Bun's fetch client in this test setup, removing
+// `Connection: close` does NOT turn any dynamic test red — the pool
+// poisoning is real HTTP-level behavior but the client under test does
+// not reliably reproduce it. Without a guard, deleting the helper or
+// forgetting to wrap a NEW 15th pre-drain return goes silent. This
+// test judges the SOURCE FILE, per lead 7a88ce29 and Constraint 3-1
+// pattern (source-based, not runner-output-based).
+//
+// PRIOR-ART GOTCHA (lead 7a88ce29 踩过): parse boundaries MUST exclude
+// comments. `req.formData()` appears in a doc comment near the top of
+// the handler too; if the boundary matches on that, the pre-drain
+// range collapses to empty and this guard silently becomes vacuously
+// true. Same trap family as "范围为空的全称断言恒真". So this test
+// has an explicit precondition: the parsed pre-drain return count must
+// be ≥ 10 (currently 14). If the count drops to 0, the boundary parser
+// broke, not the code.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const SOURCE_PATH = join(import.meta.dirname, "server.ts");
+const RAW = readFileSync(SOURCE_PATH, "utf-8");
+const LINES = RAW.split("\n");
+
+// Strip line-comments so we don't match on comment-mentioned tokens
+// like the "req.formData()" doc references at the top of the handler.
+// (Block comments /* */ are rare inside this handler; if you add one
+// that mentions the boundary, extend this helper.)
+function stripLineComment(s: string): string {
+  const idx = s.indexOf("//");
+  return idx >= 0 ? s.slice(0, idx) : s;
+}
+const CODE = LINES.map(stripLineComment);
+
+// Find the /api/upload handler start (guard against a repo rename).
+const handlerStartIdx = CODE.findIndex((line) =>
+  line.includes('url.pathname === "/api/upload"') &&
+  line.includes('req.method === "POST"'),
+);
+
+// Find the true body-drain boundary: `await req.formData()` INSIDE the
+// handler. Search from handler start forward for the first NON-COMMENT
+// occurrence (stripLineComment above already ate any `// ... formData ...`
+// mention).
+let drainIdx = -1;
+if (handlerStartIdx >= 0) {
+  for (let i = handlerStartIdx + 1; i < CODE.length; i++) {
+    if (CODE[i].includes("req.formData()")) {
+      drainIdx = i;
+      break;
+    }
+  }
+}
+
+// Collect every `return` statement in the pre-drain range that
+// invokes withCors OR earlyReject. Anything else (e.g. the helper's
+// bare `return wrapped;`) is skipped — that's the helper body, not a
+// pre-drain response return.
+type ReturnHit = { lineNumber: number; text: string; kind: "earlyReject" | "withCors" | "other" };
+const preDrainReturns: ReturnHit[] = [];
+if (handlerStartIdx >= 0 && drainIdx > handlerStartIdx) {
+  for (let i = handlerStartIdx; i < drainIdx; i++) {
+    const code = CODE[i];
+    if (!/\breturn\b/.test(code)) continue;
+    if (/\breturn earlyReject\b/.test(code)) {
+      preDrainReturns.push({ lineNumber: i + 1, text: LINES[i].trim(), kind: "earlyReject" });
+    } else if (/\breturn withCors\b/.test(code)) {
+      preDrainReturns.push({ lineNumber: i + 1, text: LINES[i].trim(), kind: "withCors" });
+    }
+    // Bare `return wrapped;`, `return;`, `return blob;` etc. are
+    // deliberately skipped — they are not pre-drain response returns.
+  }
+}
+
+describe("#503 F3=A static guard: /api/upload pre-body-drain returns use earlyReject", () => {
+  test("precondition: scanner located handler + drain boundary + non-trivial return count (defends against parse collapse)", () => {
+    expect(handlerStartIdx).toBeGreaterThanOrEqual(0);
+    expect(drainIdx).toBeGreaterThan(handlerStartIdx);
+    // If boundary parsing collapses (someone renames req.formData(),
+    // or a comment-strip bug lets a doc reference win), this range
+    // becomes 0 and the second test would vacuously pass. Anchor
+    // the range: at time of writing (85e5c140 + #503) the count is
+    // 14; lead 7a88ce29 confirmed 14/14. Floor at 10 to leave room
+    // for genuine deletions while still catching a full collapse.
+    expect(preDrainReturns.length).toBeGreaterThanOrEqual(10);
+  });
+
+  test("every pre-drain return is wrapped in earlyReject (not bare withCors)", () => {
+    const bareWithCors = preDrainReturns.filter((r) => r.kind === "withCors");
+    if (bareWithCors.length > 0) {
+      const detail = bareWithCors
+        .map((r) => `  L${r.lineNumber}: ${r.text}`)
+        .join("\n");
+      throw new Error(
+        `#503 F3=A regression: ${bareWithCors.length} pre-body-drain return(s) in ` +
+        `/api/upload use bare withCors() instead of earlyReject():\n${detail}\n\n` +
+        `Every early-reject in this range MUST set Connection: close. Otherwise ` +
+        `the client's in-flight request body poisons the keepalive pool and the ` +
+        `next pooled request stalls. Wrap with the earlyReject() helper defined ` +
+        `at the top of the upload handler.`,
+      );
+    }
+    expect(bareWithCors.length).toBe(0);
+  });
+
+  test("every pre-drain return classifies as either earlyReject or withCors (catches new response patterns)", () => {
+    // If someone introduces `return new Response(...)` or another
+    // wrapper, this test flags it so the guard can be extended
+    // rather than silently missing the new shape.
+    const classified = preDrainReturns.filter((r) => r.kind === "earlyReject" || r.kind === "withCors").length;
+    expect(classified).toBe(preDrainReturns.length);
+  });
+});

--- a/server/src/upload-early-reject-guard.test.ts
+++ b/server/src/upload-early-reject-guard.test.ts
@@ -35,6 +35,18 @@ const LINES = RAW.split("\n");
 // like the "req.formData()" doc references at the top of the handler.
 // (Block comments /* */ are rare inside this handler; if you add one
 // that mentions the boundary, extend this helper.)
+//
+// KNOWN LIMITATION (lead 50208c1b): this naive strip cuts on ANY `//`,
+// including one inside a string literal (e.g. `"https://…"`). If a
+// pre-drain line ever contains such a literal, the strip could snip
+// off the return statement after it and produce a false NEGATIVE (miss
+// a genuine unwrapped return). Currently no pre-drain line in the
+// /api/upload handler holds this shape; the precondition floor of 10
+// catches only "range collapsed to empty", not "silently minus one".
+// If someone adds a URL-string literal in this range in the future,
+// upgrade to a real tokenizer — not because block-comment mentions of
+// req.formData() need it, but because the string-literal-with-`//`
+// case is the actual gap.
 function stripLineComment(s: string): string {
   const idx = s.indexOf("//");
   return idx >= 0 ? s.slice(0, idx) : s;
@@ -61,10 +73,23 @@ if (handlerStartIdx >= 0) {
   }
 }
 
-// Collect every `return` statement in the pre-drain range that
-// invokes withCors OR earlyReject. Anything else (e.g. the helper's
-// bare `return wrapped;`) is skipped — that's the helper body, not a
-// pre-drain response return.
+// Collect every `return` statement in the pre-drain range. Classify:
+//   earlyReject  — the correct wrapping (sets Connection: close)
+//   withCors     — bare wrapping without Connection: close (regression)
+//   other        — produces a Response some OTHER way (e.g.
+//                  `return Response.json(...)` / `return new Response(...)`);
+//                  this shape ALSO skips earlyReject and MUST fail the guard.
+//                  Detected via /Response\b/ so `return wrapped;` /
+//                  `return;` / `return blob;` (helper body, non-response
+//                  returns) are correctly skipped, but any new Response-
+//                  producing path (Response.json / new Response / etc.) is
+//                  caught. Lead 50208c1b: earlier version used implicit-skip
+//                  which made the third assertion恒真 — it counted only what
+//                  it recognised, so "unrecognised = 0" was vacuous.
+//                  Order matters: earlyReject → withCors → other. A line
+//                  like `return earlyReject(new Response(…))` contains
+//                  both `earlyReject` AND `Response`, and must classify as
+//                  earlyReject (already-wrapped), not as other.
 type ReturnHit = { lineNumber: number; text: string; kind: "earlyReject" | "withCors" | "other" };
 const preDrainReturns: ReturnHit[] = [];
 if (handlerStartIdx >= 0 && drainIdx > handlerStartIdx) {
@@ -75,9 +100,13 @@ if (handlerStartIdx >= 0 && drainIdx > handlerStartIdx) {
       preDrainReturns.push({ lineNumber: i + 1, text: LINES[i].trim(), kind: "earlyReject" });
     } else if (/\breturn withCors\b/.test(code)) {
       preDrainReturns.push({ lineNumber: i + 1, text: LINES[i].trim(), kind: "withCors" });
+    } else if (/Response\b/.test(code)) {
+      // `return new Response(...)` / `return Response.json(...)` / etc.
+      // — produces a Response but skips the earlyReject wrapper.
+      preDrainReturns.push({ lineNumber: i + 1, text: LINES[i].trim(), kind: "other" });
     }
-    // Bare `return wrapped;`, `return;`, `return blob;` etc. are
-    // deliberately skipped — they are not pre-drain response returns.
+    // Bare `return wrapped;`, `return;`, `return blob;` are non-response
+    // returns and correctly skipped (no `Response` token).
   }
 }
 
@@ -112,11 +141,15 @@ describe("#503 F3=A static guard: /api/upload pre-body-drain returns use earlyRe
     expect(bareWithCors.length).toBe(0);
   });
 
-  test("every pre-drain return classifies as either earlyReject or withCors (catches new response patterns)", () => {
-    // If someone introduces `return new Response(...)` or another
-    // wrapper, this test flags it so the guard can be extended
-    // rather than silently missing the new shape.
-    const classified = preDrainReturns.filter((r) => r.kind === "earlyReject" || r.kind === "withCors").length;
-    expect(classified).toBe(preDrainReturns.length);
+  test("no pre-drain return produces a Response without going through earlyReject (catches new response shapes)", () => {
+    // Catches `return Response.json(...)` / `return new Response(...)` /
+    // any other pre-drain Response-producing path that skips the wrapper.
+    // Lead 50208c1b: previous version was 恒真 because unrecognised
+    // shapes were silently dropped from `preDrainReturns` — the filter
+    // then counted "recognised = recognised" and never failed. Now the
+    // collector classifies unrecognised Response-producers as "other";
+    // this assertion reports them by line, not just count.
+    const unknown = preDrainReturns.filter((r) => r.kind === "other");
+    expect(unknown.map((r) => `L${r.lineNumber}: ${r.text}`)).toEqual([]);
   });
 });

--- a/server/src/uploads-http.test.ts
+++ b/server/src/uploads-http.test.ts
@@ -71,13 +71,22 @@ function authHeaders(): Record<string, string> {
   return { "Authorization": `Bearer ${userToken}` };
 }
 
+// #503 — the bootstrap user is the first account in this suite's fresh
+// DB, so it is a system admin, and admins must name the target network
+// explicitly (attribution is never guessed). uploadNetworkId() keeps
+// that detail in one place.
+function uploadNetworkId(): string {
+  if (!userNetworkId) throw new Error("test bootstrap: userNetworkId missing");
+  return `?network_id=${encodeURIComponent(userNetworkId)}`;
+}
+
 async function uploadFile(content: Uint8Array, filename: string, mime: string, opts: { skipAuth?: boolean; overrideContentLength?: string | null } = {}): Promise<Response> {
   const form = new FormData();
   form.append("file", new Blob([content], { type: mime }), filename);
   const headers: Record<string, string> = opts.skipAuth ? {} : { ...authHeaders() };
   // Note: fetch sets Content-Length automatically; only override when
   // testing the missing-header path.
-  const res = await fetch(`${BASE}/api/upload`, { method: "POST", body: form, headers });
+  const res = await fetch(`${BASE}/api/upload${uploadNetworkId()}`, { method: "POST", body: form, headers });
   return res;
 }
 
@@ -137,7 +146,7 @@ describe("POST /api/upload — 6-item security checklist (HTTP integration)", ()
         controller.close();
       },
     });
-    const res = await fetch(`${BASE}/api/upload`, {
+    const res = await fetch(`${BASE}/api/upload${uploadNetworkId()}`, {
       method: "POST",
       body: stream,
       headers: { ...authHeaders(), "Content-Type": "multipart/form-data; boundary=xxx", "Transfer-Encoding": "chunked" },
@@ -153,7 +162,7 @@ describe("POST /api/upload — 6-item security checklist (HTTP integration)", ()
     // this body" which is the security property we care about; the
     // exact code depends on whether Bun's multipart parser bails before
     // or after our Content-Type pre-check.
-    const res = await fetch(`${BASE}/api/upload`, {
+    const res = await fetch(`${BASE}/api/upload${uploadNetworkId()}`, {
       method: "POST",
       body: JSON.stringify({ nope: 1 }),
       headers: { ...authHeaders(), "Content-Type": "application/json" },

--- a/server/src/uploads.ts
+++ b/server/src/uploads.ts
@@ -180,6 +180,15 @@ export type UploadIndexEntry = {
   mime: string;        // best-effort mime from the multipart Content-Type
   size: number;        // byte length of the binary
   owner?: string;      // upload token id / username, for traceability
+  // Written by the upload handler as `authCtx?.userId ?? null`, so `null`
+  // is a real on-disk value — the type must say so rather than pretend
+  // the field is `string | undefined`.
+  owner_id?: string | null;
+  // #503 — network the upload is attributed to. The key is OMITTED (not
+  // written as null) when there is no attribution, so "absent" and
+  // "unattributed" are the same on-disk shape and legacy entries written
+  // before #503 are indistinguishable from new unattributed ones.
+  network_id?: string;
   uploaded_at: string; // ISO 8601
 };
 
@@ -198,6 +207,12 @@ export function indexEntryPath(fileId: string, opts: { uploadsRoot?: string } = 
 export function validateIndexEntry(entry: unknown): entry is UploadIndexEntry {
   if (!entry || typeof entry !== "object") return false;
   const e: any = entry;
+  // #503 — if the network_id key is present it must be a non-empty string.
+  // An absent key is valid (legacy entries + unattributed uploads); that
+  // keeps this in sync with the writer, which omits the key entirely
+  // rather than writing null. owner_id is deliberately NOT constrained
+  // here — existing entries legitimately carry owner_id=null.
+  if ("network_id" in e && !(typeof e.network_id === "string" && e.network_id.length > 0)) return false;
   return (
     typeof e.file_id === "string" && FILE_ID_REGEX.test(e.file_id) &&
     typeof e.date_bucket === "string" && /^\d{4}-\d{2}-\d{2}$/.test(e.date_bucket) &&


### PR DESCRIPTION
# #503 file network scope readable — PR body draft

Fixes #503.

## Summary

Adds a network-scope authorization gate to `/api/files/:file_id` downloads and populates `network_id` on new upload index entries. All rejects return HTTP 404 with a byte-identical body to `not_found` (enumeration-safe per #500 discipline).

Single authorization entry point: `authorizeFileDownload` extended with a typed `Principal` + normalized entry; the same shared writer gate `canRestWriteNetwork` is reused for uploads. Existing 4 legacy compatibility branches (legacy master, admin bypass, owner match, null-owner+DEV_OPEN) preserved for pre-#503 entries.

## Design

Full design report v3: `/tmp/claude-1000/.../scratchpad/503-design-report-v3.md` (in author's session workspace).

Lead-signed base: `origin/main @ 85e5c140f682c3af0d9d8b870a4c2a68273bc953` (#516). Rebased onto `74e8326d` (#519) after fork. 1-line collision fix on the shared `resolveRestNetworkScope` signature change.

Governance: lead single-sign by 通信龙 (e8d49f22 + d01bb8ce + adc5e9e0 + 40be9845 + 6bd65232), 副指挥 async review (eb5c2960 + 480fb528 + 2f2d5da7 + 6fe666e4).

## Production impact (真话)

Fixes `/api/files/:file_id` cross-network read gap. Under the v3 design:
- **New ntok_-attributed files walk the network gate** — admin-issued ntok_ is classified as `kind: 'ntok'` (bound network wins over admin classification), so it walks `boundNetworkId === entry.network_id`, NOT admin bypass.
- 98 existing production index entries carry no `network_id`; they fall through to the legacy branch (owner / admin / master compatibility unchanged).
- **Behavior change**: admin-issued node tokens (ntok_) lose the implicit cross-network read权 they had today. Prod today has all files in a single network → no observable impact, but the semantic change is worth stating so nobody has to reconstruct it later.

## Breaking changes to upload contract

- **Admin utok_ upload**: if the admin has exactly 1 network membership → auto-derive (`entry.network_id` = that network, no 400). If admin has 0 or ≥2 memberships → 400 `network_id_required` (rule 4's REASON preserved: no unowned files; strict only where genuinely ambiguous).
- **utok_ upload, multi-network user**: must specify `?network_id=<>` — "first network" is never assumed.
- **ntok_ upload**: `?network_id=` param conflict with token-bound network → 400 `network_id_conflict` (silent-override was the fork's original design; lead ruled explicit reject).
- **Legacy master (`AUTH_TOKEN`) upload**: must specify `?network_id=<>` (previously implicit).
- **DEV_OPEN anonymous upload**: `?network_id=` param is ignored; blob is written unattributed (`network_id` key absent from JSON — spread pattern preserves the "no null values in JSON" contract).

## Enumeration safety

- Download: cross-network deny + unknown file_id + corrupted index + validateIndexEntry fail + invalid calendar bucket + pathForExistingBlob throw → **all HTTP 404 with byte-identical body** `{"ok":false,"error":"not_found"}` (per #500's enumeration-oracle discipline).
- Upload: non-admin caller asking for a network that either does not exist OR they are not a member of → **both HTTP 404 with byte-identical body** — non-admin cannot distinguish "network does not exist" from "network exists but is not yours". Admins receive `400 unknown_network` (no oracle since admins already know network state).

## Aggregate-run-only bug fix (pre-existing, uncovered by #503)

Prior to this PR, early-reject 4xx branches (411/413/415/429/401/…) in `/api/upload` returned before consuming the request body. Per-file test runs never triggered it (each test file opens a fresh connection), but aggregate `bun test src/` runs saw the next pooled request stall on the still-inbound body of the answered-but-not-drained one.

This PR adds `Connection: close` to all pre-body-drain 4xx branches in `/api/upload` via a local `earlyReject` helper. The bug is pre-existing; the new authz block just made it visible first. Reminder documented in the mutation matrix: use aggregate `bun test` as the gate; per-file green hides this class of bug.

## Test coverage

- `server/src/file-network-scope.test.ts` (new, ~700 lines): U1-U14, D1-D15, E1-E9, fixture integrity, Principal exhaustiveness. Every non-admin probe has `expect(roleOf(x)).not.toBe("admin")` — inline, not via a helper, so fixture drift turns a test red rather than silently passing.
- `server/src/file-network-scope-dev-open.test.ts` (new): DEV_OPEN sibling coverage (server.ts freezes `DEV_OPEN` at module load, so separate process).
- `server/src/file-download-authz.test.ts` (modified): the 3 tests literally named "STAGED carve-out; follow-up #503" (`same-network non-owner userA reads userB file`) inverted from expect(404) to expect(200). This IS the design intent — the tests were written knowing #503 would lift the carve-out.
- `server/src/uploads-http.test.ts` (modified): fixture handles the new admin auto-derive path (previously registered one user who defaulted to admin + implicit single-network scope; now goes through F auto-derive cleanly).
- Aggregate: **709 pass / 10 skip / 0 fail / 2128 expects** (baseline pre-#503: 638 pass / 3 skip / 0 fail).

## Mutation matrix

`docs/tests/p-503-file-network-scope/mutation-matrix.txt` — every row was produced by actually applying the mutation to source, running the suite, and restoring. No mutation judged by inspection. Includes:
- M1-M7 (fork's original: authorization branches, upload writer, validateIndexEntry shape check)
- M8 (F2=F auto-derive removal → U11a red)
- M9 **CANNOT REPRO** — reported honestly per lead policy. Removing `Connection: close` from earlyReject did not produce the timeout the fork originally saw. F3=A remains the correct HTTP/1.1 defence, but the pool-poisoning scenario doesn't turn red under Bun's fetch client in this test setup.
- M10 (Constraint 3-2: swap non-admin probe to first-registered admin → 8 tests red including fixture-integrity assertion → proves the assertion catches its intended shape)

## Constraint 3 triple gate (per lead adc5e9e0)

1. Static source count: `git grep -c 'not\.toBe.*admin' server/src/file-network-scope.test.ts` — judged from source file, not runner output.
2. Admin-probe mutation reversal: M10 above.
3. Test-ID → precondition map: `docs/tests/p-503-file-network-scope/test-id-map.txt` — every non-admin D row lists the exact precondition line whose truth it depends on.

## Out of scope

- Backfill `network_id` for existing 98 production entries (single-tenant, all admin, gate doesn't fire on them) — separate PR + issue.
- ext / calendar / file_id validation changes (挂起的 #509 ext CR handled separately as regression tests).
- Rate-limit / size cap / multipart parsing semantics.
- Legacy master unparameterized-upload backward compat.
- Broader viewer-role semantic changes (viewer read: allowed per lead §5 Q1).

## Release

Version tag determined at release gate (npm dist-tag current + increment, per subordinate 5435d189 point 1).
