### PR TITLE
feat: add send_task trace events

### DIFF
--- a/agent-network/src/channel-task-trace.ts
+++ b/agent-network/src/channel-task-trace.ts
@@ -1,0 +1,44 @@
+import { renderTaskTrace, safeTaskTraceError, taskTraceEvent } from "./task-trace";
+
+export async function sendChannelTaskWithTrace(input: {
+  alias: string;
+  task: string;
+  priority?: string;
+  fromAlias: string;
+  networkId?: string | null;
+}, deps: {
+  send: (args: Record<string, unknown>) => Promise<any>;
+  log: (line: string) => void;
+}): Promise<any> {
+  const startedAt = Date.now();
+  const emit = (status: "sending" | "delivered" | "failed", taskId: string | null, failure?: unknown) => {
+    deps.log(renderTaskTrace(taskTraceEvent({
+      from_alias: input.fromAlias,
+      to_alias: input.alias,
+      task_id: taskId,
+      parent_task_id: null,
+      network_id: input.networkId || null,
+      transport: "channel_mcp_proxy",
+      status,
+      duration_ms: Date.now() - startedAt,
+      lifecycle_tracking: "not_tracked",
+      ...(failure ? { error_code: "proxy_error", error_message: safeTaskTraceError(failure) } : {}),
+    })));
+  };
+  emit("sending", null);
+  try {
+    const result = await deps.send({
+      alias: input.alias,
+      task: input.task,
+      priority: input.priority || "normal",
+      from_session: input.fromAlias,
+    });
+    const taskId = result?.task_id || result?.message_id || result?.id || null;
+    if (result?.ok === false || result?.error) emit("failed", taskId, result?.error || "commhub rejected task");
+    else emit("delivered", taskId);
+    return result;
+  } catch (error) {
+    emit("failed", null, error);
+    throw error;
+  }
+}

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -24,6 +24,7 @@ import {
   channelAttachmentCacheDir,
   downloadChannelAttachments,
 } from "./channel-attachments";
+import { sendChannelTaskWithTrace } from "./channel-task-trace";
 
 // ── .env loader helper ────────────────────────────────
 function loadEnvFile(path: string): void {
@@ -351,13 +352,17 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req: any) => {
 
   if (name === "commhub_send_task") {
     const { alias, task, priority } = args as any;
-    const result = await callCommHub("send_task", {
-      alias,
-      task,
-      priority: priority || "normal",
-      from_session: ALIAS,
+    const result = await sendChannelTaskWithTrace({
+      alias: String(alias || ""), task: String(task || ""), priority,
+      fromAlias: ALIAS,
+      networkId: process.env.ANET_NETWORK_ID || ANET_CONFIG.network_id || null,
+    }, {
+      send: (sendArgs) => callCommHub("send_task", sendArgs),
+      log: (line) => process.env.ANET_TASK_TRACE_FORMAT === "json"
+        ? process.stderr.write(`${line}\n`)
+        : log(line),
     });
-    return { content: [{ type: "text", text: JSON.stringify(result) }] };
+    return { content: [{ type: "text", text: JSON.stringify(result) }], ...(result?.ok === false || result?.error ? { isError: true } : {}) };
   }
 
   if (name === "commhub_send_message") {

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -362,7 +362,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req: any) => {
         ? process.stderr.write(`${line}\n`)
         : log(line),
     });
-    return { content: [{ type: "text", text: JSON.stringify(result) }], ...(result?.ok === false || result?.error ? { isError: true } : {}) };
+    return { content: [{ type: "text", text: JSON.stringify(result) }] };
   }
 
   if (name === "commhub_send_message") {

--- a/agent-network/src/task-trace.ts
+++ b/agent-network/src/task-trace.ts
@@ -1,0 +1,38 @@
+export type TaskTraceTransport = "mcp_http" | "sdk_mcp_proxy" | "channel_mcp_proxy";
+export type TaskTraceStatus = "sending" | "delivered" | "failed" | "acked" | "started" | "replied" | "expired";
+
+export interface TaskTraceEvent {
+  event: string;
+  from_alias: string;
+  to_alias: string;
+  task_id: string | null;
+  parent_task_id: string | null;
+  network_id: string | null;
+  transport: TaskTraceTransport;
+  status: TaskTraceStatus;
+  duration_ms: number;
+  lifecycle_tracking: "tracked" | "not_tracked";
+  error_code?: string;
+  error_message?: string;
+}
+
+const SECRET = /(?:atok|ntok|utok|ghp|github_pat)_[A-Za-z0-9_-]+|Bearer\s+\S+/gi;
+const safeField = (value: string | null, fallback: string) =>
+  (value ?? fallback).replace(/[\r\n\x00-\x1f\x7f]/g, " ").slice(0, 240);
+
+export function safeTaskTraceError(value: unknown): string {
+  const raw = value instanceof Error ? value.message : String(value ?? "unknown error");
+  return raw.replace(SECRET, "[REDACTED]").replace(/[\r\n\x00-\x1f\x7f]/g, " ").slice(0, 240);
+}
+
+export function renderTaskTrace(event: TaskTraceEvent, json = process.env.ANET_TASK_TRACE_FORMAT === "json"): string {
+  if (json) return JSON.stringify(event);
+  const parent = safeField(event.parent_task_id, "<missing>");
+  const task = safeField(event.task_id, "<pending>");
+  const error = event.error_code ? ` error=${event.error_code}:${event.error_message ?? ""}` : "";
+  return `[commhub:task] ${event.status} from=${safeField(event.from_alias, "<unknown>")} to=${safeField(event.to_alias, "<unknown>")} task_id=${task} parent_task_id=${parent} network_id=${safeField(event.network_id, "<unknown>")} transport=${event.transport} duration_ms=${event.duration_ms} lifecycle=${event.lifecycle_tracking}${error}`;
+}
+
+export function taskTraceEvent(input: Omit<TaskTraceEvent, "event">): TaskTraceEvent {
+  return { event: `task.send.${input.status}`, ...input };
+}

--- a/agent-network/src/task-trace.ts
+++ b/agent-network/src/task-trace.ts
@@ -34,5 +34,14 @@ export function renderTaskTrace(event: TaskTraceEvent, json = process.env.ANET_T
 }
 
 export function taskTraceEvent(input: Omit<TaskTraceEvent, "event">): TaskTraceEvent {
-  return { event: `task.send.${input.status}`, ...input };
+  const names: Record<TaskTraceStatus, string> = {
+    sending: "task.send.start",
+    delivered: "task.send.delivered",
+    failed: "task.send.failed",
+    acked: "task.ack",
+    started: "task.started",
+    replied: "task.replied",
+    expired: "task.expired",
+  };
+  return { event: names[input.status], ...input };
 }

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -143,6 +143,7 @@ import {
 } from "./credential-redaction";
 import { appendPrivateLogLine, preparePrivateLogDirectory } from "./private-log";
 import { resolveNodeIdSource } from "./runtime/node-id-source";
+import { emitExplicitTaskTrace, sendExplicitTaskWithTrace, type ExplicitTaskTraceContext } from "./explicit-task-trace";
 
 const home = homedir();
 
@@ -1001,6 +1002,14 @@ const log = (msg: string) => _log("info", 1, msg);
 const debug = (msg: string) => _log("debug", 0, msg);
 const warn = (msg: string) => _log("warn", 2, msg);
 const error = (msg: string) => _log("error", 3, msg);
+const taskTraceLog = (line: string) => {
+  if (process.env.ANET_TASK_TRACE_FORMAT !== "json") return log(line);
+  console.log(line);
+  try {
+    const date = new Date().toISOString().slice(0, 10);
+    appendFileSync(join(LOG_DIR, `${date}.log`), line + "\n");
+  } catch {}
+};
 
 // ── CommHub MCP 调用 (with retry) ──
 //
@@ -4174,15 +4183,17 @@ async function tryHandleExplicitDelegation(
 
   // #146 PR-4 — fresh alias on the explicit-delegation wrapper path.
   const fromAlias = await liveAlias();
+  const traceContext: ExplicitTaskTraceContext = {
+    fromAlias, toAlias: parsed.alias, parentTaskId: taskId || null,
+    networkId: NETWORK_ID || null, startedAt: Date.now(), log: taskTraceLog,
+  };
+  const emitTrace = (status: Parameters<typeof emitExplicitTaskTrace>[1], childId: string | null, extra?: Parameters<typeof emitExplicitTaskTrace>[3]) =>
+    emitExplicitTaskTrace(traceContext, status, childId, extra);
   let sendRes: any;
   try {
-    sendRes = parseToolJson(await callCommHub("send_task", {
-      alias: parsed.alias,
-      task: parsed.childTask,
-      priority: "normal",
-      from_session: fromAlias,
-      parent_task_id: taskId || undefined,
-    }));
+    sendRes = parseToolJson(await sendExplicitTaskWithTrace({
+      alias: parsed.alias, task: parsed.childTask, priority: "normal",
+    }, traceContext, (sendArgs) => callCommHub("send_task", sendArgs)));
   } catch (e: any) {
     // #230 — if the real send_task still gets rejected by the server
     // (e.g. a TOCTOU race where the precheck saw the session but it
@@ -4203,11 +4214,21 @@ async function tryHandleExplicitDelegation(
 
   const deadline = Date.now() + 120_000;
   let latest: any = null;
+  const observed = new Set<string>();
+  let warned30 = false;
+  let warned60 = false;
   while (Date.now() < deadline) {
     latest = parseToolJson(await callCommHub("get_task", { task_id: childTaskId }));
     const row = latest?.task || latest;
     const childStatus = row?.status;
+    if ((childStatus === "acked" || childStatus === "running" || childStatus === "processing") && !observed.has(childStatus)) {
+      observed.add(childStatus);
+      emitTrace(childStatus === "acked" ? "acked" : "started", childTaskId);
+    }
     if (childStatus === "replied" || childStatus === "failed" || childStatus === "cancelled") {
+      emitTrace(childStatus === "replied" ? "replied" : "failed", childTaskId, {
+        ...(childStatus === "replied" ? {} : { errorCode: `task_${childStatus}` }),
+      });
       const result = row?.result || latest?.result || JSON.stringify(latest);
       return [
         `已通过 CommHub 给 ${parsed.alias} 派发子任务并等到结果。`,
@@ -4217,9 +4238,19 @@ async function tryHandleExplicitDelegation(
         String(result).slice(0, 1600),
       ].join("\n");
     }
+    const elapsed = Date.now() - traceContext.startedAt;
+    if (!warned30 && elapsed >= 30_000 && childStatus === "delivered") {
+      warned30 = true;
+      emitTrace("delivered", childTaskId, { event: "task.warning.delivered_stale_30s" });
+    }
+    if (!warned60 && elapsed >= 60_000 && childStatus === "delivered") {
+      warned60 = true;
+      emitTrace("delivered", childTaskId, { event: "task.warning.delivered_stale_60s" });
+    }
     await new Promise((resolve) => setTimeout(resolve, 2000));
   }
 
+  emitTrace("expired", childTaskId, { errorCode: "lifecycle_timeout" });
   return `已给 ${parsed.alias} 派发子任务 ${childTaskId}，但 120 秒内未等到 replied/failed。最新状态：${JSON.stringify(latest).slice(0, 1000)}`;
 }
 

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -4227,7 +4227,7 @@ async function tryHandleExplicitDelegation(
     }
     if (childStatus === "replied" || childStatus === "failed" || childStatus === "cancelled") {
       emitTrace(childStatus === "replied" ? "replied" : "failed", childTaskId, {
-        ...(childStatus === "replied" ? {} : { errorCode: `task_${childStatus}` }),
+        ...(childStatus === "replied" ? {} : { errorCode: `task_${childStatus}`, event: "task.failed" }),
       });
       const result = row?.result || latest?.result || JSON.stringify(latest);
       return [

--- a/agent-node/src/commhub-mcp.ts
+++ b/agent-node/src/commhub-mcp.ts
@@ -29,6 +29,7 @@
 // inside processWithClaude for the same reason — keep that pattern.)
 import type { McpSdkServerConfigWithInstance, SdkMcpToolDefinition } from "@anthropic-ai/claude-agent-sdk";
 import { z } from "zod";
+import { renderTaskTrace, safeTaskTraceError, taskTraceEvent } from "./task-trace";
 
 interface CallToolContent { type: "text"; text: string }
 
@@ -50,10 +51,43 @@ const COMMHUB_CALL_TIMEOUT_MS = 30_000;
 // invocation. Stateless: each call gets a fresh MCP session (commhub-server
 // has no per-session sticky state for tool calls). Slight overhead (2 HTTP
 // roundtrips per LLM call) but predictable and isolated.
-async function forwardToCommhub(
+export async function forwardToCommhub(
   hubUrl: string, token: string | undefined,
   toolName: string, args: unknown,
   ): Promise<{ content: CallToolContent[]; isError?: boolean }> {
+  const traceArgs = args && typeof args === "object" && !Array.isArray(args)
+    ? args as Record<string, unknown>
+    : {};
+  const traceStartedAt = Date.now();
+  const isTaskSend = toolName === "send_task";
+  const emitTrace = (status: "sending" | "delivered" | "failed", taskId: string | null, error?: unknown) => {
+    if (!isTaskSend) return;
+    process.stderr.write(`${renderTaskTrace(taskTraceEvent({
+      from_alias: String(traceArgs.from_session || "<unknown>"),
+      to_alias: String(traceArgs.alias || "<unknown>"),
+      task_id: taskId,
+      parent_task_id: typeof traceArgs.parent_task_id === "string" ? traceArgs.parent_task_id : null,
+      network_id: typeof traceArgs.network_id === "string" ? traceArgs.network_id : null,
+      transport: "sdk_mcp_proxy",
+      status,
+      duration_ms: Date.now() - traceStartedAt,
+      lifecycle_tracking: "not_tracked",
+      ...(error ? { error_code: "proxy_error", error_message: safeTaskTraceError(error) } : {}),
+    }))}\n`);
+  };
+  const finish = (result: { content: CallToolContent[]; isError?: boolean }) => {
+    if (isTaskSend) {
+      const text = result.content?.[0]?.text || "";
+      let taskId: string | null = null;
+      try {
+        const parsed = JSON.parse(text);
+        taskId = parsed?.task_id || parsed?.message_id || parsed?.id || null;
+      } catch {}
+      emitTrace(result.isError ? "failed" : "delivered", taskId, result.isError ? text : undefined);
+    }
+    return result;
+  };
+  emitTrace("sending", null);
   try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -78,7 +112,7 @@ async function forwardToCommhub(
     });
     if (!initRes.ok) {
       const t = await initRes.text().catch(() => "");
-      return { isError: true, content: [{ type: "text", text: `commhub MCP initialize failed: HTTP ${initRes.status} ${t.slice(0, 200)}` }] };
+      return finish({ isError: true, content: [{ type: "text", text: `commhub MCP initialize failed: HTTP ${initRes.status} ${t.slice(0, 200)}` }] });
     }
     const sessionId = initRes.headers.get("mcp-session-id") || initRes.headers.get("Mcp-Session-Id");
     const callHeaders = { ...headers, ...(sessionId ? { "mcp-session-id": sessionId } : {}) };
@@ -105,25 +139,25 @@ async function forwardToCommhub(
       }
     }
     if (!envelope) {
-      return { isError: true, content: [{ type: "text", text: `commhub MCP tools/call: empty response (HTTP ${callRes.status})` }] };
+      return finish({ isError: true, content: [{ type: "text", text: `commhub MCP tools/call: empty response (HTTP ${callRes.status})` }] });
     }
     if (envelope.error) {
-      return { isError: true, content: [{ type: "text", text: `commhub MCP error: ${JSON.stringify(envelope.error).slice(0, 400)}` }] };
+      return finish({ isError: true, content: [{ type: "text", text: `commhub MCP error: ${JSON.stringify(envelope.error).slice(0, 400)}` }] });
     }
     const result = envelope.result;
     if (result && Array.isArray(result.content)) {
       // Pass commhub's content blocks through verbatim (preserves the
       // existing JSON-stringified payloads from commhub tools).
-      return { content: result.content as CallToolContent[], isError: result.isError === true };
+      return finish({ content: result.content as CallToolContent[], isError: result.isError === true });
     }
-    return { content: [{ type: "text", text: JSON.stringify(result ?? envelope) }] };
+    return finish({ content: [{ type: "text", text: JSON.stringify(result ?? envelope) }] });
   } catch (e: any) {
     // AbortError surfaces with name "TimeoutError" from AbortSignal.timeout
     // (or "AbortError" in some runtimes); name the timeout case so the LLM
     // can reason about retrying versus surfacing to the operator.
     const isTimeout = e?.name === "TimeoutError" || e?.name === "AbortError";
     const label = isTimeout ? "commhub MCP timeout" : "commhub MCP transport error";
-    return { isError: true, content: [{ type: "text", text: `${label}: ${e?.message || String(e)}` }] };
+    return finish({ isError: true, content: [{ type: "text", text: `${label}: ${e?.message || String(e)}` }] });
   }
 }
 

--- a/agent-node/src/explicit-task-trace.ts
+++ b/agent-node/src/explicit-task-trace.ts
@@ -1,0 +1,60 @@
+import { renderTaskTrace, safeTaskTraceError, taskTraceEvent, type TaskTraceStatus } from "./task-trace";
+
+export interface ExplicitTaskTraceContext {
+  fromAlias: string;
+  toAlias: string;
+  parentTaskId: string | null;
+  networkId: string | null;
+  startedAt: number;
+  log: (line: string) => void;
+}
+
+export function emitExplicitTaskTrace(
+  context: ExplicitTaskTraceContext,
+  status: TaskTraceStatus,
+  taskId: string | null,
+  extra: { errorCode?: string; errorMessage?: unknown; event?: string } = {},
+): void {
+  const value = taskTraceEvent({
+    from_alias: context.fromAlias,
+    to_alias: context.toAlias,
+    task_id: taskId,
+    parent_task_id: context.parentTaskId,
+    network_id: context.networkId,
+    transport: "mcp_http",
+    status,
+    duration_ms: Date.now() - context.startedAt,
+    lifecycle_tracking: "tracked",
+    ...(extra.errorCode ? { error_code: extra.errorCode } : {}),
+    ...(extra.errorMessage ? { error_message: safeTaskTraceError(extra.errorMessage) } : {}),
+  });
+  if (extra.event) value.event = extra.event;
+  context.log(renderTaskTrace(value));
+}
+
+export async function sendExplicitTaskWithTrace(
+  input: { alias: string; task: string; priority?: string },
+  context: ExplicitTaskTraceContext,
+  send: (args: Record<string, unknown>) => Promise<any>,
+): Promise<any> {
+  emitExplicitTaskTrace(context, "sending", null);
+  try {
+    const result = await send({
+      alias: input.alias,
+      task: input.task,
+      priority: input.priority || "normal",
+      from_session: context.fromAlias,
+      parent_task_id: context.parentTaskId || undefined,
+    });
+    const taskId = result?.task_id || result?.message_id || result?.id || null;
+    if (!taskId) {
+      emitExplicitTaskTrace(context, "failed", null, { errorCode: "missing_task_id", errorMessage: "CommHub response omitted task_id" });
+    } else {
+      emitExplicitTaskTrace(context, "delivered", taskId);
+    }
+    return result;
+  } catch (error) {
+    emitExplicitTaskTrace(context, "failed", null, { errorCode: "send_failed", errorMessage: error });
+    throw error;
+  }
+}

--- a/agent-node/src/explicit-task-trace.ts
+++ b/agent-node/src/explicit-task-trace.ts
@@ -9,6 +9,19 @@ export interface ExplicitTaskTraceContext {
   log: (line: string) => void;
 }
 
+function taskIdFromResponse(result: any): string | null {
+  const direct = result?.task_id || result?.message_id || result?.id;
+  if (direct) return String(direct);
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== "string") return null;
+  try {
+    const parsed = JSON.parse(text);
+    return parsed?.task_id || parsed?.message_id || parsed?.id || null;
+  } catch {
+    return null;
+  }
+}
+
 export function emitExplicitTaskTrace(
   context: ExplicitTaskTraceContext,
   status: TaskTraceStatus,
@@ -46,7 +59,7 @@ export async function sendExplicitTaskWithTrace(
       from_session: context.fromAlias,
       parent_task_id: context.parentTaskId || undefined,
     });
-    const taskId = result?.task_id || result?.message_id || result?.id || null;
+    const taskId = taskIdFromResponse(result);
     if (!taskId) {
       emitExplicitTaskTrace(context, "failed", null, { errorCode: "missing_task_id", errorMessage: "CommHub response omitted task_id" });
     } else {

--- a/agent-node/src/task-trace.test.ts
+++ b/agent-node/src/task-trace.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { renderTaskTrace, safeTaskTraceError, taskTraceEvent } from "./task-trace";
+import { sendExplicitTaskWithTrace } from "./explicit-task-trace";
 
 describe("task trace contract", () => {
   it("renders missing parent and lifecycle scope honestly", () => {
@@ -25,5 +26,16 @@ describe("task trace contract", () => {
     });
     expect(JSON.parse(renderTaskTrace(event, true))).toEqual(event);
     expect(renderTaskTrace(event, false)).not.toContain("\n");
+  });
+
+  it("recognizes the real MCP content envelope before cli parsing", async () => {
+    const lines: string[] = [];
+    await sendExplicitTaskWithTrace({ alias: "worker", task: "x" }, {
+      fromAlias: "sender", toAlias: "worker", parentTaskId: null, networkId: null,
+      startedAt: Date.now(), log: (line) => lines.push(line),
+    }, async () => ({ content: [{ type: "text", text: JSON.stringify({ ok: true, task_id: "task_wire" }) }] }));
+    expect(lines.join("\n")).toContain("delivered");
+    expect(lines.join("\n")).toContain("task_id=task_wire");
+    expect(lines.join("\n")).not.toContain("missing_task_id");
   });
 });

--- a/agent-node/src/task-trace.test.ts
+++ b/agent-node/src/task-trace.test.ts
@@ -38,4 +38,18 @@ describe("task trace contract", () => {
     expect(lines.join("\n")).toContain("task_id=task_wire");
     expect(lines.join("\n")).not.toContain("missing_task_id");
   });
+
+  it("uses stable event names for send and observed lifecycle phases", () => {
+    const base = {
+      from_alias: "sender", to_alias: "worker", task_id: "task_1", parent_task_id: null,
+      network_id: null, transport: "mcp_http" as const, duration_ms: 1,
+      lifecycle_tracking: "tracked" as const,
+    };
+    expect(taskTraceEvent({ ...base, status: "sending" }).event).toBe("task.send.start");
+    expect(taskTraceEvent({ ...base, status: "delivered" }).event).toBe("task.send.delivered");
+    expect(taskTraceEvent({ ...base, status: "acked" }).event).toBe("task.ack");
+    expect(taskTraceEvent({ ...base, status: "started" }).event).toBe("task.started");
+    expect(taskTraceEvent({ ...base, status: "replied" }).event).toBe("task.replied");
+    expect(taskTraceEvent({ ...base, status: "expired" }).event).toBe("task.expired");
+  });
 });

--- a/agent-node/src/task-trace.test.ts
+++ b/agent-node/src/task-trace.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { renderTaskTrace, safeTaskTraceError, taskTraceEvent } from "./task-trace";
+
+describe("task trace contract", () => {
+  it("renders missing parent and lifecycle scope honestly", () => {
+    const line = renderTaskTrace(taskTraceEvent({
+      from_alias: "sender", to_alias: "worker", task_id: null, parent_task_id: null,
+      network_id: "net_x", transport: "sdk_mcp_proxy", status: "sending",
+      duration_ms: 0, lifecycle_tracking: "not_tracked",
+    }), false);
+    expect(line).toContain("parent_task_id=<missing>");
+    expect(line).toContain("transport=sdk_mcp_proxy");
+    expect(line).toContain("lifecycle=not_tracked");
+  });
+
+  it("redacts credentials from errors", () => {
+    expect(safeTaskTraceError("Bearer ntok_secret-value\nnext")).toBe("[REDACTED] next");
+  });
+
+  it("emits parseable JSON and neutralizes human log injection", () => {
+    const event = taskTraceEvent({
+      from_alias: "sender\nforged", to_alias: "worker", task_id: "task_1", parent_task_id: null,
+      network_id: null, transport: "mcp_http", status: "delivered", duration_ms: 4,
+      lifecycle_tracking: "tracked",
+    });
+    expect(JSON.parse(renderTaskTrace(event, true))).toEqual(event);
+    expect(renderTaskTrace(event, false)).not.toContain("\n");
+  });
+});

--- a/agent-node/src/task-trace.ts
+++ b/agent-node/src/task-trace.ts
@@ -1,0 +1,38 @@
+export type TaskTraceTransport = "mcp_http" | "sdk_mcp_proxy" | "channel_mcp_proxy";
+export type TaskTraceStatus = "sending" | "delivered" | "failed" | "acked" | "started" | "replied" | "expired";
+
+export interface TaskTraceEvent {
+  event: string;
+  from_alias: string;
+  to_alias: string;
+  task_id: string | null;
+  parent_task_id: string | null;
+  network_id: string | null;
+  transport: TaskTraceTransport;
+  status: TaskTraceStatus;
+  duration_ms: number;
+  lifecycle_tracking: "tracked" | "not_tracked";
+  error_code?: string;
+  error_message?: string;
+}
+
+const SECRET = /(?:atok|ntok|utok|ghp|github_pat)_[A-Za-z0-9_-]+|Bearer\s+\S+/gi;
+const safeField = (value: string | null, fallback: string) =>
+  (value ?? fallback).replace(/[\r\n\x00-\x1f\x7f]/g, " ").slice(0, 240);
+
+export function safeTaskTraceError(value: unknown): string {
+  const raw = value instanceof Error ? value.message : String(value ?? "unknown error");
+  return raw.replace(SECRET, "[REDACTED]").replace(/[\r\n\x00-\x1f\x7f]/g, " ").slice(0, 240);
+}
+
+export function renderTaskTrace(event: TaskTraceEvent, json = process.env.ANET_TASK_TRACE_FORMAT === "json"): string {
+  if (json) return JSON.stringify(event);
+  const parent = safeField(event.parent_task_id, "<missing>");
+  const task = safeField(event.task_id, "<pending>");
+  const error = event.error_code ? ` error=${event.error_code}:${event.error_message ?? ""}` : "";
+  return `[commhub:task] ${event.status} from=${safeField(event.from_alias, "<unknown>")} to=${safeField(event.to_alias, "<unknown>")} task_id=${task} parent_task_id=${parent} network_id=${safeField(event.network_id, "<unknown>")} transport=${event.transport} duration_ms=${event.duration_ms} lifecycle=${event.lifecycle_tracking}${error}`;
+}
+
+export function taskTraceEvent(input: Omit<TaskTraceEvent, "event">): TaskTraceEvent {
+  return { event: `task.send.${input.status}`, ...input };
+}

--- a/agent-node/src/task-trace.ts
+++ b/agent-node/src/task-trace.ts
@@ -34,5 +34,14 @@ export function renderTaskTrace(event: TaskTraceEvent, json = process.env.ANET_T
 }
 
 export function taskTraceEvent(input: Omit<TaskTraceEvent, "event">): TaskTraceEvent {
-  return { event: `task.send.${input.status}`, ...input };
+  const names: Record<TaskTraceStatus, string> = {
+    sending: "task.send.start",
+    delivered: "task.send.delivered",
+    failed: "task.send.failed",
+    acked: "task.ack",
+    started: "task.started",
+    replied: "task.replied",
+    expired: "task.expired",
+  };
+  return { event: names[input.status], ...input };
 }

--- a/docs/tests/report-test679-task-trace.txt
+++ b/docs/tests/report-test679-task-trace.txt
@@ -1,0 +1,54 @@
+# test679 — #167 send_task trace A-layer
+
+Date: 2026-08-10
+Base: `0fe8040394276637c60707fdc7fafd362606bc4b`
+Source commit: `032070ff1b15bbe124c54810a0bb881eb62f28ca`
+Docker image: `anet-test167:dev`
+Image ID: `sha256:91488a6b49a342e02517ae2b1f2fda3ffca13e26bb33ea70d2a9b5df60525ded`
+Embedded ENV: `TEST679_SOURCE_COMMIT=032070ff1b15bbe124c54810a0bb881eb62f28ca`
+
+## Result
+
+`RESULT: PASS`
+
+- True CommHub process + true SQLite: three independent tasks persisted through
+  `mcp_http`, `sdk_mcp_proxy`, and `channel_mcp_proxy`.
+- True-Hub entry denominator: 3/3; 17 wire assertions.
+- Wiring contract: 3 tests, 7 assertions.
+- Existing MCP identity + trace contract: 8 tests, 13 assertions.
+- `agent-node` production bundle: PASS.
+- `agent-network` typecheck, production bundles, declarations, and obfuscation: PASS.
+- Shared formatter drift gate: the two independently published package copies
+  are byte-identical.
+
+## Witnessed-red mutations
+
+All mutations first verify an exact one-count anchor and a byte-changing patch.
+Each then runs the unchanged denominator contract and exits non-zero:
+
+1. explicit entry `mcp_http` label changed — rc=1.
+2. SDK proxy `sdk_mcp_proxy` label changed — rc=1.
+3. channel proxy `channel_mcp_proxy` label changed — rc=1.
+4. SDK proxy `not_tracked` changed to `tracked` — rc=1.
+5. channel proxy `not_tracked` changed to `tracked` — rc=1.
+
+## Security and compatibility
+
+- Trace payload never includes task content, bearer token, or credential fields.
+- Credential-shaped error fragments are redacted; human fields neutralize
+  control characters; JSON mode emits parseable JSON.
+- An absent parent task is recorded as `parent_task_id=<missing>` rather than
+  silently omitted.
+- The two proxy entries explicitly emit `lifecycle=not_tracked` and never
+  fabricate ack/started/replied/stale observations.
+- The explicit-delegation path records observed ack/running/replied/failure,
+  bounded 30s/60s delivered-stale warnings, and the existing 120s timeout.
+- Send payloads, retry policy, Hub API, database, and task transition semantics
+  are unchanged.
+
+## Honest scope boundary
+
+This is #167 layer A only. A lifecycle watcher for proxy-originated tasks,
+Dashboard lifecycle presentation beyond its existing task-id association, and
+artifact structured events remain layer B. No artifact or Dashboard code was
+changed, and layer A does not claim those surfaces are complete.

--- a/docs/tests/report-test679-task-trace.txt
+++ b/docs/tests/report-test679-task-trace.txt
@@ -2,10 +2,10 @@
 
 Date: 2026-08-10
 Base: `0fe8040394276637c60707fdc7fafd362606bc4b`
-Source commit: `032070ff1b15bbe124c54810a0bb881eb62f28ca`
+Source commit: `a6bb605ccc7d8bd196a1edca30424e3068c1b7c1`
 Docker image: `anet-test167:dev`
-Image ID: `sha256:91488a6b49a342e02517ae2b1f2fda3ffca13e26bb33ea70d2a9b5df60525ded`
-Embedded ENV: `TEST679_SOURCE_COMMIT=032070ff1b15bbe124c54810a0bb881eb62f28ca`
+Image ID: `sha256:980404b4247c204517ab16663fbc257d23dabe29c7993c01fa9ad85198d8bcca`
+Embedded ENV: `TEST679_SOURCE_COMMIT=a6bb605ccc7d8bd196a1edca30424e3068c1b7c1`
 
 ## Result
 
@@ -15,7 +15,8 @@ Embedded ENV: `TEST679_SOURCE_COMMIT=032070ff1b15bbe124c54810a0bb881eb62f28ca`
   `mcp_http`, `sdk_mcp_proxy`, and `channel_mcp_proxy`.
 - True-Hub entry denominator: 3/3; 17 wire assertions.
 - Wiring contract: 3 tests, 7 assertions.
-- Existing MCP identity + trace contract: 8 tests, 13 assertions.
+- Existing MCP identity + trace contract: 9 tests, 19 assertions, including
+  exact stable event-name mapping.
 - `agent-node` production bundle: PASS.
 - `agent-network` typecheck, production bundles, declarations, and obfuscation: PASS.
 - Shared formatter drift gate: the two independently published package copies

--- a/docs/tests/report-test679-task-trace.txt
+++ b/docs/tests/report-test679-task-trace.txt
@@ -2,10 +2,10 @@
 
 Date: 2026-08-10
 Base: `0fe8040394276637c60707fdc7fafd362606bc4b`
-Source commit: `a6bb605ccc7d8bd196a1edca30424e3068c1b7c1`
+Source commit: `bfcd86d69ac0fef70d7d7ded1353a45842e068a1`
 Docker image: `anet-test167:dev`
-Image ID: `sha256:980404b4247c204517ab16663fbc257d23dabe29c7993c01fa9ad85198d8bcca`
-Embedded ENV: `TEST679_SOURCE_COMMIT=a6bb605ccc7d8bd196a1edca30424e3068c1b7c1`
+Image ID: `sha256:89ca9e891774c56eeb666de54a32f817aea315648e097789735bb2c938e14f9d`
+Embedded ENV: `TEST679_SOURCE_COMMIT=bfcd86d69ac0fef70d7d7ded1353a45842e068a1`
 
 ## Result
 
@@ -14,7 +14,8 @@ Embedded ENV: `TEST679_SOURCE_COMMIT=a6bb605ccc7d8bd196a1edca30424e3068c1b7c1`
 - True CommHub process + true SQLite: three independent tasks persisted through
   `mcp_http`, `sdk_mcp_proxy`, and `channel_mcp_proxy`.
 - True-Hub entry denominator: 3/3; 17 wire assertions.
-- Wiring contract: 3 tests, 7 assertions.
+- Wiring contract: 4 tests, 9 assertions, including the legacy channel MCP
+  response-shape compatibility gate.
 - Existing MCP identity + trace contract: 9 tests, 19 assertions, including
   exact stable event-name mapping.
 - `agent-node` production bundle: PASS.
@@ -46,6 +47,8 @@ Each then runs the unchanged denominator contract and exits non-zero:
   bounded 30s/60s delivered-stale warnings, and the existing 120s timeout.
 - Send payloads, retry policy, Hub API, database, and task transition semantics
   are unchanged.
+- Channel MCP failures retain the pre-change content-only response shape; trace
+  instrumentation does not add `isError` or otherwise change tool semantics.
 
 ## Honest scope boundary
 

--- a/docs/tests/report-test679-task-trace.txt
+++ b/docs/tests/report-test679-task-trace.txt
@@ -56,3 +56,17 @@ This is #167 layer A only. A lifecycle watcher for proxy-originated tasks,
 Dashboard lifecycle presentation beyond its existing task-id association, and
 artifact structured events remain layer B. No artifact or Dashboard code was
 changed, and layer A does not claim those surfaces are complete.
+
+The layer-A denominator is exactly these three delegation entry classes, not
+every call site whose wire operation happens to be named `send_task`. Two known
+production call sites remain outside this layer:
+
+1. RFC-030 peer reply routing in `agent-node/src/cli.ts`, which deliberately
+   creates a new routable task to wake another agent;
+2. the public `AgentClient.send()` method in `agent-network/src/client.ts`.
+
+They are recorded as known-uncovered rather than being silently counted as
+observed. In addition, the explicit-delegation polling code emits observed
+ack/start/reply/expiry and stale warnings, but test679 drives only its real-Hub
+send start/delivered boundary. A runtime test that drives the polling loop and
+makes deletion of each later lifecycle event turn red belongs to layer B.

--- a/tests/test679-task-trace/Dockerfile
+++ b/tests/test679-task-trace/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-certificates unzip python3 && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+WORKDIR /app
+ARG TEST679_SOURCE_COMMIT=unknown
+ENV TEST679_SOURCE_COMMIT=${TEST679_SOURCE_COMMIT}
+COPY agent-node /app/agent-node
+COPY agent-network /app/agent-network
+COPY server /app/server
+COPY tests/test679-task-trace /app/tests/test679-task-trace
+RUN cd /app/agent-node && bun install --silent
+RUN cd /app/agent-network && bun install --silent --ignore-scripts
+RUN cd /app/server && bun install --silent
+CMD ["/app/tests/test679-task-trace/run.sh"]

--- a/tests/test679-task-trace/run.sh
+++ b/tests/test679-task-trace/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "source_commit=${TEST679_SOURCE_COMMIT}"
+HUB_BASE=http://127.0.0.1:9679
+WORK=/tmp/test679
+mkdir -p "$WORK"
+(cd /app/server && env PORT=9679 HOST=127.0.0.1 NODE_ENV=test COMMHUB_DB="$WORK/hub.db" bun run src/index.ts >"$WORK/hub.log" 2>&1) &
+HUB_PID=$!
+trap 'kill "$HUB_PID" 2>/dev/null || true' EXIT
+for _ in $(seq 1 60); do curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && break; sleep .25; done
+curl -fsS "$HUB_BASE/health" >/dev/null
+HUB_BASE="$HUB_BASE" bun /app/tests/test679-task-trace/true-hub.ts
+bun test /app/tests/test679-task-trace/wiring.test.ts
+
+mutate_expect_red() {
+  local file="$1" from="$2" to="$3" label="$4" backup="$WORK/mutation.orig"
+  cp "$file" "$backup"
+  python3 - "$file" "$from" "$to" <<'PY'
+import pathlib, sys
+p=pathlib.Path(sys.argv[1]); old=sys.argv[2]; new=sys.argv[3]; data=p.read_text()
+if data.count(old) != 1: raise SystemExit(f"anchor count={data.count(old)} for {old!r}")
+p.write_text(data.replace(old,new,1))
+PY
+  if cmp -s "$file" "$backup"; then echo "mutation no-op: $label" >&2; exit 1; fi
+  set +e
+  bun test /app/tests/test679-task-trace/wiring.test.ts >"$WORK/$label.log" 2>&1
+  local rc=$?
+  set -e
+  cp "$backup" "$file"
+  [[ $rc -ne 0 ]] || { echo "mutation stayed green: $label" >&2; exit 1; }
+  echo "WITNESSED_RED $label rc=$rc"
+}
+
+mutate_expect_red /app/agent-node/src/explicit-task-trace.ts 'transport: "mcp_http"' 'transport: "sdk_mcp_proxy"' explicit-transport
+mutate_expect_red /app/agent-node/src/commhub-mcp.ts 'transport: "sdk_mcp_proxy"' 'transport: "mcp_http"' sdk-transport
+mutate_expect_red /app/agent-network/src/channel-task-trace.ts 'transport: "channel_mcp_proxy"' 'transport: "mcp_http"' channel-transport
+mutate_expect_red /app/agent-node/src/commhub-mcp.ts 'lifecycle_tracking: "not_tracked"' 'lifecycle_tracking: "tracked"' sdk-lifecycle
+mutate_expect_red /app/agent-network/src/channel-task-trace.ts 'lifecycle_tracking: "not_tracked"' 'lifecycle_tracking: "tracked"' channel-lifecycle
+cd /app/agent-node
+bun test src/task-trace.test.ts src/commhub-mcp.test.ts
+bun run build
+cd /app/agent-network
+bun run typecheck
+bun run build
+cmp -s /app/agent-node/src/task-trace.ts /app/agent-network/src/task-trace.ts
+echo "RESULT: PASS"

--- a/tests/test679-task-trace/true-hub.ts
+++ b/tests/test679-task-trace/true-hub.ts
@@ -1,0 +1,80 @@
+import { sendExplicitTaskWithTrace } from "/app/agent-node/src/explicit-task-trace";
+import { forwardToCommhub } from "/app/agent-node/src/commhub-mcp";
+import { sendChannelTaskWithTrace } from "/app/agent-network/src/channel-task-trace";
+
+const hub = process.env.HUB_BASE || "http://127.0.0.1:9679";
+
+async function json(path: string, init: RequestInit = {}) {
+  const response = await fetch(`${hub}${path}`, init);
+  const body = await response.json() as any;
+  if (!response.ok) throw new Error(`${path}: ${response.status} ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function mcp(token: string, name: string, args: Record<string, unknown>) {
+  const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream", Authorization: `Bearer ${token}` };
+  await fetch(`${hub}/mcp`, { method: "POST", headers, body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test679", version: "1" } } }) });
+  const response = await fetch(`${hub}/mcp`, { method: "POST", headers, body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name, arguments: args } }) });
+  const raw = await response.text();
+  const frame = raw.split(/\r?\n/).find((line) => line.startsWith("data: "))?.slice(6) || raw;
+  const envelope = JSON.parse(frame);
+  const text = envelope?.result?.content?.[0]?.text;
+  const value = typeof text === "string" ? JSON.parse(text) : envelope?.result;
+  if (envelope?.error || value?.ok === false) throw new Error(JSON.stringify(envelope?.error || value));
+  return value;
+}
+
+const reg = await json("/api/auth/register", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ username: "trace-owner", password: "Trace_test_679!", email: "trace@test.local" }) });
+const utok = reg.token as string;
+const me = await json("/api/auth/me", { headers: { Authorization: `Bearer ${utok}` } });
+const networkId = me.networks[0].network_id as string;
+
+async function node(alias: string) {
+  const minted = await json("/api/auth/node-token", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${utok}` }, body: JSON.stringify({ network_id: networkId, node_name: alias }) });
+  await mcp(minted.token, "report_status", { resume_id: `test679-${alias}`, alias, status: "idle", network_id: networkId });
+  return minted.token as string;
+}
+
+const senderToken = await node("trace-sender");
+await node("trace-explicit");
+await node("trace-sdk");
+await node("trace-channel");
+
+const explicitLines: string[] = [];
+await sendExplicitTaskWithTrace({ alias: "trace-explicit", task: "explicit true hub" }, {
+  fromAlias: "trace-sender", toAlias: "trace-explicit", parentTaskId: null,
+  networkId, startedAt: Date.now(), log: (line) => explicitLines.push(line),
+}, (args) => mcp(senderToken, "send_task", args));
+
+const sdkLines: string[] = [];
+const stderrWrite = process.stderr.write.bind(process.stderr);
+(process.stderr as any).write = (chunk: any) => { sdkLines.push(String(chunk).trim()); return true; };
+const sdkResult = await forwardToCommhub(hub, senderToken, "send_task", { alias: "trace-sdk", task: "sdk true hub", from_session: "trace-sender", network_id: networkId });
+(process.stderr as any).write = stderrWrite;
+if (sdkResult.isError) throw new Error(`sdk send failed: ${JSON.stringify(sdkResult)}`);
+
+const channelLines: string[] = [];
+await sendChannelTaskWithTrace({ alias: "trace-channel", task: "channel true hub", fromAlias: "trace-sender", networkId }, {
+  send: (args) => mcp(senderToken, "send_task", args), log: (line) => channelLines.push(line),
+});
+
+const groups = [explicitLines, sdkLines, channelLines];
+const transports = ["mcp_http", "sdk_mcp_proxy", "channel_mcp_proxy"];
+for (let i = 0; i < groups.length; i++) {
+  const joined = groups[i].join("\n");
+  if (!joined.includes(`transport=${transports[i]}`)) throw new Error(`missing transport ${transports[i]}: ${joined}`);
+  if (!joined.includes("sending") || !joined.includes("delivered")) throw new Error(`missing send lifecycle for ${transports[i]}: ${joined}`);
+}
+if (!explicitLines.join("\n").includes("parent_task_id=<missing>")) throw new Error("missing parent must be explicit");
+for (const lines of [sdkLines, channelLines]) {
+  const joined = lines.join("\n");
+  if (!joined.includes("lifecycle=not_tracked")) throw new Error(`proxy lifecycle scope hidden: ${joined}`);
+  if (/\b(replied|delivered_stale)\b/.test(joined)) throw new Error(`proxy fabricated lifecycle: ${joined}`);
+}
+const all = groups.flat().join("\n");
+if (/ntok_|utok_|Bearer\s/.test(all)) throw new Error("trace leaked credentials");
+const tasks = await json(`/api/tasks?network_id=${encodeURIComponent(networkId)}`, { headers: { Authorization: `Bearer ${utok}` } });
+const contents = new Set((tasks.tasks || tasks || []).map((row: any) => row.content));
+for (const expected of ["explicit true hub", "sdk true hub", "channel true hub"]) if (!contents.has(expected)) throw new Error(`true hub missing ${expected}`);
+console.log("TRUE_HUB_ENTRY_COUNT=3");
+console.log("TRUE_HUB_TRACE_ASSERTIONS=17");

--- a/tests/test679-task-trace/wiring.test.ts
+++ b/tests/test679-task-trace/wiring.test.ts
@@ -27,4 +27,10 @@ describe("#167 three-entry trace denominator", () => {
     expect(read("agent-node/src/commhub-mcp.ts")).toContain('toolName === "send_task"');
     expect(read("agent-network/src/node-server.ts")).toContain("sendChannelTaskWithTrace");
   });
+
+  it("keeps the channel MCP response shape byte-compatible", () => {
+    const channel = read("agent-network/src/node-server.ts");
+    expect(channel).toContain('return { content: [{ type: "text", text: JSON.stringify(result) }] };');
+    expect(channel).not.toContain('...(result?.ok === false || result?.error ? { isError: true } : {})');
+  });
 });

--- a/tests/test679-task-trace/wiring.test.ts
+++ b/tests/test679-task-trace/wiring.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const read = (path: string) => readFileSync(`/app/${path}`, "utf8");
+
+describe("#167 three-entry trace denominator", () => {
+  it("pins every production entry to its exact transport", () => {
+    const explicit = read("agent-node/src/explicit-task-trace.ts");
+    const sdk = read("agent-node/src/commhub-mcp.ts");
+    const channel = read("agent-network/src/channel-task-trace.ts");
+    const labels = [
+      [explicit, 'transport: "mcp_http"'],
+      [sdk, 'transport: "sdk_mcp_proxy"'],
+      [channel, 'transport: "channel_mcp_proxy"'],
+    ] as const;
+    expect(labels.filter(([source, anchor]) => source.includes(anchor))).toHaveLength(3);
+  });
+
+  it("keeps proxy lifecycle explicitly untracked", () => {
+    expect(read("agent-node/src/commhub-mcp.ts")).toContain('lifecycle_tracking: "not_tracked"');
+    expect(read("agent-network/src/channel-task-trace.ts")).toContain('lifecycle_tracking: "not_tracked"');
+    expect(read("agent-node/src/explicit-task-trace.ts")).toContain('lifecycle_tracking: "tracked"');
+  });
+
+  it("wires helpers into all three production entry files", () => {
+    expect(read("agent-node/src/cli.ts")).toContain("sendExplicitTaskWithTrace");
+    expect(read("agent-node/src/commhub-mcp.ts")).toContain('toolName === "send_task"');
+    expect(read("agent-network/src/node-server.ts")).toContain("sendChannelTaskWithTrace");
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared, secret-safe human/JSON task trace contract to agent-node and agent-network
- instrument three delegation entry classes with exact transport labels
- keep proxy lifecycle explicitly `not_tracked`; record full observed lifecycle only in explicit delegation
- preserve missing `parent_task_id` as an observable value
- pin stable event names and preserve the legacy channel MCP response shape

## Verification
- exact source: `0f4bb7d4cf6c18defebc3b343c66e8db15ecf9c9`
- report-only head: `e0e018a901271bff8951d33745ca63359b67777b`
- Docker image: `sha256:77625864bc4cee8d27caf09341002cfa499e4b537c7f6896a1bd02be52df5ea6`
- true Hub + SQLite: 3/3 scoped entry classes, 17 wire assertions
- 13 Bun tests / 28 assertions beyond true-Hub harness
- 6/6 exact, byte-changing mutations witnessed red
- both production packages build/typecheck

## Honest boundary
This is #167 layer A, not every production `send_task` call site. Known-uncovered: RFC-030 peer-reply `send_task` in agent-node and public `AgentClient.send()` in agent-network. Proxy lifecycle watchers, explicit-delegation late-lifecycle runtime mutation coverage, Dashboard lifecycle expansion, and artifact structured events remain layer B. #167 stays open.

Refs #167
