### PR TITLE
security: 从公开升级脚本移除 rm -rf ~/.npm/_npx

### DIFF
--- a/docs-site/docs/public/upgrade-preview.sh
+++ b/docs-site/docs/public/upgrade-preview.sh
@@ -19,7 +19,7 @@ fi
 
 export PATH=~/.npm-global/bin:$PATH
 
-echo "[1/4] Upgrading agent-network (channel: preview) ..."
+echo "[1/3] Upgrading agent-network (channel: preview) ..."
 if command -v anet >/dev/null 2>&1; then
   anet upgrade --channel preview
 else
@@ -29,15 +29,12 @@ else
 fi
 
 echo ""
-echo "[2/4] Stopping the dashboard tmux session ..."
+echo "[2/3] Stopping the dashboard tmux session ..."
 tmux kill-session -t anet-dashboard 2>/dev/null || true
 
-echo ""
-echo "[3/4] Clearing the npx cache (so the new preview dashboard is pulled) ..."
-rm -rf ~/.npm/_npx
 
 echo ""
-echo "[4/4] Restarting the dashboard ..."
+echo "[3/3] Restarting the dashboard ..."
 HUB_IP="${ANET_HUB_IP:-0.0.0.0}"
 PATH_PREFIX="PATH=~/.npm-global/bin:\$PATH"
 tmux new-session -d -s anet-dashboard -n dashboard "$PATH_PREFIX anet hub dashboard --ip $HUB_IP; bash"

--- a/docs-site/docs/public/upgrade.sh
+++ b/docs-site/docs/public/upgrade.sh
@@ -28,7 +28,7 @@ fi
 # Make sure npm-global is on PATH.
 export PATH=~/.npm-global/bin:$PATH
 
-echo "[1/4] Upgrading agent-network (channel: latest) ..."
+echo "[1/3] Upgrading agent-network (channel: latest) ..."
 if command -v anet >/dev/null 2>&1; then
   # Channel-aware multi-package upgrade (#88). anet upgrade resolves the
   # right dist-tag, surfaces the plan, and installs whatever is globally
@@ -42,15 +42,12 @@ else
 fi
 
 echo ""
-echo "[2/4] Stopping the dashboard tmux session ..."
+echo "[2/3] Stopping the dashboard tmux session ..."
 tmux kill-session -t anet-dashboard 2>/dev/null || true
 
-echo ""
-echo "[3/4] Clearing the npx cache (so the new Dashboard version is pulled) ..."
-rm -rf ~/.npm/_npx
 
 echo ""
-echo "[4/4] Restarting the dashboard ..."
+echo "[3/3] Restarting the dashboard ..."
 HUB_IP="${ANET_HUB_IP:-0.0.0.0}"
 PATH_PREFIX="PATH=~/.npm-global/bin:\$PATH"
 tmux new-session -d -s anet-dashboard -n dashboard "$PATH_PREFIX anet hub dashboard --ip $HUB_IP; bash"


### PR DESCRIPTION
🔴 `https://anet.sh/upgrade.sh` 与 `upgrade-preview.sh` 现在线上可下载，脚本自身即教用户 `curl | bash`。

两者都含无条件的 `rm -rf ~/.npm/_npx`。**该目录不是缓存，是活代码** —— npx 把包解到那里并从那里执行，整目录删除会破坏该机器上其它正在使用 npx 的工具。

**隔离环境实测**：种入另一工具的 npx 产物 → 执行该行 → 文件 1→0；移除后同样条件下文件仍在。（独立审查者亦在容器中复现：安装 anet 成功后走到该步，别的工具 `_npx/bbbb-other-tool` 被删光。）

原意是清缓存以拉新版 Dashboard，但前置的 `anet upgrade --channel latest` / `npm i -g` 已更新全局包；为一个包重取而清空整个 `_npx` 不成比例。

判据与 #558（退役 setup-anet.sh）一致：**公开可下载脚本不得含破坏用户环境的操作**。

改动：仅删除该行及其步骤说明，步骤编号 4→3，`bash -n` 通过。**纯删除，不新增行为。**

说明：#559 也改这两个文件（默认绑定与凭据输出），合并后需 rebase。