### PR TITLE
fix(scheduler): report real task terminal state in run history

### DIFF
--- a/docs/rfcs/RFC-034-hub-scheduled-tasks.md
+++ b/docs/rfcs/RFC-034-hub-scheduled-tasks.md
@@ -22,7 +22,7 @@
 
 `scheduled_tasks` 是计划真相：network、创建人、稳定目标、任务正文、计划规格、状态、next/last time 与 optimistic `revision`。
 
-`scheduled_task_runs` 是每个 occurrence 的不可混淆记录。`UNIQUE(schedule_id, scheduled_for)` 是多 Hub 进程竞争时的幂等 claim。run 只引用普通 `task_id`，不复制 task lifecycle。
+`scheduled_task_runs` 是每个 occurrence 的不可混淆记录。`UNIQUE(schedule_id, scheduled_for)` 是多 Hub 进程竞争时的幂等 claim。run 通过 `run_id + task_id + network_id + schedule_id` 精确绑定普通 task；它不是第二套 lifecycle 真相源，但会投影该 task 的当前终态，供运行历史直接判断真实成功、失败、取消或过期。
 
 历史取消不物理删除：计划标记 `cancelled`，run history 保留。
 
@@ -37,6 +37,9 @@
 7. `misfire_policy=skip` 在超过 60 秒宽限窗口后不创建 `task`/`inbox`，只写一条 `status=skipped,error_code=misfire_skipped` 的可审计 run，再推进到下一次未来 occurrence。60 秒以内仍按正常调度处理，避免把 scheduler tick 抖动误判为停机错过。
 8. 单次计划无论成功投递、按策略跳过或因目标失效而失败，均进入 `completed`，不永久自旋。
 9. 目标处于 stop/delete lifecycle 时 fail closed，run 记录失败；普通 offline 仍排队。
+10. `inbox`/`tasks` 持久化成功只代表派发：run 的 `completed_at` 必须保持 `NULL`。仅当精确绑定的 task 进入 `replied/failed/cancelled/expired` 时，才在同一 transaction 写入 run 的终态和 `completed_at`。
+11. `retry_task` 复用原 logical `task_id`，因此会把同一 run 重新打开为 `delivered, completed_at=NULL`；重试后的新终态再关闭该 run。`reassign_task` 只允许非终态 task，保持 run 开放且不换绑定。
+12. agent 子任务的结果通过 parent chain 回终 scheduler task 时，parent task 与 run 的终态必须同事务提交；不能把“子任务已回复、父 run 仍 delivered”当作完成。
 
 SQLite transaction 是当前生产原子边界。仓库现有 PostgreSQL adapter 已明确不提供真实跨语句 transaction；`startHub()` 会在监听前 fail closed，直到该 adapter 修复，不得把 PostgreSQL 宣称为 scheduler 的 production-safe 后端。
 

--- a/docs/tests/report-test690-scheduled-run-terminal.txt
+++ b/docs/tests/report-test690-scheduled-run-terminal.txt
@@ -1,0 +1,41 @@
+# test690 — scheduled run terminal lifecycle
+
+Date: 2026-08-10
+Issue: https://github.com/sleep2agi/agent-network/issues/690
+Source commit: d63da5a272742228eaf01f610204c1eac081b1a1
+Base lineage: bf962ae0d7b2230e3656bdd38b2abea24dc4b27f + origin/main 065a550fa7a604fc45606bafbff34203de594341
+Image: anet-test690:dev
+Image ID: sha256:a9f9189112e0477c6e95af41c3ce680442f69f4ad9e00a5360494a3a81b96b44
+Embedded ENV: TEST690_SOURCE_COMMIT=d63da5a272742228eaf01f610204c1eac081b1a1
+Runner artifact SHA256: ef3d8b0c95ae3fc2f2251bad6bd72509a11ad85a8c599262c5d21971fdfb44fc
+
+Command:
+
+    sg docker -c 'docker build -t anet-test690:dev --build-arg SOURCE_COMMIT=d63da5a272742228eaf01f610204c1eac081b1a1 -f tests/test690-scheduled-run-terminal/Dockerfile .'
+    sg docker -c 'docker run --rm -v /tmp/test690-artifacts:/artifacts anet-test690:dev'
+
+Result: PASS
+
+Layers:
+
+- L0: Bun production bundle succeeds (262 modules, 1.59 MB).
+- L1: real SQLite lifecycle suite: 9 pass / 0 fail / 28 assertions.
+- L1b: existing scheduler regression matrix: 12 pass / 0 fail / 106 assertions.
+- L2: disabling `syncScheduledRunForTask` turns the lifecycle suite red (rc=1).
+- L3: removing the exact task_id binding from lookup + CAS turns the forged-binding test red (rc=1).
+- L4: removing the exact network_id binding from lookup + CAS turns the foreign-network test red (rc=1).
+- L5: restored source returns to 9 pass / 0 fail / 28 assertions.
+
+Behavior proved:
+
+1. Successful dispatch leaves `scheduled_task_runs.completed_at=NULL`; dispatch is not reported as completion.
+2. `send_reply`, `report_completion`, cancel, expiry patrol and child-to-parent auto-chain mirror the task's actual terminal status into the exact run.
+3. The task terminal write and run terminal write share one SQLite transaction. An injected trigger failure on the run update rolls back the task update and reply inbox insert too.
+4. `retry_task` reuses the logical task_id and deliberately reopens the same run as `delivered,completed_at=NULL`; the retry's final outcome closes it again. Reassign remains non-terminal and does not change the binding.
+5. Matching is fail-closed and exact on run_id + schedule_id + task_id + network_id. Forged task metadata, another task_id, another network, or ambiguous duplicate bindings cannot close a run.
+6. Reply attachment metadata may replace task meta_json without breaking the run lifecycle because the authoritative binding is read from `scheduled_task_runs`, not caller-controlled metadata.
+7. Existing scheduler DST, misfire, multi-process claim, non-overlap, edit CAS, tenant isolation and run-history tests remain green.
+
+Pre-fix witnessed red (same Docker suite before production changes): 1 pass / 5 fail. Dispatch had a non-null completed_at and reply/cancel/report_completion/child-chain all left runs at `delivered`.
+
+No production deployment, merge, npm publish or global install was performed by this test.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1496,38 +1496,40 @@ export function chainReplyToParent(
     const marker = `\n\n[via ${childAlias} 子任务结果]\n${currentReply}`;
     const newResult = parent.result ? parent.result + marker : `[via ${childAlias} 子任务结果]\n${currentReply}`;
 
-    // Bump parent status to replied if still open. If it was already replied
-    // (e.g. 指挥室 sent an early status update), we still want to update the
-    // result so the dashboard can render the final chained answer — but keep
-    // status as replied (it was already terminal).
-    if (parent.status === "delivered" || parent.status === "acked" || parent.status === "running" || parent.status === "created") {
-      db.run(
-        "UPDATE tasks SET status = ?1, result = ?2, completed_at = datetime('now') WHERE task_id = ?3",
-        [replyStatus, newResult.slice(0, 8000), parent.task_id]
-      );
-      logTaskEvent(parent.task_id, parent.status, replyStatus, "auto-chain", `from ${childAlias}`);
-    } else {
-      db.run(
-        "UPDATE tasks SET result = ?1, completed_at = datetime('now') WHERE task_id = ?2",
-        [newResult.slice(0, 8000), parent.task_id]
-      );
-      logTaskEvent(parent.task_id, parent.status, parent.status, "auto-chain-append", `from ${childAlias}`);
-    }
-
-    if (parent.from_name && parent.from_name !== "hub" && parent.from_name !== "api") {
-      try {
-        const notifyId = `chain_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
-        const notifyNode = db.get<{ node_id: string | null }>(
-          "SELECT node_id FROM sessions WHERE alias = ?1 AND COALESCE(network_id, 'default') = COALESCE(?2, 'default') ORDER BY updated_at DESC LIMIT 1",
-          [parent.from_name, parent.network_id ?? null]
-        );
+    db.transaction(() => {
+      // Bump parent status to replied if still open. The task transition and
+      // its scheduler-run mirror share this transaction, so a crash cannot
+      // leave one terminal while the other remains delivered.
+      if (parent.status === "delivered" || parent.status === "acked" || parent.status === "running" || parent.status === "created") {
         db.run(
-          `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, in_reply_to, requires_response, network_id)
-           VALUES (?1, ?2, ?3, 'reply', 'normal', ?4, ?5, ?6, 'none', ?7)`,
-          [notifyId, parent.from_name, notifyNode?.node_id ?? null, `[${childAlias} 子任务完成]\n${currentReply.slice(0, 4000)}`, parent.to_name, parent.task_id, parent.network_id ?? null]
+          "UPDATE tasks SET status = ?1, result = ?2, completed_at = datetime('now') WHERE task_id = ?3",
+          [replyStatus, newResult.slice(0, 8000), parent.task_id]
         );
-      } catch {}
-    }
+        syncScheduledRunForTask(parent.task_id, parent.network_id);
+        logTaskEvent(parent.task_id, parent.status, replyStatus, "auto-chain", `from ${childAlias}`);
+      } else {
+        db.run(
+          "UPDATE tasks SET result = ?1, completed_at = datetime('now') WHERE task_id = ?2",
+          [newResult.slice(0, 8000), parent.task_id]
+        );
+        logTaskEvent(parent.task_id, parent.status, parent.status, "auto-chain-append", `from ${childAlias}`);
+      }
+
+      if (parent.from_name && parent.from_name !== "hub" && parent.from_name !== "api") {
+        try {
+          const notifyId = `chain_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+          const notifyNode = db.get<{ node_id: string | null }>(
+            "SELECT node_id FROM sessions WHERE alias = ?1 AND COALESCE(network_id, 'default') = COALESCE(?2, 'default') ORDER BY updated_at DESC LIMIT 1",
+            [parent.from_name, parent.network_id ?? null]
+          );
+          db.run(
+            `INSERT INTO inbox (id, session_name, node_id, type, priority, content, from_session, in_reply_to, requires_response, network_id)
+             VALUES (?1, ?2, ?3, 'reply', 'normal', ?4, ?5, ?6, 'none', ?7)`,
+            [notifyId, parent.from_name, notifyNode?.node_id ?? null, `[${childAlias} 子任务完成]\n${currentReply.slice(0, 4000)}`, parent.to_name, parent.task_id, parent.network_id ?? null]
+          );
+        } catch {}
+      }
+    });
 
     // This iteration actually wrote a parent row (and possibly an
     // inbox notification). Record that so the caller can gate its
@@ -1539,6 +1541,79 @@ export function chainReplyToParent(
     currentReply = newResult;
   }
   return { chained };
+}
+
+const SCHEDULED_RUN_TERMINAL_STATUSES = new Set(["replied", "failed", "cancelled", "expired"]);
+
+type ScheduledTaskLifecycleRow = {
+  task_id: string;
+  network_id: string | null;
+  status: string;
+  completed_at: string | null;
+};
+
+type ScheduledTaskBinding = { run_id: string; schedule_id: string };
+
+/**
+ * Mirror an exact scheduler-created task's lifecycle into its run row.
+ *
+ * The status is always read back from `tasks`; callers cannot supply one.
+ * The scheduler's storage binding is the four-part tuple
+ * (run_id, schedule_id, task_id, network_id). It is read from
+ * `scheduled_task_runs`, not caller-controlled task metadata (which may also
+ * legitimately be replaced by reply attachment metadata).
+ *
+ * Terminal states close the run. `retry_task` calls this after resetting the
+ * same logical task_id to delivered, which deliberately reopens that run so
+ * the history reflects the current retry rather than the first failed attempt.
+ */
+export function syncScheduledRunForTask(taskId: string, expectedNetworkId?: string | null): { matched: boolean; status?: string } {
+  const task = db.get<ScheduledTaskLifecycleRow>(
+    `SELECT task_id, network_id, status, completed_at
+       FROM tasks
+      WHERE task_id = ?1
+        AND (?2 IS NULL OR network_id = ?2)`,
+    taskId,
+    expectedNetworkId ?? null,
+  );
+  if (!task?.network_id) return { matched: false };
+  const bindings = db.all<ScheduledTaskBinding>(
+    `SELECT run_id, schedule_id FROM scheduled_task_runs
+      WHERE task_id = ?1 AND network_id = ?2`,
+    task.task_id,
+    task.network_id,
+  );
+  // One task belongs to at most one scheduled occurrence. Fail closed if a
+  // corrupt/legacy database violates that invariant rather than fanning one
+  // lifecycle transition into multiple runs.
+  if (bindings.length !== 1) return { matched: false };
+  const binding = bindings[0];
+
+  if (SCHEDULED_RUN_TERMINAL_STATUSES.has(task.status)) {
+    const errorCode = task.status === "replied" ? null : `task_${task.status}`;
+    const updated = db.run(
+      `UPDATE scheduled_task_runs
+          SET status = ?1,
+              error_code = ?2,
+              error_message = NULL,
+              completed_at = COALESCE(?3, datetime('now'))
+        WHERE run_id = ?4 AND task_id = ?5 AND network_id = ?6 AND schedule_id = ?7`,
+      [task.status, errorCode, task.completed_at, binding.run_id, task.task_id, task.network_id, binding.schedule_id],
+    );
+    return { matched: updated.changes === 1, status: task.status };
+  }
+
+  if (task.status === "delivered") {
+    const updated = db.run(
+      `UPDATE scheduled_task_runs
+          SET status = 'delivered', error_code = NULL, error_message = NULL, completed_at = NULL
+        WHERE run_id = ?1 AND task_id = ?2 AND network_id = ?3 AND schedule_id = ?4`,
+      [binding.run_id, task.task_id, task.network_id, binding.schedule_id],
+    );
+    return { matched: updated.changes === 1, status: task.status };
+  }
+
+  return { matched: false };
 }
 
 function taskEventTypeForStatus(toStatus: string): string {

--- a/server/src/scheduled-run-terminal.test.ts
+++ b/server/src/scheduled-run-terminal.test.ts
@@ -1,0 +1,268 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db, chainReplyToParent } from "./db.js";
+import { dispatchScheduledOccurrence } from "./scheduled-tasks.js";
+import { registerTools } from "./tools.js";
+import { patrolExpiredTasks } from "./server.js";
+
+const NET = "net_690_scheduler_terminal";
+const USER = "u_690_owner";
+const NODE = "n_690_grok";
+const ALIAS = "A站GrokTUI-690";
+
+type Handler = (args: any, extra?: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+
+function cleanup(): void {
+  for (const table of ["task_events", "inbox", "scheduled_task_runs", "scheduled_tasks", "tasks", "sessions", "nodes", "network_members", "networks", "users"]) {
+    try { db.run(`DELETE FROM ${table} WHERE network_id = ?1`, [NET]); } catch {}
+  }
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [USER]); } catch {}
+}
+
+function seedIdentity(): void {
+  db.run("INSERT INTO users (user_id, username, password_hash, role, created_at) VALUES (?1, ?2, 'x', 'user', datetime('now'))", [USER, USER]);
+  db.run("INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))", [NET, USER]);
+  db.run("INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))", [USER, NET]);
+  db.run(
+    `INSERT INTO nodes (node_id, node_name, alias, runtime, network_id, lifecycle_state)
+     VALUES (?1, ?2, ?2, 'grok-build-acp', ?3, 'active')`,
+    [NODE, ALIAS, NET],
+  );
+  db.run(
+    `INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at)
+     VALUES ('r_690', ?1, 'idle', ?2, ?3, datetime('now'), datetime('now'))`,
+    [ALIAS, NODE, NET],
+  );
+}
+
+function handlers(): Record<string, Handler> {
+  const server = new McpServer({ name: "test690", version: "0" }) as any;
+  const result: Record<string, Handler> = {};
+  const original = server.tool.bind(server);
+  server.tool = (name: string, ...args: any[]) => {
+    const handler = args.at(-1);
+    if (typeof handler === "function") result[name] = handler;
+    return original(name, ...args);
+  };
+  registerTools(server, undefined, NET, USER, USER, false, null);
+  return result;
+}
+
+async function call(handler: Handler, args: any): Promise<any> {
+  const reply = await handler(args);
+  return JSON.parse(reply.content[0].text);
+}
+
+function seedScheduledTask(status = "delivered", suffix = crypto.randomUUID()): { taskId: string; runId: string; scheduleId: string } {
+  const taskId = `task_${suffix}`;
+  const runId = `srun_${suffix}`;
+  const scheduleId = `sched_${suffix}`;
+  const meta = JSON.stringify({ scheduled_task_id: scheduleId, scheduled_run_id: runId, auth_origin: "hub_scheduler" });
+  db.run(
+    `INSERT INTO scheduled_tasks
+       (schedule_id, network_id, name, target_node_id, target_alias, task_content, priority,
+        schedule_type, schedule_json, timezone, status, next_run_at)
+     VALUES (?1, ?2, 'test690', ?3, ?4, 'test690 task', 'normal', 'interval',
+             '{"type":"interval","every_seconds":3600}', 'UTC', 'active', datetime('now', '+1 hour'))`,
+    [scheduleId, NET, NODE, ALIAS],
+  );
+  db.run(
+    `INSERT INTO tasks
+       (task_id, from_name, to_node_id, to_name, priority, status, content, requires_response,
+        created_at, delivered_at, expires_at, network_id, meta_json)
+     VALUES (?1, 'scheduler', ?2, ?3, 'normal', ?4, 'test690 task', 'reply',
+             datetime('now'), datetime('now'), datetime('now', '+1 hour'), ?5, ?6)`,
+    [taskId, NODE, ALIAS, status, NET, meta],
+  );
+  db.run(
+    `INSERT INTO inbox (id, task_id, session_name, node_id, type, priority, content, from_session, requires_response, network_id, meta_json)
+     VALUES (?1, ?1, ?2, ?3, 'task', 'normal', 'test690 task', 'scheduler', 'reply', ?4, ?5)`,
+    [taskId, ALIAS, NODE, NET, meta],
+  );
+  db.run(
+    `INSERT INTO scheduled_task_runs (run_id, schedule_id, network_id, scheduled_for, task_id, status, completed_at)
+     VALUES (?1, ?2, ?3, datetime('now'), ?4, ?5, datetime('now'))`,
+    [runId, scheduleId, NET, taskId, status],
+  );
+  return { taskId, runId, scheduleId };
+}
+
+const readRun = (runId: string) => db.get<any>(
+  "SELECT run_id, task_id, network_id, status, error_code, completed_at FROM scheduled_task_runs WHERE run_id = ?1",
+  runId,
+);
+
+beforeEach(() => { cleanup(); seedIdentity(); });
+afterAll(cleanup);
+
+describe("#690 scheduled run follows the real task lifecycle", () => {
+  test("dispatch is open until the task reaches a terminal state", () => {
+    const scheduleId = `sched_dispatch_${crypto.randomUUID()}`;
+    const row: any = {
+      schedule_id: scheduleId,
+      network_id: NET,
+      name: "dispatch open",
+      target_node_id: NODE,
+      target_alias: ALIAS,
+      task_content: "dispatch open",
+      priority: "normal",
+      schedule_type: "interval",
+      schedule_json: JSON.stringify({ type: "interval", every_seconds: 3600 }),
+      timezone: "UTC",
+      overlap_policy: "skip",
+      misfire_policy: "catch_up_once",
+      status: "active",
+      next_run_at: new Date(Date.now() + 3600_000).toISOString(),
+      last_run_at: null,
+      revision: 1,
+    };
+    db.run(
+      `INSERT INTO scheduled_tasks
+         (schedule_id, network_id, name, target_node_id, target_alias, task_content, priority,
+          schedule_type, schedule_json, timezone, overlap_policy, misfire_policy, status, next_run_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)`,
+      [scheduleId, NET, row.name, NODE, ALIAS, row.task_content, row.priority, row.schedule_type,
+       row.schedule_json, row.timezone, row.overlap_policy, row.misfire_policy, row.status, row.next_run_at],
+    );
+    const dispatched = dispatchScheduledOccurrence(row, new Date().toISOString(), false);
+    const run = readRun(dispatched.runId);
+    expect(["delivered", "queued"]).toContain(run.status);
+    expect(run.completed_at).toBeNull();
+  });
+
+  test("send_reply terminalizes the exact bound run", async () => {
+    const { taskId, runId } = seedScheduledTask();
+    const reply = await call(handlers().send_reply, {
+      alias: ALIAS,
+      text: "verified",
+      in_reply_to: taskId,
+      status: "replied",
+      network_id: NET,
+      attachments: [{ type: "file", file_id: "file_690_reply", name: "evidence.json", size: 12, mime: "application/json" }],
+    });
+    expect(reply.ok).toBe(true);
+    expect(readRun(runId).status).toBe("replied");
+    expect(readRun(runId).completed_at).toBeTruthy();
+  });
+
+  test("task and run terminal transition roll back together on an injected run-write failure", async () => {
+    const { taskId, runId } = seedScheduledTask();
+    db.exec(
+      `CREATE TRIGGER test690_fail_run_terminal
+         BEFORE UPDATE OF status ON scheduled_task_runs
+         WHEN NEW.run_id = '${runId}' AND NEW.status = 'replied'
+       BEGIN
+         SELECT RAISE(ABORT, 'test690_injected_run_failure');
+       END`,
+    );
+    let threw = false;
+    try {
+      await call(handlers().send_reply, {
+        alias: ALIAS,
+        text: "must roll back",
+        in_reply_to: taskId,
+        status: "replied",
+        network_id: NET,
+      });
+    } catch (error: any) {
+      threw = /test690_injected_run_failure/.test(String(error?.message || error));
+    } finally {
+      db.exec("DROP TRIGGER IF EXISTS test690_fail_run_terminal");
+    }
+    expect(threw).toBe(true);
+    expect(db.get<{ status: string }>("SELECT status FROM tasks WHERE task_id = ?1", taskId)?.status).toBe("delivered");
+    expect(readRun(runId).status).toBe("delivered");
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM inbox WHERE in_reply_to = ?1", taskId)?.count).toBe(0);
+  });
+
+  test("cancel terminalizes, retry reopens, and the retry result closes the same run", async () => {
+    const { taskId, runId } = seedScheduledTask();
+    const tools = handlers();
+    expect((await call(tools.cancel_task, { task_id: taskId, reason: "operator", network_id: NET })).ok).toBe(true);
+    expect(readRun(runId).status).toBe("cancelled");
+    expect(readRun(runId).completed_at).toBeTruthy();
+
+    expect((await call(tools.retry_task, { task_id: taskId, network_id: NET })).ok).toBe(true);
+    expect(readRun(runId).status).toBe("delivered");
+    expect(readRun(runId).completed_at).toBeNull();
+
+    expect((await call(tools.send_reply, {
+      alias: ALIAS,
+      text: "runtime failed",
+      in_reply_to: taskId,
+      status: "failed",
+      network_id: NET,
+    })).ok).toBe(true);
+    expect(readRun(runId).status).toBe("failed");
+    expect(readRun(runId).error_code).toBe("task_failed");
+  });
+
+  test("report_completion terminalizes a scheduler run", async () => {
+    const { taskId, runId } = seedScheduledTask();
+    const reply = await call(handlers().report_completion, {
+      alias: ALIAS,
+      task: taskId,
+      result: "done",
+      network_id: NET,
+    });
+    expect(reply.ok).toBe(true);
+    expect(readRun(runId).status).toBe("replied");
+  });
+
+  test("expiration patrol closes the exact run in the same lifecycle pass", () => {
+    const { taskId, runId } = seedScheduledTask();
+    db.run("UPDATE tasks SET expires_at = datetime('now', '-1 minute') WHERE task_id = ?1", [taskId]);
+    patrolExpiredTasks();
+    expect(db.get<{ status: string }>("SELECT status FROM tasks WHERE task_id = ?1", taskId)?.status).toBe("expired");
+    expect(readRun(runId).status).toBe("expired");
+    expect(readRun(runId).error_code).toBe("task_expired");
+    expect(readRun(runId).completed_at).toBeTruthy();
+  });
+
+  test("child auto-chain terminalizes a scheduled parent", () => {
+    const { taskId: parentId, runId } = seedScheduledTask();
+    const childId = `child_${crypto.randomUUID()}`;
+    db.run(
+      `INSERT INTO tasks
+         (task_id, parent_task_id, from_name, to_name, priority, status, content, requires_response, created_at, network_id)
+       VALUES (?1, ?2, ?3, 'A站负责人', 'normal', 'replied', 'verify candidate', 'reply', datetime('now'), ?4)`,
+      [childId, parentId, ALIAS, NET],
+    );
+    const result = chainReplyToParent(childId, "news_id=14519", "replied", 5, NET);
+    expect(result.chained).toBe(true);
+    expect(readRun(runId).status).toBe("replied");
+  });
+
+  test("forged metadata cannot cross-bind another task or network run", async () => {
+    const victim = seedScheduledTask("delivered", "victim");
+    const attackerTaskId = "task_attacker";
+    const forgedMeta = JSON.stringify({ scheduled_task_id: victim.scheduleId, scheduled_run_id: victim.runId, auth_origin: "hub_scheduler" });
+    db.run(
+      `INSERT INTO tasks
+         (task_id, from_name, to_node_id, to_name, priority, status, content, requires_response, created_at, network_id, meta_json)
+       VALUES (?1, 'scheduler', ?2, ?3, 'normal', 'delivered', 'forged', 'reply', datetime('now'), ?4, ?5)`,
+      [attackerTaskId, NODE, ALIAS, NET, forgedMeta],
+    );
+    await call(handlers().send_reply, {
+      alias: ALIAS,
+      text: "forged close",
+      in_reply_to: attackerTaskId,
+      status: "replied",
+      network_id: NET,
+    });
+    expect(readRun(victim.runId).status).toBe("delivered");
+  });
+
+  test("a task cannot close a run whose persisted network binding differs", async () => {
+    const victim = seedScheduledTask("delivered", "foreign_network");
+    db.run("UPDATE scheduled_task_runs SET network_id = 'net_690_foreign' WHERE run_id = ?1", [victim.runId]);
+    await call(handlers().send_reply, {
+      alias: ALIAS,
+      text: "must not cross network",
+      in_reply_to: victim.taskId,
+      status: "replied",
+      network_id: NET,
+    });
+    expect(readRun(victim.runId).status).toBe("delivered");
+  });
+});

--- a/server/src/scheduled-tasks.ts
+++ b/server/src/scheduled-tasks.ts
@@ -283,7 +283,9 @@ export function dispatchScheduledOccurrence(row: ScheduledRow, scheduledFor: str
        VALUES (?1, 'scheduler', ?2, ?3, ?4, 'delivered', ?5, 'reply', datetime('now'), datetime('now'), datetime('now', '+86400 seconds'), ?6, ?7)`,
       [taskId, node.node_id, node.alias, row.priority, row.task_content, row.network_id, metaJson],
     );
-    db.run("UPDATE scheduled_task_runs SET task_id = ?1, status = ?2, completed_at = datetime('now') WHERE run_id = ?3", [taskId, deliveryState, runId]);
+    // Dispatch is not completion. Keep the run open until the exact bound
+    // task reaches replied/failed/cancelled/expired; db.ts owns that mirror.
+    db.run("UPDATE scheduled_task_runs SET task_id = ?1, status = ?2, completed_at = NULL WHERE run_id = ?3", [taskId, deliveryState, runId]);
     db.run("UPDATE sessions SET task = ?1, updated_at = datetime('now') WHERE node_id = ?2 AND network_id = ?3", [row.task_content.slice(0, 200), node.node_id, row.network_id]);
     db.run("UPDATE scheduled_tasks SET target_alias = ?1, last_run_at = ?2, updated_at = datetime('now') WHERE schedule_id = ?3", [node.alias, scheduledFor, row.schedule_id]);
     if (advanceSchedule) advance({ ...row, target_alias: node.alias }, scheduledFor, advanceAfter);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { z } from "zod/v4";
 import { registerTools } from "./tools.js";
-import { db, logTaskEvent, logAudit } from "./db.js";
+import { db, logTaskEvent, logAudit, syncScheduledRunForTask } from "./db.js";
 import { createSSEStream, createNetworkObserverStream, pushEvent, pushNetworkObserverEvent, getSSEStats, PRINTABLE_OBSERVER_KEY_PREFIX } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { addNetworkScope, canRestWriteNetwork, getUserNetworkIds, resolveRestNetworkScope, resolveRestWriteNetworkId, singleNetworkId, type RestNetworkScope } from "./network-scope.js";
@@ -632,19 +632,30 @@ const wsTmuxIntervals = new Map<object, ReturnType<typeof setInterval>>();
 // Registered in startHub() (#476): this WRITES the DB, so it must never
 // run as an import side effect — a tool/test importing this module with
 // COMMHUB_DB unset would patrol the production database.
-function patrolExpiredTasks(): void {
+export function patrolExpiredTasks(): void {
   try {
-    const result = db.run(
-      `UPDATE tasks SET status = 'expired', completed_at = datetime('now')
-       WHERE expires_at IS NOT NULL AND expires_at < datetime('now')
-         AND status IN ('created', 'delivered')`
-    );
-    if (result.changes > 0) {
-      console.log(`[patrol] expired ${result.changes} stale task(s)`);
-      // Log events for expired tasks
-      const expired = db.all<{ task_id: string }>(
-        "SELECT task_id FROM tasks WHERE status = 'expired' AND completed_at >= datetime('now', '-1 minute')");
-      for (const t of expired) logTaskEvent(t.task_id, null, "expired", "patrol");
+    const expired = db.transaction(() => {
+      const due = db.all<{ task_id: string; network_id: string | null }>(
+        `SELECT task_id, network_id FROM tasks
+          WHERE expires_at IS NOT NULL AND expires_at < datetime('now')
+            AND status IN ('created', 'delivered')`,
+      );
+      const changed: Array<{ task_id: string; network_id: string | null }> = [];
+      for (const task of due) {
+        const result = db.run(
+          `UPDATE tasks SET status = 'expired', completed_at = datetime('now')
+            WHERE task_id = ?1 AND status IN ('created', 'delivered')`,
+          [task.task_id],
+        );
+        if (result.changes !== 1) continue;
+        syncScheduledRunForTask(task.task_id, task.network_id);
+        changed.push(task);
+      }
+      return changed;
+    });
+    if (expired.length > 0) {
+      console.log(`[patrol] expired ${expired.length} stale task(s)`);
+      for (const task of expired) logTaskEvent(task.task_id, null, "expired", "patrol");
     }
   } catch {}
 }

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
 import { createHash } from "node:crypto";
-import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken } from "./db.js";
+import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken, syncScheduledRunForTask } from "./db.js";
 import { pushEvent, pushNetworkObserverEvent } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { getUserNetworkRole, createNetworkTokenForNode } from "./auth.js";
@@ -814,6 +814,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         } else {
           updatedTaskId = task;
         }
+        if (updatedTaskId) syncScheduledRunForTask(updatedTaskId, effectiveNetId);
       });
       // Log event after transaction
       if (updatedTaskId) logTaskEvent(updatedTaskId, null, "replied", alias, "report_completion");
@@ -1588,6 +1589,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
             console.log(`[${ts()}] ⚠ send_reply: task ${in_reply_to?.slice(0, 8)} not found or already terminal`);
             return false;
           }
+          syncScheduledRunForTask(in_reply_to, effectiveNetId);
           return true;
         }
         return false;
@@ -1760,6 +1762,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
            WHERE task_id = ?1`;
         updateSql = addScope(updateSql, updateParams, effectiveNetId);
         db.run(updateSql, updateParams);
+        syncScheduledRunForTask(task_id, effectiveNetId ?? task.network_id ?? null);
         // Re-queue in inbox with new ID (original ID may already exist)
         const retryInboxId = uuidv4();
         db.run(
@@ -1861,15 +1864,19 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       let updateSql = `UPDATE tasks SET status = 'cancelled', result = ?1, completed_at = datetime('now')
          WHERE task_id = ?2 AND status IN ('created', 'delivered', 'acked', 'running')`;
       updateSql = addScope(updateSql, updateParams, effectiveNetId);
-      const result = db.run(updateSql, updateParams);
-      // Also ack the inbox entry to prevent agent from picking it up
-      if (result.changes > 0) {
-        const inboxParams: any[] = [task_id];
-        let inboxSql = "UPDATE inbox SET acked = 1 WHERE COALESCE(task_id, id) = ?1 AND acked = 0";
-        inboxSql = addScope(inboxSql, inboxParams, effectiveNetId);
-        db.run(inboxSql, inboxParams);
-        logTaskEvent(task_id, null, "cancelled", from_session, reason || undefined);
-      }
+      const result = db.transaction(() => {
+        const updated = db.run(updateSql, updateParams);
+        // Also ack the inbox entry to prevent agent from picking it up.
+        if (updated.changes > 0) {
+          const inboxParams: any[] = [task_id];
+          let inboxSql = "UPDATE inbox SET acked = 1 WHERE COALESCE(task_id, id) = ?1 AND acked = 0";
+          inboxSql = addScope(inboxSql, inboxParams, effectiveNetId);
+          db.run(inboxSql, inboxParams);
+          syncScheduledRunForTask(task_id, effectiveNetId);
+        }
+        return updated;
+      });
+      if (result.changes > 0) logTaskEvent(task_id, null, "cancelled", from_session, reason || undefined);
       return {
         content: [{ type: "text" as const, text: JSON.stringify({ ok: result.changes > 0, task_id, cancelled: result.changes > 0 }) }],
       };

--- a/tests/test690-scheduled-run-terminal/Dockerfile
+++ b/tests/test690-scheduled-run-terminal/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test601-hub-scheduled-tasks ./tests/test601-hub-scheduled-tasks
+COPY tests/test690-scheduled-run-terminal ./tests/test690-scheduled-run-terminal
+ARG SOURCE_COMMIT
+ENV TEST690_SOURCE_COMMIT=$SOURCE_COMMIT
+RUN chmod 0755 /workspace/tests/test690-scheduled-run-terminal/run.sh
+ENTRYPOINT ["/workspace/tests/test690-scheduled-run-terminal/run.sh"]

--- a/tests/test690-scheduled-run-terminal/run.sh
+++ b/tests/test690-scheduled-run-terminal/run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ARTIFACT_DIR=${ARTIFACT_DIR:-/artifacts}
+REPORT="$ARTIFACT_DIR/report-test690-scheduled-run-terminal.txt"
+mkdir -p "$ARTIFACT_DIR"
+: > "$REPORT"
+exec > >(tee -a "$REPORT") 2>&1
+
+echo "# test690 — scheduled run terminal lifecycle"
+echo "source_commit=${TEST690_SOURCE_COMMIT:-unknown}"
+echo "date=$(date -Is)"
+
+run_real() {
+  local db_path=$1
+  rm -f "${db_path:?}" "${db_path:?}-wal" "${db_path:?}-shm"
+  COMMHUB_DB="$db_path" bun test server/src/scheduled-run-terminal.test.ts
+}
+
+echo "L0 build"
+bun build server/src/index.ts --target bun --outfile /tmp/commhub-test690.js
+test -s /tmp/commhub-test690.js
+
+echo "L1 real SQLite lifecycle"
+run_real /tmp/test690-green.db
+
+echo "L1b scheduler regression matrix"
+COMMHUB_DB=/tmp/test690-scheduler-regression.db bun test server/src/scheduled-tasks-http.test.ts
+
+echo "L2 witnessed-red: terminal synchronization hook is load-bearing"
+cp server/src/db.ts /tmp/test690-db.ts
+sed -i '0,/  const task = db.get<ScheduledTaskLifecycleRow>/{s/  const task = db.get<ScheduledTaskLifecycleRow>/  return { matched: false };\n  const task = db.get<ScheduledTaskLifecycleRow>/}' server/src/db.ts
+if cmp -s server/src/db.ts /tmp/test690-db.ts; then
+  echo "MUTATION_NOOP: syncScheduledRunForTask anchor"
+  exit 1
+fi
+set +e
+run_real /tmp/test690-mut-sync.db >/tmp/test690-mut-sync.log 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: terminal synchronization"
+  sed -n '1,240p' /tmp/test690-mut-sync.log
+  exit 1
+fi
+echo "MUTATION_RED: terminal-sync rc=$rc"
+cp /tmp/test690-db.ts server/src/db.ts
+
+echo "L3 witnessed-red: exact task binding is load-bearing"
+cp server/src/db.ts /tmp/test690-db.ts
+sed -i 's/WHERE task_id = ?1 AND network_id = ?2/WHERE network_id = ?2/' server/src/db.ts
+sed -i 's/WHERE run_id = ?4 AND task_id = ?5 AND network_id = ?6 AND schedule_id = ?7/WHERE run_id = ?4 AND network_id = ?6 AND schedule_id = ?7/' server/src/db.ts
+if cmp -s server/src/db.ts /tmp/test690-db.ts; then
+  echo "MUTATION_NOOP: exact task binding anchor"
+  exit 1
+fi
+set +e
+run_real /tmp/test690-mut-binding.db >/tmp/test690-mut-binding.log 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: exact task binding"
+  sed -n '1,240p' /tmp/test690-mut-binding.log
+  exit 1
+fi
+echo "MUTATION_RED: exact-task-binding rc=$rc"
+cp /tmp/test690-db.ts server/src/db.ts
+
+echo "L4 witnessed-red: exact network binding is load-bearing"
+cp server/src/db.ts /tmp/test690-db.ts
+sed -i 's/WHERE task_id = ?1 AND network_id = ?2/WHERE task_id = ?1 AND ?2 IS NOT NULL/' server/src/db.ts
+sed -i 's/AND task_id = ?5 AND network_id = ?6 AND schedule_id = ?7/AND task_id = ?5 AND ?6 IS NOT NULL AND schedule_id = ?7/' server/src/db.ts
+if cmp -s server/src/db.ts /tmp/test690-db.ts; then
+  echo "MUTATION_NOOP: exact network binding anchor"
+  exit 1
+fi
+set +e
+run_real /tmp/test690-mut-network.db >/tmp/test690-mut-network.log 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "MUTATION_FALSE_GREEN: exact network binding"
+  sed -n '1,240p' /tmp/test690-mut-network.log
+  exit 1
+fi
+echo "MUTATION_RED: exact-network-binding rc=$rc"
+cp /tmp/test690-db.ts server/src/db.ts
+
+echo "L5 restored green"
+run_real /tmp/test690-restored.db
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #690.

## What changed

- keep scheduled runs open after dispatch (`completed_at=NULL`)
- mirror exact task terminal states (`replied/failed/cancelled/expired`) into the bound run
- reopen the same run on `retry_task`; reassign remains non-terminal
- bind updates fail-closed on `run_id + schedule_id + task_id + network_id`
- keep task/run transitions in the same SQLite transaction, including child auto-chain and expiry
- document the lifecycle semantics in RFC-034

## Evidence

Source: `d63da5a272742228eaf01f610204c1eac081b1a1`
Report-only head: `ce58ffa54a49ff78de3987dff0aa59eeaa1ab047`
Docker: `anet-test690:dev`, image `sha256:a9f9189112e0477c6e95af41c3ce680442f69f4ad9e00a5360494a3a81b96b44`

- targeted real SQLite: 9/0, 28 assertions
- scheduler regression: 12/0, 106 assertions
- injected transaction failure proves no half-state
- 3 witnessed-red mutations: terminal hook, exact task binding, exact network binding

Full report: `docs/tests/report-test690-scheduled-run-terminal.txt`

No production deployment, publish, or global install.
