### PR TITLE
fix(#466): make co-presence teardown identity-exclusive

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -32,6 +32,7 @@ import {
   reapMarkerGroups,
   prepareIdentityForStart,
   anchorsFromMarker,
+  markerFilePath as copresenceMarkerFilePath,
   type SessionInfo,
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
@@ -7333,6 +7334,8 @@ Stop a running agent node.
   }
 
   const displayName = nodeDisplayName(resolved.id, resolved.profile);
+  let allowLegacyTmuxNameSweep = true;
+  let identityTeardownKilled = false;
   // #122 — auto-tmux on start needs symmetric cleanup on stop. Kill the
   // tmux session first (idempotent — has-session check guards), then SIGTERM
   // the recorded PID and notify the hub. Order matters: killing tmux kills
@@ -7354,6 +7357,11 @@ Stop a running agent node.
   try {
     const markerResult = readCopresenceMarker(nodesDir(), resolved.id);
     if (markerResult.kind === "ok") {
+      // #466 — once a marker exists, identity owns teardown exclusively.
+      // Falling through to the legacy name sweep would let an unrelated
+      // process race in under the same tmux session name and be killed even
+      // though it does not carry this node's marker.
+      allowLegacyTmuxNameSweep = false;
       const uuid = markerResult.marker.marker;
       console.log(`[anet] copresence node — identity-gated teardown (uuid=${uuid.slice(0, 8)}…)`);
       const enumer = realEnumerator();
@@ -7379,6 +7387,7 @@ Stop a running agent node.
       });
       if (reapResult.kind === "success") {
         removeCopresenceMarker(nodesDir(), resolved.id);
+        identityTeardownKilled = reapResult.killedPgids.length > 0;
         console.log(`[anet] identity teardown OK (killed ${reapResult.killedPgids.length} pgroup(s))`);
       } else {
         console.error(`[anet] ⚠ identity teardown incomplete: ${reapResult.detail}`);
@@ -7388,31 +7397,45 @@ Stop a running agent node.
             console.error(`[anet]    SKIPPED pgid=${s.pgid} — ${s.reason}`);
           }
         }
+        // Fail closed. The marker remains the only trustworthy ownership
+        // handle; neither tmux names nor the pidfile may replace it after an
+        // incomplete identity proof.
+        process.exitCode = 1;
+        return;
       }
     } else if (markerResult.cause !== "MISSING") {
+      allowLegacyTmuxNameSweep = false;
       console.error(`[anet] ⚠ copresence marker present but refused (${markerResult.cause}): ${markerResult.detail}`);
-      console.error(`[anet]    Falling through to legacy tmux-name sweep. Investigate the marker file for corruption.`);
+      console.error(`[anet]    Refusing the legacy tmux-name sweep: identity could not be proven.`);
+      process.exitCode = 1;
+      return;
     }
     // markerResult.cause === "MISSING" is the ordinary-node path: silent
     // fall-through to legacy sweep (zero-diff for every runtime that never
     // ran --copresence).
   } catch (e: any) {
     console.error(`[anet] ⚠ identity gate check crashed: ${e?.message || e}`);
-    console.error(`[anet]    Falling through to legacy tmux-name sweep.`);
+    if (existsSync(copresenceMarkerFilePath(nodesDir(), resolved.id))) {
+      console.error(`[anet]    Marker still exists; refusing the legacy tmux-name sweep.`);
+      process.exitCode = 1;
+      return;
+    }
+    console.error(`[anet]    No marker exists; retaining the ordinary-node legacy stop path.`);
   }
 
-  // RFC-030 P2 — co-presence nodes own three tmux sessions
-  // (`<alias>`, `<alias>-appsrv`, `<alias>-桥`). Sweep all three
-  // unconditionally: has-session guards make the extra kills no-op for
-  // non-copresence nodes, so this stays safe for every runtime.
+  // RFC-030 P2 legacy path — nodes without an identity marker may own three
+  // tmux sessions (`<alias>`, `<alias>-appsrv`, `<alias>-桥`). Sweep those
+  // names only when marker absence proves this is the ordinary legacy path.
+  // A marker-bearing generation was already handled above by exact identity;
+  // name matching after that point would re-open #466's same-name kill race.
   const copresenceSessions = copresenceTmuxSessions(displayName);
-  const tmuxTuiKilled = tmuxSessionRunning(copresenceSessions.tui);
-  const tmuxAppsrvKilled = tmuxSessionRunning(copresenceSessions.appsrv);
-  const tmuxBridgeKilled = tmuxSessionRunning(copresenceSessions.bridge);
+  const tmuxTuiKilled = allowLegacyTmuxNameSweep && tmuxSessionRunning(copresenceSessions.tui);
+  const tmuxAppsrvKilled = allowLegacyTmuxNameSweep && tmuxSessionRunning(copresenceSessions.appsrv);
+  const tmuxBridgeKilled = allowLegacyTmuxNameSweep && tmuxSessionRunning(copresenceSessions.bridge);
   if (tmuxTuiKilled) killTmuxSession(copresenceSessions.tui);
   if (tmuxAppsrvKilled) killTmuxSession(copresenceSessions.appsrv);
   if (tmuxBridgeKilled) killTmuxSession(copresenceSessions.bridge);
-  const tmuxKilled = tmuxTuiKilled || tmuxAppsrvKilled || tmuxBridgeKilled;
+  const tmuxKilled = identityTeardownKilled || tmuxTuiKilled || tmuxAppsrvKilled || tmuxBridgeKilled;
   const stopResult = await stopNode(resolved.id);
   if (stopResult.status === "survived") {
     console.error(`[anet] could not confirm that "${displayName}" exited (pid ${stopResult.pid}); pidfile retained.`);
@@ -7424,6 +7447,7 @@ Stop a running agent node.
   await notifyServerOffline(resolved.profile, resolved.id);
   if (killed || tmuxKilled) {
     const tmuxLabels: string[] = [];
+    if (identityTeardownKilled) tmuxLabels.push("identity");
     if (tmuxTuiKilled) tmuxLabels.push("tui");
     if (tmuxAppsrvKilled) tmuxLabels.push("appsrv");
     if (tmuxBridgeKilled) tmuxLabels.push("bridge");

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -7315,6 +7315,26 @@ async function stopNode(nodeId: string): Promise<StopNodeResult> {
   return { status: "survived", pid };
 }
 
+// Marker-bearing co-presence generations are stopped exclusively by the
+// identity reaper.  After it succeeds, the pidfile is bookkeeping only: we
+// may remove a dead/stale entry, but must never signal an alive PID through
+// this second authority (it may already have been reused by an unrelated
+// process after the marker generation exited).
+function clearStoppedIdentityPidFile(nodeId: string): StopNodeResult {
+  const pidFile = join(nodesDir(), nodeId, ".pid");
+  if (!existsSync(pidFile)) return { status: "not-running" };
+  const pid = parseInt(readFileSync(pidFile, "utf-8").trim());
+  if (isNaN(pid)) {
+    rmSync(pidFile, { force: true });
+    return { status: "not-running" };
+  }
+  if (!pidAlive(pid)) {
+    rmSync(pidFile, { force: true });
+    return { status: "not-running", pid };
+  }
+  return { status: "survived", pid };
+}
+
 async function stopCommand() {
   const ref = args[1];
   if (!ref) {
@@ -7435,9 +7455,11 @@ Stop a running agent node.
   if (tmuxAppsrvKilled) killTmuxSession(copresenceSessions.appsrv);
   if (tmuxBridgeKilled) killTmuxSession(copresenceSessions.bridge);
   const tmuxKilled = identityTeardownKilled || tmuxTuiKilled || tmuxAppsrvKilled || tmuxBridgeKilled;
-  const stopResult = await stopNode(resolved.id);
+  const stopResult = allowLegacyTmuxNameSweep
+    ? await stopNode(resolved.id)
+    : clearStoppedIdentityPidFile(resolved.id);
   if (stopResult.status === "survived") {
-    console.error(`[anet] could not confirm that "${displayName}" exited (pid ${stopResult.pid}); pidfile retained.`);
+    console.error(`[anet] could not confirm that "${displayName}" exited (pid ${stopResult.pid}); pidfile retained and PID was not signalled.`);
     process.exitCode = 1;
     return;
   }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -32,7 +32,6 @@ import {
   reapMarkerGroups,
   prepareIdentityForStart,
   anchorsFromMarker,
-  markerFilePath as copresenceMarkerFilePath,
   type SessionInfo,
 } from "../src/copresence-identity";
 import { assertTmuxSupportsSessionEnv } from "../src/tmux-capability";
@@ -7415,12 +7414,12 @@ Stop a running agent node.
     // ran --copresence).
   } catch (e: any) {
     console.error(`[anet] ⚠ identity gate check crashed: ${e?.message || e}`);
-    if (existsSync(copresenceMarkerFilePath(nodesDir(), resolved.id))) {
-      console.error(`[anet]    Marker still exists; refusing the legacy tmux-name sweep.`);
-      process.exitCode = 1;
-      return;
-    }
-    console.error(`[anet]    No marker exists; retaining the ordinary-node legacy stop path.`);
+    // readMarker represents a normal missing marker as {cause:"MISSING"};
+    // reaching this catch means the ownership check itself failed.  Never
+    // reinterpret that failure as permission to kill by name.
+    console.error(`[anet]    Refusing the legacy tmux-name sweep: identity check did not complete.`);
+    process.exitCode = 1;
+    return;
   }
 
   // RFC-030 P2 legacy path — nodes without an identity marker may own three

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -7419,15 +7419,13 @@ Stop a running agent node.
         // Fail closed. The marker remains the only trustworthy ownership
         // handle; neither tmux names nor the pidfile may replace it after an
         // incomplete identity proof.
-        process.exitCode = 1;
-        return;
+        process.exit(1);
       }
     } else if (markerResult.cause !== "MISSING") {
       allowLegacyTmuxNameSweep = false;
       console.error(`[anet] ⚠ copresence marker present but refused (${markerResult.cause}): ${markerResult.detail}`);
       console.error(`[anet]    Refusing the legacy tmux-name sweep: identity could not be proven.`);
-      process.exitCode = 1;
-      return;
+      process.exit(1);
     }
     // markerResult.cause === "MISSING" is the ordinary-node path: silent
     // fall-through to legacy sweep (zero-diff for every runtime that never
@@ -7438,8 +7436,7 @@ Stop a running agent node.
     // reaching this catch means the ownership check itself failed.  Never
     // reinterpret that failure as permission to kill by name.
     console.error(`[anet]    Refusing the legacy tmux-name sweep: identity check did not complete.`);
-    process.exitCode = 1;
-    return;
+    process.exit(1);
   }
 
   // RFC-030 P2 legacy path — nodes without an identity marker may own three
@@ -7460,8 +7457,7 @@ Stop a running agent node.
     : clearStoppedIdentityPidFile(resolved.id);
   if (stopResult.status === "survived") {
     console.error(`[anet] could not confirm that "${displayName}" exited (pid ${stopResult.pid}); pidfile retained and PID was not signalled.`);
-    process.exitCode = 1;
-    return;
+    process.exit(1);
   }
   const killed = stopResult.status === "stopped";
   // Always notify server — even if PID file missing, server may have stale session

--- a/docs/tests/report-test466-codex-copresence-p3.txt
+++ b/docs/tests/report-test466-codex-copresence-p3.txt
@@ -1,0 +1,87 @@
+# test466 — Codex co-presence identity-exclusive teardown
+
+Date: 2026-08-10
+Issue: #466
+Base commit: 8be1c9748bd6d627265fc0729937daf5bbe230db
+Tested source commit: 2def43ef3303dd192754d275d3d77f3fc4e66823
+Docker tag: anet-test466:dev
+Docker image ID: sha256:ae1351f0aab675cec40178c4aca880bd1892f41ea86902218b7b63cc76d97d3d
+Embedded TEST466_SOURCE_COMMIT: 2def43ef3303dd192754d275d3d77f3fc4e66823
+
+## Scope
+
+This test closes the issue #466 P3 teardown race without changing the
+co-presence startup contract.  When an identity marker exists, teardown is
+identity-exclusive: it reaps only processes proven to carry that marker and
+never falls through to a tmux-name sweep.  A missing marker retains the legacy
+ordinary-node cleanup path.  An unreadable, corrupt, incomplete, or
+self-referential identity proof fails closed.
+
+The test runs an isolated real Hub, real agent-node bridge, installed Codex
+0.147.0 app-server, and installed Codex remote TUI.  It mounts no production
+config, token, database, port, session, or process.
+
+## Commands
+
+```sh
+sg docker -c 'docker build \
+  --build-arg TEST466_SOURCE_COMMIT=2def43ef3303dd192754d275d3d77f3fc4e66823 \
+  -t anet-test466:dev \
+  -f tests/test466-codex-copresence-p3/Dockerfile .'
+
+sg docker -c 'docker run --rm anet-test466:dev'
+```
+
+Runtime inventory from the exact image:
+
+```text
+codex-cli 0.147.0
+bun 1.3.14
+node v22.23.2
+```
+
+## Result
+
+```text
+RESULT: PASS=43 FAIL=0
+MUTATION RESULT: PASS=4 FAIL=0
+```
+
+Verified behavior:
+
+- the real isolated Hub minted a network-scoped node token;
+- normal three-piece co-presence stop reaped the complete marker generation,
+  including a detached marker-bearing descendant;
+- after the real app-server session disappeared, a hostile different-marker
+  process using the same tmux name remained alive while the real generation
+  was reaped;
+- after an exact marker-validated bridge PID received SIGKILL, external stop
+  still completed and removed all identity-owned state;
+- a stop invoked from marker-bearing TUI ancestry returned rc=2 and preserved
+  the running generation;
+- corrupt and incomplete marker proofs returned non-zero, preserved their
+  marker, and did not authorize a same-name kill;
+- marker-missing ordinary nodes retained legacy tmux cleanup.
+
+## Witnessed-red mutations
+
+All mutations changed source bytes and turned a previously green invariant
+red while the test code remained unchanged:
+
+1. delete the identity/name ownership gate;
+2. delete the real `/proc` marker scan;
+3. delete the post-rescan unreadable-process gate;
+4. delete the corrupt-marker fail-closed return.
+
+The first mutation proves the security-bearing TOCTOU case: if teardown falls
+through to name ownership after seeing a real marker, it kills the hostile
+same-name process and the suite fails.  The fourth proves that corrupt marker
+state cannot silently regain the legacy name sweep.
+
+## Provenance
+
+The build argument is declared after dependency installation, so changing the
+tested source commit does not invalidate dependency layers.  The final image
+configuration contains the exact tested source commit shown above.  This
+report is an add-only evidence commit after that source; it does not alter the
+tested production or test implementation.

--- a/tests/test466-codex-copresence-p3/Dockerfile
+++ b/tests/test466-codex-copresence-p3/Dockerfile
@@ -14,8 +14,6 @@ ENV PATH="/root/.bun/bin:${PATH}"
 RUN npm install -g --no-audit --no-fund @openai/codex@0.147.0
 
 WORKDIR /app
-ARG TEST466_SOURCE_COMMIT=unknown
-ENV TEST466_SOURCE_COMMIT=${TEST466_SOURCE_COMMIT}
 
 COPY server /app/server
 COPY agent-network /app/agent-network
@@ -27,6 +25,8 @@ RUN cd /app/server && bun install --silent
 # Keep its native postinstall out of this image, as the other CLI E2E suites do.
 RUN cd /app/agent-network && bun install --silent --ignore-scripts
 RUN cd /app/agent-node && bun install --silent --ignore-scripts
+ARG TEST466_SOURCE_COMMIT=unknown
+ENV TEST466_SOURCE_COMMIT=${TEST466_SOURCE_COMMIT}
 COPY tests/test466-codex-copresence-p3 /app/tests/test466-codex-copresence-p3
 RUN install -m 0755 /app/tests/test466-codex-copresence-p3/anet-local /usr/local/bin/anet \
     && install -m 0755 /app/tests/test466-codex-copresence-p3/agent-node-local /usr/local/bin/agent-node \

--- a/tests/test466-codex-copresence-p3/Dockerfile
+++ b/tests/test466-codex-copresence-p3/Dockerfile
@@ -15,16 +15,19 @@ RUN npm install -g --no-audit --no-fund @openai/codex@0.147.0
 
 WORKDIR /app
 
-COPY server /app/server
-COPY agent-network /app/agent-network
-COPY agent-node /app/agent-node
-COPY tests/lib /app/tests/lib
-
+COPY server/package.json /app/server/package.json
+COPY agent-network/package.json agent-network/package-lock.json /app/agent-network/
+COPY agent-node/package.json /app/agent-node/package.json
 RUN cd /app/server && bun install --silent
 # node-pty is unrelated to the tmux-managed co-presence path under test.
 # Keep its native postinstall out of this image, as the other CLI E2E suites do.
 RUN cd /app/agent-network && bun install --silent --ignore-scripts
 RUN cd /app/agent-node && bun install --silent --ignore-scripts
+
+COPY server /app/server
+COPY agent-network /app/agent-network
+COPY agent-node /app/agent-node
+COPY tests/lib /app/tests/lib
 ARG TEST466_SOURCE_COMMIT=unknown
 ENV TEST466_SOURCE_COMMIT=${TEST466_SOURCE_COMMIT}
 COPY tests/test466-codex-copresence-p3 /app/tests/test466-codex-copresence-p3

--- a/tests/test466-codex-copresence-p3/Dockerfile
+++ b/tests/test466-codex-copresence-p3/Dockerfile
@@ -24,8 +24,10 @@ COPY tests/lib /app/tests/lib
 COPY tests/test466-codex-copresence-p3 /app/tests/test466-codex-copresence-p3
 
 RUN cd /app/server && bun install --silent
-RUN cd /app/agent-network && bun install --silent
-RUN cd /app/agent-node && bun install --silent
+# node-pty is unrelated to the tmux-managed co-presence path under test.
+# Keep its native postinstall out of this image, as the other CLI E2E suites do.
+RUN cd /app/agent-network && bun install --silent --ignore-scripts
+RUN cd /app/agent-node && bun install --silent --ignore-scripts
 RUN install -m 0755 /app/tests/test466-codex-copresence-p3/anet-local /usr/local/bin/anet \
     && install -m 0755 /app/tests/test466-codex-copresence-p3/agent-node-local /usr/local/bin/agent-node \
     && chmod +x /app/tests/test466-codex-copresence-p3/run.sh \

--- a/tests/test466-codex-copresence-p3/Dockerfile
+++ b/tests/test466-codex-copresence-p3/Dockerfile
@@ -21,13 +21,13 @@ COPY server /app/server
 COPY agent-network /app/agent-network
 COPY agent-node /app/agent-node
 COPY tests/lib /app/tests/lib
-COPY tests/test466-codex-copresence-p3 /app/tests/test466-codex-copresence-p3
 
 RUN cd /app/server && bun install --silent
 # node-pty is unrelated to the tmux-managed co-presence path under test.
 # Keep its native postinstall out of this image, as the other CLI E2E suites do.
 RUN cd /app/agent-network && bun install --silent --ignore-scripts
 RUN cd /app/agent-node && bun install --silent --ignore-scripts
+COPY tests/test466-codex-copresence-p3 /app/tests/test466-codex-copresence-p3
 RUN install -m 0755 /app/tests/test466-codex-copresence-p3/anet-local /usr/local/bin/anet \
     && install -m 0755 /app/tests/test466-codex-copresence-p3/agent-node-local /usr/local/bin/agent-node \
     && chmod +x /app/tests/test466-codex-copresence-p3/run.sh \

--- a/tests/test466-codex-copresence-p3/Dockerfile
+++ b/tests/test466-codex-copresence-p3/Dockerfile
@@ -1,0 +1,36 @@
+# test466 — real Codex co-presence identity teardown E2E.
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash ca-certificates curl jq procps tmux util-linux unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+# Pin the real vendor binary.  The test wrapper below only adds a detached
+# marker-bearing child; every app-server/TUI protocol operation is performed
+# by this installed Codex binary.
+RUN npm install -g --no-audit --no-fund @openai/codex@0.147.0
+
+WORKDIR /app
+ARG TEST466_SOURCE_COMMIT=unknown
+ENV TEST466_SOURCE_COMMIT=${TEST466_SOURCE_COMMIT}
+
+COPY server /app/server
+COPY agent-network /app/agent-network
+COPY agent-node /app/agent-node
+COPY tests/lib /app/tests/lib
+COPY tests/test466-codex-copresence-p3 /app/tests/test466-codex-copresence-p3
+
+RUN cd /app/server && bun install --silent
+RUN cd /app/agent-network && bun install --silent
+RUN cd /app/agent-node && bun install --silent
+RUN install -m 0755 /app/tests/test466-codex-copresence-p3/anet-local /usr/local/bin/anet \
+    && install -m 0755 /app/tests/test466-codex-copresence-p3/agent-node-local /usr/local/bin/agent-node \
+    && chmod +x /app/tests/test466-codex-copresence-p3/run.sh \
+               /app/tests/test466-codex-copresence-p3/mutations.sh \
+               /app/tests/test466-codex-copresence-p3/codex-marker-wrapper
+
+ENV REPO=/app
+CMD ["/app/tests/test466-codex-copresence-p3/run.sh"]

--- a/tests/test466-codex-copresence-p3/README.md
+++ b/tests/test466-codex-copresence-p3/README.md
@@ -1,0 +1,12 @@
+# test466 — real Codex co-presence identity teardown
+
+This suite closes the evidence gap recorded by issue #466 and PR #477.  It
+starts the installed Codex `app-server`, the real agent-node bridge, and the
+installed Codex remote TUI inside isolated Docker/tmux sessions.
+
+The security-bearing case replaces a lost real app-server tmux session with
+an unrelated session of the same name but a different marker.  `anet node
+stop` must reap the real marker generation and leave the impostor alive.  A
+name-based fallback therefore turns the case red.
+
+No host config, token, session, port, or production process is mounted.

--- a/tests/test466-codex-copresence-p3/agent-node-local
+++ b/tests/test466-codex-copresence-p3/agent-node-local
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec bun /app/agent-node/src/cli.ts "$@"

--- a/tests/test466-codex-copresence-p3/agent-node-local
+++ b/tests/test466-codex-copresence-p3/agent-node-local
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-exec bun /app/agent-node/src/cli.ts "$@"
+exec /root/.bun/bin/bun /app/agent-node/src/cli.ts "$@"

--- a/tests/test466-codex-copresence-p3/anet-local
+++ b/tests/test466-codex-copresence-p3/anet-local
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec bun /app/agent-network/bin/cli.ts "$@"

--- a/tests/test466-codex-copresence-p3/anet-local
+++ b/tests/test466-codex-copresence-p3/anet-local
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 if [[ "${1:-}" == "node" && "${2:-}" == "start" && "$*" != *"--copresence"* && -n "${TEST466_BRIDGE_LOG:-}" ]]; then
-  exec bun /app/agent-network/bin/cli.ts "$@" >>"$TEST466_BRIDGE_LOG" 2>&1
+  exec /root/.bun/bin/bun /app/agent-network/bin/cli.ts "$@" >>"$TEST466_BRIDGE_LOG" 2>&1
 fi
-exec bun /app/agent-network/bin/cli.ts "$@"
+exec /root/.bun/bin/bun /app/agent-network/bin/cli.ts "$@"

--- a/tests/test466-codex-copresence-p3/anet-local
+++ b/tests/test466-codex-copresence-p3/anet-local
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
+if [[ "${1:-}" == "node" && "${2:-}" == "start" && "$*" != *"--copresence"* && -n "${TEST466_BRIDGE_LOG:-}" ]]; then
+  exec bun /app/agent-network/bin/cli.ts "$@" >>"$TEST466_BRIDGE_LOG" 2>&1
+fi
 exec bun /app/agent-network/bin/cli.ts "$@"

--- a/tests/test466-codex-copresence-p3/codex-marker-wrapper
+++ b/tests/test466-codex-copresence-p3/codex-marker-wrapper
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Preserve the real Codex process and protocol.  For the app-server only,
+# add one marker-bearing setsid descendant that survives loss of the tmux
+# pane.  That makes orphan reclamation observable instead of self-green.
+if [[ "${1:-}" == "app-server" && "${TEST466_SPAWN_DETACHED:-0}" == "1" ]]; then
+  : "${ANET_NODE_MARKER:?missing marker on real app-server launch}"
+  : "${TEST466_ORPHAN_PID_FILE:?missing orphan pid file}"
+  setsid env ANET_NODE_MARKER="$ANET_NODE_MARKER" \
+    bash -c 'echo $$ > "$TEST466_ORPHAN_PID_FILE"; trap "exit 0" TERM INT HUP; exec sleep 600' &
+fi
+
+exec codex "$@"

--- a/tests/test466-codex-copresence-p3/mutations.sh
+++ b/tests/test466-codex-copresence-p3/mutations.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="${REPO:-/app}"
+CLI="$REPO/agent-network/bin/cli.ts"
+IDENT="$REPO/agent-network/src/copresence-identity.ts"
+WORK="${WORK:-/tmp/test466}/mutations"
+mkdir -p "$WORK"
+cp "$CLI" "$WORK/cli.orig"
+cp "$IDENT" "$WORK/identity.orig"
+
+restore() { cp "$WORK/cli.orig" "$CLI"; cp "$WORK/identity.orig" "$IDENT"; }
+trap restore EXIT
+
+PASS=0; FAIL=0
+ok() { echo "  WITNESSED-RED $*"; PASS=$((PASS+1)); }
+bad() { echo "  MUTATION-FAIL $*"; FAIL=$((FAIL+1)); }
+
+# M1 — delete the structural ownership gate.  A marker-bearing stop with an
+# unrelated same-name tmux must then kill the impostor and expose the old bug.
+COUNT=$(grep -Fc 'allowLegacyTmuxNameSweep && tmuxSessionRunning' "$CLI")
+[[ "$COUNT" == "3" ]] || { echo "M1 anchor count=$COUNT"; exit 1; }
+sed -i 's/allowLegacyTmuxNameSweep && tmuxSessionRunning/tmuxSessionRunning/g' "$CLI"
+cmp -s "$CLI" "$WORK/cli.orig" && { echo "M1 no-op"; exit 1; }
+ALIAS=mut466
+NODE_DIR="${HOME}/project/.anet/nodes/$ALIAS"
+mkdir -p "$NODE_DIR"
+cat >"$NODE_DIR/config.json" <<'JSON'
+{"node_name":"mut466","runtime":"claude-code-cli","hub":"http://127.0.0.1:1","token":"ntok_mutation_fixture"}
+JSON
+BOOT=$(cat /proc/sys/kernel/random/boot_id)
+cat >"$NODE_DIR/copresence-identity.json" <<JSON
+{"marker":"real-generation-with-no-live-pids","boot_id":"$BOOT","started_at_epoch_ms":1,"owner_uid":$(id -u),"sessions":{}}
+JSON
+chmod 600 "$NODE_DIR/copresence-identity.json"
+tmux new-session -d -s "$ALIAS-appsrv" -e ANET_NODE_MARKER=foreign-generation bash -c 'exec sleep 600'
+(cd "${HOME}/project" && anet node stop "$ALIAS" >"$WORK/m1.log" 2>&1) || true
+if tmux has-session -t "=$ALIAS-appsrv" 2>/dev/null; then
+  bad "M1 deleting name gate did not expose a same-name kill"
+  tmux kill-session -t "=$ALIAS-appsrv" 2>/dev/null || true
+else
+  ok "M1 delete identity/name ownership gate"
+fi
+restore
+
+# M2 — make the real environ scanner ignore every marker.  The real /proc
+# integration tests must fail; a mock-only suite would stay green.
+COUNT=$(grep -Fc 'if (parts.indexOf(needle) >= 0) hits.push(pid);' "$IDENT")
+[[ "$COUNT" == "1" ]] || { echo "M2 anchor count=$COUNT"; exit 1; }
+sed -i 's/if (parts.indexOf(needle) >= 0) hits.push(pid);/if (false) hits.push(pid);/' "$IDENT"
+cmp -s "$IDENT" "$WORK/identity.orig" && { echo "M2 no-op"; exit 1; }
+(cd "$REPO/agent-network" && bun test src/copresence-identity.real.test.ts >"$WORK/m2.log" 2>&1)
+RC=$?
+[[ "$RC" -ne 0 ]] && ok "M2 delete real marker scan" || bad "M2 real scanner mutation stayed green"
+restore
+
+# M3 — drop the post-KILL unreadable half of the fail-closed rescan.  The
+# dedicated Blocker-7 regression must turn red.
+COUNT=$(grep -Fc 'if (residual.length > 0 || rescan.unreadableOwnUid.length > 0)' "$IDENT")
+[[ "$COUNT" == "1" ]] || { echo "M3 anchor count=$COUNT"; exit 1; }
+sed -i 's/if (residual.length > 0 || rescan.unreadableOwnUid.length > 0)/if (residual.length > 0)/' "$IDENT"
+cmp -s "$IDENT" "$WORK/identity.orig" && { echo "M3 no-op"; exit 1; }
+(cd "$REPO/agent-network" && bun test src/copresence-identity.test.ts >"$WORK/m3.log" 2>&1)
+RC=$?
+[[ "$RC" -ne 0 ]] && ok "M3 delete post-rescan unreadable gate" || bad "M3 post-rescan mutation stayed green"
+restore
+
+echo "MUTATION RESULT: PASS=$PASS FAIL=$FAIL"
+[[ "$PASS" -eq 3 && "$FAIL" -eq 0 ]]

--- a/tests/test466-codex-copresence-p3/mutations.sh
+++ b/tests/test466-codex-copresence-p3/mutations.sh
@@ -65,5 +65,33 @@ RC=$?
 [[ "$RC" -ne 0 ]] && ok "M3 delete post-rescan unreadable gate" || bad "M3 post-rescan mutation stayed green"
 restore
 
+# M4 — delete the corrupt-marker fail-closed branch.  The old behavior then
+# falls through and kills an unrelated same-name session.
+COUNT=$(grep -Fc 'Refusing the legacy tmux-name sweep: identity could not be proven.' "$CLI")
+[[ "$COUNT" == "1" ]] || { echo "M4 anchor count=$COUNT"; exit 1; }
+sed -i '/} else if (markerResult.cause !== "MISSING") {/,/^    }/ { \
+  /allowLegacyTmuxNameSweep = false;/d; \
+  /process.exitCode = 1;/d; \
+  /^      return;$/d; \
+}' "$CLI"
+cmp -s "$CLI" "$WORK/cli.orig" && { echo "M4 no-op"; exit 1; }
+ALIAS=mut466corrupt
+NODE_DIR="${HOME}/project/.anet/nodes/$ALIAS"
+mkdir -p "$NODE_DIR"
+cat >"$NODE_DIR/config.json" <<'JSON'
+{"node_name":"mut466corrupt","runtime":"claude-code-cli","hub":"http://127.0.0.1:1","token":"ntok_mutation_fixture"}
+JSON
+printf '{not-json\n' >"$NODE_DIR/copresence-identity.json"
+chmod 600 "$NODE_DIR/copresence-identity.json"
+tmux new-session -d -s "$ALIAS-appsrv" -e ANET_NODE_MARKER=foreign-generation bash -c 'exec sleep 600'
+(cd "${HOME}/project" && anet node stop "$ALIAS" >"$WORK/m4.log" 2>&1) || true
+if tmux has-session -t "=$ALIAS-appsrv" 2>/dev/null; then
+  bad "M4 deleting corrupt-marker refusal did not expose a name kill"
+  tmux kill-session -t "=$ALIAS-appsrv" 2>/dev/null || true
+else
+  ok "M4 delete corrupt-marker fail-closed return"
+fi
+restore
+
 echo "MUTATION RESULT: PASS=$PASS FAIL=$FAIL"
-[[ "$PASS" -eq 3 && "$FAIL" -eq 0 ]]
+[[ "$PASS" -eq 4 && "$FAIL" -eq 0 ]]

--- a/tests/test466-codex-copresence-p3/mutations.sh
+++ b/tests/test466-codex-copresence-p3/mutations.sh
@@ -69,11 +69,7 @@ restore
 # falls through and kills an unrelated same-name session.
 COUNT=$(grep -Fc 'Refusing the legacy tmux-name sweep: identity could not be proven.' "$CLI")
 [[ "$COUNT" == "1" ]] || { echo "M4 anchor count=$COUNT"; exit 1; }
-sed -i '/} else if (markerResult.cause !== "MISSING") {/,/^    }/ { \
-  /allowLegacyTmuxNameSweep = false;/d; \
-  /process.exitCode = 1;/d; \
-  /^      return;$/d; \
-}' "$CLI"
+sed -i 's/} else if (markerResult.cause !== "MISSING") {/} else if (false \&\& markerResult.cause !== "MISSING") {/' "$CLI"
 cmp -s "$CLI" "$WORK/cli.orig" && { echo "M4 no-op"; exit 1; }
 ALIAS=mut466corrupt
 NODE_DIR="${HOME}/project/.anet/nodes/$ALIAS"

--- a/tests/test466-codex-copresence-p3/run.sh
+++ b/tests/test466-codex-copresence-p3/run.sh
@@ -155,7 +155,43 @@ session_alive "$ALIAS-appsrv" && ok "self-kill refusal leaves real app-server al
 stop_external || bad "external cleanup after self-stop failed"
 assert_real_generation_gone "$UUID" "post self-refusal external stop"
 
-section "5. ordinary marker-missing node retains legacy stop"
+section "5. corrupt marker fails closed without a name kill"
+printf '{not-json\n' >"$MARKER"
+chmod 600 "$MARKER"
+tmux new-session -d -s "$ALIAS-appsrv" -e ANET_NODE_MARKER=foreign-corrupt-case bash -c 'exec sleep 600'
+(cd "$WORK/project" && anet node stop "$ALIAS" >"$WORK/corrupt.log" 2>&1)
+RC=$?
+[[ "$RC" -ne 0 ]] && ok "corrupt marker returns non-zero" || bad "corrupt marker returned success"
+[[ -e "$MARKER" ]] && ok "corrupt marker is preserved" || bad "corrupt marker was removed"
+session_alive "$ALIAS-appsrv" && ok "corrupt marker did not authorize same-name kill" || bad "corrupt marker fell through to name kill"
+tmux kill-session -t "=$ALIAS-appsrv" 2>/dev/null || true
+rm -f "$MARKER"
+
+section "6. incomplete identity proof fails closed without a name kill"
+INCOMPLETE_PID_FILE="$WORK/incomplete.pid"
+setsid env ANET_NODE_MARKER=incomplete-real \
+  bash -c 'echo $$ > "$1"; env -u ANET_NODE_MARKER sleep 600 & wait' _ "$INCOMPLETE_PID_FILE" &
+INCOMPLETE_LAUNCH=$!
+for _ in $(seq 1 30); do [[ -s "$INCOMPLETE_PID_FILE" ]] && break; sleep 0.1; done
+INCOMPLETE_PID=$(cat "$INCOMPLETE_PID_FILE")
+BOOT=$(cat /proc/sys/kernel/random/boot_id)
+cat >"$MARKER" <<JSON
+{"marker":"incomplete-real","boot_id":"$BOOT","started_at_epoch_ms":$(date +%s000),"owner_uid":$(id -u),"sessions":{}}
+JSON
+chmod 600 "$MARKER"
+tmux new-session -d -s "$ALIAS-appsrv" -e ANET_NODE_MARKER=foreign-incomplete-case bash -c 'exec sleep 600'
+(cd "$WORK/project" && anet node stop "$ALIAS" >"$WORK/incomplete.log" 2>&1)
+RC=$?
+[[ "$RC" -ne 0 ]] && ok "incomplete identity proof returns non-zero" || bad "incomplete identity proof returned success"
+[[ -e "$MARKER" ]] && ok "incomplete identity marker is preserved" || bad "incomplete marker was removed"
+kill -0 "$INCOMPLETE_PID" 2>/dev/null && ok "mixed marker pgroup was not partially killed" || bad "incomplete identity killed its mixed group"
+session_alive "$ALIAS-appsrv" && ok "incomplete identity did not authorize same-name kill" || bad "incomplete identity fell through to name kill"
+tmux kill-session -t "=$ALIAS-appsrv" 2>/dev/null || true
+kill -TERM -- "-$INCOMPLETE_PID" 2>/dev/null || true
+wait "$INCOMPLETE_LAUNCH" 2>/dev/null || true
+rm -f "$MARKER"
+
+section "7. ordinary marker-missing node retains legacy stop"
 ORD="test466-ordinary"
 mkdir -p "$WORK/project/.anet/nodes/$ORD"
 cat >"$WORK/project/.anet/nodes/$ORD/config.json" <<JSON
@@ -165,9 +201,9 @@ tmux new-session -d -s "$ORD" bash -c 'exec sleep 600'
 if (cd "$WORK/project" && anet node stop "$ORD" >>"$LOG" 2>&1); then ok "ordinary legacy stop returned success"; else bad "ordinary legacy stop failed"; fi
 session_alive "$ORD" && bad "ordinary marker-missing tmux survived" || ok "ordinary marker-missing tmux still uses legacy cleanup"
 
-section "6. non-vacuous identity mutations"
+section "8. non-vacuous identity mutations"
 if "$TEST_DIR/mutations.sh"; then
-  ok "three identity/name/rescan mutations turn red"
+  ok "four identity/name/rescan/fail-closed mutations turn red"
 else
   bad "one or more identity mutations failed to turn red"
 fi

--- a/tests/test466-codex-copresence-p3/run.sh
+++ b/tests/test466-codex-copresence-p3/run.sh
@@ -143,8 +143,14 @@ tmux kill-session -t "=$ALIAS-appsrv" 2>/dev/null || true
 section "3. bridge SIGKILL then exact identity stop"
 start_triplet || { bad "bridge-kill setup failed"; exit 1; }
 UUID=$(jq -r '.marker' "$MARKER")
-BRIDGE_PANE=$(tmux display-message -p -t "=$ALIAS-桥" '#{pane_pid}')
-kill -KILL "$BRIDGE_PANE"
+BRIDGE_PANE=$(tmux list-panes -a -F '#{session_name}|#{pane_pid}' \
+  | awk -F'|' -v expected="$ALIAS-桥" '$1 == expected { print $2 }')
+if [[ "$BRIDGE_PANE" =~ ^[0-9]+$ ]]; then
+  kill -KILL "$BRIDGE_PANE"
+else
+  bad "could not resolve exact bridge pane pid"
+  [[ -s "$TEST466_BRIDGE_LOG" ]] && tail -120 "$TEST466_BRIDGE_LOG"
+fi
 for _ in $(seq 1 30); do ! session_alive "$ALIAS-桥" && break; sleep 0.1; done
 if stop_external; then ok "stop succeeds after bridge SIGKILL"; else bad "stop failed after bridge SIGKILL"; fi
 assert_real_generation_gone "$UUID" "bridge SIGKILL"

--- a/tests/test466-codex-copresence-p3/run.sh
+++ b/tests/test466-codex-copresence-p3/run.sh
@@ -80,9 +80,16 @@ start_triplet() {
     >"$LOG" 2>&1)
   local rc=$?
   [[ "$rc" -eq 0 ]] || { echo "start rc=$rc"; tail -80 "$LOG"; return 1; }
-  for s in "$ALIAS" "$ALIAS-appsrv" "$ALIAS-桥"; do session_alive "$s" || return 1; done
-  [[ -s "$MARKER" ]] || return 1
-  [[ -s "$TEST466_ORPHAN_PID_FILE" ]] || return 1
+  for s in "$ALIAS" "$ALIAS-appsrv" "$ALIAS-桥"; do
+    if ! session_alive "$s"; then
+      echo "missing tmux session: $s"
+      tmux list-panes -a -F '#{session_name}|#{pane_dead}|#{pane_current_command}|#{pane_pid}' 2>/dev/null || true
+      tail -80 "$LOG"
+      return 1
+    fi
+  done
+  [[ -s "$MARKER" ]] || { echo "missing identity marker: $MARKER"; return 1; }
+  [[ -s "$TEST466_ORPHAN_PID_FILE" ]] || { echo "missing detached marker descendant fixture"; return 1; }
 }
 
 stop_external() {

--- a/tests/test466-codex-copresence-p3/run.sh
+++ b/tests/test466-codex-copresence-p3/run.sh
@@ -17,6 +17,7 @@ NODE_DIR="$WORK/project/.anet/nodes/$ALIAS"
 MARKER="$NODE_DIR/copresence-identity.json"
 CODEX_WRAPPER="$TEST_DIR/codex-marker-wrapper"
 LOG="$WORK/run.log"
+export TEST466_BRIDGE_LOG="$WORK/bridge.log"
 HUB_LOG="$WORK/hub.log"
 
 PASS=0; FAIL=0; HUB_PID=""
@@ -84,6 +85,7 @@ start_triplet() {
     if ! session_alive "$s"; then
       echo "missing tmux session: $s"
       tmux list-panes -a -F '#{session_name}|#{pane_dead}|#{pane_current_command}|#{pane_pid}' 2>/dev/null || true
+      [[ -s "$TEST466_BRIDGE_LOG" ]] && { echo "--- bridge log ---"; tail -120 "$TEST466_BRIDGE_LOG"; }
       tail -80 "$LOG"
       return 1
     fi

--- a/tests/test466-codex-copresence-p3/run.sh
+++ b/tests/test466-codex-copresence-p3/run.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="${REPO:-/app}"
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$REPO/tests/lib/safe-rm.sh"
+
+WORK="${WORK:-/tmp/test466}"
+export HOME="$WORK/home"
+export OPENAI_API_KEY="test466-not-a-real-secret"
+export TEST466_SPAWN_DETACHED=1
+export TEST466_ORPHAN_PID_FILE="$WORK/orphan.pid"
+HUB_PORT="${HUB_PORT:-9466}"
+HUB="http://127.0.0.1:$HUB_PORT"
+ALIAS="test466-codex"
+NODE_DIR="$WORK/project/.anet/nodes/$ALIAS"
+MARKER="$NODE_DIR/copresence-identity.json"
+CODEX_WRAPPER="$TEST_DIR/codex-marker-wrapper"
+LOG="$WORK/run.log"
+HUB_LOG="$WORK/hub.log"
+
+PASS=0; FAIL=0; HUB_PID=""
+ok() { echo "  PASS $*"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL $*"; FAIL=$((FAIL+1)); }
+section() { printf '\n=== %s ===\n' "$*"; }
+
+stop_group() {
+  local pid="${1:-}"
+  [[ -n "$pid" ]] || return 0
+  kill -TERM -- "-$pid" 2>/dev/null || true
+  for _ in $(seq 1 30); do [[ ! -e "/proc/$pid" ]] && return 0; sleep 0.1; done
+  kill -KILL -- "-$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  tmux kill-server 2>/dev/null || true
+  stop_group "$HUB_PID"
+  [[ -n "$HUB_PID" ]] && wait "$HUB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+safe_rm_rf "$WORK"
+mkdir -p "$HOME" "$WORK/project" "$NODE_DIR"
+tmux kill-server 2>/dev/null || true
+
+echo "source_commit=${TEST466_SOURCE_COMMIT:-unknown}"
+echo "codex_version=$(codex --version 2>&1 | head -1)"
+
+section "0. real isolated Hub + node credential"
+(cd "$REPO/server" && exec setsid env PORT="$HUB_PORT" HOST=127.0.0.1 NODE_ENV=test \
+  COMMHUB_DB="$WORK/hub.db" bun run src/index.ts >"$HUB_LOG" 2>&1) &
+HUB_PID=$!
+for _ in $(seq 1 80); do curl -fsS "$HUB/health" >/dev/null 2>&1 && break; sleep 0.25; done
+curl -fsS "$HUB/health" >/dev/null 2>&1 && ok "real Hub healthy" || { bad "Hub failed"; exit 1; }
+REG=$(curl -fsS -X POST "$HUB/api/auth/register" -H 'Content-Type: application/json' \
+  -d '{"username":"test466admin","password":"test466_Strong_123!","email":"t466@example.test"}')
+UTOK=$(jq -r '.token // empty' <<<"$REG")
+NET=$(curl -fsS "$HUB/api/auth/me" -H "Authorization: Bearer $UTOK" | jq -r '.networks[0].network_id')
+NTOK=$(curl -fsS -X POST "$HUB/api/auth/node-token" -H "Authorization: Bearer $UTOK" \
+  -H 'Content-Type: application/json' -d "{\"network_id\":\"$NET\",\"node_name\":\"$ALIAS\"}" | jq -r '.token')
+[[ "$NTOK" == ntok_* ]] && ok "network-scoped node token minted" || { bad "node token missing"; exit 1; }
+
+cat >"$NODE_DIR/config.json" <<JSON
+{"node_name":"$ALIAS","runtime":"codex-app-server","model":"gpt-5.5","hub":"$HUB","token":"$NTOK","network_id":"$NET","flags":{}}
+JSON
+chmod 600 "$NODE_DIR/config.json"
+
+session_alive() { tmux has-session -t "=$1" 2>/dev/null; }
+marker_pids() {
+  local uuid="$1" p
+  for p in /proc/[0-9]*; do
+    tr '\0' '\n' <"$p/environ" 2>/dev/null | grep -Fxq "ANET_NODE_MARKER=$uuid" && basename "$p"
+  done
+}
+
+start_triplet() {
+  rm -f "$TEST466_ORPHAN_PID_FILE" "$LOG"
+  (cd "$WORK/project" && timeout 75 anet node start "$ALIAS" --copresence \
+    --codex-bin "$CODEX_WRAPPER" --codex-home "$NODE_DIR/codex-home" --port 29466 \
+    >"$LOG" 2>&1)
+  local rc=$?
+  [[ "$rc" -eq 0 ]] || { echo "start rc=$rc"; tail -80 "$LOG"; return 1; }
+  for s in "$ALIAS" "$ALIAS-appsrv" "$ALIAS-桥"; do session_alive "$s" || return 1; done
+  [[ -s "$MARKER" ]] || return 1
+  [[ -s "$TEST466_ORPHAN_PID_FILE" ]] || return 1
+}
+
+stop_external() {
+  (cd "$WORK/project" && anet node stop "$ALIAS" >>"$LOG" 2>&1)
+}
+
+assert_real_generation_gone() {
+  local uuid="$1" label="$2" left
+  left=$(marker_pids "$uuid" | tr '\n' ' ')
+  [[ -z "$left" ]] && ok "$label: marker PID scan is zero" || bad "$label: marker PIDs survived: $left"
+  [[ ! -e "$MARKER" ]] && ok "$label: marker file removed" || bad "$label: marker file remains"
+  for s in "$ALIAS" "$ALIAS-appsrv" "$ALIAS-桥"; do
+    if session_alive "$s"; then bad "$label: tmux session survived: $s"; else ok "$label: tmux absent: $s"; fi
+  done
+}
+
+section "1. normal stop — real Codex app-server + bridge + TUI"
+if start_triplet; then
+  ok "real three-piece co-presence started"
+else
+  bad "real three-piece co-presence did not start"; exit 1
+fi
+UUID=$(jq -r '.marker' "$MARKER")
+ORPHAN=$(cat "$TEST466_ORPHAN_PID_FILE")
+kill -0 "$ORPHAN" 2>/dev/null && ok "detached marker descendant is genuinely alive" || bad "detached fixture absent"
+if stop_external; then ok "normal external stop returned success"; else bad "normal external stop failed"; fi
+assert_real_generation_gone "$UUID" "normal stop"
+kill -0 "$ORPHAN" 2>/dev/null && bad "normal stop left detached descendant" || ok "normal stop reaped detached descendant"
+
+section "2. lost app-server + hostile same-name replacement"
+start_triplet || { bad "same-name setup failed"; exit 1; }
+UUID=$(jq -r '.marker' "$MARKER")
+tmux kill-session -t "=$ALIAS-appsrv"
+for _ in $(seq 1 30); do ! session_alive "$ALIAS-appsrv" && break; sleep 0.1; done
+FAKE_PID_FILE="$WORK/fake.pid"
+tmux new-session -d -s "$ALIAS-appsrv" -e ANET_NODE_MARKER=not-the-real-marker \
+  bash -c "echo \$\$ > '$FAKE_PID_FILE'; exec sleep 600"
+for _ in $(seq 1 30); do [[ -s "$FAKE_PID_FILE" ]] && break; sleep 0.1; done
+FAKE_PID=$(cat "$FAKE_PID_FILE")
+kill -0 "$FAKE_PID" 2>/dev/null && ok "hostile same-name session is alive before stop" || bad "hostile fixture absent"
+if stop_external; then ok "identity stop completed with same-name impostor present"; else bad "identity stop failed"; fi
+REAL_LEFT=$(marker_pids "$UUID" | tr '\n' ' ')
+[[ -z "$REAL_LEFT" ]] && ok "real marker generation was reaped" || bad "real marker PIDs survived: $REAL_LEFT"
+kill -0 "$FAKE_PID" 2>/dev/null && ok "different-marker same-name process was NOT killed" || bad "different-marker process was killed by name"
+session_alive "$ALIAS-appsrv" && ok "different-marker same-name tmux was NOT killed" || bad "different-marker tmux was killed by name"
+[[ ! -e "$MARKER" ]] && ok "real generation marker removed" || bad "real marker remains"
+tmux kill-session -t "=$ALIAS-appsrv" 2>/dev/null || true
+
+section "3. bridge SIGKILL then exact identity stop"
+start_triplet || { bad "bridge-kill setup failed"; exit 1; }
+UUID=$(jq -r '.marker' "$MARKER")
+BRIDGE_PANE=$(tmux display-message -p -t "=$ALIAS-桥" '#{pane_pid}')
+kill -KILL "$BRIDGE_PANE"
+for _ in $(seq 1 30); do ! session_alive "$ALIAS-桥" && break; sleep 0.1; done
+if stop_external; then ok "stop succeeds after bridge SIGKILL"; else bad "stop failed after bridge SIGKILL"; fi
+assert_real_generation_gone "$UUID" "bridge SIGKILL"
+
+section "4. stop from inside marker-bearing TUI ancestry is refused"
+start_triplet || { bad "self-stop setup failed"; exit 1; }
+UUID=$(jq -r '.marker' "$MARKER")
+SELF_RC="$WORK/self-stop.rc"; SELF_LOG="$WORK/self-stop.log"
+tmux new-window -d -t "=$ALIAS" -n selfstop \
+  "cd '$WORK/project'; anet node stop '$ALIAS' >'$SELF_LOG' 2>&1; echo \$? >'$SELF_RC'; exec sleep 600"
+for _ in $(seq 1 80); do [[ -s "$SELF_RC" ]] && break; sleep 0.1; done
+RC=$(cat "$SELF_RC" 2>/dev/null || echo missing)
+[[ "$RC" == "2" ]] && ok "inside-tree stop returns exact refusal rc=2" || bad "inside-tree stop rc=$RC"
+grep -q 'would kill your own shell' "$SELF_LOG" && ok "self-kill refusal is explicit" || bad "self-kill refusal message missing"
+[[ -e "$MARKER" ]] && ok "self-kill refusal preserves marker" || bad "self-kill refusal removed marker"
+session_alive "$ALIAS-appsrv" && ok "self-kill refusal leaves real app-server alive" || bad "self-kill refusal killed app-server"
+stop_external || bad "external cleanup after self-stop failed"
+assert_real_generation_gone "$UUID" "post self-refusal external stop"
+
+section "5. ordinary marker-missing node retains legacy stop"
+ORD="test466-ordinary"
+mkdir -p "$WORK/project/.anet/nodes/$ORD"
+cat >"$WORK/project/.anet/nodes/$ORD/config.json" <<JSON
+{"node_name":"$ORD","runtime":"claude-code-cli","hub":"$HUB","token":"$NTOK"}
+JSON
+tmux new-session -d -s "$ORD" bash -c 'exec sleep 600'
+if (cd "$WORK/project" && anet node stop "$ORD" >>"$LOG" 2>&1); then ok "ordinary legacy stop returned success"; else bad "ordinary legacy stop failed"; fi
+session_alive "$ORD" && bad "ordinary marker-missing tmux survived" || ok "ordinary marker-missing tmux still uses legacy cleanup"
+
+section "6. non-vacuous identity mutations"
+if "$TEST_DIR/mutations.sh"; then
+  ok "three identity/name/rescan mutations turn red"
+else
+  bad "one or more identity mutations failed to turn red"
+fi
+
+echo
+echo "RESULT: PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/test466-codex-copresence-p3/run.sh
+++ b/tests/test466-codex-copresence-p3/run.sh
@@ -143,12 +143,15 @@ tmux kill-session -t "=$ALIAS-appsrv" 2>/dev/null || true
 section "3. bridge SIGKILL then exact identity stop"
 start_triplet || { bad "bridge-kill setup failed"; exit 1; }
 UUID=$(jq -r '.marker' "$MARKER")
-BRIDGE_PANE=$(tmux list-panes -a -F '#{session_name}|#{pane_pid}' \
-  | awk -F'|' -v expected="$ALIAS-桥" '$1 == expected { print $2 }')
-if [[ "$BRIDGE_PANE" =~ ^[0-9]+$ ]]; then
+BRIDGE_PANE=$(jq -r '.sessions.bridge.pid // empty' "$MARKER")
+if [[ "$BRIDGE_PANE" =~ ^[0-9]+$ ]] \
+  && kill -0 "$BRIDGE_PANE" 2>/dev/null \
+  && tr '\0' '\n' <"/proc/$BRIDGE_PANE/environ" 2>/dev/null \
+    | grep -Fxq "ANET_NODE_MARKER=$UUID"; then
+  ok "marker bridge hint resolves an exact live identity process"
   kill -KILL "$BRIDGE_PANE"
 else
-  bad "could not resolve exact bridge pane pid"
+  bad "marker bridge hint did not resolve an exact live identity process"
   [[ -s "$TEST466_BRIDGE_LOG" ]] && tail -120 "$TEST466_BRIDGE_LOG"
 fi
 for _ in $(seq 1 30); do ! session_alive "$ALIAS-桥" && break; sleep 0.1; done


### PR DESCRIPTION
## What changed

- make a present co-presence identity marker the exclusive teardown authority
- reap only processes proven by the marker UUID and never fall through to tmux-name cleanup
- fail closed for corrupt, unreadable, incomplete, or self-referential identity evidence
- retain legacy name cleanup only when the marker is genuinely absent
- add a real Hub + Codex 0.147 + bridge + TUI Docker suite and four witnessed-red mutations

## Root cause

After marker-based teardown, the CLI could still fall through to the legacy tmux-name sweep. If another process claimed the same tmux name during the race window, stopping the old generation could kill the new, unrelated generation. Corrupt marker state could also regain the name-based path.

## Validation

- exact tested source: `2def43ef3303dd192754d275d3d77f3fc4e66823`
- report-only head: `52f2d24b6925532dab69e0e461dc5b8db7c09756`
- Docker image: `sha256:ae1351f0aab675cec40178c4aca880bd1892f41ea86902218b7b63cc76d97d3d`
- `RESULT: PASS=43 FAIL=0`
- `MUTATION RESULT: PASS=4 FAIL=0`

The candidate is intentionally draft and is not merged, published, or deployed.

Closes #466