### PR TITLE
docs: simplify Agent Node guide

### DIFF
--- a/docs-site/docs/en/guide/agent-node.md
+++ b/docs-site/docs/en/guide/agent-node.md
@@ -1,682 +1,154 @@
 # Agent Node
 
-Agent Node is the working unit in Agent Network -- it receives tasks, invokes an AI model to process them, and reports results.
+Agent Node is the execution process between CommHub and a model runtime. It connects to the Hub, receives tasks, invokes the selected runtime, returns results, and maintains node logs, sessions, and scheduled goals.
 
-::: tip Not sure which Runtime to pick?
-- **Reuse a Claude subscription / smoothest first-time path** → `claude-code-cli` (zero config after `claude auth login`)
-- **Writing copy / translation / analysis (programmatic) / using a domestic Chinese model** → `claude-agent-sdk` + pick the matching vendor in the wizard
-- **Writing code / running commands** → `codex-sdk`
-- **Using xAI Grok Build** → `grok-build-acp` ([detailed runtime guide ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md))
-- **Reach a vendor that's NOT in the built-in list** (GLM / Kimi / OpenRouter / vLLM / SiliconFlow / Qwen ...) → `claude-agent-sdk` + pick `custom` in the vendor submenu + `ANTHROPIC_BASE_URL`
+Use the [runtime table](/en/guide/runtimes) for installation, authentication, and capability differences. Use the [CLI reference](/en/guide/cli) for complete command syntax. This page covers behavior shared by nodes.
 
-**Authoritative comparison** of runtimes × npm package × wizard behavior × prereq auth (4 in stable, 6 in preview): [runtimes — canonical table](/en/guide/runtimes#runtimes-—-canonical-table). Full `anet node create` wizard order (`node-name → runtime → ...`): [Getting Started §5](/en/guide/getting-started#_4-create-and-start-a-node).
-:::
+## Install and start
 
-## Installation
+Use Node.js ≥ 22.13 and Bun:
 
 ```bash
-# Global install
-npm install -g @sleep2agi/agent-node
-
-# Or run directly with npx (recommended, no install needed)
-npx @sleep2agi/agent-node --help
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
 ```
 
-## Runtimes
-
-Agent Node supports four AI runtime engines covering all major models:
-
-### claude-agent-sdk
-
-Based on the [Anthropic Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk).
-
-| Property | Description |
-|------|------|
-| **Models** | Latest Claude Sonnet / Opus / Haiku (specific IDs at [Anthropic Models](https://docs.anthropic.com/claude/docs/models-overview)) |
-| **Prerequisites** | Anthropic API Key, or any Anthropic-compatible API key (MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter, etc. — full list in [multi-model](/en/guide/multi-model)) |
-| **Strengths** | Programmatic Anthropic-compatible API calls for stable background agents |
-| **Isolation** | `settingSources: []` fully isolates host config |
+Start and log in to a Hub using [Getting Started](/en/guide/getting-started). Then, from the project directory where the agent should work:
 
 ```bash
-npx @sleep2agi/agent-node \
-  --alias reasoning-master \
-  --runtime claude-agent-sdk \
-  --model claude-sonnet-4-6 \
-  --hub http://YOUR_IP:9200
+anet node create my-agent
+anet node start my-agent
 ```
 
-::: details Prerequisites checklist
-- [ ] Anthropic API Key or MiniMax API Key (paid)
-- [ ] CommHub Server is running
-:::
+`node create` asks you to choose a runtime and registers a separate node identity with the Hub. `node start` runs in the foreground by default. The task-push path is connected only after the log reports `SSE connected`.
 
-::: info Verify
-After starting, you should see `SSE connected, waiting for tasks...`. If you get an `auth` / `401` / `invalid x-api-key` error: check that `ANTHROPIC_API_KEY` (for api.anthropic.com) or `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL` (for a third-party Anthropic-compatible endpoint) is set correctly — see [runtimes — common pitfalls](/en/guide/runtimes#claude-agent-sdk). `claude auth login` is for the `claude-code-cli` runtime and has no effect on the SDK path.
-:::
-
-### claude-code-cli
-
-Runs a local Claude Code CLI process -- the same `claude` command you use daily in your terminal.
-
-| Property | Description |
-|------|------|
-| **Models** | Latest Claude Sonnet / Opus / Haiku (specific IDs at [Anthropic Models](https://docs.anthropic.com/claude/docs/models-overview)) |
-| **Prerequisites** | Claude Code installed (`npm i -g @anthropic-ai/claude-code`) |
-| **Strengths** | Spawns a `claude` child process with full terminal capabilities |
-| **Difference** | vs `claude-agent-sdk`: CLI mode = spawns `claude` process; SDK mode = programmatic API calls |
+Common management commands:
 
 ```bash
-npx @sleep2agi/agent-node \
-  --alias terminal-assistant \
-  --runtime claude-code-cli \
-  --model claude-sonnet-4-6 \
-  --hub http://YOUR_IP:9200
+anet node ls
+anet info my-agent
+anet logs my-agent --follow
+anet node stop my-agent
 ```
 
-::: details Prerequisites checklist
-- [ ] Install Claude Code: `npm install -g @anthropic-ai/claude-code`
-- [ ] Verify `claude --version` outputs correctly
-- [ ] Run `claude auth login` so your local Claude subscription is active (claude-code-cli reuses the local login state)
-- [ ] CommHub Server is running
-:::
+### The working directory matters
 
-::: info Verify
-After starting, you should see `SSE connected, waiting for tasks...`.
-- If you get `claude: command not found`, make sure Claude Code is installed globally
-- If you get `auth` / 401, re-run `claude auth login` to refresh the subscription session
-:::
-
-::: info claude-code-cli vs claude-agent-sdk
-- **claude-code-cli**: Spawns a `claude` child process, just like typing commands in your terminal. Has all Claude Code capabilities (file operations, bash execution, MCP tools, etc.).
-- **claude-agent-sdk**: Calls Claude through the programmatic SDK API. Better suited for scenarios that need fine-grained control over `settingSources`, `maxTurns`, and other parameters.
-:::
-
-### codex-sdk
-
-Based on the [OpenAI Codex SDK](https://www.npmjs.com/package/@openai/codex-sdk).
-
-| Property | Description |
-|------|------|
-| **Models** | Codex SDK model (set with `--model`; see OpenAI Codex docs for the current model id) |
-| **Prerequisites** | `codex login` |
-| **Strengths** | Strong code generation, flexible tool use |
-| **Tools** | Codex CLI ships with Read / Write / Edit / Bash / Glob / Grep / WebSearch baked in (**does not honor `--tools`**) + agent-node injects per-node CommHub tools |
+File tools use the node's launch directory as their workspace. Create and start the node from the intended project, not from `$HOME` or a directory containing unrelated projects or credentials. For background execution:
 
 ```bash
-npx @sleep2agi/agent-node \
-  --alias code-assistant \
-  --runtime codex-sdk \
-  --model <codex-model-id> \
-  --hub http://YOUR_IP:9200
-# Note: codex-sdk does not honor --tools. Codex built-in tools come from the codex CLI binary;
-# CommHub tools are injected by agent-node per node, so codex nodes can actively get_all_status / send_task / get_task.
+anet node start my-agent --tmux
 ```
 
-::: details Prerequisites checklist
-- [ ] Install codex CLI: `npm install -g @openai/codex` (`@openai/codex-sdk` lives in `@sleep2agi/agent-node`'s `optionalDependencies`; npm 7+ pulls it in automatically with agent-node, but the SDK shells out to the `codex` binary — see [runtimes / codex-sdk prereqs](/en/guide/runtimes#codex-sdk))
-- [ ] Run `codex login` to authenticate with OpenAI (or `export OPENAI_API_KEY=sk-xxx`)
-- [ ] CommHub Server is running
-:::
+From a terminal this attaches to tmux; detach with `Ctrl-B D`. Without a TTY it starts detached. See [background operation](/en/deploy/daemon) for long-running and boot-time management.
 
-::: info Verify
-After starting, you should see `SSE connected, waiting for tasks...`.
-- If you get `Error: spawn codex ENOENT`, the `codex` binary isn't on PATH — run `npm install -g @openai/codex` + check `which codex`
-- If you get a codex authentication error, run `codex login` (or check the `OPENAI_API_KEY` env)
-:::
+## Choose a runtime
 
-### grok-build-acp
+Do not select a runtime here from an old version number or fixed count. Availability follows the npm release channel:
 
-Integrates with [xAI Grok Build ACP (Agent Communication Protocol)](https://docs.x.ai/docs/overview) by spawning the local `grok` ACP server. This is the 4th runtime; it is available in the `anet node create` wizard and can also be selected explicitly with `--runtime grok-build-acp`. Full configuration / Known Limits / Delegation Contract: [grok-build-runtime.md ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md).
+- Claude Code, Claude Agent SDK, Codex SDK, Grok ACP, and other current paths are listed in [Runtimes](/en/guide/runtimes).
+- Codex TUI co-presence is preview-only and must use the complete `--copresence` start and recovery flow. See [Codex TUI co-presence](/en/guide/codex-copresence).
+- OpenCode is currently a task runtime, not a shared TUI.
+- The shared Grok TUI has not shipped. The available `grok-build-acp` runtime cannot attach; see [Grok TUI status](/en/guide/grok-copresence).
 
-| Field | Description |
-|------|------|
-| **Prerequisites** | `grok` CLI already authenticated + `GROK_CODE_XAI_API_KEY` env |
-| **Strengths** | xAI Grok Build models, ACP-protocol cross-agent collaboration |
-| **Tools** | Bundled with Grok ACP, **does not accept `--tools`** |
+Stop the previous process before changing runtimes. Do not connect two different processes with the same alias and node identity.
 
-```bash
-npx @sleep2agi/agent-node \
-  --alias grok-helper \
-  --runtime grok-build-acp \
-  --hub http://YOUR_IP:9200
-```
+## Node files
 
-::: tip grok-build-acp improvements
-- [#201](https://github.com/sleep2agi/agent-network/issues/201) — 3-layer fix for delegate refusal: parser broaden + prompt softening + authorised-phrasings list
-- [#204](https://github.com/sleep2agi/agent-network/issues/204) — per-session MCP inject + per-node cwd isolation to prevent `.mcp.json` identity pollution
+Project-local node state is under `.anet/nodes/<alias>/`:
 
-See [grok-build-runtime.md Known Limits](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md#known-limits) for the full breakdown.
-
-::: details preview chain history (how it converged on preview.7)
-- **preview.2 stdio variant**: structurally fixes the `.mcp.json` shared-identity bug (ACP side)
-- **preview.6 — transport switched to HTTP**: Grok calls CommHub `/mcp` directly with a Bearer `ntok_`, bypassing subprocess / bun PATH / stdout-pollution risks entirely
-- **preview.7 — per-node isolated cwd (final)**: Grok CLI was reading the cwd `.mcp.json` alongside the ACP injection — two MCP servers coexist and the stale one wins hello. Fix: ACP `session/new` passes a per-node isolated cwd that mirrors user files but omits `.mcp.json`
-- v0.10.11 final = preview.7 promoted
-:::
-:::
-
-### opencode-cli (preview)
-
-> ⚠️ **Preview channel only**: npm latest does not include it yet — the `anet node create` picker on latest won't show it (see the [runtimes table](/en/guide/runtimes)). It lands in latest once RFC-029 stabilizes.
-
-Integrates the [public sst/opencode](https://github.com/sst/opencode) CLI (RFC-029). opencode is a multi-vendor front-end (unified UI + session + auth abstraction); anet runs a long-lived `opencode acp` (stdio JSON-RPC) subprocess to do think().
-
-| Property | Notes |
-|------|------|
-| **Prereq** | Install `opencode-ai` at the exact pinned version; export the vendor API key to env (`ANTHROPIC_API_KEY` or `OPENAI_API_KEY`) |
-| **Traits** | Multi-vendor presets (Anthropic native + OpenAI to start); per-node isolated auth.json (mode 0o600); long-lived ACP subprocess, no cold-start; same transport layer as grok-build-acp |
-| **Tools** | opencode built-ins; under a Feishu channel the commhub MCP is always denied (same as grok / claude-code-cli) |
-
-```bash
-# 1. Install the pinned version (current preview pin; trust the exact version
-#    that `anet node start` reports — it can change between releases)
-npm install -g opencode-ai@1.18.1
-
-# 2. Export the env var for your chosen preset
-export ANTHROPIC_API_KEY=sk-...    # for the anthropic preset
-# or
-export OPENAI_API_KEY=sk-...       # for the openai preset
-
-# 3. Create the node via the wizard (asks for preset + auto-writes auth.json into the node HOME)
-anet node create my-opencode --runtime opencode-cli
-anet node start my-opencode
-```
-
-::: tip Version pin + upgrade
-opencode iterates fast upstream (npm `latest` moves daily), so every `anet node start` hard-checks the exact version and rejects any mismatch.
-
-- To upgrade: `anet opencode upgrade-pin <version>` — the command will:
-  1. `npm install -g opencode-ai@<version>`
-  2. Start `opencode acp` for a smoke test (initialize + session/new)
-  3. **Only if the smoke passes**, write `~/.anet/opencode-pin.json` (with version + smokePassedAt)
-  4. The next `anet node start` accepts the new version
-
-- The pin state is per-machine; in team setups each machine upgrades + smokes on its own.
-:::
-
-::: tip Bearer-only vendor limitation (RFC-029 §8 D3)
-opencode's built-in anthropic client hardcodes `x-api-key`. Bearer-only compatible gateways (Kimi coding, etc.) return 401 out of the box. Presets support Anthropic native + OpenAI to start; Bearer vendors need an opencode plugin that controls the auth path (backlog).
-:::
-
-::: warning auth.json is a sensitive path
-opencode's `auth.json` holds the vendor API key. agent-node's read-denylist blocks a running opencode agent from Read-ing / exfiltrating its own auth.json (same defense as Feishu's access.json).
-:::
-
-### codex-app-server (preview)
-
-> ⚠️ **Preview channel only**: not in npm latest — the `anet node create` picker on latest does not list it (see [runtimes table](/en/guide/runtimes#runtimes-—-canonical-table)). Ships to latest once RFC-030 stabilizes.
-
-An **app-server bridge** over OpenAI Codex ([RFC-030](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md)) — the node owns a codex app-server process, and a human and the agent **share one codex session** (co-presence): the agent handles tasks dispatched over the network while a human can watch / take over from the same codex TUI.
-
-| Attribute | Notes |
-|------|------|
-| **Model** | OpenAI Codex (gpt-5.5 etc, reuses the codex login) |
-| **Prereq** | `codex` CLI installed + `codex login` (codex has no `auth` subcommand) |
-| **Traits** | Human-agent co-presence bridge; `codexThreadId` lives in a dedicated field, not the shared `session` |
-| **Approval** | Turns that need approval suspend for a human to handle in the TUI — the bridge **never answers on your behalf** |
-
-```bash
-anet node create codex-bridge --runtime codex-app-server
-anet node start codex-bridge --copresence
-tmux attach -t =codex-bridge
-```
-
-This is the first-class co-presence path (preview, bash, and tmux 3.2+ required; read-only by default). A plain `anet node start codex-bridge` only starts a background node with no human TUI and must not be used as co-presence recovery. See [Codex TUI Co-presence](/en/guide/codex-copresence) for the full flow, permissions, and native-Windows manual path; see [RFC-030](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md) for design limits.
-
-### claude-agent-sdk + Domestic Models
-
-Routes claude-agent-sdk requests to domestic model APIs via `ANTHROPIC_BASE_URL`, ideal for low-cost scenarios.
-
-| Property | Description |
-|------|------|
-| **Models** | MiniMax, DeepSeek, GLM, Kimi, InternLM, Xiaomi MiMo, OpenRouter — any Anthropic-compatible endpoint (full provider table: [Multi-model setup](/en/guide/multi-model)) |
-| **Prerequisites** | API key for the target model |
-| **Strengths** | Low cost, high throughput, direct access in China |
-| **Mechanism** | Routes requests to compatible APIs via `ANTHROPIC_BASE_URL` |
-
-```bash
-# MiniMax
-ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic \
-ANTHROPIC_AUTH_TOKEN=your-minimax-key \
-npx @sleep2agi/agent-node \
-  --alias minimax-bot \
-  --runtime claude-agent-sdk \
-  --model <minimax-model-id> \
-  --hub http://YOUR_IP:9200
-
-# InternLM (note: bare hostname, no /anthropic suffix)
-ANTHROPIC_BASE_URL=https://chat.intern-ai.org.cn \
-ANTHROPIC_AUTH_TOKEN=your-intern-key \
-npx @sleep2agi/agent-node \
-  --alias intern \
-  --runtime claude-agent-sdk \
-  --model intern-s1-pro \
-  --hub http://YOUR_IP:9200
-```
-
-::: details Prerequisites checklist
-- [ ] API key for the target model (e.g. MiniMax API Key)
-- [ ] Set environment variables `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`
-- [ ] CommHub Server is running
-:::
-
-::: info Verify
-After starting, you should see `SSE connected, waiting for tasks...`. If you get a `401` or `auth` error, double-check your API key.
-:::
-
-## Command-Line Parameters
-
-```bash
-npx @sleep2agi/agent-node [options]
-```
-
-| Parameter | Default | Description |
-|------|--------|------|
-| `--alias` | (required) | Agent name (display name in CommHub) |
-| `--hub` | http://127.0.0.1:9200 | CommHub Server address |
-| `--runtime` | claude-agent-sdk | Runtime engine (`claude-agent-sdk` / `codex-sdk` / `claude-code-cli` / `grok-build-acp`) |
-| `--model` | (per runtime default) | AI model name |
-| `--tools` | (none) | Available tools, comma-separated |
-| `--max-budget` | 0 | Per-task budget cap (USD; 0 means disabled) |
-| `--session` | (new) | Resume a specific session |
-| `--config` | (auto-detect) | Config file path |
-
-::: info Where token / network come from
-The auth token is supplied via the `token` field in `.anet/nodes/<name>/config.json` or the `COMMHUB_TOKEN` env var — **the CLI does not accept a `--token` flag**. The network ID is inferred from the `ntok_` token claim; no manual flag is needed. The agent-node CLI also **does not parse** single-letter short flags (`-a / -h / -r / -m / -t / -s / -c`) — only the long-form flags in the table above are accepted.
-:::
-
-## Configuration Files
-
-Agent Node supports multiple configuration methods, from highest to lowest priority (verified at [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)):
-
-```mermaid
-flowchart TD
-    A["Command-line parameters<br/>(--alias / --runtime / --model etc.)"] --> B["Environment variables<br/>(COMMHUB_ALIAS / RUNTIME / MODEL / COMMHUB_URL / COMMHUB_TOKEN)"]
-    B --> C["File specified via --config"]
-    C --> D[".anet/nodes/&lt;ALIAS&gt;/config.json<br/>(v0.8 primary path)"]
-    D --> E[".anet/profiles/&lt;ALIAS&gt;.json<br/>(legacy compatibility)"]
-    E --> G["~/.anet/config.json<br/>(global fallback — only hub + token fields)"]
-    G --> F[".agent-node.json<br/>(legacy compatibility; only when D/E/G are all empty)"]
-```
-
-::: tip Global `~/.anet/config.json` fallback
-After the project config is loaded, [`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) fills in the missing `hub` and `token` fields from the global `~/.anet/config.json`. **Only these two fields fall back across projects** — `runtime` / `model` / `tools` / `env` must be set via project `config.json` / CLI / env; global config does not cover them. Project config overrides global at the field level; missing fields fall back to global.
-:::
-
-### Full config.json Fields
-
-```json
-{
-  "anet_version": "0.1.0",
-  "node_id": "n_a1b2c3d4",
-  "node_name": "code-assistant",
-  "token": "ntok_...",
-  "runtime": "claude-agent-sdk",
-  "model": "<model-id>",
-  "session": "",
-  "channels": ["server:commhub"],
-  "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
-  "logLevel": "info",
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://api.minimaxi.com/anthropic"
-  },
-  "flags": {
-    "dangerouslySkipPermissions": true,
-    "teammateMode": "in-process",
-    "maxTurns": 20
-  }
-}
-```
-
-| Field | Type | Description |
-|------|------|------|
-| `anet_version` | string | Config version |
-| `node_id` | string | Stable unique identifier (n_ prefix + 8-char hex) |
-| `node_name` | string | Display name, can be renamed |
-| `alias` | string | Node alias (the `.anet/nodes/<alias>/` directory name + the display identifier on CommHub; equals `node_name` when not set separately) |
-| `runtime` | string | Runtime: `claude-agent-sdk` / `codex-sdk` / `claude-code-cli` / `grok-build-acp` |
-| `model` | string | AI model name |
-| `session` | string | session/thread ID. For the `claude-code-cli` runtime, `anet node create` pre-generates a UUID (first `start` binds it via `--session-id <uuid>`, restarts auto-`--resume <uuid>` to continue the conversation; v0.8.2 fixed a prior default session-loss bug). For other runtimes, this is the previous session ID for resume |
-| `channels` | string[] | Connected channels list |
-| `tools` | string[] | Allowed tools list. **`claude-agent-sdk` only**; `codex-sdk` silently ignores it (toolset is baked into the codex binary — see the L109 note above + [runtimes#codex-sdk](/en/guide/runtimes#codex-sdk)) |
-| `env` | object | Environment variable overrides |
-| `flags` | object | Runtime flags |
-| `hub` | string | CommHub Server address override (falls back to the global `~/.anet/config.json` `hub` when unset) |
-| `token` | string | Auth token override (falls back to the global config `token` when unset) |
-| `network_id` | string | Network ID (usually inferred from `ntok_`, no need to set manually) |
-| `systemPrompt` | string | System prompt, prepended to every task (can also use the `--prompt` flag; the `SYSTEM_PROMPT` env var is **not read** — see the note above) |
-
-## Task Processing Flow
-
-After starting, Agent Node automatically enters a task listening loop:
-
-```mermaid
-stateDiagram-v2
-    [*] --> ConnectCommHub: report_status(idle)
-    ConnectCommHub --> SSEListening: SSE connected
-    SSEListening --> EventReceived: new_task / broadcast
-
-    state EventReceived {
-        [*] --> FetchInbox: get_inbox
-        FetchInbox --> Acknowledge: ack_inbox
-        Acknowledge --> CheckType
-
-        state CheckType <<choice>>
-        CheckType --> AIProcess: type=task
-        CheckType --> LogOnly: type=message/reply
-
-        AIProcess --> ReportWorking: report_status(working)
-        ReportWorking --> Think: Invoke AI model
-        Think --> ReplyResult: send_reply
-        ReplyResult --> [*]
-        LogOnly --> [*]
-    }
-
-    EventReceived --> SSEListening: Processing complete
-    SSEListening --> Reconnect: SSE disconnected
-    Reconnect --> SSEListening: Exponential backoff 3s→60s
-    SSEListening --> GoOffline: SIGINT/SIGTERM
-    GoOffline --> [*]: report_status(offline)
-```
-
-### Recurring tasks / the `/loop` scheduler
-
-Starting with v0.11, **every runtime** (claude-agent-sdk / codex-sdk / grok-build-acp) supports anet's built-in /loop scheduler. Send an agent a `/loop <interval> <task>` message and the node persists it to its own `goals.json`; the scheduler then wakes the agent on the chosen interval, asks for an incremental advance, and reports progress.
-
-#### One-liner CLI (recommended)
-
-```bash
-# Check on PR #271 every 5 minutes
-anet node loop my-codex "monitor PR #271" --every 5m
-
-# Sweep Twitter every 30 minutes
-anet node loop researcher "scan twitter for grok updates" --every 30m
-
-# Post a morning summary every 2 hours
-anet node loop daily-bot "post the morning summary" --every 2h
-```
-
-Interval format: `30s` / `5m` / `2h` / `1d` (unit suffix required). `--every` defaults to `5m` when omitted.
-
-#### Or send a `/loop` message directly
-
-You can equivalently use `commhub_send_task` or the Dashboard to send a message that starts with `/loop`:
-
-```
-/loop 5m monitor PR #271
-/loop 30s check if the feishu bot is alive
-/loop 1d wrap up yesterday's release work
-```
-
-`/goal` is an alias of `/loop` and behaves identically.
-
-#### claude-agent-sdk can loop too (since v0.11)
-
-Between v0.4 and v0.10 the claude-agent-sdk runtime [could not /loop](https://github.com/sleep2agi/agent-network/issues/144) because of an incorrect design assumption (the gate assumed the SDK-spawned `claude` subprocess had its own native /loop; in fact the SDK is a one-shot `query()` Promise — the process exits after each call). v0.11 (#144) makes every runtime use anet's own scheduler:
-
-```bash
-# claude-agent-sdk nodes can now loop (v0.11+)
-anet node loop my-claude "check ANTHROPIC quota once a day" --every 1d
-```
-
-#### Inspect / edit / cancel
-
-```bash
-# List a node's loops (task / interval / next_wake / status)
-anet goal list my-codex
-
-# Edit interval / status / text (first 8 chars of the id are enough — auto-unique-matched)
-anet goal edit my-codex 3f8a2b1c --interval 10min               # change interval (supports 5min/1h/1d/hourly/daily/每5分钟…)
-anet goal edit my-codex 3f8a2b1c --status paused                # pause (status: active/paused/completed/cancelled)
-anet goal edit my-codex 3f8a2b1c --text "new task text"         # change the task text
-
-# Cancel by goal id (stop entirely)
-anet goal cancel my-codex 3f8a2b1c
-```
-
-Goals are persisted in `~/.anet/nodes/<alias>/goals.json` and restored automatically after a restart. **After `edit` / `cancel`, a running agent-node process still holds the old goal state in memory — restart the node, or wait until the next tick, for the change to take effect.**
-
-#### Tick interval
-
-Scheduler tick frequency is controlled by `ANET_GOAL_TICK_MS` (env) or `flags.goalTickMs` in config.json, default 30 seconds. A goal's `interval_ms` can never be more precise than the tick — a 5-second interval still effectively wakes every 30s. Lower the tick if you need finer granularity.
-
-#### Agent self-management: 6 self-scoped tools (RFC-025)
-
-In addition to external `anet node loop` / `/loop`, an agent can call 6 self-scoped tools during a task response to manage **its own** loops without human intervention:
-
-| Tool | Meaning |
+| Path | Purpose |
 |---|---|
-| `list_my_loops` | List all of the agent's active/paused loops |
-| `create_my_loop` | Create a new loop |
-| `edit_my_loop` | Change task / interval / schedule / paused |
-| `reschedule_my_loop` | One-shot push next_wake_at (interval unchanged) |
-| `complete_my_loop` | Archive as achieved (`status=complete`) |
-| `cancel_my_loop` | Permanent abandon (`status=cancelled`) |
+| `config.json` | Hub, runtime, node identity, token, model, and flags |
+| `.env` | Optional secrets; plaintext with expected mode `0600` |
+| `logs/` | Runtime logs |
+| `goals.json` | Scheduled goals owned by this node |
 
-None of the 6 tools take an `alias` argument — by construction they are physically isolated to the per-node `goalStore`, so an agent can never address another node's loops.
+User login and the active network are stored globally in `~/.anet/config.json`. Do not commit project `.anet`, tokens, or `.env`.
 
-**Runtime tool availability** — this is a key claude vs. codex/grok difference:
-
-- **codex-sdk / grok-build-acp**: agent-node exposes the tools on a localhost HTTP MCP server (bearer-token-protected) at startup. **Tools are callable at any time** — during task response, during a loop wake, at any turn of the subprocess.
-- **claude-agent-sdk**: tools are attached to `processWithClaude`'s tool surface via an in-process SDK MCP server. They are **only callable within a task response lifecycle** (i.e. during `processTask`).
-
-What this means for claude users:
-
-> **A loop wake triggers `processTask` → the tools become available immediately → the agent can call `create_my_loop("next step")` or `complete_my_loop(this)` in the same response** — the loop is closed-loop, because loop wakes themselves flow through `processTask`.
->
-> But when the agent is **completely idle** (not processing any task), claude has **no tool context**. So you cannot externally trigger a "let the agent decide autonomously whether to create a loop" scenario the way you can with codex/grok — you need to first send a task (via `anet node loop` or a direct `send_task`) to wake the agent up.
-
-**codex/grok are always-on** — the tools are callable by the subprocess whenever the LLM decides to reference them, from any turn onwards, right after agent-node starts. This is a natural consequence of the architectural choice: codex/grok use out-of-process HTTP MCP, claude uses in-process SDK MCP. It's not a gap or a bug.
-
-**Safety guardrails** are consistent across runtimes (all three runtimes share the same `goalStore` + counter state):
-
-- Default **20 active goals per node** cap (override with `COMMHUB_MAX_GOALS_PER_NODE`)
-- Same goal can only be edited **once per 30-second cooldown** (anti-recursion)
-- ≥ 3 cancels within 30s → the 4th triggers confirm-back; the agent must ask the user and re-call with a `confirm_token`
-- On create/edit: **preflight** the cron-lite schedule — semantically invalid schedules (bad timezone, etc.) are rejected before write to prevent self-lock
-
-### Message Type Filtering
-
-Agent Node only triggers AI processing for `task` type messages:
-
-| Message Type | SSE Event | Agent Behavior |
-|---------|---------|-----------|
-| task | `new_task` | processInbox -> AI think -> reply |
-| broadcast | `broadcast` | processInbox -> AI think -> reply |
-| reply | `new_reply` | Log only |
-| message | `new_message` | Log only |
-| ack | (not pushed) | -- |
-
-This design prevents message loops (A replies to B -> B replies to A -> infinite loop).
-
-## Tool Configuration
-
-### Default = full Claude Code preset (v0.9.0+, #101 Option B)
-
-Since [#101](https://github.com/sleep2agi/agent-network/issues/101) Option B (anet v0.9.0+), the `claude-agent-sdk` runtime's **default toolset is the full Claude Code preset** — not an empty set. As soon as a node spawns, it can use:
-
-- Filesystem: `Read` / `Write` / `Edit` / `Glob` / `Grep`
-- Shell: `Bash` (subject to `dangerouslySkipPermissions=true`, on by default — no per-call confirmation)
-- Network: `WebFetch` / `WebSearch`
-- Subtasks / notebooks: `Task` / `NotebookEdit` / ...
-
-Plus the ~40 MCP tools on the hub side (`commhub_send_task` / `commhub_reply` / ...).
-
-> **Root cause** ([#101](https://github.com/sleep2agi/agent-network/issues/101)): in older versions, with no `tools` field in `config.json`, agent-node passed the SDK `options.tools = undefined`, and the SDK treated that as "no built-in tools". The agent could only call MCP tools and would hallucinate "network restricted" when asked for WebFetch / Bash / Read. Option B forces the fallback to the SDK `{ type: 'preset', preset: 'claude_code' }` sentinel — per the SDK type defs (`sdk.d.ts:1229-1238`), this is the standard way to say "give me the full Claude Code toolset".
-
-### Three `--tools` modes (only for `claude-agent-sdk`)
-
-The `--tools` flag only affects the `claude-agent-sdk` runtime — the `codex-sdk` toolset is baked into the codex CLI (`Read/Write/Edit/Bash/Grep/Glob/WebSearch`, **does not honor** `--tools`); the `claude-code-cli` runtime shares the host's Claude Code toolset and also doesn't go through this flag.
-
-| Input | Effect | Verify |
-|------|---------|--------|
-| `--tools all` | Full SDK preset (same as above) — single source of truth | [`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| `--tools Read,Glob,Grep` | Explicit allowlist (string array), bypasses preset — strict sandbox | [`cli.ts,220`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| Absent / empty string | **Falls back to full preset** (the #101 fix; previously left as `undefined` → empty set) | [`cli.ts,221`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-
-Actual logic from source ([`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)):
-
-```ts
-const TOOLS_PRESET = { type: "preset" as const, preset: "claude_code" as const };
-// Behaviour matrix (sdk.d.ts:1229-1238):
-//   --tools "all"       → SDK preset (full Claude Code tool set)
-//   --tools "Read,Bash" → explicit allowlist
-//   --tools "" (absent) → SDK preset (the #101 fix; previously left empty)
-const TOOLS_EXPLICIT = toolsRaw === "all" ? null : toolsRaw.split(",").filter(Boolean);
-let TOOLS: string[] | typeof TOOLS_PRESET =
-  toolsRaw === "all" ? TOOLS_PRESET
-  : (TOOLS_EXPLICIT && TOOLS_EXPLICIT.length) ? TOOLS_EXPLICIT
-  : TOOLS_PRESET;
-// ... cli.ts: tools: TOOLS  ← passed to claude-agent-sdk query options (preset or string[])
-```
+envRef keeps only an environment-variable reference in `config.json`; the real value may still be stored in the node's mode-0600 `.env`. Inspect the backup and target variable before migration:
 
 ```bash
-# Default (no --tools) → full Claude Code preset
-npx @sleep2agi/agent-node --alias coder
-
-# Explicit "all" → same preset (single source of truth, replaces the old hardcoded 8-tool list)
-npx @sleep2agi/agent-node --alias coder --tools all
-
-# Explicit allowlist (read-only agent) — bypasses the preset
-npx @sleep2agi/agent-node --alias coder --tools Read,Glob,Grep
-
-# codex-sdk silently ignores --tools
-npx @sleep2agi/agent-node --alias coder --runtime codex-sdk
-# Codex has Read/Write/Edit/Bash/Grep/Glob/WebSearch baked in — you cannot detach individual tools.
+anet node migrate-token-to-envref my-agent
 ```
 
-### `anet node create` behavior-disclosure banner (Vincent push, [#101](https://github.com/sleep2agi/agent-network/issues/101))
+See [tokens and permissions](/en/concepts/tokens) and the [security model](/en/concepts/security) for the full boundary.
 
-After a successful `anet node create <alias>`, agent-node prints a **behavior-disclosure banner**: the built-in tools (explicit list or `all (Claude Code preset)`) + MCP tools + current flags (`dangerouslySkipPermissions=true` / `teammateMode=true`) + a one-liner "the agent can read/write files, run shell commands, and access the network". The banner is printed at the end of `createCommand` in [agent-network/bin/cli.ts](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) — so **you actually see what the agent can do** and decide whether to sandbox it.
+### Do not copy node identity
 
-> **⚠ User responsibility**: the default preset + default `dangerouslySkipPermissions=true` means once the agent starts it can **edit files, run shell commands, and access the network without confirmation prompts**. See [Security → Tool Permissions](/en/concepts/security#tool-permissions-default-claude-code-preset-user-responsibility).
+For another machine, log in there and run `anet node create` again. Copying `config.json` also copies `node_id` and `ntok_`, which can create identity, heartbeat, and SSE-routing conflicts.
 
-::: warning Security note
-- Default preset + default yolo mode (`dangerouslySkipPermissions`) — don't run agents directly from `$HOME`; use a disposable working directory
-- For strict sandbox: `--tools Read,Glob,Grep` gives a read-only agent
-- To turn off yolo: for codex-sdk nodes use `anet node create --no-yolo`; for claude runtimes (claude-code-cli / claude-agent-sdk) set `dangerouslySkipPermissions` to `false` in the node's `config.json` (**there is no `--no-skip-permissions` flag**). Every tool call then prompts, hurting long-task UX
-- Per-task budget cap: `--max-budget 0.1` (see [Budget Control](#budget-control) below)
-:::
+## Task processing
 
-### Vendor adapter layer (InternLM / 书生 etc.)
+```text
+CommHub ──SSE task──▶ Agent Node ──▶ Runtime / model
+   ▲                                      │
+   └──────────── task result ─────────────┘
+```
 
-On some vendor endpoints, `claude-agent-sdk` follows its RLHF defaults and drifts from Anthropic standard (canonical case: intern-s2-preview does not emit `tool_use` content blocks and falls back to verbose Thinking Process text). agent-node uses a **vendor adapter** to detect by `ANTHROPIC_BASE_URL` and inject a system-prompt bias that nudges behavior back — see [Vendor Adapters](/en/concepts/vendor-adapters) for the full mechanism, the 5 side effects, and the opt-out path.
+Only task events are sent to the model:
 
-## Budget Control
+- `send_task`: work to execute; invokes the runtime.
+- `send_reply`: a task result; does not invoke the model again.
+- `send_message`: ordinary chat; does not invoke the model again.
 
-The `--max-budget` parameter caps the maximum spend per task (in USD) — **only effective for the `claude-agent-sdk` runtime**:
+This distinction prevents agents from triggering one another in reply loops. See the [task lifecycle](/en/concepts/task-lifecycle) for states, parent-child tasks, and timeout behavior.
+
+Attachment, image, and channel support depends on the runtime. Do not assume every runtime accepts media. Check [Runtimes](/en/guide/runtimes) and [Channels](/en/guide/channels).
+
+## Tools and permissions
+
+Tools come from two layers: runtime-native tools and CommHub tools injected by Agent Network. `--tools` affects only runtimes that support a custom tool list; it does not describe the actual Codex, Claude Code, or Grok sandbox.
 
 ```bash
-# Max $0.10 per task (claude-agent-sdk)
-npx @sleep2agi/agent-node --alias coder --max-budget 0.1
-
-# Max $1.00 per task (complex tasks)
-npx @sleep2agi/agent-node --alias reasoner --max-budget 1.0
+anet node create reader --runtime claude-agent-sdk --tools Read,Glob,Grep
 ```
 
-Verified at [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts):
-```ts
-if (MAX_BUDGET > 0) options.maxBudgetUsd = MAX_BUDGET;  // passed to claude-agent-sdk query options
+After creation, read the CLI behavior disclosure and inspect `permissionMode`, `dangerouslySkipPermissions`, and runtime-specific flags in `config.json`. Defaults differ by runtime, and Codex TUI co-presence starts read-only.
+
+Treat a node that can write files, run shell commands, or use the network as untrusted code:
+
+- Use a separate, disposable working directory.
+- Keep production credentials outside the readable workspace.
+- Grant only the needed Hub and network access.
+- After changing permissions, verify behavior with a harmless task instead of trusting a flag name alone.
+
+See the [security model](/en/concepts/security) for current defaults and threats.
+
+## Scheduled tasks
+
+Create a recurring task for an online node:
+
+```bash
+anet node loop my-agent "check open issues" --every 5m
+anet goal list my-agent
+anet goal cancel my-agent <goal-id>
 ```
 
-When `SDKResultMessage.total_cost_usd` reaches `maxBudgetUsd`, claude-agent-sdk automatically ends the turn and the task moves to `error_max_budget`.
+Goal state is stored in the node's `goals.json`. Intervals require a unit; the CLI currently accepts minutes, hours, or days. Each run consumes real model quota, so validate with a conservative interval. This is not a high-precision cron service.
 
-::: warning codex-sdk / claude-code-cli runtime do not support a USD budget cap
-- The `codex-sdk` path ([`cli.ts processWithCodex`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)) does not read `MAX_BUDGET`; **`--max-budget` is silently ignored**. Codex-sdk only reports token counts (`TurnCompletedEvent.usage`), not USD — you have to derive cost from your own model→price table (aligned with the sdk-deep-dive chain).
-- `claude-code-cli` runs against your local Claude Code subscription, counted against subscription quota rather than USD.
-- **Cross-runtime budget control**: put a reverse proxy in front (nginx / Cloudflare / litellm proxy) and throttle by model-API call count.
-:::
+## Lifecycle and recovery
 
-## Lifecycle
+- **Start:** load node config, register/report status, and connect SSE.
+- **Run:** process tasks and report status; reconnect with backoff after connection loss.
+- **Stop:** prefer `anet node stop <alias>` so the node closes its connection and reports offline.
+- **Resume a session:** behavior is runtime-specific. Inspect `anet info <alias>` and the runtime guide instead of editing session/thread ids by hand.
+- **Rename:** use `anet node rename`; do not edit the directory name, alias, or `node_id` directly.
 
-The complete Agent Node lifecycle:
+If one alias produces duplicate results, flips between runtimes, or reports inconsistent state, look for duplicate processes:
 
-| Phase | CommHub Status | Description |
-|------|-------------|------|
-| Created | (not in CommHub) | `anet node create` generates config.json |
-| Registered | idle | `report_status(idle)` |
-| Online | idle | SSE connected, waiting for tasks |
-| Running | working | Processing a task |
-| Error | error | Runtime error |
-| Offline | offline | Process exited |
-| Deleted | (not in CommHub) | All data cleared |
-
-### Heartbeat
-
-- Automatic `report_status` heartbeat every **3 minutes**
-- Server marks as offline after **10 minutes** without a heartbeat
-- Heartbeat also returns `inbox_count` for checking pending tasks
-
-### Reconnection
-
-SSE auto-reconnects on disconnect using exponential backoff:
-
-```
-Retry interval ([#202](https://github.com/sleep2agi/agent-network/issues/202)): exponential backoff `1s → 2s → 4s → 8s → 16s → 30s (cap)`
+```bash
+anet info my-agent
+anet logs my-agent --follow
+tmux ls
 ```
 
-Online status is automatically restored after successful reconnection. Three changes ship together:
+Stop old instances before starting one replacement. See [Troubleshooting](/en/troubleshooting) for additional symptoms.
 
-- **Tighter backoff**: `1s → 30s` cap — full reconnect within 30s of hub restart
-- **Re-register on reconnect**: every successful reconnect re-fires the node registration (idempotent upsert on the hub), so the dashboard recovers in under 30s (previously a reconnect only restored the SSE stream and the dashboard waited for the next 3-minute heartbeat)
-- **Give-up guard**: if reconnect failures continue for over 1 hour, agent-node gives up auto-retry, logs an error, and stops burning CPU
+## References
 
-Pairs with the `anet hub stop` / `hub status` commands: during hub maintenance, `stop → start` no longer requires a follow-up `anet project restart` — nodes restore themselves. Run `anet upgrade` to pick up the latest fix.
-
-### Graceful Shutdown
-
-On SIGINT (Ctrl+C) or SIGTERM:
-
-1. Report `report_status(offline)`
-2. Close SSE connection
-3. Exit process
-
-If the process crashes (no time to report), CommHub detects via heartbeat timeout and marks the agent offline after **10 minutes** (verified at [`index.ts` stale-sweep (`COMMHUB_STALE_SWEEP_SECONDS`)](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) `Date.now() - 10 * 60 * 1000` cutoff, lazily triggered on `/api/status` calls).
-
-## Environment Variables
-
-Only the env vars that agent-node actually reads from `process.env` (verified at [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)):
-
-| Variable | Equivalent CLI flag / config field | Description |
-|------|------------------------------|------|
-| `COMMHUB_URL` | `--hub` / `--url` / `config.hub` | CommHub Server address (cli.ts) |
-| `COMMHUB_TOKEN` | `config.token` / `globalConfig.token` | Auth token (cli.ts; **no CLI flag accepted**) |
-| `COMMHUB_ALIAS` / `ALIAS` | `--alias` / `config.alias` | Agent alias — both env var names work (cli.ts) |
-| `RUNTIME` | `--runtime` / `config.runtime` | Runtime engine, defaults to `claude-agent-sdk` |
-| `MODEL` | `--model` / `config.model` | AI model |
-| `LOG_LEVEL` | `--log-level` / `config.logLevel` (**top-level**, not under `flags`) | `debug` / `info` / `warn` / `error` |
-| `ANET_NETWORK_ID` | `config.network_id` / `globalConfig.network_id` | Network ID fallback (typically inferred from `ntok_`; cli.ts) |
-| `TELEGRAM_BOT_TOKEN` | channel `.env` / `config.env.TELEGRAM_BOT_TOKEN` | Bot token for the Telegram channel — agent-node reads it directly in the telegram channel startup path (cli.ts); the allowlist comes from `access.json`, not env (see [Channel — Telegram](/en/guide/channels#telegram-channel)) |
-| `CLAUDE_TIMEOUT_MS` | `--claude-timeout-ms` / `config.flags.claudeTimeoutMs` / `config.claudeTimeoutMs` | Per-query timeout (ms) for the `claude-agent-sdk` runtime, default **`300000` (300s)** (raised from 120s in v0.9.2 by [#132 Tier 1](https://github.com/sleep2agi/agent-network/issues/132) — the [SDK concurrency investigation](https://github.com/sleep2agi/agent-network/blob/main/docs/research/sdk-concurrency-investigation.md) measured intern API per-request latency stretching to 17-37s under heavy fan-out, so the old 120s ceiling fired mid-stream and 25/30 sub-agents silently failed); on timeout it aborts and returns an error suggesting you check `ANTHROPIC_BASE_URL` reachability. Verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| `CLAUDE_MAX_RETRIES` | `--claude-max-retries` / `config.flags.claudeMaxRetries` / `config.claudeMaxRetries` | Retry count for `claude-agent-sdk` runtime queries that fail. Default **`2`** (3 attempts total including the initial). Each attempt runs its own `CLAUDE_TIMEOUT_MS` window; on transient errors / timeouts, backs off `4s, 8s + 0-1s jitter` (the jitter spreads herd retries so a recovering vendor queue isn't slammed). **Auth-class errors do not retry** ([#129 fast-fail](https://github.com/sleep2agi/agent-network/issues/129): the `isAuthError` regex matches 401 / 403 / `invalid_api_key` / intern A02xx etc. and returns a FATAL with the vendor-specific URL hint). Set `0` to revert to v0.9.1 behavior (no retry). Introduced in v0.9.2 via [#132 Tier 1](https://github.com/sleep2agi/agent-network/issues/132). Verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) + retry loop [`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| `ANET_CODEX_STDIO_DIRECT` | env only (no CLI flag / config field; per-spawn injection) | **v0.10.0+, only takes effect when `runtime=codex`** (claude-agent-sdk / claude-code-cli ignore it). Set `=1` to switch the codex runtime from the `@openai/codex-sdk` wrapper to the **direct stdio JSON-RPC client** path: agent-node runs `spawn('codex', ['app-server'])` with a ~155 LOC stdio client and the full 67-method v2 protocol surface (thread / turn / item / realtime), **bypassing** the wrapper's `--mcp-config` HTTP-transport bug family ([#102](https://github.com/sleep2agi/agent-network/issues/102) hang root cause). v0.10.x (including the current stable) **still defaults to the wrapper** (preview-feedback window + backward compat); v0.11.0 plans to flip the default, at which point the toggle becomes `ANET_CODEX_LEGACY_SDK=1` opt-out (per [`agent-node/src/cli.ts` comments](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)). Introduced in v0.10.0 via [#141](https://github.com/sleep2agi/agent-network/issues/141). Verify [`agent-node/src/cli.ts` `if (process.env.ANET_CODEX_STDIO_DIRECT === "1")`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| `ANTHROPIC_BASE_URL` | `config.env.ANTHROPIC_BASE_URL` | Model API URL (required when targeting a third-party Anthropic-compatible endpoint) |
-| `ANTHROPIC_AUTH_TOKEN` | `config.env.ANTHROPIC_AUTH_TOKEN` | Model API key — **for third-party Anthropic-compatible endpoints** (MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter / vLLM, etc.) |
-| `ANTHROPIC_API_KEY` | `config.env.ANTHROPIC_API_KEY` | Model API key — **only for direct api.anthropic.com**; don't reuse it for third-party endpoint keys (see [runtimes — claude-agent-sdk pitfalls](/en/guide/runtimes#claude-agent-sdk)) |
-
-::: warning `TOOLS` / `SYSTEM_PROMPT` env vars do not exist
-The previously listed `TOOLS` and `SYSTEM_PROMPT` env vars are **not read** by agent-node (verified: cli.ts `toolsRaw = opts.tools || fileConfig.tools` has no `process.env.TOOLS`; cli.ts `SYSTEM_PROMPT = opts.prompt || fileConfig.systemPrompt` has no env reading). To set tools, use the `--tools` CLI flag or `config.json`'s `tools` field; for the system prompt, use the `--prompt` flag or `config.json`'s `systemPrompt` field.
-:::
-
-::: tip Docker Usage
-When running in Docker, environment variables are the most convenient configuration method. See [Docker Deployment](/en/deploy/docker).
-:::
-
-## Next steps
-
-**Get started**:
-- [One-shot install](/en/guide/one-shot-install) — first agent in 5 minutes after install
-
-**Configure deeper**:
-- [Runtimes](/en/guide/runtimes) — how to pick a runtime (4 on stable, 6 on preview)
-- [Multi-model](/en/guide/multi-model) — use DeepSeek / MiniMax / Kimi / Claude
-- [Channel plugins](/en/guide/channels) — wire agents to Telegram / WeChat / Feishu
-
-**Production**:
-- [Docker deployment](/en/deploy/docker) — containerized agents
-- [Production deployment](/en/deploy/production) — multi-machine, TLS, backups
-- [Dashboard](/en/guide/dashboard) — monitor agent status, tasks, message flow
-
-**Troubleshooting**:
-- [Troubleshooting](/en/troubleshooting) — common issues
-- `anet doctor --fix` — auto-detects expired ntok_ and other issues
+- [Getting Started](/en/guide/getting-started)
+- [Runtimes](/en/guide/runtimes)
+- [CLI reference](/en/guide/cli)
+- [Security model](/en/concepts/security)
+- [Task lifecycle](/en/concepts/task-lifecycle)
+- [Channels](/en/guide/channels)
+- [Troubleshooting](/en/troubleshooting)

--- a/docs-site/docs/en/guide/agent-node.md
+++ b/docs-site/docs/en/guide/agent-node.md
@@ -51,6 +51,8 @@ Do not select a runtime here from an old version number or fixed count. Availabi
 
 Stop the previous process before changing runtimes. Do not connect two different processes with the same alias and node identity.
 
+<a id="environment-variables"></a>
+
 ## Node files
 
 Project-local node state is under `.anet/nodes/<alias>/`:
@@ -113,6 +115,8 @@ Treat a node that can write files, run shell commands, or use the network as unt
 
 See the [security model](/en/concepts/security) for current defaults and threats.
 
+<a id="recurring-tasks-the-loop-scheduler"></a>
+
 ## Scheduled tasks
 
 Create a recurring task for an online node:
@@ -124,6 +128,8 @@ anet goal cancel my-agent <goal-id>
 ```
 
 Goal state is stored in the node's `goals.json`. Intervals require a unit; the CLI currently accepts minutes, hours, or days. Each run consumes real model quota, so validate with a conservative interval. This is not a high-precision cron service.
+
+<a id="reconnection"></a>
 
 ## Lifecycle and recovery
 

--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -28,6 +28,10 @@ Rows tagged `(preview)` below are **preview-only** and not selectable on stable.
 
 > ⚠️ **`opencode-cli` is preview-channel only** (RFC-029, still iterating): npm **latest does not include it yet** — after installing latest, `anet node create` shows only the first 4 runtimes (`claude-code-cli` / `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`). It lands in latest once stable.
 
+> OpenCode's built-in Anthropic client sends `x-api-key`. Anthropic-compatible gateways that accept only Bearer authentication, such as Kimi coding, return 401 on that preset; use an OpenCode plugin or custom path that supports the gateway's authentication instead.
+
+> Agent Node does not read environment variables literally named `TOOLS` or `SYSTEM_PROMPT`. Set tools with `--tools` or config `tools`, and the system prompt with `--prompt` or config `systemPrompt`.
+
 ::: tip Not sure which one?
 - **Reuse a Claude subscription / smoothest first-time path** → `claude-code-cli` (zero config after `claude auth login`)
 - **Writing copy / translation / analysis (programmatic) / using a domestic Chinese model** → `claude-agent-sdk` + pick the matching vendor in the wizard
@@ -478,7 +482,7 @@ Older agent-node versions **do not print a `timeoutMs=...` log line at startup**
 ### See also
 
 - [`grok-build-runtime.md` full runtime guide](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md) — Known Limits + debug + preview chain
-- [agent-node § grok-build-acp tip](/en/guide/agent-node) — v0.10.11 [#204](https://github.com/sleep2agi/agent-network/issues/204) per-node isolated cwd details
+- [grok-build-acp](#grok-build-acp) — use a separate working directory per node; do not infer Grok behavior from another runtime's section
 - [troubleshooting → grok-build-acp node task hangs](/en/troubleshooting#grok-build-acp-node-task-hangs-session-prompt-timed-out-after-300000ms-json-rpc-error-32603) — `session/prompt` timeout troubleshooting
 - [architecture § Debug tip](/en/guide/architecture) — runtime debug entry point
 

--- a/docs-site/docs/guide/agent-node.md
+++ b/docs-site/docs/guide/agent-node.md
@@ -1,681 +1,154 @@
 # Agent Node
 
-Agent Node 是 Agent Network 中的工作单元 -- 接收任务、调用 AI 模型处理、回报结果。
+Agent Node 是 CommHub 与模型 runtime 之间的执行进程。它负责连接 Hub、接收任务、调用选定 runtime、回传结果，并维护节点日志、会话和定时目标。
 
-::: tip 不知道选哪个 Runtime？
-- **想白嫖 Claude 订阅 / 新手最省事** → `claude-code-cli` (`claude auth login` 后 0 配置)
-- **写文案 / 翻译 / 分析 (编程式) / 接国产模型** → `claude-agent-sdk` + 在 wizard 里选对应 vendor
-- **写代码 / 跑命令** → `codex-sdk`
-- **用 xAI Grok Build** → `grok-build-acp` ([详细见 GitHub ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md))
-- **接国产 / 非内置 vendor** (GLM / Kimi / OpenRouter / vLLM / SiliconFlow / 通义千问 等) → `claude-agent-sdk` + 在 vendor 子菜单选 `自定义 (custom)` + `ANTHROPIC_BASE_URL`
+Runtime 的安装、鉴权和能力差异以 [Runtime 对比表](/guide/runtimes)为准；完整命令以 [CLI 参考](/guide/cli)为准。本页只讲节点本身的通用行为。
 
-**runtime × npm 包 × wizard 行为 × 前置 auth 的权威对照**（正式版 4 种；预览版另加 `codex-app-server` / `opencode-cli`）: 见 [runtimes — Runtime 对比 (canonical)](/guide/runtimes#runtime-对比-canonical-表). `anet node create` wizard 完整顺序 (`节点名 → runtime → ... `): [上手指南 §5](/guide/getting-started#_4-创建并启动节点).
-:::
+## 安装并启动
 
-## 安装
+需要 Node.js ≥ 22.13 和 Bun：
 
 ```bash
-# 全局安装
-npm install -g @sleep2agi/agent-node
-
-# 或直接用 npx（推荐，无需安装）
-npx @sleep2agi/agent-node --help
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
 ```
 
-## Runtime 一览
-
-Agent Node 支持多种 AI 运行时引擎（正式版 4 种；预览版另加 `codex-app-server` / `opencode-cli`），覆盖主流模型。完整对照见 [runtimes canonical 表](/guide/runtimes#runtime-对比-canonical-表)：
-
-### claude-agent-sdk
-
-基于 [Anthropic Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk)。
-
-| 属性 | 说明 |
-|------|------|
-| **模型** | 当前主线 Claude Sonnet / Opus / Haiku（具体型号查 [Anthropic 官方](https://docs.anthropic.com/claude/docs/models-overview)） |
-| **前置** | Anthropic API Key，或任一 Anthropic 兼容 API Key（MiniMax / DeepSeek / GLM / Kimi / 书生 / 小米 MiMo / OpenRouter 等，完整列表见 [multi-model](/guide/multi-model)） |
-| **特点** | 编程式调用 Anthropic 兼容接口，适合稳定后台 Agent |
-| **隔离** | `settingSources: []` 完全隔离宿主机配置 |
+先按[上手指南](/guide/getting-started)启动并登录 Hub，然后在准备让 Agent 工作的项目目录中：
 
 ```bash
-npx @sleep2agi/agent-node \
-  --alias 推理大师 \
-  --runtime claude-agent-sdk \
-  --model claude-sonnet-4-6 \
-  --hub http://YOUR_IP:9200
+anet node create my-agent
+anet node start my-agent
 ```
 
-::: details 你需要准备
-- [ ] Anthropic API Key 或 MiniMax API Key（付费）
-- [ ] CommHub Server 已启动
-:::
+`node create` 会让你选择 runtime，并为节点向 Hub 注册独立身份。`node start` 默认前台运行；日志出现 `SSE connected` 后才表示任务推送链路已连通。
 
-::: info 验证
-启动后看到 `SSE connected, waiting for tasks...` 即表示成功。如果报 `auth` / `401` / `invalid x-api-key`：检查 `ANTHROPIC_API_KEY`（接 api.anthropic.com）或 `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL`（接第三方 Anthropic 兼容 endpoint）env 是否正确设置（详见 [runtimes — 常见坑](/guide/runtimes#claude-agent-sdk)）。`claude auth login` 是给 `claude-code-cli` 用的，跟 SDK 路径无关。
-:::
-
-### claude-code-cli
-
-基于本地 Claude Code CLI 进程，和你平时在终端里使用的 `claude` 命令完全一致。
-
-| 属性 | 说明 |
-|------|------|
-| **模型** | 当前主线 Claude Sonnet / Opus / Haiku（具体型号查 [Anthropic 官方](https://docs.anthropic.com/claude/docs/models-overview)） |
-| **前置** | Claude Code 已安装（`npm i -g @anthropic-ai/claude-code`） |
-| **特点** | 直接 spawn `claude` 进程，拥有完整终端能力 |
-| **区别** | 与 `claude-agent-sdk` 的区别：CLI 模式 = 启动 `claude` 子进程；SDK 模式 = 编程式 API 调用 |
+常用管理命令：
 
 ```bash
-npx @sleep2agi/agent-node \
-  --alias 终端助手 \
-  --runtime claude-code-cli \
-  --model claude-sonnet-4-6 \
-  --hub http://YOUR_IP:9200
+anet node ls
+anet info my-agent
+anet logs my-agent --follow
+anet node stop my-agent
 ```
 
-::: details 你需要准备
-- [ ] 安装 Claude Code：`npm install -g @anthropic-ai/claude-code`
-- [ ] 确认 `claude --version` 能正常输出
-- [ ] 跑过 `claude auth login` 让本机 Claude 订阅生效（claude-code-cli runtime 复用本地登录态）
-- [ ] CommHub Server 已启动
-:::
+### 工作目录很重要
 
-::: info 验证
-启动后看到 `SSE connected, waiting for tasks...` 即表示成功。
-- 如果报 `claude: command not found`，请确认已全局安装 Claude Code
-- 如果报 `auth` / 401，请跑 `claude auth login` 重新登录订阅
-:::
-
-::: info claude-code-cli vs claude-agent-sdk
-- **claude-code-cli**：spawn 一个 `claude` 子进程，就像你在终端里敲命令一样。拥有 Claude Code 的全部能力（文件操作、bash 执行、MCP 工具等）。
-- **claude-agent-sdk**：通过编程式 SDK API 调用 Claude，更适合需要精细控制 `settingSources`、`maxTurns` 等参数的场景。
-:::
-
-### codex-sdk
-
-基于 [OpenAI Codex SDK](https://www.npmjs.com/package/@openai/codex-sdk)。
-
-| 属性 | 说明 |
-|------|------|
-| **模型** | Codex SDK 模型（通过 `--model` 指定；具体 model id 查 OpenAI Codex 文档） |
-| **前置** | `codex login` |
-| **特点** | 代码生成强、工具调用灵活 |
-| **工具** | Codex CLI 内置 Read / Write / Edit / Bash / Glob / Grep / WebSearch（不接受 `--tools` 自定义）+ agent-node 按节点注入 CommHub 工具 |
+Agent 的文件工具以启动目录为工作区。请在目标项目目录创建、启动节点，不要从 `$HOME` 或包含其他项目/凭据的目录运行。需要后台运行时使用：
 
 ```bash
-npx @sleep2agi/agent-node \
-  --alias 代码助手 \
-  --runtime codex-sdk \
-  --model <codex-model-id> \
-  --hub http://YOUR_IP:9200
-# 注：codex-sdk 不接受 --tools flag。Codex 内建工具由 codex CLI 二进制提供；
-# CommHub 工具由 agent-node 按节点注入，可主动 get_all_status / send_task / get_task。
+anet node start my-agent --tmux
 ```
 
-::: details 你需要准备
-- [ ] 安装 codex CLI：`npm install -g @openai/codex`（`@openai/codex-sdk` 在 `@sleep2agi/agent-node` 的 `optionalDependencies` 里，npm 7+ 默认会随 agent-node 一起拉；但 SDK 实际要 spawn `codex` 二进制；详见 [runtimes / codex-sdk 前置](/guide/runtimes#codex-sdk)）
-- [ ] 跑 `codex login` 完成 OpenAI 登录（或 `export OPENAI_API_KEY=sk-xxx`）
-- [ ] CommHub Server 已启动
-:::
+从终端启动会 attach 到 tmux；用 `Ctrl-B D` detach。无 TTY 的环境会以 detached 模式启动。长期守护和开机恢复见[后台运行指南](/deploy/daemon)。
 
-::: info 验证
-启动后看到 `SSE connected, waiting for tasks...` 即表示成功。
-- 如果报 `Error: spawn codex ENOENT`，说明 `codex` 二进制不在 PATH 上，跑 `npm install -g @openai/codex` + `which codex` 检查
-- 如果报 codex 鉴权错误，请跑 `codex login`（或检查 `OPENAI_API_KEY` env）
-:::
+## 选择 Runtime
 
-### grok-build-acp
+不要在本页根据旧版本号或固定数量选 runtime。当前可安装组合由 npm 发布频道决定：
 
-基于 [xAI Grok Build ACP (Agent Communication Protocol)](https://docs.x.ai/docs/overview) 接入，spawn 本地 `grok` ACP server 跑任务。第 4 runtime，已可在 `anet node create` wizard 里选择，也可用 `--runtime grok-build-acp` 显式指定。详细配置 / Known Limits / Delegation Contract 见 [grok-build-runtime.md ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md)。
+- Claude Code、Claude Agent SDK、Codex SDK、Grok ACP 等路径见 [Runtime 对比](/guide/runtimes)。
+- Codex TUI 共存是 preview 功能，必须使用 `--copresence` 的完整启动/恢复路径，见 [Codex TUI 共存](/guide/codex-copresence)。
+- OpenCode 当前是任务 runtime，不是共享 TUI。
+- Grok 共享 TUI 尚未发布；当前可用的 `grok-build-acp` 不支持 attach，见 [Grok TUI 状态](/guide/grok-copresence)。
 
-| 属性 | 说明 |
-|------|------|
-| **前置** | `grok` CLI 已 auth + `GROK_CODE_XAI_API_KEY` env |
-| **特点** | xAI Grok Build 模型, ACP 协议跨 agent 协作 |
-| **工具** | Grok ACP 内置, 不接受 `--tools` 自定义 |
+切换 runtime 前先停止旧进程。不要让两个不同进程以同一 alias / node identity 同时连接 Hub。
 
-```bash
-npx @sleep2agi/agent-node \
-  --alias grok助手 \
-  --runtime grok-build-acp \
-  --hub http://YOUR_IP:9200
-```
+## 节点文件
 
-::: tip grok-build-acp 改进
-- [#201](https://github.com/sleep2agi/agent-network/issues/201) — delegate refusal 3-layer 修：parser broaden + prompt softening + 授权措辞表
-- [#204](https://github.com/sleep2agi/agent-network/issues/204) — MCP per-session inject + 节点 cwd 隔离，防 `.mcp.json` 身份污染
+每个项目的节点状态位于 `.anet/nodes/<alias>/`：
 
-完整说明见 [grok-build-runtime.md Known Limits](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md#known-limits)。
-
-::: details preview chain 历史（怎么收敛到 preview.7）
-- **preview.2 stdio variant**：结构修 `.mcp.json` shared-identity bug（ACP side）
-- **preview.6 transport 切到 HTTP**：Grok 直接 HTTP 调 commhub `/mcp` + Bearer ntok_，跳过 subprocess / bun PATH / stdout pollution 风险
-- **preview.7 per-node isolated cwd 收敛 final**：Grok CLI 同时读 cwd `.mcp.json` + ACP injection，两个 MCP server 共存 stale 赢 hello — fix: ACP `session/new` 传节点隔离 cwd 镜像 user 文件但 skip `.mcp.json`
-- v0.10.11 final = preview.7 promoted
-:::
-:::
-
-### opencode-cli（preview）
-
-> ⚠️ **仅 preview 渠道**：npm latest 尚未包含，装 latest 的 `anet node create` 选单里没有它（见 [runtimes 表](/guide/runtimes)）。RFC-029 稳定后进 latest。
-
-基于 [公版 sst/opencode](https://github.com/sst/opencode) CLI 接入 (RFC-029)。opencode 是多 vendor 前端 (统一 UI + session + auth 抽象), anet 通过 `opencode acp` (stdio JSON-RPC) 常驻子进程做 think()。
-
-| 属性 | 说明 |
-|------|------|
-| **前置** | `opencode-ai` 装到 exact pin 版本; vendor API key export 到 env (`ANTHROPIC_API_KEY` 或 `OPENAI_API_KEY`) |
-| **特点** | 多 vendor preset (Anthropic 原生 + OpenAI 起手); auth.json 每 node 独立隔离 (mode 0o600); ACP 常驻子进程无 cold-start; 跟 grok-build-acp 传输层同构 |
-| **工具** | opencode 内置; Feishu channel 下 commhub MCP 一律 deny (跟 grok/claude-code-cli 同) |
-
-```bash
-# 1. 装 pinned 版（preview 当前 pin；以 anet node start 报的 exact 版本为准，可能随版本更新）
-npm install -g opencode-ai@1.18.1
-
-# 2. Export 你选的 preset 对应的 env
-export ANTHROPIC_API_KEY=sk-...    # for anthropic preset
-# 或
-export OPENAI_API_KEY=sk-...       # for openai preset
-
-# 3. Wizard 建 node (会问 preset + 自动落 auth.json 到 node HOME)
-anet node create opencode助手 --runtime opencode-cli
-anet node start opencode助手
-```
-
-::: tip 版本 pin + upgrade
-opencode 上游迭代快 (npm `latest` 每天动), 每次 `anet node start` 都硬检 exact 版本, 差一个字都拒。
-
-- 想升级: `anet opencode upgrade-pin <version>` — 命令会:
-  1. `npm install -g opencode-ai@<version>`
-  2. 起 `opencode acp` 做 smoke (initialize + session/new)
-  3. **smoke 过才**写 `~/.anet/opencode-pin.json` (含 version + smokePassedAt)
-  4. 下次 `anet node start` 就认新版本
-
-- pin 状态是 per-machine 的; 团队协作时每台机器各自升级 + smoke。
-:::
-
-::: tip Bearer-only vendor 门槛 (RFC-029 §8 D3)
-opencode 内建 anthropic client 硬编码 `x-api-key`。Bearer-only 兼容网关 (Kimi coding 等) 开箱 401。preset 起手支持 Anthropic 原生 + OpenAI; Bearer vendor 需 opencode plugin 自控 auth path (实施期 backlog)。
-:::
-
-::: warning auth.json 敏感路径
-opencode 的 `auth.json` 存 vendor API key。agent-node 的 read-denylist 会阻止运行中的 opencode agent Read / exfil 自己 auth.json (跟飞书 access.json 同类防线)。
-:::
-
-### codex-app-server（preview）
-
-> ⚠️ **仅 preview 渠道**：npm latest 尚未包含，装 latest 的 `anet node create` 选单里没有它（见 [runtimes 表](/guide/runtimes#runtime-对比-canonical-表)）。RFC-030 稳定后进 latest。
-
-基于 OpenAI Codex 的 **app-server 桥**（[RFC-030](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md)）——节点持有一个 codex app-server 进程，人和 agent **共用同一个 codex 会话**（人机共存）：agent 处理网络派来的任务，人可在同一个 codex TUI 里随时查看 / 接管。
-
-| 属性 | 说明 |
-|------|------|
-| **模型** | OpenAI Codex（gpt-5.5 等，复用 codex 登录态） |
-| **前置** | 本机装 `codex` CLI 并 `codex login`（codex 没有 `auth` 子命令） |
-| **特点** | 人机共存桥；`codexThreadId` 存专属字段，不占用通用 `session` |
-| **审批** | 需要审批的 turn 会挂起交人类在 TUI 处理，桥**不代答** |
-
-```bash
-anet node create codex桥 --runtime codex-app-server
-anet node start codex桥 --copresence
-tmux attach -t =codex桥
-```
-
-上面是一等共存路径（需要 preview、bash、tmux 3.2+，默认只读）。普通 `anet node start codex桥` 只会启动后台节点，不提供人类 TUI；断线恢复也不能用普通 start。完整步骤、权限和 Windows 手工路径见 [Codex TUI 人机共存](/guide/codex-copresence)，设计边界见 [RFC-030](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md)。
-
-### claude-agent-sdk + 国产模型
-
-通过 `ANTHROPIC_BASE_URL` 将 claude-agent-sdk 的请求路由到国产模型的兼容 API，适合低成本场景。
-
-| 属性 | 说明 |
-|------|------|
-| **模型** | MiniMax、DeepSeek、GLM、Kimi、书生 Intern、小米 MiMo、OpenRouter 等任何 Anthropic-compatible endpoint（完整 provider 表见 [多模型配置](/guide/multi-model)） |
-| **前置** | 对应模型的 API Key |
-| **特点** | 低成本、高吞吐、国内直连 |
-| **机制** | 通过 `ANTHROPIC_BASE_URL` 将请求路由到兼容 API |
-
-```bash
-# MiniMax
-ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic \
-ANTHROPIC_AUTH_TOKEN=your-minimax-key \
-npx @sleep2agi/agent-node \
-  --alias 小明 \
-  --runtime claude-agent-sdk \
-  --model <minimax-model-id> \
-  --hub http://YOUR_IP:9200
-
-# 书生（注意：裸域名，无 /anthropic 后缀）
-ANTHROPIC_BASE_URL=https://chat.intern-ai.org.cn \
-ANTHROPIC_AUTH_TOKEN=your-intern-key \
-npx @sleep2agi/agent-node \
-  --alias 书生 \
-  --runtime claude-agent-sdk \
-  --model intern-s1-pro \
-  --hub http://YOUR_IP:9200
-```
-
-::: details 你需要准备
-- [ ] 对应模型的 API Key（如 MiniMax API Key）
-- [ ] 设置好环境变量 `ANTHROPIC_BASE_URL` 和 `ANTHROPIC_AUTH_TOKEN`
-- [ ] CommHub Server 已启动
-:::
-
-::: info 验证
-启动后看到 `SSE connected, waiting for tasks...` 即表示成功。如果报 `401` 或 `auth` 错误，检查 API Key 是否正确。
-:::
-
-## 命令行参数
-
-```bash
-npx @sleep2agi/agent-node [options]
-```
-
-| 参数 | 默认值 | 说明 |
-|------|--------|------|
-| `--alias` | (必需) | Agent 名称（在 CommHub 中的显示名） |
-| `--hub` | http://127.0.0.1:9200 | CommHub Server 地址 |
-| `--runtime` | claude-agent-sdk | 运行时引擎（`claude-agent-sdk` / `codex-sdk` / `claude-code-cli` / `grok-build-acp`） |
-| `--model` | (按 runtime 默认) | AI 模型名称 |
-| `--tools` | (无) | 可用工具列表，逗号分隔 |
-| `--max-budget` | 0 | 每任务预算上限（美元，0 表示不启用） |
-| `--session` | (新建) | 恢复指定 session |
-| `--config` | (自动查找) | 指定配置文件路径 |
-
-::: info Token / 网络从哪里来
-token 由 `.anet/nodes/<name>/config.json` 的 `token` 字段或 `COMMHUB_TOKEN` env 提供，**不接受 CLI flag**。网络 ID 从 `ntok_` token claim 推断，无需手动指定。agent-node CLI **不解析** `-a / -h / -r / -m / -t / -s / -c` 等单字符短 flag，只接受上表中的长形式。
-:::
-
-## 配置文件
-
-Agent Node 支持多种配置方式，优先级从高到低（verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)）：
-
-```mermaid
-flowchart TD
-    A["命令行参数<br/>(--alias / --runtime / --model 等)"] --> B["环境变量<br/>(COMMHUB_ALIAS / RUNTIME / MODEL / COMMHUB_URL / COMMHUB_TOKEN)"]
-    B --> C["--config 指定的文件"]
-    C --> D[".anet/nodes/&lt;ALIAS&gt;/config.json<br/>(v0.8 主路径)"]
-    D --> E[".anet/profiles/&lt;ALIAS&gt;.json<br/>(legacy 兼容)"]
-    E --> G["~/.anet/config.json<br/>(全局 fallback, 仅 hub + token 字段)"]
-    G --> F[".agent-node.json<br/>(legacy 兼容; 仅 D/E/G 都空时启用)"]
-```
-
-::: tip 全局 `~/.anet/config.json` fallback
-[`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) 在加载完项目 config 后会用全局 `~/.anet/config.json` 的 `hub` 和 `token` 字段填空缺。**只有这两个字段会跨项目 fallback**——`runtime` / `model` / `tools` / `env` 等都必须在项目 `config.json` / CLI / env 提供，全局 config 不接管。项目字段级覆盖全局，缺失字段才 fallback 到全局。
-:::
-
-### config.json 完整字段
-
-```json
-{
-  "anet_version": "0.1.0",
-  "node_id": "n_a1b2c3d4",
-  "node_name": "代码助手",
-  "token": "ntok_...",
-  "runtime": "claude-agent-sdk",
-  "model": "<model-id>",
-  "session": "",
-  "channels": ["server:commhub"],
-  "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
-  "logLevel": "info",
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://api.minimaxi.com/anthropic"
-  },
-  "flags": {
-    "dangerouslySkipPermissions": true,
-    "teammateMode": "in-process",
-    "maxTurns": 20
-  }
-}
-```
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `anet_version` | string | 配置版本 |
-| `node_id` | string | 稳定唯一标识（n_ 前缀 + 8 位 hex） |
-| `node_name` | string | 显示名称，可 rename |
-| `alias` | string | 节点别名（`.anet/nodes/<alias>/` 目录名 + CommHub 上的显示标识；不单独设时等于 `node_name`） |
-| `runtime` | string | 运行时：`claude-agent-sdk` / `codex-sdk` / `claude-code-cli` / `grok-build-acp` |
-| `model` | string | AI 模型名称 |
-| `session` | string | session/thread ID。`claude-code-cli` runtime 下由 `anet node create` 预生成 UUID（首次 start 用 `--session-id <uuid>` 绑定，重启自动 `--resume <uuid>` 续会话；v0.8.2 修了之前默认丢 session 的 bug）；其他 runtime 是上次 session ID 用作 resume |
-| `channels` | string[] | 接入的 Channel 列表 |
-| `tools` | string[] | 允许使用的工具列表。**仅 `claude-agent-sdk` 生效**；`codex-sdk` 静默忽略（工具集 baked in codex 二进制，见上方 L109 注 + [runtimes#codex-sdk](/guide/runtimes#codex-sdk)）|
-| `env` | object | 环境变量覆盖 |
-| `flags` | object | 运行时标志 |
-| `hub` | string | CommHub Server 地址覆盖（不设时 fallback 到全局 `~/.anet/config.json` 的 `hub`） |
-| `token` | string | 认证 Token 覆盖（不设时 fallback 到全局 config 的 `token`） |
-| `network_id` | string | 所属网络 ID（多数情况靠 `ntok_` 推断，不需手填） |
-| `systemPrompt` | string | 系统提示词，拼到每个任务前（也可用 `--prompt` flag；env `SYSTEM_PROMPT` **不读**，见上方说明） |
-
-## 任务处理流程
-
-Agent Node 启动后，自动进入任务监听循环：
-
-```mermaid
-stateDiagram-v2
-    [*] --> 连接CommHub: report_status(idle)
-    连接CommHub --> SSE监听: SSE connected
-    SSE监听 --> 收到事件: new_task / broadcast
-
-    state 收到事件 {
-        [*] --> 拉取inbox: get_inbox
-        拉取inbox --> 确认收到: ack_inbox
-        确认收到 --> 判断类型
-
-        state 判断类型 <<choice>>
-        判断类型 --> AI处理: type=task
-        判断类型 --> 记录日志: type=message/reply
-
-        AI处理 --> 上报working: report_status(working)
-        上报working --> think: 调用 AI 模型
-        think --> 回复结果: send_reply
-        回复结果 --> [*]
-        记录日志 --> [*]
-    }
-
-    收到事件 --> SSE监听: 处理完成
-    SSE监听 --> 断线重连: SSE disconnected
-    断线重连 --> SSE监听: 指数退避 3s→60s
-    SSE监听 --> 下线: SIGINT/SIGTERM
-    下线 --> [*]: report_status(offline)
-```
-
-### 循环任务 / `/loop` 调度器
-
-从 v0.11 起，**所有 runtime**（claude-agent-sdk / codex-sdk / grok-build-acp）都支持 anet 内置的 /loop 调度器。给 agent 发一个 `/loop <间隔> <任务>` 消息，节点会持久化到自己的 `goals.json`，按间隔自动唤醒、做一次增量推进、汇报进度。
-
-#### 一行命令调度（推荐）
-
-```bash
-# 每 5 分钟监控一次 PR #271
-anet node loop my-codex "监控 PR #271 进展" --every 5m
-
-# 每 30 分钟扫一次 Twitter
-anet node loop researcher "扫一遍 twitter 上 grok 的最新进展" --every 30m
-
-# 每 2 小时发一次晨报
-anet node loop daily-bot "发布今日早报" --every 2h
-```
-
-间隔格式：`30s` / `5m` / `2h` / `1d`（必须带单位）。命令在 `--every` 省略时默认 `5m`。
-
-#### 直接发 /loop 消息
-
-也可以用 `commhub_send_task` 或 dashboard 发一条以 `/loop` 开头的消息，效果等价：
-
-```
-/loop 5m 监控 #271 PR 进展
-/loop 30s 检查飞书 bot 是否在线
-/loop 1d 整理昨天的发布工作
-```
-
-`/goal` 是 `/loop` 的别名，效果一样。
-
-#### claude-agent-sdk 也能 loop（v0.11 起）
-
-v0.4–v0.10 期间 claude-agent-sdk runtime 因为 [设计前提错](https://github.com/sleep2agi/agent-network/issues/144) 不能 /loop（错误假设 SDK spawn 的 claude 子进程有自带 native /loop；实际 SDK 是单次 `query()` Promise，进程发完即退）。v0.11 (#144) 起所有 runtime 都走 anet 自己的调度器：
-
-```bash
-# claude-agent-sdk 节点也能 loop（v0.11+）
-anet node loop my-claude "每天检查一次 ANTHROPIC quota 余额" --every 1d
-```
-
-#### 查看 / 改 / 取消 loop
-
-```bash
-# 列出某节点所有 loop（看 task / interval / next_wake / status）
-anet goal list my-codex
-
-# 改间隔 / 暂停 / 改任务文本（id 用前 8 位即可，会自动唯一匹配）
-anet goal edit my-codex 3f8a2b1c --interval 10min                # 间隔改 10 分钟（支持 5min/1h/1d/每5分钟/hourly/daily 等）
-anet goal edit my-codex 3f8a2b1c --status paused                 # 暂停（status: active/paused/completed/cancelled）
-anet goal edit my-codex 3f8a2b1c --text "新的任务文案"           # 改文本
-
-# 按 goal id 取消（彻底停掉）
-anet goal cancel my-codex 3f8a2b1c
-```
-
-持久化文件在 `~/.anet/nodes/<alias>/goals.json`，节点重启自动恢复。**改完 `edit`/`cancel` 后，running agent-node 进程内仍持旧 goal 状态——重启节点或下次 tick 后才生效**。
-
-#### 间隔 + 频率
-
-调度器 tick 间隔由 `ANET_GOAL_TICK_MS` 环境变量或 config.json `flags.goalTickMs` 控制，默认 30 秒。任何 goal 的 `interval_ms` 不会比 tick 间隔更精确——一个 5 秒间隔的 goal 实际上还是按 30 秒 tick 唤醒，按需调小 tick。
-
-#### Agent 自管 loop：6 个 self-scoped 工具（RFC-025）
-
-除了外部 `anet node loop` / `/loop` 之外，agent 在响应任务时也可以调用 6 个 self-scoped 工具管理**自己**的循环，无需人工介入：
-
-| 工具 | 语义 |
+| 路径 | 用途 |
 |---|---|
-| `list_my_loops` | 看自己当前所有 loop |
-| `create_my_loop` | 新建一个 loop |
-| `edit_my_loop` | 改 task / interval / schedule / paused |
-| `reschedule_my_loop` | 一次性推下次唤醒（不改 interval） |
-| `complete_my_loop` | 达标归档（`status=complete`） |
-| `cancel_my_loop` | 永久放弃（`status=cancelled`） |
+| `config.json` | Hub、runtime、node identity、token、model、flags |
+| `.env` | 可选 secret；明文文件，权限应为 `0600` |
+| `logs/` | 运行日志 |
+| `goals.json` | 本节点的循环任务状态 |
 
-6 个工具都**没有 `alias` 参数**——从架构上就物理隔离，agent 无法操作其他节点的 loop。
+全局的用户登录与当前 network 位于 `~/.anet/config.json`。不要提交项目 `.anet`、token 或 `.env`。
 
-**runtime 工具可用时段**——这是 claude 和 codex/grok 的一个关键差异：
-
-- **codex-sdk / grok-build-acp**：agent-node 启动就把工具挂在一个 localhost HTTP MCP server 上（带 bearer token），**全时段可调**。agent 在处理任务时、在 loop 被唤醒时，都可以调这 6 个工具。
-- **claude-agent-sdk**：工具通过 in-process SDK MCP server 挂在 `processWithClaude` 的 tool surface 上，**只在 agent 响应某任务的生命周期内可调**（`processTask` 期间）。
-
-对 claude 用户来说这意味着什么：
-
-> **loop 被唤醒 → 触发 processTask → 工具立即可用 → agent 可以在同一个响应里 `create_my_loop("下一步")` 或 `complete_my_loop(this)`**——闭环没问题，因为 loop 唤醒本身就走 processTask 路径。
->
-> 但**在 agent 完全 idle 时**（没有正在处理任何任务），claude 内部**没有 tool 上下文**。所以你不能像 codex/grok 那样在外部触发一个「让 agent 自主决定要不要建 loop」的场景——需要先发一个任务（`anet node loop` 或直接 `send_task`）把 agent 唤起。
-
-**codex/grok 是常驻的**——工具从 agent-node 启动那一刻起就可以被随时触发的进程调用（LLM 在任意 turn 内都能引用）。这是 codex/grok 选择 out-of-process HTTP MCP、而 claude 选择 in-process SDK MCP 的架构决定带来的天然差异，不是 gap 也不是 bug。
-
-**安全防线** 是跨 runtime 一致的（三 runtime 共享同一份 `goalStore` + 计数器状态）：
-
-- 单节点默认 **20 个 active goal** 上限（`COMMHUB_MAX_GOALS_PER_NODE` 可覆盖）
-- 同一个 goal **30 秒 cooldown** 内只能改一次（防递归暴走）
-- 30 秒内连续 cancel ≥ 3 个 → 第 4 次触发 confirm-back，agent 必须回问用户，拿到确认后带 `confirm_token` 重调
-- 创建/编辑时**preflight**：cron-lite schedule 语义不合法（如时区错）直接拒，绝不入库自锁
-
-### 消息类型过滤
-
-Agent Node 只对 `task` 类型消息触发 AI 处理：
-
-| 消息类型 | SSE 事件 | Agent 行为 |
-|---------|---------|-----------|
-| task | `new_task` | processInbox -> AI think -> 回复 |
-| broadcast | `broadcast` | processInbox -> AI think -> 回复 |
-| reply | `new_reply` | 仅记录日志 |
-| message | `new_message` | 仅记录日志 |
-| ack | (不推送) | -- |
-
-这个设计避免了消息循环（A 给 B 回复 -> B 又给 A 回复 -> 无限循环）。
-
-## 工具配置
-
-### 默认 = Claude Code preset 全集（v0.9.0+，#101 Option B）
-
-从 [#101](https://github.com/sleep2agi/agent-network/issues/101) Option B 起（anet v0.9.0+），`claude-agent-sdk` runtime **默认 toolset 是 Claude Code preset 全集**，不再是空集。每个节点 spawn 后立刻可调：
-
-- 文件系统：`Read` / `Write` / `Edit` / `Glob` / `Grep`
-- Shell：`Bash`（受 `dangerouslySkipPermissions=true` 默认开启影响，不弹确认）
-- 网络：`WebFetch` / `WebSearch`
-- 子任务 / 笔记本：`Task` / `NotebookEdit` / ...
-
-加上 hub 端约 40 个 MCP 工具（`commhub_send_task` / `commhub_reply` / ...）。
-
-> **Root cause** ([#101](https://github.com/sleep2agi/agent-network/issues/101))：老版本 `config.json` 无 `tools` 字段时 agent-node 传 SDK `options.tools = undefined`，SDK 解读为「零内建工具」，agent 只能调 MCP 工具，被问 WebFetch / Bash / Read 时会幻觉「网络受限」。Option B 强制 fallback 到 SDK `{ type: 'preset', preset: 'claude_code' }` sentinel —— SDK 类型定义里这是「给我全套 Claude Code 工具」的标准表达（`sdk.d.ts:1229-1238`）。
-
-### 三种 `--tools` 行为（仅 `claude-agent-sdk` runtime）
-
-`--tools` flag 只控制 `claude-agent-sdk` runtime —— `codex-sdk` 的工具集由 codex CLI baked in（`Read/Write/Edit/Bash/Grep/Glob/WebSearch`，**不接受** `--tools`）；`claude-code-cli` 共享本机 Claude Code 工具集，也不通过这个 flag 选。
-
-| 输入 | 实际效果 | verify |
-|------|---------|--------|
-| `--tools all` | SDK preset 全集（同上）—— 单一 source-of-truth | [`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| `--tools Read,Glob,Grep` | 显式 allowlist（字符串数组），跳过 preset —— 严格 sandbox 用 | [`cli.ts,220`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| 未传 / 空字符串 | **fallback 到 preset 全集**（#101 fix；老版本是 `undefined` → 空集） | [`cli.ts,221`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-
-源码实际逻辑（[`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)）：
-
-```ts
-const TOOLS_PRESET = { type: "preset" as const, preset: "claude_code" as const };
-// Behaviour matrix (sdk.d.ts:1229-1238):
-//   --tools "all"       → SDK preset (full Claude Code tool set)
-//   --tools "Read,Bash" → explicit allowlist
-//   --tools "" (absent) → SDK preset (the #101 fix; previously left empty)
-const TOOLS_EXPLICIT = toolsRaw === "all" ? null : toolsRaw.split(",").filter(Boolean);
-let TOOLS: string[] | typeof TOOLS_PRESET =
-  toolsRaw === "all" ? TOOLS_PRESET
-  : (TOOLS_EXPLICIT && TOOLS_EXPLICIT.length) ? TOOLS_EXPLICIT
-  : TOOLS_PRESET;
-// ... cli.ts: tools: TOOLS  ← 传给 claude-agent-sdk query options（preset 或 string[]）
-```
+envRef 让 `config.json` 只保存环境变量引用；实际值仍可能存入节点的 mode-0600 `.env`。迁移前先检查备份和目标变量：
 
 ```bash
-# 默认（不传 --tools）→ Claude Code preset 全集
-npx @sleep2agi/agent-node --alias 代码
-
-# 显式 "all" → 同 preset（单一 source-of-truth，不是老版的硬编码 8-tool 列表）
-npx @sleep2agi/agent-node --alias 代码 --tools all
-
-# 显式 allowlist（只读 agent）→ 跳过 preset，给字符串数组
-npx @sleep2agi/agent-node --alias 代码 --tools Read,Glob,Grep
-
-# codex-sdk runtime 不接受 --tools（会被静默忽略）
-npx @sleep2agi/agent-node --alias 代码 --runtime codex-sdk
-# codex 内置 Read/Write/Edit/Bash/Grep/Glob/WebSearch 全套, 无法剥离
+anet node migrate-token-to-envref my-agent
 ```
 
-### `anet node create` 行为披露 banner（Vincent push, [#101](https://github.com/sleep2agi/agent-network/issues/101)）
+完整 token 边界见 [Token 与权限](/concepts/tokens)，配置安全见[安全设计](/concepts/security)。
 
-`anet node create <alias>` 成功后 print **行为披露 banner**：built-in tools 清单（具体 list 或 `all (Claude Code preset)`）+ MCP tools + 当前 flags（`dangerouslySkipPermissions=true` / `teammateMode=true`）+ 一行 "agent 可读写文件、跑 shell、访问网络"。banner 在 [agent-network/bin/cli.ts](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) `createCommand` 末尾打印 —— 让你**看清你创建了一个能干啥的 agent**，主动决定 sandboxing。
+### 不要复制节点身份
 
-> **⚠ User responsibility**：默认 preset + 默认 `dangerouslySkipPermissions=true` 意味着 agent 启动后**能改文件、跑 shell、访问网络且不弹确认**。详见 [安全设计 → 工具权限](/concepts/security#工具权限-默认-claude-code-preset-user-responsibility)。
+跨机器部署时，应在目标机器登录并重新运行 `anet node create`。复制 `config.json` 会同时复制 `node_id` 和 `ntok_`，可能造成身份、心跳和 SSE 路由冲突。
 
-::: warning 安全提示
-- 默认 preset 全集 + 默认 yolo mode（`dangerouslySkipPermissions`）—— 别在 `$HOME` 直接跑 agent，用一次性工作目录
-- 严格 sandbox 时 `--tools Read,Glob,Grep` 只给只读
-- 关 yolo：codex-sdk 节点用 `anet node create --no-yolo`；claude 系（claude-code-cli / claude-agent-sdk）把 node `config.json` 的 `dangerouslySkipPermissions` 设为 `false`（**没有 `--no-skip-permissions` 这个 flag**）。关掉后长任务每个工具调用都弹确认
-- 预算限制 `--max-budget 0.1`（见下方 [预算控制](#预算控制)）
-:::
+## 任务处理
 
-### Vendor 适配层（书生 intern 等）
+```text
+CommHub ──SSE task──▶ Agent Node ──▶ Runtime / model
+   ▲                                      │
+   └──────────── task result ─────────────┘
+```
 
-`claude-agent-sdk` 在某些厂商 endpoint 走 RLHF 默认会偏离 Anthropic 标准（典型：intern-s2-preview 不发 `tool_use` content blocks 改走 verbose Thinking Process）。agent-node 通过 **vendor adapter** 按 `ANTHROPIC_BASE_URL` 检测 + 注入 system-prompt bias 修正行为 —— 详见 [Vendor 适配层](/concepts/vendor-adapters)（含 5 副作用 + opt-out 路径）。
+节点只把任务类事件交给模型：
 
-## 预算控制
+- `send_task`：需要执行的任务，会触发 runtime。
+- `send_reply`：任务结果，不再次触发模型。
+- `send_message`：普通消息，不再次触发模型。
 
-`--max-budget` 参数控制每个任务的最大花费（美元）—— **只对 `claude-agent-sdk` runtime 生效**：
+这种区分避免 Agent 因回复彼此触发无限循环。状态转换、父子任务和超时语义见[任务生命周期](/concepts/task-lifecycle)。
+
+附件、图片和 channel 支持随 runtime 不同；不要假设所有 runtime 都能处理媒体。按 [Runtime 对比](/guide/runtimes)和 [Channel 指南](/guide/channels)确认。
+
+## 工具与权限
+
+工具来自两层：runtime 自带工具，以及 Agent Network 注入的 CommHub 工具。`--tools` 只对支持自定义工具列表的 runtime 生效；不要用它推断 Codex、Claude Code 或 Grok 的实际 sandbox。
 
 ```bash
-# 每任务最多 0.1 美元 (claude-agent-sdk)
-npx @sleep2agi/agent-node --alias 代码 --max-budget 0.1
-
-# 每任务最多 1 美元（复杂任务）
-npx @sleep2agi/agent-node --alias 推理 --max-budget 1.0
+anet node create reader --runtime claude-agent-sdk --tools Read,Glob,Grep
 ```
 
-verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts):
-```ts
-if (MAX_BUDGET > 0) options.maxBudgetUsd = MAX_BUDGET;  // 传给 claude-agent-sdk query options
+创建完成后，CLI 会打印行为披露；同时检查节点 `config.json` 的 `permissionMode` / `dangerouslySkipPermissions` / runtime 专用 flags。不同 runtime 默认值并不相同，且 Codex TUI 共存默认只读。
+
+把能够写文件、执行 shell 或联网的节点当作不可信代码：
+
+- 使用独立、可丢弃的工作目录。
+- 不把生产密钥放进 Agent 可读目录。
+- 只给需要的 Hub/network 权限。
+- 修改权限后用一个无害任务验证实际行为，不只看配置名称。
+
+详细威胁模型和默认值见[安全设计](/concepts/security)。
+
+## 循环任务
+
+对在线节点创建周期任务：
+
+```bash
+anet node loop my-agent "检查待处理 Issue" --every 5m
+anet goal list my-agent
+anet goal cancel my-agent <goal-id>
 ```
 
-claude-agent-sdk 在 `SDKResultMessage.total_cost_usd` 达到 `maxBudgetUsd` 时自动结束当前 turn，task 状态走 `error_max_budget`。
+循环状态保存在该节点的 `goals.json`。间隔必须带单位；CLI 当前接受分钟、小时或天。循环会真实消耗模型额度，先用较长间隔验证，不要把它当高精度 cron。
 
-::: warning codex-sdk / claude-code-cli runtime 不支持 budget cap
-- `codex-sdk` 路径（[`cli.ts processWithCodex`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)）没读 `MAX_BUDGET`，**`--max-budget` 静默忽略**；codex-sdk 仅返 token 数（`TurnCompletedEvent.usage`）不返美金，预算控制要你自己跟价表算（跟 sdk-deep-dive 一致）
-- `claude-code-cli` 走本机 Claude Code 订阅，按订阅 quota 不按美金算
-- **跨 runtime 通用预算控制**：前置反向代理（nginx / Cloudflare / litellm proxy）按 model API 调用次数限流
-:::
+## 生命周期与恢复
 
-## 生命周期
+- **启动**：读取节点配置，注册/报告状态，连接 SSE。
+- **运行**：处理任务、定期上报状态；连接中断后按退避策略重连。
+- **停止**：优先使用 `anet node stop <alias>`，让节点关闭连接并报告离线。
+- **恢复会话**：行为随 runtime 不同；先查看 `anet info <alias>` 和对应 runtime 指南，不要手工改 session/thread id。
+- **改名**：使用 `anet node rename`，不要直接改目录名、alias 或 `node_id`。
 
-Agent Node 的完整生命周期：
+若同一 alias 出现重复结果、runtime 来回变化或状态异常，先检查重复进程：
 
-| 阶段 | CommHub 状态 | 说明 |
-|------|-------------|------|
-| 创建 | (不在 CommHub) | `anet node create` 生成 config.json |
-| 注册 | idle | `report_status(idle)` |
-| 在线 | idle | SSE 连接，等待任务 |
-| 运行 | working | 正在处理任务 |
-| 错误 | error | 运行时错误 |
-| 离线 | offline | 进程退出 |
-| 删除 | (不在 CommHub) | 清除所有数据 |
-
-### 心跳机制
-
-- 每 **3 分钟** 自动发送 `report_status` 心跳
-- Server 超过 **10 分钟** 无心跳标记为 offline
-- 心跳同时返回 `inbox_count`，便于检查待处理任务
-
-### 断线重连
-
-SSE 断连后自动重连，使用指数退避策略：
-
-```
-重连间隔（[#202](https://github.com/sleep2agi/agent-network/issues/202) 起）: 指数退避 `1s → 2s → 4s → 8s → 16s → 30s (上限)`
+```bash
+anet info my-agent
+anet logs my-agent --follow
+tmux ls
 ```
 
-重连成功后自动恢复 online 状态。三件事一起改：
+停止旧实例后再启动一个。更多现象见[故障排查](/troubleshooting)。
 
-- **退避更激进**：`1s → 30s` 上限，hub 重启后 30s 内重连
-- **重连即重 register**：重连成功立即重发 register（idempotent upsert），dashboard 30s 内恢复完整节点列表（之前老路径要等下次 3min heartbeat）
-- **失败放弃保护**：连续失败 > 1h 主动放弃 + 写 error log，不再无限重试占 CPU
+## 参考
 
-跟 `anet hub stop` / `hub status` 命令配套用：hub 维护时 stop → start 流程后，节点自动恢复，**无需 `anet project restart`**。跑 `anet upgrade` 升到 latest 即可获得当前修复。
-
-### 优雅退出
-
-收到 SIGINT (Ctrl+C) 或 SIGTERM 时：
-
-1. 上报 `report_status(offline)`
-2. 关闭 SSE 连接
-3. 退出进程
-
-如果进程崩溃（来不及上报），CommHub 通过心跳超时检测，**10 分钟**后自动标记 offline（verify [`index.ts` stale-sweep (`COMMHUB_STALE_SWEEP_SECONDS`)](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) `Date.now() - 10 * 60 * 1000` cutoff，惰性触发于 `/api/status` 调用时）。
-
-## 环境变量
-
-仅列 agent-node 实际从 `process.env` 读的字段（verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)）：
-
-| 变量 | 等价 CLI flag / config 字段 | 说明 |
-|------|------------------------------|------|
-| `COMMHUB_URL` | `--hub` / `--url` / `config.hub` | CommHub Server 地址（cli.ts） |
-| `COMMHUB_TOKEN` | `config.token` / `globalConfig.token` | 认证 Token（cli.ts；**不接受 CLI flag**） |
-| `COMMHUB_ALIAS` / `ALIAS` | `--alias` / `config.alias` | Agent 别名，两个 env 名都接受（cli.ts） |
-| `RUNTIME` | `--runtime` / `config.runtime` | 运行时引擎，默认 `claude-agent-sdk` |
-| `MODEL` | `--model` / `config.model` | AI 模型 |
-| `LOG_LEVEL` | `--log-level` / `config.logLevel`（**top-level**，不在 `flags` 里） | `debug` / `info` / `warn` / `error` |
-| `ANET_NETWORK_ID` | `config.network_id` / `globalConfig.network_id` | network ID 兜底（多数情况靠 ntok_ 推断，不需手填；cli.ts） |
-| `TELEGRAM_BOT_TOKEN` | channel `.env` / `config.env.TELEGRAM_BOT_TOKEN` | Telegram channel 的 bot token —— agent-node 在 telegram channel 启动路径直接读（cli.ts）；白名单走 `access.json` 不走 env（见 [Channel — Telegram](/guide/channels#telegram-channel)） |
-| `CLAUDE_TIMEOUT_MS` | `--claude-timeout-ms` / `config.flags.claudeTimeoutMs` / `config.claudeTimeoutMs` | `claude-agent-sdk` runtime 单次 query 超时（毫秒），默认 **`300000`（300s）**（[#132 Tier 1](https://github.com/sleep2agi/agent-network/issues/132) v0.9.2 起从 120s 提升 —— [SDK concurrency investigation](https://github.com/sleep2agi/agent-network/blob/main/docs/research/sdk-concurrency-investigation.md) 实测 fan-out 高并发场景 intern API 单次 latency 拉到 17-37s，120s 老 ceiling 中途触发 abort 导致 25/30 子 agent 失败）；超时 abort + 返回错误，提示检查 `ANTHROPIC_BASE_URL` 是否可达。verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| `CLAUDE_MAX_RETRIES` | `--claude-max-retries` / `config.flags.claudeMaxRetries` / `config.claudeMaxRetries` | `claude-agent-sdk` runtime 单 query 失败时的重试次数，默认 **`2`**（共 3 attempts 含 initial）。每次 attempt 跑满 `CLAUDE_TIMEOUT_MS` window；transient error / timeout backoff `4s, 8s + 0-1s jitter`（jitter 散开 herd retries 防一窝蜂打 vendor queue）。**auth-class 错误不 retry**（[#129 fast-fail](https://github.com/sleep2agi/agent-network/issues/129)：`isAuthError` regex 命中 401 / 403 / `invalid_api_key` / intern A02xx 等直接 FATAL 返回 vendor-specific URL hint）。设 `0` 退回 v0.9.1 行为（no retry）。[#132 Tier 1](https://github.com/sleep2agi/agent-network/issues/132) v0.9.2 起引入。verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) + retry loop [`cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| `ANET_CODEX_STDIO_DIRECT` | env only（无 CLI flag / config 字段；per-spawn 注入）| **v0.10.0 起，仅 `runtime=codex` 时生效**（claude-agent-sdk / claude-code-cli 忽略）。设 `=1` 把 codex runtime 从 `@openai/codex-sdk` wrapper 切到**直 stdio JSON-RPC 客户端**路径：agent-node `spawn('codex', ['app-server'])` + ~155 LOC stdio client + 完整 67-method v2 protocol surface（thread / turn / item / realtime），**绕开** wrapper `--mcp-config` HTTP transport bug 链（[#102](https://github.com/sleep2agi/agent-network/issues/102) hang root cause family）。v0.10.x（含当前 stable）**默认仍走 wrapper**（preview 反馈窗口 + backward compat）；v0.11.0 计划 default flip，届时 toggle 改成 `ANET_CODEX_LEGACY_SDK=1` opt-out 反向开关（per [`agent-node/src/cli.ts` 注释](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)）。[#141](https://github.com/sleep2agi/agent-network/issues/141) v0.10.0 起引入。verify [`agent-node/src/cli.ts` `if (process.env.ANET_CODEX_STDIO_DIRECT === "1")`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts) |
-| `ANTHROPIC_BASE_URL` | `config.env.ANTHROPIC_BASE_URL` | 模型 API 地址（接第三方 Anthropic 兼容 endpoint 时必填） |
-| `ANTHROPIC_AUTH_TOKEN` | `config.env.ANTHROPIC_AUTH_TOKEN` | 模型 API Key —— **第三方 Anthropic 兼容 endpoint**（MiniMax / DeepSeek / GLM / Kimi / 书生 / 小米 MiMo / OpenRouter / vLLM 等）走这个 |
-| `ANTHROPIC_API_KEY` | `config.env.ANTHROPIC_API_KEY` | 模型 API Key —— **api.anthropic.com 直连专用**，不要拿来传第三方 endpoint key（详见 [runtimes — claude-agent-sdk 常见坑](/guide/runtimes#claude-agent-sdk)） |
-
-::: warning `TOOLS` / `SYSTEM_PROMPT` env vars 不存在
-旧 doc 列的 `TOOLS` / `SYSTEM_PROMPT` 这两个 env var **agent-node 不读**（verify cli.ts `toolsRaw = opts.tools || fileConfig.tools` 没 `process.env.TOOLS`；cli.ts `SYSTEM_PROMPT = opts.prompt || fileConfig.systemPrompt` 没 env）。要设置 tools 用 `--tools` CLI flag 或 `config.json` 的 `tools` 字段；系统提示词用 `--prompt` flag 或 `config.json` 的 `systemPrompt` 字段。
-:::
-
-::: tip Docker 使用
-在 Docker 中运行时，环境变量是最方便的配置方式。参见 [Docker 部署](/deploy/docker)。
-:::
-
-## 下一步
-
-**起步**：
-- [一键安装与起步](/guide/one-shot-install) — anet 装好后 5 分钟跑第一个 agent
-
-**深入配置**：
-- [Runtimes](/guide/runtimes) — runtime 怎么选（正式版 4 种，预览版 6 种）
-- [多模型配置](/guide/multi-model) — 用 DeepSeek / MiniMax / Kimi / Claude 等
-- [Channel 插件](/guide/channels) — agent 怎么接 Telegram / 微信 / 飞书
-
-**生产**：
-- [Docker 部署](/deploy/docker) — 容器化 agent
-- [生产部署](/deploy/production) — 多机部署、TLS、备份
-- [Dashboard](/guide/dashboard) — 监控 agent 状态、任务、消息流
-
-**故障排查**：
-- [故障排查](/troubleshooting) — 常见问题集合
-- `anet doctor --fix` — 自动探测 ntok_ 过期等问题
+- [上手指南](/guide/getting-started)
+- [Runtime 对比](/guide/runtimes)
+- [CLI 参考](/guide/cli)
+- [安全设计](/concepts/security)
+- [任务生命周期](/concepts/task-lifecycle)
+- [Channel 指南](/guide/channels)
+- [故障排查](/troubleshooting)

--- a/docs-site/docs/guide/agent-node.md
+++ b/docs-site/docs/guide/agent-node.md
@@ -51,6 +51,8 @@ anet node start my-agent --tmux
 
 切换 runtime 前先停止旧进程。不要让两个不同进程以同一 alias / node identity 同时连接 Hub。
 
+<a id="环境变量"></a>
+
 ## 节点文件
 
 每个项目的节点状态位于 `.anet/nodes/<alias>/`：
@@ -113,6 +115,8 @@ anet node create reader --runtime claude-agent-sdk --tools Read,Glob,Grep
 
 详细威胁模型和默认值见[安全设计](/concepts/security)。
 
+<a id="循环任务-loop-调度器"></a>
+
 ## 循环任务
 
 对在线节点创建周期任务：
@@ -124,6 +128,8 @@ anet goal cancel my-agent <goal-id>
 ```
 
 循环状态保存在该节点的 `goals.json`。间隔必须带单位；CLI 当前接受分钟、小时或天。循环会真实消耗模型额度，先用较长间隔验证，不要把它当高精度 cron。
+
+<a id="断线重连"></a>
 
 ## 生命周期与恢复
 

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -28,6 +28,10 @@
 
 > ⚠️ **`opencode-cli` 仅 preview 渠道**（RFC-029 迭代中）：npm **latest 尚未包含**——装 latest 后 `anet node create` 选单只有前 4 个 runtime（`claude-code-cli` / `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`）。稳定后再进 latest。
 
+> OpenCode 内置 Anthropic client 发送 `x-api-key`。只接受 Bearer 的 Anthropic 兼容网关（例如 Kimi coding）会返回 401；这类网关要使用支持对应鉴权的 OpenCode plugin 或自定义路径，不能直接套内置 Anthropic preset。
+
+> Agent Node 不读取名为 `TOOLS` 或 `SYSTEM_PROMPT` 的环境变量。工具列表请用 `--tools` 或配置项 `tools`；系统提示词请用 `--prompt` 或配置项 `systemPrompt`。
+
 ::: tip 不知道怎么选?
 - **想白嫖 Claude 订阅 / 新手最省事** → `claude-code-cli` (`claude auth login` 后 0 配置)
 - **写文案 / 翻译 / 分析 (编程式) / 接国产模型** → `claude-agent-sdk` + 在 wizard 里选对应 vendor
@@ -498,7 +502,7 @@ GROK_ACP_TIMEOUT_MS=900000 anet node start my-grok
 ### 详见
 
 - [`grok-build-runtime.md` 完整 runtime 指南](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md) — Known Limits + debug + preview chain
-- [agent-node § grok-build-acp tip](/guide/agent-node#claude-code-cli) — v0.10.11 [#204](https://github.com/sleep2agi/agent-network/issues/204) per-node isolated cwd 细节
+- [grok-build-acp](#grok-build-acp) — 每个节点使用独立工作目录；不要从其他 runtime 的章节推断 Grok 行为
 - [troubleshooting → grok-build-acp 节点任务挂死](/troubleshooting#grok-build-acp-节点任务挂死-session-prompt-timed-out-after-300000ms-json-rpc-error-32603) — `session/prompt` 超时排错入口
 - [architecture § Debug tip](/guide/architecture) — runtime debug 入口
 

--- a/docs/tests/report-agent-node-guide-simplification-2026-07-31.txt
+++ b/docs/tests/report-agent-node-guide-simplification-2026-07-31.txt
@@ -4,11 +4,13 @@ Scope
 -----
 - docs-site/docs/guide/agent-node.md
 - docs-site/docs/en/guide/agent-node.md
+- docs-site/docs/guide/runtimes.md
+- docs-site/docs/en/guide/runtimes.md
 
 Outcome
 -------
-- Chinese guide: 681 -> 154 lines.
-- English guide: 682 -> 154 lines.
+- Chinese guide: 681 -> 160 lines.
+- English guide: 682 -> 160 lines.
 - Removed duplicated runtime installation tables, old preview history, fixed model/version
   examples, obsolete roadmap text, and repeated troubleshooting material.
 - Kept only common node behavior and linked runtime-specific details to canonical pages.
@@ -16,6 +18,11 @@ Outcome
   permission defaults differ by runtime; a node config must not be copied across machines.
 - Clarified current UI boundaries: Codex co-presence is preview-only, OpenCode is a task
   runtime, and shared Grok TUI support is not released.
+- Preserved inbound legacy anchors for environment variables, loop scheduling, and
+  reconnection after the guide rewrite.
+- Restored three source-backed details: TOOLS/SYSTEM_PROMPT are config/CLI inputs rather
+  than env vars; OpenCode's built-in Anthropic path does not support Bearer-only
+  gateways; the Grok cross-link now targets the Grok runtime section.
 
 Static/source gates
 -------------------

--- a/docs/tests/report-agent-node-guide-simplification-2026-07-31.txt
+++ b/docs/tests/report-agent-node-guide-simplification-2026-07-31.txt
@@ -35,6 +35,8 @@ PASS  package engine requires Node >=22.13.0 and Bun >=1.2.0
 PASS  CLI source contains the documented create/start/stop/loop/goal/envRef commands
 PASS  source confirms claude-agent-sdk permissionMode=auto while other standard
       runtime configs retain dangerouslySkipPermissions for compatibility
+PASS  VitePress 1.6.4 Docker build on origin/main baseline and this candidate
+PASS  all six preserved legacy fragments appear as exact ids in rendered HTML
 PASS  stale phrase scan: old preview chain, v0.11 roadmap, fixed OpenCode version,
       grok-build-cli, ANET_CODEX_STDIO_DIRECT, universal permission default,
       and unsupported WeChat claims are absent

--- a/docs/tests/report-agent-node-guide-simplification-2026-07-31.txt
+++ b/docs/tests/report-agent-node-guide-simplification-2026-07-31.txt
@@ -1,0 +1,39 @@
+Agent Node guide simplification report — 2026-07-31
+
+Scope
+-----
+- docs-site/docs/guide/agent-node.md
+- docs-site/docs/en/guide/agent-node.md
+
+Outcome
+-------
+- Chinese guide: 681 -> 154 lines.
+- English guide: 682 -> 154 lines.
+- Removed duplicated runtime installation tables, old preview history, fixed model/version
+  examples, obsolete roadmap text, and repeated troubleshooting material.
+- Kept only common node behavior and linked runtime-specific details to canonical pages.
+- Corrected security wording: envRef may store the value in a mode-0600 node .env;
+  permission defaults differ by runtime; a node config must not be copied across machines.
+- Clarified current UI boundaries: Codex co-presence is preview-only, OpenCode is a task
+  runtime, and shared Grok TUI support is not released.
+
+Static/source gates
+-------------------
+PASS  git diff --check
+PASS  both guides are <= 220 lines
+PASS  all internal Markdown targets exist
+PASS  balanced fenced code blocks
+PASS  bilingual heading/section parity
+PASS  package engine requires Node >=22.13.0 and Bun >=1.2.0
+PASS  CLI source contains the documented create/start/stop/loop/goal/envRef commands
+PASS  source confirms claude-agent-sdk permissionMode=auto while other standard
+      runtime configs retain dangerouslySkipPermissions for compatibility
+PASS  stale phrase scan: old preview chain, v0.11 roadmap, fixed OpenCode version,
+      grok-build-cli, ANET_CODEX_STDIO_DIRECT, universal permission default,
+      and unsupported WeChat claims are absent
+
+Test policy
+-----------
+Documentation-only change. No Docker image, daemon, Hub, model runtime, npm publish,
+or production environment was invoked. This preserves user model quota and avoids
+claiming runtime coverage from a prose-only change.


### PR DESCRIPTION
## What changed

- reduce the Chinese and English Agent Node guides from about 680 lines each to 154 lines
- keep common node lifecycle, workspace, identity, task, permission, scheduling, and recovery behavior
- move runtime-specific setup to the canonical runtime pages
- remove stale preview history, fixed package/model versions, unsupported WeChat wording, and duplicated troubleshooting
- correct envRef, cross-machine identity, runtime permission, Codex/OpenCode/Grok TUI boundary wording

## Why

The old page mixed current instructions with release history and runtime-specific examples. Several examples had become stale or unsafe to generalize, and the same facts were duplicated across canonical guides.

## User impact

Readers get a shorter node guide with fewer version-sensitive claims and direct links to the pages that own runtime, security, channel, and CLI details.

## Validation

- `git diff --check`
- both guides are 154 lines and have matching sections
- all internal Markdown targets exist
- code fences are balanced
- command and permission claims checked against `agent-network/bin/cli.ts`
- Node/Bun requirements checked against `agent-network/package.json`
- stale-phrase scan passed

Documentation-only change. No Docker, Hub, model runtime, npm publish, or production environment was invoked.
