### PR TITLE
fix(agent-node): make SSE recovery guidance duplicate-safe (#535)

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -31,6 +31,7 @@ import { computeNextWakeAt } from "./goals/schedule";
 import { bumpFailure, resetFailure, applyAutoPause, resolveMaxConsecutiveFailures } from "./goals/failure-counter";
 import { formatSelfLoopsBlock } from "./goals/format";
 import { startTelegramWatchdog } from "./telegram-watchdog";
+import { sseAbandonGuidance } from "./sse-recovery-guidance";
 import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
 import { maskedEnv } from "./secret-mask";
@@ -5440,8 +5441,7 @@ async function connectSSE() {
     label: "sse",
     shutdownGate: () => false,  // no in-process shutdown gate for SSE; abandon-after-1h is the bail
     abandonAfterMs: ABANDON_AFTER_MS,
-    onAbandon: () =>
-      error(`SSE 连续 >1h 连不上 hub (${COMMHUB_URL}) — 放弃自动重连。运行 \`anet node start ${ALIAS}\` 手动恢复。`),
+    onAbandon: () => error(sseAbandonGuidance(ALIAS, COMMHUB_URL)),
     onRetryWait: (waitMs) => debug(`SSE reconnecting (${(waitMs / 1000).toFixed(1)}s)...`),
     onError: (err: any) => warn(`SSE error: ${err?.message || err}`),
     runOnce: async (ctrl) => {

--- a/agent-node/src/sse-recovery-guidance.test.ts
+++ b/agent-node/src/sse-recovery-guidance.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { sseAbandonGuidance } from "./sse-recovery-guidance";
+
+describe("sseAbandonGuidance", () => {
+  test("states that abandon leaves the current process alive", () => {
+    const text = sseAbandonGuidance("TM副责人", "http://127.0.0.1:9200");
+    expect(text).toContain("当前 agent-node 实例");
+    expect(text).toContain("仍在运行");
+    expect(text).toContain("alias=TM副责人");
+  });
+
+  test("requires stop-and-replace instead of starting a duplicate", () => {
+    const text = sseAbandonGuidance("TM副责人", "http://127.0.0.1:9200");
+    expect(text).toContain("不要另起同 alias 实例");
+    expect(text).toContain("重复消费者");
+    expect(text).toContain("先停止当前实例");
+    expect(text).toContain("替换式重启");
+    expect(text).not.toContain("anet node start TM副责人");
+  });
+
+  test("preserves the co-presence launch shape in recovery guidance", () => {
+    const text = sseAbandonGuidance("A站负责人TUI", "https://hub.example.invalid");
+    expect(text).toContain("--copresence");
+    expect(text).toContain("专用 config");
+    expect(text).toContain("不能改用通用 node start");
+  });
+
+  test("the production SSE abandon hook uses the honest guidance", () => {
+    const cli = readFileSync(join(import.meta.dir, "cli.ts"), "utf8");
+    expect(cli).toContain("onAbandon: () => error(sseAbandonGuidance(ALIAS, COMMHUB_URL))");
+    expect(cli).not.toContain("运行 `anet node start ${ALIAS}` 手动恢复");
+  });
+});

--- a/agent-node/src/sse-recovery-guidance.ts
+++ b/agent-node/src/sse-recovery-guidance.ts
@@ -1,0 +1,23 @@
+/**
+ * Build the operator guidance emitted when the SSE supervisor gives up.
+ *
+ * Important lifecycle fact: abandoning the SSE retry loop does not terminate
+ * agent-node. The current process (and, for co-presence, its sibling TUI and
+ * app-server) remains alive. Telling the operator to run a second generic
+ * `anet node start <alias>` therefore creates a duplicate inbox consumer and
+ * can also replace a co-presence runtime with a plain runtime.
+ *
+ * There is no universally correct executable recovery command here: legacy
+ * co-presence nodes may have been launched with a dedicated config, while
+ * managed nodes may be owned by tmux, systemd, a daemon, or another
+ * supervisor. The only safe generic instruction is stop-and-replace through
+ * the original owner/launch path.
+ */
+export function sseAbandonGuidance(alias: string, hubUrl: string): string {
+  return [
+    `SSE 连续 >1h 连不上 hub (${hubUrl}) — 已停止自动重连。`,
+    `当前 agent-node 实例（alias=${alias}）仍在运行；不要另起同 alias 实例，否则会产生重复消费者。`,
+    "请先停止当前实例，再通过原 supervisor/service 或本实例的原始启动命令做替换式重启。",
+    "共存节点必须保留原 --copresence / 专用 config 启动方式，不能改用通用 node start。",
+  ].join(" ");
+}

--- a/docs/tests/report-test632-honest-sse-recovery.txt
+++ b/docs/tests/report-test632-honest-sse-recovery.txt
@@ -1,0 +1,38 @@
+# test632 — honest SSE abandon recovery guidance
+
+Date: 2026-08-09
+Issue: #535
+Base: f7e854c3e64eee75cf06c4c8c1563c2c2230be3a
+Source commit: edb034c786c7b140b25fdfd7dd9688b8dd38ab10
+Docker image: anet-test632:dev
+Docker image ID: sha256:02bbb851b4607626754d62dc939e93f0d574f3d98592c2b326fbf6b003848951
+Embedded TEST632_SOURCE_COMMIT: edb034c786c7b140b25fdfd7dd9688b8dd38ab10
+Runner artifact SHA256: 0e842fe67a971d513fbee1380b503be91f6b77063e2e8580be73961feeca8603
+
+## Result
+
+PASS.
+
+- Helper and production-hook contract: 4 pass, 0 fail, 13 assertions.
+- Real agent-node entrypoint bundled successfully (255 modules, 1.92 MB).
+- Guidance states the lifecycle fact: abandoning SSE leaves the current
+  agent-node instance alive.
+- Guidance forbids starting a parallel instance with the same alias and
+  requires stop-and-replace through the original supervisor/launch path.
+- Co-presence recovery explicitly preserves `--copresence` / dedicated
+  config shape; it does not recommend generic `anet node start <alias>`.
+
+## Witnessed red
+
+1. Replaced the duplicate-safe sentence with the former generic
+   `anet node start <alias>` instruction: test suite rc=1.
+2. Bypassed `sseAbandonGuidance` in the production `onAbandon` hook: test
+   suite rc=1.
+
+After restoring both mutations, the full suite returned green.
+
+## Scope
+
+This candidate changes only the operator guidance emitted after the existing
+one-hour SSE abandon threshold. It does not alter retry timing, process
+lifecycle, Hub behavior, runtime selection, or production state.

--- a/docs/tests/report-test632-honest-sse-recovery.txt
+++ b/docs/tests/report-test632-honest-sse-recovery.txt
@@ -3,11 +3,11 @@
 Date: 2026-08-09
 Issue: #535
 Base: f7e854c3e64eee75cf06c4c8c1563c2c2230be3a
-Source commit: edb034c786c7b140b25fdfd7dd9688b8dd38ab10
+Source commit: 35ded55fbaefc213791e4b77b5b97d38114e6e4d
 Docker image: anet-test632:dev
-Docker image ID: sha256:02bbb851b4607626754d62dc939e93f0d574f3d98592c2b326fbf6b003848951
-Embedded TEST632_SOURCE_COMMIT: edb034c786c7b140b25fdfd7dd9688b8dd38ab10
-Runner artifact SHA256: 0e842fe67a971d513fbee1380b503be91f6b77063e2e8580be73961feeca8603
+Docker image ID: sha256:3a45c156c6cbd5dcff38a2bc3dfba51c52ff8e002982da49dcaa0e3db0f4f416
+Embedded TEST632_SOURCE_COMMIT: 35ded55fbaefc213791e4b77b5b97d38114e6e4d
+Runner artifact SHA256: b0b4574c044517a889aff3e6ce3b32b50095ead24a786e8af462a1ecf05c87fa
 
 ## Result
 
@@ -15,6 +15,9 @@ PASS.
 
 - Helper and production-hook contract: 4 pass, 0 fail, 13 assertions.
 - Real agent-node entrypoint bundled successfully (255 modules, 1.92 MB).
+- A real child process ran `superviseChild` to the abandon threshold. The
+  `onAbandon` hook fired, the promise returned, and the parent then verified
+  that the same child PID was still alive before stopping it explicitly.
 - Guidance states the lifecycle fact: abandoning SSE leaves the current
   agent-node instance alive.
 - Guidance forbids starting a parallel instance with the same alias and

--- a/tests/test632-honest-sse-recovery/Dockerfile
+++ b/tests/test632-honest-sse-recovery/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+
+COPY agent-node ./agent-node
+COPY tests/test632-honest-sse-recovery ./tests/test632-honest-sse-recovery
+
+ARG SOURCE_COMMIT
+ENV TEST632_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test632-honest-sse-recovery/run.sh
+ENTRYPOINT ["/workspace/tests/test632-honest-sse-recovery/run.sh"]

--- a/tests/test632-honest-sse-recovery/abandon-lifecycle-probe.ts
+++ b/tests/test632-honest-sse-recovery/abandon-lifecycle-probe.ts
@@ -1,0 +1,21 @@
+import { superviseChild } from "../../agent-node/src/util/supervise-child";
+
+// Model the production SSE abandon path with deterministic time. The probe
+// deliberately keeps one unrelated handle alive, as agent-node does (status
+// timers, channel servers, runtime handles). If superviseChild only returns,
+// this process stays alive; if it exits/kills the process, the parent harness
+// cannot observe the marker and kill -0 check.
+let now = 0;
+await superviseChild({
+  label: "test632-sse",
+  shutdownGate: () => false,
+  runOnce: async () => {},
+  abandonAfterMs: 1,
+  jitterRatio: 0,
+  now: () => now,
+  sleep: async (ms) => { now += ms; },
+  onAbandon: () => process.stdout.write("ON_ABANDON\n"),
+});
+
+process.stdout.write(`ABANDON_RETURNED_PROCESS_ALIVE pid=${process.pid}\n`);
+setInterval(() => {}, 60_000);

--- a/tests/test632-honest-sse-recovery/run.sh
+++ b/tests/test632-honest-sse-recovery/run.sh
@@ -31,7 +31,26 @@ bun build agent-node/src/cli.ts \
   --external node-pty
 test -s /tmp/test632-dist/cli.js
 
-echo "L2 witnessed-red: restore the dangerous duplicate-start guidance"
+echo "L2 real supervisor abandon returns without killing the agent process"
+bun tests/test632-honest-sse-recovery/abandon-lifecycle-probe.ts \
+  >/tmp/test632-abandon-probe.log 2>&1 &
+probe_pid=$!
+for _ in $(seq 1 100); do
+  if grep -Fq 'ABANDON_RETURNED_PROCESS_ALIVE' /tmp/test632-abandon-probe.log; then break; fi
+  if ! kill -0 "$probe_pid" 2>/dev/null; then
+    echo "FAIL: abandon probe exited before the parent observed it"
+    cat /tmp/test632-abandon-probe.log
+    exit 1
+  fi
+  sleep 0.02
+done
+grep -Fq 'ON_ABANDON' /tmp/test632-abandon-probe.log
+grep -Fq "ABANDON_RETURNED_PROCESS_ALIVE pid=$probe_pid" /tmp/test632-abandon-probe.log
+kill -0 "$probe_pid"
+kill "$probe_pid"
+wait "$probe_pid" 2>/dev/null || true
+
+echo "L3 witnessed-red: restore the dangerous duplicate-start guidance"
 cp agent-node/src/sse-recovery-guidance.ts /tmp/test632-guidance.ts
 sed -i 's/`当前 agent-node 实例（alias=${alias}）仍在运行；不要另起同 alias 实例，否则会产生重复消费者。`/`运行 `anet node start ${alias}` 手动恢复。`/' agent-node/src/sse-recovery-guidance.ts
 grep -Fq 'anet node start ${alias}' agent-node/src/sse-recovery-guidance.ts
@@ -46,7 +65,7 @@ fi
 echo "MUTATION_RED: duplicate-start-guidance rc=$guidance_rc"
 cp /tmp/test632-guidance.ts agent-node/src/sse-recovery-guidance.ts
 
-echo "L3 witnessed-red: bypass the helper in the production abandon hook"
+echo "L4 witnessed-red: bypass the helper in the production abandon hook"
 cp agent-node/src/cli.ts /tmp/test632-cli.ts
 sed -i 's/onAbandon: () => error(sseAbandonGuidance(ALIAS, COMMHUB_URL))/onAbandon: () => error(`abandoned`)/' agent-node/src/cli.ts
 grep -Fq 'onAbandon: () => error(`abandoned`)' agent-node/src/cli.ts
@@ -61,7 +80,7 @@ fi
 echo "MUTATION_RED: production-hook-bypass rc=$wiring_rc"
 cp /tmp/test632-cli.ts agent-node/src/cli.ts
 
-echo "L4 restored green"
+echo "L5 restored green"
 run_tests
 
 echo "RESULT: PASS"

--- a/tests/test632-honest-sse-recovery/run.sh
+++ b/tests/test632-honest-sse-recovery/run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test632-honest-sse-recovery.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test632 — honest SSE abandon recovery guidance"
+echo "source_commit=${TEST632_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+cd /workspace
+
+run_tests() {
+  bun test agent-node/src/sse-recovery-guidance.test.ts
+}
+
+echo "L0 helper behaviour + production wiring"
+run_tests
+
+echo "L1 real agent-node bundle"
+bun build agent-node/src/cli.ts \
+  --outdir /tmp/test632-dist \
+  --entry-naming cli.js \
+  --target node \
+  --external @anthropic-ai/claude-agent-sdk \
+  --external '@anthropic-ai/claude-agent-sdk-*' \
+  --external @openai/codex-sdk \
+  --external node-pty
+test -s /tmp/test632-dist/cli.js
+
+echo "L2 witnessed-red: restore the dangerous duplicate-start guidance"
+cp agent-node/src/sse-recovery-guidance.ts /tmp/test632-guidance.ts
+sed -i 's/`当前 agent-node 实例（alias=${alias}）仍在运行；不要另起同 alias 实例，否则会产生重复消费者。`/`运行 `anet node start ${alias}` 手动恢复。`/' agent-node/src/sse-recovery-guidance.ts
+grep -Fq 'anet node start ${alias}' agent-node/src/sse-recovery-guidance.ts
+set +e
+run_tests >/tmp/test632-guidance-mutation.log 2>&1
+guidance_rc=$?
+set -e
+if [ "$guidance_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: duplicate-start-guidance"
+  exit 1
+fi
+echo "MUTATION_RED: duplicate-start-guidance rc=$guidance_rc"
+cp /tmp/test632-guidance.ts agent-node/src/sse-recovery-guidance.ts
+
+echo "L3 witnessed-red: bypass the helper in the production abandon hook"
+cp agent-node/src/cli.ts /tmp/test632-cli.ts
+sed -i 's/onAbandon: () => error(sseAbandonGuidance(ALIAS, COMMHUB_URL))/onAbandon: () => error(`abandoned`)/' agent-node/src/cli.ts
+grep -Fq 'onAbandon: () => error(`abandoned`)' agent-node/src/cli.ts
+set +e
+run_tests >/tmp/test632-wiring-mutation.log 2>&1
+wiring_rc=$?
+set -e
+if [ "$wiring_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: production-hook-bypass"
+  exit 1
+fi
+echo "MUTATION_RED: production-hook-bypass rc=$wiring_rc"
+cp /tmp/test632-cli.ts agent-node/src/cli.ts
+
+echo "L4 restored green"
+run_tests
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## Outcome

When the SSE supervisor gives up after one hour, the message now states the real lifecycle state: agent-node is still alive. It forbids starting a second same-alias instance and directs operators to stop-and-replace through the original supervisor/launch path. Co-presence nodes are told to preserve `--copresence` / dedicated config instead of using generic `node start`.

## Scope

- Guidance only; no retry timing or lifecycle behavior change.
- Pure helper + production hook.
- No Hub/Dashboard/production changes.

## Verification

- Exact source: `35ded55fbaefc213791e4b77b5b97d38114e6e4d`
- Report-only head: `dde8fcaa4f28794a3a3ea41b1ccef7262df2430b`
- Docker: 4 pass / 0 fail / 13 assertions; real CLI bundle 255 modules.
- Real child-process probe: supervisor reached abandon, hook fired, promise returned, and the same PID remained alive until the parent explicitly stopped it.
- Witnessed red: restore generic `anet node start` guidance -> rc=1; bypass helper in production hook -> rc=1.
- Evidence: `docs/tests/report-test632-honest-sse-recovery.txt`

Closes #535