### PR TITLE
test(codex): pin that a missing owned turn is never treated as completed

### DIFF
--- a/tests/test586-codex-successor-reconcile/mutate.ts
+++ b/tests/test586-codex-successor-reconcile/mutate.ts
@@ -20,6 +20,12 @@ switch (mutation) {
       `.find((candidate) => isTerminalTurnStatus(candidate.status));`,
     );
     break;
+  case "missing_turn_fail_open":
+    replaceExact(
+      `.find((candidate) => candidate.id === activeAtStart);`,
+      `.find((candidate) => candidate.id === activeAtStart) ?? { id: activeAtStart, status: "completed", items: [] };`,
+    );
+    break;
   case "drain_during_successor":
     replaceExact(
       `if (this.turnClaimed || this.activeTurnId || this.externalActiveTurnId) return;`,

--- a/tests/test586-codex-successor-reconcile/run.sh
+++ b/tests/test586-codex-successor-reconcile/run.sh
@@ -12,7 +12,7 @@ if ! bun test \
 fi
 cat "$normal"
 
-for mutation_name in aggregate_active_shortcut wrong_turn_attribution drain_during_successor; do
+for mutation_name in aggregate_active_shortcut missing_turn_fail_open wrong_turn_attribution drain_during_successor; do
   cp ./src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
   bun /harness/mutate.ts "$mutation_name"
   mutation="/tmp/test586-${mutation_name}.log"


### PR DESCRIPTION
补 #581 的第四条 mutation。测试文件 only，无生产代码改动。

## 守的是哪一行

#581 让 watchdog 按 exact turnId 判定，找不到时返回 `recovered: false`：

```ts
const turn = result?.thread?.turns?.find(c => c.id === activeAtStart);
if (!turn || !isTerminalTurnStatus(turn.status)) { ... }
```

**`!turn` 这一支是「丢了终止帧」和「给一个还在跑的轮子发回复」之间唯一的东西。**

丢回复可以恢复，拿别的轮子的文本去答一个活着的轮子不能。这一支原本只有断言、没有 mutation —— 也就是没有任何东西证明那条断言分辨得出来。

## 加的 mutation

```ts
.find(c => c.id === activeAtStart)
  ?? { id: activeAtStart, status: "completed", items: [] }
```

查不到就伪造一个 completed 轮子。

## 亲手跑出来的，不是抄报告

```
未变异                     31 pass / 0 fail / 112 expects
missing_turn_fail_open     30 pass / 1 fail
  红的用例: "full history never attributes a different completed turn to the owned task"
还原                       31 pass / 0 fail
```

锚点在改写前断言**恰好出现一次**，所以以后那段查找被重构时，这条 mutation 不会静默退化成 no-op。