### PR TITLE
fix(cli): complete headless bootstrap and Hub precedence (#467)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -675,7 +675,7 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
   console.log(`[anet]    runtime:   codex-app-server @ ${wsUrl}  (sandbox=${sandboxMode})`);
 }
 
-async function startOpencodeCopresenceOrchestration(nodeId: string): Promise<void> {
+async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?: string): Promise<void> {
   const resolved = resolveNodeRef(nodeId);
   if (!resolved) {
     console.error(`Node "${nodeId}" not found. Create it first: anet node create ${nodeId}`);
@@ -712,7 +712,8 @@ async function startOpencodeCopresenceOrchestration(nodeId: string): Promise<voi
       ? [`export ANET_OPENCODE_SAFE_BASE=${shellQuote(process.env.ANET_OPENCODE_SAFE_BASE)}`]
       : []),
     `export ANET_OPENCODE_MODE=copresence`,
-    `exec ${shellQuote(process.execPath)} ${shellQuote(cliEntry)} node start ${shellQuote(resolved.id)}`,
+    `exec ${shellQuote(process.execPath)} ${shellQuote(cliEntry)} node start ${shellQuote(resolved.id)}`
+      + (hubOverride ? ` --hub ${shellQuote(hubOverride)}` : ""),
   ].join(" ; ");
   execFileSync("tmux", [
     "new-session", "-d", "-s", bridgeSession, "-c", process.cwd(),
@@ -3773,14 +3774,18 @@ async function createCommand(idOverride?: string) {
     }
   }
 
-  // Interactive network selection (if user has multiple writable networks and no --network specified)
-  if (!opts.network && gc.token && gc.hub && process.stdin.isTTY) {
+  // Network selection. A headless bootstrap can safely recover a missing
+  // network_id only when the authenticated user has exactly one writable
+  // network. Multiple candidates are never guessed; interactive callers may
+  // choose, while non-interactive callers get an actionable fail-closed error
+  // below. This also repairs legacy/token-only global configs (#467).
+  if (!opts.network && gc.token && gc.hub) {
     try {
       const nets = await fetch(`${gc.hub}/api/networks`, {
         headers: { Authorization: `Bearer ${gc.token}` },
       }).then(r => r.json() as any);
       const writable = (nets.networks || []).filter((n: any) => ["owner", "admin", "member"].includes(n.member_role));
-      if (writable.length > 1) {
+      if (writable.length > 1 && process.stdin.isTTY) {
         // Multiple writable networks → interactive select
         try {
           const { select: sel } = await import("@inquirer/prompts");
@@ -3867,7 +3872,9 @@ async function createCommand(idOverride?: string) {
     process.exit(1);
   }
   if (!gc.network_id) {
-    console.error(`[anet] ❌ No network selected. Run: anet login`);
+    console.error(`[anet] ❌ Global config is missing network_id; no unique writable network could be selected.`);
+    console.error(`[anet]    Run: anet network ls`);
+    console.error(`[anet]    Then: anet network use <name>`);
     process.exit(1);
   }
   let nodeTokenRes: any;
@@ -4342,7 +4349,7 @@ function maybeWarnChannelResumeBlocker(
   }
 }
 
-async function launchAgent(id: string, forceNewSession = false) {
+async function launchAgent(id: string, forceNewSession = false, hubOverride?: string) {
   const resolved = resolveNodeRef(id);
   if (!resolved) {
     console.error(`Node "${id}" not found. Create it first: anet node create ${id}`);
@@ -4357,6 +4364,11 @@ async function launchAgent(id: string, forceNewSession = false) {
     console.error(`[anet] Refusing to start node ${JSON.stringify(nodeId)}: ${error?.message || error}`);
     process.exit(1);
   }
+  // #467 — an explicit command-line hub is a per-launch override. Keep it
+  // transient (do not rewrite the node profile), but apply it before MCP
+  // materialisation and child-env construction so every runtime observes the
+  // same endpoint. CLI flags conventionally outrank persisted config.
+  if (hubOverride) profile = { ...profile, hub: hubOverride };
   const displayName = nodeDisplayName(nodeId, profile);
   const session = profileSession(profile);
   const willResume = !!session && !forceNewSession;
@@ -4955,11 +4967,11 @@ async function startCommand() {
       `start copresence node ${JSON.stringify(id)}`,
     );
     if (copresenceRuntime === "opencode-cli") {
-      await startOpencodeCopresenceOrchestration(id);
+      await startOpencodeCopresenceOrchestration(id, opts.hub);
       return;
     }
     const codexHomeDefault = join(nodesDir(), resolvedForCopresence.id, "codex-home");
-    const profileHub = (resolvedForCopresence.profile as any).hub || getHub();
+    const profileHub = opts.hub || (resolvedForCopresence.profile as any).hub || getHub();
     const profileTok = resolvedForCopresence.profile.token || "";
     await startCopresenceOrchestration(id, {
       codexBin: opts["codex-bin"] || "codex",
@@ -5009,7 +5021,7 @@ async function startCommand() {
 
   if (!wantTmux && !wantAcceptDevChannels) {
     // Default: spawn the agent runtime in this terminal.
-    await launchAgent(id, forceNewSession);
+    await launchAgent(id, forceNewSession, opts.hub);
     return;
   }
 
@@ -5031,9 +5043,10 @@ async function startCommand() {
       console.log(`[anet] tmux session "${alias}" already running — skipping spawn (use \`anet node stop\` first if you intended a fresh start).`);
       return;
     }
+    const innerHub = opts.hub ? ` --hub ${shellQuote(opts.hub)}` : "";
     const inner = forceNewSession
-      ? `anet node start ${shellQuote(alias)} --new-session`
-      : `anet node start ${shellQuote(alias)}`;
+      ? `anet node start ${shellQuote(alias)} --new-session${innerHub}`
+      : `anet node start ${shellQuote(alias)}${innerHub}`;
     try {
       execFileSync(
         "tmux",
@@ -5093,9 +5106,10 @@ async function startCommand() {
   //   -A  attach if the session already exists (handles the rerun case)
   //   -s  session name (= alias for discoverability)
   //   -c  start in cwd
+  const innerHub = opts.hub ? ` --hub ${shellQuote(opts.hub)}` : "";
   const inner = forceNewSession
-    ? `anet node start ${shellQuote(alias)} --new-session`
-    : `anet node start ${shellQuote(alias)}`;
+    ? `anet node start ${shellQuote(alias)} --new-session${innerHub}`
+    : `anet node start ${shellQuote(alias)}${innerHub}`;
 
   const headless = !process.stdin.isTTY;
   if (headless) {
@@ -9399,7 +9413,17 @@ async function goalCommand() {
 async function registerCommand() {
   const gc = loadGlobal();
   const sc = loadServerConfig();
-  let hub = gc.hub;
+  const opts = parseOpts();
+  let hub = opts.hub || gc.hub;
+
+  // #467 — scripts commonly bootstrap against an explicit remote Hub while
+  // an old global config still exists. Persist the explicit endpoint before
+  // registration so the resulting token/network config is internally
+  // consistent and subsequent commands use the same Hub.
+  if (opts.hub && opts.hub !== gc.hub) {
+    gc.hub = opts.hub;
+    saveGlobal(gc);
+  }
 
   // Auto-detect local hub
   if (!hub) {
@@ -9410,7 +9434,6 @@ async function registerCommand() {
   }
   if (!hub) { console.error("未找到 CommHub Server。请先运行: anet hub start"); return; }
 
-  const opts = parseOpts();
   const username = opts.username || opts.user || await ask("Username");
   const password = opts.password || opts.pass || await ask("Password (min 6)");
   const email = opts.email || ((opts.username || opts.user) ? "" : await ask("Email (optional)"));

--- a/docs/tests/report-test467-headless-bootstrap.txt
+++ b/docs/tests/report-test467-headless-bootstrap.txt
@@ -1,0 +1,43 @@
+# test467 — headless bootstrap and explicit Hub precedence
+
+Date: 2026-08-09 (Asia/Shanghai)
+Base: 66a9f91a48ad4a8ae6977e68e00537213155d44b
+Source commit under test: 7d926948590051891fe28f7df001d60a4568ff78
+Docker image: anet-test467:dev
+Docker image ID: sha256:2de07116e0564aa46d5ae5348182c9ded23864b5812d8e4a9abcddef0cd0ad57
+Embedded TEST467_SOURCE_COMMIT: 7d926948590051891fe28f7df001d60a4568ff78
+Raw runner artifact SHA256: 8958bba18795e247a7819ea4d2587b6f12d93cb095094a8addde0b1bb1bdcea6
+Result: PASS
+
+## Witnessed red on base
+
+The same Docker harness was first built from base 66a9f91a. It failed at the
+first behavior gate: a stale configured Hub won over an explicit `register
+--hub`, so the CLI attempted the dead endpoint and printed `Unable to connect`.
+Exit code was 1. This was captured before the implementation change.
+
+## Exact-source green layers
+
+1. `bun run typecheck` for agent-network: PASS.
+2. Real Hub process + fresh SQLite on an isolated loopback port: PASS.
+3. Non-TTY `anet register --hub ... --username ... --password ...` overrides a
+   stale configured Hub, registers successfully, and persists the explicit Hub,
+   a real `utok_`, and the default `network_id`: PASS.
+4. After deleting `network_id`, non-TTY `anet node create` recovers the only
+   writable network, persists it globally, and receives a network-bound `ntok_`:
+   PASS.
+5. With two writable networks and no selected `network_id`, create fails closed,
+   prints `anet network use <name>`, and writes no ambiguous node config: PASS.
+6. A real CLI `node start --hub` reaches a fake `npx`/agent-node boundary; the
+   child process observes the explicit Hub in `COMMHUB_URL` even when both global
+   and node configs contain a stale Hub: PASS.
+
+## Witnessed-red mutations
+
+- Remove register's explicit-Hub precedence: RED, rc=1.
+- Restore the old TTY-only unique-network recovery gate: RED, rc=1.
+- Remove the per-launch profile Hub override: RED, rc=1.
+
+Production source was byte-restored after every mutation. The test uses a fresh
+HOME, project directory, Hub process, and SQLite DB; it does not read or modify
+host/production config, tokens, nodes, or databases.

--- a/tests/test467-headless-bootstrap/Dockerfile
+++ b/tests/test467-headless-bootstrap/Dockerfile
@@ -1,0 +1,24 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl jq \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY server/package.json server/bun.lock* ./server/
+RUN cd server && bun install --ignore-scripts
+
+COPY agent-network/package.json agent-network/bun.lock* ./agent-network/
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY server ./server
+COPY agent-network ./agent-network
+COPY tests/lib ./tests/lib
+COPY tests/test467-headless-bootstrap ./tests/test467-headless-bootstrap
+
+ARG SOURCE_COMMIT
+ENV TEST467_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test467-headless-bootstrap/run.sh
+ENTRYPOINT ["/workspace/tests/test467-headless-bootstrap/run.sh"]

--- a/tests/test467-headless-bootstrap/run.sh
+++ b/tests/test467-headless-bootstrap/run.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /workspace/tests/lib/safe-rm.sh
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test467-headless-bootstrap.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test467 — headless bootstrap and explicit hub precedence"
+echo "source_commit=${TEST467_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+echo "L0 typecheck agent-network"
+(cd /workspace/agent-network && bun run typecheck)
+
+HOME_DIR=$(mktemp -d /tmp/test467-home.XXXXXX)
+PROJECT_DIR=$(mktemp -d /tmp/test467-project.XXXXXX)
+DB_PATH=$(mktemp /tmp/test467-db.XXXXXX.sqlite)
+FAKE_BIN=$(mktemp -d /tmp/test467-bin.XXXXXX)
+SERVER_PID=""
+cleanup() {
+  if [[ -n "$SERVER_PID" ]]; then kill "$SERVER_PID" >/dev/null 2>&1 || true; fi
+  safe_rm_rf "$HOME_DIR" "$PROJECT_DIR" "$FAKE_BIN"
+  rm -f "$DB_PATH" "$DB_PATH-wal" "$DB_PATH-shm"
+}
+trap cleanup EXIT
+
+BASE=http://127.0.0.1:9467
+ANET=(bun run /workspace/agent-network/bin/cli.ts)
+
+echo "L1 start real Hub with fresh SQLite"
+(
+  cd /workspace/server
+  PORT=9467 HOST=127.0.0.1 COMMHUB_DB="$DB_PATH" COMMHUB_AUTH_TOKEN=test467-auth \
+    bun run src/index.ts
+) >/tmp/test467-hub.log 2>&1 &
+SERVER_PID=$!
+for _ in $(seq 1 80); do
+  curl -fsS "$BASE/health" >/dev/null 2>&1 && break
+  sleep 0.25
+done
+curl -fsS "$BASE/health" >/dev/null
+
+echo "L2 register --hub overrides stale config without a TTY"
+mkdir -p "$HOME_DIR/.anet"
+printf '%s\n' '{"hub":"http://127.0.0.1:1"}' > "$HOME_DIR/.anet/config.json"
+set +e
+REGISTER_OUT=$(HOME="$HOME_DIR" "${ANET[@]}" register \
+  --hub "$BASE" --token test467-auth \
+  --username bootstrap467 --password Bootstrap467! 2>&1)
+REGISTER_RC=$?
+set -e
+echo "$REGISTER_OUT"
+[[ "$REGISTER_RC" -eq 0 ]] || { echo "FAIL_REGISTER_EXPLICIT_HUB"; exit 1; }
+grep -Fq 'Registered and logged in as bootstrap467' <<<"$REGISTER_OUT" || {
+  echo "FAIL_REGISTER_EXPLICIT_HUB"
+  exit 1
+}
+jq -e --arg hub "$BASE" '.hub == $hub and (.token | startswith("utok_")) and (.network_id | startswith("net_"))' \
+  "$HOME_DIR/.anet/config.json" >/dev/null || { echo "FAIL_REGISTER_PERSISTED_BOOTSTRAP"; exit 1; }
+
+echo "L3 missing network_id auto-recovers only a unique writable network"
+FIRST_NETWORK=$(jq -r '.network_id' "$HOME_DIR/.anet/config.json")
+jq 'del(.network_id, .network_name)' "$HOME_DIR/.anet/config.json" > /tmp/test467-config.json
+mv /tmp/test467-config.json "$HOME_DIR/.anet/config.json"
+chmod 0600 "$HOME_DIR/.anet/config.json"
+set +e
+(
+  cd "$PROJECT_DIR"
+  HOME="$HOME_DIR" "${ANET[@]}" node create unique-net-node --runtime codex-sdk \
+    >/tmp/test467-unique-create.log 2>&1
+)
+UNIQUE_CREATE_RC=$?
+set -e
+cat /tmp/test467-unique-create.log
+[[ "$UNIQUE_CREATE_RC" -eq 0 ]] || { echo "FAIL_UNIQUE_NETWORK_HEADLESS_RECOVERY"; exit 1; }
+echo "global config after unique recovery:"
+jq '{hub,network_id,network_name}' "$HOME_DIR/.anet/config.json"
+jq -e --arg network "$FIRST_NETWORK" '.network_id == $network' "$HOME_DIR/.anet/config.json" >/dev/null \
+  || { echo "FAIL_UNIQUE_NETWORK_HEADLESS_RECOVERY"; exit 1; }
+UNIQUE_CFG=$(find "$PROJECT_DIR/.anet/nodes" -name config.json -type f -print -quit)
+echo "unique node config: $UNIQUE_CFG"
+jq '{node_name,network_id,token_prefix:(.token[0:5])}' "$UNIQUE_CFG"
+jq -e '.token | startswith("ntok_")' "$UNIQUE_CFG" >/dev/null
+
+set +e
+HOME="$HOME_DIR" "${ANET[@]}" network create second-network >/tmp/test467-second-network.log 2>&1
+SECOND_NETWORK_RC=$?
+set -e
+cat /tmp/test467-second-network.log
+[[ "$SECOND_NETWORK_RC" -eq 0 ]]
+jq 'del(.network_id, .network_name)' "$HOME_DIR/.anet/config.json" > /tmp/test467-config.json
+mv /tmp/test467-config.json "$HOME_DIR/.anet/config.json"
+chmod 0600 "$HOME_DIR/.anet/config.json"
+set +e
+(
+  cd "$PROJECT_DIR"
+  HOME="$HOME_DIR" "${ANET[@]}" node create ambiguous-net-node --runtime codex-sdk
+) >/tmp/test467-ambiguous-create.log 2>&1
+AMBIGUOUS_RC=$?
+set -e
+cat /tmp/test467-ambiguous-create.log
+[[ "$AMBIGUOUS_RC" -ne 0 ]]
+grep -Fq 'anet network use <name>' /tmp/test467-ambiguous-create.log
+if find "$PROJECT_DIR/.anet/nodes" -name config.json -type f -exec grep -l 'ambiguous-net-node' {} + | grep -q .; then
+  echo "FAIL: ambiguous network selection wrote a node config"
+  exit 1
+fi
+
+echo "L4 node start --hub overrides stale global/profile hub in the spawned process"
+jq --arg hub 'http://127.0.0.1:1' --arg network "$FIRST_NETWORK" \
+  '.hub=$hub | .network_id=$network' "$HOME_DIR/.anet/config.json" > /tmp/test467-config.json
+mv /tmp/test467-config.json "$HOME_DIR/.anet/config.json"
+chmod 0600 "$HOME_DIR/.anet/config.json"
+jq --arg hub 'http://127.0.0.1:1' '.hub=$hub' "$UNIQUE_CFG" > /tmp/test467-node-config.json
+mv /tmp/test467-node-config.json "$UNIQUE_CFG"
+chmod 0600 "$UNIQUE_CFG"
+cat > "$FAKE_BIN/npx" <<'SH'
+#!/usr/bin/env bash
+printf 'COMMHUB_URL=%s\n' "${COMMHUB_URL:-}" > /tmp/test467-spawn-env.log
+exit 0
+SH
+chmod 0755 "$FAKE_BIN/npx"
+(
+  cd "$PROJECT_DIR"
+  PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" \
+    "${ANET[@]}" node start unique-net-node --hub "$BASE" \
+    >/tmp/test467-start.log 2>&1
+)
+cat /tmp/test467-start.log
+grep -Fxq "COMMHUB_URL=$BASE" /tmp/test467-spawn-env.log || {
+  echo "FAIL_START_EXPLICIT_HUB"
+  cat /tmp/test467-spawn-env.log
+  exit 1
+}
+
+if [[ "${TEST467_SKIP_MUTATIONS:-0}" != "1" ]]; then
+  echo "L5 witnessed-red mutations"
+  kill "$SERVER_PID" >/dev/null 2>&1 || true
+  wait "$SERVER_PID" >/dev/null 2>&1 || true
+  SERVER_PID=""
+  CLI=/workspace/agent-network/bin/cli.ts
+  cp "$CLI" /tmp/test467-cli.original.ts
+
+  expect_mutation_red() {
+    local name=$1
+    local expected=$2
+    local mutation_dir="/tmp/test467-mutation-$name"
+    safe_rm_rf "$mutation_dir"
+    mkdir -p "$mutation_dir"
+    set +e
+    TEST467_SKIP_MUTATIONS=1 ARTIFACT_DIR="$mutation_dir" "$0" >"$mutation_dir/runner.log" 2>&1
+    local rc=$?
+    set -e
+    if [[ "$rc" -eq 0 ]]; then
+      echo "MUTATION_FALSE_GREEN: $name"
+      exit 1
+    fi
+    grep -Fq "$expected" "$mutation_dir/runner.log" || {
+      echo "MUTATION_WRONG_RED: $name (expected stage: $expected)"
+      tail -80 "$mutation_dir/runner.log"
+      exit 1
+    }
+    echo "MUTATION_RED: $name rc=$rc"
+    cp /tmp/test467-cli.original.ts "$CLI"
+  }
+
+  sed -i 's/let hub = opts\.hub || gc\.hub;/let hub = gc.hub;/' "$CLI"
+  grep -Fq 'let hub = gc.hub;' "$CLI"
+  expect_mutation_red register-explicit-hub 'FAIL_REGISTER_EXPLICIT_HUB'
+
+  sed -i 's/if (!opts\.network && gc\.token && gc\.hub) {/if (!opts.network \&\& gc.token \&\& gc.hub \&\& process.stdin.isTTY) {/' "$CLI"
+  grep -Fq 'gc.hub && process.stdin.isTTY' "$CLI"
+  expect_mutation_red unique-network-headless-recovery 'FAIL_UNIQUE_NETWORK_HEADLESS_RECOVERY'
+
+  sed -i 's/if (hubOverride) profile = { \.\.\.profile, hub: hubOverride };/if (false \&\& hubOverride) profile = { ...profile, hub: hubOverride };/' "$CLI"
+  grep -Fq 'if (false && hubOverride)' "$CLI"
+  expect_mutation_red start-explicit-hub 'FAIL_START_EXPLICIT_HUB'
+
+  cmp -s "$CLI" /tmp/test467-cli.original.ts || {
+    echo "FAIL: production source was not restored after mutations"
+    exit 1
+  }
+fi
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- makes `anet register --hub <url>` override stale global config and persist the selected Hub
- lets non-interactive `node create` repair a missing `network_id` only when exactly one writable network exists
- fails closed with `anet network use <name>` guidance when network selection is ambiguous
- makes `node start --hub <url>` override persisted Hub configuration for the launched runtime, including tmux and co-presence forwarding paths

## Root cause

`registerCommand` resolved the Hub before parsing CLI options, network recovery was gated behind `process.stdin.isTTY`, and `startCommand` parsed `--hub` without passing it to `launchAgent`.

## Validation

- Docker-only `tests/test467-headless-bootstrap`
- real Hub process with fresh SQLite and isolated HOME/project
- `agent-network` TypeScript check
- exact tested source: `7d926948590051891fe28f7df001d60a4568ff78`
- three witnessed-red mutations: register Hub precedence, headless unique-network recovery, start Hub precedence
- report: `docs/tests/report-test467-headless-bootstrap.txt`

Closes #467