### PR TITLE
docs(server): audit MCP unknown-field policies

### DIFF
--- a/docs/analysis/issue-529-mcp-unknown-fields.md
+++ b/docs/analysis/issue-529-mcp-unknown-fields.md
@@ -1,0 +1,104 @@
+# Issue #529 — MCP unknown-field policy audit
+
+Date: 2026-08-09
+
+## Outcome
+
+Do **not** apply `.strict()` across all MCP tools. The safe next step is an
+observe-then-tighten rollout:
+
+1. wrap one canary tool with a top-level passthrough schema;
+2. log only sorted unknown **key names**, then strip again before its handler;
+3. measure real callers before choosing strict mode per tool;
+4. require persisted side-effect tools to echo what was actually stored.
+
+This audit changes no production tool behavior. `test629` is an executable
+feasibility probe for the proposed wrapper and a source inventory gate.
+
+## Facts
+
+- `server/src/tools.ts` contains **41** `server.tool(...)` registrations.
+- Every top-level registration uses the deprecated raw-shape form. None has an
+  explicit top-level unknown-field policy.
+- The installed real `@modelcontextprotocol/sdk` converts a raw shape to a Zod
+  object and parses before calling the handler. Its default object policy strips
+  unknown keys. `test629` proves `{known, typo}` reaches the handler as
+  `{known}` while the call still succeeds.
+- The current audit log cannot answer which callers send unknown fields: the
+  only copy is discarded before project code runs. Historical caller breakage
+  therefore cannot be measured retrospectively.
+- Nested high-risk payloads are a separate boundary. For example provider probe
+  result objects already use nested `.strict()` schemas; this proposal must not
+  loosen them.
+
+## Inventory and caller surface
+
+| Group | Tools | Known first-party callers | Strict-mode risk |
+|---|---|---|---|
+| SkillHub | `submit_skill`, `list_skills`, `get_skill`, `review_skill` | Dashboard server proxy and MCP clients | Medium; public/private clients can drift independently |
+| Agent lifecycle | `report_status`, `report_completion`, `get_inbox`, `ack_inbox`, `get_all_status`, `get_session_status` | `agent-network`, `agent-node`, test/legacy packages | High; old long-running binaries are present in production |
+| Messaging/task | `send_task`, `send_message`, `send_reply`, `send_ack`, `retry_task`, `get_task`, `list_tasks`, `cancel_task`, `reassign_task`, `broadcast`, `get_completions` | LLM MCP calls, node bridges, SDK client, Dashboard flows | Highest; LLM-generated arguments and third-party clients are open-ended |
+| Node config | `update_node_config`, `get_config_update`, `ack_config_update`, `restart_node`, `list_host_supervisors` | Dashboard/Hub and agent-node | Medium; version skew is known |
+| Daemon create/stop | `create_node`, `get_create_request`, `ack_create_request`, `stop_node`, `delete_node`, `get_stop_request`, `ack_stop_request`, `list_my_children` | agent-node daemon and Hub | High; cross-version orchestration must keep working |
+| Secrets/providers | `upsert_network_secret`, `list_network_secrets`, `upsert_provider`, `list_providers`, `probe_provider_model`, `get_probe_results`, `get_probe_request` | Dashboard/Hub and probe daemon | High; never log values, and retain nested strict schemas |
+
+Static source calls cover only first-party code. They cannot prove that an LLM,
+an older installed package, or a third-party MCP client sends no extra fields.
+That unbounded caller set is the reason a global strict migration is unsafe.
+
+## Option assessment
+
+### A. Lint requiring `.strict()` or `.passthrough()`
+
+Useful only after registrations have an explicit policy wrapper. Enabling such a
+lint today would fail all 41 tools without telling us which callers would break.
+Keep the exact inventory gate now; later replace each manifest entry with an
+explicit `observe`, `strict`, or documented legacy policy.
+
+### B. Passthrough plus shape telemetry — recommended
+
+Use `registerTool` with a top-level `z.object(shape).passthrough()` so project
+code can see unknown key names. The wrapper must then parse the same value with
+`z.object(shape).strip()` before invoking the existing handler. This preserves
+the current handler contract.
+
+Telemetry requirements:
+
+- key names only; never values;
+- tool name, authenticated caller class, package/version when already known;
+- sorted/deduplicated keys with length/count caps;
+- rate-limited logs plus aggregate counters;
+- no relaxation of nested `.strict()` schemas.
+
+Start with `send_reply`: it produced the original symptom, now echoes persisted
+attachments, and has direct regression coverage. Canary telemetry is a separate
+runtime PR and deployment decision.
+
+### C. Echo persisted fields — required complement
+
+Echoes let a well-behaved caller compare intent with stored state, and #507 has
+already used this pattern. Echoes do not protect a caller that ignores the
+response and cannot identify arbitrary future typo fields, so they complement
+rather than replace telemetry.
+
+### D. Per-tool strict canary
+
+Only consider strict mode after a named tool has a representative observation
+window with zero unexplained unknown keys. Test both failure directions:
+
+- removing strict mode must admit the targeted typo;
+- enabling strict mode must not break the recorded legacy/forward-compatible
+  caller corpus.
+
+## Implementation doors
+
+1. **Telemetry PR:** one `send_reply` wrapper, real MCP wire test, value-leak
+   negative test, rate-limit test, and handler byte-equivalence test.
+2. **Observation window:** record counts by tool/caller class; resolve each key
+   as typo, legacy, or forward-compatible extension.
+3. **Policy PR:** choose strict/strip/observe per tool. Never sweep strict across
+   the class.
+
+The issue's evaluation scope is complete when this audit and probe are reviewed.
+Production telemetry and any strict migration remain separately reviewable
+follow-ups.

--- a/docs/analysis/issue-529-mcp-unknown-fields.md
+++ b/docs/analysis/issue-529-mcp-unknown-fields.md
@@ -20,7 +20,8 @@ feasibility probe for the proposed wrapper and a source inventory gate.
 - `server/src/tools.ts` contains **41** `server.tool(...)` registrations.
 - Every top-level registration uses the deprecated raw-shape form. None has an
   explicit top-level unknown-field policy.
-- The installed real `@modelcontextprotocol/sdk` converts a raw shape to a Zod
+- The host install (1.29.x) and the dependency range's clean Docker resolution
+  (1.30.x) both convert a raw shape to a Zod
   object and parses before calling the handler. Its default object policy strips
   unknown keys. `test629` proves `{known, typo}` reaches the handler as
   `{known}` while the call still succeeds.

--- a/docs/tests/report-test629-mcp-schema-policy.txt
+++ b/docs/tests/report-test629-mcp-schema-policy.txt
@@ -1,0 +1,42 @@
+# test629 — MCP unknown-field policy audit
+
+Date: 2026-08-09
+Issue: #529
+Source commit: d8e89e5d043972167469a3ce053900da08791fb9
+Docker tag: anet-test629:dev
+Docker image: sha256:742974980c98681e469b9f094dbc49345c29ee188d6df8e35de87c76fa6cb199
+Embedded source: TEST629_SOURCE_COMMIT=d8e89e5d043972167469a3ce053900da08791fb9
+Runner artifact SHA256: f7415096c9bc944cabb024cb87ba8f76f39b2f7b9130c250192d6dd99641a2d3
+
+## Result
+
+- Production inventory: 41 `server.tool(...)` registrations, all explicitly
+  named in source order.
+- Real dependency resolution: `@modelcontextprotocol/sdk` 1.30.0 and Zod 4.4.3.
+- Raw-shape baseline: a call with an unknown field succeeds, while the handler
+  receives only known fields.
+- Global `.strict()`: the same extra field is rejected, demonstrating the
+  compatibility risk rather than assuming it.
+- Telemetry-first feasibility: passthrough preserves unknown key names for
+  observation; logs contain sorted names but not values; a second strip parse
+  produces the same handler payload as today's baseline.
+- Witnessed red: adding an unreviewed 42nd `server.tool` registration makes the
+  inventory gate fail with rc=1. Restoring the source returns PASS.
+
+```text
+MUTATION_RED: unreviewed-tool-inventory rc=1
+PASS: all 41 production MCP registrations are explicitly inventoried in source order
+PASS: real SDK silently strips the unknown field before the handler
+PASS: global strict mode would hard-fail an existing caller with an extra field
+PASS: telemetry never records unknown values
+PASS: telemetry wrapper preserves the current stripped handler contract
+inventory_count=41
+sdk_version=1.30.0
+recommended_policy=observe-key-shape-then-strip
+RESULT: PASS
+```
+
+The fixtures contain only synthetic values. No production service, database,
+token, global package, or deployment was touched. The candidate changes only
+documentation and an isolated Docker audit/probe; it does not change MCP tool
+runtime behavior.

--- a/tests/test629-mcp-schema-policy/Dockerfile
+++ b/tests/test629-mcp-schema-policy/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace/server
+COPY server/package.json ./package.json
+RUN bun install --ignore-scripts
+
+COPY server/src/tools.ts ./src/tools.ts
+COPY tests/test629-mcp-schema-policy/probe.ts ./test629/probe.ts
+COPY tests/test629-mcp-schema-policy/run.sh ./test629/run.sh
+RUN chmod 0755 ./test629/run.sh
+
+ARG SOURCE_COMMIT=unknown
+ENV TEST629_SOURCE_COMMIT=${SOURCE_COMMIT}
+
+CMD ["./test629/run.sh"]

--- a/tests/test629-mcp-schema-policy/probe.ts
+++ b/tests/test629-mcp-schema-policy/probe.ts
@@ -23,6 +23,10 @@ const expectedTools = [
 ];
 
 const toolsSource = readFileSync("src/tools.ts", "utf8");
+const sdkVersion = JSON.parse(
+  readFileSync("node_modules/@modelcontextprotocol/sdk/package.json", "utf8"),
+).version as string;
+assert(/^1\.(?:29|30)\./.test(sdkVersion), `real MCP SDK version is recorded (${sdkVersion})`);
 const registeredTools = [...toolsSource.matchAll(/server\.tool\(\s*\n\s*"([^"]+)"/g)]
   .map(match => match[1]);
 assert(
@@ -84,4 +88,5 @@ assert(
 );
 
 console.log("inventory_count=41");
+console.log(`sdk_version=${sdkVersion}`);
 console.log("recommended_policy=observe-key-shape-then-strip");

--- a/tests/test629-mcp-schema-policy/probe.ts
+++ b/tests/test629-mcp-schema-policy/probe.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`FAIL: ${message}`);
+  console.log(`PASS: ${message}`);
+}
+
+const expectedTools = [
+  "submit_skill", "list_skills", "get_skill", "review_skill",
+  "report_status", "report_completion", "get_inbox", "ack_inbox",
+  "get_all_status", "get_session_status", "send_task", "send_message",
+  "send_reply", "send_ack", "retry_task", "get_task", "list_tasks",
+  "cancel_task", "reassign_task", "broadcast", "get_completions",
+  "update_node_config", "get_config_update", "ack_config_update",
+  "restart_node", "list_host_supervisors", "create_node",
+  "get_create_request", "ack_create_request", "stop_node", "delete_node",
+  "get_stop_request", "ack_stop_request", "list_my_children",
+  "upsert_network_secret", "list_network_secrets", "upsert_provider",
+  "list_providers", "probe_provider_model", "get_probe_results",
+  "get_probe_request",
+];
+
+const toolsSource = readFileSync("src/tools.ts", "utf8");
+const registeredTools = [...toolsSource.matchAll(/server\.tool\(\s*\n\s*"([^"]+)"/g)]
+  .map(match => match[1]);
+assert(
+  JSON.stringify(registeredTools) === JSON.stringify(expectedTools),
+  "all 41 production MCP registrations are explicitly inventoried in source order",
+);
+
+// This is the production registration style today: a raw Zod shape passed to
+// deprecated server.tool(). Exercise the installed real SDK, not a local
+// imitation of its parser.
+const baseline = new McpServer({ name: "test629-baseline", version: "1" });
+baseline.tool(
+  "probe",
+  "probe",
+  { known: z.string() },
+  async args => ({ content: [{ type: "text" as const, text: JSON.stringify(args) }] }),
+);
+const baselineTool = (baseline as any)._registeredTools.probe;
+const baselineParsed = await baselineTool.inputSchema.safeParseAsync({
+  known: "kept",
+  misspelled_field: "synthetic-secret-value",
+});
+assert(baselineParsed.success, "real SDK accepts a call containing an unknown field");
+assert(
+  JSON.stringify(baselineParsed.data) === JSON.stringify({ known: "kept" }),
+  "real SDK silently strips the unknown field before the handler",
+);
+
+const strictSchema = z.object({ known: z.string() }).strict();
+const strictParsed = await strictSchema.safeParseAsync({ known: "kept", legacy_extra: true });
+assert(!strictParsed.success, "global strict mode would hard-fail an existing caller with an extra field");
+
+// Executable feasibility probe for the recommended telemetry-first wrapper:
+// the wire schema preserves unknown keys long enough to observe their shape;
+// a second strip parse restores byte-equivalent handler input. Values must
+// never enter logs because an unknown field can itself contain a credential.
+const shape = { known: z.string() };
+const wireSchema = z.object(shape).passthrough();
+const handlerSchema = z.object(shape).strip();
+const wireParsed = await wireSchema.safeParseAsync({
+  known: "kept",
+  z_extra: "synthetic-secret-value",
+  a_extra: 1,
+});
+assert(wireParsed.success, "telemetry wrapper can preserve unknown keys at the validation boundary");
+if (!wireParsed.success) throw new Error("unreachable");
+const knownKeys = new Set(Object.keys(shape));
+const unknownKeys = Object.keys(wireParsed.data)
+  .filter(key => !knownKeys.has(key))
+  .sort();
+const auditLine = JSON.stringify({ tool: "probe", unknown_keys: unknownKeys });
+assert(auditLine.includes('"a_extra"') && auditLine.includes('"z_extra"'), "telemetry records sorted key names");
+assert(!auditLine.includes("synthetic-secret-value"), "telemetry never records unknown values");
+const handlerParsed = await handlerSchema.safeParseAsync(wireParsed.data);
+assert(handlerParsed.success, "second validation accepts the known payload");
+assert(
+  handlerParsed.success && JSON.stringify(handlerParsed.data) === JSON.stringify(baselineParsed.data),
+  "telemetry wrapper preserves the current stripped handler contract",
+);
+
+console.log("inventory_count=41");
+console.log("recommended_policy=observe-key-shape-then-strip");

--- a/tests/test629-mcp-schema-policy/run.sh
+++ b/tests/test629-mcp-schema-policy/run.sh
@@ -4,5 +4,20 @@ set -euo pipefail
 cd /workspace/server
 echo "# test629 — MCP unknown-field policy audit"
 echo "source_commit=${TEST629_SOURCE_COMMIT}"
+
+cp src/tools.ts /tmp/test629-tools.ts
+printf '\nserver.tool(\n  "mutation_unreviewed_tool",\n' >> src/tools.ts
+set +e
+bun test629/probe.ts >/tmp/test629-inventory-red.log 2>&1
+inventory_rc=$?
+set -e
+cp /tmp/test629-tools.ts src/tools.ts
+if [[ "$inventory_rc" -eq 0 ]]; then
+  echo "MUTATION_FALSE_GREEN: unreviewed tool escaped the explicit inventory" >&2
+  exit 1
+fi
+grep -Fq "all 41 production MCP registrations are explicitly inventoried" /tmp/test629-inventory-red.log
+echo "MUTATION_RED: unreviewed-tool-inventory rc=${inventory_rc}"
+
 bun test629/probe.ts
 echo "RESULT: PASS"

--- a/tests/test629-mcp-schema-policy/run.sh
+++ b/tests/test629-mcp-schema-policy/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspace/server
+echo "# test629 — MCP unknown-field policy audit"
+echo "source_commit=${TEST629_SOURCE_COMMIT}"
+bun test629/probe.ts
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes the evaluation scope of #529 without changing production MCP behavior.

Findings:
- 41 top-level `server.tool(...)` registrations use the raw-shape form;
- the real SDK silently strips unknown fields before project handlers;
- current logs therefore cannot measure historical unknown-field usage;
- a global `.strict()` sweep would hard-fail version-skewed/LLM/third-party callers without a baseline.

Recommendation: telemetry-first per-tool rollout. Preserve unknown keys only at a wrapper boundary, log sorted key names (never values), strip again before the existing handler, then choose strictness tool-by-tool after an observation window. Persisting tools should additionally echo stored fields.

`test629` uses the real resolved MCP SDK and proves baseline strip, strict compatibility failure, telemetry+strip equivalence, value-safe logging, exact 41-tool inventory, and a witnessed-red unreviewed-tool mutation.

Coordinates:
- source `d8e89e5d043972167469a3ce053900da08791fb9`
- Docker `sha256:742974980c98681e469b9f094dbc49345c29ee188d6df8e35de87c76fa6cb199`
- artifact `f7415096c9bc944cabb024cb87ba8f76f39b2f7b9130c250192d6dd99641a2d3`

No production change, merge, publish, or deployment authorization is implied.
