### PR TITLE
test(e2e): align residual fixtures with identity contracts

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -52,7 +52,10 @@ jobs:
           set +e
           docker run --rm anet-e2e /app/test-all.sh 2>&1 | tee /tmp/e2e-output.log
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
-        timeout-minutes: 5
+        # The now-restored Loop suites intentionally include real 60-second
+        # scheduler windows plus cooldown checks. Five minutes killed a valid
+        # complete run before it could emit the Final Report.
+        timeout-minutes: 12
 
       - name: Surface verdict (never silent — print suite numbers)
         if: always()

--- a/docs/tests/report-test292-e2e-residual-fixtures.txt
+++ b/docs/tests/report-test292-e2e-residual-fixtures.txt
@@ -1,0 +1,66 @@
+# #292 residual E2E fixture report
+
+Date: 2026-08-10
+Base: `7dc9f8ae` (#668 merged main)
+Source commit: `7adaa1d7d3c05e88be392ca8b9e07dee85a67e26`
+Scope: test harness only; no production/server/runtime behavior changed.
+
+## Witnessed red before this source
+
+Raw full-regression output from GitHub run `31338780878` after #668:
+
+- Base E2E: 136 pass / 0 fail
+- V3 Networks: 25 pass / 1 fail (`A sees B's network!`)
+- Loop runtime: crashed before its Results trailer (`alias_not_found`)
+- Loop npm-pack: 10 pass / 2 fail (`alias_not_found`)
+- Loop self-mgmt: 2 pass / 3 fail (`alias_identity_mismatch`)
+- Reported total: 214 pass / 7 fail
+
+The network test had used the first registered global admin as an ordinary
+tenant. The loop tests had reused the registration node token for different
+node aliases. Current Hub identity checks correctly reject those fixtures.
+No production authorization or identity gate was loosened.
+
+## Exact-source Docker evidence
+
+Low-disk derivative build (production artifacts inherited from the already
+reviewed #668 exact image; this source changes only four copied test scripts
+plus its test runner):
+
+```text
+tag=anet-test292-residual:dev
+image=sha256:4c73933d56451f7db7ee3c3abcdfdaed8375eb27a38335347e0b36fee69cfdc5
+TEST292_RESIDUAL_SOURCE_COMMIT=7adaa1d7d3c05e88be392ca8b9e07dee85a67e26
+base-image=anet-test292-identity:dev
+base-image-id=sha256:2e8938630aef1b4cf31911d10d324fe82d20c2f9d350c08b29ee8c16ebafe8c8
+```
+
+Command:
+
+```sh
+sg docker -c 'docker run --rm anet-test292-residual:dev'
+```
+
+Result:
+
+```text
+PASS: networks: Results: 26 passed, 0 failed
+PASS: npm-pack: Results: 12 passed, 0 failed
+PASS: self-mgmt: Results: 47 passed, 0 failed
+PASS: runtime: Results: 21 passed, 0 failed
+PASS: mutation: restoring admin A turns tenant isolation red
+PASS: mutation: runtime exact-alias identity is load-bearing
+PASS: mutation: npm-pack exact-alias identity is load-bearing
+PASS: mutation: self-mgmt exact-alias identity is load-bearing
+RESULT: PASS=8 FAIL=0
+```
+
+The real 60-second multi-cycle scheduler windows were retained; they were not
+shortened for the focused run.
+
+## Remaining #292 gate
+
+The GitHub workflow still captures `tee`'s exit code for
+`docker run ... | tee` and remains report-only. After this fixture candidate
+merges, a separate narrow follow-up must capture `${PIPESTATUS[0]}` and prove
+the exact full-regression image exits zero before #292 can close.

--- a/tests/docker-e2e-loop-npm-pack.sh
+++ b/tests/docker-e2e-loop-npm-pack.sh
@@ -31,6 +31,7 @@ type safe_rm_rf > /dev/null 2>&1 || {
   echo "FATAL: safe-rm.sh not found — refusing to run with bare rm -rf"
   exit 99
 }
+source /app/lib/e2e-agent-bootstrap.sh
 
 PASS=0
 FAIL=0
@@ -114,24 +115,25 @@ curl -s http://127.0.0.1:9211/health | grep -q '"ok":true' \
 REG=$(curl -s -X POST http://127.0.0.1:9211/api/auth/register \
   -H "Content-Type: application/json" \
   -d '{"username":"pack-test","password":"PackTestPw123","display_name":"pack test"}')
-NET_TOKEN=$(echo "$REG" | python3 -c "import sys,json;print(json.load(sys.stdin).get('network_token',''))")
+USER_TOKEN=$(echo "$REG" | python3 -c "import sys,json;print(json.load(sys.stdin).get('token',''))")
 NET_ID=$(echo "$REG" | python3 -c "import sys,json;print(json.load(sys.stdin).get('network_id',''))")
 
 ALIAS="pack-test-claude"
 WORKDIR="/tmp/pack-test-claude"
-safe_rm_rf "$WORKDIR"
-mkdir -p "$WORKDIR/.anet/nodes/$ALIAS"
-cat > "$WORKDIR/.anet/nodes/$ALIAS/config.json" <<EOF
-{
-  "alias": "$ALIAS",
-  "runtime": "claude-agent-sdk",
-  "hub": "http://127.0.0.1:9211",
-  "model": "claude-sonnet-4-6",
-  "token": "$NET_TOKEN",
-  "network_id": "$NET_ID",
-  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
-}
-EOF
+export HOME=/tmp/pack-test-home
+safe_rm_rf "$HOME" "$WORKDIR"
+mkdir -p "$HOME" "$WORKDIR"
+anet login --hub http://127.0.0.1:9211 --username pack-test --password PackTestPw123 >/dev/null
+e2e_select_network "$NET_ID"
+cd "$WORKDIR"
+e2e_create_agent "$ALIAS" claude-agent-sdk claude-sonnet-4-6 "$NET_ID"
+CONFIG=$(e2e_agent_config_path "$ALIAS")
+CONFIG_TMP="${CONFIG}.tmp"
+jq '.flags = {dangerouslySkipPermissions:true, teammateMode:true, goalTickMs:"5000"}' \
+  "$CONFIG" > "$CONFIG_TMP"
+chmod 600 "$CONFIG_TMP"
+mv "$CONFIG_TMP" "$CONFIG"
+e2e_config_token_bound_to_network "$CONFIG" "$NET_ID"
 
 cd "$WORKDIR"
 ANTHROPIC_API_KEY="test-no-real-call" \
@@ -149,7 +151,7 @@ done
 
 # THE LOAD-BEARING CHECK: real installed `anet` binary on real
 # installed agent-node, real user CLI flow.
-COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9211" \
+COMMHUB_TOKEN="$USER_TOKEN" COMMHUB_URL="http://127.0.0.1:9211" \
   anet node loop "$ALIAS" "pack-install probe" --every 5m \
   > /tmp/pack-cli.log 2>&1 || true
 

--- a/tests/docker-e2e-loop-runtime.sh
+++ b/tests/docker-e2e-loop-runtime.sh
@@ -40,6 +40,7 @@ type safe_rm_rf > /dev/null 2>&1 || {
   echo "FATAL: safe-rm.sh not found — refusing to run with bare rm -rf"
   exit 99
 }
+source /app/lib/e2e-agent-bootstrap.sh
 
 PASS=0
 FAIL=0
@@ -74,10 +75,29 @@ REG=$(curl -s -X POST http://127.0.0.1:9210/api/auth/register \
   -H "Content-Type: application/json" \
   -d '{"username":"loop-test","password":"LoopTestPw123","display_name":"loop test"}')
 USER_TOKEN=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('token',''))" 2>/dev/null)
-NET_TOKEN=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_token',''))" 2>/dev/null)
 NET_ID=$(echo "$REG" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_id',''))" 2>/dev/null)
-[ -n "$NET_TOKEN" ] && pass "test user registered, network token issued (net=${NET_ID:0:12})" \
+[ -n "$USER_TOKEN" ] && [ -n "$NET_ID" ] && pass "test user registered (net=${NET_ID:0:12})" \
   || { fail "user registration failed: $REG"; exit 1; }
+
+export HOME=/tmp/loop-test-home
+safe_rm_rf "$HOME"
+mkdir -p "$HOME"
+anet login --hub http://127.0.0.1:9210 --username loop-test --password LoopTestPw123 >/dev/null
+e2e_select_network "$NET_ID"
+
+create_loop_agent_config() {
+  local alias=$1 runtime=$2 model=$3 workdir=$4 flags=$5 config tmp
+  safe_rm_rf "$workdir"
+  mkdir -p "$workdir"
+  cd "$workdir"
+  e2e_create_agent "$alias" "$runtime" "$model" "$NET_ID"
+  config=$(e2e_agent_config_path "$alias")
+  tmp="${config}.tmp"
+  jq --argjson flags "$flags" '.flags = $flags' "$config" > "$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$config"
+  e2e_config_token_bound_to_network "$config" "$NET_ID"
+}
 
 # 2. Test claude-agent-sdk runtime — the load-bearing one
 #
@@ -99,19 +119,8 @@ echo "2. claude-agent-sdk runtime — full CLI → parser → goal → wake fire
 
 ALIAS_CLAUDE="loop-test-claude"
 WORKDIR_CLAUDE="/tmp/loop-test-claude"
-safe_rm_rf "$WORKDIR_CLAUDE"
-mkdir -p "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE"
-cat > "$WORKDIR_CLAUDE/.anet/nodes/$ALIAS_CLAUDE/config.json" <<EOF
-{
-  "alias": "$ALIAS_CLAUDE",
-  "runtime": "claude-agent-sdk",
-  "hub": "http://127.0.0.1:9210",
-  "model": "claude-sonnet-4-6",
-  "token": "$NET_TOKEN",
-  "network_id": "$NET_ID",
-  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000", "goalAcceptSubMinute": true }
-}
-EOF
+create_loop_agent_config "$ALIAS_CLAUDE" claude-agent-sdk claude-sonnet-4-6 "$WORKDIR_CLAUDE" \
+  '{"dangerouslySkipPermissions":true,"teammateMode":true,"goalTickMs":"5000","goalAcceptSubMinute":true}'
 # NOTE: the test uses interval `5m` which the parser enforces as
 # 60_000 ms minimum. Real wake firing in 25s requires interval >= tick
 # (default 30s, here 5s) AND >= MIN_INTERVAL (60s). To make the wake
@@ -157,7 +166,7 @@ fi
 echo "  Running: anet node loop $ALIAS_CLAUDE \"e2e probe\" --every 5m"
 # CLI reads --token / COMMHUB_TOKEN / loadGlobal().token. Use env so
 # we don't need to write a config file.
-COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+COMMHUB_TOKEN="$USER_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
   anet node loop "$ALIAS_CLAUDE" "e2e probe — please ack" --every 5m \
   > /tmp/cli-loop.log 2>&1 || true
 
@@ -251,19 +260,8 @@ echo "3. codex-sdk runtime — startup enable + CLI loop + wake fire..."
 
 ALIAS_CODEX="loop-test-codex"
 WORKDIR_CODEX="/tmp/loop-test-codex"
-safe_rm_rf "$WORKDIR_CODEX"
-mkdir -p "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX"
-cat > "$WORKDIR_CODEX/.anet/nodes/$ALIAS_CODEX/config.json" <<EOF
-{
-  "alias": "$ALIAS_CODEX",
-  "runtime": "codex-sdk",
-  "hub": "http://127.0.0.1:9210",
-  "model": "gpt-5.5",
-  "token": "$NET_TOKEN",
-  "network_id": "$NET_ID",
-  "flags": { "goalTickMs": "5000" }
-}
-EOF
+create_loop_agent_config "$ALIAS_CODEX" codex-sdk gpt-5.5 "$WORKDIR_CODEX" \
+  '{"goalTickMs":"5000"}'
 
 cd "$WORKDIR_CODEX"
 OPENAI_API_KEY="test-no-real-call" \
@@ -291,7 +289,7 @@ else
 fi
 
 # Real CLI path for codex too — covers `2h` single-letter variant.
-COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+COMMHUB_TOKEN="$USER_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
   anet node loop "$ALIAS_CODEX" "e2e probe codex" --every 2h \
   > /tmp/cli-codex.log 2>&1 || true
 
@@ -351,19 +349,8 @@ echo "4. Channel /loop slash path (commhub_send_task)..."
 
 ALIAS_CH="loop-test-channel"
 WORKDIR_CH="/tmp/loop-test-channel"
-safe_rm_rf "$WORKDIR_CH"
-mkdir -p "$WORKDIR_CH/.anet/nodes/$ALIAS_CH"
-cat > "$WORKDIR_CH/.anet/nodes/$ALIAS_CH/config.json" <<EOF
-{
-  "alias": "$ALIAS_CH",
-  "runtime": "claude-agent-sdk",
-  "hub": "http://127.0.0.1:9210",
-  "model": "claude-sonnet-4-6",
-  "token": "$NET_TOKEN",
-  "network_id": "$NET_ID",
-  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
-}
-EOF
+create_loop_agent_config "$ALIAS_CH" claude-agent-sdk claude-sonnet-4-6 "$WORKDIR_CH" \
+  '{"dangerouslySkipPermissions":true,"teammateMode":true,"goalTickMs":"5000"}'
 
 cd "$WORKDIR_CH"
 ANTHROPIC_API_KEY="test-no-real-call" \
@@ -382,7 +369,7 @@ done
 # Send a /loop via /api/task directly (same shape as commhub_send_task MCP tool)
 CH_RESP=$(curl -s -X POST http://127.0.0.1:9210/api/task \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $NET_TOKEN" \
+  -H "Authorization: Bearer $USER_TOKEN" \
   -d "{\"alias\":\"$ALIAS_CH\",\"task\":\"/loop 1d nightly cleanup\",\"priority\":\"normal\",\"from\":\"channel-test\",\"network_id\":\"$NET_ID\"}")
 CH_TASK_ID=$(echo "$CH_RESP" | python3 -c "import sys,json;print(json.load(sys.stdin).get('task_id',''))" 2>/dev/null)
 sleep 3
@@ -407,7 +394,7 @@ echo ""
 echo "5. Interval format edge cases (CLI argv validation)..."
 
 # 5a. Sub-minute MUST be rejected at CLI layer (no silent success)
-SUB_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+SUB_OUT=$(COMMHUB_TOKEN="$USER_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
   anet node loop "$ALIAS_CLAUDE" "x" --every 30s 2>&1 || true)
 if echo "$SUB_OUT" | grep -q "Invalid --every"; then
   pass "interval 30s: CLI rejects with clear error (no silent ✓ success)"
@@ -417,7 +404,7 @@ else
 fi
 
 # 5b. Bogus format
-BOG_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+BOG_OUT=$(COMMHUB_TOKEN="$USER_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
   anet node loop "$ALIAS_CLAUDE" "x" --every 5x 2>&1 || true)
 if echo "$BOG_OUT" | grep -q "Invalid --every"; then
   pass "interval 5x: CLI rejects with clear error"
@@ -426,7 +413,7 @@ else
 fi
 
 # 5c. Empty --every
-EMP_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+EMP_OUT=$(COMMHUB_TOKEN="$USER_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
   anet node loop "$ALIAS_CLAUDE" "x" --every "" 2>&1 || true)
 if echo "$EMP_OUT" | grep -q "Invalid --every"; then
   pass "interval empty: CLI rejects with clear error"
@@ -442,7 +429,7 @@ echo "6. anet goal list + cancel..."
 # workdir that has the node profile (created by the agent's
 # --config write at startup).
 cd "$WORKDIR_CLAUDE"
-LIST_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+LIST_OUT=$(COMMHUB_TOKEN="$USER_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
   anet goal list "$ALIAS_CLAUDE" 2>&1 || true)
 if echo "$LIST_OUT" | grep -q "$GOAL_ID\|5min\|active"; then
   pass "anet goal list: shows the created goal"
@@ -452,7 +439,7 @@ else
   echo "$LIST_OUT" | head -10
 fi
 
-CANCEL_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+CANCEL_OUT=$(COMMHUB_TOKEN="$USER_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
   anet goal cancel "$ALIAS_CLAUDE" "${GOAL_ID:0:8}" 2>&1 || true)
 if echo "$CANCEL_OUT" | grep -qi "cancelled\|已取消\|status.*cancelled"; then
   pass "anet goal cancel: goal cancelled"
@@ -477,19 +464,8 @@ echo "6b. grok-build-acp runtime — startup enable + goal fire..."
 
 ALIAS_GROK="loop-test-grok"
 WORKDIR_GROK="/tmp/loop-test-grok"
-safe_rm_rf "$WORKDIR_GROK"
-mkdir -p "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK"
-cat > "$WORKDIR_GROK/.anet/nodes/$ALIAS_GROK/config.json" <<EOF
-{
-  "alias": "$ALIAS_GROK",
-  "runtime": "grok-build-acp",
-  "hub": "http://127.0.0.1:9210",
-  "model": "grok-build",
-  "token": "$NET_TOKEN",
-  "network_id": "$NET_ID",
-  "flags": { "goalTickMs": "5000" }
-}
-EOF
+create_loop_agent_config "$ALIAS_GROK" grok-build-acp grok-build "$WORKDIR_GROK" \
+  '{"goalTickMs":"5000"}'
 
 # Pre-create a grok-runtime goal (no real grok binary needed for the
 # scheduler-tick observation; SDK call inside processTask will fail
@@ -555,19 +531,8 @@ echo "6c. Multi-cycle wake — verify the scheduler fires the SAME goal repeated
 
 ALIAS_MULTI="loop-test-multi"
 WORKDIR_MULTI="/tmp/loop-test-multi"
-safe_rm_rf "$WORKDIR_MULTI"
-mkdir -p "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI"
-cat > "$WORKDIR_MULTI/.anet/nodes/$ALIAS_MULTI/config.json" <<EOF
-{
-  "alias": "$ALIAS_MULTI",
-  "runtime": "codex-sdk",
-  "hub": "http://127.0.0.1:9210",
-  "model": "gpt-5.5",
-  "token": "$NET_TOKEN",
-  "network_id": "$NET_ID",
-  "flags": { "goalTickMs": "5000" }
-}
-EOF
+create_loop_agent_config "$ALIAS_MULTI" codex-sdk gpt-5.5 "$WORKDIR_MULTI" \
+  '{"goalTickMs":"5000"}'
 
 MULTI_GOAL="$(python3 -c "import uuid;print(uuid.uuid4())")"
 # 60s interval (parser min) + 5s tick. Past next_wake_at so first
@@ -632,19 +597,8 @@ echo "6d. Multi-cycle wake — claude-agent-sdk (Vincent's runtime)..."
 
 ALIAS_CMULTI="loop-test-claude-multi"
 WORKDIR_CMULTI="/tmp/loop-test-claude-multi"
-safe_rm_rf "$WORKDIR_CMULTI"
-mkdir -p "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI"
-cat > "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI/config.json" <<EOF
-{
-  "alias": "$ALIAS_CMULTI",
-  "runtime": "claude-agent-sdk",
-  "hub": "http://127.0.0.1:9210",
-  "model": "claude-sonnet-4-6",
-  "token": "$NET_TOKEN",
-  "network_id": "$NET_ID",
-  "flags": { "dangerouslySkipPermissions": true, "teammateMode": true, "goalTickMs": "5000" }
-}
-EOF
+create_loop_agent_config "$ALIAS_CMULTI" claude-agent-sdk claude-sonnet-4-6 "$WORKDIR_CMULTI" \
+  '{"dangerouslySkipPermissions":true,"teammateMode":true,"goalTickMs":"5000"}'
 
 CMULTI_GOAL="$(python3 -c "import uuid;print(uuid.uuid4())")"
 cat > "$WORKDIR_CMULTI/.anet/nodes/$ALIAS_CMULTI/goals.json" <<EOF
@@ -700,7 +654,7 @@ fi
 echo ""
 echo "7. Offline node behavior (CLI must fail clearly, not silent ✅)..."
 
-OFF_OUT=$(COMMHUB_TOKEN="$NET_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
+OFF_OUT=$(COMMHUB_TOKEN="$USER_TOKEN" COMMHUB_URL="http://127.0.0.1:9210" \
   timeout 25 anet node loop "$ALIAS_CLAUDE" "this node is dead" --every 5m 2>&1 || true)
 if echo "$OFF_OUT" | grep -q "did not confirm\|node offline"; then
   pass "offline node: CLI reports timeout (does NOT print false ✅)"

--- a/tests/docker-e2e-loop-self-mgmt.sh
+++ b/tests/docker-e2e-loop-self-mgmt.sh
@@ -52,6 +52,7 @@ type safe_rm_rf > /dev/null 2>&1 || {
   echo "FATAL: safe-rm.sh not found"
   exit 99
 }
+source /app/lib/e2e-agent-bootstrap.sh
 
 PASS=0
 FAIL=0
@@ -91,12 +92,17 @@ register_test_user() {
     -H "Content-Type: application/json" \
     -d '{"username":"m4-tester","password":"M4TestPw123","display_name":"M4 Tester"}')
   USER_TOKEN=$(echo "$resp" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('token',''))")
-  NET_TOKEN=$(echo "$resp" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_token',''))")
   NET_ID=$(echo "$resp" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('network_id',''))")
-  if [ -z "$NET_TOKEN" ]; then
+  if [ -z "$USER_TOKEN" ] || [ -z "$NET_ID" ]; then
     fail "user register failed: $resp"
     exit 1
   fi
+  export HOME=/tmp/m4-home-$$
+  safe_rm_rf "$HOME"
+  mkdir -p "$HOME"
+  anet login --hub "http://127.0.0.1:$HUB_PORT" \
+    --username m4-tester --password M4TestPw123 >/dev/null || exit 1
+  e2e_select_network "$NET_ID" || exit 1
   pass "registered test user (net=${NET_ID:0:12})"
 }
 
@@ -105,22 +111,18 @@ make_node_workdir() {
   local runtime="$2"
   local workdir="/tmp/m4-${alias}-$$"
   safe_rm_rf "$workdir"
-  mkdir -p "$workdir/.anet/nodes/$alias"
-  cat > "$workdir/.anet/nodes/$alias/config.json" <<EOF
-{
-  "alias": "$alias",
-  "runtime": "$runtime",
-  "hub": "http://127.0.0.1:$HUB_PORT",
-  "token": "$NET_TOKEN",
-  "network_id": "$NET_ID",
-  "flags": {
-    "dangerouslySkipPermissions": true,
-    "teammateMode": true,
-    "goalTickMs": "5000",
-    "timezone": "Asia/Shanghai"
-  }
-}
-EOF
+  mkdir -p "$workdir"
+  local model=gpt-5.5
+  [ "$runtime" = "claude-agent-sdk" ] && model=claude-sonnet-4-6
+  [ "$runtime" = "grok-build-acp" ] && model=grok-build
+  (cd "$workdir" && e2e_create_agent "$alias" "$runtime" "$model" "$NET_ID") || return 1
+  local config="$workdir/.anet/nodes/$alias/config.json"
+  local tmp="${config}.tmp"
+  jq '.flags = {dangerouslySkipPermissions:true, teammateMode:true, goalTickMs:"5000", timezone:"Asia/Shanghai"}' \
+    "$config" > "$tmp" || return 1
+  chmod 600 "$tmp"
+  mv "$tmp" "$config"
+  e2e_config_token_bound_to_network "$config" "$NET_ID" || return 1
   echo "$workdir"
 }
 
@@ -652,7 +654,7 @@ test_claude_structural() {
   local resp ok
   resp=$(curl -s -X POST "http://127.0.0.1:$HUB_PORT/api/task" \
     -H "Content-Type: application/json" \
-    -H "Authorization: Bearer $NET_TOKEN" \
+    -H "Authorization: Bearer $USER_TOKEN" \
     -d "{\"alias\":\"$alias\",\"task\":\"/loop 5m claude structural smoke\",\"priority\":\"normal\",\"from\":\"m4-harness\",\"network_id\":\"$NET_ID\"}")
   ok=$(echo "$resp" | python3 -c "import sys,json;print(json.load(sys.stdin).get('ok',False))" 2>/dev/null || echo "False")
   if [ "$ok" != "True" ]; then fail "claude: POST /loop failed: $resp"; return; fi

--- a/tests/docker-e2e-networks.sh
+++ b/tests/docker-e2e-networks.sh
@@ -10,7 +10,7 @@ echo "  V3 Network Management + Isolation Tests"
 echo "========================================="
 echo ""
 
-cd /app/server && bun run src/index.ts &
+(cd /app/server && exec bun run src/index.ts) &
 HUB_PID=$!
 cleanup() { kill "$HUB_PID" 2>/dev/null || true; }
 trap cleanup EXIT
@@ -20,7 +20,13 @@ for _ in $(seq 1 30); do
 done
 curl -fsS http://127.0.0.1:9200/health >/dev/null
 
-# Setup: register 2 users
+# Setup: register one bootstrap admin, then 2 ordinary users. The first
+# registered account is intentionally the global admin and can see every
+# network (#94), so it is not a valid tenant-isolation fixture.
+curl -fsS -X POST http://127.0.0.1:9200/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username":"net_bootstrap_admin","password":"test123456"}' >/dev/null
+
 REG_A=$(curl -s -X POST http://127.0.0.1:9200/api/auth/register -H "Content-Type: application/json" -d '{"username":"netuser_a","password":"test123456"}')
 TOKEN_A=$(echo "$REG_A" | python3 -c "import sys,json;print(json.loads(sys.stdin.read()).get('token',''))" 2>/dev/null)
 # Login to get fresh token
@@ -31,7 +37,14 @@ REG_B=$(curl -s -X POST http://127.0.0.1:9200/api/auth/register -H "Content-Type
 LOGIN_B=$(curl -s -X POST http://127.0.0.1:9200/api/auth/login -H "Content-Type: application/json" -d '{"username":"netuser_b","password":"test123456"}')
 TOKEN_B=$(echo "$LOGIN_B" | python3 -c "import sys,json;print(json.loads(sys.stdin.read()).get('token',''))" 2>/dev/null)
 
-[ -n "$TOKEN_A" ] && [ -n "$TOKEN_B" ] && pass "2 users registered" || { fail "setup failed"; exit 1; }
+# A separate ordinary owner keeps the delete fixture empty while A/B retain
+# their networks for the isolation assertions above.
+REG_C=$(curl -s -X POST http://127.0.0.1:9200/api/auth/register -H "Content-Type: application/json" -d '{"username":"netuser_c","password":"test123456"}')
+TOKEN_C=$(echo "$REG_C" | python3 -c "import sys,json;print(json.loads(sys.stdin.read()).get('token',''))" 2>/dev/null)
+
+[ -n "$TOKEN_A" ] && [ -n "$TOKEN_B" ] && [ -n "$TOKEN_C" ] \
+  && pass "ordinary isolation and delete owners registered after bootstrap admin" \
+  || { fail "setup failed"; exit 1; }
 
 # 1. Network CRUD
 echo "1. Network CRUD..."
@@ -160,19 +173,20 @@ echo ""
 
 # 7. Network delete
 echo "7. Network delete..."
-# Create a throwaway network to delete
+# Reject the foreign delete without destroying A's populated isolation
+# fixture, then use ordinary user C's empty second network for owner delete.
+CROSS_DEL=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "http://127.0.0.1:9200/api/networks/$NET_A_ID" -H "Authorization: Bearer $TOKEN_B")
+[ "$CROSS_DEL" = "400" ] || [ "$CROSS_DEL" = "403" ] \
+  && pass "cross-user delete rejected" || fail "cross-user delete returned $CROSS_DEL"
 DEL_NET=$(curl -s -X POST http://127.0.0.1:9200/api/networks \
-  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN_A" \
+  -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN_C" \
   -d '{"name":"to-delete"}')
 DEL_ID=$(echo "$DEL_NET" | python3 -c "import sys,json;print(json.loads(sys.stdin.read()).get('network_id',''))" 2>/dev/null)
-DEL_RES=$(curl -s -X DELETE "http://127.0.0.1:9200/api/networks/$DEL_ID" -H "Authorization: Bearer $TOKEN_A")
-echo "$DEL_RES" | grep -q '"ok":true' && pass "delete network" || fail "delete failed"
+DEL_RES=$(curl -s -X DELETE "http://127.0.0.1:9200/api/networks/$DEL_ID" -H "Authorization: Bearer $TOKEN_C")
+echo "$DEL_RES" | grep -q '"ok":true' && pass "owner deletes network" || fail "delete failed"
 # Verify gone
-NETS_D=$(curl -s -H "Authorization: Bearer $TOKEN_A" http://127.0.0.1:9200/api/networks)
+NETS_D=$(curl -s -H "Authorization: Bearer $TOKEN_C" http://127.0.0.1:9200/api/networks)
 echo "$NETS_D" | grep -q 'to-delete' && fail "deleted network still in list" || pass "deleted network gone"
-# Cross-user delete rejected
-CROSS_DEL=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "http://127.0.0.1:9200/api/networks/$NET_A_ID" -H "Authorization: Bearer $TOKEN_B")
-[ "$CROSS_DEL" = "400" ] && pass "cross-user delete rejected" || pass "cross-user check ($CROSS_DEL)"
 echo ""
 
 echo ""

--- a/tests/test292-e2e-residual-fixtures/Dockerfile
+++ b/tests/test292-e2e-residual-fixtures/Dockerfile
@@ -1,0 +1,30 @@
+FROM oven/bun:1.3.14
+
+RUN apt-get update && apt-get install -y curl jq python3 make g++ procps && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY agent-network/ /app/agent-network/
+RUN cd /app/agent-network && npm install && npm run build && npm install -g .
+
+COPY server/ /app/server/
+RUN cd /app/server && bun install
+
+COPY agent-node/ /app/agent-node/
+RUN cd /app/agent-node && npm install && npm run build && npm link && \
+    npm install @openai/codex-sdk 2>/dev/null || true
+
+COPY tests/lib/ /app/lib/
+COPY tests/docker-e2e-networks.sh /app/test-networks.sh
+COPY tests/docker-e2e-loop-runtime.sh /app/test-loop-runtime.sh
+COPY tests/docker-e2e-loop-npm-pack.sh /app/test-loop-npm-pack.sh
+COPY tests/docker-e2e-loop-self-mgmt.sh /app/test-loop-self-mgmt.sh
+COPY tests/test292-e2e-residual-fixtures/run.sh /app/test292-residual.sh
+RUN chmod +x /app/test-networks.sh /app/test-loop-runtime.sh \
+  /app/test-loop-npm-pack.sh /app/test-loop-self-mgmt.sh /app/test292-residual.sh
+
+ARG TEST292_RESIDUAL_SOURCE_COMMIT=unknown
+ENV TEST292_RESIDUAL_SOURCE_COMMIT=${TEST292_RESIDUAL_SOURCE_COMMIT}
+
+ENTRYPOINT ["bash", "/app/test292-residual.sh"]

--- a/tests/test292-e2e-residual-fixtures/Dockerfile.derivative
+++ b/tests/test292-e2e-residual-fixtures/Dockerfile.derivative
@@ -1,0 +1,15 @@
+ARG TEST292_RESIDUAL_BASE_IMAGE=anet-test292-identity:dev
+FROM ${TEST292_RESIDUAL_BASE_IMAGE}
+
+COPY tests/docker-e2e-networks.sh /app/test-networks.sh
+COPY tests/docker-e2e-loop-runtime.sh /app/test-loop-runtime.sh
+COPY tests/docker-e2e-loop-npm-pack.sh /app/test-loop-npm-pack.sh
+COPY tests/docker-e2e-loop-self-mgmt.sh /app/test-loop-self-mgmt.sh
+COPY tests/test292-e2e-residual-fixtures/run.sh /app/test292-residual.sh
+RUN chmod +x /app/test-networks.sh /app/test-loop-runtime.sh \
+  /app/test-loop-npm-pack.sh /app/test-loop-self-mgmt.sh /app/test292-residual.sh
+
+ARG TEST292_RESIDUAL_SOURCE_COMMIT=unknown
+ENV TEST292_RESIDUAL_SOURCE_COMMIT=${TEST292_RESIDUAL_SOURCE_COMMIT}
+
+ENTRYPOINT ["bash", "/app/test292-residual.sh"]

--- a/tests/test292-e2e-residual-fixtures/run.sh
+++ b/tests/test292-e2e-residual-fixtures/run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+WORK=/tmp/test292-residual
+
+pass() { PASS=$((PASS + 1)); echo "PASS: $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL: $*" >&2; }
+
+mkdir -p "$WORK"
+echo "source_commit=$TEST292_RESIDUAL_SOURCE_COMMIT"
+
+run_green() {
+  local name=$1 script=$2 expected=$3 log="$WORK/$1.log"
+  if timeout 420 bash "$script" >"$log" 2>&1 && grep -Fq "$expected" "$log"; then
+    pass "$name: $expected"
+  else
+    tail -80 "$log" >&2 || true
+    fail "$name did not reach its exact green trailer"
+  fi
+}
+
+# Layered green: cheap isolation and install paths first, then the real
+# scheduler windows. A failed prerequisite stops this exact evidence run.
+run_green networks /app/test-networks.sh "Results: 26 passed, 0 failed"
+[[ $FAIL -eq 0 ]] || exit 1
+run_green npm-pack /app/test-loop-npm-pack.sh "Results: 12 passed, 0 failed"
+[[ $FAIL -eq 0 ]] || exit 1
+run_green self-mgmt /app/test-loop-self-mgmt.sh "Results: 47 passed, 0 failed"
+[[ $FAIL -eq 0 ]] || exit 1
+run_green runtime /app/test-loop-runtime.sh "Results: 21 passed, 0 failed"
+
+# Witnessed-red 1: if A becomes the bootstrap admin again, its visibility is
+# intentionally wider and the ordinary-user isolation assertion must fail.
+# The green network script owns :9200 and kills its Hub on EXIT; wait for that
+# exact listener to disappear before starting the mutated isolated Hub.
+for _ in $(seq 1 30); do
+  curl -fsS http://127.0.0.1:9200/health >/dev/null 2>&1 || break
+  sleep 0.1
+done
+MUT_NETWORK="$WORK/networks-admin-a.sh"
+cp /app/test-networks.sh "$MUT_NETWORK"
+sed -i 's/net_bootstrap_admin/netuser_a/' "$MUT_NETWORK"
+sed -i 's|(cd /app/server && exec bun run src/index.ts)|(cd /app/server \&\& exec env COMMHUB_DB=/tmp/test292-mut-network.db bun run src/index.ts)|' "$MUT_NETWORK"
+if cmp -s /app/test-networks.sh "$MUT_NETWORK"; then
+  fail "mutation: bootstrap-admin anchor did not match"
+elif timeout 30 bash "$MUT_NETWORK" >"$WORK/networks-admin-a.log" 2>&1; then
+  fail "mutation: admin A was incorrectly accepted as an isolation fixture"
+elif grep -Fq "A sees B's network!" "$WORK/networks-admin-a.log"; then
+  pass "mutation: restoring admin A turns tenant isolation red"
+else
+  tail -40 "$WORK/networks-admin-a.log" >&2 || true
+  fail "mutation: network test failed for an unrelated reason"
+fi
+
+# Witnessed-red 2-4: each loop suite must depend on the exact alias passed to
+# the public CLI identity bootstrap. Replacing it with the registration alias
+# leaves the expected config absent and must stop before an agent starts.
+mutate_exact_alias() {
+  local name=$1 source=$2 anchor=$3 replacement=$4 log="$WORK/mut-$1.log"
+  local mut="$WORK/mut-$1.sh"
+  cp "$source" "$mut"
+  sed -i "s|$anchor|$replacement|" "$mut"
+  if cmp -s "$source" "$mut"; then
+    fail "mutation: $name exact-alias anchor did not match"
+  elif timeout 45 bash "$mut" >"$log" 2>&1; then
+    fail "mutation: $name ran without its exact node identity"
+  elif grep -Eq 'No such file|not authoritative|alias_identity_mismatch|config' "$log"; then
+    pass "mutation: $name exact-alias identity is load-bearing"
+  else
+    tail -40 "$log" >&2 || true
+    fail "mutation: $name failed for an unrelated reason"
+  fi
+}
+
+mutate_exact_alias runtime /app/test-loop-runtime.sh \
+  'e2e_create_agent "$alias" "$runtime"' \
+  'e2e_create_agent loop-test "$runtime"'
+mutate_exact_alias npm-pack /app/test-loop-npm-pack.sh \
+  'e2e_create_agent "$ALIAS" claude-agent-sdk' \
+  'e2e_create_agent pack-test claude-agent-sdk'
+mutate_exact_alias self-mgmt /app/test-loop-self-mgmt.sh \
+  'e2e_create_agent "$alias" "$runtime"' \
+  'e2e_create_agent m4-tester "$runtime"'
+
+echo "RESULT: PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## What changed

- make the V3 network isolation fixture use ordinary users after a dedicated bootstrap admin
- create Loop runtime, npm-pack, and self-management nodes through the public CLI so every node has a stable `node_id` and its own token-bound alias
- use the user token only for user-originated scheduling calls
- make the network test own and reap the exact Hub process
- add a standalone exact-source Docker suite with four witnessed-red mutations

## Why

After #668 made Base E2E authoritative, the remaining full-regression failures were stale fixtures rather than product regressions. The network suite treated the first registered global admin as an ordinary tenant. Three Loop suites reused the registration token for different aliases, which current Hub identity guards correctly reject.

No production authorization or identity check is loosened.

## Validation

- V3 Networks: 26 passed, 0 failed
- Loop npm-pack: 12 passed, 0 failed
- Loop self-management: 47 passed, 0 failed
- Loop runtime: 21 passed, 0 failed, including both real 60-second multi-cycle windows
- exact derivative image source: `7adaa1d7d3c05e88be392ca8b9e07dee85a67e26`
- focused runner: `RESULT: PASS=8 FAIL=0`
- mutations turn red when admin A is restored or any Loop suite loses its exact-alias CLI identity bootstrap

## Follow-up

#292 remains open. Once this PR merges, a separate narrow change will capture Docker's real exit code through `tee` and hard-gate the now-green full regression.
