### PR TITLE
test(e2e): align Base transport contracts (#292)

### DIFF
--- a/docs/tests/report-test292-e2e-contract-drift-main.txt
+++ b/docs/tests/report-test292-e2e-contract-drift-main.txt
@@ -1,0 +1,79 @@
+# test292 transport-contract drift — standalone main candidate
+
+Date: 2026-08-10
+Base: `4ebffd3832427608e83b79f900839fdae3dba3c2`
+Source under test: `d30f180cd316c6dccb9587b0654841a433c9b73e`
+Scope: test assertions, strict response parsers, and Docker harness only. No
+production source or deployed runtime changed.
+
+## Witnessed red
+
+The earlier exact red run at
+`21d1520c60a453193a43a459c2469e628fcca5a4` used the same real-Hub contract
+probe and finished 2 passed / 10 failed. It proved that the aggregate still
+expected obsolete transport behavior while the real Hub already enforced:
+
+- anonymous health exposes numeric `sse_connections` but no `sse_sessions`;
+- `/ws/tmux/:session` is removed and returns 404;
+- MCP results/errors are SSE-framed JSON-RPC with tool payloads inside
+  `result.content[].text`;
+- the legacy master token remains REST-compatible but MCP rejects it with
+  HTTP 401 and the exact deprecation error.
+
+The standalone branch reproduces the same red-to-green commit sequence on the
+new main base rather than stacking another PR on the already-merged #665/#666
+branches.
+
+## Exact-source Docker evidence
+
+Canonical clean build:
+
+    sg docker -c 'docker build --build-arg TEST292_CONTRACT_SOURCE_COMMIT=d30f180cd316c6dccb9587b0654841a433c9b73e -t anet-test292-contract:dev -f tests/test292-e2e-contract-drift/Dockerfile .'
+
+Because the host had only about 3.4 GB free, this run used the committed
+low-disk derivative Dockerfile. Its base was the already exact, real-Hub
+`anet-test292-identity:dev` image; it replaced only this candidate's test
+scripts and embedded the source SHA. The canonical Dockerfile remains the
+fresh-checkout path for independent review.
+
+Image ID:
+`sha256:e9962767e6a50748a4be3361c4c716303bb6d28f92ad1b5e4bd6d6605c6b304a`
+
+Embedded environment:
+
+    TEST292_CONTRACT_SOURCE_COMMIT=d30f180cd316c6dccb9587b0654841a433c9b73e
+
+Result: **12 passed / 0 failed**.
+
+## Verified behavior
+
+- upgrade probing is explicitly `--no-auto-self --dry-run`;
+- both anonymous health assertions require aggregate counts and reject session
+  identity disclosure;
+- the removed tmux WebSocket route is pinned to 404;
+- legacy master-token MCP use is pinned to HTTP 401 plus the exact error;
+- MCP initialize requires a structured JSON-RPC result;
+- ghost reply requires the exact `reply_task_not_found` tool error through all
+  SSE/JSON/content wrappers;
+- absent results and wrong error codes remain rejected.
+
+## Load-bearing mutations
+
+- broadening the result predicate to accept a response without `result` turns
+  the focused suite red;
+- broadening the error predicate to accept any error code turns it red;
+- both mutations first assert their source anchor changed, so a no-op patch
+  cannot be reported as witnessed red.
+
+## Provenance
+
+Relative to base, the candidate changes exactly five functional test files:
+
+- `tests/docker-e2e.sh`
+- `tests/lib/response-json.sh`
+- `tests/test292-e2e-contract-drift/Dockerfile`
+- `tests/test292-e2e-contract-drift/Dockerfile.derivative`
+- `tests/test292-e2e-contract-drift/run.sh`
+
+This report is a report-only child of the tested source and does not relabel a
+different tree as the source under test.

--- a/tests/docker-e2e.sh
+++ b/tests/docker-e2e.sh
@@ -99,8 +99,8 @@ echo ""
 
 # 2.1 anet upgrade should not self-remove
 echo "2.1 Testing anet upgrade safety..."
-UPGRADE_OUTPUT=$(anet upgrade 2>&1 || true)
-echo "$UPGRADE_OUTPUT" | grep -q "Automatic self-upgrade is disabled" && pass "upgrade skips in-process self-update" || fail "upgrade self-update guard missing"
+UPGRADE_OUTPUT=$(anet upgrade --no-auto-self --dry-run 2>&1 || true)
+echo "$UPGRADE_OUTPUT" | grep -q -- "--dry-run: no install actions performed" && pass "upgrade dry-run performs no install actions" || fail "upgrade dry-run guard missing"
 anet -v 2>&1 | grep -q "anet v" && pass "anet still available after upgrade" || fail "anet missing after upgrade"
 echo ""
 
@@ -313,7 +313,7 @@ echo ""
 # 20. send_reply to non-existent task (graceful)
 echo "20. Testing reply to non-existent task..."
 GHOST_REPLY=$(mcp_call "send_reply" '{"alias":"e2e-agent","text":"ghost reply","in_reply_to":"non-existent-id","from_session":"tester"}')
-echo "$GHOST_REPLY" | jq -e '.ok == false and .error == "reply_task_not_found"' >/dev/null \
+response_json_error_is "$GHOST_REPLY" "reply_task_not_found" \
   && pass "reply to non-existent task returns structured error" || fail "ghost reply contract broken"
 echo ""
 
@@ -327,7 +327,9 @@ echo ""
 echo "22. Testing health endpoint..."
 HEALTH=$(curl -s http://127.0.0.1:9200/health 2>/dev/null)
 echo "$HEALTH" | grep -q '"ok":true' && pass "health ok" || fail "health broken"
-echo "$HEALTH" | grep -q '"sse_sessions"' && pass "health has sse_sessions" || fail "health missing sse_sessions"
+echo "$HEALTH" | jq -e '(.sse_connections | type == "number") and (has("sse_sessions") | not)' >/dev/null \
+  && pass "anonymous health has aggregate SSE count without session identities" \
+  || fail "anonymous health SSE redaction contract broken"
 echo ""
 
 # 22.05 stats API
@@ -607,7 +609,7 @@ AUTH_MCP=$(curl -s -X POST http://127.0.0.1:9201/mcp \
   -H "Accept: application/json, text/event-stream" \
   -H "Authorization: Bearer test-secret-token" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}')
-echo "$AUTH_MCP" | grep -q 'serverInfo\|capabilities' && pass "MCP with auth token works" || fail "MCP auth broken"
+response_json_has_result "$AUTH_MCP" && pass "MCP with auth token works" || fail "MCP auth broken"
 
 # 24g. MCP without token → 401
 AUTH_MCP_NO=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://127.0.0.1:9201/mcp \
@@ -624,9 +626,9 @@ AUTH_SSE_NO=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9201/event
 AUTH_SSE_OK=$(timeout 2 curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer test-secret-token" http://127.0.0.1:9201/events/test-agent 2>/dev/null || echo "200")
 [ "$AUTH_SSE_OK" = "200" ] && pass "SSE with token → 200" || pass "SSE with token (timeout ok: $AUTH_SSE_OK)"
 
-# 24j. WebSocket tmux without token → 401
+# 24j. Removed WebSocket tmux route stays unavailable (404, not a live unauthenticated surface)
 AUTH_WS_NO=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9201/ws/tmux/test-session 2>/dev/null)
-[ "$AUTH_WS_NO" = "401" ] && pass "WebSocket tmux without token → 401" || fail "WebSocket tmux should require auth (got $AUTH_WS_NO)"
+[ "$AUTH_WS_NO" = "404" ] && pass "removed WebSocket tmux route → 404" || fail "removed WebSocket tmux route should be 404 (got $AUTH_WS_NO)"
 
 kill $AUTH_PID 2>/dev/null || true
 echo ""

--- a/tests/docker-e2e.sh
+++ b/tests/docker-e2e.sh
@@ -603,13 +603,19 @@ AUTH_QS=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:9201/api/stat
 AUTH_HEALTH=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9201/health 2>/dev/null)
 [ "$AUTH_HEALTH" = "200" ] && pass "health endpoint no auth needed" || fail "health should not require auth (got $AUTH_HEALTH)"
 
-# 24f. MCP with token
-AUTH_MCP=$(curl -s -X POST http://127.0.0.1:9201/mcp \
+# 24f. Legacy master token remains REST-compatible during migration, but MCP
+# rejects it fail-closed. Agents must authenticate with utok_/ntok_ instead.
+AUTH_MCP=$(curl -s -w $'\n%{http_code}' -X POST http://127.0.0.1:9201/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -H "Authorization: Bearer test-secret-token" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}')
-response_json_has_result "$AUTH_MCP" && pass "MCP with auth token works" || fail "MCP auth broken"
+AUTH_MCP_STATUS=${AUTH_MCP##*$'\n'}
+AUTH_MCP_BODY=${AUTH_MCP%$'\n'*}
+[ "$AUTH_MCP_STATUS" = "401" ] && \
+  response_json_error_is "$AUTH_MCP_BODY" "master-token auth is deprecated; use admin utok_" \
+  && pass "legacy master token rejected by MCP" \
+  || fail "legacy master token MCP rejection contract broken"
 
 # 24g. MCP without token → 401
 AUTH_MCP_NO=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://127.0.0.1:9201/mcp \
@@ -838,9 +844,11 @@ echo ""
 
 # 28.5 SSE + Communication reliability
 echo "28.5 Testing communication reliability..."
-# Verify SSE sessions in health endpoint
+# Verify SSE telemetry without leaking session identities.
 HEALTH2=$(curl -s http://127.0.0.1:9200/health 2>/dev/null)
-echo "$HEALTH2" | grep -q '"sse_sessions"' && pass "SSE sessions tracked" || fail "no SSE tracking"
+echo "$HEALTH2" | jq -e '(.sse_connections | type == "number") and (has("sse_sessions") | not)' >/dev/null \
+  && pass "SSE aggregate count tracked without session identities" \
+  || fail "SSE aggregate health contract broken"
 # Verify heartbeat (agent registered earlier should have updated_at)
 STATUS2=$(curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9200/api/status 2>/dev/null)
 echo "$STATUS2" | python3 -c "

--- a/tests/lib/response-json.sh
+++ b/tests/lib/response-json.sh
@@ -75,3 +75,91 @@ for candidate in candidates:
 raise SystemExit(0 if seen_true and not seen_failure else 1)
 '
 }
+
+# Return success only for a JSON-RPC response carrying an explicit `result`
+# and no top-level error. Both plain JSON and MCP's SSE `data:` framing are
+# accepted; substring matches are intentionally not evidence.
+response_json_has_result() {
+  local payload=${1-}
+  printf '%s' "$payload" | python3 -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+candidates = []
+for line in raw.splitlines():
+    stripped = line.strip()
+    if stripped.startswith("data:"):
+        stripped = stripped[5:].strip()
+    if not stripped or stripped == "[DONE]":
+        continue
+    try:
+        candidates.append(json.loads(stripped))
+    except Exception:
+        pass
+if not candidates:
+    try:
+        candidates.append(json.loads(raw))
+    except Exception:
+        raise SystemExit(1)
+
+raise SystemExit(0 if any(
+    isinstance(value, dict)
+    and "result" in value
+    and value.get("error") is None
+    for value in candidates
+) else 1)
+'
+}
+
+# Match an exact application error code through JSON-RPC/SSE wrappers. MCP
+# tool payloads may be JSON strings inside `result.content[].text`; recurse
+# only through structured values and parseable JSON strings, never substrings.
+response_json_error_is() {
+  local payload=${1-}
+  local expected=${2-}
+  printf '%s' "$payload" | python3 -c '
+import json
+import sys
+
+expected = sys.argv[1]
+raw = sys.stdin.read().strip()
+candidates = []
+for line in raw.splitlines():
+    stripped = line.strip()
+    if stripped.startswith("data:"):
+        stripped = stripped[5:].strip()
+    if not stripped or stripped == "[DONE]":
+        continue
+    try:
+        candidates.append(json.loads(stripped))
+    except Exception:
+        pass
+if not candidates:
+    try:
+        candidates.append(json.loads(raw))
+    except Exception:
+        raise SystemExit(1)
+
+def contains_exact_error(value, depth=0):
+    if depth > 6:
+        return False
+    if isinstance(value, str):
+        try:
+            return contains_exact_error(json.loads(value), depth + 1)
+        except Exception:
+            return False
+    if isinstance(value, list):
+        return any(contains_exact_error(item, depth + 1) for item in value)
+    if not isinstance(value, dict):
+        return False
+    if value.get("error") == expected:
+        return True
+    return any(
+        key in value and contains_exact_error(value[key], depth + 1)
+        for key in ("result", "content", "text")
+    )
+
+raise SystemExit(0 if any(contains_exact_error(value) for value in candidates) else 1)
+' "$expected"
+}

--- a/tests/test292-e2e-contract-drift/Dockerfile
+++ b/tests/test292-e2e-contract-drift/Dockerfile
@@ -1,0 +1,18 @@
+FROM oven/bun:1.3.14
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl jq python3 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo
+COPY server/ /repo/server/
+RUN cd /repo/server && bun install --frozen-lockfile
+
+COPY tests/docker-e2e.sh /repo/tests/docker-e2e.sh
+COPY tests/lib/response-json.sh /repo/tests/lib/response-json.sh
+COPY tests/test292-e2e-contract-drift/run.sh /repo/run.sh
+RUN chmod +x /repo/run.sh
+
+ARG TEST292_CONTRACT_SOURCE_COMMIT
+ENV TEST292_CONTRACT_SOURCE_COMMIT=$TEST292_CONTRACT_SOURCE_COMMIT
+
+ENTRYPOINT ["/repo/run.sh"]

--- a/tests/test292-e2e-contract-drift/Dockerfile.derivative
+++ b/tests/test292-e2e-contract-drift/Dockerfile.derivative
@@ -1,0 +1,13 @@
+ARG TEST292_CONTRACT_BASE_IMAGE=anet-test292-identity:dev
+FROM ${TEST292_CONTRACT_BASE_IMAGE}
+
+RUN mkdir -p /repo/tests/lib && ln -s /app/server /repo/server
+COPY tests/docker-e2e.sh /repo/tests/docker-e2e.sh
+COPY tests/lib/response-json.sh /repo/tests/lib/response-json.sh
+COPY tests/test292-e2e-contract-drift/run.sh /repo/run.sh
+RUN chmod +x /repo/run.sh
+
+ARG TEST292_CONTRACT_SOURCE_COMMIT=unknown
+ENV TEST292_CONTRACT_SOURCE_COMMIT=${TEST292_CONTRACT_SOURCE_COMMIT}
+
+ENTRYPOINT ["/repo/run.sh"]

--- a/tests/test292-e2e-contract-drift/run.sh
+++ b/tests/test292-e2e-contract-drift/run.sh
@@ -104,10 +104,15 @@ strict_helper_check() {
   local helper=$1
   (
     source "$helper"
-    ! response_json_has_result 'event: message
-data: {"jsonrpc":"2.0","id":1}'
-    ! response_json_error_is 'event: message
-data: {"error":"permission_denied","jsonrpc":"2.0","id":2}' reply_task_not_found
+    if response_json_has_result 'event: message
+data: {"jsonrpc":"2.0","id":1}'; then
+      return 1
+    fi
+    if response_json_error_is 'event: message
+data: {"error":"permission_denied","jsonrpc":"2.0","id":2}' reply_task_not_found; then
+      return 1
+    fi
+    return 0
   )
 }
 

--- a/tests/test292-e2e-contract-drift/run.sh
+++ b/tests/test292-e2e-contract-drift/run.sh
@@ -31,6 +31,14 @@ grep -Fq 'response_json_has_result "$AUTH_MCP"' "$SCRIPT" \
   && pass "wiring: MCP initialize uses a structured result predicate" \
   || fail "wiring: MCP initialize still relies on response text tokens"
 
+grep -Fq 'has("sse_sessions") | not' "$SCRIPT" \
+  && pass "wiring: anonymous health assertion preserves SSE identity redaction" \
+  || fail "wiring: aggregate still expects anonymous SSE session identities"
+
+grep -Fq '[ "$AUTH_WS_NO" = "404" ]' "$SCRIPT" \
+  && pass "wiring: removed tmux WebSocket route expects 404" \
+  || fail "wiring: aggregate still treats the removed route as live"
+
 COMMHUB_DB_PATH=$WORK/commhub.db bun run /repo/server/src/index.ts >$WORK-server.log 2>&1 &
 SERVER_PID=$!
 for _ in $(seq 1 30); do
@@ -90,6 +98,46 @@ if declare -F response_json_error_is >/dev/null && response_json_error_is "$GHOS
 else
   printf '%s\n' "$GHOST" >&2
   fail "real Hub: exact ghost-reply error was not recognized"
+fi
+
+strict_helper_check() {
+  local helper=$1
+  (
+    source "$helper"
+    ! response_json_has_result 'event: message
+data: {"jsonrpc":"2.0","id":1}'
+    ! response_json_error_is 'event: message
+data: {"error":"permission_denied","jsonrpc":"2.0","id":2}' reply_task_not_found
+  )
+}
+
+if declare -F response_json_has_result >/dev/null && declare -F response_json_error_is >/dev/null && \
+   strict_helper_check /repo/tests/lib/response-json.sh; then
+  pass "negative controls: absent result and wrong error stay rejected"
+else
+  fail "negative controls: structured predicates are missing or fail open"
+fi
+
+RESULT_MUTANT=$WORK-result-mutant.sh
+cp /repo/tests/lib/response-json.sh "$RESULT_MUTANT"
+sed -i 's/and "result" in value/and True/' "$RESULT_MUTANT"
+if cmp -s /repo/tests/lib/response-json.sh "$RESULT_MUTANT"; then
+  fail "mutation: result predicate anchor did not match"
+elif strict_helper_check "$RESULT_MUTANT"; then
+  fail "mutation: accepting a response without result stayed green"
+else
+  pass "mutation: accepting a response without result turns red"
+fi
+
+ERROR_MUTANT=$WORK-error-mutant.sh
+cp /repo/tests/lib/response-json.sh "$ERROR_MUTANT"
+sed -i 's/value.get("error") == expected/value.get("error") is not None/' "$ERROR_MUTANT"
+if cmp -s /repo/tests/lib/response-json.sh "$ERROR_MUTANT"; then
+  fail "mutation: exact error predicate anchor did not match"
+elif strict_helper_check "$ERROR_MUTANT"; then
+  fail "mutation: accepting any error code stayed green"
+else
+  pass "mutation: accepting any error code turns red"
 fi
 
 echo "RESULT: $PASS passed, $FAIL failed"

--- a/tests/test292-e2e-contract-drift/run.sh
+++ b/tests/test292-e2e-contract-drift/run.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+source /repo/tests/lib/response-json.sh
+
+PASS=0
+FAIL=0
+BASE=http://127.0.0.1:9200
+WORK=/tmp/test292-contract
+
+pass() { PASS=$((PASS + 1)); echo "PASS: $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL: $*" >&2; }
+
+cleanup() {
+  kill "${SERVER_PID:-}" 2>/dev/null || true
+  wait "${SERVER_PID:-}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+SCRIPT=/repo/tests/docker-e2e.sh
+
+grep -Fq 'anet upgrade --no-auto-self --dry-run' "$SCRIPT" \
+  && pass "wiring: upgrade probe is explicitly side-effect free" \
+  || fail "wiring: upgrade probe may perform a real self-upgrade"
+
+grep -Fq 'response_json_error_is "$GHOST_REPLY" "reply_task_not_found"' "$SCRIPT" \
+  && pass "wiring: ghost reply uses structured SSE/JSON error parsing" \
+  || fail "wiring: ghost reply still parses the raw transport as plain JSON"
+
+grep -Fq 'response_json_has_result "$AUTH_MCP"' "$SCRIPT" \
+  && pass "wiring: MCP initialize uses a structured result predicate" \
+  || fail "wiring: MCP initialize still relies on response text tokens"
+
+COMMHUB_DB_PATH=$WORK/commhub.db bun run /repo/server/src/index.ts >$WORK-server.log 2>&1 &
+SERVER_PID=$!
+for _ in $(seq 1 30); do
+  curl -fsS "$BASE/health" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+
+HEALTH=$(curl -fsS "$BASE/health")
+if printf '%s' "$HEALTH" | jq -e '.ok == true and (.sse_connections | type == "number") and (has("sse_sessions") | not)' >/dev/null; then
+  pass "real Hub: anonymous health exposes count but not session identities"
+else
+  fail "real Hub: anonymous health contract changed"
+fi
+
+WS_STATUS=$(curl -sS -o /dev/null -w '%{http_code}' "$BASE/ws/tmux/nonexistent")
+if [[ "$WS_STATUS" == 404 ]]; then
+  pass "real Hub: removed tmux WebSocket route is a safe 404"
+else
+  fail "real Hub: removed tmux WebSocket route returned $WS_STATUS"
+fi
+
+REGISTER=$(curl -fsS -X POST "$BASE/api/auth/register" -H 'Content-Type: application/json' \
+  -d '{"username":"contract-owner","password":"contract-pass-123"}')
+TOKEN=$(printf '%s' "$REGISTER" | jq -r .token)
+NETWORK=$(curl -fsS -X POST "$BASE/api/networks" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"contract-network"}' | jq -r .network_id)
+
+mcp_call() {
+  local name=$1 arguments=$2
+  curl -fsS -X POST "$BASE/mcp" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test292","version":"1"}}}' >/dev/null
+  curl -fsS -X POST "$BASE/mcp" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d "$(jq -cn --arg name "$name" --argjson arguments "$arguments" '{jsonrpc:"2.0",id:2,method:"tools/call",params:{name:$name,arguments:$arguments}}')"
+}
+
+INIT=$(curl -fsS -X POST "$BASE/mcp" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test292","version":"1"}}}')
+if declare -F response_json_has_result >/dev/null && response_json_has_result "$INIT"; then
+  pass "real Hub: structured predicate accepts MCP initialize result"
+else
+  fail "real Hub: no structured MCP result predicate"
+fi
+
+GHOST=$(mcp_call send_reply "$(jq -cn --arg network "$NETWORK" '{alias:"nobody",text:"ghost",in_reply_to:"missing-task",from_session:"contract-owner",network_id:$network}')")
+if declare -F response_json_error_is >/dev/null && response_json_error_is "$GHOST" reply_task_not_found; then
+  pass "real Hub: structured predicate recognizes exact ghost-reply error"
+else
+  printf '%s\n' "$GHOST" >&2
+  fail "real Hub: exact ghost-reply error was not recognized"
+fi
+
+echo "RESULT: $PASS passed, $FAIL failed"
+echo "source_commit=$TEST292_CONTRACT_SOURCE_COMMIT"
+[[ $FAIL -eq 0 ]]

--- a/tests/test292-e2e-contract-drift/run.sh
+++ b/tests/test292-e2e-contract-drift/run.sh
@@ -27,13 +27,14 @@ grep -Fq 'response_json_error_is "$GHOST_REPLY" "reply_task_not_found"' "$SCRIPT
   && pass "wiring: ghost reply uses structured SSE/JSON error parsing" \
   || fail "wiring: ghost reply still parses the raw transport as plain JSON"
 
-grep -Fq 'response_json_has_result "$AUTH_MCP"' "$SCRIPT" \
-  && pass "wiring: MCP initialize uses a structured result predicate" \
-  || fail "wiring: MCP initialize still relies on response text tokens"
+grep -Fq 'response_json_error_is "$AUTH_MCP_BODY" "master-token auth is deprecated; use admin utok_"' "$SCRIPT" \
+  && grep -Fq '[ "$AUTH_MCP_STATUS" = "401" ]' "$SCRIPT" \
+  && pass "wiring: legacy master token MCP rejection is exact" \
+  || fail "wiring: aggregate still treats the legacy master token as MCP auth"
 
-grep -Fq 'has("sse_sessions") | not' "$SCRIPT" \
-  && pass "wiring: anonymous health assertion preserves SSE identity redaction" \
-  || fail "wiring: aggregate still expects anonymous SSE session identities"
+[[ $(grep -Fc 'has("sse_sessions") | not' "$SCRIPT") -eq 2 ]] \
+  && pass "wiring: both anonymous health assertions preserve SSE identity redaction" \
+  || fail "wiring: one anonymous health assertion still expects session identities"
 
 grep -Fq '[ "$AUTH_WS_NO" = "404" ]' "$SCRIPT" \
   && pass "wiring: removed tmux WebSocket route expects 404" \


### PR DESCRIPTION
## What changed

- replace stale Base E2E transport assertions with strict SSE/JSON-RPC parsers
- pin both anonymous health checks to aggregate-only SSE telemetry
- pin removed tmux WebSocket route to 404
- pin legacy master-token MCP use to the real 401 deprecation contract
- add real-Hub focused Docker coverage and two load-bearing mutations

## Why

Issue #292's aggregate test mixed current product failures with assertions for transport behavior that no longer exists. That made valid Hub behavior look broken and hid the remaining fixture problems behind cascades.

This is a standalone branch from main after #665/#666, rather than a third stacked PR.

## Impact

Test-only. No production source, runtime, database, package publication, or deployment changes.

## Validation

- exact source: `d30f180cd316c6dccb9587b0654841a433c9b73e`
- report-only head: `5f945d4d7eab6a707ea9477fe13ad3936cbd3870`
- focused real-Hub Docker result: 12 passed / 0 failed
- mutation: accepting absent JSON-RPC result turns red
- mutation: accepting any tool error code turns red

The committed canonical Dockerfile supports a clean independent build. The author run used the committed low-disk derivative because the shared host was at 99% disk utilization; the report states that boundary explicitly.

Refs #292
