### PR TITLE
fix(agent-node): bound Codex FIFO wait separately

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -2921,7 +2921,7 @@ async function processWithCodexAppServer(
   taskId: string | null,
   steerIfExternalTurn = false,
 ): Promise<string> {
-  const { openCodexAppServerRuntime, codexAppServerThink } =
+  const { openCodexAppServerRuntime, codexAppServerThink, codexAppServerReplyOrThrow } =
     await import("./runtime/codex-app-server/runtime");
 
   const existingSession = codexAppServerSessionManager.current();
@@ -2975,12 +2975,9 @@ async function processWithCodexAppServer(
     log,
   });
 
-  if (outcome.failed) {
-    // Surface as a runtime error string; processTask's failure detector
-    // treats the "错误:" marker as failed=true (dashboard shows real fail).
-    return outcome.replyText;
-  }
-  return outcome.replyText || "（无回复）";
+  // Throw failed outcomes into processTask's existing failure path so the Hub
+  // records `failed`, rather than the old false-success `replied` state.
+  return codexAppServerReplyOrThrow(outcome);
 }
 
 async function processWithGrok(task: string, from: string, images?: string[]): Promise<string> {

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -841,6 +841,44 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     await app.stop();
   });
 
+  test("cancelQueuedTask removes only the named FIFO row before it can execute", async () => {
+    const startedTaskIds: string[] = [];
+    let seq = 0;
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") return respond({ result: {} });
+        if (msg.method === "turn/start") {
+          const clientId = String((msg.params as { clientUserMessageId?: string })?.clientUserMessageId ?? "");
+          startedTaskIds.push(clientId.replace(/^anet:/, ""));
+          return respond({ result: { turn: { id: `turn_cancel_${++seq}` } } });
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+
+    await bridge.submitTask({ taskId: "cancel-active", text: "first" });
+    await bridge.submitTask({ taskId: "cancel-me", text: "must never execute" });
+    await bridge.submitTask({ taskId: "cancel-survivor", text: "third" });
+    expect(bridge.queueDepth()).toBe(2);
+    expect(bridge.cancelQueuedTask("missing-task")).toBe(false);
+    expect(bridge.cancelQueuedTask("cancel-me")).toBe(true);
+    expect(bridge.queueDepth()).toBe(1);
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turn: { id: "turn_cancel_1", status: "completed" } },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(startedTaskIds).toEqual(["cancel-active", "cancel-survivor"]);
+    expect(bridge.activeTurn()).toBe("turn_cancel_2");
+    await client.close();
+    await app.stop();
+  });
+
   test("thread/read recovers a completed owned turn while a successor keeps the thread active", async () => {
     let seq = 0;
     let firstTurnIsPersistedComplete = false;

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -594,6 +594,8 @@ describe("CodexAppServerBridge — authenticated Dashboard steering", () => {
 
     const replies: Array<{ taskId: string; text: string }> = [];
     bridge.on("task_reply", (event) => replies.push(event as never));
+    const started: unknown[] = [];
+    bridge.on("task_started", (event) => started.push(event));
     const submitted = await bridge.submitTask({
       taskId: "dash-1",
       text: "第二条消息",
@@ -601,6 +603,7 @@ describe("CodexAppServerBridge — authenticated Dashboard steering", () => {
       steerIfExternalTurn: true,
     });
     expect(submitted).toEqual({ started: true, turnId: "human-1", steered: true });
+    expect(started).toEqual([{ taskId: "dash-1", turnId: "human-1", steered: true }]);
     const steer = app.received.find((entry) => (entry as { method?: string }).method === "turn/steer") as any;
     expect(steer.params).toEqual({
       threadId: THREAD,
@@ -793,6 +796,8 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     bridge.on("task_reply", (r) => replies.push(r as { taskId: string; text: string }));
     const queued: string[] = [];
     bridge.on("task_queued", (q) => queued.push((q as { taskId: string }).taskId));
+    const started: Array<{ taskId: string; turnId: string; steered: boolean }> = [];
+    bridge.on("task_started", (event) => started.push(event as never));
 
     const r1 = await bridge.submitTask({ taskId: "t-q-1", text: "first" });
     const r2 = await bridge.submitTask({ taskId: "t-q-2", text: "second" });
@@ -803,6 +808,7 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     // Wire gate: B is admitted into bridge FIFO, but no second turn/start is
     // emitted while A is active.
     expect(turnStartTaskIds).toEqual(["t-q-1"]);
+    expect(started).toEqual([{ taskId: "t-q-1", turnId: "turn_q_1", steered: false }]);
 
     // Complete turn 1 → bridge should auto-drain and start turn 2.
     app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_q_1", item: { type: "agentMessage", phase: "final_answer", text: "answer-1" } } });
@@ -816,6 +822,10 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     expect(bridge.queueDepth()).toBe(0);
     expect(bridge.activeTurn()).toBe("turn_q_2");
     expect(turnStartTaskIds).toEqual(["t-q-1", "t-q-2"]);
+    expect(started).toEqual([
+      { taskId: "t-q-1", turnId: "turn_q_1", steered: false },
+      { taskId: "t-q-2", turnId: "turn_q_2", steered: false },
+    ]);
 
     app.broadcast({ jsonrpc: "2.0", method: "item/completed", params: { threadId: THREAD, turnId: "turn_q_2", item: { type: "agentMessage", phase: "final_answer", text: "answer-2" } } });
     app.broadcast({

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -855,6 +855,20 @@ export class CodexAppServerBridge extends EventEmitter {
     return this.taskQueue.length;
   }
 
+  /**
+   * Remove one task that has not begun `turn/start`/`turn/steer` yet.
+   * Used by the runtime's independent queue-wait deadline so a timed-out
+   * Dashboard row cannot silently execute later after its Hub lifecycle has
+   * already been closed as failed.
+   */
+  cancelQueuedTask(taskId: string): boolean {
+    const index = this.taskQueue.findIndex((task) => task.taskId === taskId);
+    if (index < 0) return false;
+    this.taskQueue.splice(index, 1);
+    this.emit("task_queue_cancelled", { taskId, depth: this.taskQueue.length });
+    return true;
+  }
+
   private setStatus(next: BridgeStatus): void {
     if (this.status === next) return;
     const previous = this.status;

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -91,6 +91,7 @@ export interface ActiveTurnReconciliation {
  *   - "status_changed"    → { previous, current }
  *   - "waiting_human"     → WaitingApproval (bridge did not respond)
  *   - "approval_resolved" → { reverseRequestId } — from serverRequest/resolved
+ *   - "task_started"      → { taskId, turnId, steered } — model budget starts
  *   - "task_reply"        → { taskId, text }  — final agent message
  *   - "task_error"        → { taskId, error }
  *   - "cross_thread_drop" → { event } — event for a thread we don't own
@@ -280,6 +281,7 @@ export class CodexAppServerBridge extends EventEmitter {
       this.externalActiveTurnId = null;
       this.externalActiveTurnSteerable = false;
     }
+    this.emit("task_started", { taskId: input.taskId, turnId, steered: false });
     return turnId;
   }
 
@@ -359,6 +361,11 @@ export class CodexAppServerBridge extends EventEmitter {
         );
       }
       state.acceptedTaskIds.add(input.taskId);
+      this.emit("task_started", {
+        taskId: input.taskId,
+        turnId: expectedTurnId,
+        steered: true,
+      });
       // If turn/completed raced the RPC response, attribution waits for this
       // acceptance proof and is emitted now rather than fail-open earlier.
       if (state.terminal) {

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -123,7 +123,68 @@ class ReconcileOnlyBridge extends EventEmitter {
   }
 }
 
+class DeferredStartBridge extends EventEmitter {
+  submitted: Record<string, unknown> | null = null;
+
+  async submitTask(input: { taskId: string }): Promise<{ started: false; queuedAt: number }> {
+    this.submitted = input;
+    return { started: false, queuedAt: 1 };
+  }
+
+  async reconcileActiveTurn(): Promise<{ recovered: false; turnId: null }> {
+    return { recovered: false, turnId: null };
+  }
+}
+
 describe("codexAppServerThink — terminal-event reconciliation watchdog", () => {
+  test("queued wait does not consume the model-response timeout budget", async () => {
+    const bridge = new DeferredStartBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    let settled = false;
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_waits_then_starts",
+      text: "second FIFO task",
+      timeoutMs: 40,
+      reconciliationIntervalMs: 0,
+    }).finally(() => { settled = true; });
+
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    expect(settled).toBe(false);
+
+    bridge.emit("task_started", {
+      taskId: "task_waits_then_starts",
+      turnId: "turn_after_queue",
+      steered: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    bridge.emit("task_reply", { taskId: "task_waits_then_starts", text: "done" });
+
+    expect(await thinking).toEqual({ replyText: "done", failed: false, queued: false });
+  });
+
+  test("another task starting cannot arm this task's timeout", async () => {
+    const bridge = new DeferredStartBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    let settled = false;
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_still_queued",
+      text: "wait for my own start",
+      timeoutMs: 35,
+      reconciliationIntervalMs: 0,
+    }).finally(() => { settled = true; });
+
+    bridge.emit("task_started", { taskId: "different_task", turnId: "turn_other" });
+    await new Promise((resolve) => setTimeout(resolve, 55));
+    expect(settled).toBe(false);
+
+    bridge.emit("task_started", { taskId: "task_still_queued", turnId: "turn_mine" });
+    await new Promise((resolve) => setTimeout(resolve, 55));
+    bridge.emit("task_reply", { taskId: "task_still_queued", text: "too late" });
+    const result = await thinking;
+    expect(result.failed).toBe(true);
+    expect(result.replyText).toContain("任务 task_still_queued 超时");
+  });
+
   test("resolves from authoritative reconciliation when turn/completed is missed", async () => {
     const bridge = new ReconcileOnlyBridge();
     const logs: string[] = [];

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -7,6 +7,7 @@ import {
   buildOwnedAppServerArgs,
   COMMHUB_MCP_TOKEN_ENV,
   codexAppServerThink,
+  codexAppServerReplyOrThrow,
   recoverSharedTurnOnAttach,
   type CodexAppServerRuntimeSession,
 } from "./runtime";
@@ -125,10 +126,20 @@ class ReconcileOnlyBridge extends EventEmitter {
 
 class DeferredStartBridge extends EventEmitter {
   submitted: Record<string, unknown> | null = null;
+  queued = false;
+  cancelCalls = 0;
 
   async submitTask(input: { taskId: string }): Promise<{ started: false; queuedAt: number }> {
     this.submitted = input;
+    this.queued = true;
     return { started: false, queuedAt: 1 };
+  }
+
+  cancelQueuedTask(_taskId: string): boolean {
+    this.cancelCalls++;
+    if (!this.queued) return false;
+    this.queued = false;
+    return true;
   }
 
   async reconcileActiveTurn(): Promise<{ recovered: false; turnId: null }> {
@@ -137,6 +148,52 @@ class DeferredStartBridge extends EventEmitter {
 }
 
 describe("codexAppServerThink — terminal-event reconciliation watchdog", () => {
+  test("a never-started FIFO task has its own finite, distinct queue deadline", async () => {
+    const bridge = new DeferredStartBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_never_starts",
+      text: "must not hang forever",
+      timeoutMs: 30,
+      queueTimeoutMs: 35,
+      reconciliationIntervalMs: 0,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    bridge.emit("task_reply", { taskId: "task_never_starts", text: "late ghost" });
+    const result = await thinking;
+    expect(result.failed).toBe(true);
+    expect(result.queued).toBe(true);
+    expect(result.replyText).toContain("在队列中等待 1 秒仍未开始");
+    expect(result.replyText).not.toContain("开始处理后");
+    expect(bridge.cancelCalls).toBe(1);
+    expect(bridge.queued).toBe(false);
+  });
+
+  test("lost task_started after FIFO removal remains finite", async () => {
+    const bridge = new DeferredStartBridge();
+    bridge.queued = false;
+    bridge.submitTask = async (input: { taskId: string }) => {
+      bridge.submitted = input;
+      return { started: false as const, queuedAt: 1 };
+    };
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_event_lost",
+      text: "start event disappears",
+      timeoutMs: 25,
+      queueTimeoutMs: 30,
+      reconciliationIntervalMs: 0,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    bridge.emit("task_reply", { taskId: "task_event_lost", text: "late after lost event" });
+    const result = await thinking;
+    expect(result.failed).toBe(true);
+    expect(result.queued).toBe(false);
+    expect(result.replyText).toContain("开始处理后");
+    expect(bridge.cancelCalls).toBe(1);
+  });
+
   test("queued wait does not consume the model-response timeout budget", async () => {
     const bridge = new DeferredStartBridge();
     const session = { bridge } as unknown as CodexAppServerRuntimeSession;
@@ -225,5 +282,20 @@ describe("codexAppServerThink — terminal-event reconciliation watchdog", () =>
       from: "admin",
       steerIfExternalTurn: true,
     });
+  });
+});
+
+describe("codexAppServerReplyOrThrow", () => {
+  test("failed bridge outcomes enter processTask's thrown failure path", () => {
+    expect(() => codexAppServerReplyOrThrow({
+      replyText: "codex-app-server 错误: queue deadline",
+      failed: true,
+      queued: true,
+    })).toThrow("queue deadline");
+  });
+
+  test("successful empty replies preserve the existing fallback", () => {
+    expect(codexAppServerReplyOrThrow({ replyText: "", failed: false, queued: false }))
+      .toBe("（无回复）");
   });
 });

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -257,13 +257,15 @@ export function codexAppServerThink(
 
   return new Promise<CodexAppServerThinkResult>((resolve) => {
     let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     let reconciliationTimer: ReturnType<typeof setTimeout> | undefined;
     const finish = (r: CodexAppServerThinkResult) => {
       if (settled) return;
       settled = true;
       bridge.off("task_reply", onReply);
       bridge.off("task_error", onError);
-      clearTimeout(timer);
+      bridge.off("task_started", onStarted);
+      if (timer) clearTimeout(timer);
       if (reconciliationTimer) clearTimeout(reconciliationTimer);
       resolve(r);
     };
@@ -277,13 +279,21 @@ export function codexAppServerThink(
       log(`[codex-app-server] task_error ${ev.taskId}: ${ev.error}`);
       finish({ replyText: `codex-app-server 错误: ${ev.error}`, failed: true, queued: false });
     };
-    const timer = setTimeout(() => {
-      finish({
-        replyText: `codex-app-server 错误: 任务 ${opts.taskId} 超时（${Math.round(timeoutMs / 1000)}s 内无最终回复）`,
-        failed: true,
-        queued: false,
-      });
-    }, timeoutMs);
+    const startResponseTimer = () => {
+      if (settled || timer) return;
+      timer = setTimeout(() => {
+        finish({
+          replyText: `codex-app-server 错误: 任务 ${opts.taskId} 超时（开始处理后 ${Math.round(timeoutMs / 1000)}s 内无最终回复）`,
+          failed: true,
+          queued: false,
+        });
+      }, timeoutMs);
+    };
+    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {
+      if (ev.taskId !== opts.taskId) return;
+      log(`[codex-app-server] task_started ${ev.taskId} turn=${ev.turnId}${ev.steered ? " (steered)" : ""}`);
+      startResponseTimer();
+    };
 
     // A shared app-server WebSocket can miss an individual terminal
     // notification while the authoritative thread history still records the
@@ -311,6 +321,7 @@ export function codexAppServerThink(
 
     bridge.on("task_reply", onReply);
     bridge.on("task_error", onError);
+    bridge.on("task_started", onStarted);
     scheduleReconciliation();
 
     bridge
@@ -321,6 +332,10 @@ export function codexAppServerThink(
         steerIfExternalTurn: opts.steerIfExternalTurn,
       })
       .then((r) => {
+        // Compatibility fallback for bridge implementations predating the
+        // task_started event. The real bridge emits before this continuation;
+        // startResponseTimer is idempotent, so both paths cannot double-arm.
+        if (r.started) startResponseTimer();
         if (!r.started) log(`[codex-app-server] task ${opts.taskId} queued (a turn is in flight)`);
         else if (r.steered) log(`[codex-app-server] task ${opts.taskId} steered into human turn ${r.turnId}`);
       })

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -231,6 +231,13 @@ export interface CodexAppServerThinkResult {
   queued: boolean;
 }
 
+export function codexAppServerReplyOrThrow(outcome: CodexAppServerThinkResult): string {
+  if (outcome.failed) {
+    throw new Error(outcome.replyText.replace(/^codex-app-server 错误:\s*/, ""));
+  }
+  return outcome.replyText || "（无回复）";
+}
+
 /**
  * Run one Agent Network task through the bridge. Submits the task (which
  * queues FIFO if a turn is already in flight) and resolves when THIS task's
@@ -243,6 +250,8 @@ export function codexAppServerThink(
     text: string;
     from?: string;
     timeoutMs?: number;
+    /** FIFO admission deadline, separate from model execution. Default 30m. */
+    queueTimeoutMs?: number;
     /** Test seam; production defaults to a 5s authoritative thread/read. */
     reconciliationIntervalMs?: number;
     log?: (m: string) => void;
@@ -251,6 +260,10 @@ export function codexAppServerThink(
   },
 ): Promise<CodexAppServerThinkResult> {
   const timeoutMs = opts.timeoutMs ?? 10 * 60_000;
+  const queueTimeoutMs = opts.queueTimeoutMs ?? 30 * 60_000;
+  const queueTimeoutLabel = queueTimeoutMs >= 60_000
+    ? `${Math.ceil(queueTimeoutMs / 60_000)} 分钟`
+    : `${Math.ceil(queueTimeoutMs / 1000)} 秒`;
   const reconciliationIntervalMs = opts.reconciliationIntervalMs ?? 5_000;
   const log = opts.log ?? (() => {});
   const { bridge } = session;
@@ -258,6 +271,7 @@ export function codexAppServerThink(
   return new Promise<CodexAppServerThinkResult>((resolve) => {
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let queueTimer: ReturnType<typeof setTimeout> | undefined;
     let reconciliationTimer: ReturnType<typeof setTimeout> | undefined;
     const finish = (r: CodexAppServerThinkResult) => {
       if (settled) return;
@@ -266,6 +280,7 @@ export function codexAppServerThink(
       bridge.off("task_error", onError);
       bridge.off("task_started", onStarted);
       if (timer) clearTimeout(timer);
+      if (queueTimer) clearTimeout(queueTimer);
       if (reconciliationTimer) clearTimeout(reconciliationTimer);
       resolve(r);
     };
@@ -281,6 +296,10 @@ export function codexAppServerThink(
     };
     const startResponseTimer = () => {
       if (settled || timer) return;
+      if (queueTimer) {
+        clearTimeout(queueTimer);
+        queueTimer = undefined;
+      }
       timer = setTimeout(() => {
         finish({
           replyText: `codex-app-server 错误: 任务 ${opts.taskId} 超时（开始处理后 ${Math.round(timeoutMs / 1000)}s 内无最终回复）`,
@@ -323,6 +342,24 @@ export function codexAppServerThink(
     bridge.on("task_error", onError);
     bridge.on("task_started", onStarted);
     scheduleReconciliation();
+
+    queueTimer = setTimeout(() => {
+      // A task still present in FIFO must be removed before we report a queue
+      // timeout; otherwise it could execute later after its Hub row is already
+      // terminal. If it already left FIFO (start RPC in flight or a lost
+      // task_started event), switch to the normal response timer so the task
+      // remains finite without falsely cancelling a running turn.
+      if (!bridge.cancelQueuedTask(opts.taskId)) {
+        log(`[codex-app-server] queue deadline reached after task left FIFO; arming response timeout for ${opts.taskId}`);
+        startResponseTimer();
+        return;
+      }
+      finish({
+        replyText: `codex-app-server 错误: 任务 ${opts.taskId} 在队列中等待 ${queueTimeoutLabel}仍未开始`,
+        failed: true,
+        queued: true,
+      });
+    }, queueTimeoutMs);
 
     bridge
       .submitTask({

--- a/agent-node/src/runtime/codex-app-server/session-manager.test.ts
+++ b/agent-node/src/runtime/codex-app-server/session-manager.test.ts
@@ -13,6 +13,8 @@ describe("createCodexSessionManager", () => {
     );
     expect(body).toContain("codexAppServerSessionManager.getOrOpen(async () =>");
     expect(body).toContain("codexAppServerThink(session,");
+    expect(body).toContain("return codexAppServerReplyOrThrow(outcome);");
+    expect(body).not.toContain("return outcome.replyText;");
   });
 
   test("concurrent Dashboard handlers share one complete open attempt", async () => {

--- a/docs/tests/report-test587-codex-start-relative-timeout.txt
+++ b/docs/tests/report-test587-codex-start-relative-timeout.txt
@@ -1,0 +1,67 @@
+Test 587 — Codex FIFO and model deadlines are finite and independent
+Date: 2026-08-04 (Asia/Shanghai)
+Base: origin/main 83f0cf9d55ca12f53f1092fafff8d899bf3533d1
+Image: anet-test587:dev
+Dockerfile: tests/test587-codex-start-relative-timeout/Dockerfile
+
+Production contradiction
+------------------------
+A Dashboard task remained in the shared-thread FIFO for the full 600-second
+runtime deadline and failed before its own Codex turn began. Logs also showed
+the returned `codex-app-server 错误` was incorrectly sent as `failed=false`.
+
+Witnessed red before implementation
+-----------------------------------
+The initial start-relative tests were mounted read-only into the unchanged
+production Docker image:
+
+- 41 pass / 3 fail / 127 assertions;
+- queued wait settled after 40 ms although no task start occurred;
+- another task's start could not be distinguished because no task-scoped start
+  event existed;
+- FIFO drain emitted no observable start event for the queued task.
+
+Final behavior
+--------------
+- the bridge emits `task_started { taskId, turnId, steered }` only after a
+  task's own `turn/start` response or authenticated `turn/steer` acceptance;
+- the existing 600-second model deadline starts only on that task-scoped event;
+- FIFO wait has a separate finite 30-minute deadline;
+- queue timeout removes the exact task before reporting failure, preventing a
+  terminal Hub row from executing later as a ghost task;
+- if the row already left FIFO but its start event was lost, the queue deadline
+  arms the normal model deadline, preserving a finite outer bound;
+- failed runtime outcomes throw into `processTask`'s established failure path,
+  so Dashboard records `failed` instead of false-success `replied`;
+- timeout messages distinguish `在队列中等待 … 仍未开始` from
+  `开始处理后 … 内无最终回复`.
+
+Docker result
+-------------
+- normal: 54 pass / 0 fail / 176 assertions;
+- actual minified agent-node bundle: PASS;
+- RESULT: PASS.
+
+Witnessed-red mutations
+-----------------------
+1. `timer_at_submission` — queue wait consumes model budget.
+2. `ignore_started_event` — own start cannot arm response deadline.
+3. `wrong_task_arms_timer` — another task expires this task.
+4. `omit_bridge_started_event` — FIFO drain omits owned start event.
+5. `omit_steer_started_event` — accepted Dashboard steer omits start event.
+6. `omit_queue_deadline` — never-started task becomes unbounded.
+7. `queue_timeout_does_not_cancel` — timed-out row remains executable.
+8. `cancel_queue_noop` — exact FIFO cancellation becomes decorative.
+9. `failure_returned_as_success` — CLI bypasses failed-outcome throw.
+
+Baseline gate
+-------------
+This candidate starts from main 83f0cf9d, which already contains #583's
+`missing_turn_fail_open` mutation. The candidate diff does not modify or remove
+test586. This corrects the superseded #584 branch's stale 02be2d69 baseline.
+
+Scope
+-----
+No Hub, Dashboard, schema, auth, token, TUI, app-server process, queue order,
+or timeout duration changes. Only timer origin, the independent FIFO bound,
+exact queued-row cancellation, and truthful failed status change.

--- a/tests/test587-codex-start-relative-timeout/Dockerfile
+++ b/tests/test587-codex-start-relative-timeout/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node/src ./agent-node/src
+COPY tests/test587-codex-start-relative-timeout/run.sh /harness/run.sh
+COPY tests/test587-codex-start-relative-timeout/mutate.ts /harness/mutate.ts
+RUN chmod 0755 /harness/run.sh
+
+ENTRYPOINT ["/harness/run.sh"]

--- a/tests/test587-codex-start-relative-timeout/mutate.ts
+++ b/tests/test587-codex-start-relative-timeout/mutate.ts
@@ -1,0 +1,52 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const mutation = process.argv[2];
+const runtimePath = "./src/runtime/codex-app-server/runtime.ts";
+const bridgePath = "./src/runtime/codex-app-server-bridge.ts";
+
+function replaceExact(path: string, before: string, after: string): void {
+  const source = readFileSync(path, "utf8");
+  const count = source.split(before).length - 1;
+  if (count !== 1) throw new Error(`${mutation}: expected one anchor in ${path}, found ${count}`);
+  writeFileSync(path, source.replace(before, after));
+}
+
+switch (mutation) {
+  case "timer_at_submission":
+    replaceExact(
+      runtimePath,
+      `    bridge.on("task_started", onStarted);`,
+      `    bridge.on("task_started", onStarted);\n    startResponseTimer();`,
+    );
+    break;
+  case "ignore_started_event":
+    replaceExact(
+      runtimePath,
+      `      startResponseTimer();\n    };\n\n    // A shared app-server WebSocket`,
+      `      void ev;\n    };\n\n    // A shared app-server WebSocket`,
+    );
+    break;
+  case "wrong_task_arms_timer":
+    replaceExact(
+      runtimePath,
+      `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (ev.taskId !== opts.taskId) return;`,
+      `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (false && ev.taskId !== opts.taskId) return;`,
+    );
+    break;
+  case "omit_bridge_started_event":
+    replaceExact(
+      bridgePath,
+      `    this.emit("task_started", { taskId: input.taskId, turnId, steered: false });`,
+      `    void turnId;`,
+    );
+    break;
+  case "omit_steer_started_event":
+    replaceExact(
+      bridgePath,
+      `      this.emit("task_started", {\n        taskId: input.taskId,\n        turnId: expectedTurnId,\n        steered: true,\n      });`,
+      `      void expectedTurnId;`,
+    );
+    break;
+  default:
+    throw new Error(`unknown mutation: ${mutation}`);
+}

--- a/tests/test587-codex-start-relative-timeout/mutate.ts
+++ b/tests/test587-codex-start-relative-timeout/mutate.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 const mutation = process.argv[2];
 const runtimePath = "./src/runtime/codex-app-server/runtime.ts";
 const bridgePath = "./src/runtime/codex-app-server-bridge.ts";
+const cliPath = "./src/cli.ts";
 
 function replaceExact(path: string, before: string, after: string): void {
   const source = readFileSync(path, "utf8");
@@ -45,6 +46,34 @@ switch (mutation) {
       bridgePath,
       `      this.emit("task_started", {\n        taskId: input.taskId,\n        turnId: expectedTurnId,\n        steered: true,\n      });`,
       `      void expectedTurnId;`,
+    );
+    break;
+  case "omit_queue_deadline":
+    replaceExact(
+      runtimePath,
+      `    queueTimer = setTimeout(() => {`,
+      `    if (false) queueTimer = setTimeout(() => {`,
+    );
+    break;
+  case "queue_timeout_does_not_cancel":
+    replaceExact(
+      runtimePath,
+      `      if (!bridge.cancelQueuedTask(opts.taskId)) {`,
+      `      if (true || !bridge.cancelQueuedTask(opts.taskId)) {`,
+    );
+    break;
+  case "cancel_queue_noop":
+    replaceExact(
+      bridgePath,
+      `  cancelQueuedTask(taskId: string): boolean {\n    const index = this.taskQueue.findIndex((task) => task.taskId === taskId);`,
+      `  cancelQueuedTask(taskId: string): boolean {\n    return false;\n    const index = this.taskQueue.findIndex((task) => task.taskId === taskId);`,
+    );
+    break;
+  case "failure_returned_as_success":
+    replaceExact(
+      cliPath,
+      `  return codexAppServerReplyOrThrow(outcome);`,
+      `  return outcome.replyText || "（无回复）";`,
     );
     break;
   default:

--- a/tests/test587-codex-start-relative-timeout/run.sh
+++ b/tests/test587-codex-start-relative-timeout/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -u
+
+cd /workspace/agent-node
+normal=/tmp/test587-normal.log
+if ! bun test \
+  ./src/runtime/codex-app-server-bridge.test.ts \
+  ./src/runtime/codex-app-server/runtime.test.ts >"$normal" 2>&1; then
+  cat "$normal"
+  echo "RESULT: FAIL normal"
+  exit 1
+fi
+cat "$normal"
+
+for mutation_name in timer_at_submission ignore_started_event wrong_task_arms_timer omit_bridge_started_event omit_steer_started_event; do
+  cp ./src/runtime/codex-app-server/runtime.ts /tmp/test587-runtime.ts
+  cp ./src/runtime/codex-app-server-bridge.ts /tmp/test587-bridge.ts
+  if ! bun /harness/mutate.ts "$mutation_name"; then
+    cp /tmp/test587-runtime.ts ./src/runtime/codex-app-server/runtime.ts
+    cp /tmp/test587-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+    echo "RESULT: FAIL mutation-anchor $mutation_name"
+    exit 1
+  fi
+  mutation=/tmp/test587-${mutation_name}.log
+  if bun test \
+    ./src/runtime/codex-app-server-bridge.test.ts \
+    ./src/runtime/codex-app-server/runtime.test.ts >"$mutation" 2>&1; then
+    cat "$mutation"
+    cp /tmp/test587-runtime.ts ./src/runtime/codex-app-server/runtime.ts
+    cp /tmp/test587-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+    echo "RESULT: FAIL mutation-survived $mutation_name"
+    exit 1
+  fi
+  echo "WITNESSED-RED: $mutation_name"
+  tail -16 "$mutation"
+  cp /tmp/test587-runtime.ts ./src/runtime/codex-app-server/runtime.ts
+  cp /tmp/test587-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+done
+
+bun run build >/tmp/test587-build.log 2>&1 || {
+  cat /tmp/test587-build.log
+  echo "RESULT: FAIL build"
+  exit 1
+}
+echo "BUILD: PASS"
+echo "RESULT: PASS"

--- a/tests/test587-codex-start-relative-timeout/run.sh
+++ b/tests/test587-codex-start-relative-timeout/run.sh
@@ -5,29 +5,34 @@ cd /workspace/agent-node
 normal=/tmp/test587-normal.log
 if ! bun test \
   ./src/runtime/codex-app-server-bridge.test.ts \
-  ./src/runtime/codex-app-server/runtime.test.ts >"$normal" 2>&1; then
+  ./src/runtime/codex-app-server/runtime.test.ts \
+  ./src/runtime/codex-app-server/session-manager.test.ts >"$normal" 2>&1; then
   cat "$normal"
   echo "RESULT: FAIL normal"
   exit 1
 fi
 cat "$normal"
 
-for mutation_name in timer_at_submission ignore_started_event wrong_task_arms_timer omit_bridge_started_event omit_steer_started_event; do
+for mutation_name in timer_at_submission ignore_started_event wrong_task_arms_timer omit_bridge_started_event omit_steer_started_event omit_queue_deadline queue_timeout_does_not_cancel cancel_queue_noop failure_returned_as_success; do
   cp ./src/runtime/codex-app-server/runtime.ts /tmp/test587-runtime.ts
   cp ./src/runtime/codex-app-server-bridge.ts /tmp/test587-bridge.ts
+  cp ./src/cli.ts /tmp/test587-cli.ts
   if ! bun /harness/mutate.ts "$mutation_name"; then
     cp /tmp/test587-runtime.ts ./src/runtime/codex-app-server/runtime.ts
     cp /tmp/test587-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+    cp /tmp/test587-cli.ts ./src/cli.ts
     echo "RESULT: FAIL mutation-anchor $mutation_name"
     exit 1
   fi
   mutation=/tmp/test587-${mutation_name}.log
   if bun test \
     ./src/runtime/codex-app-server-bridge.test.ts \
-    ./src/runtime/codex-app-server/runtime.test.ts >"$mutation" 2>&1; then
+    ./src/runtime/codex-app-server/runtime.test.ts \
+    ./src/runtime/codex-app-server/session-manager.test.ts >"$mutation" 2>&1; then
     cat "$mutation"
     cp /tmp/test587-runtime.ts ./src/runtime/codex-app-server/runtime.ts
     cp /tmp/test587-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+    cp /tmp/test587-cli.ts ./src/cli.ts
     echo "RESULT: FAIL mutation-survived $mutation_name"
     exit 1
   fi
@@ -35,6 +40,7 @@ for mutation_name in timer_at_submission ignore_started_event wrong_task_arms_ti
   tail -16 "$mutation"
   cp /tmp/test587-runtime.ts ./src/runtime/codex-app-server/runtime.ts
   cp /tmp/test587-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+  cp /tmp/test587-cli.ts ./src/cli.ts
 done
 
 bun run build >/tmp/test587-build.log 2>&1 || {


### PR DESCRIPTION
## Production bug

A Dashboard row waiting in the Codex FIFO consumed the 600-second model budget and could fail before its own turn started. Simply moving that timer would make a never-started row unbounded. Production logs also proved Codex timeout text was sent with `failed=false`.

## Fix

- start the existing 600s model budget only after this task receives `turn/start` or authenticated `turn/steer` acceptance;
- add a separate finite 30-minute FIFO deadline;
- remove the exact queued row before reporting queue timeout, preventing later ghost execution;
- if the row already left FIFO but task_started was lost, arm the normal model deadline;
- throw failed bridge outcomes through processTask so Dashboard records `failed`;
- use distinct queue-vs-model timeout text.

## Baseline correction

This branch starts from main `83f0cf9d`, including #583. `tests/test586-codex-successor-reconcile` has zero diff from main. It supersedes stale-base PR #584.

## Docker evidence

- initial witnessed red: 41 pass / 3 fail / 127 assertions;
- final: 54 pass / 0 fail / 176 assertions;
- 9 semantic mutations witnessed red;
- minified bundle PASS.

Source commits: `e7818cd4`, `9099ff7d48f311fa75bc7dc55d72c49d54dfb3f9`
Report-only HEAD: `5702a820835a08382c75904127c951f3d13edc4b`
Image: `anet-test587:dev`

No Hub, Dashboard, schema, auth, token, queue order, TUI, app-server process, or model-timeout duration changes. Independent review required; do not self-merge/publish.