### PR TITLE
security(files): require bearer headers for downloads

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -1947,6 +1947,9 @@ curl -X POST http://localhost:9200/api/upload \
 
 ### GET /api/files/:file_id
 
+文件下载只接受 `Authorization: Bearer ...` 请求头。出于凭据泄漏防护，
+此端点不接受 `?token=` URL 参数（包括 `HEAD` 请求）。
+
 > [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
 
 下载 `POST /api/upload` 返回的文件。始终强制 `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff`（浏览器不 inline 渲染，防 XSS）。

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -1839,6 +1839,10 @@ Common errors: `411 length_required` (no `Content-Length`) · `413 payload_too_l
 
 ### GET /api/files/:file_id
 
+File downloads accept only the `Authorization: Bearer ...` header. To prevent
+credential leakage, this endpoint rejects `?token=` URL authentication for both
+`GET` and `HEAD` requests.
+
 > [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
 
 Downloads a file returned by `POST /api/upload`. Always forces `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff` (the browser won't inline-render it — XSS defense).

--- a/docs/tests/report-test630-file-download-header-auth.txt
+++ b/docs/tests/report-test630-file-download-header-auth.txt
@@ -1,0 +1,50 @@
+# test630 — file download header-only authentication
+
+Date: 2026-08-09
+Issue: #501 (query-token half)
+Source commit: d512d8881a5686f27adaa3920370993940ed9490
+Docker tag: anet-test630:dev
+Docker image: sha256:dc4990b3223edd1e49fc580fe32c017b6e202934acfa8602db3b97ba607c137f
+Embedded source: TEST630_SOURCE_COMMIT=d512d8881a5686f27adaa3920370993940ed9490
+Runner artifact SHA256: daa0d23832b5eb1acd1e2a41e97ef956224230289f45859cb8952df461836b0c
+
+## Result
+
+- Real Hub file authorization suite: 20 pass / 0 fail / 50 assertions.
+- A valid user token in `?token=` is rejected with 401 for both file `GET`
+  and `HEAD`.
+- The same tokens remain valid in `Authorization: Bearer ...` headers.
+- Existing owner, same-network member, cross-network denial, node-token,
+  legacy-master, admin, null-owner, unknown-file and HEAD parity cases remain
+  green.
+- Only `/api/files/:file_id` opts out of query-token authentication. The
+  existing compatibility path remains available to SSE/EventSource and other
+  routes pending a separate migration.
+- Witnessed red: removing both file-route opt-outs makes the new GET and HEAD
+  tests fail (rc=1); restoring them returns 20/0/50.
+
+```text
+L0 production file authorization suite
+20 pass
+0 fail
+50 expect() calls
+MUTATION_RED: file-query-token-opt-out rc=1
+L2 restored green
+20 pass
+0 fail
+50 expect() calls
+RESULT: PASS
+```
+
+## Scope note: global admin
+
+This candidate does not change the second policy question in #501. Since
+#500/#503, cross-network `admin-utok` access is no longer an accidental direct
+read of `users.role`: `resolvePrincipal` classifies the credential and
+`authorizeFileDownload` explicitly grants global-admin operational access,
+while an admin-issued `ntok` is classified as a network token first and cannot
+cross its bound network. Changing the remaining global-admin grant is an API
+semantics decision and needs a separate design/rollout door.
+
+No production service, database, credential, global package, or deployment was
+touched.

--- a/server/src/file-download-authz.test.ts
+++ b/server/src/file-download-authz.test.ts
@@ -168,6 +168,10 @@ async function downloadAs(token: string | null, fileId: string): Promise<Respons
   return fetch(`${BASE}/api/files/${fileId}`, { headers });
 }
 
+async function downloadWithQueryToken(token: string, fileId: string): Promise<Response> {
+  return fetch(`${BASE}/api/files/${fileId}?token=${encodeURIComponent(token)}`);
+}
+
 describe.skipIf(!isProdMode)("#495 — GET /api/files/:file_id authorization (owner-only staged)", () => {
   let userBFileId = "";
 
@@ -238,6 +242,13 @@ describe.skipIf(!isProdMode)("#495 — GET /api/files/:file_id authorization (ow
     expect(res.status).toBe(401);
   });
 
+  test("🔴 valid query token is refused on file GET (credential must stay out of URLs)", async () => {
+    const res = await downloadWithQueryToken(userBToken, userBFileId);
+    expect(res.status).toBe(401);
+    const body: any = await res.json();
+    expect(body.error).toBe("unauthorized");
+  });
+
   test("non-owner request for an UNKNOWN file_id → 404 with same shape as owner-denied (no enumeration signal)", async () => {
     const res = await downloadAs(userAToken, "0123456789abcdef0123456789abcdef");
     expect(res.status).toBe(404);
@@ -255,6 +266,10 @@ async function headAs(token: string | null, fileId: string): Promise<Response> {
   const headers: Record<string, string> = {};
   if (token) headers.Authorization = `Bearer ${token}`;
   return fetch(`${BASE}/api/files/${fileId}`, { method: "HEAD", headers });
+}
+
+async function headWithQueryToken(token: string, fileId: string): Promise<Response> {
+  return fetch(`${BASE}/api/files/${fileId}?token=${encodeURIComponent(token)}`, { method: "HEAD" });
 }
 
 describe.skipIf(!isProdMode)("#500 CR2 — HEAD /api/files/:file_id authorization (parity with GET)", () => {
@@ -293,6 +308,11 @@ describe.skipIf(!isProdMode)("#500 CR2 — HEAD /api/files/:file_id authorizatio
 
   test("HEAD anonymous → 401 (auth still required, symmetric with GET)", async () => {
     const res = await headAs(null, userBFileId);
+    expect(res.status).toBe(401);
+  });
+
+  test("🔴 valid query token is refused on file HEAD (same gate as GET)", async () => {
+    const res = await headWithQueryToken(userBToken, userBFileId);
     expect(res.status).toBe(401);
   });
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -127,19 +127,22 @@ function createServer(clientIP?: string, enforceNetworkId?: string | null, enfor
 }
 
 // ── Auth helper ─────────────────────────────────────
-function requestToken(req: Request): string {
+type RequestTokenOptions = { allowQueryToken?: boolean };
+
+function requestToken(req: Request, options: RequestTokenOptions = {}): string {
   const header = req.headers.get("Authorization")?.replace("Bearer ", "");
+  if (options.allowQueryToken === false) return header || "";
   const url = new URL(req.url);
   return header || url.searchParams.get("token") || "";
 }
 
-function isLegacyAuthToken(req: Request): boolean {
-  const token = requestToken(req);
+function isLegacyAuthToken(req: Request, options: RequestTokenOptions = {}): boolean {
+  const token = requestToken(req, options);
   return !!AUTH_TOKEN && token === AUTH_TOKEN;
 }
 
-function requireAuth(req: Request): Response | null {
-  const token = requestToken(req);
+function requireAuth(req: Request, options: RequestTokenOptions = {}): Response | null {
+  const token = requestToken(req, options);
 
   // V3: check api_tokens first
   if (token) {
@@ -212,8 +215,8 @@ function requireTmuxAccess(req: Request, server?: any): Response | null {
 }
 
 // Extract user + network + token-binding identity from request token.
-function resolveRequestAuth(req: Request): { userId: string; networkId: string | null; username: string; tokenName: string | null; tokenId: string | null } | null {
-  const token = requestToken(req);
+function resolveRequestAuth(req: Request, options: RequestTokenOptions = {}): { userId: string; networkId: string | null; username: string; tokenName: string | null; tokenId: string | null } | null {
+  const token = requestToken(req, options);
   if (!token) return null;
   const resolved = resolveToken(token);
   if (!resolved) return null;
@@ -232,14 +235,14 @@ export type Principal =
   | { kind: "ntok"; userId: string; boundNetworkId: string }
   | { kind: "admin-utok"; userId: string; username: string };
 
-export function resolvePrincipal(req: Request): Principal {
-  const authCtx = resolveRequestAuth(req);
+export function resolvePrincipal(req: Request, options: RequestTokenOptions = {}): Principal {
+  const authCtx = resolveRequestAuth(req, options);
   if (!authCtx) {
-    if (isLegacyAuthToken(req)) return { kind: "legacy-master" };
+    if (isLegacyAuthToken(req, options)) return { kind: "legacy-master" };
     if (DEV_OPEN) return { kind: "dev-open-anon" };
     return { kind: "anonymous" };
   }
-  const token = requestToken(req);
+  const token = requestToken(req, options);
   const resolved = token ? resolveToken(token) : null;
   const isAdmin = !!resolved && resolved.user.role === "admin";
   // Bound network wins over admin classification: a ntok_ issued BY an
@@ -1957,7 +1960,11 @@ return Bun.serve({
     // allow-list inline, or the branches will drift.
     const fileMatch = url.pathname.match(/^\/api\/files\/(.+)$/);
     if (fileMatch && (req.method === "GET" || req.method === "HEAD")) {
-      const authErr = requireAuth(req);
+      // #501: file credentials must never travel in the URL. Query tokens
+      // leak through browser history, access/proxy logs, copied links, and
+      // Referer. SSE/EventSource compatibility keeps the global query-token
+      // fallback for now; file GET/HEAD deliberately opt out here.
+      const authErr = requireAuth(req, { allowQueryToken: false });
       if (authErr) return withCors(req, authErr);
 
       const fileId = decodeURIComponent(fileMatch[1]);
@@ -1988,7 +1995,7 @@ return Bun.serve({
       // "no such file". Both branches return the same 404 shape
       // for BOTH GET and HEAD (HEAD honours body-omission but the
       // status code and headers are the authoritative signal).
-      if (!authorizeFileDownload(resolvePrincipal(req), normalizeEntry(entry))) {
+      if (!authorizeFileDownload(resolvePrincipal(req, { allowQueryToken: false }), normalizeEntry(entry))) {
         return withCors(req, Response.json({ ok: false, error: "not_found" }, { status: 404 }));
       }
 

--- a/tests/test630-file-download-header-auth/Dockerfile
+++ b/tests/test630-file-download-header-auth/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace/server
+COPY server/package.json ./package.json
+RUN bun install --ignore-scripts
+COPY server ./
+COPY tests/test630-file-download-header-auth/run.sh /test630/run.sh
+RUN chmod 0755 /test630/run.sh
+
+ARG SOURCE_COMMIT=unknown
+ENV TEST630_SOURCE_COMMIT=${SOURCE_COMMIT}
+
+ENTRYPOINT ["/test630/run.sh"]

--- a/tests/test630-file-download-header-auth/run.sh
+++ b/tests/test630-file-download-header-auth/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspace/server
+echo "# test630 — file download header-only authentication"
+echo "source_commit=${TEST630_SOURCE_COMMIT}"
+
+echo "L0 production file authorization suite"
+bun test src/file-download-authz.test.ts
+
+echo "L1 witnessed-red: remove the file endpoint's query-token opt-out"
+cp src/server.ts /tmp/test630-server.ts
+sed -i '0,/const authErr = requireAuth(req, { allowQueryToken: false });/{s/const authErr = requireAuth(req, { allowQueryToken: false });/const authErr = requireAuth(req);/}' src/server.ts
+sed -i '0,/resolvePrincipal(req, { allowQueryToken: false })/{s/resolvePrincipal(req, { allowQueryToken: false })/resolvePrincipal(req)/}' src/server.ts
+grep -Fq 'const authErr = requireAuth(req);' src/server.ts
+set +e
+bun test src/file-download-authz.test.ts >/tmp/test630-red.log 2>&1
+mutation_rc=$?
+set -e
+if [[ "$mutation_rc" -eq 0 ]]; then
+  echo "MUTATION_FALSE_GREEN: file query-token authentication was accepted" >&2
+  exit 1
+fi
+grep -Fq 'valid query token is refused on file GET' /tmp/test630-red.log
+grep -Fq 'valid query token is refused on file HEAD' /tmp/test630-red.log
+echo "MUTATION_RED: file-query-token-opt-out rc=${mutation_rc}"
+
+echo "L2 restored green"
+cp /tmp/test630-server.ts src/server.ts
+bun test src/file-download-authz.test.ts
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Partial fix for #501: removes query-string token authentication from `GET` and `HEAD /api/files/:file_id` while preserving existing SSE/EventSource and compatibility routes.

Security behavior:
- file downloads require `Authorization: Bearer ...`
- valid `?token=` credentials are rejected for GET and HEAD
- existing owner, same-network, cross-network denial, node-token, legacy-master, admin and HEAD parity behavior remains covered
- auth helper uses an explicit named option; existing callers retain the compatibility default

Evidence:
- source: `d512d8881a5686f27adaa3920370993940ed9490`
- report-only head: `970cac02126c0c7f303ed1089018c2d32cea688c`
- Docker image: `sha256:dc4990b3223edd1e49fc580fe32c017b6e202934acfa8602db3b97ba607c137f`
- runner artifact: `daa0d23832b5eb1acd1e2a41e97ef956224230289f45859cb8952df461836b0c`
- 20 pass / 0 fail / 50 assertions
- witnessed-red mutation: remove both file opt-outs -> rc=1

Scope boundary:
This does not change the explicit global-admin operational grant introduced by the #500/#503 authorization model. Removing that grant changes API semantics and requires a separate design/rollout decision. Therefore this PR does not claim to close all of #501.

No merge, publish, deployment, database, credential, or global-package action is authorized by this draft.