### PR TITLE
fix(cli): keep boolean flags from swallowing operands

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -87,6 +87,7 @@ import {
   grokCopresenceDisclosure,
   type GrokCopresenceSessionDisclosure,
 } from "../src/grok-copresence-disclosure";
+import { parseCliOptions, positionalArgs } from "../src/cli-args";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -1305,56 +1306,7 @@ function listProfileIds(): string[] {
 // ── Parse --key value and repeatable --channel/--env ──
 
 function parseOpts(): Record<string, string> & { _channels: string[]; _envs: string[] } {
-  const r: any = { _channels: [], _envs: [] };
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--channel" && args[i + 1]) { r._channels.push(args[++i]); continue; }
-    if (args[i] === "--env" && args[i + 1]) { r._envs.push(args[++i]); continue; }
-    // #P2fix设计裁6 — boolean flags must not swallow the next positional as a
-    // value; `--copresence <alias>` previously assigned `copresence=<alias>`
-    // and callers checking `=== "true"` silently lost the feature. Mirrors
-    // the BOOLEAN_FLAGS handling in positionalArgs() below.
-    if (BOOLEAN_FLAGS.has(args[i])) { r[args[i].slice(2)] = "true"; continue; }
-    if (args[i].startsWith("--") && args[i + 1] && !args[i + 1].startsWith("--")) {
-      r[args[i].slice(2)] = args[++i];
-    } else if (args[i].startsWith("--")) {
-      r[args[i].slice(2)] = "true";
-    }
-  }
-  return r;
-}
-
-// #173 — boolean (no-value) flags must NOT swallow the following token as a
-// value. parseOpts's heuristic ("--flag" + non-"--" token → that token is the
-// value) would otherwise read `anet node start --all foo` as all="foo".
-const BOOLEAN_FLAGS = new Set([
-  "--all",
-  "--tmux",
-  "--new-session",
-  // RFC-030 P2 — co-presence orchestration flags.
-  "--copresence",
-  "--dangerously-allow-full-access",
-  // #P2fix设计裁5 — non-TTY confirmation of danger-full-access requires this
-  // second explicit flag alongside --dangerously-allow-full-access. TTY
-  // callers still use the typed 'yes' prompt.
-  "--yes-danger-full-access",
-  "--grok-headless",
-]);
-
-// #173 — extract the bare positional operands from an argv slice, mirroring
-// parseOpts's flag/value consumption, so `--all`'s mutual exclusion with a
-// positional <alias> can be detected reliably.
-function positionalArgs(argv: string[]): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i];
-    if (a === "--channel" || a === "--env") { i++; continue; }  // multi-value flags
-    if (a.startsWith("--")) {
-      if (!BOOLEAN_FLAGS.has(a) && argv[i + 1] && !argv[i + 1].startsWith("--")) i++;
-      continue;
-    }
-    out.push(a);
-  }
-  return out;
+  return parseCliOptions(args);
 }
 
 function commandExists(name: string, env?: NodeJS.ProcessEnv): boolean {
@@ -4908,7 +4860,7 @@ async function startCommand() {
 
   // #P2fix设计裁6 — extract alias via positionalArgs so `--copresence <alias>`
   // is not treated as `id=--copresence`. positionalArgs is already boolean-
-  // aware; parseOpts is now too (see BOOLEAN_FLAGS check above).
+  // aware; parseOpts shares the same exact flag set through cli-args.ts.
   const startPositionals = positionalArgs(args.slice(1));
   const id = startPositionals[0];
   if (!id) { showProfiles("start"); return; }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1306,7 +1306,10 @@ function listProfileIds(): string[] {
 // ── Parse --key value and repeatable --channel/--env ──
 
 function parseOpts(): Record<string, string> & { _channels: string[]; _envs: string[] } {
-  return parseCliOptions(args);
+  // Preserve the legacy call-site type while the pure parser models its two
+  // repeatable array fields honestly.
+  const parsed = parseCliOptions(args);
+  return parsed as unknown as Record<string, string> & { _channels: string[]; _envs: string[] };
 }
 
 function commandExists(name: string, env?: NodeJS.ProcessEnv): boolean {

--- a/agent-network/src/cli-args-wiring.test.ts
+++ b/agent-network/src/cli-args-wiring.test.ts
@@ -7,6 +7,6 @@ test("CLI option and positional parsing share cli-args.ts", () => {
   expect(source).toContain(
     'import { parseCliOptions, positionalArgs } from "../src/cli-args";',
   );
-  expect(source).toContain("return parseCliOptions(args);");
+  expect(source).toContain("const parsed = parseCliOptions(args);");
   expect(source).not.toContain("const BOOLEAN_FLAGS = new Set(");
 });

--- a/agent-network/src/cli-args-wiring.test.ts
+++ b/agent-network/src/cli-args-wiring.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+test("CLI option and positional parsing share cli-args.ts", () => {
+  const source = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+  expect(source).toContain(
+    'import { parseCliOptions, positionalArgs } from "../src/cli-args";',
+  );
+  expect(source).toContain("return parseCliOptions(args);");
+  expect(source).not.toContain("const BOOLEAN_FLAGS = new Set(");
+});

--- a/agent-network/src/cli-args.test.ts
+++ b/agent-network/src/cli-args.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { BOOLEAN_FLAGS, parseCliOptions, positionalArgs } from "./cli-args";
+
+const formerlyMissingBooleanFlags = [
+  "accept-dev-channels",
+  "dev-open",
+  "dry-run",
+  "follow",
+  "no-auto-self",
+  "no-yolo",
+  "resume-latest",
+  "self",
+  "f",
+];
+
+describe("CLI argument parsing", () => {
+  test("pins the complete presence-only flag set", () => {
+    expect([...BOOLEAN_FLAGS].sort()).toEqual([
+      "--accept-dev-channels",
+      "--all",
+      "--copresence",
+      "--dangerously-allow-full-access",
+      "--dev-open",
+      "--dry-run",
+      "--f",
+      "--follow",
+      "--grok-headless",
+      "--new-session",
+      "--no-auto-self",
+      "--no-yolo",
+      "--resume-latest",
+      "--self",
+      "--tmux",
+      "--yes-danger-full-access",
+    ]);
+  });
+
+  for (const flag of formerlyMissingBooleanFlags) {
+    test(`--${flag} does not swallow a following positional operand`, () => {
+      const argv = [`--${flag}`, "node-a"];
+      expect(parseCliOptions(argv)[flag]).toBe("true");
+      expect(positionalArgs(argv)).toEqual(["node-a"]);
+    });
+
+    test(`--${flag} works after a positional operand`, () => {
+      const argv = ["node-a", `--${flag}`];
+      expect(parseCliOptions(argv)[flag]).toBe("true");
+      expect(positionalArgs(argv)).toEqual(["node-a"]);
+    });
+  }
+
+  test("presence-only flags do not accept an explicit true or false value", () => {
+    expect(parseCliOptions(["--dry-run", "false"])["dry-run"]).toBe("true");
+    expect(positionalArgs(["--dry-run", "false"])).toEqual(["false"]);
+  });
+
+  test("value flags, repeatable flags, and multiple positionals retain their behavior", () => {
+    const argv = [
+      "node-a",
+      "--runtime", "codex-sdk",
+      "--channel", "server:commhub",
+      "--channel", "feishu:ops",
+      "--env", "A=1",
+      "--dry-run",
+      "node-b",
+    ];
+    const parsed = parseCliOptions(argv);
+    expect(parsed.runtime).toBe("codex-sdk");
+    expect(parsed["dry-run"]).toBe("true");
+    expect(parsed._channels).toEqual(["server:commhub", "feishu:ops"]);
+    expect(parsed._envs).toEqual(["A=1"]);
+    expect(positionalArgs(argv)).toEqual(["node-a", "node-b"]);
+  });
+
+  test("key=value remains unsupported and is treated as the complete key", () => {
+    expect(parseCliOptions(["--runtime=codex-sdk"])).toEqual({
+      _channels: [],
+      _envs: [],
+      "runtime=codex-sdk": "true",
+    });
+    expect(positionalArgs(["--runtime=codex-sdk"])).toEqual([]);
+  });
+});

--- a/agent-network/src/cli-args.ts
+++ b/agent-network/src/cli-args.ts
@@ -1,4 +1,5 @@
-export type ParsedCliOptions = Record<string, string> & {
+export type ParsedCliOptions = {
+  [key: string]: string | string[];
   _channels: string[];
   _envs: string[];
 };
@@ -26,7 +27,7 @@ export const BOOLEAN_FLAGS = new Set([
 ]);
 
 export function parseCliOptions(argv: string[]): ParsedCliOptions {
-  const result = { _channels: [], _envs: [] } as ParsedCliOptions;
+  const result: ParsedCliOptions = { _channels: [], _envs: [] };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--channel" && argv[i + 1]) {
       result._channels.push(argv[++i]);

--- a/agent-network/src/cli-args.ts
+++ b/agent-network/src/cli-args.ts
@@ -26,7 +26,7 @@ export const BOOLEAN_FLAGS = new Set([
 ]);
 
 export function parseCliOptions(argv: string[]): ParsedCliOptions {
-  const result: ParsedCliOptions = { _channels: [], _envs: [] };
+  const result = { _channels: [], _envs: [] } as ParsedCliOptions;
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--channel" && argv[i + 1]) {
       result._channels.push(argv[++i]);

--- a/agent-network/src/cli-args.ts
+++ b/agent-network/src/cli-args.ts
@@ -1,0 +1,67 @@
+export type ParsedCliOptions = Record<string, string> & {
+  _channels: string[];
+  _envs: string[];
+};
+
+// Presence-only flags. These must never consume the following positional
+// operand as a value. Keep this exact list shared by option and positional
+// parsing so the two views of argv cannot drift.
+export const BOOLEAN_FLAGS = new Set([
+  "--accept-dev-channels",
+  "--all",
+  "--copresence",
+  "--dangerously-allow-full-access",
+  "--dev-open",
+  "--dry-run",
+  "--f",
+  "--follow",
+  "--grok-headless",
+  "--new-session",
+  "--no-auto-self",
+  "--no-yolo",
+  "--resume-latest",
+  "--self",
+  "--tmux",
+  "--yes-danger-full-access",
+]);
+
+export function parseCliOptions(argv: string[]): ParsedCliOptions {
+  const result: ParsedCliOptions = { _channels: [], _envs: [] };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--channel" && argv[i + 1]) {
+      result._channels.push(argv[++i]);
+      continue;
+    }
+    if (argv[i] === "--env" && argv[i + 1]) {
+      result._envs.push(argv[++i]);
+      continue;
+    }
+    if (BOOLEAN_FLAGS.has(argv[i])) {
+      result[argv[i].slice(2)] = "true";
+      continue;
+    }
+    if (argv[i].startsWith("--") && argv[i + 1] && !argv[i + 1].startsWith("--")) {
+      result[argv[i].slice(2)] = argv[++i];
+    } else if (argv[i].startsWith("--")) {
+      result[argv[i].slice(2)] = "true";
+    }
+  }
+  return result;
+}
+
+export function positionalArgs(argv: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--channel" || arg === "--env") {
+      i++;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      if (!BOOLEAN_FLAGS.has(arg) && argv[i + 1] && !argv[i + 1].startsWith("--")) i++;
+      continue;
+    }
+    result.push(arg);
+  }
+  return result;
+}

--- a/docs/tests/report-test611-cli-boolean-flags.txt
+++ b/docs/tests/report-test611-cli-boolean-flags.txt
@@ -1,0 +1,26 @@
+# Test 611 — CLI presence-only boolean flags
+
+Date: 2026-08-09
+
+## Provenance
+
+- Source commit: `da16ad6fc272f20da0491766b5f8951f23331ef4`
+- Docker image: `anet-test611:dev`
+- Image ID: `sha256:1883357bc78b746487f61b3df4e9e875ffcebaa382ca937843b9b0759ccde8a2`
+- Embedded `TEST611_SOURCE_COMMIT`: `da16ad6fc272f20da0491766b5f8951f23331ef4`
+- Runner artifact SHA-256: `365009c79a1f12b96a604a5dec35160b2e352c3cb776941003fc3d49d0e19351`
+
+## Result
+
+`RESULT: PASS`
+
+1. `agent-network` typecheck and the complete packaged/obfuscated CLI build passed.
+2. Parser and wiring tests passed: 23 tests, 49 assertions.
+3. The formerly missing presence-only flags work before and after a positional operand: `accept-dev-channels`, `dev-open`, `dry-run`, `follow`, `no-auto-self`, `no-yolo`, `resume-latest`, `self`, and `f`.
+4. Existing value, repeatable `channel`/`env`, multi-positional, and unsupported `key=value` behavior is pinned without expansion of scope.
+5. Removing each of the nine boolean entries independently made its behavior test fail; all nine witnessed-red mutations returned `rc=1`.
+6. Disconnecting `bin/cli.ts` from the shared parser made the wiring contract fail with `rc=1`; restoring the source returned all tests to green.
+
+## Scope
+
+CLI argument parsing only. No Hub, runtime process, persisted node state, deployment, or production system was changed.

--- a/tests/test611-cli-boolean-flags/Dockerfile
+++ b/tests/test611-cli-boolean-flags/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY tests/test611-cli-boolean-flags ./tests/test611-cli-boolean-flags
+
+ARG SOURCE_COMMIT
+ENV TEST611_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test611-cli-boolean-flags/run.sh
+ENTRYPOINT ["/workspace/tests/test611-cli-boolean-flags/run.sh"]

--- a/tests/test611-cli-boolean-flags/run.sh
+++ b/tests/test611-cli-boolean-flags/run.sh
@@ -62,7 +62,7 @@ do
     echo "MUTATION_FALSE_GREEN: boolean-${flag}"
     exit 1
   fi
-  grep -Fq 'expect(received).toEqual(expected)' /tmp/test611-${flag}.log
+  grep -Fq 'expect(received).toBe(expected)' /tmp/test611-${flag}.log
   echo "MUTATION_RED: boolean-${flag} rc=$mutation_rc"
 done
 cp /tmp/test611-cli-args.ts agent-network/src/cli-args.ts

--- a/tests/test611-cli-boolean-flags/run.sh
+++ b/tests/test611-cli-boolean-flags/run.sh
@@ -31,7 +31,7 @@ bun run build
 cd /workspace
 grep -Fq 'import { parseCliOptions, positionalArgs } from "../src/cli-args";' \
   agent-network/bin/cli.ts
-grep -Fq 'return parseCliOptions(args);' agent-network/bin/cli.ts
+grep -Fq 'const parsed = parseCliOptions(args);' agent-network/bin/cli.ts
 
 echo "L3 witnessed-red: each formerly missing flag"
 cp agent-network/src/cli-args.ts /tmp/test611-cli-args.ts
@@ -69,7 +69,7 @@ cp /tmp/test611-cli-args.ts agent-network/src/cli-args.ts
 
 echo "L4 witnessed-red: disconnecting the CLI wrapper"
 cp agent-network/bin/cli.ts /tmp/test611-cli.ts
-sed -i 's/return parseCliOptions(args);/return { _channels: [], _envs: [] };/' \
+sed -i 's/const parsed = parseCliOptions(args);/const parsed = { _channels: [], _envs: [] };/' \
   agent-network/bin/cli.ts
 set +e
 bun test agent-network/src/cli-args-wiring.test.ts >/tmp/test611-wiring.log 2>&1

--- a/tests/test611-cli-boolean-flags/run.sh
+++ b/tests/test611-cli-boolean-flags/run.sh
@@ -54,7 +54,7 @@ do
   fi
   set +e
   bun test agent-network/src/cli-args.test.ts \
-    -t "--${flag} does not swallow a following positional operand" \
+    -t "${flag} does not swallow a following positional operand" \
     >/tmp/test611-${flag}.log 2>&1
   mutation_rc=$?
   set -e

--- a/tests/test611-cli-boolean-flags/run.sh
+++ b/tests/test611-cli-boolean-flags/run.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test611-cli-boolean-flags.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test611 — CLI presence-only boolean flags"
+echo "source_commit=${TEST611_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_unit() {
+  bun test \
+    agent-network/src/cli-args.test.ts \
+    agent-network/src/cli-args-wiring.test.ts
+}
+
+echo "L0 typecheck"
+cd /workspace/agent-network
+bun run typecheck
+cd /workspace
+
+echo "L1 parser matrix"
+run_unit
+
+echo "L2 full CLI build with shared parser wiring"
+cd /workspace/agent-network
+bun run build
+cd /workspace
+grep -Fq 'import { parseCliOptions, positionalArgs } from "../src/cli-args";' \
+  agent-network/bin/cli.ts
+grep -Fq 'return parseCliOptions(args);' agent-network/bin/cli.ts
+
+echo "L3 witnessed-red: each formerly missing flag"
+cp agent-network/src/cli-args.ts /tmp/test611-cli-args.ts
+for flag in \
+  accept-dev-channels \
+  dev-open \
+  dry-run \
+  follow \
+  no-auto-self \
+  no-yolo \
+  resume-latest \
+  self \
+  f
+do
+  cp /tmp/test611-cli-args.ts agent-network/src/cli-args.ts
+  sed -i "/\"--${flag}\",/d" agent-network/src/cli-args.ts
+  if grep -Fq "\"--${flag}\"," agent-network/src/cli-args.ts; then
+    echo "FAIL: mutation did not remove --${flag}"
+    exit 1
+  fi
+  set +e
+  bun test agent-network/src/cli-args.test.ts \
+    -t "--${flag} does not swallow a following positional operand" \
+    >/tmp/test611-${flag}.log 2>&1
+  mutation_rc=$?
+  set -e
+  if [ "$mutation_rc" -eq 0 ]; then
+    echo "MUTATION_FALSE_GREEN: boolean-${flag}"
+    exit 1
+  fi
+  grep -Fq 'expect(received).toEqual(expected)' /tmp/test611-${flag}.log
+  echo "MUTATION_RED: boolean-${flag} rc=$mutation_rc"
+done
+cp /tmp/test611-cli-args.ts agent-network/src/cli-args.ts
+
+echo "L4 witnessed-red: disconnecting the CLI wrapper"
+cp agent-network/bin/cli.ts /tmp/test611-cli.ts
+sed -i 's/return parseCliOptions(args);/return { _channels: [], _envs: [] };/' \
+  agent-network/bin/cli.ts
+set +e
+bun test agent-network/src/cli-args-wiring.test.ts >/tmp/test611-wiring.log 2>&1
+wiring_rc=$?
+set -e
+if [ "$wiring_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: cli-parser-wiring"
+  exit 1
+fi
+grep -Fq 'toContain' /tmp/test611-wiring.log
+echo "MUTATION_RED: cli-parser-wiring rc=$wiring_rc"
+cp /tmp/test611-cli.ts agent-network/bin/cli.ts
+
+echo "L5 restored green"
+run_unit
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Fixes #464.

## What changed

- moves option and positional parsing into one pure shared module
- adds all nine missing presence-only flags so they cannot consume the following operand
- preserves repeatable channel/env, ordinary value, and unsupported key=value behavior
- adds direct parser/wiring tests and an exact Docker mutation matrix

## Verification

- exact source commit: `da16ad6fc272f20da0491766b5f8951f23331ef4`
- typecheck: PASS
- full packaged/obfuscated CLI build: PASS
- parser/wiring: 23 tests / 49 assertions
- nine independent missing-flag mutations: all witnessed red
- CLI wrapper disconnection mutation: witnessed red

No Hub, persisted state, runtime process, deployment, or production behavior outside CLI argv parsing is changed.
