### PR TITLE
test: add deterministic mock LLM protocol

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -107,6 +107,7 @@ import {
   planPlainSecretEnvRewrites,
 } from "../src/claude-vendor-env";
 import { normalizeBatchWorkdir } from "../src/batch-workdir";
+import { loadMockLlmRules, resolveMockLlmReply } from "../src/mock-llm";
 import {
   decideDashboardListener,
   parseDashboardLaunchRecord,
@@ -11209,6 +11210,93 @@ async function fetchPrDiff(opts: Record<string, string>): Promise<{ diff: string
   throw new Error(`需要 --diff <file> / --ref <ref> / --pr <github-url> 之一`);
 }
 
+type PrReviewSection = { role: string; alias: string; text: string; durationMs: number };
+
+async function runPrReviewOrchestration(input: {
+  diff: string;
+  diffSource: string;
+  diffKb: string;
+  suffix: string;
+  outPath: string;
+  keep: boolean;
+  roleAliases: Record<string, string>;
+  invoke: (role: string, alias: string, prompt: string) => Promise<string>;
+}): Promise<void> {
+  const reviewerOutputs: PrReviewSection[] = [];
+  let judgeOutput = "";
+  const reviewerRoles = ["reviewer-security", "reviewer-performance", "reviewer-style"];
+  const t0Run = Date.now();
+
+  try {
+    console.log(`  [3/6] 广播 review task 给 3 reviewer (parallel)...`);
+    const reviewerTask = `请审查以下 diff（按你专精的维度）：\n\n\`\`\`diff\n${input.diff}\n\`\`\``;
+    const t0Fanout = Date.now();
+    const fanouts = reviewerRoles.map(async role => {
+      const alias = input.roleAliases[role];
+      const t0 = Date.now();
+      const reply = await input.invoke(role, alias, reviewerTask);
+      const dt = Date.now() - t0;
+      console.log(`        ✓ ${alias.padEnd(28)} ${Math.round(dt / 1000).toString().padStart(3)}s, ${reply.length} 字`);
+      return { role, alias, text: reply, durationMs: dt };
+    });
+    const results = await Promise.all(fanouts);
+    reviewerOutputs.push(...results);
+    const fanoutDt = Date.now() - t0Fanout;
+    const serialEstimate = results.reduce((sum, result) => sum + result.durationMs, 0);
+    console.log(`        ─ 并行总耗时 ${Math.round(fanoutDt / 1000)}s (估串行 ${Math.round(serialEstimate / 1000)}s, 节省 ~${Math.max(0, Math.round((serialEstimate - fanoutDt) / 1000))}s)`);
+
+    console.log(`  [4/6] barrier 收齐 3 份 review，整包派给 judge...`);
+    const judgePackage = [
+      `## diff 摘要`,
+      `- 来源: ${input.diffSource}`,
+      `- 大小: ${input.diffKb} KB`,
+      ``,
+      `## reviewer-security 输出`,
+      reviewerOutputs.find(output => output.role === "reviewer-security")?.text || "(无)",
+      ``,
+      `## reviewer-performance 输出`,
+      reviewerOutputs.find(output => output.role === "reviewer-performance")?.text || "(无)",
+      ``,
+      `## reviewer-style 输出`,
+      reviewerOutputs.find(output => output.role === "reviewer-style")?.text || "(无)",
+    ].join("\n");
+
+    console.log(`  [5/6] judge 整合 + 终审...`);
+    const judgeAlias = input.roleAliases.judge;
+    const t0Judge = Date.now();
+    judgeOutput = await input.invoke("judge", judgeAlias, `请整合三份 review 输出最终 PR review：\n\n${judgePackage}`);
+    console.log(`        ✓ ${judgeAlias} ${Math.round((Date.now() - t0Judge) / 1000)}s, ${judgeOutput.length} 字`);
+  } catch (error: any) {
+    console.error(`\n  ❌ 流程失败: ${error.message}`);
+    if (!input.keep) console.log(`     (--keep 未指定,稍后会清理 agent)`);
+  }
+
+  console.log(`  [6/6] 写入 review: ${input.outPath}`);
+  const finalMd = [
+    `# PR Review`,
+    ``,
+    `**来源**: ${input.diffSource}`,
+    `**大小**: ${input.diffKb} KB`,
+    `**时间**: ${new Date().toLocaleString()}`,
+    `**Run**: ${input.suffix}`,
+    `**总耗时**: ${Math.round((Date.now() - t0Run) / 1000)}s`,
+    ``,
+    judgeOutput || "(judge 没输出，看上面错误)",
+    ``,
+    `---`,
+    `## 附：3 reviewer 原始输出`,
+    ``,
+    ...reviewerOutputs.flatMap(output => [
+      `### ${output.role} (${output.alias}, ${Math.round(output.durationMs / 1000)}s)`,
+      ``,
+      output.text,
+      ``,
+    ]),
+  ].join("\n");
+  writeFileSync(input.outPath, finalMd);
+  console.log(`        ✓ ${finalMd.length} 字写入 ${input.outPath}`);
+}
+
 async function demoPrReviewCommand() {
   const opts = parseOpts();
   const help = args.includes("--help") || args.includes("-h");
@@ -11236,6 +11324,9 @@ async function demoPrReviewCommand() {
     --no-network      跑在当前/default network 内
     --network <id>    指定已存在的 network
 
+  测试专用:
+    MOCK_LLM_REPLIES_FILE=<jsonl>  用确定性 fixture 替代 4 次 LLM 回复；不连接 Hub
+
   Examples:
     anet demo pr-review --diff ./my-pr.diff
     anet demo pr-review --ref origin/main
@@ -11252,10 +11343,15 @@ async function demoPrReviewCommand() {
     return;
   }
 
+  // Explicit presence is the opt-in boundary. An unset variable must retain
+  // the real Hub/agent/vendor path byte-for-byte; an explicitly empty value
+  // is a malformed mock configuration and fails closed in the shared parser.
+  const mockMode = Object.prototype.hasOwnProperty.call(process.env, "MOCK_LLM_REPLIES_FILE");
+  const mockRepliesFile = process.env.MOCK_LLM_REPLIES_FILE ?? "";
   const gc = loadGlobal();
   const hub = gc.hub;
-  if (!hub) { console.error("  ❌ 没有 hub. 先 'anet init' 或 'anet hub start'."); return; }
-  if (!gc.token) { console.error("  ❌ 没有 token. 先 'anet login'."); return; }
+  if (!mockMode && !hub) { console.error("  ❌ 没有 hub. 先 'anet init' 或 'anet hub start'."); return; }
+  if (!mockMode && !gc.token) { console.error("  ❌ 没有 token. 先 'anet login'."); return; }
 
   // 1. Resolve diff source
   let diff = "";
@@ -11275,7 +11371,7 @@ async function demoPrReviewCommand() {
   }
 
   const minimaxKey = opts.key || process.env.MINIMAX_KEY || process.env.ANTHROPIC_AUTH_TOKEN || "";
-  if (!minimaxKey) {
+  if (!mockMode && !minimaxKey) {
     console.error("  ❌ 需要 MiniMax key. 用 --key 或 export MINIMAX_KEY=sk-cp-...");
     return;
   }
@@ -11284,6 +11380,33 @@ async function demoPrReviewCommand() {
   const keep = args.includes("--keep");
   const suffix = opts.suffix || Math.random().toString(16).slice(2, 6);
   const outPath = opts.out || `./pr-review-${suffix}-${Date.now()}.md`;
+  const roleAliases: Record<string, string> = {};
+  for (const role of PR_REVIEW_ROLES) roleAliases[role] = `${role}-${suffix}`;
+
+  if (mockMode) {
+    const rules = loadMockLlmRules(mockRepliesFile);
+    console.log(`\n  🔍 PR diff: ${diffSource}`);
+    console.log(`  📏 Size:   ${diffKb} KB`);
+    console.log(`  🧪 Mock:   ${mockRepliesFile} (${rules.length} rules)`);
+    console.log(`  🆔 Run:    ${suffix}\n`);
+    console.log(`  [1/6] 使用确定性 mock LLM（不创建 agent）`);
+    console.log(`  [2/6] 本地 mock ready`);
+    await runPrReviewOrchestration({
+      diff,
+      diffSource,
+      diffKb,
+      suffix,
+      outPath,
+      keep: true,
+      roleAliases,
+      // The real path distinguishes reviewers with their per-node system
+      // prompts. The deterministic path supplies the same role discriminator
+      // directly to the stateless matcher.
+      invoke: async (role, _alias, prompt) => resolveMockLlmReply(rules, `${role}\n${prompt}`).reply,
+    });
+    console.log(`\n  🏁 完成！review: ${outPath}\n`);
+    return;
+  }
 
   // Network selection: same convention as demo debate (default = create
   // dedicated `pr-review-<suffix>` network; --no-network = use default;
@@ -11331,9 +11454,6 @@ async function demoPrReviewCommand() {
       return;
     }
   }
-
-  const roleAliases: Record<string, string> = {};
-  for (const r of PR_REVIEW_ROLES) roleAliases[r] = `${r}-${suffix}`;
 
   console.log(`\n  🔍 PR diff: ${diffSource}`);
   console.log(`  📏 Size:   ${diffKb} KB`);
@@ -11443,80 +11563,19 @@ async function demoPrReviewCommand() {
     throw new Error(`timeout waiting for ${alias} reply`);
   }
 
-  type ReviewSection = { role: string; alias: string; text: string; durationMs: number };
-  const reviewerOutputs: ReviewSection[] = [];
-  let judgeOutput = "";
-  const reviewerRoles = ["reviewer-security", "reviewer-performance", "reviewer-style"];
-  const t0Run = Date.now();
-
-  try {
-    // 5. Parallel fan-out to 3 reviewers
-    console.log(`  [3/6] 广播 review task 给 3 reviewer (parallel)...`);
-    const reviewerTask = `请审查以下 diff（按你专精的维度）：\n\n\`\`\`diff\n${diff}\n\`\`\``;
-    const t0Fanout = Date.now();
-    const fanouts = reviewerRoles.map(async role => {
-      const alias = roleAliases[role];
-      const t0 = Date.now();
-      const msgId = await postTask(alias, reviewerTask);
-      const reply = await waitReply(msgId, alias, stepTimeout);
-      const dt = Date.now() - t0;
-      console.log(`        ✓ ${alias.padEnd(28)} ${Math.round(dt / 1000).toString().padStart(3)}s, ${reply.length} 字`);
-      return { role, alias, text: reply, durationMs: dt };
-    });
-    const results = await Promise.all(fanouts);
-    reviewerOutputs.push(...results);
-    const fanoutDt = Date.now() - t0Fanout;
-    const serialEstimate = results.reduce((s, r) => s + r.durationMs, 0);
-    console.log(`        ─ 并行总耗时 ${Math.round(fanoutDt / 1000)}s (估串行 ${Math.round(serialEstimate / 1000)}s, 节省 ~${Math.max(0, Math.round((serialEstimate - fanoutDt) / 1000))}s)`);
-
-    // 6. Barrier → judge
-    console.log(`  [4/6] barrier 收齐 3 份 review，整包派给 judge...`);
-    const judgePackage = [
-      `## diff 摘要`,
-      `- 来源: ${diffSource}`,
-      `- 大小: ${diffKb} KB`,
-      ``,
-      `## reviewer-security 输出`,
-      reviewerOutputs.find(o => o.role === "reviewer-security")?.text || "(无)",
-      ``,
-      `## reviewer-performance 输出`,
-      reviewerOutputs.find(o => o.role === "reviewer-performance")?.text || "(无)",
-      ``,
-      `## reviewer-style 输出`,
-      reviewerOutputs.find(o => o.role === "reviewer-style")?.text || "(无)",
-    ].join("\n");
-
-    console.log(`  [5/6] judge 整合 + 终审...`);
-    const judgeAlias = roleAliases["judge"];
-    const t0Judge = Date.now();
-    const judgeMsgId = await postTask(judgeAlias, `请整合三份 review 输出最终 PR review：\n\n${judgePackage}`);
-    judgeOutput = await waitReply(judgeMsgId, judgeAlias, stepTimeout);
-    console.log(`        ✓ ${judgeAlias} ${Math.round((Date.now() - t0Judge) / 1000)}s, ${judgeOutput.length} 字`);
-  } catch (e: any) {
-    console.error(`\n  ❌ 流程失败: ${e.message}`);
-    if (!keep) console.log(`     (--keep 未指定,稍后会清理 agent)`);
-  }
-
-  // 7. Write output markdown
-  console.log(`  [6/6] 写入 review: ${outPath}`);
-  const finalMd = [
-    `# PR Review`,
-    ``,
-    `**来源**: ${diffSource}`,
-    `**大小**: ${diffKb} KB`,
-    `**时间**: ${new Date().toLocaleString()}`,
-    `**Run**: ${suffix}`,
-    `**总耗时**: ${Math.round((Date.now() - t0Run) / 1000)}s`,
-    ``,
-    judgeOutput || "(judge 没输出，看上面错误)",
-    ``,
-    `---`,
-    `## 附：3 reviewer 原始输出`,
-    ``,
-    ...reviewerOutputs.flatMap(o => [`### ${o.role} (${o.alias}, ${Math.round(o.durationMs / 1000)}s)`, ``, o.text, ``]),
-  ].join("\n");
-  writeFileSync(outPath, finalMd);
-  console.log(`        ✓ ${finalMd.length} 字写入 ${outPath}`);
+  await runPrReviewOrchestration({
+    diff,
+    diffSource,
+    diffKb,
+    suffix,
+    outPath,
+    keep,
+    roleAliases,
+    invoke: async (_role, alias, prompt) => {
+      const msgId = await postTask(alias, prompt);
+      return await waitReply(msgId, alias, stepTimeout);
+    },
+  });
 
   // 8. Cleanup unless --keep
   if (!keep) {

--- a/agent-network/src/mock-llm.ts
+++ b/agent-network/src/mock-llm.ts
@@ -1,0 +1,132 @@
+import { lstatSync, readFileSync } from "node:fs";
+
+export const MOCK_LLM_FALLBACK = "(mock LLM: no rule matched)";
+const MAX_RULES_BYTES = 1024 * 1024;
+
+export type MockLlmRule = Readonly<{
+  in_substring: string;
+  out: string;
+}>;
+
+export type MockLlmResolution = Readonly<{
+  reply: string;
+  matched: boolean;
+  ruleIndex: number | null;
+}>;
+
+function fail(message: string): never {
+  throw new Error(`[mock-llm] ${message}`);
+}
+
+// JSON.parse accepts duplicate object keys and silently keeps the last one.
+// Enumerate the top-level keys first so a fixture cannot hide an earlier rule
+// value behind a duplicate key. The caller invokes this only after JSON.parse
+// has established that `line` is valid JSON.
+function topLevelObjectKeys(line: string): string[] {
+  const keys: string[] = [];
+  let index = 1;
+  const skipWhitespace = () => {
+    while (/\s/.test(line[index] ?? "")) index += 1;
+  };
+  const scanString = (): string => {
+    const start = index;
+    index += 1;
+    let escaped = false;
+    while (index < line.length) {
+      const char = line[index];
+      index += 1;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') return line.slice(start, index);
+    }
+    fail("unterminated JSON string");
+  };
+
+  while (index < line.length) {
+    skipWhitespace();
+    if (line[index] === "}") break;
+    if (line[index] !== '"') fail("rule keys must be JSON strings");
+    keys.push(JSON.parse(scanString()));
+    skipWhitespace();
+    if (line[index] !== ":") fail("expected colon after rule key");
+    index += 1;
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    while (index < line.length) {
+      const char = line[index];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (char === "\\") escaped = true;
+        else if (char === '"') inString = false;
+      } else if (char === '"') inString = true;
+      else if (char === "{" || char === "[") depth += 1;
+      else if (char === "}" || char === "]") {
+        if (depth === 0 && char === "}") break;
+        depth -= 1;
+      } else if (char === "," && depth === 0) break;
+      index += 1;
+    }
+    if (line[index] === ",") {
+      index += 1;
+      continue;
+    }
+    if (line[index] === "}") break;
+  }
+  return keys;
+}
+
+export function loadMockLlmRules(path: string): readonly MockLlmRule[] {
+  if (!path) fail("MOCK_LLM_REPLIES_FILE is required");
+
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink()) fail("rules path must be a regular, non-symlink file");
+  if (stat.size > MAX_RULES_BYTES) fail(`rules file exceeds ${MAX_RULES_BYTES} bytes`);
+
+  const rules: MockLlmRule[] = [];
+  const lines = readFileSync(path, "utf8").split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    if (!line) continue;
+
+    let value: unknown;
+    try {
+      value = JSON.parse(line);
+    } catch {
+      fail(`invalid JSON on line ${index + 1}`);
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      fail(`line ${index + 1} must be a JSON object`);
+    }
+
+    const keys = topLevelObjectKeys(line).sort();
+    if (keys.length !== 2 || keys[0] !== "in_substring" || keys[1] !== "out") {
+      fail(`line ${index + 1} must contain exactly one in_substring and one out`);
+    }
+    const record = value as Record<string, unknown>;
+    if (typeof record.in_substring !== "string" || record.in_substring.length === 0) {
+      fail(`line ${index + 1} in_substring must be a non-empty string`);
+    }
+    if (typeof record.out !== "string" || record.out.length === 0) {
+      fail(`line ${index + 1} out must be a non-empty string`);
+    }
+    rules.push({ in_substring: record.in_substring, out: record.out });
+  }
+
+  if (rules.length === 0) fail("rules file contains no rules");
+  return Object.freeze(rules);
+}
+
+export function resolveMockLlmReply(
+  rules: readonly MockLlmRule[],
+  prompt: string,
+  warn: (message: string) => void = console.error,
+): MockLlmResolution {
+  const ruleIndex = rules.findIndex((rule) => prompt.includes(rule.in_substring));
+  if (ruleIndex < 0) {
+    warn(`[mock-llm] warning: no rule matched prompt (${prompt.length} chars)`);
+    return { reply: MOCK_LLM_FALLBACK, matched: false, ruleIndex: null };
+  }
+  return { reply: rules[ruleIndex].out, matched: true, ruleIndex };
+}

--- a/docs/tests/report-test30-mock-llm-protocol.txt
+++ b/docs/tests/report-test30-mock-llm-protocol.txt
@@ -1,0 +1,55 @@
+# test30 — deterministic mock LLM protocol
+
+Date: 2026-08-10
+Base: a88deb227f021f8194ef5b7e2c89abdfd2b35f29
+Source commit: ec7f1b52592fe4442b73c043e2818a4ab4e922b4
+Docker tag: anet-test30-mock-llm:dev
+Docker image ID: sha256:ca8a9f1a683e6dbcc882dd8d889b7707cc7a6be44d5f9475747fa58f7f69ecc9
+Embedded ENV: TEST30_SOURCE_COMMIT=ec7f1b52592fe4442b73c043e2818a4ab4e922b4
+Runner artifact SHA256: b989948f90d70ff3ed3389fe44e5b76b386920bedff5faee856019ee06dbbb38
+
+Command:
+
+    sg docker -c 'docker build -t anet-test30-mock-llm:dev \
+      --build-arg SOURCE_COMMIT=ec7f1b52592fe4442b73c043e2818a4ab4e922b4 \
+      -f tests/test30-mock-llm-smoke/Dockerfile .'
+    sg docker -c 'docker run --rm -v <artifact-dir>:/artifacts \
+      anet-test30-mock-llm:dev'
+
+Result: PASS=13 FAIL=0
+
+Passing gates:
+
+1. agent-network TypeScript typecheck.
+2. Reference HTTP server starts and reports its immutable rule count.
+3. First matching substring wins in file order.
+4. step-N discriminators select independent replies.
+5. Repeated prompts return the same reply without cursor state.
+6. Unmatched prompts return the exact fallback and warn on stderr.
+7. Invalid request JSON returns HTTP 400.
+8. Malformed fixture JSON fails before listen.
+9. Unknown fixture keys fail before listen.
+10. Duplicate fixture keys fail before listen.
+11. Non-string fixture values fail before listen.
+12. Real `anet demo pr-review` runs the shared reviewer fan-out, barrier,
+    judge, and Markdown renderer with deterministic replies.
+13. An unset `MOCK_LLM_REPLIES_FILE` preserves the real Hub preflight and
+    never enters mock mode.
+
+Witnessed-red mutations:
+
+- `findIndex` -> `findLastIndex`: the broad-first fixture no longer returns
+  rule 0 (`MUTATION_RED: first-match`).
+- Remove unmatched-prompt warning: stderr warning assertion fails
+  (`MUTATION_RED: fallback-warning`).
+- Force mock mode without explicit env opt-in: the unset-env real-path gate
+  fails and the missing fixture is rejected
+  (`MUTATION_RED: mock-opt-in`).
+
+Boundary:
+
+This suite proves deterministic demo orchestration and the shared mock
+protocol. It does not prove a real LLM vendor endpoint, credential, model,
+network path, or general agent runtime. Mock mode is scoped to
+`anet demo pr-review`; other commands and agent-node runtimes do not consume
+the opt-in variable.

--- a/tests/MOCK-LLM-PROTOCOL.md
+++ b/tests/MOCK-LLM-PROTOCOL.md
@@ -1,0 +1,81 @@
+# Mock LLM protocol for deterministic demos
+
+This protocol is test infrastructure. It must not be enabled by a production
+runtime implicitly. A demo or test opts in by setting
+`MOCK_LLM_REPLIES_FILE` and sending prompts to the local reference server.
+
+## Configuration
+
+```bash
+MOCK_LLM_REPLIES_FILE=/absolute/path/replies.jsonl \
+MOCK_LLM_PORT=32100 \
+bun tests/helpers/mock-llm-server.ts
+```
+
+The server binds only to `127.0.0.1`. `MOCK_LLM_REPLIES_FILE` is required;
+startup fails before listening if the file is missing, is not a regular file,
+is larger than 1 MiB, contains malformed JSON, or contains a rule with keys
+other than `in_substring` and `out`.
+
+`MOCK_LLM_PORT` is optional and defaults to `32100`. It must be an integer in
+the range 1–65535.
+
+`anet demo pr-review` also consumes this variable directly. In that mode the
+CLI skips Hub, node, and vendor setup, but runs the same reviewer fan-out,
+barrier, judge, and Markdown renderer as the real path:
+
+```bash
+MOCK_LLM_REPLIES_FILE=./demo-replies.jsonl \
+  anet demo pr-review --diff ./change.diff --out ./review.md
+```
+
+The demo prefixes each lookup prompt with its role (`reviewer-security`,
+`reviewer-performance`, `reviewer-style`, or `judge`) so a stateless fixture
+can distinguish the otherwise identical reviewer task bodies.
+
+## Rules file
+
+The file is UTF-8 JSONL. Blank lines are ignored. Each non-blank line is one
+exact rule:
+
+```json
+{"in_substring":"step-1 introduce yourself","out":"Hi, I am reviewer A."}
+{"in_substring":"step-2 yesterday","out":"Yesterday I reviewed PR 42."}
+```
+
+Both values must be non-empty strings. Rules are evaluated in file order. The
+first rule whose `in_substring` occurs in the prompt wins. Ordering is part of
+the contract, so a broad rule placed before a narrow rule intentionally wins.
+
+## HTTP surface
+
+- `GET /health` → `{ "ok": true, "rules": N }`
+- `POST /reply` with `{ "prompt": "..." }` →
+  `{ "ok": true, "reply": "...", "matched": true|false, "rule_index": number|null }`
+
+Other paths return 404. Invalid request JSON or a missing/non-string `prompt`
+returns 400.
+
+When no rule matches, the response is the exact fallback
+`(mock LLM: no rule matched)` and the server writes a warning to stderr. A
+fallback is therefore visible while still letting a demo finish.
+
+## Multi-turn behavior
+
+The resolver is deliberately stateless. It has no cursor, consumed flag, or
+per-client state. Repeating the same prompt returns the same reply, including
+under parallel use or after a server restart.
+
+Multi-turn demos encode a stable discriminator such as `step-1`, `step-2`, or
+`turn-3` in each prompt and provide one rule per discriminator. This avoids
+shared cursor races and makes every response derivable from the request plus
+the immutable rules file.
+
+## Integration boundary
+
+The HTTP server and `anet demo pr-review` use the same parser and resolver.
+They activate only when `MOCK_LLM_REPLIES_FILE` is explicitly present. Normal
+agent-node execution, non-demo commands, and an unset demo invocation continue
+to use their configured Hub and real provider. Never ship a rules file or use
+the fallback text as an automatic response to a real provider failure. This
+mock proves deterministic orchestration, not vendor credentials or reachability.

--- a/tests/helpers/mock-llm-server.ts
+++ b/tests/helpers/mock-llm-server.ts
@@ -1,0 +1,71 @@
+import {
+  MOCK_LLM_FALLBACK,
+  loadMockLlmRules,
+  resolveMockLlmReply,
+} from "../../agent-network/src/mock-llm";
+
+export { MOCK_LLM_FALLBACK, loadMockLlmRules, resolveMockLlmReply };
+
+function fail(message: string): never {
+  throw new Error(`[mock-llm] ${message}`);
+}
+
+function parsePort(raw: string | undefined): number {
+  const value = raw ?? "32100";
+  if (!/^\d+$/.test(value)) fail("MOCK_LLM_PORT must be an integer from 1 to 65535");
+  const port = Number(value);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+    fail("MOCK_LLM_PORT must be an integer from 1 to 65535");
+  }
+  return port;
+}
+
+export function startMockLlmServer(
+  env: Record<string, string | undefined> = process.env,
+): ReturnType<typeof Bun.serve> {
+  const rules = loadMockLlmRules(env.MOCK_LLM_REPLIES_FILE ?? "");
+  const port = parsePort(env.MOCK_LLM_PORT);
+
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (request.method === "GET" && url.pathname === "/health") {
+        return Response.json({ ok: true, rules: rules.length });
+      }
+      if (request.method !== "POST" || url.pathname !== "/reply") {
+        return Response.json({ ok: false, error: "not_found" }, { status: 404 });
+      }
+
+      let value: unknown;
+      try {
+        value = await request.json();
+      } catch {
+        return Response.json({ ok: false, error: "invalid_json" }, { status: 400 });
+      }
+      const prompt = (value as { prompt?: unknown } | null)?.prompt;
+      if (typeof prompt !== "string") {
+        return Response.json({ ok: false, error: "invalid_prompt" }, { status: 400 });
+      }
+
+      const result = resolveMockLlmReply(rules, prompt);
+      return Response.json({
+        ok: true,
+        reply: result.reply,
+        matched: result.matched,
+        rule_index: result.ruleIndex,
+      });
+    },
+  });
+}
+
+if (import.meta.main) {
+  try {
+    const server = startMockLlmServer();
+    console.log(`[mock-llm] listening on http://${server.hostname}:${server.port}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/tests/test28-pr-review-room/run.sh
+++ b/tests/test28-pr-review-room/run.sh
@@ -8,10 +8,9 @@
 #   - fetchPrDiff --diff path resolves a local file (good-pr.diff)
 #   - command sanely refuses unknown options / invalid diff source
 #
-# Full L0 (unit prompt assertions) + L1 (CLI input parse) + L2 (Docker E2E
-# with mock LLM) coverage waits on issue #30 (MOCK-LLM-PROTOCOL.md). When
-# that lands, extend this runner to assert against
-# expected/assertions.json structure.
+# Full deterministic fan-out/barrier/Markdown coverage uses the shared mock
+# protocol in tests/test30-mock-llm-smoke. This suite remains the structural
+# and fixture-specific smoke for the pr-review demo.
 
 set -Eeuo pipefail
 
@@ -86,4 +85,4 @@ node -e "JSON.parse(require('fs').readFileSync('$ASSERT_FILE', 'utf-8'))" \
 pass "assertions.json valid"
 
 echo ""
-echo "RESULT: PASS (structural smoke; L2 Docker E2E with mock LLM waits on issue #30)"
+echo "RESULT: PASS (structural smoke; deterministic L2 is test30-mock-llm-smoke)"

--- a/tests/test30-mock-llm-smoke/Dockerfile
+++ b/tests/test30-mock-llm-smoke/Dockerfile
@@ -1,0 +1,19 @@
+FROM oven/bun:1.3.14
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl jq \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+
+COPY tests/MOCK-LLM-PROTOCOL.md ./tests/MOCK-LLM-PROTOCOL.md
+COPY agent-network ./agent-network
+COPY tests/helpers/mock-llm-server.ts ./tests/helpers/mock-llm-server.ts
+COPY tests/test30-mock-llm-smoke ./tests/test30-mock-llm-smoke
+
+ARG SOURCE_COMMIT=unknown
+ENV TEST30_SOURCE_COMMIT=${SOURCE_COMMIT}
+RUN chmod 0755 tests/test30-mock-llm-smoke/run.sh
+ENTRYPOINT ["/workspace/tests/test30-mock-llm-smoke/run.sh"]

--- a/tests/test30-mock-llm-smoke/fixtures/demo-replies.jsonl
+++ b/tests/test30-mock-llm-smoke/fixtures/demo-replies.jsonl
@@ -1,0 +1,4 @@
+{"in_substring":"reviewer-security\n","out":"无安全问题。\n\n## 安全 issue 数: 0"}
+{"in_substring":"reviewer-performance\n","out":"无性能问题。\n\n## 性能 issue 数: 0"}
+{"in_substring":"reviewer-style\n","out":"无风格问题。\n\n## 风格 issue 数: 0"}
+{"in_substring":"judge\n","out":"**决议：** LGTM\n\n**统计：** 安全 0 处 / 性能 0 处 / 风格 0 处\n\n## 终审说明\n三个并行 reviewer 均未发现问题。"}

--- a/tests/test30-mock-llm-smoke/fixtures/duplicate-key.jsonl
+++ b/tests/test30-mock-llm-smoke/fixtures/duplicate-key.jsonl
@@ -1,0 +1,1 @@
+{"in_substring":"first","in_substring":"hidden replacement","out":"must fail"}

--- a/tests/test30-mock-llm-smoke/fixtures/invalid.jsonl
+++ b/tests/test30-mock-llm-smoke/fixtures/invalid.jsonl
@@ -1,0 +1,2 @@
+{"in_substring":"valid","out":"valid"}
+{"in_substring":"broken","out":}

--- a/tests/test30-mock-llm-smoke/fixtures/non-string.jsonl
+++ b/tests/test30-mock-llm-smoke/fixtures/non-string.jsonl
@@ -1,0 +1,1 @@
+{"in_substring":"hello","out":42}

--- a/tests/test30-mock-llm-smoke/fixtures/replies.jsonl
+++ b/tests/test30-mock-llm-smoke/fixtures/replies.jsonl
@@ -1,0 +1,4 @@
+{"in_substring":"review","out":"broad review response"}
+{"in_substring":"review security","out":"narrow response that must lose to the first rule"}
+{"in_substring":"step-1 introduce yourself","out":"Hi, I am reviewer A."}
+{"in_substring":"step-2 yesterday","out":"Yesterday I reviewed PR 42."}

--- a/tests/test30-mock-llm-smoke/fixtures/sample.diff
+++ b/tests/test30-mock-llm-smoke/fixtures/sample.diff
@@ -1,0 +1,7 @@
+diff --git a/example.ts b/example.ts
+index 1111111..2222222 100644
+--- a/example.ts
++++ b/example.ts
+@@ -1 +1 @@
+-export const value = 1;
++export const value = 2;

--- a/tests/test30-mock-llm-smoke/fixtures/unknown-key.jsonl
+++ b/tests/test30-mock-llm-smoke/fixtures/unknown-key.jsonl
@@ -1,0 +1,1 @@
+{"in_substring":"hello","out":"hi","unexpected":"must fail"}

--- a/tests/test30-mock-llm-smoke/run.sh
+++ b/tests/test30-mock-llm-smoke/run.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=/workspace
+SERVER=$ROOT/tests/helpers/mock-llm-server.ts
+MOCK_MODULE=$ROOT/agent-network/src/mock-llm.ts
+FIXTURES=$ROOT/tests/test30-mock-llm-smoke/fixtures
+PORT=32130
+PASS=0
+FAIL=0
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT=$ARTIFACT_DIR/report-test30-mock-llm-protocol.txt
+
+mkdir -p "$ARTIFACT_DIR"
+exec > >(tee "$REPORT") 2>&1
+
+pass() { PASS=$((PASS + 1)); echo "PASS: $*"; }
+fail() { FAIL=$((FAIL + 1)); echo "FAIL: $*"; }
+finish() {
+  if [[ -n "${server_pid:-}" ]] && kill -0 "$server_pid" 2>/dev/null; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+}
+trap finish EXIT
+
+echo "# test30 — deterministic mock LLM protocol"
+echo "source_commit=${TEST30_SOURCE_COMMIT:-unknown}"
+
+(cd "$ROOT/agent-network" && bun run typecheck >/tmp/test30.typecheck 2>&1) \
+  && pass "agent-network typecheck" || { cat /tmp/test30.typecheck; fail "agent-network typecheck"; }
+
+start_server() {
+  : > /tmp/test30.stdout
+  : > /tmp/test30.stderr
+  MOCK_LLM_REPLIES_FILE=$FIXTURES/replies.jsonl MOCK_LLM_PORT=$PORT \
+    bun "$SERVER" >/tmp/test30.stdout 2>/tmp/test30.stderr &
+  server_pid=$!
+  for _ in $(seq 1 50); do
+    curl -fsS "http://127.0.0.1:$PORT/health" >/tmp/test30.health && return 0
+    sleep 0.1
+  done
+  cat /tmp/test30.stdout /tmp/test30.stderr
+  return 1
+}
+
+reply() {
+  curl -fsS -H 'Content-Type: application/json' \
+    --data "$(jq -cn --arg prompt "$1" '{prompt:$prompt}')" \
+    "http://127.0.0.1:$PORT/reply"
+}
+
+start_server
+jq -e '.ok == true and .rules == 4' /tmp/test30.health >/dev/null && pass "health exposes immutable rule count" || fail "health"
+
+first=$(reply 'please review security now')
+jq -e '.matched == true and .rule_index == 0 and .reply == "broad review response"' <<<"$first" >/dev/null \
+  && pass "first matching rule wins" || fail "first match"
+
+step_a=$(reply 'step-1 introduce yourself')
+step_b=$(reply 'step-2 yesterday')
+jq -e '.reply == "Hi, I am reviewer A."' <<<"$step_a" >/dev/null \
+  && jq -e '.reply == "Yesterday I reviewed PR 42."' <<<"$step_b" >/dev/null \
+  && pass "step discriminators support multi-turn fixtures" || fail "step fixtures"
+
+repeat_a=$(reply 'step-1 introduce yourself')
+repeat_b=$(reply 'step-1 introduce yourself')
+[[ "$repeat_a" == "$repeat_b" ]] && pass "repeated prompt is stateless and deterministic" || fail "stateless repeat"
+
+fallback=$(reply 'no fixture matches this prompt')
+jq -e '.matched == false and .rule_index == null and .reply == "(mock LLM: no rule matched)"' <<<"$fallback" >/dev/null \
+  && grep -Fq '[mock-llm] warning: no rule matched prompt' /tmp/test30.stderr \
+  && pass "unmatched prompt returns fallback and warns" || fail "fallback warning"
+
+bad_status=$(curl -sS -o /tmp/test30.bad -w '%{http_code}' -H 'Content-Type: application/json' --data '{' "http://127.0.0.1:$PORT/reply")
+[[ "$bad_status" == 400 ]] && jq -e '.error == "invalid_json"' /tmp/test30.bad >/dev/null \
+  && pass "invalid request JSON fails closed" || fail "invalid request"
+
+kill "$server_pid"
+wait "$server_pid" || true
+unset server_pid
+
+set +e
+MOCK_LLM_REPLIES_FILE=$FIXTURES/invalid.jsonl MOCK_LLM_PORT=$PORT bun "$SERVER" >/tmp/test30.invalid.out 2>/tmp/test30.invalid.err
+invalid_rc=$?
+set -e
+[[ "$invalid_rc" -ne 0 ]] && grep -Fq 'invalid JSON on line 2' /tmp/test30.invalid.err \
+  && pass "malformed rules fail before listen" || fail "malformed rules"
+
+set +e
+MOCK_LLM_REPLIES_FILE=$FIXTURES/unknown-key.jsonl MOCK_LLM_PORT=$PORT bun "$SERVER" >/tmp/test30.schema.out 2>/tmp/test30.schema.err
+schema_rc=$?
+set -e
+[[ "$schema_rc" -ne 0 ]] && grep -Fq 'must contain exactly one in_substring and one out' /tmp/test30.schema.err \
+  && pass "unknown rule keys fail before listen" || fail "unknown rule keys"
+
+set +e
+MOCK_LLM_REPLIES_FILE=$FIXTURES/duplicate-key.jsonl MOCK_LLM_PORT=$PORT bun "$SERVER" >/tmp/test30.duplicate.out 2>/tmp/test30.duplicate.err
+duplicate_rc=$?
+MOCK_LLM_REPLIES_FILE=$FIXTURES/non-string.jsonl MOCK_LLM_PORT=$PORT bun "$SERVER" >/tmp/test30.type.out 2>/tmp/test30.type.err
+type_rc=$?
+set -e
+[[ "$duplicate_rc" -ne 0 ]] && grep -Fq 'must contain exactly one in_substring and one out' /tmp/test30.duplicate.err \
+  && pass "duplicate rule keys fail before listen" || fail "duplicate rule keys"
+[[ "$type_rc" -ne 0 ]] && grep -Fq 'out must be a non-empty string' /tmp/test30.type.err \
+  && pass "non-string rule values fail before listen" || fail "non-string rule values"
+
+echo "L1 real demo orchestration with deterministic replies"
+demo_home=/tmp/test30-demo-home
+mkdir -p "$demo_home"
+MOCK_LLM_REPLIES_FILE=$FIXTURES/demo-replies.jsonl HOME=$demo_home \
+  bun "$ROOT/agent-network/bin/cli.ts" demo pr-review \
+    --diff "$FIXTURES/sample.diff" --suffix mock30 --out /tmp/test30-review.md \
+    >/tmp/test30.demo.out 2>/tmp/test30.demo.err
+grep -Fq '[3/6] 广播 review task 给 3 reviewer (parallel)' /tmp/test30.demo.out \
+  && grep -Fq '[4/6] barrier 收齐 3 份 review' /tmp/test30.demo.out \
+  && grep -Fq '[6/6] 写入 review' /tmp/test30.demo.out \
+  && grep -Fq '**决议：** LGTM' /tmp/test30-review.md \
+  && grep -Fq '无安全问题。' /tmp/test30-review.md \
+  && grep -Fq '无性能问题。' /tmp/test30-review.md \
+  && grep -Fq '无风格问题。' /tmp/test30-review.md \
+  && pass "real pr-review fan-out, barrier, and markdown use deterministic replies" \
+  || fail "real demo orchestration"
+
+env -u MOCK_LLM_REPLIES_FILE HOME=$demo_home \
+  bun "$ROOT/agent-network/bin/cli.ts" demo pr-review \
+    --diff "$FIXTURES/sample.diff" --suffix real30 --out /tmp/test30-real.md \
+    >/tmp/test30.real.out 2>/tmp/test30.real.err
+grep -Fq "没有 hub" /tmp/test30.real.err \
+  && ! grep -Fq '使用确定性 mock LLM' /tmp/test30.real.out \
+  && [[ ! -e /tmp/test30-real.md ]] \
+  && pass "unset mock env preserves the real Hub preflight" \
+  || fail "unset env fail-safe"
+
+echo "L2 witnessed-red: first-match ordering is load-bearing"
+cp "$MOCK_MODULE" /tmp/test30.module.orig
+sed -i 's/rules\.findIndex((rule) => prompt\.includes(rule\.in_substring))/rules.findLastIndex((rule) => prompt.includes(rule.in_substring))/' "$MOCK_MODULE"
+if cmp -s "$MOCK_MODULE" /tmp/test30.module.orig; then
+  echo "MUTATION_NOOP: first-match"
+  exit 1
+fi
+start_server
+mutated=$(reply 'please review security now')
+if jq -e '.rule_index == 0 and .reply == "broad review response"' <<<"$mutated" >/dev/null; then
+  echo "MUTATION_FALSE_GREEN: first-match"
+  exit 1
+fi
+echo "MUTATION_RED: first-match"
+kill "$server_pid"
+wait "$server_pid" || true
+unset server_pid
+cp /tmp/test30.module.orig "$MOCK_MODULE"
+
+echo "L3 witnessed-red: fallback warning is load-bearing"
+sed -i '/warn(`\[mock-llm\] warning: no rule matched prompt/d' "$MOCK_MODULE"
+if cmp -s "$MOCK_MODULE" /tmp/test30.module.orig; then
+  echo "MUTATION_NOOP: fallback-warning"
+  exit 1
+fi
+start_server
+reply 'still unmatched' >/tmp/test30.mut-fallback
+if grep -Fq '[mock-llm] warning: no rule matched prompt' /tmp/test30.stderr; then
+  echo "MUTATION_FALSE_GREEN: fallback-warning"
+  exit 1
+fi
+echo "MUTATION_RED: fallback-warning"
+kill "$server_pid"
+wait "$server_pid" || true
+unset server_pid
+cp /tmp/test30.module.orig "$MOCK_MODULE"
+
+echo "L4 witnessed-red: removing the explicit opt-in gate cannot pass"
+CLI=$ROOT/agent-network/bin/cli.ts
+cp "$CLI" /tmp/test30.cli.orig
+sed -i 's/const mockMode = Object\.prototype\.hasOwnProperty\.call(process\.env, "MOCK_LLM_REPLIES_FILE");/const mockMode = true;/' "$CLI"
+if cmp -s "$CLI" /tmp/test30.cli.orig; then
+  echo "MUTATION_NOOP: mock-opt-in"
+  exit 1
+fi
+set +e
+env -u MOCK_LLM_REPLIES_FILE HOME=$demo_home \
+  bun "$CLI" demo pr-review --diff "$FIXTURES/sample.diff" --suffix mutated30 --out /tmp/test30-mutated.md \
+  >/tmp/test30.mut-optin.out 2>/tmp/test30.mut-optin.err
+mut_optin_rc=$?
+set -e
+if [[ "$mut_optin_rc" -eq 0 ]] || grep -Fq "没有 hub" /tmp/test30.mut-optin.err; then
+  echo "MUTATION_FALSE_GREEN: mock-opt-in"
+  exit 1
+fi
+grep -Fq 'MOCK_LLM_REPLIES_FILE is required' /tmp/test30.mut-optin.err
+echo "MUTATION_RED: mock-opt-in"
+cp /tmp/test30.cli.orig "$CLI"
+
+echo "RESULT: PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #30.

Adds a shared fail-closed JSONL mock LLM parser, a localhost reference server, and a deterministic `anet demo pr-review` seam that keeps the real fan-out/barrier/judge/Markdown orchestration while replacing only LLM replies.

Verification:
- exact source `ec7f1b52592fe4442b73c043e2818a4ab4e922b4`
- report-only head `15b1b56134ccfce5cd23527c663ba67ffef8f409`
- Docker `13/0`
- witnessed-red mutations: first-match order, fallback warning, explicit env opt-in
- unset env preserves the real Hub preflight

No publish or deployment is included.