### PR TITLE
test(cli): correct issue 621 wizard reachability evidence

### DIFF
--- a/docs/tests/report-test625-explicit-env-crlf.txt
+++ b/docs/tests/report-test625-explicit-env-crlf.txt
@@ -2,11 +2,11 @@
 
 Date: 2026-08-09
 Issue: #621
-Source commit: 73542ee9c5cfcb2a688e3a3596463e0b1504faf4
+Source commit: f04ec2e6baa8e35968c29c54b0f12763b5a65363
 Docker tag: anet-test625:dev
-Docker image: sha256:13d47bbbcf2ff11d17b60d582207d5a15683a1c40a8f7f3ee17e9f48e0718094
-Embedded source: TEST625_SOURCE_COMMIT=73542ee9c5cfcb2a688e3a3596463e0b1504faf4
-Runner artifact SHA256: c01a98c775da963358652e23ec7bd11c19f991438f50b602fb868fef2073d74e
+Docker image: sha256:786b9bc1f21f82a8dbc445627a61c75ec2d4d040181d4b793219a6046fe52025
+Embedded source: TEST625_SOURCE_COMMIT=f04ec2e6baa8e35968c29c54b0f12763b5a65363
+Runner artifact SHA256: 8653db18eebe71e4b2458b060324881d06302d790736f0cce01266a73035f07e
 
 ## Result
 
@@ -19,10 +19,16 @@ Runner artifact SHA256: c01a98c775da963358652e23ec7bd11c19f991438f50b602fb868fef
 - A safe explicit credential still created a mode-600 dotenv containing
   exactly one assignment and no injected key.
 - All `.env`-writing create flows converge on `saveCreatedNode` and
-  `rewritePlainSecretsToEnvRef`. The named create reaches the earlier vendor
-  collector; the no-name wizard bypasses that collector but reaches the shared
-  writer preflight. Batch and the legacy missing-profile wizard call
-  `saveProfile` directly and do not write a node `.env`.
+  `rewritePlainSecretsToEnvRef`. Named create reaches the earlier vendor
+  collector and the shared writer preflight. Batch and the legacy
+  missing-profile wizard call `saveProfile` directly and do not write a node
+  `.env`.
+- The concrete no-name invocation `anet node create --runtime ... --env ...`
+  cannot enter the current interactive wizard: the parser treats `--runtime`
+  as the positional id and rejects usage before prompting or writing state.
+  The Docker test invokes this exact form and verifies nonzero exit, no secret
+  echo, and no node config or dotenv file. The writer-boundary guard remains
+  defense in depth for future or bypass callers that can reach the writer.
 - Disabling only the named-create collector still rejected the malicious value
   at the shared writer preflight before node directory, `.gitignore`, process
   environment, config, or dotenv mutation.
@@ -33,11 +39,12 @@ Runner artifact SHA256: c01a98c775da963358652e23ec7bd11c19f991438f50b602fb868fef
   no profile or dotenv write.
 
 ```text
-L3 defense-in-depth: bypassing direct collection still fails at the writer preflight
+L2 no-name CLI flags cannot enter the interactive wizard
+L4 defense-in-depth: bypassing direct collection still fails at the writer preflight
 WRITER_PREFLIGHT_PASS: direct collector bypass still rejected before create side effects
-L4 witnessed-red: bypassing both guards injects a second dotenv line
+L5 witnessed-red: bypassing both guards injects a second dotenv line
 MUTATION_RED: dotenv-writer-crlf rc=1 (injected dotenv line witnessed)
-L5 restored green
+L6 restored green
 RESULT: PASS
 ```
 

--- a/tests/test625-explicit-env-crlf/run.sh
+++ b/tests/test625-explicit-env-crlf/run.sh
@@ -57,7 +57,19 @@ grep -Fq -- '--env entries cannot contain line breaks' /tmp/test625-rejected.log
 test ! -e .anet/nodes/rejected-node/config.json
 test ! -e .anet/nodes/rejected-node/.env
 
-echo "L2 safe explicit value still creates one env assignment"
+echo "L2 no-name CLI flags cannot enter the interactive wizard"
+set +e
+printf 'wizard-node\n' | PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create \
+  --runtime claude-agent-sdk --env "$INJECTED_ENV" >/tmp/test625-wizard-unreachable.log 2>&1
+wizard_rc=$?
+set -e
+test "$wizard_rc" -ne 0
+grep -Fq 'Usage: anet node create <node-name>' /tmp/test625-wizard-unreachable.log
+! grep -Fq 'test625-bad' /tmp/test625-wizard-unreachable.log
+test ! -e .anet/nodes/wizard-node/config.json
+test ! -e .anet/nodes/wizard-node/.env
+
+echo "L3 safe explicit value still creates one env assignment"
 PATH="/tmp/test625-bin:$PATH" "${ANET[@]}" node create safe-node \
   --runtime claude-agent-sdk --env 'ANTHROPIC_API_KEY=test625-safe' >/tmp/test625-safe.log
 SAFE_ENV=.anet/nodes/safe-node/.env
@@ -66,7 +78,7 @@ test "$(stat -c %a "$SAFE_ENV")" = 600
 grep -Eq '^ANTHROPIC_API_KEY_[A-Z0-9_]+=test625-safe$' "$SAFE_ENV"
 ! grep -Fq 'INJECTED=' "$SAFE_ENV"
 
-echo "L3 defense-in-depth: bypassing direct collection still fails at the writer preflight"
+echo "L4 defense-in-depth: bypassing direct collection still fails at the writer preflight"
 cp "$HELPER" /tmp/test625-helper.ts
 cp "$CLI" /tmp/test625-cli.ts
 mkdir -p /tmp/test625-writer-project
@@ -90,7 +102,7 @@ test ! -e .anet/nodes/mutation-node/.env
 test ! -e .gitignore
 echo "WRITER_PREFLIGHT_PASS: direct collector bypass still rejected before create side effects"
 
-echo "L4 witnessed-red: bypassing both guards injects a second dotenv line"
+echo "L5 witnessed-red: bypassing both guards injects a second dotenv line"
 sed -i '0,/if (\/\[\\r\\n\]\/\.test(value))/{s/if (\/\[\\r\\n\]\/\.test(value))/if (false \&\& \/[\\r\\n]\/\.test(value))/}' "$HELPER"
 grep -Fq 'if (false && /[\r\n]/.test(value))' "$HELPER"
 cd /workspace/agent-network
@@ -108,7 +120,7 @@ if [[ "$double_mutant_rc" -ne 0 ]] || ! grep -Fxq 'INJECTED=test625-bad' .anet/n
 fi
 echo "MUTATION_RED: dotenv-writer-crlf rc=1 (injected dotenv line witnessed)"
 
-echo "L5 restored green"
+echo "L6 restored green"
 cp /tmp/test625-helper.ts "$HELPER"
 cp /tmp/test625-cli.ts "$CLI"
 cd /workspace/agent-network


### PR DESCRIPTION
Follow-up to #625. No production behavior changes.

The prior review/merge claimed that `anet node create --runtime ... --env ...` reaches the no-name wizard. The real current parser does not: `--runtime` is consumed as the positional id and usage validation exits before prompting or writing state.

This PR:
- adds a real built-CLI regression for that exact invocation (nonzero exit, usage shown, no secret echo, no config/dotenv side effect);
- corrects the committed test report and layer numbering;
- retains the already-merged writer-boundary defense-in-depth evidence: collector-only bypass remains rejected, while bypassing both guards produces the injected second dotenv line.

Exact evidence was run at source `f04ec2e6baa8e35968c29c54b0f12763b5a65363`. The merged feature paths are byte-identical to that source aside from this test/report delta. Docker: 10/0/24, image `sha256:786b9bc1f21f82a8dbc445627a61c75ec2d4d040181d4b793219a6046fe52025`, artifact `8653db18eebe71e4b2458b060324881d06302d790736f0cce01266a73035f07e`.

Not authorized for self-merge or deployment.
