### PR TITLE
fix(codex-app-server): deliver Dashboard chat into the active human turn

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -95,6 +95,7 @@ import {
 } from "./runtime/opencode-acp/profile-state";
 import { OPENCODE_DEFAULT_PIN } from "./runtime/opencode-acp/binary";
 import { createInboxDrainLane, drainInboxBatch } from "./runtime/inbox-drain-lane";
+import { dispatchInboxBatch, isInteractiveDashboardTask } from "./inbox-dispatch";
 import { createSingleFlight } from "./util/single-flight";
 
 const home = homedir();
@@ -2890,7 +2891,12 @@ async function closeOpencodeRuntime(reason: string): Promise<void> {
 // exactly like every other runtime — the bridge only wraps "run one turn".
 // A second concurrent task queues FIFO inside the bridge and is drained when
 // the in-flight turn (ours OR a human TUI's) completes.
-async function processWithCodexAppServer(task: string, _from: string, taskId: string | null): Promise<string> {
+async function processWithCodexAppServer(
+  task: string,
+  _from: string,
+  taskId: string | null,
+  steerIfExternalTurn = false,
+): Promise<string> {
   const { openCodexAppServerRuntime, codexAppServerThink } =
     await import("./runtime/codex-app-server/runtime");
 
@@ -2936,6 +2942,7 @@ async function processWithCodexAppServer(task: string, _from: string, taskId: st
     taskId: taskId || `local-${Date.now()}`,
     text: task,
     from: _from,
+    steerIfExternalTurn,
     log,
   });
 
@@ -3297,7 +3304,13 @@ let thinkQueue = Promise.resolve();
 // OLD thinkQueue ref, and the new task is killed by exit(75) mid-flight.
 let configApplyDraining = false;
 
-function think(task: string, from: string, taskId: string | null, images?: string[]): Promise<string> {
+function think(
+  task: string,
+  from: string,
+  taskId: string | null,
+  images?: string[],
+  steerIfExternalTurn = false,
+): Promise<string> {
   if (configApplyDraining) {
     // Don't accept new work during a restart drain. The error string
     // is intentionally explicit so the upstream caller (inbox handler,
@@ -3336,7 +3349,7 @@ function think(task: string, from: string, taskId: string | null, images?: strin
         return await processWithOpencode(task, from, images);
       }
       if (RUNTIME === "codex-app-server") {
-        return await processWithCodexAppServer(task, from, taskId);
+        return await processWithCodexAppServer(task, from, taskId, steerIfExternalTurn);
       }
       return await processWithClaude(task, from, images);
     } finally {
@@ -3344,6 +3357,18 @@ function think(task: string, from: string, taskId: string | null, images?: strin
       decrementInFlight();
     }
   };
+  // The app-server bridge is the concurrency authority for its one shared
+  // thread. Serializing here would prevent inbox rows 2..N from reaching
+  // turn/steer until row 1's human turn completed — the production HOL bug.
+  // Do not mutate CURRENT_TASK_ID concurrently: the adopted app-server has
+  // its own process environment and task identity is carried in the prompt.
+  if (RUNTIME === "codex-app-server") {
+    incrementInFlight();
+    return processWithCodexAppServer(task, from, taskId, steerIfExternalTurn)
+      .finally(() => {
+        decrementInFlight();
+      });
+  }
   const next = thinkQueue.then(run, run);
   thinkQueue = next.then(() => {}, () => {});
   return next;
@@ -3394,7 +3419,13 @@ async function extractImagePaths(msg: any): Promise<string[]> {
   return resolved;
 }
 
-async function processTask(task: string, from: string, taskId: string | null = null, images?: string[]): Promise<{ text: string; failed: boolean }> {
+async function processTask(
+  task: string,
+  from: string,
+  taskId: string | null = null,
+  images?: string[],
+  steerIfExternalTurn = false,
+): Promise<{ text: string; failed: boolean }> {
   log(`→ processing [${RUNTIME}]${images?.length ? ` +${images.length} image(s)` : ""}: ${task.slice(0, 80)}`);
   await reportStatus("working", task.slice(0, 200)).catch(() => {});
 
@@ -3420,7 +3451,7 @@ async function processTask(task: string, from: string, taskId: string | null = n
   let failed = false;
   try {
     text = await tryHandleExplicitDelegation(augmentedTask, from, taskId)
-      || await think(augmentedTask, from, taskId, images);
+      || await think(augmentedTask, from, taskId, images, steerIfExternalTurn);
   } catch (err: any) {
     text = `${RUNTIME} 错误: ${err.message}`;
     failed = true;
@@ -3466,7 +3497,7 @@ async function processTask(task: string, from: string, taskId: string | null = n
     );
     await new Promise((r) => setTimeout(r, backoff));
     try {
-      const retried = await think(augmentedTask, from, taskId, images);
+      const retried = await think(augmentedTask, from, taskId, images, steerIfExternalTurn);
       text = retried;
       failed = false;
       // Re-apply the API-error detection on the retry result (consistency
@@ -3579,17 +3610,17 @@ async function processInbox() {
 
   const messages = await getInbox();
   if (!messages.length) return;
-  for (const msg of messages) {
+  const processInboxMessage = async (msg: any) => {
     // OpenCode copresence informational messages belong to their own fast
     // lane. Leaving them in the task drain would make a message wait behind
     // an arbitrarily long model turn from an earlier inbox row.
     if ((msg.type || "task") === "message" && RUNTIME === "opencode" && opencodeMode === "copresence") {
-      continue;
+      return;
     }
     // (3a) Inflight guard.
     if (inflightMessageIds.has(msg.id)) {
       debug(`skip inflight message ${msg.id.slice(0, 8)}`);
-      continue;
+      return;
     }
     inflightMessageIds.add(msg.id);
     try {
@@ -3609,14 +3640,14 @@ async function processInbox() {
         // human TUI is a product decision, deliberately not made here.
         log(`← [${from}] (message, not delivered to model) ${content.slice(0, 120)}`);
         await ackMessage(msg.id).catch((e: any) => warn(`ack failed for non-task ${msg.id.slice(0, 8)}: ${e.message}`));
-        continue;
+        return;
       }
 
       const skip = shouldSkipMessage(from, content, msgType);
       if (skip) {
         debug(`skip message from ${from}: ${skip}`);
         await ackMessage(msg.id).catch((e: any) => warn(`ack failed for skipped ${msg.id.slice(0, 8)}: ${e.message}`));
-        continue;
+        return;
       }
 
       // #144 round-6: anet /loop is universal — all recognized runtimes
@@ -3638,11 +3669,17 @@ async function processInbox() {
         }
         await deliverReplyReliably(from, replyText, msg.id, goalFailed);
         await ackMessage(msg.id).catch((e: any) => warn(`ack failed for goal ${msg.id.slice(0, 8)}: ${e.message}`));
-        continue;
+        return;
       }
 
       // (3b) Run the LLM turn.
-      const { text: result, failed } = await processTask(content, from, msg.id, images);
+      const { text: result, failed } = await processTask(
+        content,
+        from,
+        msg.id,
+        images,
+        isInteractiveDashboardTask(msg),
+      );
       log(`processTask returned: "${result.slice(0, 80)}" (${result.length} chars, failed=${failed})`);
 
       // Low-value successful replies are dropped (preserve previous
@@ -3652,7 +3689,7 @@ async function processInbox() {
       if (!failed && isLowValueText(result, true)) {
         log(`skip reply: low-value (${result.slice(0, 30)})`);
         await ackMessage(msg.id).catch((e: any) => warn(`ack failed for low-value ${msg.id.slice(0, 8)}: ${e.message}`));
-        continue;
+        return;
       }
 
       // (3c-e) Persist + ack + try send.
@@ -3662,7 +3699,15 @@ async function processInbox() {
     } finally {
       inflightMessageIds.delete(msg.id);
     }
-  }
+  };
+
+  // Every Codex app-server row must reach bridge arbitration immediately.
+  // Other runtimes retain the historical serialized drain.
+  await dispatchInboxBatch(
+    messages,
+    processInboxMessage,
+    RUNTIME === "codex-app-server",
+  );
 }
 
 /**

--- a/agent-node/src/inbox-dispatch.test.ts
+++ b/agent-node/src/inbox-dispatch.test.ts
@@ -16,9 +16,9 @@ describe("isInteractiveDashboardTask", () => {
     })).toBe(true);
   });
 
-  test("accepts only the narrow legacy admin row during rolling upgrade", () => {
+  test("pre-stamp admin rows stay FIFO because aliases are not auth facts", () => {
     const meta_json = JSON.stringify({ source: "dashboard-chat", client_request_id: requestId });
-    expect(isInteractiveDashboardTask({ type: "task", from_session: "admin", meta_json })).toBe(true);
+    expect(isInteractiveDashboardTask({ type: "task", from_session: "admin", meta_json })).toBe(false);
     expect(isInteractiveDashboardTask({ type: "task", from_session: "some-node", meta_json })).toBe(false);
   });
 

--- a/agent-node/src/inbox-dispatch.test.ts
+++ b/agent-node/src/inbox-dispatch.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { dispatchInboxBatch, isInteractiveDashboardTask } from "./inbox-dispatch";
+
+const requestId = "dreq_0123456789abcdef0123456789abcdef";
+
+describe("isInteractiveDashboardTask", () => {
+  test("accepts a Hub-authenticated dashboard chat task", () => {
+    expect(isInteractiveDashboardTask({
+      type: "task",
+      from_session: "vincent",
+      meta_json: JSON.stringify({
+        source: "dashboard-chat",
+        client_request_id: requestId,
+        auth_origin: "user",
+      }),
+    })).toBe(true);
+  });
+
+  test("accepts only the narrow legacy admin row during rolling upgrade", () => {
+    const meta_json = JSON.stringify({ source: "dashboard-chat", client_request_id: requestId });
+    expect(isInteractiveDashboardTask({ type: "task", from_session: "admin", meta_json })).toBe(true);
+    expect(isInteractiveDashboardTask({ type: "task", from_session: "some-node", meta_json })).toBe(false);
+  });
+
+  test("rejects node-authenticated spoofing, malformed ids, and plain messages", () => {
+    expect(isInteractiveDashboardTask({
+      type: "task",
+      from_session: "agent",
+      meta: { source: "dashboard-chat", client_request_id: requestId, auth_origin: "node" },
+    })).toBe(false);
+    expect(isInteractiveDashboardTask({
+      type: "task",
+      from_session: "admin",
+      meta: { source: "dashboard-chat", client_request_id: "dreq_bad" },
+    })).toBe(false);
+    expect(isInteractiveDashboardTask({
+      type: "message",
+      from_session: "admin",
+      meta: { source: "dashboard-chat", client_request_id: requestId, auth_origin: "user" },
+    })).toBe(false);
+  });
+});
+
+describe("dispatchInboxBatch", () => {
+  test("concurrent mode submits later dashboard rows before the first turn completes", async () => {
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const entered: number[] = [];
+    const running = dispatchInboxBatch([1, 2, 3], async (value) => {
+      entered.push(value);
+      if (value === 1) await firstBlocked;
+    }, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(entered).toEqual([1, 2, 3]);
+    releaseFirst();
+    await running;
+  });
+
+  test("sequential mode preserves legacy runtime serialization", async () => {
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const entered: number[] = [];
+    const running = dispatchInboxBatch([1, 2], async (value) => {
+      entered.push(value);
+      if (value === 1) await firstBlocked;
+    }, false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(entered).toEqual([1]);
+    releaseFirst();
+    await running;
+    expect(entered).toEqual([1, 2]);
+  });
+});

--- a/agent-node/src/inbox-dispatch.ts
+++ b/agent-node/src/inbox-dispatch.ts
@@ -23,8 +23,8 @@ export function parseInboxDispatchMeta(message: InboxDispatchMessage): Record<st
 /**
  * Only authenticated Dashboard chat tasks may steer a human-owned Codex turn.
  * `auth_origin` is stamped by the Hub from token facts, not trusted client
- * input. The narrow legacy-admin fallback lets already-enqueued production
- * rows drain during the rolling Hub/agent-node upgrade.
+ * input. Pre-stamp rows deliberately remain ordinary FIFO tasks: an alias in
+ * old Hub data is not an authentication fact and must not unlock steering.
  */
 export function isInteractiveDashboardTask(message: InboxDispatchMessage): boolean {
   const type = message.type ?? "task";
@@ -34,8 +34,7 @@ export function isInteractiveDashboardTask(message: InboxDispatchMessage): boole
   if (typeof meta.client_request_id !== "string" || !/^dreq_[a-f0-9]{32}$/.test(meta.client_request_id)) {
     return false;
   }
-  if (meta.auth_origin === "user") return true;
-  return meta.auth_origin === undefined && message.from_session === "admin";
+  return meta.auth_origin === "user";
 }
 
 /**

--- a/agent-node/src/inbox-dispatch.ts
+++ b/agent-node/src/inbox-dispatch.ts
@@ -1,0 +1,56 @@
+export interface InboxDispatchMessage {
+  type?: string;
+  from_session?: string;
+  meta?: unknown;
+  meta_json?: string | null;
+}
+
+export function parseInboxDispatchMeta(message: InboxDispatchMessage): Record<string, unknown> | null {
+  if (message.meta && typeof message.meta === "object" && !Array.isArray(message.meta)) {
+    return message.meta as Record<string, unknown>;
+  }
+  if (typeof message.meta_json !== "string" || message.meta_json.length === 0) return null;
+  try {
+    const parsed = JSON.parse(message.meta_json);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Only authenticated Dashboard chat tasks may steer a human-owned Codex turn.
+ * `auth_origin` is stamped by the Hub from token facts, not trusted client
+ * input. The narrow legacy-admin fallback lets already-enqueued production
+ * rows drain during the rolling Hub/agent-node upgrade.
+ */
+export function isInteractiveDashboardTask(message: InboxDispatchMessage): boolean {
+  const type = message.type ?? "task";
+  if (type !== "task" && type !== "broadcast") return false;
+  const meta = parseInboxDispatchMeta(message);
+  if (!meta || meta.source !== "dashboard-chat") return false;
+  if (typeof meta.client_request_id !== "string" || !/^dreq_[a-f0-9]{32}$/.test(meta.client_request_id)) {
+    return false;
+  }
+  if (meta.auth_origin === "user") return true;
+  return meta.auth_origin === undefined && message.from_session === "admin";
+}
+
+/**
+ * Codex app-server owns its own FIFO/steer arbitration, so inbox entries must
+ * be submitted concurrently. Sequentially awaiting entry 1 recreates the
+ * production head-of-line bug: entries 2..N cannot steer the same human turn.
+ */
+export async function dispatchInboxBatch<T>(
+  messages: readonly T[],
+  handler: (message: T) => Promise<void>,
+  concurrent: boolean,
+): Promise<void> {
+  if (concurrent) {
+    await Promise.all(messages.map((message) => handler(message)));
+    return;
+  }
+  for (const message of messages) await handler(message);
+}

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -479,6 +479,168 @@ function tick(ms = 5): Promise<void> {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Dashboard → active human TUI turn steering.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("CodexAppServerBridge — authenticated Dashboard steering", () => {
+  test("uses exact turn/steer contract and maps the human turn final answer", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/steer") {
+          const expected = (msg.params as { expectedTurnId?: string })?.expectedTurnId;
+          return respond({ result: { turnId: expected } });
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    app.broadcast({ jsonrpc: "2.0", method: "turn/started", params: { threadId: THREAD, turn: { id: "human-1", status: "inProgress" } } });
+    await tick(10);
+
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (event) => replies.push(event as never));
+    const submitted = await bridge.submitTask({
+      taskId: "dash-1",
+      text: "第二条消息",
+      from: "admin",
+      steerIfExternalTurn: true,
+    });
+    expect(submitted).toEqual({ started: true, turnId: "human-1", steered: true });
+    const steer = app.received.find((entry) => (entry as { method?: string }).method === "turn/steer") as any;
+    expect(steer.params).toEqual({
+      threadId: THREAD,
+      expectedTurnId: "human-1",
+      input: [{ type: "text", text: "[Agent Network/from=admin/task=dash-1] 第二条消息" }],
+    });
+    expect(app.received.filter((entry) => (entry as any).method === "turn/start")).toHaveLength(0);
+
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "human-1", item: { type: "agentMessage", phase: "final_answer", text: "收到并处理" } } });
+    app.broadcast({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: THREAD, turn: { id: "human-1", status: "completed" } } });
+    await tick(10);
+    expect(replies).toEqual([{ taskId: "dash-1", text: "收到并处理" }]);
+    await client.close();
+    await app.stop();
+  });
+
+  test("multiple Dashboard rows steer one human turn while ordinary agent work stays queued", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/steer") return respond({ result: { turnId: (msg.params as any).expectedTurnId } });
+        if (msg.method === "turn/start") return respond({ result: { turnId: "agent-after-human" } });
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    app.broadcast({ jsonrpc: "2.0", method: "turn/started", params: { threadId: THREAD, turn: { id: "human-many" } } });
+    await tick(10);
+
+    await Promise.all([
+      bridge.submitTask({ taskId: "dash-a", text: "A", steerIfExternalTurn: true }),
+      bridge.submitTask({ taskId: "dash-b", text: "B", steerIfExternalTurn: true }),
+      bridge.submitTask({ taskId: "node-c", text: "C", from: "node" }),
+    ]);
+    expect(app.received.filter((entry) => (entry as any).method === "turn/steer")).toHaveLength(2);
+    expect(bridge.queueDepth()).toBe(1);
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (event) => replies.push(event as never));
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "human-many", item: { type: "agentMessage", phase: "final_answer", text: "shared" } } });
+    app.broadcast({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: THREAD, turn: { id: "human-many", status: "completed" } } });
+    await tick(20);
+    expect(replies).toEqual([
+      { taskId: "dash-a", text: "shared" },
+      { taskId: "dash-b", text: "shared" },
+    ]);
+    expect(app.received.filter((entry) => (entry as any).method === "turn/start")).toHaveLength(1);
+    await client.close();
+    await app.stop();
+  });
+
+  test("steer mismatch fails closed and preserves the task in the normal FIFO", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/steer") return respond({ result: { turnId: "wrong-turn" } });
+        if (msg.method === "turn/start") return respond({ result: { turnId: "recovered-turn" } });
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    app.broadcast({ jsonrpc: "2.0", method: "turn/started", params: { threadId: THREAD, turn: { id: "human-race" } } });
+    await tick(10);
+    const result = await bridge.submitTask({ taskId: "dash-race", text: "keep me", steerIfExternalTurn: true });
+    expect(result.started).toBe(false);
+    await tick(20);
+    expect(app.received.filter((entry) => (entry as any).method === "turn/start")).toHaveLength(1);
+    expect(bridge.pendingTurnCount()).toBe(1);
+    await client.close();
+    await app.stop();
+  });
+
+  test("turn completion cannot attribute a task before turn/steer acceptance", async () => {
+    let answerSteer!: () => void;
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/steer") answerSteer = () => respond({ result: { turnId: "human-accept-race" } });
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    app.broadcast({ jsonrpc: "2.0", method: "turn/started", params: { threadId: THREAD, turn: { id: "human-accept-race" } } });
+    await tick(10);
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (event) => replies.push(event as never));
+    const submission = bridge.submitTask({ taskId: "dash-accept-race", text: "late ack", steerIfExternalTurn: true });
+    await tick(10);
+    app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "human-accept-race", item: { type: "agentMessage", phase: "final_answer", text: "accepted answer" } } });
+    app.broadcast({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: THREAD, turn: { id: "human-accept-race", status: "completed" } } });
+    await tick(10);
+    expect(replies).toHaveLength(0);
+    answerSteer();
+    await submission;
+    expect(replies).toEqual([{ taskId: "dash-accept-race", text: "accepted answer" }]);
+    await client.close();
+    await app.stop();
+  });
+
+  test("reconciliation recovers a missed human turn completion and exact steered reply", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/steer") return respond({ result: { turnId: "human-missed" } });
+        if (msg.method === "thread/read" && (msg.params as any).includeTurns === false) {
+          return respond({ result: { thread: { status: "idle" } } });
+        }
+        if (msg.method === "thread/read") return respond({ result: { thread: { turns: [{ id: "human-missed", status: "completed", items: [{ type: "agentMessage", phase: "final_answer", text: "history answer" }] }] } } });
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    app.broadcast({ jsonrpc: "2.0", method: "turn/started", params: { threadId: THREAD, turn: { id: "human-missed" } } });
+    await tick(10);
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (event) => replies.push(event as never));
+    await bridge.submitTask({ taskId: "dash-missed", text: "recover", steerIfExternalTurn: true });
+    expect(await bridge.reconcileActiveTurn()).toEqual({ recovered: true, turnId: "human-missed", status: "completed" });
+    expect(replies).toEqual([{ taskId: "dash-missed", text: "history answer" }]);
+    await client.close();
+    await app.stop();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
 // 通信龙 additions — synchronous claim race fix + submitTask FIFO queue.
 // ────────────────────────────────────────────────────────────────────────────
 

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -532,6 +532,27 @@ describe("CodexAppServerBridge — authenticated Dashboard steering", () => {
     await app.stop();
   });
 
+  test("reconnect provenance ignores leading whitespace before the network prefix", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "thread/read") return respond({ result: { thread: {
+          status: { type: "active", activeFlags: [] },
+          turns: [{ id: "spaced-network-before-restart", status: "inProgress", items: [{ type: "userMessage", content: [{ type: "text", text: "  \n[Agent Network/task=old] work" }] }] }],
+        } } });
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    expect(await bridge.recoverSharedActiveTurn()).toEqual({ turnId: "spaced-network-before-restart", steerable: false });
+    expect((await bridge.submitTask({ taskId: "dash-spaced-network", text: "queue safely", steerIfExternalTurn: true })).started).toBe(false);
+    expect(app.received.filter((entry) => (entry as any).method === "turn/steer")).toHaveLength(0);
+    await client.close();
+    await app.stop();
+  });
+
   test("reconnect stays FIFO-only when real-wire active history omits userMessage", async () => {
     const app = await startFakeApp({
       onRequest: (msg, respond) => {

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -483,6 +483,55 @@ function tick(ms = 5): Promise<void> {
 // ────────────────────────────────────────────────────────────────────────────
 
 describe("CodexAppServerBridge — authenticated Dashboard steering", () => {
+  test("reconnect recovers an active human turn and keeps it steerable", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "thread/read") return respond({ result: { thread: {
+          status: { type: "active", activeFlags: [] },
+          turns: [{ id: "human-before-restart", status: "inProgress", items: [{ type: "userMessage", content: [{ type: "text", text: "human prompt" }] }] }],
+        } } });
+        if (msg.method === "turn/steer") return respond({ result: { turnId: "human-before-restart" } });
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    expect(await bridge.recoverSharedActiveTurn()).toEqual({ turnId: "human-before-restart", steerable: true });
+    expect(await bridge.submitTask({ taskId: "dash-after-restart", text: "follow up", steerIfExternalTurn: true }))
+      .toEqual({ started: true, turnId: "human-before-restart", steered: true });
+    expect(app.received.filter((entry) => (entry as any).method === "turn/steer")).toHaveLength(1);
+    await client.close();
+    await app.stop();
+  });
+
+  test("reconnect provenance keeps an orphaned network turn FIFO-only", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "thread/read") return respond({ result: { thread: {
+          status: { type: "active", activeFlags: [] },
+          turns: [{ id: "network-before-restart", status: "inProgress", items: [{ type: "userMessage", content: [{ type: "text", text: "[Agent Network/task=old] work" }] }] }],
+        } } });
+        if (msg.method === "turn/start") return respond({ result: { turnId: "after-orphan" } });
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    expect(await bridge.recoverSharedActiveTurn()).toEqual({ turnId: "network-before-restart", steerable: false });
+    expect((await bridge.submitTask({ taskId: "dash-not-mixed", text: "do not steer", steerIfExternalTurn: true })).started).toBe(false);
+    expect(app.received.filter((entry) => (entry as any).method === "turn/steer")).toHaveLength(0);
+    expect(bridge.queueDepth()).toBe(1);
+    app.broadcast({ jsonrpc: "2.0", method: "turn/completed", params: { threadId: THREAD, turn: { id: "network-before-restart", status: "completed" } } });
+    await tick(20);
+    expect(app.received.filter((entry) => (entry as any).method === "turn/start")).toHaveLength(1);
+    await client.close();
+    await app.stop();
+  });
+
   test("uses exact turn/steer contract and maps the human turn final answer", async () => {
     const app = await startFakeApp({
       onRequest: (msg, respond) => {

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -532,6 +532,27 @@ describe("CodexAppServerBridge — authenticated Dashboard steering", () => {
     await app.stop();
   });
 
+  test("reconnect stays FIFO-only when real-wire active history omits userMessage", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "thread/read") return respond({ result: { thread: {
+          status: { type: "active", activeFlags: [] },
+          turns: [{ id: "unknown-before-restart", status: "inProgress", items: [{ type: "agentMessage", text: "partial" }] }],
+        } } });
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    expect(await bridge.recoverSharedActiveTurn()).toEqual({ turnId: "unknown-before-restart", steerable: false });
+    expect((await bridge.submitTask({ taskId: "dash-unknown", text: "queue safely", steerIfExternalTurn: true })).started).toBe(false);
+    expect(app.received.filter((entry) => (entry as any).method === "turn/steer")).toHaveLength(0);
+    await client.close();
+    await app.stop();
+  });
+
   test("uses exact turn/steer contract and maps the human turn final answer", async () => {
     const app = await startFakeApp({
       onRequest: (msg, respond) => {

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -107,6 +107,8 @@ export class CodexAppServerBridge extends EventEmitter {
    * human turn; callers must opt in explicitly.
    */
   private externalActiveTurnId: string | null = null;
+  /** False when reconnect history proves the active turn came from anet. */
+  private externalActiveTurnSteerable = false;
   /** Dashboard tasks accepted through turn/steer, grouped by human turn. */
   private steeredTurns = new Map<string, SteeredTurn>();
   /**
@@ -268,7 +270,10 @@ export class CodexAppServerBridge extends EventEmitter {
     pending.turnId = turnId;
     this.pendingTurns.set(turnId, pending);
     this.activeTurnId = turnId;
-    if (this.externalActiveTurnId === turnId) this.externalActiveTurnId = null;
+    if (this.externalActiveTurnId === turnId) {
+      this.externalActiveTurnId = null;
+      this.externalActiveTurnSteerable = false;
+    }
     return turnId;
   }
 
@@ -297,7 +302,7 @@ export class CodexAppServerBridge extends EventEmitter {
       return { started: false, queuedAt: this.taskQueue.length };
     }
     if (this.externalActiveTurnId) {
-      if (input.steerIfExternalTurn) {
+      if (input.steerIfExternalTurn && this.externalActiveTurnSteerable) {
         return this.steerExternalTurn(input, this.externalActiveTurnId);
       }
       this.taskQueue.push(input);
@@ -412,6 +417,47 @@ export class CodexAppServerBridge extends EventEmitter {
   externalActiveTurn(): string | null {
     return this.externalActiveTurnId;
   }
+
+  /**
+   * Recover an already-running shared-server turn after bridge reconnect.
+   * A live turn/started notification is sufficient in the normal topology,
+   * but a restarted bridge missed that frame. Persisted first-user input is
+   * the provenance gate: `[Agent Network/…]` means an orphaned network turn
+   * and is never steerable; missing/unknown input also fails closed.
+   */
+  async recoverSharedActiveTurn(): Promise<{ turnId: string | null; steerable: boolean }> {
+    const result = await this.client.request<{
+      thread?: {
+        status?: string | { type?: string };
+        turns?: Array<{
+          id?: string;
+          status?: string;
+          items?: Array<{
+            type?: string;
+            content?: Array<{ type?: string; text?: string }>;
+          }>;
+        }>;
+      };
+    }>("thread/read", { threadId: this.threadId, includeTurns: true });
+    if (extractThreadStatus(result?.thread?.status) !== "active") {
+      return { turnId: null, steerable: false };
+    }
+    const active = [...(result?.thread?.turns ?? [])]
+      .reverse()
+      .find((turn) => turn.status === "inProgress" && typeof turn.id === "string");
+    if (!active?.id) return { turnId: null, steerable: false };
+    const firstUserText = active.items
+      ?.find((item) => item.type === "userMessage")
+      ?.content
+      ?.find((content) => content.type === "text" && typeof content.text === "string")
+      ?.text;
+    const steerable = typeof firstUserText === "string" && !/^\[Agent Network(?:\/|\])/u.test(firstUserText);
+    this.externalActiveTurnId = active.id;
+    this.externalActiveTurnSteerable = steerable;
+    if (this.waitingApprovals.size === 0) this.setStatus("working");
+    this.emit("external_turn_recovered", { turnId: active.id, steerable });
+    return { turnId: active.id, steerable };
+  }
   pendingTurnCount(): number {
     return this.pendingTurns.size;
   }
@@ -503,6 +549,7 @@ export class CodexAppServerBridge extends EventEmitter {
       // a reply unless at least one task was explicitly and successfully
       // steered into this turn.
       this.externalActiveTurnId = turnId;
+      this.externalActiveTurnSteerable = true;
       if (this.waitingApprovals.size === 0) this.setStatus("working");
       this.emit("unowned_turn_drop", { turnId, event: "turn/started" });
       return;
@@ -729,7 +776,10 @@ export class CodexAppServerBridge extends EventEmitter {
     terminal: { status?: string; error?: string; finalText?: string },
   ): boolean {
     if (this.externalActiveTurnId !== turnId && !this.steeredTurns.has(turnId)) return false;
-    if (this.externalActiveTurnId === turnId) this.externalActiveTurnId = null;
+    if (this.externalActiveTurnId === turnId) {
+      this.externalActiveTurnId = null;
+      this.externalActiveTurnSteerable = false;
+    }
     const steered = this.steeredTurns.get(turnId);
     if (steered) {
       if (terminal.finalText) steered.finalText = terminal.finalText;

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -56,6 +56,14 @@ export interface PendingTurn {
   finalText?: string;
 }
 
+interface SteeredTurn {
+  tasks: Map<string, PendingTurn>;
+  acceptedTaskIds: Set<string>;
+  agentTextChunks: string[];
+  finalText?: string;
+  terminal?: { status?: string; error?: string };
+}
+
 export interface WaitingApproval {
   reverseRequestId: number;
   method: string;
@@ -92,6 +100,15 @@ export class CodexAppServerBridge extends EventEmitter {
   private readonly label: string;
   private status: BridgeStatus = "connecting";
   private activeTurnId: string | null = null;
+  /**
+   * A turn started by the human TUI. Dashboard chat is allowed to steer this
+   * turn so a message sent while the human is actively using the TUI does not
+   * sit behind a ten-minute FIFO timeout. Agent-to-agent tasks never steer a
+   * human turn; callers must opt in explicitly.
+   */
+  private externalActiveTurnId: string | null = null;
+  /** Dashboard tasks accepted through turn/steer, grouped by human turn. */
+  private steeredTurns = new Map<string, SteeredTurn>();
   /**
    * Synchronous claim taken BEFORE the `turn/start` RPC round-trip.
    * `activeTurnId` alone is insufficient as a mutual-exclusion guard: it is
@@ -251,6 +268,7 @@ export class CodexAppServerBridge extends EventEmitter {
     pending.turnId = turnId;
     this.pendingTurns.set(turnId, pending);
     this.activeTurnId = turnId;
+    if (this.externalActiveTurnId === turnId) this.externalActiveTurnId = null;
     return turnId;
   }
 
@@ -265,16 +283,101 @@ export class CodexAppServerBridge extends EventEmitter {
    * requeued at the FRONT (original order preserved) — the app-server is the
    * authority (§6.3).
    */
-  async submitTask(input: { taskId: string; text: string; from?: string }): Promise<
-    { started: true; turnId: string } | { started: false; queuedAt: number }
+  async submitTask(input: {
+    taskId: string;
+    text: string;
+    from?: string;
+    steerIfExternalTurn?: boolean;
+  }): Promise<
+    { started: true; turnId: string; steered?: boolean } | { started: false; queuedAt: number }
   > {
-    if (this.turnClaimed || this.activeTurnId || this.taskQueue.length > 0) {
+    if (this.turnClaimed || this.activeTurnId) {
+      this.taskQueue.push(input);
+      this.emit("task_queued", { taskId: input.taskId, depth: this.taskQueue.length });
+      return { started: false, queuedAt: this.taskQueue.length };
+    }
+    if (this.externalActiveTurnId) {
+      if (input.steerIfExternalTurn) {
+        return this.steerExternalTurn(input, this.externalActiveTurnId);
+      }
+      this.taskQueue.push(input);
+      this.emit("task_queued", { taskId: input.taskId, depth: this.taskQueue.length });
+      return { started: false, queuedAt: this.taskQueue.length };
+    }
+    if (this.taskQueue.length > 0) {
       this.taskQueue.push(input);
       this.emit("task_queued", { taskId: input.taskId, depth: this.taskQueue.length });
       return { started: false, queuedAt: this.taskQueue.length };
     }
     const turnId = await this.startTaskTurn(input);
     return { started: true, turnId };
+  }
+
+  private async steerExternalTurn(
+    input: { taskId: string; text: string; from?: string; steerIfExternalTurn?: boolean },
+    expectedTurnId: string,
+  ): Promise<{ started: true; turnId: string; steered: true } | { started: false; queuedAt: number }> {
+    const state = this.steeredTurns.get(expectedTurnId) ?? {
+      tasks: new Map<string, PendingTurn>(),
+      acceptedTaskIds: new Set<string>(),
+      agentTextChunks: [],
+    };
+    state.tasks.set(input.taskId, {
+      taskId: input.taskId,
+      clientUserMessageId: `anet:${input.taskId}`,
+      submittedAt: Date.now(),
+      turnId: expectedTurnId,
+      agentTextChunks: [],
+    });
+    this.steeredTurns.set(expectedTurnId, state);
+
+    const fromLabel = displaySender(input.from);
+    const promptPrefix = fromLabel
+      ? `[Agent Network/from=${fromLabel}/task=${input.taskId}] `
+      : `[Agent Network/task=${input.taskId}] `;
+    try {
+      const response = await this.client.request("turn/steer", {
+        threadId: this.threadId,
+        input: [{ type: "text", text: promptPrefix + input.text }],
+        expectedTurnId,
+      });
+      const acceptedTurnId = extractTurnId(response);
+      if (acceptedTurnId !== expectedTurnId) {
+        throw new Error(
+          `${this.label}: turn/steer returned mismatched turnId=${acceptedTurnId ?? "(missing)"}; expected=${expectedTurnId}`,
+        );
+      }
+      state.acceptedTaskIds.add(input.taskId);
+      // If turn/completed raced the RPC response, attribution waits for this
+      // acceptance proof and is emitted now rather than fail-open earlier.
+      if (state.terminal) {
+        const task = state.tasks.get(input.taskId);
+        if (task) this.emitSteeredTask(state, task, state.terminal);
+        state.tasks.delete(input.taskId);
+        state.acceptedTaskIds.delete(input.taskId);
+        if (state.tasks.size === 0) this.steeredTurns.delete(expectedTurnId);
+      }
+      this.emit("task_steered", { taskId: input.taskId, turnId: expectedTurnId });
+      return { started: true, turnId: expectedTurnId, steered: true };
+    } catch (error) {
+      // The human turn may finish between turn/started and turn/steer. Remove
+      // the optimistic mapping, preserve the task in FIFO, and immediately
+      // try to drain: if the completion notification already raced past us,
+      // no later event would otherwise wake the queue.
+      state.tasks.delete(input.taskId);
+      state.acceptedTaskIds.delete(input.taskId);
+      if (state.tasks.size === 0) this.steeredTurns.delete(expectedTurnId);
+      if (this.externalActiveTurnId === expectedTurnId) this.externalActiveTurnId = null;
+      this.taskQueue.push(input);
+      const queuedAt = this.taskQueue.length;
+      this.emit("steer_deferred", {
+        taskId: input.taskId,
+        turnId: expectedTurnId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      void this.drainQueue();
+      return { started: false, queuedAt };
+    }
   }
 
   /** Drain the FIFO after a turn finishes. One task per idle transition. */
@@ -305,6 +408,9 @@ export class CodexAppServerBridge extends EventEmitter {
   }
   activeTurn(): string | null {
     return this.activeTurnId;
+  }
+  externalActiveTurn(): string | null {
+    return this.externalActiveTurnId;
   }
   pendingTurnCount(): number {
     return this.pendingTurns.size;
@@ -392,7 +498,12 @@ export class CodexAppServerBridge extends EventEmitter {
     const turnId = extractTurnId(params);
     if (!turnId) return;
     if (!this.pendingTurns.has(turnId)) {
-      // A turn we didn't start (§7.5 rule) — e.g. the human TUI. Observe only.
+      // A turn we didn't start — e.g. the human TUI. Track its exact id so
+      // authenticated Dashboard chat can use turn/steer. We still never map
+      // a reply unless at least one task was explicitly and successfully
+      // steered into this turn.
+      this.externalActiveTurnId = turnId;
+      if (this.waitingApprovals.size === 0) this.setStatus("working");
       this.emit("unowned_turn_drop", { turnId, event: "turn/started" });
       return;
     }
@@ -410,7 +521,11 @@ export class CodexAppServerBridge extends EventEmitter {
     if (!p || p.threadId !== this.threadId) return;
     if (typeof p.turnId !== "string") return;
     const pending = this.pendingTurns.get(p.turnId);
-    if (!pending) return; // Not our turn — human TUI is receiving deltas too.
+    if (!pending) {
+      const steered = this.steeredTurns.get(p.turnId);
+      if (steered && typeof p.delta === "string") steered.agentTextChunks.push(p.delta);
+      return; // Human TUI is receiving deltas too.
+    }
     if (typeof p.delta === "string") pending.agentTextChunks.push(p.delta);
   }
 
@@ -426,7 +541,18 @@ export class CodexAppServerBridge extends EventEmitter {
     if (!p || p.threadId !== this.threadId) return;
     if (typeof p.turnId !== "string") return;
     const pending = this.pendingTurns.get(p.turnId);
-    if (!pending) return;
+    if (!pending) {
+      const steered = this.steeredTurns.get(p.turnId);
+      if (
+        steered &&
+        p.item?.type === "agentMessage" &&
+        p.item.phase === "final_answer" &&
+        typeof p.item.text === "string"
+      ) {
+        steered.finalText = p.item.text;
+      }
+      return;
+    }
     if (
       p.item?.type === "agentMessage" &&
       p.item.phase === "final_answer" &&
@@ -450,11 +576,21 @@ export class CodexAppServerBridge extends EventEmitter {
     if (!turnId) return;
     const pending = this.pendingTurns.get(turnId);
     if (!pending) {
-      // Human-TUI-initiated turn completed. Absolutely no reply mapping —
-      // but the thread just went idle, so queued Agent tasks may proceed
-      // (§6.1: human input had its priority; FIFO resumes after).
+      // Human-TUI-initiated turn completed. Only tasks that were accepted by
+      // turn/steer are mapped; an ordinary human-only turn remains invisible
+      // to CommHub. All steered Dashboard tasks receive the same final answer
+      // because app-server emits one final answer for the shared active turn.
+      const finished = this.finishExternalTurn(turnId, {
+        status: p.turn?.status,
+        error: p.turn?.error?.message,
+      });
       this.emit("unowned_turn_drop", { turnId, event: "turn/completed" });
-      void this.drainQueue();
+      // Older app-server builds can omit turn/started for a competing human
+      // turn. Preserve the historical idle wake-up for that notification.
+      if (!finished) {
+        if (this.waitingApprovals.size === 0) this.setStatus("idle");
+        void this.drainQueue();
+      }
       return;
     }
     this.finishOwnedTurn(turnId, {
@@ -477,7 +613,9 @@ export class CodexAppServerBridge extends EventEmitter {
    */
   async reconcileActiveTurn(): Promise<ActiveTurnReconciliation> {
     if (this.reconciliationInFlight) return this.reconciliationInFlight;
-    const activeAtStart = this.activeTurnId;
+    const ownedAtStart = this.activeTurnId;
+    const externalAtStart = this.externalActiveTurnId;
+    const activeAtStart = ownedAtStart ?? externalAtStart;
     if (!activeAtStart) return { recovered: false, turnId: null };
 
     this.reconciliationInFlight = (async () => {
@@ -490,7 +628,10 @@ export class CodexAppServerBridge extends EventEmitter {
 
       // A notification may have completed the turn while thread/read was in
       // flight. Never let an old snapshot release a newer active claim.
-      if (this.activeTurnId !== activeAtStart) {
+      if (
+        (ownedAtStart && this.activeTurnId !== activeAtStart) ||
+        (externalAtStart && this.externalActiveTurnId !== activeAtStart)
+      ) {
         return { recovered: false, turnId: activeAtStart };
       }
 
@@ -510,7 +651,10 @@ export class CodexAppServerBridge extends EventEmitter {
         };
       }>("thread/read", { threadId: this.threadId, includeTurns: true });
 
-      if (this.activeTurnId !== activeAtStart) {
+      if (
+        (ownedAtStart && this.activeTurnId !== activeAtStart) ||
+        (externalAtStart && this.externalActiveTurnId !== activeAtStart)
+      ) {
         return { recovered: false, turnId: activeAtStart };
       }
 
@@ -526,11 +670,17 @@ export class CodexAppServerBridge extends EventEmitter {
           item.phase === "final_answer" &&
           typeof item.text === "string"
         )?.text;
-      const recovered = this.finishOwnedTurn(activeAtStart, {
-        status: turn.status,
-        error: turn.error?.message,
-        finalText,
-      });
+      const recovered = ownedAtStart
+        ? this.finishOwnedTurn(activeAtStart, {
+          status: turn.status,
+          error: turn.error?.message,
+          finalText,
+        })
+        : this.finishExternalTurn(activeAtStart, {
+          status: turn.status,
+          error: turn.error?.message,
+          finalText,
+        });
       if (recovered) {
         this.emit("turn_reconciled", { turnId: activeAtStart, status: turn.status });
       }
@@ -572,6 +722,47 @@ export class CodexAppServerBridge extends EventEmitter {
     // Either way the thread just went idle from our perspective → drain FIFO.
     void this.drainQueue();
     return true;
+  }
+
+  private finishExternalTurn(
+    turnId: string,
+    terminal: { status?: string; error?: string; finalText?: string },
+  ): boolean {
+    if (this.externalActiveTurnId !== turnId && !this.steeredTurns.has(turnId)) return false;
+    if (this.externalActiveTurnId === turnId) this.externalActiveTurnId = null;
+    const steered = this.steeredTurns.get(turnId);
+    if (steered) {
+      if (terminal.finalText) steered.finalText = terminal.finalText;
+      steered.terminal = { status: terminal.status, error: terminal.error };
+      for (const [taskId, task] of steered.tasks) {
+        if (!steered.acceptedTaskIds.has(taskId)) continue;
+        this.emitSteeredTask(steered, task, steered.terminal);
+        steered.tasks.delete(taskId);
+        steered.acceptedTaskIds.delete(taskId);
+      }
+      if (steered.tasks.size === 0) this.steeredTurns.delete(turnId);
+    }
+    if (this.waitingApprovals.size === 0) this.setStatus("idle");
+    void this.drainQueue();
+    return true;
+  }
+
+  private emitSteeredTask(
+    state: SteeredTurn,
+    task: PendingTurn,
+    terminal: { status?: string; error?: string },
+  ): void {
+    const turnErr = terminal.error ??
+      (terminal.status === "failed"
+        ? "Codex turn failed without an error message"
+        : terminal.status === "interrupted"
+          ? "Codex turn was interrupted without an error message"
+          : undefined);
+    const text = state.finalText && state.finalText.length > 0
+      ? state.finalText
+      : state.agentTextChunks.join("");
+    if (turnErr) this.emit("task_error", { taskId: task.taskId, error: turnErr });
+    else this.emit("task_reply", { taskId: task.taskId, text });
   }
 
   /** Read-only queue depth (for tests / observability). */

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -451,7 +451,7 @@ export class CodexAppServerBridge extends EventEmitter {
       ?.content
       ?.find((content) => content.type === "text" && typeof content.text === "string")
       ?.text;
-    const steerable = typeof firstUserText === "string" && !/^\[Agent Network(?:\/|\])/u.test(firstUserText);
+    const steerable = typeof firstUserText === "string" && !/^\s*\[Agent Network(?:\/|\])/u.test(firstUserText);
     this.externalActiveTurnId = active.id;
     this.externalActiveTurnSteerable = steerable;
     if (this.waitingApprovals.size === 0) this.setStatus("working");

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -7,6 +7,7 @@ import {
   buildOwnedAppServerArgs,
   COMMHUB_MCP_TOKEN_ENV,
   codexAppServerThink,
+  recoverSharedTurnOnAttach,
   type CodexAppServerRuntimeSession,
 } from "./runtime";
 
@@ -67,6 +68,32 @@ describe("buildOwnedAppServerArgs", () => {
     ]);
     expect(args[args.length - 2]).toBe("--listen");
     expect(args[args.length - 1]).toBe(URL);
+  });
+});
+
+describe("recoverSharedTurnOnAttach", () => {
+  test("invokes persisted active-turn recovery before shared runtime is returned", async () => {
+    const logs: string[] = [];
+    let calls = 0;
+    await recoverSharedTurnOnAttach({
+      async recoverSharedActiveTurn() {
+        calls++;
+        return { turnId: "human-reconnect", steerable: true };
+      },
+    }, (line) => logs.push(line), (line) => logs.push(`WARN:${line}`));
+    expect(calls).toBe(1);
+    expect(logs.some((line) => line.includes("human-reconnect") && line.includes("human/steerable"))).toBe(true);
+  });
+
+  test("history read failure is visible and never reported as steerable", async () => {
+    const warnings: string[] = [];
+    await recoverSharedTurnOnAttach({
+      async recoverSharedActiveTurn(): Promise<{ turnId: string | null; steerable: boolean }> {
+        throw new Error("history unavailable");
+      },
+    }, () => { throw new Error("must not log recovery"); }, (line) => warnings.push(line));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("history unavailable");
   });
 });
 

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -73,9 +73,11 @@ describe("buildOwnedAppServerArgs", () => {
 class ReconcileOnlyBridge extends EventEmitter {
   taskId = "";
   reconcileCalls = 0;
+  submitted: Record<string, unknown> | null = null;
 
-  async submitTask(input: { taskId: string }): Promise<{ started: true; turnId: string }> {
+  async submitTask(input: { taskId: string; steerIfExternalTurn?: boolean }): Promise<{ started: true; turnId: string }> {
     this.taskId = input.taskId;
+    this.submitted = input;
     return { started: true, turnId: "turn_missing_notification" };
   }
 
@@ -116,5 +118,24 @@ describe("codexAppServerThink — terminal-event reconciliation watchdog", () =>
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(bridge.reconcileCalls).toBe(1);
     expect(logs.some((line) => line.includes("recovered missed terminal event"))).toBe(true);
+  });
+
+  test("forwards the authenticated Dashboard steering decision to the bridge", async () => {
+    const bridge = new ReconcileOnlyBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    await codexAppServerThink(session, {
+      taskId: "task_dashboard",
+      text: "follow-up",
+      from: "admin",
+      steerIfExternalTurn: true,
+      timeoutMs: 250,
+      reconciliationIntervalMs: 5,
+    });
+    expect(bridge.submitted).toMatchObject({
+      taskId: "task_dashboard",
+      text: "follow-up",
+      from: "admin",
+      steerIfExternalTurn: true,
+    });
   });
 });

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -226,6 +226,8 @@ export function codexAppServerThink(
     /** Test seam; production defaults to a 5s authoritative thread/read. */
     reconciliationIntervalMs?: number;
     log?: (m: string) => void;
+    /** Dashboard chat may join the human TUI's current in-flight turn. */
+    steerIfExternalTurn?: boolean;
   },
 ): Promise<CodexAppServerThinkResult> {
   const timeoutMs = opts.timeoutMs ?? 10 * 60_000;
@@ -292,9 +294,15 @@ export function codexAppServerThink(
     scheduleReconciliation();
 
     bridge
-      .submitTask({ taskId: opts.taskId, text: opts.text, from: opts.from })
+      .submitTask({
+        taskId: opts.taskId,
+        text: opts.text,
+        from: opts.from,
+        steerIfExternalTurn: opts.steerIfExternalTurn,
+      })
       .then((r) => {
         if (!r.started) log(`[codex-app-server] task ${opts.taskId} queued (a turn is in flight)`);
+        else if (r.steered) log(`[codex-app-server] task ${opts.taskId} steered into human turn ${r.turnId}`);
       })
       .catch((e) => finish({ replyText: `codex-app-server 错误: ${e?.message ?? e}`, failed: true, queued: false }));
   });

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -31,6 +31,23 @@ export interface CodexAppServerRuntimeSession {
   get isRunning(): boolean;
 }
 
+export async function recoverSharedTurnOnAttach(
+  bridge: Pick<CodexAppServerBridge, "recoverSharedActiveTurn">,
+  log: (message: string) => void,
+  warn: (message: string) => void,
+): Promise<void> {
+  try {
+    const recovered = await bridge.recoverSharedActiveTurn();
+    if (recovered.turnId) {
+      log(`[codex-app-server] recovered active shared turn ${recovered.turnId} (${recovered.steerable ? "human/steerable" : "network-or-unknown/FIFO-only"})`);
+    }
+  } catch (e) {
+    // Older app-server versions may not hydrate active history. Do not make
+    // the node unavailable; without a proven human turn, no steer is allowed.
+    warn(`[codex-app-server] active-turn recovery unavailable: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
 function randomPort(): number {
   // Ephemeral-ish localhost range; collisions are retried by the caller.
   return 24000 + Math.floor(Math.random() * 4000);
@@ -190,6 +207,9 @@ export async function openCodexAppServerRuntime(opts: {
     warn(`[codex-app-server] turn is waiting on a human approval — bridge will NOT answer`),
   );
   await bridge.bootstrap();
+  if (opts.serverUrl) {
+    await recoverSharedTurnOnAttach(bridge, log, warn);
+  }
 
   return {
     client,

--- a/docs/sop/agent-reply-to-dashboard.md
+++ b/docs/sop/agent-reply-to-dashboard.md
@@ -50,6 +50,7 @@ busy 节点（如 codex-app-server 单线程 turn）收到新任务会**排队**
 这是“同一个用户、同一个会话”的即时补充能力，不是独立并行对话：如果人正在 TUI 里处理另一件事，
 Dashboard 补充内容会和当前上下文一起影响最终答案。需要完全隔离时，应等当前 turn 结束再发送。
 Hub 只信服务端依据 token 写入的 `auth_origin`；客户端自填 `auth_origin=user` 不会获得 steer 权限。
+升级前已入库、没有该服务端标记的消息按普通 FIFO 处理，不用 `from_session=admin` 猜测身份。
 
 ## 用了终态还是不显示？
 

--- a/docs/sop/agent-reply-to-dashboard.md
+++ b/docs/sop/agent-reply-to-dashboard.md
@@ -51,6 +51,8 @@ busy 节点（如 codex-app-server 单线程 turn）收到新任务会**排队**
 Dashboard 补充内容会和当前上下文一起影响最终答案。需要完全隔离时，应等当前 turn 结束再发送。
 Hub 只信服务端依据 token 写入的 `auth_origin`；客户端自填 `auth_origin=user` 不会获得 steer 权限。
 升级前已入库、没有该服务端标记的消息按普通 FIFO 处理，不用 `from_session=admin` 猜测身份。
+桥重连时会从 `thread/read` 恢复 active turn；只有首条持久化 user input 能证明是人类 turn 才可 steer，
+旧 bridge 启动的 network turn 或来源不明的 active turn 一律 FIFO。
 
 ## 用了终态还是不显示？
 

--- a/docs/sop/agent-reply-to-dashboard.md
+++ b/docs/sop/agent-reply-to-dashboard.md
@@ -53,6 +53,8 @@ Hub 只信服务端依据 token 写入的 `auth_origin`；客户端自填 `auth_
 升级前已入库、没有该服务端标记的消息按普通 FIFO 处理，不用 `from_session=admin` 猜测身份。
 桥重连时会从 `thread/read` 恢复 active turn；只有首条持久化 user input 能证明是人类 turn 才可 steer，
 旧 bridge 启动的 network turn 或来源不明的 active turn 一律 FIFO。
+Codex 0.133 实测 active history 可能不含 `userMessage`；这种重连不会猜测为人类，需等当前 turn
+结束。桥保持在线后，下一次实时 `turn/started` 会恢复正常即时 steer。
 
 ## 用了终态还是不显示？
 

--- a/docs/sop/agent-reply-to-dashboard.md
+++ b/docs/sop/agent-reply-to-dashboard.md
@@ -56,6 +56,10 @@ Hub 只信服务端依据 token 写入的 `auth_origin`；客户端自填 `auth_
 Codex 0.133 实测 active history 可能不含 `userMessage`；这种重连不会猜测为人类，需等当前 turn
 结束。桥保持在线后，下一次实时 `turn/started` 会恢复正常即时 steer。
 
+这里的“无 `[Agent Network/…]` 前缀 = 当作人类”只是默认行为，不是身份识别能力。不要声称桥能识别
+任意旧版或外部创建、且没有该前缀的 network turn；当前安全性依赖 Phase 0A 以来本桥始终添加该前缀，
+不是 Codex app-server 协议提供的来源保证。
+
 ## 用了终态还是不显示？
 
 那通常是**生产层传输**问题（浏览器侧 HTTP/2、或 SSE 代理被 buffer/掐掉），不是回复本身。

--- a/docs/sop/agent-reply-to-dashboard.md
+++ b/docs/sop/agent-reply-to-dashboard.md
@@ -41,6 +41,16 @@ busy 节点（如 codex-app-server 单线程 turn）收到新任务会**排队**
 
 **判死活标准动作**：先 `tmux capture-pane` 看终端实况 + 查 hub 心跳（updated_at 新鲜=活），**别只凭超时消息下结论**。改进方向（候选）：hub/runtime 把"排队中"与"真超时"区分回复。
 
+### Codex TUI 共存节点的 Dashboard 消息
+
+服务端鉴权为用户的 Dashboard chat 在人类 TUI 已有 active turn 时，会通过
+`turn/steer(expectedTurnId)` 追加到该 turn；普通 agent 任务仍在 FIFO 等待，不会注入人的 turn。
+同一 active turn 内快速发送的多条 Dashboard 消息共享该 turn 的最终答案。
+
+这是“同一个用户、同一个会话”的即时补充能力，不是独立并行对话：如果人正在 TUI 里处理另一件事，
+Dashboard 补充内容会和当前上下文一起影响最终答案。需要完全隔离时，应等当前 turn 结束再发送。
+Hub 只信服务端依据 token 写入的 `auth_origin`；客户端自填 `auth_origin=user` 不会获得 steer 权限。
+
 ## 用了终态还是不显示？
 
 那通常是**生产层传输**问题（浏览器侧 HTTP/2、或 SSE 代理被 buffer/掐掉），不是回复本身。

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,0 +1,40 @@
+Test 584 — Dashboard → Codex TUI reliable delivery
+Date: 2026-08-04 (Asia/Shanghai)
+Base: origin/main 4da56c34c3159d674fb84f7ff636d6080f83b641
+Image: anet-test584:dev
+Command: sg docker -c 'docker run --rm anet-test584:dev'
+Result: PASS (exit 0)
+
+L1 — source/build
+- agent-node CLI bundled successfully (239 modules, 1.64 MB output).
+
+L2 — app-server bridge and inbox dispatch
+- 39 tests passed, 0 failed, 111 assertions.
+- Exact turn/steer expectedTurnId contract.
+- Human-only turns do not create CommHub replies.
+- Authenticated Dashboard tasks steer an active human turn.
+- Multiple Dashboard rows enter the same turn without head-of-line blocking.
+- Ordinary agent tasks remain FIFO queued.
+- Steer mismatch/race preserves the task.
+- A task is not attributed before turn/steer acceptance.
+- Missed terminal notification is recovered from exact thread history.
+
+L3 — Hub auth boundary and rolling idempotency
+- 11 tests passed, 0 failed, 25 assertions.
+- Hub overrides client-supplied auth_origin from authenticated token facts.
+- Existing pre-stamp Dashboard requests remain idempotent across rollout.
+
+L4 — private real HTTP Hub
+- 2 tests passed, 0 failed, 6 assertions.
+- User token persists auth_origin=user.
+- Node token attempting to spoof Dashboard metadata persists auth_origin=node.
+
+L5 — witnessed-red mutations
+- node-origin-cannot-steer: RED (rc 1)
+- no-head-of-line-serialization: RED (rc 1)
+- exact-expected-turn-id: RED (rc 1)
+- accepted-steer-must-reply: RED (rc 1)
+
+Production deployment was deliberately excluded from this test container.
+Hub and agent-node bridge must be deployed as one coordinated change, then a
+real Dashboard nonce must be verified through inbox ack and task reply.

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,7 +1,7 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main 4da56c34c3159d674fb84f7ff636d6080f83b641
-Source candidate: 2e409d35f5973c6a64e5a49429c5bc16590f37ad
+Source candidate: 8dfc384d38762253556e2c56554f3ce5563d6787
 Image: anet-test584:dev
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)
@@ -10,7 +10,7 @@ L1 — source/build
 - agent-node CLI bundled successfully (239 modules, 1.64 MB output).
 
 L2 — app-server bridge and inbox dispatch
-- 39 tests passed, 0 failed, 111 assertions.
+- 43 tests passed, 0 failed, 123 assertions.
 - Exact turn/steer expectedTurnId contract.
 - Human-only turns do not create CommHub replies.
 - Authenticated Dashboard tasks steer an active human turn.
@@ -36,6 +36,7 @@ L5 — witnessed-red mutations
 - no-head-of-line-serialization: RED (rc 1)
 - exact-expected-turn-id: RED (rc 1)
 - accepted-steer-must-reply: RED (rc 1)
+- reconnect-network-turn-stays-fifo: RED (rc 1)
 - mcp-node-cannot-forge-user-origin: RED (rc 1)
 - rest-node-cannot-forge-user-origin: RED (rc 1)
 

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,6 +1,7 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main 4da56c34c3159d674fb84f7ff636d6080f83b641
+Source candidate: ab9e2d46edc10807311ee0c7d38dcda460855118
 Image: anet-test584:dev
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,7 +1,7 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main 4da56c34c3159d674fb84f7ff636d6080f83b641
-Source candidate: ff0d439d85c880eed0da31181e52d542d01024be
+Source candidate: 2e409d35f5973c6a64e5a49429c5bc16590f37ad
 Image: anet-test584:dev
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)
@@ -23,6 +23,7 @@ L2 — app-server bridge and inbox dispatch
 L3 — Hub auth boundary and rolling idempotency
 - 12 tests passed, 0 failed (MCP user and node callers both covered).
 - Hub overrides client-supplied auth_origin from authenticated token facts.
+- Pre-stamp admin aliases remain FIFO and cannot unlock steering.
 - Existing pre-stamp Dashboard requests remain idempotent across rollout.
 
 L4 — private real HTTP Hub

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,7 +1,7 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main 4da56c34c3159d674fb84f7ff636d6080f83b641
-Source candidate: 8dfc384d38762253556e2c56554f3ce5563d6787
+Source candidate: 9f264840d3a4702a23f7e8fde72fafbc5c6eaf58
 Image: anet-test584:dev
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)
@@ -10,7 +10,7 @@ L1 — source/build
 - agent-node CLI bundled successfully (239 modules, 1.64 MB output).
 
 L2 — app-server bridge and inbox dispatch
-- 43 tests passed, 0 failed, 123 assertions.
+- 44 tests passed, 0 failed, 126 assertions.
 - Exact turn/steer expectedTurnId contract.
 - Human-only turns do not create CommHub replies.
 - Authenticated Dashboard tasks steer an active human turn.
@@ -19,6 +19,7 @@ L2 — app-server bridge and inbox dispatch
 - Steer mismatch/race preserves the task.
 - A task is not attributed before turn/steer acceptance.
 - Missed terminal notification is recovered from exact thread history.
+- Codex 0.133 real-wire shape without persisted userMessage stays FIFO-only.
 
 L3 — Hub auth boundary and rolling idempotency
 - 12 tests passed, 0 failed (MCP user and node callers both covered).

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,7 +1,7 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main 4da56c34c3159d674fb84f7ff636d6080f83b641
-Source candidate: 9f264840d3a4702a23f7e8fde72fafbc5c6eaf58
+Source candidate: bb41d94f347642849eb56dbc1e1d586ba907cb3d
 Image: anet-test584:dev
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)
@@ -10,7 +10,7 @@ L1 — source/build
 - agent-node CLI bundled successfully (239 modules, 1.64 MB output).
 
 L2 — app-server bridge and inbox dispatch
-- 44 tests passed, 0 failed, 126 assertions.
+- 45 tests passed, 0 failed, 129 assertions.
 - Exact turn/steer expectedTurnId contract.
 - Human-only turns do not create CommHub replies.
 - Authenticated Dashboard tasks steer an active human turn.
@@ -20,6 +20,7 @@ L2 — app-server bridge and inbox dispatch
 - A task is not attributed before turn/steer acceptance.
 - Missed terminal notification is recovered from exact thread history.
 - Codex 0.133 real-wire shape without persisted userMessage stays FIFO-only.
+- Leading whitespace cannot hide an Agent Network prefix during reconnect recovery.
 
 L3 — Hub auth boundary and rolling idempotency
 - 12 tests passed, 0 failed (MCP user and node callers both covered).
@@ -38,6 +39,7 @@ L5 — witnessed-red mutations
 - exact-expected-turn-id: RED (rc 1)
 - accepted-steer-must-reply: RED (rc 1)
 - reconnect-network-turn-stays-fifo: RED (rc 1)
+- leading-whitespace-network-prefix-stays-fifo: RED (rc 1)
 - mcp-node-cannot-forge-user-origin: RED (rc 1)
 - rest-node-cannot-forge-user-origin: RED (rc 1)
 

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,7 +1,7 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main 4da56c34c3159d674fb84f7ff636d6080f83b641
-Source candidate: ab9e2d46edc10807311ee0c7d38dcda460855118
+Source candidate: ff0d439d85c880eed0da31181e52d542d01024be
 Image: anet-test584:dev
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)
@@ -21,7 +21,7 @@ L2 — app-server bridge and inbox dispatch
 - Missed terminal notification is recovered from exact thread history.
 
 L3 — Hub auth boundary and rolling idempotency
-- 11 tests passed, 0 failed, 25 assertions.
+- 12 tests passed, 0 failed (MCP user and node callers both covered).
 - Hub overrides client-supplied auth_origin from authenticated token facts.
 - Existing pre-stamp Dashboard requests remain idempotent across rollout.
 
@@ -35,6 +35,8 @@ L5 — witnessed-red mutations
 - no-head-of-line-serialization: RED (rc 1)
 - exact-expected-turn-id: RED (rc 1)
 - accepted-steer-must-reply: RED (rc 1)
+- mcp-node-cannot-forge-user-origin: RED (rc 1)
+- rest-node-cannot-forge-user-origin: RED (rc 1)
 
 Production deployment was deliberately excluded from this test container.
 Hub and agent-node bridge must be deployed as one coordinated change, then a

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -34,6 +34,7 @@ import { dirname as pathDirname } from "path";
 import { startRetentionSweeper } from "./retention.js";
 import { startStaleSessionSweeper } from "./stale-sweeper.js";
 import { resolveRestFromSession } from "./rest-identity.js";
+import { stampTaskAuthOrigin, type TaskAuthOrigin } from "./task-auth-origin.js";
 
 const PORT = Number(process.env.PORT) || 9200;
 const HOST = process.env.HOST || "127.0.0.1";
@@ -2137,7 +2138,13 @@ return Bun.serve({
       const mergedMeta = attachmentsResult.attachments.length
         ? { ...((body as any).meta && typeof (body as any).meta === "object" ? (body as any).meta : {}), attachments: attachmentsResult.attachments }
         : (body as any).meta;
-      const metaJson = normalizeMetaJson(mergedMeta);
+      const rawToken = requestToken(req);
+      const authOrigin: TaskAuthOrigin = rawToken.startsWith("ntok_")
+        ? "node"
+        : restAuth
+          ? "user"
+          : "legacy";
+      const metaJson = normalizeMetaJson(stampTaskAuthOrigin(mergedMeta, authOrigin));
 
       // #212 dedup guardrail. Mirrors the MCP `send_task` tool: same
       // (from_session, target_alias, task) within COMMHUB_SEND_DEDUP_WINDOW_MS

--- a/server/src/task-auth-origin-http.test.ts
+++ b/server/src/task-auth-origin-http.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createNetworkTokenForNode, register } from "./auth.js";
+import { db } from "./db.js";
+
+const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-auth-origin-http-"));
+let server: any;
+let base = "";
+let userToken = "";
+let nodeToken = "";
+let networkId = "";
+const TARGET = "auth-origin-http-target";
+
+beforeAll(async () => {
+  process.env.COMMHUB_DB = process.env.COMMHUB_DB || join(PRIVATE_DB_DIR, "hub.db");
+  const username = `auth_origin_${Date.now()}`;
+  const registered = register(username, "AuthOriginTest123!", undefined, "seed");
+  expect(registered.ok).toBe(true);
+  userToken = registered.token!;
+  networkId = registered.network_id!;
+  const userId = db.get<{ user_id: string }>("SELECT user_id FROM users WHERE username = ?1", [username])!.user_id;
+  const minted = createNetworkTokenForNode(userId, networkId, "auth-origin-node");
+  expect(minted.ok).toBe(true);
+  nodeToken = minted.token!;
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+     VALUES ('resume_auth_origin_target', ?1, 'idle', 'node_auth_origin_target', ?2, datetime('now'), datetime('now'))`,
+    [TARGET, networkId],
+  );
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, network_id, created_at, updated_at, lifecycle_state)
+     VALUES ('node_auth_origin_target', ?1, ?1, ?2, datetime('now'), datetime('now'), 'active')`,
+    [TARGET, networkId],
+  );
+  const mod: any = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop?.(true); } catch {}
+  try { rmSync(PRIVATE_DB_DIR, { recursive: true, force: true }); } catch {}
+});
+
+async function postTask(token: string, from: string, marker: string) {
+  const response = await fetch(`${base}/api/task`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      alias: TARGET,
+      from,
+      network_id: networkId,
+      task: marker,
+      meta: {
+        source: "dashboard-chat",
+        client_request_id: `dreq_${"a".repeat(31)}${marker.endsWith("user") ? "1" : "2"}`,
+        auth_origin: "user",
+      },
+    }),
+  });
+  const body = await response.json() as any;
+  expect([200, 202]).toContain(response.status);
+  const taskId = body.task_id ?? body.message_id;
+  expect(taskId).toBeTruthy();
+  return JSON.parse(db.get<{ meta_json: string }>("SELECT meta_json FROM inbox WHERE id = ?1", [taskId])!.meta_json);
+}
+
+describe("POST /api/task server-authenticated origin", () => {
+  test("user token stamps user even when the client supplied another fact", async () => {
+    const meta = await postTask(userToken, "dashboard-user", "origin-user");
+    expect(meta.auth_origin).toBe("user");
+  });
+
+  test("node token cannot spoof Dashboard trust through REST metadata", async () => {
+    const meta = await postTask(nodeToken, "auth-origin-node", "origin-node");
+    expect(meta.auth_origin).toBe("node");
+  });
+});

--- a/server/src/task-auth-origin-http.test.ts
+++ b/server/src/task-auth-origin-http.test.ts
@@ -11,7 +11,9 @@ let base = "";
 let userToken = "";
 let nodeToken = "";
 let networkId = "";
-const TARGET = "auth-origin-http-target";
+const TARGET = `auth-origin-http-target-${process.pid}`;
+const TARGET_NODE_ID = `node_auth_origin_target_${process.pid}`;
+const TARGET_RESUME_ID = `resume_auth_origin_target_${process.pid}`;
 
 beforeAll(async () => {
   process.env.COMMHUB_DB = process.env.COMMHUB_DB || join(PRIVATE_DB_DIR, "hub.db");
@@ -26,13 +28,13 @@ beforeAll(async () => {
   nodeToken = minted.token!;
   db.run(
     `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
-     VALUES ('resume_auth_origin_target', ?1, 'idle', 'node_auth_origin_target', ?2, datetime('now'), datetime('now'))`,
-    [TARGET, networkId],
+     VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))`,
+    [TARGET_RESUME_ID, TARGET, TARGET_NODE_ID, networkId],
   );
   db.run(
     `INSERT INTO nodes (node_id, node_name, alias, network_id, created_at, updated_at, lifecycle_state)
-     VALUES ('node_auth_origin_target', ?1, ?1, ?2, datetime('now'), datetime('now'), 'active')`,
-    [TARGET, networkId],
+     VALUES (?1, ?2, ?2, ?3, datetime('now'), datetime('now'), 'active')`,
+    [TARGET_NODE_ID, TARGET, networkId],
   );
   const mod: any = await import("./server.js");
   server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });

--- a/server/src/task-auth-origin.test.ts
+++ b/server/src/task-auth-origin.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { stampTaskAuthOrigin } from "./task-auth-origin";
+
+describe("stampTaskAuthOrigin", () => {
+  test("server auth fact overrides a client-spoofed origin", () => {
+    expect(stampTaskAuthOrigin({ source: "dashboard-chat", auth_origin: "user" }, "node")).toEqual({
+      source: "dashboard-chat",
+      auth_origin: "node",
+    });
+  });
+
+  test("preserves existing metadata fields", () => {
+    expect(stampTaskAuthOrigin({ client_request_id: "dreq_x", attachments: [] }, "user")).toEqual({
+      client_request_id: "dreq_x",
+      attachments: [],
+      auth_origin: "user",
+    });
+  });
+
+  test("does not manufacture metadata for old callers that supplied none", () => {
+    expect(stampTaskAuthOrigin(undefined, "legacy")).toBeUndefined();
+    expect(stampTaskAuthOrigin(null, "legacy")).toBeNull();
+  });
+});

--- a/server/src/task-auth-origin.ts
+++ b/server/src/task-auth-origin.ts
@@ -1,0 +1,7 @@
+export type TaskAuthOrigin = "user" | "node" | "legacy";
+
+/** Stamp task metadata from server authentication facts, overriding spoofed input. */
+export function stampTaskAuthOrigin(meta: unknown, origin: TaskAuthOrigin): unknown {
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return meta;
+  return { ...(meta as Record<string, unknown>), auth_origin: origin };
+}

--- a/server/src/task-idempotency-mcp.test.ts
+++ b/server/src/task-idempotency-mcp.test.ts
@@ -52,6 +52,25 @@ beforeEach(() => { cleanup(); seed(); });
 afterAll(cleanup);
 
 describe("send_task durable idempotency", () => {
+  test("Hub stamps authenticated user origin and overrides client spoofing", async () => {
+    const handler = sendTaskHandler();
+    const sent = await call(handler, {
+      alias: TARGET,
+      task: "authenticated dashboard payload",
+      priority: "normal",
+      meta: {
+        source: "dashboard-chat",
+        client_request_id: "dreq_0123456789abcdef0123456789abcdef",
+        auth_origin: "node",
+      },
+    });
+    expect(sent.ok).toBe(true);
+    const task = db.get<{ meta_json: string }>("SELECT meta_json FROM tasks WHERE task_id = ?1", [sent.message_id]);
+    const inbox = db.get<{ meta_json: string }>("SELECT meta_json FROM inbox WHERE id = ?1", [sent.message_id]);
+    expect(JSON.parse(task!.meta_json).auth_origin).toBe("user");
+    expect(JSON.parse(inbox!.meta_json).auth_origin).toBe("user");
+  });
+
   test("lost-response retry returns the original task and does not enqueue twice", async () => {
     const handler = sendTaskHandler();
     const args = {

--- a/server/src/task-idempotency-mcp.test.ts
+++ b/server/src/task-idempotency-mcp.test.ts
@@ -30,7 +30,7 @@ function seed() {
   db.run("INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at) VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))", [`resume_${TARGET}`, TARGET, `id_${TARGET}`, NET]);
 }
 
-function sendTaskHandler(): ToolHandler {
+function sendTaskHandler(auth?: { callerAlias: string; nodeToken: boolean }): ToolHandler {
   const server = new McpServer({ name: "idempotency-test", version: "0" }) as any;
   let handler: ToolHandler | undefined;
   const original = server.tool.bind(server);
@@ -38,7 +38,15 @@ function sendTaskHandler(): ToolHandler {
     if (name === "send_task") handler = candidate;
     return original(name, description, schema, candidate);
   };
-  registerTools(server, undefined, NET, USER, USER, false, null);
+  registerTools(
+    server,
+    undefined,
+    NET,
+    USER,
+    auth?.callerAlias ?? USER,
+    auth?.nodeToken ?? false,
+    auth?.nodeToken ? "token_node_chat_idem" : null,
+  );
   if (!handler) throw new Error("send_task handler missing");
   return handler;
 }
@@ -69,6 +77,23 @@ describe("send_task durable idempotency", () => {
     const inbox = db.get<{ meta_json: string }>("SELECT meta_json FROM inbox WHERE id = ?1", [sent.message_id]);
     expect(JSON.parse(task!.meta_json).auth_origin).toBe("user");
     expect(JSON.parse(inbox!.meta_json).auth_origin).toBe("user");
+  });
+
+  test("network-token caller cannot forge Dashboard user origin through MCP", async () => {
+    const handler = sendTaskHandler({ callerAlias: "node-origin-sender", nodeToken: true });
+    const sent = await call(handler, {
+      alias: TARGET,
+      task: "node attempts user-origin spoof",
+      priority: "normal",
+      meta: {
+        source: "dashboard-chat",
+        client_request_id: "dreq_fedcba9876543210fedcba9876543210",
+        auth_origin: "user",
+      },
+    });
+    expect(sent.ok).toBe(true);
+    const inbox = db.get<{ meta_json: string }>("SELECT meta_json FROM inbox WHERE id = ?1", [sent.message_id]);
+    expect(JSON.parse(inbox!.meta_json).auth_origin).toBe("node");
   });
 
   test("lost-response retry returns the original task and does not enqueue twice", async () => {

--- a/server/src/task-idempotency.test.ts
+++ b/server/src/task-idempotency.test.ts
@@ -34,6 +34,18 @@ describe("dashboard task idempotency", () => {
     })).toBe(true);
   });
 
+  test("rolling upgrade ignores the new server-only auth stamp for replay equality", () => {
+    const row: StoredIdempotentTask = {
+      task_id: "idem_x", from_name: "admin", to_name: "worker", priority: "normal",
+      content: "hello", network_id: "net_a", status: "delivered",
+      meta_json: JSON.stringify({ client_request_id: "dreq_0123456789abcdef", source: "dashboard-chat" }),
+    };
+    expect(idempotentTaskMatches(row, {
+      fromName: "admin", toName: "worker", priority: "normal", content: "hello", networkId: "net_a",
+      metaJson: JSON.stringify({ client_request_id: "dreq_0123456789abcdef", source: "dashboard-chat", auth_origin: "user" }),
+    })).toBe(true);
+  });
+
   test("same request id with changed payload is a conflict", () => {
     const row: StoredIdempotentTask = {
       task_id: "idem_x", from_name: "admin", to_name: "worker", priority: "normal",

--- a/server/src/task-idempotency.ts
+++ b/server/src/task-idempotency.ts
@@ -55,11 +55,21 @@ function parsedMeta(value: string | null): unknown {
   try { return JSON.parse(value); } catch { return value; }
 }
 
+function logicalRequestMeta(value: string | null): unknown {
+  const parsed = parsedMeta(value);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return parsed;
+  // auth_origin is a Hub-derived audit fact, not part of the client request.
+  // Ignore it for replay equality so a request first accepted by the old Hub
+  // (without the stamp) remains idempotent across a rolling upgrade.
+  const { auth_origin: _authOrigin, ...logical } = parsed as Record<string, unknown>;
+  return logical;
+}
+
 export function idempotentTaskMatches(row: StoredIdempotentTask, expected: ExpectedIdempotentTask): boolean {
   return row.from_name === expected.fromName
     && row.to_name === expected.toName
     && row.priority === expected.priority
     && row.content === expected.content
     && (row.network_id ?? null) === (expected.networkId ?? null)
-    && canonicalJson(parsedMeta(row.meta_json)) === canonicalJson(parsedMeta(expected.metaJson));
+    && canonicalJson(logicalRequestMeta(row.meta_json)) === canonicalJson(logicalRequestMeta(expected.metaJson));
 }

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -56,6 +56,7 @@ import {
 } from "./config-apply-validate.js";
 import { sharedSendDedup, buildDuplicateSendPayload } from "./send_dedup.js";
 import { clientRequestIdFromMeta, idempotentTaskId, idempotentTaskMatches, type StoredIdempotentTask } from "./task-idempotency.js";
+import { stampTaskAuthOrigin, type TaskAuthOrigin } from "./task-auth-origin.js";
 
 function ts(): string {
   return new Date().toTimeString().slice(0, 8);
@@ -839,7 +840,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     },
     async ({ alias, task, priority, context, from_session: _fromIn, ttl_seconds, network_id: netId, parent_task_id: parentIn, meta }) => { const fromMismatch = fromIdentityMismatchReply(_fromIn); if (fromMismatch) return fromMismatch; const from_session = defaultFrom(_fromIn);
       const effectiveNetId = getNetworkId(netId);
-      const metaJson = normalizeMetaJson(meta);
+      const authOrigin: TaskAuthOrigin = callerTokenIsNetwork
+        ? "node"
+        : enforceUserId
+          ? "user"
+          : "legacy";
+      const metaJson = normalizeMetaJson(stampTaskAuthOrigin(meta, authOrigin));
 
       // Role check FIRST — round5 follow-up (通信牛 oracle catch):
       // the explicit-parent verification below distinguishes

--- a/tests/test584-dashboard-codex-delivery/Dockerfile
+++ b/tests/test584-dashboard-codex-delivery/Dockerfile
@@ -1,0 +1,17 @@
+ARG SOURCE_COMMIT
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY agent-node/src ./agent-node/src
+COPY server/src ./server/src
+COPY tests/test584-dashboard-codex-delivery/run.sh /harness/run.sh
+COPY tests/test584-dashboard-codex-delivery/mutate.ts /harness/mutate.ts
+RUN chmod 0755 /harness/run.sh
+
+ARG SOURCE_COMMIT
+ENV TEST584_SOURCE_COMMIT=$SOURCE_COMMIT
+ENTRYPOINT ["/harness/run.sh"]

--- a/tests/test584-dashboard-codex-delivery/mutate.ts
+++ b/tests/test584-dashboard-codex-delivery/mutate.ts
@@ -1,0 +1,8 @@
+import { readFileSync, writeFileSync } from "fs";
+
+const [file, before, after] = process.argv.slice(2);
+if (!file || before === undefined || after === undefined) throw new Error("usage: mutate.ts FILE BEFORE AFTER");
+const source = readFileSync(file, "utf8");
+const occurrences = source.split(before).length - 1;
+if (occurrences !== 1) throw new Error(`mutation anchor count=${occurrences}, expected=1: ${before}`);
+writeFileSync(file, source.replace(before, after));

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -84,6 +84,13 @@ bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
 expect_red reconnect-network-turn-stays-fifo bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
 cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
 
+cp agent-node/src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
+bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
+  '!/^\\s*\\[Agent Network(?:\\/|\\])/u.test(firstUserText)' \
+  '!/^\\[Agent Network(?:\\/|\\])/u.test(firstUserText)'
+expect_red leading-whitespace-network-prefix-stays-fifo bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
+cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
+
 cp server/src/tools.ts /tmp/server-tools.ts
 bun /harness/mutate.ts server/src/tools.ts \
   'normalizeMetaJson(stampTaskAuthOrigin(meta, authOrigin))' \

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -77,4 +77,20 @@ bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
 expect_red accepted-steer-must-reply bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
 cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
 
+cp server/src/tools.ts /tmp/server-tools.ts
+bun /harness/mutate.ts server/src/tools.ts \
+  'normalizeMetaJson(stampTaskAuthOrigin(meta, authOrigin))' \
+  'normalizeMetaJson(meta)'
+export COMMHUB_DB=/tmp/test584-mutation-mcp.db
+expect_red mcp-node-cannot-forge-user-origin bun test server/src/task-idempotency-mcp.test.ts
+cp /tmp/server-tools.ts server/src/tools.ts
+
+cp server/src/server.ts /tmp/server-server.ts
+bun /harness/mutate.ts server/src/server.ts \
+  'normalizeMetaJson(stampTaskAuthOrigin(mergedMeta, authOrigin))' \
+  'normalizeMetaJson(mergedMeta)'
+export COMMHUB_DB=/tmp/test584-mutation-rest.db
+expect_red rest-node-cannot-forge-user-origin bun test server/src/task-auth-origin-http.test.ts
+cp /tmp/server-server.ts server/src/server.ts
+
 echo "RESULT: PASS"

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "TEST584 source=${TEST584_SOURCE_COMMIT:-unknown}"
+
+echo "L1 source/build gates"
+test -f agent-node/src/inbox-dispatch.ts
+test -f server/src/task-auth-origin.ts
+bun build agent-node/src/cli.ts \
+  --outdir /tmp/test584-dist \
+  --entry-naming cli.js \
+  --target node \
+  --external @anthropic-ai/claude-agent-sdk \
+  --external '@anthropic-ai/claude-agent-sdk-*' \
+  --external @openai/codex-sdk
+test -s /tmp/test584-dist/cli.js
+
+echo "L2 agent bridge + dispatch"
+bun test \
+  agent-node/src/inbox-dispatch.test.ts \
+  agent-node/src/runtime/codex-app-server-bridge.test.ts \
+  agent-node/src/runtime/codex-app-server/runtime.test.ts
+
+echo "L3 Hub auth boundary + rolling idempotency"
+export NODE_ENV=test
+export COMMHUB_DB=/tmp/test584-hub.db
+bun test \
+  server/src/task-auth-origin.test.ts \
+  server/src/task-idempotency.test.ts \
+  server/src/task-idempotency-mcp.test.ts
+
+echo "L4 real private HTTP Hub user/node origin"
+export COMMHUB_DB=/tmp/test584-http.db
+bun test server/src/task-auth-origin-http.test.ts
+
+expect_red() {
+  local label=$1
+  shift
+  set +e
+  "$@" >/tmp/test584-mutation.log 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "MUTATION_FALSE_GREEN: $label"
+    cat /tmp/test584-mutation.log
+    exit 1
+  fi
+  echo "MUTATION_RED: $label rc=$rc"
+}
+
+echo "L5 witnessed-red security/correctness mutations"
+cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
+bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
+  'if (meta.auth_origin === "user") return true;' \
+  'if (meta.auth_origin === "user" || meta.auth_origin === "node") return true;'
+expect_red node-origin-cannot-steer bun test agent-node/src/inbox-dispatch.test.ts
+cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
+
+cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
+bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
+  'if (concurrent) {' \
+  'if (false) {'
+expect_red no-head-of-line-serialization bun test agent-node/src/inbox-dispatch.test.ts
+cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
+
+cp agent-node/src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
+bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
+  '        expectedTurnId,' \
+  '        /* expectedTurnId deliberately removed */'
+expect_red exact-expected-turn-id bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
+cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
+
+cp agent-node/src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
+bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
+  '        this.emitSteeredTask(steered, task, steered.terminal);' \
+  '        /* reply attribution deliberately removed */'
+expect_red accepted-steer-must-reply bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
+cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
+
+echo "RESULT: PASS"

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -51,8 +51,8 @@ expect_red() {
 echo "L5 witnessed-red security/correctness mutations"
 cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
 bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
-  'if (meta.auth_origin === "user") return true;' \
-  'if (meta.auth_origin === "user" || meta.auth_origin === "node") return true;'
+  'return meta.auth_origin === "user";' \
+  'return meta.auth_origin === "user" || meta.auth_origin === "node";'
 expect_red node-origin-cannot-steer bun test agent-node/src/inbox-dispatch.test.ts
 cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
 

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -86,8 +86,8 @@ cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridg
 
 cp agent-node/src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
 bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
-  '!/^\\s*\\[Agent Network(?:\\/|\\])/u.test(firstUserText)' \
-  '!/^\\[Agent Network(?:\\/|\\])/u.test(firstUserText)'
+  '!/^\s*\[Agent Network(?:\/|\])/u.test(firstUserText)' \
+  '!/^\[Agent Network(?:\/|\])/u.test(firstUserText)'
 expect_red leading-whitespace-network-prefix-stays-fifo bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
 cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
 

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -77,6 +77,13 @@ bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
 expect_red accepted-steer-must-reply bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
 cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
 
+cp agent-node/src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
+bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
+  'if (input.steerIfExternalTurn && this.externalActiveTurnSteerable) {' \
+  'if (input.steerIfExternalTurn) {'
+expect_red reconnect-network-turn-stays-fifo bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
+cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
+
 cp server/src/tools.ts /tmp/server-tools.ts
 bun /harness/mutate.ts server/src/tools.ts \
   'normalizeMetaJson(stampTaskAuthOrigin(meta, authOrigin))' \


### PR DESCRIPTION
> **Authored by 通信牛.** Opened on its behalf — its bridge processes roughly one inbox item per 600s deadline.

## The defect

When a human turn is active on a shared codex thread, the bridge could only queue network tasks FIFO. Each queued item then waited out its own 600s node deadline, so **one long human turn wedged everything behind it indefinitely**. Production evidence: inbox rows with `target=通信牛, acked=0` sitting undelivered while the bridge had already received the SSE.

This is why Dashboard messages to a copresence node appeared to vanish.

## The fix

Use the app-server's `turn/steer` to append a Dashboard chat message into the turn already running, instead of waiting for idle.

**Only messages the Hub itself authenticated as coming from a user are eligible.** That constraint is what makes this safe, and it was not the first design.

## How the safety argument was reached

The first version proposed steering *any* network task into a human's turn and mapping the turn's final answer back as the reply. That is the same shape as a defect fixed earlier today (#574): a reply belonging to the human's turn returned to a network peer. Steering makes it worse, because it actively injects into someone else's conversation.

The author's answer was better than the check I asked for: **narrow the eligible set so the attribution problem cannot arise.** Only a `dashboard-chat` task stamped `auth_origin=user` by the server steers — so both sides of that turn are the same principal. Ordinary agent tasks still queue FIFO and never touch a human turn.

That moves the entire safety argument onto one assumption: **`auth_origin` is stamped server-side and cannot be forged.** So that is what the review had to pin.

## Independent review

| point | result |
|---|---|
| `auth_origin` stamped server-side on both transports; a node token supplying `auth_origin:user` is stored as `node` | PASS, mutation red on MCP and REST separately |
| no third write path — only two `INSERT INTO tasks` sites carry `meta_json` | PASS |
| ordinary agent tasks still FIFO (no accidental concurrency) | PASS |
| steer race requeues rather than drops | PASS |
| ack happens only after a reliable reply — `task_steered` is not completion | PASS |
| rolling idempotency ignores the server-only stamp without collapsing genuinely different requests | PASS |

## A legacy path that was removed rather than guarded

Review flagged a residual: a historical row with no stamp but `from_session=admin` would still qualify. Chasing that produced a harder fact — **the production Hub is `0.9.0-preview.26`, which predates the REST identity binding merged today (#571)**. On that Hub a node token can still claim `from=admin` over REST. Deploying this bridge ahead of the Hub would therefore have handed any node write access into a human's turn.

The author deleted the legacy path outright instead of hardening it. Unstamped rows now take the ordinary FIFO route; no identity is inferred from an alias.

Verified: `isInteractiveDashboardTask` requires `auth_origin === "user"`, and the legacy admin branch is gone.

## Deployment

The feature is **inert until the Hub is upgraded** — with no stamp, nothing steers. Confirmed fail-closed rather than permanently disabled: once the Hub stamps, steering activates with no additional switch.

Production currently runs Dashboard `54150269` and Hub `preview.26`. Hub first, then the bridge.