### PR TITLE
test: pin the argument order, not the indentation, in the inbox wiring check

### DIFF
--- a/agent-node/src/task-runtime-evidence.test.ts
+++ b/agent-node/src/task-runtime-evidence.test.ts
@@ -102,11 +102,20 @@ describe("agent-node inbox wiring", () => {
     expect(end).toBeGreaterThan(start);
     const branch = cli.slice(start, end);
 
+    // The invariant is the argument ORDER — the transport id (msg.id) must not
+    // reach processTask, which takes the stable logicalTaskId. Match on
+    // whitespace-normalised source so that reindenting or wrapping the call
+    // cannot fail this: #698 moved it inside runInboxTurnByReplyPolicy's
+    // deliverToRuntime closure, which changed nothing but the indentation and
+    // broke the old literal that pinned eight spaces per line.
+    const norm = (s: string) => s.replace(/\s+/g, " ");
+    const branchN = norm(branch);
+
     expect(branch).toContain("const logicalTaskId = logicalTaskIdFromInbox(msg)");
-    expect(branch).toContain("processTask(\n        runtimeContent,\n        from,\n        logicalTaskId,");
+    expect(branchN).toContain(norm("processTask( runtimeContent, from, logicalTaskId,"));
     expect(branch).toContain("deliverReplyReliably(from, replyBody, logicalTaskId, failed)");
     expect(branch).toContain("ackMessage(msg.id)");
-    expect(branch).not.toContain("processTask(\n        runtimeContent,\n        from,\n        msg.id,");
+    expect(branchN).not.toContain(norm("processTask( runtimeContent, from, msg.id,"));
   });
 
   test("all runtime dispatch families receive the same task-lifetime reporter", () => {


### PR DESCRIPTION
**这条是当前卡住整个发版线的红。** 它不是产品缺陷。

## 定性

首红点 `be1c7dbb`(#698)。#698 把 `processTask` 调用移进了 `runInboxTurnByReplyPolicy` 的 `deliverToRuntime` 闭包里 —— **这正是那个 PR 要做的事**(按 reply policy 决定终结方式)。调用本身唯一的变化是缩进。

坏的是断言:

```js
expect(branch).toContain("processTask(\n        runtimeContent,\n        from,\n        logicalTaskId,")
```

**它把八个空格、三行换行写死了。** 重新换行会让它红,而把保证整个删掉反而不一定红。

## 改法

改成对**空白归一化**后的源码匹配。这条用例要保的不变量是**参数顺序** —— 传输层 id(`msg.id`)绝不能进入 `processTask`,后者要的是稳定的 `logicalTaskId` —— 这个性质不受任何重新排版影响。

正负两条断言都保留:
- 正:`processTask( runtimeContent, from, logicalTaskId,`
- 负:`processTask( runtimeContent, from, msg.id,` **不得出现**

## witnessed-red(证明新断言仍然有牙)

```
把生产代码的 processTask(..., logicalTaskId, ...) 改成 msg.id  →   9 pass / 1 fail
还原                                                          →  10 pass / 0 fail
```

`10/0/41`,与 base `17b8223f` 的 `10/0/41` 一致。

## 为什么必须修而不是豁免

它是**被这次要发布的改动引入的**。豁免一个由「正要发布的 PR」引入的红,等于把发版当免检理由。而修起来就是这一处。

## 同族

`#710` 修的是同一个病的另一处(`opencode-copresence/inbox-wiring.test.ts` 按**字符距离**断言,slice 出日志行之后 300 个字符)。

🔴 **这类断言同时具备假红和假绿两种可能** —— 合法重构让它假红;真把接线删掉、只要别处还有同名调用,它可能照样绿。**测的是"两段代码挨得近不近",不是"行为对不对"。**