### PR TITLE
test(#31): anchor REST response key golden

### DIFF
--- a/docs/tests/report-test686-rest-shape-golden.txt
+++ b/docs/tests/report-test686-rest-shape-golden.txt
@@ -1,0 +1,73 @@
+================================================================
+test686 — independent REST response-key golden (#31 / #311 follow-up)
+================================================================
+
+Date: 2026-08-10
+Base: 936a41107d2e314fb932b4a40541959a0a7055c4 (origin/main)
+Source commit: 9043c4b0694adb1b9e5c4282045053c074e6f611
+Branch: test/31-rest-shape-golden
+Production source delta: none
+
+Docker image:
+  tag: anet-test686:dev
+  image id: sha256:ff7693a3fea7f8b9f9f12f6d3a2946e0bad5e3888f1475e7a8cd1c0520aee357
+  embedded TEST686_SOURCE_COMMIT:
+    9043c4b0694adb1b9e5c4282045053c074e6f611
+
+Result:
+  green: 5 pass / 0 fail / 29 assertions
+  mutation: drop-task-created-at rc=1 witnessed-red
+  restored: 5 pass / 0 fail / 29 assertions
+  RESULT: PASS
+
+Problem closed by this test
+---------------------------
+
+The #311 explicit-projection test previously derived its expected response
+keys from the same production projection constants used by the SQL query.
+That proved the constants were internally self-consistent and blocked future
+SELECT-star widening, but it could not detect a public key accidentally being
+deleted from a projection: the key disappeared from both response and
+expectation, leaving the suite green.
+
+Change
+------
+
+The real-Hub HTTP test now owns an independent, static golden for these public
+row contracts:
+
+- network list and detail;
+- status session rows;
+- task list and detail;
+- audit logs;
+- task events;
+- completions;
+- scheduled tasks.
+
+The expected keys are no longer imported from `rest-projections.ts`. Future
+intentional API changes must update the wire golden explicitly; accidental
+projection shrinkage turns red.
+
+Witnessed-red
+-------------
+
+The mutator removes the historically public `created_at` field from
+`TASK_REST_COLUMNS`, while leaving the independent test golden untouched.
+The real HTTP task list/detail test fails with rc=1 and names `created_at` in
+the diff. Restoring the production projection returns the same suite to green.
+
+The mutation requires exactly one source anchor and verifies a byte change,
+so a no-op sed/anchor miss cannot count as evidence.
+
+Scope limits
+------------
+
+- Test and report only; no production runtime, API, schema, or deployment
+  behavior changes.
+- This complements rather than replaces test647's future-column sentinel:
+  test647 blocks accidental widening, while this golden blocks accidental
+  narrowing.
+- No credentials, private hosts, or user data appear in fixtures or report.
+
+Verdict: PASS. Candidate remains unmerged and undeployed pending review.
+================================================================

--- a/server/src/rest-explicit-columns-http.test.ts
+++ b/server/src/rest-explicit-columns-http.test.ts
@@ -2,15 +2,6 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  AUDIT_LOG_REST_COLUMNS,
-  COMPLETION_REST_COLUMNS,
-  NETWORK_REST_COLUMNS,
-  SESSION_REST_COLUMNS,
-  TASK_EVENT_REST_COLUMNS,
-  TASK_REST_COLUMNS,
-  SCHEDULED_TASK_STORAGE_COLUMNS,
-} from "./rest-projections.js";
 
 const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-rest-columns-"));
 process.env.COMMHUB_DB ||= join(PRIVATE_DB_DIR, "hub.db");
@@ -24,6 +15,54 @@ let networkId = "";
 const INTERNAL_SENTINEL = "future_internal_only";
 const sortedKeys = (value: Record<string, unknown>): string[] => Object.keys(value).sort();
 const sorted = (values: readonly string[]): string[] => [...values].sort();
+
+// Independent wire-contract golden. Do not derive these expectations from
+// rest-projections.ts: doing so makes a deleted projection column disappear
+// from both the response and the expected value, producing a false green.
+const GOLDEN_RESPONSE_KEYS = {
+  networkList: [
+    "network_id", "network_name", "owner_id", "description", "settings",
+    "created_at", "updated_at", "visibility", "max_members", "member_role", "name",
+  ],
+  networkDetail: [
+    "network_id", "network_name", "owner_id", "description", "settings",
+    "created_at", "updated_at", "visibility", "max_members",
+  ],
+  statusSession: [
+    "resume_id", "alias", "tmux_name", "server", "ip", "hostname", "agent",
+    "project_dir", "version", "status", "task", "output", "progress", "score",
+    "cpu_load_1min", "cpu_cores", "mem_total_gb", "mem_used_gb", "mem_avail_gb",
+    "disk_total_gb", "disk_used_gb", "disk_avail_gb", "process_rss_bytes",
+    "process_rss_mb", "process_cpu_pct", "process_uptime_seconds",
+    "process_in_flight_count", "network_id", "registered_at", "updated_at",
+    "node_id", "session_id", "config_path", "channels", "last_seen_at", "model",
+    "runtime", "host", "process_telemetry",
+  ],
+  task: [
+    "task_id", "from_node_id", "from_name", "to_node_id", "to_name", "priority",
+    "status", "content", "result", "in_reply_to", "requires_response", "scope",
+    "created_at", "delivered_at", "started_at", "runtime_submitted_at", "consumed_at",
+    "completed_at", "expires_at", "network_id", "parent_task_id", "meta_json",
+  ],
+  audit: [
+    "id", "user_id", "username", "action", "target_type", "target_id", "detail",
+    "ip", "network_id", "created_at",
+  ],
+  taskEvent: [
+    "id", "task_id", "from_status", "to_status", "event_type", "actor", "detail",
+    "created_at", "network_id",
+  ],
+  completion: [
+    "id", "session_name", "task", "result", "artifacts", "score",
+    "duration_minutes", "network_id", "completed_at",
+  ],
+  scheduledTask: [
+    "schedule_id", "network_id", "name", "target_node_id", "target_alias",
+    "task_content", "priority", "schedule_type", "timezone", "overlap_policy",
+    "misfire_policy", "status", "next_run_at", "last_run_at", "revision",
+    "created_at", "updated_at", "schedule",
+  ],
+} as const;
 
 async function api(path: string): Promise<any> {
   const response = await fetch(`${base}${path}`, {
@@ -97,50 +136,49 @@ describe("#311 REST response projections are stable across future ALTER TABLE", 
   test("network list and detail preserve their existing public keys", async () => {
     const list = await api("/api/networks");
     const row = list.networks.find((item: any) => item.network_id === networkId);
-    expect(sortedKeys(row)).toEqual(sorted([...NETWORK_REST_COLUMNS, "member_role", "name"]));
+    expect(sortedKeys(row)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.networkList));
     expect(row[INTERNAL_SENTINEL]).toBeUndefined();
 
     const detail = await api(`/api/networks/${networkId}`);
-    expect(sortedKeys(detail.network)).toEqual(sorted(NETWORK_REST_COLUMNS));
+    expect(sortedKeys(detail.network)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.networkDetail));
     expect(detail.network[INTERNAL_SENTINEL]).toBeUndefined();
   });
 
   test("full status preserves telemetry compatibility without storage drift", async () => {
     const body = await api(`/api/status?network_id=${networkId}`);
     const row = body.sessions.find((item: any) => item.alias === "rest-shape-node");
-    expect(sortedKeys(row)).toEqual(sorted([...SESSION_REST_COLUMNS, "runtime", "host", "process_telemetry"]));
+    expect(sortedKeys(row)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.statusSession));
     expect(row[INTERNAL_SENTINEL]).toBeUndefined();
   });
 
   test("task list and task detail expose the same explicit contract", async () => {
     const list = await api(`/api/tasks?network_id=${networkId}&task_id=task-rest-shape&skip_stats=1`);
-    expect(sortedKeys(list.tasks[0])).toEqual(sorted(TASK_REST_COLUMNS));
+    expect(sortedKeys(list.tasks[0])).toEqual(sorted(GOLDEN_RESPONSE_KEYS.task));
     expect(list.tasks[0][INTERNAL_SENTINEL]).toBeUndefined();
 
     const detail = await api(`/api/tasks/task-rest-shape?network_id=${networkId}`);
-    expect(sortedKeys(detail.task)).toEqual(sorted(TASK_REST_COLUMNS));
+    expect(sortedKeys(detail.task)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.task));
     expect(detail.task[INTERNAL_SENTINEL]).toBeUndefined();
   });
 
   test("audit, task-event, and completion rows are explicit", async () => {
     const audit = await api("/api/audit-log?action=shape_action");
-    expect(sortedKeys(audit.logs[0])).toEqual(sorted(AUDIT_LOG_REST_COLUMNS));
+    expect(sortedKeys(audit.logs[0])).toEqual(sorted(GOLDEN_RESPONSE_KEYS.audit));
     expect(audit.logs[0][INTERNAL_SENTINEL]).toBeUndefined();
 
     const events = await api(`/api/task_events?network_id=${networkId}&task_id=task-rest-shape`);
-    expect(sortedKeys(events.events[0])).toEqual(sorted(TASK_EVENT_REST_COLUMNS));
+    expect(sortedKeys(events.events[0])).toEqual(sorted(GOLDEN_RESPONSE_KEYS.taskEvent));
     expect(events.events[0][INTERNAL_SENTINEL]).toBeUndefined();
 
     const completions = await api(`/api/completions?network_id=${networkId}&since=2000-01-01T00:00:00.000Z`);
-    expect(sortedKeys(completions.completions[0])).toEqual(sorted(COMPLETION_REST_COLUMNS));
+    expect(sortedKeys(completions.completions[0])).toEqual(sorted(GOLDEN_RESPONSE_KEYS.completion));
     expect(completions.completions[0][INTERNAL_SENTINEL]).toBeUndefined();
   });
 
   test("scheduled-task decoding keeps storage-only identity and JSON private", async () => {
     const body = await api(`/api/scheduled-tasks?network_id=${networkId}`);
     const row = body.schedules.find((item: any) => item.schedule_id === "schedule-rest-shape");
-    const publicColumns = SCHEDULED_TASK_STORAGE_COLUMNS.filter((key) => key !== "created_by" && key !== "schedule_json");
-    expect(sortedKeys(row)).toEqual(sorted([...publicColumns, "schedule"]));
+    expect(sortedKeys(row)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.scheduledTask));
     expect(row.created_by).toBeUndefined();
     expect(row.schedule_json).toBeUndefined();
     expect(row[INTERNAL_SENTINEL]).toBeUndefined();

--- a/tests/test686-rest-shape-golden/Dockerfile
+++ b/tests/test686-rest-shape-golden/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test686-rest-shape-golden ./tests/test686-rest-shape-golden
+
+ARG TEST686_SOURCE_COMMIT=unknown
+ENV TEST686_SOURCE_COMMIT=$TEST686_SOURCE_COMMIT
+
+RUN chmod 0755 tests/test686-rest-shape-golden/run.sh
+ENTRYPOINT ["/workspace/tests/test686-rest-shape-golden/run.sh"]

--- a/tests/test686-rest-shape-golden/mutate.mjs
+++ b/tests/test686-rest-shape-golden/mutate.mjs
@@ -1,0 +1,14 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const path = process.argv[2];
+if (!path) throw new Error("usage: mutate.mjs <rest-projections.ts>");
+
+const source = readFileSync(path, "utf8");
+const anchor = '  "created_at", "delivered_at", "started_at", "runtime_submitted_at", "consumed_at", "completed_at", "expires_at",';
+const replacement = '  "delivered_at", "started_at", "runtime_submitted_at", "consumed_at", "completed_at", "expires_at",';
+if (source.split(anchor).length - 1 !== 1) {
+  throw new Error("expected exactly one task created_at projection anchor");
+}
+const mutated = source.replace(anchor, replacement);
+if (mutated === source) throw new Error("projection mutation was byte-identical");
+writeFileSync(path, mutated);

--- a/tests/test686-rest-shape-golden/run.sh
+++ b/tests/test686-rest-shape-golden/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+test "${TEST686_SOURCE_COMMIT:-unknown}" != unknown
+cd /workspace
+
+echo "L0: independent golden remains green"
+bun test server/src/rest-explicit-columns-http.test.ts
+
+cp server/src/rest-projections.ts /tmp/rest-projections.orig
+node tests/test686-rest-shape-golden/mutate.mjs server/src/rest-projections.ts
+cmp -s server/src/rest-projections.ts /tmp/rest-projections.orig && {
+  echo "projection mutation was byte-identical" >&2
+  exit 1
+}
+
+echo "L1: removing a previously public task key must turn red"
+set +e
+bun test server/src/rest-explicit-columns-http.test.ts >/tmp/test686-mutation.log 2>&1
+mutation_rc=$?
+set -e
+cp /tmp/rest-projections.orig server/src/rest-projections.ts
+test "$mutation_rc" -ne 0
+grep -q 'task list and task detail expose the same explicit contract' /tmp/test686-mutation.log
+grep -q 'created_at' /tmp/test686-mutation.log
+printf 'mutation=drop-task-created-at rc=%s witnessed-red\n' "$mutation_rc"
+
+echo "L2: restored production projection remains green"
+bun test server/src/rest-explicit-columns-http.test.ts
+
+printf 'source_commit=%s\n' "$TEST686_SOURCE_COMMIT"
+printf 'RESULT: PASS\n'


### PR DESCRIPTION
## Summary

- replace self-derived REST response-key expectations with an independent static wire golden
- preserve test647 future-column widening coverage while also detecting accidental projection narrowing
- add exact-SHA Docker evidence and a non-vacuous mutation that removes `tasks.created_at`

## Root cause

The existing HTTP test imported the same projection constants used by production SQL. Removing a public column changed both the response and expected value, so the test could stay green.

## Validation

- source: `9043c4b0694adb1b9e5c4282045053c074e6f611`
- report-only head: `49494775ccdcda4419e56e3620be940ffc0ddf2a`
- image: `sha256:ff7693a3fea7f8b9f9f12f6d3a2946e0bad5e3888f1475e7a8cd1c0520aee357`
- green/restored: 5 tests, 29 assertions, 0 failures
- mutation `drop-task-created-at`: rc=1 witnessed-red

## Scope

Test and report only. No production runtime, API, schema, or deployment change. Draft pending review; no merge/deploy authorization.