### PR TITLE
fix(probe): pin validated DNS addresses across Node and Bun

### DIFF
--- a/agent-node/src/runtime/probe-daemon.test.ts
+++ b/agent-node/src/runtime/probe-daemon.test.ts
@@ -2,9 +2,53 @@ import { describe, expect, test } from "bun:test";
 import {
   assertSecureTlsEnv,
   classifyProbeResponse,
+  createPinnedLookup,
   handleProbeDoorbell,
   safelyFetchProbe,
 } from "./probe-daemon.js";
+
+function callPinnedLookup(
+  lookup: ReturnType<typeof createPinnedLookup>,
+  hostname: string,
+  options: any,
+): Promise<any[]> {
+  return new Promise((resolve) => {
+    (lookup as any)(hostname, options, (...args: any[]) => resolve(args));
+  });
+}
+
+describe("createPinnedLookup — Node/Bun lookup callback contract", () => {
+  const addresses = [
+    { address: "192.0.2.10", family: 4 },
+    { address: "2001:db8::10", family: 6 },
+  ] as const;
+
+  test("single-address callback honors requested family", async () => {
+    const args = await callPinnedLookup(createPinnedLookup("api.example.test", addresses), "api.example.test", { family: 6 });
+    expect(args).toEqual([null, "2001:db8::10", 6]);
+  });
+
+  test("all-address callback returns only pinned copies", async () => {
+    const args = await callPinnedLookup(createPinnedLookup("api.example.test", addresses), "API.EXAMPLE.TEST.", { all: true });
+    expect(args).toEqual([null, [
+      { address: "192.0.2.10", family: 4 },
+      { address: "2001:db8::10", family: 6 },
+    ]]);
+  });
+
+  test("wrong hostname and unavailable family fail closed without fallback", async () => {
+    for (const [hostname, options] of [
+      ["rebound.example.test", {}],
+      ["api.example.test", { family: 6 }],
+    ] as const) {
+      const onlyV4 = createPinnedLookup("api.example.test", [addresses[0]]);
+      const args = await callPinnedLookup(onlyV4, hostname, options);
+      expect(args[0]).toBeInstanceOf(Error);
+      expect(args[0].code).toBe("ENOTFOUND");
+      expect(args).toHaveLength(1);
+    }
+  });
+});
 
 describe("assertSecureTlsEnv (boot guard)", () => {
   test("clean env passes", () => {

--- a/agent-node/src/runtime/probe-daemon.ts
+++ b/agent-node/src/runtime/probe-daemon.ts
@@ -127,6 +127,30 @@ export function createPinnedLookup(
   }) as LookupFunction;
 }
 
+async function discardProbeResponseBody(body: any): Promise<void> {
+  // Node's undici BodyReadable exposes dump(); Bun's compatible request API
+  // currently returns a Web ReadableStream instead. Probe classification only
+  // needs the status, so release either representation without assuming one
+  // runtime's private body surface.
+  if (typeof body?.dump === "function") {
+    await body.dump();
+    return;
+  }
+  if (typeof body?.cancel === "function") {
+    await body.cancel();
+    return;
+  }
+  if (typeof body?.getReader === "function") {
+    await body.getReader().cancel();
+    return;
+  }
+  if (body?.[Symbol.asyncIterator]) {
+    for await (const _chunk of body) {
+      // Drain unknown compatible stream shapes to release the connection.
+    }
+  }
+}
+
 export async function safelyFetchProbe(
   vendor: string,
   baseUrl: string,
@@ -200,7 +224,7 @@ export async function safelyFetchProbe(
       signal: AbortSignal.timeout(30_000),
     });
     resp = { status: wire.statusCode } as Response;
-    await wire.body.dump();
+    await discardProbeResponseBody(wire.body);
   } catch (e: any) {
     const msg = String(e?.message || e);
     if (/timeout|abort/i.test(msg)) return { errorKind: "timeout", errorDetail: msg.slice(0, 200) };

--- a/agent-node/src/runtime/probe-daemon.ts
+++ b/agent-node/src/runtime/probe-daemon.ts
@@ -13,7 +13,9 @@
 // hub fabricates a base_url, daemon stays strict.
 
 import { promises as dns } from "node:dns";
-import { Agent, fetch as undiciFetch } from "undici";
+import type { LookupAddress } from "node:dns";
+import type { LookupFunction } from "node:net";
+import { Agent, request as undiciRequest } from "undici";
 import {
   isForbiddenIp,
   isLoopbackHost,
@@ -69,15 +71,60 @@ function buildProbeForVendor(vendor: string, baseUrl: string, model: string, api
 // DNS-resolve hostname → assert every A/AAAA record is NOT in the
 // forbidden IP set → fetch via undici with manual redirect (3xx →
 // probe_redirect_forbidden). TLS validation is mandatory (dispatcher
-// rejectUnauthorized:true + minVersion TLSv1.2). The customLookup
-// pin-IP guard against TOCTOU rebinding between our resolve and
-// undici's connect is deferred to P1.5 (undici Agent.connect.lookup
-// API is brittle across Bun + Node versions; see RFC-028 §10 P1.5).
+// rejectUnauthorized:true + minVersion TLSv1.2). The connector lookup is
+// pinned to the already-validated address set, closing the DNS-rebinding
+// window between validation and connect while keeping the vendor hostname in
+// the URL for SNI and certificate verification.
 
 export interface SafeFetchResult {
   resp?: Response;
   errorKind: null | "network_error" | "timeout" | "tls_error" | "redirect_forbidden" | "probe_resolve_unsafe_ip" | "probe_target_forbidden";
   errorDetail?: string;
+}
+
+export type ProbeHostResolver = (hostname: string) => Promise<LookupAddress[]>;
+
+function normalizedHostname(hostname: string): string {
+  return hostname.trim().replace(/\.$/, "").toLowerCase();
+}
+
+/** Build the exact node:dns lookup contract consumed by undici's connector.
+ * The callback can request one address or `{all:true}` and may constrain the
+ * family. It can never fall back to system DNS or answer for a different
+ * hostname. */
+export function createPinnedLookup(
+  expectedHostname: string,
+  validatedAddresses: readonly LookupAddress[],
+): LookupFunction {
+  const expected = normalizedHostname(expectedHostname);
+  const pinned = validatedAddresses.map(({ address, family }) => ({ address, family }));
+  let cursor = 0;
+
+  return ((hostname: string, options: any, callback: (...args: any[]) => void) => {
+    const requested = normalizedHostname(hostname);
+    const family = typeof options === "number" ? options : Number(options?.family || 0);
+    const all = typeof options === "object" && options?.all === true;
+    const eligible = requested === expected
+      ? pinned.filter((entry) => family !== 4 && family !== 6 ? true : entry.family === family)
+      : [];
+
+    queueMicrotask(() => {
+      if (eligible.length === 0) {
+        const error = Object.assign(new Error("probe_pinned_lookup_no_match"), {
+          code: "ENOTFOUND",
+          hostname,
+        });
+        callback(error);
+        return;
+      }
+      if (all) {
+        callback(null, eligible.map((entry) => ({ ...entry })));
+        return;
+      }
+      const selected = eligible[cursor++ % eligible.length];
+      callback(null, selected.address, selected.family);
+    });
+  }) as LookupFunction;
 }
 
 export async function safelyFetchProbe(
@@ -86,6 +133,7 @@ export async function safelyFetchProbe(
   model: string,
   apiKey: string,
   env: NodeJS.ProcessEnv = process.env,
+  resolveHost: ProbeHostResolver = (hostname) => dns.lookup(hostname, { all: true }),
 ): Promise<SafeFetchResult> {
   // Boot TLS env guard (cheap, repeat on every probe in case env
   // was injected after boot).
@@ -99,7 +147,7 @@ export async function safelyFetchProbe(
   // DNS resolve ALL A/AAAA records (anti single-record cherry-pick).
   let addrs: { address: string; family: number }[];
   try {
-    addrs = await dns.lookup(u.hostname, { all: true });
+    addrs = await resolveHost(u.hostname);
   } catch (e: any) {
     return { errorKind: "network_error", errorDetail: e?.message || "dns lookup failed" };
   }
@@ -121,15 +169,16 @@ export async function safelyFetchProbe(
       return { errorKind: "probe_resolve_unsafe_ip", errorDetail: `resolved IP ${a.address} in forbidden range` };
     }
   }
-  // P1 narrows the rebinding window to a single DNS roundtrip (our
-  // dns.lookup validated all records; undici will re-resolve when
-  // connecting). P1.5 will close this with a customLookup that pins
-  // the validated IP set into the connector — see RFC-028 §10.
-  void addrs;
   // Hardened TLS guarded by dispatcher: rejectUnauthorized:true,
-  // minVersion TLSv1.2.
+  // minVersion TLSv1.2. lookup is the only connector resolver: it answers
+  // from the validated set and rejects another hostname/family rather than
+  // consulting DNS again.
   const dispatcher = new Agent({
-    connect: { rejectUnauthorized: true, minVersion: "TLSv1.2" },
+    connect: {
+      lookup: createPinnedLookup(u.hostname, addrs),
+      rejectUnauthorized: true,
+      minVersion: "TLSv1.2",
+    },
     bodyTimeout: 30_000,
     headersTimeout: 30_000,
   });
@@ -138,18 +187,31 @@ export async function safelyFetchProbe(
 
   let resp: any;
   try {
-    resp = await undiciFetch(probeReq.url, {
-      ...probeReq.init,
-      // @ts-expect-error: undici fetch accepts dispatcher option
+    // Bun's `undici.fetch` compatibility surface currently ignores the
+    // dispatcher's connect.lookup hook. The lower-level request API honors
+    // the dispatcher in both Node and Bun; test648's split-horizon socket
+    // probe locks that runtime fact.
+    const wire = await undiciRequest(probeReq.url, {
+      method: probeReq.init.method as any,
+      headers: probeReq.init.headers as any,
+      body: probeReq.init.body as any,
       dispatcher,
-      redirect: "manual",
+      maxRedirections: 0,
       signal: AbortSignal.timeout(30_000),
     });
+    resp = { status: wire.statusCode } as Response;
+    await wire.body.dump();
   } catch (e: any) {
     const msg = String(e?.message || e);
     if (/timeout|abort/i.test(msg)) return { errorKind: "timeout", errorDetail: msg.slice(0, 200) };
     if (/cert|tls|ssl|handshake/i.test(msg)) return { errorKind: "tls_error", errorDetail: msg.slice(0, 200) };
     return { errorKind: "network_error", errorDetail: msg.slice(0, 200) };
+  } finally {
+    // Bun's undici-compatible Agent does not currently expose close(); Node's
+    // real undici Agent does. Close when available without turning cleanup API
+    // drift into a probe failure.
+    const close = (dispatcher as any).close;
+    if (typeof close === "function") await close.call(dispatcher).catch(() => {});
   }
   if (resp.status >= 300 && resp.status < 400) {
     return { errorKind: "redirect_forbidden", errorDetail: `status=${resp.status}` };

--- a/agent-node/src/runtime/probe-daemon.ts
+++ b/agent-node/src/runtime/probe-daemon.ts
@@ -14,6 +14,7 @@
 
 import { promises as dns } from "node:dns";
 import type { LookupAddress } from "node:dns";
+import { request as httpsRequest } from "node:https";
 import type { LookupFunction } from "node:net";
 import { Agent, request as undiciRequest } from "undici";
 import {
@@ -151,6 +152,37 @@ async function discardProbeResponseBody(body: any): Promise<void> {
   }
 }
 
+async function requestWithPinnedNodeHttps(
+  probeReq: ProbeReq,
+  lookup: LookupFunction,
+): Promise<number> {
+  const target = new URL(probeReq.url);
+  return await new Promise<number>((resolve, reject) => {
+    const req = httpsRequest({
+      protocol: target.protocol,
+      hostname: target.hostname,
+      port: target.port || undefined,
+      path: `${target.pathname}${target.search}`,
+      method: probeReq.init.method,
+      headers: probeReq.init.headers as any,
+      lookup,
+      servername: target.hostname,
+      rejectUnauthorized: true,
+      minVersion: "TLSv1.2",
+      agent: false,
+      signal: AbortSignal.timeout(30_000),
+    }, (response) => {
+      const status = response.statusCode || 0;
+      response.resume();
+      response.once("end", () => resolve(status));
+      response.once("error", reject);
+    });
+    req.once("error", reject);
+    if (probeReq.init.body != null) req.write(probeReq.init.body as any);
+    req.end();
+  });
+}
+
 export async function safelyFetchProbe(
   vendor: string,
   baseUrl: string,
@@ -211,20 +243,27 @@ export async function safelyFetchProbe(
 
   let resp: any;
   try {
-    // Bun's `undici.fetch` compatibility surface currently ignores the
-    // dispatcher's connect.lookup hook. The lower-level request API honors
-    // the dispatcher in both Node and Bun; test648's split-horizon socket
-    // probe locks that runtime fact.
-    const wire = await undiciRequest(probeReq.url, {
-      method: probeReq.init.method as any,
-      headers: probeReq.init.headers as any,
-      body: probeReq.init.body as any,
-      dispatcher,
-      maxRedirections: 0,
-      signal: AbortSignal.timeout(30_000),
-    });
-    resp = { status: wire.statusCode } as Response;
-    await discardProbeResponseBody(wire.body);
+    const pinnedLookup = createPinnedLookup(u.hostname, addrs);
+    if (typeof (globalThis as any).Bun !== "undefined") {
+      // Bun 1.3's undici compatibility layer accepts `dispatcher` but ignores
+      // its connect.lookup hook (witnessed by test648 against split-horizon
+      // targets). Its node:https implementation does honor the same lookup
+      // callback, preserving hostname SNI/certificate validation. This is a
+      // fail-closed compatibility transport, not an unpinned DNS fallback.
+      const status = await requestWithPinnedNodeHttps(probeReq, pinnedLookup);
+      resp = { status } as Response;
+    } else {
+      const wire = await undiciRequest(probeReq.url, {
+        method: probeReq.init.method as any,
+        headers: probeReq.init.headers as any,
+        body: probeReq.init.body as any,
+        dispatcher,
+        maxRedirections: 0,
+        signal: AbortSignal.timeout(30_000),
+      });
+      resp = { status: wire.statusCode } as Response;
+      await discardProbeResponseBody(wire.body);
+    }
   } catch (e: any) {
     const msg = String(e?.message || e);
     if (/timeout|abort/i.test(msg)) return { errorKind: "timeout", errorDetail: msg.slice(0, 200) };

--- a/agent-node/src/runtime/probe-daemon.ts
+++ b/agent-node/src/runtime/probe-daemon.ts
@@ -70,12 +70,12 @@ function buildProbeForVendor(vendor: string, baseUrl: string, model: string, api
 
 // ── safelyFetchProbe ───────────────────────────────────────────────
 // DNS-resolve hostname → assert every A/AAAA record is NOT in the
-// forbidden IP set → fetch via undici with manual redirect (3xx →
-// probe_redirect_forbidden). TLS validation is mandatory (dispatcher
-// rejectUnauthorized:true + minVersion TLSv1.2). The connector lookup is
-// pinned to the already-validated address set, closing the DNS-rebinding
-// window between validation and connect while keeping the vendor hostname in
-// the URL for SNI and certificate verification.
+// forbidden IP set → issue a no-redirect TLS request (Node: undici Agent;
+// Bun compatibility fallback: node:https). TLS validation is mandatory
+// (rejectUnauthorized:true + minVersion TLSv1.2). Both transports receive the
+// same connector lookup pinned to the already-validated address set, closing
+// the DNS-rebinding window while keeping the vendor hostname in the URL for
+// SNI and certificate verification.
 
 export interface SafeFetchResult {
   resp?: Response;

--- a/docs/rfcs/RFC-028-provider-model-registry.md
+++ b/docs/rfcs/RFC-028-provider-model-registry.md
@@ -529,6 +529,16 @@ async function safelyFetchProbe(baseUrl: string, env: NodeJS.ProcessEnv): Promis
 - `rejectUnauthorized: true` 显式 set (不靠 default); TLS 最低 1.2
 - daemon boot 时 `assertSecureTlsEnv` 检 `NODE_TLS_REJECT_UNAUTHORIZED=0` 等环境变量, 见到 exit; **CI lint guard** 检 daemon 源码 `rejectUnauthorized:.*false` / `tls.checkServerIdentity.*noop` / 等 pattern = 0 命中
 
+**P1.5 implementation note (#310, 2026-08-09):** production no longer
+selects one illustrative `pinIp`. `createPinnedLookup(host, addrs)` retains the
+whole pre-validated A/AAAA set, honors undici/Node's single-address,
+`family`, and `{all:true}` callback forms, and rejects a different hostname or
+an unavailable family with `ENOTFOUND`. It never falls back to system DNS.
+The URL remains the vendor hostname, so SNI and certificate SAN validation are
+unchanged. `test648-probe-ip-pin` runs a split-horizon real TLS test under both
+Node 20 and Bun: pre-validation returns `127.0.0.1`, system DNS returns
+`127.0.0.2`, and only the validated endpoint may receive the request.
+
 **关键不变量**:
 - DNS 解析 → 校验 IP → 用 IP 直连 fetch 三步原子, **rebinding window 为 0** (解析后立即固定 IP)
 - IPv4-mapped IPv6 二次校验, 防 `::ffff:10.0.0.1` 绕 v6 list
@@ -796,6 +806,8 @@ dashboard admin-only audit page 直查 (P2)。
 - [ ] **§2.3** `ack_probe_request` 签名删 `error_message?`, 改 `(probe_id, status, latency_ms, raw_status_code?)`
 - [ ] **§4.4.4** 加 `deriveErrorLabel(ack)` hub-side 派生表 (status enum + raw_status_code → 文案)
 - [ ] impl 不变量: grep `error_message` 在 daemon + hub code path = 0 命中
+- [x] **P1.5 / #310** connector lookup pins the validated A/AAAA set; Node 20
+  + Bun split-horizon TLS E2E and pin-removal mutation are load-bearing
 
 ---
 

--- a/docs/rfcs/RFC-028-provider-model-registry.md
+++ b/docs/rfcs/RFC-028-provider-model-registry.md
@@ -531,13 +531,16 @@ async function safelyFetchProbe(baseUrl: string, env: NodeJS.ProcessEnv): Promis
 
 **P1.5 implementation note (#310, 2026-08-09):** production no longer
 selects one illustrative `pinIp`. `createPinnedLookup(host, addrs)` retains the
-whole pre-validated A/AAAA set, honors undici/Node's single-address,
+whole pre-validated A/AAAA set, honors the connector's single-address,
 `family`, and `{all:true}` callback forms, and rejects a different hostname or
 an unavailable family with `ENOTFOUND`. It never falls back to system DNS.
+Node 20 uses an undici Agent. Bun 1.3 is intentionally routed through
+`node:https` because its undici compatibility layer accepts but ignores the
+Agent lookup hook; both transports receive the same pinned lookup callback.
 The URL remains the vendor hostname, so SNI and certificate SAN validation are
 unchanged. `test648-probe-ip-pin` runs a split-horizon real TLS test under both
-Node 20 and Bun: pre-validation returns `127.0.0.1`, system DNS returns
-`127.0.0.2`, and only the validated endpoint may receive the request.
+runtimes: pre-validation returns `127.0.0.1`, system DNS returns `127.0.0.2`,
+and only the validated endpoint may receive the request.
 
 **关键不变量**:
 - DNS 解析 → 校验 IP → 用 IP 直连 fetch 三步原子, **rebinding window 为 0** (解析后立即固定 IP)

--- a/docs/tests/report-test648-probe-ip-pin.txt
+++ b/docs/tests/report-test648-probe-ip-pin.txt
@@ -1,0 +1,73 @@
+# test648 — RFC-028 P1.5 pre-validated DNS IP pin
+
+Date: 2026-08-10 (Asia/Shanghai)
+
+## Provenance
+
+- Base: `adc4b94de8fc62a0eafb888c69debcd30e313ab7`
+- Tested source: `7f9e11cbd0895122575617442a8736715982208c`
+- Docker tag: `anet-test648:dev`
+- Image ID: `sha256:98ddc1d3a89eeff6eed34468bf347339d73a887b9b58aa78bc779cb1dbd826ac`
+- Embedded env: `TEST648_SOURCE_COMMIT=7f9e11cbd0895122575617442a8736715982208c`
+- Runner artifact SHA256: `98453745c356f797bb05e1b92c7da7671f1f6e997261c8884704ce66723a0a42`
+- Runtime matrix: Node `v20.20.2`, Bun `1.3.14`
+
+Commands:
+
+```sh
+sg docker -c 'docker build \
+  --build-arg TEST648_SOURCE_COMMIT=7f9e11cbd0895122575617442a8736715982208c \
+  -t anet-test648:dev \
+  -f tests/test648-probe-ip-pin/Dockerfile .'
+sg docker -c 'docker run --rm \
+  -v /tmp/test648-probe-artifacts:/artifacts \
+  anet-test648:dev'
+```
+
+## Result
+
+`RESULT: PASS`
+
+- Production `agent-node` bundle: PASS (256 modules).
+- Existing SSRF/TLS suite plus lookup callback contract: 25 pass, 0 fail,
+  40 assertions.
+- Split-horizon real TLS:
+  - pre-validation was injected as `api.anthropic.com -> 127.0.0.1`;
+  - system connect-time resolution was `/etc/hosts -> 127.0.0.2`;
+  - Node 20 hit the pinned `127.0.0.1` endpoint and returned 200;
+  - Bun 1.3.14 hit the pinned `127.0.0.1` endpoint and returned 200;
+  - pinned endpoint request count was 2; rebound endpoint count was 0;
+  - both requests retained SNI `api.anthropic.com`, so certificate hostname
+    verification was not weakened.
+- Restored implementation repeated Node+Bun green.
+
+## Witnessed-red evidence
+
+1. Removing the Node undici Agent `connect.lookup` made the real Node 20
+   request hit the rebound endpoint (`418`), producing `PIN_FAIL`, rc=3.
+2. Removing the Bun `node:https` lookup made the real Bun request hit the
+   rebound endpoint (`418`), producing `PIN_FAIL`, rc=3.
+
+Both mutations edit the production transport call site, keep the test code
+unchanged, assert that the mutation applied, and are restored before the final
+green run.
+
+## Cross-runtime finding
+
+The initially attempted `undici.fetch(..., { dispatcher })` and subsequent
+lower-level `undici.request(..., { dispatcher })` both honored the lookup hook
+under Node 20 but Bun 1.3.14 still reached the `127.0.0.2` rebound endpoint.
+The final implementation therefore keeps the undici Agent for Node and uses
+Bun's `node:https` compatibility transport with the same fail-closed pinned
+lookup callback. This is not an unpinned fallback: deleting either runtime's
+lookup hook makes its real split-horizon test turn red.
+
+## Security properties exercised
+
+- all pre-resolved A/AAAA addresses are validated before connector creation;
+- hostname mismatch and unavailable address family fail `ENOTFOUND` without
+  consulting DNS;
+- redirects are not followed;
+- TLS verification remains enabled with minimum TLS 1.2;
+- vendor hostname remains in URL/SNI;
+- no API key or response body is written to the report.

--- a/docs/tests/report-test648-probe-ip-pin.txt
+++ b/docs/tests/report-test648-probe-ip-pin.txt
@@ -5,18 +5,18 @@ Date: 2026-08-10 (Asia/Shanghai)
 ## Provenance
 
 - Base: `adc4b94de8fc62a0eafb888c69debcd30e313ab7`
-- Tested source: `7f9e11cbd0895122575617442a8736715982208c`
+- Tested source: `7f9e11cb2f0b5938715f7c91ab04fafe414fd49b`
 - Docker tag: `anet-test648:dev`
-- Image ID: `sha256:98ddc1d3a89eeff6eed34468bf347339d73a887b9b58aa78bc779cb1dbd826ac`
-- Embedded env: `TEST648_SOURCE_COMMIT=7f9e11cbd0895122575617442a8736715982208c`
-- Runner artifact SHA256: `98453745c356f797bb05e1b92c7da7671f1f6e997261c8884704ce66723a0a42`
+- Image ID: `sha256:10b9ca65032ceb0799601acf989944f9573648d1663fdfbba1e260d465ad635d`
+- Embedded env: `TEST648_SOURCE_COMMIT=7f9e11cb2f0b5938715f7c91ab04fafe414fd49b`
+- Runner artifact SHA256: `49f260d4a482c95d43b110ed70065facdf8ba269b7d5b89d8f4e662f34277f33`
 - Runtime matrix: Node `v20.20.2`, Bun `1.3.14`
 
 Commands:
 
 ```sh
 sg docker -c 'docker build \
-  --build-arg TEST648_SOURCE_COMMIT=7f9e11cbd0895122575617442a8736715982208c \
+  --build-arg TEST648_SOURCE_COMMIT=7f9e11cb2f0b5938715f7c91ab04fafe414fd49b \
   -t anet-test648:dev \
   -f tests/test648-probe-ip-pin/Dockerfile .'
 sg docker -c 'docker run --rm \

--- a/tests/test648-probe-ip-pin/Dockerfile
+++ b/tests/test648-probe-ip-pin/Dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:1.3.14 AS bun-runtime
+
+FROM node:20-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates openssl \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && npm install --omit=optional --ignore-scripts
+COPY agent-node ./agent-node
+COPY tests/test648-probe-ip-pin ./tests/test648-probe-ip-pin
+
+ARG TEST648_SOURCE_COMMIT=unknown
+ENV TEST648_SOURCE_COMMIT=$TEST648_SOURCE_COMMIT
+RUN chmod 0755 tests/test648-probe-ip-pin/run.sh
+ENTRYPOINT ["/workspace/tests/test648-probe-ip-pin/run.sh"]

--- a/tests/test648-probe-ip-pin/mock-vendor.mjs
+++ b/tests/test648-probe-ip-pin/mock-vendor.mjs
@@ -1,0 +1,21 @@
+import { createServer } from "node:https";
+import { appendFileSync, readFileSync } from "node:fs";
+
+const bind = process.env.MOCK_BIND || "127.0.0.1";
+const port = Number(process.env.MOCK_PORT || 18443);
+const status = Number(process.env.MOCK_STATUS || 200);
+const logPath = process.env.MOCK_LOG || "/tmp/test648-mock.log";
+
+const server = createServer({
+  cert: readFileSync(process.env.MOCK_CERT || "/tmp/test648-cert.pem"),
+  key: readFileSync(process.env.MOCK_KEY || "/tmp/test648-key.pem"),
+}, (req, res) => {
+  const sni = req.socket.servername || "(none)";
+  appendFileSync(logPath, `request bind=${bind} status=${status} sni=${sni} path=${req.url}\n`);
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify({ bind, status }));
+});
+
+server.listen(port, bind, () => {
+  appendFileSync(logPath, `listening bind=${bind} port=${port}\n`);
+});

--- a/tests/test648-probe-ip-pin/run.sh
+++ b/tests/test648-probe-ip-pin/run.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test648-probe-ip-pin.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+cd /workspace
+
+echo "# test648 — pre-validated DNS IP pin"
+echo "source_commit=${TEST648_SOURCE_COMMIT:-unknown}"
+echo "node=$(node --version)"
+echo "bun=$(bun --version)"
+echo "date=$(date -Is)"
+
+echo "L0: production agent-node build"
+cd /workspace/agent-node
+npm run build
+test -s dist/cli.js
+cd /workspace
+
+echo "L1: lookup callback contract + existing SSRF unit suite"
+cd /workspace/agent-node
+bun test src/runtime/probe-daemon.test.ts
+cd /workspace
+
+echo "L2: stage split-horizon TLS targets"
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -keyout /tmp/test648-key.pem -out /tmp/test648-cert.pem \
+  -subj "/CN=api.anthropic.com" \
+  -addext "subjectAltName=DNS:api.anthropic.com" >/dev/null 2>&1
+cp /tmp/test648-cert.pem /usr/local/share/ca-certificates/test648.crt
+update-ca-certificates >/dev/null 2>&1
+echo "127.0.0.2 api.anthropic.com" >> /etc/hosts
+MOCK_BIND=127.0.0.1 MOCK_STATUS=200 MOCK_LOG=/tmp/test648-pinned.log \
+  node tests/test648-probe-ip-pin/mock-vendor.mjs >/tmp/test648-pinned.stdout 2>&1 &
+pinned_pid=$!
+MOCK_BIND=127.0.0.2 MOCK_STATUS=418 MOCK_LOG=/tmp/test648-rebound.log \
+  node tests/test648-probe-ip-pin/mock-vendor.mjs >/tmp/test648-rebound.stdout 2>&1 &
+rebound_pid=$!
+trap 'kill "$pinned_pid" "$rebound_pid" 2>/dev/null || true' EXIT
+for _ in $(seq 1 30); do
+  grep -q 'listening' /tmp/test648-pinned.log 2>/dev/null \
+    && grep -q 'listening' /tmp/test648-rebound.log 2>/dev/null \
+    && break
+  sleep 0.1
+done
+grep -q 'listening' /tmp/test648-pinned.log
+grep -q 'listening' /tmp/test648-rebound.log
+
+echo "L3a: Node 20 real TLS socket uses pre-validated IP"
+bun build tests/test648-probe-ip-pin/runtime-probe.ts --target node --outfile /tmp/test648-runtime-probe.js
+NODE_EXTRA_CA_CERTS=/tmp/test648-cert.pem node /tmp/test648-runtime-probe.js
+
+echo "L3b: Bun real TLS socket uses pre-validated IP"
+NODE_EXTRA_CA_CERTS=/tmp/test648-cert.pem bun tests/test648-probe-ip-pin/runtime-probe.ts
+
+test "$(grep -c 'request .*status=200 .*sni=api.anthropic.com' /tmp/test648-pinned.log)" -eq 2
+test "$(grep -c 'request ' /tmp/test648-rebound.log || true)" -eq 0
+echo "PASS: node+bun pinned=2 rebound=0 SNI=api.anthropic.com"
+
+echo "L4 witnessed-red: remove connector lookup"
+cp agent-node/src/runtime/probe-daemon.ts /tmp/test648-probe-daemon.ts
+sed -i '/lookup: createPinnedLookup(u.hostname, addrs),/d' agent-node/src/runtime/probe-daemon.ts
+if grep -Fq 'lookup: createPinnedLookup(u.hostname, addrs),' agent-node/src/runtime/probe-daemon.ts; then
+  echo "MUTATION_NOT_APPLIED"
+  exit 1
+fi
+bun build tests/test648-probe-ip-pin/runtime-probe.ts --target node --outfile /tmp/test648-mut-runtime-probe.js
+set +e
+NODE_EXTRA_CA_CERTS=/tmp/test648-cert.pem node /tmp/test648-mut-runtime-probe.js >/tmp/test648-mutation.log 2>&1
+mutation_rc=$?
+set -e
+cp /tmp/test648-probe-daemon.ts agent-node/src/runtime/probe-daemon.ts
+test "$mutation_rc" -ne 0
+grep -Fq 'PIN_FAIL' /tmp/test648-mutation.log
+grep -q 'request .*status=418 .*sni=api.anthropic.com' /tmp/test648-rebound.log
+echo "MUTATION_RED: connector-pin-removed rc=$mutation_rc rebound-hit=1"
+
+echo "L5 restored Node+Bun green"
+bun build tests/test648-probe-ip-pin/runtime-probe.ts --target node --outfile /tmp/test648-restored.js
+NODE_EXTRA_CA_CERTS=/tmp/test648-cert.pem node /tmp/test648-restored.js
+NODE_EXTRA_CA_CERTS=/tmp/test648-cert.pem bun tests/test648-probe-ip-pin/runtime-probe.ts
+
+echo "RESULT: PASS"

--- a/tests/test648-probe-ip-pin/run.sh
+++ b/tests/test648-probe-ip-pin/run.sh
@@ -78,6 +78,23 @@ grep -Fq 'PIN_FAIL' /tmp/test648-mutation.log
 grep -q 'request .*status=418 .*sni=api.anthropic.com' /tmp/test648-rebound.log
 echo "MUTATION_RED: connector-pin-removed rc=$mutation_rc rebound-hit=1"
 
+echo "L4b witnessed-red: remove Bun node:https lookup"
+cp agent-node/src/runtime/probe-daemon.ts /tmp/test648-probe-daemon.ts
+sed -i '/^      lookup,$/d' agent-node/src/runtime/probe-daemon.ts
+if grep -Fq '      lookup,' agent-node/src/runtime/probe-daemon.ts; then
+  echo "MUTATION_NOT_APPLIED"
+  exit 1
+fi
+set +e
+NODE_EXTRA_CA_CERTS=/tmp/test648-cert.pem bun tests/test648-probe-ip-pin/runtime-probe.ts >/tmp/test648-bun-mutation.log 2>&1
+bun_mutation_rc=$?
+set -e
+cp /tmp/test648-probe-daemon.ts agent-node/src/runtime/probe-daemon.ts
+test "$bun_mutation_rc" -ne 0
+grep -Fq 'PIN_FAIL' /tmp/test648-bun-mutation.log
+test "$(grep -c 'request .*status=418 .*sni=api.anthropic.com' /tmp/test648-rebound.log)" -ge 2
+echo "MUTATION_RED: bun-https-pin-removed rc=$bun_mutation_rc rebound-hit=1"
+
 echo "L5 restored Node+Bun green"
 bun build tests/test648-probe-ip-pin/runtime-probe.ts --target node --outfile /tmp/test648-restored.js
 NODE_EXTRA_CA_CERTS=/tmp/test648-cert.pem node /tmp/test648-restored.js

--- a/tests/test648-probe-ip-pin/runtime-probe.ts
+++ b/tests/test648-probe-ip-pin/runtime-probe.ts
@@ -1,0 +1,29 @@
+import { safelyFetchProbe } from "../../agent-node/src/runtime/probe-daemon.js";
+
+let resolveCalls = 0;
+const result = await safelyFetchProbe(
+  "anthropic",
+  "https://api.anthropic.com:18443",
+  "claude-pin-test",
+  "sk-test648-not-secret",
+  { ...process.env, ANET_DAEMON_PROBE_ALLOW_LOOPBACK: "1" },
+  async (hostname) => {
+    resolveCalls++;
+    if (hostname !== "api.anthropic.com") throw new Error(`unexpected_host:${hostname}`);
+    // The pre-validation answer is 127.0.0.1. /etc/hosts deliberately points
+    // the same hostname at 127.0.0.2, so a second/system lookup reaches the
+    // rebound server. Only a real connector pin reaches the validated server.
+    return [{ address: "127.0.0.1", family: 4 }];
+  },
+);
+
+if (resolveCalls !== 1) {
+  console.error(`PIN_FAIL resolver_calls=${resolveCalls}`);
+  process.exit(2);
+}
+if (result.errorKind !== null || result.resp?.status !== 200) {
+  console.error(`PIN_FAIL error=${result.errorKind} status=${result.resp?.status ?? "none"} detail=${result.errorDetail ?? ""}`);
+  process.exit(3);
+}
+console.log(`PIN_OK runtime=${typeof Bun === "undefined" ? "node" : "bun"} status=200 resolver_calls=1`);
+process.exit(0);


### PR DESCRIPTION
Closes #310

## Summary
- pins the complete pre-validated A/AAAA set in the real connector lookup
- preserves vendor hostname SNI and certificate validation
- uses an undici Agent on Node 20 and a fail-closed `node:https` compatibility path on Bun 1.3, because Bun's undici compatibility layer accepts but ignores the dispatcher lookup hook
- rejects hostname/family mismatches without a system-DNS fallback
- documents the cross-runtime boundary in RFC-028

## Verification
Docker-only `tests/test648-probe-ip-pin` on exact source `7f9e11cbd0895122575617442a8736715982208c`:
- production agent-node build PASS
- 25 tests / 40 assertions PASS
- real split-horizon TLS: Node 20 + Bun 1.3.14 both hit pinned `127.0.0.1`; rebound `127.0.0.2` received 0 requests; SNI stayed `api.anthropic.com`
- deleting Node's undici lookup: witnessed red, real rebound hit, rc=3
- deleting Bun's node:https lookup: witnessed red, real rebound hit, rc=3
- restored Node+Bun green

Evidence: `docs/tests/report-test648-probe-ip-pin.txt`
Image: `sha256:98ddc1d3a89eeff6eed34468bf347339d73a887b9b58aa78bc779cb1dbd826ac`
Report-only head: `b2febde60b5ac3731acd17255ac85e396fdc1cbc`

No merge, publish, or deployment is requested by this draft.