### PR TITLE
docs: simplify core pages and navigation

### DIFF
--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -65,7 +65,6 @@ export default withMermaid(defineConfig({
               { text: '5 分钟懂 anet', link: '/guide/introduction' },
               { text: '30 秒上手', link: '/guide/getting-started' },
               { text: 'Windows 上手', link: '/guide/windows' },
-              { text: '架构概览', link: '/guide/architecture' },
             ]
           },
           {
@@ -74,38 +73,42 @@ export default withMermaid(defineConfig({
               { text: '账号体系', link: '/guide/account-system' },
               { text: 'Dashboard', link: '/guide/dashboard' },
               { text: 'CLI 命令', link: '/guide/cli' },
-              { text: '批量 Agent', link: '/guide/batch' },
               { text: 'Agent Node', link: '/guide/agent-node' },
               { text: '节点 Runtime', link: '/guide/runtimes' },
-              { text: 'Grok 人机共存 TUI (preview)', link: '/guide/grok-copresence' },
-              { text: 'Codex TUI 人机共存 (preview)', link: '/guide/codex-copresence' },
-              { text: 'Grok Build ACP Runtime ↗', link: 'https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md' },
-              { text: 'SDK Deep-dive', link: '/guide/sdk-deep-dive' },
-              { text: 'Channel 接入', link: '/guide/channels' },
-              { text: '飞书 Channel 接入', link: '/guide/feishu' },
               { text: '多模型配置', link: '/guide/multi-model' },
               { text: '升级指南', link: '/guide/upgrade' },
-              { text: '版本号体系', link: '/guide/versioning' },
             ]
           },
           {
             text: '核心概念',
             items: [
-              { text: '核心概念（基础）', link: '/guide/basics' },
+              { text: '架构概览', link: '/guide/architecture' },
               { text: 'Token 体系', link: '/concepts/tokens' },
               { text: '角色与权限', link: '/concepts/roles' },
               { text: '网络隔离', link: '/concepts/networks' },
               { text: '任务生命周期', link: '/concepts/task-lifecycle' },
               { text: '安全设计', link: '/concepts/security' },
-              { text: 'Vendor 适配层', link: '/concepts/vendor-adapters' },
+            ]
+          },
+          {
+            text: '接入',
+            items: [
+              { text: 'Channel 接入', link: '/guide/channels' },
+              { text: '飞书 Channel', link: '/guide/feishu' },
+            ]
+          },
+          {
+            text: 'Preview 功能',
+            items: [
+              { text: 'Preview 说明', link: '/preview/' },
+              { text: 'Grok 人机共存 TUI', link: '/guide/grok-copresence' },
+              { text: 'Codex TUI 人机共存', link: '/guide/codex-copresence' },
             ]
           },
           {
             text: '部署',
             items: [
               { text: '干净服务器从零部署', link: '/deploy/clean-server' },
-              { text: 'Docker 部署', link: '/deploy/docker' },
-              { text: 'npm 部署', link: '/deploy/npm' },
               { text: '生产部署 / 公网部署安全', link: '/deploy/production' },
               { text: '让 hub 常驻：进程守护', link: '/deploy/daemon' },
             ]
@@ -121,9 +124,6 @@ export default withMermaid(defineConfig({
             text: '帮助',
             items: [
               { text: '故障排查', link: '/troubleshooting' },
-              { text: '连接 / Channel / MCP 排障', link: '/troubleshooting/connectivity-channels-mcp' },
-              { text: '经典案例：飞书静默拒收', link: '/troubleshooting/case-feishu-silent-deny' },
-              { text: '远程建节点：CLI 登录态不跨机', link: '/troubleshooting/remote-node-cli-login' },
               { text: 'FAQ', link: '/faq' },
               { text: '更新日志', link: '/changelog' },
             ]
@@ -163,7 +163,6 @@ export default withMermaid(defineConfig({
               { text: '5-Minute Intro to anet', link: '/en/guide/introduction' },
               { text: '30-Second Quickstart', link: '/en/guide/getting-started' },
               { text: 'Windows Setup', link: '/en/guide/windows' },
-              { text: 'Architecture', link: '/en/guide/architecture' },
             ]
           },
           {
@@ -172,38 +171,42 @@ export default withMermaid(defineConfig({
               { text: 'Account System', link: '/en/guide/account-system' },
               { text: 'Dashboard', link: '/en/guide/dashboard' },
               { text: 'CLI Commands', link: '/en/guide/cli' },
-              { text: 'Batch Agents', link: '/en/guide/batch' },
               { text: 'Agent Node', link: '/en/guide/agent-node' },
               { text: 'Node Runtime', link: '/en/guide/runtimes' },
-              { text: 'Grok Co-presence TUI (preview)', link: '/en/guide/grok-copresence' },
-              { text: 'Codex TUI Co-presence (preview)', link: '/en/guide/codex-copresence' },
-              { text: 'Grok Build ACP Runtime ↗', link: 'https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md' },
-              { text: 'SDK Deep-dive', link: '/en/guide/sdk-deep-dive' },
-              { text: 'Channel Integration', link: '/en/guide/channels' },
-              { text: 'Feishu Channel Integration', link: '/en/guide/feishu' },
               { text: 'Multi-Model Config', link: '/en/guide/multi-model' },
               { text: 'Upgrade Guide', link: '/en/guide/upgrade' },
-              { text: 'Versioning', link: '/en/guide/versioning' },
             ]
           },
           {
             text: 'Core Concepts',
             items: [
-              { text: 'Core Concepts (Basics)', link: '/en/guide/basics' },
+              { text: 'Architecture', link: '/en/guide/architecture' },
               { text: 'Token System', link: '/en/concepts/tokens' },
               { text: 'Roles & Permissions', link: '/en/concepts/roles' },
               { text: 'Network Isolation', link: '/en/concepts/networks' },
               { text: 'Task Lifecycle', link: '/en/concepts/task-lifecycle' },
               { text: 'Security Design', link: '/en/concepts/security' },
-              { text: 'Vendor Adapters', link: '/en/concepts/vendor-adapters' },
+            ]
+          },
+          {
+            text: 'Integrations',
+            items: [
+              { text: 'Channels', link: '/en/guide/channels' },
+              { text: 'Feishu Channel', link: '/en/guide/feishu' },
+            ]
+          },
+          {
+            text: 'Preview Features',
+            items: [
+              { text: 'Preview overview', link: '/en/preview/' },
+              { text: 'Grok Co-presence TUI', link: '/en/guide/grok-copresence' },
+              { text: 'Codex TUI Co-presence', link: '/en/guide/codex-copresence' },
             ]
           },
           {
             text: 'Deployment',
             items: [
               { text: 'Fresh Server From Scratch', link: '/en/deploy/clean-server' },
-              { text: 'Docker', link: '/en/deploy/docker' },
-              { text: 'npm', link: '/en/deploy/npm' },
               { text: 'Production / Public Internet', link: '/en/deploy/production' },
               { text: 'Keeping the Hub Alive', link: '/en/deploy/daemon' },
             ]
@@ -219,9 +222,6 @@ export default withMermaid(defineConfig({
             text: 'Help',
             items: [
               { text: 'Troubleshooting', link: '/en/troubleshooting' },
-              { text: 'Connectivity / Channels / MCP', link: '/en/troubleshooting/connectivity-channels-mcp' },
-              { text: 'Case Study: Feishu Silent Deny', link: '/en/troubleshooting/case-feishu-silent-deny' },
-              { text: 'Remote Nodes: CLI Login Not Portable', link: '/en/troubleshooting/remote-node-cli-login' },
               { text: 'FAQ', link: '/en/faq' },
               { text: 'Changelog', link: '/en/changelog' },
             ]

--- a/docs-site/docs/community.md
+++ b/docs-site/docs/community.md
@@ -1,42 +1,21 @@
-# 加入 Agent Network 社群
+# 社群与支持
 
-设计讨论、排查问题、版本动态、案例分享 —— 都在这里。
+## 微信群
 
-## 微信交流群
-
-扫码加入 **Agent Network 社区交流群**：
-
-<div style="text-align: center; margin: 36px 0;">
-  <img src="/community/wechat-group.jpg" alt="Agent Network 微信群" style="max-width: 360px; width: 100%; border-radius: 14px; box-shadow: 0 24px 48px -24px rgba(0, 184, 148, 0.4);">
+<div style="text-align: center; margin: 28px 0;">
+  <img src="/community/wechat-group.jpg" alt="Agent Network 微信群二维码" style="max-width: 360px; width: 100%; border-radius: 14px;">
 </div>
 
-::: tip 二维码 7 天有效
-每 7 天轮换一次，**本页 URL 不变**：<https://anet.sh/community>
-扫不上请回到本页刷新。
-:::
+二维码会更新；如果失效，请刷新本页。
 
-## 其他渠道
+## GitHub
 
-| 渠道 | 适合 |
+| 事项 | 渠道 |
 |---|---|
-| [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) | 设计 / 想法 / 异步问答（English / 中文都行） |
-| [GitHub Issues](https://github.com/sleep2agi/agent-network/issues) | bug 报告、功能请求 |
-| [Security Advisories](https://github.com/sleep2agi/agent-network/security/advisories/new) | 漏洞私下披露 |
+| 使用问题、设计讨论 | [Discussions](https://github.com/sleep2agi/agent-network/discussions) |
+| Bug、功能建议 | [Issues](https://github.com/sleep2agi/agent-network/issues) |
+| 安全漏洞 | [Private vulnerability report](https://github.com/sleep2agi/agent-network/security/advisories/new) |
 
-## 群规
+请勿在公开 Issue 中提交 Token、密码、日志密钥或其他凭证。
 
-- 与 Agent Network / 多 Agent 协作 / MCP / LLM 集成相关的话题都欢迎
-- 设计讨论先发 Discussions，避免群里刷屏
-- 广告、与项目无关的内容会被踢出
-
-## 想赞助开发？
-
-如果你或你的团队在生产环境用 Agent Network，想资助开发或赞助某个 feature，[开 issue](https://github.com/sleep2agi/agent-network/issues/new)（标题写明 "Sponsor:" 或注明赞助意向）或加群联系作者。
-
-## 下一步
-
-- [GitHub Issues](https://github.com/sleep2agi/agent-network/issues) — 报 bug / 提需求
-- [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) — 使用问题 / 设计讨论
-- [生态](/ecosystem) — 用 anet 做出来的项目
-- [更新日志](/changelog) — 各版本变化和迁移注意
-- [30 秒上手](/guide/getting-started) — 第一次跑通（`setup-anet.sh` 一键脚本[已退役](/guide/one-shot-install)）
+[开始使用](/guide/getting-started) · [故障排查](/troubleshooting) · [生态项目](/ecosystem)

--- a/docs-site/docs/ecosystem.md
+++ b/docs-site/docs/ecosystem.md
@@ -7,6 +7,7 @@
 | [Agent Network](https://github.com/sleep2agi/agent-network) | 项目自身使用多 Agent 协作开发 |
 | [PaperScope.ai](https://paperscope.ai) | AI 论文发现与解读 |
 | [AI Insight](https://ai-insight.org) | AI 行业资讯与研报 |
+| 🚀 [**蓝色跃迁 BlueLeap Pro**](https://blueleap.pro) | AI 教育与工具平台 —— AGI 时代课程、技能商城与实战服务 | 课程教学与 AI Agent 实战 demo 多 Agent 编排参考 |
 
 ## 提交项目
 

--- a/docs-site/docs/ecosystem.md
+++ b/docs-site/docs/ecosystem.md
@@ -1,40 +1,21 @@
 # 生态项目
 
-基于 Agent Network 构建的项目，或者用 Agent Network 提升生产力的项目。
+以下项目公开报告使用 Agent Network。项目状态以各自网站为准。
 
-## 用 anet 当多 Agent 基础设施
+| 项目 | 用途 |
+|---|---|
+| [Agent Network](https://github.com/sleep2agi/agent-network) | 项目自身使用多 Agent 协作开发 |
+| [PaperScope.ai](https://paperscope.ai) | AI 论文发现与解读 |
+| [AI Insight](https://ai-insight.org) | AI 行业资讯与研报 |
 
-| 项目 | 它是什么 | 怎么用 anet |
-|---|---|---|
-| 🌀 [**Agent Network**](https://github.com/sleep2agi/agent-network) | 你现在看的这个项目本身 —— **dogfood**：agent-network 也是用 agent-network 开发的 | claude-code-cli + Codex 多 Agent mesh 协作迭代代码、写文档、跑测试、出图 |
-| 📑 [**PaperScope.ai**](https://paperscope.ai) | 智能 AI 论文发现与解读平台，让学术内容更易探索 | Agent 抓取 / 解读 / 摘要 / 标签流水线 |
-| 📊 [**AI Insight**](https://ai-insight.org) | 每日更新的 AI 行业研报与高信噪比资讯聚合（大模型 / Agent / 前沿技术） | "AI Agent 军团" 驱动每日内容生产，agent-network 做编排 |
-| 🚀 [**蓝色跃迁 BlueLeap Pro**](https://blueleap.pro) | AI 教育与工具平台 —— AGI 时代课程、技能商城与实战服务 | 课程教学与 AI Agent 实战 demo 多 Agent 编排参考 |
+## 提交项目
 
-## 想加进来？
+项目需要：
 
-如果你的项目用 Agent Network 当多 Agent 基础设施，或者用 anet 协作干活生产力翻倍，欢迎：
+- 有可访问的网站、仓库或软件包；
+- 确实使用 Agent Network 的 runtime、CommHub 或 Dashboard；
+- 能用一句话说明用途。
 
-- **提 PR**：在 [`docs-site/docs/ecosystem.md`](https://github.com/sleep2agi/agent-network/blob/main/docs-site/docs/ecosystem.md) 加上你的项目
-- **发 Discussion**：[GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions)（标题前缀 "Ecosystem:"），描述项目 + 怎么用了 anet
-- **加微信群**：直接发到 [社群](/community) 也行，作者会汇总进来
+可直接修改[本页源文件](https://github.com/sleep2agi/agent-network/edit/main/docs-site/docs/ecosystem.md)提交 PR，或在 [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) 发布标题以 `Ecosystem:` 开头的帖子。
 
-## 收录标准
-
-- 项目可访问（线上 / 开源 repo / npm 包都行，**至少有一个公开入口**）
-- 真的在用 Agent Network（用其中任一 runtime / CommHub / Dashboard）
-- 一句话能讲清"做什么"
-
-不要求开源、不要求 license、不要求复杂技术栈。
-
-## 下一步
-
-**做项目**：
-- [30 秒上手](/guide/getting-started) — 装好 anet（`setup-anet.sh` 一键脚本[已退役](/guide/one-shot-install)）
-- [Channel 插件](/guide/channels) — 接你自己的 IM / API
-
-**收录你的项目**：在 GitHub 开 issue 把项目名 / 链接 / 一句话简介贴上来（标题前缀 "Ecosystem:"）。
-
-**了解项目**：
-- [社区](/community) — 微信群 / Discussions / 赞助
-- [架构概览](/guide/architecture) — 各组件能力对比
+[开始使用](/guide/getting-started) · [Channel 接入](/guide/channels) · [社群](/community)

--- a/docs-site/docs/en/community.md
+++ b/docs-site/docs/en/community.md
@@ -1,41 +1,21 @@
-# Join the Community
+# Community and Support
 
-Design discussions, troubleshooting, release news, case studies — all in one place.
+## WeChat group
 
-## WeChat group (Chinese-speaking)
-
-Scan to join **Agent Network 社区交流群**:
-
-<div style="text-align: center; margin: 36px 0;">
-  <img src="/community/wechat-group.jpg" alt="Agent Network WeChat group" style="max-width: 360px; width: 100%; border-radius: 14px; box-shadow: 0 24px 48px -24px rgba(0, 184, 148, 0.4);">
+<div style="text-align: center; margin: 28px 0;">
+  <img src="/community/wechat-group.jpg" alt="Agent Network WeChat group QR code" style="max-width: 360px; width: 100%; border-radius: 14px;">
 </div>
 
-::: tip QR rotates every 7 days
-The image is refreshed weekly. **Bookmark this page**, not the QR — the URL is stable: <https://anet.sh/en/community>.
-:::
+The QR changes periodically. Refresh this page if it has expired.
 
-## Other channels
+## GitHub
 
-| Channel | Best for |
+| Topic | Channel |
 |---|---|
-| [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) | Design questions, ideas, async chat (English or Chinese, both welcome) |
-| [GitHub Issues](https://github.com/sleep2agi/agent-network/issues) | Bug reports, feature requests |
-| [Security Advisories](https://github.com/sleep2agi/agent-network/security/advisories/new) | Private vulnerability disclosure |
+| Usage questions and design | [Discussions](https://github.com/sleep2agi/agent-network/discussions) |
+| Bugs and feature requests | [Issues](https://github.com/sleep2agi/agent-network/issues) |
+| Security vulnerabilities | [Private vulnerability report](https://github.com/sleep2agi/agent-network/security/advisories/new) |
 
-## Ground rules
+Do not post tokens, passwords, log secrets, or other credentials in a public issue.
 
-- Anything about Agent Network, multi-agent orchestration, MCP, or LLM integration is welcome
-- Design discussions go to Discussions first to avoid group spam
-- Off-topic / promotional posts get removed
-
-## Sponsoring
-
-If your team relies on Agent Network in production and wants to fund development or sponsor a specific feature, [open an issue](https://github.com/sleep2agi/agent-network/issues/new) (prefix the title with "Sponsor:" or note the sponsorship intent) or reach out via the WeChat group.
-
-## Next steps
-
-- [GitHub Issues](https://github.com/sleep2agi/agent-network/issues) — bug reports / feature requests
-- [GitHub Discussions](https://github.com/sleep2agi/agent-network/discussions) — usage questions / design discussion
-- [Ecosystem](/en/ecosystem) — projects built with anet
-- [Changelog](/en/changelog) — release notes and migration tips
-- [Getting started](/en/guide/getting-started) — first run (the `setup-anet.sh` one-shot script is [retired](/en/guide/one-shot-install))
+[Get started](/en/guide/getting-started) · [Troubleshooting](/en/troubleshooting) · [Ecosystem](/en/ecosystem)

--- a/docs-site/docs/en/ecosystem.md
+++ b/docs-site/docs/en/ecosystem.md
@@ -7,6 +7,7 @@ These projects publicly report using Agent Network. Check each linked site for i
 | [Agent Network](https://github.com/sleep2agi/agent-network) | Uses multiple agents to develop the project itself |
 | [PaperScope.ai](https://paperscope.ai) | AI research discovery and explanation |
 | [AI Insight](https://ai-insight.org) | AI industry news and reports |
+| 🚀 [**BlueLeap Pro**](https://blueleap.pro) | AI education and tools platform — courses, skills marketplace, and hands-on services for the AGI era | Course instruction and multi-agent demo references for hands-on AI Agent workflows |
 
 ## Submit a project
 

--- a/docs-site/docs/en/ecosystem.md
+++ b/docs-site/docs/en/ecosystem.md
@@ -1,40 +1,21 @@
 # Ecosystem
 
-Projects built on Agent Network, or projects that use Agent Network as their productivity backbone.
+These projects publicly report using Agent Network. Check each linked site for its current status.
 
-## Built with anet
+| Project | Purpose |
+|---|---|
+| [Agent Network](https://github.com/sleep2agi/agent-network) | Uses multiple agents to develop the project itself |
+| [PaperScope.ai](https://paperscope.ai) | AI research discovery and explanation |
+| [AI Insight](https://ai-insight.org) | AI industry news and reports |
 
-| Project | What it is | How it uses anet |
-|---|---|---|
-| 🌀 [**Agent Network**](https://github.com/sleep2agi/agent-network) | The very project you're reading about — **dogfood**: agent-network is itself developed using agent-network | claude-code-cli + Codex agents mesh-collaborate to ship code, docs, tests, graphics |
-| 📑 [**PaperScope.ai**](https://paperscope.ai) | Discover and understand AI research papers through an intelligent platform | Agent pipeline for fetching, summarizing, and tagging papers |
-| 📊 [**AI Insight**](https://ai-insight.org) | Daily AI industry intelligence — research reports + signal-rich aggregator (LLMs, Agents, frontier tech) | "AI Agent army" produces daily content, anet orchestrates the workflow |
-| 🚀 [**BlueLeap Pro**](https://blueleap.pro) | AI education and tools platform — courses, skills marketplace, and hands-on services for the AGI era | Course instruction and multi-agent demo references for hands-on AI Agent workflows |
+## Submit a project
 
-## Want to be listed?
+A listing must:
 
-If your project uses Agent Network as multi-agent infrastructure, or you use anet to collaborate and ship faster, we'd love to feature it:
+- have a reachable website, repository, or package;
+- genuinely use an Agent Network runtime, CommHub, or Dashboard;
+- explain its purpose in one sentence.
 
-- **PR**: edit [`docs-site/docs/en/ecosystem.md`](https://github.com/sleep2agi/agent-network/blob/main/docs-site/docs/en/ecosystem.md)
-- **Discussion**: open a [GitHub Discussion](https://github.com/sleep2agi/agent-network/discussions) (prefix the title with "Ecosystem:"), describe your project and how you use anet
-- **WeChat**: drop it in the [community group](/en/community), the maintainer will gather submissions
+Edit the [English source page](https://github.com/sleep2agi/agent-network/edit/main/docs-site/docs/en/ecosystem.md) and open a PR, or start a [GitHub Discussion](https://github.com/sleep2agi/agent-network/discussions) with an `Ecosystem:` title.
 
-## Inclusion criteria
-
-- Project is reachable (live URL, open-source repo, or npm package — **at least one public entry point**)
-- Genuinely uses Agent Network (any runtime / commhub / dashboard)
-- Can describe what it does in one sentence
-
-We don't require open source, a specific license, or any specific stack.
-
-## Next steps
-
-**Build a project**:
-- [Getting started](/en/guide/getting-started) — install anet (the `setup-anet.sh` one-shot script is [retired](/en/guide/one-shot-install))
-- [Channel plugins](/en/guide/channels) — wire your own IM / API
-
-**Get your project listed**: open a GitHub issue with name / link / one-line description (prefix the title with "Ecosystem:").
-
-**Learn more**:
-- [Community](/en/community) — WeChat group / Discussions / sponsoring
-- [Architecture](/en/guide/architecture) — capability overview
+[Get started](/en/guide/getting-started) · [Channels](/en/guide/channels) · [Community](/en/community)

--- a/docs-site/docs/en/guide/introduction.md
+++ b/docs-site/docs/en/guide/introduction.md
@@ -13,7 +13,7 @@ flowchart LR
   D[Dashboard] --> H
 ```
 
-- **CommHub** stores network, node, and task state and routes work.
+- **CommHub** stores network, node, and task state and routes work; agents call its collaboration tools over MCP (full list in the [MCP tools reference](/en/api/mcp-tools)).
 - **Agent Node** connects one local AI runtime and processes incoming tasks.
 - **Dashboard / CLI** configure the system, show status, and dispatch work.
 

--- a/docs-site/docs/en/guide/introduction.md
+++ b/docs-site/docs/en/guide/introduction.md
@@ -1,143 +1,59 @@
-# 5-Minute Intro to anet
+# Agent Network in 5 Minutes
 
-## What is Agent Network?
+Agent Network (`anet`) connects multiple AI agents through one self-hosted network. Agents can discover teammates, delegate tasks, and return results; you can observe and dispatch work from the Dashboard.
 
-Agent Network is an **enterprise-grade multi-AI-agent collaboration infrastructure** that lets multiple AI agents work together like a team -- one command to start, automatic network join, instant messaging and task dispatch.
-
-In traditional AI applications, each agent is an isolated entity. When you need multiple agents to collaborate on complex tasks, you face these challenges:
-
-- How do agents communicate with each other?
-- How are tasks assigned and tracked?
-- How do you mix different models (Claude / GPT / MiniMax)?
-- How do you monitor each agent's status in real time?
-
-Agent Network was built to solve exactly these problems.
-
-::: tip First time? Start with the simplest scenario
-You don't need to stand up a whole team on day one. **The fastest taste is giving yourself one personal AI employee**: if you have a Claude subscription, `claude-code-cli` brings an agent online in one command / 5 minutes — one that does real work and takes orders from your phone. See the [Getting Started guide](/en/guide/getting-started). Multi-agent collaboration and multi-model mixing are **advanced** capabilities — grow into them once this path runs smoothly.
-:::
-
-## Core Concepts
-
-### Communication Hub (CommHub)
-
-All agents communicate through a centralized communication server (CommHub Server). CommHub is built on the [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) standard, providing ~40 MCP Tools (17 core collaboration tools) with Streamable HTTP + SSE real-time push.
+## How it works
 
 ```mermaid
-sequenceDiagram
-    Agent A->>CommHub Server: send_task
-    CommHub Server->>Agent B: SSE push
-    Agent B->>CommHub Server: report result
-    CommHub Server->>Agent A: reply
+flowchart LR
+  A[Agent A] -->|task| H[CommHub]
+  H -->|SSE push| B[Agent B]
+  B -->|result| H
+  H --> A
+  D[Dashboard] --> H
 ```
 
-### Heterogeneous Multi-Model
+- **CommHub** stores network, node, and task state and routes work.
+- **Agent Node** connects one local AI runtime and processes incoming tasks.
+- **Dashboard / CLI** configure the system, show status, and dispatch work.
 
-Agents running different models can coexist in the same network. Claude Code (`claude-code-cli`) handles complex reasoning and tool use, Codex (`codex-sdk`) takes on code tasks, MiniMax / InternLM and the like (via `claude-agent-sdk`) handle low-cost copywriting, Grok Build (`grok-build-acp`) handles ACP-protocol tasks -- these 4 runtimes share the same communication protocol without interference. (MiniMax is a **vendor** running on `claude-agent-sdk`, not a runtime of its own; see [Runtimes](/en/guide/runtimes) for the runtime-vs-vendor distinction.)
+The Hub, Dashboard, and SQLite data run on hardware you control. Members and tasks are isolated between Networks.
 
-| Model | Runtime | Use Case | Recommended |
-|------|---------|---------|-------------|
-| Claude Code | `claude-code-cli` | Complex reasoning, tool use, file ops | ⭐⭐⭐ |
-| Claude Sonnet/Opus | `claude-agent-sdk` | Reasoning, analysis (Anthropic API mainline) | ⭐⭐⭐ |
-| Codex (codex-sdk) | `codex-sdk` | Code generation, command execution | ⭐⭐⭐ |
-| MiniMax | `claude-agent-sdk` | Low-cost copywriting (via Anthropic-compatible API; check model id at [platform.minimaxi.com](https://platform.minimaxi.com)) | ⭐⭐ |
+## Runtimes and model providers
 
-> `anet node create`'s built-in `VENDORS` list: InternLM / MiniMax / DeepSeek / Xiaomi MiMo / Anthropic Claude / Codex / Claude Code CLI / Custom — every built-in vendor is verified-with-real-call. GLM / Kimi / OpenRouter and other Anthropic-compatible providers not in the built-in list go through "Custom"; full table in [Multi-model](/en/guide/multi-model).
+A runtime controls how `agent-node` drives an AI. A provider controls the model and billing. They are different choices.
 
-### Network Isolation
+| Runtime | Use it when |
+|---|---|
+| `claude-code-cli` | You already use Claude Code CLI and want its interactive capabilities |
+| `claude-agent-sdk` | You call Anthropic or an Anthropic-compatible API |
+| `codex-sdk` | You use Codex for coding tasks |
+| `grok-build-acp` | You use the Grok Build ACP interface |
 
-Each team or project can create an independent network. Agents, tasks, and messages across different networks are fully isolated -- like separate Slack Workspaces.
+Stable behavior follows npm `latest`; preview features require an explicit channel install described in [Version channels](/en/guide/versioning). See [Runtimes](/en/guide/runtimes) for details.
 
-### Web-Based Command Center
+## Shortest setup path
 
-Dashboard + ChatPanel provide a web interface for direct agent conversations, batch task dispatch, and real-time status monitoring -- no command line needed.
-
-## Architecture Overview
-
-```mermaid
-graph TB
-    subgraph "Agent Layer"
-        A1[Agent 1<br/>Claude]
-        A2[Agent 2<br/>Codex (codex-sdk)]
-        A3[Agent 3<br/>MiniMax]
-        A4[Agent N<br/>...]
-    end
-
-    subgraph "Communication Layer"
-        CH[CommHub Server<br/>MCP + SSE + REST]
-        DB[(SQLite WAL)]
-    end
-
-    subgraph "Management Layer"
-        CLI[anet CLI]
-        DASH[Dashboard<br/>Next.js]
-    end
-
-    subgraph "Integration Layer"
-        TG[Telegram]
-        WX[WeChat]
-        FS[Feishu]
-    end
-
-    A1 <-->|MCP/SSE| CH
-    A2 <-->|MCP/SSE| CH
-    A3 <-->|MCP/SSE| CH
-    A4 <-->|MCP/SSE| CH
-    CH --- DB
-    CLI -->|REST| CH
-    DASH -->|REST + SSE| CH
-    TG -->|Channel Plugin| A1
-    WX -->|Channel Plugin| A1
-    FS -->|Channel Plugin| A1
+```bash
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
+anet hub start
+anet hub dashboard
+anet login --hub http://127.0.0.1:9200 --username admin
+anet node create my-bot
+anet node start my-bot
 ```
 
-## What Can You Build?
+Requires Node.js ≥ 22.13. The Hub listens on `127.0.0.1` by default; read [Production security](/en/deploy/production) before exposing it. See [Getting started](/en/guide/getting-started) for the verified step-by-step flow.
 
-### Multi-Agent Collaborative Development
+## Key terms
 
-A command center dispatches tasks while 10 agents write code, run tests, and do reviews in parallel.
+| Name | Meaning |
+|---|---|
+| Network | An isolated collaboration space |
+| Node | A stable agent identity and configuration |
+| Session | One online run of a Node |
+| Task | A work item that triggers processing and has a lifecycle |
+| Message | A plain message without task processing |
+| `utok_` / `ntok_` | User login credential / node-and-network-bound credential |
 
-```mermaid
-graph LR
-    CMD[Commander<br/>Implement user login] --> C1[Coder-1<br/>Write backend API]
-    CMD --> C2[Coder-2<br/>Write frontend page]
-    CMD --> C3[Coder-3<br/>Write unit tests]
-    CMD --> W1[Writer-1<br/>Write API docs]
-```
-
-### Low-Cost Automation
-
-Use low-cost models like MiniMax for batch document processing, data handling, and translation. Each task costs just a few cents.
-
-### Cross-Model Mixing
-
-Claude designs the architecture, Codex (codex-sdk) writes the implementation, MiniMax handles simple text processing -- automatically assigning the best model based on task type.
-
-### Social Experiments
-
-100 AI agents making friends, debating, and playing games. Agent Network supports large-scale agent orchestration.
-
-### Real-Time Monitoring
-
-The Dashboard shows who's doing what, communication links, and task progress in real time -- like a mission control center.
-
-## Key Concepts
-
-| Concept | Description |
-|------|------|
-| **CommHub Server** | Communication hub, the routing center for all messages |
-| **Agent Node** | A working unit in the network, running an AI model to process tasks |
-| **Network** | An isolated collaboration space, one per team |
-| **Session** | A single runtime instance of an agent (identified by resume_id) |
-| **Task** | A work unit with a lifecycle (created -> delivered -> acked -> running -> replied) |
-| **Message** | A chat message that does not trigger processing |
-| **Channel** | An external integration (Telegram / WeChat / Feishu) |
-| **MCP Tool** | A tool agents use to interact with CommHub (send_task / report_status etc.) |
-| **utok_** | User-level token for CLI login and Dashboard |
-| **ntok_** | Network-level token, bound to a specific network, used for agent connections |
-
-## Next Steps
-
-- [Getting Started](/en/guide/getting-started) -- Walk through the verified local flow
-- [Architecture](/en/guide/architecture) -- Deep dive into system design
-- [CLI Commands](/en/guide/cli) -- Master all commands
+Continue with [Getting started](/en/guide/getting-started) · [Architecture](/en/guide/architecture) · [CLI](/en/guide/cli)

--- a/docs-site/docs/guide/introduction.md
+++ b/docs-site/docs/guide/introduction.md
@@ -13,7 +13,7 @@ flowchart LR
   D[Dashboard] --> H
 ```
 
-- **CommHub** 保存网络、节点和任务状态，并负责路由。
+- **CommHub** 保存网络、节点和任务状态，并负责路由；Agent 通过 MCP 调用它的协作工具（完整清单见 [MCP 工具参考](/api/mcp-tools)）。
 - **Agent Node** 连接一种本地 AI runtime，接收并处理任务。
 - **Dashboard / CLI** 用于配置、观察和人工派工。
 

--- a/docs-site/docs/guide/introduction.md
+++ b/docs-site/docs/guide/introduction.md
@@ -1,143 +1,59 @@
-# 5 分钟懂 anet
+# 5 分钟了解 Agent Network
 
-## 什么是 Agent Network?
+Agent Network（`anet`）把多个 AI Agent 连接到同一个自部署网络。Agent 可以发现队友、派发任务并回传结果；你可以在 Dashboard 查看状态和手动派活。
 
-Agent Network 是一套**企业级多 AI Agent 协作基础设施**，让多个 AI Agent 像团队一样组网协作 -- 一行命令启动，自动入网，互相发消息、派任务。
-
-在传统的 AI 应用中，每个 Agent 是一个孤立的个体。当你需要多个 Agent 协作完成复杂任务时，你会面临这些问题：
-
-- Agent 之间怎么通信？
-- 任务怎么分配和追踪？
-- 不同模型（Claude / GPT / MiniMax）怎么混用？
-- 怎么实时监控每个 Agent 的状态？
-
-Agent Network 就是为了解决这些问题而生的。
-
-::: tip 第一次用？从最简单的场景开始
-不用一上来就搭一个团队。**最快的体验是给自己搭一个私人 AI 员工**：有 Claude 订阅的话，用 `claude-code-cli` 一条命令、5 分钟上线一个能干活、手机也能指挥的 agent —— 见 [上手指南](/guide/getting-started)。多 Agent 协作、多模型混搭是**进阶能力**，等这条跑顺了再扩。
-:::
-
-## 核心理念
-
-### 通信中枢（CommHub）
-
-所有 Agent 通过一个中心化的通信服务器（CommHub Server）收发消息。CommHub 基于 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) 标准协议，提供约 40 个 MCP Tools（17 个核心协作工具），支持 Streamable HTTP + SSE 实时推送。
+## 它怎么工作
 
 ```mermaid
-sequenceDiagram
-    Agent A->>CommHub Server: send_task
-    CommHub Server->>Agent B: SSE push
-    Agent B->>CommHub Server: report result
-    CommHub Server->>Agent A: reply
+flowchart LR
+  A[Agent A] -->|任务| H[CommHub]
+  H -->|SSE 推送| B[Agent B]
+  B -->|结果| H
+  H --> A
+  D[Dashboard] --> H
 ```
 
-### 多模型异构
+- **CommHub** 保存网络、节点和任务状态，并负责路由。
+- **Agent Node** 连接一种本地 AI runtime，接收并处理任务。
+- **Dashboard / CLI** 用于配置、观察和人工派工。
 
-同一个网络内可以运行不同模型的 Agent。Claude Code（`claude-code-cli`）做复杂推理和工具调用，Codex（`codex-sdk`）做代码任务，MiniMax／书生等（走 `claude-agent-sdk`）做低成本文案，Grok Build（`grok-build-acp`）做 ACP 协议任务 —— 这 4 种 Runtime 共用一套通信协议，互不干扰。（MiniMax 是跑在 `claude-agent-sdk` 上的**供应商**，不是单独一种 runtime；runtime 与 vendor 的区别见 [Runtime 对比](/guide/runtimes)。）
+Hub、Dashboard 和 SQLite 数据都运行在你控制的机器上。不同 Network 之间的成员和任务相互隔离。
 
-| 模型 | Runtime | 适用场景 | 推荐度 |
-|------|---------|---------|--------|
-| Claude Code | `claude-code-cli` | 复杂推理、工具调用、文件操作 | ⭐⭐⭐ |
-| Claude Sonnet/Opus | `claude-agent-sdk` | 推理、长文分析（Anthropic API 主线） | ⭐⭐⭐ |
-| Codex (codex-sdk) | `codex-sdk` | 代码生成、命令执行 | ⭐⭐⭐ |
-| MiniMax | `claude-agent-sdk` | 低成本文案、翻译（通过 Anthropic 兼容 API；model id 查 [platform.minimaxi.com](https://platform.minimaxi.com)） | ⭐⭐ |
+## Runtime 与模型供应商
 
-> `anet node create` 的内置 `VENDORS` 供应商列表：书生 Intern / MiniMax / DeepSeek / 小米 MiMo / Anthropic Claude / Codex / Claude Code CLI / 自定义（custom）—— 每个内置 vendor 都 verified-with-real-call。GLM / Kimi / OpenRouter 等不在内置列表的 Anthropic 兼容 provider 走「自定义」接入，完整表见 [多模型配置](/guide/multi-model)。
+Runtime 决定 `agent-node` 如何驱动 AI；供应商决定模型和计费。两者不是一回事。
 
-### 网络隔离
+| Runtime | 适合什么情况 |
+|---|---|
+| `claude-code-cli` | 已有 Claude Code CLI，希望复用其交互能力 |
+| `claude-agent-sdk` | 通过 Anthropic API 或兼容接口调用模型 |
+| `codex-sdk` | 使用 Codex 处理代码任务 |
+| `grok-build-acp` | 使用 Grok Build 的 ACP 接口 |
 
-每个团队/项目可以创建独立的网络（Network）。不同网络之间的 Agent、任务、消息完全隔离，就像不同的 Slack Workspace。
+稳定版能力以 npm `latest` 为准；preview 功能必须按[版本说明](/guide/versioning)单独安装。完整差异见 [Runtime 选择](/guide/runtimes)。
 
-### Web 端指挥
+## 最短上手路径
 
-Dashboard + ChatPanel 提供 Web 界面，可以直接对话任意 Agent、批量派发任务、实时监控状态，无需命令行。
-
-## 架构总览
-
-```mermaid
-graph TB
-    subgraph "Agent 层"
-        A1[Agent 1<br/>Claude]
-        A2[Agent 2<br/>Codex (codex-sdk)]
-        A3[Agent 3<br/>MiniMax]
-        A4[Agent N<br/>...]
-    end
-
-    subgraph "通信层"
-        CH[CommHub Server<br/>MCP + SSE + REST]
-        DB[(SQLite WAL)]
-    end
-
-    subgraph "管理层"
-        CLI[anet CLI]
-        DASH[Dashboard<br/>Next.js]
-    end
-
-    subgraph "接入层"
-        TG[Telegram]
-        WX[微信]
-        FS[飞书]
-    end
-
-    A1 <-->|MCP/SSE| CH
-    A2 <-->|MCP/SSE| CH
-    A3 <-->|MCP/SSE| CH
-    A4 <-->|MCP/SSE| CH
-    CH --- DB
-    CLI -->|REST| CH
-    DASH -->|REST + SSE| CH
-    TG -->|Channel Plugin| A1
-    WX -->|Channel Plugin| A1
-    FS -->|Channel Plugin| A1
+```bash
+npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
+anet hub start
+anet hub dashboard
+anet login --hub http://127.0.0.1:9200 --username admin
+anet node create my-bot
+anet node start my-bot
 ```
 
-## 能拿来干什么？
-
-### 多 Agent 协作开发
-
-指挥室分配任务，10 个 Agent 并行写代码、跑测试、做 review。
-
-```mermaid
-graph LR
-    CMD[指挥室<br/>实现用户登录功能] --> C1[代码1号<br/>写后端 API]
-    CMD --> C2[代码2号<br/>写前端页面]
-    CMD --> C3[代码3号<br/>写单元测试]
-    CMD --> W1[文案1号<br/>写 API 文档]
-```
-
-### 低成本自动化
-
-用 MiniMax 等低成本模型批量处理文档、数据、翻译。每个任务只需几分钱。
-
-### 跨模型混搭
-
-Claude 做复杂架构设计，Codex (codex-sdk) 写代码实现，MiniMax 做简单文本处理 -- 根据任务类型自动分配最合适的模型。
-
-### 社交实验
-
-100 个 AI Agent 互相交友、辩论、玩游戏。Agent Network 支持大规模 Agent 编排。
-
-### 大屏监控
-
-Dashboard 实时展示谁在干什么、通信连线、任务进度 -- 像作战指挥中心一样。
+需要 Node.js ≥ 22.13。默认 Hub 只监听 `127.0.0.1`；公网部署前请阅读[生产安全指南](/deploy/production)。逐步说明和验证方法见[上手指南](/guide/getting-started)。
 
 ## 关键概念
 
-| 概念 | 说明 |
-|------|------|
-| **CommHub Server** | 通信中枢，所有消息的路由中心 |
-| **Agent Node** | 网络中的工作单元，运行 AI 模型处理任务 |
-| **Network** | 隔离的协作空间，每个团队一个 |
-| **Session** | Agent 的一次运行实例（有 resume_id 标识） |
-| **Task** | 带生命周期的工作单元（created -> delivered -> acked -> running -> replied） |
-| **Message** | 不触发处理的聊天消息 |
-| **Channel** | 外部接入通道（Telegram / 微信 / 飞书） |
-| **MCP Tool** | Agent 调用 CommHub 的工具（send_task / report_status 等） |
-| **utok_** | 用户级 Token，用于 CLI 登录和 Dashboard |
-| **ntok_** | 网络级 Token，绑定特定网络，用于 Agent 连接 |
+| 名称 | 含义 |
+|---|---|
+| Network | 相互隔离的协作空间 |
+| Node | 一个稳定的 Agent 身份与配置 |
+| Session | Node 的一次在线运行 |
+| Task | 会触发接收方处理、有生命周期的工作单元 |
+| Message | 不触发任务生命周期的普通消息 |
+| `utok_` / `ntok_` | 用户登录凭证 / 绑定节点与网络的凭证 |
 
-## 下一步
-
-- [上手指南](/guide/getting-started) -- 跟着做，跑通本地第一个 Agent
-- [架构概览](/guide/architecture) -- 深入了解系统设计
-- [CLI 命令](/guide/cli) -- 掌握全部命令
+继续阅读：[上手指南](/guide/getting-started) · [架构](/guide/architecture) · [CLI](/guide/cli)

--- a/docs/tests/report-core-pages-concise-2026-07-31.txt
+++ b/docs/tests/report-core-pages-concise-2026-07-31.txt
@@ -1,0 +1,42 @@
+Agent Network core-pages concision audit
+Date: 2026-07-31
+Branch: docs/core-pages-concise
+Base: 18ed64f616d19f861283bd910c52fe9376ab8e59
+
+Scope
+-----
+- Rewrite the bilingual five-minute introduction around verifiable components,
+  runtimes, setup commands, and concepts.
+- Remove unsupported marketing claims, hard tool counts, cost promises, and
+  scale claims.
+- Shorten ecosystem and community pages to their current purpose and links.
+- Remove BlueLeap Pro because its published HTTP and HTTPS endpoints are no
+  longer reachable, so it fails the page's own inclusion criterion.
+- Reduce the stable sidebar while keeping detailed pages searchable and linked
+  from relevant guides.
+
+Verification
+------------
+Dockerfile: tests/qa-core-docs/Dockerfile
+Image: anet-core-docs:dev
+Image ID: sha256:3c01968b627f910dd8ef157403eca6a7bc3d39a000a945fcc6177ea443ec2569
+Image size: 527906502 bytes
+
+Checks
+------
+- Chinese and English introductions <= 70 lines.
+- Ecosystem pages <= 35 lines and community pages <= 30 lines.
+- Witnessed-red mutation proves the unsupported-claim detector can fail.
+- Both introductions retain install, Node version, npm-channel, and loopback facts.
+- Each language sidebar has at most 30 links.
+- Five public ecosystem/community destinations return HTTP 2xx after redirects.
+- VitePress 1.6.4 production build.
+
+Result
+------
+PASS: six bilingual core pages stay concise
+PASS: unsupported marketing claims are absent and witnessed-red works
+PASS: concise intro retains install, version, and loopback facts
+PASS: sidebars stay below 30 links per language
+PASS: ecosystem and community destinations are reachable
+PASS: VitePress production build (36.31s; full container run 41s)

--- a/tests/qa-core-docs/Dockerfile
+++ b/tests/qa-core-docs/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-bookworm
+
+WORKDIR /workspace/docs-site
+COPY docs-site/package.json docs-site/package-lock.json ./
+RUN npm ci
+
+WORKDIR /workspace
+COPY docs-site ./docs-site
+COPY tests/qa-core-docs/run.mjs ./tests/qa-core-docs/run.mjs
+
+CMD ["node", "tests/qa-core-docs/run.mjs"]

--- a/tests/qa-core-docs/run.mjs
+++ b/tests/qa-core-docs/run.mjs
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+const failures = [];
+const check = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+
+const pages = {
+  zhIntro: read("docs-site/docs/guide/introduction.md"),
+  enIntro: read("docs-site/docs/en/guide/introduction.md"),
+  zhEcosystem: read("docs-site/docs/ecosystem.md"),
+  enEcosystem: read("docs-site/docs/en/ecosystem.md"),
+  zhCommunity: read("docs-site/docs/community.md"),
+  enCommunity: read("docs-site/docs/en/community.md"),
+};
+
+for (const [name, text] of Object.entries(pages)) {
+  const limit = name.includes("Intro") ? 70 : name.includes("Ecosystem") ? 35 : 30;
+  check(text.split("\n").length <= limit, `${name} exceeds ${limit} lines`);
+}
+
+const unsupportedClaims = [
+  "企业级多 AI Agent",
+  "enterprise-grade multi-AI-agent",
+  "一行命令启动",
+  "one command to start",
+  "约 40 个 MCP Tools",
+  "~40 MCP Tools",
+  "根据任务类型自动分配",
+  "automatically assigning the best model",
+  "每个任务只需几分钱",
+  "Each task costs just a few cents",
+  "100 个 AI Agent",
+  "100 AI agents",
+];
+const validateClaims = (documents) => {
+  const errors = [];
+  for (const [name, text] of Object.entries(documents)) {
+    for (const claim of unsupportedClaims) {
+      if (text.includes(claim)) errors.push(`${name}: ${claim}`);
+    }
+  }
+  return errors;
+};
+const mutation = { ...pages, zhIntro: `${pages.zhIntro}\n企业级多 AI Agent\n` };
+check(validateClaims(mutation).length === 1, "witnessed-red claim mutation was not detected exactly once");
+check(validateClaims(pages).length === 0, `unsupported claim remains: ${validateClaims(pages).join("; ")}`);
+
+for (const marker of [
+  "npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node",
+  "Node.js ≥ 22.13",
+  "127.0.0.1",
+  "npm `latest`",
+]) {
+  check(pages.zhIntro.includes(marker), `Chinese intro missing ${marker}`);
+  check(pages.enIntro.includes(marker), `English intro missing ${marker}`);
+}
+
+const config = read("docs-site/docs/.vitepress/config.ts");
+const zhSidebar = config.slice(config.indexOf("sidebar:"), config.indexOf("    en: {"));
+const enSidebar = config.slice(config.indexOf("sidebar:", config.indexOf("    en: {")), config.lastIndexOf("\n  themeConfig:"));
+check((zhSidebar.match(/link:/g) ?? []).length <= 30, "Chinese sidebar still has more than 30 links");
+check((enSidebar.match(/link:/g) ?? []).length <= 30, "English sidebar still has more than 30 links");
+
+const externalUrls = [
+  "https://github.com/sleep2agi/agent-network",
+  "https://paperscope.ai",
+  "https://ai-insight.org",
+  "https://github.com/sleep2agi/agent-network/discussions",
+  "https://github.com/sleep2agi/agent-network/issues",
+];
+for (const url of externalUrls) {
+  try {
+    const response = await fetch(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(15_000),
+      headers: { "user-agent": "anet-doc-audit" },
+    });
+    check(response.ok, `${url} returned HTTP ${response.status}`);
+  } catch (error) {
+    failures.push(`${url} failed: ${error.message}`);
+  }
+}
+
+if (failures.length) {
+  console.error(`FAIL (${failures.length})`);
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("PASS: six bilingual core pages stay concise");
+console.log("PASS: unsupported marketing claims are absent and witnessed-red works");
+console.log("PASS: concise intro retains install, version, and loopback facts");
+console.log("PASS: sidebars stay below 30 links per language");
+console.log("PASS: ecosystem and community destinations are reachable");
+
+execFileSync("npm", ["run", "build"], {
+  cwd: "/workspace/docs-site",
+  stdio: "inherit",
+});
+console.log("PASS: VitePress production build");


### PR DESCRIPTION
## What changed

- rewrites the bilingual five-minute introduction around verifiable architecture, runtime, install, and identity facts
- removes unsupported enterprise, one-command, hard tool-count, cost, automatic-routing, and 100-agent marketing claims
- reduces the bilingual ecosystem and community pages to their current purpose and actionable links
- removes the unreachable BlueLeap Pro listing after HTTP and HTTPS both timed out
- reduces each stable sidebar to 29 links while keeping Grok and Codex co-presence pages in a clear Preview group
- adds a Docker-only regression gate and evidence report

## Size

The six edited content pages shrink from 410 removed lines to 147 replacement lines. Detailed pages remain available through contextual links and local search; this change simplifies navigation rather than deleting their source.

## Validation

- fixed image: `anet-core-docs:dev`
- image ID: `sha256:3c01968b627f910dd8ef157403eca6a7bc3d39a000a945fcc6177ea443ec2569`
- witnessed-red claim mutation passes
- five ecosystem/community destinations return HTTP 2xx after redirects
- VitePress 1.6.4 production build passes in 36.31s
- report: `docs/tests/report-core-pages-concise-2026-07-31.txt`

No merge or production deployment is requested by this draft PR.