### PR TITLE
test(e2e): repair issue 292 agent registration layer

### DIFF
--- a/docs/tests/report-test292-e2e-agent-registration.txt
+++ b/docs/tests/report-test292-e2e-agent-registration.txt
@@ -1,0 +1,80 @@
+# test292 Layer 2 — real E2E agent registration
+
+Date: 2026-08-10
+Base: 4fb7e9473fe62957672f74bccfc1f9b3ece0c788
+Source under test: 0c0863bbd50d159d3d6764c694a8973a242d4d7a
+Scope: tests/docker-e2e.sh, tests/lib/e2e-agent-bootstrap.sh, and the
+tests/test292-e2e-agent-registration suite. No production source changed.
+
+## Witnessed red
+
+The red source was 6932e66aa18334b3af6a76ce3a0a6541cc6cdaf2.
+Its exact Docker run exited 1 after the real Hub/auth setup with:
+
+    FAIL: e2e agent bootstrap helper is missing
+    FAIL: docker-e2e cannot select the network and pre-create a token-bound agent
+
+Red log SHA256:
+2d7e93897564280fc95cd9dfddbf34449615e419eee4bf464854c8ce7359114c
+
+## Exact-source targeted run
+
+Command:
+
+    sg docker -c 'docker run --rm anet-test292-l2:dev'
+
+Image ID:
+sha256:56230c37c7871ea75d22121d108aefb68798b0ebc5fc2eb68db4955993dace31
+
+Embedded environment:
+
+    TEST292_L2_SOURCE_COMMIT=0c0863bbd50d159d3d6764c694a8973a242d4d7a
+
+Result: PASS, 11 passed / 0 failed.
+
+The image was restamped as a small derivative of the fully built
+50805e267449f68070b172bfc23a87117c475342 image because host disk pressure had
+evicted BuildKit's intermediate dependency cache. Between 50805e26 and the
+source under test, only the three test/helper files copied into the derivative
+changed; product binaries were unchanged. The derivative copied those exact
+0c0863bb files and embedded the full source SHA above.
+
+Green log SHA256:
+8195387c2620c45385db5f30535c851ab627f9ef9a58f989794bc858903c2d7c
+
+Verified behavior:
+
+- a real Hub registers a real user and two networks;
+- the public CLI selects the target network and creates the fixture node;
+- the generated ntok is verified against Hub's authoritative `/api/networks`
+  response, rather than a nonexistent local `network_id` snapshot;
+- a real `agent-node` registers under the exact alias;
+- an alias-targeted `send_task` is routable;
+- deleting network selection, deleting node creation, or weakening exact alias
+  equality each turns red;
+- concurrency waits are PID-scoped and cannot wait forever on the long-lived
+  Hub or agent.
+
+## Full Base E2E re-bucket
+
+Command:
+
+    sg docker -c 'docker run --rm --entrypoint bash anet-test292-l2:dev /app/test.sh'
+
+Result: expected nonzero, 97 passed / 39 failed. The suite completed normally;
+it did not hang on the real agent. Aggregate log SHA256:
+74e4816ab5fdfcc4cf6720f9f98a2e6e0335f4ca750d5351a5ec17090ea80ab0
+
+Layer 2 is now demonstrably green: exact registration and alias-targeted task
+delivery pass. This does not make the legacy aggregate green. The remaining
+failures are retained for later layers, notably:
+
+- the self-upgrade assertion expects a removed legacy message even though the
+  current CLI's detached auto-upgrade behavior changed;
+- rename-by-node-id fails, cascading into the Telegram `.env`, permission, and
+  config assertions that target the missing renamed node;
+- several legacy health, auth, task-lifecycle, and network assertions no longer
+  match current response or scoping contracts.
+
+No production database, Hub, node, npm package, or global installation was
+modified by this test.

--- a/tests/docker-e2e.sh
+++ b/tests/docker-e2e.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 source /app/lib/response-json.sh
+source /app/lib/e2e-agent-bootstrap.sh
 # Don't use set -e — we handle errors via pass()/fail()
 PASS=0
 FAIL=0
@@ -63,6 +64,7 @@ fi
 # #63: also `anet login` so subsequent `anet node create / delete / channel add`
 # CLI commands (not just curl) work under V3 auth.
 anet login --hub http://127.0.0.1:9200 --username e2e-bootstrap --password bootstrap-pass-123 > /dev/null 2>&1 || true
+e2e_select_network "$NETWORK_ID" || { echo "FATAL: could not select bootstrap network"; exit 1; }
 echo ""
 
 # ── MCP helper ── (#266 A1 refactor: hoisted to top so all callers go through
@@ -149,14 +151,24 @@ echo ""
 
 # 8. agent-node register to CommHub
 echo "8. Testing agent-node CommHub registration..."
-timeout 8 agent-node --alias e2e-agent --runtime codex-sdk 2>&1 &
-sleep 5
-curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9200/api/status | python3 -c "
-import sys,json
-data=json.load(sys.stdin)
-found = any(s['alias']=='e2e-agent' for s in data['sessions'])
-print('found' if found else 'not_found')
-" 2>/dev/null | grep -q "found" && pass "agent registered" || fail "agent not registered"
+e2e_create_agent e2e-agent codex-sdk gpt-5.4 "$NETWORK_ID" || { echo "FATAL: could not create token-bound e2e-agent"; exit 1; }
+E2E_AGENT_CONFIG="$(pwd)/.anet/nodes/e2e-agent/config.json"
+agent-node --config "$E2E_AGENT_CONFIG" --alias e2e-agent --runtime codex-sdk > /tmp/e2e-agent.log 2>&1 &
+E2E_AGENT_PID=$!
+# The suite contains legacy bare `wait` calls for short-lived concurrency
+# workers. Keep this long-lived fixture out of that job table, then stop it
+# explicitly at the end of the suite.
+disown "$E2E_AGENT_PID" 2>/dev/null || true
+E2E_AGENT_REGISTERED=0
+for _i in $(seq 1 40); do
+  E2E_STATUS=$(curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9200/api/status 2>/dev/null || true)
+  if printf '%s' "$E2E_STATUS" | e2e_status_has_alias e2e-agent; then
+    E2E_AGENT_REGISTERED=1
+    break
+  fi
+  sleep 0.25
+done
+[ "$E2E_AGENT_REGISTERED" = "1" ] && pass "agent registered" || { cat /tmp/e2e-agent.log; fail "agent not registered"; }
 echo ""
 
 # 9. send_task via MCP
@@ -858,6 +870,8 @@ echo "$BAD" | grep -q '"ok":false' && pass "invalid key rejected" || fail "bad k
 echo ""
 
 # Summary
+kill "${E2E_AGENT_PID:-}" 2>/dev/null || true
+wait "${E2E_AGENT_PID:-}" 2>/dev/null || true
 echo ""
 echo "========================================="
 echo "  Results: $PASS passed, $FAIL failed"

--- a/tests/docker-e2e.sh
+++ b/tests/docker-e2e.sh
@@ -155,10 +155,6 @@ e2e_create_agent e2e-agent codex-sdk gpt-5.4 "$NETWORK_ID" || { echo "FATAL: cou
 E2E_AGENT_CONFIG="$(pwd)/.anet/nodes/e2e-agent/config.json"
 agent-node --config "$E2E_AGENT_CONFIG" --alias e2e-agent --runtime codex-sdk > /tmp/e2e-agent.log 2>&1 &
 E2E_AGENT_PID=$!
-# The suite contains legacy bare `wait` calls for short-lived concurrency
-# workers. Keep this long-lived fixture out of that job table, then stop it
-# explicitly at the end of the suite.
-disown "$E2E_AGENT_PID" 2>/dev/null || true
 E2E_AGENT_REGISTERED=0
 for _i in $(seq 1 40); do
   E2E_STATUS=$(curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9200/api/status 2>/dev/null || true)
@@ -357,10 +353,12 @@ echo ""
 # 23.5 Concurrent registration
 echo "23.5 Testing concurrent operations..."
 # Register 5 agents simultaneously
+CONCURRENT_PIDS=()
 for i in $(seq 1 5); do
   mcp_call "report_status" "{\"resume_id\":\"concurrent-$i\",\"alias\":\"conc-$i\",\"status\":\"idle\",\"server\":\"test\"}" > /dev/null &
+  CONCURRENT_PIDS+=("$!")
 done
-wait
+for pid in "${CONCURRENT_PIDS[@]}"; do wait "$pid"; done
 sleep 1
 CONC_COUNT=$(curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9200/api/status 2>/dev/null | python3 -c "
 import sys,json
@@ -371,10 +369,12 @@ print(count)
 [ "$CONC_COUNT" = "5" ] && pass "5 concurrent registrations" || fail "concurrent: only $CONC_COUNT/5"
 
 # Concurrent send_task to same agent
+CONCURRENT_PIDS=()
 for i in $(seq 1 3); do
   mcp_call "send_task" "{\"alias\":\"conc-1\",\"task\":\"concurrent task $i\",\"from_session\":\"tester\"}" > /dev/null &
+  CONCURRENT_PIDS+=("$!")
 done
-wait
+for pid in "${CONCURRENT_PIDS[@]}"; do wait "$pid"; done
 sleep 1
 CONC_INBOX=$(mcp_call "get_inbox" '{"alias":"conc-1","limit":10}')
 CONC_MSG_COUNT=$(echo "$CONC_INBOX" | python3 -c "

--- a/tests/lib/e2e-agent-bootstrap.sh
+++ b/tests/lib/e2e-agent-bootstrap.sh
@@ -21,18 +21,38 @@ e2e_create_agent() {
 
   anet node create "$alias" --runtime "$runtime" --model "$model" >/dev/null || return 1
   [[ -f "$config_path" ]] || return 1
-  python3 - "$config_path" "$network_id" <<'PY'
+  e2e_config_token_bound_to_network "$config_path" "$network_id"
+}
+
+# Node configs intentionally do not persist network_id: the ntok_ binding in
+# Hub is authoritative. Ask Hub with that token and require exactly the
+# expected single network instead of trusting a local snapshot field.
+e2e_config_token_bound_to_network() {
+  local config_path=${1:?config path is required}
+  local expected_network=${2:?network_id is required}
+  local hub token networks
+
+  hub=$(jq -r '.hub // empty' "$config_path") || return 1
+  token=$(jq -r '.token // empty' "$config_path") || return 1
+  [[ $hub == http://* || $hub == https://* ]] || return 1
+  [[ $token == ntok_* ]] || return 1
+  networks=$(curl -fsS "$hub/api/networks" -H "Authorization: Bearer $token") || return 1
+
+  python3 - "$config_path" "$expected_network" "$networks" <<'PY'
 import json
 import sys
 
 config = json.load(open(sys.argv[1], encoding="utf-8"))
 expected_network = sys.argv[2]
+document = json.loads(sys.argv[3])
+networks = document.get("networks", [])
 valid = (
-    config.get("network_id") == expected_network
-    and isinstance(config.get("node_id"), str)
+    isinstance(config.get("node_id"), str)
     and config["node_id"].startswith("n_")
     and isinstance(config.get("token"), str)
     and config["token"].startswith("ntok_")
+    and len(networks) == 1
+    and networks[0].get("network_id") == expected_network
 )
 raise SystemExit(0 if valid else 1)
 PY

--- a/tests/lib/e2e-agent-bootstrap.sh
+++ b/tests/lib/e2e-agent-bootstrap.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Select the same network that the Base E2E MCP helper injects into writes.
+# Login alone leaves legacy/default selection state in place; node creation
+# must never infer a different network from that stale state.
+e2e_select_network() {
+  local network_id=${1:?network_id is required}
+  anet network use "$network_id" >/dev/null || return 1
+  true
+}
+
+# Create the fixture through the public CLI so its config carries the same
+# stable node_id + ntok_ binding as a real node. Hand-written or alias-only
+# configs bypass the identity contract that the E2E suite is meant to test.
+e2e_create_agent() {
+  local alias=${1:?alias is required}
+  local runtime=${2:?runtime is required}
+  local model=${3:?model is required}
+  local network_id=${4:?network_id is required}
+  local config_path="$(pwd)/.anet/nodes/$alias/config.json"
+
+  anet node create "$alias" --runtime "$runtime" --model "$model" >/dev/null || return 1
+  [[ -f "$config_path" ]] || return 1
+  python3 - "$config_path" "$network_id" <<'PY'
+import json
+import sys
+
+config = json.load(open(sys.argv[1], encoding="utf-8"))
+expected_network = sys.argv[2]
+valid = (
+    config.get("network_id") == expected_network
+    and isinstance(config.get("node_id"), str)
+    and config["node_id"].startswith("n_")
+    and isinstance(config.get("token"), str)
+    and config["token"].startswith("ntok_")
+)
+raise SystemExit(0 if valid else 1)
+PY
+}
+
+# Consume one /api/status document and succeed only for the exact alias.
+# Printing `found`/`not_found` and grepping `found` recreated the same class of
+# false-green fixed in Layer 3, because `not_found` contains the substring.
+e2e_status_has_alias() {
+  local alias=${1:?alias is required}
+  python3 -c '
+import json
+import sys
+
+alias = sys.argv[1]
+document = json.load(sys.stdin)
+sessions = document.get("sessions", [])
+raise SystemExit(0 if any(s.get("alias") == alias for s in sessions) else 1)
+' "$alias"
+}

--- a/tests/test292-e2e-agent-registration/Dockerfile
+++ b/tests/test292-e2e-agent-registration/Dockerfile
@@ -1,8 +1,5 @@
 FROM oven/bun:1.3.14
 
-ARG TEST292_L2_SOURCE_COMMIT=unknown
-ENV TEST292_L2_SOURCE_COMMIT=${TEST292_L2_SOURCE_COMMIT}
-
 RUN apt-get update && apt-get install -y curl jq python3 make g++ && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
@@ -17,6 +14,9 @@ RUN cd /app/server && bun install
 COPY agent-node/ /app/agent-node/
 RUN cd /app/agent-node && npm install && npm run build && npm link && \
     npm install @openai/codex-sdk 2>/dev/null || true
+
+ARG TEST292_L2_SOURCE_COMMIT=unknown
+ENV TEST292_L2_SOURCE_COMMIT=${TEST292_L2_SOURCE_COMMIT}
 
 COPY tests/docker-e2e.sh /app/test.sh
 COPY tests/lib/ /app/lib/

--- a/tests/test292-e2e-agent-registration/Dockerfile
+++ b/tests/test292-e2e-agent-registration/Dockerfile
@@ -1,0 +1,26 @@
+FROM oven/bun:1.3.14
+
+ARG TEST292_L2_SOURCE_COMMIT=unknown
+ENV TEST292_L2_SOURCE_COMMIT=${TEST292_L2_SOURCE_COMMIT}
+
+RUN apt-get update && apt-get install -y curl jq python3 make g++ && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY agent-network/ /app/agent-network/
+RUN cd /app/agent-network && npm install && npm run build && npm install -g .
+
+COPY server/ /app/server/
+RUN cd /app/server && bun install
+
+COPY agent-node/ /app/agent-node/
+RUN cd /app/agent-node && npm install && npm run build && npm link && \
+    npm install @openai/codex-sdk 2>/dev/null || true
+
+COPY tests/docker-e2e.sh /app/test.sh
+COPY tests/lib/ /app/lib/
+COPY tests/test292-e2e-agent-registration/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+ENTRYPOINT ["bash", "/app/run.sh"]

--- a/tests/test292-e2e-agent-registration/run.sh
+++ b/tests/test292-e2e-agent-registration/run.sh
@@ -80,13 +80,11 @@ e2e_select_network "$NETWORK_ID"
 e2e_create_agent e2e-agent codex-sdk gpt-5.4 "$NETWORK_ID"
 CFG=$WORK/project/.anet/nodes/e2e-agent/config.json
 
-if jq -e --arg network "$NETWORK_ID" \
-  '.network_id == $network and (.token | startswith("ntok_")) and (.node_id | startswith("n_"))' \
-  "$CFG" >/dev/null; then
-  pass "single point: generated config is token-bound to selected network"
+if e2e_config_token_bound_to_network "$CFG" "$NETWORK_ID"; then
+  pass "single point: generated ntok is bound by Hub to selected network"
 else
-  jq '{network_id,node_id,token:(.token|if type=="string" then (.[0:5]+"…") else . end)}' "$CFG" >&2 || true
-  fail "single point: generated config is not token-bound to selected network"
+  jq '{node_id,token:(.token|if type=="string" then (.[0:5]+"…") else . end)}' "$CFG" >&2 || true
+  fail "single point: generated token is not Hub-bound to selected network"
   exit 1
 fi
 
@@ -138,10 +136,11 @@ set +e
 MUT1_RC=$?
 set -e
 MUT1_CFG=$WORK/project/.anet/nodes/mut-no-select/config.json
-if [[ $MUT1_RC -ne 0 ]] || ! jq -e --arg network "$NETWORK_ID" '.network_id == $network' "$MUT1_CFG" >/dev/null 2>&1; then
+if [[ $MUT1_RC -ne 0 ]] && \
+   e2e_config_token_bound_to_network "$MUT1_CFG" "$WRONG_NETWORK_ID"; then
   pass "mutation: deleting network selection turns red"
 else
-  fail "mutation: missing network selection still produced a target-bound config"
+  fail "mutation: missing network selection was not proven bound to the wrong network"
 fi
 
 # Mutation 2: deleting the official node creation must fail before agent start.

--- a/tests/test292-e2e-agent-registration/run.sh
+++ b/tests/test292-e2e-agent-registration/run.sh
@@ -189,6 +189,12 @@ else
   fail "aggregate wiring: one or more Layer 2 gates are not wired"
 fi
 
+if grep -Eq '^[[:space:]]*wait[[:space:]]*$' /app/test.sh; then
+  fail "aggregate wiring: bare wait can block on the long-lived Hub or agent"
+else
+  pass "aggregate wiring: concurrency waits are PID-scoped"
+fi
+
 echo "RESULT: $PASS passed, $FAIL failed"
 echo "source_commit=$TEST292_L2_SOURCE_COMMIT"
 [[ $FAIL -eq 0 ]]

--- a/tests/test292-e2e-agent-registration/run.sh
+++ b/tests/test292-e2e-agent-registration/run.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+BASE=http://127.0.0.1:9200
+WORK=/tmp/test292-layer2
+HELPER=/app/lib/e2e-agent-bootstrap.sh
+NODE_LOG=$WORK/e2e-agent.log
+SERVER_LOG=$WORK/server.log
+
+pass() { PASS=$((PASS + 1)); echo "PASS: $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL: $*" >&2; }
+
+cleanup() {
+  kill "${AGENT_PID:-}" 2>/dev/null || true
+  wait "${AGENT_PID:-}" 2>/dev/null || true
+  kill "${SERVER_PID:-}" 2>/dev/null || true
+  wait "${SERVER_PID:-}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+if [[ ! -f "$HELPER" ]]; then
+  fail "e2e agent bootstrap helper is missing"
+  fail "docker-e2e cannot select the network and pre-create a token-bound agent"
+  echo "RESULT: $PASS passed, $FAIL failed"
+  echo "source_commit=$TEST292_L2_SOURCE_COMMIT"
+  exit 1
+fi
+
+source "$HELPER"
+source /app/lib/response-json.sh
+
+mkdir -p "$WORK/home" "$WORK/project"
+export HOME=$WORK/home
+cd "$WORK/project"
+
+COMMHUB_DB_PATH=$WORK/commhub.db bun run /app/server/src/index.ts >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+for _ in $(seq 1 30); do
+  curl -fsS "$BASE/health" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+if curl -fsS "$BASE/health" >/dev/null 2>&1; then
+  pass "environment: real Hub is healthy"
+else
+  cat "$SERVER_LOG" >&2
+  fail "environment: Hub did not become healthy"
+  exit 1
+fi
+
+REG=$(curl -fsS -X POST "$BASE/api/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"layer2-owner","password":"layer2-pass-123"}')
+TOKEN=$(printf '%s' "$REG" | jq -r '.token // empty')
+if [[ $TOKEN == utok_* ]]; then
+  pass "auth: bootstrap user token issued"
+else
+  fail "auth: bootstrap user token missing"
+  exit 1
+fi
+
+NET=$(curl -fsS -X POST "$BASE/api/networks" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"layer2-target","description":"test292 target"}')
+NETWORK_ID=$(printf '%s' "$NET" | jq -r '.network_id // empty')
+WRONG=$(curl -fsS -X POST "$BASE/api/networks" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"layer2-wrong","description":"mutation control"}')
+WRONG_NETWORK_ID=$(printf '%s' "$WRONG" | jq -r '.network_id // empty')
+if [[ -n $NETWORK_ID && -n $WRONG_NETWORK_ID && $NETWORK_ID != "$WRONG_NETWORK_ID" ]]; then
+  pass "auth: two isolated networks created"
+else
+  fail "auth: network setup failed"
+  exit 1
+fi
+
+anet login --hub "$BASE" --username layer2-owner --password layer2-pass-123 >/dev/null
+e2e_select_network "$NETWORK_ID"
+e2e_create_agent e2e-agent codex-sdk gpt-5.4 "$NETWORK_ID"
+CFG=$WORK/project/.anet/nodes/e2e-agent/config.json
+
+if jq -e --arg network "$NETWORK_ID" \
+  '.network_id == $network and (.token | startswith("ntok_")) and (.node_id | startswith("n_"))' \
+  "$CFG" >/dev/null; then
+  pass "single point: generated config is token-bound to selected network"
+else
+  jq '{network_id,node_id,token:(.token|if type=="string" then (.[0:5]+"…") else . end)}' "$CFG" >&2 || true
+  fail "single point: generated config is not token-bound to selected network"
+  exit 1
+fi
+
+timeout 25 agent-node --config "$CFG" --alias e2e-agent --runtime codex-sdk >"$NODE_LOG" 2>&1 &
+AGENT_PID=$!
+REGISTERED=0
+for _ in $(seq 1 40); do
+  STATUS=$(curl -fsS "$BASE/api/status" -H "Authorization: Bearer $TOKEN" 2>/dev/null || true)
+  if printf '%s' "$STATUS" | e2e_status_has_alias e2e-agent; then
+    REGISTERED=1
+    break
+  fi
+  sleep 0.25
+done
+if [[ $REGISTERED == 1 ]]; then
+  pass "complete flow: agent registered under the exact alias"
+else
+  cat "$NODE_LOG" >&2
+  fail "complete flow: agent did not register"
+  exit 1
+fi
+
+MCP_INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test292","version":"1"}}}'
+curl -fsS -X POST "$BASE/mcp" -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d "$MCP_INIT" >/dev/null
+SEND=$(curl -fsS -X POST "$BASE/mcp" -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"send_task\",\"arguments\":{\"alias\":\"e2e-agent\",\"task\":\"layer2 delivery\",\"network_id\":\"$NETWORK_ID\"}}}")
+if response_json_ok "$SEND"; then
+  pass "complete flow: alias-targeted send_task is routable"
+else
+  printf '%s\n' "$SEND" >&2
+  fail "complete flow: send_task was rejected"
+fi
+
+# Mutation 1: deleting the explicit network selection must create the node in
+# the deliberately selected wrong network, never silently pass.
+MUT1=$WORK/helper-no-select.sh
+cp "$HELPER" "$MUT1"
+sed -i '/anet network use "\$network_id"/d' "$MUT1"
+anet network use "$WRONG_NETWORK_ID" >/dev/null
+set +e
+(
+  source "$MUT1"
+  e2e_select_network "$NETWORK_ID"
+  e2e_create_agent mut-no-select codex-sdk gpt-5.4 "$NETWORK_ID"
+) >/dev/null 2>&1
+MUT1_RC=$?
+set -e
+MUT1_CFG=$WORK/project/.anet/nodes/mut-no-select/config.json
+if [[ $MUT1_RC -ne 0 ]] || ! jq -e --arg network "$NETWORK_ID" '.network_id == $network' "$MUT1_CFG" >/dev/null 2>&1; then
+  pass "mutation: deleting network selection turns red"
+else
+  fail "mutation: missing network selection still produced a target-bound config"
+fi
+
+# Mutation 2: deleting the official node creation must fail before agent start.
+MUT2=$WORK/helper-no-create.sh
+cp "$HELPER" "$MUT2"
+sed -i '/anet node create "\$alias"/d' "$MUT2"
+anet network use "$NETWORK_ID" >/dev/null
+set +e
+(
+  source "$MUT2"
+  e2e_create_agent mut-no-create codex-sdk gpt-5.4 "$NETWORK_ID"
+) >/dev/null 2>&1
+MUT2_RC=$?
+set -e
+if [[ $MUT2_RC -ne 0 && ! -f $WORK/project/.anet/nodes/mut-no-create/config.json ]]; then
+  pass "mutation: deleting token-bound node creation turns red"
+else
+  fail "mutation: missing node creation did not fail closed"
+fi
+
+# Mutation 3: weakening exact alias equality must accept the wrong session and
+# therefore be caught by this fixture.
+MUT3=$WORK/helper-weak-alias.sh
+cp "$HELPER" "$MUT3"
+sed -i 's/s.get("alias") == alias/s.get("alias") is not None/' "$MUT3"
+if cmp -s "$HELPER" "$MUT3"; then
+  fail "mutation: alias predicate anchor did not match"
+else
+  set +e
+  printf '%s' '{"sessions":[{"alias":"not-e2e-agent"}]}' | \
+    bash -c 'source "$1"; e2e_status_has_alias e2e-agent' _ "$MUT3"
+  MUT3_RC=$?
+  set -e
+  if [[ $MUT3_RC -eq 0 ]]; then
+    pass "mutation: weakening exact alias check turns red"
+  else
+    fail "mutation: weakened alias checker did not exercise the fixture"
+  fi
+fi
+
+if grep -Fq 'e2e_select_network "$NETWORK_ID"' /app/test.sh && \
+   grep -Fq 'e2e_create_agent e2e-agent' /app/test.sh && \
+   grep -Fq 'e2e_status_has_alias e2e-agent' /app/test.sh; then
+  pass "aggregate wiring: docker-e2e uses all three Layer 2 gates"
+else
+  fail "aggregate wiring: one or more Layer 2 gates are not wired"
+fi
+
+echo "RESULT: $PASS passed, $FAIL failed"
+echo "source_commit=$TEST292_L2_SOURCE_COMMIT"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

- select the intended writable network before creating the Base E2E node
- create a real token-bound fixture through the public CLI and verify its authoritative Hub binding
- require exact alias registration and scope concurrency waits to their worker PIDs

## Evidence

- witnessed red source: `6932e66a`
- tested source: `0c0863bbd50d159d3d6764c694a8973a242d4d7a`
- report-only head: `4ceb99289f7af77c75f51bdb97ef3bd6dc54641b`
- targeted Docker: 11 passed / 0 failed, three mutations turn red
- full Base E2E: completes at 97 passed / 39 failed; remaining failures are honestly re-bucketed in the report

This is Layer 2 of #292, not a claim that the whole legacy aggregate is green. No production source, deployment, or package publication.