### PR TITLE
fix(runtime): explain dead codex app-server endpoints

### DIFF
--- a/agent-node/src/runtime/codex-app-server-client.test.ts
+++ b/agent-node/src/runtime/codex-app-server-client.test.ts
@@ -249,12 +249,57 @@ describe("CodexAppServerClient — dead shared endpoint diagnostics (#455)", () 
     expect(err.message).not.toContain("secret-value");
   });
 
-  test("real dead loopback endpoint rejects and emits a non-empty actionable error", async () => {
+  test("scrubs nested causes and bearer credentials independently of runtime shape", () => {
+    const inner = new Error(
+      "dial ws://user:pass@127.0.0.1:4500/rpc?token=nested-secret failed; Bearer header-secret",
+    );
+    const outer = new Error("transport failed", { cause: inner });
+    const err = codexAppServerConnectionError(
+      "ws://127.0.0.1:4500/rpc?token=config-secret",
+      outer,
+      ["header-secret"],
+    );
+    expect(err.message).toContain("transport failed");
+    expect(err.message).toContain("ws://127.0.0.1:4500/rpc");
+    for (const leaked of ["nested-secret", "config-secret", "header-secret", "user:pass"]) {
+      expect(err.message).not.toContain(leaked);
+    }
+  });
+
+  test("synchronous WebSocket constructor failure uses the same safe boundary", async () => {
+    const rawUrl = "ws://127.0.0.1:4500/rpc?token=sync-secret";
+    class ThrowingWebSocket {
+      constructor(url: string) {
+        throw new Error(`invalid websocket URL ${url}`);
+      }
+    }
+    const client = new CodexAppServerClient({
+      url: rawUrl,
+      authToken: "header-sync-secret",
+      webSocketCtor: ThrowingWebSocket,
+    });
+    let caught: Error | undefined;
+    try {
+      await client.connect();
+    } catch (error) {
+      caught = error as Error;
+    }
+    expect(caught?.message).toContain("Cannot connect to codex app-server");
+    expect(caught?.message).not.toContain("sync-secret");
+    expect(caught?.message).not.toContain("header-sync-secret");
+  });
+
+  test("real dead loopback with query credential rejects/emits without leaking it", async () => {
     const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
     const port = listener.port;
     listener.stop(true);
 
-    const client = new CodexAppServerClient({ url: `ws://127.0.0.1:${port}` });
+    const querySecret = "real-dead-query-secret";
+    const headerSecret = "real-dead-header-secret";
+    const client = new CodexAppServerClient({
+      url: `ws://127.0.0.1:${port}/rpc?token=${querySecret}`,
+      authToken: headerSecret,
+    });
     const emitted: Error[] = [];
     client.on("error", (error) => emitted.push(error as Error));
 
@@ -263,6 +308,10 @@ describe("CodexAppServerClient — dead shared endpoint diagnostics (#455)", () 
     expect(emitted[0].message).toContain(`ws://127.0.0.1:${port}`);
     expect(emitted[0].message).toContain("is it running?");
     expect(emitted[0].message.trim().length).toBeGreaterThan(40);
+    for (const error of emitted) {
+      expect(error.message).not.toContain(querySecret);
+      expect(error.message).not.toContain(headerSecret);
+    }
   });
 });
 

--- a/agent-node/src/runtime/codex-app-server-client.test.ts
+++ b/agent-node/src/runtime/codex-app-server-client.test.ts
@@ -9,7 +9,10 @@
 // not spawn a real `codex app-server` here — that lives in the docker smoke.
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { CodexAppServerClient } from "./codex-app-server-client";
+import {
+  CodexAppServerClient,
+  codexAppServerConnectionError,
+} from "./codex-app-server-client";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Fake WebSocket server on loopback. Small helper to avoid pulling in `ws`.
@@ -231,6 +234,35 @@ describe("CodexAppServerClient — dispatch correctness (RFC-030 §7 + bug fix)"
     expect(parsed.error.code).toBe(-32000);
     expect(parsed.error.message).toBe("not permitted");
     expect(parsed.error.data.hint).toBe("no perms");
+  });
+});
+
+describe("CodexAppServerClient — dead shared endpoint diagnostics (#455)", () => {
+  test("wraps an empty TypeError with endpoint and remediation", () => {
+    const err = codexAppServerConnectionError(
+      "ws://127.0.0.1:4500/rpc?token=secret-value",
+      new TypeError(),
+    );
+    expect(err.message).toContain("Cannot connect to codex app-server at ws://127.0.0.1:4500/rpc");
+    expect(err.message).toContain("is it running?");
+    expect(err.message).toContain("TypeError");
+    expect(err.message).not.toContain("secret-value");
+  });
+
+  test("real dead loopback endpoint rejects and emits a non-empty actionable error", async () => {
+    const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+    const port = listener.port;
+    listener.stop(true);
+
+    const client = new CodexAppServerClient({ url: `ws://127.0.0.1:${port}` });
+    const emitted: Error[] = [];
+    client.on("error", (error) => emitted.push(error as Error));
+
+    await expect(client.connect()).rejects.toThrow("Cannot connect to codex app-server");
+    expect(emitted.length).toBeGreaterThan(0);
+    expect(emitted[0].message).toContain(`ws://127.0.0.1:${port}`);
+    expect(emitted[0].message).toContain("is it running?");
+    expect(emitted[0].message.trim().length).toBeGreaterThan(40);
   });
 });
 

--- a/agent-node/src/runtime/codex-app-server-client.ts
+++ b/agent-node/src/runtime/codex-app-server-client.ts
@@ -107,6 +107,8 @@ export interface CodexAppServerClientOptions {
   defaultTimeoutMs?: number;
   /** Debug label for logs / errors. */
   clientLabel?: string;
+  /** @internal Deterministic constructor seam for transport failure tests. */
+  webSocketCtor?: any;
 }
 
 function safeWebSocketEndpoint(rawUrl: string): string {
@@ -125,23 +127,54 @@ function safeWebSocketEndpoint(rawUrl: string): string {
   }
 }
 
-function errorDetail(cause: unknown): string {
+function scrubTransportDetail(
+  detail: string,
+  rawUrl: string,
+  secrets: readonly string[],
+): string {
+  let safe = detail.replace(/[\r\n\t]+/g, " ");
+  const replacements = [rawUrl, ...secrets].filter(Boolean);
+  for (const secret of replacements) safe = safe.split(secret).join("[redacted]");
+  // Runtime error shapes vary. Sanitize every URL independently rather than
+  // assuming the configured URL is the only one the implementation echoes.
+  safe = safe.replace(/\b(?:wss?|https?):\/\/[^\s)'"<>]+/gi, (candidate) =>
+    safeWebSocketEndpoint(candidate),
+  );
+  safe = safe.replace(/\bBearer\s+[A-Za-z0-9._~+\/-]+/gi, "Bearer [redacted]");
+  return safe.trim().slice(0, 500);
+}
+
+function errorDetail(cause: unknown, rawUrl: string, secrets: readonly string[]): string {
   if (cause instanceof Error) {
-    const own = cause.message.trim() || cause.name.trim();
-    const nested = errorDetail((cause as Error & { cause?: unknown }).cause);
+    const own = scrubTransportDetail(
+      cause.message.trim() || cause.name.trim(),
+      rawUrl,
+      secrets,
+    );
+    const nested = errorDetail(
+      (cause as Error & { cause?: unknown }).cause,
+      rawUrl,
+      secrets,
+    );
     if (nested && nested !== own && nested !== "WebSocket connection failed") {
       return own ? `${own}: ${nested}` : nested;
     }
     return own || "WebSocket connection failed";
   }
-  if (typeof cause === "string" && cause.trim()) return cause.trim();
+  if (typeof cause === "string" && cause.trim()) {
+    return scrubTransportDetail(cause, rawUrl, secrets);
+  }
   return "WebSocket connection failed";
 }
 
 /** Actionable, non-empty and credential-safe transport failure for operators. */
-export function codexAppServerConnectionError(url: string, cause: unknown): Error {
+export function codexAppServerConnectionError(
+  url: string,
+  cause: unknown,
+  secrets: readonly string[] = [],
+): Error {
   return new Error(
-    `Cannot connect to codex app-server at ${safeWebSocketEndpoint(url)} — is it running? (${errorDetail(cause)})`,
+    `Cannot connect to codex app-server at ${safeWebSocketEndpoint(url)} — is it running? (${errorDetail(cause, url, secrets)})`,
   );
 }
 
@@ -198,10 +231,24 @@ export class CodexAppServerClient extends EventEmitter {
     // WebSocket, which accepts an options bag as the third argument. If the
     // runtime doesn't, callers should embed the token in the URL query.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const WS: any = resolveWebSocketCtor();
-    this.ws = new WS(this.opts.url, undefined, headers.Authorization ? { headers } : undefined);
-
     return new Promise<void>((resolve, reject) => {
+      try {
+        const WS: any = this.opts.webSocketCtor ?? resolveWebSocketCtor();
+        this.ws = new WS(
+          this.opts.url,
+          undefined,
+          headers.Authorization ? { headers } : undefined,
+        );
+      } catch (cause) {
+        reject(
+          codexAppServerConnectionError(
+            this.opts.url,
+            cause,
+            this.opts.authToken ? [this.opts.authToken] : [],
+          ),
+        );
+        return;
+      }
       const onOpen = () => {
         this.ws!.removeEventListener("error", onErrorInit);
         this.emit("open");
@@ -212,6 +259,7 @@ export class CodexAppServerClient extends EventEmitter {
         const err = codexAppServerConnectionError(
           this.opts.url,
           extractError(ev, `connect ${safeWebSocketEndpoint(this.opts.url)}`),
+          this.opts.authToken ? [this.opts.authToken] : [],
         );
         this.ws!.removeEventListener("open", onOpen);
         reject(err);
@@ -234,7 +282,11 @@ export class CodexAppServerClient extends EventEmitter {
       this.ws!.addEventListener("error", (ev: Event) => {
         this.emit(
           "error",
-          codexAppServerConnectionError(this.opts.url, extractError(ev, "ws steady-state")),
+          codexAppServerConnectionError(
+            this.opts.url,
+            extractError(ev, "ws steady-state"),
+            this.opts.authToken ? [this.opts.authToken] : [],
+          ),
         );
       });
     });

--- a/agent-node/src/runtime/codex-app-server-client.ts
+++ b/agent-node/src/runtime/codex-app-server-client.ts
@@ -109,6 +109,42 @@ export interface CodexAppServerClientOptions {
   clientLabel?: string;
 }
 
+function safeWebSocketEndpoint(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    // Do not echo a malformed URL verbatim: it may still contain a query
+    // token. The scheme is enough to tell the operator which config to check.
+    const scheme = rawUrl.match(/^[A-Za-z][A-Za-z0-9+.-]*:/)?.[0] ?? "WebSocket";
+    return `${scheme}<invalid endpoint>`;
+  }
+}
+
+function errorDetail(cause: unknown): string {
+  if (cause instanceof Error) {
+    const own = cause.message.trim() || cause.name.trim();
+    const nested = errorDetail((cause as Error & { cause?: unknown }).cause);
+    if (nested && nested !== own && nested !== "WebSocket connection failed") {
+      return own ? `${own}: ${nested}` : nested;
+    }
+    return own || "WebSocket connection failed";
+  }
+  if (typeof cause === "string" && cause.trim()) return cause.trim();
+  return "WebSocket connection failed";
+}
+
+/** Actionable, non-empty and credential-safe transport failure for operators. */
+export function codexAppServerConnectionError(url: string, cause: unknown): Error {
+  return new Error(
+    `Cannot connect to codex app-server at ${safeWebSocketEndpoint(url)} — is it running? (${errorDetail(cause)})`,
+  );
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Client
 // ────────────────────────────────────────────────────────────────────────────
@@ -173,7 +209,10 @@ export class CodexAppServerClient extends EventEmitter {
       };
       const onErrorInit = (ev: Event) => {
         // Extract a useful message from the DOM event when possible.
-        const err = extractError(ev, `connect ${this.opts.url}`);
+        const err = codexAppServerConnectionError(
+          this.opts.url,
+          extractError(ev, `connect ${safeWebSocketEndpoint(this.opts.url)}`),
+        );
         this.ws!.removeEventListener("open", onOpen);
         reject(err);
       };
@@ -193,7 +232,10 @@ export class CodexAppServerClient extends EventEmitter {
         this.pending.clear();
       });
       this.ws!.addEventListener("error", (ev: Event) => {
-        this.emit("error", extractError(ev, "ws steady-state"));
+        this.emit(
+          "error",
+          codexAppServerConnectionError(this.opts.url, extractError(ev, "ws steady-state")),
+        );
       });
     });
   }

--- a/docs/tests/report-test613-codex-dead-endpoint.txt
+++ b/docs/tests/report-test613-codex-dead-endpoint.txt
@@ -1,26 +1,30 @@
 # test613 — codex app-server dead endpoint diagnostics
 
 Date: 2026-08-09
-Source commit: b40730981c6333ad66021cb2bcaa27da6162a66e
+Source commit: 7d40e14e0fc73a67f3d746903c27c48b2b9488d4
 Base commit: a8a9497b
 Docker image: anet-test613:dev
-Image ID: sha256:acade7a6eab396e3eafdbd719e273829deb5bc3abe71d5f8787dfeef1365481a
-Embedded ENV: TEST613_SOURCE_COMMIT=b40730981c6333ad66021cb2bcaa27da6162a66e
+Image ID: sha256:56455012c1c5a85d83e1ac4bc0e55e38bf310c24e984b377a330d783a0e2a3cf
+Embedded ENV: TEST613_SOURCE_COMMIT=7d40e14e0fc73a67f3d746903c27c48b2b9488d4
 
 ## Result
 
 PASS
 
-- L0: `codex-app-server-client.test.ts` — 14 pass, 0 fail, 38 assertions.
+- L0: `codex-app-server-client.test.ts` — 16 pass, 0 fail, 49 assertions.
 - L0 real transport: a loopback listener was allocated, closed, and then used
-  as the client endpoint. Both the rejected `connect()` promise and emitted
-  client error contained the endpoint plus `is it running?` remediation.
-- L0 privacy: query-string credential material was absent from the formatted
-  endpoint while the path remained available for diagnosis.
+  as a query-bearing client endpoint. Both the rejected `connect()` promise
+  and emitted client error contained the safe endpoint plus `is it running?`
+  remediation; neither exposed the query token or bearer token.
+- L0 privacy: nested causes, runtime-returned URLs, URL userinfo, bearer text,
+  explicit secrets, and synchronous WebSocket-constructor failures all pass
+  through the same bounded credential scrub. The path remains diagnostic.
 - L1: production `agent-node` bundle completed (253 modules).
 - L2 witnessed-red: replacing the production formatter with the raw underlying
   `Error` made the exact dead-loopback diagnostic test fail (`rc=1`).
-- L3: restoring the implementation returned the same 14 tests to green.
+- L3 witnessed-red: bypassing transport-detail scrubbing made the nested-cause
+  credential test fail (`rc=1`).
+- L4: restoring the implementation returned the same 16 tests to green.
 
 The fix is transport-boundary only. It does not change connection, retry,
 thread, task, or reply semantics.

--- a/docs/tests/report-test613-codex-dead-endpoint.txt
+++ b/docs/tests/report-test613-codex-dead-endpoint.txt
@@ -1,0 +1,26 @@
+# test613 — codex app-server dead endpoint diagnostics
+
+Date: 2026-08-09
+Source commit: b40730981c6333ad66021cb2bcaa27da6162a66e
+Base commit: a8a9497b
+Docker image: anet-test613:dev
+Image ID: sha256:acade7a6eab396e3eafdbd719e273829deb5bc3abe71d5f8787dfeef1365481a
+Embedded ENV: TEST613_SOURCE_COMMIT=b40730981c6333ad66021cb2bcaa27da6162a66e
+
+## Result
+
+PASS
+
+- L0: `codex-app-server-client.test.ts` — 14 pass, 0 fail, 38 assertions.
+- L0 real transport: a loopback listener was allocated, closed, and then used
+  as the client endpoint. Both the rejected `connect()` promise and emitted
+  client error contained the endpoint plus `is it running?` remediation.
+- L0 privacy: query-string credential material was absent from the formatted
+  endpoint while the path remained available for diagnosis.
+- L1: production `agent-node` bundle completed (253 modules).
+- L2 witnessed-red: replacing the production formatter with the raw underlying
+  `Error` made the exact dead-loopback diagnostic test fail (`rc=1`).
+- L3: restoring the implementation returned the same 14 tests to green.
+
+The fix is transport-boundary only. It does not change connection, retry,
+thread, task, or reply semantics.

--- a/tests/test613-codex-dead-endpoint/Dockerfile
+++ b/tests/test613-codex-dead-endpoint/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+
+COPY agent-node ./agent-node
+COPY tests/test613-codex-dead-endpoint ./tests/test613-codex-dead-endpoint
+
+ARG SOURCE_COMMIT
+ENV TEST613_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test613-codex-dead-endpoint/run.sh
+ENTRYPOINT ["/workspace/tests/test613-codex-dead-endpoint/run.sh"]

--- a/tests/test613-codex-dead-endpoint/run.sh
+++ b/tests/test613-codex-dead-endpoint/run.sh
@@ -26,11 +26,11 @@ cd ..
 
 echo "L2 witnessed-red: remove the actionable connection wrapper"
 cp agent-node/src/runtime/codex-app-server-client.ts /tmp/test613-client.ts
-sed -i 's/codexAppServerConnectionError(this.opts.url, extractError(ev, "ws steady-state"))/extractError(ev, "ws steady-state")/' \
+sed -i '/^export function codexAppServerConnectionError/,/^}/c\export function codexAppServerConnectionError(_url: string, cause: unknown): Error {\
+  return cause instanceof Error ? cause : new Error(String(cause));\
+}' \
   agent-node/src/runtime/codex-app-server-client.ts
-sed -i '/const err = codexAppServerConnectionError(/,/        );/c\        const err = extractError(ev, `connect ${this.opts.url}`);' \
-  agent-node/src/runtime/codex-app-server-client.ts
-grep -Fq 'const err = extractError(ev, `connect ${this.opts.url}`);' \
+grep -Fq 'return cause instanceof Error ? cause : new Error(String(cause));' \
   agent-node/src/runtime/codex-app-server-client.ts
 set +e
 bun test agent-node/src/runtime/codex-app-server-client.test.ts \
@@ -42,7 +42,8 @@ if [ "$mutation_rc" -eq 0 ]; then
   echo "MUTATION_FALSE_GREEN: dead-endpoint-wrapper"
   exit 1
 fi
-grep -Fq 'toContain' /tmp/test613-mutation.log
+grep -Fq 'real dead loopback endpoint rejects and emits a non-empty actionable error' \
+  /tmp/test613-mutation.log
 echo "MUTATION_RED: dead-endpoint-wrapper rc=$mutation_rc"
 cp /tmp/test613-client.ts agent-node/src/runtime/codex-app-server-client.ts
 

--- a/tests/test613-codex-dead-endpoint/run.sh
+++ b/tests/test613-codex-dead-endpoint/run.sh
@@ -34,7 +34,7 @@ grep -Fq 'return cause instanceof Error ? cause : new Error(String(cause));' \
   agent-node/src/runtime/codex-app-server-client.ts
 set +e
 bun test agent-node/src/runtime/codex-app-server-client.test.ts \
-  -t "real dead loopback endpoint rejects and emits a non-empty actionable error" \
+  -t "real dead loopback with query credential rejects/emits without leaking it" \
   >/tmp/test613-mutation.log 2>&1
 mutation_rc=$?
 set -e
@@ -42,12 +42,32 @@ if [ "$mutation_rc" -eq 0 ]; then
   echo "MUTATION_FALSE_GREEN: dead-endpoint-wrapper"
   exit 1
 fi
-grep -Fq 'real dead loopback endpoint rejects and emits a non-empty actionable error' \
+grep -Fq 'real dead loopback with query credential rejects/emits without leaking it' \
   /tmp/test613-mutation.log
 echo "MUTATION_RED: dead-endpoint-wrapper rc=$mutation_rc"
 cp /tmp/test613-client.ts agent-node/src/runtime/codex-app-server-client.ts
 
-echo "L3 restored green"
+echo "L3 witnessed-red: bypass transport-detail credential scrub"
+sed -i '/^function scrubTransportDetail(/,/^}/c\function scrubTransportDetail(detail: string, _rawUrl: string, _secrets: readonly string[]): string {\
+  return detail;\
+}' agent-node/src/runtime/codex-app-server-client.ts
+grep -Fq 'return detail;' agent-node/src/runtime/codex-app-server-client.ts
+set +e
+bun test agent-node/src/runtime/codex-app-server-client.test.ts \
+  -t "scrubs nested causes and bearer credentials independently of runtime shape" \
+  >/tmp/test613-scrub-mutation.log 2>&1
+scrub_rc=$?
+set -e
+if [ "$scrub_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: transport-detail-scrub"
+  exit 1
+fi
+grep -Fq 'scrubs nested causes and bearer credentials independently of runtime shape' \
+  /tmp/test613-scrub-mutation.log
+echo "MUTATION_RED: transport-detail-scrub rc=$scrub_rc"
+cp /tmp/test613-client.ts agent-node/src/runtime/codex-app-server-client.ts
+
+echo "L4 restored green"
 run_test
 
 echo "RESULT: PASS"

--- a/tests/test613-codex-dead-endpoint/run.sh
+++ b/tests/test613-codex-dead-endpoint/run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test613-codex-dead-endpoint.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+cd /workspace
+echo "# test613 — codex app-server dead endpoint diagnostics"
+echo "source_commit=${TEST613_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_test() {
+  bun test agent-node/src/runtime/codex-app-server-client.test.ts
+}
+
+echo "L0 client unit + real dead-loopback behavior"
+run_test
+
+echo "L1 production bundle"
+cd agent-node
+bun run build
+cd ..
+
+echo "L2 witnessed-red: remove the actionable connection wrapper"
+cp agent-node/src/runtime/codex-app-server-client.ts /tmp/test613-client.ts
+sed -i 's/codexAppServerConnectionError(this.opts.url, extractError(ev, "ws steady-state"))/extractError(ev, "ws steady-state")/' \
+  agent-node/src/runtime/codex-app-server-client.ts
+sed -i '/const err = codexAppServerConnectionError(/,/        );/c\        const err = extractError(ev, `connect ${this.opts.url}`);' \
+  agent-node/src/runtime/codex-app-server-client.ts
+grep -Fq 'const err = extractError(ev, `connect ${this.opts.url}`);' \
+  agent-node/src/runtime/codex-app-server-client.ts
+set +e
+bun test agent-node/src/runtime/codex-app-server-client.test.ts \
+  -t "real dead loopback endpoint rejects and emits a non-empty actionable error" \
+  >/tmp/test613-mutation.log 2>&1
+mutation_rc=$?
+set -e
+if [ "$mutation_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: dead-endpoint-wrapper"
+  exit 1
+fi
+grep -Fq 'toContain' /tmp/test613-mutation.log
+echo "MUTATION_RED: dead-endpoint-wrapper rc=$mutation_rc"
+cp /tmp/test613-client.ts agent-node/src/runtime/codex-app-server-client.ts
+
+echo "L3 restored green"
+run_test
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- wrap codex app-server WebSocket failures with the configured endpoint and an actionable `is it running?` hint
- guarantee a non-empty task failure even when the transport emits an empty `TypeError`
- redact URL credentials, query parameters, and fragments from diagnostics
- add real dead-loopback coverage plus a deletion mutation gate

## Root cause

The WebSocket client returned the transport's raw `Error`. On Windows that can be an empty `TypeError`, so the client warning was only `TypeError` and `processTask` produced `codex-app-server 错误: ` with no reason.

## Validation

Exact-source Docker test613 at `b40730981c6333ad66021cb2bcaa27da6162a66e`:

- 14 tests, 38 assertions
- real closed loopback socket behavior
- production agent-node bundle (253 modules)
- formatter deletion mutation turns the targeted test red
- restored implementation returns green

Closes #455.
