### PR TITLE
docs: simplify and correct channel guide

### DIFF
--- a/docs-site/docs/en/guide/channels.md
+++ b/docs-site/docs/en/guide/channels.md
@@ -1,264 +1,115 @@
-# Channel Integration
+# Channel integration
 
-Channels enable Agent Network to connect with external communication platforms. Currently supported: Telegram, WeChat, and Feishu.
+Channels deliver Telegram or Feishu messages to a node and send its text response back to the original conversation.
 
-## How It Works
+| Channel | Status | Setup command |
+|---|---|---|
+| Telegram | Supported | `anet channel add telegram <node>` |
+| Feishu | Supported in preview | `anet channel add feishu <node>` |
+| WeChat | Not available in the CLI | None |
 
-Channels are mounted as MCP Server plugins on Claude Code or Agent Node. When an external message arrives, the channel plugin formats it and injects it into the agent's context:
+## Telegram
 
-```mermaid
-sequenceDiagram
-    participant U as User
-    participant TG as Telegram
-    participant CH as Channel Plugin
-    participant A as Agent (Claude Code)
-    participant S as CommHub Server
+### 1. Create a bot and get your user ID
 
-    U->>TG: Send message
-    TG->>CH: Bot API webhook
-    CH->>A: <channel source="telegram"...>message</channel>
-    A->>A: AI processes
-    A->>CH: writes reply text (no telegram_* tool call)
-    CH->>TG: agent-node handler auto sendMessage
-    TG->>U: Reply
-    A->>S: report_status / send_task
-```
+Send `/newbot` to [@BotFather](https://t.me/BotFather) and save the Bot Token.
 
-## Telegram Channel
+The allowlist uses numeric Telegram user IDs. Ask each permitted user to message [@userinfobot](https://t.me/userinfobot) and send the returned ID to the administrator.
 
-### Prerequisites
-
-1. A Telegram account
-2. A Telegram Bot
-
-### Step 1: Create a Bot
-
-1. Find [@BotFather](https://t.me/BotFather) on Telegram
-2. Send `/newbot`
-3. Follow the prompts to set up the bot name
-4. Obtain the **Bot Token** (format: `123456789:ABCdefGhIJKlmNoPQRsTUVwxyz`)
-
-### Step 2: Get Your User ID
-
-You need the user IDs allowed to talk to the bot. Three methods, ranked by recommendation:
-
-**🟢 Method A — Telegram's built-in UID bots** (fastest, for your own ID)
-
-DM any of these bots to get your numeric UID instantly:
-
-| Bot username | Behavior |
-|--------------|------|
-| **[@userinfobot](https://t.me/userinfobot)** | Send `/start` or anything → replies with `User ID` |
-| **@getmyid_bot** | Auto-replies with the numeric ID |
-| **@JsonDumpBot** | Returns full user JSON (id / username / lang) |
-
-China-network users sometimes can't reach Telegram from these bots — retry, switch proxy, or fall back to Method B.
-
-**🟢 Method B — Read the bot's inbox log** (for other people's UIDs / China fallback)
-
-When adding **other people** to the allowlist (team members), don't ask them to install a third-party UID bot. Read your own bot's inbox instead:
-
-1. Have them DM your node's bot any message (`/start` is fine)
-2. Find their `chat_id` (numeric) in the inbox log:
-   ```bash
-   # In the node's workdir:
-   ls -lt .anet/nodes/<alias>/channels/telegram/inbox/
-   cat <newest .json file> | grep -E 'chat_id|user_id|sender'
-   ```
-3. Re-run `anet channel add telegram --allow <UID>` with the **full** allowlist (note: this overwrites — see [Known gaps and pitfalls](#known-gaps-and-pitfalls) below)
-
-**🟡 Method C — Self-pair** (**not yet implemented**)
-
-The intended UX would be: user DMs the bot `/pair` → bot replies with a 6-digit pairing code → admin runs `anet channel pair-approve <code>` to auto-add the allow entry. Not built yet — use Methods A + B for now.
-
-### Step 3: Bind the channel to an existing node
-
-Run `anet channel add telegram <node-name>` once to bind the bot + allowlist (verify [`cli.ts channelCommand`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)):
+### 2. Attach it to an existing node
 
 ```bash
-# Assumes you already have a claude-code-cli node 'commander'
-# (if not: anet node create commander --runtime claude-code-cli)
-anet channel add telegram commander \
+anet channel add telegram control-room \
   --bot-token 123456789:ABCdefGhIJKlmNoPQRsTUVwxyz \
   --allow 123456789
-
-# Interactive (omit flags and the CLI prompts for them)
-anet channel add telegram commander
 ```
 
-::: warning The flag is `--allow`, not `--allow-user`
-:::
+Omit the options to enter them interactively. The allowlist option is `--allow`, not `--allow-user`.
 
-### Step 4: Start
+Channel settings are not hot-reloaded. If the node is already running, restart it:
 
 ```bash
-anet node start commander
+anet node stop control-room
+anet node start control-room
 ```
 
+### 3. Inspect the configuration
 
-### Step 5: Usage
-
-Send a message to your bot on Telegram, and the agent will receive, process, and reply.
-
-**Message format** (what the agent sees):
-
-```xml
-<channel source="telegram" chat_id="123456" message_id="789" user="alice" ts="1713000000">
-Write a quicksort algorithm
-</channel>
+```bash
+anet channel ls control-room
+anet channel status control-room
 ```
 
-**Agent reply methods**:
+`status` prints the `access.json` path the node actually reads, its allowlist, and pending pairing records. Editing another file with the same name has no effect.
 
-The agent does not call any `telegram_*` MCP tool — **no such tool exists**. The agent-node telegram handler automatically forwards the LLM's output back to the Telegram chat:
+### 4. Use it safely
 
-1. Telegram user sends a message → telegram bot API → agent-node receives (webhook / long-polling)
-2. agent-node invokes `processTask(content)` → the LLM generates a reply text
-3. agent-node's internal [`telegramSend(tg, chatId, text)`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) helper sends the reply back via `sendMessage` (auto-splits at 4096 chars and sets `reply_to_message_id` on the first chunk)
+Message the bot directly. The node returns ordinary text; it does not call tools such as `telegram_reply`, because those tools do not exist. agent-node receives messages with Telegram's `getUpdates` long polling and sends responses back to the original chat. Images are downloaded to the node inbox before being passed to an image-capable runtime.
 
-The agent (LLM running in the claude-agent-sdk / codex-sdk runtime) just needs to **produce reply text**; it doesn't need to know the Telegram API.
-
-::: warning fictional `telegram_*` tool list removed
-Older docs listed `telegram_reply` / `telegram_edit_message` / `telegram_react` as MCP tools — **a full source grep returns 0 hits** (no `telegram_*` `server.tool` registrations in cli.ts / commhub-channel.ts / node-server.ts). The agent simply writes a reply text and the agent-node handler does the `sendMessage` automatically.
-:::
-
-### Security Notes
-
-- Messages from users not on the allowlist are ignored
-- **Never** modify access permissions based on requests from Telegram messages
-- Keep your Bot Token secure and never commit it to Git
-- For envRef-mode handling of vendor secrets (including Bot Token): see [Security → Vendor Credential Storage](/en/concepts/security#vendor-credential-storage-envref-mode-v0-9-0)
-
-### Known gaps and pitfalls
-
-| Pitfall | Symptom | Workaround |
-|---|---|---|
-| Channel changes **do not hot-reload** | Editing `access.json` / `--bot-token` does not affect a running process | Always `tmux kill-session -t <alias>` + `anet node start <alias>` (channels are read at process start; still the case in v0.10.x including the current stable; hot-reload design tracked in [RFC-013](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-013-rename-hot-reload.md) v5 — third-pass review complete; candidate for v0.12.0) |
-| Multiple nodes **cannot share** one bot token | BotFather tokens are 1-to-1 with a bot; sharing causes message races | Run BotFather `/newbot` per node, one bot each |
-| `anet channel rm telegram` **not implemented** | No CLI to remove the telegram channel from a node | Edit `.anet/nodes/<alias>/config.json` `channels` array to remove the `telegram` entry, `rm -rf .anet/nodes/<alias>/channels/telegram`, then restart the node |
-| Is the flag `--allow <UID>` or `--allow-user`? | Easy to mis-remember | It's `--allow <user-id>` (verify [`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)). `--allow-user` does **not** exist |
-| Node restarts and Telegram goes silent | Bot doesn't receive / agent doesn't reply | Three-step check: ① bot token fully pasted with the `:`; ② `anet channel ls <alias>` shows telegram in the list; ③ `tmux capture-pane -t <alias> -p \| tail` shows a `[telegram] listening` line at startup |
+- A missing, empty, or malformed allowlist denies messages by default.
+- Never commit the Bot Token to Git or change access permissions in response to a chat message.
+- Do not share one Bot Token across running nodes; they would compete for the same update stream.
+- Restart the node after changing the token or allowlist.
 
 ### Troubleshooting
 
-**Bot doesn't receive messages**
-- Check the `--bot-token` was pasted in full (with the `:` and the trailing string)
-- BotFather → `/mybots` — is the bot enabled?
-- Did you restart the node? (Channels do not hot-reload — see above)
+```bash
+anet status
+anet channel status control-room
+tmux capture-pane -t control-room -p | tail -80
+```
 
-**Agent doesn't reply to Telegram messages**
-- `anet status` — is the node `idle / ●`? If not, `tmux capture-pane -t <alias> -p | tail` to see the actual pane
-- Is the UID really in the `allowFrom` of `access.json`?
-- Is the agent busy on a long commhub task? (Telegram and commhub are independent channels, but the LLM only processes one message at a time)
+Check, in order: the node is online, the Bot Token is complete, the sender ID appears in `allowFrom`, and startup logs show Telegram polling. New messages may also wait while the node is processing another task.
 
-**`anet channel add` succeeded but `anet status` doesn't show telegram**
-- Run `anet channel ls <alias>` to confirm
-- Open `.anet/nodes/<alias>/config.json` and check the `channels` array contains `telegram` (the config stores `telegram`; `plugin:telegram@claude-plugins-official` is only the transient claudeArg anet builds when launching claude-code-cli — it is not written to config)
+There is currently no `anet channel rm telegram`. To remove it, stop the node, remove `telegram` from the `channels` array in `.anet/nodes/<node-id>/config.json`, delete `.anet/nodes/<node-id>/channels/telegram/`, then start the node again.
 
+## Feishu
 
-## Feishu Channel — Built-in (preview)
+Feishu is a built-in channel supporting direct messages, group @mentions, text, and images. See the [Feishu guide](/en/guide/feishu) for app creation, event subscriptions, and permissions.
 
-::: tip Feishu is built in — no more external plugin
-`anet channel add feishu <node>` is a native anet channel as of preview `2.2.22-preview.2` / `2.4.15-preview.2`. The `claude-agent-sdk` runtime supports DMs + group `@bot` + text + images.
-:::
-
-Full setup (Docker one-command + manual paths) → **[Feishu Channel Integration Guide](/en/guide/feishu)**
-
-Design + roadmap: [RFC-020 IM Integration Layer](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-020-im-platform-integration.md) / [#179](https://github.com/sleep2agi/agent-network/issues/179).
-
-## WeChat Channel — External plugin (NOT inside CommHub Server)
-
-::: warning Planned, not yet in the CLI main path
-**`anet channel add wechat` has not shipped yet.**
-
-WeChat integration lives in an **external plugin** (not in `@sleep2agi/commhub-server`):
-
-- `mcp__wechat__wechat_reply` / `mcp__wechat__wechat_reply_image` — maintainer's self-hosted WeChat ClawBot plugin
-
-This plugin talks to ClawBot **directly**, not via CommHub Server. **CommHub Server does NOT have a `wechat_reply` MCP tool**.
-
-### Workarounds available today
-
-- **Telegram**: natively supported by CommHub, wired up via `anet channel add telegram`
-- **Feishu**: see above / [full integration guide](/en/guide/feishu)
-- **WeChat community in the Hub**: use the [self-hosted WeChat community](/en/community) for human-only discussion (no agent in the group)
-
-### Roadmap
-
-`anet channel add wechat` is on the future roadmap (not scheduled). If you need it urgently, open a [GitHub Discussion](https://github.com/sleep2agi/agent-network/discussions) to discuss sponsoring the work.
-:::
-
-## Multi-Channel Integration
-
-A single agent can connect to multiple channels simultaneously: CommHub is wired up automatically by `anet node create`; Telegram is layered on top with `anet channel add telegram <node>` (which writes a `channels/telegram/` subdirectory + `access.json`).
+Minimal setup:
 
 ```bash
-# Step 1: create the agent (CommHub channel is wired up by default)
-anet node create commander --runtime claude-code-cli
+anet channel add feishu control-room \
+  --app-id cli_xxx \
+  --app-secret yyy \
+  --allow ou_xxx
 
-# Step 2: add the Telegram channel (writes channels/telegram/access.json)
-anet channel add telegram commander --bot-token <tok> --allow <user-id>
-
-# Step 3: start the agent (runs the CommHub SSE listener + Telegram polling in one process)
-anet node start commander
+# Group allowlist
+anet channel add feishu control-room \
+  --app-id cli_xxx \
+  --app-secret yyy \
+  --allow-chat oc_xxx
 ```
 
-When the agent receives a message, it identifies the source via the `<channel source="...">` tag (`commhub` / `telegram` / etc.). **The agent just produces a reply text** — the agent-node's internal handler routes it to the right platform based on `source` (telegram replies go through `telegramSend(tg, chatId, text)`, commhub replies go through SSE `send_reply`). The agent doesn't need to know Telegram API details or the commhub MCP `send_reply` call.
+Direct-message and group allowlists can be maintained separately. Options are repeatable:
 
-## Channel Plugin Technical Details
-
-A channel plugin is an MCP Server (stdio mode) that provides message receiving and reply tools:
-
-```json
-{
-  "mcpServers": {
-    "commhub": {
-      "type": "stdio",
-      "command": "bun",
-      "args": [".anet/node-server.js"]
-    }
-  }
-}
+```bash
+anet channel allow feishu control-room --add-from ou_xxx --add-chat oc_xxx
+anet channel allow feishu control-room --rm-from ou_xxx --rm-chat oc_xxx
 ```
 
-::: tip The filename is `.js`, not `.ts`
-The file installed in your project is `.anet/node-server.js` ([`cli.ts ensureMcpJson`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) copies from the npm package — preferring `dist/src/node-server.js`, falling back to `src/node-server.ts` — but the on-disk filename is always `.js`).
-:::
+Restart the node after changing these settings.
 
-What the channel plugin actually does (v0.8 capabilities):
+## Multiple channels
 
-1. Maintains an SSE long connection to CommHub (receives new_task / new_message / new_reply / broadcast events)
-2. Listens to the Telegram Bot API (webhook / long-polling) — Telegram is the only natively supported external channel in v0.8
-3. Injects messages into the agent's context (XML `<channel source="...">` tag)
-4. **The agent-node's internal handler automatically forwards** the agent's reply to the right platform (commhub via the `send_reply` MCP tool; telegram via the [`telegramSend`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) helper)
+A node can receive CommHub, Telegram, and Feishu messages at the same time:
 
-::: warning Mermaid `reply()` path correction
-The original mermaid showed `AGENT → reply() → TOOLS → TG/WX/FS` — but there's no agent-facing `reply()` / `telegram_reply()` MCP tool for the agent to call. The agent only produces reply text; agent-node's handler routes it to the platform based on `source`.
-:::
-
-```mermaid
-graph LR
-    subgraph "agent-node process"
-        SSE[SSE connection<br/>CommHub<br/>recv new_task/new_reply]
-        TG[Telegram<br/>Bot API<br/>recv DM]
-        INJECT[Message injection<br/>XML channel tag]
-        HANDLER[agent-node<br/>internal handler]
-    end
-
-    SSE --> INJECT
-    TG --> INJECT
-
-    INJECT -->|"<channel source=&quot;commhub|telegram&quot;>"| AGENT[Agent LLM<br/>claude-agent-sdk /<br/>codex-sdk]
-    AGENT -->|"reply text<br/>(no MCP tool call)"| HANDLER
-    HANDLER -->|"send_reply MCP"| SSE
-    HANDLER -->|"telegramSend()"| TG
+```bash
+anet node create control-room --runtime claude-code-cli
+anet channel add telegram control-room --bot-token <token> --allow <user-id>
+anet channel add feishu control-room --app-id <id> --app-secret <secret> --allow <open-id>
+anet node start control-room
 ```
 
-## Next steps
+agent-node preserves the message source and routes the response back to the originating platform. The node only generates response content; it does not call the platform API directly.
 
-**Hands-on**:
+## WeChat
 
-**Dig deeper**:
-- [Agent Node config](/en/guide/agent-node) — how agents wire up channel plugins
-- [Dashboard](/en/guide/dashboard) — channel message flow monitor
-- Want to build your own channel? See [demos/codex-telegram-squad](https://github.com/sleep2agi/agent-network/tree/main/demos/codex-telegram-squad) and [pitfalls](https://github.com/sleep2agi/agent-network/blob/main/docs/pitfalls.md) in the repo
+`anet channel add wechat` has not shipped, and CommHub Server does not expose WeChat reply tools. Do not treat maintainer-only external plugins as product support. Follow the roadmap or open a request in [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) if you need WeChat integration.
+
+## See also
+
+- [Feishu guide](/en/guide/feishu)
+- [Agent Node configuration](/en/guide/agent-node)
+- [Security model](/en/concepts/security)

--- a/docs-site/docs/guide/channels.md
+++ b/docs-site/docs/guide/channels.md
@@ -1,263 +1,115 @@
 # Channel 接入
 
-Channel 让 Agent Network 可以接入外部通信平台。当前支持 Telegram、微信、飞书三个 Channel。
+Channel 把 Telegram 或飞书消息交给节点处理，再把节点的文本回复发回原会话。
 
-## 工作原理
+| Channel | 状态 | 接入命令 |
+|---|---|---|
+| Telegram | 已支持 | `anet channel add telegram <node>` |
+| 飞书 | preview 已支持 | `anet channel add feishu <node>` |
+| 微信 | 尚未进入 CLI | 无 |
 
-Channel 以 MCP Server 插件的形式挂载到 Claude Code 或 Agent Node。当外部消息到达时，Channel 插件将消息格式化后注入到 Agent 的上下文中：
+## Telegram
 
-```mermaid
-sequenceDiagram
-    participant U as 用户
-    participant TG as Telegram
-    participant CH as Channel Plugin
-    participant A as Agent (Claude Code)
-    participant S as CommHub Server
+### 1. 创建 Bot 并取得用户 ID
 
-    U->>TG: 发送消息
-    TG->>CH: Bot API webhook
-    CH->>A: <channel source="telegram"...>消息</channel>
-    A->>A: AI 处理
-    A->>CH: 输出 reply 文本（不调 telegram_* tool）
-    CH->>TG: agent-node handler 自动 sendMessage
-    TG->>U: 回复消息
-    A->>S: report_status / send_task
-```
+在 Telegram 中向 [@BotFather](https://t.me/BotFather) 发送 `/newbot`，保存 Bot Token。
 
-## Telegram Channel
+白名单使用 Telegram 的数字用户 ID。让每位允许访问的人给 [@userinfobot](https://t.me/userinfobot) 发送消息，并把返回的 ID 交给管理员。
 
-### 前置条件
-
-1. 一个 Telegram 账号
-2. 创建一个 Telegram Bot
-
-### Step 1: 创建 Bot
-
-1. 在 Telegram 中找到 [@BotFather](https://t.me/BotFather)
-2. 发送 `/newbot`
-3. 按提示设置 Bot 名称
-4. 获取 **Bot Token**（格式：`123456789:ABCdefGhIJKlmNoPQRsTUVwxyz`）
-
-### Step 2: 获取用户 ID
-
-你需要知道允许与 Bot 通信的用户 ID。三种方法按推荐度排：
-
-**🟢 方法 A — Telegram 自带的 UID bot**（最快，针对自己）
-
-DM 任一以下 bot 都能秒拿自己的 UID：
-
-| Bot username | 行为 |
-|--------------|------|
-| **[@userinfobot](https://t.me/userinfobot)** | 发 `/start` 或任意消息 → 返回 `User ID` 数字 |
-| **@getmyid_bot** | 自动返回 numeric ID |
-| **@JsonDumpBot** | 返回完整 user JSON（含 ID/username/lang） |
-
-国内网络偶尔抽风访问不到 telegram，多试几次 / 切代理 / 走方法 B。
-
-**🟢 方法 B — 看 bot inbox log**（针对别人 / 国内 fallback）
-
-要把**其他人**加进白名单（团队成员等），别让他们装第三方 UID bot —— 最稳的是看你自己 bot 收到的消息：
-
-1. 让对方 DM 你这个节点的 bot 发任意消息（哪怕 `/start`）
-2. 看 bot inbox log 里的 `chat_id`（纯数字）：
-   ```bash
-   # 节点 workdir 下：
-   ls -lt .anet/nodes/<alias>/channels/telegram/inbox/
-   cat <最新的 .json 文件> | grep -E 'chat_id|user_id|sender'
-   ```
-3. 拿到对方 UID 后重跑 `anet channel add telegram --allow <UID>` 一次性传全名单（注意：会覆盖，详见下方 [常见 gap 和坑](#常见-gap-和坑)）
-
-**🟡 方法 C — Self-pair**（**当前未实现**）
-
-理想 UX 是用户 DM bot 发 `/pair` → bot 回 6 位 pairing code → admin `anet channel pair-approve <code>` 自动加 allow。这条 feature 目前没实现，需要走方法 A + B。
-
-### Step 3: 绑定 Channel 到已有节点
-
-跑 `anet channel add telegram <node-name>` 命令一次性绑定 bot + allowlist（verify [`cli.ts` `channelCommand`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)）：
+### 2. 绑定已有节点
 
 ```bash
-# 假设你已有 claude-code-cli 节点 '指挥室'（没有就先 anet node create 指挥室 --runtime claude-code-cli）
 anet channel add telegram 指挥室 \
   --bot-token 123456789:ABCdefGhIJKlmNoPQRsTUVwxyz \
   --allow 123456789
-
-# 或交互式（不传 flag 时 prompt 输入）
-anet channel add telegram 指挥室
 ```
 
-::: warning 注意 flag 是 `--allow` 不是 `--allow-user`
-:::
+省略参数会进入交互输入。正确的白名单参数是 `--allow`，不是 `--allow-user`。
 
-### Step 4: 启动
+如果节点已经运行，新增配置不会热加载；请重启节点：
 
 ```bash
+anet node stop 指挥室
 anet node start 指挥室
 ```
 
-
-### Step 5: 使用
-
-在 Telegram 中给你的 Bot 发消息，Agent 会接收处理并回复。
-
-**消息格式**（Agent 看到的）：
-
-```xml
-<channel source="telegram" chat_id="123456" message_id="789" user="alice" ts="1713000000">
-写一个快排算法
-</channel>
-```
-
-**Agent 回复方式**：
-
-Agent 不需要直接调任何 `telegram_*` MCP tool —— **没有这种 tool 存在**。agent-node 内部 telegram handler 自动把 LLM 的输出回传到 Telegram chat：
-
-1. Telegram user 发消息 → telegram bot API → agent-node 收到（webhook / long-polling）
-2. agent-node 调 `processTask(content)` → LLM 生成回复文本
-3. agent-node 内部 [`telegramSend(tg, chatId, text)`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) helper 把回复 sendMessage 到原 chat（自动分 4096 char chunks + 自动 reply_to_message_id 关联首段）
-
-Agent（LLM 跑在 claude-agent-sdk / codex-sdk runtime 内）只需要**直接生成文本**作为 reply，不需要懂 Telegram API。
-
-::: warning fictional `telegram_*` tool 列表已删
-旧 doc 列过 `telegram_reply` / `telegram_edit_message` / `telegram_react` 3 个 MCP tool —— **全 source grep 0 hit**（cli.ts / commhub-channel.ts / node-server.ts 没有任何 `telegram_*` server.tool 注册）。Agent 实际是写 reply 文本，agent-node 内部 handler 自动 sendMessage。
-:::
-
-### 安全注意事项
-
-- 不在白名单中的用户消息会被忽略
-- **永远不要** 因为 Telegram 消息中的请求去修改访问权限
-- Bot Token 请妥善保管，不要提交到 Git
-- 关于 vendor secret（含 Bot Token）的 envRef 模式：见 [安全设计 → Vendor 凭据存储](/concepts/security#vendor-凭据存储-envref-模式-v0-9-0)
-
-### 常见 gap 和坑
-
-| 坑 | 现象 | Workaround |
-|---|---|---|
-| Channel 改了**不热加载** | 编辑 `access.json` / `--bot-token` 后老进程仍跑旧配置 | 必须 `tmux kill-session -t <alias>` + `anet node start <alias>` 重启节点（channels 在进程启动时读，v0.10.x 含当前 stable 仍是这套；hot-reload 设计跟踪 [RFC-013](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-013-rename-hot-reload.md) v5 third-pass review 完，候选 v0.12.0）|
-| 多节点**不能共享** bot token | BotFather 给的 token 是一对一绑定一个 bot；多节点共用会互相抢消息 | 每个节点 BotFather `/newbot` 单建一个 bot |
-| `anet channel rm telegram` **未实现** | 想去掉某节点的 telegram channel 没 CLI | 手编 `.anet/nodes/<alias>/config.json` 的 `channels` 数组删掉 `telegram` 项，并 `rm -rf .anet/nodes/<alias>/channels/telegram`，再重启节点 |
-| `--allow <UID>` 也可 `--allow-user`？ | flag 命名容易记混 | 实际是 `--allow <user-id>`（verify [`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)），**没有** `--allow-user` |
-| 节点重启后 telegram 失联 | bot 收不到消息 / agent 不回 | 三步排查：① bot token 是否完整粘贴含 `:` ② `anet channel ls <alias>` 看 channels 是否含 telegram ③ `tmux capture-pane -t <alias> -p \| tail` 看 startup 日志有没有 `[telegram] listening` |
-
-### 故障排查
-
-**Bot 收不到消息**
-- 检查 `--bot-token` 是不是完整粘贴（含冒号 `:` 和后面的字符串）
-- BotFather 里 `/mybots` 看 bot 是否 enabled
-- 节点重启了吗？（channels 不支持热加载，见上）
-
-**Agent 不回 telegram 消息**
-- `anet status` 看节点 status 是否 `idle / ●`，不是的话 `tmux capture-pane -t <alias> -p | tail` 看实际 pane
-- UID 是否真在 `access.json` 的 `allowFrom` 里
-- agent 是不是 busy 在 commhub 长任务（telegram 跟 commhub 是两条独立 channel，但 LLM 一次只处理一条消息）
-
-**`anet channel add` 后 `anet status` 没显示 telegram**
-- `anet channel ls <alias>` 直接确认
-- 看 `.anet/nodes/<alias>/config.json` 的 `channels` 数组里有没有 `telegram`（config 里存的就是 `telegram`；`plugin:telegram@claude-plugins-official` 只是 anet 启动 claude-code-cli 时临时拼的 claudeArg，不写进 config）
-
-
-## 飞书 Channel — 内置（preview 起 ship）
-
-::: tip 飞书已内置, 不再走外部插件
-`anet channel add feishu <node>` 是 anet 原生 channel（preview `2.2.22-preview.2` / `2.4.15-preview.2` 起），`claude-agent-sdk` runtime 私聊 + 群 @bot + 文本 + 图片可用。
-:::
-
-完整接入步骤（Docker 一键 + 手动两条路径） → **[飞书 channel 接入指南](/guide/feishu)**
-
-设计 + roadmap：[RFC-020 IM 兼容层](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-020-im-platform-integration.md) / [#179](https://github.com/sleep2agi/agent-network/issues/179)。
-
-## 微信 Channel — 外部插件（不在 CommHub Server 内）
-
-::: warning Planned，未在 CLI 主路径
-**`anet channel add wechat` 暂未 ship。**
-
-WeChat 集成存在于**外部插件**中（不在 `@sleep2agi/commhub-server` 里）：
-
-- `mcp__wechat__wechat_reply` / `mcp__wechat__wechat_reply_image` — 维护者自建的 WeChat ClawBot 插件
-
-这些插件**直接**和 ClawBot 通信，不经过 CommHub Server。**CommHub Server 没有 `wechat_reply` MCP tool**。
-
-### 当前能用的替代方案
-
-- **Telegram**：CommHub 原生支持，用 `anet channel add telegram` 一键接入
-- **飞书**：见上 / [完整接入指南](/guide/feishu)
-- **微信群消息进 Hub**：用 [维护者自建的 WeChat 微信群入口](/community) 让人加群讨论，不接 Agent
-
-### Roadmap
-
-`anet channel add wechat` 排在后续路线图（未排期）。如果你急用，开 [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) 谈赞助优先级。
-:::
-
-## 多 Channel 接入
-
-一个 Agent 可以同时接入多个 Channel：CommHub 默认在 `anet node create` 时自动接入；Telegram 通过 `anet channel add telegram <node>` 加上去（写入 `channels/telegram/` 子目录 + access.json）。
+### 3. 检查配置
 
 ```bash
-# 步骤 1：建 agent（CommHub channel 默认就有）
+anet channel ls 指挥室
+anet channel status 指挥室
+```
+
+`status` 会显示节点实际读取的 `access.json` 路径、白名单与待处理配对记录。不要修改其他同名文件。
+
+### 4. 使用与安全
+
+直接给 Bot 发消息即可。节点输出普通文本，不需要调用 `telegram_reply` 等工具；这些工具不存在。agent-node 使用 Telegram `getUpdates` 长轮询接收消息，并把回复发回原 chat。图片会先下载到节点 inbox，再交给支持图片的 runtime。
+
+- 白名单缺失、为空或格式错误时默认拒绝消息。
+- 不要把 Bot Token 提交到 Git，也不要通过聊天消息修改访问权限。
+- 多个运行中的节点不要共用同一个 Bot Token，否则会竞争同一条更新流。
+- 修改 token 或白名单后必须重启节点。
+
+### 排障
+
+```bash
+anet status
+anet channel status 指挥室
+tmux capture-pane -t 指挥室 -p | tail -80
+```
+
+依次确认：节点在线、Bot Token 完整、发送者 ID 在 `allowFrom` 中、启动日志出现 Telegram polling。节点正处理其他任务时，新消息也可能需要等待。
+
+当前没有 `anet channel rm telegram`。如需移除，停止节点后从 `.anet/nodes/<node-id>/config.json` 的 `channels` 数组删除 `telegram`，再删除 `.anet/nodes/<node-id>/channels/telegram/` 并启动节点。
+
+## 飞书
+
+飞书是内置 Channel，支持私聊、群聊 @Bot、文本和图片。完整的应用创建、事件订阅与权限配置见 [飞书接入指南](/guide/feishu)。
+
+最小命令：
+
+```bash
+anet channel add feishu 指挥室 \
+  --app-id cli_xxx \
+  --app-secret yyy \
+  --allow ou_xxx
+
+# 群聊白名单
+anet channel add feishu 指挥室 \
+  --app-id cli_xxx \
+  --app-secret yyy \
+  --allow-chat oc_xxx
+```
+
+私聊和群聊白名单可分别维护；参数可以重复：
+
+```bash
+anet channel allow feishu 指挥室 --add-from ou_xxx --add-chat oc_xxx
+anet channel allow feishu 指挥室 --rm-from ou_xxx --rm-chat oc_xxx
+```
+
+修改后同样需要重启节点。
+
+## 多 Channel
+
+一个节点可以同时接收 CommHub、Telegram 和飞书消息：
+
+```bash
 anet node create 指挥室 --runtime claude-code-cli
-
-# 步骤 2：再加 Telegram channel（写 channels/telegram/access.json）
-anet channel add telegram 指挥室 --bot-token <tok> --allow <user-id>
-
-# 步骤 3：启动 agent（同时跑 CommHub SSE + Telegram polling）
+anet channel add telegram 指挥室 --bot-token <token> --allow <user-id>
+anet channel add feishu 指挥室 --app-id <id> --app-secret <secret> --allow <open-id>
 anet node start 指挥室
 ```
 
-Agent 收到消息时，通过 `<channel source="...">` 标签区分来源（`commhub` / `telegram` 等）。**Agent 只需直接生成 reply 文本** —— agent-node 的内部 handler 根据 `source` 自动路由到对应平台（telegram 走 `telegramSend(tg, chatId, text)`，commhub 走 SSE `send_reply`）。Agent 不需要懂 Telegram API / commhub MCP `send_reply` 调用细节。
+agent-node 会保留消息来源，并把回复路由回原平台。节点只需生成回复内容，不需要直接调用平台 API。
 
-## Channel Plugin 技术实现
+## 微信
 
-Channel 插件是一个 MCP Server（stdio 模式），提供消息接收和回复工具：
+`anet channel add wechat` 尚未发布，CommHub Server 也没有微信回复工具。不要把维护者自用的外部插件当作产品能力。需要微信支持时，请关注项目路线图或在 [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) 提交需求。
 
-```json
-{
-  "mcpServers": {
-    "commhub": {
-      "type": "stdio",
-      "command": "bun",
-      "args": [".anet/node-server.js"]
-    }
-  }
-}
-```
+## 延伸阅读
 
-::: tip 文件名是 `.js` 不是 `.ts`
-落盘到项目目录的文件是 `.anet/node-server.js`（[`cli.ts ensureMcpJson`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) 自动复制 npm 包 `dist/src/node-server.js` 优先 / `src/node-server.ts` 兜底，但最终落盘统一为 `.js`）。
-:::
-
-Channel 插件做的事（v0.8 实际能力）：
-
-1. 维护 SSE 长连接到 CommHub（receive new_task / new_message / new_reply / broadcast events）
-2. 监听 Telegram Bot API（webhook / long-polling）—— Telegram 是 v0.8 唯一原生支持的外部 channel
-3. 将消息注入到 Agent 上下文（XML `<channel source="...">` tag）
-4. **agent-node 内部 handler 自动转发** agent reply 到对应平台（commhub 走 `send_reply` MCP；telegram 走 [`telegramSend`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) helper）
-
-::: warning Mermaid 图 `reply()` 路径修正
-原版 mermaid 图画 `AGENT → reply() → TOOLS → TG/WX/FS` —— 实际没有 agent-facing `reply()` / `telegram_reply()` MCP tool 给 agent 调。Agent 只生成 reply 文本，agent-node handler 根据 `source` 自动路由到对应平台。
-:::
-
-```mermaid
-graph LR
-    subgraph "agent-node process"
-        SSE[SSE 连接<br/>CommHub<br/>recv new_task/new_reply]
-        TG[Telegram<br/>Bot API<br/>recv DM]
-        INJECT[消息注入<br/>XML channel tag]
-        HANDLER[agent-node<br/>internal handler]
-    end
-
-    SSE --> INJECT
-    TG --> INJECT
-
-    INJECT -->|"<channel source=&quot;commhub|telegram&quot;>"| AGENT[Agent LLM<br/>claude-agent-sdk /<br/>codex-sdk]
-    AGENT -->|"reply text<br/>(no MCP tool call)"| HANDLER
-    HANDLER -->|"send_reply MCP"| SSE
-    HANDLER -->|"telegramSend()"| TG
-```
-
-## 下一步
-
-**实操**：
-
-**深入**：
-- [Agent Node 配置](/guide/agent-node) — agent 怎么接 channel 插件
-- [Dashboard](/guide/dashboard) — channel 消息流监控
-- 想自己写一个 channel？参考仓库 [demos/codex-telegram-squad](https://github.com/sleep2agi/agent-network/tree/main/demos/codex-telegram-squad) 和 [pitfalls 踩坑](https://github.com/sleep2agi/agent-network/blob/main/docs/pitfalls.md)
+- [飞书接入指南](/guide/feishu)
+- [Agent Node 配置](/guide/agent-node)
+- [安全设计](/concepts/security)


### PR DESCRIPTION
## What changed

- Cut the bilingual Channel guide from 527 lines to 230 lines.
- Keep only the supported Telegram and preview Feishu setup paths.
- Correct Telegram transport to `getUpdates` long polling and remove the false webhook description.
- State clearly that WeChat is not a shipped CLI or CommHub capability.
- Consolidate restart, allowlist, security, and troubleshooting guidance.
- Remove stale source-line references, fictional tool discussion, duplicate diagrams, and roadmap narration.

## User impact

Readers get one short, command-first setup path without mistaking maintainer-only WeChat plugins or nonexistent `telegram_*` tools for product features.

## Validation

- `git diff --check`
- Chinese/English structure and line-count parity
- Source checks against `channelCommand()`, Telegram `getUpdates`, fail-closed allowlist behavior, and Feishu allowlist commands
- Negative searches for stale implementation links and the old “WeChat currently supported” claim

Markdown-only change; no runtime or API changes.