### PR TITLE
feat(agent-node): upgrade Claude SDK and add CommHub tool aliases

### DIFF
--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -53,7 +53,7 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.140",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.226",
     "undici": "^6.27.0",
     "zod": "^4.4.3"
   },

--- a/agent-node/src/claude-tool-aliases.test.ts
+++ b/agent-node/src/claude-tool-aliases.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { CLAUDE_COMMHUB_TOOL_ALIASES, claudeCommhubToolAliases } from "./claude-tool-aliases";
+
+describe("Claude CommHub tool aliases", () => {
+  test("pins the exact registered in-process CommHub tool set", () => {
+    expect(CLAUDE_COMMHUB_TOOL_ALIASES).toEqual({
+      commhub_send_task: "mcp__commhub__send_task",
+      commhub_send_message: "mcp__commhub__send_message",
+      commhub_get_all_status: "mcp__commhub__get_all_status",
+      commhub_get_session_status: "mcp__commhub__get_session_status",
+      commhub_get_task: "mcp__commhub__get_task",
+      commhub_list_tasks: "mcp__commhub__list_tasks",
+    });
+    expect("commhub_send_reply" in CLAUDE_COMMHUB_TOOL_ALIASES).toBe(false);
+  });
+
+  test("does not advertise aliases when the in-process server failed", () => {
+    expect(claudeCommhubToolAliases(false)).toBeUndefined();
+    expect(claudeCommhubToolAliases(true)).toEqual(CLAUDE_COMMHUB_TOOL_ALIASES);
+  });
+});

--- a/agent-node/src/claude-tool-aliases.ts
+++ b/agent-node/src/claude-tool-aliases.ts
@@ -1,0 +1,22 @@
+/**
+ * Short CommHub names accepted by Claude Agent SDK before MCP name lookup.
+ *
+ * Values are the real SDK-visible names produced by an in-process MCP server
+ * named `commhub` whose registered bare tools are `send_task`, etc. Keep this
+ * an exact set: never advertise a tool the active server does not register
+ * (notably the deliberately removed `send_reply`).
+ */
+export const CLAUDE_COMMHUB_TOOL_ALIASES = Object.freeze({
+  commhub_send_task: "mcp__commhub__send_task",
+  commhub_send_message: "mcp__commhub__send_message",
+  commhub_get_all_status: "mcp__commhub__get_all_status",
+  commhub_get_session_status: "mcp__commhub__get_session_status",
+  commhub_get_task: "mcp__commhub__get_task",
+  commhub_list_tasks: "mcp__commhub__list_tasks",
+} satisfies Record<string, string>);
+
+export function claudeCommhubToolAliases(
+  hasInProcessCommhubServer: boolean,
+): Record<string, string> | undefined {
+  return hasInProcessCommhubServer ? { ...CLAUDE_COMMHUB_TOOL_ALIASES } : undefined;
+}

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -15,6 +15,7 @@ import { readFileSync, existsSync, writeFileSync, chmodSync, realpathSync } from
 import { dirname, join, isAbsolute, resolve } from "path";
 import { hostname as osHostname, homedir } from "os";
 import { createCommhubSdkMcpServer } from "./commhub-mcp";
+import { claudeCommhubToolAliases } from "./claude-tool-aliases";
 import { getHostTelemetry } from "./host-telemetry";
 import { getProcessTelemetry, incrementInFlight, decrementInFlight } from "./process-telemetry";
 import { parseGoalCommand } from "./goals/parser";
@@ -2065,6 +2066,7 @@ async function processWithClaude(task: string, from: string, images?: string[]):
   const commhubUrl = process.env.COMMHUB_URL || COMMHUB_URL;
   const commhubToken = process.env.COMMHUB_TOKEN || AUTH_TOKEN;
   const mcpServers: Record<string, any> = {};
+  let hasInProcessCommhubServer = false;
   if (commhubUrl) {
     try {
       // #146 PR-4 — pass the ASYNC getter so every LLM-driven
@@ -2077,6 +2079,7 @@ async function processWithClaude(task: string, from: string, images?: string[]):
       // `aliasResolver.refresh()`; cache hit is microseconds, miss is
       // one round-trip with 2.5 s budget.
       mcpServers["commhub"] = await createCommhubSdkMcpServer(commhubUrl, commhubToken, liveAlias);
+      hasInProcessCommhubServer = true;
     } catch (e: any) {
       log(`[claude] ⚠ commhub SDK MCP server init failed (${e?.message || e}); falling back to type:"http" (known-broken, see #102 smoke).`);
       mcpServers["commhub"] = {
@@ -2198,6 +2201,10 @@ async function processWithClaude(task: string, from: string, images?: string[]):
     // This gives the agent commhub_send_task / get_all_status / etc. so it
     // can actually talk to other agents in the network.
     mcpServers: Object.keys(mcpServers).length ? mcpServers : undefined,
+    // SDK 0.3.x resolves these short names before MCP lookup. Only expose
+    // aliases after the in-process CommHub server was actually created;
+    // the known-broken HTTP fallback must not claim tools it may not load.
+    toolAliases: claudeCommhubToolAliases(hasInProcessCommhubServer),
     pathToClaudeCodeExecutable: claudePath,
     // Layer A of feishu hardening (RFC-020 §13 — Vincent UAT 2026-06-29
     // catch): strip operator secrets (FEISHU_APP_SECRET / ntok_ / utok_ /

--- a/docs/tests/report-test656-claude-sdk-tool-aliases.txt
+++ b/docs/tests/report-test656-claude-sdk-tool-aliases.txt
@@ -1,0 +1,94 @@
+# Test 656 — Claude Agent SDK 0.3.x + CommHub tool aliases
+
+Date: 2026-08-10 (Asia/Shanghai)
+Issue: #109
+Base commit: 124fdabb33c2f4c5731d4dbe4d55387fbea211e5
+Source commit under test: 245f85e46842c17a75367b2502262d1855e6b7df
+Docker tag: anet-test656:dev (fixed/reused tag)
+Image ID: sha256:392982b9658a39f8a8aafda8d8486da9fd27f8c73b7b150cd4d512fbfd5b951a
+Image size: 405783858 bytes
+Embedded ENV: TEST656_SOURCE_COMMIT=245f85e46842c17a75367b2502262d1855e6b7df
+
+## Audit findings
+
+- npm `latest` and `next` both resolved to `0.3.226` during the audit.
+- The installed 0.3.226 `Options` type publishes
+  `toolAliases?: Record<string, string>`; aliases are single-hop and resolve
+  before tool-name lookup.
+- The 0.3.142 breaking changes remove the deprecated V2 session API, make MCP
+  connections non-blocking by default, and replace TodoWrite with Task tools in
+  headless/SDK sessions. agent-node uses `query()` and has no SDKSession,
+  unstable_v2, TodoWrite, or TaskCreate consumer, so no removed API is called.
+- 0.3.221 fixed first-turn external MCP readiness. The selected 0.3.226 includes
+  that fix; the real-query test below proves the in-process CommHub tool is
+  available on the first tool-using turn.
+- agent-node intentionally tracks no package lock in this package (`bun.lock`
+  and `package-lock.json` are ignored). The clean Docker install resolved the
+  declared `^0.3.226` range to exactly 0.3.226; no lockfile was hand-edited.
+
+## Exact alias boundary
+
+Aliases are only enabled after `createCommhubSdkMcpServer` succeeds. The known-
+broken HTTP fallback does not receive aliases and cannot claim absent tools.
+The exact six-key set maps short names to the actual SDK names:
+
+- `commhub_send_task` -> `mcp__commhub__send_task`
+- `commhub_send_message` -> `mcp__commhub__send_message`
+- `commhub_get_all_status` -> `mcp__commhub__get_all_status`
+- `commhub_get_session_status` -> `mcp__commhub__get_session_status`
+- `commhub_get_task` -> `mcp__commhub__get_task`
+- `commhub_list_tasks` -> `mcp__commhub__list_tasks`
+
+`commhub_send_reply` is deliberately absent because that agent-facing tool was
+removed as broken. The issue's older doubled target spelling
+`mcp__commhub__commhub_send_task` is not used.
+
+## Docker command
+
+```sh
+sg docker -c 'docker build \
+  --build-arg=TEST656_SOURCE_COMMIT=245f85e46842c17a75367b2502262d1855e6b7df \
+  -t anet-test656:dev \
+  -f tests/test656-claude-sdk-tool-aliases/Dockerfile .'
+
+sg docker -c 'docker run --rm \
+  -v /tmp/test656-final.c6rjA9:/artifacts \
+  anet-test656:dev'
+```
+
+## Result
+
+Final: `RESULT pass=8 fail=0`
+
+- Clean install resolved SDK 0.3.226.
+- Exact alias unit contract: 2 pass / 0 fail / 4 assertions.
+- The 0.3.226 `Options.toolAliases` type probe passed.
+- The complete agent-node bundle built against 0.3.226.
+- Real SDK `query()` + real in-process CommHub MCP + local fake vendor completed
+  two turns. The model emitted `commhub_send_task`; the fake Hub observed exactly
+  one bare `send_task` call with `from_session=sender-test656`, then the query
+  returned `ALIAS_RUNTIME_OK`.
+- Removing alias injection made the same real query reach the final response but
+  produced zero Hub tool calls, so the unchanged behavior assertion turned red.
+- A controlled 0.2.141 install still passed the alias at runtime. This disproves
+  the original assumption that downgrade must make runtime lookup fail; it is an
+  undocumented implementation behavior, not a published 0.2 contract.
+- Under 0.2.141 the unchanged type probe turned red because `Options` has no
+  `toolAliases`. This is the supported-API boundary supplied by 0.3.x.
+
+Runner output SHA256:
+`7c30ce52de1161f45d73b43c0023ea307923990bcf28fef38ca0a0ec7a037121`
+
+Runtime-green artifact SHA256:
+`28e0a876ba79573956de435f544da35eab2a71a231083f0ef8b76e8aa71a2d45`
+
+Witnessed-red artifacts:
+
+1. Alias injection removed: Hub call count became zero.
+   SHA256 `37d076aacbcb922b2ff5f0b3c745a5166cc1c9e252ad40bfaa325b2f87ed68b5`.
+2. SDK downgraded to 0.2.141: unchanged public `Options.toolAliases` type probe
+   failed with TS2353/TS2339.
+   SHA256 `28e55d56cf2e349ce78328961f6c6d75056b130d76407f890051e7d9c81438b2`.
+
+No production endpoint, agent, global package, or credential was used. The vendor
+and Hub boundaries were local deterministic fixtures inside Docker.

--- a/tests/test656-claude-sdk-tool-aliases/Dockerfile
+++ b/tests/test656-claude-sdk-tool-aliases/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.3.14
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash curl jq ca-certificates procps && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo
+COPY agent-node /repo/agent-node
+COPY tests/test656-claude-sdk-tool-aliases /repo/tests/test656-claude-sdk-tool-aliases
+
+RUN cd /repo/agent-node && bun install
+RUN chmod +x /repo/tests/test656-claude-sdk-tool-aliases/run.sh
+
+ARG TEST656_SOURCE_COMMIT=unknown
+ENV TEST656_SOURCE_COMMIT=$TEST656_SOURCE_COMMIT
+
+CMD ["bash", "/repo/tests/test656-claude-sdk-tool-aliases/run.sh"]

--- a/tests/test656-claude-sdk-tool-aliases/Dockerfile
+++ b/tests/test656-claude-sdk-tool-aliases/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /repo
 COPY agent-node /repo/agent-node
 COPY tests/test656-claude-sdk-tool-aliases /repo/tests/test656-claude-sdk-tool-aliases
 
-RUN cd /repo/agent-node && bun install
+RUN cd /repo/agent-node && bun install && bun add --no-save typescript@5.9.3
 RUN chmod +x /repo/tests/test656-claude-sdk-tool-aliases/run.sh
 
 ARG TEST656_SOURCE_COMMIT=unknown

--- a/tests/test656-claude-sdk-tool-aliases/Dockerfile
+++ b/tests/test656-claude-sdk-tool-aliases/Dockerfile
@@ -4,10 +4,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash curl jq ca-certificates procps && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /repo
+COPY agent-node/package.json /repo/agent-node/package.json
+RUN cd /repo/agent-node && bun install && bun add --no-save typescript@5.9.3
 COPY agent-node /repo/agent-node
 COPY tests/test656-claude-sdk-tool-aliases /repo/tests/test656-claude-sdk-tool-aliases
-
-RUN cd /repo/agent-node && bun install && bun add --no-save typescript@5.9.3
 RUN chmod +x /repo/tests/test656-claude-sdk-tool-aliases/run.sh
 
 ARG TEST656_SOURCE_COMMIT=unknown

--- a/tests/test656-claude-sdk-tool-aliases/harness.ts
+++ b/tests/test656-claude-sdk-tool-aliases/harness.ts
@@ -1,0 +1,36 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { createCommhubSdkMcpServer } from "/repo/agent-node/src/commhub-mcp";
+import { claudeCommhubToolAliases } from "/repo/agent-node/src/claude-tool-aliases";
+
+const baseUrl = process.env.ANTHROPIC_BASE_URL!;
+const commhub = await createCommhubSdkMcpServer(baseUrl, "ntok_test656", "sender-test656");
+let finalText = "";
+
+for await (const message of query({
+  prompt: "Send the probe task using the requested short tool name.",
+  options: {
+    model: "claude-sonnet-4-5-20250929",
+    maxTurns: 2,
+    settingSources: [],
+    mcpServers: { commhub },
+    toolAliases: claudeCommhubToolAliases(true),
+    allowedTools: ["mcp__commhub__send_task"],
+  },
+})) {
+  const event = message as any;
+  if (event.type === "result" && event.subtype === "success") finalText = event.result || "";
+}
+
+const stats = await fetch(`${baseUrl}/stats`).then((response) => response.json()) as any;
+console.log(JSON.stringify({ finalText, stats }));
+
+if (finalText !== "ALIAS_RUNTIME_OK") throw new Error(`query did not complete: ${JSON.stringify(finalText)}`);
+if (stats.vendorRequests !== 2) throw new Error(`unexpected vendor requests: ${stats.vendorRequests}`);
+if (stats.mcpCalls !== 1 || stats.lastToolName !== "send_task") {
+  throw new Error(`short alias did not execute real send_task: ${JSON.stringify(stats)}`);
+}
+if (stats.lastToolArgs?.from_session !== "sender-test656"
+  || stats.lastToolArgs?.alias !== "receiver"
+  || stats.lastToolArgs?.task !== "alias-runtime-probe") {
+  throw new Error(`forwarded args mismatch: ${JSON.stringify(stats.lastToolArgs)}`);
+}

--- a/tests/test656-claude-sdk-tool-aliases/mock-services.ts
+++ b/tests/test656-claude-sdk-tool-aliases/mock-services.ts
@@ -1,0 +1,106 @@
+const port = Number(process.env.TEST656_PORT || 19400);
+
+let vendorRequests = 0;
+let mcpCalls = 0;
+let lastToolName = "";
+let lastToolArgs: unknown = null;
+
+function sse(events: Array<[string, unknown]>): Response {
+  const body = events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
+  return new Response(body, {
+    headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+  });
+}
+
+function messageStart(id: string) {
+  return ["message_start", {
+    type: "message_start",
+    message: {
+      id, type: "message", role: "assistant", content: [],
+      model: "claude-sonnet-4-5-20250929", stop_reason: null,
+      stop_sequence: null, usage: { input_tokens: 20, output_tokens: 0 },
+    },
+  }] as [string, unknown];
+}
+
+function toolUseResponse(): Response {
+  return sse([
+    messageStart("msg_test656_tool"),
+    ["content_block_start", {
+      type: "content_block_start", index: 0,
+      content_block: { type: "tool_use", id: "toolu_test656", name: "commhub_send_task", input: {} },
+    }],
+    ["content_block_delta", {
+      type: "content_block_delta", index: 0,
+      delta: { type: "input_json_delta", partial_json: JSON.stringify({ alias: "receiver", task: "alias-runtime-probe" }) },
+    }],
+    ["content_block_stop", { type: "content_block_stop", index: 0 }],
+    ["message_delta", {
+      type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null },
+      usage: { output_tokens: 12 },
+    }],
+    ["message_stop", { type: "message_stop" }],
+  ]);
+}
+
+function finalResponse(): Response {
+  return sse([
+    messageStart("msg_test656_final"),
+    ["content_block_start", {
+      type: "content_block_start", index: 0,
+      content_block: { type: "text", text: "" },
+    }],
+    ["content_block_delta", {
+      type: "content_block_delta", index: 0,
+      delta: { type: "text_delta", text: "ALIAS_RUNTIME_OK" },
+    }],
+    ["content_block_stop", { type: "content_block_stop", index: 0 }],
+    ["message_delta", {
+      type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: 5 },
+    }],
+    ["message_stop", { type: "message_stop" }],
+  ]);
+}
+
+Bun.serve({
+  hostname: "127.0.0.1",
+  port,
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/health") return new Response("ok");
+    if (url.pathname === "/reset") {
+      vendorRequests = 0; mcpCalls = 0; lastToolName = ""; lastToolArgs = null;
+      return Response.json({ ok: true });
+    }
+    if (url.pathname === "/stats") {
+      return Response.json({ vendorRequests, mcpCalls, lastToolName, lastToolArgs });
+    }
+    if (url.pathname === "/mcp" && request.method === "POST") {
+      const body = await request.json() as any;
+      if (body.method === "initialize") {
+        return Response.json({
+          jsonrpc: "2.0", id: body.id,
+          result: { protocolVersion: "2025-03-26", capabilities: {}, serverInfo: { name: "test656", version: "1" } },
+        }, { headers: { "mcp-session-id": "session-test656" } });
+      }
+      if (body.method === "tools/call") {
+        mcpCalls++;
+        lastToolName = body.params?.name || "";
+        lastToolArgs = body.params?.arguments ?? null;
+        return Response.json({
+          jsonrpc: "2.0", id: body.id,
+          result: { content: [{ type: "text", text: JSON.stringify({ ok: true, task_id: "task_test656" }) }] },
+        });
+      }
+      return Response.json({ jsonrpc: "2.0", id: body.id, error: { code: -32601, message: "unknown" } });
+    }
+    if (url.pathname === "/v1/messages" && request.method === "POST") {
+      vendorRequests++;
+      return vendorRequests === 1 ? toolUseResponse() : finalResponse();
+    }
+    return new Response("not found", { status: 404 });
+  },
+});
+
+console.log(`test656 services listening on ${port}`);

--- a/tests/test656-claude-sdk-tool-aliases/run.sh
+++ b/tests/test656-claude-sdk-tool-aliases/run.sh
@@ -29,6 +29,8 @@ SDK_VERSION=$(bun -e 'console.log((await Bun.file("node_modules/@anthropic-ai/cl
 [[ "$SDK_VERSION" == 0.3.226 ]] && ok "clean install resolved claude-agent-sdk 0.3.226" || bad "unexpected SDK $SDK_VERSION"
 bun test src/claude-tool-aliases.test.ts
 ok "exact alias unit contract"
+./node_modules/.bin/tsc --noEmit --skipLibCheck --moduleResolution bundler --module preserve --target ES2022 "$TEST/sdk-type-probe.ts"
+ok "SDK 0.3.226 publishes Options.toolAliases"
 bun run build >/dev/null
 ok "agent-node bundle builds against SDK 0.3.226"
 
@@ -50,7 +52,7 @@ bun add --no-save @anthropic-ai/claude-agent-sdk@0.2.141 >/dev/null
 OLD_VERSION=$(bun -e 'console.log((await Bun.file("node_modules/@anthropic-ai/claude-agent-sdk/package.json").json()).version)')
 [[ "$OLD_VERSION" == 0.2.141 ]] || bad "downgrade mutation did not install 0.2.141"
 curl -fsS "$ANTHROPIC_BASE_URL/reset" >/dev/null
-expect_red sdk-downgrade bun "$TEST/harness.ts"
+expect_red sdk-type-contract ./node_modules/.bin/tsc --noEmit --skipLibCheck --moduleResolution bundler --module preserve --target ES2022 "$TEST/sdk-type-probe.ts"
 cp /tmp/test656-package.orig package.json
 
 printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"

--- a/tests/test656-claude-sdk-tool-aliases/run.sh
+++ b/tests/test656-claude-sdk-tool-aliases/run.sh
@@ -54,6 +54,9 @@ bun add --no-save @anthropic-ai/claude-agent-sdk@0.2.141 >/dev/null
 OLD_VERSION=$(bun -e 'console.log((await Bun.file("node_modules/@anthropic-ai/claude-agent-sdk/package.json").json()).version)')
 [[ "$OLD_VERSION" == 0.2.141 ]] || bad "downgrade mutation did not install 0.2.141"
 curl -fsS "$ANTHROPIC_BASE_URL/reset" >/dev/null
+bun "$TEST/harness.ts" >"$ART/sdk-0.2-runtime-observation.log" 2>&1
+ok "SDK 0.2.141 runtime pass-through is observed but not a published type contract"
+curl -fsS "$ANTHROPIC_BASE_URL/reset" >/dev/null
 expect_red sdk-type-contract ./node_modules/.bin/tsc --noEmit --skipLibCheck --moduleResolution bundler --module preserve --target ES2022 "$TYPE_PROBE"
 cp /tmp/test656-package.orig package.json
 rm -f "$TYPE_PROBE"

--- a/tests/test656-claude-sdk-tool-aliases/run.sh
+++ b/tests/test656-claude-sdk-tool-aliases/run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT=/repo
+TEST="$ROOT/tests/test656-claude-sdk-tool-aliases"
+ART=/artifacts
+PORT=19400
+PASS=0
+FAIL=0
+mkdir -p "$ART"
+
+ok(){ PASS=$((PASS+1)); printf 'PASS %s\n' "$*"; }
+bad(){ FAIL=$((FAIL+1)); printf 'FAIL %s\n' "$*"; }
+expect_red(){
+  local name="$1"; shift
+  if "$@" >"$ART/$name.log" 2>&1; then bad "mutation $name stayed green"; else ok "mutation $name witnessed red"; fi
+}
+
+printf 'source_commit=%s\n' "${TEST656_SOURCE_COMMIT:-unknown}"
+
+bun "$TEST/mock-services.ts" >"$ART/mock.log" 2>&1 &
+MOCK_PID=$!
+trap 'kill "$MOCK_PID" 2>/dev/null || true; wait "$MOCK_PID" 2>/dev/null || true' EXIT
+for _ in $(seq 1 100); do curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null && break; sleep 0.1; done
+curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null
+
+cd "$ROOT/agent-node"
+SDK_VERSION=$(bun -e 'console.log((await Bun.file("node_modules/@anthropic-ai/claude-agent-sdk/package.json").json()).version)')
+[[ "$SDK_VERSION" == 0.3.226 ]] && ok "clean install resolved claude-agent-sdk 0.3.226" || bad "unexpected SDK $SDK_VERSION"
+bun test src/claude-tool-aliases.test.ts
+ok "exact alias unit contract"
+bun run build >/dev/null
+ok "agent-node bundle builds against SDK 0.3.226"
+
+export ANTHROPIC_BASE_URL="http://127.0.0.1:$PORT"
+export ANTHROPIC_API_KEY=test656-fake-key
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+curl -fsS "$ANTHROPIC_BASE_URL/reset" >/dev/null
+bun "$TEST/harness.ts" >"$ART/runtime-green.log" 2>&1
+ok "real SDK query resolves short alias and executes CommHub send_task"
+
+cp src/claude-tool-aliases.ts /tmp/test656-aliases.orig
+sed -i 's/return hasInProcessCommhubServer ? { \.\.\.CLAUDE_COMMHUB_TOOL_ALIASES } : undefined;/return undefined;/' src/claude-tool-aliases.ts
+curl -fsS "$ANTHROPIC_BASE_URL/reset" >/dev/null
+expect_red alias-injection bun "$TEST/harness.ts"
+cp /tmp/test656-aliases.orig src/claude-tool-aliases.ts
+
+cp package.json /tmp/test656-package.orig
+bun add --no-save @anthropic-ai/claude-agent-sdk@0.2.141 >/dev/null
+OLD_VERSION=$(bun -e 'console.log((await Bun.file("node_modules/@anthropic-ai/claude-agent-sdk/package.json").json()).version)')
+[[ "$OLD_VERSION" == 0.2.141 ]] || bad "downgrade mutation did not install 0.2.141"
+curl -fsS "$ANTHROPIC_BASE_URL/reset" >/dev/null
+expect_red sdk-downgrade bun "$TEST/harness.ts"
+cp /tmp/test656-package.orig package.json
+
+printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test656-claude-sdk-tool-aliases/run.sh
+++ b/tests/test656-claude-sdk-tool-aliases/run.sh
@@ -25,11 +25,13 @@ for _ in $(seq 1 100); do curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null &
 curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null
 
 cd "$ROOT/agent-node"
+TYPE_PROBE=.test656-sdk-type-probe.ts
+cp "$TEST/sdk-type-probe.ts" "$TYPE_PROBE"
 SDK_VERSION=$(bun -e 'console.log((await Bun.file("node_modules/@anthropic-ai/claude-agent-sdk/package.json").json()).version)')
 [[ "$SDK_VERSION" == 0.3.226 ]] && ok "clean install resolved claude-agent-sdk 0.3.226" || bad "unexpected SDK $SDK_VERSION"
 bun test src/claude-tool-aliases.test.ts
 ok "exact alias unit contract"
-./node_modules/.bin/tsc --noEmit --skipLibCheck --moduleResolution bundler --module preserve --target ES2022 "$TEST/sdk-type-probe.ts"
+./node_modules/.bin/tsc --noEmit --skipLibCheck --moduleResolution bundler --module preserve --target ES2022 "$TYPE_PROBE"
 ok "SDK 0.3.226 publishes Options.toolAliases"
 bun run build >/dev/null
 ok "agent-node bundle builds against SDK 0.3.226"
@@ -52,8 +54,9 @@ bun add --no-save @anthropic-ai/claude-agent-sdk@0.2.141 >/dev/null
 OLD_VERSION=$(bun -e 'console.log((await Bun.file("node_modules/@anthropic-ai/claude-agent-sdk/package.json").json()).version)')
 [[ "$OLD_VERSION" == 0.2.141 ]] || bad "downgrade mutation did not install 0.2.141"
 curl -fsS "$ANTHROPIC_BASE_URL/reset" >/dev/null
-expect_red sdk-type-contract ./node_modules/.bin/tsc --noEmit --skipLibCheck --moduleResolution bundler --module preserve --target ES2022 "$TEST/sdk-type-probe.ts"
+expect_red sdk-type-contract ./node_modules/.bin/tsc --noEmit --skipLibCheck --moduleResolution bundler --module preserve --target ES2022 "$TYPE_PROBE"
 cp /tmp/test656-package.orig package.json
+rm -f "$TYPE_PROBE"
 
 printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/test656-claude-sdk-tool-aliases/sdk-type-probe.ts
+++ b/tests/test656-claude-sdk-tool-aliases/sdk-type-probe.ts
@@ -1,0 +1,11 @@
+import type { Options } from "@anthropic-ai/claude-agent-sdk";
+
+// This property is the supported 0.3.x contract the production wire relies
+// on. 0.2.141 happened to pass the field through at runtime, but did not
+// publish it in Options; compiling this probe distinguishes supported API
+// from an undocumented implementation accident.
+const options: Options = {
+  toolAliases: { commhub_send_task: "mcp__commhub__send_task" },
+};
+
+if (!options.toolAliases) throw new Error("toolAliases missing");


### PR DESCRIPTION
Closes #109

## Summary
- upgrade `@anthropic-ai/claude-agent-sdk` from `^0.2.140` to `^0.3.226`
- add an exact six-entry CommHub alias map using the actual SDK-visible names (`mcp__commhub__send_task`, etc.)
- only enable aliases after the in-process CommHub MCP server succeeds; do not advertise them on the known-broken HTTP fallback
- deliberately exclude the removed/broken `commhub_send_reply`

## Runtime evidence
Docker test656 uses the real SDK `query()`, real in-process CommHub MCP server, and local fake vendor/Hub boundaries. The model emits short name `commhub_send_task`; the fake Hub observes exactly one `send_task` with the expected args and sender identity, then query completes.

- exact source: `245f85e46842c17a75367b2502262d1855e6b7df`
- report/head: `aee9f5727721d57f44d58f6abd2c1b2d77b9c69d`
- image: `sha256:392982b9658a39f8a8aafda8d8486da9fd27f8c73b7b150cd4d512fbfd5b951a`
- result: 8 pass / 0 fail
- removing alias injection produces zero Hub calls and turns red
- 0.2.141 still passes aliases at runtime (an undocumented behavior), but the unchanged `Options.toolAliases` type probe turns red; the report records this falsified assumption rather than claiming a fake runtime failure

## Boundaries
- no npm publish, deployment, global install, production endpoint, or credential
- agent-node intentionally has no tracked package lock; the clean Docker install resolved 0.3.226 exactly