### PR TITLE
fix(grok): make the staged CommHub MCP outbound-only so the node has exactly one inbox owner

### DIFF
--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -237,7 +237,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 // Helper: call CommHub MCP endpoint
 async function callCommHub(toolName: string, args: Record<string, unknown>): Promise<any> {
-  const connectionHeader = OUTBOUND_ONLY ? { Connection: "close" } : {};
+  const connectionHeader: Record<string, string> = OUTBOUND_ONLY ? { Connection: "close" } : {};
   const initRes = await fetch(`${COMMHUB_URL}/mcp`, {
     method: "POST",
     headers: {

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -106,6 +106,12 @@ function resolveAlias(): string {
 const ALIAS = resolveAlias();
 const RESUME_ID = process.env.COMMHUB_RESUME_ID || process.env.CLAUDE_RESUME_ID || randomUUID();
 const AUTH_TOKEN = process.env.COMMHUB_TOKEN || ANET_CONFIG.token || "";
+// Grok co-presence already has one agent-node owner for inbox, lifecycle and
+// presence. Its model-facing MCP child must therefore be a pure outbound tool
+// client: no channel capability, no SSE subscription, no inbox claim/ack, no
+// registration/heartbeat/offline report. Keep the legacy full channel mode as
+// the default for Claude Code installations that launch this same artifact.
+const OUTBOUND_ONLY = process.env.ANET_COMMHUB_MODE === "outbound-only";
 
 function log(msg: string) {
   const ts = new Date().toTimeString().slice(0, 8);
@@ -116,7 +122,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-log(`ENV: URL=${COMMHUB_URL} ALIAS=${ALIAS} RESUME_ID=${RESUME_ID.slice(0, 8)}... TMUX=${TMUX_NAME || "none"} CWD=${process.cwd()} PROJECT_ENV=${projectPath}`);
+log(`ENV: URL=${COMMHUB_URL} ALIAS=${ALIAS} RESUME_ID=${RESUME_ID.slice(0, 8)}... TMUX=${TMUX_NAME || "none"} CWD=${process.cwd()} PROJECT_ENV=${projectPath} MODE=${OUTBOUND_ONLY ? "outbound-only" : "channel"}`);
 
 // V2: track task_id → originator alias for send_reply routing
 const taskOriginators = new Map<string, string>();
@@ -130,23 +136,34 @@ const mcp = new Server(
     version: "0.3.0",
   },
   {
-    capabilities: {
-      experimental: { "claude/channel": {} },
-      tools: {},
-    },
-    instructions: [
-      `Messages from CommHub arrive as <channel source="commhub" task_id="..." priority="..." from="...">`,
-      `These are tasks dispatched by the hub or other sessions via the CommHub Server.`,
-      `Reply routing (IMPORTANT — the tool you pick determines whether the receiver actually gets woken up):`,
-      `  • If the sender is another agent node (from CommHub, from your peer's session alias), reply with commhub_send_task(alias="<their alias>", task="<your reply>"). This creates a new routable task that wakes the peer via new_task SSE so they process it. commhub_reply does NOT wake agent peers — they'd only see it on the next inbox poll (Vincent 2026-07-28 全网规则).`,
-      `  • Only use commhub_reply when the sender is the Dashboard/UI (task_id came from a browser chat). Use status="completed" (terminal) so send_reply routes it, updates the task row (Dashboard displays it), and emits new_reply SSE for the live Dashboard viewer. Non-terminal status (in_progress/blocked/error) just updates your session status and does NOT reach the Dashboard.`,
-      `You can also use commhub_report_status to update your session status.`,
-      `Session alias: ${ALIAS}`,
-    ].join("\n"),
+    capabilities: OUTBOUND_ONLY
+      ? { tools: {} }
+      : { experimental: { "claude/channel": {} }, tools: {} },
+    instructions: OUTBOUND_ONLY
+      ? [
+          `This is the outbound-only CommHub tool client for session alias ${ALIAS}.`,
+          `It never receives or acknowledges inbox rows and never owns lifecycle or presence.`,
+          `Use commhub_send_task for peer results; commhub_send_message is non-lifecycle chat.`,
+        ].join("\n")
+      : [
+          `Messages from CommHub arrive as <channel source="commhub" task_id="..." priority="..." from="...">`,
+          `These are tasks dispatched by the hub or other sessions via the CommHub Server.`,
+          `Reply routing (IMPORTANT — the tool you pick determines whether the receiver actually gets woken up):`,
+          `  • If the sender is another agent node (from CommHub, from your peer's session alias), reply with commhub_send_task(alias="<their alias>", task="<your reply>"). This creates a new routable task that wakes the peer via new_task SSE so they process it. commhub_reply does NOT wake agent peers — they'd only see it on the next inbox poll (Vincent 2026-07-28 全网规则).`,
+          `  • Only use commhub_reply when the sender is the Dashboard/UI (task_id came from a browser chat). Use status="completed" (terminal) so send_reply routes it, updates the task row (Dashboard displays it), and emits new_reply SSE for the live Dashboard viewer. Non-terminal status (in_progress/blocked/error) just updates your session status and does NOT reach the Dashboard.`,
+          `You can also use commhub_report_status to update your session status.`,
+          `Session alias: ${ALIAS}`,
+        ].join("\n"),
   }
 );
 
 // ── Tools ───────────────────────────────────────────
+const OUTBOUND_TOOL_NAMES = new Set([
+  "commhub_send_task",
+  "commhub_send_message",
+  "commhub_get_all_status",
+]);
+
 mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
@@ -215,16 +232,18 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
         properties: {},
       },
     },
-  ],
+  ].filter((tool) => !OUTBOUND_ONLY || OUTBOUND_TOOL_NAMES.has(tool.name)),
 }));
 
 // Helper: call CommHub MCP endpoint
 async function callCommHub(toolName: string, args: Record<string, unknown>): Promise<any> {
+  const connectionHeader = OUTBOUND_ONLY ? { Connection: "close" } : {};
   const initRes = await fetch(`${COMMHUB_URL}/mcp`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json, text/event-stream",
+      ...connectionHeader,
       ...(AUTH_TOKEN ? { Authorization: `Bearer ${AUTH_TOKEN}` } : {}),
     },
     body: JSON.stringify({
@@ -250,6 +269,7 @@ async function callCommHub(toolName: string, args: Record<string, unknown>): Pro
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json, text/event-stream",
+      ...connectionHeader,
       ...(AUTH_TOKEN ? { Authorization: `Bearer ${AUTH_TOKEN}` } : {}),
     },
     body: JSON.stringify({
@@ -271,6 +291,19 @@ async function callCommHub(toolName: string, args: Record<string, unknown>): Pro
 
 mcp.setRequestHandler(CallToolRequestSchema, async (req: any) => {
   const { name, arguments: args } = req.params;
+
+  // tools/list is not the security boundary: a client can issue tools/call
+  // with an arbitrary name. Reject lifecycle/presence/inbound names before
+  // any Hub request so a direct call cannot widen outbound-only mode.
+  if (OUTBOUND_ONLY && !OUTBOUND_TOOL_NAMES.has(name)) {
+    return {
+      isError: true,
+      content: [{
+        type: "text",
+        text: JSON.stringify({ ok: false, error: "tool unavailable in outbound-only mode" }),
+      }],
+    };
+  }
 
   if (name === "commhub_reply") {
     const { task_id, text, status } = args as any;
@@ -516,6 +549,11 @@ async function main() {
   await mcp.connect(transport);
   log("MCP stdio connected");
 
+  if (OUTBOUND_ONLY) {
+    log("ready — outbound-only tools; no channel/SSE/inbox/lifecycle/presence owner");
+    return;
+  }
+
   log("starting SSE listener...");
   connectSSE().catch((err) => log(`SSE fatal: ${err}`));
 
@@ -555,13 +593,17 @@ main().catch((err) => {
 });
 
 async function gracefulShutdown() {
-  log("shutting down, reporting offline...");
-  await callCommHub("report_status", {
-    resume_id: RESUME_ID,
-    alias: ALIAS,
-    status: "offline",
-    task: "session disconnected",
-  }).catch(() => {});
+  if (OUTBOUND_ONLY) {
+    log("shutting down outbound-only MCP client");
+  } else {
+    log("shutting down, reporting offline...");
+    await callCommHub("report_status", {
+      resume_id: RESUME_ID,
+      alias: ALIAS,
+      status: "offline",
+      task: "session disconnected",
+    }).catch(() => {});
+  }
   process.exit(0);
 }
 

--- a/agent-node/src/runtime/grok-build-cli-home.test.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.test.ts
@@ -813,6 +813,7 @@ describe("prepareGrokCliHome", () => {
     const stagedEnv = join(dirname(dirname(stateHome)), ".anet-grok-credentials", basename(stateHome), ".env");
     expect(config).toContain(`args = [${JSON.stringify(stagedServer)}]`);
     expect(config).toContain(`ANET_COMMHUB_ENV_FILE = ${JSON.stringify(stagedEnv)}`);
+    expect(config).toContain('ANET_COMMHUB_MODE = "outbound-only"');
     expect(readFileSync(stagedServer, "utf8")).toBe("// reviewed commhub MCP server\n");
     expect(readFileSync(stagedEnv, "utf8")).toBe("COMMHUB_TOKEN=ntok_test\n");
     expect(statSync(stagedServer).mode & 0o777).toBe(0o600);
@@ -942,6 +943,7 @@ describe("prepareGrokCliHome", () => {
     expect(() => prepareGrokCliHome({ ...base, commhubMcp: valid })).not.toThrow();
     const config = readFileSync(join(stateHome, "config.toml"), "utf8");
     expect(config).toContain("[mcp_servers.commhub]");
+    expect(config).toContain('ANET_COMMHUB_MODE = "outbound-only"');
     expect(config).not.toContain("ntok_secret");
     expect(config).toContain(JSON.stringify(join(stateHome, "runtime-mcp", "node-server.js")));
     expect(config).toContain(JSON.stringify(join(dirname(dirname(stateHome)), ".anet-grok-credentials", basename(stateHome), ".env")));

--- a/agent-node/src/runtime/grok-build-cli-home.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.ts
@@ -1390,7 +1390,7 @@ export function prepareGrokCliHome(opts: PrepareGrokCliHomeOptions): GrokCliHome
       "[mcp_servers.commhub]",
       'command = "bun"',
       `args = [${JSON.stringify(commhubMcp.serverPath)}]`,
-      `env = { ANET_COMMHUB_ENV_FILE = ${JSON.stringify(commhubMcp.envFile)}, COMMHUB_ALIAS = ${JSON.stringify(commhubMcp.alias)}, COMMHUB_RESUME_ID = ${JSON.stringify(commhubMcp.resumeId)} }`,
+      `env = { ANET_COMMHUB_ENV_FILE = ${JSON.stringify(commhubMcp.envFile)}, ANET_COMMHUB_MODE = "outbound-only", COMMHUB_ALIAS = ${JSON.stringify(commhubMcp.alias)}, COMMHUB_RESUME_ID = ${JSON.stringify(commhubMcp.resumeId)} }`,
       "enabled = true",
       "",
     ] : []),

--- a/agent-node/src/runtime/grok-copresence/policy.ts
+++ b/agent-node/src/runtime/grok-copresence/policy.ts
@@ -43,8 +43,8 @@ export function renderGrokCopresenceAgentProfile(): string {
     ...GROK_COPRESENCE_EFFECTIVE_TOOLS.map((tool) => `  - ${tool}`),
     "---",
     GROK_COPRESENCE_WEB_SEARCH_ENABLED
-      ? `${GROK_COPRESENCE_PROFILE_MARKER}: Answer the current user directly. The runtime-owned commhub MCP integration and general web_search are available; do not claim filesystem, shell, web-fetch/media, or subagent access. Web search is not an x.com-only network sandbox.`
-      : `${GROK_COPRESENCE_PROFILE_MARKER}: Answer the current user directly. Only the runtime-owned commhub MCP integration is available; do not claim filesystem, shell, web/media, or subagent access.`,
+      ? `${GROK_COPRESENCE_PROFILE_MARKER}: Answer the current user directly. The runtime-owned outbound-only commhub MCP integration and general web_search are available; do not claim inbound CommHub, lifecycle/presence ownership, filesystem, shell, web-fetch/media, or subagent access. Web search is not an x.com-only network sandbox.`
+      : `${GROK_COPRESENCE_PROFILE_MARKER}: Answer the current user directly. Only the runtime-owned outbound-only commhub MCP integration is available; do not claim inbound CommHub, lifecycle/presence ownership, filesystem, shell, web/media, or subagent access.`,
     "",
   ].join("\n");
 }

--- a/docs/grok-build-cli-preview.md
+++ b/docs/grok-build-cli-preview.md
@@ -105,9 +105,13 @@ it warns instead of claiming the config change took effect.
 The preview uses one runtime-owned, mode-`0600` agent profile selected with
 the TUI-effective `--agent` flag. By default its exact model-tool inventory is
 `[todo_write,search_tool,use_tool]`. The latter two expose only one
-runtime-owned CommHub MCP server; host and project MCP definitions are never
-loaded. Filesystem, shell, web, media, scheduler, and subagent tools remain
-unavailable. One explicit process-level profile is also supported:
+runtime-owned outbound-only CommHub MCP server; host and project MCP
+definitions are never loaded. That MCP child exposes only `send_task`,
+`send_message`, and `get_all_status`. It does not register a channel
+capability, open an SSE/inbox connection, claim or acknowledge tasks, or report
+lifecycle/presence. The outer `agent-node` process remains the single inbox and
+lifecycle owner. Filesystem, shell, web, media, scheduler, and subagent tools
+remain unavailable. One explicit process-level profile is also supported:
 
 ```bash
 anet node create A站GrokTUI --runtime grok-build-cli --tools WebSearch

--- a/docs/tests/report-test235-grok-mcp-outbound-only.txt
+++ b/docs/tests/report-test235-grok-mcp-outbound-only.txt
@@ -1,58 +1,60 @@
 # test235 — Grok CommHub MCP outbound-only ownership gate
-source_commit=eac7e0d6b0ef659b67627233133c3b6527a4a09f
+source_commit=d45d956f0125fc94b01e6f48db82e16bfbfbb320
 scope=structural MCP capabilities, real socket count, repeated task ownership, outbound tools, direct-call denial, mutation red
+
+$ network-typecheck bash -ceu cd\ /workspace/agent-network\ \&\&\ bun\ tsc\ --noEmit
 
 $ home-mode bun test /workspace/agent-node/src/runtime/grok-build-cli-home.test.ts
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/runtime/grok-build-cli-home.test.ts:
-(pass) prepareGrokCliHome > derives an opaque path segment and rejects dot identities [0.67ms]
-(pass) prepareGrokCliHome > accepts only the pinned Grok regular-file copy of source agent_id [10.51ms]
-(pass) prepareGrokCliHome > isolates config/trust, preserves a shared auth path, and creates stable sandbox profiles [3.19ms]
-(pass) prepareGrokCliHome > refuses broad-mode or symlinked source auth without repairing it [1.67ms]
-(pass) prepareGrokCliHome > repairs an existing Grok session store to owner-only modes [1.86ms]
-(pass) prepareGrokCliHome > does not follow a symlink while repairing an existing session store [1.18ms]
-(pass) prepareGrokCliHome > keeps the post-stop cleanup policy exact and reviewable [0.12ms]
-(pass) prepareGrokCliHome > removes exact empty read-only project placeholders before resume without admitting executable sources [4.30ms]
-(pass) prepareGrokCliHome > validates every exact project placeholder before unlinking any sibling [1.38ms]
-(pass) prepareGrokCliHome > does not let a fatal project counterexample starve independent state containment [2.10ms]
-(pass) prepareGrokCliHome > preserves nonempty, linked, wrong-mode, and wrong-type project counterexamples [5.35ms]
-(pass) prepareGrokCliHome > preserves real project extension directories and still rejects executable contents on resume [2.53ms]
-(pass) prepareGrokCliHome > removes only exact transient state and hardens retained post-stop state [8.10ms]
-(pass) prepareGrokCliHome > hardens only the native lock derived from the exact leader socket [1.39ms]
-(pass) prepareGrokCliHome > retains a non-empty leader log and rejects post-stop link attacks [3.09ms]
-(pass) prepareGrokCliHome > refuses a non-empty exact sandbox placeholder [1.62ms]
-(pass) prepareGrokCliHome > reclaims an empty mode-000 sandbox marker under a foreign pid without aborting [1.35ms]
-(pass) prepareGrokCliHome > keeps a non-empty foreign sandbox marker unreadable so it fails closed [1.53ms]
-(pass) prepareGrokCliHome > validates exact TUI process ids before mutation and refuses a placeholder symlink [2.13ms]
-(pass) prepareGrokCliHome > enables the single TUI leader only for explicit copresence mode [22.07ms]
-(pass) prepareGrokCliHome > admits only canonical owner-held commhub MCP artifacts [4.84ms]
-(pass) prepareGrokCliHome > rejects a shared auth path covered by a required sandbox deny before state mutation [0.94ms]
-(pass) prepareGrokCliHome > refuses to claim sandbox isolation when no deny target exists [1.12ms]
-(pass) prepareGrokCliHome > rejects a source GROK_HOME reached through an ancestor symlink before state mutation [0.97ms]
-(pass) prepareGrokCliHome > removes runtime-owned native hooks before every turn [1.70ms]
-(pass) prepareGrokCliHome > unlinks a runtime-owned hook symlink without touching its external target [1.59ms]
-(pass) prepareGrokCliHome > fails closed when a project native hook path exists [0.90ms]
-(pass) prepareGrokCliHome > trusts only the exact canonical nested cwd and atomically replaces stale grants [4.03ms]
-(pass) prepareGrokCliHome > rejects broad or symlinked folder-trust targets before writing trust state [1.84ms]
-(pass) prepareGrokCliHome > refuses a planted trust-store symlink and leaves its target untouched [1.93ms]
-(pass) prepareGrokCliHome > rejects every project executable source before granting folder trust [11.97ms]
-(pass) prepareGrokCliHome > does not impose the shared-folder strict policy on legacy headless mode [2.52ms]
-(pass) prepareGrokCliHome > rejects repo-root hooks from a nested cwd and dangling hook links [1.11ms]
-(pass) prepareGrokCliHome > rejects a symlinked project .grok directory [0.87ms]
-(pass) prepareGrokCliHome > rejects symlinked isolated homes and generated state without changing targets [2.43ms]
-(pass) prepareGrokCliHome > rejects a state-home path escape before chmod, removal, or writes [0.89ms]
-(pass) prepareGrokCliHome > requires a valid zero-hook inspect response [0.72ms]
-(pass) prepareGrokCliHome > flocks the canonical project inode across symlink aliases and releases cleanly [174.93ms]
-(pass) prepareGrokCliHome > gives the real flock holder only the exact helper environment [77.90ms]
+(pass) prepareGrokCliHome > derives an opaque path segment and rejects dot identities [0.94ms]
+(pass) prepareGrokCliHome > accepts only the pinned Grok regular-file copy of source agent_id [8.47ms]
+(pass) prepareGrokCliHome > isolates config/trust, preserves a shared auth path, and creates stable sandbox profiles [2.45ms]
+(pass) prepareGrokCliHome > refuses broad-mode or symlinked source auth without repairing it [1.65ms]
+(pass) prepareGrokCliHome > repairs an existing Grok session store to owner-only modes [2.88ms]
+(pass) prepareGrokCliHome > does not follow a symlink while repairing an existing session store [1.49ms]
+(pass) prepareGrokCliHome > keeps the post-stop cleanup policy exact and reviewable [0.16ms]
+(pass) prepareGrokCliHome > removes exact empty read-only project placeholders before resume without admitting executable sources [5.93ms]
+(pass) prepareGrokCliHome > validates every exact project placeholder before unlinking any sibling [2.03ms]
+(pass) prepareGrokCliHome > does not let a fatal project counterexample starve independent state containment [2.54ms]
+(pass) prepareGrokCliHome > preserves nonempty, linked, wrong-mode, and wrong-type project counterexamples [5.79ms]
+(pass) prepareGrokCliHome > preserves real project extension directories and still rejects executable contents on resume [2.32ms]
+(pass) prepareGrokCliHome > removes only exact transient state and hardens retained post-stop state [7.12ms]
+(pass) prepareGrokCliHome > hardens only the native lock derived from the exact leader socket [1.37ms]
+(pass) prepareGrokCliHome > retains a non-empty leader log and rejects post-stop link attacks [3.08ms]
+(pass) prepareGrokCliHome > refuses a non-empty exact sandbox placeholder [1.43ms]
+(pass) prepareGrokCliHome > reclaims an empty mode-000 sandbox marker under a foreign pid without aborting [1.54ms]
+(pass) prepareGrokCliHome > keeps a non-empty foreign sandbox marker unreadable so it fails closed [1.27ms]
+(pass) prepareGrokCliHome > validates exact TUI process ids before mutation and refuses a placeholder symlink [1.60ms]
+(pass) prepareGrokCliHome > enables the single TUI leader only for explicit copresence mode [13.47ms]
+(pass) prepareGrokCliHome > admits only canonical owner-held commhub MCP artifacts [3.88ms]
+(pass) prepareGrokCliHome > rejects a shared auth path covered by a required sandbox deny before state mutation [0.74ms]
+(pass) prepareGrokCliHome > refuses to claim sandbox isolation when no deny target exists [0.89ms]
+(pass) prepareGrokCliHome > rejects a source GROK_HOME reached through an ancestor symlink before state mutation [0.94ms]
+(pass) prepareGrokCliHome > removes runtime-owned native hooks before every turn [1.75ms]
+(pass) prepareGrokCliHome > unlinks a runtime-owned hook symlink without touching its external target [1.67ms]
+(pass) prepareGrokCliHome > fails closed when a project native hook path exists [1.19ms]
+(pass) prepareGrokCliHome > trusts only the exact canonical nested cwd and atomically replaces stale grants [4.23ms]
+(pass) prepareGrokCliHome > rejects broad or symlinked folder-trust targets before writing trust state [1.94ms]
+(pass) prepareGrokCliHome > refuses a planted trust-store symlink and leaves its target untouched [2.26ms]
+(pass) prepareGrokCliHome > rejects every project executable source before granting folder trust [13.82ms]
+(pass) prepareGrokCliHome > does not impose the shared-folder strict policy on legacy headless mode [2.95ms]
+(pass) prepareGrokCliHome > rejects repo-root hooks from a nested cwd and dangling hook links [1.48ms]
+(pass) prepareGrokCliHome > rejects a symlinked project .grok directory [0.90ms]
+(pass) prepareGrokCliHome > rejects symlinked isolated homes and generated state without changing targets [2.25ms]
+(pass) prepareGrokCliHome > rejects a state-home path escape before chmod, removal, or writes [1.38ms]
+(pass) prepareGrokCliHome > requires a valid zero-hook inspect response [0.78ms]
+(pass) prepareGrokCliHome > flocks the canonical project inode across symlink aliases and releases cleanly [136.11ms]
+(pass) prepareGrokCliHome > gives the real flock holder only the exact helper environment [67.78ms]
 
  39 pass
  0 fail
  284 expect() calls
-Ran 39 tests across 1 file. [468.00ms]
+Ran 39 tests across 1 file. [370.00ms]
 
 $ production-build bun build /workspace/agent-network/src/node-server.ts --outfile /tmp/node-server.js --target bun
-Bundled 221 modules in 60ms
+Bundled 221 modules in 48ms
 
   node-server.js  0.50 MB  (entry point)
 
@@ -60,35 +62,36 @@ Bundled 221 modules in 60ms
 $ production-socket-harness env MCP_BUNDLE=/tmp/node-server.js bun /test235/socket-harness.ts
 PASS assertions=68 outer_tasks=40 outbound_calls=12 mcp_hub_long_connections=0
 /bin/sh: 1: tmux: not found
-[10:17:00] [commhub] ENV: URL=http://127.0.0.1:32945 ALIAS=test235-grok RESUME_ID=grok-tes... TMUX=none CWD=/tmp/test235-V53f55 PROJECT_ENV=-tmp-test235-V53f55 MODE=outbound-only
-[10:17:00] [commhub] MCP stdio connected
-[10:17:00] [commhub] ready — outbound-only tools; no channel/SSE/inbox/lifecycle/presence owner
-[10:17:01] [commhub] shutting down outbound-only MCP client
+[10:24:42] [commhub] ENV: URL=http://127.0.0.1:34175 ALIAS=test235-grok RESUME_ID=grok-tes... TMUX=none CWD=/tmp/test235-bbLUmP PROJECT_ENV=-tmp-test235-bbLUmP MODE=outbound-only
+[10:24:42] [commhub] MCP stdio connected
+[10:24:42] [commhub] ready — outbound-only tools; no channel/SSE/inbox/lifecycle/presence owner
+[10:24:43] [commhub] shutting down outbound-only MCP client
 
 $ mutation-build bun build /workspace/agent-network/src/node-server.ts --outfile /tmp/node-server-mutated.js --target bun
-Bundled 221 modules in 44ms
+Bundled 221 modules in 52ms
 
   node-server-mutated.js  0.50 MB  (entry point)
 
 /bin/sh: 1: tmux: not found
-[10:17:11] [commhub] ENV: URL=http://127.0.0.1:35101 ALIAS=test235-grok RESUME_ID=grok-tes... TMUX=none CWD=/tmp/test235-xm7vl8 PROJECT_ENV=-tmp-test235-xm7vl8 MODE=channel
-[10:17:11] [commhub] MCP stdio connected
-[10:17:11] [commhub] starting SSE listener...
-[10:17:11] [commhub] connecting to http://127.0.0.1:35101/events/test235-grok
-[10:17:11] [commhub] ready — waiting for events
-[10:17:11] [commhub] SSE connected as "test235-grok"
-[10:17:11] [commhub] registered as "test235-grok" (grok-tes)
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
-[10:17:12] [commhub] shutting down, reporting offline...
-[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ENV: URL=http://127.0.0.1:33139 ALIAS=test235-grok RESUME_ID=grok-tes... TMUX=none CWD=/tmp/test235-oyv4fG PROJECT_ENV=-tmp-test235-oyv4fG MODE=channel
+[10:24:53] [commhub] MCP stdio connected
+[10:24:53] [commhub] starting SSE listener...
+[10:24:53] [commhub] connecting to http://127.0.0.1:33139/events/test235-grok
+[10:24:53] [commhub] ready — waiting for events
+[10:24:53] [commhub] SSE connected as "test235-grok"
+[10:24:53] [commhub] registered as "test235-grok" (grok-tes)
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:24:53] [commhub] shutting down, reporting offline...
+[10:24:53] [commhub] ← new_task: inbox_count=1 priority=normal
 230 | 
 231 |   if (expectMutation) {
 232 |     if (!failures.length) {

--- a/docs/tests/report-test235-grok-mcp-outbound-only.txt
+++ b/docs/tests/report-test235-grok-mcp-outbound-only.txt
@@ -1,0 +1,114 @@
+# test235 — Grok CommHub MCP outbound-only ownership gate
+source_commit=eac7e0d6b0ef659b67627233133c3b6527a4a09f
+scope=structural MCP capabilities, real socket count, repeated task ownership, outbound tools, direct-call denial, mutation red
+
+$ home-mode bun test /workspace/agent-node/src/runtime/grok-build-cli-home.test.ts
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/runtime/grok-build-cli-home.test.ts:
+(pass) prepareGrokCliHome > derives an opaque path segment and rejects dot identities [0.67ms]
+(pass) prepareGrokCliHome > accepts only the pinned Grok regular-file copy of source agent_id [10.51ms]
+(pass) prepareGrokCliHome > isolates config/trust, preserves a shared auth path, and creates stable sandbox profiles [3.19ms]
+(pass) prepareGrokCliHome > refuses broad-mode or symlinked source auth without repairing it [1.67ms]
+(pass) prepareGrokCliHome > repairs an existing Grok session store to owner-only modes [1.86ms]
+(pass) prepareGrokCliHome > does not follow a symlink while repairing an existing session store [1.18ms]
+(pass) prepareGrokCliHome > keeps the post-stop cleanup policy exact and reviewable [0.12ms]
+(pass) prepareGrokCliHome > removes exact empty read-only project placeholders before resume without admitting executable sources [4.30ms]
+(pass) prepareGrokCliHome > validates every exact project placeholder before unlinking any sibling [1.38ms]
+(pass) prepareGrokCliHome > does not let a fatal project counterexample starve independent state containment [2.10ms]
+(pass) prepareGrokCliHome > preserves nonempty, linked, wrong-mode, and wrong-type project counterexamples [5.35ms]
+(pass) prepareGrokCliHome > preserves real project extension directories and still rejects executable contents on resume [2.53ms]
+(pass) prepareGrokCliHome > removes only exact transient state and hardens retained post-stop state [8.10ms]
+(pass) prepareGrokCliHome > hardens only the native lock derived from the exact leader socket [1.39ms]
+(pass) prepareGrokCliHome > retains a non-empty leader log and rejects post-stop link attacks [3.09ms]
+(pass) prepareGrokCliHome > refuses a non-empty exact sandbox placeholder [1.62ms]
+(pass) prepareGrokCliHome > reclaims an empty mode-000 sandbox marker under a foreign pid without aborting [1.35ms]
+(pass) prepareGrokCliHome > keeps a non-empty foreign sandbox marker unreadable so it fails closed [1.53ms]
+(pass) prepareGrokCliHome > validates exact TUI process ids before mutation and refuses a placeholder symlink [2.13ms]
+(pass) prepareGrokCliHome > enables the single TUI leader only for explicit copresence mode [22.07ms]
+(pass) prepareGrokCliHome > admits only canonical owner-held commhub MCP artifacts [4.84ms]
+(pass) prepareGrokCliHome > rejects a shared auth path covered by a required sandbox deny before state mutation [0.94ms]
+(pass) prepareGrokCliHome > refuses to claim sandbox isolation when no deny target exists [1.12ms]
+(pass) prepareGrokCliHome > rejects a source GROK_HOME reached through an ancestor symlink before state mutation [0.97ms]
+(pass) prepareGrokCliHome > removes runtime-owned native hooks before every turn [1.70ms]
+(pass) prepareGrokCliHome > unlinks a runtime-owned hook symlink without touching its external target [1.59ms]
+(pass) prepareGrokCliHome > fails closed when a project native hook path exists [0.90ms]
+(pass) prepareGrokCliHome > trusts only the exact canonical nested cwd and atomically replaces stale grants [4.03ms]
+(pass) prepareGrokCliHome > rejects broad or symlinked folder-trust targets before writing trust state [1.84ms]
+(pass) prepareGrokCliHome > refuses a planted trust-store symlink and leaves its target untouched [1.93ms]
+(pass) prepareGrokCliHome > rejects every project executable source before granting folder trust [11.97ms]
+(pass) prepareGrokCliHome > does not impose the shared-folder strict policy on legacy headless mode [2.52ms]
+(pass) prepareGrokCliHome > rejects repo-root hooks from a nested cwd and dangling hook links [1.11ms]
+(pass) prepareGrokCliHome > rejects a symlinked project .grok directory [0.87ms]
+(pass) prepareGrokCliHome > rejects symlinked isolated homes and generated state without changing targets [2.43ms]
+(pass) prepareGrokCliHome > rejects a state-home path escape before chmod, removal, or writes [0.89ms]
+(pass) prepareGrokCliHome > requires a valid zero-hook inspect response [0.72ms]
+(pass) prepareGrokCliHome > flocks the canonical project inode across symlink aliases and releases cleanly [174.93ms]
+(pass) prepareGrokCliHome > gives the real flock holder only the exact helper environment [77.90ms]
+
+ 39 pass
+ 0 fail
+ 284 expect() calls
+Ran 39 tests across 1 file. [468.00ms]
+
+$ production-build bun build /workspace/agent-network/src/node-server.ts --outfile /tmp/node-server.js --target bun
+Bundled 221 modules in 60ms
+
+  node-server.js  0.50 MB  (entry point)
+
+
+$ production-socket-harness env MCP_BUNDLE=/tmp/node-server.js bun /test235/socket-harness.ts
+PASS assertions=68 outer_tasks=40 outbound_calls=12 mcp_hub_long_connections=0
+/bin/sh: 1: tmux: not found
+[10:17:00] [commhub] ENV: URL=http://127.0.0.1:32945 ALIAS=test235-grok RESUME_ID=grok-tes... TMUX=none CWD=/tmp/test235-V53f55 PROJECT_ENV=-tmp-test235-V53f55 MODE=outbound-only
+[10:17:00] [commhub] MCP stdio connected
+[10:17:00] [commhub] ready — outbound-only tools; no channel/SSE/inbox/lifecycle/presence owner
+[10:17:01] [commhub] shutting down outbound-only MCP client
+
+$ mutation-build bun build /workspace/agent-network/src/node-server.ts --outfile /tmp/node-server-mutated.js --target bun
+Bundled 221 modules in 44ms
+
+  node-server-mutated.js  0.50 MB  (entry point)
+
+/bin/sh: 1: tmux: not found
+[10:17:11] [commhub] ENV: URL=http://127.0.0.1:35101 ALIAS=test235-grok RESUME_ID=grok-tes... TMUX=none CWD=/tmp/test235-xm7vl8 PROJECT_ENV=-tmp-test235-xm7vl8 MODE=channel
+[10:17:11] [commhub] MCP stdio connected
+[10:17:11] [commhub] starting SSE listener...
+[10:17:11] [commhub] connecting to http://127.0.0.1:35101/events/test235-grok
+[10:17:11] [commhub] ready — waiting for events
+[10:17:11] [commhub] SSE connected as "test235-grok"
+[10:17:11] [commhub] registered as "test235-grok" (grok-tes)
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+[10:17:12] [commhub] shutting down, reporting offline...
+[10:17:12] [commhub] ← new_task: inbox_count=1 priority=normal
+230 | 
+231 |   if (expectMutation) {
+232 |     if (!failures.length) {
+233 |       throw new Error("MUTATION_STAYED_GREEN: deleting outbound-only mode gate did not violate a socket or ownership assertion");
+234 |     }
+235 |     throw new Error(`EXPECTED_MUTATION_FAILURES (${failures.length})\n- ${failures.join("\n- ")}`);
+                    ^
+error: EXPECTED_MUTATION_FAILURES (7)
+- MCP omits channel capability
+- exact three outbound tools
+- only outer owner opens SSE
+- one total long-lived SSE socket
+- MCP child Hub established sockets zero at idle
+- MCP startup performs zero Hub tool calls
+- MCP inbound/lifecycle requests zero
+      at /test235/socket-harness.ts:235:15
+
+Bun v1.3.14 (Linux x64 baseline)
+PASS: witnessed-red outbound-only mutation rc=1
+
+$ runbook-gate bash -ceu $'\n  doc=/workspace/docs/grok-build-cli-preview.md\n  grep -Fq "runtime-owned outbound-only CommHub MCP server" "$doc"\n  grep -Fq "does not register a channel" "$doc"\n  grep -Fq "single inbox and" "$doc"\n'
+
+Summary: PASS (real MCP child; zero long-lived Hub sockets; 40/40 outer ownership; 12 outbound calls; mutation red)

--- a/tests/test225-grok-preview-package-live/fake-grok.mjs
+++ b/tests/test225-grok-preview-package-live/fake-grok.mjs
@@ -174,7 +174,7 @@ const expectedAgentProfile = [
   "  - search_tool",
   "  - use_tool",
   "---",
-  "ANET_COPRESENCE_PROFILE_V1: Answer the current user directly. Only the runtime-owned commhub MCP integration is available; do not claim filesystem, shell, web/media, or subagent access.",
+  "ANET_COPRESENCE_PROFILE_V1: Answer the current user directly. Only the runtime-owned outbound-only commhub MCP integration is available; do not claim inbound CommHub, lifecycle/presence ownership, filesystem, shell, web/media, or subagent access.",
   "",
 ].join("\n");
 

--- a/tests/test225-grok-preview-package-live/run.sh
+++ b/tests/test225-grok-preview-package-live/run.sh
@@ -2140,9 +2140,9 @@ run_keyless_gate() {
     and .servers[0].name == "commhub"
     and .servers[0].transport == "stdio"
     and .servers[0].healthy == true
-    and any(.servers[0].checks[]; .label == "5 tools discovered" and .passed == true)
+    and any(.servers[0].checks[]; .label == "3 tools discovered" and .passed == true)
   ' "$mcp_doctor" >/dev/null \
-    || fail "runtime-owned commhub MCP doctor did not prove the exact five-tool server"
+    || fail "runtime-owned commhub MCP doctor did not prove the exact three-tool outbound-only server"
   scan_fixed_file /tmp/test225-markers "$mcp_doctor" \
     || fail "commhub MCP doctor leaked a synthetic credential marker"
   rm -f -- "$mcp_doctor"

--- a/tests/test235-grok-mcp-outbound-only/Dockerfile
+++ b/tests/test235-grok-mcp-outbound-only/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+
+WORKDIR /workspace
+COPY agent-network/package.json agent-network/package-lock.json /workspace/agent-network/
+RUN cd /workspace/agent-network && bun install --ignore-scripts
+COPY agent-network /workspace/agent-network
+COPY agent-node /workspace/agent-node
+COPY docs/grok-build-cli-preview.md /workspace/docs/grok-build-cli-preview.md
+COPY tests/test235-grok-mcp-outbound-only /test235
+RUN chmod 755 /test235/run.sh
+
+ENTRYPOINT ["bash", "/test235/run.sh"]

--- a/tests/test235-grok-mcp-outbound-only/run.sh
+++ b/tests/test235-grok-mcp-outbound-only/run.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test235-grok-mcp-outbound-only.txt"
+mkdir -p "$ARTIFACT_DIR"
+: >"$REPORT"
+
+run() {
+  printf '\n$ %q' "$1" | tee -a "$REPORT"
+  shift
+  printf ' %q' "$@" | tee -a "$REPORT"
+  printf '\n' | tee -a "$REPORT"
+  "$@" 2>&1 | tee -a "$REPORT"
+}
+
+printf '%s\n' \
+  '# test235 — Grok CommHub MCP outbound-only ownership gate' \
+  "source_commit=$SOURCE_COMMIT" \
+  'scope=structural MCP capabilities, real socket count, repeated task ownership, outbound tools, direct-call denial, mutation red' \
+  | tee -a "$REPORT"
+
+run home-mode bun test /workspace/agent-node/src/runtime/grok-build-cli-home.test.ts
+
+run production-build bun build /workspace/agent-network/src/node-server.ts \
+  --outfile /tmp/node-server.js --target bun
+
+run production-socket-harness env MCP_BUNDLE=/tmp/node-server.js \
+  bun /test235/socket-harness.ts
+
+# Witnessed-red: remove the exact runtime mode gate while leaving the harness
+# unchanged. The MCP then registers presence and opens its own SSE connection;
+# socket/inbound ownership assertions must fail.
+cp /workspace/agent-network/src/node-server.ts /tmp/node-server-original.ts
+sed -i 's/const OUTBOUND_ONLY = process.env.ANET_COMMHUB_MODE === "outbound-only";/const OUTBOUND_ONLY = false;/' \
+  /workspace/agent-network/src/node-server.ts
+run mutation-build bun build /workspace/agent-network/src/node-server.ts \
+  --outfile /tmp/node-server-mutated.js --target bun
+cp /tmp/node-server-original.ts /workspace/agent-network/src/node-server.ts
+set +e
+EXPECT_MUTATION=1 MCP_BUNDLE=/tmp/node-server-mutated.js bun /test235/socket-harness.ts > /tmp/mutation.out 2>&1
+mutation_rc=$?
+set -e
+cat /tmp/mutation.out | tee -a "$REPORT"
+if test "$mutation_rc" -eq 0; then
+  printf 'FAIL: deleting outbound-only mode gate stayed green\n' | tee -a "$REPORT"
+  exit 1
+fi
+printf 'PASS: witnessed-red outbound-only mutation rc=%s\n' "$mutation_rc" | tee -a "$REPORT"
+
+run runbook-gate bash -ceu '
+  doc=/workspace/docs/grok-build-cli-preview.md
+  grep -Fq "runtime-owned outbound-only CommHub MCP server" "$doc"
+  grep -Fq "does not register a channel" "$doc"
+  grep -Fq "single inbox and" "$doc"
+'
+
+printf '\nSummary: PASS (real MCP child; zero long-lived Hub sockets; 40/40 outer ownership; 12 outbound calls; mutation red)\n' | tee -a "$REPORT"

--- a/tests/test235-grok-mcp-outbound-only/run.sh
+++ b/tests/test235-grok-mcp-outbound-only/run.sh
@@ -20,6 +20,8 @@ printf '%s\n' \
   'scope=structural MCP capabilities, real socket count, repeated task ownership, outbound tools, direct-call denial, mutation red' \
   | tee -a "$REPORT"
 
+run network-typecheck bash -ceu 'cd /workspace/agent-network && bun tsc --noEmit'
+
 run home-mode bun test /workspace/agent-node/src/runtime/grok-build-cli-home.test.ts
 
 run production-build bun build /workspace/agent-network/src/node-server.ts \

--- a/tests/test235-grok-mcp-outbound-only/socket-harness.ts
+++ b/tests/test235-grok-mcp-outbound-only/socket-harness.ts
@@ -1,0 +1,277 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+type RpcMessage = { id?: number; method?: string; result?: any; error?: any; params?: any };
+
+const bundle = process.env.MCP_BUNDLE;
+if (!bundle) throw new Error("MCP_BUNDLE is required");
+const expectMutation = process.env.EXPECT_MUTATION === "1";
+
+const assertions: string[] = [];
+const failures: string[] = [];
+function assert(condition: unknown, label: string): void {
+  if (condition) assertions.push(label);
+  else failures.push(label);
+}
+
+const state = {
+  sseControllers: new Set<ReadableStreamDefaultController<Uint8Array>>(),
+  sseOpened: 0,
+  sseActive: 0,
+  sseMaxActive: 0,
+  hubTools: [] as string[],
+  hubMethods: [] as string[],
+  taskIds: Array.from({ length: 40 }, (_, i) => `task-${String(i + 1).padStart(2, "0")}`),
+};
+const encoder = new TextEncoder();
+
+function rpcSse(id: unknown, payload: unknown): Response {
+  return new Response(`data: ${JSON.stringify({ jsonrpc: "2.0", id, result: { content: [{ type: "text", text: JSON.stringify(payload) }] } })}\n\n`, {
+    headers: { "content-type": "text/event-stream", connection: "close" },
+  });
+}
+
+const hub = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  async fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname.startsWith("/events/")) {
+      state.sseOpened += 1;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          state.sseControllers.add(controller);
+          state.sseActive += 1;
+          state.sseMaxActive = Math.max(state.sseMaxActive, state.sseActive);
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "connected" })}\n\n`));
+        },
+        cancel() {
+          state.sseActive -= 1;
+        },
+      });
+      return new Response(stream, {
+        headers: {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        },
+      });
+    }
+    if (url.pathname === "/mcp" && req.method === "POST") {
+      const body = await req.json() as any;
+      state.hubMethods.push(String(body.method || ""));
+      if (body.method === "initialize") {
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocolVersion: "2025-03-26", capabilities: {}, serverInfo: { name: "fake-hub", version: "1" } } }), {
+          headers: { "content-type": "application/json", connection: "close" },
+        });
+      }
+      if (body.method === "tools/call") {
+        const name = String(body.params?.name || "");
+        state.hubTools.push(name);
+        if (name === "get_inbox") return rpcSse(body.id, { ok: true, messages: [] });
+        return rpcSse(body.id, { ok: true, tool: name });
+      }
+      return rpcSse(body.id, { ok: true });
+    }
+    return new Response("not found", { status: 404 });
+  },
+});
+
+const root = mkdtempSync(join(tmpdir(), "test235-"));
+const envFile = join(root, "commhub.env");
+writeFileSync(envFile, `COMMHUB_URL=http://127.0.0.1:${hub.port}\nCOMMHUB_TOKEN=ntok_test235\n`, { mode: 0o600 });
+chmodSync(envFile, 0o600);
+
+const child = Bun.spawn(["bun", bundle], {
+  cwd: root,
+  env: {
+    PATH: process.env.PATH || "/usr/local/bin:/usr/bin:/bin",
+    HOME: root,
+    ANET_COMMHUB_ENV_FILE: envFile,
+    ANET_COMMHUB_MODE: "outbound-only",
+    COMMHUB_ALIAS: "test235-grok",
+    COMMHUB_RESUME_ID: "grok-test235",
+  },
+  stdin: "pipe",
+  stdout: "pipe",
+  stderr: "pipe",
+});
+const stderrPromise = new Response(child.stderr).text();
+const stdoutReader = child.stdout.getReader();
+let stdoutBuffer = "";
+
+async function nextRpc(timeoutMs = 5_000): Promise<RpcMessage> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const newline = stdoutBuffer.indexOf("\n");
+    if (newline >= 0) {
+      const line = stdoutBuffer.slice(0, newline).trim();
+      stdoutBuffer = stdoutBuffer.slice(newline + 1);
+      if (line) return JSON.parse(line);
+      continue;
+    }
+    const remaining = Math.max(1, deadline - Date.now());
+    const read = await Promise.race([
+      stdoutReader.read(),
+      Bun.sleep(remaining).then(() => ({ done: true, value: undefined } as ReadableStreamReadResult<Uint8Array>)),
+    ]);
+    if (read.done) break;
+    stdoutBuffer += new TextDecoder().decode(read.value, { stream: true });
+  }
+  throw new Error("timed out waiting for MCP stdio response");
+}
+
+async function sendRpc(message: RpcMessage): Promise<void> {
+  child.stdin.write(`${JSON.stringify(message)}\n`);
+  await child.stdin.flush();
+}
+
+async function waitForId(id: number): Promise<RpcMessage> {
+  for (;;) {
+    const message = await nextRpc();
+    if (message.id === id) return message;
+  }
+}
+
+function childEstablishedHubSockets(pid: number, port: number): number {
+  let inodes = new Set<string>();
+  try {
+    for (const name of readdirSync(`/proc/${pid}/fd`)) {
+      try {
+        const target = readlinkSync(`/proc/${pid}/fd/${name}`);
+        const match = /^socket:\[(\d+)\]$/.exec(target);
+        if (match) inodes.add(match[1]!);
+      } catch {}
+    }
+  } catch {}
+  const portHex = port.toString(16).toUpperCase().padStart(4, "0");
+  let count = 0;
+  for (const table of ["/proc/net/tcp", "/proc/net/tcp6"]) {
+    let text = "";
+    try { text = readFileSync(table, "utf8"); } catch { continue; }
+    for (const line of text.trim().split("\n").slice(1)) {
+      const columns = line.trim().split(/\s+/);
+      if (columns.length < 10) continue;
+      const remote = columns[2] || "";
+      const stateCode = columns[3];
+      const inode = columns[9];
+      if (stateCode === "01" && remote.endsWith(`:${portHex}`) && inodes.has(inode)) count += 1;
+    }
+  }
+  return count;
+}
+
+const outerCounts = new Map<string, { claim: number; ack: number; terminal: number }>();
+let outerEvents = 0;
+const outerResponse = await fetch(`http://127.0.0.1:${hub.port}/events/test235-grok`);
+const outerReader = outerResponse.body!.getReader();
+const outerLoop = (async () => {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await outerReader.read();
+    if (done) return;
+    buffer += decoder.decode(value, { stream: true });
+    const blocks = buffer.split("\n\n");
+    buffer = blocks.pop() || "";
+    for (const block of blocks) {
+      const data = block.split("\n").find((line) => line.startsWith("data: "));
+      if (!data) continue;
+      const event = JSON.parse(data.slice(6));
+      if (event.type !== "new_task") continue;
+      const current = outerCounts.get(event.task_id) || { claim: 0, ack: 0, terminal: 0 };
+      current.claim += 1;
+      current.ack += 1;
+      current.terminal += 1;
+      outerCounts.set(event.task_id, current);
+      outerEvents += 1;
+    }
+  }
+})();
+
+try {
+  await sendRpc({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test235", version: "1" } } } as any);
+  const initialized = await waitForId(1);
+  assert(initialized.result?.capabilities?.tools, "MCP advertises tools capability");
+  assert(!initialized.result?.capabilities?.experimental, "MCP omits channel capability");
+  await sendRpc({ jsonrpc: "2.0", method: "notifications/initialized", params: {} } as any);
+  await sendRpc({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} } as any);
+  const listed = await waitForId(2);
+  const toolNames = listed.result?.tools?.map((tool: any) => tool.name) || [];
+  assert(JSON.stringify(toolNames) === JSON.stringify(["commhub_send_task", "commhub_send_message", "commhub_get_all_status"]), "exact three outbound tools");
+
+  await Bun.sleep(350);
+  assert(state.sseOpened === 1, "only outer owner opens SSE");
+  assert(state.sseMaxActive === 1, "one total long-lived SSE socket");
+  assert(childEstablishedHubSockets(child.pid, hub.port) === 0, "MCP child Hub established sockets zero at idle");
+  assert(state.hubTools.length === 0, "MCP startup performs zero Hub tool calls");
+
+  for (const taskId of state.taskIds) {
+    const payload = `data: ${JSON.stringify({ type: "new_task", task_id: taskId, inbox_count: 1, priority: "normal" })}\n\n`;
+    for (const controller of state.sseControllers) controller.enqueue(encoder.encode(payload));
+  }
+  const deadline = Date.now() + 3_000;
+  while (outerEvents < state.taskIds.length && Date.now() < deadline) await Bun.sleep(10);
+  assert(outerEvents === state.taskIds.length, "outer owner observed all repeated tasks");
+  for (const taskId of state.taskIds) {
+    const count = outerCounts.get(taskId);
+    assert(count?.claim === 1 && count.ack === 1 && count.terminal === 1, `${taskId} exact outer claim/ack/terminal`);
+  }
+  assert(!state.hubTools.some((name) => ["get_inbox", "ack_inbox", "send_reply", "report_status"].includes(name)), "MCP inbound/lifecycle requests zero");
+
+  if (expectMutation) {
+    if (!failures.length) {
+      throw new Error("MUTATION_STAYED_GREEN: deleting outbound-only mode gate did not violate a socket or ownership assertion");
+    }
+    throw new Error(`EXPECTED_MUTATION_FAILURES (${failures.length})\n- ${failures.join("\n- ")}`);
+  }
+
+  const outboundIds = Array.from({ length: 12 }, (_, i) => 100 + i);
+  for (const id of outboundIds) {
+    await sendRpc({ jsonrpc: "2.0", id, method: "tools/call", params: { name: "commhub_send_task", arguments: { alias: `peer-${id}`, task: `task-${id}` } } } as any);
+  }
+  const pending = new Set(outboundIds);
+  while (pending.size) {
+    const message = await nextRpc(10_000);
+    if (typeof message.id === "number" && pending.has(message.id)) {
+      assert(message.result?.isError !== true, `outbound send_task ${message.id} succeeds`);
+      pending.delete(message.id);
+    }
+  }
+  assert(state.hubTools.filter((name) => name === "send_task").length === 12, "twelve outbound send_task calls reach Hub");
+
+  const hubCountBeforeForbidden = state.hubTools.length;
+  for (const [id, name] of [[300, "commhub_report_status"], [301, "commhub_reply"], [302, "get_inbox"]] as const) {
+    await sendRpc({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: {} } } as any);
+    const denied = await waitForId(id);
+    assert(denied.result?.isError === true, `${name} direct call denied`);
+  }
+  assert(state.hubTools.length === hubCountBeforeForbidden, "forbidden direct calls make zero Hub requests");
+  await Bun.sleep(500);
+  assert(childEstablishedHubSockets(child.pid, hub.port) === 0, "MCP child Hub established sockets zero after outbound calls");
+  assert(state.sseMaxActive === 1, "MCP never adds a second long-lived socket");
+
+  if (failures.length) {
+    throw new Error(`ASSERT_FAILURES (${failures.length})\n- ${failures.join("\n- ")}`);
+  }
+  console.log(`PASS assertions=${assertions.length} outer_tasks=${outerEvents} outbound_calls=12 mcp_hub_long_connections=0`);
+} finally {
+  try { child.stdin.end(); } catch {}
+  await Promise.race([child.exited, Bun.sleep(2_000)]);
+  if (child.exitCode === null) child.kill();
+  try { await outerReader.cancel(); } catch {}
+  await Promise.race([outerLoop, Bun.sleep(500)]).catch(() => {});
+  hub.stop(true);
+  const stderr = await Promise.race([stderrPromise, Bun.sleep(500).then(() => "")]);
+  if (stderr) process.stderr.write(stderr);
+  rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
修今天唯一还活在生产上的缺陷。

## 缺陷是实证的，不是推断的

Grok 节点里**两条独立的入站链路挂在同一个别名上**，三种互不依赖的证据：

```
socket    同一工作区两个进程各自握着到 hub 的活连接（1 条 + 2 条）
MCP 日志  ← new_task  →  injected task 5c153b50
桥日志    同一秒也注入了同一个 task
```

**同一个任务被送进模型两次。** 而「谁先 ack 决定另一方是否看到任务」这个竞态在结构上一直存在 —— 那次上线验收成功，只是外层先抢到了，不是没有竞态。

## 为什么不是「让两个上报方字段一致」

那只是**把竞态变得看不见**。谁先抢到还是谁先抢到，只是界面上不再露馅，以后更难查。

**边界要划在「能不能做」，不是「做出来一不一致」。** 所以是消灭第二个消费者，不是让它俩对齐。

## 实现

```
:552   MCP connect 之后，outbound-only 直接 return
       → SSE / report_status / heartbeat / inbox 全部不执行
```

**一个 early return 挡住整个入站半边**，而不是逐个调用点加条件（那样漏一个就破功）。

```
:161   OUTBOUND_TOOL_NAMES = { commhub_send_task, commhub_send_message, commhub_get_all_status }
:298   if (OUTBOUND_ONLY && !OUTBOUND_TOOL_NAMES.has(name)) → 拒绝
```

注释点明了一件容易被忽略的事：**`tools/list` 不是安全边界** —— 客户端可以直接用任意名字发 `tools/call`。所以拒绝发生在**任何 Hub 请求之前**。

进程级由 `ANET_COMMHUB_MODE=outbound-only` 钉死；legacy channel 模式保持默认兼容。

## 验收在 socket 层，不在 grep 层

这一条是硬要求。审查时我 grep `connectSSE` 得到 **0**，那是打包混淆的**假阴** —— 如果停在 grep，结论会完全相反。**socket 不会被混淆。**

```
MCP → Hub established long socket   = 0
40/40 重复任务   每项外层 claim/ack/terminal 各恰好 1 次
12 并发 send_task 全部到达 Hub
禁止工具直调    零 Hub 请求
```

**Mutation**：`OUTBOUND_ONLY` 赋值改成 `false`，测试代码不动，rc=1，同时红 7 道门（channel capability / 精确工具集 / only-outer SSE / 单长连接 / MCP child Hub socket=0 / startup Hub calls=0 / MCP inbound+lifecycle=0）。

作者还修了变异 harness 自身的一个挂起问题 —— 变异版现在在取完 socket/ownership 证据后按预期退出，而不是卡在出站阶段。**一个靠挂死变红的门什么都不证明。**