### PR TITLE
test(server): exercise ack schema over MCP transport (#344)

### DIFF
--- a/docs/tests/report-test344-ack-transport-zod.txt
+++ b/docs/tests/report-test344-ack-transport-zod.txt
@@ -1,0 +1,32 @@
+# Test 344 — ack_create_request in-process MCP transport zod gate
+
+Date: 2026-08-09
+Base commit: b169e4fa00bf73b494af9d2d5241d9625b63dddb
+Source commit: 646e4ed6a96958b8d20c50126f9f8f8db86e506c
+Docker tag: anet-test344:dev
+Docker image: sha256:a85a27ab1106947552c72def6f2c2216aaebed77ea3ec2694965a6d32c369f69
+Embedded environment: TEST344_SOURCE_COMMIT=646e4ed6a96958b8d20c50126f9f8f8db86e506c
+Runner artifact SHA256: fff6ebac9deb2a3fa43adde5b418b72d9910c81695735b0777241c615b47d6c3
+
+Command:
+
+    sg docker -c 'docker build -t anet-test344:dev --build-arg SOURCE_COMMIT=646e4ed6a96958b8d20c50126f9f8f8db86e506c -f tests/test344-ack-transport-zod/Dockerfile . && docker run --rm -v /tmp/test344-artifacts:/artifacts anet-test344:dev'
+
+Results:
+
+- Production CommHub bundle: PASS (257 modules, 1.52 MB output).
+- Real `Client` + linked `InMemoryTransport` + registered `McpServer`: 3 passed, 0 failed, 10 assertions.
+- Existing handler/DB regression suite: 10 passed, 0 failed, 30 assertions.
+- Removing `runtime_capability_check_failed` from the zod enum: witnessed red, rc=1.
+- Replacing the runtime string schema with `z.any()`: witnessed red, rc=1.
+- Restored transport suite: 3 passed, 0 failed, 10 assertions.
+
+Wire facts pinned:
+
+- The new terminal status plus a string runtime passes the SDK validation gate and reaches the real handler.
+- Invalid status and non-string runtime are rejected before the handler; the request row remains byte-semantically unchanged at `status=delivered`.
+- SDK input-validation failure is returned as a tool result with `isError=true`, not as a rejected `Client.callTool()` promise.
+
+Initial harness correction:
+
+The first exact Docker run at source `9530e9f154b4d2da07a376e4e7e302b240918fda` expected invalid input to reject the JavaScript promise. Both negative tests failed because the real SDK correctly resolved an MCP tool-error result. No production code was changed; the test was corrected to assert the real wire shape plus DB non-mutation, then rebuilt and rerun at the source commit above.

--- a/server/src/ack-create-request-transport.test.ts
+++ b/server/src/ack-create-request-transport.test.ts
@@ -76,10 +76,19 @@ async function connectClient() {
   return { client, server };
 }
 
-function responseJson(result: { content: Array<{ type: string; text?: string }> }) {
+type ToolResult = { content: Array<{ type: string; text?: string }>; isError?: boolean };
+
+function responseJson(result: ToolResult) {
   const first = result.content[0];
-  if (!first || first.type !== "text") throw new Error("missing text tool result");
+  if (!first || first.type !== "text" || typeof first.text !== "string") throw new Error("missing text tool result");
   return JSON.parse(first.text) as { ok?: boolean; status?: string };
+}
+
+function expectTransportValidationError(result: ToolResult) {
+  expect(result.isError).toBe(true);
+  const first = result.content[0];
+  expect(first?.type).toBe("text");
+  expect(first?.text).toMatch(/Input validation error.*ack_create_request/i);
 }
 
 beforeEach(() => {
@@ -117,10 +126,11 @@ describe("#344 ack_create_request real in-process MCP transport", () => {
     seedRequest(requestId);
     const { client, server } = await connectClient();
     try {
-      await expect(client.callTool({
+      const result = await client.callTool({
         name: "ack_create_request",
         arguments: { request_id: requestId, status: "capability_failed_typo", runtime: "codex-sdk" },
-      })).rejects.toThrow(/Input validation error.*ack_create_request/i);
+      });
+      expectTransportValidationError(result);
       expect(db.get<{ status: string }>("SELECT status FROM node_create_requests WHERE request_id = ?1", requestId)?.status)
         .toBe("delivered");
     } finally {
@@ -134,10 +144,11 @@ describe("#344 ack_create_request real in-process MCP transport", () => {
     seedRequest(requestId);
     const { client, server } = await connectClient();
     try {
-      await expect(client.callTool({
+      const result = await client.callTool({
         name: "ack_create_request",
         arguments: { request_id: requestId, status: "runtime_capability_check_failed", runtime: 42 },
-      })).rejects.toThrow(/Input validation error.*ack_create_request/i);
+      });
+      expectTransportValidationError(result);
       expect(db.get<{ status: string }>("SELECT status FROM node_create_requests WHERE request_id = ?1", requestId)?.status)
         .toBe("delivered");
     } finally {

--- a/server/src/ack-create-request-transport.test.ts
+++ b/server/src/ack-create-request-transport.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db } from "./db.js";
+import { registerTools } from "./tools.js";
+
+const NET = "net_ack_transport";
+const DAEMON_NODE_ID = "node_ack_transport_daemon";
+const DAEMON_ALIAS = "ack-transport-daemon";
+const DAEMON_USER = "u_ack_transport_owner";
+const DAEMON_TOKEN_ID = "tok_ack_transport_daemon";
+
+function cleanup() {
+  try { db.run("DELETE FROM audit_log WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM node_create_requests WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM nodes WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM api_tokens WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [DAEMON_USER]); } catch {}
+}
+
+function seedWorld() {
+  db.run(
+    `INSERT INTO users (user_id, username, password_hash, role, created_at)
+     VALUES (?1, ?2, 'x', 'user', datetime('now'))`,
+    [DAEMON_USER, DAEMON_USER],
+  );
+  db.run(
+    `INSERT INTO networks (network_id, network_name, owner_id, created_at)
+     VALUES (?1, ?2, ?3, datetime('now'))`,
+    [NET, NET, DAEMON_USER],
+  );
+  db.run(
+    `INSERT INTO network_members (user_id, network_id, role, joined_at)
+     VALUES (?1, ?2, 'owner', datetime('now'))`,
+    [DAEMON_USER, NET],
+  );
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, network_id, created_at, updated_at)
+     VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))`,
+    [DAEMON_NODE_ID, DAEMON_ALIAS, DAEMON_ALIAS, NET],
+  );
+  db.run(
+    `INSERT INTO api_tokens (token_id, user_id, network_id, scope, name, token_hash, expires_at, revoked_at)
+     VALUES (?1, ?2, ?3, 'network', ?4, ?5, NULL, NULL)`,
+    [DAEMON_TOKEN_ID, DAEMON_USER, NET, `node:${DAEMON_ALIAS}`, "hash_ack_transport_daemon"],
+  );
+}
+
+function seedRequest(requestId: string) {
+  db.run(
+    `INSERT INTO node_create_requests
+       (request_id, daemon_node_id, child_name, network_id, runtime, model, flags_json, env_keys, status, created_at, created_by_token)
+     VALUES (?1, ?2, ?3, ?4, 'codex-sdk', 'x', '{}', '[]', 'delivered', ?5, ?6)`,
+    [requestId, DAEMON_NODE_ID, `child_${requestId}`, NET, Date.now(), DAEMON_TOKEN_ID],
+  );
+}
+
+async function connectClient() {
+  const server = new McpServer({ name: "ack-transport-test", version: "1" });
+  registerTools(
+    server,
+    undefined,
+    NET,
+    DAEMON_USER,
+    DAEMON_ALIAS,
+    true,
+    DAEMON_TOKEN_ID,
+  );
+  const client = new Client({ name: "ack-transport-client", version: "1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client, server };
+}
+
+function responseJson(result: { content: Array<{ type: string; text?: string }> }) {
+  const first = result.content[0];
+  if (!first || first.type !== "text") throw new Error("missing text tool result");
+  return JSON.parse(first.text) as { ok?: boolean; status?: string };
+}
+
+beforeEach(() => {
+  cleanup();
+  seedWorld();
+});
+afterAll(cleanup);
+
+describe("#344 ack_create_request real in-process MCP transport", () => {
+  test("accepts runtime_capability_check_failed plus string runtime through the SDK zod gate", async () => {
+    const requestId = "cr_transport_accept";
+    seedRequest(requestId);
+    const { client, server } = await connectClient();
+    try {
+      const result = await client.callTool({
+        name: "ack_create_request",
+        arguments: {
+          request_id: requestId,
+          status: "runtime_capability_check_failed",
+          error: "child died within 5000ms post-spawn",
+          runtime: "codex-sdk",
+        },
+      });
+      expect(responseJson(result)).toMatchObject({ ok: true, status: "runtime_capability_check_failed" });
+      expect(db.get<{ status: string }>("SELECT status FROM node_create_requests WHERE request_id = ?1", requestId)?.status)
+        .toBe("runtime_capability_check_failed");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  test("rejects unknown status at the transport gate before the handler mutates the row", async () => {
+    const requestId = "cr_transport_bad_status";
+    seedRequest(requestId);
+    const { client, server } = await connectClient();
+    try {
+      await expect(client.callTool({
+        name: "ack_create_request",
+        arguments: { request_id: requestId, status: "capability_failed_typo", runtime: "codex-sdk" },
+      })).rejects.toThrow(/Input validation error.*ack_create_request/i);
+      expect(db.get<{ status: string }>("SELECT status FROM node_create_requests WHERE request_id = ?1", requestId)?.status)
+        .toBe("delivered");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  test("rejects non-string runtime at the transport gate before the handler mutates the row", async () => {
+    const requestId = "cr_transport_bad_runtime";
+    seedRequest(requestId);
+    const { client, server } = await connectClient();
+    try {
+      await expect(client.callTool({
+        name: "ack_create_request",
+        arguments: { request_id: requestId, status: "runtime_capability_check_failed", runtime: 42 },
+      })).rejects.toThrow(/Input validation error.*ack_create_request/i);
+      expect(db.get<{ status: string }>("SELECT status FROM node_create_requests WHERE request_id = ?1", requestId)?.status)
+        .toBe("delivered");
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/server/src/ack-create-request.test.ts
+++ b/server/src/ack-create-request.test.ts
@@ -13,11 +13,11 @@ import { registerTools } from "./tools.js";
 // `daemon_capability_lied` audit was written when in fact the action wasn't
 // in the audit enum and no insert ran.
 //
-// This handler-driven suite drives the registered MCP tool through
-// registerTools() so a daemon's exact ack shape (status + runtime field)
-// flows through the real zod schema + handler branch + audit insert. It
-// would have caught the lane-recurring "single component passes but cross-
-// component path stays broken" failure mode immediately.
+// This handler-driven suite captures and invokes the registered callback
+// directly. It validates handler branches and DB effects, but deliberately
+// does NOT claim to exercise the MCP SDK's zod transport gate. The
+// complementary in-process transport coverage lives in
+// ack-create-request-transport.test.ts (#344).
 
 const NET = "net_ack_t";
 const DAEMON_NODE_ID = "node_ack_daemon";

--- a/tests/test344-ack-transport-zod/Dockerfile
+++ b/tests/test344-ack-transport-zod/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+
+COPY server ./server
+COPY tests/test344-ack-transport-zod ./tests/test344-ack-transport-zod
+
+ARG SOURCE_COMMIT
+ENV TEST344_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test344-ack-transport-zod/run.sh
+ENTRYPOINT ["/workspace/tests/test344-ack-transport-zod/run.sh"]

--- a/tests/test344-ack-transport-zod/run.sh
+++ b/tests/test344-ack-transport-zod/run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test344-ack-transport-zod.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+cd /workspace
+echo "# test344 — ack_create_request in-process MCP transport zod gate"
+echo "source_commit=${TEST344_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_transport() {
+  COMMHUB_DB="$1" bun test server/src/ack-create-request-transport.test.ts
+}
+
+expect_red() {
+  local label=$1 pattern=$2 db_path=$3
+  set +e
+  COMMHUB_DB="$db_path" bun test server/src/ack-create-request-transport.test.ts -t "$pattern" \
+    >"/tmp/test344-$label.log" 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "MUTATION_FALSE_GREEN: $label"
+    exit 1
+  fi
+  grep -Fq "$pattern" "/tmp/test344-$label.log"
+  echo "MUTATION_RED: $label rc=$rc"
+}
+
+echo "L0 production Hub bundle"
+(cd server && bun build src/index.ts --target bun --outfile /tmp/commhub-server-test344.js)
+test -s /tmp/commhub-server-test344.js
+
+echo "L1 real in-process MCP Client + InMemoryTransport"
+run_transport /tmp/test344-green.db
+
+echo "L2 existing handler regression suite"
+COMMHUB_DB=/tmp/test344-handler.db bun test server/src/ack-create-request.test.ts
+
+cp server/src/tools.ts /tmp/test344-tools.ts
+
+echo "L3 witnessed-red: remove the new terminal status from the transport schema"
+sed -i 's/, "runtime_capability_check_failed"//' server/src/tools.ts
+if grep -Fq 'z.enum(["started", "failed", "rejected", "runtime_capability_check_failed"])' server/src/tools.ts; then
+  echo "MUTATION_NOT_APPLIED: status enum"
+  exit 1
+fi
+expect_red status-enum 'accepts runtime_capability_check_failed plus string runtime' /tmp/test344-mut-status.db
+cp /tmp/test344-tools.ts server/src/tools.ts
+
+echo "L4 witnessed-red: allow a non-string runtime through the transport schema"
+sed -i 's/runtime: z.string().max(64).optional()/runtime: z.any().optional()/' server/src/tools.ts
+grep -Fq 'runtime: z.any().optional()' server/src/tools.ts
+expect_red runtime-type 'rejects non-string runtime at the transport gate' /tmp/test344-mut-runtime.db
+cp /tmp/test344-tools.ts server/src/tools.ts
+
+echo "L5 restored green"
+run_transport /tmp/test344-restored.db
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- add an in-process MCP `Client`/`McpServer` test linked with `InMemoryTransport`
- verify `runtime_capability_check_failed` plus string `runtime` passes the real SDK zod gate and reaches the handler
- verify an unknown status and non-string runtime return MCP validation errors before any DB mutation
- correct the older handler-test comment so it no longer overclaims transport coverage

## Why

The existing handler suite captured and invoked the callback directly, bypassing SDK input validation. Docker Scenario K covered the full wire path but was too heavy for fast unit feedback.

## Validation

- production Hub bundle: PASS
- transport suite: 3/0, 10 assertions
- existing handler suite: 10/0, 30 assertions
- removing the new enum value makes the positive transport test fail
- allowing any runtime type makes the negative transport test fail
- exact evidence: `docs/tests/report-test344-ack-transport-zod.txt`

This is test-only; it changes no production behavior and includes no deployment.