### PR TITLE
test(#259): gate Claude multimodal image prompt wiring

### DIFF
--- a/docs/tests/report-test673-claude-image-attachment-block.txt
+++ b/docs/tests/report-test673-claude-image-attachment-block.txt
@@ -1,0 +1,111 @@
+================================================================
+test673 — Claude SDK multimodal image-block wiring (#259)
+================================================================
+
+Date: 2026-08-10
+Base: 0bd599db232cadedaaca471d798ae23e3430ebb7 (origin/main)
+Source commit: 16e8df78643846f1c3399a6707feb436fa17e501
+Scope: tests/test673-claude-image-attachment-block/** only
+Production source delta: none
+
+Docker image:
+  tag: anet-test259:dev
+  image id: sha256:c3e7b3a40c2f4978c6ee655bb72864cd7f3e66b33ed22ffa52ee7786db800044
+  embedded TEST673_SOURCE_COMMIT:
+    16e8df78643846f1c3399a6707feb436fa17e501
+
+Final result:
+  PASS=32
+  FAIL=0
+
+What the final Docker run exercised
+------------------------------------
+
+The harness starts the real CommHub server and the real agent-node CLI.
+Only the external claude-agent-sdk query call is replaced with a preload
+stub; the production CLI, Hub HTTP/SSE flow, upload/download resolver,
+processTask/think dispatch and prompt construction are not reimplemented.
+
+1. A real 1x1 PNG is uploaded to the real Hub and represented by file_id.
+2. A real /api/task delivery reaches agent-node over SSE.
+3. agent-node downloads the exact PNG bytes through /api/files/:file_id.
+4. processWithClaude receives the resolved image and constructs an
+   AsyncIterable<SDKUserMessage>.
+5. query({prompt}) receives one base64 image block with media_type=image/png,
+   byte-identical to the upload, plus the text block.
+6. A task without attachments reaches query({prompt}) as the historical
+   string prompt and retains its unique task marker.
+7. The same image delivery with flags.modelImageCapable=false reaches query
+   as a string with zero image blocks. The unverified profile cannot receive
+   image bytes merely because an attachment exists.
+
+Witnessed-red mutations
+-----------------------
+
+Both mutations require an exact production anchor and assert a byte change
+before running. The production file is restored after each phase.
+
+1. Dispatch threading:
+   processWithClaude(task, from, images, evidence)
+     -> processWithClaude(task, from, undefined, evidence)
+
+   The task still arrives and query still runs, but its prompt changes to a
+   string with image_block_count=0. This proves the images argument is the
+   load-bearing link, rather than the red result coming from a dead task.
+
+2. Per-model capability gate:
+   if (hasImages && modelImageCapable)
+     -> if (hasImages)
+
+   A profile explicitly configured modelImageCapable=false then receives the
+   image block. This is the intended safety-contract violation and proves the
+   negative gate is load-bearing.
+
+Harness hardening found during this run
+---------------------------------------
+
+The inherited, previously unmerged test673 was not accepted as evidence.
+Two concrete harness failures were found and fixed before the final run:
+
+- It killed only a shell PID and left Bun node processes orphaned. Those stale
+  processes made later phases consume tasks and caused false green/red results.
+  The final harness starts Hub and node under their own exact process groups,
+  sends TERM then bounded KILL fallback, waits the exact group leader, and
+  leaves no test673 process behind. Six pre-existing test673 orphan PIDs were
+  individually inspected and terminated; no name-pattern kill was used.
+- Its bare-name Bun module mock worked in the host dependency layout but did
+  not intercept the installed SDK entrypoint inside Docker. The failed Docker
+  probe therefore reached the real SDK with a literal fake key and was stopped;
+  it is not counted as PASS. The final preload resolves the SDK from
+  agent-node/package.json and registers both the installed entrypoint identity
+  and public specifier. The final canonical Docker run proves the stub is used.
+- The old Dockerfile omitted unzip, which the Bun installer requires. The
+  failed build is not counted; the final image declares the dependency.
+- Bare rm -rf was replaced with the repository safe_rm_rf guard.
+
+Scope and evidence limits
+-------------------------
+
+- This is a deterministic orchestration/wire test. It proves the actual SDK
+  message shape delivered by the production CLI, not a new vendor capability.
+- The historical production commit 1eaaf622 records the real MiniMax-M3 red
+  and blue PNG calls and their correct visual descriptions; that is the real
+  vendor evidence behind the imageCapable registry entry. This test does not
+  reuse or expose the vendor credential.
+- Models not explicitly marked imageCapable remain on the text-only path.
+- No production CLI/runtime/server source changed in this candidate.
+
+Commands
+--------
+
+  sg docker -c 'docker build \
+    --build-arg TEST673_SOURCE_COMMIT=16e8df78643846f1c3399a6707feb436fa17e501 \
+    -f tests/test673-claude-image-attachment-block/Dockerfile \
+    -t anet-test259:dev .'
+
+  sg docker -c 'docker run --rm anet-test259:dev'
+
+Verdict: PASS. The previously untested #259 query-wiring and capability
+boundary are now protected by exact-SHA Docker behavior and two non-vacuous
+mutations. Candidate remains unmerged pending independent review.
+================================================================

--- a/tests/test673-claude-image-attachment-block/Dockerfile
+++ b/tests/test673-claude-image-attachment-block/Dockerfile
@@ -1,0 +1,32 @@
+# test673 — Claude runtime multimodal-wiring gate (issue #259 Y).
+#
+# Builds from LOCAL source (no npm @preview) and runs the real
+# agent-node inbound path against a real hub, with the claude-agent-sdk
+# `query` stubbed via `bun --preload` so no vendor/binary is needed.
+# See run.sh for the full assertion + witnessed-red mutation.
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash curl ca-certificates jq procps \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /app
+
+# Exact-SHA provenance — pass --build-arg TEST673_SOURCE_COMMIT=$(git rev-parse HEAD)
+ARG TEST673_SOURCE_COMMIT=unknown
+ENV TEST673_SOURCE_COMMIT=${TEST673_SOURCE_COMMIT}
+
+COPY server /app/server
+COPY agent-node /app/agent-node
+COPY tests/lib /app/tests/lib
+COPY tests/test673-claude-image-attachment-block /app/tests/test673-claude-image-attachment-block
+RUN chmod +x /app/tests/test673-claude-image-attachment-block/run.sh
+
+RUN cd /app/server && bun install --silent
+RUN cd /app/agent-node && bun install --silent
+
+ENV REPO=/app
+CMD ["/app/tests/test673-claude-image-attachment-block/run.sh"]

--- a/tests/test673-claude-image-attachment-block/Dockerfile
+++ b/tests/test673-claude-image-attachment-block/Dockerfile
@@ -7,7 +7,7 @@
 FROM node:22-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash curl ca-certificates jq procps \
+    bash curl ca-certificates jq procps unzip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://bun.sh/install | bash

--- a/tests/test673-claude-image-attachment-block/README.md
+++ b/tests/test673-claude-image-attachment-block/README.md
@@ -1,0 +1,62 @@
+# test673 — Claude runtime multimodal-wiring gate (#259 Y)
+
+Locks the previously-untested half of Dashboard image attachments reaching a
+Claude-runtime agent's model. Issue **#222** (cross-host attachment fetch) shipped
+with a Docker e2e (`tests/qa-222-cross-host-attachments`) that proves the
+**download** half (`resolveAttachmentToLocalPath` → local path). Issue **#259 Y**
+(`per-model imageCapable gate + real multimodal wiring for claude-agent-sdk`)
+shipped the **query** half — building the prompt as an
+`AsyncIterable<SDKUserMessage>` with an image content block — but **without a
+test**. This test closes that gap.
+
+## What it proves (real inbound path, no mocks of cli.ts)
+
+A commhub task with `meta.attachments=[{type:"file",file_id,mime:"image/png"}]`
+drives the real `agent-node/src/cli.ts` path end to end:
+
+```
+SSE task  →  extractImagePaths()  →  hub GET /api/files/<id>  (#222 download)
+          →  processTask → think → processWithClaude(task, from, images)  (dispatch)
+          →  prompt = AsyncIterable<SDKUserMessage> with an image block      (#259 Y)
+             { type:"image", source:{ type:"base64", media_type, data } }
+          →  claude-agent-sdk query({ prompt })  ← asserted to carry the block
+```
+
+`query` is stubbed via `bun --preload sdk-stub-preload.ts` (bun `mock.module`)
+so no vendor key or native binary is needed. The stub records the *actual*
+prompt `query()` received; the test asserts the image block's base64 equals the
+uploaded PNG bytes, and that a text block accompanies it. It also proves the
+two narrow sides of the contract: a text-only task still reaches `query()` as
+a string prompt, and a profile with `modelImageCapable=false` structurally
+cannot emit an image block.
+
+## Witnessed-red mutation
+
+Two exact-anchor, byte-changing mutations are exercised:
+
+1. the dispatch drops `images` while preserving the newer task-evidence
+   argument; the turn still runs, but the capture becomes a plain string;
+2. the `modelImageCapable` condition is removed; an unverified profile then
+   receives an image block and the negative contract turns red.
+
+`cli.ts` is restored after each mutation.
+
+## Run
+
+Docker (exact-SHA):
+
+```
+docker build -f tests/test673-claude-image-attachment-block/Dockerfile \
+  --build-arg TEST673_SOURCE_COMMIT=$(git rev-parse HEAD) -t test673 .
+docker run --rm test673
+```
+
+Host (isolated hub + tmp DB, cleans up):
+
+```
+REPO=$(pwd) TEST673_SOURCE_COMMIT=$(git rev-parse HEAD) \
+  bash tests/test673-claude-image-attachment-block/run.sh
+```
+
+The exact PASS count is printed by `run.sh`; acceptance is `FAIL=0` plus both
+witnessed-red phases reaching their intended behavior violation.

--- a/tests/test673-claude-image-attachment-block/run.sh
+++ b/tests/test673-claude-image-attachment-block/run.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# test673 — Claude runtime multimodal-wiring gate (issue #259 Y).
+#
+# Proves the FULL real inbound path in agent-node/src/cli.ts:
+#   SSE task with meta.attachments=[{type:"file",file_id,mime:"image/png"}]
+#     → extractImagePaths() downloads bytes via hub GET /api/files/<id>  (#222)
+#     → processTask → think → processWithClaude(task, from, images)      (dispatch)
+#     → processWithClaude builds prompt as AsyncIterable<SDKUserMessage> (#259 Y)
+#       whose user-message content carries an image content block
+#       { type:"image", source:{ type:"base64", media_type, data } }
+#     → claude-agent-sdk query({ prompt }) receives that image block.
+#
+# The claude-agent-sdk `query` is stubbed via `bun --preload` (see
+# sdk-stub-preload.ts) so no real vendor/binary is needed; the stub
+# records the prompt structure query() actually received to a capture
+# file, which we then assert against the uploaded bytes.
+#
+# Witnessed-red mutation: revert the dispatch to processWithClaude(task,
+# from)  — dropping the images arg — and prove the image block DISAPPEARS
+# from the query prompt (capture kind flips to "string").
+#
+# REPO defaults to /app (Docker). Override REPO to run against a source
+# checkout on the host (isolated hub + tmp DB, cleans up after).
+set -uo pipefail
+
+REPO="${REPO:-/app}"
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRELOAD="$TEST_DIR/sdk-stub-preload.ts"
+source "$REPO/tests/lib/safe-rm.sh"
+
+HUB_PORT="${HUB_PORT:-9673}"
+HUB_BASE="http://127.0.0.1:$HUB_PORT"
+WORK="${WORK:-/tmp/test673}"
+export HOME="$WORK/home"
+HUB_DB="$WORK/hub.db"
+HUB_UPLOADS="$WORK/hub-uploads"
+CAPTURE="$WORK/capture.json"
+NODE_LOG="$WORK/node.log"
+HUB_LOG="$WORK/hub.log"
+CFG="$WORK/node-config.json"
+ALIAS="test673-agent"
+ADMIN_USER="test673admin"
+ADMIN_PW="test673_TestPass_1234!"
+
+export TEST673_CAPTURE_FILE="$CAPTURE"
+
+PASS=0; FAIL=0
+note() { printf "\n=== %s ===\n" "$*"; }
+ok()   { printf "  PASS %s\n" "$*"; PASS=$((PASS+1)); }
+bad()  { printf "  FAIL %s\n" "$*"; FAIL=$((FAIL+1)); }
+
+printf "source_commit=%s\n" "${TEST673_SOURCE_COMMIT:-unknown}"
+printf "repo=%s\n" "$REPO"
+
+safe_rm_rf "$WORK"
+mkdir -p "$HOME" "$HUB_UPLOADS"
+
+HUB_PID=""; NODE_PID=""
+stop_group() {
+  local pid="${1:-}"
+  [[ -n "$pid" ]] || return 0
+  kill -TERM -- "-$pid" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    [[ ! -e "/proc/$pid" ]] && return 0
+    sleep 0.1
+  done
+  kill -KILL -- "-$pid" 2>/dev/null || true
+  for _ in $(seq 1 20); do
+    [[ ! -e "/proc/$pid" ]] && return 0
+    sleep 0.1
+  done
+  echo "test673 REFUSE: process-group leader $pid survived cleanup" >&2
+  return 1
+}
+
+stop_node() {
+  local pid="$NODE_PID"
+  NODE_PID=""
+  stop_group "$pid"
+  [[ -n "$pid" ]] && wait "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  stop_node || true
+  local hub_pid="$HUB_PID"
+  HUB_PID=""
+  stop_group "$hub_pid" || true
+  [[ -n "$hub_pid" ]] && wait "$hub_pid" 2>/dev/null || true
+  # restore cli.ts if a mutation left it patched
+  if [[ -f "$WORK/cli.ts.orig" ]]; then cp "$WORK/cli.ts.orig" "$REPO/agent-node/src/cli.ts"; fi
+}
+trap cleanup EXIT
+
+# ── 0. boot hub ───────────────────────────────────────────────────
+note "0. boot hub"
+( cd "$REPO/server" && exec setsid env PORT="$HUB_PORT" HOST=127.0.0.1 NODE_ENV=test \
+    COMMHUB_DB="$HUB_DB" COMMHUB_UPLOADS_ROOT="$HUB_UPLOADS" \
+    bun run src/index.ts >"$HUB_LOG" 2>&1 ) &
+HUB_PID=$!
+for _ in $(seq 1 60); do curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && break; sleep 0.5; done
+if curl -fsS "$HUB_BASE/health" >/dev/null 2>&1; then ok "hub /health 200 :$HUB_PORT"; else bad "hub did not start"; tail -30 "$HUB_LOG"; exit 1; fi
+
+# ── 1. register admin + network + node token ──────────────────────
+note "1. admin + network + ntok"
+REG=$(curl -sS -X POST "$HUB_BASE/api/auth/register" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PW\",\"email\":\"t673@test.local\"}")
+UTOK=$(echo "$REG" | jq -r '.token // empty')
+[[ "$UTOK" == utok_* ]] && ok "admin utok minted" || { bad "utok mint: $REG"; exit 1; }
+NET_ID=$(curl -sS "$HUB_BASE/api/auth/me" -H "Authorization: Bearer $UTOK" | jq -r '.networks[0].network_id')
+[[ -n "$NET_ID" && "$NET_ID" != "null" ]] && ok "network_id=$NET_ID" || { bad "no network"; exit 1; }
+NTOK=$(curl -sS -X POST "$HUB_BASE/api/auth/node-token" -H "Authorization: Bearer $UTOK" \
+  -H 'Content-Type: application/json' -d "{\"network_id\":\"$NET_ID\",\"node_name\":\"$ALIAS\"}" | jq -r '.token // empty')
+[[ "$NTOK" == ntok_* ]] && ok "agent ntok minted" || { bad "ntok mint failed"; exit 1; }
+
+# ── 2. upload a real PNG → file_id ────────────────────────────────
+note "2. upload real 1x1 PNG"
+# 1x1 PNG (deterministic, no secrets).
+B64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+echo -n "$B64" | base64 -d > "$WORK/pixel.png"
+UPLOAD=$(curl -sS -X POST "$HUB_BASE/api/upload" -H "Authorization: Bearer $UTOK" \
+  -F "file=@$WORK/pixel.png;type=image/png")
+FILE_ID=$(echo "$UPLOAD" | jq -r '.file_id // empty')
+[[ -n "$FILE_ID" && "$FILE_ID" != "null" ]] && ok "uploaded file_id=$FILE_ID" || { bad "upload failed: $UPLOAD"; exit 1; }
+EXPECTED_B64=$(base64 -w0 "$WORK/pixel.png")
+
+# ── 3. write node config (image-capable claude runtime) ───────────
+note "3. node config"
+write_config() {
+  local image_capable="$1"
+  cat > "$CFG" <<JSON
+{ "runtime": "claude-agent-sdk", "model": "claude-sonnet-4-6",
+  "hub": "$HUB_BASE", "token": "$NTOK", "network_id": "$NET_ID",
+  "flags": { "modelImageCapable": $image_capable, "dangerouslySkipPermissions": true } }
+JSON
+}
+write_config true
+ok "config written (flags.modelImageCapable=true)"
+
+# ── helper: start the real node under the stubbed SDK ─────────────
+start_node() {
+  rm -f "$CAPTURE"
+  ( cd "$WORK" && exec setsid env COMMHUB_URL="$HUB_BASE" COMMHUB_TOKEN="$NTOK" ANET_NETWORK_ID="$NET_ID" \
+      MODEL="claude-sonnet-4-6" ANTHROPIC_API_KEY="test673-fake-key" \
+      TEST673_CAPTURE_FILE="$CAPTURE" HOME="$HOME" \
+      bun --preload "$PRELOAD" "$REPO/agent-node/src/cli.ts" \
+        --alias "$ALIAS" --config "$CFG" >>"$NODE_LOG" 2>&1 ) &
+  NODE_PID=$!
+  # wait until the node's session shows up as active on the hub
+  for _ in $(seq 1 60); do
+    if curl -fsS "$HUB_BASE/api/status?network_id=$NET_ID" -H "Authorization: Bearer $UTOK" 2>/dev/null | jq -e \
+         --arg a "$ALIAS" '.sessions[]? | select(.alias==$a)' >/dev/null 2>&1; then return 0; fi
+    sleep 0.5
+  done
+  return 1
+}
+
+send_task_with_image() {
+  # $1 = task text (must differ between phases — the hub rejects identical
+  # task content to the same alias within a 5-min window: duplicate_send).
+  local text="$1" resp mid
+  for _ in 1 2 3; do
+    resp=$(curl -sS -X POST "$HUB_BASE/api/task" -H "Authorization: Bearer $UTOK" \
+      -H 'Content-Type: application/json' \
+      -d "{\"alias\":\"$ALIAS\",\"task\":\"$text\",\"priority\":\"normal\",\"network_id\":\"$NET_ID\",\"attachments\":[{\"type\":\"file\",\"file_id\":\"$FILE_ID\",\"mime\":\"image/png\",\"name\":\"pixel.png\"}]}")
+    mid=$(echo "$resp" | jq -r '.message_id // empty')
+    [[ -n "$mid" ]] && { echo "$mid"; return 0; }
+    echo "  (task-send retry; resp=$resp)" >&2
+    sleep 1
+  done
+  return 1
+}
+
+send_text_task() {
+  local text="$1" resp mid
+  for _ in 1 2 3; do
+    resp=$(curl -sS -X POST "$HUB_BASE/api/task" -H "Authorization: Bearer $UTOK" \
+      -H 'Content-Type: application/json' \
+      -d "{\"alias\":\"$ALIAS\",\"task\":\"$text\",\"priority\":\"normal\",\"network_id\":\"$NET_ID\"}")
+    mid=$(echo "$resp" | jq -r '.message_id // empty')
+    [[ -n "$mid" ]] && { echo "$mid"; return 0; }
+    echo "  (text-task retry; resp=$resp)" >&2
+    sleep 1
+  done
+  return 1
+}
+
+wait_capture() {
+  for _ in $(seq 1 60); do [[ -s "$CAPTURE" ]] && return 0; sleep 0.5; done
+  return 1
+}
+
+# assert_image_block: exit 0 iff the captured query prompt is an
+# AsyncIterable carrying an image block whose base64 == the uploaded PNG.
+assert_image_block() {
+  [[ -s "$CAPTURE" ]] || { echo "no capture file"; return 1; }
+  local kind cnt data
+  kind=$(jq -r '.kind' "$CAPTURE")
+  cnt=$(jq -r '.image_block_count // 0' "$CAPTURE")
+  [[ "$kind" == "async-iterable" ]] || { echo "kind=$kind (expected async-iterable)"; return 1; }
+  [[ "$cnt" -ge 1 ]] || { echo "image_block_count=$cnt"; return 1; }
+  data=$(jq -r '.blocks[] | select(.type=="image") | .data_b64' "$CAPTURE" | head -1)
+  [[ "$data" == "$EXPECTED_B64" ]] || { echo "image base64 mismatch"; return 1; }
+  return 0
+}
+
+# ── 4. GREEN: real path delivers an image block to query() ────────
+note "4. GREEN — image block reaches claude-agent-sdk query()"
+if start_node; then ok "node registered on hub"; else bad "node did not register"; tail -40 "$NODE_LOG"; exit 1; fi
+TID=$(send_task_with_image "describe the attached image [green $(date +%s%N)]")
+[[ -n "$TID" ]] && ok "task sent (id=$TID) with file_id attachment" || bad "task send failed"
+if wait_capture; then ok "query() was invoked (capture written)"; else bad "query() never captured"; tail -40 "$NODE_LOG"; fi
+if assert_image_block; then
+  MT=$(jq -r '.blocks[] | select(.type=="image") | .media_type' "$CAPTURE" | head -1)
+  ST=$(jq -r '.blocks[] | select(.type=="image") | .source_type' "$CAPTURE" | head -1)
+  HASTXT=$(jq -r '[.blocks[]? | select(.type=="text")] | length' "$CAPTURE")
+  ok "query prompt carries an image content block (source_type=$ST media_type=$MT) with the downloaded bytes"
+  [[ "$HASTXT" -ge 1 ]] && ok "prompt also carries the text block (multimodal turn, not image-only)" || bad "text block missing from multimodal prompt"
+else
+  bad "image block assertion failed: $(cat "$CAPTURE" 2>/dev/null)"
+fi
+stop_node; sleep 1
+
+# ── 5. GREEN: text-only remains the historical string prompt ─────
+note "5. GREEN — text-only task remains a string prompt"
+if start_node; then ok "text-only node registered"; else bad "text-only node did not register"; tail -40 "$NODE_LOG"; fi
+TEXT_MARKER="text-only-shape-$(date +%s%N)"
+TID_TEXT=$(send_text_task "$TEXT_MARKER")
+[[ -n "$TID_TEXT" ]] && ok "text-only task sent (id=$TID_TEXT)" || bad "text-only task send failed"
+if wait_capture; then ok "text-only query captured"; else bad "text-only query never captured"; tail -20 "$NODE_LOG"; fi
+TEXT_KIND=$(jq -r '.kind // "none"' "$CAPTURE" 2>/dev/null)
+TEXT_PREVIEW=$(jq -r '.textPreview // ""' "$CAPTURE" 2>/dev/null)
+[[ "$TEXT_KIND" == "string" ]] && ok "text-only query keeps string prompt shape" || bad "text-only prompt kind=$TEXT_KIND"
+[[ "$TEXT_PREVIEW" == *"$TEXT_MARKER"* ]] && ok "text-only prompt still contains the task bytes" || bad "text-only task marker missing"
+stop_node; sleep 1
+
+# ── 6. GREEN: unverified model must not receive image blocks ──────
+note "6. GREEN — modelImageCapable=false downgrades to text-only"
+write_config false
+if start_node; then ok "non-image-capable node registered"; else bad "non-image-capable node did not register"; tail -40 "$NODE_LOG"; fi
+TID_FALSE=$(send_task_with_image "do not attach image [capability-false $(date +%s%N)]")
+[[ -n "$TID_FALSE" ]] && ok "image task sent to non-image-capable profile (id=$TID_FALSE)" || bad "non-image-capable task send failed"
+if wait_capture; then ok "non-image-capable query captured"; else bad "non-image-capable query never captured"; tail -20 "$NODE_LOG"; fi
+FALSE_KIND=$(jq -r '.kind // "none"' "$CAPTURE" 2>/dev/null)
+FALSE_COUNT=$(jq -r '.image_block_count // 0' "$CAPTURE" 2>/dev/null)
+[[ "$FALSE_KIND" == "string" && "$FALSE_COUNT" == "0" ]] \
+  && ok "modelImageCapable=false structurally cannot send an image block" \
+  || bad "capability=false leaked image block (kind=$FALSE_KIND count=$FALSE_COUNT)"
+stop_node; sleep 1
+write_config true
+
+# ── 7. WITNESSED-RED mutation: drop images from the dispatch ──────
+note "7. RED mutation — dispatch drops images but preserves evidence"
+cp "$REPO/agent-node/src/cli.ts" "$WORK/cli.ts.orig"
+sed -i 's/return await processWithClaude(task, from, images, evidence);/return await processWithClaude(task, from, undefined, evidence);/' "$REPO/agent-node/src/cli.ts"
+if ! cmp -s "$WORK/cli.ts.orig" "$REPO/agent-node/src/cli.ts" \
+   && grep -q 'processWithClaude(task, from, undefined, evidence);' "$REPO/agent-node/src/cli.ts"; then
+  ok "mutation applied with byte change (images arg dropped, evidence preserved)"
+else
+  bad "mutation did not change the exact production dispatch anchor"
+fi
+if start_node; then ok "mutated node registered"; else bad "mutated node did not register"; tail -40 "$NODE_LOG"; fi
+sleep 1
+TID2=$(send_task_with_image "describe the attached image [mutation $(date +%s%N)]")
+[[ -n "$TID2" ]] && ok "task re-sent under mutation (id=$TID2)" || bad "task send failed under mutation"
+if wait_capture; then ok "mutated turn still ran (query captured)"; else bad "mutated query never captured"; tail -20 "$NODE_LOG"; fi
+if assert_image_block; then
+  bad "MUTATION STAYED GREEN — image block still present without the images arg (gate is vacuous)"
+else
+  KIND=$(jq -r '.kind // "none"' "$CAPTURE" 2>/dev/null)
+  CNT=$(jq -r '.image_block_count // 0' "$CAPTURE" 2>/dev/null)
+  # Clean red: the turn DID run but with a plain string prompt (no image
+  # block), proving the dropped `images` arg is what carries the image —
+  # not that the task merely failed to arrive.
+  if [[ "$KIND" == "string" ]]; then
+    ok "witnessed red — turn ran with a STRING prompt (kind=$KIND, image_block_count=$CNT); dropping the images arg removes the image block"
+  else
+    ok "witnessed red — no image block under mutation (capture kind=$KIND); dispatch threading is load-bearing"
+  fi
+fi
+stop_node
+cp "$WORK/cli.ts.orig" "$REPO/agent-node/src/cli.ts"; rm -f "$WORK/cli.ts.orig"
+ok "cli.ts restored"
+
+# ── 8. WITNESSED-RED mutation: bypass per-model capability gate ───
+note "8. RED mutation — bypass modelImageCapable gate"
+cp "$REPO/agent-node/src/cli.ts" "$WORK/cli.ts.orig"
+sed -i 's/if (hasImages && modelImageCapable) {/if (hasImages) {/' "$REPO/agent-node/src/cli.ts"
+if ! cmp -s "$WORK/cli.ts.orig" "$REPO/agent-node/src/cli.ts" \
+   && grep -q 'if (hasImages) {' "$REPO/agent-node/src/cli.ts"; then
+  ok "capability mutation applied with byte change"
+else
+  bad "capability mutation did not change the exact production gate"
+fi
+write_config false
+if start_node; then ok "capability-mutated node registered"; else bad "capability-mutated node did not register"; tail -40 "$NODE_LOG"; fi
+TID_CAP_MUT=$(send_task_with_image "capability mutation [$(date +%s%N)]")
+[[ -n "$TID_CAP_MUT" ]] && ok "task sent under capability mutation (id=$TID_CAP_MUT)" || bad "capability mutation task send failed"
+if wait_capture; then ok "capability-mutated query captured"; else bad "capability-mutated query never captured"; tail -20 "$NODE_LOG"; fi
+if assert_image_block; then
+  ok "witnessed red — removing modelImageCapable check leaks an image block to the unverified profile"
+else
+  bad "capability mutation stayed green; image block was still absent"
+fi
+stop_node
+cp "$WORK/cli.ts.orig" "$REPO/agent-node/src/cli.ts"; rm -f "$WORK/cli.ts.orig"
+write_config true
+ok "cli.ts and config restored after capability mutation"
+
+printf "\n────────────────────────────────────────────\n"
+printf "test673 claude image-attachment block — PASS=%d FAIL=%d\n" "$PASS" "$FAIL"
+printf "────────────────────────────────────────────\n"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test673-claude-image-attachment-block/sdk-stub-preload.ts
+++ b/tests/test673-claude-image-attachment-block/sdk-stub-preload.ts
@@ -1,0 +1,87 @@
+// test673 — SDK query stub (bun --preload) for the claude-agent-sdk
+// multimodal-wiring gate (#259 Y).
+//
+// The real cli.ts does `const { query } = await import("@anthropic-ai/
+// claude-agent-sdk")` inside processWithClaude, and commhub-mcp.ts does
+// `const { createSdkMcpServer, tool } = await import(... )`. We intercept
+// that module so:
+//   - `query({ prompt, options })` records the *actual* prompt cli.ts
+//     built (string vs AsyncIterable<SDKUserMessage>) and, for the
+//     iterable path, the resolved user-message content blocks — then
+//     yields a minimal success stream so cli's for-await loop completes.
+//   - createSdkMcpServer / tool return inert objects so the CommHub MCP
+//     wiring constructs without a real SDK or vendor call.
+//
+// This lets the test assert, against the REAL cli.ts inbound path
+// (SSE task → extractImagePaths download → processWithClaude), that an
+// image content block carrying the downloaded bytes reaches query().
+import { mock } from "bun:test";
+import * as fs from "fs";
+
+const CAPTURE = process.env.TEST673_CAPTURE_FILE || "/tmp/test673-capture.json";
+
+async function* fakeQuery(args: any) {
+  const prompt = args?.prompt;
+  let captured: any = { kind: "unknown", ts: Date.now() };
+  try {
+    if (typeof prompt === "string") {
+      captured = { kind: "string", ts: Date.now(), textPreview: prompt.slice(0, 160) };
+    } else if (prompt && typeof prompt[Symbol.asyncIterator] === "function") {
+      const messages: any[] = [];
+      for await (const m of prompt) messages.push(m);
+      const first: any = messages[0];
+      const content = first?.message?.content;
+      const blocks = Array.isArray(content)
+        ? content.map((b: any) =>
+            b?.type === "image"
+              ? {
+                  type: "image",
+                  source_type: b?.source?.type,
+                  media_type: b?.source?.media_type,
+                  data_len: typeof b?.source?.data === "string" ? b.source.data.length : null,
+                  data_b64: typeof b?.source?.data === "string" ? b.source.data : null,
+                }
+              : { type: b?.type, text_preview: typeof b?.text === "string" ? b.text.slice(0, 80) : undefined },
+          )
+        : content;
+      captured = {
+        kind: "async-iterable",
+        ts: Date.now(),
+        message_count: messages.length,
+        first_message_type: first?.type,
+        parent_tool_use_id: first?.parent_tool_use_id ?? null,
+        blocks,
+        image_block_count: Array.isArray(blocks) ? blocks.filter((b: any) => b?.type === "image").length : 0,
+      };
+    }
+  } catch (e: any) {
+    captured = { kind: "error", ts: Date.now(), error: String(e?.message || e) };
+  }
+  try {
+    fs.writeFileSync(CAPTURE, JSON.stringify(captured, null, 2));
+  } catch {}
+
+  // Minimal success stream so cli's loop sets a session and returns a result.
+  yield { type: "system", subtype: "init", session_id: "test673-stub-session" } as any;
+  yield {
+    type: "result",
+    subtype: "success",
+    result: "TEST673_STUB_OK",
+    usage: { input_tokens: 1, output_tokens: 1 },
+    total_cost_usd: 0.0001,
+    num_turns: 1,
+  } as any;
+}
+
+function fakeCreateSdkMcpServer(cfg: any) {
+  return { name: cfg?.name || "stub", version: cfg?.version || "0", instance: {}, tools: cfg?.tools || [] } as any;
+}
+function fakeTool(..._a: any[]) {
+  return {} as any;
+}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: fakeQuery,
+  createSdkMcpServer: fakeCreateSdkMcpServer,
+  tool: fakeTool,
+}));

--- a/tests/test673-claude-image-attachment-block/sdk-stub-preload.ts
+++ b/tests/test673-claude-image-attachment-block/sdk-stub-preload.ts
@@ -17,6 +17,9 @@
 // image content block carrying the downloaded bytes reaches query().
 import { mock } from "bun:test";
 import * as fs from "fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const CAPTURE = process.env.TEST673_CAPTURE_FILE || "/tmp/test673-capture.json";
 
@@ -80,8 +83,26 @@ function fakeTool(..._a: any[]) {
   return {} as any;
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+const sdkFactory = () => ({
   query: fakeQuery,
   createSdkMcpServer: fakeCreateSdkMcpServer,
   tool: fakeTool,
-}));
+});
+
+// Bun keys a module mock by the importer's resolved module identity. The
+// bare-name mock is enough in a source checkout whose package is hoisted, but
+// the Docker install resolves the CLI import to agent-node/node_modules/.../
+// sdk.mjs. Register both the public specifier and the package-root-resolved
+// entrypoint so the exact installed SDK cannot silently bypass the harness.
+// This is test-only; production module resolution is untouched.
+const repo = process.env.REPO || "/app";
+try {
+  const requireFromAgentNode = createRequire(join(repo, "agent-node", "package.json"));
+  const resolvedSdk = requireFromAgentNode.resolve("@anthropic-ai/claude-agent-sdk");
+  mock.module(resolvedSdk, sdkFactory);
+  mock.module(pathToFileURL(resolvedSdk).href, sdkFactory);
+} catch {
+  // The host debug path may use a hoisted dependency; the bare registration
+  // below remains authoritative there.
+}
+mock.module("@anthropic-ai/claude-agent-sdk", sdkFactory);


### PR DESCRIPTION
## What changed

- add a real Hub → SSE → attachment download → agent-node → claude-agent-sdk prompt harness for the already-shipped #259 multimodal path
- assert exact uploaded PNG bytes reach an SDK image content block alongside text
- pin the two narrow sides: text-only tasks retain a string prompt, and `modelImageCapable=false` cannot emit image blocks
- add two exact-anchor witnessed-red mutations for image argument threading and the per-model capability gate
- harden test process cleanup so Hub/node children cannot survive and contaminate later phases

## Why

The production implementation from `1eaaf622` is already on main, and its commit records real MiniMax-M3 visual calls, but the query-wiring half had no merged regression test. The earlier test673 work was never merged and only had host evidence. This PR adds exact-SHA Docker coverage without changing production source.

## Evidence

- source: `16e8df78643846f1c3399a6707feb436fa17e501`
- report-only head: `08fcb65a87476eda7a426cbd97164fe2894529ac`
- image: `sha256:c3e7b3a40c2f4978c6ee655bb72864cd7f3e66b33ed22ffa52ee7786db800044`
- embedded source SHA matches
- Docker: 32 PASS / 0 FAIL
- mutations: 2/2 witnessed red
- production source delta: zero

The report records two rejected harness false-greens found on the way: orphaned test processes and a host-only Bun mock resolution. Neither failed run is counted as evidence.

Closes #259 after independent review confirms the existing real-vendor record plus this regression gate.