### PR TITLE
fix(cli): warn when doctor detects non-UTF-8 locale

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -88,6 +88,7 @@ import {
   type GrokCopresenceSessionDisclosure,
 } from "../src/grok-copresence-disclosure";
 import { parseCliOptions, positionalArgs } from "../src/cli-args";
+import { diagnoseLocale } from "../src/locale-diagnostic";
 import {
   collectClaudeVendorEnvForCreate,
   planPlainSecretEnvRewrites,
@@ -12429,6 +12430,17 @@ async function doctorCommand() {
   check("Global config (~/.anet/config.json)", !!gc.hub, gc.hub || "missing — run: anet init");
   if (gc.token) check("Auth token configured", true);
   else warning("Auth token", "not set — agents connect without auth");
+
+  const locale = diagnoseLocale(process.env, process.platform);
+  if (locale.shouldWarn) {
+    const source = locale.effectiveVariable
+      ? `${locale.effectiveVariable}=${locale.effectiveValue}`
+      : "LANG/LC_ALL/LC_CTYPE=<unset>";
+    warning(
+      "System locale",
+      `${source} is not UTF-8; Unicode aliases and tmux output may be corrupted. Fix: export LANG=C.UTF-8 LC_ALL=C.UTF-8`,
+    );
+  }
 
   // 2. Hub connectivity
   if (gc.hub) {

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -88,7 +88,7 @@ import {
   type GrokCopresenceSessionDisclosure,
 } from "../src/grok-copresence-disclosure";
 import { parseCliOptions, positionalArgs } from "../src/cli-args";
-import { diagnoseLocale } from "../src/locale-diagnostic";
+import { diagnoseLocale, formatLocaleSource } from "../src/locale-diagnostic";
 import {
   collectClaudeVendorEnvForCreate,
   planPlainSecretEnvRewrites,
@@ -12433,9 +12433,7 @@ async function doctorCommand() {
 
   const locale = diagnoseLocale(process.env, process.platform);
   if (locale.shouldWarn) {
-    const source = locale.effectiveVariable
-      ? `${locale.effectiveVariable}=${locale.effectiveValue}`
-      : "LANG/LC_ALL/LC_CTYPE=<unset>";
+    const source = formatLocaleSource(locale);
     warning(
       "System locale",
       `${source} is not UTF-8; Unicode aliases and tmux output may be corrupted. Fix: export LANG=C.UTF-8 LC_ALL=C.UTF-8`,

--- a/agent-network/src/locale-diagnostic-wiring.test.ts
+++ b/agent-network/src/locale-diagnostic-wiring.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+test("#68 doctor reports the pure locale diagnostic as a warning", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const cli = readFileSync(join(here, "..", "bin", "cli.ts"), "utf8");
+  expect(cli).toContain('import { diagnoseLocale } from "../src/locale-diagnostic"');
+  expect(cli).toContain("const locale = diagnoseLocale(process.env, process.platform);");
+  expect(cli).toContain('"System locale",');
+  expect(cli).toContain("export LANG=C.UTF-8 LC_ALL=C.UTF-8");
+});

--- a/agent-network/src/locale-diagnostic-wiring.test.ts
+++ b/agent-network/src/locale-diagnostic-wiring.test.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "node:path";
 test("#68 doctor reports the pure locale diagnostic as a warning", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const cli = readFileSync(join(here, "..", "bin", "cli.ts"), "utf8");
-  expect(cli).toContain('import { diagnoseLocale } from "../src/locale-diagnostic"');
+  expect(cli).toContain('from "../src/locale-diagnostic"');
   expect(cli).toContain("const locale = diagnoseLocale(process.env, process.platform);");
+  expect(cli).toContain("const source = formatLocaleSource(locale);");
   expect(cli).toContain('"System locale",');
   expect(cli).toContain("export LANG=C.UTF-8 LC_ALL=C.UTF-8");
 });

--- a/agent-network/src/locale-diagnostic.test.ts
+++ b/agent-network/src/locale-diagnostic.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { diagnoseLocale } from "./locale-diagnostic";
+
+describe("#68 locale diagnostic", () => {
+  test("LC_ALL overrides an otherwise UTF-8 LANG", () => {
+    expect(diagnoseLocale({ LANG: "en_US.UTF-8", LC_ALL: "C" }, "linux")).toEqual({
+      effectiveVariable: "LC_ALL",
+      effectiveValue: "C",
+      shouldWarn: true,
+    });
+  });
+
+  test("LC_CTYPE overrides LANG when LC_ALL is empty", () => {
+    expect(diagnoseLocale({ LANG: "C", LC_ALL: "", LC_CTYPE: "zh_CN.UTF-8" }, "linux")).toEqual({
+      effectiveVariable: "LC_CTYPE",
+      effectiveValue: "zh_CN.UTF-8",
+      shouldWarn: false,
+    });
+  });
+
+  test("accepts common UTF-8 spellings", () => {
+    for (const value of ["C.UTF-8", "en_US.utf8", "zh_CN.UTF8"]) {
+      expect(diagnoseLocale({ LANG: value }, "linux").shouldWarn).toBe(false);
+    }
+  });
+
+  test("warns for POSIX, C, non-UTF-8, and unset locale", () => {
+    for (const env of [{ LANG: "POSIX" }, { LANG: "C" }, { LANG: "en_US.ISO-8859-1" }, {}]) {
+      expect(diagnoseLocale(env, "linux").shouldWarn).toBe(true);
+    }
+  });
+
+  test("does not prescribe POSIX locale variables on Windows", () => {
+    expect(diagnoseLocale({}, "win32")).toEqual({
+      effectiveVariable: null,
+      effectiveValue: null,
+      shouldWarn: false,
+    });
+  });
+});

--- a/agent-network/src/locale-diagnostic.test.ts
+++ b/agent-network/src/locale-diagnostic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { diagnoseLocale } from "./locale-diagnostic";
+import { diagnoseLocale, formatLocaleSource } from "./locale-diagnostic";
 
 describe("#68 locale diagnostic", () => {
   test("LC_ALL overrides an otherwise UTF-8 LANG", () => {
@@ -36,5 +36,14 @@ describe("#68 locale diagnostic", () => {
       effectiveValue: null,
       shouldWarn: false,
     });
+  });
+
+  test("renders locale values without terminal control or unbounded output", () => {
+    const diagnostic = diagnoseLocale({ LC_ALL: `C\n\u001b[31m${"x".repeat(200)}` }, "linux");
+    const rendered = formatLocaleSource(diagnostic);
+    expect(rendered).toStartWith("LC_ALL=C??[31m");
+    expect(rendered).not.toContain("\n");
+    expect(rendered).not.toContain("\u001b");
+    expect(rendered.length).toBeLessThanOrEqual(7 + 128);
   });
 });

--- a/agent-network/src/locale-diagnostic.ts
+++ b/agent-network/src/locale-diagnostic.ts
@@ -29,3 +29,13 @@ export function diagnoseLocale(
 
   return { effectiveVariable: null, effectiveValue: null, shouldWarn: true };
 }
+
+export function formatLocaleSource(diagnostic: LocaleDiagnostic): string {
+  if (!diagnostic.effectiveVariable || diagnostic.effectiveValue === null) {
+    return "LANG/LC_ALL/LC_CTYPE=<unset>";
+  }
+  const safeValue = diagnostic.effectiveValue
+    .replace(/[^\x20-\x7e]/g, "?")
+    .slice(0, 128);
+  return `${diagnostic.effectiveVariable}=${safeValue}`;
+}

--- a/agent-network/src/locale-diagnostic.ts
+++ b/agent-network/src/locale-diagnostic.ts
@@ -1,0 +1,31 @@
+export interface LocaleDiagnostic {
+  effectiveVariable: "LC_ALL" | "LC_CTYPE" | "LANG" | null;
+  effectiveValue: string | null;
+  shouldWarn: boolean;
+}
+
+/**
+ * Resolve the locale with the same precedence used by POSIX libc. Windows
+ * does not use these variables as its process Unicode boundary, so prescribing
+ * a POSIX locale there would be misleading.
+ */
+export function diagnoseLocale(
+  env: Readonly<Record<string, string | undefined>>,
+  platform: string,
+): LocaleDiagnostic {
+  if (platform === "win32") {
+    return { effectiveVariable: null, effectiveValue: null, shouldWarn: false };
+  }
+
+  for (const effectiveVariable of ["LC_ALL", "LC_CTYPE", "LANG"] as const) {
+    const value = env[effectiveVariable]?.trim();
+    if (!value) continue;
+    return {
+      effectiveVariable,
+      effectiveValue: value,
+      shouldWarn: !/utf-?8/i.test(value),
+    };
+  }
+
+  return { effectiveVariable: null, effectiveValue: null, shouldWarn: true };
+}

--- a/docs/tests/report-test633-doctor-locale.txt
+++ b/docs/tests/report-test633-doctor-locale.txt
@@ -1,0 +1,49 @@
+# test633 — doctor locale diagnostic
+
+Date: 2026-08-09
+Issue: #68
+Base: a10c835cbfa622c99b97540f9bc2081a632a60af
+Source commit: b118e7ec877be9a24c03c22405ad77a6f90b0860
+Docker tag: anet-test633:dev
+Docker image: sha256:50ee357cb68cd9e808dadf80f8f248b4cae17c433329923d49eba565bbf57a26
+Embedded source: TEST633_SOURCE_COMMIT=b118e7ec877be9a24c03c22405ad77a6f90b0860
+Runner artifact SHA256: e5e6c111d3491bcc23b5fb4fc8eafa62c9a143339bb6ddabb401697335838552
+
+## Result
+
+- Pure locale semantics and production wiring: 7 pass / 0 fail / 19
+  assertions.
+- The real bundled CLI ran `doctor` under `LANG=C LC_ALL=C`; it emitted the
+  warn-only `System locale` diagnostic and the `C.UTF-8` remediation.
+- The same real bundle under `LANG=C.UTF-8 LC_ALL=C.UTF-8` emitted no locale
+  warning.
+- POSIX precedence is explicit: `LC_ALL`, then `LC_CTYPE`, then `LANG`.
+  Common `UTF-8` and `utf8` spellings pass. C, POSIX, other encodings, and an
+  unset POSIX locale warn.
+- Windows does not receive the POSIX export advice because those variables do
+  not define its process Unicode boundary.
+- Locale values are bounded and control characters are replaced before being
+  printed, so a hostile environment value cannot inject terminal control or
+  an unbounded diagnostic line.
+
+## Witnessed red
+
+The pre-implementation tests failed with rc=1 because the helper and doctor
+wiring did not exist. On the exact source commit:
+
+1. Weakening UTF-8 detection so every non-empty locale passes makes the
+   semantic tests fail (`MUTATION_RED: locale-detection rc=1`).
+2. Replacing the production doctor call with a constant non-warning result
+   makes the wiring test fail (`MUTATION_RED: doctor-wiring rc=1`).
+
+## Scope
+
+This is a warn-only diagnostic. It does not mutate locale variables, files,
+processes, credentials, or services, and it does not change the doctor exit
+status. The check observes configured environment strings; it does not prove
+that a named locale is installed in the host locale database. Docker evidence
+proves the Linux behavior and the Windows behavior is a pure platform branch,
+not a Windows-host execution claim.
+
+No production service, global package, credential, database, or existing user
+file was touched.

--- a/tests/test633-doctor-locale/Dockerfile
+++ b/tests/test633-doctor-locale/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY tests/lib ./tests/lib
+COPY tests/test633-doctor-locale ./tests/test633-doctor-locale
+
+ARG SOURCE_COMMIT
+ENV TEST633_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test633-doctor-locale/run.sh
+ENTRYPOINT ["/workspace/tests/test633-doctor-locale/run.sh"]

--- a/tests/test633-doctor-locale/run.sh
+++ b/tests/test633-doctor-locale/run.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /workspace/tests/lib/safe-rm.sh
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test633-doctor-locale.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test633 — doctor locale diagnostic"
+echo "source_commit=${TEST633_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+cd /workspace
+
+run_tests() {
+  bun test \
+    agent-network/src/locale-diagnostic.test.ts \
+    agent-network/src/locale-diagnostic-wiring.test.ts
+}
+
+echo "L0 helper semantics + production wiring"
+run_tests
+
+echo "L1 real CLI bundle"
+bun build agent-network/bin/cli.ts \
+  --outdir /tmp/test633-dist \
+  --entry-naming cli.js \
+  --target node \
+  --external @sleep2agi/commhub-server \
+  --external bun:sqlite \
+  --external '../../server/*'
+test -s /tmp/test633-dist/cli.js
+
+echo "L2 real doctor output under non-UTF-8 and UTF-8 locales"
+WORK=$(mktemp -d /tmp/test633-home.XXXXXX)
+trap 'safe_rm_rf "$WORK"' EXIT
+mkdir -p "$WORK/cwd"
+
+env -i PATH="$PATH" HOME="$WORK" LANG=C LC_ALL=C \
+  node /tmp/test633-dist/cli.js doctor > /tmp/test633-c.log 2>&1
+grep -Fq '⚠  System locale: LC_ALL=C is not UTF-8' /tmp/test633-c.log
+grep -Fq 'export LANG=C.UTF-8 LC_ALL=C.UTF-8' /tmp/test633-c.log
+
+env -i PATH="$PATH" HOME="$WORK" LANG=C.UTF-8 LC_ALL=C.UTF-8 \
+  node /tmp/test633-dist/cli.js doctor > /tmp/test633-utf8.log 2>&1
+if grep -Fq 'System locale' /tmp/test633-utf8.log; then
+  echo "FAIL: UTF-8 locale produced a warning"
+  exit 1
+fi
+
+echo "L3 witnessed-red: weaken UTF-8 detection to accept every locale"
+cp agent-network/src/locale-diagnostic.ts /tmp/test633-locale.ts
+sed -i 's/shouldWarn: !\/utf-?8\/i.test(value)/shouldWarn: !\/.\/i.test(value)/' agent-network/src/locale-diagnostic.ts
+grep -Fq 'shouldWarn: !/./i.test(value)' agent-network/src/locale-diagnostic.ts
+set +e
+run_tests > /tmp/test633-detection-mutation.log 2>&1
+detection_rc=$?
+set -e
+if [ "$detection_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: locale-detection"
+  exit 1
+fi
+echo "MUTATION_RED: locale-detection rc=$detection_rc"
+cp /tmp/test633-locale.ts agent-network/src/locale-diagnostic.ts
+
+echo "L4 witnessed-red: bypass the diagnostic in doctor"
+cp agent-network/bin/cli.ts /tmp/test633-cli.ts
+sed -i 's/const locale = diagnoseLocale(process.env, process.platform);/const locale = { shouldWarn: false, effectiveVariable: null, effectiveValue: null };/' agent-network/bin/cli.ts
+grep -Fq 'const locale = { shouldWarn: false' agent-network/bin/cli.ts
+set +e
+run_tests > /tmp/test633-wiring-mutation.log 2>&1
+wiring_rc=$?
+set -e
+if [ "$wiring_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: doctor-wiring"
+  exit 1
+fi
+echo "MUTATION_RED: doctor-wiring rc=$wiring_rc"
+cp /tmp/test633-cli.ts agent-network/bin/cli.ts
+
+echo "L5 restored green"
+run_tests
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #68.

Adds a warn-only `anet doctor` diagnostic for non-UTF-8 POSIX locale settings. Resolution follows libc precedence (`LC_ALL` > `LC_CTYPE` > `LANG`), accepts common UTF-8 spellings, avoids misleading POSIX advice on Windows, and sanitizes/bounds environment-derived output.

Evidence:
- base: `a10c835cbfa622c99b97540f9bc2081a632a60af`
- source: `b118e7ec877be9a24c03c22405ad77a6f90b0860`
- report-only head: `8b04e50a77b8b81b35a459387b3677b55971401d`
- exact image: `sha256:50ee357cb68cd9e808dadf80f8f248b4cae17c433329923d49eba565bbf57a26` (removed after evidence)
- runner artifact: `e5e6c111d3491bcc23b5fb4fc8eafa62c9a143339bb6ddabb401697335838552`
- 7/0, 19 assertions; real CLI bundle exercised under C and C.UTF-8
- mutation red: weakened detection rc=1; bypassed doctor wiring rc=1

Honest boundary: this observes configured locale strings; it does not prove that the named locale is installed. Linux Docker behavior is proven; Windows is a pure platform branch, not a Windows-host execution claim.

No merge, publish, deployment, production, credential, database, or global-package action is authorized by this draft.