### PR TITLE
ci(e2e): hard-gate the restored full regression

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -37,67 +37,59 @@ jobs:
         run: docker build -t anet-e2e -f tests/Dockerfile .
         timeout-minutes: 10
 
-      # Report-only by design (#266 endgame, 2026-06-28):
-      # Same SOP as `anet QA (v0)` and the release-gate workflow — surface
-      # the verdict, never silently green-wash. Bucket A (~45 Base E2E
-      # fails) is pre-existing test-infra cascade tracked separately for
-      # v0.12 quality work; gating the merge bus on that 12-day-old red
-      # was blocking shipping without buying any product safety. The
-      # verdict step below prints per-suite pass/fail + total so a
-      # reviewer can SEE the state at a glance instead of trusting a
-      # green check that hides 45 fails.
-      - name: Run full regression (186 tests, report-only)
-        id: regression
+      - name: Verify full-regression hard gate contract
         run: |
-          set +e
-          docker run --rm anet-e2e /app/test-all.sh 2>&1 | tee /tmp/e2e-output.log
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          docker run --rm \
+            -e ROOT=/repo \
+            -v "$PWD:/repo:ro" \
+            anet-e2e \
+            bash /repo/tests/test292-e2e-hard-gate/run.sh
+        timeout-minutes: 2
+
+      # #292 restored the legacy fixtures to current identity/auth contracts.
+      # Preserve the Docker runner's real exit status across tee, then make the
+      # following step enforce both that status and the structured TOTAL line.
+      - name: Run full regression (hard-gated)
+        run: |
+          bash tests/lib/run-piped-command.sh \
+            /tmp/e2e-output.log \
+            /tmp/e2e-exit-code \
+            docker run --rm anet-e2e /app/test-all.sh
         # The now-restored Loop suites intentionally include real 60-second
         # scheduler windows plus cooldown checks. Five minutes killed a valid
         # complete run before it could emit the Final Report.
         timeout-minutes: 12
 
-      - name: Surface verdict (never silent — print suite numbers)
+      - name: Enforce full regression verdict
         if: always()
         run: |
           set -e
-          ec='${{ steps.regression.outputs.exit_code }}'
           echo
           echo "════════════════════════════════════════════════════════════"
-          echo "  Docker E2E verdict (report-only — see #266 for context)"
+          echo "  Docker E2E verdict (hard gate)"
           echo "════════════════════════════════════════════════════════════"
-          if [ ! -s /tmp/e2e-output.log ]; then
-            echo "::error::test-all.sh produced no output — likely infra/build issue, not test fail"
-            exit 1
-          fi
           # Pull the Final Report block + TOTAL line so the verdict is
           # visible in the Actions UI without expanding the run-step log.
-          awk '/Final Report/,/^$/' /tmp/e2e-output.log | tail -20
-          total_line=$(grep -E 'TOTAL: ' /tmp/e2e-output.log | tail -1)
-          [ -n "$total_line" ] || { echo "::error::no TOTAL line — test-all.sh did not complete"; exit 1; }
-          echo
-          echo "regression step exit code: $ec"
-          echo "$total_line"
-          # Non-zero exit code with output present = real test fails, NOT
-          # infra. Surface as a workflow-level warning so the PR check shows
-          # informational without false-passing a regression-day.
-          if [ "$ec" != "0" ]; then
-            echo "::warning::Docker E2E reported test fails (Bucket A cascade — tracked in #279, plan in #266)."
-            echo "::warning::This workflow is report-only by design (#266 endgame): the green tick means the harness ran and emitted a verdict, NOT that all 186 tests passed. Read the TOTAL line above."
+          if [ -s /tmp/e2e-output.log ]; then
+            awk '/Final Report/,/^$/' /tmp/e2e-output.log | tail -20
           fi
-          # Always exit 0 — report-only.
-          exit 0
+          [ -s /tmp/e2e-exit-code ] || {
+            echo "::error::runner exit-code file missing — test timed out or did not start"
+            exit 1
+          }
+          bash tests/lib/e2e-hard-gate.sh \
+            /tmp/e2e-output.log \
+            "$(cat /tmp/e2e-exit-code)"
 
   rename-ghost-gate:
-    # #180 regression gate — HARD FAIL (not report-only).
+    # #180 regression gate — standalone HARD FAIL for a focused signal.
     #
     # The rename-ghost test suite (`tests/qa-180-rename-ghost/`) reproduces the
     # exact ghost-process shape that #374 fixed: rename --force on a running
     # claude-code-cli node → old process + its MCP stdio subprocess must ALL
     # be reaped, and `/api/status` must lose the old alias immediately.
     #
-    # Why this needs its own hard gate (not folded into the report-only block
-    # above):
+    # Why this remains its own gate rather than relying only on the aggregate:
     #   - The fix relies on `sweepMcpOrphansForAlias` scanning
     #     `/proc/<pid>/environ` for `COMMHUB_ALIAS=<oldAlias>`. Delete that
     #     sweep or narrow its match set and the ghost silently returns.

--- a/docs/tests/report-test292-e2e-hard-gate.txt
+++ b/docs/tests/report-test292-e2e-hard-gate.txt
@@ -1,0 +1,105 @@
+Test 292 — full-regression CI hard gate
+=======================================
+
+Scope
+-----
+
+Base commit: 1efeeb4306ed70347ebef2579247dfe9ff92bd78
+Tested source commit: 35f594ccbfa2451257fed2cf7896b20fcf3b4bd9
+Draft PR: https://github.com/sleep2agi/agent-network/pull/670
+
+The source changes only the Docker E2E workflow and test infrastructure. It
+does not change server, CLI, agent runtime, authentication, or production
+behavior.
+
+Invariants
+----------
+
+1. The command to the left of tee is captured from PIPESTATUS, rather than
+   trusting tee's status.
+2. A tee/log write failure is represented by a non-numeric fail-closed status.
+3. The verdict requires exactly one structured TOTAL line, at least 175
+   passes, zero failures, and runner exit code zero.
+4. Empty, incomplete, malformed, duplicated, or truncated reports fail closed.
+5. The Dockerized contract is invoked by the workflow itself, so deleting the
+   helpers or their workflow wiring is not an untested refactor.
+
+Exact-source Docker evidence
+----------------------------
+
+Image tag: anet-test292-hard-gate:dev
+Image ID: sha256:3ab0fbed9f979d9c75c08d387514194b9d7da00783ac9200bd155dd0b3910ace
+Embedded environment:
+  TEST292_HARD_GATE_SOURCE_COMMIT=35f594ccbfa2451257fed2cf7896b20fcf3b4bd9
+
+Command:
+  sg docker -c 'docker run --rm anet-test292-hard-gate:dev'
+
+Result:
+  RESULT: PASS=22 FAIL=0
+
+The contract covers a green complete result, real test failures, a test failure
+whose runner status was masked to zero, a non-zero runner with a green TOTAL,
+minimum-count truncation, missing/duplicate/malformed TOTAL, missing runner
+status, and tee failure.
+
+Local witnessed-red mutations
+-------------------------------
+
+All mutations first assert that bytes changed.
+
+1. Restore the historical pair: remove pipefail and replace the runner status
+   with `$?` after tee. The behavioral status-preservation contract turns red.
+   Mutating only one half is intentionally not claimed as red because either
+   PIPESTATUS or pipefail is independently sufficient.
+2. Remove the `failed > 0` rejection. The masked-status red TOTAL is accepted,
+   so the gate contract turns red.
+3. Remove the workflow call to e2e-hard-gate.sh. The workflow-wiring contract
+   turns red.
+
+Real GitHub Actions witnessed-green
+-----------------------------------
+
+Candidate head: 35f594ccbfa2451257fed2cf7896b20fcf3b4bd9
+Run: https://github.com/sleep2agi/agent-network/actions/runs/31342289105
+Conclusion: SUCCESS
+
+Observed from the raw job log:
+  Verify full-regression hard gate contract: RESULT: PASS=22 FAIL=0
+  runner exit code: 0
+  TOTAL: 283 passed, 0 failed
+  PASS: full Docker E2E regression is complete and green
+
+The Actions contract container prints `source_commit=unembedded` because this
+workflow step deliberately bind-mounts the checked-out Actions commit into the
+already-built aggregate image. The run's authoritative head SHA above pins the
+checkout. The separate focused Docker image carries the embedded exact source
+SHA.
+
+Real GitHub Actions witnessed-red
+---------------------------------
+
+Mutation branch head: bdf806ac8abd055fef4553c1241b62faa3ab16aa
+Parent: 35f594ccbfa2451257fed2cf7896b20fcf3b4bd9
+Mutation: add exactly one deliberate `fail` call to
+  tests/docker-e2e-networks.sh
+Run: https://github.com/sleep2agi/agent-network/actions/runs/31342301920
+Conclusion: FAILURE
+
+Observed from the raw job log:
+  Verify full-regression hard gate contract: RESULT: PASS=22 FAIL=0
+  runner exit code: 1
+  TOTAL: 283 passed, 1 failed
+  ERROR: Docker E2E reported 1 failing tests
+
+The focused contract and rename-ghost job remained green. Only `Enforce full
+regression verdict` turned red, proving the failure is attributed to the full
+regression gate rather than a build, typecheck, or unrelated gate failure. The
+mutation branch is evidence-only and is not a merge candidate.
+
+Verdict
+-------
+
+PASS. The same workflow source is green for the restored 283/0 regression and
+turns red for an otherwise identical 283/1 run. PR #670 remains draft and is
+not self-merged or deployed; independent review is still required.

--- a/docs/tests/report-test292-e2e-hard-gate.txt
+++ b/docs/tests/report-test292-e2e-hard-gate.txt
@@ -5,7 +5,7 @@ Scope
 -----
 
 Base commit: 1efeeb4306ed70347ebef2579247dfe9ff92bd78
-Tested source commit: 35f594ccbfa2451257fed2cf7896b20fcf3b4bd9
+Tested source commit: 32daa2138703b2d8cf26610733af39c9efe34575
 Draft PR: https://github.com/sleep2agi/agent-network/pull/670
 
 The source changes only the Docker E2E workflow and test infrastructure. It
@@ -18,8 +18,9 @@ Invariants
 1. The command to the left of tee is captured from PIPESTATUS, rather than
    trusting tee's status.
 2. A tee/log write failure is represented by a non-numeric fail-closed status.
-3. The verdict requires exactly one structured TOTAL line, at least 175
-   passes, zero failures, and runner exit code zero.
+3. The verdict requires exactly one structured TOTAL line, at least 283
+   passes, zero failures, and runner exit code zero. The regression floor is
+   fixed in the gate and cannot be lowered through the environment.
 4. Empty, incomplete, malformed, duplicated, or truncated reports fail closed.
 5. The Dockerized contract is invoked by the workflow itself, so deleting the
    helpers or their workflow wiring is not an untested refactor.
@@ -28,20 +29,21 @@ Exact-source Docker evidence
 ----------------------------
 
 Image tag: anet-test292-hard-gate:dev
-Image ID: sha256:3ab0fbed9f979d9c75c08d387514194b9d7da00783ac9200bd155dd0b3910ace
+Image ID: sha256:7b40f2686384c9863ea7bd9ee740779d3d3af18ca8af17ed02f2b4e8138f23f5
 Embedded environment:
-  TEST292_HARD_GATE_SOURCE_COMMIT=35f594ccbfa2451257fed2cf7896b20fcf3b4bd9
+  TEST292_HARD_GATE_SOURCE_COMMIT=32daa2138703b2d8cf26610733af39c9efe34575
 
 Command:
   sg docker -c 'docker run --rm anet-test292-hard-gate:dev'
 
 Result:
-  RESULT: PASS=22 FAIL=0
+  RESULT: PASS=23 FAIL=0
 
 The contract covers a green complete result, real test failures, a test failure
 whose runner status was masked to zero, a non-zero runner with a green TOTAL,
 minimum-count truncation, missing/duplicate/malformed TOTAL, missing runner
 status, and tee failure.
+It also verifies that setting E2E_MIN_PASS=0 cannot lower the fixed floor.
 
 Local witnessed-red mutations
 -------------------------------
@@ -60,12 +62,12 @@ All mutations first assert that bytes changed.
 Real GitHub Actions witnessed-green
 -----------------------------------
 
-Candidate head: 35f594ccbfa2451257fed2cf7896b20fcf3b4bd9
-Run: https://github.com/sleep2agi/agent-network/actions/runs/31342289105
+Candidate head: 32daa2138703b2d8cf26610733af39c9efe34575
+Run: https://github.com/sleep2agi/agent-network/actions/runs/31343034003
 Conclusion: SUCCESS
 
 Observed from the raw job log:
-  Verify full-regression hard gate contract: RESULT: PASS=22 FAIL=0
+  Verify full-regression hard gate contract: RESULT: PASS=23 FAIL=0
   runner exit code: 0
   TOTAL: 283 passed, 0 failed
   PASS: full Docker E2E regression is complete and green
@@ -79,11 +81,11 @@ SHA.
 Real GitHub Actions witnessed-red
 ---------------------------------
 
-Mutation branch head: bdf806ac8abd055fef4553c1241b62faa3ab16aa
-Parent: 35f594ccbfa2451257fed2cf7896b20fcf3b4bd9
+Mutation branch head: 7558b3d64d9278f541d0bb44d2bb9babddb792e9
+Parent: 32daa2138703b2d8cf26610733af39c9efe34575
 Mutation: add exactly one deliberate `fail` call to
   tests/docker-e2e-networks.sh
-Run: https://github.com/sleep2agi/agent-network/actions/runs/31342301920
+Run: https://github.com/sleep2agi/agent-network/actions/runs/31343099705
 Conclusion: FAILURE
 
 Observed from the raw job log:

--- a/tests/lib/e2e-hard-gate.sh
+++ b/tests/lib/e2e-hard-gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 LOG_FILE=${1:-}
 RUNNER_RC=${2:-}
-MIN_PASS=${E2E_MIN_PASS:-175}
+MIN_PASS=${E2E_MIN_PASS:-283}
 
 if [[ -z "$LOG_FILE" || ! -s "$LOG_FILE" ]]; then
   echo "ERROR: test-all.sh produced no output" >&2

--- a/tests/lib/e2e-hard-gate.sh
+++ b/tests/lib/e2e-hard-gate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE=${1:-}
+RUNNER_RC=${2:-}
+MIN_PASS=${E2E_MIN_PASS:-175}
+
+if [[ -z "$LOG_FILE" || ! -s "$LOG_FILE" ]]; then
+  echo "ERROR: test-all.sh produced no output" >&2
+  exit 1
+fi
+if [[ ! "$RUNNER_RC" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: invalid or missing runner exit code: ${RUNNER_RC:-<empty>}" >&2
+  exit 1
+fi
+if [[ ! "$MIN_PASS" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: invalid minimum pass count: $MIN_PASS" >&2
+  exit 1
+fi
+
+mapfile -t total_lines < <(grep -F 'TOTAL: ' "$LOG_FILE" || true)
+if (( ${#total_lines[@]} != 1 )); then
+  echo "ERROR: expected exactly one structured TOTAL line, found ${#total_lines[@]}" >&2
+  exit 1
+fi
+
+total_line=${total_lines[0]}
+if [[ ! "$total_line" =~ TOTAL:\ ([0-9]+)\ passed,\ ([0-9]+)\ failed ]]; then
+  echo "ERROR: malformed TOTAL line" >&2
+  exit 1
+fi
+passed=${BASH_REMATCH[1]}
+failed=${BASH_REMATCH[2]}
+
+echo "runner exit code: $RUNNER_RC"
+echo "$total_line"
+
+if (( passed < MIN_PASS )); then
+  echo "ERROR: incomplete regression: $passed passes is below minimum $MIN_PASS" >&2
+  exit 1
+fi
+if (( failed > 0 )); then
+  echo "ERROR: Docker E2E reported $failed failing tests" >&2
+  exit 1
+fi
+if (( RUNNER_RC != 0 )); then
+  echo "ERROR: Docker E2E runner exited non-zero ($RUNNER_RC)" >&2
+  exit 1
+fi
+
+echo "PASS: full Docker E2E regression is complete and green"

--- a/tests/lib/e2e-hard-gate.sh
+++ b/tests/lib/e2e-hard-gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 LOG_FILE=${1:-}
 RUNNER_RC=${2:-}
-MIN_PASS=${E2E_MIN_PASS:-283}
+readonly MIN_PASS=283
 
 if [[ -z "$LOG_FILE" || ! -s "$LOG_FILE" ]]; then
   echo "ERROR: test-all.sh produced no output" >&2
@@ -13,11 +13,6 @@ if [[ ! "$RUNNER_RC" =~ ^[0-9]+$ ]]; then
   echo "ERROR: invalid or missing runner exit code: ${RUNNER_RC:-<empty>}" >&2
   exit 1
 fi
-if [[ ! "$MIN_PASS" =~ ^[0-9]+$ ]]; then
-  echo "ERROR: invalid minimum pass count: $MIN_PASS" >&2
-  exit 1
-fi
-
 mapfile -t total_lines < <(grep -F 'TOTAL: ' "$LOG_FILE" || true)
 if (( ${#total_lines[@]} != 1 )); then
   echo "ERROR: expected exactly one structured TOTAL line, found ${#total_lines[@]}" >&2

--- a/tests/lib/run-piped-command.sh
+++ b/tests/lib/run-piped-command.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+if (( $# < 3 )); then
+  echo "usage: run-piped-command.sh <log-file> <exit-code-file> <command> [args...]" >&2
+  exit 2
+fi
+
+LOG_FILE=$1
+EXIT_CODE_FILE=$2
+shift 2
+
+# The caller needs the complete log even when the runner fails. Keep this
+# wrapper successful so the following `if: always()` gate can print the final
+# report, but persist the *left side* of the pipeline rather than tee's status.
+set +e
+"$@" 2>&1 | tee "$LOG_FILE"
+pipeline_status=("${PIPESTATUS[@]}")
+runner_rc=${pipeline_status[0]}
+tee_rc=${pipeline_status[1]}
+if (( tee_rc != 0 )); then
+  # An incomplete log is not a trustworthy verdict. Keep the value deliberately
+  # non-numeric so the hard gate fails closed instead of trusting runner_rc.
+  printf 'tee_failed_%s\n' "$tee_rc" > "$EXIT_CODE_FILE"
+else
+  printf '%s\n' "$runner_rc" > "$EXIT_CODE_FILE"
+fi
+exit 0

--- a/tests/test292-e2e-hard-gate/Dockerfile
+++ b/tests/test292-e2e-hard-gate/Dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:1.3.14
+
+ARG TEST292_HARD_GATE_SOURCE_COMMIT=unknown
+ENV TEST292_HARD_GATE_SOURCE_COMMIT=$TEST292_HARD_GATE_SOURCE_COMMIT
+
+WORKDIR /app
+COPY .github/workflows/e2e-docker.yml /app/.github/workflows/e2e-docker.yml
+COPY tests/lib/run-piped-command.sh /app/tests/lib/run-piped-command.sh
+COPY tests/lib/e2e-hard-gate.sh /app/tests/lib/e2e-hard-gate.sh
+COPY tests/test292-e2e-hard-gate/run.sh /app/tests/test292-e2e-hard-gate/run.sh
+
+RUN chmod +x \
+  /app/tests/lib/run-piped-command.sh \
+  /app/tests/lib/e2e-hard-gate.sh \
+  /app/tests/test292-e2e-hard-gate/run.sh
+
+CMD ["/app/tests/test292-e2e-hard-gate/run.sh"]

--- a/tests/test292-e2e-hard-gate/run.sh
+++ b/tests/test292-e2e-hard-gate/run.sh
@@ -26,7 +26,7 @@ expect_file_contains() {
 
 expect_gate_green() {
   local log=$1 rc=$2 name=$3
-  if E2E_MIN_PASS=283 bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
+  if bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
     pass "$name"
   else
     fail "$name"
@@ -35,7 +35,7 @@ expect_gate_green() {
 
 expect_gate_red() {
   local log=$1 rc=$2 name=$3
-  if E2E_MIN_PASS=283 bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
+  if bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
     fail "$name"
   else
     pass "$name"
@@ -75,6 +75,11 @@ expect_gate_red "$TMP_DIR/red.log" 1 'test failures with non-zero runner status 
 expect_gate_red "$TMP_DIR/red.log" 0 'tee-masked runner status cannot hide TOTAL failures'
 expect_gate_red "$TMP_DIR/green.log" 7 'non-zero runner status cannot hide behind a green TOTAL'
 expect_gate_red "$TMP_DIR/short.log" 0 'truncated suite count fails closed'
+if E2E_MIN_PASS=0 bash "$GATE" "$TMP_DIR/short.log" 0 >/dev/null 2>&1; then
+  fail 'environment cannot lower the pinned regression floor'
+else
+  pass 'environment cannot lower the pinned regression floor'
+fi
 expect_gate_red "$TMP_DIR/missing.log" 0 'missing TOTAL fails closed'
 expect_gate_red "$TMP_DIR/duplicate.log" 0 'duplicate or malformed TOTAL fails closed'
 expect_gate_red "$TMP_DIR/green.log" '' 'missing runner status fails closed'
@@ -108,7 +113,7 @@ if cmp -s "$GATE" "$TMP_DIR/gate-mutant.sh"; then
 else
   pass 'failed-count mutation changed bytes'
 fi
-if E2E_MIN_PASS=283 bash "$TMP_DIR/gate-mutant.sh" "$TMP_DIR/red.log" 0 >/dev/null 2>&1; then
+if bash "$TMP_DIR/gate-mutant.sh" "$TMP_DIR/red.log" 0 >/dev/null 2>&1; then
   pass 'WITNESSED_RED: removing the failed-count gate accepts a red TOTAL'
 else
   fail 'WITNESSED_RED: removing the failed-count gate accepts a red TOTAL'

--- a/tests/test292-e2e-hard-gate/run.sh
+++ b/tests/test292-e2e-hard-gate/run.sh
@@ -26,7 +26,7 @@ expect_file_contains() {
 
 expect_gate_green() {
   local log=$1 rc=$2 name=$3
-  if E2E_MIN_PASS=175 bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
+  if E2E_MIN_PASS=283 bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
     pass "$name"
   else
     fail "$name"
@@ -35,7 +35,7 @@ expect_gate_green() {
 
 expect_gate_red() {
   local log=$1 rc=$2 name=$3
-  if E2E_MIN_PASS=175 bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
+  if E2E_MIN_PASS=283 bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
     fail "$name"
   else
     pass "$name"
@@ -43,8 +43,8 @@ expect_gate_red() {
 }
 
 printf 'Final Report\nTOTAL: 283 passed, 0 failed\n' > "$TMP_DIR/green.log"
-printf 'Final Report\nTOTAL: 282 passed, 1 failed\n' > "$TMP_DIR/red.log"
-printf 'Final Report\nTOTAL: 174 passed, 0 failed\n' > "$TMP_DIR/short.log"
+printf 'Final Report\nTOTAL: 283 passed, 1 failed\n' > "$TMP_DIR/red.log"
+printf 'Final Report\nTOTAL: 282 passed, 0 failed\n' > "$TMP_DIR/short.log"
 printf 'Final Report\nno total here\n' > "$TMP_DIR/missing.log"
 printf 'TOTAL: 283 passed, 0 failed\nTOTAL: malformed\n' > "$TMP_DIR/duplicate.log"
 
@@ -55,7 +55,7 @@ expect_file_contains "$RUNNER" 'pipeline_status=("${PIPESTATUS[@]}")' 'pipeline 
 expect_file_contains "$RUNNER" 'runner_rc=${pipeline_status[0]}' 'pipeline wrapper captures the runner rather than tee'
 
 bash "$RUNNER" "$TMP_DIR/runner.log" "$TMP_DIR/runner.rc" \
-  bash -c 'echo "TOTAL: 282 passed, 1 failed"; exit 7' >/dev/null
+  bash -c 'echo "TOTAL: 283 passed, 1 failed"; exit 7' >/dev/null
 if [[ $(cat "$TMP_DIR/runner.rc") == 7 ]]; then
   pass 'pipeline wrapper preserves a non-zero command exit through tee'
 else
@@ -92,7 +92,7 @@ else
   pass 'historical tee-masking mutation changed bytes'
 fi
 bash "$TMP_DIR/runner-mutant.sh" "$TMP_DIR/mutant-runner.log" "$TMP_DIR/mutant-runner.rc" \
-  bash -c 'echo "TOTAL: 282 passed, 1 failed"; exit 7' >/dev/null
+  bash -c 'echo "TOTAL: 283 passed, 1 failed"; exit 7' >/dev/null
 if [[ $(cat "$TMP_DIR/mutant-runner.rc") == 7 ]]; then
   fail 'WITNESSED_RED: no pipefail plus $? breaks the capture contract'
 else
@@ -108,7 +108,7 @@ if cmp -s "$GATE" "$TMP_DIR/gate-mutant.sh"; then
 else
   pass 'failed-count mutation changed bytes'
 fi
-if E2E_MIN_PASS=175 bash "$TMP_DIR/gate-mutant.sh" "$TMP_DIR/red.log" 0 >/dev/null 2>&1; then
+if E2E_MIN_PASS=283 bash "$TMP_DIR/gate-mutant.sh" "$TMP_DIR/red.log" 0 >/dev/null 2>&1; then
   pass 'WITNESSED_RED: removing the failed-count gate accepts a red TOTAL'
 else
   fail 'WITNESSED_RED: removing the failed-count gate accepts a red TOTAL'

--- a/tests/test292-e2e-hard-gate/run.sh
+++ b/tests/test292-e2e-hard-gate/run.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=${ROOT:-/app}
+WORKFLOW=${WORKFLOW_PATH:-$ROOT/.github/workflows/e2e-docker.yml}
+RUNNER=${RUNNER_PATH:-$ROOT/tests/lib/run-piped-command.sh}
+GATE=${GATE_PATH:-$ROOT/tests/lib/e2e-hard-gate.sh}
+TMP_DIR=$(mktemp -d /tmp/test292-hard-gate.XXXXXX)
+cleanup() {
+  find "$TMP_DIR" -mindepth 1 -delete 2>/dev/null || true
+  rmdir "$TMP_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "source_commit=${TEST292_HARD_GATE_SOURCE_COMMIT:-unembedded}"
+
+expect_file_contains() {
+  local file=$1 pattern=$2 name=$3
+  if grep -Fq -- "$pattern" "$file"; then pass "$name"; else fail "$name"; fi
+}
+
+expect_gate_green() {
+  local log=$1 rc=$2 name=$3
+  if E2E_MIN_PASS=175 bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
+    pass "$name"
+  else
+    fail "$name"
+  fi
+}
+
+expect_gate_red() {
+  local log=$1 rc=$2 name=$3
+  if E2E_MIN_PASS=175 bash "$GATE" "$log" "$rc" >/dev/null 2>&1; then
+    fail "$name"
+  else
+    pass "$name"
+  fi
+}
+
+printf 'Final Report\nTOTAL: 283 passed, 0 failed\n' > "$TMP_DIR/green.log"
+printf 'Final Report\nTOTAL: 282 passed, 1 failed\n' > "$TMP_DIR/red.log"
+printf 'Final Report\nTOTAL: 174 passed, 0 failed\n' > "$TMP_DIR/short.log"
+printf 'Final Report\nno total here\n' > "$TMP_DIR/missing.log"
+printf 'TOTAL: 283 passed, 0 failed\nTOTAL: malformed\n' > "$TMP_DIR/duplicate.log"
+
+expect_file_contains "$WORKFLOW" 'tests/lib/run-piped-command.sh' 'workflow uses the tested pipeline wrapper'
+expect_file_contains "$WORKFLOW" 'tests/lib/e2e-hard-gate.sh' 'workflow invokes the tested hard gate'
+expect_file_contains "$WORKFLOW" 'tests/test292-e2e-hard-gate/run.sh' 'workflow continuously runs the gate contract'
+expect_file_contains "$RUNNER" 'pipeline_status=("${PIPESTATUS[@]}")' 'pipeline wrapper snapshots both pipeline statuses'
+expect_file_contains "$RUNNER" 'runner_rc=${pipeline_status[0]}' 'pipeline wrapper captures the runner rather than tee'
+
+bash "$RUNNER" "$TMP_DIR/runner.log" "$TMP_DIR/runner.rc" \
+  bash -c 'echo "TOTAL: 282 passed, 1 failed"; exit 7' >/dev/null
+if [[ $(cat "$TMP_DIR/runner.rc") == 7 ]]; then
+  pass 'pipeline wrapper preserves a non-zero command exit through tee'
+else
+  fail 'pipeline wrapper preserves a non-zero command exit through tee'
+fi
+
+bash "$RUNNER" /dev/full "$TMP_DIR/tee-failure.rc" \
+  bash -c 'echo "TOTAL: 283 passed, 0 failed"; exit 0' >/dev/null 2>&1
+if [[ $(cat "$TMP_DIR/tee-failure.rc") == tee_failed_* ]]; then
+  pass 'tee/logging failure is preserved as a fail-closed status'
+else
+  fail 'tee/logging failure is preserved as a fail-closed status'
+fi
+
+expect_gate_green "$TMP_DIR/green.log" 0 'complete zero-failure regression passes'
+expect_gate_red "$TMP_DIR/red.log" 1 'test failures with non-zero runner status fail'
+expect_gate_red "$TMP_DIR/red.log" 0 'tee-masked runner status cannot hide TOTAL failures'
+expect_gate_red "$TMP_DIR/green.log" 7 'non-zero runner status cannot hide behind a green TOTAL'
+expect_gate_red "$TMP_DIR/short.log" 0 'truncated suite count fails closed'
+expect_gate_red "$TMP_DIR/missing.log" 0 'missing TOTAL fails closed'
+expect_gate_red "$TMP_DIR/duplicate.log" 0 'duplicate or malformed TOTAL fails closed'
+expect_gate_red "$TMP_DIR/green.log" '' 'missing runner status fails closed'
+expect_gate_red "$TMP_DIR/green.log" tee_failed_1 'tee failure status fails closed'
+
+# Witnessed-red mutation 1: fully restore the historical shape: no pipefail
+# *and* `$?` after tee. Either protection alone is sufficient, so mutating only
+# one would be a vacuous "red must happen" claim rather than the old bug.
+cp "$RUNNER" "$TMP_DIR/runner-mutant.sh"
+sed -i 's/set -u -o pipefail/set -u/' "$TMP_DIR/runner-mutant.sh"
+sed -i 's/runner_rc=${pipeline_status\[0\]}/runner_rc=$?/' "$TMP_DIR/runner-mutant.sh"
+if cmp -s "$RUNNER" "$TMP_DIR/runner-mutant.sh"; then
+  fail 'historical tee-masking mutation changed bytes'
+else
+  pass 'historical tee-masking mutation changed bytes'
+fi
+bash "$TMP_DIR/runner-mutant.sh" "$TMP_DIR/mutant-runner.log" "$TMP_DIR/mutant-runner.rc" \
+  bash -c 'echo "TOTAL: 282 passed, 1 failed"; exit 7' >/dev/null
+if [[ $(cat "$TMP_DIR/mutant-runner.rc") == 7 ]]; then
+  fail 'WITNESSED_RED: no pipefail plus $? breaks the capture contract'
+else
+  pass 'WITNESSED_RED: no pipefail plus $? breaks the capture contract'
+fi
+
+# Witnessed-red mutation 2: deleting the failed-count rejection must make the
+# masked-status fixture pass, which the contract recognizes as a regression.
+cp "$GATE" "$TMP_DIR/gate-mutant.sh"
+sed -i 's/if (( failed > 0 )); then/if (( failed < 0 )); then/' "$TMP_DIR/gate-mutant.sh"
+if cmp -s "$GATE" "$TMP_DIR/gate-mutant.sh"; then
+  fail 'failed-count mutation changed bytes'
+else
+  pass 'failed-count mutation changed bytes'
+fi
+if E2E_MIN_PASS=175 bash "$TMP_DIR/gate-mutant.sh" "$TMP_DIR/red.log" 0 >/dev/null 2>&1; then
+  pass 'WITNESSED_RED: removing the failed-count gate accepts a red TOTAL'
+else
+  fail 'WITNESSED_RED: removing the failed-count gate accepts a red TOTAL'
+fi
+
+# Witnessed-red mutation 3: the workflow wiring is part of the invariant. A
+# correct helper that is never invoked is not a gate.
+cp "$WORKFLOW" "$TMP_DIR/workflow-mutant.yml"
+sed -i 's#bash tests/lib/e2e-hard-gate.sh#bash /bin/true#' "$TMP_DIR/workflow-mutant.yml"
+if cmp -s "$WORKFLOW" "$TMP_DIR/workflow-mutant.yml"; then
+  fail 'workflow-wiring mutation changed bytes'
+else
+  pass 'workflow-wiring mutation changed bytes'
+fi
+if grep -Fq 'tests/lib/e2e-hard-gate.sh' "$TMP_DIR/workflow-mutant.yml"; then
+  fail 'WITNESSED_RED: deleting the workflow hard-gate call is detected'
+else
+  pass 'WITNESSED_RED: deleting the workflow hard-gate call is detected'
+fi
+
+echo "RESULT: PASS=$PASS FAIL=$FAIL"
+(( FAIL == 0 ))


### PR DESCRIPTION
## What changed

- preserve the real Docker runner and tee statuses through the logging pipeline
- replace the report-only verdict with a fail-closed gate over runner rc, exactly one structured TOTAL line, a fixed 283-pass floor, and zero failures
- keep the regression floor non-overridable by environment input
- run a Dockerized gate contract on every E2E workflow execution
- add witnessed-red mutations for the historical tee masking, failed-count bypass, missing workflow wiring, and floor override

## Why

#292 is now 283/0, but the workflow still recorded tee status and always exited green. That made GitHub Actions unable to prove the regression was green on its own merits.

## Validation

- exact source commit: `32daa2138703b2d8cf26610733af39c9efe34575`
- report-only head: `f6f96de5776e109ace187331bba1c3e1cd00582b`
- `anet-test292-hard-gate:dev`: 23 pass / 0 fail
- embedded source SHA and image provenance match
- Actions witnessed-green: https://github.com/sleep2agi/agent-network/actions/runs/31343034003 — 283/0, rc 0
- Actions witnessed-red: https://github.com/sleep2agi/agent-network/actions/runs/31343099705 — 283/1, rc 1
- the red branch differs from the source by one deliberate fail call; contract and rename-ghost gates remain green

Closes the final CI-gate portion of #292. This draft does not self-merge or deploy.