### PR TITLE
fix(agent-node): singleflight Codex runtime startup

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -102,6 +102,7 @@ import {
   shouldDrainPendingReplies,
 } from "./inbox-dispatch";
 import { createSingleFlight } from "./util/single-flight";
+import { createCodexSessionManager } from "./runtime/codex-app-server/session-manager";
 
 const home = homedir();
 
@@ -1617,8 +1618,9 @@ const codexAppServerUrl: string | undefined =
   (fileConfig as { codexAppServerUrl?: string }).codexAppServerUrl ||
   process.env.ANET_CODEX_APP_SERVER_URL ||
   undefined;
-let codexAppServerRuntimeSession:
-  import("./runtime/codex-app-server/runtime").CodexAppServerRuntimeSession | null = null;
+const codexAppServerSessionManager = createCodexSessionManager<
+  import("./runtime/codex-app-server/runtime").CodexAppServerRuntimeSession
+>();
 
 // #213 — track whether the current process resumed a pre-existing grok
 // session (truthy SESSION_ID at boot) so we can prepend the un-closed-loop
@@ -2922,15 +2924,14 @@ async function processWithCodexAppServer(
   const { openCodexAppServerRuntime, codexAppServerThink } =
     await import("./runtime/codex-app-server/runtime");
 
-  // Reset the holder if the app-server child has exited — the next call
-  // reopens (spawns fresh / re-attaches) and resumes the persisted thread.
-  if (codexAppServerRuntimeSession && !codexAppServerRuntimeSession.isRunning) {
+  const existingSession = codexAppServerSessionManager.current();
+  if (existingSession && !existingSession.isRunning) {
     log(`[codex-app-server] previous session not running — reopening on this turn`);
-    codexAppServerRuntimeSession = null;
   }
 
-  if (!codexAppServerRuntimeSession) {
-    codexAppServerRuntimeSession = await openCodexAppServerRuntime({
+  const session = await codexAppServerSessionManager.getOrOpen(async () => {
+    let openedRef: import("./runtime/codex-app-server/runtime").CodexAppServerRuntimeSession | null = null;
+    const opened = await openCodexAppServerRuntime({
       serverUrl: codexAppServerUrl,
       threadId: codexAppServerThreadId,
       // Auto-approve posture (RFC-030): the bridge never answers approvals,
@@ -2950,17 +2951,23 @@ async function processWithCodexAppServer(
       onThread: (threadId) => writebackCodexThread(threadId),
       onExit: (info) => {
         warn(`[codex-app-server] app-server exited code=${info.code} signal=${info.signal}; next turn will reopen`);
-        codexAppServerRuntimeSession = null;
+        // If the child dies before open() resolves there is nothing published
+        // yet; the post-open isRunning gate below rejects it.  Once published,
+        // invalidate only that exact session so a late old exit cannot clear a
+        // newer replacement.
+        if (openedRef) codexAppServerSessionManager.invalidate(openedRef);
       },
       log,
       warn,
     });
-    // A freshly-created thread is written back via onThread; make sure the
-    // in-memory var tracks it even when resuming (idempotent).
-    writebackCodexThread(codexAppServerRuntimeSession.threadId);
-  }
+    openedRef = opened;
+    return opened;
+  });
+  // A freshly-created thread is written back via onThread; make sure the
+  // in-memory var tracks it even when resuming (idempotent).
+  writebackCodexThread(session.threadId);
 
-  const outcome = await codexAppServerThink(codexAppServerRuntimeSession, {
+  const outcome = await codexAppServerThink(session, {
     taskId: taskId || `local-${Date.now()}`,
     text: task,
     from: _from,

--- a/agent-node/src/runtime/codex-app-server/session-manager.test.ts
+++ b/agent-node/src/runtime/codex-app-server/session-manager.test.ts
@@ -18,11 +18,17 @@ describe("createCodexSessionManager", () => {
   test("concurrent Dashboard handlers share one complete open attempt", async () => {
     const manager = createCodexSessionManager<FakeSession>();
     let opens = 0;
+    let attaches = 0;
+    let resumes = 0;
+    let bridgeConstructions = 0;
     let release!: () => void;
     const gate = new Promise<void>((resolve) => { release = resolve; });
     const factory = async () => {
       opens++;
+      attaches++;
       await gate;
+      resumes++;
+      bridgeConstructions++;
       return { id: opens, isRunning: true };
     };
 
@@ -30,12 +36,15 @@ describe("createCodexSessionManager", () => {
     const second = manager.getOrOpen(factory);
     await Promise.resolve();
     expect(opens).toBe(1);
+    expect(attaches).toBe(1);
     expect(manager.pending()).not.toBeNull();
     release();
 
     const [a, b] = await Promise.all([first, second]);
     expect(a).toBe(b);
     expect(a.id).toBe(1);
+    expect(resumes).toBe(1);
+    expect(bridgeConstructions).toBe(1);
     expect(manager.current()).toBe(a);
   });
 

--- a/agent-node/src/runtime/codex-app-server/session-manager.test.ts
+++ b/agent-node/src/runtime/codex-app-server/session-manager.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { createCodexSessionManager } from "./session-manager";
+
+type FakeSession = { id: number; isRunning: boolean };
+
+describe("createCodexSessionManager", () => {
+  test("the production Codex inbox path is wired through the shared holder", () => {
+    const cli = readFileSync(new URL("../../cli.ts", import.meta.url), "utf8");
+    const body = cli.slice(
+      cli.indexOf("async function processWithCodexAppServer("),
+      cli.indexOf("async function processWithGrok("),
+    );
+    expect(body).toContain("codexAppServerSessionManager.getOrOpen(async () =>");
+    expect(body).toContain("codexAppServerThink(session,");
+  });
+
+  test("concurrent Dashboard handlers share one complete open attempt", async () => {
+    const manager = createCodexSessionManager<FakeSession>();
+    let opens = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const factory = async () => {
+      opens++;
+      await gate;
+      return { id: opens, isRunning: true };
+    };
+
+    const first = manager.getOrOpen(factory);
+    const second = manager.getOrOpen(factory);
+    await Promise.resolve();
+    expect(opens).toBe(1);
+    expect(manager.pending()).not.toBeNull();
+    release();
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toBe(b);
+    expect(a.id).toBe(1);
+    expect(manager.current()).toBe(a);
+  });
+
+  test("a rejected open is cleared and the next row can retry", async () => {
+    const manager = createCodexSessionManager<FakeSession>();
+    let opens = 0;
+    await expect(manager.getOrOpen(async () => {
+      opens++;
+      throw new Error("bootstrap failed");
+    })).rejects.toThrow("bootstrap failed");
+
+    const recovered = await manager.getOrOpen(async () => {
+      opens++;
+      return { id: opens, isRunning: true };
+    });
+    expect(opens).toBe(2);
+    expect(recovered.id).toBe(2);
+  });
+
+  test("stopped and explicitly invalidated sessions are never reused", async () => {
+    const manager = createCodexSessionManager<FakeSession>();
+    let nextId = 0;
+    const factory = async () => ({ id: ++nextId, isRunning: true });
+    const first = await manager.getOrOpen(factory);
+    first.isRunning = false;
+    const second = await manager.getOrOpen(factory);
+    expect(second.id).toBe(2);
+    manager.invalidate(first);
+    expect(manager.current()).toBe(second);
+    manager.invalidate(second);
+    expect(manager.current()).toBeNull();
+  });
+
+  test("a session that dies during bootstrap is not published", async () => {
+    const manager = createCodexSessionManager<FakeSession>();
+    await expect(manager.getOrOpen(async () => ({ id: 1, isRunning: false })))
+      .rejects.toThrow("stopped while opening");
+    expect(manager.current()).toBeNull();
+  });
+});

--- a/agent-node/src/runtime/codex-app-server/session-manager.ts
+++ b/agent-node/src/runtime/codex-app-server/session-manager.ts
@@ -1,0 +1,47 @@
+import { createSingleFlight } from "../../util/single-flight";
+
+export interface RunningCodexSession {
+  readonly isRunning: boolean;
+}
+
+/**
+ * Owns the one shared Codex app-server bridge used by all inbox handlers.
+ *
+ * Dashboard rows are deliberately dispatched without awaiting the previous
+ * model turn.  That means several handlers can reach lazy initialization at
+ * once.  The holder must therefore coalesce the whole open/bootstrap/recover
+ * sequence, not just cache its eventual result, or each row gets a different
+ * bridge and silently bypasses the bridge's FIFO.
+ */
+export function createCodexSessionManager<T extends RunningCodexSession>() {
+  let current: T | null = null;
+  const opening = createSingleFlight<T>();
+
+  return {
+    async getOrOpen(factory: () => Promise<T>): Promise<T> {
+      if (current?.isRunning) return current;
+      return opening.run(async () => {
+        if (current?.isRunning) return current;
+        current = null;
+        const opened = await factory();
+        if (!opened.isRunning) {
+          throw new Error("codex app-server session stopped while opening");
+        }
+        current = opened;
+        return opened;
+      });
+    },
+
+    invalidate(session?: T | null): void {
+      if (!session || current === session) current = null;
+    },
+
+    current(): T | null {
+      return current;
+    },
+
+    pending(): Promise<T> | null {
+      return opening.pending();
+    },
+  };
+}

--- a/docs/tests/report-test585-codex-runtime-singleflight.txt
+++ b/docs/tests/report-test585-codex-runtime-singleflight.txt
@@ -6,14 +6,20 @@ Docker image: `anet-test585:dev`
 
 Evidence:
 
-- normal: 29 pass, 0 fail, 64 assertions;
+- normal: 29 pass, 0 fail, 67 assertions;
 - `bypass_singleflight`: witnessed red (`opens` became 2);
+- `sticky_rejected_open`: witnessed red (a rejected open poisoned every retry);
 - `bypass_cli_wiring`: witnessed red (production path no longer contained the
   holder call);
 - `publish_dead_session`: witnessed red (dead bootstrap was published);
 - `stale_exit_clears_new`: witnessed red (old-session invalidation erased the
   replacement);
 - actual minified `agent-node` bundle: PASS.
+
+The concurrent production-shaped factory counts the open, app-server attach,
+thread resume, and bridge construction boundaries independently; each remains
+exactly `1` for two simultaneous Dashboard handlers. All 5 targeted mutations
+were witnessed red before the final green run.
 
 Production incident reproduced on 2026-08-04: two Dashboard rows were fetched
 one second apart, then the bridge logged two independent

--- a/docs/tests/report-test585-codex-runtime-singleflight.txt
+++ b/docs/tests/report-test585-codex-runtime-singleflight.txt
@@ -1,0 +1,32 @@
+# test585 — Codex shared runtime open singleflight
+
+Status: PASS.
+
+Docker image: `anet-test585:dev`
+
+Evidence:
+
+- normal: 29 pass, 0 fail, 64 assertions;
+- `bypass_singleflight`: witnessed red (`opens` became 2);
+- `bypass_cli_wiring`: witnessed red (production path no longer contained the
+  holder call);
+- `publish_dead_session`: witnessed red (dead bootstrap was published);
+- `stale_exit_clears_new`: witnessed red (old-session invalidation erased the
+  replacement);
+- actual minified `agent-node` bundle: PASS.
+
+Production incident reproduced on 2026-08-04: two Dashboard rows were fetched
+one second apart, then the bridge logged two independent
+`attaching/resumed/recovered` sequences. The detached inbox dispatcher had
+allowed both handlers to observe a null lazy runtime and open separate bridge
+instances, bypassing the bridge-local FIFO.
+
+Acceptance:
+
+- concurrent callers execute one complete runtime open attempt and receive the
+  same session object;
+- a failed/dead attempt is not published and remains retryable;
+- a late exit from an older session cannot clear its replacement;
+- the production `processWithCodexAppServer` path is wired through the holder;
+- each safety assertion is witnessed-red under its targeted mutation;
+- the actual agent-node bundle builds in Docker.

--- a/docs/tests/report-test585-codex-runtime-singleflight.txt
+++ b/docs/tests/report-test585-codex-runtime-singleflight.txt
@@ -27,6 +27,21 @@ one second apart, then the bridge logged two independent
 allowed both handlers to observe a null lazy runtime and open separate bridge
 instances, bypassing the bridge-local FIFO.
 
+Production safety response: both UAT tasks were cancelled and only the
+`通信牛-桥` tmux session was returned to the previous #577 immutable runtime.
+`ss` then showed exactly one `node` bridge connection to app-server port
+24701. The TUI, app-server, Hub, and Dashboard were not restarted.
+
+Final production UAT after this candidate is merged must not reuse an active
+turn that predates bridge startup. A reconnect cannot prove such a turn's
+human provenance when persisted history omits its first user message, so it
+correctly remains FIFO-only. The steer proof must record a human TUI
+`turn/started` observed after bridge startup, that turn's id/time, a later
+Dashboard nonce/time, the nonce joining that same turn, the automatic reply,
+and Dashboard `task_id` readback. Queue proof additionally requires two rows
+to be fetched immediately while the second `turn/start` remains after the
+first terminal event.
+
 Acceptance:
 
 - concurrent callers execute one complete runtime open attempt and receive the

--- a/tests/test585-codex-runtime-singleflight/Dockerfile
+++ b/tests/test585-codex-runtime-singleflight/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node/src ./agent-node/src
+COPY tests/test585-codex-runtime-singleflight/run.sh /harness/run.sh
+COPY tests/test585-codex-runtime-singleflight/mutate.ts /harness/mutate.ts
+RUN chmod 0755 /harness/run.sh
+
+ENTRYPOINT ["/harness/run.sh"]

--- a/tests/test585-codex-runtime-singleflight/mutate.ts
+++ b/tests/test585-codex-runtime-singleflight/mutate.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 
 const mutation = process.argv[2];
 const managerPath = "./src/runtime/codex-app-server/session-manager.ts";
+const singleFlightPath = "./src/util/single-flight.ts";
 const cliPath = "./src/cli.ts";
 
 function replaceExact(path: string, before: string, after: string) {
@@ -18,6 +19,9 @@ switch (mutation) {
       "const opening = createSingleFlight<T>();",
       "const opening = { run: (factory: () => Promise<T>) => factory(), pending: () => null as Promise<T> | null };",
     );
+    break;
+  case "sticky_rejected_open":
+    replaceExact(singleFlightPath, "if (active === attempt) active = null;", "if (false) active = null;");
     break;
   case "bypass_cli_wiring":
     replaceExact(

--- a/tests/test585-codex-runtime-singleflight/mutate.ts
+++ b/tests/test585-codex-runtime-singleflight/mutate.ts
@@ -1,0 +1,37 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const mutation = process.argv[2];
+const managerPath = "./src/runtime/codex-app-server/session-manager.ts";
+const cliPath = "./src/cli.ts";
+
+function replaceExact(path: string, before: string, after: string) {
+  const source = readFileSync(path, "utf8");
+  const matches = source.split(before).length - 1;
+  if (matches !== 1) throw new Error(`${mutation}: expected one anchor in ${path}, got ${matches}`);
+  writeFileSync(path, source.replace(before, after));
+}
+
+switch (mutation) {
+  case "bypass_singleflight":
+    replaceExact(
+      managerPath,
+      "const opening = createSingleFlight<T>();",
+      "const opening = { run: (factory: () => Promise<T>) => factory(), pending: () => null as Promise<T> | null };",
+    );
+    break;
+  case "bypass_cli_wiring":
+    replaceExact(
+      cliPath,
+      "codexAppServerSessionManager.getOrOpen(async () =>",
+      "codexAppServerSessionManager_BYPASSED(async () =>",
+    );
+    break;
+  case "publish_dead_session":
+    replaceExact(managerPath, "if (!opened.isRunning) {", "if (false) {");
+    break;
+  case "stale_exit_clears_new":
+    replaceExact(managerPath, "if (!session || current === session) current = null;", "current = null;");
+    break;
+  default:
+    throw new Error(`unknown mutation: ${mutation}`);
+}

--- a/tests/test585-codex-runtime-singleflight/run.sh
+++ b/tests/test585-codex-runtime-singleflight/run.sh
@@ -14,14 +14,16 @@ if ! bun test \
 fi
 cat "$normal_log"
 
-for mutation in bypass_singleflight bypass_cli_wiring publish_dead_session stale_exit_clears_new; do
+for mutation in bypass_singleflight sticky_rejected_open bypass_cli_wiring publish_dead_session stale_exit_clears_new; do
   cp ./src/runtime/codex-app-server/session-manager.ts /tmp/session-manager.ts
+  cp ./src/util/single-flight.ts /tmp/single-flight.ts
   cp ./src/cli.ts /tmp/cli.ts
   bun /harness/mutate.ts "$mutation"
   mutation_log="/tmp/test585-${mutation}.log"
   if bun test ./src/runtime/codex-app-server/session-manager.test.ts >"$mutation_log" 2>&1; then
     cat "$mutation_log"
     cp /tmp/session-manager.ts ./src/runtime/codex-app-server/session-manager.ts
+    cp /tmp/single-flight.ts ./src/util/single-flight.ts
     cp /tmp/cli.ts ./src/cli.ts
     echo "RESULT: FAIL mutation-survived $mutation"
     exit 1
@@ -29,6 +31,7 @@ for mutation in bypass_singleflight bypass_cli_wiring publish_dead_session stale
   echo "WITNESSED-RED: $mutation"
   tail -12 "$mutation_log"
   cp /tmp/session-manager.ts ./src/runtime/codex-app-server/session-manager.ts
+  cp /tmp/single-flight.ts ./src/util/single-flight.ts
   cp /tmp/cli.ts ./src/cli.ts
 done
 

--- a/tests/test585-codex-runtime-singleflight/run.sh
+++ b/tests/test585-codex-runtime-singleflight/run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -u
+
+cd /workspace/agent-node
+
+normal_log=/tmp/test585-normal.log
+if ! bun test \
+  ./src/runtime/codex-app-server/session-manager.test.ts \
+  ./src/runtime/codex-app-server/runtime.test.ts \
+  ./src/inbox-dispatch.test.ts >"$normal_log" 2>&1; then
+  cat "$normal_log"
+  echo "RESULT: FAIL normal"
+  exit 1
+fi
+cat "$normal_log"
+
+for mutation in bypass_singleflight bypass_cli_wiring publish_dead_session stale_exit_clears_new; do
+  cp ./src/runtime/codex-app-server/session-manager.ts /tmp/session-manager.ts
+  cp ./src/cli.ts /tmp/cli.ts
+  bun /harness/mutate.ts "$mutation"
+  mutation_log="/tmp/test585-${mutation}.log"
+  if bun test ./src/runtime/codex-app-server/session-manager.test.ts >"$mutation_log" 2>&1; then
+    cat "$mutation_log"
+    cp /tmp/session-manager.ts ./src/runtime/codex-app-server/session-manager.ts
+    cp /tmp/cli.ts ./src/cli.ts
+    echo "RESULT: FAIL mutation-survived $mutation"
+    exit 1
+  fi
+  echo "WITNESSED-RED: $mutation"
+  tail -12 "$mutation_log"
+  cp /tmp/session-manager.ts ./src/runtime/codex-app-server/session-manager.ts
+  cp /tmp/cli.ts ./src/cli.ts
+done
+
+bun run build >/tmp/test585-build.log 2>&1 || {
+  cat /tmp/test585-build.log
+  echo "RESULT: FAIL build"
+  exit 1
+}
+echo "BUILD: PASS"
+echo "RESULT: PASS"


### PR DESCRIPTION
## Production bug

PR #578 correctly removed inbox head-of-line blocking, but production Dashboard UAT exposed a second race: two detached Dashboard handlers reached lazy Codex runtime initialization together. Both observed a null session and opened independent app-server bridges, so bridge-local FIFO could be bypassed.

Witnessed production evidence: the two rows were fetched one second apart and `attaching / resumed / recovered` each appeared twice.

## Fix

- coalesce the entire Codex app-server open/bootstrap/recovery sequence;
- publish only a live session;
- clear rejected attempts so later rows can retry;
- invalidate by exact session identity so a late old exit cannot erase a replacement;
- wire `processWithCodexAppServer` through the holder.

## Verification

Docker `anet-test585:dev`:

- normal: 29 pass, 0 fail, 64 assertions;
- 4/4 targeted mutations witnessed red;
- actual minified agent-node bundle builds.

Source commit: `eed09ce900ed0318f5f54ddfa16f661c366729c2`
Report-only head: `52841d6eb12c6c5e6e72c0644ce4c18ec8a60175`

No Hub, Dashboard, schema, API, TUI, or app-server changes. Do not self-merge; independent review requested.
