### PR TITLE
test(cli): cover foreign Dashboard PID reuse before signal

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1541,9 +1541,9 @@ function revalidateExactManagedDashboard(
   const scan = scanDashboardListenerPids(port);
   if (!scan.ok || scan.pids.length !== 1 || scan.pids[0] !== pid) return false;
   if (!sameDashboardLaunchRecord(loadDashboardLaunchRecord(port), expectedRecord)) return false;
-  if (dashboardProcessField(pid, "lstart") !== expectedRecord.listener_birth) return false;
+  const birth = dashboardProcessField(pid, "lstart");
   const command = dashboardProcessField(pid, "command");
-  return !!command && isDashboardProcessCommand(command);
+  return birth === expectedRecord.listener_birth && !!command && isDashboardProcessCommand(command);
 }
 
 async function dashboardHttpHealthy(host: string, port: string | number): Promise<boolean> {

--- a/docs/tests/report-test654-dashboard-managed-launch.txt
+++ b/docs/tests/report-test654-dashboard-managed-launch.txt
@@ -2,12 +2,12 @@
 
 Date: 2026-08-10 (Asia/Shanghai)
 Issue: #91
-Base commit: 6769d267017759cff6de5f2aea84c51a50184f9a
-Source commit under test: 9b1b0112b1d0a0d2292a8fc0d64ad772e6983742
+Base commit: 124fdabb33c2f4c5731d4dbe4d55387fbea211e5
+Source commit under test: 9b1b011200e7a3d4d3c63e7deb473b108ae80531
 Docker tag: anet-test654:dev (fixed/reused tag)
-Image ID: sha256:293772751bb76a548793a584e910f7cda2cf455874f9d240dd0aa1baf2212295
-Image size: 218171447 bytes
-Embedded ENV: TEST654_SOURCE_COMMIT=9b1b0112b1d0a0d2292a8fc0d64ad772e6983742
+Image ID: sha256:08c093e00d0dc71d80a2049d6db893ee7f45a0e21eaf49b1a6afbabde21e6795
+Image size: 218172374 bytes
+Embedded ENV: TEST654_SOURCE_COMMIT=9b1b011200e7a3d4d3c63e7deb473b108ae80531
 
 ## Scope
 
@@ -28,12 +28,12 @@ Embedded ENV: TEST654_SOURCE_COMMIT=9b1b0112b1d0a0d2292a8fc0d64ad772e6983742
 
 ```sh
 sg docker -c 'docker build \
-  --build-arg=TEST654_SOURCE_COMMIT=9b1b0112b1d0a0d2292a8fc0d64ad772e6983742 \
+  --build-arg=TEST654_SOURCE_COMMIT=9b1b011200e7a3d4d3c63e7deb473b108ae80531 \
   -t anet-test654:dev \
   -f tests/test654-dashboard-managed-launch/Dockerfile .'
 
 sg docker -c 'docker run --rm \
-  -v /tmp/test654-followup.kttZlX:/artifacts \
+  -v /tmp/test654-restamp.8VfVHV:/artifacts \
   anet-test654:dev'
 ```
 
@@ -57,24 +57,24 @@ Final: `RESULT pass=14 fail=0`
 - L6: all four safety mutations turned red, followed by a restored green unit run.
 
 Runner output SHA256:
-`f4e5d4083756830f217dd3dff83ce91118fc747e6c3077a3ba77e30ee2189e3e`
+`3e070df99bdb91cc002e91633c0da2d08b88177403d28c388fd100a483e5fa41`
 
 ## Witnessed-red evidence
 
 1. Removed version/source equality from the same-release gate. The version-change test failed
    because the stale 0.6.0 listener was incorrectly treated as already running.
-   Artifact SHA256: `eba392f5c7cf50116d2b5c0749fea1b748b917786db14e8ff76c7b1ebfb22e24`.
+   Artifact SHA256: `248047309c29d13860c777872b4212765e72fc6b58a07c4fe41332d2fd25574d`.
 2. Allowed an unmanaged listener to enter the termination path. The fail-closed matrix failed
    because `record: null` became `terminate_owned_stale` instead of `refuse`.
-   Artifact SHA256: `14c2057fbea414b546a1fdecaf66775ec815de7b352548c9c2ffb2c4895cfbc0`.
+   Artifact SHA256: `0e521d43027f37f7abcb9fa93160dbd301be5205bb96821502ec5d394e68e9a4`.
 3. Removed the immediate pre-SIGTERM revalidation while leaving the race fixture unchanged.
    The fixture changed the birth fingerprint between the authorization decision and signal;
    the mutated CLI killed the still-live listener, so the unchanged test failed.
-   Artifact SHA256: `4e25c425a95ce58d6d06c57ab1c77b37f243db28cf97f9ea5d1899b60df397ba`.
+   Artifact SHA256: `f667af1372837bfe57543c99d9d7322c6fdc62f068485ad45abaa4be7aba7863`.
 4. Removed the same pre-SIGTERM revalidation and ran the distinct same-PID foreign-reuse
    fixture. Its fake process changed both birth fingerprint and command identity after the
    decision; the mutated CLI killed it, so the unchanged test failed.
-   Artifact SHA256: `54f74f0b028f718bc15949454fad0e42b3f11bea8e7e9b22ea08839b47c4bede`.
+   Artifact SHA256: `9fb6009be67e5c33a3cc96b58722e7e6ab31a6892725604f99b20bd2e3d51850`.
 
 These mutations assert behavior, not source-text counts: deleting any authorization or
 pre-signal identity gate causes the unchanged test suite to fail.

--- a/docs/tests/report-test654-dashboard-managed-launch.txt
+++ b/docs/tests/report-test654-dashboard-managed-launch.txt
@@ -3,11 +3,11 @@
 Date: 2026-08-10 (Asia/Shanghai)
 Issue: #91
 Base commit: 6769d267017759cff6de5f2aea84c51a50184f9a
-Source commit under test: c8090a438561dae06f8a3fceb9455733052c245b
+Source commit under test: 9b1b0112b1d0a0d2292a8fc0d64ad772e6983742
 Docker tag: anet-test654:dev (fixed/reused tag)
-Image ID: sha256:9b1fb50adabe8c161dbb4e1100f8b3603e6d9f0bc93c04ca3708e157c6be759c
-Image size: 218174920 bytes
-Embedded ENV: TEST654_SOURCE_COMMIT=c8090a438561dae06f8a3fceb9455733052c245b
+Image ID: sha256:293772751bb76a548793a584e910f7cda2cf455874f9d240dd0aa1baf2212295
+Image size: 218171447 bytes
+Embedded ENV: TEST654_SOURCE_COMMIT=9b1b0112b1d0a0d2292a8fc0d64ad772e6983742
 
 ## Scope
 
@@ -28,12 +28,12 @@ Embedded ENV: TEST654_SOURCE_COMMIT=c8090a438561dae06f8a3fceb9455733052c245b
 
 ```sh
 sg docker -c 'docker build \
-  --build-arg=TEST654_SOURCE_COMMIT=c8090a438561dae06f8a3fceb9455733052c245b \
+  --build-arg=TEST654_SOURCE_COMMIT=9b1b0112b1d0a0d2292a8fc0d64ad772e6983742 \
   -t anet-test654:dev \
   -f tests/test654-dashboard-managed-launch/Dockerfile .'
 
 sg docker -c 'docker run --rm \
-  -v /tmp/test654-final.HlmaPb:/artifacts \
+  -v /tmp/test654-followup.kttZlX:/artifacts \
   anet-test654:dev'
 ```
 
@@ -57,24 +57,24 @@ Final: `RESULT pass=14 fail=0`
 - L6: all four safety mutations turned red, followed by a restored green unit run.
 
 Runner output SHA256:
-`ae629dfede68bd1bd02eb5393890c00a7d420720a6b13238bdb63cc4d90f240b`
+`f4e5d4083756830f217dd3dff83ce91118fc747e6c3077a3ba77e30ee2189e3e`
 
 ## Witnessed-red evidence
 
 1. Removed version/source equality from the same-release gate. The version-change test failed
    because the stale 0.6.0 listener was incorrectly treated as already running.
-   Artifact SHA256: `d246ae3f8ac06b6f33694a314120b82a3b4340cc9849b3d375a14a6bb1bb4ef9`.
+   Artifact SHA256: `eba392f5c7cf50116d2b5c0749fea1b748b917786db14e8ff76c7b1ebfb22e24`.
 2. Allowed an unmanaged listener to enter the termination path. The fail-closed matrix failed
    because `record: null` became `terminate_owned_stale` instead of `refuse`.
-   Artifact SHA256: `d1a63423685d22ad93743c28514724d3f553be45f496d3475ee66fd5498d84ff`.
+   Artifact SHA256: `14c2057fbea414b546a1fdecaf66775ec815de7b352548c9c2ffb2c4895cfbc0`.
 3. Removed the immediate pre-SIGTERM revalidation while leaving the race fixture unchanged.
    The fixture changed the birth fingerprint between the authorization decision and signal;
    the mutated CLI killed the still-live listener, so the unchanged test failed.
-   Artifact SHA256: `0d51a12b1b3770084128264c41ea90a50cc4a63933946c85e1ccaabb50c11e07`.
+   Artifact SHA256: `4e25c425a95ce58d6d06c57ab1c77b37f243db28cf97f9ea5d1899b60df397ba`.
 4. Removed the same pre-SIGTERM revalidation and ran the distinct same-PID foreign-reuse
    fixture. Its fake process changed both birth fingerprint and command identity after the
    decision; the mutated CLI killed it, so the unchanged test failed.
-   Artifact SHA256: `19d3bab06c123f56959b3fc671484def6b50f30ceab860deaa0a9bd4fdbd134a`.
+   Artifact SHA256: `54f74f0b028f718bc15949454fad0e42b3f11bea8e7e9b22ea08839b47c4bede`.
 
 These mutations assert behavior, not source-text counts: deleting any authorization or
 pre-signal identity gate causes the unchanged test suite to fail.

--- a/docs/tests/report-test654-dashboard-managed-launch.txt
+++ b/docs/tests/report-test654-dashboard-managed-launch.txt
@@ -3,11 +3,11 @@
 Date: 2026-08-10 (Asia/Shanghai)
 Issue: #91
 Base commit: 6769d267017759cff6de5f2aea84c51a50184f9a
-Source commit under test: 074ae852f404f80684a25ffb6965d8d62e7661e9
+Source commit under test: c8090a438561dae06f8a3fceb9455733052c245b
 Docker tag: anet-test654:dev (fixed/reused tag)
-Image ID: sha256:6361c65b1dfdca8f525f3f5724e7b6c4d9b6ad80fb1287fcf997c2fdab017617
-Image size: 218173321 bytes
-Embedded ENV: TEST654_SOURCE_COMMIT=074ae852f404f80684a25ffb6965d8d62e7661e9
+Image ID: sha256:9b1fb50adabe8c161dbb4e1100f8b3603e6d9f0bc93c04ca3708e157c6be759c
+Image size: 218174920 bytes
+Embedded ENV: TEST654_SOURCE_COMMIT=c8090a438561dae06f8a3fceb9455733052c245b
 
 ## Scope
 
@@ -22,24 +22,24 @@ Embedded ENV: TEST654_SOURCE_COMMIT=074ae852f404f80684a25ffb6965d8d62e7661e9
 - Unmanaged, ambiguous, reused-PID, foreign-command, global-install, and uninspectable
   listeners fail closed. The implementation never uses `pkill`, `killall`, or prefix matching.
 - No production process, port, config, or global package was touched. All listener tests used
-  isolated container ports 33101-33106 and fake Dashboard/npm/npx fixtures.
+  isolated container ports 33101-33108 and fake Dashboard/npm/npx fixtures.
 
 ## Commands
 
 ```sh
 sg docker -c 'docker build \
-  --build-arg=TEST654_SOURCE_COMMIT=074ae852f404f80684a25ffb6965d8d62e7661e9 \
+  --build-arg=TEST654_SOURCE_COMMIT=c8090a438561dae06f8a3fceb9455733052c245b \
   -t anet-test654:dev \
   -f tests/test654-dashboard-managed-launch/Dockerfile .'
 
 sg docker -c 'docker run --rm \
-  -v /tmp/test654-toctou.vAh0sP:/artifacts \
+  -v /tmp/test654-final.HlmaPb:/artifacts \
   anet-test654:dev'
 ```
 
 ## Result
 
-Final: `RESULT pass=12 fail=0`
+Final: `RESULT pass=14 fail=0`
 
 - L0: helper unit tests 4 pass / 0 fail / 16 assertions; agent-network TypeScript
   `tsc --noEmit` passed.
@@ -50,26 +50,31 @@ Final: `RESULT pass=12 fail=0`
   version change terminated only the exact previously recorded stale PID and recorded the
   replacement.
 - L4: the listener birth fingerprint was changed after the cleanup decision but before the
-  signal; the CLI refused to signal it and the original listener remained alive.
+  signal; a second fixture changed both birth and command to model same-PID foreign reuse.
+  The CLI refused both signals and both original listeners remained alive.
 - L5: a deliberately broken `lsof` could not authorize cleanup; the unrelated listener
   remained alive.
-- L6: all three safety mutations turned red, followed by a restored green unit run.
+- L6: all four safety mutations turned red, followed by a restored green unit run.
 
 Runner output SHA256:
-`a482ee38be5af03e66d035643acb161a0b2b49d07e241c47ff09d538a0c538cb`
+`ae629dfede68bd1bd02eb5393890c00a7d420720a6b13238bdb63cc4d90f240b`
 
 ## Witnessed-red evidence
 
 1. Removed version/source equality from the same-release gate. The version-change test failed
    because the stale 0.6.0 listener was incorrectly treated as already running.
-   Artifact SHA256: `32b1ca89290d4eedaf4979401300ed9da5a923e5015b2b0ff183d535a91c87a8`.
+   Artifact SHA256: `d246ae3f8ac06b6f33694a314120b82a3b4340cc9849b3d375a14a6bb1bb4ef9`.
 2. Allowed an unmanaged listener to enter the termination path. The fail-closed matrix failed
    because `record: null` became `terminate_owned_stale` instead of `refuse`.
-   Artifact SHA256: `f5a737f9deb3b8d7cd0f5dda00dc1bbfdd1044198cfca2b8f2f20db6ba748176`.
+   Artifact SHA256: `d1a63423685d22ad93743c28514724d3f553be45f496d3475ee66fd5498d84ff`.
 3. Removed the immediate pre-SIGTERM revalidation while leaving the race fixture unchanged.
    The fixture changed the birth fingerprint between the authorization decision and signal;
    the mutated CLI killed the still-live listener, so the unchanged test failed.
-   Artifact SHA256: `8bf1c6dea83773860424ced55e040054e40440196a6abb8695e6610c716a3488`.
+   Artifact SHA256: `0d51a12b1b3770084128264c41ea90a50cc4a63933946c85e1ccaabb50c11e07`.
+4. Removed the same pre-SIGTERM revalidation and ran the distinct same-PID foreign-reuse
+   fixture. Its fake process changed both birth fingerprint and command identity after the
+   decision; the mutated CLI killed it, so the unchanged test failed.
+   Artifact SHA256: `19d3bab06c123f56959b3fc671484def6b50f30ceab860deaa0a9bd4fdbd134a`.
 
 These mutations assert behavior, not source-text counts: deleting any authorization or
 pre-signal identity gate causes the unchanged test suite to fail.

--- a/tests/test654-dashboard-managed-launch/run.sh
+++ b/tests/test654-dashboard-managed-launch/run.sh
@@ -88,19 +88,32 @@ cat >"$RACE_BIN/ps" <<'SH'
 set -Eeuo pipefail
 case " $* " in
   *" -o lstart= "*)
-    if [[ -e "${RACE_PS_STATE:?}" ]]; then printf 'birth-2\n'; else printf 'birth-1\n'; : >"$RACE_PS_STATE"; fi
+    if [[ "${RACE_CHANGE_BIRTH:-1}" == 1 ]]; then
+      if [[ -e "${RACE_BIRTH_STATE:?}" ]]; then printf 'birth-2\n'; else printf 'birth-1\n'; : >"$RACE_BIRTH_STATE"; fi
+    else
+      printf 'birth-1\n'
+    fi
     ;;
-  *" -o command= "*) printf 'node /fixture/agent-network-dashboard/server.js\n' ;;
+  *" -o command= "*)
+    if [[ "${RACE_CHANGE_COMMAND:-0}" == 1 && -e "${RACE_COMMAND_STATE:?}" ]]; then
+      printf '/usr/bin/foreign-service --same-pid\n'
+    else
+      printf 'node /fixture/agent-network-dashboard/server.js\n'
+      : >"${RACE_COMMAND_STATE:?}"
+    fi
+    ;;
   *) exec /usr/bin/ps "$@" ;;
 esac
 SH
 chmod +x "$RACE_BIN/ps"
 
-run_birth_race(){
-  local port="$1" log="$2" pid rc alive=0
+run_identity_race(){
+  local port="$1" log="$2" change_birth="$3" change_command="$4" pid rc alive=0
   local record="$HOME/.anet/server/dashboard-$port.json"
-  export RACE_PS_STATE="$WORK/race-ps-$port.state"
-  rm -f "$RACE_PS_STATE" "$record"
+  export RACE_CHANGE_BIRTH="$change_birth" RACE_CHANGE_COMMAND="$change_command"
+  export RACE_BIRTH_STATE="$WORK/race-birth-$port.state"
+  export RACE_COMMAND_STATE="$WORK/race-command-$port.state"
+  rm -f "$RACE_BIRTH_STATE" "$RACE_COMMAND_STATE" "$record"
   PORT="$port" HOSTNAME=127.0.0.1 /usr/bin/node "$TEST/agent-network-dashboard/server.js" &
   pid=$!
   wait_listener "$port" >/dev/null
@@ -118,9 +131,12 @@ JSON
     kill "$cleanup_pid" 2>/dev/null || true
     wait "$cleanup_pid" 2>/dev/null || true
   done
-  rm -f "$record" "$RACE_PS_STATE"
+  rm -f "$record" "$RACE_BIRTH_STATE" "$RACE_COMMAND_STATE"
   return "$safe"
 }
+
+run_birth_race(){ run_identity_race "$1" "$2" 1 0; }
+run_foreign_reuse_race(){ run_identity_race "$1" "$2" 1 1; }
 
 echo "== L0 unit + typecheck =="
 cd "$ROOT/agent-network"
@@ -201,6 +217,9 @@ echo "== L4 PID birth is revalidated immediately before kill =="
 if run_birth_race 33105 "$ART/birth-race.log"; then
   ok "birth change between decision and signal refuses kill; listener remains alive"
 else bad "birth-change race was not stopped before signal"; fi
+if run_foreign_reuse_race 33107 "$ART/foreign-reuse-race.log"; then
+  ok "same PID reused by a foreign identity before signal is refused and remains alive"
+else bad "foreign PID-reuse race was not stopped before signal"; fi
 
 echo "== L5 missing inspector cannot authorize cleanup =="
 for cmd in bun node npm npx ps which timeout; do target="$(command -v "$cmd")"; ln -sf "$target" "$NO_LSOF_BIN/$cmd"; done
@@ -234,6 +253,11 @@ bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
 cp "$CLI" "$WORK/cli.ts.orig"
 sed -i '0,/if (!revalidateExactManagedDashboard(pid, port, expectedRecord)) return false;/{//d;}' "$CLI"
 expect_red birth-recheck run_birth_race 33106 "$ART/birth-recheck-inner.log"
+cp "$WORK/cli.ts.orig" "$CLI"
+
+cp "$CLI" "$WORK/cli.ts.orig"
+sed -i '0,/if (!revalidateExactManagedDashboard(pid, port, expectedRecord)) return false;/{//d;}' "$CLI"
+expect_red foreign-reuse-recheck run_foreign_reuse_race 33108 "$ART/foreign-reuse-recheck-inner.log"
 cp "$WORK/cli.ts.orig" "$CLI"
 
 printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary
- add a true-port race fixture where a recorded Dashboard PID changes birth fingerprint and command identity between decision and signal
- keep pre-SIGTERM/SIGKILL revalidation fail-closed while reading both birth and command in the same recheck
- pin the follow-up Docker evidence to exact source commit `9b1b011200e7a3d4d3c63e7deb473b108ae80531`

## Why this is a follow-up
PR #654 merged while this additional adversarial case was still being added. The production safety fix itself was already in main; this PR adds the requested non-vacuous regression gate without rewriting the merged history.

## Verification
- Docker `anet-test654:dev`: 14 pass / 0 fail
- image `sha256:08c093e00d0dc71d80a2049d6db893ee7f45a0e21eaf49b1a6afbabde21e6795`
- embedded `TEST654_SOURCE_COMMIT` equals the real source commit above
- four witnessed-red mutations, including deleting the pre-SIGTERM recheck under the foreign PID-reuse fixture
- runner output SHA256 `3e070df99bdb91cc002e91633c0da2d08b88177403d28c388fd100a483e5fa41`
- no production process or port touched

## Provenance correction
An earlier draft manually expanded the short SHA `9b1b0112` into a nonexistent object. The final report-only commit rebuilt and re-stamped all evidence using `git rev-parse` + `git cat-file`; the phantom SHA and old image metadata are not part of the merged evidence.