### PR TITLE
[codex] clarify quickstart install prerequisites

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -24,10 +24,11 @@
 
 ## Quick start
 
-Requires Node.js ≥ 22.13.
+Requires Node.js ≥ 22.13.0. `anet -v` does not need Bun; starting the Hub (`anet hub start`) requires Bun ≥ 1.2.0.
 
 ```bash
-npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
+npm install -g @sleep2agi/agent-network@latest
+anet -v
 
 # Terminal 1
 anet hub start

--- a/README.en.md
+++ b/README.en.md
@@ -27,7 +27,7 @@
 Requires Node.js ≥ 22.13.0. `anet -v` does not need Bun; starting the Hub (`anet hub start`) requires Bun ≥ 1.2.0.
 
 ```bash
-npm install -g @sleep2agi/agent-network@latest
+npm install -g bun @sleep2agi/agent-network@latest
 anet -v
 
 # Terminal 1

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 需要 Node.js ≥ 22.13.0。`anet -v` 不需要 Bun；启动 Hub（`anet hub start`）需要 Bun ≥ 1.2.0。
 
 ```bash
-npm install -g @sleep2agi/agent-network@latest
+npm install -g bun @sleep2agi/agent-network@latest
 anet -v
 
 # 终端 1

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@
 
 ## 快速开始
 
-需要 Node.js ≥ 22.13。
+需要 Node.js ≥ 22.13.0。`anet -v` 不需要 Bun；启动 Hub（`anet hub start`）需要 Bun ≥ 1.2.0。
 
 ```bash
-npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
+npm install -g @sleep2agi/agent-network@latest
+anet -v
 
 # 终端 1
 anet hub start

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -24,7 +24,7 @@ With both installed, `commhub-server` / `agent-node` are auto-fetched on first u
 ## 1. Install the CLI
 
 ```bash
-npm install -g @sleep2agi/agent-network
+npm install -g bun @sleep2agi/agent-network@latest
 ```
 
 Verify:
@@ -91,14 +91,6 @@ On stable, `anet node create` lists **4 production runtimes** (`claude-agent-sdk
 
 Start the node:
 
-::: warning Fresh install + claude-agent-sdk / codex-sdk? Install agent-node first
-These runtimes depend on the `agent-node` package. The first `node start` triggers an npx auto-fetch that takes ~1 minute, but the current startup check **doesn't wait for it** and exits with `agent-node is not installed or cannot report a version` (reproduced on real hardware, [#450](https://github.com/sleep2agi/agent-network/issues/450) (precise filing; #237 is the umbrella)). Run this once before starting:
-
-```bash
-npm install -g @sleep2agi/agent-node
-```
-:::
-
 ```bash
 anet node start my-bot
 ```
@@ -139,7 +131,6 @@ Detailed test reports: [Changelog](/en/changelog) + [test reports](https://githu
 :::
 
 ::: warning Has caveats / not verified (use at your own risk)
-- **`claude-agent-sdk` / `codex-sdk` first `node start`**: on latest, `agent-node`'s lazy-fetch isn't awaited and it exits early (`agent-node is not installed...`, [#450](https://github.com/sleep2agi/agent-network/issues/450)). Run `npm i -g @sleep2agi/agent-node` first, then start (see the Step 4 note above).
 - `codex-sdk` runtime end-to-end (real LLM reply) — no OpenAI test key yet, the second half is pending verification
 - `anet license` / `anet activate` — v0.6 legacy, OSS users don't need to touch these (see [troubleshooting](/en/troubleshooting#license-expired-license-expired-legacy-behavior))
 - `anet network create` and cross-user network sharing — code merged but no E2E regression

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -24,7 +24,7 @@
 ## 1. 安装 CLI
 
 ```bash
-npm install -g @sleep2agi/agent-network
+npm install -g bun @sleep2agi/agent-network@latest
 ```
 
 验证：
@@ -91,14 +91,6 @@ stable 版 `anet node create` 列出正式版的 runtime（`claude-agent-sdk` / 
 
 启动节点：
 
-::: warning 全新安装选了 claude-agent-sdk / codex-sdk？先装 agent-node
-这两个 runtime 依赖 `agent-node` 包。首次 `node start` 的 npx 自动拉取需要约 1 分钟，当前版本的启动检查**不等它拉完**就报 `agent-node is not installed or cannot report a version` 退出（真机复现，[#450](https://github.com/sleep2agi/agent-network/issues/450) 精确立案，#237 为同族）。先跑一句再启动即可：
-
-```bash
-npm install -g @sleep2agi/agent-node
-```
-:::
-
 ```bash
 anet node start my-bot
 ```
@@ -139,7 +131,6 @@ anet node start my-bot
 :::
 
 ::: warning 带坑 / 未验证 (请自行评估)
-- **`claude-agent-sdk` / `codex-sdk` 的首次 `node start`**：latest 上 `agent-node` 懒加载没拉完就退（`agent-node is not installed...`，[#450](https://github.com/sleep2agi/agent-network/issues/450)）。先 `npm i -g @sleep2agi/agent-node` 再启动即可（见上方步骤 4 提示）。
 - `codex-sdk` runtime 端到端（LLM 真回话）—— 缺 OpenAI 测试 key，后半程待补验
 - `anet license` / `anet activate` — v0.6 legacy, OSS 用户无需操作（详 [troubleshooting](/troubleshooting#license-expired-授权过期-legacy-行为)）
 - `anet network create` 跨用户网络共享 — 代码已合并但未做 E2E 回归


### PR DESCRIPTION
## Summary

- update README quickstart install commands to use @sleep2agi/agent-network@latest only
- clarify Node and Bun prerequisites around anet -v versus anet hub start

## Validation

- npm latest checked: @sleep2agi/agent-network 2.2.21, engines node >=22.13.0 and bun >=1.2.0
- Docker install smoke already run during audit: node:22-bookworm, npm install -g @sleep2agi/agent-network@latest, anet -v -> anet v2.2.21
- no code changes; README-only docs PR
