### PR TITLE
ci: 门禁公开可下载脚本里的破坏性模式

### DIFF
--- a/.github/scripts/check-public-script-safety.py
+++ b/.github/scripts/check-public-script-safety.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Block destructive patterns from shipping in publicly downloadable shell scripts.
+
+Everything under docs-site/docs/public/*.sh is served from https://anet.sh/<name>
+and several of those scripts tell the reader to pipe them straight into bash.
+A mistake there runs on a stranger's machine with their privileges.
+
+On 2026-07-31 four such scripts were found to contain, between them:
+  * `rm -rf ~/.npm/_npx`  — that directory is not ours. npx unpacks packages
+    there and executes FROM there, so wiping it breaks every other npx-based
+    tool on the machine. Reproduced in a container: a second tool's files
+    went 1 -> 0.
+  * `pkill -f agent-node` — pattern matching hits same-named processes owned
+    by anyone. This repo has already taken down a production hub that way.
+
+All four were found by hand. This guard exists so the next one is not.
+
+Scope note: only two rules, both unambiguous. A guard that cries wolf gets
+disabled, and then it protects nothing. Deliberately NOT flagged here:
+  * printing a documented default password (correct for the stable channel,
+    which is what these scripts install)
+  * binding 0.0.0.0 behind an explicit opt-in env var
+Those need judgement, so they stay with human review.
+"""
+import re
+import sys
+from pathlib import Path
+
+PUBLIC_DIR = Path("docs-site/docs/public")
+
+# Paths this product owns. Wiping these is the user's stated intent (WIPE=1).
+OURS = ("~/.anet", "~/.commhub", "~/anodes/.anet",
+        "~/.npm-global/lib/node_modules/@sleep2agi", "~/.anet-grok")
+
+RM_RF = re.compile(r"\brm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+(?P<targets>[^\n;&|]+)")
+KILL = re.compile(r"\b(pkill|killall)\b(?P<args>[^\n;&|]*)")
+USER_SCOPED = re.compile(r"-u\s+\S")
+
+
+def check(path: Path):
+    """Return a list of (line_no, rule, offending_text)."""
+    out = []
+    for i, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+
+        m = RM_RF.search(line)
+        if m:
+            for tok in m.group("targets").split():
+                if tok.startswith("-") or tok.startswith("2>") or tok == "||" or tok == "true":
+                    continue
+                if not any(tok.startswith(o) for o in OURS):
+                    out.append((i, "rm-rf-outside-product", tok))
+
+        k = KILL.search(line)
+        if k and not USER_SCOPED.search(k.group("args")):
+            out.append((i, "unscoped-process-kill", line.strip()[:90]))
+    return out
+
+
+def main():
+    if not PUBLIC_DIR.is_dir():
+        print(f"::error::{PUBLIC_DIR} does not exist — scope regression, refusing to pass")
+        return 2
+
+    scripts = sorted(PUBLIC_DIR.glob("*.sh"))
+    # A scan that matched nothing and a scan that never ran print the same "0".
+    # Report the denominator, and treat an empty scope as a failure.
+    if not scripts:
+        print(f"::error::scanned ZERO scripts under {PUBLIC_DIR} — scope regression, refusing to pass")
+        return 2
+
+    findings = []
+    for s in scripts:
+        for line_no, rule, text in check(s):
+            findings.append((s, line_no, rule, text))
+
+    print(f"scanned {len(scripts)} public script(s): {', '.join(s.name for s in scripts)}")
+
+    if not findings:
+        print(f"0 findings across {len(scripts)} script(s).")
+        return 0
+
+    for s, line_no, rule, text in findings:
+        if rule == "rm-rf-outside-product":
+            hint = ("path is not owned by this product — wiping it damages unrelated "
+                    "tools on the user's machine. Remove it, or narrow to a path we own.")
+        else:
+            hint = ("pattern-matched kill hits same-named processes owned by anyone. "
+                    'Scope it: pkill -u "$(id -u)" -f ...')
+        print(f"::error file={s},line={line_no}::[{rule}] {text}\n    {hint}")
+
+    print(f"\n{len(findings)} finding(s) across {len(scripts)} scanned script(s).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/public-script-safety.yml
+++ b/.github/workflows/public-script-safety.yml
@@ -1,0 +1,38 @@
+# Guard the shell scripts we serve from https://anet.sh/<name>.
+#
+# Several of them tell the reader to `curl ... | bash`, so a destructive line
+# here runs on a stranger's machine. On 2026-07-31 four of these scripts were
+# found to wipe `~/.npm/_npx` (not ours — npx executes from there, so it breaks
+# every other npx tool on the box) and to `pkill -f` by process name (which
+# has already taken down a production hub in this repo). All four were found
+# by hand; this workflow exists so the next one is not.
+#
+# Python rather than an in-yml bash loop, per the team's CI-guard pattern
+# (same reasoning as no-memory-slugs.yml).
+
+name: lint (public script safety)
+
+on:
+  pull_request:
+    paths:
+      - 'docs-site/docs/public/**'
+      - '.github/scripts/check-public-script-safety.py'
+      - '.github/workflows/public-script-safety.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs-site/docs/public/**'
+      - '.github/scripts/check-public-script-safety.py'
+      - '.github/workflows/public-script-safety.yml'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # Prints the number of scripts scanned and exits 2 on an empty scope,
+      # so "0 findings" can never be confused with "never ran".
+      - run: python3 .github/scripts/check-public-script-safety.py


### PR DESCRIPTION
`docs-site/docs/public/*.sh` 从 `https://anet.sh/<name>` 提供，其中几个脚本**自身就在教用户 `curl | bash`** —— 一行写错就跑在陌生人机器上。

2026-07-31 在这批脚本里人肉找出两类真实危害（#558 / #562 / #563 / #564 已修）：

| 模式 | 危害 |
|---|---|
| `rm -rf ~/.npm/_npx` | 那目录**不属于本产品** —— npx 解包并从那里执行，整目录删除破坏该机器上其它所有 npx 工具。容器实测：另一工具文件 1 → 0 |
| `pkill -f <name>` | 按进程名模式杀，命中任何人的同名进程。**本仓曾因此误杀生产中枢** |

**四个脚本全靠人工枚举发现。这道门是为了下一个不靠人工。**

### 只做两条规则，是刻意的

故意**不**纳入：打印固定默认口令（对这些脚本安装的稳定版而言是正确的 —— 我今天一度把它误标成缺陷并撤回）、显式 opt-in 后绑 `0.0.0.0`。

**那两条需要判断，留给人审。会误报的门会被关掉，关掉就什么都不保护。**

### 门的四个行为已实证

```
当前 main                   exit 0    scanned 6 public script(s) / 0 findings
塞回 rm -rf ~/.npm/_npx     exit 1    精确指到文件和行
去掉 pkill 的 -u 限定       exit 1    精确指到文件和行
恢复原状                    exit 0    证明不是恒红
public/ 目录不存在          exit 2    拒绝通过
public/ 存在但无 .sh        exit 2    拒绝通过
```

最后两条是因为**「0 个发现」和「根本没跑」输出长得一样** —— 所以脚本始终打印扫描分母（`scanned N public script(s)`），空作用域直接判失败。

（顺带：我第一次测第 4 条时把退出码经了管道，`$?` 取到的是 `sed` 的 0 而不是脚本的 2 —— 同一个坑今天第二次。重测才拿到真值。）
