### PR TITLE
security(config): atomically enforce private token state

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -20,6 +20,7 @@ import {
   atomicWritePrivateFile,
   atomicWritePrivateJson,
   ensurePrivateDirectory,
+  repairPrivateFilePermissions,
 } from "../src/private-state";
 import {
   writeMarker as writeCopresenceMarker,
@@ -962,6 +963,7 @@ async function sseAllConnected(hub: string, aliases: string[]): Promise<"yes" | 
 
 function loadGlobal(): Record<string, any> {
   const p = globalConfigPath();
+  repairPrivateFilePermissions(p);
   if (existsSync(p)) try { return JSON.parse(readFileSync(p, "utf-8")); } catch {}
   return {};
 }
@@ -975,6 +977,7 @@ function saveGlobal(data: Record<string, any>) {
 
 function loadServerConfig(): Record<string, any> {
   const p = serverConfigPath();
+  repairPrivateFilePermissions(p);
   if (existsSync(p)) try { return JSON.parse(readFileSync(p, "utf-8")); } catch {}
   return {};
 }
@@ -1036,6 +1039,7 @@ function saveAdminUtok(data: Record<string, any>) {
 
 function loadAdminUtok(): Record<string, any> {
   const p = adminUtokPath();
+  repairPrivateFilePermissions(p);
   if (existsSync(p)) try { return JSON.parse(readFileSync(p, "utf-8")); } catch {}
   return {};
 }
@@ -1174,6 +1178,7 @@ function validateNodeName(name: string) {
 
 function loadProfile(id: string): Profile | null {
   const p = join(nodesDir(), id, "config.json");
+  repairPrivateFilePermissions(p);
   if (!existsSync(p)) return null;
   try {
     const project = JSON.parse(readFileSync(p, "utf-8"));
@@ -1183,6 +1188,7 @@ function loadProfile(id: string): Profile | null {
 
 function loadStoredProfile(id: string): Profile | null {
   const p = join(nodesDir(), id, "config.json");
+  repairPrivateFilePermissions(p);
   if (!existsSync(p)) return null;
   try {
     const project = JSON.parse(readFileSync(p, "utf-8"));
@@ -2752,6 +2758,7 @@ function resolveProfileEnv(profileEnv: Record<string, any> | undefined, home: st
 // or unreadable. Caller logs the *key count* — never the values.
 function loadNodeDotenv(nodeId: string): Record<string, string> {
   const path = join(nodesDir(), nodeId, ".env");
+  repairPrivateFilePermissions(path);
   if (!existsSync(path)) return {};
   try {
     return parseNodeDotenv(readFileSync(path, "utf-8"));

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -17,6 +17,11 @@ import { homedir } from "os";
 import { spawn, spawnSync, execSync, execFileSync } from "child_process";
 import { createHash, randomBytes, randomUUID } from "crypto";
 import {
+  atomicWritePrivateFile,
+  atomicWritePrivateJson,
+  ensurePrivateDirectory,
+} from "../src/private-state";
+import {
   writeMarker as writeCopresenceMarker,
   readMarker as readCopresenceMarker,
   removeMarker as removeCopresenceMarker,
@@ -597,7 +602,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   rawCfg.codexAppServerUrl = wsUrl;
   rawCfg.codexThreadId = threadId;
   delete rawCfg.session;
-  writeFileSync(rawCfgPath, JSON.stringify(rawCfg, null, 2) + "\n");
+  atomicWritePrivateJson(rawCfgPath, rawCfg);
 
   // ── piece ② bridge (agent-node adopt mode) ────────────────────────────
   // The bridge re-invokes `anet node start` in foreground under tmux; that
@@ -963,11 +968,9 @@ function loadGlobal(): Record<string, any> {
 
 function saveGlobal(data: Record<string, any>) {
   const dir = join(home, ".anet");
-  mkdirSync(dir, { recursive: true, mode: 0o700 });
-  try { chmodSync(dir, 0o700); } catch {}
+  ensurePrivateDirectory(dir);
   const configPath = join(dir, "config.json");
-  writeFileSync(configPath, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
-  try { chmodSync(configPath, 0o600); } catch {}
+  atomicWritePrivateJson(configPath, data);
 }
 
 function loadServerConfig(): Record<string, any> {
@@ -1247,8 +1250,7 @@ function saveProfile(id: string, profile: Profile) {
     assertOpencodeNodeStateUntracked(dir);
     writeOpencodeRuntimeBinding(dir, opencodeBindingHome());
   } else {
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
-    try { chmodSync(dir, 0o700); } catch {}
+    ensurePrivateDirectory(dir);
   }
   const normalized = normalizeStoredProfile(id, profile);
   const toSave: Record<string, any> = {
@@ -1296,8 +1298,7 @@ function saveProfile(id: string, profile: Profile) {
     writeOpencodePrivateProfileFile(dir, "config.json", body);
   } else {
     const configPath = join(dir, "config.json");
-    writeFileSync(configPath, body, { mode: 0o600 });
-    try { chmodSync(configPath, 0o600); } catch {}
+    atomicWritePrivateFile(configPath, body);
   }
 }
 
@@ -6121,8 +6122,8 @@ async function daemonInitCommand() {
     flags: { dangerouslySkipPermissions: true, teammateMode: true },
   };
   const dir = join(nodesDir(), id);
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, "config.json"), JSON.stringify(daemonConfig, null, 2) + "\n");
+  ensurePrivateDirectory(dir);
+  atomicWritePrivateJson(join(dir, "config.json"), daemonConfig);
 
   console.log(`[anet daemon] ✓ ${existing ? "re-initialized" : "created"} host_supervisor daemon "${id}"`);
   console.log(`              config:     .anet/nodes/${id}/config.json`);
@@ -6259,8 +6260,8 @@ async function importCommand() {
       session: s.resume_id,
     };
 
-    mkdirSync(nodeDir, { recursive: true });
-    writeFileSync(configPath, JSON.stringify({
+    ensurePrivateDirectory(nodeDir);
+    atomicWritePrivateJson(configPath, {
       anet_version: config.anet_version,
       node_id: config.node_id,
       node_name: config.node_name,
@@ -6269,7 +6270,7 @@ async function importCommand() {
       env: config.env,
       flags: config.flags,
       session: config.session,
-    }, null, 2) + "\n");
+    });
     console.log(`  ✅ ${s.alias} → ${projectDir}/.anet/nodes/${s.alias}/config.json`);
     created++;
   }
@@ -6868,7 +6869,7 @@ anet node rename <node-id|node-name> <new-node-name> [--force]
         const newCfg = JSON.parse(readFileSync(newCfgPath, "utf-8"));
         if (oldCfg.session && oldCfg.session !== newCfg.session) {
           newCfg.session = oldCfg.session;
-          writeFileSync(newCfgPath, JSON.stringify(newCfg, null, 2) + "\n");
+          atomicWritePrivateJson(newCfgPath, newCfg);
           console.log(`[anet] re-synced session ${String(oldCfg.session).slice(0, 8)}… from old config (post-task writeback) — context preserved.`);
         }
       }
@@ -10247,7 +10248,7 @@ async function demoDebateCommand() {
       const cfgPath = join(nodesRoot, alias, "config.json");
       const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
       cfg.systemPrompt = DEBATE_PROMPTS[role](topic);
-      writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+      atomicWritePrivateJson(cfgPath, cfg);
     }
     console.log(`        ✓ 创建/更新 6 个 agent`);
   } finally {
@@ -10638,7 +10639,7 @@ async function demoSocialMediaCommand() {
       const cfgPath = join(nodesRoot, alias, "config.json");
       const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
       cfg.systemPrompt = SOCIAL_PROMPTS[role](topic, platform);
-      writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+      atomicWritePrivateJson(cfgPath, cfg);
     }
     console.log(`        ✓ 4 个 agent 就位`);
   } finally {
@@ -11061,7 +11062,7 @@ async function demoPrReviewCommand() {
       const cfgPath = join(nodesRoot, alias, "config.json");
       const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
       cfg.systemPrompt = PR_REVIEW_PROMPTS[role]();
-      writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+      atomicWritePrivateJson(cfgPath, cfg);
     }
     console.log(`        ✓ 创建/更新 4 个 agent`);
   } finally {
@@ -12233,7 +12234,7 @@ async function migrateTokenToEnvRefCommand() {
   }
   const bakPath = `${cfgPath}.bak-${Date.now()}`;
   try {
-    writeFileSync(bakPath, readFileSync(cfgPath, "utf-8"));
+    atomicWritePrivateFile(bakPath, readFileSync(cfgPath, "utf-8"));
   } catch (e: any) {
     console.error(`[anet] Failed to write backup ${bakPath}: ${e.message}`);
     process.exit(1);
@@ -12409,7 +12410,7 @@ async function migrateNode(id: string, opts: { hub: string; utok: string; networ
     }
   }
 
-  writeFileSync(p, JSON.stringify(raw, null, 2) + "\n");
+  atomicWritePrivateJson(p, raw);
   return { ok: true, changes };
 }
 

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1015,9 +1015,8 @@ function refreshNodeServerJsAt(targetPath: string, opts: { overwrite: boolean })
 function saveServerConfig(data: Record<string, any>) {
   const dir = join(home, ".anet", "server");
   const p = serverConfigPath();
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(p, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
-  try { chmodSync(p, 0o600); } catch {}
+  ensurePrivateDirectory(dir);
+  atomicWritePrivateJson(p, data);
 }
 
 function serverAuthTokenFromConfig(config = loadServerConfig()): string {
@@ -1031,9 +1030,8 @@ function commhubDbPath() {
 function saveAdminUtok(data: Record<string, any>) {
   const dir = join(home, ".anet", "server");
   const p = adminUtokPath();
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(p, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
-  try { chmodSync(p, 0o600); } catch {}
+  ensurePrivateDirectory(dir);
+  atomicWritePrivateJson(p, data);
 }
 
 function loadAdminUtok(): Record<string, any> {
@@ -2517,7 +2515,7 @@ async function initProject() {
   const token = gc.token || "";
   let envContent = `COMMHUB_URL=${hub}\n`;
   if (token) envContent += `COMMHUB_TOKEN=${token}\n`;
-  writeFileSync(envPath, envContent);
+  atomicWritePrivateFile(envPath, envContent);
   console.log(`CommHub URL: ${hub}${token ? " (with token)" : ""}`);
 
   // 4. .mcp.json（指向 .anet/node-server.js）
@@ -2886,8 +2884,7 @@ function rewritePlainSecretsToEnvRef(nodeId: string, profile: Profile): void {
     const body = Object.entries(merged).map(([k, v]) => `${k}=${v}`).join("\n") + "\n";
     if (isOpencode) writeOpencodePrivateProfileFile(nodeDir, ".env", body);
     else {
-      writeFileSync(dotenvPath, body, { mode: 0o600 });
-      chmodSync(dotenvPath, 0o600);
+      atomicWritePrivateFile(dotenvPath, body);
     }
     ensureNodeDotenvGitignore();
   } catch (e: any) {
@@ -3071,8 +3068,7 @@ function writeTelegramChannelConfig(nodeId: string, botToken: string, allowId: s
   mkdirSync(join(channelDir, "inbox"), { recursive: true });
 
   const envPath = join(channelDir, ".env");
-  writeFileSync(envPath, `TELEGRAM_BOT_TOKEN=${botToken}\n`);
-  try { chmodSync(envPath, 0o600); } catch {}
+  atomicWritePrivateFile(envPath, `TELEGRAM_BOT_TOKEN=${botToken}\n`);
 
   writeAccessJsonAtomic(join(channelDir, "access.json"), {
     dmPolicy: "allowlist",
@@ -3116,8 +3112,7 @@ function writeFeishuChannelConfig(
   const existingChats = parseFeishuAllowlistField(existing.allowChats, "allowChats", accessPath);
 
   const envPath = join(channelDir, ".env");
-  writeFileSync(envPath, `FEISHU_APP_ID=${appId}\nFEISHU_APP_SECRET=${appSecret}\n`);
-  try { chmodSync(envPath, 0o600); } catch {}
+  atomicWritePrivateFile(envPath, `FEISHU_APP_ID=${appId}\nFEISHU_APP_SECRET=${appSecret}\n`);
 
   writeAccessJsonAtomic(accessPath, {
     ...existing,
@@ -4144,8 +4139,7 @@ function ensureMcpJson(profile: Profile) {
   const token = profile.token || "";
   let envContent = `COMMHUB_URL=${profile.hub || "http://127.0.0.1:9200"}\n`;
   if (token) envContent += `COMMHUB_TOKEN=${token}\n`;
-  writeFileSync(anetEnvPath, envContent, { mode: 0o600 });
-  chmodSync(anetEnvPath, 0o600);
+  atomicWritePrivateFile(anetEnvPath, envContent);
 
   // #245 codex-sdk fix — only write `.mcp.json` for claude-code-cli. codex-sdk
   // does not read cwd `.mcp.json`; it reads `~/.codex/config.toml [mcp_servers.*]`

--- a/agent-network/src/private-state.test.ts
+++ b/agent-network/src/private-state.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { atomicWritePrivateFile, atomicWritePrivateJson } from "./private-state";
+import { atomicWritePrivateFile, atomicWritePrivateJson, repairPrivateFilePermissions } from "./private-state";
 
 const roots: string[] = [];
 const mode = (path: string) => lstatSync(path).mode & 0o777;
@@ -49,5 +49,26 @@ describe("#472 private state writer", () => {
     expect(readFileSync(victim, "utf8")).toBe("unchanged");
     expect(lstatSync(path).isSymbolicLink()).toBe(false);
     expect(mode(path)).toBe(0o600);
+  });
+
+  test("repairs a legacy file and parent before reading", () => {
+    const dir = root();
+    const path = join(dir, "config.json");
+    writeFileSync(path, "secret");
+    chmodSync(dir, 0o775);
+    chmodSync(path, 0o664);
+    repairPrivateFilePermissions(path);
+    expect(mode(dir)).toBe(0o700);
+    expect(mode(path)).toBe(0o600);
+  });
+
+  test("read repair refuses a symlink instead of chmod-following it", () => {
+    const dir = root();
+    const victim = join(dir, "victim");
+    const path = join(dir, "config.json");
+    writeFileSync(victim, "unchanged", { mode: 0o644 });
+    symlinkSync(victim, path);
+    expect(() => repairPrivateFilePermissions(path)).toThrow(/linked path/);
+    expect(mode(victim)).toBe(0o644);
   });
 });

--- a/agent-network/src/private-state.test.ts
+++ b/agent-network/src/private-state.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { atomicWritePrivateFile, atomicWritePrivateJson } from "./private-state";
+
+const roots: string[] = [];
+const mode = (path: string) => lstatSync(path).mode & 0o777;
+function root(): string {
+  const path = join(tmpdir(), `anet-private-state-${process.pid}-${roots.length}`);
+  mkdirSync(path, { mode: 0o777 });
+  roots.push(path);
+  return path;
+}
+afterEach(() => { while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true }); });
+
+describe("#472 private state writer", () => {
+  for (const mask of [0o000, 0o002, 0o022, 0o077]) {
+    test(`publishes 0600 files and 0700 parent under umask ${mask.toString(8)}`, () => {
+      const dir = root();
+      const path = join(dir, "config.json");
+      const previous = process.umask(mask);
+      try { atomicWritePrivateJson(path, { token: "ntok_synthetic" }); }
+      finally { process.umask(previous); }
+      expect(mode(path)).toBe(0o600);
+      expect(mode(dir)).toBe(0o700);
+    });
+  }
+
+  test("atomically replaces a legacy 0664 target with a 0600 inode", () => {
+    const dir = root();
+    const path = join(dir, "config.json");
+    writeFileSync(path, "legacy", { mode: 0o666 });
+    chmodSync(path, 0o664);
+    const oldIno = lstatSync(path).ino;
+    atomicWritePrivateFile(path, "secret");
+    expect(readFileSync(path, "utf8")).toBe("secret");
+    expect(mode(path)).toBe(0o600);
+    expect(lstatSync(path).ino).not.toBe(oldIno);
+  });
+
+  test("replaces a leaf symlink instead of writing through it", () => {
+    const dir = root();
+    const victim = join(dir, "victim");
+    const path = join(dir, "config.json");
+    writeFileSync(victim, "unchanged", { mode: 0o600 });
+    symlinkSync(victim, path);
+    atomicWritePrivateFile(path, "secret");
+    expect(readFileSync(victim, "utf8")).toBe("unchanged");
+    expect(lstatSync(path).isSymbolicLink()).toBe(false);
+    expect(mode(path)).toBe(0o600);
+  });
+});

--- a/agent-network/src/private-state.ts
+++ b/agent-network/src/private-state.ts
@@ -77,3 +77,16 @@ export function atomicWritePrivateFile(path: string, body: string): void {
 export function atomicWritePrivateJson(path: string, value: unknown): void {
   atomicWritePrivateFile(path, JSON.stringify(value, null, 2) + "\n");
 }
+
+/** Repair a legacy umask-derived private file before reading its secret. */
+export function repairPrivateFilePermissions(path: string): void {
+  let present = true;
+  try { lstatSync(path); } catch (error: any) {
+    if (error?.code === "ENOENT") present = false;
+    else throw error;
+  }
+  if (!present) return;
+  ensurePrivateDirectory(dirname(path));
+  const fd = openOwned(path, constants.O_RDONLY, "file");
+  try { fchmodSync(fd, 0o600); } finally { closeSync(fd); }
+}

--- a/agent-network/src/private-state.ts
+++ b/agent-network/src/private-state.ts
@@ -1,0 +1,79 @@
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+function openOwned(path: string, flags: number, expected: "file" | "directory"): number {
+  const before = lstatSync(path);
+  if (before.isSymbolicLink() || (expected === "file" && before.nlink !== 1)) {
+    throw new Error(`private state refuses linked path: ${path}`);
+  }
+  const fd = openSync(path, flags | (constants.O_NOFOLLOW || 0));
+  const opened = fstatSync(fd);
+  const uid = process.getuid?.();
+  const correctType = expected === "file" ? opened.isFile() : opened.isDirectory();
+  if (!correctType || (expected === "file" && opened.nlink !== 1)
+    || (uid !== undefined && opened.uid !== uid)
+    || opened.dev !== before.dev || opened.ino !== before.ino) {
+    closeSync(fd);
+    throw new Error(`private state is not an owner-controlled ${expected}: ${path}`);
+  }
+  return fd;
+}
+
+export function ensurePrivateDirectory(path: string): void {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  const fd = openOwned(path, constants.O_RDONLY | (constants.O_DIRECTORY || 0), "directory");
+  try { fchmodSync(fd, 0o700); } finally { closeSync(fd); }
+}
+
+/**
+ * Write secret-bearing state without ever publishing an umask-derived file.
+ * The 0600 temporary file is complete and fsynced before the atomic rename,
+ * so replacing a legacy 0644/0664 target also repairs it with no chmod gap.
+ */
+export function atomicWritePrivateFile(path: string, body: string): void {
+  const parent = dirname(path);
+  ensurePrivateDirectory(parent);
+  const temp = join(parent, `.${basename(path)}.${randomBytes(12).toString("hex")}.tmp`);
+  let fd: number | undefined;
+  try {
+    fd = openSync(
+      temp,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW || 0),
+      0o600,
+    );
+    writeFileSync(fd, body, "utf8");
+    fchmodSync(fd, 0o600);
+    fsyncSync(fd);
+    const stat = fstatSync(fd);
+    const uid = process.getuid?.();
+    if (!stat.isFile() || stat.nlink !== 1 || (uid !== undefined && stat.uid !== uid)) {
+      throw new Error(`private state temporary file is not owner-controlled: ${temp}`);
+    }
+    closeSync(fd);
+    fd = undefined;
+    renameSync(temp, path);
+    const parentFd = openOwned(parent, constants.O_RDONLY | (constants.O_DIRECTORY || 0), "directory");
+    try { fsyncSync(parentFd); } finally { closeSync(parentFd); }
+  } catch (error) {
+    if (fd !== undefined) try { closeSync(fd); } catch {}
+    rmSync(temp, { force: true });
+    throw error;
+  }
+}
+
+export function atomicWritePrivateJson(path: string, value: unknown): void {
+  atomicWritePrivateFile(path, JSON.stringify(value, null, 2) + "\n");
+}

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -87,6 +87,7 @@ import {
   computeApplyMode as computeConfigApplyMode,
   atomicWriteJson,
   backupConfigPrev,
+  repairPrivateConfigPermissions,
   loadConfigWithSelfHeal,
   mergePatch,
   buildConfigSnapshot,
@@ -245,6 +246,9 @@ if (opts.config) {
   const cfgPath = isAbsolute(opts.config) ? opts.config : join(process.cwd(), opts.config);
   const explicitlyOpencode = opts.runtime === "opencode-cli" || opts.runtime === "opencode";
   try {
+    // #472 — repair legacy umask-derived 0644/0664 state before reading a
+    // token. The FD-based helper refuses symlink/hardlink substitution.
+    repairPrivateConfigPermissions(cfgPath);
     // Inspect both primary and .prev without following a suspicious leaf.
     // This also lets a config-only direct launch select the hardened loader.
     opencodeConfigState = explicitlyOpencode || configStateDeclaresOpencode(cfgPath);
@@ -328,6 +332,8 @@ if (!opts.config && ALIAS) {
   const newPath = join(process.cwd(), ".anet", "nodes", ALIAS, "config.json");
   const oldPath = join(process.cwd(), ".anet", "profiles", `${ALIAS}.json`);
   const profilePath = existsSync(newPath) ? newPath : oldPath;
+  try { repairPrivateConfigPermissions(profilePath); }
+  catch (e: any) { console.error(`[agent-node] Refusing unsafe config state: ${e?.message || e}`); process.exit(1); }
   const profile = loadJson(profilePath);
   if (profile) {
     fileConfig = { ...profile, ...fileConfig };
@@ -336,7 +342,10 @@ if (!opts.config && ALIAS) {
   }
 }
 
-const globalConfig = loadJson(join(home, ".anet", "config.json")) || {};
+const globalConfigPath = join(home, ".anet", "config.json");
+try { repairPrivateConfigPermissions(globalConfigPath); }
+catch (e: any) { console.error(`[agent-node] Refusing unsafe global config: ${e?.message || e}`); process.exit(1); }
+const globalConfig = loadJson(globalConfigPath) || {};
 if (globalConfig.hub && !fileConfig.hub) fileConfig.hub = globalConfig.hub;
 if (globalConfig.token && !fileConfig.token) fileConfig.token = globalConfig.token;
 
@@ -756,7 +765,7 @@ function writebackSession(sessionId: string) {
     const cfg = JSON.parse(readFileSync(configFilePath, "utf-8"));
     if (cfg.session === sessionId) return; // 已是最新
     cfg.session = sessionId;
-    writeFileSync(configFilePath, JSON.stringify(cfg, null, 2) + "\n");
+    atomicWriteJson(configFilePath, cfg);
     debug(`session 写回: ${configFilePath} → ${sessionId.slice(0, 8)}...`);
   } catch (e: any) {
     warn(`writebackSession failed: ${e.message}`);
@@ -771,7 +780,7 @@ function writebackGrokSession(sessionId: string) {
     const key = GROK_EXECUTION_MODE === "cli" ? "grokCliSession" : "grokSession";
     if (cfg[key] === sessionId) return;
     cfg[key] = sessionId;
-    writeFileSync(configFilePath, JSON.stringify(cfg, null, 2) + "\n");
+    atomicWriteJson(configFilePath, cfg);
     debug(`${key} 写回: ${configFilePath} → ${sessionId.slice(0, 8)}...`);
   } catch (e: any) {
     warn(`writebackGrokSession failed: ${e.message}`);
@@ -788,7 +797,7 @@ function writebackCodexThread(threadId: string) {
     const cfg = JSON.parse(readFileSync(configFilePath, "utf-8"));
     if (cfg.codexThreadId === threadId) return;
     cfg.codexThreadId = threadId;
-    writeFileSync(configFilePath, JSON.stringify(cfg, null, 2) + "\n");
+    atomicWriteJson(configFilePath, cfg);
     debug(`codexThreadId 写回: ${configFilePath} → ${threadId.slice(0, 8)}...`);
   } catch (e: any) {
     warn(`writebackCodexThread failed: ${e.message}`);
@@ -803,7 +812,7 @@ function clearGrokSession(reason: string) {
     const key = GROK_EXECUTION_MODE === "cli" ? "grokCliSession" : "grokSession";
     if (!cfg[key]) return;
     delete cfg[key];
-    writeFileSync(configFilePath, JSON.stringify(cfg, null, 2) + "\n");
+    atomicWriteJson(configFilePath, cfg);
     warn(`cleared ${key} (${reason})`);
   } catch (e: any) {
     warn(`clearGrokSession failed: ${e.message}`);

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -822,6 +822,7 @@ function clearGrokSession(reason: string) {
 // ── Channel config ──
 function loadEnvFile(path: string) {
   if (!existsSync(path)) return;
+  repairPrivateConfigPermissions(path);
   for (const rawLine of readFileSync(path, "utf-8").split("\n")) {
     const line = rawLine.trim();
     if (!line || line.startsWith("#")) continue;

--- a/agent-node/src/runtime/config-apply.test.ts
+++ b/agent-node/src/runtime/config-apply.test.ts
@@ -4,7 +4,9 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -18,6 +20,7 @@ import {
   computeApplyMode,
   atomicWriteJson,
   backupConfigPrev,
+  repairPrivateConfigPermissions,
   loadConfigWithSelfHeal,
   mergePatch,
   buildConfigSnapshot,
@@ -119,6 +122,45 @@ describe("atomicWriteJson — temp + rename", () => {
     // No .tmp file should remain after the rename.
     const tmpFiles = require("node:fs").readdirSync(scratch).filter((f: string) => f.includes(".tmp."));
     expect(tmpFiles.length).toBe(0);
+  });
+});
+
+describe("#472 private config permissions", () => {
+  const mode = (path: string) => lstatSync(path).mode & 0o777;
+
+  for (const mask of [0o000, 0o002, 0o022, 0o077]) {
+    test(`atomic write is 0600 under umask ${mask.toString(8)}`, () => {
+      const path = join(scratch, "config.json");
+      chmodSync(scratch, 0o777);
+      const previous = process.umask(mask);
+      try { atomicWriteJson(path, { token: "ntok_synthetic" }); }
+      finally { process.umask(previous); }
+      expect(mode(path)).toBe(0o600);
+      expect(mode(scratch)).toBe(0o700);
+    });
+  }
+
+  test("repairs existing primary, backup, and parent before token read", () => {
+    const path = join(scratch, "config.json");
+    writeFileSync(path, JSON.stringify({ token: "ntok_primary" }));
+    writeFileSync(`${path}.prev`, JSON.stringify({ token: "ntok_backup" }));
+    chmodSync(scratch, 0o775);
+    chmodSync(path, 0o664);
+    chmodSync(`${path}.prev`, 0o644);
+    repairPrivateConfigPermissions(path);
+    expect(mode(scratch)).toBe(0o700);
+    expect(mode(path)).toBe(0o600);
+    expect(mode(`${path}.prev`)).toBe(0o600);
+  });
+
+  test("backup atomically replaces a legacy broad .prev", () => {
+    const path = join(scratch, "config.json");
+    writeFileSync(path, JSON.stringify({ token: "ntok_fresh" }), { mode: 0o600 });
+    writeFileSync(`${path}.prev`, JSON.stringify({ token: "ntok_old" }));
+    chmodSync(`${path}.prev`, 0o664);
+    backupConfigPrev(path);
+    expect(mode(`${path}.prev`)).toBe(0o600);
+    expect(JSON.parse(readFileSync(`${path}.prev`, "utf8")).token).toBe("ntok_fresh");
   });
 });
 

--- a/agent-node/src/runtime/config-apply.test.ts
+++ b/agent-node/src/runtime/config-apply.test.ts
@@ -130,27 +130,57 @@ describe("#472 private config permissions", () => {
 
   for (const mask of [0o000, 0o002, 0o022, 0o077]) {
     test(`atomic write is 0600 under umask ${mask.toString(8)}`, () => {
-      const path = join(scratch, "config.json");
-      chmodSync(scratch, 0o777);
+      const parent = join(scratch, ".anet", "nodes", "n_test");
+      mkdirSync(parent, { recursive: true });
+      const path = join(parent, "config.json");
+      chmodSync(parent, 0o777);
       const previous = process.umask(mask);
       try { atomicWriteJson(path, { token: "ntok_synthetic" }); }
       finally { process.umask(previous); }
       expect(mode(path)).toBe(0o600);
-      expect(mode(scratch)).toBe(0o700);
+      expect(mode(parent)).toBe(0o700);
     });
   }
 
   test("repairs existing primary, backup, and parent before token read", () => {
-    const path = join(scratch, "config.json");
+    const parent = join(scratch, ".anet", "nodes", "n_test");
+    mkdirSync(parent, { recursive: true });
+    const path = join(parent, "config.json");
     writeFileSync(path, JSON.stringify({ token: "ntok_primary" }));
     writeFileSync(`${path}.prev`, JSON.stringify({ token: "ntok_backup" }));
-    chmodSync(scratch, 0o775);
+    chmodSync(parent, 0o775);
     chmodSync(path, 0o664);
     chmodSync(`${path}.prev`, 0o644);
     repairPrivateConfigPermissions(path);
-    expect(mode(scratch)).toBe(0o700);
+    expect(mode(parent)).toBe(0o700);
     expect(mode(path)).toBe(0o600);
     expect(mode(`${path}.prev`)).toBe(0o600);
+  });
+
+  test("custom --config parent is never chmodded", () => {
+    const parent = join(scratch, "shared-project");
+    mkdirSync(parent);
+    chmodSync(parent, 0o750);
+    const path = join(parent, "agent.json");
+    writeFileSync(path, JSON.stringify({ token: "ntok_custom" }));
+    chmodSync(path, 0o664);
+
+    repairPrivateConfigPermissions(path);
+
+    expect(mode(parent)).toBe(0o750);
+    expect(mode(path)).toBe(0o600);
+  });
+
+  test("atomic custom --config write preserves parent mode", () => {
+    const parent = join(scratch, "shared-project");
+    mkdirSync(parent);
+    chmodSync(parent, 0o755);
+    const path = join(parent, "agent.json");
+
+    atomicWriteJson(path, { token: "ntok_custom" });
+
+    expect(mode(parent)).toBe(0o755);
+    expect(mode(path)).toBe(0o600);
   });
 
   test("backup atomically replaces a legacy broad .prev", () => {

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -30,7 +30,7 @@ import {
   writeFileSync,
   renameSync,
 } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { randomBytes } from "node:crypto";
 
 /** Sentinel exit code for "supervisor please restart me with the new
@@ -200,7 +200,7 @@ export function atomicWriteJson(path: string, data: unknown): void {
 
 function atomicWritePrivateText(path: string, body: string): void {
   const parent = dirname(path);
-  repairPrivateDirectory(parent);
+  repairPrivateDirectory(parent, isManagedAnetDirectory(parent));
   const tmp = join(parent, `.${basename(path)}.${randomBytes(12).toString("hex")}.tmp`);
   let fd: number | undefined;
   try {
@@ -222,7 +222,19 @@ function atomicWritePrivateText(path: string, body: string): void {
   }
 }
 
-function repairPrivateDirectory(path: string): void {
+/**
+ * Only Agent Network-owned state below a literal `.anet` path component has
+ * a product contract that its directory is private. `--config` is a public
+ * flag and may point at `$HOME/agent.json`, a project checkout, or another
+ * operator-owned directory; changing that parent to 0700 would be a
+ * destructive, surprising side effect. Files are still repaired/written as
+ * 0600 everywhere, but directory tightening is scoped to managed state.
+ */
+function isManagedAnetDirectory(path: string): boolean {
+  return resolve(path).split(sep).includes(".anet");
+}
+
+function repairPrivateDirectory(path: string, tightenMode: boolean): void {
   const before = lstatSync(path);
   if (before.isSymbolicLink() || !before.isDirectory()) {
     throw new Error(`private config refuses non-directory or linked parent: ${path}`);
@@ -236,14 +248,15 @@ function repairPrivateDirectory(path: string): void {
       || opened.dev !== before.dev || opened.ino !== before.ino) {
       throw new Error(`private config parent is not owner-controlled: ${path}`);
     }
-    fchmodSync(fd, 0o700);
+    if (tightenMode) fchmodSync(fd, 0o700);
   } finally { closeSync(fd); }
 }
 
 /** Tighten legacy umask-derived config state before reading any token. */
 export function repairPrivateConfigPermissions(path: string): void {
   if (!existsSync(path) && !existsSync(`${path}.prev`)) return;
-  repairPrivateDirectory(dirname(path));
+  const parent = dirname(path);
+  repairPrivateDirectory(parent, isManagedAnetDirectory(parent));
   for (const candidate of [path, `${path}.prev`]) {
     if (!existsSync(candidate)) continue;
     const before = lstatSync(candidate);

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -195,6 +195,10 @@ export function computeApplyMode(patch: ConfigPatch): ApplyMode {
  * (caught by cross-agent review on PR B).
  */
 export function atomicWriteJson(path: string, data: unknown): void {
+  atomicWritePrivateText(path, JSON.stringify(data, null, 2) + "\n");
+}
+
+function atomicWritePrivateText(path: string, body: string): void {
   const parent = dirname(path);
   repairPrivateDirectory(parent);
   const tmp = join(parent, `.${basename(path)}.${randomBytes(12).toString("hex")}.tmp`);
@@ -205,7 +209,7 @@ export function atomicWriteJson(path: string, data: unknown): void {
       constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW || 0),
       0o600,
     );
-    writeFileSync(fd, JSON.stringify(data, null, 2) + "\n", "utf8");
+    writeFileSync(fd, body, "utf8");
     fchmodSync(fd, 0o600);
     fsyncSync(fd);
     closeSync(fd);
@@ -265,7 +269,7 @@ export function repairPrivateConfigPermissions(path: string): void {
  * config (first-write case) — caller handles. */
 export function backupConfigPrev(path: string): { backedUp: boolean } {
   if (!existsSync(path)) return { backedUp: false };
-  atomicWriteJson(`${path}.prev`, JSON.parse(readFileSync(path, "utf8")));
+  atomicWritePrivateText(`${path}.prev`, readFileSync(path, "utf8"));
   return { backedUp: true };
 }
 
@@ -296,7 +300,7 @@ export function loadConfigWithSelfHeal(path: string): SelfHealOutcome {
     const prevTxt = readFileSync(prevPath, "utf-8");
     const prevParsed = JSON.parse(prevTxt);
     // Recovery: copy .prev back to primary so the next boot uses it.
-    atomicWriteJson(path, prevParsed);
+    atomicWritePrivateText(path, prevTxt);
     return { config: prevParsed, source: "prev", primaryError };
   } catch (e: any) {
     throw new Error(

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -17,13 +17,21 @@
 // the path without terminating the test runner.
 
 import {
+  closeSync,
+  constants,
   existsSync,
-  copyFileSync,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
   readFileSync,
+  rmSync,
   writeFileSync,
   renameSync,
-  unlinkSync,
 } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
 
 /** Sentinel exit code for "supervisor please restart me with the new
  * config" — borrows BSD EX_TEMPFAIL semantics. The parent supervisor
@@ -187,19 +195,68 @@ export function computeApplyMode(patch: ConfigPatch): ApplyMode {
  * (caught by cross-agent review on PR B).
  */
 export function atomicWriteJson(path: string, data: unknown): void {
-  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+  const parent = dirname(path);
+  repairPrivateDirectory(parent);
+  const tmp = join(parent, `.${basename(path)}.${randomBytes(12).toString("hex")}.tmp`);
+  let fd: number | undefined;
   try {
-    writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n");
+    fd = openSync(
+      tmp,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW || 0),
+      0o600,
+    );
+    writeFileSync(fd, JSON.stringify(data, null, 2) + "\n", "utf8");
+    fchmodSync(fd, 0o600);
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
     renameSync(tmp, path);
   } catch (e) {
-    // Best-effort cleanup; ignore if tmp doesn't exist or unlink fails.
-    // unlinkSync imported at module top — strict-ESM compatible (the
-    // earlier `require("node:fs")` inline would fail under runtimes
-    // without CJS interop).
-    try {
-      if (existsSync(tmp)) unlinkSync(tmp);
-    } catch { /* swallow */ }
+    if (fd !== undefined) try { closeSync(fd); } catch {}
+    rmSync(tmp, { force: true });
     throw e;
+  }
+}
+
+function repairPrivateDirectory(path: string): void {
+  const before = lstatSync(path);
+  if (before.isSymbolicLink() || !before.isDirectory()) {
+    throw new Error(`private config refuses non-directory or linked parent: ${path}`);
+  }
+  const fd = openSync(path, constants.O_RDONLY | (constants.O_DIRECTORY || 0) | (constants.O_NOFOLLOW || 0));
+  try {
+    const opened = fstatSync(fd);
+    const uid = process.getuid?.();
+    if (!opened.isDirectory()
+      || (uid !== undefined && opened.uid !== uid)
+      || opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error(`private config parent is not owner-controlled: ${path}`);
+    }
+    fchmodSync(fd, 0o700);
+  } finally { closeSync(fd); }
+}
+
+/** Tighten legacy umask-derived config state before reading any token. */
+export function repairPrivateConfigPermissions(path: string): void {
+  if (!existsSync(path) && !existsSync(`${path}.prev`)) return;
+  repairPrivateDirectory(dirname(path));
+  for (const candidate of [path, `${path}.prev`]) {
+    if (!existsSync(candidate)) continue;
+    const before = lstatSync(candidate);
+    if (before.isSymbolicLink() || !before.isFile() || before.nlink !== 1) {
+      throw new Error(`private config refuses linked or non-regular file: ${candidate}`);
+    }
+    const fd = openSync(candidate, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+    try {
+      const opened = fstatSync(fd);
+      const uid = process.getuid?.();
+      if (!opened.isFile() || opened.nlink !== 1
+        || (uid !== undefined && opened.uid !== uid)
+        || opened.dev !== before.dev || opened.ino !== before.ino) {
+        throw new Error(`private config is not owner-controlled: ${candidate}`);
+      }
+      fchmodSync(fd, 0o600);
+    } finally { closeSync(fd); }
   }
 }
 
@@ -208,7 +265,7 @@ export function atomicWriteJson(path: string, data: unknown): void {
  * config (first-write case) — caller handles. */
 export function backupConfigPrev(path: string): { backedUp: boolean } {
   if (!existsSync(path)) return { backedUp: false };
-  copyFileSync(path, `${path}.prev`);
+  atomicWriteJson(`${path}.prev`, JSON.parse(readFileSync(path, "utf8")));
   return { backedUp: true };
 }
 
@@ -239,7 +296,7 @@ export function loadConfigWithSelfHeal(path: string): SelfHealOutcome {
     const prevTxt = readFileSync(prevPath, "utf-8");
     const prevParsed = JSON.parse(prevTxt);
     // Recovery: copy .prev back to primary so the next boot uses it.
-    copyFileSync(prevPath, path);
+    atomicWriteJson(path, prevParsed);
     return { config: prevParsed, source: "prev", primaryError };
   } catch (e: any) {
     throw new Error(

--- a/docs/tests/report-test631-private-config-permissions.txt
+++ b/docs/tests/report-test631-private-config-permissions.txt
@@ -3,20 +3,21 @@
 Date: 2026-08-09
 Issue: #472
 Base: f1ea43d511c3b134d6cc0f95e1734aecc0cf0a1c
-Source commit: ccb7b1f32b95e547a0af0dc161723a464b011167
+Source commit: 74b4caa08393122dcd4269845d50ee87a0b4441b
 Docker tag: anet-test631:dev
-Docker image: sha256:80d50ccfa6b1ac950bde77cecfc1ff8d8e1d4bd29dc23d882064cd96530cc694
-Embedded source: TEST631_SOURCE_COMMIT=ccb7b1f32b95e547a0af0dc161723a464b011167
-Runner artifact SHA256: 395fc0d5d358499b6b3ba0c3610c45c0bb076dc73a612d5a9e8b884f83e63406
+Docker image: sha256:15afcc6ab8c8a957bf46d7a6df352c6541a47cb621aee077ec902703247e2496
+Embedded source: TEST631_SOURCE_COMMIT=74b4caa08393122dcd4269845d50ee87a0b4441b
+Runner artifact SHA256: cce3f2903ace93ee17eb2fd76641b0c99bc918eba5fb2fd5a67151e287b325d1
 
 ## Result
 
 - Both production entrypoints bundle with all local modules resolved:
   `agent-network/bin/cli.ts` (26 modules) and `agent-node/src/cli.ts`
   (79 modules).
-- Permission behavior: 90 pass / 0 fail / 157 assertions.
-- New files are 0600 and their immediate private directory is 0700 under
-  umask 000, 002, 022, and 077.
+- Permission behavior: 92 pass / 0 fail / 161 assertions.
+- New files are 0600 under umask 000, 002, 022, and 077. Recognized `.anet`
+  state directories are tightened to 0700; an arbitrary custom `--config`
+  parent retains its existing mode while the config itself becomes 0600.
 - Replacing an existing 0664 config publishes a new 0600 inode atomically;
   there is no public target between create and chmod.
 - Existing config, `.prev`, and token `.env` state is repaired with no-follow
@@ -47,8 +48,9 @@ state. Static inventory fails if a direct token-bearing config writer returns.
 
 1. Changing both private writers from 0600 to 0666 makes the umask=000
    assertions fail (`MUTATION_RED: private-mode rc=1`).
-2. Removing the explicit-config startup repair call makes the exact
-   production-path inventory fail (`MUTATION_RED: startup-repair rc=1`).
+2. Removing the explicit-config startup repair call from the real CLI bundle,
+   then starting it against a legacy 0644 config, leaves that file at 0644 and
+   makes the behavior gate fail (`MUTATION_RED: startup-repair rc=1`).
 
 The inventory originally used a shell `! grep` form that did not act as a
 reliable `set -e` gate and also matched the legitimate Codex `wx` writer. That
@@ -57,10 +59,13 @@ one-writer positive assertion before recording this report.
 
 ## Scope and residual platform boundary
 
-Only the immediate secret-state directories are set to 0700; project/workspace
-ancestors are not changed. The Docker evidence proves POSIX mode behavior on
-Linux. Windows ACL semantics are not represented by Unix mode bits and remain
-outside this claim.
+Only recognized `.anet` secret-state directories are set to 0700;
+project/workspace ancestors and arbitrary custom-config parents are not
+changed. Ownership and no-follow checks are fail-closed. A config bind-mounted
+from a different uid is therefore rejected rather than silently repaired;
+operators must align ownership or copy it into managed state. The Docker
+evidence proves POSIX mode behavior on Linux. Windows ACL semantics are not
+represented by Unix mode bits and remain outside this claim.
 
 No production service, credential, database, global package, deployment, or
 existing user file was touched.

--- a/docs/tests/report-test631-private-config-permissions.txt
+++ b/docs/tests/report-test631-private-config-permissions.txt
@@ -1,0 +1,66 @@
+# test631 — private token configuration permissions
+
+Date: 2026-08-09
+Issue: #472
+Base: f1ea43d511c3b134d6cc0f95e1734aecc0cf0a1c
+Source commit: ccb7b1f32b95e547a0af0dc161723a464b011167
+Docker tag: anet-test631:dev
+Docker image: sha256:80d50ccfa6b1ac950bde77cecfc1ff8d8e1d4bd29dc23d882064cd96530cc694
+Embedded source: TEST631_SOURCE_COMMIT=ccb7b1f32b95e547a0af0dc161723a464b011167
+Runner artifact SHA256: 395fc0d5d358499b6b3ba0c3610c45c0bb076dc73a612d5a9e8b884f83e63406
+
+## Result
+
+- Both production entrypoints bundle with all local modules resolved:
+  `agent-network/bin/cli.ts` (26 modules) and `agent-node/src/cli.ts`
+  (79 modules).
+- Permission behavior: 90 pass / 0 fail / 157 assertions.
+- New files are 0600 and their immediate private directory is 0700 under
+  umask 000, 002, 022, and 077.
+- Replacing an existing 0664 config publishes a new 0600 inode atomically;
+  there is no public target between create and chmod.
+- Existing config, `.prev`, and token `.env` state is repaired with no-follow
+  file descriptors before the secret is read.
+- A leaf symlink is never followed: atomic replacement leaves its target
+  unchanged, while read-time repair rejects it fail-closed.
+- Byte-for-byte `.prev` backup and self-heal behavior remains intact. The
+  first exact-source run caught a re-serialization regression; the writer was
+  changed to preserve raw bytes rather than weakening the existing test.
+
+## Covered production writers
+
+- global user, server, and admin-utok configuration;
+- canonical node profile create/update, daemon init, import, demos, doctor,
+  migration, copresence thread persistence, rename session resync;
+- secret migration backup (`config.json.bak-*`);
+- agent-node session/Grok/Codex thread writeback, RFC-024 apply, `.prev`
+  backup and self-heal;
+- project/node CommHub token `.env`, vendor secret `.env`, Telegram bot token
+  and Feishu app-secret sidecars.
+
+The existing one-shot Codex copresence token writer remains independent: it
+already uses `O_EXCL` (`flag:"wx"`) with mode 0600 and immediate cleanup. The
+non-secret legacy `COMMHUB_ALIAS` sidecar is not classified as credential
+state. Static inventory fails if a direct token-bearing config writer returns.
+
+## Witnessed red
+
+1. Changing both private writers from 0600 to 0666 makes the umask=000
+   assertions fail (`MUTATION_RED: private-mode rc=1`).
+2. Removing the explicit-config startup repair call makes the exact
+   production-path inventory fail (`MUTATION_RED: startup-repair rc=1`).
+
+The inventory originally used a shell `! grep` form that did not act as a
+reliable `set -e` gate and also matched the legitimate Codex `wx` writer. That
+false-green was replaced with explicit fail-closed branching plus an exact
+one-writer positive assertion before recording this report.
+
+## Scope and residual platform boundary
+
+Only the immediate secret-state directories are set to 0700; project/workspace
+ancestors are not changed. The Docker evidence proves POSIX mode behavior on
+Linux. Windows ACL semantics are not represented by Unix mode bits and remain
+outside this claim.
+
+No production service, credential, database, global package, deployment, or
+existing user file was touched.

--- a/tests/test631-private-config-permissions/Dockerfile
+++ b/tests/test631-private-config-permissions/Dockerfile
@@ -1,9 +1,8 @@
 FROM oven/bun:1.3.14
 WORKDIR /work
-COPY agent-network/src/private-state.ts agent-network/src/private-state.test.ts ./agent-network/src/
-COPY agent-node/src/runtime/config-apply.ts agent-node/src/runtime/config-apply.test.ts ./agent-node/src/runtime/
-COPY agent-network/bin/cli.ts ./agent-network/bin/cli.ts
-COPY agent-node/src/cli.ts ./agent-node/src/cli.ts
+COPY agent-network/src ./agent-network/src
+COPY agent-network/bin ./agent-network/bin
+COPY agent-node/src ./agent-node/src
 COPY tests/test631-private-config-permissions/run.sh /run.sh
 ARG TEST631_SOURCE_COMMIT=unknown
 ENV TEST631_SOURCE_COMMIT=$TEST631_SOURCE_COMMIT

--- a/tests/test631-private-config-permissions/Dockerfile
+++ b/tests/test631-private-config-permissions/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14
+WORKDIR /work
+COPY agent-network/src/private-state.ts agent-network/src/private-state.test.ts ./agent-network/src/
+COPY agent-node/src/runtime/config-apply.ts agent-node/src/runtime/config-apply.test.ts ./agent-node/src/runtime/
+COPY agent-network/bin/cli.ts ./agent-network/bin/cli.ts
+COPY agent-node/src/cli.ts ./agent-node/src/cli.ts
+COPY tests/test631-private-config-permissions/run.sh /run.sh
+ARG TEST631_SOURCE_COMMIT=unknown
+ENV TEST631_SOURCE_COMMIT=$TEST631_SOURCE_COMMIT
+RUN chmod 0755 /run.sh
+ENTRYPOINT ["/run.sh"]

--- a/tests/test631-private-config-permissions/run.sh
+++ b/tests/test631-private-config-permissions/run.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 cd /work
 echo "source_commit=$TEST631_SOURCE_COMMIT"
 
+echo "L0 local-module bundle"
+bun build --target bun --packages external agent-network/bin/cli.ts --outfile /tmp/anet-cli.js
+bun build --target bun --packages external agent-node/src/cli.ts --outfile /tmp/agent-node-cli.js
+
+echo "L1 permission behavior"
 bun test agent-network/src/private-state.test.ts agent-node/src/runtime/config-apply.test.ts
 
 # Production-path inventory: every token-preserving config write must use a

--- a/tests/test631-private-config-permissions/run.sh
+++ b/tests/test631-private-config-permissions/run.sh
@@ -30,7 +30,7 @@ grep -q 'atomicWritePrivateFile(anetEnvPath, envContent)' agent-network/bin/cli.
 grep -q 'repairPrivateFilePermissions(p);' agent-network/bin/cli.ts
 grep -q 'repairPrivateFilePermissions(path);' agent-network/bin/cli.ts
 test "$(grep -c 'atomicWriteJson(configFilePath, cfg)' agent-node/src/cli.ts)" -eq 4
-test "$(grep -c 'repairPrivateConfigPermissions' agent-node/src/cli.ts)" -eq 4
+test "$(grep -c 'repairPrivateConfigPermissions' agent-node/src/cli.ts)" -eq 5
 grep -A2 'function loadEnvFile(path: string)' agent-node/src/cli.ts | grep -q 'repairPrivateConfigPermissions(path)'
 
 # Witnessed red 1: weakening both creation and fd hardening to 0666 must make
@@ -52,7 +52,7 @@ echo "MUTATION_RED: private-mode rc=$mode_rc"
 cp agent-node/src/cli.ts /tmp/test631-cli-mutated.ts
 sed -i '/repairPrivateConfigPermissions(cfgPath);/d' /tmp/test631-cli-mutated.ts
 set +e
-test "$(grep -c 'repairPrivateConfigPermissions' /tmp/test631-cli-mutated.ts)" -eq 4
+test "$(grep -c 'repairPrivateConfigPermissions' /tmp/test631-cli-mutated.ts)" -eq 5
 repair_rc=$?
 set -e
 test "$repair_rc" -ne 0

--- a/tests/test631-private-config-permissions/run.sh
+++ b/tests/test631-private-config-permissions/run.sh
@@ -27,8 +27,11 @@ grep -q 'atomicWritePrivateFile(bakPath' agent-network/bin/cli.ts
 test "$(grep -c 'atomicWritePrivateFile(envPath' agent-network/bin/cli.ts)" -eq 3
 grep -q 'atomicWritePrivateFile(dotenvPath, body)' agent-network/bin/cli.ts
 grep -q 'atomicWritePrivateFile(anetEnvPath, envContent)' agent-network/bin/cli.ts
+grep -q 'repairPrivateFilePermissions(p);' agent-network/bin/cli.ts
+grep -q 'repairPrivateFilePermissions(path);' agent-network/bin/cli.ts
 test "$(grep -c 'atomicWriteJson(configFilePath, cfg)' agent-node/src/cli.ts)" -eq 4
 test "$(grep -c 'repairPrivateConfigPermissions' agent-node/src/cli.ts)" -eq 4
+grep -A2 'function loadEnvFile(path: string)' agent-node/src/cli.ts | grep -q 'repairPrivateConfigPermissions(path)'
 
 # Witnessed red 1: weakening both creation and fd hardening to 0666 must make
 # the umask=000 permission tests fail.

--- a/tests/test631-private-config-permissions/run.sh
+++ b/tests/test631-private-config-permissions/run.sh
@@ -15,9 +15,13 @@ bun test agent-network/src/private-state.test.ts agent-node/src/runtime/config-a
 # private choke point. These assertions deliberately name each direct path so
 # a new bypass cannot hide behind an aggregate green count.
 ! grep -nE 'writeFileSync\((rawCfgPath|configFilePath|newCfgPath|cfgPath)' agent-network/bin/cli.ts agent-node/src/cli.ts
+! grep -nE 'writeFileSync\((envPath|dotenvPath|anetEnvPath)' agent-network/bin/cli.ts
 grep -q 'atomicWritePrivateJson(rawCfgPath, rawCfg)' agent-network/bin/cli.ts
 grep -q 'atomicWritePrivateJson(join(dir, "config.json"), daemonConfig)' agent-network/bin/cli.ts
 grep -q 'atomicWritePrivateFile(bakPath' agent-network/bin/cli.ts
+test "$(grep -c 'atomicWritePrivateFile(envPath' agent-network/bin/cli.ts)" -eq 3
+grep -q 'atomicWritePrivateFile(dotenvPath, body)' agent-network/bin/cli.ts
+grep -q 'atomicWritePrivateFile(anetEnvPath, envContent)' agent-network/bin/cli.ts
 test "$(grep -c 'atomicWriteJson(configFilePath, cfg)' agent-node/src/cli.ts)" -eq 4
 test "$(grep -c 'repairPrivateConfigPermissions' agent-node/src/cli.ts)" -eq 4
 

--- a/tests/test631-private-config-permissions/run.sh
+++ b/tests/test631-private-config-permissions/run.sh
@@ -33,6 +33,35 @@ test "$(grep -c 'atomicWriteJson(configFilePath, cfg)' agent-node/src/cli.ts)" -
 test "$(grep -c 'repairPrivateConfigPermissions' agent-node/src/cli.ts)" -eq 5
 grep -A2 'function loadEnvFile(path: string)' agent-node/src/cli.ts | grep -q 'repairPrivateConfigPermissions(path)'
 
+# Real startup gate: an existing legacy config must be repaired before the
+# process reaches any Hub/runtime work. Use an isolated HOME + unreachable Hub,
+# then stop only the exact PID we launched.
+startup_repair_gate() {
+  local root="$1"
+  test ! -e "$root"
+  mkdir -p "$root/home" "$root/.anet/nodes/legacy"
+  local cfg="$root/.anet/nodes/legacy/config.json"
+  cat >"$cfg" <<'JSON'
+{"alias":"legacy","node_id":"n_test631","runtime":"claude-agent-sdk","model":"synthetic","hub":"http://127.0.0.1:1","token":"ntok_synthetic"}
+JSON
+  chmod 0644 "$cfg"
+  HOME="$root/home" bun agent-node/src/cli.ts --config "$cfg" --alias legacy \
+    >"$root/start.log" 2>&1 &
+  local pid=$!
+  for _ in $(seq 1 100); do
+    if [ "$(stat -c '%a' "$cfg")" = 600 ]; then break; fi
+    if ! kill -0 "$pid" 2>/dev/null; then break; fi
+    sleep 0.02
+  done
+  local mode
+  mode=$(stat -c '%a' "$cfg")
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  test "$mode" = 600
+}
+
+startup_repair_gate /tmp/test631-startup-green
+
 # Witnessed red 1: weakening both creation and fd hardening to 0666 must make
 # the umask=000 permission tests fail.
 mkdir -p /mutation/agent-network/src /mutation/agent-node/src/runtime
@@ -47,14 +76,15 @@ test "$mode_rc" -ne 0
 grep -Eq 'expected.*384|toBe\(384\)|Expected.*384' /tmp/test631-mode-red.txt
 echo "MUTATION_RED: private-mode rc=$mode_rc"
 
-# Witnessed red 2: deleting the startup repair call is caught by the exact
-# production-path inventory (not by a comment/string count).
-cp agent-node/src/cli.ts /tmp/test631-cli-mutated.ts
-sed -i '/repairPrivateConfigPermissions(cfgPath);/d' /tmp/test631-cli-mutated.ts
+# Witnessed red 2: deleting the startup repair call leaves a real legacy
+# config at 0644. This is a behavior gate, not a source-count proxy.
+cp agent-node/src/cli.ts /tmp/test631-cli-original.ts
+sed -i '/repairPrivateConfigPermissions(cfgPath);/d' agent-node/src/cli.ts
 set +e
-test "$(grep -c 'repairPrivateConfigPermissions' /tmp/test631-cli-mutated.ts)" -eq 5
+startup_repair_gate /tmp/test631-startup-mutated
 repair_rc=$?
 set -e
+cp /tmp/test631-cli-original.ts agent-node/src/cli.ts
 test "$repair_rc" -ne 0
 echo "MUTATION_RED: startup-repair rc=$repair_rc"
 

--- a/tests/test631-private-config-permissions/run.sh
+++ b/tests/test631-private-config-permissions/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /work
+echo "source_commit=$TEST631_SOURCE_COMMIT"
+
+bun test agent-network/src/private-state.test.ts agent-node/src/runtime/config-apply.test.ts
+
+# Production-path inventory: every token-preserving config write must use a
+# private choke point. These assertions deliberately name each direct path so
+# a new bypass cannot hide behind an aggregate green count.
+! grep -nE 'writeFileSync\((rawCfgPath|configFilePath|newCfgPath|cfgPath)' agent-network/bin/cli.ts agent-node/src/cli.ts
+grep -q 'atomicWritePrivateJson(rawCfgPath, rawCfg)' agent-network/bin/cli.ts
+grep -q 'atomicWritePrivateJson(join(dir, "config.json"), daemonConfig)' agent-network/bin/cli.ts
+grep -q 'atomicWritePrivateFile(bakPath' agent-network/bin/cli.ts
+test "$(grep -c 'atomicWriteJson(configFilePath, cfg)' agent-node/src/cli.ts)" -eq 4
+test "$(grep -c 'repairPrivateConfigPermissions' agent-node/src/cli.ts)" -eq 4
+
+# Witnessed red 1: weakening both creation and fd hardening to 0666 must make
+# the umask=000 permission tests fail.
+mkdir -p /mutation/agent-network/src /mutation/agent-node/src/runtime
+cp agent-network/src/private-state.ts agent-network/src/private-state.test.ts /mutation/agent-network/src/
+cp agent-node/src/runtime/config-apply.ts agent-node/src/runtime/config-apply.test.ts /mutation/agent-node/src/runtime/
+sed -i 's/0o600/0o666/g' /mutation/agent-network/src/private-state.ts /mutation/agent-node/src/runtime/config-apply.ts
+set +e
+(cd /mutation && bun test agent-network/src/private-state.test.ts agent-node/src/runtime/config-apply.test.ts) >/tmp/test631-mode-red.txt 2>&1
+mode_rc=$?
+set -e
+test "$mode_rc" -ne 0
+grep -Eq 'expected.*384|toBe\(384\)|Expected.*384' /tmp/test631-mode-red.txt
+echo "MUTATION_RED: private-mode rc=$mode_rc"
+
+# Witnessed red 2: deleting the startup repair call is caught by the exact
+# production-path inventory (not by a comment/string count).
+cp agent-node/src/cli.ts /tmp/test631-cli-mutated.ts
+sed -i '/repairPrivateConfigPermissions(cfgPath);/d' /tmp/test631-cli-mutated.ts
+set +e
+test "$(grep -c 'repairPrivateConfigPermissions' /tmp/test631-cli-mutated.ts)" -eq 4
+repair_rc=$?
+set -e
+test "$repair_rc" -ne 0
+echo "MUTATION_RED: startup-repair rc=$repair_rc"
+
+echo "RESULT: PASS"

--- a/tests/test631-private-config-permissions/run.sh
+++ b/tests/test631-private-config-permissions/run.sh
@@ -14,8 +14,13 @@ bun test agent-network/src/private-state.test.ts agent-node/src/runtime/config-a
 # Production-path inventory: every token-preserving config write must use a
 # private choke point. These assertions deliberately name each direct path so
 # a new bypass cannot hide behind an aggregate green count.
-! grep -nE 'writeFileSync\((rawCfgPath|configFilePath|newCfgPath|cfgPath)' agent-network/bin/cli.ts agent-node/src/cli.ts
-! grep -nE 'writeFileSync\((envPath|dotenvPath|anetEnvPath)' agent-network/bin/cli.ts
+if grep -nE 'writeFileSync\((rawCfgPath|configFilePath|newCfgPath|cfgPath)' agent-network/bin/cli.ts agent-node/src/cli.ts; then
+  echo "FAIL: direct token-bearing config writer bypass" >&2
+  exit 1
+fi
+env_direct="$(grep -nE 'writeFileSync\((envPath|dotenvPath|anetEnvPath)' agent-network/bin/cli.ts || true)"
+test "$(printf '%s\n' "$env_direct" | grep -c .)" -eq 1
+printf '%s\n' "$env_direct" | grep -q 'mode: 0o600, flag: "wx"'
 grep -q 'atomicWritePrivateJson(rawCfgPath, rawCfg)' agent-network/bin/cli.ts
 grep -q 'atomicWritePrivateJson(join(dir, "config.json"), daemonConfig)' agent-network/bin/cli.ts
 grep -q 'atomicWritePrivateFile(bakPath' agent-network/bin/cli.ts


### PR DESCRIPTION
Closes #472.

Replaces umask-dependent secret writes with private atomic writers and repairs legacy broad permissions before reading credentials.

Key behavior:
- 0600 temporary inode + fsync + atomic rename; existing 0644/0664 targets converge without a write-then-chmod window
- recognized `.anet` secret-state directories converge to 0700; arbitrary custom `--config` parent modes and workspace ancestors are untouched
- no-follow FD repair runs before global/profile/server/admin/node `.env` reads
- agent-node session/thread/config-apply and `.prev` paths share the private atomic choke point
- token sidecars (project/node/vendor/Telegram/Feishu) and migration backups are covered
- the already-safe Codex one-shot `wx`+0600 writer remains independent

Evidence:
- base: `f1ea43d511c3b134d6cc0f95e1734aecc0cf0a1c`
- source: `74b4caa08393122dcd4269845d50ee87a0b4441b`
- report-only head: `3ed73ea8fac394f3ad69bdfecdcd1d899ea64061`
- image: `sha256:15afcc6ab8c8a957bf46d7a6df352c6541a47cb621aee077ec902703247e2496`
- artifact: `cce3f2903ace93ee17eb2fd76641b0c99bc918eba5fb2fd5a67151e287b325d1`
- both production entrypoints bundle; 92 pass / 0 fail / 161 assertions
- witnessed red: 0600->0666 mutation rc=1; deleting real CLI startup repair leaves 0644 and rc=1

The review-found parent over-tightening is fixed add-only: custom config parents retain 0750/0755 while the file converges to 0600. The startup-repair mutation now proves runtime behavior rather than source inventory.

Residual boundary: Linux/POSIX mode behavior is proven. Foreign-uid bind mounts fail closed and require ownership alignment or copying into managed state; Windows ACL semantics are not claimed.

No merge, publish, deployment, production file, credential, database, or global-package action is authorized by this draft.