### PR TITLE
fix(cli): safely manage Dashboard launches

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -110,6 +110,7 @@ import { normalizeBatchWorkdir } from "../src/batch-workdir";
 import {
   decideDashboardListener,
   parseDashboardLaunchRecord,
+  isDashboardProcessCommand,
   type DashboardLaunchRecord,
   type DashboardLaunchSource,
 } from "../src/dashboard-managed-process";
@@ -1521,6 +1522,30 @@ function loadDashboardLaunchRecord(port: string | number): DashboardLaunchRecord
   } catch { return null; }
 }
 
+function sameDashboardLaunchRecord(a: DashboardLaunchRecord | null, b: DashboardLaunchRecord): boolean {
+  return !!a
+    && a.schema === b.schema
+    && a.port === b.port
+    && a.listener_pid === b.listener_pid
+    && a.listener_birth === b.listener_birth
+    && a.source === b.source
+    && a.source_key === b.source_key
+    && a.recorded_at === b.recorded_at;
+}
+
+function revalidateExactManagedDashboard(
+  pid: number,
+  port: string | number,
+  expectedRecord: DashboardLaunchRecord,
+): boolean {
+  const scan = scanDashboardListenerPids(port);
+  if (!scan.ok || scan.pids.length !== 1 || scan.pids[0] !== pid) return false;
+  if (!sameDashboardLaunchRecord(loadDashboardLaunchRecord(port), expectedRecord)) return false;
+  if (dashboardProcessField(pid, "lstart") !== expectedRecord.listener_birth) return false;
+  const command = dashboardProcessField(pid, "command");
+  return !!command && isDashboardProcessCommand(command);
+}
+
 async function dashboardHttpHealthy(host: string, port: string | number): Promise<boolean> {
   const probeHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
   try {
@@ -1547,13 +1572,23 @@ function resolveDashboardNpxVersion(tag: string): string | null {
   } catch { return null; }
 }
 
-async function stopExactManagedDashboard(pid: number, port: string | number): Promise<boolean> {
+async function stopExactManagedDashboard(
+  pid: number,
+  port: string | number,
+  expectedRecord: DashboardLaunchRecord,
+): Promise<boolean> {
+  // Re-read every identity fact immediately before the signal. The PID may
+  // have exited and been reused after the initial decision was made.
+  if (!revalidateExactManagedDashboard(pid, port, expectedRecord)) return false;
   try { process.kill(pid, "SIGTERM"); } catch { return false; }
   for (let i = 0; i < 12; i++) {
     await new Promise(resolve => setTimeout(resolve, 250));
     const scan = scanDashboardListenerPids(port);
     if (scan.ok && !scan.pids.includes(pid)) return true;
   }
+  // The grace period is another PID-reuse window. Never escalate based on
+  // the pre-SIGTERM observation; authorize the exact PID again.
+  if (!revalidateExactManagedDashboard(pid, port, expectedRecord)) return false;
   try { process.kill(pid, "SIGKILL"); } catch {}
   await new Promise(resolve => setTimeout(resolve, 250));
   const finalScan = scanDashboardListenerPids(port);
@@ -5986,10 +6021,11 @@ async function serverCommand() {
       console.warn(`[anet]   No process will be auto-stopped; an occupied port will fail normally.`);
     } else if (listenerScan.pids.length > 0) {
       const listenerPid = listenerScan.pids.length === 1 ? listenerScan.pids[0] : -1;
+      const launchRecord = loadDashboardLaunchRecord(dashPort);
       const decision = decideDashboardListener({
         port: dashPortNumber,
         listenerPids: listenerScan.pids,
-        record: loadDashboardLaunchRecord(dashPort),
+        record: launchRecord,
         listenerBirth: listenerPid > 1 ? dashboardProcessField(listenerPid, "lstart") : null,
         listenerCommand: listenerPid > 1 ? dashboardProcessField(listenerPid, "command") : null,
         desiredSource: launchSource,
@@ -6007,7 +6043,7 @@ async function serverCommand() {
       }
       if (decision.action === "terminate_owned_stale") {
         console.log(`[anet] stopping exact managed stale Dashboard pid ${decision.pid} (${decision.reason})...`);
-        if (!await stopExactManagedDashboard(decision.pid, dashPort)) {
+        if (!launchRecord || !await stopExactManagedDashboard(decision.pid, dashPort, launchRecord)) {
           console.error(`[anet] Refusing replacement startup: exact managed pid ${decision.pid} still owns port ${dashPort}.`);
           process.exit(1);
         }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -107,6 +107,12 @@ import {
   planPlainSecretEnvRewrites,
 } from "../src/claude-vendor-env";
 import { normalizeBatchWorkdir } from "../src/batch-workdir";
+import {
+  decideDashboardListener,
+  parseDashboardLaunchRecord,
+  type DashboardLaunchRecord,
+  type DashboardLaunchSource,
+} from "../src/dashboard-managed-process";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -118,6 +124,7 @@ const opencodeBindingHome = () => home === "~" ? homedir() : home;
 function globalConfigPath() { return join(home, ".anet", "config.json"); }
 function serverConfigPath() { return join(home, ".anet", "server", "config.json"); }
 function adminUtokPath() { return join(home, ".anet", "server", "admin-utok.json"); }
+function dashboardLaunchRecordPath(port: string | number) { return join(home, ".anet", "server", `dashboard-${port}.json`); }
 function nodesDir() { return join(process.cwd(), ".anet", "nodes"); }
 function shellQuote(value: string): string { return `'${value.replace(/'/g, `'\\''`)}'`; }
 function killTmuxSession(sessionName: string) {
@@ -1466,6 +1473,91 @@ function dashboardReleaseTag(): string {
   const envOverride = process.env.ANET_DASHBOARD_VERSION;
   if (envOverride) return envOverride;
   return "preview";
+}
+
+type DashboardPidScan = { ok: true; pids: number[] } | { ok: false; error: string };
+
+function scanDashboardListenerPids(port: string | number): DashboardPidScan {
+  if (!commandExists("lsof")) return { ok: false, error: "lsof is not installed" };
+  try {
+    const out = execFileSync("lsof", ["-t", "-i", `:${port}`, "-sTCP:LISTEN"], { encoding: "utf-8" }).trim();
+    const pids = [...new Set(out.split(/\s+/).filter(Boolean).map(Number).filter(pid => Number.isSafeInteger(pid) && pid > 1))];
+    return { ok: true, pids };
+  } catch (error: any) {
+    // lsof exits 1 when no matching listener exists. Distinguish that from
+    // a missing/broken inspector; commandExists above already proved the
+    // binary exists, and empty stdout is the canonical no-listener result.
+    const stdout = String(error?.stdout || "").trim();
+    if (!stdout && Number(error?.status) === 1) return { ok: true, pids: [] };
+    return { ok: false, error: `lsof failed (${error?.status ?? "unknown"})` };
+  }
+}
+
+function dashboardProcessField(pid: number, field: "lstart" | "command" | "ppid"): string | null {
+  if (!commandExists("ps")) return null;
+  try {
+    const value = execFileSync("ps", ["-p", String(pid), "-o", `${field}=`], { encoding: "utf-8" }).trim();
+    return value || null;
+  } catch { return null; }
+}
+
+function dashboardListenerDescendsFrom(pid: number, ancestorPid: number): boolean {
+  let current = pid;
+  const seen = new Set<number>();
+  for (let depth = 0; depth < 64 && current > 1 && !seen.has(current); depth++) {
+    if (current === ancestorPid) return true;
+    seen.add(current);
+    const raw = dashboardProcessField(current, "ppid");
+    const parent = raw ? Number(raw) : NaN;
+    if (!Number.isSafeInteger(parent) || parent <= 0) return false;
+    current = parent;
+  }
+  return false;
+}
+
+function loadDashboardLaunchRecord(port: string | number): DashboardLaunchRecord | null {
+  try {
+    return parseDashboardLaunchRecord(JSON.parse(readFileSync(dashboardLaunchRecordPath(port), "utf-8")));
+  } catch { return null; }
+}
+
+async function dashboardHttpHealthy(host: string, port: string | number): Promise<boolean> {
+  const probeHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  try {
+    const response = await fetch(`http://${probeHost}:${port}/login`, { signal: AbortSignal.timeout(1500), redirect: "manual" });
+    return response.status >= 200 && response.status < 500;
+  } catch { return false; }
+}
+
+function resolveGlobalDashboardBinary(): string | null {
+  try {
+    const found = execFileSync("which", ["agent-network-dashboard"], { encoding: "utf-8" }).trim();
+    return found ? realpathSync(found) : null;
+  } catch { return null; }
+}
+
+function resolveDashboardNpxVersion(tag: string): string | null {
+  try {
+    const raw = execFileSync("npm", ["view", `@sleep2agi/agent-network-dashboard@${tag}`, "version", "--json"], {
+      encoding: "utf-8",
+      timeout: 8000,
+    }).trim();
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "string" && parsed ? parsed : null;
+  } catch { return null; }
+}
+
+async function stopExactManagedDashboard(pid: number, port: string | number): Promise<boolean> {
+  try { process.kill(pid, "SIGTERM"); } catch { return false; }
+  for (let i = 0; i < 12; i++) {
+    await new Promise(resolve => setTimeout(resolve, 250));
+    const scan = scanDashboardListenerPids(port);
+    if (scan.ok && !scan.pids.includes(pid)) return true;
+  }
+  try { process.kill(pid, "SIGKILL"); } catch {}
+  await new Promise(resolve => setTimeout(resolve, 250));
+  const finalScan = scanDashboardListenerPids(port);
+  return finalScan.ok && !finalScan.pids.includes(pid);
 }
 
 // #89 — npx leaves half-baked `.agent-network-dashboard-<rand>` staging dirs in
@@ -5863,11 +5955,64 @@ async function serverCommand() {
     const gc = loadGlobal();
     const hubUrl = gc.hub || "http://127.0.0.1:9200";
     const dashPort = opts.port || "3000";
+    const dashPortNumber = Number(dashPort);
+    if (!Number.isSafeInteger(dashPortNumber) || dashPortNumber < 1 || dashPortNumber > 65535) {
+      console.error(`[anet] Invalid Dashboard port: ${dashPort}`);
+      process.exit(1);
+    }
     // --host / --ip for LAN access; defaults to 127.0.0.1.
     const dashHost = opts.ip || opts.host || process.env.HOSTNAME || "127.0.0.1";
 
+    const globalOptIn = process.env.ANET_DASHBOARD_LOCAL === "1";
+    const tag = dashboardReleaseTag();
+    const globalBinary = globalOptIn ? resolveGlobalDashboardBinary() : null;
+    if (globalOptIn && !globalBinary) {
+      console.error(`[anet] ANET_DASHBOARD_LOCAL=1 requested the global Dashboard, but agent-network-dashboard is not on PATH.`);
+      console.error(`[anet] Install it explicitly or unset ANET_DASHBOARD_LOCAL to keep channel-matched npx startup.`);
+      process.exit(1);
+    }
+    const launchSource: DashboardLaunchSource = globalOptIn ? "global" : "npx";
+    const npxVersion = globalOptIn ? null : resolveDashboardNpxVersion(tag);
+    const sourceKey = globalOptIn
+      ? `global:${globalBinary}`
+      : `npx:${npxVersion || `unresolved-${tag}`}`;
+
     console.log(`[anet] Starting Dashboard on ${dashHost}:${dashPort}...`);
     console.log(`[anet] Connecting to CommHub: ${hubUrl}`);
+
+    const listenerScan = scanDashboardListenerPids(dashPort);
+    if (!listenerScan.ok) {
+      console.warn(`[anet] ⚠ Dashboard listener inspection unavailable: ${listenerScan.error}.`);
+      console.warn(`[anet]   No process will be auto-stopped; an occupied port will fail normally.`);
+    } else if (listenerScan.pids.length > 0) {
+      const listenerPid = listenerScan.pids.length === 1 ? listenerScan.pids[0] : -1;
+      const decision = decideDashboardListener({
+        port: dashPortNumber,
+        listenerPids: listenerScan.pids,
+        record: loadDashboardLaunchRecord(dashPort),
+        listenerBirth: listenerPid > 1 ? dashboardProcessField(listenerPid, "lstart") : null,
+        listenerCommand: listenerPid > 1 ? dashboardProcessField(listenerPid, "command") : null,
+        desiredSource: launchSource,
+        desiredSourceKey: sourceKey,
+        healthy: await dashboardHttpHealthy(dashHost, dashPort),
+      });
+      if (decision.action === "already_running") {
+        console.log(`[anet] ✅ Dashboard already running on ${dashHost}:${dashPort} (managed pid ${decision.pid}); leaving it untouched.`);
+        return;
+      }
+      if (decision.action === "refuse") {
+        console.error(`[anet] Refusing automatic Dashboard cleanup: ${decision.reason}.`);
+        console.error(`[anet] Inspect the exact listener manually; anet never uses pkill/killall/prefix matching here.`);
+        process.exit(1);
+      }
+      if (decision.action === "terminate_owned_stale") {
+        console.log(`[anet] stopping exact managed stale Dashboard pid ${decision.pid} (${decision.reason})...`);
+        if (!await stopExactManagedDashboard(decision.pid, dashPort)) {
+          console.error(`[anet] Refusing replacement startup: exact managed pid ${decision.pid} still owns port ${dashPort}.`);
+          process.exit(1);
+        }
+      }
+    }
     const adminUtok = loadAdminUtok();
     const fallbackMaster = process.env.COMMHUB_AUTH_TOKEN;
     const dashboardToken = adminUtok.token || fallbackMaster || "";
@@ -5887,21 +6032,60 @@ async function serverCommand() {
       ...(dashboardToken ? { COMMHUB_AUTH_TOKEN: dashboardToken } : {}),
     };
 
-    // Match dashboard release channel to anet channel (see #61 + dashboardReleaseTag).
-    const tag = dashboardReleaseTag();
+    // Default stays channel-matched (see #61 + dashboardReleaseTag). A global
+    // binary is used only after the explicit ANET_DASHBOARD_LOCAL=1 opt-in.
     cleanStaleNpxDashboardTemp(); // #89 — self-heal npx cache before spawn
-    console.log(`[anet] spawning dashboard @${tag} (anet ${getAnetVersion() || "unknown"})`);
+    console.log(globalOptIn
+      ? `[anet] spawning explicit global Dashboard ${globalBinary} (anet ${getAnetVersion() || "unknown"})`
+      : `[anet] spawning dashboard @${tag}${npxVersion ? ` (${npxVersion})` : ""} (anet ${getAnetVersion() || "unknown"})`);
     // #214 P2.6 — first launch compiles Next.js routes on demand and can
     // take 30-60s on cold caches. Users mistook the silence for a hang and
     // killed the spawn. Surface the expectation up-front.
     console.log(`[anet] note: first launch compiles Next.js routes — expect 30-60s before http://${dashHost}:${dashPort} responds.`);
-    const dashChild = spawn("npx", ["-y", `@sleep2agi/agent-network-dashboard@${tag}`], { env, stdio: "inherit" });
+    const dashChild = globalOptIn
+      ? spawn(globalBinary!, [], { env, stdio: "inherit" })
+      : spawn("npx", ["-y", `@sleep2agi/agent-network-dashboard@${tag}`], { env, stdio: "inherit" });
     dashChild.on("error", () => {
-      console.error(`[anet] Dashboard package not found. Install manually:`);
-      console.error(`  npx @sleep2agi/agent-network-dashboard`);
+      if (globalOptIn) console.error(`[anet] Failed to start explicit global Dashboard: ${globalBinary}`);
+      else {
+        console.error(`[anet] Dashboard package not found. Install manually:`);
+        console.error(`  npx @sleep2agi/agent-network-dashboard`);
+      }
     });
     dashChild.on("exit", (code) => process.exit(code || 0));
     process.on("SIGINT", () => { dashChild.kill(); process.exit(0); });
+
+    // Record the exact listener only after proving it is a descendant of the
+    // child we just spawned. This record + port PID + birth fingerprint are
+    // all required before a future invocation may stop anything.
+    let listenerRecorded = false;
+    for (let i = 0; i < 120; i++) {
+      await new Promise(resolve => setTimeout(resolve, 500));
+      const scan = scanDashboardListenerPids(dashPort);
+      if (!scan.ok || scan.pids.length !== 1) continue;
+      const listenerPid = scan.pids[0];
+      if (!dashboardListenerDescendsFrom(listenerPid, dashChild.pid || -1)) continue;
+      if (!await dashboardHttpHealthy(dashHost, dashPort)) continue;
+      const listenerBirth = dashboardProcessField(listenerPid, "lstart");
+      if (!listenerBirth) break;
+      ensurePrivateDirectory(dirname(dashboardLaunchRecordPath(dashPort)));
+      atomicWritePrivateJson(dashboardLaunchRecordPath(dashPort), {
+        schema: 1,
+        port: dashPortNumber,
+        listener_pid: listenerPid,
+        listener_birth: listenerBirth,
+        source: launchSource,
+        source_key: sourceKey,
+        recorded_at: new Date().toISOString(),
+      } satisfies DashboardLaunchRecord);
+      console.log(`[anet] ✅ Dashboard ready; managed listener recorded (pid ${listenerPid}).`);
+      listenerRecorded = true;
+      break;
+    }
+    if (!listenerRecorded) {
+      console.warn(`[anet] ⚠ Dashboard listener could not be ownership-verified; no managed record was written.`);
+      console.warn(`[anet]   Future cleanup will fail closed instead of guessing which process to stop.`);
+    }
 
   } else if (sub === "stop") {
     // #200 — graceful stop: lsof -ti:<port> → SIGTERM each → 3s grace → SIGKILL leftovers.

--- a/agent-network/src/dashboard-managed-process.test.ts
+++ b/agent-network/src/dashboard-managed-process.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { decideDashboardListener, isDashboardProcessCommand, parseDashboardLaunchRecord } from "./dashboard-managed-process";
+
+const record = {
+  schema: 1 as const,
+  port: 3109,
+  listener_pid: 4242,
+  listener_birth: "birth-1",
+  source: "npx" as const,
+  source_key: "npx:0.6.0",
+  recorded_at: "2026-08-10T00:00:00.000Z",
+};
+
+const base = {
+  port: 3109,
+  listenerPids: [4242],
+  record,
+  listenerBirth: "birth-1",
+  listenerCommand: "node /tmp/.npm/_npx/x/node_modules/@sleep2agi/agent-network-dashboard/node_modules/next/dist/bin/next start",
+  desiredSource: "npx" as const,
+  desiredSourceKey: "npx:0.6.0",
+  healthy: true,
+};
+
+describe("managed Dashboard listener decisions", () => {
+  test("empty port starts; same healthy managed release remains untouched", () => {
+    expect(decideDashboardListener({ ...base, listenerPids: [] })).toEqual({ action: "start" });
+    expect(decideDashboardListener(base)).toEqual({ action: "already_running", pid: 4242 });
+  });
+
+  test("only an exact managed stale npx listener may be terminated", () => {
+    expect(decideDashboardListener({ ...base, desiredSourceKey: "npx:0.6.1" })).toEqual({
+      action: "terminate_owned_stale", pid: 4242, reason: "version_changed",
+    });
+    expect(decideDashboardListener({ ...base, healthy: false })).toEqual({
+      action: "terminate_owned_stale", pid: 4242, reason: "unhealthy",
+    });
+  });
+
+  test("unmanaged, ambiguous, reused, foreign, and global listeners fail closed", () => {
+    for (const candidate of [
+      { ...base, record: null },
+      { ...base, listenerPids: [4242, 4243] },
+      { ...base, listenerBirth: "reused-pid" },
+      { ...base, listenerCommand: "node /srv/unrelated/next-server" },
+      { ...base, record: { ...record, source: "global" as const, source_key: "global:/usr/bin/dashboard" } },
+    ]) expect(decideDashboardListener(candidate).action).toBe("refuse");
+  });
+});
+
+test("record parser and command identity reject malformed state", () => {
+  expect(parseDashboardLaunchRecord(record)).toEqual(record);
+  expect(parseDashboardLaunchRecord({ ...record, listener_pid: "4242" })).toBeNull();
+  expect(isDashboardProcessCommand("node /x/@sleep2agi/agent-network-dashboard/bin/start.js")).toBeTrue();
+  expect(isDashboardProcessCommand("node /x/agent-network-dashboard/server.js")).toBeTrue();
+  expect(isDashboardProcessCommand("node /x/agent-network-dashboard-evil/server.js")).toBeFalse();
+  expect(isDashboardProcessCommand("next-server")).toBeTrue();
+  expect(isDashboardProcessCommand("node /srv/unrelated/server.js")).toBeFalse();
+});

--- a/agent-network/src/dashboard-managed-process.ts
+++ b/agent-network/src/dashboard-managed-process.ts
@@ -1,0 +1,79 @@
+export type DashboardLaunchSource = "npx" | "global";
+
+export interface DashboardLaunchRecord {
+  schema: 1;
+  port: number;
+  listener_pid: number;
+  listener_birth: string;
+  source: DashboardLaunchSource;
+  source_key: string;
+  recorded_at: string;
+}
+
+export type DashboardListenerDecision =
+  | { action: "start" }
+  | { action: "already_running"; pid: number }
+  | { action: "terminate_owned_stale"; pid: number; reason: "unhealthy" | "version_changed" }
+  | { action: "refuse"; reason: string };
+
+export function isDashboardProcessCommand(command: string): boolean {
+  const normalized = command.trim();
+  if (!normalized) return false;
+  return normalized.includes("@sleep2agi/agent-network-dashboard")
+    || /(?:^|[/\\])agent-network-dashboard(?:[/\\\s]|$)/.test(normalized)
+    || /(?:^|\s)next-server(?:\s|$)/.test(normalized);
+}
+
+export function decideDashboardListener(input: {
+  port: number;
+  listenerPids: number[];
+  record: DashboardLaunchRecord | null;
+  listenerBirth: string | null;
+  listenerCommand: string | null;
+  desiredSource: DashboardLaunchSource;
+  desiredSourceKey: string;
+  healthy: boolean;
+}): DashboardListenerDecision {
+  const pids = [...new Set(input.listenerPids.filter(pid => Number.isSafeInteger(pid) && pid > 1))];
+  if (pids.length === 0) return { action: "start" };
+  if (pids.length !== 1) {
+    return { action: "refuse", reason: `port ${input.port} has ambiguous listener PIDs (${pids.join(", ")})` };
+  }
+
+  const pid = pids[0];
+  const record = input.record;
+  if (!record) return { action: "refuse", reason: `port ${input.port} is occupied by an unmanaged process (pid ${pid})` };
+  if (record.schema !== 1 || record.port !== input.port || record.listener_pid !== pid) {
+    return { action: "refuse", reason: `port ${input.port} listener does not match the managed launch record` };
+  }
+  if (!input.listenerBirth || record.listener_birth !== input.listenerBirth) {
+    return { action: "refuse", reason: `pid ${pid} birth fingerprint does not match the managed launch record` };
+  }
+  if (!input.listenerCommand || !isDashboardProcessCommand(input.listenerCommand)) {
+    return { action: "refuse", reason: `pid ${pid} is not a verified Dashboard process` };
+  }
+
+  // A global install is explicitly operator-managed. Never auto-kill it.
+  if (record.source !== "npx") {
+    return { action: "refuse", reason: `port ${input.port} is owned by an explicitly managed global Dashboard (pid ${pid})` };
+  }
+  if (input.healthy && record.source === input.desiredSource && record.source_key === input.desiredSourceKey) {
+    return { action: "already_running", pid };
+  }
+  return {
+    action: "terminate_owned_stale",
+    pid,
+    reason: input.healthy ? "version_changed" : "unhealthy",
+  };
+}
+
+export function parseDashboardLaunchRecord(value: unknown): DashboardLaunchRecord | null {
+  if (!value || typeof value !== "object") return null;
+  const row = value as Record<string, unknown>;
+  if (row.schema !== 1 || !Number.isSafeInteger(row.port) || !Number.isSafeInteger(row.listener_pid)) return null;
+  if (typeof row.listener_birth !== "string" || !row.listener_birth) return null;
+  if (row.source !== "npx" && row.source !== "global") return null;
+  if (typeof row.source_key !== "string" || !row.source_key) return null;
+  if (typeof row.recorded_at !== "string" || !row.recorded_at) return null;
+  return row as unknown as DashboardLaunchRecord;
+}

--- a/docs-site/docs/en/guide/dashboard.md
+++ b/docs-site/docs/en/guide/dashboard.md
@@ -242,6 +242,10 @@ anet hub start --port 9200
 # Terminal 2: start Dashboard
 anet hub dashboard
 
+# Optional: explicitly use the Dashboard already installed on PATH
+# (the CLI never auto-terminates this process)
+ANET_DASHBOARD_LOCAL=1 anet hub dashboard
+
 # Open in browser
 open http://localhost:3000
 ```
@@ -310,6 +314,10 @@ npm i -g @sleep2agi/agent-network@preview
 anet -v                                    # should show 2.3.0-preview.N (current preview channel; latest stable is 2.2.x)
 anet hub dashboard                          # npx auto-pulls the current preview version
 ```
+
+The default mode still starts the channel-matched release through `npx`. The CLI only replaces a stale `npx` Dashboard that it previously recorded and whose PID, birth fingerprint, and command all match exactly. It refuses automatic termination when the port belongs to an unknown process, inspection is incomplete, or a global install is in use. It never uses `pkill`, `killall`, or process-name prefix matching.
+
+To reuse a global installation from PATH, explicitly set `ANET_DASHBOARD_LOCAL=1`. That Dashboard remains operator-managed; rerunning the command does not kill or replace it.
 
 Or bypass the CLI entirely:
 

--- a/docs-site/docs/guide/dashboard.md
+++ b/docs-site/docs/guide/dashboard.md
@@ -242,6 +242,9 @@ anet hub start --port 9200
 # 终端 2：启动 Dashboard
 anet hub dashboard
 
+# 可选：显式使用 PATH 中已安装的 Dashboard（不会自动终止该进程）
+ANET_DASHBOARD_LOCAL=1 anet hub dashboard
+
 # 浏览器访问
 open http://localhost:3000
 ```
@@ -310,6 +313,10 @@ npm i -g @sleep2agi/agent-network@preview
 anet -v                                    # 应显示 2.3.0-preview.N（当前 preview 通道；latest 稳定版是 2.2.x）
 anet hub dashboard                          # 自动 npx 拉当前 preview 版本
 ```
+
+默认模式继续按 CLI 通道通过 `npx` 启动匹配版本。CLI 只会自动替换自己记录的、PID/启动时间/命令均精确匹配的旧 `npx` Dashboard；端口由未知进程占用、检查信息不完整或使用全局安装时都会拒绝自动终止。不会使用 `pkill`、`killall` 或进程名前缀匹配。
+
+需要复用 PATH 中的全局安装时，必须显式设置 `ANET_DASHBOARD_LOCAL=1`。全局 Dashboard 由操作者管理；再次运行命令不会自动杀掉或替换它。
 
 或直接绕过 CLI：
 

--- a/docs/tests/report-test654-dashboard-managed-launch.txt
+++ b/docs/tests/report-test654-dashboard-managed-launch.txt
@@ -1,0 +1,66 @@
+# Test 654 — managed Dashboard launch / exact zombie cleanup
+
+Date: 2026-08-10 (Asia/Shanghai)
+Issue: #91
+Base commit: 6769d267017759cff6de5f2aea84c51a50184f9a
+Source commit under test: b2099448950e04633905bc6f234f67f182f551b7
+Docker tag: anet-test654:dev (fixed/reused tag)
+Image ID: sha256:b06374a30a98b84e3308256aae934396af2d71148f1cafb4ee8580641baa569f
+Image size: 218170701 bytes
+Embedded ENV: TEST654_SOURCE_COMMIT=b2099448950e04633905bc6f234f67f182f551b7
+
+## Scope
+
+- Default behavior remains channel-matched `npx` startup.
+- `ANET_DASHBOARD_LOCAL=1` is the explicit opt-in for the Dashboard binary on PATH.
+- A healthy managed `npx` release is left untouched.
+- Replacement is authorized only for one exact listener whose port, PID, birth fingerprint,
+  recorded source/version, and Dashboard command identity all match.
+- Unmanaged, ambiguous, reused-PID, foreign-command, global-install, and uninspectable
+  listeners fail closed. The implementation never uses `pkill`, `killall`, or prefix matching.
+- No production process, port, config, or global package was touched. All listener tests used
+  isolated container ports 33101-33104 and fake Dashboard/npm/npx fixtures.
+
+## Commands
+
+```sh
+sg docker -c 'docker build \
+  --build-arg=TEST654_SOURCE_COMMIT=b2099448950e04633905bc6f234f67f182f551b7 \
+  -t anet-test654:dev \
+  -f tests/test654-dashboard-managed-launch/Dockerfile .'
+
+sg docker -c 'docker run --rm \
+  -v /tmp/test654-exact.zltVSs:/artifacts \
+  anet-test654:dev'
+```
+
+## Result
+
+Final: `RESULT pass=10 fail=0`
+
+- L0: helper unit tests 4 pass / 0 fail / 16 assertions; agent-network TypeScript
+  `tsc --noEmit` passed.
+- L1: an unmanaged exact-port listener was refused and remained alive.
+- L2: missing global binary failed closed; explicit global binary launched and was recorded;
+  rerun refused to auto-kill the live global Dashboard.
+- L3: exact listener PID/version was recorded; same healthy release remained untouched;
+  version change terminated only the exact previously recorded stale PID and recorded the
+  replacement.
+- L4: a deliberately broken `lsof` could not authorize cleanup; the unrelated listener
+  remained alive.
+- L5: both safety mutations turned red, followed by a restored green unit run.
+
+Runner output SHA256:
+`74c4cf1e4dffaca0be4277f3c8d15835e7cd85f3dc8691ca23e5f0d06e92768f`
+
+## Witnessed-red evidence
+
+1. Removed version/source equality from the same-release gate. The version-change test failed
+   because the stale 0.6.0 listener was incorrectly treated as already running.
+   Artifact SHA256: `268daf489ad4d1a371fed9821aa7cf79720c8c3c3700e7a4ca5a977761625418`.
+2. Allowed an unmanaged listener to enter the termination path. The fail-closed matrix failed
+   because `record: null` became `terminate_owned_stale` instead of `refuse`.
+   Artifact SHA256: `9e04c8833a58e202d469668e5f545fc71b3094c18fdf1f4f508302393f547dd0`.
+
+These mutations assert behavior, not source-text counts: deleting either authorization gate
+causes the unchanged test suite to fail.

--- a/docs/tests/report-test654-dashboard-managed-launch.txt
+++ b/docs/tests/report-test654-dashboard-managed-launch.txt
@@ -3,11 +3,11 @@
 Date: 2026-08-10 (Asia/Shanghai)
 Issue: #91
 Base commit: 6769d267017759cff6de5f2aea84c51a50184f9a
-Source commit under test: b2099448950e04633905bc6f234f67f182f551b7
+Source commit under test: 074ae852f404f80684a25ffb6965d8d62e7661e9
 Docker tag: anet-test654:dev (fixed/reused tag)
-Image ID: sha256:b06374a30a98b84e3308256aae934396af2d71148f1cafb4ee8580641baa569f
-Image size: 218170701 bytes
-Embedded ENV: TEST654_SOURCE_COMMIT=b2099448950e04633905bc6f234f67f182f551b7
+Image ID: sha256:6361c65b1dfdca8f525f3f5724e7b6c4d9b6ad80fb1287fcf997c2fdab017617
+Image size: 218173321 bytes
+Embedded ENV: TEST654_SOURCE_COMMIT=074ae852f404f80684a25ffb6965d8d62e7661e9
 
 ## Scope
 
@@ -16,27 +16,30 @@ Embedded ENV: TEST654_SOURCE_COMMIT=b2099448950e04633905bc6f234f67f182f551b7
 - A healthy managed `npx` release is left untouched.
 - Replacement is authorized only for one exact listener whose port, PID, birth fingerprint,
   recorded source/version, and Dashboard command identity all match.
+- The exact listener, managed record, birth fingerprint, and command identity are reread
+  immediately before SIGTERM and again before SIGKILL after the grace period. Any change
+  refuses the signal, closing the PID-reuse/decision-to-signal race.
 - Unmanaged, ambiguous, reused-PID, foreign-command, global-install, and uninspectable
   listeners fail closed. The implementation never uses `pkill`, `killall`, or prefix matching.
 - No production process, port, config, or global package was touched. All listener tests used
-  isolated container ports 33101-33104 and fake Dashboard/npm/npx fixtures.
+  isolated container ports 33101-33106 and fake Dashboard/npm/npx fixtures.
 
 ## Commands
 
 ```sh
 sg docker -c 'docker build \
-  --build-arg=TEST654_SOURCE_COMMIT=b2099448950e04633905bc6f234f67f182f551b7 \
+  --build-arg=TEST654_SOURCE_COMMIT=074ae852f404f80684a25ffb6965d8d62e7661e9 \
   -t anet-test654:dev \
   -f tests/test654-dashboard-managed-launch/Dockerfile .'
 
 sg docker -c 'docker run --rm \
-  -v /tmp/test654-exact.zltVSs:/artifacts \
+  -v /tmp/test654-toctou.vAh0sP:/artifacts \
   anet-test654:dev'
 ```
 
 ## Result
 
-Final: `RESULT pass=10 fail=0`
+Final: `RESULT pass=12 fail=0`
 
 - L0: helper unit tests 4 pass / 0 fail / 16 assertions; agent-network TypeScript
   `tsc --noEmit` passed.
@@ -46,21 +49,27 @@ Final: `RESULT pass=10 fail=0`
 - L3: exact listener PID/version was recorded; same healthy release remained untouched;
   version change terminated only the exact previously recorded stale PID and recorded the
   replacement.
-- L4: a deliberately broken `lsof` could not authorize cleanup; the unrelated listener
+- L4: the listener birth fingerprint was changed after the cleanup decision but before the
+  signal; the CLI refused to signal it and the original listener remained alive.
+- L5: a deliberately broken `lsof` could not authorize cleanup; the unrelated listener
   remained alive.
-- L5: both safety mutations turned red, followed by a restored green unit run.
+- L6: all three safety mutations turned red, followed by a restored green unit run.
 
 Runner output SHA256:
-`74c4cf1e4dffaca0be4277f3c8d15835e7cd85f3dc8691ca23e5f0d06e92768f`
+`a482ee38be5af03e66d035643acb161a0b2b49d07e241c47ff09d538a0c538cb`
 
 ## Witnessed-red evidence
 
 1. Removed version/source equality from the same-release gate. The version-change test failed
    because the stale 0.6.0 listener was incorrectly treated as already running.
-   Artifact SHA256: `268daf489ad4d1a371fed9821aa7cf79720c8c3c3700e7a4ca5a977761625418`.
+   Artifact SHA256: `32b1ca89290d4eedaf4979401300ed9da5a923e5015b2b0ff183d535a91c87a8`.
 2. Allowed an unmanaged listener to enter the termination path. The fail-closed matrix failed
    because `record: null` became `terminate_owned_stale` instead of `refuse`.
-   Artifact SHA256: `9e04c8833a58e202d469668e5f545fc71b3094c18fdf1f4f508302393f547dd0`.
+   Artifact SHA256: `f5a737f9deb3b8d7cd0f5dda00dc1bbfdd1044198cfca2b8f2f20db6ba748176`.
+3. Removed the immediate pre-SIGTERM revalidation while leaving the race fixture unchanged.
+   The fixture changed the birth fingerprint between the authorization decision and signal;
+   the mutated CLI killed the still-live listener, so the unchanged test failed.
+   Artifact SHA256: `8bf1c6dea83773860424ced55e040054e40440196a6abb8695e6610c716a3488`.
 
-These mutations assert behavior, not source-text counts: deleting either authorization gate
-causes the unchanged test suite to fail.
+These mutations assert behavior, not source-text counts: deleting any authorization or
+pre-signal identity gate causes the unchanged test suite to fail.

--- a/tests/test654-dashboard-managed-launch/Dockerfile
+++ b/tests/test654-dashboard-managed-launch/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.14
+
+ARG TEST654_SOURCE_COMMIT=unknown
+ENV TEST654_SOURCE_COMMIT=${TEST654_SOURCE_COMMIT}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash nodejs npm jq lsof procps curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo
+COPY agent-network /repo/agent-network
+COPY tests/test654-dashboard-managed-launch /repo/tests/test654-dashboard-managed-launch
+RUN cd /repo/agent-network && bun install --frozen-lockfile --ignore-scripts
+RUN chmod +x /repo/tests/test654-dashboard-managed-launch/run.sh
+
+CMD ["/repo/tests/test654-dashboard-managed-launch/run.sh"]

--- a/tests/test654-dashboard-managed-launch/Dockerfile
+++ b/tests/test654-dashboard-managed-launch/Dockerfile
@@ -1,11 +1,14 @@
 FROM oven/bun:1.3.14
 
-ARG TEST654_SOURCE_COMMIT=unknown
-ENV TEST654_SOURCE_COMMIT=${TEST654_SOURCE_COMMIT}
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash nodejs npm jq lsof procps curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+# Keep provenance after the dependency layer so changing the exact source SHA
+# cannot force another large apt layer while still invalidating every COPY/RUN
+# layer that constitutes the tested candidate.
+ARG TEST654_SOURCE_COMMIT=unknown
+ENV TEST654_SOURCE_COMMIT=${TEST654_SOURCE_COMMIT}
 
 WORKDIR /repo
 COPY agent-network /repo/agent-network

--- a/tests/test654-dashboard-managed-launch/agent-network-dashboard/server.js
+++ b/tests/test654-dashboard-managed-launch/agent-network-dashboard/server.js
@@ -1,0 +1,8 @@
+const http = require("http");
+const port = Number(process.env.PORT);
+const server = http.createServer((req, res) => {
+  res.writeHead(req.url === "/login" ? 200 : 404, { "content-type": "text/plain" });
+  res.end(req.url === "/login" ? "dashboard-login" : "not-found");
+});
+server.listen(port, process.env.HOSTNAME || "127.0.0.1");
+for (const signal of ["SIGTERM", "SIGINT"]) process.on(signal, () => server.close(() => process.exit(0)));

--- a/tests/test654-dashboard-managed-launch/run.sh
+++ b/tests/test654-dashboard-managed-launch/run.sh
@@ -10,8 +10,9 @@ WORK=/tmp/test654
 HOME_DIR="$WORK/home"
 BIN="$WORK/bin"
 NO_LSOF_BIN="$WORK/no-lsof-bin"
+RACE_BIN="$WORK/race-bin"
 ART=/artifacts
-mkdir -p "$HOME_DIR/.anet/server" "$BIN" "$NO_LSOF_BIN" "$ART"
+mkdir -p "$HOME_DIR/.anet/server" "$BIN" "$NO_LSOF_BIN" "$RACE_BIN" "$ART"
 export HOME="$HOME_DIR"
 export ANET_DASHBOARD_VERSION=preview
 export VERSION_FILE="$WORK/version"
@@ -76,6 +77,49 @@ wait_record_key(){
     sleep 0.1
   done
   return 1
+}
+
+for cmd in bun node npm npx lsof which timeout; do
+  target="$(command -v "$cmd")"
+  ln -sf "$target" "$RACE_BIN/$cmd"
+done
+cat >"$RACE_BIN/ps" <<'SH'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+case " $* " in
+  *" -o lstart= "*)
+    if [[ -e "${RACE_PS_STATE:?}" ]]; then printf 'birth-2\n'; else printf 'birth-1\n'; : >"$RACE_PS_STATE"; fi
+    ;;
+  *" -o command= "*) printf 'node /fixture/agent-network-dashboard/server.js\n' ;;
+  *) exec /usr/bin/ps "$@" ;;
+esac
+SH
+chmod +x "$RACE_BIN/ps"
+
+run_birth_race(){
+  local port="$1" log="$2" pid rc alive=0
+  local record="$HOME/.anet/server/dashboard-$port.json"
+  export RACE_PS_STATE="$WORK/race-ps-$port.state"
+  rm -f "$RACE_PS_STATE" "$record"
+  PORT="$port" HOSTNAME=127.0.0.1 /usr/bin/node "$TEST/agent-network-dashboard/server.js" &
+  pid=$!
+  wait_listener "$port" >/dev/null
+  cat >"$record" <<JSON
+{"schema":1,"port":$port,"listener_pid":$pid,"listener_birth":"birth-1","source":"npx","source_key":"npx:0.5.9","recorded_at":"2026-08-10T00:00:00.000Z"}
+JSON
+  set +e
+  PATH="$RACE_BIN:/usr/local/bin:/usr/bin:/bin" timeout 8 bun "$CLI" hub dashboard --port "$port" >"$log" 2>&1
+  rc=$?
+  set -e
+  kill -0 "$pid" 2>/dev/null && alive=1
+  local safe=1
+  [[ "$rc" -ne 0 && "$alive" -eq 1 ]] && grep -q 'still owns port' "$log" && safe=0
+  for cleanup_pid in $(lsof -t -i ":$port" -sTCP:LISTEN 2>/dev/null || true); do
+    kill "$cleanup_pid" 2>/dev/null || true
+    wait "$cleanup_pid" 2>/dev/null || true
+  done
+  rm -f "$record" "$RACE_PS_STATE"
+  return "$safe"
 }
 
 echo "== L0 unit + typecheck =="
@@ -153,7 +197,12 @@ if ! kill -0 "$FIRST_LISTENER" 2>/dev/null && [[ "${NEW_LISTENER:-}" =~ ^[0-9]+$
   ok "version change kills only exact recorded stale pid and records replacement"
 else bad "managed replacement failed old=$FIRST_LISTENER new=${NEW_LISTENER:-none}"; fi
 
-echo "== L4 missing inspector cannot authorize cleanup =="
+echo "== L4 PID birth is revalidated immediately before kill =="
+if run_birth_race 33105 "$ART/birth-race.log"; then
+  ok "birth change between decision and signal refuses kill; listener remains alive"
+else bad "birth-change race was not stopped before signal"; fi
+
+echo "== L5 missing inspector cannot authorize cleanup =="
 for cmd in bun node npm npx ps which timeout; do target="$(command -v "$cmd")"; ln -sf "$target" "$NO_LSOF_BIN/$cmd"; done
 cat >"$NO_LSOF_BIN/lsof" <<'SH'
 #!/usr/bin/env bash
@@ -172,7 +221,7 @@ if kill -0 "$NOINSPECT_PID" 2>/dev/null && grep -q 'listener inspection unavaila
   ok "missing lsof does not authorize a kill (child may fail on occupied port, rc=$NOINSPECT_RC)"
 else bad "missing-inspector guard failed"; fi
 
-echo "== L5 witnessed-red mutations =="
+echo "== L6 witnessed-red mutations =="
 cp "$ROOT/agent-network/src/dashboard-managed-process.ts" "$WORK/dashboard-managed-process.ts.orig"
 sed -i 's/input\.healthy && record\.source === input\.desiredSource && record\.source_key === input\.desiredSourceKey/input.healthy/' "$ROOT/agent-network/src/dashboard-managed-process.ts"
 expect_red version-gate bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
@@ -181,6 +230,11 @@ sed -i 's/if (!record) return { action: "refuse", reason: `port ${input.port} is
 expect_red unmanaged-gate bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
 cp "$WORK/dashboard-managed-process.ts.orig" "$ROOT/agent-network/src/dashboard-managed-process.ts"
 bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
+
+cp "$CLI" "$WORK/cli.ts.orig"
+sed -i '0,/if (!revalidateExactManagedDashboard(pid, port, expectedRecord)) return false;/{//d;}' "$CLI"
+expect_red birth-recheck run_birth_race 33106 "$ART/birth-recheck-inner.log"
+cp "$WORK/cli.ts.orig" "$CLI"
 
 printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/test654-dashboard-managed-launch/run.sh
+++ b/tests/test654-dashboard-managed-launch/run.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+printf 'source_commit=%s\n' "${TEST654_SOURCE_COMMIT:-unknown}"
+
+ROOT=/repo
+CLI="$ROOT/agent-network/bin/cli.ts"
+TEST="$ROOT/tests/test654-dashboard-managed-launch"
+WORK=/tmp/test654
+HOME_DIR="$WORK/home"
+BIN="$WORK/bin"
+NO_LSOF_BIN="$WORK/no-lsof-bin"
+ART=/artifacts
+mkdir -p "$HOME_DIR/.anet/server" "$BIN" "$NO_LSOF_BIN" "$ART"
+export HOME="$HOME_DIR"
+export ANET_DASHBOARD_VERSION=preview
+export VERSION_FILE="$WORK/version"
+printf '0.6.0\n' > "$VERSION_FILE"
+
+PASS=0
+FAIL=0
+ok(){ PASS=$((PASS+1)); printf 'PASS %s\n' "$*"; }
+bad(){ FAIL=$((FAIL+1)); printf 'FAIL %s\n' "$*"; }
+expect_red(){
+  local name="$1"; shift
+  if "$@" >"$ART/$name.log" 2>&1; then bad "mutation $name stayed green"; else ok "mutation $name witnessed red"; fi
+}
+
+cleanup_pids=()
+cleanup(){
+  for pid in "${cleanup_pids[@]:-}"; do
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+cat >"$BIN/npm" <<'SH'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ " $* " == *" view "* ]]; then
+  printf '"%s"\n' "$(cat "$VERSION_FILE")"
+  exit 0
+fi
+exec /usr/bin/npm "$@"
+SH
+cat >"$BIN/npx" <<SH
+#!/usr/bin/env bash
+exec /usr/bin/node "$TEST/agent-network-dashboard/server.js"
+SH
+chmod +x "$BIN/npm" "$BIN/npx"
+export PATH="$BIN:/usr/local/bin:/usr/bin:/bin"
+
+wait_listener(){
+  local port="$1"
+  for _ in $(seq 1 120); do
+    local pid
+    pid="$(lsof -t -i ":$port" -sTCP:LISTEN 2>/dev/null | head -1 || true)"
+    [[ "$pid" =~ ^[0-9]+$ ]] && { printf '%s\n' "$pid"; return 0; }
+    sleep 0.1
+  done
+  return 1
+}
+wait_record(){
+  local port="$1"
+  local file="$HOME/.anet/server/dashboard-$port.json"
+  for _ in $(seq 1 120); do [[ -s "$file" ]] && return 0; sleep 0.1; done
+  return 1
+}
+wait_record_key(){
+  local port="$1" key="$2"
+  local file="$HOME/.anet/server/dashboard-$port.json"
+  for _ in $(seq 1 120); do
+    [[ -s "$file" ]] && [[ "$(jq -r '.source_key' "$file" 2>/dev/null || true)" == "$key" ]] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+echo "== L0 unit + typecheck =="
+cd "$ROOT/agent-network"
+bun test src/dashboard-managed-process.test.ts
+bunx tsc --noEmit
+
+echo "== L1 foreign listener is never killed =="
+PORT=33101 HOSTNAME=127.0.0.1 /usr/bin/node "$TEST/agent-network-dashboard/server.js" &
+FOREIGN_PID=$!
+cleanup_pids+=("$FOREIGN_PID")
+wait_listener 33101 >/dev/null
+set +e
+timeout 8 bun "$CLI" hub dashboard --port 33101 >"$ART/foreign.log" 2>&1
+FOREIGN_RC=$?
+set -e
+if [[ "$FOREIGN_RC" -ne 0 ]] && kill -0 "$FOREIGN_PID" 2>/dev/null && grep -q 'unmanaged process' "$ART/foreign.log"; then
+  ok "unmanaged exact-port listener refused and remains alive"
+else bad "foreign listener gate rc=$FOREIGN_RC alive=$(kill -0 "$FOREIGN_PID" 2>/dev/null && echo yes || echo no)"; fi
+
+echo "== L2 global opt-in is explicit and fail-closed =="
+set +e
+ANET_DASHBOARD_LOCAL=1 timeout 8 bun "$CLI" hub dashboard --port 33103 >"$ART/global-missing.log" 2>&1
+GLOBAL_MISSING_RC=$?
+set -e
+if [[ "$GLOBAL_MISSING_RC" -ne 0 ]] && grep -q 'not on PATH' "$ART/global-missing.log"; then ok "global opt-in refuses missing binary"; else bad "missing global binary was not rejected"; fi
+
+cat >"$BIN/agent-network-dashboard" <<SH
+#!/usr/bin/env bash
+exec /usr/bin/node "$TEST/agent-network-dashboard/server.js"
+SH
+chmod +x "$BIN/agent-network-dashboard"
+ANET_DASHBOARD_LOCAL=1 bun "$CLI" hub dashboard --port 33103 >"$ART/global-first.log" 2>&1 &
+GLOBAL_CLI_PID=$!
+cleanup_pids+=("$GLOBAL_CLI_PID")
+GLOBAL_LISTENER="$(wait_listener 33103)"
+cleanup_pids+=("$GLOBAL_LISTENER")
+wait_record 33103
+if [[ "$(jq -r '.source' "$HOME/.anet/server/dashboard-33103.json")" == global ]]; then ok "explicit global binary spawned and recorded"; else bad "global source not recorded"; fi
+set +e
+ANET_DASHBOARD_LOCAL=1 timeout 8 bun "$CLI" hub dashboard --port 33103 >"$ART/global-second.log" 2>&1
+GLOBAL_SECOND_RC=$?
+set -e
+if [[ "$GLOBAL_SECOND_RC" -ne 0 ]] && kill -0 "$GLOBAL_LISTENER" 2>/dev/null && grep -q 'explicitly managed global' "$ART/global-second.log"; then
+  ok "live global Dashboard is never auto-killed"
+else bad "global listener protection failed"; fi
+
+echo "== L3 managed npx lifecycle =="
+bun "$CLI" hub dashboard --port 33102 >"$ART/npx-first.log" 2>&1 &
+FIRST_CLI_PID=$!
+cleanup_pids+=("$FIRST_CLI_PID")
+FIRST_LISTENER="$(wait_listener 33102)"
+cleanup_pids+=("$FIRST_LISTENER")
+wait_record_key 33102 npx:0.6.0
+RECORDED_PID="$(jq -r '.listener_pid' "$HOME/.anet/server/dashboard-33102.json")"
+RECORDED_KEY="$(jq -r '.source_key' "$HOME/.anet/server/dashboard-33102.json")"
+if [[ "$RECORDED_PID" == "$FIRST_LISTENER" && "$RECORDED_KEY" == npx:0.6.0 ]]; then ok "exact listener pid/version recorded"; else bad "bad managed record pid=$RECORDED_PID key=$RECORDED_KEY"; fi
+
+timeout 8 bun "$CLI" hub dashboard --port 33102 >"$ART/npx-same.log" 2>&1
+if kill -0 "$FIRST_LISTENER" 2>/dev/null && grep -q 'already running.*leaving it untouched' "$ART/npx-same.log"; then ok "same healthy release is not killed"; else bad "same-release listener changed"; fi
+
+printf '0.6.1\n' > "$VERSION_FILE"
+bun "$CLI" hub dashboard --port 33102 >"$ART/npx-upgrade.log" 2>&1 &
+UPGRADE_CLI_PID=$!
+cleanup_pids+=("$UPGRADE_CLI_PID")
+for _ in $(seq 1 120); do
+  NEW_LISTENER="$(lsof -t -i :33102 -sTCP:LISTEN 2>/dev/null | head -1 || true)"
+  [[ "$NEW_LISTENER" =~ ^[0-9]+$ && "$NEW_LISTENER" != "$FIRST_LISTENER" ]] && break
+  sleep 0.1
+done
+wait_record_key 33102 npx:0.6.1
+cleanup_pids+=("${NEW_LISTENER:-}")
+if ! kill -0 "$FIRST_LISTENER" 2>/dev/null && [[ "${NEW_LISTENER:-}" =~ ^[0-9]+$ ]] && kill -0 "$NEW_LISTENER" 2>/dev/null \
+  && [[ "$(jq -r '.source_key' "$HOME/.anet/server/dashboard-33102.json")" == npx:0.6.1 ]]; then
+  ok "version change kills only exact recorded stale pid and records replacement"
+else bad "managed replacement failed old=$FIRST_LISTENER new=${NEW_LISTENER:-none}"; fi
+
+echo "== L4 missing inspector cannot authorize cleanup =="
+for cmd in bun node npm npx ps which timeout; do target="$(command -v "$cmd")"; ln -sf "$target" "$NO_LSOF_BIN/$cmd"; done
+cat >"$NO_LSOF_BIN/lsof" <<'SH'
+#!/usr/bin/env bash
+exit 127
+SH
+chmod +x "$NO_LSOF_BIN/lsof"
+PORT=33104 HOSTNAME=127.0.0.1 /usr/bin/node "$TEST/agent-network-dashboard/server.js" &
+NOINSPECT_PID=$!
+cleanup_pids+=("$NOINSPECT_PID")
+wait_listener 33104 >/dev/null
+set +e
+PATH="$NO_LSOF_BIN:/bin" timeout 8 bun "$CLI" hub dashboard --port 33104 >"$ART/no-inspector.log" 2>&1
+NOINSPECT_RC=$?
+set -e
+if kill -0 "$NOINSPECT_PID" 2>/dev/null && grep -q 'listener inspection unavailable' "$ART/no-inspector.log"; then
+  ok "missing lsof does not authorize a kill (child may fail on occupied port, rc=$NOINSPECT_RC)"
+else bad "missing-inspector guard failed"; fi
+
+echo "== L5 witnessed-red mutations =="
+cp "$ROOT/agent-network/src/dashboard-managed-process.ts" "$WORK/dashboard-managed-process.ts.orig"
+sed -i 's/input\.healthy && record\.source === input\.desiredSource && record\.source_key === input\.desiredSourceKey/input.healthy/' "$ROOT/agent-network/src/dashboard-managed-process.ts"
+expect_red version-gate bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
+cp "$WORK/dashboard-managed-process.ts.orig" "$ROOT/agent-network/src/dashboard-managed-process.ts"
+sed -i 's/if (!record) return { action: "refuse", reason: `port ${input.port} is occupied by an unmanaged process (pid ${pid})` };/if (!record) return { action: "terminate_owned_stale", pid, reason: "unhealthy" };/' "$ROOT/agent-network/src/dashboard-managed-process.ts"
+expect_red unmanaged-gate bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
+cp "$WORK/dashboard-managed-process.ts.orig" "$ROOT/agent-network/src/dashboard-managed-process.ts"
+bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
+
+printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #91.

## What changed

- Keeps `anet hub dashboard` channel-matched through `npx` by default.
- Adds explicit `ANET_DASHBOARD_LOCAL=1` opt-in for a Dashboard binary already installed on PATH.
- Records the exact managed listener PID, birth fingerprint, source, and resolved package version.
- Replaces only a stale or unhealthy `npx` listener whose port, PID, birth fingerprint, and command identity all match.
- Refuses cleanup for unmanaged, ambiguous, reused-PID, foreign-command, global-install, or uninspectable listeners.
- Documents the behavior in Chinese and English.

## Root cause

The old command spawned a new Dashboard without an ownership record. It therefore could not safely distinguish a stale CLI-owned `npx` listener from a live PM2/global/foreign process on the same port.

## Safety boundary

No fuzzy process matching is used. The implementation never calls `pkill` or `killall`; global installations remain operator-managed and are never auto-terminated.

## Validation

Exact source under test: `b2099448950e04633905bc6f234f67f182f551b7`.

Docker `anet-test654:dev`: 10 pass / 0 fail, including real isolated listeners, exact replacement, global-process preservation, unavailable-inspector fail-closed behavior, TypeScript typecheck, and two witnessed-red safety mutations.

Full evidence: `docs/tests/report-test654-dashboard-managed-launch.txt`.