### PR TITLE
feat(hub): add task runtime evidence levels

### DIFF
--- a/docs-site/docs/api/mcp-tools.md
+++ b/docs-site/docs/api/mcp-tools.md
@@ -511,8 +511,10 @@ send_task({
       "status": "replied",
       "content": "写排序算法",
       "result": "使用快排实现...",
-      "created_at": "2026-04-12 10:00:00",
-      "completed_at": "2026-04-12 10:00:15"
+    "created_at": "2026-04-12 10:00:00",
+    "runtime_submitted_at": "2026-04-12 10:00:03",
+    "consumed_at": "2026-04-12 10:00:04",
+    "completed_at": "2026-04-12 10:00:15"
     }
   ],
   "count": 1,
@@ -525,7 +527,7 @@ send_task({
 ```
 
 ::: tip `list_tasks` 的行是 `get_task` 的子集
-`list_tasks` 每行只 SELECT **9 列**（[`tools.ts:776`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L776)）：`task_id` / `from_name` / `to_name` / `priority` / `status` / `content` / `result` / `created_at` / `completed_at`。**不含** `delivered_at` / `started_at` / `expires_at` / `network_id` / `requires_response` / `parent_task_id` —— 要这些字段用 [`get_task`](#get-task)（`SELECT *`）。`count` 是本次返回的行数（≤ `limit`），`stats` 是**整个 scope 内**按 status 分组的计数（不受 filter 影响）。
+`list_tasks` 每行包含任务身份、收发方、状态、内容/结果和时间摘要。`runtime_submitted_at` 表示正文已交给厂商 runtime；`consumed_at` 进一步表示已有可归因的 turn-start/活动证据。**不含** `delivered_at` / `started_at` / `expires_at` / `network_id` / `requires_response` / `parent_task_id` —— 要这些字段用 [`get_task`](#get-task)（`SELECT *`）。`count` 是本次返回的行数（≤ `limit`），`stats` 是**整个 scope 内**按 status 分组的计数（不受 filter 影响）。两级证据与旧字段的语义区别见 [Task 生命周期](/concepts/task-lifecycle#runtime_submitted_at-与-consumed_at两级运行时证据)。
 :::
 
 ---

--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -588,6 +588,8 @@ curl "http://localhost:9200/api/tasks?status=running&limit=10" \
       "created_at": "2026-04-12 10:00:00",
       "delivered_at": "2026-04-12 10:00:01",
       "started_at": "2026-04-12 10:00:02",
+      "runtime_submitted_at": "2026-04-12 10:00:03",
+      "consumed_at": "2026-04-12 10:00:04",
       "completed_at": "2026-04-12 10:00:15",
       "expires_at": "2026-04-12 11:00:00"
     }
@@ -600,7 +602,7 @@ curl "http://localhost:9200/api/tasks?status=running&limit=10" \
 }
 ```
 
-字段对照 `tasks` 表 schema ([`server/src/db.ts:87-105`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L87)) `SELECT *`：主键是 `task_id` 不是 `message_id`；任务完成时间字段是 `completed_at` 不是 `replied_at`；TTL 字段是 `expires_at` 绝对时间不是 `ttl_seconds` 相对秒（`ttl_seconds` 仅 send_task **入参**用，写入时算成 `expires_at`）。`anet tasks` CLI 用 `from_name` / `to_name` / `status` / `created_at` / `content` 渲染表格 (cli.ts L2810-2817)。
+字段对照 `tasks` 表 schema ([`server/src/db.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts))：主键是 `task_id` 不是 `message_id`；任务完成时间字段是 `completed_at` 不是 `replied_at`；TTL 字段是 `expires_at` 绝对时间不是 `ttl_seconds` 相对秒（`ttl_seconds` 仅 send_task **入参**用，写入时算成 `expires_at`）。`runtime_submitted_at` / `consumed_at` 是 token-bound agent-node 写入的两级运行时证据，和入队 `delivered_at`、进程 ACK、兼容 `started_at` 不同；详见 [Task 生命周期](/concepts/task-lifecycle#runtime_submitted_at-与-consumed_at两级运行时证据)。`anet tasks` CLI 用 `from_name` / `to_name` / `status` / `created_at` / `content` 渲染表格。
 
 ---
 

--- a/docs-site/docs/concepts/task-lifecycle.md
+++ b/docs-site/docs/concepts/task-lifecycle.md
@@ -52,6 +52,18 @@ stateDiagram-v2
 | `cancelled` | 已取消 | `cancel_task` | 可重试 |
 | `expired` | TTL 超时 | 自动检测 | 可重试 |
 
+### `runtime_submitted_at` 与 `consumed_at`：两级运行时证据
+
+状态字段和消费证据是两条不同的轴。`delivered_at` 只证明 Hub 已把任务写入投递队列，`acked` 只证明常驻的 agent-node 进程取走了 inbox 行；二者都不能证明模型轮次已经开始。`started_at` 由兼容的 `report_status(working)` 路径维护，可能早于厂商运行时真正接手任务，因此不能单独用于判断“节点已唤醒模型”。
+
+`runtime_submitted_at` 表示 agent-node 已把正文交给厂商 runtime（例如发出 prompt/turn 请求或写入受控共存会话），但尚不承诺模型已经开始推理。`consumed_at` 是更强的、只写一次的证据：agent-node 只有在当前 `task_id` 能归因到厂商运行时的 turn-start 或第一条活动事件后，才用自身 token-bound 身份上报。任务仍在 agent-node 本地队列中、仅完成 ACK、或进程在线但正文尚未交给 runtime 时，两个字段都保持 `null`；已经提交但尚无权威活动时只有 `runtime_submitted_at` 有值。重试或转派会同时清空它们，等待新一轮证据。
+
+不同运行时可提供的最早可靠信号不同；例如 Codex app-server 使用精确 `task_started`，Grok 共存桥使用精确匹配当前网络任务的 `network_user` 事件，而缺少可归因 start 事件的 OpenCode 共存模式要等到精确关联的 assistant response。后者更晚，但不会把“已入队”误报成“模型已接手”。
+
+::: warning 不要用 `sessions.task` 判断模型是否已接手
+兼容字段 `sessions.task` 同时会被派单路径写入任务原文、也会被节点的 `report_status(task=...)` 写入，并可能保留历史值。它是一个旧版展示字段，不是当前模型轮次的身份或消费确认。逐任务诊断请读取 `tasks.runtime_submitted_at` / `tasks.consumed_at`；节点存活只看心跳字段。
+:::
+
 ### 终态（Terminal States）
 
 以下状态是终态，不能再变更（除了 retry）：
@@ -82,6 +94,11 @@ sequenceDiagram
 
     A->>S: report_status(status="working", task="写排序算法")
     Note over S: 状态: acked → running
+
+    A->>S: mark_tasks_runtime_submitted(task_ids=["t_xxx"])
+    Note over S: runtime_submitted_at 首次写入
+    A->>S: mark_tasks_consumed(task_ids=["t_xxx"])
+    Note over S: consumed_at 首次写入（token-bound + 精确 task_id）
 
     Note over A: AI 处理中...
 
@@ -153,7 +170,7 @@ retry_task(task_id="t_xxx")
 
 1. 验证任务状态为 `failed` / `cancelled` / `expired`
 2. 重置任务状态为 `delivered`
-3. 清除 result、completed_at、started_at
+3. 清除 result、completed_at、started_at、runtime_submitted_at、consumed_at
 4. 重设 expires_at（+1 小时）
 5. 创建新的 inbox 条目
 6. SSE 推送 new_task

--- a/docs-site/docs/concepts/task-lifecycle.md
+++ b/docs-site/docs/concepts/task-lifecycle.md
@@ -56,7 +56,7 @@ stateDiagram-v2
 
 状态字段和消费证据是两条不同的轴。`delivered_at` 只证明 Hub 已把任务写入投递队列，`acked` 只证明常驻的 agent-node 进程取走了 inbox 行；二者都不能证明模型轮次已经开始。`started_at` 由兼容的 `report_status(working)` 路径维护，可能早于厂商运行时真正接手任务，因此不能单独用于判断“节点已唤醒模型”。
 
-`runtime_submitted_at` 表示 agent-node 已把正文交给厂商 runtime（例如发出 prompt/turn 请求或写入受控共存会话），但尚不承诺模型已经开始推理。`consumed_at` 是更强的、只写一次的证据：agent-node 只有在当前 `task_id` 能归因到厂商运行时的 turn-start 或第一条活动事件后，才用自身 token-bound 身份上报。任务仍在 agent-node 本地队列中、仅完成 ACK、或进程在线但正文尚未交给 runtime 时，两个字段都保持 `null`；已经提交但尚无权威活动时只有 `runtime_submitted_at` 有值。重试或转派会同时清空它们，等待新一轮证据。
+`runtime_submitted_at` 表示 agent-node 已把正文交给厂商 runtime（例如发出 prompt/turn 请求或写入受控共存会话），但尚不承诺模型已经开始推理。`consumed_at` 是更强的、只写一次的证据：agent-node 只有在当前 `task_id` 能归因到厂商运行时的 turn-start 或第一条活动事件后，才用自身 token-bound 身份上报。任务仍在 agent-node 本地队列中、仅完成 ACK、或进程在线但正文尚未交给 runtime 时，两个字段都保持 `null`；已经提交但尚无权威活动时只有 `runtime_submitted_at` 有值。两者是逻辑任务全生命周期的单调证据；重试或转派会保留已有值。新的 inbox 投递行通过 `task_id` 继续关联原逻辑任务，避免把延迟回调误认成另一个任务或丢掉已发生的事实。
 
 不同运行时可提供的最早可靠信号不同；例如 Codex app-server 使用精确 `task_started`，Grok 共存桥使用精确匹配当前网络任务的 `network_user` 事件，而缺少可归因 start 事件的 OpenCode 共存模式要等到精确关联的 assistant response。后者更晚，但不会把“已入队”误报成“模型已接手”。
 
@@ -170,9 +170,9 @@ retry_task(task_id="t_xxx")
 
 1. 验证任务状态为 `failed` / `cancelled` / `expired`
 2. 重置任务状态为 `delivered`
-3. 清除 result、completed_at、started_at、runtime_submitted_at、consumed_at
+3. 清除 result、completed_at、started_at；保留逻辑任务全生命周期的 runtime_submitted_at、consumed_at
 4. 重设 expires_at（+1 小时）
-5. 创建新的 inbox 条目
+5. 创建新的 inbox 条目，并用 task_id 关联原逻辑任务
 6. SSE 推送 new_task
 
 ```mermaid

--- a/docs-site/docs/en/api/mcp-tools.md
+++ b/docs-site/docs/en/api/mcp-tools.md
@@ -511,8 +511,10 @@ Query task list with multi-dimensional filtering.
       "status": "replied",
       "content": "Write a sorting algorithm",
       "result": "Implemented with quicksort...",
-      "created_at": "2026-04-12 10:00:00",
-      "completed_at": "2026-04-12 10:00:15"
+    "created_at": "2026-04-12 10:00:00",
+    "runtime_submitted_at": "2026-04-12 10:00:03",
+    "consumed_at": "2026-04-12 10:00:04",
+    "completed_at": "2026-04-12 10:00:15"
     }
   ],
   "count": 1,
@@ -525,7 +527,7 @@ Query task list with multi-dimensional filtering.
 ```
 
 ::: tip `list_tasks` rows are a subset of `get_task`
-Each `list_tasks` row SELECTs only **9 columns** ([`tools.ts:776`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L776)): `task_id` / `from_name` / `to_name` / `priority` / `status` / `content` / `result` / `created_at` / `completed_at`. It does **not** include `delivered_at` / `started_at` / `expires_at` / `network_id` / `requires_response` / `parent_task_id` — use [`get_task`](#get-task) (`SELECT *`) for those. `count` is the number of rows returned this call (≤ `limit`); `stats` is the status-grouped count for the **entire scope** (not affected by the filters).
+Each `list_tasks` row includes task identity, sender/recipient, status, content/result, and summary timestamps. `runtime_submitted_at` means the body was handed to the vendor runtime; `consumed_at` additionally requires attributable turn-start/activity evidence. It does **not** include `delivered_at` / `started_at` / `expires_at` / `network_id` / `requires_response` / `parent_task_id` — use [`get_task`](#get-task) (`SELECT *`) for those. `count` is the number of rows returned this call (≤ `limit`); `stats` is the status-grouped count for the **entire scope** (not affected by the filters). See [Task lifecycle](/en/concepts/task-lifecycle#runtime_submitted_at-and-consumed_at-two-runtime-evidence-levels) for the distinction from legacy fields.
 :::
 
 ---

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -588,6 +588,8 @@ curl "http://localhost:9200/api/tasks?status=running&limit=10" \
       "created_at": "2026-04-12 10:00:00",
       "delivered_at": "2026-04-12 10:00:01",
       "started_at": "2026-04-12 10:00:02",
+      "runtime_submitted_at": "2026-04-12 10:00:03",
+      "consumed_at": "2026-04-12 10:00:04",
       "completed_at": "2026-04-12 10:00:15",
       "expires_at": "2026-04-12 11:00:00"
     }
@@ -600,7 +602,7 @@ curl "http://localhost:9200/api/tasks?status=running&limit=10" \
 }
 ```
 
-Field mapping to the `tasks` table schema ([`server/src/db.ts:87-105`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L87)) via `SELECT *`: the primary key is `task_id` (not `message_id`); the completion timestamp is `completed_at` (not `replied_at`); the TTL field is `expires_at` (an absolute timestamp), not `ttl_seconds` — `ttl_seconds` is **input-only** on `send_task` and converted to `expires_at` when the row is written. The `anet tasks` CLI uses `from_name` / `to_name` / `status` / `created_at` / `content` to render the table (cli.ts L2810-2817).
+Field mapping follows the `tasks` table schema ([`server/src/db.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts)): the primary key is `task_id` (not `message_id`); the completion timestamp is `completed_at` (not `replied_at`); the TTL field is `expires_at` (an absolute timestamp), not `ttl_seconds` — `ttl_seconds` is **input-only** on `send_task` and converted to `expires_at` when the row is written. `runtime_submitted_at` / `consumed_at` are the two token-bound runtime evidence levels; they differ from queue-time `delivered_at`, process ACK, and compatibility `started_at`. See [Task lifecycle](/en/concepts/task-lifecycle#runtime_submitted_at-and-consumed_at-two-runtime-evidence-levels). The `anet tasks` CLI uses `from_name` / `to_name` / `status` / `created_at` / `content` to render the table.
 
 ---
 

--- a/docs-site/docs/en/concepts/task-lifecycle.md
+++ b/docs-site/docs/en/concepts/task-lifecycle.md
@@ -56,7 +56,7 @@ stateDiagram-v2
 
 Lifecycle status and consumption evidence are separate axes. `delivered_at` proves only that Hub wrote the task to the delivery queue, while `acked` proves only that the long-running agent-node process fetched the inbox row. Neither proves that a model turn began. `started_at` is maintained by the compatibility `report_status(working)` path and may precede the vendor runtime actually accepting the task, so it is not authoritative evidence that the model was awakened.
 
-`runtime_submitted_at` means agent-node handed the body to the vendor runtime (for example, issued a prompt/turn request or wrote it into the controlled copresence session), but it does not claim that model inference began. `consumed_at` is the stronger, write-once signal: agent-node reports it with its token-bound identity only after the current `task_id` can be attributed to a vendor turn-start or first activity event. Both remain `null` while a task is queued inside agent-node, merely acknowledged, or held by an online process that has not submitted the body. After submission but before authoritative activity, only `runtime_submitted_at` is populated. Retry and reassignment clear both so the next attempt requires fresh evidence.
+`runtime_submitted_at` means agent-node handed the body to the vendor runtime (for example, issued a prompt/turn request or wrote it into the controlled copresence session), but it does not claim that model inference began. `consumed_at` is the stronger, write-once signal: agent-node reports it with its token-bound identity only after the current `task_id` can be attributed to a vendor turn-start or first activity event. Both remain `null` while a task is queued inside agent-node, merely acknowledged, or held by an online process that has not submitted the body. After submission but before authoritative activity, only `runtime_submitted_at` is populated. Both are monotonic for the logical task lifetime; retry and reassignment preserve existing values. A fresh inbox delivery row keeps the original logical `task_id`, so delayed callbacks cannot be mistaken for another task or erase a fact that already occurred.
 
 The earliest reliable signal differs by runtime. For example, Codex app-server uses exact `task_started`, Grok copresence uses the `network_user` event matching the active network task, and OpenCode copresence—whose wire protocol lacks an attributable start event—waits for the exact linked assistant response. The last signal is later, but it never reports “model consumed” merely because the task entered a queue.
 
@@ -170,9 +170,9 @@ Retry flow:
 
 1. Verify task status is `failed` / `cancelled` / `expired`
 2. Reset task status to `delivered`
-3. Clear result, completed_at, started_at, runtime_submitted_at, consumed_at
+3. Clear result, completed_at, and started_at; preserve task-lifetime runtime_submitted_at and consumed_at
 4. Reset expires_at (+1 hour)
-5. Create a new inbox entry
+5. Create a new inbox entry linked to the original logical task_id
 6. SSE push new_task
 
 ```mermaid

--- a/docs-site/docs/en/concepts/task-lifecycle.md
+++ b/docs-site/docs/en/concepts/task-lifecycle.md
@@ -52,6 +52,18 @@ stateDiagram-v2
 | `cancelled` | Cancelled | `cancel_task` | Can be retried |
 | `expired` | TTL timeout | Auto-detected | Can be retried |
 
+### `runtime_submitted_at` and `consumed_at`: two runtime evidence levels
+
+Lifecycle status and consumption evidence are separate axes. `delivered_at` proves only that Hub wrote the task to the delivery queue, while `acked` proves only that the long-running agent-node process fetched the inbox row. Neither proves that a model turn began. `started_at` is maintained by the compatibility `report_status(working)` path and may precede the vendor runtime actually accepting the task, so it is not authoritative evidence that the model was awakened.
+
+`runtime_submitted_at` means agent-node handed the body to the vendor runtime (for example, issued a prompt/turn request or wrote it into the controlled copresence session), but it does not claim that model inference began. `consumed_at` is the stronger, write-once signal: agent-node reports it with its token-bound identity only after the current `task_id` can be attributed to a vendor turn-start or first activity event. Both remain `null` while a task is queued inside agent-node, merely acknowledged, or held by an online process that has not submitted the body. After submission but before authoritative activity, only `runtime_submitted_at` is populated. Retry and reassignment clear both so the next attempt requires fresh evidence.
+
+The earliest reliable signal differs by runtime. For example, Codex app-server uses exact `task_started`, Grok copresence uses the `network_user` event matching the active network task, and OpenCode copresence—whose wire protocol lacks an attributable start event—waits for the exact linked assistant response. The last signal is later, but it never reports “model consumed” merely because the task entered a queue.
+
+::: warning Do not use `sessions.task` as model-consumption evidence
+The compatibility `sessions.task` field is written both by dispatch (with the sender's task text) and by the node's `report_status(task=...)`, and it may retain historical text. It is a legacy display field, not the identity of the current model turn or a delivery acknowledgement. Use `tasks.runtime_submitted_at` / `tasks.consumed_at` for per-task diagnosis and heartbeat fields only for process liveness.
+:::
+
 ### Terminal States
 
 The following states are terminal and cannot change (except via retry):
@@ -82,6 +94,11 @@ sequenceDiagram
 
     A->>S: report_status(status="working", task="Write a sorting algorithm")
     Note over S: Status: acked → running
+
+    A->>S: mark_tasks_runtime_submitted(task_ids=["t_xxx"])
+    Note over S: runtime_submitted_at is set once
+    A->>S: mark_tasks_consumed(task_ids=["t_xxx"])
+    Note over S: consumed_at is set once (token-bound + exact task_id)
 
     Note over A: AI processing...
 
@@ -153,7 +170,7 @@ Retry flow:
 
 1. Verify task status is `failed` / `cancelled` / `expired`
 2. Reset task status to `delivered`
-3. Clear result, completed_at, started_at
+3. Clear result, completed_at, started_at, runtime_submitted_at, consumed_at
 4. Reset expires_at (+1 hour)
 5. Create a new inbox entry
 6. SSE push new_task

--- a/docs/rfcs/RFC-035-task-runtime-evidence.md
+++ b/docs/rfcs/RFC-035-task-runtime-evidence.md
@@ -21,7 +21,7 @@ must not be collapsed into one optimistic timestamp.
 
 ## Decision
 
-Add two nullable, attempt-scoped columns to `tasks`:
+Add two nullable, task-lifetime columns to `tasks`:
 
 - `runtime_submitted_at`: agent-node handed this exact task body to the vendor
   runtime. This may be set at a prompt/turn request or controlled copresence
@@ -30,10 +30,18 @@ Add two nullable, attempt-scoped columns to `tasks`:
   attributable activity signal for this exact task. A consumed mark also fills
   `runtime_submitted_at`, because consumption implies submission.
 
-Both fields are monotonic within one delivery attempt (`COALESCE(existing,
-now)`). `retry_task` and `reassign_task` clear both. Existing lifecycle status,
-`delivered_at`, `started_at`, and `sessions.task` retain their old semantics for
-backward compatibility.
+Both fields are monotonic for the lifetime of the logical task
+(`COALESCE(existing, now)`). `retry_task` and `reassign_task` preserve them:
+issue #520 asks whether this logical task ever crossed each runtime boundary,
+and a delayed callback from an earlier delivery must never overwrite or erase
+that fact. Existing lifecycle status, `delivered_at`, `started_at`, and
+`sessions.task` retain their old semantics for backward compatibility.
+
+Transport-row identity is separate from logical-task identity. Initial
+deliveries historically used `inbox.id == tasks.task_id`; retry/reassign create
+a fresh `inbox.id`. The additive nullable `inbox.task_id` column links every
+redelivery back to the logical task. `get_inbox` exposes that logical `task_id`
+for task rows, while ACK/cancel/reassign use the same linkage.
 
 ## Hub write boundary
 
@@ -47,10 +55,13 @@ Both tools:
 1. require a network-bound node token (`ntok_`);
 2. derive network, canonical alias, and immutable `node_id` from authenticated
    server state—not request fields;
-3. preflight every task and require `tasks.to_node_id` to equal that node;
+3. preflight every task and require `tasks.to_node_id` to equal that node when
+   present; legacy/direct token-bound tasks with `to_node_id=NULL` may fall back
+   only to the authenticated canonical alias;
 4. reject a foreign/missing/duplicate member without partially marking the
    batch;
-5. write only once per attempt.
+5. keep identity preflight and all writes in one SQLite transaction, and write
+   each logical-task field only once for its lifetime.
 
 The current synchronous PostgreSQL adapter cannot keep multiple statements on
 one backend connection. Until that adapter gains real transactions, both tools
@@ -111,8 +122,11 @@ license to weaken the database evidence: a toast or log line is not
    idempotency.
 3. Batch mark multiple exact owned tasks; a mixed owned/foreign batch must
    reject with zero writes.
-4. Retry/reassign must clear both attempt-scoped timestamps.
+4. Retry/reassign must preserve both task-lifetime timestamps, expose the
+   original logical `task_id` on the fresh inbox row, and ACK that row against
+   the original task.
 5. Queue-heavy runtime fixtures must prove FIFO admission alone stays blank;
    exact start/activity must turn the corresponding field green once.
-6. Mutating any identity check, attempt reset, or exact runtime callback must
+6. Mutating any identity check, logical-task linkage, monotonic preservation,
+   or exact runtime callback must
    turn a behavioral test red.

--- a/docs/rfcs/RFC-035-task-runtime-evidence.md
+++ b/docs/rfcs/RFC-035-task-runtime-evidence.md
@@ -1,0 +1,118 @@
+# RFC-035 — Task runtime evidence (`runtime_submitted_at` / `consumed_at`)
+
+Status: implementation candidate for issue #520
+Scope: additive Hub schema/API first; agent-node runtime wiring follows after the concurrent image-delivery change lands
+
+## Problem
+
+The existing task/session fields answer weaker questions than their names suggest:
+
+| Signal | What it actually proves |
+|---|---|
+| `delivered_at` | Hub enqueued the task |
+| `status=acked` | the long-running agent-node process fetched the inbox row |
+| `last_seen_at` | the process sent a heartbeat |
+| `started_at` | the compatibility `report_status(working)`/content-match path ran |
+| `sessions.task` | a legacy union of sender dispatch echo and node self-report; it may be stale |
+
+None proves that the task body reached a vendor runtime, or that the runtime
+actually started the corresponding model turn. Those are different facts and
+must not be collapsed into one optimistic timestamp.
+
+## Decision
+
+Add two nullable, attempt-scoped columns to `tasks`:
+
+- `runtime_submitted_at`: agent-node handed this exact task body to the vendor
+  runtime. This may be set at a prompt/turn request or controlled copresence
+  write boundary. It does **not** claim that inference started.
+- `consumed_at`: the runtime emitted an authoritative turn-start or first
+  attributable activity signal for this exact task. A consumed mark also fills
+  `runtime_submitted_at`, because consumption implies submission.
+
+Both fields are monotonic within one delivery attempt (`COALESCE(existing,
+now)`). `retry_task` and `reassign_task` clear both. Existing lifecycle status,
+`delivered_at`, `started_at`, and `sessions.task` retain their old semantics for
+backward compatibility.
+
+## Hub write boundary
+
+Two internal MCP tools accept batches of exact task IDs:
+
+- `mark_tasks_runtime_submitted({task_ids})`
+- `mark_tasks_consumed({task_ids})`
+
+Both tools:
+
+1. require a network-bound node token (`ntok_`);
+2. derive network, canonical alias, and immutable `node_id` from authenticated
+   server state—not request fields;
+3. preflight every task and require `tasks.to_node_id` to equal that node;
+4. reject a foreign/missing/duplicate member without partially marking the
+   batch;
+5. write only once per attempt.
+
+The current synchronous PostgreSQL adapter cannot keep multiple statements on
+one backend connection. Until that adapter gains real transactions, both tools
+fail closed with `task_runtime_evidence_backend_unsupported`; production Hub is
+SQLite. This preserves the batch's all-or-nothing claim instead of silently
+publishing partial evidence.
+
+User/admin tokens cannot manufacture runtime evidence. An old Hub that lacks
+the tools leaves the additive columns `NULL`; execution remains compatible.
+
+## Runtime evidence matrix
+
+The agent-node wiring must preserve this minimum evidence strength:
+
+| Runtime | `runtime_submitted_at` | `consumed_at` |
+|---|---|---|
+| Codex app-server | exact owned turn submitted/steered | exact `task_started` after `clientUserMessageId` ownership reconciliation |
+| Grok copresence | controlled network envelope written to the owned TUI | trusted `network_user` JSONL for the active exact task |
+| OpenCode copresence | exact user message POST accepted | exact assistant response causally parented to that message (later but authoritative on pinned 1.18.1) |
+| ACP runtimes | `session/prompt` issued for the exact task | first notification after the prompt boundary, or its terminal response |
+| Claude/Codex SDK | exact query/stream request created | first yielded event from that request |
+| CLI runtimes | prompt-bearing child request started | first protocol event attributable to that invocation |
+
+If a runtime lacks an authoritative attributable activity signal, it must leave
+`consumed_at=NULL`. Process entry, inbox ACK, local FIFO admission, generic PTY
+write, heartbeat, or a different concurrent turn are forbidden substitutes.
+
+## Read semantics
+
+REST task projections, `get_task`, and `list_tasks` expose both columns. The
+four useful states are:
+
+| submitted | consumed | Meaning |
+|---:|---:|---|
+| `NULL` | `NULL` | still before the vendor runtime boundary (possibly queued locally) |
+| time | `NULL` | handed to runtime, but no authoritative turn activity yet |
+| time | time | exact runtime activity was observed |
+| `NULL` | time | invalid state; Hub's consumed tool prevents this |
+
+These timestamps do not declare success, progress, or health. A consumed task
+can still run for a long time, fail, or time out. A queue timeout is likewise a
+waiting-window result, not proof of node failure.
+
+## Human-visible traces
+
+The two fields make Dashboard/API diagnosis unambiguous. Copresence runtimes
+should additionally show queued/submitted/started traces in the shared human
+surface where their upstream UI has a safe notification lane. That UX is not a
+license to weaken the database evidence: a toast or log line is not
+`consumed_at`.
+
+## Verification requirements
+
+1. Explicitly construct “process connected + inbox ACK + model not awakened”
+   and assert both fields remain `NULL` while the legacy `sessions.task` echo is
+   already populated and `last_seen_at` is unchanged.
+2. Mark submitted without consumed, then mark consumed; prove ordering and
+   idempotency.
+3. Batch mark multiple exact owned tasks; a mixed owned/foreign batch must
+   reject with zero writes.
+4. Retry/reassign must clear both attempt-scoped timestamps.
+5. Queue-heavy runtime fixtures must prove FIFO admission alone stays blank;
+   exact start/activity must turn the corresponding field green once.
+6. Mutating any identity check, attempt reset, or exact runtime callback must
+   turn a behavioral test red.

--- a/docs/tests/report-test671-task-runtime-evidence-hub.txt
+++ b/docs/tests/report-test671-task-runtime-evidence-hub.txt
@@ -5,10 +5,10 @@ Date: 2026-08-10 (Asia/Shanghai)
 ## Provenance
 
 - Base: `51bdb84a417c9a2a1fd8f07f871e307e50da80a5`
-- Tested source: `727564d800d5a72ed56e5f8c707aced41fd6b614`
+- Tested source: `7aabeb796800568d646133631258fc68e7b960ba`
 - Docker tag: `anet-test671:dev` (fixed/reused tag)
-- Docker image ID: `sha256:54174ae5dc8eb1d2dc8883c18f36f0a2a62b6d1065e617bfbd1a1a34048966f0`
-- Embedded image environment: `TEST671_SOURCE_COMMIT=727564d800d5a72ed56e5f8c707aced41fd6b614`
+- Docker image ID: `sha256:e3e8764e3834ae8c7f607b4d2d20ed2409c79bff37e9701c3a5207f3fcf05209`
+- Embedded image environment: `TEST671_SOURCE_COMMIT=7aabeb796800568d646133631258fc68e7b960ba`
 
 An earlier image used a manually expanded, nonexistent SHA and is invalid evidence. It was discarded and the fixed tag was rebuilt from the exact value returned by `git rev-parse HEAD`; only the image and results above count.
 
@@ -21,6 +21,7 @@ This layer covers the Hub half of issue #520 only:
 - atomic all-or-nothing batch ownership checks;
 - task-lifetime monotonic evidence preserved through retry/reassignment;
 - explicit `inbox.task_id` linkage across MCP, REST, scheduler, retry, and reassignment delivery paths;
+- a denominator gate that enumerates all five production task-inbox INSERT paths and rejects any path without `task_id`;
 - logical-task ACK for new consumers plus exact `inbox.id` compatibility for old consumers;
 - immutable node ownership with a canonical-alias fallback only for legacy/direct tasks whose `to_node_id` is NULL;
 - REST/tool projections and bilingual lifecycle documentation;
@@ -33,7 +34,7 @@ Agent runtime wiring is deliberately excluded from this candidate layer while th
 Command:
 
 ```sh
-sg docker -c 'docker run --rm -v /tmp/test671-727564-e40sgZ:/artifacts anet-test671:dev'
+sg docker -c 'docker run --rm -v /tmp/test671-7aabeb-ZA8Fq0:/artifacts anet-test671:dev'
 ```
 
 Result:
@@ -42,7 +43,7 @@ Result:
 - `server/src/task-auth-origin-http.test.ts`: 2 tests passed, 8 assertions passed;
 - production Hub bundle built successfully;
 - RFC and Chinese/English field-boundary documentation checks passed;
-- suite summary: `RESULT pass=13 fail=0`.
+- suite summary: `RESULT pass=14 fail=0`.
 
 The behavior tests establish that connection, enqueue, delivery, ACK, and the legacy `sessions.task` preview leave both evidence fields NULL; runtime submission marks only `runtime_submitted_at`; authoritative consumption marks both fields; duplicate reports are idempotent; foreign/missing mixed batches write nothing; user tokens cannot report evidence; legacy/direct NULL-node tasks remain usable only through their authenticated canonical alias; and MCP, REST, scheduler, retry, and reassignment deliveries expose the original logical task ID. Retry/reassignment preserve task-lifetime evidence while fresh transport rows continue to ACK and report against that logical task.
 
@@ -52,18 +53,18 @@ Each mutation changed the tested implementation and made the behavior suite fail
 
 | Mutation | Artifact SHA256 |
 | --- | --- |
-| Remove immutable node ownership enforcement | `a1e7a4a0164b8dae753abbe74db43c49eee1579252ab137ed606975e24ad1df6` |
-| Remove legacy/direct canonical-alias ownership | `132d150012da0d66c19c44fd23bbf83b4da46e7ada12c94cb95b236aea0589ab` |
-| Collapse runtime submission into consumption | `70cd1e3c4be9eda72118412b1effa550fbb66f6698dd344516a218d2d76385de` |
-| Stop consumption from implying submission | `5e82a49082336dfca363d39b706c8795bf04eaecc9925a3ef6828b4a6ec731e6` |
-| Unlink a redelivery inbox row from its logical task | `e3aaaf0414ca9797ffdd55a23126d13475c8b0e46ade9993169f4c256cb30f97` |
-| Remove logical-task ACK support | `f2877034ec8d16c4df2dfa70e6dab948b8303e2cd3e40d8d88d8fed38401e84b` |
-| Clear task-lifetime evidence on retry | `a42b3e7c575ca6abeebbb2b9ae1f793763d276815ca7def904c30125e51245ac` |
-| Unlink scheduler delivery from its logical task | `dee17714c66ed284a98504c2bc608da5e4ba860ffea40336966427f2b45b963d` |
-| Unlink REST initial delivery from its logical task | `223f239dd5d73f4947088ea604cfeaba631c6cd0acb1e3bec88323e5701e2421` |
+| Remove immutable node ownership enforcement | `88c4a49df3989e6352bf97213b30708556eafd809d20dfa373ff716a553fa6f4` |
+| Remove legacy/direct canonical-alias ownership | `ce065a6b8ef94d13368baba40c4c31bcc1d0e295b7e65d5acdec2140c81f68f8` |
+| Collapse runtime submission into consumption | `5a519b68d958c2351889e3b4f9b8ffca0faa598295062c9694d4198cce540f05` |
+| Stop consumption from implying submission | `f079b72bef8a819dcc9c3efbdf0c3860c04e7a5c62de8865862a9ee2ef4bf45b` |
+| Unlink a redelivery inbox row from its logical task | `fe89e89b6e7b36acf6f0330a84e0e07b25be9e60f641036018987dbcf4f4594c` |
+| Remove logical-task ACK support | `3bd8606d86d1867f73a4415757aee5c51eaf0a8194f4904438946a355ae6875f` |
+| Clear task-lifetime evidence on retry | `2bbd2788b85f0859690eb2a53f46a8aef45181406487582c2f81a10451060b42` |
+| Unlink scheduler delivery from its logical task | `d654202bf10caefb5858876e899e23dd2fb76189ecbfed27ac9b8edd1a465d75` |
+| Unlink REST initial delivery from its logical task | `5faf53f217161c7797d92f61333947e61442ffea485f8d1578a474944ecf499b` |
 
-Artifacts are the corresponding `.log` files under `/tmp/test671-727564-e40sgZ`.
+Artifacts are the corresponding `.log` files under `/tmp/test671-7aabeb-ZA8Fq0`.
 
 ## Result
 
-PASS for the Hub-only task runtime evidence layer at source `727564d800d5a72ed56e5f8c707aced41fd6b614`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.
+PASS for the Hub-only task runtime evidence layer at source `7aabeb796800568d646133631258fc68e7b960ba`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.

--- a/docs/tests/report-test671-task-runtime-evidence-hub.txt
+++ b/docs/tests/report-test671-task-runtime-evidence-hub.txt
@@ -5,10 +5,10 @@ Date: 2026-08-10 (Asia/Shanghai)
 ## Provenance
 
 - Base: `51bdb84a417c9a2a1fd8f07f871e307e50da80a5`
-- Tested source: `3b243c9b94b428ff960b390e518d6ee1c295b769`
+- Tested source: `8528c23c7db674ed129f6b6c153fd694d38ddc94`
 - Docker tag: `anet-test671:dev` (fixed/reused tag)
-- Docker image ID: `sha256:f52142069c30d946f7a6d36fb9efee2387cdb73fbd9dffd47ef2c30bd6b68efa`
-- Embedded image environment: `TEST671_SOURCE_COMMIT=3b243c9b94b428ff960b390e518d6ee1c295b769`
+- Docker image ID: `sha256:deaca0c9dafa9f0a4829ff148642224a66aae916b8f66ece25da5017cdedccb8`
+- Embedded image environment: `TEST671_SOURCE_COMMIT=8528c23c7db674ed129f6b6c153fd694d38ddc94`
 
 An earlier image used a manually expanded, nonexistent SHA and is invalid evidence. It was discarded and the fixed tag was rebuilt from the exact value returned by `git rev-parse HEAD`; only the image and results above count.
 
@@ -35,7 +35,7 @@ Agent runtime wiring is deliberately excluded from this candidate layer while th
 Command:
 
 ```sh
-sg docker -c 'docker run --rm -v /tmp/test671-3b243c-GcqLGn:/artifacts anet-test671:dev'
+sg docker -c 'docker run --rm -v /tmp/test671-8528c2-E0UJKl:/artifacts anet-test671:dev'
 ```
 
 Result:
@@ -54,18 +54,18 @@ Each mutation changed the tested implementation and made the behavior suite fail
 
 | Mutation | Artifact SHA256 |
 | --- | --- |
-| Remove immutable node ownership enforcement | `2b34b93b9a1a77562618a476ca0da5a801e29a6e02fa8366f14699cc97a3e3ad` |
-| Remove legacy/direct canonical-alias ownership | `b313e9d239eb2a9e2ec683272406017c3f8e93f1f958d00585d6e14157d39193` |
-| Collapse runtime submission into consumption | `4ba02d46394647bddb100a1ee455486a3cb049066b2074034c03bf9ace12963c` |
-| Stop consumption from implying submission | `e17806db0e9b0ad030ed69b7a0a6449a866911b9f14792979ee25329bf098e7c` |
-| Unlink a redelivery inbox row from its logical task | `bf3ae238486efabdbadf1d517ecb2a72c124f8069181b0e6ded210d7006db294` |
-| Remove logical-task ACK support | `56e35a3b09862b77b66670b2d9a02ab6ac17c2a6fe0bc7a9bcce9ac919ff000c` |
-| Clear task-lifetime evidence on retry | `694cdef1d553090fdd7b34e3484af651eb7e1481385a09c03393af743a780ded` |
-| Unlink scheduler delivery from its logical task | `7ebd02df7c2dc023834efda88db51100e86a5de5fcb6e0e48e1c51315cef6765` |
-| Unlink REST initial delivery from its logical task | `e3c3adeae104c6c5d11205d97f7a517cf9145b1a5fd941b05087da07fa08e0db` |
+| Remove immutable node ownership enforcement | `85605a634ed5b92b0220dcef6911b88225537e71ea7e2f102a4986cff7513e3f` |
+| Remove legacy/direct canonical-alias ownership | `ff07aaaef2125333c61543512a726f20f4e70e9c540e889886a519fccf153b15` |
+| Collapse runtime submission into consumption | `e2597162abd36e0b2232e3cb7967cbe4901f000fda2e3db8646cf41720a37d3e` |
+| Stop consumption from implying submission | `5c82cc27b3d4b973019fbc1c85ac6c3a6317b003a786f85b198a7a51be16a0ff` |
+| Unlink a redelivery inbox row from its logical task | `2c027ea6ec125f9cff7905f2b9bae76b2df82c08220e2b556cc5e9f6fe726926` |
+| Remove logical-task ACK support | `1b52e92cef816ef95891e0a5f2bdb8d93dce11d29e58e867543b0d51c25510eb` |
+| Clear task-lifetime evidence on retry | `84ba895d7793a282ef40b44d53ca1d302e8eb1e7ce022df7e1808c8c0c287ee6` |
+| Unlink scheduler delivery from its logical task | `3feb8189e62a98bc3140632a54b6c70825223a2ea6de20db3502996c2864b8f0` |
+| Unlink REST initial delivery from its logical task | `11267c8d574572416efab69ff40c98b90f342ebaf95df69210ad2bc9e02d11ff` |
 
-Artifacts are the corresponding `.log` files under `/tmp/test671-3b243c-GcqLGn`.
+Artifacts are the corresponding `.log` files under `/tmp/test671-8528c2-E0UJKl`.
 
 ## Result
 
-PASS for the Hub-only task runtime evidence layer at source `3b243c9b94b428ff960b390e518d6ee1c295b769`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.
+PASS for the Hub-only task runtime evidence layer at source `8528c23c7db674ed129f6b6c153fd694d38ddc94`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.

--- a/docs/tests/report-test671-task-runtime-evidence-hub.txt
+++ b/docs/tests/report-test671-task-runtime-evidence-hub.txt
@@ -5,10 +5,10 @@ Date: 2026-08-10 (Asia/Shanghai)
 ## Provenance
 
 - Base: `51bdb84a417c9a2a1fd8f07f871e307e50da80a5`
-- Tested source: `91e45ba185a10e24da526b76052b5dd0444b0a90`
+- Tested source: `727564d800d5a72ed56e5f8c707aced41fd6b614`
 - Docker tag: `anet-test671:dev` (fixed/reused tag)
-- Docker image ID: `sha256:3a34b7d347a36d19ccc791bae93f14d86eb6508cace5862d44f07262330e5152`
-- Embedded image environment: `TEST671_SOURCE_COMMIT=91e45ba185a10e24da526b76052b5dd0444b0a90`
+- Docker image ID: `sha256:54174ae5dc8eb1d2dc8883c18f36f0a2a62b6d1065e617bfbd1a1a34048966f0`
+- Embedded image environment: `TEST671_SOURCE_COMMIT=727564d800d5a72ed56e5f8c707aced41fd6b614`
 
 An earlier image used a manually expanded, nonexistent SHA and is invalid evidence. It was discarded and the fixed tag was rebuilt from the exact value returned by `git rev-parse HEAD`; only the image and results above count.
 
@@ -20,7 +20,7 @@ This layer covers the Hub half of issue #520 only:
 - node-token-only, exact-task-ID runtime evidence tools;
 - atomic all-or-nothing batch ownership checks;
 - task-lifetime monotonic evidence preserved through retry/reassignment;
-- explicit `inbox.task_id` linkage across fresh transport-row IDs;
+- explicit `inbox.task_id` linkage across MCP, REST, scheduler, retry, and reassignment delivery paths;
 - logical-task ACK for new consumers plus exact `inbox.id` compatibility for old consumers;
 - immutable node ownership with a canonical-alias fallback only for legacy/direct tasks whose `to_node_id` is NULL;
 - REST/tool projections and bilingual lifecycle documentation;
@@ -33,17 +33,18 @@ Agent runtime wiring is deliberately excluded from this candidate layer while th
 Command:
 
 ```sh
-sg docker -c 'docker run --rm -v /tmp/test671-91e45-IIOWOF:/artifacts anet-test671:dev'
+sg docker -c 'docker run --rm -v /tmp/test671-727564-e40sgZ:/artifacts anet-test671:dev'
 ```
 
 Result:
 
-- `server/src/task-consumption.test.ts`: 10 tests passed, 77 assertions passed;
+- `server/src/task-consumption.test.ts`: 11 tests passed, 80 assertions passed;
+- `server/src/task-auth-origin-http.test.ts`: 2 tests passed, 8 assertions passed;
 - production Hub bundle built successfully;
 - RFC and Chinese/English field-boundary documentation checks passed;
-- suite summary: `RESULT pass=10 fail=0`.
+- suite summary: `RESULT pass=13 fail=0`.
 
-The behavior tests establish that connection, enqueue, delivery, ACK, and the legacy `sessions.task` preview leave both evidence fields NULL; runtime submission marks only `runtime_submitted_at`; authoritative consumption marks both fields; duplicate reports are idempotent; foreign/missing mixed batches write nothing; user tokens cannot report evidence; legacy/direct NULL-node tasks remain usable only through their authenticated canonical alias; and retry/reassignment preserve task-lifetime evidence while fresh inbox rows continue to expose and ACK the original logical task ID.
+The behavior tests establish that connection, enqueue, delivery, ACK, and the legacy `sessions.task` preview leave both evidence fields NULL; runtime submission marks only `runtime_submitted_at`; authoritative consumption marks both fields; duplicate reports are idempotent; foreign/missing mixed batches write nothing; user tokens cannot report evidence; legacy/direct NULL-node tasks remain usable only through their authenticated canonical alias; and MCP, REST, scheduler, retry, and reassignment deliveries expose the original logical task ID. Retry/reassignment preserve task-lifetime evidence while fresh transport rows continue to ACK and report against that logical task.
 
 ## Witnessed-red mutations
 
@@ -51,16 +52,18 @@ Each mutation changed the tested implementation and made the behavior suite fail
 
 | Mutation | Artifact SHA256 |
 | --- | --- |
-| Remove immutable node ownership enforcement | `5dc1363404568873dfb9f90af2ce161df1e867f51b6de8eb398786b0833a1f63` |
-| Remove legacy/direct canonical-alias ownership | `c007846747e7892129bc6b70c552327d1269d1212da1fe83b5884d36d8d08ded` |
-| Collapse runtime submission into consumption | `b887163006ca2bb52fb688f8dc03ff7c005e9cf0b7cf04998331b3f1c2e59867` |
-| Stop consumption from implying submission | `77bb1746e1775f0f3ae21169a4b69156a1d8de5bbd12bedd4d6ede6296089724` |
-| Unlink a redelivery inbox row from its logical task | `7aaee1e63a34c5c11490399e2b0fe88f17e35f3815fc843e956af29eca9851d0` |
-| Remove logical-task ACK support | `e00ea83f4df69cd897d7852ae57794e48a8c29aa91e86b822d3e4baec08eeb22` |
-| Clear task-lifetime evidence on retry | `fdcb7a7c1e9cea199dd72ee6ed584789ae33390828a31b1518ab1b805640f314` |
+| Remove immutable node ownership enforcement | `a1e7a4a0164b8dae753abbe74db43c49eee1579252ab137ed606975e24ad1df6` |
+| Remove legacy/direct canonical-alias ownership | `132d150012da0d66c19c44fd23bbf83b4da46e7ada12c94cb95b236aea0589ab` |
+| Collapse runtime submission into consumption | `70cd1e3c4be9eda72118412b1effa550fbb66f6698dd344516a218d2d76385de` |
+| Stop consumption from implying submission | `5e82a49082336dfca363d39b706c8795bf04eaecc9925a3ef6828b4a6ec731e6` |
+| Unlink a redelivery inbox row from its logical task | `e3aaaf0414ca9797ffdd55a23126d13475c8b0e46ade9993169f4c256cb30f97` |
+| Remove logical-task ACK support | `f2877034ec8d16c4df2dfa70e6dab948b8303e2cd3e40d8d88d8fed38401e84b` |
+| Clear task-lifetime evidence on retry | `a42b3e7c575ca6abeebbb2b9ae1f793763d276815ca7def904c30125e51245ac` |
+| Unlink scheduler delivery from its logical task | `dee17714c66ed284a98504c2bc608da5e4ba860ffea40336966427f2b45b963d` |
+| Unlink REST initial delivery from its logical task | `223f239dd5d73f4947088ea604cfeaba631c6cd0acb1e3bec88323e5701e2421` |
 
-Artifacts are the corresponding `.log` files under `/tmp/test671-91e45-IIOWOF`.
+Artifacts are the corresponding `.log` files under `/tmp/test671-727564-e40sgZ`.
 
 ## Result
 
-PASS for the Hub-only task runtime evidence layer at source `91e45ba185a10e24da526b76052b5dd0444b0a90`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.
+PASS for the Hub-only task runtime evidence layer at source `727564d800d5a72ed56e5f8c707aced41fd6b614`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.

--- a/docs/tests/report-test671-task-runtime-evidence-hub.txt
+++ b/docs/tests/report-test671-task-runtime-evidence-hub.txt
@@ -5,10 +5,10 @@ Date: 2026-08-10 (Asia/Shanghai)
 ## Provenance
 
 - Base: `51bdb84a417c9a2a1fd8f07f871e307e50da80a5`
-- Tested source: `aa7f23d384bb3208122301362ce1991fa8b8abe6`
+- Tested source: `91e45ba185a10e24da526b76052b5dd0444b0a90`
 - Docker tag: `anet-test671:dev` (fixed/reused tag)
-- Docker image ID: `sha256:5ad20381f72ae45a2e981317eeeff0f1e799e682f144ad952142eeea07a16032`
-- Embedded image environment: `TEST671_SOURCE_COMMIT=aa7f23d384bb3208122301362ce1991fa8b8abe6`
+- Docker image ID: `sha256:3a34b7d347a36d19ccc791bae93f14d86eb6508cace5862d44f07262330e5152`
+- Embedded image environment: `TEST671_SOURCE_COMMIT=91e45ba185a10e24da526b76052b5dd0444b0a90`
 
 An earlier image used a manually expanded, nonexistent SHA and is invalid evidence. It was discarded and the fixed tag was rebuilt from the exact value returned by `git rev-parse HEAD`; only the image and results above count.
 
@@ -21,6 +21,7 @@ This layer covers the Hub half of issue #520 only:
 - atomic all-or-nothing batch ownership checks;
 - task-lifetime monotonic evidence preserved through retry/reassignment;
 - explicit `inbox.task_id` linkage across fresh transport-row IDs;
+- logical-task ACK for new consumers plus exact `inbox.id` compatibility for old consumers;
 - immutable node ownership with a canonical-alias fallback only for legacy/direct tasks whose `to_node_id` is NULL;
 - REST/tool projections and bilingual lifecycle documentation;
 - SQLite-backed mutation and behavior gates.
@@ -32,15 +33,15 @@ Agent runtime wiring is deliberately excluded from this candidate layer while th
 Command:
 
 ```sh
-sg docker -c 'docker run --rm -v /tmp/test671-aa7f-4elEZ0:/artifacts anet-test671:dev'
+sg docker -c 'docker run --rm -v /tmp/test671-91e45-IIOWOF:/artifacts anet-test671:dev'
 ```
 
 Result:
 
-- `server/src/task-consumption.test.ts`: 10 tests passed, 73 assertions passed;
+- `server/src/task-consumption.test.ts`: 10 tests passed, 77 assertions passed;
 - production Hub bundle built successfully;
 - RFC and Chinese/English field-boundary documentation checks passed;
-- suite summary: `RESULT pass=9 fail=0`.
+- suite summary: `RESULT pass=10 fail=0`.
 
 The behavior tests establish that connection, enqueue, delivery, ACK, and the legacy `sessions.task` preview leave both evidence fields NULL; runtime submission marks only `runtime_submitted_at`; authoritative consumption marks both fields; duplicate reports are idempotent; foreign/missing mixed batches write nothing; user tokens cannot report evidence; legacy/direct NULL-node tasks remain usable only through their authenticated canonical alias; and retry/reassignment preserve task-lifetime evidence while fresh inbox rows continue to expose and ACK the original logical task ID.
 
@@ -50,15 +51,16 @@ Each mutation changed the tested implementation and made the behavior suite fail
 
 | Mutation | Artifact SHA256 |
 | --- | --- |
-| Remove immutable node ownership enforcement | `13b2a8f8a16bd8de12be7e7c4086216dec666392264eb71cac11c28da0d415a2` |
-| Remove legacy/direct canonical-alias ownership | `dfbaf1e7628a01aefbb15c64046ed1390adc739607eefe890881305933d08199` |
-| Collapse runtime submission into consumption | `399cae4dca522a3116b70c8b4dc7b4c93dc800acf2aa8aee880bd866d405a9f2` |
-| Stop consumption from implying submission | `7f752e3abf636d401b7f89bbe6f0ea5e53b869238110c91ab1a58f0851d59df4` |
-| Unlink a redelivery inbox row from its logical task | `a5011244120df46e7958ba5896234ba09e1f3aed1caff60079d32170bbe40407` |
-| Clear task-lifetime evidence on retry | `b957c6af2a5018551c0588096ed0e65cf183e95b0178ac9c4af48db9a30b0197` |
+| Remove immutable node ownership enforcement | `5dc1363404568873dfb9f90af2ce161df1e867f51b6de8eb398786b0833a1f63` |
+| Remove legacy/direct canonical-alias ownership | `c007846747e7892129bc6b70c552327d1269d1212da1fe83b5884d36d8d08ded` |
+| Collapse runtime submission into consumption | `b887163006ca2bb52fb688f8dc03ff7c005e9cf0b7cf04998331b3f1c2e59867` |
+| Stop consumption from implying submission | `77bb1746e1775f0f3ae21169a4b69156a1d8de5bbd12bedd4d6ede6296089724` |
+| Unlink a redelivery inbox row from its logical task | `7aaee1e63a34c5c11490399e2b0fe88f17e35f3815fc843e956af29eca9851d0` |
+| Remove logical-task ACK support | `e00ea83f4df69cd897d7852ae57794e48a8c29aa91e86b822d3e4baec08eeb22` |
+| Clear task-lifetime evidence on retry | `fdcb7a7c1e9cea199dd72ee6ed584789ae33390828a31b1518ab1b805640f314` |
 
-Artifacts are the corresponding `.log` files under `/tmp/test671-aa7f-4elEZ0`.
+Artifacts are the corresponding `.log` files under `/tmp/test671-91e45-IIOWOF`.
 
 ## Result
 
-PASS for the Hub-only task runtime evidence layer at source `aa7f23d384bb3208122301362ce1991fa8b8abe6`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.
+PASS for the Hub-only task runtime evidence layer at source `91e45ba185a10e24da526b76052b5dd0444b0a90`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.

--- a/docs/tests/report-test671-task-runtime-evidence-hub.txt
+++ b/docs/tests/report-test671-task-runtime-evidence-hub.txt
@@ -1,0 +1,61 @@
+# test671 — Hub task runtime evidence
+
+Date: 2026-08-10 (Asia/Shanghai)
+
+## Provenance
+
+- Base: `51bdb84a417c9a2a1fd8f07f871e307e50da80a5`
+- Tested source: `18ec93d866bb531df7bf074a9b56bceb77326d55`
+- Docker tag: `anet-test671:dev` (fixed/reused tag)
+- Docker image ID: `sha256:edb1973cdcfb54214bde2eeba3215ab5a192b092beae2daf0a76163f0809b51b`
+- Embedded image environment: `TEST671_SOURCE_COMMIT=18ec93d866bb531df7bf074a9b56bceb77326d55`
+
+An earlier image used a manually expanded, nonexistent SHA and is invalid evidence. It was discarded and the fixed tag was rebuilt from the exact value returned by `git rev-parse HEAD`; only the image and results above count.
+
+## Scope
+
+This layer covers the Hub half of issue #520 only:
+
+- additive `runtime_submitted_at` and `consumed_at` task fields;
+- node-token-only, exact-task-ID runtime evidence tools;
+- atomic all-or-nothing batch ownership checks;
+- retry/reassignment clearing both attempt-scoped timestamps;
+- REST/tool projections and bilingual lifecycle documentation;
+- SQLite-backed mutation and behavior gates.
+
+Agent runtime wiring is deliberately excluded from this candidate layer while the overlapping image-delivery change is being coordinated. Nothing was merged, deployed, published, or written to production.
+
+## Normal path
+
+Command:
+
+```sh
+sg docker -c 'docker run --rm -v /tmp/test671-artifacts:/artifacts anet-test671:dev'
+```
+
+Result:
+
+- `server/src/task-consumption.test.ts`: 7 tests passed, 49 assertions passed;
+- production Hub bundle built successfully;
+- RFC and Chinese/English field-boundary documentation checks passed;
+- suite summary: `RESULT pass=8 fail=0`.
+
+The behavior tests establish that connection, enqueue, delivery, ACK, and the legacy `sessions.task` preview leave both evidence fields NULL; runtime submission marks only `runtime_submitted_at`; authoritative consumption marks both fields; duplicate reports are idempotent; foreign/missing mixed batches write nothing; user tokens cannot report evidence; and retry/reassignment starts a clean attempt.
+
+## Witnessed-red mutations
+
+Each mutation changed the tested implementation and made the behavior suite fail before the unmodified source returned green.
+
+| Mutation | Artifact SHA256 |
+| --- | --- |
+| Remove node ownership enforcement | `881879053c3edf95a5f8a60f1786855ea2025b4a9c77779f51b731bd84d3f4b3` |
+| Collapse runtime submission into consumption | `a62b23c4da5d8be2c5d519209f9665c4f99adb7b355e4296cf211a4145697ab3` |
+| Stop consumption from implying submission | `60376500122b825fabc9d9050f37c9fc36d32871e0e88f7f3c092a470e7c3f38` |
+| Remove `runtime_submitted_at` attempt reset | `059ed5fdd45635ec47f3856ccee9592726f08510ce71e06e32411bca09074444` |
+| Remove `consumed_at` attempt reset | `035e18297da851b35e84c009e5dc677e7a1841f7841915b1aa7f694852c998e7` |
+
+Artifacts are the corresponding `.log` files under `/tmp/test671-artifacts`.
+
+## Result
+
+PASS for the Hub-only task runtime evidence layer at source `18ec93d866bb531df7bf074a9b56bceb77326d55`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.

--- a/docs/tests/report-test671-task-runtime-evidence-hub.txt
+++ b/docs/tests/report-test671-task-runtime-evidence-hub.txt
@@ -5,10 +5,10 @@ Date: 2026-08-10 (Asia/Shanghai)
 ## Provenance
 
 - Base: `51bdb84a417c9a2a1fd8f07f871e307e50da80a5`
-- Tested source: `7aabeb796800568d646133631258fc68e7b960ba`
+- Tested source: `3b243c9b94b428ff960b390e518d6ee1c295b769`
 - Docker tag: `anet-test671:dev` (fixed/reused tag)
-- Docker image ID: `sha256:e3e8764e3834ae8c7f607b4d2d20ed2409c79bff37e9701c3a5207f3fcf05209`
-- Embedded image environment: `TEST671_SOURCE_COMMIT=7aabeb796800568d646133631258fc68e7b960ba`
+- Docker image ID: `sha256:f52142069c30d946f7a6d36fb9efee2387cdb73fbd9dffd47ef2c30bd6b68efa`
+- Embedded image environment: `TEST671_SOURCE_COMMIT=3b243c9b94b428ff960b390e518d6ee1c295b769`
 
 An earlier image used a manually expanded, nonexistent SHA and is invalid evidence. It was discarded and the fixed tag was rebuilt from the exact value returned by `git rev-parse HEAD`; only the image and results above count.
 
@@ -19,6 +19,7 @@ This layer covers the Hub half of issue #520 only:
 - additive `runtime_submitted_at` and `consumed_at` task fields;
 - node-token-only, exact-task-ID runtime evidence tools;
 - atomic all-or-nothing batch ownership checks;
+- caller session identity, task ownership preflight, and evidence stamps in one SQLite transaction;
 - task-lifetime monotonic evidence preserved through retry/reassignment;
 - explicit `inbox.task_id` linkage across MCP, REST, scheduler, retry, and reassignment delivery paths;
 - a denominator gate that enumerates all five production task-inbox INSERT paths and rejects any path without `task_id`;
@@ -34,7 +35,7 @@ Agent runtime wiring is deliberately excluded from this candidate layer while th
 Command:
 
 ```sh
-sg docker -c 'docker run --rm -v /tmp/test671-7aabeb-ZA8Fq0:/artifacts anet-test671:dev'
+sg docker -c 'docker run --rm -v /tmp/test671-3b243c-GcqLGn:/artifacts anet-test671:dev'
 ```
 
 Result:
@@ -53,18 +54,18 @@ Each mutation changed the tested implementation and made the behavior suite fail
 
 | Mutation | Artifact SHA256 |
 | --- | --- |
-| Remove immutable node ownership enforcement | `88c4a49df3989e6352bf97213b30708556eafd809d20dfa373ff716a553fa6f4` |
-| Remove legacy/direct canonical-alias ownership | `ce065a6b8ef94d13368baba40c4c31bcc1d0e295b7e65d5acdec2140c81f68f8` |
-| Collapse runtime submission into consumption | `5a519b68d958c2351889e3b4f9b8ffca0faa598295062c9694d4198cce540f05` |
-| Stop consumption from implying submission | `f079b72bef8a819dcc9c3efbdf0c3860c04e7a5c62de8865862a9ee2ef4bf45b` |
-| Unlink a redelivery inbox row from its logical task | `fe89e89b6e7b36acf6f0330a84e0e07b25be9e60f641036018987dbcf4f4594c` |
-| Remove logical-task ACK support | `3bd8606d86d1867f73a4415757aee5c51eaf0a8194f4904438946a355ae6875f` |
-| Clear task-lifetime evidence on retry | `2bbd2788b85f0859690eb2a53f46a8aef45181406487582c2f81a10451060b42` |
-| Unlink scheduler delivery from its logical task | `d654202bf10caefb5858876e899e23dd2fb76189ecbfed27ac9b8edd1a465d75` |
-| Unlink REST initial delivery from its logical task | `5faf53f217161c7797d92f61333947e61442ffea485f8d1578a474944ecf499b` |
+| Remove immutable node ownership enforcement | `2b34b93b9a1a77562618a476ca0da5a801e29a6e02fa8366f14699cc97a3e3ad` |
+| Remove legacy/direct canonical-alias ownership | `b313e9d239eb2a9e2ec683272406017c3f8e93f1f958d00585d6e14157d39193` |
+| Collapse runtime submission into consumption | `4ba02d46394647bddb100a1ee455486a3cb049066b2074034c03bf9ace12963c` |
+| Stop consumption from implying submission | `e17806db0e9b0ad030ed69b7a0a6449a866911b9f14792979ee25329bf098e7c` |
+| Unlink a redelivery inbox row from its logical task | `bf3ae238486efabdbadf1d517ecb2a72c124f8069181b0e6ded210d7006db294` |
+| Remove logical-task ACK support | `56e35a3b09862b77b66670b2d9a02ab6ac17c2a6fe0bc7a9bcce9ac919ff000c` |
+| Clear task-lifetime evidence on retry | `694cdef1d553090fdd7b34e3484af651eb7e1481385a09c03393af743a780ded` |
+| Unlink scheduler delivery from its logical task | `7ebd02df7c2dc023834efda88db51100e86a5de5fcb6e0e48e1c51315cef6765` |
+| Unlink REST initial delivery from its logical task | `e3c3adeae104c6c5d11205d97f7a517cf9145b1a5fd941b05087da07fa08e0db` |
 
-Artifacts are the corresponding `.log` files under `/tmp/test671-7aabeb-ZA8Fq0`.
+Artifacts are the corresponding `.log` files under `/tmp/test671-3b243c-GcqLGn`.
 
 ## Result
 
-PASS for the Hub-only task runtime evidence layer at source `7aabeb796800568d646133631258fc68e7b960ba`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.
+PASS for the Hub-only task runtime evidence layer at source `3b243c9b94b428ff960b390e518d6ee1c295b769`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.

--- a/docs/tests/report-test671-task-runtime-evidence-hub.txt
+++ b/docs/tests/report-test671-task-runtime-evidence-hub.txt
@@ -5,10 +5,10 @@ Date: 2026-08-10 (Asia/Shanghai)
 ## Provenance
 
 - Base: `51bdb84a417c9a2a1fd8f07f871e307e50da80a5`
-- Tested source: `18ec93d866bb531df7bf074a9b56bceb77326d55`
+- Tested source: `aa7f23d384bb3208122301362ce1991fa8b8abe6`
 - Docker tag: `anet-test671:dev` (fixed/reused tag)
-- Docker image ID: `sha256:edb1973cdcfb54214bde2eeba3215ab5a192b092beae2daf0a76163f0809b51b`
-- Embedded image environment: `TEST671_SOURCE_COMMIT=18ec93d866bb531df7bf074a9b56bceb77326d55`
+- Docker image ID: `sha256:5ad20381f72ae45a2e981317eeeff0f1e799e682f144ad952142eeea07a16032`
+- Embedded image environment: `TEST671_SOURCE_COMMIT=aa7f23d384bb3208122301362ce1991fa8b8abe6`
 
 An earlier image used a manually expanded, nonexistent SHA and is invalid evidence. It was discarded and the fixed tag was rebuilt from the exact value returned by `git rev-parse HEAD`; only the image and results above count.
 
@@ -19,7 +19,9 @@ This layer covers the Hub half of issue #520 only:
 - additive `runtime_submitted_at` and `consumed_at` task fields;
 - node-token-only, exact-task-ID runtime evidence tools;
 - atomic all-or-nothing batch ownership checks;
-- retry/reassignment clearing both attempt-scoped timestamps;
+- task-lifetime monotonic evidence preserved through retry/reassignment;
+- explicit `inbox.task_id` linkage across fresh transport-row IDs;
+- immutable node ownership with a canonical-alias fallback only for legacy/direct tasks whose `to_node_id` is NULL;
 - REST/tool projections and bilingual lifecycle documentation;
 - SQLite-backed mutation and behavior gates.
 
@@ -30,17 +32,17 @@ Agent runtime wiring is deliberately excluded from this candidate layer while th
 Command:
 
 ```sh
-sg docker -c 'docker run --rm -v /tmp/test671-artifacts:/artifacts anet-test671:dev'
+sg docker -c 'docker run --rm -v /tmp/test671-aa7f-4elEZ0:/artifacts anet-test671:dev'
 ```
 
 Result:
 
-- `server/src/task-consumption.test.ts`: 7 tests passed, 49 assertions passed;
+- `server/src/task-consumption.test.ts`: 10 tests passed, 73 assertions passed;
 - production Hub bundle built successfully;
 - RFC and Chinese/English field-boundary documentation checks passed;
-- suite summary: `RESULT pass=8 fail=0`.
+- suite summary: `RESULT pass=9 fail=0`.
 
-The behavior tests establish that connection, enqueue, delivery, ACK, and the legacy `sessions.task` preview leave both evidence fields NULL; runtime submission marks only `runtime_submitted_at`; authoritative consumption marks both fields; duplicate reports are idempotent; foreign/missing mixed batches write nothing; user tokens cannot report evidence; and retry/reassignment starts a clean attempt.
+The behavior tests establish that connection, enqueue, delivery, ACK, and the legacy `sessions.task` preview leave both evidence fields NULL; runtime submission marks only `runtime_submitted_at`; authoritative consumption marks both fields; duplicate reports are idempotent; foreign/missing mixed batches write nothing; user tokens cannot report evidence; legacy/direct NULL-node tasks remain usable only through their authenticated canonical alias; and retry/reassignment preserve task-lifetime evidence while fresh inbox rows continue to expose and ACK the original logical task ID.
 
 ## Witnessed-red mutations
 
@@ -48,14 +50,15 @@ Each mutation changed the tested implementation and made the behavior suite fail
 
 | Mutation | Artifact SHA256 |
 | --- | --- |
-| Remove node ownership enforcement | `881879053c3edf95a5f8a60f1786855ea2025b4a9c77779f51b731bd84d3f4b3` |
-| Collapse runtime submission into consumption | `a62b23c4da5d8be2c5d519209f9665c4f99adb7b355e4296cf211a4145697ab3` |
-| Stop consumption from implying submission | `60376500122b825fabc9d9050f37c9fc36d32871e0e88f7f3c092a470e7c3f38` |
-| Remove `runtime_submitted_at` attempt reset | `059ed5fdd45635ec47f3856ccee9592726f08510ce71e06e32411bca09074444` |
-| Remove `consumed_at` attempt reset | `035e18297da851b35e84c009e5dc677e7a1841f7841915b1aa7f694852c998e7` |
+| Remove immutable node ownership enforcement | `13b2a8f8a16bd8de12be7e7c4086216dec666392264eb71cac11c28da0d415a2` |
+| Remove legacy/direct canonical-alias ownership | `dfbaf1e7628a01aefbb15c64046ed1390adc739607eefe890881305933d08199` |
+| Collapse runtime submission into consumption | `399cae4dca522a3116b70c8b4dc7b4c93dc800acf2aa8aee880bd866d405a9f2` |
+| Stop consumption from implying submission | `7f752e3abf636d401b7f89bbe6f0ea5e53b869238110c91ab1a58f0851d59df4` |
+| Unlink a redelivery inbox row from its logical task | `a5011244120df46e7958ba5896234ba09e1f3aed1caff60079d32170bbe40407` |
+| Clear task-lifetime evidence on retry | `b957c6af2a5018551c0588096ed0e65cf183e95b0178ac9c4af48db9a30b0197` |
 
-Artifacts are the corresponding `.log` files under `/tmp/test671-artifacts`.
+Artifacts are the corresponding `.log` files under `/tmp/test671-aa7f-4elEZ0`.
 
 ## Result
 
-PASS for the Hub-only task runtime evidence layer at source `18ec93d866bb531df7bf074a9b56bceb77326d55`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.
+PASS for the Hub-only task runtime evidence layer at source `aa7f23d384bb3208122301362ce1991fa8b8abe6`. Agent-node reporting remains a separate pending layer and this report does not claim end-to-end runtime consumption is complete.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -162,6 +162,11 @@ for (const col of [
   { name: "scope", def: "TEXT DEFAULT 'single'" },
   { name: "meta_json", def: "TEXT" },
   { name: "node_id", def: "TEXT" },
+  // #520 — explicit logical task identity.  Initial deliveries historically
+  // used inbox.id == tasks.task_id, while retry/reassign generate a fresh
+  // inbox row id.  Keep transport-row identity and logical-task identity
+  // separate so runtime evidence/replies survive those redeliveries.
+  { name: "task_id", def: "TEXT" },
 ]) {
   try { db.exec(`ALTER TABLE inbox ADD COLUMN ${col.name} ${col.def}`); } catch {}
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -191,6 +191,8 @@ db.exec(`
     created_at        TEXT NOT NULL DEFAULT (datetime('now')),
     delivered_at      TEXT,
     started_at        TEXT,
+    runtime_submitted_at TEXT,
+    consumed_at       TEXT,
     completed_at      TEXT,
     expires_at        TEXT
   );
@@ -1061,6 +1063,13 @@ try { db.exec("CREATE INDEX IF NOT EXISTS idx_completions_network ON completions
 // the reply up the chain via parent_task_id.
 try { db.exec("ALTER TABLE tasks ADD COLUMN parent_task_id TEXT"); } catch {}
 try { db.exec("ALTER TABLE tasks ADD COLUMN meta_json TEXT"); } catch {}
+// #520 — two monotonic evidence levels for this exact task:
+// runtime_submitted_at means agent-node handed the body to the vendor runtime;
+// consumed_at requires an attributable turn-start/first-activity signal.
+// Both stay separate from delivered_at (enqueue), acked (process receipt), and
+// started_at (legacy report_status/content matching). Old binaries ignore them.
+try { db.exec("ALTER TABLE tasks ADD COLUMN runtime_submitted_at TEXT"); } catch {}
+try { db.exec("ALTER TABLE tasks ADD COLUMN consumed_at TEXT"); } catch {}
 
 // ── Hub scheduled tasks ──────────────────────────────────────────────
 // Scheduling is a Hub concern: clients manage these rows, while agents only

--- a/server/src/rest-projections.ts
+++ b/server/src/rest-projections.ts
@@ -34,7 +34,7 @@ export const TASK_EVENT_REST_COLUMNS = [
 export const TASK_REST_COLUMNS = [
   "task_id", "from_node_id", "from_name", "to_node_id", "to_name", "priority",
   "status", "content", "result", "in_reply_to", "requires_response", "scope",
-  "created_at", "delivered_at", "started_at", "completed_at", "expires_at",
+  "created_at", "delivered_at", "started_at", "runtime_submitted_at", "consumed_at", "completed_at", "expires_at",
   "network_id", "parent_task_id", "meta_json",
 ] as const;
 

--- a/server/src/scheduled-tasks.ts
+++ b/server/src/scheduled-tasks.ts
@@ -274,8 +274,8 @@ export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: str
       auth_origin: "hub_scheduler",
     });
     db.run(
-      `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, requires_response, network_id, meta_json)
-       VALUES (?1, ?2, ?3, 'task', ?4, ?5, 'scheduler', 'reply', ?6, ?7)`,
+      `INSERT INTO inbox (id, task_id, session_name, node_id, type, priority, content, from_session, requires_response, network_id, meta_json)
+       VALUES (?1, ?1, ?2, ?3, 'task', ?4, ?5, 'scheduler', 'reply', ?6, ?7)`,
       [taskId, node.alias, node.node_id, row.priority, row.task_content, row.network_id, metaJson],
     );
     db.run(

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2274,8 +2274,8 @@ return Bun.serve({
       // dispatched via REST (anet demo, dashboard Dispatch button, etc.).
       db.transaction(() => {
         db.run(
-          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, requires_response, network_id, meta_json)
-           VALUES (?1, ?2, ?3, 'task', ?4, ?5, ?6, 'reply', ?7, ?8)`,
+          `INSERT INTO inbox (id, task_id, session_name, node_id, type, priority, content, from_session, requires_response, network_id, meta_json)
+           VALUES (?1, ?1, ?2, ?3, 'task', ?4, ?5, ?6, 'reply', ?7, ?8)`,
           [id, targetAlias, targetNodeId, body.priority, body.task, fromSession, taskNetId, metaJson]
         );
         db.run(

--- a/server/src/task-auth-origin-http.test.ts
+++ b/server/src/task-auth-origin-http.test.ts
@@ -66,7 +66,12 @@ async function postTask(token: string, from: string, marker: string) {
   expect([200, 202]).toContain(response.status);
   const taskId = body.task_id ?? body.message_id;
   expect(taskId).toBeTruthy();
-  return JSON.parse(db.get<{ meta_json: string }>("SELECT meta_json FROM inbox WHERE id = ?1", [taskId])!.meta_json);
+  const inbox = db.get<{ meta_json: string; task_id: string }>(
+    "SELECT meta_json, task_id FROM inbox WHERE id = ?1",
+    [taskId],
+  )!;
+  expect(inbox.task_id).toBe(taskId);
+  return JSON.parse(inbox.meta_json);
 }
 
 describe("POST /api/task server-authenticated origin", () => {

--- a/server/src/task-consumption.test.ts
+++ b/server/src/task-consumption.test.ts
@@ -98,6 +98,9 @@ describe("task consumed_at identity and lifecycle", () => {
       NODE_A,
     );
     const taskId = await createTask(content);
+    const nodeTools = toolsFor({ alias: NODE_A, nodeToken: true });
+    const pending = await call(nodeTools.get_inbox, { alias: NODE_A, limit: 20 });
+    expect(pending.messages.find((row: any) => row.id === taskId)?.task_id).toBe(taskId);
     expect(runtimeSubmittedAt(taskId)).toBeNull();
     expect(consumedAt(taskId)).toBeNull();
     const queued = db.get<{ last_seen_at: string; task: string | null }>(
@@ -111,7 +114,6 @@ describe("task consumed_at identity and lifecycle", () => {
     expect(queued?.task).toBe(content);
     expect(queued?.last_seen_at).toBe(before?.last_seen_at);
 
-    const nodeTools = toolsFor({ alias: NODE_A, nodeToken: true });
     expect((await call(nodeTools.ack_inbox, { alias: NODE_A, message_id: taskId })).ok).toBe(true);
     expect(runtimeSubmittedAt(taskId)).toBeNull();
     expect(consumedAt(taskId)).toBeNull();
@@ -184,21 +186,87 @@ describe("task consumed_at identity and lifecycle", () => {
     expect(consumedAt(taskId)).toBeNull();
   });
 
-  test("retry and reassign clear evidence from the previous delivery attempt", async () => {
-    const taskId = await createTask("attempt-scoped evidence");
-    const nodeTools = toolsFor({ alias: NODE_A, nodeToken: true });
-    expect((await call(nodeTools.mark_tasks_consumed, { task_ids: [taskId] })).ok).toBe(true);
+  test("token-bound canonical alias is the fail-closed fallback only for tasks without node_id", async () => {
+    const taskId = await createTask("legacy direct session has no immutable node id");
+    db.run("UPDATE tasks SET to_node_id = NULL WHERE task_id = ?1", [taskId]);
+    db.run("UPDATE sessions SET node_id = NULL WHERE network_id = ?1 AND alias = ?2", [NET, NODE_A]);
+
+    const ownerResult = await call(
+      toolsFor({ alias: NODE_A, nodeToken: true }).mark_tasks_consumed,
+      { task_ids: [taskId] },
+    );
+    expect(ownerResult.ok).toBe(true);
     expect(typeof consumedAt(taskId)).toBe("string");
+
+    const foreignTask = await createTask("alias fallback must not cross target aliases", NODE_A);
+    db.run("UPDATE tasks SET to_node_id = NULL WHERE task_id = ?1", [foreignTask]);
+    const foreignResult = await call(
+      toolsFor({ alias: NODE_B, nodeToken: true }).mark_tasks_consumed,
+      { task_ids: [foreignTask] },
+    );
+    expect(foreignResult).toEqual({ ok: false, error: "task_not_owned", task_id: foreignTask });
+    expect(consumedAt(foreignTask)).toBeNull();
+  });
+
+  test("retry keeps task-lifetime evidence and exposes the logical task id on the new inbox row", async () => {
+    const taskId = await createTask("task-lifetime evidence");
+    const nodeTools = toolsFor({ alias: NODE_A, nodeToken: true });
+    expect((await call(nodeTools.ack_inbox, { alias: NODE_A, message_id: taskId })).ok).toBe(true);
+    expect((await call(nodeTools.mark_tasks_consumed, { task_ids: [taskId] })).ok).toBe(true);
+    const submitted = runtimeSubmittedAt(taskId);
+    const consumed = consumedAt(taskId);
+    expect(typeof submitted).toBe("string");
+    expect(typeof consumed).toBe("string");
 
     db.run("UPDATE tasks SET status = 'failed' WHERE task_id = ?1", [taskId]);
     expect((await call(toolsFor().retry_task, { task_id: taskId })).ok).toBe(true);
-    expect(runtimeSubmittedAt(taskId)).toBeNull();
-    expect(consumedAt(taskId)).toBeNull();
+    expect(runtimeSubmittedAt(taskId)).toBe(submitted);
+    expect(consumedAt(taskId)).toBe(consumed);
 
-    expect((await call(nodeTools.mark_tasks_consumed, { task_ids: [taskId] })).ok).toBe(true);
+    const retriedInbox = await call(nodeTools.get_inbox, { alias: NODE_A, limit: 20 });
+    const retryRow = retriedInbox.messages.find((row: any) => row.id !== taskId && row.task_id === taskId);
+    expect(retryRow).toBeDefined();
+    expect((await call(nodeTools.ack_inbox, { alias: NODE_A, message_id: retryRow.id })).ok).toBe(true);
+    expect(db.get<{ status: string }>("SELECT status FROM tasks WHERE task_id = ?1", taskId)?.status).toBe("acked");
+  });
+
+  test("an unconsumed first attempt can report against the linked task after retry", async () => {
+    const taskId = await createTask("retry must not lose logical task identity");
+    const nodeTools = toolsFor({ alias: NODE_A, nodeToken: true });
+    expect((await call(nodeTools.ack_inbox, { alias: NODE_A, message_id: taskId })).ok).toBe(true);
+    db.run("UPDATE tasks SET status = 'failed' WHERE task_id = ?1", [taskId]);
+    expect((await call(toolsFor().retry_task, { task_id: taskId })).ok).toBe(true);
+
+    const retriedInbox = await call(nodeTools.get_inbox, { alias: NODE_A, limit: 20 });
+    const retryRow = retriedInbox.messages.find((row: any) => row.id !== taskId && row.task_id === taskId);
+    expect(retryRow).toBeDefined();
+    expect((await call(nodeTools.mark_tasks_consumed, { task_ids: [retryRow.task_id] })).ok).toBe(true);
+    expect(typeof runtimeSubmittedAt(taskId)).toBe("string");
     expect(typeof consumedAt(taskId)).toBe("string");
+  });
+
+  test("reassign preserves task-lifetime evidence and binds the new inbox row to the same task", async () => {
+    const taskId = await createTask("reassign keeps logical task evidence");
+    const oldOwnerTools = toolsFor({ alias: NODE_A, nodeToken: true });
+    expect((await call(oldOwnerTools.ack_inbox, { alias: NODE_A, message_id: taskId })).ok).toBe(true);
+    expect((await call(oldOwnerTools.mark_tasks_consumed, { task_ids: [taskId] })).ok).toBe(true);
+    const submitted = runtimeSubmittedAt(taskId);
+    const consumed = consumedAt(taskId);
+
     expect((await call(toolsFor().reassign_task, { task_id: taskId, new_alias: NODE_B })).ok).toBe(true);
-    expect(runtimeSubmittedAt(taskId)).toBeNull();
-    expect(consumedAt(taskId)).toBeNull();
+    expect(runtimeSubmittedAt(taskId)).toBe(submitted);
+    expect(consumedAt(taskId)).toBe(consumed);
+
+    const newOwnerTools = toolsFor({ alias: NODE_B, nodeToken: true });
+    const reassignedInbox = await call(newOwnerTools.get_inbox, { alias: NODE_B, limit: 20 });
+    const row = reassignedInbox.messages.find((message: any) => message.task_id === taskId);
+    expect(row).toBeDefined();
+    expect(row.id).not.toBe(taskId);
+    expect(await call(oldOwnerTools.mark_tasks_consumed, { task_ids: [taskId] })).toEqual({
+      ok: false,
+      error: "task_not_owned",
+      task_id: taskId,
+    });
+    expect((await call(newOwnerTools.mark_tasks_consumed, { task_ids: [taskId] })).ok).toBe(true);
   });
 });

--- a/server/src/task-consumption.test.ts
+++ b/server/src/task-consumption.test.ts
@@ -226,7 +226,8 @@ describe("task consumed_at identity and lifecycle", () => {
     const retriedInbox = await call(nodeTools.get_inbox, { alias: NODE_A, limit: 20 });
     const retryRow = retriedInbox.messages.find((row: any) => row.id !== taskId && row.task_id === taskId);
     expect(retryRow).toBeDefined();
-    expect((await call(nodeTools.ack_inbox, { alias: NODE_A, message_id: retryRow.id })).ok).toBe(true);
+    expect((await call(nodeTools.ack_inbox, { alias: NODE_A, message_id: retryRow.task_id })).ok).toBe(true);
+    expect(db.get<{ acked: number }>("SELECT acked FROM inbox WHERE id = ?1", retryRow.id)?.acked).toBe(1);
     expect(db.get<{ status: string }>("SELECT status FROM tasks WHERE task_id = ?1", taskId)?.status).toBe("acked");
   });
 
@@ -240,6 +241,9 @@ describe("task consumed_at identity and lifecycle", () => {
     const retriedInbox = await call(nodeTools.get_inbox, { alias: NODE_A, limit: 20 });
     const retryRow = retriedInbox.messages.find((row: any) => row.id !== taskId && row.task_id === taskId);
     expect(retryRow).toBeDefined();
+    // Backward compatibility: an older consumer may still ACK the transport
+    // inbox.id even though all task lifecycle operations use logical task_id.
+    expect((await call(nodeTools.ack_inbox, { alias: NODE_A, message_id: retryRow.id })).ok).toBe(true);
     expect((await call(nodeTools.mark_tasks_consumed, { task_ids: [retryRow.task_id] })).ok).toBe(true);
     expect(typeof runtimeSubmittedAt(taskId)).toBe("string");
     expect(typeof consumedAt(taskId)).toBe("string");
@@ -262,6 +266,8 @@ describe("task consumed_at identity and lifecycle", () => {
     const row = reassignedInbox.messages.find((message: any) => message.task_id === taskId);
     expect(row).toBeDefined();
     expect(row.id).not.toBe(taskId);
+    expect((await call(newOwnerTools.ack_inbox, { alias: NODE_B, message_id: row.task_id })).ok).toBe(true);
+    expect(db.get<{ acked: number }>("SELECT acked FROM inbox WHERE id = ?1", row.id)?.acked).toBe(1);
     expect(await call(oldOwnerTools.mark_tasks_consumed, { task_ids: [taskId] })).toEqual({
       ok: false,
       error: "task_not_owned",

--- a/server/src/task-consumption.test.ts
+++ b/server/src/task-consumption.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db } from "./db.js";
+import { registerTools } from "./tools.js";
+
+const NET = "net_task_consumption";
+const USER = "user_task_consumption";
+const NODE_A = "node_consumption_a";
+const NODE_B = "node_consumption_b";
+
+type ToolHandler = (args: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+
+function cleanup() {
+  for (const table of ["tasks", "inbox", "task_events", "sessions", "nodes"]) {
+    try { db.run(`DELETE FROM ${table} WHERE network_id = ?1`, [NET]); } catch {}
+  }
+  try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [USER]); } catch {}
+}
+
+function seed() {
+  db.run("INSERT INTO users (user_id, username, password_hash, role, created_at) VALUES (?1, ?1, 'x', 'user', datetime('now'))", [USER]);
+  db.run("INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))", [NET, USER]);
+  db.run("INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))", [USER, NET]);
+  for (const alias of [NODE_A, NODE_B]) {
+    db.run(
+      "INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state) VALUES (?1, ?2, ?2, ?3, 'host', datetime('now'), datetime('now'), 'active')",
+      [`id_${alias}`, alias, NET],
+    );
+    db.run(
+      "INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at) VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))",
+      [`resume_${alias}`, alias, `id_${alias}`, NET],
+    );
+  }
+}
+
+function toolsFor(opts: { alias?: string; nodeToken?: boolean } = {}) {
+  const server = new McpServer({ name: "task-consumption-test", version: "0" }) as any;
+  const tools: Record<string, ToolHandler> = {};
+  const original = server.tool.bind(server);
+  server.tool = (name: string, description: string, schema: any, handler: ToolHandler) => {
+    tools[name] = handler;
+    return original(name, description, schema, handler);
+  };
+  registerTools(
+    server,
+    undefined,
+    NET,
+    USER,
+    opts.alias ?? USER,
+    opts.nodeToken ?? false,
+    opts.nodeToken ? `token_${opts.alias}` : null,
+  );
+  return tools;
+}
+
+async function call(handler: ToolHandler, args: any) {
+  const result = await handler(args);
+  return JSON.parse(result.content[0].text);
+}
+
+async function createTask(content: string, target = NODE_A): Promise<string> {
+  // The test calls the registered handler directly, bypassing MCP/Zod's
+  // default-value application, so spell out the production default.
+  const sent = await call(toolsFor()["send_task"], {
+    alias: target,
+    task: content,
+    priority: "normal",
+  });
+  expect(sent.ok).toBe(true);
+  return sent.task_id ?? sent.message_id;
+}
+
+function consumedAt(taskId: string): string | null {
+  return db.get<{ consumed_at: string | null }>(
+    "SELECT consumed_at FROM tasks WHERE task_id = ?1",
+    taskId,
+  )?.consumed_at ?? null;
+}
+
+function runtimeSubmittedAt(taskId: string): string | null {
+  return db.get<{ runtime_submitted_at: string | null }>(
+    "SELECT runtime_submitted_at FROM tasks WHERE task_id = ?1",
+    taskId,
+  )?.runtime_submitted_at ?? null;
+}
+
+beforeEach(() => { cleanup(); seed(); });
+afterAll(cleanup);
+
+describe("task consumed_at identity and lifecycle", () => {
+  test("enqueue and process-level ack keep consumed_at null", async () => {
+    const content = "connected process has not started a model turn";
+    const before = db.get<{ last_seen_at: string; task: string | null }>(
+      "SELECT last_seen_at, task FROM sessions WHERE network_id = ?1 AND alias = ?2",
+      NET,
+      NODE_A,
+    );
+    const taskId = await createTask(content);
+    expect(runtimeSubmittedAt(taskId)).toBeNull();
+    expect(consumedAt(taskId)).toBeNull();
+    const queued = db.get<{ last_seen_at: string; task: string | null }>(
+      "SELECT last_seen_at, task FROM sessions WHERE network_id = ?1 AND alias = ?2",
+      NET,
+      NODE_A,
+    );
+    // Preserve the issue's witnessed-red shape: dispatch echoes the sender's
+    // own text into the legacy session.task field while the receiver's
+    // heartbeat remains frozen. consumed_at must not inherit that false cue.
+    expect(queued?.task).toBe(content);
+    expect(queued?.last_seen_at).toBe(before?.last_seen_at);
+
+    const nodeTools = toolsFor({ alias: NODE_A, nodeToken: true });
+    expect((await call(nodeTools.ack_inbox, { alias: NODE_A, message_id: taskId })).ok).toBe(true);
+    expect(runtimeSubmittedAt(taskId)).toBeNull();
+    expect(consumedAt(taskId)).toBeNull();
+  });
+
+  test("runtime submission is visible without claiming authoritative consumption", async () => {
+    const taskId = await createTask("vendor request accepted but no turn event yet");
+    const handler = toolsFor({ alias: NODE_A, nodeToken: true }).mark_tasks_runtime_submitted;
+    expect((await call(handler, { task_ids: [taskId] })).ok).toBe(true);
+    expect(typeof runtimeSubmittedAt(taskId)).toBe("string");
+    expect(consumedAt(taskId)).toBeNull();
+  });
+
+  test("token-bound target marks exact task idempotently", async () => {
+    const taskId = await createTask("runtime emitted an attributable event");
+    const handler = toolsFor({ alias: NODE_A, nodeToken: true }).mark_tasks_consumed;
+
+    const first = await call(handler, { task_ids: [taskId] });
+    expect(first.ok).toBe(true);
+    expect(first.tasks).toHaveLength(1);
+    expect(typeof runtimeSubmittedAt(taskId)).toBe("string");
+    expect(typeof consumedAt(taskId)).toBe("string");
+    const timestamp = consumedAt(taskId);
+
+    const replay = await call(handler, { task_ids: [taskId] });
+    expect(replay.ok).toBe(true);
+    expect(consumedAt(taskId)).toBe(timestamp);
+
+    const listed = await call(toolsFor().list_tasks, { alias: NODE_A, limit: 20 });
+    const listedTask = listed.tasks.find((task: any) => task.task_id === taskId);
+    expect(listedTask?.runtime_submitted_at).toBe(runtimeSubmittedAt(taskId));
+    expect(listedTask?.consumed_at).toBe(timestamp);
+  });
+
+  test("one runtime wake can mark an exact batch of owned tasks", async () => {
+    const firstTask = await createTask("batched wake first");
+    const secondTask = await createTask("batched wake second");
+    const result = await call(
+      toolsFor({ alias: NODE_A, nodeToken: true }).mark_tasks_consumed,
+      { task_ids: [firstTask, secondTask] },
+    );
+    expect(result.ok).toBe(true);
+    expect(new Set(result.tasks.map((row: any) => row.task_id)))
+      .toEqual(new Set([firstTask, secondTask]));
+    expect(typeof consumedAt(firstTask)).toBe("string");
+    expect(typeof consumedAt(secondTask)).toBe("string");
+  });
+
+  test("foreign or missing row rejects the whole batch with zero partial writes", async () => {
+    const ownTask = await createTask("owned", NODE_A);
+    const foreignTask = await createTask("foreign", NODE_B);
+    const handler = toolsFor({ alias: NODE_A, nodeToken: true }).mark_tasks_consumed;
+
+    expect(await call(handler, { task_ids: [ownTask, foreignTask] })).toEqual({
+      ok: false,
+      error: "task_not_owned",
+      task_id: foreignTask,
+    });
+    expect(consumedAt(ownTask)).toBeNull();
+    expect(consumedAt(foreignTask)).toBeNull();
+    expect(runtimeSubmittedAt(ownTask)).toBeNull();
+    expect(runtimeSubmittedAt(foreignTask)).toBeNull();
+  });
+
+  test("user token cannot forge runtime consumption", async () => {
+    const taskId = await createTask("user token must not stamp node evidence");
+    const result = await call(toolsFor().mark_tasks_consumed, { task_ids: [taskId] });
+    expect(result).toEqual({ ok: false, error: "node_token_required" });
+    expect(runtimeSubmittedAt(taskId)).toBeNull();
+    expect(consumedAt(taskId)).toBeNull();
+  });
+
+  test("retry and reassign clear evidence from the previous delivery attempt", async () => {
+    const taskId = await createTask("attempt-scoped evidence");
+    const nodeTools = toolsFor({ alias: NODE_A, nodeToken: true });
+    expect((await call(nodeTools.mark_tasks_consumed, { task_ids: [taskId] })).ok).toBe(true);
+    expect(typeof consumedAt(taskId)).toBe("string");
+
+    db.run("UPDATE tasks SET status = 'failed' WHERE task_id = ?1", [taskId]);
+    expect((await call(toolsFor().retry_task, { task_id: taskId })).ok).toBe(true);
+    expect(runtimeSubmittedAt(taskId)).toBeNull();
+    expect(consumedAt(taskId)).toBeNull();
+
+    expect((await call(nodeTools.mark_tasks_consumed, { task_ids: [taskId] })).ok).toBe(true);
+    expect(typeof consumedAt(taskId)).toBe("string");
+    expect((await call(toolsFor().reassign_task, { task_id: taskId, new_alias: NODE_B })).ok).toBe(true);
+    expect(runtimeSubmittedAt(taskId)).toBeNull();
+    expect(consumedAt(taskId)).toBeNull();
+  });
+});

--- a/server/src/task-consumption.test.ts
+++ b/server/src/task-consumption.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db } from "./db.js";
+import { dispatchScheduledOccurrence } from "./scheduled-tasks.js";
 import { registerTools } from "./tools.js";
 
 const NET = "net_task_consumption";
@@ -11,7 +12,7 @@ const NODE_B = "node_consumption_b";
 type ToolHandler = (args: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
 
 function cleanup() {
-  for (const table of ["tasks", "inbox", "task_events", "sessions", "nodes"]) {
+  for (const table of ["scheduled_task_runs", "scheduled_tasks", "tasks", "inbox", "task_events", "sessions", "nodes"]) {
     try { db.run(`DELETE FROM ${table} WHERE network_id = ?1`, [NET]); } catch {}
   }
   try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET]); } catch {}
@@ -274,5 +275,55 @@ describe("task consumed_at identity and lifecycle", () => {
       task_id: taskId,
     });
     expect((await call(newOwnerTools.mark_tasks_consumed, { task_ids: [taskId] })).ok).toBe(true);
+  });
+
+  test("scheduler delivery writes and exposes the same logical task id", async () => {
+    const scheduleId = `sched_${crypto.randomUUID()}`;
+    const scheduledFor = new Date(Date.now() + 60_000).toISOString();
+    const row = {
+      schedule_id: scheduleId,
+      network_id: NET,
+      created_by: USER,
+      name: "task linkage schedule",
+      target_node_id: `id_${NODE_A}`,
+      target_alias: NODE_A,
+      task_content: "scheduler must preserve logical task identity",
+      priority: "normal",
+      schedule_type: "once",
+      schedule_json: JSON.stringify({ type: "once", run_at: scheduledFor }),
+      timezone: "UTC",
+      overlap_policy: "skip",
+      misfire_policy: "catch_up_once",
+      status: "active",
+      next_run_at: scheduledFor,
+      last_run_at: null,
+      revision: 1,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as any;
+    db.run(
+      `INSERT INTO scheduled_tasks
+       (schedule_id, network_id, created_by, name, target_node_id, target_alias,
+        task_content, priority, schedule_type, schedule_json, timezone,
+        overlap_policy, misfire_policy, status, next_run_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)`,
+      [scheduleId, NET, USER, row.name, row.target_node_id, NODE_A, row.task_content,
+       row.priority, row.schedule_type, row.schedule_json, row.timezone,
+       row.overlap_policy, row.misfire_policy, row.status, row.next_run_at],
+    );
+
+    const dispatched = dispatchScheduledOccurrence(row, scheduledFor, false);
+    expect(dispatched.taskId).toBeTruthy();
+    const inbox = db.get<{ id: string; task_id: string }>(
+      "SELECT id, task_id FROM inbox WHERE id = ?1",
+      [dispatched.taskId],
+    );
+    expect(inbox).toEqual({ id: dispatched.taskId!, task_id: dispatched.taskId! });
+    const pending = await call(
+      toolsFor({ alias: NODE_A, nodeToken: true }).get_inbox,
+      { alias: NODE_A, limit: 20 },
+    );
+    expect(pending.messages.find((message: any) => message.id === dispatched.taskId)?.task_id)
+      .toBe(dispatched.taskId);
   });
 });

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -850,7 +850,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const rows0 = db.get<{ cnt: number }>(countSql, ...countParams);
       console.log(`[${ts()}] ${alias} → get_inbox: ${rows0?.cnt ?? 0} pending messages`);
       const rowsParams: any[] = [alias];
-      let rowsSql = `SELECT id, type, priority, content, context, from_session, created_at, network_id, meta_json
+      let rowsSql = `SELECT id, type, priority, content, context, from_session, created_at, network_id, meta_json,
+         CASE WHEN type = 'task' THEN COALESCE(task_id, id) ELSE task_id END AS task_id
          FROM inbox WHERE session_name = ?1 AND acked = 0`;
       rowsSql = addReadScope(rowsSql, rowsParams, readScope);
       rowsSql += ` ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END, created_at
@@ -883,6 +884,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const ackParams: any[] = [message_id, alias];
       let ackSql = "UPDATE inbox SET acked = 1 WHERE id = ?1 AND session_name = ?2";
       ackSql = addScope(ackSql, ackParams, effectiveNetId);
+      const inboxTaskParams: any[] = [message_id, alias];
+      let inboxTaskSql = "SELECT type, COALESCE(task_id, id) AS task_id FROM inbox WHERE id = ?1 AND session_name = ?2";
+      inboxTaskSql = addScope(inboxTaskSql, inboxTaskParams, effectiveNetId);
+      const inboxTask = db.get<{ type: string; task_id: string }>(inboxTaskSql, ...inboxTaskParams);
       const result = db.run(ackSql, ackParams);
       if (result.changes === 0) {
         return {
@@ -891,11 +896,14 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }
       // V2: sync tasks table — ack_inbox means delivered→acked
       try {
-        const taskParams: any[] = [message_id];
+        if (inboxTask?.type !== "task") {
+          return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }] };
+        }
+        const taskParams: any[] = [inboxTask?.task_id ?? message_id];
         let taskSql = "UPDATE tasks SET status = 'acked' WHERE task_id = ?1 AND status = 'delivered'";
         taskSql = addScope(taskSql, taskParams, effectiveNetId);
         const ackResult = db.run(taskSql, taskParams);
-        if (ackResult.changes > 0) logTaskEvent(message_id, "delivered", "acked", alias);
+        if (ackResult.changes > 0) logTaskEvent(inboxTask?.task_id ?? message_id, "delivered", "acked", alias);
       } catch {}
       return {
         content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }],
@@ -940,60 +948,69 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         };
       }
 
+      const placeholders = uniqueTaskIds.map((_, i) => `?${i + 2}`).join(", ");
       const canonicalCaller = resolveCanonicalAlias(enforceNetworkId, callerAlias).alias;
       const callerSession = db.get<{ node_id: string | null }>(
-        "SELECT node_id FROM sessions WHERE network_id = ?1 AND alias = ?2",
+        `SELECT node_id FROM sessions
+         WHERE network_id = ?1 AND alias = ?2
+         ORDER BY updated_at DESC LIMIT 1`,
         enforceNetworkId,
         canonicalCaller,
       );
-      if (!callerSession?.node_id) {
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "node_identity_unavailable" }) }],
-        };
-      }
 
-      const placeholders = uniqueTaskIds.map((_, i) => `?${i + 2}`).join(", ");
-      const rows = db.all<{ task_id: string; to_node_id: string | null }>(
-        `SELECT task_id, to_node_id FROM tasks
-         WHERE network_id = ?1 AND task_id IN (${placeholders})`,
-        enforceNetworkId,
-        ...uniqueTaskIds,
-      );
-      const owned = new Map(rows.map((row) => [row.task_id, row.to_node_id]));
-      const rejectedTaskId = uniqueTaskIds.find(
-        (taskId) => owned.get(taskId) !== callerSession.node_id,
-      );
-      if (rejectedTaskId) {
-        // One foreign/missing row rejects the whole batch.  Partial marking
-        // would make a single agent wake look different depending on input
-        // order and would hide an identity/configuration fault.
-        return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({ ok: false, error: "task_not_owned", task_id: rejectedTaskId }),
-          }],
-        };
-      }
+      // Keep ownership preflight and every stamp in one SQLite transaction.
+      // This closes the cross-process preflight→UPDATE race: no other writer
+      // can reassign a task between the identity decision and the write.
+      const outcome = db.transaction(() => {
+        const rows = db.all<{ task_id: string; to_node_id: string | null; to_name: string }>(
+          `SELECT task_id, to_node_id, to_name FROM tasks
+           WHERE network_id = ?1 AND task_id IN (${placeholders})`,
+          enforceNetworkId,
+          ...uniqueTaskIds,
+        );
+        const owned = new Map(rows.map((row) => [row.task_id, row]));
+        const rejectedTaskId = uniqueTaskIds.find((taskId) => {
+          const row = owned.get(taskId);
+          if (!row) return true;
+          // Prefer immutable node identity whenever the task has one.  Direct
+          // and legacy token-bound sessions legitimately have NULL node_id;
+          // only that shape may fall back to the canonical token alias.
+          if (row.to_node_id) return row.to_node_id !== callerSession?.node_id;
+          return resolveCanonicalAlias(enforceNetworkId, row.to_name).alias !== canonicalCaller;
+        });
+        if (rejectedTaskId) {
+          return { ok: false as const, error: "task_not_owned", task_id: rejectedTaskId };
+        }
 
-      const evidenceRows = db.transaction(() => {
         for (const taskId of uniqueTaskIds) {
+          const row = owned.get(taskId)!;
+          const ownershipSql = row.to_node_id
+            ? "to_node_id = ?3"
+            : "to_node_id IS NULL AND to_name = ?3";
+          const ownerValue = row.to_node_id ?? row.to_name;
+          let updateResult;
           if (level === "consumed") {
-            db.run(
+            updateResult = db.run(
               `UPDATE tasks SET
                  runtime_submitted_at = COALESCE(runtime_submitted_at, datetime('now')),
                  consumed_at = COALESCE(consumed_at, datetime('now'))
-               WHERE network_id = ?1 AND task_id = ?2 AND to_node_id = ?3`,
-              [enforceNetworkId, taskId, callerSession.node_id],
+               WHERE network_id = ?1 AND task_id = ?2 AND ${ownershipSql}`,
+              [enforceNetworkId, taskId, ownerValue],
             );
           } else {
-            db.run(
+            updateResult = db.run(
               `UPDATE tasks SET runtime_submitted_at = COALESCE(runtime_submitted_at, datetime('now'))
-               WHERE network_id = ?1 AND task_id = ?2 AND to_node_id = ?3`,
-              [enforceNetworkId, taskId, callerSession.node_id],
+               WHERE network_id = ?1 AND task_id = ?2 AND ${ownershipSql}`,
+              [enforceNetworkId, taskId, ownerValue],
             );
           }
+          if (updateResult.changes !== 1) {
+            // A zero-row write after a successful preflight is an invariant
+            // failure, never a successful evidence report.
+            throw new Error(`task_runtime_evidence_write_race:${taskId}`);
+          }
         }
-        return db.all<{
+        const evidenceRows = db.all<{
           task_id: string;
           runtime_submitted_at: string;
           consumed_at: string | null;
@@ -1003,12 +1020,13 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           enforceNetworkId,
           ...uniqueTaskIds,
         );
+        return { ok: true as const, tasks: evidenceRows };
       });
 
       return {
         content: [{
           type: "text" as const,
-          text: JSON.stringify({ ok: true, tasks: evidenceRows }),
+          text: JSON.stringify(outcome),
         }],
       };
   };
@@ -1272,8 +1290,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       // 报告冲突）。
       db.transaction(() => {
         db.run(
-          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, context, from_session, requires_response, network_id, meta_json)
-           VALUES (?1, ?2, ?3, 'task', ?4, ?5, ?6, ?7, 'reply', ?8, ?9)`,
+          `INSERT INTO inbox (id, task_id, session_name, node_id, type, priority, content, context, from_session, requires_response, network_id, meta_json)
+           VALUES (?1, ?1, ?2, ?3, 'task', ?4, ?5, ?6, ?7, 'reply', ?8, ?9)`,
           [id, targetAlias, targetNodeId, priority, task, context ?? null, from_session, effectiveNetId ?? null, metaJson]
         );
         db.run(
@@ -1700,16 +1718,16 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       db.transaction(() => {
         // Reset task status
         const updateParams: any[] = [task_id];
-        let updateSql = `UPDATE tasks SET status = 'delivered', result = NULL, completed_at = NULL, started_at = NULL, runtime_submitted_at = NULL, consumed_at = NULL, delivered_at = datetime('now'), expires_at = datetime('now', '+1 hour')
+        let updateSql = `UPDATE tasks SET status = 'delivered', result = NULL, completed_at = NULL, started_at = NULL, delivered_at = datetime('now'), expires_at = datetime('now', '+1 hour')
            WHERE task_id = ?1`;
         updateSql = addScope(updateSql, updateParams, effectiveNetId);
         db.run(updateSql, updateParams);
         // Re-queue in inbox with new ID (original ID may already exist)
         const retryInboxId = uuidv4();
         db.run(
-          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, requires_response, network_id)
-           VALUES (?1, ?2, ?3, 'task', ?4, ?5, ?6, 'reply', ?7)`,
-          [retryInboxId, task.to_name, task.to_node_id ?? resolveNodeIdForAlias(task.to_name, effectiveNetId ?? task.network_id ?? null), task.priority, task.content, from_session, effectiveNetId ?? task.network_id ?? null]
+          `INSERT INTO inbox (id, task_id, session_name, node_id, type, priority, content, from_session, requires_response, network_id)
+           VALUES (?1, ?2, ?3, ?4, 'task', ?5, ?6, ?7, 'reply', ?8)`,
+          [retryInboxId, task_id, task.to_name, task.to_node_id ?? resolveNodeIdForAlias(task.to_name, effectiveNetId ?? task.network_id ?? null), task.priority, task.content, from_session, effectiveNetId ?? task.network_id ?? null]
         );
       });
       logTaskEvent(task_id, task.status, "delivered", from_session, "retry");
@@ -1809,7 +1827,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       // Also ack the inbox entry to prevent agent from picking it up
       if (result.changes > 0) {
         const inboxParams: any[] = [task_id];
-        let inboxSql = "UPDATE inbox SET acked = 1 WHERE id = ?1 AND acked = 0";
+        let inboxSql = "UPDATE inbox SET acked = 1 WHERE COALESCE(task_id, id) = ?1 AND acked = 0";
         inboxSql = addScope(inboxSql, inboxParams, effectiveNetId);
         db.run(inboxSql, inboxParams);
         logTaskEvent(task_id, null, "cancelled", from_session, reason || undefined);
@@ -1855,18 +1873,18 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       db.transaction(() => {
         // Ack old inbox to prevent original agent from picking it up
         const inboxParams: any[] = [task_id];
-        let inboxSql = "UPDATE inbox SET acked = 1 WHERE id = ?1 AND acked = 0";
+        let inboxSql = "UPDATE inbox SET acked = 1 WHERE COALESCE(task_id, id) = ?1 AND acked = 0";
         inboxSql = addScope(inboxSql, inboxParams, effectiveNetId);
         db.run(inboxSql, inboxParams);
 
         const updateParams: any[] = [reassignedAlias, newNodeId, task_id];
-        let updateSql = "UPDATE tasks SET to_name = ?1, to_node_id = ?2, status = 'delivered', started_at = NULL, runtime_submitted_at = NULL, consumed_at = NULL, delivered_at = datetime('now') WHERE task_id = ?3";
+        let updateSql = "UPDATE tasks SET to_name = ?1, to_node_id = ?2, status = 'delivered', started_at = NULL, delivered_at = datetime('now') WHERE task_id = ?3";
         updateSql = addScope(updateSql, updateParams, effectiveNetId);
         db.run(updateSql, updateParams);
 
         const newInboxId = uuidv4();
-        db.run("INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, requires_response, network_id) VALUES (?1, ?2, ?3, 'task', ?4, ?5, ?6, 'reply', ?7)",
-          [newInboxId, reassignedAlias, newNodeId, task.priority, task.content, from_session, effectiveNetId ?? task.network_id ?? null]);
+        db.run("INSERT INTO inbox (id, task_id, session_name, node_id, type, priority, content, from_session, requires_response, network_id) VALUES (?1, ?2, ?3, ?4, 'task', ?5, ?6, ?7, 'reply', ?8)",
+          [newInboxId, task_id, reassignedAlias, newNodeId, task.priority, task.content, from_session, effectiveNetId ?? task.network_id ?? null]);
       });
       logTaskEvent(task_id, task.status, "delivered", from_session, `reassign: ${oldAlias} → ${reassignedAlias}`);
       pushEvent(reassignedAlias, { type: "new_task", inbox_count: 1, priority: task.priority, from: from_session, ...(canonical.renamed ? { renamed_from: new_alias } : {}) }, effectiveNetId ?? task.network_id ?? null);

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -881,13 +881,27 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const effectiveNetId = getNetworkId(netId);
       if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId);
       console.log(`[${ts()}] ${alias} → ack_inbox: ${message_id.slice(0, 8)}`);
-      const ackParams: any[] = [message_id, alias];
-      let ackSql = "UPDATE inbox SET acked = 1 WHERE id = ?1 AND session_name = ?2";
-      ackSql = addScope(ackSql, ackParams, effectiveNetId);
+      // New task consumers ACK by the logical tasks.task_id exposed by
+      // get_inbox. Keep exact inbox.id support for legacy consumers and for
+      // non-task messages. Restrict the lookup to pending rows: after a retry
+      // the original row can have id == task_id but is already ACKed, while
+      // the current row has a fresh transport id and the same logical task_id.
       const inboxTaskParams: any[] = [message_id, alias];
-      let inboxTaskSql = "SELECT type, COALESCE(task_id, id) AS task_id FROM inbox WHERE id = ?1 AND session_name = ?2";
+      let inboxTaskSql = `SELECT id, type, COALESCE(task_id, id) AS task_id
+         FROM inbox
+         WHERE session_name = ?2 AND acked = 0
+           AND (id = ?1 OR (type = 'task' AND task_id = ?1))`;
       inboxTaskSql = addScope(inboxTaskSql, inboxTaskParams, effectiveNetId);
-      const inboxTask = db.get<{ type: string; task_id: string }>(inboxTaskSql, ...inboxTaskParams);
+      inboxTaskSql += " ORDER BY created_at DESC LIMIT 1";
+      const inboxTask = db.get<{ id: string; type: string; task_id: string }>(inboxTaskSql, ...inboxTaskParams);
+      if (!inboxTask) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "message not found or already acknowledged" }) }],
+        };
+      }
+      const ackParams: any[] = [inboxTask.id, alias];
+      let ackSql = "UPDATE inbox SET acked = 1 WHERE id = ?1 AND session_name = ?2 AND acked = 0";
+      ackSql = addScope(ackSql, ackParams, effectiveNetId);
       const result = db.run(ackSql, ackParams);
       if (result.changes === 0) {
         return {
@@ -899,11 +913,11 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         if (inboxTask?.type !== "task") {
           return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }] };
         }
-        const taskParams: any[] = [inboxTask?.task_id ?? message_id];
+        const taskParams: any[] = [inboxTask.task_id];
         let taskSql = "UPDATE tasks SET status = 'acked' WHERE task_id = ?1 AND status = 'delivered'";
         taskSql = addScope(taskSql, taskParams, effectiveNetId);
         const ackResult = db.run(taskSql, taskParams);
-        if (ackResult.changes > 0) logTaskEvent(inboxTask?.task_id ?? message_id, "delivered", "acked", alias);
+        if (ackResult.changes > 0) logTaskEvent(inboxTask.task_id, "delivered", "acked", alias);
       } catch {}
       return {
         content: [{ type: "text" as const, text: JSON.stringify({ ok: true }) }],

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -963,12 +963,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }
 
       const placeholders = uniqueTaskIds.map((_, i) => `?${i + 2}`).join(", ");
-      const canonicalCaller = resolveCanonicalAlias(enforceNetworkId, callerAlias).alias;
 
       // Keep ownership preflight and every stamp in one SQLite transaction.
       // This closes the cross-process preflight→UPDATE race: no other writer
       // can reassign a task between the identity decision and the write.
       const outcome = db.transaction(() => {
+        const canonicalCaller = resolveCanonicalAlias(enforceNetworkId, callerAlias).alias;
         const callerSession = db.get<{ node_id: string | null }>(
           `SELECT node_id FROM sessions
            WHERE network_id = ?1 AND alias = ?2

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -964,18 +964,18 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
       const placeholders = uniqueTaskIds.map((_, i) => `?${i + 2}`).join(", ");
       const canonicalCaller = resolveCanonicalAlias(enforceNetworkId, callerAlias).alias;
-      const callerSession = db.get<{ node_id: string | null }>(
-        `SELECT node_id FROM sessions
-         WHERE network_id = ?1 AND alias = ?2
-         ORDER BY updated_at DESC LIMIT 1`,
-        enforceNetworkId,
-        canonicalCaller,
-      );
 
       // Keep ownership preflight and every stamp in one SQLite transaction.
       // This closes the cross-process preflight→UPDATE race: no other writer
       // can reassign a task between the identity decision and the write.
       const outcome = db.transaction(() => {
+        const callerSession = db.get<{ node_id: string | null }>(
+          `SELECT node_id FROM sessions
+           WHERE network_id = ?1 AND alias = ?2
+           ORDER BY updated_at DESC LIMIT 1`,
+          enforceNetworkId,
+          canonicalCaller,
+        );
         const rows = db.all<{ task_id: string; to_node_id: string | null; to_name: string }>(
           `SELECT task_id, to_node_id, to_name FROM tasks
            WHERE network_id = ?1 AND task_id IN (${placeholders})`,

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -903,6 +903,134 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     }
   );
 
+  // #520 — two monotonic runtime-evidence levels for exact tasks.
+  //
+  // runtime_submitted_at means agent-node handed the body to the vendor
+  // runtime. consumed_at is stronger: an attributable turn-start or first
+  // activity event came back. Merely fetching/acking an inbox row sets neither.
+  // Node identity comes exclusively from the ntok; callers cannot self-report
+  // an alias or node_id. A consumed mark also fills runtime_submitted_at because
+  // that stronger fact logically implies submission.
+  const markTaskRuntimeEvidence = (
+    taskIds: string[],
+    level: "submitted" | "consumed",
+  ) => {
+    const task_ids = taskIds;
+    if (!callerTokenIsNetwork || !callerAlias || !enforceNetworkId) {
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "node_token_required" }) }],
+      };
+    }
+    // PgAdapter.transaction currently opens a fresh subprocess/connection
+    // per statement. The all-or-nothing batch promise cannot be made there;
+    // refuse evidence rather than publish a partially stamped batch.
+    if (db.dialect !== "sqlite") {
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({
+          ok: false,
+          error: "task_runtime_evidence_backend_unsupported",
+        }) }],
+      };
+    }
+
+      const uniqueTaskIds = [...new Set(task_ids)];
+      if (uniqueTaskIds.length !== task_ids.length) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "duplicate_task_id" }) }],
+        };
+      }
+
+      const canonicalCaller = resolveCanonicalAlias(enforceNetworkId, callerAlias).alias;
+      const callerSession = db.get<{ node_id: string | null }>(
+        "SELECT node_id FROM sessions WHERE network_id = ?1 AND alias = ?2",
+        enforceNetworkId,
+        canonicalCaller,
+      );
+      if (!callerSession?.node_id) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "node_identity_unavailable" }) }],
+        };
+      }
+
+      const placeholders = uniqueTaskIds.map((_, i) => `?${i + 2}`).join(", ");
+      const rows = db.all<{ task_id: string; to_node_id: string | null }>(
+        `SELECT task_id, to_node_id FROM tasks
+         WHERE network_id = ?1 AND task_id IN (${placeholders})`,
+        enforceNetworkId,
+        ...uniqueTaskIds,
+      );
+      const owned = new Map(rows.map((row) => [row.task_id, row.to_node_id]));
+      const rejectedTaskId = uniqueTaskIds.find(
+        (taskId) => owned.get(taskId) !== callerSession.node_id,
+      );
+      if (rejectedTaskId) {
+        // One foreign/missing row rejects the whole batch.  Partial marking
+        // would make a single agent wake look different depending on input
+        // order and would hide an identity/configuration fault.
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({ ok: false, error: "task_not_owned", task_id: rejectedTaskId }),
+          }],
+        };
+      }
+
+      const evidenceRows = db.transaction(() => {
+        for (const taskId of uniqueTaskIds) {
+          if (level === "consumed") {
+            db.run(
+              `UPDATE tasks SET
+                 runtime_submitted_at = COALESCE(runtime_submitted_at, datetime('now')),
+                 consumed_at = COALESCE(consumed_at, datetime('now'))
+               WHERE network_id = ?1 AND task_id = ?2 AND to_node_id = ?3`,
+              [enforceNetworkId, taskId, callerSession.node_id],
+            );
+          } else {
+            db.run(
+              `UPDATE tasks SET runtime_submitted_at = COALESCE(runtime_submitted_at, datetime('now'))
+               WHERE network_id = ?1 AND task_id = ?2 AND to_node_id = ?3`,
+              [enforceNetworkId, taskId, callerSession.node_id],
+            );
+          }
+        }
+        return db.all<{
+          task_id: string;
+          runtime_submitted_at: string;
+          consumed_at: string | null;
+        }>(
+          `SELECT task_id, runtime_submitted_at, consumed_at FROM tasks
+           WHERE network_id = ?1 AND task_id IN (${placeholders})`,
+          enforceNetworkId,
+          ...uniqueTaskIds,
+        );
+      });
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify({ ok: true, tasks: evidenceRows }),
+        }],
+      };
+  };
+
+  const taskRuntimeEvidenceSchema = {
+    task_ids: z.array(z.string().min(1).max(200)).min(1).max(100),
+  };
+
+  server.tool(
+    "mark_tasks_runtime_submitted",
+    "Internal agent-node signal: exact task bodies were submitted to this token-bound node's vendor runtime.",
+    taskRuntimeEvidenceSchema,
+    async ({ task_ids }) => markTaskRuntimeEvidence(task_ids, "submitted"),
+  );
+
+  server.tool(
+    "mark_tasks_consumed",
+    "Internal agent-node signal: exact tasks produced attributable turn-start/activity evidence in this token-bound node's runtime.",
+    taskRuntimeEvidenceSchema,
+    async ({ task_ids }) => markTaskRuntimeEvidence(task_ids, "consumed"),
+  );
+
   // ═══════════════════════════════════════════
   //  Hub Tools (5)
   // ═══════════════════════════════════════════
@@ -1572,7 +1700,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       db.transaction(() => {
         // Reset task status
         const updateParams: any[] = [task_id];
-        let updateSql = `UPDATE tasks SET status = 'delivered', result = NULL, completed_at = NULL, started_at = NULL, delivered_at = datetime('now'), expires_at = datetime('now', '+1 hour')
+        let updateSql = `UPDATE tasks SET status = 'delivered', result = NULL, completed_at = NULL, started_at = NULL, runtime_submitted_at = NULL, consumed_at = NULL, delivered_at = datetime('now'), expires_at = datetime('now', '+1 hour')
            WHERE task_id = ?1`;
         updateSql = addScope(updateSql, updateParams, effectiveNetId);
         db.run(updateSql, updateParams);
@@ -1632,7 +1760,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     async ({ alias, status, from_name, from_node_id, network_id: netId, limit }) => {
       const readScope = resolveReadScope(netId);
       if (readScope.denied) return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: readScope.denied }) }] };
-      let sql = "SELECT task_id, from_node_id, from_name, to_node_id, to_name, priority, status, content, result, created_at, completed_at FROM tasks WHERE 1=1";
+      let sql = "SELECT task_id, from_node_id, from_name, to_node_id, to_name, priority, status, content, result, created_at, runtime_submitted_at, consumed_at, completed_at FROM tasks WHERE 1=1";
       const params: any[] = [];
       sql = addReadScope(sql, params, readScope);
       if (alias) { sql += ` AND to_name = ?${params.length + 1}`; params.push(alias); }
@@ -1732,7 +1860,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         db.run(inboxSql, inboxParams);
 
         const updateParams: any[] = [reassignedAlias, newNodeId, task_id];
-        let updateSql = "UPDATE tasks SET to_name = ?1, to_node_id = ?2, status = 'delivered', started_at = NULL, delivered_at = datetime('now') WHERE task_id = ?3";
+        let updateSql = "UPDATE tasks SET to_name = ?1, to_node_id = ?2, status = 'delivered', started_at = NULL, runtime_submitted_at = NULL, consumed_at = NULL, delivered_at = datetime('now') WHERE task_id = ?3";
         updateSql = addScope(updateSql, updateParams, effectiveNetId);
         db.run(updateSql, updateParams);
 

--- a/tests/test671-task-runtime-evidence-hub/Dockerfile
+++ b/tests/test671-task-runtime-evidence-hub/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /repo
+COPY server/package.json /repo/server/package.json
+RUN cd /repo/server && bun install
+COPY server /repo/server
+COPY docs/rfcs/RFC-035-task-runtime-evidence.md /repo/docs/rfcs/RFC-035-task-runtime-evidence.md
+COPY docs-site/docs /repo/docs-site/docs
+COPY tests/test671-task-runtime-evidence-hub /repo/tests/test671-task-runtime-evidence-hub
+RUN chmod +x /repo/tests/test671-task-runtime-evidence-hub/run.sh
+
+ARG TEST671_SOURCE_COMMIT=unknown
+ENV TEST671_SOURCE_COMMIT=$TEST671_SOURCE_COMMIT
+
+CMD ["bash", "/repo/tests/test671-task-runtime-evidence-hub/run.sh"]

--- a/tests/test671-task-runtime-evidence-hub/run.sh
+++ b/tests/test671-task-runtime-evidence-hub/run.sh
@@ -83,6 +83,16 @@ else
 fi
 cp /tmp/test671-tools.orig server/src/tools.ts
 
+sed -i "s/AND (id = ?1 OR (type = 'task' AND task_id = ?1))/AND id = ?1/" server/src/tools.ts
+if cmp -s /tmp/test671-tools.orig server/src/tools.ts; then
+  bad "remove-logical-task-ack mutation did not change source"
+else
+  grep -F "AND id = ?1" server/src/tools.ts >/dev/null
+  expect_red remove-logical-task-ack env COMMHUB_DB=/tmp/test671-mut-logical-ack.db \
+    bun test server/src/task-consumption.test.ts
+fi
+cp /tmp/test671-tools.orig server/src/tools.ts
+
 sed -i "s/status = 'delivered', result = NULL, completed_at = NULL, started_at = NULL, delivered_at/status = 'delivered', result = NULL, completed_at = NULL, started_at = NULL, runtime_submitted_at = NULL, consumed_at = NULL, delivered_at/" server/src/tools.ts
 if cmp -s /tmp/test671-tools.orig server/src/tools.ts; then
   bad "clear-task-lifetime-evidence-on-retry mutation did not change source"

--- a/tests/test671-task-runtime-evidence-hub/run.sh
+++ b/tests/test671-task-runtime-evidence-hub/run.sh
@@ -29,6 +29,9 @@ cd "$ROOT"
 COMMHUB_DB=/tmp/test671-hub.db bun test server/src/task-consumption.test.ts
 ok "two-level task runtime evidence contract"
 
+COMMHUB_DB=/tmp/test671-rest.db bun test server/src/task-auth-origin-http.test.ts
+ok "REST initial task delivery writes logical inbox task_id"
+
 bun build server/src/index.ts --target bun --outdir /tmp/test671-server-build >/dev/null
 ok "production Hub bundle builds"
 
@@ -102,6 +105,34 @@ else
     bun test server/src/task-consumption.test.ts
 fi
 cp /tmp/test671-tools.orig server/src/tools.ts
+
+cp server/src/scheduled-tasks.ts /tmp/test671-scheduled.orig
+if [[ "$(grep -F "VALUES (?1, ?1, ?2, ?3, 'task'" server/src/scheduled-tasks.ts | wc -l)" -ne 1 ]]; then
+  bad "scheduler task-id mutation anchor count changed"
+else
+  sed -i "s/VALUES (?1, ?1, ?2, ?3, 'task'/VALUES (?1, NULL, ?2, ?3, 'task'/" server/src/scheduled-tasks.ts
+  if cmp -s /tmp/test671-scheduled.orig server/src/scheduled-tasks.ts; then
+    bad "unlink-scheduler-task-id mutation did not change source"
+  else
+    expect_red unlink-scheduler-task-id env COMMHUB_DB=/tmp/test671-mut-scheduler-link.db \
+      bun test server/src/task-consumption.test.ts
+  fi
+fi
+cp /tmp/test671-scheduled.orig server/src/scheduled-tasks.ts
+
+cp server/src/server.ts /tmp/test671-server.orig
+if [[ "$(grep -F "VALUES (?1, ?1, ?2, ?3, 'task'" server/src/server.ts | wc -l)" -ne 1 ]]; then
+  bad "REST task-id mutation anchor count changed"
+else
+  sed -i "s/VALUES (?1, ?1, ?2, ?3, 'task'/VALUES (?1, NULL, ?2, ?3, 'task'/" server/src/server.ts
+  if cmp -s /tmp/test671-server.orig server/src/server.ts; then
+    bad "unlink-rest-task-id mutation did not change source"
+  else
+    expect_red unlink-rest-task-id env COMMHUB_DB=/tmp/test671-mut-rest-link.db \
+      bun test server/src/task-auth-origin-http.test.ts
+  fi
+fi
+cp /tmp/test671-server.orig server/src/server.ts
 
 printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/test671-task-runtime-evidence-hub/run.sh
+++ b/tests/test671-task-runtime-evidence-hub/run.sh
@@ -32,6 +32,24 @@ ok "two-level task runtime evidence contract"
 COMMHUB_DB=/tmp/test671-rest.db bun test server/src/task-auth-origin-http.test.ts
 ok "REST initial task delivery writes logical inbox task_id"
 
+bun -e '
+const files = ["server/src/tools.ts", "server/src/server.ts", "server/src/scheduled-tasks.ts"];
+let taskInserts = 0;
+for (const file of files) {
+  const source = await Bun.file(file).text();
+  for (const match of source.matchAll(/INSERT INTO inbox\s*\(([^)]*)\)\s*VALUES\s*\(([^)]*)\)/g)) {
+    if (!match[2].includes("task")) continue;
+    taskInserts += 1;
+    const columns = match[1].split(",").map((value) => value.trim());
+    if (!columns.includes("task_id")) {
+      throw new Error(`task inbox INSERT without task_id linkage: ${file}`);
+    }
+  }
+}
+if (taskInserts !== 5) throw new Error(`expected 5 production task inbox INSERT paths, found ${taskInserts}`);
+'
+ok "all production task inbox INSERT paths carry logical task_id"
+
 bun build server/src/index.ts --target bun --outdir /tmp/test671-server-build >/dev/null
 ok "production Hub bundle builds"
 

--- a/tests/test671-task-runtime-evidence-hub/run.sh
+++ b/tests/test671-task-runtime-evidence-hub/run.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT=/repo
+ART=/artifacts
+PASS=0
+FAIL=0
+mkdir -p "$ART"
+
+ok(){ PASS=$((PASS+1)); printf 'PASS %s\n' "$*"; }
+bad(){ FAIL=$((FAIL+1)); printf 'FAIL %s\n' "$*"; }
+expect_red(){
+  local name="$1"; shift
+  if "$@" >"$ART/$name.log" 2>&1; then
+    bad "mutation $name stayed green"
+  else
+    ok "mutation $name witnessed red"
+  fi
+}
+
+printf 'source_commit=%s\n' "${TEST671_SOURCE_COMMIT:-unknown}"
+if [[ ! "${TEST671_SOURCE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]]; then
+  bad "source commit is not an exact SHA"
+  printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+  exit 1
+fi
+
+cd "$ROOT"
+COMMHUB_DB=/tmp/test671-hub.db bun test server/src/task-consumption.test.ts
+ok "two-level task runtime evidence contract"
+
+bun build server/src/index.ts --target bun --outdir /tmp/test671-server-build >/dev/null
+ok "production Hub bundle builds"
+
+grep -F 'runtime_submitted_at' docs/rfcs/RFC-035-task-runtime-evidence.md >/dev/null
+grep -F 'task_runtime_evidence_backend_unsupported' docs/rfcs/RFC-035-task-runtime-evidence.md >/dev/null
+grep -F '不要用 `sessions.task` 判断模型是否已接手' docs-site/docs/concepts/task-lifecycle.md >/dev/null
+grep -F 'Do not use `sessions.task` as model-consumption evidence' docs-site/docs/en/concepts/task-lifecycle.md >/dev/null
+ok "RFC and bilingual field-boundary documentation"
+
+cp server/src/tools.ts /tmp/test671-tools.orig
+
+sed -i 's/(taskId) => owned.get(taskId) !== callerSession.node_id/(taskId) => false/' server/src/tools.ts
+grep -F '(taskId) => false' server/src/tools.ts >/dev/null
+expect_red remove-node-ownership env COMMHUB_DB=/tmp/test671-mut-owner.db \
+  bun test server/src/task-consumption.test.ts
+cp /tmp/test671-tools.orig server/src/tools.ts
+
+sed -i "s/UPDATE tasks SET runtime_submitted_at = COALESCE(runtime_submitted_at, datetime('now'))/UPDATE tasks SET runtime_submitted_at = COALESCE(runtime_submitted_at, datetime('now')), consumed_at = COALESCE(consumed_at, datetime('now'))/" server/src/tools.ts
+grep -F "consumed_at = COALESCE(consumed_at, datetime('now'))" server/src/tools.ts >/dev/null
+expect_red collapse-submitted-into-consumed env COMMHUB_DB=/tmp/test671-mut-collapse.db \
+  bun test server/src/task-consumption.test.ts
+cp /tmp/test671-tools.orig server/src/tools.ts
+
+sed -i '/runtime_submitted_at = COALESCE(runtime_submitted_at, datetime('\''now'\'')),/d' server/src/tools.ts
+expect_red consumed-no-longer-implies-submitted env COMMHUB_DB=/tmp/test671-mut-implies.db \
+  bun test server/src/task-consumption.test.ts
+cp /tmp/test671-tools.orig server/src/tools.ts
+
+if [[ "$(grep -o 'runtime_submitted_at = NULL' server/src/tools.ts | wc -l)" -ne 2 ]]; then
+  bad "runtime-submitted reset anchor count changed"
+else
+  sed -i 's/runtime_submitted_at = NULL, //g' server/src/tools.ts
+  expect_red remove-submission-attempt-reset env COMMHUB_DB=/tmp/test671-mut-submit-reset.db \
+    bun test server/src/task-consumption.test.ts
+fi
+cp /tmp/test671-tools.orig server/src/tools.ts
+
+if [[ "$(grep -o 'consumed_at = NULL' server/src/tools.ts | wc -l)" -ne 2 ]]; then
+  bad "consumed reset anchor count changed"
+else
+  sed -i 's/consumed_at = NULL, //g' server/src/tools.ts
+  expect_red remove-consumed-attempt-reset env COMMHUB_DB=/tmp/test671-mut-consumed-reset.db \
+    bun test server/src/task-consumption.test.ts
+fi
+cp /tmp/test671-tools.orig server/src/tools.ts
+
+printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test671-task-runtime-evidence-hub/run.sh
+++ b/tests/test671-task-runtime-evidence-hub/run.sh
@@ -34,16 +34,32 @@ ok "production Hub bundle builds"
 
 grep -F 'runtime_submitted_at' docs/rfcs/RFC-035-task-runtime-evidence.md >/dev/null
 grep -F 'task_runtime_evidence_backend_unsupported' docs/rfcs/RFC-035-task-runtime-evidence.md >/dev/null
+grep -F 'monotonic for the lifetime of the logical task' docs/rfcs/RFC-035-task-runtime-evidence.md >/dev/null
 grep -F '不要用 `sessions.task` 判断模型是否已接手' docs-site/docs/concepts/task-lifecycle.md >/dev/null
+grep -F '逻辑任务全生命周期的单调证据' docs-site/docs/concepts/task-lifecycle.md >/dev/null
 grep -F 'Do not use `sessions.task` as model-consumption evidence' docs-site/docs/en/concepts/task-lifecycle.md >/dev/null
+grep -F 'monotonic for the logical task lifetime' docs-site/docs/en/concepts/task-lifecycle.md >/dev/null
 ok "RFC and bilingual field-boundary documentation"
 
 cp server/src/tools.ts /tmp/test671-tools.orig
 
-sed -i 's/(taskId) => owned.get(taskId) !== callerSession.node_id/(taskId) => false/' server/src/tools.ts
-grep -F '(taskId) => false' server/src/tools.ts >/dev/null
-expect_red remove-node-ownership env COMMHUB_DB=/tmp/test671-mut-owner.db \
-  bun test server/src/task-consumption.test.ts
+sed -i 's/if (row.to_node_id) return row.to_node_id !== callerSession?.node_id;/if (row.to_node_id) return false;/' server/src/tools.ts
+if cmp -s /tmp/test671-tools.orig server/src/tools.ts; then
+  bad "remove-node-ownership mutation did not change source"
+else
+  grep -F 'if (row.to_node_id) return false;' server/src/tools.ts >/dev/null
+  expect_red remove-node-ownership env COMMHUB_DB=/tmp/test671-mut-owner.db \
+    bun test server/src/task-consumption.test.ts
+fi
+cp /tmp/test671-tools.orig server/src/tools.ts
+
+sed -i 's/return resolveCanonicalAlias(enforceNetworkId, row.to_name).alias !== canonicalCaller;/return false;/' server/src/tools.ts
+if cmp -s /tmp/test671-tools.orig server/src/tools.ts; then
+  bad "remove-legacy-alias-ownership mutation did not change source"
+else
+  expect_red remove-legacy-alias-ownership env COMMHUB_DB=/tmp/test671-mut-alias.db \
+    bun test server/src/task-consumption.test.ts
+fi
 cp /tmp/test671-tools.orig server/src/tools.ts
 
 sed -i "s/UPDATE tasks SET runtime_submitted_at = COALESCE(runtime_submitted_at, datetime('now'))/UPDATE tasks SET runtime_submitted_at = COALESCE(runtime_submitted_at, datetime('now')), consumed_at = COALESCE(consumed_at, datetime('now'))/" server/src/tools.ts
@@ -57,20 +73,22 @@ expect_red consumed-no-longer-implies-submitted env COMMHUB_DB=/tmp/test671-mut-
   bun test server/src/task-consumption.test.ts
 cp /tmp/test671-tools.orig server/src/tools.ts
 
-if [[ "$(grep -o 'runtime_submitted_at = NULL' server/src/tools.ts | wc -l)" -ne 2 ]]; then
-  bad "runtime-submitted reset anchor count changed"
+sed -i "s/CASE WHEN type = 'task' THEN COALESCE(task_id, id) ELSE task_id END AS task_id/CASE WHEN type = 'task' THEN id ELSE task_id END AS task_id/" server/src/tools.ts
+if cmp -s /tmp/test671-tools.orig server/src/tools.ts; then
+  bad "unlink-redelivery-task-id mutation did not change source"
 else
-  sed -i 's/runtime_submitted_at = NULL, //g' server/src/tools.ts
-  expect_red remove-submission-attempt-reset env COMMHUB_DB=/tmp/test671-mut-submit-reset.db \
+  grep -F "CASE WHEN type = 'task' THEN id ELSE task_id END AS task_id" server/src/tools.ts >/dev/null
+  expect_red unlink-redelivery-task-id env COMMHUB_DB=/tmp/test671-mut-link.db \
     bun test server/src/task-consumption.test.ts
 fi
 cp /tmp/test671-tools.orig server/src/tools.ts
 
-if [[ "$(grep -o 'consumed_at = NULL' server/src/tools.ts | wc -l)" -ne 2 ]]; then
-  bad "consumed reset anchor count changed"
+sed -i "s/status = 'delivered', result = NULL, completed_at = NULL, started_at = NULL, delivered_at/status = 'delivered', result = NULL, completed_at = NULL, started_at = NULL, runtime_submitted_at = NULL, consumed_at = NULL, delivered_at/" server/src/tools.ts
+if cmp -s /tmp/test671-tools.orig server/src/tools.ts; then
+  bad "clear-task-lifetime-evidence-on-retry mutation did not change source"
 else
-  sed -i 's/consumed_at = NULL, //g' server/src/tools.ts
-  expect_red remove-consumed-attempt-reset env COMMHUB_DB=/tmp/test671-mut-consumed-reset.db \
+  grep -F "started_at = NULL, runtime_submitted_at = NULL, consumed_at = NULL, delivered_at" server/src/tools.ts >/dev/null
+  expect_red clear-task-lifetime-evidence-on-retry env COMMHUB_DB=/tmp/test671-mut-lifetime.db \
     bun test server/src/task-consumption.test.ts
 fi
 cp /tmp/test671-tools.orig server/src/tools.ts


### PR DESCRIPTION
## What changed

Adds the Hub half of #520 with two distinct, additive, task-lifetime evidence timestamps:

- `runtime_submitted_at`: the task body was handed to a vendor runtime.
- `consumed_at`: the runtime emitted an authoritative turn-start or first attributable event.

Both fields are monotonic set-once facts for the logical task. Retry and reassignment preserve them. A new nullable `inbox.task_id` separates logical task identity from fresh transport-row IDs. MCP, REST, scheduler, retry, and reassignment deliveries all write the original logical task ID, with a legacy `COALESCE(task_id,id)` read fallback.

`get_inbox` exposes logical `task_id`. `ack_inbox` accepts that logical ID for task rows while retaining exact `inbox.id` support for legacy consumers and non-task messages. The lookup is restricted to the current pending row, so retry cannot match the already-ACKed initial row.

The node-token-only evidence tools validate exact task IDs and whole-batch ownership inside one SQLite transaction. Immutable `to_node_id` is authoritative when present; canonical token alias is a fallback only for legacy/direct tasks whose `to_node_id` is NULL. Every update must change exactly one row. `sessions.task`, delivery, ACK, queueing, and PTY writes are not consumption evidence.

## Why

Existing `delivered_at` is enqueue time and ACK is process-level. Dispatchers cannot distinguish a sleeping node from a runtime that actually began consuming the task. Collapsing submission and consumption would manufacture false observability for runtimes without an authoritative signal.

The first review also exposed a pre-existing retry/reassign wire bug: those paths generated a fresh inbox ID but did not expose the original `tasks.task_id`, so agents used a non-existent task ID for lifecycle operations. Attempt-scoped clearing without an attempt nonce additionally allowed a delayed old callback to stamp a newer attempt. Task-lifetime monotonic evidence makes such repeats idempotent; any future attempt timeline must add an explicit delivery-attempt/nonce CAS design.

## Validation

- Exact source: `8528c23c7db674ed129f6b6c153fd694d38ddc94`
- Report-only head: `4e49bea7b56efa988b43172a06982dc88f50de4e`
- Docker image: `sha256:deaca0c9dafa9f0a4829ff148642224a66aae916b8f66ece25da5017cdedccb8`
- Embedded ENV matches exact source
- Hub behavior: 11 tests / 80 assertions
- REST initial delivery: 2 tests / 8 assertions
- Hub production bundle build
- Suite `RESULT pass=14 fail=0`, including a denominator gate that enumerates all five production task-inbox INSERT paths
- 9 witnessed-red mutations: immutable and legacy ownership, submission/consumption separation, implication, logical retry/reassign linkage, logical ACK, task-lifetime preservation, scheduler linkage, and REST initial linkage

## Scope / rollout

This draft is intentionally Hub-only. Agent runtime callbacks are pending coordination with the overlapping image-delivery change in `agent-node/src/cli.ts`; this PR does not claim end-to-end consumption reporting is complete. **DO NOT MERGE OR DEPLOY** until that layer, full runtime E2E, and independent review are complete.
