### PR TITLE
fix(cli): require explicit bootstrap database path

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -114,6 +114,10 @@ import {
   type DashboardLaunchRecord,
   type DashboardLaunchSource,
 } from "../src/dashboard-managed-process";
+import {
+  buildBootstrapPasswordUpdateInvocation,
+  resolveBootstrapDatabasePath,
+} from "../src/bootstrap-password-db";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -5810,8 +5814,12 @@ async function serverCommand() {
           // password and `anet passwd` works regardless of the flag).
           if (defaultPassIsRandom && reg.user?.user_id) {
             try {
-              const sql = `UPDATE users SET must_change_password = 1 WHERE user_id = '${reg.user.user_id.replace(/'/g, "''")}'`;
-              execFileSync("bun", ["-e", `import { Database } from "bun:sqlite"; const db = new Database(process.env.COMMHUB_DB || (process.env.HOME + "/.commhub/commhub.db")); db.run(${JSON.stringify(sql)});`], { encoding: "utf-8", env: process.env });
+              const dbPath = resolveBootstrapDatabasePath(process.env, home, process.cwd());
+              const invocation = buildBootstrapPasswordUpdateInvocation(reg.user.user_id, dbPath);
+              execFileSync(invocation.argv[0], invocation.argv.slice(1), {
+                encoding: "utf-8",
+                env: invocation.env,
+              });
             } catch (e: any) {
               console.log(`  ⚠ must_change_password flag not set (non-fatal): ${e?.message || e}`);
             }

--- a/agent-network/src/bootstrap-password-db.test.ts
+++ b/agent-network/src/bootstrap-password-db.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  buildBootstrapPasswordUpdateInvocation,
+  resolveBootstrapDatabasePath,
+} from "./bootstrap-password-db";
+
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "anet-661-"));
+  roots.push(root);
+  return root;
+}
+
+function seedUser(dbPath: string, userId = "user-661"): void {
+  mkdirSync(join(dbPath, ".."), { recursive: true });
+  const db = new Database(dbPath);
+  db.exec("CREATE TABLE users (user_id TEXT PRIMARY KEY, must_change_password INTEGER NOT NULL DEFAULT 0)");
+  db.query("INSERT INTO users (user_id) VALUES (?1)").run(userId);
+  db.close();
+}
+
+function mustChange(dbPath: string, userId = "user-661"): number {
+  const db = new Database(dbPath, { readonly: true });
+  const row = db.query<{ must_change_password: number }, [string]>(
+    "SELECT must_change_password FROM users WHERE user_id = ?1",
+  ).get(userId);
+  db.close();
+  return row?.must_change_password ?? -1;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("bootstrap password database binding", () => {
+  test("turns the local default into an explicit absolute path", () => {
+    const home = tempRoot();
+    expect(resolveBootstrapDatabasePath({}, home, "/work")).toBe(
+      join(home, ".commhub", "commhub.db"),
+    );
+  });
+
+  test("anchors a relative COMMHUB_DB to the hub launch cwd", () => {
+    const home = tempRoot();
+    expect(resolveBootstrapDatabasePath({ COMMHUB_DB: "state/hub.db" }, home, "/srv/anet")).toBe(
+      "/srv/anet/state/hub.db",
+    );
+  });
+
+  test("rejects an unusable default before opening a database", () => {
+    expect(() => resolveBootstrapDatabasePath({}, "~", "/work")).toThrow(/absolute HOME/);
+    expect(() => resolveBootstrapDatabasePath({ COMMHUB_DB: "bad\0path" }, "/home/test", "/work"))
+      .toThrow(/NUL/);
+  });
+
+  test("does not invent a SQLite target for a PostgreSQL Hub", () => {
+    const home = tempRoot();
+    expect(() => resolveBootstrapDatabasePath(
+      { DATABASE_URL: "postgresql://db.example/commhub" },
+      home,
+      "/work",
+    )).toThrow(/PostgreSQL Hub/);
+  });
+
+  test("updates only the explicitly resolved database, never ambient HOME", () => {
+    const root = tempRoot();
+    const explicitDb = join(root, "explicit", "hub.db");
+    const decoyHome = join(root, "decoy-home");
+    const decoyDb = join(decoyHome, ".commhub", "commhub.db");
+    seedUser(explicitDb);
+    seedUser(decoyDb);
+
+    const invocation = buildBootstrapPasswordUpdateInvocation("user-661", explicitDb, {
+      ...process.env,
+      HOME: decoyHome,
+    });
+    expect(invocation.argv.slice(0, 2)).toEqual(["bun", "-e"]);
+    expect(invocation.env.ANET_BOOTSTRAP_DB_PATH).toBe(explicitDb);
+    expect(invocation.script).not.toContain(".commhub/commhub.db");
+    expect(invocation.script).not.toContain("process.env.HOME");
+
+    const proc = Bun.spawnSync(invocation.argv, {
+      env: invocation.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(mustChange(explicitDb)).toBe(1);
+    expect(mustChange(decoyDb)).toBe(0);
+  });
+
+  test("child refuses a missing explicit path without falling back to HOME", () => {
+    const root = tempRoot();
+    const decoyHome = join(root, "decoy-home");
+    const decoyDb = join(decoyHome, ".commhub", "commhub.db");
+    seedUser(decoyDb);
+
+    const invocation = buildBootstrapPasswordUpdateInvocation("user-661", join(root, "unused.db"), {
+      ...process.env,
+      HOME: decoyHome,
+    });
+    delete invocation.env.ANET_BOOTSTRAP_DB_PATH;
+    const proc = Bun.spawnSync(invocation.argv, {
+      env: invocation.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode).not.toBe(0);
+    expect(proc.stderr.toString()).toContain("explicit absolute database path");
+    expect(mustChange(decoyDb)).toBe(0);
+  });
+});

--- a/agent-network/src/bootstrap-password-db.ts
+++ b/agent-network/src/bootstrap-password-db.ts
@@ -1,0 +1,82 @@
+import { isAbsolute, join, resolve } from "path";
+
+const DB_PATH_ENV = "ANET_BOOTSTRAP_DB_PATH";
+const USER_ID_ENV = "ANET_BOOTSTRAP_USER_ID";
+
+export interface BootstrapPasswordUpdateInvocation {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+  script: string;
+}
+
+/**
+ * Resolve the database selected for the local Hub into an explicit absolute
+ * path before launching the bootstrap helper. The helper must never infer a
+ * database from its own HOME/cwd: those can differ from the parent process.
+ */
+export function resolveBootstrapDatabasePath(
+  env: NodeJS.ProcessEnv,
+  home: string,
+  cwd: string,
+): string {
+  if (/^postgres(?:ql)?:\/\//.test(env.DATABASE_URL || "")) {
+    throw new Error("[anet] REFUSING SQLite bootstrap update for a PostgreSQL Hub");
+  }
+  const configured = env.COMMHUB_DB;
+  if (configured?.includes("\0")) {
+    throw new Error("[anet] REFUSING bootstrap database path containing NUL");
+  }
+  if (configured) {
+    if (!isAbsolute(cwd)) {
+      throw new Error("[anet] REFUSING to resolve bootstrap database from a non-absolute cwd");
+    }
+    return isAbsolute(configured) ? resolve(configured) : resolve(cwd, configured);
+  }
+  if (!isAbsolute(home) || home.includes("\0")) {
+    throw new Error("[anet] REFUSING bootstrap database default without an absolute HOME");
+  }
+  return join(home, ".commhub", "commhub.db");
+}
+
+export const BOOTSTRAP_PASSWORD_UPDATE_SCRIPT = String.raw`
+import { Database } from "bun:sqlite";
+import { isAbsolute } from "node:path";
+
+const dbPath = process.env.ANET_BOOTSTRAP_DB_PATH;
+const userId = process.env.ANET_BOOTSTRAP_USER_ID;
+if (!dbPath || !isAbsolute(dbPath) || dbPath.includes("\0")) {
+  throw new Error("REFUSING bootstrap update without an explicit absolute database path");
+}
+if (!userId || userId.includes("\0")) {
+  throw new Error("REFUSING bootstrap update without a valid user id");
+}
+
+const db = new Database(dbPath);
+try {
+  db.query("UPDATE users SET must_change_password = 1 WHERE user_id = ?1").run(userId);
+} finally {
+  db.close();
+}
+`;
+
+export function buildBootstrapPasswordUpdateInvocation(
+  userId: string,
+  dbPath: string,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): BootstrapPasswordUpdateInvocation {
+  if (!dbPath || !isAbsolute(dbPath) || dbPath.includes("\0")) {
+    throw new Error("[anet] REFUSING bootstrap update without an explicit absolute database path");
+  }
+  if (!userId || userId.includes("\0")) {
+    throw new Error("[anet] REFUSING bootstrap update without a valid user id");
+  }
+  return {
+    argv: ["bun", "-e", BOOTSTRAP_PASSWORD_UPDATE_SCRIPT],
+    env: {
+      ...baseEnv,
+      [DB_PATH_ENV]: dbPath,
+      [USER_ID_ENV]: userId,
+    },
+    script: BOOTSTRAP_PASSWORD_UPDATE_SCRIPT,
+  };
+}

--- a/docs/tests/report-test661-explicit-bootstrap-db.txt
+++ b/docs/tests/report-test661-explicit-bootstrap-db.txt
@@ -1,0 +1,84 @@
+# Issue #661 — explicit bootstrap database report
+
+Date: 2026-08-10
+Base: dd502f9f8900957150b60d660fd5d09b7291cb1c
+Source commit under test: c0493085c78673b0509f23af5f705ee76ae0af6d
+Branch: fix/661-explicit-bootstrap-db
+
+## Finding and scope
+
+`agent-network/bin/cli.ts` used a raw `bun -e` SQLite script whose child-side
+selection was `COMMHUB_DB || HOME/.commhub/commhub.db`. That write was an
+intentional, non-fatal local-Hub bootstrap operation, but it bypassed the
+explicit database discipline added to the server adapter by #660.
+
+The CLI and server are independently versioned packages; `anet hub start`
+launches the pinned server through a transient `bunx` environment, so a deep
+adapter import from the CLI is not a reliable installed-package contract. This
+change implements Issue #661's compatible alternative: the parent resolves
+the selected SQLite database into an explicit absolute path, and the child
+accepts only that dedicated path. The child contains no HOME/default fallback.
+
+- Relative `COMMHUB_DB` is anchored to the Hub launch cwd before spawning.
+- A missing/relative/NUL child path fails before `new Database()`.
+- A PostgreSQL Hub skips this non-fatal SQLite-only flag update rather than
+  inventing or touching a default SQLite database.
+- The update uses a bound SQLite parameter instead of interpolated SQL.
+
+No REST/API, schema, server adapter, production runtime, or database was
+changed.
+
+## Docker provenance
+
+- Dockerfile: `tests/test661-explicit-bootstrap-db/Dockerfile`
+- Image tag: `anet-test661-db:dev`
+- Image ID: `sha256:bd7976b9af302972dae7e2d6f246a6afbe14df219142d78218f0d4fd7fe08d99`
+- Embedded ENV: `TEST661_SOURCE_COMMIT=c0493085c78673b0509f23af5f705ee76ae0af6d`
+- Artifacts: `/tmp/test661-artifacts.YUUR1Y`
+
+The image installs dependencies with `--ignore-scripts` because node-pty's
+native postinstall is unrelated to this CLI/bootstrap path. The full
+agent-network production build, including declarations and obfuscation, runs
+inside the image and passes.
+
+## Results
+
+`RESULT pass=6 fail=0`
+
+1. Unit + real SQLite child process: 6/6 tests, 15 assertions.
+2. Real source CLI against an isolated fake Hub: PASS. A random-password
+   bootstrap updates the explicitly selected DB; a valid decoy DB under HOME
+   remains byte-logically unchanged (`must_change_password=0`). The fake `bun`
+   shim records that the child received the exact explicit path and `-e` argv.
+3. Production build: PASS.
+4. Mutation restoring child HOME/default fallback: witnessed red.
+5. Mutation removing the PostgreSQL refusal: witnessed red.
+6. Mutation bypassing CLI explicit selection: witnessed red.
+
+Mutation artifacts:
+
+- `child-restores-home-fallback.log` — 2421 bytes —
+  `976db0b86deeb6d9dc9ff9c186d20da696ab77f68ff71946c53810bcfe7ca176`
+- `postgres-invents-sqlite.log` — 1318 bytes —
+  `c5d66ebd1375014ccf1311e93c2374111ddae27d5cd589cb569c21839409b931`
+- `cli-bypasses-explicit-selection.log` — 113 bytes —
+  `cc8ab802735c00a1809ecc525e2b587c66fcdfbe235c4fa08ef2588fb0936946`
+
+## Witnessed harness failures
+
+The first two exact-source attempts stopped in the mutation injector due to
+Perl/sed delimiter escaping errors; product tests and the production build had
+already passed. Those anchors were replaced with verified exact substitutions.
+
+The next attempt exposed a more important harness defect: Bash suppresses
+`set -e` inside a function invoked as an `if` condition. The CLI-bypass
+mutation broke the database assertions, but the function continued to cleanup
+and returned 0, producing a false green. The E2E now explicitly aggregates and
+returns every observable (CLI rc, selected DB value, decoy DB value, captured
+path, first child argv). With that correction, the same mutation is non-empty
+and red; the unmodified source is green.
+
+The fixed tag was reused for each attempt. Docker had already discarded the
+three superseded manifest IDs when inspected; no broad prune or pattern delete
+was used. Host free space after the final run was approximately 5.2 GB, so no
+additional image was created.

--- a/tests/test661-explicit-bootstrap-db/Dockerfile
+++ b/tests/test661-explicit-bootstrap-db/Dockerfile
@@ -1,0 +1,18 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /repo
+ARG TEST661_SOURCE_COMMIT=unknown
+ENV TEST661_SOURCE_COMMIT=$TEST661_SOURCE_COMMIT
+
+COPY agent-network/package.json /repo/agent-network/package.json
+# node-pty is unrelated to this CLI/bootstrap suite. Avoid its native
+# postinstall while retaining the package/type surface used by the build.
+RUN cd /repo/agent-network && bun install --ignore-scripts
+
+COPY agent-network /repo/agent-network
+COPY tests/lib /repo/tests/lib
+COPY tests/test661-explicit-bootstrap-db /repo/tests/test661-explicit-bootstrap-db
+RUN chmod +x /repo/tests/test661-explicit-bootstrap-db/run.sh \
+  /repo/tests/test661-explicit-bootstrap-db/fake-bin/bun
+
+CMD ["bash", "/repo/tests/test661-explicit-bootstrap-db/run.sh"]

--- a/tests/test661-explicit-bootstrap-db/db-tool.ts
+++ b/tests/test661-explicit-bootstrap-db/db-tool.ts
@@ -1,0 +1,23 @@
+import { Database } from "bun:sqlite";
+import { dirname } from "path";
+import { mkdirSync } from "fs";
+
+const [command, dbPath] = Bun.argv.slice(2);
+if (!command || !dbPath) throw new Error("usage: db-tool.ts <seed|read> <db-path>");
+
+if (command === "seed") {
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  db.exec("CREATE TABLE users (user_id TEXT PRIMARY KEY, must_change_password INTEGER NOT NULL DEFAULT 0)");
+  db.query("INSERT INTO users (user_id) VALUES ('user-661')").run();
+  db.close();
+} else if (command === "read") {
+  const db = new Database(dbPath, { readonly: true });
+  const row = db.query<{ must_change_password: number }, []>(
+    "SELECT must_change_password FROM users WHERE user_id = 'user-661'",
+  ).get();
+  db.close();
+  process.stdout.write(String(row?.must_change_password ?? -1));
+} else {
+  throw new Error(`unknown command: ${command}`);
+}

--- a/tests/test661-explicit-bootstrap-db/fake-bin/bun
+++ b/tests/test661-explicit-bootstrap-db/fake-bin/bun
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+printf '%s\n' "${ANET_BOOTSTRAP_DB_PATH:-}" > "${TEST661_CAPTURE}.path"
+printf '%s\n' "$@" > "${TEST661_CAPTURE}.argv"
+exec /usr/local/bin/bun "$@"

--- a/tests/test661-explicit-bootstrap-db/fixture-server.ts
+++ b/tests/test661-explicit-bootstrap-db/fixture-server.ts
@@ -1,0 +1,31 @@
+const port = Number(process.env.TEST661_PORT || "25661");
+const readyFile = process.env.TEST661_READY_FILE;
+if (!readyFile) throw new Error("TEST661_READY_FILE is required");
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port,
+  fetch(request) {
+    const path = new URL(request.url).pathname;
+    if (path === "/health") return Response.json({ ok: true, version: "test661-fixture" });
+    if (path === "/api/auth/login") return Response.json({ ok: false, error: "invalid credentials" });
+    if (path === "/api/auth/register") {
+      return Response.json({
+        ok: true,
+        token: "utok_test661_fixture",
+        user: { user_id: "user-661", username: "admin" },
+      });
+    }
+    return Response.json({ ok: false, error: "not found" }, { status: 404 });
+  },
+});
+
+await Bun.write(readyFile, String(server.port));
+
+function stop() {
+  server.stop(true);
+  process.exit(0);
+}
+process.on("SIGTERM", stop);
+process.on("SIGINT", stop);
+await new Promise(() => {});

--- a/tests/test661-explicit-bootstrap-db/run.sh
+++ b/tests/test661-explicit-bootstrap-db/run.sh
@@ -68,14 +68,14 @@ ok "agent-network production build"
 cp agent-network/src/bootstrap-password-db.ts /tmp/test661-bootstrap-db.orig
 cp agent-network/bin/cli.ts /tmp/test661-cli.orig
 
-sed -i 's|const dbPath = process.env.ANET_BOOTSTRAP_DB_PATH;|const dbPath = process.env.ANET_BOOTSTRAP_DB_PATH || (process.env.HOME + "/.commhub/commhub.db");|' \
+sed -i 's@const dbPath = process.env.ANET_BOOTSTRAP_DB_PATH;@const dbPath = process.env.ANET_BOOTSTRAP_DB_PATH || (process.env.HOME + "/.commhub/commhub.db");@' \
   agent-network/src/bootstrap-password-db.ts
 grep -Fq 'process.env.HOME + "/.commhub/commhub.db"' agent-network/src/bootstrap-password-db.ts
 expect_red child-restores-home-fallback bun test agent-network/src/bootstrap-password-db.test.ts
 cp /tmp/test661-bootstrap-db.orig agent-network/src/bootstrap-password-db.ts
 
-sed -i 's|if (/^postgres(?:ql)?:\/\//.test(env.DATABASE_URL || "")) {|if (false) {|' \
-  agent-network/src/bootstrap-password-db.ts
+[[ "$(grep -Fc 'DATABASE_URL ||' agent-network/src/bootstrap-password-db.ts)" -eq 1 ]]
+sed -i '/DATABASE_URL ||/c\  if (false) {' agent-network/src/bootstrap-password-db.ts
 grep -Fq 'if (false) {' agent-network/src/bootstrap-password-db.ts
 expect_red postgres-invents-sqlite bun test agent-network/src/bootstrap-password-db.test.ts
 cp /tmp/test661-bootstrap-db.orig agent-network/src/bootstrap-password-db.ts

--- a/tests/test661-explicit-bootstrap-db/run.sh
+++ b/tests/test661-explicit-bootstrap-db/run.sh
@@ -68,13 +68,13 @@ ok "agent-network production build"
 cp agent-network/src/bootstrap-password-db.ts /tmp/test661-bootstrap-db.orig
 cp agent-network/bin/cli.ts /tmp/test661-cli.orig
 
-perl -0pi -e 's/const dbPath = process\.env\.ANET_BOOTSTRAP_DB_PATH;/const dbPath = process.env.ANET_BOOTSTRAP_DB_PATH || (process.env.HOME + "\\/.commhub\\/commhub.db");/' \
+sed -i 's|const dbPath = process.env.ANET_BOOTSTRAP_DB_PATH;|const dbPath = process.env.ANET_BOOTSTRAP_DB_PATH || (process.env.HOME + "/.commhub/commhub.db");|' \
   agent-network/src/bootstrap-password-db.ts
-grep -Fq 'process.env.HOME + "\/.commhub\/commhub.db"' agent-network/src/bootstrap-password-db.ts
+grep -Fq 'process.env.HOME + "/.commhub/commhub.db"' agent-network/src/bootstrap-password-db.ts
 expect_red child-restores-home-fallback bun test agent-network/src/bootstrap-password-db.test.ts
 cp /tmp/test661-bootstrap-db.orig agent-network/src/bootstrap-password-db.ts
 
-sed -i 's/if (\/\^postgres(?:ql)?:\\\/\\\/\/.test(env.DATABASE_URL || "")) {/if (false) {/' \
+sed -i 's|if (/^postgres(?:ql)?:\/\//.test(env.DATABASE_URL || "")) {|if (false) {|' \
   agent-network/src/bootstrap-password-db.ts
 grep -Fq 'if (false) {' agent-network/src/bootstrap-password-db.ts
 expect_red postgres-invents-sqlite bun test agent-network/src/bootstrap-password-db.test.ts

--- a/tests/test661-explicit-bootstrap-db/run.sh
+++ b/tests/test661-explicit-bootstrap-db/run.sh
@@ -17,6 +17,7 @@ expect_red(){
 
 run_cli_e2e(){
   local case_root home explicit_db decoy_db ready capture fixture_pid rc
+  local explicit_value decoy_value captured_path first_arg
   case_root=$(mktemp -d /tmp/test661-e2e.XXXXXX)
   home="$case_root/home"
   explicit_db="$case_root/explicit/hub.db"
@@ -24,8 +25,8 @@ run_cli_e2e(){
   ready="$case_root/ready"
   capture="$case_root/capture"
   mkdir -p "$home"
-  /usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" seed "$explicit_db"
-  /usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" seed "$decoy_db"
+  /usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" seed "$explicit_db" || return 1
+  /usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" seed "$decoy_db" || return 1
 
   TEST661_PORT=25661 TEST661_READY_FILE="$ready" \
     /usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/fixture-server.ts" \
@@ -43,11 +44,17 @@ run_cli_e2e(){
   set -e
   kill "$fixture_pid" 2>/dev/null || true
   wait "$fixture_pid" 2>/dev/null || true
-  [[ "$rc" -eq 0 ]]
-  [[ "$(/usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" read "$explicit_db")" == 1 ]]
-  [[ "$(/usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" read "$decoy_db")" == 0 ]]
-  [[ "$(cat "$capture.path")" == "$explicit_db" ]]
-  [[ "$(sed -n '1p' "$capture.argv")" == "-e" ]]
+  explicit_value=$(/usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" read "$explicit_db") || return 1
+  decoy_value=$(/usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" read "$decoy_db") || return 1
+  captured_path=$(cat "$capture.path" 2>/dev/null || true)
+  first_arg=$(sed -n '1p' "$capture.argv" 2>/dev/null || true)
+  if [[ "$rc" -ne 0 || "$explicit_value" != 1 || "$decoy_value" != 0 \
+    || "$captured_path" != "$explicit_db" || "$first_arg" != "-e" ]]; then
+    printf 'E2E mismatch rc=%s explicit=%s decoy=%s captured_path=%s first_arg=%s\n' \
+      "$rc" "$explicit_value" "$decoy_value" "$captured_path" "$first_arg" >&2
+    safe_rm_rf "$case_root"
+    return 1
+  fi
   safe_rm_rf "$case_root"
 }
 

--- a/tests/test661-explicit-bootstrap-db/run.sh
+++ b/tests/test661-explicit-bootstrap-db/run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT=/repo
+ART=/artifacts
+PASS=0
+FAIL=0
+mkdir -p "$ART"
+source "$ROOT/tests/lib/safe-rm.sh"
+
+ok(){ PASS=$((PASS+1)); printf 'PASS %s\n' "$*"; }
+bad(){ FAIL=$((FAIL+1)); printf 'FAIL %s\n' "$*"; }
+expect_red(){
+  local name="$1"; shift
+  if "$@" >"$ART/$name.log" 2>&1; then bad "mutation $name stayed green"; else ok "mutation $name witnessed red"; fi
+}
+
+run_cli_e2e(){
+  local case_root home explicit_db decoy_db ready capture fixture_pid rc
+  case_root=$(mktemp -d /tmp/test661-e2e.XXXXXX)
+  home="$case_root/home"
+  explicit_db="$case_root/explicit/hub.db"
+  decoy_db="$home/.commhub/commhub.db"
+  ready="$case_root/ready"
+  capture="$case_root/capture"
+  mkdir -p "$home"
+  /usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" seed "$explicit_db"
+  /usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" seed "$decoy_db"
+
+  TEST661_PORT=25661 TEST661_READY_FILE="$ready" \
+    /usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/fixture-server.ts" \
+    >"$case_root/server.log" 2>&1 &
+  fixture_pid=$!
+  for _ in $(seq 1 50); do [[ -s "$ready" ]] && break; sleep 0.05; done
+  if [[ ! -s "$ready" ]]; then kill "$fixture_pid" 2>/dev/null || true; return 1; fi
+
+  set +e
+  HOME="$home" COMMHUB_DB="$explicit_db" TEST661_CAPTURE="$capture" \
+    PATH="$ROOT/tests/test661-explicit-bootstrap-db/fake-bin:$PATH" \
+    /usr/local/bin/bun "$ROOT/agent-network/bin/cli.ts" hub start --port 25661 \
+    >"$case_root/cli.log" 2>&1
+  rc=$?
+  set -e
+  kill "$fixture_pid" 2>/dev/null || true
+  wait "$fixture_pid" 2>/dev/null || true
+  [[ "$rc" -eq 0 ]]
+  [[ "$(/usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" read "$explicit_db")" == 1 ]]
+  [[ "$(/usr/local/bin/bun "$ROOT/tests/test661-explicit-bootstrap-db/db-tool.ts" read "$decoy_db")" == 0 ]]
+  [[ "$(cat "$capture.path")" == "$explicit_db" ]]
+  [[ "$(sed -n '1p' "$capture.argv")" == "-e" ]]
+  safe_rm_rf "$case_root"
+}
+
+printf 'source_commit=%s\n' "${TEST661_SOURCE_COMMIT:-unknown}"
+cd "$ROOT"
+
+bun test agent-network/src/bootstrap-password-db.test.ts
+ok "explicit bootstrap database unit + real SQLite subprocess"
+run_cli_e2e
+ok "real anet hub start bootstrap updates only explicit database"
+
+(
+  cd agent-network
+  bun run build
+)
+ok "agent-network production build"
+
+cp agent-network/src/bootstrap-password-db.ts /tmp/test661-bootstrap-db.orig
+cp agent-network/bin/cli.ts /tmp/test661-cli.orig
+
+perl -0pi -e 's/const dbPath = process\.env\.ANET_BOOTSTRAP_DB_PATH;/const dbPath = process.env.ANET_BOOTSTRAP_DB_PATH || (process.env.HOME + "\\/.commhub\\/commhub.db");/' \
+  agent-network/src/bootstrap-password-db.ts
+grep -Fq 'process.env.HOME + "\/.commhub\/commhub.db"' agent-network/src/bootstrap-password-db.ts
+expect_red child-restores-home-fallback bun test agent-network/src/bootstrap-password-db.test.ts
+cp /tmp/test661-bootstrap-db.orig agent-network/src/bootstrap-password-db.ts
+
+sed -i 's/if (\/\^postgres(?:ql)?:\\\/\\\/\/.test(env.DATABASE_URL || "")) {/if (false) {/' \
+  agent-network/src/bootstrap-password-db.ts
+grep -Fq 'if (false) {' agent-network/src/bootstrap-password-db.ts
+expect_red postgres-invents-sqlite bun test agent-network/src/bootstrap-password-db.test.ts
+cp /tmp/test661-bootstrap-db.orig agent-network/src/bootstrap-password-db.ts
+
+sed -i 's/const dbPath = resolveBootstrapDatabasePath(process.env, home, process.cwd());/const dbPath = join(home, ".commhub", "commhub.db");/' \
+  agent-network/bin/cli.ts
+grep -Fq 'const dbPath = join(home, ".commhub", "commhub.db");' agent-network/bin/cli.ts
+expect_red cli-bypasses-explicit-selection run_cli_e2e
+cp /tmp/test661-cli.orig agent-network/bin/cli.ts
+
+printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What changed

- replace the bootstrap child script's implicit `COMMHUB_DB || HOME/.commhub` selection with a parent-resolved explicit absolute path
- fail closed before SQLite open when the child path is missing/relative/NUL
- skip the non-fatal SQLite-only password flag update for PostgreSQL Hubs
- bind `user_id` as a SQLite parameter
- add a real `anet hub start` → isolated fake Hub → SQLite E2E, production build, and three witnessed-red mutations

## Why

#660 made the server adapter refuse accidental default production DB opens, but this CLI bootstrap write bypassed that choke point with its own child-side HOME fallback. The CLI and pinned server are independently packaged, so this uses Issue #661's compatible explicit-path assertion path rather than adding an unreliable deep import or expanding the REST API.

## Validation

- base: `dd502f9f8900957150b60d660fd5d09b7291cb1c`
- exact source: `c0493085c78673b0509f23af5f705ee76ae0af6d`
- report-only HEAD: `a882a84586c6f45482e9c53e6fa73eeba596f9ae`
- image: `sha256:bd7976b9af302972dae7e2d6f246a6afbe14df219142d78218f0d4fd7fe08d99`
- result: 6/0; unit 6/6 (15 assertions); production build PASS; 3 mutations red

The report documents two injector syntax failures and a subsequently discovered false-green Bash harness condition; the final E2E uses explicit observable aggregation and the CLI-bypass mutation now turns red.

Full evidence: `docs/tests/report-test661-explicit-bootstrap-db.txt`.

Closes #661
