### PR TITLE
fix(cli): reject CRLF in explicit --env (#621)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -88,7 +88,10 @@ import {
   type GrokCopresenceSessionDisclosure,
 } from "../src/grok-copresence-disclosure";
 import { parseCliOptions, positionalArgs } from "../src/cli-args";
-import { collectClaudeVendorEnvForCreate } from "../src/claude-vendor-env";
+import {
+  collectClaudeVendorEnvForCreate,
+  planPlainSecretEnvRewrites,
+} from "../src/claude-vendor-env";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -2810,6 +2813,14 @@ function ensureAnetInRootGitignore(): void {
 }
 
 function saveCreatedNode(id: string, profile: Profile) {
+  // Preflight the exact values that rewritePlainSecretsToEnvRef will persist
+  // before any node directory, gitignore, process.env, config, or dotenv
+  // mutation. This is the shared create choke-point used by both the named
+  // command and the no-name interactive wizard.
+  planPlainSecretEnvRewrites({
+    env: (profile as any).env,
+    nodeId: ((profile as any).node_id || id),
+  });
   if (normalizeRuntime(profile) === "opencode-cli") {
     // This must be the first node-state operation: the envRef rewrite and
     // saveProfile both carry credentials. Reject node/leaf symlinks first.
@@ -2839,21 +2850,20 @@ function saveCreatedNode(id: string, profile: Profile) {
 function rewritePlainSecretsToEnvRef(nodeId: string, profile: Profile): void {
   const env: any = (profile as any).env;
   if (!env || typeof env !== "object") return;
-  const SECRET_KEY_RX = /(_TOKEN|_KEY|_SECRET|AUTH)$/i;
-  const SECRET_VAL_RX = /^(sk-|utok_|ntok_|atok_|ak-|gsk_|key-|Bearer\s)/i;
-  const nodeIdShort = ((profile as any).node_id || nodeId).replace(/[^A-Za-z0-9_]/g, "_").slice(0, 16);
-  const rewrites: { key: string; refName: string; value: string }[] = [];
-  for (const [k, v] of Object.entries(env)) {
-    if (typeof v !== "string") continue; // already envRef
-    if (!(SECRET_KEY_RX.test(k) || SECRET_VAL_RX.test(v))) continue;
-    const refName = `${k}_${nodeIdShort}`.toUpperCase();
-    rewrites.push({ key: k, refName, value: v });
-    env[k] = { _envRef: refName };
+  // Re-run the side-effect-free planner at the actual writer boundary. The
+  // saveCreatedNode preflight guarantees zero create-side effects; this call
+  // is defense in depth for any future caller that reaches the writer directly.
+  const rewrites = planPlainSecretEnvRewrites({
+    env,
+    nodeId: ((profile as any).node_id || nodeId),
+  });
+  for (const { key, refName, value } of rewrites) {
+    env[key] = { _envRef: refName };
     // Also surface the value in the *current* process.env so this very
     // session's downstream (e.g. spawning the agent right after create) can
     // start without the user having to re-`export`. Persistent storage is
     // still the user's responsibility (.bashrc / secrets manager).
-    if (!process.env[refName]) process.env[refName] = v;
+    if (!process.env[refName]) process.env[refName] = value;
   }
   if (rewrites.length === 0) return;
 

--- a/agent-network/src/claude-vendor-env-wiring.test.ts
+++ b/agent-network/src/claude-vendor-env-wiring.test.ts
@@ -10,3 +10,33 @@ test("node create captures vendor shell env before profile construction", () => 
   expect(profile).toBeGreaterThan(call);
   expect(cli.slice(call, profile)).toContain("shellEnv: process.env");
 });
+
+test("every dotenv-writing create preflights before any node-state side effect", () => {
+  const saveStart = cli.indexOf("function saveCreatedNode(id: string, profile: Profile)");
+  const saveEnd = cli.indexOf("function rewritePlainSecretsToEnvRef", saveStart);
+  const body = cli.slice(saveStart, saveEnd);
+  const preflight = body.indexOf("planPlainSecretEnvRewrites({");
+  expect(saveStart).toBeGreaterThan(0);
+  expect(preflight).toBeGreaterThan(0);
+  for (const sideEffect of [
+    "prepareOpencodeNodeForProfileWrite(",
+    "writeOpencodePrivateProfileFile(",
+    "ensureAnetInRootGitignore()",
+    "rewritePlainSecretsToEnvRef(",
+    "writeLegacyProjectAlias(",
+    "saveProfile(",
+  ]) {
+    expect(body.indexOf(sideEffect)).toBeGreaterThan(preflight);
+  }
+});
+
+test("the dotenv writer itself reuses the side-effect-free planner", () => {
+  const writerStart = cli.indexOf("function rewritePlainSecretsToEnvRef");
+  const writerEnd = cli.indexOf("async function requestNodeToken", writerStart);
+  const body = cli.slice(writerStart, writerEnd);
+  const planner = body.indexOf("const rewrites = planPlainSecretEnvRewrites({");
+  expect(writerStart).toBeGreaterThan(0);
+  expect(planner).toBeGreaterThan(0);
+  expect(body.indexOf("process.env[refName] = value")).toBeGreaterThan(planner);
+  expect(body.indexOf("writeFileSync(dotenvPath, body")).toBeGreaterThan(planner);
+});

--- a/agent-network/src/claude-vendor-env.test.ts
+++ b/agent-network/src/claude-vendor-env.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { collectClaudeVendorEnvForCreate } from "./claude-vendor-env.js";
+import {
+  collectClaudeVendorEnvForCreate,
+  planPlainSecretEnvRewrites,
+} from "./claude-vendor-env.js";
 
 describe("collectClaudeVendorEnvForCreate", () => {
   test("captures known vendor endpoint and credential for claude-agent-sdk", () => {
@@ -59,5 +62,30 @@ describe("collectClaudeVendorEnvForCreate", () => {
         shellEnv: {},
       })).toThrow("--env entries cannot contain line breaks");
     }
+  });
+});
+
+describe("planPlainSecretEnvRewrites", () => {
+  test("plans the exact dotenv assignment without mutating the profile", () => {
+    const env = {
+      ANTHROPIC_API_KEY: "safe-value",
+      NON_SECRET_SETTING: "kept-in-config",
+    };
+    expect(planPlainSecretEnvRewrites({ env, nodeId: "n_test-1" })).toEqual([{
+      key: "ANTHROPIC_API_KEY",
+      refName: "ANTHROPIC_API_KEY_N_TEST_1",
+      value: "safe-value",
+    }]);
+    expect(env).toEqual({
+      ANTHROPIC_API_KEY: "safe-value",
+      NON_SECRET_SETTING: "kept-in-config",
+    });
+  });
+
+  test("rejects a secret dotenv value with CRLF before any caller mutation", () => {
+    expect(() => planPlainSecretEnvRewrites({
+      env: { ANTHROPIC_API_KEY: "safe\r\nINJECTED=bad" },
+      nodeId: "n_test",
+    })).toThrow("ANTHROPIC_API_KEY contains a line break");
   });
 });

--- a/agent-network/src/claude-vendor-env.test.ts
+++ b/agent-network/src/claude-vendor-env.test.ts
@@ -47,4 +47,17 @@ describe("collectClaudeVendorEnvForCreate", () => {
       shellEnv: { ANTHROPIC_AUTH_TOKEN: "safe\nINJECTED=value" },
     })).toThrow("contains a line break");
   });
+
+  test("rejects line breaks in explicit --env for every runtime", () => {
+    for (const [runtime, entry] of [
+      ["claude-agent-sdk", "ANTHROPIC_API_KEY=safe\nINJECTED=value"],
+      ["codex-sdk", "OPENAI_API_KEY=safe\rINJECTED=value"],
+    ] as const) {
+      expect(() => collectClaudeVendorEnvForCreate({
+        runtime,
+        explicitEnv: [entry],
+        shellEnv: {},
+      })).toThrow("--env entries cannot contain line breaks");
+    }
+  });
 });

--- a/agent-network/src/claude-vendor-env.ts
+++ b/agent-network/src/claude-vendor-env.ts
@@ -4,6 +4,44 @@ export const CLAUDE_VENDOR_ENV_KEYS = [
   "ANTHROPIC_API_KEY",
 ] as const;
 
+const SECRET_ENV_KEY_RX = /(_TOKEN|_KEY|_SECRET|AUTH)$/i;
+const SECRET_ENV_VALUE_RX = /^(sk-|utok_|ntok_|atok_|ak-|gsk_|key-|Bearer\s)/i;
+
+export type PlainSecretEnvRewrite = {
+  key: string;
+  refName: string;
+  value: string;
+};
+
+/**
+ * Plan the values that the node-create writer will move into its line-oriented
+ * `.env` file. This is deliberately side-effect free: callers can run it as a
+ * preflight before creating a node directory, changing process.env, or writing
+ * config.json. Keeping the line-break rejection here makes it cover every
+ * caller of the dotenv writer, including the no-name interactive wizard.
+ */
+export function planPlainSecretEnvRewrites(input: {
+  env: unknown;
+  nodeId: string;
+}): PlainSecretEnvRewrite[] {
+  if (!input.env || typeof input.env !== "object") return [];
+  const nodeIdShort = input.nodeId.replace(/[^A-Za-z0-9_]/g, "_").slice(0, 16);
+  const rewrites: PlainSecretEnvRewrite[] = [];
+  for (const [key, value] of Object.entries(input.env)) {
+    if (typeof value !== "string") continue;
+    if (!(SECRET_ENV_KEY_RX.test(key) || SECRET_ENV_VALUE_RX.test(value))) continue;
+    if (/[\r\n]/.test(value)) {
+      throw new Error(`${key} contains a line break and cannot be persisted safely`);
+    }
+    rewrites.push({
+      key,
+      refName: `${key}_${nodeIdShort}`.toUpperCase(),
+      value,
+    });
+  }
+  return rewrites;
+}
+
 /**
  * Persist the exact Anthropic-compatible vendor environment used by an
  * explicit claude-agent-sdk create. Explicit --env values retain precedence;

--- a/agent-network/src/claude-vendor-env.ts
+++ b/agent-network/src/claude-vendor-env.ts
@@ -16,6 +16,11 @@ export function collectClaudeVendorEnvForCreate(input: {
   shellEnv: Readonly<Record<string, string | undefined>>;
 }): string[] {
   const out = [...input.explicitEnv];
+  for (const entry of out) {
+    if (/[\r\n]/.test(entry)) {
+      throw new Error("--env entries cannot contain line breaks");
+    }
+  }
   if (input.runtime !== "claude-agent-sdk") return out;
 
   const explicitKeys = new Set(

--- a/docs/tests/report-test625-explicit-env-crlf.txt
+++ b/docs/tests/report-test625-explicit-env-crlf.txt
@@ -2,32 +2,42 @@
 
 Date: 2026-08-09
 Issue: #621
-Source commit: 65a8863233e419888dcaa97e43471eb01c7c3221
+Source commit: 73542ee9c5cfcb2a688e3a3596463e0b1504faf4
 Docker tag: anet-test625:dev
-Docker image: sha256:6150f392f993c3c2f41d3175216c68563fd15f6e822271c7d56aeec7c4f8b9cf
-Embedded source: TEST625_SOURCE_COMMIT=65a8863233e419888dcaa97e43471eb01c7c3221
-Runner artifact SHA256: 5359f3e82baa38f16194eb2ed75dd5631a0a0f138274c03d7c329925cabe39fe
+Docker image: sha256:13d47bbbcf2ff11d17b60d582207d5a15683a1c40a8f7f3ee17e9f48e0718094
+Embedded source: TEST625_SOURCE_COMMIT=73542ee9c5cfcb2a688e3a3596463e0b1504faf4
+Runner artifact SHA256: c01a98c775da963358652e23ec7bd11c19f991438f50b602fb868fef2073d74e
 
 ## Result
 
 - TypeScript `tsc --noEmit`: PASS.
-- Helper contracts: 5 pass / 0 fail / 6 assertions.
+- Helper and writer-wiring contracts: 10 pass / 0 fail / 24 assertions.
 - Production CLI/node-server/worker build: PASS.
 - Real isolated Hub + built CLI rejected a newline-bearing explicit `--env`
   before either `config.json` or `.env` existed.
 - The rejection log did not echo the synthetic injected value.
 - A safe explicit credential still created a mode-600 dotenv containing
   exactly one assignment and no injected key.
-- Removing the validation, rebuilding the real CLI, and repeating the same
-  create command produced a second `INJECTED=...` dotenv line. This is a true
-  behavior mutation, not a source-string assertion.
+- All `.env`-writing create flows converge on `saveCreatedNode` and
+  `rewritePlainSecretsToEnvRef`. The named create reaches the earlier vendor
+  collector; the no-name wizard bypasses that collector but reaches the shared
+  writer preflight. Batch and the legacy missing-profile wizard call
+  `saveProfile` directly and do not write a node `.env`.
+- Disabling only the named-create collector still rejected the malicious value
+  at the shared writer preflight before node directory, `.gitignore`, process
+  environment, config, or dotenv mutation.
+- Disabling both the named-create collector and the writer planner, rebuilding
+  the real CLI, and repeating the command produced a second `INJECTED=...`
+  dotenv line. This is a true behavior mutation, not a source-string assertion.
 - Restoring the validation and rebuilding restored fail-closed behavior with
   no profile or dotenv write.
 
 ```text
-L3 witnessed-red: removing validation injects a second dotenv line
-MUTATION_RED: explicit-env-crlf rc=1 (injected dotenv line witnessed)
-L4 restored green
+L3 defense-in-depth: bypassing direct collection still fails at the writer preflight
+WRITER_PREFLIGHT_PASS: direct collector bypass still rejected before create side effects
+L4 witnessed-red: bypassing both guards injects a second dotenv line
+MUTATION_RED: dotenv-writer-crlf rc=1 (injected dotenv line witnessed)
+L5 restored green
 RESULT: PASS
 ```
 

--- a/docs/tests/report-test625-explicit-env-crlf.txt
+++ b/docs/tests/report-test625-explicit-env-crlf.txt
@@ -1,0 +1,36 @@
+# test625 — explicit `--env` CRLF rejection
+
+Date: 2026-08-09
+Issue: #621
+Source commit: 65a8863233e419888dcaa97e43471eb01c7c3221
+Docker tag: anet-test625:dev
+Docker image: sha256:6150f392f993c3c2f41d3175216c68563fd15f6e822271c7d56aeec7c4f8b9cf
+Embedded source: TEST625_SOURCE_COMMIT=65a8863233e419888dcaa97e43471eb01c7c3221
+Runner artifact SHA256: 5359f3e82baa38f16194eb2ed75dd5631a0a0f138274c03d7c329925cabe39fe
+
+## Result
+
+- TypeScript `tsc --noEmit`: PASS.
+- Helper contracts: 5 pass / 0 fail / 6 assertions.
+- Production CLI/node-server/worker build: PASS.
+- Real isolated Hub + built CLI rejected a newline-bearing explicit `--env`
+  before either `config.json` or `.env` existed.
+- The rejection log did not echo the synthetic injected value.
+- A safe explicit credential still created a mode-600 dotenv containing
+  exactly one assignment and no injected key.
+- Removing the validation, rebuilding the real CLI, and repeating the same
+  create command produced a second `INJECTED=...` dotenv line. This is a true
+  behavior mutation, not a source-string assertion.
+- Restoring the validation and rebuilding restored fail-closed behavior with
+  no profile or dotenv write.
+
+```text
+L3 witnessed-red: removing validation injects a second dotenv line
+MUTATION_RED: explicit-env-crlf rc=1 (injected dotenv line witnessed)
+L4 restored green
+RESULT: PASS
+```
+
+All credentials and injected values were synthetic fixtures inside Docker.
+No production service, database, token, global package, or deployment was
+touched.

--- a/tests/test625-explicit-env-crlf/Dockerfile
+++ b/tests/test625-explicit-env-crlf/Dockerfile
@@ -1,0 +1,19 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+COPY server/package.json ./server/
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+
+COPY agent-network/package.json agent-network/package-lock.json ./agent-network/
+RUN cd agent-network && bun install --ignore-scripts
+COPY agent-network ./agent-network
+COPY tests/test625-explicit-env-crlf ./tests/test625-explicit-env-crlf
+
+ARG SOURCE_COMMIT
+ENV TEST625_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 tests/test625-explicit-env-crlf/run.sh tests/test625-explicit-env-crlf/fake-agent-node.sh
+ENTRYPOINT ["/workspace/tests/test625-explicit-env-crlf/run.sh"]

--- a/tests/test625-explicit-env-crlf/README.md
+++ b/tests/test625-explicit-env-crlf/README.md
@@ -1,0 +1,7 @@
+# test625 — explicit `--env` CRLF rejection
+
+Runs a built CLI against a real isolated Hub and verifies that `anet node
+create --env` rejects CR/LF before writing a node profile or dotenv file.
+
+The mutation removes the validation, rebuilds the CLI, and witnesses a second
+dotenv assignment being injected. All state stays inside the Docker container.

--- a/tests/test625-explicit-env-crlf/fake-agent-node.sh
+++ b/tests/test625-explicit-env-crlf/fake-agent-node.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  echo "agent-node v2.5.0-preview.30"
+  exit 0
+fi
+if [[ "${1:-}" == "--help" ]]; then
+  echo "agent-node --config --alias --runtime"
+  exit 0
+fi
+exit 0

--- a/tests/test625-explicit-env-crlf/run.sh
+++ b/tests/test625-explicit-env-crlf/run.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
 REPORT="$ARTIFACT_DIR/report-test625-explicit-env-crlf.txt"
 HELPER=/workspace/agent-network/src/claude-vendor-env.ts
+CLI=/workspace/agent-network/bin/cli.ts
 mkdir -p "$ARTIFACT_DIR"
 : >"$REPORT"
 exec > >(tee -a "$REPORT") 2>&1
@@ -15,7 +16,7 @@ echo "date=$(date -Is)"
 echo "L0 typecheck + helper contracts + production build"
 cd /workspace/agent-network
 bun run typecheck
-bun test src/claude-vendor-env.test.ts
+bun test src/claude-vendor-env.test.ts src/claude-vendor-env-wiring.test.ts
 bun run build >/tmp/test625-build.log
 cd /workspace
 
@@ -65,8 +66,9 @@ test "$(stat -c %a "$SAFE_ENV")" = 600
 grep -Eq '^ANTHROPIC_API_KEY_[A-Z0-9_]+=test625-safe$' "$SAFE_ENV"
 ! grep -Fq 'INJECTED=' "$SAFE_ENV"
 
-echo "L3 witnessed-red: removing validation injects a second dotenv line"
+echo "L3 defense-in-depth: bypassing direct collection still fails at the writer preflight"
 cp "$HELPER" /tmp/test625-helper.ts
+cp "$CLI" /tmp/test625-cli.ts
 sed -i 's/if (\/\[\\r\\n\]\/\.test(entry))/if (false \&\& \/[\\r\\n]\/\.test(entry))/' "$HELPER"
 grep -Fq 'if (false && /[\r\n]/.test(entry))' "$HELPER"
 cd /workspace/agent-network
@@ -77,15 +79,37 @@ PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create mutation-node \
   --runtime claude-agent-sdk --env "$INJECTED_ENV" >/tmp/test625-mutant.log 2>&1
 mutant_rc=$?
 set -e
-if [[ "$mutant_rc" -ne 0 ]] || ! grep -Fxq 'INJECTED=test625-bad' .anet/nodes/mutation-node/.env; then
-  echo "MUTATION_FALSE_GREEN: explicit-env-crlf"
+if [[ "$mutant_rc" -eq 0 ]] || ! grep -Fq 'ANTHROPIC_API_KEY contains a line break' /tmp/test625-mutant.log; then
+  echo "WRITER_PREFLIGHT_FALSE_GREEN: direct collector bypass"
   sed -n '1,160p' /tmp/test625-mutant.log
   exit 1
 fi
-echo "MUTATION_RED: explicit-env-crlf rc=1 (injected dotenv line witnessed)"
+test ! -e .anet/nodes/mutation-node/config.json
+test ! -e .anet/nodes/mutation-node/.env
+test ! -e .gitignore
+echo "WRITER_PREFLIGHT_PASS: direct collector bypass still rejected before create side effects"
 
-echo "L4 restored green"
+echo "L4 witnessed-red: bypassing both guards injects a second dotenv line"
+sed -i '0,/if (\/\[\\r\\n\]\/\.test(value))/{s/if (\/\[\\r\\n\]\/\.test(value))/if (false \&\& \/[\\r\\n]\/\.test(value))/}' "$HELPER"
+grep -Fq 'if (false && /[\r\n]/.test(value))' "$HELPER"
+cd /workspace/agent-network
+bun run build >/tmp/test625-double-mutant-build.log
+cd /tmp/test625-project
+set +e
+PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create double-mutation-node \
+  --runtime claude-agent-sdk --env "$INJECTED_ENV" >/tmp/test625-double-mutant.log 2>&1
+double_mutant_rc=$?
+set -e
+if [[ "$double_mutant_rc" -ne 0 ]] || ! grep -Fxq 'INJECTED=test625-bad' .anet/nodes/double-mutation-node/.env; then
+  echo "MUTATION_FALSE_GREEN: dotenv-writer-crlf"
+  sed -n '1,160p' /tmp/test625-double-mutant.log
+  exit 1
+fi
+echo "MUTATION_RED: dotenv-writer-crlf rc=1 (injected dotenv line witnessed)"
+
+echo "L5 restored green"
 cp /tmp/test625-helper.ts "$HELPER"
+cp /tmp/test625-cli.ts "$CLI"
 cd /workspace/agent-network
 bun run build >/tmp/test625-restored-build.log
 cd /tmp/test625-project

--- a/tests/test625-explicit-env-crlf/run.sh
+++ b/tests/test625-explicit-env-crlf/run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test625-explicit-env-crlf.txt"
+HELPER=/workspace/agent-network/src/claude-vendor-env.ts
+mkdir -p "$ARTIFACT_DIR"
+: >"$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test625 — explicit --env CRLF rejection"
+echo "source_commit=${TEST625_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+echo "L0 typecheck + helper contracts + production build"
+cd /workspace/agent-network
+bun run typecheck
+bun test src/claude-vendor-env.test.ts
+bun run build >/tmp/test625-build.log
+cd /workspace
+
+echo "L1 real Hub + built CLI rejects before profile write"
+export HOME=/tmp/test625-home
+export COMMHUB_DB=/tmp/test625-hub.db
+export PORT=9625
+mkdir -p "$HOME" /tmp/test625-project /tmp/test625-bin
+cp tests/test625-explicit-env-crlf/fake-agent-node.sh /tmp/test625-bin/agent-node
+chmod 0755 /tmp/test625-bin/agent-node
+PATH="/tmp/test625-bin:$PATH" bun run server/src/index.ts >/tmp/test625-hub.log 2>&1 &
+hub_pid=$!
+trap 'kill "$hub_pid" 2>/dev/null || true' EXIT
+for _ in $(seq 1 50); do
+  if curl -fsS http://127.0.0.1:9625/health >/dev/null; then break; fi
+  sleep 0.1
+done
+curl -fsS http://127.0.0.1:9625/health | grep -Fq '"ok":true'
+curl -fsS -X POST http://127.0.0.1:9625/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"anethub"}' | grep -Fq '"ok":true'
+
+ANET=(bun /workspace/agent-network/dist/bin/cli.js)
+"${ANET[@]}" login --hub http://127.0.0.1:9625 --username admin --password anethub \
+  >/tmp/test625-login.log
+cd /tmp/test625-project
+unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY
+INJECTED_ENV=$'ANTHROPIC_API_KEY=test625-safe\nINJECTED=test625-bad'
+
+set +e
+PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create rejected-node \
+  --runtime claude-agent-sdk --env "$INJECTED_ENV" >/tmp/test625-rejected.log 2>&1
+reject_rc=$?
+set -e
+test "$reject_rc" -ne 0
+grep -Fq -- '--env entries cannot contain line breaks' /tmp/test625-rejected.log
+! grep -Fq 'test625-bad' /tmp/test625-rejected.log
+test ! -e .anet/nodes/rejected-node/config.json
+test ! -e .anet/nodes/rejected-node/.env
+
+echo "L2 safe explicit value still creates one env assignment"
+PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create safe-node \
+  --runtime claude-agent-sdk --env 'ANTHROPIC_API_KEY=test625-safe' >/tmp/test625-safe.log
+SAFE_ENV=.anet/nodes/safe-node/.env
+test -f "$SAFE_ENV"
+test "$(stat -c %a "$SAFE_ENV")" = 600
+grep -Eq '^ANTHROPIC_API_KEY_[A-Z0-9_]+=test625-safe$' "$SAFE_ENV"
+! grep -Fq 'INJECTED=' "$SAFE_ENV"
+
+echo "L3 witnessed-red: removing validation injects a second dotenv line"
+cp "$HELPER" /tmp/test625-helper.ts
+sed -i 's/if (\/\[\\r\\n\]\/\.test(entry))/if (false \&\& \/[\\r\\n]\/\.test(entry))/' "$HELPER"
+grep -Fq 'if (false && /[\r\n]/.test(entry))' "$HELPER"
+cd /workspace/agent-network
+bun run build >/tmp/test625-mutant-build.log
+cd /tmp/test625-project
+set +e
+PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create mutation-node \
+  --runtime claude-agent-sdk --env "$INJECTED_ENV" >/tmp/test625-mutant.log 2>&1
+mutant_rc=$?
+set -e
+if [[ "$mutant_rc" -ne 0 ]] || ! grep -Fxq 'INJECTED=test625-bad' .anet/nodes/mutation-node/.env; then
+  echo "MUTATION_FALSE_GREEN: explicit-env-crlf"
+  sed -n '1,160p' /tmp/test625-mutant.log
+  exit 1
+fi
+echo "MUTATION_RED: explicit-env-crlf rc=1 (injected dotenv line witnessed)"
+
+echo "L4 restored green"
+cp /tmp/test625-helper.ts "$HELPER"
+cd /workspace/agent-network
+bun run build >/tmp/test625-restored-build.log
+cd /tmp/test625-project
+set +e
+PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create restored-node \
+  --runtime claude-agent-sdk --env "$INJECTED_ENV" >/tmp/test625-restored.log 2>&1
+restored_rc=$?
+set -e
+test "$restored_rc" -ne 0
+grep -Fq -- '--env entries cannot contain line breaks' /tmp/test625-restored.log
+test ! -e .anet/nodes/restored-node/config.json
+test ! -e .anet/nodes/restored-node/.env
+
+echo "RESULT: PASS"

--- a/tests/test625-explicit-env-crlf/run.sh
+++ b/tests/test625-explicit-env-crlf/run.sh
@@ -69,11 +69,12 @@ grep -Eq '^ANTHROPIC_API_KEY_[A-Z0-9_]+=test625-safe$' "$SAFE_ENV"
 echo "L3 defense-in-depth: bypassing direct collection still fails at the writer preflight"
 cp "$HELPER" /tmp/test625-helper.ts
 cp "$CLI" /tmp/test625-cli.ts
+mkdir -p /tmp/test625-writer-project
 sed -i 's/if (\/\[\\r\\n\]\/\.test(entry))/if (false \&\& \/[\\r\\n]\/\.test(entry))/' "$HELPER"
 grep -Fq 'if (false && /[\r\n]/.test(entry))' "$HELPER"
 cd /workspace/agent-network
 bun run build >/tmp/test625-mutant-build.log
-cd /tmp/test625-project
+cd /tmp/test625-writer-project
 set +e
 PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create mutation-node \
   --runtime claude-agent-sdk --env "$INJECTED_ENV" >/tmp/test625-mutant.log 2>&1
@@ -94,7 +95,7 @@ sed -i '0,/if (\/\[\\r\\n\]\/\.test(value))/{s/if (\/\[\\r\\n\]\/\.test(value))/
 grep -Fq 'if (false && /[\r\n]/.test(value))' "$HELPER"
 cd /workspace/agent-network
 bun run build >/tmp/test625-double-mutant-build.log
-cd /tmp/test625-project
+cd /tmp/test625-writer-project
 set +e
 PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create double-mutation-node \
   --runtime claude-agent-sdk --env "$INJECTED_ENV" >/tmp/test625-double-mutant.log 2>&1
@@ -112,7 +113,7 @@ cp /tmp/test625-helper.ts "$HELPER"
 cp /tmp/test625-cli.ts "$CLI"
 cd /workspace/agent-network
 bun run build >/tmp/test625-restored-build.log
-cd /tmp/test625-project
+cd /tmp/test625-writer-project
 set +e
 PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create restored-node \
   --runtime claude-agent-sdk --env "$INJECTED_ENV" >/tmp/test625-restored.log 2>&1


### PR DESCRIPTION
## Summary
- reject CR/LF in every explicit `anet node create --env` entry before profile construction
- keep safe explicit values and Claude vendor-shell inheritance behavior unchanged
- add exact-source Docker coverage with a real Hub and built CLI

## Verification
- helper contracts: 5 pass / 0 fail / 6 assertions
- production build: PASS
- real built CLI: malformed explicit env rejected before `config.json`/`.env` write
- witnessed-red: removing validation produces a second injected dotenv assignment
- restored behavior: PASS

Evidence: `docs/tests/report-test625-explicit-env-crlf.txt`

Closes #621.