### PR TITLE
fix(agent-node): cancel Codex rows requeued after deadline

### DIFF
--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -194,6 +194,43 @@ describe("codexAppServerThink — terminal-event reconciliation watchdog", () =>
     expect(bridge.cancelCalls).toBe(1);
   });
 
+  test("a start failure that requeues after the queue deadline cannot leave a ghost row", async () => {
+    const bridge = new DeferredStartBridge();
+    bridge.queued = false;
+    bridge.submitTask = async (input: { taskId: string }) => {
+      bridge.submitted = input;
+      return { started: false as const, queuedAt: 1 };
+    };
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_requeues_after_deadline",
+      text: "failed start must not become a ghost",
+      timeoutMs: 200,
+      queueTimeoutMs: 30,
+      reconciliationIntervalMs: 0,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 55));
+    bridge.queued = true;
+    bridge.emit("drain_deferred", {
+      taskId: "task_requeues_after_deadline",
+      error: "turn/start lost idle race",
+    });
+    const lateReply = setTimeout(() => {
+      bridge.emit("task_reply", {
+        taskId: "task_requeues_after_deadline",
+        text: "ghost execution completed",
+      });
+    }, 260);
+    const result = await thinking;
+    clearTimeout(lateReply);
+    expect(result.failed).toBe(true);
+    expect(result.queued).toBe(true);
+    expect(result.replyText).toContain("在队列中等待");
+    expect(bridge.queued).toBe(false);
+    expect(bridge.cancelCalls).toBe(2);
+  });
+
   test("queued wait does not consume the model-response timeout budget", async () => {
     const bridge = new DeferredStartBridge();
     const session = { bridge } as unknown as CodexAppServerRuntimeSession;

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -194,41 +194,38 @@ describe("codexAppServerThink — terminal-event reconciliation watchdog", () =>
     expect(bridge.cancelCalls).toBe(1);
   });
 
-  test("a start failure that requeues after the queue deadline cannot leave a ghost row", async () => {
-    const bridge = new DeferredStartBridge();
-    bridge.queued = false;
-    bridge.submitTask = async (input: { taskId: string }) => {
-      bridge.submitted = input;
-      return { started: false as const, queuedAt: 1 };
-    };
-    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
-    const thinking = codexAppServerThink(session, {
-      taskId: "task_requeues_after_deadline",
-      text: "failed start must not become a ghost",
-      timeoutMs: 200,
-      queueTimeoutMs: 30,
-      reconciliationIntervalMs: 0,
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 55));
-    bridge.queued = true;
-    bridge.emit("drain_deferred", {
-      taskId: "task_requeues_after_deadline",
-      error: "turn/start lost idle race",
-    });
-    const lateReply = setTimeout(() => {
-      bridge.emit("task_reply", {
-        taskId: "task_requeues_after_deadline",
-        text: "ghost execution completed",
+  test("a failed start or steer requeued after the queue deadline cannot leave a ghost row", async () => {
+    for (const eventName of ["drain_deferred", "steer_deferred"] as const) {
+      const taskId = `task_requeues_after_deadline_${eventName}`;
+      const bridge = new DeferredStartBridge();
+      bridge.queued = false;
+      bridge.submitTask = async (input: { taskId: string }) => {
+        bridge.submitted = input;
+        return { started: false as const, queuedAt: 1 };
+      };
+      const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+      const thinking = codexAppServerThink(session, {
+        taskId,
+        text: "failed admission must not become a ghost",
+        timeoutMs: 200,
+        queueTimeoutMs: 30,
+        reconciliationIntervalMs: 0,
       });
-    }, 260);
-    const result = await thinking;
-    clearTimeout(lateReply);
-    expect(result.failed).toBe(true);
-    expect(result.queued).toBe(true);
-    expect(result.replyText).toContain("在队列中等待");
-    expect(bridge.queued).toBe(false);
-    expect(bridge.cancelCalls).toBe(2);
+
+      await new Promise((resolve) => setTimeout(resolve, 55));
+      bridge.queued = true;
+      bridge.emit(eventName, { taskId, error: "admission lost idle race" });
+      const lateReply = setTimeout(() => {
+        bridge.emit("task_reply", { taskId, text: "ghost execution completed" });
+      }, 260);
+      const result = await thinking;
+      clearTimeout(lateReply);
+      expect(result.failed).toBe(true);
+      expect(result.queued).toBe(true);
+      expect(result.replyText).toContain("在队列中等待");
+      expect(bridge.queued).toBe(false);
+      expect(bridge.cancelCalls).toBe(2);
+    }
   });
 
   test("queued wait does not consume the model-response timeout budget", async () => {

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -270,6 +270,7 @@ export function codexAppServerThink(
 
   return new Promise<CodexAppServerThinkResult>((resolve) => {
     let settled = false;
+    let queueDeadlineElapsed = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let queueTimer: ReturnType<typeof setTimeout> | undefined;
     let reconciliationTimer: ReturnType<typeof setTimeout> | undefined;
@@ -279,6 +280,8 @@ export function codexAppServerThink(
       bridge.off("task_reply", onReply);
       bridge.off("task_error", onError);
       bridge.off("task_started", onStarted);
+      bridge.off("drain_deferred", onRequeued);
+      bridge.off("steer_deferred", onRequeued);
       if (timer) clearTimeout(timer);
       if (queueTimer) clearTimeout(queueTimer);
       if (reconciliationTimer) clearTimeout(reconciliationTimer);
@@ -307,6 +310,18 @@ export function codexAppServerThink(
           queued: false,
         });
       }, timeoutMs);
+    };
+    const finishQueueTimeout = () => finish({
+      replyText: `codex-app-server 错误: 任务 ${opts.taskId} 在队列中等待 ${queueTimeoutLabel}仍未开始`,
+      failed: true,
+      queued: true,
+    });
+    const onRequeued = (ev: { taskId: string }) => {
+      if (!queueDeadlineElapsed || ev.taskId !== opts.taskId) return;
+      // The deadline may fire while this row is between FIFO shift and a
+      // failed turn/start or turn/steer RPC. If that RPC requeues it, remove
+      // it immediately instead of leaving a ghost row behind a model timer.
+      if (bridge.cancelQueuedTask(opts.taskId)) finishQueueTimeout();
     };
     const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {
       if (ev.taskId !== opts.taskId) return;
@@ -341,6 +356,8 @@ export function codexAppServerThink(
     bridge.on("task_reply", onReply);
     bridge.on("task_error", onError);
     bridge.on("task_started", onStarted);
+    bridge.on("drain_deferred", onRequeued);
+    bridge.on("steer_deferred", onRequeued);
     scheduleReconciliation();
 
     queueTimer = setTimeout(() => {
@@ -349,16 +366,13 @@ export function codexAppServerThink(
       // terminal. If it already left FIFO (start RPC in flight or a lost
       // task_started event), switch to the normal response timer so the task
       // remains finite without falsely cancelling a running turn.
+      queueDeadlineElapsed = true;
       if (!bridge.cancelQueuedTask(opts.taskId)) {
         log(`[codex-app-server] queue deadline reached after task left FIFO; arming response timeout for ${opts.taskId}`);
         startResponseTimer();
         return;
       }
-      finish({
-        replyText: `codex-app-server 错误: 任务 ${opts.taskId} 在队列中等待 ${queueTimeoutLabel}仍未开始`,
-        failed: true,
-        queued: true,
-      });
+      finishQueueTimeout();
     }, queueTimeoutMs);
 
     bridge

--- a/docs/tests/report-test587-codex-start-relative-timeout.txt
+++ b/docs/tests/report-test587-codex-start-relative-timeout.txt
@@ -38,7 +38,7 @@ Final behavior
 
 Docker result
 -------------
-- normal: 54 pass / 0 fail / 176 assertions;
+- normal: 55 pass / 0 fail / 181 assertions;
 - actual minified agent-node bundle: PASS;
 - RESULT: PASS.
 
@@ -51,8 +51,9 @@ Witnessed-red mutations
 5. `omit_steer_started_event` — accepted Dashboard steer omits start event.
 6. `omit_queue_deadline` — never-started task becomes unbounded.
 7. `queue_timeout_does_not_cancel` — timed-out row remains executable.
-8. `cancel_queue_noop` — exact FIFO cancellation becomes decorative.
-9. `failure_returned_as_success` — CLI bypasses failed-outcome throw.
+8. `ignore_post_deadline_requeue` — a failed start can requeue a ghost row.
+9. `cancel_queue_noop` — exact FIFO cancellation becomes decorative.
+10. `failure_returned_as_success` — CLI bypasses failed-outcome throw.
 
 Baseline gate
 -------------

--- a/docs/tests/report-test587-codex-start-relative-timeout.txt
+++ b/docs/tests/report-test587-codex-start-relative-timeout.txt
@@ -38,7 +38,7 @@ Final behavior
 
 Docker result
 -------------
-- normal: 55 pass / 0 fail / 181 assertions;
+- normal: 55 pass / 0 fail / 186 assertions;
 - actual minified agent-node bundle: PASS;
 - RESULT: PASS.
 
@@ -52,8 +52,9 @@ Witnessed-red mutations
 6. `omit_queue_deadline` — never-started task becomes unbounded.
 7. `queue_timeout_does_not_cancel` — timed-out row remains executable.
 8. `ignore_post_deadline_requeue` — a failed start can requeue a ghost row.
-9. `cancel_queue_noop` — exact FIFO cancellation becomes decorative.
-10. `failure_returned_as_success` — CLI bypasses failed-outcome throw.
+9. `ignore_post_deadline_steer_requeue` — failed steer can do the same.
+10. `cancel_queue_noop` — exact FIFO cancellation becomes decorative.
+11. `failure_returned_as_success` — CLI bypasses failed-outcome throw.
 
 Baseline gate
 -------------

--- a/tests/test587-codex-start-relative-timeout/mutate.ts
+++ b/tests/test587-codex-start-relative-timeout/mutate.ts
@@ -62,6 +62,13 @@ switch (mutation) {
       `      if (true || !bridge.cancelQueuedTask(opts.taskId)) {`,
     );
     break;
+  case "ignore_post_deadline_requeue":
+    replaceExact(
+      runtimePath,
+      `    bridge.on("drain_deferred", onRequeued);`,
+      `    void onRequeued;`,
+    );
+    break;
   case "cancel_queue_noop":
     replaceExact(
       bridgePath,

--- a/tests/test587-codex-start-relative-timeout/mutate.ts
+++ b/tests/test587-codex-start-relative-timeout/mutate.ts
@@ -69,6 +69,13 @@ switch (mutation) {
       `    void onRequeued;`,
     );
     break;
+  case "ignore_post_deadline_steer_requeue":
+    replaceExact(
+      runtimePath,
+      `    bridge.on("steer_deferred", onRequeued);`,
+      `    void onRequeued;`,
+    );
+    break;
   case "cancel_queue_noop":
     replaceExact(
       bridgePath,

--- a/tests/test587-codex-start-relative-timeout/run.sh
+++ b/tests/test587-codex-start-relative-timeout/run.sh
@@ -13,7 +13,7 @@ if ! bun test \
 fi
 cat "$normal"
 
-for mutation_name in timer_at_submission ignore_started_event wrong_task_arms_timer omit_bridge_started_event omit_steer_started_event omit_queue_deadline queue_timeout_does_not_cancel ignore_post_deadline_requeue cancel_queue_noop failure_returned_as_success; do
+for mutation_name in timer_at_submission ignore_started_event wrong_task_arms_timer omit_bridge_started_event omit_steer_started_event omit_queue_deadline queue_timeout_does_not_cancel ignore_post_deadline_requeue ignore_post_deadline_steer_requeue cancel_queue_noop failure_returned_as_success; do
   cp ./src/runtime/codex-app-server/runtime.ts /tmp/test587-runtime.ts
   cp ./src/runtime/codex-app-server-bridge.ts /tmp/test587-bridge.ts
   cp ./src/cli.ts /tmp/test587-cli.ts

--- a/tests/test587-codex-start-relative-timeout/run.sh
+++ b/tests/test587-codex-start-relative-timeout/run.sh
@@ -13,7 +13,7 @@ if ! bun test \
 fi
 cat "$normal"
 
-for mutation_name in timer_at_submission ignore_started_event wrong_task_arms_timer omit_bridge_started_event omit_steer_started_event omit_queue_deadline queue_timeout_does_not_cancel cancel_queue_noop failure_returned_as_success; do
+for mutation_name in timer_at_submission ignore_started_event wrong_task_arms_timer omit_bridge_started_event omit_steer_started_event omit_queue_deadline queue_timeout_does_not_cancel ignore_post_deadline_requeue cancel_queue_noop failure_returned_as_success; do
   cp ./src/runtime/codex-app-server/runtime.ts /tmp/test587-runtime.ts
   cp ./src/runtime/codex-app-server-bridge.ts /tmp/test587-bridge.ts
   cp ./src/cli.ts /tmp/test587-cli.ts


### PR DESCRIPTION
## Narrow race follow-up to #585

#585 correctly separates a finite 30-minute FIFO deadline from the 600-second model deadline. This add-only follow-up closes one TOCTOU window: the FIFO deadline can fire after `drainQueue()` shifts a row or while `turn/steer` is pending, before admission failure requeues it. Without a requeue listener, the already-failed Hub row can remain in FIFO as a ghost.

## Fix

- mark the queue deadline as elapsed;
- listen for matching `drain_deferred` and `steer_deferred`;
- if the row re-enters FIFO after the deadline, remove it immediately and return the distinct queue-timeout failure;
- remove both listeners on settle.

## Evidence

- Docker normal: 55 pass / 0 fail / 186 assertions;
- separate `ignore_post_deadline_requeue` and `ignore_post_deadline_steer_requeue` mutations witnessed red;
- all prior nine #585 mutations remain red;
- minified bundle PASS.

Production source: `c0849553`
Test add-only: `7566a1e8`
Report-only head: `d742bc82`
Image: `anet-test587:dev`

No other production/API/schema/timeout/queue-order changes. Independent narrow review required; do not self-merge/publish.