### PR TITLE
docs: simplify package READMEs and remove stale pins

### DIFF
--- a/agent-network/README.md
+++ b/agent-network/README.md
@@ -5,387 +5,74 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/sleep2agi/agent-network/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-anet.sh-009e7e.svg)](https://anet.sh)
 
-Run a local network of AI agents from one CLI.
-
-`anet` starts a CommHub, launches the web dashboard, creates agent nodes, and lets those nodes talk to each other through MCP tools such as `send_task`, `get_task`, and `get_all_status`.
-
-## What It Is
-
-Agent Network is a local-first multi-agent runtime:
-
-- **CommHub**: MCP + REST + SSE hub for task routing, auth, networks, and status.
-- **Agent nodes**: long-running AI workers backed by Claude Code, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, or OpenCode ACP.
-- **Dashboard**: browser UI for topology, chat, tasks, node health, and server telemetry.
-- **CLI**: `anet`, the single entry point for setup, auth, node lifecycle, and demos.
-
-The default path runs entirely on your machine. LAN sharing is opt-in.
-
-## Requirements
-
-- Node.js **>= 22.13.0**
-- npm **>= 10**
-- Bun **>= 1.2.0** (`anet hub start` lazy-runs the Bun-based CommHub server)
-- macOS or Linux
-
-Install Bun if needed:
-
-```bash
-curl -fsSL https://bun.sh/install | bash
-```
+`anet` connects local AI agents through one self-hosted Hub. It starts CommHub and the Dashboard, creates node identities, and manages node lifecycle, networks, tokens, tasks, and channels.
 
 ## Install
 
-Stable:
+Requires Node.js ≥ 22.13 and Bun ≥ 1.2.
 
 ```bash
-npm install -g @sleep2agi/agent-network
-anet -v
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
 ```
 
-Preview channel:
+Stable releases use npm's `latest` tag. Features that are still being validated use `preview`:
 
 ```bash
-npm install -g @sleep2agi/agent-network@preview
-anet -v
+anet upgrade --channel preview
 ```
 
-Current preview channel (keep `agent-network` / `agent-node` aligned; OpenCode's automatic `npx` fallback is intentionally disabled):
+Do not copy fixed package or preview numbers from old issues. Check the [versioning guide](https://anet.sh/guide/versioning) and npm dist-tags for the current release.
+
+## Quick start
+
+Open three terminals:
 
 ```bash
-npm install -g @sleep2agi/agent-network@preview \
-  @sleep2agi/agent-node@preview \
-  opencode-ai@1.18.1
-```
-
-Current npm dist-tags verified on 2026-05-28 (v0.10.11 stable):
-
-| Package | latest | preview |
-|---|---:|---:|
-| `@sleep2agi/agent-network` | `2.2.10` | `2.2.10-preview.3` |
-| `@sleep2agi/commhub-server` | `0.8.4` | `0.8.4-preview.1` |
-| `@sleep2agi/agent-network-dashboard` | `0.5.6` | `0.5.7-preview.2` |
-| `@sleep2agi/agent-node` | `2.4.7` | `2.4.8-preview.0` |
-
-## 5-Minute Quick Start
-
-Open three terminals.
-
-### 1. Start CommHub
-
-```bash
+# Terminal 1 — Hub
 anet hub start
-```
 
-Default local URL:
-
-```text
-http://127.0.0.1:9200
-```
-
-By default the hub binds to localhost. Use `--host 0.0.0.0` only when you intentionally want LAN clients to connect.
-
-### 2. Start Dashboard
-
-```bash
+# Terminal 2 — Dashboard
 anet hub dashboard
-```
 
-Open:
-
-```text
-http://localhost:3000
-```
-
-### 3. Log In, Create A Node, Start It
-
-```bash
-anet login --hub http://127.0.0.1:9200 --username admin --password anethub
+# Terminal 3 — login, create, start
+anet login --hub http://127.0.0.1:9200 --username admin
 anet node create my-bot
 anet node start my-bot
 ```
 
-`anet node create` walks you through:
+The node is ready after its log reports `SSE connected`. Open `http://localhost:3000` and send it a task from Dashboard.
 
-1. Runtime: `claude-agent-sdk`, `claude-code-cli`, `codex-sdk`, `codex-app-server`, `grok-build-acp`, or `opencode-cli` (the canonical preview picker has exactly these 6 choices).
-2. Provider preset: Anthropic, MiniMax, InternLM, Xiaomi MiMo, or `custom` (any Anthropic-compatible endpoint — used for DeepSeek / GLM / Kimi / OpenRouter etc.; Codex runtimes reuse Codex auth; grok-build-acp reuses Grok auth; opencode-cli offers Anthropic/OpenAI presets).
-3. API key and model settings.
+## Runtime selection
 
-When the node starts successfully, look for:
+`anet node create` shows only runtimes available in the installed release channel. Installation, authentication, permissions, and current availability are maintained in the [runtime guide](https://anet.sh/guide/runtimes).
 
-```text
-SSE connected
-```
+- Claude Code, Claude Agent SDK, Codex SDK, and Grok Build ACP are the published task-runtime paths.
+- Codex TUI co-presence is preview-only and must be started and recovered with `--copresence`; see the [co-presence guide](https://anet.sh/guide/codex-copresence).
+- OpenCode support is preview-only.
+- A shared Grok TUI is not in the current npm packages. Use `grok-build-acp` for published Grok nodes and follow the [Grok TUI status page](https://anet.sh/guide/grok-copresence).
 
-Then use the Dashboard chat panel to send `my-bot` a message.
+Development branches may contain source-only runtime experiments. They are not supported installation paths until they appear in an npm dist-tag and the runtime guide.
 
-## Multi-Agent Collaboration
+## What it provides
 
-Create a second node:
+- **CommHub** — MCP, REST, SSE task delivery, authentication, networks, and audit state.
+- **Agent Node** — long-running workers backed by the selected runtime.
+- **Dashboard** — topology, chat, tasks, messages, and node health.
+- **CLI** — setup, login, node/project lifecycle, channels, tokens, and diagnostics.
 
-```bash
-anet node create reviewer
-anet node start reviewer
-```
+Runtimes with CommHub tool integration can discover peers and delegate work with tools such as `get_all_status`, `send_task`, and `get_task`. Replies and ordinary messages do not recursively invoke another model; see the [task lifecycle](https://anet.sh/concepts/task-lifecycle).
 
-Ask `my-bot`:
+## Security
 
-```text
-Ask reviewer to review this plan and summarize the risks.
-```
-
-The first agent can discover peers with `get_all_status`, delegate work with `send_task`, poll with `get_task`, and integrate the reply. The dashboard Tasks and Messages views show the chain.
-
-## LAN Hub
-
-On the hub machine:
-
-```bash
-anet hub start --host 0.0.0.0
-```
-
-On another machine:
-
-```bash
-npm install -g @sleep2agi/agent-network
-anet init --hub http://<HUB-LAN-IP>:9200
-anet login --username admin --password anethub
-anet node create remote-bot
-anet node start remote-bot
-```
-
-Do not expose the hub directly to the public internet without a reverse proxy, HTTPS, firewall rules, and reviewed auth settings.
-
-## Runtimes
-
-| Runtime | Use When | Notes |
-|---|---|---|
-| `claude-code-cli` | You want Claude Code CLI sessions and channel support | Uses Claude Code process; supports stable `COMMHUB_RESUME_ID` in recent previews |
-| `claude-agent-sdk` | You want Anthropic-compatible API providers | Good default for provider presets |
-| `codex-sdk` | You want Codex-backed nodes | Useful as a backup runtime when Claude quota is constrained |
-| `codex-app-server` | You want a Codex TUI thread shared with network tasks | Canonical preview; connects to the local app-server over WebSocket |
-| `grok-build-acp` | You want Grok Build through `grok agent stdio` | Requires Grok Build CLI auth; stable for receive/reply, session persistence, and explicit `send_task` delegation |
-| `opencode-cli` | You want public OpenCode ACP with Anthropic/OpenAI presets | Canonical preview; exact `opencode-ai@1.18.1` and exact network/node pair required |
-
-For Codex TUI co-presence, install the preview channel, create a `codex-app-server` node, then use the first-class start path:
-
-```bash
-anet upgrade --channel preview
-codex login
-cd /path/to/project
-for v in $(env | sed -n 's/^\(COMMHUB_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$v"; done
-anet node create codex-human --runtime codex-app-server
-anet node start codex-human --copresence
-tmux attach -t =codex-human
-```
-
-It requires bash + tmux 3.2+, defaults to read-only, and must also be restarted with `--copresence` after a disconnect. A plain `anet node start` is a background-node path, not co-presence recovery. Full guide: <https://anet.sh/en/guide/codex-copresence>.
-
-### Grok Build ACP
-
-`grok-build-acp` uses the local Grok Build CLI via Agent Client Protocol (ACP). Install and authenticate Grok first:
-
-```bash
-curl -fsSL https://x.ai/cli/install.sh | bash
-grok
-```
-
-Create and start a node:
-
-```bash
-anet node create grok-demo --runtime grok-build-acp
-anet node start grok-demo
-```
-
-Look for:
-
-```text
-runtime: grok-build-acp
-SSE connected
-```
-
-Stable support:
-
-- Receive CommHub tasks through SSE.
-- Run one Grok Build ACP turn per task.
-- Persist `grokSession` into `.anet/nodes/<name>/config.json`.
-- Resume the saved Grok session on the next task.
-- Reply to the original sender through CommHub.
-- Explicit delegation such as `给 A站助手 发任务: ...` is intercepted by `agent-node`, sent through CommHub with `parent_task_id`, and polled until the child task reaches `replied` or `failed`.
-
-Current boundary:
-
-- Grok native MCP tool injection is not the stable path yet.
-- For cross-agent delegation, use explicit delegation wording so `agent-node` handles the CommHub call deterministically.
-- If Grok returns `grok ACP error -32603`, upgrade to the latest `@sleep2agi/agent-node` and restart the node; recent builds narrow ACP capabilities and include `error.data` diagnostics.
-
-Details: `docs/grok-build-runtime.md`.
-
-## Provider Presets
-
-`anet node create` writes the correct provider environment into `.anet/nodes/<name>/config.json`.
-
-| Provider | Status | Notes |
-|---|---|---|
-| Anthropic | verified path | Native Anthropic Messages API |
-| MiniMax | verified path | Anthropic-compatible endpoint |
-| DeepSeek | verified path | Anthropic-compatible endpoint |
-| GLM / Zhipu | verified path | Anthropic-compatible endpoint |
-| Kimi / Moonshot | verified path | Anthropic-compatible endpoint |
-| OpenRouter | available | Anthropic-compatible routing |
-| Custom | available | Provide base URL, model, and token |
-
-## Common Commands
-
-```bash
-# Hub and dashboard
-anet hub start
-anet hub dashboard
-
-# Auth
-anet register
-anet login --username <user> --password <password>
-anet logout
-anet whoami
-anet passwd
-
-# Nodes
-anet node create <name>
-anet node start <name>
-anet node start --all
-anet node stop <name>
-anet node resume <name>
-anet node rename <old> <new> --force
-anet node delete <name>
-anet node ls
-anet info <name>
-anet logs <name>
-
-# Network status and repair
-anet status
-anet tasks [status]
-anet doctor
-anet doctor --fix
-
-# Project and session helpers
-anet init --hub <url>
-anet init project
-anet project up
-anet project restart
-anet project down
-anet session ls
-
-# Channels and upgrades
-anet channel add telegram <name> --bot-token <tok> --allow <uid>
-anet channel add feishu   <name> --app-id <id> --app-secret <secret> --allow <open-id>   # see docs/feishu-quickstart.md
-anet channel ls
-anet upgrade
-anet upgrade --channel preview --dry-run
-
-# Batch / demos
-anet create --batch
-anet batch list
-anet batch stop <prefix>
-anet demo sci-team
-```
-
-## Configuration Files
-
-```text
-~/.anet/config.json
-  Global CLI profile: hub URL, user token, default network.
-
-~/.anet/server/admin-utok.json
-  Local bootstrap admin token for the hub.
-
-{project}/.anet/nodes/<name>/config.json
-  Per-node runtime, model, provider env, node token, channels, and session IDs.
-```
-
-Example node config:
-
-```json
-{
-  "node_id": "n_a1b2c3d4",
-  "node_name": "my-bot",
-  "alias": "my-bot",
-  "hub": "http://127.0.0.1:9200",
-  "network_id": "default",
-  "token": "ntok_...",
-  "runtime": "claude-agent-sdk",
-  "model": "your-model",
-  "channels": ["server:commhub"],
-  "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://example.com/anthropic",
-    "ANTHROPIC_AUTH_TOKEN": "sk-..."
-  },
-  "flags": {
-    "dangerouslySkipPermissions": true,
-    "teammateMode": "in-process",
-    "maxTurns": 50
-  }
-}
-```
-
-Do not commit `.anet/` or provider API keys.
-
-## Security Notes
-
-- The hub binds to `127.0.0.1` by default.
-- LAN mode is explicit: `anet hub start --host 0.0.0.0`.
-- Node tokens are network-scoped `ntok_` tokens; user tokens are `utok_`.
-- Keep API keys in local node config or env refs; never paste real keys into issues or docs.
-- Treat tmux / terminal streaming features as local-admin tools.
-
-## What Is Stable vs Experimental
-
-Stable day-to-day path:
-
-- `anet hub start` / `anet hub stop` / `anet hub status` (v0.10.11+: SIGTERM → 3s grace → SIGKILL stop; status shows PID + port + `/health` version — no more manual `lsof+kill`)
-- `anet hub dashboard`
-- `anet login`
-- `anet node create/start/stop/delete/rename`
-- `anet node start --all`
-- `anet project up/restart/down`
-- Dashboard chat, task list, topology, and status views
-
-Actively evolving:
-
-- IM platform integration (Feishu / Slack / WhatsApp / WeCom)
-- Telegram channel binding
-- Advanced dashboard topology edges
-- Batch orchestration and science-team demos
-- Codex runtime expansion
-- Grok Build ACP runtime
-- Cross-version rename hot-reload
+The default Hub is local-only. Before exposing it beyond localhost, change the initial password and follow the [production deployment guide](https://anet.sh/deploy/production). Do not copy `.anet` node configs between machines: they contain network-bound identity and token material.
 
 ## Documentation
 
-- Docs site: https://anet.sh
-- Getting started: https://anet.sh/guide/getting-started
-- Preview guide: https://anet.sh/guide/preview/getting-started
-- Issues: https://github.com/sleep2agi/agent-network/issues
+- [Getting started](https://anet.sh/guide/getting-started)
+- [CLI reference](https://anet.sh/guide/cli)
+- [Runtime guide](https://anet.sh/guide/runtimes)
+- [Tokens and permissions](https://anet.sh/concepts/tokens)
+- [Troubleshooting](https://anet.sh/troubleshooting)
+- [GitHub repository](https://github.com/sleep2agi/agent-network)
 
-## Repository Layout
-
-This package lives in the `agent-network/` subdirectory of the monorepo:
-
-```text
-agent-network/
-  bin/cli.ts           anet CLI
-  src/client.ts        SDK client
-  src/node-server.ts   CommHub MCP server bridge used by claude-code-cli
-  src/im/              IM integration contracts and future adapters
-```
-
-Related packages live next to it:
-
-```text
-server/                @sleep2agi/commhub-server
-agent-node/            @sleep2agi/agent-node
-docs-site/             anet.sh documentation site
-```
-
-## License
-
-Apache-2.0
+Apache-2.0.

--- a/agent-network/README.md
+++ b/agent-network/README.md
@@ -48,8 +48,8 @@ The node is ready after its log reports `SSE connected`. Open `http://localhost:
 
 - Claude Code, Claude Agent SDK, Codex SDK, and Grok Build ACP are the published task-runtime paths.
 - Codex TUI co-presence is preview-only and must be started and recovered with `--copresence`; see the [co-presence guide](https://anet.sh/guide/codex-copresence).
-- OpenCode support is preview-only.
-- A shared Grok TUI is not in the current npm packages. Use `grok-build-acp` for published Grok nodes and follow the [Grok TUI status page](https://anet.sh/guide/grok-copresence).
+- OpenCode support is preview-only. Its automatic `npx` fallback is intentionally disabled, so install the documented CLI explicitly.
+- Neither npm `latest` nor `preview` includes a shared Grok TUI. Use `grok-build-acp` for published Grok nodes and follow the [Grok TUI status page](https://anet.sh/guide/grok-copresence).
 
 Development branches may contain source-only runtime experiments. They are not supported installation paths until they appear in an npm dist-tag and the runtime guide.
 

--- a/agent-node/README.md
+++ b/agent-node/README.md
@@ -46,7 +46,7 @@ Runtime availability follows the installed npm channel; do not infer it from a f
 | `codex-app-server` | Share a Codex thread with a human TUI | Preview-only; use `anet node start <name> --copresence` |
 | `opencode-cli` | Run the vetted OpenCode ACP path | Preview-only |
 
-A shared Grok TUI is not in the current npm packages. Development branches may contain source-only experiments, but they are not an installable product path until published and listed in the [Grok TUI status page](https://anet.sh/guide/grok-copresence).
+Neither npm `latest` nor `preview` includes a shared Grok TUI. Development branches may contain source-only experiments, but they are not an installable product path until published and listed in the [Grok TUI status page](https://anet.sh/guide/grok-copresence).
 
 ## Configuration and security
 

--- a/agent-node/README.md
+++ b/agent-node/README.md
@@ -1,211 +1,79 @@
-# @sleep2agi/agent-node
+# `@sleep2agi/agent-node`
 
 [![npm version](https://img.shields.io/npm/v/@sleep2agi/agent-node.svg)](https://www.npmjs.com/package/@sleep2agi/agent-node)
 [![npm downloads](https://img.shields.io/npm/dm/@sleep2agi/agent-node.svg)](https://www.npmjs.com/package/@sleep2agi/agent-node)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/sleep2agi/agent-network/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-anet.sh-009e7e.svg)](https://anet.sh)
 
-Agent runtime for Agent Network. Connects to a CommHub server, registers under an alias, and processes incoming tasks with Claude, Codex, Codex app-server, Grok Build, or OpenCode ACP runtimes.
+Agent Node is the worker process between CommHub and a model runtime. It receives tasks over SSE, invokes the configured runtime, returns results, and reports node status.
 
-The supported entry point is the `anet` CLI from `@sleep2agi/agent-network`, which writes the right `config.json`, network token, and environment variables for you.
+Most users should manage it through the `anet` CLI. `anet node create` writes the network-bound identity and runtime configuration; `anet node start` launches the matching Agent Node.
 
-## Install
-
-You usually don't install this package directly — `anet node create` and `anet node start` use it via `npx`. To pin it:
+## Install and run
 
 ```bash
-npm install -g @sleep2agi/agent-node
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
+
+anet hub start
+anet hub dashboard
+anet login --hub http://127.0.0.1:9200 --username admin
+anet node create my-bot
+anet node start my-bot
 ```
 
-For the current preview channel, install `agent-network` and `agent-node` from the same dist-tag. The OpenCode path does not execute an ambient package or automatic `npx` fallback:
+The node is ready after `SSE connected` appears in its log.
+
+For an existing profile, direct invocation is possible but normally unnecessary:
 
 ```bash
-npm install -g @sleep2agi/agent-network@preview \
-  @sleep2agi/agent-node@preview \
-  opencode-ai@1.18.1
+npx @sleep2agi/agent-node \
+  --config .anet/nodes/<name>/config.json \
+  --alias <name>
 ```
 
-## Verified flow
-
-```bash
-npm install -g @sleep2agi/agent-network
-anet hub start                      # local hub (terminal 1)
-anet hub dashboard                  # web UI (terminal 2)
-anet login --hub http://127.0.0.1:9200 --username admin --password anethub
-anet node create my-bot             # two-step picker: runtime, then provider
-anet node start my-bot              # → SSE connected
-```
-
-The picker writes `.anet/nodes/<name>/config.json`. `anet node start` reads it and runs this package under the hood.
-
-## Direct invocation
-
-For scripts and CI:
-
-```bash
-npx @sleep2agi/agent-node --alias my-bot --hub http://127.0.0.1:9200 --tools all
-```
-
-CLI flags:
-
-| Flag | Default | Notes |
-|---|---|---|
-| `--alias` | required | unique name in the hub |
-| `--hub` | `http://127.0.0.1:9200` | CommHub URL |
-| `--runtime` | `claude-agent-sdk` | `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `codex-app-server` / `grok-build-acp` / `opencode-cli` |
-| `--model` | runtime default | passed through to the SDK |
-| `--tools` | (none) | `all` or comma-separated list |
-| `--max-turns` | `50` | upper bound per task |
-| `--session` | (none) | resume a prior session / thread |
+The config must contain a valid node token, or authentication must resolve through the documented legacy fallback. Do not pass a user token as node identity.
 
 ## Runtimes
 
-| Runtime | Backend | Status | Notes |
-|---|---|---|---|
-| `claude-agent-sdk` | [@anthropic-ai/claude-agent-sdk](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) | verified | Anthropic-compatible API; works with MiniMax, DeepSeek, GLM, Kimi, Anthropic, OpenRouter, or custom endpoints |
-| `codex-sdk` | [@openai/codex-sdk](https://www.npmjs.com/package/@openai/codex-sdk) | unverified end-to-end | unit tests pass, no full E2E with real codex auth |
-| `claude-code-cli` | local `claude` CLI | unverified end-to-end | runs locally for Claude Pro subscribers (v0.8.2 fixed the session-resume default-loss bug; see [changelog](https://anet.sh/en/changelog)) |
-| `codex-app-server` | local `codex app-server` WebSocket | preview, Windows-verified | shares a Codex TUI thread with dispatched network tasks |
-| `grok-build-acp` | local `grok agent stdio` | stable runtime, native MCP injection boundary remains preview | requires Grok Build CLI login; stable for receive/reply, session persistence, and explicit CommHub delegation handled by agent-node |
-| `opencode-cli` | exact `opencode-ai@1.18.1` ACP child | canonical preview, release-gated | defaults to a launch-scoped external workspace with tools disabled; Anthropic/OpenAI presets |
+Runtime availability follows the installed npm channel; do not infer it from a fixed version table in a README. Use the [runtime guide](https://anet.sh/guide/runtimes) as the current compatibility matrix.
 
-The canonical preview picker exposes exactly these 6 runtimes. They are loaded lazily; picking one does not pull the others' SDK dependencies. `claude-code-cli` adds zero extra SDK weight.
+| Runtime | Purpose | Availability boundary |
+|---|---|---|
+| `claude-code-cli` | Reuse a local Claude Code login/session | Published task runtime |
+| `claude-agent-sdk` | Call Anthropic-compatible APIs | Published task runtime |
+| `codex-sdk` | Run Codex-backed tasks | Published task runtime |
+| `grok-build-acp` | Run Grok Build through ACP | Published task runtime; no human attach |
+| `codex-app-server` | Share a Codex thread with a human TUI | Preview-only; use `anet node start <name> --copresence` |
+| `opencode-cli` | Run the vetted OpenCode ACP path | Preview-only |
 
-`codex-app-server` co-presence is preview-only and is orchestrated by the `anet` CLI:
+A shared Grok TUI is not in the current npm packages. Development branches may contain source-only experiments, but they are not an installable product path until published and listed in the [Grok TUI status page](https://anet.sh/guide/grok-copresence).
 
-```bash
-cd /path/to/project
-for v in $(env | sed -n 's/^\(COMMHUB_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$v"; done
-anet node create codex-human --runtime codex-app-server
-anet node start codex-human --copresence
-tmux attach -t =codex-human
-```
+## Configuration and security
 
-The command starts a dedicated app-server, this bridge runtime, and a human TUI in three identity-linked tmux sessions. It requires tmux 3.2+, defaults to read-only, and recovery must keep the `--copresence` flag. See <https://anet.sh/en/guide/codex-copresence>.
+Project-local profiles live under `.anet/nodes/<alias>/`. A profile includes the Hub URL, runtime, `node_id`, network-bound `ntok_`, model settings, and runtime flags. Treat it as a secret:
 
-## Grok Build ACP
+- Do not commit `.anet`, profile files, `.env`, or tokens.
+- Do not copy one node profile to another machine or alias.
+- Create a separate node identity on each machine.
+- Start from the intended project directory; runtime file tools inherit that workspace.
+- Runtime permission defaults differ. Read the CLI disclosure and [security guide](https://anet.sh/concepts/security) before allowing shell, file-write, or network access.
 
-`grok-build-acp` runs the local Grok Build CLI over Agent Client Protocol:
+Agent Node does not read environment variables literally named `TOOLS` or `SYSTEM_PROMPT`. Use `--tools` / config `tools` and `--prompt` / config `systemPrompt`.
 
-```bash
-curl -fsSL https://x.ai/cli/install.sh | bash
-grok
-anet node create grok-demo --runtime grok-build-acp
-anet node start grok-demo
-```
+## Task behavior
 
-The runtime starts `grok agent stdio`, authenticates with the cached Grok login, opens or loads a Grok session, sends the task prompt, collects streamed ACP notifications, and writes `grokSession` back to the node config.
+- `send_task` creates executable work and can invoke the target runtime.
+- `send_reply` completes a task without invoking another model.
+- `send_message` is ordinary chat and does not invoke another model.
 
-Stable behavior:
+This distinction prevents reply loops. See the [task lifecycle](https://anet.sh/concepts/task-lifecycle) for state, retry, timeout, and parent-child semantics.
 
-- CommHub task delivery and replies are handled by `agent-node`, not by Grok itself.
-- Plain text tasks should be answered directly by Grok.
-- Explicit delegation tasks are intercepted before Grok when they use a clear pattern such as `给 <alias> 发任务: <task>`.
-- Intercepted delegation calls CommHub directly, passes `parent_task_id`, polls `get_task`, and returns the child result.
+## Documentation
 
-Known boundary:
+- [Agent Node guide](https://anet.sh/guide/agent-node)
+- [Runtime guide](https://anet.sh/guide/runtimes)
+- [CLI reference](https://anet.sh/guide/cli)
+- [Troubleshooting](https://anet.sh/troubleshooting)
+- [Source repository](https://github.com/sleep2agi/agent-network)
 
-- Native Grok MCP tool injection is still experimental. Do not rely on Grok itself seeing `commhub_get_all_status` or `commhub_send_task`.
-- Image attachments are currently text-only because the captured Grok ACP capability reports `promptCapabilities.image=false`.
-- `grok ACP error -32603` is treated as retryable once with a fresh session; the runtime now logs JSON-RPC `error.data` when Grok provides it.
-- Grok tool-state boilerplate such as "Do not attempt to use tools from these servers yet" is stripped from final CommHub replies so users see the actual task answer.
-
-## Provider presets (claude-agent-sdk)
-
-`anet node create` step 2 picks one of these and writes `ANTHROPIC_BASE_URL` + a default model. All Anthropic-compatible HTTP API; `--model` is passed through verbatim.
-
-| Provider | Base URL | Default model | Status |
-|---|---|---|---|
-| Anthropic | `https://api.anthropic.com` | configured by `--model` | verified |
-| MiniMax (国际) | `https://api.minimax.io/anthropic` | `MiniMax-M2.7` | verified |
-| MiniMax (国内) | `https://api.minimaxi.com/anthropic` | `MiniMax-M2.7` | verified |
-| DeepSeek | `https://api.deepseek.com/anthropic` | `deepseek-chat` | verified |
-| GLM (智谱) | `https://open.bigmodel.cn/api/anthropic` | `glm-4-plus` | verified |
-| Kimi (Moonshot) | `https://api.moonshot.cn/anthropic` | `moonshot-v1-32k` | verified |
-| OpenRouter | `https://openrouter.ai/api/v1` | (user-chosen) | unverified end-to-end |
-| Custom | user-supplied | user-supplied | unverified end-to-end |
-
-## Manual env-var examples
-
-```bash
-# DeepSeek
-ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic \
-ANTHROPIC_AUTH_TOKEN=sk-... \
-npx @sleep2agi/agent-node --alias deep --hub http://127.0.0.1:9200 --tools all
-
-# MiniMax
-ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic \
-ANTHROPIC_AUTH_TOKEN=your-key \
-npx @sleep2agi/agent-node --alias mini --model <minimax-model-id> --hub http://127.0.0.1:9200 --tools all
-```
-
-## Configuration file
-
-Typical output of `anet node create` at `.anet/nodes/<name>/config.json`:
-
-```json
-{
-  "node_id": "n_a1b2c3d4",
-  "node_name": "my-bot",
-  "hub": "http://127.0.0.1:9200",
-  "token": "ntok_...",
-  "runtime": "claude-agent-sdk",
-  "model": "<minimax-model-id>",
-  "channels": ["server:commhub"],
-  "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
-    "ANTHROPIC_AUTH_TOKEN": "sk-..."
-  },
-  "flags": {
-    "dangerouslySkipPermissions": true,
-    "teammateMode": "in-process",
-    "maxTurns": 50
-  }
-}
-```
-
-Per-node config wins over `~/.anet/config.json`; missing fields fall back to global, then defaults.
-
-## Main loop
-
-Same shape across runtimes:
-
-```
-start
-  → report_status: idle
-  → SSE long-poll /events/:alias
-  → on new_task: get_inbox → ack_inbox
-  → report_status: working
-  → run the LLM (with commhub MCP tools injected)
-  → send_reply
-  → report_status: idle
-```
-
-## Peer coordination (verified)
-
-When the agent runs, the commhub MCP tools are auto-injected. The model can call:
-
-- `commhub_get_all_status()` — see who else is online
-- `commhub_send_task(alias, task)` — dispatch a sub-task to a peer
-- `commhub_get_task(task_id)` — poll for the peer's reply
-- `commhub_send_message(alias, message)` — chat without a task lifecycle
-- `commhub_report_status(status, task)` — push status update
-
-This is what powers the multi-agent flow demonstrated in `anet hub dashboard` (e.g. ask one bot to consult another — the Tasks and Messages pages show the full handshake live).
-
-## Isolation
-
-When the runtime is `claude-code-cli`, the spawned subprocess gets `settingSources: []` so it doesn't read the host's `~/.claude.json` and accidentally cross networks.
-
-## Companion packages
-
-| Package | Version |
-|---|---|
-| [@sleep2agi/agent-network](https://www.npmjs.com/package/@sleep2agi/agent-network) | 2.2.10 |
-| [@sleep2agi/commhub-server](https://www.npmjs.com/package/@sleep2agi/commhub-server) | 0.8.4 |
-| [@sleep2agi/agent-network-dashboard](https://www.npmjs.com/package/@sleep2agi/agent-network-dashboard) | 0.5.6 |
-
-## License
-
-Apache-2.0
+Apache-2.0.

--- a/docs/tests/report-package-readme-simplification-2026-07-31.txt
+++ b/docs/tests/report-package-readme-simplification-2026-07-31.txt
@@ -1,0 +1,47 @@
+Package README simplification report — 2026-07-31
+
+Scope
+-----
+- agent-network/README.md
+- agent-node/README.md
+
+Outcome
+-------
+- agent-network README: 391 -> 78 lines.
+- agent-node README: 211 -> 79 lines.
+- Removed fixed npm/preview version tables, fixed OpenCode/model pins, repeated
+  provider matrices, implementation narration, duplicated command catalogs,
+  and status claims that drift independently from the published packages.
+- Kept the install and first-run path, release-channel boundary, runtime status,
+  token/config safety, task semantics, and canonical troubleshooting links.
+- Kept the Grok boundary precise: grok-build-acp is published; shared Grok TUI
+  is not in current npm packages. Source-only development work is not presented
+  as an installable feature.
+
+Deleted-detail routing
+----------------------
+- Full commands -> docs-site CLI reference.
+- Runtime install/auth/permissions -> runtime and Agent Node guides.
+- Provider endpoints/models -> multi-model guide, not a version-pinned table.
+- Hub/LAN/security detail -> production and token/security guides.
+- Grok/Codex co-presence detail -> their dedicated status/guides.
+- Tool and state-machine internals -> task lifecycle and API references.
+
+Verification
+------------
+PASS  git diff --check
+PASS  independent Dockerfile source/static gate (anet-docs-readme:dev)
+PASS  both READMEs are under 100 lines
+PASS  no fixed preview, package, OpenCode, or model version remains
+PASS  CLI source contains the documented preview upgrade path
+PASS  package engines confirm Node >=22.13.0 and Bun >=1.2.0
+PASS  source confirms TOOLS/SYSTEM_PROMPT configuration and token precedence
+PASS  all eleven linked anet.sh documentation pages returned HTTP 200
+PASS  npm dist-tags queried during audit; no returned version is copied into
+      user-facing prose, so the README does not stale on the next release
+
+Test policy
+-----------
+Documentation-only change. The Docker gate copied only the two READMEs and their
+source/package evidence. It did not start a Hub, model runtime, npm publish,
+production process, database, or user configuration, and consumed no model quota.


### PR DESCRIPTION
## What changed

- reduce `agent-network/README.md` from 391 to 78 lines
- reduce `agent-node/README.md` from 211 to 79 lines
- remove fixed npm/preview/OpenCode/model versions and duplicated implementation catalogs
- keep install, first-run, runtime/channel boundaries, config/token safety, task semantics, and canonical documentation links
- state the current Grok boundary precisely: `grok-build-acp` is published; shared Grok TUI is not in current npm packages; development branches are not an installable product path

## Why

These npm/GitHub package entry points had drifted several releases behind current dist-tags and duplicated details already maintained on anet.sh. The fixed tables became incorrect automatically on every release.

## Validation

- `git diff --check`
- dedicated Docker source/static gate (`anet-docs-readme:dev`)
- both READMEs under 100 lines
- no fixed preview/package/OpenCode/model versions remain
- CLI/package/source checks for upgrade path, engines, token precedence, and `TOOLS`/`SYSTEM_PROMPT`
- all eleven linked anet.sh documentation pages returned HTTP 200

No Hub, model runtime, npm publish, production process, database, or user configuration was touched.