### PR TITLE
[codex] fix codex app-server reply routing

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -56,6 +56,11 @@ import {
 import { CurrentAliasResolver } from "./runtime/current-alias";
 import { delegationTargetExists } from "./runtime/delegation-precheck";
 import {
+  buildCodexAppServerReplyTask,
+  createReplyRouteCache,
+  resolveReplyRoute,
+} from "./runtime/reply-routing";
+import {
   isRateLimitOrQuotaError,
   quotaRemediationHint,
 } from "./runtime/claude-error-classify";
@@ -419,6 +424,7 @@ if (RUNTIME === "opencode") {
 // wake for the immediate originator). See sendReply() for the empirical
 // rationale. Other runtimes keep the send_reply task-lifecycle-close path.
 const REPLY_VIA_SEND_TASK = RUNTIME === "codex-app-server";
+const replyRouteCache = createReplyRouteCache();
 
 const COMMHUB_URL = opts.url || opts.hub || process.env.COMMHUB_URL || fileConfig.hub || "http://127.0.0.1:9200";
 const MODEL = opts.model || process.env.MODEL || fileConfig.model;
@@ -1147,18 +1153,28 @@ async function sendReply(
   // viewer would see as an orphaned reply from a non-existent sender).
   const fromAlias = await liveAlias();
 
-  // RFC-030 — codex-app-server replies via send_task, NOT send_reply.
-  // Empirically (isolated-hub e2e), send_reply enqueues to the originator's
-  // inbox as type='reply' but does NOT SSE-wake the immediate originator
-  // (only a chained-to-parent push fires) — an agent peer would only see it
-  // on its next poll. send_task fires a `new_task` SSE wake so the peer acts
-  // immediately, matching the network's "回复用 send_task" convention
-  // (Vincent, 2026-07-09). Failures are prefixed so the peer sees the error.
-  if (REPLY_VIA_SEND_TASK) {
+  // RFC-030 — codex-app-server replies to real agent sessions via send_task
+  // (immediate SSE wake + actionable), but dashboard/API senders are not
+  // routable sessions. Probe the roster instead of hardcoding sender names:
+  // if tomorrow dashboard changes from_name from "admin" to any other
+  // non-session label, this still falls back to send_reply and closes the
+  // original task lifecycle.
+  if (await resolveReplyRoute({
+    target,
+    taskId,
+    replyViaSendTask: REPLY_VIA_SEND_TASK,
+    cache: replyRouteCache,
+    loadSessions: async () => {
+      const status = parseToolJson(await callCommHub("get_all_status", {}));
+      return status?.sessions;
+    },
+  }) === "send_task") {
+    const replyTask = buildCodexAppServerReplyTask(message, failed);
     const taskResult = await callCommHub("send_task", {
       alias: target,
-      task: failed ? `⚠️ ${message}` : message,
-      priority: failed ? "high" : "normal",
+      task: replyTask.task,
+      priority: replyTask.priority,
+      from_session: fromAlias,
       parent_task_id: taskId || undefined,
     });
     return { delivered: true, reply_id: taskResult?.message_id ?? taskResult?.task_id, payload: taskResult };

--- a/agent-node/src/runtime/reply-routing.test.ts
+++ b/agent-node/src/runtime/reply-routing.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCodexAppServerReplyTask,
+  createReplyRouteCache,
+  resolveReplyRoute,
+} from "./reply-routing";
+
+const sessions = (...aliases: string[]) => aliases.map((alias) => ({ alias }));
+
+describe("codex-app-server reply routing", () => {
+  test("dashboard/user sender that is not a session falls back to send_reply", async () => {
+    const route = await resolveReplyRoute({
+      target: "admin",
+      taskId: "task-dashboard",
+      replyViaSendTask: true,
+      cache: createReplyRouteCache(),
+      loadSessions: async () => sessions("codex-node", "peer-agent"),
+    });
+    expect(route).toBe("send_reply");
+  });
+
+  test("agent sender with a real session keeps send_task wake path", async () => {
+    const route = await resolveReplyRoute({
+      target: "peer-agent",
+      taskId: "task-peer",
+      replyViaSendTask: true,
+      cache: createReplyRouteCache(),
+      loadSessions: async () => sessions("codex-node", "peer-agent"),
+    });
+    expect(route).toBe("send_task");
+  });
+
+  test("missing task id does not create an unparented reply task", async () => {
+    const route = await resolveReplyRoute({
+      target: "peer-agent",
+      replyViaSendTask: true,
+      cache: createReplyRouteCache(),
+      loadSessions: async () => sessions("peer-agent"),
+    });
+    expect(route).toBe("send_reply");
+  });
+
+  test("roster load failure fails closed to send_reply", async () => {
+    const route = await resolveReplyRoute({
+      target: "peer-agent",
+      taskId: "task-peer",
+      replyViaSendTask: true,
+      cache: createReplyRouteCache(),
+      loadSessions: async () => {
+        throw new Error("hub unavailable");
+      },
+    });
+    expect(route).toBe("send_reply");
+  });
+
+  test("short ttl cache avoids repeated roster fetches and refreshes after expiry", async () => {
+    let now = 1000;
+    let calls = 0;
+    let currentSessions = sessions("peer-agent");
+    const cache = createReplyRouteCache();
+    const loadSessions = async () => {
+      calls++;
+      return currentSessions;
+    };
+
+    await expect(resolveReplyRoute({
+      target: "peer-agent",
+      taskId: "task-peer",
+      replyViaSendTask: true,
+      cache,
+      cacheTtlMs: 3000,
+      nowMs: () => now,
+      loadSessions,
+    })).resolves.toBe("send_task");
+    expect(calls).toBe(1);
+
+    currentSessions = sessions("other-agent");
+    now = 2000;
+    await expect(resolveReplyRoute({
+      target: "peer-agent",
+      taskId: "task-peer",
+      replyViaSendTask: true,
+      cache,
+      cacheTtlMs: 3000,
+      nowMs: () => now,
+      loadSessions,
+    })).resolves.toBe("send_task");
+    expect(calls).toBe(1);
+
+    now = 5001;
+    await expect(resolveReplyRoute({
+      target: "peer-agent",
+      taskId: "task-peer",
+      replyViaSendTask: true,
+      cache,
+      cacheTtlMs: 3000,
+      nowMs: () => now,
+      loadSessions,
+    })).resolves.toBe("send_reply");
+    expect(calls).toBe(2);
+  });
+
+  test("failed send_task replies keep the peer-visible failure marker and high priority", () => {
+    expect(buildCodexAppServerReplyTask("boom", true)).toEqual({
+      task: "⚠️ boom",
+      priority: "high",
+    });
+    expect(buildCodexAppServerReplyTask("done", false)).toEqual({
+      task: "done",
+      priority: "normal",
+    });
+  });
+});

--- a/agent-node/src/runtime/reply-routing.ts
+++ b/agent-node/src/runtime/reply-routing.ts
@@ -1,0 +1,67 @@
+export type ReplyRoute = "send_reply" | "send_task";
+
+export interface CommHubSessionLike {
+  alias?: unknown;
+}
+
+export interface ReplyRouteCache {
+  expiresAt: number;
+  aliases: Set<string>;
+}
+
+export interface ResolveReplyRouteOptions {
+  target: string;
+  taskId?: string;
+  replyViaSendTask: boolean;
+  loadSessions: () => Promise<CommHubSessionLike[] | null | undefined>;
+  cache: ReplyRouteCache;
+  nowMs?: () => number;
+  cacheTtlMs?: number;
+}
+
+export function createReplyRouteCache(): ReplyRouteCache {
+  return { expiresAt: 0, aliases: new Set() };
+}
+
+export function buildCodexAppServerReplyTask(message: string, failed: boolean) {
+  return {
+    task: failed ? `⚠️ ${message}` : message,
+    priority: failed ? "high" : "normal",
+  };
+}
+
+export async function resolveReplyRoute(options: ResolveReplyRouteOptions): Promise<ReplyRoute> {
+  if (!options.replyViaSendTask || !options.taskId) return "send_reply";
+  return await isRoutableCommHubSession(options) ? "send_task" : "send_reply";
+}
+
+export async function isRoutableCommHubSession(options: Omit<ResolveReplyRouteOptions, "replyViaSendTask" | "taskId">): Promise<boolean> {
+  const now = options.nowMs?.() ?? Date.now();
+  const ttl = options.cacheTtlMs ?? 3000;
+  const target = options.target.trim();
+  if (!target) return false;
+
+  if (now < options.cache.expiresAt) {
+    return options.cache.aliases.has(target);
+  }
+
+  try {
+    const sessions = await options.loadSessions();
+    if (!Array.isArray(sessions)) {
+      options.cache.aliases = new Set();
+      options.cache.expiresAt = now + ttl;
+      return false;
+    }
+    options.cache.aliases = new Set(
+      sessions
+        .map((session) => session?.alias)
+        .filter((alias): alias is string => typeof alias === "string" && alias.length > 0),
+    );
+    options.cache.expiresAt = now + ttl;
+    return options.cache.aliases.has(target);
+  } catch {
+    options.cache.aliases = new Set();
+    options.cache.expiresAt = now + ttl;
+    return false;
+  }
+}

--- a/docs/tests/report-test-node04-codex-app-server-reply-routing.txt
+++ b/docs/tests/report-test-node04-codex-app-server-reply-routing.txt
@@ -1,0 +1,22 @@
+# qa-node-04 codex-app-server reply routing
+[0] start isolated hub
+[1] register dashboard user and network
+[2] register codex-app-server receiver and peer sender sessions
+sessions visible in isolated hub: 2
+[3] witnessed-red: dashboard from_name=admin is not a routable node session
+WITNESSED_RED_RAW_SEND_TASK_TO_ADMIN={"ok":false,"error":"alias_not_found","message":"alias not found: admin","alias":"admin","queued":false}
+WITNESSED_RED_ADMIN_SESSION_COUNT=0
+WITNESSED_RED_REPLY_MESSAGE_COUNT=0
+WITNESSED_RED_PARENT_TASK_ROW={"task_id":"2e89b39c-9bd6-47d0-8808-48fdeed9a2bb","from_node_id":null,"from_name":"admin","to_node_id":null,"to_name":"codex-node","priority":"normal","status":"delivered","content":"dashboard asks codex","result":null,"in_reply_to":null,"requires_response":"reply","scope":"single","created_at":"2026-08-01 11:16:38","delivered_at":"2026-08-01 11:16:38","started_at":null,"completed_at":null,"expires_at":"2026-08-01 12:16:38","network_id":"net_feb75f4305c0","parent_task_id":null,"meta_json":null}
+[4] fixed wire route: dashboard source falls back to send_reply and is dashboard-visible
+FIX_DASHBOARD_RAW={"ok":true,"message_id":"3dc400f1-56b9-4ca7-8a0a-e25bd73727e8","session_status":"unknown"}
+FIX_DASHBOARD_REPLY_MESSAGE_COUNT=1
+FIX_DASHBOARD_PARENT_TASK_ROW={"task_id":"2e89b39c-9bd6-47d0-8808-48fdeed9a2bb","from_node_id":null,"from_name":"admin","to_node_id":null,"to_name":"codex-node","priority":"normal","status":"replied","content":"dashboard asks codex","result":"[codex-node] fixed dashboard reply","in_reply_to":null,"requires_response":"reply","scope":"single","created_at":"2026-08-01 11:16:38","delivered_at":"2026-08-01 11:16:38","started_at":null,"completed_at":"2026-08-01 11:16:39","expires_at":"2026-08-01 12:16:38","network_id":"net_feb75f4305c0","parent_task_id":null,"meta_json":null}
+[5] fixed wire route: agent peer remains send_task-routed, including failed priority marker
+FIX_PEER_RAW={"ok":true,"message_id":"d707c22d-e1a3-417e-83f0-3589b23c1c3a","session_status":"idle"}
+FIX_PEER_INBOX={"ok":true,"messages":[{"id":"d707c22d-e1a3-417e-83f0-3589b23c1c3a","type":"task","priority":"high","content":"⚠️ [codex-node] reply routed as peer task","context":null,"from_session":"codex-node","created_at":"2026-08-01 11:16:39","network_id":"net_feb75f4305c0","meta_json":null,"meta":null}]}
+FIX_PEER_HIGH_FAILURE_TASK_COUNT=1
+FIX_PEER_REPLY_MESSAGE_COUNT=0
+PASS qa-node-04 codex-app-server reply routing
+Assertions: 5/5
+Duration_ms: 3660

--- a/docs/tests/report-test-node04-codex-app-server-reply-routing.txt
+++ b/docs/tests/report-test-node04-codex-app-server-reply-routing.txt
@@ -7,16 +7,16 @@ sessions visible in isolated hub: 2
 WITNESSED_RED_RAW_SEND_TASK_TO_ADMIN={"ok":false,"error":"alias_not_found","message":"alias not found: admin","alias":"admin","queued":false}
 WITNESSED_RED_ADMIN_SESSION_COUNT=0
 WITNESSED_RED_REPLY_MESSAGE_COUNT=0
-WITNESSED_RED_PARENT_TASK_ROW={"task_id":"2e89b39c-9bd6-47d0-8808-48fdeed9a2bb","from_node_id":null,"from_name":"admin","to_node_id":null,"to_name":"codex-node","priority":"normal","status":"delivered","content":"dashboard asks codex","result":null,"in_reply_to":null,"requires_response":"reply","scope":"single","created_at":"2026-08-01 11:16:38","delivered_at":"2026-08-01 11:16:38","started_at":null,"completed_at":null,"expires_at":"2026-08-01 12:16:38","network_id":"net_feb75f4305c0","parent_task_id":null,"meta_json":null}
+WITNESSED_RED_PARENT_TASK_ROW={"task_id":"e96829fb-16f4-4dd6-b89f-12dd9505a8c0","from_node_id":null,"from_name":"admin","to_node_id":null,"to_name":"codex-node","priority":"normal","status":"delivered","content":"dashboard asks codex","result":null,"in_reply_to":null,"requires_response":"reply","scope":"single","created_at":"2026-08-01 12:03:39","delivered_at":"2026-08-01 12:03:39","started_at":null,"completed_at":null,"expires_at":"2026-08-01 13:03:39","network_id":"net_55cf55893929","parent_task_id":null,"meta_json":null}
 [4] fixed wire route: dashboard source falls back to send_reply and is dashboard-visible
-FIX_DASHBOARD_RAW={"ok":true,"message_id":"3dc400f1-56b9-4ca7-8a0a-e25bd73727e8","session_status":"unknown"}
+FIX_DASHBOARD_RAW={"ok":true,"message_id":"f971c0f1-b9f2-4111-be5c-a12eb8460e10","session_status":"unknown"}
 FIX_DASHBOARD_REPLY_MESSAGE_COUNT=1
-FIX_DASHBOARD_PARENT_TASK_ROW={"task_id":"2e89b39c-9bd6-47d0-8808-48fdeed9a2bb","from_node_id":null,"from_name":"admin","to_node_id":null,"to_name":"codex-node","priority":"normal","status":"replied","content":"dashboard asks codex","result":"[codex-node] fixed dashboard reply","in_reply_to":null,"requires_response":"reply","scope":"single","created_at":"2026-08-01 11:16:38","delivered_at":"2026-08-01 11:16:38","started_at":null,"completed_at":"2026-08-01 11:16:39","expires_at":"2026-08-01 12:16:38","network_id":"net_feb75f4305c0","parent_task_id":null,"meta_json":null}
+FIX_DASHBOARD_PARENT_TASK_ROW={"task_id":"e96829fb-16f4-4dd6-b89f-12dd9505a8c0","from_node_id":null,"from_name":"admin","to_node_id":null,"to_name":"codex-node","priority":"normal","status":"replied","content":"dashboard asks codex","result":"[codex-node] fixed dashboard reply","in_reply_to":null,"requires_response":"reply","scope":"single","created_at":"2026-08-01 12:03:39","delivered_at":"2026-08-01 12:03:39","started_at":null,"completed_at":"2026-08-01 12:03:40","expires_at":"2026-08-01 13:03:39","network_id":"net_55cf55893929","parent_task_id":null,"meta_json":null}
 [5] fixed wire route: agent peer remains send_task-routed, including failed priority marker
-FIX_PEER_RAW={"ok":true,"message_id":"d707c22d-e1a3-417e-83f0-3589b23c1c3a","session_status":"idle"}
-FIX_PEER_INBOX={"ok":true,"messages":[{"id":"d707c22d-e1a3-417e-83f0-3589b23c1c3a","type":"task","priority":"high","content":"⚠️ [codex-node] reply routed as peer task","context":null,"from_session":"codex-node","created_at":"2026-08-01 11:16:39","network_id":"net_feb75f4305c0","meta_json":null,"meta":null}]}
+FIX_PEER_RAW={"ok":true,"message_id":"5857977c-8bdd-41e9-a72c-6cb906515d24","session_status":"idle"}
+FIX_PEER_INBOX={"ok":true,"messages":[{"id":"5857977c-8bdd-41e9-a72c-6cb906515d24","type":"task","priority":"high","content":"⚠️ [codex-node] reply routed as peer task","context":null,"from_session":"codex-node","created_at":"2026-08-01 12:03:41","network_id":"net_55cf55893929","meta_json":null,"meta":null}]}
 FIX_PEER_HIGH_FAILURE_TASK_COUNT=1
 FIX_PEER_REPLY_MESSAGE_COUNT=0
 PASS qa-node-04 codex-app-server reply routing
 Assertions: 5/5
-Duration_ms: 3660
+Duration_ms: 3556

--- a/tests/qa-node-04-codex-app-server-reply-routing/Dockerfile
+++ b/tests/qa-node-04-codex-app-server-reply-routing/Dockerfile
@@ -11,6 +11,7 @@ COPY server/src ./src
 
 WORKDIR /app
 COPY tests/qa-node-04-codex-app-server-reply-routing/run.sh /app/run.sh
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
 CMD ["/app/run.sh"]

--- a/tests/qa-node-04-codex-app-server-reply-routing/Dockerfile
+++ b/tests/qa-node-04-codex-app-server-reply-routing/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-certificates jq unzip && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /app/server
+COPY server/package.json ./
+RUN bun install
+COPY server/src ./src
+
+WORKDIR /app
+COPY tests/qa-node-04-codex-app-server-reply-routing/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/qa-node-04-codex-app-server-reply-routing/run.sh
+++ b/tests/qa-node-04-codex-app-server-reply-routing/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/safe-rm.sh"
 
 export HOME=/tmp/anethome
 export COMMHUB_DB=/tmp/commhub-qa-node-04.db
@@ -93,7 +94,7 @@ fixed_reply_route() {
 
 log "# qa-node-04 codex-app-server reply routing"
 log "[0] start isolated hub"
-rm -rf "$HOME/.commhub" "$HOME/.anet/server" "$COMMHUB_DB"
+safe_rm_rf "$HOME/.commhub" "$HOME/.anet/server" "$COMMHUB_DB"
 cd /app/server
 HOST=127.0.0.1 PORT="$HUB_PORT" bun run src/index.ts >/tmp/hub.log 2>&1 &
 HUB_PID=$!

--- a/tests/qa-node-04-codex-app-server-reply-routing/run.sh
+++ b/tests/qa-node-04-codex-app-server-reply-routing/run.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export HOME=/tmp/anethome
+export COMMHUB_DB=/tmp/commhub-qa-node-04.db
+HUB_PORT=9224
+HUB_BASE="http://127.0.0.1:$HUB_PORT"
+REPORT="/app/docs/tests/report-test-node04-codex-app-server-reply-routing.txt"
+ADMIN_PW="StrongPassw0rd"
+START_MS=$(date +%s%3N)
+ASSERTIONS=0
+
+cleanup() {
+  [[ -n "${HUB_PID:-}" ]] && kill "$HUB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$REPORT")"
+: > "$REPORT"
+
+log() {
+  echo "$*"
+  echo "$*" >> "$REPORT"
+}
+
+pass_assert() {
+  ASSERTIONS=$((ASSERTIONS + 1))
+}
+
+mcp_call() {
+  local tok="$1" name="$2" args="$3"
+  local body
+  body=$(jq -nc --arg n "$name" --argjson a "$args" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:$n,arguments:$a}}')
+  curl -sS -X POST "$HUB_BASE/mcp" \
+    -H "Authorization: Bearer $tok" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -H 'MCP-Protocol-Version: 2025-03-26' \
+    -d "$body" \
+    | sed -n 's/^data: //p' | head -1 \
+    | jq -r '.result.content[0].text // empty'
+}
+
+register_node() {
+  local alias="$1" resume="$2"
+  local ntok arg rs
+  ntok=$(curl -fsS -X POST "$HUB_BASE/api/auth/node-token" \
+    -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' \
+    -d "{\"network_id\":\"$NET_ID\",\"node_name\":\"$alias\"}" | jq -r '.token')
+  [[ "$ntok" == ntok_* ]] || { log "FAIL: ntok not minted for $alias"; exit 1; }
+  arg=$(jq -nc --arg net "$NET_ID" --arg alias "$alias" --arg resume "$resume" \
+    '{resume_id:$resume,alias:$alias,status:"idle",network_id:$net}')
+  rs=$(mcp_call "$ntok" "report_status" "$arg")
+  echo "$rs" | jq -e '.ok == true' >/dev/null || { log "FAIL: report_status $alias: $rs"; exit 1; }
+  echo "$ntok"
+}
+
+task_row() {
+  local tid="$1"
+  curl -fsS "$HUB_BASE/api/tasks?task_id=$tid&network_id=$NET_ID" \
+    -H "Authorization: Bearer $UTOK" | jq -c '.tasks[0]'
+}
+
+reply_message_count() {
+  local content="$1"
+  curl -fsS "$HUB_BASE/api/messages?limit=100" -H "Authorization: Bearer $UTOK" \
+    | jq --arg c "$content" '[.messages[] | select(.type == "reply" and .content == $c)] | length'
+}
+
+fixed_reply_route() {
+  local tok="$1" target="$2" text="$3" parent="$4" from_alias="$5" failed="${6:-false}"
+  local status exists arg task priority
+  status=$(mcp_call "$tok" "get_all_status" '{}')
+  exists=$(echo "$status" | jq --arg target "$target" 'any((.sessions // [])[]; .alias == $target)')
+  if [[ "$exists" == "true" ]]; then
+    if [[ "$failed" == "true" ]]; then
+      task="⚠️ $text"
+      priority="high"
+    else
+      task="$text"
+      priority="normal"
+    fi
+    arg=$(jq -nc --arg alias "$target" --arg task "$task" --arg priority "$priority" --arg from "$from_alias" --arg parent "$parent" \
+      '{alias:$alias,task:$task,priority:$priority,from_session:$from,parent_task_id:$parent}')
+    mcp_call "$tok" "send_task" "$arg"
+  else
+    arg=$(jq -nc --arg alias "$target" --arg text "$text" --arg from "$from_alias" --arg parent "$parent" --arg status "$([[ "$failed" == "true" ]] && echo failed || echo replied)" \
+      '{alias:$alias,text:$text,from_session:$from,in_reply_to:$parent,status:$status}')
+    mcp_call "$tok" "send_reply" "$arg"
+  fi
+}
+
+log "# qa-node-04 codex-app-server reply routing"
+log "[0] start isolated hub"
+rm -rf "$HOME/.commhub" "$HOME/.anet/server" "$COMMHUB_DB"
+cd /app/server
+HOST=127.0.0.1 PORT="$HUB_PORT" bun run src/index.ts >/tmp/hub.log 2>&1 &
+HUB_PID=$!
+for _ in {1..60}; do curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && break; sleep 0.5; done
+curl -fsS "$HUB_BASE/health" >/dev/null || { log "FAIL: hub did not start"; cat /tmp/hub.log; exit 1; }
+
+log "[1] register dashboard user and network"
+REG=$(curl -fsS -X POST "$HUB_BASE/api/auth/register" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"admin\",\"password\":\"$ADMIN_PW\",\"email\":\"admin@example.test\"}")
+UTOK=$(echo "$REG" | jq -r '.token // empty')
+[[ "$UTOK" == utok_* ]] || { log "FAIL: register did not return utok: $REG"; exit 1; }
+NET_RESP=$(curl -fsS -X POST "$HUB_BASE/api/networks" \
+  -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' \
+  -d '{"name":"node04-net"}')
+NET_ID=$(echo "$NET_RESP" | jq -r '.network.network_id // .network_id // empty')
+[[ -n "$NET_ID" && "$NET_ID" != "null" ]] || { log "FAIL: network create: $NET_RESP"; exit 1; }
+pass_assert
+
+log "[2] register codex-app-server receiver and peer sender sessions"
+CODEX_NTOK=$(register_node "codex-node" "resume-codex-node")
+PEER_NTOK=$(register_node "peer-agent" "resume-peer-agent")
+SESSION_COUNT=$(mcp_call "$CODEX_NTOK" "get_all_status" '{}' | jq '.sessions | length')
+log "sessions visible in isolated hub: $SESSION_COUNT"
+[[ "$SESSION_COUNT" -ge 2 ]] || { log "FAIL: sessions not visible"; exit 1; }
+pass_assert
+
+log "[3] witnessed-red: dashboard from_name=admin is not a routable node session"
+DASH_TASK=$(curl -fsS -X POST "$HUB_BASE/api/task" \
+  -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' \
+  -d "{\"alias\":\"codex-node\",\"task\":\"dashboard asks codex\",\"priority\":\"normal\",\"network_id\":\"$NET_ID\",\"from\":\"admin\"}")
+DASH_TASK_ID=$(echo "$DASH_TASK" | jq -r '.task_id // .message_id')
+RED_TEXT="[codex-node] red reply should be dropped by old send_task"
+RED_ARG=$(jq -nc --arg alias "admin" --arg task "$RED_TEXT" --arg from "codex-node" --arg parent "$DASH_TASK_ID" \
+  '{alias:$alias,task:$task,priority:"normal",from_session:$from,parent_task_id:$parent}')
+RED_RAW=$(mcp_call "$CODEX_NTOK" "send_task" "$RED_ARG" || true)
+RED_MSG_COUNT=$(reply_message_count "$RED_TEXT")
+RED_ROW=$(task_row "$DASH_TASK_ID")
+ADMIN_SESSION_COUNT=$(mcp_call "$CODEX_NTOK" "get_all_status" '{}' | jq '[.sessions[] | select(.alias=="admin")] | length')
+log "WITNESSED_RED_RAW_SEND_TASK_TO_ADMIN=$RED_RAW"
+log "WITNESSED_RED_ADMIN_SESSION_COUNT=$ADMIN_SESSION_COUNT"
+log "WITNESSED_RED_REPLY_MESSAGE_COUNT=$RED_MSG_COUNT"
+log "WITNESSED_RED_PARENT_TASK_ROW=$RED_ROW"
+[[ "$ADMIN_SESSION_COUNT" -eq 0 ]] || { log "FAIL: test invalid, admin unexpectedly routable"; exit 1; }
+[[ "$RED_MSG_COUNT" -eq 0 ]] || { log "FAIL: old send_task unexpectedly created dashboard-visible reply"; exit 1; }
+[[ "$(echo "$RED_ROW" | jq -r '.status')" == "delivered" ]] || { log "FAIL: red parent task should remain delivered"; exit 1; }
+pass_assert
+
+log "[4] fixed wire route: dashboard source falls back to send_reply and is dashboard-visible"
+FIX_TEXT="[codex-node] fixed dashboard reply"
+FIX_RAW=$(fixed_reply_route "$CODEX_NTOK" "admin" "$FIX_TEXT" "$DASH_TASK_ID" "codex-node")
+FIX_MSG_COUNT=$(reply_message_count "$FIX_TEXT")
+FIX_ROW=$(task_row "$DASH_TASK_ID")
+log "FIX_DASHBOARD_RAW=$FIX_RAW"
+log "FIX_DASHBOARD_REPLY_MESSAGE_COUNT=$FIX_MSG_COUNT"
+log "FIX_DASHBOARD_PARENT_TASK_ROW=$FIX_ROW"
+[[ "$FIX_MSG_COUNT" -ge 1 ]] || { log "FAIL: fixed dashboard reply not visible in /api/messages"; exit 1; }
+[[ "$(echo "$FIX_ROW" | jq -r '.status')" == "replied" ]] || { log "FAIL: fixed parent task should be replied"; exit 1; }
+[[ "$(echo "$FIX_ROW" | jq -r '.result')" == "$FIX_TEXT" ]] || { log "FAIL: fixed parent task result mismatch"; exit 1; }
+pass_assert
+
+log "[5] fixed wire route: agent peer remains send_task-routed, including failed priority marker"
+PEER_SEND_ARG=$(jq -nc --arg alias "codex-node" --arg task "peer asks codex" --arg from "peer-agent" \
+  '{alias:$alias,task:$task,priority:"normal",from_session:$from}')
+PEER_TASK_RAW=$(mcp_call "$PEER_NTOK" "send_task" "$PEER_SEND_ARG")
+PEER_TASK_ID=$(echo "$PEER_TASK_RAW" | jq -r '.task_id // .message_id')
+PEER_REPLY_TEXT="[codex-node] reply routed as peer task"
+PEER_REPLY_RAW=$(fixed_reply_route "$CODEX_NTOK" "peer-agent" "$PEER_REPLY_TEXT" "$PEER_TASK_ID" "codex-node" true)
+PEER_INBOX=$(mcp_call "$PEER_NTOK" "get_inbox" '{"alias":"peer-agent","limit":20}')
+PEER_REPLY_TASK_COUNT=$(echo "$PEER_INBOX" | jq --arg c "⚠️ $PEER_REPLY_TEXT" '[.messages[] | select(.type=="task" and .content==$c and .priority=="high" and .from_session=="codex-node")] | length')
+PEER_REPLY_MSG_COUNT=$(reply_message_count "$PEER_REPLY_TEXT")
+log "FIX_PEER_RAW=$PEER_REPLY_RAW"
+log "FIX_PEER_INBOX=$PEER_INBOX"
+log "FIX_PEER_HIGH_FAILURE_TASK_COUNT=$PEER_REPLY_TASK_COUNT"
+log "FIX_PEER_REPLY_MESSAGE_COUNT=$PEER_REPLY_MSG_COUNT"
+[[ "$PEER_REPLY_TASK_COUNT" -ge 1 ]] || { log "FAIL: peer reply was not delivered as high-priority failure task to peer-agent"; exit 1; }
+[[ "$PEER_REPLY_MSG_COUNT" -eq 0 ]] || { log "FAIL: peer route over-fixed into dashboard send_reply path"; exit 1; }
+pass_assert
+
+END_MS=$(date +%s%3N)
+DURATION_MS=$((END_MS - START_MS))
+log "PASS qa-node-04 codex-app-server reply routing"
+log "Assertions: $ASSERTIONS/5"
+log "Duration_ms: $DURATION_MS"

--- a/tests/test-rfc029-pr3-preset/run.sh
+++ b/tests/test-rfc029-pr3-preset/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/safe-rm.sh"
 
 REPORT_DIR="${REPORT_DIR:-/report}"
 REPORT="$REPORT_DIR/pr3-smoke.txt"
@@ -95,7 +96,7 @@ fi
 S4_FAKE_BIN=/tmp/pr3-fake-bin
 S4_NPM_SENTINEL=/tmp/pr3-npm-called
 S4_LOG=/tmp/pr3-upgrade-pin.log
-rm -rf "$S4_FAKE_BIN"
+safe_rm_rf "$S4_FAKE_BIN"
 rm -f "$S4_NPM_SENTINEL" "$S4_LOG" "$HOME/.anet/opencode-pin.json"
 mkdir -p "$S4_FAKE_BIN"
 cat > "$S4_FAKE_BIN/npm" <<'FAKE_NPM'

--- a/tests/test384-opencode-local-package-e2e/run.sh
+++ b/tests/test384-opencode-local-package-e2e/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/safe-rm.sh"
 
 REPORT_DIR="${REPORT_DIR:-/report}"
 REPORT="$REPORT_DIR/report-test384.txt"
@@ -730,9 +731,9 @@ rm -f -- "$PROFILE_STALE_MARKER"
 # the runtime must use a fresh launch data root and leave this outside target
 # completely empty through fake and real ACP turns.
 PERSISTENT_DATA_DIR="$OPENAI_NODE/.local/share/opencode"
-rm -rf -- "$PERSISTENT_DATA_DIR/log"
+safe_rm_rf "$PERSISTENT_DATA_DIR/log"
 rm -f -- "$PERSISTENT_DATA_DIR"/opencode.db*
-rm -rf -- "$PERSISTENT_DATA_ESCAPE"
+safe_rm_rf "$PERSISTENT_DATA_ESCAPE"
 mkdir -m 700 "$PERSISTENT_DATA_ESCAPE"
 ln -s "$PERSISTENT_DATA_ESCAPE" "$PERSISTENT_DATA_DIR/log"
 ln -s "$PERSISTENT_DATA_ESCAPE/opencode.db" "$PERSISTENT_DATA_DIR/opencode.db"


### PR DESCRIPTION
## Summary

Fix the `codex-app-server` reply route in main / the publishable package path.

`codex-app-server` previously replied with `send_task` unconditionally. Dashboard-originated tasks can have `from_name` set to a login username such as `admin`, with no matching routable agent session. Sending a task back to that name returns `alias_not_found`, so the dashboard-visible reply is silently lost.

This PR changes the decision from a sender-name blacklist to a routability check: `codex-app-server` replies use `send_task` only when the target exists in `get_all_status().sessions[].alias`; otherwise they fall back to `send_reply` so the original task lifecycle closes and the dashboard can read the reply. The roster probe is cached briefly with a 3s TTL, and probe failures fail closed to `send_reply`.

The existing peer failure semantics are preserved: failed peer replies still become high-priority `send_task` messages with the `⚠️` prefix.

## Scope Boundary

This PR only fixes the main / publishable-package implementation.

The `/home/vansin/rfc030-work` implementation currently used by 通信牛 is a separate implementation with a known bad `api`/`hub` allowlist-style exemption. That branch is being fixed separately by 通信牛. Do not cherry-pick between these two implementations blindly.

No npm publish is included in this PR.

## Base

Base SHA: `6faa3d2ac1ceded3555cc0b774d94c773f7eb29c`

## Validation

Mutation red, with `isRoutableCommHubSession` temporarily changed to always return false:

```text
Expected: "send_task"
Received: "send_reply"
(fail) codex-app-server reply routing > agent sender with a real session keeps send_task wake path
(fail) codex-app-server reply routing > short ttl cache avoids repeated roster fetches and refreshes after expiry
4 pass
2 fail
```

Unit test:

```text
bun test src/runtime/reply-routing.test.ts
6 pass
0 fail
12 expect() calls
```

Build:

```text
npm run build
Bundled 234 modules in 83ms
```

Docker wire gate:

```text
PASS qa-node-04 codex-app-server reply routing
Assertions: 5/5
Duration_ms: 3660
```

Witnessed-red from isolated Docker hub:

```text
WITNESSED_RED_RAW_SEND_TASK_TO_ADMIN={"ok":false,"error":"alias_not_found","message":"alias not found: admin","alias":"admin","queued":false}
WITNESSED_RED_ADMIN_SESSION_COUNT=0
WITNESSED_RED_REPLY_MESSAGE_COUNT=0
WITNESSED_RED_PARENT_TASK_ROW={"task_id":"2e89b39c-9bd6-47d0-8808-48fdeed9a2bb","from_node_id":null,"from_name":"admin","to_node_id":null,"to_name":"codex-node","priority":"normal","status":"delivered","content":"dashboard asks codex","result":null,...}
```
