### PR TITLE
release: gate that a tag actually points at the commit that was built

### DIFF
--- a/docs/release/tag-binds-build-sha.md
+++ b/docs/release/tag-binds-build-sha.md
@@ -1,0 +1,44 @@
+# release tag 必须绑定构建 commit
+
+这道门防的是一类**只在灾难恢复时才暴露**的缺陷 —— 平时一切正常,
+只有真去重建的时候才发现拿错了源码。对应 `AGENTS.md` §19。
+
+## 事故(2026-08-12,tmwork 线实际发生)
+
+```
+tag  desktop-v1.20.8-alpha.12   剥出 04a66b20   ← 当时 main 的 head
+实际构建 commit                  6a3db442       ← 差 26 个 commit
+```
+
+根因:**`gh release create <tag>` 在 tag 不存在时,默认在 `target_commitish`
+(默认 `main`)上建 tag**,而不是在你打包用的那个 commit 上。
+
+🔴 **它不会报错。** release 页面完全正常,安装包也是对的。
+于是 `git clone --branch <tag>` 拿到的**不是构建那份代码** ——
+而"凭 tag 能重建"正是所有人默认相信的假设。
+
+## 判据
+
+1. `gh release create <tag> --target <打包用的完整构建 SHA>` —— **`--target` 不可省**
+2. create **之后回读**并逐字符比对,不符即 exit≠0:
+   ```bash
+   scripts/verify-release-tag.sh <owner/repo> <tag> <构建 SHA>
+   ```
+3. 🔴 **witnessed-red 必做**:故意省掉 `--target`、或指向错的 tag,
+   观测到 exit≠0。**没有这一条,它就只是一份 checklist,不是门。**
+
+## 两条容易写错的地方
+
+- 🔴 **回读必须用远端**(`git ls-remote`),不要用本地 `git rev-parse <tag>`。
+  本地 tag 可能就是你自己刚建的那个 —— 那样验的是自己写的东西。
+- 🔴 **不要只断言"退出码非零"就完事**,还要断言**失败时该做的事没做**
+  (没继续上传 asset、没写 feed)。
+
+  同源反例:`if ! cmd; then rc=$?` —— `!` 取反后 `$?` 是取反的结果 `0`,
+  于是"校验失败却退出 0",调用方以为成功。抓住它的是**配对断言**:
+  「该拦的拦住了」是绿的,但「拦住时对外报的是失败」是红的。
+  **验闸要同时验这两面。**
+
+## 归属
+
+判据来自 tmwork 线的实际事故复盘,在此推广到 anet 的四个 npm 包发布流程。

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# 校验 release tag 真的指向【打包用的那个 commit】。
+#
+# 为什么需要这道门(tmwork 2026-08-12 实际事故):
+#   `gh release create <tag>` 在 tag 不存在时,默认在 target_commitish(默认 main)
+#   上建 tag。于是 tag `desktop-v1.20.8-alpha.12` 剥出 04a66b20(当时 main 的 head),
+#   而实际构建 commit 是 6a3db442 —— 差 26 个 commit。
+#
+# 🔴 它不会报错:release 页面完全正常,安装包也是对的。
+#   只有真去重建的时候才会发现 `git clone --branch <tag>` 拿到的不是构建那份代码。
+#   而"凭 tag 能重建"正是所有人默认相信的假设 —— 这类缺陷只在灾难恢复时暴露。
+#
+# 用法: verify-release-tag.sh <repo> <tag> <构建用的完整 SHA>
+set -uo pipefail
+
+REPO="${1:?repo, e.g. owner/name}"
+TAG="${2:?tag}"
+BUILD_SHA="${3:?完整的构建 commit SHA}"
+
+# 🔴 回读必须用【远端】,不要用本地 `git rev-parse <tag>`。
+# 本地 tag 可能就是你自己刚建的那个,那样验的是自己写的东西。
+peeled="$(git ls-remote "https://github.com/${REPO}.git" "refs/tags/${TAG}^{}" | cut -f1)"
+[ -n "$peeled" ] || peeled="$(git ls-remote "https://github.com/${REPO}.git" "refs/tags/${TAG}" | cut -f1)"
+
+if [ -z "$peeled" ]; then
+  echo "FAIL: tag ${TAG} 在远端不存在(或无法读取)" >&2
+  exit 1
+fi
+
+if [ "$peeled" != "$BUILD_SHA" ]; then
+  echo "FAIL: tag 未绑定构建 commit" >&2
+  echo "  tag ${TAG} 剥出 : ${peeled}" >&2
+  echo "  实际构建 commit : ${BUILD_SHA}" >&2
+  echo "  → 用 \`gh release create ${TAG} --target ${BUILD_SHA}\` 重建;--target 不可省。" >&2
+  exit 1
+fi
+
+echo "PASS: ${TAG} -> ${peeled} == 构建 commit"


### PR DESCRIPTION
在 R2 发版之前先把这道门设上,否则会把缺陷烤进这次的 tag。

## 防的是什么

`gh release create <tag>` 在 tag **不存在**时,默认在 `target_commitish`(默认 `main`)上建 tag,**而不是在你打包用的那个 commit 上**。

tmwork 线今天真踩到:
```
tag  desktop-v1.20.8-alpha.12   剥出 04a66b20   ← 当时 main 的 head
实际构建 commit                  6a3db442       ← 差 26 个 commit
```

🔴 **它不会报错。** release 页面完全正常,安装包也是对的。唯一症状是 `git clone --branch <tag>` 拿到的**不是构建那份代码** —— 而"凭 tag 能重建"正是所有人默认相信的假设。

**这类缺陷只在灾难恢复时暴露**,正是 `AGENTS.md` §19 要防的那一类。

## 改了什么(纯新增 2 个文件)

- **`scripts/verify-release-tag.sh`** —— create 之后回读并逐字符比对,不符 exit≠0
- **`docs/release/tag-binds-build-sha.md`** —— 判据、事故、两条容易写错的地方

## 两条写在文档里的坑

- 🔴 **回读必须用远端 `git ls-remote`,不要用本地 `git rev-parse <tag>`** —— 本地 tag 可能就是你自己刚建的那个,那样验的是自己写的东西
- 🔴 **不要只断言"退出码非零"**,还要断言**失败时该做的事没做**。同源反例:`if ! cmd; then rc=$?` —— `!` 取反后 `$?` 是取反的结果 `0`,于是"校验失败却退出 0",调用方以为成功。**验闸要同时验「该拦的拦住了」和「拦住时对外报的是失败」。**

## 验证

```
bash -n                                        ✅
witnessed-red(对不存在的 tag)  rc=1           ✅
```

🔴 **完整的 witnessed-red(故意省掉 `--target` 后观测 exit≠0)需要真建一个 release,尚未做** —— 按 §19 如实标注,不宣称已验证。将在 R2 发版时作为第一次真实使用同时完成。

## 出处

判据来自 tmwork 线自己的事故复盘,他们主动分享过来,在此推广到 anet 的四个 npm 包发布流程。