### PR TITLE
docs(server): 去掉会静默过时的写死数量与版本

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -38,13 +38,16 @@ Once running:
 
 ## Pairs with
 
-| Package | Version |
+| Package | |
 |---|---|
-| [`@sleep2agi/agent-network`](https://www.npmjs.com/package/@sleep2agi/agent-network) | 2.1.7 |
-| [`@sleep2agi/agent-network-dashboard`](https://www.npmjs.com/package/@sleep2agi/agent-network-dashboard) | 0.4.2 |
-| [`@sleep2agi/agent-node`](https://www.npmjs.com/package/@sleep2agi/agent-node) | 2.3.0 |
+| [`@sleep2agi/agent-network`](https://www.npmjs.com/package/@sleep2agi/agent-network) | CLI |
+| [`@sleep2agi/agent-network-dashboard`](https://www.npmjs.com/package/@sleep2agi/agent-network-dashboard) | Web UI |
+| [`@sleep2agi/agent-node`](https://www.npmjs.com/package/@sleep2agi/agent-node) | Agent runtime host |
 
-## MCP tools (17)
+Install the matching versions with `npm install -g <pkg>` — the `latest` dist-tag on npm is
+authoritative. Pinning versions here goes stale on every release and nobody comes back to fix it.
+
+## MCP tools
 
 ### Agent-side
 | Tool | Description |
@@ -96,7 +99,7 @@ Network-management endpoints (`/api/networks…`) are present and used by the cu
 
 Auth: `Authorization: Bearer <token>` header, or `?token=<token>` query.
 
-## SQLite schema (13 tables)
+## SQLite schema
 
 Auto-created on first run.
 


### PR DESCRIPTION
`server/README.md` 三处写死值都已与现实脱节：

| 写着 | 实际 |
|---|---|
| MCP tools **(17)** | 我数 37 `server.tool` + 3 `registerTool` = **40**；另一位数出 **38** |
| SQLite schema **(13 tables)** | `db.ts` 有 25 处 `CREATE TABLE`、**24** 个唯一表名 |
| Pairs with: 2.1.7 / 0.4.2 / 2.3.0 | npm latest 实为 **2.2.21 / 0.6.0 / 2.4.13** |

🔴 **第一项最能说明问题：同一个「有多少工具」，三次统计给出三个不同的数（17 / 38 / 40）。** 不同数法算不同的东西（是否含 registerTool、是否含 alias），而任何一个写进标题都会在下次增删时静默变错。

改法统一为**不写数字、指向权威来源**：标题去掉计数（下面的表格本身就是清单），版本表改为说明各包用途并明写以 npm `latest` dist-tag 为准。

同判据今日已用于 #561（introduction 的「约 40 个 MCP Tools」改为指向 `/api/mcp-tools`）及多处版本去硬编码。