### PR TITLE
docs: simplify and correct core concepts

### DIFF
--- a/docs-site/docs/concepts/networks.md
+++ b/docs-site/docs/concepts/networks.md
@@ -93,7 +93,7 @@ anet network delete old-network --force
 ```
 
 ::: warning 删除网络
-删除网络前必须先停止所有 Agent。网络删除后，所有关联的任务和消息数据将丢失。
+删除前必须先停止该网络的所有 Agent。删除不可通过 CLI 撤销；请先备份 Hub 数据库。
 :::
 
 ## RBAC 权限模型
@@ -105,9 +105,9 @@ anet network delete old-network --force
 | 角色 | 含义 | 谁是 |
 |------|------|------|
 | **owner** | 网络创建者 | 创建网络的用户 |
-| **admin** | 管理员 | 被 owner 提升的用户 |
+| **admin** | 管理员 | 通过 admin 邀请加入，或由 owner 调整角色 |
 | **member** | 成员 | 通过邀请码加入的用户 |
-| **viewer** | 只读 | 通过 `anet network invite --role viewer` 邀请码加入；公开网络自动加入是设计目标（[方式三](#方式三-公开网络) 未实装） |
+| **viewer** | 只读 | 通过 `anet network invite --role viewer` 邀请码加入 |
 
 ### 权限矩阵
 
@@ -116,17 +116,17 @@ anet network delete old-network --force
 | 删除/重命名网络 | &check; | | | |
 | 邀请/踢除成员 | &check; | &check; | | |
 | 创建/撤销 network Token | &check; | &check; | &check; | |
-| 启动 Agent Node | &check; | &check; | &check; | |
+| 创建 Agent (`anet node create`) | &check; | &check; | &check; | |
 | 发任务 (send_task) | &check; | &check; | &check; | |
 | 回复任务 (send_reply) | &check; | &check; | &check; | |
 | 取消/重试任务 | &check; | &check; | &check; | |
 | 查看 Agent 状态 | &check; | &check; | &check; | &check; |
 | 查看任务列表 | &check; | &check; | &check; | &check; |
 
-> 「创建/撤销 network Token」原本标 member ❌，实际 [`auth.ts:303-320 createToken`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L303) 只挡 **viewer**（`viewer cannot create full-access network tokens`），owner / admin / member 都能建。撤销 Token 走 [`auth.ts revokeToken`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) `WHERE token_id = ? AND user_id = ?` —— 任何用户都能撤销**自己的** token，也不按网络角色门控。不带 `network_id` 的纯 user token（`utok_`）任何登录用户都能创建。
+> owner / admin / member 可以创建 network Token，viewer 不可以。任何用户都只能撤销自己的 Token；登录用户也可以创建不带 `network_id` 的 user Token。
 
 ::: warning 审计日志权限**不**走网络角色
-旧 doc 在这里列「查看审计日志」一行 —— 实际 `/api/audit-log` 不按 owner / admin / member / viewer **网络角色**门控（verify [`server/src/index.ts:1926-1929`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L1926)）：
+`/api/audit-log` 不按 owner / admin / member / viewer **网络角色**门控：
 
 - **系统级 admin**（`users.role='admin'`，首位注册用户）：看所有人 audit_log
 - **非 admin**（`users.role='user'`）：只看自己的 audit_log（server 自动加 `WHERE user_id = self` 过滤）
@@ -136,15 +136,7 @@ anet network delete old-network --force
 
 ### Dashboard 权限表现
 
-Dashboard 根据角色调整按钮可见性 / 可点击性（设计目标）：
-
-- **viewer** 看不到"发任务"、"广播"按钮
-- **member** 看不到"管理成员"、"设置"按钮
-- **admin** 看不到"删除网络"按钮
-
-::: info Dashboard 实际行为（当前 stable）
-角色 → 按钮可见性的 UI 联动**部分实装**。即使按钮当前还显示，**Server 端会 403 拒绝**（`canWrite()` 强制 RBAC），权限本身不会绕过。完整 UI 按钮 hiding **v0.9.x / v0.10.x 整条 stable 线都未动**（每个 release 的具体改动见 [changelog](/changelog)），排到 v0.11+ Dashboard 改造里再补。
-:::
+Dashboard 会根据角色调整部分按钮，但 UI 不是授权边界。Server 会对每次请求重新执行 RBAC；即使按钮仍可见，无权操作也会返回 403。
 
 ## 加入网络
 
@@ -173,7 +165,7 @@ anet network join inv_abc123def456
 
 ### 方式二：跨机器部署 Agent {#跨机器部署}
 
-**v0.8 推荐做法**：在每台目标机器上**直接 `anet node create`**，不要复制 `config.json`。每台机器的 node 是独立的注册，hub 自动颁发独立的 `ntok_`，互不冲突。
+在每台目标机器上**直接 `anet node create`**，不要复制 `config.json`。每台机器独立注册，Hub 会颁发独立的 `ntok_`。
 
 ```bash
 # 在目标机器上 — 一步同时配 hub 地址 + 登录（拿到 utok_）
@@ -185,22 +177,8 @@ anet node start remote-agent                     # 启动
 ```
 
 ::: warning 不要跨机 copy `.anet/nodes/<name>/config.json`
-config 里的 `node_id` 是 `anet node create` 时**本地随机生成**的稳定 ID（`generateNodeId()`，CommHub `resume_id` = `sdk-${node_id}`）。复制到另一台机器会让两台机器用同一个 `node_id` → 同一个 `resume_id`，hub 端 SSE 路由会乱（先到的连接接收 task，第二台机器收不到）。
-
-如果一定要把 config 从 A 机器移到 B 机器（而不是新建），用 `anet node rename` 或在 B 上重新 `anet node create`。
-
-> ⚠ `anet node rename` 的已知 gap（[#110](https://github.com/sleep2agi/agent-network/issues/110)）：节点必须**至少 `anet node start` 过一次**才能 rename（否则 CommHub Server 端没 sessions 行，`prepareRename` 失败）。复制 config 后第一步先 start 一次让 server 注册，再 rename。失败安全（PHASE 1 rollback 老节点完好）。
+复制 config 会复用同一套 `node_id`、alias 和节点凭证，让两台机器同时声称同一个身份。Hub 可能拒绝连接或把投递交给错误进程。新机器应重新运行 `anet node create`；真正迁机时必须先停止源机器，且绝不能让两端同时启动。
 :::
-
-### 方式三：公开网络
-
-::: info 设计中
-公开网络功能为设计目标，尚未完全实现。
-:::
-
-```bash
-# (Planned, not yet implemented. Tracking: https://github.com/sleep2agi/agent-network/issues/new?title=network+visibility)
-```
 
 ## 系统角色 vs 网络角色
 
@@ -210,108 +188,30 @@ Agent Network 有两层权限：
 
 | 角色 | 谁 | 权限 |
 |------|-----|------|
-| **admin** | 第一个注册的用户（自动） | 管理所有用户、全局统计 |
+| **admin** | 第一个注册的用户（自动） | hub 级用户列表、审计和 server log；本机可重置密码 |
 | **user** | 后续注册的用户 | 创建网络、加入网络 |
 
 ### Layer 2: 网络角色（per network）
 
 每个用户在每个网络中有独立的角色（owner / admin / member / viewer）。
 
-两层权限叠加。例如：系统 admin 可以看全局数据，但在某个网络中如果是 viewer，则不能在该网络中发任务。
+两层权限分别生效。系统 admin 可以使用 hub 级用户、审计和日志接口，但 `/api/networks` 仍只列 membership；若它在某个 network 中是 viewer，也不能在该网络发任务。
 
-## 配额限制（v0.6 设计目标 — v0.8 部分启用） {#quota-limits}
+## 当前配额 {#quota-limits}
 
-::: warning v0.6 配额体系多数已搁置
-v0.6 时代设计过 Free / Pro / Admin 三档配额体系（下表），Apache 2.0 OSS 转向后**多数项已搁置**，但 **createNetwork 仍 enforces 一项**：
-
-| 配额项 | v0.8 实际行为 |
-|--------|---------------|
-| **创建网络数** (`max_networks_owned`) | ✅ **仍 enforced** —— [`auth.ts:249-262 createNetwork`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L249) 按 `users.plan || "free"` 查 `QUOTAS` 上限，free 默认 **2**，仅 `users.role='admin'` 豁免 |
-| 加入网络数 | ❌ hub 没在 join path 调 quota check |
-| 每网络 Agent 数 | ❌ |
-| 每天任务数 | ❌ |
-| Token 数 | ❌ |
-| 网络最大成员 | ❌ `networks.max_members` 字段 dormant |
-
-- `anet activate <key>` 是 v0.6 legacy 命令，OSS 后**不再用作"升级"路径**
-- `users.role = 'admin'`（首位注册用户自动获得）才能突破 free 配额，详见 [troubleshooting → quota_exceeded 解决方案](/troubleshooting#quota-exceeded-max-n-networks-for-free-plan)
-
-下表保留为自部署管理员**手动设置软配额**的设计参考（v0.9.x / v0.10.x 整条 stable 线都未实现 — 每个 release 的具体改动见 [changelog](/changelog)；排到 v0.11+ / 未排期）。
-:::
-
-| 配额项 | Free（v0.6 设计） | Pro（v0.6 设计） | Admin |
-|--------|:----------:|:---------:|:-----:|
-| 创建网络数 | 2 | 10 | 无限 |
-| 加入网络数 | 3 | 20 | 无限 |
-| 每网络 Agent 数 | 5 | 50 | 无限 |
-| 每天任务数 | 100 | 5000 | 无限 |
-| Token 数 | 3 | 20 | 无限 |
-| 网络最大成员 | 5 | 50 | 无限 |
-
-OSS 自部署场景下，硬件 / 数据库性能上限才是实际配额（SQLite 单机 100+ agent 验证过，多于此请 issue 讨论扩展方案）。
+`createNetwork()` 仍限制普通用户拥有的 network 数，默认 free 上限为 2；`users.role='admin'` 豁免。加入 network、每网 Agent、每日任务、Token 和成员数目前不执行对应配额。遇到 `quota exceeded` 见 [排障指南](/troubleshooting#quota-exceeded-max-n-networks-for-free-plan)。
 
 ## Server 端强制隔离
 
-网络隔离在 **Server 端强制执行**，客户端无法绕过：
-
-```typescript
-// Server 端：从 Token 提取 network_id，不信任客户端传入的
-const effectiveNetId = enforceNetworkId ?? clientNetId ?? null;
-
-// 所有查询自动加 network_id 过滤
-sql = addScope(sql, params, effectiveNetId);
-// → WHERE ... AND network_id = ?
-```
+网络隔离在 **Server 端强制执行**：
 
 这意味着：
 
-- ntok_ 绑定了 network A → 所有操作都限定在 network A
-- 即使客户端传 `network_id=B`，Server 会忽略，强制用 A
-- 不同网络的数据完全不可见
+- `ntok_` 固定绑定一个 network，不能借请求参数切换到另一个 network
+- `utok_` 请求必须通过目标 network 的 membership 检查
+- 任务、消息、节点和成员查询都按解析后的 network scope 过滤
 
-## 数据库表
-
-网络相关的数据库表：
-
-```sql
--- 网络表
-CREATE TABLE networks (
-  -- 基础 schema（db.ts:413-424）
-  network_id   TEXT PRIMARY KEY,
-  network_name TEXT NOT NULL,
-  owner_id     TEXT NOT NULL,
-  description  TEXT,
-  settings     TEXT,                     -- network 级配置 JSON（预留字段）
-  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at   TEXT NOT NULL DEFAULT (datetime('now')),
-  UNIQUE(owner_id, network_name),         -- 同一 owner 下 network 名唯一
-  -- V3.13 ALTER TABLE 迁移补的列（db.ts:675-676）
-  visibility   TEXT DEFAULT 'private',  -- private/public (**字段存在, 当前不启用**, 见下方 [配额限制 section](#quota-limits))
-  max_members  INTEGER DEFAULT 50        -- **字段存在, server 端不强制检查**: addNetworkMember + joinByInvite 都没有 max_members gate, 是 v0.6 配额体系的预留字段, 见 [配额限制 v0.6 设计目标 — v0.8 部分启用](#quota-limits)
-);
-
--- 网络成员表
-CREATE TABLE network_members (
-  network_id  TEXT NOT NULL,
-  user_id     TEXT NOT NULL,
-  role        TEXT NOT NULL DEFAULT 'member',
-  invited_by  TEXT,
-  joined_at   TEXT NOT NULL DEFAULT (datetime('now')),
-  PRIMARY KEY (network_id, user_id)
-);
-
--- 邀请码表
-CREATE TABLE network_invites (
-  invite_code TEXT PRIMARY KEY,
-  network_id  TEXT NOT NULL,
-  role        TEXT NOT NULL DEFAULT 'member',
-  created_by  TEXT NOT NULL,
-  max_uses    INTEGER DEFAULT 1,
-  used_count  INTEGER DEFAULT 0,
-  expires_at  TEXT,
-  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
-);
-```
+数据库以 `networks`、`network_members` 和 `network_invites` 分别保存网络、成员角色和邀请码；字段级细节以当前 migration 为准。
 
 ## 下一步
 
@@ -321,5 +221,5 @@ CREATE TABLE network_invites (
 
 **深入**：
 - 双 token 边界（utok_ vs ntok_）：[安全模型](/concepts/security)
-- 网络 + 账号在 SQLite 怎么存：上方 schema + [架构](/guide/architecture)
+- 网络 + 账号在 SQLite 怎么存：[架构](/guide/architecture)
 - 多 network 同时跑：[CLI 命令](/guide/cli) 的 `anet network ls / use` 章节

--- a/docs-site/docs/concepts/roles.md
+++ b/docs-site/docs/concepts/roles.md
@@ -1,7 +1,7 @@
 # 角色 / Roles & 权限
 
 ::: tip 一句话
-Agent Network 用 4 个角色：`owner` / `admin` / `member` / `viewer`。**你 utok_ 里带的角色决定你能调哪些 API**。RFC-001 已于 v0.8 落地之后，没有"超级 master 钥匙"，全部基于角色。
+每个 network 都有 4 个成员角色：`owner` / `admin` / `member` / `viewer`。Server 根据当前用户在目标 network 的 membership 判定权限；`utok_` 本身不固定某个 network 角色。
 :::
 
 ## 4 个角色对照
@@ -9,7 +9,7 @@ Agent Network 用 4 个角色：`owner` / `admin` / `member` / `viewer`。**你 
 | 角色 | 典型用例 | 简介 |
 |---|---|---|
 | **owner** | network 创建者 / 唯一最高权 | 能改成员 + 能删 network + 全部 admin 操作 |
-| **admin** | 团队负责人 / 受信运维 | 能加减成员 + 能改 hub 设置（注：`/api/audit-log` / `/api/users` 等 admin-only 端点是**系统级** `users.role='admin'` 限定，**不是** network admin；详见下方 [hub 全局 admin 特殊](#hub-全局-admin-特殊)） |
+| **admin** | 团队负责人 / 受信运维 | 能邀请和移除成员；hub 级管理接口需要单独的系统 admin 身份 |
 | **member** | 普通团队工程师 | 能创建 agent + 派 task + 看本网络数据（`anet node start/stop/delete` 是本地操作，不受角色门控 —— 见下方注 ※）|
 | **viewer** | 实习生 / 审计员 / 只读对接 | 只能看，不能写 |
 
@@ -42,153 +42,59 @@ Agent Network 用 4 个角色：`owner` / `admin` / `member` / `viewer`。**你 
 | 删除 network | ❌ | ❌ | ❌ | ✅ |
 | **hub 全局**（系统级 `users.role` 门控，**不是** 网络角色） | | | | |
 | 看 `/api/audit-log` 自己的 row | ✅ | ✅ | ✅ | ✅ |
-| 看 `/api/audit-log` 全部 row | 仅 `users.role='admin'`（verify [`server/src/index.ts:1926-1929`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L1926)） | | | |
+| 看 `/api/audit-log` 全部 row | 仅 `users.role='admin'` | | | |
 | `/api/users` 看用户列表 | 仅 `users.role='admin'`（同上系统级） | | | |
 | `/api/server-logs` 调试 console | 仅 `users.role='admin'` | | | |
 | `anet hub admin reset-user`（重置任意用户密码） | 仅 hub 本机命令行调用，与角色无关（owner 本机权限即可） | | | |
 
-> ※ `anet node start / stop / delete` 是**纯本地 CLI 操作** —— 直接读写本机 `.anet/nodes/<alias>/` 目录，`startCommand` / `deleteCommand` 里**没有任何网络角色 / owner / per-creator 检查**。谁的机器上有那份 node config，谁就能 start/stop/delete 它，跟该 user 在网络里是什么 role 无关。受网络角色门控的只有 `anet node create`（要向 hub 换 `ntok_`，`canWrite` 挡 viewer）。
+> ※ `anet node start / stop / delete` 由本机 `.anet/nodes/<alias>/` 配置发起，不做 network membership 检查（stop/delete 仍会向 Hub 报告离线或清理身份）。谁持有该本地配置，谁就能执行；`anet node create` 则需要 non-viewer membership 才能取得节点凭证。
 
-> `send_task` / `cancel_task` / `reassign_task` 三个 MCP 写工具**只过一道 [`canWrite` 门](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L111)**（`role !== "viewer"` —— owner/admin/member 都放行），**没有 per-task ownership 检查** —— member 可以 cancel / reassign 网络里**任何**任务，不限「自己派的」。重命名 network 是 owner-only（[`auth.ts:282 renameNetwork`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L282) `if (net.owner_id !== userId)`），跟「删除 network」一样，admin 不能改名。
+> `send_task` / `cancel_task` / `reassign_task` 对 owner/admin/member 开放，viewer 被拒绝；取消和转移任务没有“仅限自己创建的任务”规则。重命名和删除 network 仅 owner 可执行。
 
 ---
 
-## 每个角色细讲
+## 分配角色
 
-### viewer
+邀请时可以直接指定 `admin`、`member` 或 `viewer`：
 
-**给谁**：实习生、审计员、想看不能动的人。
-
-**能干什么**：
-- 任何**读**接口（任务列表 / agent 状态 / messages / completions）
-- 看 dashboard 主页面 / 浏览
-
-**不能干什么**：
-- ❌ 任何**网络级写操作**（派 task / `cancel_task` / `reassign_task` / `anet node create` —— 都过 `canWrite` 门挡 viewer）
-- ❌ 看其他人的 `/api/audit-log` row（系统级 `users.role='admin'` 才有跨用户访问；viewer **能看自己的** audit log row）
-
-> 注：`anet node start / stop / delete` 是**纯本地 CLI 操作**，不受网络角色门控（见上方权限矩阵注 ※）—— viewer 在自己机器上仍能 start/stop/delete 已有的 node。受网络角色门控的只有 `anet node create`（要向 hub 换 `ntok_`）。
-
-**怎么变成 viewer**：
 ```bash
-# admin / owner 邀请时指定
+anet network invite --role admin --uses 1
+anet network invite --role member --uses 5
 anet network invite --role viewer --uses 1
 ```
 
----
-
-### member
-
-**给谁**：团队里参与生产的工程师，独立干活。
-
-**能干什么**：
-- viewer 的全部
-- 创建自己的 agent (`anet node create`)
-- 启动 / 停止 / 删自己的 agent
-- 派 / 取消 / 转移任务 `send_task` / `cancel_task` / `reassign_task`（都只过 `canWrite` 门，所以 member 能取消 / 转移网络里**任何**任务，不限「自己派的」）
-
-**不能干什么**：
-- ❌ 改别人的 agent
-- ❌ 加减 network 成员
-- ❌ admin 接口
-
-**怎么变成 member**：
-```bash
-anet network invite --role member --uses 5      # 默认就是 member
-anet network join <code>                         # 用邀请码加入
-```
-
----
-
-### admin
-
-**给谁**：团队负责人、受信运维、需要管成员的人。
-
-**能干什么**：
-- member 的全部
-- 邀请新成员入网 + 移除非 owner 成员（invite [`index.ts` `POST /api/networks/:id/invite`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) / remove [`index.ts` `DELETE /api/networks/:id/members/:id`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)：`["owner","admin"]` 门控）
-
-> 注：`anet node start / stop / delete` / 改 config **不是 admin 的网络角色特权** —— 它们是纯本地 CLI 操作（见上方权限矩阵注 ※），谁的机器上有那份 node config 谁就能管，跟网络角色无关。admin **不能**远程 start/stop 别人机器上的 agent。
-
-**不能干什么**：
-- ❌ **改成员 role** —— `PUT /api/networks/:id/members/:user_id` 是 **owner only**（[`index.ts` `PUT /api/networks/:id/members/:id`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) `if (callerRole !== "owner")` 直接 403）；admin 只能 invite / remove，不能改已有成员的 role
-- ❌ 删除 network 本身（只有 owner 能）
-- ❌ 移除 owner / 把别人升到 owner
-- ❌ 看其他人的 `/api/audit-log` row —— admin-only 端点是**系统级** `users.role='admin'` 限定（**不是** network admin）；network admin 跟 viewer / member 一样只能看自己的 audit log row
-
-**怎么变成 admin**：
-```bash
-# 方式 1：owner 创建邀请码（推荐）—— 对方用邀请码加入直接拿到 admin role
-anet network invite --role admin --uses 1
-
-# 方式 2：现有 member 升级 —— 走 REST（CLI promote 子命令 v0.10.15 仍未提供，排到 v0.11+ / 未排期）
-curl -X PUT http://localhost:9200/api/networks/<net_id>/members/<user_id> \
-  -H "Authorization: Bearer <owner_utok>" \
-  -H "Content-Type: application/json" \
-  -d '{"role": "admin"}'
-# 详见 [API — PUT members](/api/rest#put-api-networks-id-members-user-id)
-```
-
----
-
-### owner
-
-**给谁**：network 创建者，全权最高，**每个 network 至少 1 个 owner**。
-
-**能干什么**：
-- admin 的全部
-- 删除 network
-- 改其他成员的 role（`PUT /api/networks/:id/members/:user` 要求 caller 是 owner —— admin 改不了成员 role）
-
-**特殊保护**：
-- ❌ 不能被 admin 改 role
-- ❌ 不能被 admin 移除
-- 如果 network 只剩一个 owner，**不能降级 / 删除自己**（避免无 owner 状态）
-- ⚠ owner 角色**不能授予**给别人（`updateMemberRole` / `createInvite` 都显式拒 `owner`，详见下方「怎么变成 owner」）—— 所以「多 owner」不是正常路径
-
-**怎么变成 owner**：
-- 创建 network 时自动是 owner：`anet network create <name>`
-- ⚠ **不能通过 REST `PUT /members/:user_id` promote 到 owner** —— server 拒绝（返回 `cannot assign owner role` 400，详见 [API — PUT members 4xx](/api/rest#put-api-networks-id-members-user-id)）。owner 角色只能通过创建 network 获得
+修改已有成员的角色使用 `PUT /api/networks/:id/members/:user_id`，且仅 owner 可调用。`owner` 不能通过邀请或该接口授予；创建 network 的用户自动成为 owner。
 
 ---
 
 ## hub 全局 admin（特殊）
 
 ::: warning 这跟 network admin 不一样
-network 的 4 个 role（owner/admin/member/viewer）是**绑定到某个 network** 的。还有一个 **hub 全局 admin**（first-run 创建的 `admin` user）—— 这个 user **在所有 network 都自动是 admin**，并且能调 hub 级管理接口。
+network 的 4 个 role（owner/admin/member/viewer）绑定到具体 network。另有 `users.role='admin'` 的 **hub 全局 admin**，可调用用户列表、完整审计日志、server logs 等 hub 级接口；它**不会自动获得每个 network 的 admin 成员身份**。
 :::
 
 | 操作 | network admin | hub 全局 admin (`admin` user) |
 |---|---|---|
 | 调 `/api/audit-log` 看**自己的** row | ✅ | ✅ |
-| 调 `/api/audit-log` 看**其他人** row | ❌（server 自动 `WHERE user_id = self` 过滤） | ✅（看全部，index.ts:1926-1929） |
+| 调 `/api/audit-log` 看**其他人** row | ❌（server 自动 `WHERE user_id = self` 过滤） | ✅ |
 | `anet hub admin reset-user`（重置任意用户密码） | ❌ | ✅（仅 hub 本机调用） |
-| 创建新 user | ❌ | ✅（仅 hub 全局 admin） |
-| 看 hub 所有 network | ❌（只看自己有 role 的） | ✅ |
+| 通过公开注册接口创建 user | ✅（受注册限速与密码规则约束） | ✅ |
+| 直接列出所有 network | ❌（只看自己有 role 的） | ❌（同样按 membership 列表） |
 
 ---
 
 ## 角色信息存在哪
 
-每个 utok_ 都绑了 `(user_id, network_id, role)` 三元组（在 `api_tokens` 表的 `scope` 字段）。
+`utok_` 绑定用户身份；network 角色存于 `network_members`。请求进入具体 network 后，Server 再查询该用户的 membership。`ntok_` 另带固定的 `network_id`，供节点访问单一网络。
 
-```ts
-// server 端 auth 解析
-const ctx = await resolveToken(req.headers.authorization);
-// ctx = { user_id, network_id, role: 'admin' | 'member' | ... }
-
-// endpoint handler
-if (!isAdminLike(ctx.role)) return new Response("403", { status: 403 });
-```
-
-CLI 不需要你输任何 role 信息 —— `anet login` 时 hub 把 role 写进 token，CLI 自动带着调接口。
+CLI 不需要你手工输入 role；登录后，Server 依据用户身份和目标 network 的 membership 做判定。
 
 ---
 
 ## 升降级一个成员的角色
 
-::: warning 当前 stable 仍没有 `promote` / `demote` CLI 子命令
-v0.9.x / v0.10.x 整条 stable 线都未触碰 member role 管理（每个 release 的具体改动见 [changelog](/changelog)）；完整 CLI 入口排到 v0.11+ / 未排期。目前列成员可以走 CLI，**改角色 / 移除成员一律走 REST**（详见 [API — networks members](/api/rest#get-api-networks-id-members)）。
+::: info 当前操作入口
+CLI 可以列成员；改角色和移除成员使用 REST（详见 [API — networks members](/api/rest#get-api-networks-id-members)）。
 :::
 
 ```bash
@@ -234,30 +140,19 @@ A：`anet whoami` 输出的 `Role:` 是**系统级 role**（`users.role` —— 
 **Q：能跨 network 用不同 role 吗？**
 A：能。同一个 user 在 networkA 是 admin，在 networkB 是 viewer，完全 OK。每个 network 独立 role。
 
-**Q：默认 `admin / anethub` 账号是什么 role？**
+**Q：首次启动创建的 `admin` 账号是什么 role？**
 A：first-run 创建时自动是 hub 全局 admin + default network 的 owner。
 
 **Q：能不能让一个 user 只在某个 network 是 admin、在 hub 全局不是？**
-A：能。把他设为 network owner 即可（不给 hub 全局 admin）。
+A：能。把他设为该 network 的 `admin` 即可；系统级 `users.role` 不会随之改变。
 
 **Q：viewer 真的什么都不能写吗，连派 task 都不行？**
 A：对，连派 task 都不行。如果想"能看 + 偶尔派"，给 member。
 
 ---
 
-## 与 RFC-001 的关系
-
-[RFC-001](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md) 已于 **v0.8.0 落地**：`COMMHUB_AUTH_TOKEN` 进入软废弃（v1.0 完全移除），**hub 鉴权完全基于本文档的 4 个 role**：
-- ✅ 没有 "master 钥匙" bypass role 检查
-- ✅ 所有 admin 操作 = admin role `utok_` + role check
-- ✅ 所有 hub ↔ dashboard 内部通信 = admin user 的 `utok_`（Dashboard 已是 thin cookie-proxy）
-
-这就是为啥要把 role 体系写清楚 —— 它是**唯一**的鉴权基础。
-
 ## 下一步
 
-- **CLI 操作 role**：[CLI 命令 — network 管理](/guide/cli)（`anet network members` 列成员；改角色走 REST [PUT members](/api/rest#put-api-networks-id-members-user-id)，CLI promote/demote 排到 v0.11+ / 未排期）
+- **CLI 操作 role**：[CLI 命令 — network 管理](/guide/cli)
 - **Token 体系联动**：[Token 概念](/concepts/tokens) — 4 个 role 跟 utok_/ntok_ 关系
 - **完整安全模型**：[安全设计](/concepts/security)
-- **升级 v0.7 → v0.8 怎么影响 role**：[升级指南](/guide/upgrade#v0-7-v0-8-升级注意-最新)
-- **RFC-001 路线图**：[RFC-001](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md)

--- a/docs-site/docs/concepts/security.md
+++ b/docs-site/docs/concepts/security.md
@@ -15,7 +15,7 @@ graph TB
     subgraph "权限控制"
         RBAC[RBAC 四级权限<br/>owner/admin/member/viewer]
         NET[网络隔离<br/>Server 端强制]
-        SCOPE[Token Scope<br/>full/agent/readonly]
+        SCOPE[网络成员权限<br/>owner/admin/member/viewer]
     end
 
     subgraph "数据安全"
@@ -25,7 +25,7 @@ graph TB
     end
 
     subgraph "审计追踪"
-        AUDIT[审计日志<br/>全操作记录]
+        AUDIT[审计日志<br/>关键安全操作]
         EVENTS[任务事件日志]
     end
 
@@ -36,26 +36,23 @@ graph TB
     SQL --> AUDIT
 ```
 
-::: info v0.10.11 实际启用 vs 设计目标
-上图反映**设计目标**，当前 v0.10.11 实际执行情况：
-
-- ✅ **已启用**：速率限制 / Token 认证（utok_/ntok_/atok_）/ CORS / RBAC 四级权限 / 网络隔离（Server 端强制） / SQL 注入防护 / 密码 salted scrypt / 审计日志 / 任务事件日志
-- ⏳ **未完全启用**：Token Scope 字段（`api_tokens.scope` 列存在 + [`auth.ts` `createToken`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) 按 token 类型写不同 scope，但 [`auth.ts` `resolveToken`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) 返回结构里**没 scope 字段** —— RBAC 决策不消费 scope 写入；security report **R12** v0.9.x / v0.10.x 都未动（Recovery & Observability / Direct Runtime + Observability Foundations / Hero A+D / 后续 UX 修复 chain 主题为先），排到 v0.11+ / 未排期；详见 [安全审计报告](https://github.com/sleep2agi/agent-network/blob/main/docs/open-source-security-risk-report.md)）
-- ✅ **密码哈希 = salted scrypt**（Round-6 A1 已上线，闭环 security report **R9**）：Node 内建 `crypto.scryptSync`，每密码独立随机 salt，verify [`db.ts:1057 hashPassword`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L1057)。刻意未选 Argon2id（避免原生依赖），详见下方「密码安全」
+::: info 当前边界
+网络绑定和 membership 由 Server 强制检查。`api_tokens.scope` 会被记录，但当前权限判定主要依赖 token 的用户/网络绑定与 `network_members`，不要把 `scope` 字符串单独当作授权证明。
 :::
 
 ## 认证（Authentication）
 
 ### Token 体系
 
-v0.8 是**双 Token 体系**：
+当前使用三类 Token：
 
 | Token | 前缀 | 绑定 | 用途 |
 |-------|------|------|------|
 | 用户 Token | `utok_` | 用户 | CLI / Dashboard 登录 |
 | 网络 Token | `ntok_` | 用户 + 网络 | Agent 连接 |
+| API Token | `atok_` | 用户，可选绑定网络 | `anet token create` 创建的长期 API 凭证 |
 
-`atok_`（V2 时代的 api token）已被 `utok_` + `ntok_` 取代 —— 代码里还保留前缀兼容判断（不报错），但**新用户不需要接触**，`anet token create / ls / revoke` 底层走的都是 `utok_` / `ntok_`。详见 [Token 体系](/concepts/tokens)。
+详见 [Token 体系](/concepts/tokens)。
 
 ### Token 存储
 
@@ -74,9 +71,9 @@ const inputHash = hashToken(inputToken);
 const row = db.get("SELECT * FROM api_tokens WHERE token_hash = ?", inputHash);
 ```
 
-### Vendor 凭据存储（envRef 模式，v0.9.0+）
+### Vendor 凭据存储（envRef 模式） {#vendor-凭据存储-envref-模式-v0-9-0}
 
-agent node 跑 `claude-agent-sdk` runtime 时需要厂商 API key（`ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `MINIMAX_KEY` …），存哪里非常关键。从 [#125](https://github.com/sleep2agi/agent-network/issues/125)（v0.9.0 promote gate #2）起，**agent node config.json env map 支持两种值形态**（tagged union）：
+agent node 跑 `claude-agent-sdk` runtime 时需要厂商 API key（`ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `MINIMAX_KEY` 等）。`config.json` 的 env map 支持两种值形态：
 
 ```jsonc
 // 老格式（仍兼容、deprecated）—— 明文 token 落 config.json
@@ -94,15 +91,13 @@ agent node 跑 `claude-agent-sdk` runtime 时需要厂商 API key（`ANTHROPIC_A
 }
 ```
 
-**为啥要 envRef**：明文 token 写进 `config.json` 会泄漏到 git history / dashboard payload / `anet ls` 输出 / error envelope / log line 等多处 surface。secret 留在 `process.env` 则永远不落盘。
+**为啥要 envRef**：避免把明文 token 写进 `config.json`，进而泄漏到 git、配置展示或日志。启动器可以从进程环境或节点目录下权限为 0600 的 `.env` 读取实际值；envRef 不是“永不落盘”的承诺。
 
 **agent-node 兼容两种**：
 - 拿到 `string` → 仍按明文用，同时 print 一次 deprecation banner 提示用 `anet node migrate-token-to-envref <alias>` 迁
 - 拿到 `{ _envRef: "<NAME>" }` → 读 `process.env[NAME]`；**unset 时启动直接 FATAL exit**（refuse to start silently broken），打印 `export NAME='...'` remediation hint
 
-**`anet node create` 自动用 envRef**：[#125](https://github.com/sleep2agi/agent-network/issues/125) 之后，`saveCreatedNode` 前会跑 `rewritePlainSecretsToEnvRef()` —— 新建节点的 vendor secret **永不持久化明文**，原值临时塞进当前 shell `process.env`（spawn 直接拿）+ print `export NAME='value'` 让你自己抄进 `~/.bashrc` 或 secrets manager。
-
-**v0.10.10 起 envRef Option A wizard 自动衔接（[#193](https://github.com/sleep2agi/agent-network/issues/193)）**：除了上面 `process.env` + print export 行为，`anet node create` **额外**把 API key 写入 `.anet/nodes/<alias>/.env`（mode 0600，自动加入 `.anet/.gitignore`）。同一 shell 跑 `anet node start <alias>` 时启动前自动 source 该 `.env`，**无需手动 `export ANTHROPIC_AUTH_TOKEN_N_<id>=...` 也无需抄到 `~/.bashrc`**。跨机部署仍需手动 copy 一次（`anet node create` 也会 print 一次 export 命令供 copy）。详见 [cli.md `anet node create`](/guide/cli#anet-node-create) ::: tip envRef wizard 自动衔接段。
+**`anet node create` 自动用 envRef**：`config.json` 只保存变量名；实际 API key 写入 `.anet/nodes/<alias>/.env`（mode 0600，并加入 `.anet/.gitignore`），启动时自动加载。跨机部署仍需安全迁移这份 secret；详见 [`anet node create`](/guide/cli#anet-node-create)。
 
 **已有节点一键迁**：
 
@@ -118,40 +113,17 @@ anet node migrate-token-to-envref <alias>
 
 **Secret 识别启发式**（agent-node / cli.ts / doctor 共享）：env key 后缀匹配 `/_TOKEN|_KEY|_SECRET|AUTH$/`，或 value 前缀匹配 `/sk-|utok_|ntok_|atok_|ak-|gsk_|key-|Bearer/` —— 任一命中就当作 secret 处理。
 
-### Token 验证流程（v0.8）
+### Token 验证流程
 
-```mermaid
-flowchart TD
-    REQ[HTTP 请求] --> EXTRACT[提取 Token]
-    EXTRACT --> HDR{Authorization 头?}
-    HDR -->|有| TOKEN[Bearer token]
-    HDR -->|无| QS{URL ?token=?}
-    QS -->|有| TOKEN
-    QS -->|无| DEVOPEN{--dev-open?}
+Hub 从 Bearer header（少数 SSE/兼容接口也接受 query token）解析凭证，检查 token 是否存在、过期或撤销，再应用用户身份、network 绑定和 membership。`--dev-open` 只适合隔离的本地演示。
 
-    TOKEN --> RESOLVE[resolveToken<br/>查 api_tokens 表]
-    RESOLVE --> FOUND{找到?}
-    FOUND -->|是| CHECK_EXPIRE{过期?}
-    CHECK_EXPIRE -->|否| OK[认证通过<br/>提取 user + network]
-    CHECK_EXPIRE -->|是| DENY[401]
-    FOUND -->|否| LEGACY{COMMHUB_AUTH_TOKEN<br/>set & 匹配?<br/>仅 /api/* 读类}
-
-    LEGACY -->|是| OK_LEGACY[认证通过<br/>+ 打 deprecation warning<br/>v1.0 移除]
-    LEGACY -->|否| DENY
-
-    DEVOPEN -->|是| OK_OPEN[开放模式<br/>仅离线 tutorial 用]
-    DEVOPEN -->|否| DENY
-```
-
-::: warning v0.8 关键变化
-- v0.5 时代 `COMMHUB_AUTH_TOKEN` 未设 → 自动 open mode 的路径**已删除**。现在 hub 不带 `--dev-open` 必须有 utok_/ntok_。
-- master token 兼容路径**只允许少量 `/api/*` 读请求**，写操作一律拒绝。
-- 这条 legacy 路径 v1.0 完全移除（[RFC-001 阶段 3](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md)；tracking issue 见 [open issues: COMMHUB_AUTH_TOKEN](https://github.com/sleep2agi/agent-network/issues?q=is%3Aissue+COMMHUB_AUTH_TOKEN)）。
+::: warning Legacy master token
+`COMMHUB_AUTH_TOKEN` 仍是向后兼容的 master 路径，权限范围较宽。新部署不要启用；旧部署应迁移到 `utok_` / `ntok_`，但不能假设该兼容路径已从代码删除。
 :::
 
 ### 密码安全
 
-- 密码用 **salted scrypt** 哈希存储（Node 内建 `crypto.scryptSync`，不是 SHA-256）—— verify [`server/src/db.ts:1057 hashPassword`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L1057):
+- 密码用 **salted scrypt** 哈希存储（Node 内建 `crypto.scryptSync`，不是 SHA-256）：
   ```ts
   export function hashPassword(plain: string): string {
     const N = getScryptN();               // 默认 14 → 2^14≈16384 iter (~50ms)，可用 COMMHUB_SCRYPT_N 调
@@ -160,52 +132,34 @@ flowchart TD
     return `scrypt$${N}$${salt.toString("base64")}$${hash.toString("base64")}`;
   }
   ```
-  **每个密码独立 16 字节随机 salt**（一并存进哈希串），所以同一密码在不同账户哈希值**不同**；scrypt 内存硬、抗 GPU/ASIC，强于 bcrypt。旧的裸 SHA-256 哈希在登录时**惰性迁移**到 scrypt（`verifyPassword` 两种格式都认，命中旧格式且密码正确就地 rehash）。刻意不用 Argon2id：scrypt 用 Node 内建、零新增依赖。
+  **每个密码独立 16 字节随机 salt**（一并存进哈希串），所以同一密码在不同账户哈希值不同。旧的裸 SHA-256 哈希在成功登录后惰性迁移到 scrypt。
 
-- **密码强度** —— verify [`server/src/auth.ts:56-77 validatePasswordStrength`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L56):
+- **密码强度**由 `validatePasswordStrength()` 统一检查：
   - 用户自选密码（register / `anet passwd`）：**≥ 8 字符** + 拒绝 [`password-dict.ts WEAK_PASSWORDS`](https://github.com/sleep2agi/agent-network/blob/main/server/src/password-dict.ts) 字典
-  - 首次 bootstrap admin **register 例外**：≥ 4 字符即可（让快速上手 `admin / anethub` 默认成立）—— [`auth.ts:43-44`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L43) 检测「首位注册用户」时只校验 length ≥ 4；**`anet passwd` / `reset-user` 无此豁免**，永远强制 ≥ 8 + 非弱密码
+  - 首次 bootstrap admin 的 register 例外：最低 4 字符；**`anet passwd` / `reset-user` 无此豁免**，要求 ≥ 8 且不在弱密码字典
   - 公网部署必须**立刻** `anet passwd` 改强密码
 
 - 用户名支持字母、数字、下划线、中文
-- 登录失败不提示是用户名错还是密码错（[`auth.ts:99-100`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L99) 故意把两种错误合并成同一文案，避免 username enumeration）
+- 登录失败不提示是用户名错还是密码错，避免 username enumeration
 
-::: info 密码哈希 = salted scrypt（已实现，Round-6 A1）
-密码哈希已从早期的 SHA-256 升级为 **salted scrypt**（`scrypt$N$salt$hash` 格式，每密码独立随机 salt），闭环 security report R9。**未选 Argon2id 是刻意的** —— scrypt 用 Node 内建 `crypto.scryptSync`、零原生依赖，内存硬 + 抗 GPU/ASIC 已够；旧 SHA-256 哈希登录时惰性迁移。Token 哈希（`hashToken` 用纯 SHA-256 无 salt）不需要这些 —— token 是 128-bit 随机字符串，rainbow table 不适用。
+::: info 密码与 Token 使用不同哈希策略
+密码使用带独立 salt 的 scrypt，旧 SHA-256 密码哈希在成功登录后惰性迁移。Token 本身是高熵随机值，数据库只保存其 SHA-256 哈希。
 :::
 
 ## 授权（Authorization）
 
 ### RBAC 权限检查
 
-每次 MCP 工具调用都进行权限检查（[`server/src/tools.ts:106 canWrite`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L106)）：
-
-```typescript
-const canWrite = (effectiveNetworkId?: string | null): boolean => {
-  if (!enforceUserId) return true; // legacy 全局 token 模式（仅 dev-open / 旧 atok_ 路径）
-  // ntok_: enforceNetworkId 由 token 绑定锁死；utok_: 从 effectiveNetworkId 走（MCP 调用传入）
-  const netId = enforceNetworkId ?? effectiveNetworkId ?? null;
-  if (!netId) return false;        // 解析不到 network 拒绝
-  const role = getUserNetworkRole(enforceUserId, netId);
-  return !!role && role !== "viewer"; // owner/admin/member 可写
-};
-```
+MCP 写工具通过共享的 `canWrite` 检查目标 network 的 membership：
 
 **关键点**:
 - `ntok_` → 由 token 锁死 `enforceNetworkId`，**不接受**客户端传入的 network_id（防跨 network 写）
-- `utok_` → `enforceNetworkId` 为空，**接受**客户端在 MCP 调用里传 `effectiveNetworkId`，并查 `network_members.role`
+- `utok_` → 解析目标 network 后查询 `network_members.role`
 - 任何一种 token，只要 role 是 `viewer` 都拒绝写
 
 ### Server 端网络强制
 
-这是安全设计的核心 -- 网络 ID **不信任客户端**：
-
-```typescript
-// Server 从 Token 提取 network_id，不用客户端传入的
-const getNetworkId = (clientNetId) => enforceNetworkId ?? clientNetId ?? null;
-```
-
-即使客户端传了 `network_id=other_network`，Server 会忽略，强制使用 Token 绑定的网络。
+`ntok_` 的 network 由 token 绑定，客户端参数不能覆盖。`utok_` 可以选择目标 network，但 Server 会验证该用户确实是成员；它不是“信任任意客户端 network_id”。
 
 ### REST API 权限
 
@@ -215,9 +169,9 @@ REST API 根据 Token 类型自动限制范围：
 |-----------|-------------|
 | `ntok_` | 只能看绑定网络的数据 |
 | `utok_` | 可以看用户所属的所有网络 |
-| `atok_` (full) | 可以看用户所属的所有网络 |
-| 全局 Token | 可以看所有数据 |
-| 系统 admin | 可以看所有数据 |
+| `atok_` | 若绑定 network 则仅该网络；未绑定则按用户 membership |
+| Legacy master token | 可通过通用 REST scope；不能替代需要具体 user membership 的端点 |
+| 系统 admin | 可用 hub 级管理和跨网络查询端点；成员管理仍检查该 network 的角色 |
 
 ## 速率限制（Rate Limiting）
 
@@ -229,44 +183,22 @@ REST API 根据 Token 类型自动限制范围：
 | `POST /api/auth/login` | 10 次/分 | 防暴力破解 |
 
 ::: info register 与 login 用不同机制
-- **register**：通用 `checkRateLimit()`（30/min），verify [`index.ts` `checkRateLimit()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)。`checkRateLimit` 签名 `maxPerMinute = 60` 默认值为未来扩展预留。
-- **login**：专用 `LoginIpRateLimiter`（每 IP 每 60 秒窗口 10 次）**外加**基于失败次数的账户级渐进锁定（连续失败 ≥ 5 次触发，锁定时长 30 秒起、指数退避至上限 15 分钟），verify [`server/src/auth_login_guard.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth_login_guard.ts)。
+- **register**：通用 `checkRateLimit()`（30/min）。
+- **login**：专用 `LoginIpRateLimiter`（每 IP 每 60 秒窗口 10 次）**外加**账户级渐进锁定（连续失败 ≥ 5 次触发，30 秒起、指数退避至 15 分钟上限）。
 - **其它 endpoint 当前不做 IP rate limit** —— 担心写操作被滥用，前置反向代理（nginx / cloudflare 等）补即可。
 :::
 
-### 实现方式
-
-```typescript
-// 内存存储，per IP（verify `checkRateLimit()` in index.ts）
-const rateLimits = new Map<string, { count: number; resetAt: number }>();
-
-function checkRateLimit(ip: string, maxPerMinute = 60): boolean {
-  // localhost / internal / unknown 免限制（开发/测试）
-  if (!ip || ip === "unknown" || ip === "127.0.0.1" || ip === "::1") return true;
-
-  const now = Date.now();
-  const entry = rateLimits.get(ip);
-  if (!entry || now > entry.resetAt) {
-    rateLimits.set(ip, { count: 1, resetAt: now + 60000 });
-    return true;
-  }
-  if (entry.count >= maxPerMinute) return false;  // 命中上限，不再 ++
-  entry.count++;
-  return true;
-}
-```
-
-超过限制返回 HTTP 429，body 形如：
+### 429 响应
 
 ```json
 { "ok": false, "error": "too many requests, try again later" }
 ```
 
-（上面是 register 的 429 body；`/login` 走专用 guard —— 命中 IP 限流返回 `error: "rate_limited"`、命中失败锁定返回 `error: "login_locked"`，**两者都带 `Retry-After` header + body 里的 `retry_after_ms`**，并写 audit `action='login_rate_limited'` + clientIP。verify [`server/src/auth_login_guard.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth_login_guard.ts)。）
+上面是 register 的响应。Login 的 IP 限流返回 `rate_limited`，账户锁定返回 `login_locked`；两者都带 `Retry-After` 和 `retry_after_ms`。
 
 ### 本地豁免
 
-localhost (`127.0.0.1` / `::1`)、以及 IP 解析为空 / `"unknown"` 的请求免速率限制，方便开发和测试（[`index.ts` `checkRateLimit()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）。
+register 的通用 limiter 对 localhost 和 `"unknown"` 豁免；login 的专用 limiter **不豁免**这些值。生产环境应由可信反向代理写入客户端 IP，并在网关再加一层限流。
 
 ## CORS 配置
 
@@ -279,49 +211,23 @@ COMMHUB_CORS_ORIGINS="https://dashboard.example.com" anet hub start
 ```
 
 ::: warning CORS 默认 **不是** `*`
-verify [`index.ts` `CORS_ORIGINS`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)：`COMMHUB_CORS_ORIGINS` 未设时默认白名单 = `["http://localhost:3000", "http://localhost:3001"]`（**仅本机 dev origin**），**不是** `*`。设了 `COMMHUB_CORS_ORIGINS`（逗号分隔）会**完全替换**这个默认值。
+`COMMHUB_CORS_ORIGINS` 未设时默认白名单是 `http://localhost:3000` 和 `http://localhost:3001`，**不是** `*`。设置该变量会完全替换默认值。
 
 `Access-Control-Allow-Origin` 只在请求的 `Origin` 命中白名单时回显该 origin，否则回空字符串（浏览器据此拦截跨域请求）。源码不 hardcode 任何作者域名 —— 生产部署 Dashboard 跨域必须显式设 `COMMHUB_CORS_ORIGINS`。
 :::
 
 ## 审计日志
 
-所有关键操作记录到 `audit_log` 表（verify [`server/src/db.ts:201-212`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L201)）：
+关键操作写入 `audit_log`，包含调用用户、action、目标、详情、IP、network 与时间。Action 会随能力增加，不在这里维护易过时的固定总数。
 
-```sql
-CREATE TABLE audit_log (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id       TEXT,
-  username      TEXT,
-  action        TEXT NOT NULL,
-  target_type   TEXT,           -- 'user' / 'network' / 'token' / 'auth' / ...
-  target_id     TEXT,           -- 关联的 user_id / network_id / token_id
-  detail        TEXT,           -- 操作描述，如 '<user_id> as <role>' / '<old> → <new>'
-  ip            TEXT,           -- 触发请求的 client IP（rate-limited 等场景）
-  network_id    TEXT,           -- 操作发生在哪个 network
-  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
-);
-```
+常见 action 分组：
 
-记录的 action 取值（**共 19 个**；verify `grep logAudit server/src/*.ts + auth.ts resetUserPassword() + cli.ts` —— 18 个走 [`logAudit()` helper](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L447)，`password_reset_by_admin` 走 [`auth.ts` `resetUserPassword()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) 直接 INSERT）：
+- 登录与密码：`register`、`login`、`login_failed`、`login_rate_limited`、`login_locked`、`password_changed`
+- Network 与成员：`network_renamed`、`network_deleted`、`network_joined`、`member_*`、`invite_created`
+- Token 与节点：`token_*`、`node_token_created`、`node_rename_*`、`node_attrs_updated`
 
-| 操作 | 触发场景 |
-|------|---------|
-| `register` | 用户注册（[`index.ts` `POST /api/auth/register`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)） |
-| `login` | 用户登录成功 |
-| `login_failed` | 用户登录失败（密码不匹配 / username 不存在） |
-| `login_rate_limited` | login 触发 IP rate limit（10/分） |
-| `password_changed` | `anet passwd` 改密码（[`index.ts` `POST /api/auth/password`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)） |
-| `password_reset_by_admin` | hub admin 用 `anet hub admin reset-user` 强制重置（[`auth.ts` `resetUserPassword()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)） |
-| `network_renamed` / `network_deleted` / `network_joined` | network 改名 / 删除 / 加入 |
-| `member_added` / `member_role_changed` / `member_removed` | network 成员变更（`detail` 字段记 `<user_id> as <role>` / `<user_id> → <role>`） |
-| `token_created` / `token_revoked` | API token 生命周期 |
-| `node_token_created` | `anet node create` 自动 mint `ntok_` |
-| `node_rename_prepared` / `node_rename_committed` / `node_rename_aborted` | RFC-010 节点改名两阶段事务（PREPARE / COMMIT / ABORT 各写一条 audit） |
-| `invite_created` | 创建网络邀请码 |
-
-::: info `create_network` / `network_created` 不写 audit
-当前 [`index.ts` `POST /api/networks`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 的 POST `/api/networks` 不调 `logAudit`，所以新建 network 不留 audit 行。仅 rename / delete / join 写 audit。
+::: info 创建 network 当前不写 audit
+POST `/api/networks` 不写 `create_network` 或 `network_created`。不要依赖不存在的 action。
 :::
 
 ### 查询审计日志
@@ -334,7 +240,7 @@ curl -H "Authorization: Bearer $UTOK" "$HUB/api/audit-log?limit=50"
 
 ## SQL 注入防护
 
-所有数据库操作使用参数化查询：
+数据库查询使用参数绑定，不拼接用户输入：
 
 ```typescript
 // 正确：参数化查询
@@ -344,12 +250,11 @@ db.run("SELECT * FROM sessions WHERE alias = ?1", [alias]);
 db.run(`SELECT * FROM sessions WHERE alias = '${alias}'`);
 ```
 
-全部 `db.run()` / `db.get()` / `db.all()` 调用（[`server/src/*.ts` grep 当前 150+ 处](https://github.com/sleep2agi/agent-network/tree/main/server/src)）都已迁移到参数化方式。（原 doc 写「85+」是 v0.5 时代估算，server 端代码量翻倍后实际 150+。）
-
 ## 数据库安全
 
 ::: tip 后端是 SQLite —— 完整性保证也基于 SQLite
 anet 生产用 **SQLite**（`~/.commhub/commhub.db`）。本节及授权/审计的完整性与隔离保证都建立在 SQLite 的事务 / 约束语义上。代码里虽有 `DATABASE_URL` 的 PostgreSQL 入口，但**未做端到端验证、不建议生产使用**（见 [FAQ — PostgreSQL 支持如何？](/faq#_20-postgresql-支持如何)）。
+:::
 
 ### SQLite WAL 模式
 
@@ -372,9 +277,9 @@ chmod 600 ~/.commhub/commhub.db
 
 | 数据 | 存储方式 | 细节 |
 |------|---------|------|
-| 密码 | salted scrypt（`scrypt$N$salt$hash`） | [db.ts:1057](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L1057)；每密码独立随机 salt，旧 SHA-256 哈希登录时惰性迁移 |
-| Token | SHA-256 哈希（无 salt） | token 是 `crypto.randomUUID()` 128-bit 随机值，rainbow table 不适用 |
-| API Key | 不存储（仅 process env / config.env） | agent-node 进程内 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` env，hub 端 db 不存 |
+| 密码 | salted scrypt（`scrypt$N$salt$hash`） | 每密码独立随机 salt，旧 SHA-256 哈希登录时惰性迁移 |
+| Token | SHA-256 哈希（无 salt） | token 由 `crypto.randomUUID()` 生成，数据库不保存明文 |
+| API Key | 不存 Hub 数据库 | agent-node 从进程环境或节点 `.env` 读取；envRef 让 `config.json` 只保存变量名 |
 | 任务内容 | 明文 | `tasks.content` 列；多用户共享 hub 时 admin 能看所有；`audit_log` 不含 task body |
 | 审计日志 | 明文 | `audit_log` 10 列含 user_id / username / action / detail / ip / network_id |
 
@@ -405,24 +310,22 @@ COMMHUB_CORS_ORIGINS="https://dashboard.example.com"
 
 ### SSE 连接安全
 
-SSE 连接使用与 REST API 相同的认证机制（Bearer Token / URL token 参数）。**v0.8.1 起 agent-node SSE 收到 401 会自动 reload token 并重连**，避免老 ntok_ 过期导致 agent 静默离线。
+SSE 连接使用与 REST API 相同的认证机制（Bearer Token / URL token 参数）。agent-node 在 SSE 返回 401 后会重新加载 token 并重连。
 
-### Dashboard 鉴权（v0.8 thin cookie-proxy）
+### Dashboard 鉴权
 
-v0.8.0 起 Dashboard（`@sleep2agi/agent-network-dashboard@0.4.2+`）改为**thin cookie-proxy** 模式：
+Dashboard 使用 thin cookie-proxy：
 
 - 浏览器走 username / password 登录 Dashboard → Next.js 后端拿到 `utok_` 写入 HttpOnly cookie
-- Dashboard 前端**不再持有任何长效 service token**（旧 v0.7 时代需要 `COMMHUB_AUTH_TOKEN` 或 `DASHBOARD_PASSWORD` env，已全部移除）
+- Dashboard 前端不持有长效 service token
 - 后端把请求透传到 Hub 时附上当前 session 的 `utok_` Bearer Header
 - session cookie 过期 / 用户登出 → cookie 清除 → 下次请求 401 强制重登
-
-这是 RFC-001 Phase 2 在 Dashboard 端的落地，**结合 `admin-utok.json` 本地恢复机制实现 0-token-config** 起步部署。完整设计见 [RFC-001](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md)。
 
 ## Agent 运行时安全
 
 ### 隔离策略
 
-每个 Agent Node 完全隔离，不读取宿主机配置 —— claude-agent-sdk 调 `query()` 时传 `settingSources: []`（claude-agent-sdk 入口是 `query()` 函数，不是 `new Agent({...})` 类）：
+`claude-agent-sdk` 默认用 `settingSources: []`，不会自动载入宿主的 Claude 配置：
 
 ```typescript
 const options = {
@@ -432,9 +335,11 @@ const options = {
 for await (const message of query({ prompt, options })) { /* ... */ }
 ```
 
+这不等于操作系统级隔离：Agent 获得的文件、Shell 和网络工具仍作用于宿主环境。需要强隔离时应使用容器或专用低权限账户。
+
 ### 工具权限（默认 Claude Code preset，user responsibility）
 
-从 [#101](https://github.com/sleep2agi/agent-network/issues/101) Option B 起（anet v0.9.0+），`claude-agent-sdk` runtime 的**默认 toolset 是 Claude Code preset 全集** —— 不再是空集。每个新节点 spawn 起来后就能：
+`claude-agent-sdk` runtime 的默认 toolset 是 Claude Code preset 全集。每个新节点启动后就能：
 
 - 文件系统：`Read` / `Write` / `Edit` / `Glob` / `Grep`
 - Shell：`Bash`（受 `dangerouslySkipPermissions` 默认开启影响，不弹确认）
@@ -442,8 +347,6 @@ for await (const message of query({ prompt, options })) { /* ... */ }
 - 子任务：`Task` / `NotebookEdit` / ...
 
 加上 hub 端约 40 个 MCP 工具（`commhub_send_task` / `commhub_reply` / ...）。
-
-**为啥默认改成 preset**：[#101 root cause](https://github.com/sleep2agi/agent-network/issues/101) —— 老版 `config.json` 没 `tools` 字段时 agent-node 设 SDK `options.tools = undefined`，SDK 解读为「零内建工具」，agent 只能调 MCP 工具，被问 `WebFetch` / `Bash` / `Read` 时会幻觉成「网络受限」。Option B 强制 fallback 到 SDK `{ type: 'preset', preset: 'claude_code' }` sentinel —— SDK 类型定义里这是「给我全套 Claude Code 工具」的正确表达。
 
 **控制粒度**：
 
@@ -461,7 +364,7 @@ anet node create my-agent --tools Read,Glob,Grep
 anet info my-agent           # 列 tools: + flags: 行
 ```
 
-`anet node create` 成功后 print **行为披露 banner**：built-in tools 清单（list 或 "all (Claude Code preset)"）+ MCP tools + 当前 flags（`dangerouslySkipPermissions=true` / `teammateMode=true`）+ "The agent can read/write files, run shell commands, and access the network"。Vincent [4927](https://github.com/sleep2agi/agent-network/issues/101) push 加这个 banner 的初衷：**用户必须看见，承担起 sandboxing 责任**。
+`anet node create` 成功后会打印实际工具和权限 flags。用户仍需根据工作目录和数据敏感度配置隔离。
 
 > ⚠ **User responsibility**：默认 preset + 默认 `dangerouslySkipPermissions=true` 意味着 agent 启动后能**改文件、跑 shell、访问网络且不弹确认**。请：
 > 1. **不要在 `$HOME` 直接跑 agent**，用一次性工作目录（`mkdir agent-work && cd agent-work && anet node create ...`）—— 详见 [SECURITY.md](https://github.com/sleep2agi/agent-network/blob/main/SECURITY.md)
@@ -484,13 +387,13 @@ npx @sleep2agi/agent-node --alias my-agent --max-budget 0.1
 
 ### 生产部署
 
-- [ ] `anet hub start` 后**立刻** `anet passwd` 改强密码（默认 `admin/anethub` 仅供本机快速上手）
-- [ ] **不要**设置 `COMMHUB_AUTH_TOKEN` env（v0.8 软废弃 / v1.0 移除；新部署直接走 admin `utok_` bootstrap）
+- [ ] `anet hub start` 后**立刻** `anet passwd` 改强密码
+- [ ] 新部署不要设置 legacy `COMMHUB_AUTH_TOKEN`，使用 `utok_` / `ntok_`
 - [ ] 使用 TLS（HTTPS），Caddy 自动 cert
 - [ ] 配置防火墙规则（只放 80/443）
 - [ ] 配置 CORS 白名单 `COMMHUB_CORS_ORIGINS`
 - [ ] Agent 节点用 ntok_（每个 agent 一个，hub 强制 network 锁）
-- [ ] `~/.anet/server/admin-utok.json` 权限设为 600（v0.8 bootstrap 自动）
+- [ ] 确认 `~/.anet/server/admin-utok.json` 权限为 600
 - [ ] 定期备份 `~/.commhub/commhub.db`
 - [ ] 监控审计日志（`/api/audit-log`）
 
@@ -499,18 +402,16 @@ npx @sleep2agi/agent-node --alias my-agent --max-budget 0.1
 - [ ] 限制工具权限（不要 `--tools all`）
 - [ ] 设置预算上限
 - [ ] 使用 Docker 隔离
-- [ ] 不在环境变量中硬编码密钥
+- [ ] 不把密钥明文写入 `config.json`；使用 envRef、受控 `.env` 或 secrets manager
 - [ ] `.anet/` 加入 `.gitignore`
 
 ## 下一步
 
 **深入对应实现**：
-- [RFC-001 — COMMHUB_AUTH_TOKEN 废弃路线图](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md) — 三阶段 master token 软废弃机制
 - [架构概览 — 安全章节](/guide/architecture#安全架构) — token 流和数据库表的对应
 - [账号体系](/guide/account-system) — utok_ / ntok_ / 密码 三者关系
 
 **实操**：
-- 想升级到 v0.8 admin 体系？看 [升级指南 — v0.7 → v0.8](/guide/upgrade#v0-7-v0-8-升级注意-最新)
 - 忘密码：在 Hub 机器跑 `anet hub admin reset-user <username>`
 - 修复过期 token：`anet doctor --fix` 自动 probe + 重发 ntok_
 - 改密码：`anet passwd` 交互式
@@ -518,7 +419,3 @@ npx @sleep2agi/agent-node --alias my-agent --max-budget 0.1
 **生产部署清单**：
 - [生产部署指南](/deploy/production) — TLS / 防火墙 / CORS / 备份 完整 checklist
 - [Docker 部署](/deploy/docker) — 容器化最佳实践
-
-::: warning 当前阶段
-密码哈希 = **salted scrypt**（Round-6 A1 已上线，verify [`db.ts:1057 hashPassword`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L1057)）：每密码独立随机 salt，旧 SHA-256 哈希登录时惰性迁移到 scrypt；刻意未用 Argon2id（避免原生依赖）。security report **R9** 即由此闭环。生产环境仍须配合：强密码 + TLS + 防火墙 + 定期备份。
-:::

--- a/docs-site/docs/concepts/task-lifecycle.md
+++ b/docs-site/docs/concepts/task-lifecycle.md
@@ -6,9 +6,9 @@ Task（任务）是 Agent Network 中的核心数据单元。每个任务都有�
 
 ```mermaid
 stateDiagram-v2
-    [*] --> created: send_task
+    [*] --> delivered: send_task
+    [*] --> created: 兼容/直接写库
 
-    created --> delivered: 写入 inbox + 推送 SSE
     created --> cancelled: cancel_task
     created --> acked: send_ack
     created --> expired: TTL 超时（巡检）
@@ -36,18 +36,7 @@ stateDiagram-v2
 ```
 
 ::: warning `created` 在生产路径上基本不可见
-状态机里的 `[*] → created → delivered` 是按 schema 默认值（[`server/src/db.ts:185`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L185) `status TEXT NOT NULL DEFAULT 'created'`）画的，但 **没有任何代码路径会把 `created` UPDATE 成 `delivered`**：[`server/src/tools.ts:932-933`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L932) 的 `send_task` 在 INSERT 时就直接写 `VALUES (..., 'delivered', ...)`，跳过默认值。所以正常 API 流程里**永远观察不到** `created` 这个状态。
-
-`created` 仍然作为防御性兜底出现在三条 WHERE 子句里：
-
-| 操作 | 接受的当前状态 | 源码 |
-|------|---------------|------|
-| `cancel_task` | `created` / `delivered` / `acked` / `running` | [tools.ts:1356](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1356) |
-| `send_ack`（Hub tool） | `created` / `delivered` | [tools.ts:1211](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1211) |
-| 过期巡检（patrol） | `created` / `delivered` | [index.ts:508-510](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L508) |
-| `ack_inbox`（Agent tool） | `delivered`（**仅 1 个**） | [tools.ts:710](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L710) |
-
-`ack_inbox` 和 `send_ack` 的 WHERE 子句不同 —— `ack_inbox`（agent 端 tool，L687）只接受 `delivered`，`send_ack`（hub 端 tool，L1200）接受 `created` / `delivered` 两种。「4 个可取消状态」就是 `cancel_task` 那行；本节状态机图为简化未画 `created` 的出边，实际 SQL 允许（直接构造 DB row 走 INSERT 默认值才能进入 `created` 态，REST/MCP 没有这种入口）。
+`created` 是数据库默认值，但正常 REST/MCP 发送路径会直接写入 `delivered`。它只作为兼容兜底被 `cancel_task`、`send_ack` 和过期巡检接受；`ack_inbox` 只接受 `delivered`。因此正常调用中通常看不到 `created`。
 :::
 
 ## 状态说明
@@ -81,7 +70,7 @@ sequenceDiagram
     participant A as 代码1号
 
     H->>S: send_task(alias="代码1号", task="写排序算法")
-    Note over S: 状态: created → delivered
+    Note over S: 状态: delivered
     S->>S: INSERT inbox + tasks
     S-->>A: SSE: {type: "new_task"}
 
@@ -140,7 +129,7 @@ expires_at = datetime('now', '+3600 seconds')
 ```
 
 ::: warning 过期巡检只覆盖 `created` / `delivered`
-verify [`server/src/index.ts:502-515`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L502)：过期不是实时的 —— 一个 **每 5 分钟跑一次的 patrol** 把 `expires_at < now` 且 **`status IN ('created', 'delivered')`** 的任务 UPDATE 成 `expired`。
+过期不是实时的：默认每 5 分钟运行一次 patrol，把 `expires_at < now` 且状态为 `created` 或 `delivered` 的任务改为 `expired`。可通过 `COMMHUB_TASK_PATROL_MS` 调整周期。
 
 含义：
 - 实际状态翻转最多比 `expires_at` 晚 ~5 分钟
@@ -152,7 +141,7 @@ verify [`server/src/index.ts:502-515`](https://github.com/sleep2agi/agent-networ
 失败、取消、过期的任务都可以重试：
 
 ::: tip
-下面的调用走 REST `POST /mcp`，不是 Claude Code agent 的 stdio channel wrapper。channel wrapper（[`channel/commhub-channel.ts:138-196`](https://github.com/sleep2agi/agent-network/blob/main/channel/commhub-channel.ts#L138)）只暴露 5 个 `commhub_*` tool（`commhub_reply` / `commhub_report_status` / `commhub_send_task` / `commhub_send_message` / `commhub_get_all_status`）；`cancel_task` / `retry_task` / `reassign_task` / `get_inbox` 属于管理 / Dashboard 操作，不对 agent self-service 开放。
+下面的管理调用走 REST `POST /mcp`。Claude Code channel wrapper 只暴露通信与状态工具，不提供 `cancel_task` / `retry_task` / `reassign_task` / `get_inbox`。
 :::
 
 ```bash
@@ -195,7 +184,7 @@ cancel_task(task_id="t_xxx", reason="不再需要")
 3. 记录取消原因到 result 字段
 4. 记录 task_event
 
-可取消的状态：`created` / `delivered` / `acked` / `running`（4 个状态，verify [`server/src/tools.ts:1356`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1356) `WHERE status IN ('created', 'delivered', 'acked', 'running')` —— server 的 tool description 字符串只列 3 个少一个 `created`，实际 SQL 4 个；终态 `replied` / `failed` / `cancelled` / `expired` 不能直接 cancel，需先 retry 再 cancel）
+可取消状态是 `created` / `delivered` / `acked` / `running`。终态 `replied` / `failed` / `cancelled` / `expired` 不能直接取消。
 
 ## 转移任务
 
@@ -250,7 +239,7 @@ sequenceDiagram
 
 ## 任务事件日志
 
-每个状态变更都记录到 `task_events` 表（verify [`server/src/db.ts:235-244`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L235)）：
+每个状态变更都记录到 `task_events` 表：
 
 ```sql
 CREATE TABLE task_events (
@@ -303,61 +292,18 @@ Agent 拉取 inbox 时，自动按优先级排序：
 ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END, created_at
 ```
 
-## 数据库表结构
+## 持久化字段
 
-下方是 v0.8 实际生效的 schema（含所有 ALTER TABLE migration 之后的字段）。CREATE TABLE 原文 + migrations 见 [`server/src/db.ts:178-195`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L178)（tasks 原 17 列）+ [`db.ts:702`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L702) (V3 给 `tasks` 等 6 张表加 `network_id`) + [`db.ts:989`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L989) (加 `parent_task_id`)。
-
-```sql
--- 实际 tasks 表 19 列（原 17 + migration 2）
-CREATE TABLE tasks (
-  task_id           TEXT PRIMARY KEY,
-  from_node_id      TEXT,
-  from_name         TEXT NOT NULL DEFAULT 'hub',
-  to_node_id        TEXT,
-  to_name           TEXT NOT NULL,
-  priority          TEXT NOT NULL DEFAULT 'normal',
-  status            TEXT NOT NULL DEFAULT 'created',
-  content           TEXT NOT NULL,
-  result            TEXT,
-  in_reply_to       TEXT,
-  requires_response TEXT DEFAULT 'reply',
-  scope             TEXT DEFAULT 'single',
-  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
-  delivered_at      TEXT,
-  started_at        TEXT,
-  completed_at      TEXT,
-  expires_at        TEXT,
-  network_id        TEXT,           -- ALTER (V3)
-  parent_task_id    TEXT            -- ALTER (子任务 chain)
-);
-
--- 实际 inbox 表（原 9 + migration 5）
-CREATE TABLE inbox (
-  id                TEXT PRIMARY KEY,
-  session_name      TEXT NOT NULL,
-  type              TEXT DEFAULT 'task',
-  priority          TEXT DEFAULT 'normal',
-  content           TEXT NOT NULL,
-  context           TEXT,
-  from_session      TEXT DEFAULT 'hub',
-  acked             INTEGER DEFAULT 0,
-  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
-  in_reply_to       TEXT,           -- ALTER
-  requires_response TEXT DEFAULT 'reply',  -- ALTER
-  expires_at        TEXT,           -- ALTER
-  scope             TEXT DEFAULT 'single', -- ALTER
-  network_id        TEXT            -- ALTER (V3)
-);
-```
+`tasks` 保存发送方、接收方、状态、优先级、内容、结果、过期时间、`network_id` 和可选的 `parent_task_id`；`inbox` 保存面向具体会话的投递记录。字段会随 migration 演进，集成方应使用 REST/MCP 契约，而不是依赖表列数量。
 
 ::: info `from_node_id` / `to_node_id` vs `from_name` / `to_name`
-`*_node_id` 是**持久节点 ID**（跟 `nodes` 表 join 用，agent 删除后 task 还能回查 metadata）；`*_name` 是**当时的 alias** 字符串（人类可读，渲染表用）。两者并存是因为 alias 可以重命名/重用，但 node_id 永远唯一。`from_name` 默认 `'hub'`（非 agent 发起的 task）。
+`*_node_id` 是持久节点 ID，`*_name` 是任务创建时的人类可读 alias。两者并存是为了在 alias 重命名后仍保留稳定关联；非 agent 发起的任务可使用 `from_name='hub'`。
 :::
 
 ## 下一步
 
 **实操**：
-- 发任务的 4 种方式：`commhub_send_task` MCP 工具 / Dashboard ChatPanel / REST `/api/tasks` / SSE 推送
+- 发任务的入口：`commhub_send_task`、Dashboard ChatPanel 或 REST `/api/tasks`；Hub 再通过 SSE 通知在线接收方
 - 想看任务流：[Dashboard — Tasks 面板](/guide/dashboard#tasks-任务管理)
 - 重试 / 取消失败任务：Dashboard 直接点按钮
 

--- a/docs-site/docs/en/concepts/networks.md
+++ b/docs-site/docs/en/concepts/networks.md
@@ -93,7 +93,7 @@ anet network delete old-network --force
 ```
 
 ::: warning Deleting a Network
-All agents must be stopped before deleting a network. Once deleted, all associated tasks and message data are permanently lost.
+Stop every agent in the network before deleting it. The CLI cannot undo deletion; back up the Hub database first.
 :::
 
 ## RBAC Permission Model
@@ -105,9 +105,9 @@ Each user has a role in each network. Four permission levels from highest to low
 | Role | Meaning | Who |
 |------|------|------|
 | **owner** | Network creator | The user who created the network |
-| **admin** | Administrator | Users promoted by the owner |
+| **admin** | Administrator | Joins through an admin invite or is assigned by the owner |
 | **member** | Member | Users who joined via invite code |
-| **viewer** | Read-only | Joined via `anet network invite --role viewer`; auto-join for public networks is a design goal ([Option 3](#option-3-public-networks) not implemented yet) |
+| **viewer** | Read-only | Joined via an `anet network invite --role viewer` code |
 
 ### Permission Matrix
 
@@ -116,17 +116,17 @@ Each user has a role in each network. Four permission levels from highest to low
 | Delete/rename network | &check; | | | |
 | Invite/remove members | &check; | &check; | | |
 | Create/revoke network tokens | &check; | &check; | &check; | |
-| Start Agent Node | &check; | &check; | &check; | |
+| Create an agent (`anet node create`) | &check; | &check; | &check; | |
 | Send task (send_task) | &check; | &check; | &check; | |
 | Reply to task (send_reply) | &check; | &check; | &check; | |
 | Cancel/retry task | &check; | &check; | &check; | |
 | View agent status | &check; | &check; | &check; | &check; |
 | View task list | &check; | &check; | &check; | &check; |
 
-> "Create/revoke network tokens" was previously marked member ❌. In fact [`auth.ts:303-320 createToken`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L303) only blocks **viewer** (`viewer cannot create full-access network tokens`) — owner / admin / member can all create them. Revoking goes through [`auth.ts revokeToken`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) `WHERE token_id = ? AND user_id = ?` — any user can revoke **their own** tokens, also not network-role-gated. Pure user tokens (`utok_`, no `network_id`) can be created by any logged-in user.
+> owner/admin/member can create network tokens; viewers cannot. Users can revoke only their own tokens. Any logged-in user can also create a user token without a `network_id`.
 
 ::: warning Audit log permission is **not** gated by network role
-The matrix used to list "View audit log" — but `/api/audit-log` is **not** gated by the network-level role (`owner` / `admin` / `member` / `viewer`). Verified at [`server/src/index.ts:1926-1929`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L1926):
+`/api/audit-log` is **not** gated by the network-level role (`owner` / `admin` / `member` / `viewer`):
 
 - **System admin** (`users.role='admin'`, the first registered user): can read everyone's audit log
 - **Non-admin** (`users.role='user'`): can only see their own audit log (the server auto-adds `WHERE user_id = self`)
@@ -136,15 +136,7 @@ This is a **system-level** role gate, not a **network-level** one (the `whoami` 
 
 ### Dashboard Permission Behavior
 
-The Dashboard adjusts button visibility / interactivity based on role (design goal):
-
-- **viewer** cannot see "Send Task" or "Broadcast" buttons
-- **member** cannot see "Manage Members" or "Settings" buttons
-- **admin** cannot see "Delete Network" button
-
-::: info Dashboard `0.6.0` actual behavior (current stable)
-The role → button-visibility UI binding is **partially implemented**. Even if a button is still displayed, the **server side returns 403** (`canWrite()` enforces RBAC), so permissions cannot be bypassed. Full button hiding **was not touched in any v0.9.x / v0.10.x stable release** (per-release detail in the [changelog](/en/changelog)); queued for the v0.11+ Dashboard rework.
-:::
+The Dashboard adjusts some controls based on role, but the UI is not the authorization boundary. The server applies RBAC to every request; an unauthorized action returns 403 even if a control is visible.
 
 ## Joining a Network
 
@@ -173,7 +165,7 @@ Invite code properties:
 
 ### Option 2: Cross-machine Agent Deployment {#cross-machine-deployment}
 
-**v0.8 recommended**: on each target machine, run `anet node create` **locally** — don't copy `config.json` across machines. Each machine registers its own node, and the hub mints a unique `ntok_` per node so they don't collide.
+On each target machine, run `anet node create` **locally** instead of copying `config.json`. Each machine registers independently and receives its own `ntok_`.
 
 ```bash
 # On the target machine — one step: configure hub address + login (obtain utok_)
@@ -185,22 +177,8 @@ anet node start remote-agent                    # start
 ```
 
 ::: warning Do not copy `.anet/nodes/<name>/config.json` across machines
-The `node_id` inside the config is a stable ID generated **locally** by `anet node create` (`generateNodeId()`; the CommHub `resume_id` is `sdk-${node_id}`). Copying it makes both machines use the same `node_id` → the same `resume_id`, and hub-side SSE routing breaks (whichever connection arrives first receives the task; the second one is silently ignored).
-
-If you really need to move a node from machine A to machine B (instead of creating a new one), use `anet node rename` or just re-run `anet node create` on B.
-
-> ⚠ Known gap with `anet node rename` ([#110](https://github.com/sleep2agi/agent-network/issues/110)): the node must have been started **at least once** with `anet node start` (otherwise there is no sessions row on the commhub server and `prepareRename` fails). After copying the config to B, run `anet node start` once so the server registers it, then rename. Fail-safe (PHASE 1 rollback leaves the old node intact).
+Copying config reuses the same `node_id`, alias, and node credential, making two machines claim one identity. The Hub may reject the connection or deliver work to the wrong process. Run `anet node create` on the new machine instead. For a true machine move, stop the source first and never run both copies at once.
 :::
-
-### Option 3: Public Networks
-
-::: info In Development
-Public network functionality is a design goal and not yet fully implemented.
-:::
-
-```bash
-# (Planned, not yet implemented. Tracking: https://github.com/sleep2agi/agent-network/issues/new?title=network+visibility)
-```
 
 ## System Roles vs. Network Roles
 
@@ -210,108 +188,30 @@ Agent Network has two layers of permissions:
 
 | Role | Who | Permissions |
 |------|-----|------|
-| **admin** | First registered user (automatic) | Manage all users, global statistics |
+| **admin** | First registered user (automatic) | Hub-wide user list, audit, and server logs; local password reset |
 | **user** | Subsequently registered users | Create networks, join networks |
 
 ### Layer 2: Network Roles (Per Network)
 
 Each user has an independent role in each network (owner / admin / member / viewer).
 
-The two layers stack. For example: a system admin can see global data, but if they are a viewer in a specific network, they cannot send tasks in that network.
+The two layers apply separately. A system admin can use hub-wide user, audit, and log APIs, but `/api/networks` still returns only memberships. If that user is a viewer in one network, they still cannot dispatch tasks there.
 
-## Quota Limits (v0.6 design — partially enforced in v0.8) {#quota-limits}
+## Current Quotas {#quota-limits}
 
-::: warning v0.6 quota system mostly shelved
-v0.6 designed a Free / Pro / Admin three-tier quota system (table below). After the Apache 2.0 OSS pivot **most items are shelved**, but **`createNetwork` still enforces one of them**:
-
-| Quota | v0.8 actual behavior |
-|--------|---------------|
-| **Networks created** (`max_networks_owned`) | ✅ **Still enforced** — [`auth.ts:249-262 createNetwork`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L249) reads `users.plan || "free"` and checks the `QUOTAS` cap; free defaults to **2**. Only `users.role='admin'` is exempt. |
-| Networks joined | ❌ Hub does not run quota checks on the join path |
-| Agents per network | ❌ |
-| Tasks per day | ❌ |
-| Tokens | ❌ |
-| Max network members | ❌ The `networks.max_members` column is dormant |
-
-- `anet activate <key>` is a v0.6 legacy command, **no longer the "upgrade" path** after OSS
-- Only `users.role = 'admin'` (auto-granted to the first registered user) can break through the free quota — see [troubleshooting → quota_exceeded fix](/en/troubleshooting#quota-exceeded-max-n-networks-for-free-plan)
-
-The table below is kept as a design reference for **manual soft quotas** in self-hosted admin setups (not implemented in any v0.9.x / v0.10.x stable release — per-release detail in the [changelog](/en/changelog); queued for v0.11+ / unscheduled).
-:::
-
-| Quota | Free (v0.6 design) | Pro (v0.6 design) | Admin |
-|--------|:----------:|:---------:|:-----:|
-| Networks created | 2 | 10 | Unlimited |
-| Networks joined | 3 | 20 | Unlimited |
-| Agents per network | 5 | 50 | Unlimited |
-| Tasks per day | 100 | 5000 | Unlimited |
-| Tokens | 3 | 20 | Unlimited |
-| Max network members | 5 | 50 | Unlimited |
-
-In OSS self-hosted deployments, hardware / database limits are the actual quota (SQLite single-machine validated past 100+ agents — beyond that, open an issue to discuss scaling options).
+`createNetwork()` still limits the number of networks owned by a regular user; the default free cap is 2 and `users.role='admin'` is exempt. The hub currently does not enforce the corresponding caps for joined networks, agents, daily tasks, tokens, or members. See [Troubleshooting](/en/troubleshooting#quota-exceeded-max-n-networks-for-free-plan) for `quota exceeded`.
 
 ## Server-Side Enforced Isolation
 
-Network isolation is **enforced on the server side** -- clients cannot bypass it:
-
-```typescript
-// Server-side: Extract network_id from token, don't trust client input
-const effectiveNetId = enforceNetworkId ?? clientNetId ?? null;
-
-// All queries automatically add network_id filtering
-sql = addScope(sql, params, effectiveNetId);
-// → WHERE ... AND network_id = ?
-```
+Network isolation is **enforced on the server side**:
 
 This means:
 
-- ntok_ bound to network A → all operations are restricted to network A
-- Even if the client sends `network_id=B`, the server ignores it and enforces A
-- Data across different networks is completely invisible
+- An `ntok_` is fixed to one network and cannot switch scope through request parameters
+- A `utok_` request must pass the target network's membership check
+- Task, message, node, and member queries filter by the resolved network scope
 
-## Database Tables
-
-Network-related database tables:
-
-```sql
--- Networks table
-CREATE TABLE networks (
-  -- Base schema (db.ts:413-424)
-  network_id   TEXT PRIMARY KEY,
-  network_name TEXT NOT NULL,
-  owner_id     TEXT NOT NULL,
-  description  TEXT,
-  settings     TEXT,                     -- network-level config JSON (reserved field)
-  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at   TEXT NOT NULL DEFAULT (datetime('now')),
-  UNIQUE(owner_id, network_name),         -- network name unique per owner
-  -- Columns added by the V3.13 ALTER TABLE migration (db.ts:675-676)
-  visibility   TEXT DEFAULT 'private',  -- private/public (**field exists but currently inert** — see [Quota limits — v0.6 design / partially enforced in v0.8](#quota-limits))
-  max_members  INTEGER DEFAULT 50        -- **field exists, server-side enforcement is OFF**: addNetworkMember + joinByInvite have no max_members gate. Reserved for the v0.6 quota system. See the quota-limits section below.
-);
-
--- Network members table
-CREATE TABLE network_members (
-  network_id  TEXT NOT NULL,
-  user_id     TEXT NOT NULL,
-  role        TEXT NOT NULL DEFAULT 'member',
-  invited_by  TEXT,
-  joined_at   TEXT NOT NULL DEFAULT (datetime('now')),
-  PRIMARY KEY (network_id, user_id)
-);
-
--- Invite codes table
-CREATE TABLE network_invites (
-  invite_code TEXT PRIMARY KEY,
-  network_id  TEXT NOT NULL,
-  role        TEXT NOT NULL DEFAULT 'member',
-  created_by  TEXT NOT NULL,
-  max_uses    INTEGER DEFAULT 1,
-  used_count  INTEGER DEFAULT 0,
-  expires_at  TEXT,
-  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
-);
-```
+The database stores networks, memberships, and invites in `networks`, `network_members`, and `network_invites`; use the current migrations as the source of truth for individual fields.
 
 ## Next steps
 
@@ -321,5 +221,5 @@ CREATE TABLE network_invites (
 
 **Dig deeper**:
 - Dual token boundary (utok_ vs ntok_): [Security model](/en/concepts/security)
-- How networks + accounts persist in SQLite: schema above + [Architecture](/en/guide/architecture)
+- How networks + accounts persist in SQLite: [Architecture](/en/guide/architecture)
 - Switching between multiple networks: see `anet network ls / use` in [CLI commands](/en/guide/cli)

--- a/docs-site/docs/en/concepts/roles.md
+++ b/docs-site/docs/en/concepts/roles.md
@@ -1,7 +1,7 @@
 # Roles & Permissions
 
 ::: tip One line
-Agent Network has 4 roles: `owner` / `admin` / `member` / `viewer`. **The role embedded in your `utok_` decides which APIs you can call.** After RFC-001 (landed in v0.8), there is no master-key bypass — everything is role-based.
+Each network has four membership roles: `owner`, `admin`, `member`, and `viewer`. The server checks the current user's membership in the target network; a `utok_` does not embed one fixed network role.
 :::
 
 ## The 4 roles at a glance
@@ -9,7 +9,7 @@ Agent Network has 4 roles: `owner` / `admin` / `member` / `viewer`. **The role e
 | Role | Typical use | One-liner |
 |---|---|---|
 | **owner** | Network creator, top of the hierarchy | Manage members + delete network + all admin ops |
-| **admin** | Team lead / trusted operator | Add/remove members + hub settings (Note: `/api/audit-log` / `/api/users` and other admin-only endpoints are gated by **system-level** `users.role='admin'`, **not** by network admin — see [hub-global admin](#hub-global-admin-special) below) |
+| **admin** | Team lead / trusted operator | Invite and remove members; hub-wide admin APIs require a separate system-admin identity |
 | **member** | Regular team engineer | Create agents, dispatch tasks, see network data (`anet node start/stop/delete` are local ops, not gated by role — see note ※ below) |
 | **viewer** | Intern / auditor / read-only integration | Read only, no writes |
 
@@ -42,116 +42,59 @@ Agent Network has 4 roles: `owner` / `admin` / `member` / `viewer`. **The role e
 | Delete network | ❌ | ❌ | ❌ | ✅ |
 | **Hub-global** (system-level `users.role` gate, **not** network role) | | | | |
 | `/api/audit-log` — your own rows | ✅ | ✅ | ✅ | ✅ |
-| `/api/audit-log` — all rows | Only `users.role='admin'` (verified at [`server/src/index.ts:1926-1929`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L1926)) | | | |
+| `/api/audit-log` — all rows | Only `users.role='admin'` | | | |
 | `/api/users` (list users) | Only `users.role='admin'` (same system-level gate) | | | |
 | `/api/server-logs` (debug console) | Only `users.role='admin'` | | | |
 | `anet hub admin reset-user` (reset any user's password) | Local-only CLI command on the hub host, not role-gated (the hub owner just needs local shell access) | | | |
 
-> ※ `anet node start / stop / delete` are **pure local CLI operations** — they read/write the local `.anet/nodes/<alias>/` directory directly, and `startCommand` / `deleteCommand` have **no network-role / owner / per-creator check** whatsoever. Whoever has that node config on their machine can start/stop/delete it, regardless of their network role. The only network-role-gated lifecycle op is `anet node create` (it requests an `ntok_` from the hub, and `canWrite` blocks viewer).
+> ※ `anet node start / stop / delete` are initiated from the local `.anet/nodes/<alias>/` config and do not check network membership (stop/delete still notify the Hub or clean up identity). Whoever holds that local config can run them. `anet node create`, by contrast, requires non-viewer membership to obtain a node credential.
 
-> the three MCP write tools `send_task` / `cancel_task` / `reassign_task` pass through **a single [`canWrite` gate](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L111)** (`role !== "viewer"` — owner/admin/member all pass) with **no per-task ownership check** — a member can cancel / reassign **any** task in the network, not just ones they dispatched. Renaming a network is owner-only ([`auth.ts:282 renameNetwork`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L282) `if (net.owner_id !== userId)`), same as deleting it — admin cannot rename.
+> `send_task`, `cancel_task`, and `reassign_task` are available to owner/admin/member and reject viewers. Cancel and reassign do not have an “only tasks I created” rule. Network rename and deletion are owner-only.
 
 ---
 
-## Each role in detail
+## Assigning roles
 
-### viewer
+Choose `admin`, `member`, or `viewer` when creating an invite:
 
-For interns, auditors, read-only integrations.
-
-- **Can**: any read endpoint (tasks, agent status, messages, completions), browse dashboard, **view their own audit log rows** .
-- **Cannot**: any **network-level write op** (dispatch / `cancel_task` / `reassign_task` / `anet node create` — all blocked by the `canWrite` gate); read **other users'** `/api/audit-log` rows (cross-user access needs system-level `users.role='admin'`).
-
-  > Note: `anet node start / stop / delete` are **pure local CLI operations**, not gated by network role (see note ※ on the permission matrix above) — a viewer can still start/stop/delete an existing node on their own machine. Only `anet node create` is network-role-gated (it requests an `ntok_` from the hub).
-
-Become a viewer:
 ```bash
+anet network invite --role admin --uses 1
+anet network invite --role member --uses 5
 anet network invite --role viewer --uses 1
 ```
 
-### member
-
-For engineers doing production work inside a team.
-
-- **Can**: everything viewer can; create their own agents (`anet node create`); start / stop / delete own agents; dispatch / cancel / reassign tasks (`send_task` / `cancel_task` / `reassign_task` — all gated only by `canWrite`, so a member can cancel/reassign **any** task in the network, not just their own).
-- **Cannot**: modify someone else's agents; manage members; hit admin endpoints.
-
-Become a member:
-```bash
-anet network invite --role member --uses 5      # default role is member
-anet network join <code>
-```
-
-### admin
-
-For team leads, trusted operators, anyone who needs to manage members.
-
-- **Can**: everything member can; invite new members + remove non-owner members (invite [`index.ts` `POST /api/networks/:id/invite`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) / remove [`index.ts` `DELETE /api/networks/:id/members/:id`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts): `["owner","admin"]` gate).
-
-  > Note: `anet node start / stop / delete` / editing config are **not** admin network-role privileges — they're pure local CLI operations (see note ※ on the permission matrix above), available to whoever holds the node config on their machine, regardless of network role. An admin **cannot** remotely start/stop an agent on someone else's machine.
-- **Cannot**: **change an existing member's role** — `PUT /api/networks/:id/members/:user_id` is **owner-only** ([`index.ts` `PUT /api/networks/:id/members/:id`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) `if (callerRole !== "owner")` → 403); admin can only invite / remove, not re-role existing members. Also cannot: delete the network itself; remove an owner or promote anyone to owner; **read other users' `/api/audit-log` rows** — admin-only endpoints are gated by **system-level** `users.role='admin'` (**not** network admin). A network admin sees only their own audit log rows, same as members and viewers.
-
-Become an admin:
-```bash
-# Option 1 (recommended): owner issues an admin invite — recipient joins directly with admin role
-anet network invite --role admin --uses 1
-
-# Option 2: promote an existing member via REST (current stable still has no CLI promote subcommand; queued for v0.11+ / unscheduled)
-curl -X PUT http://localhost:9200/api/networks/<net_id>/members/<user_id> \
-  -H "Authorization: Bearer <owner_utok>" \
-  -H "Content-Type: application/json" \
-  -d '{"role": "admin"}'
-# See [API — PUT members](/en/api/rest#put-api-networks-id-members-user-id)
-```
-
-### owner
-
-For network creator. Fully privileged. **Every network must have at least one owner.**
-
-- **Can**: everything admin can; delete the network; change other members' roles (`PUT /api/networks/:id/members/:user` requires the caller to be an owner — admin cannot re-role members).
-- **Protections**: cannot be downgraded or removed by an admin. If only one owner remains, that owner cannot demote or remove themselves. ⚠ The owner role **cannot be granted** to anyone (`updateMemberRole` / `createInvite` both explicitly reject `owner`) — so "multiple owners" is not a normal path; see "Become an owner" below.
-
-Become an owner:
-- Create a network: `anet network create <name>` (creator is auto-owner)
-- ⚠ **You cannot be promoted to owner via REST `PUT /members/:user_id`** — the server rejects it with `cannot assign owner role` (400). See [API — PUT members 4xx](/en/api/rest#put-api-networks-id-members-user-id). Owner is acquired only by creating the network.
+Changing an existing member uses `PUT /api/networks/:id/members/:user_id`, and only an owner may call it. `owner` cannot be assigned through an invite or that endpoint; the user who creates a network becomes its owner.
 
 ---
 
 ## Hub-global admin (special)
 
 ::: warning Different from "network admin"
-The 4 roles above are scoped to a single network. There is also a **hub-global admin** — the `admin` user created on first run. This user is automatically admin in every network and can hit hub-level management endpoints.
+The four roles above are scoped to one network. A separate system-level `users.role='admin'` can access hub-wide user, audit, and server-log endpoints, but it **does not automatically become a network admin member in every network**.
 :::
 
 | Operation | network admin | hub-global admin (`admin` user) |
 |---|---|---|
 | `/api/audit-log` — own rows | ✅ | ✅ |
-| `/api/audit-log` — all rows | ❌ (server auto-filters `WHERE user_id = self`) | ✅ (index.ts:1926-1929) |
+| `/api/audit-log` — all rows | ❌ (server auto-filters `WHERE user_id = self`) | ✅ |
 | `anet hub admin reset-user` (reset any user's password) | ❌ | ✅ (local-only) |
-| Create new users | ❌ | ✅ |
-| See all networks on the hub | ❌ (only ones they're a member of) | ✅ |
+| Create a user through the public registration endpoint | ✅ (subject to rate limits and password rules) | ✅ |
+| List every network directly | ❌ (membership list only) | ❌ (same membership list) |
 
 ---
 
 ## Where role info lives
 
-Each `utok_` is bound to a `(user_id, network_id, role)` tuple (in the `api_tokens` table's `scope` field).
+A `utok_` binds a user identity; network roles live in `network_members`. Once a request targets a network, the server looks up that user's membership. An `ntok_` additionally carries a fixed `network_id` for one-network node access.
 
-```ts
-const ctx = await resolveToken(req.headers.authorization);
-// ctx = { user_id, network_id, role: 'admin' | 'member' | ... }
-
-if (!isAdminLike(ctx.role)) return new Response("403", { status: 403 });
-```
-
-The CLI never asks you for role info — `anet login` makes the hub embed it in the token, and the CLI attaches it automatically.
+The CLI does not ask you to enter a role. After login, the server uses the user identity and target-network membership for authorization.
 
 ---
 
 ## Promote / demote a member
 
-::: warning No `promote` / `demote` CLI subcommand yet
-v0.10.x stable still has no CLI promote/demote subcommand — the v0.9.x / v0.10.x stable line never touched member-role management (per-release detail in the [changelog](/en/changelog)); the full CLI entry is queued for v0.11+ / unscheduled. Today you can list members via the CLI, but **role changes / member removal go through REST** (see [API — networks members](/en/api/rest#get-api-networks-id-members)).
+::: info Current entry points
+The CLI can list members. Use REST for role changes and member removal (see [API — networks members](/en/api/rest#get-api-networks-id-members)).
 :::
 
 ```bash
@@ -198,31 +141,19 @@ To check your role **within the current network** (owner/admin/member/viewer), r
 **Q: Can the same user have different roles in different networks?**
 A: Yes. Roles are per-network.
 
-**Q: What role does the default `admin / anethub` account have?**
+**Q: What role does the first-start `admin` account have?**
 A: First-run creation sets it as hub-global admin + owner of the default network.
 
 **Q: Can a user be admin in just one network without being hub-global admin?**
-A: Yes. Make them a network owner without granting hub `admin` (i.e., don't add them to hub-global admin users). They control that one network but cannot reach hub-level admin endpoints.
+A: Yes. Give them the network's `admin` role; their system-level `users.role` remains unchanged.
 
 **Q: Viewers really can't write anything, not even dispatch tasks?**
 A: Correct. If you want "read + occasional dispatch", grant `member`.
 
 ---
 
-## Relationship to RFC-001
-
-[RFC-001](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md) **landed in v0.8.0**: `COMMHUB_AUTH_TOKEN` is now soft-deprecated (full removal in v1.0). Hub authentication is entirely based on these 4 roles:
-
-- ✅ No master-key bypass for role checks
-- ✅ All admin ops = admin-role `utok_` + role check
-- ✅ All hub ↔ dashboard internal calls = admin user's `utok_` (Dashboard is a thin cookie-proxy)
-
-The role system is the only auth basis going forward.
-
 ## Next steps
 
-- **CLI ops for roles**: [CLI commands — network management](/en/guide/cli) (`anet network members` lists members; role changes go through REST [PUT members](/en/api/rest#put-api-networks-id-members-user-id) — the CLI `promote` / `demote` subcommands are queued for v0.11+ / unscheduled)
+- **CLI ops for roles**: [CLI commands — network management](/en/guide/cli)
 - **Token system mapping**: [Tokens](/en/concepts/tokens) — how the 4 roles relate to `utok_` / `ntok_`
 - **Full security model**: [Security design](/en/concepts/security)
-- **How v0.7 → v0.8 upgrade affects roles**: [Upgrade guide](/en/guide/upgrade#v0-7-v0-8-upgrade-notes-latest)
-- **RFC-001 roadmap**: [RFC-001](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md)

--- a/docs-site/docs/en/concepts/security.md
+++ b/docs-site/docs/en/concepts/security.md
@@ -15,7 +15,7 @@ graph TB
     subgraph "Access Control"
         RBAC[RBAC Four Levels<br/>owner/admin/member/viewer]
         NET[Network Isolation<br/>Server-side enforced]
-        SCOPE[Token Scope<br/>full/agent/readonly]
+        SCOPE[Network Membership<br/>owner/admin/member/viewer]
     end
 
     subgraph "Data Security"
@@ -25,7 +25,7 @@ graph TB
     end
 
     subgraph "Audit Trail"
-        AUDIT[Audit Log<br/>All operations recorded]
+        AUDIT[Audit Log<br/>Security-relevant operations]
         EVENTS[Task Event Log]
     end
 
@@ -36,26 +36,23 @@ graph TB
     SQL --> AUDIT
 ```
 
-::: info Actually shipped vs design goal (v0.10.11)
-The diagram above represents the **design goal**. Current v0.10.11 reality:
-
-- ✅ **Shipped**: Rate limiting / token auth (utok_/ntok_/atok_) / CORS / 4-tier RBAC / network isolation (server-enforced) / SQL-injection guards / salted scrypt password hashing / audit log / task event log
-- ⏳ **Not fully enforced**: Token Scope (`api_tokens.scope` column exists and [`auth.ts` `createToken`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) writes different scope values per token type, but [`auth.ts` `resolveToken`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) **does not return `scope` in its result** — RBAC decisions don't consume the written scope; security report **R12** was not addressed in v0.9.x or any v0.10.x scope (Recovery & Observability / Direct Runtime + Observability Foundations / Hero A+D / subsequent UX-fix chain themes took priority), queued for v0.11+ / unscheduled — see [security audit](https://github.com/sleep2agi/agent-network/blob/main/docs/open-source-security-risk-report.md))
-- ✅ **Password hashing = salted scrypt** (shipped in Round-6 A1, closing security report **R9**): Node built-in `crypto.scryptSync`, per-password random salt — verify [`db.ts:1057 hashPassword`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L1057). Argon2id was deliberately not adopted (avoids a native dep); see "Password Security" below
+::: info Current boundary
+The server enforces network binding and membership. `api_tokens.scope` is recorded, but current authorization primarily relies on the token's user/network binding and `network_members`; do not treat the `scope` string alone as proof of permission.
 :::
 
 ## Authentication
 
 ### Token System
 
-v0.8 uses a **dual-token system**:
+The current system uses three token types:
 
 | Token | Prefix | Binding | Purpose |
 |-------|------|------|------|
 | User Token | `utok_` | User | CLI / Dashboard login |
 | Network Token | `ntok_` | User + Network | Agent connection |
+| API Token | `atok_` | User, optionally network-bound | Long-lived API credential created by `anet token create` |
 
-`atok_` (the V2-era API token) has been superseded by `utok_` + `ntok_` — the code still keeps a prefix-compatibility check (it won't error), but **new users never need to touch it**; `anet token create / ls / revoke` all operate on `utok_` / `ntok_` underneath. See [Token System](/en/concepts/tokens) for details.
+See [Token System](/en/concepts/tokens) for details.
 
 ### Token Storage
 
@@ -74,9 +71,9 @@ const inputHash = hashToken(inputToken);
 const row = db.get("SELECT * FROM api_tokens WHERE token_hash = ?", inputHash);
 ```
 
-### Vendor Credential Storage (envRef mode, v0.9.0+)
+### Vendor Credential Storage (envRef mode) {#vendor-credential-storage-envref-mode-v0-9-0}
 
-When an agent node runs the `claude-agent-sdk` runtime it needs vendor API keys (`ANTHROPIC_AUTH_TOKEN` / `OPENAI_API_KEY` / `MINIMAX_KEY` …). Where they live matters a lot. Since [#125](https://github.com/sleep2agi/agent-network/issues/125) (v0.9.0 promote gate #2), the agent-node `config.json` env map **accepts two value shapes** (tagged union):
+When an agent node runs `claude-agent-sdk`, it needs vendor API keys such as `ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, or `MINIMAX_KEY`. The `config.json` env map accepts two value shapes:
 
 ```jsonc
 // Legacy shape (still works, deprecated) — plain token persisted to config.json
@@ -94,15 +91,13 @@ When an agent node runs the `claude-agent-sdk` runtime it needs vendor API keys 
 }
 ```
 
-**Why envRef**: a plain token written into `config.json` leaks into git history, dashboard payloads, `anet ls` output, error envelopes, log lines, and more. Keeping the secret in `process.env` instead means it never touches disk.
+**Why envRef**: it keeps plaintext tokens out of `config.json`, reducing exposure through git, configuration displays, and logs. The launcher can read the actual value from the process environment or a mode-0600 `.env` file in the node directory; envRef is not a “never touches disk” promise.
 
 **agent-node accepts both shapes**:
 - A bare `string` → still used as plain, prints a one-shot deprecation banner pointing at `anet node migrate-token-to-envref <alias>`
 - A `{ _envRef: "<NAME>" }` → reads `process.env[NAME]`; if the var is unset the agent **fatally exits at startup** (refuses to start silently broken) and prints an `export NAME='...'` remediation hint
 
-**`anet node create` automatically uses envRef**: after [#125](https://github.com/sleep2agi/agent-network/issues/125), `saveCreatedNode` runs `rewritePlainSecretsToEnvRef()` before writing config.json — new nodes **never persist plain secrets**; the original value is dropped into the current shell's `process.env` (so the immediate spawn works) and `export NAME='value'` lines are printed for the user to persist into `~/.bashrc` or a secrets manager.
-
-**Since v0.10.10 — envRef Option A wizard auto-source ([#193](https://github.com/sleep2agi/agent-network/issues/193))**: in addition to the `process.env` + printed `export` behavior above, `anet node create` **also** writes the API key to `.anet/nodes/<alias>/.env` (mode 0600, auto-added to `.anet/.gitignore`). When you run `anet node start <alias>` from the same shell, the `.env` is sourced automatically before launch — **no manual `export ANTHROPIC_AUTH_TOKEN_N_<id>=...` and no copy into `~/.bashrc` needed**. Cross-machine deployment still requires copying once (the wizard still prints an `export` line for that). See [cli.md `anet node create`](/en/guide/cli#anet-node-create) — the envRef wizard auto-source ::: tip block.
+**`anet node create` uses envRef automatically**: `config.json` stores only the variable name. The actual API key is written to `.anet/nodes/<alias>/.env` (mode 0600 and ignored through `.anet/.gitignore`) and loaded at startup. Cross-machine deployment still requires securely transferring that secret; see [`anet node create`](/en/guide/cli#anet-node-create).
 
 **Migrating existing nodes**:
 
@@ -118,40 +113,17 @@ anet node migrate-token-to-envref <alias>
 
 **Secret detection heuristic** (shared across agent-node / `anet node create` / `anet doctor`): env key suffix matches `/_TOKEN|_KEY|_SECRET|AUTH$/`, or value prefix matches `/sk-|utok_|ntok_|atok_|ak-|gsk_|key-|Bearer/` — either match flags the value as a secret.
 
-### Token Verification Flow (v0.8)
+### Token Verification Flow
 
-```mermaid
-flowchart TD
-    REQ[HTTP Request] --> EXTRACT[Extract Token]
-    EXTRACT --> HDR{Authorization header?}
-    HDR -->|Yes| TOKEN[Bearer token]
-    HDR -->|No| QS{URL ?token=?}
-    QS -->|Yes| TOKEN
-    QS -->|No| DEVOPEN{--dev-open?}
+The Hub parses credentials from the Bearer header (a few SSE/compatibility routes also accept a query token), checks whether the token exists, is expired, or is revoked, then applies user identity, network binding, and membership. Use `--dev-open` only for isolated local demos.
 
-    TOKEN --> RESOLVE[resolveToken<br/>Query api_tokens table]
-    RESOLVE --> FOUND{Found?}
-    FOUND -->|Yes| CHECK_EXPIRE{Expired?}
-    CHECK_EXPIRE -->|No| OK[Auth passed<br/>Extract user + network]
-    CHECK_EXPIRE -->|Yes| DENY[401]
-    FOUND -->|No| LEGACY{COMMHUB_AUTH_TOKEN<br/>set & matches?<br/>/api/* reads only}
-
-    LEGACY -->|Yes| OK_LEGACY[Auth passed<br/>+ deprecation warning<br/>removed in v1.0]
-    LEGACY -->|No| DENY
-
-    DEVOPEN -->|Yes| OK_OPEN[Open mode<br/>offline tutorial only]
-    DEVOPEN -->|No| DENY
-```
-
-::: warning Key changes in v0.8
-- The v0.5-era path where unset `COMMHUB_AUTH_TOKEN` triggered open mode is **deleted**. The hub now refuses to start without `--dev-open` unless a valid utok_/ntok_ exists.
-- The master-token compat path **only allows `/api/*` read requests**; all writes are rejected.
-- This legacy path is fully removed in v1.0 ([RFC-001 Phase 3](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md); tracking issue: [open issues: COMMHUB_AUTH_TOKEN](https://github.com/sleep2agi/agent-network/issues?q=is%3Aissue+COMMHUB_AUTH_TOKEN)).
+::: warning Legacy master token
+`COMMHUB_AUTH_TOKEN` remains a backward-compatible master path with broad privileges. Do not enable it in new deployments. Migrate older deployments to `utok_` / `ntok_`, but do not assume the compatibility path has already been removed from the code.
 :::
 
 ### Password Security
 
-- Passwords are stored with **salted scrypt** (Node built-in `crypto.scryptSync`, not SHA-256) — verified at [`server/src/db.ts:1057 hashPassword`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L1057):
+- Passwords are stored with **salted scrypt** (Node built-in `crypto.scryptSync`, not SHA-256):
   ```ts
   export function hashPassword(plain: string): string {
     const N = getScryptN();               // default 14 → 2^14≈16384 iter (~50ms), tunable via COMMHUB_SCRYPT_N
@@ -160,52 +132,34 @@ flowchart TD
     return `scrypt$${N}$${salt.toString("base64")}$${hash.toString("base64")}`;
   }
   ```
-  **Each password gets its own 16-byte random salt** (stored inside the hash string), so the same password yields a **different** hash across accounts; scrypt is memory-hard and GPU/ASIC-resistant, stronger than bcrypt. Legacy bare SHA-256 hashes are **lazily migrated** to scrypt on login (`verifyPassword` accepts both formats and rehashes in place on a legacy match). Argon2id was deliberately not used: scrypt is a Node built-in with zero new deps.
+  **Each password gets its own 16-byte random salt** (stored inside the hash string), so the same password yields a different hash across accounts. Legacy bare SHA-256 hashes are lazily migrated to scrypt after a successful login.
 
-- **Password strength** — verified at [`server/src/auth.ts:56-77 validatePasswordStrength`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L56):
+- **Password strength** is handled by the shared `validatePasswordStrength()` check:
   - User-chosen passwords (register / `anet passwd`): **≥ 8 chars** + rejected against [`password-dict.ts WEAK_PASSWORDS`](https://github.com/sleep2agi/agent-network/blob/main/server/src/password-dict.ts)
-  - Bootstrap admin **register exception**: ≥ 4 chars (so the quick-start `admin / anethub` default works) — [`auth.ts:43-44`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L43) only requires length ≥ 4 for the very first registered user; **`anet passwd` / `reset-user` have no such exemption**, always enforcing ≥ 8 + not in the weak-password dictionary
+  - The bootstrap admin's register path has a 4-character minimum. **`anet passwd` / `reset-user` do not have this exemption**: they require at least 8 characters and reject the weak-password dictionary.
   - Public deployments must rotate the password **immediately** via `anet passwd`
 
 - Usernames support letters, numbers, underscores, and Chinese characters
-- Login failures don't reveal whether the username or password was wrong ([`auth.ts:99-100`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L99) intentionally merges both errors into the same message to prevent username enumeration)
+- Login failures do not reveal whether the username or password was wrong, preventing username enumeration
 
-::: info Password hashing = salted scrypt (shipped, Round-6 A1)
-Password hashing was upgraded from the earlier SHA-256 to **salted scrypt** (`scrypt$N$salt$hash` format, a fresh random salt per password), closing security report R9. **Argon2id was deliberately not chosen** — scrypt is a Node built-in (`crypto.scryptSync`) with zero native deps, and its memory-hard, GPU/ASIC-resistant properties are sufficient; legacy SHA-256 hashes are lazily migrated on login. Token hashes (`hashToken` uses bare SHA-256 without a salt) don't need any of this — tokens are 128-bit random strings, so rainbow tables don't apply.
+::: info Passwords and tokens use different hash strategies
+Passwords use scrypt with a fresh salt; legacy SHA-256 password hashes are lazily migrated after a successful login. Tokens are high-entropy random values, and the database stores only their SHA-256 hashes.
 :::
 
 ## Authorization
 
 ### RBAC Permission Checks
 
-Every MCP tool call goes through a permission check ([`server/src/tools.ts:106 canWrite`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L106)):
-
-```typescript
-const canWrite = (effectiveNetworkId?: string | null): boolean => {
-  if (!enforceUserId) return true; // legacy global-token mode (dev-open / atok_ only)
-  // ntok_: enforceNetworkId is locked by the token; utok_: use effectiveNetworkId from the MCP call
-  const netId = enforceNetworkId ?? effectiveNetworkId ?? null;
-  if (!netId) return false;        // no resolvable network → deny
-  const role = getUserNetworkRole(enforceUserId, netId);
-  return !!role && role !== "viewer"; // owner/admin/member can write
-};
-```
+MCP write tools use a shared `canWrite` check against membership in the target network:
 
 **Key points**:
 - `ntok_` → `enforceNetworkId` is locked by the token; the server **does not honor** any client-supplied network_id (prevents cross-network writes).
-- `utok_` → `enforceNetworkId` is empty, so the server **accepts** the `effectiveNetworkId` passed in the MCP call and checks `network_members.role`.
+- `utok_` → the server resolves a target network and checks `network_members.role`.
 - Regardless of token type, a `viewer` role is denied on writes.
 
 ### Server-Side Network Enforcement
 
-This is the core of the security design -- the network ID is **never trusted from the client**:
-
-```typescript
-// Server extracts network_id from token, ignores client-provided value
-const getNetworkId = (clientNetId) => enforceNetworkId ?? clientNetId ?? null;
-```
-
-Even if the client sends `network_id=other_network`, the server ignores it and enforces the token-bound network.
+An `ntok_` has a token-bound network that client parameters cannot override. A `utok_` may select a target network, but the server verifies that the user is a member; it does not trust an arbitrary client-supplied network ID.
 
 ### REST API Permissions
 
@@ -215,9 +169,9 @@ REST API automatically scopes based on token type:
 |-----------|-------------|
 | `ntok_` | Only bound network data |
 | `utok_` | All networks the user belongs to |
-| `atok_` (full) | All networks the user belongs to |
-| Global Token | All data |
-| System admin | All data |
+| `atok_` | Bound network only when scoped; otherwise the user's memberships |
+| Legacy master token | Generic REST scope; not a substitute for endpoints requiring a concrete user membership |
+| System admin | Hub-wide admin and cross-network query routes; membership management still checks the caller's role in that network |
 
 ## Rate Limiting
 
@@ -229,44 +183,22 @@ REST API automatically scopes based on token type:
 | `POST /api/auth/login` | 10/min | Prevent brute force |
 
 ::: info register and login use different mechanisms
-- **register**: the generic `checkRateLimit()` (30/min) — verify [`index.ts` `checkRateLimit()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts). The `maxPerMinute = 60` default is reserved for future expansion.
-- **login**: a dedicated `LoginIpRateLimiter` (10 requests per 60-second window, per IP) **plus** a failure-based progressive account lockout (triggered after ≥ 5 consecutive failures; lock duration starts at 30 s and backs off exponentially up to a 15-minute cap) — verify [`server/src/auth_login_guard.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth_login_guard.ts).
+- **register**: the generic `checkRateLimit()` (30/min).
+- **login**: a dedicated `LoginIpRateLimiter` (10 requests per 60-second window, per IP) **plus** progressive account lockout after ≥ 5 consecutive failures (30 seconds initially, exponential backoff to 15 minutes).
 - **No other endpoint rate-limits per IP** — if you're worried about write abuse, layer rate limiting at a reverse proxy (nginx / Cloudflare / etc.) in front.
 :::
 
-### Implementation
-
-```typescript
-// In-memory store, per IP (verify `checkRateLimit()` in index.ts)
-const rateLimits = new Map<string, { count: number; resetAt: number }>();
-
-function checkRateLimit(ip: string, maxPerMinute = 60): boolean {
-  // localhost / internal / unknown exempt (dev/testing)
-  if (!ip || ip === "unknown" || ip === "127.0.0.1" || ip === "::1") return true;
-
-  const now = Date.now();
-  const entry = rateLimits.get(ip);
-  if (!entry || now > entry.resetAt) {
-    rateLimits.set(ip, { count: 1, resetAt: now + 60000 });
-    return true;
-  }
-  if (entry.count >= maxPerMinute) return false;  // at limit, no further ++
-  entry.count++;
-  return true;
-}
-```
-
-When the limit is exceeded the server returns HTTP 429 with a body like:
+### 429 responses
 
 ```json
 { "ok": false, "error": "too many requests, try again later" }
 ```
 
-(the register 429 body is shown above; `/login` goes through the dedicated guard — an IP-limit hit returns `error: "rate_limited"` and a failure-lockout hit returns `error: "login_locked"`, **both with a `Retry-After` header and a `retry_after_ms` field in the body**, and the server writes audit `action='login_rate_limited'` with the client IP. Verify [`server/src/auth_login_guard.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth_login_guard.ts).)
+That is the register response. Login returns `rate_limited` for the IP limit or `login_locked` for account lockout; both include `Retry-After` and `retry_after_ms`.
 
 ### Localhost Exemption
 
-localhost (`127.0.0.1` / `::1`), plus requests whose IP resolves to empty / `"unknown"`, are exempt from rate limiting for convenient development and testing ([`index.ts` `checkRateLimit()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)).
+The generic register limiter exempts localhost and `"unknown"`. The dedicated login limiter **does not**. In production, use a trusted reverse proxy to supply the client IP and add a gateway-level rate limit.
 
 ## CORS Configuration
 
@@ -279,49 +211,23 @@ COMMHUB_CORS_ORIGINS="https://dashboard.example.com" anet hub start
 ```
 
 ::: warning CORS default is **not** `*`
-Verify [`index.ts` `CORS_ORIGINS`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts): when `COMMHUB_CORS_ORIGINS` is unset the default allowlist is `["http://localhost:3000", "http://localhost:3001"]` (**localhost dev origins only**), **not** `*`. Setting `COMMHUB_CORS_ORIGINS` (comma-separated) **fully replaces** that default.
+When `COMMHUB_CORS_ORIGINS` is unset, the allowlist is `http://localhost:3000` and `http://localhost:3001`, **not** `*`. Setting the variable fully replaces the defaults.
 
 `Access-Control-Allow-Origin` echoes the request `Origin` only when it's in the allowlist, otherwise it returns an empty string (the browser then blocks the cross-origin request). No author-specific domains are hardcoded — production deployments serving the Dashboard cross-origin must set `COMMHUB_CORS_ORIGINS` explicitly.
 :::
 
 ## Audit Logging
 
-All key operations are recorded in the `audit_log` table (verify [`server/src/db.ts:201-212`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L201)):
+Important operations are written to `audit_log` with the caller, action, target, details, IP, network, and timestamp. Actions grow with product capabilities, so this page does not pin a count.
 
-```sql
-CREATE TABLE audit_log (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  user_id       TEXT,
-  username      TEXT,
-  action        TEXT NOT NULL,
-  target_type   TEXT,           -- 'user' / 'network' / 'token' / 'auth' / ...
-  target_id     TEXT,           -- linked user_id / network_id / token_id
-  detail        TEXT,           -- e.g. '<user_id> as <role>' / '<old> → <new>'
-  ip            TEXT,           -- client IP (rate-limited paths set this)
-  network_id    TEXT,           -- the network the operation happened in
-  created_at    TEXT NOT NULL DEFAULT (datetime('now'))
-);
-```
+Common action groups:
 
-Recorded `action` values (**19 total**; verify `grep logAudit server/src/*.ts + auth.ts resetUserPassword() + cli.ts` — 18 go through the [`logAudit()` helper](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L447), `password_reset_by_admin` is a direct INSERT at [`auth.ts` `resetUserPassword()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts)):
+- Login and password: `register`, `login`, `login_failed`, `login_rate_limited`, `login_locked`, `password_changed`
+- Networks and members: `network_renamed`, `network_deleted`, `network_joined`, `member_*`, `invite_created`
+- Tokens and nodes: `token_*`, `node_token_created`, `node_rename_*`, `node_attrs_updated`
 
-| Operation | Trigger |
-|------|---------|
-| `register` | User registration ([`index.ts` `POST /api/auth/register`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) |
-| `login` | Successful login |
-| `login_failed` | Login failure (wrong password / unknown username) |
-| `login_rate_limited` | Login hit the IP rate limit (10/min) |
-| `password_changed` | `anet passwd` ([`index.ts` `POST /api/auth/password`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) |
-| `password_reset_by_admin` | hub admin force-reset via `anet hub admin reset-user` ([`auth.ts` `resetUserPassword()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)) |
-| `network_renamed` / `network_deleted` / `network_joined` | Network rename / delete / join |
-| `member_added` / `member_role_changed` / `member_removed` | Network membership changes (`detail` records `<user_id> as <role>` / `<user_id> → <role>`) |
-| `token_created` / `token_revoked` | API-token lifecycle |
-| `node_token_created` | `anet node create` auto-mints an `ntok_` |
-| `node_rename_prepared` / `node_rename_committed` / `node_rename_aborted` | RFC-010 node-rename two-phase transaction (one audit row each for PREPARE / COMMIT / ABORT) |
-| `invite_created` | Network invite code creation |
-
-::: info `create_network` / `network_created` is NOT audited
-Today's POST `/api/networks` handler ([`index.ts` `POST /api/networks`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) does not call `logAudit`, so new networks leave no audit row. Only rename / delete / join write audit entries.
+::: info Network creation is not currently audited
+POST `/api/networks` does not write `create_network` or `network_created`. Do not depend on those nonexistent actions.
 :::
 
 ### Querying Audit Logs
@@ -334,7 +240,7 @@ curl -H "Authorization: Bearer $UTOK" "$HUB/api/audit-log?limit=50"
 
 ## SQL Injection Protection
 
-All database operations use parameterized queries:
+Database queries bind parameters instead of concatenating user input:
 
 ```typescript
 // Correct: Parameterized query
@@ -344,12 +250,11 @@ db.run("SELECT * FROM sessions WHERE alias = ?1", [alias]);
 db.run(`SELECT * FROM sessions WHERE alias = '${alias}'`);
 ```
 
-All `db.run()` / `db.get()` / `db.all()` calls ([currently 150+ across `server/src/*.ts`](https://github.com/sleep2agi/agent-network/tree/main/server/src)) use parameterized binding. (The older "85+" figure was a v0.5-era estimate; the server codebase has roughly doubled since.)
-
 ## Database Security
 
 ::: tip The backend is SQLite — the integrity guarantees are SQLite-based too
 anet runs on **SQLite** in production (`~/.commhub/commhub.db`). The integrity and isolation guarantees in this section (and in authorization / audit) rest on SQLite's transaction / constraint semantics. The code has a `DATABASE_URL` PostgreSQL entry point, but it is **not end-to-end verified and not recommended for production** (see [FAQ — PostgreSQL support?](/en/faq#_20-what-about-postgresql-support)).
+:::
 
 ### SQLite WAL Mode
 
@@ -372,9 +277,9 @@ chmod 600 ~/.commhub/commhub.db
 
 | Data | Storage method | Details |
 |------|---------|------|
-| Passwords | salted scrypt (`scrypt$N$salt$hash`) | [db.ts:1057](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L1057); fresh random salt per password, legacy SHA-256 lazily migrated on login |
-| Tokens | SHA-256 hash (no salt) | Tokens are `crypto.randomUUID()` 128-bit random values; rainbow tables do not apply |
-| API keys | Not stored (only `process.env` / `config.env`) | Agent-node reads `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from env; the hub's DB does not store them |
+| Passwords | salted scrypt (`scrypt$N$salt$hash`) | fresh random salt per password, legacy SHA-256 lazily migrated on login |
+| Tokens | SHA-256 hash (no salt) | Tokens come from `crypto.randomUUID()`; plaintext is not stored in the database |
+| API keys | Not stored in the Hub database | agent-node reads process environment or a node `.env`; envRef keeps only the variable name in `config.json` |
 | Task content | Plaintext | The `tasks.content` column; on a shared hub, admins can read everything. `audit_log` does not contain task bodies |
 | Audit logs | Plaintext | `audit_log` has 10 columns including `user_id` / `username` / `action` / `detail` / `ip` / `network_id` |
 
@@ -405,24 +310,22 @@ COMMHUB_CORS_ORIGINS="https://dashboard.example.com"
 
 ### SSE Connection Security
 
-SSE connections use the same authentication mechanism as the REST API (Bearer Token / URL token parameter). **From v0.8.1, agent-node auto-reloads its token and reconnects when SSE returns 401**, so an expired ntok_ no longer leaves the agent silently offline.
+SSE connections use the same authentication mechanism as the REST API (Bearer Token / URL token parameter). agent-node reloads its token and reconnects after an SSE 401.
 
-### Dashboard auth (v0.8 thin cookie-proxy)
+### Dashboard auth
 
-From v0.8.0, the Dashboard (`@sleep2agi/agent-network-dashboard@0.4.2+`) runs as a **thin cookie-proxy**:
+The Dashboard runs as a thin cookie-proxy:
 
 - Browser logs into the Dashboard with username / password → Next.js backend obtains a `utok_` and writes it to an HttpOnly cookie
-- The Dashboard frontend **no longer holds any long-lived service token** (the v0.7-era `COMMHUB_AUTH_TOKEN` / `DASHBOARD_PASSWORD` env vars are gone)
+- The Dashboard frontend does not hold a long-lived service token
 - The backend forwards requests to the Hub with the current session's `utok_` Bearer header
 - Session cookie expires / user logs out → cookie cleared → next request returns 401, forcing re-login
-
-This is the Dashboard side of RFC-001 Phase 2 landing. **Combined with `admin-utok.json` local recovery, the project ships with 0-token-config quick-start**. Full design: [RFC-001](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md).
 
 ## Agent Runtime Security
 
 ### Isolation Strategy
 
-Each Agent Node is fully isolated and does not read host machine config — claude-agent-sdk passes `settingSources: []` to `query()` (the SDK entry point is the `query()` function, not a `new Agent({...})` class):
+`claude-agent-sdk` defaults to `settingSources: []`, so it does not automatically load host Claude configuration:
 
 ```typescript
 const options = {
@@ -432,9 +335,11 @@ const options = {
 for await (const message of query({ prompt, options })) { /* ... */ }
 ```
 
+This is not operating-system isolation. Filesystem, shell, and network tools still act on the host environment. Use a container or a dedicated low-privilege account when stronger isolation is required.
+
 ### Tool Permissions (default = Claude Code preset, user responsibility)
 
-Since [#101](https://github.com/sleep2agi/agent-network/issues/101) Option B (anet v0.9.0+), the `claude-agent-sdk` runtime's **default toolset is the full Claude Code preset** — not an empty set. Every new node, right after spawn, can:
+The `claude-agent-sdk` runtime defaults to the full Claude Code preset. A newly started node can:
 
 - Filesystem: `Read` / `Write` / `Edit` / `Glob` / `Grep`
 - Shell: `Bash` (subject to `dangerouslySkipPermissions=true` on by default — no per-call confirmation)
@@ -442,8 +347,6 @@ Since [#101](https://github.com/sleep2agi/agent-network/issues/101) Option B (an
 - Subtasks: `Task` / `NotebookEdit` / ...
 
 Plus the ~40 MCP tools on the hub side (`commhub_send_task` / `commhub_reply` / ...).
-
-**Why the default changed to preset**: [#101 root cause](https://github.com/sleep2agi/agent-network/issues/101) — when `config.json` had no `tools` field, agent-node set the SDK's `options.tools = undefined`, which the SDK reads as "zero built-in tools". Agents could only call MCP tools and hallucinated "network restricted" when asked for `WebFetch` / `Bash` / `Read`. Option B forces the fallback to the SDK `{ type: 'preset', preset: 'claude_code' }` sentinel — per the SDK type definitions this is the right way to say "give me the full Claude Code toolset".
 
 **Granularity**:
 
@@ -461,7 +364,7 @@ anet node create my-agent --tools Read,Glob,Grep
 anet info my-agent           # prints tools: + flags: lines
 ```
 
-After a successful `anet node create`, agent-node prints a **behavior-disclosure banner**: the built-in tools (list or `"all (Claude Code preset)"`) + MCP tools + current flags (`dangerouslySkipPermissions=true` / `teammateMode=true`) + the sentence "The agent can read/write files, run shell commands, and access the network". Vincent [4927](https://github.com/sleep2agi/agent-network/issues/101) pushed for this banner so **users actually see what they signed up for and take ownership of sandboxing**.
+After `anet node create`, the CLI prints the effective tools and permission flags. You still need to choose isolation appropriate to the working directory and data sensitivity.
 
 > ⚠ **User responsibility**: the default preset + default `dangerouslySkipPermissions=true` means the agent can **edit files, run shell commands, and access the network without confirmation prompts**. Please:
 > 1. **Do NOT run agents from `$HOME` directly** — use a disposable working directory (`mkdir agent-work && cd agent-work && anet node create ...`); see [SECURITY.md](https://github.com/sleep2agi/agent-network/blob/main/SECURITY.md)
@@ -484,13 +387,13 @@ Or persist it via `flags.maxBudgetUsd` in `config.json`.
 
 ### Production Deployment
 
-- [ ] Run `anet passwd` **immediately** after `anet hub start` to change the strong password (the `admin/anethub` default is for local quick-start only)
-- [ ] **Do NOT** set `COMMHUB_AUTH_TOKEN` env (soft-deprecated v0.8 / removed v1.0; new deployments go through admin `utok_` bootstrap)
+- [ ] Run `anet passwd` **immediately** after `anet hub start`
+- [ ] Do not set legacy `COMMHUB_AUTH_TOKEN` in new deployments; use `utok_` / `ntok_`
 - [ ] Use TLS (HTTPS); Caddy auto-cert recommended
 - [ ] Configure firewall rules (only open 80/443)
 - [ ] Configure CORS whitelist via `COMMHUB_CORS_ORIGINS`
 - [ ] Agent nodes use `ntok_` (one per agent, hub enforces network binding)
-- [ ] Set `~/.anet/server/admin-utok.json` permissions to 600 (v0.8 bootstrap does this automatically)
+- [ ] Confirm `~/.anet/server/admin-utok.json` has mode 600
 - [ ] Regular `~/.commhub/commhub.db` backups
 - [ ] Monitor audit log (`/api/audit-log`)
 
@@ -499,18 +402,16 @@ Or persist it via `flags.maxBudgetUsd` in `config.json`.
 - [ ] Restrict tool permissions (avoid `--tools all`)
 - [ ] Set budget caps
 - [ ] Use Docker for isolation
-- [ ] Don't hardcode secrets in environment variables
+- [ ] Do not store plaintext secrets in `config.json`; use envRef, a protected `.env`, or a secrets manager
 - [ ] Add `.anet/` to `.gitignore`
 
 ## Next steps
 
 **Dig into the implementation**:
-- [RFC-001 — `COMMHUB_AUTH_TOKEN` deprecation roadmap](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-001-deprecate-commhub-auth-token.md) — three-phase master-token soft-deprecation
 - [Architecture — Security section](/en/guide/architecture#security-architecture) — token flow and the corresponding DB tables
 - [Account system](/en/guide/account-system) — relationship between utok_ / ntok_ / password
 
 **Hands-on**:
-- Upgrade to the v0.8 admin model: [Upgrade guide — v0.7 → v0.8](/en/guide/upgrade#v0-7-v0-8-upgrade-notes-latest)
 - Forgot password: run `anet hub admin reset-user <username>` on the Hub machine
 - Repair expired tokens: `anet doctor --fix` auto-probes and reissues ntok_
 - Change password: `anet passwd` interactive
@@ -518,7 +419,3 @@ Or persist it via `flags.maxBudgetUsd` in `config.json`.
 **Production deployment checklist**:
 - [Production deployment](/en/deploy/production) — full TLS / firewall / CORS / backup checklist
 - [Docker deployment](/en/deploy/docker) — containerization best practices
-
-::: warning Current state
-Password hashing = **salted scrypt** (shipped in Round-6 A1, verify [`db.ts:1057 hashPassword`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L1057)): a fresh random salt per password, with legacy SHA-256 hashes lazily migrated to scrypt on login; Argon2id was deliberately not used (avoids a native dep). This closes security report **R9**. Production environments must still pair this with: strong passwords + TLS + firewall + regular backups.
-:::

--- a/docs-site/docs/en/concepts/task-lifecycle.md
+++ b/docs-site/docs/en/concepts/task-lifecycle.md
@@ -6,9 +6,9 @@ A Task is the core data unit in Agent Network. Every task has a complete lifecyc
 
 ```mermaid
 stateDiagram-v2
-    [*] --> created: send_task
+    [*] --> delivered: send_task
+    [*] --> created: compatibility/direct insert
 
-    created --> delivered: Write to inbox + SSE push
     created --> cancelled: cancel_task
     created --> acked: send_ack
     created --> expired: TTL timeout (patrol)
@@ -36,18 +36,7 @@ stateDiagram-v2
 ```
 
 ::: warning `created` is essentially invisible on the production path
-The diagram's `[*] → created → delivered` reflects the **schema default** ([`server/src/db.ts:185`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L185) `status TEXT NOT NULL DEFAULT 'created'`), but **no code path UPDATEs `created` to `delivered`**: [`server/src/tools.ts:932-933`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L932) `send_task` inserts with `VALUES (..., 'delivered', ...)` directly, bypassing the default. So through normal API flows you'll **never observe** a task in `created` state.
-
-`created` still appears in three WHERE clauses defensively:
-
-| Operation | Accepted source states | Source |
-|------|------------------------|------|
-| `cancel_task` | `created` / `delivered` / `acked` / `running` | [tools.ts:1356](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1356) |
-| `send_ack` (Hub tool) | `created` / `delivered` | [tools.ts:1211](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1211) |
-| Expiration patrol | `created` / `delivered` | [index.ts:508-510](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L508) |
-| `ack_inbox` (Agent tool) | `delivered` (**only 1**) | [tools.ts:710](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L710) |
-
-`ack_inbox` and `send_ack` have different WHERE clauses — `ack_inbox` (agent-side tool, L687) accepts only `delivered`, while `send_ack` (hub-side tool, L1200) accepts `created` / `delivered`. The "4 cancellable states" are exactly the `cancel_task` row. The state diagram above doesn't draw `created`'s outgoing edges for simplicity; SQL allows them, but the only way a row enters the `created` state is a direct DB INSERT that omits the status column — no REST/MCP entry point does that.
+`created` is the database default, but normal REST/MCP dispatch writes `delivered` directly. It remains a compatibility state accepted by `cancel_task`, `send_ack`, and the expiration patrol; `ack_inbox` accepts only `delivered`. Normal callers therefore rarely observe `created`.
 :::
 
 ## Status Reference
@@ -81,7 +70,7 @@ sequenceDiagram
     participant A as Coder-1
 
     H->>S: send_task(alias="coder-1", task="Write a sorting algorithm")
-    Note over S: Status: created → delivered
+    Note over S: Status: delivered
     S->>S: INSERT inbox + tasks
     S-->>A: SSE: {type: "new_task"}
 
@@ -140,7 +129,7 @@ expires_at = datetime('now', '+3600 seconds')
 ```
 
 ::: warning The expiry patrol only covers `created` / `delivered`
-Verify [`server/src/index.ts:502-515`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L502): expiration is not real-time — a **patrol that runs every 5 minutes** UPDATEs tasks with `expires_at < now` **and `status IN ('created', 'delivered')`** to `expired`.
+Expiry is not real-time. By default, a patrol runs every five minutes and marks tasks whose `expires_at` has passed and whose status is `created` or `delivered` as `expired`. `COMMHUB_TASK_PATROL_MS` can override the interval.
 
 Implications:
 - The actual status flip can lag `expires_at` by up to ~5 minutes
@@ -152,7 +141,7 @@ Implications:
 Failed, cancelled, and expired tasks can all be retried:
 
 ::: tip
-The following calls go via REST `POST /mcp` rather than the Claude Code agent's stdio channel wrapper. The channel wrapper ([`channel/commhub-channel.ts:138-196`](https://github.com/sleep2agi/agent-network/blob/main/channel/commhub-channel.ts#L138)) exposes 5 `commhub_*` tools (`commhub_reply` / `commhub_report_status` / `commhub_send_task` / `commhub_send_message` / `commhub_get_all_status`); `cancel_task` / `retry_task` / `reassign_task` / `get_inbox` are admin / dashboard ops and not exposed to agent self-service.
+The management calls below go through REST `POST /mcp`. The Claude Code channel wrapper exposes communication and status tools, not `cancel_task`, `retry_task`, `reassign_task`, or `get_inbox`.
 :::
 
 ```bash
@@ -195,7 +184,7 @@ Cancellation will:
 3. Record the cancellation reason in the result field
 4. Log a task_event
 
-Cancellable statuses: `created` / `delivered` / `acked` / `running` (4 statuses — verified at [`server/src/tools.ts:1356`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1356) `WHERE status IN ('created', 'delivered', 'acked', 'running')`. The tool's own description string only mentions 3 (missing `created`); the SQL is the source of truth with 4. Terminal states `replied` / `failed` / `cancelled` / `expired` cannot be cancelled directly — retry first, then cancel.)
+Cancellable statuses are `created`, `delivered`, `acked`, and `running`. Terminal states (`replied`, `failed`, `cancelled`, `expired`) cannot be cancelled directly.
 
 ## Reassigning Tasks
 
@@ -250,7 +239,7 @@ By distinguishing types, only `task` and `broadcast` trigger processing, while `
 
 ## Task Event Log
 
-Every status change is recorded in the `task_events` table (verified at [`server/src/db.ts:235-244`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L235)):
+Every status change is recorded in the `task_events` table:
 
 ```sql
 CREATE TABLE task_events (
@@ -303,61 +292,18 @@ When agents fetch their inbox, items are automatically sorted by priority:
 ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END, created_at
 ```
 
-## Database Table Schema
+## Persisted fields
 
-Below is the schema as it actually exists in v0.8 (after all ALTER TABLE migrations). The original CREATE TABLE and migrations live in [`server/src/db.ts:178-195`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L178) (tasks, 17 original columns), [`db.ts:702`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L702) (V3 adds `network_id` to `tasks` and 5 other tables), and [`db.ts:989`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L989) (adds `parent_task_id`).
-
-```sql
--- Effective tasks schema: 19 columns (17 original + 2 migrations)
-CREATE TABLE tasks (
-  task_id           TEXT PRIMARY KEY,
-  from_node_id      TEXT,
-  from_name         TEXT NOT NULL DEFAULT 'hub',
-  to_node_id        TEXT,
-  to_name           TEXT NOT NULL,
-  priority          TEXT NOT NULL DEFAULT 'normal',
-  status            TEXT NOT NULL DEFAULT 'created',
-  content           TEXT NOT NULL,
-  result            TEXT,
-  in_reply_to       TEXT,
-  requires_response TEXT DEFAULT 'reply',
-  scope             TEXT DEFAULT 'single',
-  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
-  delivered_at      TEXT,
-  started_at        TEXT,
-  completed_at      TEXT,
-  expires_at        TEXT,
-  network_id        TEXT,           -- ALTER (V3)
-  parent_task_id    TEXT            -- ALTER (sub-task chain)
-);
-
--- Effective inbox schema (9 original + 5 migrations)
-CREATE TABLE inbox (
-  id                TEXT PRIMARY KEY,
-  session_name      TEXT NOT NULL,
-  type              TEXT DEFAULT 'task',
-  priority          TEXT DEFAULT 'normal',
-  content           TEXT NOT NULL,
-  context           TEXT,
-  from_session      TEXT DEFAULT 'hub',
-  acked             INTEGER DEFAULT 0,
-  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
-  in_reply_to       TEXT,           -- ALTER
-  requires_response TEXT DEFAULT 'reply',  -- ALTER
-  expires_at        TEXT,           -- ALTER
-  scope             TEXT DEFAULT 'single', -- ALTER
-  network_id        TEXT            -- ALTER (V3)
-);
-```
+`tasks` stores sender, recipient, status, priority, content, result, expiry, `network_id`, and an optional `parent_task_id`. `inbox` stores delivery records for individual sessions. Columns evolve through migrations; integrations should rely on the REST/MCP contracts rather than a fixed column count.
 
 ::: info `from_node_id` / `to_node_id` vs `from_name` / `to_name`
-`*_node_id` is the **persistent node ID** (joins against the `nodes` table — useful for looking up metadata even after the agent is deleted). `*_name` is the **alias as a string at the time of writing** (human-readable, used in table renders). Both exist because aliases can be renamed or reused, while `node_id` is permanently unique. `from_name` defaults to `'hub'` for tasks dispatched by the hub itself (not by an agent).
+`*_node_id` is the persistent node ID, while `*_name` is the human-readable alias captured when the task was created. Keeping both preserves stable linkage after an alias is renamed. Non-agent-originated tasks may use `from_name='hub'`.
 :::
 
 ## Next steps
 
 **Hands-on**:
-- 4 ways to send a task: `commhub_send_task` MCP tool / Dashboard ChatPanel / REST `/api/tasks` / SSE push
+- Send tasks through `commhub_send_task`, the Dashboard ChatPanel, or REST `/api/tasks`; the Hub then notifies online recipients over SSE
 - View the task flow: [Dashboard — Tasks panel](/en/guide/dashboard#tasks)
 - Retry / cancel failed tasks: click the buttons in the Dashboard
 


### PR DESCRIPTION
## What changed

- Simplified the bilingual Security, Roles, Networks, and Task Lifecycle concept pages.
- Reduced the eight pages from 2,921 to 2,233 lines (net -688).
- Removed all 28 stale `server/src/index.ts` references from this slice, plus drift-prone source line anchors.
- Kept stable endpoint, command, table, and function names where implementation detail is useful.

## Factual corrections

- `utok_` identifies a user; network roles live in `network_members` rather than being embedded in the token.
- `anet token create` still creates an `atok_`; the token model has three active token types, not two.
- envRef keeps plaintext out of `config.json`, but the node wizard intentionally writes a protected mode-0600 `.env`; it is not a “never touches disk” guarantee.
- Public registration is not restricted to the Hub-global admin.
- Hub-global admin does not automatically become a member/admin of every network, and `/api/networks` remains membership-scoped.
- Network deletion does not justify the old claim that all task/message rows are deleted.
- Local node start/stop/delete and network membership authorization are now described separately.
- Normal task dispatch starts at `delivered`; `created` remains a compatibility/database-default state.
- SSE is described as the delivery notification transport, not a fourth task-submission API.
- Legacy `COMMHUB_AUTH_TOKEN` is documented as a broad compatibility path that still exists, rather than a removed/read-only path.

## Why

The pages had accumulated release history, roadmap notes, copied schemas, exact line links, and several claims that no longer matched current behavior. This made the docs both verbose and unsafe to use as an authorization or operations reference.

## Validation

- `git diff --check`
- Markdown fence parity for all eight files
- VitePress custom-container open/close parity for all eight files
- Negative searches for stale `index.ts`/line references and the removed false claims
- Source-evidence checks against current `origin/main` for token generators, role gates, task states, patrol interval, CORS defaults, envRef rewrite, `settingSources: []`, and the Claude Code tool preset

This is a docs-only Draft PR. No code, API, schema, package, or published artifact changes.