### PR TITLE
fix(agent-node): reconcile Codex replies across active successor turns

### DIFF
--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -967,6 +967,47 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     await app.stop();
   });
 
+  test("full history never attributes a different completed turn to the owned task", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/start") return respond({ result: { turn: { id: "turn_exact_owner" } } });
+        if (msg.method === "thread/read") {
+          const includeTurns = (msg.params as { includeTurns?: boolean } | undefined)?.includeTurns;
+          return respond({ result: { thread: {
+            status: { type: "active" },
+            turns: includeTurns ? [{
+              id: "different_completed_turn",
+              status: "completed",
+              items: [{ type: "agentMessage", phase: "final_answer", text: "must-not-leak" }],
+            }] : undefined,
+          } } });
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({
+      client,
+      threadId: THREAD,
+      fullHistoryReconciliationIntervalMs: 0,
+    });
+    await bridge.bootstrap();
+    const replies: unknown[] = [];
+    bridge.on("task_reply", (reply) => replies.push(reply));
+    await bridge.submitTask({ taskId: "t-exact-owner", text: "do not steal another turn" });
+
+    expect(await bridge.reconcileActiveTurn()).toEqual({
+      recovered: false,
+      turnId: "turn_exact_owner",
+      status: "active",
+    });
+    expect(replies).toHaveLength(0);
+    expect(bridge.activeTurn()).toBe("turn_exact_owner");
+    await client.close();
+    await app.stop();
+  });
+
   test("thread/read never recovers an interrupted turn as success", async () => {
     const app = await startFakeApp({
       onRequest: (msg, respond) => {

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -831,7 +831,7 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     await app.stop();
   });
 
-  test("thread/read recovers a missed turn/completed and drains the queued task", async () => {
+  test("thread/read recovers a completed owned turn while a successor keeps the thread active", async () => {
     let seq = 0;
     let firstTurnIsPersistedComplete = false;
     const app = await startFakeApp({
@@ -848,7 +848,10 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
             result: {
               thread: {
                 id: THREAD,
-                status: { type: firstTurnIsPersistedComplete ? "idle" : "active" },
+                // Production UAT: the exact owned turn completed, but a new
+                // TUI/goal turn started without an idle polling gap. Aggregate
+                // thread status therefore stays active throughout.
+                status: { type: "active" },
                 turns: includeTurns && firstTurnIsPersistedComplete
                   ? [{
                       id: "turn_reconcile_1",
@@ -888,22 +891,78 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     expect(bridge.activeTurn()).toBe("turn_reconcile_1");
     expect(bridge.queueDepth()).toBe(1);
 
-    // This is the production failure shape: the exact turn is terminal in
-    // thread/read, but its terminal WebSocket frame never reached the bridge.
+    // Production failure shape: the exact owned turn is terminal, its
+    // turn/completed frame is lost, and a successor starts immediately so the
+    // aggregate thread never becomes idle. The successor notification forces
+    // one exact-history reconciliation.
     firstTurnIsPersistedComplete = true;
-    expect(await bridge.reconcileActiveTurn()).toEqual({
-      recovered: true,
-      turnId: "turn_reconcile_1",
-      status: "completed",
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: THREAD, turn: { id: "human-successor" } },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(replies).toEqual([{ taskId: "t-reconcile-1", text: "recovered-answer-1" }]);
+    expect(bridge.queueDepth()).toBe(1);
+    expect(bridge.activeTurn()).toBeNull();
+    expect(app.received.filter((entry) => (entry as { method?: string }).method === "turn/start")).toHaveLength(1);
+
+    // Recovery must not start queued task 2 while the successor is active.
+    // Its terminal event is the next legitimate FIFO drain edge.
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turn: { id: "human-successor", status: "completed" } },
     });
     await new Promise((resolve) => setTimeout(resolve, 40));
-    expect(replies).toEqual([{ taskId: "t-reconcile-1", text: "recovered-answer-1" }]);
     expect(bridge.queueDepth()).toBe(0);
     expect(bridge.activeTurn()).toBe("turn_reconcile_2");
-    // First check stops after the cheap active-status read. Recovery does a
-    // cheap idle-status read followed by one full-history read.
-    expect(app.received.filter((entry) => (entry as { method?: string }).method === "thread/read")).toHaveLength(3);
+    expect(app.received.filter((entry) => (entry as { method?: string }).method === "turn/start")).toHaveLength(2);
 
+    await client.close();
+    await app.stop();
+  });
+
+  test("slow full-history fallback recovers when both terminal and successor notifications are lost", async () => {
+    let persistedComplete = false;
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/start") return respond({ result: { turn: { id: "turn_double_loss" } } });
+        if (msg.method === "thread/read") {
+          const includeTurns = (msg.params as { includeTurns?: boolean } | undefined)?.includeTurns;
+          return respond({ result: { thread: {
+            status: { type: "active" },
+            turns: includeTurns && persistedComplete ? [{
+              id: "turn_double_loss",
+              status: "completed",
+              items: [{ type: "agentMessage", phase: "final_answer", text: "fallback-answer" }],
+            }] : undefined,
+          } } });
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({
+      client,
+      threadId: THREAD,
+      // Test seam: make the production 60s slow fallback due immediately.
+      fullHistoryReconciliationIntervalMs: 0,
+    });
+    await bridge.bootstrap();
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (reply) => replies.push(reply as never));
+    await bridge.submitTask({ taskId: "t-double-loss", text: "recover without frames" });
+
+    persistedComplete = true;
+    expect(await bridge.reconcileActiveTurn()).toEqual({
+      recovered: true,
+      turnId: "turn_double_loss",
+      status: "completed",
+    });
+    expect(replies).toEqual([{ taskId: "t-double-loss", text: "fallback-answer" }]);
+    expect(app.received.filter((entry) => (entry as { method?: string }).method === "thread/read")).toHaveLength(2);
     await client.close();
     await app.stop();
   });

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -38,6 +38,8 @@ export interface CodexAppServerBridgeOptions {
   threadId?: string;
   /** Optional label for logs. */
   bridgeLabel?: string;
+  /** Slow full-history fallback; production default avoids 5s multi-MB reads. */
+  fullHistoryReconciliationIntervalMs?: number;
 }
 
 export type BridgeStatus =
@@ -131,12 +133,16 @@ export class CodexAppServerBridge extends EventEmitter {
   private draining = false;
   /** Coalesce watchdog reads so concurrent callers never stampede app-server. */
   private reconciliationInFlight: Promise<ActiveTurnReconciliation> | null = null;
+  private readonly fullHistoryReconciliationIntervalMs: number;
+  private lastFullHistoryReconciliationAt = Date.now();
 
   constructor(opts: CodexAppServerBridgeOptions) {
     super();
     this.client = opts.client;
     this.threadId = opts.threadId ?? "";
     this.label = opts.bridgeLabel ?? `bridge:${(this.threadId || "new").slice(0, 8)}`;
+    this.fullHistoryReconciliationIntervalMs =
+      opts.fullHistoryReconciliationIntervalMs ?? 60_000;
     this.attachClientListeners();
   }
 
@@ -388,7 +394,7 @@ export class CodexAppServerBridge extends EventEmitter {
   /** Drain the FIFO after a turn finishes. One task per idle transition. */
   private async drainQueue(): Promise<void> {
     if (this.draining) return;
-    if (this.turnClaimed || this.activeTurnId) return;
+    if (this.turnClaimed || this.activeTurnId || this.externalActiveTurnId) return;
     const next = this.taskQueue.shift();
     if (!next) return;
     this.draining = true;
@@ -439,6 +445,7 @@ export class CodexAppServerBridge extends EventEmitter {
         }>;
       };
     }>("thread/read", { threadId: this.threadId, includeTurns: true });
+    this.lastFullHistoryReconciliationAt = Date.now();
     if (extractThreadStatus(result?.thread?.status) !== "active") {
       return { turnId: null, steerable: false };
     }
@@ -544,6 +551,7 @@ export class CodexAppServerBridge extends EventEmitter {
     const turnId = extractTurnId(params);
     if (!turnId) return;
     if (!this.pendingTurns.has(turnId)) {
+      const ownedTurnWasActive = this.activeTurnId !== null;
       // A turn we didn't start — e.g. the human TUI. Track its exact id so
       // authenticated Dashboard chat can use turn/steer. We still never map
       // a reply unless at least one task was explicitly and successfully
@@ -552,6 +560,16 @@ export class CodexAppServerBridge extends EventEmitter {
       this.externalActiveTurnSteerable = true;
       if (this.waitingApprovals.size === 0) this.setStatus("working");
       this.emit("unowned_turn_drop", { turnId, event: "turn/started" });
+      if (ownedTurnWasActive) {
+        // A successor can start immediately after our turn completes while
+        // its terminal frame is lost. First join any in-flight cheap read,
+        // then force one exact-history read. This avoids both a missed force
+        // race and a 5-second loop over multi-megabyte thread history.
+        void this.reconcileActiveTurn()
+          .catch(() => ({ recovered: false, turnId: this.activeTurnId }))
+          .then(() => this.reconcileActiveTurn(true))
+          .catch((error) => this.emit("reconciliation_error", error));
+      }
       return;
     }
   }
@@ -652,43 +670,49 @@ export class CodexAppServerBridge extends EventEmitter {
    *
    * WebSocket notifications are best-effort. If one `turn/completed` frame is
    * missed, the old implementation retained `activeTurnId` forever: every
-   * later Agent Network task entered the FIFO and timed out even though
-   * `thread/read` reported the thread idle and the turn completed. This method
-   * closes that one-frame failure mode without guessing that an old turn is
-   * done: only an explicit terminal status for the exact active turn releases
-   * the claim.
+   * later Agent Network task entered the FIFO and timed out even though the
+   * exact persisted turn was completed. The aggregate thread can be idle or
+   * already active with a successor; only an explicit terminal status for the
+   * exact claimed turn releases it.
    */
-  async reconcileActiveTurn(): Promise<ActiveTurnReconciliation> {
+  async reconcileActiveTurn(forceFullHistory = false): Promise<ActiveTurnReconciliation> {
     if (this.reconciliationInFlight) return this.reconciliationInFlight;
     const ownedAtStart = this.activeTurnId;
     const externalAtStart = this.externalActiveTurnId;
     const activeAtStart = ownedAtStart ?? externalAtStart;
     if (!activeAtStart) return { recovered: false, turnId: null };
+    const claimedTurnChanged = () => ownedAtStart !== null
+      ? this.activeTurnId !== activeAtStart
+      : this.externalActiveTurnId !== activeAtStart;
 
     this.reconciliationInFlight = (async () => {
-      // Keep the steady-state watchdog cheap: read only the thread status
-      // while Codex is working. Hydrate full turn history only after the
-      // authoritative status says idle (or an older server omits status).
+      // Most watchdog ticks stay cheap. Full history on a real long-lived TUI
+      // can be several megabytes, so hydrate it only when the thread is idle,
+      // a successor event explicitly forces an exact check, or the slow
+      // fallback interval expires (covering loss of both terminal and
+      // successor notifications).
       const statusResult = await this.client.request<{
         thread?: { status?: string | { type?: string } };
       }>("thread/read", { threadId: this.threadId, includeTurns: false });
 
-      // A notification may have completed the turn while thread/read was in
-      // flight. Never let an old snapshot release a newer active claim.
-      if (
-        (ownedAtStart && this.activeTurnId !== activeAtStart) ||
-        (externalAtStart && this.externalActiveTurnId !== activeAtStart)
-      ) {
+      if (claimedTurnChanged()) {
         return { recovered: false, turnId: activeAtStart };
       }
 
       const threadStatus = extractThreadStatus(statusResult?.thread?.status);
-      if (threadStatus && threadStatus !== "idle") {
+      const fullHistoryDue =
+        forceFullHistory ||
+        !threadStatus ||
+        threadStatus === "idle" ||
+        Date.now() - this.lastFullHistoryReconciliationAt >=
+          this.fullHistoryReconciliationIntervalMs;
+      if (!fullHistoryDue) {
         return { recovered: false, turnId: activeAtStart, status: threadStatus };
       }
 
       const result = await this.client.request<{
         thread?: {
+          status?: string | { type?: string };
           turns?: Array<{
             id?: string;
             status?: string;
@@ -697,17 +721,21 @@ export class CodexAppServerBridge extends EventEmitter {
           }>;
         };
       }>("thread/read", { threadId: this.threadId, includeTurns: true });
+      this.lastFullHistoryReconciliationAt = Date.now();
 
-      if (
-        (ownedAtStart && this.activeTurnId !== activeAtStart) ||
-        (externalAtStart && this.externalActiveTurnId !== activeAtStart)
-      ) {
+      // A notification may have completed the turn while thread/read was in
+      // flight. Never let an old snapshot release a newer active claim.
+      if (claimedTurnChanged()) {
         return { recovered: false, turnId: activeAtStart };
       }
 
       const turn = result?.thread?.turns?.find((candidate) => candidate.id === activeAtStart);
       if (!turn || !isTerminalTurnStatus(turn.status)) {
-        return { recovered: false, turnId: activeAtStart, status: turn?.status };
+        return {
+          recovered: false,
+          turnId: activeAtStart,
+          status: turn?.status ?? extractThreadStatus(result?.thread?.status),
+        };
       }
 
       const finalText = [...(turn.items ?? [])]

--- a/docs/tests/report-test586-codex-successor-reconcile.txt
+++ b/docs/tests/report-test586-codex-successor-reconcile.txt
@@ -1,0 +1,40 @@
+# test586 — exact-turn reconciliation under an active successor
+
+Status: PASS.
+
+Docker image: `anet-test586:dev`
+
+Evidence:
+
+- normal bridge/runtime suite: 41 pass, 0 fail, 127 assertions;
+- exact production-shaped test keeps aggregate thread status `active` while
+  the locally owned turn changes from active to completed, then proves the
+  mapped reply and FIFO drain;
+- `aggregate_active_shortcut` mutation reintroduces the faulty early return
+  and is witnessed red (`recovered:false/status:active` instead of the exact
+  completed-turn recovery);
+- actual minified agent-node bundle: PASS.
+
+Performance gate: a real full-history read on the current 185-turn Codex
+thread measured 9,575,061 bytes and 4,517 ms. The implementation therefore
+keeps ordinary 5-second watchdog ticks on cheap `includeTurns:false` reads,
+forces one exact-history read when a successor `turn/started` is observed, and
+uses a 60-second full-history fallback only when both terminal and successor
+notifications were lost. Tests separately prove the successor-triggered path,
+the double-notification-loss fallback, and that FIFO task 2 is not started
+while the successor human turn remains active.
+
+Production witness (2026-08-04):
+
+- app-server `thread/read` showed owned Dashboard turn
+  `5ac3d4e4-ac91-4453-8d92-3873ad25a71a` as `completed` with the exact ACK;
+- a newer goal/TUI turn was already `inProgress`, so aggregate thread status
+  remained `active`;
+- Hub task `idem_5656030b102e4594d06fc9f10a73e304a5d045a8` remained `running` and
+  the bridge emitted no `task_reply`.
+
+Acceptance: reconciliation must inspect the exact locally claimed turn even
+when the aggregate thread is active, recover its terminal result, emit the
+mapped reply, and drain the next FIFO row. Reintroducing the aggregate-active
+early return must make the focused test red. The actual agent-node bundle must
+still build in Docker.

--- a/docs/tests/report-test586-codex-successor-reconcile.txt
+++ b/docs/tests/report-test586-codex-successor-reconcile.txt
@@ -6,13 +6,13 @@ Docker image: `anet-test586:dev`
 
 Evidence:
 
-- normal bridge/runtime suite: 41 pass, 0 fail, 127 assertions;
+- normal bridge/runtime suite: 42 pass, 0 fail, 130 assertions;
 - exact production-shaped test keeps aggregate thread status `active` while
   the locally owned turn changes from active to completed, then proves the
   mapped reply and FIFO drain;
-- `aggregate_active_shortcut` mutation reintroduces the faulty early return
-  and is witnessed red (`recovered:false/status:active` instead of the exact
-  completed-turn recovery);
+- three targeted mutations are witnessed red: aggregate-active shortcut
+  suppresses recovery, wrong-turn attribution steals another turn's answer,
+  and ignoring the active successor drains task 2 too early;
 - actual minified agent-node bundle: PASS.
 
 Performance gate: a real full-history read on the current 185-turn Codex

--- a/tests/test586-codex-successor-reconcile/Dockerfile
+++ b/tests/test586-codex-successor-reconcile/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node/src ./agent-node/src
+COPY tests/test586-codex-successor-reconcile/run.sh /harness/run.sh
+COPY tests/test586-codex-successor-reconcile/mutate.ts /harness/mutate.ts
+RUN chmod 0755 /harness/run.sh
+
+ENTRYPOINT ["/harness/run.sh"]

--- a/tests/test586-codex-successor-reconcile/mutate.ts
+++ b/tests/test586-codex-successor-reconcile/mutate.ts
@@ -1,0 +1,12 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+if (process.argv[2] !== "aggregate_active_shortcut") {
+  throw new Error(`unknown mutation: ${process.argv[2]}`);
+}
+
+const path = "./src/runtime/codex-app-server-bridge.ts";
+const source = readFileSync(path, "utf8");
+const anchor = `        forceFullHistory ||\n`;
+const matches = source.split(anchor).length - 1;
+if (matches !== 1) throw new Error(`expected one anchor, got ${matches}`);
+writeFileSync(path, source.replace(anchor, `        false ||\n`));

--- a/tests/test586-codex-successor-reconcile/mutate.ts
+++ b/tests/test586-codex-successor-reconcile/mutate.ts
@@ -1,12 +1,31 @@
 import { readFileSync, writeFileSync } from "node:fs";
 
-if (process.argv[2] !== "aggregate_active_shortcut") {
-  throw new Error(`unknown mutation: ${process.argv[2]}`);
-}
-
 const path = "./src/runtime/codex-app-server-bridge.ts";
 const source = readFileSync(path, "utf8");
-const anchor = `        forceFullHistory ||\n`;
-const matches = source.split(anchor).length - 1;
-if (matches !== 1) throw new Error(`expected one anchor, got ${matches}`);
-writeFileSync(path, source.replace(anchor, `        false ||\n`));
+const mutation = process.argv[2];
+
+function replaceExact(before: string, after: string) {
+  const matches = source.split(before).length - 1;
+  if (matches !== 1) throw new Error(`${mutation}: expected one anchor, got ${matches}`);
+  writeFileSync(path, source.replace(before, after));
+}
+
+switch (mutation) {
+  case "aggregate_active_shortcut":
+    replaceExact(`        forceFullHistory ||\n`, `        false ||\n`);
+    break;
+  case "wrong_turn_attribution":
+    replaceExact(
+      `.find((candidate) => candidate.id === activeAtStart);`,
+      `.find((candidate) => isTerminalTurnStatus(candidate.status));`,
+    );
+    break;
+  case "drain_during_successor":
+    replaceExact(
+      `if (this.turnClaimed || this.activeTurnId || this.externalActiveTurnId) return;`,
+      `if (this.turnClaimed || this.activeTurnId) return;`,
+    );
+    break;
+  default:
+    throw new Error(`unknown mutation: ${mutation}`);
+}

--- a/tests/test586-codex-successor-reconcile/run.sh
+++ b/tests/test586-codex-successor-reconcile/run.sh
@@ -12,19 +12,20 @@ if ! bun test \
 fi
 cat "$normal"
 
-cp ./src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
-bun /harness/mutate.ts aggregate_active_shortcut
-mutation=/tmp/test586-mutation.log
-if bun test ./src/runtime/codex-app-server-bridge.test.ts \
-  --test-name-pattern 'successor keeps the thread active' >"$mutation" 2>&1; then
-  cat "$mutation"
+for mutation_name in aggregate_active_shortcut wrong_turn_attribution drain_during_successor; do
+  cp ./src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
+  bun /harness/mutate.ts "$mutation_name"
+  mutation="/tmp/test586-${mutation_name}.log"
+  if bun test ./src/runtime/codex-app-server-bridge.test.ts >"$mutation" 2>&1; then
+    cat "$mutation"
+    cp /tmp/codex-app-server-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+    echo "RESULT: FAIL mutation-survived $mutation_name"
+    exit 1
+  fi
+  echo "WITNESSED-RED: $mutation_name"
+  tail -18 "$mutation"
   cp /tmp/codex-app-server-bridge.ts ./src/runtime/codex-app-server-bridge.ts
-  echo "RESULT: FAIL mutation-survived"
-  exit 1
-fi
-echo "WITNESSED-RED: aggregate_active_shortcut"
-cat "$mutation"
-cp /tmp/codex-app-server-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+done
 
 bun run build >/tmp/test586-build.log 2>&1 || {
   cat /tmp/test586-build.log

--- a/tests/test586-codex-successor-reconcile/run.sh
+++ b/tests/test586-codex-successor-reconcile/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -u
+
+cd /workspace/agent-node
+normal=/tmp/test586-normal.log
+if ! bun test \
+  ./src/runtime/codex-app-server-bridge.test.ts \
+  ./src/runtime/codex-app-server/runtime.test.ts >"$normal" 2>&1; then
+  cat "$normal"
+  echo "RESULT: FAIL normal"
+  exit 1
+fi
+cat "$normal"
+
+cp ./src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
+bun /harness/mutate.ts aggregate_active_shortcut
+mutation=/tmp/test586-mutation.log
+if bun test ./src/runtime/codex-app-server-bridge.test.ts \
+  --test-name-pattern 'successor keeps the thread active' >"$mutation" 2>&1; then
+  cat "$mutation"
+  cp /tmp/codex-app-server-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+  echo "RESULT: FAIL mutation-survived"
+  exit 1
+fi
+echo "WITNESSED-RED: aggregate_active_shortcut"
+cat "$mutation"
+cp /tmp/codex-app-server-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+
+bun run build >/tmp/test586-build.log 2>&1 || {
+  cat /tmp/test586-build.log
+  echo "RESULT: FAIL build"
+  exit 1
+}
+echo "BUILD: PASS"
+echo "RESULT: PASS"


### PR DESCRIPTION
## Production bug

After #580 removed the double-open race, real Dashboard UAT produced this authoritative contradiction:

- owned Dashboard turn `5ac3d4e4…` was persisted `completed` with the exact ACK;
- a successor goal/TUI turn was already `inProgress`, so aggregate thread status stayed `active`;
- the Hub task remained `running` and no automatic reply was emitted.

The watchdog treated aggregate `active` as proof that its exact claimed turn was still active. With continuous TUI turns and a missed terminal frame, it could never recover.

## Fix

- successor `turn/started` forces one exact-history reconciliation after joining any in-flight cheap read;
- ordinary 5s watchdog ticks remain cheap (`includeTurns:false`);
- a 60s full-history fallback covers loss of both terminal and successor notifications;
- exact claim race checks select owned vs external state correctly when both exist;
- FIFO drain refuses to start task 2 while the successor human turn is active.

## Performance evidence

A real full read of the current 185-turn thread was 9,575,061 bytes / 4,517 ms. This is why the patch does not perform full history reads every 5 seconds.

## Verification

Docker `anet-test586:dev`:

- 41 pass, 0 fail, 127 assertions;
- production-shaped active-successor recovery passes;
- double-notification-loss fallback passes;
- aggregate-active early-return mutation is witnessed red;
- actual minified agent-node bundle builds.

Source/test commit: `1c6484bdd72adf896383198abda768ef2eca0baf`
Report-only head: `5966c1bd483455021430e53bfb265ed419990b6a`

No Hub, Dashboard, schema, API, TUI, or app-server changes. Independent review required; do not self-merge.
