### PR TITLE
release: preview 2.3.0-preview.39 / 2.5.0-preview.31 / 0.9.0-preview.29

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -788,7 +788,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // refetch). A `latest` agent-network release must pin a *stable* server.
 // `anet upgrade` (#88) surfaces this constant in its plan output so users
 // understand global-install version != version anet hub start actually runs.
-const PINNED_SERVER_VERSION = "0.9.0-preview.27";
+const PINNED_SERVER_VERSION = "0.9.0-preview.29";
 function sessionFileExists(uuid: string, cwd: string = process.cwd()): boolean {
   if (!uuid) return false;
   return existsSync(join(homedir(), ".claude", "projects", encodeCwd(cwd), `${uuid}.jsonl`));

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.37",
+  "version": "2.3.0-preview.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.37",
+      "version": "2.3.0-preview.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.37",
+  "version": "2.3.0-preview.39",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.29",
+  "version": "2.5.0-preview.31",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.27",
+  "version": "0.9.0-preview.29",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and 17 MCP tools.",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
把本次 preview 发版的版本号回合 main。

## 发了什么

```
@sleep2agi/agent-network    2.3.0-preview.39
@sleep2agi/agent-node       2.5.0-preview.31
@sleep2agi/commhub-server   0.9.0-preview.29
```

`latest` 三个包**一个都没动**(仍是 `2.2.21` / `2.4.13` / `0.8.8`)。

载荷:#697(model 注入)、#698(peer reply 终结原任务)、#699(自动网络按 owner 命名)、#696(人类提问不再被当低价值回复丢掉)。

## 🔴 关键:同时改了 `PINNED_SERVER_VERSION`

`anet hub start` 实际启动的是:

```js
const serverArgs = ["--bun", `@sleep2agi/commhub-server@${PINNED_SERVER_VERSION}`];
```

所以**只发 commhub-server 而不动这个常量,这次发版等于什么都没发** —— 用户升级 CLI 之后,CLI 仍然去拉 `preview.27`,#698 的服务端改动(删掉 `liveSse < 1` 这个 capability 条件)**永远到不了任何人手里**。

发布顺序因此是:**先发 server → 把 pin 指过去 → 再发 CLI**(反过来会让 CLI 拉一个还不存在的版本,`bunx` 直接 ETARGET)。

**验证方式是真装真跑,不是 grep** —— 发布产物是混淆过的,grep 会假阴性:

```
干净容器 → npm i -g @sleep2agi/agent-network@2.3.0-preview.39
        → anet --version           anet v2.3.0-preview.39
        → anet hub start           commhub-server v0.9.0-preview.29   ✅
```

## 顺带修掉一个长期漂移

三个 `package.json` 的版本**各自比 npm 上已有的低一位**(`.37/.29/.27` vs `.38/.30/.28`)—— 说明上一次发版是在发布时 bump、但没把 bump 提交回来。本 PR 一并纠正,让 repo 不再落后 registry。

## R1 前置(本次发版的依据)

main `bec372c8` 上五道门全绿:`Docker E2E` / `anet QA (v0)` / 三个 lint。

那 39 条 Grok copresence 红已定性为**环境缺件**:在 base `17b8223f` 上跑同样是 39 fail,且从来不在 CI 的 L0 白名单里。

## 未做

- **未发 `latest`**,未做任何节点升级 —— R3 单节点 pilot 需要单独授权
- tag 与 `scripts/verify-release-tag.sh` 校验在本 PR 之后单独执行
