### PR TITLE
fix(grok): report CLI-owned default model honestly

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -5606,7 +5606,16 @@ log(`  alias:   ${ALIAS || "(none!)"} [from: ${ALIAS_SOURCE}]`);  // #203 tracea
 // "wrong runtime"). The raw input is kept alongside so the line still
 // answers "did my flag land?".
 log(`  runtime: ${RUNTIME}${RUNTIME_LABEL === RUNTIME ? "" : ` (input: ${RUNTIME_LABEL})`}`);
-log(`  model:   ${MODEL || (RUNTIME === "codex" || RUNTIME === "codex-app-server" ? "gpt-5.5" : RUNTIME === "grok" ? "grok-build" : "claude-sonnet-4-6")} ${MODEL ? "" : "(default)"}`);
+// Grok ACP/CLI does not receive a model flag when MODEL is unset. The Grok
+// process selects from its own config/default, so a runtime-family alias such
+// as `grok-build` must never be presented as a concrete model id (#553).
+const STARTUP_MODEL_LABEL = MODEL
+  || (RUNTIME === "grok"
+    ? "configured by Grok CLI"
+    : RUNTIME === "codex" || RUNTIME === "codex-app-server"
+      ? "gpt-5.5"
+      : "claude-sonnet-4-6");
+log(`  model:   ${STARTUP_MODEL_LABEL} ${MODEL || RUNTIME === "grok" ? "" : "(default)"}`);
 log(`  hub:     ${COMMHUB_URL}${AUTH_TOKEN ? " (auth)" : " (no auth!)"}`);
 // #214 维度 5 A6 — surface the grok ACP idle-timeout resolution so the
 // operator can see at a glance whether their `flags.grokAcpTimeoutMs`

--- a/agent-node/src/runtime-effective-label.test.ts
+++ b/agent-node/src/runtime-effective-label.test.ts
@@ -83,6 +83,12 @@ function bannerRuntimeLine(stdout: string): string | null {
   return m ? m[1].trim() : null;
 }
 
+/** The `model:` line of the startup banner, without the log prefix. */
+function bannerModelLine(stdout: string): string | null {
+  const m = stdout.match(/^.*\bmodel:\s*(.+)$/m);
+  return m ? m[1].trim() : null;
+}
+
 describe("#491 startup banner reports the EFFECTIVE runtime", () => {
   test("alias input 'codex-tui' → banner names the effective runtime (codex-app-server), not just the raw input", async () => {
     const r = await runCli(["--alias", "p491-node", "--runtime", "codex-tui"]);
@@ -116,5 +122,26 @@ describe("#491 regression lock — unknown runtime fails closed", () => {
     expect(out).toMatch(/codex-sdk/);
     // …and it must NOT have silently started as claude.
     expect(bannerRuntimeLine(r.stdout) ?? "").not.toContain("claude-agent-sdk");
+  }, 30_000);
+});
+
+describe("#553 Grok startup banner reports model ownership truthfully", () => {
+  test("unset model on Grok ACP names the Grok CLI as owner, not the runtime alias as a model id", async () => {
+    const r = await runCli(["--alias", "p553-node", "--runtime", "grok-build-acp"]);
+    const line = bannerModelLine(r.stdout);
+    expect(line).toBe("configured by Grok CLI");
+    expect(line).not.toContain("grok-build");
+  }, 30_000);
+
+  test("unset model on Grok CLI uses the same non-versioned ownership statement", async () => {
+    const r = await runCli(["--alias", "p553-node", "--runtime", "grok-build-cli"]);
+    const line = bannerModelLine(r.stdout);
+    expect(line).toBe("configured by Grok CLI");
+    expect(line).not.toContain("grok-build");
+  }, 30_000);
+
+  test("an explicit Grok model is still reported exactly", async () => {
+    const r = await runCli(["--alias", "p553-node", "--runtime", "grok-build-acp", "--model", "grok-4.5"]);
+    expect(bannerModelLine(r.stdout)).toBe("grok-4.5");
   }, 30_000);
 });

--- a/agent-node/src/runtime/grok-build-acp/client.test.ts
+++ b/agent-node/src/runtime/grok-build-acp/client.test.ts
@@ -1,10 +1,28 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { GrokAcpClient } from "./client";
 
 describe("GrokAcpClient", () => {
+  test("starts the ACP server as `grok agent stdio` without inventing a model flag", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "grok-acp-argv-"));
+    const argsFile = join(cwd, "args.json");
+    const fake = join(cwd, "fake-grok.js");
+    writeFileSync(fake, `#!/usr/bin/env node
+require("fs").writeFileSync(process.env.ARGS_FILE, JSON.stringify(process.argv.slice(2)));
+setTimeout(() => process.exit(0), 20);
+`);
+    chmodSync(fake, 0o755);
+
+    const client = new GrokAcpClient();
+    client.start({ cwd, binary: fake, env: { ...process.env, ARGS_FILE: argsFile } });
+    for (let i = 0; i < 50 && !existsSync(argsFile); i++) await Bun.sleep(10);
+    await client.close();
+
+    expect(JSON.parse(readFileSync(argsFile, "utf8"))).toEqual(["agent", "stdio"]);
+  });
+
   test("handles ACP server-to-client fs and permission requests", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "grok-acp-client-"));
     writeFileSync(join(cwd, "README.md"), "before\n");

--- a/docs/grok-build-runtime.md
+++ b/docs/grok-build-runtime.md
@@ -44,9 +44,14 @@ Expected startup markers:
 
 ```text
 runtime: grok-build-acp
-model:   grok-build (default)
+model:   configured by Grok CLI
 SSE connected
 ```
+
+When no `--model` is supplied, Agent Network does not pass a model id to the
+ACP child. Grok selects the model from its own configuration/default. The
+runtime name `grok-build-acp` (and its legacy alias `grok-build`) is not a
+model id.
 
 Send a REST task（三个变量都从登录后的 `~/.anet/config.json` 取——`anet login` 会写入；缺 `network_id` 请求会被拒）:
 

--- a/docs/tests/report-test605.txt
+++ b/docs/tests/report-test605.txt
@@ -1,0 +1,31 @@
+# test605 — Grok startup model label
+
+- Date: 2026-08-09
+- Source commit: `e47ebf6f3bd779c818be995ea3a5ce8fbaae468d`
+- Image tag: `anet-test605:dev`
+- Image ID: `sha256:8c544e7c8662d28257c9570ccb3d656f1531da34b46cc4144a813ba255167e15`
+- Embedded image env: `TEST605_SOURCE_COMMIT=e47ebf6f3bd779c818be995ea3a5ce8fbaae468d`
+- Runner artifact SHA256: `cae81ebe4380923bb33e2e70104d83335f2f2e427e0022244b9e824791a94e53`
+
+## Result
+
+`RESULT: PASS`
+
+Layered checks:
+
+1. Built the real `agent-node/src/cli.ts` entrypoint: PASS (253 modules, 1.11 MB bundle).
+2. Spawned the real CLI and inspected its startup banner: 6 tests, 14 assertions, 0 failures.
+   - unset Grok ACP model reports `configured by Grok CLI`;
+   - unset Grok CLI/co-presence model reports the same non-versioned ownership statement;
+   - an explicit `grok-4.5` value is preserved exactly;
+   - existing effective-runtime and unknown-runtime fail-closed checks remain green.
+3. Spawned a real fake ACP child and captured argv: exactly `["agent", "stdio"]`; no model flag was invented.
+4. User-facing runtime documentation names the Grok CLI as model owner and no longer presents `grok-build` as a model id.
+5. Restored-source rerun: 6 banner tests + 1 ACP argv test, all green.
+
+## Witnessed-red evidence
+
+- Replaced the truthful Grok ownership label with `grok-build`: banner suite failed (`rc=1`).
+- Added `--model grok-build` to the ACP child argv: argv test failed (`rc=1`).
+
+The first Docker attempt is not counted as evidence: it stopped at a line-sensitive documentation grep. The assertion was corrected in the add-only commit above, the image was rebuilt with the exact new source SHA, and the entire red/green sequence was rerun from scratch.

--- a/tests/test605-grok-startup-model-label/Dockerfile
+++ b/tests/test605-grok-startup-model-label/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+
+COPY agent-node ./agent-node
+COPY docs/grok-build-runtime.md ./docs/grok-build-runtime.md
+COPY tests/test605-grok-startup-model-label ./tests/test605-grok-startup-model-label
+
+ARG SOURCE_COMMIT
+ENV TEST605_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test605-grok-startup-model-label/run.sh
+ENTRYPOINT ["/workspace/tests/test605-grok-startup-model-label/run.sh"]

--- a/tests/test605-grok-startup-model-label/run.sh
+++ b/tests/test605-grok-startup-model-label/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test605-grok-startup-model-label.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test605 — Grok startup model label"
+echo "source_commit=${TEST605_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_banner_test() {
+  bun test agent-node/src/runtime-effective-label.test.ts
+}
+
+run_acp_argv_test() {
+  bun test agent-node/src/runtime/grok-build-acp/client.test.ts --test-name-pattern 'without inventing a model flag'
+}
+
+expect_red() {
+  local label=$1
+  shift
+  set +e
+  "$@" >/tmp/test605-red.log 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "MUTATION_FALSE_GREEN: $label"
+    sed -n '1,200p' /tmp/test605-red.log
+    exit 1
+  fi
+  echo "MUTATION_RED: $label rc=$rc"
+}
+
+echo "L0 build real agent-node entrypoint"
+cd agent-node
+bun run build
+test -s dist/cli.js
+cd /workspace
+
+echo "L1 real CLI banner + real ACP child argv"
+run_banner_test
+run_acp_argv_test
+
+echo "L2 user-facing documentation"
+grep -Fq 'model:   configured by Grok CLI' docs/grok-build-runtime.md
+! grep -Fq 'model:   grok-build (default)' docs/grok-build-runtime.md
+grep -Fq 'is not a model id' docs/grok-build-runtime.md
+
+cp agent-node/src/cli.ts /tmp/test605-cli.ts
+cp agent-node/src/runtime/grok-build-acp/client.ts /tmp/test605-client.ts
+
+echo "L3 witnessed-red: runtime alias must not return as model id"
+sed -i 's/? "configured by Grok CLI"/? "grok-build"/' agent-node/src/cli.ts
+grep -Fq '? "grok-build"' agent-node/src/cli.ts
+expect_red grok-runtime-alias-is-not-model run_banner_test
+cp /tmp/test605-cli.ts agent-node/src/cli.ts
+
+echo "L4 witnessed-red: ACP spawn must not acquire a model flag"
+sed -i 's/\["agent", "stdio"\]/["agent", "stdio", "--model", "grok-build"]/' agent-node/src/runtime/grok-build-acp/client.ts
+grep -Fq '["agent", "stdio", "--model", "grok-build"]' agent-node/src/runtime/grok-build-acp/client.ts
+expect_red acp-argv-has-no-invented-model run_acp_argv_test
+cp /tmp/test605-client.ts agent-node/src/runtime/grok-build-acp/client.ts
+
+echo "L5 restored green"
+run_banner_test
+run_acp_argv_test
+
+echo "RESULT: PASS"

--- a/tests/test605-grok-startup-model-label/run.sh
+++ b/tests/test605-grok-startup-model-label/run.sh
@@ -47,7 +47,7 @@ run_acp_argv_test
 echo "L2 user-facing documentation"
 grep -Fq 'model:   configured by Grok CLI' docs/grok-build-runtime.md
 ! grep -Fq 'model:   grok-build (default)' docs/grok-build-runtime.md
-grep -Fq 'is not a model id' docs/grok-build-runtime.md
+grep -Fq 'model id.' docs/grok-build-runtime.md
 
 cp agent-node/src/cli.ts /tmp/test605-cli.ts
 cp agent-node/src/runtime/grok-build-acp/client.ts /tmp/test605-client.ts


### PR DESCRIPTION
## What changed

- report `configured by Grok CLI` when a Grok runtime has no explicit Agent Network model
- preserve an explicitly supplied model verbatim
- document that `grok-build[-acp]` is a runtime name, not a model id
- add real-entrypoint banner coverage and a real child-process argv assertion

## Root cause

The startup banner substituted the internal runtime bucket `grok-build` as though it were a model id. The ACP runtime does not pass a model flag at all; it launches `grok agent stdio`, and Grok chooses from its own configuration/default.

## Validation

Docker `test605` on source `e47ebf6f3bd779c818be995ea3a5ce8fbaae468d`:

- real agent-node build: PASS
- real CLI banner: 6 tests / 14 assertions / 0 failures
- real ACP child argv: exactly `["agent", "stdio"]`
- mutation restoring `grok-build` as model: witnessed red
- mutation adding an ACP model flag: witnessed red
- restored green: PASS

Evidence: `docs/tests/report-test605.txt`.

Fixes #553