### PR TITLE
feat(#166): add evidence-only task diagnostics

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -1377,13 +1377,44 @@ curl -X POST http://localhost:9200/api/task \
 | `priority` | enum | | `high` / `normal`（默认）/ `low` |
 | `from` | string | | 发送者标识（默认 `"api"`） |
 | `network_id` | string | | 目标 network（utok\_ 调用时；ntok\_ 调用强制绑定） |
+| `parent_task_id` | string | | 用于自动回串结果的父任务 ID；没有权威当前任务 ID 时应省略。 |
 | `ttl_seconds` | number | | 过期秒数（默认 3600；非 schema 字段，server 在 [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 直接取 `body.ttl_seconds`） |
 
 **响应**（成功）：
 
 ```json
-{ "ok": true, "message_id": "uuid-xxx" }
+{ "ok": true, "task_id": "uuid-xxx", "message_id": "uuid-xxx" }
 ```
+
+`task_id` 是 canonical task identifier；`message_id` 为兼容旧调用方保留，
+当前与 `task_id` 相同。
+
+### MCP 优先与 REST fallback
+
+当前模型会话确实挂载 CommHub MCP 时，优先使用 `send_task` / `get_task`。
+若工具面板没有这些工具，应显式走带认证的 REST 路径，不得虚构工具调用，
+也不得声称任务链已经建立：
+
+```bash
+TASK_ID=$(curl -fsS -X POST http://localhost:9200/api/task \
+  -H "Authorization: Bearer $COMMHUB_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"alias":"代码1号","task":"排查这个故障","priority":"normal"}' \
+  | jq -r '.task_id')
+
+curl -fsS "http://localhost:9200/api/tasks/$TASK_ID" \
+  -H "Authorization: Bearer $COMMHUB_TOKEN"
+```
+
+只有拿到权威的当前任务 ID 时才传 `parent_task_id`；否则省略。省略意味着
+子任务结果不会自动回串到上游任务。
+
+单任务响应包含顶层 `diagnostic`。其中 `code`、`action_hint` 和 `evidence`
+只陈述 Hub 可观测事实：任务生命周期、目标注册/状态、按 network 隔离的实时
+SSE 连接数，以及权威 runtime submission/consumption 时间戳。它不能证明外部模型会话是否挂载了 MCP tools，也不能把相关性冒充为卡住任务的根因。
+
+两个 REST endpoint 都受 network scope 约束。认证请使用 `Authorization` header，
+不要把 token 放进 URL query。
 
 **常见 4xx**：
 

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -1314,13 +1314,48 @@ curl -X POST http://localhost:9200/api/task \
 | `priority` | enum | | `high` / `normal` (default) / `low` |
 | `from` | string | | Sender identifier (default `"api"`) |
 | `network_id` | string | | Target network (utok\_ caller; ntok\_ is force-bound) |
+| `parent_task_id` | string | | Parent task for automatic reply chaining. Omit it when no authoritative current task id is available. |
 | `ttl_seconds` | number | | Expiry in seconds (default 3600). Not part of the schema — server reads it directly from `body.ttl_seconds` at [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts). |
 
 **Response** (success):
 
 ```json
-{ "ok": true, "message_id": "uuid-xxx" }
+{ "ok": true, "task_id": "uuid-xxx", "message_id": "uuid-xxx" }
 ```
+
+`task_id` is the canonical task identifier. `message_id` is retained as a
+compatibility alias and currently has the same value.
+
+### MCP-first delegation and REST fallback
+
+Use the CommHub MCP `send_task` / `get_task` tools when the current model
+session actually exposes them. If they are absent, use the authenticated REST
+path explicitly; do not invent a tool call or claim that chaining is present:
+
+```bash
+TASK_ID=$(curl -fsS -X POST http://localhost:9200/api/task \
+  -H "Authorization: Bearer $COMMHUB_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"alias":"coder-1","task":"Inspect the failure","priority":"normal"}' \
+  | jq -r '.task_id')
+
+curl -fsS "http://localhost:9200/api/tasks/$TASK_ID" \
+  -H "Authorization: Bearer $COMMHUB_TOKEN"
+```
+
+When an authoritative current task id is available, include it as
+`parent_task_id`; otherwise omit the field. Omitting it means the child result
+will not automatically chain back to an upstream task.
+
+The single-task response includes a top-level `diagnostic` object. Its `code`,
+`action_hint`, and `evidence` report only facts the Hub can observe: task
+lifecycle state, target registration/status, network-scoped live SSE count,
+and authoritative runtime submission/consumption timestamps. A diagnostic
+does not prove whether MCP tools are mounted in an external model session, nor
+does it prove the root cause of a stalled task.
+
+Both routes are network-scoped. Use an `Authorization` header; do not put a
+token in the query string.
 
 **Common 4xx errors**:
 

--- a/docs/tests/report-test166-task-diagnostics.txt
+++ b/docs/tests/report-test166-task-diagnostics.txt
@@ -1,0 +1,99 @@
+================================================================
+test166 — evidence-only task diagnostics and REST fallback (#166)
+================================================================
+
+Date: 2026-08-10
+Base: 936a41107d2e314fb932b4a40541959a0a7055c4 (origin/main)
+Source commit: 8d290a8e91a747ca350091a8181c2cf9c9f54104
+Branch: feat/166-task-diagnostics
+
+Docker image:
+  tag: anet-test166:dev
+  image id: sha256:42fd92e9bf0aa9dfaabaa519348a123005d5df356f47cb702c365cdfedbe8da8
+  embedded TEST166_SOURCE_COMMIT:
+    8d290a8e91a747ca350091a8181c2cf9c9f54104
+
+Final result:
+  10 pass / 0 fail / 22 expect() calls
+  4 witnessed-red mutations, each rc=1
+  RESULT: PASS
+
+Scope
+-----
+
+- Adds an evidence-only diagnostic to the already network-scoped single-task
+  REST response (`GET /api/tasks/:id` and its existing singular alias).
+- Adds Chinese and English MCP-first / REST-fallback documentation.
+- Does not change task creation, delivery, retry, reply, or lifecycle state.
+- Does not add a Dashboard surface and does not change any agent runtime.
+
+Diagnostic contract
+-------------------
+
+The top-level `diagnostic` object has schema_version=1, a finite `code`, an
+`action_hint`, and these evidence facts only:
+
+- task status;
+- target session existence/status;
+- the exact target alias's live SSE connection count in the task network;
+- authoritative runtime_submitted_at / consumed_at presence.
+
+Precedence is terminal > consumed > submitted > missing registration >
+offline > no live SSE > lifecycle-only progress > delivered/waiting.
+
+The API deliberately does not claim that an external model session has or
+lacks MCP tools. The Hub cannot observe that capability. It also does not
+turn a correlation into a root-cause assertion.
+
+Real-wire coverage
+------------------
+
+The HTTP suite boots the real Hub with a private SQLite DB, creates two real
+users/networks, registers the same alias in both, and opens real SSE streams.
+It proves:
+
+1. Network B's same-alias SSE connection is not counted for network A.
+2. Network B cannot read network A's task (404 task_not_found).
+3. A same-network SSE connection is reported without claiming runtime
+   submission or consumption.
+4. Authoritative runtime timestamps outrank current connectivity.
+5. Offline and missing target sessions remain distinct.
+
+Witnessed-red mutations
+-----------------------
+
+Each mutator requires exactly one production anchor and a byte change before
+the test is run. Removing any of the following turns the named behavior red:
+
+1. terminal-precedence — rc=1
+2. runtime-consumed-precedence — rc=1
+3. no-sse-gate — rc=1
+4. cross-network-sse — rc=1
+
+The fourth mutation intentionally sums every same-alias SSE connection across
+networks; the real two-network HTTP test rejects that leakage.
+
+Documentation behavior
+----------------------
+
+Both language variants now document:
+
+- MCP-first delegation and explicit REST fallback;
+- canonical task_id plus compatibility message_id;
+- parent_task_id only when an authoritative current task id exists;
+- omission means no automatic upstream reply chaining;
+- Authorization header use, not a query token;
+- diagnostic evidence limits, including that MCP mounting is unobservable.
+
+Residual issue scope
+--------------------
+
+This candidate closes the REST diagnostic and fallback-documentation portion
+of #166. It does not pretend that the Hub can inspect an arbitrary external
+Codex/Claude tool panel at startup. A future runtime-owned bootstrap check may
+warn when its own known MCP configuration is absent, but that is outside this
+server-only evidence contract.
+
+Verdict: PASS. Candidate remains unmerged and undeployed pending independent
+review.
+================================================================

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -43,6 +43,7 @@ import {
 } from "./rest-projections.js";
 import { resolveRestFromSession } from "./rest-identity.js";
 import { stampTaskAuthOrigin, type TaskAuthOrigin } from "./task-auth-origin.js";
+import { diagnoseTask } from "./task-diagnostic.js";
 import { assertScheduledTaskBackendSupported, handleScheduledTaskRequest, startScheduledTaskScheduler } from "./scheduled-tasks.js";
 import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
 
@@ -2973,7 +2974,38 @@ return Bun.serve({
       if (!task) {
         return withCors(req, Response.json({ ok: false, error: "task_not_found", task_id: taskId }, { status: 404 }));
       }
-      return withCors(req, Response.json({ ok: true, task }));
+      const taskNetworkId = typeof task.network_id === "string" ? task.network_id : null;
+      const canonicalTarget = task.to_node_id
+        ? null
+        : resolveCanonicalAlias(taskNetworkId, String(task.to_name ?? "")).alias;
+      const targetParams: unknown[] = [];
+      let targetSql = "SELECT alias, status FROM sessions WHERE ";
+      if (task.to_node_id) {
+        targetSql += "node_id = ?1";
+        targetParams.push(task.to_node_id);
+      } else {
+        targetSql += "alias = ?1";
+        targetParams.push(canonicalTarget);
+      }
+      if (taskNetworkId) {
+        targetSql += " AND network_id = ?2";
+        targetParams.push(taskNetworkId);
+      } else {
+        targetSql += " AND network_id IS NULL";
+      }
+      targetSql += " ORDER BY updated_at DESC LIMIT 1";
+      const targetSession = db.get<{ alias: string; status: string }>(targetSql, ...targetParams);
+      const targetAlias = targetSession?.alias ?? canonicalTarget ?? String(task.to_name ?? "");
+      const liveSseConnections = getSSEStats().sessions[`${taskNetworkId || "global"}:${targetAlias}`] ?? 0;
+      const diagnostic = diagnoseTask({
+        status: String(task.status ?? "unknown"),
+        runtimeSubmittedAt: typeof task.runtime_submitted_at === "string" ? task.runtime_submitted_at : null,
+        consumedAt: typeof task.consumed_at === "string" ? task.consumed_at : null,
+        targetSessionStatus: targetSession?.status ?? null,
+        targetSessionExists: Boolean(targetSession),
+        liveSseConnections,
+      });
+      return withCors(req, Response.json({ ok: true, task, diagnostic }));
     }
 
     // ── REST: tasks table (V2) ──

--- a/server/src/task-diagnostic-http.test.ts
+++ b/server/src/task-diagnostic-http.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-task-diagnostic-"));
+process.env.COMMHUB_DB = join(PRIVATE_DB_DIR, "hub.db");
+
+let db: typeof import("./db.js").db;
+let server: ReturnType<typeof Bun.serve>;
+let base = "";
+let tokenA = "";
+let tokenB = "";
+let networkA = "";
+let networkB = "";
+
+const ALIAS = "diagnostic-worker";
+
+async function detail(token: string, taskId: string): Promise<{ status: number; body: any }> {
+  const response = await fetch(`${base}/api/tasks/${encodeURIComponent(taskId)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+function insertTask(taskId: string, patch: {
+  status?: string;
+  runtimeSubmittedAt?: string | null;
+  consumedAt?: string | null;
+} = {}) {
+  db.run(
+    `INSERT INTO tasks
+       (task_id, from_name, to_node_id, to_name, status, content, priority,
+        network_id, runtime_submitted_at, consumed_at)
+     VALUES (?1, 'diagnostic-sender', 'node-diagnostic-a', ?2, ?3,
+             'diagnose me', 'normal', ?4, ?5, ?6)`,
+    [taskId, ALIAS, patch.status ?? "delivered", networkA, patch.runtimeSubmittedAt ?? null, patch.consumedAt ?? null],
+  );
+}
+
+async function openSse(token: string, networkId: string): Promise<ReadableStreamDefaultReader<Uint8Array>> {
+  const response = await fetch(`${base}/events/${encodeURIComponent(ALIAS)}?network_id=${encodeURIComponent(networkId)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(response.status).toBe(200);
+  const reader = response.body!.getReader();
+  const first = await reader.read();
+  expect(new TextDecoder().decode(first.value)).toContain('"type":"connected"');
+  return reader;
+}
+
+beforeAll(async () => {
+  ({ db } = await import("./db.js"));
+  const { register } = await import("./auth.js");
+  const authA = register(`diagnostic_a_${Date.now()}`, "Diagnostic-A-Strong-1!", undefined, "diagnostic-a");
+  const authB = register(`diagnostic_b_${Date.now()}`, "Diagnostic-B-Strong-1!", undefined, "diagnostic-b");
+  expect(authA.ok).toBe(true);
+  expect(authB.ok).toBe(true);
+  tokenA = authA.token!;
+  tokenB = authB.token!;
+  networkA = authA.network_id!;
+  networkB = authB.network_id!;
+
+  for (const [networkId, suffix] of [[networkA, "a"], [networkB, "b"]] as const) {
+    db.run(
+      `INSERT INTO nodes
+         (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state)
+       VALUES (?1, ?2, ?2, ?3, 'diagnostic-host', datetime('now'), datetime('now'), 'active')`,
+      [`node-diagnostic-${suffix}`, ALIAS, networkId],
+    );
+    db.run(
+      `INSERT INTO sessions
+         (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+       VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))`,
+      [`resume-diagnostic-${suffix}`, ALIAS, `node-diagnostic-${suffix}`, networkId],
+    );
+  }
+
+  const mod = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop(true); } catch {}
+  try { rmSync(PRIVATE_DB_DIR, { recursive: true, force: true }); } catch {}
+});
+
+describe("#166 scoped single-task diagnostics", () => {
+  test("does not count another network's same-alias SSE connection", async () => {
+    insertTask("diag-cross-network");
+    const foreignReader = await openSse(tokenB, networkB);
+    try {
+      const own = await detail(tokenA, "diag-cross-network");
+      expect(own.status).toBe(200);
+      expect(own.body.diagnostic).toMatchObject({
+        code: "target_no_live_sse",
+        evidence: { live_sse_connections: 0 },
+      });
+      const foreign = await detail(tokenB, "diag-cross-network");
+      expect(foreign.status).toBe(404);
+      expect(foreign.body).toMatchObject({ ok: false, error: "task_not_found" });
+    } finally {
+      await foreignReader.cancel();
+    }
+  });
+
+  test("reports a live same-network SSE without claiming runtime consumption", async () => {
+    insertTask("diag-live-sse");
+    const reader = await openSse(tokenA, networkA);
+    try {
+      const result = await detail(tokenA, "diag-live-sse");
+      expect(result.body.diagnostic).toMatchObject({
+        code: "delivered_waiting_for_agent",
+        evidence: {
+          target_session_status: "idle",
+          live_sse_connections: 1,
+          runtime_submitted: false,
+          runtime_consumed: false,
+        },
+      });
+    } finally {
+      await reader.cancel();
+    }
+  });
+
+  test("uses authoritative runtime evidence before current connectivity", async () => {
+    insertTask("diag-submitted", { runtimeSubmittedAt: "2026-08-10T00:00:00Z" });
+    insertTask("diag-consumed", {
+      runtimeSubmittedAt: "2026-08-10T00:00:00Z",
+      consumedAt: "2026-08-10T00:00:01Z",
+    });
+    db.run("UPDATE sessions SET status = 'offline' WHERE node_id = 'node-diagnostic-a' AND network_id = ?1", [networkA]);
+    expect((await detail(tokenA, "diag-submitted")).body.diagnostic.code).toBe("runtime_submitted_waiting_for_signal");
+    expect((await detail(tokenA, "diag-consumed")).body.diagnostic.code).toBe("runtime_consumed_nonterminal");
+  });
+
+  test("distinguishes offline and missing target sessions", async () => {
+    insertTask("diag-offline");
+    expect((await detail(tokenA, "diag-offline")).body.diagnostic.code).toBe("target_session_offline");
+    db.run("DELETE FROM sessions WHERE node_id = 'node-diagnostic-a' AND network_id = ?1", [networkA]);
+    insertTask("diag-missing");
+    expect((await detail(tokenA, "diag-missing")).body.diagnostic.code).toBe("target_session_missing");
+  });
+});

--- a/server/src/task-diagnostic.test.ts
+++ b/server/src/task-diagnostic.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { diagnoseTask, type TaskDiagnosticInput } from "./task-diagnostic";
+
+const base = (patch: Partial<TaskDiagnosticInput> = {}): TaskDiagnosticInput => ({
+  status: "delivered",
+  runtimeSubmittedAt: null,
+  consumedAt: null,
+  targetSessionStatus: "idle",
+  targetSessionExists: true,
+  liveSseConnections: 1,
+  ...patch,
+});
+
+describe("#166 evidence-only task diagnostics", () => {
+  test("terminal state wins over stale transport and runtime evidence", () => {
+    expect(diagnoseTask(base({
+      status: "replied",
+      runtimeSubmittedAt: "2026-08-10T00:00:00Z",
+      consumedAt: "2026-08-10T00:00:01Z",
+      targetSessionExists: false,
+      targetSessionStatus: null,
+      liveSseConnections: 0,
+    }))).toMatchObject({ code: "terminal", action_hint: "none" });
+  });
+
+  test("runtime evidence outranks current target connectivity", () => {
+    expect(diagnoseTask(base({ consumedAt: "2026-08-10T00:00:01Z", liveSseConnections: 0 }))).toMatchObject({
+      code: "runtime_consumed_nonterminal",
+      action_hint: "inspect_runtime",
+    });
+    expect(diagnoseTask(base({ runtimeSubmittedAt: "2026-08-10T00:00:00Z", targetSessionStatus: "offline" }))).toMatchObject({
+      code: "runtime_submitted_waiting_for_signal",
+      action_hint: "inspect_runtime",
+    });
+  });
+
+  test("distinguishes missing, offline, and no-SSE targets", () => {
+    expect(diagnoseTask(base({ targetSessionExists: false, targetSessionStatus: null }))).toMatchObject({
+      code: "target_session_missing",
+      action_hint: "check_target_registration",
+    });
+    expect(diagnoseTask(base({ targetSessionStatus: "offline" }))).toMatchObject({
+      code: "target_session_offline",
+      action_hint: "restore_target",
+    });
+    expect(diagnoseTask(base({ liveSseConnections: 0 }))).toMatchObject({
+      code: "target_no_live_sse",
+      action_hint: "restore_sse",
+    });
+  });
+
+  test("does not infer consumption from lifecycle status alone", () => {
+    const diagnostic = diagnoseTask(base({ status: "running" }));
+    expect(diagnostic).toMatchObject({
+      code: "lifecycle_progress_without_runtime_evidence",
+      action_hint: "inspect_runtime",
+      evidence: { runtime_submitted: false, runtime_consumed: false },
+    });
+  });
+
+  test("reports delivered waiting only when registration and SSE are present", () => {
+    expect(diagnoseTask(base())).toEqual({
+      schema_version: 1,
+      code: "delivered_waiting_for_agent",
+      action_hint: "inspect_agent_queue",
+      evidence: {
+        task_status: "delivered",
+        target_session_status: "idle",
+        live_sse_connections: 1,
+        runtime_submitted: false,
+        runtime_consumed: false,
+      },
+    });
+  });
+
+  test("normalizes invalid SSE counts without widening the evidence", () => {
+    expect(diagnoseTask(base({ liveSseConnections: Number.NaN }))).toMatchObject({
+      code: "target_no_live_sse",
+      evidence: { live_sse_connections: 0 },
+    });
+  });
+});

--- a/server/src/task-diagnostic.ts
+++ b/server/src/task-diagnostic.ts
@@ -1,0 +1,89 @@
+const TERMINAL_STATUSES = new Set(["replied", "failed", "cancelled", "expired"]);
+
+export type TaskDiagnosticCode =
+  | "terminal"
+  | "runtime_consumed_nonterminal"
+  | "runtime_submitted_waiting_for_signal"
+  | "target_session_missing"
+  | "target_session_offline"
+  | "target_no_live_sse"
+  | "lifecycle_progress_without_runtime_evidence"
+  | "delivered_waiting_for_agent";
+
+export type TaskDiagnosticAction =
+  | "none"
+  | "inspect_runtime"
+  | "check_target_registration"
+  | "restore_target"
+  | "restore_sse"
+  | "inspect_agent_queue";
+
+export interface TaskDiagnosticInput {
+  status: string;
+  runtimeSubmittedAt: string | null;
+  consumedAt: string | null;
+  targetSessionStatus: string | null;
+  targetSessionExists: boolean;
+  liveSseConnections: number;
+}
+
+export interface TaskDiagnostic {
+  schema_version: 1;
+  code: TaskDiagnosticCode;
+  action_hint: TaskDiagnosticAction;
+  evidence: {
+    task_status: string;
+    target_session_status: string | null;
+    live_sse_connections: number;
+    runtime_submitted: boolean;
+    runtime_consumed: boolean;
+  };
+}
+
+/**
+ * Classify only facts the Hub can prove. This deliberately does not claim
+ * that a model session has (or lacks) MCP tools: that capability lives in an
+ * external runtime and is not observable from the Hub wire.
+ */
+export function diagnoseTask(input: TaskDiagnosticInput): TaskDiagnostic {
+  const liveSseConnections = Number.isSafeInteger(input.liveSseConnections) && input.liveSseConnections > 0
+    ? input.liveSseConnections
+    : 0;
+  const evidence: TaskDiagnostic["evidence"] = {
+    task_status: input.status,
+    target_session_status: input.targetSessionStatus,
+    live_sse_connections: liveSseConnections,
+    runtime_submitted: Boolean(input.runtimeSubmittedAt),
+    runtime_consumed: Boolean(input.consumedAt),
+  };
+
+  let code: TaskDiagnosticCode;
+  let action_hint: TaskDiagnosticAction;
+  if (TERMINAL_STATUSES.has(input.status)) {
+    code = "terminal";
+    action_hint = "none";
+  } else if (input.consumedAt) {
+    code = "runtime_consumed_nonterminal";
+    action_hint = "inspect_runtime";
+  } else if (input.runtimeSubmittedAt) {
+    code = "runtime_submitted_waiting_for_signal";
+    action_hint = "inspect_runtime";
+  } else if (!input.targetSessionExists) {
+    code = "target_session_missing";
+    action_hint = "check_target_registration";
+  } else if (input.targetSessionStatus === "offline") {
+    code = "target_session_offline";
+    action_hint = "restore_target";
+  } else if (liveSseConnections === 0) {
+    code = "target_no_live_sse";
+    action_hint = "restore_sse";
+  } else if (input.status === "acked" || input.status === "running") {
+    code = "lifecycle_progress_without_runtime_evidence";
+    action_hint = "inspect_runtime";
+  } else {
+    code = "delivered_waiting_for_agent";
+    action_hint = "inspect_agent_queue";
+  }
+
+  return { schema_version: 1, code, action_hint, evidence };
+}

--- a/tests/test166-task-diagnostics/Dockerfile
+++ b/tests/test166-task-diagnostics/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test166-task-diagnostics ./tests/test166-task-diagnostics
+
+ARG TEST166_SOURCE_COMMIT=unknown
+ENV TEST166_SOURCE_COMMIT=${TEST166_SOURCE_COMMIT}
+RUN chmod 0755 tests/test166-task-diagnostics/run.sh
+ENTRYPOINT ["/workspace/tests/test166-task-diagnostics/run.sh"]

--- a/tests/test166-task-diagnostics/Dockerfile
+++ b/tests/test166-task-diagnostics/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /workspace
 COPY server/package.json ./server/package.json
 RUN cd server && bun install --ignore-scripts
 COPY server ./server
+COPY docs-site/docs/api/rest.md ./docs-site/docs/api/rest.md
+COPY docs-site/docs/en/api/rest.md ./docs-site/docs/en/api/rest.md
 COPY tests/test166-task-diagnostics ./tests/test166-task-diagnostics
 
 ARG TEST166_SOURCE_COMMIT=unknown

--- a/tests/test166-task-diagnostics/mutate.mjs
+++ b/tests/test166-task-diagnostics/mutate.mjs
@@ -1,9 +1,34 @@
 import { readFileSync, writeFileSync } from "node:fs";
 
-const path = process.argv[2];
+const [mode, path] = process.argv.slice(2);
+if (!mode || !path) throw new Error("usage: mutate.mjs <mode> <path>");
+
+const mutations = {
+  "terminal-precedence": [
+    "if (TERMINAL_STATUSES.has(input.status)) {",
+    "if (false) {",
+  ],
+  "runtime-consumed-precedence": [
+    "} else if (input.consumedAt) {",
+    "} else if (false) {",
+  ],
+  "no-sse-gate": [
+    "} else if (liveSseConnections === 0) {",
+    "} else if (false) {",
+  ],
+  "cross-network-sse": [
+    'const liveSseConnections = getSSEStats().sessions[`${taskNetworkId || "global"}:${targetAlias}`] ?? 0;',
+    'const liveSseConnections = Object.entries(getSSEStats().sessions).filter(([key]) => key.endsWith(`:${targetAlias}`)).reduce((sum, [, count]) => sum + count, 0);',
+  ],
+};
+
+const pair = mutations[mode];
+if (!pair) throw new Error(`unknown mutation mode: ${mode}`);
 const source = readFileSync(path, "utf8");
-const anchor = "if (TERMINAL_STATUSES.has(input.status)) {";
-if (source.split(anchor).length - 1 !== 1) throw new Error("expected one terminal precedence anchor");
-const mutated = source.replace(anchor, "if (false) {");
-if (mutated === source) throw new Error("task diagnostic mutation was byte-identical");
+const [anchor, replacement] = pair;
+if (source.split(anchor).length - 1 !== 1) {
+  throw new Error(`expected exactly one ${mode} anchor`);
+}
+const mutated = source.replace(anchor, replacement);
+if (mutated === source) throw new Error(`${mode} mutation was byte-identical`);
 writeFileSync(path, mutated);

--- a/tests/test166-task-diagnostics/mutate.mjs
+++ b/tests/test166-task-diagnostics/mutate.mjs
@@ -1,0 +1,9 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const path = process.argv[2];
+const source = readFileSync(path, "utf8");
+const anchor = "if (TERMINAL_STATUSES.has(input.status)) {";
+if (source.split(anchor).length - 1 !== 1) throw new Error("expected one terminal precedence anchor");
+const mutated = source.replace(anchor, "if (false) {");
+if (mutated === source) throw new Error("task diagnostic mutation was byte-identical");
+writeFileSync(path, mutated);

--- a/tests/test166-task-diagnostics/run.sh
+++ b/tests/test166-task-diagnostics/run.sh
@@ -4,7 +4,7 @@ set -eu
 test "${TEST166_SOURCE_COMMIT:-unknown}" != unknown
 cd /workspace/server
 
-bun test src/task-diagnostic.test.ts
+bun test src/task-diagnostic.test.ts src/task-diagnostic-http.test.ts
 
 cp src/task-diagnostic.ts /tmp/task-diagnostic.orig
 node /workspace/tests/test166-task-diagnostics/mutate.mjs src/task-diagnostic.ts

--- a/tests/test166-task-diagnostics/run.sh
+++ b/tests/test166-task-diagnostics/run.sh
@@ -7,19 +7,44 @@ cd /workspace/server
 bun test src/task-diagnostic.test.ts src/task-diagnostic-http.test.ts
 
 cp src/task-diagnostic.ts /tmp/task-diagnostic.orig
-node /workspace/tests/test166-task-diagnostics/mutate.mjs src/task-diagnostic.ts
-cmp -s src/task-diagnostic.ts /tmp/task-diagnostic.orig && {
-  echo "terminal precedence mutation was byte-identical" >&2
-  exit 1
+cp src/server.ts /tmp/server.orig
+
+run_mutation() {
+  mode="$1"
+  target="$2"
+  test_file="$3"
+  expected="$4"
+  original="$5"
+  log="/tmp/test166-${mode}.log"
+
+  node /workspace/tests/test166-task-diagnostics/mutate.mjs "$mode" "$target"
+  cmp -s "$target" "$original" && {
+    echo "$mode mutation was byte-identical" >&2
+    exit 1
+  }
+  set +e
+  bun test "$test_file" >"$log" 2>&1
+  mutation_rc=$?
+  set -e
+  cp "$original" "$target"
+  test "$mutation_rc" -ne 0
+  grep -q "$expected" "$log"
+  printf 'mutation=%s rc=%s witnessed-red\n' "$mode" "$mutation_rc"
 }
-set +e
-bun test src/task-diagnostic.test.ts >/tmp/test166-mutation.log 2>&1
-mutation_rc=$?
-set -e
-cp /tmp/task-diagnostic.orig src/task-diagnostic.ts
-test "$mutation_rc" -ne 0
-grep -q 'terminal state wins over stale transport and runtime evidence' /tmp/test166-mutation.log
-printf 'mutation=remove-terminal-precedence rc=%s witnessed-red\n' "$mutation_rc"
+
+run_mutation terminal-precedence src/task-diagnostic.ts src/task-diagnostic.test.ts \
+  'terminal state wins over stale transport and runtime evidence' /tmp/task-diagnostic.orig
+run_mutation runtime-consumed-precedence src/task-diagnostic.ts src/task-diagnostic.test.ts \
+  'runtime evidence outranks current target connectivity' /tmp/task-diagnostic.orig
+run_mutation no-sse-gate src/task-diagnostic.ts src/task-diagnostic.test.ts \
+  'distinguishes missing, offline, and no-SSE targets' /tmp/task-diagnostic.orig
+run_mutation cross-network-sse src/server.ts src/task-diagnostic-http.test.ts \
+  "does not count another network's same-alias SSE connection" /tmp/server.orig
+
+grep -q 'MCP-first' /workspace/docs-site/docs/en/api/rest.md
+grep -q 'MCP 优先' /workspace/docs-site/docs/api/rest.md
+grep -q 'does not prove whether MCP tools are mounted' /workspace/docs-site/docs/en/api/rest.md
+grep -q '不能证明外部模型会话是否挂载了 MCP tools' /workspace/docs-site/docs/api/rest.md
 
 printf 'source_commit=%s\n' "$TEST166_SOURCE_COMMIT"
 printf 'RESULT: PASS\n'

--- a/tests/test166-task-diagnostics/run.sh
+++ b/tests/test166-task-diagnostics/run.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+test "${TEST166_SOURCE_COMMIT:-unknown}" != unknown
+cd /workspace/server
+
+bun test src/task-diagnostic.test.ts
+
+cp src/task-diagnostic.ts /tmp/task-diagnostic.orig
+node /workspace/tests/test166-task-diagnostics/mutate.mjs src/task-diagnostic.ts
+cmp -s src/task-diagnostic.ts /tmp/task-diagnostic.orig && {
+  echo "terminal precedence mutation was byte-identical" >&2
+  exit 1
+}
+set +e
+bun test src/task-diagnostic.test.ts >/tmp/test166-mutation.log 2>&1
+mutation_rc=$?
+set -e
+cp /tmp/task-diagnostic.orig src/task-diagnostic.ts
+test "$mutation_rc" -ne 0
+grep -q 'terminal state wins over stale transport and runtime evidence' /tmp/test166-mutation.log
+printf 'mutation=remove-terminal-precedence rc=%s witnessed-red\n' "$mutation_rc"
+
+printf 'source_commit=%s\n' "$TEST166_SOURCE_COMMIT"
+printf 'RESULT: PASS\n'


### PR DESCRIPTION
## Summary

- add network-scoped evidence-only diagnostics to single-task REST responses
- distinguish terminal/runtime/session/SSE/lifecycle states without claiming unobservable MCP presence
- document MCP-first and authenticated REST fallback in Chinese and English
- add real-Hub/two-network/SSE tests plus four witnessed-red mutations

## Evidence

- source: `8d290a8e91a747ca350091a8181c2cf9c9f54104`
- report-only head: `69e7b85ababb1ded427774ad4e5e52e354741a14`
- Docker: `10 pass / 0 fail / 22 assertions`
- mutations: terminal precedence, runtime-consumed precedence, no-SSE gate, cross-network SSE scope — all rc=1
- report: `docs/tests/report-test166-task-diagnostics.txt`

## Boundaries

This closes the REST diagnostic/fallback-doc portion of #166. It does not claim the Hub can inspect whether an arbitrary external model session has MCP tools mounted.

Draft pending independent review; no merge or deployment authorization.