### PR TITLE
feat(server): add task cursor pagination (#459)

### DIFF
--- a/docs/tests/report-test624-task-cursor-pagination.txt
+++ b/docs/tests/report-test624-task-cursor-pagination.txt
@@ -2,17 +2,20 @@
 
 Date: 2026-08-09
 Issue: #459
-Source commit: d25dcc07e15c5cc36385761d43c2336d96dce11a
+Source commit: bf086cd70f9421413cc7d1a18edeb3fa3d30063b
 Docker tag: anet-test624:dev
-Docker image: sha256:39964ee986799abd8d3b9e91240f2dd629cb7e587f191ff29329b47032e70c3c
-Embedded source: TEST624_SOURCE_COMMIT=d25dcc07e15c5cc36385761d43c2336d96dce11a
-Runner artifact SHA256: a52f5b37af73e802fb3462b181cc22c6999193d6e6e91f4758e393af83655849
+Docker image: sha256:c46ec4b356360a09f24e03447959f5f5ac9c55c2f143915e84186edda7194150
+Embedded source: TEST624_SOURCE_COMMIT=bf086cd70f9421413cc7d1a18edeb3fa3d30063b
+Runner artifact SHA256: d8d0c3cfcc849c9b5d45ad3d0fd53caac7d468f0a6190aca214dfdf5aa023aca
 
 ## Result
 
 - Production Hub bundle: PASS.
-- Real isolated Hub + SQLite: 4 pass / 0 fail / 15 assertions.
+- Real isolated Hub + SQLite: 6 pass / 0 fail / 24 assertions.
 - Exclusive `before` cursor excludes the cursor row and all newer rows.
+- Optional `before_task_id` forms a stable compound cursor with `before`, so
+  pagination does not silently drop unreturned rows that share SQLite's
+  one-second `created_at` precision.
 - Authenticated member sees only its own network; a matching foreign row is
   absent even when it satisfies `before` and `to_name`.
 - ISO UTC and native SQLite cursor shapes converge on the same query value.
@@ -20,22 +23,30 @@ Runner artifact SHA256: a52f5b37af73e802fb3462b181cc22c6999193d6e6e91f4758e393af
 - No-cursor response remains `{ok,tasks,count}` under `skip_stats=1`, newest
   first.
 - Empty, malformed, and rolled-over dates return HTTP 400 `invalid_before`.
+- Missing, empty, or oversized compound task cursors fail
+  closed with HTTP 400 `invalid_before_task_id`.
 - Remove cursor predicate: witnessed RED (`rc=1`).
 - Change `<` to `<=`: witnessed RED (`rc=1`).
+- Reverse the compound task-id tie-break: witnessed RED (`rc=1`).
 - Remove malformed-cursor rejection: witnessed RED (`rc=1`).
-- Restored suite: 4 pass / 0 fail / 15 assertions.
+- Remove compound-cursor validation: witnessed RED (`rc=1`).
+- Restored suite: 6 pass / 0 fail / 24 assertions.
 
 ```text
 L2 witnessed-red: before predicate is load-bearing
 MUTATION_RED: before-filter rc=1
 L3 witnessed-red: exact cursor row must stay excluded
 MUTATION_RED: exclusive-cursor rc=1
-L4 witnessed-red: malformed cursor rejection is load-bearing
+L4 witnessed-red: compound cursor tie-break is load-bearing
+MUTATION_RED: same-second-cursor rc=1
+L5 witnessed-red: malformed cursor rejection is load-bearing
 MUTATION_RED: invalid-cursor rc=1
-L5 restored green
-4 pass
+L6 witnessed-red: compound cursor validation is load-bearing
+MUTATION_RED: compound-validation rc=1
+L7 restored green
+6 pass
 0 fail
-15 expect() calls
+24 expect() calls
 RESULT: PASS
 ```
 

--- a/docs/tests/report-test624-task-cursor-pagination.txt
+++ b/docs/tests/report-test624-task-cursor-pagination.txt
@@ -1,0 +1,42 @@
+# test624 — `/api/tasks` cursor pagination
+
+Date: 2026-08-09
+Issue: #459
+Source commit: d25dcc07e15c5cc36385761d43c2336d96dce11a
+Docker tag: anet-test624:dev
+Docker image: sha256:39964ee986799abd8d3b9e91240f2dd629cb7e587f191ff29329b47032e70c3c
+Embedded source: TEST624_SOURCE_COMMIT=d25dcc07e15c5cc36385761d43c2336d96dce11a
+Runner artifact SHA256: a52f5b37af73e802fb3462b181cc22c6999193d6e6e91f4758e393af83655849
+
+## Result
+
+- Production Hub bundle: PASS.
+- Real isolated Hub + SQLite: 4 pass / 0 fail / 15 assertions.
+- Exclusive `before` cursor excludes the cursor row and all newer rows.
+- Authenticated member sees only its own network; a matching foreign row is
+  absent even when it satisfies `before` and `to_name`.
+- ISO UTC and native SQLite cursor shapes converge on the same query value.
+- `to_name` composes with the cursor.
+- No-cursor response remains `{ok,tasks,count}` under `skip_stats=1`, newest
+  first.
+- Empty, malformed, and rolled-over dates return HTTP 400 `invalid_before`.
+- Remove cursor predicate: witnessed RED (`rc=1`).
+- Change `<` to `<=`: witnessed RED (`rc=1`).
+- Remove malformed-cursor rejection: witnessed RED (`rc=1`).
+- Restored suite: 4 pass / 0 fail / 15 assertions.
+
+```text
+L2 witnessed-red: before predicate is load-bearing
+MUTATION_RED: before-filter rc=1
+L3 witnessed-red: exact cursor row must stay excluded
+MUTATION_RED: exclusive-cursor rc=1
+L4 witnessed-red: malformed cursor rejection is load-bearing
+MUTATION_RED: invalid-cursor rc=1
+L5 restored green
+4 pass
+0 fail
+15 expect() calls
+RESULT: PASS
+```
+
+No production service, database, package, or deployment was touched.

--- a/docs/tests/report-test624-task-cursor-pagination.txt
+++ b/docs/tests/report-test624-task-cursor-pagination.txt
@@ -4,9 +4,9 @@ Date: 2026-08-09
 Issue: #459
 Source commit: bf086cd70f9421413cc7d1a18edeb3fa3d30063b
 Docker tag: anet-test624:dev
-Docker image: sha256:c46ec4b356360a09f24e03447959f5f5ac9c55c2f143915e84186edda7194150
+Docker image: sha256:611fea96dfe2fecf297309d4edc78c83d61129bd17246aadabdb51df0530f640
 Embedded source: TEST624_SOURCE_COMMIT=bf086cd70f9421413cc7d1a18edeb3fa3d30063b
-Runner artifact SHA256: d8d0c3cfcc849c9b5d45ad3d0fd53caac7d468f0a6190aca214dfdf5aa023aca
+Runner artifact SHA256: 4bb3a5bdb4afa3b787f6087c421f4df160c16d5da2a55002f283e2788f91aa8a
 
 ## Result
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -369,6 +369,20 @@ function parseSqliteTime(value: string | null | undefined): number {
   return Number.isFinite(ts) ? ts : 0;
 }
 
+function normalizeTaskBeforeCursor(value: string): string | null {
+  const cursor = value.trim();
+  if (!cursor) return null;
+  const sqliteShape = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+  if (sqliteShape.test(cursor)) {
+    const parsed = new Date(`${cursor.replace(" ", "T")}Z`);
+    if (!Number.isFinite(parsed.getTime()) || sqliteTime(parsed) !== cursor) return null;
+    return cursor;
+  }
+  const timestamp = Date.parse(cursor);
+  if (!Number.isFinite(timestamp)) return null;
+  return sqliteTime(new Date(timestamp));
+}
+
 function cpuPct(load: number | null | undefined, cores: number | null | undefined): number | null {
   if (typeof load !== "number" || typeof cores !== "number" || cores <= 0) return null;
   return Math.round((load / cores) * 1000) / 10;
@@ -2893,6 +2907,11 @@ return Bun.serve({
       const status = url.searchParams.get("status");
       const toName = url.searchParams.get("to_name");
       const fromName = url.searchParams.get("from_name");
+      const rawBefore = url.searchParams.get("before");
+      const before = rawBefore === null ? null : normalizeTaskBeforeCursor(rawBefore);
+      if (rawBefore !== null && before === null) {
+        return withCors(req, Response.json({ ok: false, error: "invalid_before" }, { status: 400 }));
+      }
       const limit = Math.min(Number(url.searchParams.get("limit")) || 50, 200);
       // #248 — opt-out of the stats GROUP-BY scan. The dashboard chat panel
       // never consumes `stats`; it's a global per-status table scan that
@@ -2908,7 +2927,8 @@ return Bun.serve({
       if (status) { sql += ` AND status = ?${params.length + 1}`; params.push(status); }
       if (toName) { sql += ` AND to_name = ?${params.length + 1}`; params.push(toName); }
       if (fromName) { sql += ` AND from_name = ?${params.length + 1}`; params.push(fromName); }
-      sql += ` ORDER BY created_at DESC LIMIT ?${params.length + 1}`;
+      if (before) { sql += ` AND created_at < ?${params.length + 1}`; params.push(before); }
+      sql += ` ORDER BY created_at DESC, task_id DESC LIMIT ?${params.length + 1}`;
       params.push(limit);
 
       const rows = db.all(sql, ...params);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -383,6 +383,12 @@ function normalizeTaskBeforeCursor(value: string): string | null {
   return sqliteTime(new Date(timestamp));
 }
 
+function normalizeTaskBeforeTaskId(value: string): string | null {
+  const taskId = value.trim();
+  if (!taskId || taskId.length > 256 || /[\u0000-\u001f\u007f]/.test(taskId)) return null;
+  return taskId;
+}
+
 function cpuPct(load: number | null | undefined, cores: number | null | undefined): number | null {
   if (typeof load !== "number" || typeof cores !== "number" || cores <= 0) return null;
   return Math.round((load / cores) * 1000) / 10;
@@ -2912,6 +2918,11 @@ return Bun.serve({
       if (rawBefore !== null && before === null) {
         return withCors(req, Response.json({ ok: false, error: "invalid_before" }, { status: 400 }));
       }
+      const rawBeforeTaskId = url.searchParams.get("before_task_id");
+      const beforeTaskId = rawBeforeTaskId === null ? null : normalizeTaskBeforeTaskId(rawBeforeTaskId);
+      if (rawBeforeTaskId !== null && (before === null || beforeTaskId === null)) {
+        return withCors(req, Response.json({ ok: false, error: "invalid_before_task_id" }, { status: 400 }));
+      }
       const limit = Math.min(Number(url.searchParams.get("limit")) || 50, 200);
       // #248 — opt-out of the stats GROUP-BY scan. The dashboard chat panel
       // never consumes `stats`; it's a global per-status table scan that
@@ -2927,7 +2938,15 @@ return Bun.serve({
       if (status) { sql += ` AND status = ?${params.length + 1}`; params.push(status); }
       if (toName) { sql += ` AND to_name = ?${params.length + 1}`; params.push(toName); }
       if (fromName) { sql += ` AND from_name = ?${params.length + 1}`; params.push(fromName); }
-      if (before) { sql += ` AND created_at < ?${params.length + 1}`; params.push(before); }
+      if (before && beforeTaskId) {
+        const createdAtParam = params.length + 1;
+        const taskIdParam = params.length + 2;
+        sql += ` AND (created_at < ?${createdAtParam} OR (created_at = ?${createdAtParam} AND task_id < ?${taskIdParam}))`;
+        params.push(before, beforeTaskId);
+      } else if (before) {
+        sql += ` AND created_at < ?${params.length + 1}`;
+        params.push(before);
+      }
       sql += ` ORDER BY created_at DESC, task_id DESC LIMIT ?${params.length + 1}`;
       params.push(limit);
 

--- a/server/src/tasks-pagination-http.test.ts
+++ b/server/src/tasks-pagination-http.test.ts
@@ -31,8 +31,11 @@ function seedTask(
 beforeAll(async () => {
   ({ db } = await import("./db.js"));
   ({ register } = await import("./auth.js"));
-  const a = register(`page_a_${Date.now()}`, "PageTest-A-Strong!", undefined, "seed-a");
   const b = register(`page_b_${Date.now()}`, "PageTest-B-Strong!", undefined, "seed-b");
+  // The first registered user is the instance admin and may read all
+  // networks. Register the foreign fixture first so tokenA exercises the
+  // ordinary member-scoped path rather than the admin bypass.
+  const a = register(`page_a_${Date.now()}`, "PageTest-A-Strong!", undefined, "seed-a");
   expect(a.ok).toBe(true);
   expect(b.ok).toBe(true);
   tokenA = a.token!;

--- a/server/src/tasks-pagination-http.test.ts
+++ b/server/src/tasks-pagination-http.test.ts
@@ -43,6 +43,9 @@ beforeAll(async () => {
   networkB = b.network_id!;
 
   seedTask("a-new", networkA, "agent-a", "2026-01-04 00:00:00");
+  seedTask("tie-z", networkA, "agent-a", "2026-01-05 00:00:00");
+  seedTask("tie-y", networkA, "agent-a", "2026-01-05 00:00:00");
+  seedTask("tie-x", networkA, "agent-a", "2026-01-05 00:00:00");
   seedTask("a-cursor", networkA, "agent-a", "2026-01-03 00:00:00");
   seedTask("a-old-2", networkA, "agent-a", "2026-01-02 00:00:00");
   seedTask("a-old-1", networkA, "agent-b", "2026-01-01 00:00:00");
@@ -79,11 +82,31 @@ describe("GET /api/tasks cursor pagination", () => {
     expect(body.tasks.map((row: any) => row.task_id)).toEqual(["a-old-2"]);
   });
 
+  test("before_task_id preserves rows that share the cursor second", async () => {
+    const first = await list("limit=2");
+    expect(first.body.tasks.map((row: any) => row.task_id)).toEqual(["tie-z", "tie-y"]);
+    const cursor = first.body.tasks.at(-1);
+    const second = await list(
+      `before=${encodeURIComponent(cursor.created_at)}&before_task_id=${encodeURIComponent(cursor.task_id)}&limit=20`,
+    );
+    expect(second.response.status).toBe(200);
+    expect(second.body.tasks.map((row: any) => row.task_id)).toEqual([
+      "tie-x",
+      "a-new",
+      "a-cursor",
+      "a-old-2",
+      "a-old-1",
+    ]);
+  });
+
   test("omitting before preserves the existing response shape and newest-first order", async () => {
     const { body } = await list("limit=20");
     expect(body.ok).toBe(true);
-    expect(body.count).toBe(4);
+    expect(body.count).toBe(7);
     expect(body.tasks.map((row: any) => row.task_id)).toEqual([
+      "tie-z",
+      "tie-y",
+      "tie-x",
       "a-new",
       "a-cursor",
       "a-old-2",
@@ -97,6 +120,18 @@ describe("GET /api/tasks cursor pagination", () => {
       const { response, body } = await list(`before=${encodeURIComponent(cursor)}`);
       expect(response.status).toBe(400);
       expect(body).toEqual({ ok: false, error: "invalid_before" });
+    }
+  });
+
+  test("before_task_id requires a valid timestamp cursor and task id", async () => {
+    for (const query of [
+      "before_task_id=tie-y",
+      "before=2026-01-05%2000%3A00%3A00&before_task_id=",
+      `before=2026-01-05%2000%3A00%3A00&before_task_id=${"x".repeat(257)}`,
+    ]) {
+      const { response, body } = await list(query);
+      expect(response.status).toBe(400);
+      expect(body).toEqual({ ok: false, error: "invalid_before_task_id" });
     }
   });
 });

--- a/server/src/tasks-pagination-http.test.ts
+++ b/server/src/tasks-pagination-http.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-task-pagination-"));
+process.env.COMMHUB_DB = join(PRIVATE_DB_DIR, "hub.db");
+
+let db: typeof import("./db.js").db;
+let register: typeof import("./auth.js").register;
+let server: ReturnType<typeof Bun.serve>;
+let base = "";
+let tokenA = "";
+let networkA = "";
+let networkB = "";
+
+function seedTask(
+  taskId: string,
+  networkId: string,
+  toName: string,
+  createdAt: string,
+): void {
+  db.run(
+    `INSERT INTO tasks
+       (task_id, from_name, to_name, priority, status, content, network_id, created_at)
+     VALUES (?1, 'sender', ?2, 'normal', 'delivered', ?1, ?3, ?4)`,
+    [taskId, toName, networkId, createdAt],
+  );
+}
+
+beforeAll(async () => {
+  ({ db } = await import("./db.js"));
+  ({ register } = await import("./auth.js"));
+  const a = register(`page_a_${Date.now()}`, "PageTest-A-Strong!", undefined, "seed-a");
+  const b = register(`page_b_${Date.now()}`, "PageTest-B-Strong!", undefined, "seed-b");
+  expect(a.ok).toBe(true);
+  expect(b.ok).toBe(true);
+  tokenA = a.token!;
+  networkA = a.network_id!;
+  networkB = b.network_id!;
+
+  seedTask("a-new", networkA, "agent-a", "2026-01-04 00:00:00");
+  seedTask("a-cursor", networkA, "agent-a", "2026-01-03 00:00:00");
+  seedTask("a-old-2", networkA, "agent-a", "2026-01-02 00:00:00");
+  seedTask("a-old-1", networkA, "agent-b", "2026-01-01 00:00:00");
+  seedTask("b-old", networkB, "agent-a", "2026-01-02 12:00:00");
+
+  const mod = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop(true); } catch {}
+  try { rmSync(PRIVATE_DB_DIR, { recursive: true, force: true }); } catch {}
+});
+
+async function list(query: string): Promise<{ response: Response; body: any }> {
+  const response = await fetch(`${base}/api/tasks?skip_stats=1&${query}`, {
+    headers: { Authorization: `Bearer ${tokenA}` },
+  });
+  return { response, body: await response.json() };
+}
+
+describe("GET /api/tasks cursor pagination", () => {
+  test("before is exclusive and remains network-scoped", async () => {
+    const { response, body } = await list("before=2026-01-03%2000%3A00%3A00&limit=20");
+    expect(response.status).toBe(200);
+    expect(body.tasks.map((row: any) => row.task_id)).toEqual(["a-old-2", "a-old-1"]);
+    expect(body.tasks.some((row: any) => row.task_id === "a-cursor")).toBe(false);
+    expect(body.tasks.some((row: any) => row.task_id === "b-old")).toBe(false);
+  });
+
+  test("ISO cursor normalizes to SQLite UTC and composes with to_name", async () => {
+    const { body } = await list("before=2026-01-03T00%3A00%3A00Z&to_name=agent-a&limit=20");
+    expect(body.tasks.map((row: any) => row.task_id)).toEqual(["a-old-2"]);
+  });
+
+  test("omitting before preserves the existing response shape and newest-first order", async () => {
+    const { body } = await list("limit=20");
+    expect(body.ok).toBe(true);
+    expect(body.count).toBe(4);
+    expect(body.tasks.map((row: any) => row.task_id)).toEqual([
+      "a-new",
+      "a-cursor",
+      "a-old-2",
+      "a-old-1",
+    ]);
+    expect(body.stats).toBeUndefined();
+  });
+
+  test("empty, malformed, and rolled-over cursors fail closed", async () => {
+    for (const cursor of ["", "not-a-time", "2026-02-31 00:00:00"]) {
+      const { response, body } = await list(`before=${encodeURIComponent(cursor)}`);
+      expect(response.status).toBe(400);
+      expect(body).toEqual({ ok: false, error: "invalid_before" });
+    }
+  });
+});

--- a/tests/test624-task-cursor-pagination/Dockerfile
+++ b/tests/test624-task-cursor-pagination/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test624-task-cursor-pagination ./tests/test624-task-cursor-pagination
+ARG SOURCE_COMMIT
+ENV TEST624_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test624-task-cursor-pagination/run.sh
+ENTRYPOINT ["/workspace/tests/test624-task-cursor-pagination/run.sh"]

--- a/tests/test624-task-cursor-pagination/README.md
+++ b/tests/test624-task-cursor-pagination/README.md
@@ -1,0 +1,12 @@
+# test624 — task cursor pagination
+
+Runs a real isolated Hub and SQLite database to verify that `/api/tasks`:
+
+- honors an exclusive `before` cursor;
+- composes it with `to_name` and authenticated network scope;
+- accepts SQLite and ISO UTC timestamp shapes;
+- rejects malformed/rolled-over cursors;
+- preserves the no-cursor response contract.
+
+Three source mutations prove the cursor filter, exclusivity, and validation
+are load-bearing.

--- a/tests/test624-task-cursor-pagination/README.md
+++ b/tests/test624-task-cursor-pagination/README.md
@@ -2,6 +2,10 @@
 
 Runs a real isolated Hub and SQLite database to verify that `/api/tasks`:
 
+- supports `before=<created_at>&before_task_id=<task_id>` as a stable
+  compound cursor, so rows sharing SQLite's one-second timestamp precision
+  are not skipped between pages;
+
 - honors an exclusive `before` cursor;
 - composes it with `to_name` and authenticated network scope;
 - accepts SQLite and ISO UTC timestamp shapes;

--- a/tests/test624-task-cursor-pagination/run.sh
+++ b/tests/test624-task-cursor-pagination/run.sh
@@ -40,23 +40,35 @@ run_real /tmp/test624-green.db
 cp "$SOURCE" /tmp/test624-server.ts
 
 echo "L2 witnessed-red: before predicate is load-bearing"
-sed -i 's/if (before) { sql += ` AND created_at < ?${params.length + 1}`; params.push(before); }/if (false \&\& before) { sql += ` AND created_at < ?${params.length + 1}`; params.push(before); }/' "$SOURCE"
-grep -Fq 'if (false && before)' "$SOURCE"
+sed -i 's/} else if (before) {/} else if (false \&\& before) {/' "$SOURCE"
+grep -Fq 'else if (false && before)' "$SOURCE"
 expect_red before-filter 'before is exclusive and remains network-scoped'
 cp /tmp/test624-server.ts "$SOURCE"
 
 echo "L3 witnessed-red: exact cursor row must stay excluded"
-sed -i 's/AND created_at < ?${params.length + 1}/AND created_at <= ?${params.length + 1}/' "$SOURCE"
-grep -Fq 'AND created_at <= ?${params.length + 1}' "$SOURCE"
+sed -i 's/sql += ` AND created_at < ?${params.length + 1}`;/sql += ` AND created_at <= ?${params.length + 1}`;/' "$SOURCE"
+grep -Fq 'sql += ` AND created_at <= ?${params.length + 1}`;' "$SOURCE"
 expect_red exclusive-cursor 'before is exclusive and remains network-scoped'
 cp /tmp/test624-server.ts "$SOURCE"
 
-echo "L4 witnessed-red: malformed cursor rejection is load-bearing"
+echo "L4 witnessed-red: compound cursor tie-break is load-bearing"
+sed -i 's/AND task_id < ?${taskIdParam}/AND task_id > ?${taskIdParam}/' "$SOURCE"
+grep -Fq 'AND task_id > ?${taskIdParam}' "$SOURCE"
+expect_red same-second-cursor 'before_task_id preserves rows that share the cursor second'
+cp /tmp/test624-server.ts "$SOURCE"
+
+echo "L5 witnessed-red: malformed cursor rejection is load-bearing"
 sed -i 's/if (rawBefore !== null \&\& before === null)/if (false \&\& rawBefore !== null \&\& before === null)/' "$SOURCE"
 grep -Fq 'if (false && rawBefore' "$SOURCE"
 expect_red invalid-cursor 'empty, malformed, and rolled-over cursors fail closed'
 cp /tmp/test624-server.ts "$SOURCE"
 
-echo "L5 restored green"
+echo "L6 witnessed-red: compound cursor validation is load-bearing"
+sed -i 's/if (rawBeforeTaskId !== null \&\& (before === null || beforeTaskId === null))/if (false \&\& rawBeforeTaskId !== null \&\& (before === null || beforeTaskId === null))/' "$SOURCE"
+grep -Fq 'if (false && rawBeforeTaskId' "$SOURCE"
+expect_red compound-validation 'before_task_id requires a valid timestamp cursor and task id'
+cp /tmp/test624-server.ts "$SOURCE"
+
+echo "L7 restored green"
 run_real /tmp/test624-restored.db
 echo "RESULT: PASS"

--- a/tests/test624-task-cursor-pagination/run.sh
+++ b/tests/test624-task-cursor-pagination/run.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test624-task-cursor-pagination.txt"
+SOURCE=server/src/server.ts
+mkdir -p "$ARTIFACT_DIR"
+: >"$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+run_real() {
+  COMMHUB_DB="$1" bun test server/src/tasks-pagination-http.test.ts
+}
+
+expect_red() {
+  local label=$1 marker=$2
+  set +e
+  run_real "/tmp/test624-$label.db" >/tmp/test624-red.log 2>&1
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    echo "MUTATION_FALSE_GREEN: $label"
+    sed -n '1,220p' /tmp/test624-red.log
+    exit 1
+  fi
+  grep -Fq "$marker" /tmp/test624-red.log
+  echo "MUTATION_RED: $label rc=$rc"
+}
+
+echo "# test624 — /api/tasks cursor pagination"
+echo "source_commit=${TEST624_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+echo "L0 build"
+bun build server/src/index.ts --target bun --outfile /tmp/commhub-task-page.js
+test -s /tmp/commhub-task-page.js
+
+echo "L1 real Hub + SQLite pagination"
+run_real /tmp/test624-green.db
+cp "$SOURCE" /tmp/test624-server.ts
+
+echo "L2 witnessed-red: before predicate is load-bearing"
+sed -i 's/if (before) { sql += ` AND created_at < ?${params.length + 1}`; params.push(before); }/if (false \&\& before) { sql += ` AND created_at < ?${params.length + 1}`; params.push(before); }/' "$SOURCE"
+grep -Fq 'if (false && before)' "$SOURCE"
+expect_red before-filter 'before is exclusive and remains network-scoped'
+cp /tmp/test624-server.ts "$SOURCE"
+
+echo "L3 witnessed-red: exact cursor row must stay excluded"
+sed -i 's/AND created_at < ?${params.length + 1}/AND created_at <= ?${params.length + 1}/' "$SOURCE"
+grep -Fq 'AND created_at <= ?${params.length + 1}' "$SOURCE"
+expect_red exclusive-cursor 'before is exclusive and remains network-scoped'
+cp /tmp/test624-server.ts "$SOURCE"
+
+echo "L4 witnessed-red: malformed cursor rejection is load-bearing"
+sed -i 's/if (rawBefore !== null \&\& before === null)/if (false \&\& rawBefore !== null \&\& before === null)/' "$SOURCE"
+grep -Fq 'if (false && rawBefore' "$SOURCE"
+expect_red invalid-cursor 'empty, malformed, and rolled-over cursors fail closed'
+cp /tmp/test624-server.ts "$SOURCE"
+
+echo "L5 restored green"
+run_real /tmp/test624-restored.db
+echo "RESULT: PASS"


### PR DESCRIPTION
## Summary
- honor exclusive `before` on `GET /api/tasks` using the indexed `created_at` column
- compose cursor pagination with existing `to_name`, `from_name`, status, task-id, and authenticated network scope
- accept native SQLite or ISO timestamp cursors; fail closed with `400 invalid_before` for malformed/rolled-over values
- preserve the no-cursor response contract and add deterministic task-id tie ordering

## Verification
- source: `d25dcc07e15c5cc36385761d43c2336d96dce11a`
- exact Docker real Hub + SQLite: 4 pass / 15 assertions; restored green
- cursor filter, exclusivity, and validation mutations all red
- report-only head includes `docs/tests/report-test624-task-cursor-pagination.txt`

Closes #459

No production mutation or deployment.