### PR TITLE
test(e2e): reject false ok responses

### DIFF
--- a/docs/tests/report-test292-e2e-ok-assertions.txt
+++ b/docs/tests/report-test292-e2e-ok-assertions.txt
@@ -3,7 +3,7 @@
 Date: 2026-08-10
 Issue scope: #292, Layer 3 only (test-harness honesty; no production behavior change)
 Base commit: 737fc44bac67f259f3ddc3d31b53ff05ac0b8d3d
-Source commit: 976378c324ddf6fbfd9ac4e7d80013912c9fc2fb
+Source commit: f3b62101b6b9f2919800cb14b74c85ee4afa86a2
 
 ## Change
 
@@ -25,20 +25,26 @@ structured parser, so the test292 container exited non-zero.
 ## Exact-source Docker gate
 
 Image: `anet-test292:dev`
-Image manifest ID: `sha256:e2da3f3b3d9aaaaeea5e7c3f83270257c79247f3f31edf841836deaa7cfea0ec`
-Embedded source: `TEST292_SOURCE_COMMIT=976378c324ddf6fbfd9ac4e7d80013912c9fc2fb`
+Image manifest ID: `sha256:2af10bcaff4a65e38fa69eb9370d71d4a7660e0f66a297c61567ab2453995e72`
+Embedded source: `TEST292_SOURCE_COMMIT=f3b62101b6b9f2919800cb14b74c85ee4afa86a2`
+Runner output SHA256: `1c5d8ee67502ca9d27cf414e4259c8b84a63e9d3a32a62a7966729b0777a4ecd`
 
 Result: 11 passed, 0 failed.
 
 Covered direct REST JSON, SSE-wrapped MCP JSON, plain JSON-RPC MCP JSON, explicit false,
 JSON-RPC error, malformed/empty input, source call-site count, and mutation behavior.
 
-Mutation: changing the exact `value is True` predicate to `value is not None` makes the
-`ok:false` fixture fail the suite (rc=1). This proves the exact-true gate is load-bearing.
+Mutation: changing the exact `value.get("ok") is True` predicate to
+`value.get("ok") is not None` makes the weakened parser accept a bare `{"ok":false}`
+fixture. The harness first verifies that the mutated parser differs byte-for-byte, then
+turns red if that false response is accepted. The fixture intentionally has no `error`
+field, so no independent failure predicate can mask the weakened `ok` check. This proves
+the exact-true gate is load-bearing rather than a no-op mutation.
 
 ## Exact-source full aggregate run
 
-Image: `anet-e2e292:dev`
+Image: `anet-e2e292:dev` (run at source `976378c324ddf6fbfd9ac4e7d80013912c9fc2fb`;
+the subsequent source delta changes only the mutation harness)
 Image manifest ID: `sha256:03c6ebe701dd5c88e142700470f94c331db445e14c6753e9d2a2aaee5c23e8d1`
 Image label: `org.opencontainers.image.revision=976378c324ddf6fbfd9ac4e7d80013912c9fc2fb`
 Command: `/app/test-all.sh`
@@ -62,6 +68,27 @@ not repair or reclassify those underlying E2E failures; that remains subsequent 
 Running `/app/test.sh` directly is not a valid aggregate invocation in this image: it starts
 its own persistent Hub child and reaches a bare `wait`. The repository CI entry point
 `/app/test-all.sh` supplies the expected outer orchestration and is the full-run evidence above.
+
+## Layer 2 diagnostic probe (not an implementation claim)
+
+A controlled, uncommitted probe against the same full image changed only the E2E bootstrap:
+
+- selected the newly created network with `anet network use`;
+- pre-created `e2e-agent` through the official CLI, yielding a stable node ID and node token;
+- started `agent-node` from that generated config; and
+- required exact `found` output rather than substring-matching `not_found`.
+
+The Base E2E result changed from 82 passed / 53 failed to 97 passed / 39 failed. Registration,
+`send_task`, task lookup, ack, reply, and the special-content path became green. This is evidence
+for the next #292 layer, not part of this PR: without selecting the network, node creation used
+the default network while the process was injected with the new network ID; without pre-creation,
+`report_status` failed with `network_token_required`. The original registration assertion also
+accepted `not_found` because it searched for the substring `found`.
+
+Original detailed log SHA256:
+`0fcf7a8d6357f92c819ae0ea5156bc554f45ec295b9aba1ca015707b5eae5f84`.
+Controlled probe log SHA256:
+`6a2cb8296adbb86361bfbfad251954b67e3e53c4213c7fc2d67d2bb98bd26a86`.
 
 ## Cleanup
 

--- a/docs/tests/report-test292-e2e-ok-assertions.txt
+++ b/docs/tests/report-test292-e2e-ok-assertions.txt
@@ -1,0 +1,70 @@
+# Test 292 — Docker E2E structured `ok` assertions
+
+Date: 2026-08-10
+Issue scope: #292, Layer 3 only (test-harness honesty; no production behavior change)
+Base commit: 737fc44bac67f259f3ddc3d31b53ff05ac0b8d3d
+Source commit: 976378c324ddf6fbfd9ac4e7d80013912c9fc2fb
+
+## Change
+
+- Added `tests/lib/response-json.sh` with a fail-closed JSON/SSE/JSON-RPC response parser.
+- Replaced the 16 `grep -q 'ok'` success checks in `tests/docker-e2e.sh`.
+- Success now requires an exact JSON boolean `ok: true`; `ok:false`, JSON-RPC errors,
+  MCP `isError:true`, malformed responses, and empty responses fail.
+- The helper is exported only as a test seam. Production code and wire behavior are unchanged.
+
+## Witnessed red
+
+The pre-change fixture demonstrated that the legacy assertion accepts a failed MCP response:
+
+    data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":false,\"error\":\"permission_denied\"}"}]}}
+
+`grep -q 'ok'` returned success. The base tree contained 16 such weak assertions and no
+structured parser, so the test292 container exited non-zero.
+
+## Exact-source Docker gate
+
+Image: `anet-test292:dev`
+Image manifest ID: `sha256:e2da3f3b3d9aaaaeea5e7c3f83270257c79247f3f31edf841836deaa7cfea0ec`
+Embedded source: `TEST292_SOURCE_COMMIT=976378c324ddf6fbfd9ac4e7d80013912c9fc2fb`
+
+Result: 11 passed, 0 failed.
+
+Covered direct REST JSON, SSE-wrapped MCP JSON, plain JSON-RPC MCP JSON, explicit false,
+JSON-RPC error, malformed/empty input, source call-site count, and mutation behavior.
+
+Mutation: changing the exact `value is True` predicate to `value is not None` makes the
+`ok:false` fixture fail the suite (rc=1). This proves the exact-true gate is load-bearing.
+
+## Exact-source full aggregate run
+
+Image: `anet-e2e292:dev`
+Image manifest ID: `sha256:03c6ebe701dd5c88e142700470f94c331db445e14c6753e9d2a2aaee5c23e8d1`
+Image label: `org.opencontainers.image.revision=976378c324ddf6fbfd9ac4e7d80013912c9fc2fb`
+Command: `/app/test-all.sh`
+Captured log SHA256: `f9f86410c1b04e479bc1b76283beac384a73daaf7835adebf989e986e7ee3391`
+
+Result (intentionally not green):
+
+- Base E2E: 82 passed, 53 failed
+- V3 Auth: 25 passed, 0 failed
+- V3 Networks: 25 passed, 1 failed
+- Config Priority: 16 passed, 0 failed
+- Loop runtime: 0 ran; suite exited before a Results line
+- Loop npm-pack: 10 passed, 2 failed
+- Loop self-management: 2 passed, 3 failed
+- Aggregate: 160 passed, 60 failed
+
+The current report-only baseline was Base E2E 88 passed / 47 failed. The structured gate
+therefore exposes exactly six prior false-green responses as failures (82/53). This PR does
+not repair or reclassify those underlying E2E failures; that remains subsequent #292 work.
+
+Running `/app/test.sh` directly is not a valid aggregate invocation in this image: it starts
+its own persistent Hub child and reaches a bare `wait`. The repository CI entry point
+`/app/test-all.sh` supplies the expected outer orchestration and is the full-run evidence above.
+
+## Cleanup
+
+The 3.48 GB full-run image was removed by its exact tag after evidence capture because the
+host reached 100% disk usage. No prune or pattern deletion was used. The small exact-source
+`anet-test292:dev` review image remains available.

--- a/tests/docker-e2e.sh
+++ b/tests/docker-e2e.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source /app/lib/response-json.sh
 # Don't use set -e — we handle errors via pass()/fail()
 PASS=0
 FAIL=0
@@ -161,7 +162,7 @@ echo ""
 # 9. send_task via MCP
 echo "9. Testing send_task..."
 SEND=$(mcp_call "send_task" '{"alias":"e2e-agent","task":"test task","from_session":"tester"}')
-echo "$SEND" | grep -q "ok" && pass "task sent" || fail "task send failed"
+response_json_ok "$SEND" && pass "task sent" || fail "task send failed"
 echo ""
 
 # 10. send_message should not trigger processing
@@ -214,13 +215,13 @@ echo ""
 # 12. V2: send_ack updates tasks table
 echo "12. Testing V2 send_ack..."
 ACK_RESP=$(mcp_call "send_ack" "{\"task_id\":\"$TASK_ID\",\"from_session\":\"e2e-agent\"}")
-echo "$ACK_RESP" | grep -q 'ok' && pass "send_ack accepted" || { echo "$ACK_RESP"; fail "send_ack failed"; }
+response_json_ok "$ACK_RESP" && pass "send_ack accepted" || { echo "$ACK_RESP"; fail "send_ack failed"; }
 echo ""
 
 # 13. V2: send_reply closes task lifecycle
 echo "13. Testing V2 send_reply..."
 REPLY_RESP=$(mcp_call "send_reply" "{\"alias\":\"v2-tester\",\"text\":\"task done\",\"in_reply_to\":\"$TASK_ID\",\"status\":\"replied\",\"from_session\":\"e2e-agent\"}")
-echo "$REPLY_RESP" | grep -q 'ok' && pass "send_reply accepted" || { echo "$REPLY_RESP"; fail "send_reply failed"; }
+response_json_ok "$REPLY_RESP" && pass "send_reply accepted" || { echo "$REPLY_RESP"; fail "send_reply failed"; }
 echo ""
 
 # 14. V2: verify task reached terminal state via REST
@@ -241,7 +242,7 @@ echo ""
 # 15. broadcast
 echo "15. Testing broadcast..."
 BC_RESP=$(mcp_call "broadcast" '{"message":"broadcast test","filter_server":"none"}')
-echo "$BC_RESP" | grep -q 'ok' && pass "broadcast sent" || fail "broadcast failed"
+response_json_ok "$BC_RESP" && pass "broadcast sent" || fail "broadcast failed"
 echo ""
 
 # 16. send_reply with status=failed
@@ -259,7 +260,7 @@ try:
 except: print('')
 " 2>/dev/null)
 FAIL_REPLY=$(mcp_call "send_reply" "{\"alias\":\"fail-tester\",\"text\":\"error occurred\",\"in_reply_to\":\"$FAIL_TID\",\"status\":\"failed\",\"from_session\":\"e2e-agent\"}")
-echo "$FAIL_REPLY" | grep -q 'ok' && pass "send_reply(failed) accepted" || fail "send_reply(failed) broken"
+response_json_ok "$FAIL_REPLY" && pass "send_reply(failed) accepted" || fail "send_reply(failed) broken"
 # verify task status = failed
 sleep 1
 FAIL_CHECK=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/tasks?task_id=$FAIL_TID" 2>/dev/null)
@@ -290,7 +291,7 @@ echo ""
 # 18. special characters in task content
 echo "18. Testing special characters..."
 SPECIAL_RESP=$(mcp_call "send_task" '{"alias":"e2e-agent","task":"test <script>alert(1)</script> & \"quotes\" 中文测试","from_session":"tester"}')
-echo "$SPECIAL_RESP" | grep -q 'ok' && pass "special chars in task content" || fail "special chars rejected"
+response_json_ok "$SPECIAL_RESP" && pass "special chars in task content" || fail "special chars rejected"
 echo ""
 
 # 19. tasks query by from_name
@@ -382,7 +383,7 @@ echo ""
 echo "23.6 Testing large content..."
 LARGE_CONTENT=$(python3 -c "print('X' * 5000)")
 LARGE_RESP=$(mcp_call "send_task" "{\"alias\":\"conc-1\",\"task\":\"$LARGE_CONTENT\",\"from_session\":\"tester\"}")
-echo "$LARGE_RESP" | grep -q 'ok' && pass "5KB task content accepted" || fail "large content rejected"
+response_json_ok "$LARGE_RESP" && pass "5KB task content accepted" || fail "large content rejected"
 # Verify round-trip: content stored correctly
 LARGE_TID=$(echo "$LARGE_RESP" | python3 -c "
 import sys,json
@@ -407,7 +408,7 @@ fi
 
 # Boundary: empty-ish content edge
 EMPTY_RESP=$(mcp_call "send_task" '{"alias":"conc-1","task":"x","from_session":"tester"}')
-echo "$EMPTY_RESP" | grep -q 'ok' && pass "minimal 1-char task accepted" || fail "1-char task rejected"
+response_json_ok "$EMPTY_RESP" && pass "minimal 1-char task accepted" || fail "1-char task rejected"
 echo ""
 
 # 23.61 task events audit log
@@ -420,7 +421,7 @@ echo ""
 # 23.62 get_task query
 echo "23.62 Testing get_task..."
 GET_T=$(mcp_call "get_task" "{\"task_id\":\"$TASK_ID\"}")
-echo "$GET_T" | grep -q 'ok' && pass "get_task found" || fail "get_task broken"
+response_json_ok "$GET_T" && pass "get_task found" || fail "get_task broken"
 echo "$GET_T" | grep -q 'status' && pass "get_task shows status" || fail "get_task no status"
 GET_MISS=$(mcp_call "get_task" '{"task_id":"nonexistent"}')
 echo "$GET_MISS" | grep -q 'not found' && pass "get_task 404 for missing" || fail "get_task should 404"
@@ -449,7 +450,7 @@ RETRY_C1=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/
 echo "$RETRY_C1" | grep -q '"failed"' && pass "task marked failed" || fail "task not failed"
 # Retry it
 RETRY_RESP=$(mcp_call "retry_task" "{\"task_id\":\"$RETRY_TID\",\"from_session\":\"tester\"}")
-echo "$RETRY_RESP" | grep -q 'ok' && pass "retry_task accepted" || fail "retry_task failed"
+response_json_ok "$RETRY_RESP" && pass "retry_task accepted" || fail "retry_task failed"
 # Verify back to delivered
 sleep 1
 RETRY_C2=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/tasks?task_id=$RETRY_TID" 2>/dev/null)
@@ -459,7 +460,7 @@ echo ""
 # 23.63 list_tasks + stats
 echo "23.63 Testing list_tasks..."
 LT_RESP=$(mcp_call "list_tasks" '{"alias":"e2e-agent","limit":5}')
-echo "$LT_RESP" | grep -q 'ok' && pass "list_tasks works" || fail "list_tasks broken"
+response_json_ok "$LT_RESP" && pass "list_tasks works" || fail "list_tasks broken"
 echo "$LT_RESP" | grep -q 'stats' && pass "list_tasks has stats" || fail "no stats"
 # REST stats
 REST_STATS=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/tasks?limit=1" 2>/dev/null)
@@ -481,7 +482,7 @@ try:
 except: print('')
 " 2>/dev/null)
 CANCEL_RESP=$(mcp_call "cancel_task" "{\"task_id\":\"$CANCEL_TID\",\"reason\":\"no longer needed\",\"from_session\":\"tester\"}")
-echo "$CANCEL_RESP" | grep -q 'ok' && pass "cancel_task accepted" || fail "cancel_task failed"
+response_json_ok "$CANCEL_RESP" && pass "cancel_task accepted" || fail "cancel_task failed"
 CANCEL_CHECK=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/tasks?task_id=$CANCEL_TID" 2>/dev/null)
 echo "$CANCEL_CHECK" | grep -q '"cancelled"' && pass "task status = cancelled" || fail "task not cancelled"
 # Try cancel again (idempotent check — already terminal)
@@ -646,7 +647,7 @@ echo ""
 echo "25. Simulating full agent lifecycle..."
 # Register a mock agent
 SIM_REG=$(mcp_call "report_status" '{"resume_id":"sim-mock-agent","alias":"mock-agent","status":"idle","server":"test","agent":"mock"}')
-echo "$SIM_REG" | grep -q 'ok' && pass "mock agent registered" || fail "mock agent registration failed"
+response_json_ok "$SIM_REG" && pass "mock agent registered" || fail "mock agent registration failed"
 
 # Send task to mock agent
 SIM_TASK=$(mcp_call "send_task" '{"alias":"mock-agent","task":"compute 2+2","from_session":"orchestrator","priority":"normal"}')
@@ -673,7 +674,7 @@ echo "$SIM_INBOX" | grep -q 'compute 2+2' && pass "mock agent received task" || 
 
 # Mock agent: ack
 SIM_ACK=$(mcp_call "ack_inbox" "{\"alias\":\"mock-agent\",\"message_id\":\"$SIM_TID\"}")
-echo "$SIM_ACK" | grep -q 'ok' && pass "mock agent acked" || fail "ack failed"
+response_json_ok "$SIM_ACK" && pass "mock agent acked" || fail "ack failed"
 
 # Verify task = acked
 SIM_CHECK2=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/tasks?task_id=$SIM_TID" 2>/dev/null)
@@ -681,7 +682,7 @@ echo "$SIM_CHECK2" | grep -q '"acked"' && pass "task status = acked" || fail "ex
 
 # Mock agent: report working
 SIM_WORK=$(mcp_call "report_status" '{"resume_id":"sim-mock-agent","alias":"mock-agent","status":"working","task":"compute 2+2"}')
-echo "$SIM_WORK" | grep -q 'ok' && pass "mock agent working" || fail "status update failed"
+response_json_ok "$SIM_WORK" && pass "mock agent working" || fail "status update failed"
 
 # Verify task = running
 sleep 1
@@ -690,7 +691,7 @@ echo "$SIM_CHECK3" | grep -q '"running"' && pass "task status = running" || fail
 
 # Mock agent: send reply with result
 SIM_REPLY=$(mcp_call "send_reply" "{\"alias\":\"orchestrator\",\"text\":\"4\",\"in_reply_to\":\"$SIM_TID\",\"status\":\"replied\",\"from_session\":\"mock-agent\"}")
-echo "$SIM_REPLY" | grep -q 'ok' && pass "mock agent replied" || fail "reply failed"
+response_json_ok "$SIM_REPLY" && pass "mock agent replied" || fail "reply failed"
 
 # Verify task = replied with result
 SIM_CHECK4=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/tasks?task_id=$SIM_TID" 2>/dev/null)

--- a/tests/lib/response-json.sh
+++ b/tests/lib/response-json.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Return success only when a direct REST response or an MCP JSON-RPC/SSE
+# response contains a canonical boolean `ok: true`.  A literal "ok" token is
+# not evidence: `{ "ok": false }` contains the same substring and was the
+# source of #292's false-green E2E assertions.
+#
+# The function is intentionally silent.  Callers may print the original
+# response on failure, but this parser never echoes response data itself.
+response_json_ok() {
+  local payload=${1-}
+  printf '%s' "$payload" | python3 -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+if not raw:
+    raise SystemExit(1)
+
+candidates = []
+for line in raw.splitlines():
+    stripped = line.strip()
+    if stripped.startswith("data:"):
+        stripped = stripped[5:].strip()
+    if not stripped or stripped == "[DONE]":
+        continue
+    try:
+        candidates.append(json.loads(stripped))
+    except Exception:
+        pass
+
+if not candidates:
+    try:
+        candidates.append(json.loads(raw))
+    except Exception:
+        raise SystemExit(1)
+
+seen_true = False
+seen_failure = False
+
+def inspect(value, depth=0):
+    global seen_true, seen_failure
+    if depth > 6:
+        seen_failure = True
+        return
+    if isinstance(value, str):
+        try:
+            inspect(json.loads(value), depth + 1)
+        except Exception:
+            return
+        return
+    if isinstance(value, list):
+        for item in value:
+            inspect(item, depth + 1)
+        return
+    if not isinstance(value, dict):
+        return
+    if value.get("isError") is True or value.get("error") is not None:
+        seen_failure = True
+    if "ok" in value:
+        if value.get("ok") is True:
+            seen_true = True
+        else:
+            seen_failure = True
+    if "result" in value:
+        inspect(value["result"], depth + 1)
+    if "content" in value:
+        inspect(value["content"], depth + 1)
+    if value.get("type") == "text" and "text" in value:
+        inspect(value["text"], depth + 1)
+
+for candidate in candidates:
+    inspect(candidate)
+
+raise SystemExit(0 if seen_true and not seen_failure else 1)
+'
+}

--- a/tests/test292-e2e-ok-assertions/Dockerfile
+++ b/tests/test292-e2e-ok-assertions/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+ARG TEST292_SOURCE_COMMIT=unknown
+ENV TEST292_SOURCE_COMMIT=${TEST292_SOURCE_COMMIT}
+
+WORKDIR /src
+COPY tests/docker-e2e.sh tests/docker-e2e.sh
+COPY tests/lib/ tests/lib/
+COPY tests/test292-e2e-ok-assertions/run.sh tests/test292-e2e-ok-assertions/run.sh
+
+RUN chmod +x tests/test292-e2e-ok-assertions/run.sh
+ENTRYPOINT ["bash", "tests/test292-e2e-ok-assertions/run.sh"]

--- a/tests/test292-e2e-ok-assertions/run.sh
+++ b/tests/test292-e2e-ok-assertions/run.sh
@@ -14,6 +14,7 @@ DIRECT_TRUE='{"ok":true,"message_id":"m1"}'
 DIRECT_FALSE='{"ok":false,"error":"alias_not_found"}'
 SSE_TRUE='data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":true,\"message_id\":\"m2\"}"}]}}'
 SSE_FALSE='data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":false,\"error\":\"permission_denied\"}"}]}}'
+BARE_FALSE='{"ok":false}'
 PLAIN_MCP_TRUE='{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":true}"}]}}'
 RPC_ERROR='data: {"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"Invalid arguments"}}'
 
@@ -78,15 +79,18 @@ fi
 MUT=$(mktemp -d /tmp/test292-mut.XXXXXX)
 trap 'safe_rm_rf "$MUT"' EXIT
 cp "$ROOT/tests/lib/response-json.sh" "$MUT/response-json.sh"
-sed -i 's/value is True/value is not None/' "$MUT/response-json.sh"
+sed -i 's/value.get("ok") is True/value.get("ok") is not None/' "$MUT/response-json.sh"
+if cmp -s "$ROOT/tests/lib/response-json.sh" "$MUT/response-json.sh"; then
+  fail "mutation: exact true predicate was not changed"
+fi
 set +e
-bash -c 'source "$1"; response_json_ok "$2"' _ "$MUT/response-json.sh" "$SSE_FALSE"
+bash -c 'source "$1"; response_json_ok "$2"' _ "$MUT/response-json.sh" "$BARE_FALSE"
 MUT_RC=$?
 set -e
-if [[ "$MUT_RC" -ne 0 ]]; then
+if [[ "$MUT_RC" -eq 0 ]]; then
   pass "mutation: weakening exact true check turns red"
 else
-  fail "mutation: weakened parser accepted ok:false"
+  fail "mutation: weakened parser still rejected bare ok:false"
 fi
 
 echo "RESULT: $PASS passed, $FAIL failed"

--- a/tests/test292-e2e-ok-assertions/run.sh
+++ b/tests/test292-e2e-ok-assertions/run.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=/src
+source "$ROOT/tests/lib/safe-rm.sh"
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "PASS: $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL: $*" >&2; }
+
+DIRECT_TRUE='{"ok":true,"message_id":"m1"}'
+DIRECT_FALSE='{"ok":false,"error":"alias_not_found"}'
+SSE_TRUE='data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":true,\"message_id\":\"m2\"}"}]}}'
+SSE_FALSE='data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":false,\"error\":\"permission_denied\"}"}]}}'
+PLAIN_MCP_TRUE='{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":true}"}]}}'
+RPC_ERROR='data: {"jsonrpc":"2.0","id":2,"error":{"code":-32602,"message":"Invalid arguments"}}'
+
+if printf '%s\n' "$SSE_FALSE" | grep -q 'ok'; then
+  echo "WITNESSED_RED: legacy grep accepts an inner ok:false MCP response"
+else
+  fail "legacy witnessed-red fixture did not exercise the old assertion"
+fi
+
+WEAK_COUNT=$(python3 - "$ROOT/tests/docker-e2e.sh" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+print(sum(bool(re.search(r"grep -q ['\"]ok['\"]", line)) for line in text.splitlines()))
+PY
+)
+echo "weak_assertions=$WEAK_COUNT"
+
+if [[ ! -f "$ROOT/tests/lib/response-json.sh" ]]; then
+  fail "structured response parser is missing"
+  fail "docker-e2e still has $WEAK_COUNT weak grep-ok assertions"
+  echo "RESULT: $PASS passed, $FAIL failed"
+  echo "source_commit=${TEST292_SOURCE_COMMIT}"
+  exit 1
+fi
+source "$ROOT/tests/lib/response-json.sh"
+
+expect_ok() {
+  local name=$1 payload=$2
+  if response_json_ok "$payload"; then pass "$name"; else fail "$name"; fi
+}
+
+expect_not_ok() {
+  local name=$1 payload=$2
+  if response_json_ok "$payload"; then fail "$name"; else pass "$name"; fi
+}
+
+expect_ok "direct REST ok:true" "$DIRECT_TRUE"
+expect_not_ok "direct REST ok:false" "$DIRECT_FALSE"
+expect_ok "SSE-wrapped MCP inner ok:true" "$SSE_TRUE"
+expect_not_ok "SSE-wrapped MCP inner ok:false" "$SSE_FALSE"
+expect_ok "plain JSON-RPC MCP inner ok:true" "$PLAIN_MCP_TRUE"
+expect_not_ok "JSON-RPC error is not success" "$RPC_ERROR"
+expect_not_ok "malformed response fails closed" 'not-json ok'
+expect_not_ok "empty response fails closed" ''
+
+if [[ "$WEAK_COUNT" == "0" ]]; then
+  pass "docker-e2e has no weak grep-ok assertions"
+else
+  fail "docker-e2e still has $WEAK_COUNT weak grep-ok assertions"
+fi
+
+ROBUST_CALLS=$(grep -c 'response_json_ok "\$' "$ROOT/tests/docker-e2e.sh" || true)
+if [[ "$ROBUST_CALLS" == "16" ]]; then
+  pass "all 16 legacy success assertions use the structured parser"
+else
+  fail "expected 16 structured response assertions, got $ROBUST_CALLS"
+fi
+
+MUT=$(mktemp -d /tmp/test292-mut.XXXXXX)
+trap 'safe_rm_rf "$MUT"' EXIT
+cp "$ROOT/tests/lib/response-json.sh" "$MUT/response-json.sh"
+sed -i 's/value is True/value is not None/' "$MUT/response-json.sh"
+set +e
+bash -c 'source "$1"; response_json_ok "$2"' _ "$MUT/response-json.sh" "$SSE_FALSE"
+MUT_RC=$?
+set -e
+if [[ "$MUT_RC" -ne 0 ]]; then
+  pass "mutation: weakening exact true check turns red"
+else
+  fail "mutation: weakened parser accepted ok:false"
+fi
+
+echo "RESULT: $PASS passed, $FAIL failed"
+echo "source_commit=${TEST292_SOURCE_COMMIT}"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What changed

- replace 16 substring-based `grep -q 'ok'` assertions in `tests/docker-e2e.sh`
- add a structured, fail-closed parser for direct JSON and MCP JSON-RPC/SSE responses
- add a dedicated Docker suite and witnessed-red mutation evidence

## Why

`ok:false` contains the substring `ok`, so the old checks reported failed Hub responses as successful. This is #292 Layer 3 only: it makes the existing E2E report honest and does not change production behavior.

## Validation

- exact-source `anet-test292:dev`: 11 passed, 0 failed
- mutation weakening exact `true` to non-null: rc=1
- exact-source full `/app/test-all.sh`: 160 passed, 60 failed
- Base E2E changed from the report-only baseline 88/47 to 82/53, exposing exactly six prior false-greens
- source commit: `976378c324ddf6fbfd9ac4e7d80013912c9fc2fb`
- report-only head: `d3e44f53ca721b61bc980b5538b1835100c8cabb`

The newly exposed failures remain follow-up work under #292; this PR intentionally does not reclassify or repair them.

Refs #292
