### PR TITLE
fix(server): bind REST /api/task from_session to the caller's token identity

### DIFF
--- a/server/src/rest-identity.test.ts
+++ b/server/src/rest-identity.test.ts
@@ -1,0 +1,92 @@
+// REST from_session identity binding.
+//
+// Run: COMMHUB_DB=/tmp/rest-identity-test.db bun test src/rest-identity.test.ts
+// (COMMHUB_DB must be set explicitly — unset defaults to the production DB.)
+//
+// Assertion discipline: results are compared with toEqual against the whole
+// object, so a widened accepted-set fails instead of silently passing.
+
+import { describe, expect, test } from "bun:test";
+import { nodeAliasForToken, resolveRestFromSession } from "./rest-identity.js";
+
+const NTOK = "ntok_abc123";
+const UTOK = "utok_abc123";
+
+describe("REST from_session identity binding", () => {
+  test("node token claiming another node's alias is refused", () => {
+    expect(resolveRestFromSession({
+      token: NTOK,
+      tokenName: "node:通信IM牛",
+      requestedFrom: "通信龙",
+    })).toEqual({
+      ok: false,
+      error: "from_session_identity_mismatch",
+      message: "network token from_session does not match token-bound node alias",
+      tokenAlias: "通信IM牛",
+      requestedFromSession: "通信龙",
+    });
+  });
+
+  test("node token omitting from is bound to its own alias, not 'api'", () => {
+    expect(resolveRestFromSession({
+      token: NTOK,
+      tokenName: "node:通信IM牛",
+      requestedFrom: undefined,
+    })).toEqual({ ok: true, fromSession: "通信IM牛" });
+  });
+
+  test("node token claiming its own alias is accepted", () => {
+    expect(resolveRestFromSession({
+      token: NTOK,
+      tokenName: "node:通信IM牛",
+      requestedFrom: "通信IM牛",
+    })).toEqual({ ok: true, fromSession: "通信IM牛" });
+  });
+
+  test("whitespace padding does not defeat the comparison", () => {
+    expect(resolveRestFromSession({
+      token: NTOK,
+      tokenName: "node:通信IM牛",
+      requestedFrom: "  通信IM牛  ",
+    })).toEqual({ ok: true, fromSession: "通信IM牛" });
+  });
+
+  // The Dashboard posts as its logged-in user; this path must not change.
+  test("user token keeps the previous behaviour", () => {
+    expect(resolveRestFromSession({
+      token: UTOK,
+      tokenName: "dashboard",
+      requestedFrom: "admin",
+    })).toEqual({ ok: true, fromSession: "admin" });
+  });
+
+  test("user token with no from still defaults to 'api'", () => {
+    expect(resolveRestFromSession({
+      token: UTOK,
+      tokenName: null,
+      requestedFrom: undefined,
+    })).toEqual({ ok: true, fromSession: "api" });
+  });
+
+  // A non-string `from` must not be coerced into an identity.
+  test("non-string from is not treated as a claim", () => {
+    expect(resolveRestFromSession({
+      token: NTOK,
+      tokenName: "node:通信IM牛",
+      requestedFrom: { toString: () => "通信龙" },
+    })).toEqual({ ok: true, fromSession: "通信IM牛" });
+  });
+
+  describe("nodeAliasForToken", () => {
+    test("only ntok_ + node: prefix yields an alias", () => {
+      expect(nodeAliasForToken(NTOK, "node:X")).toBe("X");
+      // A user token whose name merely looks node-shaped must not bind.
+      expect(nodeAliasForToken(UTOK, "node:X")).toBeNull();
+      // A node token whose name is not node-scoped must not bind.
+      expect(nodeAliasForToken(NTOK, "dashboard")).toBeNull();
+      expect(nodeAliasForToken(NTOK, null)).toBeNull();
+      // `node:` with nothing after it is not an identity.
+      expect(nodeAliasForToken(NTOK, "node:   ")).toBeNull();
+    });
+  });
+});

--- a/server/src/rest-identity.test.ts
+++ b/server/src/rest-identity.test.ts
@@ -77,6 +77,34 @@ describe("REST from_session identity binding", () => {
     })).toEqual({ ok: true, fromSession: "通信IM牛" });
   });
 
+  // A network-bound token we cannot resolve to an alias must not be able to
+  // call itself anything. Found by independent review of this change.
+  describe("ntok_ with an unresolvable alias fails closed", () => {
+    for (const tokenName of ["node:", "node:   ", "dashboard", null, undefined]) {
+      test(`claim is refused when tokenName is ${JSON.stringify(tokenName)}`, () => {
+        expect(resolveRestFromSession({
+          token: NTOK,
+          tokenName,
+          requestedFrom: "通信龙",
+        })).toEqual({
+          ok: false,
+          error: "from_session_identity_mismatch",
+          message: "network token has no resolvable node alias and may not claim a from_session",
+          tokenAlias: "",
+          requestedFromSession: "通信龙",
+        });
+      });
+    }
+
+    test("no claim at all still resolves to 'api'", () => {
+      expect(resolveRestFromSession({
+        token: NTOK,
+        tokenName: "node:",
+        requestedFrom: undefined,
+      })).toEqual({ ok: true, fromSession: "api" });
+    });
+  });
+
   describe("nodeAliasForToken", () => {
     test("only ntok_ + node: prefix yields an alias", () => {
       expect(nodeAliasForToken(NTOK, "node:X")).toBe("X");

--- a/server/src/rest-identity.ts
+++ b/server/src/rest-identity.ts
@@ -1,0 +1,71 @@
+// REST from_session identity binding.
+//
+// Both transports resolve the same `api_tokens` row through resolveToken, and
+// auth.ts already states the invariant:
+//
+//   "Network-bound node tokens are an identity boundary: they must not spoof
+//    another node via from_session."
+//
+// tools.ts enforced it for MCP (defaultFrom + fromIdentityMismatchReply).
+// POST /api/task did not — it took `body.from` verbatim, so any node holding
+// its own ntok_ could claim another node's alias. That value is stored on the
+// task row and, once sender labels reach the copresence TUIs, rendered to a
+// human as an attribution.
+//
+// This is the same decision expressed as a pure function so every credential
+// kind is a directly constructible test input rather than a hand-assembled
+// Request (the #503 convention in this codebase).
+
+export interface RestIdentityInput {
+  /** Raw bearer token, only its prefix matters (`ntok_` = network-bound). */
+  token: string;
+  /** `api_tokens.name`; for node tokens it is `node:<alias>`. */
+  tokenName: string | null | undefined;
+  /** Caller-supplied `body.from`. */
+  requestedFrom: unknown;
+}
+
+export type RestIdentityResult =
+  | { ok: true; fromSession: string }
+  | {
+      ok: false;
+      error: "from_session_identity_mismatch";
+      message: string;
+      tokenAlias: string;
+      requestedFromSession: string;
+    };
+
+/** Alias a token is bound to, or null when it is not node-scoped. */
+export function nodeAliasForToken(token: string, tokenName: string | null | undefined): string | null {
+  if (!token.startsWith("ntok_")) return null;
+  if (typeof tokenName !== "string" || !tokenName.startsWith("node:")) return null;
+  const alias = tokenName.slice("node:".length).trim();
+  return alias || null;
+}
+
+export function resolveRestFromSession(input: RestIdentityInput): RestIdentityResult {
+  const alias = nodeAliasForToken(input.token, input.tokenName);
+  const requested = typeof input.requestedFrom === "string" ? input.requestedFrom.trim() : "";
+
+  // Not a node token: unchanged behaviour. The Dashboard legitimately posts as
+  // its logged-in user; tightening that is a separate change with its own
+  // compatibility surface.
+  if (!alias) {
+    return { ok: true, fromSession: requested || "api" };
+  }
+
+  // Node token claiming somebody else — refuse rather than silently rewrite,
+  // so a misconfigured caller is visible instead of quietly relabelled.
+  if (requested && requested !== alias) {
+    return {
+      ok: false,
+      error: "from_session_identity_mismatch",
+      message: "network token from_session does not match token-bound node alias",
+      tokenAlias: alias,
+      requestedFromSession: requested,
+    };
+  }
+
+  // Node token, no claim or a matching one: bind to the token's own alias.
+  return { ok: true, fromSession: alias };
+}

--- a/server/src/rest-identity.ts
+++ b/server/src/rest-identity.ts
@@ -47,6 +47,28 @@ export function resolveRestFromSession(input: RestIdentityInput): RestIdentityRe
   const alias = nodeAliasForToken(input.token, input.tokenName);
   const requested = typeof input.requestedFrom === "string" ? input.requestedFrom.trim() : "";
 
+  // A network-bound token whose name we cannot resolve to an alias (`node:`,
+  // `node:   `, or a name that was never node-scoped) is the degenerate case.
+  // We know it IS a node credential; we just cannot tell WHICH node. Letting it
+  // claim anything is the worst available option, so refuse the claim outright
+  // rather than falling through to the unbound path.
+  //
+  // Production always writes `node:${nodeName}`, so this costs nothing real —
+  // but "we couldn't identify you, so you may call yourself anything" is
+  // exactly the fail-open shape this change exists to remove.
+  if (!alias && input.token.startsWith("ntok_")) {
+    if (requested) {
+      return {
+        ok: false,
+        error: "from_session_identity_mismatch",
+        message: "network token has no resolvable node alias and may not claim a from_session",
+        tokenAlias: "",
+        requestedFromSession: requested,
+      };
+    }
+    return { ok: true, fromSession: "api" };
+  }
+
   // Not a node token: unchanged behaviour. The Dashboard legitimately posts as
   // its logged-in user; tightening that is a separate change with its own
   // compatibility surface.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -33,6 +33,7 @@ import { mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from "fs
 import { dirname as pathDirname } from "path";
 import { startRetentionSweeper } from "./retention.js";
 import { startStaleSessionSweeper } from "./stale-sweeper.js";
+import { resolveRestFromSession } from "./rest-identity.js";
 
 const PORT = Number(process.env.PORT) || 9200;
 const HOST = process.env.HOST || "127.0.0.1";
@@ -2088,7 +2089,38 @@ return Bun.serve({
         }, { status: 404 }));
       }
       const id = crypto.randomUUID();
-      const fromSession = body.from || "api";
+      // Identity binding, mirroring the MCP transport (tools.ts defaultFrom /
+      // fromIdentityMismatchReply). Both transports resolve the same
+      // api_tokens row through resolveToken, and auth.ts already documents the
+      // invariant: "Network-bound node tokens are an identity boundary: they
+      // must not spoof another node via from_session."
+      //
+      // MCP enforced it; this REST handler did not — it took `body.from`
+      // verbatim, so any node could POST /api/task with another node's alias
+      // and be recorded (and, once sender labels ship, *rendered in a human's
+      // TUI*) as that node. Same table, same token, one transport hardened and
+      // its sibling not.
+      //
+      // User tokens keep the previous behaviour: the Dashboard legitimately
+      // posts as its logged-in user, and tightening that is a separate change
+      // with its own compatibility surface.
+      // The decision itself lives in rest-identity.ts as a pure function so the
+      // shipped path and the tested path are the same code.
+      const identity = resolveRestFromSession({
+        token: requestToken(req),
+        tokenName: restAuth?.tokenName,
+        requestedFrom: body.from,
+      });
+      if (!identity.ok) {
+        return withCors(req, Response.json({
+          ok: false,
+          error: identity.error,
+          message: identity.message,
+          token_alias: identity.tokenAlias,
+          requested_from_session: identity.requestedFromSession,
+        }, { status: 403 }));
+      }
+      const fromSession = identity.fromSession;
       const ttlSeconds = (body as any).ttl_seconds || 3600;
       const fromNodeId = resolveRestNodeIdForAlias(fromSession, taskNetId);
       const targetNodeId = target.session?.node_id ?? null;


### PR DESCRIPTION
## The gap

`POST /api/task` took `body.from` verbatim. The MCP transport binds the same field to the token.

Both resolve the **same `api_tokens` row** through `resolveToken`, and `auth.ts` already states the invariant:

> Network-bound node tokens are an identity boundary: they must not spoof another node via from_session.

`tools.ts` enforces it (`defaultFrom` + `fromIdentityMismatchReply`). `server.ts:2091` did not:

```js
const fromSession = body.from || "api";
```

**Any node holding its own `ntok_` could POST `/api/task` claiming another node's alias and be recorded as that node.** One transport hardened, its sibling not — the network authz checks around it (403 / permission_denied) all pass, because they check *which network*, never *who*.

## Why now

Impact is rising rather than static. The copresence sender-label work renders `from_session` into a human's TUI as `[来自 X]`. A field that was a data-integrity gap becomes **an attribution a person reads and trusts**.

This was surfaced as a MINOR during an unrelated review ("pre-existing hub semantics"), which is accurate as scoping — but the severity is higher than MINOR once the label ships, so it is fixed separately here rather than folded into that PR.

## Behaviour

| caller | result |
|---|---|
| `ntok_` with name `node:<alias>` | `from_session` forced to `<alias>`; a different claim gets **403 `from_session_identity_mismatch`** |
| anything else | **unchanged** |

Refusing rather than silently relabelling keeps a misconfigured caller visible instead of quietly rewriting its identity.

User tokens are deliberately untouched: the Dashboard legitimately posts as its logged-in user, and tightening that has its own compatibility surface. Called out as follow-up, not smuggled in here.

## Testability

The decision is a pure function in `rest-identity.ts`, so **the shipped path and the tested path are the same code** — not a re-implementation that can drift from what ships. This follows the `#503` convention already in the package: make each credential kind a directly constructible test input instead of a hand-assembled `Request`.

## Verification

`COMMHUB_DB` pointed at a scratch file for every run — never the default, which is the production database.

```
bun test src/rest-identity.test.ts   ->  8 pass / 0 fail / 12 expect
```

**Witnessed-red.** Forcing the old "trust `body.from`" behaviour:

```
(fail) node token claiming another node's alias is refused
(fail) node token omitting from is bound to its own alias, not 'api'
(fail) non-string from is not treated as a claim
 5 pass / 3 fail
```

Restoring returns 8/0.

`tsc`: **0 errors** in `server.ts` and `rest-identity.ts`; the 10 pre-existing errors elsewhere in the package are unchanged.

## Not done here

- User-token binding (see above).
- No end-to-end HTTP test: the handler is inside the main fetch switch. The extracted function is what the handler calls, so the control flow is covered, but a full request-level test is a real gap and is stated rather than papered over.