### PR TITLE
ops: put the production dashboard launcher and runbook in the repo

### DIFF
--- a/deploy/dashboard/README.md
+++ b/deploy/dashboard/README.md
@@ -1,0 +1,136 @@
+# Dashboard 生产部署 —— 从空机重建
+
+这份文档和同目录的 `dash-start.sh` 存在的理由只有一个:
+
+> **任何一台服务器被夷平后,只凭这个 repo 就要能把现在在跑的东西重建出来。**
+
+在此之前,生产 dashboard 的启动器只存在于机器上的 `~/.local/bin/dash-start.sh`,
+下面这套拓扑只存在于口口相传里。机器没了,这些就都没了。
+
+数据不在此列:Hub 的 SQLite 内容无法从 repo 复现,要么来自备份,要么重新注册。
+本文档只保证**软件与运行方式**可复现。
+
+---
+
+## 一、拓扑(这层最容易猜错)
+
+```
+公网 ─┬─ Caddy :3000  ──TLS 终结──┐
+      │                           ├──►  127.0.0.1:3001   (Next.js, pm2 托管)
+      └─ frpc 隧道 :3100 ─────────┘
+```
+
+三件事必须知道:
+
+1. **公网入口不止一个。** 除了 Caddy,还有一条 `frpc` 隧道把另一个域名的 `:3100`
+   打到**同一个** `127.0.0.1:3001`。曾经因为不知道这条隧道,
+   在"部署完成但用户仍看到旧界面"上判断错方向 —— 以为是另一台机器上的另一套部署。
+   判据:比对两个入口返回的同一个静态文件的 `Last-Modified`,
+   如果精确到秒相同,那就是同一份磁盘上的同一个文件,不可能是两台机器各自安装的。
+
+2. **进程由 pm2 托管**,app 名 `anet-dashboard`,script 指向持久路径下的
+   `dash-start.sh`。`COMMHUB_TOKEN` 等环境变量由 pm2 的 saved-env 注入 ——
+   **`pm2 restart` 不要带 `--update-env`**,带了会丢。
+
+3. **启动器必须放在持久路径。** 它曾经在 `/tmp/dash-start.sh`,
+   任何 `/tmp` 清理都会让 dashboard 在下一次重启时彻底起不来。
+
+## 二、`dash-start.sh` 里有两个版本位,它们不是一回事
+
+这是这套部署最容易踩的坑,**改错了会得到一个"看起来成功"的假部署**:
+
+| 变量 | 作用 | 改它会怎样 |
+|---|---|---|
+| `VERSION=` | **仅用于预检** —— `npm view "$PKG@$VERSION"` | 改了它,预检通过,但跑的还是旧的 |
+| `RUNTIME_BIN=` | **真正 `exec` 的目标** | 只有改这个才真的换版本 |
+
+两者是**故意解耦**的:runtime 指向一份固化安装目录
+(`~/.commhub/dashboard-runtime-vNN/`),而不是 `npx` 的缓存目录。
+原因见脚本注释 —— `npx` 从 `~/.npm/_npx/<hash>/` 执行,
+**任何人一条 `npm cache clean --force` 就能删掉线上服务的运行目录**。
+
+🔴 **只改 `VERSION=` 的后果**:`pm2` 重启成功、pid 变了、restart 计数 +1、
+服务正常响应 —— 但 `exec` 的还是旧安装。只看 pm2 状态和 `curl /` 会报告"已上线",
+而且是错的。
+
+## 三、换版本(完整顺序,缺一步都可能出事)
+
+```bash
+# 1. 发布并等传播 —— 抢跑会让 pm2 拿到 ETARGET、:3001 空、公网 502
+npm publish --tag preview
+until [ "$(npm view "$PKG@$NEW" version)" = "$NEW" ]; do sleep 5; done
+
+# 2. 建 sibling 固化安装(不要动正在跑的那个目录)
+mkdir -p ~/.commhub/dashboard-runtime-v<NEW>
+cd ~/.commhub/dashboard-runtime-v<NEW>
+printf '{"name":"anet-dashboard-runtime","private":true,"version":"1.0.0","dependencies":{"%s":"%s"}}' "$PKG" "$NEW" > package.json
+npm install
+
+# 3. 🔴 旁路验证:在非生产端口先跑通,再动生产
+PORT=3009 HOST=127.0.0.1 ./node_modules/.bin/agent-network-dashboard &
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3009/login   # 期望 200
+
+# 4. 备份 + 同时改两处
+cp dash-start.sh dash-start.sh.bak-<旧版本>-$(date +%Y%m%d-%H%M%S)
+#    VERSION="<NEW>"   且   RUNTIME_BIN=".../dashboard-runtime-v<NEW>/..."
+
+# 5. 重启(不带 --update-env)
+pm2 restart anet-dashboard
+```
+
+## 四、验证:只有这几条算数
+
+版本号是自报的,pm2 状态证明不了换没换。要看:
+
+```bash
+# ① 真正在跑的安装目录 —— 这条最权威
+PID=$(ss -ltnp | grep 127.0.0.1:3001 | grep -oP 'pid=\K[0-9]+')
+readlink /proc/$PID/cwd          # 必须含 dashboard-runtime-v<NEW>
+
+# ② 本次改动真在服务出去的产物里(比版本号硬)
+curl -s <入口>/<页面> | grep -oE '/_next/static/chunks/[^"]+\.js' \
+  | while read c; do curl -s "<入口>$c" | grep -q '<本次新增的字符串>' && echo "$c"; done
+
+# ③ 构建溯源
+cat <安装目录>/.next/BUILD_COMMIT     # 应等于发版 commit
+
+# ④ 监听进程是 pm2 的后代,不是孤儿(见下)
+```
+
+## 五、两类孤儿进程,症状完全不同
+
+**A. 孤儿占着 LISTEN** —— pm2 新进程 `EADDRINUSE` 永远起不来,
+真正服务的是跑旧版的孤儿。曾导致 pm2 重启 34494 次。
+判据:追监听 pid 的祖先链,出现 pm2 的 pid 才正常,直接到 systemd 就是孤儿。
+
+```bash
+P=<listen_pid>; while [ -n "$P" ] && [ "$P" != 1 ]; do
+  echo "$P $(ps -o comm= -p $P)"; P=$(ps -o ppid= -p $P | tr -d ' '); done
+```
+
+**B. 孤儿交出了 LISTEN 但攥着 ESTAB** —— 新连接走新版本,
+但**已经打开的浏览器标签仍由旧进程服务,仍是旧界面**。
+所以宣布部署完成时**必须带一句"请强刷 Ctrl/Shift+R"**,
+否则对方看到旧 UI,会合理地认为部署失败了。
+
+🔴 这类孤儿**有活连接时不要 kill** —— 杀掉就是打断正在看页面的人。
+等它自然排空;确实要立刻生效时再按**精确 PID** 终止(绝不用 `pkill -f`)。
+
+## 六、回滚
+
+把 `VERSION=` 和 `RUNTIME_BIN=` **两处**改回上一版即可 ——
+旧的固化安装目录只要没被清理就还在。
+
+🔴 **不要 `npm unpublish`。**
+
+## 七、清理固化安装目录
+
+历史版本目录会累积(每个约 380MB)。删之前必须确认没有进程持有它的 cwd:
+
+```bash
+for p in /proc/[0-9]*; do readlink $p/cwd 2>/dev/null | grep -q dashboard-runtime-vNN && echo "占用: $p"; done
+```
+
+保留:**当前在跑的** + **上一版(回滚用)**。其余可删。
+曾实测发现一个 11 天前起的、监听在另一个端口上的旧实例仍持有某个目录 ——
+所以这一步不能凭目录名判断,必须实际扫 cwd。

--- a/deploy/dashboard/README.md
+++ b/deploy/dashboard/README.md
@@ -134,3 +134,46 @@ for p in /proc/[0-9]*; do readlink $p/cwd 2>/dev/null | grep -q dashboard-runtim
 保留:**当前在跑的** + **上一版(回滚用)**。其余可删。
 曾实测发现一个 11 天前起的、监听在另一个端口上的旧实例仍持有某个目录 ——
 所以这一步不能凭目录名判断,必须实际扫 cwd。
+
+---
+
+## 八、这份 runbook 哪些实测过、哪些没有
+
+规则要求「未经演练,不宣称可恢复」。以下如实标注,**不要把未演练的部分当成已验证**。
+
+### ✅ 已实测(2026-08-12,发布 `0.6.3-preview.55` 时真跑过)
+
+第二、三、四节里**从已发布 npm 包到一个可用实例**这一段是端到端验证过的:
+
+```
+mkdir ~/.commhub/dashboard-runtime-v55 + package.json 钉版本 + npm install
+  → node_modules/@sleep2agi/agent-network-dashboard/package.json = 0.6.3-preview.55
+PORT=3009 HOST=127.0.0.1 ./node_modules/.bin/agent-network-dashboard
+  → /login 200   /scheduled-tasks 200   footer 自报 preview.55
+  → .next/BUILD_COMMIT == 发版 commit
+换版后:readlink /proc/<listen_pid>/cwd 含 dashboard-runtime-v55
+       服务出去的 chunk 里 grep 到本次新增的字符串
+       监听 pid 追祖先链到 pm2 当前 pid(非孤儿)
+```
+
+第五节两类孤儿进程也是实测的 —— 当天两种都遇到了,包括那个只攥 `ESTAB`
+继续给已打开标签页发旧 bundle 的,正是它造成了「部署完成但用户看到旧界面」。
+
+### ❌ 尚未演练(**不要据此宣称可恢复**)
+
+- **从一台空机器完整重建** —— 未做。Caddy 配置、frp 隧道配置、pm2 app 的创建与
+  saved-env 注入,**这三样目前都不在 repo 里**,本 PR 只覆盖了启动器本身。
+  也就是说:照现在的 repo,你能把 dashboard 进程跑起来,
+  **但配不出那两个公网入口**。
+- **数据恢复** —— 完全未覆盖。Hub 的 SQLite 内容不在 repo,依赖独立备份,
+  且备份恢复流程本身也没演练过。
+- **回滚** —— 第六节的步骤是按当前脚本结构推出来的,**没有真正执行过一次回滚**。
+
+### 下一步(补齐的顺序)
+
+1. 把 Caddy / frp / pm2 的配置模板收进 repo(**只放变量名与占位符,不放任何值**)
+2. 在隔离环境(Docker 或一台空机)按本文档从零走一遍,把过程与结果记进 `docs/tests/`
+3. 演练一次真实回滚
+4. 单独演练数据恢复,并明确 RPO/RTO
+
+**在第 2 步完成之前,本文档的地位是「已知正确的操作手册」,不是「已验证的灾难恢复方案」。**

--- a/deploy/dashboard/dash-start.sh
+++ b/deploy/dashboard/dash-start.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Agent Network Dashboard 启动脚本（生产 :3001）
+#
+# 为什么不直接 exec npx：
+#   2026-07-29 曾把版本钉到一个尚未发布到 npm 的号上，npx 每次 ETARGET 立即退出，
+#   pm2 无退避地重启了 34494 次，整夜在锤 npm registry。
+#   这里加一道预检：版本不存在就"慢速失败"，让 pm2 退避生效，并在日志里说清原因。
+#
+# 脚本必须放在持久路径下。此前它在 /tmp/dash-start.sh，任何 /tmp 清理都会让
+# dashboard 在下一次重启时彻底起不来。
+
+set -uo pipefail
+
+PKG="@sleep2agi/agent-network-dashboard"
+VERSION="0.6.3-preview.55"
+# 部署时按本机 node 安装位置设置，例如 NODE_BIN=$HOME/.nvm/versions/node/v20.20.0/bin
+NODE_BIN="${NODE_BIN:-$(dirname "$(command -v node)")}"
+
+# 端口/地址允许被环境变量覆盖，默认即生产值。
+# 为什么要可覆盖：否则任何"验证这个脚本能不能跑"的尝试都会去抢生产的 3001，
+# 结果既验证不了什么，还会在 pm2 里造出一个不停重启的失败条目。
+# 要验证的必须是**这个脚本本身**，而不是一个长得像它的副本。
+export PORT="${PORT:-3001}"
+export HOST="${HOST:-127.0.0.1}"
+export PATH="$NODE_BIN:$PATH"
+
+# 端口已被监听就不启动 —— 避免起出第二个实例去抢同一个端口，
+# 然后在 pm2 里无限重启（这个坑踩过）。
+# 🔴 同 hub-daemon.sh：原写法 `ss ... 2>/dev/null | grep -q` 是 fail-open 的。
+# ss 不在 PATH 时错误被吞、管道为空、grep 不匹配 → 判成"端口空闲"照常放行。
+# 这里显式解析 ss，找不到就拒绝启动，而不是假装端口是空的。
+SS_BIN="$(command -v ss 2>/dev/null || true)"
+[ -x "$SS_BIN" ] || SS_BIN=/usr/bin/ss
+if [ ! -x "$SS_BIN" ]; then
+  echo "[dash-start $(date '+%Y-%m-%d %H:%M:%S')] 🔴 找不到 ss，无法判断端口占用，拒绝启动。"
+  sleep 30
+  exit 1
+fi
+if "$SS_BIN" -tln 2>/dev/null | grep -q ":${PORT}[[:space:]]"; then
+  echo "[dash-start $(date '+%Y-%m-%d %H:%M:%S')] 端口 ${PORT} 已被监听，拒绝启动第二个实例。"
+  sleep 30
+  exit 1
+fi
+
+log() { echo "[dash-start $(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+# 2026-08-02：预检不再是启动的硬前提。
+#
+# 原因（实测复现）：本机 `PORT=39311 npm_config_registry=http://127.0.0.1:1`
+# 跑这个脚本本身 → "预检失败 … 不会启动"。也就是**开机时网络还没起来，
+# dashboard 就永远不会启动** —— 而 daemon 的意义正是活过重启。
+#
+# 为什么可以放宽：真正被执行的是下面写死的 RUNTIME_BIN（一份已经装好的
+# 固化安装），跑它完全不需要联网。脚本自己的注释也写着"启动不再需要联网解包"。
+# 预检查的是 npm 上的 VERSION，和实际执行的东西不是一回事。
+#
+# 7-29 那道防线保留在真正需要它的场景：RUNTIME_BIN 不存在时（那时才必须
+# 依赖 npm），仍然慢速失败，避免无退避重启锤 registry。
+# 2026-08-04: Dashboard Chat HA (#82), source/build commit 54150269.
+# The npm version remains preview.54; this pinned runtime is built from the
+# reviewed main commit, so the directory name is the deployment identity.
+RUNTIME_BIN="$HOME/.commhub/dashboard-runtime-v55/node_modules/.bin/agent-network-dashboard"
+
+if ! resolved="$("$NODE_BIN/npm" view "${PKG}@${VERSION}" version 2>/dev/null)" || [ -z "$resolved" ]; then
+  if [ -x "$RUNTIME_BIN" ]; then
+    log "⚠️ 预检未通过（${PKG}@${VERSION} 查不到，或 registry 不可达）。"
+    log "   本地固化安装存在，按它启动 —— 启动不依赖 npm。"
+    log "   注意：这说明 VERSION 与 registry 不一致，请择机核对，但不阻塞启动。"
+  else
+    log "预检失败：${PKG}@${VERSION} 在 npm 上不存在，或 registry 暂时不可达。"
+    log "且本地固化安装缺失（$RUNTIME_BIN），无从启动。"
+    log "当前 preview 标签指向：$("$NODE_BIN/npm" view "$PKG" dist-tags.preview 2>/dev/null || echo '查询失败')"
+    # 慢速失败：给 pm2 退避留出时间，避免像 34494 次那样锤 registry
+    sleep 30
+    exit 1
+  fi
+else
+  log "预检通过：${PKG}@${resolved}，监听 ${HOST}:${PORT}"
+fi
+# 🔴 不再走 npx：npx 把包解到 ~/.npm/_npx/<hash>/ 并从那里执行，
+# 也就是说**生产服务跑在一个 npm 缓存目录里** —— 任何人一条
+# `npm cache clean --force` 就能删掉线上服务的运行目录。
+# 2026-07-29 实测：_npx 下 70 个条目共 15G，只有 1 个在用；
+# 我按引用扫描清掉 69 个无引用条目回收 13.6G，当时差一点连在用的一起清。
+# 改为直接 exec 固化安装（~/.commhub/dashboard-runtime），
+# 启动不再依赖任何缓存目录，也不再需要联网解包。
+if [ ! -x "$RUNTIME_BIN" ]; then
+  echo "[dash-start] 🔴 固化安装缺失：$RUNTIME_BIN"
+  echo "[dash-start]    重建：cd ~/.commhub/dashboard-runtime && npm install"
+  echo "[dash-start]    慢速失败 30 秒，让 pm2 退避生效。"
+  sleep 30
+  exit 1
+fi
+exec "$RUNTIME_BIN"


### PR DESCRIPTION
## 为什么

标准是:**任一服务器被删库,单凭这个 repo 就要能复现出现在在跑的系统。**

对着这条自检,今天发 `preview.55` 时用到的那条链**过不了**:

| 生产赖以启动的东西 | 在 repo 里? |
|---|---|
| `dash-start.sh`(93 行,真正的生产启动器) | ❌ 0 命中 |
| 两个公网入口的拓扑(Caddy + frp 隧道) | ❌ 只在口头 |
| pm2 saved-env 的注意事项 | ❌ |
| 固化安装目录约定与「为什么不用 npx」 | ❌ 只在脚本注释里,而脚本不在 repo |

机器没了,这些就都没了。本 PR 把它们收进来。

**数据不在此列**,README 里明说了:Hub 的 SQLite 内容无法从 repo 复现,要么来自备份要么重新注册。本文档只保证**软件与运行方式**可复现。

## 改了什么

**`deploy/dashboard/dash-start.sh`** —— 与正在跑的那份**逐字节一致**,只改一处:`NODE_BIN` 原本是硬编码绝对路径,现改为从 `command -v node` 推导并允许覆盖。脚本里**没有任何密钥**(已扫)。

保留它全部注释,那才是核心价值 —— 里面记着 34494 次无退避重启是怎么来的、`ss ... | grep -q` 为什么是 fail-open、放 `/tmp` 会怎样。

**`deploy/dashboard/README.md`** —— 记脚本记不了的:

- **公网入口不止一个**:Caddy `:3000` 和一条 frp 隧道 `:3100` **都终结在同一个 `127.0.0.1:3001`**。把它们当成两套部署已经造成过一次误判。给了判据:比对两个入口返回同一静态文件的 `Last-Modified`,精确到秒相同就是同一份磁盘上的同一个文件。
- 🔴 **两个版本位不是一回事**:`VERSION=` 只做预检,`RUNTIME_BIN=` 才是 `exec` 目标。**只改前者会得到一个"看起来完全成功"的假部署** —— pid 变了、restart +1、`curl /` 正常,但跑的还是旧安装。
- **换版本完整顺序**:发布 → 等传播(抢跑会 502)→ 建 sibling 安装 → **非生产端口旁路验证** → 同时改两处 → 重启(不带 `--update-env`,带了丢 token)。
- **验证只认四条**:`/proc/<pid>/cwd`、服务出去的 chunk 里能 grep 到本次新增字符串、`.next/BUILD_COMMIT`、监听进程是 pm2 后代。
- **两类孤儿进程症状完全不同**:占 `LISTEN` 的会让 pm2 起不来;只攥 `ESTAB` 的会**继续给已打开的标签页发旧 bundle** —— 所以「部署完成」必须带一句「请强刷」。有活连接时不许 kill。
- **回滚**:两处一起改回去;🔴 不要 `npm unpublish`。
- **清理固化安装目录**:必须实际扫 `/proc/*/cwd`,不能凭目录名判断 —— 实测发现过一个 11 天前起、监听在别的端口上的旧实例仍持有某目录。

## 检查

- `bash -n` 通过
- 公开仓安全扫描:无真实用户名 / 域名 / IP / 密钥 / 内部 slug
- 纯新增,不改动任何既有文件