### PR TITLE
docs: retire unsafe one-shot installer

### DIFF
--- a/docs-site/docs/deploy/clean-server.md
+++ b/docs-site/docs/deploy/clean-server.md
@@ -374,9 +374,9 @@ sudo systemctl status anet-hub anet-node@my-bot
 ## 下一步
 
 - [上手指南](/guide/getting-started) — 已经装好 anet 的端到端走查（笔记本场景）
-- [一键安装](/guide/one-shot-install) — `setup-anet.sh` 自动起 hub + dashboard + 多 agent
+- [一键安装脚本退役说明](/guide/one-shot-install) — 旧脚本已停用，请使用本页的分步流程
 - [生产部署 / 公网部署安全](/deploy/production) — TLS / 防火墙 / 备份 / 公网风险点
-- [Channel 接入](/guide/channels) — Telegram / WeChat / 飞书 完整接入手册
+- [Channel 接入](/guide/channels) — 当前渠道状态与 Telegram / 飞书接入；微信尚未发布
 - [节点 Runtime](/guide/runtimes) — runtime 详细对比
 
 如果踩到本页没覆盖的坑，欢迎到 [GitHub Issues](https://github.com/sleep2agi/agent-network/issues) 开一条 + cite 哪一步、什么报错、`anet -v` 输出。

--- a/docs-site/docs/en/deploy/clean-server.md
+++ b/docs-site/docs/en/deploy/clean-server.md
@@ -374,9 +374,9 @@ In the order they hit you on a real fresh machine — **symptom → cause → fi
 ## Next
 
 - [Getting Started](/en/guide/getting-started) — end-to-end walkthrough for an already-installed laptop setup
-- [One-shot install](/en/guide/one-shot-install) — `setup-anet.sh` brings up hub + dashboard + multi-agent in one shot
+- [One-shot installer retirement](/en/guide/one-shot-install) — the old script is disabled; use this page's step-by-step flow
 - [Production / public-internet deployment](/en/deploy/production) — TLS / firewall / backup / public-internet risk surface
-- [Channel integration](/en/guide/channels) — full Telegram / WeChat / Feishu integration manual
+- [Channel integration](/en/guide/channels) — current channel status and Telegram / Feishu setup; WeChat has not shipped
 - [Node runtime](/en/guide/runtimes) — detailed comparison of the runtimes
 
 If you hit a bug not covered here, please open a [GitHub issue](https://github.com/sleep2agi/agent-network/issues) — include which step failed, the exact error, and the `anet -v` output.

--- a/docs-site/docs/en/guide/one-shot-install.md
+++ b/docs-site/docs/en/guide/one-shot-install.md
@@ -1,145 +1,33 @@
-# One-Shot Install (Multi-Agent + tmux)
+# One-shot installer retired
 
-::: warning ⚠️ Experimental — not end-to-end verified, audit before use
-**Vincent feedback (2026-06-29)**: `setup-anet.sh` has **not been end-to-end verified by the maintainers**. The script file is reachable at `https://anet.sh/setup-anet.sh` (and syntactically complete), but there is no reproducible smoke report of it running through on a clean Ubuntu/Debian host. The `MINIMAX_KEY=sk-cp-your-key` vendor-key form may also not match MiniMax's current API — use the verified-with-real-call vendors listed in [Multi-Model Config](/en/guide/multi-model).
-
-**Recommended path**: follow the [Getting Started guide](/en/guide/getting-started) (verified 5-terminal manual flow) + [Fresh Server From Scratch](/en/deploy/clean-server) (includes a systemd template).
-
-The contents below are **kept for script-author reference**, but please audit and dry-run in an isolated environment before using.
+::: danger Do not run an old copy of `setup-anet.sh`
+The old script had no reproducible end-to-end verification and used broad process
+cleanup plus recursive state deletion that could affect unrelated services on the
+same host. It also used an unsafe network default and secret-forwarding method.
 :::
 
-If you want to spin up a complete Agent Network (hub + dashboard + multiple agents, each in its own tmux session) on a fresh Ubuntu/Debian server with **a single command**, use `setup-anet.sh`.
+## Current status
 
-## When to use this
+`https://anet.sh/setup-anet.sh` remains available for old bookmarks, but now only
+prints a retirement notice, makes no system changes, and exits non-zero.
 
-- ✅ Deploying the full stack to a cloud server (Aliyun / AWS / DigitalOcean)
-- ✅ Demoing multi-agent coordination to a team
-- ✅ Local LAN testing across multiple machines
+Do not run a previously downloaded or copied version, even for a “clean reinstall”
+or “cache cleanup.” Its cleanup scope was not limited to this installation and
+could stop other Agent Network processes or delete npx code and state still in use.
 
-## Prerequisites
+## Supported alternatives
 
-The script auto-installs anything missing from the list below:
+- Local evaluation: [30-second quickstart](/en/guide/getting-started)
+- New server: [fresh-server deployment](/en/deploy/clean-server)
+- Production: [public-internet security](/en/deploy/production)
+- Multiple nodes: [batch agents](/en/guide/batch)
 
-- `nodejs ≥ 22.13.0` (`@sleep2agi/agent-network` `engines.node`)
-- `npm`
-- `tmux`
-- `bun` (required by commhub-server)
-- `unzip`, `curl`, `ca-certificates`
+These paths separate installation, authentication, network binding, node creation,
+and verification, so a failure can be traced to one step.
 
-If you're currently `root`, the script will **auto-create a non-root user `anet`** (Claude Code refuses to use `--dangerously-skip-permissions` as root, so a non-root user is required).
+## Why it was not patched in place
 
-## Single command
-
-```bash
-curl -fsSL https://anet.sh/setup-anet.sh \
-  | MINIMAX_KEY=sk-cp-your-key bash
-```
-
-Or save locally and run:
-
-```bash
-curl -fsSL https://anet.sh/setup-anet.sh \
-  -o setup-anet.sh
-chmod +x setup-anet.sh
-MINIMAX_KEY=sk-cp-your-key ./setup-anet.sh
-```
-
-## Customization
-
-| Env var | Default | Purpose |
-|---|---|---|
-| `MINIMAX_KEY` | (required) | MiniMax API key (`ANTHROPIC_AUTH_TOKEN`) |
-| `MINIMAX_MODEL` | `MiniMax-M2.7` | Which MiniMax model ID to use |
-| `ANET_HUB_IP` | `0.0.0.0` | Hub + Dashboard bind address (0.0.0.0 = LAN accessible; change to `127.0.0.1` for loopback only) |
-| `ANET_USER` | `anet` | Non-root username (auto-created by the script) |
-| `WIPE` | `0` | Set to `1` to wipe all state before starting (tmux sessions / `~/.anet` / `~/.commhub` / npx cache). Handy when debugging |
-
-```bash
-# Custom node list (default: 5 nodes — publisher / editor-in-chief / scout / editor / reviewer)
-MINIMAX_KEY=sk-cp-xxx ./setup-anet.sh nodeA nodeB nodeC
-
-# Pick a MiniMax model
-MINIMAX_KEY=sk-cp-xxx MINIMAX_MODEL=MiniMax-M3 ./setup-anet.sh
-
-# Change hub bind address
-MINIMAX_KEY=sk-cp-xxx ANET_HUB_IP=127.0.0.1 ./setup-anet.sh
-
-# Change non-root username
-MINIMAX_KEY=sk-cp-xxx ANET_USER=worker ./setup-anet.sh
-
-# Full wipe and reinstall (kills tmux + clears ~/.anet / ~/.commhub + npx cache, then reinstalls)
-MINIMAX_KEY=sk-cp-xxx WIPE=1 ./setup-anet.sh
-```
-
-## Available MiniMax models
-
-| Model ID | Notes |
-|---|---|
-| `MiniMax-M3` | **Current latest** (vision-capable; anet wizard default) — recommend `MINIMAX_MODEL=MiniMax-M3` |
-| `MiniMax-M2.7` | `setup-anet.sh` default fallback (check MiniMax docs for the current latest model id) |
-| `MiniMax-M2.7-highspeed` | High-speed variant |
-| `MiniMax-M2.5` | |
-| `MiniMax-M2.5-highspeed` | |
-| `MiniMax-M2.1` | |
-| `MiniMax-M2.1-highspeed` | |
-| `MiniMax-M2` | Legacy |
-
-See the [MiniMax official docs](https://platform.minimaxi.com/docs/api-reference/text-anthropic-api).
-
-## After it finishes
-
-Each process runs in its own tmux session:
-
-```bash
-tmux ls
-# anet-hub: 1 windows ...
-# anet-dashboard: 1 windows ...
-# anet-node-publisher: 1 windows ...
-# anet-node-editor-in-chief: 1 windows ...
-# ...
-```
-
-Operations:
-
-```bash
-# Attach to a specific process to view its output
-tmux a -t anet-hub
-tmux a -t anet-dashboard
-tmux a -t anet-node-editor-in-chief
-
-# Detach (leaves it running): Ctrl-b then d
-
-# Stop one node
-tmux kill-session -t anet-node-editor
-
-# Stop the whole network
-tmux ls | awk -F: '/^anet-/{print $1}' | xargs -I{} tmux kill-session -t {}
-```
-
-Default ports:
-
-| Service | Port | tmux session |
-|---|---|---|
-| CommHub Server | `9200` | `anet-hub` |
-| Dashboard | `3000` | `anet-dashboard` |
-| Agent Node | in-process `stdio` (no network port) | `anet-node-<alias>` |
-
-Open a browser at:
-
-```
-http://your-server-ip:3000
-```
-
-Log in with `admin / anethub`. All nodes show up on the Nodes page; click any node to dispatch a task. **Run `anet passwd` to set a strong password right away** (see [troubleshooting → password strength](/en/troubleshooting)).
-
-## Verified
-
-- End-to-end tested in a fresh `ubuntu:22.04` Docker container: full stack up in ~70-90s (dependency install + package download + 5 agents started)
-- Hub healthy + Dashboard 200 + all agents registered idle
-- With a real MiniMax key, agents can dispatch tasks to each other via the commhub MCP tools and integrate the replies
-
-## Known limitations (unverified)
-
-- Only verified on Ubuntu 22.04 / 24.04; the `apt-get` commands need substitution for CentOS / RHEL.
-- Bun is installed via `curl bun.sh/install`, which requires Internet access; pre-install Bun in air-gapped environments.
-- If `MINIMAX_KEY` or the model ID is wrong, the script will finish successfully but agents will return failed when handling tasks — check the `[stderr]` lines via `tmux a -t anet-node-<alias>`.
+A safe rewrite needs redesigned process ownership, credential forwarding,
+idempotent recovery, and uninstall boundaries, followed by reproducible E2E on
+clean Ubuntu/Debian environments. Until that exists, an unverified one-shot script
+is not a supported entry point.

--- a/docs-site/docs/guide/one-shot-install.md
+++ b/docs-site/docs/guide/one-shot-install.md
@@ -1,145 +1,29 @@
-# 一键安装（多 Agent + tmux）
+# 一键安装脚本已退役
 
-::: warning ⚠️ 实验性 — 未经端到端验证, 用前自审
-**Vincent 2026-06-29 反馈**: `setup-anet.sh` **未经维护者端到端验证**——脚本文件挂在 `https://anet.sh/setup-anet.sh` 可下载（且语法上完整），但没有在干净 Ubuntu/Debian 上跑通的可复现 smoke 报告。`MINIMAX_KEY=sk-cp-你的key` 这个 vendor key 形式也可能跟 MiniMax 当前 API 不符——以 [多模型配置](/guide/multi-model) 里 verified-with-real-call 的 vendor 为准。
-
-**推荐路径**: 跟 [上手指南](/guide/getting-started)（已验证 5 终端手动流程）+ [干净服务器从零部署](/deploy/clean-server)（含 systemd 模板）。
-
-下面内容**保留作脚本作者参考**，但用前请自行审计 + 在隔离环境试跑。
+::: danger 不要运行旧版 `setup-anet.sh`
+旧脚本未经可复现的端到端验证，并包含可能影响同机其他服务的批量进程清理和递归
+状态删除。它还使用了不安全的网络默认值与密钥传递方式。
 :::
 
-如果你想在一台空 Ubuntu/Debian 服务器上**一行命令**起完整 Agent Network（hub + dashboard + 多个 agent，每个进程一个独立 tmux session），用 `setup-anet.sh`。
+## 当前状态
 
-## 适用场景
+`https://anet.sh/setup-anet.sh` 保留是为了兼容旧书签，但脚本现在只打印退役说明，
+不修改系统，并以非零状态退出。
 
-- ✅ 在云服务器（阿里云 / AWS / DO）部署一整套
-- ✅ 给团队演示 multi-agent 协作
-- ✅ 本地 LAN 多机测试
+不要运行以前下载或复制的旧版本，即使只想“重新安装”或“清缓存”。旧脚本的清理范围
+不局限于本次安装，可能停止其他 Agent Network 进程或删除仍在使用的 npx 代码与状态。
 
-## 前置依赖
+## 替代路径
 
-脚本会自动安装下面所有缺失的包：
+- 本机体验：[30 秒上手](/guide/getting-started)
+- 新服务器：[干净服务器从零部署](/deploy/clean-server)
+- 生产环境：[公网部署安全](/deploy/production)
+- 多节点管理：[批量 Agent](/guide/batch)
 
-- `nodejs ≥ 22.13.0`（`@sleep2agi/agent-network` `engines.node`）
-- `npm`
-- `tmux`
-- `bun`（commhub-server 需要）
-- `unzip`、`curl`、`ca-certificates`
+这些路径把安装、认证、网络绑定、节点创建与验证分开，失败时可以确定是哪一步出错。
 
-如果当前是 `root`，脚本会**自动建非 root 用户 `anet`**（Claude Code 拒绝 root 下用 `--dangerously-skip-permissions`，必须切非 root）。
+## 为什么不是直接修补
 
-## 一行命令
-
-```bash
-curl -fsSL https://anet.sh/setup-anet.sh \
-  | MINIMAX_KEY=sk-cp-你的key bash
-```
-
-或者保存到本地后执行：
-
-```bash
-curl -fsSL https://anet.sh/setup-anet.sh \
-  -o setup-anet.sh
-chmod +x setup-anet.sh
-MINIMAX_KEY=sk-cp-你的key ./setup-anet.sh
-```
-
-## 自定义
-
-| 环境变量 | 默认 | 作用 |
-|---|---|---|
-| `MINIMAX_KEY` | （必填） | MiniMax API key（`ANTHROPIC_AUTH_TOKEN`） |
-| `MINIMAX_MODEL` | `MiniMax-M2.7` | 走哪个 MiniMax 模型 ID |
-| `ANET_HUB_IP` | `0.0.0.0` | Hub + Dashboard 绑定地址（0.0.0.0 = LAN 可访问，改 `127.0.0.1` 限本机） |
-| `ANET_USER` | `anet` | 非 root 用户名（脚本自动创建） |
-| `WIPE` | `0` | 设 `1` 启动前清光所有状态（tmux session / `~/.anet` / `~/.commhub` / npx cache），调试时常用 |
-
-```bash
-# 自定义节点列表（默认 5 个：排版发布者 / 主编 / 信息采集 / 编辑 / 审核）
-MINIMAX_KEY=sk-cp-xxx ./setup-anet.sh 节点A 节点B 节点C
-
-# 选择 MiniMax 模型
-MINIMAX_KEY=sk-cp-xxx MINIMAX_MODEL=MiniMax-M3 ./setup-anet.sh
-
-# 改 Hub 绑定地址
-MINIMAX_KEY=sk-cp-xxx ANET_HUB_IP=127.0.0.1 ./setup-anet.sh
-
-# 改非 root 用户名
-MINIMAX_KEY=sk-cp-xxx ANET_USER=worker ./setup-anet.sh
-
-# 全清重跑（卸 tmux + 删 ~/.anet / ~/.commhub + 清 npx cache，再装一遍）
-MINIMAX_KEY=sk-cp-xxx WIPE=1 ./setup-anet.sh
-```
-
-## MiniMax 可用模型
-
-| 模型 ID | 备注 |
-|---|---|
-| `MiniMax-M3` | **当前最新**（vision-capable；anet 向导默认）—— 推荐显式设 `MINIMAX_MODEL=MiniMax-M3` |
-| `MiniMax-M2.7` | `setup-anet.sh` 默认 fallback（MiniMax 迭代后请到官方文档查最新 model id） |
-| `MiniMax-M2.7-highspeed` | 高速版 |
-| `MiniMax-M2.5` | |
-| `MiniMax-M2.5-highspeed` | |
-| `MiniMax-M2.1` | |
-| `MiniMax-M2.1-highspeed` | |
-| `MiniMax-M2` | 旧版 |
-
-参考 [MiniMax 官方文档](https://platform.minimaxi.com/docs/api-reference/text-anthropic-api)。
-
-## 跑完后
-
-每个进程在独立 tmux session 里：
-
-```bash
-tmux ls
-# anet-hub: 1 windows ...
-# anet-dashboard: 1 windows ...
-# anet-node-排版发布者: 1 windows ...
-# anet-node-主编: 1 windows ...
-# ...
-```
-
-操作：
-
-```bash
-# attach 到某个进程查看输出
-tmux a -t anet-hub
-tmux a -t anet-dashboard
-tmux a -t anet-node-主编
-
-# detach（保留运行）：Ctrl-b 然后 d
-
-# 停掉某一个
-tmux kill-session -t anet-node-编辑
-
-# 停掉整个网络
-tmux ls | awk -F: '/^anet-/{print $1}' | xargs -I{} tmux kill-session -t {}
-```
-
-默认端口：
-
-| 服务 | 端口 | tmux session |
-|---|---|---|
-| CommHub Server | `9200` | `anet-hub` |
-| Dashboard | `3000` | `anet-dashboard` |
-| Agent Node | `stdio` 进程内（无网络端口） | `anet-node-<alias>` |
-
-打开浏览器访问：
-
-```
-http://你的服务器IP:3000
-```
-
-用 `admin / anethub` 登录。所有节点在 Nodes 页面里可见，点任意节点可以发任务。**登录后立刻 `anet passwd` 改强密码**（参考 [troubleshooting → 密码强度](/troubleshooting)）。
-
-## 已验证
-
-- 在 fresh `ubuntu:22.04` Docker 容器里端到端测过：约 70-90s 完成全套（依赖安装 + 包下载 + 起 5 个 agent）
-- Hub 健康 + Dashboard 200 + 全部 agent register 成 idle
-- 真实 MiniMax key 下，agent 间能通过 commhub MCP 工具互相发任务并整合回复
-
-## 已知限制（未验证）
-
-- 仅在 Ubuntu 22.04 / 24.04 上验证；CentOS / RHEL 的 apt-get 命令需要替换。
-- Bun 安装走 `curl bun.sh/install`，需要外网；内网环境请预装 Bun。
-- 如果 `MINIMAX_KEY` 错或模型 ID 错，脚本会成功跑完但 agent 处理任务时返回 failed —— 检查 `tmux a -t anet-node-<alias>` 那个 session 的 `[stderr]` 行。
+安全重写需要重新设计进程所有权、凭据传递、幂等恢复与卸载边界，并在干净的
+Ubuntu/Debian 环境完成可复现 E2E。在这些条件满足前，不把未经验证的一键脚本作为
+受支持入口。

--- a/docs-site/docs/public/setup-anet.sh
+++ b/docs-site/docs/public/setup-anet.sh
@@ -1,239 +1,26 @@
 #!/usr/bin/env bash
-# 一键安装 + 启动 Agent Network (Ubuntu/Debian)
-#
-# 在 root 上跑会自动建 anet 用户切过去,然后:
-#   1. 装 nodejs 22 + tmux (agent-node preview.9+ 要求 node >= 22.13)
-#   2. npm i -g @sleep2agi/agent-network @sleep2agi/agent-node
-#   3. tmux session "anet" 内启动: hub + dashboard + N 个 agent
-#
-# 用法:
-#   curl -fsSL https://anet.sh/setup-anet.sh -o setup-anet.sh
-#   chmod +x setup-anet.sh
-#   MINIMAX_KEY=sk-cp-xxxxx ./setup-anet.sh                       # 默认 5 个节点
-#   MINIMAX_KEY=sk-cp-xxxxx ./setup-anet.sh 节点A 节点B 节点C       # 自定义节点列表
-#
-# 之后:
-#   tmux a -t anet                # 进入查看所有 window
-#   tmux kill-session -t anet     # 关闭整网
 
 set -euo pipefail
 
-MINIMAX_KEY="${MINIMAX_KEY:-}"
-# MiniMax Anthropic-compatible 网关支持的模型 (官方文档):
-#   MiniMax-M2.7, MiniMax-M2.7-highspeed,
-#   MiniMax-M2.5, MiniMax-M2.5-highspeed,
-#   MiniMax-M2.1, MiniMax-M2.1-highspeed, MiniMax-M2
-# 默认 MiniMax-M2.7 (最新); 可用 MINIMAX_MODEL=MiniMax-M2 ./setup-anet.sh 覆盖
-MINIMAX_MODEL="${MINIMAX_MODEL:-MiniMax-M2.7}"
-USERNAME="${ANET_USER:-anet}"
-HUB_IP="${ANET_HUB_IP:-0.0.0.0}"
-# WIPE=1 — 启动前清光所有状态:tmux session / ~/.anet / ~/.commhub / npx cache
-# 适合每次都从干净环境重跑测试.默认关闭(增量启动).
-WIPE="${WIPE:-0}"
+cat >&2 <<'EOF'
+[anet] setup-anet.sh 已退役，本次未做任何更改。
 
-# 默认节点列表
-if [ "$#" -gt 0 ]; then
-  NODES=("$@")
-else
-  NODES=("排版发布者" "主编" "信息采集" "编辑" "审核")
-fi
+旧脚本未经端到端验证，并包含批量进程匹配、递归状态删除、不安全的网络默认值和
+密钥转发方式，因此已停用。请勿运行以前保存的旧版本。
 
-wipe_state() {
-  echo "[wipe] 杀光 anet-* tmux session..."
-  tmux ls 2>/dev/null | awk -F: '/^anet-/{print $1}' | xargs -I{} tmux kill-session -t {} 2>/dev/null || true
-  echo "[wipe] 杀光 commhub-server / agent-network-dashboard / agent-node 进程..."
-  pkill -f commhub-server 2>/dev/null || true
-  pkill -f agent-network-dashboard 2>/dev/null || true
-  pkill -f agent-node 2>/dev/null || true
-  echo "[wipe] 删 ~/.anet ~/.commhub ~/.npm/_npx ~/anodes/.anet ..."
-  rm -rf ~/.anet ~/.commhub ~/.npm/_npx ~/anodes/.anet 2>/dev/null || true
-  # npm-global 的 @sleep2agi 包有时半安装遗留 dir 导致下次 npm i 报 ENOTEMPTY,
-  # WIPE 模式下顺手清掉.
-  echo "[wipe] 删 ~/.npm-global/lib/node_modules/@sleep2agi/ ..."
-  rm -rf ~/.npm-global/lib/node_modules/@sleep2agi 2>/dev/null || true
-  echo "[wipe] 完成。"
-}
+[anet] setup-anet.sh has been retired and made no changes.
 
-# === 1. 在 root 上时:建非 root 用户,装基础包,然后切过去重新执行 ===
-if [ "$(id -u)" -eq 0 ]; then
-  echo "[1/5] root 检测到 — 准备 $USERNAME 用户 + 系统依赖..."
-  id "$USERNAME" >/dev/null 2>&1 || useradd -m -s /bin/bash "$USERNAME"
-  apt-get update -qq
-  apt-get install -y -qq curl tmux ca-certificates unzip >/dev/null
-  # agent-network preview.9+ engines require Node >= 22.13. Older Node
-  # makes npm refuse install with a misleading EBADENGINE — install 22 LTS.
-  NODE_NEEDS_INSTALL=0
-  if ! command -v node >/dev/null 2>&1; then
-    NODE_NEEDS_INSTALL=1
-  else
-    NODE_MAJOR=$(node -p "process.versions.node.split('.')[0]" 2>/dev/null || echo 0)
-    if [ "$NODE_MAJOR" -lt 22 ]; then NODE_NEEDS_INSTALL=1; fi
-  fi
-  if [ "$NODE_NEEDS_INSTALL" = "1" ]; then
-    echo "[1/5] 装 Node.js 22 LTS (agent-node preview.9+ 要求) ..."
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null 2>&1
-    apt-get install -y -qq nodejs >/dev/null
-  fi
-  # Bun is required by commhub-server (TypeScript source with bun shebang).
-  # Install system-wide so both root and the anet user can use it.
-  if ! command -v bun >/dev/null 2>&1; then
-    echo "[1/5] 装 Bun (commhub-server 需要) ..."
-    curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || true
-    if [ -x "$HOME/.bun/bin/bun" ]; then
-      cp "$HOME/.bun/bin/bun" /usr/local/bin/bun
-      chmod +x /usr/local/bin/bun
-    fi
-  fi
-  cp "$0" "/home/$USERNAME/setup-anet.sh"
-  chmod +x "/home/$USERNAME/setup-anet.sh"
-  chown "$USERNAME:$USERNAME" "/home/$USERNAME/setup-anet.sh"
-  echo "[1/5] 切到 $USERNAME 用户继续 ..."
-  exec su - "$USERNAME" -c "MINIMAX_KEY='$MINIMAX_KEY' MINIMAX_MODEL='$MINIMAX_MODEL' ANET_HUB_IP='$HUB_IP' WIPE='$WIPE' bash ~/setup-anet.sh ${NODES[*]}"
-fi
+This unverified installer used broad process matching, recursive state deletion,
+an unsafe network default, and insecure secret forwarding. It is intentionally
+disabled instead of being silently kept as an unsupported installation path.
 
-# === 以下以非 root 用户执行 ===
+Use the maintained step-by-step guides:
+  中文快速开始: https://anet.sh/guide/getting-started
+  中文服务器部署: https://anet.sh/deploy/clean-server
+  English quickstart: https://anet.sh/en/guide/getting-started
+  English server setup: https://anet.sh/en/deploy/clean-server
 
-if [ "$WIPE" = "1" ] || [ "$WIPE" = "true" ]; then
-  wipe_state
-fi
+Do not run an older saved copy of setup-anet.sh.
+EOF
 
-if [ -z "$MINIMAX_KEY" ]; then
-  echo "[!] MINIMAX_KEY 环境变量未设置。"
-  echo "    运行: MINIMAX_KEY=sk-cp-xxxxx ./setup-anet.sh"
-  exit 1
-fi
-
-cd ~
-
-# === 2. npm 全局到 ~/.npm-global (避免 root 权限) ===
-echo "[2/5] 装 anet cli + agent-node 到 ~/.npm-global ..."
-mkdir -p ~/.npm-global
-npm config set prefix ~/.npm-global >/dev/null
-grep -q '.npm-global/bin' ~/.bashrc 2>/dev/null || echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.bashrc
-export PATH=~/.npm-global/bin:$PATH
-# Don't silence — npm 错误必须暴露,之前 --silent | tail -5 把失败信息吞了
-# 用 set +e 包一下,失败的话不让 pipefail 直接退出整个脚本
-set +e
-npm i -g @sleep2agi/agent-network @sleep2agi/agent-node 2>&1
-NPM_RC=$?
-# ENOTEMPTY recovery: a prior half-finished npm install can leave the
-# package dir behind; npm's atomic rename then fails. Wipe the offending
-# scope dir and retry once.
-if [ $NPM_RC -ne 0 ]; then
-  echo "[2/5] 检测到 npm install 失败,清理半装残留并重试..."
-  rm -rf ~/.npm-global/lib/node_modules/@sleep2agi 2>/dev/null
-  npm i -g @sleep2agi/agent-network @sleep2agi/agent-node 2>&1
-  NPM_RC=$?
-fi
-set -e
-if [ $NPM_RC -ne 0 ]; then
-  echo ""
-  echo "[!] npm install 失败 (exit $NPM_RC)。可能原因:"
-  echo "    - 网络问题: 试试 npm config set registry https://registry.npmmirror.com"
-  echo "    - 权限问题: 确认 ~/.npm-global 可写"
-  echo "    - 单独装试试: npm i -g @sleep2agi/agent-network"
-  exit 1
-fi
-# 验证 anet 在 PATH 里
-if ! command -v anet >/dev/null 2>&1; then
-  echo "[!] anet 命令找不到,~/.npm-global/bin 没在 PATH 里。"
-  echo "    试试: export PATH=~/.npm-global/bin:\$PATH; anet -v"
-  exit 1
-fi
-anet -v | head -1
-
-# 每个进程独立 tmux session,方便独立 attach/restart 不干扰别人
-PATH_PREFIX="PATH=~/.npm-global/bin:\$PATH"
-kill_session() { tmux kill-session -t "$1" 2>/dev/null || true; }
-
-# === 3. 启动 hub (独立 tmux session: anet-hub) ===
-mkdir -p ~/anodes && cd ~/anodes
-echo "[3/5] 启动 hub (tmux session: anet-hub) ..."
-kill_session anet-hub
-tmux new-session -d -s anet-hub -n hub "$PATH_PREFIX anet hub start --ip $HUB_IP; bash"
-
-# 等 hub 健康
-for i in $(seq 1 30); do
-  if curl -fs http://127.0.0.1:9200/health >/dev/null 2>&1; then
-    break
-  fi
-  sleep 1
-done
-
-# 等默认账户 admin/anethub 可登录 — anet hub start 在 /health OK 之后才异步
-# register default account, 需要再给它几秒钟. 这里直接轮询 login API.
-echo "[3/5] 等默认账户就绪 ..."
-LOGIN_OK=0
-for i in $(seq 1 30); do
-  RES=$(curl -s -X POST http://127.0.0.1:9200/api/auth/login \
-    -H 'Content-Type: application/json' \
-    -d '{"username":"admin","password":"anethub"}' 2>/dev/null || true)
-  if echo "$RES" | grep -q '"ok":true'; then
-    LOGIN_OK=1
-    break
-  fi
-  sleep 1
-done
-if [ "$LOGIN_OK" -ne 1 ]; then
-  echo "[!] admin/anethub 登录始终失败. anet-hub 那个 tmux session 里看看 hub 启动有没有报错:"
-  echo "    tmux a -t anet-hub"
-  exit 1
-fi
-
-# 登录 (cli 全局态写入 ~/.anet/config.json)
-echo "[3/5] 登录 admin/anethub ..."
-anet login --hub http://127.0.0.1:9200 --username admin --password anethub
-
-# === 4. 启动 dashboard (独立 tmux session: anet-dashboard) ===
-echo "[4/5] 启动 dashboard (tmux session: anet-dashboard) ..."
-kill_session anet-dashboard
-tmux new-session -d -s anet-dashboard -n dashboard "$PATH_PREFIX anet hub dashboard --ip $HUB_IP; bash"
-
-# === 5. 每个 agent 独立 tmux session: anet-node-<alias> ===
-echo "[5/5] 创建并启动 ${NODES[*]} ..."
-for alias in "${NODES[@]}"; do
-  if [ ! -f ".anet/nodes/$alias/config.json" ]; then
-    echo "  + 创建节点 $alias"
-    anet node create "$alias" --runtime claude-agent-sdk \
-      --model "$MINIMAX_MODEL" \
-      --env "ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic" \
-      --env "ANTHROPIC_AUTH_TOKEN=$MINIMAX_KEY" \
-      --env "ANTHROPIC_MODEL=$MINIMAX_MODEL" \
-      >/dev/null
-  else
-    echo "  - 节点 $alias 已存在,跳过创建"
-  fi
-  SESS="anet-node-$alias"
-  kill_session "$SESS"
-  tmux new-session -d -s "$SESS" -n "$alias" "$PATH_PREFIX anet node start \"$alias\"; bash"
-  sleep 0.5
-done
-
-LAN_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
-echo ""
-echo "================================================================"
-echo "  ✅ Agent Network 已启动 (每个进程一个独立 tmux session)"
-echo ""
-echo "  Hub:        http://$LAN_IP:9200    (tmux session: anet-hub)"
-echo "  Dashboard:  http://$LAN_IP:3000    (tmux session: anet-dashboard)  admin/anethub"
-echo ""
-for alias in "${NODES[@]}"; do
-  echo "  Agent $alias  →  tmux a -t anet-node-$alias"
-done
-echo ""
-echo "  查看所有 sessions:    tmux ls"
-echo "  attach 某个进程:      tmux a -t anet-hub | anet-dashboard | anet-node-<alias>"
-echo "  detach:               Ctrl-b d"
-echo "  停掉某个:             tmux kill-session -t anet-node-<alias>"
-echo "  停掉所有 anet-*:      tmux ls | awk -F: '/^anet-/{print \$1}' | xargs -I{} tmux kill-session -t {}"
-echo "================================================================"
-echo "  机器重启后一键恢复 (#117):"
-echo "    cd ~/anodes && anet project up"
-echo "  升级到最新 (channel-aware, #88):"
-echo "    anet upgrade                   # 当前 channel"
-echo "    anet upgrade --channel preview # 切 preview"
-echo "  Claude session 绑定 (#115):"
-echo "    anet node create <alias> --resume <session-id>"
-echo "    anet node create <alias> --resume-latest"
-echo "================================================================"
-tmux ls
+exit 64

--- a/docs/tests/report-one-shot-retirement-2026-07-31.txt
+++ b/docs/tests/report-one-shot-retirement-2026-07-31.txt
@@ -1,0 +1,63 @@
+One-shot installer retirement — 2026-07-31
+
+Base
+----
+9681c6f5e6c81b196aa2559ae4b8818966b62e1b
+
+Scope
+-----
+- public setup-anet.sh: 239 -> 26 lines
+- Chinese status page: 145 -> 29 lines
+- English status page: 145 -> 33 lines
+- clean-server retirement/channel link text: two lines per language
+
+Reason
+------
+The public installer was explicitly marked unverified while still being promoted
+as runnable. It contained broad process-name kills, recursive removal of user and
+npx state, a public bind default, a fixed bootstrap credential flow, shell-string
+secret forwarding, and stale MiniMax model claims.
+
+The URL is retained for old bookmarks, but now performs no setup, explains the
+retirement, links to maintained guides, and exits with status 64. The pages explain
+why old downloaded copies are unsafe instead of silently dropping the URL.
+
+Witnessed red — exact old artifact
+----------------------------------
+The exact script from base commit 9681c6f5 was extracted inside an isolated Alpine
+container and run as an unprivileged test user with WIPE=1 and a temporary HOME.
+Three sentinel files represented `.anet`, `.commhub`, and live `~/.npm/_npx` code.
+
+Result:
+
+  WITNESSED_RED old_rc=1 sentinels_deleted=3/3
+
+No host path was writable by the container.
+
+Witnessed green — retired artifact
+-----------------------------------
+PASS independent Dockerfile: `/tmp/commniu-one-shot-harness/Dockerfile`
+
+  sg docker -c 'docker build \
+    -f /tmp/commniu-one-shot-harness/Dockerfile \
+    -t anet-docs-one-shot-retired:dev \
+    /tmp/commniu-one-shot-retirement'
+
+The green gate verifies:
+- Bash syntax
+- exact non-zero status 64
+- retirement message present
+- before/after hashes of `.anet`, `.commhub`, and `_npx` fixtures are identical
+- destructive/process-match/public-bind/default-credential/model strings absent
+- contradictory verified/unverified page claims absent
+- WeChat is not described as shipped in clean-server
+
+PASS final VitePress 1.6.4 Docker build: 39.50 s
+PASS rendered Chinese and English retirement pages contain their status headings
+PASS rendered public `setup-anet.sh` contains the retirement notice
+PASS git diff --check
+
+Boundaries
+----------
+- No npm publish, merge, deployment, or production mutation.
+- No Codex or Claude model-node invocation.


### PR DESCRIPTION
## What changed

- replace the public `setup-anet.sh` with a zero-mutation retirement notice that exits 64
- replace both 145-line one-shot tutorials with short retirement/status pages
- keep the old URL alive for bookmarks instead of returning 404
- correct clean-server links that described WeChat as shipped and the retired installer as active

## Why

The unverified installer used broad `pkill -f`, recursive deletion of user and live npx state, a public bind default, fixed bootstrap credentials, shell-string secret forwarding, and stale model defaults. Merely simplifying its tutorial would have left the dangerous executable public.

## Validation

- witnessed red: exact pre-change script with `WIPE=1` deleted `.anet`, `.commhub`, and `_npx` sentinels 3/3 in an isolated container
- witnessed green: retired script exits 64 and leaves all three fixture hashes unchanged
- independent Docker source/static gate: PASS
- real VitePress 1.6.4 Docker build: PASS
- rendered retirement pages and public script: PASS
- `git diff --check`: PASS

Evidence: `docs/tests/report-one-shot-retirement-2026-07-31.txt`

Draft for independent review. No merge, npm publish, or deployment performed.