### PR TITLE
fix(feishu): wait for websocket readiness before reporting online

### DIFF
--- a/agent-network/src/im/feishu/adapter-lifecycle.test.ts
+++ b/agent-network/src/im/feishu/adapter-lifecycle.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test";
+import type * as lark from "@larksuiteoapi/node-sdk";
+
+import {
+  FeishuAdapter,
+  type FeishuWsClientFactory,
+  type FeishuWsClientLike,
+} from "./adapter.js";
+import type { IMChannelConfig } from "../types.js";
+import { exitFeishuWorker } from "./worker-lifecycle.js";
+
+type WsParams = Parameters<FeishuWsClientFactory>[0];
+
+class FakeWsClient implements FeishuWsClientLike {
+  started = 0;
+  closed = 0;
+
+  async start(): Promise<void> {
+    this.started += 1;
+    // Deliberately resolves before readiness, matching the SDK behavior that
+    // caused #452. The adapter must wait for params.onReady instead.
+  }
+
+  close(): void {
+    this.closed += 1;
+  }
+}
+
+function config(appSecret = "secret-452"): IMChannelConfig {
+  return {
+    platform: "feishu",
+    connectionName: "test-feishu",
+    ingressMode: "socket",
+    groupPolicy: "mention",
+    ackPlaceholder: false,
+    auditRaw: false,
+    taskTimeoutMs: 1_000,
+    platformConfig: {
+      appId: "app-452",
+      appSecret,
+      access: { allowFrom: [], allowChats: [] },
+      groupPolicy: "mention",
+      ackPlaceholder: false,
+      auditRaw: false,
+      taskTimeoutMs: 1_000,
+      outboundRender: "plain",
+      channelDir: "/tmp/test452-channel",
+    },
+  };
+}
+
+function harness(options: {
+  timeoutMs?: number;
+  terminal?: (error: Error) => void;
+} = {}) {
+  let params: WsParams | undefined;
+  const ws = new FakeWsClient();
+  const adapter = new FeishuAdapter({
+    createClient: () =>
+      ({ request: async () => ({ bot: { open_id: "bot-452" } }) }) as unknown as lark.Client,
+    createWsClient: (input) => {
+      params = input;
+      return ws;
+    },
+    wsReadyTimeoutMs: options.timeoutMs ?? 100,
+    onTerminalError: options.terminal,
+  });
+  return { adapter, ws, get params() { return params; } };
+}
+
+const onEvent = async (): Promise<void> => {};
+
+describe("FeishuAdapter WS lifecycle", () => {
+  test("SDK start resolution is not readiness; missing onReady times out fail-closed", async () => {
+    const h = harness({ timeoutMs: 15 });
+    await h.adapter.init(config());
+
+    await expect(h.adapter.start(onEvent)).rejects.toThrow("did not become ready");
+    expect(h.ws.started).toBe(1);
+    expect(h.ws.closed).toBe(1);
+    expect(h.adapter.health().connected).toBe(false);
+  });
+
+  test("onReady is the only initial online authority", async () => {
+    const h = harness();
+    await h.adapter.init(config());
+    const starting = h.adapter.start(onEvent);
+    await Bun.sleep(1);
+    expect(h.adapter.health().connected).toBe(false);
+
+    h.params?.onReady?.();
+    await starting;
+    expect(h.adapter.health()).toMatchObject({ connected: true, lastError: null });
+  });
+
+  test("initial onError rejects and scrubs credentials", async () => {
+    const terminal: Error[] = [];
+    const h = harness({ terminal: (error) => terminal.push(error) });
+    await h.adapter.init(config("do-not-log-me"));
+    const starting = h.adapter.start(onEvent);
+    await Bun.sleep(1);
+    h.params?.onError?.(new Error("bad app-452 / do-not-log-me\ncredential"));
+
+    await expect(starting).rejects.toThrow("bad [redacted] / [redacted] credential");
+    expect(h.adapter.health().connected).toBe(false);
+    expect(h.adapter.health().lastError).not.toContain("do-not-log-me");
+    expect(terminal).toHaveLength(0);
+  });
+
+  test("reconnecting lowers health and reconnected restores it", async () => {
+    const h = harness();
+    await h.adapter.init(config());
+    const starting = h.adapter.start(onEvent);
+    await Bun.sleep(1);
+    h.params?.onReady?.();
+    await starting;
+
+    h.params?.onReconnecting?.();
+    expect(h.adapter.health().connected).toBe(false);
+    h.params?.onReconnected?.();
+    expect(h.adapter.health().connected).toBe(true);
+  });
+
+  test("terminal error after ready lowers health and notifies worker owner once", async () => {
+    const terminal: Error[] = [];
+    const h = harness({ terminal: (error) => terminal.push(error) });
+    await h.adapter.init(config());
+    const starting = h.adapter.start(onEvent);
+    await Bun.sleep(1);
+    h.params?.onReady?.();
+    await starting;
+
+    h.params?.onError?.(new Error("retries exhausted"));
+    h.params?.onError?.(new Error("duplicate terminal callback"));
+    h.params?.onReconnected?.();
+    expect(h.adapter.health()).toMatchObject({
+      connected: false,
+      lastError: "retries exhausted",
+    });
+    expect(terminal.map((error) => error.message)).toEqual(["retries exhausted"]);
+  });
+
+  test("stop closes the public SDK client and invalidates late callbacks", async () => {
+    const h = harness();
+    await h.adapter.init(config());
+    const starting = h.adapter.start(onEvent);
+    await Bun.sleep(1);
+    h.params?.onReady?.();
+    await starting;
+    await h.adapter.stop();
+    expect(h.ws.closed).toBe(1);
+    h.params?.onReconnected?.();
+    expect(h.adapter.health().connected).toBe(false);
+  });
+});
+
+test("worker terminal owner logs safely and exits non-zero", () => {
+  const writes: string[] = [];
+  const exits: number[] = [];
+  exitFeishuWorker(new Error("retries exhausted"), {
+    stderr: { write: (message) => writes.push(message) },
+    exit: (code) => exits.push(code),
+  });
+  expect(writes).toEqual([
+    "[feishu:worker] connection failed after ready: retries exhausted\n",
+  ]);
+  expect(exits).toEqual([1]);
+});

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -44,6 +44,26 @@ import { resolveOutboundRoute } from "./outbound-route.js";
 
 type OnEventHandler = (event: NormalizedIMEvent) => Promise<void>;
 
+export type FeishuWsClientLike = Pick<lark.WSClient, "start" | "close">;
+export type FeishuWsClientFactory = (
+  params: ConstructorParameters<typeof lark.WSClient>[0],
+) => FeishuWsClientLike;
+
+export interface FeishuAdapterOptions {
+  /** @internal Avoids real bot-info HTTP calls in lifecycle tests. */
+  createClient?: (
+    params: ConstructorParameters<typeof lark.Client>[0],
+  ) => lark.Client;
+  /** @internal Test seam; production uses the pinned Lark SDK WSClient. */
+  createWsClient?: FeishuWsClientFactory;
+  /** Independent outer bound in case the SDK promise/callback path stalls. */
+  wsReadyTimeoutMs?: number;
+  /** Called once when an already-ready socket exhausts reconnect attempts. */
+  onTerminalError?: (error: Error) => void;
+}
+
+const DEFAULT_WS_READY_TIMEOUT_MS = 30_000;
+
 export class FeishuAdapter implements IMAdapter {
   readonly platform = "feishu";
   readonly ingressMode: IMIngressMode = "socket";
@@ -51,7 +71,11 @@ export class FeishuAdapter implements IMAdapter {
   private feishuConfig: FeishuChannelConfig | null = null;
   private connectionName_ = "";
   private client: lark.Client | null = null;
-  private wsClient: lark.WSClient | null = null;
+  private wsClient: FeishuWsClientLike | null = null;
+  private lifecycleGeneration = 0;
+  private readonly options: Required<
+    Pick<FeishuAdapterOptions, "createClient" | "createWsClient" | "wsReadyTimeoutMs">
+  > & Pick<FeishuAdapterOptions, "onTerminalError">;
   /**
    * The bot's own open_id, resolved at init() via /open-apis/bot/v3/info.
    * Used to detect real @bot mentions (vs any mention) in group messages.
@@ -67,6 +91,15 @@ export class FeishuAdapter implements IMAdapter {
     lastEventAt: null,
     lastError: null,
   };
+
+  constructor(options: FeishuAdapterOptions = {}) {
+    this.options = {
+      createClient: options.createClient ?? ((params) => new lark.Client(params)),
+      createWsClient: options.createWsClient ?? ((params) => new lark.WSClient(params)),
+      wsReadyTimeoutMs: options.wsReadyTimeoutMs ?? DEFAULT_WS_READY_TIMEOUT_MS,
+      onTerminalError: options.onTerminalError,
+    };
+  }
 
   /**
    * Snapshot of the current `access.allowFrom` list (from access.json).
@@ -105,7 +138,7 @@ export class FeishuAdapter implements IMAdapter {
     }
     this.feishuConfig = fc as FeishuChannelConfig;
     this.connectionName_ = config.connectionName;
-    this.client = new lark.Client({
+    this.client = this.options.createClient({
       appId: fc.appId,
       appSecret: fc.appSecret,
       disableTokenCache: false,
@@ -176,19 +209,85 @@ export class FeishuAdapter implements IMAdapter {
       },
     });
 
-    this.wsClient = new lark.WSClient({
-      appId,
-      appSecret,
-      loggerLevel: lark.LoggerLevel.warn,
+    const generation = ++this.lifecycleGeneration;
+    let ready = false;
+    let settled = false;
+    let terminalDispatched = false;
+
+    const readyPromise = new Promise<void>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finishError = (rawError: unknown): void => {
+        if (generation !== this.lifecycleGeneration) return;
+        if (ready && terminalDispatched) return;
+        const error = sanitizeFeishuWsError(rawError, appId, appSecret);
+        this.health_ = { ...this.health_, connected: false, lastError: error.message };
+        if (!settled) {
+          settled = true;
+          if (timer) clearTimeout(timer);
+          reject(error);
+          return;
+        }
+        if (ready && !terminalDispatched) {
+          terminalDispatched = true;
+          this.options.onTerminalError?.(error);
+        }
+      };
+
+      timer = setTimeout(() => {
+        if (settled || generation !== this.lifecycleGeneration) return;
+        finishError(
+          new Error(
+            `Feishu WebSocket did not become ready within ${this.options.wsReadyTimeoutMs}ms`,
+          ),
+        );
+        try {
+          this.wsClient?.close({ force: true });
+        } catch {
+          // Best effort; the startup error remains authoritative.
+        }
+      }, this.options.wsReadyTimeoutMs);
+
+      this.wsClient = this.options.createWsClient({
+        appId,
+        appSecret,
+        loggerLevel: lark.LoggerLevel.warn,
+        handshakeTimeoutMs: this.options.wsReadyTimeoutMs,
+        onReady: () => {
+          if (settled || generation !== this.lifecycleGeneration) return;
+          ready = true;
+          settled = true;
+          clearTimeout(timer);
+          this.health_ = { ...this.health_, connected: true, lastError: null };
+          resolve();
+        },
+        onError: finishError,
+        onReconnecting: () => {
+          if (generation !== this.lifecycleGeneration || terminalDispatched) return;
+          this.health_ = { ...this.health_, connected: false };
+        },
+        onReconnected: () => {
+          if (generation !== this.lifecycleGeneration || terminalDispatched) return;
+          this.health_ = { ...this.health_, connected: true, lastError: null };
+        },
+      });
+
+      // SDK start() has historically resolved before the first handshake.
+      // The callback above, not this promise, is the readiness authority.
+      void Promise.resolve(this.wsClient.start({ eventDispatcher: dispatcher })).catch(
+        finishError,
+      );
     });
 
-    await this.wsClient.start({ eventDispatcher: dispatcher });
-    this.health_ = { ...this.health_, connected: true, lastError: null };
+    await readyPromise;
   }
 
   async stop(): Promise<void> {
-    // Lark SDK does not expose a public close on WSClient (as of 1.42); allow
-    // GC + mark health for callers. Worker process exit drops the connection.
+    ++this.lifecycleGeneration;
+    try {
+      this.wsClient?.close({ force: true });
+    } catch {
+      // Best-effort shutdown; worker exit is the final transport boundary.
+    }
     this.health_ = { ...this.health_, connected: false };
     this.wsClient = null;
     this.client = null;
@@ -1333,6 +1432,24 @@ async function uploadFile(
     );
     return null;
   }
+}
+
+/**
+ * Lark errors may echo request/config values. Keep worker logs actionable while
+ * ensuring credentials and multiline payloads never cross the process boundary.
+ */
+export function sanitizeFeishuWsError(
+  rawError: unknown,
+  appId: string,
+  appSecret: string,
+): Error {
+  const raw = rawError instanceof Error ? rawError.message : String(rawError);
+  let message = raw.replace(/[\r\n\t]+/g, " ");
+  for (const secret of [appSecret, appId]) {
+    if (secret) message = message.split(secret).join("[redacted]");
+  }
+  message = message.trim().slice(0, 500) || "Feishu WebSocket failed";
+  return new Error(message);
 }
 
 // ── Internals: bot identity resolution (RFC-020 §4.3 / #179 M5b) ────────

--- a/agent-network/src/im/feishu/bridge.ts
+++ b/agent-network/src/im/feishu/bridge.ts
@@ -54,6 +54,8 @@ export interface FeishuBridgeOptions {
    *   - stderr logger otherwise (standalone smoke debugging).
    */
   onEvent?: (event: NormalizedIMEvent) => Promise<void>;
+  /** Fatal WS failure after initial readiness (for worker lifecycle ownership). */
+  onTerminalError?: (error: Error) => void;
 }
 
 // ── IPC contract with the agent-node parent (M3) ─────────────────────────
@@ -107,7 +109,7 @@ export async function startFeishuBridge(
 ): Promise<FeishuAdapter> {
   const channelConfig = loadFeishuChannelConfig(opts.channelDir);
 
-  const adapter = new FeishuAdapter();
+  const adapter = new FeishuAdapter({ onTerminalError: opts.onTerminalError });
   await adapter.init({
     platform: "feishu",
     connectionName: opts.nodeAlias,

--- a/agent-network/src/im/feishu/worker-lifecycle.ts
+++ b/agent-network/src/im/feishu/worker-lifecycle.ts
@@ -1,0 +1,19 @@
+interface WorkerProcessBoundary {
+  stderr: { write(message: string): unknown };
+  exit(code: number): unknown;
+}
+
+/**
+ * A terminal WS error means this worker no longer owns a live ingress path.
+ * Exit non-zero so the parent/supervisor cannot continue advertising it as
+ * healthy. Kept separate from worker.ts so the real exit contract is testable.
+ */
+export function exitFeishuWorker(
+  error: Error,
+  boundary: WorkerProcessBoundary = process,
+): void {
+  boundary.stderr.write(
+    `[feishu:worker] connection failed after ready: ${error.message}\n`,
+  );
+  boundary.exit(1);
+}

--- a/agent-network/src/im/feishu/worker.ts
+++ b/agent-network/src/im/feishu/worker.ts
@@ -27,6 +27,7 @@
  *   M5: agent-node spawn site that forks this worker (see agent-node/cli.ts).
  */
 import { startFeishuBridge } from "./bridge.js";
+import { exitFeishuWorker } from "./worker-lifecycle.js";
 
 interface ParsedArgs {
   channelDir?: string;
@@ -62,13 +63,16 @@ async function main(): Promise<void> {
     await startFeishuBridge({
       channelDir: args.channelDir,
       nodeAlias: args.nodeAlias,
+      onTerminalError: (error) => {
+        exitFeishuWorker(error);
+      },
     });
     process.stderr.write(
       `[feishu:worker] bridge online — node=${args.nodeAlias} dir=${args.channelDir}` +
         ` ipc=${typeof process.send === "function" ? "yes" : "no"}\n`,
     );
   } catch (err) {
-    const msg = err instanceof Error ? err.stack ?? err.message : String(err);
+    const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`[feishu:worker] startup failed: ${msg}\n`);
     process.exit(1);
   }

--- a/docs/tests/report-test617-feishu-ws-readiness.txt
+++ b/docs/tests/report-test617-feishu-ws-readiness.txt
@@ -1,0 +1,42 @@
+# test617 — Feishu WS readiness and worker health
+
+Date: 2026-08-09
+Issue: #452
+Source commit under test: 60de9b7ba9e62d4aaf5739fff8ad4e89b572c4c6
+Docker image: anet-test617:dev
+Docker image ID: sha256:27ce1562854a347a3f66343f2be3ad36cf83150991f03cad2b5e3c7c99028eb3
+Embedded ENV: TEST617_SOURCE_COMMIT=60de9b7ba9e62d4aaf5739fff8ad4e89b572c4c6
+
+Command:
+  sg docker -c 'docker run --rm -v <artifact-dir>:/artifacts anet-test617:dev'
+
+Result: PASS
+
+Layers:
+  L0 TypeScript typecheck: PASS
+  L1 lifecycle matrix: 7 pass / 0 fail / 18 assertions
+  L2 real Feishu worker bundle: PASS (worker.js generated, 2.29 MB)
+  L3 mutation — trust SDK start resolution instead of onReady: RED (rc=1)
+  L4 mutation — remove reconnecting connected=false transition: RED (rc=1)
+  L5 mutation — terminal worker exit 1 changed to exit 0: RED (rc=1)
+  L6 restored source lifecycle matrix: 7 pass / 0 fail / 18 assertions
+
+Behavior pinned:
+  - WSClient.start() resolving does not advertise the bridge online.
+  - Only the SDK onReady callback completes initial startup.
+  - Missing onReady is bounded by a 30-second production timeout and closes
+    the SDK client fail-closed.
+  - Initial onError rejects startup; credentials and multiline payloads are
+    removed from the surfaced error.
+  - onReconnecting immediately marks health disconnected; onReconnected
+    restores it.
+  - Terminal onError after readiness marks health disconnected and makes the
+    worker exit non-zero exactly once.
+  - stop() uses the public WSClient.close() API and invalidates late callbacks.
+
+Scope/limitations:
+  - The test uses the real pinned @larksuiteoapi/node-sdk types and builds the
+    real worker binary, but drives lifecycle callbacks with a deterministic
+    fake WS transport. No Feishu test App credential was available, so a live
+    Feishu handshake is not claimed.
+  - No production process, channel config, or global npm installation changed.

--- a/tests/test617-feishu-ws-readiness/Dockerfile
+++ b/tests/test617-feishu-ws-readiness/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json agent-network/package-lock.json ./agent-network/
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY tests/test617-feishu-ws-readiness ./tests/test617-feishu-ws-readiness
+
+ARG SOURCE_COMMIT
+ENV TEST617_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test617-feishu-ws-readiness/run.sh
+ENTRYPOINT ["/workspace/tests/test617-feishu-ws-readiness/run.sh"]

--- a/tests/test617-feishu-ws-readiness/run.sh
+++ b/tests/test617-feishu-ws-readiness/run.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test617-feishu-ws-readiness.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test617 — Feishu WS readiness and worker health"
+echo "source_commit=${TEST617_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_lifecycle() {
+  bun test agent-network/src/im/feishu/adapter-lifecycle.test.ts
+}
+
+echo "L0 environment + typecheck"
+bun --version
+cd /workspace/agent-network
+bun run typecheck
+cd /workspace
+
+echo "L1 lifecycle matrix"
+run_lifecycle
+
+echo "L2 real worker bundle"
+cd /workspace/agent-network
+bun run build
+cd /workspace
+test -s agent-network/dist/src/im/feishu/worker.js
+
+echo "L3 witnessed-red: SDK start promise must not impersonate readiness"
+cp agent-network/src/im/feishu/adapter.ts /tmp/test617-adapter.ts
+sed -i 's/^    await readyPromise;$/    return; \/\/ MUTATION: trust SDK start resolution/' \
+  agent-network/src/im/feishu/adapter.ts
+grep -Fq 'MUTATION: trust SDK start resolution' agent-network/src/im/feishu/adapter.ts
+set +e
+run_lifecycle >/tmp/test617-ready.log 2>&1
+ready_rc=$?
+set -e
+if [ "$ready_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: ready-authority"
+  exit 1
+fi
+grep -Fq 'missing onReady times out fail-closed' /tmp/test617-ready.log
+echo "MUTATION_RED: ready-authority rc=$ready_rc"
+cp /tmp/test617-adapter.ts agent-network/src/im/feishu/adapter.ts
+
+echo "L4 witnessed-red: reconnecting must lower health"
+sed -i '/onReconnecting: () => {/,/onReconnected: () => {/ {
+  /this.health_ = { ...this.health_, connected: false };/d
+}' agent-network/src/im/feishu/adapter.ts
+if sed -n '/onReconnecting: () => {/,/onReconnected: () => {/p' \
+  agent-network/src/im/feishu/adapter.ts | grep -Fq 'connected: false'; then
+  echo "FAIL: reconnect mutation did not apply"
+  exit 1
+fi
+set +e
+run_lifecycle >/tmp/test617-reconnect.log 2>&1
+reconnect_rc=$?
+set -e
+if [ "$reconnect_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: reconnect-health"
+  exit 1
+fi
+grep -Fq 'reconnecting lowers health' /tmp/test617-reconnect.log
+echo "MUTATION_RED: reconnect-health rc=$reconnect_rc"
+cp /tmp/test617-adapter.ts agent-network/src/im/feishu/adapter.ts
+
+echo "L5 witnessed-red: terminal worker failure must be non-zero"
+cp agent-network/src/im/feishu/worker-lifecycle.ts /tmp/test617-worker-lifecycle.ts
+sed -i 's/boundary.exit(1);/boundary.exit(0); \/\/ MUTATION/' \
+  agent-network/src/im/feishu/worker-lifecycle.ts
+grep -Fq 'boundary.exit(0); // MUTATION' agent-network/src/im/feishu/worker-lifecycle.ts
+set +e
+run_lifecycle >/tmp/test617-worker.log 2>&1
+worker_rc=$?
+set -e
+if [ "$worker_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: worker-nonzero-exit"
+  exit 1
+fi
+grep -Fq 'worker terminal owner logs safely and exits non-zero' /tmp/test617-worker.log
+echo "MUTATION_RED: worker-nonzero-exit rc=$worker_rc"
+cp /tmp/test617-worker-lifecycle.ts agent-network/src/im/feishu/worker-lifecycle.ts
+
+echo "L6 restored green"
+run_lifecycle
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #452

## What changed
- treat the Lark SDK `onReady` callback—not `WSClient.start()` resolution—as the initial online authority
- fail closed on initial auth/handshake error or a bounded 30s readiness timeout, with credential-safe errors
- mark health disconnected during reconnect and restore it only on `onReconnected`
- exit the worker non-zero if reconnect attempts terminate after readiness
- close the public SDK client on stop and ignore stale callbacks

## Evidence
- exact source: `60de9b7ba9e62d4aaf5739fff8ad4e89b572c4c6`
- report-only head: `abda7de8a6be525333789d01a002d89e3d0c5eb1`
- Docker: 7 tests / 18 assertions, real worker bundle PASS
- witnessed-red mutations: trusting start resolution, removing reconnect health downgrade, changing terminal exit 1 to exit 0
- report: `docs/tests/report-test617-feishu-ws-readiness.txt`

No production changes, npm publish, or live Feishu credential claim.