### PR TITLE
feat: add network-scoped SkillHub registry

### DIFF
--- a/docs/rfcs/RFC-032-skillhub-registry.md
+++ b/docs/rfcs/RFC-032-skillhub-registry.md
@@ -1,0 +1,61 @@
+# RFC-032 — Network-scoped SkillHub registry
+
+Status: implementation candidate
+
+## Goal
+
+Give agents and Dashboard users one place to submit reusable `SKILL.md`
+knowledge. A submission is not executable code and is not published
+automatically: it is an immutable text snapshot awaiting network review.
+
+## Trust and tenancy
+
+- Every row is scoped by `network_id`; reads and writes use the existing MCP
+  membership/token scope helpers.
+- A node cannot supply its own author identity. For `ntok_` callers the source
+  alias comes from the authenticated token binding. User submissions use the
+  authenticated user principal.
+- New submissions always enter `pending`. Only a network `owner` or `admin`
+  can publish or reject them. Ordinary members and nodes see published rows
+  only; pending rows return `skill_not_found` to avoid metadata disclosure.
+- `(network_id, slug, version)` is immutable. An identical retry is
+  idempotent; different content under the same version is rejected.
+- `SKILL.md` content is UTF-8 text capped at 128 KiB. Skill execution and
+  installation are deliberately out of scope for this first module.
+
+## Interfaces
+
+MCP tools:
+
+- `submit_skill` — nodes or writable members submit a version.
+- `list_skills` — published list; reviewers may request pending rows.
+- `get_skill` — fetch a single text snapshot under the same visibility rule.
+- `review_skill` — owner/admin publishes or rejects a pending row.
+
+Dashboard `/skillhub` calls these tools through its authenticated server-side
+proxy. Browser code never receives a Hub token.
+
+Example node submission:
+
+```json
+{
+  "name": "submit_skill",
+  "arguments": {
+    "slug": "incident-handoff",
+    "name": "Incident handoff",
+    "description": "Create a concise, verifiable incident handoff.",
+    "version": "1.0.0",
+    "content": "# Incident handoff\n\n..."
+  }
+}
+```
+
+The server ignores any attempted author fields because none exist in the tool
+schema. The response reports the token-bound source and `pending` status.
+
+## Compatibility and rollout
+
+The schema is additive and existing APIs are unchanged. Dashboard detects an
+older Hub and reports that the SkillHub backend is unavailable instead of
+showing fake success. Rollout order is Hub first, Dashboard second, then one
+real node upload and reviewer publish UAT.

--- a/docs/tests/report-test599-skillhub.txt
+++ b/docs/tests/report-test599-skillhub.txt
@@ -1,7 +1,8 @@
 # test599 — Dashboard SkillHub
 
 Date: 2026-08-08
-Candidate: local clean worktrees `feat/skillhub-registry` and `feat/dashboard-skillhub`
+Candidate source: Hub `b85d2579aa4e6e08e86884037f82426ee101f8ce`;
+Dashboard `424c2cb8bdae8d01b2c29de25ec36ab5513cb8f5`.
 
 ## Result
 
@@ -22,7 +23,7 @@ PASS.
 - Witnessed-red mutation removing review lookup network predicate: rc=1.
 - Restored source: 3 tests passed, 28 assertions; `RESULT: PASS`.
 - Final image digest used for the run:
-  `sha256:f622b8681403776fbccf2e7337d0c1a05c259665c0edb540c3c1734805bc014e`.
+  `sha256:9c0c86d04105d4b39ea3fa5a4c1e2ee7fc5c7a52eb127039ec64c61aed66afa9`.
 
 ### Dashboard (`anet-skillhub-dashboard:dev`)
 
@@ -33,7 +34,7 @@ PASS.
 - Generated routes include `ƒ /api/anet/skills` and `○ /skillhub`.
 - Runtime contract rerun from the built image: PASS.
 - Final image digest:
-  `sha256:9fe17bfacc225321e2a278d20beb57ea9518d93f2b57bc98034ac93e5831102c`.
+  `sha256:bca4711d2a4972e2f797be1baeefcb6539928010e4cec387d967b8bd6070950b`.
 
 Both exact test images were removed after evidence capture because the host had
 7.7 GiB free. No bulk prune or pattern deletion was used; running containers

--- a/docs/tests/report-test599-skillhub.txt
+++ b/docs/tests/report-test599-skillhub.txt
@@ -1,0 +1,45 @@
+# test599 — Dashboard SkillHub
+
+Date: 2026-08-08
+Candidate: local clean worktrees `feat/skillhub-registry` and `feat/dashboard-skillhub`
+
+## Result
+
+PASS.
+
+### Hub / registry (`anet-skillhub:dev`)
+
+- Production entry bundled: 256 modules, 1.49 MB.
+- Real private Hub process + real SQLite: 3 tests passed, 28 assertions.
+- Verified node-token author attribution cannot be replaced by a submitted
+  `source_alias` field.
+- Verified new versions are pending, identical retry is idempotent, and
+  changed content under the same version is rejected.
+- Verified node tokens cannot inherit their minting owner's reviewer role.
+- Verified owner publish makes the skill visible to nodes.
+- Verified foreign-network list/review is denied.
+- Witnessed-red mutation `pending -> published`: rc=1.
+- Witnessed-red mutation removing review lookup network predicate: rc=1.
+- Restored source: 3 tests passed, 28 assertions; `RESULT: PASS`.
+- Final image digest used for the run:
+  `sha256:f622b8681403776fbccf2e7337d0c1a05c259665c0edb540c3c1734805bc014e`.
+
+### Dashboard (`anet-skillhub-dashboard:dev`)
+
+- Contract test: PASS (desktop/mobile navigation, authenticated proxy,
+  selected-network forwarding, submit/review wiring, no browser token field).
+- `next build`: PASS, including TypeScript and all 52 static pages.
+- Generated routes include `ƒ /api/anet/skills` and `○ /skillhub`.
+- Runtime contract rerun from the built image: PASS.
+- Final image digest:
+  `sha256:66a0ce4e43785efbb73b13758aa0e4476d2c0add6e3ce5744bdbf0ee0eb2a81d`.
+
+Both exact test images were removed after evidence capture because the host had
+7.7 GiB free. No bulk prune or pattern deletion was used; running containers
+and other projects' images were untouched.
+
+## Remaining rollout gate
+
+No production deployment or public publish was performed. Required rollout:
+Hub first, Dashboard second, then one real node `submit_skill` followed by one
+owner publish and one ordinary-node readback.

--- a/docs/tests/report-test599-skillhub.txt
+++ b/docs/tests/report-test599-skillhub.txt
@@ -1,7 +1,7 @@
 # test599 — Dashboard SkillHub
 
 Date: 2026-08-08
-Candidate source: Hub `b85d2579aa4e6e08e86884037f82426ee101f8ce`;
+Candidate source: Hub `7c06fb79cd9a308b4052acf31bc662145cf271cd`;
 Dashboard `424c2cb8bdae8d01b2c29de25ec36ab5513cb8f5`.
 
 ## Result
@@ -11,7 +11,7 @@ PASS.
 ### Hub / registry (`anet-skillhub:dev`)
 
 - Production entry bundled: 256 modules, 1.49 MB.
-- Real private Hub process + real SQLite: 3 tests passed, 28 assertions.
+- Real private Hub process + real SQLite: 3 tests passed, 32 assertions.
 - Verified node-token author attribution cannot be replaced by a submitted
   `source_alias` field.
 - Verified new versions are pending, identical retry is idempotent, and
@@ -19,11 +19,12 @@ PASS.
 - Verified node tokens cannot inherit their minting owner's reviewer role.
 - Verified owner publish makes the skill visible to nodes.
 - Verified foreign-network list/review is denied.
+- Verified published detail omits internal user UUIDs and content hash.
 - Witnessed-red mutation `pending -> published`: rc=1.
 - Witnessed-red mutation removing review lookup network predicate: rc=1.
-- Restored source: 3 tests passed, 28 assertions; `RESULT: PASS`.
+- Restored source: 3 tests passed, 32 assertions; `RESULT: PASS`.
 - Final image digest used for the run:
-  `sha256:9c0c86d04105d4b39ea3fa5a4c1e2ee7fc5c7a52eb127039ec64c61aed66afa9`.
+  `sha256:6f890ab8b8d01ff67f790acfd73290bd30fbef281507b9feb78ec819066dae77`.
 
 ### Dashboard (`anet-skillhub-dashboard:dev`)
 

--- a/docs/tests/report-test599-skillhub.txt
+++ b/docs/tests/report-test599-skillhub.txt
@@ -1,8 +1,8 @@
 # test599 — Dashboard SkillHub
 
 Date: 2026-08-08
-Candidate source: Hub `7c06fb79cd9a308b4052acf31bc662145cf271cd`;
-Dashboard `424c2cb8bdae8d01b2c29de25ec36ab5513cb8f5`.
+Candidate source: Hub `faecf3cf1cef68a61d9b597ad764a87cb29c442a`;
+Dashboard `862fe6994d6c740042df3622668dd2e998688b87`.
 
 ## Result
 
@@ -11,7 +11,7 @@ PASS.
 ### Hub / registry (`anet-skillhub:dev`)
 
 - Production entry bundled: 256 modules, 1.49 MB.
-- Real private Hub process + real SQLite: 3 tests passed, 32 assertions.
+- Real private Hub process + real SQLite: 3 tests passed, 36 assertions.
 - Verified node-token author attribution cannot be replaced by a submitted
   `source_alias` field.
 - Verified new versions are pending, identical retry is idempotent, and
@@ -20,11 +20,13 @@ PASS.
 - Verified owner publish makes the skill visible to nodes.
 - Verified foreign-network list/review is denied.
 - Verified published detail omits internal user UUIDs and content hash.
+- Verified concurrent different-content submissions under one version resolve
+  to one winner plus one clean `skill_version_conflict`, never a storage 500.
 - Witnessed-red mutation `pending -> published`: rc=1.
 - Witnessed-red mutation removing review lookup network predicate: rc=1.
-- Restored source: 3 tests passed, 32 assertions; `RESULT: PASS`.
+- Restored source: 3 tests passed, 36 assertions; `RESULT: PASS`.
 - Final image digest used for the run:
-  `sha256:6f890ab8b8d01ff67f790acfd73290bd30fbef281507b9feb78ec819066dae77`.
+  `sha256:2c780f03ec24ac245807ae8ff2037e7a87dbadeb8cc1fdf4cdcb8ab7d36bca2c`.
 
 ### Dashboard (`anet-skillhub-dashboard:dev`)
 
@@ -35,7 +37,7 @@ PASS.
 - Generated routes include `ƒ /api/anet/skills` and `○ /skillhub`.
 - Runtime contract rerun from the built image: PASS.
 - Final image digest:
-  `sha256:bca4711d2a4972e2f797be1baeefcb6539928010e4cec387d967b8bd6070950b`.
+  `sha256:2bab6eee16f354fb1738d5dfb7a6bec249a78de5d0dc6397512c2978504af3d6`.
 
 Both exact test images were removed after evidence capture because the host had
 7.7 GiB free. No bulk prune or pattern deletion was used; running containers

--- a/docs/tests/report-test599-skillhub.txt
+++ b/docs/tests/report-test599-skillhub.txt
@@ -28,11 +28,12 @@ PASS.
 
 - Contract test: PASS (desktop/mobile navigation, authenticated proxy,
   selected-network forwarding, submit/review wiring, no browser token field).
+- Targeted ESLint: 0 errors (one pre-existing Sidebar navigation warning).
 - `next build`: PASS, including TypeScript and all 52 static pages.
 - Generated routes include `ƒ /api/anet/skills` and `○ /skillhub`.
 - Runtime contract rerun from the built image: PASS.
 - Final image digest:
-  `sha256:66a0ce4e43785efbb73b13758aa0e4476d2c0add6e3ce5744bdbf0ee0eb2a81d`.
+  `sha256:9fe17bfacc225321e2a278d20beb57ea9518d93f2b57bc98034ac93e5831102c`.
 
 Both exact test images were removed after evidence capture because the host had
 7.7 GiB free. No bulk prune or pattern deletion was used; running containers

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -634,6 +634,37 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_audit_network ON audit_log(network_id);
 `);
 
+// SkillHub — immutable, network-scoped skill submissions. A (network, slug,
+// version) tuple is write-once: retries with the same content are idempotent,
+// while different content must use a new version. Node submissions remain
+// pending until an owner/admin explicitly publishes them.
+db.exec(`
+  CREATE TABLE IF NOT EXISTS skillhub_skills (
+    skill_id          TEXT PRIMARY KEY,
+    network_id        TEXT NOT NULL,
+    slug              TEXT NOT NULL,
+    name              TEXT NOT NULL,
+    description       TEXT NOT NULL DEFAULT '',
+    version           TEXT NOT NULL,
+    content           TEXT NOT NULL,
+    content_hash      TEXT NOT NULL,
+    status            TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'published', 'rejected', 'archived')),
+    source_type       TEXT NOT NULL CHECK(source_type IN ('node', 'user')),
+    source_alias      TEXT,
+    created_by_user   TEXT,
+    reviewed_by_user  TEXT,
+    review_note       TEXT,
+    created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
+    reviewed_at       TEXT,
+    UNIQUE(network_id, slug, version)
+  );
+  CREATE INDEX IF NOT EXISTS idx_skillhub_network_status
+    ON skillhub_skills(network_id, status, updated_at DESC);
+  CREATE INDEX IF NOT EXISTS idx_skillhub_network_slug
+    ON skillhub_skills(network_id, slug, version);
+`);
+
 // ── V3: licenses table ──
 db.exec(`
   CREATE TABLE IF NOT EXISTS licenses (

--- a/server/src/skillhub-http.test.ts
+++ b/server/src/skillhub-http.test.ts
@@ -55,6 +55,13 @@ describe("SkillHub real Hub + SQLite", () => {
     expect(retry.idempotent).toBe(true); expect(retry.skill_id).toBe(skillId);
     const conflict = await tool(nodeToken, "submit_skill", { ...input, content: "changed" });
     expect(conflict.error).toBe("skill_version_conflict");
+    const raceBase = { ...input, slug: "concurrent-version", version: "2.0.0" };
+    const raced = await Promise.all([
+      tool(nodeToken, "submit_skill", { ...raceBase, content: "winner-a" }),
+      tool(nodeToken, "submit_skill", { ...raceBase, content: "winner-b" }),
+    ]);
+    expect(raced.filter(x => x.ok).length).toBe(1);
+    expect(raced.filter(x => x.error === "skill_version_conflict").length).toBe(1);
   });
 
   test("pending is reviewer-only; owner publishes; published becomes visible", async () => {

--- a/server/src/skillhub-http.test.ts
+++ b/server/src/skillhub-http.test.ts
@@ -69,6 +69,8 @@ describe("SkillHub real Hub + SQLite", () => {
     const published = await tool(nodeToken, "list_skills", { network_id: networkId });
     expect(published.skills.map((x: any) => x.skill_id)).toContain(skillId);
     expect((await tool(nodeToken, "get_skill", { network_id: networkId, skill_id: skillId })).skill.skill_id).toBe(skillId);
+    const detail = (await tool(nodeToken, "get_skill", { network_id: networkId, skill_id: skillId })).skill;
+    expect(detail.created_by_user).toBeUndefined(); expect(detail.reviewed_by_user).toBeUndefined(); expect(detail.content_hash).toBeUndefined();
   });
 
   test("foreign user cannot read or review another network", async () => {

--- a/server/src/skillhub-http.test.ts
+++ b/server/src/skillhub-http.test.ts
@@ -69,7 +69,7 @@ describe("SkillHub real Hub + SQLite", () => {
     expect(nodeList.skills).toHaveLength(0);
     expect((await tool(nodeToken, "get_skill", { network_id: networkId, skill_id: skillId })).error).toBe("skill_not_found");
     const ownerList = await tool(ownerToken, "list_skills", { network_id: networkId, include_pending: true });
-    expect(ownerList.reviewer).toBe(true); expect(ownerList.skills[0].skill_id).toBe(skillId);
+    expect(ownerList.reviewer).toBe(true); expect(ownerList.skills.map((x: any) => x.skill_id)).toContain(skillId);
     expect((await tool(ownerToken, "get_skill", { network_id: networkId, skill_id: skillId })).skill.content).toContain("Verify facts");
     const reviewed = await tool(ownerToken, "review_skill", { network_id: networkId, skill_id: skillId, decision: "published" });
     expect(reviewed.status).toBe("published");

--- a/server/src/skillhub-http.test.ts
+++ b/server/src/skillhub-http.test.ts
@@ -1,0 +1,79 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createNetworkTokenForNode, register } from "./auth.js";
+import { db } from "./db.js";
+
+const dir = mkdtempSync(join(tmpdir(), "anet-skillhub-"));
+let server: any;
+let base = "";
+let ownerToken = "";
+let nodeToken = "";
+let foreignToken = "";
+let networkId = "";
+
+async function tool(token: string, name: string, args: Record<string, unknown>) {
+  const res = await fetch(`${base}/mcp`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json", Accept: "application/json, text/event-stream", "MCP-Protocol-Version": "2025-03-26" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } }),
+  });
+  expect(res.status).toBe(200);
+  const raw = await res.text();
+  const dataLines = raw.split("\n").filter(x => x.startsWith("data:"));
+  const payload = dataLines.length
+    ? JSON.parse(dataLines.at(-1)!.slice(5).trim())
+    : JSON.parse(raw);
+  return JSON.parse(payload.result.content[0].text);
+}
+
+beforeAll(async () => {
+  process.env.COMMHUB_DB = join(dir, "hub.db");
+  const owner = register(`skill_owner_${Date.now()}`, "SkillHubOwner123!", undefined, "seed");
+  expect(owner.ok).toBe(true);
+  ownerToken = owner.token!; networkId = owner.network_id!;
+  const ownerId = db.get<{ user_id: string }>("SELECT owner_id AS user_id FROM networks WHERE network_id = ?1", networkId)!.user_id;
+  const node = createNetworkTokenForNode(ownerId, networkId, "skill-writer");
+  expect(node.ok).toBe(true); nodeToken = node.token!;
+  const foreign = register(`skill_foreign_${Date.now()}`, "SkillHubForeign123!", undefined, "seed");
+  expect(foreign.ok).toBe(true); foreignToken = foreign.token!;
+  const mod: any = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => { try { server?.stop?.(true); } catch {} try { rmSync(dir, { recursive: true, force: true }); } catch {} });
+
+describe("SkillHub real Hub + SQLite", () => {
+  let skillId = "";
+  test("node submit is token-attributed, pending and immutable/idempotent", async () => {
+    const input = { network_id: networkId, slug: "incident-handoff", name: "Incident handoff", version: "1.0.0", description: "handoff", content: "# Incident handoff\n\nVerify facts." };
+    const first = await tool(nodeToken, "submit_skill", { ...input, source_alias: "forged-admin" });
+    expect(first.ok).toBe(true); expect(first.status).toBe("pending"); expect(first.source_alias).toBe("skill-writer"); skillId = first.skill_id;
+    const retry = await tool(nodeToken, "submit_skill", input);
+    expect(retry.idempotent).toBe(true); expect(retry.skill_id).toBe(skillId);
+    const conflict = await tool(nodeToken, "submit_skill", { ...input, content: "changed" });
+    expect(conflict.error).toBe("skill_version_conflict");
+  });
+
+  test("pending is reviewer-only; owner publishes; published becomes visible", async () => {
+    const nodeList = await tool(nodeToken, "list_skills", { network_id: networkId, include_pending: true });
+    expect(nodeList.skills).toHaveLength(0);
+    expect((await tool(nodeToken, "get_skill", { network_id: networkId, skill_id: skillId })).error).toBe("skill_not_found");
+    const ownerList = await tool(ownerToken, "list_skills", { network_id: networkId, include_pending: true });
+    expect(ownerList.reviewer).toBe(true); expect(ownerList.skills[0].skill_id).toBe(skillId);
+    expect((await tool(ownerToken, "get_skill", { network_id: networkId, skill_id: skillId })).skill.content).toContain("Verify facts");
+    const reviewed = await tool(ownerToken, "review_skill", { network_id: networkId, skill_id: skillId, decision: "published" });
+    expect(reviewed.status).toBe("published");
+    const published = await tool(nodeToken, "list_skills", { network_id: networkId });
+    expect(published.skills.map((x: any) => x.skill_id)).toContain(skillId);
+    expect((await tool(nodeToken, "get_skill", { network_id: networkId, skill_id: skillId })).skill.skill_id).toBe(skillId);
+  });
+
+  test("foreign user cannot read or review another network", async () => {
+    expect((await tool(foreignToken, "list_skills", { network_id: networkId })).ok).toBe(false);
+    const review = await tool(foreignToken, "review_skill", { network_id: networkId, skill_id: skillId, decision: "rejected" });
+    expect(review.ok).toBe(false);
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -188,12 +188,29 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         return skillHubReply({ ok: false, error: "skill_version_conflict", hint: "publish changed content under a new version" });
       }
       const skillId = `skill_${uuidv4()}`;
-      db.run(
-        `INSERT INTO skillhub_skills
-         (skill_id, network_id, slug, name, description, version, content, content_hash, status, source_type, source_alias, created_by_user)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'pending', ?9, ?10, ?11)`,
-        [skillId, effectiveNetId, slug, name.trim(), description?.trim() || "", version, content, contentHash, sourceType, callerAlias, enforceUserId || null],
-      );
+      try {
+        db.run(
+          `INSERT INTO skillhub_skills
+           (skill_id, network_id, slug, name, description, version, content, content_hash, status, source_type, source_alias, created_by_user)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'pending', ?9, ?10, ?11)`,
+          [skillId, effectiveNetId, slug, name.trim(), description?.trim() || "", version, content, contentHash, sourceType, callerAlias, enforceUserId || null],
+        );
+      } catch (error: any) {
+        // Two submitters may pass the preflight SELECT together. Resolve the
+        // UNIQUE race into the same deterministic idempotent/conflict contract
+        // instead of leaking a storage exception as HTTP/MCP 500.
+        if (!/unique|duplicate key/i.test(error?.message || "")) throw error;
+        const winner = db.get<any>(
+          `SELECT skill_id, content_hash, status FROM skillhub_skills
+           WHERE network_id = ?1 AND slug = ?2 AND version = ?3`,
+          effectiveNetId, slug, version,
+        );
+        if (!winner) throw error;
+        if (winner.content_hash === contentHash) {
+          return skillHubReply({ ok: true, idempotent: true, skill_id: winner.skill_id, status: winner.status });
+        }
+        return skillHubReply({ ok: false, error: "skill_version_conflict", hint: "publish changed content under a new version" });
+      }
       db.run(
         `INSERT INTO audit_log (user_id, username, action, target_type, target_id, detail, network_id)
          VALUES (?1, ?2, 'skill_submit', 'skill', ?3, ?4, ?5)`,

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
+import { createHash } from "node:crypto";
 import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken } from "./db.js";
 import { pushEvent, pushNetworkObserverEvent } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
@@ -149,6 +150,141 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     }
     return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error, message }) }] };
   };
+
+  const skillHubReply = (value: Record<string, unknown>) => ({
+    content: [{ type: "text" as const, text: JSON.stringify(value) }],
+  });
+
+  // SkillHub is a network registry, not a public filesystem. Content is an
+  // immutable SKILL.md snapshot; identity comes only from the authenticated
+  // MCP principal (never from request fields).
+  server.tool(
+    "submit_skill",
+    "Submit an immutable SKILL.md version to the caller's network SkillHub. Node identity is token-bound. New submissions require review.",
+    {
+      slug: z.string().min(2).max(80).regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+      name: z.string().min(1).max(120),
+      description: z.string().max(1000).optional(),
+      version: z.string().min(1).max(40).regex(/^[0-9A-Za-z]+(?:[._-][0-9A-Za-z]+)*$/),
+      content: z.string().min(1).max(128 * 1024).refine(value => !value.includes("\0"), "content must not contain NUL bytes"),
+      network_id: z.string().max(200).optional(),
+    },
+    async ({ slug, name, description, version, content, network_id: clientNetId }) => {
+      const effectiveNetId = getNetworkId(clientNetId);
+      if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId, "write");
+      if (!effectiveNetId) return writeDeniedReply(effectiveNetId, "write");
+      const sourceType = callerTokenIsNetwork ? "node" : "user";
+      if (sourceType === "node" && !callerAlias) return skillHubReply({ ok: false, error: "node_identity_unbound" });
+      const contentHash = createHash("sha256").update(content, "utf8").digest("hex");
+      const existing = db.get<any>(
+        `SELECT skill_id, content_hash, status FROM skillhub_skills
+         WHERE network_id = ?1 AND slug = ?2 AND version = ?3`,
+        effectiveNetId, slug, version,
+      );
+      if (existing) {
+        if (existing.content_hash === contentHash) {
+          return skillHubReply({ ok: true, idempotent: true, skill_id: existing.skill_id, status: existing.status });
+        }
+        return skillHubReply({ ok: false, error: "skill_version_conflict", hint: "publish changed content under a new version" });
+      }
+      const skillId = `skill_${uuidv4()}`;
+      db.run(
+        `INSERT INTO skillhub_skills
+         (skill_id, network_id, slug, name, description, version, content, content_hash, status, source_type, source_alias, created_by_user)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'pending', ?9, ?10, ?11)`,
+        [skillId, effectiveNetId, slug, name.trim(), description?.trim() || "", version, content, contentHash, sourceType, callerAlias, enforceUserId || null],
+      );
+      db.run(
+        `INSERT INTO audit_log (user_id, username, action, target_type, target_id, detail, network_id)
+         VALUES (?1, ?2, 'skill_submit', 'skill', ?3, ?4, ?5)`,
+        [enforceUserId || null, callerAlias || null, skillId, JSON.stringify({ slug, version, source_type: sourceType }), effectiveNetId],
+      );
+      return skillHubReply({ ok: true, skill_id: skillId, status: "pending", source_type: sourceType, source_alias: callerAlias });
+    },
+  );
+
+  server.tool(
+    "list_skills",
+    "List published skills in a network. Owners/admins may include pending review items.",
+    {
+      network_id: z.string().max(200).optional(),
+      include_pending: z.boolean().optional(),
+      query: z.string().max(120).optional(),
+      limit: z.number().int().min(1).max(200).optional(),
+    },
+    async ({ network_id: clientNetId, include_pending, query, limit }) => {
+      const effectiveNetId = getNetworkId(clientNetId);
+      if (!effectiveNetId) return writeDeniedReply(effectiveNetId, "read");
+      const role = enforceUserId ? getUserNetworkRole(enforceUserId, effectiveNetId) : null;
+      if (enforceUserId && !role) return writeDeniedReply(effectiveNetId, "read");
+      // An ntok_ belongs to a node even when it was minted by the network
+      // owner. Never inherit the owner's review power through that token.
+      const reviewer = !callerTokenIsNetwork && (role === "owner" || role === "admin");
+      const showPending = !!include_pending && reviewer;
+      const params: unknown[] = [effectiveNetId];
+      let sql = `SELECT skill_id, slug, name, description, version, status, source_type, source_alias,
+                        created_at, updated_at, reviewed_at, review_note
+                   FROM skillhub_skills WHERE network_id = ?1`;
+      if (!showPending) sql += ` AND status = 'published'`;
+      if (query?.trim()) {
+        params.push(`%${query.trim()}%`);
+        sql += ` AND (slug LIKE ?${params.length} OR name LIKE ?${params.length} OR description LIKE ?${params.length})`;
+      }
+      sql += ` ORDER BY updated_at DESC LIMIT ${limit ?? 100}`;
+      return skillHubReply({ ok: true, reviewer, skills: db.all(sql, ...params) });
+    },
+  );
+
+  server.tool(
+    "get_skill",
+    "Read one SkillHub SKILL.md. Pending content is visible only to owners/admins.",
+    { skill_id: z.string().regex(/^skill_[A-Za-z0-9_-]+$/).max(200), network_id: z.string().max(200).optional() },
+    async ({ skill_id, network_id: clientNetId }) => {
+      const effectiveNetId = getNetworkId(clientNetId);
+      if (!effectiveNetId) return writeDeniedReply(effectiveNetId, "read");
+      const role = enforceUserId ? getUserNetworkRole(enforceUserId, effectiveNetId) : null;
+      if (enforceUserId && !role) return writeDeniedReply(effectiveNetId, "read");
+      const row = db.get<any>(`SELECT * FROM skillhub_skills WHERE skill_id = ?1 AND network_id = ?2`, skill_id, effectiveNetId);
+      if (!row) return skillHubReply({ ok: false, error: "skill_not_found" });
+      const reviewer = !callerTokenIsNetwork && (role === "owner" || role === "admin");
+      if (row.status !== "published" && !reviewer) {
+        return skillHubReply({ ok: false, error: "skill_not_found" });
+      }
+      return skillHubReply({ ok: true, skill: row });
+    },
+  );
+
+  server.tool(
+    "review_skill",
+    "Publish or reject a pending SkillHub submission. Network owner/admin only.",
+    {
+      skill_id: z.string().regex(/^skill_[A-Za-z0-9_-]+$/).max(200),
+      decision: z.enum(["published", "rejected"]),
+      note: z.string().max(1000).optional(),
+      network_id: z.string().max(200).optional(),
+    },
+    async ({ skill_id, decision, note, network_id: clientNetId }) => {
+      const effectiveNetId = getNetworkId(clientNetId);
+      if (!effectiveNetId) return writeDeniedReply(effectiveNetId, "write");
+      const role = enforceUserId ? getUserNetworkRole(enforceUserId, effectiveNetId) : null;
+      if (callerTokenIsNetwork || (role !== "owner" && role !== "admin")) return skillHubReply({ ok: false, error: "skill_review_admin_required" });
+      const row = db.get<any>(`SELECT status FROM skillhub_skills WHERE skill_id = ?1 AND network_id = ?2`, skill_id, effectiveNetId);
+      if (!row) return skillHubReply({ ok: false, error: "skill_not_found" });
+      if (row.status !== "pending") return skillHubReply({ ok: false, error: "skill_not_pending", status: row.status });
+      const updated = db.run(
+        `UPDATE skillhub_skills SET status = ?1, review_note = ?2, reviewed_by_user = ?3,
+         reviewed_at = datetime('now'), updated_at = datetime('now') WHERE skill_id = ?4 AND network_id = ?5 AND status = 'pending'`,
+        [decision, note?.trim() || null, enforceUserId || null, skill_id, effectiveNetId],
+      );
+      if (updated.changes !== 1) return skillHubReply({ ok: false, error: "skill_not_pending" });
+      db.run(
+        `INSERT INTO audit_log (user_id, username, action, target_type, target_id, detail, network_id)
+         VALUES (?1, ?2, 'skill_review', 'skill', ?3, ?4, ?5)`,
+        [enforceUserId || null, callerAlias || null, skill_id, JSON.stringify({ decision }), effectiveNetId],
+      );
+      return skillHubReply({ ok: true, skill_id, status: decision });
+    },
+  );
 
   const addScope = (sql: string, params: any[], networkId?: string | null, column = "network_id"): string => {
     if (!networkId) return sql;

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -244,7 +244,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       if (!effectiveNetId) return writeDeniedReply(effectiveNetId, "read");
       const role = enforceUserId ? getUserNetworkRole(enforceUserId, effectiveNetId) : null;
       if (enforceUserId && !role) return writeDeniedReply(effectiveNetId, "read");
-      const row = db.get<any>(`SELECT * FROM skillhub_skills WHERE skill_id = ?1 AND network_id = ?2`, skill_id, effectiveNetId);
+      const row = db.get<any>(
+        `SELECT skill_id, slug, name, description, version, content, status,
+                source_type, source_alias, created_at, updated_at, reviewed_at, review_note
+           FROM skillhub_skills WHERE skill_id = ?1 AND network_id = ?2`,
+        skill_id, effectiveNetId,
+      );
       if (!row) return skillHubReply({ ok: false, error: "skill_not_found" });
       const reviewer = !callerTokenIsNetwork && (role === "owner" || role === "admin");
       if (row.status !== "published" && !reviewer) {

--- a/tests/test599-skillhub/Dockerfile
+++ b/tests/test599-skillhub/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test599-skillhub ./tests/test599-skillhub
+ARG SOURCE_COMMIT
+ENV TEST599_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test599-skillhub/run.sh
+ENTRYPOINT ["/workspace/tests/test599-skillhub/run.sh"]

--- a/tests/test599-skillhub/run.sh
+++ b/tests/test599-skillhub/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test599-skillhub.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test599 — network-scoped SkillHub"
+echo "source_commit=${TEST599_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_real() {
+  local db_path=$1
+  COMMHUB_DB="$db_path" bun test server/src/skillhub-http.test.ts
+}
+
+expect_red() {
+  local label=$1 db_path=$2
+  set +e
+  run_real "$db_path" >/tmp/test599-red.log 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "MUTATION_FALSE_GREEN: $label"
+    sed -n '1,180p' /tmp/test599-red.log
+    exit 1
+  fi
+  echo "MUTATION_RED: $label rc=$rc"
+}
+
+echo "L0 build + schema"
+bun build server/src/index.ts --target bun --outfile /tmp/commhub-skillhub.js
+test -s /tmp/commhub-skillhub.js
+grep -Fq 'CREATE TABLE IF NOT EXISTS skillhub_skills' server/src/db.ts
+
+echo "L1-L4 real Hub, auth, idempotency, review and tenant isolation"
+run_real /tmp/test599-green.db
+
+echo "L5 witnessed-red: pending cannot silently publish"
+cp server/src/tools.ts /tmp/test599-tools.ts
+sed -i "0,/'pending', ?9/s//'published', ?9/" server/src/tools.ts
+grep -Fq "'published', ?9" server/src/tools.ts
+expect_red pending-review-required /tmp/test599-mut-publish.db
+cp /tmp/test599-tools.ts server/src/tools.ts
+
+echo "L6 witnessed-red: network predicate is load-bearing"
+sed -i 's/SELECT status FROM skillhub_skills WHERE skill_id = ?1 AND network_id = ?2/SELECT status FROM skillhub_skills WHERE skill_id = ?1/' server/src/tools.ts
+grep -Fq 'SELECT status FROM skillhub_skills WHERE skill_id = ?1`' server/src/tools.ts
+expect_red cross-network-review-denied /tmp/test599-mut-tenant.db
+cp /tmp/test599-tools.ts server/src/tools.ts
+
+echo "L7 restored green"
+run_real /tmp/test599-restored.db
+echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- add an immutable, network-scoped SkillHub registry
- expose `submit_skill`, `list_skills`, `get_skill`, and `review_skill` MCP tools
- bind node authorship to authenticated ntok aliases and keep submissions pending until owner/admin review
- add idempotent version handling, concurrent conflict resolution, explicit detail projections, audit rows, RFC-032, and Docker evidence

## Why

Dashboard users and agent nodes need a safe shared place to turn operational knowledge into reusable `SKILL.md` assets without allowing cross-network reads, identity spoofing, or automatic publication.

## Validation

- real Hub process + real SQLite: 3 tests, 36 assertions
- pending/publication and cross-network mutation gates witnessed red
- Docker source provenance pinned to `faecf3cf1cef68a61d9b597ad764a87cb29c442a`
- independent review: 0 BLOCKER / 0 MAJOR

Deployment order: Hub first, Dashboard second. No npm publish in this PR.