### PR TITLE
fix(cli): keep node start --hub transient during legacy repair

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -4364,6 +4364,10 @@ async function launchAgent(id: string, forceNewSession = false, hubOverride?: st
     console.error(`[anet] Refusing to start node ${JSON.stringify(nodeId)}: ${error?.message || error}`);
     process.exit(1);
   }
+  // Keep the resolved persisted profile separate from the per-launch view.
+  // A legacy config may need its canonical node_id repaired below; that write
+  // must not accidentally bake a transient --hub override into config.json.
+  const persistedProfile = profile;
   // #467 — an explicit command-line hub is a per-launch override. Keep it
   // transient (do not rewrite the node profile), but apply it before MCP
   // materialisation and child-env construction so every runtime observes the
@@ -4421,7 +4425,7 @@ async function launchAgent(id: string, forceNewSession = false, hubOverride?: st
     const rawCfgPath = join(nodesDir(), nodeId, "config.json");
     const rawCfg = JSON.parse(readFileSync(rawCfgPath, "utf-8"));
     if (!rawCfg.node_id && profile.node_id) {
-      saveProfile(nodeId, profile);
+      saveProfile(nodeId, persistedProfile);
       console.log(`[anet] persisted canonical node_id ${profile.node_id} (legacy config had none).`);
     }
   } catch {}

--- a/docs/tests/report-test643-transient-hub-legacy-repair.txt
+++ b/docs/tests/report-test643-transient-hub-legacy-repair.txt
@@ -1,0 +1,28 @@
+# test643 — transient `--hub` survives legacy node_id repair
+
+Date: 2026-08-09
+Base commit: `5b2688fdc41e8c5bfa57820645abcf1f09ffe3df`
+Source commit: `47d3a16c1bacfa6b4712a1f1830bbc4e637f48c3`
+Docker image: `anet-test643:dev`
+Image ID: `sha256:c962697151952a88dcf9285cba5bb18f5c88adcd8fbeafd2fa168f932f4d80eb`
+Embedded ENV: `TEST643_SOURCE_COMMIT=47d3a16c1bacfa6b4712a1f1830bbc4e637f48c3`
+Raw runner report SHA256: `59b1be513f1123663fd844fd64e77f001d85899d8fa883e844acc2fd42bfc62b`
+
+## Result
+
+PASS
+
+- L0: `agent-network` TypeScript check passed.
+- L1: a real Hub process started against fresh SQLite.
+- L2: a real CLI registration and node creation produced a node token; after
+  removing the stored `node_id`, `node start --hub <new>` sent the spawned
+  process to the new Hub, repaired the canonical `node_id`, and kept the
+  persisted node Hub at its original value.
+- L3 witnessed-red: changing the repair write back from `persistedProfile` to
+  the launch-time `profile` persisted the transient Hub and failed at the
+  intended invariant (`rc=1`).
+- L4: restoring production source returned the same real CLI flow to green.
+
+The change is limited to which resolved profile is used for the one-time
+legacy `node_id` repair. Runtime launch paths still consume the explicit Hub
+override, while global config and the node's persisted Hub remain unchanged.

--- a/tests/test643-transient-hub-legacy-repair/Dockerfile
+++ b/tests/test643-transient-hub-legacy-repair/Dockerfile
@@ -1,0 +1,22 @@
+FROM oven/bun:1.3.14
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl jq \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY agent-network/package.json ./agent-network/package.json
+COPY server/package.json ./server/package.json
+RUN cd agent-network && bun install --ignore-scripts \
+  && cd /workspace/server && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY server ./server
+COPY tests/lib ./tests/lib
+COPY tests/test643-transient-hub-legacy-repair ./tests/test643-transient-hub-legacy-repair
+
+ARG SOURCE_COMMIT
+ENV TEST643_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test643-transient-hub-legacy-repair/run.sh
+ENTRYPOINT ["/workspace/tests/test643-transient-hub-legacy-repair/run.sh"]

--- a/tests/test643-transient-hub-legacy-repair/run.sh
+++ b/tests/test643-transient-hub-legacy-repair/run.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /workspace/tests/lib/safe-rm.sh
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test643-transient-hub-legacy-repair.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test643 — transient --hub survives legacy node_id repair"
+echo "source_commit=${TEST643_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+echo "L0 typecheck agent-network"
+(cd /workspace/agent-network && bun run typecheck)
+
+DB_PATH=$(mktemp /tmp/test643-db.XXXXXX.sqlite)
+SERVER_PID=""
+cleanup() {
+  if [[ -n "$SERVER_PID" ]]; then kill "$SERVER_PID" >/dev/null 2>&1 || true; fi
+  rm -f "$DB_PATH" "$DB_PATH-wal" "$DB_PATH-shm"
+}
+trap cleanup EXIT
+
+BASE=http://127.0.0.1:9643
+STALE_HUB=http://127.0.0.1:1
+ANET=(bun run /workspace/agent-network/bin/cli.ts)
+
+echo "L1 start real Hub with fresh SQLite"
+(
+  cd /workspace/server
+  PORT=9643 HOST=127.0.0.1 COMMHUB_DB="$DB_PATH" COMMHUB_AUTH_TOKEN=test643-auth \
+    bun run src/index.ts
+) >/tmp/test643-hub.log 2>&1 &
+SERVER_PID=$!
+for _ in $(seq 1 80); do
+  curl -fsS "$BASE/health" >/dev/null 2>&1 && break
+  sleep 0.25
+done
+curl -fsS "$BASE/health" >/dev/null
+
+run_case() {
+  local suffix=$1
+  local expected_failure=${2:-0}
+  local home_dir project_dir fake_bin node_cfg start_log spawn_log
+  home_dir=$(mktemp -d "/tmp/test643-home-${suffix}.XXXXXX")
+  project_dir=$(mktemp -d "/tmp/test643-project-${suffix}.XXXXXX")
+  fake_bin=$(mktemp -d "/tmp/test643-bin-${suffix}.XXXXXX")
+  start_log="/tmp/test643-start-${suffix}.log"
+  spawn_log="/tmp/test643-spawn-${suffix}.log"
+
+  HOME="$home_dir" "${ANET[@]}" register --hub "$BASE" --token test643-auth \
+    --username "legacy643-${suffix}" --password 'Legacy643!' >/tmp/test643-register.log 2>&1
+  (
+    cd "$project_dir"
+    HOME="$home_dir" "${ANET[@]}" node create "legacy-${suffix}" --runtime codex-sdk \
+      >/tmp/test643-create.log 2>&1
+  )
+  node_cfg=$(find "$project_dir/.anet/nodes" -name config.json -type f -print -quit)
+  [[ -n "$node_cfg" ]]
+  jq --arg hub "$STALE_HUB" 'del(.node_id) | .hub=$hub' "$node_cfg" > /tmp/test643-node-config.json
+  mv /tmp/test643-node-config.json "$node_cfg"
+  chmod 0600 "$node_cfg"
+
+  cat > "$fake_bin/npx" <<SH
+#!/usr/bin/env bash
+printf 'COMMHUB_URL=%s\n' "\${COMMHUB_URL:-}" > "$spawn_log"
+exit 0
+SH
+  chmod 0755 "$fake_bin/npx"
+
+  (
+    cd "$project_dir"
+    PATH="$fake_bin:$PATH" HOME="$home_dir" \
+      "${ANET[@]}" node start "legacy-${suffix}" --hub "$BASE"
+  ) >"$start_log" 2>&1
+  cat "$start_log"
+
+  grep -Fxq "COMMHUB_URL=$BASE" "$spawn_log" || {
+    echo "FAIL_START_DID_NOT_USE_OVERRIDE"
+    return 1
+  }
+  jq -e --arg hub "$STALE_HUB" '.hub == $hub and (.node_id | type == "string" and length > 0)' \
+    "$node_cfg" >/dev/null || {
+      echo "FAIL_TRANSIENT_HUB_WAS_PERSISTED"
+      jq '{hub,node_id}' "$node_cfg"
+      return 1
+    }
+  grep -Fq 'persisted canonical node_id' "$start_log"
+
+  safe_rm_rf "$home_dir" "$project_dir" "$fake_bin"
+  if [[ "$expected_failure" == 1 ]]; then
+    echo "MUTATION_FALSE_GREEN: persisted-profile-separation"
+    return 1
+  fi
+}
+
+echo "L2 legacy repair persists node_id but not the transient Hub"
+run_case green
+
+echo "L3 witnessed-red: repair writes the launch-time override"
+CLI=/workspace/agent-network/bin/cli.ts
+cp "$CLI" /tmp/test643-cli.original.ts
+sed -i 's/saveProfile(nodeId, persistedProfile);/saveProfile(nodeId, profile);/' "$CLI"
+grep -Fq 'saveProfile(nodeId, profile);' "$CLI"
+set +e
+run_case mutation 1 >/tmp/test643-mutation.log 2>&1
+mutation_rc=$?
+set -e
+cat /tmp/test643-mutation.log
+[[ "$mutation_rc" -ne 0 ]] || { echo "MUTATION_FALSE_GREEN: persisted-profile-separation"; exit 1; }
+grep -Fq 'FAIL_TRANSIENT_HUB_WAS_PERSISTED' /tmp/test643-mutation.log || {
+  echo "MUTATION_WRONG_RED: persisted-profile-separation"
+  exit 1
+}
+echo "MUTATION_RED: persisted-profile-separation rc=$mutation_rc"
+cp /tmp/test643-cli.original.ts "$CLI"
+cmp -s "$CLI" /tmp/test643-cli.original.ts
+
+echo "L4 restored green"
+run_case restored
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #643

## What changed
- preserve the resolved persisted profile before applying the per-launch `--hub` override
- use that persisted profile for the one-time legacy `node_id` repair
- keep all runtime launch paths on the explicit override without rewriting node/global Hub config

## Verification
- Docker-only `test643` against source `a14210271138c69e4a3a9e6da98724c4c7464b4e`
- real Hub + fresh SQLite + real CLI registration/create/start flow
- TypeScript check passes
- child process observes the override Hub while repaired `config.json` retains its original Hub
- mutation reverting the repair write to the launch-time profile turns red at the persisted-Hub invariant
- fixed image `anet-test643:dev`, image ID `sha256:5c9c5573e9b4cef0bdda191dbbb5dead47e6f4f87b3112e183e9953362c2c18d`

No merge, publish, or deployment performed.