### PR TITLE
test(agent-node): enforce missing-turn reconciliation guard

### DIFF
--- a/docs/tests/report-test586-codex-successor-reconcile.txt
+++ b/docs/tests/report-test586-codex-successor-reconcile.txt
@@ -10,9 +10,10 @@ Evidence:
 - exact production-shaped test keeps aggregate thread status `active` while
   the locally owned turn changes from active to completed, then proves the
   mapped reply and FIFO drain;
-- three targeted mutations are witnessed red: aggregate-active shortcut
-  suppresses recovery, wrong-turn attribution steals another turn's answer,
-  and ignoring the active successor drains task 2 too early;
+- four targeted mutations are witnessed red: aggregate-active shortcut
+  suppresses recovery, a missing exact turn fails open as fake completion,
+  wrong-turn attribution steals another turn's answer, and ignoring the active
+  successor drains task 2 too early;
 - actual minified agent-node bundle: PASS.
 
 Performance gate: a real full-history read on the current 185-turn Codex

--- a/tests/test586-codex-successor-reconcile/mutate.ts
+++ b/tests/test586-codex-successor-reconcile/mutate.ts
@@ -20,6 +20,12 @@ switch (mutation) {
       `.find((candidate) => isTerminalTurnStatus(candidate.status));`,
     );
     break;
+  case "missing_turn_fail_open":
+    replaceExact(
+      `.find((candidate) => candidate.id === activeAtStart);`,
+      `.find((candidate) => candidate.id === activeAtStart) ?? { id: activeAtStart, status: "completed", items: [] };`,
+    );
+    break;
   case "drain_during_successor":
     replaceExact(
       `if (this.turnClaimed || this.activeTurnId || this.externalActiveTurnId) return;`,

--- a/tests/test586-codex-successor-reconcile/run.sh
+++ b/tests/test586-codex-successor-reconcile/run.sh
@@ -12,7 +12,7 @@ if ! bun test \
 fi
 cat "$normal"
 
-for mutation_name in aggregate_active_shortcut wrong_turn_attribution drain_during_successor; do
+for mutation_name in aggregate_active_shortcut missing_turn_fail_open wrong_turn_attribution drain_during_successor; do
   cp ./src/runtime/codex-app-server-bridge.ts /tmp/codex-app-server-bridge.ts
   bun /harness/mutate.ts "$mutation_name"
   mutation="/tmp/test586-${mutation_name}.log"


### PR DESCRIPTION
## Scope

Add-only follow-up to merged #581. No production/API/schema changes.

The independent review requested a second mutation proving that an exact owned turn missing from full history cannot be treated as a completed turn. `missing_turn_fail_open` semantically replaces the fail-closed lookup with a fake completed turn; the unchanged production tests turn red.

## Docker evidence

- normal: 42 pass, 0 fail, 130 assertions
- witnessed-red mutations: aggregate active shortcut, missing exact turn fail-open, wrong-turn attribution, drain during successor
- minified agent-node bundle: PASS

Test commit: `b71f30e4`
Report-only head: `bfa2b4a5`

Independent review required. Do not self-merge or publish.