### PR TITLE
fix(grok): disclose the exact capability profile, and stop claiming a resumed session picked up a config change

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -83,6 +83,10 @@ import {
   grokBuildCliCreationFields,
   prepareGrokPreviewResolverConfigs,
 } from "../src/grok-copresence-profile";
+import {
+  grokCopresenceDisclosure,
+  type GrokCopresenceSessionDisclosure,
+} from "../src/grok-copresence-disclosure";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -2248,11 +2252,16 @@ function printClaudeCodeNotice() {
   console.log(`  - For other models, use --runtime codex-sdk or claude-agent-sdk`);
 }
 
-function printGrokCopresenceWarning(nodeRef?: string) {
+function printGrokCopresenceWarning(
+  nodeRef?: string,
+  tools?: unknown,
+  session: GrokCopresenceSessionDisclosure = "configured",
+) {
+  const disclosure = grokCopresenceDisclosure(tools, session);
   console.warn(`[anet] ⚠ EXPERIMENTAL/DANGEROUS Grok co-presence preview.`);
   console.warn(`[anet]   Network tasks drive the same Grok TUI; its fixed tools are automatically approved.`);
-  console.warn(`[anet]   Fixed tools: [todo_write,search_tool,use_tool]; MCP is the single runtime-owned CommHub server.`);
-  console.warn(`[anet]   No filesystem, shell, web, media, project/host MCP, or subagents.`);
+  for (const line of disclosure.lines) console.warn(`[anet]   ${line}`);
+  console.warn(`[anet]   MCP is the single runtime-owned CommHub server.`);
   console.warn(`[anet]   Use only with trusted tasks and a trusted network. Do not use in production.`);
   if (nodeRef) console.warn(`[anet]   Attach from another terminal: anet grok attach ${nodeRef}`);
 }
@@ -3479,7 +3488,7 @@ This wizard creates one agent node for this project:
   } else if (pickedRuntime === "grok-build-acp" || pickedRuntime === "grok-build-cli") {
     opts.runtime = pickedRuntime;
     console.log(`[anet] 请确保已安装并登录 Grok Build CLI: grok login`);
-    if (pickedRuntime === "grok-build-cli") printGrokCopresenceWarning(id);
+    if (pickedRuntime === "grok-build-cli") printGrokCopresenceWarning(id, undefined, "configured");
   } else if (pickedRuntime === "opencode-cli") {
     await configureOpencodeRuntime(opts, true);
   } else {
@@ -3581,7 +3590,7 @@ Telegram setup:
   if (normalizeRuntime(profile) === "opencode-cli") {
     printOpencodeCreationSecurityDisclosure(profile);
   } else if (profile.grokCopresence === true) {
-    printGrokCopresenceWarning(id);
+    printGrokCopresenceWarning(id, profile.tools, "configured");
   } else {
     console.log(`[anet] ⚠ dangerouslySkipPermissions and teammateMode enabled by default.`);
     console.log(`[anet] To disable: edit .anet/nodes/${id}/config.json → flags`);
@@ -3694,7 +3703,10 @@ async function createCommand(idOverride?: string) {
     console.log("[anet] 请确保已执行: codex login（codex-app-server 需要 codex CLI）");
   } else if (opts.runtime === "grok-build-acp" || opts.runtime === "grok-build-cli") {
     console.log("[anet] 请确保已安装并登录 Grok Build CLI: grok login");
-    if (opts.runtime === "grok-build-cli") printGrokCopresenceWarning(id);
+    if (opts.runtime === "grok-build-cli") {
+      const requestedTools = opts.tools ? opts.tools.split(",").map((tool) => tool.trim()) : undefined;
+      printGrokCopresenceWarning(id, requestedTools, "configured");
+    }
   } else if (opts.runtime === "opencode-cli") {
     await configureOpencodeRuntime(opts, Boolean(process.stdin.isTTY));
   } else {
@@ -3845,7 +3857,7 @@ async function createCommand(idOverride?: string) {
   if (normalizeRuntime(profile) === "opencode-cli") {
     printOpencodeCreationSecurityDisclosure(profile);
   } else if (profile.grokCopresence === true) {
-    printGrokCopresenceWarning(id);
+    printGrokCopresenceWarning(id, profile.tools, "configured");
     console.log(`[anet]   Start the node first, then attach from a second terminal.`);
     console.log(`\nStart: anet node start ${id}`);
     closeRL();
@@ -4142,7 +4154,7 @@ async function grokCommand() {
     process.exit(1);
   }
 
-  printGrokCopresenceWarning();
+  printGrokCopresenceWarning(undefined, profile.tools, "resume");
   const relay = new PassThrough({ highWaterMark: 64 * 1024 });
   const stdin = process.stdin;
   const wasRaw = stdin.isRaw === true;
@@ -4300,7 +4312,9 @@ async function launchAgent(id: string, forceNewSession = false) {
   const willResume = !!session && !forceNewSession;
   const label = willResume ? `Resuming session ${session.slice(0, 8)}...` : "Starting new session";
   console.log(`[anet] ${label} for "${displayName}" [${runtime}]...\n`);
-  if (profile.grokCopresence === true) printGrokCopresenceWarning(nodeId);
+  if (profile.grokCopresence === true) {
+    printGrokCopresenceWarning(nodeId, profile.tools, willResume ? "resume" : "new");
+  }
   checkRuntimeDependency(runtime, "start");
   assertStartCompatibility(runtime);
 

--- a/agent-network/src/grok-copresence-disclosure.test.ts
+++ b/agent-network/src/grok-copresence-disclosure.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { grokCopresenceDisclosure } from "./grok-copresence-disclosure";
+
+describe("grok co-presence disclosure", () => {
+  test("default profile reports the exact three tools and no web", () => {
+    const disclosure = grokCopresenceDisclosure(undefined, "new");
+    const text = disclosure.lines.join("\n");
+    expect(disclosure.profile).toBe("commhub-only");
+    expect(text).toContain("[todo_write,search_tool,use_tool]");
+    expect(text).toContain("No filesystem, shell, web");
+    expect(text).toContain("will pin this tool inventory");
+    expect(text).not.toContain("web_search is enabled");
+  });
+
+  test("WebSearch profile reports general web_search without widening other tools", () => {
+    const disclosure = grokCopresenceDisclosure(["WebSearch"], "new");
+    const text = disclosure.lines.join("\n");
+    expect(disclosure.profile).toBe("x-search");
+    expect(text).toContain("[todo_write,search_tool,use_tool,web_search]");
+    expect(text).toContain("General web_search is enabled");
+    expect(text).toContain("WebFetch, filesystem, shell");
+    expect(text).not.toContain("No filesystem, shell, web,");
+  });
+
+  test("near-match tools are disclosed as invalid rather than a reviewed profile", () => {
+    for (const tools of [["websearch"], ["WebSearch", "Bash"], [" WebSearch"]]) {
+      const disclosure = grokCopresenceDisclosure(tools, "configured");
+      expect(disclosure.profile).toBe("invalid");
+      expect(disclosure.lines.join("\n")).toContain("startup will fail closed");
+    }
+  });
+
+  test("resume warns that a changed config cannot mutate the existing session", () => {
+    const text = grokCopresenceDisclosure(["WebSearch"], "resume").lines.join("\n");
+    expect(text).toContain("keeps the tool inventory from session creation");
+    expect(text).toContain("resume cannot apply a later profile change");
+    expect(text).toContain("start it with --new-session");
+  });
+});

--- a/agent-network/src/grok-copresence-disclosure.ts
+++ b/agent-network/src/grok-copresence-disclosure.ts
@@ -1,0 +1,47 @@
+export type GrokCopresenceSessionDisclosure = "configured" | "new" | "resume";
+
+export type GrokCopresenceDisclosure = {
+  profile: "commhub-only" | "x-search" | "invalid";
+  lines: readonly string[];
+};
+
+/**
+ * Describe only the two exact tool profiles accepted by the pinned Grok TUI
+ * runtime. This is deliberately exact: a near-miss must never be presented as
+ * either reviewed capability set.
+ */
+export function grokCopresenceDisclosure(
+  tools: unknown,
+  session: GrokCopresenceSessionDisclosure = "configured",
+): GrokCopresenceDisclosure {
+  const configured = Array.isArray(tools) ? tools : [];
+  const xSearch = configured.length === 1 && configured[0] === "WebSearch";
+  const defaultProfile = configured.length === 0;
+
+  const lines: string[] = [];
+  let profile: GrokCopresenceDisclosure["profile"];
+  if (xSearch) {
+    profile = "x-search";
+    lines.push("Configured profile: x-search; fixed tools: [todo_write,search_tool,use_tool,web_search].");
+    lines.push("General web_search is enabled; WebFetch, filesystem, shell, media, project/host MCP, and subagents remain unavailable.");
+  } else if (defaultProfile) {
+    profile = "commhub-only";
+    lines.push("Configured profile: commhub-only; fixed tools: [todo_write,search_tool,use_tool].");
+    lines.push("No filesystem, shell, web, media, project/host MCP, or subagents.");
+  } else {
+    profile = "invalid";
+    lines.push("Configured tools do not match a supported exact Grok co-presence profile; startup will fail closed.");
+    lines.push("Supported profiles are [] and [WebSearch]; custom or near-match tool names are not accepted.");
+  }
+
+  if (session === "new") {
+    lines.push("Grok 0.2.93 will pin this tool inventory when the new session is created.");
+  } else if (session === "resume") {
+    lines.push("Grok 0.2.93 keeps the tool inventory from session creation; resume cannot apply a later profile change.");
+    lines.push("After changing tools, stop the node and start it with --new-session.");
+  } else {
+    lines.push("Grok 0.2.93 pins tools when a session is created; after changing tools, start with --new-session.");
+  }
+
+  return { profile, lines };
+}

--- a/docs/grok-build-cli-preview.md
+++ b/docs/grok-build-cli-preview.md
@@ -80,6 +80,28 @@ Press `Ctrl-]` to detach without stopping the node.
 
 The default `grok-build-cli` profile created by `anet` enables co-presence. `anet node start` owns one Grok PTY and exposes a local, same-user attach socket. The attached terminal renders that TUI. A network task sent to `grok-shared` is submitted into the same session, appears in the TUI, and its completed answer is routed to the original CommHub task.
 
+### Changing the tool profile requires a new session
+
+Grok 0.2.93 fixes the available tool inventory when it creates a session. A
+later config/profile change does **not** add or remove tools from that saved
+session: a normal restart resumes the old capability set. This was reproduced
+with a session created under the default profile; after its config was changed
+to `WebSearch`, resuming the same session still had no `web_search` tool.
+
+After changing between the default and `WebSearch` profiles, stop the node and
+create a fresh Grok session explicitly:
+
+```bash
+anet node stop grok-shared
+anet node start grok-shared --new-session
+```
+
+The old session data remains on disk, but the node config is updated to the new
+session ID. The startup banner labels the configured profile and states whether
+the command is creating a new session or resuming one. On resume it cannot
+infer that an edited config matches the session's creation-time inventory, so
+it warns instead of claiming the config change took effect.
+
 The preview uses one runtime-owned, mode-`0600` agent profile selected with
 the TUI-effective `--agent` flag. By default its exact model-tool inventory is
 `[todo_write,search_tool,use_tool]`. The latter two expose only one

--- a/docs/tests/report-test234-grok-profile-disclosure.txt
+++ b/docs/tests/report-test234-grok-profile-disclosure.txt
@@ -1,0 +1,32 @@
+# test234 — Grok profile disclosure and session-pinning runbook
+
+Date: 2026-08-04
+Source commit: 0f07f287e61e9e50ea86b653830153c0819cea72
+Base: 8167c494f418b4ddfe5a9f697c5c1265832cc1b6
+Docker image: anet-test234:dev
+Raw Docker report SHA256: e7f06b87a69f3353352d7d137f8d71535d60fc2ff37f7fa42b004a01f6d5470e
+
+Scope:
+
+- default profile discloses exact `[todo_write,search_tool,use_tool]` and no web;
+- exact `[WebSearch]` config discloses x-search
+  `[todo_write,search_tool,use_tool,web_search]` and its remaining denies;
+- near-match/custom tool sets are labelled invalid and fail-closed;
+- resume warns that Grok 0.2.93 retains the creation-time inventory and that
+  a profile change requires `--new-session`;
+- the runbook records the reproduced session-pinning behavior and migration
+  command;
+- the production CLI bundles successfully with the disclosure helper wired at
+  create, start, and attach call sites.
+
+Docker results:
+
+- disclosure unit tests: 4 pass, 0 fail, 19 assertions;
+- CLI build: PASS, 23 modules bundled;
+- runbook session-pin gate: PASS;
+- CLI wiring gate: PASS, seven declaration/call-site occurrences;
+- mutation: changed exact `WebSearch` recognition to a disabled sentinel while
+  leaving tests unchanged; the x-search test failed with expected
+  `x-search`, received `invalid` (rc=1). Witnessed-red PASS.
+
+Summary: PASS.

--- a/tests/test234-grok-profile-disclosure/Dockerfile
+++ b/tests/test234-grok-profile-disclosure/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1.3.14
+
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+
+WORKDIR /workspace
+COPY agent-network /workspace/agent-network
+COPY docs/grok-build-cli-preview.md /workspace/docs/grok-build-cli-preview.md
+COPY tests/test234-grok-profile-disclosure /test234
+RUN chmod 755 /test234/run.sh
+
+ENTRYPOINT ["bash", "/test234/run.sh"]

--- a/tests/test234-grok-profile-disclosure/run.sh
+++ b/tests/test234-grok-profile-disclosure/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test234-grok-profile-disclosure.txt"
+mkdir -p "$ARTIFACT_DIR"
+: >"$REPORT"
+
+run() {
+  printf '\n$ %q' "$1" | tee -a "$REPORT"
+  shift
+  printf ' %q' "$@" | tee -a "$REPORT"
+  printf '\n' | tee -a "$REPORT"
+  "$@" 2>&1 | tee -a "$REPORT"
+}
+
+printf '%s\n' \
+  '# test234 — Grok profile disclosure and session-pinning runbook' \
+  "source_commit=$SOURCE_COMMIT" \
+  'scope=exact default/x-search/invalid banner text, resume warning, docs, CLI build' \
+  | tee -a "$REPORT"
+
+run disclosure-unit bun test /workspace/agent-network/src/grok-copresence-disclosure.test.ts
+
+run cli-build bun build /workspace/agent-network/bin/cli.ts \
+  --outdir /tmp/agent-network-dist --target node \
+  --external @inquirer/prompts \
+  --external @sleep2agi/commhub-server \
+  --external bun:sqlite --external node-pty \
+  --external '../../server/*'
+
+run runbook-session-pin bash -ceu '
+  doc=/workspace/docs/grok-build-cli-preview.md
+  grep -Fq "Grok 0.2.93 fixes the available tool inventory when it creates a session" "$doc"
+  grep -Fq "anet node start grok-shared --new-session" "$doc"
+  grep -Fq "resumes the old capability set" "$doc"
+'
+
+run cli-wiring bash -ceu '
+  src=/workspace/agent-network/bin/cli.ts
+  grep -Fq "printGrokCopresenceWarning(undefined, profile.tools, \"resume\")" "$src"
+  grep -Fq "printGrokCopresenceWarning(nodeId, profile.tools, willResume ? \"resume\" : \"new\")" "$src"
+  count=$(grep -c "printGrokCopresenceWarning" "$src")
+  test "$count" -eq 7
+'
+
+# Witnessed-red: deleting the exact WebSearch recognition must make the same
+# unchanged behavior tests fail. A green mutation would mean the x-search
+# disclosure is decorative rather than protected.
+mkdir -p /tmp/mutation
+cp /workspace/agent-network/src/grok-copresence-disclosure.ts /tmp/mutation/grok-copresence-disclosure.ts
+cp /workspace/agent-network/src/grok-copresence-disclosure.test.ts /tmp/mutation/grok-copresence-disclosure.test.ts
+sed -i 's/configured\[0\] === "WebSearch"/configured[0] === "__mutation_disabled__"/' \
+  /tmp/mutation/grok-copresence-disclosure.ts
+set +e
+bun test /tmp/mutation/grok-copresence-disclosure.test.ts > /tmp/mutation.out 2>&1
+mutation_rc=$?
+set -e
+cat /tmp/mutation.out | tee -a "$REPORT"
+if test "$mutation_rc" -eq 0; then
+  printf 'FAIL: WebSearch disclosure mutation stayed green\n' | tee -a "$REPORT"
+  exit 1
+fi
+printf 'PASS: witnessed-red WebSearch recognition mutation rc=%s\n' "$mutation_rc" | tee -a "$REPORT"
+
+printf '\nSummary: PASS (4 unit tests; CLI build; runbook/wiring gates; mutation red)\n' | tee -a "$REPORT"


### PR DESCRIPTION
## 两个问题，第二个是今天实测踩出来的

**一、启动横幅说反了。** X-search 档已经带着 `web_search` 在跑，横幅仍写「无网页搜索」。

缺失和说反不是一回事：

```
缺失  → 运维不知道       → 会去查
说反  → 运维以为自己知道  → 不会去查
```

后者更坏。现在按精确档显示：默认档 3 个工具 / 无 web；`[WebSearch]` 档 4 个工具 / general web；两档都明确列出仍被拒的 `WebFetch/fs/shell/media/host MCP/subagents`。

**近似值（`websearch`、`Web Search` 之类）显示为 `invalid`，fail-closed，不当成已审档位。**

**二、`resume` 会让人以为改了配置就生效了。**

真机实测：**Grok 0.2.93 的工具能力在 session 创建时固化。** 旧 session `4ce6840b` 换了配置之后复测，仍然报告自己没有 `web_search` —— 必须 `--new-session` 才能拿到新档。

这一点如果不写出来，下一个人换完配置发现没生效，**会去怀疑代码，而不是怀疑 session**。

现在 `start` 区分 new / resume，resume 明确提示：

```
resume cannot apply a later profile change
… start it with --new-session
```

runbook 里补了旧 session 的复现实证和迁移命令。

## 证据

Docker 固定 tag `anet-test234:dev`，source ENV `0f07f287`：4 tests / 19 assertions、CLI build、docs/wiring 全 PASS。

**Mutation**：禁掉 `WebSearch` 的精确识别后同测 rc1（expected `x-search` / received `invalid`），witnessed-red。

镜像 86MB。

## 顺带

这个「能力显示与实际能力不符」和今天开的另一个全舰队缺陷（Dashboard 上显示的 tmux 会话名是别的节点的）是同一类问题：**界面上的身份/能力，和真实的身份/能力，是两个可以各自漂移的东西。**