### PR TITLE
feat: add scheduled task misfire policy

### DIFF
--- a/docs/rfcs/RFC-034-hub-scheduled-tasks.md
+++ b/docs/rfcs/RFC-034-hub-scheduled-tasks.md
@@ -14,6 +14,7 @@
 - 建立单次、固定间隔、每日、每周计划。
 - 每日/每周计划显式记录 IANA timezone；单次时间保存为 UTC ISO 8601。
 - 查看下次/上次执行、暂停、恢复、立即执行、取消和运行历史。
+- 创建时选择错过执行窗口后的处理方式：恢复后补跑一次，或跳过本次等待下一周期。
 - 目标节点改名后仍按 `node_id` 解析当前 alias。
 - 默认 `overlap_policy=skip`：上一轮普通 task 尚未终态时，本轮记 `skipped`，不重复压入节点。
 
@@ -32,8 +33,10 @@
 3. occurrence claim、run row、inbox row、task row及 next occurrence 推进处于同一个数据库 transaction。
 4. commit 后才发送 SSE doorbell。SSE 失败不回滚已持久化任务；节点仍会通过 inbox 拉取。
 5. Hub 长时间停机后，每个到期计划只补一次；下一次从恢复时刻以后计算，禁止补发所有错过的 tick 形成风暴。
-6. 单次计划无论成功投递或因目标失效而失败，均进入 `completed`，不永久自旋。
-7. 目标处于 stop/delete lifecycle 时 fail closed，run 记录失败；普通 offline 仍排队。
+6. `misfire_policy=catch_up_once` 是默认值和旧数据兼容值：恢复后最多补发一条普通任务，再从恢复时刻以后计算下一次。
+7. `misfire_policy=skip` 在超过 60 秒宽限窗口后不创建 `task`/`inbox`，只写一条 `status=skipped,error_code=misfire_skipped` 的可审计 run，再推进到下一次未来 occurrence。60 秒以内仍按正常调度处理，避免把 scheduler tick 抖动误判为停机错过。
+8. 单次计划无论成功投递、按策略跳过或因目标失效而失败，均进入 `completed`，不永久自旋。
+9. 目标处于 stop/delete lifecycle 时 fail closed，run 记录失败；普通 offline 仍排队。
 
 SQLite transaction 是当前生产原子边界。仓库现有 PostgreSQL adapter 已明确不提供真实跨语句 transaction；`startHub()` 会在监听前 fail closed，直到该 adapter 修复，不得把 PostgreSQL 宣称为 scheduler 的 production-safe 后端。
 
@@ -56,6 +59,8 @@ SQLite transaction 是当前生产原子边界。仓库现有 PostgreSQL adapter
 - `POST /api/scheduled-tasks/:schedule_id/run-now`
 
 PATCH 必须携带当前 `revision`；陈旧客户端得到 `409 revision_conflict`，不得覆盖另一设备的新状态。
+
+创建请求中的 `misfire_policy` 只接受 `catch_up_once` 或 `skip`。省略时按 `catch_up_once` 处理；Dashboard 与 App 必须把该选择显式展示给用户，不得用隐式客户端默认值掩盖 Hub 语义。
 
 ## 7. 发布与回滚
 

--- a/docs/tests/report-test602-scheduled-misfire.txt
+++ b/docs/tests/report-test602-scheduled-misfire.txt
@@ -1,7 +1,12 @@
 # test602 — Hub scheduled-task misfire policy
 
 Date: 2026-08-09
-Status: PASS (pre-commit source tree; exact commit provenance pending final review build)
+Status: PASS (exact source commit)
+
+Source commit: `cea39d266aa2250ced3fc513383d0fae70a1ba75`
+Image ID: `sha256:acc73084294bb18d2290e011b6774c060ae70f8170b76e66cb96360be0cf5de0`
+Embedded environment: `TEST602_SOURCE_COMMIT=cea39d266aa2250ced3fc513383d0fae70a1ba75`
+Runner artifact SHA256: `2ec9b9b835c5874d4169c47a6c7068c36c50004b86568fdf713148df3cfc3883`
 
 ## Scope
 
@@ -13,7 +18,7 @@ Status: PASS (pre-commit source tree; exact commit provenance pending final revi
 
 ## Layer 1 — Hub real SQLite/HTTP tests
 
-Command: `sg docker -c 'docker build -t anet-test602:dev -f tests/test602-scheduled-misfire/Dockerfile . && docker run --rm anet-test602:dev'`
+Command: `sg docker -c 'docker build --build-arg SOURCE_COMMIT=cea39d266aa2250ced3fc513383d0fae70a1ba75 -t anet-test602:dev -f tests/test602-scheduled-misfire/Dockerfile . && docker run --rm -v /tmp/test602-exact-artifacts:/artifacts anet-test602:dev'`
 
 Result:
 
@@ -23,6 +28,7 @@ Result:
 - skip created no task/inbox, wrote `misfire_skipped`, preserved `last_run_at`, and advanced
 - an occurrence only 10 seconds late remained a normal dispatch
 - a skipped one-shot schedule completed without dispatch
+- node-token GET and POST both returned `403 user_token_required`
 
 ## Mutation
 
@@ -45,4 +51,4 @@ Result: witnessed red, exit code 1. Restoring production code returned the suite
 
 ## Operational note
 
-The three suites reused the single exact tag `anet-test602:dev`, which was removed after each layer. Docker was paused when host free space fell below 9 GB; no prune or broad image deletion was used. A final exact-commit provenance rebuild is required before merge/deploy.
+The three suites reused the single exact tag `anet-test602:dev`. The final exact-source image was removed by that exact tag after evidence capture. No prune or broad image deletion was used; host free space remained 11 GB after cleanup.

--- a/docs/tests/report-test602-scheduled-misfire.txt
+++ b/docs/tests/report-test602-scheduled-misfire.txt
@@ -1,0 +1,48 @@
+# test602 — Hub scheduled-task misfire policy
+
+Date: 2026-08-09
+Status: PASS (pre-commit source tree; exact commit provenance pending final review build)
+
+## Scope
+
+- Hub schema/API/scheduler support for `misfire_policy=catch_up_once|skip`
+- backward-compatible default `catch_up_once`
+- 60-second grace window for ordinary scheduler jitter
+- skipped occurrence audit without task/inbox creation
+- Dashboard and App creation controls and policy disclosure
+
+## Layer 1 — Hub real SQLite/HTTP tests
+
+Command: `sg docker -c 'docker build -t anet-test602:dev -f tests/test602-scheduled-misfire/Dockerfile . && docker run --rm anet-test602:dev'`
+
+Result:
+
+- 10 tests passed, 0 failed, 81 assertions
+- default/validation/create/read compatibility passed
+- catch-up created exactly one task and advanced into the future
+- skip created no task/inbox, wrote `misfire_skipped`, preserved `last_run_at`, and advanced
+- an occurrence only 10 seconds late remained a normal dispatch
+- a skipped one-shot schedule completed without dispatch
+
+## Mutation
+
+Mutation: replace the production skip decision with an always-false condition.
+
+Result: witnessed red, exit code 1. Restoring production code returned the suite to green.
+
+## Layer 2 — Dashboard
+
+- 14 contract checks passed
+- production Next.js build/typecheck passed
+- 53/53 pages generated
+- both policies are selectable, forwarded to the Hub, explained, and disclosed on schedule cards
+
+## Layer 3 — App
+
+- 13 contract checks passed
+- Expo 56 web export passed (423 modules)
+- both policies are selectable, forwarded to the Hub, and disclosed on schedule cards
+
+## Operational note
+
+The three suites reused the single exact tag `anet-test602:dev`, which was removed after each layer. Docker was paused when host free space fell below 9 GB; no prune or broad image deletion was used. A final exact-commit provenance rebuild is required before merge/deploy.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1081,6 +1081,7 @@ db.exec(`
     schedule_json    TEXT NOT NULL,
     timezone         TEXT NOT NULL DEFAULT 'UTC',
     overlap_policy   TEXT NOT NULL DEFAULT 'skip',
+    misfire_policy   TEXT NOT NULL DEFAULT 'catch_up_once',
     status           TEXT NOT NULL DEFAULT 'active',
     next_run_at      TEXT,
     last_run_at      TEXT,
@@ -1115,6 +1116,7 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_scheduled_runs_network
     ON scheduled_task_runs(network_id, created_at DESC);
 `);
+try { db.exec("ALTER TABLE scheduled_tasks ADD COLUMN misfire_policy TEXT NOT NULL DEFAULT 'catch_up_once'"); } catch {}
 try { db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_task_id)"); } catch {}
 
 // Helpers

--- a/server/src/scheduled-tasks-http.test.ts
+++ b/server/src/scheduled-tasks-http.test.ts
@@ -93,6 +93,8 @@ describe("Hub scheduled task API and dispatcher", () => {
       (db as any).dialect = original;
     }
     expect(() => assertScheduledTaskBackendSupported()).not.toThrow();
+    const misfireColumn = db.all<any>("PRAGMA table_info(scheduled_tasks)").find((column: any) => column.name === "misfire_policy");
+    expect(misfireColumn?.dflt_value).toBe("'catch_up_once'");
   });
 
   test("owner creates; viewer and node token cannot mutate", async () => {
@@ -120,6 +122,7 @@ describe("Hub scheduled task API and dispatcher", () => {
     expect(created.body.schedule.target_node_id).toBe(nodeId);
     expect(created.body.schedule.target_alias).toBe("scheduler-node");
     expect(created.body.schedule.schedule.type).toBe("interval");
+    expect(created.body.schedule.misfire_policy).toBe("catch_up_once");
     expect(created.body.schedule.created_by).toBeUndefined();
     expect(created.body.schedule.schedule_json).toBeUndefined();
     scheduleId = created.body.schedule.schedule_id;
@@ -152,6 +155,78 @@ describe("Hub scheduled task API and dispatcher", () => {
     expect(JSON.parse(task.meta_json).created_by).toBeUndefined();
     expect(db.get<any>("SELECT id FROM inbox WHERE id = ?1", run.task_id)).toBeTruthy();
     expect(runDueScheduledTasks().processed).toBe(0);
+  });
+
+  test("misfire policy catches up once by default or skips an overdue occurrence", async () => {
+    const make = async (name: string, misfirePolicy?: string) => api(ownerToken, "/api/scheduled-tasks", {
+      method: "POST",
+      body: JSON.stringify({
+        network_id: networkId,
+        name,
+        target_node_id: nodeId,
+        task: `misfire probe ${name}`,
+        timezone: "UTC",
+        schedule: { type: "interval", every_seconds: 60 },
+        ...(misfirePolicy === undefined ? {} : { misfire_policy: misfirePolicy }),
+      }),
+    });
+
+    const invalid = await make("invalid misfire", "run_everything");
+    expect(invalid.status).toBe(400);
+    expect(invalid.body.error).toBe("invalid_misfire_policy");
+
+    const now = new Date();
+    const overdue = new Date(now.getTime() - 5 * 60_000).toISOString();
+
+    const catchUp = await make("catch up default");
+    expect(catchUp.status).toBe(201);
+    expect(catchUp.body.schedule.misfire_policy).toBe("catch_up_once");
+    const catchUpId = catchUp.body.schedule.schedule_id as string;
+    db.run("UPDATE scheduled_tasks SET next_run_at = ?1 WHERE schedule_id = ?2", [overdue, catchUpId]);
+    expect(runDueScheduledTasks(now).processed).toBe(1);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE meta_json LIKE '%' || ?1 || '%'", catchUpId)!.count).toBe(1);
+    expect(new Date(db.get<{ next_run_at: string }>("SELECT next_run_at FROM scheduled_tasks WHERE schedule_id = ?1", catchUpId)!.next_run_at).getTime()).toBeGreaterThan(now.getTime());
+
+    const skipped = await make("skip overdue", "skip");
+    expect(skipped.status).toBe(201);
+    expect(skipped.body.schedule.misfire_policy).toBe("skip");
+    const skippedId = skipped.body.schedule.schedule_id as string;
+    db.run("UPDATE scheduled_tasks SET next_run_at = ?1 WHERE schedule_id = ?2", [overdue, skippedId]);
+    expect(runDueScheduledTasks(now).processed).toBe(1);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE meta_json LIKE '%' || ?1 || '%'", skippedId)!.count).toBe(0);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM inbox WHERE meta_json LIKE '%' || ?1 || '%'", skippedId)!.count).toBe(0);
+    const skippedRun = db.get<any>("SELECT * FROM scheduled_task_runs WHERE schedule_id = ?1", skippedId)!;
+    expect(skippedRun.status).toBe("skipped");
+    expect(skippedRun.error_code).toBe("misfire_skipped");
+    const skippedRow = db.get<any>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1", skippedId)!;
+    expect(skippedRow.last_run_at).toBeNull();
+    expect(new Date(skippedRow.next_run_at).getTime()).toBeGreaterThan(now.getTime());
+
+    const withinGrace = await make("skip within grace", "skip");
+    const withinGraceId = withinGrace.body.schedule.schedule_id as string;
+    const recent = new Date(now.getTime() - 10_000).toISOString();
+    db.run("UPDATE scheduled_tasks SET next_run_at = ?1 WHERE schedule_id = ?2", [recent, withinGraceId]);
+    expect(runDueScheduledTasks(now).processed).toBe(1);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE meta_json LIKE '%' || ?1 || '%'", withinGraceId)!.count).toBe(1);
+
+    const once = await api(ownerToken, "/api/scheduled-tasks", {
+      method: "POST",
+      body: JSON.stringify({
+        network_id: networkId,
+        name: "skip missed once",
+        target_node_id: nodeId,
+        task: "this missed one-time task must never run",
+        timezone: "UTC",
+        misfire_policy: "skip",
+        schedule: { type: "once", run_at: new Date(Date.now() + 3600_000).toISOString() },
+      }),
+    });
+    const onceId = once.body.schedule.schedule_id as string;
+    db.run("UPDATE scheduled_tasks SET next_run_at = ?1 WHERE schedule_id = ?2", [overdue, onceId]);
+    expect(runDueScheduledTasks(now).processed).toBe(1);
+    const onceRow = db.get<any>("SELECT status, next_run_at, last_run_at FROM scheduled_tasks WHERE schedule_id = ?1", onceId)!;
+    expect(onceRow).toEqual({ status: "completed", next_run_at: null, last_run_at: null });
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE meta_json LIKE '%' || ?1 || '%'", onceId)!.count).toBe(0);
   });
 
   test("dispatch failure rolls back occurrence, inbox, task, and schedule advance as one unit", async () => {

--- a/server/src/scheduled-tasks.ts
+++ b/server/src/scheduled-tasks.ts
@@ -9,6 +9,8 @@ export type ScheduleSpec =
   | { type: "daily"; time: string }
   | { type: "weekly"; time: string; weekdays: number[] };
 
+export type MisfirePolicy = "catch_up_once" | "skip";
+
 type ScheduledRow = {
   schedule_id: string;
   network_id: string;
@@ -22,6 +24,7 @@ type ScheduledRow = {
   schedule_json: string;
   timezone: string;
   overlap_policy: "skip" | "allow";
+  misfire_policy: MisfirePolicy;
   status: "active" | "paused" | "completed" | "cancelled";
   next_run_at: string | null;
   last_run_at: string | null;
@@ -48,6 +51,8 @@ export type ScheduledRequestContext = {
 const PRIORITIES = new Set(["high", "normal", "low"]);
 const TIME_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 const OPEN_TASK_STATUSES = ["created", "delivered", "acked", "running"];
+const MISFIRE_POLICIES = new Set<MisfirePolicy>(["catch_up_once", "skip"]);
+export const MISFIRE_GRACE_MS = 60_000;
 
 export function assertScheduledTaskBackendSupported(): void {
   if (db.dialect !== "sqlite") {
@@ -70,6 +75,12 @@ function validTimezone(timezone: string): boolean {
   } catch {
     return false;
   }
+}
+
+function parseMisfirePolicy(raw: unknown, fallback: MisfirePolicy = "catch_up_once"): MisfirePolicy {
+  if (raw === undefined) return fallback;
+  if (typeof raw !== "string" || !MISFIRE_POLICIES.has(raw as MisfirePolicy)) throw new Error("invalid_misfire_policy");
+  return raw as MisfirePolicy;
 }
 
 function zonedParts(date: Date, timezone: string): { date: string; time: string; weekday: number } {
@@ -190,7 +201,7 @@ function validateTarget(networkId: string, nodeId: unknown): { node_id: string; 
 
 type DispatchEvent = { alias: string; networkId: string; taskId: string; priority: string; state: "delivered" | "queued" };
 
-export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: string, advanceSchedule: boolean): { runId: string; taskId?: string; status: string; event?: DispatchEvent } {
+export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: string, advanceSchedule: boolean, advanceAfter = new Date()): { runId: string; taskId?: string; status: string; event?: DispatchEvent } {
   const runId = `srun_${crypto.randomUUID()}`;
   let event: DispatchEvent | undefined;
   let finalStatus = "failed";
@@ -220,7 +231,7 @@ export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: str
           "UPDATE scheduled_task_runs SET status = 'skipped', error_code = 'previous_run_active', completed_at = datetime('now') WHERE run_id = ?1",
           [runId],
         );
-        if (advanceSchedule) advance(row, scheduledFor);
+        if (advanceSchedule) advance(row, scheduledFor, advanceAfter);
         return;
       }
     }
@@ -235,7 +246,7 @@ export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: str
         "UPDATE scheduled_task_runs SET status = 'failed', error_code = 'target_node_not_found', error_message = 'The bound node no longer exists in this network', completed_at = datetime('now') WHERE run_id = ?1",
         [runId],
       );
-      if (advanceSchedule) advance(row, scheduledFor);
+      if (advanceSchedule) advance(row, scheduledFor, advanceAfter);
       return;
     }
     const lifecycle = assertNodeActive(node.alias, row.network_id);
@@ -245,7 +256,7 @@ export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: str
         "UPDATE scheduled_task_runs SET status = 'failed', error_code = 'target_not_active', error_message = ?1, completed_at = datetime('now') WHERE run_id = ?2",
         [String((lifecycle as any).error || "target_not_active").slice(0, 500), runId],
       );
-      if (advanceSchedule) advance(row, scheduledFor);
+      if (advanceSchedule) advance(row, scheduledFor, advanceAfter);
       return;
     }
 
@@ -274,7 +285,7 @@ export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: str
     db.run("UPDATE scheduled_task_runs SET task_id = ?1, status = ?2, completed_at = datetime('now') WHERE run_id = ?3", [taskId, deliveryState, runId]);
     db.run("UPDATE sessions SET task = ?1, updated_at = datetime('now') WHERE node_id = ?2 AND network_id = ?3", [row.task_content.slice(0, 200), node.node_id, row.network_id]);
     db.run("UPDATE scheduled_tasks SET target_alias = ?1, last_run_at = ?2, updated_at = datetime('now') WHERE schedule_id = ?3", [node.alias, scheduledFor, row.schedule_id]);
-    if (advanceSchedule) advance({ ...row, target_alias: node.alias }, scheduledFor);
+    if (advanceSchedule) advance({ ...row, target_alias: node.alias }, scheduledFor, advanceAfter);
     createdTaskId = taskId;
     finalStatus = deliveryState;
     event = { alias: node.alias, networkId: row.network_id, taskId, priority: row.priority, state: deliveryState };
@@ -296,20 +307,41 @@ export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: str
   return { runId, taskId: createdTaskId, status: finalStatus, event };
 }
 
-function advance(row: ScheduledRow, scheduledFor: string): void {
+function advance(row: ScheduledRow, scheduledFor: string, after = new Date(), recordLastRun = true): void {
   const spec = JSON.parse(row.schedule_json) as ScheduleSpec;
-  const next = nextOccurrence(spec, row.timezone, new Date());
+  const next = nextOccurrence(spec, row.timezone, after);
+  const lastRunAt = recordLastRun ? scheduledFor : row.last_run_at;
   if (spec.type === "once" || !next) {
     db.run(
       "UPDATE scheduled_tasks SET status = 'completed', next_run_at = NULL, last_run_at = ?1, revision = revision + 1, updated_at = datetime('now') WHERE schedule_id = ?2",
-      [scheduledFor, row.schedule_id],
+      [lastRunAt, row.schedule_id],
     );
   } else {
     db.run(
       "UPDATE scheduled_tasks SET next_run_at = ?1, last_run_at = ?2, revision = revision + 1, updated_at = datetime('now') WHERE schedule_id = ?3",
-      [iso(next), scheduledFor, row.schedule_id],
+      [iso(next), lastRunAt, row.schedule_id],
     );
   }
+}
+
+function isMissedOccurrence(scheduledFor: string, now: Date): boolean {
+  const scheduledAt = new Date(scheduledFor).getTime();
+  return Number.isFinite(scheduledAt) && now.getTime() - scheduledAt > MISFIRE_GRACE_MS;
+}
+
+function skipScheduledMisfire(row: ScheduledRow, scheduledFor: string, now: Date): void {
+  const runId = `srun_${crypto.randomUUID()}`;
+  db.transaction(() => {
+    db.run(
+      `INSERT INTO scheduled_task_runs
+       (run_id, schedule_id, network_id, scheduled_for, status, error_code, error_message, completed_at)
+       VALUES (?1, ?2, ?3, ?4, 'skipped', 'misfire_skipped', 'The occurrence was overdue and the schedule is configured to skip missed runs', datetime('now'))`,
+      [runId, row.schedule_id, row.network_id, scheduledFor],
+    );
+    // A skipped occurrence is auditable but is not an execution: preserve
+    // last_run_at while moving the schedule directly to its next future slot.
+    advance(row, scheduledFor, now, false);
+  });
 }
 
 export function runDueScheduledTasks(now = new Date(), limit = 100): { processed: number; failed: number } {
@@ -325,7 +357,14 @@ export function runDueScheduledTasks(now = new Date(), limit = 100): { processed
       // tick wins. The unique occurrence key handles a second scheduler.
       const current = db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1 AND status = 'active' AND next_run_at = ?2", row.schedule_id, row.next_run_at);
       if (!current?.next_run_at) continue;
-      dispatchScheduledOccurrence(current, current.next_run_at, true);
+      if (current.misfire_policy === "skip" && isMissedOccurrence(current.next_run_at, now)) {
+        skipScheduledMisfire(current, current.next_run_at, now);
+      } else {
+        // catch_up_once is also the compatibility default for pre-migration
+        // rows. Advancing from `now` collapses any number of missed slots into
+        // one task instead of replaying an outage as a dispatch storm.
+        dispatchScheduledOccurrence(current, current.next_run_at, true, now);
+      }
       processed++;
     } catch (e: any) {
       if (/UNIQUE|duplicate key/i.test(String(e?.message))) continue;
@@ -388,6 +427,7 @@ export async function handleScheduledTaskRequest(ctx: ScheduledRequestContext): 
       if (!content || content.length > 10_000) throw new Error("invalid_task");
       const priority = typeof body.priority === "string" ? body.priority : "normal";
       if (!PRIORITIES.has(priority)) throw new Error("invalid_priority");
+      const misfirePolicy = parseMisfirePolicy(body.misfire_policy);
       const target = validateTarget(networkId, body.target_node_id);
       const { spec, timezone } = parseScheduleSpec(body.schedule, body.timezone);
       const next = nextOccurrence(spec, timezone, new Date());
@@ -395,9 +435,9 @@ export async function handleScheduledTaskRequest(ctx: ScheduledRequestContext): 
       const scheduleId = `sched_${crypto.randomUUID()}`;
       db.run(
         `INSERT INTO scheduled_tasks
-         (schedule_id, network_id, created_by, name, target_node_id, target_alias, task_content, priority, schedule_type, schedule_json, timezone, overlap_policy, next_run_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'skip', ?12)`,
-        [scheduleId, networkId, ctx.auth?.userId ?? null, name, target.node_id, target.alias, content, priority, spec.type, JSON.stringify(spec), timezone, iso(next)],
+         (schedule_id, network_id, created_by, name, target_node_id, target_alias, task_content, priority, schedule_type, schedule_json, timezone, overlap_policy, misfire_policy, next_run_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'skip', ?12, ?13)`,
+        [scheduleId, networkId, ctx.auth?.userId ?? null, name, target.node_id, target.alias, content, priority, spec.type, JSON.stringify(spec), timezone, misfirePolicy, iso(next)],
       );
       const created = db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1", scheduleId)!;
       return Response.json({ ok: true, schedule: decodeRow(created) }, { status: 201 });
@@ -459,13 +499,14 @@ export async function handleScheduledTaskRequest(ctx: ScheduledRequestContext): 
       if (!validTimezone(parsed.timezone)) throw new Error("invalid_timezone");
       const requestedStatus = body.status === undefined ? row.status : String(body.status);
       if (!new Set(["active", "paused"]).has(requestedStatus)) throw new Error("invalid_status");
+      const misfirePolicy = parseMisfirePolicy(body.misfire_policy, row.misfire_policy);
       const next = requestedStatus === "active" ? nextOccurrence(parsed.spec, parsed.timezone, new Date()) : null;
       if (requestedStatus === "active" && !next) throw new Error("schedule_has_no_future_occurrence");
       const updated = db.run(
         `UPDATE scheduled_tasks SET name = ?1, target_node_id = ?2, target_alias = ?3, task_content = ?4,
          priority = ?5, schedule_type = ?6, schedule_json = ?7, timezone = ?8, status = ?9, next_run_at = ?10,
-         revision = revision + 1, updated_at = datetime('now') WHERE schedule_id = ?11 AND revision = ?12`,
-        [name, target.node_id, target.alias, content, priority, parsed.spec.type, JSON.stringify(parsed.spec), parsed.timezone, requestedStatus, next ? iso(next) : null, row.schedule_id, row.revision],
+         misfire_policy = ?11, revision = revision + 1, updated_at = datetime('now') WHERE schedule_id = ?12 AND revision = ?13`,
+        [name, target.node_id, target.alias, content, priority, parsed.spec.type, JSON.stringify(parsed.spec), parsed.timezone, requestedStatus, next ? iso(next) : null, misfirePolicy, row.schedule_id, row.revision],
       );
       if (updated.changes !== 1) return jsonError("revision_conflict", 409);
       return Response.json({ ok: true, schedule: decodeRow(db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1", row.schedule_id)!) });

--- a/tests/test602-scheduled-misfire/Dockerfile
+++ b/tests/test602-scheduled-misfire/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test601-hub-scheduled-tasks ./tests/test601-hub-scheduled-tasks
+COPY tests/test602-scheduled-misfire ./tests/test602-scheduled-misfire
+ARG SOURCE_COMMIT
+ENV TEST602_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test602-scheduled-misfire/run.sh
+ENTRYPOINT ["/workspace/tests/test602-scheduled-misfire/run.sh"]

--- a/tests/test602-scheduled-misfire/run.sh
+++ b/tests/test602-scheduled-misfire/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test602-scheduled-misfire.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test602 — scheduled-task misfire policy"
+echo "source_commit=${TEST602_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_real() {
+  local db_path=$1
+  COMMHUB_DB="$db_path" bun test server/src/scheduled-tasks-http.test.ts
+}
+
+echo "L0 build + additive schema"
+bun build server/src/index.ts --target bun --outfile /tmp/commhub-misfire.js
+test -s /tmp/commhub-misfire.js
+grep -Fq 'misfire_policy' server/src/db.ts
+
+echo "L1-L5 real Hub + SQLite behavior"
+run_real /tmp/test602-green.db
+
+echo "L6 witnessed-red: skip policy is load-bearing"
+cp server/src/scheduled-tasks.ts /tmp/test602-scheduled-tasks.ts
+sed -i 's/current.misfire_policy === "skip"/false \&\& current.misfire_policy === "skip"/' server/src/scheduled-tasks.ts
+grep -Fq 'false && current.misfire_policy === "skip"' server/src/scheduled-tasks.ts
+set +e
+run_real /tmp/test602-mut-skip.db >/tmp/test602-red.log 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: misfire skip gate"
+  sed -n '1,240p' /tmp/test602-red.log
+  exit 1
+fi
+echo "MUTATION_RED: misfire-skip-gate rc=$rc"
+cp /tmp/test602-scheduled-tasks.ts server/src/scheduled-tasks.ts
+
+echo "L7 restored green"
+run_real /tmp/test602-restored.db
+echo "RESULT: PASS"


### PR DESCRIPTION
Adds an explicit catch-up-once or skip policy for missed Hub schedule occurrences. Preserves catch_up_once as the compatibility default, records skipped runs without creating task/inbox rows, and adds a 60-second grace window. Validated in Docker with real Hub/SQLite tests and a witnessed-red mutation; exact-commit rebuild remains a pre-merge gate.