### PR TITLE
fix(cli): persist explicit Claude vendor environment

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -88,6 +88,7 @@ import {
   type GrokCopresenceSessionDisclosure,
 } from "../src/grok-copresence-disclosure";
 import { parseCliOptions, positionalArgs } from "../src/cli-args";
+import { collectClaudeVendorEnvForCreate } from "../src/claude-vendor-env";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -2873,7 +2874,10 @@ function rewritePlainSecretsToEnvRef(nodeId: string, profile: Profile): void {
     for (const { refName, value } of rewrites) merged[refName] = value;
     const body = Object.entries(merged).map(([k, v]) => `${k}=${v}`).join("\n") + "\n";
     if (isOpencode) writeOpencodePrivateProfileFile(nodeDir, ".env", body);
-    else writeFileSync(dotenvPath, body, { mode: 0o600 });
+    else {
+      writeFileSync(dotenvPath, body, { mode: 0o600 });
+      chmodSync(dotenvPath, 0o600);
+    }
     ensureNodeDotenvGitignore();
   } catch (e: any) {
     console.warn(`[anet] ⚠ could not write per-node .env: ${e?.message || e} — fall back to manual export only.`);
@@ -3819,6 +3823,21 @@ async function createCommand(idOverride?: string) {
         console.log(`[anet] 绑定已有 Claude session: ${picked.slice(0, 8)}…`);
       }
     }
+  }
+
+  // #453 — an explicit claude-agent-sdk create may intentionally inherit its
+  // vendor endpoint/credential from the current shell. Persist only the known
+  // Anthropic-compatible keys into the existing envRef path so a fresh shell
+  // can restart the node. Explicit --env values remain authoritative.
+  try {
+    opts._envs = collectClaudeVendorEnvForCreate({
+      runtime: normalizeRuntime(opts.runtime || "claude-agent-sdk"),
+      explicitEnv: opts._envs || [],
+      shellEnv: process.env,
+    });
+  } catch (error) {
+    console.error(`[anet] ❌ ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
   }
 
   const profile = createProfileFromOpts(id, opts);

--- a/agent-network/src/claude-vendor-env-wiring.test.ts
+++ b/agent-network/src/claude-vendor-env-wiring.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const cli = readFileSync(new URL("../bin/cli.ts", import.meta.url), "utf8");
+
+test("node create captures vendor shell env before profile construction", () => {
+  const call = cli.indexOf("opts._envs = collectClaudeVendorEnvForCreate({");
+  const profile = cli.indexOf("const profile = createProfileFromOpts(id, opts);", call);
+  expect(call).toBeGreaterThan(0);
+  expect(profile).toBeGreaterThan(call);
+  expect(cli.slice(call, profile)).toContain("shellEnv: process.env");
+});

--- a/agent-network/src/claude-vendor-env.test.ts
+++ b/agent-network/src/claude-vendor-env.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { collectClaudeVendorEnvForCreate } from "./claude-vendor-env.js";
+
+describe("collectClaudeVendorEnvForCreate", () => {
+  test("captures known vendor endpoint and credential for claude-agent-sdk", () => {
+    expect(collectClaudeVendorEnvForCreate({
+      runtime: "claude-agent-sdk",
+      explicitEnv: [],
+      shellEnv: {
+        ANTHROPIC_BASE_URL: "https://vendor.invalid/anthropic",
+        ANTHROPIC_AUTH_TOKEN: "secret-test-token",
+        UNRELATED_SECRET: "must-not-copy",
+      },
+    })).toEqual([
+      "ANTHROPIC_BASE_URL=https://vendor.invalid/anthropic",
+      "ANTHROPIC_AUTH_TOKEN=secret-test-token",
+    ]);
+  });
+
+  test("explicit --env value wins without duplicate capture", () => {
+    expect(collectClaudeVendorEnvForCreate({
+      runtime: "claude-agent-sdk",
+      explicitEnv: ["ANTHROPIC_BASE_URL=https://explicit.invalid/anthropic"],
+      shellEnv: {
+        ANTHROPIC_BASE_URL: "https://ambient.invalid/anthropic",
+        ANTHROPIC_API_KEY: "ambient-key",
+      },
+    })).toEqual([
+      "ANTHROPIC_BASE_URL=https://explicit.invalid/anthropic",
+      "ANTHROPIC_API_KEY=ambient-key",
+    ]);
+  });
+
+  test("does not capture vendor variables for another runtime", () => {
+    expect(collectClaudeVendorEnvForCreate({
+      runtime: "codex-sdk",
+      explicitEnv: ["KEEP=explicit"],
+      shellEnv: { ANTHROPIC_AUTH_TOKEN: "ambient-key" },
+    })).toEqual(["KEEP=explicit"]);
+  });
+
+  test("rejects line-oriented dotenv injection", () => {
+    expect(() => collectClaudeVendorEnvForCreate({
+      runtime: "claude-agent-sdk",
+      explicitEnv: [],
+      shellEnv: { ANTHROPIC_AUTH_TOKEN: "safe\nINJECTED=value" },
+    })).toThrow("contains a line break");
+  });
+});

--- a/agent-network/src/claude-vendor-env.ts
+++ b/agent-network/src/claude-vendor-env.ts
@@ -1,0 +1,37 @@
+export const CLAUDE_VENDOR_ENV_KEYS = [
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_API_KEY",
+] as const;
+
+/**
+ * Persist the exact Anthropic-compatible vendor environment used by an
+ * explicit claude-agent-sdk create. Explicit --env values retain precedence;
+ * ambient shell values only fill missing known keys. Other environment values
+ * are intentionally ignored so node create never snapshots the whole shell.
+ */
+export function collectClaudeVendorEnvForCreate(input: {
+  runtime: string;
+  explicitEnv: readonly string[];
+  shellEnv: Readonly<Record<string, string | undefined>>;
+}): string[] {
+  const out = [...input.explicitEnv];
+  if (input.runtime !== "claude-agent-sdk") return out;
+
+  const explicitKeys = new Set(
+    out.map((entry) => {
+      const eq = entry.indexOf("=");
+      return eq > 0 ? entry.slice(0, eq) : "";
+    }),
+  );
+  for (const key of CLAUDE_VENDOR_ENV_KEYS) {
+    if (explicitKeys.has(key)) continue;
+    const value = input.shellEnv[key];
+    if (value === undefined || value === "") continue;
+    if (/[\r\n]/.test(value)) {
+      throw new Error(`${key} contains a line break and cannot be persisted safely`);
+    }
+    out.push(`${key}=${value}`);
+  }
+  return out;
+}

--- a/docs/tests/report-test618-claude-vendor-env.txt
+++ b/docs/tests/report-test618-claude-vendor-env.txt
@@ -1,0 +1,41 @@
+# test618 — explicit claude-agent-sdk vendor env persistence
+
+Date: 2026-08-09
+Issue: #453
+Source commit: f082c87d0b2f25f1b631d40a34dfa8c80aa22a6e
+Docker image: anet-test618:dev
+Image ID: sha256:1c71222b1655f0bdc5f661efb18a97651b1e90e21cc582677c5299547e7a312e
+Embedded ENV: TEST618_SOURCE_COMMIT=f082c87d0b2f25f1b631d40a34dfa8c80aa22a6e
+
+Result: PASS (container rc=0)
+
+Layers:
+- L0 TypeScript + helper/wiring contracts: 5 pass, 0 fail, 7 assertions;
+  full production CLI build passed.
+- L1 isolated real Hub + built CLI: registered/logged in an isolated owner,
+  then `node create --runtime claude-agent-sdk --model vendor-model` inherited
+  an Anthropic-compatible endpoint and non-production credential from its
+  creation shell.
+- L2 persistence/security: config retained runtime/model/endpoint; credential
+  was absent as plaintext and represented by `_envRef`; per-node `.env` existed
+  with mode 0600.
+- L3 fresh-shell start: all original `ANTHROPIC_*` variables were unset before
+  `node start`. A controlled agent-node boundary confirmed that both endpoint
+  and credential were loaded from the node store.
+- L4 witnessed-red: disconnecting the CLI collection assignment from
+  `opts._envs` made the wiring test fail (rc=1).
+- L5 restored source: 5 pass, 0 fail, 7 assertions.
+
+Additional contracts:
+- Explicit `--env KEY=value` wins over an ambient value of the same key.
+- Only the three known Anthropic-compatible vendor keys are captured; unrelated
+  shell secrets and other runtimes are not snapshotted.
+- CR/LF-bearing values fail before profile construction to prevent dotenv line
+  injection.
+- Existing dotenv files are chmod-verified to 0600 after write, not merely
+  created with a mode hint.
+
+No real vendor credential or model request was used. The acceptance boundary
+proven here is create -> unset/new shell -> start env loading; actual vendor
+availability is intentionally outside this deterministic regression suite.
+No production, global npm installation, or host configuration was changed.

--- a/tests/test618-claude-vendor-env/Dockerfile
+++ b/tests/test618-claude-vendor-env/Dockerfile
@@ -1,0 +1,19 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY server/package.json ./server/
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+
+COPY agent-network/package.json agent-network/package-lock.json ./agent-network/
+RUN cd agent-network && bun install --ignore-scripts
+COPY agent-network ./agent-network
+COPY tests/test618-claude-vendor-env ./tests/test618-claude-vendor-env
+
+ARG SOURCE_COMMIT
+ENV TEST618_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 tests/test618-claude-vendor-env/run.sh tests/test618-claude-vendor-env/fake-agent-node.sh
+ENTRYPOINT ["/workspace/tests/test618-claude-vendor-env/run.sh"]

--- a/tests/test618-claude-vendor-env/fake-agent-node.sh
+++ b/tests/test618-claude-vendor-env/fake-agent-node.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  echo "agent-node v2.5.0-preview.30"
+  exit 0
+fi
+if [[ "${1:-}" == "--help" ]]; then
+  echo "agent-node --config --alias --runtime"
+  exit 0
+fi
+
+[[ "${ANTHROPIC_BASE_URL:-}" == "https://vendor.invalid/anthropic" ]]
+[[ "${ANTHROPIC_AUTH_TOKEN:-}" == "test618-not-a-real-secret" ]]
+[[ -n "${TEST618_CAPTURE:-}" ]]
+printf 'vendor-env-loaded\n' > "$TEST618_CAPTURE"

--- a/tests/test618-claude-vendor-env/run.sh
+++ b/tests/test618-claude-vendor-env/run.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test618-claude-vendor-env.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test618 — explicit claude-agent-sdk vendor env persistence"
+echo "source_commit=${TEST618_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+echo "L0 typecheck + helper contracts"
+cd /workspace/agent-network
+bun run typecheck
+bun test src/claude-vendor-env.test.ts src/claude-vendor-env-wiring.test.ts
+bun run build >/tmp/test618-build.log
+cd /workspace
+
+echo "L1 isolated real Hub + built CLI create"
+export HOME=/tmp/test618-home
+export COMMHUB_DB=/tmp/test618-hub.db
+export PORT=9618
+mkdir -p "$HOME" /tmp/test618-project /tmp/test618-bin
+cp tests/test618-claude-vendor-env/fake-agent-node.sh /tmp/test618-bin/agent-node
+chmod 0755 /tmp/test618-bin/agent-node
+PATH="/tmp/test618-bin:$PATH" bun run server/src/index.ts >/tmp/test618-hub.log 2>&1 &
+hub_pid=$!
+trap 'kill "$hub_pid" 2>/dev/null || true' EXIT
+for _ in $(seq 1 50); do
+  if curl -fsS http://127.0.0.1:9618/health >/dev/null; then break; fi
+  sleep 0.1
+done
+curl -fsS http://127.0.0.1:9618/health | grep -Fq '"ok":true'
+curl -fsS -X POST http://127.0.0.1:9618/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"anethub"}' | grep -Fq '"ok":true'
+
+ANET=(bun /workspace/agent-network/dist/bin/cli.js)
+"${ANET[@]}" login --hub http://127.0.0.1:9618 --username admin --password anethub \
+  >/tmp/test618-login.log
+cd /tmp/test618-project
+export ANTHROPIC_BASE_URL=https://vendor.invalid/anthropic
+export ANTHROPIC_AUTH_TOKEN=test618-not-a-real-secret
+PATH="/tmp/test618-bin:$PATH" "${ANET[@]}" node create vendor-node \
+  --runtime claude-agent-sdk --model vendor-model >/tmp/test618-create.log
+
+echo "L2 config/envRef/permissions"
+CONFIG=.anet/nodes/vendor-node/config.json
+DOTENV=.anet/nodes/vendor-node/.env
+test -f "$CONFIG"
+test -f "$DOTENV"
+test "$(stat -c %a "$DOTENV")" = 600
+bun -e '
+  const c = await Bun.file(process.argv[1]).json();
+  if (c.runtime !== "claude-agent-sdk" || c.model !== "vendor-model") process.exit(1);
+  if (c.env?.ANTHROPIC_BASE_URL !== "https://vendor.invalid/anthropic") process.exit(2);
+  const ref = c.env?.ANTHROPIC_AUTH_TOKEN?._envRef;
+  if (typeof ref !== "string" || !ref.startsWith("ANTHROPIC_AUTH_TOKEN_")) process.exit(3);
+  if (JSON.stringify(c).includes("test618-not-a-real-secret")) process.exit(4);
+' "$CONFIG"
+grep -Fq 'test618-not-a-real-secret' "$DOTENV"
+
+echo "L3 fresh-shell start auto-loads vendor env"
+unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY
+export TEST618_CAPTURE=/tmp/test618-agent-capture
+PATH="/tmp/test618-bin:$PATH" "${ANET[@]}" node start vendor-node >/tmp/test618-start.log
+grep -Fxq 'vendor-env-loaded' "$TEST618_CAPTURE"
+
+echo "L4 witnessed-red: disconnect create wiring"
+cp /workspace/agent-network/bin/cli.ts /tmp/test618-cli.ts
+sed -i 's/opts\._envs = collectClaudeVendorEnvForCreate({/const disconnectedVendorEnv = collectClaudeVendorEnvForCreate({/' \
+  /workspace/agent-network/bin/cli.ts
+grep -Fq 'const disconnectedVendorEnv = collectClaudeVendorEnvForCreate({' \
+  /workspace/agent-network/bin/cli.ts
+set +e
+bun test /workspace/agent-network/src/claude-vendor-env-wiring.test.ts \
+  >/tmp/test618-wiring-red.log 2>&1
+wiring_rc=$?
+set -e
+if [[ "$wiring_rc" -eq 0 ]]; then
+  echo "MUTATION_FALSE_GREEN: create-vendor-env-wiring"
+  exit 1
+fi
+grep -Fq 'node create captures vendor shell env before profile construction' \
+  /tmp/test618-wiring-red.log
+echo "MUTATION_RED: create-vendor-env-wiring rc=$wiring_rc"
+cp /tmp/test618-cli.ts /workspace/agent-network/bin/cli.ts
+
+echo "L5 restored helper contracts"
+bun test /workspace/agent-network/src/claude-vendor-env.test.ts \
+  /workspace/agent-network/src/claude-vendor-env-wiring.test.ts
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #453

## What changed
- persist known `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_API_KEY` shell values when creating a `claude-agent-sdk` node
- keep explicit `--env` values authoritative and never snapshot unrelated shell variables
- reuse the existing envRef/per-node `.env` path; re-assert mode 0600 after writes
- reject CR/LF-bearing values before profile construction

## Evidence
- source: `f082c87d0b2f25f1b631d40a34dfa8c80aa22a6e`
- report-only head: `84c43678dba41b7ee40183e45b613fd9e787f3a6`
- exact-SHA Docker rc=0: real isolated Hub + built CLI create, unset all original `ANTHROPIC_*`, fresh-shell start through a controlled agent-node boundary
- config plaintext-secret absence, `_envRef`, endpoint persistence, and `.env` mode 0600 asserted
- 5 helper/wiring tests; disconnected-wiring mutation red
- report: `docs/tests/report-test618-claude-vendor-env.txt`

No real vendor credential/model request, production change, npm publish, or deployment.