### PR TITLE
test(opencode): isolate hold-open lifecycle layer (#458)

### DIFF
--- a/docs/tests/report-test621-test384-layer-isolation.txt
+++ b/docs/tests/report-test621-test384-layer-isolation.txt
@@ -1,0 +1,45 @@
+# test621 — test384 hold-open layer isolation
+
+Date: 2026-08-09
+Issue: #458
+Source commit: 2ff5921fab8e460eacde933da23e4546ea5f9f76
+Docker tag: anet-test621:dev
+Docker image: sha256:dd51856cfaa6fa1c43c2ffc1e0470b65c5a393a76dab8246e8c3abf6bc48ea81
+Embedded source: TEST621_SOURCE_COMMIT=2ff5921fab8e460eacde933da23e4546ea5f9f76
+Runner artifact SHA256: ad6bdfb4f7e9ae47bd6acc7bc4f5f27786feb5012c153384d53a8d8a93904a4e
+
+## Adjudication
+
+An inbox row is acknowledged only after its model turn and reliable reply
+handoff. If the node exits while the turn is still open, the unacknowledged
+row remains eligible for at-least-once delivery after restart. That product
+behavior is intentional. The `pending-replies: dropped` warning is emitted by
+the separate outbound reply retry queue and does not mean the inbound task was
+dropped or dispatched twice.
+
+The defect in #458 was test orchestration: test384 L5 intentionally stopped a
+node during an unresolved initialize request, then allowed that layer's
+unacknowledged task to enter later layers. The fix cancels the exact L5 task
+after process/orphan cleanup and verifies both terminal `cancelled` state and
+absence from the inbox before L5.5/L6.
+
+## Docker result
+
+```text
+# test621 — test384 hold-open layer isolation
+source_commit=2ff5921fab8e460eacde933da23e4546ea5f9f76
+date=2026-08-09T10:37:41+00:00
+L0 syntax + orchestration contract
+L1 real Hub cancellation removes the unacked row before restart
+L2 witnessed-red: deleting the layer cancellation must fail
+MUTATION_RED: hold-open-layer-cancel rc=1
+RESULT: PASS
+```
+
+L1 used a real isolated Hub process and SQLite database. It created an unacked
+task, observed it in the target inbox, cancelled it through the real MCP tool,
+verified the task was terminal, and verified two subsequent inbox pulls did
+not return the row. L2 removed the exact test384 layer-boundary cancellation;
+the orchestration contract failed non-zero.
+
+No production service, database, node, package, or global install was touched.

--- a/tests/test384-opencode-local-package-e2e/run.sh
+++ b/tests/test384-opencode-local-package-e2e/run.sh
@@ -186,6 +186,40 @@ submit_task() {
   [[ -n "$TASK_ID" ]]
 }
 
+mcp_call() {
+  local tool_name="$1"
+  local tool_args="$2"
+  local body
+  body=$(jq -nc --arg name "$tool_name" --argjson args "$tool_args" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:$name,arguments:$args}}')
+  curl -fsS -X POST "$HUB/mcp" \
+    -H "Authorization: Bearer $USER_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -H 'MCP-Protocol-Version: 2025-03-26' \
+    --data "$body" \
+    | sed -n 's/^data: //p' | head -1 \
+    | jq -r '.result.content[0].text // empty'
+}
+
+cancel_layer_task() {
+  local task_id="$1"
+  local cancel_result inbox_result
+  cancel_result=$(mcp_call cancel_task "$(jq -nc --arg id "$task_id" --arg network "$NETWORK_ID" \
+    '{task_id:$id,reason:"test384 layer teardown",from_session:"test384",network_id:$network}')")
+  jq -e '.ok == true and .cancelled == true' <<<"$cancel_result" >/dev/null
+
+  # Cancellation is the layer boundary: it must also acknowledge the inbox
+  # row, otherwise the next node start can legitimately redeliver it under
+  # the Hub's at-least-once contract and make a later layer model-dependent.
+  inbox_result=$(mcp_call get_inbox "$(jq -nc --arg alias "$LIVE_ALIAS" '{alias:$alias,limit:100}')")
+  jq -e --arg id "$task_id" \
+    '.ok == true and all(.messages[]?; .id != $id)' <<<"$inbox_result" >/dev/null
+  curl -fsS "$HUB/api/tasks?task_id=$task_id&network_id=$NETWORK_ID" \
+    -H "Authorization: Bearer $USER_TOKEN" \
+    | jq -e '.tasks[0].status == "cancelled"' >/dev/null
+}
+
 wait_task_replied() {
   local expected_text="${1:-}"
   TASK_ROW=""
@@ -788,11 +822,13 @@ echo "PASS: child that rejected initialize and stayed alive was explicitly reape
 
 start_fake_node hang "$ROOT/node-fake-hang.log"
 submit_task "Hold the ACP initialize request open until supervisor shutdown."
+HOLD_OPEN_TASK_ID="$TASK_ID"
 wait_fake_started hang
 stop_node
 wait_fake_gone hang
 assert_no_opencode_transient_roots "$OPENAI_NODE"
-echo "PASS: SIGTERM during unresolved initialize reaped agent-node + opening OpenCode child"
+cancel_layer_task "$HOLD_OPEN_TASK_ID"
+echo "PASS: SIGTERM during unresolved initialize reaped agent-node + opening OpenCode child; layer task cancelled and absent from inbox"
 
 CURRENT_LAYER="L5.5 external safe-base ancestor candidate pre-spawn refusal"
 echo

--- a/tests/test621-test384-layer-isolation/Dockerfile
+++ b/tests/test621-test384-layer-isolation/Dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:1.3.14
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash curl jq \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test384-opencode-local-package-e2e/run.sh ./tests/test384-opencode-local-package-e2e/run.sh
+COPY tests/test621-test384-layer-isolation ./tests/test621-test384-layer-isolation
+
+ARG SOURCE_COMMIT
+ENV TEST621_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test621-test384-layer-isolation/run.sh
+ENTRYPOINT ["/workspace/tests/test621-test384-layer-isolation/run.sh"]

--- a/tests/test621-test384-layer-isolation/README.md
+++ b/tests/test621-test384-layer-isolation/README.md
@@ -1,0 +1,12 @@
+# test621 — test384 hold-open layer isolation
+
+This narrow suite pins the adjudication for issue #458:
+
+- an inbox task that is not acknowledged before process shutdown is eligible
+  for at-least-once delivery after restart;
+- test384 must therefore cancel its intentional L5 hold-open task before L6;
+- cancellation must make the task terminal and acknowledge the inbox row;
+- removing the layer-boundary cancellation is a witnessed-red mutation.
+
+It uses an isolated real Hub and SQLite database. It does not contact or
+modify production.

--- a/tests/test621-test384-layer-isolation/run.sh
+++ b/tests/test621-test384-layer-isolation/run.sh
@@ -80,10 +80,11 @@ REGISTER=$(curl -fsS -X POST "$HUB/api/auth/register" \
   -H 'Content-Type: application/json' \
   --data '{"username":"test621","password":"Test621-Strong-Password!"}')
 TOKEN=$(jq -r '.token' <<<"$REGISTER")
+NODE_TOKEN=$(jq -r '.network_token' <<<"$REGISTER")
 NETWORK=$(jq -r '.network_id' <<<"$REGISTER")
-[[ "$TOKEN" == utok_* && "$NETWORK" == net_* ]]
+[[ "$TOKEN" == utok_* && "$NODE_TOKEN" == ntok_* && "$NETWORK" == net_* ]]
 
-STATUS=$(mcp_call "$TOKEN" report_status "$(jq -nc --arg net "$NETWORK" \
+STATUS=$(mcp_call "$NODE_TOKEN" report_status "$(jq -nc --arg net "$NETWORK" \
   '{resume_id:"test621-resume",alias:"test621-node",status:"idle",network_id:$net}')")
 jq -e '.ok == true' <<<"$STATUS" >/dev/null
 
@@ -94,14 +95,14 @@ DISPATCH=$(curl -fsS -X POST "$HUB/api/task" \
 TASK_ID=$(jq -r '.task_id // .message_id // empty' <<<"$DISPATCH")
 [[ -n "$TASK_ID" ]]
 
-BEFORE=$(mcp_call "$TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
+BEFORE=$(mcp_call "$NODE_TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
 jq -e --arg id "$TASK_ID" 'any(.messages[]?; .id == $id)' <<<"$BEFORE" >/dev/null
 
 CANCEL=$(mcp_call "$TOKEN" cancel_task "$(jq -nc --arg id "$TASK_ID" --arg net "$NETWORK" \
   '{task_id:$id,reason:"test621 layer teardown",from_session:"test621",network_id:$net}')")
 jq -e '.ok == true and .cancelled == true' <<<"$CANCEL" >/dev/null
 
-AFTER=$(mcp_call "$TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
+AFTER=$(mcp_call "$NODE_TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
 jq -e --arg id "$TASK_ID" 'all(.messages[]?; .id != $id)' <<<"$AFTER" >/dev/null
 curl -fsS "$HUB/api/tasks?task_id=$TASK_ID&network_id=$NETWORK" \
   -H "Authorization: Bearer $TOKEN" \
@@ -109,7 +110,7 @@ curl -fsS "$HUB/api/tasks?task_id=$TASK_ID&network_id=$NETWORK" \
 
 # A second pull models the fresh process reconnect. The row remains absent;
 # cancel_task closed both the task lifecycle and its inbox delivery.
-RESTART_PULL=$(mcp_call "$TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
+RESTART_PULL=$(mcp_call "$NODE_TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
 jq -e --arg id "$TASK_ID" 'all(.messages[]?; .id != $id)' <<<"$RESTART_PULL" >/dev/null
 
 echo "L2 witnessed-red: deleting the layer cancellation must fail"

--- a/tests/test621-test384-layer-isolation/run.sh
+++ b/tests/test621-test384-layer-isolation/run.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test621-test384-layer-isolation.txt"
+HUB=http://127.0.0.1:9621
+DB=/tmp/test621.db
+HUB_PID=""
+mkdir -p "$ARTIFACT_DIR"
+: >"$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+cleanup() {
+  if [[ -n "$HUB_PID" ]] && kill -0 "$HUB_PID" 2>/dev/null; then
+    kill -TERM "$HUB_PID" 2>/dev/null || true
+    wait "$HUB_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+mcp_call() {
+  local token="$1" tool_name="$2" tool_args="$3"
+  local body
+  body=$(jq -nc --arg name "$tool_name" --argjson args "$tool_args" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:$name,arguments:$args}}')
+  curl -fsS -X POST "$HUB/mcp" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -H 'MCP-Protocol-Version: 2025-03-26' \
+    --data "$body" \
+    | sed -n 's/^data: //p' | head -1 \
+    | jq -r '.result.content[0].text // empty'
+}
+
+assert_script_boundary() {
+  local script=$1
+  local start_line capture_line stop_line cancel_line end_line
+  start_line=$(grep -n '^start_fake_node hang ' "$script" | cut -d: -f1) \
+    || { echo 'missing start_fake_node hang'; return 1; }
+  capture_line=$(grep -n '^HOLD_OPEN_TASK_ID="\$TASK_ID"$' "$script" | cut -d: -f1) \
+    || { echo 'missing HOLD_OPEN_TASK_ID capture'; return 1; }
+  stop_line=$(tail -n "+$start_line" "$script" | grep -n '^stop_node$' | head -1 | cut -d: -f1) \
+    || { echo 'missing exact stop_node after hold-open start'; return 1; }
+  stop_line=$((start_line + stop_line - 1))
+  cancel_line=$(grep -n '^cancel_layer_task "\$HOLD_OPEN_TASK_ID"$' "$script" | cut -d: -f1) \
+    || { echo 'missing cancel_layer_task boundary'; return 1; }
+  end_line=$(tail -n "+$start_line" "$script" | grep -n '^CURRENT_LAYER="L5.5 ' | head -1 | cut -d: -f1) \
+    || { echo 'missing L5.5 boundary'; return 1; }
+  end_line=$((start_line + end_line - 1))
+  [[ "$start_line" -lt "$capture_line" \
+    && "$capture_line" -lt "$stop_line" \
+    && "$stop_line" -lt "$cancel_line" \
+    && "$cancel_line" -lt "$end_line" ]] \
+    || { echo 'hold-open teardown ordering regressed'; return 1; }
+  grep -Fq 'all(.messages[]?; .id != $id)' "$script" \
+    || { echo 'missing cancelled-inbox absence assertion'; return 1; }
+}
+
+echo "# test621 — test384 hold-open layer isolation"
+echo "source_commit=${TEST621_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+echo "L0 syntax + orchestration contract"
+bash -n tests/test384-opencode-local-package-e2e/run.sh
+assert_script_boundary tests/test384-opencode-local-package-e2e/run.sh
+
+echo "L1 real Hub cancellation removes the unacked row before restart"
+COMMHUB_DB="$DB" HOST=127.0.0.1 PORT=9621 \
+  bun run server/bin/commhub.ts --port 9621 --host 127.0.0.1 --db "$DB" \
+  >/tmp/test621-hub.log 2>&1 &
+HUB_PID=$!
+for _ in $(seq 1 100); do
+  curl -fsS "$HUB/health" >/dev/null 2>&1 && break
+  sleep 0.1
+done
+curl -fsS "$HUB/health" | jq -e '.ok == true' >/dev/null
+
+REGISTER=$(curl -fsS -X POST "$HUB/api/auth/register" \
+  -H 'Content-Type: application/json' \
+  --data '{"username":"test621","password":"Test621-Strong-Password!"}')
+TOKEN=$(jq -r '.token' <<<"$REGISTER")
+NETWORK=$(jq -r '.network_id' <<<"$REGISTER")
+[[ "$TOKEN" == utok_* && "$NETWORK" == net_* ]]
+
+STATUS=$(mcp_call "$TOKEN" report_status "$(jq -nc --arg net "$NETWORK" \
+  '{resume_id:"test621-resume",alias:"test621-node",status:"idle",network_id:$net}')")
+jq -e '.ok == true' <<<"$STATUS" >/dev/null
+
+DISPATCH=$(curl -fsS -X POST "$HUB/api/task" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  --data "$(jq -nc --arg net "$NETWORK" \
+    '{alias:"test621-node",task:"hold-open",priority:"normal",network_id:$net}')")
+TASK_ID=$(jq -r '.task_id // .message_id // empty' <<<"$DISPATCH")
+[[ -n "$TASK_ID" ]]
+
+BEFORE=$(mcp_call "$TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
+jq -e --arg id "$TASK_ID" 'any(.messages[]?; .id == $id)' <<<"$BEFORE" >/dev/null
+
+CANCEL=$(mcp_call "$TOKEN" cancel_task "$(jq -nc --arg id "$TASK_ID" --arg net "$NETWORK" \
+  '{task_id:$id,reason:"test621 layer teardown",from_session:"test621",network_id:$net}')")
+jq -e '.ok == true and .cancelled == true' <<<"$CANCEL" >/dev/null
+
+AFTER=$(mcp_call "$TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
+jq -e --arg id "$TASK_ID" 'all(.messages[]?; .id != $id)' <<<"$AFTER" >/dev/null
+curl -fsS "$HUB/api/tasks?task_id=$TASK_ID&network_id=$NETWORK" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -e '.tasks[0].status == "cancelled"' >/dev/null
+
+# A second pull models the fresh process reconnect. The row remains absent;
+# cancel_task closed both the task lifecycle and its inbox delivery.
+RESTART_PULL=$(mcp_call "$TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
+jq -e --arg id "$TASK_ID" 'all(.messages[]?; .id != $id)' <<<"$RESTART_PULL" >/dev/null
+
+echo "L2 witnessed-red: deleting the layer cancellation must fail"
+cp tests/test384-opencode-local-package-e2e/run.sh /tmp/test621-mutated.sh
+sed -i '/^cancel_layer_task "\$HOLD_OPEN_TASK_ID"$/d' /tmp/test621-mutated.sh
+if grep -Fq 'cancel_layer_task "$HOLD_OPEN_TASK_ID"' /tmp/test621-mutated.sh; then
+  echo "MUTATION_NOT_APPLIED"
+  exit 1
+fi
+set +e
+assert_script_boundary /tmp/test621-mutated.sh >/tmp/test621-mutated.log 2>&1
+MUTATION_RC=$?
+set -e
+if [[ "$MUTATION_RC" -eq 0 ]]; then
+  echo "MUTATION_FALSE_GREEN: hold-open-layer-cancel"
+  exit 1
+fi
+grep -Fq 'missing cancel_layer_task boundary' /tmp/test621-mutated.log
+echo "MUTATION_RED: hold-open-layer-cancel rc=$MUTATION_RC"
+
+echo "RESULT: PASS"

--- a/tests/test621-test384-layer-isolation/run.sh
+++ b/tests/test621-test384-layer-isolation/run.sh
@@ -85,24 +85,24 @@ NETWORK=$(jq -r '.network_id' <<<"$REGISTER")
 [[ "$TOKEN" == utok_* && "$NODE_TOKEN" == ntok_* && "$NETWORK" == net_* ]]
 
 STATUS=$(mcp_call "$NODE_TOKEN" report_status "$(jq -nc --arg net "$NETWORK" \
-  '{resume_id:"test621-resume",alias:"test621-node",status:"idle",network_id:$net}')")
+  '{resume_id:"test621-resume",alias:"test621",status:"idle",network_id:$net}')")
 jq -e '.ok == true' <<<"$STATUS" >/dev/null
 
 DISPATCH=$(curl -fsS -X POST "$HUB/api/task" \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
   --data "$(jq -nc --arg net "$NETWORK" \
-    '{alias:"test621-node",task:"hold-open",priority:"normal",network_id:$net}')")
+    '{alias:"test621",task:"hold-open",priority:"normal",network_id:$net}')")
 TASK_ID=$(jq -r '.task_id // .message_id // empty' <<<"$DISPATCH")
 [[ -n "$TASK_ID" ]]
 
-BEFORE=$(mcp_call "$NODE_TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
+BEFORE=$(mcp_call "$NODE_TOKEN" get_inbox '{"alias":"test621","limit":100}')
 jq -e --arg id "$TASK_ID" 'any(.messages[]?; .id == $id)' <<<"$BEFORE" >/dev/null
 
 CANCEL=$(mcp_call "$TOKEN" cancel_task "$(jq -nc --arg id "$TASK_ID" --arg net "$NETWORK" \
   '{task_id:$id,reason:"test621 layer teardown",from_session:"test621",network_id:$net}')")
 jq -e '.ok == true and .cancelled == true' <<<"$CANCEL" >/dev/null
 
-AFTER=$(mcp_call "$NODE_TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
+AFTER=$(mcp_call "$NODE_TOKEN" get_inbox '{"alias":"test621","limit":100}')
 jq -e --arg id "$TASK_ID" 'all(.messages[]?; .id != $id)' <<<"$AFTER" >/dev/null
 curl -fsS "$HUB/api/tasks?task_id=$TASK_ID&network_id=$NETWORK" \
   -H "Authorization: Bearer $TOKEN" \
@@ -110,7 +110,7 @@ curl -fsS "$HUB/api/tasks?task_id=$TASK_ID&network_id=$NETWORK" \
 
 # A second pull models the fresh process reconnect. The row remains absent;
 # cancel_task closed both the task lifecycle and its inbox delivery.
-RESTART_PULL=$(mcp_call "$NODE_TOKEN" get_inbox '{"alias":"test621-node","limit":100}')
+RESTART_PULL=$(mcp_call "$NODE_TOKEN" get_inbox '{"alias":"test621","limit":100}')
 jq -e --arg id "$TASK_ID" 'all(.messages[]?; .id != $id)' <<<"$RESTART_PULL" >/dev/null
 
 echo "L2 witnessed-red: deleting the layer cancellation must fail"


### PR DESCRIPTION
## Summary
- adjudicate unacked task redelivery after restart as intentional at-least-once semantics
- cancel test384 L5 hold-open task after exact process/orphan cleanup and prove it is terminal + absent from inbox before L6
- add isolated real-Hub Docker test with a witnessed-red removal mutation

## Verification
- exact source: `2ff5921fab8e460eacde933da23e4546ea5f9f76`
- report-only head: `cd78b39e902a63889f0f463c37e8eec2c8d3ec92`
- `anet-test621:dev`: `RESULT: PASS`
- real isolated Hub + SQLite cancellation/restart pull
- removing `cancel_layer_task "$HOLD_OPEN_TASK_ID"` turns red (`rc=1`)

Closes #458

No production changes, package publish, or deployment.