### PR TITLE
fix(agent-node): log skipped inbox messages at info

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -111,6 +111,7 @@ import {
   isInteractiveDashboardTask,
   shouldDrainPendingReplies,
 } from "./inbox-dispatch";
+import { formatInboxSkipLog } from "./inbox-skip-log";
 import { createSingleFlight } from "./util/single-flight";
 import { createCodexSessionManager } from "./runtime/codex-app-server/session-manager";
 import { buildGrokChildEnv } from "./runtime/grok-child-env";
@@ -4532,7 +4533,12 @@ async function processInbox() {
 
       const skip = shouldSkipMessage(from, content, msgType);
       if (skip) {
-        debug(`skip message from ${from}: ${skip}`);
+        log(formatInboxSkipLog({
+          sender: from,
+          reason: skip,
+          taskId: String(msg.id),
+          messageType: msgType,
+        }));
         await ackMessage(msg.id).catch((e: any) => warn(`ack failed for skipped ${msg.id.slice(0, 8)}: ${e.message}`));
         return;
       }

--- a/agent-node/src/inbox-skip-log-wiring.test.ts
+++ b/agent-node/src/inbox-skip-log-wiring.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+test("processInbox logs skipped messages at INFO before acknowledging", () => {
+  const source = readFileSync(join(import.meta.dir, "cli.ts"), "utf8");
+  expect(source).toContain('import { formatInboxSkipLog } from "./inbox-skip-log";');
+  expect(source).toContain("log(formatInboxSkipLog({");
+  expect(source).not.toContain("debug(`skip message from ${from}: ${skip}`)");
+
+  const logIndex = source.indexOf("log(formatInboxSkipLog({");
+  const ackIndex = source.indexOf("ackMessage(msg.id)", logIndex);
+  expect(logIndex).toBeGreaterThan(-1);
+  expect(ackIndex).toBeGreaterThan(logIndex);
+});

--- a/agent-node/src/inbox-skip-log.test.ts
+++ b/agent-node/src/inbox-skip-log.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { formatInboxSkipLog } from "./inbox-skip-log";
+
+describe("formatInboxSkipLog", () => {
+  test("self-message diagnostics identify the routing layer and full task", () => {
+    const line = formatInboxSkipLog({
+      sender: "tester",
+      reason: "self",
+      taskId: "task_1234567890abcdef",
+      messageType: "task",
+    });
+    expect(line).toContain("skipped inbound task task_1234567890abcdef from tester: self");
+    expect(line).toContain("sender alias equals node alias");
+    expect(line).toContain("reply-loop guard");
+    expect(line).toContain("acknowledged without model delivery");
+  });
+
+  test("all inbound filter reasons produce an actionable INFO-safe line", () => {
+    for (const reason of ["own-prefix", "cooldown", "low-value-inbound"]) {
+      const line = formatInboxSkipLog({
+        sender: "sender-a",
+        reason,
+        taskId: "task_reason_matrix",
+        messageType: "broadcast",
+      });
+      expect(line).toContain(reason);
+      expect(line).toContain("task_reason_matrix");
+      expect(line).toContain("acknowledged without model delivery");
+    }
+  });
+
+  test("the formatter has no message-content input", () => {
+    const line = formatInboxSkipLog({
+      sender: "sender-a",
+      reason: "self",
+      taskId: "task_no_content",
+      messageType: "task",
+    });
+    expect(line).not.toContain("secret payload");
+  });
+});

--- a/agent-node/src/inbox-skip-log.ts
+++ b/agent-node/src/inbox-skip-log.ts
@@ -1,0 +1,16 @@
+const REASON_DETAILS: Record<string, string> = {
+  self: "sender alias equals node alias; reply-loop guard",
+  "own-prefix": "message carries this node's own reply prefix; reply-loop guard",
+  cooldown: "sender cooldown is active",
+  "low-value-inbound": "non-task message matched the low-value filter",
+};
+
+export function formatInboxSkipLog(input: {
+  sender: string;
+  reason: string;
+  taskId: string;
+  messageType: string;
+}): string {
+  const detail = REASON_DETAILS[input.reason] || "inbound filter rejected the message";
+  return `skipped inbound ${input.messageType} ${input.taskId} from ${input.sender}: ${input.reason} (${detail}); acknowledged without model delivery`;
+}

--- a/docs/tests/report-test612-visible-inbox-skip.txt
+++ b/docs/tests/report-test612-visible-inbox-skip.txt
@@ -1,0 +1,26 @@
+# Test 612 — Visible inbox skip diagnostics
+
+Date: 2026-08-09
+
+## Provenance
+
+- Source commit: `9c3708d87bae23b55cfb280f63031b3f24bfea0b`
+- Docker image: `anet-test612:dev`
+- Image ID: `sha256:ded0f9ae44e953498a983105e202c95a254be177832d1b25ae63779acb0b9020`
+- Embedded `TEST612_SOURCE_COMMIT`: `9c3708d87bae23b55cfb280f63031b3f24bfea0b`
+- Runner artifact SHA-256: `dbecf534b2734d75bf5d5f60c2a0c13dbc90de9a1b0aad84e0ad92f58f7c60f0`
+
+## Result
+
+`RESULT: PASS`
+
+1. Formatter and source wiring passed: 4 tests, 19 assertions.
+2. The complete `agent-node` production bundle built successfully.
+3. Self, own-prefix, cooldown, and low-value skip diagnostics identify sender, reason, complete task ID, routing-layer disposition, and acknowledgement without accepting message content.
+4. Witnessed-red mutation: downgrading the call from `log` to `debug` made the INFO-level wiring contract fail with `rc=1`.
+5. Witnessed-red mutation: truncating the task ID to eight characters made the formatter contract fail with `rc=1`.
+6. Restoring the source returned all tests to green.
+
+## Scope
+
+Observability only. Inbox filtering, acknowledgement, model delivery, persistence, Hub behavior, and production processes are unchanged.

--- a/tests/test612-visible-inbox-skip/Dockerfile
+++ b/tests/test612-visible-inbox-skip/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+
+COPY agent-node ./agent-node
+COPY tests/test612-visible-inbox-skip ./tests/test612-visible-inbox-skip
+
+ARG SOURCE_COMMIT
+ENV TEST612_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test612-visible-inbox-skip/run.sh
+ENTRYPOINT ["/workspace/tests/test612-visible-inbox-skip/run.sh"]

--- a/tests/test612-visible-inbox-skip/run.sh
+++ b/tests/test612-visible-inbox-skip/run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test612-visible-inbox-skip.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test612 — visible inbox skip diagnostics"
+echo "source_commit=${TEST612_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_tests() {
+  bun test \
+    agent-node/src/inbox-skip-log.test.ts \
+    agent-node/src/inbox-skip-log-wiring.test.ts
+}
+
+echo "L0 formatter and source wiring"
+run_tests
+
+echo "L1 full agent-node build"
+cd /workspace/agent-node
+bun run build
+cd /workspace
+test -s agent-node/dist/cli.js
+
+echo "L2 witnessed-red: INFO is downgraded to DEBUG"
+cp agent-node/src/cli.ts /tmp/test612-cli.ts
+sed -i 's/log(formatInboxSkipLog({/debug(formatInboxSkipLog({/' agent-node/src/cli.ts
+grep -Fq 'debug(formatInboxSkipLog({' agent-node/src/cli.ts
+set +e
+bun test agent-node/src/inbox-skip-log-wiring.test.ts >/tmp/test612-level.log 2>&1
+level_rc=$?
+set -e
+if [ "$level_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: skip-info-level"
+  exit 1
+fi
+grep -Fq 'toContain' /tmp/test612-level.log
+echo "MUTATION_RED: skip-info-level rc=$level_rc"
+cp /tmp/test612-cli.ts agent-node/src/cli.ts
+
+echo "L3 witnessed-red: task identity is truncated"
+cp agent-node/src/inbox-skip-log.ts /tmp/test612-log.ts
+sed -i 's/${input.taskId}/${input.taskId.slice(0, 8)}/' agent-node/src/inbox-skip-log.ts
+grep -Fq '${input.taskId.slice(0, 8)}' agent-node/src/inbox-skip-log.ts
+set +e
+bun test agent-node/src/inbox-skip-log.test.ts >/tmp/test612-task-id.log 2>&1
+task_id_rc=$?
+set -e
+if [ "$task_id_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: full-task-id"
+  exit 1
+fi
+grep -Fq 'toContain' /tmp/test612-task-id.log
+echo "MUTATION_RED: full-task-id rc=$task_id_rc"
+cp /tmp/test612-log.ts agent-node/src/inbox-skip-log.ts
+
+echo "L4 restored green"
+run_tests
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Fixes #522.

## What changed

- raises inbox-filter skip diagnostics from DEBUG to INFO
- includes sender, filter reason, full task ID, and the acknowledgement/no-model disposition
- keeps message content out of the new formatter
- keeps filtering and acknowledgement semantics unchanged

## Verification

- exact source commit: `9c3708d87bae23b55cfb280f63031b3f24bfea0b`
- formatter/wiring: 4 tests / 19 assertions
- complete agent-node production bundle: PASS
- INFO→DEBUG mutation: witnessed red
- full task ID→truncated ID mutation: witnessed red

This is observability-only; no Hub, inbox, model-delivery, persistence, or production state is changed.
