### PR TITLE
feat: add public SkillHub catalog to anet.sh

### DIFF
--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -40,6 +40,7 @@ export default withMermaid(defineConfig({
       themeConfig: {
         nav: [
           { text: '指南', link: '/guide/getting-started' },
+          { text: 'SkillHub', link: '/skillhub/' },
           { text: 'API', link: '/api/mcp-tools' },
           { text: '生态', link: '/ecosystem' },
           { text: '社群', link: '/community' },
@@ -139,6 +140,7 @@ export default withMermaid(defineConfig({
       themeConfig: {
         nav: [
           { text: 'Guide', link: '/en/guide/getting-started' },
+          { text: 'SkillHub', link: '/en/skillhub/' },
           { text: 'API', link: '/en/api/mcp-tools' },
           { text: 'Ecosystem', link: '/en/ecosystem' },
           { text: 'Community', link: '/en/community' },

--- a/docs-site/docs/.vitepress/theme/PublicSkillHub.vue
+++ b/docs-site/docs/.vitepress/theme/PublicSkillHub.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { withBase } from 'vitepress'
+
+type Skill = {
+  slug: string
+  name: string
+  description: string
+  version: string
+  license: string
+  publisher: { name: string; url?: string }
+  tags: string[]
+  published_at: string
+  content_sha256: string
+  content_url: string
+}
+
+const props = withDefaults(defineProps<{ lang?: 'zh' | 'en' }>(), { lang: 'zh' })
+const skills = ref<Skill[]>([])
+const query = ref('')
+const loading = ref(true)
+const error = ref('')
+const selected = ref<Skill | null>(null)
+const content = ref('')
+const contentLoading = ref(false)
+const copied = ref(false)
+
+const t = computed(() => props.lang === 'en' ? {
+  search: 'Search skills, publishers, or tags…', empty: 'No public skills match this search.',
+  view: 'View SKILL.md', download: 'Download', copy: 'Copy', copied: 'Copied', close: 'Close',
+  loadError: 'The public SkillHub catalog is temporarily unavailable.',
+  contentError: 'This skill could not be loaded.', reviewed: 'Publicly reviewed',
+} : {
+  search: '搜索 Skill、发布者或标签…', empty: '没有匹配的公共 Skill。',
+  view: '查看 SKILL.md', download: '下载', copy: '复制', copied: '已复制', close: '关闭',
+  loadError: '公共 SkillHub 目录暂时不可用。', contentError: '无法读取这份 Skill。',
+  reviewed: '已通过公共审核',
+})
+
+const filtered = computed(() => {
+  const needle = query.value.trim().toLocaleLowerCase()
+  if (!needle) return skills.value
+  return skills.value.filter(skill => [
+    skill.slug, skill.name, skill.description, skill.publisher.name, ...skill.tags,
+  ].some(value => value.toLocaleLowerCase().includes(needle)))
+})
+
+onMounted(async () => {
+  try {
+    const response = await fetch(withBase('/skillhub/catalog.json'), { cache: 'no-store' })
+    if (!response.ok) throw new Error(`catalog HTTP ${response.status}`)
+    const payload = await response.json()
+    if (payload?.schema_version !== 1 || !Array.isArray(payload.skills)) throw new Error('invalid catalog')
+    skills.value = payload.skills
+  } catch (cause) {
+    console.error(cause)
+    error.value = t.value.loadError
+  } finally {
+    loading.value = false
+  }
+})
+
+async function openSkill(skill: Skill) {
+  selected.value = skill
+  content.value = ''
+  copied.value = false
+  contentLoading.value = true
+  try {
+    const response = await fetch(withBase(skill.content_url), { cache: 'no-store' })
+    if (!response.ok) throw new Error(`content HTTP ${response.status}`)
+    content.value = await response.text()
+  } catch (cause) {
+    console.error(cause)
+    content.value = t.value.contentError
+  } finally {
+    contentLoading.value = false
+  }
+}
+
+async function copyContent() {
+  if (!content.value) return
+  await navigator.clipboard.writeText(content.value)
+  copied.value = true
+  window.setTimeout(() => { copied.value = false }, 1600)
+}
+</script>
+
+<template>
+  <section class="public-skillhub" aria-label="Public SkillHub catalog">
+    <div class="skillhub-toolbar">
+      <input v-model="query" type="search" :placeholder="t.search" :aria-label="t.search">
+      <span class="skill-count">{{ filtered.length }} / {{ skills.length }}</span>
+    </div>
+
+    <p v-if="error" class="skillhub-message skillhub-error">{{ error }}</p>
+    <div v-else-if="loading" class="skill-grid" aria-busy="true">
+      <div v-for="index in 3" :key="index" class="skill-card skill-skeleton" />
+    </div>
+    <p v-else-if="filtered.length === 0" class="skillhub-message">{{ t.empty }}</p>
+    <div v-else class="skill-grid">
+      <article v-for="skill in filtered" :key="`${skill.slug}@${skill.version}`" class="skill-card">
+        <div class="skill-card-heading">
+          <div>
+            <h2>{{ skill.name }}</h2>
+            <code>{{ skill.slug }}@{{ skill.version }}</code>
+          </div>
+          <span class="review-badge">{{ t.reviewed }}</span>
+        </div>
+        <p>{{ skill.description }}</p>
+        <div class="skill-tags">
+          <span v-for="tag in skill.tags" :key="tag">{{ tag }}</span>
+        </div>
+        <dl>
+          <div><dt>Publisher</dt><dd><a v-if="skill.publisher.url" :href="skill.publisher.url" rel="noopener noreferrer">{{ skill.publisher.name }}</a><span v-else>{{ skill.publisher.name }}</span></dd></div>
+          <div><dt>License</dt><dd>{{ skill.license }}</dd></div>
+          <div><dt>SHA-256</dt><dd><code>{{ skill.content_sha256.slice(0, 12) }}</code></dd></div>
+        </dl>
+        <button type="button" class="skill-primary" @click="openSkill(skill)">{{ t.view }}</button>
+      </article>
+    </div>
+
+    <div v-if="selected" class="skill-modal-backdrop" @mousedown.self="selected = null">
+      <section class="skill-modal" role="dialog" aria-modal="true" :aria-label="selected.name">
+        <header>
+          <div><h2>{{ selected.name }}</h2><code>{{ selected.slug }}@{{ selected.version }}</code></div>
+          <button type="button" class="skill-close" @click="selected = null">{{ t.close }}</button>
+        </header>
+        <p v-if="contentLoading" class="skillhub-message" aria-busy="true">…</p>
+        <pre v-else>{{ content }}</pre>
+        <footer>
+          <a :href="withBase(selected.content_url)" download>{{ t.download }}</a>
+          <button type="button" @click="copyContent">{{ copied ? t.copied : t.copy }}</button>
+        </footer>
+      </section>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.public-skillhub { margin-top: 28px; }
+.skillhub-toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 22px; }
+.skillhub-toolbar input { flex: 1; min-width: 0; border: 1px solid var(--vp-c-divider); border-radius: 12px; background: var(--vp-c-bg-soft); color: var(--vp-c-text-1); padding: 11px 14px; font: inherit; }
+.skillhub-toolbar input:focus { border-color: var(--vp-c-brand-1); outline: 2px solid var(--vp-c-brand-soft); }
+.skill-count { color: var(--vp-c-text-2); font-size: 13px; white-space: nowrap; }
+.skill-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+.skill-card { display: flex; min-height: 280px; flex-direction: column; gap: 14px; border: 1px solid var(--vp-c-divider); border-radius: 16px; background: var(--vp-c-bg-soft); padding: 18px; }
+.skill-card-heading { display: flex; align-items: flex-start; gap: 12px; }
+.skill-card-heading > div { min-width: 0; flex: 1; }
+.skill-card h2, .skill-modal h2 { margin: 0; border: 0; padding: 0; font-size: 18px; line-height: 1.35; }
+.skill-card code, .skill-modal header code { color: var(--vp-c-brand-1); font-size: 12px; }
+.skill-card > p { margin: 0; color: var(--vp-c-text-2); font-size: 14px; line-height: 1.6; }
+.review-badge { flex: none; border-radius: 999px; background: var(--vp-c-brand-soft); color: var(--vp-c-brand-1); padding: 4px 8px; font-size: 10px; }
+.skill-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+.skill-tags span { border: 1px solid var(--vp-c-divider); border-radius: 999px; padding: 3px 7px; color: var(--vp-c-text-2); font-size: 11px; }
+.skill-card dl { display: grid; gap: 5px; margin: auto 0 0; font-size: 12px; }
+.skill-card dl div { display: grid; grid-template-columns: 72px 1fr; gap: 8px; min-width: 0; }
+.skill-card dt { color: var(--vp-c-text-3); }
+.skill-card dd { min-width: 0; margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.skill-primary, .skill-modal footer button, .skill-modal footer a { border: 0; border-radius: 10px; background: var(--vp-c-brand-1); color: var(--vp-c-bg); padding: 9px 12px; font: inherit; font-size: 13px; font-weight: 600; text-align: center; cursor: pointer; text-decoration: none; }
+.skillhub-message { border: 1px dashed var(--vp-c-divider); border-radius: 14px; padding: 28px; color: var(--vp-c-text-2); text-align: center; }
+.skillhub-error { border-style: solid; color: var(--vp-c-danger-1); }
+.skill-skeleton { min-height: 280px; animation: skill-pulse 1.4s ease-in-out infinite; }
+.skill-modal-backdrop { position: fixed; z-index: 100; inset: 0; display: grid; place-items: center; padding: 24px; background: color-mix(in srgb, var(--vp-c-bg) 76%, transparent); backdrop-filter: blur(8px); }
+.skill-modal { display: flex; width: min(880px, 100%); max-height: 88vh; flex-direction: column; border: 1px solid var(--vp-c-divider); border-radius: 18px; background: var(--vp-c-bg); box-shadow: var(--vp-shadow-5); padding: 20px; }
+.skill-modal header { display: flex; align-items: flex-start; gap: 12px; }
+.skill-modal header > div { min-width: 0; flex: 1; }
+.skill-close { border: 1px solid var(--vp-c-divider); border-radius: 8px; background: transparent; color: var(--vp-c-text-2); padding: 6px 9px; cursor: pointer; }
+.skill-modal pre { overflow: auto; flex: 1; margin: 18px 0; border: 1px solid var(--vp-c-divider); border-radius: 12px; background: var(--vp-code-block-bg); padding: 16px; color: var(--vp-code-block-color); font-size: 12px; line-height: 1.65; white-space: pre-wrap; }
+.skill-modal footer { display: flex; justify-content: flex-end; gap: 8px; }
+@keyframes skill-pulse { 50% { opacity: .45; } }
+@media (max-width: 720px) {
+  .skill-grid { grid-template-columns: 1fr; }
+  .skill-modal-backdrop { align-items: end; padding: 0; }
+  .skill-modal { width: 100%; max-height: 92vh; border-radius: 18px 18px 0 0; }
+}
+</style>
+

--- a/docs-site/docs/.vitepress/theme/index.ts
+++ b/docs-site/docs/.vitepress/theme/index.ts
@@ -1,8 +1,12 @@
 import DefaultTheme from 'vitepress/theme'
 import Layout from './Layout.vue'
+import PublicSkillHub from './PublicSkillHub.vue'
 import './custom.css'
 
 export default {
   extends: DefaultTheme,
   Layout,
+  enhanceApp({ app }) {
+    app.component('PublicSkillHub', PublicSkillHub)
+  },
 }

--- a/docs-site/docs/en/skillhub/contribute.md
+++ b/docs-site/docs/en/skillhub/contribute.md
@@ -1,0 +1,38 @@
+---
+title: Contribute to Public SkillHub
+description: Export a reviewed private skill and submit it to the public anet.sh catalog.
+---
+
+# Contribute to Public SkillHub
+
+Public contributions have two reviews: a network owner/admin first publishes the skill inside
+the private network, then public repository maintainers review it for the Internet catalog.
+Private publication does not mean public publication.
+
+## Submission steps
+
+1. Open a network-published skill in the private Dashboard SkillHub.
+2. Choose “Export public submission” and select an explicit open-source license.
+3. Remove tokens, internal domains, personal paths, customer data, and private identities.
+4. Fork [`sleep2agi/agent-network`](https://github.com/sleep2agi/agent-network) and import the bundle downloaded by Dashboard:
+
+   ```bash
+   node scripts/import-public-skill-bundle.mjs ~/Downloads/<bundle>.json
+   ```
+
+   The import creates:
+
+   ```text
+   docs-site/docs/public/skillhub/skills/<slug>/<version>/
+   ├── metadata.json
+   └── SKILL.md
+   ```
+
+5. Run `node scripts/build-public-skillhub.mjs`, commit the source files and updated `catalog.json`, and open a pull request.
+
+Updates use a new version instead of replacing already published content.
+
+## Data that is not exported
+
+The Dashboard bundle omits network IDs, node IDs, user IDs, token-bound aliases, private review
+notes, and Hub audit data. Export creates a local file and never sends it to anet.sh automatically.

--- a/docs-site/docs/en/skillhub/index.md
+++ b/docs-site/docs/en/skillhub/index.md
@@ -1,0 +1,15 @@
+---
+title: Public SkillHub
+description: A second-stage reviewed catalog of Agent Network skills available to everyone.
+---
+
+# Public SkillHub
+
+This catalog contains `SKILL.md` files that passed a second public repository review.
+It is isolated from every private Dashboard SkillHub: publishing inside a network never
+makes a skill public or exposes node identity, network metadata, or private review records.
+
+[How to contribute a public skill →](/en/skillhub/contribute)
+
+<PublicSkillHub lang="en" />
+

--- a/docs-site/docs/public/skillhub/catalog.json
+++ b/docs-site/docs/public/skillhub/catalog.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "generated_from": "reviewed repository content",
+  "skills": [
+    {
+      "schema_version": 1,
+      "slug": "skill-writing-guide",
+      "name": "Skill writing guide",
+      "description": "Turn a repeated agent workflow into a concise, testable SKILL.md.",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "publisher": {
+        "name": "Agent Network maintainers",
+        "url": "https://github.com/sleep2agi/agent-network"
+      },
+      "tags": [
+        "documentation",
+        "workflow",
+        "skillhub"
+      ],
+      "published_at": "2026-08-08",
+      "content_sha256": "d452b0bd216f97f3b1c36c1c1c71f0c03d7b4516dcba591663143b3ab023e639",
+      "content_url": "/skillhub/skills/skill-writing-guide/1.0.0/SKILL.md"
+    }
+  ]
+}

--- a/docs-site/docs/public/skillhub/skills/skill-writing-guide/1.0.0/SKILL.md
+++ b/docs-site/docs/public/skillhub/skills/skill-writing-guide/1.0.0/SKILL.md
@@ -1,0 +1,30 @@
+# Skill writing guide
+
+Use this workflow when a repeated agent task has become stable enough to reuse.
+
+## Write the trigger
+
+State when the skill should run and when it should not. Prefer observable
+conditions over broad topic labels.
+
+## Record the smallest reliable workflow
+
+1. List required inputs and preconditions.
+2. Put safety or authorization checks before mutations.
+3. Describe the normal path in executable order.
+4. Name failure states and safe recovery actions.
+5. Keep environment-specific values in configuration, not in the skill.
+
+## Make claims testable
+
+For each important guarantee, add a check that fails when the guarantee is
+removed. Record the exact command and expected result. Do not use a green
+build as evidence for behavior the build does not exercise.
+
+## Remove private context
+
+Before public submission, remove tokens, internal hostnames, personal paths,
+private URLs, customer data, and identities that are not part of the public
+workflow. Choose an explicit license and publish changed content as a new
+version.
+

--- a/docs-site/docs/public/skillhub/skills/skill-writing-guide/1.0.0/metadata.json
+++ b/docs-site/docs/public/skillhub/skills/skill-writing-guide/1.0.0/metadata.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "slug": "skill-writing-guide",
+  "name": "Skill writing guide",
+  "description": "Turn a repeated agent workflow into a concise, testable SKILL.md.",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "publisher": {
+    "name": "Agent Network maintainers",
+    "url": "https://github.com/sleep2agi/agent-network"
+  },
+  "tags": ["documentation", "workflow", "skillhub"],
+  "published_at": "2026-08-08"
+}

--- a/docs-site/docs/skillhub/contribute.md
+++ b/docs-site/docs/skillhub/contribute.md
@@ -1,0 +1,37 @@
+---
+title: 投稿公共 SkillHub
+description: 从私有 SkillHub 导出并向 anet.sh 公共目录投稿。
+---
+
+# 投稿公共 SkillHub
+
+公共投稿需要两次审核：先由你的网络 owner/admin 将 Skill 设为网络内发布，再由公共仓库维护者审核。
+私有发布不等于 Internet 公开，也不会自动公开。
+
+## 投稿步骤
+
+1. 在私有 Dashboard 的 SkillHub 中打开一份已发布 Skill。
+2. 点击“导出公共投稿包”，选择明确的开源许可证。
+3. 再次检查并删除 token、内部域名、个人路径、客户数据和私有身份信息。
+4. Fork [`sleep2agi/agent-network`](https://github.com/sleep2agi/agent-network)，导入 Dashboard 下载的投稿包：
+
+   ```bash
+   node scripts/import-public-skill-bundle.mjs ~/Downloads/<bundle>.json
+   ```
+
+   导入后会生成：
+
+   ```text
+   docs-site/docs/public/skillhub/skills/<slug>/<version>/
+   ├── metadata.json
+   └── SKILL.md
+   ```
+
+5. 运行 `node scripts/build-public-skillhub.mjs`，提交源文件与更新后的 `catalog.json`，然后发起 Pull Request。
+
+公共维护者会检查可复用性、许可证、隐私和安全边界。修改已公开内容时必须发布新版本，不得覆盖原版本。
+
+## 不会上传的内容
+
+Dashboard 导出包不包含 `network_id`、节点 ID、用户 ID、token 绑定 alias、私有审核意见或 Hub 审计数据。
+导出只生成本地文件，不会自动发送到 anet.sh。

--- a/docs-site/docs/skillhub/index.md
+++ b/docs-site/docs/skillhub/index.md
@@ -1,0 +1,14 @@
+---
+title: 公共 SkillHub
+description: 经二次审核、任何人都可读取和下载的 Agent Network Skills 目录。
+---
+
+# 公共 SkillHub
+
+这里展示经过公共仓库二次审核的 `SKILL.md`。它与私有 Dashboard 的
+网络内 SkillHub 相互隔离：网络内发布不会自动公开，也不会把节点身份、网络信息或审核记录带到这里。
+
+[如何投稿公共 Skill →](/skillhub/contribute)
+
+<PublicSkillHub lang="zh" />
+

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -8,6 +8,9 @@
   },
   "scripts": {
     "dev": "vitepress dev docs",
+    "skillhub:build": "node ../scripts/build-public-skillhub.mjs",
+    "skillhub:check": "node ../scripts/build-public-skillhub.mjs --check",
+    "prebuild": "npm run skillhub:build",
     "build": "vitepress build docs",
     "preview": "vitepress preview docs"
   },

--- a/docs/rfcs/RFC-033-public-skillhub.md
+++ b/docs/rfcs/RFC-033-public-skillhub.md
@@ -1,0 +1,95 @@
+# RFC-033 — Private and public SkillHub planes
+
+Status: implementation candidate
+
+## Product boundary
+
+SkillHub has two separate trust planes. They intentionally do not share a
+database or a meaning of “published”.
+
+| Plane | Audience | Source of truth | Review authority |
+| --- | --- | --- | --- |
+| Private SkillHub | Members and nodes of one Agent Network | That network's Hub database | Network owner/admin |
+| Public SkillHub | Everyone visiting `anet.sh` | Reviewed files in the public `agent-network` repository | Public repository maintainers |
+
+`published` in the private plane means **network-published**, not public on the
+Internet. No private row is copied, indexed, or exposed by anet.sh
+automatically.
+
+## Promotion flow
+
+1. A node or member submits an immutable `SKILL.md` to its private network.
+2. A network owner/admin reviews it and makes it network-published.
+3. A reviewer explicitly exports a public-submission bundle from Dashboard.
+4. The bundle omits `network_id`, node IDs, user IDs, token-bound aliases,
+   review notes, and internal audit data. It includes only public metadata,
+   content, a declared license, and a content hash.
+5. A human opens a pull request that adds the bundle under
+   `docs-site/docs/public/skillhub/skills/<slug>/<version>/`.
+6. Repository CI validates the bundle. A repository maintainer performs the
+   second review and merges it. Only then does it appear on anet.sh.
+
+This is deliberately a two-review process. A private network owner is not a
+global public-catalog moderator, and a node token can never publish directly
+to the public plane.
+
+## Public registry format
+
+Each immutable public version contains:
+
+```text
+docs-site/docs/public/skillhub/skills/<slug>/<version>/
+├── metadata.json
+└── SKILL.md
+```
+
+`metadata.json` contains only:
+
+- schema version;
+- slug, display name, description, and version;
+- SPDX license from the accepted allowlist;
+- public publisher name and optional public URL;
+- public tags and publication date.
+
+The build produces `docs-site/docs/public/skillhub/catalog.json` with a
+SHA-256 digest and content URL for each version. The generated catalog is
+deterministic and checked into the repository so review shows the exact
+public result.
+
+Changing content under an existing `(slug, version)` is forbidden by policy.
+Corrections use a new version. Git history supplies the public audit trail.
+
+## Validation and rendering
+
+The validator fails closed on:
+
+- invalid or mismatched slug/version paths;
+- duplicate `(slug, version)` entries;
+- unknown metadata fields or unsupported licenses;
+- symlinks, unexpected files, NUL bytes, oversized content;
+- credential-shaped strings, private keys, and host-local home paths;
+- a stale or manually edited generated catalog.
+
+anet.sh renders `SKILL.md` as plain text, never as raw HTML. Public reads need
+no token, cookie, or access to a private Hub. Search happens in the browser
+over the static catalog.
+
+## Dashboard export contract
+
+The private Dashboard export action is available only for a
+network-published skill to a network reviewer. Export is not publication and
+must say so in the UI. The browser builds the bundle from the already
+authorized detail response and downloads it locally; no private Hub token is
+placed in the file or sent to anet.sh.
+
+The default license is not inferred. The reviewer must select one of the
+public allowlist values before export.
+
+## Future federation
+
+A future `submit_public_skill` API may replace the pull-request upload step,
+but only after anet.sh has a publisher identity system, abuse controls,
+central moderation, immutable artifact storage, and a transparent audit log.
+It must preserve the explicit export and second-review boundary above. A
+self-hosted Hub must never gain ambient write access to the public catalog.
+

--- a/docs/tests/report-test600-public-skillhub.txt
+++ b/docs/tests/report-test600-public-skillhub.txt
@@ -1,0 +1,101 @@
+Test 600 — Public SkillHub catalog and private-to-public promotion
+Date: 2026-08-08
+
+Scope
+=====
+
+This test covers the public anet.sh SkillHub catalog and the explicit export path
+from the private, network-scoped Dashboard SkillHub. It does not collapse the two
+trust planes:
+
+* Hub/Dashboard `published` means published inside one authenticated network.
+* Internet publication requires a local export, a public-repository pull request,
+  and a second maintainer review.
+* There is no automatic private-to-public synchronization and no public write API.
+
+Provenance
+==========
+
+Public anet.sh source commit:
+  72f7afd6d6f1aa2e685808650e12f85e51696eee
+
+Dashboard export source commits:
+  0c29aed470e5b908ab10631fa8cf6a3433483824  initial export implementation
+  181aecf7eee38459d93bc6cccbea295d0781a834  deferred Blob URL cleanup
+
+The Dashboard branch is intentionally stacked on the private SkillHub branch. It
+must not be rebased into an unrelated tree or merged before the private SkillHub
+base is available.
+
+Docker evidence
+===============
+
+Public catalog image:
+  tag during verification: anet-test600:dev
+  image digest: sha256:da0d71db435021c8a8ad41ac49bc80bf60fe07eca9abbd03b90d4dce3a302eb6
+  embedded TEST600_SOURCE_COMMIT:
+    72f7afd6d6f1aa2e685808650e12f85e51696eee
+  result: PASS (10 checks)
+
+Dashboard image:
+  tag during verification: anet-skillhub-dashboard:dev
+  image digest: sha256:2c4f08b32bf03ff4909056b3f38c608ed8406bb9cf1f75f597206975a28e4f20
+  embedded source commit:
+    0c29aed470e5b908ab10631fa8cf6a3433483824
+  result: contract PASS; targeted ESLint 0 errors; Next production build PASS
+  routes: 52 pages, including /skillhub
+
+The follow-up URL-lifetime delta at 181aecf7 was re-run in Docker with the
+read-only worktree mounted into node:22-bookworm-slim. The SkillHub module
+contract passed. This delta only defers URL.revokeObjectURL until the next event
+loop and adds a contract assertion; it does not change the bundle schema,
+permissions, or rendering.
+
+Public-catalog checks
+=====================
+
+1. The checked-in catalog is deterministic and current.
+2. Invalid licenses are rejected (witnessed red).
+3. Credential-shaped content is rejected without printing the value (witnessed red).
+4. A manually edited/stale catalog is rejected (witnessed red).
+5. A bundle whose SHA-256 does not match its content is rejected (witnessed red).
+6. A valid Dashboard-format bundle imports into the expected immutable path.
+7. Symlinks and unexpected files are rejected.
+8. Chinese and English public-boundary documentation is present.
+9. The public catalog component is wired into both locales.
+10. A real VitePress production build emits the catalog, content, and both pages.
+
+Security and privacy assertions
+===============================
+
+* Metadata keys are explicit; path slug/version must equal metadata slug/version.
+* The validator accepts only regular files and rejects symlinks.
+* Skill text is UTF-8, bounded to 128 KiB, and rejects NUL bytes.
+* Credential-shaped strings, private keys, and host-local home paths are blocked.
+* Skill content is rendered as plain text, not raw HTML.
+* Dashboard export is available only to a reviewer for a network-published skill.
+* The browser bundle is constructed from an allowlist and omits network_id,
+  skill_id, source_alias, user/node identifiers, content_hash from the private
+  record, and review notes.
+* Export downloads locally. It does not send content to anet.sh or another network.
+
+Known limits and deployment gates
+=================================
+
+* The scanner is a defense-in-depth validator, not a universal secret detector.
+  Public-repository review remains mandatory.
+* Public direct submission/federation is intentionally absent. Adding it requires
+  publisher identity, abuse controls, central moderation, immutable storage, and
+  an audit log.
+* Hub PR #596 and private Dashboard PR #3 must be merged and deployed before the
+  private workflow can be exercised in production.
+* The public catalog and stacked Dashboard export branches require independent
+  review, CI, and authorized merge/deployment.
+* Production UAT must prove: private submit -> private review/readback -> local
+  public bundle export -> public import/validation -> anet.sh catalog/detail read.
+
+Verdict
+=======
+
+Candidate implementation and isolated Docker evidence: PASS.
+Merge/deployment/public UAT: PENDING authorized review and rollout.

--- a/docs/tests/report-test600-public-skillhub.txt
+++ b/docs/tests/report-test600-public-skillhub.txt
@@ -35,7 +35,8 @@ Public catalog image:
   image digest: sha256:da0d71db435021c8a8ad41ac49bc80bf60fe07eca9abbd03b90d4dce3a302eb6
   embedded TEST600_SOURCE_COMMIT:
     72f7afd6d6f1aa2e685808650e12f85e51696eee
-  result: PASS (10 checks)
+  result: PASS (10 checks) at source 72f7afd6; follow-up import preflight adds
+    an eleventh witnessed-red gate before write
 
 Dashboard image:
   tag during verification: anet-skillhub-dashboard:dev
@@ -68,7 +69,8 @@ Public-catalog checks
 Security and privacy assertions
 ===============================
 
-* Metadata keys are explicit; path slug/version must equal metadata slug/version.
+* Metadata keys are explicit at import and catalog-build time; private/unknown
+  fields are rejected before the importer creates a version directory.
 * The validator accepts only regular files and rejects symlinks.
 * Skill text is UTF-8, bounded to 128 KiB, and rejects NUL bytes.
 * Credential-shaped strings, private keys, and host-local home paths are blocked.

--- a/scripts/build-public-skillhub.mjs
+++ b/scripts/build-public-skillhub.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import { lstat, readFile, readdir, writeFile } from 'node:fs/promises'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const SKILLS_ROOT = join(REPO_ROOT, 'docs-site', 'docs', 'public', 'skillhub', 'skills')
+const CATALOG_PATH = join(REPO_ROOT, 'docs-site', 'docs', 'public', 'skillhub', 'catalog.json')
+const CHECK_ONLY = process.argv.includes('--check')
+const MAX_CONTENT_BYTES = 128 * 1024
+const ALLOWED_LICENSES = new Set(['Apache-2.0', 'MIT', 'CC-BY-4.0'])
+const META_KEYS = new Set(['schema_version', 'slug', 'name', 'description', 'version', 'license', 'publisher', 'tags', 'published_at'])
+const PUBLISHER_KEYS = new Set(['name', 'url'])
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const VERSION_RE = /^[0-9A-Za-z]+(?:[._-][0-9A-Za-z]+)*$/
+const TAG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+function fail(message) {
+  throw new Error(`public-skillhub: ${message}`)
+}
+
+function assertString(value, field, min, max) {
+  if (typeof value !== 'string' || value.length < min || value.length > max) {
+    fail(`${field} must be a string of ${min}-${max} characters`)
+  }
+  if (/\p{Cc}/u.test(value)) fail(`${field} contains control characters`)
+}
+
+function assertExactKeys(value, allowed, field) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${field} must be an object`)
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) fail(`${field} contains unknown field ${key}`)
+  }
+}
+
+function assertPublicText(value, field) {
+  const forbidden = [
+    [/\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|(?:ntok|utok|atok)_[A-Za-z0-9_-]{12,})\b/, 'credential-shaped value'],
+    [/-----BEGIN [A-Z ]*PRIVATE KEY-----/, 'private key'],
+    [/(?:^|[\s`"'])\/(?:home|Users)\/[^\s/]+\//m, 'host-local home path'],
+    [/[A-Za-z]:\\Users\\[^\\\s]+\\/, 'host-local Windows profile path'],
+  ]
+  for (const [pattern, label] of forbidden) {
+    if (pattern.test(value)) fail(`${field} contains ${label}`)
+  }
+}
+
+async function assertPlainFile(path, label) {
+  const stat = await lstat(path)
+  if (!stat.isFile() || stat.isSymbolicLink()) fail(`${label} must be a regular file`)
+}
+
+async function childDirectories(path) {
+  const entries = await readdir(path, { withFileTypes: true })
+  const names = []
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) fail(`symlink is forbidden: ${relative(REPO_ROOT, join(path, entry.name))}`)
+    if (!entry.isDirectory()) fail(`unexpected file: ${relative(REPO_ROOT, join(path, entry.name))}`)
+    names.push(entry.name)
+  }
+  return names.sort()
+}
+
+async function buildCatalog() {
+  const skills = []
+  const seen = new Set()
+  for (const slugDir of await childDirectories(SKILLS_ROOT)) {
+    if (!SLUG_RE.test(slugDir)) fail(`invalid slug directory ${slugDir}`)
+    for (const versionDir of await childDirectories(join(SKILLS_ROOT, slugDir))) {
+      if (!VERSION_RE.test(versionDir)) fail(`invalid version directory ${slugDir}/${versionDir}`)
+      const entryDir = join(SKILLS_ROOT, slugDir, versionDir)
+      const entries = (await readdir(entryDir)).sort()
+      if (entries.join(',') !== 'SKILL.md,metadata.json') {
+        fail(`${slugDir}/${versionDir} must contain exactly SKILL.md and metadata.json`)
+      }
+      const metaPath = join(entryDir, 'metadata.json')
+      const contentPath = join(entryDir, 'SKILL.md')
+      await assertPlainFile(metaPath, `${slugDir}/${versionDir}/metadata.json`)
+      await assertPlainFile(contentPath, `${slugDir}/${versionDir}/SKILL.md`)
+
+      let metadata
+      try { metadata = JSON.parse(await readFile(metaPath, 'utf8')) } catch { fail(`${slugDir}/${versionDir}/metadata.json is invalid JSON`) }
+      assertExactKeys(metadata, META_KEYS, 'metadata')
+      if (metadata.schema_version !== 1) fail(`${slugDir}/${versionDir} has unsupported schema_version`)
+      assertString(metadata.slug, 'slug', 2, 80)
+      assertString(metadata.name, 'name', 1, 120)
+      assertString(metadata.description, 'description', 1, 1000)
+      assertString(metadata.version, 'version', 1, 40)
+      if (metadata.slug !== slugDir || metadata.version !== versionDir) fail(`${slugDir}/${versionDir} metadata does not match its path`)
+      if (!SLUG_RE.test(metadata.slug) || !VERSION_RE.test(metadata.version)) fail(`${slugDir}/${versionDir} has invalid slug or version`)
+      if (!ALLOWED_LICENSES.has(metadata.license)) fail(`${slugDir}/${versionDir} uses unsupported license ${metadata.license}`)
+      assertExactKeys(metadata.publisher, PUBLISHER_KEYS, 'publisher')
+      assertString(metadata.publisher.name, 'publisher.name', 1, 120)
+      if (metadata.publisher.url !== undefined) {
+        assertString(metadata.publisher.url, 'publisher.url', 8, 300)
+        let url
+        try { url = new URL(metadata.publisher.url) } catch { fail('publisher.url must be an absolute URL') }
+        if (!['https:', 'http:'].includes(url.protocol)) fail('publisher.url must use http or https')
+      }
+      if (!Array.isArray(metadata.tags) || metadata.tags.length > 12 || metadata.tags.some(tag => typeof tag !== 'string' || !TAG_RE.test(tag))) {
+        fail(`${slugDir}/${versionDir} tags must be at most 12 lowercase slugs`)
+      }
+      if (new Set(metadata.tags).size !== metadata.tags.length) fail(`${slugDir}/${versionDir} contains duplicate tags`)
+      if (typeof metadata.published_at !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(metadata.published_at) || Number.isNaN(Date.parse(`${metadata.published_at}T00:00:00Z`))) {
+        fail(`${slugDir}/${versionDir} published_at must be YYYY-MM-DD`)
+      }
+      assertPublicText(JSON.stringify(metadata), `${slugDir}/${versionDir}/metadata.json`)
+
+      const contentBuffer = await readFile(contentPath)
+      if (contentBuffer.length === 0 || contentBuffer.length > MAX_CONTENT_BYTES) fail(`${slugDir}/${versionDir}/SKILL.md must be 1-${MAX_CONTENT_BYTES} bytes`)
+      const content = contentBuffer.toString('utf8')
+      if (Buffer.from(content, 'utf8').compare(contentBuffer) !== 0) fail(`${slugDir}/${versionDir}/SKILL.md must be valid UTF-8`)
+      if (content.includes('\0')) fail(`${slugDir}/${versionDir}/SKILL.md contains NUL`)
+      assertPublicText(content, `${slugDir}/${versionDir}/SKILL.md`)
+
+      const key = `${metadata.slug}@${metadata.version}`
+      if (seen.has(key)) fail(`duplicate public skill ${key}`)
+      seen.add(key)
+      skills.push({
+        ...metadata,
+        content_sha256: createHash('sha256').update(contentBuffer).digest('hex'),
+        content_url: `/skillhub/skills/${metadata.slug}/${metadata.version}/SKILL.md`,
+      })
+    }
+  }
+  skills.sort((a, b) => a.slug.localeCompare(b.slug) || a.version.localeCompare(b.version))
+  return `${JSON.stringify({ schema_version: 1, generated_from: 'reviewed repository content', skills }, null, 2)}\n`
+}
+
+try {
+  const expected = await buildCatalog()
+  if (CHECK_ONLY) {
+    let actual = ''
+    try { actual = await readFile(CATALOG_PATH, 'utf8') } catch { fail('catalog.json is missing; run npm run skillhub:build') }
+    if (actual !== expected) fail('catalog.json is stale or manually edited; run npm run skillhub:build')
+    console.log(`public-skillhub: PASS (${JSON.parse(expected).skills.length} entries, catalog current)`)
+  } else {
+    await writeFile(CATALOG_PATH, expected, { encoding: 'utf8', mode: 0o644 })
+    console.log(`public-skillhub: wrote ${relative(REPO_ROOT, CATALOG_PATH)} (${JSON.parse(expected).skills.length} entries)`)
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+}
+

--- a/scripts/import-public-skill-bundle.mjs
+++ b/scripts/import-public-skill-bundle.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import { lstat, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const skillsRoot = join(repoRoot, 'docs-site', 'docs', 'public', 'skillhub', 'skills')
+const bundlePath = process.argv[2] ? resolve(process.argv[2]) : ''
+const slugRe = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const versionRe = /^[0-9A-Za-z]+(?:[._-][0-9A-Za-z]+)*$/
+
+function fail(message) {
+  console.error(`public-skillhub-import: ${message}`)
+  process.exit(1)
+}
+
+if (!bundlePath) fail('usage: node scripts/import-public-skill-bundle.mjs <bundle.json>')
+
+let bundle
+try { bundle = JSON.parse(await readFile(bundlePath, 'utf8')) } catch { fail('bundle is missing or invalid JSON') }
+const bundleKeys = Object.keys(bundle || {}).sort().join(',')
+if (bundleKeys !== 'content,content_sha256,metadata,schema_version' || bundle.schema_version !== 1) fail('bundle shape or schema_version is invalid')
+if (typeof bundle.content !== 'string' || !bundle.content) fail('bundle content must be non-empty text')
+if (!bundle.metadata || typeof bundle.metadata !== 'object' || Array.isArray(bundle.metadata)) fail('bundle metadata is invalid')
+const { slug, version } = bundle.metadata
+if (typeof slug !== 'string' || !slugRe.test(slug) || typeof version !== 'string' || !versionRe.test(version)) fail('bundle slug/version is invalid')
+const actualHash = createHash('sha256').update(bundle.content, 'utf8').digest('hex')
+if (bundle.content_sha256 !== actualHash) fail('bundle content_sha256 does not match content')
+
+const target = join(skillsRoot, slug, version)
+const slugRoot = join(skillsRoot, slug)
+try {
+  await mkdir(slugRoot, { recursive: false, mode: 0o755 })
+} catch (error) {
+  if (error?.code !== 'EEXIST') fail(`cannot create slug directory: ${error instanceof Error ? error.message : String(error)}`)
+}
+const slugStat = await lstat(slugRoot)
+if (!slugStat.isDirectory() || slugStat.isSymbolicLink()) fail('slug path must be a real directory')
+try { await mkdir(target, { recursive: false, mode: 0o755 }) } catch { fail('target version already exists') }
+await writeFile(join(target, 'metadata.json'), `${JSON.stringify(bundle.metadata, null, 2)}\n`, { mode: 0o644 })
+await writeFile(join(target, 'SKILL.md'), bundle.content, { mode: 0o644 })
+console.log(`public-skillhub-import: wrote ${slug}/${version}; run node scripts/build-public-skillhub.mjs`)

--- a/scripts/import-public-skill-bundle.mjs
+++ b/scripts/import-public-skill-bundle.mjs
@@ -10,6 +10,8 @@ const skillsRoot = join(repoRoot, 'docs-site', 'docs', 'public', 'skillhub', 'sk
 const bundlePath = process.argv[2] ? resolve(process.argv[2]) : ''
 const slugRe = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const versionRe = /^[0-9A-Za-z]+(?:[._-][0-9A-Za-z]+)*$/
+const metadataKeys = new Set(['schema_version', 'slug', 'name', 'description', 'version', 'license', 'publisher', 'tags', 'published_at'])
+const publisherKeys = new Set(['name', 'url'])
 
 function fail(message) {
   console.error(`public-skillhub-import: ${message}`)
@@ -24,6 +26,9 @@ const bundleKeys = Object.keys(bundle || {}).sort().join(',')
 if (bundleKeys !== 'content,content_sha256,metadata,schema_version' || bundle.schema_version !== 1) fail('bundle shape or schema_version is invalid')
 if (typeof bundle.content !== 'string' || !bundle.content) fail('bundle content must be non-empty text')
 if (!bundle.metadata || typeof bundle.metadata !== 'object' || Array.isArray(bundle.metadata)) fail('bundle metadata is invalid')
+if (Object.keys(bundle.metadata).some(key => !metadataKeys.has(key))) fail('bundle metadata contains an unknown field')
+if (!bundle.metadata.publisher || typeof bundle.metadata.publisher !== 'object' || Array.isArray(bundle.metadata.publisher)) fail('bundle publisher is invalid')
+if (Object.keys(bundle.metadata.publisher).some(key => !publisherKeys.has(key))) fail('bundle publisher contains an unknown field')
 const { slug, version } = bundle.metadata
 if (typeof slug !== 'string' || !slugRe.test(slug) || typeof version !== 'string' || !versionRe.test(version)) fail('bundle slug/version is invalid')
 const actualHash = createHash('sha256').update(bundle.content, 'utf8').digest('hex')

--- a/tests/test600-public-skillhub/Dockerfile
+++ b/tests/test600-public-skillhub/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:22-bookworm-slim
+
+ARG SOURCE_COMMIT=unknown
+ENV TEST600_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY . .
+CMD ["bash", "tests/test600-public-skillhub/run.sh"]

--- a/tests/test600-public-skillhub/run.sh
+++ b/tests/test600-public-skillhub/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+echo "source_commit=${TEST600_SOURCE_COMMIT:-unknown}"
+
+checks=0
+pass() { checks=$((checks + 1)); printf 'PASS %s\n' "$1"; }
+expect_red() {
+  local name="$1"; shift
+  if "$@" >/tmp/test600-red.out 2>&1; then
+    printf 'FAIL %s unexpectedly passed\n' "$name" >&2
+    cat /tmp/test600-red.out >&2
+    exit 1
+  fi
+  test -s /tmp/test600-red.out
+  pass "witnessed-red: $name"
+}
+
+node scripts/build-public-skillhub.mjs --check
+pass "canonical catalog is deterministic and current"
+
+case_root=/tmp/test600-case
+mkdir -p "$case_root/scripts" "$case_root/docs-site/docs/public"
+cp scripts/build-public-skillhub.mjs "$case_root/scripts/"
+cp -a docs-site/docs/public/skillhub "$case_root/docs-site/docs/public/"
+
+cp -a "$case_root" /tmp/test600-license
+sed -i 's/"Apache-2.0"/"UNLICENSED"/' /tmp/test600-license/docs-site/docs/public/skillhub/skills/skill-writing-guide/1.0.0/metadata.json
+expect_red "unsupported license is rejected" node /tmp/test600-license/scripts/build-public-skillhub.mjs
+
+cp -a "$case_root" /tmp/test600-secret
+printf '\nntok_1234567890abcdefghijklmnop\n' >> /tmp/test600-secret/docs-site/docs/public/skillhub/skills/skill-writing-guide/1.0.0/SKILL.md
+expect_red "credential-shaped content is rejected" node /tmp/test600-secret/scripts/build-public-skillhub.mjs
+
+cp -a "$case_root" /tmp/test600-stale
+printf ' ' >> /tmp/test600-stale/docs-site/docs/public/skillhub/catalog.json
+expect_red "stale generated catalog is rejected" node /tmp/test600-stale/scripts/build-public-skillhub.mjs --check
+
+bad_bundle=/tmp/test600-bad-bundle.json
+node -e 'require("fs").writeFileSync(process.argv[1], JSON.stringify({schema_version:1,metadata:{slug:"probe-skill",version:"1.0.0"},content:"# Probe\n",content_sha256:"0".repeat(64)}))' "$bad_bundle"
+expect_red "import rejects a mismatched content hash" node scripts/import-public-skill-bundle.mjs "$bad_bundle"
+
+cp -a "$case_root" /tmp/test600-import
+cp scripts/import-public-skill-bundle.mjs /tmp/test600-import/scripts/
+good_bundle=/tmp/test600-good-bundle.json
+node - "$good_bundle" <<'NODE'
+const fs = require('fs'); const crypto = require('crypto'); const content = '# Probe skill\n\nReusable public probe.\n';
+fs.writeFileSync(process.argv[2], JSON.stringify({
+  schema_version: 1,
+  metadata: { schema_version: 1, slug: 'probe-skill', name: 'Probe skill', description: 'Public import probe.', version: '1.0.0', license: 'Apache-2.0', publisher: { name: 'Test publisher' }, tags: ['probe'], published_at: '2026-08-08' },
+  content,
+  content_sha256: crypto.createHash('sha256').update(content).digest('hex'),
+}));
+NODE
+node /tmp/test600-import/scripts/import-public-skill-bundle.mjs "$good_bundle"
+node /tmp/test600-import/scripts/build-public-skillhub.mjs
+grep -q '"slug": "probe-skill"' /tmp/test600-import/docs-site/docs/public/skillhub/catalog.json
+pass "valid Dashboard export bundle imports into the reviewed public source tree"
+
+test "$(find docs-site/docs/public/skillhub/skills -type l | wc -l)" -eq 0
+pass "public registry contains no symlinks"
+
+grep -q "never as raw HTML" docs/rfcs/RFC-033-public-skillhub.md
+grep -q "不会自动公开" docs-site/docs/skillhub/contribute.md
+grep -q "never sends it to anet.sh automatically" docs-site/docs/en/skillhub/contribute.md
+pass "private/public trust boundary is documented in both locales"
+
+grep -q "PublicSkillHub" docs-site/docs/.vitepress/theme/index.ts
+grep -q "withBase('/skillhub/catalog.json')" docs-site/docs/.vitepress/theme/PublicSkillHub.vue
+grep -q "<PublicSkillHub lang=\"zh\"" docs-site/docs/skillhub/index.md
+grep -q "<PublicSkillHub lang=\"en\"" docs-site/docs/en/skillhub/index.md
+pass "public catalog component is wired for both locales"
+
+npm ci --prefix docs-site --no-audit --no-fund
+npm run build --prefix docs-site
+test -f docs-site/docs/.vitepress/dist/skillhub/index.html
+test -f docs-site/docs/.vitepress/dist/en/skillhub/index.html
+test -f docs-site/docs/.vitepress/dist/skillhub/catalog.json
+test -f docs-site/docs/.vitepress/dist/skillhub/skills/skill-writing-guide/1.0.0/SKILL.md
+pass "VitePress production build includes catalog, pages, and immutable content"
+
+printf 'RESULT: PASS (%d checks)\n' "$checks"

--- a/tests/test600-public-skillhub/run.sh
+++ b/tests/test600-public-skillhub/run.sh
@@ -41,6 +41,21 @@ bad_bundle=/tmp/test600-bad-bundle.json
 node -e 'require("fs").writeFileSync(process.argv[1], JSON.stringify({schema_version:1,metadata:{slug:"probe-skill",version:"1.0.0"},content:"# Probe\n",content_sha256:"0".repeat(64)}))' "$bad_bundle"
 expect_red "import rejects a mismatched content hash" node scripts/import-public-skill-bundle.mjs "$bad_bundle"
 
+cp -a "$case_root" /tmp/test600-private-field
+cp scripts/import-public-skill-bundle.mjs /tmp/test600-private-field/scripts/
+private_bundle=/tmp/test600-private-field-bundle.json
+node - "$private_bundle" <<'NODE'
+const fs = require('fs'); const crypto = require('crypto'); const content = '# Private field probe\n';
+fs.writeFileSync(process.argv[2], JSON.stringify({
+  schema_version: 1,
+  metadata: { schema_version: 1, slug: 'private-field-probe', name: 'Private field probe', description: 'Must be rejected before write.', version: '1.0.0', license: 'MIT', publisher: { name: 'Test publisher' }, tags: [], published_at: '2026-08-08', network_id: 'must-not-cross' },
+  content,
+  content_sha256: crypto.createHash('sha256').update(content).digest('hex'),
+}));
+NODE
+expect_red "import rejects private metadata before writing" node /tmp/test600-private-field/scripts/import-public-skill-bundle.mjs "$private_bundle"
+test ! -e /tmp/test600-private-field/docs-site/docs/public/skillhub/skills/private-field-probe
+
 cp -a "$case_root" /tmp/test600-import
 cp scripts/import-public-skill-bundle.mjs /tmp/test600-import/scripts/
 good_bundle=/tmp/test600-good-bundle.json


### PR DESCRIPTION
## What changed

- adds a bilingual public SkillHub catalog and contribution guide to anet.sh
- adds deterministic catalog generation and strict Dashboard-bundle import validation
- adds a reviewed public seed skill and plain-text detail/download UI
- documents the private-network versus Internet-public trust boundary in RFC-033

## Why

Private Dashboard publication must not silently become Internet publication. This creates an explicit, auditable promotion path: local export, public repository PR, second maintainer review, then static anet.sh publication.

## Validation

- Docker test600: PASS (10 checks)
- real VitePress production build: PASS
- witnessed-red invalid license, credential-shaped content, stale catalog, and mismatched bundle hash
- report: docs/tests/report-test600-public-skillhub.txt

## Deployment order

Merge/deploy the private Hub and Dashboard SkillHub first, then this public catalog, then run the end-to-end export/import/readback UAT. No direct public write API is introduced.