### PR TITLE
docs: simplify troubleshooting safely

### DIFF
--- a/docs-site/docs/en/troubleshooting.md
+++ b/docs-site/docs/en/troubleshooting.md
@@ -132,6 +132,9 @@ See [Tokens and permissions](/en/concepts/tokens), [Roles](/en/concepts/roles), 
 
 ### Other authentication/network errors
 
+<a id="quota-exceeded-max-n-networks-for-free-plan"></a>
+<a id="license-expired-license-expired-legacy-behavior"></a>
+
 | Error | Safe response |
 |---|---|
 | `password must be at least 8 characters` / `too common` | Choose at least eight characters and avoid the weak-password list |
@@ -140,6 +143,8 @@ See [Tokens and permissions](/en/concepts/tokens), [Roles](/en/concepts/roles), 
 | `network has N active session(s)` | Use `anet status`, stop the nodes normally, then retry network deletion |
 | `quota exceeded` | Use `anet network ls` and remove unused networks. There is currently no public CLI for changing a user plan/global role; contact the Hub operator and do not promote the user to global admin as a shortcut |
 | `license_expired` | If it remains after `anet license` and an upgrade, contact the Hub operator. There is no safe public CLI for cleaning legacy rows; stop the Hub, back up the database, and file a redacted diagnostic instead of deleting `licenses` rows online |
+
+Direct database writes bypass API authorization, auditing, and consistency checks and can corrupt related license or identity state, so this guide does not provide SQL “fixes.”
 
 ## Agent Node
 
@@ -179,6 +184,10 @@ Stop old instances and keep one process. Do not reclaim identity by editing `nod
 ### Wrong working directory
 
 File tools use the node's launch directory. Stop it, enter the intended project, and start again. In Codex TUI co-presence, the thread directory is inherited from the app-server process. Follow [Codex TUI co-presence](/en/guide/codex-copresence) and inspect the full session group, not only the bridge.
+
+<a id="vendor-api-auth-failure-401-invalid-api-key-expired-token-intern-a02xx-user-token-expired"></a>
+<a id="vendor-api-timeout-high-concurrency-fan-out-132-retry-with-backoff"></a>
+<a id="grok-build-acp-node-task-hangs-session-prompt-timed-out-after-300000ms-json-rpc-error-32603"></a>
 
 ## Runtime and model
 

--- a/docs-site/docs/en/troubleshooting.md
+++ b/docs-site/docs/en/troubleshooting.md
@@ -1,969 +1,257 @@
 # Troubleshooting
 
-Quickly identify problems and solutions based on error messages.
+Debug in this order: environment → Hub → authentication → node → runtime → task. If an earlier layer is broken, later errors are usually secondary symptoms.
 
-For `anet doctor`, Telegram channel setup, MCP tool injection, or codex-sdk active `send_task`, start with the dedicated runbook: [Connectivity / Channels / MCP](/en/troubleshooting/connectivity-channels-mcp).
+See the [CLI reference](/en/guide/cli) for complete syntax, [Production deployment](/en/deploy/production) for infrastructure, and [Runtimes](/en/guide/runtimes) for runtime-specific setup.
 
-::: tip Not a failure — just curious about versions?
-See [Versioning](/en/guide/versioning) to map the npm-package versions printed by `anet -v` onto `v0.10.x` bundle releases. To upgrade, follow the [Upgrade Guide](/en/guide/upgrade).
-:::
+## Collect a minimal diagnostic first
 
-## Startup Errors (most common on first run)
-
-### `anet hub start` -- `spawn bunx ENOENT`
-
-```
-Error: spawn bunx ENOENT
-```
-
-**Cause**: **Bun** is not installed. `commhub-server` is Bun-shebang TypeScript, and `anet hub start` launches it via `bunx --bun` — without Bun it crashes on the very first step.
-
-**Fix**:
-
-```bash
-npm i -g bun
-# or: curl -fsSL https://bun.sh/install | bash
-bun --version        # should print 1.2.x or newer
-```
-
-Then run `anet hub start` again. Full prerequisites: [Getting Started · Prerequisites](/en/guide/getting-started). ([#235](https://github.com/sleep2agi/agent-network/issues/235) tracks a friendly pre-start check.)
-
----
-
-### `anet node start` -- `agent-node is not installed or cannot report a version`
-
-```
-agent-node is not installed or cannot report a version. Run: anet upgrade
-```
-
-**Cause**: the `claude-agent-sdk` / `codex-sdk` runtimes depend on the `agent-node` package. It's designed to lazy-fetch via npx on the first `node start`, but the current startup check **doesn't wait for the fetch** and exits with this error ([#450](https://github.com/sleep2agi/agent-network/issues/450); #237 is the umbrella).
-
-**Fix**: install it once, then start:
-
-```bash
-npm i -g @sleep2agi/agent-node
-agent-node --version     # should print the current latest or newer
-anet node start <name>
-```
-
-> The `claude-code-cli` / `grok-build-acp` runtimes don't hit this (they don't use the `agent-node` SDK-adapter path).
-
----
-
-## Connection Errors
-
-### `ECONNREFUSED` -- Connection Refused
-
-```
-Error: connect ECONNREFUSED 127.0.0.1:9200
-```
-
-**Cause**: CommHub Server is not running.
-
-**Solution**:
-
-```bash
-# Check if the server is running (v0.10.11+ recommended; one line shows PID + port + /health version)
-anet hub status                # default port 9200
-anet hub status --port 9201    # non-default port
-
-# Or fall back to curl /health (works on older versions too)
-curl http://localhost:9200/health
-
-# If not running, start the server
-anet hub start --port 9200
-
-# If the port is wrong, check config
-cat ~/.anet/config.json
-```
-
----
-
-### `ETIMEDOUT` -- Connection Timeout
-
-```
-Error: connect ETIMEDOUT 203.0.113.10:9200
-```
-
-**Cause**: Network unreachable or blocked by firewall.
-
-**Solution**:
-
-```bash
-# Check network connectivity
-ping 203.0.113.10
-telnet 203.0.113.10 9200
-
-# Check firewall
-sudo ufw status
-sudo ufw allow 9200
-
-# Check cloud server security groups
-# Ensure inbound rules allow TCP 9200
-```
-
----
-
-### `SSE connection failed` -- SSE Connection Failure
-
-```
-[agent-node] SSE connection failed, reconnecting in 3s...
-```
-
-**Cause**: SSE long connection dropped, usually due to network fluctuation.
-
-**Solution**: The agent will auto-reconnect (since [#202](https://github.com/sleep2agi/agent-network/issues/202): exponential backoff `1s → 30s` cap + re-register on every successful (re)connect + give up after 1h continuous failure — [see agent-node reconnection](/en/guide/agent-node#reconnection)); no manual intervention usually needed.
-
-If it persists:
-
-```bash
-# Check if the server is running (v0.10.11+ recommended; one line shows PID + port + /health version)
-anet hub status
-
-# Or fall back to curl /health
-curl http://localhost:9200/health
-
-# Check if the token is valid
-curl -H "Authorization: Bearer ntok_xxx" http://localhost:9200/api/status
-
-# Check reverse proxy config (if applicable)
-# Nginx needs:
-# proxy_read_timeout 86400;
-# proxy_buffering off;
-```
-
-### Dashboard shows no nodes after a hub restart
-
-**Symptom**: After `anet hub stop` + `anet hub start` (or after the hub process crashes and restarts), the Dashboard shows every node as `offline` or missing from the list entirely — even though the agent processes are still alive.
-
-**Cause (v0.10.10 and earlier)**: The hub restart clears its in-memory sessions table. Older `agent-node` versions only restored the event stream on reconnect; they **did not re-send `register`** — so the hub-side sessions table only rebuilt on the next 3-minute heartbeat, leaving the Dashboard blank in between.
-
-**Solution**: Since [#202](https://github.com/sleep2agi/agent-network/issues/202), every successful SSE reconnect immediately re-fires `register` (idempotent upsert on the hub), and the Dashboard recovers the full node list within ~30s. **No `anet project restart` needed**; pair this with the `anet hub stop` / `hub status` commands for a one-shot maintenance SOP. If you're on an older agent-node, run `anet upgrade` to pick up the fix on npm `latest`.
-
----
-
-## Auth Errors
-
-### `No hub configured. Pass --hub <url> or run 'anet init' first.`
-
-**Symptom**: on a fresh install, your first `anet login` (or the `anet login --username admin --password anethub` suggested by `anet hub start`) fails with this — you can't log in.
-
-**Cause**: `anet hub start` only launches the hub; it does **not** write the hub URL into your global config. But `anet login` needs to know which hub to reach — the "set the hub URL" step (done by `anet init` or `--hub`) is missing in between.
-
-**Fix**: pass `--hub` directly at login (a local hub defaults to `127.0.0.1:9200`):
-
-```bash
-anet login --hub http://127.0.0.1:9200 --username admin --password anethub
-```
-
-Or run `anet init --hub <url>` first, then `anet login`. For a remote hub, use its IP.
-
----
-
-### 401 `auth required` / `invalid token` / `token required`
-
-The server actually returns one of three 401 errors (**not** `{"error": "unauthorized"}`; verify `grep error.*401 server/src/index.ts`):
-
-```json
-{ "ok": false, "error": "auth required" }     // most REST endpoints when Authorization header is missing
-{ "ok": false, "error": "token required" }    // some auth endpoints (e.g. /api/auth/me) when token is absent
-{ "ok": false, "error": "invalid token" }     // token is syntactically present but resolveToken failed (revoked / expired / hub DB wiped)
-```
-
-**Cause**: Token is invalid or missing. `invalid token` is also common right after a hub DB wipe (reset of commhub.db) — every existing utok\_ / ntok\_ is now stale.
-
-**Solution**:
-
-```bash
-# Check current token / identity (v0.8 recommended entrypoint)
-anet whoami
-
-# If token expired, log in again
-anet login
-
-# Check token in config file
-cat ~/.anet/config.json
-
-# (Legacy path, not recommended) `COMMHUB_AUTH_TOKEN` is soft-deprecated since v0.8;
-# v1.0 removes it. For identity checks use `anet whoami`. If your env still has this
-# variable set, unset it to avoid the deprecation warning on every request.
-```
-
----
-
-### MCP write rejected — `network_id_required` / `access_denied` / `permission_denied`
-
-When a write tool (send_task / send_message / send_reply / ack_inbox / send_ack / retry_task / cancel_task / reassign_task …) is rejected, the `error` code distinguishes **three different real causes** — don't treat them all as a permissions problem (that misdirection is exactly what #517 fixed):
-
-| `error` | Real cause | Fix |
-|---|---|---|
-| `network_id_required`<br>(message says "no network memberships") | The user belongs to no network | Create a network or join one via invite code |
-| `network_id_required`<br>(message says "spans N networks") | The utok_ spans multiple networks — the write target is ambiguous | Pass `network_id` explicitly (from `networks[].network_id` in `/api/auth/me`) |
-| `access_denied` | The `network_id` you passed names a network you are not a member of | Use the right network_id, or have the owner invite you |
-| `permission_denied` | You are a **viewer** (read-only) in that network | Have the owner promote your role (below) |
-
-> **A utok_ caller with exactly one network does NOT need to pass `network_id`** — the hub auto-resolves to the single membership (same rule as REST `POST /api/task`, #517). Hubs from before the #517 fix answered ALL of the above with `permission_denied` and a "utok current_network is null" hint: if you see that old text, upgrade the hub first.
-
-**Solution**:
-
-```bash
-# Promote a viewer / or switch to ntok_
-# Agent Nodes must connect using ntok_. The token lives in
-# .anet/nodes/<name>/config.json — agent-node CLI does NOT accept a --token flag.
-# If your current node config still has utok_/atok_, doctor migrates it:
-anet doctor --fix
-
-# viewer → member role promotion
-# Have the owner (not admin — admin can't change roles; PUT members is an owner-only gate)
-# call REST to promote you (v0.10.x stable still does not expose a CLI promote subcommand — the v0.9.x and v0.10.x scopes did not touch member-role management; queued for v0.11+ / unscheduled):
-NET=$(jq -r .network_id ~/.anet/config.json)
-UTOK=$(jq -r .token ~/.anet/config.json)        # owner's own utok_
-curl -X PUT "$HUB/api/networks/$NET/members/<your_user_id>" \
-  -H "Authorization: Bearer $UTOK" \
-  -H "Content-Type: application/json" \
-  -d '{"role": "member"}'
-# See [API — PUT members](/en/api/rest#put-api-networks-id-members-user-id)
-# Alternative: the owner issues a new invite code with the target role and you re-join.
-anet network invite --role member
-```
-
----
-
-### `license_expired` -- License Expired (legacy behavior)
-
-```json
-{"ok": false, "error": "license_expired", "message": "Trial expired. Activate a license: anet activate <key>"}
-```
-
-::: info anet is Apache-2.0 OSS since v0.8 — there is no real license to buy
-This gate is a V3-era leftover still firing in the `send_task` path (verify [`server/src/tools.ts:616`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L616) where `license_expired` is emitted; same file L611 has `SELECT type, expires_at FROM licenses`). It triggers when your local SQLite has a `licenses` row with `expires_at` in the past. **The v0.9.x and v0.10.x scopes did not touch this** (Recovery & Observability took priority); full removal is queued for v0.11+ / unscheduled.
-:::
-
-**Cause**: Your local SQLite `licenses` table has a row with `expires_at < now()`.
-
-**Solution**:
-
-```bash
-# Option A (recommended): just delete the expired license row
-sqlite3 ~/.commhub/commhub.db "DELETE FROM licenses WHERE expires_at < datetime('now');"
-
-# Option B (legacy commands, no-op placeholders):
-anet license          # inspect
-anet activate <key>   # v0.6 legacy command, writes a new license row (the key is not validated — placeholder only)
-
-# Option C (offline tutorial): start the hub with --dev-open to skip auth
-anet hub start --dev-open
-# When you can't pass a CLI flag (Docker / systemd), the env var is equivalent:
-# COMMHUB_DEV_OPEN=1 anet hub start
-# (verify [`index.ts` `DEV_OPEN`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts): either the `--dev-open` flag or `COMMHUB_DEV_OPEN=1` works)
-```
-
----
-
-### `password must be at least 8 characters` / `password is too common` -- Password strength (v0.8)
-
-```json
-{ "ok": false, "error": "password must be at least 8 characters" }
-{ "ok": false, "error": "password is too common" }
-{ "ok": false, "error": "new password must be at least 8 characters" }   // changePassword
-{ "ok": false, "error": "new password is too common" }                   // changePassword
-```
-
-Verify [`auth.ts:24-28 validatePasswordStrength()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L24). The `label` parameter is why `changePassword` returns the `new password` variant.
-
-**Cause**: From v0.8, `register` / `anet passwd` / `anet hub admin reset-user` all run the same `validatePasswordStrength()`:
-- Length ≥ 8 characters
-- Not in the weak-password dictionary ([`password-dict.ts WEAK_PASSWORDS`](https://github.com/sleep2agi/agent-network/blob/main/server/src/password-dict.ts) covers `"password"` / `"12345678"` / `"qwerty123"` and other top entries)
-
-**Exception (first registered user only)**: [`auth.ts:43-44`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L43) detects the "first user" case and only enforces `length >= 4` (so the bootstrap `admin / anethub` flow works). `anet passwd` / `reset-user` have **no such exemption** — they always require ≥ 8 + non-weak.
-
-**Fix**:
-
-```bash
-# Generate a strong 16-char password
-openssl rand -base64 16
-
-# Or with pwgen
-pwgen -s 16 1
-```
-
-::: warning Production deployments
-For any `--host 0.0.0.0` / public deployment, change the default `anethub` **immediately** after first admin bootstrap:
-```bash
-anet login --username admin --password anethub
-anet passwd                    # rotate to a strong password
-```
-:::
-
----
-
-### `anet hub start` keeps re-bootstrapping the admin?
-
-The first `anet hub start` created admin, but a second start still prints `Admin account created`?
-
-::: tip Bootstrap is **non-interactive** — there is no "Set up admin account" prompt
-Verified at [`agent-network/bin/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts): `anet hub start` simply POSTs `/api/auth/register` with username=`admin` and password=`anethub` (unless overridden by `--username` / `--password`). **No interactive prompt is involved**, so the older "repeating prompt" framing in this doc is stale and has been removed.
-
-Idempotency is driven by `~/.anet/server/admin-utok.json` as a marker — if it exists, the register flow is skipped (output: `✅ Admin already exists`). If it's missing, the register call re-runs; if the user row already exists, the hub returns `username already taken` and the CLI prints `ℹ Admin account "admin" already exists` (no duplicate is created).
-:::
-
-**Cause**: `~/.anet/server/admin-utok.json` was deleted, or the hub's `~/.commhub/commhub.db` was wiped, or you're running with a different `HOME` (e.g. a Docker container without a mounted volume).
-
-**Inspect state**:
-
-```bash
-# 1. Where is the marker?
-ls -la ~/.anet/server/admin-utok.json   # exists → next start skips register
-
-# 2. Is the admin user row present on the hub?
-sqlite3 ~/.commhub/commhub.db "SELECT username, role FROM users WHERE role='admin'"
-```
-
-**Two-file state vs. `anet hub start` output**:
-
-| `admin-utok.json` | `users` table admin row | `anet hub start` output |
-|---|---|---|
-| Present | Present | `✅ Admin already exists (admin-utok.json found, user=...)` |
-| Missing | Present | `ℹ  Admin account "admin" already exists` (hub returns `username already taken`) |
-| Missing | Missing | `✅ Admin account created` + `Admin token saved to ~/.anet/server/admin-utok.json` |
-| Present | Missing (db wiped) | `✅ Admin already exists`, but `anet login` will fail — the marker and the db are out of sync; remove the marker and re-run start |
-
-**Fix**:
-
-```bash
-# Symptom: admin-utok.json exists, but `anet login` fails
-# → marker and db are out of sync. Remove the marker so the next start re-bootstraps.
-rm ~/.anet/server/admin-utok.json
-anet hub start                  # re-runs the register flow
-anet login --username admin --password anethub
-```
-
----
-
-### 429 Rate limited (`too many requests` / `too many attempts`)
-
-```
-HTTP 429
-{ "ok": false, "error": "too many requests, try again later" }    # register hit
-{ "ok": false, "error": "too many attempts, try again later" }    # login hit
-```
-
-**Cause**: Too many requests from the same IP within the window.
-
-| Endpoint | Limit | Hit message |
-|------|------|---|
-| `POST /api/auth/register` | 30/minute | `too many requests, try again later` |
-| `POST /api/auth/login` | 10/minute | `too many attempts, try again later` (also writes audit `login_rate_limited`) |
-
-::: info Only these two endpoints have IP rate limiting in v0.8
-No other endpoint is currently IP-rate-limited. The `checkRateLimit` function's `default = 60` is a function-signature default, not actual behavior — the only call sites are register/login ([`index.ts` `checkRateLimit()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts); see [Security — Rate limiting](/en/concepts/security#rate-limiting)). If you're worried about write abuse on other endpoints, layer rate limiting at a reverse proxy (nginx / Cloudflare).
-:::
-
-**Solution**: Wait 60 seconds before retrying. Localhost / `::1` / `unknown` IPs are exempt ([`index.ts` `checkRateLimit()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)). The response has **no** `retry_after_seconds` field and **no** `Retry-After` header; the window is a fixed 60 seconds.
-
----
-
-## Task Errors
-
-### `task not found`
-
-```json
-{"ok": false, "error": "task not found"}
-```
-
-**Cause**:
-
-1. Incorrect task_id
-2. The task is in a different network (ntok_ is bound to a different network)
-
-**Solution**:
-
-```bash
-# Confirm the task exists
-anet tasks
-
-# Confirm the current network
-anet whoami
-
-# Check task details
-curl "http://localhost:9200/api/tasks?limit=10" -H "Authorization: Bearer ntok_xxx"
-```
-
----
-
-### `task status is X, not retryable`
-
-```json
-{"ok": false, "error": "task status is running, not retryable"}
-```
-
-**Cause**: Only tasks with status `failed` / `expired` / `cancelled` can be retried.
-
-**Solution**:
-
-::: tip
-The `cancel_task` / `retry_task` below are server-side MCP tools called via REST `POST /mcp` (or via an SDK) — **not** the Claude Code agent's stdio channel wrapper. The channel wrapper ([`channel/commhub-channel.ts`](https://github.com/sleep2agi/agent-network/blob/main/channel/commhub-channel.ts)) exposes only 5 `commhub_*` tools (`commhub_reply` / `commhub_report_status` / `commhub_send_task` / `commhub_send_message` / `commhub_get_all_status`). `cancel_task` / `retry_task` / `reassign_task` / `get_inbox` are admin / Dashboard ops, not part of the Claude Code chat-agent toolset ([`commhub-channel.ts:136-203`](https://github.com/sleep2agi/agent-network/blob/main/channel/commhub-channel.ts#L136)).
-:::
-
-```bash
-# Cancel the running task first (POST /mcp, tool=cancel_task)
-cancel_task(task_id="t_xxx", reason="Need to retry")
-
-# Then retry (POST /mcp, tool=retry_task)
-retry_task(task_id="t_xxx")
-```
-
----
-
-### `task is terminal`
-
-```json
-{"ok": false, "error": "task is terminal (replied)"}
-```
-
-**Cause**: The task is already in a terminal state (replied / failed / cancelled / expired) and cannot be modified.
-
-**Solution**: If you need to re-execute, create a new task:
-
-```bash
-commhub_send_task(alias="coder-1", task="Re-execute: ...")
-```
-
----
-
-### `message not found or not yours`
-
-```json
-{"ok": false, "error": "message not found or not yours"}
-```
-
-**Cause**:
-
-1. Incorrect message_id
-2. The message doesn't belong to the current agent (alias mismatch)
-3. The message is in a different network
-
-**Solution**:
-
-::: tip
-`get_inbox` is a server-side MCP tool called via REST `POST /mcp` (or via an SDK) — **not** the Claude Code agent's stdio channel wrapper. The channel wrapper exposes only 5 `commhub_*` tools (`commhub_reply` / `commhub_report_status` / `commhub_send_task` / `commhub_send_message` / `commhub_get_all_status`); `get_inbox` is intentionally left out because agents auto-poll the inbox via SSE — see [`channel/commhub-channel.ts:136-203`](https://github.com/sleep2agi/agent-network/blob/main/channel/commhub-channel.ts#L136).
-:::
-
-```bash
-# Check messages in the inbox (POST /mcp, tool=get_inbox)
-get_inbox(alias="coder-1")
-```
-
----
-
-## Network Errors
-
-### `network name already exists`
-
-```json
-{"ok": false, "error": "network name already exists"}
-```
-
-**Cause**: You already have a network with the same name.
-
-**Solution**:
-
-```bash
-# Check existing networks
-anet network ls
-
-# Use a different name
-anet network create my-other-network
-```
-
----
-
-### `network has N active session(s)`
-
-```json
-{"ok": false, "error": "network has 3 active session(s) — stop them first"}
-```
-
-**Cause**: All agents must be stopped before deleting a network.
-
-**Solution**:
-
-```bash
-# Check agents in the network
-anet status
-
-# Stop all agents
-anet node stop coder-1
-anet node stop coder-2
-anet node stop coder-3
-
-# Then delete (--force is required, otherwise it only prints a confirmation prompt)
-anet network delete my-network --force
-```
-
----
-
-### `quota exceeded: max N networks for free plan`
-
-```json
-{"ok": false, "error": "quota exceeded: max 2 networks for free plan"}
-```
-
-::: warning Still enforced in v0.8 (POST /api/networks for non-admin callers)
-The older "plan quotas not enforced from v0.8 onward" claim is inaccurate. Verify [`auth.ts` `createNetwork()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts): it still looks up `users.plan || 'free'` in the `QUOTAS` table and gates `network create`. **Only `users.role = 'admin'` (the first registered user) is exempt** — that path sets `plan = "admin"` and uses `QUOTAS.admin`. Other users get `plan = 'free'` with `max_networks_owned = 2` by default (v0.8 did not change this default). The [Networks — Quota Limits](/en/concepts/networks#quota-limits) note about "plan tiers not enforced" actually refers to **no Dashboard plan-upgrade UI + no SaaS billing**, not "server no longer runs quota checks".
-:::
-
-**Trigger**: a non-admin user already owns the maximum number of networks (free = 2).
-
-**Solution**:
-
-```bash
-# Option A (recommended): promote the user to admin (a system-admin op on the hub host)
-# There's no public endpoint for this — edit SQLite directly:
-sqlite3 ~/.commhub/commhub.db "UPDATE users SET role = 'admin' WHERE user_id = 'u_xxx';"
-# After this, users.role='admin' → createNetwork uses plan='admin' → QUOTAS.admin (essentially unlimited)
-
-# Option B: delete one of the extra networks
-anet network ls           # find one to drop
-anet network delete <old-net> --force
-```
-
-::: tip Why setting `users.plan = 'admin'` is not enough
-[`auth.ts:185`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L185) actually checks `users.role === 'admin'`, not `users.plan`. A bare `UPDATE users SET plan = 'admin'` won't take effect — you must update the `role` column (the same system-admin gate that applies to audit-log actions like `password_reset_by_admin`).
-:::
-
----
-
-## Agent Node Errors
-
-### `Node "coder-1" already exists` -- local alias collision (`anet node create`)
-
-```
-Node "coder-1" already exists: .anet/nodes/coder-1/config.json
-```
-
-Verified at [`agent-network/bin/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) + [`agent-network/bin/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts): both the interactive and non-interactive paths of `anet node create` call `resolveNodeRef(id)` to check whether `.anet/nodes/<alias>/config.json` already exists; if so, they `process.exit(1)` without ever contacting the hub.
-
-**Cause**: a subdirectory with the same alias already exists under `.anet/nodes/` in the current project directory. This is a **local filesystem collision** — it has nothing to do with the hub-side session state.
-
-**Solution**:
-
-```bash
-# List locally registered nodes (scans .anet/nodes/)
-anet node ls
-
-# Option A: pick a different name
-anet node create coder-1-v2
-
-# Option B: delete the old one and reuse the name (delete needs --force, otherwise it only prints a confirmation prompt)
-anet node delete coder-1 --force
-anet node create coder-1
-```
-
-::: warning Hub-side alias collisions are silently overwritten — there is no error
-Contrary to common intuition, the hub server has **no** `alias is already taken` error. If you run two agents with the same alias from different machines or project dirs (i.e. with two distinct `resume_id`s), the later agent's `report_status` triggers [`server/src/tools.ts:127 DELETE FROM sessions WHERE alias = ?1 AND resume_id != ?2 AND network_id = ?3`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L127), which **silently evicts the previous session**. The older agent's SSE connection is still open but it no longer receives task dispatches, and the row disappears from the dashboard.
-
-**So**: don't diagnose "my agent isn't showing up in the dashboard" as an "alias-taken error" — that error doesn't exist. First check for duplicate same-alias starts across machines (use `anet status` to inspect `resume_id` / version / hostname).
-:::
-
----
-
-### `settingSources` related errors
-
-```
-TypeError: Cannot read properties of undefined (reading 'settingSources')
-```
-
-**Cause**: Claude Agent SDK version incompatibility.
-
-**Solution**:
-
-```bash
-# Upgrade agent-node
-npm install -g @sleep2agi/agent-node@latest
-```
-
----
-
-### `ANTHROPIC_BASE_URL` connection failure
-
-```
-Error: Failed to connect to api.minimaxi.com
-```
-
-**Cause**: MiniMax / other compatible API URL is incorrect or unreachable.
-
-**Solution**:
-
-```bash
-# Check the API URL
-echo $ANTHROPIC_BASE_URL
-
-# Test connectivity
-curl -I $ANTHROPIC_BASE_URL
-
-# Verify the API key works
-curl -H "Authorization: Bearer $ANTHROPIC_AUTH_TOKEN" \
-  $ANTHROPIC_BASE_URL/v1/messages \
-  -H "Content-Type: application/json" \
-  -d '{"model":"<minimax-model-id>","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
-# Replace <minimax-model-id> with the current model id supported by your MiniMax account (check https://platform.minimaxi.com)
-```
-
-### Vendor API auth failure (401 / `invalid_api_key` / `expired_token` / intern `A02xx` / `user_token_expired`)
-
-You see this in the agent log:
-
-```
-[claude] ✗ FATAL: vendor API auth failed (...)
-[anet] FATAL: Vendor API auth failed — ...
-[anet]        → Refresh INTERN_S1_API_KEY at https://chat.intern-ai.org.cn and re-export it
-```
-
-**Cause**: The upstream vendor LLM API returned an auth-class error (401/403, `invalid_api_key`, `authentication_error`, intern's `A02xx` code family, OpenAI-compat `expired_token` / `unauthorized`, etc.).
-
-**Fast-fail behavior since v0.9.2** ([#129](https://github.com/sleep2agi/agent-network/issues/129); verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)):
-- agent-node uses the `isAuthError(msg)` heuristic (regex: `(401|403)\b|invalid[_\s]?api[_\s]?key|authentication[_\s]?error|expired[_\s]?token|unauthor(iz|is)ed|A02\d{2}|user[_\s]?token[_\s]?expired`)
-- **Short-circuits the retry loop** (no point retrying with the same bad key, wasting the backoff window) — before v0.9.1 you'd wait 3 attempts × 5min = 15 minutes before getting a useful error; v0.9.2+ returns **FATAL in under 5 seconds**
-- Picks a **vendor-specific remediation hint** by `ANTHROPIC_BASE_URL` host match:
-  - `intern-ai.org.cn` → `https://chat.intern-ai.org.cn`
-  - `minimax` → `https://platform.minimaxi.com`
-  - `anthropic` → `https://console.anthropic.com/settings/keys`
-  - otherwise → generic "Refresh your vendor API key and re-export the ENV var"
-
-**Solution** (look for the vendor URL in the log, then):
-
-```bash
-# 1. Get a fresh API key from the vendor's platform (URL in the log)
-
-# 2. Update the ENV var
-export ANTHROPIC_AUTH_TOKEN='<new-key>'
-
-# 3. Restart the agent so the new value takes effect (agent-node reads process.env at startup, no hot reload)
-anet node stop <alias>
-anet node start <alias>
-
-# 4. If you're on envRef mode (recommended, see /en/concepts/security#vendor-credential-storage-envref-mode-v0-9-0):
-#    config.json is unchanged (it stores the env-var NAME), just re-export the new value and restart the agent.
-```
-
-### Vendor API timeout (high-concurrency fan-out, #132 retry-with-backoff)
-
-You see this in the agent log:
-
-```
-[claude] attempt 1/3 timed out after 300000ms; retry in 4000ms
-[claude] attempt 2/3 errored: ...; retry in 8000ms
-[claude] ✗ all 3 attempts failed; last: timed out after 300000ms
-```
-
-Or finally:
-
-```
-执行出错: claude-agent-sdk 调用超时 (300s × 3 attempts) — vendor 长时间未响应, 检查 ANTHROPIC_BASE_URL endpoint 或 vendor 负载
-```
-
-**Cause**: under heavy fan-out (e.g. [#132 Tier 1's](https://github.com/sleep2agi/agent-network/issues/132) 30-agent papercope demo), per-request latency on the vendor API stretches from a 1.57s baseline to 17-37s as requests pile up in the vendor's queue.
-
-**Retry-with-backoff since v0.9.2** (verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)):
-- Each attempt has its own abort controller + timeout window (default `CLAUDE_TIMEOUT_MS=300000`, i.e. 300s — see [#132 ship](https://github.com/sleep2agi/agent-network/issues/132))
-- On transient errors / timeouts, backoff `4s, 8s` + 0-1s jitter (the jitter spreads herd retries so the recovering vendor queue isn't slammed all at once)
-- Default `CLAUDE_MAX_RETRIES=2` (so 3 attempts total including the initial one) — set `0` to revert to v0.9.1 behavior (no retry)
-- **Auth-class errors do not retry** (fast-fail above)
-
-**Tuning**:
-
-```bash
-# config.json field
-{
-  "flags": {
-    "claudeTimeoutMs": 600000,   // raise per-attempt timeout to 600s
-    "claudeMaxRetries": 5        // retry up to 5 times (6 attempts total)
-  }
-}
-
-# Or via ENV
-CLAUDE_TIMEOUT_MS=600000 CLAUDE_MAX_RETRIES=5 anet node start <alias>
-```
-
-If timeouts persist, the root cause is usually vendor capacity. Shard horizontally across multiple vendors and stagger startup (`--stagger` on `anet project up`, [#117](https://github.com/sleep2agi/agent-network/issues/117)).
-
-### `codex-direct-stdio` opt-in path errors (v0.10.0+, only when `ANET_CODEX_STDIO_DIRECT=1`)
-
-v0.10.0 [#141](https://github.com/sleep2agi/agent-network/issues/141) introduces a direct stdio JSON-RPC client path that bypasses the `@openai/codex-sdk` wrapper — errors surface more directly (no wrapper buffer), but you now face the `codex` binary + `codex app-server` protocol straight on.
-
-**1. `Error: spawn codex ENOENT` (immediate failure after opt-in)**
-
-agent-node can't find the `codex` binary — the opt-in path **spawns directly**, there's no `@openai/codex-sdk` fallback.
-
-```bash
-# Check
-which codex
-# If empty, install:
-npm install -g @openai/codex
-
-# Or if the npm global bin isn't on PATH, see runtimes § codex-sdk PATH fix.
-```
-
-Fall back to the wrapper path (drop the env var):
-
-```bash
-unset ANET_CODEX_STDIO_DIRECT
-anet node start <codex-node>
-```
-
-**2. `codex app-server` subcommand missing / `unknown subcommand: app-server`**
-
-Older codex CLI versions don't have `codex app-server` ([#141](https://github.com/sleep2agi/agent-network/issues/141) verified against codex `0.130.0+`). Upgrade:
-
-```bash
-npm install -g @openai/codex@latest
-codex --version  # expect ≥ 0.130.0
-codex app-server --help  # should print subcommand help, not "unknown subcommand"
-```
-
-If you can't upgrade, fall back to the wrapper: `unset ANET_CODEX_STDIO_DIRECT`.
-
-**3. `JSON-RPC parse error` / `-32600` invalid request**
-
-Stdio protocol mismatch — usually from a codex CLI version that's older or newer than what anet expects (experimental status means the protocol can break). Reproducer + fix:
-
-```bash
-# Inspect the protocol handshake
-ANET_CODEX_STDIO_DIRECT=1 LOG_LEVEL=debug anet node start <codex-node> 2>&1 | grep -iE "initialize|protocolVersion|error"
-
-# If you see a protocolVersion mismatch
-npm install -g @openai/codex@latest
-
-# Temporary fallback to the wrapper:
-unset ANET_CODEX_STDIO_DIRECT
-```
-
-If the codex CLI is already at latest but it still errors, please file an issue with the debug output above and `codex --version`. [#141](https://github.com/sleep2agi/agent-network/issues/141) is still inside the preview-feedback window (v0.11.0 plans the default flip), so protocol-break is a known risk + mitigation path.
-
-### Dashboard agent hover card shows `process_telemetry` as `null` (shipped since v0.10.0, dashboard 0.5.0+)
-
-The dashboard `≥ 0.5.0` §3.E hover detail card expects agent-node `≥ 2.4.0` ([#142](https://github.com/sleep2agi/agent-network/issues/142) — v0.10.0 ship made the agent emit `process_telemetry` on every heartbeat) plus commhub-server `≥ 0.8.2` (schema align). Three possible causes:
-
-- **agent-node older than 2.4.0**: run `anet upgrade` to pull the current latest (satisfies the ≥ 2.4.0 minimum)
-- **commhub-server older than 0.8.2**: upgrade the server (`bunx @sleep2agi/commhub-server@latest`)
-- **Agent hasn't reported a heartbeat yet**: `process_telemetry` rides on the same heartbeat as host telemetry — a freshly started node needs ~15s
-
-Verify the real data flow:
-
-```bash
-curl http://localhost:9200/api/server/<host>/agents \
-  -H "Authorization: Bearer ntok_xxx" | jq '.agents[0].process_telemetry'
-# Expect non-null rss_bytes / cpu_pct / uptime_seconds / in_flight_count
-```
-
-### `grok-build-acp` node task hangs / `session/prompt timed out after 300000ms` / JSON-RPC error 32603
-
-**Symptom**: A node created with the `grok-build-acp` runtime accepts a task longer than ~5 min via CommHub and then never reports back. No error, no reply — the pane is stuck on a `session/prompt` call. The agent-node log shows either `session/prompt timed out after 300000ms` or a JSON-RPC `code: 32603` returned by the ACP server.
-
-**Root cause**: agent-node 2.4.8 and below hard-coded a 300 s `session/prompt` timeout (inherited from the older codex-sdk wrapper). The grok-build-acp backend, however, is biased toward longer user-level tasks where 5 min is routinely too tight.
-
-**Fix**: Run `anet upgrade` to the current latest (the hotfix landed in `agent-node 2.4.9` / v0.10.13 and is in every later version) — it widens the client-side `session/prompt` timeout to match the grok backend's real working window. Live-tested in-house: tasks of 47 s / 5 min / >10 min all complete normally.
-
-```bash
-# 1. Upgrade
-anet upgrade            # one-shot
-# or: npm install -g @sleep2agi/agent-node@latest
-
-# 2. Restart the grok node
-anet node stop grok-marketing && anet node start grok-marketing
-
-# 3. Verify
-anet --version          # agent-node ≥ 2.4.9
-```
-
-**Genuinely long jobs still hit the cap (video generation / large X searches)**: the 300 s default in the current latest is still too tight for some video or batch workloads. Bump it via `flags.grokAcpTimeoutMs` (config) or `GROK_ACP_TIMEOUT_MS` (env, takes precedence):
-
-```bash
-# Per-shell (export before starting the grok node)
-GROK_ACP_TIMEOUT_MS=900000 anet node start my-grok
-```
-
-```json
-// Persistent (in .anet/nodes/<alias>/config.json)
-{
-  "runtime": "grok-build-acp",
-  "flags": { "grokAcpTimeoutMs": 900000 }
-}
-```
-
-Full detail: [runtimes → Long-task timeout tuning](/en/guide/runtimes#long-task-timeout-tuning-flags-grokacptimeoutms).
-
-::: warning Startup log follows the current latest
-Older agent-node versions **do not print** `timeoutMs=<new value>` at startup — the value is read but not surfaced in `anet node start` output. If you set it and tasks still time out, the config is likely in the wrong file or the env-var name has a typo; upgrade to npm `latest` first, then [open an issue](https://github.com/sleep2agi/agent-network/issues/new).
-:::
-
-**Still hangs?** Rule out: the grok backend quota is exhausted (grok's own `~/.config/grok-build/` log will hint at it) / the node `cwd` is outside the user-workspace boundary ([#204](https://github.com/sleep2agi/agent-network/issues/204) isolated cwd boundary) / `grok login` credentials expired.
-
-### Hub box load is abnormally high / new claude sessions are slow / piles of zombie `bun` processes
-
-**Symptom**: The machine hosting the hub shows a sustained high load average (>10× the CPU core count). Opening new claude / agent sessions feels slow, and CommHub MCP calls occasionally time out. `top` shows lots of `bun ... server.ts` processes that look like they're doing nothing.
-
-**Root cause**: A plugin directory or agent workdir was renamed or deleted while older `bun` child processes still held its now-`deleted` cwd. Every new session forks another zombie on top, and they accumulate until they saturate the CPU. **Real-world repro**: 86 zombie `bun` processes, load average 92.
-
-**Detect** (one-liner):
-
-```bash
-for pid in $(pgrep -f "bun.*server.ts"); do readlink /proc/$pid/cwd; done | grep deleted | wc -l
-```
-
-`>5` means something is wrong. To see exactly which PIDs:
-
-```bash
-for pid in $(pgrep -f "bun.*server.ts"); do
-  cwd=$(readlink /proc/$pid/cwd 2>/dev/null)
-  [[ "$cwd" == *deleted* ]] && echo "PID $pid → $cwd"
-done
-```
-
-**Fix**:
-
-```bash
-# Kill every bun process whose cwd points to a deleted dir
-for pid in $(pgrep -f "bun.*server.ts"); do
-  cwd=$(readlink /proc/$pid/cwd 2>/dev/null)
-  [[ "$cwd" == *deleted* ]] && kill -9 $pid
-done
-
-# Or, if you know what you're killing, blow the whole pgrep set away
-pkill -9 -f "bun.*server.ts"
-```
-
-Then restart whatever agent / hub processes you needed.
-
-**Prevent**: Kill the corresponding `bun` child process **first** (`anet node stop <name>` or a manual `kill`) before renaming / deleting a plugin directory or agent workdir.
-
----
-
-## Docker Errors
-
-### `service "seed" is not running`
-
-The seed container is one-shot -- it exits after completion (exit code 0). This is normal.
-
-```bash
-# Check if it succeeded
-docker compose logs seed
-# You should see: seed: wrote ntok_ to /shared/ntok
-```
-
----
-
-### Worker containers keep restarting
-
-```bash
-# Check logs for the cause
-docker compose logs worker-1
-
-# Common causes:
-# 1. Server not started yet (health check not passed)
-# 2. ntok_ doesn't exist (seed failed)
-# 3. Codex auth missing (~/.codex not mounted)
-```
-
----
-
-### `permission denied` in Docker
-
-```
-Error: EACCES: permission denied, mkdir '/root/.claude'
-```
-
-**Solution**: Ensure the `.claude` directory is mounted as tmpfs:
-
-```yaml
-tmpfs:
-  - /root/.claude
-  - /tmp
-```
-
----
-
-## Diagnostic Tools
-
-### anet doctor
-
-Comprehensive system health check:
+Run these on the affected machine and from the affected project directory:
 
 ```bash
 anet doctor
+anet hub status
+anet whoami
+anet status
+anet node ls
+anet info <alias>
+anet logs <alias> --follow
 ```
 
-It checks: global config + auth token, hub reachability (version / sessions / SSE), each node's config health (legacy fields get a `--fix` migration hint), plain-secret hygiene ([#125](https://github.com/sleep2agi/agent-network/issues/125)), and required CLIs (Claude Code / Codex / Bun). Add `--fix` to auto-migrate repairable node configs and re-issue any `ntok_` the hub rejects.
+`doctor` checks configuration, Hub connectivity, node identity, and local dependencies. Do not begin with `doctor --fix`; read what it intends to change and back up the affected configuration first.
 
-### Manual Checklist
+Before sharing logs, remove tokens, API keys, passwords, cookies, complete environment variables, and private Hub URLs. Do not upload all of `~/.anet`, `.anet/nodes/*/config.json`, or `.env`.
+
+## Installation and startup
+
+### `spawn bunx ENOENT` / Bun not found
+
+Agent Network CLI requires Node.js ≥ 22.13, and the Hub requires Bun ≥ 1.2:
 
 ```bash
-# 1. Server health (includes SSE connection count + sessions / license / uptime, no auth required)
-curl http://localhost:9200/health
-# Key fields: ok / version / sessions_count / sse_connections / sse_sessions / uptime
-# Verified at the `GET /health` handler in index.ts
-
-# 2. Valid auth + summary of all session states
-curl -H "Authorization: Bearer ntok_xxx" http://localhost:9200/api/status
-# Returns sessions[] (full list) + summary { idle, working, offline, total }
-# ⚠ The status query param is NOT honored — the server does not filter by status
-#   (the `GET /api/tasks` handler in index.ts). Filter idle agents locally with jq:
-#   curl ... /api/status | jq '.sessions[] | select(.status=="idle")'
-
-# 3. Database size
-ls -lh ~/.commhub/commhub.db
-
-# 4. Task / node / session aggregates (NOT the SSE connection count)
-curl -H "Authorization: Bearer ntok_xxx" http://localhost:9200/api/stats
-# Returns tasks { total, by_status } / sessions { by_status } / nodes { total } / recent_tasks[5]
-# Verified at server/src/index.ts:1022-1058
+node --version
+bun --version
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
 ```
 
-::: tip Full 30+ endpoint index
-See [REST API → metadata table](/en/api/rest) for the full endpoint catalog (11 categories including SSE / Tmux opt-in / Legacy etc.).
-:::
+If a newly installed command is still missing, open a new shell and inspect `PATH`. For a global npm `EACCES` error, use nvm/fnm to manage Node instead of `sudo npm` or weakening system-directory permissions.
 
-### Log Levels
-
-Agent Node supports adjustable log levels (**top-level field — not nested under `flags`**):
-
-```json
-// config.json (.anet/nodes/<alias>/config.json)
-{
-  "logLevel": "debug"   // debug / info / warn / error
-}
-```
-
-Verified at [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts): `LOG_LEVEL` is read from `opts["log-level"] || process.env.LOG_LEVEL || fileConfig.logLevel || "info"` — it **only honors the top-level `logLevel`**. Putting `logLevel` inside `flags` has no effect.
-
-You can also set it via environment variable or CLI flag:
+### `agent-node is not installed` / version check failed
 
 ```bash
-LOG_LEVEL=debug anet node start <alias>
-# or
-anet node start <alias> --log-level debug
+agent-node --version
+anet upgrade --dry-run
+npm install -g @sleep2agi/agent-node
 ```
 
-## Still Having Issues?
+Upgrade on the selected release channel. Do not copy a fixed preview or package version from an old document. See [Versioning](/en/guide/versioning) and [Upgrading](/en/guide/upgrade).
 
-**Try these v0.8 auto-repair tools first**:
+### Port conflict or immediate Hub exit
 
-- `anet doctor` — probes current hub / token / network state, prioritized output
-- `anet doctor --fix` — auto-probes expired ntok_ and reissues; agent-node SSE 401 auto-reloads
-- `anet hub admin reset-user <username>` — local owner on the Hub machine force-resets a user password (forgot-password recovery)
-- `anet passwd` — interactive password change
+```bash
+anet hub status
+curl http://127.0.0.1:9200/health
+lsof -iTCP:9200 -sTCP:LISTEN
+```
 
-**Still stuck**:
+First determine whether the listener is an existing Hub. Stop an anet-managed instance with `anet hub stop`; do not kill processes by a broad name match. If you change the port, the Hub, CLI, and node configurations must all use the new URL.
 
-- **GitHub Issues**: [github.com/sleep2agi/agent-network/issues](https://github.com/sleep2agi/agent-network/issues) — report bugs or search known issues
-- **GitHub Discussions**: [discussions](https://github.com/sleep2agi/agent-network/discussions) — usage questions / design discussion
-- **Source code**: All error messages can be found in `server/src/tools.ts` and `server/src/auth.ts`
-- **FAQ**: [Frequently asked questions](/en/faq) — model choice / cost / upgrade caveats
+## Hub and network connectivity
 
-## Next steps
+### `ECONNREFUSED`
 
-- [Upgrade to v0.8](/en/guide/upgrade#v0-7-v0-8-upgrade-notes-latest) — upgrade path and behavior changes for older installs
-- [Security design](/en/concepts/security) — read before chasing an auth issue
-- [Architecture](/en/guide/architecture) — locate which layer is failing
-- [Community](/en/community) — chat groups and discussion
+Verify the Hub locally:
+
+```bash
+curl http://127.0.0.1:9200/health
+anet hub status
+```
+
+Then test the configured URL from the node machine:
+
+```bash
+curl http://HUB_HOST:9200/health
+```
+
+If local access works but remote access does not, the Hub may be bound only to loopback, a firewall/security group may block the port, or the URL may be wrong. For cross-machine deployments, bind to a reachable address and protect public access with a TLS reverse proxy.
+
+### `ETIMEDOUT` / DNS / TLS errors
+
+Check resolution, routing, certificates, and proxies from the node machine, not only on the Hub host. Verify that the domain does not point to an old host and that an HTTPS reverse proxy can reach the backend `/health` endpoint.
+
+### `SSE connection failed` / reconnect loop
+
+First prove that ordinary health and login requests work, then inspect the node log. SSE is a long-lived connection: Nginx/Caddy/load balancers must not buffer the response or impose a short idle timeout. See [Production deployment](/en/deploy/production).
+
+The task-push path is established only after the log reports `SSE connected`. Brief drops reconnect with backoff; persistent failures should be fixed at the proxy or identity layer rather than hidden by repeated restarts.
+
+## Login, tokens, and networks
+
+### `No hub configured`
+
+```bash
+anet init --hub http://HUB_HOST:9200
+anet login
+```
+
+`~/.anet/config.json` stores the current Hub, user token, and network. Do not assemble tokens by hand or copy one from another machine.
+
+### 401 `invalid token` / `auth required`
+
+```bash
+anet whoami
+anet login
+anet doctor
+```
+
+Old tokens become invalid after a Hub database rebuild, token revocation, or switching to another Hub. Log in again before checking nodes. A node must use its own `ntok_`; do not place a user `utok_` in node configuration.
+
+For a legacy node config or rejected token, back up `.anet/nodes/<alias>/config.json`, read the `anet doctor` result, and only then decide whether to run:
+
+```bash
+anet doctor --fix
+```
+
+### Forgotten password
+
+Run on the Hub host:
+
+```bash
+anet hub admin reset-user --username <username>
+```
+
+This generates a new password and user token and revokes old user tokens. Do not delete `users`, token rows, or bootstrap markers directly; that bypasses auditing and can corrupt related state.
+
+### `network_id_required` / `access_denied` / `permission_denied`
+
+- `network_id_required`: no unique network can be inferred. Log in/select the intended network, or pass `network_id` in calls that support it.
+- `access_denied` / `permission_denied`: identity resolution succeeded, but the role cannot perform the operation. Ask the network owner to change membership; a global admin is not automatically every network's owner.
+- Agent Nodes use an `ntok_` bound to one network. Do not reuse a node token across networks.
+
+See [Tokens and permissions](/en/concepts/tokens), [Roles](/en/concepts/roles), and [Networks](/en/concepts/networks).
+
+### Other authentication/network errors
+
+| Error | Safe response |
+|---|---|
+| `password must be at least 8 characters` / `too common` | Choose at least eight characters and avoid the weak-password list |
+| 429 / `too many attempts` | Stop retrying and wait for the indicated window; correct the credential before trying again |
+| `network name already exists` | Inspect current networks and choose another name; do not edit the database |
+| `network has N active session(s)` | Use `anet status`, stop the nodes normally, then retry network deletion |
+| `quota exceeded` | Use `anet network ls` and remove unused networks. There is currently no public CLI for changing a user plan/global role; contact the Hub operator and do not promote the user to global admin as a shortcut |
+| `license_expired` | If it remains after `anet license` and an upgrade, contact the Hub operator. There is no safe public CLI for cleaning legacy rows; stop the Hub, back up the database, and file a redacted diagnostic instead of deleting `licenses` rows online |
+
+## Agent Node
+
+### Node remains offline / receives no tasks
+
+Verify in order:
+
+1. The node machine can reach Hub `/health`.
+2. `anet whoami` points to the intended Hub and network.
+3. `anet info <alias>` shows the correct runtime, working directory, and identity.
+4. `anet logs <alias> --follow` eventually reports `SSE connected`.
+5. No other process uses the same alias, `node_id`, or `ntok_`.
+
+Restart one node safely:
+
+```bash
+anet node stop <alias>
+anet node start <alias>
+```
+
+Do not copy a node `config.json` to another machine. Log in and run `anet node create` on the target so the Hub issues a separate identity.
+
+### Duplicate results / changing runtime / `alias_identity_mismatch`
+
+This usually means multiple processes or old configs use one identity:
+
+```bash
+anet info <alias>
+anet logs <alias> --follow
+tmux ls
+```
+
+Stop old instances and keep one process. Do not reclaim identity by editing `node_id`, alias, token, or the Hub database. Use `anet node rename` for renaming.
+
+`Node "<alias>" already exists` usually means the current project already has that local config under `.anet/nodes/`. Inspect it with `anet node ls` / `anet info <alias>` before reusing it; do not delete the directory merely to recreate the name.
+
+### Wrong working directory
+
+File tools use the node's launch directory. Stop it, enter the intended project, and start again. In Codex TUI co-presence, the thread directory is inherited from the app-server process. Follow [Codex TUI co-presence](/en/guide/codex-copresence) and inspect the full session group, not only the bridge.
+
+## Runtime and model
+
+Confirm that the configured runtime exists on the installed release channel:
+
+```bash
+anet info <alias>
+anet logs <alias> --follow
+anet upgrade --dry-run
+```
+
+| Symptom | Check |
+|---|---|
+| Claude/Codex command missing | The corresponding CLI is installed, is in the node process `PATH`, and is authenticated |
+| Vendor 401/403 | API key, envRef target, and `ANTHROPIC_BASE_URL` belong to the same service |
+| Vendor timeout/rate limit | Service status, account quota, and node concurrency; do not burn quota with unbounded retries |
+| Long Grok ACP task times out | Check `flags.grokAcpTimeoutMs` / `GROK_ACP_TIMEOUT_MS` in the runtime guide |
+| Codex co-presence recovers as a normal node | Continue using `anet node start <alias> --copresence`, not plain start |
+
+OpenCode is currently a task runtime, not a shared TUI. Shared Grok TUI support has not shipped. Follow [Runtimes](/en/guide/runtimes), not old versions or historical changelog commands.
+
+## Tasks and messages
+
+### Work does not invoke the model
+
+Executable work must use `send_task`. `send_reply` is a task result and `send_message` is ordinary chat; neither invokes the model again.
+
+```bash
+anet status
+```
+
+Confirm that the target node is online, the task is in the current network, and the alias is correct. See [Task lifecycle](/en/concepts/task-lifecycle) for status, retry, and parent-child semantics.
+
+### `task not found` / `message not found`
+
+The current token/network may not own the object, or a message may belong to another node. Start with `anet whoami` and `anet status`; do not bypass network isolation by querying or editing SQLite directly.
+
+### Scheduled task did not run
+
+```bash
+anet goal list <alias>
+anet info <alias>
+```
+
+Recurring goals require an online node and consume real model quota. They are not a high-precision cron service; validate with a conservative interval.
+
+## Channels
+
+```bash
+anet channel status <alias>
+anet logs <alias> --follow
+```
+
+Check the bot token, pairing/allowlist, target node, and channel runtime. Telegram uses long polling; reverse-proxy webhook settings do not apply to it. See [Channels](/en/guide/channels) for current support and restart requirements.
+
+## Docker
+
+```bash
+docker compose ps
+docker compose logs --tail=200 <service>
+```
+
+Check Hub health, persistent volumes, the Hub URL inside the container, token files, and model-credential mounts. Inside a container, `localhost` refers to that container, not the host.
+
+Do not run `docker system prune`, `docker image prune -a`, or broad name-pattern cleanup on a shared host. Resolve containers and exact image references first.
+
+## Still unresolved
+
+Include the following in an issue:
+
+- `anet -v`, Node/Bun versions, and release channel
+- runtime, operating system, and deployment method
+- minimal reproduction and exact error
+- redacted excerpts from `anet doctor`, `anet info`, and relevant logs
+
+Search [Issues](https://github.com/sleep2agi/agent-network/issues) first. Report security problems through a [GitHub Security Advisory](https://github.com/sleep2agi/agent-network/security/advisories/new), not a public issue.

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -1,967 +1,257 @@
 # 故障排查
 
-按错误信息快速定位问题和解决方案。
+按“环境 → Hub → 认证 → 节点 → runtime → 任务”的顺序排查。前一层不通时，后面的报错通常只是连带现象。
 
-如果问题集中在 `anet doctor`、Telegram channel、MCP 工具注入、codex-sdk 主动 `send_task`，优先看专项 runbook：[连接 / Channel / MCP 排障](/troubleshooting/connectivity-channels-mcp)。
+完整命令见 [CLI 参考](/guide/cli)，部署问题见[生产部署](/deploy/production)，runtime 专属问题见 [Runtime 对比](/guide/runtimes)。
 
-::: tip 不是故障，只是想了解版本？
-看 [版本号体系](/guide/versioning) 理清 npm 包版（`anet -v` 那几行）和 `v0.10.x` bundle release 的对应关系；想升级走 [升级指南](/guide/upgrade)。
-:::
+## 先收集最小诊断
 
-## 启动类错误（首次运行最常见）
-
-### `anet hub start` -- `spawn bunx ENOENT`
-
-```
-Error: spawn bunx ENOENT
-```
-
-**原因**：本机没装 **Bun**。`commhub-server` 是 Bun-shebang TypeScript，`anet hub start` 底层用 `bunx --bun` 起它，没有 Bun 就崩在第一步。
-
-**解决**：
-
-```bash
-npm i -g bun
-# 或： curl -fsSL https://bun.sh/install | bash
-bun --version        # 应输出 1.2.x 或更新
-```
-
-装好 Bun 再跑 `anet hub start`。完整前置见 [上手指南 · 前置](/guide/getting-started)。（[#235](https://github.com/sleep2agi/agent-network/issues/235) 跟进给启动前友好预检。）
-
----
-
-### `anet node start` -- `agent-node is not installed or cannot report a version`
-
-```
-agent-node is not installed or cannot report a version. Run: anet upgrade
-```
-
-**原因**：`claude-agent-sdk` / `codex-sdk` 两个 runtime 依赖 `agent-node` 包。设计是首次 `node start` 由 npx 懒加载自动拉取，但当前版本的启动检查**不等它拉完**就报错退出（[#450](https://github.com/sleep2agi/agent-network/issues/450)，#237 同族）。
-
-**解决**：先手动装一次再启动：
-
-```bash
-npm i -g @sleep2agi/agent-node
-agent-node --version     # 应输出当前 latest 或更新
-anet node start <name>
-```
-
-> `claude-code-cli` / `grok-build-acp` runtime 不吃这个坑（不走 `agent-node` SDK 适配路径）。
-
----
-
-## 连接类错误
-
-### `ECONNREFUSED` -- 连接被拒绝
-
-```
-Error: connect ECONNREFUSED 127.0.0.1:9200
-```
-
-**原因**：CommHub Server 没有运行。
-
-**解决**：
-
-```bash
-# 检查 Server 是否在运行 (v0.10.11+ 推荐, 一行看清 PID + port + /health version)
-anet hub status                # 默认端口 9200
-anet hub status --port 9201    # 非默认端口
-
-# 或老办法 curl /health (老版本兼容)
-curl http://localhost:9200/health
-
-# 如果没有运行，启动 Server
-anet hub start --port 9200
-
-# 如果端口不对，检查配置
-cat ~/.anet/config.json
-```
-
----
-
-### `ETIMEDOUT` -- 连接超时
-
-```
-Error: connect ETIMEDOUT 203.0.113.10:9200
-```
-
-**原因**：网络不可达或防火墙阻止。
-
-**解决**：
-
-```bash
-# 检查网络连通性
-ping 203.0.113.10
-telnet 203.0.113.10 9200
-
-# 检查防火墙
-sudo ufw status
-sudo ufw allow 9200
-
-# 检查云服务器安全组
-# 确保入站规则允许 TCP 9200
-```
-
----
-
-### `SSE connection failed` -- SSE 连接失败
-
-```
-[agent-node] SSE connection failed, reconnecting in 3s...
-```
-
-**原因**：SSE 长连接断开，通常是网络波动。
-
-**解决**：Agent 会自动重连（[#202](https://github.com/sleep2agi/agent-network/issues/202) 起：指数退避 `1s → 30s` 上限 + 重连即重 register + 1h 失败放弃，[详见 agent-node 断线重连](/guide/agent-node#断线重连)），通常无需手动干预。
-
-如果持续失败：
-
-```bash
-# 检查 Server 是否在运行 (v0.10.11+ 推荐, 一行看清 PID + port + /health version)
-anet hub status
-
-# 或老办法 curl /health
-curl http://localhost:9200/health
-
-# 检查 Token 是否有效
-curl -H "Authorization: Bearer ntok_xxx" http://localhost:9200/api/status
-
-# 检查反向代理配置（如果有）
-# Nginx 需要以下配置：
-# proxy_read_timeout 86400;
-# proxy_buffering off;
-```
-
-### Hub 重启后 Dashboard 看不到节点
-
-**症状**：`anet hub stop` + `anet hub start`（或 hub 进程崩溃后重启）几秒钟后，Dashboard 看到所有节点 `offline` 或完全不在节点列表里。Agent 进程实际还活着。
-
-**原因（v0.10.10 及以前）**：hub 重启会清空 sessions 内存表。老版本 `agent-node` 的 SSE 重连只恢复事件流，**不重发 register**——hub 端 sessions 表要等下次 3 分钟 heartbeat 才会重建，期间 Dashboard 看不到任何节点。
-
-**解决**：[#202](https://github.com/sleep2agi/agent-network/issues/202) 起结构性修复，SSE 重连成功立即重发 register（idempotent upsert），Dashboard 30s 内自动恢复完整节点列表。**无需手动 `anet project restart`**，跟 `anet hub stop` / `hub status` 配套用 → hub 维护 SOP 一键完成。如果你 agent-node 较旧，跑 `anet upgrade` 升到 npm latest 即享受。
-
----
-
-## 认证类错误
-
-### `No hub configured. Pass --hub <url> or run 'anet init' first.`
-
-**现象**：全新装后第一次 `anet login`（或照着 `anet hub start` 的提示跑 `anet login --username admin --password anethub`）直接报这个，登不进去。
-
-**原因**：`anet hub start` 只起 hub，**不会**把 hub 地址写进全局配置；而 `anet login` 需要知道连哪个 hub —— 中间少了「设置 hub 地址」这一步（`anet init` 或 `--hub` 会做）。
-
-**解决**：登录时直接带 `--hub`（本机 hub 默认 `127.0.0.1:9200`）：
-
-```bash
-anet login --hub http://127.0.0.1:9200 --username admin --password anethub
-```
-
-或先 `anet init --hub <url>` 设好 hub 再 `anet login`。连远程 hub 把地址换成对应 IP。
-
----
-
-### 401 `auth required` / `invalid token` / `token required`
-
-实际 server 返回三种 401 错码（**不是** `{"error": "unauthorized"}`；verify `grep error.*401 server/src/index.ts`）：
-
-```json
-{ "ok": false, "error": "auth required" }     // 多数 REST 端点缺 Authorization header
-{ "ok": false, "error": "token required" }    // 部分认证端点（如 /api/auth/me）缺 token
-{ "ok": false, "error": "invalid token" }     // token 字面对但 resolveToken 失败（被 revoke / 过期 / hub DB wipe）
-```
-
-**原因**：Token 无效或缺失。`invalid token` 常见于 hub DB 被 wipe（重置 commhub.db），原有 utok\_ / ntok\_ 全失效。
-
-**解决**：
-
-```bash
-# 检查当前 Token / 用户身份（v0.8 推荐入口）
-anet whoami
-
-# 如果 Token 过期，重新登录
-anet login
-
-# 检查配置文件中的 Token
-cat ~/.anet/config.json
-
-# （旧路径，已不推荐）COMMHUB_AUTH_TOKEN 自 v0.8 起软废弃；v1.0 移除。
-# 如果你只是想看身份，请用 anet whoami；如果环境里残留了这个变量请清掉，避免触发 deprecation warning。
-```
-
----
-
-### MCP 写操作被拒 — `network_id_required` / `access_denied` / `permission_denied`
-
-写工具（send_task / send_message / send_reply / ack_inbox / send_ack / retry_task / cancel_task / reassign_task …）被拒时，`error` 码区分**三种不同的真实原因**——别一律当权限问题查（那正是 #517 修掉的误导）：
-
-| `error` | 真实原因 | 解决 |
-|---|---|---|
-| `network_id_required`<br>（message 含 "no network memberships"） | 该用户不属于任何 network | 先创建或通过邀请码加入一个 network |
-| `network_id_required`<br>（message 含 "spans N networks"） | utok_ 跨多个 network，写目标有歧义 | 显式传 `network_id`（从 `/api/auth/me` 的 `networks[].network_id` 取） |
-| `access_denied` | 显式传的 `network_id` 你不是其成员 | 换正确的 network_id，或让 owner 邀请你加入 |
-| `permission_denied` | 你在该 network 是 **viewer**（只读） | 让 owner 提升角色（见下） |
-
-> **恰好属于 1 个 network 的 utok_ 调用方无需传 `network_id`** —— hub 自动解析到唯一成员网络（与 REST `POST /api/task` 同一规则，#517）。修复 #517 之前的 hub 对上述所有情况一律报 `permission_denied` 并提示 "utok current_network is null"：如果你看到那个旧文案，先升级 hub。
-
-**解决**：
-
-```bash
-# viewer 提升角色 / 或改用 ntok_
-# Agent Node 必须使用 ntok_，token 来自 .anet/nodes/<name>/config.json 文件
-# （agent-node CLI 不接受 --token flag；token 由 config.json 提供）
-# 如果当前 node 的 token 是 utok_/atok_，跑 doctor 自动修：
-anet doctor --fix
-
-# viewer → member 提升角色
-# 让 owner（不是 admin —— admin 改不了角色，PUT members 是 owner-only gate）
-# 通过 REST 调用提升角色（CLI promote 子命令 v0.10.x 仍未提供 —— v0.9.x / v0.10.x scope chain 都未动 member role 管理；排到 v0.11+ / 未排期）：
-NET=$(jq -r .network_id ~/.anet/config.json)
-UTOK=$(jq -r .token ~/.anet/config.json)        # owner 自己的 utok_
-curl -X PUT "$HUB/api/networks/$NET/members/<your_user_id>" \
-  -H "Authorization: Bearer $UTOK" \
-  -H "Content-Type: application/json" \
-  -d '{"role": "member"}'
-# 详见 [API — PUT members](/api/rest#put-api-networks-id-members-user-id)
-# 或者：owner 创建新邀请码让你重新加入（拿到目标 role）
-anet network invite --role member
-```
-
----
-
-### `license_expired` -- 授权过期（legacy 行为）
-
-```json
-{"ok": false, "error": "license_expired", "message": "Trial expired. Activate a license: anet activate <key>"}
-```
-
-::: info v0.8 起 anet 完全 Apache-2.0 OSS，没有真正的 license 销售
-这条 license gate 是 V3 时代的遗留代码，仍在 `send_task` 路径里跑（verify [`server/src/tools.ts:616`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L616) `license_expired` emit；同文件 L611 `SELECT type, expires_at FROM licenses`），如果你的本地 SQLite 有过期 `licenses` 行就会触发。**v0.9.x / v0.10.x scope 都未动**（Recovery & Observability 主题为先），排到 v0.11+ / 未排期移除整段 license 检查。
-:::
-
-**原因**：本地 SQLite `licenses` 表里有一行 `expires_at < now()`。
-
-**解决**：
-
-```bash
-# 方案 A（推荐）：直接清掉过期 license 行
-sqlite3 ~/.commhub/commhub.db "DELETE FROM licenses WHERE expires_at < datetime('now');"
-
-# 方案 B（legacy 命令，仅占位实现）：
-anet license       # 查看
-anet activate <key>   # v0.6 legacy 命令，写入新 license row（不验证 key，仅占位）
-
-# 方案 C（离线 tutorial）：起 hub 时加 --dev-open 跳过鉴权（仅本机调试用）
-anet hub start --dev-open
-# Docker / systemd 场景没法加 CLI flag 时，用 env 变量等效开启：
-# COMMHUB_DEV_OPEN=1 anet hub start
-# （verify [`index.ts` `DEV_OPEN`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)：`--dev-open` flag 或 `COMMHUB_DEV_OPEN=1` 二选一即可）
-```
-
----
-
-### `password must be at least 8 characters` / `password is too common` -- 密码强度不达标（v0.8）
-
-```json
-{ "ok": false, "error": "password must be at least 8 characters" }
-{ "ok": false, "error": "password is too common" }
-{ "ok": false, "error": "new password must be at least 8 characters" }   // changePassword
-{ "ok": false, "error": "new password is too common" }                   // changePassword
-```
-
-verify [`auth.ts:24-28 validatePasswordStrength()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L24)。`label` 参数让 changePassword 把前缀加成 `new password`。
-
-**原因**：v0.8 起 `register` / `anet passwd` / `anet hub admin reset-user` 都走同一 `validatePasswordStrength()` 校验：
-- 长度 ≥ 8 字符
-- 不在弱密码字典里（[`password-dict.ts WEAK_PASSWORDS`](https://github.com/sleep2agi/agent-network/blob/main/server/src/password-dict.ts) 含 `"password"` / `"12345678"` / `"qwerty123"` 等 top 弱密码）
-
-**例外（仅 register 首位用户）**：[`auth.ts:43-44`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L43) 检测「首位注册的用户」时只校验 `length >= 4`（让 bootstrap `admin / anethub` 能成立）。`anet passwd` / `reset-user` **无此豁免**，永远强制 ≥ 8 + 非弱密码。
-
-**解决**：
-
-```bash
-# 随机生成一个 16 字符强密码
-openssl rand -base64 16
-
-# 或用 pwgen
-pwgen -s 16 1
-```
-
-::: warning 生产部署
-任何 `--host 0.0.0.0` 公网部署，首次 admin 设默认 `anethub` 之后**立刻**改强密码：
-```bash
-anet login --username admin --password anethub
-anet passwd                    # 改成强密码
-```
-:::
-
----
-
-### 第二次 `anet hub start` 还重新 bootstrap admin？
-
-第一次 `anet hub start` 已经建了 admin，再启动还输出 `Admin account created`？
-
-::: tip bootstrap 是**非交互**的，没有 "Set up admin account" prompt
-verify [`agent-network/bin/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)：`anet hub start` 默认直接 POST `/api/auth/register` username=`admin` password=`anethub`（除非传 `--username` / `--password`）。**没有任何交互 prompt**，所以「反复 prompt」描述是旧 doc，已删。
-
-幂等性靠 `~/.anet/server/admin-utok.json` 作 marker —— 文件在就跳过 register flow（输出 `✅ Admin already exists`），文件丢了就再跑 register（hub 端会因 `username already taken` 而返 `ℹ Admin account "admin" already exists`，不会重建）。
-:::
-
-**原因**：`~/.anet/server/admin-utok.json` 被删了 / hub `~/.commhub/commhub.db` 被清了 / 用了不同的 `HOME`（Docker 没挂卷）。
-
-**确认状态**：
-
-```bash
-# 1. marker 文件在哪
-ls -la ~/.anet/server/admin-utok.json   # 该文件存在 → 下次 start 跳过 register
-
-# 2. hub 端 admin user 在不在
-sqlite3 ~/.commhub/commhub.db "SELECT username, role FROM users WHERE role='admin'"
-```
-
-**两文件状态 vs `anet hub start` 行为**：
-
-| `admin-utok.json` | `users` 表 admin row | `anet hub start` 输出 |
-|---|---|---|
-| 存在 | 存在 | `✅ Admin already exists (admin-utok.json found, user=...)` |
-| 不存在 | 存在 | `ℹ  Admin account "admin" already exists`（hub 返 `username already taken`） |
-| 不存在 | 不存在 | `✅ Admin account created` + `Admin token saved to ~/.anet/server/admin-utok.json` |
-| 存在 | 不存在（db 被清） | `✅ Admin already exists` 但 `anet login` 会失败 —— 需 `rm admin-utok.json` 再 `anet hub start` |
-
-**解决**：
-
-```bash
-# 状况：admin-utok.json 在但 login 失败
-# → marker 跟 db 不同步，删 marker 让下次 start 重建 admin row
-rm ~/.anet/server/admin-utok.json
-anet hub start                  # 重新走 register flow
-anet login --username admin --password anethub
-```
-
----
-
-### 429 速率限制（`too many requests` / `too many attempts`）
-
-```
-HTTP 429
-{ "ok": false, "error": "too many requests, try again later" }     # register 命中
-{ "ok": false, "error": "too many attempts, try again later" }     # login 命中
-```
-
-**原因**：同一 IP 在窗口内请求过多。
-
-| 端点 | 限制 | 命中 message |
-|------|------|---|
-| `POST /api/auth/register` | 30 次/分钟 | `too many requests, try again later` |
-| `POST /api/auth/login` | 10 次/分钟 | `too many attempts, try again later`（+ audit `login_rate_limited`） |
-
-::: info v0.8 当前只有这两个 endpoint 做 IP rate limit
-其他 endpoint **不做 IP rate limit**（`checkRateLimit` 函数 default=60 仅函数签名 default，[`index.ts` `checkRateLimit()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 实际只在 register/login 两处调；详见 [安全设计 — 速率限制](/concepts/security#速率限制-rate-limiting)）。担心其他端点被写滥用，前置反向代理（nginx / Cloudflare）加 rate limit。
-:::
-
-**解决**：等 60 秒后重试。localhost / `::1` / `unknown` IP 免限制（[`index.ts` `checkRateLimit()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）。响应**无** `retry_after_seconds` 字段，**无** `Retry-After` header，窗口固定 60 秒。
-
----
-
-## 任务类错误
-
-### `task not found`
-
-```json
-{"ok": false, "error": "task not found"}
-```
-
-**原因**：
-
-1. task_id 不正确
-2. 任务在另一个网络中（ntok_ 绑定的网络不同）
-
-**解决**：
-
-```bash
-# 确认任务存在
-anet tasks
-
-# 确认当前网络
-anet whoami
-
-# 检查任务详情
-curl "http://localhost:9200/api/tasks?limit=10" -H "Authorization: Bearer ntok_xxx"
-```
-
----
-
-### `task status is X, not retryable`
-
-```json
-{"ok": false, "error": "task status is running, not retryable"}
-```
-
-**原因**：只有 `failed` / `expired` / `cancelled` 状态的任务可以重试。
-
-**解决**：
-
-::: tip
-下面的 `cancel_task` / `retry_task` 是 server 端 MCP tool，调用走 REST `POST /mcp`（或 SDK 直连），**不是** Claude Code agent 的 stdio wrapper。channel-wrapper（[`channel/commhub-channel.ts`](https://github.com/sleep2agi/agent-network/blob/main/channel/commhub-channel.ts)）只暴露 5 个 `commhub_*` tool（`commhub_reply` / `commhub_report_status` / `commhub_send_task` / `commhub_send_message` / `commhub_get_all_status`）—— `cancel_task` / `retry_task` / `reassign_task` / `get_inbox` 是管理 / Dashboard 操作，不在 Claude Code chat agent 的 self-service 工具集里（[`commhub-channel.ts:136-203`](https://github.com/sleep2agi/agent-network/blob/main/channel/commhub-channel.ts#L136)）。
-:::
-
-```bash
-# 先取消正在运行的任务（POST /mcp tool=cancel_task）
-cancel_task(task_id="t_xxx", reason="需要重试")
-
-# 然后重试（POST /mcp tool=retry_task）
-retry_task(task_id="t_xxx")
-```
-
----
-
-### `task is terminal`
-
-```json
-{"ok": false, "error": "task is terminal (replied)"}
-```
-
-**原因**：任务已处于终态（replied / failed / cancelled / expired），不能再操作。
-
-**解决**：如果需要重新执行，创建新任务：
-
-```bash
-commhub_send_task(alias="代码1号", task="重新执行: ...")
-```
-
----
-
-### `message not found or not yours`
-
-```json
-{"ok": false, "error": "message not found or not yours"}
-```
-
-**原因**：
-
-1. message_id 不正确
-2. 消息不属于当前 Agent（alias 不匹配）
-3. 消息在另一个网络中
-
-**解决**：
-
-::: tip
-`get_inbox` 是 server 端 MCP tool，调用走 REST `POST /mcp`（或 SDK 直连），**不是** Claude Code agent 的 stdio channel wrapper。channel-wrapper 只暴露 5 个 `commhub_*` tool（`commhub_reply` / `commhub_report_status` / `commhub_send_task` / `commhub_send_message` / `commhub_get_all_status`）；`get_inbox` 故意没在 wrapper 里 —— agent 通过 SSE 自动轮询 inbox，见 [`channel/commhub-channel.ts:136-203`](https://github.com/sleep2agi/agent-network/blob/main/channel/commhub-channel.ts#L136)。
-:::
-
-```bash
-# 确认 inbox 中的消息（POST /mcp，tool=get_inbox）
-get_inbox(alias="代码1号")
-```
-
----
-
-## 网络类错误
-
-### `network name already exists`
-
-```json
-{"ok": false, "error": "network name already exists"}
-```
-
-**原因**：同一用户已经有同名网络。
-
-**解决**：
-
-```bash
-# 查看已有网络
-anet network ls
-
-# 使用不同名称
-anet network create my-other-network
-```
-
----
-
-### `network has N active session(s)`
-
-```json
-{"ok": false, "error": "network has 3 active session(s) — stop them first"}
-```
-
-**原因**：删除网络前必须先停止所有 Agent。
-
-**解决**：
-
-```bash
-# 查看网络中的 Agent
-anet status
-
-# 停止所有 Agent
-anet node stop 代码1号
-anet node stop 代码2号
-anet node stop 代码3号
-
-# 然后删除（必须加 --force，否则只打印确认提示）
-anet network delete my-network --force
-```
-
----
-
-### `quota exceeded: max N networks for free plan`
-
-```json
-{"ok": false, "error": "quota exceeded: max 2 networks for free plan"}
-```
-
-::: warning v0.8 仍 enforced（POST /api/networks，非 admin）
-旧版 doc 说「v0.8 起不启用 plan 配额」**不准** —— verify [`auth.ts` `createNetwork()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts)：仍然按 `users.plan || 'free'` 查 `QUOTAS` 表门控 `network create`。**仅 `users.role='admin'`（首位注册用户）豁免**（`plan = "admin"` 走 `QUOTAS.admin`）。其他用户 `plan='free'` 默认上限 `max_networks_owned=2`（v0.8 没改这个默认值）。跟 [Networks — 配额限制](/concepts/networks#quota-limits) 描述的「未启用 plan 区分」实际指的是 **dashboard 不显示 plan 升级 UI + 没 SaaS 计费**，不是「server 端不再做 quota 检查」。
-:::
-
-**触发条件**：non-admin 用户创建了 ≥ `max_networks_owned`（free=2）的网络。
-
-**解决**：
-
-```bash
-# 方案 A（推荐）：让 hub 把该用户升 admin（任何已 hub 主机本机权限的 system admin 操作）
-# 没有公开 endpoint, 只能 SQLite 直改：
-sqlite3 ~/.commhub/commhub.db "UPDATE users SET role = 'admin' WHERE user_id = 'u_xxx';"
-# 之后该 user.role='admin' → createNetwork plan='admin' → quota 走 QUOTAS.admin（基本无限）
-
-# 方案 B：直接删多余的 network
-anet network ls           # 看哪些可删
-anet network delete <old-net> --force
-```
-
-::: tip 为什么 `users.plan='admin'` 不够
-[`auth.ts:185`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L185) 实际 check 的是 `users.role === 'admin'`，不是 `users.plan`。直接 SQL `UPDATE users SET plan = 'admin'` 不生效；要走 `role` 列才有效（跟 audit log action `password_reset_by_admin` 等 system-admin gate 同款）。
-:::
-
----
-
-## Agent Node 错误
-
-### `Node "代码1号" already exists` -- alias 本地冲突（`anet node create`）
-
-```
-Node "代码1号" already exists: .anet/nodes/代码1号/config.json
-```
-
-verify [`agent-network/bin/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) + [`agent-network/bin/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)：`anet node create` 在交互式 / 非交互式两条路径都用 `resolveNodeRef(id)` 检查本地 `.anet/nodes/<alias>/config.json` 是否已存在；命中就直接 `process.exit(1)` 不连 hub。
-
-**原因**：当前项目目录 `.anet/nodes/` 下已有同名 node config 子目录。这是**本地文件冲突**，跟 hub 端 session 状态无关。
-
-**解决**：
-
-```bash
-# 看本地哪些 node 已注册（按 .anet/nodes/ 目录扫）
-anet node ls
-
-# 方案 A：换名
-anet node create 代码1号-v2
-
-# 方案 B：删旧的再用同名（delete 必须加 --force，否则只打印确认提示不实际删除）
-anet node delete 代码1号 --force
-anet node create 代码1号
-```
-
-::: warning hub 端 alias 冲突是「静默接管」不报错
-跟很多人想的不一样，hub server **没有** 「`alias is already taken`」错。如果你在不同机器 / 不同项目 dir 用同一个 alias 跑两个 agent（两条不同 `resume_id`），后启动那条 `report_status` 时会触发 [`server/src/tools.ts:127 DELETE FROM sessions WHERE alias = ?1 AND resume_id != ?2 AND network_id = ?3`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L127) **静默把旧 session 清掉**。旧 agent SSE 连接还在但不再收任务派发，dashboard 里旧那行直接消失。
-
-**所以**：不要把「dashboard 看不到我的 agent」归因为「alias 冲突报错」—— 没有这个错，先排查同 alias 多机重复 start（用 `anet status` 看 `resume_id` 看版本是哪台机器）。
-:::
-
----
-
-### `settingSources` 相关错误
-
-```
-TypeError: Cannot read properties of undefined (reading 'settingSources')
-```
-
-**原因**：Claude Agent SDK 版本不兼容。
-
-**解决**：
-
-```bash
-# 升级 agent-node
-npm install -g @sleep2agi/agent-node@latest
-```
-
----
-
-### `ANTHROPIC_BASE_URL` 连接失败
-
-```
-Error: Failed to connect to api.minimaxi.com
-```
-
-**原因**：MiniMax / 其他兼容 API 地址不正确或网络不通。
-
-**解决**：
-
-```bash
-# 检查 API 地址
-echo $ANTHROPIC_BASE_URL
-
-# 测试连通性
-curl -I $ANTHROPIC_BASE_URL
-
-# 确认 API Key 有效
-curl -H "Authorization: Bearer $ANTHROPIC_AUTH_TOKEN" \
-  $ANTHROPIC_BASE_URL/v1/messages \
-  -H "Content-Type: application/json" \
-  -d '{"model":"<minimax-model-id>","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
-# 把 <minimax-model-id> 替换为你 MiniMax 账号当前可用 model id（查 https://platform.minimaxi.com）
-```
-
-### Vendor API auth 失败（401 / `invalid_api_key` / `expired_token` / intern `A02xx` / `user_token_expired`）
-
-agent 日志里出现：
-
-```
-[claude] ✗ FATAL: vendor API auth failed (...)
-[anet] FATAL: Vendor API auth failed — ...
-[anet]        → Refresh INTERN_S1_API_KEY at https://chat.intern-ai.org.cn and re-export it
-```
-
-**原因**：上游 vendor LLM API 返回 auth-class 错误（401/403、`invalid_api_key`、`authentication_error`、intern `A02xx` 系列码、OpenAI-compat `expired_token` / `unauthorized` 等）。
-
-**v0.9.2 起 fast-fail 行为**（[#129](https://github.com/sleep2agi/agent-network/issues/129)，verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)）：
-- agent-node 用 `isAuthError(msg)` 启发式（正则：`(401|403)\b|invalid[_\s]?api[_\s]?key|authentication[_\s]?error|expired[_\s]?token|unauthor(iz|is)ed|A02\d{2}|user[_\s]?token[_\s]?expired`）检测到 auth 错误
-- **短路 retry loop**（避免拿同一个坏 key 浪费 backoff window）—— v0.9.1 之前会跑满 3 attempts × 5min 一共 15min 才报错，v0.9.2 起 **<5s** 就 FATAL 返回
-- 按 `ANTHROPIC_BASE_URL` 域名匹配出 **vendor-specific remediation hint**：
-  - `intern-ai.org.cn` → `https://chat.intern-ai.org.cn`
-  - `minimax` → `https://platform.minimaxi.com`
-  - `anthropic` → `https://console.anthropic.com/settings/keys`
-  - 其他 → generic「Refresh your vendor API key and re-export the ENV var」
-
-**解决**（按 vendor 看 log 里的 URL，然后）：
-
-```bash
-# 1. 去 vendor 平台拿新 API key（log 里有 URL）
-
-# 2. 更新 ENV var
-export ANTHROPIC_AUTH_TOKEN='<新 key>'
-
-# 3. 重启 agent 让新值生效（agent-node 在启动时读 process.env，不热加载）
-anet node stop <alias>
-anet node start <alias>
-
-# 4. 如果用 envRef 模式 (推荐, 见 /concepts/security#vendor-凭据存储-envref-模式-v0-9-0):
-#    config.json 不动 (它存的是 env var 名), 只需要把新值 export 到 process.env 再重启 agent
-```
-
-### Vendor API 超时（fan-out 高并发，#132 retry-with-backoff）
-
-agent 日志里出现：
-
-```
-[claude] attempt 1/3 timed out after 300000ms; retry in 4000ms
-[claude] attempt 2/3 errored: ...; retry in 8000ms
-[claude] ✗ all 3 attempts failed; last: timed out after 300000ms
-```
-
-或最终：
-
-```
-执行出错: claude-agent-sdk 调用超时 (300s × 3 attempts) — vendor 长时间未响应, 检查 ANTHROPIC_BASE_URL endpoint 或 vendor 负载
-```
-
-**原因**：fan-out 高并发场景下（如 [#132 Tier 1](https://github.com/sleep2agi/agent-network/issues/132) 的 30-agent papercope demo），vendor API 单次 latency 从基线 1.57s 拉到 17-37s，请求在 vendor 队列里堆积。
-
-**v0.9.2 起 retry-with-backoff** 行为（verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)）：
-- 每次 attempt 独立的 abort controller + timeout window（default `CLAUDE_TIMEOUT_MS=300000` 即 300s，[#132 ship](https://github.com/sleep2agi/agent-network/issues/132)）
-- transient error / timeout 时 backoff `4s, 8s` + 0-1s jitter（jitter 散开 herd retries 避免一窝蜂打 vendor queue）
-- 默认 `CLAUDE_MAX_RETRIES=2`（共 3 attempts 含 initial）—— 设 `0` 退回 v0.9.1 行为（no retry）
-- **auth-class 错误不 retry**（fast-fail 见上方）
-
-**调参**：
-
-```bash
-# config.json 字段
-{
-  "flags": {
-    "claudeTimeoutMs": 600000,   // 单次超时拉到 600s
-    "claudeMaxRetries": 5        // 重试 5 次（最多 6 attempts）
-  }
-}
-
-# 或者 ENV
-CLAUDE_TIMEOUT_MS=600000 CLAUDE_MAX_RETRIES=5 anet node start <alias>
-```
-
-仍然 timeout 的话，根本原因常是 vendor 容量不足 → 横向 sharding 到多个 vendor + 错峰（`--stagger` per `anet project up`，[#117](https://github.com/sleep2agi/agent-network/issues/117)）。
-
-### `codex-direct-stdio` opt-in 路径错误（v0.10.0+，仅 `ANET_CODEX_STDIO_DIRECT=1` 时触发）
-
-v0.10.0 [#141](https://github.com/sleep2agi/agent-network/issues/141) 引入的 codex direct stdio JSON-RPC 客户端路径绕开 `@openai/codex-sdk` wrapper —— 错误 surface 更直接（不经 wrapper buffer），但意味着你直接面对 `codex` 二进制 + `codex app-server` 协议。
-
-**1. `Error: spawn codex ENOENT`（启用 opt-in 后立即失败）**
-
-agent-node 找不到 `codex` 二进制 ——「opt-in 路径」**直 spawn**，没有 `@openai/codex-sdk` 兜底。
-
-```bash
-# 检查
-which codex
-# 若空：装一遍
-npm install -g @openai/codex
-
-# 或者 npm 全局 bin 不在 PATH 上 —— 参见 runtimes / codex-sdk § 前置 PATH 修复
-```
-
-退一步用默认 wrapper 路径（取消 env）：
-
-```bash
-unset ANET_CODEX_STDIO_DIRECT
-anet node start <codex-node>
-```
-
-**2. `codex app-server` 子命令不存在 / `unknown subcommand: app-server`**
-
-`codex app-server` 在老版本 codex CLI 上没有（[#141](https://github.com/sleep2agi/agent-network/issues/141) 验证基线 `codex 0.130.0+`）。升级：
-
-```bash
-npm install -g @openai/codex@latest
-codex --version  # 期望 ≥ 0.130.0
-codex app-server --help  # 应能 print subcommand help, 不报 "unknown subcommand"
-```
-
-升不动就回 wrapper：`unset ANET_CODEX_STDIO_DIRECT`。
-
-**3. `JSON-RPC parse error` / `-32600` invalid request**
-
-stdio 协议 mismatch —— 一般来自 codex CLI 比 anet 期望版本旧 / 新（experimental 状态下协议可能 breaking）。复现 + 修：
-
-```bash
-# 看协议握手
-ANET_CODEX_STDIO_DIRECT=1 LOG_LEVEL=debug anet node start <codex-node> 2>&1 | grep -iE "initialize|protocolVersion|error"
-
-# 若发现 protocolVersion mismatch
-npm install -g @openai/codex@latest
-
-# 临时回退用 wrapper：
-unset ANET_CODEX_STDIO_DIRECT
-```
-
-如果 codex CLI 已经 latest 仍报错，开 issue 带这段 debug 输出 + `codex --version` —— [#141](https://github.com/sleep2agi/agent-network/issues/141) 仍在 preview-feedback 窗口（v0.11.0 计划 default flip），protocol breaking 是已知 risk + mitigation 方向。
-
-### Dashboard agent hover card `process_telemetry` 字段全 `null`（v0.10.0 起 ship，dashboard 0.5.0+）
-
-dashboard `≥ 0.5.0` 的 §3.E hover detail card 期望 agent-node `≥ 2.4.0`（[#142](https://github.com/sleep2agi/agent-network/issues/142) v0.10.0 ship 起 agent 心跳带 `process_telemetry`）+ commhub-server `≥ 0.8.2`（schema align）。三种可能：
-
-- **agent-node 老于 2.4.0**：跑 `anet upgrade` 升级到当前 latest（满足 ≥ 2.4.0 最低要求即可）
-- **commhub-server 老于 0.8.2**：升级 server 端（`bunx @sleep2agi/commhub-server@latest`）
-- **agent 短期还没心跳**：`process_telemetry` 跟普通 host telemetry 一样需要至少 1 次心跳；新启动节点等 ~15s
-
-verify 真实数据流：
-
-```bash
-curl http://localhost:9200/api/server/<host>/agents \
-  -H "Authorization: Bearer ntok_xxx" | jq '.agents[0].process_telemetry'
-# 期望非 null 的 rss_bytes / cpu_pct / uptime_seconds / in_flight_count
-```
-
-### `grok-build-acp` 节点任务挂死 / `session/prompt timed out after 300000ms` / JSON-RPC error 32603
-
-**症状**：用 `grok-build-acp` runtime 创建的节点，CommHub 给它派一个稍长一点（> 5min）的任务，节点不报错也不回复，pane 卡在 `session/prompt` 调用上；agent-node 日志里能看到 `session/prompt timed out after 300000ms` 或 ACP server 回了 JSON-RPC `code: 32603`。
-
-**根因**：agent-node 2.4.8 及以下对 ACP `session/prompt` 写死了 300 s 超时（沿用 codex-sdk wrapper 的旧值），但 grok-build-acp 后端是用户级长任务为主，5 min 是常态偏短。
-
-**修复**：跑 `anet upgrade` 升到当前 latest（该 hotfix 自 `agent-node 2.4.9` / v0.10.13 起，之后版本都带）— 把 `session/prompt` 的 client-side 超时拉宽到 grok 后端的实际工作窗口，本机活体节点 47s / 5min / >10min 的任务都能正常完成。
-
-```bash
-# 1. 升级
-anet upgrade            # 一键
-# 或：npm install -g @sleep2agi/agent-node@latest
-
-# 2. 重启 grok 节点
-anet node stop grok-marketing && anet node start grok-marketing
-
-# 3. 验证
-anet --version          # agent-node ≥ 2.4.9
-```
-
-**真长任务仍超时（视频生成 / 大型 X 搜索）**：当前 latest 的 300 s 默认上限对一些视频或大批量场景仍偏短。用 `flags.grokAcpTimeoutMs`（config）或 `GROK_ACP_TIMEOUT_MS`（env，优先）调大：
-
-```bash
-# 临时（启 grok 节点前 export）
-GROK_ACP_TIMEOUT_MS=900000 anet node start my-grok
-```
-
-```json
-// 长期（写进 .anet/nodes/<alias>/config.json）
-{
-  "runtime": "grok-build-acp",
-  "flags": { "grokAcpTimeoutMs": 900000 }
-}
-```
-
-完整说明见 [runtimes → 长任务超时调整](/guide/runtimes#长任务超时调整-flags-grokacptimeoutms)。
-
-::: warning startup log 以当前 latest 为准
-旧版本 agent-node 启动日志**不打** `timeoutMs=<新值>` —— 值会读到但 `anet node start` 输出不一定反映。如果设了仍超时，多半是 config 写错位置或 env 字段名 typo；请先升级到 npm `latest`，再 [开 issue](https://github.com/sleep2agi/agent-network/issues/new) 上报。
-:::
-
-**仍卡死**，先排除：grok backend 端 quota 用尽（grok 自己的 `~/.config/grok-build/` log 会有提示）/ 节点 cwd 不在 user workspace 边界内（[#204](https://github.com/sleep2agi/agent-network/issues/204) isolated cwd 边界）/ `grok login` 凭据过期。
-
-### 服务器负载异常 / claude session 越开越卡 / 一堆 zombie bun 占满 CPU
-
-**症状**：服务器（hub 所在机）load average 持续偏高（>10×CPU 核心数），开新 claude / agent session 越来越慢、CommHub MCP 调用偶发超时。`top` 里看到一堆 `bun ... server.ts` 进程一直在跑，看起来"什么也没干"。
-
-**根因**：插件目录 / agent workdir 被改名或删除后，老的 `bun` 子进程仍然死握着已经 `deleted` 状态的 cwd，每开一个新 session 就再 fork 一个 zombie。累积起来吃满 CPU。**生产实测**：86 个 zombie bun，load 92。
-
-**检测**（一行命令）：
-
-```bash
-for pid in $(pgrep -f "bun.*server.ts"); do readlink /proc/$pid/cwd; done | grep deleted | wc -l
-```
-
-输出 `>5` 就明显异常。看到具体哪些 PID：
-
-```bash
-for pid in $(pgrep -f "bun.*server.ts"); do
-  cwd=$(readlink /proc/$pid/cwd 2>/dev/null)
-  [[ "$cwd" == *deleted* ]] && echo "PID $pid → $cwd"
-done
-```
-
-**解法**：
-
-```bash
-# 杀掉所有 cwd 指向 deleted 目录的 bun 进程
-for pid in $(pgrep -f "bun.*server.ts"); do
-  cwd=$(readlink /proc/$pid/cwd 2>/dev/null)
-  [[ "$cwd" == *deleted* ]] && kill -9 $pid
-done
-
-# 或直接全部 pgrep + kill（确保你知道在杀什么）
-pkill -9 -f "bun.*server.ts"
-```
-
-之后重启所需的 agent / hub 进程即可。
-
-**预防**：改 / 删插件目录或 agent workdir 之前，**先**把对应的 `bun` 子进程 kill 掉（`anet node stop <name>` 或手动 `kill`），再动目录。
-
----
-
-## Docker 错误
-
-### `service "seed" is not running`
-
-Seed 容器是一次性的，执行完就退出（exit code 0），这是正常的。
-
-```bash
-# 检查是否成功
-docker compose logs seed
-# 应该看到: seed: wrote ntok_ to /shared/ntok
-```
-
----
-
-### Worker 容器反复重启
-
-```bash
-# 查看日志找原因
-docker compose logs worker-1
-
-# 常见原因：
-# 1. Server 还没启动（健康检查未通过）
-# 2. ntok_ 不存在（seed 失败）
-# 3. Codex 认证缺失（~/.codex 未挂载）
-```
-
----
-
-### `permission denied` in Docker
-
-```
-Error: EACCES: permission denied, mkdir '/root/.claude'
-```
-
-**解决**：确保 tmpfs 挂载了 `.claude` 目录：
-
-```yaml
-tmpfs:
-  - /root/.claude
-  - /tmp
-```
-
----
-
-## 诊断工具
-
-### anet doctor
-
-全面检查系统状态：
+在出问题的机器和项目目录运行：
 
 ```bash
 anet doctor
+anet hub status
+anet whoami
+anet status
+anet node ls
+anet info <alias>
+anet logs <alias> --follow
 ```
 
-检查项：全局配置 + auth token、hub 连通性（版本 / sessions / SSE）、每个节点配置健康度（旧字段给 `--fix` 迁移提示）、明文密钥卫生（[#125](https://github.com/sleep2agi/agent-network/issues/125)）、必需 CLI（Claude Code / Codex / Bun）。加 `--fix` 自动迁移可修的节点配置 + 重发被 hub 拒的 `ntok_`。
+`doctor` 会检查配置、Hub 连通性、节点身份和本机依赖。不要一上来运行 `doctor --fix`；先读清它准备修改的项目，再备份相关配置。
 
-### 手动检查清单
+公开日志前删除 token、API key、密码、Cookie、完整环境变量和私有 Hub 地址。不要把 `~/.anet`、`.anet/nodes/*/config.json` 或 `.env` 整份上传。
+
+## 安装和启动
+
+### `spawn bunx ENOENT` / 找不到 Bun
+
+Agent Network CLI 需要 Node.js ≥ 22.13，Hub 需要 Bun ≥ 1.2：
 
 ```bash
-# 1. Server 健康（含 SSE 连接数 + sessions / license / uptime，无需 auth）
-curl http://localhost:9200/health
-# 关注字段: ok / version / sessions_count / sse_connections / sse_sessions / uptime
-# verify: the `GET /health` handler in index.ts
-
-# 2. 认证有效 + 看所有 session 状态汇总
-curl -H "Authorization: Bearer ntok_xxx" http://localhost:9200/api/status
-# 返回 sessions[] 全列 + summary { idle, working, offline, total }
-# ⚠ status query param 不生效 — server 端不按 status 过滤（the `GET /api/tasks` handler in index.ts）。
-#   要筛 idle agent，本地用 jq： curl ... /api/status | jq '.sessions[] | select(.status=="idle")'
-
-# 3. 数据库大小
-ls -lh ~/.commhub/commhub.db
-
-# 4. 任务 / 节点 / session 统计（非 SSE 连接数）
-curl -H "Authorization: Bearer ntok_xxx" http://localhost:9200/api/stats
-# 返回 tasks { total, by_status } / sessions { by_status } / nodes { total } / recent_tasks[5]
-# verify: server/src/index.ts:1022-1058
+node --version
+bun --version
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
 ```
 
-::: tip 全 30+ endpoint 索引
-跳 [REST API → 基础信息表](/api/rest) 看完整 endpoint 分类（11 类含 SSE / Tmux opt-in / Legacy 等）。
-:::
+若刚安装仍找不到命令，重新打开 shell 并检查 `PATH`。全局 npm 安装报 `EACCES` 时，优先用 nvm/fnm 管理 Node，不要用 `sudo npm` 或放宽系统目录权限。
 
-### 日志级别
-
-Agent Node 支持调整日志级别（**top-level 字段，不在 `flags` 里**）：
-
-```json
-// config.json (.anet/nodes/<alias>/config.json)
-{
-  "logLevel": "debug"   // debug / info / warn / error
-}
-```
-
-verify [`agent-node/src/cli.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)：`LOG_LEVEL` 从 `opts["log-level"] || process.env.LOG_LEVEL || fileConfig.logLevel || "info"` 取，**只认 top-level `logLevel`**，写在 `flags.logLevel` 不生效。
-
-也可以走环境变量或命令行：
+### `agent-node is not installed` / 版本检查失败
 
 ```bash
-LOG_LEVEL=debug anet node start <alias>
-# 或
-anet node start <alias> --log-level debug
+agent-node --version
+anet upgrade --dry-run
+npm install -g @sleep2agi/agent-node
 ```
 
-## 还有问题？
+按当前发布频道升级，不要从旧文档复制固定 preview 或 package 版本。升级策略见[版本说明](/guide/versioning)和[升级指南](/guide/upgrade)。
 
-**先试这几个 v0.8 自动修复工具**：
+### 端口被占用或 Hub 立即退出
 
-- `anet doctor` — 探测当前 hub / token / network 状态，问题分级输出
-- `anet doctor --fix` — 自动 probe 过期 ntok_ 并重发；agent-node SSE 401 自动 reload
-- `anet hub admin reset-user <username>` — 本机 owner 在 Hub 机器强制重置用户密码（忘密码场景）
-- `anet passwd` — 交互改密码
+```bash
+anet hub status
+curl http://127.0.0.1:9200/health
+lsof -iTCP:9200 -sTCP:LISTEN
+```
 
-**还不行**：
+先确认占用端口的是不是已有 Hub。由 anet 启动的实例用 `anet hub stop` 停止；不要按进程名批量 kill。需要换端口时，Hub、CLI 和节点配置必须同时指向新地址。
 
-- **GitHub Issues**：[github.com/sleep2agi/agent-network/issues](https://github.com/sleep2agi/agent-network/issues) — 报 bug 或搜已知问题
-- **GitHub Discussions**：[discussions](https://github.com/sleep2agi/agent-network/discussions) — 使用问题 / 设计讨论
-- **查看源码**：所有错误消息可以在 `server/src/tools.ts` 和 `server/src/auth.ts` 中找到
-- **FAQ**：[常见问题](/faq) — 模型选择 / 费用 / 升级注意
+## Hub 和网络连接
 
-## 下一步
+### `ECONNREFUSED`
 
-- [升级到 v0.8](/guide/upgrade#v0-7-v0-8-升级注意-最新) — 老用户升级路径 + 行为变化
-- [安全设计](/concepts/security) — 排查鉴权问题前看一遍
-- [架构概览](/guide/architecture) — 出问题时定位是哪一层
-- [社区](/community) — 加群和讨论
+本机先验证：
+
+```bash
+curl http://127.0.0.1:9200/health
+anet hub status
+```
+
+远端节点再验证它实际配置的 Hub URL：
+
+```bash
+curl http://HUB_HOST:9200/health
+```
+
+本机通、远端不通，通常是 Hub 只监听 loopback、防火墙/安全组未放行，或 URL/端口写错。跨机器部署需让 Hub 监听可达地址，并用 TLS 反向代理保护公网入口。
+
+### `ETIMEDOUT` / DNS / TLS 错误
+
+从节点机器检查解析、路由、证书和代理，而不是只在 Hub 主机测试。若使用域名，确认它没有指向旧主机；若使用 HTTPS，确认反向代理能访问后端 `/health`。
+
+### `SSE connection failed` / 反复重连
+
+先确认普通健康请求和登录都正常，再看节点日志。SSE 需要长连接；Nginx/Caddy/负载均衡器不得缓冲响应，也不能使用过短的空闲超时。配置示例见[生产部署](/deploy/production)。
+
+日志出现 `SSE connected` 才表示任务推送链路已建立。短暂断线会自动退避重连；持续失败时不要靠反复重启掩盖代理或身份错误。
+
+## 登录、token 和 network
+
+### `No hub configured`
+
+```bash
+anet init --hub http://HUB_HOST:9200
+anet login
+```
+
+`~/.anet/config.json` 中保存当前 Hub、用户 token 和 network。不要手工拼接或从另一台机器复制 token。
+
+### 401 `invalid token` / `auth required`
+
+```bash
+anet whoami
+anet login
+anet doctor
+```
+
+Hub 数据库重建、token 被撤销或登录切到另一台 Hub 后，旧 token 都会失效。重新登录后再检查节点；节点必须使用自己的 `ntok_`，不要把用户 `utok_` 填进节点配置。
+
+若节点配置是旧格式或 token 已失效，先备份 `.anet/nodes/<alias>/config.json`，再根据 `anet doctor` 的输出决定是否运行：
+
+```bash
+anet doctor --fix
+```
+
+### 忘记密码
+
+在 Hub 主机上运行：
+
+```bash
+anet hub admin reset-user --username <username>
+```
+
+它会生成新密码和用户 token，并撤销旧用户 token。不要直接删除 `users`、token 行或 bootstrap marker；这些做法会绕过审计并破坏关联状态。
+
+### `network_id_required` / `access_denied` / `permission_denied`
+
+- `network_id_required`：调用者没有唯一可推断的 network。登录/切换到正确 network，或在支持的调用中显式传 `network_id`。
+- `access_denied` / `permission_denied`：身份已解析，但角色无权执行该操作。由 network owner 调整成员角色；全局 admin 不自动成为每个 network 的 owner。
+- Agent Node 使用绑定到单一 network 的 `ntok_`；不要跨 network 复用节点 token。
+
+完整权限边界见 [Token 与权限](/concepts/tokens)、[角色](/concepts/roles)和 [Network](/concepts/networks)。
+
+### 其它认证/network 报错
+
+| 报错 | 安全处理 |
+|---|---|
+| `password must be at least 8 characters` / `too common` | 使用至少 8 位且不在弱密码表中的新密码 |
+| 429 / `too many attempts` | 停止重试，等待响应指示的窗口后再试；先修正凭据，避免继续触发限流 |
+| `network name already exists` | 查看当前 network，换一个名称；不要直接改数据库 |
+| `network has N active session(s)` | 用 `anet status` 找出节点，正常停止后再删除 network |
+| `quota exceeded` | 用 `anet network ls` 检查并删除不再使用的 network。目前没有公开 CLI 可修改用户 plan/全局角色；联系 Hub 运维，不要把用户直接改成全局 admin |
+| `license_expired` | 运行 `anet license` 并升级后仍出现时，联系 Hub 运维。目前没有安全的公开 CLI 可清理 legacy 行；停止 Hub、备份数据库并提交脱敏诊断，不要在线删除 `licenses` 行 |
+
+## Agent Node
+
+### 节点一直 offline / 收不到任务
+
+依次确认：
+
+1. 节点机器能访问 Hub `/health`。
+2. `anet whoami` 指向预期 Hub/network。
+3. `anet info <alias>` 的 runtime、工作目录和身份正确。
+4. `anet logs <alias> --follow` 最终出现 `SSE connected`。
+5. 没有另一个进程使用同一 alias、`node_id` 或 `ntok_`。
+
+安全重启单个节点：
+
+```bash
+anet node stop <alias>
+anet node start <alias>
+```
+
+不要复制节点 `config.json` 到另一台机器。目标机器应重新登录并运行 `anet node create`，让 Hub 签发独立身份。
+
+### 重复结果 / runtime 来回变化 / `alias_identity_mismatch`
+
+这通常意味着同一身份被多个进程或旧配置使用：
+
+```bash
+anet info <alias>
+anet logs <alias> --follow
+tmux ls
+```
+
+停止旧实例，只保留一个进程。不要通过改 `node_id`、alias、token 或直接编辑 Hub 数据库“抢回”身份；改名用 `anet node rename`。
+
+`Node "<alias>" already exists` 通常只是当前项目的 `.anet/nodes/` 已有同名配置。先用 `anet node ls` / `anet info <alias>` 确认是否应复用，不要为了重建而直接删目录。
+
+### 工作目录不对
+
+文件工具使用节点的启动目录。停止节点，切到正确项目目录再启动。Codex TUI 共存时，线程目录继承自 app-server 进程；请按 [Codex TUI 共存指南](/guide/codex-copresence)检查整组会话，不要只看桥进程。
+
+## Runtime 和模型
+
+先确认节点选中的 runtime 与已安装发布频道一致：
+
+```bash
+anet info <alias>
+anet logs <alias> --follow
+anet upgrade --dry-run
+```
+
+| 现象 | 检查 |
+|---|---|
+| Claude/Codex 命令找不到 | 对应 CLI 是否安装、在节点进程的 `PATH` 中、已完成登录 |
+| Vendor 401/403 | API key、envRef 指向的变量、`ANTHROPIC_BASE_URL` 是否匹配同一服务 |
+| Vendor 超时/限流 | 服务状态、账户配额、节点并发；不要靠无限重试消耗额度 |
+| Grok ACP 长任务超时 | 按 runtime 指南核 `flags.grokAcpTimeoutMs` / `GROK_ACP_TIMEOUT_MS` |
+| Codex 共存恢复后变成普通节点 | 必须继续用 `anet node start <alias> --copresence`，不要改用普通 start |
+
+OpenCode 当前是任务 runtime，不是共享 TUI；Grok 共享 TUI 尚未发布。以 [Runtime 对比](/guide/runtimes)为准，不要照旧版本或 changelog 历史命令操作。
+
+## 任务和消息
+
+### 任务没有触发模型
+
+需要执行的工作必须用 `send_task`。`send_reply` 是任务结果，`send_message` 是普通消息，两者都不会再次触发模型。
+
+```bash
+anet status
+```
+
+确认目标节点在线、任务属于当前 network，且目标 alias 正确。任务状态、重试和父子任务语义见[任务生命周期](/concepts/task-lifecycle)。
+
+### `task not found` / `message not found`
+
+常见原因是当前 token/network 与对象不一致，或者该对象不属于当前节点。先运行 `anet whoami` 和 `anet status`；不要通过直接查改 SQLite 绕过 network 隔离。
+
+### 定时任务没有运行
+
+```bash
+anet goal list <alias>
+anet info <alias>
+```
+
+循环任务要求节点在线，并会消耗真实模型额度。它不是高精度 cron；先用较长周期验证。
+
+## Channel
+
+```bash
+anet channel status <alias>
+anet logs <alias> --follow
+```
+
+检查 bot token、pairing/allowlist、目标节点和 channel runtime 是否一致。Telegram 使用长轮询；反向代理 webhook 设置与它无关。当前支持范围和重启要求见 [Channel 指南](/guide/channels)。
+
+## Docker
+
+```bash
+docker compose ps
+docker compose logs --tail=200 <service>
+```
+
+检查 Hub 健康检查、持久卷、容器内 Hub URL、token 文件和模型凭据挂载。容器内的 `localhost` 指向容器自身，不是宿主机。
+
+不要用 `docker system prune`、`docker image prune -a` 或宽泛名称匹配清理共享宿主机；先逐个确认容器和精确镜像引用。
+
+## 仍未解决
+
+提交 Issue 时附：
+
+- `anet -v`、Node/Bun 版本和发布频道
+- runtime、操作系统、部署方式
+- 最小复现步骤和实际报错
+- 已脱敏的 `anet doctor`、`anet info` 与相关日志片段
+
+先搜索 [Issues](https://github.com/sleep2agi/agent-network/issues)；安全问题请使用 [GitHub Security Advisory](https://github.com/sleep2agi/agent-network/security/advisories/new)，不要公开漏洞或凭据。

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -132,6 +132,9 @@ anet hub admin reset-user --username <username>
 
 ### 其它认证/network 报错
 
+<a id="quota-exceeded-max-n-networks-for-free-plan"></a>
+<a id="license-expired-授权过期-legacy-行为"></a>
+
 | 报错 | 安全处理 |
 |---|---|
 | `password must be at least 8 characters` / `too common` | 使用至少 8 位且不在弱密码表中的新密码 |
@@ -140,6 +143,8 @@ anet hub admin reset-user --username <username>
 | `network has N active session(s)` | 用 `anet status` 找出节点，正常停止后再删除 network |
 | `quota exceeded` | 用 `anet network ls` 检查并删除不再使用的 network。目前没有公开 CLI 可修改用户 plan/全局角色；联系 Hub 运维，不要把用户直接改成全局 admin |
 | `license_expired` | 运行 `anet license` 并升级后仍出现时，联系 Hub 运维。目前没有安全的公开 CLI 可清理 legacy 行；停止 Hub、备份数据库并提交脱敏诊断，不要在线删除 `licenses` 行 |
+
+直接写数据库会绕过 API 的鉴权、审计和一致性检查，并可能损坏关联的许可或身份状态，所以这里不提供 SQL“修复”。
 
 ## Agent Node
 
@@ -179,6 +184,10 @@ tmux ls
 ### 工作目录不对
 
 文件工具使用节点的启动目录。停止节点，切到正确项目目录再启动。Codex TUI 共存时，线程目录继承自 app-server 进程；请按 [Codex TUI 共存指南](/guide/codex-copresence)检查整组会话，不要只看桥进程。
+
+<a id="vendor-api-auth-失败-401-invalid-api-key-expired-token-intern-a02xx-user-token-expired"></a>
+<a id="vendor-api-超时-fan-out-高并发-132-retry-with-backoff"></a>
+<a id="grok-build-acp-节点任务挂死-session-prompt-timed-out-after-300000ms-json-rpc-error-32603"></a>
 
 ## Runtime 和模型
 

--- a/docs/tests/report-troubleshooting-simplification-2026-07-31.txt
+++ b/docs/tests/report-troubleshooting-simplification-2026-07-31.txt
@@ -7,8 +7,8 @@ Scope
 
 Outcome
 -------
-- Chinese guide: 967 -> 257 lines.
-- English guide: 969 -> 257 lines.
+- Chinese guide: 967 -> 266 lines.
+- English guide: 969 -> 266 lines.
 - Reorganized diagnosis by dependency layer: environment, Hub, auth/network,
   node, runtime, task, channel, and Docker.
 - Removed release-history narration, fixed preview/package versions, obsolete
@@ -21,11 +21,15 @@ Outcome
 - Verified that the current CLI can list network members but cannot change a
   user's global role/plan. The guide therefore does not invent a replacement
   command for the removed privilege-escalation SQL.
+- Preserved all ten repository-referenced legacy fragments for quota, license,
+  vendor auth/timeout, and Grok timeout troubleshooting.
+- Explained why direct SQL is not a supported fallback: it bypasses API auth,
+  auditing, and consistency checks and can corrupt related state.
 
 Static/source gates
 -------------------
 PASS  git diff --check
-PASS  both guides are 257 lines and have 27 matching section headings
+PASS  both guides are 266 lines and have 27 matching section headings
 PASS  all internal Markdown targets exist
 PASS  balanced fenced code blocks
 PASS  stale/dangerous phrase scan: no v0.x/preview-number instructions,
@@ -37,10 +41,12 @@ PASS  CLI/source inspection confirms no public global role/plan mutation command
 PASS  package engines confirm Node >=22.13.0 and Bun >=1.2.0
 PASS  agent-node source confirms the `SSE connected` readiness signal
 PASS  server source confirms license_expired remains a possible legacy error
+PASS  VitePress 1.6.4 Docker build on origin/main baseline and this candidate
+PASS  every repository inbound troubleshooting fragment appears as an exact id
+      in VitePress-rendered Chinese and English HTML
 
 Test policy
 -----------
-Documentation-only change. No Docker image, Hub, model runtime, npm package,
-production process, database, or user configuration was changed. The user asked
-to conserve Codex/Claude quota, so verification was limited to source and static
-checks appropriate to the prose-only scope.
+Documentation-only change. A disposable Docker image ran VitePress only; no Hub,
+model runtime, npm publish, production process, database, or user configuration
+was touched. This did not consume Codex or Claude quota.

--- a/docs/tests/report-troubleshooting-simplification-2026-07-31.txt
+++ b/docs/tests/report-troubleshooting-simplification-2026-07-31.txt
@@ -1,0 +1,46 @@
+Troubleshooting guide simplification report — 2026-07-31
+
+Scope
+-----
+- docs-site/docs/troubleshooting.md
+- docs-site/docs/en/troubleshooting.md
+
+Outcome
+-------
+- Chinese guide: 967 -> 257 lines.
+- English guide: 969 -> 257 lines.
+- Reorganized diagnosis by dependency layer: environment, Hub, auth/network,
+  node, runtime, task, channel, and Docker.
+- Removed release-history narration, fixed preview/package versions, obsolete
+  roadmap claims, stale source line references, and duplicated API internals.
+- Removed unsafe recovery recipes that directly mutated SQLite rows, deleted
+  bootstrap markers, recursively wiped state, or broadly killed processes.
+- Preserved current error breadcrumbs such as license_expired, rate limits,
+  network quota/active-session errors, alias identity conflicts, and runtime
+  timeout symptoms, with safe recovery or canonical links.
+- Verified that the current CLI can list network members but cannot change a
+  user's global role/plan. The guide therefore does not invent a replacement
+  command for the removed privilege-escalation SQL.
+
+Static/source gates
+-------------------
+PASS  git diff --check
+PASS  both guides are 257 lines and have 27 matching section headings
+PASS  all internal Markdown targets exist
+PASS  balanced fenced code blocks
+PASS  stale/dangerous phrase scan: no v0.x/preview-number instructions,
+      ANET_CODEX_STDIO_DIRECT, direct DELETE/UPDATE SQL, recursive state wipe,
+      fixed bootstrap password, unpublished grok-build-cli, or fixed OpenCode pin
+PASS  documented CLI commands exist in agent-network/bin/cli.ts
+PASS  CLI/source inspection confirms no public global role/plan mutation command;
+      owner-only network member role changes exist only on the scoped REST route
+PASS  package engines confirm Node >=22.13.0 and Bun >=1.2.0
+PASS  agent-node source confirms the `SSE connected` readiness signal
+PASS  server source confirms license_expired remains a possible legacy error
+
+Test policy
+-----------
+Documentation-only change. No Docker image, Hub, model runtime, npm package,
+production process, database, or user configuration was changed. The user asked
+to conserve Codex/Claude quota, so verification was limited to source and static
+checks appropriate to the prose-only scope.


### PR DESCRIPTION
## What changed

- reduce the Chinese and English troubleshooting pages from 967/969 lines to 257 lines each
- organize diagnosis by dependency layer: environment, Hub, authentication/network, node, runtime, task, channel, and Docker
- retain current error breadcrumbs and link detailed behavior to canonical guides
- remove fixed preview/package history, stale roadmaps, obsolete source line references, and duplicate API internals
- remove direct SQLite privilege escalation/license deletion, bootstrap-marker deletion, recursive state wipe, and broad process/image cleanup recipes

## Why

The old pages mixed historical implementation notes with current operator guidance. Two public recipes directly modified Hub security data: one deleted license rows and one promoted a user to global admin in SQLite, bypassing permission checks and audit logging.

The current CLI has no public command for mutating a user global role/plan. The replacement therefore says so explicitly instead of inventing a command: operators should remove unused networks or handle policy through the Hub operator. The legacy license error likewise gets an upgrade/backup/operator path without online SQL mutation.

## User impact

Readers get a shorter, symptom-oriented guide whose commands are safe to copy and whose runtime/version-sensitive details live on canonical pages.

## Validation

- `git diff --check`
- both guides are 257 lines with 27 matching sections
- all internal Markdown targets exist; code fences are balanced
- documented commands checked against `agent-network/bin/cli.ts`
- Node/Bun requirements checked against package engines
- `SSE connected` and `license_expired` claims checked against source
- stale/dangerous phrase scan passed in both languages
- confirmed CLI has no public global-role/plan mutation command

Documentation-only change. No Docker, Hub, model runtime, npm package, production process, database, or user configuration was touched.
