### PR TITLE
fix(codex-app-server): drain later Dashboard SSE tasks live

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -96,8 +96,8 @@ import {
 import { OPENCODE_DEFAULT_PIN } from "./runtime/opencode-acp/binary";
 import { createInboxDrainLane, drainInboxBatch } from "./runtime/inbox-drain-lane";
 import {
+  createDetachedInboxDispatcher,
   dispatchInboxBatch,
-  dispatchInboxBatchDetached,
   isInteractiveDashboardTask,
   shouldDrainPendingReplies,
 } from "./inbox-dispatch";
@@ -1267,6 +1267,23 @@ const informationalInboxDrain = createInboxDrainLane((cause) => {
   const error = cause as any;
   warn(`inbox informational drain failed: ${error?.message || error}`);
 }, INBOX_RETRY);
+
+// One Hub get_inbox page is 20 rows. Keep at most one page of Codex handlers
+// active; later unique rows wait in this dispatcher and enter bridge
+// arbitration as slots settle. The bridge independently guarantees at most
+// one turn/start per thread and FIFO-queues ordinary network tasks.
+const CODEX_INBOX_MAX_CONCURRENT = 20;
+const codexInboxDispatcher = createDetachedInboxDispatcher<any>({
+  maxConcurrent: CODEX_INBOX_MAX_CONCURRENT,
+  key: (message) => String(message.id),
+  onError: (cause) => {
+    const detachedError = cause as any;
+    warn(`detached codex inbox row failed: ${detachedError?.message || detachedError}`);
+  },
+  // Advance beyond get_inbox's first 20 unacked rows and retry a failed row.
+  // The work lane coalesces simultaneous completions into a bounded dirty run.
+  onSettled: scheduleWorkInboxDrain,
+});
 
 function isGoalCommand(content: string): boolean {
   return /^\s*\/(?:goal|loop)\b/i.test(content || "");
@@ -3716,12 +3733,10 @@ async function processInbox() {
   // the serialized fetch lane. Other runtimes retain their historical
   // awaited/serialized drain.
   if (RUNTIME === "codex-app-server") {
-    dispatchInboxBatchDetached(messages, processInboxMessage, (cause) => {
-      const detachedError = cause as any;
-      warn(`detached codex inbox row failed: ${detachedError?.message || detachedError}`);
-      const retryTimer = setTimeout(scheduleWorkInboxDrain, INBOX_RETRY.initialDelayMs);
-      retryTimer.unref?.();
-    });
+    const dispatch = codexInboxDispatcher.submit(messages, processInboxMessage);
+    if (dispatch.queued > 0) {
+      debug(`codex inbox admission: active=${dispatch.active}, queued=${dispatch.queued}`);
+    }
     return;
   }
   await dispatchInboxBatch(messages, processInboxMessage, false);

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -3739,7 +3739,7 @@ async function processInbox() {
     }
     return;
   }
-  await dispatchInboxBatch(messages, processInboxMessage, false);
+  await dispatchInboxBatch(messages, processInboxMessage);
 }
 
 /**

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -95,7 +95,12 @@ import {
 } from "./runtime/opencode-acp/profile-state";
 import { OPENCODE_DEFAULT_PIN } from "./runtime/opencode-acp/binary";
 import { createInboxDrainLane, drainInboxBatch } from "./runtime/inbox-drain-lane";
-import { dispatchInboxBatch, isInteractiveDashboardTask } from "./inbox-dispatch";
+import {
+  dispatchInboxBatch,
+  dispatchInboxBatchDetached,
+  isInteractiveDashboardTask,
+  shouldDrainPendingReplies,
+} from "./inbox-dispatch";
 import { createSingleFlight } from "./util/single-flight";
 
 const home = homedir();
@@ -3606,7 +3611,9 @@ function shouldSkipMessage(from: string, content: string, msgType?: string): str
 //         loud warn — retrying would not help.
 async function processInbox() {
   // (1) Drain leftovers from previous runs.
-  await drainPendingReplies();
+  if (shouldDrainPendingReplies(RUNTIME, inflightMessageIds.size)) {
+    await drainPendingReplies();
+  }
 
   const messages = await getInbox();
   if (!messages.length) return;
@@ -3701,13 +3708,23 @@ async function processInbox() {
     }
   };
 
-  // Every Codex app-server row must reach bridge arbitration immediately.
-  // Other runtimes retain the historical serialized drain.
-  await dispatchInboxBatch(
-    messages,
-    processInboxMessage,
-    RUNTIME === "codex-app-server",
-  );
+  // Every Codex app-server row must reach bridge arbitration immediately,
+  // including rows announced by a *later* SSE wake. Waiting for Promise.all
+  // here keeps workInboxDrain occupied for the whole model turn; its dirty
+  // rerun cannot fetch that later row until the first turn times out. Submit
+  // Codex rows after taking their synchronous inflight claims, then release
+  // the serialized fetch lane. Other runtimes retain their historical
+  // awaited/serialized drain.
+  if (RUNTIME === "codex-app-server") {
+    dispatchInboxBatchDetached(messages, processInboxMessage, (cause) => {
+      const detachedError = cause as any;
+      warn(`detached codex inbox row failed: ${detachedError?.message || detachedError}`);
+      const retryTimer = setTimeout(scheduleWorkInboxDrain, INBOX_RETRY.initialDelayMs);
+      retryTimer.unref?.();
+    });
+    return;
+  }
+  await dispatchInboxBatch(messages, processInboxMessage, false);
 }
 
 /**

--- a/agent-node/src/inbox-dispatch-wiring.test.ts
+++ b/agent-node/src/inbox-dispatch-wiring.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const cli = readFileSync(join(import.meta.dir, "cli.ts"), "utf8");
+
+describe("Codex app-server live inbox kick wiring", () => {
+  test("a Codex snapshot releases the serialized fetch lane after submission", () => {
+    const start = cli.indexOf("async function processInbox()");
+    const end = cli.indexOf("async function processOpencodeCopresenceMessages()", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const processInbox = cli.slice(start, end);
+
+    expect(processInbox).toContain('if (RUNTIME === "codex-app-server")');
+    expect(processInbox).toContain("dispatchInboxBatchDetached(messages, processInboxMessage");
+    expect(processInbox).toContain("await dispatchInboxBatch(messages, processInboxMessage, false)");
+  });
+
+  test("pending reply drain is fenced while detached Codex rows are active", () => {
+    const start = cli.indexOf("async function processInbox()");
+    const end = cli.indexOf("const messages = await getInbox()", start);
+    const prelude = cli.slice(start, end);
+    expect(prelude).toContain("shouldDrainPendingReplies(RUNTIME, inflightMessageIds.size)");
+    expect(prelude).toContain("await drainPendingReplies()");
+  });
+});

--- a/agent-node/src/inbox-dispatch-wiring.test.ts
+++ b/agent-node/src/inbox-dispatch-wiring.test.ts
@@ -14,7 +14,7 @@ describe("Codex app-server live inbox kick wiring", () => {
 
     expect(processInbox).toContain('if (RUNTIME === "codex-app-server")');
     expect(processInbox).toContain("codexInboxDispatcher.submit(messages, processInboxMessage)");
-    expect(processInbox).toContain("await dispatchInboxBatch(messages, processInboxMessage, false)");
+    expect(processInbox).toContain("await dispatchInboxBatch(messages, processInboxMessage)");
   });
 
   test("Codex detached admission is explicitly bounded and completion wakes the Hub window", () => {

--- a/agent-node/src/inbox-dispatch-wiring.test.ts
+++ b/agent-node/src/inbox-dispatch-wiring.test.ts
@@ -13,8 +13,14 @@ describe("Codex app-server live inbox kick wiring", () => {
     const processInbox = cli.slice(start, end);
 
     expect(processInbox).toContain('if (RUNTIME === "codex-app-server")');
-    expect(processInbox).toContain("dispatchInboxBatchDetached(messages, processInboxMessage");
+    expect(processInbox).toContain("codexInboxDispatcher.submit(messages, processInboxMessage)");
     expect(processInbox).toContain("await dispatchInboxBatch(messages, processInboxMessage, false)");
+  });
+
+  test("Codex detached admission is explicitly bounded and completion wakes the Hub window", () => {
+    expect(cli).toContain("const CODEX_INBOX_MAX_CONCURRENT = 20;");
+    expect(cli).toContain("maxConcurrent: CODEX_INBOX_MAX_CONCURRENT");
+    expect(cli).toContain("onSettled: scheduleWorkInboxDrain");
   });
 
   test("pending reply drain is fenced while detached Codex rows are active", () => {

--- a/agent-node/src/inbox-dispatch.test.ts
+++ b/agent-node/src/inbox-dispatch.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createDetachedInboxDispatcher,
   dispatchInboxBatch,
@@ -6,6 +9,7 @@ import {
   shouldDrainPendingReplies,
 } from "./inbox-dispatch";
 import { createInboxDrainLane } from "./runtime/inbox-drain-lane";
+import { PendingReplyQueue } from "./reply-reliability";
 
 const requestId = "dreq_0123456789abcdef0123456789abcdef";
 
@@ -48,28 +52,14 @@ describe("isInteractiveDashboardTask", () => {
 });
 
 describe("dispatchInboxBatch", () => {
-  test("concurrent mode submits later dashboard rows before the first turn completes", async () => {
-    let releaseFirst!: () => void;
-    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
-    const entered: number[] = [];
-    const running = dispatchInboxBatch([1, 2, 3], async (value) => {
-      entered.push(value);
-      if (value === 1) await firstBlocked;
-    }, true);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(entered).toEqual([1, 2, 3]);
-    releaseFirst();
-    await running;
-  });
-
-  test("sequential mode preserves legacy runtime serialization", async () => {
+  test("awaited batches preserve legacy runtime serialization", async () => {
     let releaseFirst!: () => void;
     const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
     const entered: number[] = [];
     const running = dispatchInboxBatch([1, 2], async (value) => {
       entered.push(value);
       if (value === 1) await firstBlocked;
-    }, false);
+    });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(entered).toEqual([1]);
     releaseFirst();
@@ -226,5 +216,36 @@ describe("dispatchInboxBatch", () => {
     expect(shouldDrainPendingReplies("codex-app-server", 1)).toBe(false);
     expect(shouldDrainPendingReplies("codex-app-server", 0)).toBe(true);
     expect(shouldDrainPendingReplies("opencode", 3)).toBe(true);
+  });
+
+  test("active Codex direct delivery and durable drain send one reply, not two", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "test584-pending-singleflight-"));
+    try {
+      const queue = new PendingReplyQueue(join(dir, "pending.json"));
+      queue.persist({
+        to: "admin",
+        text: "one final reply",
+        taskId: "dashboard-task",
+        failed: false,
+        queuedAt: 1,
+      });
+      let sends = 0;
+      if (shouldDrainPendingReplies("codex-app-server", 1)) {
+        await queue.drain(async () => { sends++; });
+      }
+
+      // The active handler owns direct send/clear while the durable drain is
+      // fenced. Its completion wake sees an empty queue.
+      sends++;
+      queue.clear("admin", "dashboard-task");
+      if (shouldDrainPendingReplies("codex-app-server", 0)) {
+        await queue.drain(async () => { sends++; });
+      }
+
+      expect(sends).toBe(1);
+      expect(queue.load()).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/agent-node/src/inbox-dispatch.test.ts
+++ b/agent-node/src/inbox-dispatch.test.ts
@@ -158,6 +158,30 @@ describe("dispatchInboxBatch", () => {
     expect(settled).toBe(1);
   });
 
+  test("a throwing settle callback cannot strand queued N+1 work", async () => {
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const entered: number[] = [];
+    const errors: unknown[] = [];
+    const dispatcher = createDetachedInboxDispatcher<number>({
+      maxConcurrent: 1,
+      key: String,
+      onError: (error) => errors.push(error),
+      onSettled: () => { throw new Error("wake callback failed"); },
+    });
+    dispatcher.submit([1, 2], async (value) => {
+      entered.push(value);
+      if (value === 1) await firstBlocked;
+    });
+    expect(entered).toEqual([1]);
+
+    releaseFirst();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(entered).toEqual([1, 2]);
+    expect(errors).toHaveLength(2);
+    expect((errors[0] as Error).message).toBe("wake callback failed");
+  });
+
   test("same-tick duplicate kicks claim one row exactly once", async () => {
     let release!: () => void;
     const blocked = new Promise<void>((resolve) => { release = resolve; });

--- a/agent-node/src/inbox-dispatch.test.ts
+++ b/agent-node/src/inbox-dispatch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
+  createDetachedInboxDispatcher,
   dispatchInboxBatch,
-  dispatchInboxBatchDetached,
   isInteractiveDashboardTask,
   shouldDrainPendingReplies,
 } from "./inbox-dispatch";
@@ -86,9 +86,14 @@ describe("dispatchInboxBatch", () => {
       entered.push(value);
       if (value === 1) await firstBlocked;
     };
+    const dispatcher = createDetachedInboxDispatcher<number>({
+      maxConcurrent: 2,
+      key: String,
+      onError: (error) => errors.push(error),
+    });
 
-    dispatchInboxBatchDetached([1], handler, (error) => errors.push(error));
-    dispatchInboxBatchDetached([2], handler, (error) => errors.push(error));
+    dispatcher.submit([1], handler);
+    dispatcher.submit([2], handler);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(entered).toEqual([1, 2]);
@@ -106,15 +111,20 @@ describe("dispatchInboxBatch", () => {
     const entered: number[] = [];
     const errors: unknown[] = [];
     const lane = createInboxDrainLane((error) => errors.push(error));
+    const dispatcher = createDetachedInboxDispatcher<number>({
+      maxConcurrent: 2,
+      key: String,
+      onError: (error) => errors.push(error),
+    });
     const drain = async () => {
       const snapshot = snapshots.shift() || [];
-      dispatchInboxBatchDetached(snapshot, async (value) => {
+      dispatcher.submit(snapshot, async (value) => {
         entered.push(value);
         if (value === 1) {
           firstEntered();
           await firstBlocked;
         }
-      }, (error) => errors.push(error));
+      });
     };
 
     lane.schedule(drain);
@@ -132,12 +142,84 @@ describe("dispatchInboxBatch", () => {
 
   test("detached completion failures remain observable", async () => {
     const errors: unknown[] = [];
-    dispatchInboxBatchDetached(["late-row"], async () => {
+    const dispatcher = createDetachedInboxDispatcher<string>({
+      maxConcurrent: 1,
+      key: String,
+      onError: (error) => errors.push(error),
+    });
+    dispatcher.submit(["late-row"], async () => {
       throw new Error("detached row failed");
-    }, (error) => errors.push(error));
+    });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(errors).toHaveLength(1);
     expect((errors[0] as Error).message).toBe("detached row failed");
+  });
+
+  test("settling detached work emits a wake for the next Hub inbox window", async () => {
+    let settled = 0;
+    const dispatcher = createDetachedInboxDispatcher<string>({
+      maxConcurrent: 1,
+      key: String,
+      onError: () => {},
+      onSettled: () => { settled++; },
+    });
+    dispatcher.submit(["row"], async () => {});
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toBe(1);
+  });
+
+  test("same-tick duplicate kicks claim one row exactly once", async () => {
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => { release = resolve; });
+    let calls = 0;
+    const dispatcher = createDetachedInboxDispatcher<{ id: string }>({
+      maxConcurrent: 2,
+      key: (message) => message.id,
+      onError: () => {},
+    });
+    const handler = async () => {
+      calls++;
+      await blocked;
+    };
+
+    const first = dispatcher.submit([{ id: "same-row" }], handler);
+    const second = dispatcher.submit([{ id: "same-row" }], handler);
+
+    expect(calls).toBe(1);
+    expect(first.accepted).toBe(1);
+    expect(second.deduplicated).toBe(1);
+    release();
+    await blocked;
+  });
+
+  test("bounded admission waits N+1 and starts it after a slot settles", async () => {
+    const releases = new Map<number, () => void>();
+    const gates = new Map<number, Promise<void>>();
+    for (const value of [1, 2, 3]) {
+      gates.set(value, new Promise<void>((resolve) => releases.set(value, resolve)));
+    }
+    const entered: number[] = [];
+    const dispatcher = createDetachedInboxDispatcher<number>({
+      maxConcurrent: 2,
+      key: String,
+      onError: () => {},
+    });
+
+    const admission = dispatcher.submit([1, 2, 3], async (value) => {
+      entered.push(value);
+      await gates.get(value)!;
+    });
+    expect(admission).toMatchObject({ active: 2, queued: 1, accepted: 3 });
+    expect(entered).toEqual([1, 2]);
+
+    releases.get(1)!();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(entered).toEqual([1, 2, 3]);
+    expect(dispatcher.stats()).toEqual({ active: 2, queued: 0 });
+
+    releases.get(2)!();
+    releases.get(3)!();
+    await Promise.all([...gates.values()]);
   });
 
   test("durable reply drain waits until detached Codex rows finish", () => {

--- a/agent-node/src/inbox-dispatch.test.ts
+++ b/agent-node/src/inbox-dispatch.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { dispatchInboxBatch, isInteractiveDashboardTask } from "./inbox-dispatch";
+import {
+  dispatchInboxBatch,
+  dispatchInboxBatchDetached,
+  isInteractiveDashboardTask,
+  shouldDrainPendingReplies,
+} from "./inbox-dispatch";
+import { createInboxDrainLane } from "./runtime/inbox-drain-lane";
 
 const requestId = "dreq_0123456789abcdef0123456789abcdef";
 
@@ -69,5 +75,74 @@ describe("dispatchInboxBatch", () => {
     releaseFirst();
     await running;
     expect(entered).toEqual([1, 2]);
+  });
+
+  test("a later SSE snapshot enters while the first detached turn is still running", async () => {
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const entered: number[] = [];
+    const errors: unknown[] = [];
+    const handler = async (value: number) => {
+      entered.push(value);
+      if (value === 1) await firstBlocked;
+    };
+
+    dispatchInboxBatchDetached([1], handler, (error) => errors.push(error));
+    dispatchInboxBatchDetached([2], handler, (error) => errors.push(error));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(entered).toEqual([1, 2]);
+    expect(errors).toEqual([]);
+    releaseFirst();
+    await firstBlocked;
+  });
+
+  test("the real serialized drain lane can fetch a later SSE snapshot before the active turn ends", async () => {
+    let releaseFirst!: () => void;
+    let firstEntered!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const firstStarted = new Promise<void>((resolve) => { firstEntered = resolve; });
+    const snapshots = [[1], [2]];
+    const entered: number[] = [];
+    const errors: unknown[] = [];
+    const lane = createInboxDrainLane((error) => errors.push(error));
+    const drain = async () => {
+      const snapshot = snapshots.shift() || [];
+      dispatchInboxBatchDetached(snapshot, async (value) => {
+        entered.push(value);
+        if (value === 1) {
+          firstEntered();
+          await firstBlocked;
+        }
+      }, (error) => errors.push(error));
+    };
+
+    lane.schedule(drain);
+    await firstStarted;
+    // This models a new_task SSE arriving after get_inbox snapshot #1 has
+    // already submitted a long-running model turn.
+    lane.schedule(drain);
+    await lane.idle();
+
+    expect(entered).toEqual([1, 2]);
+    expect(errors).toEqual([]);
+    releaseFirst();
+    await firstBlocked;
+  });
+
+  test("detached completion failures remain observable", async () => {
+    const errors: unknown[] = [];
+    dispatchInboxBatchDetached(["late-row"], async () => {
+      throw new Error("detached row failed");
+    }, (error) => errors.push(error));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("detached row failed");
+  });
+
+  test("durable reply drain waits until detached Codex rows finish", () => {
+    expect(shouldDrainPendingReplies("codex-app-server", 1)).toBe(false);
+    expect(shouldDrainPendingReplies("codex-app-server", 0)).toBe(true);
+    expect(shouldDrainPendingReplies("opencode", 3)).toBe(true);
   });
 });

--- a/agent-node/src/inbox-dispatch.ts
+++ b/agent-node/src/inbox-dispatch.ts
@@ -37,20 +37,10 @@ export function isInteractiveDashboardTask(message: InboxDispatchMessage): boole
   return meta.auth_origin === "user";
 }
 
-/**
- * Codex app-server owns its own FIFO/steer arbitration, so inbox entries must
- * be submitted concurrently. Sequentially awaiting entry 1 recreates the
- * production head-of-line bug: entries 2..N cannot steer the same human turn.
- */
 export async function dispatchInboxBatch<T>(
   messages: readonly T[],
   handler: (message: T) => Promise<void>,
-  concurrent: boolean,
 ): Promise<void> {
-  if (concurrent) {
-    await Promise.all(messages.map((message) => handler(message)));
-    return;
-  }
   for (const message of messages) await handler(message);
 }
 

--- a/agent-node/src/inbox-dispatch.ts
+++ b/agent-node/src/inbox-dispatch.ts
@@ -60,23 +60,93 @@ export async function dispatchInboxBatch<T>(
  * as every row has entered bridge arbitration; otherwise a later SSE wake is
  * only marked dirty and sits behind the first row's (up to ten-minute) turn.
  *
- * Calling the async handler directly is intentional: it runs synchronously
- * through its per-row inflight claim before yielding, so a following inbox
- * snapshot cannot double-submit the same row. Completion errors remain
- * observable through `onError` and can schedule a fresh inbox read.
+ * The bounded dispatcher claims each Hub row key synchronously before calling
+ * its async handler, deduplicates later snapshots, and queues N+1 work. Its
+ * completion hook keeps reading beyond Hub's first unacked page. Completion
+ * errors remain observable through `onError`.
  */
-export function dispatchInboxBatchDetached<T>(
-  messages: readonly T[],
-  handler: (message: T) => Promise<void>,
-  onError: (error: unknown) => void,
-): void {
-  for (const message of messages) {
-    try {
-      void handler(message).catch(onError);
-    } catch (error) {
-      onError(error);
-    }
+export interface DetachedInboxDispatcherStats {
+  active: number;
+  queued: number;
+  accepted: number;
+  deduplicated: number;
+}
+
+export interface DetachedInboxDispatcher<T> {
+  submit(messages: readonly T[], handler: (message: T) => Promise<void>): DetachedInboxDispatcherStats;
+  stats(): Pick<DetachedInboxDispatcherStats, "active" | "queued">;
+}
+
+/**
+ * Keep detached inbox work bounded and deduplicated across later SSE snapshots.
+ * The key is claimed before invoking the async handler, so two kicks in the
+ * same tick cannot double-submit one Hub row. N+1 work waits in the local FIFO
+ * and is started automatically when any active handler settles.
+ */
+export function createDetachedInboxDispatcher<T>(opts: {
+  maxConcurrent: number;
+  key: (message: T) => string;
+  onError: (error: unknown) => void;
+  onSettled?: () => void;
+}): DetachedInboxDispatcher<T> {
+  if (!Number.isInteger(opts.maxConcurrent) || opts.maxConcurrent < 1) {
+    throw new Error("maxConcurrent must be a positive integer");
   }
+  const activeKeys = new Set<string>();
+  const queuedKeys = new Set<string>();
+  const queue: Array<{ message: T; handler: (message: T) => Promise<void> }> = [];
+
+  const pump = () => {
+    while (activeKeys.size < opts.maxConcurrent && queue.length > 0) {
+      const item = queue.shift()!;
+      const key = opts.key(item.message);
+      queuedKeys.delete(key);
+      // Claim before invoking handler: an async function runs synchronously
+      // until its first await, but the dispatcher does not depend on that
+      // language detail for cross-snapshot deduplication.
+      activeKeys.add(key);
+      let running: Promise<void>;
+      try {
+        running = item.handler(item.message);
+      } catch (error) {
+        running = Promise.reject(error);
+      }
+      void running
+        .catch(opts.onError)
+        .finally(() => {
+          activeKeys.delete(key);
+          opts.onSettled?.();
+          pump();
+        });
+    }
+  };
+
+  return {
+    submit(messages, handler) {
+      let accepted = 0;
+      let deduplicated = 0;
+      for (const message of messages) {
+        const key = opts.key(message);
+        if (activeKeys.has(key) || queuedKeys.has(key)) {
+          deduplicated++;
+          continue;
+        }
+        queuedKeys.add(key);
+        queue.push({ message, handler });
+        accepted++;
+      }
+      pump();
+      return {
+        active: activeKeys.size,
+        queued: queue.length,
+        accepted,
+        deduplicated,
+      };
+    },
+    stats() {
+      return { active: activeKeys.size, queued: queue.length };
+    },
+  };
 }
 
 /**

--- a/agent-node/src/inbox-dispatch.ts
+++ b/agent-node/src/inbox-dispatch.ts
@@ -105,8 +105,15 @@ export function createDetachedInboxDispatcher<T>(opts: {
         .catch(opts.onError)
         .finally(() => {
           activeKeys.delete(key);
-          opts.onSettled?.();
-          pump();
+          try {
+            opts.onSettled?.();
+          } catch (error) {
+            opts.onError(error);
+          } finally {
+            // Queue progress must not depend on a notification callback.
+            // A thrown onSettled used to strand N+1 until another SSE arrived.
+            pump();
+          }
         });
     }
   };

--- a/agent-node/src/inbox-dispatch.ts
+++ b/agent-node/src/inbox-dispatch.ts
@@ -53,3 +53,38 @@ export async function dispatchInboxBatch<T>(
   }
   for (const message of messages) await handler(message);
 }
+
+/**
+ * Submit one Codex app-server inbox snapshot without waiting for the model
+ * turns to finish. The serialized SSE drain must become free again as soon
+ * as every row has entered bridge arbitration; otherwise a later SSE wake is
+ * only marked dirty and sits behind the first row's (up to ten-minute) turn.
+ *
+ * Calling the async handler directly is intentional: it runs synchronously
+ * through its per-row inflight claim before yielding, so a following inbox
+ * snapshot cannot double-submit the same row. Completion errors remain
+ * observable through `onError` and can schedule a fresh inbox read.
+ */
+export function dispatchInboxBatchDetached<T>(
+  messages: readonly T[],
+  handler: (message: T) => Promise<void>,
+  onError: (error: unknown) => void,
+): void {
+  for (const message of messages) {
+    try {
+      void handler(message).catch(onError);
+    } catch (error) {
+      onError(error);
+    }
+  }
+}
+
+/**
+ * A detached Codex row may be between "persist pending reply" and
+ * "send/clear". Draining the durable reply queue concurrently in that
+ * window can send the same reply twice, so only drain it when no Codex inbox
+ * row is active. Other runtimes retain their historical behaviour.
+ */
+export function shouldDrainPendingReplies(runtime: string, inflightRows: number): boolean {
+  return runtime !== "codex-app-server" || inflightRows === 0;
+}

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -582,6 +582,7 @@ describe("CodexAppServerBridge — authenticated Dashboard steering", () => {
           const expected = (msg.params as { expectedTurnId?: string })?.expectedTurnId;
           return respond({ result: { turnId: expected } });
         }
+        if (msg.method === "turn/start") return respond({ result: { turnId: "must-not-start" } });
       },
     });
     const client = new CodexAppServerClient({ url: app.url });
@@ -770,12 +771,15 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
 
   test("submitTask queues the second task and drains it after turn/completed (order preserved)", async () => {
     let seq = 0;
+    const turnStartTaskIds: string[] = [];
     const app = await startFakeApp({
       onRequest: (msg, respond) => {
         if (msg.method === "initialize") return respond({ result: {} });
         if (msg.method === "thread/resume") return respond({ result: {} });
         if (msg.method === "turn/start") {
           seq++;
+          const clientUserMessageId = (msg.params as any)?.clientUserMessageId as string;
+          turnStartTaskIds.push(clientUserMessageId.replace(/^anet:/, ""));
           respond({ result: { turn: { id: `turn_q_${seq}` } } });
         }
       },
@@ -796,6 +800,9 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     expect(r2.started).toBe(false);
     expect(queued).toEqual(["t-q-2"]);
     expect(bridge.queueDepth()).toBe(1);
+    // Wire gate: B is admitted into bridge FIFO, but no second turn/start is
+    // emitted while A is active.
+    expect(turnStartTaskIds).toEqual(["t-q-1"]);
 
     // Complete turn 1 → bridge should auto-drain and start turn 2.
     app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_q_1", item: { type: "agentMessage", phase: "final_answer", text: "answer-1" } } });
@@ -808,6 +815,7 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     await new Promise((r) => setTimeout(r, 80));
     expect(bridge.queueDepth()).toBe(0);
     expect(bridge.activeTurn()).toBe("turn_q_2");
+    expect(turnStartTaskIds).toEqual(["t-q-1", "t-q-2"]);
 
     app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_q_2", item: { type: "agentMessage", phase: "final_answer", text: "answer-2" } } });
     app.broadcast({

--- a/docs/sop/agent-reply-to-dashboard.md
+++ b/docs/sop/agent-reply-to-dashboard.md
@@ -53,9 +53,19 @@ busy 节点（如 codex-app-server 单线程 turn）收到新任务会**排队**
 bridge 的同步 `turnClaimed` 和 FIFO 仍保证普通 network task 一次只启动一个 turn。只有已由实时事件证明
 属于人类的 active turn，鉴权 Dashboard chat 才会走 `turn/steer`。
 
+因此要区分两种“收到”：人类 TUI turn 中的 Dashboard chat 会立即 `turn/steer` 进当前轮；bridge 自己
+已有 network task turn 时，新 task 会被立即从 Hub 取走、进入 bridge FIFO，但仍须等前一轮 terminal
+后才能 `turn/start`。本修复消灭的是“后续 SSE 根本不再读取、白等首轮 600 秒”，不是把 Codex 的单
+turn FIFO 变成并行推理。当前 600 秒任务计时仍包含排队时间；前一轮本身超过该窗口时，后续 FIFO task
+仍可能以超时结束，这是独立的 queue-deadline 语义，不应把日志里出现 `processing` 单独当成回复闭环。
+
 多条 Dashboard chat steer 到同一个人类 turn 时，它们共同取得该 turn 的最终答案，不是多条独立模型
 请求；在 terminal 与 steer 回执竞态下，各 task 的回复落库先后不作保证。若业务依赖严格逐条顺序和独立
 答案，应等当前 turn 结束后逐条发送，让它们走 FIFO turn。
+
+可靠回复队列目前也和 Codex active handler 共用安全门：只要仍有 handler 在 bridge FIFO/turn 中等待，
+durable pending reply 暂不 drain，以避免和该 handler 的直接 send/clear 重复发送。进程重启仍会恢复
+该队列；将它拆成独立 singleflight lane 是后续优化，不属于“Dashboard 入站未读取”的修复。
 
 这是“同一个用户、同一个会话”的即时补充能力，不是独立并行对话：如果人正在 TUI 里处理另一件事，
 Dashboard 补充内容会和当前上下文一起影响最终答案。需要完全隔离时，应等当前 turn 结束再发送。

--- a/docs/sop/agent-reply-to-dashboard.md
+++ b/docs/sop/agent-reply-to-dashboard.md
@@ -47,6 +47,16 @@ busy 节点（如 codex-app-server 单线程 turn）收到新任务会**排队**
 `turn/steer(expectedTurnId)` 追加到该 turn；普通 agent 任务仍在 FIFO 等待，不会注入人的 turn。
 同一 active turn 内快速发送的多条 Dashboard 消息共享该 turn 的最终答案。
 
+桥的 inbox admission 最多同时保留 20 个 Codex handler（等于一个 `get_inbox` 页面）。第 21 条及以后
+不会丢弃：先在本地 FIFO 等待，任一 handler 结束后自动继续，并重新读取 Hub 以越过前 20 条未 ack
+记录。这个并发只表示“同时进入桥的仲裁”，**不表示向同一 Codex thread 并发发多个 `turn/start`**：
+bridge 的同步 `turnClaimed` 和 FIFO 仍保证普通 network task 一次只启动一个 turn。只有已由实时事件证明
+属于人类的 active turn，鉴权 Dashboard chat 才会走 `turn/steer`。
+
+多条 Dashboard chat steer 到同一个人类 turn 时，它们共同取得该 turn 的最终答案，不是多条独立模型
+请求；在 terminal 与 steer 回执竞态下，各 task 的回复落库先后不作保证。若业务依赖严格逐条顺序和独立
+答案，应等当前 turn 结束后逐条发送，让它们走 FIFO turn。
+
 这是“同一个用户、同一个会话”的即时补充能力，不是独立并行对话：如果人正在 TUI 里处理另一件事，
 Dashboard 补充内容会和当前上下文一起影响最终答案。需要完全隔离时，应等当前 turn 结束再发送。
 Hub 只信服务端依据 token 写入的 `auth_origin`；客户端自填 `auth_origin=user` 不会获得 steer 权限。

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,48 +1,72 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
-Base: origin/main 4da56c34c3159d674fb84f7ff636d6080f83b641
-Source candidate: bb41d94f347642849eb56dbc1e1d586ba907cb3d
+Base: origin/main 7876336513903c42bc9212aeaf5f038bf51844cc
+Source candidate: 9cc3d7c5c1c5fbaee673ce730524f7065d49c60d
 Image: anet-test584:dev
+Image ID: sha256:3e200d1d47d3f9da066e7a088196d54e5e059c90dd4a477faa5f662e98b87ce0
+Image ENV: TEST584_SOURCE_COMMIT=9cc3d7c5c1c5fbaee673ce730524f7065d49c60d
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)
 
-L1 — source/build
-- agent-node CLI bundled successfully (239 modules, 1.64 MB output).
+Production witnessed-red that motivated this follow-up
+- Dashboard task idem_74cbad5ff7fc4b14eb0c180d1a534f2f9c23c430 reached the
+  current Codex TUI and was answered UAT584-ACK, proving authenticated inbound
+  delivery, but its bridge handler remained queued behind an already-active turn.
+- A second Dashboard task idem_f0c9855b6057f8e63ad3a2cef72f6c539decf620
+  emitted new_task while that handler was active. The bridge logged the SSE event
+  but did not fetch/process the row.
+- Root cause: workInboxDrain serialized the whole processInbox promise. Although
+  rows from one get_inbox snapshot were concurrent, a later SSE wake only set the
+  lane dirty and could not run get_inbox again until the first model turn ended
+  (or reached its 600-second default timeout).
 
-L2 — app-server bridge and inbox dispatch
-- 45 tests passed, 0 failed, 129 assertions.
-- Exact turn/steer expectedTurnId contract.
-- Human-only turns do not create CommHub replies.
-- Authenticated Dashboard tasks steer an active human turn.
-- Multiple Dashboard rows enter the same turn without head-of-line blocking.
-- Ordinary agent tasks remain FIFO queued.
-- Steer mismatch/race preserves the task.
-- A task is not attributed before turn/steer acceptance.
-- Missed terminal notification is recovered from exact thread history.
-- Codex 0.133 real-wire shape without persisted userMessage stays FIFO-only.
-- Leading whitespace cannot hide an Agent Network prefix during reconnect recovery.
+Candidate behavior
+- Codex inbox rows take their synchronous per-row inflight claim and enter bridge
+  arbitration without keeping the serialized fetch lane occupied for the model
+  turn's lifetime.
+- A later new_task/new_message/broadcast SSE wake can therefore fetch and submit a
+  new Dashboard row while the first Codex turn is still active.
+- Detached completion failures are observable and schedule a fresh inbox drain.
+- Durable pending-reply draining is fenced while any detached Codex row is active,
+  preventing a concurrent drain from racing direct send/clear and duplicating a
+  reply. Other runtimes preserve their awaited serialized behavior.
+
+L1 — source/build
+- Exact source SHA was embedded in the image ENV and printed by the harness.
+- agent-node CLI bundled successfully (239 modules, 1.65 MB output).
+
+L2 — app-server bridge, dispatch, and production wiring
+- 51 tests passed, 0 failed, 145 assertions.
+- Real createInboxDrainLane behavior proves snapshot #2 enters before snapshot #1's
+  blocked model turn is released.
+- Source wiring pins the Codex-only detached path and the active-row pending-reply
+  fence; non-Codex runtimes remain awaited and serial.
+- Existing exact turn/steer, provenance, race, FIFO, approval, and reconciliation
+  tests remain green.
 
 L3 — Hub auth boundary and rolling idempotency
-- 12 tests passed, 0 failed (MCP user and node callers both covered).
-- Hub overrides client-supplied auth_origin from authenticated token facts.
-- Pre-stamp admin aliases remain FIFO and cannot unlock steering.
-- Existing pre-stamp Dashboard requests remain idempotent across rollout.
+- 12 tests passed, 0 failed, 27 assertions.
+- Hub-authenticated user origin, node spoof rejection, replay idempotency, and
+  changed-payload conflicts remain green.
 
 L4 — private real HTTP Hub
 - 2 tests passed, 0 failed, 6 assertions.
-- User token persists auth_origin=user.
-- Node token attempting to spoof Dashboard metadata persists auth_origin=node.
+- User tokens persist auth_origin=user; node tokens cannot spoof it.
 
-L5 — witnessed-red mutations
-- node-origin-cannot-steer: RED (rc 1)
-- no-head-of-line-serialization: RED (rc 1)
-- exact-expected-turn-id: RED (rc 1)
-- accepted-steer-must-reply: RED (rc 1)
-- reconnect-network-turn-stays-fifo: RED (rc 1)
-- leading-whitespace-network-prefix-stays-fifo: RED (rc 1)
-- mcp-node-cannot-forge-user-origin: RED (rc 1)
-- rest-node-cannot-forge-user-origin: RED (rc 1)
+L5 — witnessed-red mutations (all rc 1)
+- node-origin-cannot-steer
+- no-head-of-line-serialization
+- later-sse-kick-cannot-wait-for-active-turn
+- pending-reply-drain-cannot-race-active-row
+- exact-expected-turn-id
+- accepted-steer-must-reply
+- reconnect-network-turn-stays-fifo
+- leading-whitespace-network-prefix-stays-fifo
+- mcp-node-cannot-forge-user-origin
+- rest-node-cannot-forge-user-origin
 
-Production deployment was deliberately excluded from this test container.
-Hub and agent-node bridge must be deployed as one coordinated change, then a
-real Dashboard nonce must be verified through inbox ack and task reply.
+Production deployment remains excluded from this container result. Completion
+requires independent review, a bridge-only rollout that preserves the current TUI
+and app-server, and one new real Dashboard nonce proven through: authenticated DB
+row → live SSE/steer while a TUI turn is active → automatic task reply → inbox ack
+→ Dashboard readback.

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,10 +1,10 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main 7876336513903c42bc9212aeaf5f038bf51844cc
-Source candidate: 8c651389742b70123b7c6c0d5df4d262130a9255
+Source candidate: 0b2a875b755369675d664653eb96158dff2bc0e1
 Image: anet-test584:dev
-Image ID: sha256:528cca798095fbcb36cbc732f321aad2d75ffe9779c2b69f08a241124b449437
-Image ENV: TEST584_SOURCE_COMMIT=8c651389742b70123b7c6c0d5df4d262130a9255
+Image ID: sha256:8ef83ef65aaca85eaf21a6011ebf4b865a9d96a83657a0789f11c8a57ec6f4a9
+Image ENV: TEST584_SOURCE_COMMIT=0b2a875b755369675d664653eb96158dff2bc0e1
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)
 
@@ -42,13 +42,15 @@ L1 — source/build
 - agent-node CLI bundled successfully (239 modules, 1.65 MB output).
 
 L2 — app-server bridge, dispatch, and production wiring
-- 55 tests passed, 0 failed, 156 assertions.
+- 55 tests passed, 0 failed, 157 assertions.
 - Real createInboxDrainLane behavior proves snapshot #2 enters before snapshot #1's
   blocked model turn is released.
 - Source wiring pins the Codex-only detached path and the active-row pending-reply
   fence; non-Codex runtimes remain awaited and serial.
 - Same-tick duplicate kicks invoke one handler exactly once; cap N+1 waits and is
   admitted after a slot settles; settling emits the next Hub-window wake.
+- A real PendingReplyQueue harness proves the active direct-send path and the
+  durable drain produce one outbound reply, not two.
 - Existing exact turn/steer, provenance, race, FIFO, approval, and reconciliation
   tests remain green.
 
@@ -63,7 +65,6 @@ L4 — private real HTTP Hub
 
 L5 — witnessed-red mutations (all rc 1)
 - node-origin-cannot-steer
-- no-head-of-line-serialization
 - later-sse-kick-cannot-wait-for-active-turn
 - same-tick-row-claim-is-unique
 - detached-admission-cap-is-real

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,10 +1,10 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main 7876336513903c42bc9212aeaf5f038bf51844cc
-Source candidate: 9cc3d7c5c1c5fbaee673ce730524f7065d49c60d
+Source candidate: 8c651389742b70123b7c6c0d5df4d262130a9255
 Image: anet-test584:dev
-Image ID: sha256:3e200d1d47d3f9da066e7a088196d54e5e059c90dd4a477faa5f662e98b87ce0
-Image ENV: TEST584_SOURCE_COMMIT=9cc3d7c5c1c5fbaee673ce730524f7065d49c60d
+Image ID: sha256:528cca798095fbcb36cbc732f321aad2d75ffe9779c2b69f08a241124b449437
+Image ENV: TEST584_SOURCE_COMMIT=8c651389742b70123b7c6c0d5df4d262130a9255
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)
 
@@ -26,6 +26,12 @@ Candidate behavior
   turn's lifetime.
 - A later new_task/new_message/broadcast SSE wake can therefore fetch and submit a
   new Dashboard row while the first Codex turn is still active.
+- Admission is synchronously deduplicated and capped at 20 active handlers. N+1
+  waits in a local FIFO, starts when a slot settles, and completion wakes another
+  Hub read so backlogs beyond the first get_inbox page continue advancing.
+- This handler concurrency never bypasses the bridge's synchronous turn claim:
+  ordinary network tasks still produce one turn/start at a time and remain FIFO;
+  only authenticated Dashboard chat may steer a proven human turn.
 - Detached completion failures are observable and schedule a fresh inbox drain.
 - Durable pending-reply draining is fenced while any detached Codex row is active,
   preventing a concurrent drain from racing direct send/clear and duplicating a
@@ -36,11 +42,13 @@ L1 — source/build
 - agent-node CLI bundled successfully (239 modules, 1.65 MB output).
 
 L2 — app-server bridge, dispatch, and production wiring
-- 51 tests passed, 0 failed, 145 assertions.
+- 55 tests passed, 0 failed, 156 assertions.
 - Real createInboxDrainLane behavior proves snapshot #2 enters before snapshot #1's
   blocked model turn is released.
 - Source wiring pins the Codex-only detached path and the active-row pending-reply
   fence; non-Codex runtimes remain awaited and serial.
+- Same-tick duplicate kicks invoke one handler exactly once; cap N+1 waits and is
+  admitted after a slot settles; settling emits the next Hub-window wake.
 - Existing exact turn/steer, provenance, race, FIFO, approval, and reconciliation
   tests remain green.
 
@@ -57,6 +65,9 @@ L5 — witnessed-red mutations (all rc 1)
 - node-origin-cannot-steer
 - no-head-of-line-serialization
 - later-sse-kick-cannot-wait-for-active-turn
+- same-tick-row-claim-is-unique
+- detached-admission-cap-is-real
+- settled-row-must-wake-next-hub-window
 - pending-reply-drain-cannot-race-active-row
 - exact-expected-turn-id
 - accepted-steer-must-reply

--- a/docs/tests/report-test584-dashboard-codex-delivery.txt
+++ b/docs/tests/report-test584-dashboard-codex-delivery.txt
@@ -1,10 +1,10 @@
 Test 584 — Dashboard → Codex TUI reliable delivery
 Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main 7876336513903c42bc9212aeaf5f038bf51844cc
-Source candidate: 0b2a875b755369675d664653eb96158dff2bc0e1
+Source candidate: 904d8959f66a1f09cd694be71358bf57bbbed794
 Image: anet-test584:dev
-Image ID: sha256:8ef83ef65aaca85eaf21a6011ebf4b865a9d96a83657a0789f11c8a57ec6f4a9
-Image ENV: TEST584_SOURCE_COMMIT=0b2a875b755369675d664653eb96158dff2bc0e1
+Image ID: sha256:25e2b1e37775938374add2ccf26a9be492e324f34a67f5a1f557310749ccfcde
+Image ENV: TEST584_SOURCE_COMMIT=904d8959f66a1f09cd694be71358bf57bbbed794
 Command: sg docker -c 'docker run --rm anet-test584:dev'
 Result: PASS (exit 0)
 
@@ -42,15 +42,20 @@ L1 — source/build
 - agent-node CLI bundled successfully (239 modules, 1.65 MB output).
 
 L2 — app-server bridge, dispatch, and production wiring
-- 55 tests passed, 0 failed, 157 assertions.
+- 56 tests passed, 0 failed, 163 assertions.
 - Real createInboxDrainLane behavior proves snapshot #2 enters before snapshot #1's
   blocked model turn is released.
 - Source wiring pins the Codex-only detached path and the active-row pending-reply
   fence; non-Codex runtimes remain awaited and serial.
 - Same-tick duplicate kicks invoke one handler exactly once; cap N+1 waits and is
   admitted after a slot settles; settling emits the next Hub-window wake.
+- If the settle notification callback throws, its error remains observable and
+  the queued N+1 row is still pumped; the queue cannot silently stall.
 - A real PendingReplyQueue harness proves the active direct-send path and the
   durable drain produce one outbound reply, not two.
+- Wire assertions distinguish both runtime paths: Dashboard on a proven human
+  turn emits turn/steer and zero turn/start; a bridge-task B emits no second
+  turn/start until A's terminal event, then starts in FIFO order.
 - Existing exact turn/steer, provenance, race, FIFO, approval, and reconciliation
   tests remain green.
 
@@ -69,9 +74,12 @@ L5 — witnessed-red mutations (all rc 1)
 - same-tick-row-claim-is-unique
 - detached-admission-cap-is-real
 - settled-row-must-wake-next-hub-window
+- throwing-settle-callback-cannot-stall-queue
 - pending-reply-drain-cannot-race-active-row
 - exact-expected-turn-id
 - accepted-steer-must-reply
+- human-turn-dashboard-must-steer-not-start
+- network-task-b-cannot-start-before-a-terminal
 - reconnect-network-turn-stays-fifo
 - leading-whitespace-network-prefix-stays-fifo
 - mcp-node-cannot-forge-user-origin

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -18,6 +18,7 @@ test -s /tmp/test584-dist/cli.js
 echo "L2 agent bridge + dispatch"
 bun test \
   agent-node/src/inbox-dispatch.test.ts \
+  agent-node/src/inbox-dispatch-wiring.test.ts \
   agent-node/src/runtime/codex-app-server-bridge.test.ts \
   agent-node/src/runtime/codex-app-server/runtime.test.ts
 
@@ -61,6 +62,20 @@ bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
   'if (concurrent) {' \
   'if (false) {'
 expect_red no-head-of-line-serialization bun test agent-node/src/inbox-dispatch.test.ts
+cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
+
+cp agent-node/src/cli.ts /tmp/agent-node-cli.ts
+bun /harness/mutate.ts agent-node/src/cli.ts \
+  '    dispatchInboxBatchDetached(messages, processInboxMessage, (cause) => {' \
+  '    await dispatchInboxBatch(messages, processInboxMessage, true).catch((cause) => {'
+expect_red later-sse-kick-cannot-wait-for-active-turn bun test agent-node/src/inbox-dispatch-wiring.test.ts
+cp /tmp/agent-node-cli.ts agent-node/src/cli.ts
+
+cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
+bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
+  '  return runtime !== "codex-app-server" || inflightRows === 0;' \
+  '  return true;'
+expect_red pending-reply-drain-cannot-race-active-row bun test agent-node/src/inbox-dispatch.test.ts
 cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
 
 cp agent-node/src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -57,17 +57,10 @@ bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
 expect_red node-origin-cannot-steer bun test agent-node/src/inbox-dispatch.test.ts
 cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
 
-cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
-bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
-  'if (concurrent) {' \
-  'if (false) {'
-expect_red no-head-of-line-serialization bun test agent-node/src/inbox-dispatch.test.ts
-cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
-
 cp agent-node/src/cli.ts /tmp/agent-node-cli.ts
 bun /harness/mutate.ts agent-node/src/cli.ts \
   '    const dispatch = codexInboxDispatcher.submit(messages, processInboxMessage);' \
-  '    const dispatch = await dispatchInboxBatch(messages, processInboxMessage, true) as any;'
+  '    const dispatch = await dispatchInboxBatch(messages, processInboxMessage) as any;'
 expect_red later-sse-kick-cannot-wait-for-active-turn bun test agent-node/src/inbox-dispatch-wiring.test.ts
 cp /tmp/agent-node-cli.ts agent-node/src/cli.ts
 

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -87,6 +87,13 @@ cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
 
 cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
 bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
+  $'          } catch (error) {\n            opts.onError(error);\n          } finally {' \
+  $'          } catch (error) {\n            throw error;\n          }\n          {'
+expect_red throwing-settle-callback-cannot-stall-queue bun test agent-node/src/inbox-dispatch.test.ts
+cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
+
+cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
+bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
   '  return runtime !== "codex-app-server" || inflightRows === 0;' \
   '  return true;'
 expect_red pending-reply-drain-cannot-race-active-row bun test agent-node/src/inbox-dispatch.test.ts
@@ -104,6 +111,20 @@ bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
   '        this.emitSteeredTask(steered, task, steered.terminal);' \
   '        /* reply attribution deliberately removed */'
 expect_red accepted-steer-must-reply bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
+cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
+
+cp agent-node/src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
+bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
+  '    if (this.externalActiveTurnId) {' \
+  '    if (false) {'
+expect_red human-turn-dashboard-must-steer-not-start bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
+cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
+
+cp agent-node/src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
+bun /harness/mutate.ts agent-node/src/runtime/codex-app-server-bridge.ts \
+  $'    if (this.turnClaimed || this.activeTurnId) {\n      this.taskQueue.push(input);' \
+  $'    if (false) {\n      this.taskQueue.push(input);'
+expect_red network-task-b-cannot-start-before-a-terminal bun test agent-node/src/runtime/codex-app-server-bridge.test.ts
 cp /tmp/codex-app-server-bridge.ts agent-node/src/runtime/codex-app-server-bridge.ts
 
 cp agent-node/src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts

--- a/tests/test584-dashboard-codex-delivery/run.sh
+++ b/tests/test584-dashboard-codex-delivery/run.sh
@@ -66,10 +66,31 @@ cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
 
 cp agent-node/src/cli.ts /tmp/agent-node-cli.ts
 bun /harness/mutate.ts agent-node/src/cli.ts \
-  '    dispatchInboxBatchDetached(messages, processInboxMessage, (cause) => {' \
-  '    await dispatchInboxBatch(messages, processInboxMessage, true).catch((cause) => {'
+  '    const dispatch = codexInboxDispatcher.submit(messages, processInboxMessage);' \
+  '    const dispatch = await dispatchInboxBatch(messages, processInboxMessage, true) as any;'
 expect_red later-sse-kick-cannot-wait-for-active-turn bun test agent-node/src/inbox-dispatch-wiring.test.ts
 cp /tmp/agent-node-cli.ts agent-node/src/cli.ts
+
+cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
+bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
+  'activeKeys.has(key) || queuedKeys.has(key)' \
+  'false'
+expect_red same-tick-row-claim-is-unique bun test agent-node/src/inbox-dispatch.test.ts
+cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
+
+cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
+bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
+  'activeKeys.size < opts.maxConcurrent' \
+  'true'
+expect_red detached-admission-cap-is-real bun test agent-node/src/inbox-dispatch.test.ts
+cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
+
+cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
+bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \
+  '          opts.onSettled?.();' \
+  '          /* next Hub inbox window wake removed */'
+expect_red settled-row-must-wake-next-hub-window bun test agent-node/src/inbox-dispatch.test.ts
+cp /tmp/inbox-dispatch.ts agent-node/src/inbox-dispatch.ts
 
 cp agent-node/src/inbox-dispatch.ts /tmp/inbox-dispatch.ts
 bun /harness/mutate.ts agent-node/src/inbox-dispatch.ts \


### PR DESCRIPTION
## What changed

- Release the serialized inbox-fetch lane after bounded Codex admission, so a later Dashboard SSE wake is fetched while an earlier model turn is active.
- Deduplicate Hub row keys synchronously across snapshots and cap detached handlers at 20; N+1 waits in FIFO and advances on settlement.
- Keep queue progress independent of settle-callback failures.
- Fence durable pending-reply draining while detached Codex handlers are active.
- Preserve awaited serialization for every non-Codex runtime.
- Document the distinct human-turn steer and bridge-task FIFO semantics.

## Root cause

`workInboxDrain` serialized the entire `processInbox()` promise. Same-snapshot rows were concurrent after #577, but a later SSE wake only marked the lane dirty and could not call `get_inbox` until the first model turn finished or timed out.

## Important behavior boundary

- Proven human TUI turn + authenticated Dashboard chat: `turn/steer(expectedTurnId)`, zero new `turn/start`.
- Existing bridge-owned task turn: the later row is fetched immediately but remains FIFO; wire emits B's `turn/start` only after A's terminal event.
- The existing 600-second task deadline still includes FIFO queue time; this PR fixes unread later SSE rows, not single-thread model scheduling.

## Validation

- Exact source `904d8959f66a1f09cd694be71358bf57bbbed794` embedded in Docker image `sha256:25e2b1e37775938374add2ccf26a9be492e324f34a67f5a1f557310749ccfcde`.
- 56 bridge/dispatch tests + 12 Hub boundary tests + 2 private real-HTTP tests, all green.
- 15/15 targeted mutations witnessed red, including later-SSE regression, duplicate same-tick claim, cap bypass, lost settlement wake, throwing callback stall, pending-reply double send, steer-vs-start, and FIFO early-start.
- Report: `docs/tests/report-test584-dashboard-codex-delivery.txt`.

No npm publish or production rollout is included. Production remains on the #577 bridge pending independent merge.