### PR TITLE
docs: mark Grok TUI co-presence as unreleased

### DIFF
--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,11 +5,15 @@
 - **2026-05 起**：采用 v0.6 → v0.7 → v0.8 → v0.9 → v0.10 → v0.11 渐进发布，`v0.X.Y` 格式对齐 `commhub-server` 的 `0.X.Y` semver 风格
 - **2026-04 之前**：曾使用 `v1.0.0-preview.N` / `v2.1` 等过度承诺型版本号，已废弃
 - **当前 stable**：npm `latest` tag（按 [版本号体系](/guide/versioning) 查 npm latest 即为权威）；v0.8.1 是 Apache 2.0 OSS 首发版本
-- **当前 preview**：Grok 人机共存 TUI（`agent-network@2.3.0-preview.23` / `agent-node@2.5.0-preview.21`，见下方第一条；通过 npm `@preview` tag 发布；尚未 promote 到 `@latest`）
+- **当前 preview**：以 npm `preview` dist-tag 为准；当前发布包不含 `grok-build-cli` / `anet grok attach`。Grok TUI 状态见 [Issue #537](https://github.com/sleep2agi/agent-network/issues/537)
 - 旧版历史保留作 git blame 完整性，详见下方 v1.0.0-preview / v2.1 / v0.x 段落
 :::
 
 ## Grok 人机共存 TUI（`grok-build-cli`）—— preview（2026-07-15）🟡 preview
+
+::: danger 2026-07-31 更正
+下文记录的是当时的候选里程碑，不是当前可安装能力。重新核验 npm 发布包后，当前 `latest` 与 `preview` 均不含 `grok-build-cli` / `anet grok attach`；其中的安装与运行命令请勿执行。现状见 [Grok TUI 状态页](/guide/grok-copresence)。
+:::
 
 **版本同步**（npm `@preview` tag）：
 - `@sleep2agi/agent-network@2.3.0-preview.23`

--- a/docs-site/docs/en/changelog.md
+++ b/docs-site/docs/en/changelog.md
@@ -5,11 +5,15 @@ This log runs reverse-chronologically. **The version scheme was reshuffled once*
 - **From 2026-05 onward**: gradual v0.6 → v0.7 → v0.8 → v0.9 → v0.10 → v0.11 releases; the `v0.X.Y` format mirrors `commhub-server`'s `0.X.Y` semver style.
 - **Before 2026-04**: used `v1.0.0-preview.N` / `v2.1` style version numbers that overpromised. Deprecated.
 - **Current stable**: whatever npm's `latest` tag points to (see [Versioning](/en/guide/versioning) — npm `latest` is authoritative); v0.8.1 was the first Apache 2.0 OSS release.
-- **Current preview**: Grok Co-presence TUI (`agent-network@2.3.0-preview.23` / `agent-node@2.5.0-preview.21`, first entry below; shipped via npm `@preview` tag; not yet promoted to `@latest`).
+- **Current preview**: follow npm's `preview` dist-tag. Current published packages do not include `grok-build-cli` / `anet grok attach`; see [Issue #537](https://github.com/sleep2agi/agent-network/issues/537) for Grok TUI status.
 - Older entries kept for git-blame continuity — see v1.0.0-preview / v2.1 / v0.x sections below.
 :::
 
 ## Grok Co-presence TUI (`grok-build-cli`) — preview (2026-07-15) 🟡 preview
+
+::: danger Correction — 2026-07-31
+The section below records a candidate milestone, not a currently installable feature. Rechecking the published npm packages showed that neither current `latest` nor `preview` contains `grok-build-cli` / `anet grok attach`; do not run the installation or usage commands in this historical entry. See the [Grok TUI status page](/en/guide/grok-copresence).
+:::
 
 **Version sync** (npm `@preview` tag):
 - `@sleep2agi/agent-network@2.3.0-preview.23`

--- a/docs-site/docs/en/guide/grok-copresence.md
+++ b/docs-site/docs/en/guide/grok-copresence.md
@@ -1,91 +1,20 @@
-# Grok Co-presence TUI (`grok-build-cli`, preview)
+# Grok Co-presence TUI (not released)
 
-The `grok-build-cli` runtime lets you **attach to the real Grok TUI held by the agent-node**. You and CommHub network tasks share one Grok session: network tasks enter the same session, render live in the terminal, and reply back to the task originator — while you can watch and type alongside. Human and agent share one session context.
-
-> `grok-build-acp` is a separate ACP (`grok agent stdio`) path and **does not support attach**. For co-presence, use `grok-build-cli`.
-
-::: warning Preview
-This is a **preview**, not latest/production. Only connect to trusted Hubs and trusted tasks.
+::: danger Not currently available
+`grok-build-cli` and `anet grok attach` are **not included in npm `latest` or `preview`**. Do not follow older instructions that run `anet node create ... --runtime grok-build-cli`; current published packages do not contain this path.
 :::
 
-## Prerequisites
+The repository has a candidate implementation for sharing one Grok TUI between a human and network tasks, but it is still being requalified and is not a released feature. Follow [Issue #537](https://github.com/sleep2agi/agent-network/issues/537) and [Draft PR #538](https://github.com/sleep2agi/agent-network/pull/538) for status and test evidence.
 
-- **Linux** (needs `/proc` and `/proc/self/fd`)
-- **Node.js ≥ 22.13**
-- The **exact** Grok CLI version installed and logged in: `grok 0.2.93 (f00f96316d)` (a trailing `[stable]` is fine), with `grok login` run as the **same OS user** that runs anet.
+## What works today
+
+- `grok-build-acp`: the current stable Grok runtime. It runs network tasks through `grok agent stdio` and **cannot attach to the same TUI**.
+- `grok`: you can use the Grok CLI directly in a terminal, but that does not turn the TUI into an Agent Network co-presence node.
 
 ```bash
-# Install the exact version (co-presence is grok-version-sensitive) — install.sh supports bash -s <version>
-curl -fsSL https://x.ai/cli/install.sh | bash -s 0.2.93
 grok login
-grok --version   # must be grok 0.2.93 (f00f96316d)
+anet node create grok-agent --runtime grok-build-acp
+anet node start grok-agent
 ```
 
-## Install
-
-```bash
-npm install -g @sleep2agi/agent-network@preview
-```
-
-Install only `agent-network`; the first `node start` auto-fetches and verifies `agent-node@preview` (so the first start needs the npm registry or a warm cache).
-
-To pin the exact verified combination:
-
-```bash
-npm install -g \
-  @sleep2agi/agent-network@2.3.0-preview.23 \
-  @sleep2agi/agent-node@2.5.0-preview.21
-```
-
-## Minimal flow
-
-If CommHub isn't configured yet, follow [Getting Started](./getting-started.md) to start and log into the Hub. Then, in your **target project directory**:
-
-```bash
-# Terminal 1: create and start the co-presence node
-anet node create grok-shared --runtime grok-build-cli
-anet node start grok-shared
-```
-
-Wait for the startup log hint:
-
-```text
-attach with anet grok attach grok-shared
-```
-
-Then, from a real interactive terminal on the **same machine, same OS user, same project directory**:
-
-```bash
-# Terminal 2
-anet grok attach grok-shared
-```
-
-- No other flags are required to attach.
-- `Ctrl-]` only **detaches**; it does not stop the node.
-- To start receiving network tasks, wait for `SSE connected` in the log.
-
-## The three Grok paths
-
-| Configuration | Execution | Attachable |
-|---|---|---|
-| `--runtime grok-build-cli` | Co-presence TUI | ✅ Yes |
-| `--runtime grok-build-cli --grok-headless` | One CLI turn per task | ❌ No |
-| `--runtime grok-build-acp` | `grok agent stdio` ACP | ❌ No |
-
-For co-presence attach, do **not** add `--grok-headless`.
-
-## Caveats
-
-- **Linux only**; needs `/proc` and `/proc/self/fd`.
-- Grok must be exactly `0.2.93 (f00f96316d)`, with `grok login` by the same OS user.
-- Attach must be a **real TTY**, run from the same machine, user, and project directory.
-- The co-presence session is a fixed **text-only `[todo_write]` profile**: no filesystem, shell, network, media, MCP, or subagent tools.
-- This path has **no Grok MCP tool handshake** — ignore any older "wait a few seconds for the MCP handshake" note. Attach follows the startup log hint; task reception follows `SSE connected`.
-- Executable project-directory config (MCP / LSP / hooks / plugins / permission / sandbox / `.envrc`) triggers **fail-closed** (start/resume refused).
-- The Feishu channel is currently **rejected**.
-- Trusted Hubs and tasks only; this is a preview, not latest/production.
-
-## References
-
-- [Node Runtimes](./runtimes.md)
-- [Grok Build runtime notes](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md)
+Installation and attach steps will return to this page only after the feature ships in a published package. See [version channels](./versioning.md).

--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -7,7 +7,7 @@ Every Agent Node has a **Runtime** (engine kernel) that decides how the node cal
 > This table is the **single source of truth** for runtimes across the entire site. Other pages (`cli` / `agent-node` / `getting-started` / `clean-server`) reference it — they do not duplicate the full table.
 
 ::: tip Which runtimes are available in which channel (real-machine verified)
-- **Stable** (`npm i -g @sleep2agi/agent-network`, currently 2.2.21): **4 production runtimes** — `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`.
+- **Stable** (`npm i -g @sleep2agi/agent-network`): **4 production runtimes** — `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`. Follow npm's `latest` dist-tag for the exact version.
 - **Preview** (`@preview`): adds `codex-app-server` / `opencode-cli` on top of the 4 (**6 total**), and rejects unknown runtimes with an explicit error (stable **silently falls back** to the default runtime instead).
 
 Rows tagged `(preview)` below are **preview-only** and not selectable on stable.

--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -13,6 +13,10 @@ Every Agent Node has a **Runtime** (engine kernel) that decides how the node cal
 Rows tagged `(preview)` below are **preview-only** and not selectable on stable.
 :::
 
+::: warning Grok TUI co-presence has not shipped
+`grok-build-cli` / `anet grok attach` are not in the current `latest` or `preview` packages, so they are not selectable runtimes in the table below. Use `grok-build-acp` for now; it does not support attach. See the [Grok TUI status page](/en/guide/grok-copresence).
+:::
+
 | Runtime | npm package / engine | When to pick | Default models | Prereq auth | Wizard behavior (`anet node create`) |
 |---|---|---|---|---|---|
 | `claude-code-cli` **⭐ recommended start** | spawn local `claude` CLI | "Just use Claude in the terminal" — **zero config if you already have the Claude subscription** (the **first choice** if you have a Claude subscription — most stable) | Claude Sonnet / Opus (subscription) | `claude auth login` done | Wizard ends right after pick, **skips vendor / model / API-key** |
@@ -30,10 +34,9 @@ Rows tagged `(preview)` below are **preview-only** and not selectable on stable.
 - **Writing code / running commands** → `codex-sdk`
 - **Human and Agent sharing one Codex TUI/thread** → preview `codex-app-server` + `anet node start <alias> --copresence` ([full guide](/en/guide/codex-copresence))
 - **Using xAI Grok Build** → `grok-build-acp` ([detailed runtime guide ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md))
-- **Human + agent sharing one Grok TUI (co-presence, attach to the live Grok session)** → `grok-build-cli` ([Grok Co-presence TUI · preview](/en/guide/grok-copresence))
 - **Use the public sst/opencode CLI as a multi-vendor front-end (unified session/auth)** → `opencode-cli` (needs the local `opencode` CLI + an Anthropic/OpenAI env key, [RFC-029](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-029-opencode-runtime-integration.md))
 - **Reach a vendor that's NOT in the built-in list** (GLM / Kimi / OpenRouter / vLLM / SiliconFlow / Qwen ...) → `claude-agent-sdk` + pick `custom` in the vendor submenu + `ANTHROPIC_BASE_URL`
-- **Mix and match (recommended)** → run all five on one Hub, pick the best engine per role
+- **Mix and match (recommended)** → combine currently available runtimes by role on one Hub
 :::
 
 ::: tip Wizard order at a glance

--- a/docs-site/docs/guide/grok-copresence.md
+++ b/docs-site/docs/guide/grok-copresence.md
@@ -1,91 +1,20 @@
-# Grok 人机共存 TUI（`grok-build-cli`，preview）
+# Grok 人机共存 TUI（未发布）
 
-`grok-build-cli` runtime 让你 **attach 到 agent-node 持有的那个真实 Grok TUI**。你和 CommHub 网络任务共享同一段 Grok 会话：网络任务进入同一个 Grok session、在终端里实时渲染、完成后把答复回传给任务发起者，而你随时能在旁边一起看、一起打字——人和 agent 同处一个会话上下文。
-
-> `grok-build-acp` 是独立的 ACP（`grok agent stdio`）路径，**不支持 attach**。需要人机共存请用 `grok-build-cli`。
-
-::: warning Preview
-这是 **preview**，不属于 latest/生产。只连接可信 Hub 与可信任务。
+::: danger 当前不可用
+`grok-build-cli` 和 `anet grok attach` **尚未进入 npm `latest` 或 `preview`**。不要照旧文档执行 `anet node create ... --runtime grok-build-cli`；当前发布包不包含这条路径。
 :::
 
-## 前提
+项目中已有让人和网络任务共享同一个 Grok TUI 的候选实现，但它仍在重新验收，不能视为已发布功能。进度与实测证据见 [Issue #537](https://github.com/sleep2agi/agent-network/issues/537) 和 [Draft PR #538](https://github.com/sleep2agi/agent-network/pull/538)。
 
-- **Linux**（需要 `/proc` 与 `/proc/self/fd` 可用）
-- **Node.js ≥ 22.13**
-- 已安装并登录**精确版本**的 Grok CLI：`grok 0.2.93 (f00f96316d)`（末尾允许 `[stable]`），且由**运行 anet 的同一 OS 用户**执行 `grok login`。
+## 现在可以用什么
+
+- `grok-build-acp`：当前正式 Grok runtime，通过 `grok agent stdio` 执行网络任务；**不能 attach 到同一个 TUI**。
+- `grok`：可直接在终端使用 Grok CLI，但这不会把该 TUI 变成 Agent Network 共存节点。
 
 ```bash
-# 装精确版本（共存对 grok 版本敏感）——install.sh 支持 bash -s <版本>
-curl -fsSL https://x.ai/cli/install.sh | bash -s 0.2.93
 grok login
-grok --version   # 必须是 grok 0.2.93 (f00f96316d)
+anet node create grok-agent --runtime grok-build-acp
+anet node start grok-agent
 ```
 
-## 安装
-
-```bash
-npm install -g @sleep2agi/agent-network@preview
-```
-
-只需安装 `agent-network`；首次 `node start` 会自动拉取并校验 `agent-node@preview`（因此首次启动需要 npm registry 或已有缓存）。
-
-如需锁死本次验证过的组合：
-
-```bash
-npm install -g \
-  @sleep2agi/agent-network@2.3.0-preview.23 \
-  @sleep2agi/agent-node@2.5.0-preview.21
-```
-
-## 最小流程
-
-若尚未配置 CommHub，先按 [快速开始](./getting-started.md) 启动并登录 Hub。然后在**目标项目目录**：
-
-```bash
-# Terminal 1：创建并启动共存节点
-anet node create grok-shared --runtime grok-build-cli
-anet node start grok-shared
-```
-
-等启动日志出现提示：
-
-```text
-attach with anet grok attach grok-shared
-```
-
-再从**同机、同 OS 用户、同一项目目录**的真实交互终端：
-
-```bash
-# Terminal 2
-anet grok attach grok-shared
-```
-
-- attach 没有其他必需 flag。
-- `Ctrl-]` 只会 **detach**，不会停止节点。
-- 要开始接收网络任务，等日志出现 `SSE connected`。
-
-## 三种 Grok 路径的区别
-
-| 配置 | 执行方式 | 可 attach |
-|---|---|---|
-| `--runtime grok-build-cli` | 共存 TUI | ✅ 是 |
-| `--runtime grok-build-cli --grok-headless` | 每任务一个 CLI turn | ❌ 否 |
-| `--runtime grok-build-acp` | `grok agent stdio` ACP | ❌ 否 |
-
-想要共存 attach，**不要**加 `--grok-headless`。
-
-## Caveats
-
-- **仅 Linux**，需要 `/proc` 与 `/proc/self/fd`。
-- Grok 必须是精确的 `0.2.93 (f00f96316d)`，并由同一 OS 用户 `grok login`。
-- attach 必须是**真实 TTY**，且从同机、同用户、同一项目目录运行。
-- 共存会话是固定的 **text-only `[todo_write]` profile**：没有 filesystem、shell、network、media、MCP 或 subagent 工具。
-- 这条路径**没有 Grok MCP tool handshake**——不要按旧文档「等待几秒 MCP 握手」；attach 以启动日志提示为准，接收任务以 `SSE connected` 为准。
-- 项目目录中的 MCP / LSP / hooks / plugins / permission / sandbox / `.envrc` 等可执行配置会触发 **fail-closed**（拒绝启动/恢复）。
-- 当前**明确拒绝** Feishu channel。
-- 只连接可信 Hub 与可信任务；这是 preview，不属于 latest/生产。
-
-## 参考
-
-- [节点 Runtime 对比](./runtimes.md)
-- [Grok Build 运行时说明](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md)
+功能正式进入发布包后，本页才会恢复安装与 attach 步骤。发布频道说明见[版本说明](./versioning.md)。

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -7,7 +7,7 @@
 > 本表是全站 runtime 信息的**单一权威来源**, 其他页面 (`cli` / `agent-node` / `getting-started` / `clean-server`) 都引用这里, 别在那些页面里重复整表.
 
 ::: tip 哪些 runtime 在哪个版本可用（真机实测）
-- **正式版**（`npm i -g @sleep2agi/agent-network`, 当前 2.2.21）：**4 种正式 runtime** —— `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`。
+- **正式版**（`npm i -g @sleep2agi/agent-network`）：**4 种正式 runtime** —— `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`。具体版本以 npm `latest` dist-tag 为准。
 - **预览版**（`@preview`）：在正式 4 种之外再加 `codex-app-server` / `opencode-cli`（共 **6 种**）；且对未知 runtime 会明确报错拦截（正式版会**静默退化**成默认 runtime，不报错）。
 
 下表标 `(preview)` 的行**仅预览版可用**，正式版选不到。

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -13,6 +13,10 @@
 下表标 `(preview)` 的行**仅预览版可用**，正式版选不到。
 :::
 
+::: warning Grok TUI 共存尚未发布
+`grok-build-cli` / `anet grok attach` 不在当前 `latest` 或 `preview` 包中，因此不属于下面的可选 runtime。当前请使用 `grok-build-acp`；它不支持 attach。详见 [Grok TUI 状态页](/guide/grok-copresence)。
+:::
+
 | Runtime | npm 包 / 内核 | 适用场景 | 主推模型 | 前置 auth | wizard 行为 (`anet node create`) |
 |---|---|---|---|---|---|
 | `claude-code-cli` **⭐推荐入门** | spawn 本机 `claude` 命令 | 想"像在终端用 Claude"那样干活, **复用 Claude 订阅 0 配置**（有 Claude 订阅的**首选**，最稳） | Claude Sonnet / Opus (订阅) | 已 `claude auth login` | 选完直接结束, **跳过 vendor / model / API key** |
@@ -30,10 +34,9 @@
 - **写代码 / 跑命令** → `codex-sdk`
 - **人和 Agent 共用一个 Codex TUI/thread** → preview `codex-app-server` + `anet node start <alias> --copresence`（[完整指南](/guide/codex-copresence)）
 - **用 xAI Grok Build** → `grok-build-acp` ([详细 runtime 指南 ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md))
-- **想人和 agent 同时用同一个 Grok TUI（共存，attach 到活的 Grok 会话）** → `grok-build-cli` ([Grok 人机共存 TUI · preview](/guide/grok-copresence))
 - **想用公版 sst/opencode CLI 当多 vendor 前端（统一 session/auth）** → `opencode-cli`（需本机装 `opencode` CLI + Anthropic/OpenAI env key，[RFC-029](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-029-opencode-runtime-integration.md)）
 - **接国产 / 非内置 vendor** (GLM / Kimi / OpenRouter / vLLM / SiliconFlow / 通义千问 等) → `claude-agent-sdk` + 在 vendor 子菜单选 `自定义 (custom)` + `ANTHROPIC_BASE_URL`
-- **混搭 (推荐)** → 同一 Hub 五种全开, 每个角色挑最合适的内核
+- **混搭 (推荐)** → 在同一 Hub 按角色组合当前可用 runtime
 :::
 
 ::: tip wizard 顺序速览

--- a/docs/tests/report-grok-tui-doc-correction-2026-07-31.txt
+++ b/docs/tests/report-grok-tui-doc-correction-2026-07-31.txt
@@ -24,6 +24,8 @@ Documentation result
 - Corrected the changelog's current-preview summary and marked the old entry
   as a historical candidate record whose commands must not be run.
 - Removed the stale "run all five" runtime count.
+- Replaced a hardcoded "current stable 2.2.21" label with the authoritative
+  npm latest dist-tag rule.
 
 Static verification
 -------------------

--- a/docs/tests/report-grok-tui-doc-correction-2026-07-31.txt
+++ b/docs/tests/report-grok-tui-doc-correction-2026-07-31.txt
@@ -8,13 +8,19 @@ Scope
 - Bilingual runtime guide
 - Bilingual changelog correction notice
 
-Authoritative package check
----------------------------
+Published CLI check
+-------------------
 - @sleep2agi/agent-network: latest 2.2.21, preview 2.3.0-preview.36
 - @sleep2agi/agent-node: latest 2.4.13, preview 2.5.0-preview.27
-- Downloaded both current preview tarballs from npm and searched their built
-  JavaScript for grok-build-cli, anet grok attach, and the Grok co-presence
-  capability marker: zero matches.
+- Under Node 22.23.2 with an isolated HOME, the real published CLIs returned:
+    npx -y @sleep2agi/agent-network@2.2.21 grok attach probe-node
+    -> Unknown: grok (exit 1)
+    npx -y @sleep2agi/agent-network@2.3.0-preview.36 grok attach probe-node
+    -> Unknown: grok (exit 1)
+- Auxiliary only: searching downloaded, built JavaScript found no literal
+  Grok co-presence markers. This is not an availability gate: minification or
+  escaped/obfuscated strings can cause false negatives. Executing the real
+  package command above is the authoritative evidence.
 
 Documentation result
 --------------------
@@ -37,5 +43,5 @@ Static verification
 - Linked versioning pages exist: PASS
 
 No Docker image or npm package was built. This is a Markdown-only correction;
-the user requested conserving Codex/Claude quota, and the npm tarballs plus
+the user requested conserving Codex/Claude quota. Published CLI execution plus
 source/static checks are the relevant availability evidence.

--- a/docs/tests/report-grok-tui-doc-correction-2026-07-31.txt
+++ b/docs/tests/report-grok-tui-doc-correction-2026-07-31.txt
@@ -1,0 +1,39 @@
+Grok TUI documentation correction
+Date: 2026-07-31
+Base: origin/main f78c9373
+
+Scope
+-----
+- Bilingual Grok co-presence guide
+- Bilingual runtime guide
+- Bilingual changelog correction notice
+
+Authoritative package check
+---------------------------
+- @sleep2agi/agent-network: latest 2.2.21, preview 2.3.0-preview.36
+- @sleep2agi/agent-node: latest 2.4.13, preview 2.5.0-preview.27
+- Downloaded both current preview tarballs from npm and searched their built
+  JavaScript for grok-build-cli, anet grok attach, and the Grok co-presence
+  capability marker: zero matches.
+
+Documentation result
+--------------------
+- Replaced each 91-line install guide with a 20-line not-released status page.
+- Removed grok-build-cli from runtime recommendations.
+- Kept grok-build-acp as the currently available, non-attachable Grok path.
+- Corrected the changelog's current-preview summary and marked the old entry
+  as a historical candidate record whose commands must not be run.
+- Removed the stale "run all five" runtime count.
+
+Static verification
+-------------------
+- git diff --check: PASS
+- Unsupported install commands absent from both live status pages: PASS
+- Unpublished runtime absent from both recommendation lists: PASS
+- Current availability warning present in both runtime pages: PASS
+- Changelog correction present in both languages: PASS
+- Linked versioning pages exist: PASS
+
+No Docker image or npm package was built. This is a Markdown-only correction;
+the user requested conserving Codex/Claude quota, and the npm tarballs plus
+source/static checks are the relevant availability evidence.


### PR DESCRIPTION
## What changed

- replace the bilingual Grok co-presence install guides with concise not-released status pages
- remove `grok-build-cli` from current runtime recommendations
- keep `grok-build-acp` as the available, non-attachable Grok path
- correct the changelog's current-preview summary and label the old Grok entry as a historical candidate record
- remove the stale "run all five" runtime count

## Why

The current npm `latest` and `preview` packages do not contain `grok-build-cli`, `anet grok attach`, or the Grok co-presence capability marker. The public docs nevertheless presented the feature and old preview pins as installable, sending users to commands that cannot work.

## Impact

Users now get one accurate path: use `grok-build-acp` today, and follow #537 / #538 for the unreleased shared-TUI work. The live guides are 71 lines shorter per language.

## Validation

- with Node 22.23.2 and an isolated HOME, real published CLIs both reject the command: `agent-network@2.2.21 grok attach probe-node` → `Unknown: grok`, rc=1; `agent-network@2.3.0-preview.36 grok attach probe-node` → the same result
- checked npm dist-tags and downloaded the current preview tarballs (`agent-network@2.3.0-preview.36`, `agent-node@2.5.0-preview.27`); all Grok co-presence markers had zero matches
- `git diff --check`
- bilingual negative checks for unsupported install commands and recommendations
- bilingual positive checks for availability warnings and changelog corrections
- internal versioning links exist

Detailed evidence: `docs/tests/report-grok-tui-doc-correction-2026-07-31.txt`.

Draft only; no merge, npm publish, or deployment is requested.
