### PR TITLE
security(avatar): same-origin /avatars/ pool paths — exact-set relax, absolute branch untouched

### DIFF
--- a/server/src/avatar-validate.test.ts
+++ b/server/src/avatar-validate.test.ts
@@ -60,8 +60,10 @@ describe("#462 validateAvatarUrl", () => {
     expect(validateAvatarUrl("ftp://example.com/a.png").ok).toBe(false);
   });
 
-  test("rejects relative / protocol-relative / non-URL strings", () => {
-    expect(validateAvatarUrl("/avatars/1.png").ok).toBe(false);
+  test("rejects protocol-relative / non-URL / schemeless strings", () => {
+    // SPEC CHANGE (通信龙 裁定, avatar 接线单): same-origin pool paths
+    // (/avatars/<name>.<ext>) are now ACCEPTED — that case moved to the
+    // dedicated relative-branch suite below. Everything here stays rejected.
     expect(validateAvatarUrl("//cdn.example.com/1.png").ok).toBe(false);
     expect(validateAvatarUrl("not a url").ok).toBe(false);
     expect(validateAvatarUrl("example.com/x.png").ok).toBe(false);
@@ -109,5 +111,53 @@ describe("#462 validateAvatarUrl", () => {
     const ok = base + "a".repeat(MAX_AVATAR_URL_LENGTH - base.length);
     expect(validateAvatarUrl(ok).ok).toBe(true);
     expect(validateAvatarUrl(ok + "a").ok).toBe(false);
+  });
+});
+
+// ── Same-origin relative branch (通信龙 裁定: relax to portable pool paths;
+//    absolute URLs would weld one hostname into the DB across multi-origin
+//    entry points). Each direction is its OWN test so any single guard
+//    being deleted turns its OWN assertion red (no merged catch-all).
+describe("validateAvatarUrl — same-origin relative pool paths", () => {
+  test("accepts a pool path: /avatars/avatar-09.webp", () => {
+    const r = validateAvatarUrl("/avatars/avatar-09.webp");
+    expect(r).toEqual({ ok: true, value: "/avatars/avatar-09.webp" });
+  });
+
+  test("accepts png and svg pool files", () => {
+    expect(validateAvatarUrl("/avatars/intern_avatar.png")).toEqual({ ok: true, value: "/avatars/intern_avatar.png" });
+    expect(validateAvatarUrl("/avatars/team-logo.svg")).toEqual({ ok: true, value: "/avatars/team-logo.svg" });
+  });
+
+  test("rejects protocol-relative //host (classic same-origin bypass)", () => {
+    const r = validateAvatarUrl("//evil.com/x.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("protocol-relative");
+  });
+
+  test("rejects javascript: scheme (still, after the relax)", () => {
+    expect(validateAvatarUrl("javascript:alert(1)").ok).toBe(false);
+  });
+
+  test("rejects non-/avatars/ absolute paths (/etc/passwd)", () => {
+    expect(validateAvatarUrl("/etc/passwd").ok).toBe(false);
+  });
+
+  test("rejects non-whitelisted extensions under /avatars/", () => {
+    expect(validateAvatarUrl("/avatars/payload.html").ok).toBe(false);
+  });
+
+  test("rejects nested/traversal paths (charset forbids further slashes)", () => {
+    expect(validateAvatarUrl("/avatars/../secrets.webp").ok).toBe(false);
+    expect(validateAvatarUrl("/avatars/sub/x.webp").ok).toBe(false);
+  });
+
+  test("rejects percent-encoding inside the filename (no encoded surprises)", () => {
+    expect(validateAvatarUrl("/avatars/a%2f..%2fx.webp").ok).toBe(false);
+  });
+
+  test("absolute http(s) branch is UNTOUCHED by the relax (positive control)", () => {
+    const r = validateAvatarUrl("https://example.com/pic.png");
+    expect(r.ok).toBe(true);
   });
 });

--- a/server/src/avatar-validate.ts
+++ b/server/src/avatar-validate.ts
@@ -15,9 +15,26 @@ export type AvatarValidation =
  * Normalize + validate an untrusted avatar_url patch value.
  *
  *   null / undefined / "" / whitespace-only  → { ok, value: null }  (clear)
- *   valid absolute http(s) URL               → { ok, value: trimmed }
+ *   same-origin pool path /avatars/<name>.<ext>  → { ok, value: trimmed }
+ *   valid absolute http(s) URL               → { ok, value: normalized }
  *   anything else                            → { ok: false, reason }
+ *
+ * Relative branch rationale (通信龙 裁定, avatar 接线单): the hub is
+ * reached through several origins (localhost dev, public domains) — an
+ * absolute URL would weld ONE hostname into the DB and break the image
+ * for every other entry point; a same-origin relative path is portable.
+ * 🔴 Trap this branch must block: "starts with /" ≠ "same-origin" —
+ * "//evil.com/x.png" ALSO starts with "/" but is a protocol-relative URL
+ * the browser resolves to evil.com. Hence: single leading slash with the
+ * SECOND char not "/", then an exact value-set match (the /avatars/ pool
+ * prefix + extension whitelist), not a shape match.
  */
+
+// Exact allowed set for same-origin values: the dashboard's designed pool
+// under /avatars/. Filename charset excludes "/" (no traversal, no nested
+// paths) and "%" (no encoded surprises); extensions mirror the actual
+// pool contents. Widen ONLY by extending this list deliberately.
+const SAME_ORIGIN_AVATAR_RE = /^\/avatars\/[A-Za-z0-9._-]+\.(webp|png|svg)$/;
 export function validateAvatarUrl(raw: unknown): AvatarValidation {
   if (raw === null || raw === undefined) return { ok: true, value: null };
   if (typeof raw !== "string") {
@@ -35,6 +52,23 @@ export function validateAvatarUrl(raw: unknown): AvatarValidation {
   if (/[\u0000-\u001f\u007f-\u009f\s]/.test(trimmed)) {
     return { ok: false, reason: "avatar_url must not contain whitespace or control characters" };
   }
+  // Same-origin relative branch (runs AFTER the whitespace/control gate
+  // above — that check protects this branch too). Order of the two tests
+  // matters for the reason string, not for safety: the exact-set regex
+  // alone already rejects "//…" (second char is "/", first segment must
+  // literally be "avatars"), the explicit double-slash check just names
+  // the classic bypass in its own words.
+  if (trimmed.startsWith("/")) {
+    if (trimmed.startsWith("//")) {
+      return { ok: false, reason: "avatar_url must not be protocol-relative (//host/…)" };
+    }
+    if (!SAME_ORIGIN_AVATAR_RE.test(trimmed)) {
+      return { ok: false, reason: "relative avatar_url must match /avatars/<name>.(webp|png|svg)" };
+    }
+    return { ok: true, value: trimmed };
+  }
+  // Absolute http(s) branch — unchanged from #462 (do not touch while
+  // relaxing: 通信龙 裁定 condition 3).
   let parsed: URL;
   try {
     parsed = new URL(trimmed);


### PR DESCRIPTION
Per 通信龙's ruling on the avatar-wiring investigation (multi-origin hub → absolute URLs weld a hostname into the DB; relative pool paths are portable).

Three ruling conditions, each implemented and tested:
1. single leading `/` with second char not `/` — `//evil.com/x.png` (protocol-relative, the classic bypass) rejected by its own named check + the exact-set regex
2. exact value set, not shape: `^/avatars/[A-Za-z0-9._-]+\.(webp|png|svg)$` — no traversal (charset forbids `/`), no percent-encoding, extension whitelist mirrors the actual pool
3. absolute http(s) branch byte-identical

Tests: one direction per test. Sabotage (naive `startsWith('/')`) → exactly 6 negatives red, positives + absolute control green; restored 23/23; full server suite green.

One pre-existing assertion (`/avatars/1.png` rejected) updated for the spec change, ruling cited inline.

Draft for the independent security review 通信龙 is assigning — I will not self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)