### PR TITLE
fix(feishu): make Docker allowlists safe and additive

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -3078,21 +3078,53 @@ function writeFeishuChannelConfig(
   nodeId: string,
   appId: string,
   appSecret: string,
-  allowOpenId: string,
-  allowChatId?: string,
+  allowOpenIds: string[],
+  allowChatIds: string[],
 ): string {
   const channelDir = join(nodesDir(), nodeId, "channels", "feishu");
   mkdirSync(channelDir, { recursive: true });
+  const accessPath = join(channelDir, "access.json");
+  let existing: Record<string, unknown> = {};
+  if (existsSync(accessPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(accessPath, "utf-8"));
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("root must be a JSON object");
+      }
+      existing = parsed as Record<string, unknown>;
+    } catch (error: any) {
+      throw new Error(`refusing to replace malformed ${accessPath}: ${error?.message || error}`);
+    }
+  }
+
+  const existingFrom = parseFeishuAllowlistField(existing.allowFrom, "allowFrom", accessPath);
+  const existingChats = parseFeishuAllowlistField(existing.allowChats, "allowChats", accessPath);
 
   const envPath = join(channelDir, ".env");
   writeFileSync(envPath, `FEISHU_APP_ID=${appId}\nFEISHU_APP_SECRET=${appSecret}\n`);
   try { chmodSync(envPath, 0o600); } catch {}
 
-  writeAccessJsonAtomic(join(channelDir, "access.json"), {
-    allowFrom: allowOpenId ? [allowOpenId] : [],
-    allowChats: allowChatId ? [allowChatId] : [],
+  writeAccessJsonAtomic(accessPath, {
+    ...existing,
+    // Docker bootstrap is additive: preserve ids added through `anet channel
+    // allow`, while normalising the historical single-element CSV shape.
+    allowFrom: [...new Set([...existingFrom, ...allowOpenIds])],
+    allowChats: [...new Set([...existingChats, ...allowChatIds])],
   });
   return channelDir;
+}
+
+function parseFeishuAllowlist(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return [...new Set(raw.split(",").map((value) => value.trim()).filter(Boolean))];
+}
+
+function parseFeishuAllowlistField(raw: unknown, field: string, path: string): string[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw) || raw.some((value) => typeof value !== "string")) {
+    throw new Error(`refusing malformed ${path}: ${field} must be a string array`);
+  }
+  return [...new Set(raw.flatMap((value) => parseFeishuAllowlist(value)))];
 }
 
 async function askChoice<T extends string>(title: string, choices: { label: string; value: T; description?: string }[]): Promise<T> {
@@ -7723,12 +7755,14 @@ Examples:
         console.error("Error: --app-id and --app-secret required");
         process.exit(1);
       }
-      if (!allowOpenId && !allowChatId) {
+      const allowOpenIds = parseFeishuAllowlist(allowOpenId);
+      const allowChatIds = parseFeishuAllowlist(allowChatId);
+      if (allowOpenIds.length === 0 && allowChatIds.length === 0) {
         console.error("Error: at least one of --allow <open-id> or --allow-chat <chat-id> required");
         process.exit(1);
       }
 
-      channelDir = writeFeishuChannelConfig(nodeId, appId, appSecret, allowOpenId, allowChatId);
+      channelDir = writeFeishuChannelConfig(nodeId, appId, appSecret, allowOpenIds, allowChatIds);
       attachChannel(storedProfile, "feishu");
     }
 

--- a/docker/feishu/.env.example
+++ b/docker/feishu/.env.example
@@ -39,11 +39,11 @@ ANTHROPIC_AUTH_TOKEN=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # NOT mean allow-all. Obtain an ID scoped to this App from your Feishu
 # admin or the official API Explorer before first startup.
 #
-# Docker bootstrap currently accepts one ID per variable; it does NOT
-# split comma-separated values. Multi-ID Docker allowlists are not yet
-# supported: a restart rewrites access.json from these two variables.
-FEISHU_ALLOW_FROM=ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-# FEISHU_ALLOW_CHATS=oc_xxxxxxxxxxxxxxxxxxxxxxxx
+# Comma-separated values are supported. Whitespace/empty entries are removed
+# and duplicates are collapsed. On restart these bootstrap IDs are merged with
+# IDs previously added through `anet channel allow` (they are not overwritten).
+FEISHU_ALLOW_FROM=ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,ou_yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+# FEISHU_ALLOW_CHATS=oc_xxxxxxxxxxxxxxxxxxxxxxxx,oc_yyyyyyyyyyyyyyyyyyyy
 
 # ─── Optional tweaks ───────────────────────────────────────────────────
 # NODE_ALIAS — alias the hub sees this node by. Default: feishu-agent.

--- a/docker/feishu/README.md
+++ b/docker/feishu/README.md
@@ -24,7 +24,7 @@ HUB_PASSWORD=your-password                 # login is non-interactive via --user
 
 FEISHU_APP_ID=cli_xxxx                     # from https://open.feishu.cn → your app
 FEISHU_APP_SECRET=xxxx
-FEISHU_ALLOW_FROM=ou_xxx                   # one app-scoped open_id; required unless FEISHU_ALLOW_CHATS is set
+FEISHU_ALLOW_FROM=ou_xxx,ou_yyy            # app-scoped open_ids; required unless FEISHU_ALLOW_CHATS is set
 
 ANET_MODEL=deepseek-v4-pro                 # or MiniMax-M3 (vision) / claude-sonnet-4-6 / etc.
 ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
@@ -33,11 +33,11 @@ ANTHROPIC_AUTH_TOKEN=sk-xxxx
 
 Access allowlist (required — set at least one; empty is not allow-all):
 ```bash
-FEISHU_ALLOW_FROM=ou_xxx                   # one sender open_id (DM)
-FEISHU_ALLOW_CHATS=oc_xxx                  # one chat_id (group)
+FEISHU_ALLOW_FROM=ou_xxx,ou_yyy            # sender open_ids (DM), comma-separated
+FEISHU_ALLOW_CHATS=oc_xxx,oc_yyy            # chat_ids (group), comma-separated
 ```
 
-The Docker bootstrap does not split comma-separated values, so it currently supports at most one ID of each kind. Do not append extra IDs with the CLI inside the container: the next restart rewrites `access.json` from `.env`. Use the non-Docker manual setup for multi-ID allowlists until the entrypoint is fixed.
+The Docker bootstrap trims comma-separated values, removes empty entries and duplicates, and merges them into `access.json`. IDs added later with `anet channel allow` survive container restarts; removing an ID still requires the corresponding `anet channel allow ... --rm-*` command.
 
 See `.env.example` for the full annotated list (verified vendor + model combos, NODE_ALIAS override, etc.).
 

--- a/docker/feishu/entrypoint.sh
+++ b/docker/feishu/entrypoint.sh
@@ -9,8 +9,7 @@
 #   4. `anet node create $NODE_ALIAS --runtime claude-agent-sdk --model $ANET_MODEL`
 #      (only if node not already created — checks .anet/nodes/<alias>/config.json)
 #   5. `anet channel add feishu $NODE_ALIAS --app-id ... --app-secret ... [--allow ...]`
-#      (idempotent — already-added is downgraded to a log line, not a hard
-#      fail)
+#      (idempotent additive merge; any real failure remains fatal)
 #   6. `exec agent-node ...` so the agent runs as PID 1 (under tini) —
 #      SIGTERM from `docker stop` reaches the agent cleanly.
 #
@@ -39,6 +38,35 @@ set -o pipefail
 : "${ANTHROPIC_AUTH_TOKEN:?missing — set ANTHROPIC_AUTH_TOKEN=sk-... in .env}"
 
 NODE_ALIAS="${NODE_ALIAS:-feishu-agent}"
+
+# Docker bootstrap accepts comma-separated IDs. Normalise before any login or
+# node write so whitespace-only / comma-only values fail without side effects.
+parse_csv_unique() {
+  local raw="$1" out_name="$2" item trimmed
+  local -a pieces=()
+  local -A seen=()
+  local -n out="$out_name"
+  out=()
+  IFS=',' read -r -a pieces <<< "$raw"
+  for item in "${pieces[@]}"; do
+    trimmed="${item#"${item%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+    [ -n "$trimmed" ] || continue
+    if [ -z "${seen[$trimmed]+x}" ]; then
+      seen[$trimmed]=1
+      out+=("$trimmed")
+    fi
+  done
+}
+
+ALLOW_FROM_IDS=()
+ALLOW_CHAT_IDS=()
+parse_csv_unique "${FEISHU_ALLOW_FROM:-}" ALLOW_FROM_IDS
+parse_csv_unique "${FEISHU_ALLOW_CHATS:-}" ALLOW_CHAT_IDS
+if [ "${#ALLOW_FROM_IDS[@]}" -eq 0 ] && [ "${#ALLOW_CHAT_IDS[@]}" -eq 0 ]; then
+  echo "[feishu-entrypoint] FATAL — at least one valid ID is required in FEISHU_ALLOW_FROM or FEISHU_ALLOW_CHATS"
+  exit 1
+fi
 
 cd /work
 
@@ -90,25 +118,22 @@ else
     2>&1 | sed 's/^/[node] /'
 fi
 
-# ── 4) channel add feishu (idempotent — already-added → log + continue) ──
+# ── 4) channel add feishu (idempotent additive merge; failures are fatal) ──
 ALLOW_FLAGS=()
-if [ -n "${FEISHU_ALLOW_FROM:-}" ]; then
-  ALLOW_FLAGS+=(--allow "$FEISHU_ALLOW_FROM")
+if [ "${#ALLOW_FROM_IDS[@]}" -gt 0 ]; then
+  ALLOW_FROM_CSV="$(IFS=,; echo "${ALLOW_FROM_IDS[*]}")"
+  ALLOW_FLAGS+=(--allow "$ALLOW_FROM_CSV")
 fi
-if [ -n "${FEISHU_ALLOW_CHATS:-}" ]; then
-  ALLOW_FLAGS+=(--allow-chat "$FEISHU_ALLOW_CHATS")
+if [ "${#ALLOW_CHAT_IDS[@]}" -gt 0 ]; then
+  ALLOW_CHAT_CSV="$(IFS=,; echo "${ALLOW_CHAT_IDS[*]}")"
+  ALLOW_FLAGS+=(--allow-chat "$ALLOW_CHAT_CSV")
 fi
 echo "[channel] adding feishu to '${NODE_ALIAS}'${ALLOW_FLAGS:+ (with ${#ALLOW_FLAGS[@]}/2 allow flags)}"
 anet channel add feishu "$NODE_ALIAS" \
     --app-id "$FEISHU_APP_ID" \
     --app-secret "$FEISHU_APP_SECRET" \
     "${ALLOW_FLAGS[@]}" \
-  2>&1 | sed 's/^/[channel] /' || {
-    # Tolerate "already added" — first-run vs restart-run distinction
-    # is in the exit code; for now we always continue and let the agent
-    # decide whether the channel is healthy.
-    echo "[channel] add returned non-zero (likely already-added on restart) — continuing"
-  }
+  2>&1 | sed 's/^/[channel] /'
 
 # ── 5) start agent-node — PID 1 under tini ──────────────────────────────
 echo "[start] exec agent-node alias=${NODE_ALIAS} config=${NODE_CONFIG}"

--- a/docs-site/docs/en/guide/feishu.md
+++ b/docs-site/docs/en/guide/feishu.md
@@ -82,8 +82,8 @@ The container entrypoint runs the full bring-up chain: `hub init` → `anet logi
 | `HUB_USER` / `HUB_PASSWORD` | Account on that hub (**non-interactive `anet login --username/--password` runs on every container start, so there is no pre-issued ntok_ to manage**) | ✅ |
 | `FEISHU_APP_ID` / `FEISHU_APP_SECRET` | The credentials from §2 | ✅ |
 | `ANET_MODEL` + `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` | LLM-backend triple (see §4) | ✅ |
-| `FEISHU_ALLOW_FROM` | One DM sender `open_id` scoped to the **current app** (the Docker bootstrap option does not parse comma-separated lists) | ✅ At least one of these two |
-| `FEISHU_ALLOW_CHATS` | One group `chat_id` scoped to the current app | ✅ At least one of these two |
+| `FEISHU_ALLOW_FROM` | DM sender `open_id` values scoped to the current app (comma-separated) | ✅ At least one of these two |
+| `FEISHU_ALLOW_CHATS` | Group `chat_id` values scoped to the current app (comma-separated) | ✅ At least one of these two |
 | `NODE_ALIAS` | Node alias (default `feishu-agent`) | Optional |
 | `ACK_PLACEHOLDER` | "⏳ 处理中…" placeholder switch (default `true`, see §7) | Optional |
 
@@ -159,7 +159,7 @@ When the picked backend doesn't support images and Feishu delivers an image mess
 
 The bridge does **not** accept messages from the entire network — you must explicitly list allowed **users** (`open_id`) and **groups** (`chat_id`) in `access.json`.
 
-**Docker path** (recommended): before the first startup, set at least one of `.env` `FEISHU_ALLOW_FROM` (one real `open_id` scoped to the current app) or `FEISHU_ALLOW_CHATS` (one `chat_id`). Empty does not mean "allow everyone." Neither bootstrap option parses comma-separated lists, so the current Docker path supports at most one ID of each kind. Do not append more IDs with the CLI inside the container: the entrypoint rewrites `access.json` from `.env` on the next restart. Use the non-Docker manual path below when multiple IDs are required.
+**Docker path** (recommended): before the first startup, set at least one of `.env` `FEISHU_ALLOW_FROM` (real `open_id` values scoped to the current app) or `FEISHU_ALLOW_CHATS` (`chat_id` values). Empty or comma/whitespace-only input does not mean "allow everyone"; the container refuses to start. Separate multiple IDs with commas. The entrypoint trims, removes empty/duplicate entries, and merges the bootstrap IDs into `access.json`. IDs added with `anet channel allow` survive restarts; use the matching `--rm-*` command to remove one.
 
 **Manual `anet` path**: use the CLI to add / remove entries:
 

--- a/docs-site/docs/guide/feishu.md
+++ b/docs-site/docs/guide/feishu.md
@@ -82,8 +82,8 @@ docker compose logs -f feishu-agent         # 跟启动 + 运行日志
 | `HUB_USER` / `HUB_PASSWORD` | 该 hub 上的账号（**非交互式 `anet login --username/--password`，每次启动重新登录，不用预签 ntok\_**） | ✅ |
 | `FEISHU_APP_ID` / `FEISHU_APP_SECRET` | §2 拿到的飞书自建应用凭证 | ✅ |
 | `ANET_MODEL` + `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` | 模型后端三件套（详见 §4） | ✅ |
-| `FEISHU_ALLOW_FROM` | 允许私聊的、**当前 App 下的一个 `open_id`**（Docker 启动参数不支持逗号列表） | ✅ 与下一项至少填一项 |
-| `FEISHU_ALLOW_CHATS` | 允许群聊的、当前 App 下的一个 `chat_id` | ✅ 与上一项至少填一项 |
+| `FEISHU_ALLOW_FROM` | 允许私聊的、当前 App 下的 `open_id`（多个用逗号分隔） | ✅ 与下一项至少填一项 |
+| `FEISHU_ALLOW_CHATS` | 允许群聊的、当前 App 下的 `chat_id`（多个用逗号分隔） | ✅ 与上一项至少填一项 |
 | `NODE_ALIAS` | 节点 alias（默认 `feishu-agent`） | 可选 |
 | `ACK_PLACEHOLDER` | "⏳ 处理中…" 占位开关（默认 `true`，详见 §7） | 可选 |
 
@@ -159,7 +159,7 @@ docker compose up -d
 
 bridge 不接受全网消息——必须在 `access.json` 里把允许的 **人**（`open_id`）和 **群**（`chat_id`）显式列出。
 
-**Docker 路径**（推荐）：第一次启动前，`.env` 的 `FEISHU_ALLOW_FROM`（当前 App 下的一个真实 `open_id`）和 `FEISHU_ALLOW_CHATS`（一个 `chat_id`）**必须至少填一项**；留空不是「允许所有人」。这两个启动参数都**不支持逗号列表**，因此当前 Docker 路径每类最多配置一个 ID。不要在容器里用 CLI 追加更多 ID：entrypoint 会在下次重启时按 `.env` 重写 `access.json`。需要多 ID 时暂用下面的非 Docker 手动路径。
+**Docker 路径**（推荐）：第一次启动前，`.env` 的 `FEISHU_ALLOW_FROM`（当前 App 下的真实 `open_id`）和 `FEISHU_ALLOW_CHATS`（`chat_id`）**必须至少填一项**；留空或只有逗号/空白不是「允许所有人」，容器会直接拒绝启动。多个 ID 用逗号分隔；entrypoint 会 trim、去空、去重并合并到 `access.json`。通过 `anet channel allow` 追加的 ID 会在重启后保留；删除仍使用对应的 `--rm-*` 命令。
 
 **手动 anet 路径**：用 CLI 增删：
 

--- a/docs/tests/report-test616-feishu-docker-bootstrap.txt
+++ b/docs/tests/report-test616-feishu-docker-bootstrap.txt
@@ -1,0 +1,41 @@
+# test616 — Feishu Docker bootstrap allowlist and failure propagation
+
+Date: 2026-08-09
+Issue: #451
+Base: 4980e14f8317a3c94b2684d8a7f710adf21841fe
+Source commit: 0669c4e4ae0b8c7dacb4518d012b463aec2f0277
+Docker tag: anet-test616:dev
+Docker image: sha256:d624100763408319bd895b5ae2bc5689dc4f013f205c3b1c1c7eb588dd506621
+Embedded ENV: TEST616_SOURCE_COMMIT=0669c4e4ae0b8c7dacb4518d012b463aec2f0277
+
+## Command
+
+```sh
+sg docker -c 'docker build \
+  --build-arg SOURCE_COMMIT=0669c4e4ae0b8c7dacb4518d012b463aec2f0277 \
+  -t anet-test616:dev \
+  -f tests/test616-feishu-docker-bootstrap/Dockerfile .'
+sg docker -c 'docker run --rm anet-test616:dev'
+```
+
+## Layer results
+
+- L0: TypeScript typecheck plus Docker/Chinese/English contract checks — PASS.
+- L1: Real source CLI writes trimmed/deduplicated arrays; restart merge preserves
+  IDs added through `anet channel allow`; historical `["a,b"]` shape is repaired
+  and unknown fields are retained — PASS.
+- L2: malformed existing access state and comma/whitespace-only input fail
+  closed; `access.json` and credential `.env` remain byte-identical — PASS.
+- L3: real entrypoint shell forwards one normalized CSV value per allowlist and
+  reaches the agent only after successful bootstrap — PASS.
+- L4: empty bootstrap and synthetic unknown channel-add failure both exit
+  non-zero before agent-node — PASS.
+- L5 witnessed red:
+  - removing `set -o pipefail` lets a failing channel-add reach agent-node;
+  - deleting the CSV split recreates the single-element allowlist defect.
+
+Result: PASS (6 tests, 24 assertions).
+
+No live Feishu app, credential, Hub, message, production PID, or production
+configuration was read or used. All IDs and credentials in this suite are
+synthetic.

--- a/tests/test616-feishu-docker-bootstrap/Dockerfile
+++ b/tests/test616-feishu-docker-bootstrap/Dockerfile
@@ -1,0 +1,19 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY docker/feishu ./docker/feishu
+COPY docs-site/docs/guide/feishu.md ./docs-site/docs/guide/feishu.md
+COPY docs-site/docs/en/guide/feishu.md ./docs-site/docs/en/guide/feishu.md
+COPY tests/lib ./tests/lib
+COPY tests/test616-feishu-docker-bootstrap ./tests/test616-feishu-docker-bootstrap
+
+ARG SOURCE_COMMIT
+ENV TEST616_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test616-feishu-docker-bootstrap/run.sh
+ENTRYPOINT ["/workspace/tests/test616-feishu-docker-bootstrap/run.sh"]

--- a/tests/test616-feishu-docker-bootstrap/run.sh
+++ b/tests/test616-feishu-docker-bootstrap/run.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/safe-rm.sh"
+export SAFE_RM_ALLOW_PREFIXES="/tmp/ /work/"
+
+ROOT=/workspace
+CLI="$ROOT/agent-network/bin/cli.ts"
+ENTRYPOINT="$ROOT/docker/feishu/entrypoint.sh"
+PASS=0
+ASSERTS=0
+
+pass() { PASS=$((PASS + 1)); printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+assert() { ASSERTS=$((ASSERTS + 1)); "$@" || fail "assertion failed: $*"; }
+
+echo "test616 source_commit=${TEST616_SOURCE_COMMIT:-missing}"
+test -n "${TEST616_SOURCE_COMMIT:-}" || fail "SOURCE_COMMIT provenance missing"
+
+echo "L0: typecheck + source/doc contract"
+(cd "$ROOT/agent-network" && bun x tsc --noEmit)
+assert grep -Fq 'set -o pipefail' "$ENTRYPOINT"
+assert grep -Fq 'comma-separated' "$ROOT/docker/feishu/README.md"
+assert grep -Fq '多个用逗号分隔' "$ROOT/docs-site/docs/guide/feishu.md"
+assert grep -Fq 'comma-separated' "$ROOT/docs-site/docs/en/guide/feishu.md"
+pass "typecheck and bilingual contract"
+
+echo "L1: real CLI CSV normalization + additive restart"
+CLI_WORK=/tmp/test616-cli
+safe_rm_rf "$CLI_WORK"
+mkdir -p "$CLI_WORK/.anet/nodes/feishu-test"
+cat >"$CLI_WORK/.anet/nodes/feishu-test/config.json" <<'JSON'
+{
+  "node_name": "feishu-test",
+  "node_id": "n_test616",
+  "runtime": "claude-agent-sdk",
+  "hub": "http://127.0.0.1:1",
+  "token": "ntok_test616",
+  "network_id": "net_test616",
+  "channels": [],
+  "env": {},
+  "flags": {}
+}
+JSON
+(
+  cd "$CLI_WORK"
+  bun "$CLI" channel add feishu feishu-test \
+    --app-id cli_dummy --app-secret dummy-secret \
+    --allow ' ou_A,ou_B,,ou_A ' --allow-chat ' oc_A, oc_B,oc_A '
+)
+ACCESS="$CLI_WORK/.anet/nodes/feishu-test/channels/feishu/access.json"
+assert bun -e 'const a=await Bun.file(process.argv[1]).json(); process.exit(JSON.stringify(a.allowFrom)==JSON.stringify(["ou_A","ou_B"]) && JSON.stringify(a.allowChats)==JSON.stringify(["oc_A","oc_B"])?0:1)' "$ACCESS"
+
+(
+  cd "$CLI_WORK"
+  bun "$CLI" channel allow feishu feishu-test --add-from ou_manual --add-chat oc_manual
+  bun "$CLI" channel add feishu feishu-test \
+    --app-id cli_dummy --app-secret dummy-secret \
+    --allow 'ou_A,ou_B' --allow-chat 'oc_A,oc_B'
+)
+assert bun -e 'const a=await Bun.file(process.argv[1]).json(); process.exit(a.allowFrom.includes("ou_manual") && a.allowChats.includes("oc_manual") && a.allowFrom.length===3 && a.allowChats.length===3?0:1)' "$ACCESS"
+
+cat >"$ACCESS" <<'JSON'
+{"allowFrom":["ou_legacy_A, ou_legacy_B"],"allowChats":["oc_legacy_A,oc_legacy_B"],"futureField":"kept"}
+JSON
+(
+  cd "$CLI_WORK"
+  bun "$CLI" channel add feishu feishu-test \
+    --app-id cli_dummy --app-secret dummy-secret --allow ou_new --allow-chat oc_new
+)
+assert bun -e 'const a=await Bun.file(process.argv[1]).json(); process.exit(a.allowFrom.join(",")==="ou_legacy_A,ou_legacy_B,ou_new" && a.allowChats.join(",")==="oc_legacy_A,oc_legacy_B,oc_new" && a.futureField==="kept"?0:1)' "$ACCESS"
+pass "real CLI writes arrays, preserves supported additions, and repairs legacy CSV shape"
+
+echo "L2: malformed/empty input fail closed without partial config"
+printf '%s\n' '{"allowFrom":[123],"allowChats":[]}' >"$ACCESS"
+ENV_FILE="$CLI_WORK/.anet/nodes/feishu-test/channels/feishu/.env"
+before_access="$(sha256sum "$ACCESS" | cut -d' ' -f1)"
+before_env="$(sha256sum "$ENV_FILE" | cut -d' ' -f1)"
+set +e
+(cd "$CLI_WORK" && bun "$CLI" channel add feishu feishu-test --app-id changed --app-secret changed --allow ou_x) >/tmp/test616-malformed.log 2>&1
+malformed_rc=$?
+set -e
+assert test "$malformed_rc" -ne 0
+assert test "$(sha256sum "$ACCESS" | cut -d' ' -f1)" = "$before_access"
+assert test "$(sha256sum "$ENV_FILE" | cut -d' ' -f1)" = "$before_env"
+assert grep -Fq 'refusing malformed' /tmp/test616-malformed.log
+
+mkdir -p "$CLI_WORK/.anet/nodes/blank-test"
+cp "$CLI_WORK/.anet/nodes/feishu-test/config.json" "$CLI_WORK/.anet/nodes/blank-test/config.json"
+set +e
+(cd "$CLI_WORK" && bun "$CLI" channel add feishu blank-test --app-id cli_dummy --app-secret dummy --allow ' ,  ,' --allow-chat ',') >/tmp/test616-blank.log 2>&1
+blank_rc=$?
+set -e
+assert test "$blank_rc" -ne 0
+assert test ! -e "$CLI_WORK/.anet/nodes/blank-test/channels/feishu/access.json"
+pass "malformed existing state and empty CSV fail closed"
+
+make_fake_bin() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/anet" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>/tmp/test616-anet-calls
+if [ "${1:-}" = login ]; then echo '✅ Logged in as test'; exit 0; fi
+if [ "${1:-} ${2:-} ${3:-}" = 'channel add feishu' ] && [ "${FAIL_CHANNEL_ADD:-0}" = 1 ]; then
+  echo 'synthetic channel failure' >&2
+  exit 42
+fi
+exit 0
+SH
+  cat >"$dir/agent-node" <<'SH'
+#!/usr/bin/env bash
+touch /tmp/test616-agent-started
+exit 0
+SH
+  chmod 0755 "$dir/anet" "$dir/agent-node"
+}
+
+prepare_entrypoint_case() {
+  safe_rm_rf /work/.anet /tmp/test616-agent-started /tmp/test616-anet-calls
+  mkdir -p /work/.anet/nodes/feishu-docker
+  printf '%s\n' '{}' >/work/.anet/nodes/feishu-docker/config.json
+}
+
+run_entrypoint() {
+  local script="$1"
+  HUB_URL=http://hub.invalid HUB_USER=user HUB_PASSWORD=pass \
+  FEISHU_APP_ID=cli_dummy FEISHU_APP_SECRET=dummy ANET_MODEL=mock \
+  ANTHROPIC_BASE_URL=http://model.invalid ANTHROPIC_AUTH_TOKEN=dummy \
+  NODE_ALIAS=feishu-docker PATH="/tmp/test616-bin:$PATH" \
+  bash "$script"
+}
+
+echo "L3: entrypoint happy path normalizes args"
+make_fake_bin /tmp/test616-bin
+prepare_entrypoint_case
+FEISHU_ALLOW_FROM=' ou_A,ou_B,,ou_A ' FEISHU_ALLOW_CHATS=' oc_A, oc_B,oc_A ' run_entrypoint "$ENTRYPOINT" >/tmp/test616-entry-happy.log 2>&1
+assert test -e /tmp/test616-agent-started
+assert grep -Fq -- '--allow ou_A,ou_B --allow-chat oc_A,oc_B' /tmp/test616-anet-calls
+pass "entrypoint forwards one normalized CSV value per allowlist"
+
+echo "L4: empty input and unknown channel failure never start agent-node"
+prepare_entrypoint_case
+set +e
+FEISHU_ALLOW_FROM=' ,  ,' FEISHU_ALLOW_CHATS='  ,' run_entrypoint "$ENTRYPOINT" >/tmp/test616-entry-empty.log 2>&1
+empty_rc=$?
+set -e
+assert test "$empty_rc" -ne 0
+assert test ! -e /tmp/test616-agent-started
+assert test ! -e /tmp/test616-anet-calls
+
+prepare_entrypoint_case
+set +e
+FAIL_CHANNEL_ADD=1 FEISHU_ALLOW_FROM=ou_A FEISHU_ALLOW_CHATS= run_entrypoint "$ENTRYPOINT" >/tmp/test616-entry-fail.log 2>&1
+channel_rc=$?
+set -e
+assert test "$channel_rc" -ne 0
+assert test ! -e /tmp/test616-agent-started
+assert grep -Fq 'synthetic channel failure' /tmp/test616-entry-fail.log
+pass "entrypoint rejects empty bootstrap and propagates unknown channel-add failure"
+
+echo "L5: witnessed-red mutations"
+MUT_ENTRY=/tmp/test616-entrypoint-no-pipefail.sh
+sed '/set -o pipefail/d' "$ENTRYPOINT" >"$MUT_ENTRY"
+prepare_entrypoint_case
+set +e
+FAIL_CHANNEL_ADD=1 FEISHU_ALLOW_FROM=ou_A FEISHU_ALLOW_CHATS= run_entrypoint "$MUT_ENTRY" >/tmp/test616-mut-pipefail.log 2>&1
+mut_pipe_rc=$?
+set -e
+assert test "$mut_pipe_rc" -eq 0
+assert test -e /tmp/test616-agent-started
+echo "WITNESSED_RED: removing pipefail lets failed channel-add reach agent-node"
+
+MUT_CLI="$ROOT/agent-network/bin/cli-mut-test616.ts"
+sed 's/raw\.split(",")/raw.split("\\u0000")/' "$CLI" >"$MUT_CLI"
+safe_rm_rf "$CLI_WORK/.anet/nodes/mutation-test"
+mkdir -p "$CLI_WORK/.anet/nodes/mutation-test"
+cp "$CLI_WORK/.anet/nodes/feishu-test/config.json" "$CLI_WORK/.anet/nodes/mutation-test/config.json"
+(cd "$CLI_WORK" && bun "$MUT_CLI" channel add feishu mutation-test --app-id cli_dummy --app-secret dummy --allow 'ou_A,ou_B') >/tmp/test616-mut-csv.log 2>&1
+MUT_ACCESS="$CLI_WORK/.anet/nodes/mutation-test/channels/feishu/access.json"
+set +e
+bun -e 'const a=await Bun.file(process.argv[1]).json(); process.exit(JSON.stringify(a.allowFrom)==JSON.stringify(["ou_A","ou_B"])?0:1)' "$MUT_ACCESS"
+mut_csv_contract=$?
+set -e
+assert test "$mut_csv_contract" -ne 0
+echo "WITNESSED_RED: deleting CSV split recreates the single-element allowlist defect"
+rm -f "$MUT_CLI"
+pass "both safety/correctness mutations are non-empty"
+
+printf 'RESULT: PASS (%s tests, %s assertions) source=%s\n' "$PASS" "$ASSERTS" "$TEST616_SOURCE_COMMIT"


### PR DESCRIPTION
## Summary
- parse Docker/CLI Feishu allowlists as trimmed, deduplicated CSV arrays
- merge bootstrap IDs with existing `access.json` so supported CLI additions survive restarts
- fail before agent startup on empty allowlists, malformed state, or any real `channel add` error
- update Docker and bilingual docs with the additive semantics

## Verification
- Docker test616: 6 tests / 24 assertions PASS
- exact source: `0669c4e4ae0b8c7dacb4518d012b463aec2f0277`
- report-only head: `b4a7b7203db54e476762396891831725e4634e85`
- witnessed red: remove pipefail -> failed channel-add starts agent; remove CSV split -> single-element list returns

Closes #451