### PR TITLE
test(grok-tui): reject stale saved-report provenance

### DIFF
--- a/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
+++ b/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
@@ -48,9 +48,14 @@ Committed report hashes:
   60af8b022187177504393c8b0d45cce8d617b65a0c9c0f30c1754981430a50c2  report-test224.txt
   f8108d0dc0c0d0afd519c782d81c5e3f3edd948204c7c298954f3cb7da9a67bb  report-test225.txt
 
-The test225 source-commit file contains the literal Git export-subst marker
-`$Format:%H$`; this is valid for an archive boundary but does not repair the
-three stale committed reports.
+The candidate's test225 source-commit file contains the Git export-subst marker
+`$Format:%H$`. The final gate consumes a minimal `git archive`, where Git
+expands that marker to the actual archived commit:
+
+  4854928b35c14abaaae788aba7ec043cea10643b
+
+This independently binds the copied reports to the candidate source boundary,
+but does not repair the three stale committed reports.
 
 Root-cause classification
 -------------------------
@@ -83,23 +88,22 @@ relabeled or overwritten. This verdict concerns evidence provenance; it does
 not claim that the later runtime implementation itself is functionally broken.
 
 The reusable hard-precondition gate is recorded in
-`tests/test537-grok-tui-provenance/`. Its shell was syntax-checked. Its
-Dockerfile was deliberately not built under the capacity condition below.
+`tests/test537-grok-tui-provenance/`. It rejects dirty worktrees, derives the
+full SHA from candidate HEAD, creates a minimal `git archive`, and requires
+both the expanded archive marker and all three reports to equal that SHA.
 
 Witnessed-red execution
 -----------------------
-The runner was also executed once in a disposable, read-only, network-disabled
-container with the candidate and reporting worktrees mounted read-only:
+The final wrapper built a fixed-tag gate image from the minimal candidate
+archive, then ran it in a disposable, read-only, network-disabled container:
 
-  image: node:22.13.1-bookworm-slim
+  image tag: anet-test537-grok-tui-provenance:dev
+  image id: sha256:e936799f72480ded6c9bd292a4e43e4a0937df3b6bee0797b14412dcff2e6da6
   container controls:
     --rm --read-only --network none --cap-drop ALL
     --security-opt no-new-privileges
 
-The base image was not cached and Docker pulled it before the run. No custom
-image was built, and the disposable container was removed after execution.
-
-Observed runner output:
+Actual-candidate run, expected SHA derived from its clean HEAD:
 
   FAIL test219 source_commit=501764f83c0428ebc153d132ae049de38d7041f6
        expected=4854928b35c14abaaae788aba7ec043cea10643b
@@ -107,17 +111,35 @@ Observed runner output:
        expected=4854928b35c14abaaae788aba7ec043cea10643b
   FAIL test225 source_commit=501764f83c0428ebc153d132ae049de38d7041f6
        expected=4854928b35c14abaaae788aba7ec043cea10643b
-  PASS test225 archive marker is an unexpanded Git export-subst marker
+  PASS candidate archive source_commit=4854928b35c14abaaae788aba7ec043cea10643b
   RESULT: FAIL — exact-candidate provenance is not established
 
-The runner returned rc=1 as required for the stale-report condition. The
-outer assertion accepted only rc=1 and returned rc=0, proving that the gate
-is witnessed-red rather than merely described.
+Observed rc=1, as required for the stale-report condition.
+
+Environment-only bypass mutation:
+
+  EXPECTED_SOURCE_COMMIT=501764f83c0428ebc153d132ae049de38d7041f6
+  PASS test219/test224/test225 report source_commit
+  FAIL candidate archive source_commit=4854928b... expected=501764f8...
+  RESULT: FAIL
+
+Observed rc=1. This proves that changing only the expected environment value
+cannot make reports from a different candidate archive pass.
+
+Controlled positive:
+
+  Starting from the same exact candidate archive, temporary report copies were
+  changed to declare 4854928b...; no repository report was edited. All three
+  report checks and the independently expanded archive marker passed.
+
+Observed rc=0. This is evidence for gate behavior only, not evidence that
+test219/test224/test225 actually passed on the candidate.
 
 Host capacity note
 ------------------
-Before the Docker run, `/` had 9.6 GiB available and was 97% used. No Docker
-build was started, both because the provenance gate already failed and because
-the host was above the agreed capacity warning threshold. After the one-shot
-run and concurrent host activity, `/` reported 13 GiB available and 96% used;
-that increase is not attributed to this test.
+Before the first one-shot Docker run, `/` had 9.6 GiB available and was 97%
+used. That run pulled the previously uncached official
+`node:22.13.1-bookworm-slim` base image but built no custom image. After
+concurrent host cleanup, `/` reported 13 GiB available and 96% used. Only then
+was the small fixed-tag gate image built and exercised; no rotating SHA tag or
+broad cleanup was used.

--- a/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
+++ b/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
@@ -73,6 +73,32 @@ the candidate advanced. There are exactly 62 commits from the reported
 insertions and 504 deletions, including runtime containment, credentials,
 recovery, lifecycle, and the test gates themselves.
 
+Published-preview usability control
+-----------------------------------
+The currently published preview packages were fetched without installing them
+on the host:
+
+  @sleep2agi/agent-network@2.3.0-preview.36
+    tarball sha256=c290941939c0c3744c0e7bab0bc5417220e9b60a237798a0f03fdd18385f8026
+  @sleep2agi/agent-node@2.5.0-preview.27
+    tarball sha256=f07e2f7678ea404256247c3c27d8a531bb16546e743ac2b8162a055c858a51e1
+
+An extracted-payload scan found zero files containing `grok-build-cli`,
+`anet grok attach`, or the Grok co-presence capability marker.
+
+Both exact packages were then installed together in a disposable clean
+`node:22.13.1-bookworm-slim` container. The real entrypoints reported:
+
+  anet v2.3.0-preview.36
+  agent-node v2.5.0-preview.27
+  anet help Grok TUI marker count: 0
+  agent-node help Grok TUI marker count: 0
+
+The agent-node runtime list contains `grok-build-acp` only; it does not contain
+`grok-build-cli`. Therefore the currently published preview channel does not
+provide the shared Grok TUI runtime. This is a user-path control, not an
+inference from version numbers.
+
 Verdict
 -------
 FAIL.
@@ -86,6 +112,9 @@ Per the approved #537 protocol, downstream Docker suites 219, 224, and 225
 were not run after this hard precondition failed. The reports were not
 relabeled or overwritten. This verdict concerns evidence provenance; it does
 not claim that the later runtime implementation itself is functionally broken.
+It also does not claim that Grok TUI is currently installable: the published
+preview control above proves that it is not present in the current preview
+packages.
 
 The reusable hard-precondition gate is recorded in
 `tests/test537-grok-tui-provenance/`. It rejects dirty worktrees, derives the

--- a/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
+++ b/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
@@ -83,11 +83,41 @@ relabeled or overwritten. This verdict concerns evidence provenance; it does
 not claim that the later runtime implementation itself is functionally broken.
 
 The reusable hard-precondition gate is recorded in
-`tests/test537-grok-tui-provenance/`. Its shell was syntax-checked, but its
-Docker image was deliberately not built under the capacity condition below.
+`tests/test537-grok-tui-provenance/`. Its shell was syntax-checked. Its
+Dockerfile was deliberately not built under the capacity condition below.
+
+Witnessed-red execution
+-----------------------
+The runner was also executed once in a disposable, read-only, network-disabled
+container with the candidate and reporting worktrees mounted read-only:
+
+  image: node:22.13.1-bookworm-slim
+  container controls:
+    --rm --read-only --network none --cap-drop ALL
+    --security-opt no-new-privileges
+
+The base image was not cached and Docker pulled it before the run. No custom
+image was built, and the disposable container was removed after execution.
+
+Observed runner output:
+
+  FAIL test219 source_commit=501764f83c0428ebc153d132ae049de38d7041f6
+       expected=4854928b35c14abaaae788aba7ec043cea10643b
+  FAIL test224 source_commit=501764f83c0428ebc153d132ae049de38d7041f6
+       expected=4854928b35c14abaaae788aba7ec043cea10643b
+  FAIL test225 source_commit=501764f83c0428ebc153d132ae049de38d7041f6
+       expected=4854928b35c14abaaae788aba7ec043cea10643b
+  PASS test225 archive marker is an unexpanded Git export-subst marker
+  RESULT: FAIL — exact-candidate provenance is not established
+
+The runner returned rc=1 as required for the stale-report condition. The
+outer assertion accepted only rc=1 and returned rc=0, proving that the gate
+is witnessed-red rather than merely described.
 
 Host capacity note
 ------------------
-Before any Docker work, `/` had 9.6 GiB available and was 97% used. No Docker
+Before the Docker run, `/` had 9.6 GiB available and was 97% used. No Docker
 build was started, both because the provenance gate already failed and because
-the host was above the agreed capacity warning threshold.
+the host was above the agreed capacity warning threshold. After the one-shot
+run and concurrent host activity, `/` reported 13 GiB available and 96% used;
+that increase is not attributed to this test.

--- a/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
+++ b/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
@@ -148,7 +148,9 @@ The final wrapper built a fixed-tag gate image from the minimal candidate
 archive, then ran it in a disposable, read-only, network-disabled container:
 
   image tag: anet-test537-grok-tui-provenance:dev
-  image id: sha256:e936799f72480ded6c9bd292a4e43e4a0937df3b6bee0797b14412dcff2e6da6
+  image id: sha256:e03f05564d2920452b926341dc7e05bf3b5028be00bec8603ec9b9cf131cefeb
+  image id source:
+    docker image inspect --format '{{.Id}}' anet-test537-grok-tui-provenance:dev
   container controls:
     --rm --read-only --network none --cap-drop ALL
     --security-opt no-new-privileges
@@ -165,6 +167,11 @@ Actual-candidate run, expected SHA derived from its clean HEAD:
   RESULT: FAIL — exact-candidate provenance is not established
 
 Observed rc=1, as required for the stale-report condition.
+The wrapper emitted
+`image_id=sha256:e03f05564d2920452b926341dc7e05bf3b5028be00bec8603ec9b9cf131cefeb`;
+an independent post-run `docker image inspect --format '{{.Id}}'` of the fixed
+tag returned the same value. The ID was therefore obtained from the built
+artifact rather than copied from a prior tag incarnation.
 
 Environment-only bypass mutation:
 

--- a/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
+++ b/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
@@ -52,6 +52,22 @@ The test225 source-commit file contains the literal Git export-subst marker
 `$Format:%H$`; this is valid for an archive boundary but does not repair the
 three stale committed reports.
 
+Root-cause classification
+-------------------------
+The gate generators already require a full SHA:
+
+- test219 reads `TEST219_SOURCE_COMMIT`.
+- test224 reads `TEST224_SOURCE_COMMIT`.
+- test225 reads `TEST225_SOURCE_COMMIT` and additionally compares it with the
+  archive-expanded source marker.
+
+Therefore this is not evidence that the generators silently accept an
+unbound run. It is evidence that the saved reports were not regenerated after
+the candidate advanced. There are exactly 62 commits from the reported
+`501764f8` state through `4854928b`; their diff changes 62 files with 16,587
+insertions and 504 deletions, including runtime containment, credentials,
+recovery, lifecycle, and the test gates themselves.
+
 Verdict
 -------
 FAIL.

--- a/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
+++ b/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
@@ -1,0 +1,77 @@
+Test: #537 Grok TUI exact-candidate clean-checkout provenance
+Date: 2026-07-31 (Asia/Shanghai)
+Issue: https://github.com/sleep2agi/agent-network/issues/537
+Finding comment:
+  https://github.com/sleep2agi/agent-network/issues/537#issuecomment-5139054614
+
+Scope
+-----
+Reporting base:
+  origin/main
+  71b3d8964f780d8e9503f52624d1a596e6fb4660
+
+Candidate under review:
+  origin/preview/grok-build-cli
+  4854928b35c14abaaae788aba7ec043cea10643b
+
+Clean-checkout evidence
+-----------------------
+Reporting worktree:
+  /home/vansin/commniu-wt-537
+  branch test/537-grok-tui-requalification
+  clean before report changes
+
+Candidate worktree:
+  /home/vansin/commniu-grok-candidate-537
+  detached at 4854928b35c14abaaae788aba7ec043cea10643b
+  git status --porcelain: empty
+
+The candidate worktree consumed 22 MiB. No existing /tmp/grok-* worktree,
+shared runtime source, production process, npm package, or Docker artifact was
+modified.
+
+Hard precondition
+-----------------
+Expected every saved report to bind to:
+  4854928b35c14abaaae788aba7ec043cea10643b
+
+Observed:
+  docs/tests/report-test219.txt:3
+    source_commit=501764f83c0428ebc153d132ae049de38d7041f6
+  docs/tests/report-test224.txt:4
+    source_commit=501764f83c0428ebc153d132ae049de38d7041f6
+  docs/tests/report-test225.txt:3
+    source_commit=501764f83c0428ebc153d132ae049de38d7041f6
+
+Committed report hashes:
+  cbfdf73e1a4cefa9155b191a3dd3e116d412c594eab3f7b66b3d8e77a0f19ded  report-test219.txt
+  60af8b022187177504393c8b0d45cce8d617b65a0c9c0f30c1754981430a50c2  report-test224.txt
+  f8108d0dc0c0d0afd519c782d81c5e3f3edd948204c7c298954f3cb7da9a67bb  report-test225.txt
+
+The test225 source-commit file contains the literal Git export-subst marker
+`$Format:%H$`; this is valid for an archive boundary but does not repair the
+three stale committed reports.
+
+Verdict
+-------
+FAIL.
+
+Exact candidate 4854928b35c14abaaae788aba7ec043cea10643b is not eligible
+to enter release closeout on the currently committed evidence. The existing
+green conclusions prove behavior only for
+501764f83c0428ebc153d132ae049de38d7041f6.
+
+Per the approved #537 protocol, downstream Docker suites 219, 224, and 225
+were not run after this hard precondition failed. The reports were not
+relabeled or overwritten. This verdict concerns evidence provenance; it does
+not claim that the later runtime implementation itself is functionally broken.
+
+The reusable hard-precondition gate is recorded in
+`tests/test537-grok-tui-provenance/`. Its shell was syntax-checked, but its
+Docker image was deliberately not built under the capacity condition below.
+
+Host capacity note
+------------------
+Before any Docker work, `/` had 9.6 GiB available and was 97% used. No Docker
+build was started, both because the provenance gate already failed and because
+the host was above the agreed capacity warning threshold.

--- a/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
+++ b/docs/tests/report-test537-grok-tui-exact-candidate-provenance.txt
@@ -99,6 +99,27 @@ The agent-node runtime list contains `grok-build-acp` only; it does not contain
 provide the shared Grok TUI runtime. This is a user-path control, not an
 inference from version numbers.
 
+Main-integration preflight
+--------------------------
+A read-only three-way merge preflight used:
+
+  main=71b3d8964f780d8e9503f52624d1a596e6fb4660
+  candidate=4854928b35c14abaaae788aba7ec043cea10643b
+  merge_base=4437ffb30737c333ffdd3b51281260103f5d2983
+
+The branches have 248 main-only commits and 84 candidate-only commits.
+`git merge-tree` reports 18 files changed on both sides; 17 contain a total of
+55 conflict blocks. The largest production hotspots are:
+
+  agent-network/bin/cli.ts: 27 conflict blocks
+  agent-node/src/cli.ts: 7 conflict blocks
+  agent-network/src/normalize-runtime.ts: 1 conflict block
+
+The remaining conflicts cover package manifests/lockfiles, runtime and deploy
+documentation, and RFC-030. This proves that delivery requires an explicit
+owner-led integration onto current main; treating the old preview branch as a
+merge-ready release candidate would be unsafe.
+
 Verdict
 -------
 FAIL.

--- a/tests/test537-grok-tui-provenance/Dockerfile
+++ b/tests/test537-grok-tui-provenance/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+FROM node:22.13.1-bookworm-slim
+
+WORKDIR /gate
+
+COPY tests/test537-grok-tui-provenance/run.sh /gate/run.sh
+COPY --from=candidate docs/tests/report-test219.txt /candidate/docs/tests/report-test219.txt
+COPY --from=candidate docs/tests/report-test224.txt /candidate/docs/tests/report-test224.txt
+COPY --from=candidate docs/tests/report-test225.txt /candidate/docs/tests/report-test225.txt
+COPY --from=candidate tests/test225-grok-preview-package-live/source-commit.txt /candidate/tests/test225-grok-preview-package-live/source-commit.txt
+
+ENTRYPOINT ["/gate/run.sh"]

--- a/tests/test537-grok-tui-provenance/README.md
+++ b/tests/test537-grok-tui-provenance/README.md
@@ -1,27 +1,27 @@
 # test537 — Grok TUI saved-report provenance
 
 This gate compares the source commit declared by saved Grok TUI reports with
-the exact candidate commit being reviewed. It must run before test219,
-test224, or test225; a mismatch is a hard stop, not an instruction to relabel
-old reports.
+the exact candidate commit being reviewed. It also requires the
+`git archive`-expanded source marker to equal that commit, so changing only
+`EXPECTED_SOURCE_COMMIT` cannot make a different checkout pass. It must run
+before test219, test224, or test225; a mismatch is a hard stop, not an
+instruction to relabel old reports.
 
-From the reporting worktree, build with the candidate clean checkout supplied
-as a read-only named context:
-
-```bash
-sg docker -c 'docker build \
-  --build-context candidate=/home/vansin/commniu-grok-candidate-537 \
-  -t anet-grok-tui-537:dev \
-  -f tests/test537-grok-tui-provenance/Dockerfile .'
-```
-
-Then run:
+From the reporting worktree, run the wrapper against a clean candidate
+worktree:
 
 ```bash
-sg docker -c 'docker run --rm \
-  -e EXPECTED_SOURCE_COMMIT=4854928b35c14abaaae788aba7ec043cea10643b \
-  anet-grok-tui-537:dev'
+tests/test537-grok-tui-provenance/run-docker.sh \
+  /home/vansin/commniu-grok-candidate-537
 ```
+
+The wrapper refuses a dirty worktree, derives the full expected SHA from its
+HEAD, creates a minimal temporary `git archive`, builds the fixed
+`anet-test537-grok-tui-provenance:dev` tag, and runs the gate in a read-only,
+network-disabled container. The archive expands test225's `$Format:%H$`
+marker, independently binding the copied reports to the candidate commit.
+Temporary extraction is restricted to a `mktemp` directory under `/tmp` and
+removed through the repository safe-delete guard.
 
 For issue #537 the expected result is exit code 1, because the three committed
 reports identify `501764f83c0428ebc153d132ae049de38d7041f6`.

--- a/tests/test537-grok-tui-provenance/README.md
+++ b/tests/test537-grok-tui-provenance/README.md
@@ -1,0 +1,27 @@
+# test537 — Grok TUI saved-report provenance
+
+This gate compares the source commit declared by saved Grok TUI reports with
+the exact candidate commit being reviewed. It must run before test219,
+test224, or test225; a mismatch is a hard stop, not an instruction to relabel
+old reports.
+
+From the reporting worktree, build with the candidate clean checkout supplied
+as a read-only named context:
+
+```bash
+sg docker -c 'docker build \
+  --build-context candidate=/home/vansin/commniu-grok-candidate-537 \
+  -t anet-grok-tui-537:dev \
+  -f tests/test537-grok-tui-provenance/Dockerfile .'
+```
+
+Then run:
+
+```bash
+sg docker -c 'docker run --rm \
+  -e EXPECTED_SOURCE_COMMIT=4854928b35c14abaaae788aba7ec043cea10643b \
+  anet-grok-tui-537:dev'
+```
+
+For issue #537 the expected result is exit code 1, because the three committed
+reports identify `501764f83c0428ebc153d132ae049de38d7041f6`.

--- a/tests/test537-grok-tui-provenance/README.md
+++ b/tests/test537-grok-tui-provenance/README.md
@@ -20,6 +20,10 @@ HEAD, creates a minimal temporary `git archive`, builds the fixed
 `anet-test537-grok-tui-provenance:dev` tag, and runs the gate in a read-only,
 network-disabled container. The archive expands test225's `$Format:%H$`
 marker, independently binding the copied reports to the candidate commit.
+Immediately after the build, the wrapper obtains the immutable image ID from
+the built artifact with `docker image inspect --format '{{.Id}}'` and prints
+both `image_tag` and `image_id`; saved evidence must copy that emitted value,
+not a remembered tag-to-digest mapping.
 Temporary extraction is restricted to a `mktemp` directory under `/tmp` and
 removed through the repository safe-delete guard.
 

--- a/tests/test537-grok-tui-provenance/run-docker.sh
+++ b/tests/test537-grok-tui-provenance/run-docker.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$REPO_ROOT/tests/lib/safe-rm.sh"
+
+candidate="${1:-}"
+if [[ -z "$candidate" ]]; then
+  echo "usage: $0 /absolute/path/to/clean-candidate-worktree" >&2
+  exit 2
+fi
+candidate="$(cd "$candidate" && pwd)"
+
+if [[ -n "$(git -C "$candidate" status --porcelain)" ]]; then
+  echo "FAIL: candidate worktree is dirty: $candidate" >&2
+  exit 2
+fi
+
+expected="$(git -C "$candidate" rev-parse --verify HEAD)"
+if [[ ! "$expected" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "FAIL: candidate HEAD is not a full commit SHA: $expected" >&2
+  exit 2
+fi
+
+archive_dir="$(mktemp -d /tmp/anet-test537-candidate.XXXXXX)"
+cleanup() {
+  safe_rm_rf "$archive_dir"
+}
+trap cleanup EXIT
+
+git -C "$candidate" archive --format=tar HEAD -- \
+  docs/tests/report-test219.txt \
+  docs/tests/report-test224.txt \
+  docs/tests/report-test225.txt \
+  tests/test225-grok-preview-package-live/source-commit.txt \
+  | tar -xf - -C "$archive_dir"
+
+echo "candidate_worktree=$candidate"
+echo "candidate_commit=$expected"
+df -h / | tail -n 1
+
+export TEST537_ARCHIVE_DIR="$archive_dir"
+export TEST537_EXPECTED="$expected"
+export TEST537_REPO_ROOT="$REPO_ROOT"
+
+sg docker -c 'docker build \
+  --build-context "candidate=$TEST537_ARCHIVE_DIR" \
+  -t anet-test537-grok-tui-provenance:dev \
+  -f "$TEST537_REPO_ROOT/tests/test537-grok-tui-provenance/Dockerfile" \
+  "$TEST537_REPO_ROOT"'
+
+sg docker -c 'docker run --rm \
+  --read-only \
+  --network none \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  -e "EXPECTED_SOURCE_COMMIT=$TEST537_EXPECTED" \
+  anet-test537-grok-tui-provenance:dev'

--- a/tests/test537-grok-tui-provenance/run-docker.sh
+++ b/tests/test537-grok-tui-provenance/run-docker.sh
@@ -43,12 +43,23 @@ df -h / | tail -n 1
 export TEST537_ARCHIVE_DIR="$archive_dir"
 export TEST537_EXPECTED="$expected"
 export TEST537_REPO_ROOT="$REPO_ROOT"
+export TEST537_IMAGE_TAG="anet-test537-grok-tui-provenance:dev"
 
 sg docker -c 'docker build \
   --build-context "candidate=$TEST537_ARCHIVE_DIR" \
-  -t anet-test537-grok-tui-provenance:dev \
+  -t "$TEST537_IMAGE_TAG" \
   -f "$TEST537_REPO_ROOT/tests/test537-grok-tui-provenance/Dockerfile" \
   "$TEST537_REPO_ROOT"'
+
+image_id="$(
+  sg docker -c 'docker image inspect --format "{{.Id}}" "$TEST537_IMAGE_TAG"'
+)"
+if [[ ! "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "FAIL: built image returned an invalid immutable id: $image_id" >&2
+  exit 2
+fi
+printf 'image_tag=%s\n' "$TEST537_IMAGE_TAG"
+printf 'image_id=%s\n' "$image_id"
 
 sg docker -c 'docker run --rm \
   --read-only \
@@ -56,4 +67,4 @@ sg docker -c 'docker run --rm \
   --cap-drop ALL \
   --security-opt no-new-privileges \
   -e "EXPECTED_SOURCE_COMMIT=$TEST537_EXPECTED" \
-  anet-test537-grok-tui-provenance:dev'
+  "$TEST537_IMAGE_TAG"'

--- a/tests/test537-grok-tui-provenance/run.sh
+++ b/tests/test537-grok-tui-provenance/run.sh
@@ -23,11 +23,11 @@ for test_id in 219 224 225; do
 done
 
 archive_marker="$(tr -d '\r\n' < /candidate/tests/test225-grok-preview-package-live/source-commit.txt)"
-if [ "$archive_marker" != '$Format:%H$' ] && [ "$archive_marker" != "$expected" ]; then
-  echo "FAIL: test225 archive marker=$archive_marker expected literal export marker or $expected"
+if [ "$archive_marker" != "$expected" ]; then
+  echo "FAIL: candidate archive source_commit=$archive_marker expected=$expected"
   failed=1
 else
-  echo "PASS: test225 archive marker is valid for a checkout/export boundary"
+  echo "PASS: candidate archive source_commit=$archive_marker"
 fi
 
 if [ "$failed" -ne 0 ]; then

--- a/tests/test537-grok-tui-provenance/run.sh
+++ b/tests/test537-grok-tui-provenance/run.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+expected="${EXPECTED_SOURCE_COMMIT:-}"
+if [ -z "$expected" ]; then
+  echo "FAIL: EXPECTED_SOURCE_COMMIT is required"
+  exit 2
+fi
+
+failed=0
+for test_id in 219 224 225; do
+  report="/candidate/docs/tests/report-test${test_id}.txt"
+  observed="$(sed -n 's/^source_commit=//p' "$report" | head -n 1)"
+  if [ -z "$observed" ]; then
+    echo "FAIL: test${test_id} has no source_commit"
+    failed=1
+  elif [ "$observed" != "$expected" ]; then
+    echo "FAIL: test${test_id} source_commit=$observed expected=$expected"
+    failed=1
+  else
+    echo "PASS: test${test_id} source_commit=$observed"
+  fi
+done
+
+archive_marker="$(tr -d '\r\n' < /candidate/tests/test225-grok-preview-package-live/source-commit.txt)"
+if [ "$archive_marker" != '$Format:%H$' ] && [ "$archive_marker" != "$expected" ]; then
+  echo "FAIL: test225 archive marker=$archive_marker expected literal export marker or $expected"
+  failed=1
+else
+  echo "PASS: test225 archive marker is valid for a checkout/export boundary"
+fi
+
+if [ "$failed" -ne 0 ]; then
+  echo "RESULT: FAIL — exact-candidate provenance is not established"
+  exit 1
+fi
+
+echo "RESULT: PASS — all saved reports bind to $expected"


### PR DESCRIPTION
Closes #537. Follow-up to #439.

This adds a reusable hard precondition that compares Grok TUI saved-report `source_commit` values with the exact candidate under review, plus the independent audit report for `origin/preview/grok-build-cli@4854928b35c14abaaae788aba7ec043cea10643b`.

The precondition fails: test219/224/225 all bind to `501764f83c0428ebc153d132ae049de38d7041f6`. The candidate advanced by exactly 62 commits (+16,587/-504 across 62 files), so the existing green results cannot qualify `4854928b` for release closeout. Per the approved protocol, downstream suites were not run and old evidence was not relabeled.

No runtime, CLI, attach, co-presence implementation, production state, existing Grok worktree, package, or deployment is changed. The Docker runner was not built because the host had only 9.6 GiB free (97% used); the report records this explicitly and the shell passed syntax validation.