### PR TITLE
feat(agent-node): report exact task runtime evidence

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -33,6 +33,11 @@ import { bumpFailure, resetFailure, applyAutoPause, resolveMaxConsecutiveFailure
 import { formatSelfLoopsBlock } from "./goals/format";
 import { startTelegramWatchdog } from "./telegram-watchdog";
 import { sseAbandonGuidance } from "./sse-recovery-guidance";
+import {
+  createTaskRuntimeEvidenceReporter,
+  logicalTaskIdFromInbox,
+  type TaskRuntimeEvidenceReporter,
+} from "./task-runtime-evidence";
 import type { AgentGoal } from "./goals/types";
 import { extractExplicitDelegation } from "./explicit-delegation";
 import { maskedEnv } from "./secret-mask";
@@ -1808,7 +1813,12 @@ if (NEW_SESSION && RUNTIME === "grok" && GROK_EXECUTION_MODE === "cli") {
 const HAD_GROK_SESSION_AT_BOOT = RUNTIME === "grok" && !!SESSION_ID;
 let grokResumeHintFired = false;
 
-async function processWithClaude(task: string, from: string, images?: string[]): Promise<string> {
+async function processWithClaude(
+  task: string,
+  from: string,
+  images?: string[],
+  evidence?: TaskRuntimeEvidenceReporter,
+): Promise<string> {
   // #259 Y (2026-06-25, 通信龙 GO after MiniMax-M3 real-call verified):
   // image capability is per-MODEL (not per-vendor) — the create wizard
   // writes `flags.modelImageCapable: true` when the picked model is on
@@ -2327,7 +2337,10 @@ async function processWithClaude(task: string, from: string, images?: string[]):
         const forward = () => ac.abort();
         signal.addEventListener("abort", forward, { once: true });
         try {
-          for await (const message of query({ prompt, options })) {
+          const messages = query({ prompt, options });
+          evidence?.submitted();
+          for await (const message of messages) {
+            evidence?.consumed();
             const m = message as any;
             if (m.type === "system" && m.subtype === "init") {
               claudeSessionId = m.session_id;
@@ -2610,7 +2623,12 @@ const CODEX_CONFIG = new Proxy({} as Record<string, any>, {
   getOwnPropertyDescriptor: (_t, prop) => Object.getOwnPropertyDescriptor(getCodexConfig(), prop),
 });
 
-async function processWithCodex(task: string, from: string, images?: string[]): Promise<string> {
+async function processWithCodex(
+  task: string,
+  from: string,
+  images?: string[],
+  evidence?: TaskRuntimeEvidenceReporter,
+): Promise<string> {
   // Ensure system-installed codex binary is found (npm global bin)
   try {
     const { execSync } = await import("child_process");
@@ -2685,10 +2703,12 @@ async function processWithCodex(task: string, from: string, images?: string[]): 
     const outcome = await withTimeout(
       async (signal) => {
         const { events } = await codexThread.runStreamed(input, { signal });
+        evidence?.submitted();
         let finalResponse = "";
         let usage: any = null;
         let itemCount = 0;
         for await (const ev of events) {
+          evidence?.consumed();
           if (ev.type === "item.started") {
             const it = ev.item as any;
             debug(`[codex] ${it.type}${it.command ? `: ${it.command.slice(0, 60)}` : it.tool ? `: ${it.server}/${it.tool}` : ""}`);
@@ -2793,7 +2813,12 @@ async function ensureCodexStdio(): Promise<import("./runtime/codex-stdio-client"
   return client;
 }
 
-async function processWithCodexStdio(task: string, _from: string, images?: string[]): Promise<string> {
+async function processWithCodexStdio(
+  task: string,
+  _from: string,
+  images?: string[],
+  evidence?: TaskRuntimeEvidenceReporter,
+): Promise<string> {
   const client = await ensureCodexStdio();
   if (!codexStdioThreadId) {
     // Note on wire conventions (see #120 R225 + Phase 1.4 smoke discovery):
@@ -2848,6 +2873,11 @@ async function processWithCodexStdio(task: string, _from: string, images?: strin
       const tStart = Date.now();
       const turnResp = await client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", { threadId: codexStdioThreadId, input });
       pendingTurnId = (turnResp?.turn?.id ?? turnResp?.turnId) || null;
+      // Direct stdio does not yet send/echo clientUserMessageId, so the
+      // response turn id is admission evidence only (the #587 race proved it
+      // is not authoritative ownership). Report submitted, never consumed,
+      // until this lane grows an exact identity echo.
+      evidence?.submitted();
       log(`[codex-stdio] turn/start → ${pendingTurnId ?? "(no id)"} ${(Date.now() - tStart)}ms`);
     } catch (e: any) {
       client.off("item/completed", onItemCompleted);
@@ -2941,11 +2971,19 @@ function sanitizeGrokCommhubLeak(text: string): string {
 // Stable string marker for release tarball inspection. Bun minifies function
 // identifiers, so keep an independently reachable literal in the bundle.
 const OPENCODE_PROCESS_BUNDLE_MARKER = "processWithOpencode";
-async function processWithOpencode(task: string, _from: string, _images?: string[]): Promise<string> {
+async function processWithOpencode(
+  task: string,
+  _from: string,
+  _images?: string[],
+  evidence?: TaskRuntimeEvidenceReporter,
+): Promise<string> {
   debug(`[${OPENCODE_PROCESS_BUNDLE_MARKER}] dispatch`);
   if (opencodeMode === "copresence") {
     const runtime = await ensureOpencodeCopresenceRuntime();
-    const outcome = await runtime.submit(task, undefined, _from);
+    const outcome = await runtime.submit(task, undefined, _from, {
+      onSubmitted: evidence?.submitted,
+      onConsumed: evidence?.consumed,
+    });
     log(`[opencode-copresence] turn done | reply=${outcome.replyText.length}ch session=${runtime.sessionId.slice(0, 12)}`);
     return outcome.replyText || "（无回复）";
   }
@@ -3002,6 +3040,8 @@ async function processWithOpencode(task: string, _from: string, _images?: string
     sessionId: opencodeRuntimeSession.sessionId,
     log,
     warn,
+    onSubmitted: evidence?.submitted,
+    onConsumed: evidence?.consumed,
   });
 
   const u = outcome.state.usage;
@@ -3106,6 +3146,7 @@ async function processWithCodexAppServer(
   _from: string,
   taskId: string | null,
   steerIfExternalTurn = false,
+  evidence?: TaskRuntimeEvidenceReporter,
 ): Promise<string> {
   const { openCodexAppServerRuntime, codexAppServerThink, codexAppServerReplyOrThrow } =
     await import("./runtime/codex-app-server/runtime");
@@ -3173,6 +3214,8 @@ async function processWithCodexAppServer(
         debug(`[codex-app-server] activity report_status failed: ${error instanceof Error ? error.message : String(error)}`);
       });
     },
+    onSubmitted: evidence?.submitted,
+    onConsumed: evidence?.consumed,
   });
 
   // Throw failed outcomes into processTask's existing failure path so the Hub
@@ -3180,7 +3223,12 @@ async function processWithCodexAppServer(
   return codexAppServerReplyOrThrow(outcome);
 }
 
-async function processWithGrok(task: string, from: string, images?: string[]): Promise<string> {
+async function processWithGrok(
+  task: string,
+  from: string,
+  images?: string[],
+  evidence?: TaskRuntimeEvidenceReporter,
+): Promise<string> {
   if (images?.length) {
     warn(`[grok] image attachments received but Grok ACP fixture reports promptCapabilities.image=false; sending text-only prompt`);
   }
@@ -3358,6 +3406,8 @@ async function processWithGrok(task: string, from: string, images?: string[]): P
           debug(`[grok] skipped replay chunks=${state.skippedReplay}`);
         }
       },
+      onSubmitted: evidence?.submitted,
+      onConsumed: evidence?.consumed,
       // #204 preview.4 — surface Grok stderr (carries MCP subprocess
       // handshake / spawn errors). Lines tagged so `anet logs` filtering
       // is obvious. Severity routing: lines mentioning error/fail/cannot
@@ -3803,6 +3853,7 @@ async function processWithGrokCopresence(
   from: string,
   taskId: string | null,
   images?: string[],
+  evidence?: TaskRuntimeEvidenceReporter,
 ): Promise<string> {
   if (images?.length) {
     warn(`[grok-copresence] image attachments are not wired into the shared TUI; sending text-only task`);
@@ -3820,6 +3871,8 @@ async function processWithGrokCopresence(
       from,
       text: task,
       timeoutMs: grokCopresenceTimeoutMs(),
+      onSubmitted: evidence?.submitted,
+      onConsumed: evidence?.consumed,
     });
     return sanitizeGrokCommhubLeak(result.replyText || "（无回复）");
   } catch (error) {
@@ -3847,7 +3900,12 @@ async function processWithGrokCopresence(
   }
 }
 
-async function processWithGrokCli(task: string, from: string, images?: string[]): Promise<string> {
+async function processWithGrokCli(
+  task: string,
+  from: string,
+  images?: string[],
+  evidence?: TaskRuntimeEvidenceReporter,
+): Promise<string> {
   if (images?.length) {
     warn(`[grok-cli] image attachments are not wired into --prompt-json yet; sending text-only prompt`);
   }
@@ -4018,6 +4076,8 @@ async function processWithGrokCli(task: string, from: string, images?: string[])
           "/proc",
         ],
         signal: controller.signal,
+        onSubmitted: evidence?.submitted,
+        onConsumed: evidence?.consumed,
         onEvent: (event) => {
           if (event.type === "end") debug(`[grok-cli] end stopReason=${event.stopReason || "unknown"}`);
         },
@@ -4176,6 +4236,7 @@ function think(
   taskId: string | null,
   images?: string[],
   steerIfExternalTurn = false,
+  evidence?: TaskRuntimeEvidenceReporter,
 ): Promise<string> {
   if (configApplyDraining) {
     // Don't accept new work during a restart drain. The error string
@@ -4204,24 +4265,24 @@ function think(
         // Preview.N+1 (after Vincent macOS verify) will flip the default
         // and switch the toggle to ANET_CODEX_LEGACY_SDK=1 opt-out.
         if (process.env.ANET_CODEX_STDIO_DIRECT === "1") {
-          return await processWithCodexStdio(task, from, images);
+          return await processWithCodexStdio(task, from, images, evidence);
         }
-        return await processWithCodex(task, from, images);
+        return await processWithCodex(task, from, images, evidence);
       }
       if (RUNTIME === "grok") {
         return GROK_EXECUTION_MODE === "cli"
           ? GROK_COPRESENCE
-            ? await processWithGrokCopresence(task, from, taskId, images)
-            : await processWithGrokCli(task, from, images)
-          : await processWithGrok(task, from, images);
+            ? await processWithGrokCopresence(task, from, taskId, images, evidence)
+            : await processWithGrokCli(task, from, images, evidence)
+          : await processWithGrok(task, from, images, evidence);
       }
       if (RUNTIME === "opencode") {
-        return await processWithOpencode(task, from, images);
+        return await processWithOpencode(task, from, images, evidence);
       }
       if (RUNTIME === "codex-app-server") {
-        return await processWithCodexAppServer(task, from, taskId, steerIfExternalTurn);
+        return await processWithCodexAppServer(task, from, taskId, steerIfExternalTurn, evidence);
       }
-      return await processWithClaude(task, from, images);
+      return await processWithClaude(task, from, images, evidence);
     } finally {
       if (prev !== undefined) process.env.CURRENT_TASK_ID = prev; else delete process.env.CURRENT_TASK_ID;
       decrementInFlight();
@@ -4234,7 +4295,7 @@ function think(
   // its own process environment and task identity is carried in the prompt.
   if (RUNTIME === "codex-app-server") {
     incrementInFlight();
-    return processWithCodexAppServer(task, from, taskId, steerIfExternalTurn)
+    return processWithCodexAppServer(task, from, taskId, steerIfExternalTurn, evidence)
       .finally(() => {
         decrementInFlight();
       });
@@ -4344,12 +4405,20 @@ async function processTask(
   let failed = false;
   let grokFailureCode: string | null = null;
   let grokFailureSubcode: string | null = null;
+  const runtimeEvidence = createTaskRuntimeEvidenceReporter({
+    taskId,
+    report: (level, exactTaskId) => callCommHub(
+      level === "submitted" ? "mark_tasks_runtime_submitted" : "mark_tasks_consumed",
+      { task_ids: [exactTaskId] },
+    ),
+    debug,
+  });
   try {
     // Every inbound network task must be visible in the shared Grok TUI. A2
     // delegation is intentionally human-only, so the legacy network-side
     // wrapper is skipped for copresence and remains unchanged elsewhere.
     text = (GROK_COPRESENCE ? null : await tryHandleExplicitDelegation(augmentedTask, from, taskId))
-      || await think(augmentedTask, from, taskId, images, steerIfExternalTurn);
+      || await think(augmentedTask, from, taskId, images, steerIfExternalTurn, runtimeEvidence);
   } catch (err: any) {
     text = `${RUNTIME} 错误: ${err.message}`;
     failed = true;
@@ -4407,7 +4476,7 @@ async function processTask(
     );
     await new Promise((r) => setTimeout(r, backoff));
     try {
-      const retried = await think(augmentedTask, from, taskId, images, steerIfExternalTurn);
+      const retried = await think(augmentedTask, from, taskId, images, steerIfExternalTurn, runtimeEvidence);
       text = retried;
       failed = false;
       if (GROK_COPRESENCE) {
@@ -4570,6 +4639,10 @@ async function processInbox() {
       const from = msg.from_session || "hub";
       const content = msg.content as string;
       const msgType = msg.type || "task";
+      // inbox.id identifies this delivery row. task_id identifies the stable
+      // logical task across retry/reassign. Keep ACK on the transport row,
+      // but bind runtime evidence and replies to the logical task.
+      const logicalTaskId = logicalTaskIdFromInbox(msg);
       const images = await extractImagePaths(msg);
       const inboundLogSuffix = GROK_EXECUTION_MODE === "cli"
         ? ` (${content.length} chars; content withheld)`
@@ -4594,7 +4667,7 @@ async function processInbox() {
         log(formatInboxSkipLog({
           sender: from,
           reason: skip,
-          taskId: String(msg.id),
+          taskId: logicalTaskId,
           messageType: msgType,
         }));
         await ackMessage(msg.id).catch((e: any) => warn(`ack failed for skipped ${msg.id.slice(0, 8)}: ${e.message}`));
@@ -4615,7 +4688,7 @@ async function processInbox() {
         try {
           // Goal state is durable and bypasses processTask. Keep the Grok
           // preview's redact-before-persistence invariant on this branch too.
-          const created = await createScheduledGoal(persistenceSafeContent, from, msg.id);
+          const created = await createScheduledGoal(persistenceSafeContent, from, logicalTaskId);
           replyText = `[${ALIAS}] ${created}`;
         } catch (e: any) {
           replyText = `[${ALIAS}] /aloop 创建失败：${e.message}`;
@@ -4626,7 +4699,7 @@ async function processInbox() {
           persistenceSafeContent,
           interactiveDashboardTask,
         );
-        await deliverReplyReliably(from, replyText, msg.id, goalFailed);
+        await deliverReplyReliably(from, replyText, logicalTaskId, goalFailed);
         await ackMessage(msg.id).catch((e: any) => warn(`ack failed for goal ${msg.id.slice(0, 8)}: ${e.message}`));
         return;
       }
@@ -4635,7 +4708,7 @@ async function processInbox() {
       const taskOutcome = await processTask(
         content,
         from,
-        msg.id,
+        logicalTaskId,
         images,
         interactiveDashboardTask,
       );
@@ -4668,7 +4741,7 @@ async function processInbox() {
 
       // (3c-e) Persist + ack + try send.
       const replyBody = `[${ALIAS}] ${result.slice(0, 2000)}`;
-      await deliverReplyReliably(from, replyBody, msg.id, failed);
+      await deliverReplyReliably(from, replyBody, logicalTaskId, failed);
       await ackMessage(msg.id).catch((e: any) => warn(`ack failed for ${msg.id.slice(0, 8)}: ${e.message}`));
     } finally {
       inflightMessageIds.delete(msg.id);

--- a/agent-node/src/runtime/codex-app-server-bridge.test.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.test.ts
@@ -184,11 +184,14 @@ describe("CodexAppServerBridge — bootstrap + task mapping", () => {
   });
 
   test("startTaskTurn returns the server-assigned turnId and marks bridge working", async () => {
+    const submitted: Array<{ taskId: string; steered: boolean }> = [];
+    bridge.on("task_runtime_submitted", (event) => submitted.push(event as never));
     const turnId = await bridge.startTaskTurn({ taskId: "task_1", text: "please help" });
     expect(turnId).toBeTypeOf("string");
     expect(bridge.currentStatus()).toBe("working");
     expect(bridge.activeTurn()).toBe(turnId);
     expect(bridge.pendingTurnCount()).toBe(1);
+    expect(submitted).toEqual([{ taskId: "task_1", steered: false }]);
   });
 
   test("turn/completed for OUR turn fires task_reply mapped back to the task_id", async () => {

--- a/agent-node/src/runtime/codex-app-server-bridge.ts
+++ b/agent-node/src/runtime/codex-app-server-bridge.ts
@@ -280,11 +280,16 @@ export class CodexAppServerBridge extends EventEmitter {
 
     let resp: unknown;
     try {
-      resp = await this.client.request("turn/start", {
+      const request = this.client.request("turn/start", {
         threadId: this.threadId,
         clientUserMessageId,
         input: [{ type: "text", text: promptPrefix + input.text }],
       });
+      // request() has synchronously accepted the exact body for transport.
+      // This is weaker than task_started (model activity) but stronger than
+      // FIFO admission, which never reaches this branch.
+      this.emit("task_runtime_submitted", { taskId: input.taskId, steered: false });
+      resp = await request;
     } catch (e) {
       // If the server accepted the turn but the RPC response was lost, the
       // echoed user-message client id is stronger evidence than the failed
@@ -429,11 +434,17 @@ export class CodexAppServerBridge extends EventEmitter {
       ? `[Agent Network/from=${fromLabel}/task=${input.taskId}] `
       : `[Agent Network/task=${input.taskId}] `;
     try {
-      const response = await this.client.request("turn/steer", {
+      const request = this.client.request("turn/steer", {
         threadId: this.threadId,
         input: [{ type: "text", text: promptPrefix + input.text }],
         expectedTurnId,
       });
+      this.emit("task_runtime_submitted", {
+        taskId: input.taskId,
+        turnId: expectedTurnId,
+        steered: true,
+      });
+      const response = await request;
       const acceptedTurnId = extractTurnId(response);
       if (acceptedTurnId !== expectedTurnId) {
         throw new Error(

--- a/agent-node/src/runtime/codex-app-server/runtime.test.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.test.ts
@@ -179,6 +179,10 @@ class IdentityNeverConfirmedBridge extends EventEmitter {
 
 class ActivityBridge extends EventEmitter {
   async submitTask(input: { taskId: string }): Promise<{ started: true; turnId: string }> {
+    this.emit("task_runtime_submitted", {
+      taskId: input.taskId,
+      steered: false,
+    });
     this.emit("task_started", {
       taskId: input.taskId,
       turnId: `turn_${input.taskId}`,
@@ -197,6 +201,48 @@ class ActivityBridge extends EventEmitter {
 }
 
 describe("codexAppServerThink — terminal-event reconciliation watchdog", () => {
+  test("FIFO admission reports neither submission nor consumption", async () => {
+    const bridge = new DeferredStartBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    const evidence: string[] = [];
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_waiting_fifo",
+      text: "must remain without runtime evidence while queued",
+      queueTimeoutMs: 20,
+      reconciliationIntervalMs: 0,
+      onSubmitted: () => evidence.push("submitted"),
+      onConsumed: () => evidence.push("consumed"),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(evidence).toEqual([]);
+    expect((await thinking).queued).toBe(true);
+    expect(evidence).toEqual([]);
+  });
+
+  test("exact runtime submission and task_started report each level once", async () => {
+    const bridge = new ActivityBridge();
+    const session = { bridge } as unknown as CodexAppServerRuntimeSession;
+    const evidence: string[] = [];
+    const thinking = codexAppServerThink(session, {
+      taskId: "task_exact_evidence",
+      text: "bind exact runtime evidence",
+      timeoutMs: 100,
+      queueTimeoutMs: 500,
+      reconciliationIntervalMs: 0,
+      onSubmitted: (event) => evidence.push(`submitted:${event.taskId}`),
+      onConsumed: (event) => evidence.push(`consumed:${event.taskId}`),
+    });
+    bridge.emit("task_runtime_submitted", { taskId: "other_task" });
+    bridge.emit("task_started", { taskId: "other_task", turnId: "other_turn" });
+    bridge.emit("task_started", { taskId: "task_exact_evidence", turnId: "duplicate" });
+    bridge.emit("task_reply", { taskId: "task_exact_evidence", text: "done" });
+    await thinking;
+    expect(evidence).toEqual([
+      "submitted:task_exact_evidence",
+      "consumed:task_exact_evidence",
+    ]);
+  });
+
   test("exact task activity resets the response idle deadline for a long-running turn", async () => {
     const bridge = new ActivityBridge();
     const session = { bridge } as unknown as CodexAppServerRuntimeSession;

--- a/agent-node/src/runtime/codex-app-server/runtime.ts
+++ b/agent-node/src/runtime/codex-app-server/runtime.ts
@@ -260,6 +260,10 @@ export function codexAppServerThink(
     steerIfExternalTurn?: boolean;
     /** Exact owned-turn progress; callers may relay a throttled Hub heartbeat. */
     onActivity?: (event: CodexAppServerTaskActivity) => void;
+    /** Exact body entered turn/start or turn/steer; FIFO admission is excluded. */
+    onSubmitted?: (event: { taskId: string; turnId?: string; steered?: boolean }) => void;
+    /** Exact task_started identity proof; queue admission alone is not enough. */
+    onConsumed?: (event: { taskId: string; turnId: string; steered?: boolean }) => void;
   },
 ): Promise<CodexAppServerThinkResult> {
   const timeoutMs = opts.timeoutMs ?? 10 * 60_000;
@@ -274,6 +278,8 @@ export function codexAppServerThink(
   return new Promise<CodexAppServerThinkResult>((resolve) => {
     let settled = false;
     let queueDeadlineElapsed = false;
+    let submittedReported = false;
+    let consumedReported = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let lastResponseActivityAt = 0;
     let queueTimer: ReturnType<typeof setTimeout> | undefined;
@@ -283,6 +289,7 @@ export function codexAppServerThink(
       settled = true;
       bridge.off("task_reply", onReply);
       bridge.off("task_error", onError);
+      bridge.off("task_runtime_submitted", onSubmitted);
       bridge.off("task_started", onStarted);
       bridge.off("task_activity", onActivity);
       bridge.off("drain_deferred", onRequeued);
@@ -336,9 +343,26 @@ export function codexAppServerThink(
       // it immediately instead of leaving a ghost row behind a model timer.
       if (bridge.cancelQueuedTask(opts.taskId)) finishQueueTimeout();
     };
+    const onSubmitted = (ev: { taskId: string; turnId?: string; steered?: boolean }) => {
+      if (ev.taskId !== opts.taskId || submittedReported) return;
+      submittedReported = true;
+      try {
+        opts.onSubmitted?.(ev);
+      } catch (error) {
+        log(`[codex-app-server] runtime-submitted callback failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    };
     const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {
       if (ev.taskId !== opts.taskId) return;
       log(`[codex-app-server] task_started ${ev.taskId} turn=${ev.turnId}${ev.steered ? " (steered)" : ""}`);
+      if (!consumedReported) {
+        consumedReported = true;
+        try {
+          opts.onConsumed?.(ev);
+        } catch (error) {
+          log(`[codex-app-server] consumed callback failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
       armResponseIdleTimer();
     };
     const onActivity = (ev: CodexAppServerTaskActivity) => {
@@ -381,6 +405,7 @@ export function codexAppServerThink(
 
     bridge.on("task_reply", onReply);
     bridge.on("task_error", onError);
+    bridge.on("task_runtime_submitted", onSubmitted);
     bridge.on("task_started", onStarted);
     bridge.on("task_activity", onActivity);
     bridge.on("drain_deferred", onRequeued);

--- a/agent-node/src/runtime/grok-build-acp/runtime.test.ts
+++ b/agent-node/src/runtime/grok-build-acp/runtime.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runGrokAcpTurn } from "./runtime";
+
+describe("runGrokAcpTurn runtime evidence", () => {
+  test("separates prompt submission from exact prompt-response consumption", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "grok-acp-evidence-"));
+    const fake = join(cwd, "fake-grok.js");
+    writeFileSync(fake, `#!/usr/bin/env node
+const readline = require("readline");
+const rl = readline.createInterface({ input: process.stdin });
+function send(payload) { process.stdout.write(JSON.stringify(payload) + "\\n"); }
+rl.on("line", (line) => {
+  const req = JSON.parse(line);
+  if (req.method === "initialize") {
+    send({ jsonrpc: "2.0", id: req.id, result: { authMethods: [{ id: "cached_token" }] } });
+  } else if (req.method === "authenticate") {
+    send({ jsonrpc: "2.0", id: req.id, result: {} });
+  } else if (req.method === "session/new") {
+    send({ jsonrpc: "2.0", id: req.id, result: { sessionId: "grok-evidence-session" } });
+  } else if (req.method === "session/prompt") {
+    setTimeout(() => send({ jsonrpc: "2.0", id: req.id, result: { stopReason: "end_turn" } }), 25);
+  }
+});
+`);
+    chmodSync(fake, 0o755);
+    const evidence: string[] = [];
+    try {
+      const turn = runGrokAcpTurn({
+        cwd,
+        binary: fake,
+        prompt: "exact grok evidence",
+        drainMs: 0,
+        onSubmitted: () => evidence.push("submitted"),
+        onConsumed: () => evidence.push("consumed"),
+      });
+      for (let i = 0; i < 100 && evidence.length === 0; i++) await Bun.sleep(2);
+      expect(evidence).toEqual(["submitted"]);
+      await turn;
+      expect(evidence).toEqual(["submitted", "consumed"]);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/agent-node/src/runtime/grok-build-acp/runtime.ts
+++ b/agent-node/src/runtime/grok-build-acp/runtime.ts
@@ -80,6 +80,10 @@ export interface GrokAcpTurnOptions {
   mcpServers?: AcpMcpServerEntry[];
   onSession?: (sessionId: string) => void | Promise<void>;
   onEvent?: (event: GrokAcpNotification, state: GrokTurnState) => void;
+  /** Exact session/prompt request entered the ACP client. */
+  onSubmitted?: () => void;
+  /** Exact session/prompt response completed. Session-wide notifications alone are insufficient. */
+  onConsumed?: () => void;
   /**
    * #204 preview.4 — Grok agent's stderr stream (handshake errors, MCP
    * subprocess crash logs, etc.). Caller routes this to agent-node's
@@ -255,10 +259,13 @@ export async function runGrokAcpTurn(opts: GrokAcpTurnOptions): Promise<GrokAcpT
     // turns no longer get falsely killed mid-flight, but a genuinely
     // stuck agent (no frames for `timeoutMs`) still surfaces an error
     // with a hint that the work may still be running in the background.
-    const promptResponse = await client.requestWithIdleTimeout("session/prompt", {
+    const promptRequest = client.requestWithIdleTimeout("session/prompt", {
       sessionId,
       prompt: [{ type: "text", text: opts.prompt }],
     }, timeoutMs);
+    opts.onSubmitted?.();
+    const promptResponse = await promptRequest;
+    opts.onConsumed?.();
     await waitForPromptDrain(state, drainMs);
 
     return {

--- a/agent-node/src/runtime/grok-build-cli.test.ts
+++ b/agent-node/src/runtime/grok-build-cli.test.ts
@@ -115,6 +115,28 @@ describe("buildGrokCliArgs", () => {
 });
 
 describe("runGrokCliTurn", () => {
+  it("reports spawn submission before first exact JSONL event consumption", async () => {
+    const { root, binary } = fakeGrok(`
+      setTimeout(() => {
+        process.stdout.write(JSON.stringify({type:"text",data:"DONE"}) + "\\n");
+        process.stdout.write(JSON.stringify({type:"end",stopReason:"EndTurn",sessionId:"session-evidence"}) + "\\n");
+      }, 25);
+    `);
+    const evidence: string[] = [];
+    const turn = runGrokCliTurn({
+      prompt: "exact evidence",
+      cwd: root,
+      binary,
+      idleTimeoutMs: 1_000,
+      onSubmitted: () => evidence.push("submitted"),
+      onConsumed: () => evidence.push("consumed"),
+    });
+    await Bun.sleep(5);
+    expect(evidence).toEqual(["submitted"]);
+    await turn;
+    expect(evidence).toEqual(["submitted", "consumed"]);
+  });
+
   it("reduces streaming JSON text and persists the end-event session", async () => {
     const { root, binary } = fakeGrok(`
       process.stdout.write(JSON.stringify({type:"thought",data:"hidden"}) + "\\n");

--- a/agent-node/src/runtime/grok-build-cli.ts
+++ b/agent-node/src/runtime/grok-build-cli.ts
@@ -35,6 +35,10 @@ export interface GrokCliTurnOptions {
   /** Paths the model must not read through built-in Read/Grep tools. */
   protectedPaths?: readonly string[];
   signal?: AbortSignal;
+  /** The exact prompt worker was spawned successfully. */
+  onSubmitted?: () => void;
+  /** The first parsed JSONL event from this per-turn worker. */
+  onConsumed?: () => void;
   onEvent?: (event: GrokCliEvent) => void;
   onStderr?: (line: string) => void;
 }
@@ -240,6 +244,7 @@ export async function runGrokCliTurn(opts: GrokCliTurnOptions): Promise<GrokCliT
       reject(error);
       return;
     }
+    opts.onSubmitted?.();
 
     let stdoutBuffer = "";
     let stderrBuffer = "";
@@ -250,6 +255,7 @@ export async function runGrokCliTurn(opts: GrokCliTurnOptions): Promise<GrokCliT
     let stopReason: string | undefined;
     let requestId: string | undefined;
     let eventCount = 0;
+    let consumptionReported = false;
     let sawEnd = false;
     let idleTimer: ReturnType<typeof setTimeout> | undefined;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
@@ -317,6 +323,10 @@ export async function runGrokCliTurn(opts: GrokCliTurnOptions): Promise<GrokCliT
         return;
       }
       armIdleTimer();
+      if (!consumptionReported) {
+        consumptionReported = true;
+        opts.onConsumed?.();
+      }
       opts.onEvent?.(event);
       if (event.type === "error") {
         cliError = typeof event.message === "string" ? event.message : "unknown Grok CLI error";

--- a/agent-node/src/runtime/grok-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.test.ts
@@ -1253,6 +1253,50 @@ describe("Grok copresence runtime integration", () => {
     }
   }, 10_000);
 
+  test("reports exact submission and trusted consumption, never queued admission", async () => {
+    const fixture = new RuntimeFixture();
+    let runtime: GrokCopresenceRuntimeSession | undefined;
+    try {
+      runtime = await fixture.open();
+      const firstEvidence: string[] = [];
+      const queuedEvidence: string[] = [];
+      const first = runtime.submit({
+        taskId: "evidence-active",
+        from: "reviewer",
+        text: "HOLD_OPEN",
+        timeoutMs: 4_000,
+        onSubmitted: () => firstEvidence.push("submitted"),
+        onConsumed: () => firstEvidence.push("consumed"),
+      });
+      await waitFor(() => firstEvidence.join(",") === "submitted,consumed");
+
+      const queued = runtime.submit({
+        taskId: "evidence-queued",
+        from: "reviewer",
+        text: "event-first multi assistant",
+        timeoutMs: 4_000,
+        onSubmitted: () => queuedEvidence.push("submitted"),
+        onConsumed: () => queuedEvidence.push("consumed"),
+      });
+      await Bun.sleep(75);
+      expect(queuedEvidence).toEqual([]);
+
+      const sessionDir = grokSessionDirectory(fixture.grokHome, fixture.cwd, SESSION);
+      appendJson(join(sessionDir, "chat_history.jsonl"), {
+        type: "assistant",
+        content: "FINAL evidence-active",
+      });
+      appendJson(join(sessionDir, "events.jsonl"), { type: "turn_ended", outcome: "completed" });
+      expect((await first).replyText).toBe("FINAL evidence-active");
+      expect((await queued).replyText).toBe("FINAL evidence-queued");
+      expect(firstEvidence).toEqual(["submitted", "consumed"]);
+      expect(queuedEvidence).toEqual(["submitted", "consumed"]);
+    } finally {
+      await runtime?.close();
+      await fixture.close();
+    }
+  }, 10_000);
+
   test("arbitrates a live PTY, settles final JSONL, attaches once, and resumes", async () => {
     const fixture = new RuntimeFixture();
     let runtime: GrokCopresenceRuntimeSession | undefined;

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -178,6 +178,10 @@ export interface GrokCopresenceThinkOptions {
   from: string;
   text: string;
   timeoutMs?: number;
+  /** Called after this exact task is written into the owned TUI. */
+  onSubmitted?: () => void;
+  /** Called after the exact trusted network_user envelope appears in JSONL. */
+  onConsumed?: () => void;
 }
 
 export interface GrokCopresenceThinkResult {
@@ -608,6 +612,10 @@ interface PendingTask {
   reject: (error: Error) => void;
   timer: ReturnType<typeof setTimeout>;
   queued: boolean;
+  submitted: boolean;
+  consumed: boolean;
+  onSubmitted?: () => void;
+  onConsumed?: () => void;
 }
 
 interface ApprovalInputAction {
@@ -920,6 +928,10 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
         reject: rejectTask,
         timer,
         queued: wasBusy,
+        submitted: false,
+        consumed: false,
+        onSubmitted: opts.onSubmitted,
+        onConsumed: opts.onConsumed,
       });
       // Yield one event-loop turn so a human key already readable on the
       // attach socket can claim the composer before network injection.
@@ -1703,6 +1715,15 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
           taskId: effect.task.taskId,
         });
         this.pty.write(formatNetworkTuiInput(effect.task));
+        const pending = this.pending.get(effect.task.taskId);
+        if (pending && !pending.submitted) {
+          pending.submitted = true;
+          try {
+            pending.onSubmitted?.();
+          } catch (error) {
+            this.warn(`[grok-copresence] runtime-submitted callback failed: ${errorMessage(error)}`);
+          }
+        }
         this.log(`[grok-copresence] injected network task ${effect.task.taskId} from=${effect.task.from}`);
       } catch (error) {
         unregisterOwnedNetworkTask(this.logState, effect.task.taskId);
@@ -1852,6 +1873,16 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
         const active = this.arbitration.activeTurn;
         if (active?.owner !== "network" || active.task.taskId !== event.task.taskId) {
           this.warn(`[grok-copresence] dropped mismatched network user log task=${event.task.taskId}`);
+          return;
+        }
+        const pending = this.pending.get(event.task.taskId);
+        if (pending && !pending.consumed) {
+          pending.consumed = true;
+          try {
+            pending.onConsumed?.();
+          } catch (error) {
+            this.warn(`[grok-copresence] consumed callback failed: ${errorMessage(error)}`);
+          }
         }
         return;
       }

--- a/agent-node/src/runtime/opencode-acp/runtime.test.ts
+++ b/agent-node/src/runtime/opencode-acp/runtime.test.ts
@@ -335,6 +335,57 @@ process.stdin.on("data", (chunk) => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test("reports submission before exact prompt-response consumption", async () => {
+    const root = mkdtempSync(join(tmpdir(), "opencode-runtime-evidence-"));
+    const launchBase = makeLaunchBase("runtime-evidence");
+    const workDir = join(root, "node");
+    const binary = makeStubBinary(launchBase, `
+      let buf = "";
+      process.stdin.on("data", (chunk) => {
+        buf += chunk;
+        while (buf.includes("\\n")) {
+          const idx = buf.indexOf("\\n");
+          const line = buf.slice(0, idx).trim();
+          buf = buf.slice(idx + 1);
+          if (!line) continue;
+          const req = JSON.parse(line);
+          if (req.method === "initialize") {
+            process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: req.id, result: {} }) + "\\n");
+          } else if (req.method === "session/new") {
+            process.stdout.write(JSON.stringify({
+              jsonrpc: "2.0", id: req.id, result: { sessionId: "ses_evidence" },
+            }) + "\\n");
+          } else if (req.method === "session/prompt") {
+            setTimeout(() => process.stdout.write(JSON.stringify({
+              jsonrpc: "2.0", id: req.id, result: { stopReason: "end_turn" },
+            }) + "\\n"), 20);
+          }
+        }
+      });
+    `);
+    let session: Awaited<ReturnType<typeof openOpencodeRuntime>> | null = null;
+    const evidence: string[] = [];
+    try {
+      mkdirSync(workDir, { mode: 0o700 });
+      session = await openOpencodeRuntime({ cwd: root, workDir, binary, launchBase });
+      const thinking = opencodeThink(session, {
+        prompt: "consume this exact prompt",
+        cwd: root,
+        workDir,
+        onSubmitted: () => evidence.push("submitted"),
+        onConsumed: () => evidence.push("consumed"),
+      });
+      await Bun.sleep(5);
+      expect(evidence).toEqual(["submitted"]);
+      await thinking;
+      expect(evidence).toEqual(["submitted", "consumed"]);
+    } finally {
+      if (session?.client.isRunning) await session.client.stop("SIGKILL");
+      rmSync(launchBase, { recursive: true, force: true });
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("openOpencodeRuntime — opening lifecycle", () => {

--- a/agent-node/src/runtime/opencode-acp/runtime.ts
+++ b/agent-node/src/runtime/opencode-acp/runtime.ts
@@ -79,6 +79,10 @@ export interface OpencodeThinkOptions {
   /** Logger. Falls back to `console.log` / `console.warn`. */
   log?: (msg: string) => void;
   warn?: (msg: string) => void;
+  /** Exact session/prompt request was accepted by the runtime client. */
+  onSubmitted?: () => void;
+  /** Exact session/prompt response completed; session notifications alone are insufficient. */
+  onConsumed?: () => void;
   /** #383 rescue toggle. Falls through to the process env if unset. */
   disableThinkingOnlyRescue?: boolean;
 }
@@ -350,10 +354,13 @@ export async function opencodeThink(
 
   let response: any;
   try {
-    response = await runtime.client.requestWithIdleTimeout("session/prompt", {
+    const request = runtime.client.requestWithIdleTimeout("session/prompt", {
       sessionId: runtime.sessionId,
       prompt: [{ type: "text", text: opts.prompt }],
     }, idleTimeoutMs);
+    opts.onSubmitted?.();
+    response = await request;
+    opts.onConsumed?.();
   } catch (error) {
     await killFailedTurnChild("session/prompt failure");
     throw error;

--- a/agent-node/src/runtime/opencode-copresence/inbox-wiring.test.ts
+++ b/agent-node/src/runtime/opencode-copresence/inbox-wiring.test.ts
@@ -52,7 +52,9 @@ describe("OpenCode copresence CommHub message wiring", () => {
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
     const branch = cli.slice(start, end);
-    expect(branch).toContain("runtime.submit(task, undefined, _from)");
+    expect(branch).toContain("runtime.submit(task, undefined, _from, {");
+    expect(branch).toContain("onSubmitted: evidence?.submitted");
+    expect(branch).toContain("onConsumed: evidence?.consumed");
     expect(branch).not.toContain("runtime.submit(task);");
   });
 

--- a/agent-node/src/runtime/opencode-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.test.ts
@@ -245,12 +245,24 @@ describe("OpenCode native serve+attach copresence", () => {
 
       await runtime.notify("notice:dashboard-message", 5_000);
 
-      const [one, two] = await Promise.all([
-        runtime.submit("one", 5_000),
-        runtime.submit("two", 5_000),
-      ]);
+      const oneEvidence: string[] = [];
+      const twoEvidence: string[] = [];
+      const first = runtime.submit("one", 5_000, undefined, {
+        onSubmitted: () => oneEvidence.push("submitted"),
+        onConsumed: () => oneEvidence.push("consumed"),
+      });
+      const second = runtime.submit("two", 5_000, undefined, {
+        onSubmitted: () => twoEvidence.push("submitted"),
+        onConsumed: () => twoEvidence.push("consumed"),
+      });
+      // FIFO admission and idle checks are not runtime evidence.
+      expect(oneEvidence).toEqual([]);
+      expect(twoEvidence).toEqual([]);
+      const [one, two] = await Promise.all([first, second]);
       expect(one.replyText).toBe("FAKE_REPLY:one");
       expect(two.replyText).toBe("FAKE_REPLY:two");
+      expect(oneEvidence).toEqual(["submitted", "consumed"]);
+      expect(twoEvidence).toEqual(["submitted", "consumed"]);
       expect(runtime.isRunning).toBe(true);
     } finally {
       await runtime?.close();

--- a/agent-node/src/runtime/opencode-copresence/runtime.ts
+++ b/agent-node/src/runtime/opencode-copresence/runtime.ts
@@ -63,7 +63,12 @@ export interface OpenCodeCopresenceSession {
   readonly attachScriptPath: string;
   readonly isRunning: boolean;
   notify(message: string, timeoutMs?: number, sender?: string): Promise<void>;
-  submit(prompt: string, timeoutMs?: number, sender?: string): Promise<OpenCodeCopresenceSubmitResult>;
+  submit(
+    prompt: string,
+    timeoutMs?: number,
+    sender?: string,
+    evidence?: { onSubmitted?: () => void; onConsumed?: () => void },
+  ): Promise<OpenCodeCopresenceSubmitResult>;
   close(): Promise<void>;
 }
 
@@ -478,7 +483,12 @@ export async function openVettedOpenCodeCopresence(
           }, timeoutMs);
         })();
       },
-      submit(prompt: string, timeoutMs = 300_000, sender?: string) {
+      submit(
+        prompt: string,
+        timeoutMs = 300_000,
+        sender?: string,
+        evidence?: { onSubmitted?: () => void; onConsumed?: () => void },
+      ) {
         const operation = queue.then(async () => {
           if (!session.isRunning) throw new Error("OpenCode copresence server is not running");
           await waitUntilSessionIdle(url, password, created.id, timeoutMs);
@@ -518,6 +528,12 @@ export async function openVettedOpenCodeCopresence(
           if (message?.info?.role !== "assistant" || message?.info?.parentID !== messageId) {
             throw new Error("OpenCode reply was not owned by the submitted network message");
           }
+          // OpenCode 1.18.1 exposes no exact per-message start event on this
+          // REST lane. The causally-parented assistant response is later but
+          // authoritative; report both evidence levels here rather than at
+          // idle admission or before an unconfirmed POST.
+          evidence?.onSubmitted?.();
+          evidence?.onConsumed?.();
           const replyText = parseMessageReply(message);
           if (!replyText) {
             throw new Error("OpenCode POST /session/:id/message returned no assistant text");
@@ -641,7 +657,8 @@ export async function openOpenCodeCopresenceRuntime(
       get attachScriptPath() { return core!.attachScriptPath; },
       get isRunning() { return core!.isRunning; },
       notify: (message, timeoutMs, sender) => core!.notify(message, timeoutMs, sender),
-      submit: (prompt, timeoutMs, sender) => core!.submit(prompt, timeoutMs, sender),
+      submit: (prompt, timeoutMs, sender, evidence) =>
+        core!.submit(prompt, timeoutMs, sender, evidence),
       async close() {
         await core!.close();
         if (!cleanup()) {

--- a/agent-node/src/task-runtime-evidence.test.ts
+++ b/agent-node/src/task-runtime-evidence.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createTaskRuntimeEvidenceReporter,
+  logicalTaskIdFromInbox,
+} from "./task-runtime-evidence";
+
+const sourceDir = dirname(fileURLToPath(import.meta.url));
+
+describe("logicalTaskIdFromInbox", () => {
+  test("retry/reassign task rows use stable task_id, not fresh inbox.id", () => {
+    expect(logicalTaskIdFromInbox({
+      id: "fresh-redelivery-row",
+      task_id: "stable-logical-task",
+      type: "task",
+    })).toBe("stable-logical-task");
+  });
+
+  test("legacy task rows and non-task rows retain transport identity", () => {
+    expect(logicalTaskIdFromInbox({ id: "legacy-row", type: "task" })).toBe("legacy-row");
+    expect(logicalTaskIdFromInbox({
+      id: "message-row",
+      task_id: "must-not-bind-message",
+      type: "message",
+    })).toBe("message-row");
+  });
+});
+
+describe("createTaskRuntimeEvidenceReporter", () => {
+  test("construction and process admission report no evidence", async () => {
+    const reported: string[] = [];
+    createTaskRuntimeEvidenceReporter({
+      taskId: "task_exact_520",
+      report: async (level, taskId) => { reported.push(`${level}:${taskId}`); },
+    });
+    await Promise.resolve();
+    expect(reported).toEqual([]);
+  });
+
+  test("submission and many runtime events produce one exact report per level", async () => {
+    const reported: string[] = [];
+    const reporter = createTaskRuntimeEvidenceReporter({
+      taskId: "task_once_520",
+      report: async (level, taskId) => { reported.push(`${level}:${taskId}`); },
+    });
+    reporter.submitted();
+    reporter.submitted();
+    reporter.consumed();
+    reporter.consumed();
+    await Promise.resolve();
+    expect(reported).toEqual([
+      "submitted:task_once_520",
+      "consumed:task_once_520",
+    ]);
+  });
+
+  test("a consumed-only runtime remains honest and lets the Hub imply submission", async () => {
+    const reported: string[] = [];
+    const reporter = createTaskRuntimeEvidenceReporter({
+      taskId: "task_late_proof_520",
+      report: async (level, taskId) => { reported.push(`${level}:${taskId}`); },
+    });
+    reporter.consumed();
+    await Promise.resolve();
+    expect(reported).toEqual(["consumed:task_late_proof_520"]);
+  });
+
+  test("missing logical task identity is a fail-closed no-op", async () => {
+    let calls = 0;
+    const reporter = createTaskRuntimeEvidenceReporter({
+      taskId: null,
+      report: async () => { calls++; },
+    });
+    reporter.submitted();
+    reporter.consumed();
+    await Promise.resolve();
+    expect(calls).toBe(0);
+  });
+
+  test("an old-Hub failure is visible but never breaks the model turn", async () => {
+    const logs: string[] = [];
+    const reporter = createTaskRuntimeEvidenceReporter({
+      taskId: "task_old_hub_520",
+      report: async () => { throw new Error("unknown tool"); },
+      debug: (message) => logs.push(message),
+    });
+    expect(() => reporter.submitted()).not.toThrow();
+    await Bun.sleep(0);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("unknown tool");
+  });
+});
+
+describe("agent-node inbox wiring", () => {
+  test("keeps transport ACK separate from stable task evidence and replies", () => {
+    const cli = readFileSync(resolve(sourceDir, "cli.ts"), "utf8");
+    const start = cli.indexOf("async function processInbox()");
+    const end = cli.indexOf("async function processOpencodeCopresenceMessages", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const branch = cli.slice(start, end);
+
+    expect(branch).toContain("const logicalTaskId = logicalTaskIdFromInbox(msg)");
+    expect(branch).toContain("processTask(\n        content,\n        from,\n        logicalTaskId,");
+    expect(branch).toContain("deliverReplyReliably(from, replyBody, logicalTaskId, failed)");
+    expect(branch).toContain("ackMessage(msg.id)");
+    expect(branch).not.toContain("processTask(\n        content,\n        from,\n        msg.id,");
+  });
+
+  test("all runtime dispatch families receive the same task-lifetime reporter", () => {
+    const cli = readFileSync(resolve(sourceDir, "cli.ts"), "utf8");
+    const start = cli.indexOf("function think(");
+    const end = cli.indexOf("async function processTask(", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const branch = cli.slice(start, end);
+
+    for (const call of [
+      "processWithCodexStdio(task, from, images, evidence)",
+      "processWithCodex(task, from, images, evidence)",
+      "processWithGrokCopresence(task, from, taskId, images, evidence)",
+      "processWithGrokCli(task, from, images, evidence)",
+      "processWithGrok(task, from, images, evidence)",
+      "processWithOpencode(task, from, images, evidence)",
+      "processWithCodexAppServer(task, from, taskId, steerIfExternalTurn, evidence)",
+      "processWithClaude(task, from, images, evidence)",
+    ]) {
+      expect(branch).toContain(call);
+    }
+  });
+
+  test("SDK and direct-stdio boundaries preserve their distinct evidence semantics", () => {
+    const cli = readFileSync(resolve(sourceDir, "cli.ts"), "utf8");
+    const section = (from: string, to: string) => {
+      const start = cli.indexOf(from);
+      const end = cli.indexOf(to, start + from.length);
+      expect(start).toBeGreaterThanOrEqual(0);
+      expect(end).toBeGreaterThan(start);
+      return cli.slice(start, end);
+    };
+
+    const claude = section("async function processWithClaude(", "const CODEX_CONFIG");
+    expect(claude.indexOf("const messages = query({ prompt, options })"))
+      .toBeLessThan(claude.indexOf("evidence?.submitted()"));
+    expect(claude.indexOf("evidence?.submitted()"))
+      .toBeLessThan(claude.indexOf("for await (const message of messages)"));
+    expect(claude.indexOf("for await (const message of messages)"))
+      .toBeLessThan(claude.indexOf("evidence?.consumed()"));
+
+    const codexSdk = section("async function processWithCodex(", "async function ensureCodexStdio(");
+    expect(codexSdk.indexOf("await codexThread.runStreamed(input, { signal })"))
+      .toBeLessThan(codexSdk.indexOf("evidence?.submitted()"));
+    expect(codexSdk.indexOf("for await (const ev of events)"))
+      .toBeLessThan(codexSdk.indexOf("evidence?.consumed()"));
+
+    const codexStdio = section("async function processWithCodexStdio(", "function sanitizeGrokCommhubLeak(");
+    expect(codexStdio).toContain("evidence?.submitted()");
+    expect(codexStdio).not.toContain("evidence?.consumed()");
+    expect(codexStdio).toContain("is not authoritative ownership");
+  });
+});

--- a/agent-node/src/task-runtime-evidence.ts
+++ b/agent-node/src/task-runtime-evidence.ts
@@ -1,0 +1,63 @@
+export type TaskRuntimeEvidenceLevel = "submitted" | "consumed";
+
+export interface TaskRuntimeEvidenceReporterOptions {
+  taskId: string | null;
+  report: (level: TaskRuntimeEvidenceLevel, taskId: string) => Promise<unknown>;
+  debug?: (message: string) => void;
+}
+
+export interface TaskRuntimeEvidenceReporter {
+  /** The exact task body crossed the runtime adapter's submission boundary. */
+  submitted(): void;
+  /** Exact turn-start or attributable runtime activity was observed. */
+  consumed(): void;
+}
+
+export function logicalTaskIdFromInbox(message: {
+  id: unknown;
+  task_id?: unknown;
+  type?: unknown;
+}): string {
+  if (
+    (message.type ?? "task") === "task"
+    && typeof message.task_id === "string"
+    && message.task_id.length > 0
+  ) {
+    return message.task_id;
+  }
+  return String(message.id);
+}
+
+/**
+ * Build non-blocking, write-once callbacks for one logical Hub task.
+ *
+ * Merely creating this reporter, acknowledging an inbox row, or entering
+ * processTask reports nothing. Runtime adapters own the two boundaries. A
+ * consumed report also implies submission at the Hub, so it is safe for a
+ * runtime with no distinct, trustworthy submission acknowledgement to call
+ * only consumed().
+ */
+export function createTaskRuntimeEvidenceReporter(
+  opts: TaskRuntimeEvidenceReporterOptions,
+): TaskRuntimeEvidenceReporter {
+  const attempted = new Set<TaskRuntimeEvidenceLevel>();
+
+  const fire = (level: TaskRuntimeEvidenceLevel) => {
+    if (!opts.taskId || attempted.has(level)) return;
+    attempted.add(level);
+    void opts.report(level, opts.taskId).catch((cause: unknown) => {
+      // The tools are additive. Old Hubs and transient reporting failures
+      // must not break the model turn; leaving a false-negative NULL is safer
+      // than inventing a timestamp or retrying the model task.
+      opts.debug?.(
+        `[runtime-evidence] ${level} report failed task=${opts.taskId!.slice(0, 8)}: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+      );
+    });
+  };
+
+  return {
+    submitted: () => fire("submitted"),
+    consumed: () => fire("consumed"),
+  };
+}

--- a/docs/tests/report-test520-agent-node-runtime-evidence.txt
+++ b/docs/tests/report-test520-agent-node-runtime-evidence.txt
@@ -1,0 +1,67 @@
+# #520 agent-node per-runtime evidence — Docker report
+
+Date: 2026-08-10
+Base: 3cebc82e8465bcb9475dd38df54529e96449de19
+Source commit: 0013abd50d0ed61cfb8db72e9f0051c5c668fb46
+Branch: feat/520-runtime-consumption
+Image: anet-test520-runtime:dev
+Image ID: sha256:07cee82825dcf3293d352df870c168b04b2dbec020c67a33173731175b13f585
+Embedded TEST520_SOURCE_COMMIT: 0013abd50d0ed61cfb8db72e9f0051c5c668fb46
+Runner artifact SHA256: 2b3579056149f2c5e59a5dcd8af8f4312a0b322edd12267dfc8fb3a0066783eb
+
+## Result
+
+PASS.
+
+- Production `agent-node` bundle: PASS (260 modules, 1.12 MB bundle).
+- Serial runtime tests: 128 pass / 0 fail / 683 assertions.
+- Isolated Grok copresence evidence case: 1 pass / 0 fail / 5 assertions.
+- Total: 129 pass / 0 fail / 688 assertions.
+- Witnessed-red mutations: 11 / 11.
+
+## Semantics verified
+
+- Queue/FIFO admission and inbox ACK do not report runtime evidence.
+- `runtime_submitted_at` is reported only after an exact runtime adapter
+  accepts the task body for submission.
+- `consumed_at` is reported only from an exact turn-start or attributable
+  runtime event. A runtime without such an identity signal leaves it NULL.
+- Direct Codex stdio is intentionally submitted-only: the #587 race proved
+  its `turn/start` response turn ID is not authoritative ownership evidence.
+- Retry/reassign uses stable `inbox.task_id`; ACK remains bound to the exact
+  transport `inbox.id` row.
+- Evidence is task-lifetime monotonic and one-shot across a transient retry.
+- Old-Hub/reporting failures are visible but do not repeat the model turn.
+
+Runtime coverage: Claude Agent SDK, Codex SDK, direct Codex stdio,
+Codex app-server, OpenCode ACP, OpenCode copresence, Grok ACP, Grok CLI,
+and Grok copresence.
+
+## Mutation matrix
+
+Each mutation changed source bytes and made its targeted test fail:
+
+1. stable logical task ID -> transport inbox ID
+2. reporter dispatch removed
+3. Codex app-server exact consumed callback removed
+4. Grok copresence trusted consumed callback removed
+5. OpenCode ACP consumed callback removed
+6. Grok ACP consumed callback removed
+7. Grok CLI first-event consumed callback removed
+8. OpenCode copresence attributable-response callback removed
+9. Claude SDK first-event callback removed
+10. Codex SDK first-event callback removed
+11. direct Codex stdio submission callback removed
+
+## Controlled harness findings
+
+Two pre-commit harness failures were not counted as product evidence:
+
+- Running the whole Grok copresence file beside the other runtime files caused
+  its existing process-wide project-lock fixtures to cascade. The new case was
+  therefore run alone, preserving the real production runtime.
+- The first Docker image omitted the cross-tree
+  `agent-network/src/grok-attach-client.ts` test dependency. The image was
+  corrected to copy that source file; production code was unchanged.
+
+No Hub, Dashboard, production runtime, npm package, or deployment was changed.

--- a/tests/test520-task-runtime-evidence/Dockerfile
+++ b/tests/test520-task-runtime-evidence/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node ./agent-node
+COPY agent-network/src/grok-attach-client.ts ./agent-network/src/grok-attach-client.ts
+COPY tests/test520-task-runtime-evidence ./tests/test520-task-runtime-evidence
+
+ARG TEST520_SOURCE_COMMIT=uncommitted
+ENV TEST520_SOURCE_COMMIT=$TEST520_SOURCE_COMMIT
+RUN chmod 0755 tests/test520-task-runtime-evidence/run.sh
+
+ENTRYPOINT ["/workspace/tests/test520-task-runtime-evidence/run.sh"]

--- a/tests/test520-task-runtime-evidence/mutate.mjs
+++ b/tests/test520-task-runtime-evidence/mutate.mjs
@@ -1,0 +1,12 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [file, before, after] = process.argv.slice(2);
+if (!file || before === undefined || after === undefined) {
+  throw new Error("usage: mutate.mjs FILE BEFORE AFTER");
+}
+const source = readFileSync(file, "utf8");
+const count = source.split(before).length - 1;
+if (count !== 1) throw new Error(`mutation anchor count=${count} file=${file}`);
+const mutated = source.replace(before, after);
+if (mutated === source) throw new Error(`mutation was byte-identical file=${file}`);
+writeFileSync(file, mutated);

--- a/tests/test520-task-runtime-evidence/run.sh
+++ b/tests/test520-task-runtime-evidence/run.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=/workspace
+NODE="$ROOT/agent-node"
+ARTIFACT_DIR=/artifacts
+mkdir -p "$ARTIFACT_DIR"
+REPORT="$ARTIFACT_DIR/report-test520-task-runtime-evidence.txt"
+exec > >(tee "$REPORT") 2>&1
+
+echo "source_commit=$TEST520_SOURCE_COMMIT"
+echo "layer=agent-node exact runtime evidence"
+
+cd "$NODE"
+bun run build
+
+bun test \
+  src/task-runtime-evidence.test.ts \
+  src/runtime/codex-app-server/runtime.test.ts \
+  src/runtime/codex-app-server-bridge.test.ts \
+  src/runtime/grok-build-acp/runtime.test.ts \
+  src/runtime/grok-build-cli.test.ts \
+  src/runtime/opencode-acp/runtime.test.ts \
+  src/runtime/opencode-copresence/runtime.test.ts \
+  src/runtime/opencode-copresence/inbox-wiring.test.ts
+
+# The full Grok copresence file owns process-wide project locks. Run the new
+# evidence case alone so unrelated lifetime fixtures cannot create a false red.
+bun test src/runtime/grok-copresence/runtime.test.ts \
+  --test-name-pattern 'reports exact submission'
+
+MUTATIONS=0
+expect_mutation_red() {
+  local name=$1 file=$2 before=$3 after=$4 test_file=$5 pattern=${6:-}
+  local backup
+  backup=$(mktemp)
+  cp "$file" "$backup"
+  bun "$ROOT/tests/test520-task-runtime-evidence/mutate.mjs" \
+    "$file" "$before" "$after"
+  if cmp -s "$file" "$backup"; then
+    echo "MUTATION INVALID byte-identical: $name" >&2
+    cp "$backup" "$file"
+    rm -f "$backup"
+    exit 1
+  fi
+  set +e
+  if [[ -n "$pattern" ]]; then
+    bun test "$test_file" --test-name-pattern "$pattern" >/tmp/test520-mutation.log 2>&1
+  else
+    bun test "$test_file" >/tmp/test520-mutation.log 2>&1
+  fi
+  local rc=$?
+  set -e
+  cp "$backup" "$file"
+  rm -f "$backup"
+  if [[ $rc -eq 0 ]]; then
+    echo "MUTATION SURVIVED: $name" >&2
+    cat /tmp/test520-mutation.log >&2
+    exit 1
+  fi
+  MUTATIONS=$((MUTATIONS + 1))
+  echo "MUTATION RED: $name rc=$rc"
+}
+
+expect_mutation_red \
+  logical-task-id \
+  src/task-runtime-evidence.ts \
+  'return message.task_id;' \
+  'return String(message.id);' \
+  src/task-runtime-evidence.test.ts \
+  'retry/reassign task rows'
+
+expect_mutation_red \
+  reporter-dispatch \
+  src/task-runtime-evidence.ts \
+  'attempted.add(level);' \
+  'return;' \
+  src/task-runtime-evidence.test.ts \
+  'submission and many runtime events'
+
+expect_mutation_red \
+  codex-appserver-consumed \
+  src/runtime/codex-app-server/runtime.ts \
+  'opts.onConsumed?.(ev);' \
+  'void ev;' \
+  src/runtime/codex-app-server/runtime.test.ts \
+  'exact runtime submission'
+
+expect_mutation_red \
+  grok-copresence-consumed \
+  src/runtime/grok-copresence/runtime.ts \
+  'pending.onConsumed?.();' \
+  'void pending;' \
+  src/runtime/grok-copresence/runtime.test.ts \
+  'reports exact submission'
+
+expect_mutation_red \
+  opencode-acp-consumed \
+  src/runtime/opencode-acp/runtime.ts \
+  'opts.onConsumed?.();' \
+  'void opts;' \
+  src/runtime/opencode-acp/runtime.test.ts \
+  'reports submission before exact'
+
+expect_mutation_red \
+  grok-acp-consumed \
+  src/runtime/grok-build-acp/runtime.ts \
+  'opts.onConsumed?.();' \
+  'void opts;' \
+  src/runtime/grok-build-acp/runtime.test.ts
+
+expect_mutation_red \
+  grok-cli-consumed \
+  src/runtime/grok-build-cli.ts \
+  'opts.onConsumed?.();' \
+  'void opts;' \
+  src/runtime/grok-build-cli.test.ts \
+  'reports spawn submission'
+
+expect_mutation_red \
+  opencode-copresence-consumed \
+  src/runtime/opencode-copresence/runtime.ts \
+  'evidence?.onConsumed?.();' \
+  'void evidence;' \
+  src/runtime/opencode-copresence/runtime.test.ts \
+  'one authenticated loopback session'
+
+expect_mutation_red \
+  claude-sdk-consumed \
+  src/cli.ts \
+  $'for await (const message of messages) {\n            evidence?.consumed();' \
+  $'for await (const message of messages) {\n            void evidence;' \
+  src/task-runtime-evidence.test.ts \
+  'SDK and direct-stdio boundaries'
+
+expect_mutation_red \
+  codex-sdk-consumed \
+  src/cli.ts \
+  $'for await (const ev of events) {\n          evidence?.consumed();' \
+  $'for await (const ev of events) {\n          void evidence;' \
+  src/task-runtime-evidence.test.ts \
+  'SDK and direct-stdio boundaries'
+
+expect_mutation_red \
+  codex-stdio-submitted \
+  src/cli.ts \
+  $'evidence?.submitted();\n      log(`[codex-stdio]' \
+  $'void evidence;\n      log(`[codex-stdio]' \
+  src/task-runtime-evidence.test.ts \
+  'SDK and direct-stdio boundaries'
+
+if [[ $MUTATIONS -ne 11 ]]; then
+  echo "mutation denominator mismatch: $MUTATIONS/11" >&2
+  exit 1
+fi
+
+echo "mutation_red=$MUTATIONS/11"
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes the remaining agent-node half of #520.

## What changed

- carries the stable logical `inbox.task_id` through runtime evidence and replies while keeping ACK bound to the transport inbox row
- reports `runtime_submitted_at` and `consumed_at` from each runtime's strongest exact boundary
- deliberately leaves direct Codex stdio `consumed_at` NULL because it lacks authoritative per-task identity
- keeps evidence one-shot, task-lifetime monotonic, non-blocking, and backward-compatible with old Hubs
- covers Claude/Codex/OpenCode/Grok SDK, ACP, CLI, app-server, and copresence lanes

## Verification

- exact source: `0013abd50d0ed61cfb8db72e9f0051c5c668fb46`
- report-only head: `00db74b1e01491d0df5d6d1326571269c9d73c88`
- Docker production bundle: PASS
- 129 tests, 0 failures, 688 assertions
- 11/11 witnessed-red mutations
- image embeds the exact source SHA; runner artifact SHA is recorded in `docs/tests/report-test520-agent-node-runtime-evidence.txt`

No Hub, Dashboard, npm publish, or production deployment is included.
