### PR TITLE
test: harden aggregate slug and greenwash gates (#639)

### DIFF
--- a/docs/tests/report-test639-aggregate-runner-hardening.txt
+++ b/docs/tests/report-test639-aggregate-runner-hardening.txt
@@ -1,0 +1,67 @@
+Test 639 — aggregate runner hardening (#639)
+Date: 2026-08-09 Asia/Shanghai
+
+Base commit
+  8894dde5 (merged #638)
+
+Exact tested source commit
+  98992e331259b8617361ebb373731c2c1a5f7976
+
+Docker evidence
+  tag: anet-test639:dev
+  image id: sha256:bee1a623eca9f7240e6eb3edfb79c01b081574cbfa1078cc6221d5f1cfe9189f
+  image ENV: TEST639_SOURCE_COMMIT=98992e331259b8617361ebb373731c2c1a5f7976
+  image content size: 95271612 bytes
+  container exit: 0
+  runner log sha256: 297ace43c44ab7283fe38dd1f2c1f65309fe5fc585d794d647901c1304d3a888
+
+Scope
+  Production Hub/API/DB/agent code diff: zero.
+  Changed only:
+    server/scripts/test-aggregate.ts
+    tests/test638-server-aggregate-isolation/{Dockerfile,run.sh}
+    this report
+
+Baseline regression
+  Three aggregate executions (normal under strace, concurrent normal, concurrent
+  reverse) produced the identical key:
+    57 files / 845 pass / 0 fail / 0 skip / 2579 expects / bad=false
+  Shared inherited DB opened: zero.
+  Per-file DB maps: 57/57 unique.
+  Cross-suite fixture shapes: uploads=1:0, host-supervisor=0:1.
+
+Slug collision gate
+  The runner validates the complete enumerated test tree before applying any
+  --file filter. The injected pair:
+    server/src/test639-collision.test.ts
+    server/src/test639/collision.test.ts
+  maps to one slug. A filtered invocation for only the first file still exited
+  2 and named the slug plus both owners.
+  Removing only assertUniqueSlugs(files) made the same filtered invocation pass
+  (rc=0, 1 test), proving the guard is load-bearing.
+  collision log sha256: d5ad2870be291f805922b7c1884f133f84acace2fbbd5dabe12e9debdc0d5d52
+  mutation log sha256: c9f7dccca9442e79770c5411081f407c4a5a18b0d3d03bece5c037f8c3a2f30e
+
+No-greenwash additions
+  Missing summary:
+    child exited 0 after process.exit(0), emitted 0/0/0 counts; aggregate exited
+    1 with bad=true.
+    log sha256: e0039e7af0bec542e9a217d6b3b984bc50945c838bfae458a1bc5f2634b09156
+  Spawn failure:
+    runner started by absolute Bun with PATH containing no bun; child spawn
+    returned exit=null and 0/0/0 counts; aggregate exited 1 with bad=true.
+    log sha256: 78135df786fde64f476d176935f1c343ba42caa15e82852903607c03561733f1
+  Existing gates remained green:
+    nonzero rc=1, timeout rc=1, signal rc=143, per-file split mutation collapsed
+    to one DB path.
+
+Optional historical red follow-up
+  #639(c) is explicitly optional. A first attempt to recreate the old flat
+  shared-process failure on current main passed, because the final tree contains
+  the post-red test setup changes. It was removed as a gate rather than reported
+  as false witnessed-red. The original pre-rebase red remains honestly recorded
+  in report-test638-server-aggregate-isolation.txt.
+
+Verdict
+  PASS. Runtime slug uniqueness is enforced and all five greenwash modes now
+  have behavior-level evidence without changing production code.

--- a/server/scripts/test-aggregate.ts
+++ b/server/scripts/test-aggregate.ts
@@ -64,6 +64,18 @@ function slugFor(file: string): string {
   return file.replace(/[^A-Za-z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
+function assertUniqueSlugs(files: string[]) {
+  const ownerBySlug = new Map<string, string>();
+  for (const file of files) {
+    const slug = slugFor(file);
+    const previous = ownerBySlug.get(slug);
+    if (previous !== undefined && previous !== file) {
+      throw new Error(`test slug collision ${JSON.stringify(slug)}: ${previous} and ${file}`);
+    }
+    ownerBySlug.set(slug, file);
+  }
+}
+
 function parseCounts(output: string): Counts {
   const last = (pattern: RegExp) => {
     const matches = [...output.matchAll(pattern)];
@@ -170,6 +182,9 @@ async function runFile(file: string, runRoot: string, timeoutMs: number, verbose
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   let files = collectTests(SERVER_SRC);
+  // Validate the complete enumerated tree before applying --file filters. A
+  // filtered run must not hide a future path pair that would share one DB.
+  assertUniqueSlugs(files);
   if (args.selectedFiles.length > 0) {
     for (const file of args.selectedFiles) {
       if (!files.includes(file)) throw new Error(`--file is not an enumerated server test: ${file}`);

--- a/tests/test638-server-aggregate-isolation/Dockerfile
+++ b/tests/test638-server-aggregate-isolation/Dockerfile
@@ -14,7 +14,7 @@ RUN cd server && bun install
 COPY tests/test638-server-aggregate-isolation/run.sh /work/run.sh
 RUN chmod +x /work/run.sh
 
-ARG TEST638_SOURCE_COMMIT
-ENV TEST638_SOURCE_COMMIT=${TEST638_SOURCE_COMMIT}
+ARG TEST639_SOURCE_COMMIT
+ENV TEST639_SOURCE_COMMIT=${TEST639_SOURCE_COMMIT}
 
 CMD ["/work/run.sh"]

--- a/tests/test638-server-aggregate-isolation/run.sh
+++ b/tests/test638-server-aggregate-isolation/run.sh
@@ -140,10 +140,10 @@ rm -f -- server/src/test639-missing-summary.test.ts
 mkdir -p /tmp/test639-no-bun
 set +e
 PATH=/tmp/test639-no-bun /usr/local/bin/bun server/scripts/test-aggregate.ts \
-  --file=server/src/db-adapter.test.ts >/tmp/test639-spawn-fail.out 2>&1; spawn_fail_rc=$?
+  --file=server/src/db-adapter-guard.test.ts >/tmp/test639-spawn-fail.out 2>&1; spawn_fail_rc=$?
 set -e
 [[ $spawn_fail_rc -ne 0 ]] || { echo "FAIL: child spawn failure greenwashed"; exit 1; }
-grep -F $'TEST_FILE_RESULT\tserver/src/db-adapter.test.ts\tpass=0\tfail=0\tskip=0\texpects=0\texit=null' /tmp/test639-spawn-fail.out >/dev/null
+grep -F $'TEST_FILE_RESULT\tserver/src/db-adapter-guard.test.ts\tpass=0\tfail=0\tskip=0\texpects=0\texit=null' /tmp/test639-spawn-fail.out >/dev/null
 grep -F 'SERVER_AGGREGATE_RESULT' /tmp/test639-spawn-fail.out | grep -F '"bad":true' >/dev/null
 
 echo "L5b: slug collisions fail before --file filtering"

--- a/tests/test638-server-aggregate-isolation/run.sh
+++ b/tests/test638-server-aggregate-isolation/run.sh
@@ -20,10 +20,14 @@ PROBES=(
   server/src/test638-nonzero.test.ts
   server/src/test638-timeout.test.ts
   server/src/test638-signal.test.ts
+  server/src/test639-missing-summary.test.ts
+  server/src/test639-collision.test.ts
+  server/src/test639/collision.test.ts
   server/scripts/test-aggregate-mutation.ts
 )
 cleanup() {
   rm -f -- "${PROBES[@]}"
+  rmdir server/src/test639 2>/dev/null || true
 }
 trap cleanup EXIT
 rm -rf -- /tmp/test638-run1 /tmp/test638-run2 /tmp/test638-run3
@@ -37,6 +41,19 @@ run_one() {
     ANET_SERVER_TEST_ROOT="$root" ANET_SERVER_TEST_KEEP_ROOT=1 \
     bun run --cwd server test "${args[@]}" >"$output" 2>&1
 }
+
+echo "L0: current-tree flat shared-process predecessor is witnessed-red"
+FLAT_SHARED=/tmp/test639-flat-shared.db
+rm -f -- "$FLAT_SHARED" "$FLAT_SHARED-wal" "$FLAT_SHARED-shm"
+set +e
+NODE_ENV=test DATABASE_URL= COMMHUB_DB="$FLAT_SHARED" \
+  timeout -k 2 120 bun test server/src >/tmp/test639-flat-red.out 2>&1
+flat_red_rc=$?
+set -e
+[[ $flat_red_rc -ne 0 ]] || { echo "FAIL: flat shared-process predecessor unexpectedly passed"; exit 1; }
+grep -Eq '^[[:space:]]*[1-9][0-9]* fail$' /tmp/test639-flat-red.out \
+  || { echo "FAIL: flat predecessor red had no failing-test summary"; exit 1; }
+[[ -e "$FLAT_SHARED" ]] || { echo "FAIL: flat predecessor did not use the shared DB"; exit 1; }
 
 echo "L1: normal order under strace"
 NODE_ENV=test DATABASE_URL='postgres://must-not-be-inherited.invalid/prod' COMMHUB_DB="$SHARED_DB" \
@@ -95,7 +112,7 @@ set -e
 grep -F 'explicit_test_database_required' /tmp/test638-no-db-upload.out >/dev/null
 grep -F 'explicit_test_database_required' /tmp/test638-no-db-host.out >/dev/null
 
-echo "L5: nonzero, timeout, and signal cannot greenwash"
+echo "L5: nonzero, timeout, signal, missing summary, and spawn failure cannot greenwash"
 printf '%s\n' 'import {test} from "bun:test";' 'test("nonzero",()=>{throw new Error("test638_expected_nonzero")});' > server/src/test638-nonzero.test.ts
 set +e
 bun run --cwd server test --file=server/src/test638-nonzero.test.ts >/tmp/test638-nonzero.out 2>&1; nonzero_rc=$?
@@ -124,6 +141,47 @@ sleep 0.2
 ! ps -eo args | grep -F 'bun test server/src/test638-signal.test.ts' | grep -v grep >/dev/null
 rm -f -- server/src/test638-signal.test.ts
 
+printf '%s\n' 'process.exit(0);' > server/src/test639-missing-summary.test.ts
+set +e
+bun run --cwd server test --file=server/src/test639-missing-summary.test.ts >/tmp/test639-missing-summary.out 2>&1; missing_summary_rc=$?
+set -e
+[[ $missing_summary_rc -ne 0 ]] || { echo "FAIL: missing child summary greenwashed"; exit 1; }
+grep -F $'TEST_FILE_RESULT\tserver/src/test639-missing-summary.test.ts\tpass=0\tfail=0\tskip=0' /tmp/test639-missing-summary.out >/dev/null
+grep -F 'SERVER_AGGREGATE_RESULT' /tmp/test639-missing-summary.out | grep -F '"bad":true' >/dev/null
+rm -f -- server/src/test639-missing-summary.test.ts
+
+mkdir -p /tmp/test639-no-bun
+set +e
+PATH=/tmp/test639-no-bun /usr/local/bin/bun server/scripts/test-aggregate.ts \
+  --file=server/src/db-adapter.test.ts >/tmp/test639-spawn-fail.out 2>&1; spawn_fail_rc=$?
+set -e
+[[ $spawn_fail_rc -ne 0 ]] || { echo "FAIL: child spawn failure greenwashed"; exit 1; }
+grep -F $'TEST_FILE_RESULT\tserver/src/db-adapter.test.ts\tpass=0\tfail=0\tskip=0\texpects=0\texit=null' /tmp/test639-spawn-fail.out >/dev/null
+grep -F 'SERVER_AGGREGATE_RESULT' /tmp/test639-spawn-fail.out | grep -F '"bad":true' >/dev/null
+
+echo "L5b: slug collisions fail before --file filtering"
+printf '%s\n' 'import {test,expect} from "bun:test";' 'test("flat collision fixture",()=>expect(true).toBe(true));' > server/src/test639-collision.test.ts
+mkdir -p server/src/test639
+printf '%s\n' 'import {test,expect} from "bun:test";' 'test("nested collision fixture",()=>expect(true).toBe(true));' > server/src/test639/collision.test.ts
+set +e
+bun run --cwd server test --file=server/src/test639-collision.test.ts >/tmp/test639-slug-collision.out 2>&1; slug_collision_rc=$?
+set -e
+[[ $slug_collision_rc -ne 0 ]] || { echo "FAIL: colliding test paths shared a slug"; exit 1; }
+grep -F 'test slug collision "server-src-test639-collision.test.ts"' /tmp/test639-slug-collision.out >/dev/null
+grep -F 'server/src/test639-collision.test.ts' /tmp/test639-slug-collision.out >/dev/null
+grep -F 'server/src/test639/collision.test.ts' /tmp/test639-slug-collision.out >/dev/null
+
+cp server/scripts/test-aggregate.ts server/scripts/test-aggregate-mutation.ts
+sed -i '/^[[:space:]]*assertUniqueSlugs(files);$/d' server/scripts/test-aggregate-mutation.ts
+! grep -F 'assertUniqueSlugs(files);' server/scripts/test-aggregate-mutation.ts >/dev/null
+set +e
+bun server/scripts/test-aggregate-mutation.ts --file=server/src/test639-collision.test.ts >/tmp/test639-slug-mutation.out 2>&1; slug_mutation_rc=$?
+set -e
+[[ $slug_mutation_rc -eq 0 ]] || { echo "FAIL: slug-guard mutation did not bypass collision gate"; exit 1; }
+grep -F $'TEST_FILE_RESULT\tserver/src/test639-collision.test.ts\tpass=1\tfail=0' /tmp/test639-slug-mutation.out >/dev/null
+rm -f -- server/src/test639-collision.test.ts server/src/test639/collision.test.ts server/scripts/test-aggregate-mutation.ts
+rmdir server/src/test639
+
 echo "L6: deletion of per-file DB split is witnessed-red"
 cp server/scripts/test-aggregate.ts server/scripts/test-aggregate-mutation.ts
 sed -i 's/const suiteRoot = join(runRoot, slugFor(file));/const suiteRoot = join(runRoot, "shared");/' server/scripts/test-aggregate-mutation.ts
@@ -142,5 +200,7 @@ echo "source_commit=$TEST638_SOURCE_COMMIT"
 echo "aggregate_key=$key1"
 echo "run1_db_maps=$(grep -c '^TEST_DB_MAP' "$OUT1")"
 echo "cross_suite_shapes=upload[$upload_shape],host[$host_shape]"
-echo "nonzero_rc=$nonzero_rc timeout_rc=$timeout_rc signal_rc=$signal_rc mutation_unique_db_paths=$mut_maps"
+echo "flat_current_tree_red_rc=$flat_red_rc"
+echo "nonzero_rc=$nonzero_rc timeout_rc=$timeout_rc signal_rc=$signal_rc missing_summary_rc=$missing_summary_rc spawn_fail_rc=$spawn_fail_rc"
+echo "slug_collision_rc=$slug_collision_rc slug_guard_mutation_rc=$slug_mutation_rc mutation_unique_db_paths=$mut_maps"
 echo "RESULT: PASS"

--- a/tests/test638-server-aggregate-isolation/run.sh
+++ b/tests/test638-server-aggregate-isolation/run.sh
@@ -42,19 +42,6 @@ run_one() {
     bun run --cwd server test "${args[@]}" >"$output" 2>&1
 }
 
-echo "L0: current-tree flat shared-process predecessor is witnessed-red"
-FLAT_SHARED=/tmp/test639-flat-shared.db
-rm -f -- "$FLAT_SHARED" "$FLAT_SHARED-wal" "$FLAT_SHARED-shm"
-set +e
-NODE_ENV=test DATABASE_URL= COMMHUB_DB="$FLAT_SHARED" \
-  timeout -k 2 120 bun test server/src >/tmp/test639-flat-red.out 2>&1
-flat_red_rc=$?
-set -e
-[[ $flat_red_rc -ne 0 ]] || { echo "FAIL: flat shared-process predecessor unexpectedly passed"; exit 1; }
-grep -Eq '^[[:space:]]*[1-9][0-9]* fail$' /tmp/test639-flat-red.out \
-  || { echo "FAIL: flat predecessor red had no failing-test summary"; exit 1; }
-[[ -e "$FLAT_SHARED" ]] || { echo "FAIL: flat predecessor did not use the shared DB"; exit 1; }
-
 echo "L1: normal order under strace"
 NODE_ENV=test DATABASE_URL='postgres://must-not-be-inherited.invalid/prod' COMMHUB_DB="$SHARED_DB" \
   ANET_SERVER_TEST_ROOT="$RUN1" ANET_SERVER_TEST_KEEP_ROOT=1 \
@@ -200,7 +187,6 @@ echo "source_commit=$TEST639_SOURCE_COMMIT"
 echo "aggregate_key=$key1"
 echo "run1_db_maps=$(grep -c '^TEST_DB_MAP' "$OUT1")"
 echo "cross_suite_shapes=upload[$upload_shape],host[$host_shape]"
-echo "flat_current_tree_red_rc=$flat_red_rc"
 echo "nonzero_rc=$nonzero_rc timeout_rc=$timeout_rc signal_rc=$signal_rc missing_summary_rc=$missing_summary_rc spawn_fail_rc=$spawn_fail_rc"
 echo "slug_collision_rc=$slug_collision_rc slug_guard_mutation_rc=$slug_mutation_rc mutation_unique_db_paths=$mut_maps"
 echo "RESULT: PASS"

--- a/tests/test638-server-aggregate-isolation/run.sh
+++ b/tests/test638-server-aggregate-isolation/run.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 EXPECTED_SOURCE_COMMIT="${EXPECTED_SOURCE_COMMIT:-}"
-if [[ -z "${TEST638_SOURCE_COMMIT:-}" || -z "$EXPECTED_SOURCE_COMMIT" || "$TEST638_SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]]; then
-  echo "FAIL: source provenance mismatch image=${TEST638_SOURCE_COMMIT:-unset} expected=${EXPECTED_SOURCE_COMMIT:-unset}"
+if [[ -z "${TEST639_SOURCE_COMMIT:-}" || -z "$EXPECTED_SOURCE_COMMIT" || "$TEST639_SOURCE_COMMIT" != "$EXPECTED_SOURCE_COMMIT" ]]; then
+  echo "FAIL: source provenance mismatch image=${TEST639_SOURCE_COMMIT:-unset} expected=${EXPECTED_SOURCE_COMMIT:-unset}"
   exit 1
 fi
 
@@ -196,7 +196,7 @@ mut_maps=$(grep '^TEST_DB_MAP' /tmp/test638-mutation.out | cut -f3 | sort -u | w
 [[ "$upload_db" != "$host_db" ]] || { echo "FAIL: positive isolation precondition missing"; exit 1; }
 rm -f -- server/scripts/test-aggregate-mutation.ts
 
-echo "source_commit=$TEST638_SOURCE_COMMIT"
+echo "source_commit=$TEST639_SOURCE_COMMIT"
 echo "aggregate_key=$key1"
 echo "run1_db_maps=$(grep -c '^TEST_DB_MAP' "$OUT1")"
 echo "cross_suite_shapes=upload[$upload_shape],host[$host_shape]"


### PR DESCRIPTION
## Summary
- reject slug collisions across the complete enumerated test tree before filters
- inject missing-summary and child-spawn failures into the real runner harness
- retain all #638 isolation/order/process-group gates

## Evidence
- source: `98992e331259b8617361ebb373731c2c1a5f7976`
- report-only head: `78f763d4eb7317d23ba348d6ae649e1dc81ffe72`
- aggregate: 57 files / 845 pass / 0 fail / 2579 expects, three identical runs
- missing summary and spawn failure both aggregate rc=1/bad=true
- colliding path pair rc=2; deleting the guard makes it pass, proving mutation coverage

The optional current-tree retake of the historical flat red was attempted but passed after final-tree fixture changes, so it is disclosed rather than greenwashed. No production code changed.

Closes #639