### PR TITLE
fix(agent-node): prefer configured node identity

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -123,6 +123,7 @@ import {
   type CredentialRedactor,
 } from "./credential-redaction";
 import { appendPrivateLogLine, preparePrivateLogDirectory } from "./private-log";
+import { resolveNodeIdSource } from "./runtime/node-id-source";
 
 const home = homedir();
 
@@ -1037,11 +1038,17 @@ async function callCommHub(method: string, params: Record<string, unknown>, retr
   throw lastErr || new Error(`callCommHub(${method}) failed after ${retries} retries`);
 }
 
-// #146 PR-4 — prefer the COMMHUB_NODE_ID env that PR-3 (e0aa4d8) sets on
-// every launched node, fall back to the config field for back-compat with
-// nodes started before PR-3 landed. The env wins because the launcher
-// always knows the canonical node id; a stale config file would mislead.
-const NODE_ID = process.env.COMMHUB_NODE_ID || fileConfig.node_id || "";
+// #532 — config+token is the durable identity pair. COMMHUB_NODE_ID is an
+// internal launcher propagation value, not a public identity override. The
+// standard `anet node start` paths already replace/remove inherited values;
+// direct agent-node and external supervisors can still inherit a stale value.
+// Keep the env only as a legacy fallback when the config has no node_id.
+const { value: NODE_ID } = resolveNodeIdSource({
+  configNodeId: fileConfig.node_id,
+  envNodeId: process.env.COMMHUB_NODE_ID,
+  configPath: configFilePath,
+  warn: (message) => warn(`[identity] ${message}`),
+});
 const NODE_NAME = fileConfig.node_name || "";
 const NETWORK_ID = fileConfig.network_id || process.env.ANET_NETWORK_ID || globalConfig.network_id || "";
 const RESUME_ID = NODE_ID ? `sdk-${NODE_ID}` : `sdk-${ALIAS}-${Date.now().toString(36)}`;

--- a/agent-node/src/runtime/node-id-source.test.ts
+++ b/agent-node/src/runtime/node-id-source.test.ts
@@ -16,10 +16,10 @@ describe("resolveNodeIdSource", () => {
       warn: (message) => warnings.push(message),
     });
 
-    expect(resolved).toEqual({ value: "n_config532", source: "config" });
     if (aliasByNodeId[resolved.value] === "wrong-env-alias") {
       throw new Error("ENV_POLLUTION_RESOLVED_WRONG_ALIAS");
     }
+    expect(resolved).toEqual({ value: "n_config532", source: "config" });
     expect(aliasByNodeId[resolved.value]).toBe("config-alias");
     expect(aliasByNodeId[resolved.value]).not.toBe("wrong-env-alias");
     expect(warnings).toHaveLength(1);

--- a/agent-node/src/runtime/node-id-source.test.ts
+++ b/agent-node/src/runtime/node-id-source.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { resolveNodeIdSource } from "./node-id-source";
+
+const aliasByNodeId: Record<string, string> = {
+  n_config532: "config-alias",
+  n_foreign532: "wrong-env-alias",
+};
+
+describe("resolveNodeIdSource", () => {
+  test("configured identity wins over a polluted supervisor env", () => {
+    const warnings: string[] = [];
+    const resolved = resolveNodeIdSource({
+      configNodeId: "n_config532",
+      envNodeId: "n_foreign532",
+      configPath: "/fleet/config-alias/config.json",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(resolved).toEqual({ value: "n_config532", source: "config" });
+    if (aliasByNodeId[resolved.value] === "wrong-env-alias") {
+      throw new Error("ENV_POLLUTION_RESOLVED_WRONG_ALIAS");
+    }
+    expect(aliasByNodeId[resolved.value]).toBe("config-alias");
+    expect(aliasByNodeId[resolved.value]).not.toBe("wrong-env-alias");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('env="n_foreign532"');
+    expect(warnings[0]).toContain('config="n_config532"');
+    expect(warnings[0]).toContain('config_path="/fleet/config-alias/config.json"');
+    expect(warnings[0]).toContain("ignoring env COMMHUB_NODE_ID, using config node_id");
+  });
+
+  test("matching launcher env is accepted without a warning", () => {
+    const warnings: string[] = [];
+    const resolved = resolveNodeIdSource({
+      configNodeId: "n_config532",
+      envNodeId: "n_config532",
+      warn: (message) => warnings.push(message),
+    });
+    expect(resolved).toEqual({ value: "n_config532", source: "config" });
+    expect(warnings).toEqual([]);
+  });
+
+  test("legacy config without node_id keeps the env fallback", () => {
+    expect(resolveNodeIdSource({ envNodeId: "n_legacy532" })).toEqual({
+      value: "n_legacy532",
+      source: "env",
+    });
+  });
+
+  test("missing identity remains empty", () => {
+    expect(resolveNodeIdSource({})).toEqual({ value: "", source: "none" });
+  });
+
+  test("warning escapes control characters from inherited env", () => {
+    const warnings: string[] = [];
+    resolveNodeIdSource({
+      configNodeId: "n_config532",
+      envNodeId: "n_bad\n\u001b[31m",
+      configPath: "/fleet/config.json",
+      warn: (message) => warnings.push(message),
+    });
+    expect(warnings[0]).not.toContain("\n");
+    expect(warnings[0]).not.toContain("\u001b");
+    expect(warnings[0]).toContain("\\n");
+    expect(warnings[0]).toContain("\\u001b");
+  });
+});

--- a/agent-node/src/runtime/node-id-source.ts
+++ b/agent-node/src/runtime/node-id-source.ts
@@ -1,0 +1,45 @@
+export interface ResolveNodeIdInput {
+  configNodeId?: string | null;
+  envNodeId?: string | null;
+  configPath?: string | null;
+  warn?: (message: string) => void;
+}
+
+export interface ResolvedNodeId {
+  value: string;
+  source: "config" | "env" | "none";
+}
+
+function quoted(value: string): string {
+  // JSON quoting keeps control characters from becoming terminal control
+  // sequences while preserving the exact identity value for diagnosis.
+  return JSON.stringify(value);
+}
+
+/**
+ * Resolve the node identity used by a direct agent-node launch.
+ *
+ * A persisted config is the durable identity source. COMMHUB_NODE_ID is an
+ * internal launcher-to-child propagation variable, not a documented identity
+ * override. It remains a fallback for legacy direct launches whose config has
+ * no node_id, but it must not replace a configured identity when inherited
+ * from a stale supervisor shell.
+ */
+export function resolveNodeIdSource(input: ResolveNodeIdInput): ResolvedNodeId {
+  const configNodeId = input.configNodeId || "";
+  const envNodeId = input.envNodeId || "";
+
+  if (configNodeId) {
+    if (envNodeId && envNodeId !== configNodeId) {
+      input.warn?.(
+        `COMMHUB_NODE_ID mismatch: env=${quoted(envNodeId)} ` +
+          `config=${quoted(configNodeId)} config_path=${quoted(input.configPath || "config.json")}; ` +
+          `ignoring env COMMHUB_NODE_ID, using config node_id`,
+      );
+    }
+    return { value: configNodeId, source: "config" };
+  }
+
+  if (envNodeId) return { value: envNodeId, source: "env" };
+  return { value: "", source: "none" };
+}

--- a/docs/tests/report-test646-config-node-id-precedence.txt
+++ b/docs/tests/report-test646-config-node-id-precedence.txt
@@ -1,0 +1,49 @@
+# test646 — direct agent-node node_id precedence
+
+Date: 2026-08-09
+Issue: #532
+Base: 47fe27ec8cfa992626a52e89ee738b491b2bc4e5
+Tested source: f21ec7261f490459e52391edf197682d19353c2b
+Docker tag: anet-test646:dev
+Docker image: sha256:26f174c9561408b7989568a93927bd35a1c6e291f24db767e89c3c0767f54dd4
+Embedded source: TEST646_SOURCE_COMMIT=f21ec7261f490459e52391edf197682d19353c2b
+
+## Scope
+
+This is the narrow availability repair approved for #532 option A. For a
+direct `agent-node --config` launch:
+
+- configured `node_id` is authoritative;
+- a different inherited `COMMHUB_NODE_ID` is ignored with an actionable
+  warning containing the env id, config id, and config path;
+- an identical launcher value is accepted silently;
+- `COMMHUB_NODE_ID` remains a compatibility fallback when a legacy config has
+  no `node_id`.
+
+The standard `anet node start` launcher branches were not changed; test646
+shape-pins both existing set/delete boundaries. This change does not claim the
+issue's broader three-value fail-closed diagnostic: token-bound alias
+introspection requires a separately reviewed Hub/API wire extension.
+
+## Docker result
+
+```text
+source_commit=f21ec7261f490459e52391edf197682d19353c2b
+L0: config/env identity resolver
+5 pass
+0 fail
+16 expect() calls
+L1: production CLI integration
+Bundled 81 modules
+L2: witnessed-red env-first mutation
+MUTATION_RED: env-first-precedence rc=1
+RESULT: PASS
+```
+
+The mutation restores the pre-fix env-first ordering. The conflicting fixture
+then resolves `n_foreign532` to `wrong-env-alias` and fails with the explicit
+`ENV_POLLUTION_RESOLVED_WRONG_ALIAS` marker. Restoring config-first returns the
+suite to green.
+
+No Hub, database, installed package, production process, or deployment was
+modified. Fixture identities and paths are synthetic.

--- a/tests/test646-config-node-id-precedence/Dockerfile
+++ b/tests/test646-config-node-id-precedence/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+
+COPY agent-network/src ./agent-network/src
+COPY agent-node/src ./agent-node/src
+COPY tests/test646-config-node-id-precedence/run.sh /run.sh
+
+ARG TEST646_SOURCE_COMMIT=unknown
+ENV TEST646_SOURCE_COMMIT=$TEST646_SOURCE_COMMIT
+
+RUN chmod 0755 /run.sh
+ENTRYPOINT ["/run.sh"]

--- a/tests/test646-config-node-id-precedence/Dockerfile
+++ b/tests/test646-config-node-id-precedence/Dockerfile
@@ -2,6 +2,7 @@ FROM oven/bun:1.3.14
 WORKDIR /workspace
 
 COPY agent-network/src ./agent-network/src
+COPY agent-network/bin ./agent-network/bin
 COPY agent-node/src ./agent-node/src
 COPY tests/test646-config-node-id-precedence/run.sh /run.sh
 

--- a/tests/test646-config-node-id-precedence/run.sh
+++ b/tests/test646-config-node-id-precedence/run.sh
@@ -16,8 +16,8 @@ grep -Fq 'envNodeId: process.env.COMMHUB_NODE_ID' agent-node/src/cli.ts
 
 # The standard anet launcher already owns the child env boundary. #532 must
 # not weaken or duplicate those two existing branches.
-test "$(grep -c 'delete childEnv.COMMHUB_NODE_ID' agent-network/bin/cli.ts)" -eq 2
-test "$(grep -c 'childEnv.COMMHUB_NODE_ID = profile.node_id' agent-network/bin/cli.ts)" -eq 2
+test "$(grep -c 'if (!profile.node_id) delete (env as Record<string, unknown>).COMMHUB_NODE_ID' agent-network/bin/cli.ts)" -eq 2
+test "$(grep -c '...(profile.node_id ? { COMMHUB_NODE_ID: profile.node_id } : {})' agent-network/bin/cli.ts)" -eq 2
 
 echo "L2: witnessed-red env-first mutation"
 cp agent-node/src/runtime/node-id-source.ts /tmp/test646-node-id-source.ts

--- a/tests/test646-config-node-id-precedence/run.sh
+++ b/tests/test646-config-node-id-precedence/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspace
+echo "source_commit=$TEST646_SOURCE_COMMIT"
+
+echo "L0: config/env identity resolver"
+bun test agent-node/src/runtime/node-id-source.test.ts
+
+echo "L1: production CLI integration"
+bun build --target bun --packages external agent-node/src/cli.ts --outfile /tmp/test646-agent-node.js
+test -s /tmp/test646-agent-node.js
+grep -Fq 'resolveNodeIdSource({' agent-node/src/cli.ts
+grep -Fq 'configNodeId: fileConfig.node_id' agent-node/src/cli.ts
+grep -Fq 'envNodeId: process.env.COMMHUB_NODE_ID' agent-node/src/cli.ts
+
+# The standard anet launcher already owns the child env boundary. #532 must
+# not weaken or duplicate those two existing branches.
+test "$(grep -c 'delete childEnv.COMMHUB_NODE_ID' agent-network/bin/cli.ts)" -eq 2
+test "$(grep -c 'childEnv.COMMHUB_NODE_ID = profile.node_id' agent-network/bin/cli.ts)" -eq 2
+
+echo "L2: witnessed-red env-first mutation"
+cp agent-node/src/runtime/node-id-source.ts /tmp/test646-node-id-source.ts
+sed -i '/  if (configNodeId) {/i\  if (envNodeId) return { value: envNodeId, source: "env" };\n' \
+  agent-node/src/runtime/node-id-source.ts
+grep -Fq 'if (envNodeId) return { value: envNodeId, source: "env" };' \
+  agent-node/src/runtime/node-id-source.ts
+
+set +e
+bun test agent-node/src/runtime/node-id-source.test.ts >/tmp/test646-mutation.log 2>&1
+mutation_rc=$?
+set -e
+cp /tmp/test646-node-id-source.ts agent-node/src/runtime/node-id-source.ts
+
+test "$mutation_rc" -ne 0
+grep -Fq 'ENV_POLLUTION_RESOLVED_WRONG_ALIAS' /tmp/test646-mutation.log
+echo "MUTATION_RED: env-first-precedence rc=$mutation_rc"
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## Summary

Implements the approved option A narrow repair for #532 without changing Hub/API wire semantics:

- `config.node_id` wins over an inherited `COMMHUB_NODE_ID`;
- a mismatch emits an actionable warning with env id, config id, and config path;
- identical values stay quiet;
- legacy direct launches without `config.node_id` retain the env fallback;
- the two standard `anet node start` launcher identity boundaries are unchanged and shape-pinned.

This deliberately does **not** claim the issue's broader three-value token-bound alias diagnostic. `/api/auth/me` does not expose the token-bound alias today; that requires a separate Hub-wire design and review. Therefore this PR does not auto-close #532.

## Evidence

- tested source: `f21ec7261f490459e52391edf197682d19353c2b`
- report-only head: `683e13b9bf308c0520d14e5f559985606c3516c7`
- Docker image: `sha256:26f174c9561408b7989568a93927bd35a1c6e291f24db767e89c3c0767f54dd4`
- embedded source: `TEST646_SOURCE_COMMIT=f21ec7261f490459e52391edf197682d19353c2b`
- result: 5 tests, 16 assertions, 81-module production CLI bundle, env-first mutation red with `ENV_POLLUTION_RESOLVED_WRONG_ALIAS`.

No production service, database, installed package, merge, publish, or deployment is included.