### PR TITLE
docs(mcp): explain logical task acknowledgements

### DIFF
--- a/docs-site/docs/api/mcp-tools.md
+++ b/docs-site/docs/api/mcp-tools.md
@@ -141,7 +141,7 @@ report_completion({
 
 ### get_inbox
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L300)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L837)
 
 拉取待处理的消息。
 
@@ -160,6 +160,7 @@ report_completion({
   "messages": [
     {
       "id": "uuid-xxx",
+      "task_id": "task-uuid-xxx",
       "type": "task",
       "priority": "high",
       "content": "写排序算法",
@@ -172,13 +173,15 @@ report_completion({
 }
 ```
 
+任务消息的 `id` 是本次 inbox 投递行 ID；`task_id` 是跨重试/转派保持不变的逻辑任务 ID。旧数据没有独立 `task_id` 时，Hub 会回退为 `task_id = id`。处理任务时应把返回的 `task_id` 传给 `ack_inbox.message_id`；非任务消息继续传 `id`。
+
 消息按优先级排序：high > normal > low，同优先级按时间排序。
 
 ---
 
 ### ack_inbox
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L330)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L871)
 
 确认消息已接收。ACK 后消息不会再被 `get_inbox` 返回。
 
@@ -187,8 +190,8 @@ report_completion({
 | 参数 | 类型 | 必需 | 说明 |
 |------|------|:----:|------|
 | `alias` | string | &check; | Session 别名 |
-| `message_id` | string | &check; | 消息 ID |
-| `response` | string | | **当前 no-op**：handler 接受这个参数但不写库（[`tools.ts:337-360`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L337) 整段没有引用 `response`）。schema 保留是为了 forward-compat / 不破坏现有调用方；想真正回复用 [`send_reply`](#send-reply) |
+| `message_id` | string | &check; | inbox 投递行 `id`，或任务消息的逻辑 `task_id`。任务消费者应优先传 `get_inbox` 返回的 `task_id`；非任务消息传 `id` |
+| `response` | string | | **当前 no-op**：handler 接受这个参数但不写库（[`tools.ts:872-924`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L872) 没有读取 `response`）。schema 保留是为了 forward-compat / 不破坏现有调用方；想真正回复用 [`send_reply`](#send-reply) |
 | `network_id` | string | | Network 范围。utok_ 恰好 1 个成员网络时自动解析，可省略；跨多网络必须显式传（#517） |
 
 **返回值**：
@@ -197,10 +200,10 @@ report_completion({
 { "ok": true }
 ```
 
-**错误**：`message_id` 不存在或不属于该 alias → `{ok: false, error: "message not found or not yours"}`。
+**错误**：找不到属于该 alias 的待确认投递 → `message not found or already acknowledged`；投递在查询后不再可写 → `message not found or not yours`。
 
 ::: tip 副作用：tasks 表状态机
-ack 成功还会把 `tasks` 表里 `task_id = message_id` 的行从 `status='delivered'` UPDATE 到 `'acked'`（[`tools.ts:354`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L354)；**仅** `delivered` 起跳，跟 hub 端 [`send_ack`](#send-ack)（接受 `created` / `delivered`）不同 —— 详见 [Task 生命周期 — `created` 状态](/concepts/task-lifecycle#状态机)）。
+Hub 先用 `id = message_id`，或对任务消息用 `task_id = message_id`，解析出当前未确认的 inbox 行并只 ACK 那一行。若它是任务消息，再用该行解析出的稳定逻辑 `task_id` 把 `tasks` 从 `status='delivered'` UPDATE 到 `'acked'`（[`tools.ts:884-920`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L884)）。因此 retry/reassign 产生新 inbox `id` 后，仍能 ACK 原任务；旧消费者继续传 inbox `id` 也兼容。任务状态**仅**从 `delivered` 起跳，跟 hub 端 [`send_ack`](#send-ack)（接受 `created` / `delivered`）不同 —— 详见 [Task 生命周期 — `created` 状态](/concepts/task-lifecycle#状态机)。
 :::
 
 ---

--- a/docs-site/docs/en/api/mcp-tools.md
+++ b/docs-site/docs/en/api/mcp-tools.md
@@ -141,7 +141,7 @@ Compared to [`send_reply`](#send-reply): `send_reply` is a hub tool that require
 
 ### get_inbox
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L300)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L837)
 
 Fetch pending messages.
 
@@ -160,6 +160,7 @@ Fetch pending messages.
   "messages": [
     {
       "id": "uuid-xxx",
+      "task_id": "task-uuid-xxx",
       "type": "task",
       "priority": "high",
       "content": "Write sorting algorithm",
@@ -172,13 +173,15 @@ Fetch pending messages.
 }
 ```
 
+For task messages, `id` identifies this inbox delivery row while `task_id` is the stable logical task identity across retry and reassignment. For legacy rows without a separate task ID, the Hub returns `task_id = id`. Task consumers should pass the returned `task_id` to `ack_inbox.message_id`; non-task consumers should continue to pass `id`.
+
 Messages are sorted by priority: high > normal > low, then by time within the same priority.
 
 ---
 
 ### ack_inbox
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L330)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L871)
 
 Acknowledge message receipt. After ACK, the message won't be returned by `get_inbox`.
 
@@ -187,8 +190,8 @@ Acknowledge message receipt. After ACK, the message won't be returned by `get_in
 | Parameter | Type | Required | Description |
 |------|------|:----:|------|
 | `alias` | string | &check; | Session alias |
-| `message_id` | string | &check; | Message ID |
-| `response` | string | | **Currently a no-op**: the handler accepts this parameter but never writes it to the database ([`tools.ts:337-360`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L337) never references `response`). The schema is kept for forward-compat / to avoid breaking existing callers; if you want to actually reply, use [`send_reply`](#send-reply). |
+| `message_id` | string | &check; | The inbox delivery-row `id`, or a task message's logical `task_id`. Task consumers should prefer the `task_id` returned by `get_inbox`; use `id` for non-task messages. |
+| `response` | string | | **Currently a no-op**: the handler accepts this parameter but never writes it to the database ([`tools.ts:872-924`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L872) does not read `response`). The schema is kept for forward-compat / to avoid breaking existing callers; if you want to actually reply, use [`send_reply`](#send-reply). |
 | `network_id` | string | | Network scope. Auto-resolved for utok_ callers with exactly one membership — optional then; required when the caller spans multiple networks (#517) |
 
 **Response**:
@@ -197,10 +200,10 @@ Acknowledge message receipt. After ACK, the message won't be returned by `get_in
 { "ok": true }
 ```
 
-**Error**: `message_id` not found or not owned by this alias → `{ok: false, error: "message not found or not yours"}`.
+**Errors**: no pending delivery owned by the alias → `message not found or already acknowledged`; the resolved delivery becomes unwritable after lookup → `message not found or not yours`.
 
 ::: tip Side effect: tasks-table state machine
-A successful ack also UPDATEs the `tasks` row where `task_id = message_id` from `status='delivered'` to `'acked'` ([`tools.ts:354`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L354); **only** transitions from `delivered`, unlike the hub-side [`send_ack`](#send-ack) which also accepts `created` — see [Task lifecycle — the `created` state](/en/concepts/task-lifecycle#state-machine)).
+The Hub first resolves the current unacknowledged inbox row by `id = message_id`, or for a task message by `task_id = message_id`, and ACKs only that row. For task messages it then uses the row's resolved stable logical `task_id` to UPDATE the matching `tasks` row from `status='delivered'` to `'acked'` ([`tools.ts:884-920`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L884)). Retry/reassign deliveries can therefore have a new inbox `id` while still ACKing the original task; legacy callers that pass an inbox `id` remain compatible. The task transition **only** accepts `delivered`, unlike the hub-side [`send_ack`](#send-ack), which also accepts `created` — see [Task lifecycle — the `created` state](/en/concepts/task-lifecycle#state-machine).
 :::
 
 ---

--- a/docs/tests/report-test520-ack-inbox-docs.txt
+++ b/docs/tests/report-test520-ack-inbox-docs.txt
@@ -1,0 +1,53 @@
+Test 520 docs follow-up — ack_inbox logical task identity
+Date: 2026-08-10
+Base: c1fde003fb501693088a5dfae3717b7e153f36e2
+Source commit: 90522e636a636920d313394c9acc5044a65596c4
+Image: anet-test520-docs:dev
+Image ID: sha256:9fc99684e50418c6e599a4563deb7d4d2dd2274ee0c8637c4409707ac89c9475
+Embedded ENV: TEST520_DOCS_SOURCE_COMMIT=90522e636a636920d313394c9acc5044a65596c4
+
+Scope
+-----
+- Chinese and English MCP get_inbox / ack_inbox documentation
+- A Docker contract test that checks the documentation against the merged Hub wire
+- No production source, API, runtime, schema, or deployment changes
+
+Contract checks
+---------------
+The runner checks all of these against the same source archive:
+
+1. get_inbox exposes stable logical task_id with legacy COALESCE(id)
+2. ack_inbox resolves a pending row by transport id or task task_id
+3. ack_inbox updates the resolved inbox row id
+4. the resolved logical task advances delivered -> acked
+5. Chinese and English examples include task_id
+6. both languages explain stability across retry/reassign
+7. both languages explain legacy inbox-id compatibility
+8. the old direct task_id = message_id claim is absent in both languages
+9. the complete VitePress site builds and renders both MCP reference pages
+
+Exact-source command
+--------------------
+
+  sg docker -c 'docker build -t anet-test520-docs:dev \
+    -f tests/test520-ack-inbox-docs/Dockerfile \
+    --build-arg TEST520_DOCS_SOURCE_COMMIT=90522e636a636920d313394c9acc5044a65596c4 .'
+  sg docker -c 'docker run --rm anet-test520-docs:dev'
+
+Result
+------
+
+  source_commit=90522e636a636920d313394c9acc5044a65596c4
+  VitePress client/server bundles: PASS
+  VitePress page rendering: PASS
+  RESULT: PASS (13 checks)
+
+An earlier docs-build attempt failed with `spawn git ENOENT` because the slim
+test image omitted git. That environment failure was not counted as product
+evidence; the image was corrected and the full build rerun successfully.
+
+Conclusion
+----------
+PASS. The MCP reference now matches the merged dual-capability wire: task
+consumers ACK with the stable logical task_id, non-task and legacy consumers
+may use the inbox id, and retry/reassign no longer make the documentation lie.

--- a/tests/test520-ack-inbox-docs/Dockerfile
+++ b/tests/test520-ack-inbox-docs/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+COPY docs-site/package*.json docs-site/
+RUN npm ci --prefix docs-site --ignore-scripts
+COPY server/src/tools.ts server/src/tools.ts
+COPY docs-site docs-site
+COPY tests/test520-ack-inbox-docs/run.sh tests/test520-ack-inbox-docs/run.sh
+RUN chmod +x tests/test520-ack-inbox-docs/run.sh
+
+ARG TEST520_DOCS_SOURCE_COMMIT=unknown
+ENV TEST520_DOCS_SOURCE_COMMIT=$TEST520_DOCS_SOURCE_COMMIT
+
+CMD ["tests/test520-ack-inbox-docs/run.sh"]

--- a/tests/test520-ack-inbox-docs/run.sh
+++ b/tests/test520-ack-inbox-docs/run.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -eu
+
+ZH=docs-site/docs/api/mcp-tools.md
+EN=docs-site/docs/en/api/mcp-tools.md
+TOOLS=server/src/tools.ts
+pass=0
+
+require() {
+  pattern=$1
+  file=$2
+  label=$3
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "FAIL: $label" >&2
+    exit 1
+  fi
+  pass=$((pass + 1))
+}
+
+reject() {
+  pattern=$1
+  file=$2
+  label=$3
+  if grep -Fqi "$pattern" "$file"; then
+    echo "FAIL: $label" >&2
+    exit 1
+  fi
+  pass=$((pass + 1))
+}
+
+echo "source_commit=$TEST520_DOCS_SOURCE_COMMIT"
+
+# Production wire: get_inbox exposes logical identity, ack accepts both
+# transport-row and logical-task capabilities, then updates the resolved row.
+require "CASE WHEN type = 'task' THEN COALESCE(task_id, id) ELSE task_id END AS task_id" "$TOOLS" "get_inbox exposes task_id"
+require "AND (id = ?1 OR (type = 'task' AND task_id = ?1))" "$TOOLS" "ack resolves transport or logical id"
+require "UPDATE inbox SET acked = 1 WHERE id = ?1" "$TOOLS" "ack updates the resolved inbox row"
+require "UPDATE tasks SET status = 'acked' WHERE task_id = ?1 AND status = 'delivered'" "$TOOLS" "ack advances the resolved logical task"
+
+# Chinese and English docs must teach the same dual-capability contract.
+require '"task_id": "task-uuid-xxx"' "$ZH" "Chinese get_inbox example contains task_id"
+require '"task_id": "task-uuid-xxx"' "$EN" "English get_inbox example contains task_id"
+require '跨重试/转派保持不变的逻辑任务 ID' "$ZH" "Chinese stable task identity explained"
+require 'stable logical task identity across retry and reassignment' "$EN" "English stable task identity explained"
+require '旧消费者继续传 inbox `id` 也兼容' "$ZH" "Chinese legacy id compatibility explained"
+require 'legacy callers that pass an inbox `id` remain compatible' "$EN" "English legacy id compatibility explained"
+reject 'where `task_id = message_id`' "$EN" "English old direct-equality claim removed"
+reject 'ack 成功还会把 `tasks` 表里 `task_id = message_id`' "$ZH" "Chinese old direct-equality claim removed"
+
+npm run build --prefix docs-site >/tmp/test520-docs-build.log
+test -s docs-site/docs/.vitepress/dist/api/mcp-tools.html
+test -s docs-site/docs/.vitepress/dist/en/api/mcp-tools.html
+pass=$((pass + 1))
+
+echo "RESULT: PASS ($pass checks)"


### PR DESCRIPTION
## What changed

- document `get_inbox.id` as transport-row identity and `task_id` as stable logical task identity
- tell task consumers to ACK with the returned `task_id`, while non-task and legacy callers keep using `id`
- describe retry/reassign behavior and the resolved-row task-state side effect accurately
- update stale source links in the Chinese and English MCP references

## Why

Hub PR #672 separated inbox delivery identity from logical task identity. The previous docs still claimed that `ack_inbox` directly updated `tasks.task_id = message_id`, which is false after retry/reassign creates a new inbox row.

## Validation

- exact source `90522e636a636920d313394c9acc5044a65596c4`
- image `sha256:9fc99684e50418c6e599a4563deb7d4d2dd2274ee0c8637c4409707ac89c9475`
- 12 source/docs contract assertions plus complete VitePress build: 13/13 pass
- Chinese and English rendered MCP pages exist

## Scope

Docs and tests only. No production source, API, runtime, schema, or deployment changes.

Follow-up for sleep2agi/agent-network#520; the issue remains open for agent-node runtime wiring.
