### PR TITLE
fix(cli): stop hardcoding from:"api" in POST /api/task bodies

### DIFF
--- a/.github/workflows/lint-from-session.yml
+++ b/.github/workflows/lint-from-session.yml
@@ -1,0 +1,40 @@
+# Reject hardcoded `from` / `from_session` in POST /api/task bodies.
+#
+# 2026-08-04: PR #571 bound REST identity to the bearer token, so a node
+# token may no longer claim a different from_session (403
+# from_session_identity_mismatch). Four call sites in
+# agent-network/bin/cli.ts still hardcoded `from: "api"` — `anet loop`
+# plus the debate / social / pr-review orchestrators. They passed only
+# because the operator config holds a `utok_`; measured the same day,
+# 297 processes on the fleet host carried `COMMHUB_TOKEN=ntok_` and none
+# carried a `utok_`, so any agent invoking those commands from its own
+# shell would have hit the 403.
+#
+# Deliberately no `paths:` filter. A path-filtered job does not run on a
+# PR that misses the filter, and a check that never ran is displayed the
+# same way as one that passed. The script reads two files and finishes in
+# well under a second, so it always runs.
+#
+# See: server/src/rest-identity.ts, tests/scripts/lint-no-hardcoded-from-session.py
+
+name: lint (from_session guard)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: lint-from-session-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  hardcoded-from-session:
+    name: no hardcoded from_session
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run lint-no-hardcoded-from-session.py
+        run: python3 tests/scripts/lint-no-hardcoded-from-session.py

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -7121,7 +7121,6 @@ to stop one.
     alias: displayName,
     task: slashCmd,
     priority: "normal",
-    from: "api",
     network_id: networkId || undefined,
   });
 
@@ -9835,7 +9834,7 @@ async function demoDebateCommand() {
   const transcript: Speech[] = [];
 
   async function postTask(alias: string, task: string): Promise<string> {
-    const body = JSON.stringify({ alias, task, priority: "normal", from: "api", network_id: networkId || undefined });
+    const body = JSON.stringify({ alias, task, priority: "normal", network_id: networkId || undefined });
     const res = await fetch(`${hub}/api/task`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...authHeaders() },
@@ -10220,7 +10219,7 @@ async function demoSocialMediaCommand() {
   const transcript: Speech[] = [];
 
   async function postTask(alias: string, task: string): Promise<string> {
-    const body = JSON.stringify({ alias, task, priority: "normal", from: "api", network_id: networkId || undefined });
+    const body = JSON.stringify({ alias, task, priority: "normal", network_id: networkId || undefined });
     const res = await fetch(`${hub}/api/task`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...authHeaders() },
@@ -10641,7 +10640,7 @@ async function demoPrReviewCommand() {
 
   // 4. Helpers: post task + wait reply
   async function postTask(alias: string, task: string): Promise<string> {
-    const body = JSON.stringify({ alias, task, priority: "normal", from: "api", network_id: networkId || undefined });
+    const body = JSON.stringify({ alias, task, priority: "normal", network_id: networkId || undefined });
     const res = await fetch(`${hub}/api/task`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...authHeaders() },

--- a/tests/scripts/lint-no-hardcoded-from-session.py
+++ b/tests/scripts/lint-no-hardcoded-from-session.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Reject hardcoded `from` / `from_session` in POST /api/task bodies.
+
+Why this guard exists (2026-08-04):
+
+PR #571 bound REST identity to the bearer token. A network token (`ntok_`)
+whose name resolves to `node:<alias>` may no longer claim a different
+`from_session`; the hub answers 403 `from_session_identity_mismatch`.
+
+At that moment `agent-network/bin/cli.ts` hardcoded `from: "api"` in four
+POST /api/task bodies — `anet loop` (scheduled goals) plus the debate,
+social and pr-review orchestrators. They worked only because the operator
+config happens to hold a `utok_`, which takes the permissive branch.
+
+Measured on the fleet host the same day:
+
+    processes with COMMHUB_TOKEN=ntok_ : 297
+    processes with COMMHUB_TOKEN=utok_ : 0
+
+`getToken()` prefers `--token` > `COMMHUB_TOKEN` > config, so any agent
+running `anet loop` from its own shell sends a node token, and the
+hardcoded `from: "api"` no longer matches its alias -> 403.
+
+Omitting the field is strictly better in both directions:
+
+    user token -> server resolves "api"          (unchanged)
+    node token -> server binds the token's alias (correct, and what #571 is for)
+
+So the rule is: never state `from` on this path. Let the server derive it
+from the credential — a caller cannot know its own alias more reliably than
+the token does.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# Only real callers. Test fixtures legitimately post spoofed identities to
+# assert the 403 fires, so they are not scanned.
+TARGETS = [
+    "agent-network/bin/cli.ts",
+    "agent-node/src/cli.ts",
+]
+
+# `from: "..."` or `from_session: "..."` appearing in an object literal.
+PATTERN = re.compile(r'\bfrom(?:_session)?\s*:\s*["\']')
+
+# A bare `from:` hit is a candidate, not a defect. The first draft of this
+# guard flagged a code comment that quoted `from:"api"` and an unrelated
+# diagnostics object `{ kind: "legacy_alias_field", from: "alias" }` — two
+# false reds on correct code. Narrow to the shape that actually goes to
+# POST /api/task: an object literal that also carries `priority:`.
+SHAPE = re.compile(r'\bpriority\s*:')
+WINDOW = 8
+
+
+# A comment line, i.e. `// ...` or a ` * ...` continuation inside a block.
+# Deliberately per-line: an earlier draft stripped `/* ... */` with a
+# non-greedy regex over the whole file, and a `/*` sitting inside a string
+# literal made it swallow ~4000 lines of real code. The guard then scanned
+# blank text and reported OK on a file that did contain the defect — a
+# vacuous pass that looks byte-identical to a real one.
+COMMENT_LINE = re.compile(r'^\s*(?://|\*|/\*)')
+
+
+failures = []
+scanned = 0
+
+for rel in TARGETS:
+    path = ROOT / rel
+    if not path.exists():
+        # A missing target means the guard silently stops checking it, which
+        # is how a scope bug turns into a vacuous pass. Fail loudly instead.
+        failures.append(f"{rel}: guard target missing — update TARGETS")
+        continue
+    scanned += 1
+    lines = path.read_text(encoding="utf8").splitlines()
+    # Report the denominator per file too: a guard that reads 0 lines and a
+    # guard that reads 12000 clean ones both print "OK" otherwise.
+    print(f"  {rel}: {len(lines)} lines")
+    for lineno, line in enumerate(lines, 1):
+        if not PATTERN.search(line) or COMMENT_LINE.match(line):
+            continue
+        lo = max(0, lineno - 1 - WINDOW)
+        hi = min(len(lines), lineno + WINDOW)
+        if not any(SHAPE.search(l) for l in lines[lo:hi]):
+            continue  # not a task-post body
+        failures.append(f"{rel}:{lineno}: {line.strip()[:100]}")
+
+# Report the denominator: "0 hits" is only meaningful next to "n files read".
+print(f"scanned {scanned}/{len(TARGETS)} files for hardcoded from_session")
+
+if failures:
+    print("\nhardcoded from_session in a hub request body:\n")
+    for f in failures:
+        print(f"  {f}")
+    print(
+        "\nRemove the field. The hub derives from_session from the bearer "
+        "token (PR #571); stating it makes a node token 403 with "
+        "from_session_identity_mismatch."
+    )
+    sys.exit(1)
+
+print("OK: no hardcoded from_session")


### PR DESCRIPTION
## 为什么

PR #571 把 REST 身份绑定到 bearer token：名字能解析出 `node:<alias>` 的网络令牌不能再声称别的 `from_session`，hub 返回 403 `from_session_identity_mismatch`。

`agent-network/bin/cli.ts` 有 **4 处**仍然硬编 `from: "api"`：

| 位置 | 命令 |
|---|---|
| 7124 | `anet loop`（定时目标） |
| 9837 / 10222 / 10643 | debate / social / pr-review 编排 |

它们至今能用，只是因为运维配置里恰好是 `utok_`，走了宽容分支。

同日在舰队主机上实测：

```
COMMHUB_TOKEN=ntok_ 的进程 : 297
COMMHUB_TOKEN=utok_ 的进程 : 0
```

`getToken()` 的优先级是 `--token` > `COMMHUB_TOKEN` > config，所以**任何 agent 在自己的 shell 里跑 `anet loop`，带的都是节点令牌** —— 带 #571 的 hub 一上线就会 403。

## 改法

删掉这个字段，不改成别的值。两个方向都不劣：

```
用户令牌 → 服务端解析为 "api"        （行为不变）
节点令牌 → 绑定令牌自己的别名        （正确，正是 #571 的目的）
```

调用方不可能比令牌更可靠地知道自己的别名，所以这条路径上就不该声明这个字段。

## 守卫

新增 `tests/scripts/lint-no-hardcoded-from-session.py` + 一个**总是运行**的 CI job（不加 `paths:` 过滤 —— 被过滤掉没跑的 check 和通过了的 check 在界面上长得一样）。

五个方向都验过：

| 方向 | 期望 | 实测 |
|---|---|---|
| 干净树 | PASS | rc=0 |
| 还原单行式 body | FAIL | rc=1，命中 9837 |
| 还原多行式 body（`anet loop`） | FAIL | rc=1，命中 7124 |
| 扫描目标缺失 | FAIL | rc=1，报 `guard target missing` |
| 恢复后 | PASS | rc=0 |

### 守卫自己先坏过一次，写在这里

第一版用非贪婪正则整文件剥 `/* */`。某个字符串字面量里的 `/*` 让它吞掉了约 4000 行真代码 —— 于是它扫的是空文本，对一个**确实含有该缺陷**的文件报了 OK。

发现的方式是第 3 个方向没红；但**没有立刻断定守卫漏了**，而是先确认 mutation 是否真的改到了文件（改到了，7124 行确有 `from: "api",`），才定位到守卫本身。

现在改成逐行判定注释，并且**每个文件都打印读到的行数** —— 扫了 0 行的 OK 和扫了 12376 行的 OK，不打印分母就完全一样。