### PR TITLE
docs(daemon): show the three prerequisites as one chain, and disambiguate the name

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -7,6 +7,27 @@ PM2、systemd、cron 看门狗不能同时管理同一个 Hub。多个守护者�
 让它们争用同一个端口和 SQLite 数据库。
 :::
 
+## 先决条件(按顺序,每一道都会挡住你)
+
+在干净机器上实测出来的完整链条。三道门都是 fail-closed 且报错可执行,
+但文档此前没把它们连起来写,只能一次撞一个:
+
+| 顺序 | 缺了会看到 | 怎么办 |
+|---|---|---|
+| 1. **Bun ≥ 1.2** | `❌ anet hub start requires the Bun runtime (commhub-server is bun-only — uses Bun.serve + bun:sqlite, no Node fallback)` | `npm i -g bun` 或 `curl -fsSL https://bun.sh/install \| bash`,然后**重开 shell** 让 PATH 生效 |
+| 2. **Hub 在跑** | `未找到 CommHub Server。请先运行: anet hub start` | `anet hub start`(约 3 秒起来) |
+| 3. **已登录且有 network_id** | `未登录或缺少 network_id。请运行: anet login` | `anet register` 建账号,或 `anet login` |
+
+::: warning `anet daemon` 和本文说的「守护」不是一回事
+本文讲的是**用 PM2 守护 `anet hub start`**(让 Hub 常驻)。
+
+而 `anet daemon init` / `up` 是**另一件事** —— 创建并启动一个
+`host_supervisor` 节点(RFC-026)。两者名字相近、做的事不同。
+
+另外 `anet daemon --help` 目前会打出全局帮助;要看子命令请直接敲
+`anet daemon`(不带参数)。
+:::
+
 ## 推荐入口
 
 守护 `anet hub start`，不要在配置里钉死 `commhub-server` 的 preview 版本。

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -8,6 +8,28 @@ Do not let PM2, systemd, and a cron watchdog manage the same Hub. Competing
 supervisors can start two processes against one port and one SQLite database.
 :::
 
+## Prerequisites (in order — each one will stop you)
+
+Measured on a clean machine. All three fail closed with an actionable
+message, but the docs never showed them as one chain, so you hit them one at
+a time:
+
+| # | What you see if it is missing | Fix |
+|---|---|---|
+| 1. **Bun ≥ 1.2** | `❌ anet hub start requires the Bun runtime (commhub-server is bun-only — uses Bun.serve + bun:sqlite, no Node fallback)` | `npm i -g bun`, then **restart your shell** so PATH picks it up |
+| 2. **Hub running** | `未找到 CommHub Server。请先运行: anet hub start` | `anet hub start` (up in ~3s) |
+| 3. **Logged in with a network_id** | `未登录或缺少 network_id。请运行: anet login` | `anet register`, or `anet login` |
+
+::: warning `anet daemon` is not what this page daemonizes
+This page is about **keeping the Hub alive with PM2** (`anet hub start`).
+
+`anet daemon init` / `up` is a different thing: it creates and starts a
+`host_supervisor` node (RFC-026). Similar names, different jobs.
+
+Also note `anet daemon --help` currently prints the global help — run
+`anet daemon` with no arguments to see its subcommands.
+:::
+
 ## Recommended entry point
 
 Supervise `anet hub start`; do not pin an old `commhub-server` preview in the


### PR DESCRIPTION
把在干净机器上实测出来的 daemon 前置链写进文档,并消歧一个容易搞混的命名。

## 缺口

跑 daemon 要按顺序满足三个前置,**每一道都会挡住你**。三道都是 fail-closed 且**报错本身写得很好**(明确、可执行、还给安装命令)。缺的是:**文档从没把它们作为一条链展示**,所以用户只能一次撞一个。

实测(干净容器,`@sleep2agi/agent-network@preview`):

```
无 Bun     → ❌ anet hub start requires the Bun runtime
              (commhub-server is bun-only — uses Bun.serve + bun:sqlite, no Node fallback)
有 Bun     → hub 约 3 秒起来
hub 没起   → anet daemon init: 未找到 CommHub Server。请先运行: anet hub start
没登录     → anet daemon init: 未登录或缺少 network_id。请运行: anet login
```

中英两版各加一张三行表。

## 顺带消歧一个真会误导人的命名

`deploy/daemon.md` 讲的是**用 PM2 守护 `anet hub start`**(让 Hub 常驻)。

而 `anet daemon init` / `up` 是**另一件事** —— 创建并启动 `host_supervisor` 节点(RFC-026)。

**两者名字相近、做的事完全不同,而这页文档此前一个字都没提过那个命令。** 一个读完本页、然后敲 `anet daemon` 的用户会得到完全不同的东西。已加 warning 块说明。

同时注明 `anet daemon --help` 目前会落到全局帮助(见 #717),让读者知道要敲不带参数的 `anet daemon`。

## 为什么是「实测」不是「推断」

这三条报错原文都是我在一次性容器里真跑出来的,不是从源码推的。前置顺序也是撞出来的 —— 我最初以为装完 Bun 就能 `daemon init`,结果连撞两道。
