### PR TITLE
fix: surface non-image attachments to Read runtimes

### DIFF
--- a/agent-network/src/channel-attachments.test.ts
+++ b/agent-network/src/channel-attachments.test.ts
@@ -6,6 +6,7 @@ import {
   appendChannelAttachmentPaths,
   channelAttachmentCacheDir,
   downloadChannelImageAttachments,
+  readableAttachmentsFromInbox,
 } from "./channel-attachments";
 
 const roots: string[] = [];
@@ -14,6 +15,25 @@ afterEach(() => {
 });
 
 describe("Claude channel attachments", () => {
+  test("pins the readable extension allowlist as an exact value set", () => {
+    const allowed = [
+      ".bmp", ".csv", ".docx", ".gif", ".jpeg", ".jpg", ".json",
+      ".md", ".pdf", ".png", ".txt", ".webp",
+    ];
+    const attachments = [
+      ...allowed.map((extension, index) => ({
+        type: "file",
+        file_id: `file_allowed_${index}`,
+        name: `attachment${extension}`,
+        mime: "application/octet-stream",
+      })),
+      { type: "file", file_id: "file_near_pdfx", name: "attachment.pdfx", mime: "application/octet-stream" },
+      { type: "file", file_id: "file_near_exe", name: "attachment.txt.exe", mime: "application/octet-stream" },
+    ];
+    expect(readableAttachmentsFromInbox({ meta: { attachments } }))
+      .toEqual(attachments.slice(0, allowed.length));
+  });
+
   test("cache roots are alias-isolated even for path-shaped aliases", () => {
     const root = "/tmp/channel-cache-root";
     const first = channelAttachmentCacheDir(root, "owner-a");
@@ -75,6 +95,20 @@ describe("Claude channel attachments", () => {
     expect(result.paths[0]).toEndWith(".pdf");
     expect([...readFileSync(result.paths[0]!)]).toEqual([...pdf]);
     expect(statSync(result.paths[0]!).mode & 0o777).toBe(0o600);
+  });
+
+  test("does not fetch or inject a non-allowlisted file type", async () => {
+    let fetches = 0;
+    const result = await downloadChannelImageAttachments({
+      meta: { attachments: [{ type: "file", file_id: "file_exe_365", name: "payload.exe", mime: "application/octet-stream" }] },
+    }, {
+      hubUrl: "http://hub.invalid",
+      authToken: "ntok_test",
+      cacheDir: "/tmp/test365-unsupported",
+      fetch: (async () => { fetches++; return new Response("bad"); }) as typeof fetch,
+    });
+    expect(fetches).toBe(0);
+    expect(result.paths).toEqual([]);
   });
 
   test("download failure preserves the original text and exposes no token", async () => {

--- a/agent-network/src/channel-attachments.test.ts
+++ b/agent-network/src/channel-attachments.test.ts
@@ -55,6 +55,28 @@ describe("Claude channel attachments", () => {
     expect(content).not.toContain("ntok_test_secret");
   });
 
+  test("downloads an authenticated non-image file for the Read-capable channel", async () => {
+    const root = mkdtempSync(join(tmpdir(), "channel-file-attachment-"));
+    roots.push(root);
+    const pdf = Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]);
+    const result = await downloadChannelImageAttachments({
+      meta: { attachments: [{ type: "file", file_id: "file_pdf_365", name: "brief.pdf", mime: "application/pdf", size: pdf.length }] },
+    }, {
+      hubUrl: "http://hub.invalid",
+      authToken: "ntok_test",
+      cacheDir: channelAttachmentCacheDir(root, "reader"),
+      fetch: (async () => new Response(pdf, {
+        headers: { "content-length": String(pdf.length), "content-type": "application/pdf" },
+      })) as typeof fetch,
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.paths).toHaveLength(1);
+    expect(result.paths[0]).toEndWith(".pdf");
+    expect([...readFileSync(result.paths[0]!)]).toEqual([...pdf]);
+    expect(statSync(result.paths[0]!).mode & 0o777).toBe(0o600);
+  });
+
   test("download failure preserves the original text and exposes no token", async () => {
     const root = mkdtempSync(join(tmpdir(), "channel-attachment-fail-"));
     roots.push(root);

--- a/agent-network/src/channel-attachments.ts
+++ b/agent-network/src/channel-attachments.ts
@@ -41,12 +41,11 @@ function messageMeta(message: any): any {
   try { return JSON.parse(message.meta_json); } catch { return null; }
 }
 
-export function imageAttachmentsFromInbox(message: any): AttachmentDescriptor[] {
+export function readableAttachmentsFromInbox(message: any): AttachmentDescriptor[] {
   const attachments = messageMeta(message)?.attachments;
   if (!Array.isArray(attachments)) return [];
   return attachments.filter((attachment: AttachmentDescriptor) =>
     attachment && typeof attachment === "object"
-    && (attachment.type === "image" || String(attachment.mime || "").startsWith("image/"))
     && (typeof attachment.file_id === "string" || typeof attachment.path === "string"));
 }
 
@@ -67,6 +66,11 @@ function extensionFor(attachment: AttachmentDescriptor): string {
     "image/gif": ".gif",
     "image/webp": ".webp",
     "image/bmp": ".bmp",
+    "application/pdf": ".pdf",
+    "text/plain": ".txt",
+    "text/csv": ".csv",
+    "application/json": ".json",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
   };
   return byMime[mime] || "";
 }
@@ -171,13 +175,13 @@ async function fetchOne(
   return { ok: true, path };
 }
 
-export async function downloadChannelImageAttachments(
+export async function downloadChannelAttachments(
   message: any,
   deps: ChannelAttachmentDeps,
 ): Promise<ChannelAttachmentResult> {
   const paths: string[] = [];
   const failures: ChannelAttachmentResult["failures"] = [];
-  for (const attachment of imageAttachmentsFromInbox(message)) {
+  for (const attachment of readableAttachmentsFromInbox(message)) {
     const result = await fetchOne(attachment, deps);
     if (result.ok) {
       if (!paths.includes(result.path)) paths.push(result.path);
@@ -191,6 +195,11 @@ export async function downloadChannelImageAttachments(
   }
   return { paths, failures };
 }
+
+// Compatibility for callers compiled against the image-only implementation.
+// The channel is Read-capable, so the implementation now accepts any
+// authenticated file_id while retaining the old exported name.
+export const downloadChannelImageAttachments = downloadChannelAttachments;
 
 export function appendChannelAttachmentPaths(content: string, paths: readonly string[]): string {
   if (paths.length === 0) return content;

--- a/agent-network/src/channel-attachments.ts
+++ b/agent-network/src/channel-attachments.ts
@@ -12,6 +12,23 @@ import { extname, join } from "node:path";
 
 const FILE_ID = /^[A-Za-z0-9_-]{8,64}$/;
 const DEFAULT_MAX_BYTES = 50 * 1024 * 1024;
+const READABLE_EXTENSION_SET = new Set([
+  ".bmp", ".csv", ".docx", ".gif", ".jpeg", ".jpg", ".json",
+  ".md", ".pdf", ".png", ".txt", ".webp",
+]);
+const READABLE_MIME_EXTENSION: Readonly<Record<string, string>> = {
+  "application/json": ".json",
+  "application/pdf": ".pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+  "image/bmp": ".bmp",
+  "image/gif": ".gif",
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+  "text/csv": ".csv",
+  "text/markdown": ".md",
+  "text/plain": ".txt",
+};
 
 interface AttachmentDescriptor {
   type?: unknown;
@@ -46,7 +63,8 @@ export function readableAttachmentsFromInbox(message: any): AttachmentDescriptor
   if (!Array.isArray(attachments)) return [];
   return attachments.filter((attachment: AttachmentDescriptor) =>
     attachment && typeof attachment === "object"
-    && (typeof attachment.file_id === "string" || typeof attachment.path === "string"));
+    && (typeof attachment.file_id === "string" || typeof attachment.path === "string")
+    && extensionFor(attachment) !== null);
 }
 
 export function channelAttachmentCacheDir(home: string, alias: string): string {
@@ -54,25 +72,13 @@ export function channelAttachmentCacheDir(home: string, alias: string): string {
   return join(home, ".anet", "cache", "attachments", "channel", ownerKey);
 }
 
-function extensionFor(attachment: AttachmentDescriptor): string {
+function extensionFor(attachment: AttachmentDescriptor): string | null {
   if (typeof attachment.name === "string") {
-    const ext = extname(attachment.name);
-    if (/^\.[A-Za-z0-9]{1,8}$/.test(ext)) return ext.toLowerCase();
+    const extension = extname(attachment.name).toLowerCase();
+    if (READABLE_EXTENSION_SET.has(extension)) return extension;
   }
   const mime = typeof attachment.mime === "string" ? attachment.mime.toLowerCase() : "";
-  const byMime: Record<string, string> = {
-    "image/png": ".png",
-    "image/jpeg": ".jpg",
-    "image/gif": ".gif",
-    "image/webp": ".webp",
-    "image/bmp": ".bmp",
-    "application/pdf": ".pdf",
-    "text/plain": ".txt",
-    "text/csv": ".csv",
-    "application/json": ".json",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
-  };
-  return byMime[mime] || "";
+  return READABLE_MIME_EXTENSION[mime] ?? null;
 }
 
 function existingRegularFile(path: string, expectedSize?: number): boolean {
@@ -108,7 +114,11 @@ async function fetchOne(
     && attachment.size >= 0
     ? attachment.size
     : undefined;
-  const path = join(deps.cacheDir, `${fileId}${extensionFor(attachment)}`);
+  const extension = extensionFor(attachment);
+  if (extension === null) {
+    return { ok: false, code: "unsupported_type", message: "attachment type is not in the readable allowlist" };
+  }
+  const path = join(deps.cacheDir, `${fileId}${extension}`);
   if (existingRegularFile(path, expectedSize)) return { ok: true, path };
 
   const controller = new AbortController();
@@ -198,7 +208,7 @@ export async function downloadChannelAttachments(
 
 // Compatibility for callers compiled against the image-only implementation.
 // The channel is Read-capable, so the implementation now accepts any
-// authenticated file_id while retaining the old exported name.
+// allowlisted, authenticated file_id while retaining the old exported name.
 export const downloadChannelImageAttachments = downloadChannelAttachments;
 
 export function appendChannelAttachmentPaths(content: string, paths: readonly string[]): string {

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -22,7 +22,7 @@ import { loadOwnerOnlyEnvFile } from "./owner-env-file";
 import {
   appendChannelAttachmentPaths,
   channelAttachmentCacheDir,
-  downloadChannelImageAttachments,
+  downloadChannelAttachments,
 } from "./channel-attachments";
 
 // ── .env loader helper ────────────────────────────────
@@ -521,7 +521,7 @@ async function handleSSEEvent(event: any) {
       for (const msg of inbox.messages) {
         let channelContent = String(msg.content || "");
         try {
-          const attachments = await downloadChannelImageAttachments(msg, {
+          const attachments = await downloadChannelAttachments(msg, {
             hubUrl: COMMHUB_URL,
             authToken: AUTH_TOKEN,
             cacheDir: channelAttachmentCacheDir(HOME, ALIAS),

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -4310,37 +4310,34 @@ function think(
   return next;
 }
 
-/** #222 cross-host attachment resolution — replaces the legacy
- *  sync `extractImagePaths`. For each attachment, prefer file_id
+/** #222/#365 cross-host attachment resolution. For each attachment, prefer file_id
  *  (fetch via hub /api/files/<id>, cache locally, hand temp path
  *  to LLM); fall back to host-local `path` for single-host setups.
  *  Drops attachments that fail to resolve (with warn) so a partial
  *  failure doesn't crash the whole message processing path.
- *  Filter logic preserved: only image attachments are surfaced
- *  (matched by `type === "image"` OR `mime` starting "image/").
- *  Non-image attachments (PDF/docx/etc) are still silently dropped
- *  today — broader file-type support is a follow-up. */
-async function extractImagePaths(msg: any): Promise<string[]> {
+ *  Structured multimodal lanes receive images only. Read-path lanes
+ *  (Codex app-server and OpenCode) may receive any authenticated Hub
+ *  file_id, but never a sender-local path. */
+async function extractRuntimeAttachmentPaths(msg: any): Promise<string[]> {
   const meta = msg?.meta || (() => {
     try { return msg?.meta_json ? JSON.parse(msg.meta_json) : null; } catch { return null; }
   })();
   const attachments = Array.isArray(meta?.attachments) ? meta.attachments : [];
-  const imageAttachments = attachments.filter(
+  const attachmentDescriptors = attachments.filter(
     (a: any) =>
       a && typeof a === "object" &&
-      (a.type === "image" || String(a.mime || "").startsWith("image/")) &&
       (typeof a.file_id === "string" || typeof a.path === "string"),
   );
-  if (imageAttachments.length === 0) return [];
+  if (attachmentDescriptors.length === 0) return [];
   const { resolveAttachmentToLocalPath } = await import("./runtime/fetch-attachment.js");
   // Cache lives under the user's home, keyed by alias — mirrors
   // ~/.anet/deleted root chosen by RFC-027 D7 (host-level scope, not
   // per-cwd, so a node started from a different cwd still hits the
   // same cache). chmod 700 + chmod 600 enforced in fetch-attachment.ts.
   const cacheDir = join(home, ".anet", "cache", "attachments", ALIAS || "default");
-  const resolvableAttachments = attachmentDescriptorsForRuntime(RUNTIME, imageAttachments);
-  if (resolvableAttachments.length !== imageAttachments.length) {
-    warn(`[attachment] refused ${imageAttachments.length - resolvableAttachments.length} sender-local path attachment(s) for ${RUNTIME}; preserving text-only references`);
+  const resolvableAttachments = attachmentDescriptorsForRuntime(RUNTIME, attachmentDescriptors);
+  if (resolvableAttachments.length !== attachmentDescriptors.length) {
+    warn(`[attachment] refused ${attachmentDescriptors.length - resolvableAttachments.length} unsupported or sender-local attachment(s) for ${RUNTIME}; preserving text-only references`);
   }
   const resolved: string[] = [];
   for (const a of resolvableAttachments) {
@@ -4656,11 +4653,11 @@ async function processInbox() {
       // logical task across retry/reassign. Keep ACK on the transport row,
       // but bind runtime evidence and replies to the logical task.
       const logicalTaskId = logicalTaskIdFromInbox(msg);
-      const images = await extractImagePaths(msg);
+      const images = await extractRuntimeAttachmentPaths(msg);
       const inboundLogSuffix = GROK_EXECUTION_MODE === "cli"
         ? ` (${content.length} chars; content withheld)`
         : ` ${content.slice(0, 100)}`;
-      log(`← [${from}] (${msgType}/${msg.priority || "normal"})${images.length ? ` +${images.length} image(s)` : ""}${inboundLogSuffix}`);
+      log(`← [${from}] (${msgType}/${msg.priority || "normal"})${images.length ? ` +${images.length} attachment(s)` : ""}${inboundLogSuffix}`);
 
       // Other non-task / non-broadcast messages retain their historical
       // ack-only behavior; send_message never implies an LLM response.

--- a/agent-node/src/runtime/readable-attachment-prompt.test.ts
+++ b/agent-node/src/runtime/readable-attachment-prompt.test.ts
@@ -39,19 +39,20 @@ describe("readable attachment prompt", () => {
 
   test("path-prompt runtimes reject sender-local paths while structured lanes retain legacy behavior", () => {
     const attachments = [
-      { file_id: "file_authorized_520", path: "/tmp/hub-machine.png" },
-      { path: "/etc/passwd" },
+      { type: "image", mime: "image/png", file_id: "file_authorized_520", path: "/tmp/hub-machine.png" },
+      { type: "file", mime: "application/pdf", file_id: "file_pdf_365" },
+      { type: "file", mime: "text/plain", path: "/etc/passwd" },
     ];
-    expect(attachmentDescriptorsForRuntime("opencode", attachments)).toEqual([attachments[0]]);
-    expect(attachmentDescriptorsForRuntime("codex-app-server", attachments)).toEqual([attachments[0]]);
-    expect(attachmentDescriptorsForRuntime("claude", attachments)).toEqual(attachments);
-    expect(attachmentDescriptorsForRuntime("codex", attachments)).toEqual(attachments);
+    expect(attachmentDescriptorsForRuntime("opencode", attachments)).toEqual([attachments[0], attachments[1]]);
+    expect(attachmentDescriptorsForRuntime("codex-app-server", attachments)).toEqual([attachments[0], attachments[1]]);
+    expect(attachmentDescriptorsForRuntime("claude", attachments)).toEqual([attachments[0]]);
+    expect(attachmentDescriptorsForRuntime("codex", attachments)).toEqual([attachments[0]]);
   });
 
   test("the inbox choke point feeds the augmented text into processTask", () => {
     const cli = readFileSync(join(import.meta.dir, "..", "cli.ts"), "utf8");
     expect(cli).toContain("const runtimeContent = runtimeNeedsReadableAttachmentPrompt(RUNTIME)");
-    expect(cli).toContain("attachmentDescriptorsForRuntime(RUNTIME, imageAttachments)");
+    expect(cli).toContain("attachmentDescriptorsForRuntime(RUNTIME, attachmentDescriptors)");
     expect(cli).toContain("appendReadableAttachmentPaths(content, images)");
     expect(cli).toContain("processTask(\n        runtimeContent,");
   });

--- a/agent-node/src/runtime/readable-attachment-prompt.test.ts
+++ b/agent-node/src/runtime/readable-attachment-prompt.test.ts
@@ -21,6 +21,25 @@ describe("readable attachment prompt", () => {
     expect(runtimeNeedsReadableAttachmentPrompt("grok")).toBe(false);
   });
 
+  test("pins the readable extension allowlist as an exact value set", () => {
+    const allowed = [
+      ".bmp", ".csv", ".docx", ".gif", ".jpeg", ".jpg", ".json",
+      ".md", ".pdf", ".png", ".txt", ".webp",
+    ];
+    const attachments = [
+      ...allowed.map((extension, index) => ({
+        type: "file",
+        file_id: `file_allowed_${index}`,
+        name: `attachment${extension}`,
+        mime: "application/octet-stream",
+      })),
+      { type: "file", file_id: "file_near_pdfx", name: "attachment.pdfx", mime: "application/octet-stream" },
+      { type: "file", file_id: "file_near_exe", name: "attachment.txt.exe", mime: "application/octet-stream" },
+    ];
+    expect(attachmentDescriptorsForRuntime("opencode", attachments))
+      .toEqual(attachments.slice(0, allowed.length));
+  });
+
   test("injects absolute deduplicated paths and escapes control characters", () => {
     const prompt = appendReadableAttachmentPaths("inspect it", [
       "/tmp/inbox/image.png",
@@ -40,8 +59,9 @@ describe("readable attachment prompt", () => {
   test("path-prompt runtimes reject sender-local paths while structured lanes retain legacy behavior", () => {
     const attachments = [
       { type: "image", mime: "image/png", file_id: "file_authorized_520", path: "/tmp/hub-machine.png" },
-      { type: "file", mime: "application/pdf", file_id: "file_pdf_365" },
+      { type: "file", mime: "application/pdf", name: "brief.pdf", file_id: "file_pdf_365" },
       { type: "file", mime: "text/plain", path: "/etc/passwd" },
+      { type: "file", mime: "application/octet-stream", name: "payload.exe", file_id: "file_exe_365" },
     ];
     expect(attachmentDescriptorsForRuntime("opencode", attachments)).toEqual([attachments[0], attachments[1]]);
     expect(attachmentDescriptorsForRuntime("codex-app-server", attachments)).toEqual([attachments[0], attachments[1]]);

--- a/agent-node/src/runtime/readable-attachment-prompt.ts
+++ b/agent-node/src/runtime/readable-attachment-prompt.ts
@@ -1,9 +1,33 @@
-import { resolve } from "node:path";
+import { extname, resolve } from "node:path";
 
 const PATH_PROMPT_RUNTIME_SET = new Set([
   "codex-app-server",
   "opencode",
 ]);
+const READABLE_EXTENSION_SET = new Set([
+  ".bmp", ".csv", ".docx", ".gif", ".jpeg", ".jpg", ".json",
+  ".md", ".pdf", ".png", ".txt", ".webp",
+]);
+const READABLE_MIME_SET = new Set([
+  "application/json",
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "text/csv",
+  "text/markdown",
+  "text/plain",
+]);
+
+function isAllowlistedReadableAttachment(attachment: { name?: unknown; mime?: unknown }): boolean {
+  const mime = typeof attachment.mime === "string" ? attachment.mime.toLowerCase() : "";
+  if (READABLE_MIME_SET.has(mime)) return true;
+  const extension = typeof attachment.name === "string" ? extname(attachment.name).toLowerCase() : "";
+  return READABLE_EXTENSION_SET.has(extension);
+}
 
 /**
  * Runtime buckets whose current adapter does not carry `images[]` as native
@@ -27,13 +51,15 @@ export function attachmentDescriptorsForRuntime<T extends {
   path?: unknown;
   type?: unknown;
   mime?: unknown;
+  name?: unknown;
 }>(
   runtime: string,
   attachments: readonly T[],
 ): T[] {
   if (runtimeNeedsReadableAttachmentPrompt(runtime)) {
     return attachments.filter((attachment) =>
-      typeof attachment.file_id === "string" && attachment.file_id.length > 0);
+      typeof attachment.file_id === "string" && attachment.file_id.length > 0
+      && isAllowlistedReadableAttachment(attachment));
   }
   return attachments.filter((attachment) =>
     (attachment.type === "image" || String(attachment.mime || "").startsWith("image/"))

--- a/agent-node/src/runtime/readable-attachment-prompt.ts
+++ b/agent-node/src/runtime/readable-attachment-prompt.ts
@@ -22,13 +22,22 @@ export function runtimeNeedsReadableAttachmentPrompt(runtime: string): boolean {
  * while path-prompt lanes surface only attachments that the Hub can authorize
  * by file_id.
  */
-export function attachmentDescriptorsForRuntime<T extends { file_id?: unknown }>(
+export function attachmentDescriptorsForRuntime<T extends {
+  file_id?: unknown;
+  path?: unknown;
+  type?: unknown;
+  mime?: unknown;
+}>(
   runtime: string,
   attachments: readonly T[],
 ): T[] {
-  if (!runtimeNeedsReadableAttachmentPrompt(runtime)) return [...attachments];
+  if (runtimeNeedsReadableAttachmentPrompt(runtime)) {
+    return attachments.filter((attachment) =>
+      typeof attachment.file_id === "string" && attachment.file_id.length > 0);
+  }
   return attachments.filter((attachment) =>
-    typeof attachment.file_id === "string" && attachment.file_id.length > 0);
+    (attachment.type === "image" || String(attachment.mime || "").startsWith("image/"))
+    && (typeof attachment.file_id === "string" || typeof attachment.path === "string"));
 }
 
 /** Add owner-local paths as data, never as instructions supplied by sender. */

--- a/docs/tests/report-test365-nonimage-read-attachments.txt
+++ b/docs/tests/report-test365-nonimage-read-attachments.txt
@@ -1,0 +1,86 @@
+# test365 — authenticated non-image attachments for Read-capable runtimes
+
+Date: 2026-08-10
+Base: ccf23458228d8c1a9f43d20b0ab3c95a5c972bee
+Source commit: 1925cf89e09faa2aeaa152328fd63698e53ed176
+Image tag: anet-test365:dev
+Image ID: sha256:9484a17ca4cb7301063b15dfa664b855086c73cfa846d4541338f720ec9ba5ef
+Embedded ENV: TEST365_SOURCE_COMMIT=1925cf89e09faa2aeaa152328fd63698e53ed176
+
+Scope
+-----
+- Preserve the existing structured-image lanes as image-only.
+- For exact Read-path runtimes (`codex-app-server`, `opencode`), surface only
+  allowlisted attachments with a Hub `file_id`; sender-provided host paths are
+  never promoted into the prompt.
+- Extend the Claude channel receiver to download allowlisted non-image Hub
+  attachments to its alias-isolated cache and append their owner-local paths.
+- Keep download failures fail-safe: original task text remains available and
+  the task is still acknowledged.
+
+The readable extension set is pinned exactly to:
+`.bmp .csv .docx .gif .jpeg .jpg .json .md .pdf .png .txt .webp`.
+The corresponding MIME set is exact as well. This type list is a capability
+boundary, not an authenticity claim about sender-supplied metadata. The actual
+download trust boundary is a validated `file_id` fetched from Hub with the
+receiver's token; the resulting local file is mode 0600.
+
+Witnessed red
+-------------
+Before the production change, the new PDF unit case ran against the image-only
+implementation and failed: 5 pass / 1 fail, with zero resolved PDF paths.
+The final suite also applies six byte-changing production mutations. Every
+mutation exits non-zero:
+
+1. restore the Claude channel's image-only filter;
+2. restore the Read-path runtime's image-only filter;
+3. admit non-images into structured multimodal lanes;
+4. weaken the channel extension allowlist to any non-empty suffix;
+5. weaken the runtime extension allowlist to any non-empty suffix;
+6. admit a sender-provided local path into a Read-path prompt.
+
+Exact-source Docker run
+-----------------------
+Commands:
+
+    sg docker -c 'docker build \
+      --build-arg TEST365_SOURCE_COMMIT=1925cf89e09faa2aeaa152328fd63698e53ed176 \
+      -t anet-test365:dev \
+      -f tests/test365-nonimage-read-attachments/Dockerfile .'
+    sg docker -c 'docker run --rm anet-test365:dev'
+
+Result:
+
+- agent-network typecheck: PASS
+- agent-network attachment tests: 8 pass / 0 fail / 31 assertions
+- agent-node build: PASS
+- agent-node attachment tests: 25 pass / 0 fail / 84 assertions
+- real Hub wire harness: 15 assertions PASS
+- mutations: 6 witnessed red / 0 survived
+- final: RESULT: PASS
+
+The wire harness starts the real Hub with SQLite, registers a user, obtains the
+real network, mints a token-bound node identity, uploads deterministic PDF
+bytes, sends a real task carrying the returned `file_id`, and observes the real
+Claude channel notification. It verifies exact bytes, `.pdf` local path, mode
+0600, original-text preservation, and zero token disclosure in payload/stderr.
+
+Compatibility gate
+------------------
+The pre-existing test520 suite was rebuilt at the same source commit after its
+mutation anchor was updated for the exact allowlist:
+
+- agent-network: 8 pass / 0 fail / 31 assertions
+- agent-node: 35 pass / 0 fail / 125 assertions
+- real channel harness: 14 assertions PASS
+- existing attachment mutations: 6/6 witnessed red
+- final: RESULT: PASS
+
+Honest boundaries
+-----------------
+- This change does not make PDF/docx/text into structured image blocks.
+- It does not trust a filename or MIME value as proof of file content.
+- It does not grant cross-network access; Hub authorization remains the
+  authority for `/api/files/<file_id>`.
+- It does not surface arbitrary file types or arbitrary sender host paths.
+- No production deployment or npm publication was performed.

--- a/tests/test365-nonimage-read-attachments/Dockerfile
+++ b/tests/test365-nonimage-read-attachments/Dockerfile
@@ -1,0 +1,24 @@
+FROM oven/bun:1.3.14
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl jq ca-certificates python3 \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY agent-network/package.json ./agent-network/package.json
+RUN cd agent-network && bun install --ignore-scripts
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+
+COPY server ./server
+COPY agent-network ./agent-network
+COPY agent-node ./agent-node
+COPY tests/lib ./tests/lib
+COPY tests/test365-nonimage-read-attachments ./tests/test365-nonimage-read-attachments
+
+ARG TEST365_SOURCE_COMMIT=uncommitted
+ENV TEST365_SOURCE_COMMIT=$TEST365_SOURCE_COMMIT
+RUN chmod 0755 tests/test365-nonimage-read-attachments/run.sh
+
+ENTRYPOINT ["/workspace/tests/test365-nonimage-read-attachments/run.sh"]

--- a/tests/test365-nonimage-read-attachments/README.md
+++ b/tests/test365-nonimage-read-attachments/README.md
@@ -1,0 +1,11 @@
+# test365 — non-image attachments for Read-capable runtimes
+
+This suite starts the real Hub, uploads deterministic PDF bytes, sends a real
+task carrying the returned `file_id`, and observes the real Claude channel
+notification. The receiver must download the PDF through authenticated Hub
+HTTP, cache it as an alias-local mode-0600 file, and surface its path as
+untrusted data.
+
+Structured multimodal runtimes remain image-only. The suite does not claim
+that PDF/docx files are valid image blocks or that every runtime can read
+arbitrary files.

--- a/tests/test365-nonimage-read-attachments/mutate.mjs
+++ b/tests/test365-nonimage-read-attachments/mutate.mjs
@@ -1,0 +1,8 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [file, before, after] = process.argv.slice(2);
+if (!file || before === undefined || after === undefined) throw new Error("file/before/after required");
+const source = readFileSync(file, "utf8");
+const count = source.split(before).length - 1;
+if (count !== 1) throw new Error(`anchor count=${count} expected=1`);
+writeFileSync(file, source.replace(before, after));

--- a/tests/test365-nonimage-read-attachments/real-hub-channel-harness.ts
+++ b/tests/test365-nonimage-read-attachments/real-hub-channel-harness.ts
@@ -1,0 +1,144 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const hubBase = process.env.HUB_BASE;
+const bundle = process.env.CHANNEL_BUNDLE;
+if (!hubBase || !bundle) throw new Error("HUB_BASE and CHANNEL_BUNDLE are required");
+
+const alias = "test365-file-reader";
+const pdf = Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a]);
+const checks: string[] = [];
+function check(value: unknown, label: string): void {
+  if (!value) throw new Error(`FAIL: ${label}`);
+  checks.push(label);
+}
+
+const registered = await fetch(`${hubBase}/api/auth/register`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ username: "test365admin", password: "test365_TestPass_1234!", email: "test365@example.invalid" }),
+}).then((response) => response.json() as Promise<any>);
+const userToken = String(registered.token || "");
+check(userToken.startsWith("utok_"), "real Hub minted user token");
+const me = await fetch(`${hubBase}/api/auth/me`, {
+  headers: { authorization: `Bearer ${userToken}` },
+}).then((response) => response.json() as Promise<any>);
+const networkId = String(me.networks?.[0]?.network_id || "");
+check(Boolean(networkId), "real Hub returned network membership");
+const minted = await fetch(`${hubBase}/api/auth/node-token`, {
+  method: "POST",
+  headers: { authorization: `Bearer ${userToken}`, "content-type": "application/json" },
+  body: JSON.stringify({ network_id: networkId, node_name: alias }),
+}).then((response) => response.json() as Promise<any>);
+const nodeToken = String(minted.token || "");
+check(nodeToken.startsWith("ntok_"), "real Hub minted token-bound node identity");
+
+const form = new FormData();
+form.append("file", new Blob([pdf], { type: "application/pdf" }), "brief.pdf");
+const uploaded = await fetch(`${hubBase}/api/upload`, {
+  method: "POST",
+  headers: { authorization: `Bearer ${userToken}` },
+  body: form,
+}).then((response) => response.json() as Promise<any>);
+const fileId = String(uploaded.file_id || "");
+check(Boolean(fileId), "real Hub accepted PDF and returned file_id");
+
+const root = mkdtempSync(join(tmpdir(), "test365-real-channel-"));
+const child = Bun.spawn(["bun", bundle], {
+  cwd: root,
+  env: {
+    HOME: root,
+    PATH: process.env.PATH || "/usr/local/bin:/usr/bin:/bin",
+    COMMHUB_URL: hubBase,
+    COMMHUB_TOKEN: nodeToken,
+    COMMHUB_ALIAS: alias,
+    COMMHUB_RESUME_ID: "test365-resume-id",
+  },
+  stdin: "pipe",
+  stdout: "pipe",
+  stderr: "pipe",
+});
+const stderrPromise = new Response(child.stderr).text();
+const reader = child.stdout.getReader();
+let buffered = "";
+async function nextMessage(timeoutMs = 12_000): Promise<any> {
+  const end = Date.now() + timeoutMs;
+  while (Date.now() < end) {
+    const newline = buffered.indexOf("\n");
+    if (newline >= 0) {
+      const line = buffered.slice(0, newline).trim();
+      buffered = buffered.slice(newline + 1);
+      if (line) return JSON.parse(line);
+      continue;
+    }
+    const read = await Promise.race([
+      reader.read(),
+      Bun.sleep(Math.max(1, end - Date.now())).then(() => ({ done: true } as ReadableStreamReadResult<Uint8Array>)),
+    ]);
+    if (read.done) break;
+    buffered += new TextDecoder().decode(read.value, { stream: true });
+  }
+  throw new Error("timed out waiting for channel output");
+}
+async function until(predicate: (value: any) => boolean): Promise<any> {
+  for (;;) {
+    const value = await nextMessage();
+    if (predicate(value)) return value;
+  }
+}
+
+try {
+  child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test365", version: "1" } } })}\n`);
+  await child.stdin.flush();
+  const initialized = await until((value) => value.id === 1);
+  check(Boolean(initialized.result?.capabilities?.experimental?.["claude/channel"]), "real channel initialized");
+  child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} })}\n`);
+  await child.stdin.flush();
+
+  let online = false;
+  for (let i = 0; i < 80; i++) {
+    const status = await fetch(`${hubBase}/api/status?network_id=${encodeURIComponent(networkId)}`, {
+      headers: { authorization: `Bearer ${userToken}` },
+    }).then((response) => response.json() as Promise<any>);
+    if (status.sessions?.some((entry: any) => entry.alias === alias)) {
+      online = true;
+      break;
+    }
+    await Bun.sleep(100);
+  }
+  check(online, "real channel registered on Hub before task send");
+
+  const sent = await fetch(`${hubBase}/api/task`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${userToken}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      alias,
+      network_id: networkId,
+      task: "Read the attached PDF",
+      attachments: [{ type: "file", file_id: fileId, name: "brief.pdf", mime: "application/pdf", size: pdf.length }],
+    }),
+  });
+  check(sent.ok, "real Hub accepted task with PDF attachment");
+
+  const notification = await until((value) => value.method === "notifications/claude/channel");
+  const content = String(notification.params?.content || "");
+  check(content.startsWith("Read the attached PDF"), "original task text is preserved");
+  check(content.includes("[Agent Network local attachments]"), "channel appended local attachment block");
+  const pathLine = content.split("\n").find((line) => line.startsWith('- "/'));
+  const localPath = pathLine ? JSON.parse(pathLine.slice(2)) : "";
+  check(Boolean(localPath) && localPath.endsWith(".pdf"), "prompt exposes a PDF path, not an image block");
+  check(Boolean(localPath) && existsSync(localPath), "downloaded PDF path exists");
+  check(Boolean(localPath) && Buffer.from(readFileSync(localPath)).equals(Buffer.from(pdf)), "downloaded bytes equal Hub upload");
+  check(Boolean(localPath) && (statSync(localPath).mode & 0o777) === 0o600, "downloaded PDF is mode 0600");
+  check(!content.includes(nodeToken) && !content.includes(userToken), "prompt leaks no bearer token");
+} finally {
+  child.kill("SIGTERM");
+  await child.exited;
+  const stderr = await stderrPromise;
+  check(!stderr.includes(nodeToken) && !stderr.includes(userToken), "stderr leaks no bearer token");
+  rmSync(root, { recursive: true, force: true });
+}
+
+for (const label of checks) console.log(`PASS: ${label}`);
+console.log(`ASSERTIONS: ${checks.length}`);

--- a/tests/test365-nonimage-read-attachments/run.sh
+++ b/tests/test365-nonimage-read-attachments/run.sh
@@ -66,8 +66,8 @@ expect_red \
 expect_red \
   path-runtime-restores-image-only-filter \
   agent-node/src/runtime/readable-attachment-prompt.ts \
-  $'    return attachments.filter((attachment) =>\n      typeof attachment.file_id === "string" && attachment.file_id.length > 0);' \
-  $'    return attachments.filter((attachment) =>\n      (attachment.type === "image" || String(attachment.mime || "").startsWith("image/"))\n      && typeof attachment.file_id === "string" && attachment.file_id.length > 0);' \
+  $'    return attachments.filter((attachment) =>\n      typeof attachment.file_id === "string" && attachment.file_id.length > 0\n      && isAllowlistedReadableAttachment(attachment));' \
+  $'    return attachments.filter((attachment) =>\n      (attachment.type === "image" || String(attachment.mime || "").startsWith("image/"))\n      && typeof attachment.file_id === "string" && attachment.file_id.length > 0\n      && isAllowlistedReadableAttachment(attachment));' \
   'cd /workspace/agent-node && bun test src/runtime/readable-attachment-prompt.test.ts'
 
 expect_red \
@@ -77,6 +77,27 @@ expect_red \
   '  return [...attachments];' \
   'cd /workspace/agent-node && bun test src/runtime/readable-attachment-prompt.test.ts'
 
-[[ $MUTATIONS -eq 3 ]] || { echo "mutation denominator mismatch: $MUTATIONS/3" >&2; exit 1; }
+expect_red \
+  channel-extension-allowlist-weakened \
+  agent-network/src/channel-attachments.ts \
+  '    if (READABLE_EXTENSION_SET.has(extension)) return extension;' \
+  '    if (extension.length > 0) return extension;' \
+  'cd /workspace/agent-network && bun test src/channel-attachments.test.ts'
+
+expect_red \
+  runtime-extension-allowlist-weakened \
+  agent-node/src/runtime/readable-attachment-prompt.ts \
+  '  return READABLE_EXTENSION_SET.has(extension);' \
+  '  return extension.length > 0;' \
+  'cd /workspace/agent-node && bun test src/runtime/readable-attachment-prompt.test.ts'
+
+expect_red \
+  sender-path-enters-read-prompt \
+  agent-node/src/runtime/readable-attachment-prompt.ts \
+  '      typeof attachment.file_id === "string" && attachment.file_id.length > 0' \
+  '      (typeof attachment.file_id === "string" || typeof attachment.path === "string")' \
+  'cd /workspace/agent-node && bun test src/runtime/readable-attachment-prompt.test.ts'
+
+[[ $MUTATIONS -eq 6 ]] || { echo "mutation denominator mismatch: $MUTATIONS/6" >&2; exit 1; }
 echo "MUTATION RESULT: PASS=$MUTATIONS FAIL=0"
 echo "RESULT: PASS"

--- a/tests/test365-nonimage-read-attachments/run.sh
+++ b/tests/test365-nonimage-read-attachments/run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=/workspace
+WORK=/tmp/test365
+source "$ROOT/tests/lib/safe-rm.sh"
+safe_rm_rf "$WORK"
+mkdir -p "$WORK/home" "$WORK/uploads"
+export HOME="$WORK/home"
+
+echo "source_commit=$TEST365_SOURCE_COMMIT"
+echo "layer=real Hub file_id PDF -> real Claude channel Read path"
+
+cd "$ROOT/agent-network"
+bun run typecheck
+bun build src/node-server.ts --outfile "$WORK/node-server.js" --target node
+bun test src/channel-attachments.test.ts
+
+cd "$ROOT/agent-node"
+bun run build
+bun test src/runtime/fetch-attachment.test.ts src/runtime/readable-attachment-prompt.test.ts
+
+cd "$ROOT"
+PORT=9365 HOST=127.0.0.1 NODE_ENV=test \
+  COMMHUB_DB="$WORK/hub.db" COMMHUB_UPLOADS_ROOT="$WORK/uploads" \
+  bun run server/src/index.ts >"$WORK/hub.log" 2>&1 &
+HUB_PID=$!
+cleanup() {
+  kill "$HUB_PID" 2>/dev/null || true
+  wait "$HUB_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+for _ in $(seq 1 80); do curl -fsS http://127.0.0.1:9365/health >/dev/null 2>&1 && break; sleep 0.25; done
+curl -fsS http://127.0.0.1:9365/health >/dev/null
+CHANNEL_BUNDLE="$WORK/node-server.js" HUB_BASE=http://127.0.0.1:9365 \
+  bun tests/test365-nonimage-read-attachments/real-hub-channel-harness.ts
+
+MUTATIONS=0
+expect_red() {
+  local name=$1 file=$2 before=$3 after=$4 command=$5
+  local backup="$WORK/$(basename "$file").$MUTATIONS.bak"
+  cp "$file" "$backup"
+  bun tests/test365-nonimage-read-attachments/mutate.mjs "$file" "$before" "$after"
+  ! cmp -s "$file" "$backup" || { echo "MUTATION INVALID byte-identical: $name" >&2; exit 1; }
+  set +e
+  bash -lc "$command" >"$WORK/mutation.log" 2>&1
+  local rc=$?
+  set -e
+  cp "$backup" "$file"
+  if [[ $rc -eq 0 ]]; then
+    echo "MUTATION SURVIVED: $name" >&2
+    cat "$WORK/mutation.log" >&2
+    exit 1
+  fi
+  MUTATIONS=$((MUTATIONS + 1))
+  echo "WITNESSED-RED $name rc=$rc"
+}
+
+expect_red \
+  channel-restores-image-only-filter \
+  agent-network/src/channel-attachments.ts \
+  '    attachment && typeof attachment === "object"' \
+  '    attachment && typeof attachment === "object" && (attachment.type === "image" || String(attachment.mime || "").startsWith("image/"))' \
+  'cd /workspace/agent-network && bun test src/channel-attachments.test.ts'
+
+expect_red \
+  path-runtime-restores-image-only-filter \
+  agent-node/src/runtime/readable-attachment-prompt.ts \
+  $'    return attachments.filter((attachment) =>\n      typeof attachment.file_id === "string" && attachment.file_id.length > 0);' \
+  $'    return attachments.filter((attachment) =>\n      (attachment.type === "image" || String(attachment.mime || "").startsWith("image/"))\n      && typeof attachment.file_id === "string" && attachment.file_id.length > 0);' \
+  'cd /workspace/agent-node && bun test src/runtime/readable-attachment-prompt.test.ts'
+
+expect_red \
+  structured-runtime-accepts-nonimage \
+  agent-node/src/runtime/readable-attachment-prompt.ts \
+  $'  return attachments.filter((attachment) =>\n    (attachment.type === "image" || String(attachment.mime || "").startsWith("image/"))\n    && (typeof attachment.file_id === "string" || typeof attachment.path === "string"));' \
+  '  return [...attachments];' \
+  'cd /workspace/agent-node && bun test src/runtime/readable-attachment-prompt.test.ts'
+
+[[ $MUTATIONS -eq 3 ]] || { echo "mutation denominator mismatch: $MUTATIONS/3" >&2; exit 1; }
+echo "MUTATION RESULT: PASS=$MUTATIONS FAIL=0"
+echo "RESULT: PASS"

--- a/tests/test520-dashboard-attachment-read/run.sh
+++ b/tests/test520-dashboard-attachment-read/run.sh
@@ -82,7 +82,7 @@ expect_mutation_red \
 expect_mutation_red \
   readable-runtime-host-path-rejection \
   agent-node/src/runtime/readable-attachment-prompt.ts \
-  $'    return attachments.filter((attachment) =>\n+      typeof attachment.file_id === "string" && attachment.file_id.length > 0);' \
+  $'    return attachments.filter((attachment) =>\n      typeof attachment.file_id === "string" && attachment.file_id.length > 0\n      && isAllowlistedReadableAttachment(attachment));' \
   '    return [...attachments];' \
   'cd /workspace/agent-node && bun test src/runtime/readable-attachment-prompt.test.ts'
 

--- a/tests/test520-dashboard-attachment-read/run.sh
+++ b/tests/test520-dashboard-attachment-read/run.sh
@@ -82,8 +82,8 @@ expect_mutation_red \
 expect_mutation_red \
   readable-runtime-host-path-rejection \
   agent-node/src/runtime/readable-attachment-prompt.ts \
-  '  if (!runtimeNeedsReadableAttachmentPrompt(runtime)) return [...attachments];' \
-  '  if (runtimeNeedsReadableAttachmentPrompt(runtime)) return [...attachments];' \
+  $'    return attachments.filter((attachment) =>\n+      typeof attachment.file_id === "string" && attachment.file_id.length > 0);' \
+  '    return [...attachments];' \
   'cd /workspace/agent-node && bun test src/runtime/readable-attachment-prompt.test.ts'
 
 expect_mutation_red \


### PR DESCRIPTION
## What changed

- allow the Claude channel receiver to download an exact allowlist of non-image Hub attachments into its alias-isolated mode-0600 cache
- surface authenticated local paths to the exact Read-path runtime set (`codex-app-server`, `opencode`)
- keep structured multimodal lanes image-only and reject sender-provided host paths
- add a real-Hub Docker harness, exact allowlist tests, and six load-bearing mutations

## Why

Issue #365 remained open after image attachments were fixed because PDF/text/docx-style files were still reduced to a text label. Agents with a native Read capability need an authenticated owner-local path, while untrusted sender paths and arbitrary file types must remain excluded.

## Validation

- exact source Docker image embeds `1925cf89e09faa2aeaa152328fd63698e53ed176`
- agent-network: 8 tests / 31 assertions
- agent-node: 25 tests / 84 assertions
- real Hub wire: 15 assertions
- mutation: 6/6 witnessed red
- compatibility test520: 35 tests / 125 assertions + 14 wire assertions + 6/6 mutations

Full evidence: `docs/tests/report-test365-nonimage-read-attachments.txt`

No deployment or npm publication was performed.

Closes #365
