### PR TITLE
security(test): reject inherited DATABASE_URL before adapter construction

### DIFF
--- a/docs/tests/report-test637-database-url-guard.txt
+++ b/docs/tests/report-test637-database-url-guard.txt
@@ -1,0 +1,67 @@
+# test637 — inherited DATABASE_URL test guard
+
+Date: 2026-08-09
+Issue: #435
+Base: 8e74f6e1e0e73664dbcd3c04202de41d11db6a70
+Witnessed-red commit: 65ace517cc4921e2f17512d548e378470e0e8037
+Source commit: 30532ade619423b3d15be7ce2f70fe2b2af2a3e0
+Production implementation commit: 125bcc13c92fbcffe4d113a9cc91216c1e1ae09f
+Docker tag: anet-test637:dev
+Docker image: sha256:f123e587d3768ab5f11656614eef2b7ea8f782ccb11e4ec84ca141bad4b2de0c
+Embedded source: TEST637_SOURCE_COMMIT=30532ade619423b3d15be7ce2f70fe2b2af2a3e0
+Runner artifact SHA256: ec5c068a84e10c66b1aa271c326f81359e9257f4c0d0f7c3a9a1001ab6154196
+
+## Root cause and result
+
+`createAdapter()` previously selected and constructed `PgAdapter` before the
+existing `NODE_ENV=test` SQLite guard. An inherited production
+`DATABASE_URL` therefore bypassed that guard and could make a test process
+open a real PostgreSQL socket.
+
+The new `assertSafeTestDatabaseEnv(process.env)` is the first executable line
+of `createAdapter()`. Under `NODE_ENV=test`, any non-empty `DATABASE_URL` is
+rejected before target selection, banner output, DNS, adapter construction,
+or socket activity. There is no opt-in bypass.
+
+Target selection is also exposed as a pure function so tests prove that
+production/unset `NODE_ENV` still selects PostgreSQL and explicit
+`COMMHUB_DB` still selects SQLite without constructing either adapter.
+
+## Real socket evidence
+
+The Docker suite installs real `pg`, Node, and `strace`. It starts a real TCP
+listener on loopback, then invokes the real `createAdapter()` in a subprocess
+with a PostgreSQL URL aimed at that listener.
+
+- Base `65ace517` (test-only, production code unchanged): the PostgreSQL
+  banner appeared, `strace` recorded `connect()` to the listener, and the
+  listener accepted the socket. This is the witnessed red for the original
+  ordering bug.
+- Fixed `30532ade`: the subprocess returned the actionable DATABASE_URL
+  refusal, emitted no PostgreSQL banner, `strace` contained no connect to the
+  listener, and the listener accepted nothing.
+- Mutation: deleting only the earliest production guard from the fixed source
+  restored the PostgreSQL banner and a real accepted `connect()`; the gate
+  turned red.
+
+The mutation copy intentionally remains below `/work`, so its real
+`require("pg")` resolves the installed package. An earlier `/tmp` mutation
+failed on module resolution before dialing and was rejected as false evidence.
+
+## Unit matrix
+
+Exact-source Docker: 8 pass / 0 fail / 10 assertions.
+
+- `postgres://`, `postgresql://`, and a non-Postgres scheme all fail closed
+  when inherited under `NODE_ENV=test`.
+- DATABASE_URL refusal wins even when a safe `COMMHUB_DB` is also present.
+- With DATABASE_URL unset, the existing missing-COMMHUB_DB SQLite guard still
+  owns its original error path.
+- Production and unset NODE_ENV preserve PostgreSQL selection.
+- Test and production modes preserve explicit SQLite selection.
+
+## Scope
+
+This change does not modify production credentials, databases, adapters,
+services, global packages, or deployment state. It does not mix in #434 test
+aggregation work. The fixed Docker tag was removed after evidence capture.

--- a/server/src/db-adapter-guard.test.ts
+++ b/server/src/db-adapter-guard.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertSafeTestDatabaseEnv,
+  resolveDatabaseTarget,
+} from "./db-adapter";
+
+const BASE_ENV: NodeJS.ProcessEnv = { HOME: "/nonexistent" };
+
+describe("#435 inherited DATABASE_URL guard", () => {
+  for (const databaseUrl of [
+    "postgres://user:pw@prod.example:5432/commhub",
+    "postgresql://user:pw@prod.example:5432/commhub",
+    "sqlite:///tmp/not-an-escape",
+  ]) {
+    test(`NODE_ENV=test rejects ${databaseUrl.split(":", 1)[0]} DATABASE_URL`, () => {
+      expect(() => assertSafeTestDatabaseEnv({
+        ...BASE_ENV,
+        NODE_ENV: "test",
+        DATABASE_URL: databaseUrl,
+      })).toThrow(/REFUSING to honor inherited DATABASE_URL/);
+    });
+  }
+
+  test("test without DATABASE_URL leaves the existing SQLite guard in charge", () => {
+    expect(() => assertSafeTestDatabaseEnv({ ...BASE_ENV, NODE_ENV: "test" })).not.toThrow();
+    expect(() => resolveDatabaseTarget({ ...BASE_ENV, NODE_ENV: "test" }))
+      .toThrow(/REFUSING to open the default SQLite database/);
+  });
+
+  test("DATABASE_URL refusal wins even when COMMHUB_DB is also set", () => {
+    expect(() => resolveDatabaseTarget({
+      ...BASE_ENV,
+      NODE_ENV: "test",
+      DATABASE_URL: "postgres://user:pw@prod.example:5432/commhub",
+      COMMHUB_DB: "/tmp/isolated.db",
+    })).toThrow(/REFUSING to honor inherited DATABASE_URL/);
+  });
+
+  test("production postgres branch remains unchanged without constructing it", () => {
+    const url = "postgres://user:pw@prod.example:5432/commhub";
+    expect(resolveDatabaseTarget({
+      ...BASE_ENV,
+      NODE_ENV: "production",
+      DATABASE_URL: url,
+    })).toEqual({ kind: "postgres", url });
+  });
+
+  test("unset NODE_ENV still selects postgres", () => {
+    const url = "postgresql://user:pw@prod.example:5432/commhub";
+    expect(resolveDatabaseTarget({ ...BASE_ENV, DATABASE_URL: url }))
+      .toEqual({ kind: "postgres", url });
+  });
+
+  test("explicit SQLite targets remain unchanged in test and production", () => {
+    for (const NODE_ENV of ["test", "production"]) {
+      expect(resolveDatabaseTarget({
+        ...BASE_ENV,
+        NODE_ENV,
+        COMMHUB_DB: "/tmp/isolated.db",
+      })).toEqual({ kind: "sqlite", path: "/tmp/isolated.db" });
+    }
+  });
+});

--- a/server/src/db-adapter.ts
+++ b/server/src/db-adapter.ts
@@ -212,10 +212,28 @@ export class PgAdapter implements DbAdapter {
 //  Factory
 // ════════════════════════════════════════════
 
+export type DbTarget =
+  | { kind: "postgres"; url: string }
+  | { kind: "sqlite"; path: string };
+
 /**
- * Create the appropriate adapter based on environment.
- * - DATABASE_URL starts with "postgres://" → PgAdapter
- * - Otherwise → SQLiteAdapter with COMMHUB_DB or default path
+ * Refuse every inherited DATABASE_URL under the Bun test environment before
+ * adapter selection, logging, DNS, or construction. A test that intentionally
+ * exercises PostgreSQL needs a separately reviewed isolated harness; accepting
+ * a shell/CI DATABASE_URL here could connect a unit test to production.
+ */
+export function assertSafeTestDatabaseEnv(env: NodeJS.ProcessEnv = process.env): void {
+  if (env.NODE_ENV === "test" && env.DATABASE_URL) {
+    throw new Error(
+      "[commhub] REFUSING to honor inherited DATABASE_URL under NODE_ENV=test.\n" +
+      "  Tests must unset DATABASE_URL and set COMMHUB_DB to an isolated path.\n" +
+      "  This guard is fail-closed and has no opt-in bypass."
+    );
+  }
+}
+
+/**
+ * Pure target selection after the inherited-DATABASE_URL safety gate.
  *
  * Test-default-prod GUARD: when `NODE_ENV === "test"` (set automatically by
  * `bun test`) AND `COMMHUB_DB` is unset, we REFUSE to fall through to the
@@ -236,18 +254,14 @@ export class PgAdapter implements DbAdapter {
  * guard can't catch that case. The rule (never read or write the
  * production hub database) is documented in CLAUDE.md.
  */
-export function createAdapter(): DbAdapter {
-  const dbUrl = process.env.DATABASE_URL;
+function resolveDatabaseTargetAfterGuard(env: NodeJS.ProcessEnv): DbTarget {
+  const dbUrl = env.DATABASE_URL;
   if (dbUrl && (dbUrl.startsWith("postgres://") || dbUrl.startsWith("postgresql://"))) {
-    console.log("[commhub] database: PostgreSQL");
-    return new PgAdapter(dbUrl);
+    return { kind: "postgres", url: dbUrl };
   }
-  // Default: SQLite
-  const { mkdirSync } = require("fs");
-  const { dirname } = require("path");
 
   // Test-default-prod GUARD (see docblock above).
-  if (process.env.NODE_ENV === "test" && !process.env.COMMHUB_DB) {
+  if (env.NODE_ENV === "test" && !env.COMMHUB_DB) {
     throw new Error(
       "[commhub] REFUSING to open the default SQLite database under NODE_ENV=test.\n" +
       "  Tests must explicitly set COMMHUB_DB to a throwaway path so they don't\n" +
@@ -257,10 +271,32 @@ export function createAdapter(): DbAdapter {
     );
   }
 
-  const dbPath = process.env.COMMHUB_DB || `${process.env.HOME}/.commhub/commhub.db`;
-  mkdirSync(dirname(dbPath), { recursive: true });
-  console.log(`[commhub] database: ${dbPath}`);
-  const rawDb = new Database(dbPath);
+  return { kind: "sqlite", path: env.COMMHUB_DB || `${env.HOME}/.commhub/commhub.db` };
+}
+
+/** Pure public resolver used by tests without constructing an adapter. */
+export function resolveDatabaseTarget(env: NodeJS.ProcessEnv = process.env): DbTarget {
+  assertSafeTestDatabaseEnv(env);
+  return resolveDatabaseTargetAfterGuard(env);
+}
+
+/**
+ * Create the appropriate adapter based on environment.
+ * The inherited-DATABASE_URL guard is deliberately the first executable line.
+ */
+export function createAdapter(): DbAdapter {
+  assertSafeTestDatabaseEnv(process.env);
+  const target = resolveDatabaseTargetAfterGuard(process.env);
+  if (target.kind === "postgres") {
+    console.log("[commhub] database: PostgreSQL");
+    return new PgAdapter(target.url);
+  }
+
+  const { mkdirSync } = require("fs");
+  const { dirname } = require("path");
+  mkdirSync(dirname(target.path), { recursive: true });
+  console.log(`[commhub] database: ${target.path}`);
+  const rawDb = new Database(target.path);
   rawDb.exec("PRAGMA journal_mode=WAL");
   rawDb.exec("PRAGMA busy_timeout=5000");
   return new SQLiteAdapter(rawDb);

--- a/tests/test637-database-url-guard/Dockerfile
+++ b/tests/test637-database-url-guard/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.14
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends nodejs strace \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work
+COPY tests/test637-database-url-guard/package.json ./package.json
+RUN bun install --production
+COPY server/src ./server/src
+COPY tests/test637-database-url-guard ./tests/test637-database-url-guard
+
+ARG TEST637_SOURCE_COMMIT=unknown
+ENV TEST637_SOURCE_COMMIT=$TEST637_SOURCE_COMMIT
+RUN chmod 0755 tests/test637-database-url-guard/run.sh
+ENTRYPOINT ["tests/test637-database-url-guard/run.sh"]

--- a/tests/test637-database-url-guard/package.json
+++ b/tests/test637-database-url-guard/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "pg": "8.16.3"
+  }
+}

--- a/tests/test637-database-url-guard/probe.ts
+++ b/tests/test637-database-url-guard/probe.ts
@@ -1,0 +1,12 @@
+import { pathToFileURL } from "node:url";
+
+const modulePath = process.env.DB_ADAPTER_MODULE || "/work/server/src/db-adapter.ts";
+try {
+  const mod = await import(pathToFileURL(modulePath).href);
+  mod.createAdapter();
+  console.log("UNEXPECTED_NO_THROW");
+  process.exit(0);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(2);
+}

--- a/tests/test637-database-url-guard/run.sh
+++ b/tests/test637-database-url-guard/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /work
+echo "source_commit=$TEST637_SOURCE_COMMIT"
+port=25435
+probe_dir="$(mktemp -d /tmp/test637-probe.XXXXXX)"
+ready="$probe_dir/ready"
+accepted="$probe_dir/accepted"
+
+bun tests/test637-database-url-guard/tcp-listener.ts "$port" "$ready" "$accepted" &
+listener_pid=$!
+for _ in $(seq 1 100); do
+  test -e "$ready" && break
+  kill -0 "$listener_pid" 2>/dev/null || { echo "listener exited" >&2; exit 1; }
+  sleep 0.02
+done
+test -e "$ready"
+
+run_probe() {
+  local module_path="$1" prefix="$2"
+  set +e
+  env -u COMMHUB_DB \
+    NODE_ENV=test \
+    DATABASE_URL="postgres://user:pw@127.0.0.1:${port}/commhub?connect_timeout=1" \
+    DB_ADAPTER_MODULE="$module_path" \
+    timeout 10 strace -f -e trace=connect -o "$prefix.strace" \
+      bun tests/test637-database-url-guard/probe.ts \
+      >"$prefix.stdout" 2>"$prefix.stderr"
+  probe_rc=$?
+  set -e
+  test "$probe_rc" -ne 0
+}
+
+if [ "${TEST637_EXPECT_RED:-0}" = 1 ]; then
+  run_probe /work/server/src/db-adapter.ts "$probe_dir/base"
+  grep -q 'database: PostgreSQL' "$probe_dir/base.stdout"
+  grep -Eq "sin_port=htons\(${port}\)" "$probe_dir/base.strace"
+  test -s "$accepted"
+  ! grep -q 'REFUSING to honor inherited DATABASE_URL' "$probe_dir/base.stderr"
+  echo "WITNESSED_RED: current main attempted a real TCP connect before its test guard"
+  kill "$listener_pid" 2>/dev/null || true
+  wait "$listener_pid" 2>/dev/null || true
+  echo "RESULT: EXPECTED RED"
+  exit 0
+fi
+
+echo "L0 pure guard and target-selection tests"
+bun test server/src/db-adapter-guard.test.ts
+
+echo "L1 real subprocess syscall gate"
+run_probe /work/server/src/db-adapter.ts "$probe_dir/green"
+grep -q 'REFUSING to honor inherited DATABASE_URL' "$probe_dir/green.stderr"
+! grep -q 'database: PostgreSQL' "$probe_dir/green.stdout"
+! grep -Eq "sin_port=htons\(${port}\)" "$probe_dir/green.strace"
+test ! -e "$accepted"
+
+echo "L2 delete-guard mutation"
+mutation_dir="$(mktemp -d /tmp/test637-mutation.XXXXXX)"
+cp server/src/db-adapter.ts "$mutation_dir/db-adapter.ts"
+sed -i '/assertSafeTestDatabaseEnv(process.env);/d' "$mutation_dir/db-adapter.ts"
+run_probe "$mutation_dir/db-adapter.ts" "$probe_dir/mutation"
+grep -q 'database: PostgreSQL' "$probe_dir/mutation.stdout"
+grep -Eq "sin_port=htons\(${port}\)" "$probe_dir/mutation.strace"
+test -s "$accepted"
+! grep -q 'REFUSING to honor inherited DATABASE_URL' "$probe_dir/mutation.stderr"
+echo "MUTATION_RED: deleting the earliest guard produced a real connect"
+
+kill "$listener_pid" 2>/dev/null || true
+wait "$listener_pid" 2>/dev/null || true
+echo "RESULT: PASS"

--- a/tests/test637-database-url-guard/run.sh
+++ b/tests/test637-database-url-guard/run.sh
@@ -56,7 +56,10 @@ grep -q 'REFUSING to honor inherited DATABASE_URL' "$probe_dir/green.stderr"
 test ! -e "$accepted"
 
 echo "L2 delete-guard mutation"
-mutation_dir="$(mktemp -d /tmp/test637-mutation.XXXXXX)"
+# Keep the copied module below /work so its real `require("pg")` resolves the
+# same installed package as production. A /tmp copy would fail before dial on
+# module resolution and create a false-red mutation.
+mutation_dir="$(mktemp -d /work/test637-mutation.XXXXXX)"
 cp server/src/db-adapter.ts "$mutation_dir/db-adapter.ts"
 sed -i '/assertSafeTestDatabaseEnv(process.env);/d' "$mutation_dir/db-adapter.ts"
 run_probe "$mutation_dir/db-adapter.ts" "$probe_dir/mutation"

--- a/tests/test637-database-url-guard/tcp-listener.ts
+++ b/tests/test637-database-url-guard/tcp-listener.ts
@@ -1,0 +1,13 @@
+import { appendFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+
+const port = Number(process.argv[2]);
+const readyPath = process.argv[3];
+const acceptedPath = process.argv[4];
+if (!Number.isInteger(port) || !readyPath || !acceptedPath) process.exit(2);
+
+const server = createServer((socket) => {
+  appendFileSync(acceptedPath, "accepted\n");
+  socket.destroy();
+});
+server.listen(port, "127.0.0.1", () => writeFileSync(readyPath, "ready\n"));


### PR DESCRIPTION
## What changed

- reject any inherited `DATABASE_URL` at the first executable line of `createAdapter()` when `NODE_ENV=test`
- keep production PostgreSQL and explicit SQLite selection unchanged through a pure target resolver
- add a real `pg` + TCP listener + `strace connect()` Docker gate
- record exact-source witnessed-red, green, and delete-guard mutation evidence

## Root cause

The existing test safety check only protected the default SQLite branch. `createAdapter()` selected and constructed `PgAdapter` first, so an inherited production `DATABASE_URL` could open a PostgreSQL socket before any test guard ran.

## Validation

- witnessed-red base `65ace517`: real listener accepted a connection from current-main `createAdapter()`
- exact-source fixed Docker `30532ade`: 8 pass / 0 fail / 10 assertions, no PostgreSQL banner, no matching `connect()`, listener accepted nothing
- mutation deleting only the earliest guard restores the real PostgreSQL banner and accepted `connect()`
- production/unset `NODE_ENV` still resolves PostgreSQL; explicit `COMMHUB_DB` still resolves SQLite

Evidence: `docs/tests/report-test637-database-url-guard.txt`

This does not include #434 aggregate-runner work.

Closes #435
