### PR TITLE
fix(agent-node): renew Codex timeout on owned turn activity

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -3142,12 +3142,26 @@ async function processWithCodexAppServer(
   // in-memory var tracks it even when resuming (idempotent).
   writebackCodexThread(session.threadId);
 
+  let lastActivityHeartbeatAt = Date.now();
   const outcome = await codexAppServerThink(session, {
     taskId: taskId || `local-${Date.now()}`,
     text: task,
     from: _from,
     steerIfExternalTurn,
     log,
+    onActivity: (event) => {
+      const now = Date.now();
+      if (now - lastActivityHeartbeatAt < 30_000) return;
+      lastActivityHeartbeatAt = now;
+      log(`[codex-app-server] active turn heartbeat task=${event.taskId} kind=${event.kind}`);
+      // Re-emit working status at a bounded cadence. This produces the Hub's
+      // normal status_update SSE without creating a terminal reply or a new
+      // inbox row, so observers can distinguish active work from a silent
+      // hang while the local idle deadline is being renewed.
+      void reportStatus("working", task.slice(0, 200)).catch((error) => {
+        debug(`[codex-app-server] activity report_status failed: ${error instanceof Error ? error.message : String(error)}`);
+      });
+    },
   });
 
   // Throw failed outcomes into processTask's existing failure path so the Hub

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -207,6 +207,58 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
     expect(bridge.activeTurn()).toBeNull();
   });
 
+  test("only exact owned-turn item events emit task_activity", async () => {
+    const turnId = await bridge.startTaskTurn({ taskId: "task_activity_owner", text: "work" });
+    const activities: Array<{ taskId: string; turnId: string; kind: string }> = [];
+    bridge.on("task_activity", (event) => activities.push(event as never));
+
+    // A response turn id is not sufficient ownership proof. Activity before
+    // the exact client-id echo must not renew this task's deadline.
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: { threadId: THREAD, turnId, item: { id: "unconfirmed", type: "commandExecution" } },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { threadId: THREAD, turnId, item: { type: "userMessage", clientId: "anet:task_activity_owner" } },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: { threadId: THREAD, turnId, item: { id: "tool-1", type: "commandExecution" } },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { threadId: THREAD, turnId, itemId: "agent-1", delta: "still working" },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: { threadId: THREAD, turnId, item: { id: "tool-1", type: "commandExecution" } },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/agentMessage/delta",
+      params: { threadId: THREAD, turnId: "turn_foreign", itemId: "agent-2", delta: "wrong turn" },
+    });
+    app.broadcast({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: { threadId: "thread_foreign", turnId, item: { id: "tool-2", type: "commandExecution" } },
+    });
+    await tick(10);
+
+    expect(activities).toEqual([
+      { taskId: "task_activity_owner", turnId, kind: "item_completed" },
+      { taskId: "task_activity_owner", turnId, kind: "item_started" },
+      { taskId: "task_activity_owner", turnId, kind: "agent_delta" },
+      { taskId: "task_activity_owner", turnId, kind: "item_completed" },
+    ]);
+  });
+
   test("authenticated Dashboard native /goal text reaches the shared thread unchanged and replies", async () => {
     const exactPayload = "/goal 更新一下文档";
     const turnId = await bridge.startTaskTurn({

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -92,6 +92,12 @@ export interface ActiveTurnReconciliation {
   status?: string;
 }
 
+export interface CodexAppServerTaskActivity {
+  taskId: string;
+  turnId: string;
+  kind: "item_started" | "agent_delta" | "item_completed";
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Bridge
 // ────────────────────────────────────────────────────────────────────────────
@@ -102,6 +108,7 @@ export interface ActiveTurnReconciliation {
  *   - "waiting_human"     → WaitingApproval (bridge did not respond)
  *   - "approval_resolved" → { reverseRequestId } — from serverRequest/resolved
  *   - "task_started"      → { taskId, turnId, steered } — model budget starts
+ *   - "task_activity"     → CodexAppServerTaskActivity — exact owned turn made progress
  *   - "task_turn_rebound" → { taskId, fromTurnId, toTurnId } — client-id repair
  *   - "task_reply"        → { taskId, text }  — final agent message
  *   - "task_error"        → { taskId, error }
@@ -660,9 +667,10 @@ export class CodexAppServerBridge extends EventEmitter {
     }
   }
 
-  private onItemStarted(_params: unknown): void {
-    // No-op in Phase 0. Real bridge will use item ids to gate approval
-    // acceptance in later phases.
+  private onItemStarted(params: unknown): void {
+    const p = params as { threadId?: string; turnId?: string };
+    if (!p || p.threadId !== this.threadId || typeof p.turnId !== "string") return;
+    this.emitTaskActivity(p.turnId, "item_started");
   }
 
   private onAgentDelta(params: unknown): void {
@@ -674,10 +682,16 @@ export class CodexAppServerBridge extends EventEmitter {
     const pending = this.pendingTurns.get(p.turnId);
     if (!pending) {
       const steered = this.steeredTurns.get(p.turnId);
-      if (steered && typeof p.delta === "string") steered.agentTextChunks.push(p.delta);
+      if (steered && typeof p.delta === "string") {
+        steered.agentTextChunks.push(p.delta);
+        this.emitTaskActivity(p.turnId, "agent_delta");
+      }
       return; // Human TUI is receiving deltas too.
     }
-    if (typeof p.delta === "string") pending.agentTextChunks.push(p.delta);
+    if (typeof p.delta === "string") {
+      pending.agentTextChunks.push(p.delta);
+      this.emitTaskActivity(p.turnId, "agent_delta");
+    }
   }
 
   private onItemCompleted(params: unknown): void {
@@ -721,6 +735,7 @@ export class CodexAppServerBridge extends EventEmitter {
       ) {
         steered.finalText = p.item.text;
       }
+      if (steered) this.emitTaskActivity(p.turnId, "item_completed");
       return;
     }
     if (
@@ -729,6 +744,28 @@ export class CodexAppServerBridge extends EventEmitter {
       typeof p.item.text === "string"
     ) {
       pending.finalText = p.item.text;
+    }
+    this.emitTaskActivity(p.turnId, "item_completed");
+  }
+
+  private emitTaskActivity(
+    turnId: string,
+    kind: CodexAppServerTaskActivity["kind"],
+  ): void {
+    const pending = this.pendingTurns.get(turnId);
+    // turn/start's response id is not an identity proof: a concurrent goal
+    // successor can persist our exact user message under a different turn.
+    // Only the echoed clientUserMessageId makes this mapping authoritative.
+    // Otherwise an unrelated response-id turn could keep our idle deadline
+    // alive indefinitely (#587 race family).
+    if (pending?.identityConfirmed) {
+      this.emit("task_activity", { taskId: pending.taskId, turnId, kind } satisfies CodexAppServerTaskActivity);
+      return;
+    }
+    const steered = this.steeredTurns.get(turnId);
+    if (!steered) return;
+    for (const taskId of steered.acceptedTaskIds) {
+      this.emit("task_activity", { taskId, turnId, kind } satisfies CodexAppServerTaskActivity);
     }
   }
 

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -177,7 +177,74 @@ class IdentityNeverConfirmedBridge extends EventEmitter {
   }
 }
 
+class ActivityBridge extends EventEmitter {
+  async submitTask(input: { taskId: string }): Promise<{ started: true; turnId: string }> {
+    this.emit("task_started", {
+      taskId: input.taskId,
+      turnId: `turn_${input.taskId}`,
+      steered: false,
+    });
+    return { started: true, turnId: `turn_${input.taskId}` };
+  }
+
+  cancelQueuedTask(): boolean {
+    return false;
+  }
+
+  async reconcileActiveTurn(): Promise<{ recovered: false; turnId: null }> {
+    return { recovered: false, turnId: null };
+  }
+}
+
 describe("codexAppServerThink — terminal-event reconciliation watchdog", () => {
+  test("exact task activity resets the response idle deadline for a long-running turn", async () => {
+    const bridge = new ActivityBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    const activities: string[] = [];
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_long_active",
+      text: "keep working while tools stream",
+      timeoutMs: 35,
+      queueTimeoutMs: 500,
+      reconciliationIntervalMs: 0,
+      onActivity: (event) => activities.push(event.kind),
+    });
+
+    for (const kind of ["item_started", "agent_delta", "item_completed"] as const) {
+      await new Promise((resolve) => setTimeout(resolve, 22));
+      bridge.emit("task_activity", { taskId: "task_long_active", turnId: "turn_task_long_active", kind });
+    }
+    bridge.emit("task_reply", { taskId: "task_long_active", text: "finished after the original deadline" });
+
+    expect(await thinking).toEqual({
+      replyText: "finished after the original deadline",
+      failed: false,
+      queued: false,
+    });
+    expect(activities).toEqual(["item_started", "agent_delta", "item_completed"]);
+  });
+
+  test("activity from another task cannot keep a silent owned task alive", async () => {
+    const bridge = new ActivityBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_silent",
+      text: "must time out",
+      timeoutMs: 35,
+      queueTimeoutMs: 500,
+      reconciliationIntervalMs: 0,
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 18));
+      bridge.emit("task_activity", { taskId: "different_task", turnId: "turn_other", kind: "agent_delta" });
+    }
+
+    const result = await thinking;
+    expect(result.failed).toBe(true);
+    expect(result.replyText).toContain("无活动");
+  });
+
   test("a started task whose client identity never confirms has a bounded, distinct response timeout", async () => {
     const bridge = new IdentityNeverConfirmedBridge();
     const session = { bridge } as unknown as CodexAppServerRuntimeSession;

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -275,6 +275,7 @@ export function codexAppServerThink(
     let settled = false;
     let queueDeadlineElapsed = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let lastResponseActivityAt = 0;
     let queueTimer: ReturnType<typeof setTimeout> | undefined;
     let reconciliationTimer: ReturnType<typeof setTimeout> | undefined;
     const finish = (r: CodexAppServerThinkResult) => {
@@ -301,24 +302,27 @@ export function codexAppServerThink(
       log(`[codex-app-server] task_error ${ev.taskId}: ${ev.error}`);
       finish({ replyText: `codex-app-server 错误: ${ev.error}`, failed: true, queued: false });
     };
-    const armResponseIdleTimer = (reset = false) => {
-      if (settled) return;
-      if (timer) {
-        if (!reset) return;
-        clearTimeout(timer);
-        timer = undefined;
-      }
+    const armResponseIdleTimer = () => {
+      if (settled || timer) return;
       if (queueTimer) {
         clearTimeout(queueTimer);
         queueTimer = undefined;
       }
-      timer = setTimeout(() => {
+      lastResponseActivityAt = Date.now();
+      const checkResponseIdle = () => {
+        timer = undefined;
+        const idleMs = Date.now() - lastResponseActivityAt;
+        if (idleMs < timeoutMs) {
+          timer = setTimeout(checkResponseIdle, timeoutMs - idleMs);
+          return;
+        }
         finish({
           replyText: `codex-app-server 错误: 任务 ${opts.taskId} 超时（开始处理后连续 ${Math.round(timeoutMs / 1000)}s 无活动；turn 可能仍在后台运行，请先检查共享线程，勿盲目重复派发）`,
           failed: true,
           queued: false,
         });
-      }, timeoutMs);
+      };
+      timer = setTimeout(checkResponseIdle, timeoutMs);
     };
     const finishQueueTimeout = () => finish({
       replyText: `codex-app-server 错误: 任务 ${opts.taskId} 在队列中等待 ${queueTimeoutLabel}仍未开始`,
@@ -339,8 +343,11 @@ export function codexAppServerThink(
     };
     const onActivity = (ev: CodexAppServerTaskActivity) => {
       if (ev.taskId !== opts.taskId || !timer) return;
-      log(`[codex-app-server] task_activity ${ev.taskId} turn=${ev.turnId} kind=${ev.kind}; reset idle deadline`);
-      armResponseIdleTimer(true);
+      // Hot path: streamed deltas may arrive many times per second. Updating
+      // one timestamp avoids clear/set timer churn and per-token log floods;
+      // the existing timer checks the timestamp at the current deadline and
+      // reschedules only once for the remaining idle window.
+      lastResponseActivityAt = Date.now();
       try {
         opts.onActivity?.(ev);
       } catch (error) {

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -20,6 +20,7 @@
 import { spawn, type ChildProcess } from "child_process";
 import { CodexAppServerClient, resolveWebSocketCtor } from "../codex-app-server-client";
 import { CodexAppServerBridge } from "../codex-app-server-bridge";
+import type { CodexAppServerTaskActivity } from "../codex-app-server-bridge";
 
 export interface CodexAppServerRuntimeSession {
   client: CodexAppServerClient;
@@ -257,6 +258,8 @@ export function codexAppServerThink(
     log?: (m: string) => void;
     /** Dashboard chat may join the human TUI's current in-flight turn. */
     steerIfExternalTurn?: boolean;
+    /** Exact owned-turn progress; callers may relay a throttled Hub heartbeat. */
+    onActivity?: (event: CodexAppServerTaskActivity) => void;
   },
 ): Promise<CodexAppServerThinkResult> {
   const timeoutMs = opts.timeoutMs ?? 10 * 60_000;
@@ -280,6 +283,7 @@ export function codexAppServerThink(
       bridge.off("task_reply", onReply);
       bridge.off("task_error", onError);
       bridge.off("task_started", onStarted);
+      bridge.off("task_activity", onActivity);
       bridge.off("drain_deferred", onRequeued);
       bridge.off("steer_deferred", onRequeued);
       if (timer) clearTimeout(timer);
@@ -297,15 +301,20 @@ export function codexAppServerThink(
       log(`[codex-app-server] task_error ${ev.taskId}: ${ev.error}`);
       finish({ replyText: `codex-app-server 错误: ${ev.error}`, failed: true, queued: false });
     };
-    const startResponseTimer = () => {
-      if (settled || timer) return;
+    const armResponseIdleTimer = (reset = false) => {
+      if (settled) return;
+      if (timer) {
+        if (!reset) return;
+        clearTimeout(timer);
+        timer = undefined;
+      }
       if (queueTimer) {
         clearTimeout(queueTimer);
         queueTimer = undefined;
       }
       timer = setTimeout(() => {
         finish({
-          replyText: `codex-app-server 错误: 任务 ${opts.taskId} 超时（开始处理后 ${Math.round(timeoutMs / 1000)}s 内无最终回复）`,
+          replyText: `codex-app-server 错误: 任务 ${opts.taskId} 超时（开始处理后连续 ${Math.round(timeoutMs / 1000)}s 无活动；turn 可能仍在后台运行，请先检查共享线程，勿盲目重复派发）`,
           failed: true,
           queued: false,
         });
@@ -326,7 +335,17 @@ export function codexAppServerThink(
     const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {
       if (ev.taskId !== opts.taskId) return;
       log(`[codex-app-server] task_started ${ev.taskId} turn=${ev.turnId}${ev.steered ? " (steered)" : ""}`);
-      startResponseTimer();
+      armResponseIdleTimer();
+    };
+    const onActivity = (ev: CodexAppServerTaskActivity) => {
+      if (ev.taskId !== opts.taskId || !timer) return;
+      log(`[codex-app-server] task_activity ${ev.taskId} turn=${ev.turnId} kind=${ev.kind}; reset idle deadline`);
+      armResponseIdleTimer(true);
+      try {
+        opts.onActivity?.(ev);
+      } catch (error) {
+        log(`[codex-app-server] activity heartbeat callback failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
     };
 
     // A shared app-server WebSocket can miss an individual terminal
@@ -356,6 +375,7 @@ export function codexAppServerThink(
     bridge.on("task_reply", onReply);
     bridge.on("task_error", onError);
     bridge.on("task_started", onStarted);
+    bridge.on("task_activity", onActivity);
     bridge.on("drain_deferred", onRequeued);
     bridge.on("steer_deferred", onRequeued);
     scheduleReconciliation();
@@ -373,7 +393,7 @@ export function codexAppServerThink(
         // so convert the elapsed admission deadline into the normal bounded
         // model-response wait instead of silently hanging forever.
         log(`[codex-app-server] queue deadline reached after task left FIFO; arming response timeout for ${opts.taskId}`);
-        startResponseTimer();
+        armResponseIdleTimer();
         return;
       }
       finishQueueTimeout();
@@ -389,8 +409,8 @@ export function codexAppServerThink(
       .then((r) => {
         // Compatibility fallback for bridge implementations predating the
         // task_started event. The real bridge emits before this continuation;
-        // startResponseTimer is idempotent, so both paths cannot double-arm.
-        if (r.started) startResponseTimer();
+        // armResponseIdleTimer is idempotent, so both paths cannot double-arm.
+        if (r.started) armResponseIdleTimer();
         if (!r.started) log(`[codex-app-server] task ${opts.taskId} queued (a turn is in flight)`);
         else if (r.steered) log(`[codex-app-server] task ${opts.taskId} steered into human turn ${r.turnId}`);
       })

--- a/docs/rfcs/RFC-030-codex-tui-bridge.md
+++ b/docs/rfcs/RFC-030-codex-tui-bridge.md
@@ -952,5 +952,5 @@ tmux attach -t =<alias>
 - 接管字段已支持 `anet node create --codex-app-server-url <ws> --codex-thread-id <id>`；推荐的人机共存路径是 `anet node start <alias> --copresence` 自动生成并写回字段，不再要求手改 config。
 - `codex resume --remote` 接入时必须带 `codexThreadId`；省略会进入历史会话 picker，容易接错 thread。
 - 每个节点必须使用独立 app-server：CommHub bearer token 是 app-server 进程级环境，不能在多个节点之间复用。
-- 当前任务等待最终回复默认 600s（可由 runtime 选项覆盖），超时不证明 turn 已死，也不会取消底层 Codex turn。
+- 当前任务在 `task_started` 后采用默认 600s 的**无活动阈值**（可由 runtime 选项覆盖），而非总时长硬上限。精确归属于该 task 的 `item/started`、agent delta、`item/completed` 会续期；无关 thread/turn 不会续期。活动状态最多每 30s 通过常规 `report_status(working)` 上报一次。连续静默超时仍不证明 turn 已死，也不会取消底层 Codex turn，错误提示会要求先检查共享线程、不要盲目重复派发。
 - codex-app-server 内层 codex 的 loops MCP（自管 /loop 工具）接线为后续增强; 派工闭环不依赖它。

--- a/docs/sop/agent-reply-to-dashboard.md
+++ b/docs/sop/agent-reply-to-dashboard.md
@@ -35,11 +35,11 @@ Dashboard 聊天窗口。**会不会触发取决于 status**——交互式/协�
 
 补充（同日多次实测）：**commhub_reply 的 task_id 窗口会过期**——回复稍晚就报 `reply_task_not_found`（600s 窗口关闭）。遇到别重试 reply，**直接 send_task 补发**；耗时长的任务从一开始就用 send_task 回。
 
-## 「任务超时（600s 内无最终回复）」自动回复 ≠ 节点死了
+## 「任务连续 600s 无活动」自动回复 ≠ 节点死了
 
-busy 节点（如 codex-app-server 单线程 turn）收到新任务会**排队**（日志：`queued (a turn is in flight)`），排满 600s 就自动回一条「codex-app-server 错误: 任务超时」。**这条超时经常只是排队溢出**——节点可能正健康地跑着一个几小时的大 turn。真实翻车（2026-07-16）：协调者据此差点重启一个正在跑关键任务的节点，capture-pane 才发现它活得好好的。
+codex-app-server 的 FIFO 排队等待和模型执行等待是两个独立期限。任务开始后，桥只接受经 `clientUserMessageId` 确认属于该 task 的 item/delta 作为活动，并据此重置 600s 无活动阈值；另一个 turn 的输出不能替它续命。持续有活动的几小时 turn 不再因总时长被误判，真正连续静默才超时。超时不会取消底层 Codex turn，所以仍可能在后台落下改动。
 
-**判死活标准动作**：先 `tmux capture-pane` 看终端实况 + 查 hub 心跳（updated_at 新鲜=活），**别只凭超时消息下结论**。改进方向（候选）：hub/runtime 把"排队中"与"真超时"区分回复。
+**判死活标准动作**：先 `tmux capture-pane` 看终端实况 + 查 hub 心跳（updated_at 新鲜=活），**别只凭超时消息下结论，也别直接重复派发**。排队超时文案含「在队列中等待」；执行期超时文案含「连续 … 无活动」，两者不要混用。
 
 ### Codex TUI 共存节点的 Dashboard 消息
 

--- a/docs/tests/report-test659-codex-appserver-activity-timeout.txt
+++ b/docs/tests/report-test659-codex-appserver-activity-timeout.txt
@@ -2,12 +2,12 @@
 
 Date: 2026-08-10 (Asia/Shanghai)
 Base: 4dacd93a6c441c243ce1537e437d254fbc485da7
-Source commit: 293c5b2b938eb61b864e32f17ef4fdadc5dcb44a
+Source commit: 5b282b5b6f4b2ae73306c1b6c6942fed23c0f38f
 Docker tag: anet-test659:dev
-Image ID: sha256:3d3dcfd756d60dcfcb2e7f2f3b9b8e45049085e79a2003817799080dc75976d5
-Image size: 384070049 bytes
-Embedded TEST659_SOURCE_COMMIT: 293c5b2b938eb61b864e32f17ef4fdadc5dcb44a
-Mutation artifact tar SHA256: 8f2d0b034573cb064227a3e872d78c421d4780566b6d0d127f33720b94f1af4a
+Image ID: sha256:7c2f35f1e52e06e5cd6dd1092e5bca28483c2557cbab9bf16b2e5c2899b0d769
+Image size: 384071715 bytes
+Embedded TEST659_SOURCE_COMMIT: 5b282b5b6f4b2ae73306c1b6c6942fed23c0f38f
+Mutation artifact tar SHA256: 728df05e89fbc7a81ab583ea9d4cd438642e186736dc73b52e4da5639b2b19fa
 
 ## Facts before the change
 
@@ -19,6 +19,7 @@ Mutation artifact tar SHA256: 8f2d0b034573cb064227a3e872d78c421d4780566b6d0d127f
 
 - The bridge emits `task_activity` only after the immutable `clientUserMessageId` echo confirms the exact turn→task owner. The non-authoritative `turn/start` response id alone cannot renew a deadline.
 - Owned item start, agent delta, and item completion renew the response **idle** threshold. Cross-thread, foreign-turn, unconfirmed-turn, and queued events do not.
+- Streamed deltas only update one activity timestamp. The timer checks that timestamp at its deadline and reschedules once for the remaining window, avoiding per-token timer churn and log floods.
 - A task with no activity still fails after the same default 600s threshold; the queue deadline remains separate and unchanged.
 - `agent-node` relays active work through the existing non-terminal `report_status(working)` / status-update path at most once per 30 seconds. It does not create a reply or inbox row.
 - The timeout text explicitly warns that the underlying turn may still run and should be inspected before re-dispatch.

--- a/docs/tests/report-test659-codex-appserver-activity-timeout.txt
+++ b/docs/tests/report-test659-codex-appserver-activity-timeout.txt
@@ -1,0 +1,43 @@
+# test659 — codex-app-server owned-turn activity timeout (#445)
+
+Date: 2026-08-10 (Asia/Shanghai)
+Base: 4dacd93a6c441c243ce1537e437d254fbc485da7
+Source commit: 293c5b2b938eb61b864e32f17ef4fdadc5dcb44a
+Docker tag: anet-test659:dev
+Image ID: sha256:3d3dcfd756d60dcfcb2e7f2f3b9b8e45049085e79a2003817799080dc75976d5
+Image size: 384070049 bytes
+Embedded TEST659_SOURCE_COMMIT: 293c5b2b938eb61b864e32f17ef4fdadc5dcb44a
+Mutation artifact tar SHA256: 8f2d0b034573cb064227a3e872d78c421d4780566b6d0d127f33720b94f1af4a
+
+## Facts before the change
+
+- `codexAppServerThink()` armed one model-response timer at `task_started` and never renewed it.
+- The bridge already consumed `item/started`, `item/agentMessage/delta`, and `item/completed`, but did not expose task-scoped activity.
+- Controlled pre-implementation run: 57 pass / 3 fail. The three red assertions were: a long active task still timed out, no `task_activity` events were emitted, and the timeout still claimed "no final reply" instead of inactivity.
+
+## Implemented boundary
+
+- The bridge emits `task_activity` only after the immutable `clientUserMessageId` echo confirms the exact turn→task owner. The non-authoritative `turn/start` response id alone cannot renew a deadline.
+- Owned item start, agent delta, and item completion renew the response **idle** threshold. Cross-thread, foreign-turn, unconfirmed-turn, and queued events do not.
+- A task with no activity still fails after the same default 600s threshold; the queue deadline remains separate and unchanged.
+- `agent-node` relays active work through the existing non-terminal `report_status(working)` / status-update path at most once per 30 seconds. It does not create a reply or inbox row.
+- The timeout text explicitly warns that the underlying turn may still run and should be inspected before re-dispatch.
+
+## Docker result
+
+Command:
+
+    sg docker -c 'docker run --rm -v /tmp/test659-artifacts:/artifacts anet-test659:dev'
+
+Result: PASS (6 gates, 0 failures)
+
+- 60 unit tests / 209 assertions passed across the real bridge and runtime source.
+- Agent-node production bundle built successfully.
+- Hub working-heartbeat wiring and 30s rate limit were present in the built source.
+- Mutation `remove-idle-reset`: witnessed red.
+- Mutation `trust-unconfirmed-response-turn`: witnessed red.
+- Mutation `remove-activity-listener`: witnessed red.
+
+## Honest scope
+
+The Docker suite uses the repository's WebSocket fake app-server to drive the same JSON-RPC notification handlers; it does not spend vendor quota on a literal >600s Codex turn. Prior production/runtime evidence established these real-wire event shapes. This candidate proves task scoping, idle renewal, continued silent timeout, queue separation, buildability, and mutation sensitivity; production rollout remains outside this candidate.

--- a/tests/test659-codex-appserver-activity-timeout/Dockerfile
+++ b/tests/test659-codex-appserver-activity-timeout/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /repo
+COPY agent-node/package.json /repo/agent-node/package.json
+RUN cd /repo/agent-node && bun install
+COPY agent-node /repo/agent-node
+COPY tests/test659-codex-appserver-activity-timeout /repo/tests/test659-codex-appserver-activity-timeout
+RUN chmod +x /repo/tests/test659-codex-appserver-activity-timeout/run.sh
+
+ARG TEST659_SOURCE_COMMIT=unknown
+ENV TEST659_SOURCE_COMMIT=$TEST659_SOURCE_COMMIT
+
+CMD ["bash", "/repo/tests/test659-codex-appserver-activity-timeout/run.sh"]

--- a/tests/test659-codex-appserver-activity-timeout/run.sh
+++ b/tests/test659-codex-appserver-activity-timeout/run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT=/repo
+ART=/artifacts
+PASS=0
+FAIL=0
+mkdir -p "$ART"
+
+ok(){ PASS=$((PASS+1)); printf 'PASS %s\n' "$*"; }
+bad(){ FAIL=$((FAIL+1)); printf 'FAIL %s\n' "$*"; }
+expect_red(){
+  local name="$1"; shift
+  if "$@" >"$ART/$name.log" 2>&1; then bad "mutation $name stayed green"; else ok "mutation $name witnessed red"; fi
+}
+
+printf 'source_commit=%s\n' "${TEST659_SOURCE_COMMIT:-unknown}"
+cd "$ROOT/agent-node"
+
+bun test \
+  src/runtime/codex-app-server/runtime.test.ts \
+  src/runtime/codex-app-server-bridge.test.ts
+ok "activity-reset and exact-turn unit contracts"
+
+bun run build >/dev/null
+ok "agent-node bundle builds with activity heartbeat wiring"
+
+grep -F 'if (now - lastActivityHeartbeatAt < 30_000) return;' src/cli.ts >/dev/null
+grep -F 'reportStatus("working", task.slice(0, 200))' src/cli.ts >/dev/null
+ok "Hub working heartbeat is bounded to at most once per 30 seconds"
+
+cp src/runtime/codex-app-server/runtime.ts /tmp/test659-runtime.orig
+sed -i 's/armResponseIdleTimer(true);/\/\/ mutation: idle deadline is not reset/' src/runtime/codex-app-server/runtime.ts
+grep -F '// mutation: idle deadline is not reset' src/runtime/codex-app-server/runtime.ts >/dev/null
+expect_red remove-idle-reset bun test src/runtime/codex-app-server/runtime.test.ts
+cp /tmp/test659-runtime.orig src/runtime/codex-app-server/runtime.ts
+
+cp src/runtime/codex-app-server-bridge.ts /tmp/test659-bridge.orig
+sed -i 's/if (pending?.identityConfirmed) {/if (pending) {/' src/runtime/codex-app-server-bridge.ts
+grep -F 'if (pending) {' src/runtime/codex-app-server-bridge.ts >/dev/null
+expect_red trust-unconfirmed-response-turn bun test src/runtime/codex-app-server-bridge.test.ts
+cp /tmp/test659-bridge.orig src/runtime/codex-app-server-bridge.ts
+
+sed -i 's/bridge.on("task_activity", onActivity);/\/\/ mutation: listener removed/' src/runtime/codex-app-server/runtime.ts
+grep -F '// mutation: listener removed' src/runtime/codex-app-server/runtime.ts >/dev/null
+expect_red remove-activity-listener bun test src/runtime/codex-app-server/runtime.test.ts
+cp /tmp/test659-runtime.orig src/runtime/codex-app-server/runtime.ts
+
+printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test659-codex-appserver-activity-timeout/run.sh
+++ b/tests/test659-codex-appserver-activity-timeout/run.sh
@@ -30,7 +30,7 @@ grep -F 'reportStatus("working", task.slice(0, 200))' src/cli.ts >/dev/null
 ok "Hub working heartbeat is bounded to at most once per 30 seconds"
 
 cp src/runtime/codex-app-server/runtime.ts /tmp/test659-runtime.orig
-sed -i 's/armResponseIdleTimer(true);/\/\/ mutation: idle deadline is not reset/' src/runtime/codex-app-server/runtime.ts
+sed -i '0,/lastResponseActivityAt = Date.now();/! s/lastResponseActivityAt = Date.now();/\/\/ mutation: idle deadline is not reset/' src/runtime/codex-app-server/runtime.ts
 grep -F '// mutation: idle deadline is not reset' src/runtime/codex-app-server/runtime.ts >/dev/null
 expect_red remove-idle-reset bun test src/runtime/codex-app-server/runtime.test.ts
 cp /tmp/test659-runtime.orig src/runtime/codex-app-server/runtime.ts


### PR DESCRIPTION
Closes #445

## Outcome
- changes the post-start 600s hard deadline into a 600s inactivity threshold
- renews only for item events belonging to the exact client-id-confirmed turn→task owner
- preserves the separate FIFO queue deadline and silent-turn timeout
- emits bounded `report_status(working)` heartbeats (max once per 30s) without creating replies/inbox rows
- avoids per-token timer churn: streamed activity updates one timestamp and the deadline check reschedules only when needed
- warns that a timed-out underlying turn may still be running

## Safety boundaries
- cross-thread, foreign-turn, unconfirmed response-turn, and queued events cannot renew the task
- the non-authoritative `turn/start` response id is not treated as ownership proof
- no Hub/API/schema change; no deployment or publish

## Evidence
- source: `5b282b5b6f4b2ae73306c1b6c6942fed23c0f38f`
- report/head: `b5c403829fc9d14610c5688f201bed710ca5d9c1`
- Docker: `anet-test659:dev`, image `sha256:7c2f35f1e52e06e5cd6dd1092e5bca28483c2557cbab9bf16b2e5c2899b0d769`
- 60 tests / 209 assertions, bundle build PASS
- mutations witnessed red: remove idle reset; trust unconfirmed response turn; remove activity listener
- report: `docs/tests/report-test659-codex-appserver-activity-timeout.txt`

## Honest limit
Docker drives the production notification handlers through the repository fake WebSocket app-server; it does not consume vendor quota on a literal >600s turn. Production rollout remains out of scope.