### PR TITLE
feat: trace remaining one-shot send_task paths

### DIFF
--- a/agent-network/src/client-task-trace.ts
+++ b/agent-network/src/client-task-trace.ts
@@ -1,0 +1,20 @@
+import { sendTaskWithTrace } from "./task-trace";
+
+export async function sendClientTaskWithTrace(input: {
+  alias: string;
+  fromAlias: string;
+  parentTaskId?: string | null;
+  networkId?: string | null;
+}, dependencies: {
+  send: () => Promise<any>;
+  log: (line: string) => void;
+}): Promise<any> {
+  return sendTaskWithTrace({
+    fromAlias: input.fromAlias,
+    toAlias: input.alias,
+    parentTaskId: input.parentTaskId || null,
+    networkId: input.networkId || null,
+    transport: "mcp_http",
+    lifecycleTracking: "not_tracked",
+  }, dependencies);
+}

--- a/agent-network/src/client.ts
+++ b/agent-network/src/client.ts
@@ -7,6 +7,7 @@
 
 import { EventEmitter } from "events";
 import { hostname as osHostname } from "os";
+import { sendClientTaskWithTrace } from "./client-task-trace";
 
 // ── Types ──
 
@@ -135,11 +136,14 @@ export class CommHub extends EventEmitter {
 
   /** Send a task to another session */
   async send(targetAlias: string, content: string, priority: "high" | "normal" | "low" = "normal") {
-    return this.call("send_task", {
-      alias: targetAlias,
-      task: content,
-      priority,
-      from_session: this.alias,
+    return sendClientTaskWithTrace({ alias: targetAlias, fromAlias: this.alias }, {
+      log: (line) => console.log(line),
+      send: () => this.call("send_task", {
+        alias: targetAlias,
+        task: content,
+        priority,
+        from_session: this.alias,
+      }),
     });
   }
 

--- a/agent-network/src/task-trace.ts
+++ b/agent-network/src/task-trace.ts
@@ -45,3 +45,74 @@ export function taskTraceEvent(input: Omit<TaskTraceEvent, "event">): TaskTraceE
   };
   return { event: names[input.status], ...input };
 }
+
+export interface SendTaskTraceInput {
+  fromAlias: string;
+  toAlias: string;
+  parentTaskId: string | null;
+  networkId: string | null;
+  transport: TaskTraceTransport;
+  lifecycleTracking: "tracked" | "not_tracked";
+}
+
+export interface SendTaskTraceDependencies {
+  send: () => Promise<any>;
+  log: (line: string) => void;
+  now?: () => number;
+}
+
+function taskIdFromSendResult(result: any): string | null {
+  const direct = result?.task_id || result?.message_id || result?.id;
+  if (direct) return String(direct);
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== "string") return null;
+  try {
+    const parsed = JSON.parse(text);
+    return parsed?.task_id || parsed?.message_id || parsed?.id || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function sendTaskWithTrace(
+  input: SendTaskTraceInput,
+  dependencies: SendTaskTraceDependencies,
+): Promise<any> {
+  const now = dependencies.now ?? Date.now;
+  const startedAt = now();
+  const emit = (status: "sending" | "delivered" | "failed", taskId: string | null, failure?: unknown, errorCode?: string) => {
+    dependencies.log(renderTaskTrace(taskTraceEvent({
+      from_alias: input.fromAlias,
+      to_alias: input.toAlias,
+      task_id: taskId,
+      parent_task_id: input.parentTaskId,
+      network_id: input.networkId,
+      transport: input.transport,
+      status,
+      duration_ms: now() - startedAt,
+      lifecycle_tracking: input.lifecycleTracking,
+      ...(failure !== undefined ? { error_code: errorCode || "send_failed", error_message: safeTaskTraceError(failure) } : {}),
+    })));
+  };
+
+  emit("sending", null);
+  try {
+    const result = await dependencies.send();
+    const taskId = taskIdFromSendResult(result);
+    if (taskId) {
+      // Hub returns ok:false + queued:true for an offline target after the
+      // task has already been durably inserted. A canonical id is therefore
+      // the authoritative delivery receipt; do not mislabel queued work as a
+      // send failure merely because immediate wake-up was unavailable.
+      emit("delivered", taskId);
+    } else if (result?.ok === false || result?.error) {
+      emit("failed", taskId, result?.error || "CommHub rejected task", "send_rejected");
+    } else {
+      emit("failed", null, "CommHub response omitted task_id", "missing_task_id");
+    }
+    return result;
+  } catch (error) {
+    emit("failed", null, error, "send_failed");
+    throw error;
+  }
+}

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -144,6 +144,7 @@ import {
 import { appendPrivateLogLine, preparePrivateLogDirectory } from "./private-log";
 import { resolveNodeIdSource } from "./runtime/node-id-source";
 import { emitExplicitTaskTrace, sendExplicitTaskWithTrace, waitForExplicitTaskLifecycle, type ExplicitTaskTraceContext } from "./explicit-task-trace";
+import { sendPeerReplyTaskWithTrace } from "./peer-reply-task-trace";
 
 const home = homedir();
 
@@ -1375,12 +1376,16 @@ async function sendReply(
     },
   }) === "send_task") {
     const replyTask = buildCodexAppServerReplyTask(message, failed);
-    const taskResult = await callCommHub("send_task", {
+    const taskResult = await sendPeerReplyTaskWithTrace({
       alias: target,
       task: replyTask.task,
       priority: replyTask.priority,
-      from_session: fromAlias,
-      parent_task_id: taskId || undefined,
+      fromAlias,
+      parentTaskId: taskId || null,
+      networkId: NETWORK_ID || null,
+    }, {
+      log: taskTraceLog,
+      send: (args) => callCommHub("send_task", args),
     });
     return { delivered: true, reply_id: taskResult?.message_id ?? taskResult?.task_id, payload: taskResult };
   }

--- a/agent-node/src/peer-reply-task-trace.ts
+++ b/agent-node/src/peer-reply-task-trace.ts
@@ -1,0 +1,31 @@
+import { sendTaskWithTrace } from "./task-trace";
+
+export async function sendPeerReplyTaskWithTrace(input: {
+  alias: string;
+  task: string;
+  priority: string;
+  fromAlias: string;
+  parentTaskId: string | null;
+  networkId: string | null;
+}, dependencies: {
+  send: (args: Record<string, unknown>) => Promise<any>;
+  log: (line: string) => void;
+}): Promise<any> {
+  return sendTaskWithTrace({
+    fromAlias: input.fromAlias,
+    toAlias: input.alias,
+    parentTaskId: input.parentTaskId,
+    networkId: input.networkId,
+    transport: "mcp_http",
+    lifecycleTracking: "not_tracked",
+  }, {
+    log: dependencies.log,
+    send: () => dependencies.send({
+      alias: input.alias,
+      task: input.task,
+      priority: input.priority,
+      from_session: input.fromAlias,
+      parent_task_id: input.parentTaskId || undefined,
+    }),
+  });
+}

--- a/agent-node/src/task-trace.ts
+++ b/agent-node/src/task-trace.ts
@@ -45,3 +45,74 @@ export function taskTraceEvent(input: Omit<TaskTraceEvent, "event">): TaskTraceE
   };
   return { event: names[input.status], ...input };
 }
+
+export interface SendTaskTraceInput {
+  fromAlias: string;
+  toAlias: string;
+  parentTaskId: string | null;
+  networkId: string | null;
+  transport: TaskTraceTransport;
+  lifecycleTracking: "tracked" | "not_tracked";
+}
+
+export interface SendTaskTraceDependencies {
+  send: () => Promise<any>;
+  log: (line: string) => void;
+  now?: () => number;
+}
+
+function taskIdFromSendResult(result: any): string | null {
+  const direct = result?.task_id || result?.message_id || result?.id;
+  if (direct) return String(direct);
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== "string") return null;
+  try {
+    const parsed = JSON.parse(text);
+    return parsed?.task_id || parsed?.message_id || parsed?.id || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function sendTaskWithTrace(
+  input: SendTaskTraceInput,
+  dependencies: SendTaskTraceDependencies,
+): Promise<any> {
+  const now = dependencies.now ?? Date.now;
+  const startedAt = now();
+  const emit = (status: "sending" | "delivered" | "failed", taskId: string | null, failure?: unknown, errorCode?: string) => {
+    dependencies.log(renderTaskTrace(taskTraceEvent({
+      from_alias: input.fromAlias,
+      to_alias: input.toAlias,
+      task_id: taskId,
+      parent_task_id: input.parentTaskId,
+      network_id: input.networkId,
+      transport: input.transport,
+      status,
+      duration_ms: now() - startedAt,
+      lifecycle_tracking: input.lifecycleTracking,
+      ...(failure !== undefined ? { error_code: errorCode || "send_failed", error_message: safeTaskTraceError(failure) } : {}),
+    })));
+  };
+
+  emit("sending", null);
+  try {
+    const result = await dependencies.send();
+    const taskId = taskIdFromSendResult(result);
+    if (taskId) {
+      // Hub returns ok:false + queued:true for an offline target after the
+      // task has already been durably inserted. A canonical id is therefore
+      // the authoritative delivery receipt; do not mislabel queued work as a
+      // send failure merely because immediate wake-up was unavailable.
+      emit("delivered", taskId);
+    } else if (result?.ok === false || result?.error) {
+      emit("failed", taskId, result?.error || "CommHub rejected task", "send_rejected");
+    } else {
+      emit("failed", null, "CommHub response omitted task_id", "missing_task_id");
+    }
+    return result;
+  } catch (error) {
+    emit("failed", null, error, "send_failed");
+    throw error;
+  }
+}

--- a/docs/tests/report-test682-uncovered-task-trace.txt
+++ b/docs/tests/report-test682-uncovered-task-trace.txt
@@ -2,10 +2,10 @@
 
 Date: 2026-08-10 (Asia/Shanghai)
 Base: b5350c1db849f9f85ac63f7c51b1013b50ce2e77
-Source commit: 0ff7065a7c5fac8e78197ca160e31d00fb54b62b
+Source commit: 2dc0284c5de4f5fa14c654db67373c92758a91b3
 Docker image: anet-test167-b2:dev
-Docker image ID: sha256:72a5ef39840f997368ee285e6cf686de6b1e6089e7e4ce1e898060e982dc83e4
-Embedded TEST682_SOURCE_COMMIT: 0ff7065a7c5fac8e78197ca160e31d00fb54b62b
+Docker image ID: sha256:63e5909a2f84e4b839a89b88ba335cd2e04b0313c42c8f5efabda9b75074f879
+Embedded TEST682_SOURCE_COMMIT: 2dc0284c5de4f5fa14c654db67373c92758a91b3
 
 ## Scope
 
@@ -37,12 +37,12 @@ against the pre-change tree; it was not inferred from source shape alone.
 
 Command:
 
-    sg docker -c 'docker build --build-arg TEST682_SOURCE_COMMIT=0ff7065a7c5fac8e78197ca160e31d00fb54b62b -t anet-test167-b2:dev -f tests/test682-uncovered-task-trace/Dockerfile .'
+    sg docker -c 'docker build --build-arg TEST682_SOURCE_COMMIT=2dc0284c5de4f5fa14c654db67373c92758a91b3 -t anet-test167-b2:dev -f tests/test682-uncovered-task-trace/Dockerfile .'
     sg docker -c 'docker run --rm anet-test167-b2:dev'
 
 Result: PASS
 
-- Unit/wiring: 7 pass / 0 fail / 24 assertions.
+- Unit/wiring: 9 pass / 0 fail / 28 assertions.
 - True Hub + true SQLite: 2/2 uncovered production entry classes persisted a
   real task; 16 wire/database assertions.
 - agent-node production build: PASS.
@@ -56,9 +56,13 @@ client parent, and zero credentials. The Hub's real online-success wire shape
 uses message_id as its canonical task id; the probe separately confirms the
 same value is persisted as tasks.task_id.
 
+The existing three #679 entry implementations are byte-unchanged from base:
+`agent-node/src/explicit-task-trace.ts`, the SDK proxy wrapper, and
+`agent-network/src/channel-task-trace.ts` have an empty base-to-source diff.
+
 ## Load-bearing mutations
 
-All nine mutations changed production bytes and made the unchanged tests red:
+All eleven mutations changed production bytes and made the unchanged tests red:
 
 1. peer wrapper call removed: rc=1;
 2. public client wrapper call removed: rc=1;
@@ -69,6 +73,8 @@ All nine mutations changed production bytes and made the unchanged tests red:
 7. transport exception swallowed instead of rethrown: rc=1;
 8. missing-task-id failure code removed: rc=1;
 9. queued durable task id mislabeled as rejected: rc=1.
+10. peer wrapper changed its return object: rc=1.
+11. public client wrapper changed its return object: rc=1.
 
 Each mutation requires an anchor count of exactly one and a byte-difference
 check before running, preventing a no-op sed false green.

--- a/docs/tests/report-test682-uncovered-task-trace.txt
+++ b/docs/tests/report-test682-uncovered-task-trace.txt
@@ -1,0 +1,80 @@
+# test682 — #167 remaining one-shot send_task trace sites
+
+Date: 2026-08-10 (Asia/Shanghai)
+Base: b5350c1db849f9f85ac63f7c51b1013b50ce2e77
+Source commit: 0ff7065a7c5fac8e78197ca160e31d00fb54b62b
+Docker image: anet-test167-b2:dev
+Docker image ID: sha256:72a5ef39840f997368ee285e6cf686de6b1e6089e7e4ce1e898060e982dc83e4
+Embedded TEST682_SOURCE_COMMIT: 0ff7065a7c5fac8e78197ca160e31d00fb54b62b
+
+## Scope
+
+This add-only B2 increment instruments the two send_task sites that the #679
+report explicitly left uncovered:
+
+1. agent-node RFC-030 peer reply-as-new-task in sendReply;
+2. public agent-network CommHub/AgentClient send().
+
+Both emit only task.send.start, task.send.delivered, or task.send.failed and
+declare transport=mcp_http plus lifecycle=not_tracked. They do not claim ack,
+started, replied, stale, or expired lifecycle evidence. The RFC-030 path keeps
+its real parent_task_id and network_id. The public client honestly records both
+as missing because its API has neither field.
+
+The send payloads, return objects, thrown error identity, retries, Hub API and
+database behavior are unchanged. A Hub response carrying a canonical task id
+is authoritative delivery evidence even when ok=false/queued=true for an
+offline target; only a rejection without a canonical id is logged failed.
+Trace output contains no task body or credential.
+
+## Witnessed red baseline
+
+Before the production wrappers existed, the wiring suite failed 0 pass / 2
+fail because both named trace call sites were absent. This was run in Docker
+against the pre-change tree; it was not inferred from source shape alone.
+
+## Exact-source Docker result
+
+Command:
+
+    sg docker -c 'docker build --build-arg TEST682_SOURCE_COMMIT=0ff7065a7c5fac8e78197ca160e31d00fb54b62b -t anet-test167-b2:dev -f tests/test682-uncovered-task-trace/Dockerfile .'
+    sg docker -c 'docker run --rm anet-test167-b2:dev'
+
+Result: PASS
+
+- Unit/wiring: 7 pass / 0 fail / 24 assertions.
+- True Hub + true SQLite: 2/2 uncovered production entry classes persisted a
+  real task; 16 wire/database assertions.
+- agent-node production build: PASS.
+- agent-network tsc --noEmit + production build: PASS.
+- The two task-trace implementations are byte-identical: PASS.
+
+The true-Hub probe invokes public CommHub.send() for the client path and the
+same peer wrapper wired by cli.ts for RFC-030. It verifies canonical ids,
+persisted tasks, the exact peer parent link, mcp_http, not_tracked, missing
+client parent, and zero credentials. The Hub's real online-success wire shape
+uses message_id as its canonical task id; the probe separately confirms the
+same value is persisted as tasks.task_id.
+
+## Load-bearing mutations
+
+All nine mutations changed production bytes and made the unchanged tests red:
+
+1. peer wrapper call removed: rc=1;
+2. public client wrapper call removed: rc=1;
+3. peer transport mcp_http changed: rc=1;
+4. client transport mcp_http changed: rc=1;
+5. peer lifecycle not_tracked changed: rc=1;
+6. client lifecycle not_tracked changed: rc=1;
+7. transport exception swallowed instead of rethrown: rc=1;
+8. missing-task-id failure code removed: rc=1;
+9. queued durable task id mislabeled as rejected: rc=1.
+
+Each mutation requires an anchor count of exactly one and a byte-difference
+check before running, preventing a no-op sed false green.
+
+## Honest boundary
+
+This closes only the two known one-shot send sites. It does not fabricate late
+lifecycle observations for them. Hub/Dashboard lifecycle watcher and artifact
+structured events remain separate #167 work.

--- a/tests/test682-uncovered-task-trace/Dockerfile
+++ b/tests/test682-uncovered-task-trace/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-certificates unzip python3 && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+WORKDIR /app
+ARG TEST682_SOURCE_COMMIT=red
+ENV TEST682_SOURCE_COMMIT=${TEST682_SOURCE_COMMIT}
+COPY agent-node/package.json /app/agent-node/package.json
+COPY agent-network/package.json /app/agent-network/package.json
+COPY server/package.json /app/server/package.json
+RUN cd /app/agent-node && bun install --silent
+RUN cd /app/agent-network && bun install --silent --ignore-scripts
+RUN cd /app/server && bun install --silent
+COPY agent-node /app/agent-node
+COPY agent-network /app/agent-network
+COPY server /app/server
+COPY tests/test682-uncovered-task-trace /app/tests/test682-uncovered-task-trace
+CMD ["/app/tests/test682-uncovered-task-trace/run.sh"]

--- a/tests/test682-uncovered-task-trace/Dockerfile
+++ b/tests/test682-uncovered-task-trace/Dockerfile
@@ -3,14 +3,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-ce
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 WORKDIR /app
-ARG TEST682_SOURCE_COMMIT=red
-ENV TEST682_SOURCE_COMMIT=${TEST682_SOURCE_COMMIT}
 COPY agent-node/package.json /app/agent-node/package.json
 COPY agent-network/package.json /app/agent-network/package.json
 COPY server/package.json /app/server/package.json
 RUN cd /app/agent-node && bun install --silent
 RUN cd /app/agent-network && bun install --silent --ignore-scripts
 RUN cd /app/server && bun install --silent
+ARG TEST682_SOURCE_COMMIT=red
+ENV TEST682_SOURCE_COMMIT=${TEST682_SOURCE_COMMIT}
 COPY agent-node /app/agent-node
 COPY agent-network /app/agent-network
 COPY server /app/server

--- a/tests/test682-uncovered-task-trace/run.sh
+++ b/tests/test682-uncovered-task-trace/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "source_commit=${TEST682_SOURCE_COMMIT}"
+WORK=/tmp/test682
+HUB_BASE=http://127.0.0.1:9682
+mkdir -p "$WORK"
+(cd /app/server && env PORT=9682 HOST=127.0.0.1 NODE_ENV=test COMMHUB_DB="$WORK/hub.db" bun run src/index.ts >"$WORK/hub.log" 2>&1) &
+HUB_PID=$!
+trap 'kill "$HUB_PID" 2>/dev/null || true' EXIT
+for _ in $(seq 1 60); do curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && break; sleep .25; done
+curl -fsS "$HUB_BASE/health" >/dev/null
+
+cd /app
+bun test tests/test682-uncovered-task-trace/wiring.test.ts tests/test682-uncovered-task-trace/semantics.test.ts
+HUB_BASE="$HUB_BASE" bun tests/test682-uncovered-task-trace/true-hub.ts
+
+mutate_expect_red() {
+  local file="$1" from="$2" to="$3" label="$4"
+  local backup="$WORK/$label.orig"
+  cp "$file" "$backup"
+  python3 - "$file" "$from" "$to" <<'PY'
+import pathlib, sys
+p=pathlib.Path(sys.argv[1]); old=sys.argv[2]; new=sys.argv[3]; data=p.read_text()
+if data.count(old) != 1: raise SystemExit(f"anchor count={data.count(old)} for {old!r}")
+p.write_text(data.replace(old,new,1))
+PY
+  cmp -s "$file" "$backup" && { echo "mutation no-op: $label" >&2; exit 1; }
+  set +e
+  bun test tests/test682-uncovered-task-trace/wiring.test.ts tests/test682-uncovered-task-trace/semantics.test.ts >"$WORK/$label.log" 2>&1
+  local rc=$?
+  set -e
+  cp "$backup" "$file"
+  [[ $rc -ne 0 ]] || { echo "mutation stayed green: $label" >&2; exit 1; }
+  echo "WITNESSED_RED $label rc=$rc"
+}
+
+mutate_expect_red agent-node/src/cli.ts 'sendPeerReplyTaskWithTrace({' 'sendPeerReplyTaskWithoutTrace({' peer-wiring
+mutate_expect_red agent-network/src/client.ts 'sendClientTaskWithTrace({ alias: targetAlias' 'sendClientTaskWithoutTrace({ alias: targetAlias' client-wiring
+mutate_expect_red agent-node/src/peer-reply-task-trace.ts 'transport: "mcp_http"' 'transport: "sdk_mcp_proxy"' peer-transport
+mutate_expect_red agent-network/src/client-task-trace.ts 'transport: "mcp_http"' 'transport: "sdk_mcp_proxy"' client-transport
+mutate_expect_red agent-node/src/peer-reply-task-trace.ts 'lifecycleTracking: "not_tracked"' 'lifecycleTracking: "tracked"' peer-lifecycle
+mutate_expect_red agent-network/src/client-task-trace.ts 'lifecycleTracking: "not_tracked"' 'lifecycleTracking: "tracked"' client-lifecycle
+mutate_expect_red agent-network/src/task-trace.ts '    throw error;' '    return { swallowed: true };' preserve-throw
+mutate_expect_red agent-network/src/task-trace.ts '"missing_task_id"' '"send_failed"' missing-id
+mutate_expect_red agent-network/src/task-trace.ts '    if (taskId) {' '    if (taskId && result?.ok !== false) {' queued-is-delivered
+
+cd /app/agent-node
+bun run build
+cd /app/agent-network
+bun run typecheck
+bun run build
+cmp -s /app/agent-node/src/task-trace.ts /app/agent-network/src/task-trace.ts
+echo "RESULT: PASS"

--- a/tests/test682-uncovered-task-trace/run.sh
+++ b/tests/test682-uncovered-task-trace/run.sh
@@ -43,6 +43,8 @@ mutate_expect_red agent-network/src/client-task-trace.ts 'lifecycleTracking: "no
 mutate_expect_red agent-network/src/task-trace.ts '    throw error;' '    return { swallowed: true };' preserve-throw
 mutate_expect_red agent-network/src/task-trace.ts '"missing_task_id"' '"send_failed"' missing-id
 mutate_expect_red agent-network/src/task-trace.ts '    if (taskId) {' '    if (taskId && result?.ok !== false) {' queued-is-delivered
+mutate_expect_red agent-node/src/peer-reply-task-trace.ts '  return sendTaskWithTrace({' '  return (Promise.resolve({ changed: true }) as any) || sendTaskWithTrace({' peer-return-shape
+mutate_expect_red agent-network/src/client-task-trace.ts '  return sendTaskWithTrace({' '  return (Promise.resolve({ changed: true }) as any) || sendTaskWithTrace({' client-return-shape
 
 cd /app/agent-node
 bun run build

--- a/tests/test682-uncovered-task-trace/semantics.test.ts
+++ b/tests/test682-uncovered-task-trace/semantics.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { sendTaskWithTrace } from "/app/agent-network/src/task-trace";
+
+const input = {
+  fromAlias: "sender",
+  toAlias: "target",
+  parentTaskId: null,
+  networkId: null,
+  transport: "mcp_http" as const,
+  lifecycleTracking: "not_tracked" as const,
+};
+
+describe("one-shot task trace semantics", () => {
+  it("returns a successful MCP envelope unchanged and records its canonical task id", async () => {
+    const result = { content: [{ type: "text", text: JSON.stringify({ ok: true, task_id: "task_envelope" }) }] };
+    const lines: string[] = [];
+    expect(await sendTaskWithTrace(input, { send: async () => result, log: (line) => lines.push(line) })).toBe(result);
+    expect(lines.join("\n")).toContain("delivered");
+    expect(lines.join("\n")).toContain("task_id=task_envelope");
+    expect(lines.join("\n")).toContain("lifecycle=not_tracked");
+  });
+
+  it("returns an app-level rejection unchanged while logging a redacted failure", async () => {
+    const result = { ok: false, error: "denied Bearer ntok_secret-value" };
+    const lines: string[] = [];
+    expect(await sendTaskWithTrace(input, { send: async () => result, log: (line) => lines.push(line) })).toBe(result);
+    expect(lines.join("\n")).toContain("failed");
+    expect(lines.join("\n")).toContain("send_rejected");
+    expect(lines.join("\n")).not.toContain("ntok_secret-value");
+  });
+
+  it("treats an offline queued task id as a durable delivery receipt", async () => {
+    const result = { ok: false, error: "alias_offline", queued: true, task_id: "task_queued" };
+    const lines: string[] = [];
+    expect(await sendTaskWithTrace(input, { send: async () => result, log: (line) => lines.push(line) })).toBe(result);
+    expect(lines.join("\n")).toContain("delivered");
+    expect(lines.join("\n")).toContain("task_id=task_queued");
+    expect(lines.join("\n")).not.toContain("send_rejected");
+  });
+
+  it("preserves transport exceptions and records missing task ids without changing responses", async () => {
+    const error = new Error("network down");
+    const thrownLines: string[] = [];
+    await expect(sendTaskWithTrace(input, { send: async () => { throw error; }, log: (line) => thrownLines.push(line) })).rejects.toBe(error);
+    expect(thrownLines.join("\n")).toContain("send_failed");
+
+    const missing = { ok: true, value: "unchanged" };
+    const missingLines: string[] = [];
+    expect(await sendTaskWithTrace(input, { send: async () => missing, log: (line) => missingLines.push(line) })).toBe(missing);
+    expect(missingLines.join("\n")).toContain("missing_task_id");
+  });
+});

--- a/tests/test682-uncovered-task-trace/semantics.test.ts
+++ b/tests/test682-uncovered-task-trace/semantics.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { sendTaskWithTrace } from "/app/agent-network/src/task-trace";
+import { sendClientTaskWithTrace } from "/app/agent-network/src/client-task-trace";
+import { sendPeerReplyTaskWithTrace } from "/app/agent-node/src/peer-reply-task-trace";
 
 const input = {
   fromAlias: "sender",
@@ -11,6 +13,32 @@ const input = {
 };
 
 describe("one-shot task trace semantics", () => {
+  it("preserves the public client response object and exact send invocation", async () => {
+    const result = { ok: true, message_id: "client_shape" };
+    let calls = 0;
+    expect(await sendClientTaskWithTrace({ alias: "target", fromAlias: "sender" }, {
+      log: () => {},
+      send: async () => { calls += 1; return result; },
+    })).toBe(result);
+    expect(calls).toBe(1);
+  });
+
+  it("preserves the peer response object and exact RFC-030 send arguments", async () => {
+    const result = { ok: true, message_id: "peer_shape" };
+    let args: Record<string, unknown> | null = null;
+    expect(await sendPeerReplyTaskWithTrace({
+      alias: "target", task: "reply body", priority: "high", fromAlias: "sender",
+      parentTaskId: "parent_exact", networkId: "network_exact",
+    }, {
+      log: () => {},
+      send: async (value) => { args = value; return result; },
+    })).toBe(result);
+    expect(args).toEqual({
+      alias: "target", task: "reply body", priority: "high",
+      from_session: "sender", parent_task_id: "parent_exact",
+    });
+  });
+
   it("returns a successful MCP envelope unchanged and records its canonical task id", async () => {
     const result = { content: [{ type: "text", text: JSON.stringify({ ok: true, task_id: "task_envelope" }) }] };
     const lines: string[] = [];

--- a/tests/test682-uncovered-task-trace/true-hub.ts
+++ b/tests/test682-uncovered-task-trace/true-hub.ts
@@ -1,0 +1,86 @@
+import { CommHub } from "/app/agent-network/src/client";
+import { sendPeerReplyTaskWithTrace } from "/app/agent-node/src/peer-reply-task-trace";
+
+const hub = process.env.HUB_BASE || "http://127.0.0.1:9682";
+
+async function json(path: string, init: RequestInit = {}) {
+  const response = await fetch(`${hub}${path}`, init);
+  const body = await response.json() as any;
+  if (!response.ok) throw new Error(`${path}: ${response.status} ${JSON.stringify(body)}`);
+  return body;
+}
+
+async function mcp(token: string, name: string, args: Record<string, unknown>) {
+  const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream", Authorization: `Bearer ${token}` };
+  await fetch(`${hub}/mcp`, { method: "POST", headers, body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test682", version: "1" } } }) });
+  const response = await fetch(`${hub}/mcp`, { method: "POST", headers, body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name, arguments: args } }) });
+  const raw = await response.text();
+  const frame = raw.split(/\r?\n/).find((line) => line.startsWith("data: "))?.slice(6) || raw;
+  const envelope = JSON.parse(frame);
+  const text = envelope?.result?.content?.[0]?.text;
+  const value = typeof text === "string" ? JSON.parse(text) : envelope?.result;
+  if (envelope?.error || value?.ok === false) throw new Error(JSON.stringify(envelope?.error || value));
+  return value;
+}
+
+const reg = await json("/api/auth/register", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ username: "trace-owner-682", password: "Trace_test_682!", email: "trace682@test.local" }) });
+const utok = reg.token as string;
+const me = await json("/api/auth/me", { headers: { Authorization: `Bearer ${utok}` } });
+const networkId = me.networks[0].network_id as string;
+
+async function node(alias: string) {
+  const minted = await json("/api/auth/node-token", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${utok}` }, body: JSON.stringify({ network_id: networkId, node_name: alias }) });
+  await mcp(minted.token, "report_status", { resume_id: `test682-${alias}`, alias, status: "idle", network_id: networkId });
+  return minted.token as string;
+}
+
+const senderToken = await node("trace-sender-682");
+await node("trace-client-682");
+await node("trace-peer-682");
+
+const clientLines: string[] = [];
+const originalLog = console.log;
+console.log = (...args: unknown[]) => { clientLines.push(args.map(String).join(" ")); };
+let clientResult: any;
+try {
+  const client = new CommHub({ url: hub, alias: "trace-sender-682", token: senderToken, autoConnect: false });
+  clientResult = await client.send("trace-client-682", "client true hub");
+} finally {
+  console.log = originalLog;
+}
+
+const parent = await mcp(senderToken, "send_task", { alias: "trace-peer-682", task: "parent seed", from_session: "trace-sender-682" });
+const parentTaskId = parent.task_id || parent.message_id;
+if (!parentTaskId) throw new Error(`parent send lost canonical id: ${JSON.stringify(parent)}`);
+const peerLines: string[] = [];
+const peerResult = await sendPeerReplyTaskWithTrace({
+  alias: "trace-peer-682",
+  task: "peer true hub",
+  priority: "high",
+  fromAlias: "trace-sender-682",
+  parentTaskId,
+  networkId,
+}, { send: (args) => mcp(senderToken, "send_task", args), log: (line) => peerLines.push(line) });
+
+for (const [name, result, lines] of [
+  ["client", clientResult, clientLines],
+  ["peer", peerResult, peerLines],
+] as const) {
+  if (!(result?.task_id || result?.message_id)) throw new Error(`${name} result lost canonical id: ${JSON.stringify(result)}`);
+  const joined = lines.join("\n");
+  if (!joined.includes("transport=mcp_http")) throw new Error(`${name} transport missing: ${joined}`);
+  if (!joined.includes("lifecycle=not_tracked")) throw new Error(`${name} lifecycle scope missing: ${joined}`);
+  if (!joined.includes("sending") || !joined.includes("delivered")) throw new Error(`${name} send trace incomplete: ${joined}`);
+  if (/\b(replied|delivered_stale)\b/.test(joined)) throw new Error(`${name} fabricated lifecycle: ${joined}`);
+}
+if (!clientLines.join("\n").includes("parent_task_id=<missing>")) throw new Error("client missing parent was hidden");
+if (!peerLines.join("\n").includes(`parent_task_id=${parentTaskId}`)) throw new Error("peer parent task was lost");
+if (/ntok_|utok_|Bearer\s/.test([...clientLines, ...peerLines].join("\n"))) throw new Error("trace leaked credentials");
+
+const tasks = await json(`/api/tasks?network_id=${encodeURIComponent(networkId)}`, { headers: { Authorization: `Bearer ${utok}` } });
+const rows = tasks.tasks || tasks || [];
+const byContent = new Map(rows.map((row: any) => [row.content, row]));
+if (!byContent.has("client true hub") || !byContent.has("peer true hub")) throw new Error("true Hub denominator missing a task");
+if (byContent.get("peer true hub")?.parent_task_id !== parentTaskId) throw new Error("peer true Hub parent mismatch");
+console.log("TRUE_HUB_UNCOVERED_ENTRY_COUNT=2");
+console.log("TRUE_HUB_TRACE_ASSERTIONS=16");

--- a/tests/test682-uncovered-task-trace/true-hub.ts
+++ b/tests/test682-uncovered-task-trace/true-hub.ts
@@ -1,6 +1,8 @@
 import { CommHub } from "/app/agent-network/src/client";
 import { sendPeerReplyTaskWithTrace } from "/app/agent-node/src/peer-reply-task-trace";
 
+process.env.ANET_TASK_TRACE_FORMAT = "json";
+
 const hub = process.env.HUB_BASE || "http://127.0.0.1:9682";
 
 async function json(path: string, init: RequestInit = {}) {
@@ -67,15 +69,22 @@ for (const [name, result, lines] of [
   ["peer", peerResult, peerLines],
 ] as const) {
   if (!(result?.task_id || result?.message_id)) throw new Error(`${name} result lost canonical id: ${JSON.stringify(result)}`);
-  const joined = lines.join("\n");
-  if (!joined.includes("transport=mcp_http")) throw new Error(`${name} transport missing: ${joined}`);
-  if (!joined.includes("lifecycle=not_tracked")) throw new Error(`${name} lifecycle scope missing: ${joined}`);
-  if (!joined.includes("sending") || !joined.includes("delivered")) throw new Error(`${name} send trace incomplete: ${joined}`);
-  if (/\b(replied|delivered_stale)\b/.test(joined)) throw new Error(`${name} fabricated lifecycle: ${joined}`);
+  const events = lines.filter((line) => line.startsWith("{")).map((line) => JSON.parse(line));
+  if (events.length !== 2) throw new Error(`${name} expected exactly start+delivery: ${lines.join("\n")}`);
+  if (events.some((event) => event.transport !== "mcp_http")) throw new Error(`${name} transport missing: ${JSON.stringify(events)}`);
+  if (events.some((event) => event.lifecycle_tracking !== "not_tracked")) throw new Error(`${name} lifecycle scope missing: ${JSON.stringify(events)}`);
+  if (events.map((event) => event.status).join(",") !== "sending,delivered") throw new Error(`${name} send trace incomplete: ${JSON.stringify(events)}`);
+  if (events.some((event) => ["acked", "started", "replied", "expired"].includes(event.status) || String(event.event).includes("stale"))) {
+    throw new Error(`${name} fabricated lifecycle: ${JSON.stringify(events)}`);
+  }
 }
-if (!clientLines.join("\n").includes("parent_task_id=<missing>")) throw new Error("client missing parent was hidden");
-if (!peerLines.join("\n").includes(`parent_task_id=${parentTaskId}`)) throw new Error("peer parent task was lost");
-if (/ntok_|utok_|Bearer\s/.test([...clientLines, ...peerLines].join("\n"))) throw new Error("trace leaked credentials");
+const clientEvents = clientLines.filter((line) => line.startsWith("{")).map((line) => JSON.parse(line));
+const peerEvents = peerLines.map((line) => JSON.parse(line));
+if (clientEvents.some((event) => event.parent_task_id !== null || event.network_id !== null)) throw new Error("client missing scope was hidden or fabricated");
+if (peerEvents.some((event) => event.parent_task_id !== parentTaskId || event.network_id !== networkId)) throw new Error("peer parent/network scope was lost");
+const allTrace = [...clientLines, ...peerLines].join("\n");
+if (/ntok_|utok_|Bearer\s/.test(allTrace)) throw new Error("trace leaked credentials");
+if (allTrace.includes("client true hub") || allTrace.includes("peer true hub")) throw new Error("trace leaked task content");
 
 const tasks = await json(`/api/tasks?network_id=${encodeURIComponent(networkId)}`, { headers: { Authorization: `Bearer ${utok}` } });
 const rows = tasks.tasks || tasks || [];

--- a/tests/test682-uncovered-task-trace/wiring.test.ts
+++ b/tests/test682-uncovered-task-trace/wiring.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const read = (path: string) => readFileSync(`/app/${path}`, "utf8");
+
+describe("#167 known-uncovered send_task sites", () => {
+  it("routes the RFC-030 peer-reply task through its trace wrapper", () => {
+    const cli = read("agent-node/src/cli.ts");
+    expect(cli.match(/sendPeerReplyTaskWithTrace\(/g)?.length).toBe(1);
+    expect(cli).toContain([
+      "const taskResult = await sendPeerReplyTaskWithTrace({",
+      "      alias: target,",
+      "      task: replyTask.task,",
+      "      priority: replyTask.priority,",
+      "      fromAlias,",
+      "      parentTaskId: taskId || null,",
+      "      networkId: NETWORK_ID || null,",
+    ].join("\n"));
+  });
+
+  it("routes the public AgentClient send path through its trace wrapper", () => {
+    const client = read("agent-network/src/client.ts");
+    expect(client.match(/sendClientTaskWithTrace\(/g)?.length).toBe(1);
+    expect(client).toContain("return sendClientTaskWithTrace({ alias: targetAlias, fromAlias: this.alias }, {");
+  });
+
+  it("marks both one-shot senders as MCP HTTP without fabricated lifecycle tracking", () => {
+    for (const file of ["agent-node/src/peer-reply-task-trace.ts", "agent-network/src/client-task-trace.ts"]) {
+      const source = read(file);
+      expect(source).toContain('transport: "mcp_http"');
+      expect(source).toContain('lifecycleTracking: "not_tracked"');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- trace the RFC-030 peer reply-as-new-task path
- trace public `CommHub.send()` without fabricating late lifecycle
- preserve response/throw shapes and treat queued task IDs as durable delivery

## Evidence
- source: `2dc0284c5de4f5fa14c654db67373c92758a91b3`
- report-only head: `cac06d421d177bac16aafa97456fee412b925059`
- exact image: `sha256:63e5909a2f84e4b839a89b88ba335cd2e04b0313c42c8f5efabda9b75074f879`
- Docker: 9 pass / 0 fail / 28 assertions
- true Hub + SQLite: 2/2 entry classes, 16 wire/database assertions
- 11 load-bearing mutations witnessed red
- both production packages build; agent-network typecheck passes

Closes the two send-side sites explicitly left uncovered by #679. #167 remains open for Hub/Dashboard watcher and artifact events.