### PR TITLE
test(opencode): isolate Git-state fixture from system temp

### DIFF
--- a/agent-network/src/opencode-runtime-binding.test.ts
+++ b/agent-network/src/opencode-runtime-binding.test.ts
@@ -9,14 +9,15 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   readdirSync,
   rmSync,
   symlinkSync,
   unlinkSync,
   writeFileSync,
 } from "fs";
-import { tmpdir } from "os";
-import { dirname, join } from "path";
+import { homedir, tmpdir } from "os";
+import { dirname, join, resolve } from "path";
 import {
   assertExactOpencodeRuntimeBinding,
   assertOpencodeNodeStateUntracked,
@@ -26,6 +27,30 @@ import {
   removeOpencodeRuntimeBinding,
   writeOpencodeRuntimeBinding,
 } from "./opencode-runtime-binding";
+
+function assertNoGitMarkerInAncestors(start: string): void {
+  let current = resolve(start);
+  while (true) {
+    if (existsSync(join(current, ".git"))) {
+      throw new Error(`OpenCode test workspace has Git metadata in its ancestor chain: ${current}`);
+    }
+    const parent = dirname(current);
+    if (parent === current) return;
+    current = parent;
+  }
+}
+
+function createIsolatedGitStateTestRoot(): string {
+  const workspaceParent = resolve(
+    process.env.OPENCODE_TEST_WORKSPACE_ROOT
+      || join(homedir(), ".opencode-test-workspaces"),
+  );
+  assertNoGitMarkerInAncestors(workspaceParent);
+  mkdirSync(workspaceParent, { recursive: true, mode: 0o700 });
+  const canonicalWorkspaceParent = realpathSync(workspaceParent);
+  assertNoGitMarkerInAncestors(canonicalWorkspaceParent);
+  return mkdtempSync(join(canonicalWorkspaceParent, `run-${process.pid}-`));
+}
 
 describe("external OpenCode runtime binding", () => {
   let root: string;
@@ -291,12 +316,12 @@ describe("external OpenCode runtime binding", () => {
 });
 
 describe("assertOpencodeNodeStateUntracked", () => {
-  let root: string;
+  let root = "";
   let project: string;
   let node: string;
 
   beforeEach(() => {
-    root = mkdtempSync(join(tmpdir(), "opencode-git-state-"));
+    root = createIsolatedGitStateTestRoot();
     chmodSync(root, 0o700);
     project = join(root, "project");
     node = join(project, ".anet", "nodes", "node-a");
@@ -306,7 +331,8 @@ describe("assertOpencodeNodeStateUntracked", () => {
   });
 
   afterEach(() => {
-    rmSync(root, { recursive: true, force: true });
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = "";
   });
 
   test("allows ordinary non-Git projects", () => {

--- a/docs/tests/report-test610-opencode-clean-test-workspace.txt
+++ b/docs/tests/report-test610-opencode-clean-test-workspace.txt
@@ -1,0 +1,25 @@
+# Test 610 — OpenCode Git-state test workspace isolation
+
+Date: 2026-08-09
+
+## Provenance
+
+- Source commit: `706eaac173f56492b39e25f711f9a9a1a2100f1d`
+- Docker image: `anet-test610:dev`
+- Image ID: `sha256:ed4701148d0dd27ddb0ade65a0d785c8ae0fbd849d16fa3631eccdb5f0f37bc6`
+- Embedded `TEST610_SOURCE_COMMIT`: `706eaac173f56492b39e25f711f9a9a1a2100f1d`
+- Runner artifact SHA-256: `28b94dc32317de4fa8e60364516274c38c716e77930c581aba7542af0442e909`
+
+## Result
+
+`RESULT: PASS`
+
+1. `agent-network` typecheck passed.
+2. With an intentionally invalid `/tmp/.git`, all 18 OpenCode runtime-binding tests passed from the isolated workspace root; `/tmp/.git` remained untouched.
+3. An override beneath the contaminated `/tmp` ancestor failed closed before creating its workspace.
+4. The test-owned per-run directory was removed without removing the shared workspace parent or unrelated paths.
+5. Witnessed-red mutation: restoring the old `mkdtempSync(join(tmpdir(), ...))` fixture made the real test fail with `Git repository metadata is invalid`; restoring the isolated fixture returned all 18 tests to green.
+
+## Scope
+
+Test fixture and its Docker regression suite only. Production OpenCode runtime behavior is unchanged.

--- a/tests/test610-opencode-clean-test-workspace/Dockerfile
+++ b/tests/test610-opencode-clean-test-workspace/Dockerfile
@@ -1,5 +1,9 @@
 FROM oven/bun:1.3.14
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace
 
 COPY agent-network/package.json ./agent-network/package.json

--- a/tests/test610-opencode-clean-test-workspace/Dockerfile
+++ b/tests/test610-opencode-clean-test-workspace/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY tests/lib ./tests/lib
+COPY tests/test610-opencode-clean-test-workspace ./tests/test610-opencode-clean-test-workspace
+
+ARG SOURCE_COMMIT
+ENV TEST610_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test610-opencode-clean-test-workspace/run.sh
+ENTRYPOINT ["/workspace/tests/test610-opencode-clean-test-workspace/run.sh"]

--- a/tests/test610-opencode-clean-test-workspace/run.sh
+++ b/tests/test610-opencode-clean-test-workspace/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test610-opencode-clean-test-workspace.txt"
+WORKSPACE_PARENT=/workspace/opencode-test-workspaces
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test610 — OpenCode Git-state test workspace isolation"
+echo "source_commit=${TEST610_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_target() {
+  OPENCODE_TEST_WORKSPACE_ROOT="$WORKSPACE_PARENT" \
+    bun test agent-network/src/opencode-runtime-binding.test.ts
+}
+
+echo "L0 typecheck"
+cd /workspace/agent-network
+bun run typecheck
+cd /workspace
+
+echo "L1 hostile system temp ancestor"
+mkdir -p /tmp/.git
+test -d /tmp/.git
+run_target
+test -d /tmp/.git
+if find "$WORKSPACE_PARENT" -mindepth 1 -print -quit | grep -q .; then
+  echo "FAIL: test-owned workspace child was not cleaned"
+  exit 1
+fi
+
+echo "L2 fail-closed override whose ancestor contains Git metadata"
+set +e
+OPENCODE_TEST_WORKSPACE_ROOT=/tmp/opencode-test-workspaces \
+  bun test agent-network/src/opencode-runtime-binding.test.ts \
+  >/tmp/test610-dirty-override.log 2>&1
+dirty_override_rc=$?
+set -e
+test "$dirty_override_rc" -ne 0
+grep -Fq 'OpenCode test workspace has Git metadata in its ancestor chain: /tmp' \
+  /tmp/test610-dirty-override.log
+test ! -e /tmp/opencode-test-workspaces
+
+echo "L3 witnessed-red: restore the old tmpdir-based fixture"
+cp agent-network/src/opencode-runtime-binding.test.ts /tmp/test610-binding.test.ts
+sed -i \
+  's/root = createIsolatedGitStateTestRoot();/root = mkdtempSync(join(tmpdir(), "opencode-git-state-"));/' \
+  agent-network/src/opencode-runtime-binding.test.ts
+grep -Fq 'root = mkdtempSync(join(tmpdir(), "opencode-git-state-"));' \
+  agent-network/src/opencode-runtime-binding.test.ts
+set +e
+run_target >/tmp/test610-mutation.log 2>&1
+mutation_rc=$?
+set -e
+if [ "$mutation_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: tmpdir-ancestor-isolation"
+  exit 1
+fi
+grep -Fq 'Git repository metadata is invalid' /tmp/test610-mutation.log
+echo "MUTATION_RED: tmpdir-ancestor-isolation rc=$mutation_rc"
+cp /tmp/test610-binding.test.ts agent-network/src/opencode-runtime-binding.test.ts
+
+echo "L4 restored green"
+run_target
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Fixes #488.
Fixes #511.

## What changed

- isolates the `assertOpencodeNodeStateUntracked` fixture from the host system temp directory
- supports `OPENCODE_TEST_WORKSPACE_ROOT` for CI/sandbox placement
- rejects workspace roots whose lexical or canonical ancestor chain contains Git metadata
- removes only the per-test `mkdtemp` child
- adds a Docker regression suite that constructs the real invalid `/tmp/.git` failure shape

## Verification

- exact source commit: `706eaac173f56492b39e25f711f9a9a1a2100f1d`
- typecheck: PASS
- runtime-binding tests under hostile `/tmp/.git`: 18 pass / 0 fail
- dirty override: fail closed before workspace creation
- restoring the old `tmpdir()` fixture: witnessed red with `Git repository metadata is invalid`
- restored source: 18 pass / 0 fail

This is test-only; production OpenCode runtime behavior is unchanged. The host `/tmp/.git` is never modified.
