### PR TITLE
security: agent-only.sh / hub-only.sh 的 WIPE 不再删 ~/.npm/_npx

### DIFF
--- a/docs-site/docs/public/agent-only.sh
+++ b/docs-site/docs/public/agent-only.sh
@@ -87,7 +87,7 @@ if [ "$WIPE" = "1" ] || [ "$WIPE" = "true" ]; then
   echo "[wipe] 清状态..."
   tmux ls 2>/dev/null | awk -F: '/^anet-/{print $1}' | xargs -I{} tmux kill-session -t {} 2>/dev/null || true
   pkill -f agent-node 2>/dev/null || true
-  rm -rf ~/.anet ~/anodes/.anet ~/.npm/_npx ~/.npm-global/lib/node_modules/@sleep2agi 2>/dev/null
+  rm -rf ~/.anet ~/anodes/.anet ~/.npm-global/lib/node_modules/@sleep2agi 2>/dev/null
 fi
 
 echo "[1/4] 装 anet cli + agent-node (preview)..."

--- a/docs-site/docs/public/hub-only.sh
+++ b/docs-site/docs/public/hub-only.sh
@@ -120,7 +120,7 @@ if [ "$WIPE" = "1" ] || [ "$WIPE" = "true" ]; then
   pkill -9 -f commhub-server 2>/dev/null || true
   pkill -9 -f agent-network-dashboard 2>/dev/null || true
   pkill -9 -f agent-node 2>/dev/null || true
-  rm -rf ~/.anet ~/.commhub ~/.npm/_npx ~/.npm-global/lib/node_modules/@sleep2agi 2>/dev/null
+  rm -rf ~/.anet ~/.commhub ~/.npm-global/lib/node_modules/@sleep2agi 2>/dev/null
   mkdir -p ~/.commhub
 fi
 


### PR DESCRIPTION
承接 #562。**枚举全部 6 个公开脚本后发现问题比已报告的更广** —— 我先前只修了被点名的两个。

| 脚本 | 状态 |
|---|---|
| install.sh | ✅ 干净 |
| setup-anet.sh | ✅ 已退役（#558） |
| upgrade.sh / upgrade-preview.sh | ✅ _npx 已移除（#562） |
| **agent-only.sh / hub-only.sh** | 🔴 本 PR |

两者 WIPE=1 时 `rm -rf ... ~/.npm/_npx ...`。**该目录不属于 anet**，是本机所有 npx 工具的活代码目录。用户选择「清掉我的 anet」并未选择销毁其它工具。

仅摘除该路径，anet 自身清理路径全部保留，`bash -n` 通过，纯删除。

**遗留（另行跟进，未在本 PR）**：
- 两脚本 WIPE 分支仍用 `pkill -f` / `pkill -9 -f` 按名杀进程 —— 会误杀同名的他人进程（本仓出过此类事故）
- hub-only.sh 仍硬编码并打印 `admin/anethub`（与今日确认的分渠道口径不符）