### PR TITLE
feat(server): persist delivered-stale lifecycle events

### DIFF
--- a/docs/tests/report-test683-hub-lifecycle-watcher.txt
+++ b/docs/tests/report-test683-hub-lifecycle-watcher.txt
@@ -1,0 +1,89 @@
+# test683 — Hub lifecycle watcher (#167 B3-A backend)
+
+Date: 2026-08-10 (Asia/Shanghai)
+Base: b214a7f9954acea9fda0d134ca3cfbd8019abc7a
+Source commit: ea197924a2f5aad9522f757ab9821b067cb36be4
+Docker image: anet-test167-b3:dev
+Docker image ID: sha256:bbd28103ea17c215e3e547b49cdb7564a50877a90a532e3c3dd36c22bb9b0691
+Embedded TEST683_SOURCE_COMMIT: ea197924a2f5aad9522f757ab9821b067cb36be4
+Runner artifact SHA256: 3412721dbbea41506574f35113e7f2a2399746da855eb3fe44b6955c1d77a1e9
+
+## Scope
+
+This is the backend-only B3-A increment. It reuses the existing `task_events`
+audit table and adds:
+
+- standard `event_type` names for ordinary Hub lifecycle transitions;
+- a Hub-owned 30s/60s delivered-stale watcher;
+- an internal `event_key` protected by a unique `(task_id, event_key)` index,
+  making each stale threshold write-once across patrol rounds, restarts, and
+  workers;
+- an additive legacy-database migration for both columns and the index;
+- an explicit REST projection which exposes `event_type` but not `event_key`.
+
+The watcher only reads tasks whose authoritative Hub status remains
+`delivered`, inherits the task's `network_id`, and runs under `startHub` every
+five seconds (environment-overridable for tests). It does not change task
+status, inbox state, delivery, retries, or the existing expiration patrol.
+
+This commit does not touch Dashboard code or artifact metadata. In particular,
+it does not expose host-local artifact paths.
+
+## Witnessed red
+
+The test-only commit `db6bc7238c1ba5d672d1f4e189d2e20266a387b5`
+was built and run in Docker before production code existed. It failed with
+rc=1 because `task-lifecycle-watcher.js` did not exist (0 pass / 1 fail / 1
+module error). That proves the pre-change tree did not already satisfy this
+suite; the load-bearing gates below additionally isolate individual behavior.
+
+## Exact-source Docker result
+
+Commands:
+
+    sg docker -c 'docker build --build-arg TEST683_SOURCE_COMMIT=ea197924a2f5aad9522f757ab9821b067cb36be4 -t anet-test167-b3:dev -f tests/test683-hub-lifecycle-watcher/Dockerfile .'
+    sg docker -c 'docker run --rm -v /tmp/test683-exact.T8BcMD:/artifacts anet-test167-b3:dev'
+
+Result: PASS
+
+- Production Bun bundle: PASS (259 modules).
+- Legacy `task_events` migration: PASS; existing row bytes were not rewritten.
+- Real Hub + real SQLite: 5 pass / 0 fail / 26 assertions.
+- 29s stays silent; exact 30s emits only the 30s event; exact 60s emits both.
+- Non-delivered and missing-delivery-time tasks stay silent.
+- A second patrol inserts zero rows; total remains one row per task/threshold.
+- Standard delivered/ack/started/replied/failed/expired event names: PASS.
+- REST returns `event_type`, keeps internal `event_key` absent: PASS.
+- A real child `startHub` process crosses the threshold after startup and the
+  periodic watcher persists the event: PASS.
+- Canonical aggregate runner, filtered to this new suite: 5 pass / 0 fail / 26
+  assertions, `bad=false`.
+
+The complete repository aggregate is not claimed by this narrow image; it is
+left to the pull request's ordinary CI because several unrelated server tests
+require agent-node and test fixture trees that this Dockerfile intentionally
+does not copy.
+
+## Load-bearing mutations
+
+All eight mutations required one exact anchor and a production byte change.
+The unchanged test suite turned red for each:
+
+1. remove `(task_id, event_key)` conflict suppression: rc=1;
+2. move the 30-second threshold to 31 seconds: rc=1;
+3. admit `acked` tasks to the watcher: rc=1;
+4. drop task `network_id` propagation: rc=1;
+5. remove public `event_type`: rc=1;
+6. leak internal `event_key` through REST: rc=1;
+7. map `acked` to the wrong standard event name: rc=1;
+8. remove the live `startHub` watcher timer: rc=1.
+
+The restored production tree returned to 5 pass / 0 fail / 26 assertions.
+
+## Honest boundary
+
+This backend increment provides durable lifecycle/stale events. The separate
+Dashboard follow-up may fix its existing TaskDrawer field mapping, with
+before/after screenshots and no change to the top four-step timeline semantics.
+Artifact presentation remains held for a separate privacy-reviewed design;
+host absolute paths are explicitly out of scope.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -244,6 +244,8 @@ db.exec(`
     task_id       TEXT NOT NULL,
     from_status   TEXT,
     to_status     TEXT NOT NULL,
+    event_type    TEXT,
+    event_key     TEXT,
     actor         TEXT NOT NULL DEFAULT 'system',
     detail        TEXT,
     created_at    TEXT NOT NULL DEFAULT (datetime('now'))
@@ -781,6 +783,14 @@ try {
 for (const table of ["sessions", "nodes", "tasks", "inbox", "task_events", "completions"]) {
   try { db.exec(`ALTER TABLE ${table} ADD COLUMN network_id TEXT`); } catch {}
 }
+
+// #167 — stable lifecycle event names plus an internal idempotency key.
+// Ordinary status transitions keep event_key NULL, so retries and repeated
+// transitions remain auditable. Watcher warnings set a stable key; the unique
+// index makes every (task, threshold) write-once across patrol rounds/workers.
+try { db.exec("ALTER TABLE task_events ADD COLUMN event_type TEXT"); } catch {}
+try { db.exec("ALTER TABLE task_events ADD COLUMN event_key TEXT"); } catch {}
+try { db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_task_events_task_key ON task_events(task_id, event_key)"); } catch {}
 
 // PR-1 (#146): durable node identity on historical inbox/tasks rows. Some
 // existing databases created `tasks` before from_node_id/to_node_id were in the
@@ -1484,12 +1494,25 @@ export function chainReplyToParent(
   return { chained };
 }
 
+function taskEventTypeForStatus(toStatus: string): string {
+  switch (toStatus) {
+    case "delivered": return "task.send.delivered";
+    case "acked": return "task.ack";
+    case "running": return "task.started";
+    case "replied": return "task.replied";
+    case "expired": return "task.expired";
+    case "failed":
+    case "cancelled": return "task.failed";
+    default: return `task.status.${toStatus}`;
+  }
+}
+
 export function logTaskEvent(taskId: string, fromStatus: string | null, toStatus: string, actor: string, detail?: string) {
   try {
     db.run(
-      `INSERT INTO task_events (task_id, from_status, to_status, actor, detail, network_id)
-       VALUES (?1, ?2, ?3, ?4, ?5, (SELECT network_id FROM tasks WHERE task_id = ?1))`,
-      [taskId, fromStatus, toStatus, actor, detail ?? null]
+      `INSERT INTO task_events (task_id, from_status, to_status, event_type, actor, detail, network_id)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, (SELECT network_id FROM tasks WHERE task_id = ?1))`,
+      [taskId, fromStatus, toStatus, taskEventTypeForStatus(toStatus), actor, detail ?? null]
     );
   } catch {}
 }

--- a/server/src/rest-projections.ts
+++ b/server/src/rest-projections.ts
@@ -27,8 +27,8 @@ export const AUDIT_LOG_REST_COLUMNS = [
 ] as const;
 
 export const TASK_EVENT_REST_COLUMNS = [
-  "id", "task_id", "from_status", "to_status", "actor", "detail", "created_at",
-  "network_id",
+  "id", "task_id", "from_status", "to_status", "event_type", "actor", "detail",
+  "created_at", "network_id",
 ] as const;
 
 export const TASK_REST_COLUMNS = [

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -44,6 +44,7 @@ import {
 import { resolveRestFromSession } from "./rest-identity.js";
 import { stampTaskAuthOrigin, type TaskAuthOrigin } from "./task-auth-origin.js";
 import { assertScheduledTaskBackendSupported, handleScheduledTaskRequest, startScheduledTaskScheduler } from "./scheduled-tasks.js";
+import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
 
 const PORT = Number(process.env.PORT) || 9200;
 const HOST = process.env.HOST || "127.0.0.1";
@@ -645,6 +646,17 @@ function patrolExpiredTasks(): void {
       for (const t of expired) logTaskEvent(t.task_id, null, "expired", "patrol");
     }
   } catch {}
+}
+
+function patrolDeliveredStaleTasks(): void {
+  try {
+    const result = recordDeliveredStaleEvents();
+    if (result.inserted > 0) {
+      console.warn(`[patrol] recorded ${result.inserted} delivered-stale task warning(s)`);
+    }
+  } catch (error: any) {
+    console.error(`[patrol] delivered-stale watcher failed: ${error?.message || error}`);
+  }
 }
 
 // #434 — test-safety seam, same signature as PR #438 so the two branches
@@ -3209,8 +3221,12 @@ export function startHub(opts?: { port?: number; hostname?: string }): ReturnTyp
     ? Number(process.env.COMMHUB_RATELIMIT_SWEEP_MS) : 300000;
   const taskPatrolMs = Number(process.env.COMMHUB_TASK_PATROL_MS) > 0
     ? Number(process.env.COMMHUB_TASK_PATROL_MS) : 5 * 60 * 1000;
+  const deliveredStalePatrolMs = Number(process.env.COMMHUB_DELIVERED_STALE_PATROL_MS) > 0
+    ? Number(process.env.COMMHUB_DELIVERED_STALE_PATROL_MS) : 5 * 1000;
   const rateLimitSweepTimer = setInterval(sweepStaleRateLimits, rateLimitSweepMs);
   const taskPatrolTimer = setInterval(patrolExpiredTasks, taskPatrolMs);
+  patrolDeliveredStaleTasks();
+  const deliveredStalePatrolTimer = setInterval(patrolDeliveredStaleTasks, deliveredStalePatrolMs);
   const scheduledTaskTimer = startScheduledTaskScheduler();
 
   // The Bun.serve socket is what keeps the process alive; the periodic
@@ -3220,6 +3236,7 @@ export function startHub(opts?: { port?: number; hostname?: string }): ReturnTyp
   (staleSweeperTimer as any)?.unref?.();
   (rateLimitSweepTimer as any)?.unref?.();
   (taskPatrolTimer as any)?.unref?.();
+  (deliveredStalePatrolTimer as any)?.unref?.();
   (scheduledTaskTimer as any)?.unref?.();
 
   // ── Graceful shutdown ───────────────────────────────
@@ -3229,6 +3246,7 @@ export function startHub(opts?: { port?: number; hostname?: string }): ReturnTyp
     clearInterval(staleSweeperTimer);
     clearInterval(rateLimitSweepTimer);
     clearInterval(taskPatrolTimer);
+    clearInterval(deliveredStalePatrolTimer);
     clearInterval(scheduledTaskTimer);
     db.close();
     process.exit(0);

--- a/server/src/task-lifecycle-watcher.test.ts
+++ b/server/src/task-lifecycle-watcher.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import { db, logTaskEvent } from "./db.js";
 import { TASK_EVENT_REST_COLUMNS } from "./rest-projections.js";
 import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
@@ -16,6 +17,10 @@ function insertTask(taskId: string, status: string, deliveredAt: string | null, 
      VALUES (?1, 'sender', 'target', ?2, 'watcher fixture', ?3, ?4)`,
     [taskId, status, deliveredAt, network],
   );
+}
+
+function sqliteUtcTimestamp(date: Date): string {
+  return date.toISOString().slice(0, 19).replace("T", " ");
 }
 
 beforeAll(async () => {
@@ -73,16 +78,22 @@ describe("#167 Hub delivered-stale lifecycle watcher", () => {
   });
 
   test("ordinary lifecycle events get standard event names without a dedupe key", () => {
+    logTaskEvent("stale-30", null, "delivered", "target");
     logTaskEvent("stale-30", "delivered", "acked", "target");
     logTaskEvent("stale-30", "acked", "running", "target");
     logTaskEvent("stale-30", "running", "replied", "target");
+    logTaskEvent("stale-30", "running", "failed", "target");
+    logTaskEvent("stale-30", "delivered", "expired", "target");
     const rows = db.all<any>(
       "SELECT event_type, event_key FROM task_events WHERE task_id = 'stale-30' AND actor = 'target' ORDER BY id",
     );
     expect(rows).toEqual([
+      { event_type: "task.send.delivered", event_key: null },
       { event_type: "task.ack", event_key: null },
       { event_type: "task.started", event_key: null },
       { event_type: "task.replied", event_key: null },
+      { event_type: "task.failed", event_key: null },
+      { event_type: "task.expired", event_key: null },
     ]);
   });
 
@@ -98,5 +109,52 @@ describe("#167 Hub delivered-stale lifecycle watcher", () => {
     expect(body.events).toHaveLength(2);
     expect(body.events.every((event: any) => typeof event.event_type === "string")).toBe(true);
     expect(body.events.every((event: any) => event.event_key === undefined)).toBe(true);
+  });
+
+  test("startHub owns a live watcher timer instead of relying on import side effects", async () => {
+    const childDbPath = `/tmp/test683-live-${process.pid}-${Date.now()}.db`;
+    const init = Bun.spawnSync(["bun", "-e", "await import('./server/src/db.js')"], {
+      cwd: process.cwd(),
+      env: { ...process.env, COMMHUB_DB: childDbPath },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(init.exitCode).toBe(0);
+
+    const child = Bun.spawn(["bun", "run", "server/src/index.ts"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        COMMHUB_DB: childDbPath,
+        COMMHUB_DELIVERED_STALE_PATROL_MS: "25",
+        PORT: "0",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await Bun.sleep(800);
+    expect(child.exitCode).toBeNull();
+
+    const taskId = "stale-live-wiring";
+    const childDb = new Database(childDbPath);
+    try {
+      childDb.run(
+        `INSERT INTO tasks
+           (task_id, from_name, to_name, status, content, delivered_at, network_id)
+         VALUES (?1, 'sender', 'target', 'delivered', 'live watcher fixture', ?2, ?3)`,
+        [taskId, sqliteUtcTimestamp(new Date(Date.now() - 28_000)), networkId],
+      );
+      expect(childDb.query<{ count: number }, [string]>(
+        "SELECT COUNT(*) AS count FROM task_events WHERE task_id = ?1",
+      ).get(taskId)!.count).toBe(0);
+      await Bun.sleep(3_200);
+      expect(childDb.query<{ count: number }, [string]>(
+        "SELECT COUNT(*) AS count FROM task_events WHERE task_id = ?1 AND event_type = 'task.warning.delivered_stale_30s'",
+      ).get(taskId)!.count).toBe(1);
+    } finally {
+      childDb.close();
+      try { child.kill("SIGTERM"); } catch {}
+      await child.exited;
+    }
   });
 });

--- a/server/src/task-lifecycle-watcher.test.ts
+++ b/server/src/task-lifecycle-watcher.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { db, logTaskEvent } from "./db.js";
+import { TASK_EVENT_REST_COLUMNS } from "./rest-projections.js";
+import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
+
+const NOW = new Date("2026-08-10T00:01:01.000Z");
+let server: ReturnType<typeof Bun.serve>;
+let base = "";
+let token = "";
+let networkId = "";
+
+function insertTask(taskId: string, status: string, deliveredAt: string | null, network = networkId) {
+  db.run(
+    `INSERT INTO tasks
+       (task_id, from_name, to_name, status, content, delivered_at, network_id)
+     VALUES (?1, 'sender', 'target', ?2, 'watcher fixture', ?3, ?4)`,
+    [taskId, status, deliveredAt, network],
+  );
+}
+
+beforeAll(async () => {
+  const { register } = await import("./auth.js");
+  const auth = register(`watcher_owner_${Date.now()}`, "WatcherOwner-Strong-1!", undefined, "watcher");
+  expect(auth.ok).toBe(true);
+  token = auth.token!;
+  networkId = auth.network_id!;
+
+  insertTask("stale-29", "delivered", "2026-08-10 00:00:32");
+  insertTask("stale-30", "delivered", "2026-08-10 00:00:31");
+  insertTask("stale-60", "delivered", "2026-08-10 00:00:01");
+  insertTask("stale-acked", "acked", "2026-08-10 00:00:00");
+  insertTask("stale-no-delivery", "delivered", null);
+
+  const mod = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop(true); } catch {}
+});
+
+describe("#167 Hub delivered-stale lifecycle watcher", () => {
+  test("30s/60s thresholds are exact and non-delivered tasks stay silent", () => {
+    const first = recordDeliveredStaleEvents(NOW);
+    expect(first.inserted).toBe(3);
+    expect(first.by_threshold_seconds).toEqual({ 30: 2, 60: 1 });
+
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM task_events WHERE task_id = 'stale-29'")!.count).toBe(0);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM task_events WHERE task_id = 'stale-30'")!.count).toBe(1);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM task_events WHERE task_id = 'stale-60'")!.count).toBe(2);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM task_events WHERE task_id = 'stale-acked'")!.count).toBe(0);
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM task_events WHERE task_id = 'stale-no-delivery'")!.count).toBe(0);
+
+    const sixty = db.all<any>("SELECT * FROM task_events WHERE task_id = 'stale-60' ORDER BY event_type");
+    expect(sixty.map((row) => row.event_type)).toEqual([
+      "task.warning.delivered_stale_30s",
+      "task.warning.delivered_stale_60s",
+    ]);
+    expect(sixty.map((row) => row.event_key)).toEqual(sixty.map((row) => row.event_type));
+    expect(sixty.every((row) => row.from_status === "delivered" && row.to_status === "delivered")).toBe(true);
+    expect(sixty.every((row) => row.actor === "patrol")).toBe(true);
+    expect(sixty.every((row) => row.network_id === networkId)).toBe(true);
+  });
+
+  test("a second patrol is write-once for each task and threshold", () => {
+    const second = recordDeliveredStaleEvents(NOW);
+    expect(second.inserted).toBe(0);
+    expect(second.by_threshold_seconds).toEqual({ 30: 0, 60: 0 });
+    expect(db.get<{ count: number }>(
+      "SELECT COUNT(*) AS count FROM task_events WHERE event_type LIKE 'task.warning.delivered_stale_%'",
+    )!.count).toBe(3);
+  });
+
+  test("ordinary lifecycle events get standard event names without a dedupe key", () => {
+    logTaskEvent("stale-30", "delivered", "acked", "target");
+    logTaskEvent("stale-30", "acked", "running", "target");
+    logTaskEvent("stale-30", "running", "replied", "target");
+    const rows = db.all<any>(
+      "SELECT event_type, event_key FROM task_events WHERE task_id = 'stale-30' AND actor = 'target' ORDER BY id",
+    );
+    expect(rows).toEqual([
+      { event_type: "task.ack", event_key: null },
+      { event_type: "task.started", event_key: null },
+      { event_type: "task.replied", event_key: null },
+    ]);
+  });
+
+  test("REST exposes event_type but keeps the internal idempotency key private", async () => {
+    expect(TASK_EVENT_REST_COLUMNS).toContain("event_type");
+    expect(TASK_EVENT_REST_COLUMNS).not.toContain("event_key" as any);
+    const response = await fetch(
+      `${base}/api/task_events?network_id=${encodeURIComponent(networkId)}&task_id=stale-60`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json() as any;
+    expect(body.events).toHaveLength(2);
+    expect(body.events.every((event: any) => typeof event.event_type === "string")).toBe(true);
+    expect(body.events.every((event: any) => event.event_key === undefined)).toBe(true);
+  });
+});

--- a/server/src/task-lifecycle-watcher.ts
+++ b/server/src/task-lifecycle-watcher.ts
@@ -1,0 +1,49 @@
+import { db } from "./db.js";
+
+export const DELIVERED_STALE_THRESHOLDS = [30, 60] as const;
+
+export type DeliveredStalePatrolResult = {
+  inserted: number;
+  by_threshold_seconds: Record<(typeof DELIVERED_STALE_THRESHOLDS)[number], number>;
+};
+
+function sqliteUtcTimestamp(date: Date): string {
+  return date.toISOString().slice(0, 19).replace("T", " ");
+}
+
+/**
+ * Persist Hub-authoritative warnings for tasks which are still delivered.
+ *
+ * The task row, not an agent-local timer, is the source of truth. event_key is
+ * equal to the stable event name and protected by a unique index, so every
+ * threshold is write-once across restarts, patrols, and multiple Hub workers.
+ */
+export function recordDeliveredStaleEvents(now = new Date()): DeliveredStalePatrolResult {
+  if (!Number.isFinite(now.getTime())) throw new Error("invalid lifecycle patrol time");
+
+  const byThreshold = { 30: 0, 60: 0 };
+  let inserted = 0;
+
+  for (const thresholdSeconds of DELIVERED_STALE_THRESHOLDS) {
+    const eventType = `task.warning.delivered_stale_${thresholdSeconds}s`;
+    const cutoff = sqliteUtcTimestamp(new Date(now.getTime() - thresholdSeconds * 1000));
+    const detail = thresholdSeconds === 30
+      ? "still delivered after 30s; target has not started"
+      : "still delivered after 60s; target may be offline or not consuming";
+    const result = db.run(
+      `INSERT INTO task_events
+         (task_id, from_status, to_status, event_type, event_key, actor, detail, network_id)
+       SELECT task_id, 'delivered', 'delivered', ?1, ?1, 'patrol', ?2, network_id
+       FROM tasks
+       WHERE status = 'delivered'
+         AND delivered_at IS NOT NULL
+         AND delivered_at <= ?3
+       ON CONFLICT(task_id, event_key) DO NOTHING`,
+      [eventType, detail, cutoff],
+    );
+    byThreshold[thresholdSeconds] = result.changes;
+    inserted += result.changes;
+  }
+
+  return { inserted, by_threshold_seconds: byThreshold };
+}

--- a/tests/test683-hub-lifecycle-watcher/Dockerfile
+++ b/tests/test683-hub-lifecycle-watcher/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+
+COPY server ./server
+COPY tests/test683-hub-lifecycle-watcher ./tests/test683-hub-lifecycle-watcher
+
+ARG TEST683_SOURCE_COMMIT=uncommitted-red
+ENV TEST683_SOURCE_COMMIT=$TEST683_SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test683-hub-lifecycle-watcher/run.sh
+ENTRYPOINT ["/workspace/tests/test683-hub-lifecycle-watcher/run.sh"]

--- a/tests/test683-hub-lifecycle-watcher/run.sh
+++ b/tests/test683-hub-lifecycle-watcher/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test683-hub-lifecycle-watcher.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test683 — Hub lifecycle watcher"
+echo "source_commit=${TEST683_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+COMMHUB_DB=/tmp/test683.db bun test server/src/task-lifecycle-watcher.test.ts
+
+echo "RESULT: PASS"

--- a/tests/test683-hub-lifecycle-watcher/run.sh
+++ b/tests/test683-hub-lifecycle-watcher/run.sh
@@ -11,6 +11,137 @@ echo "# test683 — Hub lifecycle watcher"
 echo "source_commit=${TEST683_SOURCE_COMMIT:-unknown}"
 echo "date=$(date -Is)"
 
-COMMHUB_DB=/tmp/test683.db bun test server/src/task-lifecycle-watcher.test.ts
+run_suite() {
+  local db_path=$1
+  COMMHUB_DB="$db_path" bun test server/src/task-lifecycle-watcher.test.ts
+}
+
+expect_red() {
+  local label=$1 db_path=$2
+  set +e
+  run_suite "$db_path" >/tmp/test683-red.log 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "MUTATION_FALSE_GREEN: $label"
+    sed -n '1,220p' /tmp/test683-red.log
+    exit 1
+  fi
+  echo "MUTATION_RED: $label rc=$rc"
+}
+
+mutate_once() {
+  local file=$1 anchor=$2 replacement=$3
+  bun -e '
+    import { readFileSync, writeFileSync } from "node:fs";
+    const [file, anchor, replacement] = process.argv.slice(1);
+    const before = readFileSync(file, "utf8");
+    const count = before.split(anchor).length - 1;
+    if (count !== 1) throw new Error(`mutation anchor count=${count}: ${anchor}`);
+    const after = before.replace(anchor, replacement);
+    if (after === before) throw new Error(`mutation made no byte change: ${anchor}`);
+    writeFileSync(file, after);
+  ' "$file" "$anchor" "$replacement"
+}
+
+echo "L0 production build"
+bun build server/src/index.ts --target bun --outfile /tmp/commhub-test683.js
+test -s /tmp/commhub-test683.js
+
+echo "L0 legacy task_events migration"
+bun - <<'BUN'
+  import { Database } from "bun:sqlite";
+  const db = new Database("/tmp/test683-legacy.db");
+  db.exec(`CREATE TABLE task_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    from_status TEXT,
+    to_status TEXT NOT NULL,
+    actor TEXT NOT NULL DEFAULT 'system',
+    detail TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    network_id TEXT
+  );`);
+  db.exec(`INSERT INTO task_events (task_id, to_status) VALUES ('legacy-event', 'delivered')`);
+  db.close();
+BUN
+COMMHUB_DB=/tmp/test683-legacy.db bun -e '
+  const { db } = await import("./server/src/db.js");
+  const columns = db.all("PRAGMA table_info(task_events)").map((row) => row.name);
+  if (!columns.includes("event_type") || !columns.includes("event_key")) {
+    throw new Error(`legacy migration missing columns: ${columns.join(",")}`);
+  }
+  const old = db.get("SELECT task_id, event_type, event_key FROM task_events WHERE task_id = ?1", "legacy-event");
+  if (!old || old.event_type !== null || old.event_key !== null) throw new Error("legacy row was rewritten");
+  const indexes = db.all("PRAGMA index_list(task_events)").map((row) => row.name);
+  if (!indexes.includes("idx_task_events_task_key")) throw new Error("legacy migration missing idempotency index");
+'
+
+echo "L1-L5 real Hub + SQLite lifecycle watcher"
+run_suite /tmp/test683-green.db
+
+cp server/src/db.ts /tmp/test683-db.ts
+cp server/src/rest-projections.ts /tmp/test683-rest-projections.ts
+cp server/src/server.ts /tmp/test683-server.ts
+cp server/src/task-lifecycle-watcher.ts /tmp/test683-watcher.ts
+
+echo "L6 mutation: remove write-once conflict gate"
+mutate_once server/src/task-lifecycle-watcher.ts \
+  '       ON CONFLICT(task_id, event_key) DO NOTHING' \
+  ''
+expect_red write-once-task-threshold /tmp/test683-mut-write-once.db
+cp /tmp/test683-watcher.ts server/src/task-lifecycle-watcher.ts
+
+echo "L7 mutation: move the first threshold past the exact 30s boundary"
+mutate_once server/src/task-lifecycle-watcher.ts \
+  'export const DELIVERED_STALE_THRESHOLDS = [30, 60] as const;' \
+  'export const DELIVERED_STALE_THRESHOLDS = [31, 60] as const;'
+expect_red exact-30-second-threshold /tmp/test683-mut-threshold.db
+cp /tmp/test683-watcher.ts server/src/task-lifecycle-watcher.ts
+
+echo "L8 mutation: allow acked tasks into the stale watcher"
+mutate_once server/src/task-lifecycle-watcher.ts \
+  "WHERE status = 'delivered'" \
+  "WHERE status IN ('delivered', 'acked')"
+expect_red delivered-status-only /tmp/test683-mut-status.db
+cp /tmp/test683-watcher.ts server/src/task-lifecycle-watcher.ts
+
+echo "L9 mutation: drop task network propagation"
+mutate_once server/src/task-lifecycle-watcher.ts \
+  "SELECT task_id, 'delivered', 'delivered', ?1, ?1, 'patrol', ?2, network_id" \
+  "SELECT task_id, 'delivered', 'delivered', ?1, ?1, 'patrol', ?2, NULL"
+expect_red network-propagation /tmp/test683-mut-network.db
+cp /tmp/test683-watcher.ts server/src/task-lifecycle-watcher.ts
+
+echo "L10 mutation: remove event_type from the public projection"
+mutate_once server/src/rest-projections.ts \
+  '"id", "task_id", "from_status", "to_status", "event_type", "actor", "detail",' \
+  '"id", "task_id", "from_status", "to_status", "actor", "detail",'
+expect_red public-event-type /tmp/test683-mut-event-type.db
+cp /tmp/test683-rest-projections.ts server/src/rest-projections.ts
+
+echo "L11 mutation: leak the internal event_key through REST"
+mutate_once server/src/rest-projections.ts \
+  '"id", "task_id", "from_status", "to_status", "event_type", "actor", "detail",' \
+  '"id", "task_id", "from_status", "to_status", "event_type", "event_key", "actor", "detail",'
+expect_red internal-key-private /tmp/test683-mut-private.db
+cp /tmp/test683-rest-projections.ts server/src/rest-projections.ts
+
+echo "L12 mutation: break the standard ack event name"
+mutate_once server/src/db.ts \
+  'case "acked": return "task.ack";' \
+  'case "acked": return "task.started";'
+expect_red standard-event-name /tmp/test683-mut-name.db
+cp /tmp/test683-db.ts server/src/db.ts
+
+echo "L13 mutation: remove the live startHub patrol timer"
+mutate_once server/src/server.ts \
+  'const deliveredStalePatrolTimer = setInterval(patrolDeliveredStaleTasks, deliveredStalePatrolMs);' \
+  'const deliveredStalePatrolTimer = ({ unref() {} } as any);'
+expect_red start-hub-live-wiring /tmp/test683-mut-wiring.db
+cp /tmp/test683-server.ts server/src/server.ts
+
+echo "L14 restored green"
+run_suite /tmp/test683-restored.db
 
 echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- add standard `event_type` values to the existing Hub `task_events` audit stream
- persist 30s/60s delivered-stale warnings from an authoritative Hub watcher
- make each `(task_id, threshold)` warning write-once with an internal unique `event_key`
- migrate existing SQLite databases additively and keep `event_key` out of REST responses
- wire the watcher into `startHub` with a live, unref'd, shutdown-cleaned timer

## Why

#167 requires operators and Dashboard consumers to distinguish delivery from actual task progress and to see explicit warnings when a task remains delivered without starting. Agent-local proxy traces cannot honestly infer those late lifecycle states; the Hub task row is the authoritative source.

## Safety and compatibility

- no task status, inbox, retry, dispatch, or expiration behavior changes
- ordinary lifecycle transitions remain repeatable/auditable because their `event_key` is `NULL`
- stale warnings alone use a stable key and database uniqueness, so repeated patrols/restarts/workers cannot flood history
- task `network_id` is copied into every warning and the existing REST network scope remains in force
- legacy rows are not rewritten; migrations only add nullable columns and an index
- Dashboard and artifact presentation are intentionally not part of this PR

## Validation

- exact source: `ea197924a2f5aad9522f757ab9821b067cb36be4`
- Docker image: `anet-test167-b3:dev` / `sha256:bbd28103ea17c215e3e547b49cdb7564a50877a90a532e3c3dd36c22bb9b0691`
- real Hub + real SQLite: 5 pass / 0 fail / 26 assertions
- canonical aggregate runner filtered to the new suite: 5 pass / 0 fail / 26 assertions, `bad=false`
- legacy schema migration: pass
- eight load-bearing mutations: all witnessed red
- pre-production test-only commit `db6bc723...`: witnessed red (missing watcher module)

Full evidence: `docs/tests/report-test683-hub-lifecycle-watcher.txt`.

Closes part of #167; #167 remains open for the separately reviewed Dashboard mapping and artifact boundary.
