### PR TITLE
fix(anet): print exact tmux targets in attach hints

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -515,7 +515,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   const bound = await waitForTmuxPaneText(appsrvSession, `listening on: ${wsUrl}`, 25_000);
   if (!bound) {
     console.error(`[anet] ❌ app-server did not bind ${wsUrl} within 25s.`);
-    console.error(`[anet]    Debug:   tmux attach -t ${appsrvSession}`);
+    console.error(`[anet]    Debug:   tmux attach -t ${shellQuote(`=${appsrvSession}`)}`);
     console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
     // #P2fix复审顺手3 — env file was source-then-rm'd by the tmux child on
     // the happy path, but if the bash chain crashed before reaching `rm -f`
@@ -557,7 +557,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     threadId = await createCodexCopresenceThread(wsUrl);
   } catch (e: any) {
     console.error(`[anet] ❌ thread/start failed: ${e?.message || e}`);
-    console.error(`[anet]    Debug:   tmux attach -t ${appsrvSession}`);
+    console.error(`[anet]    Debug:   tmux attach -t ${shellQuote(`=${appsrvSession}`)}`);
     console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
     // #P2fix复审顺手3 — defense-in-depth env-file cleanup (see :431).
     try { rmSync(envFilePath, { force: true }); } catch { /* best-effort */ }
@@ -641,7 +641,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   const hubBase = opts.hub.replace(/\/+$/, "");
   console.log("");
   console.log(`[anet] ✅ 共存节点 ${displayName} 就绪`);
-  console.log(`[anet]    attach:    tmux attach -t ${shellQuote(displayName)}`);
+  console.log(`[anet]    attach:    tmux attach -t ${shellQuote(`=${displayName}`)}`);
   console.log(`[anet]    stop:      anet node stop ${shellQuote(displayName)}`);
   console.log(`[anet]    dashboard: ${hubBase}/nodes/${encodeURIComponent(displayName)}`);
   console.log(`[anet]    runtime:   codex-app-server @ ${wsUrl}  (sandbox=${sandboxMode})`);
@@ -4622,7 +4622,7 @@ async function startCommand() {
       process.exit(1);
     }
     console.log(`[anet] ✅ tmux session "${alias}" started detached.`);
-    console.log(`[anet]    Attach:   tmux attach -t ${alias}`);
+    console.log(`[anet]    Attach:   tmux attach -t ${shellQuote(`=${alias}`)}`);
     console.log(`[anet]    Stop:     anet node stop ${alias}`);
     // #494 — a detached `--tmux` start does not run the dev-channels
     // prompt watcher; a claude node with server: channels will sit on the


### PR DESCRIPTION
`tmux -t <name>` is a **prefix match**, not an exact match. When the named session is gone it silently resolves to any session whose name starts with that string — and reports no error.

Our copresence naming is the worst possible case: `X`, `X-桥`, `X-appsrv`, `X-tui`. Once `X` exits, `tmux attach -t X` lands on `X-桥`, so the operator watches the **bridge log** believing it is the TUI.

This is not hypothetical. A real user sent the same question **nine times** because the answers were never on the screen they were looking at, and three separate diagnoses (starvation, delivery failure, model loop) were all wrong because the display path was never suspected.

## Reproduced on this host

```
tmux new-session -d -s 'zzprobe-桥'
tmux has-session  -t 'zzprobe'    -> hit    (prefix-matched into -桥)
tmux has-session  -t '=zzprobe'   -> miss   (exact, correct)
tmux capture-pane -t 'zzprobe'    -> also prefix-matched
```

Disposable session removed afterwards with an exact target.

## Change

The OpenCode copresence path already prints `=${displayName}`. This applies the same treatment to the four remaining hints — **including the codex copresence one, which is what the fleet actually runs**.

Only user-facing hint strings change. No tmux invocation semantics are altered.

`kill-session` is the one that is genuinely dangerous to get wrong: aiming at a session that already exited can take down its still-running sibling. Exact targets should be what we teach by example.

## Verification

`bun run build` exit code **0**, captured directly rather than through a pipe.