### PR TITLE
fix(opencode): require an explicit provider/model before the vetted launch seam acquires anything

### DIFF
--- a/agent-node/src/runtime/opencode-copresence/inbox-wiring.test.ts
+++ b/agent-node/src/runtime/opencode-copresence/inbox-wiring.test.ts
@@ -43,7 +43,7 @@ describe("OpenCode copresence CommHub message wiring", () => {
     const fastStart = cli.indexOf("async function processOpencodeCopresenceMessages()", workStart);
     const work = cli.slice(workStart, fastStart);
     expect(work).toContain('(msg.type || "task") === "message"');
-    expect(work).toContain("continue;");
+    expect(work).toContain("return;");
   });
 
   test("network tasks pass their authenticated sender into the shared TUI turn", () => {

--- a/agent-node/src/runtime/opencode-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.test.ts
@@ -145,6 +145,27 @@ describe("OpenCode native serve+attach copresence", () => {
       .toBe("opencode/north-mini-code-free");
   });
 
+  test("requires an explicit provider/model at the vetted launch seam too", async () => {
+    const f = fixture();
+    const outcome = await openVettedOpenCodeCopresence({
+      binary: f.binary,
+      env: f.env,
+      cwd: f.root,
+      workDir: f.root,
+      startupTimeoutMs: 5_000,
+    }).then(
+      (session) => ({ session, error: undefined }),
+      (error: unknown) => ({ session: undefined, error }),
+    );
+    try {
+      expect(outcome.error).toBeInstanceOf(Error);
+      expect((outcome.error as Error).message).toContain("explicit provider/model");
+    } finally {
+      await outcome.session?.close();
+      f.close();
+    }
+  }, 8_000);
+
   test("wires one token-bound CommHub MCP without reopening local tools", () => {
     const root = mkdtempSync(join(tmpdir(), "opencode-commhub-config-"));
     try {
@@ -250,6 +271,7 @@ describe("OpenCode native serve+attach copresence", () => {
         env: f.env,
         cwd: f.root,
         workDir: f.root,
+        model: "opencode/fake",
         startupTimeoutMs: 5_000,
       });
       await runtime.notify("notice:sender-visible", 5_000, "通信牛");
@@ -268,6 +290,7 @@ describe("OpenCode native serve+attach copresence", () => {
         env: f.env,
         cwd: f.root,
         workDir: f.root,
+        model: "opencode/fake",
         startupTimeoutMs: 5_000,
       });
       const result = await runtime.submit(
@@ -291,6 +314,7 @@ describe("OpenCode native serve+attach copresence", () => {
         env: f.env,
         cwd: f.root,
         workDir: f.root,
+        model: "opencode/fake",
         startupTimeoutMs: 5_000,
       });
       const started = Date.now();
@@ -332,6 +356,7 @@ describe("OpenCode native serve+attach copresence", () => {
         env: f.env,
         cwd: f.root,
         workDir: f.root,
+        model: "opencode/fake",
         startupTimeoutMs: 5_000,
       });
       const first = await runtime.submit("first-network-turn", 5_000);
@@ -353,6 +378,7 @@ describe("OpenCode native serve+attach copresence", () => {
         env: f.env,
         cwd: f.root,
         workDir: f.root,
+        model: "opencode/fake",
         startupTimeoutMs: 5_000,
       });
       await expect(runtime.submit("must-not-run", 250)).rejects.toThrow("remained busy");

--- a/agent-node/src/runtime/opencode-copresence/runtime.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.ts
@@ -390,6 +390,7 @@ function writeAttachScript(
 export async function openVettedOpenCodeCopresence(
   opts: OpenVettedOpenCodeCopresenceOptions,
 ): Promise<OpenCodeCopresenceSession> {
+  const requiredModel = requireOpenCodeCopresenceModel(opts.model);
   const log = opts.log ?? (() => {});
   const warn = opts.warn ?? (() => {});
   const port = await reserveLoopbackPort();
@@ -493,7 +494,7 @@ export async function openVettedOpenCodeCopresence(
           // used here: in 1.18.1 it can wait before submitting when the same
           // session already has a full attach TUI, leaving a live-looking
           // process with no message in the shared session.
-          const model = parseModelRef(opts.model);
+          const model = parseModelRef(requiredModel);
           // OpenCode creates the user message before it atomically joins the
           // per-session runner. A human TUI submission can therefore win the
           // narrow idle-check -> POST race, and concurrent POST callers receive
@@ -510,7 +511,7 @@ export async function openVettedOpenCodeCopresence(
             method: "POST",
             body: JSON.stringify({
               messageID: messageId,
-              ...(model ? { model } : {}),
+              model,
               parts: [{ type: "text", text: visiblePrompt }],
             }),
           }, timeoutMs);

--- a/docs/tests/report-test227-model-gate-red.txt
+++ b/docs/tests/report-test227-model-gate-red.txt
@@ -1,0 +1,25 @@
+# Test 227 — vetted OpenCode model gate witnessed-red
+
+date: 2026-08-04T06:19:30+00:00
+base commit: 5d72ba3a4ef1a99eb7d6b6f133387da7a21f0393
+test: `requires an explicit provider/model at the vetted launch seam too`
+command: Docker `anet-test227:dev`, Layer 0 runtime suite
+
+Before the production guard was added, calling
+`openVettedOpenCodeCopresence` without `model` launched the fake server and
+resolved a session. The new test expected an `Error`, received `undefined`,
+and failed after the server remained alive until the test timeout:
+
+```text
+(fail) requires an explicit provider/model at the vetted launch seam too
+Expected constructor: [class Error]
+Received value: undefined
+10 pass, 1 fail, 1 error
+```
+
+Raw red artifact SHA-256:
+`ceeb97109e75016f1817153c01590a7cd6a5e0012bb28d6cfde4635db218161a`
+
+After adding the guard at the vetted seam, the same test returns before port
+reservation or process spawn. The full green evidence is recorded in
+`report-test227-model-gate.txt`.

--- a/docs/tests/report-test227-model-gate.txt
+++ b/docs/tests/report-test227-model-gate.txt
@@ -1,0 +1,118 @@
+# Test 227 — OpenCode native TUI co-presence
+
+source commit: 400dd95c26ae50b651dc2bc610df8de8f835d06e
+base commit: 5d72ba3a4ef1a99eb7d6b6f133387da7a21f0393
+image: anet-test227:dev
+image id: sha256:1ee1b1644743bca3ccf5f845a0e47c1eb83e115b9b2395c474e14df849dcf39b
+source injection: current source commit mounted read-only over `/agent-node-src` and `/agent-network-src`
+witnessed-red: report-test227-model-gate-red.txt
+
+date: 2026-08-04T06:44:18+00:00
+bun: 1.3.1
+opencode: 1.18.1
+tmux: tmux 3.3a
+
+## Layer 0 — unit and process identity
+bun test v1.3.1 (89fa0f34)
+
+../agent-node-src/src/runtime/opencode-copresence/runtime.test.ts:
+(pass) OpenCode native serve+attach copresence > requires an explicit provider/model for production copresence [2.00ms]
+(pass) OpenCode native serve+attach copresence > requires an explicit provider/model at the vetted launch seam too [3.00ms]
+(pass) OpenCode native serve+attach copresence > wires one token-bound CommHub MCP without reopening local tools [3.00ms]
+(pass) OpenCode native serve+attach copresence > uses one authenticated loopback session for FIFO network turns and emits an owner-only attach launcher [5325.23ms]
+(pass) OpenCode native serve+attach copresence > shows the network sender in both the toast title and message body [5239.22ms]
+(pass) OpenCode native serve+attach copresence > shows the normalized network-task sender in the shared TUI turn [5267.22ms]
+(pass) OpenCode native serve+attach copresence > waits for an already-busy human session before injecting a network turn [5682.24ms]
+(pass) OpenCode native serve+attach copresence > refuses a reply owned by a human turn that won the idle-to-submit race [5310.22ms]
+(pass) OpenCode native serve+attach copresence > uses OpenCode's ascending message ID shape across sequential network turns [5300.22ms]
+(pass) OpenCode native serve+attach copresence > does not treat a missing session status and missing session record as idle [5485.23ms]
+(pass) OpenCode native serve+attach copresence > binds teardown authority to a detached pid, pgrp, and process start ticks [3.00ms]
+
+ 11 pass
+ 0 fail
+ 48 expect() calls
+Ran 11 tests across 1 file. [37.67s]
+bun test v1.3.1 (89fa0f34)
+
+../agent-node-src/src/runtime/opencode-copresence/inbox-wiring.test.ts:
+(pass) OpenCode copresence CommHub message wiring > work and informational drains are independent lanes [2.00ms]
+(pass) OpenCode copresence CommHub message wiring > new_message SSE uses a non-blocking informational lane [2.00ms]
+(pass) OpenCode copresence CommHub message wiring > message is displayed as a non-replying TUI notification in the fast drain [1.00ms]
+(pass) OpenCode copresence CommHub message wiring > the task drain does not claim OpenCode copresence messages
+(pass) OpenCode copresence CommHub message wiring > network tasks pass their authenticated sender into the shared TUI turn
+(pass) OpenCode copresence CommHub message wiring > startup and SSE reconnect both recover pending informational messages [1.00ms]
+(pass) OpenCode copresence CommHub message wiring > runtime startup is single-flight and shutdown waits for an in-flight open
+(pass) OpenCode copresence CommHub message wiring > tmux SIGHUP enters the same cleanup path as SIGTERM
+
+ 8 pass
+ 0 fail
+ 31 expect() calls
+Ran 8 tests across 1 file. [56.00ms]
+bun test v1.3.1 (89fa0f34)
+
+../agent-node-src/src/runtime/inbox-drain-lane.test.ts:
+(pass) inbox drain lanes > an informational lane drains while the work lane is busy [3.00ms]
+(pass) inbox drain lanes > each lane remains serial [2.00ms]
+(pass) inbox drain lanes > repeated wakeups for the same drain coalesce into one dirty rerun
+(pass) inbox drain lanes > a failed drain is reported and does not poison later retries [1.00ms]
+(pass) inbox drain lanes > retry mode backs off and eventually completes the same drain [4.00ms]
+(pass) inbox drain lanes > one failed inbox item does not starve later items in the same snapshot
+(pass) inbox drain lanes > ack-only retry does not duplicate the first notification or delay the second [2.00ms]
+
+ 7 pass
+ 0 fail
+ 17 expect() calls
+Ran 7 tests across 1 file. [37.00ms]
+bun test v1.3.1 (89fa0f34)
+
+../agent-node-src/src/util/single-flight.test.ts:
+(pass) single-flight resource initialization > concurrent callers share exactly one initializer [4.00ms]
+(pass) single-flight resource initialization > a rejected initializer is cleared and can be retried [1.00ms]
+
+ 2 pass
+ 0 fail
+ 9 expect() calls
+Ran 2 tests across 1 file. [25.00ms]
+bun test v1.3.1 (89fa0f34)
+
+../agent-network-src/src/opencode-copresence-cli.test.ts:
+(pass) OpenCode co-presence CLI wiring > persists copresence mode before launching the bridge
+(pass) OpenCode co-presence CLI wiring > starts only exact alias and alias-bridge tmux sessions
+(pass) OpenCode co-presence CLI wiring > does not depend on a long-lived tmux server's stale launcher environment
+(pass) OpenCode co-presence CLI wiring > waits for the owner-only runtime launcher before starting the official TUI
+(pass) OpenCode co-presence CLI wiring > the generic --copresence dispatcher selects OpenCode by stored runtime
+(pass) OpenCode co-presence CLI wiring > operator help names the create, attach, and stop commands [2.00ms]
+(pass) OpenCode co-presence CLI wiring > prints an exact tmux target so an exited TUI cannot prefix-match the bridge
+
+ 7 pass
+ 0 fail
+ 20 expect() calls
+Ran 7 tests across 1 file. [47.00ms]
+
+## Layers 1–5 — auth, CommHub MCP outbound, official attach TUI, shared turns, lifecycle
+{
+  "checks": {
+    "loopback": true,
+    "session": "ses_0347b3b05ffeAbhhYXvWBQe5ss",
+    "launcherMode": 448,
+    "launcherUsesOfficialAttach": true,
+    "launcherDoesNotLogPassword": true,
+    "tuiAliveBefore": true,
+    "tuiRenderedBefore": true,
+    "informationalMessageVisible": true,
+    "tuiAliveAfterNotice": true,
+    "mcpAuthenticated": true,
+    "outboundReplyLength": 73,
+    "outboundToolCalled": true,
+    "firstReplyLength": 15,
+    "noticeDidNotLeakIntoFirstReply": true,
+    "sharedTurnVisibleInTui": true,
+    "tuiAliveAfterFirst": true,
+    "secondReplyLength": 14,
+    "tuiAliveAfterSecond": true,
+    "runtimeAliveAfterSecond": true
+  },
+  "paneTail": "                              \u001b[48;5;233m\n\u001b[48;5;232m                                                                                                  \u001b[48;5;233m  \u001b[48;5;234m    \u001b[38;5;8mConnect from 75+ providers to \u001b[38;5;15m    \u001b[48;5;233m\n\u001b[48;5;232m                                                                                                  \u001b[48;5;233m  \u001b[48;5;234m    \u001b[38;5;8muse other models, including \u001b[38;5;15m      \u001b[48;5;233m\n\u001b[48;5;232m                                                                                                  \u001b[48;5;233m  \u001b[48;5;234m    \u001b[38;5;8mClaude, GPT, Gemini etc\u001b[38;5;15m           \u001b[48;5;233m\n\u001b[48;5;232m                                                                                                  \u001b[48;5;233m  \u001b[48;5;234m                                      \u001b[48;5;233m\n\u001b[48;5;232m                                                                                                  \u001b[48;5;233m  \u001b[48;5;234m    \u001b[38;5;255mConnect provider\u001b[38;5;15m        \u001b[38;5;8m/connect\u001b[38;5;15m  \u001b[48;5;233m\n\u001b[48;5;232m  \u001b[38;5;75m┃\u001b[38;5;15m\u001b[48;5;234m                                                                                             \u001b[48;5;232m  \u001b[48;5;233m  \u001b[48;5;234m                                      \u001b[48;5;233m\n\u001b[48;5;232m  \u001b[38;5;75m┃\u001b[38;5;15m\u001b[48;5;234m                                                                                             \u001b[48;5;232m  \u001b[48;5;233m\n\u001b[48;5;232m  \u001b[38;5;75m┃\u001b[38;5;15m\u001b[48;5;234m                                                                                             \u001b[48;5;232m  \u001b[48;5;233m  \u001b[38;5;8m/run/user/0/.anet-opencode-launch-\u001b[38;5;15m\n\u001b[48;5;232m  \u001b[38;5;75m┃\u001b[38;5;15m\u001b[48;5;234m  \u001b[38;5;75mBuild\u001b[38;5;15m \u001b[38;5;8m·\u001b[38;5;15m \u001b[38;5;255mNorth Mini Code Free\u001b[38;5;15m \u001b[38;5;8mOpenCode Zen\u001b[38;5;15m                                                  \u001b[48;5;232m  \u001b[48;5;233m  \u001b[38;5;8mBetmLx/\u001b[38;5;255mworkspace\u001b[38;5;15m\n\u001b[48;5;232m  \u001b[38;5;75m╹\u001b[38;5;234m▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀\u001b[38;5;15m  \u001b[48;5;233m\n\u001b[48;5;232m   \u001b[38;5;8m/run/user/0/.anet-opencode-launch-BetmLx/workspace\u001b[38;5;15m                 \u001b[38;5;8m2.1K (1%)\u001b[38;5;15m  \u001b[38;5;255mctrl+p \u001b[38;5;8mcommands\u001b[38;5;15m  \u001b[48;5;233m  \u001b[38;5;114m•\u001b[38;5;8m \u001b[1mOpen\u001b[38;5;255mCode\u001b[0m\u001b[38;5;8m\u001b[48;5;233m 1.18.1\u001b[38;5;15m\n\u001b[48;5;232m                                                                                                  \u001b[48;5;233m\n"
+}
+
+OVERALL: PASS


### PR DESCRIPTION
## 改动

`openVettedOpenCodeCopresence` 在**占用任何资源之前**强制解析 provider/model，`submit` 永远携带解析后的 model（不再是 `...(model ? { model } : {})` 的条件展开）。

## 独立复核

我关心的是它自己提的那条：**下层 seam 还能不能省掉 model**。逐条查过：

**门确实在资源获取之前**（行号来自候选源码）：

```
:393  requireOpenCodeCopresenceModel(opts.model)   ← 门
:396  reserveLoopbackPort()                        ← 占端口
:404  spawn(opts.binary, ["serve", …])             ← 起进程
```

**畸形 model 不会退化成「显式 undefined」**——这是我担心的边界，已封住：

- `parseModelRef` 对畸形串**抛异常**，只有 falsy 输入才返回 `undefined`
- `requireOpenCodeCopresenceModel` 先拒空，再调 `parseModelRef(normalized)` 做格式校验

所以经过门之后 `requiredModel` 既非空又合法，`parseModelRef(requiredModel)` 不可能返回 `undefined`，无条件展开 `model` 是安全的。

**单入口**：全站只有 `:626` 一处调用该 seam，且传了 `model`；`submit` 委托给 core，没有旁路。

## 证据

Docker 固定 tag `anet-test227:dev`，**OpenCode 1.18.1 真二进制**：35 tests 全绿，harness OVERALL PASS。新增用例 `requires an explicit provider/model at the vetted launch seam too`。

真二进制这一点是关键：本仓有过一次教训——契约测 26 pass / mutation 全红 / 两人独立 PASS，真机一跑即塌，因为 fake server 是按我们自己的假设作答的。涉及上游行为的改动，真二进制不可省。

顺带把 `inbox-wiring.test.ts` 里一处断言从旧的 `continue` 校正为 main 上已改成的 `return`。