### PR TITLE
docs: replace verbose FAQ with concise answers

### DIFF
--- a/docs-site/docs/en/faq.md
+++ b/docs-site/docs/en/faq.md
@@ -1,424 +1,121 @@
 # FAQ
 
-Frequently asked questions and answers.
-
-::: tip First time using anet?
-- Want to run your first agent → [Getting Started](/en/guide/getting-started) (install + dispatch in 30 seconds)
-- Wondering about version numbers → [Versioning](/en/guide/versioning) (npm package versions vs `v0.10.x` bundle releases)
-- Didn't find your answer → [Troubleshooting](/en/troubleshooting) / [Discussions](https://github.com/sleep2agi/agent-network/discussions)
-:::
+This page answers common questions. Use [Getting Started](/en/guide/getting-started) for installation and [Troubleshooting](/en/troubleshooting) for specific errors.
 
 ## Basics
 
-### 1. What is Agent Network? How does it differ from LangChain / CrewAI?
+### What is Agent Network?
 
-Agent Network is a **multi-agent communication infrastructure**, not an agent framework. It doesn't care how your agent "thinks" -- it's solely responsible for enabling multiple agents to communicate, dispatch tasks, and track results.
+It is a self-hosted communication layer for multiple agents. CommHub handles identity, tasks, and messages; agents discover teammates through MCP and receive work over SSE. It does not prescribe how an agent reasons internally.
 
-| Comparison | Agent Network | LangChain / CrewAI |
-|------|-------------|-------------------|
-| Positioning | Communication infrastructure | Agent framework |
-| Protocol | MCP standard protocol | Custom |
-| Models | Any model mix | Typically single model |
-| Deployment | Distributed (multi-machine) | Typically single process |
-| Management | CLI + Dashboard | Code-defined |
+### Is it free? Do I need a server?
 
-### 2. Do I need a server?
+The code is licensed under Apache 2.0 and can be self-hosted. Personal setups can run the Hub locally. For teams or multiple machines, run the Hub somewhere every node can reach. The project does not provide an official hosted Hub.
 
-**Development / personal use**: `anet hub start` starts on your local machine -- no extra server needed.
+### Which agents and models are supported?
 
-**Team use**: We recommend deploying CommHub Server on a dedicated server, with team members each connecting remotely. Minimum config: 1 core, 1GB RAM.
+Authentication and capabilities depend on the runtime. Use the [runtime table](/en/guide/runtimes) and [model-provider guide](/en/guide/multi-model) instead of runtime counts or model versions copied from older posts.
 
-### 3. Is it free?
+Stable features follow npm `latest`. Check [version channels](/en/guide/versioning) and the published packages before relying on an experimental feature.
 
-**Apache-2.0 open source and fully self-hosted.** The repository license does not require purchasing a product license and there is no official hosted SaaS, but the current stable server code still contains a legacy trial/pro-license table plus a `send_task` expiry check.
+## Installation and configuration
 
-- Public repo, modifiable source
-- Business model = courses + consulting, not a forced hosted SaaS
-- `anet license` / `anet activate` are v0.6 legacy commands, **no longer needed after Apache 2.0 OSS**. If you hit `license_expired` (Hub still creates a 14-day trial for backward-compat), follow [troubleshooting — license_expired](/en/troubleshooting#license-expired-license-expired-legacy-behavior) to clear the `licenses` table.
+### What environment is required?
 
-::: info v0.6 license path planned for removal
-The server still runs `licenses.expires_at` checks inside `send_task` (V3 legacy code; verify [`server/src/tools.ts` still emits `license_expired`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts)) — **no v0.9.x or v0.10.x stable release touched the license path** (per-release detail in the [changelog](/en/changelog)); planned for v0.11+ removal.
-:::
-
-### 4. Which AI models are supported?
-
-Any model that supports the Anthropic Messages API can be integrated via the `claude-agent-sdk` runtime. Providers **built into** the `anet node create` `VENDORS` list (every entry is verified-with-real-call before it lands — see [runtimes — Verified vs not](/en/guide/runtimes#verified-vs-not)):
-
-- **Anthropic** native SDK (Claude Sonnet / Opus / Haiku; see [Anthropic Models](https://docs.anthropic.com/claude/docs/models-overview))
-- **MiniMax** (Anthropic-compatible; see [MiniMax platform](https://platform.minimaxi.com))
-- **DeepSeek** (Anthropic-compatible; see [DeepSeek platform](https://platform.deepseek.com))
-- **InternLM** (Anthropic-compatible; see [InternLM chat](https://chat.intern-ai.org.cn))
-- **Xiaomi MiMo** (Anthropic-compatible; see [Xiaomi platform](https://platform.xiaomimimo.com))
-- **OpenAI Codex** (`codex-sdk` runtime; see OpenAI Codex docs)
-- **xAI Grok** (`grok-build-acp` runtime over ACP protocol; currently only enabled via the `--runtime grok-build-acp` flag — [detailed runtime guide ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md))
-
-Providers NOT in the `VENDORS` list (Zhipu GLM / Moonshot Kimi / OpenRouter, etc.) — reach them via the `custom` vendor: any Anthropic-compatible API accepts a base URL + model id there; usable, but verify it yourself first.
-
-Full endpoint table + configuration examples at [Multi-model](/en/guide/multi-model). Any provider that supports the Anthropic Messages API works via `ANTHROPIC_BASE_URL`.
-
-### 4a. I have a Claude subscription (Claude Code) — what's the fastest way to start?
-
-**This is the easiest path — zero API keys, zero model picking.** Prerequisite: Claude Code CLI installed locally (`npm i -g @anthropic-ai/claude-code`) and logged in via `claude auth login`. Then:
+Use Node.js ≥ 22.13 and Bun. The shortest install command is:
 
 ```bash
-anet node create my-agent     # in the wizard, MANUALLY pick claude-code-cli
-anet node start my-agent
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
 ```
 
-::: warning Don't just press Enter
-The `anet node create` wizard **highlights `claude-agent-sdk` by default**, so hitting Enter all the way lands you on the "fill in a vendor + API key" path. For the zero-config route, **manually select `claude-code-cli`** at the runtime step.
-:::
+If global installation fails with `EACCES`, install Node 22 through nvm/fnm instead of using `sudo npm` or changing system-directory permissions.
 
-Once you pick `claude-code-cli`, the agent runs off your existing Claude Code login — no vendor key, no model selection. Full 5-minute walkthrough (including phone control) in [Getting Started — fastest path](/en/guide/getting-started).
+### Where are configuration and data stored?
 
-### 5. How many agents can a single network support?
+| Path | Contents |
+|---|---|
+| `~/.anet/config.json` | Current Hub, user token, and network |
+| `<project>/.anet/nodes/<alias>/config.json` | Node runtime, identity, and flags |
+| `<project>/.anet/nodes/<alias>/.env` | Optional node secrets; plaintext with expected mode `0600` |
+| `~/.commhub/commhub.db` | Hub SQLite database |
 
-There is no hard technical limit. In our testing:
+Do not commit `.anet`, tokens, or `.env`. envRef keeps a secret out of `config.json`; it does not promise that the secret is never stored on disk. See the [security model](/en/concepts/security).
 
-- **10 agents**: Completely smooth
-- **50 agents**: Normal operation
-- **100 agents**: Slight SSE push delay (< 1s)
+### The Hub will not start, or port 9200 is busy
 
-SQLite WAL mode supports high-concurrency reads and writes. The bottleneck is typically the AI model's response time.
-
-## Installation and Configuration
-
-### 6. Permission error during install (EACCES)
+Check the health endpoint and port owner first:
 
 ```bash
-# Option 1: Use nvm to manage Node.js (recommended)
-nvm install 20
-nvm use 20
-npm install -g @sleep2agi/agent-network
-
-# Option 2: Change npm global directory
-mkdir ~/.npm-global
-npm config set prefix '~/.npm-global'
-echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.bashrc
-source ~/.bashrc
-npm install -g @sleep2agi/agent-network
-```
-
-### 7. bun command not found
-
-```bash
-# Install Bun
-curl -fsSL https://bun.sh/install | bash
-
-# Refresh PATH
-source ~/.bashrc
-# or
-export PATH="$HOME/.bun/bin:$PATH"
-
-# Verify
-bun --version
-```
-
-### 8. anet hub start reports port in use
-
-```bash
-# Check what's using the port
+curl http://127.0.0.1:9200/health
 lsof -i :9200
-# or
-ss -tlnp | grep 9200
-
-# Use a different port
-anet hub start --port 9201
-
-# Or stop the process using it
-kill <PID>
-
-# anet hub stop subcommand ([#200](https://github.com/sleep2agi/agent-network/issues/200), shipped v0.10.11, already in @latest)
-# SIGTERM → 3s → SIGKILL fallback; no manual PID lookup needed
-anet hub stop          # default port 9200
-anet hub stop --port 8080
 ```
 
-::: tip Easier from v0.10.11 onward
-v0.10.11 ([#200](https://github.com/sleep2agi/agent-network/issues/200)) introduces `anet hub stop`, removing the manual `lsof + kill <PID>` step. Already in `@latest`; existing users just run `anet upgrade`.
-:::
+Use `anet hub start --port <port>` for another port, or `anet hub stop` to stop a Hub launched by anet. See [Troubleshooting](/en/troubleshooting) for startup, password, and database failures.
 
-### 9. Where are the config files?
+## Nodes and tasks
 
-| File | Path | Contents |
-|------|------|------|
-| Global config | `~/.anet/config.json` | Hub address, `utok_`, current active network |
-| Node config | `{cwd}/.anet/nodes/<alias>/config.json` | Runtime, model, tools, `ntok_`, env, flags (directory name is the alias, not the internal `node_id`) |
-| Node env file (v0.10.10+) | `{cwd}/.anet/nodes/<alias>/.env` | API key auto-sourced via envRef Option A (mode 0600; written by `anet node create`, auto-sourced by `anet node start` at launch; [see envRef wizard auto-source](/en/guide/cli#anet-node-create)) |
-| Database | `~/.commhub/commhub.db` | Hub-side SQLite (WAL mode) |
+### Why does a node stay offline?
 
-## Agent Issues
+Check in this order:
 
-### 10. Agent stays offline after starting
+1. Reach the Hub's `/health` endpoint from the node machine.
+2. Confirm the node config points to the intended Hub and network.
+3. Run `anet logs <alias> --follow` and wait for `SSE connected`.
+4. After changing runtime, token, or identity config, stop the old process before starting another one with the same alias.
 
-Possible causes:
+### Why did a message not trigger the agent?
 
-1. **Network unreachable**: Check if the agent can access the CommHub Server
+Use `send_task` for work that should invoke the model. `send_reply` carries a task result, while `send_message` is ordinary chat; neither invokes the model again, which prevents reply loops. See the [task lifecycle](/en/concepts/task-lifecycle).
+
+### How do I inspect logs?
 
 ```bash
-curl http://YOUR_IP:9200/health
+anet logs <alias>
+anet logs <alias> --follow
 ```
 
-2. **Invalid token**: Check if the token is valid
+For Docker deployments, use `docker compose logs -f <service>`. Do not paste tokens, API keys, or complete environment dumps into a public issue.
+
+## Identity and networks
+
+### What are `utok_`, `ntok_`, and `atok_`?
+
+- `utok_`: user/CLI identity; access also depends on membership in the target network.
+- `ntok_`: node identity, restricted to its bound network.
+- `atok_`: legacy API token retained for older clients.
+
+Do not use a token as an alias or share one `ntok_` between nodes. See [tokens and permissions](/en/concepts/tokens) for the complete boundary.
+
+### Can I copy a node config to another machine?
+
+No. Log in on the target machine, select the target network, and run `anet node create` there so the Hub issues a new node identity and token. Copying `config.json` also copies `node_id` / `ntok_` and can create identity conflicts.
+
+### I forgot a password
+
+On the Hub host, have an administrator run:
 
 ```bash
-anet whoami
+anet hub admin reset-user --username <username>
 ```
 
-3. **Firewall**: Ensure port 9200 is open
+Do not delete user rows directly from SQLite; that bypasses audit and related-data handling. See the [account model](/en/guide/account-system) for password rules and token revocation behavior.
 
-```bash
-ufw allow 9200
-```
+## Deployment
 
-4. **Heartbeat timeout**: If the agent ran normally then crashed, wait 10 minutes for timeout or manually restart
+### Can I expose ports 9200 and 3000 directly to the internet?
 
-### 11. Agent processes a task but result isn't returned
+Not recommended. Change the initial password, then put Caddy/Nginx with TLS and access control in front. Do not expose the Hub, Dashboard, or admin endpoints directly. Follow the [production guide](/en/deploy/production).
 
-Check the agent's message type handling logic:
+### Is PostgreSQL supported?
 
-- `task` / `broadcast` -> AI processes and replies (correct)
-- `reply` / `message` / `ack` -> No processing (correct, prevents think loops; see [Task lifecycle — Message types](/en/concepts/task-lifecycle#message-types))
+SQLite is the currently maintained and verified default. A PostgreSQL compatibility entry point in the code is not a production-support guarantee; do not use it in production without the missing E2E coverage.
 
-If using the `claude-code-cli` runtime, check that the project-root `CLAUDE.md` contains the right reply rules (CLAUDE.md is the instruction file Claude Code auto-loads).
+### Why does SSE disconnect?
 
-### 12. Two agents sending messages back and forth in an infinite loop
+Check the network, firewall, and reverse-proxy timeouts. Nginx/Caddy must allow long-lived connections and disable response buffering for SSE. See [Production](/en/deploy/production) and [Troubleshooting](/en/troubleshooting).
 
-This is a message type design issue. Ensure:
+## Still stuck?
 
-- Use `send_task` for tasks (type=task) -> triggers AI processing
-- Use `send_reply` for results (type=reply) -> does NOT trigger AI processing
-- Use `send_message` for chat (type=message) -> does NOT trigger AI processing
-
-If looping persists, verify that agent-node only responds to `new_task` and `broadcast` events.
-
-### 13. MiniMax Agent reports API errors
-
-```bash
-# Check if the API key is correct
-curl -H "Authorization: Bearer $MINIMAX_API_KEY" \
-  https://api.minimaxi.com/anthropic/v1/messages \
-  -d '{"model":"<minimax-model-id>","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}'
-# Replace <minimax-model-id> with the current model id supported by your MiniMax account (check https://platform.minimaxi.com)
-```
-
-Note:
-
-- `ANTHROPIC_BASE_URL` must be `https://api.minimaxi.com/anthropic` (note the `/anthropic` suffix)
-- MiniMax uses `ANTHROPIC_AUTH_TOKEN` for the key (**not** `ANTHROPIC_API_KEY` — the latter is only for direct api.anthropic.com calls; see [runtimes — claude-agent-sdk pitfalls](/en/guide/runtimes#claude-agent-sdk))
-
-### 14. How do I view detailed agent logs?
-
-```bash
-# Agent started via anet
-anet logs coder-1                # recent slice
-anet logs coder-1 --follow       # live tail (like `tail -f`)
-
-# Agent started via npx: check terminal output directly
-
-# Agent in Docker
-docker compose logs -f worker-1
-
-# CommHub Server logs
-docker compose logs -f server
-```
-
-## Network and Permissions
-
-### 15. What's the difference between utok_ and ntok_? When should I use which?
-
-| Token | Purpose | Can Do | Cannot Do |
-|-------|------|---------|-----------|
-| `utok_` | CLI / Dashboard login | Cross-network reads; MCP writes within a network when role ≥ member (owner / admin / member can write, viewer is read-only — see [tokens — auth decision](/en/concepts/tokens#authorization-decision-how-the-hub-decides)) | viewer writes in that network; writes against networks where the user isn't a member |
-| `ntok_` | Agent connection | All member+ operations within the locked single network (hub force-binds network_id) | Cross-network |
-
-**Quick rule**: Humans use utok_, agents use ntok_.
-
-### 16. How do I add an agent to another network?
-
-```bash
-# Option 1: Invite code (recommended)
-anet network use other-network
-anet network invite --role member
-# Share the invite code with the recipient
-# Recipient runs (on their own machine): anet network join inv_xxx
-
-# Option 2: Register the node locally on the target machine (cross-machine, **do NOT copy config.json**)
-# On the target machine:
-anet login --hub http://<hub-host>:9200 --username admin --password ...
-anet network use other-network
-anet node create other-agent                   # CLI registers with the hub and gets its own ntok_
-anet node start other-agent
-```
-
-::: warning Do not copy `.anet/nodes/<name>/config.json` across machines
-The `node_id` inside the config is a unique ID the hub assigns at registration. Copying it makes two machines claim the same node and breaks SSE routing. See [networks — cross-machine deployment](/en/concepts/networks#cross-machine-deployment).
-:::
-
-### 17. How do I view/manage network members?
-
-```bash
-# View members of the current network (CLI)
-anet network members
-
-# View members (direct REST)
-curl http://localhost:9200/api/networks/net_xxx/members \
-  -H "Authorization: Bearer utok_xxx"
-
-# Invite a new member (owner/admin)
-anet network invite --role member        # Generate invite code (admin/member/viewer)
-```
-
-::: tip Role changes
-The current v0.10.x stable line still does not expose `promote` / `demote` CLI subcommands (the [changelog](/en/changelog) confirms no release in the line touched member-role management). To change roles, call [REST `/api/networks/:id/members/:user_id`](/en/api/rest) directly or use the Dashboard Admin page (partial; see [Dashboard Admin](/en/guide/dashboard#admin)). Full CLI entry is scheduled for v0.11+ / unscheduled.
-:::
-
-### 17a. How do I change my password?
-
-```bash
-anet passwd                       # interactive: old password → new password ≥ 8 chars + not in weak-password dict
-```
-
-Requirements: ≥ 8 characters + not in [`password-dict.ts WEAK_PASSWORDS`](https://github.com/sleep2agi/agent-network/blob/main/server/src/password-dict.ts). **`anet passwd` and `anet hub admin reset-user` have no length exemption** — only the first-time admin **register** path allows ≥ 4 chars so that the quick-start `admin / anethub` default works (verified in [`auth.ts` `register()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts), the `isFirstUser` branch).
-
-### 17b. Forgot my password — how to reset?
-
-**Option A (recommended)**: Reset via admin on the Hub machine:
-
-```bash
-anet hub admin reset-user <username>   # force-reset a user's password; no old password needed
-# → generates a new random password + revokes all of that user's utok_ + issues a fresh utok_ + writes audit_log password_reset_by_admin
-```
-
-**Option B (last resort, if you can't even reach the Hub machine)**: Edit SQLite directly AND remove the admin marker:
-
-```bash
-# 1. Delete the user row
-sqlite3 ~/.commhub/commhub.db "DELETE FROM users WHERE username='admin'"
-
-# 2. CRITICAL: delete the admin-utok.json marker (otherwise `anet hub start` will skip register and not recreate admin)
-rm -f ~/.anet/server/admin-utok.json
-
-# 3. Restart the hub to trigger the non-interactive bootstrap (outputs '✅ Admin account created')
-anet hub start
-```
-
-::: warning You must delete the marker
-`anet hub start` bootstrap is **non-interactive and idempotent**, driven by the `~/.anet/server/admin-utok.json` marker file. **Running only `DELETE FROM users` without removing the marker → hub start sees the marker and skips the register flow → admin is NOT recreated** (you'll see `✅ Admin already exists` while the DB has no admin row). See [troubleshooting → second `anet hub start` re-bootstraps admin?](/en/troubleshooting)
-:::
-
-⚠️ Option B is a last resort and clears user records; the reset is not recorded in `audit_log`. Production should prefer Option A. See [Security design](/en/concepts/security) for details.
-
-## Deployment Issues
-
-### 18. Workers can't connect to Server in Docker Compose
-
-Ensure:
-
-1. Server health check passes before starting workers
-
-```yaml
-depends_on:
-  server:
-    condition: service_healthy
-```
-
-2. Use Docker's internal network name (`server:9200` not `localhost:9200`)
-
-3. Seed container successfully exported ntok_
-
-```bash
-docker compose logs seed
-```
-
-### 19. Dashboard deployment to Vercel fails
-
-You must use prebuilt deployment — two steps, order matters:
-
-```bash
-cd agent-network-dashboard
-vercel build --prod                  # build locally; output goes to .vercel/output
-vercel deploy --prebuilt --prod      # upload .vercel/output
-```
-
-Note that **step one must be `vercel build`, not `npm run build`** — `vercel deploy --prebuilt` only uploads the `.vercel/output` directory, which is produced by `vercel build`; running just `npm run build` leaves `.vercel/output` empty or stale. Building locally instead of on Vercel saves build cost and avoids missing environment variables.
-
-### 20. What about PostgreSQL support?
-
-::: warning Not recommended on the current stable line
-The code has a `DATABASE_URL=postgres://...` entry point, but PostgreSQL **has not been end-to-end verified on the current stable line** — don't use it in production yet.
-
-For now, please stick with the default **SQLite** (`~/.commhub/commhub.db`). SQLite handles 100+ agents on a single machine just fine for the supported deployment shape.
-
-Note: **v0.8+ product direction is SQLite only** (see [docs/v3-postgresql-design.md banner](https://github.com/sleep2agi/agent-network/blob/main/docs/v3-postgresql-design.md)) — Postgres is no longer on the maintained roadmap. The adapter interface is preserved as a community extension point — if you have a real HA / multi-writer use case, open a [GitHub Discussion](https://github.com/sleep2agi/agent-network/discussions) to coordinate a self-hosted approach.
-:::
-
-## Performance Issues
-
-### 21. Slow task response
-
-Check:
-
-1. **AI model latency**: Different models have different response times
-   - Codex (codex-sdk): 3-15 seconds
-   - Claude: 5-30 seconds
-   - MiniMax: 1-5 seconds
-2. **Network latency**: Latency between agent and server
-3. **Server load**: Run `anet doctor` to check server status
-4. **Database size**: Large amounts of historical data may affect query speed
-
-### 22. SSE connections frequently dropping
-
-Possible causes:
-
-- Unstable network
-- Reverse proxy timeout set too short
-- Firewall closing long connections
-- nginx `proxy_buffering` left at the default `on` (must be `off` for SSE, otherwise events sit in the buffer until it fills)
-
-> **The agent reconnects on its own when the stream drops**: since [#202](https://github.com/sleep2agi/agent-network/issues/202), agent-node uses exponential backoff `1s → 30s` cap + re-register on every successful (re)connect + give up after 1h continuous failure. If the hub restarted and the dashboard can no longer see your nodes, see [troubleshooting — Dashboard shows no nodes after a hub restart](/en/troubleshooting#dashboard-shows-no-nodes-after-a-hub-restart).
-
-Nginx configuration recommendation:
-
-```nginx
-location /events/ {
-    proxy_pass http://127.0.0.1:9200;
-    proxy_http_version 1.1;
-    proxy_set_header Connection "";
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # rate limit needs real client IP
-    proxy_read_timeout 86400;   # 24 hours
-    proxy_buffering off;
-    proxy_cache off;
-}
-
-# Also pass X-Forwarded-For on /api/* + /mcp so audit_log records the real IP
-location / {
-    proxy_pass http://127.0.0.1:9200;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $host;
-}
-```
-
-::: tip Rate-limit IP detection
-The hub's register / login endpoints take `req.headers["x-forwarded-for"]?.split(",")[0]` as the `clientIP` passed to `checkRateLimit` ([`index.ts` `POST /api/auth/register` / `POST /api/auth/login` handlers](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)). If the reverse proxy doesn't set `X-Forwarded-For`, all requests appear to come from the same IP (the proxy itself) — rate limiting then mis-trips on every user.
-:::
-
-## Next steps
-
-**Getting-started tutorials**:
-- [One-shot install](/en/guide/one-shot-install) — first agent after install
-- [Getting started](/en/guide/getting-started) — install through first run
-
-**Dig into concepts**:
-- [Security design](/en/concepts/security) — tokens / passwords / isolation
-- [Account system](/en/guide/account-system) — utok_ / ntok_ / password relationship
-- [Architecture](/en/guide/architecture) — overall system design
-
-**Upgrade and troubleshooting**:
-- [v0.7 → v0.8 upgrade](/en/guide/upgrade#v0-7-v0-8-upgrade-notes-latest) — admin bootstrap / password management
-- [Troubleshooting](/en/troubleshooting) — common errors
-- `anet doctor --fix` — auto-probe + reissue ntok_
-
-**Community**:
-- [GitHub Issues](https://github.com/sleep2agi/agent-network/issues) — bug reports / feature requests
-- [Community](/en/community) — join the discussion
+- Run `anet doctor` for non-secret diagnostics.
+- Search [Issues](https://github.com/sleep2agi/agent-network/issues) and [Discussions](https://github.com/sleep2agi/agent-network/discussions).
+- Include versions, runtime, a minimal reproduction, and redacted logs. Report security issues through a [GitHub Security Advisory](https://github.com/sleep2agi/agent-network/security/advisories/new).

--- a/docs-site/docs/faq.md
+++ b/docs-site/docs/faq.md
@@ -1,424 +1,121 @@
 # FAQ
 
-常见问题解答。
+这里回答最常见的问题。安装步骤见[上手指南](/guide/getting-started)，具体报错见[故障排查](/troubleshooting)。
 
-::: tip 第一次用 anet?
-- 想跑通第一个 agent → [上手指南](/guide/getting-started) (30 秒装好 + 派任务)
-- 想知道版本号含义 → [版本号体系](/guide/versioning) (npm 包版 vs `v0.10.x` bundle release)
-- 没找到答案 → [故障排查](/troubleshooting) / [Discussions](https://github.com/sleep2agi/agent-network/discussions)
-:::
+## 基础
 
-## 基础问题
+### Agent Network 是什么？
 
-### 1. Agent Network 是什么？和 LangChain / CrewAI 有什么区别？
+它是自部署的多 Agent 通信层：CommHub 负责身份、任务和消息，Agent 通过 MCP 发现队友，通过 SSE 接收任务。它不规定 Agent 内部怎样推理。
 
-Agent Network 是一个 **多 Agent 通信基础设施**，而不是 Agent 框架。它不关心你的 Agent 怎么"想"，只负责让多个 Agent 能互相通信、派任务、追踪结果。
+### 免费吗？需要服务器吗？
 
-| 对比 | Agent Network | LangChain / CrewAI |
-|------|-------------|-------------------|
-| 定位 | 通信基础设施 | Agent 框架 |
-| 协议 | MCP 标准协议 | 自定义 |
-| 模型 | 任意模型混搭 | 通常单模型 |
-| 部署 | 分布式（多机） | 通常单进程 |
-| 管理 | CLI + Dashboard | 代码定义 |
+代码使用 Apache 2.0 许可证，可自行部署。个人使用可把 Hub 跑在本机；跨机器或团队使用时，把 Hub 部署在一台所有节点都能访问的机器上。项目不提供官方托管 Hub。
 
-### 2. 需要服务器吗？
+### 支持哪些 Agent 和模型？
 
-**开发/个人使用**：`anet hub start` 在本地笔记本上启动，不需要额外服务器。
+不同 runtime 的鉴权和能力不同。请以 [Runtime 对比表](/guide/runtimes)和[多模型配置](/guide/multi-model)为准，不要根据旧文章里的 runtime 数量或模型版本选型。
 
-**团队使用**：建议在一台服务器上部署 CommHub Server，团队成员各自连接。最低配置 1 核 1G 内存即可。
+稳定功能跟随 npm `latest`；实验功能是否可安装，以[版本说明](/guide/versioning)和当前发布包为准。
 
-### 3. 免费吗？
+## 安装与配置
 
-**Apache-2.0 开源、self-hosted。** 代码和仓库许可证不要求购买 license，没有官方 SaaS 托管；但当前 stable 代码里仍保留 legacy trial/pro-license 表和 `send_task` 过期检查。
+### 需要什么环境？
 
-- 仓库公开、源码可改
-- 商业模式 = 卖课 + 卖服务咨询，不依赖强制官方 SaaS
-- `anet license` / `anet activate` 是 v0.6 legacy 命令，**OSS 后不再需要**；若命中 `license_expired`（Hub 后向兼容仍创建 14 天 trial），按 [troubleshooting — license_expired](/troubleshooting#license-expired-授权过期-legacy-行为) 直接清掉 `licenses` 表即可
-
-::: info v0.6 license 路径计划清理
-当前 server 在 `send_task` 仍跑 `licenses.expires_at` 检查（V3 遗留代码，verify [`server/src/tools.ts` `license_expired` 仍在](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts)）—— **v0.9.x / v0.10.x 整条 stable 线都未动 license 路径**（每个 release 的具体改动见 [changelog](/changelog)），排到 v0.11+ 整段移除。
-:::
-
-### 4. 支持哪些 AI 模型？
-
-任何支持 Anthropic Messages API 的模型都可以通过 `claude-agent-sdk` runtime 接入。`anet node create` 的 `VENDORS` 列表里**内置**的 provider（每项都是 verified-with-real-call 才进列表，详见 [runtimes 已验证 vs 未验证](/guide/runtimes#已验证-vs-未验证)）：
-
-- **Anthropic** 原生 SDK（Claude Sonnet / Opus / Haiku；查 [Anthropic Models](https://docs.anthropic.com/claude/docs/models-overview)）
-- **MiniMax**（Anthropic 兼容；查 [MiniMax 平台](https://platform.minimaxi.com)）
-- **DeepSeek**（Anthropic 兼容；查 [DeepSeek 平台](https://platform.deepseek.com)）
-- **书生 InternLM**（Anthropic 兼容；查 [书生](https://chat.intern-ai.org.cn)）
-- **小米 MiMo**（Anthropic 兼容；查 [小米开放平台](https://platform.xiaomimimo.com)）
-- **OpenAI Codex**（`codex-sdk` runtime；查 OpenAI Codex 文档）
-- **xAI Grok**（`grok-build-acp` runtime, ACP 协议；目前只通过 `--runtime grok-build-acp` flag 启用，[详细 runtime 指南 ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md)）
-
-未进 `VENDORS` 列表的 provider（智谱 GLM / Moonshot Kimi / OpenRouter 等）—— 用「自定义 `custom`」供应商接入：任何 Anthropic 兼容 API 都能填 base URL + model id，能用但请自己先跑通验证。
-
-完整 endpoint 表 + 配置示例见 [多模型配置](/guide/multi-model)。任何支持 Anthropic Messages API 的服务商都可以通过 `ANTHROPIC_BASE_URL` 接入。
-
-### 4a. 我有 Claude 订阅（Claude Code），怎么最快用起来？
-
-**这是最省事的路径 —— 零 API key、零选型。** 前提：本机装好 Claude Code CLI（`npm i -g @anthropic-ai/claude-code`）并 `claude auth login` 登录过。然后：
+需要 Node.js ≥ 22.13 和 Bun。最短安装命令：
 
 ```bash
-anet node create my-agent     # 向导里【手动选 claude-code-cli】
-anet node start my-agent
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
 ```
 
-::: warning 别一路 Enter
-`anet node create` 向导**默认高亮的是 `claude-agent-sdk`**，一路回车会落到"要填 vendor + API Key"的复杂路径。想走零配置，第一步 runtime 选择处**手动选 `claude-code-cli`**。
-:::
+如果全局安装报 `EACCES`，优先用 nvm/fnm 安装 Node 22，而不是用 `sudo npm` 或修改系统目录权限。
 
-选了 `claude-code-cli` 后，agent 直接复用你 Claude Code 的登录态跑，全程不用填任何 vendor key、不用选模型。完整 5 分钟上手（含手机指挥）见 [快速开始 — 最快路径](/guide/getting-started)。
+### 配置和数据在哪里？
 
-### 5. 一个网络最多支持多少 Agent？
+| 路径 | 内容 |
+|---|---|
+| `~/.anet/config.json` | 当前 Hub、用户 token、network |
+| `<项目>/.anet/nodes/<alias>/config.json` | 节点 runtime、身份和 flags |
+| `<项目>/.anet/nodes/<alias>/.env` | 可选的节点 secret，明文文件但权限应为 `0600` |
+| `~/.commhub/commhub.db` | Hub 的 SQLite 数据库 |
 
-技术上没有硬限制。实测：
+不要提交 `.anet`、token 或 `.env`。envRef 的作用是避免把 secret 写进 `config.json`，不是承诺 secret 永不落盘。详见[安全设计](/concepts/security)。
 
-- **10 Agent**：完全流畅
-- **50 Agent**：正常运行
-- **100 Agent**：SSE 推送有轻微延迟（< 1s）
+### Hub 启不来或端口被占用怎么办？
 
-SQLite WAL 模式支持高并发读写，瓶颈通常在 AI 模型的响应速度。
-
-## 安装和配置
-
-### 6. 安装时报权限错误（EACCES）
+先确认健康端点和占用者：
 
 ```bash
-# 方法一：使用 nvm 管理 Node.js（推荐）
-nvm install 20
-nvm use 20
-npm install -g @sleep2agi/agent-network
-
-# 方法二：修改 npm 全局目录
-mkdir ~/.npm-global
-npm config set prefix '~/.npm-global'
-echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.bashrc
-source ~/.bashrc
-npm install -g @sleep2agi/agent-network
-```
-
-### 7. 找不到 bun 命令
-
-```bash
-# 安装 Bun
-curl -fsSL https://bun.sh/install | bash
-
-# 刷新 PATH
-source ~/.bashrc
-# 或
-export PATH="$HOME/.bun/bin:$PATH"
-
-# 验证
-bun --version
-```
-
-### 8. anet hub start 报端口被占用
-
-```bash
-# 查看谁占了端口
+curl http://127.0.0.1:9200/health
 lsof -i :9200
-# 或
-ss -tlnp | grep 9200
-
-# 换个端口
-anet hub start --port 9201
-
-# 或停掉占用的进程
-kill <PID>
-
-# anet hub stop 子命令（[#200](https://github.com/sleep2agi/agent-network/issues/200) v0.10.11 起 ship，已在 npm latest）
-# SIGTERM → 3s → SIGKILL 兜底, 不用手动找 PID
-anet hub stop          # 默认端口 9200
-anet hub stop --port 8080
 ```
 
-::: tip v0.10.11 起更简单
-v0.10.11 ([#200](https://github.com/sleep2agi/agent-network/issues/200)) 加了 `anet hub stop` 命令, 不用 `lsof + kill <PID>` 手动 hack。已在 npm `latest`，老用户跑 `anet upgrade` 即得。
-:::
+可改用 `anet hub start --port <port>`，或用 `anet hub stop` 停止由 anet 启动的 Hub。更多启动、密码和数据库问题见[故障排查](/troubleshooting)。
 
-### 9. 配置文件在哪里？
+## 节点与任务
 
-| 文件 | 路径 | 内容 |
-|------|------|------|
-| 全局配置 | `~/.anet/config.json` | hub 地址、`utok_`、当前激活 network |
-| 节点配置 | `{cwd}/.anet/nodes/<alias>/config.json` | runtime、model、tools、`ntok_`、env、flags（目录名是 alias，不是内部 `node_id`） |
-| 节点 env 文件（v0.10.10+）| `{cwd}/.anet/nodes/<alias>/.env` | envRef Option A 自动 source 的 API key（mode 0600；`anet node create` 写入，`anet node start` 启动前自动 source；[详见 envRef wizard 自动衔接](/guide/cli#anet-node-create)）|
-| 数据库 | `~/.commhub/commhub.db` | hub 端 SQLite（WAL 模式） |
+### 节点一直 offline 怎么查？
 
-## Agent 问题
+按顺序检查：
 
-### 10. Agent 启动后状态一直是 offline
+1. 从节点机器访问 Hub 的 `/health`。
+2. 确认节点配置指向正确 Hub 和 network。
+3. 查看 `anet logs <alias> --follow`，等待 `SSE connected`。
+4. 若刚改过 runtime、token 或配置，停止旧进程后再启动，避免同一 alias 多实例竞争。
 
-可能的原因：
+### 任务为什么没有触发 Agent？
 
-1. **网络不通**：检查 Agent 能否访问 CommHub Server
+需要模型处理的工作用 `send_task`。`send_reply` 是任务结果，`send_message` 是普通消息；它们不会再次触发模型，避免回复循环。详见[任务生命周期](/concepts/task-lifecycle)。
+
+### 如何查看日志？
 
 ```bash
-curl http://YOUR_IP:9200/health
+anet logs <alias>
+anet logs <alias> --follow
 ```
 
-2. **Token 错误**：检查 Token 是否有效
+Docker 部署用 `docker compose logs -f <service>`。不要把含 token、API key 或完整环境变量的日志贴到公开 Issue。
+
+## 身份与网络
+
+### `utok_`、`ntok_`、`atok_` 有什么区别？
+
+- `utok_`：用户/CLI 身份，权限还取决于目标 network 的成员角色。
+- `ntok_`：节点身份，限制在绑定的 network。
+- `atok_`：兼容旧客户端的 legacy API token。
+
+不要把 token 当作 alias，也不要跨节点复用 `ntok_`。完整边界见 [Token 与权限](/concepts/tokens)。
+
+### 可以复制节点配置到另一台机器吗？
+
+不要复制。应在目标机器登录、切换到目标 network，再运行 `anet node create`，让 Hub 颁发新的节点身份和 token。复制 `config.json` 会复制 `node_id` / `ntok_`，可能造成身份冲突。
+
+### 忘记密码怎么办？
+
+在 Hub 主机上由管理员运行：
 
 ```bash
-anet whoami
+anet hub admin reset-user --username <username>
 ```
 
-3. **防火墙**：确保 9200 端口开放
+不要直接删 SQLite 用户行；那会绕过审计和关联数据处理。密码规则与 token 撤销行为见[账号体系](/guide/account-system)。
 
-```bash
-ufw allow 9200
-```
+## 部署
 
-4. **心跳超时**：如果 Agent 之前正常运行后崩溃，需要等 10 分钟超时或手动重启
+### 可以直接把 9200/3000 暴露到公网吗？
 
-### 11. Agent 处理任务后结果没有返回
+不建议。先改初始密码，再通过 Caddy/Nginx 配 TLS 和访问控制；不要把 Hub、Dashboard 或管理端点裸露在公网。按[生产部署指南](/deploy/production)逐项检查。
 
-检查 Agent 的消息类型处理逻辑：
+### PostgreSQL 支持吗？
 
-- `task` / `broadcast` 类型 -> AI 处理后回复（正确）
-- `reply` / `message` / `ack` 类型 -> 不处理（正确，避免 think 循环；详见 [Task 生命周期 — 消息类型](/concepts/task-lifecycle#消息类型)）
+当前维护和验证的默认后端是 SQLite。代码中的 PostgreSQL 兼容入口不代表生产支持；没有完成对应 E2E 前不要用于生产。
 
-如果是 `claude-code-cli` runtime，检查项目根目录 `CLAUDE.md` 中是否有正确的回复规则（CLAUDE.md 是 Claude Code 自动加载的指令文件）。
+### SSE 经常断开怎么办？
 
-### 12. 两个 Agent 互相发消息导致无限循环
+检查网络、防火墙和反向代理超时。Nginx/Caddy 必须允许长连接，并关闭 SSE 响应缓冲。配置示例见[生产部署](/deploy/production)和[故障排查](/troubleshooting)。
 
-这是消息类型设计的问题。确保：
+## 还没解决？
 
-- 发任务用 `send_task`（type=task）-> 触发 AI 处理
-- 回复结果用 `send_reply`（type=reply）-> 不触发 AI 处理
-- 日常聊天用 `send_message`（type=message）-> 不触发 AI 处理
-
-如果仍然循环，检查 agent-node 是否只响应 `new_task` 和 `broadcast` 事件。
-
-### 13. MiniMax Agent 报 API 错误
-
-```bash
-# 检查 API Key 是否正确
-curl -H "Authorization: Bearer $MINIMAX_API_KEY" \
-  https://api.minimaxi.com/anthropic/v1/messages \
-  -d '{"model":"<minimax-model-id>","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}'
-# 把 <minimax-model-id> 替换为你 MiniMax 账号当前可用的 model id（查 https://platform.minimaxi.com 控制台）
-```
-
-注意：
-
-- `ANTHROPIC_BASE_URL` 必须是 `https://api.minimaxi.com/anthropic`（注意 `/anthropic` 后缀）
-- MiniMax 用 `ANTHROPIC_AUTH_TOKEN` 传 Key（**不是** `ANTHROPIC_API_KEY`——后者仅用于 api.anthropic.com 直连。两者职责区分详见 [runtimes — claude-agent-sdk 常见坑](/guide/runtimes#claude-agent-sdk)）
-
-### 14. 如何查看 Agent 的详细日志？
-
-```bash
-# anet 启动的 Agent
-anet logs 代码1号                # 最近一段
-anet logs 代码1号 --follow       # 实时 tail（类似 tail -f）
-
-# npx 启动的 Agent：直接看终端输出
-
-# Docker 中的 Agent
-docker compose logs -f worker-1
-
-# CommHub Server 日志
-docker compose logs -f server
-```
-
-## 网络和权限
-
-### 15. utok_ 和 ntok_ 的区别？什么时候用哪个？
-
-| Token | 用途 | 能做什么 | 不能做什么 |
-|-------|------|---------|-----------|
-| `utok_` | CLI / Dashboard 登录 | 跨网络读取；在所属 network 内 role ≥ member 时可 MCP 写（owner / admin / member 可写，viewer 只读，详见 [tokens 权限决策](/concepts/tokens#权限决策-hub-端怎么判断你能不能调)） | viewer 在该网络写、跨网络写非成员的 network |
-| `ntok_` | Agent 连接 | 锁定的单网络内所有 member+ 权限操作（hub 强制锁 network_id） | 跨网络 |
-
-**简记**：人用 utok_，Agent 用 ntok_。
-
-### 16. 怎么把 Agent 加入另一个网络？
-
-```bash
-# 方法一：邀请码加入（推荐）
-anet network use other-network
-anet network invite --role member
-# 把邀请码给对方
-# 对方在自己机器上执行：anet network join inv_xxx
-
-# 方法二：在目标机器本地注册 node（跨机部署，**不要 copy config.json**）
-# 在目标机器上：
-anet login --hub http://<hub-host>:9200 --username admin --password ...
-anet network use other-network
-anet node create other-agent                   # CLI 跟 hub 注册 + 拿独立 ntok_
-anet node start other-agent
-```
-
-::: warning 不要跨机 copy `.anet/nodes/<name>/config.json`
-config 里的 `node_id` 是 hub 注册时分配的唯一 ID, 复制到另一台机器会让两台机器同时报告同一个 node, SSE 路由会乱. 详见 [networks — 跨机器部署](/concepts/networks#跨机器部署).
-:::
-
-### 17. 怎么查看/管理网络成员？
-
-```bash
-# 查看当前 network 成员（CLI）
-anet network members
-
-# 查看成员（REST 直查）
-curl http://localhost:9200/api/networks/net_xxx/members \
-  -H "Authorization: Bearer utok_xxx"
-
-# 邀请新成员（owner/admin）
-anet network invite --role member        # 生成邀请码（admin/member/viewer）
-```
-
-::: tip 角色变更入口
-当前 v0.10.x stable 线仍不提供 CLI `promote` / `demote` 子命令（[changelog](/changelog) 整条线都未触碰 member role 管理）。改角色目前要通过 [REST API `/api/networks/:id/members/:user_id`](/api/rest) 调用或 Dashboard Admin 页（部分实装，[详见 Dashboard Admin](/guide/dashboard#admin-管理面板)）。完整 CLI 入口排到 v0.11+ / 未排期。
-:::
-
-### 17a. 怎么改密码？
-
-```bash
-anet passwd                       # 交互式：输旧密码 → 输新密码 ≥ 8 字符 + 非弱密码字典
-```
-
-要求：≥ 8 字符 + 不在 [`password-dict.ts WEAK_PASSWORDS`](https://github.com/sleep2agi/agent-network/blob/main/server/src/password-dict.ts) 字典里。**`anet passwd` / `anet hub admin reset-user` 无任何长度豁免** —— 只有首次注册 admin（register 路径）才允许 ≥ 4，让 quick-start `admin / anethub` 默认成立（verify [`auth.ts` `register()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) 的 `isFirstUser` 分支）。
-
-### 17b. 忘密码怎么办？
-
-**方案 A（推荐）**：在 Hub 所在机器跑 admin reset：
-
-```bash
-anet hub admin reset-user <username>   # 强制重置某用户密码，无需老密码
-# → 生成随机新密码 + 撤销该用户全部 utok_ + 颁发新 utok_ + 写 audit_log password_reset_by_admin
-```
-
-**方案 B（兜底，连 Hub 机器都不能登的极端情况）**：直接改 SQLite + 删 admin marker：
-
-```bash
-# 1. 删用户记录
-sqlite3 ~/.commhub/commhub.db "DELETE FROM users WHERE username='admin'"
-
-# 2. 关键：删 admin-utok.json marker（否则 anet hub start 会跳过 register 不重建）
-rm -f ~/.anet/server/admin-utok.json
-
-# 3. 重启 hub 触发 non-interactive bootstrap（输出 '✅ Admin account created'）
-anet hub start
-```
-
-::: warning 必须删 marker
-`anet hub start` bootstrap 是 **non-interactive 幂等**的，幂等性靠 `~/.anet/server/admin-utok.json` marker 文件。**只 `DELETE FROM users` 不删 marker → hub start 看到 marker 还在直接跳过 register flow → admin 不会重建**（输出 `✅ Admin already exists`，但 db 里其实没 admin row）。详见 [troubleshooting → 第二次 anet hub start 还重新 bootstrap admin？](/troubleshooting)
-:::
-
-⚠️ 方案 B 是兜底，会清掉用户记录 + audit_log 不记 reset 事件。生产建议方案 A。详见 [安全设计](/concepts/security)。
-
-## 部署问题
-
-### 18. Docker Compose 中 Worker 连不上 Server
-
-确保：
-
-1. Server 健康检查通过后再启动 Worker
-
-```yaml
-depends_on:
-  server:
-    condition: service_healthy
-```
-
-2. 使用 Docker 内部网络名（`server:9200` 而非 `localhost:9200`）
-
-3. Seed 容器成功导出了 ntok_
-
-```bash
-docker compose logs seed
-```
-
-### 19. Dashboard 部署到 Vercel 失败
-
-必须使用 prebuilt 方式部署 —— 两步，顺序不能错：
-
-```bash
-cd agent-network-dashboard
-vercel build --prod                  # 本地 build，产物写入 .vercel/output
-vercel deploy --prebuilt --prod      # 上传 .vercel/output
-```
-
-注意 **第一步必须是 `vercel build`，不是 `npm run build`** —— `vercel deploy --prebuilt` 只上传 `.vercel/output` 目录，而这个目录由 `vercel build` 生成；只跑 `npm run build` 的话 `.vercel/output` 是空的或上一次的旧产物。不在 Vercel 云端 build 既省构建费，也避免环境变量缺失。
-
-### 20. PostgreSQL 支持如何？
-
-::: warning 当前 stable 暂不推荐 PostgreSQL
-代码里有 `DATABASE_URL=postgres://...` 的入口，但当前 stable 上没有做过 PostgreSQL 的 E2E 验证，**不建议生产使用**。
-
-当前请用默认的 **SQLite**（在 `~/.commhub/commhub.db`）。SQLite 已经能跑到 100+ Agent 规模，单机部署足够。
-
-注：**v0.8+ 产品方向已转 SQLite only**（见 [docs/v3-postgresql-design.md banner](https://github.com/sleep2agi/agent-network/blob/main/docs/v3-postgresql-design.md)），不在 maintained roadmap 上。adapter 接口保留作社区扩展点 —— HA / 多写副本场景需要 Postgres 的话，欢迎到 [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) 讨论自部署方案。
-:::
-
-## 性能问题
-
-### 21. 任务响应慢
-
-检查：
-
-1. **AI 模型延迟**：不同模型响应时间不同
-   - Codex (codex-sdk)：3-15 秒
-   - Claude：5-30 秒
-   - MiniMax：1-5 秒
-2. **网络延迟**：Agent 和 Server 之间的网络延迟
-3. **Server 负载**：`anet doctor` 检查服务器状态
-4. **数据库大小**：大量历史数据可能影响查询速度
-
-### 22. SSE 连接经常断开
-
-可能原因：
-
-- 网络不稳定
-- 反向代理超时设置太短
-- 防火墙关闭了长连接
-- nginx `proxy_buffering` 默认 on（SSE 必须 off，否则事件被缓冲到 buffer 满才一次性送达）
-
-> **断了 agent 会自己重连**：[#202](https://github.com/sleep2agi/agent-network/issues/202) 起，指数退避 `1s → 30s` 上限 + 重连即重 register + 1h 失败放弃。如果 hub 重启了 dashboard 看不到节点，参考 [troubleshooting — Hub 重启后 Dashboard 看不到节点](/troubleshooting#hub-重启后-dashboard-看不到节点)。
-
-Nginx 配置建议：
-
-```nginx
-location /events/ {
-    proxy_pass http://127.0.0.1:9200;
-    proxy_http_version 1.1;
-    proxy_set_header Connection "";
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # rate limit 看真实 client IP
-    proxy_read_timeout 86400;   # 24 小时
-    proxy_buffering off;
-    proxy_cache off;
-}
-
-# /api/* + /mcp 也建议透传 X-Forwarded-For 以便 audit_log 记录真实 IP
-location / {
-    proxy_pass http://127.0.0.1:9200;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $host;
-}
-```
-
-::: tip rate limit IP 检测
-hub 端 register / login 端点取 `req.headers["x-forwarded-for"]?.split(",")[0]` 作为 `clientIP` 喂给 `checkRateLimit`（[`index.ts` `POST /api/auth/register` / `POST /api/auth/login` handlers](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）。如果反代不设 `X-Forwarded-For`，所有请求会被认成同一个 IP（反代自身），rate limit 会误伤所有用户。
-:::
-
-## 下一步
-
-**起步教程**：
-- [一键安装与起步](/guide/one-shot-install) — 装好 anet 后第一个 agent
-- [上手指南](/guide/getting-started) — 完整安装到第一次跑
-
-**深入概念**：
-- [安全设计](/concepts/security) — token / 密码 / 隔离
-- [账号体系](/guide/account-system) — utok_ / ntok_ / 密码 关系
-- [架构概览](/guide/architecture) — 整体系统设计
-
-**升级和故障排查**：
-- [v0.7 → v0.8 升级指南](/guide/upgrade#v0-7-v0-8-升级注意-最新) — admin bootstrap / 密码管理
-- [故障排查](/troubleshooting) — 常见错误集合
-- `anet doctor --fix` — 自动 probe + 重发 ntok_
-
-**社区**：
-- [GitHub Issues](https://github.com/sleep2agi/agent-network/issues) — 报 bug / 功能建议
-- [社区](/community) — 加入讨论
+- 运行 `anet doctor` 收集非敏感诊断。
+- 搜索 [Issues](https://github.com/sleep2agi/agent-network/issues) 和 [Discussions](https://github.com/sleep2agi/agent-network/discussions)。
+- 报告时附版本、runtime、最小复现和已脱敏日志；安全问题请用 [GitHub Security Advisory](https://github.com/sleep2agi/agent-network/security/advisories/new)。

--- a/docs/tests/report-faq-simplification-2026-07-31.txt
+++ b/docs/tests/report-faq-simplification-2026-07-31.txt
@@ -1,0 +1,38 @@
+FAQ simplification
+Date: 2026-07-31
+Base: origin/main f78c9373
+
+Scope
+-----
+- docs-site/docs/faq.md
+- docs-site/docs/en/faq.md
+
+Result
+------
+- Chinese FAQ: 424 -> 121 lines
+- English FAQ: 424 -> 121 lines
+- Removed duplicated provider/runtime tables, release history, long deployment
+  recipes, speculative performance numbers, and roadmap promises.
+- Removed stale Node 20 installation advice; the repository requires Node
+  >=22.13.0.
+- Removed the unsafe password-recovery recipe that directly deleted SQLite
+  rows and local markers. The FAQ now documents only the audited
+  `anet hub admin reset-user --username <username>` path.
+- Corrected envRef wording: a mode-0600 .env may contain plaintext; envRef
+  keeps the secret out of config.json rather than promising no disk storage.
+- Kept short answers for installation, config locations, offline nodes,
+  task/message semantics, token types, cross-machine identity, production,
+  SQLite, SSE, and support channels.
+
+Static verification
+-------------------
+- git diff --check: PASS
+- each FAQ <= 150 lines: PASS
+- stale/unsafe phrase negative scan: PASS
+- every internal Markdown route resolves to an existing source page: PASS
+- Node >=22.13.0 source gate: PASS
+- CLI source gates for logs, hub stop, and admin reset-user: PASS
+
+No Docker image or package was built. This is a Markdown-only rewrite with
+source/static verification; no runtime, schema, API, or production state was
+changed.


### PR DESCRIPTION
## What changed

- rewrite the bilingual FAQ from 424 to 121 lines per language
- keep short answers for setup, configuration, nodes, task semantics, tokens, identity, passwords, production, SQLite, and SSE
- link detailed procedures to their canonical guides instead of duplicating them

## Why

The old FAQ had become a second manual. It duplicated runtime/provider tables, release history, deployment recipes, and troubleshooting content. Several copies had drifted: it told users to install Node 20 although the CLI requires Node 22.13, claimed unsupported 100-agent performance figures, described envRef as plaintext-free storage, and included a destructive password-recovery recipe that deleted SQLite rows and local markers.

## User impact

The FAQ is now scannable and avoids version-sensitive claims. Password recovery uses only `anet hub admin reset-user --username <username>`; detailed or changing behavior stays in the maintained guide pages.

## Validation

- `git diff --check`
- both FAQ files are at most 150 lines
- stale and unsafe phrase negative scan
- every internal Markdown route resolves to an existing source page
- source gates for Node >=22.13, `anet logs`, `anet hub stop`, and admin reset-user

Evidence: `docs/tests/report-faq-simplification-2026-07-31.txt`.

Draft only; no merge, package publish, or deployment is requested.
