### PR TITLE
fix(opencode): correlate network replies to their originating message

### DIFF
--- a/agent-node/src/runtime/opencode-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.test.ts
@@ -77,9 +77,10 @@ if (command === "serve") {
       await new Promise(r => setTimeout(r, Number(env.FAKE_TURN_MS || 25)));
       const prompt = json.parts?.[0]?.text || "";
       const reply = "FAKE_REPLY:" + prompt;
-      messages[id].push({ info:{role:"assistant"}, parts:[{type:"text",text:reply}] });
+      const parentID = env.FAKE_RACE_HUMAN === "1" ? "msg_human_race" : json.messageID;
+      messages[id].push({ info:{role:"assistant",parentID}, parts:[{type:"text",text:reply}] });
       delete statuses[id];
-      return send(res, { parts:[{type:"text",text:reply}] });
+      return send(res, { info:{role:"assistant",parentID}, parts:[{type:"text",text:reply}] });
     }
     res.writeHead(404); res.end("not found");
   });
@@ -287,6 +288,26 @@ describe("OpenCode native serve+attach copresence", () => {
       const result = await runtime.submit("after-human", 5_000);
       expect(Date.now() - started).toBeGreaterThanOrEqual(300);
       expect(result.replyText).toBe("FAKE_REPLY:after-human");
+    } finally {
+      await runtime?.close();
+      f.close();
+    }
+  }, 15_000);
+
+  test("refuses a reply owned by a human turn that won the idle-to-submit race", async () => {
+    const f = fixture({ FAKE_RACE_HUMAN: "1" });
+    let runtime: Awaited<ReturnType<typeof openVettedOpenCodeCopresence>> | undefined;
+    try {
+      runtime = await openVettedOpenCodeCopresence({
+        binary: f.binary,
+        env: f.env,
+        cwd: f.root,
+        workDir: f.root,
+        model: "opencode/fake",
+        startupTimeoutMs: 5_000,
+      });
+      await expect(runtime.submit("network-must-own-its-reply", 5_000))
+        .rejects.toThrow("not owned by the submitted network message");
     } finally {
       await runtime?.close();
       f.close();

--- a/agent-node/src/runtime/opencode-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.test.ts
@@ -29,7 +29,6 @@ if (command === "serve") {
   const statuses = {};
   const messages = {};
   let lastResponse = null;
-  let staleRunnerUntil = 0;
   const server = http.createServer(async (req, res) => {
     if (req.headers.authorization !== expectedAuth) { res.writeHead(401); return res.end("unauthorized"); }
     const body = await new Promise((resolve) => { let s=""; req.on("data", c => s+=c); req.on("end", () => resolve(s)); });
@@ -76,7 +75,8 @@ if (command === "serve") {
       if (env.FAKE_REQUIRE_MODEL === "1" && (json.model?.providerID !== "opencode" || json.model?.modelID !== "fake")) {
         res.writeHead(400); return res.end("missing model identity");
       }
-      if (lastResponse && Date.now() < staleRunnerUntil) {
+      if (lastResponse && env.FAKE_REQUIRE_ASCENDING_MESSAGE_ID === "1" &&
+          !/^msg_[0-9a-f]{12}[0-9A-Za-z]{14}$/.test(json.messageID || "")) {
         messages[id].push({ info:{role:"user",id:json.messageID}, parts:json.parts || [] });
         return send(res, lastResponse);
       }
@@ -88,7 +88,6 @@ if (command === "serve") {
       messages[id].push({ info:{role:"user",id:json.messageID}, parts:json.parts || [] });
       lastResponse = { info:{role:"assistant",parentID}, parts:[{type:"text",text:reply}] };
       messages[id].push(lastResponse);
-      staleRunnerUntil = Date.now() + Number(env.FAKE_STALE_RUNNER_MS || 0);
       delete statuses[id];
       return send(res, lastResponse);
     }
@@ -324,8 +323,8 @@ describe("OpenCode native serve+attach copresence", () => {
     }
   }, 15_000);
 
-  test("waits past OpenCode's status-idle to Runner-cleanup gap before the next network turn", async () => {
-    const f = fixture({ FAKE_STALE_RUNNER_MS: "150" });
+  test("uses OpenCode's ascending message ID shape across sequential network turns", async () => {
+    const f = fixture({ FAKE_REQUIRE_ASCENDING_MESSAGE_ID: "1" });
     let runtime: Awaited<ReturnType<typeof openVettedOpenCodeCopresence>> | undefined;
     try {
       runtime = await openVettedOpenCodeCopresence({

--- a/agent-node/src/runtime/opencode-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.test.ts
@@ -28,6 +28,8 @@ if (command === "serve") {
   const port = Number(value("--port"));
   const statuses = {};
   const messages = {};
+  let lastResponse = null;
+  let staleRunnerUntil = 0;
   const server = http.createServer(async (req, res) => {
     if (req.headers.authorization !== expectedAuth) { res.writeHead(401); return res.end("unauthorized"); }
     const body = await new Promise((resolve) => { let s=""; req.on("data", c => s+=c); req.on("end", () => resolve(s)); });
@@ -65,6 +67,7 @@ if (command === "serve") {
       return send(res, true);
     }
     const match = req.url.match(/^\\/session\\/(ses_[A-Za-z0-9]+)\\/message$/);
+    if (match && req.method === "GET") return send(res, messages[match[1]] || []);
     if (match && req.method === "POST") {
       const id = match[1];
       if ((json.parts?.[0]?.text || "").startsWith("notice:") || json.noReply === true) {
@@ -73,14 +76,21 @@ if (command === "serve") {
       if (env.FAKE_REQUIRE_MODEL === "1" && (json.model?.providerID !== "opencode" || json.model?.modelID !== "fake")) {
         res.writeHead(400); return res.end("missing model identity");
       }
+      if (lastResponse && Date.now() < staleRunnerUntil) {
+        messages[id].push({ info:{role:"user",id:json.messageID}, parts:json.parts || [] });
+        return send(res, lastResponse);
+      }
       statuses[id] = { type:"busy" };
       await new Promise(r => setTimeout(r, Number(env.FAKE_TURN_MS || 25)));
       const prompt = json.parts?.[0]?.text || "";
       const reply = "FAKE_REPLY:" + prompt;
       const parentID = env.FAKE_RACE_HUMAN === "1" ? "msg_human_race" : json.messageID;
-      messages[id].push({ info:{role:"assistant",parentID}, parts:[{type:"text",text:reply}] });
+      messages[id].push({ info:{role:"user",id:json.messageID}, parts:json.parts || [] });
+      lastResponse = { info:{role:"assistant",parentID}, parts:[{type:"text",text:reply}] };
+      messages[id].push(lastResponse);
+      staleRunnerUntil = Date.now() + Number(env.FAKE_STALE_RUNNER_MS || 0);
       delete statuses[id];
-      return send(res, { info:{role:"assistant",parentID}, parts:[{type:"text",text:reply}] });
+      return send(res, lastResponse);
     }
     res.writeHead(404); res.end("not found");
   });
@@ -308,6 +318,27 @@ describe("OpenCode native serve+attach copresence", () => {
       });
       await expect(runtime.submit("network-must-own-its-reply", 5_000))
         .rejects.toThrow("not owned by the submitted network message");
+    } finally {
+      await runtime?.close();
+      f.close();
+    }
+  }, 15_000);
+
+  test("waits past OpenCode's status-idle to Runner-cleanup gap before the next network turn", async () => {
+    const f = fixture({ FAKE_STALE_RUNNER_MS: "150" });
+    let runtime: Awaited<ReturnType<typeof openVettedOpenCodeCopresence>> | undefined;
+    try {
+      runtime = await openVettedOpenCodeCopresence({
+        binary: f.binary,
+        env: f.env,
+        cwd: f.root,
+        workDir: f.root,
+        startupTimeoutMs: 5_000,
+      });
+      const first = await runtime.submit("first-network-turn", 5_000);
+      const second = await runtime.submit("second-network-turn", 5_000);
+      expect(first.replyText).toBe("FAKE_REPLY:first-network-turn");
+      expect(second.replyText).toBe("FAKE_REPLY:second-network-turn");
     } finally {
       await runtime?.close();
       f.close();

--- a/agent-node/src/runtime/opencode-copresence/runtime.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.ts
@@ -247,12 +247,22 @@ async function waitUntilSessionIdle(
   timeoutMs: number,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
+  // OpenCode 1.18.1 clears /session/status just before its in-process Runner
+  // promise is removed. A POST in that narrow tail can join the completed
+  // Runner, receive the previous assistant message, and leave the newly
+  // persisted user message unanswered. Require an idle observation to remain
+  // stable across this bounded grace period before submitting another turn.
+  // This is not an atomic human/network claim; the parentID check below still
+  // fails closed if a human wins after the stable-idle observation.
+  const idleStabilityMs = 250;
+  let idleSince = 0;
   while (Date.now() < deadline) {
+    let appearsIdle = false;
     try {
       const statuses = await fetchJson(url, password, "/session/status", {}, 2_000);
       if (statuses && typeof statuses === "object" && !Array.isArray(statuses)) {
         const state = statuses[sessionId];
-        if (state?.type === "idle") return;
+        if (state?.type === "idle") appearsIdle = true;
         if (state === undefined) {
           // Pinned OpenCode 1.18.1 returns an empty status map for an idle
           // session, so absence alone cannot be rejected. Distinguish the
@@ -261,7 +271,7 @@ async function waitUntilSessionIdle(
           // status stays fail-closed and retries until the caller's timeout.
           try {
             const session = await fetchJson(url, password, `/session/${sessionId}`, {}, 2_000);
-            if (session?.id === sessionId) return;
+            if (session?.id === sessionId) appearsIdle = true;
           } catch {
             // Keep waiting: missing session is not evidence of idle.
           }
@@ -269,6 +279,12 @@ async function waitUntilSessionIdle(
       }
     } catch {
       // A transient status failure is also not evidence of idle.
+    }
+    if (appearsIdle) {
+      idleSince ||= Date.now();
+      if (Date.now() - idleSince >= idleStabilityMs) return;
+    } else {
+      idleSince = 0;
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }

--- a/agent-node/src/runtime/opencode-copresence/runtime.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.ts
@@ -27,6 +27,30 @@ const USERNAME = "opencode";
 const OUTPUT_LIMIT = 64 * 1024;
 export const OPENCODE_COMMHUB_TOKEN_ENV = "ANET_OPENCODE_COMMHUB_TOKEN";
 const OPENCODE_COMMHUB_INSTRUCTIONS = "ANET-COMMHUB.md";
+let lastOpenCodeMessageTimestamp = 0;
+let openCodeMessageCounter = 0;
+
+function createOpenCodeAscendingMessageId(): string {
+  const timestamp = Date.now();
+  if (timestamp !== lastOpenCodeMessageTimestamp) {
+    lastOpenCodeMessageTimestamp = timestamp;
+    openCodeMessageCounter = 0;
+  }
+  openCodeMessageCounter++;
+  if (openCodeMessageCounter > 0xfff) {
+    throw new Error("OpenCode message ID counter overflowed within one millisecond");
+  }
+  const encoded = BigInt(timestamp) * 0x1000n + BigInt(openCodeMessageCounter);
+  const timeBytes = Buffer.alloc(6);
+  for (let index = 0; index < timeBytes.length; index++) {
+    timeBytes[index] = Number((encoded >> BigInt(40 - 8 * index)) & 0xffn);
+  }
+  const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  const entropy = randomBytes(14);
+  let suffix = "";
+  for (const byte of entropy) suffix += alphabet[byte % alphabet.length];
+  return `msg_${timeBytes.toString("hex")}${suffix}`;
+}
 
 export interface OpenCodeCopresenceSubmitResult {
   replyText: string;
@@ -247,22 +271,12 @@ async function waitUntilSessionIdle(
   timeoutMs: number,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
-  // OpenCode 1.18.1 clears /session/status just before its in-process Runner
-  // promise is removed. A POST in that narrow tail can join the completed
-  // Runner, receive the previous assistant message, and leave the newly
-  // persisted user message unanswered. Require an idle observation to remain
-  // stable across this bounded grace period before submitting another turn.
-  // This is not an atomic human/network claim; the parentID check below still
-  // fails closed if a human wins after the stable-idle observation.
-  const idleStabilityMs = 250;
-  let idleSince = 0;
   while (Date.now() < deadline) {
-    let appearsIdle = false;
     try {
       const statuses = await fetchJson(url, password, "/session/status", {}, 2_000);
       if (statuses && typeof statuses === "object" && !Array.isArray(statuses)) {
         const state = statuses[sessionId];
-        if (state?.type === "idle") appearsIdle = true;
+        if (state?.type === "idle") return;
         if (state === undefined) {
           // Pinned OpenCode 1.18.1 returns an empty status map for an idle
           // session, so absence alone cannot be rejected. Distinguish the
@@ -271,7 +285,7 @@ async function waitUntilSessionIdle(
           // status stays fail-closed and retries until the caller's timeout.
           try {
             const session = await fetchJson(url, password, `/session/${sessionId}`, {}, 2_000);
-            if (session?.id === sessionId) appearsIdle = true;
+            if (session?.id === sessionId) return;
           } catch {
             // Keep waiting: missing session is not evidence of idle.
           }
@@ -279,12 +293,6 @@ async function waitUntilSessionIdle(
       }
     } catch {
       // A transient status failure is also not evidence of idle.
-    }
-    if (appearsIdle) {
-      idleSince ||= Date.now();
-      if (Date.now() - idleSince >= idleStabilityMs) return;
-    } else {
-      idleSince = 0;
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
@@ -492,7 +500,12 @@ export async function openVettedOpenCodeCopresence(
           // the same runner result. Give this network turn a unique user-message
           // identity and accept only an assistant response causally parented to
           // it; otherwise a human answer could be misrouted to CommHub.
-          const messageId = `msg_anet_${randomBytes(16).toString("hex")}`;
+          // OpenCode compares message IDs lexicographically to decide whether
+          // the newest user turn still needs an assistant response. A UUID-ish
+          // custom suffix sorts after OpenCode's timestamp prefix and can make
+          // a later user turn appear already answered. Generate the exact
+          // ascending ID shape used by OpenCode 1.18.1 instead.
+          const messageId = createOpenCodeAscendingMessageId();
           const message = await fetchJson(url, password, `/session/${created.id}/message`, {
             method: "POST",
             body: JSON.stringify({

--- a/agent-node/src/runtime/opencode-copresence/runtime.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.ts
@@ -470,13 +470,24 @@ export async function openVettedOpenCodeCopresence(
           // session already has a full attach TUI, leaving a live-looking
           // process with no message in the shared session.
           const model = parseModelRef(opts.model);
+          // OpenCode creates the user message before it atomically joins the
+          // per-session runner. A human TUI submission can therefore win the
+          // narrow idle-check -> POST race, and concurrent POST callers receive
+          // the same runner result. Give this network turn a unique user-message
+          // identity and accept only an assistant response causally parented to
+          // it; otherwise a human answer could be misrouted to CommHub.
+          const messageId = `msg_anet_${randomBytes(16).toString("hex")}`;
           const message = await fetchJson(url, password, `/session/${created.id}/message`, {
             method: "POST",
             body: JSON.stringify({
+              messageID: messageId,
               ...(model ? { model } : {}),
               parts: [{ type: "text", text: visiblePrompt }],
             }),
           }, timeoutMs);
+          if (message?.info?.role !== "assistant" || message?.info?.parentID !== messageId) {
+            throw new Error("OpenCode reply was not owned by the submitted network message");
+          }
           const replyText = parseMessageReply(message);
           if (!replyText) {
             throw new Error("OpenCode POST /session/:id/message returned no assistant text");

--- a/docs/tests/report-test575.txt
+++ b/docs/tests/report-test575.txt
@@ -1,0 +1,48 @@
+Test 575 — OpenCode TUI network reply ownership
+Date: 2026-08-03 Asia/Shanghai
+Status: PASS (isolated candidate; not deployed/published)
+
+Candidate
+---------
+Worktree: /tmp/commniu-opencode-correlate
+Branch: fix/opencode-correlated-network-reply
+Base: 849a851949e8a72ba857c737849771421516c852
+Head: 7f2040da6d959b39f0c6dda502df049ad46243b1
+Fixed Docker tag: anet-tui-audit-opencode:dev
+Image ENV: TEST575_SOURCE_COMMIT=7f2040da6d959b39f0c6dda502df049ad46243b1
+
+Finding and fix
+---------------
+The bridge checked that a shared OpenCode session was idle and then submitted a
+network message. OpenCode 1.18.1 does not expose an atomic idle claim; a human
+TUI message can win that interval. The old bridge accepted whichever assistant
+message the POST returned, so a human-owned reply could be sent to the network
+task originator.
+
+The bridge now supplies a cryptographically random msg_anet_* messageID and
+accepts only an assistant message whose parentID equals that exact network
+message ID. A human-owned or otherwise uncorrelated reply fails closed.
+
+Witnessed red / green
+---------------------
+1. Before the production fix, a fake OpenCode server returned an assistant
+   parented by msg_human_race. The bridge resolved it; the new rejection test
+   failed (rc=1).
+2. Final focused Docker gate: PASS (rc=0).
+3. Mutation drop-reply-ownership changes only the production ownership check;
+   the test then receives a resolved promise instead of the required rejection
+   (rc=1). This is a target-path red, not a startup/import failure.
+
+Full Docker gate
+----------------
+- OpenCode copresence, inbox wiring, independent drain lanes, and single-flight:
+  26 pass, 0 fail, 101 assertions across 4 files.
+- agent-node bundle: 238 modules, cli.js 0.95 MB.
+- All containers ran with --network none.
+
+Safety
+------
+No global npm package, existing node process, token, Hub state, remote branch,
+merge, publish, or deployment was changed by this candidate. The separately
+requested opencode-指挥狗 recovery used the already installed reviewed candidate,
+not this new source branch.

--- a/docs/tests/report-test575.txt
+++ b/docs/tests/report-test575.txt
@@ -1,4 +1,4 @@
-Test 575 — OpenCode TUI network reply ownership
+Test 575 — OpenCode TUI network reply ownership and message ordering
 Date: 2026-08-03 Asia/Shanghai
 Status: PASS (isolated candidate; not deployed/published)
 
@@ -7,42 +7,64 @@ Candidate
 Worktree: /tmp/commniu-opencode-correlate
 Branch: fix/opencode-correlated-network-reply
 Base: 849a851949e8a72ba857c737849771421516c852
-Head: 7f2040da6d959b39f0c6dda502df049ad46243b1
-Fixed Docker tag: anet-tui-audit-opencode:dev
-Image ENV: TEST575_SOURCE_COMMIT=7f2040da6d959b39f0c6dda502df049ad46243b1
+Source head: 925a2a5e220d1a3c06c51d44fab255d5d31ae05a
+Fixed Docker tags: anet-tui-audit-opencode:dev, anet-test227:dev
+Focused image ENV:
+TEST575_SOURCE_COMMIT=925a2a5e220d1a3c06c51d44fab255d5d31ae05a
 
-Finding and fix
----------------
-The bridge checked that a shared OpenCode session was idle and then submitted a
-network message. OpenCode 1.18.1 does not expose an atomic idle claim; a human
-TUI message can win that interval. The old bridge accepted whichever assistant
-message the POST returned, so a human-owned reply could be sent to the network
-task originator.
+Findings and fixes
+------------------
+1. Reply ownership race
+   The bridge checked that the shared session was idle and then submitted a
+   network turn. OpenCode 1.18.1 has no atomic human/network claim, so a human
+   TUI turn can win that interval. The old bridge accepted whichever assistant
+   response the POST returned. The candidate gives each network turn a unique
+   message ID and accepts only an assistant whose parentID is that exact ID.
+   Any human-owned or uncorrelated response fails closed.
 
-The bridge now supplies a cryptographically random msg_anet_* messageID and
-accepts only an assistant message whose parentID equals that exact network
-message ID. A human-owned or otherwise uncorrelated reply fails closed.
+2. Chronological message-ID invariant
+   The first version of the ownership fix used msg_anet_<random>. Real
+   OpenCode 1.18.1 accepted and persisted that ID, but its prompt loop compares
+   message IDs lexicographically to determine whether a user turn has already
+   been answered. On a later sequential POST, msg_anet_* sorted incorrectly;
+   OpenCode returned the preceding assistant response and left the new user
+   turn unanswered. The ownership guard prevented a wrong CommHub reply, but
+   normal sequential work failed.
+
+   The final candidate generates the exact OpenCode 1.18.1 ascending ID shape:
+   msg_ + 12 lowercase hex timestamp/counter characters + 14 base62 entropy
+   characters. This preserves OpenCode's chronological ordering while retaining
+   exact parentID correlation.
 
 Witnessed red / green
 ---------------------
-1. Before the production fix, a fake OpenCode server returned an assistant
-   parented by msg_human_race. The bridge resolved it; the new rejection test
-   failed (rc=1).
-2. Final focused Docker gate: PASS (rc=0).
-3. Mutation drop-reply-ownership changes only the production ownership check;
-   the test then receives a resolved promise instead of the required rejection
-   (rc=1). This is a target-path red, not a startup/import failure.
+1. Before the ownership guard, a fake OpenCode server returned an assistant
+   parented by msg_human_race. The bridge resolved it; the rejection test failed.
+2. With the initial msg_anet_* guard, the real OpenCode 1.18.1 Docker harness
+   failed (rc=1): the next user message was persisted without an assistant and
+   POST returned the previous assistant parentID. A --network none attempt was
+   rejected as invalid evidence because the harness uses OpenCode's free model.
+3. Final focused Docker gate passed (rc=0) on source head 925a2a5e.
+4. Mutation drop-reply-ownership produced rc=1 at the human-race assertion.
+5. Mutation use-unordered-message-id restored msg_anet_* and produced rc=1 at
+   the second sequential network-turn assertion. Both mutations changed the
+   intended production gate and left test code unchanged.
 
-Full Docker gate
-----------------
-- OpenCode copresence, inbox wiring, independent drain lanes, and single-flight:
-  26 pass, 0 fail, 101 assertions across 4 files.
-- agent-node bundle: 238 modules, cli.js 0.95 MB.
-- All containers ran with --network none.
+Docker verification
+-------------------
+- Focused test575: PASS for the human race and sequential ordering cases.
+- Full non-ACP OpenCode unit set: 27 pass, 0 fail, 103 assertions across four
+  files; production bundle: 238 modules, cli.js 0.95 MB.
+- Real test227 with opencode-ai 1.18.1: OVERALL PASS (rc=0).
+  Layer 0: 34 tests pass across runtime, inbox wiring, drain lanes,
+  single-flight, and CLI wiring. Live layers verified authenticated CommHub MCP
+  outbound, official attach TUI rendering, informational toast isolation,
+  three sequential network submissions, shared-turn visibility, and lifecycle.
+  All 19 harness checks were true.
 
 Safety
 ------
-No global npm package, existing node process, token, Hub state, remote branch,
-merge, publish, or deployment was changed by this candidate. The separately
-requested opencode-指挥狗 recovery used the already installed reviewed candidate,
-not this new source branch.
+All test execution was isolated in Docker. No global npm package, existing node
+process, token, Hub state, remote branch, merge, publish, or deployment was
+changed. The live opencode-指挥狗, 指挥狗, and TM副责人 processes were not restarted
+or pointed at this candidate.

--- a/tests/test575-opencode-reply-ownership/Dockerfile
+++ b/tests/test575-opencode-reply-ownership/Dockerfile
@@ -10,6 +10,8 @@ RUN cd agent-node && bun install --ignore-scripts
 
 COPY agent-node/src ./agent-node/src
 COPY tests/test575-opencode-reply-ownership ./tests/test575-opencode-reply-ownership
+RUN chmod 0755 ./tests/test575-opencode-reply-ownership/run.sh \
+  ./tests/test575-opencode-reply-ownership/run-mutation.sh
 
 ARG SOURCE_COMMIT
 ENV TEST575_SOURCE_COMMIT=$SOURCE_COMMIT

--- a/tests/test575-opencode-reply-ownership/Dockerfile
+++ b/tests/test575-opencode-reply-ownership/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.1
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+
+COPY agent-node/src ./agent-node/src
+COPY tests/test575-opencode-reply-ownership ./tests/test575-opencode-reply-ownership
+
+ARG SOURCE_COMMIT
+ENV TEST575_SOURCE_COMMIT=$SOURCE_COMMIT
+ENTRYPOINT ["bash", "tests/test575-opencode-reply-ownership/run.sh"]

--- a/tests/test575-opencode-reply-ownership/mutate.mjs
+++ b/tests/test575-opencode-reply-ownership/mutate.mjs
@@ -1,13 +1,24 @@
 import { readFileSync, writeFileSync } from "node:fs";
 
-const path = process.argv[2];
-if (!path) throw new Error("usage: mutate.mjs <runtime.ts>");
+const [mutation, path] = process.argv.slice(2);
+if (!mutation || !path) throw new Error("usage: mutate.mjs <mutation> <runtime.ts>");
 const source = readFileSync(path, "utf8");
-const before = '          if (message?.info?.role !== "assistant" || message?.info?.parentID !== messageId) {';
-const after = '          if (false) {';
+const mutations = {
+  "drop-reply-ownership": [
+    '          if (message?.info?.role !== "assistant" || message?.info?.parentID !== messageId) {',
+    '          if (false) {',
+  ],
+  "drop-idle-stability": [
+    "  const idleStabilityMs = 250;",
+    "  const idleStabilityMs = 0;",
+  ],
+};
+const pair = mutations[mutation];
+if (!pair) throw new Error(`unknown mutation: ${mutation}`);
+const [before, after] = pair;
 const first = source.indexOf(before);
 if (first < 0 || source.indexOf(before, first + before.length) >= 0) {
-  throw new Error("expected exactly one reply ownership anchor");
+  throw new Error(`${mutation}: expected exactly one anchor`);
 }
 writeFileSync(path, source.replace(before, after));
-console.log("MUTATED drop-reply-ownership");
+console.log(`MUTATED ${mutation}`);

--- a/tests/test575-opencode-reply-ownership/mutate.mjs
+++ b/tests/test575-opencode-reply-ownership/mutate.mjs
@@ -8,9 +8,9 @@ const mutations = {
     '          if (message?.info?.role !== "assistant" || message?.info?.parentID !== messageId) {',
     '          if (false) {',
   ],
-  "drop-idle-stability": [
-    "  const idleStabilityMs = 250;",
-    "  const idleStabilityMs = 0;",
+  "use-unordered-message-id": [
+    "          const messageId = createOpenCodeAscendingMessageId();",
+    '          const messageId = `msg_anet_${randomBytes(16).toString("hex")}`;',
   ],
 };
 const pair = mutations[mutation];

--- a/tests/test575-opencode-reply-ownership/mutate.mjs
+++ b/tests/test575-opencode-reply-ownership/mutate.mjs
@@ -1,0 +1,13 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const path = process.argv[2];
+if (!path) throw new Error("usage: mutate.mjs <runtime.ts>");
+const source = readFileSync(path, "utf8");
+const before = '          if (message?.info?.role !== "assistant" || message?.info?.parentID !== messageId) {';
+const after = '          if (false) {';
+const first = source.indexOf(before);
+if (first < 0 || source.indexOf(before, first + before.length) >= 0) {
+  throw new Error("expected exactly one reply ownership anchor");
+}
+writeFileSync(path, source.replace(before, after));
+console.log("MUTATED drop-reply-ownership");

--- a/tests/test575-opencode-reply-ownership/run-mutation.sh
+++ b/tests/test575-opencode-reply-ownership/run-mutation.sh
@@ -12,8 +12,8 @@ case "$mutation" in
   drop-reply-ownership)
     test_name="refuses a reply owned by a human turn that won the idle-to-submit race"
     ;;
-  drop-idle-stability)
-    test_name="waits past OpenCode's status-idle to Runner-cleanup gap before the next network turn"
+  use-unordered-message-id)
+    test_name="uses OpenCode's ascending message ID shape across sequential network turns"
     ;;
   *)
     echo "unknown mutation: $mutation" >&2

--- a/tests/test575-opencode-reply-ownership/run-mutation.sh
+++ b/tests/test575-opencode-reply-ownership/run-mutation.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rm -rf /tmp/agent-node-under-test
+cp -a /workspace/agent-node /tmp/agent-node-under-test
+bun /workspace/tests/test575-opencode-reply-ownership/mutate.mjs \
+  /tmp/agent-node-under-test/src/runtime/opencode-copresence/runtime.ts
+cd /tmp/agent-node-under-test
+bun test src/runtime/opencode-copresence/runtime.test.ts \
+  -t "refuses a reply owned by a human turn that won the idle-to-submit race"

--- a/tests/test575-opencode-reply-ownership/run-mutation.sh
+++ b/tests/test575-opencode-reply-ownership/run-mutation.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+mutation="${1:?mutation name required}"
 rm -rf /tmp/agent-node-under-test
 cp -a /workspace/agent-node /tmp/agent-node-under-test
 bun /workspace/tests/test575-opencode-reply-ownership/mutate.mjs \
+  "$mutation" \
   /tmp/agent-node-under-test/src/runtime/opencode-copresence/runtime.ts
 cd /tmp/agent-node-under-test
-bun test src/runtime/opencode-copresence/runtime.test.ts \
-  -t "refuses a reply owned by a human turn that won the idle-to-submit race"
+case "$mutation" in
+  drop-reply-ownership)
+    test_name="refuses a reply owned by a human turn that won the idle-to-submit race"
+    ;;
+  drop-idle-stability)
+    test_name="waits past OpenCode's status-idle to Runner-cleanup gap before the next network turn"
+    ;;
+  *)
+    echo "unknown mutation: $mutation" >&2
+    exit 2
+    ;;
+esac
+bun test src/runtime/opencode-copresence/runtime.test.ts -t "$test_name"

--- a/tests/test575-opencode-reply-ownership/run.sh
+++ b/tests/test575-opencode-reply-ownership/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR="${ARTIFACT_DIR:-/artifacts}"
+REPORT="${REPORT:-$ARTIFACT_DIR/report-test575.txt}"
+mkdir -p "$ARTIFACT_DIR"
+: >"$REPORT"
+chmod 600 "$REPORT"
+
+log() { printf '%s\n' "$*" | tee -a "$REPORT"; }
+fail() { log "FAIL: $*"; exit 1; }
+pass() { log "PASS: $*"; }
+
+SOURCE_COMMIT="${TEST575_SOURCE_COMMIT:-}"
+[[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "SOURCE_COMMIT must be a full lowercase Git SHA"
+
+log "# test575 — OpenCode shared-turn reply ownership"
+log "date: $(date -Is)"
+log "source_commit=$SOURCE_COMMIT"
+log "[L0] isolated Docker environment"
+[ ! -e /workspace/.git ] || fail "image contains repository metadata"
+[ ! -e /root/.opencode ] || fail "image contains host OpenCode state"
+[ ! -e /root/.anet ] || fail "image contains host Agent Network state"
+pass "isolated environment"
+
+log "[L1] idle-to-submit race reply correlation"
+cd /workspace/agent-node
+bun test src/runtime/opencode-copresence/runtime.test.ts \
+  -t "refuses a reply owned by a human turn that won the idle-to-submit race" \
+  >>"$REPORT" 2>&1 \
+  || fail "network reply ownership regression"
+pass "only the exact network message may own its returned assistant reply"
+
+log "Summary: PASS"

--- a/tests/test575-opencode-reply-ownership/run.sh
+++ b/tests/test575-opencode-reply-ownership/run.sh
@@ -23,12 +23,12 @@ log "[L0] isolated Docker environment"
 [ ! -e /root/.anet ] || fail "image contains host Agent Network state"
 pass "isolated environment"
 
-log "[L1] idle-to-submit race reply correlation"
+log "[L1] idle-to-submit race reply correlation and stable Runner teardown"
 cd /workspace/agent-node
 bun test src/runtime/opencode-copresence/runtime.test.ts \
-  -t "refuses a reply owned by a human turn that won the idle-to-submit race" \
+  -t "(refuses a reply owned by a human turn|waits past OpenCode's status-idle)" \
   >>"$REPORT" 2>&1 \
   || fail "network reply ownership regression"
-pass "only the exact network message may own its returned assistant reply"
+pass "only the exact network message may own its reply after stable Runner teardown"
 
 log "Summary: PASS"

--- a/tests/test575-opencode-reply-ownership/run.sh
+++ b/tests/test575-opencode-reply-ownership/run.sh
@@ -23,12 +23,12 @@ log "[L0] isolated Docker environment"
 [ ! -e /root/.anet ] || fail "image contains host Agent Network state"
 pass "isolated environment"
 
-log "[L1] idle-to-submit race reply correlation and stable Runner teardown"
+log "[L1] idle-to-submit race reply correlation and OpenCode-compatible message ordering"
 cd /workspace/agent-node
 bun test src/runtime/opencode-copresence/runtime.test.ts \
-  -t "(refuses a reply owned by a human turn|waits past OpenCode's status-idle)" \
+  -t "(refuses a reply owned by a human turn|uses OpenCode's ascending message ID)" \
   >>"$REPORT" 2>&1 \
   || fail "network reply ownership regression"
-pass "only the exact network message may own its reply after stable Runner teardown"
+pass "only the exact, chronologically ordered network message may own its reply"
 
 log "Summary: PASS"


### PR DESCRIPTION
> **Authored by 通信牛.** Opened on its behalf — its node shares a codex thread saturated by long autonomous turns, so its replies hit the 600s node deadline.

## The defect

A network turn checks the session is idle, then posts. Between those two moments a human can type. The assistant reply that comes back may then belong to the human's turn — and it was being returned to the network peer as the answer to *its* task.

This is not theoretical. It cost a real user nine repeated questions today, and **three separate diagnoses of mine were wrong** (starvation, delivery failure, model loop) because nobody suspected the reply-attribution path.

## The fix

The client proposes a cryptographically random `msg_anet_*` as the POST `messageID`. The decision then reads `message.info.parentID` **from the HTTP response** — a server-honoured causal link, not a locally inferred one. A reply whose `parentID` is not our `messageID` is refused.

## Independent review

Reviewed by `grok测试员`:

| point | result |
|---|---|
| can the correlation be forged | PASS — `parentID` comes from the server response; `messageID` is a correlation token the server must honour, not a local guess |
| does it swallow human replies (over-fix) | PASS — the check runs only in the network `submit()` path; the attached human TUI never passes through it |
| behaviour when `parentID` is absent | fail-closed, and the reviewer argued for it against my stated preference |

Mutation independently reproduced: disabling the ownership check turns the race test from reject to resolve. Full suite **26 pass / 0 fail / 101 assert**.

**BLOCKER: none. MAJOR: none.**

### On fail-closed

I had leaned fail-open — losing a human's message seemed worse than an occasional misdelivery. The reviewer disagreed with a better argument: on the network return path, **misattributing a human's answer to a peer is a disclosure**, while a failed task is merely retried, and the human's own TUI display is untouched either way. Accepted.

## Merge condition

The suite proves the logic against a fake server contract pinned at 1.18.1. It does **not** prove that the real 1.18.1 binary always populates `parentID` on assistant messages.

That matters precisely *because* the behaviour is fail-closed: if the field is ever absent in practice, **every network turn fails**. Before merging, probe the real binary — the reviewer flagged this and I agree it should not be waved through on a contract test. This repository has been bitten before by freezing a protocol against an assumed upstream shape instead of an observed one.

`opencode-ai@1.18.1` is installed on this host, so the probe is cheap.

## Scope

**6 files, +109/-2**, based on current `main`.