### PR TITLE
fix(codex-app-server): reconcile a missed turn/completed instead of wedging the queue

### DIFF
--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -284,6 +284,25 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     expect(errors).toEqual([{ taskId: "task_1", error: "model unavailable" }]);
     expect(bridge.currentStatus()).toBe("idle");
   });
+
+  test("turn/completed with interrupted status cannot become a successful reply", async () => {
+    const turnId = await bridge.startTaskTurn({ taskId: "task_interrupted", text: "hi" });
+    const replies: unknown[] = [];
+    const errors: Array<{ taskId: string; error: string }> = [];
+    bridge.on("task_reply", (r) => replies.push(r));
+    bridge.on("task_error", (e) => errors.push(e as never));
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turn: { id: turnId, status: "interrupted" } },
+    });
+    await tick(10);
+    expect(replies).toHaveLength(0);
+    expect(errors).toEqual([{
+      taskId: "task_interrupted",
+      error: "Codex turn was interrupted without an error message",
+    }]);
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -623,6 +642,57 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     // First check stops after the cheap active-status read. Recovery does a
     // cheap idle-status read followed by one full-history read.
     expect(app.received.filter((entry) => (entry as { method?: string }).method === "thread/read")).toHaveLength(3);
+
+    await client.close();
+    await app.stop();
+  });
+
+  test("thread/read never recovers an interrupted turn as success", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize") return respond({ result: {} });
+        if (msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/start") {
+          return respond({ result: { turn: { id: "turn_reconcile_interrupted" } } });
+        }
+        if (msg.method === "thread/read") {
+          const includeTurns = (msg.params as { includeTurns?: boolean } | undefined)?.includeTurns;
+          return respond({
+            result: {
+              thread: {
+                id: THREAD,
+                status: { type: "idle" },
+                turns: includeTurns ? [{
+                  id: "turn_reconcile_interrupted",
+                  status: "interrupted",
+                  items: [{ type: "agentMessage", phase: "final_answer", text: "partial text" }],
+                }] : undefined,
+              },
+            },
+          });
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    const replies: unknown[] = [];
+    const errors: Array<{ taskId: string; error: string }> = [];
+    bridge.on("task_reply", (reply) => replies.push(reply));
+    bridge.on("task_error", (error) => errors.push(error as never));
+
+    await bridge.submitTask({ taskId: "t-reconcile-interrupted", text: "first" });
+    expect(await bridge.reconcileActiveTurn()).toEqual({
+      recovered: true,
+      turnId: "turn_reconcile_interrupted",
+      status: "interrupted",
+    });
+    expect(replies).toHaveLength(0);
+    expect(errors).toEqual([{
+      taskId: "t-reconcile-interrupted",
+      error: "Codex turn was interrupted without an error message",
+    }]);
 
     await client.close();
     await app.stop();

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -551,6 +551,83 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     await app.stop();
   });
 
+  test("thread/read recovers a missed turn/completed and drains the queued task", async () => {
+    let seq = 0;
+    let firstTurnIsPersistedComplete = false;
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize") return respond({ result: {} });
+        if (msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/start") {
+          seq++;
+          return respond({ result: { turn: { id: `turn_reconcile_${seq}` } } });
+        }
+        if (msg.method === "thread/read") {
+          const includeTurns = (msg.params as { includeTurns?: boolean } | undefined)?.includeTurns;
+          return respond({
+            result: {
+              thread: {
+                id: THREAD,
+                status: { type: firstTurnIsPersistedComplete ? "idle" : "active" },
+                turns: includeTurns && firstTurnIsPersistedComplete
+                  ? [{
+                      id: "turn_reconcile_1",
+                      status: "completed",
+                      items: [{
+                        type: "agentMessage",
+                        phase: "final_answer",
+                        text: "recovered-answer-1",
+                      }],
+                    }]
+                  : undefined,
+              },
+            },
+          });
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (reply) => replies.push(reply as { taskId: string; text: string }));
+
+    await bridge.submitTask({ taskId: "t-reconcile-1", text: "first" });
+    await bridge.submitTask({ taskId: "t-reconcile-2", text: "second" });
+    expect(bridge.activeTurn()).toBe("turn_reconcile_1");
+    expect(bridge.queueDepth()).toBe(1);
+
+    // No turn/completed notification is broadcast. A non-terminal persisted
+    // status must not release the local claim.
+    expect(await bridge.reconcileActiveTurn()).toEqual({
+      recovered: false,
+      turnId: "turn_reconcile_1",
+      status: "active",
+    });
+    expect(bridge.activeTurn()).toBe("turn_reconcile_1");
+    expect(bridge.queueDepth()).toBe(1);
+
+    // This is the production failure shape: the exact turn is terminal in
+    // thread/read, but its terminal WebSocket frame never reached the bridge.
+    firstTurnIsPersistedComplete = true;
+    expect(await bridge.reconcileActiveTurn()).toEqual({
+      recovered: true,
+      turnId: "turn_reconcile_1",
+      status: "completed",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(replies).toEqual([{ taskId: "t-reconcile-1", text: "recovered-answer-1" }]);
+    expect(bridge.queueDepth()).toBe(0);
+    expect(bridge.activeTurn()).toBe("turn_reconcile_2");
+    // First check stops after the cheap active-status read. Recovery does a
+    // cheap idle-status read followed by one full-history read.
+    expect(app.received.filter((entry) => (entry as { method?: string }).method === "thread/read")).toHaveLength(3);
+
+    await client.close();
+    await app.stop();
+  });
+
   test("drain losing the idle race requeues at the FRONT and retries on next idle", async () => {
     let denials = 0;
     let seq = 0;

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -53,6 +53,7 @@ export interface PendingTurn {
   submittedAt: number;
   turnId?: string;
   agentTextChunks: string[];
+  finalText?: string;
 }
 
 export interface WaitingApproval {
@@ -60,6 +61,15 @@ export interface WaitingApproval {
   method: string;
   params: unknown;
   observedAt: number;
+}
+
+export interface ActiveTurnReconciliation {
+  /** Whether a missed terminal notification was recovered from thread/read. */
+  recovered: boolean;
+  /** Active turn id observed when reconciliation started, if any. */
+  turnId: string | null;
+  /** Authoritative status returned by thread/read when a turn was found. */
+  status?: string;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -100,6 +110,8 @@ export class CodexAppServerBridge extends EventEmitter {
    */
   private taskQueue: Array<{ taskId: string; text: string; from?: string }> = [];
   private draining = false;
+  /** Coalesce watchdog reads so concurrent callers never stampede app-server. */
+  private reconciliationInFlight: Promise<ActiveTurnReconciliation> | null = null;
 
   constructor(opts: CodexAppServerBridgeOptions) {
     super();
@@ -445,13 +457,105 @@ export class CodexAppServerBridge extends EventEmitter {
       void this.drainQueue();
       return;
     }
+    this.finishOwnedTurn(turnId, {
+      status: p.turn?.status,
+      error: p.turn?.error?.message,
+    });
+  }
+
+  /**
+   * Reconcile the bridge's local active-turn claim against app-server's
+   * authoritative persisted thread state.
+   *
+   * WebSocket notifications are best-effort. If one `turn/completed` frame is
+   * missed, the old implementation retained `activeTurnId` forever: every
+   * later Agent Network task entered the FIFO and timed out even though
+   * `thread/read` reported the thread idle and the turn completed. This method
+   * closes that one-frame failure mode without guessing that an old turn is
+   * done: only an explicit terminal status for the exact active turn releases
+   * the claim.
+   */
+  async reconcileActiveTurn(): Promise<ActiveTurnReconciliation> {
+    if (this.reconciliationInFlight) return this.reconciliationInFlight;
+    const activeAtStart = this.activeTurnId;
+    if (!activeAtStart) return { recovered: false, turnId: null };
+
+    this.reconciliationInFlight = (async () => {
+      // Keep the steady-state watchdog cheap: read only the thread status
+      // while Codex is working. Hydrate full turn history only after the
+      // authoritative status says idle (or an older server omits status).
+      const statusResult = await this.client.request<{
+        thread?: { status?: string | { type?: string } };
+      }>("thread/read", { threadId: this.threadId, includeTurns: false });
+
+      // A notification may have completed the turn while thread/read was in
+      // flight. Never let an old snapshot release a newer active claim.
+      if (this.activeTurnId !== activeAtStart) {
+        return { recovered: false, turnId: activeAtStart };
+      }
+
+      const threadStatus = extractThreadStatus(statusResult?.thread?.status);
+      if (threadStatus && threadStatus !== "idle") {
+        return { recovered: false, turnId: activeAtStart, status: threadStatus };
+      }
+
+      const result = await this.client.request<{
+        thread?: {
+          turns?: Array<{
+            id?: string;
+            status?: string;
+            error?: { message?: string } | null;
+            items?: Array<{ type?: string; text?: string; phase?: string }>;
+          }>;
+        };
+      }>("thread/read", { threadId: this.threadId, includeTurns: true });
+
+      if (this.activeTurnId !== activeAtStart) {
+        return { recovered: false, turnId: activeAtStart };
+      }
+
+      const turn = result?.thread?.turns?.find((candidate) => candidate.id === activeAtStart);
+      if (!turn || !isTerminalTurnStatus(turn.status)) {
+        return { recovered: false, turnId: activeAtStart, status: turn?.status };
+      }
+
+      const finalText = [...(turn.items ?? [])]
+        .reverse()
+        .find((item) =>
+          item.type === "agentMessage" &&
+          item.phase === "final_answer" &&
+          typeof item.text === "string"
+        )?.text;
+      const recovered = this.finishOwnedTurn(activeAtStart, {
+        status: turn.status,
+        error: turn.error?.message,
+        finalText,
+      });
+      if (recovered) {
+        this.emit("turn_reconciled", { turnId: activeAtStart, status: turn.status });
+      }
+      return { recovered, turnId: activeAtStart, status: turn.status };
+    })().finally(() => {
+      this.reconciliationInFlight = null;
+    });
+    return this.reconciliationInFlight;
+  }
+
+  private finishOwnedTurn(
+    turnId: string,
+    terminal: { status?: string; error?: string; finalText?: string },
+  ): boolean {
+    const pending = this.pendingTurns.get(turnId);
+    if (!pending) return false;
+    if (terminal.finalText) pending.finalText = terminal.finalText;
     this.pendingTurns.delete(turnId);
     if (this.activeTurnId === turnId) {
       this.activeTurnId = null;
       this.turnClaimed = false;
       this.setStatus(this.waitingApprovals.size > 0 ? "waiting_human" : "idle");
     }
-    const turnErr = p.turn?.error?.message;
+    const turnErr = terminal.error ??
+      (terminal.status === "failed" ? "Codex turn failed without an error message" : undefined);
     if (turnErr) {
       this.emit("task_error", { taskId: pending.taskId, error: turnErr });
     } else {
@@ -463,6 +567,7 @@ export class CodexAppServerBridge extends EventEmitter {
     }
     // Either way the thread just went idle from our perspective → drain FIFO.
     void this.drainQueue();
+    return true;
   }
 
   /** Read-only queue depth (for tests / observability). */
@@ -491,6 +596,19 @@ function extractTurnId(v: unknown): string | null {
   if (o.turn && typeof o.turn === "object" && typeof o.turn.id === "string") return o.turn.id;
   if (typeof o.turnId === "string") return o.turnId;
   return null;
+}
+
+function isTerminalTurnStatus(status: unknown): status is "completed" | "failed" | "interrupted" {
+  return status === "completed" || status === "failed" || status === "interrupted";
+}
+
+function extractThreadStatus(status: unknown): string | undefined {
+  if (typeof status === "string") return status;
+  if (status && typeof status === "object") {
+    const type = (status as { type?: unknown }).type;
+    if (typeof type === "string") return type;
+  }
+  return undefined;
 }
 
 /** Recognise the app-server's "already initialized" rejection (shared server). */

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -555,7 +555,11 @@ export class CodexAppServerBridge extends EventEmitter {
       this.setStatus(this.waitingApprovals.size > 0 ? "waiting_human" : "idle");
     }
     const turnErr = terminal.error ??
-      (terminal.status === "failed" ? "Codex turn failed without an error message" : undefined);
+      (terminal.status === "failed"
+        ? "Codex turn failed without an error message"
+        : terminal.status === "interrupted"
+          ? "Codex turn was interrupted without an error message"
+          : undefined);
     if (turnErr) {
       this.emit("task_error", { taskId: pending.taskId, error: turnErr });
     } else {

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -1,10 +1,14 @@
-// RFC-030 — unit tests for the owned codex app-server argv builder.
-// Locks the auto-approve wiring (approval_policy / sandbox_mode) and the
-// CommHub MCP wiring (url + bearer-token-env-var): passed as `-c` overrides
-// only when set, in a stable order, token never in argv, --listen always last.
+// RFC-030 — unit tests for the owned codex app-server argv builder and the
+// shared-thread terminal-event reconciliation watchdog.
 
 import { describe, expect, test } from "bun:test";
-import { buildOwnedAppServerArgs, COMMHUB_MCP_TOKEN_ENV } from "./runtime";
+import { EventEmitter } from "events";
+import {
+  buildOwnedAppServerArgs,
+  COMMHUB_MCP_TOKEN_ENV,
+  codexAppServerThink,
+  type CodexAppServerRuntimeSession,
+} from "./runtime";
 
 const URL = "ws://127.0.0.1:24555";
 
@@ -63,5 +67,54 @@ describe("buildOwnedAppServerArgs", () => {
     ]);
     expect(args[args.length - 2]).toBe("--listen");
     expect(args[args.length - 1]).toBe(URL);
+  });
+});
+
+class ReconcileOnlyBridge extends EventEmitter {
+  taskId = "";
+  reconcileCalls = 0;
+
+  async submitTask(input: { taskId: string }): Promise<{ started: true; turnId: string }> {
+    this.taskId = input.taskId;
+    return { started: true, turnId: "turn_missing_notification" };
+  }
+
+  async reconcileActiveTurn(): Promise<{
+    recovered: boolean;
+    turnId: string;
+    status: string;
+  }> {
+    this.reconcileCalls++;
+    this.emit("task_reply", { taskId: this.taskId, text: "recovered-by-watchdog" });
+    return {
+      recovered: true,
+      turnId: "turn_missing_notification",
+      status: "completed",
+    };
+  }
+}
+
+describe("codexAppServerThink — terminal-event reconciliation watchdog", () => {
+  test("resolves from authoritative reconciliation when turn/completed is missed", async () => {
+    const bridge = new ReconcileOnlyBridge();
+    const logs: string[] = [];
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+
+    const result = await codexAppServerThink(session, {
+      taskId: "task_watchdog",
+      text: "message delivered by Agent Network",
+      timeoutMs: 250,
+      reconciliationIntervalMs: 5,
+      log: (line) => logs.push(line),
+    });
+
+    expect(result).toEqual({
+      replyText: "recovered-by-watchdog",
+      failed: false,
+      queued: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(bridge.reconcileCalls).toBe(1);
+    expect(logs.some((line) => line.includes("recovered missed terminal event"))).toBe(true);
   });
 });

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -218,20 +218,31 @@ export interface CodexAppServerThinkResult {
  */
 export function codexAppServerThink(
   session: CodexAppServerRuntimeSession,
-  opts: { taskId: string; text: string; from?: string; timeoutMs?: number; log?: (m: string) => void },
+  opts: {
+    taskId: string;
+    text: string;
+    from?: string;
+    timeoutMs?: number;
+    /** Test seam; production defaults to a 5s authoritative thread/read. */
+    reconciliationIntervalMs?: number;
+    log?: (m: string) => void;
+  },
 ): Promise<CodexAppServerThinkResult> {
   const timeoutMs = opts.timeoutMs ?? 10 * 60_000;
+  const reconciliationIntervalMs = opts.reconciliationIntervalMs ?? 5_000;
   const log = opts.log ?? (() => {});
   const { bridge } = session;
 
   return new Promise<CodexAppServerThinkResult>((resolve) => {
     let settled = false;
+    let reconciliationTimer: ReturnType<typeof setTimeout> | undefined;
     const finish = (r: CodexAppServerThinkResult) => {
       if (settled) return;
       settled = true;
       bridge.off("task_reply", onReply);
       bridge.off("task_error", onError);
       clearTimeout(timer);
+      if (reconciliationTimer) clearTimeout(reconciliationTimer);
       resolve(r);
     };
     const onReply = (ev: { taskId: string; text: string }) => {
@@ -252,8 +263,33 @@ export function codexAppServerThink(
       });
     }, timeoutMs);
 
+    // A shared app-server WebSocket can miss an individual terminal
+    // notification while the authoritative thread history still records the
+    // completed turn. Periodically reconcile the exact active turn so one
+    // dropped frame cannot wedge this task and every later FIFO entry for the
+    // lifetime of the bridge process.
+    const scheduleReconciliation = () => {
+      if (settled || reconciliationIntervalMs <= 0) return;
+      reconciliationTimer = setTimeout(async () => {
+        try {
+          const reconciled = await bridge.reconcileActiveTurn();
+          if (reconciled.recovered) {
+            log(`[codex-app-server] recovered missed terminal event for turn ${reconciled.turnId}`);
+          }
+        } catch (e) {
+          // A failed read is not evidence that the turn completed. Preserve
+          // the local claim and retry; the normal task timeout remains the
+          // outer bound.
+          log(`[codex-app-server] turn reconciliation failed: ${e instanceof Error ? e.message : String(e)}`);
+        } finally {
+          scheduleReconciliation();
+        }
+      }, reconciliationIntervalMs);
+    };
+
     bridge.on("task_reply", onReply);
     bridge.on("task_error", onError);
+    scheduleReconciliation();
 
     bridge
       .submitTask({ taskId: opts.taskId, text: opts.text, from: opts.from })

--- a/docs/tests/report-test573.txt
+++ b/docs/tests/report-test573.txt
@@ -1,0 +1,101 @@
+Test 573 — Codex shared-TUI missed-terminal reconciliation
+Date: 2026-08-03 Asia/Shanghai
+Status: PASS (candidate); live node restored on existing production source
+
+Scope
+-----
+TM副责人 accepted CommHub tasks but they did not appear in the attached Codex
+TUI. Diagnose Hub → inbox → bridge → app-server → shared TUI and prevent one
+missed terminal event from permanently wedging later tasks.
+
+Production facts (read-only diagnosis)
+--------------------------------------
+- Hub session: alias=TM副责人, node_id=n_ace53877, runtime=codex-app-server,
+  app-server ws://127.0.0.1:24702, thread
+  019f4af0-177b-75a3-8d40-9251b1e719ee.
+- The TUI command used the same URL and exact thread id; this was not an
+  attach-to-the-wrong-thread failure.
+- The old bridge PID 331368 started 2026-07-31 and therefore predated
+  rfc030-work commit 81589a05 (new_message wake + non-blocking inbox drain).
+- Old bridge log: 10 task_reply successes, then 28 consecutive 600-second
+  timeouts. Later tasks were logged as "queued (a turn is in flight)".
+- App-server thread/read was authoritative counter-evidence: thread status was
+  idle; the first locally-stuck task, anet:5eb11df6-..., existed as a completed
+  turn in persisted history. The bridge had missed/lost the terminal event but
+  retained activeTurnId indefinitely.
+
+Immediate live recovery
+-----------------------
+- Cancelled only the diagnostic probe 9e76b9bb... before restart.
+- Stopped exact bridge PID 331368 with SIGTERM. TUI and app-server were not
+  restarted.
+- Restarted bridge from rfc030-work @ 81589a05 in exact tmux
+  `TM副责人-桥`; cleared all inherited COMMHUB_* plus unrelated
+  TELEGRAM_STATE_DIR/CODEX_COMPANION_SESSION_ID first.
+- Live send_task 0431779d-d642-4a00-92cf-bd41710ac8d9 was visible in tmux
+  `TM副责人` and returned the exact marker
+  `TM副责人链路恢复-20260803-002` in about five seconds.
+- Post-check: session idle, inbox_pending=0.
+- Subsequent real tasks from TM负责人 and TMCode负责人 also reached the same
+  TUI and completed, proving this was not a one-shot self-probe recovery.
+
+Message-type boundary
+---------------------
+- CommHub `task`/`broadcast` rows are model/TUI work and are the supported
+  node-to-node delivery path. The fleet rule requires peer results and
+  receipts to use send_task.
+- Plain `send_message` rows now wake the bridge on new_message (81589a05) but
+  remain intentionally ack/log-only in cli.ts; they do not enter the model or
+  TUI. A live TM网站运维 message at 08:28:58 confirmed this exact behavior.
+- A no-model `thread/inject_items` probe returned success but emitted no item
+  notification and did not render live in the attached TUI. It is therefore
+  not used as a fake passive-notification mechanism. Turning send_message into
+  a full model turn would expand it into a full-access execution surface and
+  was deliberately rejected.
+
+Candidate behavior
+------------------
+- CodexAppServerBridge.reconcileActiveTurn() treats app-server thread/read as
+  authoritative only for the exact locally-active turn.
+- Normal watchdog reads only thread status. It hydrates full turn history only
+  when the server reports idle (or an older server omits status).
+- It releases the claim only for completed/failed/interrupted. Active, missing,
+  failed-read, and stale-snapshot cases remain fail-closed.
+- Exact final_answer is recovered from persisted items, then the existing FIFO
+  drains. A single-flight guard prevents concurrent thread/read stampedes.
+- codexAppServerThink schedules reconciliation every five seconds and retains
+  the existing 600-second outer timeout.
+
+Docker evidence
+---------------
+Fixed/reused image tag: anet-test-tm-codex-reconcile:dev
+Image: sha256:cfe53bc15fda5b363b67e18bd85ec02bd2826af871933709cd1e6d4837151a52
+Size: 85,922,732 bytes
+
+1. Focused normal gate
+   docker run ... anet-test-tm-codex-reconcile:dev
+   PASS: 26 tests, 81 assertions, 0 failures.
+
+2. Full Codex app-server runtime/client/bridge gate
+   bun test codex-app-server*.test.ts codex-app-server/*.test.ts (inside Docker)
+   PASS: 38 tests, 110 assertions, 0 failures.
+
+3. Node bundle build (inside Docker, source copied to ephemeral /tmp)
+   bun run build
+   PASS: 238 modules, dist/cli.js 947,017 bytes.
+
+4. Witnessed-red mutation: remove watchdog start
+   RESULT: 25 pass, 1 fail; runtime test timed out instead of recovering.
+
+5. Witnessed-red mutation: suppress exact terminal release
+   RESULT: 25 pass, 1 fail; completed persisted turn remained unrecovered.
+
+Safety / provenance
+-------------------
+- Development worktree: /tmp/commniu-tm-codex-reconcile
+- Branch: fix/tm-codex-turn-reconcile
+- Base: origin/main 849a851949e8a72ba857c737849771421516c852
+- No edit to /home/vansin/agent-orchestra or /home/vansin/rfc030-work.
+- No push, merge, npm publish, or deployment of the candidate code.
+- Production currently runs the already-reviewed 81589a05 source; the new
+  reconciliation candidate remains separate pending review.

--- a/docs/tests/report-test576.txt
+++ b/docs/tests/report-test576.txt
@@ -1,0 +1,50 @@
+Test 576 — Codex TUI interrupted-turn fail-closed extension
+Date: 2026-08-03 Asia/Shanghai
+Status: PASS (isolated candidate; not deployed/published)
+
+Candidate
+---------
+Worktree: /tmp/commniu-tm-codex-reconcile
+Branch: fix/tm-codex-turn-reconcile
+Base: 849a851949e8a72ba857c737849771421516c852
+Head: 64cc6720272d295e95b9b88db92368790efb822d
+Fixed Docker tag: anet-tui-audit-codex:dev
+Image ENV: TEST573_SOURCE_COMMIT=64cc6720272d295e95b9b88db92368790efb822d
+
+Finding and fix
+---------------
+The existing reconciliation candidate recovered a missed turn/completed event,
+but its common terminal handler treated only explicit errors and status=failed
+as failures. An interrupted turn with partial assistant text could therefore be
+emitted as a successful task_reply from either the live notification path or
+the authoritative thread/read reconciliation path.
+
+Status=interrupted now produces task_error. Without an upstream error message,
+the stable error is: Codex turn was interrupted without an error message.
+
+Witnessed red / green
+---------------------
+1. Against the pre-fix candidate, the two new tests observed one successful
+   reply each for live and reconciled interrupted turns (26 pass, 2 fail).
+2. Final focused gate: 28 pass, 0 fail, 86 assertions.
+3. Final mutations, test code unchanged:
+   - drop-watchdog-start: 27 pass, 1 fail (missed terminal times out), rc=1.
+   - drop-terminal-release: 26 pass, 2 fail (authoritative terminal is not
+     recovered), rc=1.
+   - accept-interrupted: 26 pass, 2 fail (both interrupted paths emit a reply),
+     rc=1.
+
+Full Docker gate
+----------------
+- Codex app-server client, bridge, and runtime: 40 pass, 0 fail,
+  115 assertions across 3 files.
+- agent-node bundle: 238 modules, cli.js 0.95 MB.
+- The test573 image is now self-contained with exact source and dependencies;
+  its prior mount-only form was rejected when the build could not resolve zod
+  and undici.
+- All containers ran with --network none.
+
+Safety
+------
+No global npm package, live Codex bridge/TUI/app-server, token, Hub state,
+remote branch, merge, publish, or deployment was changed.

--- a/tests/test573-codex-turn-reconcile/Dockerfile
+++ b/tests/test573-codex-turn-reconcile/Dockerfile
@@ -1,0 +1,9 @@
+FROM oven/bun:1
+
+WORKDIR /workspace
+COPY run.sh /harness/run.sh
+COPY run-mutation.sh /harness/run-mutation.sh
+COPY mutate.mjs /harness/mutate.mjs
+RUN chmod 0755 /harness/run.sh /harness/run-mutation.sh
+
+ENTRYPOINT ["/harness/run.sh"]

--- a/tests/test573-codex-turn-reconcile/Dockerfile
+++ b/tests/test573-codex-turn-reconcile/Dockerfile
@@ -1,9 +1,16 @@
-FROM oven/bun:1
+ARG SOURCE_COMMIT
+FROM oven/bun:1.3.14
 
 WORKDIR /workspace
-COPY run.sh /harness/run.sh
-COPY run-mutation.sh /harness/run-mutation.sh
-COPY mutate.mjs /harness/mutate.mjs
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node/src ./agent-node/src
+COPY tests/test573-codex-turn-reconcile/run.sh /harness/run.sh
+COPY tests/test573-codex-turn-reconcile/run-mutation.sh /harness/run-mutation.sh
+COPY tests/test573-codex-turn-reconcile/mutate.mjs /harness/mutate.mjs
 RUN chmod 0755 /harness/run.sh /harness/run-mutation.sh
+
+ARG SOURCE_COMMIT
+ENV TEST573_SOURCE_COMMIT=$SOURCE_COMMIT
 
 ENTRYPOINT ["/harness/run.sh"]

--- a/tests/test573-codex-turn-reconcile/mutate.mjs
+++ b/tests/test573-codex-turn-reconcile/mutate.mjs
@@ -27,6 +27,12 @@ if (mutation === "drop-watchdog-start") {
     "      const recovered = this.finishOwnedTurn(activeAtStart, {\n",
     "      const recovered = false && this.finishOwnedTurn(activeAtStart, {\n",
   );
+} else if (mutation === "accept-interrupted") {
+  replaceExactlyOnce(
+    "src/runtime/codex-app-server-bridge.ts",
+    ': terminal.status === "interrupted"\n          ? "Codex turn was interrupted without an error message"',
+    ': false\n          ? "Codex turn was interrupted without an error message"',
+  );
 } else {
   throw new Error(`unknown mutation: ${mutation}`);
 }

--- a/tests/test573-codex-turn-reconcile/mutate.mjs
+++ b/tests/test573-codex-turn-reconcile/mutate.mjs
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const [mutation, root] = process.argv.slice(2);
+if (!mutation || !root) throw new Error("usage: mutate.mjs <mutation> <agent-node-root>");
+
+function replaceExactlyOnce(relativePath, before, after) {
+  const path = join(root, relativePath);
+  const source = readFileSync(path, "utf8");
+  const first = source.indexOf(before);
+  if (first < 0 || source.indexOf(before, first + before.length) >= 0) {
+    throw new Error(`${mutation}: expected exactly one anchor in ${relativePath}`);
+  }
+  writeFileSync(path, source.replace(before, after));
+  console.log(`MUTATED ${mutation}: ${relativePath}`);
+}
+
+if (mutation === "drop-watchdog-start") {
+  replaceExactlyOnce(
+    "src/runtime/codex-app-server/runtime.ts",
+    '    bridge.on("task_error", onError);\n    scheduleReconciliation();\n\n    bridge\n',
+    '    bridge.on("task_error", onError);\n\n    bridge\n',
+  );
+} else if (mutation === "drop-terminal-release") {
+  replaceExactlyOnce(
+    "src/runtime/codex-app-server-bridge.ts",
+    "      const recovered = this.finishOwnedTurn(activeAtStart, {\n",
+    "      const recovered = false && this.finishOwnedTurn(activeAtStart, {\n",
+  );
+} else {
+  throw new Error(`unknown mutation: ${mutation}`);
+}

--- a/tests/test573-codex-turn-reconcile/run-mutation.sh
+++ b/tests/test573-codex-turn-reconcile/run-mutation.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mutation="${1:?mutation name required}"
+rm -rf /tmp/agent-node-under-test
+cp -a /workspace/agent-node /tmp/agent-node-under-test
+bun /harness/mutate.mjs "$mutation" /tmp/agent-node-under-test
+
+bun test \
+  /tmp/agent-node-under-test/src/runtime/codex-app-server-bridge.test.ts \
+  /tmp/agent-node-under-test/src/runtime/codex-app-server/runtime.test.ts

--- a/tests/test573-codex-turn-reconcile/run-mutation.sh
+++ b/tests/test573-codex-turn-reconcile/run-mutation.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 mutation="${1:?mutation name required}"
 rm -rf /tmp/agent-node-under-test
-cp -a /workspace/agent-node /tmp/agent-node-under-test
+mkdir -p /tmp/agent-node-under-test
+cp -a /workspace/agent-node/src /workspace/agent-node/package.json /tmp/agent-node-under-test/
+ln -s /workspace/agent-node/node_modules /tmp/agent-node-under-test/node_modules
 bun /harness/mutate.mjs "$mutation" /tmp/agent-node-under-test
 
 bun test \

--- a/tests/test573-codex-turn-reconcile/run.sh
+++ b/tests/test573-codex-turn-reconcile/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test -f /workspace/agent-node/src/runtime/codex-app-server-bridge.ts
+test -f /workspace/agent-node/src/runtime/codex-app-server/runtime.ts
+
+bun test \
+  /workspace/agent-node/src/runtime/codex-app-server-bridge.test.ts \
+  /workspace/agent-node/src/runtime/codex-app-server/runtime.test.ts


### PR DESCRIPTION
> **Authored by 通信牛.** Opened on its behalf — its node shares a codex thread that is saturated by long autonomous turns, so its replies hit the 600s node deadline. The work and the evidence are the author's.

## The defect

A single dropped `turn/completed` frame **permanently wedges the FIFO**. The bridge keeps treating that turn as active, so every later task reports `queued` and dies on its own deadline.

Production evidence from one node: **10 successful `task_reply`, then 28 consecutive 600s timeouts.** Server-side `thread/read(includeTurns)` showed the stuck turn was already `completed` and the thread `idle` — the bridge's local state had diverged from the server's truth and had no way back.

This also explains an earlier observation that had no explanation: interrupting the in-flight turn to free the thread did **not** drain the queue. The queue logic was fine; the turn-state tracking was wrong.

## The fix

A 5s cheap `thread/read` (status only, `includeTurns:false`). Full turn read happens **only** when the thread reports idle. Release happens **only** when the exact active turn carries an authoritative terminal status, and `interrupted` is forced to `task_error` so partial text can never surface as a successful reply.

## Independent review

Reviewed by `grok测试员` against four points I set, each verified structurally *and* by mutation:

| point | result |
|---|---|
| never release a turn the bridge did not claim | PASS — release requires a `pendingTurns` entry, which only `startTaskTurn` writes; a human-TUI turn has none |
| `interrupted` + partial text cannot become success | PASS — both event and reconcile paths |
| race between reconcile-release and a new claim | PASS — `activeTurnId` compared against the start-of-reconcile snapshot at two points; single-flight guard |
| polling cost, and fail-closed on read failure | PASS — read failure logs and reschedules, never settles or releases |

Mutations independently reproduced (author's numbers not taken on trust):

```
drop watchdog start      27 pass / 1 fail
drop terminal release    26 pass / 2 fail
accept interrupted       26 pass / 2 fail
restored                 28 pass / 0 fail / 86 expect
```

**BLOCKER: none. MAJOR: none.**

## Follow-ups, recorded rather than fixed here

- No separately named "reconcile while a human turn is active" test. The behaviour is covered through the exact-id + pending + non-idle short circuit, but it is not pinned under its own name.
- If a `pendingTurns` entry were lost while `activeTurnId` remained, release would early-return and the queue could wedge again through a different door. Called out by the reviewer as theoretical; worth a defensive release or a loud warning rather than silence, since silence is exactly what made the original defect take hours to find.
- I asked for one more test: the "already timed out, then a late `task_reply` arrives" path is safe by construction (`finish()` has a `settled` guard and removes both listeners), but nothing pins it — moving those two `bridge.off` lines would regress it silently.

## Scope

Based directly on `origin/main@849a8519`: **9 files, +542/-7.**