### PR TITLE
fix(agent-node): start Codex timeout after FIFO admission

### DIFF
--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -594,6 +594,8 @@ describe("CodexAppServerBridge — authenticated Dashboard steering", () => {
 
     const replies: Array<{ taskId: string; text: string }> = [];
     bridge.on("task_reply", (event) => replies.push(event as never));
+    const started: unknown[] = [];
+    bridge.on("task_started", (event) => started.push(event));
     const submitted = await bridge.submitTask({
       taskId: "dash-1",
       text: "第二条消息",
@@ -601,6 +603,7 @@ describe("CodexAppServerBridge — authenticated Dashboard steering", () => {
       steerIfExternalTurn: true,
     });
     expect(submitted).toEqual({ started: true, turnId: "human-1", steered: true });
+    expect(started).toEqual([{ taskId: "dash-1", turnId: "human-1", steered: true }]);
     const steer = app.received.find((entry) => (entry as { method?: string }).method === "turn/steer") as any;
     expect(steer.params).toEqual({
       threadId: THREAD,
@@ -793,6 +796,8 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     bridge.on("task_reply", (r) => replies.push(r as { taskId: string; text: string }));
     const queued: string[] = [];
     bridge.on("task_queued", (q) => queued.push((q as { taskId: string }).taskId));
+    const started: Array<{ taskId: string; turnId: string; steered: boolean }> = [];
+    bridge.on("task_started", (event) => started.push(event as never));
 
     const r1 = await bridge.submitTask({ taskId: "t-q-1", text: "first" });
     const r2 = await bridge.submitTask({ taskId: "t-q-2", text: "second" });
@@ -803,6 +808,7 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     // Wire gate: B is admitted into bridge FIFO, but no second turn/start is
     // emitted while A is active.
     expect(turnStartTaskIds).toEqual(["t-q-1"]);
+    expect(started).toEqual([{ taskId: "t-q-1", turnId: "turn_q_1", steered: false }]);
 
     // Complete turn 1 → bridge should auto-drain and start turn 2.
     app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_q_1", item: { type: "agentMessage", phase: "final_answer", text: "answer-1" } } });
@@ -816,6 +822,10 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     expect(bridge.queueDepth()).toBe(0);
     expect(bridge.activeTurn()).toBe("turn_q_2");
     expect(turnStartTaskIds).toEqual(["t-q-1", "t-q-2"]);
+    expect(started).toEqual([
+      { taskId: "t-q-1", turnId: "turn_q_1", steered: false },
+      { taskId: "t-q-2", turnId: "turn_q_2", steered: false },
+    ]);
 
     app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_q_2", item: { type: "agentMessage", phase: "final_answer", text: "answer-2" } } });
     app.broadcast({

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -91,6 +91,7 @@ export interface ActiveTurnReconciliation {
  *   - "status_changed"    → { previous, current }
  *   - "waiting_human"     → WaitingApproval (bridge did not respond)
  *   - "approval_resolved" → { reverseRequestId } — from serverRequest/resolved
+ *   - "task_started"      → { taskId, turnId, steered } — model budget starts
  *   - "task_reply"        → { taskId, text }  — final agent message
  *   - "task_error"        → { taskId, error }
  *   - "cross_thread_drop" → { event } — event for a thread we don't own
@@ -280,6 +281,7 @@ export class CodexAppServerBridge extends EventEmitter {
       this.externalActiveTurnId = null;
       this.externalActiveTurnSteerable = false;
     }
+    this.emit("task_started", { taskId: input.taskId, turnId, steered: false });
     return turnId;
   }
 
@@ -359,6 +361,11 @@ export class CodexAppServerBridge extends EventEmitter {
         );
       }
       state.acceptedTaskIds.add(input.taskId);
+      this.emit("task_started", {
+        taskId: input.taskId,
+        turnId: expectedTurnId,
+        steered: true,
+      });
       // If turn/completed raced the RPC response, attribution waits for this
       // acceptance proof and is emitted now rather than fail-open earlier.
       if (state.terminal) {

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -123,7 +123,68 @@ class ReconcileOnlyBridge extends EventEmitter {
   }
 }
 
+class DeferredStartBridge extends EventEmitter {
+  submitted: Record<string, unknown> | null = null;
+
+  async submitTask(input: { taskId: string }): Promise<{ started: false; queuedAt: number }> {
+    this.submitted = input;
+    return { started: false, queuedAt: 1 };
+  }
+
+  async reconcileActiveTurn(): Promise<{ recovered: false; turnId: null }> {
+    return { recovered: false, turnId: null };
+  }
+}
+
 describe("codexAppServerThink — terminal-event reconciliation watchdog", () => {
+  test("queued wait does not consume the model-response timeout budget", async () => {
+    const bridge = new DeferredStartBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    let settled = false;
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_waits_then_starts",
+      text: "second FIFO task",
+      timeoutMs: 40,
+      reconciliationIntervalMs: 0,
+    }).finally(() => { settled = true; });
+
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    expect(settled).toBe(false);
+
+    bridge.emit("task_started", {
+      taskId: "task_waits_then_starts",
+      turnId: "turn_after_queue",
+      steered: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    bridge.emit("task_reply", { taskId: "task_waits_then_starts", text: "done" });
+
+    expect(await thinking).toEqual({ replyText: "done", failed: false, queued: false });
+  });
+
+  test("another task starting cannot arm this task's timeout", async () => {
+    const bridge = new DeferredStartBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    let settled = false;
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_still_queued",
+      text: "wait for my own start",
+      timeoutMs: 35,
+      reconciliationIntervalMs: 0,
+    }).finally(() => { settled = true; });
+
+    bridge.emit("task_started", { taskId: "different_task", turnId: "turn_other" });
+    await new Promise((resolve) => setTimeout(resolve, 55));
+    expect(settled).toBe(false);
+
+    bridge.emit("task_started", { taskId: "task_still_queued", turnId: "turn_mine" });
+    await new Promise((resolve) => setTimeout(resolve, 55));
+    bridge.emit("task_reply", { taskId: "task_still_queued", text: "too late" });
+    const result = await thinking;
+    expect(result.failed).toBe(true);
+    expect(result.replyText).toContain("任务 task_still_queued 超时");
+  });
+
   test("resolves from authoritative reconciliation when turn/completed is missed", async () => {
     const bridge = new ReconcileOnlyBridge();
     const logs: string[] = [];

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -257,13 +257,15 @@ export function codexAppServerThink(
 
   return new Promise<CodexAppServerThinkResult>((resolve) => {
     let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     let reconciliationTimer: ReturnType<typeof setTimeout> | undefined;
     const finish = (r: CodexAppServerThinkResult) => {
       if (settled) return;
       settled = true;
       bridge.off("task_reply", onReply);
       bridge.off("task_error", onError);
-      clearTimeout(timer);
+      bridge.off("task_started", onStarted);
+      if (timer) clearTimeout(timer);
       if (reconciliationTimer) clearTimeout(reconciliationTimer);
       resolve(r);
     };
@@ -277,13 +279,21 @@ export function codexAppServerThink(
       log(`[codex-app-server] task_error ${ev.taskId}: ${ev.error}`);
       finish({ replyText: `codex-app-server 错误: ${ev.error}`, failed: true, queued: false });
     };
-    const timer = setTimeout(() => {
-      finish({
-        replyText: `codex-app-server 错误: 任务 ${opts.taskId} 超时（${Math.round(timeoutMs / 1000)}s 内无最终回复）`,
-        failed: true,
-        queued: false,
-      });
-    }, timeoutMs);
+    const startResponseTimer = () => {
+      if (settled || timer) return;
+      timer = setTimeout(() => {
+        finish({
+          replyText: `codex-app-server 错误: 任务 ${opts.taskId} 超时（开始处理后 ${Math.round(timeoutMs / 1000)}s 内无最终回复）`,
+          failed: true,
+          queued: false,
+        });
+      }, timeoutMs);
+    };
+    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {
+      if (ev.taskId !== opts.taskId) return;
+      log(`[codex-app-server] task_started ${ev.taskId} turn=${ev.turnId}${ev.steered ? " (steered)" : ""}`);
+      startResponseTimer();
+    };
 
     // A shared app-server WebSocket can miss an individual terminal
     // notification while the authoritative thread history still records the
@@ -311,6 +321,7 @@ export function codexAppServerThink(
 
     bridge.on("task_reply", onReply);
     bridge.on("task_error", onError);
+    bridge.on("task_started", onStarted);
     scheduleReconciliation();
 
     bridge
@@ -321,6 +332,10 @@ export function codexAppServerThink(
         steerIfExternalTurn: opts.steerIfExternalTurn,
       })
       .then((r) => {
+        // Compatibility fallback for bridge implementations predating the
+        // task_started event. The real bridge emits before this continuation;
+        // startResponseTimer is idempotent, so both paths cannot double-arm.
+        if (r.started) startResponseTimer();
         if (!r.started) log(`[codex-app-server] task ${opts.taskId} queued (a turn is in flight)`);
         else if (r.steered) log(`[codex-app-server] task ${opts.taskId} steered into human turn ${r.turnId}`);
       })

--- a/docs/tests/report-test587-codex-start-relative-timeout.txt
+++ b/docs/tests/report-test587-codex-start-relative-timeout.txt
@@ -1,0 +1,54 @@
+Test 587 — Codex FIFO wait must not consume model timeout
+Date: 2026-08-04 (Asia/Shanghai)
+Base: origin/main 02be2d6980a194f5e0a17d7dc5b86c857d72907a
+Image: anet-test587:dev
+Dockerfile: tests/test587-codex-start-relative-timeout/Dockerfile
+
+Production contradiction
+------------------------
+A Dashboard task remained in the bridge FIFO for the full 600-second runtime
+deadline and failed before its own Codex turn began. `codexAppServerThink()`
+armed the response timer before `submitTask()`, so queue admission and model
+execution incorrectly shared one budget.
+
+Witnessed red (unchanged production implementation)
+---------------------------------------------------
+The new tests were mounted read-only into the existing Docker dependency image
+before the implementation changed:
+
+- 41 pass / 3 fail / 127 assertions;
+- queued wait settled after 40 ms although no task start occurred;
+- another task's start could not be distinguished because no task-scoped start
+  event existed;
+- FIFO drain emitted no observable start event for the queued task.
+
+Implementation
+--------------
+- the bridge emits `task_started { taskId, turnId, steered }` only after a
+  task's own `turn/start` response or authenticated `turn/steer` acceptance;
+- `codexAppServerThink()` arms its 600-second model-response timer only for the
+  matching task-scoped start event;
+- queue wait therefore does not consume the model budget;
+- an idempotent `submitTask().started` fallback preserves compatibility with
+  older/test bridge implementations without double-arming the timer;
+- completion removes the new listener and clears the timer.
+
+Docker result
+-------------
+- normal: 44 pass / 0 fail / 138 assertions;
+- actual minified agent-node bundle: PASS;
+- RESULT: PASS.
+
+Witnessed-red mutations
+-----------------------
+1. `timer_at_submission`: re-arm at submission; queued-wait tests fail.
+2. `ignore_started_event`: remove event-to-timer action; late reply is accepted.
+3. `wrong_task_arms_timer`: remove task_id match; another task expires this one.
+4. `omit_bridge_started_event`: remove owned-turn event; FIFO event contract fails.
+5. `omit_steer_started_event`: remove steer event; Dashboard steer contract fails.
+
+Scope
+-----
+No Hub, Dashboard, schema, auth, token, TUI, app-server process, queue ordering,
+or timeout duration changes. This fixes only the timer origin: actual task start
+instead of queue arrival.

--- a/tests/test587-codex-start-relative-timeout/Dockerfile
+++ b/tests/test587-codex-start-relative-timeout/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node/src ./agent-node/src
+COPY tests/test587-codex-start-relative-timeout/run.sh /harness/run.sh
+COPY tests/test587-codex-start-relative-timeout/mutate.ts /harness/mutate.ts
+RUN chmod 0755 /harness/run.sh
+
+ENTRYPOINT ["/harness/run.sh"]

--- a/tests/test587-codex-start-relative-timeout/mutate.ts
+++ b/tests/test587-codex-start-relative-timeout/mutate.ts
@@ -1,0 +1,52 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const mutation = process.argv[2];
+const runtimePath = "./src/runtime/codex-app-server/runtime.ts";
+const bridgePath = "./src/runtime/codex-app-server-bridge.ts";
+
+function replaceExact(path: string, before: string, after: string): void {
+  const source = readFileSync(path, "utf8");
+  const count = source.split(before).length - 1;
+  if (count !== 1) throw new Error(`${mutation}: expected one anchor in ${path}, found ${count}`);
+  writeFileSync(path, source.replace(before, after));
+}
+
+switch (mutation) {
+  case "timer_at_submission":
+    replaceExact(
+      runtimePath,
+      `    bridge.on("task_started", onStarted);`,
+      `    bridge.on("task_started", onStarted);\n    startResponseTimer();`,
+    );
+    break;
+  case "ignore_started_event":
+    replaceExact(
+      runtimePath,
+      `      startResponseTimer();\n    };\n\n    // A shared app-server WebSocket`,
+      `      void ev;\n    };\n\n    // A shared app-server WebSocket`,
+    );
+    break;
+  case "wrong_task_arms_timer":
+    replaceExact(
+      runtimePath,
+      `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (ev.taskId !== opts.taskId) return;`,
+      `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (false && ev.taskId !== opts.taskId) return;`,
+    );
+    break;
+  case "omit_bridge_started_event":
+    replaceExact(
+      bridgePath,
+      `    this.emit("task_started", { taskId: input.taskId, turnId, steered: false });`,
+      `    void turnId;`,
+    );
+    break;
+  case "omit_steer_started_event":
+    replaceExact(
+      bridgePath,
+      `      this.emit("task_started", {\n        taskId: input.taskId,\n        turnId: expectedTurnId,\n        steered: true,\n      });`,
+      `      void expectedTurnId;`,
+    );
+    break;
+  default:
+    throw new Error(`unknown mutation: ${mutation}`);
+}

--- a/tests/test587-codex-start-relative-timeout/run.sh
+++ b/tests/test587-codex-start-relative-timeout/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -u
+
+cd /workspace/agent-node
+normal=/tmp/test587-normal.log
+if ! bun test \
+  ./src/runtime/codex-app-server-bridge.test.ts \
+  ./src/runtime/codex-app-server/runtime.test.ts >"$normal" 2>&1; then
+  cat "$normal"
+  echo "RESULT: FAIL normal"
+  exit 1
+fi
+cat "$normal"
+
+for mutation_name in timer_at_submission ignore_started_event wrong_task_arms_timer omit_bridge_started_event omit_steer_started_event; do
+  cp ./src/runtime/codex-app-server/runtime.ts /tmp/test587-runtime.ts
+  cp ./src/runtime/codex-app-server-bridge.ts /tmp/test587-bridge.ts
+  if ! bun /harness/mutate.ts "$mutation_name"; then
+    cp /tmp/test587-runtime.ts ./src/runtime/codex-app-server/runtime.ts
+    cp /tmp/test587-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+    echo "RESULT: FAIL mutation-anchor $mutation_name"
+    exit 1
+  fi
+  mutation=/tmp/test587-${mutation_name}.log
+  if bun test \
+    ./src/runtime/codex-app-server-bridge.test.ts \
+    ./src/runtime/codex-app-server/runtime.test.ts >"$mutation" 2>&1; then
+    cat "$mutation"
+    cp /tmp/test587-runtime.ts ./src/runtime/codex-app-server/runtime.ts
+    cp /tmp/test587-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+    echo "RESULT: FAIL mutation-survived $mutation_name"
+    exit 1
+  fi
+  echo "WITNESSED-RED: $mutation_name"
+  tail -16 "$mutation"
+  cp /tmp/test587-runtime.ts ./src/runtime/codex-app-server/runtime.ts
+  cp /tmp/test587-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+done
+
+bun run build >/tmp/test587-build.log 2>&1 || {
+  cat /tmp/test587-build.log
+  echo "RESULT: FAIL build"
+  exit 1
+}
+echo "BUILD: PASS"
+echo "RESULT: PASS"


### PR DESCRIPTION
## Production bug

A Dashboard task that waited in the Codex shared-thread FIFO consumed the same 600-second deadline as model execution. A task could therefore fail before its own turn began.

## Fix

- bridge emits task-scoped `task_started` only after `turn/start` or authenticated `turn/steer` acceptance;
- runtime arms the existing response timeout only for the matching task start;
- FIFO wait no longer consumes model time;
- idempotent compatibility fallback avoids double-arm.

## Docker evidence

- witnessed-red old implementation: 41 pass / 3 fail / 127 assertions;
- fixed: 44 pass / 0 fail / 138 assertions;
- five semantic mutations witnessed red;
- minified agent-node bundle: PASS.

Source/test commit: `357731951749f80faadcef7c598d76a8fcca04ee`
Report-only head: `1e3184e5839384009400f452c582433245d8ebfa`
Image: `anet-test587:dev`

No Hub, Dashboard, API, schema, auth, timeout duration, queue ordering, TUI, or app-server process changes. Independent review required; do not self-merge/publish.