### PR TITLE
fix(cli): resolve the explicit current network

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -124,6 +124,7 @@ import {
   DEFAULT_CODEX_MODEL,
   defaultCodexModelForRuntime,
 } from "../src/codex-model-default";
+import { resolvePrimaryNetwork } from "../src/primary-network";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -10518,17 +10519,12 @@ async function demoDebateCommand() {
     networkLabel = `(provided ${explicitNetwork.slice(0, 16)})`;
   } else if (useDefaultNetwork) {
     try {
-      const me = await fetch(`${hub}/api/auth/me`, { headers: authHeaders() }).then(r => r.json() as any);
-      networkId = me?.user?.default_network_id || "";
-    } catch {}
-    if (!networkId) {
-      try {
-        const nets = await fetch(`${hub}/api/networks`, { headers: authHeaders() }).then(r => r.json() as any);
-        const def = (nets?.networks || []).find((n: any) => n.network_name === "default") || nets?.networks?.[0];
-        networkId = def?.network_id || "";
-      } catch {}
+      networkId = await resolvePrimaryNetwork(hub, authHeaders());
+    } catch (e: any) {
+      console.error(`  ❌ ${e?.message || "无法读取当前 network"}`);
+      return;
     }
-    networkLabel = `(default network)`;
+    networkLabel = `(current network)`;
   } else {
     const netName = `debate-${suffix}`;
     console.log(`  ⏳ 正在创建独立 network: ${netName}...`);
@@ -10922,17 +10918,12 @@ async function demoSocialMediaCommand() {
     networkLabel = `(provided ${explicitNetwork.slice(0, 16)})`;
   } else if (useDefaultNetwork) {
     try {
-      const me = await fetch(`${hub}/api/auth/me`, { headers: authHeaders() }).then(r => r.json() as any);
-      networkId = me?.user?.default_network_id || "";
-    } catch {}
-    if (!networkId) {
-      try {
-        const nets = await fetch(`${hub}/api/networks`, { headers: authHeaders() }).then(r => r.json() as any);
-        const def = (nets?.networks || []).find((n: any) => n.network_name === "default") || nets?.networks?.[0];
-        networkId = def?.network_id || "";
-      } catch {}
+      networkId = await resolvePrimaryNetwork(hub, authHeaders());
+    } catch (e: any) {
+      console.error(`  ❌ ${e?.message || "无法读取当前 network"}`);
+      return;
     }
-    networkLabel = `(default network)`;
+    networkLabel = `(current network)`;
   } else {
     const netName = `demo-social-${suffix}`;
     try {
@@ -11468,17 +11459,12 @@ async function demoPrReviewCommand() {
     networkLabel = `(provided ${explicitNetwork.slice(0, 16)})`;
   } else if (useDefaultNetwork) {
     try {
-      const me = await fetch(`${hub}/api/auth/me`, { headers: authHeaders() }).then(r => r.json() as any);
-      networkId = me?.user?.default_network_id || "";
-    } catch {}
-    if (!networkId) {
-      try {
-        const nets = await fetch(`${hub}/api/networks`, { headers: authHeaders() }).then(r => r.json() as any);
-        const def = (nets?.networks || []).find((n: any) => n.network_name === "default") || nets?.networks?.[0];
-        networkId = def?.network_id || "";
-      } catch {}
+      networkId = await resolvePrimaryNetwork(hub, authHeaders());
+    } catch (e: any) {
+      console.error(`  ❌ ${e?.message || "无法读取当前 network"}`);
+      return;
     }
-    networkLabel = `(default network)`;
+    networkLabel = `(current network)`;
   } else {
     const netName = `pr-review-${suffix}`;
     console.log(`  ⏳ 正在创建独立 network: ${netName}...`);

--- a/agent-network/src/primary-network.test.ts
+++ b/agent-network/src/primary-network.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  PrimaryNetworkResolutionError,
+  resolvePrimaryNetwork,
+  type PrimaryNetworkFetch,
+  type PrimaryNetworkResponse,
+} from "./primary-network";
+
+function fakeFetch(body: PrimaryNetworkResponse, status = 200): PrimaryNetworkFetch {
+  return async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+describe("resolvePrimaryNetwork", () => {
+  test("uses current_network even when the network list is reversed and renamed", async () => {
+    const selected = await resolvePrimaryNetwork("https://hub.example", { Authorization: "Bearer test" }, fakeFetch({
+      ok: true,
+      current_network: "net-primary",
+      networks: [
+        { network_id: "net-newest", network_name: "renamed-second" },
+        { network_id: "net-primary", network_name: "owner-named-primary" },
+      ],
+    }));
+
+    expect(selected).toBe("net-primary");
+  });
+
+  test("fails explicitly when current_network is missing instead of guessing networks[0]", async () => {
+    const result = resolvePrimaryNetwork("https://hub.example", {}, fakeFetch({
+      ok: true,
+      networks: [{ network_id: "net-wrong", network_name: "default" }],
+    }));
+
+    await expect(result).rejects.toBeInstanceOf(PrimaryNetworkResolutionError);
+    await expect(result).rejects.toThrow("未返回 current_network");
+  });
+
+  test("turns transport and HTTP failures into explicit resolution errors", async () => {
+    const offline: PrimaryNetworkFetch = async () => { throw new Error("offline"); };
+    await expect(resolvePrimaryNetwork("https://hub.example", {}, offline)).rejects.toThrow("检查 Hub 连接");
+    await expect(resolvePrimaryNetwork("https://hub.example", {}, fakeFetch({}, 401))).rejects.toThrow("HTTP 401");
+  });
+});
+
+test("debate, demo-social, and pr-review all use the shared resolver", () => {
+  const cli = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+  expect(cli.match(/await resolvePrimaryNetwork\(/g)?.length).toBe(3);
+  expect(cli).not.toContain("default_network_id");
+  expect(cli).not.toMatch(/network_name\s*===\s*["']default["']/);
+});

--- a/agent-network/src/primary-network.ts
+++ b/agent-network/src/primary-network.ts
@@ -1,0 +1,56 @@
+export interface PrimaryNetworkResponse {
+  ok?: boolean;
+  current_network?: unknown;
+  networks?: unknown;
+}
+
+export type PrimaryNetworkFetch = (
+  input: string,
+  init: { headers: Record<string, string> },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<PrimaryNetworkResponse> }>;
+
+export class PrimaryNetworkResolutionError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PrimaryNetworkResolutionError";
+  }
+}
+
+/**
+ * Resolve the authenticated user's active network from the server's explicit
+ * `/api/auth/me.current_network` field.
+ *
+ * Do not fall back to a network name or list position: both are presentation
+ * details, and guessing either can silently run a command in the wrong network.
+ */
+export async function resolvePrimaryNetwork(
+  hub: string,
+  headers: Record<string, string>,
+  fetchImpl: PrimaryNetworkFetch = fetch as PrimaryNetworkFetch,
+): Promise<string> {
+  let response: Awaited<ReturnType<PrimaryNetworkFetch>>;
+  try {
+    response = await fetchImpl(`${hub}/api/auth/me`, { headers });
+  } catch (cause) {
+    throw new PrimaryNetworkResolutionError("无法读取当前 network，请检查 Hub 连接后重试。", { cause });
+  }
+
+  if (!response.ok) {
+    throw new PrimaryNetworkResolutionError(`无法读取当前 network：Hub 返回 HTTP ${response.status}。`);
+  }
+
+  let body: PrimaryNetworkResponse;
+  try {
+    body = await response.json();
+  } catch (cause) {
+    throw new PrimaryNetworkResolutionError("无法读取当前 network：Hub 返回了无效响应。", { cause });
+  }
+
+  const networkId = typeof body.current_network === "string" ? body.current_network.trim() : "";
+  if (!networkId) {
+    throw new PrimaryNetworkResolutionError(
+      "Hub 未返回 current_network，无法安全选择 network；请重新登录或用 --network <id> 明确指定。",
+    );
+  }
+  return networkId;
+}

--- a/docs/tests/report-test702-primary-network.txt
+++ b/docs/tests/report-test702-primary-network.txt
@@ -1,0 +1,32 @@
+test702 — explicit primary-network resolution (#702)
+Date: 2026-08-12
+Environment: Docker, oven/bun:1.3.14
+Scope: agent-network/src/primary-network.ts and the three CLI --no-network call sites
+
+GREEN
+Command:
+  sg docker -c 'docker build --build-arg SOURCE_COMMIT=$(git rev-parse HEAD) -f tests/test702-primary-network/Dockerfile -t anet-test702:local . && docker run --rm anet-test702:local'
+Result:
+  - primary-network behavior + CLI wiring: 4 pass, 0 fail
+  - TypeScript typecheck: PASS
+  - package build: PASS
+  - container exit: 0
+
+WITNESSED RED
+Mutation:
+  Replace the resolver's read of body.current_network with an empty string.
+Command:
+  Build and run the same Docker test gate with SOURCE_COMMIT=witnessed-red-no-current-network.
+Result:
+  - "uses current_network even when the network list is reversed and renamed": FAIL
+  - 3 pass, 1 fail
+  - container exit: 1
+  - failure was PrimaryNetworkResolutionError: Hub did not return current_network
+
+RESTORATION
+  Restored the current_network read exactly. The final green gate was rerun before commit.
+
+BOUNDARIES
+  - No production DB, node config, or process was touched.
+  - No live Hub request was required; transport behavior is deterministic via injected fetch.
+  - This test does not validate a production deployment or npm publication.

--- a/tests/test702-primary-network/Dockerfile
+++ b/tests/test702-primary-network/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14
+
+WORKDIR /workspace/agent-network
+
+COPY agent-network/package.json agent-network/package-lock.json ./
+RUN bun install --ignore-scripts
+
+COPY agent-network ./
+COPY tests/test702-primary-network/run.sh /workspace/run.sh
+
+ARG SOURCE_COMMIT=unknown
+ENV TEST702_SOURCE_COMMIT=${SOURCE_COMMIT}
+
+RUN chmod 0755 /workspace/run.sh
+ENTRYPOINT ["/workspace/run.sh"]

--- a/tests/test702-primary-network/run.sh
+++ b/tests/test702-primary-network/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[test702] source=${TEST702_SOURCE_COMMIT:-unknown}"
+echo "[test702] primary-network behavior + CLI wiring"
+bun test src/primary-network.test.ts
+
+echo "[test702] TypeScript typecheck"
+bun run typecheck
+
+echo "[test702] package build"
+bun run build
+
+echo "[test702] PASS"


### PR DESCRIPTION
## What changed

- add a shared `resolvePrimaryNetwork()` that reads the explicit top-level `current_network` returned by `GET /api/auth/me`
- route `demo debate --no-network`, `demo socialmedia --no-network`, and `demo pr-review --no-network` through that resolver
- remove the dead `user.default_network_id` read and the `network_name === "default" || networks[0]` fallback
- fail with a readable error when the Hub does not return `current_network`, instead of silently guessing a list entry
- add a Docker-isolated test gate and committed witnessed-red/green report

## Why

The server already returns the authenticated token's active network as `current_network`. The old CLI ignored that field and inferred a network from a mutable display name or list order, so a reordered or renamed list could silently run a command in the wrong network.

The production observation supplied during triage was that the 25 networks currently have no user owning more than one network. That makes `networks[0]` accidentally equivalent today and explains why the bug stayed hidden; it is context, not the correctness proof. The tests deliberately use multiple reversed and renamed networks.

## Validation

Docker-only gate using `oven/bun:1.3.14`:

- resolver behavior and CLI wiring: 4 passed, 0 failed
- TypeScript typecheck: passed
- full `@sleep2agi/agent-network` package build: passed
- witnessed red: replacing the `current_network` read with an empty value caused the reversed/renamed-list positive test to fail (3 passed, 1 failed; exit 1)
- restored commit `85a149f4`: complete gate passed again

Evidence: `docs/tests/report-test702-primary-network.txt`.

## Boundaries

- no production DB, node configuration, or process changes
- no deployment or npm publication performed
- this PR does not change `#478`, `#450`, `#490`, or `agent-node/src/task-runtime-evidence.test.ts`

Closes #702