### PR TITLE
fix(cli): make token creation arguments explicit

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -94,6 +94,7 @@ import {
   type GrokCopresenceSessionDisclosure,
 } from "../src/grok-copresence-disclosure";
 import { parseCliOptions, positionalArgs } from "../src/cli-args";
+import { parseTokenCreateName } from "../src/token-cli";
 import { diagnoseLocale, formatLocaleSource } from "../src/locale-diagnostic";
 import {
   formatSecretAssignment,
@@ -9882,15 +9883,35 @@ function logsCommand() {
 // ── token ──
 
 async function tokenCommand() {
+  const sub = args[1];
+
+  if (sub === "--help" || sub === "-h" || sub === "help") {
+    console.log(`
+anet token <command>
+
+  ls                    List all tokens
+  create <name>         Create a new API token (legacy positional form)
+  create --name <name>  Create a new API token
+  revoke <token-id>     Revoke a token by ID
+`);
+    return;
+  }
+
+  const createName = sub === "create" ? parseTokenCreateName(args.slice(2)) : null;
+  if (createName && !createName.ok) {
+    console.error(`Invalid token create arguments: ${createName.error}`);
+    console.error("Usage: anet token create --name <name>");
+    process.exit(1);
+  }
+
   const gc = loadGlobal();
   const hub = gc.hub;
   const token = gc.token;
   if (!hub || !token) { console.error("Not logged in. Run: anet login"); return; }
   const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
-  const sub = args[1];
 
   if (sub === "create") {
-    const name = args[2] || "api-token";
+    const name = createName!.name;
     try {
       const res = await fetch(`${hub}/api/auth/tokens`, { method: "POST", headers, body: JSON.stringify({ name }) }).then(r => r.json() as any);
       if (res.ok) {
@@ -9914,27 +9935,16 @@ async function tokenCommand() {
     return;
   }
 
-  if (sub === "--help" || sub === "-h" || sub === "help") {
-    console.log(`
-anet token <command>
-
-  ls                    List all tokens
-  create <name>         Create a new API token
-  revoke <token-id>     Revoke a token by ID
-`);
-    return;
-  }
-
   // Default: list tokens (same as "ls")
   try {
     const res = await fetch(`${hub}/api/auth/tokens`, { headers }).then(r => r.json() as any);
     if (!res.ok) { console.error(res.error); return; }
     if (!res.tokens?.length) { console.log("\n  No tokens. Create one: anet token create <name>\n"); return; }
     console.log("\n  API Tokens:\n");
-    console.log("  ID                   NAME           LAST USED");
-    console.log("  ──────────────────── ────────────── ──────────────────");
+    console.log("  ID                   NAME           CREATED                  LAST USED");
+    console.log("  ──────────────────── ────────────── ──────────────────────── ────────────────────────");
     for (const t of res.tokens) {
-      console.log(`  ${(t.token_id || "?").padEnd(22)} ${(t.name || "?").padEnd(14)} ${t.last_used_at || "never"}`);
+      console.log(`  ${(t.token_id || "?").padEnd(22)} ${(t.name || "?").padEnd(14)} ${(t.created_at || "?").padEnd(24)} ${t.last_used_at || "never"}`);
     }
     console.log();
   } catch (e: any) { console.error(friendlyError(e)); }

--- a/agent-network/src/token-cli.test.ts
+++ b/agent-network/src/token-cli.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { parseTokenCreateName } from "./token-cli";
+
+describe("parseTokenCreateName", () => {
+  test("keeps the legacy positional form", () => {
+    expect(parseTokenCreateName(["legacy-name"])).toEqual({ ok: true, name: "legacy-name" });
+  });
+
+  test("accepts separated and equals --name forms", () => {
+    expect(parseTokenCreateName(["--name", "flag-name"])).toEqual({ ok: true, name: "flag-name" });
+    expect(parseTokenCreateName(["--name=equals-name"])).toEqual({ ok: true, name: "equals-name" });
+  });
+
+  test("fails closed for missing, empty, unknown, mixed, or extra operands", () => {
+    for (const argv of [
+      [],
+      [""],
+      ["--name"],
+      ["--name="],
+      ["--name", "--role"],
+      ["--role", "admin"],
+      ["positional", "extra"],
+      ["positional", "--name", "other"],
+    ]) {
+      expect(parseTokenCreateName(argv).ok).toBeFalse();
+    }
+  });
+});

--- a/agent-network/src/token-cli.ts
+++ b/agent-network/src/token-cli.ts
@@ -1,0 +1,40 @@
+export type TokenCreateNameResult =
+  | { ok: true; name: string }
+  | { ok: false; error: string };
+
+/** Parse only `anet token create` operands.
+ *
+ * The legacy positional form stays supported, while flag parsing is strict so
+ * a typo cannot become the name of a newly issued credential.
+ */
+export function parseTokenCreateName(argv: readonly string[]): TokenCreateNameResult {
+  if (argv.length === 0) {
+    return { ok: false, error: "token name is required" };
+  }
+
+  if (argv.length === 1 && !argv[0].startsWith("--")) {
+    return argv[0].trim()
+      ? { ok: true, name: argv[0] }
+      : { ok: false, error: "token name must not be empty" };
+  }
+
+  if (argv.length === 1 && argv[0].startsWith("--name=")) {
+    const name = argv[0].slice("--name=".length);
+    return name.trim()
+      ? { ok: true, name }
+      : { ok: false, error: "--name requires a non-empty value" };
+  }
+
+  if (argv[0] === "--name") {
+    if (argv.length === 1 || !argv[1].trim() || argv[1].startsWith("--")) {
+      return { ok: false, error: "--name requires a non-empty value" };
+    }
+    if (argv.length === 2) return { ok: true, name: argv[1] };
+    return { ok: false, error: "unexpected extra token create arguments" };
+  }
+
+  if (argv.some((arg) => arg.startsWith("--"))) {
+    return { ok: false, error: `unknown token create option: ${argv.find((arg) => arg.startsWith("--"))}` };
+  }
+  return { ok: false, error: "expected exactly one token name" };
+}

--- a/docs/tests/report-test649-token-cli.txt
+++ b/docs/tests/report-test649-token-cli.txt
@@ -1,0 +1,45 @@
+# test649 — token CLI argument and audit output
+
+Date: 2026-08-10 (Asia/Shanghai)
+
+## Provenance
+
+- Base: `adc4b94de8fc62a0eafb888c69debcd30e313ab7`
+- Tested source: `b6163161b1c51e3f30c8f2c552894946aafb2e68`
+- Docker tag: `anet-test649:dev`
+- Image ID: `sha256:cc6500cc06dd53f1087fcaf8f0ec4e484fcf039dff848ee2b66554731025498a`
+- Embedded env: `TEST649_SOURCE_COMMIT=b6163161b1c51e3f30c8f2c552894946aafb2e68`
+- Runner artifact SHA256: `525f0a4fb4b411fd673f29e81dfa5a2c7aae917ca99e3700a1691008bc04a68c`
+- Runtime: Bun `1.3.14` (production CLI bundle executed with Node)
+
+## Result
+
+`RESULT: PASS`
+
+- Pure parser: 3 pass, 0 fail, 11 assertions.
+- Production CLI bundle built successfully.
+- Real CLI against an isolated fake Hub:
+  - `token create --name flag-name` posted `{name:"flag-name"}`;
+  - `token create --name=equals-name` posted the equals-form value;
+  - legacy `token create legacy-name` remained compatible;
+  - no argument, missing `--name` value, unknown flag, and extra positional
+    argument all exited non-zero before any Hub request;
+  - `token ls` rendered both `created_at` and `last_used_at` values returned by
+    the Hub;
+  - `token help` made no Hub request.
+- Restored parser, production bundle, create, and list checks passed again.
+
+## Witnessed-red evidence
+
+1. Restoring the former silent `api-token` default made the parser contract
+   fail (`rc=1`).
+2. Bypassing the parsed name at the real POST call site made the real
+   `--name mutation-name` request body differ and turned the wiring gate red
+   (`rc=1`).
+3. Removing `created_at` from the rendered list made the real CLI output gate
+   fail (`rc=1`).
+
+All mutations edit production source, assert that their target was changed,
+leave the test assertions unchanged, and restore source before the final green
+run. No real credential is minted; the isolated server returns a synthetic
+token and the report does not contain its value.

--- a/tests/test649-token-cli/Dockerfile
+++ b/tests/test649-token-cli/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY tests/lib ./tests/lib
+COPY tests/test649-token-cli ./tests/test649-token-cli
+
+ARG TEST649_SOURCE_COMMIT=unknown
+ENV TEST649_SOURCE_COMMIT=$TEST649_SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test649-token-cli/run.sh
+ENTRYPOINT ["/workspace/tests/test649-token-cli/run.sh"]

--- a/tests/test649-token-cli/mock-hub.mjs
+++ b/tests/test649-token-cli/mock-hub.mjs
@@ -1,0 +1,35 @@
+import { appendFileSync } from "node:fs";
+
+const logPath = process.env.MOCK_LOG || "/tmp/test649-hub.log";
+const port = Number(process.env.MOCK_PORT || 19149);
+
+Bun.serve({
+  hostname: "127.0.0.1",
+  port,
+  async fetch(req) {
+    const url = new URL(req.url);
+    let body = null;
+    if (req.method === "POST") body = await req.json();
+    appendFileSync(logPath, `${JSON.stringify({ method: req.method, path: url.pathname, body })}\n`);
+    if (url.pathname !== "/api/auth/tokens") {
+      return Response.json({ ok: false, error: "not_found" }, { status: 404 });
+    }
+    if (req.method === "POST") {
+      return Response.json({ ok: true, token: "utok_test649_redacted", token_id: "tok_created_649" });
+    }
+    if (req.method === "GET") {
+      return Response.json({
+        ok: true,
+        tokens: [{
+          token_id: "tok_listed_649",
+          name: "listed-token",
+          created_at: "2026-08-09T01:02:03.000Z",
+          last_used_at: "2026-08-09T04:05:06.000Z",
+        }],
+      });
+    }
+    return Response.json({ ok: false, error: "method_not_allowed" }, { status: 405 });
+  },
+});
+
+console.log(`READY ${port}`);

--- a/tests/test649-token-cli/run.sh
+++ b/tests/test649-token-cli/run.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /workspace/tests/lib/safe-rm.sh
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test649-token-cli.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+cd /workspace
+
+echo "# test649 — token CLI argument and audit output"
+echo "source_commit=${TEST649_SOURCE_COMMIT:-unknown}"
+echo "bun=$(bun --version)"
+echo "date=$(date -Is)"
+
+build_cli() {
+  safe_rm_rf /tmp/test649-dist
+  bun build agent-network/bin/cli.ts \
+    --outdir /tmp/test649-dist \
+    --entry-naming cli.js \
+    --target node \
+    --external @sleep2agi/commhub-server \
+    --external bun:sqlite \
+    --external '../../server/*' >/tmp/test649-build.log
+  test -s /tmp/test649-dist/cli.js
+}
+
+WORK=$(mktemp -d /tmp/test649-home.XXXXXX)
+trap 'kill "${hub_pid:-}" 2>/dev/null || true; safe_rm_rf "$WORK"' EXIT
+mkdir -p "$WORK/.anet" "$WORK/cwd"
+chmod 0700 "$WORK/.anet"
+cat > "$WORK/.anet/config.json" <<'JSON'
+{"hub":"http://127.0.0.1:19149","token":"utok_test649_local"}
+JSON
+chmod 0600 "$WORK/.anet/config.json"
+
+: > /tmp/test649-hub.log
+MOCK_LOG=/tmp/test649-hub.log bun tests/test649-token-cli/mock-hub.mjs >/tmp/test649-hub.stdout 2>&1 &
+hub_pid=$!
+for _ in $(seq 1 30); do
+  grep -q '^READY ' /tmp/test649-hub.stdout 2>/dev/null && break
+  sleep 0.1
+done
+grep -q '^READY 19149' /tmp/test649-hub.stdout
+
+run_cli() {
+  env -i PATH="$PATH" HOME="$WORK" LANG=C.UTF-8 \
+    node /tmp/test649-dist/cli.js "$@"
+}
+
+echo "L0: pure parser contract"
+cd /workspace/agent-network
+bun test src/token-cli.test.ts
+cd /workspace
+
+echo "L1: production CLI build"
+build_cli
+
+echo "L2: real CLI create/list/help behavior"
+: > /tmp/test649-hub.log
+run_cli token create --name flag-name >/tmp/test649-create-flag.out
+grep -Fq '"body":{"name":"flag-name"}' /tmp/test649-hub.log
+
+run_cli token create --name=equals-name >/tmp/test649-create-equals.out
+grep -Fq '"body":{"name":"equals-name"}' /tmp/test649-hub.log
+
+run_cli token create legacy-name >/tmp/test649-create-positional.out
+grep -Fq '"body":{"name":"legacy-name"}' /tmp/test649-hub.log
+
+before=$(wc -l < /tmp/test649-hub.log)
+for invalid in noargs missing unknown extra; do
+  set +e
+  case "$invalid" in
+    noargs) run_cli token create >/tmp/test649-invalid.out 2>&1 ;;
+    missing) run_cli token create --name >/tmp/test649-invalid.out 2>&1 ;;
+    unknown) run_cli token create --role admin >/tmp/test649-invalid.out 2>&1 ;;
+    extra) run_cli token create one two >/tmp/test649-invalid.out 2>&1 ;;
+  esac
+  rc=$?
+  set -e
+  test "$rc" -ne 0
+  grep -Fq 'Usage: anet token create --name <name>' /tmp/test649-invalid.out
+done
+after=$(wc -l < /tmp/test649-hub.log)
+test "$after" -eq "$before"
+
+run_cli token ls >/tmp/test649-list.out
+grep -Fq 'CREATED' /tmp/test649-list.out
+grep -Fq '2026-08-09T01:02:03.000Z' /tmp/test649-list.out
+grep -Fq '2026-08-09T04:05:06.000Z' /tmp/test649-list.out
+
+before=$(wc -l < /tmp/test649-hub.log)
+run_cli token help >/tmp/test649-help.out
+grep -Fq 'create --name <name>' /tmp/test649-help.out
+after=$(wc -l < /tmp/test649-hub.log)
+test "$after" -eq "$before"
+
+echo "L3 witnessed-red: restore silent no-argument default"
+cp agent-network/src/token-cli.ts /tmp/test649-token-cli.ts
+sed -i 's/return { ok: false, error: "token name is required" };/return { ok: true, name: "api-token" };/' agent-network/src/token-cli.ts
+grep -Fq 'return { ok: true, name: "api-token" };' agent-network/src/token-cli.ts
+set +e
+cd /workspace/agent-network
+bun test src/token-cli.test.ts >/tmp/test649-default-mutation.log 2>&1
+default_rc=$?
+cd /workspace
+set -e
+test "$default_rc" -ne 0
+echo "MUTATION_RED: silent-default rc=$default_rc"
+cp /tmp/test649-token-cli.ts agent-network/src/token-cli.ts
+
+echo "L4 witnessed-red: bypass parsed flag name at the POST call site"
+cp agent-network/bin/cli.ts /tmp/test649-cli.ts
+sed -i 's/const name = createName!\.name;/const name = args[2] || "api-token";/' agent-network/bin/cli.ts
+grep -Fq 'const name = args[2] || "api-token";' agent-network/bin/cli.ts
+build_cli
+: > /tmp/test649-hub.log
+run_cli token create --name mutation-name >/tmp/test649-name-mutation.out
+set +e
+grep -Fq '"body":{"name":"mutation-name"}' /tmp/test649-hub.log
+name_rc=$?
+set -e
+test "$name_rc" -ne 0
+echo "MUTATION_RED: parsed-name-bypassed rc=$name_rc"
+cp /tmp/test649-cli.ts agent-network/bin/cli.ts
+
+echo "L5 witnessed-red: omit created_at from rendered list"
+sed -i 's/(t.created_at || "?")\.padEnd(24)/"".padEnd(24)/' agent-network/bin/cli.ts
+grep -Fq '"".padEnd(24)' agent-network/bin/cli.ts
+build_cli
+run_cli token ls >/tmp/test649-created-mutation.out
+set +e
+grep -Fq '2026-08-09T01:02:03.000Z' /tmp/test649-created-mutation.out
+created_rc=$?
+set -e
+test "$created_rc" -ne 0
+echo "MUTATION_RED: created-at-omitted rc=$created_rc"
+cp /tmp/test649-cli.ts agent-network/bin/cli.ts
+
+echo "L6 restored green"
+cd /workspace/agent-network
+bun test src/token-cli.test.ts
+cd /workspace
+build_cli
+: > /tmp/test649-hub.log
+run_cli token create --name restored-name >/tmp/test649-restored-create.out
+grep -Fq '"body":{"name":"restored-name"}' /tmp/test649-hub.log
+run_cli token ls >/tmp/test649-restored-list.out
+grep -Fq '2026-08-09T01:02:03.000Z' /tmp/test649-restored-list.out
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #219

## Summary
- supports `anet token create --name <name>` and `--name=<name>`
- preserves legacy `anet token create <name>`
- fails non-zero before any Hub request for no name, missing values, unknown flags, mixed/extra operands
- moves token help before authentication and keeps it side-effect free
- displays the Hub-provided `created_at` alongside `last_used_at`

## Verification
Docker-only test649 on exact source `b6163161b1c51e3f30c8f2c552894946aafb2e68`:
- parser 3 pass / 11 assertions
- production CLI build PASS
- real CLI against isolated fake Hub proves both flag forms and positional compatibility
- four invalid forms make zero Hub requests
- list renders created_at and last_used_at
- 3 witnessed-red mutations: silent default, parsed-name bypass, created_at omission

Evidence: `docs/tests/report-test649-token-cli.txt`
Image: `sha256:cc6500cc06dd53f1087fcaf8f0ec4e484fcf039dff848ee2b66554731025498a`
Report-only head: `96cbb16e4dc49e56439d66634fa8cd26917978b0`

No merge, publish, or deployment is requested by this draft.