### PR TITLE
fix(server): let global admins discover all networks

### DIFF
--- a/docs/tests/report-test652-admin-network-list.txt
+++ b/docs/tests/report-test652-admin-network-list.txt
@@ -1,0 +1,35 @@
+# test652 — global admin `/api/networks` visibility
+
+Date: 2026-08-10 (Asia/Shanghai)
+
+## Provenance
+
+- Base: `afddc6636d4894de0e1bd7f26372674af0e66d48`
+- Tested source: `159b73d0d084286e51d82e6629281508d4e6a873`
+- Docker tag: `anet-test652:dev`
+- Image ID: `sha256:b885b3ea19a7f8c7de8929ea3e59e5304dbaf0a472df5228b63611da3531ab29`
+- Embedded env: `TEST652_SOURCE_COMMIT=159b73d0d084286e51d82e6629281508d4e6a873`
+- Runner artifact SHA256: `fe6888ec10258f9419cccac5f45096eb4505f3e7b828d838f969dc645d34374d`
+- Runtime: Bun `1.3.14`.
+
+## Result
+
+`RESULT: PASS`
+
+- The production Hub entrypoint built successfully.
+- Real HTTP tests used two users with disjoint networks plus one network-bound
+  token: 3 tests, 0 failures, 14 assertions.
+- The global Hub admin saw both networks. Its own membership stayed `owner`;
+  the otherwise-authorized foreign network was labelled `admin`.
+- The response retained exactly the explicit public network projection plus
+  the existing `member_role` and `name` compatibility fields.
+- The ordinary user token saw only its membership network.
+- The node token saw only its bound network.
+- Restoring membership-only behavior for the global admin turned the unchanged
+  test red (`rc=1`).
+- Giving the global listing to an ordinary user turned the unchanged isolation
+  test red (`rc=1`).
+- Restored production source returned all tests to green.
+
+All users, tokens, networks, and databases were generated inside the isolated
+container. No credential value is included in the runner artifact or report.

--- a/server/src/admin-networks-http.test.ts
+++ b/server/src/admin-networks-http.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NETWORK_REST_COLUMNS } from "./rest-projections.js";
+
+const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-admin-networks-"));
+process.env.COMMHUB_DB ||= join(PRIVATE_DB_DIR, "hub.db");
+
+let server: ReturnType<typeof Bun.serve>;
+let base = "";
+let adminToken = "";
+let memberToken = "";
+let nodeToken = "";
+let adminNetworkId = "";
+let memberNetworkId = "";
+
+async function listNetworks(token: string): Promise<any[]> {
+  const response = await fetch(`${base}/api/networks`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(response.status).toBe(200);
+  const body = await response.json() as any;
+  expect(body.ok).toBe(true);
+  return body.networks;
+}
+
+beforeAll(async () => {
+  const { db } = await import("./db.js");
+  const { createNetworkTokenForNode, register } = await import("./auth.js");
+
+  // The first registered user is the global Hub admin. The second user owns a
+  // separate network and is intentionally not a member of the admin's network.
+  const admin = register(`admin_networks_${Date.now()}`, "AdminNetworks-Strong-1!", undefined, "admin");
+  expect(admin.ok).toBe(true);
+  adminToken = admin.token!;
+  adminNetworkId = admin.network_id!;
+
+  const member = register(`member_networks_${Date.now()}`, "MemberNetworks-Strong-1!", undefined, "member");
+  expect(member.ok).toBe(true);
+  memberToken = member.token!;
+  memberNetworkId = member.network_id!;
+
+  const memberUserId = db.get<{ user_id: string }>(
+    "SELECT user_id FROM users WHERE username LIKE 'member_networks_%' ORDER BY created_at DESC LIMIT 1",
+  )!.user_id;
+  const minted = createNetworkTokenForNode(memberUserId, memberNetworkId, "admin-networks-node");
+  expect(minted.ok).toBe(true);
+  nodeToken = minted.token!;
+
+  const mod = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop(true); } catch {}
+  try { rmSync(PRIVATE_DB_DIR, { recursive: true, force: true }); } catch {}
+});
+
+describe("GET /api/networks global-admin visibility (#94)", () => {
+  test("global admin utok sees every network without losing public shape", async () => {
+    const rows = await listNetworks(adminToken);
+    expect(new Set(rows.map((row) => row.network_id))).toEqual(new Set([adminNetworkId, memberNetworkId]));
+
+    const own = rows.find((row) => row.network_id === adminNetworkId);
+    const foreign = rows.find((row) => row.network_id === memberNetworkId);
+    expect(own.member_role).toBe("owner");
+    expect(foreign.member_role).toBe("admin");
+    expect(Object.keys(foreign).sort()).toEqual([...NETWORK_REST_COLUMNS, "member_role", "name"].sort());
+  });
+
+  test("ordinary utok remains limited to member networks", async () => {
+    const rows = await listNetworks(memberToken);
+    expect(rows.map((row) => row.network_id)).toEqual([memberNetworkId]);
+    expect(rows.some((row) => row.network_id === adminNetworkId)).toBe(false);
+  });
+
+  test("network token remains limited to its bound network", async () => {
+    const rows = await listNetworks(nodeToken);
+    expect(rows.map((row) => row.network_id)).toEqual([memberNetworkId]);
+    expect(rows.some((row) => row.network_id === adminNetworkId)).toBe(false);
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1122,8 +1122,23 @@ return Bun.serve({
         const net = db.get<any>(`SELECT ${NETWORK_REST_SELECT} FROM networks WHERE network_id = ?1`, resolved.networkId);
         return withCors(req, Response.json({ ok: true, networks: net ? [withNetworkNameAlias(net)] : [] }));
       }
-      const networks = getUserAllNetworks(resolved.user.user_id).map(withNetworkNameAlias);
-      return withCors(req, Response.json({ ok: true, networks }));
+      // Global Hub admins have cross-network authority throughout the REST
+      // surface, so limiting this discovery endpoint to their membership rows
+      // made otherwise-authorized networks impossible to select (#94). Keep
+      // ordinary utok_ callers membership-scoped; ntok_ returned above stays
+      // bound to exactly one network.
+      const networks = resolved.user.role === "admin"
+        ? db.all<any>(
+            `SELECT ${NETWORK_REST_SELECT},
+                    COALESCE((SELECT nm.role FROM network_members nm
+                              WHERE nm.network_id = networks.network_id
+                                AND nm.user_id = ?1), 'admin') AS member_role
+             FROM networks ORDER BY created_at`,
+            resolved.user.user_id,
+          )
+        : getUserAllNetworks(resolved.user.user_id);
+      const visibleNetworks = networks.map(withNetworkNameAlias);
+      return withCors(req, Response.json({ ok: true, networks: visibleNetworks }));
     }
 
     if (url.pathname === "/api/networks" && req.method === "POST") {

--- a/tests/test652-admin-network-list/Dockerfile
+++ b/tests/test652-admin-network-list/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test652-admin-network-list/run.sh /run.sh
+
+ARG TEST652_SOURCE_COMMIT=unknown
+ENV TEST652_SOURCE_COMMIT=$TEST652_SOURCE_COMMIT
+
+RUN chmod 0755 /run.sh
+ENTRYPOINT ["/run.sh"]

--- a/tests/test652-admin-network-list/run.sh
+++ b/tests/test652-admin-network-list/run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test652-admin-network-list.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+cd /workspace
+
+echo "# test652 — global admin /api/networks visibility"
+echo "source_commit=${TEST652_SOURCE_COMMIT:-unknown}"
+echo "bun=$(bun --version)"
+echo "date=$(date -Is)"
+
+run_http_test() {
+  COMMHUB_DB=$(mktemp /tmp/test652-db.XXXXXX) \
+    bun test server/src/admin-networks-http.test.ts
+}
+
+echo "L0: production Hub build"
+bun build server/src/index.ts --target bun --outfile /tmp/test652-hub.js
+test -s /tmp/test652-hub.js
+
+echo "L1: real HTTP admin/member/ntok visibility"
+run_http_test
+
+cp server/src/server.ts /tmp/test652-server.ts
+
+echo "L2 witnessed-red: collapse global admin back to membership-only listing"
+sed -i '/const networks = resolved.user.role === "admin"/,/: getUserAllNetworks(resolved.user.user_id);/c\      const networks = getUserAllNetworks(resolved.user.user_id);' server/src/server.ts
+grep -Fq 'const networks = getUserAllNetworks(resolved.user.user_id);' server/src/server.ts
+set +e
+run_http_test >/tmp/test652-admin-mutation.log 2>&1
+admin_rc=$?
+set -e
+test "$admin_rc" -ne 0
+grep -Fq 'global admin utok sees every network' /tmp/test652-admin-mutation.log
+echo "MUTATION_RED: admin-membership-only rc=$admin_rc"
+cp /tmp/test652-server.ts server/src/server.ts
+
+echo "L3 witnessed-red: let ordinary utok use the global-admin listing"
+sed -i '/const networks = resolved.user.role === "admin"/,/: getUserAllNetworks(resolved.user.user_id);/ s/resolved.user.role === "admin"/true/' server/src/server.ts
+grep -Fq 'const networks = true' server/src/server.ts
+set +e
+run_http_test >/tmp/test652-member-mutation.log 2>&1
+member_rc=$?
+set -e
+test "$member_rc" -ne 0
+grep -Fq 'ordinary utok remains limited to member networks' /tmp/test652-member-mutation.log
+echo "MUTATION_RED: ordinary-user-global-list rc=$member_rc"
+cp /tmp/test652-server.ts server/src/server.ts
+
+echo "L4 restored green"
+run_http_test
+
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #94

## Summary
- let global Hub admins discover all networks through `GET /api/networks`
- preserve actual membership roles, using `admin` for globally-authorized non-member rows
- keep ordinary utok callers membership-scoped and ntok callers bound to one network
- retain the explicit public response projection

## Verification
- real HTTP Hub test with two disjoint users and a network token
- 3 tests, 14 assertions
- membership-only-admin and ordinary-user-global-list mutations both turn red

Tested source: `159b73d0d084286e51d82e6629281508d4e6a873`
Report-only head: `af72ef84c748047a5d0f51b603916f04f3de4415`

No merge or deployment performed.
