### PR TITLE
docs: record test698 evidence limitations

### DIFF
--- a/docs/tests/report-test698-capability-negotiated-peer-reply.txt
+++ b/docs/tests/report-test698-capability-negotiated-peer-reply.txt
@@ -39,10 +39,34 @@ Production deployment: NOT PERFORMED.
   worktree. The base commit supplies the old Hub context; the exact source
   commit separately supplies `Dockerfile.legacy-hub` into that temporary
   context. This is required because the base predates the test698 directory.
-- The first attempted reproduction that assumed the Dockerfile existed in
-  the base archive failed loudly and is not counted as PASS. All recorded
+- The first attempted reproduction assumed the Dockerfile existed in the
+  base archive. It printed `fatal: not a tree object` and
+  `tar: Exiting with failure status` to stderr, but the outer pipeline still
+  exited `0` because `| tee` ran without `pipefail`. The failure was therefore
+  indistinguishable from success to automated exit-code evaluation, which is
+  why that run was initially recorded as PASS. Reproducing the same failure
+  gave exit `0` without outer `pipefail` and exit `2` with
+  `set -o pipefail`. Noise on stderr is not failure detection; the pipeline
+  exit status is the contract. That invalid run is not counted as PASS. All
   PASS evidence below comes from the corrected exact-source runner with
   shell `pipefail` enabled at the evidence-capture boundary.
+
+## Evidence-capture limitations and operational notes
+
+1. The two archived-old-Hub log digests below identify timestamped runs with
+   random task ids. They are not reproducible digests and are not used as
+   source provenance, just like the main run artifact digest above.
+2. The archived old-Hub build no longer reads its Dockerfile from the live
+   worktree, but the runner is not fully independent of that worktree:
+   `run-legacy-wire.sh` still sources `tests/lib/safe-rm.sh` through `$ROOT`.
+3. `safe_rm_rf` permits `/tmp/`, while `mktemp -d` follows `TMPDIR`. With
+   `TMPDIR=/var/tmp`, cleanup is refused and the temporary directory is left
+   behind. This does not turn a failing run green or a passing run red, but it
+   can leak test artifacts.
+4. The archived old-Hub image tag encodes `BASE_COMMIT`, but not the separate
+   `SOURCE_COMMIT` that supplies `Dockerfile.legacy-hub`. The runner rebuilds
+   and retags the image each time, so no stale-image failure was observed;
+   the tag alone is nevertheless an incomplete provenance label.
 
 ## Product behavior
 


### PR DESCRIPTION
## What changed

This docs-only update records five evidence limitations and operational notes in the authoritative test698 report:

1. The failed legacy reproduction printed fatal errors but exited `0` because an outer `| tee` lacked `pipefail`; the same failure exits `2` with `set -o pipefail`. This explains why stderr noise did not prevent an automated false PASS.
2. Timestamped archived-old-Hub log digests contain random task ids and are not reproducible provenance.
3. The archived build no longer reads the live Dockerfile, but `run-legacy-wire.sh` still sources `tests/lib/safe-rm.sh` from `$ROOT`; it is not worktree-independent.
4. `mktemp -d` follows `TMPDIR`, while `safe_rm_rf` only permits `/tmp/`; `/var/tmp` therefore leaves cleanup artifacts without changing the test verdict.
5. The old-Hub image tag names `BASE_COMMIT` but not the separate `SOURCE_COMMIT` supplying its Dockerfile, so the tag is an incomplete provenance label even though each run rebuilds it.

## Scope

- Base: `6e87a346dcf54c6094d3282cc427f55ffcda7556`
- Head: `e9775724d78a6429c32c4778d7228e272ab50d35`
- Exactly one changed file: `docs/tests/report-test698-capability-negotiated-peer-reply.txt`
- No harness, product code, dist, #697 files, gates, or deployment changes

## Validation

In an existing Docker image (`node:20-bookworm`) against the read-only worktree:

- `tests/scripts/lint-no-hardcoded-from-session.py`: PASS
- `.github/scripts/check-no-memory-slugs.py`: PASS
- `git diff --check`: PASS
- `git diff origin/main...HEAD --name-only`: exactly the one report file above

Draft only. Merge, release, rollout, TM微软牛 pilot, and fleet configuration remain on HOLD pending Vincent.
