### PR TITLE
feat: add Hub scheduled tasks

### DIFF
--- a/docs/rfcs/RFC-034-hub-scheduled-tasks.md
+++ b/docs/rfcs/RFC-034-hub-scheduled-tasks.md
@@ -37,6 +37,8 @@
 
 SQLite transaction 是当前生产原子边界。仓库现有 PostgreSQL adapter 已明确不提供真实跨语句 transaction；在该 adapter 修复前，不得把 PostgreSQL 宣称为 scheduler 的 production-safe 后端。
 
+多 Hub occurrence 竞争验证针对“进程均已完成数据库初始化”的运行态。独立 Docker 探针发现仓库既有 SQLite adapter 在两个进程完全同时冷启动时，`PRAGMA journal_mode=WAL` 可能先报 `SQLITE_BUSY`；这是 adapter 启动协调的独立既有风险，不能用 scheduler 的 occurrence 唯一键来掩盖，也不计作本 RFC 已修复。
+
 ## 5. 身份与租户边界
 
 - 只有 `utok_` 用户可管理计划；`ntok_` 无论签发者是谁都拒绝，避免节点给自己植入永久执行循环。

--- a/docs/rfcs/RFC-034-hub-scheduled-tasks.md
+++ b/docs/rfcs/RFC-034-hub-scheduled-tasks.md
@@ -1,0 +1,66 @@
+# RFC-034 — Hub 级定时任务
+
+状态：实现候选
+
+## 1. 结论
+
+定时任务由 CommHub 持有和执行。Dashboard 与官方 App 是同一组 Hub API 的管理客户端；agent-node、TUI、MCP bridge 不保存计划，也不负责计时。每次触发最终生成一条普通 `inbox` + `tasks` 任务，因此节点侧无需新增协议，离线节点沿用既有排队语义。
+
+`/aloop` 和节点本地 `goals.json` 是兼容能力，不是本 RFC 的数据源、执行器或容灾副本。两套语义不得互相同步，以免形成双调度 owner。
+
+## 2. 用户能力
+
+- 从 Dashboard 或 App 选择同一 network 中的稳定 `node_id`。
+- 建立单次、固定间隔、每日、每周计划。
+- 每日/每周计划显式记录 IANA timezone；单次时间保存为 UTC ISO 8601。
+- 查看下次/上次执行、暂停、恢复、立即执行、取消和运行历史。
+- 目标节点改名后仍按 `node_id` 解析当前 alias。
+- 默认 `overlap_policy=skip`：上一轮普通 task 尚未终态时，本轮记 `skipped`，不重复压入节点。
+
+## 3. 数据模型
+
+`scheduled_tasks` 是计划真相：network、创建人、稳定目标、任务正文、计划规格、状态、next/last time 与 optimistic `revision`。
+
+`scheduled_task_runs` 是每个 occurrence 的不可混淆记录。`UNIQUE(schedule_id, scheduled_for)` 是多 Hub 进程竞争时的幂等 claim。run 只引用普通 `task_id`，不复制 task lifecycle。
+
+历史取消不物理删除：计划标记 `cancelled`，run history 保留。
+
+## 4. 调度和故障语义
+
+1. `startHub()` 启动 scheduler；单纯 import 或 `bootServer()` 不启动后台 timer。
+2. tick 读取 `active AND next_run_at <= now`，默认 10 秒，可通过 `COMMHUB_SCHEDULER_TICK_MS` 调整。
+3. occurrence claim、run row、inbox row、task row及 next occurrence 推进处于同一个数据库 transaction。
+4. commit 后才发送 SSE doorbell。SSE 失败不回滚已持久化任务；节点仍会通过 inbox 拉取。
+5. Hub 长时间停机后，每个到期计划只补一次；下一次从恢复时刻以后计算，禁止补发所有错过的 tick 形成风暴。
+6. 单次计划无论成功投递或因目标失效而失败，均进入 `completed`，不永久自旋。
+7. 目标处于 stop/delete lifecycle 时 fail closed，run 记录失败；普通 offline 仍排队。
+
+SQLite transaction 是当前生产原子边界。仓库现有 PostgreSQL adapter 已明确不提供真实跨语句 transaction；在该 adapter 修复前，不得把 PostgreSQL 宣称为 scheduler 的 production-safe 后端。
+
+## 5. 身份与租户边界
+
+- 只有 `utok_` 用户可管理计划；`ntok_` 无论签发者是谁都拒绝，避免节点给自己植入永久执行循环。
+- viewer 可读、不可写；member/admin/owner 依既有 `canRestWriteNetwork` 写门。
+- `network_id` 取 token-bound scope 或经成员校验的显式值，不信任客户端自报身份。
+- 目标必须由 `nodes(network_id,node_id)` 命中；禁止跨 network alias/node_id 拼接。
+- 列表、详情与 runs 均使用相同 network scope；找不到与无权读取都返回 `schedule_not_found`，不泄漏外网元数据。
+- 创建人取认证 user id，客户端不可覆写。
+
+## 6. REST API
+
+- `GET/POST /api/scheduled-tasks`
+- `GET/PATCH/DELETE /api/scheduled-tasks/:schedule_id`
+- `GET /api/scheduled-tasks/:schedule_id/runs`
+- `POST /api/scheduled-tasks/:schedule_id/run-now`
+
+PATCH 必须携带当前 `revision`；陈旧客户端得到 `409 revision_conflict`，不得覆盖另一设备的新状态。
+
+## 7. 发布与回滚
+
+发布顺序必须是 Hub → Dashboard → App。旧 Dashboard/App 对新增表和 API 无感；新客户端连旧 Hub 应明确显示 API 不可用，不得伪装为空计划。
+
+回滚 UI 不删除数据。回滚 Hub binary 后新增表由旧 binary 忽略；再次升级后 scheduler 根据持久状态收敛。回滚期间不会由节点本地补跑。
+
+## 8. 验收门
+
+分层 Docker 门：schema/时间计算 → 认证与 network isolation → 单次真实投递 → recurrence/重启/幂等/non-overlap/rename → Dashboard/App contract → 安全 mutation。报告必须区分“设计/契约通过”和“真实 Hub 触发普通 task 通过”。

--- a/docs/rfcs/RFC-034-hub-scheduled-tasks.md
+++ b/docs/rfcs/RFC-034-hub-scheduled-tasks.md
@@ -35,7 +35,7 @@
 6. 单次计划无论成功投递或因目标失效而失败，均进入 `completed`，不永久自旋。
 7. 目标处于 stop/delete lifecycle 时 fail closed，run 记录失败；普通 offline 仍排队。
 
-SQLite transaction 是当前生产原子边界。仓库现有 PostgreSQL adapter 已明确不提供真实跨语句 transaction；在该 adapter 修复前，不得把 PostgreSQL 宣称为 scheduler 的 production-safe 后端。
+SQLite transaction 是当前生产原子边界。仓库现有 PostgreSQL adapter 已明确不提供真实跨语句 transaction；`startHub()` 会在监听前 fail closed，直到该 adapter 修复，不得把 PostgreSQL 宣称为 scheduler 的 production-safe 后端。
 
 多 Hub occurrence 竞争验证针对“进程均已完成数据库初始化”的运行态。独立 Docker 探针发现仓库既有 SQLite adapter 在两个进程完全同时冷启动时，`PRAGMA journal_mode=WAL` 可能先报 `SQLITE_BUSY`；这是 adapter 启动协调的独立既有风险，不能用 scheduler 的 occurrence 唯一键来掩盖，也不计作本 RFC 已修复。
 

--- a/docs/tests/report-test601-hub-scheduled-tasks.txt
+++ b/docs/tests/report-test601-hub-scheduled-tasks.txt
@@ -1,0 +1,82 @@
+# test601 — Hub scheduled tasks
+source_commit=c4d06f38d58e8288ea16106cf4d3cbcd9194f590
+date=2026-08-09T02:13:44+00:00
+L0 build + additive schema
+Bundled 257 modules in 74ms
+
+  commhub-scheduler.js  1.51 MB  (entry point)
+
+L1-L5 real Hub + SQLite: time, auth, dispatch, recurrence, rename, history
+bun test v1.3.14 (0d9b296a)
+
+server/src/scheduled-tasks-http.test.ts:
+[commhub] database: /tmp/test601-green.db
+[commhub] 🎉 14-day free trial started!
+[commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [218.41ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [45.11ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [91.62ms]
+(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [10.30ms]
+[scheduled-tasks] occurrence failed schedule=sched_4b22dcf0-bf91-45bd-ba9a-94b70439a557: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [20.48ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [15.13ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [28.03ms]
+
+ 7 pass
+ 0 fail
+ 42 expect() calls
+Ran 7 tests across 1 file. [1026.00ms]
+L6 witnessed-red: node token cannot create persistent schedules
+MUTATION_RED: node-token-write-gate rc=1
+L7 witnessed-red: overlap check is load-bearing
+MUTATION_RED: no-overlapping-occurrences rc=1
+L8 witnessed-red: optimistic revision rejects stale devices
+MUTATION_RED: optimistic-revision rc=1
+L9 restored green
+bun test v1.3.14 (0d9b296a)
+
+server/src/scheduled-tasks-http.test.ts:
+[commhub] database: /tmp/test601-restored.db
+[commhub] 🎉 14-day free trial started!
+[commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [188.69ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [35.03ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [82.47ms]
+(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [8.61ms]
+[scheduled-tasks] occurrence failed schedule=sched_984f9921-20e3-48a7-88bf-c864fae1546a: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [16.27ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [15.12ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [23.02ms]
+
+ 7 pass
+ 0 fail
+ 42 expect() calls
+Ran 7 tests across 1 file. [966.00ms]
+RESULT: PASS
+
+## Dashboard client — Docker production build
+
+source_commit=ef8708e5fab1c9dfb80e964a43c7b420a92dd72f
+command=sg docker -c 'docker build -t anet-scheduler-dashboard:dev --build-arg SOURCE_COMMIT=ef8708e5fab1c9dfb80e964a43c7b420a92dd72f -f tests/test-scheduled-tasks/Dockerfile . && docker run --rm anet-scheduler-dashboard:dev'
+
+- scheduled-tasks module contract: 11 pass
+- TypeScript (`npx tsc --noEmit`): PASS
+- Next.js 16 production build: PASS, 53/53 static pages
+- generated routes include `/scheduled-tasks` and `/api/hub/scheduled-tasks/[[...path]]`
+- selected-network scope is preserved in both `/api/nodes` and the legacy `/api/status` fallback
+- image tag removed by exact name after evidence capture
+
+RESULT: PASS
+
+## Official App client — Docker Expo 56 export
+
+source_commit=d96bee789a8a323ba5ed5e8711087e740310b92e
+command=sg docker -c 'docker build -t anet-scheduler-app:dev --build-arg SOURCE_COMMIT=d96bee789a8a323ba5ed5e8711087e740310b92e -f tests/test-scheduled-tasks/Dockerfile . && docker run --rm anet-scheduler-app:dev'
+
+- scheduled-tasks API contract: 10 pass
+- auth token remains in Authorization header; network and stable node_id are explicit
+- Expo 56 real web export: PASS, 423 modules, `index.html` emitted
+- repository-wide standalone `tsc` remains blocked by pre-existing Buffer typings in `src/attach-download.test.ts`; no scheduler file is in that diagnostic set
+- image tag removed by exact name after evidence capture
+
+RESULT: PASS

--- a/docs/tests/report-test601-hub-scheduled-tasks.txt
+++ b/docs/tests/report-test601-hub-scheduled-tasks.txt
@@ -1,10 +1,10 @@
 # test601 — Hub scheduled tasks
-source_commit=fe19ef1363d840c88472cd5800c195fe74a184ee
-date=2026-08-09T02:24:14+00:00
+source_commit=7b54723e4ca30f1344714c4f72c025ffd37766dd
+date=2026-08-09T02:26:30+00:00
 L0 build + additive schema
-Bundled 257 modules in 62ms
+Bundled 257 modules in 66ms
 
-  commhub-scheduler.js  1.51 MB  (entry point)
+  commhub-scheduler.js  1.52 MB  (entry point)
 
 L1-L5 real Hub + SQLite: time, auth, dispatch, recurrence, rename, history
 bun test v1.3.14 (0d9b296a)
@@ -13,20 +13,20 @@ server/src/scheduled-tasks-http.test.ts:
 [commhub] database: /tmp/test601-green.db
 [commhub] 🎉 14-day free trial started!
 [commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
-(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [205.66ms]
-(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [37.03ms]
-(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [71.28ms]
-(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [12.12ms]
-[scheduled-tasks] occurrence failed schedule=sched_07302a06-e09a-4e8c-b06e-9910b23978e0: test601_injected_task_failure
-(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [16.31ms]
-(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [159.59ms]
-(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [16.13ms]
-(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [23.13ms]
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [850.26ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [31.65ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [90.31ms]
+(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [12.27ms]
+[scheduled-tasks] occurrence failed schedule=sched_2376c489-f046-47e3-a6d3-1e30bcbce72a: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [18.14ms]
+(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [180.43ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [16.25ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [26.81ms]
 
  8 pass
  0 fail
- 49 expect() calls
-Ran 8 tests across 1 file. [1173.00ms]
+ 52 expect() calls
+Ran 8 tests across 1 file. [1.91s]
 L6 witnessed-red: node token cannot create persistent schedules
 MUTATION_RED: node-token-write-gate rc=1
 L7 witnessed-red: cross-process occurrence claim is load-bearing
@@ -35,27 +35,29 @@ L8 witnessed-red: overlap check is load-bearing
 MUTATION_RED: no-overlapping-occurrences rc=1
 L9 witnessed-red: optimistic revision rejects stale devices
 MUTATION_RED: optimistic-revision rc=1
-L10 restored green
+L10 witnessed-red: DST fall-back duplicate suppression is load-bearing
+MUTATION_RED: dst-fallback-single-occurrence rc=1
+L11 restored green
 bun test v1.3.14 (0d9b296a)
 
 server/src/scheduled-tasks-http.test.ts:
 [commhub] database: /tmp/test601-restored.db
 [commhub] 🎉 14-day free trial started!
 [commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
-(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [195.62ms]
-(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [36.22ms]
-(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [83.90ms]
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [964.22ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [33.83ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [91.92ms]
 (pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [10.02ms]
-[scheduled-tasks] occurrence failed schedule=sched_b7132fa3-4723-4393-8e44-0e2f4b053c8a: test601_injected_task_failure
-(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [17.92ms]
-(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [170.70ms]
-(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [16.84ms]
-(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [22.67ms]
+[scheduled-tasks] occurrence failed schedule=sched_6617c767-4b2c-40b9-885a-ef81e11d4553: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [21.80ms]
+(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [159.94ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [15.64ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [21.55ms]
 
  8 pass
  0 fail
- 49 expect() calls
-Ran 8 tests across 1 file. [1176.00ms]
+ 52 expect() calls
+Ran 8 tests across 1 file. [2.00s]
 RESULT: PASS
 
 ## Dashboard client — Docker production build

--- a/docs/tests/report-test601-hub-scheduled-tasks.txt
+++ b/docs/tests/report-test601-hub-scheduled-tasks.txt
@@ -1,8 +1,8 @@
 # test601 — Hub scheduled tasks
-source_commit=7b54723e4ca30f1344714c4f72c025ffd37766dd
-date=2026-08-09T02:26:30+00:00
+source_commit=8c8d8d653e118d8ca075ed28656cd772eb3a4892
+date=2026-08-09T02:28:48+00:00
 L0 build + additive schema
-Bundled 257 modules in 66ms
+Bundled 257 modules in 62ms
 
   commhub-scheduler.js  1.52 MB  (entry point)
 
@@ -13,20 +13,21 @@ server/src/scheduled-tasks-http.test.ts:
 [commhub] database: /tmp/test601-green.db
 [commhub] 🎉 14-day free trial started!
 [commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
-(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [850.26ms]
-(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [31.65ms]
-(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [90.31ms]
-(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [12.27ms]
-[scheduled-tasks] occurrence failed schedule=sched_2376c489-f046-47e3-a6d3-1e30bcbce72a: test601_injected_task_failure
-(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [18.14ms]
-(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [180.43ms]
-(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [16.25ms]
-(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [26.81ms]
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [892.22ms]
+(pass) Hub scheduled task API and dispatcher > scheduler startup rejects a backend without real transactions [0.47ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [37.56ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [84.69ms]
+(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [11.93ms]
+[scheduled-tasks] occurrence failed schedule=sched_4bc6ce98-3b16-42a6-a48e-826cac849c37: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [17.26ms]
+(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [165.36ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [16.28ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [22.30ms]
 
- 8 pass
+ 9 pass
  0 fail
- 52 expect() calls
-Ran 8 tests across 1 file. [1.91s]
+ 58 expect() calls
+Ran 9 tests across 1 file. [1.94s]
 L6 witnessed-red: node token cannot create persistent schedules
 MUTATION_RED: node-token-write-gate rc=1
 L7 witnessed-red: cross-process occurrence claim is load-bearing
@@ -37,27 +38,30 @@ L9 witnessed-red: optimistic revision rejects stale devices
 MUTATION_RED: optimistic-revision rc=1
 L10 witnessed-red: DST fall-back duplicate suppression is load-bearing
 MUTATION_RED: dst-fallback-single-occurrence rc=1
-L11 restored green
+L11 witnessed-red: non-transactional backend startup gate is load-bearing
+MUTATION_RED: non-transactional-backend-gate rc=1
+L12 restored green
 bun test v1.3.14 (0d9b296a)
 
 server/src/scheduled-tasks-http.test.ts:
 [commhub] database: /tmp/test601-restored.db
 [commhub] 🎉 14-day free trial started!
 [commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
-(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [964.22ms]
-(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [33.83ms]
-(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [91.92ms]
-(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [10.02ms]
-[scheduled-tasks] occurrence failed schedule=sched_6617c767-4b2c-40b9-885a-ef81e11d4553: test601_injected_task_failure
-(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [21.80ms]
-(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [159.94ms]
-(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [15.64ms]
-(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [21.55ms]
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [870.90ms]
+(pass) Hub scheduled task API and dispatcher > scheduler startup rejects a backend without real transactions [0.62ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [33.92ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [98.04ms]
+(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [8.98ms]
+[scheduled-tasks] occurrence failed schedule=sched_60d8ea83-397b-434e-861f-8141f03edfad: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [16.82ms]
+(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [169.63ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [17.92ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [25.36ms]
 
- 8 pass
+ 9 pass
  0 fail
- 52 expect() calls
-Ran 8 tests across 1 file. [2.00s]
+ 58 expect() calls
+Ran 9 tests across 1 file. [1.93s]
 RESULT: PASS
 
 ## Dashboard client — Docker production build

--- a/docs/tests/report-test601-hub-scheduled-tasks.txt
+++ b/docs/tests/report-test601-hub-scheduled-tasks.txt
@@ -1,8 +1,8 @@
 # test601 — Hub scheduled tasks
-source_commit=c4d06f38d58e8288ea16106cf4d3cbcd9194f590
-date=2026-08-09T02:13:44+00:00
+source_commit=41412bcce8f212db0482628fa6ab821ab5f5b40d
+date=2026-08-09T02:17:37+00:00
 L0 build + additive schema
-Bundled 257 modules in 74ms
+Bundled 257 modules in 58ms
 
   commhub-scheduler.js  1.51 MB  (entry point)
 
@@ -13,19 +13,19 @@ server/src/scheduled-tasks-http.test.ts:
 [commhub] database: /tmp/test601-green.db
 [commhub] 🎉 14-day free trial started!
 [commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
-(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [218.41ms]
-(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [45.11ms]
-(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [91.62ms]
-(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [10.30ms]
-[scheduled-tasks] occurrence failed schedule=sched_4b22dcf0-bf91-45bd-ba9a-94b70439a557: test601_injected_task_failure
-(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [20.48ms]
-(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [15.13ms]
-(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [28.03ms]
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [185.94ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [35.17ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [89.56ms]
+(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [11.33ms]
+[scheduled-tasks] occurrence failed schedule=sched_0f6673b2-7cc0-40c4-ad1b-0d402a5b288d: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [22.91ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [20.32ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [39.51ms]
 
  7 pass
  0 fail
- 42 expect() calls
-Ran 7 tests across 1 file. [1026.00ms]
+ 44 expect() calls
+Ran 7 tests across 1 file. [1035.00ms]
 L6 witnessed-red: node token cannot create persistent schedules
 MUTATION_RED: node-token-write-gate rc=1
 L7 witnessed-red: overlap check is load-bearing
@@ -39,19 +39,19 @@ server/src/scheduled-tasks-http.test.ts:
 [commhub] database: /tmp/test601-restored.db
 [commhub] 🎉 14-day free trial started!
 [commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
-(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [188.69ms]
-(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [35.03ms]
-(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [82.47ms]
-(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [8.61ms]
-[scheduled-tasks] occurrence failed schedule=sched_984f9921-20e3-48a7-88bf-c864fae1546a: test601_injected_task_failure
-(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [16.27ms]
-(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [15.12ms]
-(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [23.02ms]
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [202.75ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [37.01ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [82.70ms]
+(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [9.04ms]
+[scheduled-tasks] occurrence failed schedule=sched_7225dcc8-5597-4b79-b5c4-5de9d973337c: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [22.81ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [17.51ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [24.74ms]
 
  7 pass
  0 fail
- 42 expect() calls
-Ran 7 tests across 1 file. [966.00ms]
+ 44 expect() calls
+Ran 7 tests across 1 file. [1032.00ms]
 RESULT: PASS
 
 ## Dashboard client — Docker production build

--- a/docs/tests/report-test601-hub-scheduled-tasks.txt
+++ b/docs/tests/report-test601-hub-scheduled-tasks.txt
@@ -66,10 +66,10 @@ RESULT: PASS
 
 ## Dashboard client — Docker production build
 
-source_commit=ef8708e5fab1c9dfb80e964a43c7b420a92dd72f
-command=sg docker -c 'docker build -t anet-scheduler-dashboard:dev --build-arg SOURCE_COMMIT=ef8708e5fab1c9dfb80e964a43c7b420a92dd72f -f tests/test-scheduled-tasks/Dockerfile . && docker run --rm anet-scheduler-dashboard:dev'
+source_commit=4bbc4ea4b561392e6a0bd43b703cb9fcafb2063f
+command=sg docker -c 'docker build -t anet-scheduler-dashboard:dev --build-arg SOURCE_COMMIT=4bbc4ea4b561392e6a0bd43b703cb9fcafb2063f -f tests/test-scheduled-tasks/Dockerfile . && docker run --rm anet-scheduler-dashboard:dev'
 
-- scheduled-tasks module contract: 11 pass
+- scheduled-tasks module contract: 12 pass
 - TypeScript (`npx tsc --noEmit`): PASS
 - Next.js 16 production build: PASS, 53/53 static pages
 - generated routes include `/scheduled-tasks` and `/api/hub/scheduled-tasks/[[...path]]`
@@ -80,10 +80,10 @@ RESULT: PASS
 
 ## Official App client — Docker Expo 56 export
 
-source_commit=d96bee789a8a323ba5ed5e8711087e740310b92e
-command=sg docker -c 'docker build -t anet-scheduler-app:dev --build-arg SOURCE_COMMIT=d96bee789a8a323ba5ed5e8711087e740310b92e -f tests/test-scheduled-tasks/Dockerfile . && docker run --rm anet-scheduler-app:dev'
+source_commit=be52ae8c63e0b490323e205e9009555f0dd4ff4a
+command=sg docker -c 'docker build -t anet-scheduler-app:dev --build-arg SOURCE_COMMIT=be52ae8c63e0b490323e205e9009555f0dd4ff4a -f tests/test-scheduled-tasks/Dockerfile . && docker run --rm anet-scheduler-app:dev'
 
-- scheduled-tasks API contract: 10 pass
+- scheduled-tasks API contract: 11 pass
 - auth token remains in Authorization header; network and stable node_id are explicit
 - Expo 56 real web export: PASS, 423 modules, `index.html` emitted
 - repository-wide standalone `tsc` remains blocked by pre-existing Buffer typings in `src/attach-download.test.ts`; no scheduler file is in that diagnostic set

--- a/docs/tests/report-test601-hub-scheduled-tasks.txt
+++ b/docs/tests/report-test601-hub-scheduled-tasks.txt
@@ -1,8 +1,8 @@
 # test601 — Hub scheduled tasks
-source_commit=41412bcce8f212db0482628fa6ab821ab5f5b40d
-date=2026-08-09T02:17:37+00:00
+source_commit=fe19ef1363d840c88472cd5800c195fe74a184ee
+date=2026-08-09T02:24:14+00:00
 L0 build + additive schema
-Bundled 257 modules in 58ms
+Bundled 257 modules in 62ms
 
   commhub-scheduler.js  1.51 MB  (entry point)
 
@@ -13,45 +13,49 @@ server/src/scheduled-tasks-http.test.ts:
 [commhub] database: /tmp/test601-green.db
 [commhub] 🎉 14-day free trial started!
 [commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
-(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [185.94ms]
-(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [35.17ms]
-(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [89.56ms]
-(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [11.33ms]
-[scheduled-tasks] occurrence failed schedule=sched_0f6673b2-7cc0-40c4-ad1b-0d402a5b288d: test601_injected_task_failure
-(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [22.91ms]
-(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [20.32ms]
-(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [39.51ms]
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [205.66ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [37.03ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [71.28ms]
+(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [12.12ms]
+[scheduled-tasks] occurrence failed schedule=sched_07302a06-e09a-4e8c-b06e-9910b23978e0: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [16.31ms]
+(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [159.59ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [16.13ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [23.13ms]
 
- 7 pass
+ 8 pass
  0 fail
- 44 expect() calls
-Ran 7 tests across 1 file. [1035.00ms]
+ 49 expect() calls
+Ran 8 tests across 1 file. [1173.00ms]
 L6 witnessed-red: node token cannot create persistent schedules
 MUTATION_RED: node-token-write-gate rc=1
-L7 witnessed-red: overlap check is load-bearing
+L7 witnessed-red: cross-process occurrence claim is load-bearing
+MUTATION_RED: cross-process-occurrence-claim rc=1
+L8 witnessed-red: overlap check is load-bearing
 MUTATION_RED: no-overlapping-occurrences rc=1
-L8 witnessed-red: optimistic revision rejects stale devices
+L9 witnessed-red: optimistic revision rejects stale devices
 MUTATION_RED: optimistic-revision rc=1
-L9 restored green
+L10 restored green
 bun test v1.3.14 (0d9b296a)
 
 server/src/scheduled-tasks-http.test.ts:
 [commhub] database: /tmp/test601-restored.db
 [commhub] 🎉 14-day free trial started!
 [commhub] node_id backfill: inbox=0, tasks.to=0, tasks.from=0, total=0
-(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [202.75ms]
-(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [37.01ms]
-(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [82.70ms]
-(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [9.04ms]
-[scheduled-tasks] occurrence failed schedule=sched_7225dcc8-5597-4b79-b5c4-5de9d973337c: test601_injected_task_failure
-(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [22.81ms]
-(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [17.51ms]
-(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [24.74ms]
+(pass) Hub scheduled task API and dispatcher > schedule math supports timezone-aware daily and weekly forms [195.62ms]
+(pass) Hub scheduled task API and dispatcher > owner creates; viewer and node token cannot mutate [36.22ms]
+(pass) Hub scheduled task API and dispatcher > network scope hides schedules from foreign users and viewers may read [83.90ms]
+(pass) Hub scheduled task API and dispatcher > due occurrence creates ordinary inbox/task/run atomically and is idempotent [10.02ms]
+[scheduled-tasks] occurrence failed schedule=sched_b7132fa3-4723-4393-8e44-0e2f4b053c8a: test601_injected_task_failure
+(pass) Hub scheduled task API and dispatcher > dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit [17.92ms]
+(pass) Hub scheduled task API and dispatcher > two real Hub processes claim one occurrence exactly once [170.70ms]
+(pass) Hub scheduled task API and dispatcher > non-overlap skips while prior task is open; rename follows stable node_id [16.84ms]
+(pass) Hub scheduled task API and dispatcher > optimistic revision, pause/resume, run-now and cancel preserve history [22.67ms]
 
- 7 pass
+ 8 pass
  0 fail
- 44 expect() calls
-Ran 7 tests across 1 file. [1032.00ms]
+ 49 expect() calls
+Ran 8 tests across 1 file. [1176.00ms]
 RESULT: PASS
 
 ## Dashboard client — Docker production build

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1061,6 +1061,60 @@ try { db.exec("CREATE INDEX IF NOT EXISTS idx_completions_network ON completions
 // the reply up the chain via parent_task_id.
 try { db.exec("ALTER TABLE tasks ADD COLUMN parent_task_id TEXT"); } catch {}
 try { db.exec("ALTER TABLE tasks ADD COLUMN meta_json TEXT"); } catch {}
+
+// ── Hub scheduled tasks ──────────────────────────────────────────────
+// Scheduling is a Hub concern: clients manage these rows, while agents only
+// receive the ordinary inbox/tasks rows produced for each occurrence.  Keep
+// the occurrence table separate so retries, skips and failures remain
+// auditable without overloading the task lifecycle.
+db.exec(`
+  CREATE TABLE IF NOT EXISTS scheduled_tasks (
+    schedule_id      TEXT PRIMARY KEY,
+    network_id       TEXT NOT NULL,
+    created_by       TEXT,
+    name             TEXT NOT NULL,
+    target_node_id   TEXT NOT NULL,
+    target_alias     TEXT NOT NULL,
+    task_content     TEXT NOT NULL,
+    priority         TEXT NOT NULL DEFAULT 'normal',
+    schedule_type    TEXT NOT NULL,
+    schedule_json    TEXT NOT NULL,
+    timezone         TEXT NOT NULL DEFAULT 'UTC',
+    overlap_policy   TEXT NOT NULL DEFAULT 'skip',
+    status           TEXT NOT NULL DEFAULT 'active',
+    next_run_at      TEXT,
+    last_run_at      TEXT,
+    revision         INTEGER NOT NULL DEFAULT 1,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_scheduled_tasks_due
+    ON scheduled_tasks(status, next_run_at);
+  CREATE INDEX IF NOT EXISTS idx_scheduled_tasks_network
+    ON scheduled_tasks(network_id, updated_at DESC);
+  CREATE INDEX IF NOT EXISTS idx_scheduled_tasks_target
+    ON scheduled_tasks(network_id, target_node_id);
+
+  CREATE TABLE IF NOT EXISTS scheduled_task_runs (
+    run_id           TEXT PRIMARY KEY,
+    schedule_id      TEXT NOT NULL,
+    network_id       TEXT NOT NULL,
+    scheduled_for    TEXT NOT NULL,
+    task_id          TEXT,
+    status           TEXT NOT NULL,
+    error_code       TEXT,
+    error_message    TEXT,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at     TEXT,
+    UNIQUE(schedule_id, scheduled_for)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_scheduled_runs_schedule
+    ON scheduled_task_runs(schedule_id, created_at DESC);
+  CREATE INDEX IF NOT EXISTS idx_scheduled_runs_network
+    ON scheduled_task_runs(network_id, created_at DESC);
+`);
 try { db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_task_id)"); } catch {}
 
 // Helpers

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -181,15 +181,25 @@ describe("Hub scheduled task API and dispatcher", () => {
     const gate = join(raceDir, "go");
     const workerPath = "tests/test601-hub-scheduled-tasks/race-worker.ts";
     const dbPath = process.env.COMMHUB_DB!;
-    const workers = ["a", "b"].map((id) => Bun.spawn(
+    const spawnWorker = (id: string) => Bun.spawn(
       ["bun", workerPath, dbPath, raceScheduleId, due, join(raceDir, `ready-${id}`), gate],
       { cwd: process.cwd(), stdout: "pipe", stderr: "pipe", env: { ...process.env, COMMHUB_DB: dbPath } },
-    ));
-    const readyDeadline = Date.now() + 12_000;
-    while ((!existsSync(join(raceDir, "ready-a")) || !existsSync(join(raceDir, "ready-b"))) && Date.now() < readyDeadline) {
-      await Bun.sleep(10);
-    }
-    if (!existsSync(join(raceDir, "ready-a")) || !existsSync(join(raceDir, "ready-b"))) {
+    );
+    const waitReady = async (id: string) => {
+      const readyPath = join(raceDir, `ready-${id}`);
+      const deadline = Date.now() + 8_000;
+      while (!existsSync(readyPath) && Date.now() < deadline) await Bun.sleep(10);
+      return existsSync(readyPath);
+    };
+
+    // Start both DB connections before opening the claim gate. Initializing
+    // them sequentially isolates the occurrence race from the repository's
+    // pre-existing simultaneous-cold-start PRAGMA journal_mode=WAL race.
+    const workers = [spawnWorker("a")];
+    const readyA = await waitReady("a");
+    if (readyA) workers.push(spawnWorker("b"));
+    const readyB = readyA && await waitReady("b");
+    if (!readyA || !readyB) {
       for (const worker of workers) worker.kill();
       await Promise.all(workers.map((worker) => worker.exited));
       const diagnostics = await Promise.all(workers.map(async (worker) => ({

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -185,19 +185,26 @@ describe("Hub scheduled task API and dispatcher", () => {
       ["bun", workerPath, dbPath, raceScheduleId, due, join(raceDir, `ready-${id}`), gate],
       { cwd: process.cwd(), stdout: "pipe", stderr: "pipe", env: { ...process.env, COMMHUB_DB: dbPath } },
     ));
-    const readyDeadline = Date.now() + 10_000;
+    const readyDeadline = Date.now() + 12_000;
     while ((!existsSync(join(raceDir, "ready-a")) || !existsSync(join(raceDir, "ready-b"))) && Date.now() < readyDeadline) {
       await Bun.sleep(10);
     }
-    expect(existsSync(join(raceDir, "ready-a"))).toBe(true);
-    expect(existsSync(join(raceDir, "ready-b"))).toBe(true);
+    if (!existsSync(join(raceDir, "ready-a")) || !existsSync(join(raceDir, "ready-b"))) {
+      for (const worker of workers) worker.kill();
+      await Promise.all(workers.map((worker) => worker.exited));
+      const diagnostics = await Promise.all(workers.map(async (worker) => ({
+        stdout: await new Response(worker.stdout).text(),
+        stderr: await new Response(worker.stderr).text(),
+      })));
+      throw new Error(`race_workers_not_ready: ${JSON.stringify(diagnostics)}`);
+    }
     writeFileSync(gate, "go\n", { mode: 0o600 });
     const exits = (await Promise.all(workers.map((worker) => worker.exited))).sort((a, b) => a - b);
     expect(exits).toEqual([0, 3]);
     expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM scheduled_task_runs WHERE schedule_id = ?1", raceScheduleId)!.count).toBe(1);
     expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE meta_json LIKE '%' || ?1 || '%'", raceScheduleId)!.count).toBe(1);
     expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM inbox WHERE meta_json LIKE '%' || ?1 || '%'", raceScheduleId)!.count).toBe(1);
-  });
+  }, 20_000);
 
   test("non-overlap skips while prior task is open; rename follows stable node_id", () => {
     const firstTask = db.get<{ task_id: string }>("SELECT task_id FROM scheduled_task_runs WHERE schedule_id = ?1 AND task_id IS NOT NULL LIMIT 1", scheduleId)!.task_id;

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { addNetworkMember, createNetworkTokenForNode, register } from "./auth.js";
@@ -158,6 +158,45 @@ describe("Hub scheduled task API and dispatcher", () => {
     db.run("DROP TRIGGER test601_abort_scheduled_task_insert");
     expect(runDueScheduledTasks().processed).toBe(1);
     expect(db.get("SELECT task_id FROM scheduled_task_runs WHERE schedule_id = ?1", atomicScheduleId)).toBeTruthy();
+  });
+
+  test("two real Hub processes claim one occurrence exactly once", async () => {
+    const created = await api(ownerToken, "/api/scheduled-tasks", {
+      method: "POST",
+      body: JSON.stringify({
+        network_id: networkId,
+        name: "Cross-process claim probe",
+        target_node_id: nodeId,
+        task: "Only one worker may create this task",
+        timezone: "UTC",
+        schedule: { type: "interval", every_seconds: 60 },
+      }),
+    });
+    expect(created.status).toBe(201);
+    const raceScheduleId = created.body.schedule.schedule_id as string;
+    const due = new Date(Date.now() - 5_000).toISOString();
+    db.run("UPDATE scheduled_tasks SET next_run_at = ?1 WHERE schedule_id = ?2", [due, raceScheduleId]);
+
+    const raceDir = mkdtempSync(join(dir, "race-"));
+    const gate = join(raceDir, "go");
+    const workerPath = "tests/test601-hub-scheduled-tasks/race-worker.ts";
+    const dbPath = process.env.COMMHUB_DB!;
+    const workers = ["a", "b"].map((id) => Bun.spawn(
+      ["bun", workerPath, dbPath, raceScheduleId, due, join(raceDir, `ready-${id}`), gate],
+      { cwd: process.cwd(), stdout: "pipe", stderr: "pipe", env: { ...process.env, COMMHUB_DB: dbPath } },
+    ));
+    const readyDeadline = Date.now() + 10_000;
+    while ((!existsSync(join(raceDir, "ready-a")) || !existsSync(join(raceDir, "ready-b"))) && Date.now() < readyDeadline) {
+      await Bun.sleep(10);
+    }
+    expect(existsSync(join(raceDir, "ready-a"))).toBe(true);
+    expect(existsSync(join(raceDir, "ready-b"))).toBe(true);
+    writeFileSync(gate, "go\n", { mode: 0o600 });
+    const exits = (await Promise.all(workers.map((worker) => worker.exited))).sort((a, b) => a - b);
+    expect(exits).toEqual([0, 3]);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM scheduled_task_runs WHERE schedule_id = ?1", raceScheduleId)!.count).toBe(1);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE meta_json LIKE '%' || ?1 || '%'", raceScheduleId)!.count).toBe(1);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM inbox WHERE meta_json LIKE '%' || ?1 || '%'", raceScheduleId)!.count).toBe(1);
   });
 
   test("non-overlap skips while prior task is open; rename follows stable node_id", () => {

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { addNetworkMember, createNetworkTokenForNode, register } from "./auth.js";
 import { db } from "./db.js";
-import { nextOccurrence, runDueScheduledTasks } from "./scheduled-tasks.js";
+import { assertScheduledTaskBackendSupported, nextOccurrence, runDueScheduledTasks } from "./scheduled-tasks.js";
 
 const dir = mkdtempSync(join(tmpdir(), "anet-scheduler-"));
 const activeDbPath = process.env.COMMHUB_DB;
@@ -84,6 +84,17 @@ describe("Hub scheduled task API and dispatcher", () => {
     expect(fallAfterFirst?.toISOString()).toBe("2026-11-02T06:30:00.000Z");
   });
 
+  test("scheduler startup rejects a backend without real transactions", () => {
+    const original = db.dialect;
+    try {
+      (db as any).dialect = "postgres";
+      expect(() => assertScheduledTaskBackendSupported()).toThrow("scheduled_tasks_require_transactional_sqlite_backend");
+    } finally {
+      (db as any).dialect = original;
+    }
+    expect(() => assertScheduledTaskBackendSupported()).not.toThrow();
+  });
+
   test("owner creates; viewer and node token cannot mutate", async () => {
     const input = {
       network_id: networkId,
@@ -99,6 +110,10 @@ describe("Hub scheduled task API and dispatcher", () => {
     const node = await api(nodeToken, "/api/scheduled-tasks", { method: "POST", body: JSON.stringify(input) });
     expect(node.status).toBe(403);
     expect(node.body.error).toBe("user_token_required");
+    const nodeRead = await api(nodeToken, `/api/scheduled-tasks?network_id=${encodeURIComponent(networkId)}`);
+    expect(nodeRead.status).toBe(403);
+    expect(nodeRead.body.error).toBe("user_token_required");
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM scheduled_tasks WHERE name = 'Daily briefing'")!.count).toBe(0);
 
     const created = await api(ownerToken, "/api/scheduled-tasks", { method: "POST", body: JSON.stringify(input) });
     expect(created.status).toBe(201);
@@ -134,6 +149,7 @@ describe("Hub scheduled task API and dispatcher", () => {
     expect(task.to_name).toBe("scheduler-node");
     expect(task.from_name).toBe("scheduler");
     expect(JSON.parse(task.meta_json).scheduled_task_id).toBe(scheduleId);
+    expect(JSON.parse(task.meta_json).created_by).toBeUndefined();
     expect(db.get<any>("SELECT id FROM inbox WHERE id = ?1", run.task_id)).toBeTruthy();
     expect(runDueScheduledTasks().processed).toBe(0);
   });

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -122,6 +122,42 @@ describe("Hub scheduled task API and dispatcher", () => {
     expect(runDueScheduledTasks().processed).toBe(0);
   });
 
+  test("dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit", async () => {
+    const created = await api(ownerToken, "/api/scheduled-tasks", {
+      method: "POST",
+      body: JSON.stringify({
+        network_id: networkId,
+        name: "Atomic rollback probe",
+        target_node_id: nodeId,
+        task: "This dispatch must be all-or-nothing",
+        timezone: "UTC",
+        schedule: { type: "interval", every_seconds: 60 },
+      }),
+    });
+    expect(created.status).toBe(201);
+    const atomicScheduleId = created.body.schedule.schedule_id as string;
+    const due = new Date(Date.now() - 10_000).toISOString();
+    db.run("UPDATE scheduled_tasks SET next_run_at = ?1 WHERE schedule_id = ?2", [due, atomicScheduleId]);
+
+    // Test-only fault injection at the second durable write. The inbox row has
+    // already been attempted when this aborts, so any missing transaction
+    // boundary leaves an observable half-state.
+    db.run(`CREATE TRIGGER test601_abort_scheduled_task_insert
+      BEFORE INSERT ON tasks
+      WHEN NEW.meta_json LIKE '%${atomicScheduleId}%'
+      BEGIN SELECT RAISE(ABORT, 'test601_injected_task_failure'); END`);
+    const failed = runDueScheduledTasks();
+    expect(failed.failed).toBe(1);
+    expect(db.get("SELECT run_id FROM scheduled_task_runs WHERE schedule_id = ?1", atomicScheduleId)).toBeNull();
+    expect(db.get("SELECT id FROM inbox WHERE meta_json LIKE '%' || ?1 || '%'", atomicScheduleId)).toBeNull();
+    expect(db.get("SELECT task_id FROM tasks WHERE meta_json LIKE '%' || ?1 || '%'", atomicScheduleId)).toBeNull();
+    expect(db.get<{ next_run_at: string }>("SELECT next_run_at FROM scheduled_tasks WHERE schedule_id = ?1", atomicScheduleId)!.next_run_at).toBe(due);
+
+    db.run("DROP TRIGGER test601_abort_scheduled_task_insert");
+    expect(runDueScheduledTasks().processed).toBe(1);
+    expect(db.get("SELECT task_id FROM scheduled_task_runs WHERE schedule_id = ?1", atomicScheduleId)).toBeTruthy();
+  });
+
   test("non-overlap skips while prior task is open; rename follows stable node_id", () => {
     const firstTask = db.get<{ task_id: string }>("SELECT task_id FROM scheduled_task_runs WHERE schedule_id = ?1 AND task_id IS NOT NULL LIMIT 1", scheduleId)!.task_id;
     const due2 = new Date(Date.now() - 60_000).toISOString();

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -91,6 +91,8 @@ describe("Hub scheduled task API and dispatcher", () => {
     expect(created.body.schedule.target_node_id).toBe(nodeId);
     expect(created.body.schedule.target_alias).toBe("scheduler-node");
     expect(created.body.schedule.schedule.type).toBe("interval");
+    expect(created.body.schedule.created_by).toBeUndefined();
+    expect(created.body.schedule.schedule_json).toBeUndefined();
     scheduleId = created.body.schedule.schedule_id;
     revision = created.body.schedule.revision;
   });

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -7,6 +7,8 @@ import { db } from "./db.js";
 import { nextOccurrence, runDueScheduledTasks } from "./scheduled-tasks.js";
 
 const dir = mkdtempSync(join(tmpdir(), "anet-scheduler-"));
+const activeDbPath = process.env.COMMHUB_DB;
+if (!activeDbPath) throw new Error("test601 requires COMMHUB_DB before module import");
 let server: any;
 let base = "";
 let ownerToken = "";
@@ -25,7 +27,6 @@ async function api(token: string, path: string, init?: RequestInit) {
 }
 
 beforeAll(async () => {
-  process.env.COMMHUB_DB = join(dir, "hub.db");
   const owner = register(`scheduler_owner_${Date.now()}`, "SchedulerOwner123!", undefined, "seed");
   expect(owner.ok).toBe(true);
   ownerToken = owner.token!;
@@ -180,7 +181,7 @@ describe("Hub scheduled task API and dispatcher", () => {
     const raceDir = mkdtempSync(join(dir, "race-"));
     const gate = join(raceDir, "go");
     const workerPath = "tests/test601-hub-scheduled-tasks/race-worker.ts";
-    const dbPath = process.env.COMMHUB_DB!;
+    const dbPath = activeDbPath;
     const spawnWorker = (id: string) => Bun.spawn(
       ["bun", workerPath, dbPath, raceScheduleId, due, join(raceDir, `ready-${id}`), gate],
       { cwd: process.cwd(), stdout: "pipe", stderr: "pipe", env: { ...process.env, COMMHUB_DB: dbPath } },

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -69,6 +69,19 @@ describe("Hub scheduled task API and dispatcher", () => {
     expect(daily?.toISOString()).toBe("2026-08-10T01:30:00.000Z");
     const weekly = nextOccurrence({ type: "weekly", time: "09:30", weekdays: [1] }, "Asia/Shanghai", new Date("2026-08-09T02:00:00Z"));
     expect(weekly?.toISOString()).toBe("2026-08-10T01:30:00.000Z");
+
+    // America/New_York skips 02:30 on 2026-03-08, so the next valid wall
+    // clock occurrence is the following day rather than an offset guess.
+    const springGap = nextOccurrence({ type: "daily", time: "02:30" }, "America/New_York", new Date("2026-03-08T05:00:00Z"));
+    expect(springGap?.toISOString()).toBe("2026-03-09T06:30:00.000Z");
+
+    // 01:30 occurs twice on the fall-back day. Before the first occurrence we
+    // select it; after it has run, the duplicate instant on the same local
+    // date is skipped so a daily schedule remains once-per-day.
+    const fallFirst = nextOccurrence({ type: "daily", time: "01:30" }, "America/New_York", new Date("2026-11-01T04:00:00Z"));
+    expect(fallFirst?.toISOString()).toBe("2026-11-01T05:30:00.000Z");
+    const fallAfterFirst = nextOccurrence({ type: "daily", time: "01:30" }, "America/New_York", fallFirst!);
+    expect(fallAfterFirst?.toISOString()).toBe("2026-11-02T06:30:00.000Z");
   });
 
   test("owner creates; viewer and node token cannot mutate", async () => {

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { addNetworkMember, createNetworkTokenForNode, register } from "./auth.js";
+import { db } from "./db.js";
+import { nextOccurrence, runDueScheduledTasks } from "./scheduled-tasks.js";
+
+const dir = mkdtempSync(join(tmpdir(), "anet-scheduler-"));
+let server: any;
+let base = "";
+let ownerToken = "";
+let viewerToken = "";
+let nodeToken = "";
+let networkId = "";
+let ownerId = "";
+const nodeId = `n_sched_${Date.now()}`;
+
+async function api(token: string, path: string, init?: RequestInit) {
+  const res = await fetch(`${base}${path}`, {
+    ...init,
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json", ...(init?.headers || {}) },
+  });
+  return { status: res.status, body: await res.json() as any };
+}
+
+beforeAll(async () => {
+  process.env.COMMHUB_DB = join(dir, "hub.db");
+  const owner = register(`scheduler_owner_${Date.now()}`, "SchedulerOwner123!", undefined, "seed");
+  expect(owner.ok).toBe(true);
+  ownerToken = owner.token!;
+  networkId = owner.network_id!;
+  ownerId = db.get<{ owner_id: string }>("SELECT owner_id FROM networks WHERE network_id = ?1", networkId)!.owner_id;
+
+  const viewer = register(`scheduler_viewer_${Date.now()}`, "SchedulerViewer123!", undefined, "seed");
+  expect(viewer.ok).toBe(true);
+  viewerToken = viewer.token!;
+  const viewerId = db.get<{ user_id: string }>("SELECT user_id FROM users WHERE username = ?1", viewer.user!.username)!.user_id;
+  addNetworkMember(networkId, viewerId, "viewer", ownerId);
+  const ntok = createNetworkTokenForNode(ownerId, networkId, "scheduler-node");
+  expect(ntok.ok).toBe(true);
+  nodeToken = ntok.token!;
+
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, runtime, network_id) VALUES (?1, 'Scheduler Node', 'scheduler-node', 'codex-sdk', ?2)`,
+    [nodeId, networkId],
+  );
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, node_id, network_id) VALUES (?1, 'scheduler-node', 'idle', ?2, ?3)`,
+    [`r_${Date.now()}`, nodeId, networkId],
+  );
+  const mod: any = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop?.(true); } catch {}
+  try { rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+describe("Hub scheduled task API and dispatcher", () => {
+  let scheduleId = "";
+  let revision = 0;
+
+  test("schedule math supports timezone-aware daily and weekly forms", () => {
+    const daily = nextOccurrence({ type: "daily", time: "09:30" }, "Asia/Shanghai", new Date("2026-08-09T02:00:00Z"));
+    expect(daily?.toISOString()).toBe("2026-08-10T01:30:00.000Z");
+    const weekly = nextOccurrence({ type: "weekly", time: "09:30", weekdays: [1] }, "Asia/Shanghai", new Date("2026-08-09T02:00:00Z"));
+    expect(weekly?.toISOString()).toBe("2026-08-10T01:30:00.000Z");
+  });
+
+  test("owner creates; viewer and node token cannot mutate", async () => {
+    const input = {
+      network_id: networkId,
+      name: "Daily briefing",
+      target_node_id: nodeId,
+      task: "Summarize the current release state",
+      priority: "high",
+      timezone: "Asia/Shanghai",
+      schedule: { type: "interval", every_seconds: 60 },
+    };
+    const viewer = await api(viewerToken, "/api/scheduled-tasks", { method: "POST", body: JSON.stringify(input) });
+    expect(viewer.status).toBe(403);
+    const node = await api(nodeToken, "/api/scheduled-tasks", { method: "POST", body: JSON.stringify(input) });
+    expect(node.status).toBe(403);
+    expect(node.body.error).toBe("user_token_required");
+
+    const created = await api(ownerToken, "/api/scheduled-tasks", { method: "POST", body: JSON.stringify(input) });
+    expect(created.status).toBe(201);
+    expect(created.body.schedule.target_node_id).toBe(nodeId);
+    expect(created.body.schedule.target_alias).toBe("scheduler-node");
+    expect(created.body.schedule.schedule.type).toBe("interval");
+    scheduleId = created.body.schedule.schedule_id;
+    revision = created.body.schedule.revision;
+  });
+
+  test("network scope hides schedules from foreign users and viewers may read", async () => {
+    const visible = await api(viewerToken, `/api/scheduled-tasks?network_id=${encodeURIComponent(networkId)}`);
+    expect(visible.status).toBe(200);
+    expect(visible.body.schedules.map((x: any) => x.schedule_id)).toContain(scheduleId);
+
+    const foreign = register(`scheduler_foreign_${Date.now()}`, "SchedulerForeign123!", undefined, "seed");
+    expect(foreign.ok).toBe(true);
+    const hidden = await api(foreign.token!, `/api/scheduled-tasks?network_id=${encodeURIComponent(networkId)}`);
+    expect(hidden.status).toBe(403);
+  });
+
+  test("due occurrence creates ordinary inbox/task/run atomically and is idempotent", () => {
+    const due = new Date(Date.now() - 120_000).toISOString();
+    db.run("UPDATE scheduled_tasks SET next_run_at = ?1 WHERE schedule_id = ?2", [due, scheduleId]);
+    expect(runDueScheduledTasks().processed).toBe(1);
+    const run = db.get<any>("SELECT * FROM scheduled_task_runs WHERE schedule_id = ?1 ORDER BY created_at DESC LIMIT 1", scheduleId)!;
+    expect(["delivered", "queued"]).toContain(run.status);
+    expect(run.task_id).toBeTruthy();
+    const task = db.get<any>("SELECT * FROM tasks WHERE task_id = ?1", run.task_id)!;
+    expect(task.to_node_id).toBe(nodeId);
+    expect(task.to_name).toBe("scheduler-node");
+    expect(task.from_name).toBe("scheduler");
+    expect(JSON.parse(task.meta_json).scheduled_task_id).toBe(scheduleId);
+    expect(db.get<any>("SELECT id FROM inbox WHERE id = ?1", run.task_id)).toBeTruthy();
+    expect(runDueScheduledTasks().processed).toBe(0);
+  });
+
+  test("non-overlap skips while prior task is open; rename follows stable node_id", () => {
+    const firstTask = db.get<{ task_id: string }>("SELECT task_id FROM scheduled_task_runs WHERE schedule_id = ?1 AND task_id IS NOT NULL LIMIT 1", scheduleId)!.task_id;
+    const due2 = new Date(Date.now() - 60_000).toISOString();
+    db.run("UPDATE scheduled_tasks SET next_run_at = ?1 WHERE schedule_id = ?2", [due2, scheduleId]);
+    expect(runDueScheduledTasks().processed).toBe(1);
+    expect(db.get<any>("SELECT status FROM scheduled_task_runs WHERE schedule_id = ?1 AND scheduled_for = ?2", scheduleId, due2)!.status).toBe("skipped");
+
+    db.run("UPDATE tasks SET status = 'replied', completed_at = datetime('now') WHERE task_id = ?1", [firstTask]);
+    db.run("UPDATE nodes SET alias = 'scheduler-renamed' WHERE node_id = ?1 AND network_id = ?2", [nodeId, networkId]);
+    db.run("UPDATE sessions SET alias = 'scheduler-renamed' WHERE node_id = ?1 AND network_id = ?2", [nodeId, networkId]);
+    const due3 = new Date(Date.now() - 30_000).toISOString();
+    db.run("UPDATE scheduled_tasks SET next_run_at = ?1 WHERE schedule_id = ?2", [due3, scheduleId]);
+    expect(runDueScheduledTasks().processed).toBe(1);
+    const renamedTask = db.get<any>("SELECT t.* FROM tasks t JOIN scheduled_task_runs r ON r.task_id=t.task_id WHERE r.schedule_id=?1 AND r.scheduled_for=?2", scheduleId, due3)!;
+    expect(renamedTask.to_name).toBe("scheduler-renamed");
+  });
+
+  test("optimistic revision, pause/resume, run-now and cancel preserve history", async () => {
+    const latest = await api(ownerToken, `/api/scheduled-tasks/${scheduleId}?network_id=${encodeURIComponent(networkId)}`);
+    revision = latest.body.schedule.revision;
+    const stale = await api(ownerToken, `/api/scheduled-tasks/${scheduleId}?network_id=${encodeURIComponent(networkId)}`, { method: "PATCH", body: JSON.stringify({ revision: revision - 1, status: "paused" }) });
+    expect(stale.status).toBe(409);
+    const paused = await api(ownerToken, `/api/scheduled-tasks/${scheduleId}?network_id=${encodeURIComponent(networkId)}`, { method: "PATCH", body: JSON.stringify({ revision, status: "paused" }) });
+    expect(paused.body.schedule.status).toBe("paused");
+    expect(paused.body.schedule.next_run_at).toBeNull();
+    const resumed = await api(ownerToken, `/api/scheduled-tasks/${scheduleId}?network_id=${encodeURIComponent(networkId)}`, { method: "PATCH", body: JSON.stringify({ revision: paused.body.schedule.revision, status: "active" }) });
+    expect(resumed.body.schedule.next_run_at).toBeTruthy();
+
+    db.run("UPDATE tasks SET status='replied' WHERE task_id IN (SELECT task_id FROM scheduled_task_runs WHERE schedule_id=?1)", [scheduleId]);
+    const manual = await api(ownerToken, `/api/scheduled-tasks/${scheduleId}/run-now?network_id=${encodeURIComponent(networkId)}`, { method: "POST", body: "{}" });
+    expect(manual.status).toBe(202);
+    expect(manual.body.taskId).toBeTruthy();
+    const cancelled = await api(ownerToken, `/api/scheduled-tasks/${scheduleId}?network_id=${encodeURIComponent(networkId)}`, { method: "DELETE" });
+    expect(cancelled.body.status).toBe("cancelled");
+    const runs = await api(ownerToken, `/api/scheduled-tasks/${scheduleId}/runs?network_id=${encodeURIComponent(networkId)}`);
+    expect(runs.body.runs.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/server/src/scheduled-tasks.ts
+++ b/server/src/scheduled-tasks.ts
@@ -136,7 +136,8 @@ export function nextOccurrence(spec: ScheduleSpec, timezone: string, after: Date
 function decodeRow(row: ScheduledRow): Record<string, unknown> {
   let schedule: unknown = null;
   try { schedule = JSON.parse(row.schedule_json); } catch {}
-  return { ...row, schedule, schedule_json: undefined };
+  const { created_by: _createdBy, schedule_json: _scheduleJson, ...publicRow } = row;
+  return { ...publicRow, schedule };
 }
 
 function scopedSchedule(scheduleId: string, scope: RestNetworkScope): ScheduledRow | null {
@@ -255,11 +256,18 @@ function dispatchOccurrence(row: ScheduledRow, scheduledFor: string, advanceSche
     event = { alias: node.alias, networkId: row.network_id, taskId, priority: row.priority, state: deliveryState };
   });
 
-  if (createdTaskId) logTaskEvent(createdTaskId, null, "delivered", "hub-scheduler", `schedule=${row.schedule_id} run=${runId}`);
-  if (event) {
-    const pending = db.get<{ cnt: number }>("SELECT COUNT(*) AS cnt FROM inbox WHERE session_name = ?1 AND network_id = ?2 AND acked = 0", event.alias, event.networkId);
-    if (event.state === "delivered") pushEvent(event.alias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority: event.priority, from: "scheduler" }, event.networkId);
-    pushNetworkObserverEvent(event.networkId, { type: "new_task", task_id: event.taskId, from: "scheduler", to: event.alias, status: event.state, priority: event.priority });
+  // Everything below is a post-commit doorbell. A logging/SSE failure must
+  // never turn a durably-created task into an API-level failure: callers may
+  // retry an apparent failure and create a second manual occurrence.
+  try {
+    if (createdTaskId) logTaskEvent(createdTaskId, null, "delivered", "hub-scheduler", `schedule=${row.schedule_id} run=${runId}`);
+    if (event) {
+      const pending = db.get<{ cnt: number }>("SELECT COUNT(*) AS cnt FROM inbox WHERE session_name = ?1 AND network_id = ?2 AND acked = 0", event.alias, event.networkId);
+      if (event.state === "delivered") pushEvent(event.alias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority: event.priority, from: "scheduler" }, event.networkId);
+      pushNetworkObserverEvent(event.networkId, { type: "new_task", task_id: event.taskId, from: "scheduler", to: event.alias, status: event.state, priority: event.priority });
+    }
+  } catch (e: any) {
+    console.error(`[scheduled-tasks] post-commit notification failed schedule=${row.schedule_id} run=${runId}: ${e?.message || e}`);
   }
   return { runId, taskId: createdTaskId, status: finalStatus, event };
 }
@@ -330,7 +338,7 @@ function writeAllowed(ctx: ScheduledRequestContext, networkId: string | null): b
 
 export async function handleScheduledTaskRequest(ctx: ScheduledRequestContext): Promise<Response | null> {
   const { req, url } = ctx;
-  if (!url.pathname.startsWith("/api/scheduled-tasks")) return null;
+  if (url.pathname !== "/api/scheduled-tasks" && !url.pathname.startsWith("/api/scheduled-tasks/")) return null;
   if (ctx.isNodeToken) return jsonError("user_token_required", 403);
 
   if (url.pathname === "/api/scheduled-tasks" && req.method === "GET") {

--- a/server/src/scheduled-tasks.ts
+++ b/server/src/scheduled-tasks.ts
@@ -165,7 +165,7 @@ function validateTarget(networkId: string, nodeId: unknown): { node_id: string; 
 
 type DispatchEvent = { alias: string; networkId: string; taskId: string; priority: string; state: "delivered" | "queued" };
 
-function dispatchOccurrence(row: ScheduledRow, scheduledFor: string, advanceSchedule: boolean): { runId: string; taskId?: string; status: string; event?: DispatchEvent } {
+export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: string, advanceSchedule: boolean): { runId: string; taskId?: string; status: string; event?: DispatchEvent } {
   const runId = `srun_${crypto.randomUUID()}`;
   let event: DispatchEvent | undefined;
   let finalStatus = "failed";
@@ -301,7 +301,7 @@ export function runDueScheduledTasks(now = new Date(), limit = 100): { processed
       // tick wins. The unique occurrence key handles a second scheduler.
       const current = db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1 AND status = 'active' AND next_run_at = ?2", row.schedule_id, row.next_run_at);
       if (!current?.next_run_at) continue;
-      dispatchOccurrence(current, current.next_run_at, true);
+      dispatchScheduledOccurrence(current, current.next_run_at, true);
       processed++;
     } catch (e: any) {
       if (/UNIQUE|duplicate key/i.test(String(e?.message))) continue;
@@ -405,7 +405,7 @@ export async function handleScheduledTaskRequest(ctx: ScheduledRequestContext): 
   if (sub === "run-now" && req.method === "POST") {
     if (row.status === "cancelled") return jsonError("schedule_cancelled", 409);
     try {
-      const result = dispatchOccurrence(row, iso(new Date()), false);
+      const result = dispatchScheduledOccurrence(row, iso(new Date()), false);
       return Response.json({ ok: true, ...result }, { status: result.status === "failed" ? 409 : 202 });
     } catch (e: any) {
       return jsonError("dispatch_failed", 409, { message: String(e?.message || e).slice(0, 500) });

--- a/server/src/scheduled-tasks.ts
+++ b/server/src/scheduled-tasks.ts
@@ -66,9 +66,12 @@ function validTimezone(timezone: string): boolean {
   }
 }
 
-function zonedParts(date: Date, timezone: string): { time: string; weekday: number } {
+function zonedParts(date: Date, timezone: string): { date: string; time: string; weekday: number } {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
     hourCycle: "h23",
     hour: "2-digit",
     minute: "2-digit",
@@ -76,7 +79,7 @@ function zonedParts(date: Date, timezone: string): { time: string; weekday: numb
   }).formatToParts(date);
   const value = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value || "";
   const weekday = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].indexOf(value("weekday"));
-  return { time: `${value("hour")}:${value("minute")}`, weekday };
+  return { date: `${value("year")}-${value("month")}-${value("day")}`, time: `${value("hour")}:${value("minute")}`, weekday };
 }
 
 /** Parse and validate the public schedule shape. No cron expressions: the
@@ -123,11 +126,27 @@ export function nextOccurrence(spec: ScheduleSpec, timezone: string, after: Date
   }
   if (spec.type === "interval") return new Date(after.getTime() + spec.every_seconds * 1000);
 
+  // A wall-clock time can occur twice when DST falls back. If today's local
+  // occurrence already happened at or before `after`, skip every duplicate
+  // carrying that same local date. Otherwise a "daily 01:30" schedule runs
+  // twice on the fall-back day.
+  const afterLocal = zonedParts(after, timezone);
+  let alreadyOccurredDate: string | null = null;
+  const backward = new Date(Math.floor(after.getTime() / 60000) * 60000);
+  for (let i = 0; i <= 26 * 60; i++, backward.setTime(backward.getTime() - 60000)) {
+    const local = zonedParts(backward, timezone);
+    if (local.date === afterLocal.date && local.time === spec.time && (spec.type === "daily" || spec.weekdays.includes(local.weekday))) {
+      alreadyOccurredDate = local.date;
+      break;
+    }
+  }
+
   const cursor = new Date(Math.floor(after.getTime() / 60000) * 60000 + 60000);
   const max = 8 * 24 * 60;
   for (let i = 0; i < max; i++, cursor.setTime(cursor.getTime() + 60000)) {
     const local = zonedParts(cursor, timezone);
     if (local.time !== spec.time) continue;
+    if (local.date === alreadyOccurredDate) continue;
     if (spec.type === "daily" || spec.weekdays.includes(local.weekday)) return new Date(cursor);
   }
   throw new Error("next_occurrence_unresolvable");

--- a/server/src/scheduled-tasks.ts
+++ b/server/src/scheduled-tasks.ts
@@ -1,0 +1,446 @@
+import { db, logTaskEvent } from "./db.js";
+import { assertNodeActive } from "./lifecycle-guard.js";
+import { addNetworkScope, canRestWriteNetwork, singleNetworkId, type RestNetworkScope } from "./network-scope.js";
+import { pushEvent, pushNetworkObserverEvent } from "./push.js";
+
+export type ScheduleSpec =
+  | { type: "once"; run_at: string }
+  | { type: "interval"; every_seconds: number }
+  | { type: "daily"; time: string }
+  | { type: "weekly"; time: string; weekdays: number[] };
+
+type ScheduledRow = {
+  schedule_id: string;
+  network_id: string;
+  created_by: string | null;
+  name: string;
+  target_node_id: string;
+  target_alias: string;
+  task_content: string;
+  priority: "high" | "normal" | "low";
+  schedule_type: ScheduleSpec["type"];
+  schedule_json: string;
+  timezone: string;
+  overlap_policy: "skip" | "allow";
+  status: "active" | "paused" | "completed" | "cancelled";
+  next_run_at: string | null;
+  last_run_at: string | null;
+  revision: number;
+  created_at: string;
+  updated_at: string;
+};
+
+type RequestAuth = {
+  userId: string;
+  networkId: string | null;
+  username: string;
+} | null;
+
+export type ScheduledRequestContext = {
+  req: Request;
+  url: URL;
+  auth: RequestAuth;
+  isAdmin: boolean;
+  isNodeToken: boolean;
+  scope: RestNetworkScope;
+};
+
+const PRIORITIES = new Set(["high", "normal", "low"]);
+const TIME_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+const OPEN_TASK_STATUSES = ["created", "delivered", "acked", "running"];
+
+function jsonError(error: string, status: number, extra: Record<string, unknown> = {}): Response {
+  return Response.json({ ok: false, error, ...extra }, { status });
+}
+
+function iso(date: Date): string {
+  return date.toISOString();
+}
+
+function validTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function zonedParts(date: Date, timezone: string): { time: string; weekday: number } {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hourCycle: "h23",
+    hour: "2-digit",
+    minute: "2-digit",
+    weekday: "short",
+  }).formatToParts(date);
+  const value = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value || "";
+  const weekday = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].indexOf(value("weekday"));
+  return { time: `${value("hour")}:${value("minute")}`, weekday };
+}
+
+/** Parse and validate the public schedule shape. No cron expressions: the
+ * supported forms are intentionally portable between Dashboard and mobile. */
+export function parseScheduleSpec(raw: unknown, timezoneRaw: unknown): { spec: ScheduleSpec; timezone: string } {
+  if (!raw || typeof raw !== "object") throw new Error("schedule_required");
+  const obj = raw as Record<string, unknown>;
+  const type = obj.type;
+  const timezone = typeof timezoneRaw === "string" && timezoneRaw.trim() ? timezoneRaw.trim() : "UTC";
+  if (!validTimezone(timezone)) throw new Error("invalid_timezone");
+
+  if (type === "once") {
+    if (typeof obj.run_at !== "string") throw new Error("run_at_required");
+    const when = new Date(obj.run_at);
+    if (!Number.isFinite(when.getTime())) throw new Error("invalid_run_at");
+    return { spec: { type, run_at: iso(when) }, timezone };
+  }
+  if (type === "interval") {
+    const every = Number(obj.every_seconds);
+    if (!Number.isSafeInteger(every) || every < 60 || every > 365 * 86400) throw new Error("invalid_interval");
+    return { spec: { type, every_seconds: every }, timezone };
+  }
+  if (type === "daily") {
+    if (typeof obj.time !== "string" || !TIME_RE.test(obj.time)) throw new Error("invalid_time");
+    return { spec: { type, time: obj.time }, timezone };
+  }
+  if (type === "weekly") {
+    if (typeof obj.time !== "string" || !TIME_RE.test(obj.time)) throw new Error("invalid_time");
+    if (!Array.isArray(obj.weekdays) || obj.weekdays.length === 0) throw new Error("weekdays_required");
+    const weekdays = [...new Set(obj.weekdays.map(Number))].sort();
+    if (weekdays.some((d) => !Number.isSafeInteger(d) || d < 0 || d > 6)) throw new Error("invalid_weekdays");
+    return { spec: { type, time: obj.time, weekdays }, timezone };
+  }
+  throw new Error("invalid_schedule_type");
+}
+
+/** Return the first occurrence strictly after `after`. Daily/weekly scans UTC
+ * minutes and compares IANA-zone wall time, so DST gaps/folds follow the
+ * platform timezone database instead of a hand-written offset guess. */
+export function nextOccurrence(spec: ScheduleSpec, timezone: string, after: Date): Date | null {
+  if (spec.type === "once") {
+    const when = new Date(spec.run_at);
+    return when.getTime() > after.getTime() ? when : null;
+  }
+  if (spec.type === "interval") return new Date(after.getTime() + spec.every_seconds * 1000);
+
+  const cursor = new Date(Math.floor(after.getTime() / 60000) * 60000 + 60000);
+  const max = 8 * 24 * 60;
+  for (let i = 0; i < max; i++, cursor.setTime(cursor.getTime() + 60000)) {
+    const local = zonedParts(cursor, timezone);
+    if (local.time !== spec.time) continue;
+    if (spec.type === "daily" || spec.weekdays.includes(local.weekday)) return new Date(cursor);
+  }
+  throw new Error("next_occurrence_unresolvable");
+}
+
+function decodeRow(row: ScheduledRow): Record<string, unknown> {
+  let schedule: unknown = null;
+  try { schedule = JSON.parse(row.schedule_json); } catch {}
+  return { ...row, schedule, schedule_json: undefined };
+}
+
+function scopedSchedule(scheduleId: string, scope: RestNetworkScope): ScheduledRow | null {
+  const params: unknown[] = [scheduleId];
+  let sql = "SELECT * FROM scheduled_tasks WHERE schedule_id = ?1";
+  sql = addNetworkScope(sql, params, scope);
+  return db.get<ScheduledRow>(sql, ...params);
+}
+
+function resolveWriteNetwork(body: Record<string, unknown>, ctx: ScheduledRequestContext): string | null {
+  if (ctx.auth?.networkId) return ctx.auth.networkId;
+  if (typeof body.network_id === "string" && body.network_id) return body.network_id;
+  return singleNetworkId(ctx.scope);
+}
+
+function validateTarget(networkId: string, nodeId: unknown): { node_id: string; alias: string } {
+  if (typeof nodeId !== "string" || nodeId.length < 2 || nodeId.length > 200) throw new Error("invalid_target_node_id");
+  const node = db.get<{ node_id: string; alias: string | null }>(
+    "SELECT node_id, alias FROM nodes WHERE node_id = ?1 AND network_id = ?2",
+    nodeId, networkId,
+  );
+  if (!node?.alias) throw new Error("target_node_not_found");
+  return { node_id: node.node_id, alias: node.alias };
+}
+
+type DispatchEvent = { alias: string; networkId: string; taskId: string; priority: string; state: "delivered" | "queued" };
+
+function dispatchOccurrence(row: ScheduledRow, scheduledFor: string, advanceSchedule: boolean): { runId: string; taskId?: string; status: string; event?: DispatchEvent } {
+  const runId = `srun_${crypto.randomUUID()}`;
+  let event: DispatchEvent | undefined;
+  let finalStatus = "failed";
+  let createdTaskId: string | undefined;
+
+  db.transaction(() => {
+    // UNIQUE(schedule_id, scheduled_for) is the cross-process claim. If two
+    // Hub processes race, one INSERT wins and the other transaction aborts.
+    db.run(
+      `INSERT INTO scheduled_task_runs (run_id, schedule_id, network_id, scheduled_for, status)
+       VALUES (?1, ?2, ?3, ?4, 'claiming')`,
+      [runId, row.schedule_id, row.network_id, scheduledFor],
+    );
+
+    if (row.overlap_policy === "skip") {
+      const placeholders = OPEN_TASK_STATUSES.map((_, i) => `?${i + 2}`).join(", ");
+      const open = db.get<{ task_id: string }>(
+        `SELECT r.task_id FROM scheduled_task_runs r
+         JOIN tasks t ON t.task_id = r.task_id
+         WHERE r.schedule_id = ?1 AND t.status IN (${placeholders})
+         ORDER BY r.created_at DESC LIMIT 1`,
+        row.schedule_id, ...OPEN_TASK_STATUSES,
+      );
+      if (open) {
+        finalStatus = "skipped";
+        db.run(
+          "UPDATE scheduled_task_runs SET status = 'skipped', error_code = 'previous_run_active', completed_at = datetime('now') WHERE run_id = ?1",
+          [runId],
+        );
+        if (advanceSchedule) advance(row, scheduledFor);
+        return;
+      }
+    }
+
+    const node = db.get<{ node_id: string; alias: string | null }>(
+      "SELECT node_id, alias FROM nodes WHERE node_id = ?1 AND network_id = ?2",
+      row.target_node_id, row.network_id,
+    );
+    if (!node?.alias) {
+      finalStatus = "failed";
+      db.run(
+        "UPDATE scheduled_task_runs SET status = 'failed', error_code = 'target_node_not_found', error_message = 'The bound node no longer exists in this network', completed_at = datetime('now') WHERE run_id = ?1",
+        [runId],
+      );
+      if (advanceSchedule) advance(row, scheduledFor);
+      return;
+    }
+    const lifecycle = assertNodeActive(node.alias, row.network_id);
+    if (!lifecycle.ok) {
+      finalStatus = "failed";
+      db.run(
+        "UPDATE scheduled_task_runs SET status = 'failed', error_code = 'target_not_active', error_message = ?1, completed_at = datetime('now') WHERE run_id = ?2",
+        [String((lifecycle as any).error || "target_not_active").slice(0, 500), runId],
+      );
+      if (advanceSchedule) advance(row, scheduledFor);
+      return;
+    }
+
+    const taskId = crypto.randomUUID();
+    const session = db.get<{ status: string | null }>(
+      "SELECT status FROM sessions WHERE node_id = ?1 AND network_id = ?2 ORDER BY updated_at DESC LIMIT 1",
+      row.target_node_id, row.network_id,
+    );
+    const deliveryState: "delivered" | "queued" = session && session.status !== "offline" ? "delivered" : "queued";
+    const metaJson = JSON.stringify({
+      scheduled_task_id: row.schedule_id,
+      scheduled_run_id: runId,
+      scheduled_for: scheduledFor,
+      created_by: row.created_by,
+      auth_origin: "hub_scheduler",
+    });
+    db.run(
+      `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, requires_response, network_id, meta_json)
+       VALUES (?1, ?2, ?3, 'task', ?4, ?5, 'scheduler', 'reply', ?6, ?7)`,
+      [taskId, node.alias, node.node_id, row.priority, row.task_content, row.network_id, metaJson],
+    );
+    db.run(
+      `INSERT INTO tasks (task_id, from_name, to_node_id, to_name, priority, status, content, requires_response, created_at, delivered_at, expires_at, network_id, meta_json)
+       VALUES (?1, 'scheduler', ?2, ?3, ?4, 'delivered', ?5, 'reply', datetime('now'), datetime('now'), datetime('now', '+86400 seconds'), ?6, ?7)`,
+      [taskId, node.node_id, node.alias, row.priority, row.task_content, row.network_id, metaJson],
+    );
+    db.run("UPDATE scheduled_task_runs SET task_id = ?1, status = ?2, completed_at = datetime('now') WHERE run_id = ?3", [taskId, deliveryState, runId]);
+    db.run("UPDATE sessions SET task = ?1, updated_at = datetime('now') WHERE node_id = ?2 AND network_id = ?3", [row.task_content.slice(0, 200), node.node_id, row.network_id]);
+    db.run("UPDATE scheduled_tasks SET target_alias = ?1, last_run_at = ?2, updated_at = datetime('now') WHERE schedule_id = ?3", [node.alias, scheduledFor, row.schedule_id]);
+    if (advanceSchedule) advance({ ...row, target_alias: node.alias }, scheduledFor);
+    createdTaskId = taskId;
+    finalStatus = deliveryState;
+    event = { alias: node.alias, networkId: row.network_id, taskId, priority: row.priority, state: deliveryState };
+  });
+
+  if (createdTaskId) logTaskEvent(createdTaskId, null, "delivered", "hub-scheduler", `schedule=${row.schedule_id} run=${runId}`);
+  if (event) {
+    const pending = db.get<{ cnt: number }>("SELECT COUNT(*) AS cnt FROM inbox WHERE session_name = ?1 AND network_id = ?2 AND acked = 0", event.alias, event.networkId);
+    if (event.state === "delivered") pushEvent(event.alias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority: event.priority, from: "scheduler" }, event.networkId);
+    pushNetworkObserverEvent(event.networkId, { type: "new_task", task_id: event.taskId, from: "scheduler", to: event.alias, status: event.state, priority: event.priority });
+  }
+  return { runId, taskId: createdTaskId, status: finalStatus, event };
+}
+
+function advance(row: ScheduledRow, scheduledFor: string): void {
+  const spec = JSON.parse(row.schedule_json) as ScheduleSpec;
+  const next = nextOccurrence(spec, row.timezone, new Date());
+  if (spec.type === "once" || !next) {
+    db.run(
+      "UPDATE scheduled_tasks SET status = 'completed', next_run_at = NULL, last_run_at = ?1, revision = revision + 1, updated_at = datetime('now') WHERE schedule_id = ?2",
+      [scheduledFor, row.schedule_id],
+    );
+  } else {
+    db.run(
+      "UPDATE scheduled_tasks SET next_run_at = ?1, last_run_at = ?2, revision = revision + 1, updated_at = datetime('now') WHERE schedule_id = ?3",
+      [iso(next), scheduledFor, row.schedule_id],
+    );
+  }
+}
+
+export function runDueScheduledTasks(now = new Date(), limit = 100): { processed: number; failed: number } {
+  const due = db.all<ScheduledRow>(
+    "SELECT * FROM scheduled_tasks WHERE status = 'active' AND next_run_at IS NOT NULL AND next_run_at <= ?1 ORDER BY next_run_at LIMIT ?2",
+    iso(now), limit,
+  );
+  let processed = 0;
+  let failed = 0;
+  for (const row of due) {
+    try {
+      // Re-read inside the claim path so a pause/cancel immediately before the
+      // tick wins. The unique occurrence key handles a second scheduler.
+      const current = db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1 AND status = 'active' AND next_run_at = ?2", row.schedule_id, row.next_run_at);
+      if (!current?.next_run_at) continue;
+      dispatchOccurrence(current, current.next_run_at, true);
+      processed++;
+    } catch (e: any) {
+      if (/UNIQUE|duplicate key/i.test(String(e?.message))) continue;
+      failed++;
+      console.error(`[scheduled-tasks] occurrence failed schedule=${row.schedule_id}: ${e?.message || e}`);
+    }
+  }
+  return { processed, failed };
+}
+
+export function startScheduledTaskScheduler(intervalMs?: number): ReturnType<typeof setInterval> {
+  const configured = Number(process.env.COMMHUB_SCHEDULER_TICK_MS);
+  const ms = intervalMs && intervalMs > 0 ? intervalMs : configured > 0 ? configured : 10_000;
+  // First tick is immediate so a restarted Hub converges without waiting one
+  // full cadence. Recurrences advance from "now", intentionally collapsing a
+  // long outage into one catch-up occurrence instead of a dispatch storm.
+  runDueScheduledTasks();
+  return setInterval(() => runDueScheduledTasks(), ms);
+}
+
+async function bodyObject(req: Request): Promise<Record<string, unknown>> {
+  try {
+    const value = await req.json();
+    if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error();
+    return value as Record<string, unknown>;
+  } catch {
+    throw new Error("invalid_json");
+  }
+}
+
+function writeAllowed(ctx: ScheduledRequestContext, networkId: string | null): boolean {
+  return !ctx.isNodeToken && canRestWriteNetwork(ctx.auth, networkId, ctx.isAdmin);
+}
+
+export async function handleScheduledTaskRequest(ctx: ScheduledRequestContext): Promise<Response | null> {
+  const { req, url } = ctx;
+  if (!url.pathname.startsWith("/api/scheduled-tasks")) return null;
+  if (ctx.isNodeToken) return jsonError("user_token_required", 403);
+
+  if (url.pathname === "/api/scheduled-tasks" && req.method === "GET") {
+    const params: unknown[] = [];
+    let sql = "SELECT * FROM scheduled_tasks WHERE 1=1";
+    sql = addNetworkScope(sql, params, ctx.scope);
+    const status = url.searchParams.get("status");
+    if (status) { sql += ` AND status = ?${params.length + 1}`; params.push(status); }
+    sql += " ORDER BY updated_at DESC LIMIT 500";
+    return Response.json({ ok: true, schedules: db.all<ScheduledRow>(sql, ...params).map(decodeRow) });
+  }
+
+  if (url.pathname === "/api/scheduled-tasks" && req.method === "POST") {
+    let body: Record<string, unknown>;
+    try { body = await bodyObject(req); } catch { return jsonError("invalid_json", 400); }
+    const networkId = resolveWriteNetwork(body, ctx);
+    if (!networkId) return jsonError("network_id_required", 400);
+    if (!writeAllowed(ctx, networkId)) return jsonError("permission_denied", 403);
+    try {
+      const name = typeof body.name === "string" ? body.name.trim() : "";
+      const content = typeof body.task === "string" ? body.task.trim() : "";
+      if (!name || name.length > 120) throw new Error("invalid_name");
+      if (!content || content.length > 10_000) throw new Error("invalid_task");
+      const priority = typeof body.priority === "string" ? body.priority : "normal";
+      if (!PRIORITIES.has(priority)) throw new Error("invalid_priority");
+      const target = validateTarget(networkId, body.target_node_id);
+      const { spec, timezone } = parseScheduleSpec(body.schedule, body.timezone);
+      const next = nextOccurrence(spec, timezone, new Date());
+      if (!next) throw new Error("schedule_has_no_future_occurrence");
+      const scheduleId = `sched_${crypto.randomUUID()}`;
+      db.run(
+        `INSERT INTO scheduled_tasks
+         (schedule_id, network_id, created_by, name, target_node_id, target_alias, task_content, priority, schedule_type, schedule_json, timezone, overlap_policy, next_run_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'skip', ?12)`,
+        [scheduleId, networkId, ctx.auth?.userId ?? null, name, target.node_id, target.alias, content, priority, spec.type, JSON.stringify(spec), timezone, iso(next)],
+      );
+      const created = db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1", scheduleId)!;
+      return Response.json({ ok: true, schedule: decodeRow(created) }, { status: 201 });
+    } catch (e: any) {
+      const code = String(e?.message || "invalid_schedule");
+      const status = code === "target_node_not_found" ? 404 : 400;
+      return jsonError(code, status);
+    }
+  }
+
+  const match = url.pathname.match(/^\/api\/scheduled-tasks\/([^/]+)(?:\/(runs|run-now))?$/);
+  if (!match) return jsonError("not_found", 404);
+  const scheduleId = decodeURIComponent(match[1]);
+  const sub = match[2] || null;
+  const row = scopedSchedule(scheduleId, ctx.scope);
+  if (!row) return jsonError("schedule_not_found", 404);
+
+  if (sub === "runs" && req.method === "GET") {
+    const limit = Math.max(1, Math.min(200, Number(url.searchParams.get("limit")) || 50));
+    const runs = db.all(
+      "SELECT run_id, schedule_id, scheduled_for, task_id, status, error_code, error_message, created_at, completed_at FROM scheduled_task_runs WHERE schedule_id = ?1 AND network_id = ?2 ORDER BY created_at DESC LIMIT ?3",
+      row.schedule_id, row.network_id, limit,
+    );
+    return Response.json({ ok: true, runs });
+  }
+  if (!sub && req.method === "GET") return Response.json({ ok: true, schedule: decodeRow(row) });
+  if (!writeAllowed(ctx, row.network_id)) return jsonError("permission_denied", 403);
+
+  if (sub === "run-now" && req.method === "POST") {
+    if (row.status === "cancelled") return jsonError("schedule_cancelled", 409);
+    try {
+      const result = dispatchOccurrence(row, iso(new Date()), false);
+      return Response.json({ ok: true, ...result }, { status: result.status === "failed" ? 409 : 202 });
+    } catch (e: any) {
+      return jsonError("dispatch_failed", 409, { message: String(e?.message || e).slice(0, 500) });
+    }
+  }
+
+  if (!sub && req.method === "DELETE") {
+    db.run("UPDATE scheduled_tasks SET status = 'cancelled', next_run_at = NULL, revision = revision + 1, updated_at = datetime('now') WHERE schedule_id = ?1", [row.schedule_id]);
+    return Response.json({ ok: true, status: "cancelled" });
+  }
+
+  if (!sub && req.method === "PATCH") {
+    let body: Record<string, unknown>;
+    try { body = await bodyObject(req); } catch { return jsonError("invalid_json", 400); }
+    if (!Number.isSafeInteger(body.revision) || Number(body.revision) !== row.revision) return jsonError("revision_conflict", 409, { current_revision: row.revision });
+    try {
+      const name = body.name === undefined ? row.name : String(body.name).trim();
+      const content = body.task === undefined ? row.task_content : String(body.task).trim();
+      const priority = body.priority === undefined ? row.priority : String(body.priority);
+      if (!name || name.length > 120) throw new Error("invalid_name");
+      if (!content || content.length > 10_000) throw new Error("invalid_task");
+      if (!PRIORITIES.has(priority)) throw new Error("invalid_priority");
+      const target = body.target_node_id === undefined ? { node_id: row.target_node_id, alias: row.target_alias } : validateTarget(row.network_id, body.target_node_id);
+      const parsed = body.schedule === undefined
+        ? { spec: JSON.parse(row.schedule_json) as ScheduleSpec, timezone: body.timezone === undefined ? row.timezone : String(body.timezone) }
+        : parseScheduleSpec(body.schedule, body.timezone === undefined ? row.timezone : body.timezone);
+      if (!validTimezone(parsed.timezone)) throw new Error("invalid_timezone");
+      const requestedStatus = body.status === undefined ? row.status : String(body.status);
+      if (!new Set(["active", "paused"]).has(requestedStatus)) throw new Error("invalid_status");
+      const next = requestedStatus === "active" ? nextOccurrence(parsed.spec, parsed.timezone, new Date()) : null;
+      if (requestedStatus === "active" && !next) throw new Error("schedule_has_no_future_occurrence");
+      const updated = db.run(
+        `UPDATE scheduled_tasks SET name = ?1, target_node_id = ?2, target_alias = ?3, task_content = ?4,
+         priority = ?5, schedule_type = ?6, schedule_json = ?7, timezone = ?8, status = ?9, next_run_at = ?10,
+         revision = revision + 1, updated_at = datetime('now') WHERE schedule_id = ?11 AND revision = ?12`,
+        [name, target.node_id, target.alias, content, priority, parsed.spec.type, JSON.stringify(parsed.spec), parsed.timezone, requestedStatus, next ? iso(next) : null, row.schedule_id, row.revision],
+      );
+      if (updated.changes !== 1) return jsonError("revision_conflict", 409);
+      return Response.json({ ok: true, schedule: decodeRow(db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1", row.schedule_id)!) });
+    } catch (e: any) {
+      const code = String(e?.message || "invalid_schedule");
+      return jsonError(code, code === "target_node_not_found" ? 404 : 400);
+    }
+  }
+  return jsonError("method_not_allowed", 405);
+}

--- a/server/src/scheduled-tasks.ts
+++ b/server/src/scheduled-tasks.ts
@@ -49,6 +49,12 @@ const PRIORITIES = new Set(["high", "normal", "low"]);
 const TIME_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 const OPEN_TASK_STATUSES = ["created", "delivered", "acked", "running"];
 
+export function assertScheduledTaskBackendSupported(): void {
+  if (db.dialect !== "sqlite") {
+    throw new Error("scheduled_tasks_require_transactional_sqlite_backend");
+  }
+}
+
 function jsonError(error: string, status: number, extra: Record<string, unknown> = {}): Response {
   return Response.json({ ok: false, error, ...extra }, { status });
 }
@@ -253,7 +259,6 @@ export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: str
       scheduled_task_id: row.schedule_id,
       scheduled_run_id: runId,
       scheduled_for: scheduledFor,
-      created_by: row.created_by,
       auth_origin: "hub_scheduler",
     });
     db.run(

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -35,6 +35,7 @@ import { startRetentionSweeper } from "./retention.js";
 import { startStaleSessionSweeper } from "./stale-sweeper.js";
 import { resolveRestFromSession } from "./rest-identity.js";
 import { stampTaskAuthOrigin, type TaskAuthOrigin } from "./task-auth-origin.js";
+import { handleScheduledTaskRequest, startScheduledTaskScheduler } from "./scheduled-tasks.js";
 
 const PORT = Number(process.env.PORT) || 9200;
 const HOST = process.env.HOST || "127.0.0.1";
@@ -1348,6 +1349,20 @@ return Bun.serve({
     if (restScope.denied) {
       return withCors(req, Response.json({ ok: false, error: restScope.denied }, { status: 403 }));
     }
+
+    // Hub-owned scheduled tasks. Dashboard and mobile are management
+    // clients only; each occurrence is dispatched as an ordinary task by the
+    // scheduler started in startHub(). Node tokens are rejected in the
+    // handler so an agent cannot grant itself a persistent execution loop.
+    const scheduledResponse = await handleScheduledTaskRequest({
+      req,
+      url,
+      auth: restAuth,
+      isAdmin,
+      isNodeToken: requestToken(req).startsWith("ntok_"),
+      scope: restScope,
+    });
+    if (scheduledResponse) return withCors(req, scheduledResponse);
 
     // ── #473 REST: SSE connection detail (ops-only) ──
     // The per-key breakdown /health used to expose anonymously: keys are
@@ -3095,6 +3110,7 @@ export function startHub(opts?: { port?: number; hostname?: string }): ReturnTyp
     ? Number(process.env.COMMHUB_TASK_PATROL_MS) : 5 * 60 * 1000;
   const rateLimitSweepTimer = setInterval(sweepStaleRateLimits, rateLimitSweepMs);
   const taskPatrolTimer = setInterval(patrolExpiredTasks, taskPatrolMs);
+  const scheduledTaskTimer = startScheduledTaskScheduler();
 
   // The Bun.serve socket is what keeps the process alive; the periodic
   // jobs must not — otherwise a test (or a future caller) that stops the
@@ -3103,6 +3119,7 @@ export function startHub(opts?: { port?: number; hostname?: string }): ReturnTyp
   (staleSweeperTimer as any)?.unref?.();
   (rateLimitSweepTimer as any)?.unref?.();
   (taskPatrolTimer as any)?.unref?.();
+  (scheduledTaskTimer as any)?.unref?.();
 
   // ── Graceful shutdown ───────────────────────────────
   function shutdown() {
@@ -3111,6 +3128,7 @@ export function startHub(opts?: { port?: number; hostname?: string }): ReturnTyp
     clearInterval(staleSweeperTimer);
     clearInterval(rateLimitSweepTimer);
     clearInterval(taskPatrolTimer);
+    clearInterval(scheduledTaskTimer);
     db.close();
     process.exit(0);
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -35,7 +35,7 @@ import { startRetentionSweeper } from "./retention.js";
 import { startStaleSessionSweeper } from "./stale-sweeper.js";
 import { resolveRestFromSession } from "./rest-identity.js";
 import { stampTaskAuthOrigin, type TaskAuthOrigin } from "./task-auth-origin.js";
-import { handleScheduledTaskRequest, startScheduledTaskScheduler } from "./scheduled-tasks.js";
+import { assertScheduledTaskBackendSupported, handleScheduledTaskRequest, startScheduledTaskScheduler } from "./scheduled-tasks.js";
 
 const PORT = Number(process.env.PORT) || 9200;
 const HOST = process.env.HOST || "127.0.0.1";
@@ -3077,6 +3077,11 @@ export function startHub(opts?: { port?: number; hostname?: string }): ReturnTyp
       `For an additional throwaway instance use bootServer({ port: 0 }).`
     );
   }
+  // The current PostgreSQL adapter opens a fresh process/connection for each
+  // statement, so its transaction() cannot provide the occurrence claim +
+  // task creation atomicity this scheduler requires. Refuse before opening a
+  // listening socket instead of silently running an unsafe scheduler.
+  assertScheduledTaskBackendSupported();
   const server = bootServer(opts);
 
   // Round-2/4 review ② — periodic retention sweep + incremental VACUUM.

--- a/tests/test601-hub-scheduled-tasks/Dockerfile
+++ b/tests/test601-hub-scheduled-tasks/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test601-hub-scheduled-tasks ./tests/test601-hub-scheduled-tasks
+ARG SOURCE_COMMIT
+ENV TEST601_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test601-hub-scheduled-tasks/run.sh
+ENTRYPOINT ["/workspace/tests/test601-hub-scheduled-tasks/run.sh"]

--- a/tests/test601-hub-scheduled-tasks/race-worker.ts
+++ b/tests/test601-hub-scheduled-tasks/race-worker.ts
@@ -1,0 +1,24 @@
+import { existsSync, writeFileSync } from "node:fs";
+
+const [dbPath, scheduleId, scheduledFor, readyPath, gatePath] = Bun.argv.slice(2);
+if (![dbPath, scheduleId, scheduledFor, readyPath, gatePath].every(Boolean)) process.exit(10);
+process.env.COMMHUB_DB = dbPath;
+
+const { db } = await import("../../server/src/db.js");
+const { dispatchScheduledOccurrence } = await import("../../server/src/scheduled-tasks.js");
+const row = db.get("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1", scheduleId);
+if (!row) process.exit(11);
+
+writeFileSync(readyPath, "ready\n", { mode: 0o600 });
+const deadline = Date.now() + 10_000;
+while (!existsSync(gatePath) && Date.now() < deadline) await Bun.sleep(5);
+if (!existsSync(gatePath)) process.exit(12);
+
+try {
+  dispatchScheduledOccurrence(row as any, scheduledFor, true);
+  process.exit(0);
+} catch (error: any) {
+  if (/UNIQUE|duplicate key/i.test(String(error?.message || error))) process.exit(3);
+  console.error(error);
+  process.exit(4);
+}

--- a/tests/test601-hub-scheduled-tasks/run.sh
+++ b/tests/test601-hub-scheduled-tasks/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test601-hub-scheduled-tasks.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test601 — Hub scheduled tasks"
+echo "source_commit=${TEST601_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_real() {
+  local db_path=$1
+  COMMHUB_DB="$db_path" bun test server/src/scheduled-tasks-http.test.ts
+}
+
+expect_red() {
+  local label=$1 db_path=$2
+  set +e
+  run_real "$db_path" >/tmp/test601-red.log 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "MUTATION_FALSE_GREEN: $label"
+    sed -n '1,220p' /tmp/test601-red.log
+    exit 1
+  fi
+  echo "MUTATION_RED: $label rc=$rc"
+}
+
+echo "L0 build + additive schema"
+bun build server/src/index.ts --target bun --outfile /tmp/commhub-scheduler.js
+test -s /tmp/commhub-scheduler.js
+grep -Fq 'CREATE TABLE IF NOT EXISTS scheduled_tasks' server/src/db.ts
+grep -Fq 'UNIQUE(schedule_id, scheduled_for)' server/src/db.ts
+
+echo "L1-L5 real Hub + SQLite: time, auth, dispatch, recurrence, rename, history"
+run_real /tmp/test601-green.db
+
+cp server/src/scheduled-tasks.ts /tmp/test601-scheduled-tasks.ts
+
+echo "L6 witnessed-red: node token cannot create persistent schedules"
+sed -i 's/if (ctx.isNodeToken) return jsonError("user_token_required", 403);/if (false \&\& ctx.isNodeToken) return jsonError("user_token_required", 403);/' server/src/scheduled-tasks.ts
+grep -Fq 'if (false && ctx.isNodeToken)' server/src/scheduled-tasks.ts
+expect_red node-token-write-gate /tmp/test601-mut-node.db
+cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
+
+echo "L7 witnessed-red: overlap check is load-bearing"
+sed -i '0,/if (open) {/s//if (false \&\& open) {/' server/src/scheduled-tasks.ts
+grep -Fq 'if (false && open)' server/src/scheduled-tasks.ts
+expect_red no-overlapping-occurrences /tmp/test601-mut-overlap.db
+cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
+
+echo "L8 witnessed-red: optimistic revision rejects stale devices"
+sed -i 's/if (!Number.isSafeInteger(body.revision) || Number(body.revision) !== row.revision)/if (false \&\& (!Number.isSafeInteger(body.revision) || Number(body.revision) !== row.revision))/' server/src/scheduled-tasks.ts
+grep -Fq 'if (false && (!Number.isSafeInteger' server/src/scheduled-tasks.ts
+expect_red optimistic-revision /tmp/test601-mut-revision.db
+cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
+
+echo "L9 restored green"
+run_real /tmp/test601-restored.db
+echo "RESULT: PASS"

--- a/tests/test601-hub-scheduled-tasks/run.sh
+++ b/tests/test601-hub-scheduled-tasks/run.sh
@@ -68,6 +68,12 @@ grep -Fq 'if (false && (!Number.isSafeInteger' server/src/scheduled-tasks.ts
 expect_red optimistic-revision /tmp/test601-mut-revision.db
 cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
 
-echo "L10 restored green"
+echo "L10 witnessed-red: DST fall-back duplicate suppression is load-bearing"
+sed -i 's/if (local.date === alreadyOccurredDate) continue;/if (false \&\& local.date === alreadyOccurredDate) continue;/' server/src/scheduled-tasks.ts
+grep -Fq 'if (false && local.date === alreadyOccurredDate)' server/src/scheduled-tasks.ts
+expect_red dst-fallback-single-occurrence /tmp/test601-mut-dst.db
+cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
+
+echo "L11 restored green"
 run_real /tmp/test601-restored.db
 echo "RESULT: PASS"

--- a/tests/test601-hub-scheduled-tasks/run.sh
+++ b/tests/test601-hub-scheduled-tasks/run.sh
@@ -46,18 +46,28 @@ grep -Fq 'if (false && ctx.isNodeToken)' server/src/scheduled-tasks.ts
 expect_red node-token-write-gate /tmp/test601-mut-node.db
 cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
 
-echo "L7 witnessed-red: overlap check is load-bearing"
+echo "L7 witnessed-red: cross-process occurrence claim is load-bearing"
+cp server/src/db.ts /tmp/test601-db.ts
+perl -0pi -e 's/completed_at     TEXT,\n    UNIQUE\(schedule_id, scheduled_for\)/completed_at     TEXT/' server/src/db.ts
+if grep -Fq 'UNIQUE(schedule_id, scheduled_for)' server/src/db.ts; then
+  echo "MUTATION_NOT_APPLIED: occurrence unique claim"
+  exit 1
+fi
+expect_red cross-process-occurrence-claim /tmp/test601-mut-claim.db
+cp /tmp/test601-db.ts server/src/db.ts
+
+echo "L8 witnessed-red: overlap check is load-bearing"
 sed -i '0,/if (open) {/s//if (false \&\& open) {/' server/src/scheduled-tasks.ts
 grep -Fq 'if (false && open)' server/src/scheduled-tasks.ts
 expect_red no-overlapping-occurrences /tmp/test601-mut-overlap.db
 cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
 
-echo "L8 witnessed-red: optimistic revision rejects stale devices"
+echo "L9 witnessed-red: optimistic revision rejects stale devices"
 sed -i 's/if (!Number.isSafeInteger(body.revision) || Number(body.revision) !== row.revision)/if (false \&\& (!Number.isSafeInteger(body.revision) || Number(body.revision) !== row.revision))/' server/src/scheduled-tasks.ts
 grep -Fq 'if (false && (!Number.isSafeInteger' server/src/scheduled-tasks.ts
 expect_red optimistic-revision /tmp/test601-mut-revision.db
 cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
 
-echo "L9 restored green"
+echo "L10 restored green"
 run_real /tmp/test601-restored.db
 echo "RESULT: PASS"

--- a/tests/test601-hub-scheduled-tasks/run.sh
+++ b/tests/test601-hub-scheduled-tasks/run.sh
@@ -42,7 +42,9 @@ cp server/src/scheduled-tasks.ts /tmp/test601-scheduled-tasks.ts
 
 echo "L6 witnessed-red: node token cannot create persistent schedules"
 sed -i 's/if (ctx.isNodeToken) return jsonError("user_token_required", 403);/if (false \&\& ctx.isNodeToken) return jsonError("user_token_required", 403);/' server/src/scheduled-tasks.ts
+sed -i 's/return !ctx.isNodeToken \&\& canRestWriteNetwork(ctx.auth, networkId, ctx.isAdmin);/return canRestWriteNetwork(ctx.auth, networkId, ctx.isAdmin);/' server/src/scheduled-tasks.ts
 grep -Fq 'if (false && ctx.isNodeToken)' server/src/scheduled-tasks.ts
+grep -Fq 'return canRestWriteNetwork(ctx.auth, networkId, ctx.isAdmin);' server/src/scheduled-tasks.ts
 expect_red node-token-write-gate /tmp/test601-mut-node.db
 cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
 
@@ -74,6 +76,12 @@ grep -Fq 'if (false && local.date === alreadyOccurredDate)' server/src/scheduled
 expect_red dst-fallback-single-occurrence /tmp/test601-mut-dst.db
 cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
 
-echo "L11 restored green"
+echo "L11 witnessed-red: non-transactional backend startup gate is load-bearing"
+sed -i 's/if (db.dialect !== "sqlite") {/if (false \&\& db.dialect !== "sqlite") {/' server/src/scheduled-tasks.ts
+grep -Fq 'if (false && db.dialect !== "sqlite")' server/src/scheduled-tasks.ts
+expect_red non-transactional-backend-gate /tmp/test601-mut-backend.db
+cp /tmp/test601-scheduled-tasks.ts server/src/scheduled-tasks.ts
+
+echo "L12 restored green"
 run_real /tmp/test601-restored.db
 echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

Adds Hub-owned scheduled task persistence, REST management APIs, execution history, and ordinary task dispatch. Supports one-time, interval, daily, and weekly schedules with explicit IANA timezones, stable node IDs, pause/resume, run-now, cancellation, non-overlap, and restart convergence.

## Safety

Network-scoped user authorization; node tokens cannot read or write schedules. SQLite occurrence claim, inbox/task creation, run history, and schedule advancement are atomic. PostgreSQL startup fails closed because the current adapter is not transaction-safe. DST fall-back remains once per local day.

## Validation

Docker test601: 9 tests, 58 assertions, six witnessed-red mutations, restored green. Includes two real Hub processes racing one occurrence, transaction fault injection, rename, offline queueing, DST gap/fold, optimistic revision, and tenant isolation. Independent adversarial review: PASS.

Clients are shipped in separate Dashboard and App PRs.