### PR TITLE
security: WIPE 分支的 pkill 限定到调用者自己的进程

### DIFF
--- a/docs-site/docs/public/agent-only.sh
+++ b/docs-site/docs/public/agent-only.sh
@@ -86,7 +86,7 @@ export PATH=~/.npm-global/bin:$PATH
 if [ "$WIPE" = "1" ] || [ "$WIPE" = "true" ]; then
   echo "[wipe] 清状态..."
   tmux ls 2>/dev/null | awk -F: '/^anet-/{print $1}' | xargs -I{} tmux kill-session -t {} 2>/dev/null || true
-  pkill -f agent-node 2>/dev/null || true
+  pkill -u "$(id -u)" -f agent-node 2>/dev/null || true
   rm -rf ~/.anet ~/anodes/.anet ~/.npm-global/lib/node_modules/@sleep2agi 2>/dev/null
 fi
 

--- a/docs-site/docs/public/hub-only.sh
+++ b/docs-site/docs/public/hub-only.sh
@@ -117,9 +117,9 @@ if [ "$WIPE" = "1" ] || [ "$WIPE" = "true" ]; then
         ~/.config/systemd/user/anet-dashboard.service \
         ~/.config/systemd/user/anet-commander.service 2>/dev/null
   tmux ls 2>/dev/null | awk -F: '/^anet-/{print $1}' | xargs -I{} tmux kill-session -t {} 2>/dev/null || true
-  pkill -9 -f commhub-server 2>/dev/null || true
-  pkill -9 -f agent-network-dashboard 2>/dev/null || true
-  pkill -9 -f agent-node 2>/dev/null || true
+  pkill -9 -u "$(id -u)" -f commhub-server 2>/dev/null || true
+  pkill -9 -u "$(id -u)" -f agent-network-dashboard 2>/dev/null || true
+  pkill -9 -u "$(id -u)" -f agent-node 2>/dev/null || true
   rm -rf ~/.anet ~/.commhub ~/.npm-global/lib/node_modules/@sleep2agi 2>/dev/null
   mkdir -p ~/.commhub
 fi


### PR DESCRIPTION
承接 #562 / #563 —— 公开脚本里最后一项已知的破坏性模式。

`agent-only.sh` / `hub-only.sh` 的 `WIPE=1` 分支按进程名模式杀进程。**模式匹配会命中同名的其它进程**，在多用户 / 多实例机器上会杀掉不属于调用者的 `agent-node` / `commhub-server`（本仓曾因模式杀进程导致生产中枢被误杀）。

加 `-u "$(id -u)"`：单用户安装行为完全不变；共享机器上不再波及他人进程。

WIPE 段前一行已用 `tmux kill-session` 清 `anet-*` 会话，pkill 是孤儿兜底，限定范围不影响正常清理路径。`bash -n` 通过。

**顺带一个现场证据**：我原本想写个测试验证「限定后仍能杀自己的进程」，用了 `pkill -f "sleep 400"` —— 结果它连带杀掉了**运行该测试脚本的 shell 本身**，因为脚本自己的命令行里含有那个字符串。测试进程退出码 144。

**这恰好就是本 PR 要消除的失效模式**：`-f` 匹配的是完整命令行，会命中任何「碰巧提到该字符串」的进程，包括你自己。

**遗留（另行处理）**：`hub-only.sh` 仍硬编码并打印 `admin/anethub`。