### PR TITLE
test: exercise explicit delegation lifecycle tracing

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -143,7 +143,7 @@ import {
 } from "./credential-redaction";
 import { appendPrivateLogLine, preparePrivateLogDirectory } from "./private-log";
 import { resolveNodeIdSource } from "./runtime/node-id-source";
-import { emitExplicitTaskTrace, sendExplicitTaskWithTrace, type ExplicitTaskTraceContext } from "./explicit-task-trace";
+import { emitExplicitTaskTrace, sendExplicitTaskWithTrace, waitForExplicitTaskLifecycle, type ExplicitTaskTraceContext } from "./explicit-task-trace";
 
 const home = homedir();
 
@@ -4212,46 +4212,21 @@ async function tryHandleExplicitDelegation(
     return `已尝试给 ${parsed.alias} 派任务，但 CommHub 未返回 task_id：${JSON.stringify(sendRes).slice(0, 1000)}`;
   }
 
-  const deadline = Date.now() + 120_000;
-  let latest: any = null;
-  const observed = new Set<string>();
-  let warned30 = false;
-  let warned60 = false;
-  while (Date.now() < deadline) {
-    latest = parseToolJson(await callCommHub("get_task", { task_id: childTaskId }));
-    const row = latest?.task || latest;
-    const childStatus = row?.status;
-    if ((childStatus === "acked" || childStatus === "running" || childStatus === "processing") && !observed.has(childStatus)) {
-      observed.add(childStatus);
-      emitTrace(childStatus === "acked" ? "acked" : "started", childTaskId);
-    }
-    if (childStatus === "replied" || childStatus === "failed" || childStatus === "cancelled") {
-      emitTrace(childStatus === "replied" ? "replied" : "failed", childTaskId, {
-        ...(childStatus === "replied" ? {} : { errorCode: `task_${childStatus}`, event: "task.failed" }),
-      });
-      const result = row?.result || latest?.result || JSON.stringify(latest);
-      return [
-        `已通过 CommHub 给 ${parsed.alias} 派发子任务并等到结果。`,
-        `子任务：${childTaskId}`,
-        `状态：${childStatus}`,
-        ``,
-        String(result).slice(0, 1600),
-      ].join("\n");
-    }
-    const elapsed = Date.now() - traceContext.startedAt;
-    if (!warned30 && elapsed >= 30_000 && childStatus === "delivered") {
-      warned30 = true;
-      emitTrace("delivered", childTaskId, { event: "task.warning.delivered_stale_30s" });
-    }
-    if (!warned60 && elapsed >= 60_000 && childStatus === "delivered") {
-      warned60 = true;
-      emitTrace("delivered", childTaskId, { event: "task.warning.delivered_stale_60s" });
-    }
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+  const lifecycle = await waitForExplicitTaskLifecycle(childTaskId, traceContext.startedAt, {
+    getTask: async (id) => parseToolJson(await callCommHub("get_task", { task_id: id })),
+    emit: emitTrace,
+  });
+  if (lifecycle.kind === "terminal") {
+    const result = lifecycle.row?.result || lifecycle.latest?.result || JSON.stringify(lifecycle.latest);
+    return [
+      `已通过 CommHub 给 ${parsed.alias} 派发子任务并等到结果。`,
+      `子任务：${childTaskId}`,
+      `状态：${lifecycle.status}`,
+      ``,
+      String(result).slice(0, 1600),
+    ].join("\n");
   }
-
-  emitTrace("expired", childTaskId, { errorCode: "lifecycle_timeout" });
-  return `已给 ${parsed.alias} 派发子任务 ${childTaskId}，但 120 秒内未等到 replied/failed。最新状态：${JSON.stringify(latest).slice(0, 1000)}`;
+  return `已给 ${parsed.alias} 派发子任务 ${childTaskId}，但 120 秒内未等到 replied/failed。最新状态：${JSON.stringify(lifecycle.latest).slice(0, 1000)}`;
 }
 
 // ══════════════════════════════════════

--- a/agent-node/src/explicit-task-lifecycle.test.ts
+++ b/agent-node/src/explicit-task-lifecycle.test.ts
@@ -12,13 +12,23 @@ function harness(statuses: Array<Record<string, unknown>>, options: {
   let now = options.startedAt ?? 0;
   let index = 0;
   const emissions: ExplicitTaskLifecycleEmission[] = [];
+  const emissionTimes: number[] = [];
+  const sleepDelays: number[] = [];
   return {
     emissions,
+    emissionTimes,
+    sleepDelays,
     run: () => waitForExplicitTaskLifecycle("task_child", options.startedAt ?? 0, {
       getTask: async () => statuses[Math.min(index++, statuses.length - 1)],
-      emit: (status, taskId, extra) => emissions.push({ status, taskId, extra }),
+      emit: (status, taskId, extra) => {
+        emissions.push({ status, taskId, extra });
+        emissionTimes.push(now);
+      },
       now: () => now,
-      sleep: async (ms) => { now += ms; },
+      sleep: async (ms) => {
+        sleepDelays.push(ms);
+        now += ms;
+      },
       timeoutMs: options.timeoutMs,
       pollIntervalMs: options.pollIntervalMs,
       stale30Ms: options.stale30Ms,
@@ -67,6 +77,15 @@ describe("explicit delegation lifecycle trace", () => {
       "expired",
     ]);
     expect(h.emissions.at(-1)?.extra?.errorCode).toBe("lifecycle_timeout");
+  });
+
+  it("pins the production poll, stale-warning, and timeout defaults", async () => {
+    const h = harness([{ task: { status: "delivered" } }]);
+    const outcome = await h.run();
+    expect(outcome.kind).toBe("expired");
+    expect(h.sleepDelays).toHaveLength(60);
+    expect(new Set(h.sleepDelays)).toEqual(new Set([2_000]));
+    expect(h.emissionTimes).toEqual([30_000, 60_000, 120_000]);
   });
 
   it("maps failed and cancelled terminal states to a failed trace without retrying", async () => {

--- a/agent-node/src/explicit-task-lifecycle.test.ts
+++ b/agent-node/src/explicit-task-lifecycle.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { waitForExplicitTaskLifecycle, type ExplicitTaskLifecycleEmission } from "./explicit-task-trace";
+
+function harness(statuses: Array<Record<string, unknown>>, options: {
+  startedAt?: number;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  stale30Ms?: number;
+  stale60Ms?: number;
+} = {}) {
+  let now = options.startedAt ?? 0;
+  let index = 0;
+  const emissions: ExplicitTaskLifecycleEmission[] = [];
+  return {
+    emissions,
+    run: () => waitForExplicitTaskLifecycle("task_child", options.startedAt ?? 0, {
+      getTask: async () => statuses[Math.min(index++, statuses.length - 1)],
+      emit: (status, taskId, extra) => emissions.push({ status, taskId, extra }),
+      now: () => now,
+      sleep: async (ms) => { now += ms; },
+      timeoutMs: options.timeoutMs,
+      pollIntervalMs: options.pollIntervalMs,
+      stale30Ms: options.stale30Ms,
+      stale60Ms: options.stale60Ms,
+    }),
+  };
+}
+
+describe("explicit delegation lifecycle trace", () => {
+  it("keeps the production delegation loop wired through the tested state machine", () => {
+    const cli = readFileSync(new URL("./cli.ts", import.meta.url), "utf8");
+    expect(cli.match(/await waitForExplicitTaskLifecycle\(/g)?.length).toBe(1);
+    expect(cli).toContain([
+      "const lifecycle = await waitForExplicitTaskLifecycle(childTaskId, traceContext.startedAt, {",
+      "    getTask: async (id) => parseToolJson(await callCommHub(\"get_task\", { task_id: id })),",
+      "    emit: emitTrace,",
+      "  });",
+    ].join("\n"));
+  });
+
+  it("emits ack, start, and reply from the production polling state machine", async () => {
+    const h = harness([
+      { task: { status: "delivered" } },
+      { task: { status: "acked" } },
+      { task: { status: "running" } },
+      { task: { status: "replied", result: "done" } },
+    ]);
+    const outcome = await h.run();
+    expect(outcome.kind).toBe("terminal");
+    expect(outcome.status).toBe("replied");
+    expect(h.emissions.map((entry) => entry.status)).toEqual(["acked", "started", "replied"]);
+  });
+
+  it("emits both bounded stale warnings and expiry when delivery never advances", async () => {
+    const h = harness([{ task: { status: "delivered" } }], {
+      timeoutMs: 30,
+      pollIntervalMs: 10,
+      stale30Ms: 10,
+      stale60Ms: 20,
+    });
+    const outcome = await h.run();
+    expect(outcome.kind).toBe("expired");
+    expect(h.emissions.map((entry) => entry.extra?.event ?? entry.status)).toEqual([
+      "task.warning.delivered_stale_30s",
+      "task.warning.delivered_stale_60s",
+      "expired",
+    ]);
+    expect(h.emissions.at(-1)?.extra?.errorCode).toBe("lifecycle_timeout");
+  });
+
+  it("maps failed and cancelled terminal states to a failed trace without retrying", async () => {
+    for (const status of ["failed", "cancelled"] as const) {
+      const h = harness([{ status }]);
+      const outcome = await h.run();
+      expect(outcome.kind).toBe("terminal");
+      expect(outcome.status).toBe(status);
+      expect(h.emissions).toEqual([{
+        status: "failed",
+        taskId: "task_child",
+        extra: { errorCode: `task_${status}`, event: "task.failed" },
+      }]);
+    }
+  });
+});

--- a/agent-node/src/explicit-task-trace.ts
+++ b/agent-node/src/explicit-task-trace.ts
@@ -9,6 +9,29 @@ export interface ExplicitTaskTraceContext {
   log: (line: string) => void;
 }
 
+export type ExplicitTaskTraceExtra = { errorCode?: string; errorMessage?: unknown; event?: string };
+
+export interface ExplicitTaskLifecycleEmission {
+  status: TaskTraceStatus;
+  taskId: string | null;
+  extra?: ExplicitTaskTraceExtra;
+}
+
+export type ExplicitTaskLifecycleOutcome =
+  | { kind: "terminal"; status: "replied" | "failed" | "cancelled"; latest: any; row: any }
+  | { kind: "expired"; latest: any };
+
+export interface ExplicitTaskLifecycleDependencies {
+  getTask: (taskId: string) => Promise<any>;
+  emit: (status: TaskTraceStatus, taskId: string | null, extra?: ExplicitTaskTraceExtra) => void;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  stale30Ms?: number;
+  stale60Ms?: number;
+}
+
 function taskIdFromResponse(result: any): string | null {
   const direct = result?.task_id || result?.message_id || result?.id;
   if (direct) return String(direct);
@@ -26,7 +49,7 @@ export function emitExplicitTaskTrace(
   context: ExplicitTaskTraceContext,
   status: TaskTraceStatus,
   taskId: string | null,
-  extra: { errorCode?: string; errorMessage?: unknown; event?: string } = {},
+  extra: ExplicitTaskTraceExtra = {},
 ): void {
   const value = taskTraceEvent({
     from_alias: context.fromAlias,
@@ -43,6 +66,54 @@ export function emitExplicitTaskTrace(
   });
   if (extra.event) value.event = extra.event;
   context.log(renderTaskTrace(value));
+}
+
+export async function waitForExplicitTaskLifecycle(
+  taskId: string,
+  startedAt: number,
+  dependencies: ExplicitTaskLifecycleDependencies,
+): Promise<ExplicitTaskLifecycleOutcome> {
+  const now = dependencies.now ?? Date.now;
+  const sleep = dependencies.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const timeoutMs = dependencies.timeoutMs ?? 120_000;
+  const pollIntervalMs = dependencies.pollIntervalMs ?? 2_000;
+  const stale30Ms = dependencies.stale30Ms ?? 30_000;
+  const stale60Ms = dependencies.stale60Ms ?? 60_000;
+  const emit = dependencies.emit;
+  const deadline = now() + timeoutMs;
+  let latest: any = null;
+  const observed = new Set<string>();
+  let warned30 = false;
+  let warned60 = false;
+
+  while (now() < deadline) {
+    latest = await dependencies.getTask(taskId);
+    const row = latest?.task || latest;
+    const childStatus = row?.status;
+    if ((childStatus === "acked" || childStatus === "running" || childStatus === "processing") && !observed.has(childStatus)) {
+      observed.add(childStatus);
+      emit(childStatus === "acked" ? "acked" : "started", taskId);
+    }
+    if (childStatus === "replied" || childStatus === "failed" || childStatus === "cancelled") {
+      emit(childStatus === "replied" ? "replied" : "failed", taskId, {
+        ...(childStatus === "replied" ? {} : { errorCode: `task_${childStatus}`, event: "task.failed" }),
+      });
+      return { kind: "terminal", status: childStatus, latest, row };
+    }
+    const elapsed = now() - startedAt;
+    if (!warned30 && elapsed >= stale30Ms && childStatus === "delivered") {
+      warned30 = true;
+      emit("delivered", taskId, { event: "task.warning.delivered_stale_30s" });
+    }
+    if (!warned60 && elapsed >= stale60Ms && childStatus === "delivered") {
+      warned60 = true;
+      emit("delivered", taskId, { event: "task.warning.delivered_stale_60s" });
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  emit("expired", taskId, { errorCode: "lifecycle_timeout" });
+  return { kind: "expired", latest };
 }
 
 export async function sendExplicitTaskWithTrace(

--- a/docs/tests/report-test681-explicit-lifecycle.txt
+++ b/docs/tests/report-test681-explicit-lifecycle.txt
@@ -2,10 +2,10 @@
 
 Date: 2026-08-10
 Base: `45ca09853922f1be8574b84e932b404b9cc2f778`
-Source commit: `f8521d58b32efc96558cbfb67df38a7bcc6a17ae`
+Source commit: `3dc31f2d9258521be975d5317c48d3865928d6cf`
 Docker image: `anet-test167-b1:dev`
-Image ID: `sha256:13143a4a84849b327236d05173e9d152c8545cf858d9c4e9da894275c3d5bf25`
-Embedded ENV: `TEST681_SOURCE_COMMIT=f8521d58b32efc96558cbfb67df38a7bcc6a17ae`
+Image ID: `sha256:26386c8f5e8801339b2855963024603ec684f6de091fec4ed6b432887add21de`
+Embedded ENV: `TEST681_SOURCE_COMMIT=3dc31f2d9258521be975d5317c48d3865928d6cf`
 
 ## Witnessed red
 
@@ -20,7 +20,7 @@ whose late polling emissions were unexercised.
 
 `RESULT: PASS`
 
-- Production state-machine contract: 4 tests, 14 assertions.
+- Production state-machine contract: 5 tests, 18 assertions.
 - `delivered -> acked -> running -> replied` emits exactly
   `task.ack`, `task.started`, and `task.replied` through the existing formatter.
 - A permanently delivered task emits the bounded 30s and 60s warnings, then
@@ -41,6 +41,10 @@ patch, and runs the unchanged tests. All exited rc=1:
 4. 60-second stale warning event renamed;
 5. expiry event mapped to failed;
 6. production lifecycle emitter replaced with a no-op.
+7. timeout default changed from 120 seconds;
+8. polling default changed from 2 seconds;
+9. first stale threshold changed from 30 seconds;
+10. second stale threshold changed from 60 seconds.
 
 ## Behavior boundary
 

--- a/docs/tests/report-test681-explicit-lifecycle.txt
+++ b/docs/tests/report-test681-explicit-lifecycle.txt
@@ -1,0 +1,56 @@
+# test681 — #167 explicit delegation lifecycle trace gate
+
+Date: 2026-08-10
+Base: `45ca09853922f1be8574b84e932b404b9cc2f778`
+Source commit: `f8521d58b32efc96558cbfb67df38a7bcc6a17ae`
+Docker image: `anet-test167-b1:dev`
+Image ID: `sha256:13143a4a84849b327236d05173e9d152c8545cf858d9c4e9da894275c3d5bf25`
+Embedded ENV: `TEST681_SOURCE_COMMIT=f8521d58b32efc96558cbfb67df38a7bcc6a17ae`
+
+## Witnessed red
+
+Before the lifecycle helper existed, the unchanged Docker test exited rc=1:
+
+`Export named 'waitForExplicitTaskLifecycle' not found`
+
+This establishes that the test does not pass against the #679 implementation
+whose late polling emissions were unexercised.
+
+## Result
+
+`RESULT: PASS`
+
+- Production state-machine contract: 4 tests, 14 assertions.
+- `delivered -> acked -> running -> replied` emits exactly
+  `task.ack`, `task.started`, and `task.replied` through the existing formatter.
+- A permanently delivered task emits the bounded 30s and 60s warnings, then
+  `task.expired` with `lifecycle_timeout` at the existing 120s bound.
+- `failed` and `cancelled` remain terminal and emit `task.failed` without retry.
+- The production `tryHandleExplicitDelegation` path is pinned to the tested
+  state machine; the test is not a disconnected helper-only contract.
+- The production agent-node bundle builds successfully.
+
+## Witnessed-red mutations
+
+Each mutation requires an exact one-count anchor, verifies a byte-changing
+patch, and runs the unchanged tests. All exited rc=1:
+
+1. ack event mapped to started;
+2. replied event mapped to failed;
+3. 30-second stale warning event renamed;
+4. 60-second stale warning event renamed;
+5. expiry event mapped to failed;
+6. production lifecycle emitter replaced with a no-op.
+
+## Behavior boundary
+
+The extraction preserves the existing production defaults: 2-second polling,
+30/60-second delivered warnings, 120-second timeout, status mapping, result
+formatting, and CommHub `get_task` transport. Clock/sleep thresholds are
+injectable only at the internal test seam so the real-duration state machine is
+covered without a two-minute test.
+
+This closes the explicit-delegation late-lifecycle test gap recorded after
+#679. It does not add proxy lifecycle watchers, Dashboard lifecycle UI, artifact
+events, or coverage for the two known-uncovered `send_task` call sites; those
+remain #167 layer B work.

--- a/tests/test681-explicit-lifecycle/Dockerfile
+++ b/tests/test681-explicit-lifecycle/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-certificates unzip python3 && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+WORKDIR /app
+ARG TEST681_SOURCE_COMMIT=red
+ENV TEST681_SOURCE_COMMIT=${TEST681_SOURCE_COMMIT}
+COPY agent-node /app/agent-node
+RUN cd /app/agent-node && bun install --silent
+COPY tests/test681-explicit-lifecycle /app/tests/test681-explicit-lifecycle
+CMD ["/app/tests/test681-explicit-lifecycle/run.sh"]

--- a/tests/test681-explicit-lifecycle/Dockerfile
+++ b/tests/test681-explicit-lifecycle/Dockerfile
@@ -5,7 +5,8 @@ ENV PATH="/root/.bun/bin:${PATH}"
 WORKDIR /app
 ARG TEST681_SOURCE_COMMIT=red
 ENV TEST681_SOURCE_COMMIT=${TEST681_SOURCE_COMMIT}
-COPY agent-node /app/agent-node
+COPY agent-node/package.json /app/agent-node/package.json
 RUN cd /app/agent-node && bun install --silent
+COPY agent-node /app/agent-node
 COPY tests/test681-explicit-lifecycle /app/tests/test681-explicit-lifecycle
 CMD ["/app/tests/test681-explicit-lifecycle/run.sh"]

--- a/tests/test681-explicit-lifecycle/run.sh
+++ b/tests/test681-explicit-lifecycle/run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "source_commit=${TEST681_SOURCE_COMMIT}"
+WORK=/tmp/test681
+mkdir -p "$WORK"
+
+cd /app/agent-node
+bun test src/explicit-task-lifecycle.test.ts
+bun run build
+
+mutate_expect_red() {
+  local file="$1" from="$2" to="$3" label="$4"
+  local backup="$WORK/$label.orig"
+  cp "$file" "$backup"
+  python3 - "$file" "$from" "$to" <<'PY'
+import pathlib, sys
+p=pathlib.Path(sys.argv[1]); old=sys.argv[2]; new=sys.argv[3]; data=p.read_text()
+if data.count(old) != 1: raise SystemExit(f"anchor count={data.count(old)} for {old!r}")
+p.write_text(data.replace(old,new,1))
+PY
+  cmp -s "$file" "$backup" && { echo "mutation no-op: $label" >&2; exit 1; }
+  set +e
+  bun test src/explicit-task-lifecycle.test.ts >"$WORK/$label.log" 2>&1
+  local rc=$?
+  set -e
+  cp "$backup" "$file"
+  [[ $rc -ne 0 ]] || { echo "mutation stayed green: $label" >&2; exit 1; }
+  echo "WITNESSED_RED $label rc=$rc"
+}
+
+mutate_expect_red src/explicit-task-trace.ts 'emit(childStatus === "acked" ? "acked" : "started", taskId);' 'emit("started", taskId);' ack-event
+mutate_expect_red src/explicit-task-trace.ts 'emit(childStatus === "replied" ? "replied" : "failed", taskId, {' 'emit("failed", taskId, {' reply-event
+mutate_expect_red src/explicit-task-trace.ts 'event: "task.warning.delivered_stale_30s"' 'event: "task.warning.deleted"' stale-30-event
+mutate_expect_red src/explicit-task-trace.ts 'event: "task.warning.delivered_stale_60s"' 'event: "task.warning.deleted"' stale-60-event
+mutate_expect_red src/explicit-task-trace.ts 'emit("expired", taskId, { errorCode: "lifecycle_timeout" });' 'emit("failed", taskId, { errorCode: "lifecycle_timeout" });' expiry-event
+mutate_expect_red src/cli.ts '    emit: emitTrace,' '    emit: () => {},' production-wiring
+
+echo "RESULT: PASS"

--- a/tests/test681-explicit-lifecycle/run.sh
+++ b/tests/test681-explicit-lifecycle/run.sh
@@ -34,5 +34,9 @@ mutate_expect_red src/explicit-task-trace.ts 'event: "task.warning.delivered_sta
 mutate_expect_red src/explicit-task-trace.ts 'event: "task.warning.delivered_stale_60s"' 'event: "task.warning.deleted"' stale-60-event
 mutate_expect_red src/explicit-task-trace.ts 'emit("expired", taskId, { errorCode: "lifecycle_timeout" });' 'emit("failed", taskId, { errorCode: "lifecycle_timeout" });' expiry-event
 mutate_expect_red src/cli.ts '    emit: emitTrace,' '    emit: () => {},' production-wiring
+mutate_expect_red src/explicit-task-trace.ts 'dependencies.timeoutMs ?? 120_000' 'dependencies.timeoutMs ?? 121_000' timeout-default
+mutate_expect_red src/explicit-task-trace.ts 'dependencies.pollIntervalMs ?? 2_000' 'dependencies.pollIntervalMs ?? 3_000' poll-default
+mutate_expect_red src/explicit-task-trace.ts 'dependencies.stale30Ms ?? 30_000' 'dependencies.stale30Ms ?? 31_000' stale-30-default
+mutate_expect_red src/explicit-task-trace.ts 'dependencies.stale60Ms ?? 60_000' 'dependencies.stale60Ms ?? 61_000' stale-60-default
 
 echo "RESULT: PASS"


### PR DESCRIPTION
## Summary
- extract the existing explicit-delegation polling loop into an internal, testable state machine
- preserve the existing 2s poll, 30/60s stale warnings, 120s timeout, terminal mappings, and result text
- drive ack/start/reply/failure/stale/expiry through the production-wired helper
- add exact, byte-changing mutations for every late lifecycle class and the production wiring

## Verification
- base: `45ca09853922f1be8574b84e932b404b9cc2f778` (#679 merge; #680 is test-only and non-overlapping)
- source: `3dc31f2d9258521be975d5317c48d3865928d6cf`
- report-only head: `f9bce98e134c4e4408d29af74249e080e9ac2014`
- Docker image: `sha256:26386c8f5e8801339b2855963024603ec684f6de091fec4ed6b432887add21de`
- embedded ENV equals source
- old implementation witnessed red: missing lifecycle-helper export, rc=1
- 5 tests / 18 assertions
- 10/10 exact mutations witnessed red, including all four production timing defaults
- production agent-node bundle PASS

## Honest boundary
This closes the explicit-delegation late-lifecycle runtime-test gap from #679. It does not add proxy lifecycle watchers, Dashboard lifecycle UI, artifact events, or the two known-uncovered send_task call sites. #167 remains open.

Refs #167
