### PR TITLE
fix(dashboard): route an authenticated /goal into the shared Codex thread instead of the scheduler

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -18,6 +18,7 @@ import { createCommhubSdkMcpServer } from "./commhub-mcp";
 import { getHostTelemetry } from "./host-telemetry";
 import { getProcessTelemetry, incrementInFlight, decrementInFlight } from "./process-telemetry";
 import { parseGoalCommand } from "./goals/parser";
+import { appendDashboardCodexGoalNotice, shouldCreateScheduledGoal } from "./goals/routing";
 import { GoalStore, newGoal, runtimeBucket, decideStartupAction } from "./goals/store";
 import { decideTickWork } from "./goals/scheduler";
 import { runCodexWakeForGoal, type CodexWakeDeps } from "./goals/codex-wake";
@@ -1422,10 +1423,6 @@ const codexInboxDispatcher = createDetachedInboxDispatcher<any>({
   // The work lane coalesces simultaneous completions into a bounded dirty run.
   onSettled: scheduleWorkInboxDrain,
 });
-
-function isGoalCommand(content: string): boolean {
-  return /^\s*\/(?:goal|loop)\b/i.test(content || "");
-}
 
 function formatInterval(ms: number): string {
   const min = Math.round(ms / 60_000);
@@ -4539,15 +4536,14 @@ async function processInbox() {
       const persistenceSafeContent = GROK_EXECUTION_MODE === "cli"
         ? persistenceRedactor.redactText(content).text
         : content;
+      const interactiveDashboardTask = isInteractiveDashboardTask(msg);
 
-      // #144 round-6: anet /loop is universal — all recognized runtimes
-      // (claude / codex / grok) route /loop and /goal commands to the
-      // scheduler. The pre-#144 `RUNTIME !== "claude"` carve-out was
-      // removed because the underlying premise (claude-agent-sdk has a
-      // native /loop) was false: the SDK is one-shot per-task, no
-      // persistent CC REPL to fire CronCreate/ScheduleWakeup from. See
-      // goals/store.ts runtimeBucket comment for full rationale.
-      if (isGoalCommand(persistenceSafeContent)) {
+      // `/loop` remains Agent Network's universal recurring scheduler.
+      // `/goal` remains its backwards-compatible alias except for a
+      // Hub-authenticated Dashboard task entering a shared Codex TUI. That
+      // surface owns `/goal`; intercepting it here both changes its semantics
+      // and rejects normal goal text that intentionally has no interval.
+      if (shouldCreateScheduledGoal(persistenceSafeContent, RUNTIME, interactiveDashboardTask)) {
         let replyText: string;
         let goalFailed = false;
         try {
@@ -4565,12 +4561,20 @@ async function processInbox() {
       }
 
       // (3b) Run the LLM turn.
-      const { text: result, failed } = await processTask(
+      const taskOutcome = await processTask(
         content,
         from,
         msg.id,
         images,
-        isInteractiveDashboardTask(msg),
+        interactiveDashboardTask,
+      );
+      const failed = taskOutcome.failed;
+      const result = appendDashboardCodexGoalNotice(
+        taskOutcome.text,
+        persistenceSafeContent,
+        RUNTIME,
+        interactiveDashboardTask,
+        failed,
       );
       if (GROK_EXECUTION_MODE === "cli") {
         log(`processTask returned (${result.length} chars, content withheld, failed=${failed})`);

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -18,7 +18,7 @@ import { createCommhubSdkMcpServer } from "./commhub-mcp";
 import { getHostTelemetry } from "./host-telemetry";
 import { getProcessTelemetry, incrementInFlight, decrementInFlight } from "./process-telemetry";
 import { parseGoalCommand } from "./goals/parser";
-import { appendDashboardCodexGoalNotice, shouldCreateScheduledGoal } from "./goals/routing";
+import { prepareDashboardCodexGoalReply, shouldCreateScheduledGoal } from "./goals/routing";
 import { GoalStore, newGoal, runtimeBucket, decideStartupAction } from "./goals/store";
 import { decideTickWork } from "./goals/scheduler";
 import { runCodexWakeForGoal, type CodexWakeDeps } from "./goals/codex-wake";
@@ -4569,13 +4569,15 @@ async function processInbox() {
         interactiveDashboardTask,
       );
       const failed = taskOutcome.failed;
-      const result = appendDashboardCodexGoalNotice(
+      const preparedReply = prepareDashboardCodexGoalReply(
         taskOutcome.text,
         persistenceSafeContent,
         RUNTIME,
         interactiveDashboardTask,
         failed,
+        (text) => isLowValueText(text, true),
       );
+      const result = preparedReply.text;
       if (GROK_EXECUTION_MODE === "cli") {
         log(`processTask returned (${result.length} chars, content withheld, failed=${failed})`);
       } else {
@@ -4586,7 +4588,7 @@ async function processInbox() {
       // behaviour — codex / claude often emit "done." / "✅" for trivial
       // confirmations). Failures ALWAYS surface so the dispatcher sees
       // the real error instead of silence.
-      if (!failed && isLowValueText(result, true)) {
+      if (!preparedReply.shouldDeliver) {
         log(GROK_EXECUTION_MODE === "cli"
           ? `skip reply: low-value (${result.length} chars; content withheld)`
           : `skip reply: low-value (${result.slice(0, 30)})`);

--- a/agent-node/src/goals/routing.test.ts
+++ b/agent-node/src/goals/routing.test.ts
@@ -40,7 +40,10 @@ describe("shouldCreateScheduledGoal", () => {
       true,
       false,
     );
-    expect(reply).toBe(`目标已创建\n\n${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}`);
+    expect(reply).toBe(`${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}\n\n目标已创建`);
+    expect(appendDashboardCodexGoalNotice(
+      "x".repeat(2_500), "/goal 5m 检查日志", "codex-app-server", true, false,
+    ).slice(0, 2_000)).toContain(DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE);
   });
 
   test("does not add a misleading notice to ordinary goals, failures, or legacy paths", () => {

--- a/agent-node/src/goals/routing.test.ts
+++ b/agent-node/src/goals/routing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   appendDashboardCodexGoalNotice,
   DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE,
+  prepareDashboardCodexGoalReply,
   shouldCreateScheduledGoal,
 } from "./routing";
 
@@ -59,5 +60,18 @@ describe("shouldCreateScheduledGoal", () => {
     expect(appendDashboardCodexGoalNotice(
       "loop", "/loop 5m 检查日志", "codex-app-server", true, false,
     )).toBe("loop");
+  });
+
+  test("delivers the interval notice even when the model reply alone is low-value", () => {
+    const prepared = prepareDashboardCodexGoalReply(
+      "收到",
+      "/goal 5m 检查日志",
+      "codex-app-server",
+      true,
+      false,
+      (text) => text === "收到",
+    );
+    expect(prepared.shouldDeliver).toBe(true);
+    expect(prepared.text).toContain(DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE);
   });
 });

--- a/agent-node/src/goals/routing.test.ts
+++ b/agent-node/src/goals/routing.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  appendDashboardCodexGoalNotice,
+  DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE,
+  shouldCreateScheduledGoal,
+} from "./routing";
+
+describe("shouldCreateScheduledGoal", () => {
+  test("passes authenticated Dashboard /goal through to the shared Codex TUI", () => {
+    expect(shouldCreateScheduledGoal(
+      "/goal 更新一下 https://anet.sh 把乱七八糟的文档都删了",
+      "codex-app-server",
+      true,
+    )).toBe(false);
+  });
+
+  test("keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks", () => {
+    expect(shouldCreateScheduledGoal("/loop 每小时更新文档", "codex-app-server", true)).toBe(true);
+  });
+
+  test("preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI", () => {
+    expect(shouldCreateScheduledGoal("/goal 1h update docs", "codex-app-server", false)).toBe(true);
+    expect(shouldCreateScheduledGoal("/goal 1h update docs", "codex", true)).toBe(true);
+    expect(shouldCreateScheduledGoal("/goal 1h update docs", "claude", true)).toBe(true);
+    expect(shouldCreateScheduledGoal("/goal 1h update docs", "grok", true)).toBe(true);
+    expect(shouldCreateScheduledGoal("/goal 1h update docs", "opencode", true)).toBe(true);
+  });
+
+  test("does not treat near matches or ordinary chat as scheduler commands", () => {
+    expect(shouldCreateScheduledGoal("/goalkeeper status", "codex-app-server", true)).toBe(false);
+    expect(shouldCreateScheduledGoal("please /loop later", "codex-app-server", true)).toBe(false);
+    expect(shouldCreateScheduledGoal("更新一下文档", "codex-app-server", true)).toBe(false);
+  });
+
+  test("warns when Dashboard /goal text contains a scheduler interval", () => {
+    const reply = appendDashboardCodexGoalNotice(
+      "目标已创建",
+      "/goal 5m 检查日志",
+      "codex-app-server",
+      true,
+      false,
+    );
+    expect(reply).toBe(`目标已创建\n\n${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}`);
+  });
+
+  test("does not add a misleading notice to ordinary goals, failures, or legacy paths", () => {
+    expect(appendDashboardCodexGoalNotice(
+      "目标已创建", "/goal 更新文档", "codex-app-server", true, false,
+    )).toBe("目标已创建");
+    expect(appendDashboardCodexGoalNotice(
+      "创建失败", "/goal 5m 检查日志", "codex-app-server", true, true,
+    )).toBe("创建失败");
+    expect(appendDashboardCodexGoalNotice(
+      "legacy", "/goal 5m 检查日志", "codex-app-server", false, false,
+    )).toBe("legacy");
+    expect(appendDashboardCodexGoalNotice(
+      "loop", "/loop 5m 检查日志", "codex-app-server", true, false,
+    )).toBe("loop");
+  });
+});

--- a/agent-node/src/goals/routing.ts
+++ b/agent-node/src/goals/routing.ts
@@ -41,3 +41,22 @@ export function appendDashboardCodexGoalNotice(
   if (!parseGoalCommand(content).ok) return replyText;
   return `${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}\n\n${replyText}`;
 }
+
+/** Compose the visible goal notice before applying the ordinary reply filter. */
+export function prepareDashboardCodexGoalReply(
+  replyText: string,
+  content: string,
+  runtime: GoalRoutingRuntime,
+  interactiveDashboardTask: boolean,
+  failed: boolean,
+  isLowValueReply: (text: string) => boolean,
+): { text: string; shouldDeliver: boolean } {
+  const text = appendDashboardCodexGoalNotice(
+    replyText,
+    content,
+    runtime,
+    interactiveDashboardTask,
+    failed,
+  );
+  return { text, shouldDeliver: failed || !isLowValueReply(text) };
+}

--- a/agent-node/src/goals/routing.ts
+++ b/agent-node/src/goals/routing.ts
@@ -25,8 +25,9 @@ export function shouldCreateScheduledGoal(
 
 /**
  * Make the narrow Dashboard/Codex semantic split visible when the goal text
- * also contains a scheduler interval. The model reply is preserved verbatim;
- * this deterministic suffix prevents a user from silently expecting a loop.
+ * also contains a scheduler interval. Put the deterministic notice first so
+ * the outer 2000-character reply cap cannot truncate it from a long model
+ * response.
  */
 export function appendDashboardCodexGoalNotice(
   replyText: string,
@@ -38,5 +39,5 @@ export function appendDashboardCodexGoalNotice(
   if (failed || runtime !== "codex-app-server" || !interactiveDashboardTask) return replyText;
   if (!/^\s*\/goal\b/i.test(content || "")) return replyText;
   if (!parseGoalCommand(content).ok) return replyText;
-  return `${replyText}\n\n${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}`;
+  return `${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}\n\n${replyText}`;
 }

--- a/agent-node/src/goals/routing.ts
+++ b/agent-node/src/goals/routing.ts
@@ -1,0 +1,42 @@
+import { parseGoalCommand } from "./parser";
+
+export type GoalRoutingRuntime = "claude" | "codex" | "grok" | "opencode" | "codex-app-server";
+
+export const DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE =
+  "提示：已作为一次性目标处理；要定时请用 /loop <间隔> <任务>。";
+
+/**
+ * `/loop` is Agent Network's recurring scheduler command.
+ *
+ * `/goal` remains its backwards-compatible alias except for an authenticated
+ * Dashboard chat targeting a shared Codex TUI. Codex owns `/goal` in that
+ * interactive surface, so intercepting it here changes a persistent goal into
+ * a recurring loop and rejects ordinary goal text that has no interval.
+ */
+export function shouldCreateScheduledGoal(
+  content: string,
+  runtime: GoalRoutingRuntime,
+  interactiveDashboardTask: boolean,
+): boolean {
+  if (/^\s*\/loop\b/i.test(content || "")) return true;
+  if (!/^\s*\/goal\b/i.test(content || "")) return false;
+  return !(runtime === "codex-app-server" && interactiveDashboardTask);
+}
+
+/**
+ * Make the narrow Dashboard/Codex semantic split visible when the goal text
+ * also contains a scheduler interval. The model reply is preserved verbatim;
+ * this deterministic suffix prevents a user from silently expecting a loop.
+ */
+export function appendDashboardCodexGoalNotice(
+  replyText: string,
+  content: string,
+  runtime: GoalRoutingRuntime,
+  interactiveDashboardTask: boolean,
+  failed: boolean,
+): string {
+  if (failed || runtime !== "codex-app-server" || !interactiveDashboardTask) return replyText;
+  if (!/^\s*\/goal\b/i.test(content || "")) return replyText;
+  if (!parseGoalCommand(content).ok) return replyText;
+  return `${replyText}\n\n${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}`;
+}

--- a/docs/tests/report-test236-dashboard-codex-goal.txt
+++ b/docs/tests/report-test236-dashboard-codex-goal.txt
@@ -1,102 +1,105 @@
 # test236 — Dashboard /goal reaches shared Codex TUI
-source_commit=050b6a0465497e9fc268f21c86d07253cb6b1bf5
+source_commit=a75f8dc6a7a00b3c399b6554975ff561b0d47696
 scope=authenticated Dashboard routing, /loop compatibility, legacy /goal compatibility, production wiring, mutation red
 
 $ routing-unit bun test /workspace/agent-node/src/goals/routing.test.ts /workspace/agent-node/src/inbox-dispatch.test.ts
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/goals/routing.test.ts:
-(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.26ms]
-(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.07ms]
-(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.11ms]
-(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.11ms]
-(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.11ms]
-(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.15ms]
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.36ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.12ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.15ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.10ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.94ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.13ms]
+(pass) shouldCreateScheduledGoal > delivers the interval notice even when the model reply alone is low-value [0.20ms]
 
 agent-node/src/inbox-dispatch.test.ts:
-(pass) isInteractiveDashboardTask > accepts a Hub-authenticated dashboard chat task [0.49ms]
+(pass) isInteractiveDashboardTask > accepts a Hub-authenticated dashboard chat task [0.37ms]
 (pass) isInteractiveDashboardTask > pre-stamp admin rows stay FIFO because aliases are not auth facts [0.10ms]
-(pass) isInteractiveDashboardTask > rejects node-authenticated spoofing, malformed ids, and plain messages [0.07ms]
-(pass) dispatchInboxBatch > awaited batches preserve legacy runtime serialization [3.29ms]
-(pass) dispatchInboxBatch > a later SSE snapshot enters while the first detached turn is still running [1.92ms]
+(pass) isInteractiveDashboardTask > rejects node-authenticated spoofing, malformed ids, and plain messages [0.08ms]
+(pass) dispatchInboxBatch > awaited batches preserve legacy runtime serialization [2.61ms]
+(pass) dispatchInboxBatch > a later SSE snapshot enters while the first detached turn is still running [1.78ms]
 (pass) dispatchInboxBatch > the real serialized drain lane can fetch a later SSE snapshot before the active turn ends [0.98ms]
 (pass) dispatchInboxBatch > detached completion failures remain observable [1.44ms]
-(pass) dispatchInboxBatch > settling detached work emits a wake for the next Hub inbox window [1.43ms]
-(pass) dispatchInboxBatch > a throwing settle callback cannot strand queued N+1 work [1.40ms]
-(pass) dispatchInboxBatch > same-tick duplicate kicks claim one row exactly once [0.32ms]
-(pass) dispatchInboxBatch > bounded admission waits N+1 and starts it after a slot settles [1.97ms]
-(pass) dispatchInboxBatch > durable reply drain waits until detached Codex rows finish [0.06ms]
-(pass) dispatchInboxBatch > active Codex direct delivery and durable drain send one reply, not two [12.05ms]
+(pass) dispatchInboxBatch > settling detached work emits a wake for the next Hub inbox window [1.36ms]
+(pass) dispatchInboxBatch > a throwing settle callback cannot strand queued N+1 work [1.51ms]
+(pass) dispatchInboxBatch > same-tick duplicate kicks claim one row exactly once [0.42ms]
+(pass) dispatchInboxBatch > bounded admission waits N+1 and starts it after a slot settles [1.92ms]
+(pass) dispatchInboxBatch > durable reply drain waits until detached Codex rows finish [0.08ms]
+(pass) dispatchInboxBatch > active Codex direct delivery and durable drain send one reply, not two [8.22ms]
 
- 19 pass
+ 20 pass
  0 fail
- 47 expect() calls
-Ran 19 tests across 2 files. [78.00ms]
+ 49 expect() calls
+Ran 20 tests across 2 files. [90.00ms]
 
-$ production-wiring bash -ceu $'\n  cli=/workspace/agent-node/src/cli.ts\n  grep -Fq "const interactiveDashboardTask = isInteractiveDashboardTask(msg);" "$cli"\n  grep -Fq "shouldCreateScheduledGoal(persistenceSafeContent, RUNTIME, interactiveDashboardTask)" "$cli"\n  grep -Fq "const result = appendDashboardCodexGoalNotice(" "$cli"\n  grep -Fq "interactiveDashboardTask," "$cli"\n'
+$ production-wiring bash -ceu $'\n  cli=/workspace/agent-node/src/cli.ts\n  grep -Fq "const interactiveDashboardTask = isInteractiveDashboardTask(msg);" "$cli"\n  grep -Fq "shouldCreateScheduledGoal(persistenceSafeContent, RUNTIME, interactiveDashboardTask)" "$cli"\n  grep -Fq "const preparedReply = prepareDashboardCodexGoalReply(" "$cli"\n  grep -Fq "if (!preparedReply.shouldDeliver)" "$cli"\n  grep -Fq "interactiveDashboardTask," "$cli"\n'
 
 $ production-build bash -ceu $'\n  cd /workspace/agent-node\n  bun build src/cli.ts --outfile /tmp/agent-node-cli.js --target node \\\n    --external @anthropic-ai/claude-agent-sdk \\\n    --external "@anthropic-ai/claude-agent-sdk-*" \\\n    --external @openai/codex-sdk \\\n    --external node-pty\n  test -s /tmp/agent-node-cli.js\n'
-Bundled 253 modules in 76ms
+Bundled 253 modules in 77ms
 
   agent-node-cli.js  1.91 MB  (entry point)
 
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/goals/routing.test.ts:
- 9 |   test("passes authenticated Dashboard /goal through to the shared Codex TUI", () => {
-10 |     expect(shouldCreateScheduledGoal(
-11 |       "/goal 更新一下 https://anet.sh 把乱七八糟的文档都删了",
-12 |       "codex-app-server",
-13 |       true,
-14 |     )).toBe(false);
+10 |   test("passes authenticated Dashboard /goal through to the shared Codex TUI", () => {
+11 |     expect(shouldCreateScheduledGoal(
+12 |       "/goal 更新一下 https://anet.sh 把乱七八糟的文档都删了",
+13 |       "codex-app-server",
+14 |       true,
+15 |     )).toBe(false);
             ^
 error: expect(received).toBe(expected)
 
 Expected: false
 Received: true
 
-      at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:14:8)
-(fail) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.42ms]
-(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.07ms]
-(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.09ms]
-(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.07ms]
-(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.86ms]
+      at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:15:8)
+(fail) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.61ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.09ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.92ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.13ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.51ms]
 (pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.14ms]
+(pass) shouldCreateScheduledGoal > delivers the interval notice even when the model reply alone is low-value [0.14ms]
 
- 5 pass
+ 6 pass
  1 fail
- 16 expect() calls
-Ran 6 tests across 1 file. [21.00ms]
+ 18 expect() calls
+Ran 7 tests across 1 file. [39.00ms]
 PASS: witnessed-red Dashboard Codex /goal mutation rc=1
 
 $ restored-green bun test /workspace/agent-node/src/goals/routing.test.ts
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/goals/routing.test.ts:
-(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.40ms]
-(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.29ms]
-(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.14ms]
-(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.10ms]
-(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.10ms]
-(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.14ms]
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.48ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.08ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.15ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.76ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.36ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.18ms]
+(pass) shouldCreateScheduledGoal > delivers the interval notice even when the model reply alone is low-value [0.23ms]
 
- 6 pass
+ 7 pass
  0 fail
- 16 expect() calls
-Ran 6 tests across 1 file. [25.00ms]
+ 18 expect() calls
+Ran 7 tests across 1 file. [34.00ms]
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/goals/routing.test.ts:
-(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.36ms]
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.32ms]
 (pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.08ms]
-(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.13ms]
-(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.09ms]
-38 |       "/goal 5m 检查日志",
-39 |       "codex-app-server",
-40 |       true,
-41 |       false,
-42 |     );
-43 |     expect(reply).toBe(`${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}\n\n目标已创建`);
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.21ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.12ms]
+39 |       "/goal 5m 检查日志",
+40 |       "codex-app-server",
+41 |       true,
+42 |       false,
+43 |     );
+44 |     expect(reply).toBe(`${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}\n\n目标已创建`);
                        ^
 error: expect(received).toBe(expected)
 
@@ -108,30 +111,91 @@ error: expect(received).toBe(expected)
 - Expected  - 3
 + Received  + 1
 
-      at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:43:19)
-(fail) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.17ms]
-(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.20ms]
+      at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:44:19)
+(fail) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.24ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.17ms]
+69 |       "codex-app-server",
+70 |       true,
+71 |       false,
+72 |       (text) => text === "收到",
+73 |     );
+74 |     expect(prepared.shouldDeliver).toBe(true);
+                                        ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:74:36)
+(fail) shouldCreateScheduledGoal > delivers the interval notice even when the model reply alone is low-value [0.29ms]
 
  5 pass
- 1 fail
- 15 expect() calls
-Ran 6 tests across 1 file. [32.00ms]
+ 2 fail
+ 16 expect() calls
+Ran 7 tests across 1 file. [38.00ms]
 PASS: witnessed-red interval notice mutation rc=1
 
 $ final-green bun test /workspace/agent-node/src/goals/routing.test.ts
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/goals/routing.test.ts:
-(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.31ms]
-(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.07ms]
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.34ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.08ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.12ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.11ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [3.48ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.17ms]
+(pass) shouldCreateScheduledGoal > delivers the interval notice even when the model reply alone is low-value [0.21ms]
+
+ 7 pass
+ 0 fail
+ 18 expect() calls
+Ran 7 tests across 1 file. [32.00ms]
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/goals/routing.test.ts:
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.37ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.09ms]
 (pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.13ms]
-(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.10ms]
-(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.00ms]
-(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.15ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.09ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.91ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.18ms]
+69 |       "codex-app-server",
+70 |       true,
+71 |       false,
+72 |       (text) => text === "收到",
+73 |     );
+74 |     expect(prepared.shouldDeliver).toBe(true);
+                                        ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:74:36)
+(fail) shouldCreateScheduledGoal > delivers the interval notice even when the model reply alone is low-value [0.31ms]
 
  6 pass
- 0 fail
- 16 expect() calls
-Ran 6 tests across 1 file. [30.00ms]
+ 1 fail
+ 17 expect() calls
+Ran 7 tests across 1 file. [30.00ms]
+PASS: witnessed-red notice/filter ordering mutation rc=1
 
-Summary: PASS (authenticated Dashboard /goal passes to Codex TUI; interval ambiguity is explicit; /loop and legacy paths preserved; production bundle builds; two mutations red)
+$ order-restored-green bun test /workspace/agent-node/src/goals/routing.test.ts
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/goals/routing.test.ts:
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.29ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.06ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.12ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.09ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.99ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.14ms]
+(pass) shouldCreateScheduledGoal > delivers the interval notice even when the model reply alone is low-value [0.19ms]
+
+ 7 pass
+ 0 fail
+ 18 expect() calls
+Ran 7 tests across 1 file. [28.00ms]
+
+Summary: PASS (authenticated Dashboard /goal passes to Codex TUI; interval ambiguity survives reply filtering/cap; /loop and legacy paths preserved; production bundle builds; three mutations red)

--- a/docs/tests/report-test236-dashboard-codex-goal.txt
+++ b/docs/tests/report-test236-dashboard-codex-goal.txt
@@ -1,0 +1,137 @@
+# test236 — Dashboard /goal reaches shared Codex TUI
+source_commit=23f26af8e96a229ac56e33ed941400d381412006
+scope=authenticated Dashboard routing, /loop compatibility, legacy /goal compatibility, production wiring, mutation red
+
+$ routing-unit bun test /workspace/agent-node/src/goals/routing.test.ts /workspace/agent-node/src/inbox-dispatch.test.ts
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/goals/routing.test.ts:
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.26ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.05ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.08ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.07ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.80ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.11ms]
+
+agent-node/src/inbox-dispatch.test.ts:
+(pass) isInteractiveDashboardTask > accepts a Hub-authenticated dashboard chat task [1.55ms]
+(pass) isInteractiveDashboardTask > pre-stamp admin rows stay FIFO because aliases are not auth facts [0.12ms]
+(pass) isInteractiveDashboardTask > rejects node-authenticated spoofing, malformed ids, and plain messages [0.09ms]
+(pass) dispatchInboxBatch > awaited batches preserve legacy runtime serialization [6.01ms]
+(pass) dispatchInboxBatch > a later SSE snapshot enters while the first detached turn is still running [2.03ms]
+(pass) dispatchInboxBatch > the real serialized drain lane can fetch a later SSE snapshot before the active turn ends [0.98ms]
+(pass) dispatchInboxBatch > detached completion failures remain observable [1.46ms]
+(pass) dispatchInboxBatch > settling detached work emits a wake for the next Hub inbox window [1.40ms]
+(pass) dispatchInboxBatch > a throwing settle callback cannot strand queued N+1 work [1.60ms]
+(pass) dispatchInboxBatch > same-tick duplicate kicks claim one row exactly once [0.56ms]
+(pass) dispatchInboxBatch > bounded admission waits N+1 and starts it after a slot settles [2.18ms]
+(pass) dispatchInboxBatch > durable reply drain waits until detached Codex rows finish [0.09ms]
+(pass) dispatchInboxBatch > active Codex direct delivery and durable drain send one reply, not two [13.34ms]
+
+ 19 pass
+ 0 fail
+ 46 expect() calls
+Ran 19 tests across 2 files. [89.00ms]
+
+$ production-wiring bash -ceu $'\n  cli=/workspace/agent-node/src/cli.ts\n  grep -Fq "const interactiveDashboardTask = isInteractiveDashboardTask(msg);" "$cli"\n  grep -Fq "shouldCreateScheduledGoal(persistenceSafeContent, RUNTIME, interactiveDashboardTask)" "$cli"\n  grep -Fq "const result = appendDashboardCodexGoalNotice(" "$cli"\n  grep -Fq "interactiveDashboardTask," "$cli"\n'
+
+$ production-build bash -ceu $'\n  cd /workspace/agent-node\n  bun build src/cli.ts --outfile /tmp/agent-node-cli.js --target node \\\n    --external @anthropic-ai/claude-agent-sdk \\\n    --external "@anthropic-ai/claude-agent-sdk-*" \\\n    --external @openai/codex-sdk \\\n    --external node-pty\n  test -s /tmp/agent-node-cli.js\n'
+Bundled 253 modules in 93ms
+
+  agent-node-cli.js  1.91 MB  (entry point)
+
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/goals/routing.test.ts:
+ 9 |   test("passes authenticated Dashboard /goal through to the shared Codex TUI", () => {
+10 |     expect(shouldCreateScheduledGoal(
+11 |       "/goal 更新一下 https://anet.sh 把乱七八糟的文档都删了",
+12 |       "codex-app-server",
+13 |       true,
+14 |     )).toBe(false);
+            ^
+error: expect(received).toBe(expected)
+
+Expected: false
+Received: true
+
+      at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:14:8)
+(fail) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.54ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.10ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.15ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.10ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.00ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.16ms]
+
+ 5 pass
+ 1 fail
+ 15 expect() calls
+Ran 6 tests across 1 file. [31.00ms]
+PASS: witnessed-red Dashboard Codex /goal mutation rc=1
+
+$ restored-green bun test /workspace/agent-node/src/goals/routing.test.ts
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/goals/routing.test.ts:
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.30ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.06ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.14ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.11ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.93ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.15ms]
+
+ 6 pass
+ 0 fail
+ 15 expect() calls
+Ran 6 tests across 1 file. [34.00ms]
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/goals/routing.test.ts:
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.36ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.07ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.12ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.09ms]
+38 |       "/goal 5m 检查日志",
+39 |       "codex-app-server",
+40 |       true,
+41 |       false,
+42 |     );
+43 |     expect(reply).toBe(`目标已创建\n\n${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}`);
+                       ^
+error: expect(received).toBe(expected)
+
+- "目标已创建
+-
+- 提示：已作为一次性目标处理；要定时请用 /loop <间隔> <任务>。"
++ "目标已创建"
+
+- Expected  - 3
++ Received  + 1
+
+      at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:43:19)
+(fail) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.15ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.16ms]
+
+ 5 pass
+ 1 fail
+ 15 expect() calls
+Ran 6 tests across 1 file. [32.00ms]
+PASS: witnessed-red interval notice mutation rc=1
+
+$ final-green bun test /workspace/agent-node/src/goals/routing.test.ts
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/goals/routing.test.ts:
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.27ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.06ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.12ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.08ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.78ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.15ms]
+
+ 6 pass
+ 0 fail
+ 15 expect() calls
+Ran 6 tests across 1 file. [30.00ms]
+
+Summary: PASS (authenticated Dashboard /goal passes to Codex TUI; interval ambiguity is explicit; /loop and legacy paths preserved; production bundle builds; two mutations red)

--- a/docs/tests/report-test236-dashboard-codex-goal.txt
+++ b/docs/tests/report-test236-dashboard-codex-goal.txt
@@ -1,5 +1,5 @@
 # test236 — Dashboard /goal reaches shared Codex TUI
-source_commit=23f26af8e96a229ac56e33ed941400d381412006
+source_commit=050b6a0465497e9fc268f21c86d07253cb6b1bf5
 scope=authenticated Dashboard routing, /loop compatibility, legacy /goal compatibility, production wiring, mutation red
 
 $ routing-unit bun test /workspace/agent-node/src/goals/routing.test.ts /workspace/agent-node/src/inbox-dispatch.test.ts
@@ -7,36 +7,36 @@ bun test v1.3.14 (0d9b296a)
 
 agent-node/src/goals/routing.test.ts:
 (pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.26ms]
-(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.05ms]
-(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.08ms]
-(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.07ms]
-(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.80ms]
-(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.11ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.07ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.11ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.11ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.11ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.15ms]
 
 agent-node/src/inbox-dispatch.test.ts:
-(pass) isInteractiveDashboardTask > accepts a Hub-authenticated dashboard chat task [1.55ms]
-(pass) isInteractiveDashboardTask > pre-stamp admin rows stay FIFO because aliases are not auth facts [0.12ms]
-(pass) isInteractiveDashboardTask > rejects node-authenticated spoofing, malformed ids, and plain messages [0.09ms]
-(pass) dispatchInboxBatch > awaited batches preserve legacy runtime serialization [6.01ms]
-(pass) dispatchInboxBatch > a later SSE snapshot enters while the first detached turn is still running [2.03ms]
+(pass) isInteractiveDashboardTask > accepts a Hub-authenticated dashboard chat task [0.49ms]
+(pass) isInteractiveDashboardTask > pre-stamp admin rows stay FIFO because aliases are not auth facts [0.10ms]
+(pass) isInteractiveDashboardTask > rejects node-authenticated spoofing, malformed ids, and plain messages [0.07ms]
+(pass) dispatchInboxBatch > awaited batches preserve legacy runtime serialization [3.29ms]
+(pass) dispatchInboxBatch > a later SSE snapshot enters while the first detached turn is still running [1.92ms]
 (pass) dispatchInboxBatch > the real serialized drain lane can fetch a later SSE snapshot before the active turn ends [0.98ms]
-(pass) dispatchInboxBatch > detached completion failures remain observable [1.46ms]
-(pass) dispatchInboxBatch > settling detached work emits a wake for the next Hub inbox window [1.40ms]
-(pass) dispatchInboxBatch > a throwing settle callback cannot strand queued N+1 work [1.60ms]
-(pass) dispatchInboxBatch > same-tick duplicate kicks claim one row exactly once [0.56ms]
-(pass) dispatchInboxBatch > bounded admission waits N+1 and starts it after a slot settles [2.18ms]
-(pass) dispatchInboxBatch > durable reply drain waits until detached Codex rows finish [0.09ms]
-(pass) dispatchInboxBatch > active Codex direct delivery and durable drain send one reply, not two [13.34ms]
+(pass) dispatchInboxBatch > detached completion failures remain observable [1.44ms]
+(pass) dispatchInboxBatch > settling detached work emits a wake for the next Hub inbox window [1.43ms]
+(pass) dispatchInboxBatch > a throwing settle callback cannot strand queued N+1 work [1.40ms]
+(pass) dispatchInboxBatch > same-tick duplicate kicks claim one row exactly once [0.32ms]
+(pass) dispatchInboxBatch > bounded admission waits N+1 and starts it after a slot settles [1.97ms]
+(pass) dispatchInboxBatch > durable reply drain waits until detached Codex rows finish [0.06ms]
+(pass) dispatchInboxBatch > active Codex direct delivery and durable drain send one reply, not two [12.05ms]
 
  19 pass
  0 fail
- 46 expect() calls
-Ran 19 tests across 2 files. [89.00ms]
+ 47 expect() calls
+Ran 19 tests across 2 files. [78.00ms]
 
 $ production-wiring bash -ceu $'\n  cli=/workspace/agent-node/src/cli.ts\n  grep -Fq "const interactiveDashboardTask = isInteractiveDashboardTask(msg);" "$cli"\n  grep -Fq "shouldCreateScheduledGoal(persistenceSafeContent, RUNTIME, interactiveDashboardTask)" "$cli"\n  grep -Fq "const result = appendDashboardCodexGoalNotice(" "$cli"\n  grep -Fq "interactiveDashboardTask," "$cli"\n'
 
 $ production-build bash -ceu $'\n  cd /workspace/agent-node\n  bun build src/cli.ts --outfile /tmp/agent-node-cli.js --target node \\\n    --external @anthropic-ai/claude-agent-sdk \\\n    --external "@anthropic-ai/claude-agent-sdk-*" \\\n    --external @openai/codex-sdk \\\n    --external node-pty\n  test -s /tmp/agent-node-cli.js\n'
-Bundled 253 modules in 93ms
+Bundled 253 modules in 76ms
 
   agent-node-cli.js  1.91 MB  (entry point)
 
@@ -56,61 +56,61 @@ Expected: false
 Received: true
 
       at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:14:8)
-(fail) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.54ms]
-(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.10ms]
-(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.15ms]
-(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.10ms]
-(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.00ms]
-(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.16ms]
+(fail) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.42ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.07ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.09ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.07ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.86ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.14ms]
 
  5 pass
  1 fail
- 15 expect() calls
-Ran 6 tests across 1 file. [31.00ms]
+ 16 expect() calls
+Ran 6 tests across 1 file. [21.00ms]
 PASS: witnessed-red Dashboard Codex /goal mutation rc=1
 
 $ restored-green bun test /workspace/agent-node/src/goals/routing.test.ts
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/goals/routing.test.ts:
-(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.30ms]
-(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.06ms]
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.40ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.29ms]
 (pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.14ms]
-(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.11ms]
-(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.93ms]
-(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.15ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.10ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.10ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.14ms]
 
  6 pass
  0 fail
- 15 expect() calls
-Ran 6 tests across 1 file. [34.00ms]
+ 16 expect() calls
+Ran 6 tests across 1 file. [25.00ms]
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/goals/routing.test.ts:
 (pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.36ms]
-(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.07ms]
-(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.12ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.08ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.13ms]
 (pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.09ms]
 38 |       "/goal 5m 检查日志",
 39 |       "codex-app-server",
 40 |       true,
 41 |       false,
 42 |     );
-43 |     expect(reply).toBe(`目标已创建\n\n${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}`);
+43 |     expect(reply).toBe(`${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}\n\n目标已创建`);
                        ^
 error: expect(received).toBe(expected)
 
-- "目标已创建
+- "提示：已作为一次性目标处理；要定时请用 /loop <间隔> <任务>。
 -
-- 提示：已作为一次性目标处理；要定时请用 /loop <间隔> <任务>。"
+- 目标已创建"
 + "目标已创建"
 
 - Expected  - 3
 + Received  + 1
 
       at <anonymous> (/workspace/agent-node/src/goals/routing.test.ts:43:19)
-(fail) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.15ms]
-(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.16ms]
+(fail) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.17ms]
+(pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.20ms]
 
  5 pass
  1 fail
@@ -122,16 +122,16 @@ $ final-green bun test /workspace/agent-node/src/goals/routing.test.ts
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/goals/routing.test.ts:
-(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.27ms]
-(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.06ms]
-(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.12ms]
-(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.08ms]
-(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [0.78ms]
+(pass) shouldCreateScheduledGoal > passes authenticated Dashboard /goal through to the shared Codex TUI [0.31ms]
+(pass) shouldCreateScheduledGoal > keeps /loop on the recurring scheduler for Dashboard Codex TUI tasks [0.07ms]
+(pass) shouldCreateScheduledGoal > preserves the legacy /goal scheduler alias outside authenticated Dashboard Codex TUI [0.13ms]
+(pass) shouldCreateScheduledGoal > does not treat near matches or ordinary chat as scheduler commands [0.10ms]
+(pass) shouldCreateScheduledGoal > warns when Dashboard /goal text contains a scheduler interval [1.00ms]
 (pass) shouldCreateScheduledGoal > does not add a misleading notice to ordinary goals, failures, or legacy paths [0.15ms]
 
  6 pass
  0 fail
- 15 expect() calls
+ 16 expect() calls
 Ran 6 tests across 1 file. [30.00ms]
 
 Summary: PASS (authenticated Dashboard /goal passes to Codex TUI; interval ambiguity is explicit; /loop and legacy paths preserved; production bundle builds; two mutations red)

--- a/tests/test236-dashboard-codex-goal/Dockerfile
+++ b/tests/test236-dashboard-codex-goal/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+
+WORKDIR /workspace
+COPY agent-node/package.json /workspace/agent-node/package.json
+RUN cd /workspace/agent-node && bun install --ignore-scripts
+COPY agent-node /workspace/agent-node
+COPY tests/test236-dashboard-codex-goal /test236
+RUN chmod -R a+rwX /workspace/agent-node && chmod 755 /test236/run.sh
+
+ENTRYPOINT ["bash", "/test236/run.sh"]

--- a/tests/test236-dashboard-codex-goal/run.sh
+++ b/tests/test236-dashboard-codex-goal/run.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test236-dashboard-codex-goal.txt"
+mkdir -p "$ARTIFACT_DIR"
+: >"$REPORT"
+
+run() {
+  printf '\n$ %q' "$1" | tee -a "$REPORT"
+  shift
+  printf ' %q' "$@" | tee -a "$REPORT"
+  printf '\n' | tee -a "$REPORT"
+  "$@" 2>&1 | tee -a "$REPORT"
+}
+
+printf '%s\n' \
+  '# test236 — Dashboard /goal reaches shared Codex TUI' \
+  "source_commit=$SOURCE_COMMIT" \
+  'scope=authenticated Dashboard routing, /loop compatibility, legacy /goal compatibility, production wiring, mutation red' \
+  | tee -a "$REPORT"
+
+run routing-unit bun test \
+  /workspace/agent-node/src/goals/routing.test.ts \
+  /workspace/agent-node/src/inbox-dispatch.test.ts
+
+run production-wiring bash -ceu '
+  cli=/workspace/agent-node/src/cli.ts
+  grep -Fq "const interactiveDashboardTask = isInteractiveDashboardTask(msg);" "$cli"
+  grep -Fq "shouldCreateScheduledGoal(persistenceSafeContent, RUNTIME, interactiveDashboardTask)" "$cli"
+  grep -Fq "const result = appendDashboardCodexGoalNotice(" "$cli"
+  grep -Fq "interactiveDashboardTask," "$cli"
+'
+
+run production-build bash -ceu '
+  cd /workspace/agent-node
+  bun build src/cli.ts --outfile /tmp/agent-node-cli.js --target node \
+    --external @anthropic-ai/claude-agent-sdk \
+    --external "@anthropic-ai/claude-agent-sdk-*" \
+    --external @openai/codex-sdk \
+    --external node-pty
+  test -s /tmp/agent-node-cli.js
+'
+
+# Witnessed-red: remove the authenticated Dashboard Codex exception while
+# leaving the test unchanged. The screenshot's interval-free `/goal` must be
+# intercepted again, so the focused routing test has to fail.
+cp /workspace/agent-node/src/goals/routing.ts /tmp/routing.original.ts
+sed -i 's/return !(runtime === "codex-app-server" && interactiveDashboardTask);/return true;/' \
+  /workspace/agent-node/src/goals/routing.ts
+set +e
+bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/mutation.out 2>&1
+mutation_rc=$?
+set -e
+cat /tmp/mutation.out | tee -a "$REPORT"
+cp /tmp/routing.original.ts /workspace/agent-node/src/goals/routing.ts
+if test "$mutation_rc" -eq 0; then
+  printf 'FAIL: deleting the Dashboard Codex /goal exception stayed green\n' | tee -a "$REPORT"
+  exit 1
+fi
+printf 'PASS: witnessed-red Dashboard Codex /goal mutation rc=%s\n' "$mutation_rc" | tee -a "$REPORT"
+
+run restored-green bun test /workspace/agent-node/src/goals/routing.test.ts
+
+# Witnessed-red: keep the routing exception but remove the deterministic
+# interval notice from the successful reply. The ambiguity regression must be
+# observable even though the goal itself still reaches Codex.
+sed -i 's/return `${replyText}\\n\\n${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}`;/return replyText;/' \
+  /workspace/agent-node/src/goals/routing.ts
+set +e
+bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/notice-mutation.out 2>&1
+notice_mutation_rc=$?
+set -e
+cat /tmp/notice-mutation.out | tee -a "$REPORT"
+cp /tmp/routing.original.ts /workspace/agent-node/src/goals/routing.ts
+if test "$notice_mutation_rc" -eq 0; then
+  printf 'FAIL: deleting the interval ambiguity notice stayed green\n' | tee -a "$REPORT"
+  exit 1
+fi
+printf 'PASS: witnessed-red interval notice mutation rc=%s\n' "$notice_mutation_rc" | tee -a "$REPORT"
+
+run final-green bun test /workspace/agent-node/src/goals/routing.test.ts
+
+printf '\nSummary: PASS (authenticated Dashboard /goal passes to Codex TUI; interval ambiguity is explicit; /loop and legacy paths preserved; production bundle builds; two mutations red)\n' \
+  | tee -a "$REPORT"

--- a/tests/test236-dashboard-codex-goal/run.sh
+++ b/tests/test236-dashboard-codex-goal/run.sh
@@ -65,7 +65,7 @@ run restored-green bun test /workspace/agent-node/src/goals/routing.test.ts
 # Witnessed-red: keep the routing exception but remove the deterministic
 # interval notice from the successful reply. The ambiguity regression must be
 # observable even though the goal itself still reaches Codex.
-sed -i 's/return `${replyText}\\n\\n${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}`;/return replyText;/' \
+sed -i 's/return `${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}\\n\\n${replyText}`;/return replyText;/' \
   /workspace/agent-node/src/goals/routing.ts
 set +e
 bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/notice-mutation.out 2>&1

--- a/tests/test236-dashboard-codex-goal/run.sh
+++ b/tests/test236-dashboard-codex-goal/run.sh
@@ -28,7 +28,8 @@ run production-wiring bash -ceu '
   cli=/workspace/agent-node/src/cli.ts
   grep -Fq "const interactiveDashboardTask = isInteractiveDashboardTask(msg);" "$cli"
   grep -Fq "shouldCreateScheduledGoal(persistenceSafeContent, RUNTIME, interactiveDashboardTask)" "$cli"
-  grep -Fq "const result = appendDashboardCodexGoalNotice(" "$cli"
+  grep -Fq "const preparedReply = prepareDashboardCodexGoalReply(" "$cli"
+  grep -Fq "if (!preparedReply.shouldDeliver)" "$cli"
   grep -Fq "interactiveDashboardTask," "$cli"
 '
 
@@ -81,5 +82,24 @@ printf 'PASS: witnessed-red interval notice mutation rc=%s\n' "$notice_mutation_
 
 run final-green bun test /workspace/agent-node/src/goals/routing.test.ts
 
-printf '\nSummary: PASS (authenticated Dashboard /goal passes to Codex TUI; interval ambiguity is explicit; /loop and legacy paths preserved; production bundle builds; two mutations red)\n' \
+# Witnessed-red: evaluate low-value status against the raw model text instead
+# of the notice-prefixed text. A model reply of "收到" would then suppress the
+# required interval warning.
+sed -i 's/!isLowValueReply(text)/!isLowValueReply(replyText)/' \
+  /workspace/agent-node/src/goals/routing.ts
+set +e
+bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/order-mutation.out 2>&1
+order_mutation_rc=$?
+set -e
+cat /tmp/order-mutation.out | tee -a "$REPORT"
+cp /tmp/routing.original.ts /workspace/agent-node/src/goals/routing.ts
+if test "$order_mutation_rc" -eq 0; then
+  printf 'FAIL: moving notice composition after low-value filtering stayed green\n' | tee -a "$REPORT"
+  exit 1
+fi
+printf 'PASS: witnessed-red notice/filter ordering mutation rc=%s\n' "$order_mutation_rc" | tee -a "$REPORT"
+
+run order-restored-green bun test /workspace/agent-node/src/goals/routing.test.ts
+
+printf '\nSummary: PASS (authenticated Dashboard /goal passes to Codex TUI; interval ambiguity survives reply filtering/cap; /loop and legacy paths preserved; production bundle builds; three mutations red)\n' \
   | tee -a "$REPORT"


### PR DESCRIPTION
## 缺陷不是解析器写错了，是语义冲突

`parser.ts` 第一行写着 `/goal / /loop scheduler command parser`，第 16 行明确「no interval at all」是**设计上拒绝**的。所以 Dashboard 发 `/goal 更新一下…` 报「没有识别到间隔」是**按设计行为**。

但实际用法从来不带间隔。真正的冲突是：

| | |
|---|---|
| 代码定义 | `/goal` = 定时循环别名，要间隔 |
| 实际用法 | `/goal` = 设定一个目标，不要间隔 |

## 先量再改

存量审计：**31 条 goal，30 已完成，1 个 active —— 而那个 active 明确是 `/loop 5min` 建的。**

所以改 `/goal` 语义不动任何在跑的东西。

（作者同时如实说明：schema 不保存原始命令，**已完成的 30 条无法反推来源** —— 没有拿「入站日志里 `/goal` 41 次 vs `/loop` 67 次」去凑一个看起来精确的归因。）

## 改动收敛在一个条件里

```
runtime === "codex-app-server" && interactiveDashboardTask
```

`parser.ts` 改动 **0 行**，`store.ts` 改动 **0 行**。`/loop` 全路径、节点间 `/goal` 兼容别名，全部走原路。

认证事实**复用**已有的 `isInteractiveDashboardTask`（读 `auth_origin` 盖章），不重新推导 —— 一次解析、入口记录、全程携带。

## 两个作者自己抓到的静默失败

**一、末尾提示会被 2000 字上限截掉。** 长回复时提示消失，平时测不出来。改为前置，并断言「2500 字回复截到 2000 后提示仍在」。

**二、提示改变了低价值判定。** 模型只回「收到」时，以前整条被丢弃；拼上提示后不再命中低价值短语 → 现在会送达。这是行为变更，所以钉住它：

```js
predicate: (text) => text === "收到"
expect(prepared.shouldDeliver).toBe(true)
expect(prepared.text).toContain(NOTICE)
```

对应第三条 mutation：把低价值判定改回检查**原始**模型文本 → rc1。

**这条测试同时守住「提示在过滤之前」这个顺序** —— 不必指望下一个人也去读那两行的先后。

## 证据

Docker `anet-test236:dev` exact source：**20 pass / 49 assertions**，production bundle build，**三条 mutation 全 rc1**，恢复后全绿。