### PR TITLE
fix(codex): bind pending turns by clientUserMessageId, not the turn/start response id

### DIFF
--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -449,6 +449,61 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     expect(bridge.pendingTurnCount()).toBe(1);
   });
 
+  test("real bridge + runtime bounds an unresolved turn/start through the left-FIFO fallback", async () => {
+    await client.close();
+    await app.stop();
+    app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") {
+          return respond({ result: {} });
+        }
+        if (msg.method === "thread/read") {
+          return respond({ result: { thread: { status: { type: "active" }, turns: [] } } });
+        }
+        if (msg.method === "turn/start") {
+          // Simulate an accepted-or-lost RPC whose response never resolves and
+          // whose userMessage clientId is never observed. The task has left
+          // FIFO but cannot emit task_started, so #585's queue-deadline branch
+          // must convert it to the bounded model-response timer.
+          return;
+        }
+      },
+    });
+    client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+
+    const thinking = codexAppServerThink(
+      { bridge } as unknown as CodexAppServerRuntimeSession,
+      {
+        taskId: "turn-start-never-resolves-real-bridge",
+        text: "must remain finite after leaving FIFO",
+        timeoutMs: 25,
+        queueTimeoutMs: 25,
+        reconciliationIntervalMs: 0,
+      },
+    );
+    const observed = await Promise.race([
+      thinking.then((result) => ({ kind: "result" as const, result })),
+      new Promise<{ kind: "hung" }>((resolve) => setTimeout(() => resolve({ kind: "hung" }), 100)),
+    ]);
+    if (observed.kind === "hung") {
+      bridge.emit("task_reply", {
+        taskId: "turn-start-never-resolves-real-bridge",
+        text: "mutation cleanup",
+      });
+      await thinking;
+    }
+
+    expect(observed.kind).toBe("result");
+    if (observed.kind !== "result") return;
+    expect(observed.result.failed).toBe(true);
+    expect(observed.result.queued).toBe(false);
+    expect(observed.result.replyText).toContain("开始处理后");
+    expect(observed.result.replyText).not.toContain("在队列中等待");
+  });
+
   test("agentMessage/delta accumulates when server omits finalText", async () => {
     const turnId = await bridge.startTaskTurn({ taskId: "task_1", text: "hi" });
     const replies: Array<{ taskId: string; text: string }> = [];

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -235,6 +235,22 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
 
     const result = await bridge.submitTask({ taskId: "goal-race", text: "answer me" });
     expect(result).toEqual({ started: true, turnId: "turn_response_phantom" });
+    // Two turns are concurrently in progress. A positional/latest-turn
+    // heuristic would bind the task to this first, wrong client id.
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: THREAD, turn: { id: "turn_competing_wrong_client", status: "inProgress" } },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: THREAD,
+        turnId: "turn_competing_wrong_client",
+        item: { type: "userMessage", clientId: "anet:different-task" },
+      },
+    });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/started",
@@ -250,6 +266,24 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     });
     await tick(10);
     expect(errors).toEqual([]);
+    expect(replies).toEqual([]);
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: THREAD,
+        turnId: "turn_competing_wrong_client",
+        item: { type: "agentMessage", phase: "final_answer", text: "wrong concurrent reply" },
+      },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turn: { id: "turn_competing_wrong_client", status: "completed" } },
+    });
+    await tick(10);
+    expect(rebound).toEqual([]);
     expect(replies).toEqual([]);
 
     app.broadcast({
@@ -308,6 +342,23 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
               item: { type: "userMessage", clientId: "anet:early-race" },
             },
           });
+          // The authoritative terminal arrives before turn/start returns and
+          // therefore before task_started. It must be cached, then claimed
+          // after the exact client id establishes ownership.
+          broadcast({
+            jsonrpc: "2.0",
+            method: "item/completed",
+            params: {
+              threadId: THREAD,
+              turnId: "turn_actual_early",
+              item: { type: "agentMessage", phase: "final_answer", text: "early reply" },
+            },
+          });
+          broadcast({
+            jsonrpc: "2.0",
+            method: "turn/completed",
+            params: { threadId: THREAD, turn: { id: "turn_actual_early", status: "completed" } },
+          });
           setTimeout(() => respond({ result: { turn: { id: "turn_response_late" } } }), 5);
         }
       },
@@ -322,24 +373,9 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     bridge.on("task_reply", () => events.push("reply"));
     const result = await bridge.submitTask({ taskId: "early-race", text: "answer me" });
     expect(result).toEqual({ started: true, turnId: "turn_actual_early" });
-    expect(bridge.activeTurn()).toBe("turn_actual_early");
-
-    app.broadcast({
-      jsonrpc: "2.0",
-      method: "item/completed",
-      params: {
-        threadId: THREAD,
-        turnId: "turn_actual_early",
-        item: { type: "agentMessage", phase: "final_answer", text: "early reply" },
-      },
-    });
-    app.broadcast({
-      jsonrpc: "2.0",
-      method: "turn/completed",
-      params: { threadId: THREAD, turn: { id: "turn_actual_early", status: "completed" } },
-    });
     await tick(10);
     expect(events).toEqual(["started", "reply"]);
+    expect(bridge.activeTurn()).toBeNull();
   });
 
   test("agentMessage/delta accumulates when server omits finalText", async () => {

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -16,6 +16,10 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { CodexAppServerClient } from "./codex-app-server-client";
 import { CodexAppServerBridge } from "./codex-app-server-bridge";
+import {
+  codexAppServerThink,
+  type CodexAppServerRuntimeSession,
+} from "./codex-app-server/runtime";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Fake app-server that autoreplies to initialize / thread/resume / turn/start.
@@ -376,6 +380,73 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     await tick(10);
     expect(events).toEqual(["started", "reply"]);
     expect(bridge.activeTurn()).toBeNull();
+  });
+
+  test("real bridge + runtime bounds a deferred terminal when exact client identity never arrives", async () => {
+    await client.close();
+    await app.stop();
+    app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") {
+          return respond({ result: {} });
+        }
+        if (msg.method === "thread/read") {
+          return respond({ result: { thread: { status: { type: "active" }, turns: [] } } });
+        }
+        if (msg.method === "turn/start") {
+          return respond({ result: { turn: { id: "turn_identity_phantom" } } });
+        }
+      },
+    });
+    client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+
+    const thinking = codexAppServerThink(
+      { bridge } as unknown as CodexAppServerRuntimeSession,
+      {
+        taskId: "identity-never-confirms-real-bridge",
+        text: "must remain finite across both layers",
+        timeoutMs: 25,
+        queueTimeoutMs: 500,
+        reconciliationIntervalMs: 0,
+      },
+    );
+    while (!app.received.some((message) => (message as { method?: string }).method === "turn/start")) {
+      await tick(1);
+    }
+    await tick(1);
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: THREAD, turn: { id: "turn_competing_without_our_client_id", status: "inProgress" } },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turn: { id: "turn_identity_phantom", status: "interrupted" } },
+    });
+
+    const observed = await Promise.race([
+      thinking.then((result) => ({ kind: "result" as const, result })),
+      new Promise<{ kind: "hung" }>((resolve) => setTimeout(() => resolve({ kind: "hung" }), 100)),
+    ]);
+    if (observed.kind === "hung") {
+      bridge.emit("task_reply", {
+        taskId: "identity-never-confirms-real-bridge",
+        text: "mutation cleanup",
+      });
+      await thinking;
+    }
+
+    expect(observed.kind).toBe("result");
+    if (observed.kind !== "result") return;
+    expect(observed.result.failed).toBe(true);
+    expect(observed.result.queued).toBe(false);
+    expect(observed.result.replyText).toContain("开始处理后");
+    expect(observed.result.replyText).not.toContain("在队列中等待");
+    expect(bridge.pendingTurnCount()).toBe(1);
   });
 
   test("agentMessage/delta accumulates when server omits finalText", async () => {

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -203,6 +203,145 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     expect(bridge.activeTurn()).toBeNull();
   });
 
+  test("clientUserMessageId rebinds a task when a goal successor replaces the turn/start response id", async () => {
+    await client.close();
+    await app.stop();
+    app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") {
+          return respond({ result: {} });
+        }
+        if (msg.method === "thread/read") {
+          return respond({ result: { thread: { status: { type: "active" }, turns: [] } } });
+        }
+        if (msg.method === "turn/start") {
+          return respond({ result: { turn: { id: "turn_response_phantom" } } });
+        }
+      },
+    });
+    client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+
+    const started: Array<{ taskId: string; turnId: string }> = [];
+    const rebound: Array<{ taskId: string; fromTurnId: string; toTurnId: string }> = [];
+    const replies: Array<{ taskId: string; text: string }> = [];
+    const errors: Array<{ taskId: string; error: string }> = [];
+    bridge.on("task_started", (event) => started.push(event as never));
+    bridge.on("task_turn_rebound", (event) => rebound.push(event as never));
+    bridge.on("task_reply", (event) => replies.push(event as never));
+    bridge.on("task_error", (event) => errors.push(event as never));
+
+    const result = await bridge.submitTask({ taskId: "goal-race", text: "answer me" });
+    expect(result).toEqual({ started: true, turnId: "turn_response_phantom" });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: THREAD, turn: { id: "turn_actual_successor", status: "inProgress" } },
+    });
+    // The response-id turn can report interrupted while the actual successor
+    // is taking ownership. It must not fail the Hub task before identity is
+    // confirmed by the echoed client id.
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turn: { id: "turn_response_phantom", status: "interrupted" } },
+    });
+    await tick(10);
+    expect(errors).toEqual([]);
+    expect(replies).toEqual([]);
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: THREAD,
+        turnId: "turn_actual_successor",
+        item: { type: "userMessage", clientId: "anet:goal-race" },
+      },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: THREAD,
+        turnId: "turn_actual_successor",
+        item: { type: "agentMessage", phase: "final_answer", text: "race-safe reply" },
+      },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turn: { id: "turn_actual_successor", status: "completed" } },
+    });
+    await tick(20);
+
+    expect(started).toEqual([{ taskId: "goal-race", turnId: "turn_response_phantom", steered: false }]);
+    expect(rebound).toEqual([{
+      taskId: "goal-race",
+      fromTurnId: "turn_response_phantom",
+      toTurnId: "turn_actual_successor",
+      clientUserMessageId: "anet:goal-race",
+    }]);
+    expect(errors).toEqual([]);
+    expect(replies).toEqual([{ taskId: "goal-race", text: "race-safe reply" }]);
+    expect(bridge.activeTurn()).toBeNull();
+    expect(bridge.pendingTurnCount()).toBe(0);
+  });
+
+  test("client-id ownership observed before the RPC response wins without reversing task event order", async () => {
+    await client.close();
+    await app.stop();
+    app = await startFakeApp({
+      onRequest: (msg, respond, broadcast) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") {
+          return respond({ result: {} });
+        }
+        if (msg.method === "turn/start") {
+          broadcast({
+            jsonrpc: "2.0",
+            method: "item/completed",
+            params: {
+              threadId: THREAD,
+              turnId: "turn_actual_early",
+              item: { type: "userMessage", clientId: "anet:early-race" },
+            },
+          });
+          setTimeout(() => respond({ result: { turn: { id: "turn_response_late" } } }), 5);
+        }
+      },
+    });
+    client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+
+    const events: string[] = [];
+    bridge.on("task_started", () => events.push("started"));
+    bridge.on("task_reply", () => events.push("reply"));
+    const result = await bridge.submitTask({ taskId: "early-race", text: "answer me" });
+    expect(result).toEqual({ started: true, turnId: "turn_actual_early" });
+    expect(bridge.activeTurn()).toBe("turn_actual_early");
+
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: THREAD,
+        turnId: "turn_actual_early",
+        item: { type: "agentMessage", phase: "final_answer", text: "early reply" },
+      },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: THREAD, turn: { id: "turn_actual_early", status: "completed" } },
+    });
+    await tick(10);
+    expect(events).toEqual(["started", "reply"]);
+  });
+
   test("agentMessage/delta accumulates when server omits finalText", async () => {
     const turnId = await bridge.startTaskTurn({ taskId: "task_1", text: "hi" });
     const replies: Array<{ taskId: string; text: string }> = [];
@@ -276,6 +415,15 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     bridge.on("task_error", (e) => errors.push(e as never));
     app.broadcast({
       jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: THREAD,
+        turnId,
+        item: { type: "userMessage", clientId: "anet:task_1" },
+      },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
       method: "turn/completed",
       params: { threadId: THREAD, turn: { id: turnId, error: { message: "model unavailable" } } },
     });
@@ -291,6 +439,15 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     const errors: Array<{ taskId: string; error: string }> = [];
     bridge.on("task_reply", (r) => replies.push(r));
     bridge.on("task_error", (e) => errors.push(e as never));
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: THREAD,
+        turnId,
+        item: { type: "userMessage", clientId: "anet:task_interrupted" },
+      },
+    });
     app.broadcast({
       jsonrpc: "2.0",
       method: "turn/completed",
@@ -967,6 +1124,57 @@ describe("CodexAppServerBridge — sync claim + FIFO queue (通信龙)", () => {
     expect(bridge.activeTurn()).toBe("turn_reconcile_2");
     expect(app.received.filter((entry) => (entry as { method?: string }).method === "turn/start")).toHaveLength(2);
 
+    await client.close();
+    await app.stop();
+  });
+
+  test("thread/read uses clientUserMessageId to recover a replacement turn when all live item events were lost", async () => {
+    const app = await startFakeApp({
+      onRequest: (msg, respond) => {
+        if (msg.method === "initialize" || msg.method === "thread/resume") {
+          return respond({ result: {} });
+        }
+        if (msg.method === "turn/start") {
+          return respond({ result: { turn: { id: "turn_history_phantom" } } });
+        }
+        if (msg.method === "thread/read" && !(msg.params as { includeTurns?: boolean })?.includeTurns) {
+          return respond({ result: { thread: { status: { type: "active" } } } });
+        }
+        if (msg.method === "thread/read") {
+          return respond({
+            result: {
+              thread: {
+                status: { type: "active" },
+                turns: [{
+                  id: "turn_history_actual",
+                  status: "completed",
+                  items: [
+                    { type: "userMessage", clientId: "anet:history-race" },
+                    { type: "agentMessage", phase: "final_answer", text: "history rebound reply" },
+                  ],
+                }],
+              },
+            },
+          });
+        }
+      },
+    });
+    const client = new CodexAppServerClient({ url: app.url });
+    await client.connect();
+    const bridge = new CodexAppServerBridge({ client, threadId: THREAD });
+    await bridge.bootstrap();
+    const replies: Array<{ taskId: string; text: string }> = [];
+    bridge.on("task_reply", (event) => replies.push(event as never));
+
+    await bridge.submitTask({ taskId: "history-race", text: "first" });
+    expect(await bridge.reconcileActiveTurn(true)).toEqual({
+      recovered: true,
+      turnId: "turn_history_actual",
+      status: "completed",
+    });
+    expect(replies).toEqual([{ taskId: "history-race", text: "history rebound reply" }]);
+    expect(bridge.activeTurn()).toBeNull();
+    expect(bridge.pendingTurnCount()).toBe(0);
     await client.close();
     await app.stop();
   });

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -54,6 +54,16 @@ export interface PendingTurn {
   clientUserMessageId: string;
   submittedAt: number;
   turnId?: string;
+  /** Raw id returned by turn/start; may be superseded by a goal successor race. */
+  responseTurnId?: string;
+  /** True once an app-server userMessage echoes our exact client id. */
+  identityConfirmed?: boolean;
+  /** task_started must precede any terminal task event. */
+  startAnnounced?: boolean;
+  /** An unknown successor appeared before our client-id echo. */
+  competingTurnObserved?: boolean;
+  /** Terminal raced turn/start response or identity confirmation. */
+  deferredTerminal?: { turnId: string; status?: string; error?: string };
   agentTextChunks: string[];
   finalText?: string;
 }
@@ -92,6 +102,7 @@ export interface ActiveTurnReconciliation {
  *   - "waiting_human"     → WaitingApproval (bridge did not respond)
  *   - "approval_resolved" → { reverseRequestId } — from serverRequest/resolved
  *   - "task_started"      → { taskId, turnId, steered } — model budget starts
+ *   - "task_turn_rebound" → { taskId, fromTurnId, toTurnId } — client-id repair
  *   - "task_reply"        → { taskId, text }  — final agent message
  *   - "task_error"        → { taskId, error }
  *   - "cross_thread_drop" → { event } — event for a thread we don't own
@@ -123,6 +134,8 @@ export class CodexAppServerBridge extends EventEmitter {
    */
   private turnClaimed = false;
   private pendingTurns = new Map<string, PendingTurn>();
+  /** Stable task identity across turn-id replacement races. */
+  private pendingByClientUserMessageId = new Map<string, PendingTurn>();
   /** Reverse-request ids we've observed but not resolved (bridge policy). */
   private waitingApprovals = new Map<number, WaitingApproval>();
   /**
@@ -251,6 +264,10 @@ export class CodexAppServerBridge extends EventEmitter {
       submittedAt: Date.now(),
       agentTextChunks: [],
     };
+    // Install the stable identity before the RPC. Notifications can race the
+    // turn/start response, and Codex may replace the response turn id when an
+    // automatic goal successor starts at the same idle boundary.
+    this.pendingByClientUserMessageId.set(clientUserMessageId, pending);
     // Optimistically claim active so a concurrent call races cleanly.
     this.setStatus("working");
 
@@ -262,27 +279,83 @@ export class CodexAppServerBridge extends EventEmitter {
         input: [{ type: "text", text: promptPrefix + input.text }],
       });
     } catch (e) {
+      // If the server accepted the turn but the RPC response was lost, the
+      // echoed user-message client id is stronger evidence than the failed
+      // response transport. Preserve the accepted task instead of duplicating
+      // it on retry.
+      if (pending.identityConfirmed && pending.turnId) {
+        this.announcePendingStart(pending);
+        return pending.turnId;
+      }
+      this.pendingByClientUserMessageId.delete(clientUserMessageId);
       this.turnClaimed = false;
       this.setStatus("idle");
       throw e;
     }
-    const turnId = extractTurnId(resp);
-    if (!turnId) {
+    const responseTurnId = extractTurnId(resp);
+    pending.responseTurnId = responseTurnId ?? undefined;
+    if (!responseTurnId && !pending.turnId) {
+      this.pendingByClientUserMessageId.delete(clientUserMessageId);
       this.turnClaimed = false;
       this.setStatus("idle");
       throw new Error(
         `${this.label}: turn/start response did not include a turnId (task=${input.taskId})`,
       );
     }
+    if (!pending.turnId && responseTurnId) {
+      this.bindPendingToTurn(pending, responseTurnId, false);
+    } else if (responseTurnId && pending.turnId !== responseTurnId) {
+      this.emit("task_turn_rebound", {
+        taskId: pending.taskId,
+        fromTurnId: responseTurnId,
+        toTurnId: pending.turnId,
+        clientUserMessageId,
+      });
+    }
+    this.announcePendingStart(pending);
+    return pending.turnId!;
+  }
+
+  private bindPendingToTurn(
+    pending: PendingTurn,
+    turnId: string,
+    identityConfirmed: boolean,
+  ): void {
+    const previousTurnId = pending.turnId;
+    if (previousTurnId && previousTurnId !== turnId && this.pendingTurns.get(previousTurnId) === pending) {
+      this.pendingTurns.delete(previousTurnId);
+    }
     pending.turnId = turnId;
+    if (identityConfirmed) pending.identityConfirmed = true;
     this.pendingTurns.set(turnId, pending);
     this.activeTurnId = turnId;
     if (this.externalActiveTurnId === turnId) {
       this.externalActiveTurnId = null;
       this.externalActiveTurnSteerable = false;
     }
-    this.emit("task_started", { taskId: input.taskId, turnId, steered: false });
-    return turnId;
+    if (previousTurnId && previousTurnId !== turnId) {
+      this.emit("task_turn_rebound", {
+        taskId: pending.taskId,
+        fromTurnId: previousTurnId,
+        toTurnId: turnId,
+        clientUserMessageId: pending.clientUserMessageId,
+      });
+    }
+  }
+
+  private announcePendingStart(pending: PendingTurn): void {
+    if (pending.startAnnounced || !pending.turnId) return;
+    pending.startAnnounced = true;
+    this.emit("task_started", {
+      taskId: pending.taskId,
+      turnId: pending.turnId,
+      steered: false,
+    });
+    const deferred = pending.deferredTerminal;
+    if (deferred && deferred.turnId === pending.turnId) {
+      pending.deferredTerminal = undefined;
+      this.finishOwnedTurn(pending.turnId, deferred);
+    }
   }
 
   /**
@@ -559,6 +632,12 @@ export class CodexAppServerBridge extends EventEmitter {
     if (!turnId) return;
     if (!this.pendingTurns.has(turnId)) {
       const ownedTurnWasActive = this.activeTurnId !== null;
+      const activePending = this.activeTurnId
+        ? this.pendingTurns.get(this.activeTurnId)
+        : undefined;
+      if (activePending && !activePending.identityConfirmed) {
+        activePending.competingTurnObserved = true;
+      }
       // A turn we didn't start — e.g. the human TUI. Track its exact id so
       // authenticated Dashboard chat can use turn/steer. We still never map
       // a reply unless at least one task was explicitly and successfully
@@ -608,10 +687,29 @@ export class CodexAppServerBridge extends EventEmitter {
     const p = params as {
       threadId?: string;
       turnId?: string;
-      item?: { type?: string; text?: string; phase?: string };
+      item?: { type?: string; text?: string; phase?: string; clientId?: string };
     };
     if (!p || p.threadId !== this.threadId) return;
     if (typeof p.turnId !== "string") return;
+
+    // Codex can accept turn/start with response id A, then let an automatic
+    // goal successor win the same idle boundary and persist our user message
+    // under turn id B. The echoed clientId is generated from the immutable Hub
+    // task id and is therefore the only deterministic cross-surface join key.
+    // Rebind before consuming answer/terminal events for B.
+    if (p.item?.type === "userMessage" && typeof p.item.clientId === "string") {
+      const byClientId = this.pendingByClientUserMessageId.get(p.item.clientId);
+      if (byClientId) {
+        this.bindPendingToTurn(byClientId, p.turnId, true);
+        const deferred = byClientId.deferredTerminal;
+        if (deferred) {
+          byClientId.deferredTerminal = undefined;
+          if (deferred.turnId === p.turnId && byClientId.startAnnounced) {
+            this.finishOwnedTurn(p.turnId, deferred);
+          }
+        }
+      }
+    }
     const pending = this.pendingTurns.get(p.turnId);
     if (!pending) {
       const steered = this.steeredTurns.get(p.turnId);
@@ -663,6 +761,25 @@ export class CodexAppServerBridge extends EventEmitter {
         if (this.waitingApprovals.size === 0) this.setStatus("idle");
         void this.drainQueue();
       }
+      return;
+    }
+    // Preserve ordering (task_started before task_reply/error) when
+    // notifications beat the turn/start response. Also distrust a terminal
+    // for the response id after a distinct successor appeared but before the
+    // exact client-id echo confirms which turn actually owns the task.
+    const terminalNeedsIdentity =
+      Boolean(p.turn?.error?.message) ||
+      p.turn?.status === "failed" ||
+      p.turn?.status === "interrupted";
+    if (
+      !pending.startAnnounced ||
+      (!pending.identityConfirmed && (pending.competingTurnObserved || terminalNeedsIdentity))
+    ) {
+      pending.deferredTerminal = {
+        turnId,
+        status: p.turn?.status,
+        error: p.turn?.error?.message,
+      };
       return;
     }
     this.finishOwnedTurn(turnId, {
@@ -724,7 +841,7 @@ export class CodexAppServerBridge extends EventEmitter {
             id?: string;
             status?: string;
             error?: { message?: string } | null;
-            items?: Array<{ type?: string; text?: string; phase?: string }>;
+            items?: Array<{ type?: string; text?: string; phase?: string; clientId?: string }>;
           }>;
         };
       }>("thread/read", { threadId: this.threadId, includeTurns: true });
@@ -736,11 +853,28 @@ export class CodexAppServerBridge extends EventEmitter {
         return { recovered: false, turnId: activeAtStart };
       }
 
-      const turn = result?.thread?.turns?.find((candidate) => candidate.id === activeAtStart);
+      const turns = result?.thread?.turns ?? [];
+      const activePending = ownedAtStart
+        ? this.pendingTurns.get(activeAtStart)
+        : undefined;
+      let turn = turns.find((candidate) => candidate.id === activeAtStart);
+      if (activePending) {
+        const clientMatchedTurn = turns.find((candidate) =>
+          candidate.items?.some((item) =>
+            item.type === "userMessage" &&
+            item.clientId === activePending.clientUserMessageId
+          )
+        );
+        if (clientMatchedTurn?.id) {
+          this.bindPendingToTurn(activePending, clientMatchedTurn.id, true);
+          turn = clientMatchedTurn;
+        }
+      }
+      const resolvedTurnId = activePending?.turnId ?? activeAtStart;
       if (!turn || !isTerminalTurnStatus(turn.status)) {
         return {
           recovered: false,
-          turnId: activeAtStart,
+          turnId: resolvedTurnId,
           status: turn?.status ?? extractThreadStatus(result?.thread?.status),
         };
       }
@@ -753,7 +887,7 @@ export class CodexAppServerBridge extends EventEmitter {
           typeof item.text === "string"
         )?.text;
       const recovered = ownedAtStart
-        ? this.finishOwnedTurn(activeAtStart, {
+        ? this.finishOwnedTurn(resolvedTurnId, {
           status: turn.status,
           error: turn.error?.message,
           finalText,
@@ -764,9 +898,9 @@ export class CodexAppServerBridge extends EventEmitter {
           finalText,
         });
       if (recovered) {
-        this.emit("turn_reconciled", { turnId: activeAtStart, status: turn.status });
+        this.emit("turn_reconciled", { turnId: resolvedTurnId, status: turn.status });
       }
-      return { recovered, turnId: activeAtStart, status: turn.status };
+      return { recovered, turnId: resolvedTurnId, status: turn.status };
     })().finally(() => {
       this.reconciliationInFlight = null;
     });
@@ -781,6 +915,7 @@ export class CodexAppServerBridge extends EventEmitter {
     if (!pending) return false;
     if (terminal.finalText) pending.finalText = terminal.finalText;
     this.pendingTurns.delete(turnId);
+    this.pendingByClientUserMessageId.delete(pending.clientUserMessageId);
     if (this.activeTurnId === turnId) {
       this.activeTurnId = null;
       this.turnClaimed = false;

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -775,6 +775,11 @@ export class CodexAppServerBridge extends EventEmitter {
       !pending.startAnnounced ||
       (!pending.identityConfirmed && (pending.competingTurnObserved || terminalNeedsIdentity))
     ) {
+      // This cached terminal cannot wait forever: startOwnedTaskTurn announces
+      // the response-id claim before returning, and codexAppServerThink arms
+      // its bounded model-response timer from task_started (with the resolved
+      // submit result as a compatibility fallback). The cross-layer
+      // identity-never-confirms test protects that dependency.
       pending.deferredTerminal = {
         turnId,
         status: p.turn?.status,

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -147,7 +147,68 @@ class DeferredStartBridge extends EventEmitter {
   }
 }
 
+class IdentityNeverConfirmedBridge extends EventEmitter {
+  taskId = "";
+
+  async submitTask(input: { taskId: string }): Promise<{ started: true; turnId: string }> {
+    this.taskId = input.taskId;
+    this.emit("task_started", {
+      taskId: input.taskId,
+      turnId: "turn_response_without_client_identity",
+      steered: false,
+    });
+    return { started: true, turnId: "turn_response_without_client_identity" };
+  }
+
+  cancelQueuedTask(): boolean {
+    return false;
+  }
+
+  async reconcileActiveTurn(): Promise<{
+    recovered: false;
+    turnId: string;
+    status: "inProgress";
+  }> {
+    return {
+      recovered: false,
+      turnId: "turn_response_without_client_identity",
+      status: "inProgress",
+    };
+  }
+}
+
 describe("codexAppServerThink — terminal-event reconciliation watchdog", () => {
+  test("a started task whose client identity never confirms has a bounded, distinct response timeout", async () => {
+    const bridge = new IdentityNeverConfirmedBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_identity_never_confirms",
+      text: "must not defer a terminal forever",
+      timeoutMs: 25,
+      queueTimeoutMs: 500,
+      reconciliationIntervalMs: 0,
+    });
+
+    const observed = await Promise.race([
+      thinking.then((result) => ({ kind: "result" as const, result })),
+      new Promise<{ kind: "hung" }>((resolve) => setTimeout(() => resolve({ kind: "hung" }), 100)),
+    ]);
+    if (observed.kind === "hung") {
+      // Let a deliberately broken mutation settle and clear its timers so the
+      // suite reports the assertion instead of waiting for the queue deadline.
+      bridge.emit("task_reply", { taskId: bridge.taskId, text: "test cleanup" });
+      await thinking;
+    }
+
+    expect(observed.kind).toBe("result");
+    if (observed.kind !== "result") return;
+    expect(observed.result.failed).toBe(true);
+    expect(observed.result.queued).toBe(false);
+    expect(observed.result.replyText).toContain("任务 task_identity_never_confirms 超时");
+    expect(observed.result.replyText).toContain("开始处理后");
+    expect(observed.result.replyText).not.toContain("在队列中等待");
+  });
+
   test("a never-started FIFO task has its own finite, distinct queue deadline", async () => {
     const bridge = new DeferredStartBridge();
     const session = { bridge } as unknown as CodexAppServerRuntimeSession;

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -368,6 +368,10 @@ export function codexAppServerThink(
       // remains finite without falsely cancelling a running turn.
       queueDeadlineElapsed = true;
       if (!bridge.cancelQueuedTask(opts.taskId)) {
+        // This is also the finite bound for a turn/start RPC that never
+        // resolves and therefore cannot emit task_started: it has left FIFO,
+        // so convert the elapsed admission deadline into the normal bounded
+        // model-response wait instead of silently hanging forever.
         log(`[codex-app-server] queue deadline reached after task left FIFO; arming response timeout for ${opts.taskId}`);
         startResponseTimer();
         return;

--- a/docs/tests/report-test588-codex-turn-clientid-rebind.txt
+++ b/docs/tests/report-test588-codex-turn-clientid-rebind.txt
@@ -4,11 +4,11 @@ Base: origin/main c8a549e2ad258e8419249028a90c21da6307200a
 Worktree: /tmp/commniu-codex-turn-rebind
 Branch: fix/codex-turn-clientid-rebind
 Implementation commit: 4a15289b226153a52538ea0931a4bdce0cfc4941
-Source candidate (including merge-gate tests): e3d51f872f6912cbf60a5d2729a93cf8c1b05078
+Source candidate (including merge-gate tests): d3abb1aba352f52d2e79afbc2991fb42548a997b
 Docker image: anet-test588:dev
-Docker image id: sha256:7e63987d54fa6aad6745566e8316034bde4e63293363656c28e8cd7e59e7aedb
+Docker image id: sha256:3d60d3ab34860fc3ca14258141410802069a8ed4619abfea1fe886814032c1ab
 Image revision label / ANET_TEST_SOURCE_COMMIT:
-e3d51f872f6912cbf60a5d2729a93cf8c1b05078
+d3abb1aba352f52d2e79afbc2991fb42548a997b
 
 Reusable upstream wire conclusion
 ---------------------------------
@@ -65,15 +65,19 @@ Merge-condition regression coverage
   fake WebSocket app-server wire, and codexAppServerThink: a competing turn is
   observed, the response-id interruption is deferred, no matching clientId
   ever arrives, and the runtime still produces the bounded response timeout.
+- A second cross-layer case leaves the real turn/start RPC unresolved forever.
+  Because that task has left FIFO but cannot emit task_started, #585's queue
+  deadline must convert it to the normal response timer. Removing that exact
+  fallback is independently witnessed red.
 
 Docker command
 --------------
-sg docker -c 'docker build --build-arg SOURCE_COMMIT=e3d51f872f6912cbf60a5d2729a93cf8c1b05078 -t anet-test588:dev -f tests/test588-codex-turn-clientid-rebind/Dockerfile .'
+sg docker -c 'docker build --build-arg SOURCE_COMMIT=d3abb1aba352f52d2e79afbc2991fb42548a997b -t anet-test588:dev -f tests/test588-codex-turn-clientid-rebind/Dockerfile .'
 sg docker -c 'docker run --rm anet-test588:dev'
 
 Normal result
 -------------
-60 pass, 0 fail, 216 expect() calls across:
+61 pass, 0 fail, 221 expect() calls across:
 - codex-app-server-bridge.test.ts
 - codex-app-server/runtime.test.ts
 - codex-app-server/session-manager.test.ts
@@ -82,7 +86,7 @@ RESULT: PASS
 
 Witnessed-red mutation result
 -----------------------------
-All 18 targeted mutations made the unchanged test suite fail:
+All 19 targeted mutations made the unchanged test suite fail:
 1. no_client_index
 2. ignore_user_client_rebind
 3. ignore_history_client_rebind
@@ -96,11 +100,12 @@ All 18 targeted mutations made the unchanged test suite fail:
 11. omit_bridge_started_event
 12. omit_steer_started_event
 13. omit_queue_deadline
-14. queue_timeout_does_not_cancel
-15. ignore_post_deadline_requeue
-16. ignore_post_deadline_steer_requeue
-17. cancel_queue_noop
-18. failure_returned_as_success
+14. omit_left_fifo_response_fallback
+15. queue_timeout_does_not_cancel
+16. ignore_post_deadline_requeue
+17. ignore_post_deadline_steer_requeue
+18. cancel_queue_noop
+19. failure_returned_as_success
 
 Production status
 -----------------

--- a/docs/tests/report-test588-codex-turn-clientid-rebind.txt
+++ b/docs/tests/report-test588-codex-turn-clientid-rebind.txt
@@ -1,0 +1,81 @@
+Test 588 — Codex app-server client-id turn rebind
+Date: 2026-08-04 (Asia/Shanghai)
+Base: origin/main c8a549e2ad258e8419249028a90c21da6307200a
+Worktree: /tmp/commniu-codex-turn-rebind
+Branch: fix/codex-turn-clientid-rebind
+Source commit: 4a15289b226153a52538ea0931a4bdce0cfc4941
+Docker image: anet-test588:dev
+Docker image id: sha256:aa29a51b1d84a803cf211b60e9a403498ab20bca414d09d8fbae2890782f0cdf
+Image revision label / ANET_TEST_SOURCE_COMMIT:
+4a15289b226153a52538ea0931a4bdce0cfc4941
+
+Production witnessed-red
+------------------------
+Dashboard task idem_cf2eda67c8c3ade91e76df9e82783b39836b030d reached 通信牛 TUI
+and received the exact model answer. The bridge recorded turn/start response id
+019fcaa0-73f4-71d2-a9aa-b883593e7de0, while the app-server's authoritative
+turn/started, userMessage, final_answer, turn/completed, and thread/read history
+all used replacement id 1c11f248-bbcf-41ac-9732-00412043d58a. The userMessage
+carried clientId anet:idem_cf2eda67c8c3ade91e76df9e82783b39836b030d.
+
+Because the old bridge indexed pending work only by the response turn id, the
+exact answer was visible in the TUI but no task_reply was emitted, the Dashboard
+row remained running, and the next FIFO row could not start. A control task
+(idem_d284261d0095dbc8d8bd446cd81f1be652184b38) where the bridge won the idle
+race used one consistent turn id and completed end-to-end: task_reply emitted,
+Hub status replied, and Dashboard /api/hub/tasks read back the exact ACK.
+
+Fix
+---
+- Index every pending owned turn by the immutable clientUserMessageId
+  (anet:<Hub task id>) before turn/start is sent.
+- When item/completed echoes the userMessage clientId under a different turn,
+  atomically move the pending entry from the response id to the real turn id.
+- Remove the stale response-id map entry and clear the temporary external-turn
+  classification for the real owner.
+- Defer terminal attribution if task_started has not been announced, or if an
+  unconfirmed response turn reports failure/interruption after a competing turn
+  appeared. This prevents a phantom interruption from failing the real task.
+- Reconcile missed live events by searching authoritative thread history for
+  the same userMessage clientId, then finish only the matched replacement turn.
+
+Docker command
+--------------
+sg docker -c 'docker build --build-arg SOURCE_COMMIT=4a15289b226153a52538ea0931a4bdce0cfc4941 -t anet-test588:dev -f tests/test588-codex-turn-clientid-rebind/Dockerfile .'
+sg docker -c 'docker run --rm anet-test588:dev'
+
+Normal result
+-------------
+58 pass, 0 fail, 202 expect() calls across:
+- codex-app-server-bridge.test.ts
+- codex-app-server/runtime.test.ts
+- codex-app-server/session-manager.test.ts
+BUILD: PASS
+RESULT: PASS
+
+Witnessed-red mutation result
+-----------------------------
+All 17 targeted mutations made the unchanged test suite fail:
+1. no_client_index
+2. ignore_user_client_rebind
+3. ignore_history_client_rebind
+4. keep_stale_response_mapping
+5. trust_phantom_terminal
+6. overwrite_actual_with_response
+7. timer_at_submission
+8. ignore_started_event
+9. wrong_task_arms_timer
+10. omit_bridge_started_event
+11. omit_steer_started_event
+12. omit_queue_deadline
+13. queue_timeout_does_not_cancel
+14. ignore_post_deadline_requeue
+15. ignore_post_deadline_steer_requeue
+16. cancel_queue_noop
+17. failure_returned_as_success
+
+Production status
+-----------------
+This report proves the source candidate in Docker. It is not merge, publish, or
+deployment authorization. The production bridge remains on the previously
+reviewed c0849553 package until independent review and merge of this candidate.

--- a/docs/tests/report-test588-codex-turn-clientid-rebind.txt
+++ b/docs/tests/report-test588-codex-turn-clientid-rebind.txt
@@ -3,11 +3,18 @@ Date: 2026-08-04 (Asia/Shanghai)
 Base: origin/main c8a549e2ad258e8419249028a90c21da6307200a
 Worktree: /tmp/commniu-codex-turn-rebind
 Branch: fix/codex-turn-clientid-rebind
-Source commit: 4a15289b226153a52538ea0931a4bdce0cfc4941
+Implementation commit: 4a15289b226153a52538ea0931a4bdce0cfc4941
+Source candidate (including merge-gate tests): a68031681e180fb45c14e8a0fa1f19400d29e5cb
 Docker image: anet-test588:dev
-Docker image id: sha256:aa29a51b1d84a803cf211b60e9a403498ab20bca414d09d8fbae2890782f0cdf
+Docker image id: sha256:fd25690ddd291f85787b2e47dc7a41dcbca003ea5f3c4dca3876238ef85673f3
 Image revision label / ANET_TEST_SOURCE_COMMIT:
-4a15289b226153a52538ea0931a4bdce0cfc4941
+a68031681e180fb45c14e8a0fa1f19400d29e5cb
+
+Reusable upstream wire conclusion
+---------------------------------
+turn/start 的响应 turnId 在竞态下不是权威的，真正的绑定是
+clientUserMessageId；“我的那一个 turn”必须按该精确标识认领，不能按最近、
+时间顺序或唯一 inProgress turn 推断。
 
 Production witnessed-red
 ------------------------
@@ -38,15 +45,31 @@ Fix
   appeared. This prevents a phantom interruption from failing the real task.
 - Reconcile missed live events by searching authoritative thread history for
   the same userMessage clientId, then finish only the matched replacement turn.
+- Cache an early terminal until exact ownership and task_started ordering are
+  established; never discard it. The existing model-response timer bounds this
+  deferred state and reports the distinct "开始处理后 ... 无最终回复" failure.
+
+Merge-condition regression coverage
+-----------------------------------
+- Two turns are concurrently in progress. The wrong turn echoes a different
+  clientId and completes first; it is not claimed. Only the turn echoing the
+  exact task clientUserMessageId can rebind and produce task_reply.
+- userMessage, final_answer, and turn/completed can all arrive before the
+  delayed turn/start response/task_started. The terminal is cached and then
+  completes in task_started -> task_reply order.
+- A started task whose client identity never confirms exits through the bounded
+  model-response timeout. Its wording is asserted distinct from FIFO queue
+  timeout wording, and a 100ms observation bound makes removal of both timer
+  arming paths fail without hanging the mutation suite.
 
 Docker command
 --------------
-sg docker -c 'docker build --build-arg SOURCE_COMMIT=4a15289b226153a52538ea0931a4bdce0cfc4941 -t anet-test588:dev -f tests/test588-codex-turn-clientid-rebind/Dockerfile .'
+sg docker -c 'docker build --build-arg SOURCE_COMMIT=a68031681e180fb45c14e8a0fa1f19400d29e5cb -t anet-test588:dev -f tests/test588-codex-turn-clientid-rebind/Dockerfile .'
 sg docker -c 'docker run --rm anet-test588:dev'
 
 Normal result
 -------------
-58 pass, 0 fail, 202 expect() calls across:
+59 pass, 0 fail, 210 expect() calls across:
 - codex-app-server-bridge.test.ts
 - codex-app-server/runtime.test.ts
 - codex-app-server/session-manager.test.ts
@@ -55,7 +78,7 @@ RESULT: PASS
 
 Witnessed-red mutation result
 -----------------------------
-All 17 targeted mutations made the unchanged test suite fail:
+All 18 targeted mutations made the unchanged test suite fail:
 1. no_client_index
 2. ignore_user_client_rebind
 3. ignore_history_client_rebind
@@ -64,15 +87,16 @@ All 17 targeted mutations made the unchanged test suite fail:
 6. overwrite_actual_with_response
 7. timer_at_submission
 8. ignore_started_event
-9. wrong_task_arms_timer
-10. omit_bridge_started_event
-11. omit_steer_started_event
-12. omit_queue_deadline
-13. queue_timeout_does_not_cancel
-14. ignore_post_deadline_requeue
-15. ignore_post_deadline_steer_requeue
-16. cancel_queue_noop
-17. failure_returned_as_success
+9. identity_defer_unbounded
+10. wrong_task_arms_timer
+11. omit_bridge_started_event
+12. omit_steer_started_event
+13. omit_queue_deadline
+14. queue_timeout_does_not_cancel
+15. ignore_post_deadline_requeue
+16. ignore_post_deadline_steer_requeue
+17. cancel_queue_noop
+18. failure_returned_as_success
 
 Production status
 -----------------

--- a/docs/tests/report-test588-codex-turn-clientid-rebind.txt
+++ b/docs/tests/report-test588-codex-turn-clientid-rebind.txt
@@ -4,11 +4,11 @@ Base: origin/main c8a549e2ad258e8419249028a90c21da6307200a
 Worktree: /tmp/commniu-codex-turn-rebind
 Branch: fix/codex-turn-clientid-rebind
 Implementation commit: 4a15289b226153a52538ea0931a4bdce0cfc4941
-Source candidate (including merge-gate tests): a68031681e180fb45c14e8a0fa1f19400d29e5cb
+Source candidate (including merge-gate tests): e3d51f872f6912cbf60a5d2729a93cf8c1b05078
 Docker image: anet-test588:dev
-Docker image id: sha256:fd25690ddd291f85787b2e47dc7a41dcbca003ea5f3c4dca3876238ef85673f3
+Docker image id: sha256:7e63987d54fa6aad6745566e8316034bde4e63293363656c28e8cd7e59e7aedb
 Image revision label / ANET_TEST_SOURCE_COMMIT:
-a68031681e180fb45c14e8a0fa1f19400d29e5cb
+e3d51f872f6912cbf60a5d2729a93cf8c1b05078
 
 Reusable upstream wire conclusion
 ---------------------------------
@@ -61,15 +61,19 @@ Merge-condition regression coverage
   model-response timeout. Its wording is asserted distinct from FIFO queue
   timeout wording, and a 100ms observation bound makes removal of both timer
   arming paths fail without hanging the mutation suite.
+- The same bound is exercised end-to-end across a real CodexAppServerBridge,
+  fake WebSocket app-server wire, and codexAppServerThink: a competing turn is
+  observed, the response-id interruption is deferred, no matching clientId
+  ever arrives, and the runtime still produces the bounded response timeout.
 
 Docker command
 --------------
-sg docker -c 'docker build --build-arg SOURCE_COMMIT=a68031681e180fb45c14e8a0fa1f19400d29e5cb -t anet-test588:dev -f tests/test588-codex-turn-clientid-rebind/Dockerfile .'
+sg docker -c 'docker build --build-arg SOURCE_COMMIT=e3d51f872f6912cbf60a5d2729a93cf8c1b05078 -t anet-test588:dev -f tests/test588-codex-turn-clientid-rebind/Dockerfile .'
 sg docker -c 'docker run --rm anet-test588:dev'
 
 Normal result
 -------------
-59 pass, 0 fail, 210 expect() calls across:
+60 pass, 0 fail, 216 expect() calls across:
 - codex-app-server-bridge.test.ts
 - codex-app-server/runtime.test.ts
 - codex-app-server/session-manager.test.ts

--- a/tests/test588-codex-turn-clientid-rebind/Dockerfile
+++ b/tests/test588-codex-turn-clientid-rebind/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+ARG SOURCE_COMMIT=uncommitted
+LABEL org.opencontainers.image.revision=$SOURCE_COMMIT
+ENV ANET_TEST_SOURCE_COMMIT=$SOURCE_COMMIT
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node/src ./agent-node/src
+COPY tests/test588-codex-turn-clientid-rebind/run.sh /harness/run.sh
+COPY tests/test588-codex-turn-clientid-rebind/mutate.ts /harness/mutate.ts
+RUN chmod 0755 /harness/run.sh
+
+ENTRYPOINT ["/harness/run.sh"]

--- a/tests/test588-codex-turn-clientid-rebind/mutate.ts
+++ b/tests/test588-codex-turn-clientid-rebind/mutate.ts
@@ -61,6 +61,10 @@ switch (mutation) {
   case "ignore_started_event":
     replaceExact(runtimePath, `      startResponseTimer();\n    };\n\n    // A shared app-server WebSocket`, `      void ev;\n    };\n\n    // A shared app-server WebSocket`);
     break;
+  case "identity_defer_unbounded":
+    replaceExact(runtimePath, `      startResponseTimer();\n    };\n\n    // A shared app-server WebSocket`, `      void ev;\n    };\n\n    // A shared app-server WebSocket`);
+    replaceExact(runtimePath, `        if (r.started) startResponseTimer();`, `        if (false && r.started) startResponseTimer();`);
+    break;
   case "wrong_task_arms_timer":
     replaceExact(runtimePath, `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (ev.taskId !== opts.taskId) return;`, `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (false && ev.taskId !== opts.taskId) return;`);
     break;

--- a/tests/test588-codex-turn-clientid-rebind/mutate.ts
+++ b/tests/test588-codex-turn-clientid-rebind/mutate.ts
@@ -81,6 +81,13 @@ switch (mutation) {
   case "omit_queue_deadline":
     replaceExact(runtimePath, `    queueTimer = setTimeout(() => {`, `    if (false) queueTimer = setTimeout(() => {`);
     break;
+  case "omit_left_fifo_response_fallback":
+    replaceExact(
+      runtimePath,
+      `        log(\`[codex-app-server] queue deadline reached after task left FIFO; arming response timeout for \${opts.taskId}\`);\n        startResponseTimer();\n        return;`,
+      `        log(\`[codex-app-server] queue deadline reached after task left FIFO; response timeout omitted by mutation\`);\n        return;`,
+    );
+    break;
   case "queue_timeout_does_not_cancel":
     replaceExact(runtimePath, `      if (!bridge.cancelQueuedTask(opts.taskId)) {`, `      if (true || !bridge.cancelQueuedTask(opts.taskId)) {`);
     break;

--- a/tests/test588-codex-turn-clientid-rebind/mutate.ts
+++ b/tests/test588-codex-turn-clientid-rebind/mutate.ts
@@ -1,0 +1,97 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const mutation = process.argv[2];
+const runtimePath = "./src/runtime/codex-app-server/runtime.ts";
+const bridgePath = "./src/runtime/codex-app-server-bridge.ts";
+const cliPath = "./src/cli.ts";
+
+function replaceExact(path: string, before: string, after: string): void {
+  const source = readFileSync(path, "utf8");
+  const count = source.split(before).length - 1;
+  if (count !== 1) throw new Error(`${mutation}: expected one anchor in ${path}, found ${count}`);
+  writeFileSync(path, source.replace(before, after));
+}
+
+switch (mutation) {
+  case "no_client_index":
+    replaceExact(
+      bridgePath,
+      `    this.pendingByClientUserMessageId.set(clientUserMessageId, pending);`,
+      `    void clientUserMessageId;`,
+    );
+    break;
+  case "ignore_user_client_rebind":
+    replaceExact(
+      bridgePath,
+      `      if (byClientId) {`,
+      `      if (false && byClientId) {`,
+    );
+    break;
+  case "ignore_history_client_rebind":
+    replaceExact(
+      bridgePath,
+      `        if (clientMatchedTurn?.id) {`,
+      `        if (false && clientMatchedTurn?.id) {`,
+    );
+    break;
+  case "keep_stale_response_mapping":
+    replaceExact(
+      bridgePath,
+      `      this.pendingTurns.delete(previousTurnId);`,
+      `      void previousTurnId;`,
+    );
+    break;
+  case "trust_phantom_terminal":
+    replaceExact(
+      bridgePath,
+      `      (!pending.identityConfirmed && (pending.competingTurnObserved || terminalNeedsIdentity))`,
+      `      false`,
+    );
+    break;
+  case "overwrite_actual_with_response":
+    replaceExact(
+      bridgePath,
+      `    if (!pending.turnId && responseTurnId) {`,
+      `    if (responseTurnId) {`,
+    );
+    break;
+  case "timer_at_submission":
+    replaceExact(runtimePath, `    bridge.on("task_started", onStarted);`, `    bridge.on("task_started", onStarted);\n    startResponseTimer();`);
+    break;
+  case "ignore_started_event":
+    replaceExact(runtimePath, `      startResponseTimer();\n    };\n\n    // A shared app-server WebSocket`, `      void ev;\n    };\n\n    // A shared app-server WebSocket`);
+    break;
+  case "wrong_task_arms_timer":
+    replaceExact(runtimePath, `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (ev.taskId !== opts.taskId) return;`, `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (false && ev.taskId !== opts.taskId) return;`);
+    break;
+  case "omit_bridge_started_event":
+    replaceExact(
+      bridgePath,
+      `    this.emit("task_started", {\n      taskId: pending.taskId,\n      turnId: pending.turnId,\n      steered: false,\n    });`,
+      `    void pending;`,
+    );
+    break;
+  case "omit_steer_started_event":
+    replaceExact(bridgePath, `      this.emit("task_started", {\n        taskId: input.taskId,\n        turnId: expectedTurnId,\n        steered: true,\n      });`, `      void expectedTurnId;`);
+    break;
+  case "omit_queue_deadline":
+    replaceExact(runtimePath, `    queueTimer = setTimeout(() => {`, `    if (false) queueTimer = setTimeout(() => {`);
+    break;
+  case "queue_timeout_does_not_cancel":
+    replaceExact(runtimePath, `      if (!bridge.cancelQueuedTask(opts.taskId)) {`, `      if (true || !bridge.cancelQueuedTask(opts.taskId)) {`);
+    break;
+  case "ignore_post_deadline_requeue":
+    replaceExact(runtimePath, `    bridge.on("drain_deferred", onRequeued);`, `    void onRequeued;`);
+    break;
+  case "ignore_post_deadline_steer_requeue":
+    replaceExact(runtimePath, `    bridge.on("steer_deferred", onRequeued);`, `    void onRequeued;`);
+    break;
+  case "cancel_queue_noop":
+    replaceExact(bridgePath, `  cancelQueuedTask(taskId: string): boolean {\n    const index = this.taskQueue.findIndex((task) => task.taskId === taskId);`, `  cancelQueuedTask(taskId: string): boolean {\n    return false;\n    const index = this.taskQueue.findIndex((task) => task.taskId === taskId);`);
+    break;
+  case "failure_returned_as_success":
+    replaceExact(cliPath, `  return codexAppServerReplyOrThrow(outcome);`, `  return outcome.replyText || "（无回复）";`);
+    break;
+  default:
+    throw new Error(`unknown mutation: ${mutation}`);
+}

--- a/tests/test588-codex-turn-clientid-rebind/run.sh
+++ b/tests/test588-codex-turn-clientid-rebind/run.sh
@@ -17,7 +17,7 @@ for mutation_name in \
   no_client_index ignore_user_client_rebind ignore_history_client_rebind keep_stale_response_mapping \
   trust_phantom_terminal overwrite_actual_with_response \
   timer_at_submission ignore_started_event identity_defer_unbounded wrong_task_arms_timer \
-  omit_bridge_started_event omit_steer_started_event omit_queue_deadline \
+  omit_bridge_started_event omit_steer_started_event omit_queue_deadline omit_left_fifo_response_fallback \
   queue_timeout_does_not_cancel ignore_post_deadline_requeue \
   ignore_post_deadline_steer_requeue cancel_queue_noop failure_returned_as_success; do
   cp ./src/runtime/codex-app-server/runtime.ts /tmp/test588-runtime.ts

--- a/tests/test588-codex-turn-clientid-rebind/run.sh
+++ b/tests/test588-codex-turn-clientid-rebind/run.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -u
+
+cd /workspace/agent-node
+normal=/tmp/test588-normal.log
+if ! bun test \
+  ./src/runtime/codex-app-server-bridge.test.ts \
+  ./src/runtime/codex-app-server/runtime.test.ts \
+  ./src/runtime/codex-app-server/session-manager.test.ts >"$normal" 2>&1; then
+  cat "$normal"
+  echo "RESULT: FAIL normal"
+  exit 1
+fi
+cat "$normal"
+
+for mutation_name in \
+  no_client_index ignore_user_client_rebind ignore_history_client_rebind keep_stale_response_mapping \
+  trust_phantom_terminal overwrite_actual_with_response \
+  timer_at_submission ignore_started_event wrong_task_arms_timer \
+  omit_bridge_started_event omit_steer_started_event omit_queue_deadline \
+  queue_timeout_does_not_cancel ignore_post_deadline_requeue \
+  ignore_post_deadline_steer_requeue cancel_queue_noop failure_returned_as_success; do
+  cp ./src/runtime/codex-app-server/runtime.ts /tmp/test588-runtime.ts
+  cp ./src/runtime/codex-app-server-bridge.ts /tmp/test588-bridge.ts
+  cp ./src/cli.ts /tmp/test588-cli.ts
+  if ! bun /harness/mutate.ts "$mutation_name"; then
+    cp /tmp/test588-runtime.ts ./src/runtime/codex-app-server/runtime.ts
+    cp /tmp/test588-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+    cp /tmp/test588-cli.ts ./src/cli.ts
+    echo "RESULT: FAIL mutation-anchor $mutation_name"
+    exit 1
+  fi
+  mutation=/tmp/test588-${mutation_name}.log
+  if bun test \
+    ./src/runtime/codex-app-server-bridge.test.ts \
+    ./src/runtime/codex-app-server/runtime.test.ts \
+    ./src/runtime/codex-app-server/session-manager.test.ts >"$mutation" 2>&1; then
+    cat "$mutation"
+    cp /tmp/test588-runtime.ts ./src/runtime/codex-app-server/runtime.ts
+    cp /tmp/test588-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+    cp /tmp/test588-cli.ts ./src/cli.ts
+    echo "RESULT: FAIL mutation-survived $mutation_name"
+    exit 1
+  fi
+  echo "WITNESSED-RED: $mutation_name"
+  tail -16 "$mutation"
+  cp /tmp/test588-runtime.ts ./src/runtime/codex-app-server/runtime.ts
+  cp /tmp/test588-bridge.ts ./src/runtime/codex-app-server-bridge.ts
+  cp /tmp/test588-cli.ts ./src/cli.ts
+done
+
+bun run build >/tmp/test588-build.log 2>&1 || {
+  cat /tmp/test588-build.log
+  echo "RESULT: FAIL build"
+  exit 1
+}
+echo "BUILD: PASS"
+echo "RESULT: PASS"

--- a/tests/test588-codex-turn-clientid-rebind/run.sh
+++ b/tests/test588-codex-turn-clientid-rebind/run.sh
@@ -16,7 +16,7 @@ cat "$normal"
 for mutation_name in \
   no_client_index ignore_user_client_rebind ignore_history_client_rebind keep_stale_response_mapping \
   trust_phantom_terminal overwrite_actual_with_response \
-  timer_at_submission ignore_started_event wrong_task_arms_timer \
+  timer_at_submission ignore_started_event identity_defer_unbounded wrong_task_arms_timer \
   omit_bridge_started_event omit_steer_started_event omit_queue_deadline \
   queue_timeout_does_not_cancel ignore_post_deadline_requeue \
   ignore_post_deadline_steer_requeue cancel_queue_noop failure_returned_as_success; do


### PR DESCRIPTION
## 上游 wire 事实（本次唯一改变认知的一条）

**`turn/start` 的响应 turnId 在竞态下不是权威的，真正的绑定是 `clientUserMessageId`。**

生产 witnessed-red：`/goal` 后继轮与 FIFO drain 同时抢轮子时

```
turn/start response       019fcaa0…
真实 user/final/terminal  1c11f248…
唯一 clientId             anet:idem_cf2…
```

桥在等 `019fcaa0`，而答案挂在 `1c11f248` 上 —— TUI 里已经有答案，Dashboard 那行永远 `running`。

在此之前所有代码都默认「start 的返回值就是我的 turn」。这个假设被真机推翻。**以后任何「拿 start 返回的 id 去等」的写法都应被这句挡住。**

## 修复

只动 `codex-app-server-bridge.ts`：clientId 预索引 / rebind、stale response map 删除、phantom terminal defer、`thread/read` 按 clientId 恢复。

## 审查条件与落实

| 条件 | 落实 |
|---|---|
| 认领必须**精确标识**，不许按位置/时间/唯一性推断 | `Map` 按 clientId 精确索引；历史恢复用 `item.clientId === pending.clientUserMessageId` |
| 真 terminal **缓存待认领**，不能丢弃 | `deferredTerminal` 缓存，认领时校验 `turnId` 一致且 `startAnnounced` |
| defer 必须**有界** | 复用 runtime 的 response timer；新增跨层测试 + `identity_defer_unbounded` mutation 同时删两个 arm 点 |

跨层这条是重点：defer 路径的有界性依赖 runtime 层的兜底分支，**原本没有任何测试守着它** —— 删的人看不出自己删了什么。现在有 mutation 钉住，而且它是靠新用例变红，**不是靠把测试套件挂死**。

## 证据

Docker 固定 tag `anet-test588:dev`，label + ENV 均为 `a6803168`：**59 pass / 0 fail / 210 assertions，18/18 mutation witnessed-red**。

覆盖：双并发 turn 下错误 clientId 的轮子先完成仍零 rebind、身份永不确认最终失败且文案与「在队列中等待」可区分、terminal 早于 start response 到达时事件顺序仍严格 `task_started → task_reply`。

既有 11 条 queue/steer/timeout mutation 原样保留并复验（`test586`=4、`test587`=11，与 main 一致）。