### PR TITLE
docs(dashboard): point users to embedded chat panel

### DIFF
--- a/docs-site/docs/en/guide/architecture.md
+++ b/docs-site/docs/en/guide/architecture.md
@@ -44,7 +44,7 @@ graph TB
 | Component | Runs On | Port | Purpose | npm Package |
 |-----------|---------|------|---------|-------------|
 | **CommHub Server** | Server (1 machine) | `9200` | Message routing, task management, auth, database | `@sleep2agi/commhub-server` |
-| **Dashboard** | Local or standalone server | `3000` default | Web UI (Overview / Nodes / Tasks / Messages / Chat / Admin / Settings — see the [Dashboard doc](/en/guide/dashboard#page-overview) for per-page detail) | `@sleep2agi/agent-network-dashboard` |
+| **Dashboard** | Local or standalone server | `3000` default | Web UI (primary navigation: Nodes / Overview / Schedules / SkillHub / Tasks / Servers / Providers / Admin / Settings; ChatPanel is embedded in node/overview interactions, not a standalone page — see the [Dashboard doc](/en/guide/dashboard#page-overview)) | `@sleep2agi/agent-network-dashboard` |
 | **anet CLI** | Each client machine | -- | Command-line management tool (full command list: [CLI reference](/en/guide/cli)) | `@sleep2agi/agent-network` |
 | **Agent Node** | Each client machine | -- | AI worker (receives tasks, calls AI, reports results) | `@sleep2agi/agent-node` |
 | **Claude Code** | Client machine | -- | Interactive AI development (joins network via MCP) | Anthropic official |
@@ -130,7 +130,7 @@ Agent Network ships as four npm packages with clear responsibilities:
 | `@sleep2agi/agent-network` | **anet CLI** -- config management, service launcher, status monitoring | `npm i -g @sleep2agi/agent-network` |
 | `@sleep2agi/agent-node` | **Agent runtime** -- AI model + tool calls + task handling | `anet node create` + `anet node start` |
 | `@sleep2agi/commhub-server` | **Communication hub** -- message routing + SSE push + task management | `anet hub start` |
-| `@sleep2agi/agent-network-dashboard` | **Web Dashboard** -- visual monitoring + task management (Overview / Nodes / Tasks / Messages / Chat / Admin / Settings) | `anet hub dashboard` (CLI auto-fetches) |
+| `@sleep2agi/agent-network-dashboard` | **Web Dashboard** -- visual monitoring + task management (Nodes / Overview / Schedules / SkillHub / Tasks / Servers / Providers / Admin / Settings; ChatPanel is embedded) | `anet hub dashboard` (CLI auto-fetches) |
 
 They can be used independently or composed:
 

--- a/docs-site/docs/en/guide/basics.md
+++ b/docs-site/docs/en/guide/basics.md
@@ -37,7 +37,7 @@ Every Agent needs a unique name within its network -- that's the alias. Other ag
 anet node create coder-1 --runtime claude-agent-sdk --model MiniMax-M3
 ```
 
-In the Dashboard ChatPanel, select "coder-1" and send a Task:
+In Dashboard **Overview**, click the online "coder-1" card, then send a Task from the embedded ChatPanel (it is not a standalone navigation page):
 
 ```text
 Write a Hello World script

--- a/docs-site/docs/en/guide/dashboard.md
+++ b/docs-site/docs/en/guide/dashboard.md
@@ -41,6 +41,8 @@ Shipped alongside the [v0.10.8 release](/en/changelog) ([#157](https://github.co
 
 ## Page Overview
 
+The current primary navigation is **Nodes / Overview / Schedules / SkillHub / Tasks / Servers / Providers / Admin / Settings** (Admin is visible only to system-level admins). Low-frequency routes such as `Messages` remain available through a direct URL or the command palette. **ChatPanel is embedded and opens from an online agent card in Overview or a node view in Nodes; there is no standalone Chat navigation page.**
+
 ### Overview
 
 The overview page displays the overall network state:
@@ -163,7 +165,7 @@ Message data comes from CommHub REST APIs. Agents receive push events through `/
 
 ### ChatPanel
 
-ChatPanel lets you talk to agents directly in the browser:
+ChatPanel lets you talk to agents directly in the browser. It is not a standalone page: open it from an online agent card in **Overview** or from a node view in **Nodes**:
 
 1. Select a target agent (from the online list)
 2. Enter your message

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -115,7 +115,7 @@ Clean a half-baked node with `anet node delete <alias>` (run once without `--for
 
 Back in your browser at `http://localhost:3000`:
 
-1. Go to the Chat page, pick `my-bot` on the left
+1. Open **Overview** and click the online `my-bot` card to open its embedded ChatPanel (there is no standalone Chat navigation page)
 2. Type a message in the input ("what time is it?" / "write hello world"), hit Enter
 3. Your message appears immediately with an optimistic echo (`You` label)
 4. After the agent calls the LLM, the reply appears with full markdown rendering (`↳ my-bot` label)

--- a/docs-site/docs/guide/architecture.md
+++ b/docs-site/docs/guide/architecture.md
@@ -44,7 +44,7 @@ graph TB
 | 组件 | 跑在哪 | 端口 | 作用 | npm 包 |
 |------|--------|------|------|--------|
 | **CommHub Server** | 服务器（1 台） | `9200` | 消息路由、任务管理、认证、数据库 | `@sleep2agi/commhub-server` |
-| **Dashboard** | 本机或独立服务器 | `3000`（默认） | Web UI（Overview / Nodes / Tasks / Messages / Chat / Admin / Settings，页面明细见 [Dashboard 文档](/guide/dashboard#页面一览)） | `@sleep2agi/agent-network-dashboard` |
+| **Dashboard** | 本机或独立服务器 | `3000`（默认） | Web UI（主导航：Nodes / Overview / Schedules / SkillHub / Tasks / Servers / Providers / Admin / Settings；ChatPanel 内嵌于节点/总览交互，不是独立页面。详见 [Dashboard 文档](/guide/dashboard#页面一览)） | `@sleep2agi/agent-network-dashboard` |
 | **anet CLI** | 每台客户端机器 | -- | 管理命令行工具（完整命令清单见 [CLI 命令参考](/guide/cli)） | `@sleep2agi/agent-network` |
 | **Agent Node** | 每台客户端机器 | -- | AI 工作节点（接任务、调 AI、回结果） | `@sleep2agi/agent-node` |
 | **Claude Code** | 客户端机器 | -- | 交互式 AI 开发（通过 MCP 接入网络） | Anthropic 官方 |
@@ -130,7 +130,7 @@ Agent Network 由四个 npm 包组成，职责清晰：
 | `@sleep2agi/agent-network` | **anet CLI** -- 配置管理、启动服务、状态监控 | `npm i -g @sleep2agi/agent-network` |
 | `@sleep2agi/agent-node` | **Agent 运行时** -- AI 模型 + 工具调用 + 任务处理 | `anet node create` + `anet node start` |
 | `@sleep2agi/commhub-server` | **通信中枢** -- 消息路由 + SSE 推送 + 任务管理 | `anet hub start` |
-| `@sleep2agi/agent-network-dashboard` | **Web Dashboard** -- 可视化监控 + 任务管理（Overview / Nodes / Tasks / Messages / Chat / Admin / Settings） | `anet hub dashboard`（CLI 自动拉起）|
+| `@sleep2agi/agent-network-dashboard` | **Web Dashboard** -- 可视化监控 + 任务管理（Nodes / Overview / Schedules / SkillHub / Tasks / Servers / Providers / Admin / Settings；ChatPanel 为内嵌面板） | `anet hub dashboard`（CLI 自动拉起）|
 
 这些包可以独立使用，也可以配合使用：
 

--- a/docs-site/docs/guide/basics.md
+++ b/docs-site/docs/guide/basics.md
@@ -39,7 +39,7 @@ ANTHROPIC_AUTH_TOKEN=你的MiniMax-API-Key \
 anet node create 文案1号 --runtime claude-agent-sdk
 ```
 
-在 Dashboard 的 ChatPanel 里选择 "文案1号"，发送 Task：
+在 Dashboard 的 **Overview** 点击在线的“文案1号”卡片，打开内嵌 ChatPanel 后发送 Task（ChatPanel 不是独立导航页）：
 
 ```text
 写一段产品介绍

--- a/docs-site/docs/guide/dashboard.md
+++ b/docs-site/docs/guide/dashboard.md
@@ -41,6 +41,8 @@ Dashboard 是 Agent Network 的 Web 管理界面，提供实时监控和任务�
 
 ## 页面一览
 
+当前主导航是 **Nodes / Overview / Schedules / SkillHub / Tasks / Servers / Providers / Admin / Settings**（Admin 仅系统级管理员可见）。`Messages` 等低频页面仍可通过直接 URL 或命令面板访问。**ChatPanel 是从 Overview 的在线节点卡片或 Nodes 节点视图打开的内嵌面板，不存在单独的 Chat 导航页。**
+
 ### Overview（总览）
 
 总览页展示网络的整体状态：
@@ -163,7 +165,7 @@ Event Log:
 
 ### ChatPanel（对话面板）
 
-ChatPanel 让你直接在 Web 端与 Agent 对话：
+ChatPanel 让你直接在 Web 端与 Agent 对话。它不是独立页面：从 **Overview** 点击在线 Agent 卡片，或在 **Nodes** 节点视图中打开：
 
 1. 选择目标 Agent（从在线列表中选择）
 2. 输入消息内容

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -115,7 +115,7 @@ anet node start my-bot
 
 回浏览器 `http://localhost:3000`：
 
-1. 进 Chat 页面, 左侧选 `my-bot`
+1. 进 **Overview**, 点击在线的 `my-bot` 卡片，打开内嵌 ChatPanel（Dashboard 没有单独的 Chat 导航页）
 2. 输入框写一句话（"现在几点？" / "做个 hello world"）, 回车
 3. 自己消息立刻乐观回显（`You` 标签）
 4. Agent 调用 LLM 后回复, markdown 完整渲染（`↳ my-bot` 标签）

--- a/docs/tests/report-test609-dashboard-chat-doc-path.txt
+++ b/docs/tests/report-test609-dashboard-chat-doc-path.txt
@@ -1,0 +1,24 @@
+# Test 609 — Dashboard ChatPanel documentation path
+
+Date: 2026-08-09
+
+## Provenance
+
+- Source commit: `63e0b0985ff810c219bd40c07a9ce89706882bbd`
+- Docker image: `anet-test609:dev`
+- Image ID: `sha256:94b536555ca9f9bcd9b995bcbea40370c0e9421c2466227367aa63b705495b69`
+- Embedded `TEST609_SOURCE_COMMIT`: `63e0b0985ff810c219bd40c07a9ce89706882bbd`
+- Runner artifact SHA-256: `faadc4f5a57edfa9f220e988d65900a83274caf5080eb08aec62d6c15d899be7`
+
+## Result
+
+`RESULT: PASS`
+
+1. Bilingual route contract passed. The Chinese and English guides point users to the embedded ChatPanel from Overview/Nodes and explicitly state that Dashboard has no standalone Chat page.
+2. The documented primary navigation matches the current Dashboard navigation.
+3. The complete VitePress production build passed and rendered both language variants.
+4. Witnessed-red mutation: removing the no-standalone-page disclosure made the contract fail with `rc=1`; restoring the source returned it to green.
+
+## Scope
+
+Documentation and its regression test only. No Hub, agent runtime, Dashboard runtime, deployment, or production state was changed.

--- a/tests/dashboard-chat-doc-path.test.mjs
+++ b/tests/dashboard-chat-doc-path.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(path, 'utf8');
+
+const zhGettingStarted = read('docs-site/docs/guide/getting-started.md');
+const enGettingStarted = read('docs-site/docs/en/guide/getting-started.md');
+const zhDashboard = read('docs-site/docs/guide/dashboard.md');
+const enDashboard = read('docs-site/docs/en/guide/dashboard.md');
+const zhArchitecture = read('docs-site/docs/guide/architecture.md');
+const enArchitecture = read('docs-site/docs/en/guide/architecture.md');
+const zhReadme = read('README.md');
+const enReadme = read('README.en.md');
+
+assert.ok(!zhGettingStarted.includes('进 Chat 页面'));
+assert.ok(!enGettingStarted.includes('Go to the Chat page'));
+assert.match(zhGettingStarted, /Overview.*在线.*my-bot.*内嵌 ChatPanel/);
+assert.match(enGettingStarted, /Overview.*online.*my-bot.*embedded ChatPanel/);
+
+const nav = 'Nodes / Overview / Schedules / SkillHub / Tasks / Servers / Providers / Admin / Settings';
+for (const [name, text] of [
+  ['zh dashboard', zhDashboard],
+  ['en dashboard', enDashboard],
+  ['zh architecture', zhArchitecture],
+  ['en architecture', enArchitecture],
+]) {
+  assert.ok(text.includes(nav), `${name} must carry the current primary navigation`);
+}
+
+assert.match(zhDashboard, /不存在单独的 Chat 导航页/);
+assert.match(enDashboard, /no standalone Chat navigation page/);
+assert.ok(!zhArchitecture.includes('Overview / Nodes / Tasks / Messages / Chat / Admin / Settings'));
+assert.ok(!enArchitecture.includes('Overview / Nodes / Tasks / Messages / Chat / Admin / Settings'));
+
+assert.ok(!/Chat 面板|Chat 页面/.test(zhReadme));
+assert.ok(!/Chat panel|Chat page/i.test(enReadme));
+
+console.log('dashboard ChatPanel documentation path: PASS');

--- a/tests/test609-dashboard-chat-doc-path/Dockerfile
+++ b/tests/test609-dashboard-chat-doc-path/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+
+COPY docs-site/package.json docs-site/package-lock.json ./docs-site/
+RUN npm ci --prefix docs-site --no-audit --no-fund
+
+COPY README.md README.en.md ./
+COPY docs-site ./docs-site
+COPY tests/dashboard-chat-doc-path.test.mjs ./tests/dashboard-chat-doc-path.test.mjs
+COPY tests/test609-dashboard-chat-doc-path ./tests/test609-dashboard-chat-doc-path
+
+ARG SOURCE_COMMIT
+ENV TEST609_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test609-dashboard-chat-doc-path/run.sh
+ENTRYPOINT ["/workspace/tests/test609-dashboard-chat-doc-path/run.sh"]

--- a/tests/test609-dashboard-chat-doc-path/Dockerfile
+++ b/tests/test609-dashboard-chat-doc-path/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:22-bookworm-slim
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace
 
 COPY docs-site/package.json docs-site/package-lock.json ./docs-site/

--- a/tests/test609-dashboard-chat-doc-path/run.sh
+++ b/tests/test609-dashboard-chat-doc-path/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test609-dashboard-chat-doc-path.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test609 — Dashboard ChatPanel documentation path"
+echo "source_commit=${TEST609_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_contract() {
+  node tests/dashboard-chat-doc-path.test.mjs
+}
+
+echo "L0 bilingual route contract"
+run_contract
+
+echo "L1 VitePress production build"
+npm run build --prefix docs-site
+test -s docs-site/docs/.vitepress/dist/guide/getting-started.html
+test -s docs-site/docs/.vitepress/dist/en/guide/getting-started.html
+test -s docs-site/docs/.vitepress/dist/guide/dashboard.html
+test -s docs-site/docs/.vitepress/dist/en/guide/dashboard.html
+
+echo "L2 witnessed-red: removing the no-standalone-page disclosure"
+cp docs-site/docs/guide/dashboard.md /tmp/test609-dashboard.md
+sed -i 's/不存在单独的 Chat 导航页/打开 Chat 导航页/' docs-site/docs/guide/dashboard.md
+grep -Fq '打开 Chat 导航页' docs-site/docs/guide/dashboard.md
+set +e
+run_contract >/tmp/test609-red.log 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: standalone-chat-page-disclosure"
+  exit 1
+fi
+test -s /tmp/test609-red.log
+echo "MUTATION_RED: standalone-chat-page-disclosure rc=$rc"
+cp /tmp/test609-dashboard.md docs-site/docs/guide/dashboard.md
+
+echo "L3 restored green"
+run_contract
+echo "RESULT: PASS"


### PR DESCRIPTION
Fixes #487.

## What changed

- replaces the obsolete instruction to open a standalone Chat page with the real Overview/Nodes embedded ChatPanel path
- documents the current primary Dashboard navigation in Chinese and English
- removes obsolete Messages/Chat architecture entries
- adds a Docker regression suite with a full VitePress production build and witnessed-red disclosure mutation

## Verification

- exact source commit: `63e0b0985ff810c219bd40c07a9ce89706882bbd`
- `test609`: PASS
- bilingual route contract: PASS
- VitePress production build: PASS
- removing the no-standalone-page disclosure: witnessed red

No runtime or production behavior is changed.
