### PR TITLE
fix(cli): print PowerShell secret persistence guidance on Windows

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -89,6 +89,11 @@ import {
 } from "../src/grok-copresence-disclosure";
 import { parseCliOptions, positionalArgs } from "../src/cli-args";
 import {
+  formatSecretAssignment,
+  secretPersistenceHeading,
+  secretShellAction,
+} from "../src/secret-shell-guidance";
+import {
   collectClaudeVendorEnvForCreate,
   planPlainSecretEnvRewrites,
 } from "../src/claude-vendor-env";
@@ -2895,11 +2900,10 @@ function rewritePlainSecretsToEnvRef(nodeId: string, profile: Profile): void {
 
   console.log(`\n[anet] 🔐 ${rewrites.length} secret value(s) in env moved out of config.json (envRef shape, #125).`);
   console.log(`[anet]    Persisted to .anet/nodes/${nodeId}/.env (mode 600, gitignored) — \`anet node start\` auto-loads it.`);
-  console.log(`[anet]    For cross-machine / cross-shell portability, also append to ~/.bashrc / ~/.zshrc:`);
+  console.log(`[anet]    ${secretPersistenceHeading(process.platform)}`);
   console.log("");
   for (const { refName, value } of rewrites) {
-    const safe = value.replace(/'/g, `'\\''`);
-    console.log(`    export ${refName}='${safe}'`);
+    console.log(`    ${formatSecretAssignment(process.platform, refName, value)}`);
   }
   console.log("");
 }
@@ -12215,14 +12219,11 @@ async function migrateTokenToEnvRefCommand() {
   // breaks `export NAME=...` interpolation. Pick the ASCII path.
   const nodeIdShort = (profile.node_id || nodeId).replace(/[^A-Za-z0-9_]/g, "_").slice(0, 16);
   const newEnv: any = { ...envMap };
-  const exportLines: string[] = [];
+  const assignmentLines: string[] = [];
   for (const { key, value } of candidates) {
     const refName = `${key}_${nodeIdShort}`.toUpperCase();
     newEnv[key] = { _envRef: refName };
-    // Quote the value: it may contain shell-special chars; single-quote and
-    // escape any literal single quote inside.
-    const safeVal = value.replace(/'/g, `'\\''`);
-    exportLines.push(`export ${refName}='${safeVal}'`);
+    assignmentLines.push(formatSecretAssignment(process.platform, refName, value));
   }
 
   // Backup the original config before overwriting, so users can revert.
@@ -12247,11 +12248,11 @@ async function migrateTokenToEnvRefCommand() {
   console.log(`\n[anet] ✅ Migrated ${candidates.length} env value(s) in node "${nodeId}":`);
   for (const { key } of candidates) console.log(`         env.${key} → { _envRef: "${key}_${nodeIdShort}".toUpperCase() }`);
   console.log(`[anet]    Backup written: ${bakPath}\n`);
-  console.log(`[anet] 🔑 Now export the secret values in your shell BEFORE starting this node:`);
+  console.log(`[anet] 🔑 Now ${secretShellAction(process.platform)} the secret values in your shell BEFORE starting this node:`);
   console.log("");
-  for (const line of exportLines) console.log(`    ${line}`);
+  for (const line of assignmentLines) console.log(`    ${line}`);
   console.log("");
-  console.log(`[anet]    (Append these to ~/.bashrc / ~/.zshrc / your secrets manager for persistence.)`);
+  console.log(`[anet]    (${secretPersistenceHeading(process.platform)})`);
   console.log(`[anet]    The agent-node runtime will refuse to start if any referenced var is unset.`);
   console.log(`[anet]    Restart the node: anet node start ${nodeId}\n`);
 }

--- a/agent-network/src/secret-shell-guidance-wiring.test.ts
+++ b/agent-network/src/secret-shell-guidance-wiring.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+test("#379 create and migrate both use platform-aware secret guidance", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const cli = readFileSync(join(here, "..", "bin", "cli.ts"), "utf8");
+  expect(cli).toContain('from "../src/secret-shell-guidance"');
+  expect(cli.match(/secretPersistenceHeading\(process\.platform\)/g)?.length).toBe(2);
+  expect(cli.match(/formatSecretAssignment\(process\.platform/g)?.length).toBe(2);
+  expect(cli).not.toContain("also append to ~/.bashrc / ~/.zshrc");
+  expect(cli).not.toContain("Append these to ~/.bashrc / ~/.zshrc");
+});

--- a/agent-network/src/secret-shell-guidance.test.ts
+++ b/agent-network/src/secret-shell-guidance.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatSecretAssignment,
+  secretPersistenceHeading,
+  secretShellAction,
+} from "./secret-shell-guidance";
+
+describe("#379 secret shell guidance", () => {
+  test("keeps the existing POSIX export form", () => {
+    expect(formatSecretAssignment("linux", "API_TOKEN_NODE", "a'b")).toBe(
+      `export API_TOKEN_NODE='a'\\''b'`,
+    );
+    expect(secretPersistenceHeading("linux")).toContain("~/.bashrc / ~/.zshrc");
+    expect(secretShellAction("linux")).toBe("export");
+  });
+
+  test("uses PowerShell syntax and quote escaping on Windows", () => {
+    expect(formatSecretAssignment("win32", "API_TOKEN_NODE", "a'b")).toBe(
+      `$env:API_TOKEN_NODE='a''b'`,
+    );
+    expect(secretPersistenceHeading("win32")).toContain("PowerShell $PROFILE");
+    expect(secretPersistenceHeading("win32")).not.toContain(".bashrc");
+    expect(secretShellAction("win32")).toBe("set");
+  });
+});

--- a/agent-network/src/secret-shell-guidance.ts
+++ b/agent-network/src/secret-shell-guidance.ts
@@ -1,0 +1,16 @@
+export function formatSecretAssignment(platform: string, name: string, value: string): string {
+  if (platform === "win32") {
+    return `$env:${name}='${value.replace(/'/g, "''")}'`;
+  }
+  return `export ${name}='${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function secretPersistenceHeading(platform: string): string {
+  return platform === "win32"
+    ? "For cross-machine / cross-shell portability, add these assignments to your PowerShell $PROFILE or secrets manager:"
+    : "For cross-machine / cross-shell portability, also append to ~/.bashrc / ~/.zshrc or your secrets manager:";
+}
+
+export function secretShellAction(platform: string): "set" | "export" {
+  return platform === "win32" ? "set" : "export";
+}

--- a/docs/tests/report-test634-windows-secret-guidance.txt
+++ b/docs/tests/report-test634-windows-secret-guidance.txt
@@ -1,0 +1,50 @@
+# test634 — Windows secret shell guidance
+
+Date: 2026-08-09
+Issue: #379 (portable guidance half only)
+Base: a10c835cbfa622c99b97540f9bc2081a632a60af
+Source commit: 6b9da314b19510a11009391452d368f13897e4f8
+Docker tag: anet-test634:dev
+Docker image: sha256:206d8d1a28affa4c1632171c53a548d755796703570a9ad77db3fd3eb31376f1
+Embedded source: TEST634_SOURCE_COMMIT=6b9da314b19510a11009391452d368f13897e4f8
+Runner artifact SHA256: bddf02a4f0cd8ba58bfd6a92013b4c3121e29edbe0852f59ccd8644abf156520
+
+## Result
+
+- Platform semantics and both production call sites: 3 pass / 0 fail / 12
+  assertions.
+- POSIX output retains the existing `export NAME='value'` form and
+  bash/zsh/secrets-manager persistence guidance.
+- Windows output uses PowerShell `$env:NAME='value'`, escapes a literal single
+  quote by doubling it, and points to PowerShell `$PROFILE` or a secrets
+  manager. It no longer tells Windows users to edit `.bashrc` or `.zshrc`.
+- Both the create-time envRef rewrite and the explicit
+  `migrate-token-to-envref` flow call the shared formatter.
+- The real production CLI bundles successfully with 197 modules.
+
+## Witnessed red
+
+The pre-implementation tests failed with rc=1 because neither the helper nor
+the two production call sites existed. On the exact source commit:
+
+1. Disabling the Windows branch makes the PowerShell behavior test fail
+   (`MUTATION_RED: windows-platform-branch rc=1`).
+2. Replacing the migration call with a hard-coded POSIX export makes the
+   two-call-site wiring test fail (`MUTATION_RED: migrate-wiring rc=1`).
+
+## Explicit non-claim: Windows rename remains blocked
+
+This candidate does not claim to fix the process-discovery half of #379.
+`findNodeProcessesByAlias` first runs the Unix-only `ps -eww`; native Windows
+therefore fails closed before its slash-only basename branch is reachable.
+Additionally, a Windows executable commonly ends in `.exe`, which the current
+exact `claude` / `agent-node` comparison does not accept. Fixing only
+`split("/")` would be a false green.
+
+A real fix needs a Windows process-table provider (for example a narrowly
+scoped PowerShell `Get-CimInstance Win32_Process` adapter), injectable parsing,
+and execution on a real Windows host/runner. Linux Docker contract evidence is
+not presented as Windows rename evidence.
+
+No process matching, kill behavior, production service, global package,
+credential, database, or existing user file was changed.

--- a/tests/test634-windows-secret-guidance/Dockerfile
+++ b/tests/test634-windows-secret-guidance/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY tests/test634-windows-secret-guidance ./tests/test634-windows-secret-guidance
+
+ARG SOURCE_COMMIT
+ENV TEST634_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test634-windows-secret-guidance/run.sh
+ENTRYPOINT ["/workspace/tests/test634-windows-secret-guidance/run.sh"]

--- a/tests/test634-windows-secret-guidance/run.sh
+++ b/tests/test634-windows-secret-guidance/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test634-windows-secret-guidance.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test634 — Windows secret shell guidance"
+echo "source_commit=${TEST634_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+cd /workspace
+
+run_tests() {
+  bun test \
+    agent-network/src/secret-shell-guidance.test.ts \
+    agent-network/src/secret-shell-guidance-wiring.test.ts
+}
+
+echo "L0 platform semantics + both production call sites"
+run_tests
+
+echo "L1 real CLI bundle"
+bun build agent-network/bin/cli.ts \
+  --outdir /tmp/test634-dist \
+  --entry-naming cli.js \
+  --target node \
+  --external @sleep2agi/commhub-server \
+  --external bun:sqlite \
+  --external '../../server/*'
+test -s /tmp/test634-dist/cli.js
+
+echo "L2 witnessed-red: disable the Windows PowerShell branch"
+cp agent-network/src/secret-shell-guidance.ts /tmp/test634-guidance.ts
+sed -i 's/platform === "win32"/false/g' agent-network/src/secret-shell-guidance.ts
+grep -Fq 'if (false)' agent-network/src/secret-shell-guidance.ts
+set +e
+run_tests > /tmp/test634-platform-mutation.log 2>&1
+platform_rc=$?
+set -e
+if [ "$platform_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: windows-platform-branch"
+  exit 1
+fi
+echo "MUTATION_RED: windows-platform-branch rc=$platform_rc"
+cp /tmp/test634-guidance.ts agent-network/src/secret-shell-guidance.ts
+
+echo "L3 witnessed-red: bypass platform-aware guidance in migrate"
+cp agent-network/bin/cli.ts /tmp/test634-cli.ts
+sed -i 's/assignmentLines.push(formatSecretAssignment(process.platform, refName, value));/assignmentLines.push(`export ${refName}=${value}`);/' agent-network/bin/cli.ts
+grep -Fq 'assignmentLines.push(`export ${refName}=${value}`);' agent-network/bin/cli.ts
+set +e
+run_tests > /tmp/test634-wiring-mutation.log 2>&1
+wiring_rc=$?
+set -e
+if [ "$wiring_rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: migrate-wiring"
+  exit 1
+fi
+echo "MUTATION_RED: migrate-wiring rc=$wiring_rc"
+cp /tmp/test634-cli.ts agent-network/bin/cli.ts
+
+echo "L4 restored green"
+run_tests
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Refs #379. This deliberately fixes only the portable-guidance half and does not close the issue.

Both create-time envRef rewriting and `anet node migrate-token-to-envref` now use one platform-aware formatter:
- POSIX behavior remains `export` + bash/zsh guidance.
- Windows uses PowerShell `$env:` assignment syntax, correct single-quote escaping, and `$PROFILE` / secrets-manager persistence guidance.

Evidence:
- base: `a10c835cbfa622c99b97540f9bc2081a632a60af`
- source: `6b9da314b19510a11009391452d368f13897e4f8`
- report-only head: `4d68eb1fa01bc6e5e04020d23565b31331254cac`
- exact image: `sha256:206d8d1a28affa4c1632171c53a548d755796703570a9ad77db3fd3eb31376f1` (removed after evidence)
- runner artifact: `bddf02a4f0cd8ba58bfd6a92013b4c3121e29edbe0852f59ccd8644abf156520`
- 3/0, 12 assertions; real CLI bundle 197 modules; 2 mutations rc=1

Explicit non-claim: Windows rename is not fixed. Process discovery first invokes Unix-only `ps -eww`, so the slash-only basename branch is unreachable on native Windows; `.exe` names are also unmatched. That half needs a Windows provider plus real Windows-host evidence. Linux Docker is not presented as Windows rename proof.

No merge, publish, deployment, process matching, kill behavior, credential, database, or global-package action is authorized by this draft.