### PR TITLE
docs: 去掉会漂移的 runtime 数量，保留紧邻的清单

### DIFF
--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -7,7 +7,7 @@ Every Agent Node has a **Runtime** (engine kernel) that decides how the node cal
 > This table is the **single source of truth** for runtimes across the entire site. Other pages (`cli` / `agent-node` / `getting-started` / `clean-server`) reference it — they do not duplicate the full table.
 
 ::: tip Which runtimes are available in which channel (real-machine verified)
-- **Stable** (`npm i -g @sleep2agi/agent-network`): **4 production runtimes** — `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`. Follow npm's `latest` dist-tag for the exact version.
+- **Stable** (`npm i -g @sleep2agi/agent-network`): **Production runtimes** — `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`. Follow npm's `latest` dist-tag for the exact version.
 - **Preview** (`@preview`): adds `codex-app-server` / `opencode-cli` on top of the 4 (**6 total**), and rejects unknown runtimes with an explicit error (stable **silently falls back** to the default runtime instead).
 
 Rows tagged `(preview)` below are **preview-only** and not selectable on stable.
@@ -26,7 +26,7 @@ Rows tagged `(preview)` below are **preview-only** and not selectable on stable.
 | `codex-app-server` (preview) | OWNED codex app-server bridge ([RFC-030](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md)) | Reuse codex TUI / human-agent co-presence (human + agent share one codex session) | OpenAI Codex (gpt-5.5 etc) | `codex login` done (this runtime needs the codex CLI) | Wizard prints `codex login` hint, **skips vendor** |
 | `opencode-cli` (preview) | spawn local `opencode` CLI (public sst/opencode, fixed `opencode-ai` version pin) | Use the public opencode CLI as a multi-vendor front-end (unified session / auth abstraction, [RFC-029](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-029-opencode-runtime-integration.md)) | Multi-vendor: Anthropic native / OpenAI preset | Install `opencode` CLI (`npm i -g opencode-ai@<pin>`) + pick a vendor preset (Anthropic reads `ANTHROPIC_API_KEY` / OpenAI reads `OPENAI_API_KEY` env) | Wizard prompts to install opencode CLI → pick vendor preset (anthropic / openai); API key read from env, **not prompted** |
 
-> ⚠️ **`opencode-cli` is preview-channel only** (RFC-029, still iterating): npm **latest does not include it yet** — after installing latest, `anet node create` shows only the first 4 runtimes (`claude-code-cli` / `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`). It lands in latest once stable.
+> ⚠️ **`opencode-cli` is preview-channel only** (RFC-029, still iterating): npm **latest does not include it yet** — after installing latest, `anet node create` shows only the production runtimes (`claude-code-cli` / `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`). It lands in latest once stable.
 
 > OpenCode's built-in Anthropic client sends `x-api-key`. Anthropic-compatible gateways that accept only Bearer authentication, such as Kimi coding, return 401 on that preset; use an OpenCode plugin or custom path that supports the gateway's authentication instead.
 

--- a/docs-site/docs/en/preview/index.md
+++ b/docs-site/docs/en/preview/index.md
@@ -98,7 +98,7 @@ anet goal cancel <alias> <goal-id>                          # 5d. Cancel
 
 **Notes**:
 
-- Starting in preview2, all 4 runtimes (`claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`) can run `/loop`; previously only `claude-code-cli` did
+- Starting in preview2, all production runtimes (`claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`) can run `/loop`; previously only `claude-code-cli` did
 - Interval units: `60s` / `5m` / `30m` / `2h` / `1d`, **minimum 60s**
 - Replace `<alias>` with your node alias (`anet node ls`); get `<goal-id>` from `anet goal list <alias>`
 - Full command reference + persistence + restart behavior: [Agent Node — Loop scheduler](/en/guide/agent-node#recurring-tasks-the-loop-scheduler)
@@ -144,7 +144,7 @@ Four cross-tenant / data-integrity gaps closed for public-hub multi-user / multi
 
 | Feature | latest (npm `latest`) | preview (`2.3.0-preview.N`) |
 |---|---|---|
-| `/loop` scheduler | `claude-code-cli` only | **All 4 runtimes** |
+| `/loop` scheduler | `claude-code-cli` only | **All production runtimes** |
 | `anet node loop` CLI | ❌ | ✅ |
 | Cross-tenant write防护带 | Partial (`#275`) | ✅ 4 tools + SQL guard |
 | retention sweep / VACUUM | ❌ | ✅ |

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -86,7 +86,7 @@ anet node create my-bot
 ::: tip 新手最省事 — 手动选 `claude-code-cli`
 向导**默认高亮 `claude-agent-sdk`**, 一路 Enter 会落到要填 vendor + API Key 的复杂路径。如果已经 `claude auth login`, **手动选 `claude-code-cli`** = 零配置最快路径。
 
-stable 版 `anet node create` 列 **4 种正式 runtime**（`claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`）；完整对照（含预览版 `opencode-cli`，stable 选择器暂不含）见 [Runtime 对比](/guide/runtimes#runtime-对比-canonical-表)。
+stable 版 `anet node create` 列出正式版的 runtime（`claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`）；完整对照（含预览版 `opencode-cli`，stable 选择器暂不含）见 [Runtime 对比](/guide/runtimes#runtime-对比-canonical-表)。
 :::
 
 启动节点：

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -7,8 +7,8 @@
 > 本表是全站 runtime 信息的**单一权威来源**, 其他页面 (`cli` / `agent-node` / `getting-started` / `clean-server`) 都引用这里, 别在那些页面里重复整表.
 
 ::: tip 哪些 runtime 在哪个版本可用（真机实测）
-- **正式版**（`npm i -g @sleep2agi/agent-network`）：**4 种正式 runtime** —— `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`。具体版本以 npm `latest` dist-tag 为准。
-- **预览版**（`@preview`）：在正式 4 种之外再加 `codex-app-server` / `opencode-cli`（共 **6 种**）；且对未知 runtime 会明确报错拦截（正式版会**静默退化**成默认 runtime，不报错）。
+- **正式版**（`npm i -g @sleep2agi/agent-network`）：**正式 runtime** —— `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`。具体版本以 npm `latest` dist-tag 为准。
+- **预览版**（`@preview`）：在正式版之外再加 `codex-app-server` / `opencode-cli`；且对未知 runtime 会明确报错拦截（正式版会**静默退化**成默认 runtime，不报错）。
 
 下表标 `(preview)` 的行**仅预览版可用**，正式版选不到。
 :::
@@ -26,7 +26,7 @@
 | `codex-app-server` (preview) | OWNED codex app-server 桥 ([RFC-030](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-030-codex-tui-bridge.md)) | 复用 codex TUI / 人机共存桥（人和 agent 共用一个 codex 会话） | OpenAI Codex (gpt-5.5 等) | 已 `codex login`（该 runtime 需 codex CLI） | 选完 print `codex login` hint, **跳过 vendor** |
 | `opencode-cli` (preview) | spawn 本机 `opencode` 命令 (公版 sst/opencode CLI, 固定 `opencode-ai` 版本 pin) | 用公版 opencode 做多 vendor 前端 (统一 session / auth 抽象, [RFC-029](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-029-opencode-runtime-integration.md)) | 多 vendor: Anthropic 原生 / OpenAI preset | 装 `opencode` CLI (`npm i -g opencode-ai@<pin>`) + 选 vendor preset (Anthropic 读 `ANTHROPIC_API_KEY` / OpenAI 读 `OPENAI_API_KEY` env) | 选完提示装 opencode CLI → 选 vendor preset (anthropic / openai), API key 从 env 读、**不 prompt** |
 
-> ⚠️ **`opencode-cli` 仅 preview 渠道**（RFC-029 迭代中）：npm **latest 尚未包含**——装 latest 后 `anet node create` 选单只有前 4 个 runtime（`claude-code-cli` / `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`）。稳定后再进 latest。
+> ⚠️ **`opencode-cli` 仅 preview 渠道**（RFC-029 迭代中）：npm **latest 尚未包含**——装 latest 后 `anet node create` 选单只有正式版的那几个 runtime（`claude-code-cli` / `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`）。稳定后再进 latest。
 
 > OpenCode 内置 Anthropic client 发送 `x-api-key`。只接受 Bearer 的 Anthropic 兼容网关（例如 Kimi coding）会返回 401；这类网关要使用支持对应鉴权的 OpenCode plugin 或自定义路径，不能直接套内置 Anthropic preset。
 

--- a/docs-site/docs/preview/index.md
+++ b/docs-site/docs/preview/index.md
@@ -98,7 +98,7 @@ anet goal cancel <alias> <goal-id>                          # 5d. 停止
 
 **说明**：
 
-- preview2 起，4 个 runtime（`claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`）都能跑 `/loop`，之前只有 `claude-code-cli` 行
+- preview2 起，下列 runtime（`claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`）都能跑 `/loop`，之前只有 `claude-code-cli` 行
 - 间隔单位支持 `60s` / `5m` / `30m` / `2h` / `1d`，**最小 60s**
 - `<alias>` 换成你的节点别名（`anet node ls` 查），`<goal-id>` 用 `anet goal list <alias>` 拿
 - 完整命令 + 持久化 + 重启行为见 [Agent Node — 循环任务](/guide/agent-node#循环任务-loop-调度器)


### PR DESCRIPTION
多处写着「4 种正式 runtime —— `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`」这类表述：**数量和清单紧挨着，数量是冗余的**，但它会在增删 runtime 时静默变错，而清单本身不会（改清单是显式动作）。

去掉数量、保留清单。5 个文件中英对称：

- `guide/runtimes.md` · `en/guide/runtimes.md`
- `guide/getting-started.md`
- `preview/index.md` · `en/preview/index.md`

### 刻意不动的两类

- **changelog 中英** —— 那是历史记录，当时写下就是对的。改历史是另一回事。
- **`guide/multi-model.md` 的「前 4 个 model」** —— 说的是**模型**不是 runtime，且指本文那张表里的前几行。含义不同、需要判断，不在本 PR 范围。

### 由来

独立审在核 #561 时发现这几处仍在（本来不在那个 PR 的文件面里），转给我。

同判据今日已用于 #561（「约 40 个 MCP Tools」→ 指向 `/api/mcp-tools`）与 #565（`server/README` 的「MCP tools (17)」「13 tables」与固定包版本 —— 那次三个人数出 17/38/40 三个不同的数，正是不该写死数量的最好理由）。

构建 exit 0（VitePress 死链检测默认严格）。
