### PR TITLE
docs(site): simplify the bilingual landing pages

### DIFF
--- a/docs-site/docs/en/index.md
+++ b/docs-site/docs/en/index.md
@@ -1,73 +1,35 @@
 ---
 layout: home
 title: Agent Network
-titleTemplate: Build your AI agent army
+titleTemplate: Turn AI agents into a team
 hero:
   name: Agent Network
-  text: Build your AI agent army
-  tagline: Orchestrate Claude · Codex · Grok with one command into a coordinated AI team you direct. 4 runtimes · any mainstream LLM · local-first · Apache 2.0 open source
+  text: Turn AI agents into a team
+  tagline: Connect Claude, Codex, and Grok on your own hardware so they can discover one another, delegate tasks, and work together.
   actions:
     - theme: brand
-      text: Get Started →
+      text: Get started
       link: /en/guide/getting-started
     - theme: alt
       text: GitHub
       link: https://github.com/sleep2agi/agent-network
 
 features:
+  - icon: 🔗
+    title: One network
+    details: Agents discover one another and exchange tasks through a shared Hub.
   - icon: 🖥️
-    title: Local-first
-    details: Hub, nodes, and data all run on your own hardware — single-file SQLite storage, no hosted service required.
-  - icon: 🤖
-    title: 4 runtimes · any mainstream LLM
-    details: Claude Code · Claude Agent SDK · Codex · Grok Build working side by side; any Anthropic-compatible endpoint (InternLM / MiniMax / Xiaomi MiMo / DeepSeek / GLM / Kimi / OpenRouter / Anthropic direct ...) plugs straight in.
-  - icon: 📖
-    title: Apache 2.0 open source
-    details: Fully open code, free for commercial use, issue-driven iteration — contributions welcome.
+    title: Local control
+    details: Services, nodes, and data stay on hardware you control.
+  - icon: 🧩
+    title: Mix and match
+    details: Combine Claude, Codex, Grok, and different models by role.
 ---
 
-<section class="trust-row">
-  <div class="trust-item"><span class="trust-num">∞</span><span class="trust-label">Multi-vendor · any Anthropic-compatible</span></div>
-  <div class="trust-item"><span class="trust-num">4</span><span class="trust-label">Runtimes</span></div>
-  <div class="trust-item"><span class="trust-num">100%</span><span class="trust-label">Local-First</span></div>
-  <div class="trust-item"><a href="/en/changelog"><span class="trust-num">Latest</span><span class="trust-label">npm stable</span></a></div>
-</section>
-
-## 30-second quickstart
-
-::: warning Install these two first, or step one crashes
-**Node.js ≥ 22.13.0** + **Bun ≥ 1.2.0**. `anet hub start` uses `bunx` under the hood to launch
-`commhub-server`; without Bun it fails immediately with `spawn bunx ENOENT`.
+## Install in one command
 
 ```bash
-npm i -g bun
-```
-:::
-
-```bash
-# Install one global package
-npm install -g @sleep2agi/agent-network
-
-# Terminal 1 — start the hub (keep open)
-anet hub start
-
-# Terminal 2 — start the dashboard (keep open)
-anet hub dashboard
-
-# Terminal 3 — log in, create + start an agent
-anet login --hub http://127.0.0.1:9200 --username admin --password anethub
-anet node create my-bot
-anet node start my-bot
+curl -fsSL https://anet.sh/install.sh | sh
 ```
 
-Open `http://localhost:3000` in your browser and dispatch tasks from the Chat panel. For the full walkthrough + one-shot installer, see the [Getting Started guide →](/en/guide/getting-started).
-
-<section class="final-cta">
-  <h2 class="final-cta-title">Install anet now</h2>
-  <p class="final-cta-sub">Run a Hub on one machine. Plug in your team and your models.</p>
-  <div class="final-cta-actions">
-    <a class="cta-primary" href="/en/guide/getting-started">Read the guide</a>
-    <a class="cta-ghost" href="/en/community">💬 Community</a>
-    <a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">★ Star on GitHub</a>
-  </div>
-</section>
+[Full setup guide →](/en/guide/getting-started) · [Production security →](/en/deploy/production)

--- a/docs-site/docs/en/index.md
+++ b/docs-site/docs/en/index.md
@@ -20,16 +20,16 @@ features:
     details: Agents discover one another and exchange tasks through a shared Hub.
   - icon: 🖥️
     title: Local control
-    details: Services, nodes, and data stay on hardware you control.
+    details: The Hub, Dashboard, and data run on hardware you control.
   - icon: 🧩
     title: Mix and match
     details: Combine Claude, Codex, Grok, and different models by role.
 ---
 
-## Install in one command
+## Install
 
 ```bash
-curl -fsSL https://anet.sh/install.sh | sh
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
 ```
 
-[Full setup guide →](/en/guide/getting-started) · [Production security →](/en/deploy/production)
+Requires Node.js ≥ 22.13. [Full setup guide →](/en/guide/getting-started) · [Production security →](/en/deploy/production)

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -1,73 +1,35 @@
 ---
 layout: home
 title: Agent Network
-titleTemplate: 助力搭建你的数字 AI 员工军团
+titleTemplate: 让 AI Agent 组成团队
 hero:
   name: Agent Network
-  text: 助力搭建你的数字 AI 员工军团
-  tagline: Claude · Codex · Grok 一行命令编入网协作 —— 任你指挥的 AI 团队。4 种 Runtime · 任意主流大模型 · 本地优先 · Apache 2.0 开源
+  text: 让 AI Agent 组成团队
+  tagline: 在自己的机器上连接 Claude、Codex 和 Grok，让它们发现彼此、互派任务、协同工作。
   actions:
     - theme: brand
-      text: 快速上手 →
+      text: 开始使用
       link: /guide/getting-started
     - theme: alt
       text: GitHub
       link: https://github.com/sleep2agi/agent-network
 
 features:
+  - icon: 🔗
+    title: 一个网络
+    details: 不同 Agent 通过同一个 Hub 发现彼此、收发任务。
   - icon: 🖥️
-    title: 本地优先
-    details: Hub、节点、数据全跑在你自己的硬件上，SQLite 单文件存储，不依赖任何托管服务。
-  - icon: 🤖
-    title: 4 种 Runtime · 任意主流大模型
-    details: Claude Code · Claude Agent SDK · Codex · Grok Build 同台协作；任意 Anthropic 兼容 API（书生 / MiniMax / 小米 MiMo / DeepSeek / GLM / Kimi / OpenRouter / Anthropic 直连 ...）即插即用。
-  - icon: 📖
-    title: Apache 2.0 开源
-    details: 代码全部开放，自由商用，issue 驱动迭代，欢迎共建。
+    title: 本地掌控
+    details: 服务、节点和数据都运行在你的机器上。
+  - icon: 🧩
+    title: 自由组合
+    details: 按角色混用 Claude、Codex、Grok 和不同模型。
 ---
 
-<section class="trust-row">
-  <div class="trust-item"><span class="trust-num">∞</span><span class="trust-label">多厂商接入 · 任意 Anthropic 兼容</span></div>
-  <div class="trust-item"><span class="trust-num">4</span><span class="trust-label">Runtime</span></div>
-  <div class="trust-item"><span class="trust-num">100%</span><span class="trust-label">本地优先</span></div>
-  <div class="trust-item"><a href="/changelog"><span class="trust-num">Latest</span><span class="trust-label">npm stable</span></a></div>
-</section>
-
-## 30 秒上手
-
-::: warning 先装这两个，否则第一步就崩
-**Node.js ≥ 22.13.0** + **Bun ≥ 1.2.0**。`anet hub start` 底层用 `bunx` 起 `commhub-server`，
-没装 Bun 会直接报 `spawn bunx ENOENT`。
+## 一行安装
 
 ```bash
-npm i -g bun
-```
-:::
-
-```bash
-# 装一个全局包
-npm install -g @sleep2agi/agent-network
-
-# 终端 1 —— 起 Hub（保持开着）
-anet hub start
-
-# 终端 2 —— 起 Dashboard（保持开着）
-anet hub dashboard
-
-# 终端 3 —— 登录 + 创节点 + 启动
-anet login --hub http://127.0.0.1:9200 --username admin --password anethub
-anet node create my-bot
-anet node start my-bot
+curl -fsSL https://anet.sh/install.sh | sh
 ```
 
-浏览器打开 `http://localhost:3000`，Chat 面板派任务。详细步骤 + 一键脚本路径见 [上手指南 →](/guide/getting-started)。
-
-<section class="final-cta">
-  <h2 class="final-cta-title">现在就装一个 anet</h2>
-  <p class="final-cta-sub">一台机器跑 Hub，把团队和模型都接上来。</p>
-  <div class="final-cta-actions">
-    <a class="cta-primary" href="/guide/getting-started">读上手指南</a>
-    <a class="cta-ghost" href="/community">💬 加入社群</a>
-    <a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">★ Star on GitHub</a>
-  </div>
-</section>
+[完整上手指南 →](/guide/getting-started) · [生产部署安全指南 →](/deploy/production)

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -20,16 +20,16 @@ features:
     details: 不同 Agent 通过同一个 Hub 发现彼此、收发任务。
   - icon: 🖥️
     title: 本地掌控
-    details: 服务、节点和数据都运行在你的机器上。
+    details: Hub、Dashboard 和数据运行在你控制的机器上。
   - icon: 🧩
     title: 自由组合
     details: 按角色混用 Claude、Codex、Grok 和不同模型。
 ---
 
-## 一行安装
+## 安装
 
 ```bash
-curl -fsSL https://anet.sh/install.sh | sh
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
 ```
 
-[完整上手指南 →](/guide/getting-started) · [生产部署安全指南 →](/deploy/production)
+需要 Node.js ≥ 22.13。[完整上手指南 →](/guide/getting-started) · [生产部署安全指南 →](/deploy/production)


### PR DESCRIPTION
## What changed

- reduce the Chinese and English anet.sh landing pages to one positioning statement, three capabilities, one explicit install command, and two next-step links
- remove repeated runtime/provider counts, trust-number blocks, repeated calls to action, and the long quick-start walkthrough
- replace the misleading `install.sh` one-liner with the complete stable install command (`bun`, `agent-network`, and `agent-node`) and state the Node.js requirement

## Why

The old landing pages repeated material already covered by the getting-started and production guides, and included specific counts that drift as runtimes and providers change. The published `install.sh` installs only the CLI, so presenting it as the complete setup path could leave users without Bun or `agent-node`.

## User impact

The first screen is shorter, bilingual, and points users to a setup command that matches the current stable npm packages. Detailed guidance remains in the linked documentation.

## Checks

- Docker, Node 22: clean `npm ci` and `npm run build` with VitePress 1.6.4 — PASS
- generated Chinese and English homepages checked — PASS
- linked getting-started and production pages exist — PASS
- npm stable packages installed in the same isolated verifier: `anet 2.2.21`, `agent-node 2.4.13`, Bun `1.3.14` — PASS

The existing VitePress chunk-size warning remains unchanged and is unrelated to these Markdown-only edits.