### PR TITLE
fix(hub): make Dashboard chat sends idempotent

### DIFF
--- a/docs/tests/report-test583-dashboard-chat-idempotency.txt
+++ b/docs/tests/report-test583-dashboard-chat-idempotency.txt
@@ -1,0 +1,29 @@
+Test 583 — Dashboard chat idempotency
+Date: 2026-08-03 (Asia/Shanghai)
+Base: origin/main 9c5082162284cc24850509cab58ff88a91ebfca9
+Scope: MCP send_task only; existing callers without meta.client_request_id are unchanged.
+
+Contract
+- A valid dashboard client_request_id is scoped by authenticated network and sender.
+- An exact replay returns the original task/message id and current task status.
+- Reusing the id with a different target, content, priority, or metadata fails closed
+  with idempotency_conflict.
+- The identifier is bounded and is not a credential.
+
+Docker commands
+  sg docker -c 'docker build -t anet-chat-ha-core:dev -f tests/test583-dashboard-chat-idempotency/Dockerfile .'
+  sg docker -c 'docker run --rm anet-chat-ha-core:dev'
+
+Results
+- Focused idempotency suite: 6 pass, 0 fail.
+- Full server suite in the same Docker dependency image: 786 pass, 10 skip,
+  0 fail, 2264 assertions.
+- Witnessed-red mutation: replacing the stable derived task id with a random id
+  caused replay, conflict, and determinism assertions to fail (exit 1). Restoring
+  production code returned the suite to green.
+
+Compatibility / exclusions
+- No schema migration.
+- No change to REST /api/task behavior.
+- Old atok_ and callers that omit client_request_id retain existing behavior.
+- No production database, token, process, package, or deployment was changed.

--- a/server/src/task-idempotency-mcp.test.ts
+++ b/server/src/task-idempotency-mcp.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db } from "./db.js";
+import { registerTools } from "./tools.js";
+import { sharedSendDedup } from "./send_dedup.js";
+
+const NET = "net_chat_idem";
+const USER = "user_chat_idem";
+const TARGET = "node_chat_idem";
+
+type ToolHandler = (args: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+
+function cleanup() {
+  for (const table of ["tasks", "inbox", "task_events"]) {
+    try { db.run(`DELETE FROM ${table} WHERE network_id = ?1`, [NET]); } catch {}
+  }
+  try { db.run("DELETE FROM sessions WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM nodes WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [USER]); } catch {}
+  sharedSendDedup.clear();
+}
+
+function seed() {
+  db.run("INSERT INTO users (user_id, username, password_hash, role, created_at) VALUES (?1, ?1, 'x', 'user', datetime('now'))", [USER]);
+  db.run("INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))", [NET, USER]);
+  db.run("INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))", [USER, NET]);
+  db.run("INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state) VALUES (?1, ?2, ?2, ?3, 'host', datetime('now'), datetime('now'), 'active')", [`id_${TARGET}`, TARGET, NET]);
+  db.run("INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at) VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))", [`resume_${TARGET}`, TARGET, `id_${TARGET}`, NET]);
+}
+
+function sendTaskHandler(): ToolHandler {
+  const server = new McpServer({ name: "idempotency-test", version: "0" }) as any;
+  let handler: ToolHandler | undefined;
+  const original = server.tool.bind(server);
+  server.tool = (name: string, description: string, schema: any, candidate: ToolHandler) => {
+    if (name === "send_task") handler = candidate;
+    return original(name, description, schema, candidate);
+  };
+  registerTools(server, undefined, NET, USER, USER, false, null);
+  if (!handler) throw new Error("send_task handler missing");
+  return handler;
+}
+
+async function call(handler: ToolHandler, args: any) {
+  const result = await handler(args);
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => { cleanup(); seed(); });
+afterAll(cleanup);
+
+describe("send_task durable idempotency", () => {
+  test("lost-response retry returns the original task and does not enqueue twice", async () => {
+    const handler = sendTaskHandler();
+    const args = {
+      alias: TARGET,
+      task: "chat idempotent payload",
+      priority: "normal",
+      meta: { client_request_id: "dreq_0123456789abcdef" },
+    };
+    const first = await call(handler, args);
+    const replay = await call(handler, args);
+
+    expect(first.ok).toBe(true);
+    expect(replay).toEqual({
+      ok: true,
+      message_id: first.message_id,
+      task_id: first.message_id,
+      task_status: "delivered",
+      idempotent_replay: true,
+    });
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE network_id = ?1", [NET])?.count).toBe(1);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM inbox WHERE network_id = ?1", [NET])?.count).toBe(1);
+  });
+
+  test("request-id reuse with changed content fails closed without a second row", async () => {
+    const handler = sendTaskHandler();
+    const base = {
+      alias: TARGET,
+      priority: "normal",
+      meta: { client_request_id: "dreq_0123456789abcdef" },
+    };
+    expect((await call(handler, { ...base, task: "first payload" })).ok).toBe(true);
+    expect(await call(handler, { ...base, task: "changed payload" })).toEqual({
+      ok: false,
+      error: "idempotency_conflict",
+      message: "client_request_id was already used with a different task payload",
+    });
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE network_id = ?1", [NET])?.count).toBe(1);
+  });
+});

--- a/server/src/task-idempotency.test.ts
+++ b/server/src/task-idempotency.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clientRequestIdFromMeta,
+  idempotentTaskId,
+  idempotentTaskMatches,
+  type StoredIdempotentTask,
+} from "./task-idempotency.js";
+
+describe("dashboard task idempotency", () => {
+  test("accepts only bounded dashboard request ids", () => {
+    expect(clientRequestIdFromMeta({ client_request_id: "dreq_0123456789abcdef" })).toBe("dreq_0123456789abcdef");
+    expect(clientRequestIdFromMeta({ client_request_id: "short" })).toBeNull();
+    expect(clientRequestIdFromMeta({ client_request_id: "dreq_bad space 0123456789" })).toBeNull();
+    expect(clientRequestIdFromMeta(null)).toBeNull();
+  });
+
+  test("same caller scope and request id derive the same task id", () => {
+    const a = idempotentTaskId("net_a", "admin", "dreq_0123456789abcdef");
+    expect(idempotentTaskId("net_a", "admin", "dreq_0123456789abcdef")).toBe(a);
+    expect(idempotentTaskId("net_b", "admin", "dreq_0123456789abcdef")).not.toBe(a);
+    expect(idempotentTaskId("net_a", "other", "dreq_0123456789abcdef")).not.toBe(a);
+    expect(a).toMatch(/^idem_[0-9a-f]{40}$/);
+  });
+
+  test("replay accepts semantically identical metadata regardless of key order", () => {
+    const row: StoredIdempotentTask = {
+      task_id: "idem_x", from_name: "admin", to_name: "worker", priority: "normal",
+      content: "hello", network_id: "net_a", status: "delivered",
+      meta_json: JSON.stringify({ client_request_id: "dreq_0123456789abcdef", attachments: [{ name: "a", file_id: "f1" }] }),
+    };
+    expect(idempotentTaskMatches(row, {
+      fromName: "admin", toName: "worker", priority: "normal", content: "hello", networkId: "net_a",
+      metaJson: JSON.stringify({ attachments: [{ file_id: "f1", name: "a" }], client_request_id: "dreq_0123456789abcdef" }),
+    })).toBe(true);
+  });
+
+  test("same request id with changed payload is a conflict", () => {
+    const row: StoredIdempotentTask = {
+      task_id: "idem_x", from_name: "admin", to_name: "worker", priority: "normal",
+      content: "hello", network_id: "net_a", status: "delivered",
+      meta_json: JSON.stringify({ client_request_id: "dreq_0123456789abcdef" }),
+    };
+    expect(idempotentTaskMatches(row, {
+      fromName: "admin", toName: "worker", priority: "normal", content: "changed", networkId: "net_a",
+      metaJson: row.meta_json,
+    })).toBe(false);
+  });
+});

--- a/server/src/task-idempotency.ts
+++ b/server/src/task-idempotency.ts
@@ -1,0 +1,65 @@
+import { createHash } from "crypto";
+
+const CLIENT_REQUEST_ID_RE = /^dreq_[A-Za-z0-9_-]{16,96}$/;
+
+export interface StoredIdempotentTask {
+  task_id: string;
+  from_name: string;
+  to_name: string;
+  priority: string;
+  content: string;
+  network_id: string | null;
+  meta_json: string | null;
+  status: string;
+}
+
+export interface ExpectedIdempotentTask {
+  fromName: string;
+  toName: string;
+  priority: string;
+  content: string;
+  networkId: string | null;
+  metaJson: string | null;
+}
+
+export function clientRequestIdFromMeta(meta: unknown): string | null {
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return null;
+  const value = (meta as Record<string, unknown>).client_request_id;
+  return typeof value === "string" && CLIENT_REQUEST_ID_RE.test(value) ? value : null;
+}
+
+export function idempotentTaskId(networkId: string | null, fromName: string, requestId: string): string {
+  const digest = createHash("sha256")
+    .update(networkId ?? "<legacy-global>")
+    .update("\0")
+    .update(fromName)
+    .update("\0")
+    .update(requestId)
+    .digest("hex");
+  return `idem_${digest.slice(0, 40)}`;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${canonicalJson(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function parsedMeta(value: string | null): unknown {
+  if (!value) return null;
+  try { return JSON.parse(value); } catch { return value; }
+}
+
+export function idempotentTaskMatches(row: StoredIdempotentTask, expected: ExpectedIdempotentTask): boolean {
+  return row.from_name === expected.fromName
+    && row.to_name === expected.toName
+    && row.priority === expected.priority
+    && row.content === expected.content
+    && (row.network_id ?? null) === (expected.networkId ?? null)
+    && canonicalJson(parsedMeta(row.meta_json)) === canonicalJson(parsedMeta(expected.metaJson));
+}

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -55,6 +55,7 @@ import {
   isAllowedToChangeFlag,
 } from "./config-apply-validate.js";
 import { sharedSendDedup, buildDuplicateSendPayload } from "./send_dedup.js";
+import { clientRequestIdFromMeta, idempotentTaskId, idempotentTaskMatches, type StoredIdempotentTask } from "./task-idempotency.js";
 
 function ts(): string {
   return new Date().toTimeString().slice(0, 8);
@@ -913,6 +914,37 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const target = resolveDeliveryTarget(targetAlias, effectiveNetId);
       if (target.state === "not_found") return deliveryTargetReply(target)!;
 
+      // Dashboard sends carry a random client_request_id inside meta. Derive
+      // the task primary key from authenticated scope + that request id so a
+      // lost HTTP response can be retried safely, even after a hub restart.
+      // The existing row must match the full request; key reuse with changed
+      // content/target fails closed instead of silently returning another task.
+      const clientRequestId = clientRequestIdFromMeta(meta);
+      const id = clientRequestId
+        ? idempotentTaskId(effectiveNetId ?? null, from_session, clientRequestId)
+        : uuidv4();
+      if (clientRequestId) {
+        const existing = db.get<StoredIdempotentTask>(
+          "SELECT task_id, from_name, to_name, priority, content, network_id, meta_json, status FROM tasks WHERE task_id = ?1",
+          [id],
+        );
+        if (existing) {
+          if (!idempotentTaskMatches(existing, {
+            fromName: from_session, toName: targetAlias, priority, content: task,
+            networkId: effectiveNetId ?? null, metaJson,
+          })) {
+            return { content: [{ type: "text" as const, text: JSON.stringify({
+              ok: false, error: "idempotency_conflict",
+              message: "client_request_id was already used with a different task payload",
+            }) }] };
+          }
+          return { content: [{ type: "text" as const, text: JSON.stringify({
+            ok: true, message_id: existing.task_id, task_id: existing.task_id,
+            task_status: existing.status, idempotent_replay: true,
+          }) }] };
+        }
+      }
+
       // #212 dedup guardrail. If this exact (from, to, content) has already
       // been delivered within COMMHUB_SEND_DEDUP_WINDOW_MS (default 5 min)
       // we refuse the call and surface a structured `duplicate_send`
@@ -940,7 +972,6 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }
 
       console.log(`[${ts()}] ${from_session} → send_task → ${targetAlias}: ${task.slice(0, 60)}${priority === "high" ? " [HIGH]" : ""}${canonical.renamed ? ` [renamed from ${alias}]` : ""}`);
-      const id = uuidv4();
       const fromNodeId = resolveNodeIdForAlias(from_session, effectiveNetId);
       const targetNodeId = target.session?.node_id ?? null;
       // 事务：inbox + tasks 双写 + 触碰目标 session 的 task/updated_at（让

--- a/tests/test583-dashboard-chat-idempotency/Dockerfile
+++ b/tests/test583-dashboard-chat-idempotency/Dockerfile
@@ -1,0 +1,9 @@
+FROM oven/bun:1
+WORKDIR /work/server
+COPY server/package.json ./package.json
+RUN bun install
+COPY server/src ./src
+COPY agent-node/src/shared /work/agent-node/src/shared
+COPY tests/test583-dashboard-chat-idempotency/run.sh /work/run.sh
+RUN chmod +x /work/run.sh
+CMD ["/work/run.sh"]

--- a/tests/test583-dashboard-chat-idempotency/run.sh
+++ b/tests/test583-dashboard-chat-idempotency/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+export COMMHUB_DB=/tmp/test583-chat-idempotency.db
+rm -f "$COMMHUB_DB" "$COMMHUB_DB-wal" "$COMMHUB_DB-shm"
+bun test src/task-idempotency.test.ts src/task-idempotency-mcp.test.ts


### PR DESCRIPTION
## What changed

- Accept an optional bounded `meta.client_request_id` on MCP `send_task`.
- Derive a durable task ID from authenticated network, authenticated sender, and request ID.
- Return the existing task on an exact replay after a lost response.
- Fail closed with `idempotency_conflict` if the same key is reused with a changed payload.

## Why

Dashboard retries after an ambiguous transport failure previously risked creating a duplicate task. The Hub now provides the durable idempotency boundary required by the matching Dashboard recovery flow.

## Compatibility

- No schema migration.
- `/api/task` is unchanged.
- Callers that omit `client_request_id`, including old `atok_` clients, retain the UUID path.
- No historical data cleanup or deployment is included.

## Validation

- Docker focused suite: 6 passed, 0 failed.
- Author-run full Hub suite: 786 passed, 10 skipped, 0 failed, 2264 assertions.
- Witnessed-red mutation replacing the stable ID with a random ID breaks replay, conflict, and determinism tests.
- Independent review source-audited the behavior; the shared-host disk limit prevented an independent full-suite rebuild.

Companion Dashboard Draft PR carries the UI retry, outbox, timeout, and privacy lifecycle changes.
