### PR TITLE
fix(agent-node): wake on new_message and stop blocking the SSE read loop

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -3483,6 +3483,34 @@ function shouldSkipMessage(from: string, content: string, msgType?: string): str
 //         failure, leave queued for the next drain. On app-level
 //         rejection (e.g. target offline, task closed), drop with a
 //         loud warn — retrying would not help.
+// Coalescing, non-blocking inbox drain. The SSE read loop must never await a
+// task turn (see the call site comment). If events arrive while a drain is in
+// flight we set a pending flag instead of starting a second drain, then loop
+// once more so nothing that arrived mid-drain is missed. Per-message duplicate
+// work is already prevented by the `inflightMessageIds` guard inside
+// processInbox, so a coalesced re-run is safe.
+let inboxDraining = false;
+let inboxDrainPending = false;
+function drainInboxSoon(): void {
+  if (inboxDraining) {
+    inboxDrainPending = true;
+    return;
+  }
+  inboxDraining = true;
+  void (async () => {
+    try {
+      do {
+        inboxDrainPending = false;
+        await processInbox();
+      } while (inboxDrainPending);
+    } catch (e: any) {
+      warn(`inbox drain failed: ${e?.message || e}`);
+    } finally {
+      inboxDraining = false;
+    }
+  })();
+}
+
 async function processInbox() {
   // (1) Drain leftovers from previous runs.
   await drainPendingReplies();
@@ -3505,7 +3533,12 @@ async function processInbox() {
 
       // Non-task / non-broadcast: ack and move on, nothing to reply to.
       if (msgType !== "task" && msgType !== "broadcast") {
-        debug(`skip non-task message: type=${msgType}`);
+        // This used to be debug(), i.e. a plain message was acked and discarded
+        // with no trace at the default log level while the SENDER saw a
+        // successful delivery. Surface it at INFO so a dropped message is at
+        // least diagnosable. Whether plain messages should reach the model or a
+        // human TUI is a product decision, deliberately not made here.
+        log(`← [${from}] (message, not delivered to model) ${content.slice(0, 120)}`);
         await ackMessage(msg.id).catch((e: any) => warn(`ack failed for non-task ${msg.id.slice(0, 8)}: ${e.message}`));
         continue;
       }
@@ -4354,9 +4387,22 @@ async function connectSSE() {
               firstConnect = false;
               continue;
             }
-            if (["new_task", "broadcast"].includes(ev.type)) {
+            // Two defects fixed here, both observed live on 2026-08-02:
+            //  (a) `new_message` was missing from this list even though the hub
+            //      emits it (server/src/tools.ts pushEvent type:"new_message"),
+            //      so plain commhub_send_message traffic never woke a node.
+            //      Evidence from a production bridge log: new_task 96 hits,
+            //      new_message 0 hits.
+            //  (b) `await processInbox()` blocked the SSE read loop for the
+            //      whole duration of a task turn. On codex-app-server nodes a
+            //      turn can run for many minutes, so every later event queued
+            //      behind it and died on the node deadline — observed as 1932
+            //      log lines across ~6h with a task_reply count of 0. Drain off
+            //      the read loop, with a coalescing guard so overlapping events
+            //      never start two concurrent drains.
+            if (["new_task", "new_message", "broadcast"].includes(ev.type)) {
               log(`← SSE ${ev.type}`);
-              await processInbox();
+              drainInboxSoon();
             }
             if (ev.type === "new_reply") {
               log(`← SSE reply from ${ev.from || "?"}${ev.in_reply_to ? ` (task ${ev.in_reply_to.slice(0, 8)})` : ""}`);


### PR DESCRIPTION
Three silent-failure defects found while diagnosing "节点收不到 dashboard 的消息 / 普通消息也收不到". None of them surfaced an error; the sender saw a successful delivery every time.

| # | Symptom | Root cause |
|---|---|---|
| 1 | plain messages never arrive | `new_message` missing from the SSE wake list |
| 2 | every task dies at the node deadline | SSE read loop `await`s a whole task turn |
| 3 | dropped messages leave no trace | non-task branch acked + discarded at `debug` level |

## Evidence (production, before the fix)

- Bridge log: `new_task` **96** hits, `new_message` **0** hits — the hub does emit it (`server/src/tools.ts` `pushEvent type:"new_message"`), the node just never listened.
- Bridge log: **1932 lines across ~6h, `task_reply` count 0.** Every task logged `queued (a turn is in flight)` and then timed out. Interrupting the in-flight turn did **not** drain the queue, which is what pointed at the read loop rather than the queue logic.

## Fix

1. `new_message` added to the wake list.
2. `drainInboxSoon()` — non-blocking, **coalescing** drain. Not a bare fire-and-forget: overlapping events set a pending flag and loop once more instead of starting a second drain. Per-message duplicate work was already prevented by the existing `inflightMessageIds` guard, so a coalesced re-run is safe.
3. Silent drop → INFO log explicitly marked *not delivered to the model*.

## Deliberately not done

Whether plain messages should reach the model or a human TUI is a **product decision**, not a bug fix — making them drive a model turn would add turn cost across every node. Left unchanged and documented in the comment.

## Verification

- `bun run build` exit code **0** (captured directly, not through a pipe), 234 modules bundled.
- The identical change is already running in production on two `codex-app-server` nodes from the shared source tree, verified end to end:
  ```
  ← SSE new_message
  ← [通信龙] (message/normal) PLAIN_MESSAGE_WAKE_PROBE_20260802 …
  ← [通信龙] (message, not delivered to model) …
  ```
  Same probe against the same nodes before the fix produced **zero** `new_message` lines.

## Scope note

This is the `main` / published-package port. The fleet currently runs from a separate source tree that received the same change first; the two implementations are not cherry-picked from each other.