### PR TITLE
fix(cli): stop prompting for legacy token during init

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2380,7 +2380,9 @@ Channel:
   anet channel ls [name]        List channels
 
 Setup:
-  anet init                     Configure hub URL (global)
+  anet init [--hub <url>]       Configure hub URL (global; no token prompt)
+  anet init --hub <url> --token <tok>
+                                Legacy master-token compatibility path
   anet init project             Setup project (channel plugin)
   anet setup                    Install runtime dependencies
   anet hub start                 Start CommHub Server + admin bootstrap
@@ -2504,10 +2506,10 @@ async function initGlobal() {
   if (!hub) { closeRL(); console.error("Error: hub URL required"); process.exit(1); }
   hub = hub.replace(/\/+$/, ""); // 去掉结尾斜杠
 
-  let token = opts.token || "";
-  if (!token) {
-    token = await ask("Auth token (legacy, press Enter to skip — most users skip)");
-  }
+  // V3 users authenticate with `anet login`; the legacy master token is an
+  // explicit compatibility path only. Do not make ordinary init look as
+  // though a token is required (#56).
+  const token = opts.token || "";
   closeRL();
   try {
     const res = await fetch(`${hub}/health`, { headers: token ? { Authorization: `Bearer ${token}` } : {} });

--- a/docs/tests/report-test651-init-no-token-prompt.txt
+++ b/docs/tests/report-test651-init-no-token-prompt.txt
@@ -1,0 +1,32 @@
+# test651 — `anet init` has no implicit legacy-token prompt
+
+Date: 2026-08-10 (Asia/Shanghai)
+
+## Provenance
+
+- Base: `ed608a8c699c8c7676c5b9c3d4f1a2909357dc5f`
+- Tested source: `1ca1e2551e883a9d66c48e5b22f4d330dda639b4`
+- Docker tag: `anet-test651:dev`
+- Image ID: `sha256:f647db9ac24ebef521318388122b506e3c29c80c04359d086d88c709fa07f3be`
+- Embedded env: `TEST651_SOURCE_COMMIT=1ca1e2551e883a9d66c48e5b22f4d330dda639b4`
+- Runner artifact SHA256: `335e96f5030c1042b6f8bd27ea9a7e6dece16c230e5550190f6d1e23c0698eee`
+- Runtime: Bun `1.3.14`; production CLI bundle executed with Node.
+
+## Result
+
+`RESULT: PASS`
+
+- The production CLI bundle built successfully.
+- Default `anet init --hub <url>` made an unauthenticated `/health` request,
+  printed no `Auth token` prompt, and persisted no token field.
+- Explicit `anet init --hub <url> --token <tok>` still sent the legacy Bearer
+  credential and persisted it, preserving the compatibility path requested by
+  issue #56.
+- Restoring the implicit prompt made the unchanged default-path assertion fail
+  (`rc=1`).
+- Discarding the explicit flag made the unchanged legacy compatibility
+  assertion fail (`rc=1`).
+- Restoring production source returned both paths to green.
+
+The isolated fake Hub and temporary HOME contain only synthetic credentials.
+No credential value is printed in the runner artifact or this report.

--- a/tests/test651-init-no-token-prompt/Dockerfile
+++ b/tests/test651-init-no-token-prompt/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY agent-network ./agent-network
+COPY tests/lib ./tests/lib
+COPY tests/test651-init-no-token-prompt ./tests/test651-init-no-token-prompt
+
+ARG TEST651_SOURCE_COMMIT=unknown
+ENV TEST651_SOURCE_COMMIT=$TEST651_SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test651-init-no-token-prompt/run.sh
+ENTRYPOINT ["/workspace/tests/test651-init-no-token-prompt/run.sh"]

--- a/tests/test651-init-no-token-prompt/mock-hub.mjs
+++ b/tests/test651-init-no-token-prompt/mock-hub.mjs
@@ -1,0 +1,23 @@
+import { appendFileSync } from "node:fs";
+
+const logPath = process.env.MOCK_LOG;
+if (!logPath) throw new Error("MOCK_LOG is required");
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 19151,
+  async fetch(req) {
+    const url = new URL(req.url);
+    appendFileSync(logPath, `${JSON.stringify({
+      method: req.method,
+      path: url.pathname,
+      authorization: req.headers.get("authorization"),
+    })}\n`);
+    if (url.pathname === "/health") {
+      return Response.json({ version: "test651", sessions_count: 2, sse_connections: 1 });
+    }
+    return new Response("not found", { status: 404 });
+  },
+});
+
+console.log(`READY ${server.port}`);

--- a/tests/test651-init-no-token-prompt/run.sh
+++ b/tests/test651-init-no-token-prompt/run.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /workspace/tests/lib/safe-rm.sh
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test651-init-no-token-prompt.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+cd /workspace
+
+echo "# test651 — anet init has no implicit legacy token prompt"
+echo "source_commit=${TEST651_SOURCE_COMMIT:-unknown}"
+echo "bun=$(bun --version)"
+echo "date=$(date -Is)"
+
+build_cli() {
+  safe_rm_rf /tmp/test651-dist
+  bun build agent-network/bin/cli.ts \
+    --outdir /tmp/test651-dist \
+    --entry-naming cli.js \
+    --target node \
+    --external @sleep2agi/commhub-server \
+    --external bun:sqlite \
+    --external '../../server/*' >/tmp/test651-build.log
+  test -s /tmp/test651-dist/cli.js
+}
+
+WORK=$(mktemp -d /tmp/test651-home.XXXXXX)
+trap 'kill "${hub_pid:-}" 2>/dev/null || true; safe_rm_rf "$WORK"' EXIT
+mkdir -p "$WORK/default" "$WORK/explicit"
+
+: > /tmp/test651-hub.log
+MOCK_LOG=/tmp/test651-hub.log bun tests/test651-init-no-token-prompt/mock-hub.mjs >/tmp/test651-hub.stdout 2>&1 &
+hub_pid=$!
+for _ in $(seq 1 30); do
+  grep -q '^READY 19151' /tmp/test651-hub.stdout 2>/dev/null && break
+  sleep 0.1
+done
+grep -q '^READY 19151' /tmp/test651-hub.stdout
+
+run_cli() {
+  local home=$1
+  shift
+  env -i PATH="$PATH" HOME="$home" LANG=C.UTF-8 \
+    node /tmp/test651-dist/cli.js "$@"
+}
+
+assert_default_no_prompt() {
+  safe_rm_rf "$WORK/default"
+  mkdir -p "$WORK/default"
+  : > /tmp/test651-hub.log
+  printf '\n' | run_cli "$WORK/default" init --hub http://127.0.0.1:19151 \
+    >/tmp/test651-default.out 2>&1
+  if grep -Fq 'Auth token' /tmp/test651-default.out; then
+    echo "FAIL: default init still prompted for a legacy token"
+    return 1
+  fi
+  grep -Fq '"authorization":null' /tmp/test651-hub.log
+  test -s "$WORK/default/.anet/config.json"
+  bun -e 'const c=JSON.parse(await Bun.file(process.argv[1]).text()); if(c.token!==undefined) process.exit(1)' \
+    "$WORK/default/.anet/config.json"
+}
+
+assert_explicit_token_works() {
+  safe_rm_rf "$WORK/explicit"
+  mkdir -p "$WORK/explicit"
+  : > /tmp/test651-hub.log
+  run_cli "$WORK/explicit" init --hub http://127.0.0.1:19151 --token test651_legacy_secret \
+    >/tmp/test651-explicit.out 2>&1
+  grep -Fq '"authorization":"Bearer test651_legacy_secret"' /tmp/test651-hub.log
+  bun -e 'const c=JSON.parse(await Bun.file(process.argv[1]).text()); if(c.token!=="test651_legacy_secret") process.exit(1)' \
+    "$WORK/explicit/.anet/config.json"
+}
+
+echo "L0: production CLI build"
+build_cli
+
+echo "L1: default init makes one unauthenticated health request without prompting"
+assert_default_no_prompt
+
+echo "L2: explicit legacy --token remains supported"
+assert_explicit_token_works
+
+echo "L3 witnessed-red: restore the implicit token prompt"
+cp agent-network/bin/cli.ts /tmp/test651-cli.ts
+sed -i 's/const token = opts.token || "";/let token = opts.token || ""; if (!token) token = await ask("Auth token (legacy)");/' agent-network/bin/cli.ts
+grep -Fq 'if (!token) token = await ask("Auth token (legacy)")' agent-network/bin/cli.ts
+build_cli
+set +e
+assert_default_no_prompt >/tmp/test651-prompt-mutation.log 2>&1
+prompt_rc=$?
+set -e
+test "$prompt_rc" -ne 0
+echo "MUTATION_RED: implicit-token-prompt rc=$prompt_rc"
+cp /tmp/test651-cli.ts agent-network/bin/cli.ts
+
+echo "L4 witnessed-red: discard the explicit --token path"
+sed -i 's/const token = opts.token || "";/const token = "";/' agent-network/bin/cli.ts
+grep -Fq 'const token = "";' agent-network/bin/cli.ts
+build_cli
+set +e
+assert_explicit_token_works >/tmp/test651-token-mutation.log 2>&1
+token_rc=$?
+set -e
+test "$token_rc" -ne 0
+echo "MUTATION_RED: explicit-token-discarded rc=$token_rc"
+cp /tmp/test651-cli.ts agent-network/bin/cli.ts
+
+echo "L5 restored green"
+build_cli
+assert_default_no_prompt
+assert_explicit_token_works
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #56

## Summary
- remove the implicit legacy token prompt from ordinary `anet init`
- retain the explicit `--token` compatibility path
- document both paths in CLI help

## Verification
- Docker test651 runs the production CLI bundle against an isolated fake Hub
- default path sends no Authorization header and persists no token
- explicit `--token` still authenticates and persists
- prompt-restoration and explicit-token-discard mutations both turn red

Tested source: `1ca1e2551e883a9d66c48e5b22f4d330dda639b4`
Report-only head: `6eb3c637503069239eecd6901274a5bc6fb601b7`

No merge, publish, or deployment performed.