### PR TITLE
fix(server): expose REST network name alias

### DIFF
--- a/docs/tests/report-test615-network-name.txt
+++ b/docs/tests/report-test615-network-name.txt
@@ -1,0 +1,25 @@
+# test615 — GET /api/networks name compatibility
+
+Date: 2026-08-09
+Source commit: 1295913240c188541112d3038f502e1d7af26711
+Base commit: aae77dfa
+Docker image: anet-test615:dev
+Image ID: sha256:6cb2b112e276d492f03f99775e955a38594f8c06443c136fe0f2f4f60b7b30ee
+Embedded ENV: TEST615_SOURCE_COMMIT=1295913240c188541112d3038f502e1d7af26711
+Raw runner report SHA256: `325c175ce752ad0faaea1ba577047062e5bfa685e54163dd66f8eac7b8067522`
+
+## Result
+
+PASS
+
+- L0: real Hub HTTP tests — 2 pass, 0 fail, 13 assertions.
+- The user-token list path returned `name === network_name === "default"`.
+- The network-bound node-token path returned the same non-null alias.
+- The canonical `network_name` field remains present for existing clients.
+- L1: production Hub bundle completed (257 modules, 1.52 MB entry point).
+- L2 witnessed-red: forcing the compatibility `name` alias to null made the
+  exact HTTP contract tests fail (`rc=1`).
+- L3: restoring production code returned both tests green.
+
+This is an additive response-field compatibility fix; storage and write APIs
+remain unchanged.

--- a/server/src/network-name-http.test.ts
+++ b/server/src/network-name-http.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createNetworkTokenForNode, register } from "./auth.js";
+import { db } from "./db.js";
+
+const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-network-name-http-"));
+let server: any;
+let base = "";
+let userToken = "";
+let nodeToken = "";
+let networkId = "";
+
+beforeAll(async () => {
+  process.env.COMMHUB_DB = process.env.COMMHUB_DB || join(PRIVATE_DB_DIR, "hub.db");
+  const username = `network_name_${Date.now()}_${process.pid}`;
+  const registered = register(username, "NetworkName123!", undefined, "seed");
+  expect(registered.ok).toBe(true);
+  userToken = registered.token!;
+  networkId = registered.network_id!;
+  const userId = db.get<{ user_id: string }>(
+    "SELECT user_id FROM users WHERE username = ?1",
+    [username],
+  )!.user_id;
+  const minted = createNetworkTokenForNode(userId, networkId, "network-name-node");
+  expect(minted.ok).toBe(true);
+  nodeToken = minted.token!;
+  const mod: any = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop?.(true); } catch {}
+  try { rmSync(PRIVATE_DB_DIR, { recursive: true, force: true }); } catch {}
+});
+
+async function networks(token: string): Promise<any[]> {
+  const response = await fetch(`${base}/api/networks`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(response.status).toBe(200);
+  const body = await response.json() as any;
+  expect(body.ok).toBe(true);
+  return body.networks;
+}
+
+describe("GET /api/networks name compatibility (#449)", () => {
+  test("utok rows expose equal non-null name and network_name", async () => {
+    const rows = await networks(userToken);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].network_id).toBe(networkId);
+    expect(rows[0].network_name).toBe("default");
+    expect(rows[0].name).toBe("default");
+  });
+
+  test("network-bound ntok rows expose the same alias", async () => {
+    const rows = await networks(nodeToken);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].network_id).toBe(networkId);
+    expect(rows[0].network_name).toBe("default");
+    expect(rows[0].name).toBe(rows[0].network_name);
+    expect(rows[0].name).not.toBeNull();
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -517,6 +517,17 @@ function resolveRestNodeIdForAlias(alias: string, networkId: string | null): str
   return target.state === "not_found" ? null : (target.session?.node_id ?? null);
 }
 
+function withNetworkNameAlias<T extends { network_name?: unknown }>(row: T): T & { name: string | null } {
+  return {
+    ...row,
+    // `network_name` is the canonical V3 storage/API field and remains for
+    // existing CLI/Dashboard clients. `name` is the documented REST-friendly
+    // compatibility alias; never let it drift or serialize as null when the
+    // canonical NOT NULL field is present.
+    name: typeof row.network_name === "string" ? row.network_name : null,
+  };
+}
+
 // ── REST input schema ───────────────────────────────
 const TaskSchema = z.object({
   alias: z.string().min(1).max(200),
@@ -1099,9 +1110,9 @@ return Bun.serve({
       if (resolved.networkId) {
         // ntok_ — only return the bound network
         const net = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", resolved.networkId);
-        return withCors(req, Response.json({ ok: true, networks: net ? [net] : [] }));
+        return withCors(req, Response.json({ ok: true, networks: net ? [withNetworkNameAlias(net)] : [] }));
       }
-      const networks = getUserAllNetworks(resolved.user.user_id);
+      const networks = getUserAllNetworks(resolved.user.user_id).map(withNetworkNameAlias);
       return withCors(req, Response.json({ ok: true, networks }));
     }
 

--- a/tests/test615-network-name/Dockerfile
+++ b/tests/test615-network-name/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+
+COPY server ./server
+COPY tests/test615-network-name ./tests/test615-network-name
+
+ARG SOURCE_COMMIT
+ENV TEST615_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test615-network-name/run.sh
+ENTRYPOINT ["/workspace/tests/test615-network-name/run.sh"]

--- a/tests/test615-network-name/run.sh
+++ b/tests/test615-network-name/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test615-network-name.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+cd /workspace
+export COMMHUB_AUTH_TOKEN=test615-master-token
+
+echo "# test615 — GET /api/networks name compatibility"
+echo "source_commit=${TEST615_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_test() {
+  local test_dir
+  test_dir=$(mktemp -d)
+  COMMHUB_DB="$test_dir/hub.db" bun test server/src/network-name-http.test.ts
+}
+
+echo "L0 real Hub utok + ntok HTTP paths"
+run_test
+
+echo "L1 production server bundle"
+cd server
+bun build src/index.ts --outdir /tmp/test615-server-build --target bun
+cd ..
+
+echo "L2 witnessed-red: remove the REST name compatibility alias"
+cp server/src/server.ts /tmp/test615-server.ts
+sed -i 's/name: typeof row.network_name === "string" ? row.network_name : null,/name: null,/' \
+  server/src/server.ts
+grep -Fq 'name: null,' server/src/server.ts
+set +e
+mutation_dir=$(mktemp -d)
+COMMHUB_DB="$mutation_dir/hub.db" bun test server/src/network-name-http.test.ts \
+  >/tmp/test615-mutation.log 2>&1
+mutation_rc=$?
+set -e
+if [ "$mutation_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: network-name-alias"
+  exit 1
+fi
+grep -Fq 'GET /api/networks name compatibility' /tmp/test615-mutation.log
+echo "MUTATION_RED: network-name-alias rc=$mutation_rc"
+cp /tmp/test615-server.ts server/src/server.ts
+
+echo "L3 restored green"
+run_test
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- add `name` as a non-null compatibility alias of canonical `network_name` in `GET /api/networks`
- cover both user-token and network-bound node-token response paths
- preserve `network_name` unchanged for existing CLI and Dashboard clients

## Root cause

The database and current clients use `network_name`, while REST examples/integrations used `name`. The list endpoint returned raw rows without an alias, so `.name` was absent/null even though `anet whoami` correctly displayed `default` from `network_name`.

## Validation

Exact-source Docker test615 at `16b7b21b534223a93263c911163836026a812139`:

- real Hub HTTP: 2 pass, 13 assertions
- utok and ntok response paths
- production Hub bundle (257 modules)
- forcing `name:null` turns the contract tests red

Closes #449.
