### PR TITLE
fix(#526): rename-ghost harness — PTY wrap + trailer trap + preflight + witnessed-red

### DIFF
--- a/docs/tests/p-526-rename-ghost-harness/README.md
+++ b/docs/tests/p-526-rename-ghost-harness/README.md
@@ -1,0 +1,85 @@
+# #526 · rename-ghost harness — PTY wrap + trailer trap + preflight
+
+**One-line purpose**: the `rename-ghost-gate` CI job was red 13/13 on main because Claude CLI 2.1.220+ refuses to start without a TTY, but `run.sh` was running `nohup anet node start ...` — no PTY, no `--accept-dev-channels`. anet correctly fail-closed with a "requires TTY" error; the harness never reached the trailer emit, so the CI gate reported "no trailer → treat as regression". This is *harness缺前提*, not product regression.
+
+## Fix, in order of narrowness
+
+1. **Preflight per-condition**: assert `script`, `tmux`, `anet`, `bun`, `claude`, `curl`, `jq`, `python3`, `sqlite3`, `pgrep`, `ps`, `kill`, and ≥ 200 MiB free on `/tmp` — each with its own ✗ line naming what's missing (not "the harness didn't produce a trailer"). #526 §1.
+2. **Trailer trap**: `trap emit_trailer EXIT` at the top so every exit path — happy path, `exit 1` from A.1/B.1 bailout, preflight refusal — emits `PASS=N FAIL=N`. The CI gate always sees a trailer; distinguishes "detected ghost" (FAIL > 0) from "harness bailed" (FAIL ≥ 1 from A.1/B.1 bad) rather than losing both to "no trailer".
+3. **CASE A: `script -q -c ...` PTY, NOT tmux**: wraps `anet node start` with a real PTY so `process.stdin.isTTY` is true for the child. Claude CLI 2.1.220+ auto-switches to `--print` without TTY and refuses interactive; anet #494 preflight fail-closes with the "requires TTY" hint pointing at `--accept-dev-channels`. **We do NOT switch to `--accept-dev-channels`** — that spawns a *detached tmux session* (see `agent-network/bin/cli.ts` L4476/L4499), collapsing CASE A into a copy of CASE B while the label still claims "no tmux". CASE A's "no tmux" is load-bearing because the process-tree shape drives ghost-production conditions (cleanup path is shared, production is not). Judgment call by 通信龙 2026-07-30.
+4. **Mock upgrade: `setsid` on mock-mcp spawn**: without `setsid`, mock-mcp lived in the parent's process group, so a SIGHUP cascade killed it whenever mock-claude died. That meant sweep-stubbing produced no ghost — the harness had *never* actually witnessed a red case in this test. `setsid` detaches mock-mcp into its own session, making it survive parent death via the exact mechanism sweep is meant to catch.
+
+## What this harness verifies (that unit tests do NOT)
+
+| Layer                              | Unit test | This harness |
+|------------------------------------|-----------|--------------|
+| `sweepMcpOrphansForAlias` code correctness (function-level) | ✅ | ❌ |
+| Env-alias regex against `/proc/PID/environ` reality | ❌ | ✅ |
+| Whole-flow: rename → parent SIGKILL → orphaned subprocess survives → sweep reaps → `/api/status` clean | ❌ | ✅ |
+| SIGHUP-cascade vs setsid detach behaviour | ❌ | ✅ |
+| CI gate can distinguish "green" / "ghost detected" / "harness bailed" | ❌ | ✅ |
+
+## Run
+
+```bash
+docker build -t anet-qa180 -f tests/qa-180-rename-ghost/Dockerfile .
+docker run --rm --tmpfs /tmp:rw,exec anet-qa180
+```
+
+Expected trailer (production sweep, setsid mock):
+
+```
+PASS=20 FAIL=0
+```
+
+## Witnessed-red evidence
+
+`witnessed-red.txt` — captured 2026-07-30 with:
+1. `sweepMcpOrphansForAlias` stubbed to `return []` (no-op) in `agent-network/bin/cli.ts`
+2. Mock-mcp `setsid`-detached (this branch's improvement)
+
+Result:
+
+```
+✗ A.6b GHOST DETECTED: 1 MCP subprocess(es) still heart-beating with OLD alias=rename-target-a
+✗ B.6b GHOST DETECTED: 1 MCP subprocess(es) still heart-beating with OLD alias=rename-target-b
+PASS=18 FAIL=2
+```
+
+CI gate now reports **`rename-ghost regression: FAIL=2 (any FAIL > 0 = ghost process reproduced)`**, not `no trailer → treat as regression`.
+
+**Judgment cross-check for future readers**:
+- Production sweep + setsid mock → `PASS=20 FAIL=0` (fix works)
+- Sweep stubbed + setsid mock → `PASS=18 FAIL=2` "GHOST DETECTED" (门 truly witnesses ghost)
+- Sweep stubbed + non-setsid mock (pre-branch state) → `PASS=20 FAIL=0` (mock's SIGHUP cascade masks the missing sweep — 门 has never witnessed red)
+
+The third row is the discovery that motivated the mock upgrade. Before this branch, disabling the entire `#180` fix would have shown the same green as keeping it — the门 was not actually protecting anything. Now it does.
+
+## Why `--accept-dev-channels` was rejected (deliberate design record)
+
+The purpose-built headless flag `--accept-dev-channels` exists in anet for this class of scenario:
+
+```
+• For headless / CI / systemd / docker without -it:
+  anet node start '<alias>' --accept-dev-channels
+  (detached tmux session with a real PTY; auto-confirms the
+   dev-channels prompt if the node uses server: channels)
+```
+
+Reading anet source confirms it **always** spawns detached tmux (`agent-network/bin/cli.ts` L4476/L4499). Substituting it for CASE A's `nohup ...` would:
+
+- fix the "no PTY" symptom (green)
+- silently transform CASE A into "detached tmux" — a duplicate of CASE B
+- leave the label "foreground start (no tmux)" in place
+- lose real ghost coverage of the non-tmux path
+
+That is precisely the "test name lies" shape that we treat as a P0 defect elsewhere. See 通信龙 hard 裁定 2026-07-30 (task 2a95a950).
+
+Fallback ladder if `script` becomes unavailable: `socat` PTY, `expect` PTY, then **only if all three fail**, switch to `--accept-dev-channels` **AND** simultaneously (a) rename CASE A's title + file header to reflect the change, (b) open a follow-up issue tracking "non-tmux ghost coverage lost".
+
+## Related
+
+- Issue #526 (this fix)
+- Issue #494 (the TTY-required preflight in anet that fail-closed correctly)
+- Issue #518 (the `--accept-dev-channels` flag is anet's own suggested fix in error messages but is absent from `--help`; add this case as a real-world example of a harness red for 13 runs because the writer couldn't find that flag in `--help`)
+- Issue #180 (the ghost bug this harness was created to prevent)

--- a/docs/tests/p-526-rename-ghost-harness/witnessed-red.txt
+++ b/docs/tests/p-526-rename-ghost-harness/witnessed-red.txt
@@ -1,0 +1,191 @@
+# #526 witnessed-red evidence — sweep stubbed, ghost detected, trailer emitted
+# Captured: 2026-07-30 · docker run --rm --tmpfs /tmp:rw,exec anet-qa180-red
+# See README.md §Witnessed-red evidence for interpretation.
+---
+
+=== preflight — assert each dependency separately ===
+  ✓ preflight: /tmp free space ok (32193096 KiB)
+  ✓ preflight: 'script' present (/usr/bin/script)
+  ✓ preflight: 'tmux' present
+  ✓ preflight: 'anet' present (anet v2.3.0-preview.34)
+  ✓ preflight: 'bun' present
+  ✓ preflight: 'claude' present (/usr/local/bin/claude)
+  ✓ preflight: all auxiliaries present (curl, jq, python3, sqlite3, pgrep, ps, kill)
+
+=== 0. boot hub + admin ===
+  ✓ hub /health 200 :9239
+  ✓ admin utok minted
+  ✓ anet global config written (hub + utok + net_id)
+
+=== A. foreground start — anet node start (no tmux) ===
+  · created node rename-target-a @ /tmp/qa-180-work/.anet/nodes/rename-target-a (ntok minted, config written)
+  · anet node start rename-target-a → wrapper PID 182 (backgrounded via script PTY, no tmux)
+  ✓ A.1 claude spawned under alias=rename-target-a: pids=[334]
+  · A.2 /api/status doesn't show rename-target-a yet (mock heartbeat may still be ramping)
+  · A.3 firing: anet node rename rename-target-a renamed-a --force
+  · A.3 rename exit code=0 wall=78s
+    · [anet] note: "rename-target-a" has no server registration yet (never started). Performing local-only rename — no commhub 2PC needed.
+    · [anet] node was running — restarting under new alias "renamed-a" (#146 Option B)...
+    · [anet] ⚠ "rename-target-a" still running a task after 60s — proceeding with restart (--force).
+    · [anet]   An in-flight task may be interrupted without a reply (dispatcher's task stays open).
+    · [anet] stopped old agent process(es): 334
+    · [witnessed-red] sweepMcpOrphansForAlias intentionally disabled — MCP orphan sweep skipped.
+    · [anet] node_id node_rename-target-a_9e67f8bc8705 unchanged in local config; this runtime's commhub identity is resume_id cc-node_rename-target-a_9e67f8bc8705 — also stable across the rename. ntok_ token still valid.
+    · [anet] ✅ Renamed "rename-target-a" → "renamed-a" (txn null) — agent restarted + verified live under the new alias (new process pid alive (hub heartbeat still catching up)).
+  ✓ A.4 pgrep alias=rename-target-a AFTER rename → NONE (no ghost in this case)
+  ✓ A.5 new alias=renamed-a has claude pids=[2990]
+  ✓ A.6 /api/status no longer shows rename-target-a (clean)
+  ✗ A.6b GHOST DETECTED: 1 MCP subprocess(es) still heart-beating with OLD alias=rename-target-a
+    · 335 bash -c      set -uo pipefail     HUB='http://127.0.0.1:9239'     TOK='ntok_bab3777f1ce84325ae0a18e8fe51ed31'     ALIAS='rename-target-a'     NETID=''     echo "[mock-mcp pid=$$] started, will heartbeat alias=$ALIAS" >&2     trap 'echo "[mock-mcp pid=$$] SIGTERM received, exiting" >&2; exit 0' SIGTERM     while true; do       if [[ -n "$HUB" && -n "$TOK" && -n "$ALIAS" ]]; then         curl -sS -X POST "$HUB/api/status"           -H "Authorization: Bearer $TOK"           -H 'Content-Type: application/json'           -d "{\"alias\":\"$ALIAS\",\"status\":\"idle\",\"agent\":\"mock-mcp\",\"task\":\"waiting\",\"progress\":0${NETID:+,\"network_id\":\"$NETID\"}}"           >/dev/null 2>&1 || true       fi       # Sleep in short chunks so SIGTERM is responsive       for _ in $(seq 1 20); do sleep 0.1; done     done   
+  · A.6c diagnostic total pgrep mock-mcp count = 5
+  · A.7 /api/status doesn't yet show renamed-a (new node still starting)
+
+=== B. tmux-detached start — startNodeTmuxSession pattern ===
+  · created node rename-target-b @ /tmp/qa-180-work/.anet/nodes/rename-target-b (ntok minted, config written)
+  · B.1 tmux new-session -d -s rename-target-b 'anet node start rename-target-b' fired
+  ✓ B.1 claude spawned under alias=rename-target-b: pids=[4133]
+  ·   process tree:
+  ·     claude pid=4133 ← parent pid=3764 (node) ← grandparent pid=3762 (tmux: server)
+  · B.3 firing: anet node rename rename-target-b renamed-b --force
+  · B.3 rename exit code=0 wall=77s
+    · [anet] persisted canonical node_id node_rename-target-b_f9dd18143d49 before rename.
+    · [anet] note: "rename-target-b" has no server registration yet (never started). Performing local-only rename — no commhub 2PC needed.
+    · [anet] node was running — restarting under new alias "renamed-b" (#146 Option B)...
+    · [anet] ⚠ "rename-target-b" still running a task after 60s — proceeding with restart (--force).
+    · [anet]   An in-flight task may be interrupted without a reply (dispatcher's task stays open).
+    · [anet] stopped old agent process(es): 4133
+    · [witnessed-red] sweepMcpOrphansForAlias intentionally disabled — MCP orphan sweep skipped.
+    · [anet] node_id node_rename-target-b_f9dd18143d49 unchanged in local config; this runtime's commhub identity is resume_id cc-node_rename-target-b_f9dd18143d49 — also stable across the rename. ntok_ token still valid.
+    · [anet] ✅ Renamed "rename-target-b" → "renamed-b" (txn null) — agent restarted + verified live under the new alias (new process pid alive (hub heartbeat still catching up)).
+  ✓ B.4 pgrep alias=rename-target-b AFTER rename → NONE (no ghost in this case either)
+  ✓ B.5 new alias=renamed-b has claude pids=[10203]
+  ✓ B.6 /api/status no longer shows rename-target-b (clean)
+  ✗ B.6b GHOST DETECTED: 1 MCP subprocess(es) still heart-beating with OLD alias=rename-target-b
+    · 4134 bash -c      set -uo pipefail     HUB='http://127.0.0.1:9239'     TOK='ntok_726cb65c1204404699b98c4fab7aaddc'     ALIAS='rename-target-b'     NETID=''     echo "[mock-mcp pid=$$] started, will heartbeat alias=$ALIAS" >&2     trap 'echo "[mock-mcp pid=$$] SIGTERM received, exiting" >&2; exit 0' SIGTERM     while true; do       if [[ -n "$HUB" && -n "$TOK" && -n "$ALIAS" ]]; then         curl -sS -X POST "$HUB/api/status"           -H "Authorization: Bearer $TOK"           -H 'Content-Type: application/json'           -d "{\"alias\":\"$ALIAS\",\"status\":\"idle\",\"agent\":\"mock-mcp\",\"task\":\"waiting\",\"progress\":0${NETID:+,\"network_id\":\"$NETID\"}}"           >/dev/null 2>&1 || true       fi       # Sleep in short chunks so SIGTERM is responsive       for _ in $(seq 1 20); do sleep 0.1; done     done   
+  · B.6c diagnostic total pgrep mock-mcp count = 9
+  · B.7 /api/status doesn't yet show renamed-b
+  · B.8 tmux session 'rename-target-b' gone
+  · B.8 tmux session 'renamed-b' running (auto-restart under new alias)
+
+────────────────────────────────────────────
+issue #180 rename ghost e2e — PASS=18 FAIL=2
+  (FAIL count = ghost/reproductions; higher = worse)
+────────────────────────────────────────────
+...
+(intermediate lines truncated — see full log for verbose diagnostics)
+...
+  · created node rename-target-b @ /tmp/qa-180-work/.anet/nodes/rename-target-b (ntok minted, config written)
+  · B.1 tmux new-session -d -s rename-target-b 'anet node start rename-target-b' fired
+  ✓ B.1 claude spawned under alias=rename-target-b: pids=[4133]
+  ·   process tree:
+  ·     claude pid=4133 ← parent pid=3764 (node) ← grandparent pid=3762 (tmux: server)
+  · B.3 firing: anet node rename rename-target-b renamed-b --force
+  · B.3 rename exit code=0 wall=77s
+    · [anet] persisted canonical node_id node_rename-target-b_f9dd18143d49 before rename.
+    · [anet] note: "rename-target-b" has no server registration yet (never started). Performing local-only rename — no commhub 2PC needed.
+    · [anet] node was running — restarting under new alias "renamed-b" (#146 Option B)...
+    · [anet] ⚠ "rename-target-b" still running a task after 60s — proceeding with restart (--force).
+    · [anet]   An in-flight task may be interrupted without a reply (dispatcher's task stays open).
+    · [anet] stopped old agent process(es): 4133
+    · [witnessed-red] sweepMcpOrphansForAlias intentionally disabled — MCP orphan sweep skipped.
+    · [anet] node_id node_rename-target-b_f9dd18143d49 unchanged in local config; this runtime's commhub identity is resume_id cc-node_rename-target-b_f9dd18143d49 — also stable across the rename. ntok_ token still valid.
+    · [anet] ✅ Renamed "rename-target-b" → "renamed-b" (txn null) — agent restarted + verified live under the new alias (new process pid alive (hub heartbeat still catching up)).
+  ✓ B.4 pgrep alias=rename-target-b AFTER rename → NONE (no ghost in this case either)
+  ✓ B.5 new alias=renamed-b has claude pids=[10203]
+  ✓ B.6 /api/status no longer shows rename-target-b (clean)
+  ✗ B.6b GHOST DETECTED: 1 MCP subprocess(es) still heart-beating with OLD alias=rename-target-b
+    · 4134 bash -c      set -uo pipefail     HUB='http://127.0.0.1:9239'     TOK='ntok_726cb65c1204404699b98c4fab7aaddc'     ALIAS='rename-target-b'     NETID=''     echo "[mock-mcp pid=$$] started, will heartbeat alias=$ALIAS" >&2     trap 'echo "[mock-mcp pid=$$] SIGTERM received, exiting" >&2; exit 0' SIGTERM     while true; do       if [[ -n "$HUB" && -n "$TOK" && -n "$ALIAS" ]]; then         curl -sS -X POST "$HUB/api/status"           -H "Authorization: Bearer $TOK"           -H 'Content-Type: application/json'           -d "{\"alias\":\"$ALIAS\",\"status\":\"idle\",\"agent\":\"mock-mcp\",\"task\":\"waiting\",\"progress\":0${NETID:+,\"network_id\":\"$NETID\"}}"           >/dev/null 2>&1 || true       fi       # Sleep in short chunks so SIGTERM is responsive       for _ in $(seq 1 20); do sleep 0.1; done     done   
+  · B.6c diagnostic total pgrep mock-mcp count = 9
+  · B.7 /api/status doesn't yet show renamed-b
+  · B.8 tmux session 'rename-target-b' gone
+  · B.8 tmux session 'renamed-b' running (auto-restart under new alias)
+
+────────────────────────────────────────────
+issue #180 rename ghost e2e — PASS=18 FAIL=2
+  (FAIL count = ghost/reproductions; higher = worse)
+────────────────────────────────────────────
+
+
+════════════════════════════════════════════════════════════════════
+3RD STATE — sweep stubbed AND setsid removed (pre-branch mock shape)
+Captured: 2026-07-30 · docker run --rm --tmpfs /tmp:rw,exec anet-qa180-red
+Purpose: capture the "该出现而没出现的东西" evidence (通信龙 task b9c0bcf7).
+
+Setup for this run (all mutations applied together):
+  • agent-network/bin/cli.ts: sweepMcpOrphansForAlias body replaced with
+    `return []` — the entire #180 main fix disabled.
+  • tests/qa-180-rename-ghost/mock-claude: `setsid` REMOVED from the
+    mock-mcp spawn line — reverts to the pre-branch mock shape where
+    mock-mcp lives in mock-claude's process group.
+
+Expected observation: PASS=N FAIL=0 despite the #180 fix being fully
+disabled. Why: mock-mcp dies by SIGHUP cascade when mock-claude dies
+(same process group), so no orphan survives for the sweep to catch or
+miss. The harness was structurally unable to witness a red case.
+
+Key signals (grepped from full run log — the [witnessed-red] console
+line confirms the stub is in effect):
+════════════════════════════════════════════════════════════════════
+
+--- preflight (all green) ---
+
+=== preflight — assert each dependency separately ===
+  ✓ preflight: /tmp free space ok (32193096 KiB)
+  ✓ preflight: 'script' present (/usr/bin/script)
+  ✓ preflight: 'tmux' present
+  ✓ preflight: 'anet' present (anet v2.3.0-preview.34)
+  ✓ preflight: 'bun' present
+  ✓ preflight: 'claude' present (/usr/local/bin/claude)
+  ✓ preflight: all auxiliaries present (curl, jq, python3, sqlite3, pgrep, ps, kill)
+
+=== 0. boot hub + admin ===
+  ✓ hub /health 200 :9239
+  ✓ admin utok minted
+  ✓ anet global config written (hub + utok + net_id)
+
+=== A. foreground start — anet node start (no tmux) ===
+  · created node rename-target-a @ /tmp/qa-180-work/.anet/nodes/rename-target-a (ntok minted, config written)
+  · anet node start rename-target-a → wrapper PID 181 (backgrounded via script PTY, no tmux)
+  ✓ A.1 claude spawned under alias=rename-target-a: pids=[334]
+  · A.2 /api/status doesn't show rename-target-a yet (mock heartbeat may still be ramping)
+  · A.3 firing: anet node rename rename-target-a renamed-a --force
+  · A.3 rename exit code=0 wall=78s
+    · [anet] note: "rename-target-a" has no server registration yet (never started). Performing local-only rename — no commhub 2PC needed.
+    · [anet] node was running — restarting under new alias "renamed-a" (#146 Option B)...
+    · [anet] ⚠ "rename-target-a" still running a task after 60s — proceeding with restart (--force).
+    · [anet]   An in-flight task may be interrupted without a reply (dispatcher's task stays open).
+    · [anet] stopped old agent process(es): 334
+    · [witnessed-red] sweepMcpOrphansForAlias intentionally disabled — MCP orphan sweep skipped.
+    · [anet] node_id node_rename-target-a_76bca2c952f8 unchanged in local config; this runtime's commhub identity is resume_id cc-node_rename-target-a_76bca2c952f8 — also stable across the rename. ntok_ token still valid.
+    · [anet] ✅ Renamed "rename-target-a" → "renamed-a" (txn null) — agent restarted + verified live under the new alias (new process pid alive (hub
+
+--- middle: sweep-stub signal fires + A.6b/B.6b still PASS ---
+    · [witnessed-red] sweepMcpOrphansForAlias intentionally disabled — MCP orphan sweep skipped.
+  ✓ A.4 pgrep alias=rename-target-a AFTER rename → NONE (no ghost in this case)
+  ✓ A.6 /api/status no longer shows rename-target-a (clean)
+  ✓ A.6b no MCP subprocess heart-beating OLD alias=rename-target-a (sweepMcpOrphansForAlias caught them)
+  · A.6c diagnostic total pgrep mock-mcp count = 3
+    · [witnessed-red] sweepMcpOrphansForAlias intentionally disabled — MCP orphan sweep skipped.
+  ✓ B.4 pgrep alias=rename-target-b AFTER rename → NONE (no ghost in this case either)
+  ✓ B.6 /api/status no longer shows rename-target-b (clean)
+  ✓ B.6b no MCP subprocess heart-beating OLD alias=rename-target-b (sweepMcpOrphansForAlias caught them)
+  · B.6c diagnostic total pgrep mock-mcp count = 3
+issue #180 rename ghost e2e — PASS=20 FAIL=0
+
+════════════════════════════════════════════════════════════════════
+Conclusion (the finding that justifies the mock-mcp setsid upgrade):
+
+  • Second state (setsid mock + sweep stub)   → PASS=18 FAIL=2  GHOST DETECTED
+  • Third state (no-setsid mock + sweep stub) → PASS=20 FAIL=0  WRONG-green
+
+The delta between second and third state IS the mock's fidelity. The
+production ghost class (`findMcpBridgeOrphansByAlias` matches env-
+carrying orphans that survived the parent) requires the child to
+actually survive; the pre-branch mock never allowed that. This is
+why the门 was previously green regardless of whether the fix existed.
+
+Not-appearing evidence: no `✗ ... GHOST DETECTED` line appears
+anywhere in the 3rd-state output despite `[witnessed-red]` firing —
+confirming the sweep function's stub took effect but there was
+nothing to sweep because there was no ghost.
+════════════════════════════════════════════════════════════════════

--- a/tests/qa-180-rename-ghost/mock-claude
+++ b/tests/qa-180-rename-ghost/mock-claude
@@ -51,7 +51,7 @@ echo "[mock-claude pid=$$] alias: '${ALIAS:-<none>}'" >&2
 # by NOT wiring the subprocess's stdin to anything — the subprocess
 # heart-beats until externally SIGTERM'd.
 spawn_mcp_subprocess() {
-  bash -c "
+  setsid bash -c "
     set -uo pipefail
     HUB='${COMMHUB_URL:-}'
     TOK='${COMMHUB_TOKEN:-}'

--- a/tests/qa-180-rename-ghost/run.sh
+++ b/tests/qa-180-rename-ghost/run.sh
@@ -38,6 +38,90 @@ ok()   { printf "  ✓ %s\n" "$*"; PASS=$((PASS+1)); }
 bad()  { printf "  ✗ %s\n" "$*"; FAIL=$((FAIL+1)); }
 raw()  { printf "  · %s\n" "$*"; }
 
+# #526 — emit the PASS=N FAIL=N trailer on EVERY exit path.
+# The CI gate parses `PASS=X FAIL=Y` from stdout; an early `exit 1`
+# (missing binary / bailout / preflight fail) that skips this line
+# makes the gate report "no trailer → treat as regression", which
+# fails-closed but masks the real cause (see #526 log analysis).
+# A trap catches early exits so the gate always gets a truthy verdict.
+emit_trailer() {
+  printf "\n────────────────────────────────────────────\n"
+  printf "issue #180 rename ghost e2e — PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
+  printf "  (FAIL count = ghost/reproductions; higher = worse)\n"
+  printf "────────────────────────────────────────────\n"
+}
+trap emit_trailer EXIT
+
+# #526 — preflight: each dependency asserts itself and reports its own
+# failure reason (not "the harness didn't produce a trailer"). Docker /
+# image / disk are the workflow's job before invoking this script;
+# these are the in-container prereqs the harness itself relies on.
+preflight() {
+  note "preflight — assert each dependency separately"
+  local missing=0
+  local disk_avail
+  disk_avail=$(df -Pk /tmp 2>/dev/null | awk 'NR==2{print $4}')
+  # 200 MiB floor — mock hub db + logs + fixtures easily fit; anything
+  # less risks weird failure modes (sqlite write fails silently).
+  if [ -z "${disk_avail:-}" ] || [ "$disk_avail" -lt 204800 ]; then
+    bad "preflight: /tmp free space too low (need ≥ 200 MiB, got ${disk_avail:-unknown} KiB)"
+    missing=$((missing+1))
+  else
+    ok "preflight: /tmp free space ok (${disk_avail} KiB)"
+  fi
+  # `script` (util-linux) — the CASE A PTY wrapper needs it.
+  if ! command -v script >/dev/null 2>&1; then
+    bad "preflight: 'script' (util-linux) missing — CASE A PTY wrapper cannot run"
+    missing=$((missing+1))
+  else
+    ok "preflight: 'script' present ($(command -v script))"
+  fi
+  # tmux — CASE B pattern uses tmux new-session -d.
+  if ! command -v tmux >/dev/null 2>&1; then
+    bad "preflight: 'tmux' missing — CASE B (tmux-detached start) cannot run"
+    missing=$((missing+1))
+  else
+    ok "preflight: 'tmux' present"
+  fi
+  # anet — the CLI under test.
+  if ! command -v anet >/dev/null 2>&1; then
+    bad "preflight: 'anet' missing — the CLI under test is not installed"
+    missing=$((missing+1))
+  else
+    ok "preflight: 'anet' present ($(anet --version 2>/dev/null | head -1 || echo 'no version'))"
+  fi
+  # bun — server + node runtime.
+  if ! command -v bun >/dev/null 2>&1; then
+    bad "preflight: 'bun' missing — hub cannot start"
+    missing=$((missing+1))
+  else
+    ok "preflight: 'bun' present"
+  fi
+  # mock claude binary — CI installs to /usr/local/bin/claude, dev
+  # runs may symlink elsewhere. Fail-clear rather than let downstream
+  # ps grep silently return empty.
+  if ! command -v claude >/dev/null 2>&1; then
+    bad "preflight: 'claude' missing — mock claude binary not on PATH"
+    missing=$((missing+1))
+  else
+    ok "preflight: 'claude' present ($(command -v claude))"
+  fi
+  # Basic auxiliaries. Each on its own line so a red preflight names
+  # the exact one that is missing.
+  for tool in curl jq python3 sqlite3 pgrep ps kill; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      bad "preflight: '$tool' missing"
+      missing=$((missing+1))
+    fi
+  done
+  [ "$missing" -eq 0 ] && ok "preflight: all auxiliaries present (curl, jq, python3, sqlite3, pgrep, ps, kill)"
+  if [ "$missing" -gt 0 ]; then
+    printf "\n::error::preflight failed with %d missing prerequisites — refusing to run the harness (see individual ✗ lines above).\n" "$missing"
+    exit 1
+  fi
+}
+preflight
+
 # alias_pgrep — list PIDs of claude processes matching --alias/-n <name>
 alias_pgrep() {
   # Matches how findNodeProcessesByAlias parses argv (require binary name +
@@ -121,9 +205,23 @@ cd "$WORK"
 # Start in the background — mimics user opening a terminal + running the cmd.
 # `anet node start` for claude-code-cli runtime enters launchAgent → spawns
 # claude → awaits its exit. We background it so the shell continues.
-COMMHUB_URL="$HUB_BASE" nohup anet node start "$CHILD_A" >/tmp/anet-start-A.log 2>&1 &
+#
+# #526 — wrap with `script -q -c ... /dev/null` so `process.stdin.isTTY`
+# is true for the child. Claude CLI 2.1.220+ auto-switches to `--print`
+# mode without a TTY and refuses to start its interactive session, so
+# anet's #494 preflight fail-closes with a clear "requires TTY" error
+# and the harness never reaches the trailer. `script` allocates a real
+# PTY WITHOUT introducing tmux — CASE A's "foreground no tmux" language
+# above is load-bearing (进程树 shape differs, ghost-production
+# conditions per case are distinct even though the CLEANUP path
+# (`sweepMcpOrphansForAlias`) is common). Do NOT switch to
+# `--accept-dev-channels`: that spawns a DETACHED tmux session (see
+# `agent-network/bin/cli.ts` L4476/L4499), collapsing CASE A into a
+# duplicate of CASE B while the label still claims "no tmux" —
+# 通信龙 2026-07-30 hard裁定.
+COMMHUB_URL="$HUB_BASE" nohup script -q -c "anet node start '$CHILD_A'" /dev/null >/tmp/anet-start-A.log 2>&1 &
 ANET_START_A_PID=$!
-raw "anet node start $CHILD_A → wrapper PID $ANET_START_A_PID (backgrounded)"
+raw "anet node start $CHILD_A → wrapper PID $ANET_START_A_PID (backgrounded via script PTY, no tmux)"
 
 # Wait for claude to appear in ps (mock claude prints readiness on stderr).
 for i in $(seq 1 30); do
@@ -136,6 +234,17 @@ if [[ -n "$CLAUDE_A_PIDS_BEFORE" ]]; then
 else
   bad "A.1 claude never appeared for $CHILD_A after 30s"
   tail -30 /tmp/anet-start-A.log
+  # #526 — do NOT exit early. The trailer trap will fire regardless,
+  # but the CI gate needs to distinguish "detected ghost" (FAIL>0 from
+  # real repro) from "harness bailed" (FAIL≥1 from A.1 bad). Both
+  # correctly show as failed, but the log tells operators whether the
+  # harness reached its detection code or fell over before it. Skipping
+  # the rest of CASE A + CASE B here means we still exit non-zero (FAIL>0)
+  # but with a trailer — which is the point of #526.
+  #
+  # We still short-circuit the rest of CASE A + CASE B because they
+  # depend on the CASE A node existing, but we do it via the trap
+  # rather than a naked `exit 1` that skipped the trailer.
   exit 1
 fi
 
@@ -248,9 +357,9 @@ else
   bad "B.1 claude never appeared for $CHILD_B after 30s"
   tmux capture-pane -t "$CHILD_B" -p 2>/dev/null | sed 's/^/    · /'
   raw "SKIP rest of B due to no claude"
-  printf "\n────────────────────────────────────────────\n"
-  printf "issue #180 rename ghost e2e — PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
-  printf "────────────────────────────────────────────\n"
+  # #526 — trailer is now emitted via the EXIT trap, no need to print
+  # it manually here (avoids double-emission when the trap fires on
+  # exit 1). Trap catches EVERY exit path.
   exit 1
 fi
 
@@ -334,8 +443,8 @@ tmux kill-server 2>/dev/null || true
 pkill -f "^/usr/local/bin/claude" 2>/dev/null || true
 sleep 1
 
-printf "\n────────────────────────────────────────────\n"
-printf "issue #180 rename ghost e2e — PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
-printf "  (FAIL count = ghost/reproductions; higher = worse)\n"
-printf "────────────────────────────────────────────\n"
+# #526 — trailer is emitted by the `trap emit_trailer EXIT` at the top;
+# don't print it here or it would double-emit on normal completion.
+# Final rc = FAIL count. The gate reads it as `runner exit code` (must
+# be 0) alongside the trailer.
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #526.

## Diagnosis (posted to task earlier, condensed here)

`Docker E2E Tests` `rename-ghost-gate` was 0/13 on main. CI log
(run `30547019602`) shows the harness never emitted its `PASS=N FAIL=N`
trailer; the gate correctly fail-closed on "no trailer → treat as
regression". Root cause is **harness缺前提, not product regression**:

- `tests/qa-180-rename-ghost/run.sh:124` (pre-fix) started the node
  with `nohup anet node start …` — no PTY.
- Claude CLI 2.1.220+ auto-switches to `--print` mode without a TTY.
- anet's #494 preflight refuses to spawn without a TTY (fail-closed —
  correctly) and prints the "requires TTY" hint pointing at
  `--accept-dev-channels`.
- `run.sh` exit'd at A.1 without ever reaching the trailer emit.

The gate's fail-closed behaviour is right; anet's TTY refuse is
right; the harness was left behind by the Claude CLI upgrade. Fix is
in the harness only.

## Four narrow changes

**1. `run.sh` preflight per-condition (#526 §1)**

Assert `script`, `tmux`, `anet`, `bun`, `claude`, `curl`, `jq`,
`python3`, `sqlite3`, `pgrep`, `ps`, `kill` on their own ✗ lines,
plus a 200 MiB `/tmp` floor. A red preflight names the specific
missing prerequisite instead of collapsing to "no trailer".

**2. `run.sh` trailer trap**

`trap emit_trailer EXIT` at the top so every exit path — normal,
A.1/B.1 bailout, preflight refusal, `set -u` trip — emits
`PASS=N FAIL=N`. The gate now distinguishes:

- `PASS=20 FAIL=0` → clean
- `PASS=18 FAIL=2 GHOST DETECTED` → real regression
- `PASS=0 FAIL=1 preflight…` → harness gap

Before, all three collapsed to "no trailer" and looked identical.

**3. `run.sh` CASE A: `script -q -c` PTY, NOT `--accept-dev-channels`**

`script` allocates a real PTY without introducing tmux. CASE A's
"foreground no tmux" is load-bearing because process tree shape
drives ghost-production conditions per case (the cleanup path is
shared; the production path is not).

**Deliberately rejected**: `anet node start --accept-dev-channels`
would fix the symptom but spawn detached tmux (source: `agent-network/bin/cli.ts` L4476/L4499), collapsing CASE A into a
copy of CASE B while the label still claims "foreground no tmux" —
the "test name lies" failure mode we treat as P0 elsewhere. Judgment
call by 通信龙 hard 裁定 2026-07-30 (task 2a95a950). Fallback ladder
if `script` becomes unavailable: `socat`, then `expect`, then only if
all three fail switch to `--accept-dev-channels` AND simultaneously
rename the case label + open a follow-up issue about lost non-tmux
coverage.

**4. `mock-claude`: `setsid` on `mock-mcp` spawn**

**Discovery**: without `setsid`, mock-mcp lived in mock-claude's
process group and died by SIGHUP cascade whenever mock-claude died.
Meaning **even with the entire `#180` sweep disabled, no ghost
survived to be detected — the harness had never actually witnessed a
red case**. This is exactly the "永远绿的门" 通信龙 warned about in
#526.

Real Claude Code CLI's MCP subprocesses can survive parent death
(multiple mechanisms documented in `mock-claude`'s header comment
and in the `#180` fix rationale). `setsid` makes the mock a faithful
reproduction of that class. This is a legitimate fixture upgrade,
not a stub.

## Witnessed-red (methodology from #504)

With all four fix changes in place PLUS a temporary stub of
`sweepMcpOrphansForAlias` (returns `[]` — reverts `#180` main fix):

```
✗ A.6b GHOST DETECTED: 1 MCP subprocess(es) heart-beating with OLD alias=rename-target-a
✗ B.6b GHOST DETECTED: 1 MCP subprocess(es) heart-beating with OLD alias=rename-target-b
PASS=18 FAIL=2
```

Trailer emitted; gate now reports `rename-ghost regression: FAIL=2`,
not `no trailer → treat as regression`. Restore sweep → 20/0 green.

Mutation applied on the被测系统 real behaviour (sweep function body),
NOT on the mock's fake ghost data — per 通信龙 task 85315f9f: "mock
上造出来的红只证明检测器对 mock 自洽, 不证明它能发现真 ghost."

Evidence archived at `docs/tests/p-526-rename-ghost-harness/`:
- `README.md` — design rationale + green/red/witnessed-red matrix
- `witnessed-red.txt` — captured red output showing GHOST DETECTED + trailer

## Three-state matrix (verified in isolated Docker, no touch of prod)

| State | Sweep | Mock setsid | Result | CI gate reports |
|---|---|---|---|---|
| Production (this PR) | active | yes | PASS=20 FAIL=0 | ✅ PASS |
| Witnessed-red | stubbed | yes | PASS=18 FAIL=2 | 🔴 GHOST DETECTED FAIL=2 |
| Pre-branch discovery | stubbed | no | PASS=20 FAIL=0 | ✅ (WRONG — 门 protects nothing) |

The bottom row is the discovery that motivated the mock upgrade.
Before this branch, deleting the entire `#180` fix would look
identical to keeping it.

## Test plan

- [x] Preflight full pass on stock Dockerfile (12 deps + `/tmp` floor)
- [x] Production run: PASS=20 FAIL=0
- [x] Witnessed-red run: PASS=18 FAIL=2 with GHOST DETECTED lines
- [x] Restore sweep after red run → back to 20/0
- [x] Cross-verify: pre-branch state (no setsid) with sweep stubbed
      still returned 20/0 green — confirms "永远绿的门" discovery
- [ ] (post-merge) Rerun this CI workflow on main after landing; the
      `rename-ghost-gate` job should go from 0/N to N/N pass ratio
      starting with the run that includes this commit

## Related

- #180 (ghost bug this harness was built for)
- #494 (anet TTY preflight — the fail-closed behaviour that surfaced
  the harness gap)
- #518 (`--accept-dev-channels` is anet's own suggested fix in error
  messages but absent from `--help`; this incident is a real-world
  example of the cost of that gap — I'll add the case there after
  this lands)

## Attribution

Author: 通信demo马
CC: 通信龙 (dispatch + hard 裁定 on CASE A semantic preservation)