### PR TITLE
feat(cli): attach exact node tmux session

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -95,6 +95,7 @@ import {
 } from "../src/grok-copresence-disclosure";
 import { parseCliOptions, positionalArgs } from "../src/cli-args";
 import { parseTokenCreateName } from "../src/token-cli";
+import { findExactTmuxSession, parseTmuxSessions } from "../src/tmux-attach";
 import { diagnoseLocale, formatLocaleSource } from "../src/locale-diagnostic";
 import {
   formatSecretAssignment,
@@ -2325,6 +2326,7 @@ Node Management:
   anet node delete <name>        Delete node and config
   anet node rename <ref> <new>   Rename a node
   anet node ls                   List all nodes
+  anet attach <name>             Attach the node's exact tmux TUI session
   anet info <name>              Detailed node info + server status
   anet status                   Network overview (agents + tasks)
   anet tasks [status]           Query tasks (replied/failed/delivered)
@@ -2422,6 +2424,52 @@ Legacy aliases:
   anet create <name>              Alias for anet node create
   anet start <name>               Alias for anet node start
 `);
+}
+
+function attachCommand() {
+  const ref = args[1];
+  if (!ref || args.length !== 2) {
+    console.error("Usage: anet attach <node-name>");
+    process.exit(1);
+  }
+  const resolved = resolveNodeRef(ref);
+  if (!resolved) {
+    console.error(`Node "${ref}" not found.`);
+    process.exit(1);
+  }
+  const displayName = nodeDisplayName(resolved.id, resolved.profile);
+  let listing: string;
+  try {
+    listing = execFileSync("tmux", ["list-sessions", "-F", "#{session_id}\t#{session_name}"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error: any) {
+    const code = error?.code === "ENOENT" ? "tmux is not installed" : "no tmux server/session is available";
+    console.error(`[anet] Cannot attach ${JSON.stringify(displayName)}: ${code}.`);
+    console.error(`[anet] Start it first: anet node start ${shellQuote(displayName)} --tmux`);
+    process.exit(1);
+  }
+
+  const session = findExactTmuxSession(listing, displayName);
+  if (!session) {
+    const related = parseTmuxSessions(listing)
+      .filter((candidate) => candidate.name.startsWith(`${displayName}-`))
+      .map((candidate) => candidate.name);
+    console.error(`[anet] TUI session ${JSON.stringify(displayName)} is not running.`);
+    if (related.length) {
+      console.error(`[anet] Refusing prefix fallback to related non-TUI session(s): ${related.join(", ")}`);
+    }
+    console.error(`[anet] Start it first: anet node start ${shellQuote(displayName)} --tmux`);
+    process.exit(1);
+  }
+
+  const child = spawnSync("tmux", ["attach-session", "-t", session.id], { stdio: "inherit" });
+  if (child.error) {
+    console.error(`[anet] tmux attach failed: ${child.error.message}`);
+    process.exit(1);
+  }
+  if (child.status !== 0) process.exit(child.status ?? 1);
 }
 
 function printNodeStartHelp() {
@@ -12759,6 +12807,7 @@ switch (command) {
     else await initGlobal();
     break;
   case "create": await createCommand(); break;
+  case "attach": attachCommand(); break;
   case "server": await serverCommand(); break;
   case "hub": await serverCommand(); break; // anet hub start/dashboard/config
   case "node": // anet node create/start/stop/resume/delete/ls/rename
@@ -12852,7 +12901,7 @@ switch (command) {
       // hand-maintained to avoid scanning the switch at runtime; keep in
       // sync if new top-level commands are added.
       const TOP_COMMANDS = [
-        "init", "create", "server", "hub", "node", "project", "start", "resume",
+        "init", "create", "attach", "server", "hub", "node", "project", "start", "resume",
         "rename", "stop", "delete", "import", "channel", "setup", "upgrade",
         "session", "ls", "list", "status", "tasks", "goal", "doctor", "license",
         "activate", "passwd", "token", "demo", "batch", "logs", "info", "config",

--- a/agent-network/src/tmux-attach.test.ts
+++ b/agent-network/src/tmux-attach.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { findExactTmuxSession, parseTmuxSessions } from "./tmux-attach";
+
+describe("tmux attach resolution", () => {
+  const listing = "$1\t通信牛-node\n$2\t通信牛\n$3\t通信牛-桥\n";
+
+  test("parses opaque IDs and Unicode names", () => {
+    expect(parseTmuxSessions(listing)).toEqual([
+      { id: "$1", name: "通信牛-node" },
+      { id: "$2", name: "通信牛" },
+      { id: "$3", name: "通信牛-桥" },
+    ]);
+  });
+
+  test("selects the exact TUI instead of prefix siblings", () => {
+    expect(findExactTmuxSession(listing, "通信牛")).toEqual({ id: "$2", name: "通信牛" });
+  });
+
+  test("does not fall back to a bridge or node session", () => {
+    expect(findExactTmuxSession("$1\t通信牛-node\n$3\t通信牛-桥\n", "通信牛")).toBeNull();
+  });
+});

--- a/agent-network/src/tmux-attach.ts
+++ b/agent-network/src/tmux-attach.ts
@@ -1,0 +1,20 @@
+export type TmuxSession = { id: string; name: string };
+
+export function parseTmuxSessions(output: string): TmuxSession[] {
+  const sessions: TmuxSession[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    if (!line) continue;
+    const tab = line.indexOf("\t");
+    if (tab <= 0) continue;
+    const id = line.slice(0, tab);
+    const name = line.slice(tab + 1);
+    if (name) sessions.push({ id, name });
+  }
+  return sessions;
+}
+
+/** Resolve by exact decoded session name, then attach by tmux's opaque ID.
+ * This avoids tmux target prefix matching and works for Unicode names. */
+export function findExactTmuxSession(output: string, expectedName: string): TmuxSession | null {
+  return parseTmuxSessions(output).find((session) => session.name === expectedName) || null;
+}

--- a/docs/tests/report-test650-anet-attach.txt
+++ b/docs/tests/report-test650-anet-attach.txt
@@ -1,0 +1,37 @@
+# test650 — exact tmux attach
+
+Date: 2026-08-10 (Asia/Shanghai)
+
+## Provenance
+
+- Base: `9d87873a29f48cc076487d1a304f75f6fd0880e4`
+- Tested source: `94fb6281ec62ad987127a920d076de53c5da1889`
+- Docker tag: `anet-test650:dev`
+- Image ID: `sha256:4b89ed3950c66acd979fd486548d21eb19454c6591a02ff8eebe92c1185db2e3`
+- Embedded env: `TEST650_SOURCE_COMMIT=94fb6281ec62ad987127a920d076de53c5da1889`
+- Runner artifact SHA256: `0adff3d2307af7e400df3d7fdc62d6e26c580804bd15c12e4e1e0df79bc996d7`
+
+## Result
+
+`RESULT: PASS`
+
+- Exact-name helper: 3 pass, 0 fail, 3 assertions.
+- Production CLI bundle built successfully.
+- Real CLI with a fake tmux process proved that `anet attach 测试牛` chose
+  opaque session ID `$2`, even though `$1 / 测试牛-node` appeared first.
+- With only `测试牛-node` and `测试牛-桥` present, the command exited non-zero,
+  printed the explicit prefix-fallback refusal, and never invoked attach.
+- An unknown node exited non-zero before invoking tmux.
+- Help now exposes the top-level attach command.
+- Restored helper, bundle, and real attach check passed again.
+
+## Witnessed red
+
+Changing the production helper from exact equality to `startsWith()` made the
+unchanged prefix-sibling test fail (`rc=1`). This proves the test guards the
+same ambiguity that previously sent users into a `-node`/`-桥` session when the
+TUI session was absent.
+
+The implementation passes tmux's opaque session ID as a direct argv element;
+it performs no shell interpolation and does not use tmux's target prefix
+matching for a user-controlled alias.

--- a/tests/test650-anet-attach/Dockerfile
+++ b/tests/test650-anet-attach/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+COPY agent-network ./agent-network
+COPY tests/lib ./tests/lib
+COPY tests/test650-anet-attach ./tests/test650-anet-attach
+ARG TEST650_SOURCE_COMMIT=unknown
+ENV TEST650_SOURCE_COMMIT=$TEST650_SOURCE_COMMIT
+RUN chmod 0755 tests/test650-anet-attach/run.sh tests/test650-anet-attach/fake-bin/tmux
+ENTRYPOINT ["/workspace/tests/test650-anet-attach/run.sh"]

--- a/tests/test650-anet-attach/fake-bin/tmux
+++ b/tests/test650-anet-attach/fake-bin/tmux
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+case "${1:-}" in
+  list-sessions)
+    if [ "${TMUX_FIXTURE:-full}" = "missing-tui" ]; then
+      printf '$1\t测试牛-node\n$3\t测试牛-桥\n'
+    else
+      printf '$1\t测试牛-node\n$2\t测试牛\n$3\t测试牛-桥\n'
+    fi
+    ;;
+  attach-session)
+    printf '%s\n' "$*" >> "${TMUX_ATTACH_LOG:?}"
+    ;;
+  *) exit 64 ;;
+esac

--- a/tests/test650-anet-attach/run.sh
+++ b/tests/test650-anet-attach/run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source /workspace/tests/lib/safe-rm.sh
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test650-anet-attach.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+cd /workspace
+
+echo "# test650 — exact tmux attach"
+echo "source_commit=${TEST650_SOURCE_COMMIT:-unknown}"
+echo "bun=$(bun --version)"
+echo "date=$(date -Is)"
+
+run_tests() { (cd agent-network && bun test src/tmux-attach.test.ts); }
+build_cli() {
+  safe_rm_rf /tmp/test650-dist
+  bun build agent-network/bin/cli.ts --outdir /tmp/test650-dist --entry-naming cli.js --target node \
+    --external @sleep2agi/commhub-server --external bun:sqlite --external '../../server/*' >/tmp/test650-build.log
+  test -s /tmp/test650-dist/cli.js
+}
+
+WORK=$(mktemp -d /tmp/test650-home.XXXXXX)
+trap 'safe_rm_rf "$WORK"' EXIT
+mkdir -p "$WORK/project/.anet/nodes/n_test650" "$WORK/.anet" /tmp/test650-fake-bin
+cp tests/test650-anet-attach/fake-bin/tmux /tmp/test650-fake-bin/tmux
+chmod 0755 /tmp/test650-fake-bin/tmux
+cat > "$WORK/project/.anet/nodes/n_test650/config.json" <<'JSON'
+{"node_id":"n_test650","node_name":"测试牛","alias":"测试牛","runtime":"claude-agent-sdk"}
+JSON
+chmod 0600 "$WORK/project/.anet/nodes/n_test650/config.json"
+: > /tmp/test650-attach.log
+
+run_cli() {
+  (cd "$WORK/project" && env -i PATH="/tmp/test650-fake-bin:$PATH" HOME="$WORK" LANG=C.UTF-8 \
+    TMUX_ATTACH_LOG=/tmp/test650-attach.log TMUX_FIXTURE="${TMUX_FIXTURE:-full}" \
+    node /tmp/test650-dist/cli.js "$@")
+}
+
+echo "L0: exact-name helper"
+run_tests
+echo "L1: production CLI build"
+build_cli
+
+echo "L2: real CLI attaches Unicode alias by opaque session ID"
+: > /tmp/test650-attach.log
+run_cli attach 测试牛
+grep -Fxq 'attach-session -t $2' /tmp/test650-attach.log
+if grep -Fq '$1' /tmp/test650-attach.log; then exit 1; fi
+
+echo "L3: missing exact TUI refuses related bridge/node prefix"
+: > /tmp/test650-attach.log
+set +e
+TMUX_FIXTURE=missing-tui run_cli attach 测试牛 >/tmp/test650-missing.out 2>&1
+missing_rc=$?
+set -e
+test "$missing_rc" -ne 0
+grep -Fq 'Refusing prefix fallback' /tmp/test650-missing.out
+test ! -s /tmp/test650-attach.log
+
+echo "L4: unknown node fails before tmux"
+: > /tmp/test650-attach.log
+set +e
+run_cli attach 不存在 >/tmp/test650-unknown.out 2>&1
+unknown_rc=$?
+set -e
+test "$unknown_rc" -ne 0
+grep -Fq 'Node "不存在" not found.' /tmp/test650-unknown.out
+test ! -s /tmp/test650-attach.log
+
+echo "L5 witnessed-red: exact resolution weakened to prefix match"
+cp agent-network/src/tmux-attach.ts /tmp/test650-helper.ts
+sed -i 's/session.name === expectedName/session.name.startsWith(expectedName)/' agent-network/src/tmux-attach.ts
+grep -Fq 'session.name.startsWith(expectedName)' agent-network/src/tmux-attach.ts
+set +e
+run_tests >/tmp/test650-prefix-mutation.log 2>&1
+mutation_rc=$?
+set -e
+test "$mutation_rc" -ne 0
+echo "MUTATION_RED: prefix-match rc=$mutation_rc"
+cp /tmp/test650-helper.ts agent-network/src/tmux-attach.ts
+
+echo "L6 restored green"
+run_tests
+build_cli
+: > /tmp/test650-attach.log
+run_cli attach 测试牛
+grep -Fxq 'attach-session -t $2' /tmp/test650-attach.log
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #121

## Summary
- adds `anet attach <node-name>`
- resolves node aliases/node IDs through the existing local inventory
- enumerates tmux session ID + decoded name, matches the TUI name exactly in JS, then attaches by opaque session ID
- refuses prefix fallback when only `<alias>-node`, `<alias>-桥`, or another related non-TUI session remains
- adds the command to top-level help

## Verification
Docker-only test650 on exact source `94fb6281ec62ad987127a920d076de53c5da1889`:
- helper 3 pass / 3 assertions
- production CLI bundle PASS
- real CLI + fake tmux: Unicode alias chose `$2` exact TUI while prefix sibling `$1` appeared first
- missing exact TUI and unknown node both fail before attach
- exact-equality to startsWith mutation turns red

Evidence: `docs/tests/report-test650-anet-attach.txt`
Image: `sha256:4b89ed3950c66acd979fd486548d21eb19454c6591a02ff8eebe92c1185db2e3`
Report-only head: `c90f578a727cd75801518363b2110b383f30c98f`

No merge, publish, or deployment is requested by this draft.