### PR TITLE
fix(agent-node): pin Claude native fallback to installed SDK version

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -62,6 +62,10 @@ import {
   resolveAgentNodeDir,
 } from "./runtime/codex-dep-loader";
 import {
+  CLAUDE_LINUX_X64_PACKAGE,
+  installPinnedClaudeNativeBinary,
+} from "./runtime/claude-native-binary";
+import {
   buildResumeHint,
   fetchUnresolvedOutbound,
 } from "./runtime/grok-build-acp/resume-hint";
@@ -1838,11 +1842,15 @@ async function processWithClaude(task: string, from: string, images?: string[]):
   }
   if (!hasBinary && process.platform === "linux") {
     try {
-      const { execSync } = await import("child_process");
-      log(`[claude] no Claude binary found — installing @anthropic-ai/claude-agent-sdk-linux-x64 (glibc) ...`);
-      execSync("npm install --no-save --prefix " + JSON.stringify(__dirname + "/../") + " @anthropic-ai/claude-agent-sdk-linux-x64", {
-        stdio: "pipe", timeout: 60_000,
+      const { execFileSync } = await import("child_process");
+      const install = installPinnedClaudeNativeBinary({
+        prefix: __dirname + "/../",
+        resolvePackage: (specifier) => require.resolve(specifier),
+        runNpm: (args) => execFileSync("npm", args, {
+          stdio: "pipe", timeout: 60_000,
+        }),
       });
+      log(`[claude] no Claude binary found — installed ${CLAUDE_LINUX_X64_PACKAGE}@${install.sdkVersion} (glibc) ...`);
       try {
         const glibcPath2 = require.resolve("@anthropic-ai/claude-agent-sdk-linux-x64/claude");
         if (existsSync(glibcPath2)) {

--- a/agent-node/src/runtime/claude-native-binary.test.ts
+++ b/agent-node/src/runtime/claude-native-binary.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CLAUDE_LINUX_X64_PACKAGE,
+  CLAUDE_SDK_PACKAGE,
+  claudeLinuxX64PackageSpec,
+  installPinnedClaudeNativeBinary,
+  resolveInstalledClaudeSdkVersion,
+} from "./claude-native-binary";
+
+describe("Claude native binary version pin", () => {
+  test("uses a directly exported package manifest when available", () => {
+    const version = resolveInstalledClaudeSdkVersion({
+      resolvePackage: (specifier) => {
+        if (specifier === `${CLAUDE_SDK_PACKAGE}/package.json`) return "/sdk/package.json";
+        throw new Error("unexpected fallback");
+      },
+      readText: () => JSON.stringify({ name: CLAUDE_SDK_PACKAGE, version: "0.3.226" }),
+      pathExists: () => true,
+    });
+    expect(version).toBe("0.3.226");
+    expect(claudeLinuxX64PackageSpec(version)).toBe(`${CLAUDE_LINUX_X64_PACKAGE}@0.3.226`);
+  });
+
+  test("walks from the resolved entrypoint when package exports hide package.json", () => {
+    const manifests = new Map([
+      ["/install/node_modules/@anthropic-ai/claude-agent-sdk/package.json",
+        JSON.stringify({ name: CLAUDE_SDK_PACKAGE, version: "0.3.229-beta.1" })],
+    ]);
+    const version = resolveInstalledClaudeSdkVersion({
+      resolvePackage: (specifier) => {
+        if (specifier.endsWith("/package.json")) throw new Error("ERR_PACKAGE_PATH_NOT_EXPORTED");
+        return "/install/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs";
+      },
+      readText: (path) => manifests.get(path) ?? "{}",
+      pathExists: (path) => manifests.has(path),
+    });
+    expect(version).toBe("0.3.229-beta.1");
+    expect(claudeLinuxX64PackageSpec(version)).toBe(`${CLAUDE_LINUX_X64_PACKAGE}@0.3.229-beta.1`);
+  });
+
+  test("fails closed instead of installing latest when the SDK cannot be attested", () => {
+    expect(() => resolveInstalledClaudeSdkVersion({
+      resolvePackage: () => { throw new Error("missing"); },
+    })).toThrow("cannot resolve installed");
+    expect(() => claudeLinuxX64PackageSpec("latest")).toThrow("refusing non-exact");
+    expect(() => claudeLinuxX64PackageSpec("^0.3.226")).toThrow("refusing non-exact");
+  });
+
+  test("missing-binary fallback invokes npm with the installed SDK exact version", () => {
+    const calls: string[][] = [];
+    const result = installPinnedClaudeNativeBinary({
+      prefix: "/agent-node",
+      resolvePackage: (specifier) => {
+        if (specifier === `${CLAUDE_SDK_PACKAGE}/package.json`) return "/sdk/package.json";
+        throw new Error("unexpected fallback");
+      },
+      readText: () => JSON.stringify({ name: CLAUDE_SDK_PACKAGE, version: "0.3.226" }),
+      pathExists: () => true,
+      runNpm: (args) => calls.push(args),
+    });
+    expect(result).toEqual({
+      sdkVersion: "0.3.226",
+      packageSpec: `${CLAUDE_LINUX_X64_PACKAGE}@0.3.226`,
+    });
+    expect(calls).toEqual([[
+      "install", "--no-save", "--prefix", "/agent-node",
+      `${CLAUDE_LINUX_X64_PACKAGE}@0.3.226`,
+    ]]);
+  });
+});

--- a/agent-node/src/runtime/claude-native-binary.ts
+++ b/agent-node/src/runtime/claude-native-binary.ts
@@ -1,0 +1,92 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+
+export const CLAUDE_SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
+export const CLAUDE_LINUX_X64_PACKAGE = "@anthropic-ai/claude-agent-sdk-linux-x64";
+
+const EXACT_PACKAGE_VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export interface ClaudeSdkVersionDeps {
+  resolvePackage: (specifier: string) => string;
+  readText?: (path: string) => string;
+  pathExists?: (path: string) => boolean;
+}
+
+export interface ClaudeNativeInstallDeps extends ClaudeSdkVersionDeps {
+  prefix: string;
+  runNpm: (args: string[]) => void;
+}
+
+function readMatchingManifest(
+  path: string,
+  readText: (path: string) => string,
+): string | null {
+  try {
+    const parsed = JSON.parse(readText(path));
+    if (parsed?.name !== CLAUDE_SDK_PACKAGE) return null;
+    if (typeof parsed.version !== "string" || !EXACT_PACKAGE_VERSION_RE.test(parsed.version)) {
+      throw new Error("installed Claude SDK package.json has an invalid exact version");
+    }
+    return parsed.version;
+  } catch (error: any) {
+    if (String(error?.message || error).includes("invalid exact version")) throw error;
+    return null;
+  }
+}
+
+/**
+ * Resolve the version of the SDK instance that Node/Bun will actually load.
+ * Package exports can hide package.json, so the fallback starts at the
+ * resolved SDK entrypoint and walks only its ancestor directories.
+ */
+export function resolveInstalledClaudeSdkVersion(
+  deps: ClaudeSdkVersionDeps = {
+    resolvePackage: (specifier) => require.resolve(specifier),
+  },
+): string {
+  const readText = deps.readText ?? ((path) => readFileSync(path, "utf8"));
+  const pathExists = deps.pathExists ?? existsSync;
+
+  try {
+    const direct = deps.resolvePackage(`${CLAUDE_SDK_PACKAGE}/package.json`);
+    const version = readMatchingManifest(direct, readText);
+    if (version) return version;
+  } catch {
+    // The SDK currently hides package.json behind package exports. Fall
+    // through to the resolved-entrypoint walk; never fall back to "latest".
+  }
+
+  let current: string;
+  try {
+    current = dirname(deps.resolvePackage(CLAUDE_SDK_PACKAGE));
+  } catch (error: any) {
+    throw new Error(`cannot resolve installed ${CLAUDE_SDK_PACKAGE}: ${error?.message || error}`);
+  }
+  const root = parse(current).root;
+  while (current !== root) {
+    const manifest = join(current, "package.json");
+    if (pathExists(manifest)) {
+      const version = readMatchingManifest(manifest, readText);
+      if (version) return version;
+    }
+    current = dirname(current);
+  }
+  throw new Error(`cannot attest installed ${CLAUDE_SDK_PACKAGE} version`);
+}
+
+export function claudeLinuxX64PackageSpec(version: string): string {
+  if (!EXACT_PACKAGE_VERSION_RE.test(version)) {
+    throw new Error("refusing non-exact Claude SDK native binary version");
+  }
+  return `${CLAUDE_LINUX_X64_PACKAGE}@${version}`;
+}
+
+export function installPinnedClaudeNativeBinary(deps: ClaudeNativeInstallDeps): {
+  sdkVersion: string;
+  packageSpec: string;
+} {
+  const sdkVersion = resolveInstalledClaudeSdkVersion(deps);
+  const packageSpec = claudeLinuxX64PackageSpec(sdkVersion);
+  deps.runNpm(["install", "--no-save", "--prefix", deps.prefix, packageSpec]);
+  return { sdkVersion, packageSpec };
+}

--- a/docs/tests/report-test657-claude-native-version-pin.txt
+++ b/docs/tests/report-test657-claude-native-version-pin.txt
@@ -1,0 +1,51 @@
+# test657 — Claude SDK native fallback exact-version pin
+
+Issue: #657
+Base: 3bbfceefdd90c8acc83c7751593e54a92ac2dffb
+Source commit: 29cb3d1f5c417ffd81377445e853a80649ae107c
+Date: 2026-08-10
+
+## Scope
+
+- Resolve the version of the installed `@anthropic-ai/claude-agent-sdk`
+  instance that the runtime will actually load.
+- Install `@anthropic-ai/claude-agent-sdk-linux-x64@<exact-version>` via
+  argv, never an unversioned/latest native package.
+- Fail closed when the installed SDK version cannot be attested or is not an
+  exact package version.
+
+## Docker evidence
+
+Command:
+
+    sg docker -c 'docker run --rm -v /tmp/test657-artifacts:/artifacts anet-test657:dev'
+
+Image:
+
+- tag: `anet-test657:dev`
+- image id: `sha256:5f20c157bcc9d9131efcc8f1b498b774df939d2f0d4965f72d23fab5f80a804d`
+- size: `384068315`
+- embedded `TEST657_SOURCE_COMMIT`: `29cb3d1f5c417ffd81377445e853a80649ae107c`
+- artifact tar SHA256: `c4b7fef33a60385a76e9a13f13fc3ab59a74f91bda4a428a330b65738f38515d`
+
+Result:
+
+    PASS fallback unit contract
+    PASS resolver matches real installed SDK 0.3.226
+    PASS agent-node bundle builds with pinned fallback
+    PASS mutation unpin-native-version witnessed red
+    PASS mutation bypass-installed-version witnessed red
+    RESULT pass=5 fail=0
+
+The clean Docker install resolved `@anthropic-ai/claude-agent-sdk@0.3.226`.
+The production resolver independently returned the same version.
+
+## Witnessed-red gates
+
+1. Replacing the native spec with the bare package name produced 3 failing
+   assertions: expected `...linux-x64@0.3.226`, received the unversioned name.
+2. Replacing installed-version resolution with `"latest"` failed before npm
+   invocation with `refusing non-exact Claude SDK native binary version`.
+
+No production process, global npm installation, Hub, Dashboard, or node was
+modified.

--- a/tests/test657-claude-native-version-pin/Dockerfile
+++ b/tests/test657-claude-native-version-pin/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /repo
+COPY agent-node/package.json /repo/agent-node/package.json
+RUN cd /repo/agent-node && bun install
+COPY agent-node /repo/agent-node
+COPY tests/test657-claude-native-version-pin /repo/tests/test657-claude-native-version-pin
+RUN chmod +x /repo/tests/test657-claude-native-version-pin/run.sh
+
+ARG TEST657_SOURCE_COMMIT=unknown
+ENV TEST657_SOURCE_COMMIT=$TEST657_SOURCE_COMMIT
+
+CMD ["bash", "/repo/tests/test657-claude-native-version-pin/run.sh"]

--- a/tests/test657-claude-native-version-pin/run.sh
+++ b/tests/test657-claude-native-version-pin/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT=/repo
+ART=/artifacts
+PASS=0
+FAIL=0
+mkdir -p "$ART"
+
+ok(){ PASS=$((PASS+1)); printf 'PASS %s\n' "$*"; }
+bad(){ FAIL=$((FAIL+1)); printf 'FAIL %s\n' "$*"; }
+expect_red(){
+  local name="$1"; shift
+  if "$@" >"$ART/$name.log" 2>&1; then bad "mutation $name stayed green"; else ok "mutation $name witnessed red"; fi
+}
+
+printf 'source_commit=%s\n' "${TEST657_SOURCE_COMMIT:-unknown}"
+cd "$ROOT/agent-node"
+
+bun test src/runtime/claude-native-binary.test.ts
+ok "fallback unit contract"
+
+INSTALLED=$(bun -e 'console.log((await Bun.file("node_modules/@anthropic-ai/claude-agent-sdk/package.json").json()).version)')
+RESOLVED=$(bun -e 'import { resolveInstalledClaudeSdkVersion } from "./src/runtime/claude-native-binary.ts"; console.log(resolveInstalledClaudeSdkVersion())')
+[[ "$INSTALLED" == "$RESOLVED" ]] && ok "resolver matches real installed SDK $INSTALLED" || bad "resolver=$RESOLVED installed=$INSTALLED"
+
+bun run build >/dev/null
+ok "agent-node bundle builds with pinned fallback"
+
+cp src/runtime/claude-native-binary.ts /tmp/test657-native.orig
+sed -i 's/return `${CLAUDE_LINUX_X64_PACKAGE}@${version}`;/return CLAUDE_LINUX_X64_PACKAGE;/' src/runtime/claude-native-binary.ts
+grep -F 'return CLAUDE_LINUX_X64_PACKAGE;' src/runtime/claude-native-binary.ts >/dev/null
+expect_red unpin-native-version bun test src/runtime/claude-native-binary.test.ts
+cp /tmp/test657-native.orig src/runtime/claude-native-binary.ts
+
+sed -i 's/const sdkVersion = resolveInstalledClaudeSdkVersion(deps);/const sdkVersion = "latest";/' src/runtime/claude-native-binary.ts
+grep -F 'const sdkVersion = "latest";' src/runtime/claude-native-binary.ts >/dev/null
+expect_red bypass-installed-version bun test src/runtime/claude-native-binary.test.ts
+cp /tmp/test657-native.orig src/runtime/claude-native-binary.ts
+
+printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #657.

## What changed

- Resolves the exact version of the installed `@anthropic-ai/claude-agent-sdk` instance.
- Installs `@anthropic-ai/claude-agent-sdk-linux-x64@<same-version>` when the bundled/native binary is missing.
- Uses argv-based `execFileSync` instead of a shell-built npm command.
- Fails closed when the SDK version cannot be attested or is not exact; it never falls back to `latest`.

## Root cause

The emergency native-binary install used an unversioned package spec. npm could therefore install a newer native binary than the SDK JavaScript package, creating a mismatched runtime pair.

## Validation

- Source commit: `29cb3d1f5c417ffd81377445e853a80649ae107c`
- Report-only head: `1a440964a06df450d4dab732fa9beb120fdac7a0`
- Docker: `RESULT pass=5 fail=0`
- Real clean install: SDK resolver matched installed `0.3.226`
- Bundle build passed
- Witnessed-red mutations:
  - removing the native package version
  - bypassing installed-version resolution with `latest`

Evidence: `docs/tests/report-test657-claude-native-version-pin.txt`

No production process, global npm installation, Hub, Dashboard, or node was modified.