### PR TITLE
feat(#521,#523): opencode agent-node pm2 supervision + startup recipe

### DIFF
--- a/agent-network/scripts/README.md
+++ b/agent-network/scripts/README.md
@@ -1,0 +1,89 @@
+# `agent-network/scripts/` — opencode node pm2 recipe (#521 + #523)
+
+The startup recipe for an opencode agent-node under pm2 supervision. Source of truth for what runs; the actual runtime copy lives elsewhere (see §Install).
+
+## Files
+
+- **`opencode-node-start.sh`** — the launch recipe. Runs preflight checks then `exec`s into agent-node in the foreground so pm2 tracks it.
+- **`pm2-opencode.config.cjs`** — the pm2 ecosystem config. Points at the installed copy of the script, not this repo.
+
+## Why two files (and two locations)
+
+`opencode-node-start.sh` here is **the source of truth**. Reviews land against this copy. But **pm2 references** `/home/vansin/.local/bin/opencode-node-start.sh`, **not this file**.
+
+The reason ([issue #526 same class](../../docs/tests/p-526-rename-ghost-harness/README.md), same lesson): any pm2/systemd/cron path that points inside a git worktree becomes a booby trap. When the branch merges, the worktree is cleaned; the reference goes dead; the daemon fails silently on next restart (`pm2 list` still shows the app). We put the *runtime* copy at `~/.local/bin/` alongside the other host daemons (`dash-start.sh`, `hub-daemon.sh`, `pm2-fleet-boot.sh`) so this class of failure is out of scope.
+
+## Install / upgrade
+
+```bash
+# From this directory (or the repo root — path is absolute below)
+cp -v agent-network/scripts/opencode-node-start.sh /home/vansin/.local/bin/opencode-node-start.sh
+chmod +x /home/vansin/.local/bin/opencode-node-start.sh
+```
+
+🔴 **`cp`, not `ln`.** A symlink target that disappears is even less visible than an absolute path pointing at nothing.
+
+**When you edit the source of truth in this directory, you must `cp` it again.** The pm2 config file `pm2-opencode.config.cjs` does not need to change on script upgrades — its `script:` field is a stable absolute path.
+
+## Start / stop
+
+Both invocations from anywhere on the host:
+
+```bash
+# Start (or resurrect after crash)
+pm2 start /path/to/agent-network/scripts/pm2-opencode.config.cjs
+
+# Or reference by name after it's known
+pm2 restart opencode-node-测试1号
+pm2 stop opencode-node-测试1号
+pm2 delete opencode-node-测试1号
+```
+
+After a first-time start, run `pm2 save` **only after** a PONG confirms the node actually receives tasks (not just "process is up"). See §Test flow.
+
+## Test flow (adapted from #526)
+
+1. **Config parse** (zero side-effect): `node -e "console.log(JSON.stringify(require('./agent-network/scripts/pm2-opencode.config.cjs'), null, 2))"`
+2. **Preflight only** (zero side-effect, per §preflight): `bash agent-network/scripts/opencode-node-start.sh --alias opencode测试1号 --preflight-only`
+3. **Cold start**: `pm2 start …/pm2-opencode.config.cjs`
+4. **Route check**: from another session, send `PONG` via commhub → node replies within ~10s
+5. **Auto-restart check**: `kill -9 <pid>` → pm2 restarts within `restart_delay` (5s) → new pid, `restart_time` incremented, `status=online`
+6. **Env-defense check** (this recipe's key invariant): `tr '\0' '\n' </proc/<new-pid>/environ | grep -c '^COMMHUB_'` → **must be 0**
+7. **PONG again** to prove the restarted process routes correctly
+8. **Only after everything above green**: `pm2 save`
+
+## Preflight — what the script asserts
+
+Each item fails-closed with its own ✗ line so a red preflight names the exact prerequisite. Discovered empirically 2026-07-30:
+
+| # | Assertion | Why |
+|---|---|---|
+| 1 | `NODE_HOME` exists + has `node_modules` | Base install layout |
+| 2 | opencode binary in `$SUPPORT_MODULES` | Runtime dependency |
+| 2b | 🔴 `opencode-ai` **not** in `$NODE_HOME/node_modules` | agent-node supply-chain guard refuses "overlaps forbidden root" |
+| 3 | Node config JSON exists + alias matches | Sanity |
+| 3b | 🔴 Node workDir `owner=uid, mode=0700` | OpenCode state module supply-chain guard |
+| 3c | 🔴 `config.json` `owner=uid, mode=0600` | Paired guard |
+| 4 | `agent-node` binary executable | Sanity |
+| 5 | `node` on PATH | Sanity |
+| 6 | Env pollution report (`COMMHUB_ALIAS` / `COMMHUB_TOKEN`) | Informational — unset happens below anyway |
+
+`mkdir -p` and `cat >file` use default umask (usually 755/644) and both fail 3b + 3c. `anet node create` gets this right; hand-creating a node misses. Only path to catch this before spawn is preflight.
+
+## Env defense — two layers
+
+agent-node reads `COMMHUB_NODE_ID` / `COMMHUB_ALIAS` / etc. from the environment **before** it reads its own `config.json` (see `agent-network/bin/cli.ts:600`). A polluted shell can override a node's identity that way — [issue #532](https://github.com/sleep2agi/agent-network/issues/532) captures the underlying agent-node bug (canonical-alias reverse lookup by node_id doesn't filter offline sessions).
+
+This recipe defends at two layers:
+
+1. **Ecosystem `env: { COMMHUB_*: '' }`** — explicit override of anything pm2's daemon inherited from its own bootstrap shell. `env: {}` is *not* enough — that means "no override", not "clear". pm2 daemon's env transparently reaches every managed app when the ecosystem is empty.
+2. **Script `for/unset $(env | grep ^COMMHUB_)`** — pattern-clears every `COMMHUB_*` inside the script, catching any variable the ecosystem override didn't name.
+
+**Both layers required.** Enumeration always misses something eventually; only clearing by pattern covers future additions.
+
+## Related
+
+- [#521](https://github.com/sleep2agi/agent-network/issues/521) — startup recipe scripted (this PR)
+- [#523](https://github.com/sleep2agi/agent-network/issues/523) — pm2 supervision + auto-restart (this PR)
+- [#532](https://github.com/sleep2agi/agent-network/issues/532) — agent-node canonical-alias bug found while doing this (通信龙 立项)
+- [#526](https://github.com/sleep2agi/agent-network/issues/526) — same "daemon paths in worktrees" lesson from the rename-ghost gate

--- a/agent-network/scripts/opencode-node-start.sh
+++ b/agent-network/scripts/opencode-node-start.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# agent-network/scripts/opencode-node-start.sh — #521 + #523
+#
+# The opencode agent-node start recipe, made script-shaped so it can be
+# submitted to pm2 (foreground process) instead of living in an ad-hoc
+# nohup command that only exists in someone's shell history.
+#
+# Design notes:
+#   - This script is FOREGROUND-blocking on purpose: pm2 needs to
+#     watch the child, so we `exec` into agent-node at the end without
+#     backgrounding.
+#   - The prerequisites of the opencode runtime (per #521) are each
+#     asserted independently with fail-closed semantics; a red
+#     preflight names the specific missing prerequisite instead of
+#     dying with a downstream ambiguous error 30s later.
+#   - We deliberately do NOT `set -e` — `set -uo pipefail` is enough
+#     to fail-closed on any real error while letting us decide when
+#     to accumulate and report vs bail. Same convention as tests/qa-*
+#     runners in the repo.
+#
+# Usage:
+#   opencode-node-start.sh --alias <alias>
+#     [--node-home /home/vansin/opencode-node]
+#     [--support /home/vansin/opencode-support]
+#     [--debug]                # opt-in — see note below
+#
+# Log level: default is agent-node's normal level. `--debug` is
+# opt-in for troubleshooting. Debug is intentionally NOT the default
+# because (a) it pumps volume on a long-running node — magnetic on
+# a 95%-full disk — and (b) it can print token prefixes / message
+# bodies to the log. The one operational reason debug was previously
+# hardcoded (self-skip diagnosis, #522) is being fixed at the source
+# in #522, after which the diagnostic line survives at normal level.
+# The two issues are a set: #522 lets default-level be sufficient;
+# #521 (this script) shifts the default down.
+#
+# Meant to be launched via
+#   pm2 start agent-network/scripts/pm2-opencode.config.js
+# (see the ecosystem file next to this one). Running by hand is fine
+# for a smoke test, but production wants it under pm2 so a crash gets
+# an automatic restart (#523).
+
+set -uo pipefail
+
+# ── Defaults matching the observed 2026-07-30 recipe ─────────────
+ALIAS=""
+NODE_HOME="/home/vansin/opencode-node"
+SUPPORT_HOME="/home/vansin/opencode-support"
+DEBUG=0
+# --preflight-only: run preflight and exit 0 WITHOUT spawning agent-node.
+# 🔴 Motivation: attempting to sed the exec line out at runtime for a
+# "dry check" is fragile — the script has two exec branches (--debug
+# on/off), and a sed that only patched the first branch let the second
+# branch spawn a rogue duplicate opencode-测试1号 in a live prod hub
+# (2026-07-30 near-miss; contained by precise-pid kill). Use this flag
+# for any verification that shouldn't actually launch a node.
+PREFLIGHT_ONLY=0
+
+# ── Argv parse ───────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --alias)          ALIAS="$2"; shift 2 ;;
+    --node-home)      NODE_HOME="$2"; shift 2 ;;
+    --support)        SUPPORT_HOME="$2"; shift 2 ;;
+    --debug)          DEBUG=1; shift 1 ;;
+    --preflight-only) PREFLIGHT_ONLY=1; shift 1 ;;
+    -h|--help)
+      grep '^# ' "$0" | sed 's/^# //'
+      exit 0
+      ;;
+    *)
+      echo "::error::unknown argument: $1"
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$ALIAS" ]; then
+  echo "::error::--alias is required (e.g. --alias opencode测试1号)"
+  exit 2
+fi
+
+# ── Derived paths ────────────────────────────────────────────────
+SUPPORT_MODULES="$SUPPORT_HOME/node_modules"
+CONFIG_PATH="$NODE_HOME/.anet/nodes/$ALIAS/config.json"
+AGENT_NODE_BIN="$NODE_HOME/node_modules/.bin/agent-node"
+
+# ── Preflight — each check on its own ✗ line (#526 pattern) ─────
+missing=0
+say_ok() { echo "  ✓ preflight: $*"; }
+say_bad() { echo "  ✗ preflight: $*"; missing=$((missing+1)); }
+
+echo "── preflight: opencode-node-start (alias=$ALIAS) ──"
+
+# 1. cwd — must be an opencode-node install with its own node_modules.
+if [ ! -d "$NODE_HOME" ]; then
+  say_bad "NODE_HOME does not exist: $NODE_HOME"
+elif [ ! -d "$NODE_HOME/node_modules" ]; then
+  say_bad "NODE_HOME has no node_modules — did you 'npm install' in $NODE_HOME?"
+else
+  say_ok "NODE_HOME present with node_modules ($NODE_HOME)"
+fi
+
+# 2. SUPPORT — must contain opencode-ai (provides opencode.exe on PATH).
+if [ ! -d "$SUPPORT_MODULES" ]; then
+  say_bad "SUPPORT node_modules missing: $SUPPORT_MODULES"
+elif [ ! -x "$SUPPORT_MODULES/.bin/opencode" ] && [ ! -x "$SUPPORT_MODULES/opencode-ai/bin/opencode.exe" ]; then
+  say_bad "opencode binary not found in $SUPPORT_MODULES (need opencode-ai)"
+else
+  # Report whichever we found so the log makes clear which path the
+  # runtime will actually use.
+  found=""
+  [ -x "$SUPPORT_MODULES/.bin/opencode" ] && found="$SUPPORT_MODULES/.bin/opencode"
+  [ -z "$found" ] && found="$SUPPORT_MODULES/opencode-ai/bin/opencode.exe"
+  say_ok "opencode binary present ($found)"
+fi
+
+# 2b. 🔴 NEGATIVE assertion — opencode-ai MUST NOT be installed INSIDE
+# NODE_HOME. agent-node has a supply-chain guard that refuses to
+# start when opencode-ai resolves inside the node's workDir
+# ("resolved opencode-ai package overlaps forbidden root"). The
+# recipe requires opencode-ai to live in SUPPORT_HOME (external),
+# not inside NODE_HOME/node_modules. This is counter-intuitive —
+# a well-meaning `npm i opencode-ai` inside the project would
+# break the node with an opaque runtime error. Fail-closed here
+# with a preflight message that tells the reader exactly what to
+# do about it. — 通信龙 empirical, 2026-07-30 middag lunch case.
+if [ -e "$NODE_HOME/node_modules/opencode-ai" ]; then
+  say_bad "opencode-ai is installed INSIDE the node workDir ($NODE_HOME/node_modules/opencode-ai) — agent-node's supply-chain guard will refuse to start with 'overlaps forbidden root'. Move it to \$SUPPORT_HOME/node_modules and set NODE_PATH to point there (this script does that automatically once opencode-ai is in the right place)."
+else
+  say_ok "no opencode-ai leak in workDir (workDir supply-chain guard ok)"
+fi
+
+# 3. Node config file must exist and be valid JSON with matching alias.
+if [ ! -f "$CONFIG_PATH" ]; then
+  say_bad "node config missing: $CONFIG_PATH — did you 'anet node create $ALIAS'?"
+else
+  cfg_alias=$(python3 -c "import json,sys;print(json.load(open('$CONFIG_PATH')).get('alias',''))" 2>/dev/null || echo "")
+  if [ "$cfg_alias" != "$ALIAS" ]; then
+    say_bad "node config alias mismatch: file says '$cfg_alias', argv says '$ALIAS'"
+  else
+    say_ok "node config present + alias matches ($CONFIG_PATH)"
+  fi
+fi
+
+# 3b. 🔴 NODE workDir + config.json owner+mode gates.
+#
+# agent-node's OpenCode state module has TWO paired supply-chain
+# guards. Both refuse to bind unless owner=current-uid AND the
+# specified mode. Silent restart-loop otherwise (empirically it
+# looks like the agent starts and pm2 immediately restarts, over
+# and over — the stderr reveals the real cause):
+#
+#   ERR 1: [agent-node] Refusing unsafe OpenCode config: OpenCode
+#          state refuses node workDir at <dir>: owner/mode must be
+#          current uid/0700
+#   ERR 2: [agent-node] Refusing unsafe OpenCode config: OpenCode
+#          state refuses config.json at <file>: owner/mode must be
+#          current uid/0600
+#
+# Discovered 2026-07-30 empirically — cat/mkdir with default umask
+# (usually 022→755/644 or 002→775/664) both flunk the guards.
+# `anet node create` gets this right; hand-creating a node misses.
+# Fail-closed here with explicit remediation. Both guards.
+NODE_DIR="$NODE_HOME/.anet/nodes/$ALIAS"
+self_uid=$(id -u)
+if [ -d "$NODE_DIR" ]; then
+  dir_owner=$(stat -c '%u' "$NODE_DIR" 2>/dev/null || echo "?")
+  dir_mode=$(stat -c '%a' "$NODE_DIR" 2>/dev/null || echo "?")
+  if [ "$dir_owner" != "$self_uid" ]; then
+    say_bad "node workDir owner mismatch: uid=$dir_owner, expected uid=$self_uid — run 'chown $self_uid $NODE_DIR'"
+  elif [ "$dir_mode" != "700" ]; then
+    say_bad "node workDir mode is $dir_mode, expected 0700 — run 'chmod 0700 $NODE_DIR' (agent-node OpenCode guard rejects otherwise)"
+  else
+    say_ok "node workDir owner+mode ok (uid=$self_uid, mode=0700)"
+  fi
+fi
+# 3c. config.json owner+mode gate (paired with 3b).
+if [ -f "$CONFIG_PATH" ]; then
+  cfg_owner=$(stat -c '%u' "$CONFIG_PATH" 2>/dev/null || echo "?")
+  cfg_mode=$(stat -c '%a' "$CONFIG_PATH" 2>/dev/null || echo "?")
+  if [ "$cfg_owner" != "$self_uid" ]; then
+    say_bad "config.json owner mismatch: uid=$cfg_owner, expected uid=$self_uid — run 'chown $self_uid $CONFIG_PATH'"
+  elif [ "$cfg_mode" != "600" ]; then
+    say_bad "config.json mode is $cfg_mode, expected 0600 — run 'chmod 0600 $CONFIG_PATH' (agent-node OpenCode guard rejects otherwise)"
+  else
+    say_ok "config.json owner+mode ok (uid=$self_uid, mode=0600)"
+  fi
+fi
+
+# 4. agent-node binary — must be executable.
+if [ ! -x "$AGENT_NODE_BIN" ]; then
+  say_bad "agent-node binary missing/not-executable: $AGENT_NODE_BIN"
+else
+  say_ok "agent-node binary present ($AGENT_NODE_BIN)"
+fi
+
+# 5. Node.js — pm2 fleet runs on nvm node v20; verify a `node` is on
+# PATH regardless. The exec at the bottom of this script will use
+# whatever `node` resolves to when pm2 calls us, and pm2's own PATH
+# is not our concern here.
+if ! command -v node >/dev/null 2>&1; then
+  say_bad "node not on PATH (pm2's PATH must include a node binary)"
+else
+  say_ok "node present ($(command -v node), version $(node --version))"
+fi
+
+# 6. Env pollution — the recipe explicitly unsets COMMHUB_ALIAS /
+# COMMHUB_TOKEN before spawning agent-node so a parent shell's env
+# doesn't leak into the child (would cause identity mismatch on the
+# hub if the parent had a different node's creds). Verify they're
+# either unset or we'll unset them. We do NOT fail on presence —
+# unset happens below — but we DO surface it in the log.
+if [ -n "${COMMHUB_ALIAS:-}" ] || [ -n "${COMMHUB_TOKEN:-}" ]; then
+  say_ok "env pollution present (COMMHUB_ALIAS='${COMMHUB_ALIAS:-}' / COMMHUB_TOKEN=<len ${#COMMHUB_TOKEN}>) — will unset before spawn"
+else
+  say_ok "env clean (no COMMHUB_ALIAS / COMMHUB_TOKEN in parent env)"
+fi
+
+if [ "$missing" -gt 0 ]; then
+  echo "::error::preflight failed with $missing missing prerequisite(s) — see ✗ lines above."
+  exit 1
+fi
+
+# ── --preflight-only: stop here, do NOT spawn agent-node ─────────
+if [ "$PREFLIGHT_ONLY" -eq 1 ]; then
+  echo "── preflight-only mode: not launching agent-node ──"
+  exit 0
+fi
+
+# ── Launch agent-node in-place (exec, no background) ─────────────
+echo "── preflight ok · launching agent-node (foreground for pm2) ──"
+cd "$NODE_HOME" || { echo "::error::chdir to $NODE_HOME failed"; exit 1; }
+export NODE_PATH="$SUPPORT_MODULES"
+export PATH="$SUPPORT_MODULES/.bin:$NODE_HOME/node_modules/.bin:$PATH"
+
+# 🔴 Clear ALL COMMHUB_* env vars by pattern, not by enumeration.
+# Motivation (2026-07-30 opencode #521/#523 near-miss): the previous
+# `unset COMMHUB_ALIAS COMMHUB_TOKEN` was enumerated, missed
+# COMMHUB_NODE_ID + COMMHUB_RESUME_ID that had polluted the caller's
+# shell, and agent-node's cli.ts:600 (`process.env.COMMHUB_NODE_ID
+# || fileConfig.node_id`) let the stale env override the node's own
+# config. Result: canonical-alias fetch by nodeId hit the offline
+# 2号 audit row → alias_identity_mismatch crash-loop.
+# Pattern-clear catches every current AND future COMMHUB_* variable.
+# Enumeration always misses something eventually.
+# — 通信龙 empirical fix, 2026-07-30 late night.
+for _oc_env_var in $(env | sed -n 's/^\(COMMHUB_[A-Za-z0-9_]*\)=.*/\1/p'); do
+  unset "$_oc_env_var"
+done
+unset _oc_env_var
+
+# `exec` — this process becomes agent-node. pm2 tracks THIS pid. No
+# backgrounding, no nohup, no `&`. If agent-node dies, pm2 sees the
+# exit code and applies its restart policy.
+if [ "$DEBUG" -eq 1 ]; then
+  exec "$AGENT_NODE_BIN" --config "$CONFIG_PATH" --log-level debug
+else
+  # Default level — see file header re: #522.
+  exec "$AGENT_NODE_BIN" --config "$CONFIG_PATH"
+fi

--- a/agent-network/scripts/pm2-opencode.config.cjs
+++ b/agent-network/scripts/pm2-opencode.config.cjs
@@ -1,0 +1,116 @@
+// #521 + #523 — pm2 ecosystem config for opencode agent-node processes.
+//
+// Why a .config.js file (not inline `pm2 start` args):
+//   - Config in-tree can be reviewed / diffed / evolved without ssh
+//     into the host to inspect `pm2 dump.pm2`.
+//   - `pm2 save` writes the same values to `~/.pm2/dump.pm2` for
+//     resurrect at boot, but that dump is generated state, not
+//     source-of-truth.
+//
+// Why `.config.js` and NOT `.cjs`:
+//   - pm2 does not recognise `.cjs` for ecosystem configs (silent
+//     "no processes started"). `*.config.js` is required.
+//     — 通信龙 empirical, 2026-07-30.
+//
+// Restart policy notes (also 通信龙 empirical):
+//   - min_uptime must be > any sleep the app does on a crash-restart
+//     otherwise the crash-loop counter can't tell "keeps crashing"
+//     apart from "took a while to boot".
+//   - exp_backoff_restart_delay: when set, pm2 never enters the
+//     `errored` state, which means `max_restarts` is silently
+//     ignored (process just backs off forever). We DO NOT set it —
+//     we want the errored state so downstream alerting (or our own
+//     eyes) can notice a real dead node instead of it hiding behind
+//     escalating backoff.
+//
+// Add a second node by copying the object literal + changing the
+// `name` and the `--alias` in `args`. Do NOT reuse a name — pm2
+// treats name as the primary key.
+//
+// 🔴 `script` points at ~/.local/bin/, NOT at this repo. Any pm2 /
+// systemd / cron reference to a git worktree or repo working tree
+// is a booby trap: when the worktree is cleaned (branch merged,
+// `git worktree prune`, /tmp cleanup, whatever), the daemon's
+// script disappears and pm2 fails silently at the next restart
+// (the pm2 list still shows the app so it looks fine — that's
+// exactly the story of #523 which this PR is meant to fix).
+//
+// The sibling neighbors (hub-daemon.sh, dash-start.sh) all live in
+// ~/.local/bin/ for the same reason. When you edit the source of
+// truth in this file's directory (agent-network/scripts/) you MUST
+// also `cp` it over to ~/.local/bin/opencode-node-start.sh — see
+// README.md in this directory for the install/upgrade steps.
+//
+// Do NOT symlink ~/.local/bin/opencode-node-start.sh back to the
+// repo — a symlink target disappearing is even less visible than
+// an absolute path pointing at nothing.
+
+module.exports = {
+  apps: [
+    {
+      name: 'opencode-node-测试1号',
+      script: '/home/vansin/.local/bin/opencode-node-start.sh',
+      // NB: pm2 argv strings are passed as separate tokens. Do NOT
+      // quote the alias here — pm2 already handles quoting.
+      args: ['--alias', 'opencode测试1号'],
+
+      // The script `exec`s into agent-node, so pm2 sees agent-node's
+      // pid as the tracked pid. Fork mode (default) is right for a
+      // single-instance long-running process.
+      exec_mode: 'fork',
+      instances: 1,
+
+      // Restart policy — see file header for rationale.
+      autorestart: true,
+      max_restarts: 10,
+      // 30 s: agent-node's boot path (hub reachability + config
+      // validation + acp handshake) is typically well under 10 s.
+      // A crash after 30 s stops counting toward the 10-restart
+      // cap; a crash before that increments it. Anything below 10 s
+      // would risk normal slow-boot on a busy host being counted as
+      // a crash-loop.
+      min_uptime: '30s',
+      // Explicit: do NOT set exp_backoff_restart_delay. See header.
+      // restart_delay is the fixed pause between restart attempts,
+      // separate from backoff. 5 s gives the OS a beat to reap the
+      // dead process and release its file descriptors (hub SSE
+      // reconnect, node-modules file locks).
+      restart_delay: 5000,
+
+      // Logs — pm2 tails these; we also keep them separate from
+      // stdout mixing so `pm2 logs opencode-node-测试1号 --err` is
+      // useful when a real crash happens.
+      out_file: '/home/vansin/.pm2/logs/opencode-node-测试1号-out.log',
+      error_file: '/home/vansin/.pm2/logs/opencode-node-测试1号-err.log',
+      merge_logs: true,
+      time: true,
+
+      // 🔴 Env — DO NOT leave this an empty object `{}`. pm2's
+      // daemon is likely started with COMMHUB_* env in its own
+      // shell (in this fleet: `COMMHUB_ALIAS=微信马` + a stale
+      // COMMHUB_TOKEN belonging to the daemon's own bootstrap
+      // shell). `env: {}` means "don't override anything", so
+      // those daemon-inherited COMMHUB_* variables would flow
+      // straight into agent-node.
+      //
+      // The script (opencode-node-start.sh) does clear ALL
+      // COMMHUB_* by pattern before the exec, so this defense is
+      // strictly a belt on the suspenders — but the two layers
+      // together are the fix. If someone edits the script later
+      // and weakens the pattern-clear, this ecosystem env at
+      // least still overrides the specific poison variables the
+      // daemon carries. — 通信龙 2026-07-30.
+      //
+      // Empty string forces override to "empty" (which the script
+      // then also `unset`s pattern-wide). We don't set them to a
+      // real value here because the node's identity lives entirely
+      // in its config.json (alias / token / network_id).
+      env: {
+        COMMHUB_ALIAS: '',
+        COMMHUB_TOKEN: '',
+        COMMHUB_NODE_ID: '',
+        COMMHUB_RESUME_ID: '',
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Closes #521, closes #523. Related: #532.

The opencode agent-node ran under a one-shot `nohup` for the last few months — no supervision (a crash left it dead until someone noticed), and the launch recipe existed only in one operator's shell history. This PR turns it into a submittable script under pm2.

## What ships

`agent-network/scripts/`:

- **`opencode-node-start.sh`** — launch recipe. Preflight-then-`exec` so pm2 tracks agent-node's own pid (no `nohup`, no `&`).
- **`pm2-opencode.config.cjs`** — pm2 ecosystem. `.config.cjs` because `agent-network/package.json` is `"type":"module"` and `.config.js` in an ESM package flips it to ESM (pm2 needs CommonJS). `.config.cjs` is explicitly recognised via pm2's `Common.js:283 isConfigFile` substring match on `.config.`.
- **`README.md`** — install/upgrade steps, test flow, preflight assertions, env-defense rationale.

## Runtime copy lives at `~/.local/bin/`, NOT in the repo

pm2 references `/home/vansin/.local/bin/opencode-node-start.sh` per the sibling daemon convention (`hub-daemon.sh`, `dash-start.sh`, `pm2-fleet-boot.sh` all live there).

Any pm2/systemd/cron path that points inside a git worktree becomes a booby trap on merge/clean — the daemon fails silently on next restart, `pm2 list` still shows the app so it looks fine, and only a real reboot exposes it. Same lesson as #526.

Install step is **`cp`** (not `ln`). README documents "when you edit the source of truth here, `cp` it again". Symlink-back-to-worktree is even less visible than absolute-path-to-nowhere.

## Preflight — 7 assertions on their own ✗ lines

Three of them are 🔴 supply-chain guards **discovered empirically while doing this PR** (agent-node fail-closed at spawn; without preflight, the failure is a 5s restart loop with a cryptic stderr and no clue what's wrong):

1. opencode-ai must NOT be in `NODE_HOME/node_modules` (workDir supply-chain guard)
2. Node workDir `owner=uid, mode=0700` (state module guard)
3. `config.json` `owner=uid, mode=0600` (paired guard)

`mkdir -p` and `cat >file` use default umask (755/644) — **both fail** guards 2+3. `anet node create` gets this right; hand-creating a node misses. Only path to catch this before spawn is preflight.

## Two-layer env defense (both required)

`agent-network/bin/cli.ts:600` reads `COMMHUB_NODE_ID` from env *before* `config.json`:

```ts
const NODE_ID = process.env.COMMHUB_NODE_ID || fileConfig.node_id || "";
```

A polluted shell overrides node identity that way. **#532 covers the underlying agent-node bug** — canonical-alias reverse lookup by node_id doesn't filter lifecycle status, so a deleted node's offline audit row can override an unrelated node's alias. **This PR is the client-side defense; #532 is the product-side fix.**

Layer 1 — ecosystem `env: { COMMHUB_*: '' }`: explicit override of anything pm2 daemon inherited from its bootstrap shell. `env: {}` is **not** enough; that means "no override", so daemon env transparently reaches every managed app.

Layer 2 — script `for/unset $(env | grep ^COMMHUB_)`: pattern-clears any `COMMHUB_*` inside the script, catching variables the ecosystem name-list missed. Enumeration always misses eventually.

**Both layers required.** Verified empirically: a witnessed-red run in a shell polluted with `COMMHUB_ALIAS=通信demo马`, `COMMHUB_NODE_ID=n_82535e5b`, `COMMHUB_RESUME_ID=cc-n_82535e5b` produced `/proc/<child pid>/environ` `COMMHUB_*` count = **0** in the spawned agent-node. If either layer were removed the environ would carry the poison through.

## Test flow — verified on production 1号 (with fallback ready)

Every step ran on the actual `opencode测试1号` node (the same alias in production), with 通信龙's rollback script `/home/vansin/.commhub/opencode-1号-rollback.sh` on hand:

| # | Step | Evidence |
|---|---|---|
| 1 | Config parse via `node -e require(...)` | 0 side-effect, correct shape |
| 2 | `--preflight-only` mode | 7/7 assertions ok |
| 3 | `kill -TERM` old nohup pid | ppid/cmdline verified before, clean exit |
| 4 | `pm2 start pm2-opencode.config.cjs` | up in 12s, status=online |
| 5 | Four-layer check (active-only) | L1=1 L2 active=1 L3=1 L4 active-only=1 |
| 6 | PONG from CommHub (routing) | 7s reply |
| 7 | `kill -9 <pid>` on production 1号 | pm2 restarted within 5s, new pid, restart_time++ |
| 8 | `/proc/<new-pid>/environ` COMMHUB_* count | **0** — restart path also clean |
| 9 | PONG again after restart | 9s reply |
| 10 | `pm2 save` | dump.pm2 gained opencode-node-测试1号; no other process definition dropped |

## What was NOT verified (documented honestly)

**Boot-time resurrect via `~/.config/systemd/user/pm2-fleet.service`.** Only a real machine reboot proves it; we don't reboot the production host to test. Same standard the sibling hub/dashboard boot-persist is documented under (they also currently list boot-persist as "未验证"). The systemd unit reads `pm2 resurrect` which reads `dump.pm2`, and `dump.pm2` now includes opencode with the correct script path + env — so the mechanism is in place, but "in place" is not "verified reboot survives".

## Related

- [#521](https://github.com/sleep2agi/agent-network/issues/521) — startup recipe scripted
- [#523](https://github.com/sleep2agi/agent-network/issues/523) — pm2 supervision + auto-restart
- [#532](https://github.com/sleep2agi/agent-network/issues/532) — canonical-alias reverse-lookup bug (identified while doing this PR; 通信龙 立项)
- [#526](https://github.com/sleep2agi/agent-network/issues/526) — same "daemon paths in worktrees" lesson applied here

## Attribution

Author: 通信demo马
Reviewer / dispatch: 通信龙 (independent verification at every gate + `#532` root-cause read + rollback script prep)