### PR TITLE
fix(agent-node): preserve authenticated human short replies

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -4753,7 +4753,7 @@ async function processInbox() {
       const preparedReply = prepareDashboardNativeSlashReply(
         taskOutcome.text,
         persistenceSafeContent,
-        interactiveDashboardTask,
+        { messageType: msgType, interactiveDashboardTask },
         failed,
         (text) => isLowValueText(text, true),
       );
@@ -4764,10 +4764,10 @@ async function processInbox() {
         log(`processTask returned: "${result.slice(0, 80)}" (${result.length} chars, failed=${failed})`);
       }
 
-      // Low-value successful replies are dropped (preserve previous
+      // Low-value successful agent chatter is dropped (preserve previous
       // behaviour — codex / claude often emit "done." / "✅" for trivial
-      // confirmations). Failures ALWAYS surface so the dispatcher sees
-      // the real error instead of silence.
+      // confirmations). Authenticated Dashboard human tasks and failures
+      // ALWAYS surface so the dispatcher sees a reply instead of silence.
       if (!preparedReply.shouldDeliver) {
         log(GROK_EXECUTION_MODE === "cli"
           ? `skip reply: low-value (${result.length} chars; content withheld)`

--- a/agent-node/src/goals/routing.test.ts
+++ b/agent-node/src/goals/routing.test.ts
@@ -85,7 +85,7 @@ describe("Dashboard native slash migration notice", () => {
     const prepared = prepareDashboardNativeSlashReply(
       "收到",
       "/loop 5m work",
-      true,
+      { messageType: "task", interactiveDashboardTask: true },
       false,
       (text) => text === "收到",
     );
@@ -99,11 +99,51 @@ describe("Dashboard native slash migration notice", () => {
     const prepared = prepareDashboardNativeSlashReply(
       "native failed",
       "/loop 5m work",
-      true,
+      { messageType: "task", interactiveDashboardTask: true },
       true,
       () => false,
     );
     expect(prepared.shouldDeliver).toBe(true);
     expect(prepared.text).toBe(`${DASHBOARD_NATIVE_SCHEDULE_NOTICE}\n\nnative failed`);
+  });
+});
+
+describe("reply filtering uses authenticated message provenance", () => {
+  test("a short presence reply to an authenticated Dashboard human task is delivered", () => {
+    for (const messageType of ["task", "broadcast"]) {
+      const prepared = prepareDashboardNativeSlashReply(
+        "在线。",
+        "在线吗?",
+        { messageType, interactiveDashboardTask: true },
+        false,
+        () => true,
+      );
+
+      expect(prepared).toEqual({ text: "在线。", shouldDeliver: true });
+    }
+  });
+
+  test("the same low-value class remains filtered for agent-to-agent tasks", () => {
+    const prepared = prepareDashboardNativeSlashReply(
+      "收到",
+      "同步状态",
+      { messageType: "task", interactiveDashboardTask: false },
+      false,
+      () => true,
+    );
+
+    expect(prepared).toEqual({ text: "收到", shouldDeliver: false });
+  });
+
+  test("a provenance flag cannot bypass filtering for a non-task message type", () => {
+    const prepared = prepareDashboardNativeSlashReply(
+      "收到",
+      "同步状态",
+      { messageType: "message", interactiveDashboardTask: true },
+      false,
+      () => true,
+    );
+
+    expect(prepared).toEqual({ text: "收到", shouldDeliver: false });
   });
 });

--- a/agent-node/src/goals/routing.ts
+++ b/agent-node/src/goals/routing.ts
@@ -2,6 +2,11 @@ import { parseGoalCommand } from "./parser";
 
 export type GoalRoutingRuntime = "claude" | "codex" | "grok" | "opencode" | "codex-app-server";
 
+export interface ReplyMessageProvenance {
+  messageType: string;
+  interactiveDashboardTask: boolean;
+}
+
 const ANET_SCHEDULE_COMMAND_RE = /^\s*\/(?:agoal|aloop)\b/i;
 const LEGACY_SCHEDULE_COMMAND_RE = /^\s*\/(?:goal|loop)\b/i;
 
@@ -62,10 +67,15 @@ export function appendDashboardNativeScheduleNotice(
 export function prepareDashboardNativeSlashReply(
   replyText: string,
   content: string,
-  interactiveDashboardTask: boolean,
+  provenance: ReplyMessageProvenance,
   failed: boolean,
   isLowValueReply: (text: string) => boolean,
 ): { text: string; shouldDeliver: boolean } {
+  const { interactiveDashboardTask, messageType } = provenance;
   const text = appendDashboardNativeScheduleNotice(replyText, content, interactiveDashboardTask);
-  return { text, shouldDeliver: failed || !isLowValueReply(text) };
+  // The Hub-stamped Dashboard provenance is the authorization fact here; an
+  // agent alias or task type alone is not enough to bypass chatter filtering.
+  const humanDashboardRequest = interactiveDashboardTask
+    && (messageType === "task" || messageType === "broadcast");
+  return { text, shouldDeliver: failed || humanDashboardRequest || !isLowValueReply(text) };
 }

--- a/docs/tests/report-test696-human-low-value-reply.txt
+++ b/docs/tests/report-test696-human-low-value-reply.txt
@@ -1,0 +1,39 @@
+test696 — authenticated human short replies are not silently dropped (#696)
+Date: 2026-08-13
+Environment: Docker, oven/bun:1.3.14
+Scope: agent-node outbound low-value filtering and authenticated Dashboard provenance wiring
+
+GREEN
+Command:
+  sg docker -c 'docker build --build-arg SOURCE_COMMIT=$(git rev-parse HEAD) -f tests/test696-human-low-value-reply/Dockerfile -t anet-test696:local . && docker run --rm anet-test696:local'
+Result:
+  - routing and authenticated provenance tests: 27 pass, 0 fail
+  - production CLI provenance wiring: PASS
+  - production bundle build: PASS
+  - container exit: 0
+
+WITNESSED RED
+Pre-fix result:
+  - "在线吗?" -> "在线。" from an authenticated Dashboard task: FAIL
+  - received { shouldDeliver: false }, expected { shouldDeliver: true }
+  - agent-to-agent task reply "收到": PASS (remained filtered)
+  - targeted suite: 13 pass, 1 fail; exit 1
+
+BROAD NON-GATE ATTEMPT
+  A generic `bun test src` run in the narrow test696 image produced 1198 pass,
+  25 fail, and 2 setup errors. It is not a valid full-suite gate: that image
+  intentionally omits the agent-network tree, crontab, Grok fixtures/binary,
+  OpenCode runtime, and root ownership required by those suites. No failing
+  assertion involved the new reply-provenance behavior. The dedicated Docker
+  gate and production bundle build are the acceptance evidence for this PR.
+
+GREEN INVARIANTS
+  - Authenticated Dashboard task/broadcast short replies bypass low-value filtering.
+  - Agent-to-agent task replies do not bypass filtering merely because type=task.
+  - A provenance flag paired with a non-task type does not bypass filtering.
+  - Failed replies and Dashboard native slash notices retain their prior delivery behavior.
+
+BOUNDARIES
+  - No production DB, node configuration, or process was touched.
+  - No live Hub request was required; the gate uses the Hub-stamped provenance predicate tests.
+  - This test does not validate a production deployment or npm publication.

--- a/tests/test696-human-low-value-reply/Dockerfile
+++ b/tests/test696-human-low-value-reply/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+
+WORKDIR /workspace
+COPY agent-node/package.json /workspace/agent-node/package.json
+RUN cd /workspace/agent-node && bun install --ignore-scripts
+COPY agent-node /workspace/agent-node
+COPY tests/test696-human-low-value-reply/run.sh /test696/run.sh
+RUN chmod 755 /test696/run.sh
+
+ENTRYPOINT ["bash", "/test696/run.sh"]

--- a/tests/test696-human-low-value-reply/run.sh
+++ b/tests/test696-human-low-value-reply/run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' \
+  "[test696] source=${SOURCE_COMMIT}" \
+  "[test696] authenticated Dashboard provenance + low-value reply filtering"
+
+bun test \
+  /workspace/agent-node/src/goals/routing.test.ts \
+  /workspace/agent-node/src/inbox-dispatch.test.ts
+
+cli=/workspace/agent-node/src/cli.ts
+grep -Fq 'const interactiveDashboardTask = isInteractiveDashboardTask(msg);' "$cli"
+grep -Fq '{ messageType: msgType, interactiveDashboardTask },' "$cli"
+
+cd /workspace/agent-node
+bun build src/cli.ts --outfile /tmp/agent-node-cli.js --target node \
+  --external @anthropic-ai/claude-agent-sdk \
+  --external '@anthropic-ai/claude-agent-sdk-*' \
+  --external @openai/codex-sdk \
+  --external node-pty
+test -s /tmp/agent-node-cli.js
+
+printf '%s\n' '[test696] PASS'


### PR DESCRIPTION
## Summary

Fixes #696.

- pass Hub-authenticated Dashboard provenance and inbox message type into outbound low-value reply routing
- deliver short successful replies such as `在线。` for authenticated Dashboard task/broadcast requests
- retain low-value filtering for agent-to-agent chatter such as `收到`
- retain failure delivery and Dashboard native slash notice behavior

The bypass does not trust sender aliases or `type=task` alone. It requires the existing Hub-stamped `isInteractiveDashboardTask` provenance and an actionable Dashboard task/broadcast type.

## Verification

- dedicated Docker gate: 27 tests passed, 0 failed
- production CLI provenance wiring assertion passed
- production agent-node bundle build passed
- witnessed-red before the fix: Dashboard `在线吗?` → `在线。` produced `shouldDeliver=false`; 13 passed, 1 failed
- the same red run kept the agent-agent `收到` filtering assertion green
- post-commit Docker gate passed at `d4abdf1f761217d7bf7efaf2ef7371ebe16e67c2`

Evidence: `docs/tests/report-test696-human-low-value-reply.txt`.

A generic `bun test src` run in the intentionally narrow test image was also attempted but is not used as a gate: the image omits other suites' agent-network tree, crontab, Grok/OpenCode binaries and fixtures, and root ownership assumptions. It reported 1198 pass, 25 fail, and 2 setup errors; none involved this reply-provenance behavior.

## Boundaries

- no production DB, node configuration, or process changes
- no deployment or npm publication validation
- does not touch `agent-node/src/task-runtime-evidence.test.ts`
