### PR TITLE
docs: make bootstrap password guidance channel-neutral

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -45,7 +45,7 @@ Verify: `curl http://127.0.0.1:9200/health` should return JSON containing `"ok":
 
 Open `http://localhost:3000` and dispatch work from the Dashboard.
 
-Save the random password printed by the first `anet hub start`; enter it at login and change it when prompted.
+The default administrator username is `admin`. Use the initial password shown by the first `anet hub start`, then run `anet passwd` immediately after login.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ anet node start my-bot
 
 打开 `http://localhost:3000`，从 Dashboard 给 Agent 派任务。
 
-保存 `anet hub start` 首次启动时打印的随机密码；登录时输入该密码，并按提示立即修改。
+默认管理员用户名是 `admin`。初始密码以首次 `anet hub start` 的启动输出为准；登录后立即运行 `anet passwd`。
 
 ## 能做什么
 


### PR DESCRIPTION
## What changed

Replaced the README's preview-only “random bootstrap password” statement with channel-neutral guidance:

- administrator username is `admin`
- use the initial password shown by the first `anet hub start`
- run `anet passwd` immediately after login

The login command remains interactive and therefore works for both published channels.

## Root cause

The prior correction was validated against `origin/main`, but the public README serves users installing npm `latest` as well as `preview`. The channels currently differ:

- `@sleep2agi/agent-network@latest` (`2.2.21`) still uses the fixed initial password
- `@sleep2agi/agent-network@preview` (`2.3.0-preview.36`) generates a one-time random bootstrap password

A README statement that described only `main/preview` was therefore wrong for stable users.

## Validation

- inspected the actual npm tarballs for both dist-tags, not only repository source
- stable artifact contains the `anethub` bootstrap path and no `must_change_password` flow
- preview artifact contains the random bootstrap and `must_change_password` flow
- `git diff --check`
- exactly two Markdown lines changed; no commands, code, API, or schema changed

This is a Draft only so the release coordinator can independently verify and merge.