### PR TITLE
fix(server): pin REST response column contracts

### DIFF
--- a/docs/tests/report-test647-rest-explicit-columns.txt
+++ b/docs/tests/report-test647-rest-explicit-columns.txt
@@ -1,0 +1,51 @@
+# test647 — REST explicit-column response contracts
+
+Status: PASS
+Tested source: ec66f1172de03ab0cd3cb63872021562ce7844ef
+Base: d899f697f46222edd6c479f376f3cd343998d791
+Docker image: anet-test647:dev
+Docker image ID: sha256:dd865aa7c940db923b6180507fb5d6e48a12f229b43967af5f50f7ff28d6ce76
+Embedded ENV: TEST647_SOURCE_COMMIT=ec66f1172de03ab0cd3cb63872021562ce7844ef
+Run date: 2026-08-09T15:51:38Z
+
+Scope audited
+
+- REST rows pinned: networks list/detail, full status sessions, audit log,
+  task events, task list/detail, completions, scheduled tasks.
+- Internal existence/ownership reads narrowed: license, upload network lookup,
+  node delete, network rename/delete, invite redemption.
+- Current response keys are preserved. The change only prevents a future
+  ALTER TABLE from silently widening the wire response.
+- Dashboard consumer audit: status telemetry/model/runtime, task/chat fields,
+  network identity/description/owner, audit/events, completion fallback.
+- Mobile consumer audit: light status, task detail/history, meta_json
+  attachments, task events. meta_json remains in the explicit task contract.
+- Remaining production SELECT-star queries are classified as non-REST:
+  server/src/tools.ts is MCP-only; server/src/rename.ts is internal 2PC state.
+
+Evidence
+
+L0 production build: PASS
+- bun build server/src/index.ts --target bun
+- 258 modules, output 1.52 MB
+
+L1 REST source classification: PASS
+- server.ts, auth.ts, scheduled-tasks.ts contain zero executable SELECT-star
+  queries after the change.
+
+L2 real HTTP + SQLite shape gate: PASS
+- 5 tests, 0 failures, 29 assertions.
+- Each REST-backed table was ALTERed with future_internal_only before requests.
+- Every endpoint preserved its documented/current key set.
+- future_internal_only was absent everywhere.
+- scheduled-task created_by and schedule_json remained absent.
+
+L3 witnessed-red mutations: PASS
+- tasks REST projection -> SELECT-star: rc=1; leaked sentinel detected.
+- joined network REST projection -> n.*: rc=1; leaked sentinel detected.
+- scheduled-task list projection -> SELECT-star: rc=1; leaked sentinel detected.
+
+L4 restored source: PASS
+- 5 tests, 0 failures, 29 assertions.
+
+Result: PASS

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -3,6 +3,7 @@
  */
 import { db, generateId, hashPassword, verifyPassword, hashToken, generateToken, generateUserToken, generateNetworkToken, uuidv4 } from "./db.js";
 import { WEAK_PASSWORDS } from "./password-dict.js";
+import { NETWORK_REST_COLUMNS, NETWORK_REST_SELECT, sqlColumns } from "./rest-projections.js";
 
 // Round-6 A1 hardening — dummy hash for username-enumeration timing
 // close. We compute ONE scrypt hash of a throwaway password and reuse
@@ -235,7 +236,7 @@ export function resolveToken(token: string): { user: AuthUser; networkId: string
 
 export function getUserNetworks(userId: string) {
   return db.all<any>(
-    "SELECT * FROM networks WHERE owner_id = ?1 ORDER BY created_at",
+    `SELECT ${NETWORK_REST_SELECT} FROM networks WHERE owner_id = ?1 ORDER BY created_at`,
     userId);
 }
 
@@ -280,7 +281,7 @@ export function listTokens(userId: string) {
 }
 
 export function renameNetwork(userId: string, networkId: string, newName: string): { ok: boolean; error?: string } {
-  const net = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", networkId);
+  const net = db.get<any>("SELECT owner_id FROM networks WHERE network_id = ?1", networkId);
   if (!net) return { ok: false, error: "network not found" };
   if (net.owner_id !== userId) return { ok: false, error: "not your network" };
   const dup = db.get<any>("SELECT network_id FROM networks WHERE owner_id = ?1 AND network_name = ?2", userId, newName);
@@ -290,7 +291,7 @@ export function renameNetwork(userId: string, networkId: string, newName: string
 }
 
 export function deleteNetwork(userId: string, networkId: string): { ok: boolean; error?: string } {
-  const net = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", networkId);
+  const net = db.get<any>("SELECT owner_id FROM networks WHERE network_id = ?1", networkId);
   if (!net) return { ok: false, error: "network not found" };
   if (net.owner_id !== userId) return { ok: false, error: "not your network" };
   // Check if any sessions/tasks still reference this network
@@ -449,7 +450,10 @@ export function createInvite(networkId: string, createdBy: string, role: string 
 }
 
 export function joinByInvite(inviteCode: string, userId: string): { ok: boolean; network_id?: string; role?: string; error?: string } {
-  const invite = db.get<any>("SELECT * FROM network_invites WHERE invite_code = ?1", inviteCode);
+  const invite = db.get<any>(
+    "SELECT invite_code, network_id, role, created_by, max_uses, used_count, expires_at, created_at FROM network_invites WHERE invite_code = ?1",
+    inviteCode,
+  );
   if (!invite) return { ok: false, error: "invalid invite code" };
   if (invite.max_uses > 0 && invite.used_count >= invite.max_uses) return { ok: false, error: "invite code fully used" };
   if (invite.expires_at) {
@@ -474,7 +478,7 @@ export function joinByInvite(inviteCode: string, userId: string): { ok: boolean;
 /** Get all networks a user is a member of (replaces owner-only query) */
 export function getUserAllNetworks(userId: string) {
   return db.all<any>(
-    `SELECT n.*, nm.role as member_role
+    `SELECT ${sqlColumns(NETWORK_REST_COLUMNS, "n")}, nm.role as member_role
      FROM networks n JOIN network_members nm ON n.network_id = nm.network_id
      WHERE nm.user_id = ?1 ORDER BY nm.role = 'owner' DESC, n.created_at`,
     userId);

--- a/server/src/rest-explicit-columns-http.test.ts
+++ b/server/src/rest-explicit-columns-http.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  AUDIT_LOG_REST_COLUMNS,
+  COMPLETION_REST_COLUMNS,
+  NETWORK_REST_COLUMNS,
+  SESSION_REST_COLUMNS,
+  TASK_EVENT_REST_COLUMNS,
+  TASK_REST_COLUMNS,
+  SCHEDULED_TASK_STORAGE_COLUMNS,
+} from "./rest-projections.js";
+
+const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-rest-columns-"));
+process.env.COMMHUB_DB ||= join(PRIVATE_DB_DIR, "hub.db");
+
+let db: typeof import("./db.js").db;
+let server: ReturnType<typeof Bun.serve>;
+let base = "";
+let token = "";
+let networkId = "";
+
+const INTERNAL_SENTINEL = "future_internal_only";
+const sortedKeys = (value: Record<string, unknown>): string[] => Object.keys(value).sort();
+const sorted = (values: readonly string[]): string[] => [...values].sort();
+
+async function api(path: string): Promise<any> {
+  const response = await fetch(`${base}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(response.status).toBe(200);
+  return response.json();
+}
+
+beforeAll(async () => {
+  ({ db } = await import("./db.js"));
+  const { register } = await import("./auth.js");
+  const auth = register(`rest_shape_${Date.now()}`, "RestShape-Strong-1!", undefined, "rest-shape");
+  expect(auth.ok).toBe(true);
+  token = auth.token!;
+  networkId = auth.network_id!;
+
+  // Simulate future migrations. Any REST SELECT * silently broadcasts these
+  // columns; every endpoint below must keep them private without needing a
+  // code change when the table grows.
+  for (const table of ["networks", "sessions", "audit_log", "task_events", "tasks", "completions", "scheduled_tasks"]) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${INTERNAL_SENTINEL} TEXT`);
+  }
+
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, agent, model, network_id)
+     VALUES ('resume-rest-shape', 'rest-shape-node', 'idle', 'agent-node:codex', 'gpt-shape', ?1)`,
+    [networkId],
+  );
+  db.run(
+    `INSERT INTO tasks (task_id, from_name, to_name, status, content, priority, network_id, parent_task_id, meta_json)
+     VALUES ('task-rest-shape', 'sender', 'rest-shape-node', 'delivered', 'shape', 'normal', ?1, 'parent-shape', '{"attachment":true}')`,
+    [networkId],
+  );
+  db.run(
+    `INSERT INTO task_events (task_id, from_status, to_status, actor, detail, network_id)
+     VALUES ('task-rest-shape', 'created', 'delivered', 'shape-test', 'shape', ?1)`,
+    [networkId],
+  );
+  db.run(
+    `INSERT INTO completions (id, session_name, task, result, network_id)
+     VALUES ('completion-rest-shape', 'rest-shape-node', 'shape', 'done', ?1)`,
+    [networkId],
+  );
+  db.run(
+    `INSERT INTO audit_log (user_id, username, action, target_type, target_id, detail, ip, network_id)
+     VALUES ((SELECT owner_id FROM networks WHERE network_id = ?1), 'shape-user', 'shape_action', 'shape', 'shape-id', 'shape', '127.0.0.1', ?1)`,
+    [networkId],
+  );
+  db.run(
+    `INSERT INTO scheduled_tasks
+       (schedule_id, network_id, created_by, name, target_node_id, target_alias,
+        task_content, schedule_type, schedule_json, timezone, next_run_at)
+     VALUES ('schedule-rest-shape', ?1, 'private-user-id', 'shape schedule',
+             'node-rest-shape', 'rest-shape-node', 'shape task', 'interval',
+             '{"type":"interval","every_seconds":3600}', 'UTC', '2099-01-01T00:00:00.000Z')`,
+    [networkId],
+  );
+
+  const mod = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop(true); } catch {}
+  try { rmSync(PRIVATE_DB_DIR, { recursive: true, force: true }); } catch {}
+});
+
+describe("#311 REST response projections are stable across future ALTER TABLE", () => {
+  test("network list and detail preserve their existing public keys", async () => {
+    const list = await api("/api/networks");
+    const row = list.networks.find((item: any) => item.network_id === networkId);
+    expect(sortedKeys(row)).toEqual(sorted([...NETWORK_REST_COLUMNS, "member_role", "name"]));
+    expect(row[INTERNAL_SENTINEL]).toBeUndefined();
+
+    const detail = await api(`/api/networks/${networkId}`);
+    expect(sortedKeys(detail.network)).toEqual(sorted(NETWORK_REST_COLUMNS));
+    expect(detail.network[INTERNAL_SENTINEL]).toBeUndefined();
+  });
+
+  test("full status preserves telemetry compatibility without storage drift", async () => {
+    const body = await api(`/api/status?network_id=${networkId}`);
+    const row = body.sessions.find((item: any) => item.alias === "rest-shape-node");
+    expect(sortedKeys(row)).toEqual(sorted([...SESSION_REST_COLUMNS, "runtime", "host", "process_telemetry"]));
+    expect(row[INTERNAL_SENTINEL]).toBeUndefined();
+  });
+
+  test("task list and task detail expose the same explicit contract", async () => {
+    const list = await api(`/api/tasks?network_id=${networkId}&task_id=task-rest-shape&skip_stats=1`);
+    expect(sortedKeys(list.tasks[0])).toEqual(sorted(TASK_REST_COLUMNS));
+    expect(list.tasks[0][INTERNAL_SENTINEL]).toBeUndefined();
+
+    const detail = await api(`/api/tasks/task-rest-shape?network_id=${networkId}`);
+    expect(sortedKeys(detail.task)).toEqual(sorted(TASK_REST_COLUMNS));
+    expect(detail.task[INTERNAL_SENTINEL]).toBeUndefined();
+  });
+
+  test("audit, task-event, and completion rows are explicit", async () => {
+    const audit = await api("/api/audit-log?action=shape_action");
+    expect(sortedKeys(audit.logs[0])).toEqual(sorted(AUDIT_LOG_REST_COLUMNS));
+    expect(audit.logs[0][INTERNAL_SENTINEL]).toBeUndefined();
+
+    const events = await api(`/api/task_events?network_id=${networkId}&task_id=task-rest-shape`);
+    expect(sortedKeys(events.events[0])).toEqual(sorted(TASK_EVENT_REST_COLUMNS));
+    expect(events.events[0][INTERNAL_SENTINEL]).toBeUndefined();
+
+    const completions = await api(`/api/completions?network_id=${networkId}&since=2000-01-01T00:00:00.000Z`);
+    expect(sortedKeys(completions.completions[0])).toEqual(sorted(COMPLETION_REST_COLUMNS));
+    expect(completions.completions[0][INTERNAL_SENTINEL]).toBeUndefined();
+  });
+
+  test("scheduled-task decoding keeps storage-only identity and JSON private", async () => {
+    const body = await api(`/api/scheduled-tasks?network_id=${networkId}`);
+    const row = body.schedules.find((item: any) => item.schedule_id === "schedule-rest-shape");
+    const publicColumns = SCHEDULED_TASK_STORAGE_COLUMNS.filter((key) => key !== "created_by" && key !== "schedule_json");
+    expect(sortedKeys(row)).toEqual(sorted([...publicColumns, "schedule"]));
+    expect(row.created_by).toBeUndefined();
+    expect(row.schedule_json).toBeUndefined();
+    expect(row[INTERNAL_SENTINEL]).toBeUndefined();
+  });
+});

--- a/server/src/rest-projections.ts
+++ b/server/src/rest-projections.ts
@@ -1,0 +1,66 @@
+/**
+ * Stable REST row projections.
+ *
+ * These lists deliberately mirror the fields already exposed by the public
+ * endpoints before #311.  Keeping them in one place makes the wire contract
+ * independent from future ALTER TABLE migrations: adding a storage-only
+ * column must never silently add a REST response key.
+ */
+export const NETWORK_REST_COLUMNS = [
+  "network_id", "network_name", "owner_id", "description", "settings",
+  "created_at", "updated_at", "visibility", "max_members",
+] as const;
+
+export const SESSION_REST_COLUMNS = [
+  "resume_id", "alias", "tmux_name", "server", "ip", "hostname", "agent",
+  "project_dir", "version", "status", "task", "output", "progress", "score",
+  "cpu_load_1min", "cpu_cores", "mem_total_gb", "mem_used_gb", "mem_avail_gb",
+  "disk_total_gb", "disk_used_gb", "disk_avail_gb", "process_rss_bytes",
+  "process_rss_mb", "process_cpu_pct", "process_uptime_seconds",
+  "process_in_flight_count", "network_id", "registered_at", "updated_at",
+  "node_id", "session_id", "config_path", "channels", "last_seen_at", "model",
+] as const;
+
+export const AUDIT_LOG_REST_COLUMNS = [
+  "id", "user_id", "username", "action", "target_type", "target_id", "detail",
+  "ip", "network_id", "created_at",
+] as const;
+
+export const TASK_EVENT_REST_COLUMNS = [
+  "id", "task_id", "from_status", "to_status", "actor", "detail", "created_at",
+  "network_id",
+] as const;
+
+export const TASK_REST_COLUMNS = [
+  "task_id", "from_node_id", "from_name", "to_node_id", "to_name", "priority",
+  "status", "content", "result", "in_reply_to", "requires_response", "scope",
+  "created_at", "delivered_at", "started_at", "completed_at", "expires_at",
+  "network_id", "parent_task_id", "meta_json",
+] as const;
+
+export const COMPLETION_REST_COLUMNS = [
+  "id", "session_name", "task", "result", "artifacts", "score",
+  "duration_minutes", "network_id", "completed_at",
+] as const;
+
+// Storage projection for scheduled-task rows. `created_by` and
+// `schedule_json` are intentionally selected for server-side auth/decoding,
+// then removed by decodeRow before the REST response is serialized.
+export const SCHEDULED_TASK_STORAGE_COLUMNS = [
+  "schedule_id", "network_id", "created_by", "name", "target_node_id",
+  "target_alias", "task_content", "priority", "schedule_type", "schedule_json",
+  "timezone", "overlap_policy", "misfire_policy", "status", "next_run_at",
+  "last_run_at", "revision", "created_at", "updated_at",
+] as const;
+
+export function sqlColumns(columns: readonly string[], qualifier?: string): string {
+  return columns.map((column) => qualifier ? `${qualifier}.${column}` : column).join(", ");
+}
+
+export const NETWORK_REST_SELECT = sqlColumns(NETWORK_REST_COLUMNS);
+export const SESSION_REST_SELECT = sqlColumns(SESSION_REST_COLUMNS);
+export const AUDIT_LOG_REST_SELECT = sqlColumns(AUDIT_LOG_REST_COLUMNS);
+export const TASK_EVENT_REST_SELECT = sqlColumns(TASK_EVENT_REST_COLUMNS);
+export const TASK_REST_SELECT = sqlColumns(TASK_REST_COLUMNS);
+export const COMPLETION_REST_SELECT = sqlColumns(COMPLETION_REST_COLUMNS);
+export const SCHEDULED_TASK_STORAGE_SELECT = sqlColumns(SCHEDULED_TASK_STORAGE_COLUMNS);

--- a/server/src/scheduled-tasks.ts
+++ b/server/src/scheduled-tasks.ts
@@ -2,6 +2,7 @@ import { db, logTaskEvent } from "./db.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { addNetworkScope, canRestWriteNetwork, singleNetworkId, type RestNetworkScope } from "./network-scope.js";
 import { pushEvent, pushNetworkObserverEvent } from "./push.js";
+import { SCHEDULED_TASK_STORAGE_SELECT } from "./rest-projections.js";
 
 export type ScheduleSpec =
   | { type: "once"; run_at: string }
@@ -178,7 +179,7 @@ function decodeRow(row: ScheduledRow): Record<string, unknown> {
 
 function scopedSchedule(scheduleId: string, scope: RestNetworkScope): ScheduledRow | null {
   const params: unknown[] = [scheduleId];
-  let sql = "SELECT * FROM scheduled_tasks WHERE schedule_id = ?1";
+  let sql = `SELECT ${SCHEDULED_TASK_STORAGE_SELECT} FROM scheduled_tasks WHERE schedule_id = ?1`;
   sql = addNetworkScope(sql, params, scope);
   return db.get<ScheduledRow>(sql, ...params);
 }
@@ -346,7 +347,7 @@ function skipScheduledMisfire(row: ScheduledRow, scheduledFor: string, now: Date
 
 export function runDueScheduledTasks(now = new Date(), limit = 100): { processed: number; failed: number } {
   const due = db.all<ScheduledRow>(
-    "SELECT * FROM scheduled_tasks WHERE status = 'active' AND next_run_at IS NOT NULL AND next_run_at <= ?1 ORDER BY next_run_at LIMIT ?2",
+    `SELECT ${SCHEDULED_TASK_STORAGE_SELECT} FROM scheduled_tasks WHERE status = 'active' AND next_run_at IS NOT NULL AND next_run_at <= ?1 ORDER BY next_run_at LIMIT ?2`,
     iso(now), limit,
   );
   let processed = 0;
@@ -355,7 +356,7 @@ export function runDueScheduledTasks(now = new Date(), limit = 100): { processed
     try {
       // Re-read inside the claim path so a pause/cancel immediately before the
       // tick wins. The unique occurrence key handles a second scheduler.
-      const current = db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1 AND status = 'active' AND next_run_at = ?2", row.schedule_id, row.next_run_at);
+      const current = db.get<ScheduledRow>(`SELECT ${SCHEDULED_TASK_STORAGE_SELECT} FROM scheduled_tasks WHERE schedule_id = ?1 AND status = 'active' AND next_run_at = ?2`, row.schedule_id, row.next_run_at);
       if (!current?.next_run_at) continue;
       if (current.misfire_policy === "skip" && isMissedOccurrence(current.next_run_at, now)) {
         skipScheduledMisfire(current, current.next_run_at, now);
@@ -406,7 +407,7 @@ export async function handleScheduledTaskRequest(ctx: ScheduledRequestContext): 
 
   if (url.pathname === "/api/scheduled-tasks" && req.method === "GET") {
     const params: unknown[] = [];
-    let sql = "SELECT * FROM scheduled_tasks WHERE 1=1";
+    let sql = `SELECT ${SCHEDULED_TASK_STORAGE_SELECT} FROM scheduled_tasks WHERE 1=1`;
     sql = addNetworkScope(sql, params, ctx.scope);
     const status = url.searchParams.get("status");
     if (status) { sql += ` AND status = ?${params.length + 1}`; params.push(status); }
@@ -439,7 +440,7 @@ export async function handleScheduledTaskRequest(ctx: ScheduledRequestContext): 
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'skip', ?12, ?13)`,
         [scheduleId, networkId, ctx.auth?.userId ?? null, name, target.node_id, target.alias, content, priority, spec.type, JSON.stringify(spec), timezone, misfirePolicy, iso(next)],
       );
-      const created = db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1", scheduleId)!;
+      const created = db.get<ScheduledRow>(`SELECT ${SCHEDULED_TASK_STORAGE_SELECT} FROM scheduled_tasks WHERE schedule_id = ?1`, scheduleId)!;
       return Response.json({ ok: true, schedule: decodeRow(created) }, { status: 201 });
     } catch (e: any) {
       const code = String(e?.message || "invalid_schedule");
@@ -525,7 +526,7 @@ export async function handleScheduledTaskRequest(ctx: ScheduledRequestContext): 
         [name, target.node_id, target.alias, content, priority, parsed.spec.type, scheduleJson, parsed.timezone, requestedStatus, next ? iso(next) : null, misfirePolicy, row.schedule_id, row.revision],
       );
       if (updated.changes !== 1) return jsonError("revision_conflict", 409);
-      return Response.json({ ok: true, schedule: decodeRow(db.get<ScheduledRow>("SELECT * FROM scheduled_tasks WHERE schedule_id = ?1", row.schedule_id)!) });
+      return Response.json({ ok: true, schedule: decodeRow(db.get<ScheduledRow>(`SELECT ${SCHEDULED_TASK_STORAGE_SELECT} FROM scheduled_tasks WHERE schedule_id = ?1`, row.schedule_id)!) });
     } catch (e: any) {
       const code = String(e?.message || "invalid_schedule");
       return jsonError(code, code === "target_node_not_found" ? 404 : 400);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -33,6 +33,14 @@ import { mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from "fs
 import { dirname as pathDirname } from "path";
 import { startRetentionSweeper } from "./retention.js";
 import { startStaleSessionSweeper } from "./stale-sweeper.js";
+import {
+  AUDIT_LOG_REST_SELECT,
+  COMPLETION_REST_SELECT,
+  NETWORK_REST_SELECT,
+  SESSION_REST_SELECT,
+  TASK_EVENT_REST_SELECT,
+  TASK_REST_SELECT,
+} from "./rest-projections.js";
 import { resolveRestFromSession } from "./rest-identity.js";
 import { stampTaskAuthOrigin, type TaskAuthOrigin } from "./task-auth-origin.js";
 import { assertScheduledTaskBackendSupported, handleScheduledTaskRequest, startScheduledTaskScheduler } from "./scheduled-tasks.js";
@@ -851,7 +859,9 @@ return Bun.serve({
 
     // ── V3: License endpoints ──
     if (url.pathname === "/api/license" && req.method === "GET") {
-      const license = db.get<any>("SELECT * FROM licenses ORDER BY created_at LIMIT 1");
+      const license = db.get<any>(
+        "SELECT type, expires_at, max_agents, max_networks, max_tasks_day FROM licenses ORDER BY created_at LIMIT 1",
+      );
       if (!license) return withCors(req, Response.json({ ok: true, status: "no_license" }));
       const now = new Date().toISOString().replace("T", " ").slice(0, 19);
       const expired = license.expires_at && license.expires_at < now;
@@ -1109,7 +1119,7 @@ return Bun.serve({
       // V3.13: ntok_ can only see its bound network; utok_ sees all member networks
       if (resolved.networkId) {
         // ntok_ — only return the bound network
-        const net = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", resolved.networkId);
+        const net = db.get<any>(`SELECT ${NETWORK_REST_SELECT} FROM networks WHERE network_id = ?1`, resolved.networkId);
         return withCors(req, Response.json({ ok: true, networks: net ? [withNetworkNameAlias(net)] : [] }));
       }
       const networks = getUserAllNetworks(resolved.user.user_id).map(withNetworkNameAlias);
@@ -1215,7 +1225,7 @@ return Bun.serve({
       const resolved = resolveToken(token);
       if (!resolved) return withCors(req, Response.json({ ok: false, error: "invalid token" }, { status: 401 }));
       const networkId = netDetailMatch[1];
-      const network = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", networkId);
+      const network = db.get<any>(`SELECT ${NETWORK_REST_SELECT} FROM networks WHERE network_id = ?1`, networkId);
       if (!network) return withCors(req, Response.json({ ok: false, error: "network not found" }, { status: 404 }));
       // Membership check: must be a member or system admin
       const viewerRole = getUserNetworkRole(resolved.user.user_id, networkId);
@@ -1444,10 +1454,10 @@ return Bun.serve({
       const params: any[] = [];
       let sql = isLight
         ? "SELECT alias, status, agent, task, server, updated_at, network_id FROM sessions WHERE 1=1"
-        : "SELECT * FROM sessions WHERE 1=1";
+        : `SELECT ${SESSION_REST_SELECT} FROM sessions WHERE 1=1`;
       sql = addNetworkScope(sql, params, restScope);
       sql += " ORDER BY updated_at DESC";
-      // `model` comes straight from the sessions row (SELECT *); `runtime` is
+      // `model` comes straight from the explicit sessions projection; `runtime` is
       // derived from the raw `agent` field. Both default to null for old nodes
       // that never reported a model — the dashboard falls back to a placeholder.
       const sessions = db.all(sql, ...params).map((s: any) => {
@@ -1845,7 +1855,7 @@ return Bun.serve({
       }
 
       if (uploadNetId !== null) {
-        const networkRow = db.get<any>("SELECT * FROM networks WHERE network_id = ?1", uploadNetId);
+        const networkRow = db.get<any>("SELECT network_id FROM networks WHERE network_id = ?1", uploadNetId);
         if (!networkRow) {
           if (principal.kind === "admin-utok" || principal.kind === "legacy-master") {
             return earlyReject(Response.json({
@@ -2475,7 +2485,7 @@ return Bun.serve({
       const limit = Math.min(Number(url.searchParams.get("limit")) || 50, 200);
       const action = url.searchParams.get("action");
       const userId = url.searchParams.get("user_id");
-      let sql = "SELECT * FROM audit_log WHERE 1=1";
+      let sql = `SELECT ${AUDIT_LOG_REST_SELECT} FROM audit_log WHERE 1=1`;
       const params: any[] = [];
       // Non-admin can only see own logs
       if (resolved.user.role !== "admin") { sql += ` AND user_id = ?${params.length + 1}`; params.push(resolved.user.user_id); }
@@ -2491,7 +2501,7 @@ return Bun.serve({
     if (url.pathname === "/api/task_events") {
       const taskId = url.searchParams.get("task_id");
       const limit = Math.min(Number(url.searchParams.get("limit")) || 50, 500);
-      let sql = "SELECT * FROM task_events WHERE 1=1";
+      let sql = `SELECT ${TASK_EVENT_REST_SELECT} FROM task_events WHERE 1=1`;
       const params: any[] = [];
       sql = addNetworkScope(sql, params, restScope);
       if (taskId) { sql += ` AND task_id = ?${params.length + 1}`; params.push(taskId); }
@@ -2506,7 +2516,7 @@ return Bun.serve({
     if (nodeDeleteMatch && req.method === "DELETE") {
       const ref = decodeURIComponent(nodeDeleteMatch[1]);
       const params: any[] = [ref, ref, ref];
-      let sql = "SELECT * FROM nodes WHERE (node_id = ?1 OR node_name = ?2 OR alias = ?3)";
+      let sql = "SELECT node_id, node_name, alias, network_id FROM nodes WHERE (node_id = ?1 OR node_name = ?2 OR alias = ?3)";
       sql = addNetworkScope(sql, params, restScope);
       sql += " ORDER BY updated_at DESC LIMIT 1";
       const node = db.get<any>(sql, ...params);
@@ -2929,7 +2939,7 @@ return Bun.serve({
     if (taskPathMatch && req.method === "GET") {
       const taskId = decodeURIComponent(taskPathMatch[1] ?? "");
       const params: any[] = [taskId];
-      let sql = "SELECT * FROM tasks WHERE task_id = ?1";
+      let sql = `SELECT ${TASK_REST_SELECT} FROM tasks WHERE task_id = ?1`;
       sql = addNetworkScope(sql, params, restScope);
       sql += " LIMIT 1";
       const task = db.get(sql, ...params);
@@ -2963,7 +2973,7 @@ return Bun.serve({
       // {ok, tasks, count, stats} shape — backwards-compatible.
       const skipStats = url.searchParams.get("skip_stats") === "1";
 
-      let sql = "SELECT * FROM tasks WHERE 1=1";
+      let sql = `SELECT ${TASK_REST_SELECT} FROM tasks WHERE 1=1`;
       const params: any[] = [];
       sql = addNetworkScope(sql, params, restScope);
       if (taskId) { sql += ` AND task_id = ?${params.length + 1}`; params.push(taskId); }
@@ -2998,7 +3008,7 @@ return Bun.serve({
     if (url.pathname === "/api/completions") {
       const since = url.searchParams.get("since") ?? new Date(Date.now() - 86400000).toISOString();
       const params: any[] = [since];
-      let sql = "SELECT * FROM completions WHERE completed_at >= ?1";
+      let sql = `SELECT ${COMPLETION_REST_SELECT} FROM completions WHERE completed_at >= ?1`;
       sql = addNetworkScope(sql, params, restScope);
       sql += " ORDER BY completed_at DESC LIMIT 100";
       const rows = db.all(sql, ...params);

--- a/tests/test647-rest-explicit-columns/Dockerfile
+++ b/tests/test647-rest-explicit-columns/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test647-rest-explicit-columns/run.sh /run.sh
+
+ARG TEST647_SOURCE_COMMIT=unknown
+ENV TEST647_SOURCE_COMMIT=$TEST647_SOURCE_COMMIT
+
+RUN chmod 0755 /run.sh
+ENTRYPOINT ["/run.sh"]

--- a/tests/test647-rest-explicit-columns/run.sh
+++ b/tests/test647-rest-explicit-columns/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test647-rest-explicit-columns.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+cd /workspace
+
+echo "# test647 — REST explicit-column response contracts"
+echo "source_commit=${TEST647_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_shape_test() {
+  local db_path=$1
+  COMMHUB_DB="$db_path" bun test server/src/rest-explicit-columns-http.test.ts
+}
+
+echo "L0: production Hub build"
+bun build server/src/index.ts --target bun --outfile /tmp/test647-hub.js
+test -s /tmp/test647-hub.js
+
+echo "L1: exhaustive REST SELECT-star classification"
+if grep -En '["`]SELECT ([A-Za-z]+\.)?\* FROM' server/src/server.ts server/src/auth.ts server/src/scheduled-tasks.ts; then
+  echo "FAIL: REST-facing source still contains SELECT *"
+  exit 1
+fi
+echo "PASS: REST-facing source has zero SELECT-star queries"
+
+echo "L2: live HTTP shape + future-column sentinel"
+run_shape_test /tmp/test647-green.db
+
+cp server/src/server.ts /tmp/test647-server.ts
+cp server/src/auth.ts /tmp/test647-auth.ts
+cp server/src/scheduled-tasks.ts /tmp/test647-scheduled-tasks.ts
+
+echo "L3a witnessed-red: task list SELECT-star leaks future column"
+sed -i 's/SELECT ${TASK_REST_SELECT} FROM tasks WHERE 1=1/SELECT * FROM tasks WHERE 1=1/' server/src/server.ts
+grep -Fq 'SELECT * FROM tasks WHERE 1=1' server/src/server.ts
+set +e
+run_shape_test /tmp/test647-mut-task.db >/tmp/test647-mut-task.log 2>&1
+task_rc=$?
+set -e
+test "$task_rc" -ne 0
+grep -Fq 'future_internal_only' /tmp/test647-mut-task.log
+echo "MUTATION_RED: task-rest-select-star rc=$task_rc"
+cp /tmp/test647-server.ts server/src/server.ts
+
+echo "L3b witnessed-red: network membership SELECT-star leaks future column"
+sed -i 's/SELECT ${sqlColumns(NETWORK_REST_COLUMNS, "n")}, nm.role as member_role/SELECT n.*, nm.role as member_role/' server/src/auth.ts
+grep -Fq 'SELECT n.*, nm.role as member_role' server/src/auth.ts
+set +e
+run_shape_test /tmp/test647-mut-network.db >/tmp/test647-mut-network.log 2>&1
+network_rc=$?
+set -e
+test "$network_rc" -ne 0
+grep -Fq 'future_internal_only' /tmp/test647-mut-network.log
+echo "MUTATION_RED: network-rest-select-star rc=$network_rc"
+cp /tmp/test647-auth.ts server/src/auth.ts
+
+echo "L3c witnessed-red: scheduled-task SELECT-star leaks future column"
+sed -i '0,/SELECT ${SCHEDULED_TASK_STORAGE_SELECT} FROM scheduled_tasks WHERE 1=1/s//SELECT * FROM scheduled_tasks WHERE 1=1/' server/src/scheduled-tasks.ts
+grep -Fq 'SELECT * FROM scheduled_tasks WHERE 1=1' server/src/scheduled-tasks.ts
+set +e
+run_shape_test /tmp/test647-mut-schedule.db >/tmp/test647-mut-schedule.log 2>&1
+schedule_rc=$?
+set -e
+test "$schedule_rc" -ne 0
+grep -Fq 'future_internal_only' /tmp/test647-mut-schedule.log
+echo "MUTATION_RED: schedule-rest-select-star rc=$schedule_rc"
+cp /tmp/test647-scheduled-tasks.ts server/src/scheduled-tasks.ts
+
+echo "L4: restored source remains green"
+run_shape_test /tmp/test647-restored.db
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #311.

## What changed
- replaces every REST-facing `SELECT *` in `server.ts`, `auth.ts`, and `scheduled-tasks.ts` with centralized explicit projections
- preserves every currently exposed response key after auditing Dashboard, mobile App, CLI/docs consumers
- narrows internal existence/ownership reads to the fields they actually use
- leaves MCP-only `tools.ts` and internal rename-2PC queries out of this REST change

## Evidence
- tested source: `ec66f1172de03ab0cd3cb63872021562ce7844ef`
- report-only head: `539f0bab6085f05f930b3909d5ff38c1f00ce9bc`
- Docker image: `anet-test647:dev` / `sha256:dd865aa7c940db923b6180507fb5d6e48a12f229b43967af5f50f7ff28d6ce76`
- production Hub build: PASS (258 modules)
- real HTTP + SQLite shape gate: 5 pass / 29 assertions
- every backing table gets a synthetic `future_internal_only` column; all REST responses exclude it
- witnessed-red mutations: tasks `SELECT *`, networks `n.*`, scheduled-tasks `SELECT *` each fail with the sentinel leak
- report: `docs/tests/report-test647-rest-explicit-columns.txt`

No merge, publish, or deployment performed.