### PR TITLE
feat(server): expose upload limits via health

### DIFF
--- a/docs/tests/report-test607-health-upload-limits.txt
+++ b/docs/tests/report-test607-health-upload-limits.txt
@@ -1,0 +1,32 @@
+Test 607 — Hub authoritative upload limits
+
+Issue: https://github.com/sleep2agi/agent-network/issues/496
+Base commit: 5b2688fdc41e8c5bfa57820645abcf1f09ffe3df
+Source commit: a90c0cf64231702f2c06dd309471653314d579a6
+
+Scope
+- Adds an anonymous, additive `limits` object to `GET /health`.
+- Values are sourced from the same server constants that enforce upload and request limits.
+- Existing health fields and authentication behavior are unchanged.
+
+Docker evidence
+- Image: anet-test607-hub:dev
+- Image ID: sha256:b34d34c6b768ee280dedf5e719e7a8e445fe7d1997b461c0fc8aa8e53a39d895
+- Embedded TEST607_SOURCE_COMMIT: a90c0cf64231702f2c06dd309471653314d579a6
+- Artifact SHA256: 4c792b5a4d0fe6b20cb8241f064130e914df38362e5cbc1c799de49134b3c656
+
+Results
+- Real Hub build: PASS (257 modules, 1.52 MB output)
+- Real HTTP health tests: PASS (2 tests, 9 assertions)
+- Anonymous health response retains watchdog-compatible shape: PASS
+- `max_upload_bytes` equals the enforced Hub upload constant: PASS
+- `max_request_content_length` equals the enforced request constant: PASS
+- Request limit is not lower than upload limit: PASS
+
+Witnessed-red mutation
+- Mutation: replace the exact health response binding
+  `max_upload_bytes: MAX_UPLOAD_BYTES` with `max_upload_bytes: 1`.
+- Result: FAIL (rc=1) on the public health limit assertion.
+- Restored source: PASS (2 tests, 9 assertions).
+
+Final result: PASS

--- a/server/src/health-redaction.test.ts
+++ b/server/src/health-redaction.test.ts
@@ -17,6 +17,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { register, addNetworkMember, removeNetworkMember } from "./auth.js";
 import { db } from "./db.js";
+import { MAX_REQUEST_CONTENT_LENGTH, MAX_UPLOAD_BYTES } from "./uploads.js";
 
 const SERVER_DB = mkdtempSync(join(tmpdir(), "anet-health-red-db-")) + "/commhub.db";
 
@@ -89,6 +90,17 @@ describe("#473 anonymous /health — watchdog contract intact, no topology leak"
     expect(typeof body.sessions_count).toBe("number");
     expect(typeof body.sse_connections).toBe("number");
     expect(body.sse_connections).toBeGreaterThanOrEqual(1);
+  });
+
+  test("exposes stable upload limits anonymously without exposing topology", async () => {
+    const res = await fetch(`${BASE}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.limits).toEqual({
+      max_upload_bytes: MAX_UPLOAD_BYTES,
+      max_request_content_length: MAX_REQUEST_CONTENT_LENGTH,
+    });
+    expect(body.limits.max_request_content_length).toBeGreaterThan(body.limits.max_upload_bytes);
   });
 
   test("CLI count source stays truthful: health.sse_connections == /api/stats/sse total (no fake 0)", async () => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1366,6 +1366,14 @@ return Bun.serve({
         multi_network: true,
         license: license?.type || "none",
         uptime: Math.floor(process.uptime()),
+        // #496 — public, stable capability data. Dashboard upload proxies
+        // need the Hub's real limits before opening a streaming request;
+        // duplicating these constants client-side creates a silent
+        // lower-limit drift that the Hub can never observe.
+        limits: {
+          max_upload_bytes: MAX_UPLOAD_BYTES,
+          max_request_content_length: MAX_REQUEST_CONTENT_LENGTH,
+        },
       };
       if (scopedSessions !== undefined) body.sse_sessions = scopedSessions;
       return withCors(req, Response.json(body));

--- a/tests/test607-health-upload-limits/Dockerfile
+++ b/tests/test607-health-upload-limits/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+
+COPY server ./server
+COPY tests/test607-health-upload-limits ./tests/test607-health-upload-limits
+
+ARG SOURCE_COMMIT
+ENV TEST607_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test607-health-upload-limits/run.sh
+ENTRYPOINT ["/workspace/tests/test607-health-upload-limits/run.sh"]

--- a/tests/test607-health-upload-limits/run.sh
+++ b/tests/test607-health-upload-limits/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test607-health-upload-limits.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test607 — authoritative upload limits on public health"
+echo "source_commit=${TEST607_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_health() {
+  COMMHUB_DB="$(mktemp /tmp/test607-db.XXXXXX)" \
+    bun test server/src/health-redaction.test.ts \
+      --test-name-pattern 'stays anonymous 200|exposes stable upload limits anonymously'
+}
+
+echo "L0 build real Hub"
+bun build server/src/index.ts --target bun --outfile /tmp/test607-hub.js
+test -s /tmp/test607-hub.js
+
+echo "L1 real HTTP /health contract"
+run_health
+
+echo "L2 witnessed-red: removing the limits field breaks the HTTP contract"
+cp server/src/server.ts /tmp/test607-server.ts
+sed -i '0,/        limits: {/s//        disabled_limits: {/' server/src/server.ts
+grep -Fq 'disabled_limits: {' server/src/server.ts
+set +e
+run_health >/tmp/test607-red.log 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: public-health-upload-limits"
+  sed -n '1,200p' /tmp/test607-red.log
+  exit 1
+fi
+echo "MUTATION_RED: public-health-upload-limits rc=$rc"
+cp /tmp/test607-server.ts server/src/server.ts
+
+echo "L3 restored green"
+run_health
+echo "RESULT: PASS"

--- a/tests/test607-health-upload-limits/run.sh
+++ b/tests/test607-health-upload-limits/run.sh
@@ -26,8 +26,8 @@ run_health
 
 echo "L2 witnessed-red: removing the limits field breaks the HTTP contract"
 cp server/src/server.ts /tmp/test607-server.ts
-sed -i '0,/        limits: {/s//        disabled_limits: {/' server/src/server.ts
-grep -Fq 'disabled_limits: {' server/src/server.ts
+sed -i 's/max_upload_bytes: MAX_UPLOAD_BYTES/max_upload_bytes: 1/' server/src/server.ts
+grep -Fq 'max_upload_bytes: 1' server/src/server.ts
 set +e
 run_health >/tmp/test607-red.log 2>&1
 rc=$?


### PR DESCRIPTION
## Summary

- expose Hub-enforced upload and request-size limits in the anonymous `/health` response
- source both values from the existing enforcement constants
- preserve the existing health contract through an additive `limits` object
- add real HTTP coverage and an exact witnessed-red mutation

## Verification

- Docker test607 exact source: `d788d2083967bc57a60f93461b1cb4237c070381`
- Hub build: PASS
- real anonymous HTTP tests: 2 tests / 9 assertions
- exact health-binding mutation: FAIL as required, restored source PASS
- report: `docs/tests/report-test607-health-upload-limits.txt`

Fixes #496
