### PR TITLE
fix(feishu): scrub access tokens and gate reconnect health (#618)

### DIFF
--- a/agent-network/src/im/feishu/adapter-lifecycle.test.ts
+++ b/agent-network/src/im/feishu/adapter-lifecycle.test.ts
@@ -120,17 +120,18 @@ describe("FeishuAdapter WS lifecycle", () => {
   });
 
   test("initial onError scrubs arbitrary Lark access-token shapes", async () => {
+    const jwt = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0NjE4In0.SIG";
     const h = harness();
     await h.adapter.init(config());
     const starting = h.adapter.start(onEvent);
     await Bun.sleep(1);
     h.params?.onError?.(new Error(
       "Bearer bearer-token-618 a-application-token-618 t-tenant-token-618 " +
-      "u-user-token-618 T-UPPERCASE-TOKEN-618 cli_other-app-618 t-shirts u-boat",
+      `u-user-token-618 T-UPPERCASE-TOKEN-618 cli_other-app-618 ${jwt} t-shirts u-boat`,
     ));
 
     await expect(starting).rejects.toThrow(
-      "Bearer [redacted] [redacted] [redacted] [redacted] [redacted] [redacted] t-shirts u-boat",
+      "Bearer [redacted] [redacted] [redacted] [redacted] [redacted] [redacted] [redacted] t-shirts u-boat",
     );
     const lastError = h.adapter.health().lastError ?? "";
     for (const secret of [
@@ -140,6 +141,7 @@ describe("FeishuAdapter WS lifecycle", () => {
       "u-user-token-618",
       "T-UPPERCASE-TOKEN-618",
       "cli_other-app-618",
+      jwt,
     ]) {
       expect(lastError).not.toContain(secret);
     }

--- a/agent-network/src/im/feishu/adapter-lifecycle.test.ts
+++ b/agent-network/src/im/feishu/adapter-lifecycle.test.ts
@@ -125,17 +125,20 @@ describe("FeishuAdapter WS lifecycle", () => {
     const starting = h.adapter.start(onEvent);
     await Bun.sleep(1);
     h.params?.onError?.(new Error(
-      "Bearer bearer-token-618 t-tenant-token-618 u-user-token-618 cli_other-app-618",
+      "Bearer bearer-token-618 a-application-token-618 t-tenant-token-618 " +
+      "u-user-token-618 T-UPPERCASE-TOKEN-618 cli_other-app-618 t-shirts u-boat",
     ));
 
     await expect(starting).rejects.toThrow(
-      "Bearer [redacted] [redacted] [redacted] [redacted]",
+      "Bearer [redacted] [redacted] [redacted] [redacted] [redacted] [redacted] t-shirts u-boat",
     );
     const lastError = h.adapter.health().lastError ?? "";
     for (const secret of [
       "bearer-token-618",
+      "a-application-token-618",
       "t-tenant-token-618",
       "u-user-token-618",
+      "T-UPPERCASE-TOKEN-618",
       "cli_other-app-618",
     ]) {
       expect(lastError).not.toContain(secret);
@@ -160,7 +163,7 @@ describe("FeishuAdapter WS lifecycle", () => {
     (inboundConfig.platformConfig as { access: { allowFrom: string[] } }).access.allowFrom = ["ou_test"];
     await h.adapter.init(inboundConfig);
     const starting = h.adapter.start(async () => {
-      throw new Error("inbound t-inbound-token-618 Bearer inbound-bearer-618");
+      throw new Error("inbound a-inbound-token-618 Bearer inbound-bearer-618");
     });
     await Bun.sleep(1);
     h.params?.onReady?.();

--- a/agent-network/src/im/feishu/adapter-lifecycle.test.ts
+++ b/agent-network/src/im/feishu/adapter-lifecycle.test.ts
@@ -3,6 +3,7 @@ import type * as lark from "@larksuiteoapi/node-sdk";
 
 import {
   FeishuAdapter,
+  type FeishuEventDispatcherLike,
   type FeishuWsClientFactory,
   type FeishuWsClientLike,
 } from "./adapter.js";
@@ -54,6 +55,7 @@ function harness(options: {
   terminal?: (error: Error) => void;
 } = {}) {
   let params: WsParams | undefined;
+  let inbound: ((rawEvent: unknown) => Promise<unknown>) | undefined;
   const ws = new FakeWsClient();
   const adapter = new FeishuAdapter({
     createClient: () =>
@@ -62,10 +64,20 @@ function harness(options: {
       params = input;
       return ws;
     },
+    createEventDispatcher: () => ({
+      register: (handlers) => {
+        inbound = handlers["im.message.receive_v1"];
+      },
+    }) satisfies FeishuEventDispatcherLike,
     wsReadyTimeoutMs: options.timeoutMs ?? 100,
     onTerminalError: options.terminal,
   });
-  return { adapter, ws, get params() { return params; } };
+  return {
+    adapter,
+    ws,
+    get params() { return params; },
+    get inbound() { return inbound; },
+  };
 }
 
 const onEvent = async (): Promise<void> => {};
@@ -105,6 +117,68 @@ describe("FeishuAdapter WS lifecycle", () => {
     expect(h.adapter.health().connected).toBe(false);
     expect(h.adapter.health().lastError).not.toContain("do-not-log-me");
     expect(terminal).toHaveLength(0);
+  });
+
+  test("initial onError scrubs arbitrary Lark access-token shapes", async () => {
+    const h = harness();
+    await h.adapter.init(config());
+    const starting = h.adapter.start(onEvent);
+    await Bun.sleep(1);
+    h.params?.onError?.(new Error(
+      "Bearer bearer-token-618 t-tenant-token-618 u-user-token-618 cli_other-app-618",
+    ));
+
+    await expect(starting).rejects.toThrow(
+      "Bearer [redacted] [redacted] [redacted] [redacted]",
+    );
+    const lastError = h.adapter.health().lastError ?? "";
+    for (const secret of [
+      "bearer-token-618",
+      "t-tenant-token-618",
+      "u-user-token-618",
+      "cli_other-app-618",
+    ]) {
+      expect(lastError).not.toContain(secret);
+    }
+  });
+
+  test("spurious reconnect before first ready cannot mark health connected", async () => {
+    const h = harness({ timeoutMs: 15 });
+    await h.adapter.init(config());
+    const starting = h.adapter.start(onEvent);
+    await Bun.sleep(1);
+
+    h.params?.onReconnected?.();
+    expect(h.adapter.health().connected).toBe(false);
+    await expect(starting).rejects.toThrow("did not become ready");
+    expect(h.adapter.health().connected).toBe(false);
+  });
+
+  test("inbound handler errors use the same token scrub before health", async () => {
+    const h = harness();
+    await h.adapter.init(config());
+    const starting = h.adapter.start(async () => {
+      throw new Error("inbound t-inbound-token-618 Bearer inbound-bearer-618");
+    });
+    await Bun.sleep(1);
+    h.params?.onReady?.();
+    await starting;
+
+    await h.inbound?.({
+      sender: { sender_id: { open_id: "ou_test" }, tenant_key: "tenant" },
+      message: {
+        message_id: "om_test618",
+        message_type: "text",
+        content: '{"text":"hello"}',
+        chat_type: "p2p",
+        chat_id: "oc_test618",
+        mentions: [],
+      },
+    });
+
+    expect(h.adapter.health().lastError).toBe(
+      "inbound [redacted] Bearer [redacted]",
+    );
   });
 
   test("reconnecting lowers health and reconnected restores it", async () => {

--- a/agent-network/src/im/feishu/adapter-lifecycle.test.ts
+++ b/agent-network/src/im/feishu/adapter-lifecycle.test.ts
@@ -156,7 +156,9 @@ describe("FeishuAdapter WS lifecycle", () => {
 
   test("inbound handler errors use the same token scrub before health", async () => {
     const h = harness();
-    await h.adapter.init(config());
+    const inboundConfig = config();
+    (inboundConfig.platformConfig as { access: { allowFrom: string[] } }).access.allowFrom = ["ou_test"];
+    await h.adapter.init(inboundConfig);
     const starting = h.adapter.start(async () => {
       throw new Error("inbound t-inbound-token-618 Bearer inbound-bearer-618");
     });

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -48,6 +48,10 @@ export type FeishuWsClientLike = Pick<lark.WSClient, "start" | "close">;
 export type FeishuWsClientFactory = (
   params: ConstructorParameters<typeof lark.WSClient>[0],
 ) => FeishuWsClientLike;
+type FeishuInboundHandler = (rawEvent: unknown) => Promise<unknown>;
+export interface FeishuEventDispatcherLike {
+  register(handlers: Record<string, FeishuInboundHandler>): unknown;
+}
 
 export interface FeishuAdapterOptions {
   /** @internal Avoids real bot-info HTTP calls in lifecycle tests. */
@@ -56,6 +60,8 @@ export interface FeishuAdapterOptions {
   ) => lark.Client;
   /** @internal Test seam; production uses the pinned Lark SDK WSClient. */
   createWsClient?: FeishuWsClientFactory;
+  /** @internal Test seam; production uses the pinned Lark SDK dispatcher. */
+  createEventDispatcher?: () => FeishuEventDispatcherLike;
   /** Independent outer bound in case the SDK promise/callback path stalls. */
   wsReadyTimeoutMs?: number;
   /** Called once when an already-ready socket exhausts reconnect attempts. */
@@ -74,7 +80,7 @@ export class FeishuAdapter implements IMAdapter {
   private wsClient: FeishuWsClientLike | null = null;
   private lifecycleGeneration = 0;
   private readonly options: Required<
-    Pick<FeishuAdapterOptions, "createClient" | "createWsClient" | "wsReadyTimeoutMs">
+    Pick<FeishuAdapterOptions, "createClient" | "createWsClient" | "createEventDispatcher" | "wsReadyTimeoutMs">
   > & Pick<FeishuAdapterOptions, "onTerminalError">;
   /**
    * The bot's own open_id, resolved at init() via /open-apis/bot/v3/info.
@@ -96,6 +102,7 @@ export class FeishuAdapter implements IMAdapter {
     this.options = {
       createClient: options.createClient ?? ((params) => new lark.Client(params)),
       createWsClient: options.createWsClient ?? ((params) => new lark.WSClient(params)),
+      createEventDispatcher: options.createEventDispatcher ?? (() => new lark.EventDispatcher({})),
       wsReadyTimeoutMs: options.wsReadyTimeoutMs ?? DEFAULT_WS_READY_TIMEOUT_MS,
       onTerminalError: options.onTerminalError,
     };
@@ -177,7 +184,7 @@ export class FeishuAdapter implements IMAdapter {
     const mediaDir = this.mediaDir;
     const client = this.client;
 
-    const dispatcher = new lark.EventDispatcher({});
+    const dispatcher = this.options.createEventDispatcher();
     dispatcher.register({
       "im.message.receive_v1": async (rawEvent: unknown): Promise<unknown> => {
         try {
@@ -202,7 +209,7 @@ export class FeishuAdapter implements IMAdapter {
           }
           await onEvent(normalized);
         } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
+          const msg = sanitizeFeishuWsError(err, appId, appSecret).message;
           this.health_ = { ...this.health_, lastError: msg };
           auditLog("error", null, msg);
         }
@@ -266,14 +273,14 @@ export class FeishuAdapter implements IMAdapter {
           this.health_ = { ...this.health_, connected: false };
         },
         onReconnected: () => {
-          if (generation !== this.lifecycleGeneration || terminalDispatched) return;
+          if (!ready || generation !== this.lifecycleGeneration || terminalDispatched) return;
           this.health_ = { ...this.health_, connected: true, lastError: null };
         },
       });
 
       // SDK start() has historically resolved before the first handshake.
       // The callback above, not this promise, is the readiness authority.
-      void Promise.resolve(this.wsClient.start({ eventDispatcher: dispatcher })).catch(
+      void Promise.resolve(this.wsClient.start({ eventDispatcher: dispatcher as lark.EventDispatcher })).catch(
         finishError,
       );
     });
@@ -1448,6 +1455,13 @@ export function sanitizeFeishuWsError(
   for (const secret of [appSecret, appId]) {
     if (secret) message = message.split(secret).join("[redacted]");
   }
+  // Lark access tokens can be returned by an SDK error even when they are not
+  // one of the two configured app credentials. Redact the stable token shapes
+  // before the message reaches health, audit, stderr, or the worker owner.
+  message = message
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .replace(/\b(?:t|u)-[A-Za-z0-9._~+/=-]{6,}/g, "[redacted]")
+    .replace(/\bcli_[A-Za-z0-9_-]{6,}/g, "[redacted]");
   message = message.trim().slice(0, 500) || "Feishu WebSocket failed";
   return new Error(message);
 }

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -1457,10 +1457,11 @@ export function sanitizeFeishuWsError(
   }
   // Lark access tokens can be returned by an SDK error even when they are not
   // one of the two configured app credentials. Redact the stable token shapes
-  // before the message reaches health, audit, stderr, or the worker owner.
+  // before the message reaches health, audit, or the worker owner.
   message = message
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
     .replace(/\b(?:a|t|u)-[A-Za-z0-9._~+/=-]{12,}/gi, "[redacted]")
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}/g, "[redacted]")
     .replace(/\bcli_[A-Za-z0-9_-]{6,}/g, "[redacted]");
   message = message.trim().slice(0, 500) || "Feishu WebSocket failed";
   return new Error(message);

--- a/agent-network/src/im/feishu/adapter.ts
+++ b/agent-network/src/im/feishu/adapter.ts
@@ -1460,7 +1460,7 @@ export function sanitizeFeishuWsError(
   // before the message reaches health, audit, stderr, or the worker owner.
   message = message
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
-    .replace(/\b(?:t|u)-[A-Za-z0-9._~+/=-]{6,}/g, "[redacted]")
+    .replace(/\b(?:a|t|u)-[A-Za-z0-9._~+/=-]{12,}/gi, "[redacted]")
     .replace(/\bcli_[A-Za-z0-9_-]{6,}/g, "[redacted]");
   message = message.trim().slice(0, 500) || "Feishu WebSocket failed";
   return new Error(message);

--- a/docs/tests/report-test623-feishu-scrub-health.txt
+++ b/docs/tests/report-test623-feishu-scrub-health.txt
@@ -1,0 +1,38 @@
+# test623 — Feishu token scrub + prior-ready health gate
+
+Date: 2026-08-09
+Issue: #618
+Source commit: 108d893e1336d835395d750dc5992efe0a883a22
+Docker tag: anet-test623:dev
+Docker image: sha256:31130e15d50674004d50e09b24ccf3cfa3bb155c1b7bed3363431d00afcf94b5
+Embedded source: TEST623_SOURCE_COMMIT=108d893e1336d835395d750dc5992efe0a883a22
+Runner artifact SHA256: 30ac937a8499d85ed31b7f4713eb531c853b06b0a097b59e6b6fbbbafe907c46
+
+## Result
+
+- TypeScript `tsc --noEmit`: PASS.
+- Feishu lifecycle tests: 10 pass / 0 fail / 27 assertions.
+- Production CLI, node-server, and Feishu worker bundle: PASS.
+- Sanitized inbound audit evidence contained only
+  `inbound [redacted] Bearer [redacted]`.
+- Remove arbitrary `t-`/`u-` token scrub: witnessed RED (`rc=1`).
+- Bypass scrub in the inbound dispatcher catch: witnessed RED (`rc=1`).
+- Remove the prior-ready reconnect gate: witnessed RED (`rc=1`).
+- Restored lifecycle suite: 10 pass / 0 fail / 27 assertions.
+
+```text
+L3 witnessed-red: arbitrary access-token scrub is load-bearing
+MUTATION_RED: access-token-scrub rc=1
+L4 witnessed-red: inbound errors must not bypass scrub
+MUTATION_RED: inbound-error-scrub rc=1
+L5 witnessed-red: reconnect cannot become ready before onReady
+MUTATION_RED: reconnect-prior-ready rc=1
+L6 restored green
+10 pass
+0 fail
+27 expect() calls
+RESULT: PASS
+```
+
+All credentials in the fixture are synthetic test strings. No production
+channel, Hub, token, package installation, or deployment was touched.

--- a/docs/tests/report-test623-feishu-scrub-health.txt
+++ b/docs/tests/report-test623-feishu-scrub-health.txt
@@ -2,35 +2,38 @@
 
 Date: 2026-08-09
 Issue: #618
-Source commit: 22441775c8d0542dd55bc275814fcc4792f9c083
+Source commit: 4c7a64dbabf12ec3af9cbf0607698c6bfac86311
 Docker tag: anet-test623:dev
-Docker image: sha256:b7318ebf54d4faba37be2b93dc4c27098bf546346d803878afb0f40dc46f8c8b
-Embedded source: TEST623_SOURCE_COMMIT=22441775c8d0542dd55bc275814fcc4792f9c083
-Runner artifact SHA256: 6b2e6845cfc3bd2b3c594fae48b9966d5f955d000fe37cc9cb7f0ca668a49c05
+Docker image: sha256:1bc0797732c6e129b8e21e73ad5a6d80e0984698dd64be55ee1cdd9af771b25d
+Embedded source: TEST623_SOURCE_COMMIT=4c7a64dbabf12ec3af9cbf0607698c6bfac86311
+Runner artifact SHA256: 0f2adcf79f39bacf18b0b203110bcc6b6c4123f33ef6fd3c8c3a4c879d60a01e
 
 ## Result
 
 - TypeScript `tsc --noEmit`: PASS.
-- Feishu lifecycle tests: 10 pass / 0 fail / 29 assertions.
+- Feishu lifecycle tests: 10 pass / 0 fail / 30 assertions.
 - Production CLI, node-server, and Feishu worker bundle: PASS.
 - Sanitized inbound audit evidence contained only
   `inbound [redacted] Bearer [redacted]`.
 - Remove arbitrary `a-`/`t-`/`u-` token scrub: witnessed RED (`rc=1`).
+- Remove bare JWT scrub: witnessed RED (`rc=1`).
 - Bypass scrub in the inbound dispatcher catch: witnessed RED (`rc=1`).
 - Remove the prior-ready reconnect gate: witnessed RED (`rc=1`).
-- Restored lifecycle suite: 10 pass / 0 fail / 29 assertions.
+- Restored lifecycle suite: 10 pass / 0 fail / 30 assertions.
 
 ```text
 L3 witnessed-red: arbitrary access-token scrub is load-bearing
 MUTATION_RED: access-token-scrub rc=1
-L4 witnessed-red: inbound errors must not bypass scrub
+L4 witnessed-red: bare JWT scrub is load-bearing
+MUTATION_RED: jwt-token-scrub rc=1
+L5 witnessed-red: inbound errors must not bypass scrub
 MUTATION_RED: inbound-error-scrub rc=1
-L5 witnessed-red: reconnect cannot become ready before onReady
+L6 witnessed-red: reconnect cannot become ready before onReady
 MUTATION_RED: reconnect-prior-ready rc=1
-L6 restored green
+L7 restored green
 10 pass
 0 fail
-29 expect() calls
+30 expect() calls
 RESULT: PASS
 ```
 

--- a/docs/tests/report-test623-feishu-scrub-health.txt
+++ b/docs/tests/report-test623-feishu-scrub-health.txt
@@ -4,9 +4,9 @@ Date: 2026-08-09
 Issue: #618
 Source commit: 4c7a64dbabf12ec3af9cbf0607698c6bfac86311
 Docker tag: anet-test623:dev
-Docker image: sha256:1bc0797732c6e129b8e21e73ad5a6d80e0984698dd64be55ee1cdd9af771b25d
+Docker image: sha256:a85afb2252be93b619880d24a65daa6827a8d269168a28f68d159b929b6c0d81
 Embedded source: TEST623_SOURCE_COMMIT=4c7a64dbabf12ec3af9cbf0607698c6bfac86311
-Runner artifact SHA256: 0f2adcf79f39bacf18b0b203110bcc6b6c4123f33ef6fd3c8c3a4c879d60a01e
+Runner artifact SHA256: 421059ca361c88cec5f8626a948c5dd62327c654df7d67af77eb79e2216db36e
 
 ## Result
 

--- a/docs/tests/report-test623-feishu-scrub-health.txt
+++ b/docs/tests/report-test623-feishu-scrub-health.txt
@@ -2,23 +2,23 @@
 
 Date: 2026-08-09
 Issue: #618
-Source commit: 108d893e1336d835395d750dc5992efe0a883a22
+Source commit: 22441775c8d0542dd55bc275814fcc4792f9c083
 Docker tag: anet-test623:dev
-Docker image: sha256:31130e15d50674004d50e09b24ccf3cfa3bb155c1b7bed3363431d00afcf94b5
-Embedded source: TEST623_SOURCE_COMMIT=108d893e1336d835395d750dc5992efe0a883a22
-Runner artifact SHA256: 30ac937a8499d85ed31b7f4713eb531c853b06b0a097b59e6b6fbbbafe907c46
+Docker image: sha256:b7318ebf54d4faba37be2b93dc4c27098bf546346d803878afb0f40dc46f8c8b
+Embedded source: TEST623_SOURCE_COMMIT=22441775c8d0542dd55bc275814fcc4792f9c083
+Runner artifact SHA256: 6b2e6845cfc3bd2b3c594fae48b9966d5f955d000fe37cc9cb7f0ca668a49c05
 
 ## Result
 
 - TypeScript `tsc --noEmit`: PASS.
-- Feishu lifecycle tests: 10 pass / 0 fail / 27 assertions.
+- Feishu lifecycle tests: 10 pass / 0 fail / 29 assertions.
 - Production CLI, node-server, and Feishu worker bundle: PASS.
 - Sanitized inbound audit evidence contained only
   `inbound [redacted] Bearer [redacted]`.
-- Remove arbitrary `t-`/`u-` token scrub: witnessed RED (`rc=1`).
+- Remove arbitrary `a-`/`t-`/`u-` token scrub: witnessed RED (`rc=1`).
 - Bypass scrub in the inbound dispatcher catch: witnessed RED (`rc=1`).
 - Remove the prior-ready reconnect gate: witnessed RED (`rc=1`).
-- Restored lifecycle suite: 10 pass / 0 fail / 27 assertions.
+- Restored lifecycle suite: 10 pass / 0 fail / 29 assertions.
 
 ```text
 L3 witnessed-red: arbitrary access-token scrub is load-bearing
@@ -30,7 +30,7 @@ MUTATION_RED: reconnect-prior-ready rc=1
 L6 restored green
 10 pass
 0 fail
-27 expect() calls
+29 expect() calls
 RESULT: PASS
 ```
 

--- a/tests/test623-feishu-scrub-health/Dockerfile
+++ b/tests/test623-feishu-scrub-health/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+COPY agent-network/package.json agent-network/package-lock.json ./agent-network/
+RUN cd agent-network && bun install --ignore-scripts
+COPY agent-network ./agent-network
+COPY tests/test623-feishu-scrub-health ./tests/test623-feishu-scrub-health
+
+ARG SOURCE_COMMIT
+ENV TEST623_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test623-feishu-scrub-health/run.sh
+ENTRYPOINT ["/workspace/tests/test623-feishu-scrub-health/run.sh"]

--- a/tests/test623-feishu-scrub-health/README.md
+++ b/tests/test623-feishu-scrub-health/README.md
@@ -1,0 +1,9 @@
+# test623 — Feishu scrub and health hardening
+
+This suite verifies issue #618 in an isolated Docker build:
+
+- access-token shapes not equal to configured app credentials are redacted;
+- inbound-dispatch errors pass through the same sanitizer before health/audit;
+- `onReconnected` cannot report online before the first authoritative
+  `onReady` callback;
+- removing each guard is a witnessed-red mutation.

--- a/tests/test623-feishu-scrub-health/run.sh
+++ b/tests/test623-feishu-scrub-health/run.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test623-feishu-scrub-health.txt"
+ADAPTER=agent-network/src/im/feishu/adapter.ts
+TEST=agent-network/src/im/feishu/adapter-lifecycle.test.ts
+mkdir -p "$ARTIFACT_DIR"
+: >"$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+run_lifecycle() {
+  bun test "$TEST"
+}
+
+expect_red() {
+  local label=$1 marker=$2
+  set +e
+  run_lifecycle >/tmp/test623-red.log 2>&1
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    echo "MUTATION_FALSE_GREEN: $label"
+    sed -n '1,220p' /tmp/test623-red.log
+    exit 1
+  fi
+  grep -Fq "$marker" /tmp/test623-red.log
+  echo "MUTATION_RED: $label rc=$rc"
+}
+
+echo "# test623 — Feishu token scrub + prior-ready health gate"
+echo "source_commit=${TEST623_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+echo "L0 typecheck"
+cd /workspace/agent-network
+bun run typecheck
+cd /workspace
+
+echo "L1 real lifecycle behavior"
+run_lifecycle
+
+echo "L2 production bundle"
+cd /workspace/agent-network
+bun run build
+cd /workspace
+test -s agent-network/dist/src/im/feishu/adapter.js
+
+cp "$ADAPTER" /tmp/test623-adapter.ts
+
+echo "L3 witnessed-red: arbitrary access-token scrub is load-bearing"
+sed -i '/\.replace(\/\\b(?:t|u)-/,/\.replace(\/\\bcli_/ {
+  /\.replace(\/\\b(?:t|u)-/d
+}' "$ADAPTER"
+if grep -Fq '.replace(/\b(?:t|u)-' "$ADAPTER"; then
+  echo "MUTATION_NOT_APPLIED: access-token-scrub"
+  exit 1
+fi
+expect_red access-token-scrub 'initial onError scrubs arbitrary Lark access-token shapes'
+cp /tmp/test623-adapter.ts "$ADAPTER"
+
+echo "L4 witnessed-red: inbound errors must not bypass scrub"
+sed -i 's/const msg = sanitizeFeishuWsError(err, appId, appSecret).message;/const msg = err instanceof Error ? err.message : String(err); \/\/ MUTATION/' "$ADAPTER"
+grep -Fq 'MUTATION' "$ADAPTER"
+expect_red inbound-error-scrub 'inbound handler errors use the same token scrub before health'
+cp /tmp/test623-adapter.ts "$ADAPTER"
+
+echo "L5 witnessed-red: reconnect cannot become ready before onReady"
+sed -i 's/if (!ready || generation !== this.lifecycleGeneration || terminalDispatched) return;/if (generation !== this.lifecycleGeneration || terminalDispatched) return; \/\/ MUTATION/' "$ADAPTER"
+grep -Fq 'MUTATION' "$ADAPTER"
+expect_red reconnect-prior-ready 'spurious reconnect before first ready cannot mark health connected'
+cp /tmp/test623-adapter.ts "$ADAPTER"
+
+echo "L6 restored green"
+run_lifecycle
+echo "RESULT: PASS"

--- a/tests/test623-feishu-scrub-health/run.sh
+++ b/tests/test623-feishu-scrub-health/run.sh
@@ -44,7 +44,7 @@ echo "L2 production bundle"
 cd /workspace/agent-network
 bun run build
 cd /workspace
-test -s agent-network/dist/src/im/feishu/adapter.js
+test -s agent-network/dist/src/im/feishu/worker.js
 
 cp "$ADAPTER" /tmp/test623-adapter.ts
 

--- a/tests/test623-feishu-scrub-health/run.sh
+++ b/tests/test623-feishu-scrub-health/run.sh
@@ -49,10 +49,10 @@ test -s agent-network/dist/src/im/feishu/worker.js
 cp "$ADAPTER" /tmp/test623-adapter.ts
 
 echo "L3 witnessed-red: arbitrary access-token scrub is load-bearing"
-sed -i '/\.replace(\/\\b(?:t|u)-/,/\.replace(\/\\bcli_/ {
-  /\.replace(\/\\b(?:t|u)-/d
+sed -i '/\.replace(\/\\b(?:a|t|u)-/,/\.replace(\/\\bcli_/ {
+  /\.replace(\/\\b(?:a|t|u)-/d
 }' "$ADAPTER"
-if grep -Fq '.replace(/\b(?:t|u)-' "$ADAPTER"; then
+if grep -Fq '.replace(/\b(?:a|t|u)-' "$ADAPTER"; then
   echo "MUTATION_NOT_APPLIED: access-token-scrub"
   exit 1
 fi

--- a/tests/test623-feishu-scrub-health/run.sh
+++ b/tests/test623-feishu-scrub-health/run.sh
@@ -59,18 +59,27 @@ fi
 expect_red access-token-scrub 'initial onError scrubs arbitrary Lark access-token shapes'
 cp /tmp/test623-adapter.ts "$ADAPTER"
 
-echo "L4 witnessed-red: inbound errors must not bypass scrub"
+echo "L4 witnessed-red: bare JWT scrub is load-bearing"
+sed -i '/\.replace(.*\\beyJ/d' "$ADAPTER"
+if grep -Fq '.replace(/\beyJ' "$ADAPTER"; then
+  echo "MUTATION_NOT_APPLIED: jwt-token-scrub"
+  exit 1
+fi
+expect_red jwt-token-scrub 'initial onError scrubs arbitrary Lark access-token shapes'
+cp /tmp/test623-adapter.ts "$ADAPTER"
+
+echo "L5 witnessed-red: inbound errors must not bypass scrub"
 sed -i 's/const msg = sanitizeFeishuWsError(err, appId, appSecret).message;/const msg = err instanceof Error ? err.message : String(err); \/\/ MUTATION/' "$ADAPTER"
 grep -Fq 'MUTATION' "$ADAPTER"
 expect_red inbound-error-scrub 'inbound handler errors use the same token scrub before health'
 cp /tmp/test623-adapter.ts "$ADAPTER"
 
-echo "L5 witnessed-red: reconnect cannot become ready before onReady"
+echo "L6 witnessed-red: reconnect cannot become ready before onReady"
 sed -i 's/if (!ready || generation !== this.lifecycleGeneration || terminalDispatched) return;/if (generation !== this.lifecycleGeneration || terminalDispatched) return; \/\/ MUTATION/' "$ADAPTER"
 grep -Fq 'MUTATION' "$ADAPTER"
 expect_red reconnect-prior-ready 'spurious reconnect before first ready cannot mark health connected'
 cp /tmp/test623-adapter.ts "$ADAPTER"
 
-echo "L6 restored green"
+echo "L7 restored green"
 run_lifecycle
 echo "RESULT: PASS"


### PR DESCRIPTION
## Summary
- redact arbitrary Feishu `t-` / `u-` / `cli_` / Bearer token shapes, not only configured app credentials
- route inbound-dispatch failures through the same sanitizer before health/audit
- refuse spurious `onReconnected` health=true before the first authoritative `onReady`
- add real lifecycle tests, production bundle gate, and three witnessed-red mutations

## Verification
- source: `108d893e1336d835395d750dc5992efe0a883a22`
- exact Docker: 10 pass / 0 fail / 27 assertions; production bundle PASS
- report-only head recorded in `docs/tests/report-test623-feishu-scrub-health.txt`
- all credential fixtures are synthetic

Closes #618

No production changes, publish, or deployment.