### PR TITLE
docs: neutralize retired one-shot installer promotion (14 sites, ZH+EN)

### DIFF
--- a/docs-site/docs/community.md
+++ b/docs-site/docs/community.md
@@ -39,4 +39,4 @@
 - [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) — 使用问题 / 设计讨论
 - [生态](/ecosystem) — 用 anet 做出来的项目
 - [更新日志](/changelog) — 各版本变化和迁移注意
-- [一键安装与起步](/guide/one-shot-install) — 第一次跑通
+- [30 秒上手](/guide/getting-started) — 第一次跑通（`setup-anet.sh` 一键脚本[已退役](/guide/one-shot-install)）

--- a/docs-site/docs/deploy/docker.md
+++ b/docs-site/docs/deploy/docker.md
@@ -10,7 +10,7 @@
 
 绝大多数自部署用户实际跑的是 **npm 全局装 + tmux + `anet project up`** 组合 —— 比 docker compose 更轻、debug 更直、迭代更快。详见：
 
-- [一键安装（多 Agent + tmux）](/guide/one-shot-install) — `setup-anet.sh` 在一台空 Ubuntu/Debian 上一行命令起 hub + dashboard + 多个 agent
+- [干净服务器从零部署](/deploy/clean-server) — 空 Ubuntu/Debian 上起 hub + dashboard + 多个 agent 的分步流程（`setup-anet.sh` 一键脚本[已退役](/guide/one-shot-install)，不要运行旧副本）
 - [npm 部署指南](/deploy/npm) — 手动版本的 step-by-step
 - [生产部署 / 公网部署安全](/deploy/production) — TLS / 防火墙 / 备份 / 公网风险点
 
@@ -48,4 +48,4 @@
 
 - [npm 部署指南](/deploy/npm) — 不走 Docker 的标准 step-by-step
 - [生产部署 / 公网部署安全](/deploy/production) — TLS / 防火墙 / 备份 / 安全注意
-- [一键安装](/guide/one-shot-install) — 最快路径
+- [一键安装脚本已退役](/guide/one-shot-install) — 旧 `setup-anet.sh` 已停用，页内说明替代路径

--- a/docs-site/docs/deploy/npm.md
+++ b/docs-site/docs/deploy/npm.md
@@ -320,7 +320,7 @@ npm install -g @sleep2agi/agent-network@preview
 ## 下一步
 
 **起步**：
-- [一键安装与起步](/guide/one-shot-install) — anet 装好后 5 分钟跑第一个 agent
+- [30 秒上手](/guide/getting-started) — anet 装好后跑第一个 agent（`setup-anet.sh` 一键脚本[已退役](/guide/one-shot-install)）
 
 **生产**：
 - [生产部署](/deploy/production) — 多机部署 + TLS + 备份

--- a/docs-site/docs/ecosystem.md
+++ b/docs-site/docs/ecosystem.md
@@ -30,7 +30,7 @@
 ## 下一步
 
 **做项目**：
-- [一键安装与起步](/guide/one-shot-install) — 装好 anet
+- [30 秒上手](/guide/getting-started) — 装好 anet（`setup-anet.sh` 一键脚本[已退役](/guide/one-shot-install)）
 - [Channel 插件](/guide/channels) — 接你自己的 IM / API
 
 **收录你的项目**：在 GitHub 开 issue 把项目名 / 链接 / 一句话简介贴上来（标题前缀 "Ecosystem:"）。

--- a/docs-site/docs/en/community.md
+++ b/docs-site/docs/en/community.md
@@ -38,4 +38,4 @@ If your team relies on Agent Network in production and wants to fund development
 - [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) — usage questions / design discussion
 - [Ecosystem](/en/ecosystem) — projects built with anet
 - [Changelog](/en/changelog) — release notes and migration tips
-- [One-shot install](/en/guide/one-shot-install) — first run
+- [Getting started](/en/guide/getting-started) — first run (the `setup-anet.sh` one-shot script is [retired](/en/guide/one-shot-install))

--- a/docs-site/docs/en/deploy/docker.md
+++ b/docs-site/docs/en/deploy/docker.md
@@ -10,7 +10,7 @@ Until then, the section below is the minimum "this actually works" path.
 
 Most self-hosters actually run **npm global install + tmux + `anet project up`**. It's lighter than docker compose, easier to debug, and iterates faster. See:
 
-- [One-shot install (multi-agent + tmux)](/en/guide/one-shot-install) — `setup-anet.sh` spins up hub + dashboard + multiple agents on a blank Ubuntu/Debian box in one command
+- [Clean-server deployment](/en/deploy/clean-server) — step-by-step flow for bringing up hub + dashboard + multiple agents on a blank Ubuntu/Debian box (the `setup-anet.sh` one-shot script is [retired](/en/guide/one-shot-install) — do not run an old copy)
 - [npm deployment guide](/en/deploy/npm) — manual, step-by-step
 - [Production / public-internet deployment](/en/deploy/production) — TLS / firewall / backup / public-internet risks
 
@@ -48,4 +48,4 @@ A containerized version is just steps 1–5 split across different services / co
 
 - [npm deployment guide](/en/deploy/npm) — non-Docker step-by-step
 - [Production / public-internet deployment](/en/deploy/production) — TLS / firewall / backup / safety
-- [One-shot install](/en/guide/one-shot-install) — fastest path
+- [One-shot installer retirement](/en/guide/one-shot-install) — the old `setup-anet.sh` is disabled; the page lists the replacement paths

--- a/docs-site/docs/en/deploy/npm.md
+++ b/docs-site/docs/en/deploy/npm.md
@@ -320,7 +320,7 @@ npm install -g @sleep2agi/agent-network@preview
 ## Next steps
 
 **Get started**:
-- [One-shot install](/en/guide/one-shot-install) — first agent in 5 minutes after install
+- [Getting started](/en/guide/getting-started) — run your first agent after install (the `setup-anet.sh` one-shot script is [retired](/en/guide/one-shot-install))
 
 **Production**:
 - [Production deployment](/en/deploy/production) — multi-machine + TLS + backups

--- a/docs-site/docs/en/ecosystem.md
+++ b/docs-site/docs/en/ecosystem.md
@@ -30,7 +30,7 @@ We don't require open source, a specific license, or any specific stack.
 ## Next steps
 
 **Build a project**:
-- [One-shot install](/en/guide/one-shot-install) — install anet
+- [Getting started](/en/guide/getting-started) — install anet (the `setup-anet.sh` one-shot script is [retired](/en/guide/one-shot-install))
 - [Channel plugins](/en/guide/channels) — wire your own IM / API
 
 **Get your project listed**: open a GitHub issue with name / link / one-line description (prefix the title with "Ecosystem:").

--- a/docs-site/docs/en/guide/account-system.md
+++ b/docs-site/docs/en/guide/account-system.md
@@ -325,7 +325,7 @@ If you still know the old password, run `anet passwd` (it prompts for the old on
 - [Network isolation](/en/concepts/networks) — RBAC permission matrix, invite codes, data isolation
 
 **Hands-on**:
-- [One-shot install](/en/guide/one-shot-install) — first agent after install
+- [Getting started](/en/guide/getting-started) — first agent after install (the `setup-anet.sh` one-shot script is [retired](/en/guide/one-shot-install))
 - [Multi-model config](/en/guide/multi-model) — configure different AI models
 - [Dashboard](/en/guide/dashboard) — Web UI for tokens / users / networks
 

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -143,7 +143,7 @@ Detailed test reports: [Changelog](/en/changelog) + [test reports](https://githu
 - `codex-sdk` runtime end-to-end (real LLM reply) — no OpenAI test key yet, the second half is pending verification
 - `anet license` / `anet activate` — v0.6 legacy, OSS users don't need to touch these (see [troubleshooting](/en/troubleshooting#license-expired-license-expired-legacy-behavior))
 - `anet network create` and cross-user network sharing — code merged but no E2E regression
-- **One-shot install script `setup-anet.sh`** — not end-to-end verified, audit before use, see [One-shot install (experimental)](/en/guide/one-shot-install)
+- **One-shot install script `setup-anet.sh`** — retired and disabled, do not run an old copy, see [retirement notice](/en/guide/one-shot-install)
 :::
 
 ::: tip No hosted service

--- a/docs-site/docs/en/guide/multi-model.md
+++ b/docs-site/docs/en/guide/multi-model.md
@@ -309,7 +309,7 @@ done
 **Use it now**:
 
 **Configure and tune**:
-- Where does the cost go? See the cost comparison in [One-shot install](/en/guide/one-shot-install)
+- Where does the cost go? See the "Cost" column in the model tables earlier on this page
 - Persist multiple API keys? See [Agent Node -- config.json env field](/en/guide/agent-node)
 - Rate-limit errors? Most providers have concurrency caps -- see [FAQ](/en/faq)
 

--- a/docs-site/docs/guide/account-system.md
+++ b/docs-site/docs/guide/account-system.md
@@ -326,7 +326,7 @@ Key 在 `anet node create` 时输入，保存在当前项目的 `.anet/nodes/<�
 - [网络隔离](/concepts/networks) — RBAC 权限矩阵、邀请码、数据隔离原理
 
 **实操**：
-- [一键安装与起步](/guide/one-shot-install) — 装好 anet 后第一个 agent
+- [30 秒上手](/guide/getting-started) — 装好 anet 后第一个 agent（`setup-anet.sh` 一键脚本[已退役](/guide/one-shot-install)）
 - [多模型配置](/guide/multi-model) — 各种 AI 模型怎么配
 - [Dashboard](/guide/dashboard) — Web UI 看 token / 用户 / 网络
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -143,7 +143,7 @@ anet node start my-bot
 - `codex-sdk` runtime 端到端（LLM 真回话）—— 缺 OpenAI 测试 key，后半程待补验
 - `anet license` / `anet activate` — v0.6 legacy, OSS 用户无需操作（详 [troubleshooting](/troubleshooting#license-expired-授权过期-legacy-行为)）
 - `anet network create` 跨用户网络共享 — 代码已合并但未做 E2E 回归
-- **一键安装脚本 `setup-anet.sh`** — 未经端到端验证, 用前自审, 见 [一键安装（实验性）](/guide/one-shot-install)
+- **一键安装脚本 `setup-anet.sh`** — 已退役停用, 不要运行旧副本, 见 [退役说明](/guide/one-shot-install)
 :::
 
 ::: tip 没有官方托管

--- a/docs-site/docs/guide/multi-model.md
+++ b/docs-site/docs/guide/multi-model.md
@@ -254,7 +254,7 @@ done
 **直接用**：
 
 **配置和调优**：
-- 钱花在哪儿？看 [一键安装与起步](/guide/one-shot-install) 一节的成本对比
+- 钱花在哪儿？看本页上方模型对照表的「成本」列
 - 想把多个 API Key 持久化？看 [Agent Node 配置](/guide/agent-node) 的 env 字段
 - API 限流报错？多数厂商有并发上限，[FAQ](/faq) 里有应对策略
 


### PR DESCRIPTION
`setup-anet.sh` was retired in #558, but other pages still promised it would install everything in one command — a reader was told "one command brings up hub + dashboard + agents" and only found out after clicking through.

Links to the retirement page are kept (it explains *why* the script is gone); no wording still promises a working one-shot install.

## Scope is wider than the review list

Swept the whole ref rather than trusting the 4 listed pages:

```
git grep -n -iE 'one-shot|setup-anet|一键' origin/main -- docs-site
```

Most `一键` hits are unrelated (`anet upgrade 一键`, Docker compose, demos) — mentions are candidates, not defects. Filtering to pages that actually link `/guide/one-shot-install` surfaced **4 page pairs the review had not listed**, two of which were independently wrong:

| Page | Was | Now |
|---|---|---|
| `deploy/docker.md:13` | "`setup-anet.sh` … in one command" (restated the retired behaviour) | points at `/deploy/clean-server` step-by-step + retirement note |
| `deploy/docker.md:51` | "fastest path" | "the old script is disabled" |
| `deploy/npm.md:323` | "first agent in 5 minutes" | points at getting-started |
| `community.md:42` | "first run" | points at getting-started |
| `ecosystem.md:33` *(missed by review)* | "install anet" | points at getting-started |
| `guide/account-system.md:329` *(missed)* | "first agent after install" | points at getting-started |
| `guide/getting-started.md:146` *(missed)* | "**experimental**, not E2E verified, audit before use" | "retired and disabled, do not run an old copy" |
| `guide/multi-model.md:257` *(missed)* | "see the **cost comparison** in One-shot install" — no such section exists on that page | the Cost column in this page's own model tables |

Untouched by agreement: `deploy/daemon.md`, `guide/upgrade.md`, `guide/architecture.md`.

## Verification

**Checker self-proved before use** — same script run against `origin/main` (known-bad sample) and the branch:

```
[origin/main]  18 reference lines / 16 still promotional   ← all 16 named above
[branch]       16 reference lines /  0 still promotional
```

Non-zero denominator on both sides, so a scan that silently matched nothing would not read as a pass. (18 → 16 because the two false `multi-model` pointers became on-page references, not links.)

**Dead-link gate proved real, not assumed.** `vitepress build docs` exits 0 on this branch — but exit 0 only means something if the gate can fail, so I appended a deliberate `/guide/this-page-does-not-exist-xyz`, rebuilt, and got exit **1**. Removed it; final build exit **0**.

Merge impact read with three-dot `git diff origin/main...HEAD`: 14 files, 16 insertions / 16 deletions — symmetric ZH/EN, no line-count drift. No headings touched, so no anchors change and external links keep resolving.

Draft, not self-merging. This site has no auto-deploy — merging alone will not publish.