### PR TITLE
test(e2e): use token-bound agent fixtures (#292)

### DIFF
--- a/docs/tests/report-test292-e2e-identity-fixtures-main.txt
+++ b/docs/tests/report-test292-e2e-identity-fixtures-main.txt
@@ -1,0 +1,95 @@
+# test292 token-bound identity fixtures — standalone main candidate
+
+Date: 2026-08-10
+Base: `44cff974c66f0d7081d5712d8d2f92f6271a3bd7`
+Source under test: `4ec7db0102a6a7c58c35f4af188a7c13e9596155`
+Scope: Docker E2E fixtures, shared test helper, aggregate assertions, and
+test-only Dockerfiles. Production source was not changed.
+
+## Witnessed-red progression
+
+The same functional fixture sequence was executed before extraction to this
+standalone main branch:
+
+1. Exact source `fef3dc75e9ce2239d1de891e1281d92ff3403b2e`
+   failed after environment/auth with
+   `e2e_agent_config_path: command not found`. No authoritative token-bound
+   simulated-agent helper existed.
+2. After identity and transport closure, exact aggregate source
+   `ec0ead84cadecbf65cbe0ef7972266b7e0c4debd` reached 131/6. The remaining
+   failures exposed stale free-network quota, unknown target aliases, and the
+   intentionally removed `quickstart` command.
+3. After quota/quickstart correction, the aggregate reached 134/2; both
+   failures were `alias_not_found` behavior caused by dispatching to targets
+   that had never registered.
+4. Registering one Hub-authoritative token-bound target in each network
+   produced the final 136/0 aggregate.
+
+The standalone branch cherry-picks that add-only test sequence onto the main
+that already contains #667; it does not stack a PR on an unmerged branch.
+
+## Exact-source Docker evidence
+
+Canonical independent build:
+
+    sg docker -c 'docker build --build-arg TEST292_IDENTITY_SOURCE_COMMIT=4ec7db0102a6a7c58c35f4af188a7c13e9596155 -t anet-test292-identity:dev -f tests/test292-e2e-identity-fixtures/Dockerfile .'
+
+The author run used the committed low-disk derivative because the shared host
+had about 3.4 GB free. Its base was the prior exact identity image; only test
+scripts/helpers were replaced and the standalone source SHA embedded. The
+canonical Dockerfile remains the clean-checkout path for independent review.
+
+Image ID:
+`sha256:2e8938630aef1b4cf31911d10d324fe82d20c2f9d350c08b29ee8c16ebafe8c8`
+
+Embedded environment:
+
+    TEST292_IDENTITY_SOURCE_COMMIT=4ec7db0102a6a7c58c35f4af188a7c13e9596155
+
+Focused real-Hub result: **19 passed / 0 failed**.
+
+Full Base aggregate result: **136 passed / 0 failed**.
+
+The aggregate container installed `procps` at runtime because the historical
+aggregate invokes `ps`. This changed only the one-shot container, not the image
+or production.
+
+## Verified behavior
+
+- fixtures are created by the public CLI and carry a stable `node_id` plus a
+  Hub-issued, network-bound `ntok_`;
+- `report_status` overwrites caller identity with config-bound alias/node ID;
+- a user token cannot impersonate an agent;
+- node-token inbox read, acknowledgement, working status, and terminal reply
+  complete, with the exact node ID persisted in inventory;
+- concurrency, retry, cancel, reassign, expiration, offline, and full mock
+  lifecycle paths no longer perform agent identity writes with an owner token;
+- the free-user isolation test uses registration's default network plus one
+  created network, matching the real two-network free quota;
+- each isolation target is registered in its own network before dispatch, so
+  the test measures tenant isolation instead of `alias_not_found`;
+- positive task visibility and negative cross-network visibility both pass;
+- removed `quickstart` exits non-zero with migration guidance and creates no
+  agent state.
+
+## Load-bearing negative controls
+
+- deleting config-bound alias pinning exposes `alias_identity_mismatch`;
+- deleting stable node-ID injection loses authoritative inventory identity;
+- restoring the owner-token mock acknowledgement path turns the aggregate
+  wiring gate red;
+- the staged aggregate itself gives real behavior red/green evidence for quota,
+  removed-command, and missing-target assumptions.
+
+## Provenance and cleanup
+
+Relative to base, the tested source changes exactly five test files:
+
+- `tests/docker-e2e.sh`
+- `tests/lib/e2e-agent-bootstrap.sh`
+- `tests/test292-e2e-identity-fixtures/Dockerfile`
+- `tests/test292-e2e-identity-fixtures/Dockerfile.derivative`
+- `tests/test292-e2e-identity-fixtures/run.sh`
+
+No production process, database, global package, Hub, Dashboard, or deployed
+node was changed. The report commit is an add-only child of the tested source.

--- a/tests/docker-e2e.sh
+++ b/tests/docker-e2e.sh
@@ -829,10 +829,27 @@ NET_B_ID=$(echo "$NET_B" | python3 -c "import sys,json;print(json.loads(sys.stdi
 TOKEN="$NET_TOKEN"
 NETWORK_ID="$NET_A_ID"
 
+# Delivery now fails closed for unknown aliases. Register one authoritative
+# token-bound fixture in each network so this section tests tenant isolation,
+# not the unrelated alias_not_found guard.
+anet login --hub http://127.0.0.1:9200 --username net-test-user --password test123456 >/dev/null 2>&1
+e2e_select_network "$NET_A_ID" || fail "select net-alpha failed"
+e2e_create_agent alpha-agent codex-sdk gpt-5.4 "$NET_A_ID" >/dev/null \
+  || fail "alpha-agent fixture creation failed"
+e2e_agent_mcp_call alpha-agent report_status \
+  '{"resume_id":"isolation-alpha","status":"idle","server":"test"}' >/dev/null
+e2e_select_network "$NET_B_ID" || fail "select net-beta failed"
+e2e_create_agent beta-agent codex-sdk gpt-5.4 "$NET_B_ID" >/dev/null \
+  || fail "beta-agent fixture creation failed"
+e2e_agent_mcp_call beta-agent report_status \
+  '{"resume_id":"isolation-beta","status":"idle","server":"test"}' >/dev/null
+
 # Send task to each network
-mcp_call "send_task" "{\"alias\":\"alpha-agent\",\"task\":\"alpha task\",\"from_session\":\"tester\",\"network_id\":\"$NET_A_ID\"}" > /dev/null
-mcp_call "send_task" "{\"alias\":\"beta-agent\",\"task\":\"beta task\",\"from_session\":\"tester\",\"network_id\":\"$NET_B_ID\"}" > /dev/null
-pass "tasks sent to different networks"
+SEND_A=$(mcp_call "send_task" "{\"alias\":\"alpha-agent\",\"task\":\"alpha task\",\"from_session\":\"tester\",\"network_id\":\"$NET_A_ID\"}")
+SEND_B=$(mcp_call "send_task" "{\"alias\":\"beta-agent\",\"task\":\"beta task\",\"from_session\":\"tester\",\"network_id\":\"$NET_B_ID\"}")
+response_json_ok "$SEND_A" && response_json_ok "$SEND_B" \
+  && pass "tasks sent to different networks" \
+  || { printf 'alpha=%s\nbeta=%s\n' "$SEND_A" "$SEND_B" >&2; fail "cross-network fixture dispatch failed"; }
 
 # Query network A — should only see alpha task
 TASKS_A=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/tasks?network_id=$NET_A_ID" 2>/dev/null)

--- a/tests/docker-e2e.sh
+++ b/tests/docker-e2e.sh
@@ -222,13 +222,13 @@ echo ""
 
 # 12. V2: send_ack updates tasks table
 echo "12. Testing V2 send_ack..."
-ACK_RESP=$(mcp_call "send_ack" "{\"task_id\":\"$TASK_ID\",\"from_session\":\"e2e-agent\"}")
+ACK_RESP=$(e2e_agent_mcp_call e2e-agent send_ack "{\"task_id\":\"$TASK_ID\",\"from_session\":\"e2e-agent\"}")
 response_json_ok "$ACK_RESP" && pass "send_ack accepted" || { echo "$ACK_RESP"; fail "send_ack failed"; }
 echo ""
 
 # 13. V2: send_reply closes task lifecycle
 echo "13. Testing V2 send_reply..."
-REPLY_RESP=$(mcp_call "send_reply" "{\"alias\":\"v2-tester\",\"text\":\"task done\",\"in_reply_to\":\"$TASK_ID\",\"status\":\"replied\",\"from_session\":\"e2e-agent\"}")
+REPLY_RESP=$(e2e_agent_mcp_call e2e-agent send_reply "{\"alias\":\"v2-tester\",\"text\":\"task done\",\"in_reply_to\":\"$TASK_ID\",\"status\":\"replied\",\"from_session\":\"e2e-agent\"}")
 response_json_ok "$REPLY_RESP" && pass "send_reply accepted" || { echo "$REPLY_RESP"; fail "send_reply failed"; }
 echo ""
 
@@ -267,7 +267,7 @@ try:
   print(t.get('message_id',''))
 except: print('')
 " 2>/dev/null)
-FAIL_REPLY=$(mcp_call "send_reply" "{\"alias\":\"fail-tester\",\"text\":\"error occurred\",\"in_reply_to\":\"$FAIL_TID\",\"status\":\"failed\",\"from_session\":\"e2e-agent\"}")
+FAIL_REPLY=$(e2e_agent_mcp_call e2e-agent send_reply "{\"alias\":\"fail-tester\",\"text\":\"error occurred\",\"in_reply_to\":\"$FAIL_TID\",\"status\":\"failed\",\"from_session\":\"e2e-agent\"}")
 response_json_ok "$FAIL_REPLY" && pass "send_reply(failed) accepted" || fail "send_reply(failed) broken"
 # verify task status = failed
 sleep 1
@@ -277,10 +277,10 @@ echo ""
 
 # 17. high priority ordering
 echo "17. Testing priority ordering..."
-anet node create prio-agent --runtime codex-sdk 2>&1 >/dev/null
+e2e_create_agent prio-agent codex-sdk gpt-5.4 "$NETWORK_ID" >/dev/null || fail "prio-agent fixture creation failed"
 mcp_call "send_task" '{"alias":"prio-agent","task":"low prio","from_session":"tester","priority":"low"}' >/dev/null
 mcp_call "send_task" '{"alias":"prio-agent","task":"high prio","from_session":"tester","priority":"high"}' >/dev/null
-INBOX=$(mcp_call "get_inbox" '{"alias":"prio-agent","limit":5}')
+INBOX=$(e2e_agent_mcp_call prio-agent get_inbox '{"alias":"prio-agent","limit":5}')
 # high priority should come first
 FIRST=$(echo "$INBOX" | python3 -c "
 import sys,json
@@ -354,10 +354,17 @@ echo ""
 
 # 23.5 Concurrent registration
 echo "23.5 Testing concurrent operations..."
+# Identity-bearing operations must use one real ntok-bound fixture per agent.
+# Pre-create sequentially through the public CLI, then exercise only the
+# report_status calls concurrently so this remains a concurrency test rather
+# than a token-mint race.
+for i in $(seq 1 5); do
+  e2e_create_agent "conc-$i" codex-sdk gpt-5.4 "$NETWORK_ID" >/dev/null || fail "conc-$i fixture creation failed"
+done
 # Register 5 agents simultaneously
 CONCURRENT_PIDS=()
 for i in $(seq 1 5); do
-  mcp_call "report_status" "{\"resume_id\":\"concurrent-$i\",\"alias\":\"conc-$i\",\"status\":\"idle\",\"server\":\"test\"}" > /dev/null &
+  e2e_agent_mcp_call "conc-$i" "report_status" "{\"resume_id\":\"concurrent-$i\",\"status\":\"idle\",\"server\":\"test\"}" > /dev/null &
   CONCURRENT_PIDS+=("$!")
 done
 for pid in "${CONCURRENT_PIDS[@]}"; do wait "$pid"; done
@@ -378,7 +385,7 @@ for i in $(seq 1 3); do
 done
 for pid in "${CONCURRENT_PIDS[@]}"; do wait "$pid"; done
 sleep 1
-CONC_INBOX=$(mcp_call "get_inbox" '{"alias":"conc-1","limit":10}')
+CONC_INBOX=$(e2e_agent_mcp_call "conc-1" "get_inbox" '{"alias":"conc-1","limit":10}')
 CONC_MSG_COUNT=$(echo "$CONC_INBOX" | python3 -c "
 import sys,json
 raw=sys.stdin.read()
@@ -457,7 +464,7 @@ try:
 except: print('')
 " 2>/dev/null)
 # Fail it
-mcp_call "send_reply" "{\"alias\":\"tester\",\"text\":\"error\",\"in_reply_to\":\"$RETRY_TID\",\"status\":\"failed\",\"from_session\":\"conc-1\"}" > /dev/null
+e2e_agent_mcp_call "conc-1" "send_reply" "{\"alias\":\"tester\",\"text\":\"error\",\"in_reply_to\":\"$RETRY_TID\",\"status\":\"failed\",\"from_session\":\"conc-1\"}" > /dev/null
 sleep 1
 # Verify failed
 RETRY_C1=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/tasks?task_id=$RETRY_TID" 2>/dev/null)
@@ -506,8 +513,10 @@ echo ""
 
 # 23.66 Task reassign
 echo "23.66 Testing task reassign..."
-mcp_call "report_status" '{"resume_id":"reassign-src","alias":"agent-a","status":"idle","server":"test"}' > /dev/null
-mcp_call "report_status" '{"resume_id":"reassign-dst","alias":"agent-b","status":"idle","server":"test"}' > /dev/null
+e2e_create_agent agent-a codex-sdk gpt-5.4 "$NETWORK_ID" >/dev/null || fail "agent-a fixture creation failed"
+e2e_create_agent agent-b codex-sdk gpt-5.4 "$NETWORK_ID" >/dev/null || fail "agent-b fixture creation failed"
+e2e_agent_mcp_call agent-a report_status '{"resume_id":"reassign-src","status":"idle","server":"test"}' > /dev/null
+e2e_agent_mcp_call agent-b report_status '{"resume_id":"reassign-dst","status":"idle","server":"test"}' > /dev/null
 RA_SEND=$(mcp_call "send_task" '{"alias":"agent-a","task":"reassign me","from_session":"tester"}')
 RA_TID=$(echo "$RA_SEND" | python3 -c "
 import sys,json
@@ -554,7 +563,7 @@ echo "$EXP_C1" | grep -q '"delivered"' && pass "task initially delivered" || fai
 # Wait for expiration + trigger patrol manually via SQLite (can't wait 5 min in test)
 sleep 3
 # Manually run the expiration query (same as server patrol)
-mcp_call "report_status" '{"resume_id":"patrol-trigger","alias":"patrol","status":"idle"}' > /dev/null
+e2e_agent_mcp_call conc-1 report_status '{"resume_id":"concurrent-1","status":"idle","server":"test"}' > /dev/null
 # The patrol runs in get_all_status, let's call that
 mcp_call "get_all_status" '{}' > /dev/null
 # Check if task expired — patrol may not have run yet, so also do direct check
@@ -642,7 +651,8 @@ echo ""
 # 24k. notifyServerOffline verification
 echo "24k. Testing anet node stop offline effect..."
 # Register a fake agent on main server, then stop it
-mcp_call "report_status" '{"resume_id":"sim-stop-test","alias":"stop-verify","status":"idle","server":"test"}' > /dev/null
+e2e_create_agent stop-verify codex-sdk gpt-5.4 "$NETWORK_ID" >/dev/null || fail "stop-verify fixture creation failed"
+e2e_agent_mcp_call stop-verify report_status '{"resume_id":"sim-stop-test","status":"idle","server":"test"}' > /dev/null
 # Verify it's idle
 STOP_BEFORE=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/status" 2>/dev/null | python3 -c "
 import sys,json
@@ -652,7 +662,7 @@ print(s['status'] if s else 'not_found')
 " 2>/dev/null)
 [ "$STOP_BEFORE" = "idle" ] && pass "stop-verify starts as idle" || fail "stop-verify not idle ($STOP_BEFORE)"
 # Set it to offline
-mcp_call "report_status" '{"resume_id":"sim-stop-test","alias":"stop-verify","status":"offline"}' > /dev/null
+e2e_agent_mcp_call stop-verify report_status '{"resume_id":"sim-stop-test","status":"offline"}' > /dev/null
 # Verify it's now offline
 STOP_AFTER=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/api/status" 2>/dev/null | python3 -c "
 import sys,json
@@ -666,7 +676,8 @@ echo ""
 # 25. Full task lifecycle simulation (mock agent)
 echo "25. Simulating full agent lifecycle..."
 # Register a mock agent
-SIM_REG=$(mcp_call "report_status" '{"resume_id":"sim-mock-agent","alias":"mock-agent","status":"idle","server":"test","agent":"mock"}')
+e2e_create_agent mock-agent codex-sdk gpt-5.4 "$NETWORK_ID" >/dev/null || fail "mock-agent fixture creation failed"
+SIM_REG=$(e2e_agent_mcp_call mock-agent report_status '{"resume_id":"sim-mock-agent","status":"idle","server":"test","agent":"mock"}')
 response_json_ok "$SIM_REG" && pass "mock agent registered" || fail "mock agent registration failed"
 
 # Send task to mock agent
@@ -689,11 +700,11 @@ SIM_CHECK1=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/ap
 echo "$SIM_CHECK1" | grep -q '"delivered"' && pass "task status = delivered" || fail "expected delivered"
 
 # Mock agent: pull inbox
-SIM_INBOX=$(mcp_call "get_inbox" '{"alias":"mock-agent","limit":5}')
+SIM_INBOX=$(e2e_agent_mcp_call mock-agent get_inbox '{"alias":"mock-agent","limit":5}')
 echo "$SIM_INBOX" | grep -q 'compute 2+2' && pass "mock agent received task" || fail "mock agent inbox empty"
 
 # Mock agent: ack
-SIM_ACK=$(mcp_call "ack_inbox" "{\"alias\":\"mock-agent\",\"message_id\":\"$SIM_TID\"}")
+SIM_ACK=$(e2e_agent_mcp_call mock-agent ack_inbox "{\"alias\":\"mock-agent\",\"message_id\":\"$SIM_TID\"}")
 response_json_ok "$SIM_ACK" && pass "mock agent acked" || fail "ack failed"
 
 # Verify task = acked
@@ -701,7 +712,7 @@ SIM_CHECK2=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/ap
 echo "$SIM_CHECK2" | grep -q '"acked"' && pass "task status = acked" || fail "expected acked"
 
 # Mock agent: report working
-SIM_WORK=$(mcp_call "report_status" '{"resume_id":"sim-mock-agent","alias":"mock-agent","status":"working","task":"compute 2+2"}')
+SIM_WORK=$(e2e_agent_mcp_call mock-agent report_status '{"resume_id":"sim-mock-agent","status":"working","task":"compute 2+2"}')
 response_json_ok "$SIM_WORK" && pass "mock agent working" || fail "status update failed"
 
 # Verify task = running
@@ -710,7 +721,7 @@ SIM_CHECK3=$(curl -s -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:9200/ap
 echo "$SIM_CHECK3" | grep -q '"running"' && pass "task status = running" || fail "expected running"
 
 # Mock agent: send reply with result
-SIM_REPLY=$(mcp_call "send_reply" "{\"alias\":\"orchestrator\",\"text\":\"4\",\"in_reply_to\":\"$SIM_TID\",\"status\":\"replied\",\"from_session\":\"mock-agent\"}")
+SIM_REPLY=$(e2e_agent_mcp_call mock-agent send_reply "{\"alias\":\"orchestrator\",\"text\":\"4\",\"in_reply_to\":\"$SIM_TID\",\"status\":\"replied\",\"from_session\":\"mock-agent\"}")
 response_json_ok "$SIM_REPLY" && pass "mock agent replied" || fail "reply failed"
 
 # Verify task = replied with result
@@ -734,7 +745,7 @@ print('PASS' if ok else 'FAIL')
 " 2>/dev/null | grep -q 'PASS' && pass "all lifecycle timestamps set" || fail "missing timestamps"
 
 # Mock agent: back to idle
-mcp_call "report_status" '{"resume_id":"sim-mock-agent","alias":"mock-agent","status":"idle"}' > /dev/null
+e2e_agent_mcp_call mock-agent report_status '{"resume_id":"sim-mock-agent","status":"idle"}' > /dev/null
 pass "mock agent back to idle"
 
 # Verify task_events audit trail for mock agent task

--- a/tests/docker-e2e.sh
+++ b/tests/docker-e2e.sh
@@ -788,9 +788,10 @@ echo "$ME" | grep -q '"networks"' && pass "auth/me has networks" || fail "no net
 # Create network
 NET=$(curl -s -H "Authorization: Bearer $TOKEN" -X POST http://127.0.0.1:9200/api/networks \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
   -d '{"name":"test-network","description":"E2E test"}')
-echo "$NET" | grep -q '"ok":true' && pass "create network" || fail "create network failed"
+echo "$NET" | jq -e '.ok == true and (.network_id | type == "string")' >/dev/null \
+  && pass "create network" \
+  || { echo "V3 create network response: $NET" >&2; fail "create network failed"; }
 
 # List networks
 NETS=$(curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9200/api/networks)
@@ -812,16 +813,21 @@ REG_A=$(curl -s -H "Authorization: Bearer $TOKEN" -X POST http://127.0.0.1:9200/
 NET_TOKEN=$(echo "$REG_A" | python3 -c "import sys,json;print(json.loads(sys.stdin.read()).get('token',''))" 2>/dev/null)
 [ -n "$NET_TOKEN" ] && pass "user registered for network test" || fail "registration failed"
 
-# Create two networks
-NET_A=$(curl -s -H "Authorization: Bearer $TOKEN" -X POST http://127.0.0.1:9200/api/networks \
-  -H "Content-Type: application/json" -H "Authorization: Bearer $NET_TOKEN" \
-  -d '{"name":"net-alpha"}')
-NET_A_ID=$(echo "$NET_A" | python3 -c "import sys,json;print(json.loads(sys.stdin.read()).get('network_id',''))" 2>/dev/null)
-NET_B=$(curl -s -H "Authorization: Bearer $TOKEN" -X POST http://127.0.0.1:9200/api/networks \
+# Registration already creates the first network. A free user may own two
+# networks total, so use that authoritative default as alpha and create only
+# beta instead of incorrectly asking the fixture to exceed the free quota.
+NET_A_ID=$(echo "$REG_A" | python3 -c "import sys,json;print(json.loads(sys.stdin.read()).get('network_id',''))" 2>/dev/null)
+NET_B=$(curl -s -X POST http://127.0.0.1:9200/api/networks \
   -H "Content-Type: application/json" -H "Authorization: Bearer $NET_TOKEN" \
   -d '{"name":"net-beta"}')
 NET_B_ID=$(echo "$NET_B" | python3 -c "import sys,json;print(json.loads(sys.stdin.read()).get('network_id',''))" 2>/dev/null)
 [ -n "$NET_A_ID" ] && [ -n "$NET_B_ID" ] && pass "two networks created" || fail "network creation failed"
+
+# From here onward both task writes and reads must authenticate as the member
+# whose two networks are under test; keeping e2e-user's token here would test
+# permission denial, not isolation.
+TOKEN="$NET_TOKEN"
+NETWORK_ID="$NET_A_ID"
 
 # Send task to each network
 mcp_call "send_task" "{\"alias\":\"alpha-agent\",\"task\":\"alpha task\",\"from_session\":\"tester\",\"network_id\":\"$NET_A_ID\"}" > /dev/null
@@ -845,12 +851,17 @@ echo ""
 
 # 28. anet quickstart non-interactive
 echo "28. Testing anet quickstart..."
-QS_OUT=$(timeout 10 anet quickstart --username qs-user --password qs123456 --agent qs-bot --runtime codex-sdk 2>&1 || true)
-echo "$QS_OUT" | grep -q "登录成功\|Logged in" && pass "quickstart login" || fail "quickstart login failed"
-# Verify config saved
-grep -q "qs-user" /root/.anet/config.json 2>/dev/null && pass "quickstart saved user" || pass "quickstart config check"
-# Verify agent created
-[ -f .anet/nodes/qs-bot/config.json ] 2>/dev/null && pass "quickstart created agent" || pass "agent check (may use different cwd)"
+QS_OUT=$(timeout 10 anet quickstart --username qs-user --password qs123456 --agent qs-bot --runtime codex-sdk 2>&1)
+QS_RC=$?
+if [ "$QS_RC" -ne 0 ] && echo "$QS_OUT" | grep -q "quickstart.*已删除\|quickstart.*removed"; then
+  pass "removed quickstart fails with migration guidance"
+else
+  echo "$QS_OUT" >&2
+  fail "removed quickstart contract broken"
+fi
+[ ! -e .anet/nodes/qs-bot/config.json ] \
+  && pass "removed quickstart creates no agent" \
+  || fail "removed quickstart left agent state"
 echo ""
 
 # 28.5 SSE + Communication reliability

--- a/tests/lib/e2e-agent-bootstrap.sh
+++ b/tests/lib/e2e-agent-bootstrap.sh
@@ -24,6 +24,45 @@ e2e_create_agent() {
   e2e_config_token_bound_to_network "$config_path" "$network_id"
 }
 
+e2e_agent_config_path() {
+  local alias=${1:?alias is required}
+  printf '%s/.anet/nodes/%s/config.json\n' "$(pwd)" "$alias"
+}
+
+# Call an identity-bearing MCP tool as the fixture node itself. User tokens
+# may schedule/manage work, but they must never impersonate an arbitrary node
+# for report_status/get_inbox/ack/send_reply. The config produced by
+# e2e_create_agent is the single source of the stable node_id + ntok binding.
+e2e_agent_mcp_call() {
+  local alias=${1:?alias is required}
+  local tool=${2:?tool is required}
+  local args=${3:?arguments JSON is required}
+  local config_path hub token node_id
+
+  config_path=$(e2e_agent_config_path "$alias") || return 1
+  [[ -f "$config_path" ]] || return 1
+  hub=$(jq -r '.hub // empty' "$config_path") || return 1
+  token=$(jq -r '.token // empty' "$config_path") || return 1
+  node_id=$(jq -r '.node_id // empty' "$config_path") || return 1
+  [[ $hub == http://* || $hub == https://* ]] || return 1
+  [[ $token == ntok_* && $node_id == n_* ]] || return 1
+
+  if [[ $tool == report_status ]]; then
+    args=$(printf '%s' "$args" | jq -c --arg node_id "$node_id" --arg alias "$alias" \
+      '. + {node_id: $node_id, alias: $alias}') || return 1
+  fi
+
+  local initialize='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-fixture","version":"1"}}}'
+  timeout 5 curl -fsS -H "Authorization: Bearer $token" -X POST "$hub/mcp" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d "$initialize" >/dev/null || return 1
+  timeout 5 curl -fsS -H "Authorization: Bearer $token" -X POST "$hub/mcp" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}"
+}
+
 # Node configs intentionally do not persist network_id: the ntok_ binding in
 # Hub is authoritative. Ask Hub with that token and require exactly the
 # expected single network instead of trusting a local snapshot field.

--- a/tests/test292-e2e-identity-fixtures/Dockerfile
+++ b/tests/test292-e2e-identity-fixtures/Dockerfile
@@ -11,6 +11,10 @@ RUN cd /app/agent-network && npm install && npm run build && npm install -g .
 COPY server/ /app/server/
 RUN cd /app/server && bun install
 
+COPY agent-node/ /app/agent-node/
+RUN cd /app/agent-node && npm install && npm run build && npm link && \
+    npm install @openai/codex-sdk 2>/dev/null || true
+
 COPY tests/docker-e2e.sh /app/test.sh
 COPY tests/lib/ /app/lib/
 COPY tests/test292-e2e-identity-fixtures/run.sh /app/run.sh

--- a/tests/test292-e2e-identity-fixtures/Dockerfile
+++ b/tests/test292-e2e-identity-fixtures/Dockerfile
@@ -1,0 +1,22 @@
+FROM oven/bun:1.3.14
+
+RUN apt-get update && apt-get install -y curl jq python3 make g++ && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY agent-network/ /app/agent-network/
+RUN cd /app/agent-network && npm install && npm run build && npm install -g .
+
+COPY server/ /app/server/
+RUN cd /app/server && bun install
+
+COPY tests/docker-e2e.sh /app/test.sh
+COPY tests/lib/ /app/lib/
+COPY tests/test292-e2e-identity-fixtures/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+ARG TEST292_IDENTITY_SOURCE_COMMIT=unknown
+ENV TEST292_IDENTITY_SOURCE_COMMIT=${TEST292_IDENTITY_SOURCE_COMMIT}
+
+ENTRYPOINT ["bash", "/app/run.sh"]

--- a/tests/test292-e2e-identity-fixtures/Dockerfile.derivative
+++ b/tests/test292-e2e-identity-fixtures/Dockerfile.derivative
@@ -1,0 +1,12 @@
+ARG TEST292_IDENTITY_BASE_IMAGE=anet-test292-identity-base:ec0ead84
+FROM ${TEST292_IDENTITY_BASE_IMAGE}
+
+COPY tests/docker-e2e.sh /app/test.sh
+COPY tests/lib/ /app/lib/
+COPY tests/test292-e2e-identity-fixtures/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+ARG TEST292_IDENTITY_SOURCE_COMMIT=unknown
+ENV TEST292_IDENTITY_SOURCE_COMMIT=${TEST292_IDENTITY_SOURCE_COMMIT}
+
+ENTRYPOINT ["bash", "/app/run.sh"]

--- a/tests/test292-e2e-identity-fixtures/run.sh
+++ b/tests/test292-e2e-identity-fixtures/run.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+BASE=http://127.0.0.1:9200
+WORK=/tmp/test292-identity
+SERVER_LOG=$WORK/server.log
+
+pass() { PASS=$((PASS + 1)); echo "PASS: $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL: $*" >&2; }
+
+cleanup() {
+  kill "${SERVER_PID:-}" 2>/dev/null || true
+  wait "${SERVER_PID:-}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+source /app/lib/response-json.sh
+source /app/lib/e2e-agent-bootstrap.sh
+
+mkdir -p "$WORK/home" "$WORK/project"
+export HOME=$WORK/home
+cd "$WORK/project"
+
+COMMHUB_DB_PATH=$WORK/commhub.db bun run /app/server/src/index.ts >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+for _ in $(seq 1 30); do
+  curl -fsS "$BASE/health" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+curl -fsS "$BASE/health" >/dev/null
+pass "environment: real Hub is healthy"
+
+REGISTER=$(curl -fsS -X POST "$BASE/api/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"identity-owner","password":"identity-pass-123"}')
+OWNER_TOKEN=$(printf '%s' "$REGISTER" | jq -r '.token // empty')
+[[ $OWNER_TOKEN == utok_* ]]
+NETWORK=$(curl -fsS -X POST "$BASE/api/networks" \
+  -H "Authorization: Bearer $OWNER_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"identity-network"}')
+NETWORK_ID=$(printf '%s' "$NETWORK" | jq -r '.network_id // empty')
+[[ -n $NETWORK_ID ]]
+anet login --hub "$BASE" --username identity-owner --password identity-pass-123 >/dev/null
+e2e_select_network "$NETWORK_ID"
+pass "auth: owner selected one explicit network"
+
+e2e_create_agent sim-a codex-sdk gpt-5.4 "$NETWORK_ID"
+CONFIG=$(e2e_agent_config_path sim-a)
+NODE_ID=$(jq -r '.node_id' "$CONFIG")
+if e2e_config_token_bound_to_network "$CONFIG" "$NETWORK_ID"; then
+  pass "fixture: public CLI created stable node_id + Hub-bound ntok"
+else
+  fail "fixture: generated identity is not authoritative"
+fi
+
+REPORT=$(e2e_agent_mcp_call sim-a report_status \
+  '{"resume_id":"identity-sim-a","alias":"forged-alias","status":"idle","server":"test"}')
+if response_json_ok "$REPORT"; then
+  pass "identity: helper reports only its config-bound alias"
+else
+  printf '%s\n' "$REPORT" >&2
+  fail "identity: token-bound report_status failed"
+fi
+
+STATUS=$(curl -fsS "$BASE/api/status" -H "Authorization: Bearer $OWNER_TOKEN")
+printf '%s' "$STATUS" | e2e_status_has_alias sim-a \
+  && pass "identity: exact session alias registered" \
+  || fail "identity: exact session alias missing"
+if printf '%s' "$STATUS" | e2e_status_has_alias forged-alias; then
+  fail "identity: caller-supplied forged alias escaped helper"
+else
+  pass "identity: forged alias cannot escape config binding"
+fi
+
+NODES=$(curl -fsS "$BASE/api/nodes" -H "Authorization: Bearer $OWNER_TOKEN")
+if printf '%s' "$NODES" | jq -e --arg node_id "$NODE_ID" --arg alias sim-a \
+  '.nodes | any(.node_id == $node_id and .alias == $alias)' >/dev/null; then
+  pass "identity: inventory stores the exact stable node_id"
+else
+  fail "identity: inventory omitted or changed stable node_id"
+fi
+
+FORGED_USER=$(timeout 5 curl -fsS -X POST "$BASE/mcp" \
+  -H "Authorization: Bearer $OWNER_TOKEN" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"report_status","arguments":{"resume_id":"forged-user","alias":"user-forged","status":"idle"}}}')
+if response_json_error_is "$FORGED_USER" network_token_required; then
+  pass "security: user token cannot impersonate a fixture agent"
+else
+  printf '%s\n' "$FORGED_USER" >&2
+  fail "security: user-token report_status did not fail closed"
+fi
+
+SEND=$(timeout 5 curl -fsS -X POST "$BASE/mcp" \
+  -H "Authorization: Bearer $OWNER_TOKEN" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"send_task\",\"arguments\":{\"alias\":\"sim-a\",\"task\":\"identity lifecycle\",\"network_id\":\"$NETWORK_ID\"}}}")
+TASK_ID=$(printf '%s' "$SEND" | python3 -c '
+import json,sys
+raw=sys.stdin.read()
+for line in raw.splitlines():
+    if line.startswith("data: "): raw=line[6:]
+outer=json.loads(raw)
+inner=json.loads(outer["result"]["content"][0]["text"])
+print(inner.get("message_id", ""))
+')
+[[ -n $TASK_ID ]]
+INBOX=$(e2e_agent_mcp_call sim-a get_inbox '{"alias":"sim-a","limit":5}')
+printf '%s' "$INBOX" | grep -Fq 'identity lifecycle' \
+  && pass "lifecycle: ntok fixture reads its inbox" \
+  || fail "lifecycle: fixture inbox is empty"
+ACK=$(e2e_agent_mcp_call sim-a ack_inbox "{\"alias\":\"sim-a\",\"message_id\":\"$TASK_ID\"}")
+response_json_ok "$ACK" \
+  && pass "lifecycle: ntok fixture acknowledges its task" \
+  || fail "lifecycle: fixture ack failed"
+REPLY=$(e2e_agent_mcp_call sim-a send_reply \
+  "{\"alias\":\"identity-owner\",\"text\":\"done\",\"in_reply_to\":\"$TASK_ID\",\"status\":\"replied\",\"from_session\":\"sim-a\"}")
+response_json_ok "$REPLY" \
+  && pass "lifecycle: ntok fixture terminates its task" \
+  || fail "lifecycle: fixture reply failed"
+TASK=$(curl -fsS "$BASE/api/tasks?task_id=$TASK_ID" -H "Authorization: Bearer $OWNER_TOKEN")
+printf '%s' "$TASK" | jq -e '.tasks[0] | .status == "replied" and .result == "done"' >/dev/null \
+  && pass "lifecycle: terminal result persisted" \
+  || fail "lifecycle: terminal result mismatch"
+
+grep -Fq 'e2e_agent_mcp_call "conc-$i" "report_status"' /app/test.sh \
+  && grep -Fq 'e2e_agent_mcp_call mock-agent ack_inbox' /app/test.sh \
+  && grep -Fq 'e2e_agent_mcp_call stop-verify report_status' /app/test.sh \
+  && pass "aggregate: simulated identity paths use token-bound fixtures" \
+  || fail "aggregate: one or more identity paths still use the owner token"
+
+echo "RESULT: $PASS passed, $FAIL failed"
+echo "source_commit=${TEST292_IDENTITY_SOURCE_COMMIT:-unknown}"
+[[ $FAIL -eq 0 ]]

--- a/tests/test292-e2e-identity-fixtures/run.sh
+++ b/tests/test292-e2e-identity-fixtures/run.sh
@@ -125,11 +125,69 @@ printf '%s' "$TASK" | jq -e '.tasks[0] | .status == "replied" and .result == "do
   && pass "lifecycle: terminal result persisted" \
   || fail "lifecycle: terminal result mismatch"
 
+MUT_ALIAS=$WORK/helper-no-alias-pin.sh
+cp /app/lib/e2e-agent-bootstrap.sh "$MUT_ALIAS"
+sed -i 's/\. + {node_id: \$node_id, alias: \$alias}/. + {node_id: $node_id}/' "$MUT_ALIAS"
+if cmp -s /app/lib/e2e-agent-bootstrap.sh "$MUT_ALIAS"; then
+  fail "mutation: alias-pin anchor did not match"
+else
+  e2e_create_agent mut-alias codex-sdk gpt-5.4 "$NETWORK_ID"
+  set +e
+  MUT_ALIAS_RESULT=$(bash -c '
+    source "$1"
+    cd "$2"
+    e2e_agent_mcp_call mut-alias report_status \
+      "{\"resume_id\":\"mut-alias\",\"alias\":\"escaped-alias\",\"status\":\"idle\"}"
+  ' _ "$MUT_ALIAS" "$WORK/project")
+  MUT_ALIAS_RC=$?
+  set -e
+  if [[ $MUT_ALIAS_RC -eq 0 ]] && response_json_error_is "$MUT_ALIAS_RESULT" alias_identity_mismatch; then
+    pass "mutation: deleting config-bound alias pin turns red"
+  else
+    fail "mutation: missing alias pin did not expose identity mismatch"
+  fi
+fi
+
+MUT_NODE=$WORK/helper-no-node-id.sh
+cp /app/lib/e2e-agent-bootstrap.sh "$MUT_NODE"
+sed -i 's/\. + {node_id: \$node_id, alias: \$alias}/. + {alias: $alias}/' "$MUT_NODE"
+if cmp -s /app/lib/e2e-agent-bootstrap.sh "$MUT_NODE"; then
+  fail "mutation: node-id anchor did not match"
+else
+  e2e_create_agent mut-node codex-sdk gpt-5.4 "$NETWORK_ID"
+  MUT_NODE_ID=$(jq -r '.node_id' "$(e2e_agent_config_path mut-node)")
+  MUT_NODE_RESULT=$(bash -c '
+    source "$1"
+    cd "$2"
+    e2e_agent_mcp_call mut-node report_status \
+      "{\"resume_id\":\"mut-node\",\"status\":\"idle\"}"
+  ' _ "$MUT_NODE" "$WORK/project")
+  MUT_NODES=$(curl -fsS "$BASE/api/nodes" -H "Authorization: Bearer $OWNER_TOKEN")
+  if response_json_ok "$MUT_NODE_RESULT" && \
+     ! printf '%s' "$MUT_NODES" | jq -e --arg node_id "$MUT_NODE_ID" \
+       '.nodes | any(.node_id == $node_id)' >/dev/null; then
+    pass "mutation: deleting stable node_id injection turns red"
+  else
+    fail "mutation: missing node_id did not lose authoritative inventory"
+  fi
+fi
+
 grep -Fq 'e2e_agent_mcp_call "conc-$i" "report_status"' /app/test.sh \
   && grep -Fq 'e2e_agent_mcp_call mock-agent ack_inbox' /app/test.sh \
   && grep -Fq 'e2e_agent_mcp_call stop-verify report_status' /app/test.sh \
   && pass "aggregate: simulated identity paths use token-bound fixtures" \
   || fail "aggregate: one or more identity paths still use the owner token"
+
+MUT_AGGREGATE=$WORK/docker-e2e-owner-ack.sh
+cp /app/test.sh "$MUT_AGGREGATE"
+sed -i 's/e2e_agent_mcp_call mock-agent ack_inbox/mcp_call "ack_inbox"/' "$MUT_AGGREGATE"
+if cmp -s /app/test.sh "$MUT_AGGREGATE"; then
+  fail "mutation: aggregate ack anchor did not match"
+elif grep -Fq 'e2e_agent_mcp_call mock-agent ack_inbox' "$MUT_AGGREGATE"; then
+  fail "mutation: owner-token ack bypass escaped aggregate gate"
+else
+  pass "mutation: restoring owner-token identity write turns red"
+fi
 
 echo "RESULT: $PASS passed, $FAIL failed"
 echo "source_commit=${TEST292_IDENTITY_SOURCE_COMMIT:-unknown}"

--- a/tests/test292-e2e-identity-fixtures/run.sh
+++ b/tests/test292-e2e-identity-fixtures/run.sh
@@ -125,6 +125,44 @@ printf '%s' "$TASK" | jq -e '.tasks[0] | .status == "replied" and .result == "do
   && pass "lifecycle: terminal result persisted" \
   || fail "lifecycle: terminal result mismatch"
 
+QUOTA_REGISTER=$(curl -fsS -X POST "$BASE/api/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"quota-user","password":"quota-pass-123"}')
+QUOTA_TOKEN=$(printf '%s' "$QUOTA_REGISTER" | jq -r '.token // empty')
+QUOTA_DEFAULT=$(printf '%s' "$QUOTA_REGISTER" | jq -r '.network_id // empty')
+QUOTA_SECOND=$(curl -fsS -X POST "$BASE/api/networks" \
+  -H "Authorization: Bearer $QUOTA_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"quota-second"}')
+QUOTA_SECOND_ID=$(printf '%s' "$QUOTA_SECOND" | jq -r '.network_id // empty')
+QUOTA_THIRD=$(curl -sS -X POST "$BASE/api/networks" \
+  -H "Authorization: Bearer $QUOTA_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"quota-third"}')
+if [[ -n $QUOTA_DEFAULT && -n $QUOTA_SECOND_ID ]] && \
+   printf '%s' "$QUOTA_THIRD" | jq -e '.ok == false and (.error | contains("quota exceeded"))' >/dev/null; then
+  pass "contract: free-user isolation fixture uses default plus one created network"
+else
+  fail "contract: free-network quota fixture is not authoritative"
+fi
+
+set +e
+QUICKSTART_OUT=$(cd "$WORK/project" && anet quickstart --username removed-user \
+  --password removed-pass-123 --agent removed-agent --runtime codex-sdk 2>&1)
+QUICKSTART_RC=$?
+set -e
+if [[ $QUICKSTART_RC -ne 0 ]] && \
+   printf '%s' "$QUICKSTART_OUT" | grep -q 'quickstart.*已删除\|quickstart.*removed' && \
+   [[ ! -e $WORK/project/.anet/nodes/removed-agent/config.json ]]; then
+  pass "contract: removed quickstart fails with guidance and no agent state"
+else
+  fail "contract: removed quickstart behavior drifted"
+fi
+
+grep -Fq 'NET_A_ID=$(echo "$REG_A"' /app/test.sh \
+  && ! grep -Fq '"name":"net-alpha"' /app/test.sh \
+  && grep -Fq 'removed quickstart fails with migration guidance' /app/test.sh \
+  && pass "aggregate: V3 quota and removed-command contracts are wired" \
+  || fail "aggregate: stale V3 or quickstart contract remains"
+
 MUT_ALIAS=$WORK/helper-no-alias-pin.sh
 cp /app/lib/e2e-agent-bootstrap.sh "$MUT_ALIAS"
 sed -i 's/\. + {node_id: \$node_id, alias: \$alias}/. + {node_id: $node_id}/' "$MUT_ALIAS"

--- a/tests/test292-e2e-identity-fixtures/run.sh
+++ b/tests/test292-e2e-identity-fixtures/run.sh
@@ -159,9 +159,12 @@ fi
 
 grep -Fq 'NET_A_ID=$(echo "$REG_A"' /app/test.sh \
   && ! grep -Fq '"name":"net-alpha"' /app/test.sh \
+  && grep -Fq 'e2e_create_agent alpha-agent' /app/test.sh \
+  && grep -Fq 'e2e_create_agent beta-agent' /app/test.sh \
+  && grep -Fq 'response_json_ok "$SEND_A" && response_json_ok "$SEND_B"' /app/test.sh \
   && grep -Fq 'removed quickstart fails with migration guidance' /app/test.sh \
-  && pass "aggregate: V3 quota and removed-command contracts are wired" \
-  || fail "aggregate: stale V3 or quickstart contract remains"
+  && pass "aggregate: V3 quota, target identity, and removed-command contracts are wired" \
+  || fail "aggregate: stale V3 isolation or quickstart contract remains"
 
 MUT_ALIAS=$WORK/helper-no-alias-pin.sh
 cp /app/lib/e2e-agent-bootstrap.sh "$MUT_ALIAS"


### PR DESCRIPTION
## What changed

- create simulated agents through the public CLI with stable `node_id` and Hub-issued, network-bound `ntok_`
- route agent identity writes, inbox acknowledgement, status, and replies through those node tokens
- make concurrency/retry/cancel/reassign/expiration/offline/full-lifecycle fixtures authoritative
- align V3 isolation with the real free-network quota and register one target per network
- pin the intentionally removed `quickstart` command to non-zero guidance/no state
- add focused real-Hub coverage and load-bearing negative controls

## Why

Issue #292's Base aggregate used owner tokens to impersonate simulated agents and dispatched isolation tasks to aliases that did not exist. That caused large cascades and made the suite test authorization/alias failures instead of lifecycle and tenant isolation.

This is a standalone branch from main after #667; it does not stack on an unmerged PR.

## Impact

Test-only. No production source, runtime, database, package publication, or deployment changes.

## Validation

- exact source: `4ec7db0102a6a7c58c35f4af188a7c13e9596155`
- report-only head: `567c5d2605f497057da043d62ff6db88c55e26f8`
- focused real-Hub suite: 19 passed / 0 failed
- full Base aggregate: 136 passed / 0 failed
- alias-pin removal exposes `alias_identity_mismatch`
- node-ID injection removal loses authoritative inventory identity
- owner-token acknowledgement restoration turns the aggregate wiring gate red

The canonical Dockerfile remains available for a clean independent build. The author run used the committed low-disk derivative because the shared host was at 99% disk utilization; the report states that boundary explicitly.

Refs #292
