### PR TITLE
fix(cli): expose headless start flag in help

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2444,6 +2444,25 @@ Legacy aliases:
 `);
 }
 
+function printNodeStartHelp() {
+  console.log(`
+Usage: anet node start <name> [options]
+       anet node start --all [--stagger <seconds>] [--only a,b] [--exclude x,y]
+
+Options:
+  --tmux                       Start in a tmux session
+  --new-session               Start with a fresh model session
+  --copresence                Start a supported shared human + agent TUI
+  --accept-dev-channels       Headless / CI / no-TTY mode: start in detached
+                              tmux and auto-confirm the dev-channel prompt
+                              (requires tmux)
+  --dangerously-allow-full-access
+                              Request full filesystem/network access for
+                              supported co-presence runtimes
+  --yes-danger-full-access    Required with the previous flag in non-TTY use
+`);
+}
+
 // ── init (global) ──
 
 async function initGlobal() {
@@ -12637,7 +12656,9 @@ if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
       // (examples + interval format) rather than the generic node
       // subcommand list. Other `anet node <sub> --help` calls still
       // get the generic node usage.
-      if (args[1] === "loop") {
+      if (args[1] === "start") {
+        printNodeStartHelp();
+      } else if (args[1] === "loop") {
         args.splice(0, 1); // drop "node" so nodeLoopCommand sees args[1] as alias slot (no alias → prints loop help)
         // strip --help so it's not treated as an alias literal
         const hi = args.indexOf("--help");
@@ -12646,8 +12667,9 @@ if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
         if (hi2 >= 0) args.splice(hi2, 1);
         await nodeLoopCommand();
         process.exit(0);
+      } else {
+        console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|loop|migrate-token-to-envref> [name]`);
       }
-      console.log(`Usage: anet node <create|start|stop|restart|resume|delete|ls|rename|loop|migrate-token-to-envref> [name]`);
       break;
     default:
       printHelp();

--- a/agent-network/src/node-start-help.test.ts
+++ b/agent-network/src/node-start-help.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "..", "bin", "cli.ts");
+
+function realHelp(...args: string[]): { code: number | null; stdout: string; stderr: string } {
+  const home = mkdtempSync(join(tmpdir(), "anet-518-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "anet-518-cwd-"));
+  try {
+    const result = spawnSync("bun", [CLI, ...args], {
+      cwd,
+      env: { PATH: process.env.PATH ?? "", HOME: home },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    return { code: result.status, stdout: result.stdout, stderr: result.stderr };
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+describe("#518 node start help exposes the recommended headless flag", () => {
+  test("real `anet node start --help` names --accept-dev-channels and its operating boundary", () => {
+    const result = realHelp("node", "start", "--help");
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Usage: anet node start <name> [options]");
+    expect(result.stdout).toContain("--accept-dev-channels");
+    expect(result.stdout).toMatch(/Headless \/ CI \/ no-TTY/);
+    expect(result.stdout).toMatch(/detached\s+tmux/);
+    expect(result.stdout).toMatch(/requires tmux/);
+  });
+
+  test("asking for help performs no node-start work", () => {
+    const result = realHelp("node", "start", "--help");
+    expect(result.stdout).not.toContain("Starting agent-node");
+    expect(result.stdout).not.toContain("not found");
+    expect(result.stderr).toBe("");
+  });
+});

--- a/docs/tests/report-test606.txt
+++ b/docs/tests/report-test606.txt
@@ -1,0 +1,26 @@
+# test606 — `anet node start --help` headless flags
+
+- Date: 2026-08-09
+- Source commit: `e8902ac63194716829df2456614be64eb6e40df2`
+- Image tag: `anet-test606:dev`
+- Image ID: `sha256:4a2052d42685854071305d5989d91e1c888c4469748350168ed5998175edc00b`
+- Embedded image env: `TEST606_SOURCE_COMMIT=e8902ac63194716829df2456614be64eb6e40df2`
+- Runner artifact SHA256: `2c1f40068f4d66750b9817bbe151c0a7837307adf1a029f465af0d58944aa278`
+
+## Result
+
+`RESULT: PASS`
+
+1. `agent-network` TypeScript check: PASS.
+2. Real source CLI `node start --help`: 2 tests, 10 assertions, 0 failures.
+3. Full package build, including the obfuscated `dist/bin/cli.js`: PASS.
+4. Executed the packaged CLI with Node; output includes:
+   - `--accept-dev-channels`;
+   - `Headless / CI / no-TTY`;
+   - detached tmux behavior and the `requires tmux` boundary.
+5. Help execution does not enter node-start business logic.
+6. Restored-source rerun: 2 tests, 10 assertions, 0 failures.
+
+## Witnessed-red evidence
+
+The route from `node start --help` to its dedicated help printer was disabled while leaving the test unchanged. The real CLI test failed (`rc=1`), proving that the assertion covers printed behavior rather than merely grepping a source literal.

--- a/tests/test606-node-start-help/Dockerfile
+++ b/tests/test606-node-start-help/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY tests/test606-node-start-help ./tests/test606-node-start-help
+
+ARG SOURCE_COMMIT
+ENV TEST606_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test606-node-start-help/run.sh
+ENTRYPOINT ["/workspace/tests/test606-node-start-help/run.sh"]

--- a/tests/test606-node-start-help/run.sh
+++ b/tests/test606-node-start-help/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test606-node-start-help.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test606 — node start headless help"
+echo "source_commit=${TEST606_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_help_test() {
+  bun test agent-network/src/node-start-help.test.ts
+}
+
+echo "L0 typecheck"
+cd agent-network
+bun run typecheck
+cd /workspace
+
+echo "L1 real source CLI help"
+run_help_test
+
+echo "L2 packaged/obfuscated CLI help"
+cd agent-network
+bun run build
+node dist/bin/cli.js node start --help >/tmp/test606-packed-help.txt
+cd /workspace
+grep -Fq -- '--accept-dev-channels' /tmp/test606-packed-help.txt
+grep -Fq -- 'Headless / CI / no-TTY' /tmp/test606-packed-help.txt
+grep -Fq -- 'requires tmux' /tmp/test606-packed-help.txt
+
+echo "L3 witnessed-red: removing the start-help route hides the flag"
+cp agent-network/bin/cli.ts /tmp/test606-cli.ts
+sed -i 's/if (args\[1\] === "start")/if (false \&\& args[1] === "start")/' agent-network/bin/cli.ts
+grep -Fq 'if (false && args[1] === "start")' agent-network/bin/cli.ts
+set +e
+run_help_test >/tmp/test606-red.log 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: node-start-specific-help-route"
+  sed -n '1,200p' /tmp/test606-red.log
+  exit 1
+fi
+echo "MUTATION_RED: node-start-specific-help-route rc=$rc"
+cp /tmp/test606-cli.ts agent-network/bin/cli.ts
+
+echo "L4 restored green"
+run_help_test
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- add dedicated `anet node start --help` output
- expose `--accept-dev-channels` with its headless/no-TTY, detached-tmux, and tmux-required boundaries
- include the adjacent start options users need to distinguish from it
- add a real CLI regression test and packaged-output evidence

## Root cause

The universal help intercept routed `anet node start --help` to a generic one-line node usage string. The runtime error correctly recommended `--accept-dev-channels`, but the command's own help never displayed it, making a valid recovery path look stale or unsupported.

## Validation

Docker `test606` on source `e8902ac63194716829df2456614be64eb6e40df2`:

- TypeScript check: PASS
- real source CLI: 2 tests / 10 assertions / 0 failures
- complete packaged and obfuscated CLI build: PASS
- executed `dist/bin/cli.js node start --help`: flag and operating boundaries present
- mutation removing the start-help route: witnessed red
- restored green: PASS

Evidence: `docs/tests/report-test606.txt`.

Fixes #518