### PR TITLE
feat: report external node schedules

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -18,6 +18,7 @@ import { createCommhubSdkMcpServer } from "./commhub-mcp";
 import { claudeCommhubToolAliases } from "./claude-tool-aliases";
 import { getHostTelemetry } from "./host-telemetry";
 import { getProcessTelemetry, incrementInFlight, decrementInFlight } from "./process-telemetry";
+import { readExternalSchedulesSnapshot } from "./external-schedules";
 import { parseGoalCommand } from "./goals/parser";
 import {
   appendLegacyScheduledGoalNotice,
@@ -1270,6 +1271,7 @@ const register = async () => {
     network_id: NETWORK_ID || undefined,
     host: getHostTelemetry(),
     process_telemetry: getProcessTelemetry(),
+    external_schedules: readExternalSchedulesSnapshot(configFilePath),
   });
   // Server is authoritative: if it told us a canonical alias different
   // from what we just sent, treat that as a snapshot update so the
@@ -1300,6 +1302,7 @@ const reportStatus = async (status: string, task?: string) => {
     network_id: NETWORK_ID || undefined,
     host: getHostTelemetry(),
     process_telemetry: getProcessTelemetry(),
+    external_schedules: readExternalSchedulesSnapshot(configFilePath),
     // RFC-024 N6 — masked snapshot of effective model+flags so dashboard
     // can show the current state without touching per-node files.
     // config_update_capable signals whether this process runs under a

--- a/agent-node/src/external-schedules.test.ts
+++ b/agent-node/src/external-schedules.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtempSync } from "node:fs";
+import { parseExternalSchedulesManifest, readExternalSchedulesSnapshot } from "./external-schedules";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "anet-external-schedules-"));
+  roots.push(root);
+  const nodeDir = join(root, "node");
+  mkdirSync(nodeDir);
+  const config = join(nodeDir, "config.json");
+  writeFileSync(config, "{}\n");
+  return { root, nodeDir, config, manifest: join(nodeDir, "external-schedules.json") };
+}
+
+describe("external schedule manifest", () => {
+  test("reports an exact bounded shape and strips host paths to basename", () => {
+    const snapshot = parseExternalSchedulesManifest(JSON.stringify({ external_schedules: [{
+      id: "pstation-smoke", name: "P station smoke", kind: "playwright",
+      frequency: "*/5 * * * *", last_run_at: "2026-08-10T01:02:03Z",
+      last_status: "success", last_error: null, next_run_at: "2026-08-10T01:07:03Z",
+      log_path: "/var/private/pstation-smoke.log", enabled: true,
+    }] }), "2026-08-10T02:00:00Z");
+    expect(snapshot).toEqual({
+      observed_at: "2026-08-10T02:00:00.000Z",
+      schedules: [{
+        id: "pstation-smoke", name: "P station smoke", kind: "playwright",
+        frequency: "*/5 * * * *", last_run_at: "2026-08-10T01:02:03.000Z",
+        last_status: "success", last_error: null, next_run_at: "2026-08-10T01:07:03.000Z",
+        log_ref: "pstation-smoke.log", enabled: true,
+      }],
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("/var/private");
+  });
+
+  test("missing manifest is an explicit empty observation; config-less legacy stays omitted", () => {
+    const { config } = fixture();
+    expect(readExternalSchedulesSnapshot(config, "2026-08-10T02:00:00Z")).toEqual({
+      observed_at: "2026-08-10T02:00:00Z", schedules: [],
+    });
+    expect(readExternalSchedulesSnapshot("", "2026-08-10T02:00:00Z")).toBeUndefined();
+  });
+
+  test("unknown keys, duplicate ids, invalid timestamps, and oversized lists fail closed", () => {
+    const good = { id: "a", name: "A", kind: "cron", frequency: "* * * * *" };
+    for (const value of [
+      { external_schedules: [{ ...good, command: "cat /etc/passwd" }] },
+      { external_schedules: [good, good] },
+      { external_schedules: [{ ...good, next_run_at: "not-a-time" }] },
+      { external_schedules: Array.from({ length: 65 }, (_, i) => ({ ...good, id: `s${i}` })) },
+    ]) expect(() => parseExternalSchedulesManifest(JSON.stringify(value))).toThrow();
+  });
+
+  test("symlink manifest never follows the target", () => {
+    const { root, manifest, config } = fixture();
+    const outside = join(root, "outside.json");
+    writeFileSync(outside, JSON.stringify({ external_schedules: [] }));
+    symlinkSync(outside, manifest);
+    expect(readExternalSchedulesSnapshot(config, "2026-08-10T02:00:00Z")).toEqual({
+      observed_at: "2026-08-10T02:00:00Z", schedules: [], error: "unsafe_manifest",
+    });
+  });
+});

--- a/agent-node/src/external-schedules.ts
+++ b/agent-node/src/external-schedules.ts
@@ -1,0 +1,108 @@
+import { lstatSync, readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+const MAX_MANIFEST_BYTES = 64 * 1024;
+const MAX_SCHEDULES = 64;
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const KINDS = new Set(["cron", "systemd", "tmux", "playwright", "custom"]);
+const STATUSES = new Set(["success", "failed", "running", "unknown"]);
+const ENTRY_KEYS = new Set([
+  "id", "name", "kind", "frequency", "last_run_at", "last_status",
+  "last_error", "next_run_at", "log_path", "enabled",
+]);
+
+export interface ExternalScheduleReport {
+  id: string;
+  name: string;
+  kind: "cron" | "systemd" | "tmux" | "playwright" | "custom";
+  frequency: string;
+  last_run_at: string | null;
+  last_status: "success" | "failed" | "running" | "unknown";
+  last_error: string | null;
+  next_run_at: string | null;
+  log_ref: string | null;
+  enabled: boolean;
+}
+
+export interface ExternalSchedulesSnapshot {
+  observed_at: string;
+  schedules: ExternalScheduleReport[];
+  error?: "invalid_manifest" | "unsafe_manifest" | "read_failed";
+}
+
+function boundedString(value: unknown, field: string, max: number, nullable = false): string | null {
+  if (value == null && nullable) return null;
+  if (typeof value !== "string" || value.length === 0 || value.length > max || /[\r\n\0]/.test(value)) {
+    throw new Error(`invalid ${field}`);
+  }
+  return value;
+}
+
+function timestamp(value: unknown, field: string): string | null {
+  if (value == null) return null;
+  const text = boundedString(value, field, 64);
+  if (!text || !Number.isFinite(Date.parse(text))) throw new Error(`invalid ${field}`);
+  return new Date(text).toISOString();
+}
+
+export function parseExternalSchedulesManifest(raw: string, observedAt = new Date().toISOString()): ExternalSchedulesSnapshot {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("manifest must be an object");
+  const root = parsed as Record<string, unknown>;
+  if (Object.keys(root).some((key) => key !== "external_schedules")) throw new Error("unknown manifest key");
+  if (!Array.isArray(root.external_schedules) || root.external_schedules.length > MAX_SCHEDULES) {
+    throw new Error("invalid external_schedules");
+  }
+  const ids = new Set<string>();
+  const schedules = root.external_schedules.map((entry, index): ExternalScheduleReport => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) throw new Error(`invalid schedule ${index}`);
+    const row = entry as Record<string, unknown>;
+    if (Object.keys(row).some((key) => !ENTRY_KEYS.has(key))) throw new Error(`unknown schedule key ${index}`);
+    const id = boundedString(row.id, "id", 128);
+    if (!id || !ID_RE.test(id) || ids.has(id)) throw new Error(`invalid schedule id ${index}`);
+    ids.add(id);
+    const kind = boundedString(row.kind, "kind", 32);
+    const lastStatus = boundedString(row.last_status ?? "unknown", "last_status", 16);
+    if (!kind || !KINDS.has(kind) || !lastStatus || !STATUSES.has(lastStatus)) throw new Error(`invalid schedule enum ${index}`);
+    const logPath = row.log_path == null ? null : boundedString(row.log_path, "log_path", 1024);
+    const logRef = logPath ? basename(logPath) : null;
+    if (logPath && (!logRef || logRef === "." || logRef === "..")) throw new Error(`invalid log_path ${index}`);
+    if (row.enabled !== undefined && typeof row.enabled !== "boolean") throw new Error(`invalid enabled ${index}`);
+    return {
+      id,
+      name: boundedString(row.name, "name", 200)!,
+      kind: kind as ExternalScheduleReport["kind"],
+      frequency: boundedString(row.frequency, "frequency", 120)!,
+      last_run_at: timestamp(row.last_run_at, "last_run_at"),
+      last_status: lastStatus as ExternalScheduleReport["last_status"],
+      last_error: row.last_error == null ? null : boundedString(row.last_error, "last_error", 500, true),
+      next_run_at: timestamp(row.next_run_at, "next_run_at"),
+      // Never report a host path. The basename is enough to identify the log
+      // locally without exposing the node's directory layout to Hub clients.
+      log_ref: logRef,
+      enabled: row.enabled === undefined ? true : row.enabled === true,
+    };
+  });
+  return { observed_at: timestamp(observedAt, "observed_at")!, schedules };
+}
+
+export function readExternalSchedulesSnapshot(
+  configPath: string,
+  observedAt = new Date().toISOString(),
+): ExternalSchedulesSnapshot | undefined {
+  if (!configPath) return undefined;
+  const manifestPath = join(dirname(configPath), "external-schedules.json");
+  try {
+    const stat = lstatSync(manifestPath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_MANIFEST_BYTES) {
+      return { observed_at: observedAt, schedules: [], error: "unsafe_manifest" };
+    }
+    return parseExternalSchedulesManifest(readFileSync(manifestPath, "utf8"), observedAt);
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return { observed_at: observedAt, schedules: [] };
+    if (error instanceof SyntaxError || /^invalid |^unknown |manifest /.test(String(error?.message || ""))) {
+      return { observed_at: observedAt, schedules: [], error: "invalid_manifest" };
+    }
+    return { observed_at: observedAt, schedules: [], error: "read_failed" };
+  }
+}

--- a/docs/tests/report-test185-external-schedules.txt
+++ b/docs/tests/report-test185-external-schedules.txt
@@ -1,0 +1,40 @@
+# test185 — external node schedule inventory
+
+Date: 2026-08-10
+Issue: #185
+Base: 936a4110354ee26efcda7455554f202365743e2a
+Source commit: 80132996f265c0ca8f95d501e1134f525064c140
+Image: anet-test185:dev
+Image ID: sha256:66e1feb7e3298d56bbb9b1f154f7e8be19de63dcb5f67abf7e07ae731b806c4a
+Embedded TEST185_SOURCE_COMMIT: 80132996f265c0ca8f95d501e1134f525064c140
+
+## Result
+
+PASS — 8 checks.
+
+- A real Hub and real agent-node heartbeat carried a bounded external-schedule snapshot.
+- The Hub response exposed only the manifest contract and a basename `log_ref`; the supplied host path was absent.
+- A missing manifest produced an explicit empty inventory, distinct from a legacy node that omitted the capability.
+- Unknown manifest fields failed closed and did not leak a command string.
+- Unit tests: 4 pass / 9 assertions.
+- REST projection tests: 5 pass / 30 assertions.
+- Removing both production heartbeat wiring anchors made the real-wire assertion fail (`witnessed-red`).
+- The agent-node production build completed in the image.
+
+Command:
+
+    sg docker -c 'docker build -f tests/test185-external-schedules/Dockerfile --build-arg TEST185_SOURCE_COMMIT=80132996f265c0ca8f95d501e1134f525064c140 -t anet-test185:dev .'
+    sg docker -c 'docker run --rm anet-test185:dev'
+
+## Security and semantics
+
+- The input is a fixed `external-schedules.json` beside the selected node config; Agent Network does not inspect cron, systemd, or tmux automatically.
+- The schema is exact, capped at 64 KiB / 64 entries, and rejects duplicate IDs, unknown keys, symlinks, non-files, invalid timestamps, and invalid enum values.
+- No command is accepted. `log_path` is reduced to a basename `log_ref` before it leaves the node.
+- The snapshot is stored on the token-bound session inside the existing status transaction.
+- Omitted heartbeat data preserves the prior value for backward compatibility; an explicit empty list clears it.
+- Dashboard/API wording must treat the data as node-reported inventory, not verified execution state.
+
+## Honest limitation
+
+The repository-wide server TypeScript command is not a usable candidate gate on this base: it reports numerous pre-existing rootDir, MCP SDK, BlobPart, and test-tree errors. Runtime server tests and the real Hub wire test above passed; this report does not claim the repository-wide server typecheck passed.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -89,6 +89,7 @@ for (const col of [
   { name: "process_cpu_pct", def: "REAL" },
   { name: "process_uptime_seconds", def: "REAL" },
   { name: "process_in_flight_count", def: "INTEGER" },
+  { name: "external_schedules", def: "TEXT" },
 ]) {
   try { db.exec(`ALTER TABLE sessions ADD COLUMN ${col.name} ${col.def}`); } catch {}
 }

--- a/server/src/rest-explicit-columns-http.test.ts
+++ b/server/src/rest-explicit-columns-http.test.ts
@@ -49,9 +49,9 @@ beforeAll(async () => {
   }
 
   db.run(
-    `INSERT INTO sessions (resume_id, alias, status, agent, model, network_id)
-     VALUES ('resume-rest-shape', 'rest-shape-node', 'idle', 'agent-node:codex', 'gpt-shape', ?1)`,
-    [networkId],
+    `INSERT INTO sessions (resume_id, alias, status, agent, model, network_id, external_schedules)
+     VALUES ('resume-rest-shape', 'rest-shape-node', 'idle', 'agent-node:codex', 'gpt-shape', ?1, ?2)`,
+    [networkId, JSON.stringify({ observed_at: "2026-08-10T02:00:00.000Z", schedules: [] })],
   );
   db.run(
     `INSERT INTO tasks (task_id, from_name, to_name, status, content, priority, network_id, parent_task_id, meta_json)
@@ -110,6 +110,7 @@ describe("#311 REST response projections are stable across future ALTER TABLE", 
     const row = body.sessions.find((item: any) => item.alias === "rest-shape-node");
     expect(sortedKeys(row)).toEqual(sorted([...SESSION_REST_COLUMNS, "runtime", "host", "process_telemetry"]));
     expect(row[INTERNAL_SENTINEL]).toBeUndefined();
+    expect(row.external_schedules).toEqual({ observed_at: "2026-08-10T02:00:00.000Z", schedules: [] });
   });
 
   test("task list and task detail expose the same explicit contract", async () => {

--- a/server/src/rest-projections.ts
+++ b/server/src/rest-projections.ts
@@ -19,6 +19,7 @@ export const SESSION_REST_COLUMNS = [
   "process_rss_mb", "process_cpu_pct", "process_uptime_seconds",
   "process_in_flight_count", "network_id", "registered_at", "updated_at",
   "node_id", "session_id", "config_path", "channels", "last_seen_at", "model",
+  "external_schedules",
 ] as const;
 
 export const AUDIT_LOG_REST_COLUMNS = [

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1500,8 +1500,14 @@ return Bun.serve({
             network_id: s.network_id ?? null,
           };
         }
+        const externalSchedules = (() => {
+          if (typeof s.external_schedules !== "string") return null;
+          try { return JSON.parse(s.external_schedules); } catch { return null; }
+        })();
+        const { external_schedules: _externalSchedulesJson, ...publicSession } = s;
         return {
-          ...s,
+          ...publicSession,
+          external_schedules: externalSchedules,
           model: s.model ?? null,
           runtime: normalizeRuntime(s.agent),
           host: {
@@ -1618,7 +1624,7 @@ return Bun.serve({
       if (detailKind === "agents") {
         const params: any[] = [host, host];
         let sql = `
-          SELECT alias, agent, status, task, progress, model, hostname, ip,
+          SELECT alias, agent, status, task, progress, model, hostname, ip, external_schedules,
                  cpu_load_1min, cpu_cores, mem_avail_gb, mem_used_gb, mem_total_gb,
                  disk_avail_gb, disk_used_gb, disk_total_gb,
                  process_rss_bytes, process_rss_mb, process_cpu_pct, process_uptime_seconds, process_in_flight_count,
@@ -1636,6 +1642,10 @@ return Bun.serve({
           status: s.status ?? "offline",
           task: s.task ?? null,
           progress: s.progress ?? 0,
+          external_schedules: (() => {
+            if (typeof s.external_schedules !== "string") return null;
+            try { return JSON.parse(s.external_schedules); } catch { return null; }
+          })(),
           last_seen: s.last_seen ?? null,
           health: agentHealthChip(s.status, s.last_seen),
           hostname: s.hostname ?? null,

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -483,6 +483,22 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         uptime_seconds: z.number().nullable().optional(),
         in_flight_count: z.number().nullable().optional(),
       }).optional().describe("Per-agent process telemetry reported by agent-node"),
+      external_schedules: z.object({
+        observed_at: z.string().datetime({ offset: true }).max(64),
+        schedules: z.array(z.object({
+          id: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/),
+          name: z.string().min(1).max(200),
+          kind: z.enum(["cron", "systemd", "tmux", "playwright", "custom"]),
+          frequency: z.string().min(1).max(120),
+          last_run_at: z.string().datetime({ offset: true }).max(64).nullable(),
+          last_status: z.enum(["success", "failed", "running", "unknown"]),
+          last_error: z.string().max(500).nullable(),
+          next_run_at: z.string().datetime({ offset: true }).max(64).nullable(),
+          log_ref: z.string().min(1).max(255).nullable(),
+          enabled: z.boolean(),
+        }).strict()).max(64),
+        error: z.enum(["invalid_manifest", "unsafe_manifest", "read_failed"]).optional(),
+      }).strict().optional().describe("Bounded node-reported external schedule snapshot; never includes host paths or commands"),
       // RFC-024 B6 — masked snapshot of the node's effective config
       // (model + 6 dashboard-editable flags). Secrets ARE NOT in this
       // shape (env._envRef stays on host); the dashboard reads this
@@ -513,7 +529,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         }).optional(),
       }).optional().describe("RFC-024 — masked node config snapshot"),
     },
-    async ({ resume_id, alias, status, task, output, score, progress, server: srv, hostname: hn, agent: ag, project_dir: pd, version: ver, tmux_name: tmux, node_id, session_id, config_path, channels, model: mdl, node_name: nn, network_id: netId, host, process_telemetry: proc, config_snapshot: cfgSnap }) => {
+    async ({ resume_id, alias, status, task, output, score, progress, server: srv, hostname: hn, agent: ag, project_dir: pd, version: ver, tmux_name: tmux, node_id, session_id, config_path, channels, model: mdl, node_name: nn, network_id: netId, host, process_telemetry: proc, external_schedules: externalSchedules, config_snapshot: cfgSnap }) => {
       const effectiveNetId = getNetworkId(netId);
       const sessionNetId = effectiveNetId ?? "default";
       if (!callerTokenIsNetwork || !enforceNetworkId) {
@@ -598,6 +614,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       const processCpuPct = typeof proc?.cpu_pct === "number" ? proc.cpu_pct : null;
       const processUptimeSeconds = typeof proc?.uptime_seconds === "number" ? proc.uptime_seconds : null;
       const processInFlightCount = typeof proc?.in_flight_count === "number" ? proc.in_flight_count : null;
+      const externalSchedulesJson = externalSchedules === undefined ? null : JSON.stringify(externalSchedules);
       const statusHostTelemetry = host ? {
         hostname: hostHostname,
         ip: hostIp,
@@ -622,8 +639,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         // Only delete same-alias sessions within the same network
         db.run("DELETE FROM sessions WHERE alias = ?1 AND resume_id != ?2 AND network_id = ?3", [effectiveAlias, resume_id, sessionNetId]);
         db.run(
-          `INSERT INTO sessions (resume_id, alias, tmux_name, server, ip, hostname, agent, project_dir, version, status, task, output, progress, score, node_id, session_id, config_path, channels, network_id, model, cpu_load_1min, cpu_cores, mem_total_gb, mem_used_gb, mem_avail_gb, disk_total_gb, disk_used_gb, disk_avail_gb, process_rss_bytes, process_rss_mb, process_cpu_pct, process_uptime_seconds, process_in_flight_count, last_seen_at, updated_at)
-           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, datetime('now'), datetime('now'))
+          `INSERT INTO sessions (resume_id, alias, tmux_name, server, ip, hostname, agent, project_dir, version, status, task, output, progress, score, node_id, session_id, config_path, channels, network_id, model, cpu_load_1min, cpu_cores, mem_total_gb, mem_used_gb, mem_avail_gb, disk_total_gb, disk_used_gb, disk_avail_gb, process_rss_bytes, process_rss_mb, process_cpu_pct, process_uptime_seconds, process_in_flight_count, external_schedules, last_seen_at, updated_at)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, datetime('now'), datetime('now'))
            ON CONFLICT(resume_id) DO UPDATE SET
              alias = COALESCE(?2, sessions.alias), tmux_name = COALESCE(?3, sessions.tmux_name),
              server = COALESCE(?4, sessions.server), ip = COALESCE(?5, sessions.ip),
@@ -648,8 +665,9 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
              process_cpu_pct = COALESCE(?31, sessions.process_cpu_pct),
              process_uptime_seconds = COALESCE(?32, sessions.process_uptime_seconds),
              process_in_flight_count = COALESCE(?33, sessions.process_in_flight_count),
+             external_schedules = COALESCE(?34, sessions.external_schedules),
              last_seen_at = datetime('now'), updated_at = datetime('now')`,
-          [resume_id, effectiveAlias, tmux ?? null, srv ?? null, hostIp, hostHostname, ag ?? null, pd ?? null, ver ?? null, status, task ?? null, trimmedOutput ?? null, progress ?? null, score ?? null, node_id ?? null, session_id ?? null, config_path ?? null, channels ?? null, sessionNetId, mdl ?? null, cpuLoad1m, cpuCores, memTotalGb, memUsedGb, memAvailGb, diskTotalGb, diskUsedGb, diskAvailGb, processRssBytes, processRssMb, processCpuPct, processUptimeSeconds, processInFlightCount]
+          [resume_id, effectiveAlias, tmux ?? null, srv ?? null, hostIp, hostHostname, ag ?? null, pd ?? null, ver ?? null, status, task ?? null, trimmedOutput ?? null, progress ?? null, score ?? null, node_id ?? null, session_id ?? null, config_path ?? null, channels ?? null, sessionNetId, mdl ?? null, cpuLoad1m, cpuCores, memTotalGb, memUsedGb, memAvailGb, diskTotalGb, diskUsedGb, diskAvailGb, processRssBytes, processRssMb, processCpuPct, processUptimeSeconds, processInFlightCount, externalSchedulesJson]
         );
         if (host || proc) {
           db.run(

--- a/tests/test185-external-schedules/Dockerfile
+++ b/tests/test185-external-schedules/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash curl ca-certificates jq procps sqlite3 \
+    bash curl ca-certificates jq procps sqlite3 unzip \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"

--- a/tests/test185-external-schedules/Dockerfile
+++ b/tests/test185-external-schedules/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash curl ca-certificates jq procps sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /app
+ARG TEST185_SOURCE_COMMIT=unknown
+ENV TEST185_SOURCE_COMMIT=${TEST185_SOURCE_COMMIT}
+
+COPY server /app/server
+COPY agent-node /app/agent-node
+COPY tests/lib /app/tests/lib
+COPY tests/test185-external-schedules /app/tests/test185-external-schedules
+RUN cd /app/server && bun install --silent
+RUN cd /app/agent-node && bun install --silent
+RUN chmod +x /app/tests/test185-external-schedules/run.sh
+
+CMD ["/app/tests/test185-external-schedules/run.sh"]

--- a/tests/test185-external-schedules/mutate-heartbeat.mjs
+++ b/tests/test185-external-schedules/mutate-heartbeat.mjs
@@ -1,0 +1,10 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const path = process.argv[2];
+const source = readFileSync(path, "utf8");
+const anchor = "    external_schedules: readExternalSchedulesSnapshot(configFilePath),\n";
+const matches = source.split(anchor).length - 1;
+if (matches !== 2) throw new Error(`expected two heartbeat anchors, found ${matches}`);
+const mutated = source.split(anchor).join("");
+if (mutated === source) throw new Error("heartbeat mutation was byte-identical");
+writeFileSync(path, mutated);

--- a/tests/test185-external-schedules/run.sh
+++ b/tests/test185-external-schedules/run.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${REPO:-/app}"
+source "$REPO/tests/lib/safe-rm.sh"
+WORK="${WORK:-/tmp/test185}"
+PORT="${PORT:-9185}"
+BASE="http://127.0.0.1:$PORT"
+ALIAS="external-schedule-node"
+ADMIN="external_schedule_admin"
+PASSWORD="External-Schedule-Strong-1!"
+PASS=0
+
+ok() { PASS=$((PASS + 1)); printf 'PASS %s\n' "$*"; }
+fail() { printf 'FAIL %s\n' "$*" >&2; exit 1; }
+
+test "${TEST185_SOURCE_COMMIT:-unknown}" != unknown
+safe_rm_rf "$WORK"
+mkdir -p "$WORK/home" "$WORK/node"
+export HOME="$WORK/home"
+
+HUB_PID=""
+NODE_PID=""
+stop_group() {
+  local pid="${1:-}"
+  [[ -n "$pid" ]] || return 0
+  kill -TERM -- "-$pid" 2>/dev/null || true
+  for _ in $(seq 1 40); do [[ ! -e "/proc/$pid" ]] && return 0; sleep 0.1; done
+  kill -KILL -- "-$pid" 2>/dev/null || true
+}
+cleanup() {
+  stop_group "$NODE_PID" || true
+  stop_group "$HUB_PID" || true
+  if [[ -f "$WORK/cli.ts.orig" ]]; then cp "$WORK/cli.ts.orig" "$REPO/agent-node/src/cli.ts"; fi
+}
+trap cleanup EXIT
+
+(cd "$REPO/server" && exec setsid env PORT="$PORT" HOST=127.0.0.1 NODE_ENV=test \
+  COMMHUB_DB="$WORK/hub.db" bun run src/index.ts >"$WORK/hub.log" 2>&1) &
+HUB_PID=$!
+for _ in $(seq 1 80); do curl -fsS "$BASE/health" >/dev/null 2>&1 && break; sleep 0.25; done
+curl -fsS "$BASE/health" >/dev/null || { tail -100 "$WORK/hub.log"; fail 'hub boot'; }
+ok 'real Hub booted'
+
+REG=$(curl -fsS -X POST "$BASE/api/auth/register" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN\",\"password\":\"$PASSWORD\",\"email\":\"test185@example.invalid\"}")
+UTOK=$(jq -r '.token // empty' <<<"$REG")
+NET=$(jq -r '.network_id // empty' <<<"$REG")
+[[ "$UTOK" == utok_* && -n "$NET" ]] || fail 'admin registration'
+NTOK=$(curl -fsS -X POST "$BASE/api/auth/node-token" -H "Authorization: Bearer $UTOK" \
+  -H 'Content-Type: application/json' -d "{\"network_id\":\"$NET\",\"node_name\":\"$ALIAS\"}" | jq -r '.token // empty')
+[[ "$NTOK" == ntok_* ]] || fail 'node token mint'
+ok 'network-scoped node token minted'
+
+CFG="$WORK/node/config.json"
+MANIFEST="$WORK/node/external-schedules.json"
+cat >"$CFG" <<JSON
+{"alias":"$ALIAS","runtime":"claude-agent-sdk","model":"claude-sonnet-4-6","hub":"$BASE","token":"$NTOK","network_id":"$NET"}
+JSON
+cat >"$MANIFEST" <<'JSON'
+{"external_schedules":[{"id":"pstation-smoke","name":"P station smoke","kind":"playwright","frequency":"*/5 * * * *","last_run_at":"2026-08-10T01:02:03Z","last_status":"success","last_error":null,"next_run_at":"2026-08-10T01:07:03Z","log_path":"/var/private/pstation-smoke.log","enabled":true}]}
+JSON
+
+start_node() {
+  NODE_PID=""
+  (cd "$WORK" && exec setsid env ANTHROPIC_API_KEY=test185-not-used HOME="$HOME" \
+    bun "$REPO/agent-node/src/cli.ts" --alias "$ALIAS" --config "$CFG" >"$WORK/node.log" 2>&1) &
+  NODE_PID=$!
+}
+stop_node() {
+  local pid="$NODE_PID"
+  NODE_PID=""
+  stop_group "$pid"
+  [[ -n "$pid" ]] && wait "$pid" 2>/dev/null || true
+}
+status_row() {
+  curl -fsS "$BASE/api/status?network_id=$NET" -H "Authorization: Bearer $UTOK" | jq -c --arg a "$ALIAS" '.sessions[]? | select(.alias==$a)'
+}
+wait_snapshot() {
+  local predicate="$1"
+  for _ in $(seq 1 80); do
+    local row
+    row=$(status_row || true)
+    if [[ -n "$row" ]] && jq -e "$predicate" >/dev/null 2>&1 <<<"$row"; then printf '%s\n' "$row"; return 0; fi
+    sleep 0.25
+  done
+  return 1
+}
+
+start_node
+ROW=$(wait_snapshot '.external_schedules.schedules[0].id == "pstation-smoke"') || { tail -100 "$WORK/node.log"; fail 'real heartbeat did not surface manifest'; }
+jq -e '.external_schedules.schedules[0].log_ref == "pstation-smoke.log"' >/dev/null <<<"$ROW" || fail 'basename log_ref missing'
+if grep -q '/var/private' <<<"$ROW"; then fail 'host path leaked through REST'; fi
+ok 'real agent heartbeat surfaces bounded snapshot without host path'
+
+stop_node
+rm -f "$MANIFEST"
+start_node
+ROW=$(wait_snapshot '.external_schedules.schedules == [] and (.external_schedules.error == null)') || fail 'missing manifest did not become explicit empty observation'
+ok 'new agent reports explicit empty list for missing manifest'
+
+stop_node
+printf '%s\n' '{"external_schedules":[{"id":"x","name":"x","kind":"custom","frequency":"5m","command":"cat /etc/passwd"}]}' >"$MANIFEST"
+start_node
+ROW=$(wait_snapshot '.external_schedules.error == "invalid_manifest" and .external_schedules.schedules == []') || fail 'invalid manifest was not fail-closed telemetry'
+if grep -q 'cat /etc/passwd' <<<"$ROW"; then fail 'unknown manifest field leaked'; fi
+ok 'malformed/unknown manifest fields fail closed without leaking content'
+
+stop_node
+cp "$REPO/agent-node/src/cli.ts" "$WORK/cli.ts.orig"
+node "$REPO/tests/test185-external-schedules/mutate-heartbeat.mjs" "$REPO/agent-node/src/cli.ts"
+rm -f "$MANIFEST"
+start_node
+set +e
+wait_snapshot '.external_schedules.schedules == [] and (.external_schedules.error == null)' >"$WORK/mutation-row.json"
+MUT_RC=$?
+set -e
+stop_node
+cp "$WORK/cli.ts.orig" "$REPO/agent-node/src/cli.ts"
+[[ "$MUT_RC" -ne 0 ]] || fail 'delete-heartbeat-wiring mutation stayed green'
+ok 'witnessed-red: deleting heartbeat wiring removes the observable snapshot'
+
+(cd "$REPO/agent-node" && bun test src/external-schedules.test.ts)
+ok 'manifest parser unit gates pass'
+(cd "$REPO/server" && bun test src/rest-explicit-columns-http.test.ts)
+ok 'REST projection gate passes'
+
+printf 'source_commit=%s\n' "$TEST185_SOURCE_COMMIT"
+printf 'RESULT: PASS (%s checks)\n' "$PASS"


### PR DESCRIPTION
Closes #185

Adds a bounded, explicit node-owned external schedule manifest to agent-node heartbeats and Hub session projections. The inventory is informational only: Agent Network does not execute or verify these schedules. Host paths are reduced to basename-only log references, unknown fields fail closed, and legacy omission remains distinguishable from an explicit empty inventory.

Verification: exact-SHA Docker test185 PASS (8 checks), real Hub + real heartbeat, mutation witnessed-red.

Dashboard UI is a separate stacked delivery in sleep2agi/agent-network-dashboard.