### PR TITLE
fix(cli): fail fast when Claude CLI is missing

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2268,9 +2268,17 @@ function printGrokCopresenceWarning(
 
 function checkRuntimeDependency(runtime: RuntimeName, phase: "create" | "start") {
   if (runtime === "claude-code-cli") {
-    if (!commandExists("claude")) {
+    const claudeInstalled = commandExists("claude");
+    if (!claudeInstalled && phase === "create") {
       console.warn(`[anet] Warning: claude CLI not found in PATH.`);
       console.warn(`[anet] Install: npm install -g @anthropic-ai/claude-code`);
+    }
+    if (!claudeInstalled && phase === "start") {
+      console.error(`[anet] ❌ Cannot start: claude-code-cli requires the Claude Code CLI, but \`claude\` was not found in PATH.`);
+      console.error(`[anet]    Install: npm install -g @anthropic-ai/claude-code`);
+      console.error(`[anet]    Login:   claude auth login`);
+      console.error(`[anet]    No Claude subscription? Recreate the node with \`--runtime claude-agent-sdk\` or \`--runtime codex-sdk\`.`);
+      process.exit(1);
     }
     if (phase === "start") printClaudeCodeNotice();
     return;

--- a/agent-network/src/claude-code-cli-dependency-preflight.test.ts
+++ b/agent-network/src/claude-code-cli-dependency-preflight.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CLI = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+
+function functionBody(name: string): string {
+  const start = CLI.indexOf(`function ${name}(`);
+  expect(start).toBeGreaterThan(-1);
+  const rest = CLI.slice(start + 1);
+  const end = rest.search(/\n(?:export )?(?:async )?function /);
+  return end < 0 ? rest : rest.slice(0, end);
+}
+
+describe("#485 claude-code-cli dependency preflight", () => {
+  const dependencyBody = functionBody("checkRuntimeDependency");
+  const launchBody = functionBody("launchAgent");
+
+  test("create remains a warning while start fails closed", () => {
+    expect(dependencyBody).toContain('!claudeInstalled && phase === "create"');
+    expect(dependencyBody).toContain('!claudeInstalled && phase === "start"');
+    const startGate = dependencyBody.slice(
+      dependencyBody.indexOf('!claudeInstalled && phase === "start"'),
+      dependencyBody.indexOf('if (phase === "start") printClaudeCodeNotice'),
+    );
+    expect(startGate).toMatch(/console\.error/);
+    expect(startGate).toMatch(/process\.exit\(1\)/);
+    expect(startGate).toContain("npm install -g @anthropic-ai/claude-code");
+    expect(startGate).toContain("claude auth login");
+    expect(startGate).toContain("--runtime claude-agent-sdk");
+  });
+
+  test("dependency refusal runs before launch side effects", () => {
+    const dependencyCheck = launchBody.indexOf('checkRuntimeDependency(runtime, "start")');
+    const mcpWrite = launchBody.indexOf("ensureMcpJson(profile)");
+    const claudeSpawn = launchBody.indexOf('spawn("claude", claudeArgs');
+    expect(dependencyCheck).toBeGreaterThan(-1);
+    expect(mcpWrite).toBeGreaterThan(dependencyCheck);
+    expect(claudeSpawn).toBeGreaterThan(dependencyCheck);
+  });
+});

--- a/docs/tests/report-test608-claude-cli-dependency.txt
+++ b/docs/tests/report-test608-claude-cli-dependency.txt
@@ -1,0 +1,31 @@
+Test 608 — claude-code-cli missing dependency preflight
+
+Issue: https://github.com/sleep2agi/agent-network/issues/485
+Base commit: 8d2674ffa5d9fcbed3d034a130926f106734e2a6
+Source commit: 7aa89b540f99681988b31dee873dd21569f32aef
+
+Behavior
+- `anet node create` keeps the existing non-blocking missing-CLI warning.
+- `anet node start` fails closed when `claude` is absent from PATH.
+- The error names the missing dependency and provides install, login, and alternate-runtime actions.
+- Refusal occurs before MCP config writes, PID writes, tmux, or child-process launch.
+
+Docker provenance
+- Image: anet-test608:dev
+- Image ID: sha256:128b05238d75ba46867f25e0e610f744691ffde2322cf7d53645e0bb4e66aab8
+- Embedded TEST608_SOURCE_COMMIT: 7aa89b540f99681988b31dee873dd21569f32aef
+- Runner artifact SHA256: 42c56099abefdbfacd74675bf991025cd30d52a0f6a948731bd5dac63ca58b6e
+
+Results
+- TypeScript typecheck: PASS
+- Source-order contract: PASS (2 tests, 12 assertions)
+- Real source CLI with missing `claude`: PASS (non-zero, actionable error, zero launch artifacts)
+- Full packaged/obfuscated CLI with missing `claude`: PASS
+- Positive control with an installed fake `claude`: PASS (dependency gate permits progress to the existing TTY gate)
+
+Witnessed-red mutation
+- Disabled only the missing-CLI start gate.
+- The real source CLI probe failed its expected error/zero-side-effect contract (rc=1).
+- Restored source contract and real CLI probe returned PASS.
+
+Final result: PASS

--- a/tests/test608-claude-cli-dependency/Dockerfile
+++ b/tests/test608-claude-cli-dependency/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY tests/lib ./tests/lib
+COPY tests/test608-claude-cli-dependency ./tests/test608-claude-cli-dependency
+
+ARG SOURCE_COMMIT
+ENV TEST608_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test608-claude-cli-dependency/run.sh
+ENTRYPOINT ["/workspace/tests/test608-claude-cli-dependency/run.sh"]

--- a/tests/test608-claude-cli-dependency/run.sh
+++ b/tests/test608-claude-cli-dependency/run.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test608-claude-cli-dependency.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test608 — claude-code-cli dependency preflight"
+echo "source_commit=${TEST608_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+source /workspace/tests/lib/safe-rm.sh
+
+run_contract() {
+  bun test agent-network/src/claude-code-cli-dependency-preflight.test.ts
+}
+
+write_fixture() {
+  local root="$1"
+  mkdir -p "$root/.anet/nodes/n_test608"
+  cat >"$root/.anet/nodes/n_test608/config.json" <<'JSON'
+{
+  "anet_version": "2.5.0",
+  "node_id": "n_test608",
+  "node_name": "missing-claude",
+  "alias": "missing-claude",
+  "runtime": "claude-code-cli",
+  "token": "ntok_test608",
+  "channels": ["server:commhub"],
+  "env": {},
+  "flags": {}
+}
+JSON
+}
+
+run_missing_binary() {
+  local cli="$1"
+  local root="$2"
+  local log="$3"
+  safe_rm_rf "$root"
+  mkdir -p "$root/home" "$root/bin"
+  write_fixture "$root"
+  set +e
+  (
+    cd "$root"
+    HOME="$root/home" PATH="$root/bin:/usr/local/bin:/usr/bin:/bin" \
+      bun "$cli" node start missing-claude
+  ) >"$log" 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: missing claude returned success"
+    cat "$log"
+    exit 1
+  fi
+  grep -Fq 'Cannot start: claude-code-cli requires the Claude Code CLI' "$log"
+  grep -Fq 'npm install -g @anthropic-ai/claude-code' "$log"
+  grep -Fq 'claude auth login' "$log"
+  grep -Fq -- '--runtime claude-agent-sdk' "$log"
+  if grep -Fq 'requires an interactive TTY' "$log"; then
+    echo "FAIL: launch advanced past the dependency preflight"
+    cat "$log"
+    exit 1
+  fi
+  test ! -e "$root/.mcp.json"
+  test ! -e "$root/.anet/nodes/n_test608/.pid"
+}
+
+echo "L0 typecheck + source contract"
+cd /workspace/agent-network
+bun run typecheck
+cd /workspace
+run_contract
+
+echo "L1 real source CLI, missing binary"
+run_missing_binary /workspace/agent-network/bin/cli.ts /tmp/test608-source /tmp/test608-source.log
+
+echo "L2 packaged CLI, missing binary"
+cd /workspace/agent-network
+bun run build
+cd /workspace
+run_missing_binary /workspace/agent-network/dist/bin/cli.js /tmp/test608-packed /tmp/test608-packed.log
+
+echo "L3 positive control: an installed claude passes this gate"
+safe_rm_rf /tmp/test608-positive
+mkdir -p /tmp/test608-positive/home /tmp/test608-positive/bin
+write_fixture /tmp/test608-positive
+cat >/tmp/test608-positive/bin/claude <<'SH'
+#!/usr/bin/env sh
+exit 0
+SH
+chmod 0755 /tmp/test608-positive/bin/claude
+set +e
+(
+  cd /tmp/test608-positive
+  HOME=/tmp/test608-positive/home PATH="/tmp/test608-positive/bin:/usr/local/bin:/usr/bin:/bin" \
+    bun /workspace/agent-network/bin/cli.ts node start missing-claude
+) >/tmp/test608-positive.log 2>&1
+positive_rc=$?
+set -e
+test "$positive_rc" -ne 0
+grep -Fq 'requires an interactive TTY' /tmp/test608-positive.log
+if grep -Fq 'was not found in PATH' /tmp/test608-positive.log; then
+  echo "FAIL: installed claude was treated as missing"
+  exit 1
+fi
+
+echo "L4 witnessed-red: disabling the start dependency gate"
+cp agent-network/bin/cli.ts /tmp/test608-cli.ts
+sed -i 's/if (!claudeInstalled && phase === "start")/if (false)/' agent-network/bin/cli.ts
+grep -Fq 'if (false)' agent-network/bin/cli.ts
+set +e
+run_missing_binary /workspace/agent-network/bin/cli.ts /tmp/test608-mutated /tmp/test608-mutated.log \
+  >/tmp/test608-mutation.log 2>&1
+mutation_rc=$?
+set -e
+if [ "$mutation_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: missing-claude-start-gate"
+  exit 1
+fi
+echo "MUTATION_RED: missing-claude-start-gate rc=$mutation_rc"
+cp /tmp/test608-cli.ts agent-network/bin/cli.ts
+
+echo "L5 restored green"
+run_contract
+run_missing_binary /workspace/agent-network/bin/cli.ts /tmp/test608-restored /tmp/test608-restored.log
+
+echo "RESULT: PASS"

--- a/tests/test608-claude-cli-dependency/run.sh
+++ b/tests/test608-claude-cli-dependency/run.sh
@@ -42,14 +42,16 @@ run_missing_binary() {
   safe_rm_rf "$root"
   mkdir -p "$root/home" "$root/bin"
   write_fixture "$root"
-  set +e
-  (
+  local rc
+  if (
     cd "$root"
     HOME="$root/home" PATH="$root/bin:/usr/local/bin:/usr/bin:/bin" \
       bun "$cli" node start missing-claude
-  ) >"$log" 2>&1
-  local rc=$?
-  set -e
+  ) >"$log" 2>&1; then
+    rc=0
+  else
+    rc=$?
+  fi
   if [ "$rc" -eq 0 ]; then
     echo "FAIL: missing claude returned success"
     cat "$log"

--- a/tests/test608-claude-cli-dependency/run.sh
+++ b/tests/test608-claude-cli-dependency/run.sh
@@ -53,19 +53,19 @@ run_missing_binary() {
   if [ "$rc" -eq 0 ]; then
     echo "FAIL: missing claude returned success"
     cat "$log"
-    exit 1
+    return 1
   fi
-  grep -Fq 'Cannot start: claude-code-cli requires the Claude Code CLI' "$log"
-  grep -Fq 'npm install -g @anthropic-ai/claude-code' "$log"
-  grep -Fq 'claude auth login' "$log"
-  grep -Fq -- '--runtime claude-agent-sdk' "$log"
+  grep -Fq 'Cannot start: claude-code-cli requires the Claude Code CLI' "$log" || return 1
+  grep -Fq 'npm install -g @anthropic-ai/claude-code' "$log" || return 1
+  grep -Fq 'claude auth login' "$log" || return 1
+  grep -Fq -- '--runtime claude-agent-sdk' "$log" || return 1
   if grep -Fq 'requires an interactive TTY' "$log"; then
     echo "FAIL: launch advanced past the dependency preflight"
     cat "$log"
-    exit 1
+    return 1
   fi
-  test ! -e "$root/.mcp.json"
-  test ! -e "$root/.anet/nodes/n_test608/.pid"
+  test ! -e "$root/.mcp.json" || return 1
+  test ! -e "$root/.anet/nodes/n_test608/.pid" || return 1
 }
 
 echo "L0 typecheck + source contract"


### PR DESCRIPTION
## Summary

- keep node creation non-blocking when Claude Code CLI is not installed
- make `anet node start` fail closed before launch side effects when `claude` is absent from PATH
- provide install, login, and alternate-runtime actions instead of allowing an unrelated downstream error
- cover the real source CLI and the fully packaged/obfuscated CLI

## Verification

- Docker test608 exact source: `7aa89b540f99681988b31dee873dd21569f32aef`
- TypeScript and source contract: PASS (2 tests / 12 assertions)
- real source CLI and packaged CLI missing-binary probes: PASS
- installed-binary positive control: PASS
- disabling the start gate: witnessed red
- report: `docs/tests/report-test608-claude-cli-dependency.txt`

Fixes #485
