### PR TITLE
fix(server): resolve sole admin network for REST tasks

### DIFF
--- a/docs/tests/report-test614-rest-single-network.txt
+++ b/docs/tests/report-test614-rest-single-network.txt
@@ -1,0 +1,28 @@
+# test614 — REST single-network task resolution
+
+Date: 2026-08-09
+Source commit: 58748178d0e2abefe6e656e3a8339df51bbee5f6
+Base commit: bdb722c2248a6dbcace724f6ee365e584d1e0b93
+Docker image: anet-test614:dev
+Image ID: sha256:7bdbc4c78e7886afc8640e278992e16cf2ba0d42398c3ad428748fc4b58f3e3b
+Embedded ENV: TEST614_SOURCE_COMMIT=58748178d0e2abefe6e656e3a8339df51bbee5f6
+Raw runner report SHA256: `463fb3a03d169d76fd951fd1457e9fd257aecc9fa048cf8bdc3496c9a850f52e`
+
+## Result
+
+PASS
+
+- L0: real `bootServer()` HTTP matrix — 5 pass, 0 fail, 13 assertions.
+- A system admin with exactly one real network membership omitted
+  `network_id`; the task was accepted and persisted in that network.
+- The existing ordinary single-network user fallback remained green.
+- Admins with zero or multiple memberships received HTTP 400 with the stable
+  `network_id_required` code and factually accurate message.
+- A multi-network admin could still select an explicit network.
+- L1: production Hub bundle completed (257 modules).
+- L2 witnessed-red: deleting only the admin single-membership fallback made
+  its exact HTTP behavior test fail (`rc=1`).
+- L3: restoring the production implementation returned all five tests green.
+
+Read scoping remains unchanged: admins still retain intentional global read
+scope. Only unambiguous REST write-target resolution changes.

--- a/server/src/network-scope.ts
+++ b/server/src/network-scope.ts
@@ -72,6 +72,26 @@ export function singleNetworkId(scope: RestNetworkScope): string | null {
   return null;
 }
 
+/**
+ * Resolve one unambiguous network for a REST write.
+ *
+ * Admin read scope is intentionally global (`networkIds=null`), so it cannot
+ * by itself express that an admin happens to have exactly one membership.
+ * Writes must not inherit that ambiguity: use the sole real membership when
+ * one exists, and keep requiring an explicit network for zero or 2+.
+ */
+export function resolveRestWriteNetworkId(
+  scope: RestNetworkScope,
+  authCtx: { userId: string; networkId: string | null } | null,
+  isAdmin: boolean,
+): string | null {
+  const scoped = singleNetworkId(scope);
+  if (scoped) return scoped;
+  if (!authCtx || !isAdmin) return null;
+  const memberships = getUserNetworkIds(authCtx.userId);
+  return memberships.length === 1 ? memberships[0] : null;
+}
+
 export function canRestWriteNetwork(authCtx: { userId: string; networkId: string | null } | null, networkId: string | null, isAdmin: boolean): boolean {
   if (!authCtx) return true; // legacy global token or open dev mode
   if (isAdmin) return true;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,7 +5,7 @@ import { registerTools } from "./tools.js";
 import { db, logTaskEvent, logAudit } from "./db.js";
 import { createSSEStream, createNetworkObserverStream, pushEvent, pushNetworkObserverEvent, getSSEStats, PRINTABLE_OBSERVER_KEY_PREFIX } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
-import { addNetworkScope, canRestWriteNetwork, getUserNetworkIds, resolveRestNetworkScope, singleNetworkId, type RestNetworkScope } from "./network-scope.js";
+import { addNetworkScope, canRestWriteNetwork, getUserNetworkIds, resolveRestNetworkScope, resolveRestWriteNetworkId, singleNetworkId, type RestNetworkScope } from "./network-scope.js";
 import { validateAvatarUrl } from "./avatar-validate.js";
 import { narrowTags, parseStoredTags, validateScalarAttr } from "./node-attrs-validate.js";
 import { register, login, resolveToken, getUserNetworks, getUserAllNetworks, createNetwork, deleteNetwork, renameNetwork, changePassword, issueUserToken, listTokens, createToken, revokeToken, getNetworkMembers, getUserNetworkRole, addNetworkMember, updateMemberRole, removeNetworkMember, createInvite, joinByInvite, createNetworkTokenForNode, type AuthUser } from "./auth.js";
@@ -2121,10 +2121,16 @@ return Bun.serve({
         }
         taskNetId = body.network_id;
       } else {
-        taskNetId = restAuth ? singleNetworkId(restScope) : null;
+        taskNetId = restAuth
+          ? resolveRestWriteNetworkId(restScope, restAuth, isAdmin)
+          : null;
       }
       if (restAuth && !taskNetId) {
-        return withCors(req, Response.json({ ok: false, error: "network_id required for user token when multiple networks are available" }, { status: 400 }));
+        return withCors(req, Response.json({
+          ok: false,
+          error: "network_id_required",
+          message: "network_id is required when the user token has zero or multiple network memberships",
+        }, { status: 400 }));
       }
       if (!canRestWriteNetwork(restAuth, taskNetId, isAdmin)) {
         return withCors(req, Response.json({ ok: false, error: "permission_denied" }, { status: 403 }));

--- a/server/src/task-network-resolution-http.test.ts
+++ b/server/src/task-network-resolution-http.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { register } from "./auth.js";
+import { db } from "./db.js";
+
+const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-task-network-resolution-"));
+let server: any;
+let base = "";
+
+type Principal = { token: string; userId: string; networkId: string; target: string };
+let adminSingle: Principal;
+let userSingle: Principal;
+let adminMulti: Principal;
+let adminZero: Principal;
+
+function registerPrincipal(label: string, admin: boolean): Principal {
+  const username = `task_net_${label}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  const registered = register(username, "TaskNetwork123!", undefined, "seed");
+  expect(registered.ok).toBe(true);
+  const userId = db.get<{ user_id: string }>(
+    "SELECT user_id FROM users WHERE username = ?1",
+    [username],
+  )!.user_id;
+  if (admin) db.run("UPDATE users SET role = 'admin' WHERE user_id = ?1", [userId]);
+  return {
+    token: registered.token!,
+    userId,
+    networkId: registered.network_id!,
+    target: `task-net-${label}-${process.pid}`,
+  };
+}
+
+function seedTarget(principal: Principal): void {
+  const nodeId = `node_${principal.target}`;
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+     VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))`,
+    [`resume_${principal.target}`, principal.target, nodeId, principal.networkId],
+  );
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, network_id, created_at, updated_at, lifecycle_state)
+     VALUES (?1, ?2, ?2, ?3, datetime('now'), datetime('now'), 'active')`,
+    [nodeId, principal.target, principal.networkId],
+  );
+}
+
+beforeAll(async () => {
+  process.env.COMMHUB_DB = process.env.COMMHUB_DB || join(PRIVATE_DB_DIR, "hub.db");
+  adminSingle = registerPrincipal("admin_single", true);
+  userSingle = registerPrincipal("user_single", false);
+  adminMulti = registerPrincipal("admin_multi", true);
+  adminZero = registerPrincipal("admin_zero", true);
+  seedTarget(adminSingle);
+  seedTarget(userSingle);
+  seedTarget(adminMulti);
+
+  const secondNetwork = `net_task_second_${process.pid}`;
+  db.run(
+    "INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, 'second', ?2, datetime('now'))",
+    [secondNetwork, adminMulti.userId],
+  );
+  db.run(
+    "INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))",
+    [adminMulti.userId, secondNetwork],
+  );
+  db.run("DELETE FROM network_members WHERE user_id = ?1", [adminZero.userId]);
+
+  const mod: any = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop?.(true); } catch {}
+  try { rmSync(PRIVATE_DB_DIR, { recursive: true, force: true }); } catch {}
+});
+
+async function post(principal: Principal, marker: string, networkId?: string) {
+  const response = await fetch(`${base}/api/task`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${principal.token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      alias: principal.target,
+      from: "api",
+      task: marker,
+      priority: "high",
+      ...(networkId ? { network_id: networkId } : {}),
+    }),
+  });
+  return { response, body: await response.json() as any };
+}
+
+describe("POST /api/task single-network resolution (#448)", () => {
+  test("admin with exactly one membership may omit network_id", async () => {
+    const marker = `x448-admin-single-${Date.now()}`;
+    const { response, body } = await post(adminSingle, marker);
+    expect([200, 202]).toContain(response.status);
+    expect(body.ok).toBe(true);
+    expect(db.get<{ network_id: string }>("SELECT network_id FROM tasks WHERE content = ?1", [marker])?.network_id)
+      .toBe(adminSingle.networkId);
+  });
+
+  test("ordinary single-network user behavior remains unchanged", async () => {
+    const marker = `x448-user-single-${Date.now()}`;
+    const { response, body } = await post(userSingle, marker);
+    expect([200, 202]).toContain(response.status);
+    expect(body.ok).toBe(true);
+    expect(db.get<{ network_id: string }>("SELECT network_id FROM tasks WHERE content = ?1", [marker])?.network_id)
+      .toBe(userSingle.networkId);
+  });
+
+  test("multi-network admin must select a network explicitly", async () => {
+    const { response, body } = await post(adminMulti, `x448-admin-multi-${Date.now()}`);
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      ok: false,
+      error: "network_id_required",
+      message: "network_id is required when the user token has zero or multiple network memberships",
+    });
+  });
+
+  test("zero-membership admin gets the same accurate error", async () => {
+    const { response, body } = await post(adminZero, `x448-admin-zero-${Date.now()}`);
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("network_id_required");
+    expect(body.message).toContain("zero or multiple network memberships");
+  });
+
+  test("multi-network admin can still select an explicit member network", async () => {
+    const marker = `x448-admin-explicit-${Date.now()}`;
+    const { response, body } = await post(adminMulti, marker, adminMulti.networkId);
+    expect([200, 202]).toContain(response.status);
+    expect(body.ok).toBe(true);
+  });
+});

--- a/tests/test614-rest-single-network/Dockerfile
+++ b/tests/test614-rest-single-network/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+
+COPY server ./server
+COPY tests/test614-rest-single-network ./tests/test614-rest-single-network
+
+ARG SOURCE_COMMIT
+ENV TEST614_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test614-rest-single-network/run.sh
+ENTRYPOINT ["/workspace/tests/test614-rest-single-network/run.sh"]

--- a/tests/test614-rest-single-network/run.sh
+++ b/tests/test614-rest-single-network/run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test614-rest-single-network.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+cd /workspace
+export COMMHUB_DB=/tmp/test614-hub.db
+export COMMHUB_AUTH_TOKEN=test614-master-token
+
+echo "# test614 — REST single-network task resolution"
+echo "source_commit=${TEST614_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_test() {
+  local test_dir
+  test_dir=$(mktemp -d)
+  COMMHUB_DB="$test_dir/hub.db" bun test server/src/task-network-resolution-http.test.ts
+}
+
+echo "L0 real Hub HTTP matrix"
+run_test
+
+echo "L1 production server bundle"
+cd server
+bun build src/index.ts --outdir /tmp/test614-server-build --target bun
+cd ..
+
+echo "L2 witnessed-red: delete admin single-membership fallback"
+cp server/src/network-scope.ts /tmp/test614-network-scope.ts
+sed -i 's/return memberships.length === 1 ? memberships\[0\] : null;/return null;/' \
+  server/src/network-scope.ts
+grep -Fq 'const memberships = getUserNetworkIds(authCtx.userId);' server/src/network-scope.ts
+grep -Fq 'return null;' server/src/network-scope.ts
+set +e
+mutation_dir=$(mktemp -d)
+COMMHUB_DB="$mutation_dir/hub.db" bun test server/src/task-network-resolution-http.test.ts \
+  -t "admin with exactly one membership may omit network_id" \
+  >/tmp/test614-mutation.log 2>&1
+mutation_rc=$?
+set -e
+if [ "$mutation_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: admin-single-network-fallback"
+  exit 1
+fi
+grep -Fq 'admin with exactly one membership may omit network_id' /tmp/test614-mutation.log
+echo "MUTATION_RED: admin-single-network-fallback rc=$mutation_rc"
+cp /tmp/test614-network-scope.ts server/src/network-scope.ts
+
+echo "L3 restored green"
+run_test
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- resolve an admin user token to its sole real network membership for `POST /api/task`
- keep zero-membership and multi-network writes fail-closed unless `network_id` is explicit
- return a stable `network_id_required` code with factually accurate wording
- preserve global admin read scope and existing ordinary-user behavior

## Root cause

Admin REST read scope is intentionally global, represented as `networkIds=null`. The task write path incorrectly passed that read scope to `singleNetworkId()`, so even an admin with exactly one membership looked ambiguous.

## Validation

Exact-source Docker test614 at `6dceac79e08d482c14f2fe8eb392db267c780087`:

- real Hub HTTP matrix: 5 pass, 13 assertions
- admin single/zero/multi membership cases
- ordinary single-network user regression case
- explicit admin network selection
- production Hub bundle (257 modules)
- deletion mutation turns the admin-single behavior red

Closes #448.
