### PR TITLE
fix(server): require explicit production database opt-in

### DIFF
--- a/docs/tests/report-test660-explicit-prod-db-optin.txt
+++ b/docs/tests/report-test660-explicit-prod-db-optin.txt
@@ -1,0 +1,73 @@
+# Test 660 — explicit production DB opt-in
+
+Issue: #253
+
+Source commit tested: `c40445c265063e20ca3a24d612d6f364098dc05e`
+
+Base commit: `4dacd93a6c441c243ce1537e437d254fbc485da7`
+
+## Result
+
+PASS — Docker suite: 8 checks, 0 failures. Pure contract suite: 11 tests,
+19 assertions, 0 failures.
+
+## Provenance
+
+- Image tag: `anet-test660:dev`
+- Image ID: `sha256:12bb2d9e2a1f2899ab781db8e6547508e7415b36ab1ab85fd4dee0b082231335`
+- Embedded `TEST660_SOURCE_COMMIT`:
+  `c40445c265063e20ca3a24d612d6f364098dc05e`
+- Runner artifacts archive SHA-256:
+  `1fb614e96e8e2dc17774ce036be98ce6126f574aa24fb4526f322a864951108d`
+
+## Witnessed red / green
+
+Pre-implementation contract red:
+
+- an unflagged non-test default target was accepted;
+- lookalike `COMMHUB_SERVER` values were accepted by the old fallback.
+
+Final green:
+
+- a real unflagged `bun -e` import refuses before creating
+  `$HOME/.commhub/commhub.db`;
+- an explicit `COMMHUB_DB` still opens normally;
+- real `server/src/index.ts` boots in an isolated HOME and creates its default DB;
+- real `server/bin/commhub.ts` boots in an isolated HOME and creates its default DB.
+
+Mutation gates, all witnessed red:
+
+1. remove the default-path capability guard;
+2. remove the `src/index.ts` pre-import server opt-in;
+3. remove the packaged-bin pre-import server opt-in.
+
+The entrypoint mutations run the real server and require a healthy `/health`
+response. A merely long-running or immediately failed process cannot satisfy the
+gate.
+
+## Caller audit
+
+The canonical production paths are covered in code before the server dependency
+graph is imported:
+
+- `server/bin/commhub.ts` — used by the deployed `hub-daemon.sh` runtime;
+- `server/src/index.ts` — source/dev run entry;
+- `agent-network/src/server.ts` imports `server/src/index.js`, so it inherits the
+  same pre-import opt-in.
+
+Modules such as retention, stale sweeper, vault, probes, auth, and tools import
+the DB only as part of the server graph. Tests already use either an explicit
+`COMMHUB_DB` or the inherited `NODE_ENV=test` safety guard. Ad-hoc scripts and
+`bun -e` probes must now name an explicit SQLite path (or an explicit reviewed
+PostgreSQL `DATABASE_URL`).
+
+The separate agent-network CLI SQLite maintenance path does not use
+`server/src/db-adapter.ts` and is intentionally outside this change.
+
+## Safety and compatibility
+
+- The existing `NODE_ENV=test` and `DATABASE_URL` protections are retained.
+- Explicit SQLite and PostgreSQL targets are unchanged.
+- Only the implicit production SQLite fallback is capability-gated.
+- No production database, global install, Hub process, or deployment was touched.
+

--- a/server/bin/commhub.ts
+++ b/server/bin/commhub.ts
@@ -54,6 +54,10 @@ Examples:
   }
 }
 
+// Opt into the default production DB path before loading the server graph.
+// Ordinary imports / bun -e probes do not receive this capability.
+process.env.COMMHUB_SERVER = "1";
+
 // Load the server module (side-effect-free since the #438 corrective:
 // importing binds nothing) and start the hub EXPLICITLY. Never rely on
 // import side effects or import.meta.main here — this bin is a dynamic

--- a/server/package.json
+++ b/server/package.json
@@ -12,8 +12,8 @@
     "bin"
   ],
   "scripts": {
-    "start": "bun run src/index.ts",
-    "dev": "bun --watch run src/index.ts",
+    "start": "COMMHUB_SERVER=1 bun run src/index.ts",
+    "dev": "COMMHUB_SERVER=1 bun --watch run src/index.ts",
     "test": "bun run scripts/test-aggregate.ts"
   },
   "keywords": [

--- a/server/src/db-adapter-guard.test.ts
+++ b/server/src/db-adapter-guard.test.ts
@@ -60,4 +60,26 @@ describe("#435 inherited DATABASE_URL guard", () => {
       })).toEqual({ kind: "sqlite", path: "/tmp/isolated.db" });
     }
   });
+
+  test("non-server callers cannot silently fall through to the production default SQLite path", () => {
+    for (const NODE_ENV of [undefined, "development", "production"]) {
+      expect(() => resolveDatabaseTarget({ ...BASE_ENV, NODE_ENV }))
+        .toThrow(/explicit COMMHUB_DB|COMMHUB_SERVER=1/);
+    }
+  });
+
+  test("the explicit server boot capability permits the canonical default SQLite path", () => {
+    expect(resolveDatabaseTarget({
+      ...BASE_ENV,
+      NODE_ENV: "production",
+      COMMHUB_SERVER: "1",
+    })).toEqual({ kind: "sqlite", path: "/nonexistent/.commhub/commhub.db" });
+  });
+
+  test("lookalike server capability values fail closed", () => {
+    for (const COMMHUB_SERVER of ["", "true", "yes", "01", " 1"] ) {
+      expect(() => resolveDatabaseTarget({ ...BASE_ENV, COMMHUB_SERVER }))
+        .toThrow(/COMMHUB_SERVER=1/);
+    }
+  });
 });

--- a/server/src/db-adapter.ts
+++ b/server/src/db-adapter.ts
@@ -245,14 +245,11 @@ export function assertSafeTestDatabaseEnv(env: NodeJS.ProcessEnv = process.env):
  * pre-existing history of test pollution in the same DB). The guard makes
  * the failure mode loud + actionable instead of silent + destructive.
  *
- * The guard does NOT fire when:
- *   - COMMHUB_DB is set (the test runner's documented contract); or
- *   - NODE_ENV is unset (production server) or any non-"test" value.
- *
- * Operators who run `bun -e` snippets that touch the DB are expected to
- * `COMMHUB_DB=/tmp/...` themselves — `bun -e` doesn't set NODE_ENV, so the
- * guard can't catch that case. The rule (never read or write the
- * production hub database) is documented in CLAUDE.md.
+ * The production default path is a capability, not a generic fallback:
+ * only canonical server entrypoints set COMMHUB_SERVER=1 before importing
+ * the database graph. Tests, scripts, and `bun -e` probes must name an
+ * explicit COMMHUB_DB (or a reviewed PostgreSQL DATABASE_URL), so forgetting
+ * one fails before mkdir/open/write instead of touching the live Hub.
  */
 function resolveDatabaseTargetAfterGuard(env: NodeJS.ProcessEnv): DbTarget {
   const dbUrl = env.DATABASE_URL;
@@ -268,6 +265,14 @@ function resolveDatabaseTargetAfterGuard(env: NodeJS.ProcessEnv): DbTarget {
       "  pollute the production hub DB. Run tests via:\n" +
       "    COMMHUB_DB=/tmp/test-$$.db bun test src/\n" +
       "  (or use the `npm run test` script which sets this for you)."
+    );
+  }
+
+  if (!env.COMMHUB_DB && env.COMMHUB_SERVER !== "1") {
+    throw new Error(
+      "[commhub] REFUSING to open the default production SQLite database from a non-server entrypoint.\n" +
+      "  Scripts and probes must set an explicit COMMHUB_DB path. The canonical\n" +
+      "  Hub entrypoints set COMMHUB_SERVER=1 before loading the database."
     );
   }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,10 @@
 // tests and tooling import "./server.js" and get bootServer/startHub
 // without binding any port. Do NOT add logic here, and do NOT import
 // this module to "get at the server" — that starts one.
-import { startHub } from "./server.js";
-
+// The default production DB path is deliberately unavailable to ordinary
+// imports / bun -e probes. This run-entry is one of the two canonical places
+// allowed to opt in, and it must do so before dynamically importing server.ts
+// (whose dependency graph constructs the DB adapter at module evaluation).
+process.env.COMMHUB_SERVER = "1";
+const { startHub } = await import("./server.js");
 startHub();

--- a/tests/test660-explicit-prod-db-optin/Dockerfile
+++ b/tests/test660-explicit-prod-db-optin/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /repo
+COPY server/package.json /repo/server/package.json
+RUN cd /repo/server && bun install
+COPY server /repo/server
+COPY tests/test660-explicit-prod-db-optin /repo/tests/test660-explicit-prod-db-optin
+RUN chmod +x /repo/tests/test660-explicit-prod-db-optin/run.sh
+
+ARG TEST660_SOURCE_COMMIT=unknown
+ENV TEST660_SOURCE_COMMIT=$TEST660_SOURCE_COMMIT
+
+CMD ["bash", "/repo/tests/test660-explicit-prod-db-optin/run.sh"]

--- a/tests/test660-explicit-prod-db-optin/run.sh
+++ b/tests/test660-explicit-prod-db-optin/run.sh
@@ -87,7 +87,18 @@ sed -i 's/process.env.COMMHUB_SERVER = "1";/\/\/ mutation: server capability rem
 expect_red remove-index-optin bash -c '
   mutation_home=$(mktemp -d /tmp/test660-index-mutation.XXXXXX)
   env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER HOME="$mutation_home" PORT=25662 HOST=127.0.0.1 COMMHUB_DEV_OPEN=1 \
-    timeout 3 bun run server/src/index.ts > /tmp/test660-index-mutation.log 2>&1
+    bun run server/src/index.ts > /tmp/test660-index-mutation.log 2>&1 &
+  mutation_pid=$!
+  for _ in $(seq 1 60); do
+    kill -0 "$mutation_pid" 2>/dev/null || exit 1
+    if PORT_TO_CHECK=25662 bun -e '\''const r=await fetch(`http://127.0.0.1:${process.env.PORT_TO_CHECK}/health`).catch(()=>null); process.exit(r?.ok?0:1)'\'' >/dev/null 2>&1; then
+      kill "$mutation_pid"; wait "$mutation_pid" 2>/dev/null || true; exit 0
+    fi
+    sleep 0.05
+  done
+  kill "$mutation_pid" 2>/dev/null || true
+  wait "$mutation_pid" 2>/dev/null || true
+  exit 1
 '
 cp /tmp/test660-index.orig server/src/index.ts
 
@@ -96,7 +107,18 @@ sed -i 's/process.env.COMMHUB_SERVER = "1";/\/\/ mutation: server capability rem
 expect_red remove-bin-optin bash -c '
   mutation_home=$(mktemp -d /tmp/test660-bin-mutation.XXXXXX)
   env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER HOME="$mutation_home" \
-    timeout 3 bun server/bin/commhub.ts --port 25663 --host 127.0.0.1 --dev-open > /tmp/test660-bin-mutation.log 2>&1
+    bun server/bin/commhub.ts --port 25663 --host 127.0.0.1 --dev-open > /tmp/test660-bin-mutation.log 2>&1 &
+  mutation_pid=$!
+  for _ in $(seq 1 60); do
+    kill -0 "$mutation_pid" 2>/dev/null || exit 1
+    if PORT_TO_CHECK=25663 bun -e '\''const r=await fetch(`http://127.0.0.1:${process.env.PORT_TO_CHECK}/health`).catch(()=>null); process.exit(r?.ok?0:1)'\'' >/dev/null 2>&1; then
+      kill "$mutation_pid"; wait "$mutation_pid" 2>/dev/null || true; exit 0
+    fi
+    sleep 0.05
+  done
+  kill "$mutation_pid" 2>/dev/null || true
+  wait "$mutation_pid" 2>/dev/null || true
+  exit 1
 '
 cp /tmp/test660-bin.orig server/bin/commhub.ts
 

--- a/tests/test660-explicit-prod-db-optin/run.sh
+++ b/tests/test660-explicit-prod-db-optin/run.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT=/repo
+ART=/artifacts
+PASS=0
+FAIL=0
+mkdir -p "$ART"
+
+ok(){ PASS=$((PASS+1)); printf 'PASS %s\n' "$*"; }
+bad(){ FAIL=$((FAIL+1)); printf 'FAIL %s\n' "$*"; }
+expect_red(){
+  local name="$1"; shift
+  if "$@" >"$ART/$name.log" 2>&1; then bad "mutation $name stayed green"; else ok "mutation $name witnessed red"; fi
+}
+
+wait_health(){
+  local port="$1"
+  for _ in $(seq 1 100); do
+    if PORT_TO_CHECK="$port" bun -e 'const r=await fetch(`http://127.0.0.1:${process.env.PORT_TO_CHECK}/health`).catch(()=>null); process.exit(r?.ok?0:1)' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  return 1
+}
+
+printf 'source_commit=%s\n' "${TEST660_SOURCE_COMMIT:-unknown}"
+cd "$ROOT"
+
+bun test server/src/db-adapter-guard.test.ts
+ok "pure default-path capability contract"
+
+probe_home=$(mktemp -d /tmp/test660-probe-home.XXXXXX)
+set +e
+env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER HOME="$probe_home" \
+  bun -e 'const {createAdapter}=await import("./server/src/db-adapter.ts"); createAdapter()' \
+  >"$ART/unflagged.stdout" 2>"$ART/unflagged.stderr"
+probe_rc=$?
+set -e
+test "$probe_rc" -ne 0
+grep -F 'REFUSING to open the default production SQLite database' "$ART/unflagged.stderr" >/dev/null
+test ! -e "$probe_home/.commhub/commhub.db"
+ok "real bun -e fails before creating the production-default DB"
+
+explicit_db=$(mktemp /tmp/test660-explicit.XXXXXX.db)
+env -u DATABASE_URL -u COMMHUB_SERVER COMMHUB_DB="$explicit_db" \
+  bun -e 'const {createAdapter}=await import("./server/src/db-adapter.ts"); const db=createAdapter(); db.close()'
+test -s "$explicit_db"
+ok "explicit SQLite path remains available to scripts"
+
+index_home=$(mktemp -d /tmp/test660-index-home.XXXXXX)
+env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER \
+  HOME="$index_home" PORT=25660 HOST=127.0.0.1 COMMHUB_DEV_OPEN=1 \
+  bun run server/src/index.ts >"$ART/index.log" 2>&1 &
+index_pid=$!
+wait_health 25660
+test -s "$index_home/.commhub/commhub.db"
+kill "$index_pid"
+wait "$index_pid" 2>/dev/null || true
+ok "canonical src/index.ts opts into the default DB before import"
+
+bin_home=$(mktemp -d /tmp/test660-bin-home.XXXXXX)
+env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER \
+  HOME="$bin_home" bun server/bin/commhub.ts --port 25661 --host 127.0.0.1 --dev-open \
+  >"$ART/bin.log" 2>&1 &
+bin_pid=$!
+wait_health 25661
+test -s "$bin_home/.commhub/commhub.db"
+kill "$bin_pid"
+wait "$bin_pid" 2>/dev/null || true
+ok "packaged commhub bin opts into the default DB before import"
+
+cp server/src/db-adapter.ts /tmp/test660-db-adapter.orig
+sed -i 's/if (!env.COMMHUB_DB && env.COMMHUB_SERVER !== "1") {/if (false) {/' server/src/db-adapter.ts
+grep -F 'if (false) {' server/src/db-adapter.ts >/dev/null
+expect_red remove-default-path-guard bash -c '
+  mutation_home=$(mktemp -d /tmp/test660-mutation-home.XXXXXX)
+  env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER HOME="$mutation_home" \
+    bun -e '\''const {createAdapter}=await import("./server/src/db-adapter.ts"); const db=createAdapter(); db.close()'\'' >/dev/null 2>&1
+  test ! -e "$mutation_home/.commhub/commhub.db"
+'
+cp /tmp/test660-db-adapter.orig server/src/db-adapter.ts
+
+cp server/src/index.ts /tmp/test660-index.orig
+sed -i 's/process.env.COMMHUB_SERVER = "1";/\/\/ mutation: server capability removed/' server/src/index.ts
+expect_red remove-index-optin bash -c '
+  mutation_home=$(mktemp -d /tmp/test660-index-mutation.XXXXXX)
+  env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER HOME="$mutation_home" PORT=25662 HOST=127.0.0.1 COMMHUB_DEV_OPEN=1 \
+    timeout 3 bun run server/src/index.ts > /tmp/test660-index-mutation.log 2>&1
+'
+cp /tmp/test660-index.orig server/src/index.ts
+
+cp server/bin/commhub.ts /tmp/test660-bin.orig
+sed -i 's/process.env.COMMHUB_SERVER = "1";/\/\/ mutation: server capability removed/' server/bin/commhub.ts
+expect_red remove-bin-optin bash -c '
+  mutation_home=$(mktemp -d /tmp/test660-bin-mutation.XXXXXX)
+  env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER HOME="$mutation_home" \
+    timeout 3 bun server/bin/commhub.ts --port 25663 --host 127.0.0.1 --dev-open > /tmp/test660-bin-mutation.log 2>&1
+'
+cp /tmp/test660-bin.orig server/bin/commhub.ts
+
+printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #253.

## Root cause

Non-test imports of `server/src/db-adapter.ts` silently fell back to `$HOME/.commhub/commhub.db`. An ad-hoc `bun -e` probe that forgot `COMMHUB_DB` could therefore open or mutate the live Hub database.

## What changed

- Gate the implicit production SQLite fallback behind exact `COMMHUB_SERVER=1`.
- Set that capability in both canonical code entrypoints **before** dynamically importing the server graph:
  - `server/bin/commhub.ts` (the deployed daemon path)
  - `server/src/index.ts` (source/dev path)
- Keep explicit `COMMHUB_DB` and PostgreSQL `DATABASE_URL` behavior unchanged.
- Add a Docker suite with real source/bin boots and three behavior-sensitive mutations.

## Evidence

Source tested: `c40445c265063e20ca3a24d612d6f364098dc05e`

Report-only head: `3a33b6abc1b079035c80970b91f5676dd068bf09`

- Docker: 8 checks, 0 failures
- Contract: 11 tests, 19 assertions, 0 failures
- Mutations witnessed red:
  - delete default-path guard
  - delete source-entry opt-in
  - delete packaged-bin opt-in
- No production DB, Hub process, global package, or deployment was touched.

Full evidence: `docs/tests/report-test660-explicit-prod-db-optin.txt`