### PR TITLE
fix(cli): normalize batch workdirs before cwd changes (#178)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -106,6 +106,7 @@ import {
   collectClaudeVendorEnvForCreate,
   planPlainSecretEnvRewrites,
 } from "../src/claude-vendor-env";
+import { normalizeBatchWorkdir } from "../src/batch-workdir";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -11629,6 +11630,11 @@ async function createBatch(opts: BatchOptions): Promise<BatchResult> {
     validateNodeName(opts.leaderAlias);
   }
 
+  // #178 — normalize once, before the loop changes process.cwd(). A literal
+  // wizard value such as `~/design` is not expanded by Node; if left relative,
+  // every process.chdir() iteration nests another `~/design` segment.
+  opts = { ...opts, workdir: normalizeBatchWorkdir(opts.workdir) };
+
   const tmuxPrefix = opts.team || opts.prefix;
   const gc = loadGlobal();
   mkdirSync(opts.workdir, { recursive: true });
@@ -11793,11 +11799,13 @@ function batchLifecycle(opts: { prefix: string; verb: "start" | "stop" | "restar
   if (verb === "stop") return;
 
   if (verb === "cleanup") {
-    const dir = workdir;
-    if (!dir) {
+    if (!workdir) {
       console.error("[anet] cleanup 需要 --workdir <path> 指明清理目录。");
       return;
     }
+    // Use the same one-time expansion as createBatch. Besides matching create,
+    // this prevents cleanup from treating a literal `~/...` as cwd-relative.
+    const dir = normalizeBatchWorkdir(workdir);
     if (!existsSync(dir)) {
       console.error(`[anet] 工作目录不存在: ${dir}`);
       return;

--- a/agent-network/src/batch-workdir-wiring.test.ts
+++ b/agent-network/src/batch-workdir-wiring.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const cli = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+
+describe("batch workdir wiring", () => {
+  test("normalizes create workdir before mkdir or chdir", () => {
+    expect(cli).toContain('import { normalizeBatchWorkdir } from "../src/batch-workdir"');
+    const createStart = cli.indexOf("async function createBatch(opts: BatchOptions)");
+    const mkdir = cli.indexOf("mkdirSync(opts.workdir", createStart);
+    const normalize = cli.indexOf("opts = { ...opts, workdir: normalizeBatchWorkdir", createStart);
+    expect(createStart).toBeGreaterThan(-1);
+    expect(normalize).toBeGreaterThan(createStart);
+    expect(mkdir).toBeGreaterThan(normalize);
+  });
+
+  test("normalizes cleanup workdir before filesystem mutation", () => {
+    const lifecycleStart = cli.indexOf("function batchLifecycle(");
+    const cleanupStart = cli.indexOf('if (verb === "cleanup")', lifecycleStart);
+    const normalize = cli.indexOf("normalizeBatchWorkdir(workdir)", cleanupStart);
+    const exists = cli.indexOf("existsSync(dir)", cleanupStart);
+    const remove = cli.indexOf("rmSync(join(dir, sub)", cleanupStart);
+    expect(normalize).toBeGreaterThan(cleanupStart);
+    expect(exists).toBeGreaterThan(normalize);
+    expect(remove).toBeGreaterThan(exists);
+  });
+});

--- a/agent-network/src/batch-workdir.test.ts
+++ b/agent-network/src/batch-workdir.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+import { normalizeBatchWorkdir } from "./batch-workdir";
+
+describe("normalizeBatchWorkdir", () => {
+  test("expands current-user tilde before a batch changes cwd", () => {
+    const root = normalizeBatchWorkdir("~/design", "/workspace/current", "/home/tester");
+    expect(root).toBe("/home/tester/design");
+    expect(join(root, "node1")).toBe("/home/tester/design/node1");
+    expect(join(root, "node2")).toBe("/home/tester/design/node2");
+    expect(root).not.toContain("~");
+  });
+
+  test("anchors a relative workdir once to the caller cwd", () => {
+    const root = normalizeBatchWorkdir("teams/research", "/workspace/current", "/home/tester");
+    expect(root).toBe("/workspace/current/teams/research");
+    expect(join(root, "node3")).toBe("/workspace/current/teams/research/node3");
+  });
+
+  test("keeps an absolute workdir absolute", () => {
+    expect(normalizeBatchWorkdir("/srv/agents", "/elsewhere", "/home/tester"))
+      .toBe("/srv/agents");
+  });
+
+  test("rejects empty and unsupported named-user shorthands", () => {
+    expect(() => normalizeBatchWorkdir("  ", "/work", "/home/tester")).toThrow("empty");
+    expect(() => normalizeBatchWorkdir("~other/team", "/work", "/home/tester"))
+      .toThrow("unsupported home shorthand");
+  });
+});

--- a/agent-network/src/batch-workdir.ts
+++ b/agent-network/src/batch-workdir.ts
@@ -1,0 +1,30 @@
+import { homedir } from "os";
+import { resolve } from "path";
+
+/**
+ * Resolve one batch workdir before any mkdir/chdir loop starts.
+ *
+ * Node does not expand shell tildes. Leaving `~/team` relative means every
+ * iteration can resolve it from the previous node's cwd and create paths such
+ * as `/work/~/team/~/team`. Only the current user's `~` form is supported;
+ * `~other` is rejected instead of being written as a literal directory.
+ */
+export function normalizeBatchWorkdir(
+  input: string,
+  cwd = process.cwd(),
+  home = homedir(),
+): string {
+  const trimmed = input.trim();
+  if (!trimmed) throw new Error("batch workdir is empty");
+
+  let expanded = trimmed;
+  if (trimmed === "~") {
+    expanded = home;
+  } else if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    expanded = resolve(home, trimmed.slice(2));
+  } else if (trimmed.startsWith("~")) {
+    throw new Error(`unsupported home shorthand in batch workdir: ${trimmed}`);
+  }
+
+  return resolve(cwd, expanded);
+}

--- a/docs/tests/report-test653-batch-workdir.txt
+++ b/docs/tests/report-test653-batch-workdir.txt
@@ -1,0 +1,46 @@
+# test653 — #178 batch workdir normalization
+
+Date: 2026-08-10 (Asia/Shanghai)
+Base: `4a23a4f46c6455ab567227e63c2f2795283d27b2`
+Tested source commit: `29e1fc90f31225025c1c0e1024ece697b045b209`
+Docker tag: `anet-test653:dev`
+Docker image: `sha256:0d6f99acd51f41b25c5a27abd23c2c1013ce12db7d639d69b059719ce4a30b88`
+Embedded env: `TEST653_SOURCE_COMMIT=29e1fc90f31225025c1c0e1024ece697b045b209`
+Runner artifact SHA256: `a1f0833280c32895e8406c96c0d8b40a82b08683a16ce48198b1fb860ca0d12d`
+
+## Fact audit
+
+- Production status contained 203 sessions; 198 reported `project_dir`.
+- 15 historical offline rows contained literal `~` segments, including increasing forms such as:
+  - `/Users/vansin/code/VideoNode/~/code/VideoNode/...`
+  - `/home/vansin/design/~/design/...`
+- All 15 suspicious rows were already offline; this change does not rewrite or delete historical rows.
+- Every current producer reports `process.cwd()`. The corruption source was the batch CLI accepting a literal or relative workdir, then changing cwd inside its node loop. A value such as `~/design` was therefore resolved again from each previous node cwd.
+
+## Change
+
+- Added one `normalizeBatchWorkdir()` choke point.
+- `~` and `~/...` expand to the current user's home.
+- Relative workdirs are anchored once to the caller cwd before any loop.
+- Absolute workdirs remain absolute.
+- Unsupported `~other/...` and empty input fail closed.
+- Batch cleanup uses the same normalization, so create and cleanup resolve the same root.
+
+## Docker evidence
+
+- Production CLI bundle built successfully under Bun 1.3.14.
+- Unit/wiring layer: 6 pass, 0 fail, 16 assertions.
+- Real CLI create layer:
+  - isolated HOME, fake Hub only for node-token issuance, fake tmux only for cwd capture;
+  - `anet create --batch --workdir '~/design' --count 2` created exactly:
+    - `<HOME>/design/node1/.anet/nodes/worker1号/config.json`
+    - `<HOME>/design/node2/.anet/nodes/worker2号/config.json`
+  - tmux launch cwd values were exactly `<HOME>/design/node1` and `<HOME>/design/node2`;
+  - no literal `~` directory appeared below the invocation cwd.
+- Real CLI cleanup layer removed the same expanded `<HOME>/design` tree.
+- Mutation witnessed-red:
+  - delete create normalization: rc=1 and the real CLI recreated `start/~/design/node1` nesting;
+  - replace cleanup normalization with raw input: rc=1 and the intended home tree remained untouched.
+- Restored source reran all layers green.
+
+Final result: `PASS`.

--- a/tests/test653-batch-workdir/Dockerfile
+++ b/tests/test653-batch-workdir/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+COPY agent-network ./agent-network
+COPY tests/test653-batch-workdir /test653
+
+ARG TEST653_SOURCE_COMMIT=unknown
+ENV TEST653_SOURCE_COMMIT=$TEST653_SOURCE_COMMIT
+
+RUN chmod 0755 /test653/run.sh /test653/tmux
+ENTRYPOINT ["/test653/run.sh"]

--- a/tests/test653-batch-workdir/fake-hub.ts
+++ b/tests/test653-batch-workdir/fake-hub.ts
@@ -1,0 +1,13 @@
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 19178,
+  fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/api/auth/node-token" && request.method === "POST") {
+      return Response.json({ ok: true, token: `ntok_test653_${crypto.randomUUID()}` });
+    }
+    return Response.json({ ok: false, error: "not_found" }, { status: 404 });
+  },
+});
+
+console.log(`fake-hub=${server.url}`);

--- a/tests/test653-batch-workdir/run.sh
+++ b/tests/test653-batch-workdir/run.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test653-batch-workdir.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+cd /workspace
+
+echo "# test653 — batch workdir normalization"
+echo "source_commit=${TEST653_SOURCE_COMMIT:-unknown}"
+echo "bun=$(bun --version)"
+echo "date=$(date -Is)"
+
+run_tests() {
+  bun test agent-network/src/batch-workdir.test.ts agent-network/src/batch-workdir-wiring.test.ts
+}
+
+build_cli() {
+  cd /workspace/agent-network
+  bun build bin/cli.ts --target node --outfile /tmp/test653-cli.js \
+    --external @sleep2agi/commhub-server --external bun:sqlite --external '../../server/*'
+  test -s /tmp/test653-cli.js
+  cd /workspace
+}
+
+prepare_case() {
+  local case_root=$1
+  mkdir -p "$case_root/home/.anet" "$case_root/start"
+  chmod 0700 "$case_root/home/.anet"
+  printf '%s\n' '{"hub":"http://127.0.0.1:19178","token":"utok_test653","user":{"user_id":"u_test653","username":"tester","role":"admin"},"network_id":"net_test653","network_name":"test653"}' > "$case_root/home/.anet/config.json"
+  chmod 0600 "$case_root/home/.anet/config.json"
+  : > "$case_root/tmux-cwds"
+}
+
+run_create_case() {
+  local case_root=$1
+  prepare_case "$case_root"
+  (
+    cd "$case_root/start"
+    HOME="$case_root/home" \
+    PATH="/test653:$PATH" \
+    TEST653_TMUX_CWDS="$case_root/tmux-cwds" \
+      bun /tmp/test653-cli.js create --batch \
+        --preset claude-sonnet-4-6 --api-key fake-test-key \
+        --workdir '~/design' --workdir-mode separate \
+        --prefix worker --count 2 --description test653
+  )
+  test -f "$case_root/home/design/node1/.anet/nodes/worker1号/config.json" \
+    && test -f "$case_root/home/design/node2/.anet/nodes/worker2号/config.json" \
+    && test ! -e "$case_root/start/~" \
+    && test "$(sed -n '1p' "$case_root/tmux-cwds")" = "$case_root/home/design/node1" \
+    && test "$(sed -n '2p' "$case_root/tmux-cwds")" = "$case_root/home/design/node2"
+}
+
+run_cleanup_case() {
+  local case_root=$1
+  prepare_case "$case_root"
+  mkdir -p "$case_root/home/design/node1"
+  printf '%s\n' keep-until-cleanup > "$case_root/home/design/node1/marker"
+  (
+    cd "$case_root/start"
+    HOME="$case_root/home" \
+    PATH="/test653:$PATH" \
+    TEST653_TMUX_CWDS="$case_root/tmux-cwds" \
+      bun /tmp/test653-cli.js batch cleanup worker --workdir '~/design'
+  )
+  test ! -e "$case_root/home/design" \
+    && test ! -e "$case_root/start/~"
+}
+
+echo "L0: production CLI build"
+build_cli
+
+echo "L1: tilde, relative, absolute, invalid shorthand, and production wiring"
+run_tests
+
+echo "L1b: real CLI batch create anchors two nodes under one expanded home"
+bun /test653/fake-hub.ts >/tmp/test653-fake-hub.log 2>&1 &
+hub_pid=$!
+trap 'kill "$hub_pid" 2>/dev/null || true' EXIT
+for _ in $(seq 1 50); do
+  if grep -Fq 'fake-hub=' /tmp/test653-fake-hub.log; then break; fi
+  sleep 0.1
+done
+grep -Fq 'fake-hub=' /tmp/test653-fake-hub.log
+run_create_case /tmp/test653-live
+
+echo "L1c: real CLI cleanup targets the same expanded home"
+run_cleanup_case /tmp/test653-cleanup-live
+
+cp agent-network/bin/cli.ts /tmp/test653-cli.ts
+
+echo "L2 witnessed-red: remove createBatch normalization"
+sed -i '/opts = { \.\.\.opts, workdir: normalizeBatchWorkdir(opts.workdir) };/d' agent-network/bin/cli.ts
+if cmp -s agent-network/bin/cli.ts /tmp/test653-cli.ts; then
+  echo "mutation did not change cli.ts" >&2
+  exit 1
+fi
+build_cli
+set +e
+run_create_case /tmp/test653-create-mutation >/tmp/test653-create-mutation.log 2>&1
+create_rc=$?
+set -e
+test "$create_rc" -ne 0
+test -d '/tmp/test653-create-mutation/start/~/design/node1'
+echo "MUTATION_RED: create-normalization-removed rc=$create_rc"
+cp /tmp/test653-cli.ts agent-network/bin/cli.ts
+
+echo "L3 witnessed-red: remove cleanup normalization"
+sed -i 's/const dir = normalizeBatchWorkdir(workdir);/const dir = workdir;/' agent-network/bin/cli.ts
+grep -Fq 'const dir = workdir;' agent-network/bin/cli.ts
+build_cli
+set +e
+run_cleanup_case /tmp/test653-cleanup-mutation >/tmp/test653-cleanup-mutation.log 2>&1
+cleanup_rc=$?
+set -e
+test "$cleanup_rc" -ne 0
+test -f /tmp/test653-cleanup-mutation/home/design/node1/marker
+echo "MUTATION_RED: cleanup-normalization-removed rc=$cleanup_rc"
+cp /tmp/test653-cli.ts agent-network/bin/cli.ts
+
+echo "L4 restored green"
+build_cli
+run_tests
+run_create_case /tmp/test653-restored
+run_cleanup_case /tmp/test653-cleanup-restored
+
+echo "RESULT: PASS"

--- a/tests/test653-batch-workdir/tmux
+++ b/tests/test653-batch-workdir/tmux
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "new-session" ]]; then
+  pwd >> "${TEST653_TMUX_CWDS:?}"
+fi
+exit 0


### PR DESCRIPTION
## Summary

- normalize batch workdirs exactly once before the create loop changes cwd
- expand current-user `~`, anchor relative paths to the original cwd, and reject unsupported named-user shorthand
- make batch cleanup resolve the same root as batch create
- leave historical Hub rows untouched

## Root cause

Node does not expand `~`. Batch creation previously passed a literal/relative workdir directly to `mkdirSync` and `process.chdir`; later loop iterations then resolved it from the prior node cwd, producing paths like `/home/user/design/~/design/...`.

## Verification

- Docker tag: `anet-test653:dev`
- tested source: `29e1fc90f31225025c1c0e1024ece697b045b209`
- 6 unit/wiring tests, 16 assertions
- real CLI create with isolated HOME + fake Hub/tmux dependency seams creates two nodes under one expanded absolute root
- real CLI cleanup removes that same root
- two behavior mutations turn red when create or cleanup normalization is removed
- report: `docs/tests/report-test653-batch-workdir.txt`

Closes #178.
