### PR TITLE
test: harden send_task response-shape gate

### DIFF
--- a/docs/tests/report-test679-task-trace.txt
+++ b/docs/tests/report-test679-task-trace.txt
@@ -2,10 +2,10 @@
 
 Date: 2026-08-10
 Base: `0fe8040394276637c60707fdc7fafd362606bc4b`
-Source commit: `bfcd86d69ac0fef70d7d7ded1353a45842e068a1`
+Source commit: `8128b97c90b15746df32be0fd05c3e5475bf8dc4`
 Docker image: `anet-test167:dev`
-Image ID: `sha256:89ca9e891774c56eeb666de54a32f817aea315648e097789735bb2c938e14f9d`
-Embedded ENV: `TEST679_SOURCE_COMMIT=bfcd86d69ac0fef70d7d7ded1353a45842e068a1`
+Image ID: `sha256:f61cf96bf6c3e53d491706aaf6cb1f6cf948a97922a7395a35be1085a7de836a`
+Embedded ENV: `TEST679_SOURCE_COMMIT=8128b97c90b15746df32be0fd05c3e5475bf8dc4`
 
 ## Result
 
@@ -33,6 +33,7 @@ Each then runs the unchanged denominator contract and exits non-zero:
 3. channel proxy `channel_mcp_proxy` label changed — rc=1.
 4. SDK proxy `not_tracked` changed to `tracked` — rc=1.
 5. channel proxy `not_tracked` changed to `tracked` — rc=1.
+6. channel MCP failure response adds `isError: true` — rc=1.
 
 ## Security and compatibility
 

--- a/tests/test679-task-trace/Dockerfile
+++ b/tests/test679-task-trace/Dockerfile
@@ -8,8 +8,8 @@ ENV TEST679_SOURCE_COMMIT=${TEST679_SOURCE_COMMIT}
 COPY agent-node /app/agent-node
 COPY agent-network /app/agent-network
 COPY server /app/server
-COPY tests/test679-task-trace /app/tests/test679-task-trace
 RUN cd /app/agent-node && bun install --silent
 RUN cd /app/agent-network && bun install --silent --ignore-scripts
 RUN cd /app/server && bun install --silent
+COPY tests/test679-task-trace /app/tests/test679-task-trace
 CMD ["/app/tests/test679-task-trace/run.sh"]

--- a/tests/test679-task-trace/Dockerfile
+++ b/tests/test679-task-trace/Dockerfile
@@ -3,13 +3,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-ce
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 WORKDIR /app
-ARG TEST679_SOURCE_COMMIT=unknown
-ENV TEST679_SOURCE_COMMIT=${TEST679_SOURCE_COMMIT}
 COPY agent-node /app/agent-node
 COPY agent-network /app/agent-network
 COPY server /app/server
 RUN cd /app/agent-node && bun install --silent
 RUN cd /app/agent-network && bun install --silent --ignore-scripts
 RUN cd /app/server && bun install --silent
+ARG TEST679_SOURCE_COMMIT=unknown
+ENV TEST679_SOURCE_COMMIT=${TEST679_SOURCE_COMMIT}
 COPY tests/test679-task-trace /app/tests/test679-task-trace
 CMD ["/app/tests/test679-task-trace/run.sh"]

--- a/tests/test679-task-trace/run.sh
+++ b/tests/test679-task-trace/run.sh
@@ -36,6 +36,7 @@ mutate_expect_red /app/agent-node/src/commhub-mcp.ts 'transport: "sdk_mcp_proxy"
 mutate_expect_red /app/agent-network/src/channel-task-trace.ts 'transport: "channel_mcp_proxy"' 'transport: "mcp_http"' channel-transport
 mutate_expect_red /app/agent-node/src/commhub-mcp.ts 'lifecycle_tracking: "not_tracked"' 'lifecycle_tracking: "tracked"' sdk-lifecycle
 mutate_expect_red /app/agent-network/src/channel-task-trace.ts 'lifecycle_tracking: "not_tracked"' 'lifecycle_tracking: "tracked"' channel-lifecycle
+mutate_expect_red /app/agent-network/src/node-server.ts 'return { content: [{ type: "text", text: JSON.stringify(result) }] };' 'return { content: [{ type: "text", text: JSON.stringify(result) }], isError: true };' channel-response-shape
 cd /app/agent-node
 bun test src/task-trace.test.ts src/commhub-mcp.test.ts
 bun run build

--- a/tests/test679-task-trace/run.sh
+++ b/tests/test679-task-trace/run.sh
@@ -36,7 +36,10 @@ mutate_expect_red /app/agent-node/src/commhub-mcp.ts 'transport: "sdk_mcp_proxy"
 mutate_expect_red /app/agent-network/src/channel-task-trace.ts 'transport: "channel_mcp_proxy"' 'transport: "mcp_http"' channel-transport
 mutate_expect_red /app/agent-node/src/commhub-mcp.ts 'lifecycle_tracking: "not_tracked"' 'lifecycle_tracking: "tracked"' sdk-lifecycle
 mutate_expect_red /app/agent-network/src/channel-task-trace.ts 'lifecycle_tracking: "not_tracked"' 'lifecycle_tracking: "tracked"' channel-lifecycle
-mutate_expect_red /app/agent-network/src/node-server.ts 'return { content: [{ type: "text", text: JSON.stringify(result) }] };' 'return { content: [{ type: "text", text: JSON.stringify(result) }], isError: true };' channel-response-shape
+mutate_expect_red /app/agent-network/src/node-server.ts \
+  $'    return { content: [{ type: "text", text: JSON.stringify(result) }] };\n  }\n\n  if (name === "commhub_send_message")' \
+  $'    return { content: [{ type: "text", text: JSON.stringify(result) }], isError: true };\n  }\n\n  if (name === "commhub_send_message")' \
+  channel-response-shape
 cd /app/agent-node
 bun test src/task-trace.test.ts src/commhub-mcp.test.ts
 bun run build

--- a/tests/test679-task-trace/wiring.test.ts
+++ b/tests/test679-task-trace/wiring.test.ts
@@ -30,7 +30,12 @@ describe("#167 three-entry trace denominator", () => {
 
   it("keeps the channel MCP response shape byte-compatible", () => {
     const channel = read("agent-network/src/node-server.ts");
-    expect(channel).toContain('return { content: [{ type: "text", text: JSON.stringify(result) }] };');
+    expect(channel).toContain([
+      '    return { content: [{ type: "text", text: JSON.stringify(result) }] };',
+      '  }',
+      '',
+      '  if (name === "commhub_send_message")',
+    ].join("\n"));
     expect(channel).not.toContain('...(result?.ok === false || result?.error ? { isError: true } : {})');
   });
 });


### PR DESCRIPTION
## Summary
- add a load-bearing regression mutation for the channel MCP response shape merged in #679
- make the wiring assertion target the exact handler boundary rather than any of several similar response literals
- reorder Docker copies so dependency installation remains cacheable while the exact harness source is embedded
- refresh exact-SHA Docker evidence; production source is unchanged

## Verification
- base: `45ca09853922f1be8574b84e932b404b9cc2f778` (#679 squash merge)
- exact source: `8128b97c90b15746df32be0fd05c3e5475bf8dc4`
- report-only head: `8c9bb9fdbae984ef3205f8e65e86dba00ea901cc`
- Docker image: `sha256:f61cf96bf6c3e53d491706aaf6cb1f6cf948a97922a7395a35be1085a7de836a`
- true Hub + SQLite: 3/3 entry classes, 17 assertions
- wiring: 4 tests / 9 assertions
- existing agent-node tests: 9 tests / 19 assertions
- 6/6 exact, byte-changing mutations witnessed red
- both production packages build/typecheck

## Scope
Tests and report only: four files under `tests/test679-task-trace/` and `docs/tests/`. No production, API, schema, runtime, Dashboard, or deployment changes.

Refs #167
