### PR TITLE
refactor(uploads): share extension token validator (#527)

### DIFF
--- a/docs/tests/report-test527-ext-validator-dedup.txt
+++ b/docs/tests/report-test527-ext-validator-dedup.txt
@@ -1,0 +1,28 @@
+# Test 527 — shared stored extension-token validator
+
+Date: 2026-08-09
+Base commit: b169e4fa00bf73b494af9d2d5241d9625b63dddb
+Source commit: 2bf6be26d90669ccab56e0aa32ba748ae0b0fefc
+Docker tag: anet-test527:dev
+Docker image: sha256:9d944940f81d4a312bcc96efa6e298a58e8e95ffe21ac0cd3c2793e1dfd28ddd
+Embedded environment: TEST527_SOURCE_COMMIT=2bf6be26d90669ccab56e0aa32ba748ae0b0fefc
+Runner artifact SHA256: f57d6608d6440935aec16ac48ba79fbe9e4246f04c5a4a4113155da2cdaf8802
+
+Command:
+
+    sg docker -c 'docker build -t anet-test527:dev --build-arg SOURCE_COMMIT=2bf6be26d90669ccab56e0aa32ba748ae0b0fefc -f tests/test527-ext-validator-dedup/Dockerfile . && docker run --rm -v /tmp/test527-artifacts:/artifacts anet-test527:dev'
+
+Result:
+
+- Structural scope: one stored-token regex and exactly three consumers; `sanitizeExt` remains an independent filename parser.
+- Shared-boundary plus existing upload tests: 73 passed, 0 failed, 276 assertions.
+- Production CommHub bundle: PASS (257 modules, 1.52 MB output).
+- Mutation widens the one shared grammar to `/./`:
+  - new-upload path: witnessed red, rc=1;
+  - existing-blob path: witnessed red, rc=1;
+  - stored-index gate: witnessed red, rc=1.
+- Restored source: 73 passed, 0 failed, 276 assertions.
+
+Conclusion:
+
+`buildStoragePath`, `pathForExistingBlob`, and `validateIndexEntry` enforce the same stored extension-token invariant and now share one private validator. `sanitizeExt` is intentionally not deduplicated because it parses a client filename and has different anchoring/capture semantics.

--- a/server/src/ext-token-shared.test.ts
+++ b/server/src/ext-token-shared.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildStoragePath,
+  pathForExistingBlob,
+  validateIndexEntry,
+} from "./uploads.js";
+
+const fileId = "0123456789abcdef0123456789abcdef";
+const dateBucket = "2026-08-09";
+const uploadsRoot = "/srv/uploads";
+
+const malicious = [
+  "../x",
+  "/abs/x",
+  ".png/../../y",
+  ".p ng",
+  ".p\0ng",
+  ".\\..\\x",
+  "." + "a".repeat(17),
+  ".tar.gz",
+];
+
+const legal = ["", ".png", ".PNG", ".mp4", "." + "a".repeat(16)];
+
+describe("#527 shared extension-token invariant", () => {
+  test("new-upload path rejects every malformed token and accepts the shared legal set", () => {
+    for (const ext of malicious) {
+      expect(() => buildStoragePath(fileId, ext, { uploadsRoot })).toThrow(/ext .* is invalid/);
+    }
+    for (const ext of legal) {
+      expect(buildStoragePath(fileId, ext, { uploadsRoot }).ext).toBe(ext);
+    }
+  });
+
+  test("existing-blob path rejects every malformed token and accepts the shared legal set", () => {
+    for (const ext of malicious) {
+      expect(() => pathForExistingBlob(dateBucket, fileId, ext, { uploadsRoot })).toThrow(/ext .* is invalid/);
+    }
+    for (const ext of legal) {
+      expect(pathForExistingBlob(dateBucket, fileId, ext, { uploadsRoot }).ext).toBe(ext);
+    }
+  });
+
+  test("stored-index gate rejects every malformed token and accepts the shared legal set", () => {
+    for (const ext of malicious) {
+      expect(validateIndexEntry({ file_id: fileId, date_bucket: dateBucket, ext, size: 0 })).toBe(false);
+    }
+    for (const ext of legal) {
+      expect(validateIndexEntry({ file_id: fileId, date_bucket: dateBucket, ext, size: 0 })).toBe(true);
+    }
+  });
+
+  test("all three boundaries fail closed on non-string runtime values", () => {
+    for (const ext of [undefined, null, 7, {}, []]) {
+      expect(() => buildStoragePath(fileId, ext as never, { uploadsRoot })).toThrow(/ext .* is invalid/);
+      expect(() => pathForExistingBlob(dateBucket, fileId, ext as never, { uploadsRoot })).toThrow(/ext .* is invalid/);
+      expect(validateIndexEntry({ file_id: fileId, date_bucket: dateBucket, ext, size: 0 })).toBe(false);
+    }
+  });
+});

--- a/server/src/ext-validation-regression.test.ts
+++ b/server/src/ext-validation-regression.test.ts
@@ -1,23 +1,16 @@
 // Task #25 — regression pins for ext validation in validateIndexEntry.
 //
-// 🔴 SCOPE (lead d505179d): this suite covers ONLY the ext regex copy
-// inside `validateIndexEntry` (uploads.ts). The same-shape regex has
-// FOUR copies in this file:
-//   • L93  sanitizeExt         /\.([A-Za-z0-9]{1,16})$/    (client-name parse; no leading-dot anchor, captures group)
-//   • L141 buildStoragePath    /^\.[A-Za-z0-9]{1,16}$/     (upload-path build)
-//   • L165 pathForExistingBlob /^\.[A-Za-z0-9]{1,16}$/     (download-path build)
-//   • L219 validateIndexEntry  /^\.[A-Za-z0-9]{1,16}$/     ← THIS SUITE
-// Mutation reversal proved the other three copies get ZERO coverage
-// from this suite (each was widened to `/./` in turn — this suite still
-// passed 30/0). See docs/tests/p-25-ext-regression/mutation-red.txt.
-// Do NOT read the file name "ext validation regression" as "the ext
-// validation is regression-protected" — the ext validation exists in
-// four independent copies and only ONE is pinned here.
-// Follow-up issue tracks the dedup/alignment evaluation (see PR body).
+// 🔴 SCOPE: this suite exercises the stored-index boundary through
+// `validateIndexEntry`. Issue #527 removed the three independent copies
+// of the stored extension-token grammar: buildStoragePath,
+// pathForExistingBlob and validateIndexEntry now use one shared private
+// validator. `ext-token-shared.test.ts` separately pins all three call
+// sites. sanitizeExt remains intentionally independent because it parses
+// a client filename rather than validating an already-extracted token.
 //
-// Background (通信龙 d01bb8ce): the current regex `/^\.[A-Za-z0-9]{1,16}$/`
-// in validateIndexEntry (uploads.ts) correctly rejects 11 known malicious
-// ext values (path-escape, traversal, absolute paths, doubles, NUL bytes,
+// Background (通信龙 d01bb8ce): the stored extension-token grammar
+// `/^\.[A-Za-z0-9]{1,16}$/` correctly rejects 11 known malicious ext
+// values (path-escape, traversal, absolute paths, doubles, NUL bytes,
 // backslash forms, over-length, whitespace). Verified via real-run on
 // origin/main by lead — 11/11 malicious values → false.
 //

--- a/server/src/uploads.ts
+++ b/server/src/uploads.ts
@@ -53,6 +53,17 @@ export const UPLOAD_RATE_MAX_ENTRIES = 50_000;
 // traversal.
 export const FILE_ID_REGEX = /^[A-Za-z0-9_-]{8,64}$/;
 
+// Stored extension tokens have one invariant at every path boundary:
+// either no extension, or a leading dot followed by 1-16 ASCII
+// alphanumeric characters. Keep this separate from sanitizeExt(), which
+// parses a client filename and therefore deliberately has different
+// capture/anchoring semantics.
+const EXT_TOKEN_REGEX = /^\.[A-Za-z0-9]{1,16}$/;
+
+function isValidExtToken(ext: unknown): ext is string {
+  return typeof ext === "string" && (ext === "" || EXT_TOKEN_REGEX.test(ext));
+}
+
 export type GeneratedFile = {
   fileId: string;
   ext: string;
@@ -138,7 +149,7 @@ export function isValidCalendarBucket(bucket: unknown): bucket is string {
  */
 export function buildStoragePath(fileId: string, ext: string, opts: { uploadsRoot?: string; now?: Date } = {}): GeneratedFile {
   if (!FILE_ID_REGEX.test(fileId)) throw new Error(`file_id "${fileId}" is invalid`);
-  if (ext && !/^\.[A-Za-z0-9]{1,16}$/.test(ext)) throw new Error(`ext "${ext}" is invalid`);
+  if (!isValidExtToken(ext)) throw new Error(`ext "${ext}" is invalid`);
   const dateBucket = getDateBucket(opts.now);
   const root = opts.uploadsRoot ?? getUploadsRoot();
   const relativePath = join(dateBucket, fileId + ext);
@@ -162,7 +173,7 @@ export function buildStoragePath(fileId: string, ext: string, opts: { uploadsRoo
  */
 export function pathForExistingBlob(dateBucket: string, fileId: string, ext: string, opts: { uploadsRoot?: string } = {}): GeneratedFile {
   if (!FILE_ID_REGEX.test(fileId)) throw new Error(`file_id "${fileId}" is invalid`);
-  if (ext && !/^\.[A-Za-z0-9]{1,16}$/.test(ext)) throw new Error(`ext "${ext}" is invalid`);
+  if (!isValidExtToken(ext)) throw new Error(`ext "${ext}" is invalid`);
   if (typeof dateBucket !== "string" || !DATE_BUCKET_REGEX.test(dateBucket)) {
     throw new Error(`date_bucket "${dateBucket}" is invalid`);
   }
@@ -216,7 +227,7 @@ export function validateIndexEntry(entry: unknown): entry is UploadIndexEntry {
   return (
     typeof e.file_id === "string" && FILE_ID_REGEX.test(e.file_id) &&
     typeof e.date_bucket === "string" && /^\d{4}-\d{2}-\d{2}$/.test(e.date_bucket) &&
-    typeof e.ext === "string" && (e.ext === "" || /^\.[A-Za-z0-9]{1,16}$/.test(e.ext)) &&
+    isValidExtToken(e.ext) &&
     typeof e.size === "number" && e.size >= 0 && e.size <= MAX_UPLOAD_BYTES
   );
 }

--- a/tests/test527-ext-validator-dedup/Dockerfile
+++ b/tests/test527-ext-validator-dedup/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+
+COPY server ./server
+COPY tests/test527-ext-validator-dedup ./tests/test527-ext-validator-dedup
+
+ARG SOURCE_COMMIT
+ENV TEST527_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test527-ext-validator-dedup/run.sh
+ENTRYPOINT ["/workspace/tests/test527-ext-validator-dedup/run.sh"]

--- a/tests/test527-ext-validator-dedup/run.sh
+++ b/tests/test527-ext-validator-dedup/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test527-ext-validator-dedup.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+cd /workspace
+echo "# test527 — shared stored extension-token validator"
+echo "source_commit=${TEST527_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_tests() {
+  bun test \
+    server/src/ext-token-shared.test.ts \
+    server/src/ext-validation-regression.test.ts \
+    server/src/uploads.test.ts
+}
+
+echo "L0 structural scope"
+test "$(grep -Fc 'const EXT_TOKEN_REGEX =' server/src/uploads.ts)" -eq 1
+test "$(grep -Fc 'isValidExtToken(' server/src/uploads.ts)" -eq 4
+grep -Fq 'base.match(/\.([A-Za-z0-9]{1,16})$/)' server/src/uploads.ts
+
+echo "L1 three-boundary behavior + existing regressions"
+run_tests
+
+echo "L2 production server bundle"
+(cd server && bun build src/index.ts --target bun --outfile /tmp/commhub-server-test527.js)
+test -s /tmp/commhub-server-test527.js
+
+echo "L3 witnessed-red: widen the single shared grammar"
+cp server/src/uploads.ts /tmp/test527-uploads.ts
+bun -e '
+  const path = "server/src/uploads.ts";
+  const source = await Bun.file(path).text();
+  const before = "const EXT_TOKEN_REGEX = /^\\.[A-Za-z0-9]{1,16}$/;";
+  if (!source.includes(before)) throw new Error("mutation anchor missing");
+  await Bun.write(path, source.replace(before, "const EXT_TOKEN_REGEX = /./;"));
+'
+grep -Fq 'const EXT_TOKEN_REGEX = /./;' server/src/uploads.ts
+
+for pattern in \
+  'new-upload path rejects every malformed token' \
+  'existing-blob path rejects every malformed token' \
+  'stored-index gate rejects every malformed token'
+do
+  slug=$(printf '%s' "$pattern" | tr ' ' '-')
+  set +e
+  bun test server/src/ext-token-shared.test.ts -t "$pattern" >"/tmp/test527-$slug.log" 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "MUTATION_FALSE_GREEN: $pattern"
+    exit 1
+  fi
+  grep -Fq "$pattern" "/tmp/test527-$slug.log"
+  echo "MUTATION_RED: $pattern rc=$rc"
+done
+
+cp /tmp/test527-uploads.ts server/src/uploads.ts
+
+echo "L4 restored green"
+run_tests
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- extract one private validator for stored extension tokens
- use it from new-upload path construction, existing-blob path construction, and stored-index validation
- keep `sanitizeExt` independent because it parses a client filename and intentionally has different capture/anchoring semantics
- add three-boundary behavior tests and exact-SHA Docker mutation evidence

## Root cause

The same stored-token grammar existed as three independent regex copies. Fixing or widening one copy could silently diverge from the others, while the prior regression suite only exercised the stored-index copy.

## Compatibility

The accepted stored-token set is unchanged: empty string, or a leading dot plus 1–16 ASCII alphanumeric characters. The path boundaries now additionally fail closed on non-string runtime values instead of accidentally concatenating `undefined`/`null` into a path.

## Validation

- 73 tests passed, 0 failed, 276 assertions
- production CommHub bundle passed
- widening the single shared grammar makes each of the three consumer tests independently fail
- exact evidence: `docs/tests/report-test527-ext-validator-dedup.txt`

No deployment or publish is included.