### PR TITLE
ops: hub upgrade runbook, and the first drill report that is actually a drill

### DIFF
--- a/deploy/hub/README.md
+++ b/deploy/hub/README.md
@@ -1,0 +1,88 @@
+# 生产 Hub 换版本
+
+对应 `AGENTS.md` §19。与 `deploy/dashboard/` 同一套「固化安装 + 指针切换」模式,
+但 Hub 是**全网唯一**的,所以每一步的代价更高。
+
+🔴 **这份文档标注为「已演练」** —— 2026-08-13 真跑过一次
+(`0.9.0-preview.27 → 0.9.0-preview.29`),证据见 `docs/tests/report-hub-upgrade-preview29.txt`。
+这是 `deploy/` 下目前唯一不是「未演练」的一份。
+
+## 拓扑
+
+```
+pm2 app  commhub-hub
+  └─ script  ~/.local/bin/hub-daemon.sh   (bash)
+       └─ RUNTIME_DIR="$HOME/.commhub/runtime-vNN-<label>"   ← 版本切换点,只此一行
+            └─ exec bun <RUNTIME_DIR>/node_modules/@sleep2agi/commhub-server/bin/commhub.ts
+```
+
+启动脚本自己维护一份变更历史,每次切换都追加「从哪到哪 + 回滚目标」。**照做,别省。**
+
+## 为什么不用 `bunx`
+
+脚本注释里写了:`bunx --bun @sleep2agi/commhub-server@<版本>` 执行的二进制落在
+`/tmp/bunx-*/node_modules/.bin/`,**任何 `/tmp` 清理都会让生产在下次重启时起不来**。
+固化安装把运行时从缓存目录里摘出来。
+
+## 换版本(实测顺序,一步都别省)
+
+```bash
+# 1. 回滚坐标三件套 —— 先记下来
+pm2 describe commhub-hub | grep -E 'script path|pid'
+readlink /proc/<pid>/cwd
+grep '^RUNTIME_DIR=' ~/.local/bin/hub-daemon.sh
+curl -s localhost:9200/health          # 记下当前 version
+
+# 2. 备份:启动脚本 + 一致性 DB 备份(不要 cp,WAL 在写)
+cp ~/.local/bin/hub-daemon.sh ~/.local/bin/hub-daemon.sh.bak-<旧版本>-$(date +%Y%m%d-%H%M%S)
+bun -e "new (require('bun:sqlite').Database)('<db>',{readonly:true}).exec(\"VACUUM INTO '<备份路径>'\")"
+# 验备份:PRAGMA integrity_check 必须 ok,并记下 sessions/tasks 行数
+
+# 3. sibling 固化安装(不动正在跑的那个目录)
+mkdir -p ~/.commhub/runtime-vNN-<label> && cd $_
+printf '{"name":"commhub-runtime","private":true,"version":"1.0.0","dependencies":{"@sleep2agi/commhub-server":"<新版本>"}}' > package.json
+npm install
+
+# 4. 🔴 旁路验证 —— 备用端口 + DB 的【副本】,绝不碰生产库
+COMMHUB_DB=/tmp/verify.db PORT=9291 HOST=127.0.0.1 \
+  bun ~/.commhub/runtime-vNN-<label>/node_modules/@sleep2agi/commhub-server/bin/commhub.ts &
+curl -s localhost:9291/health                     # 版本对不对
+curl -s -H "Authorization: Bearer <verify-token>" localhost:9291/api/status   # 真实数据读得出来吗
+# 验完按精确 PID 停掉,删掉验证库
+
+# 5. 原子替换:只改 RUNTIME_DIR 一行 + 追加变更历史
+# 6. 🔴 pm2 restart commhub-hub    —— 【不要】带 --update-env
+```
+
+🔴 **`--update-env` 会丢掉 pm2 saved-env 里的 `ANET_HUB_SECRET_VAULT_KEY` 等**,
+之后所有 vault 操作会抛 `vault_master_key_missing`。验证方式:重启后 grep 日志里
+该关键字的出现次数必须是 **0**。
+
+## 验证:这五条都要过
+
+```bash
+# ① 真跑的是哪个安装(权威,不看 pm2 状态)
+tr '\0' ' ' < /proc/$(ss -ltnp | grep :9200 | grep -oP 'pid=\K[0-9]+')/cmdline
+
+# ② 版本 + 数据量
+curl -s localhost:9200/health          # version 与 sessions_count
+
+# ③ 监听进程是 pm2 后代,不是孤儿(追祖先链,不是看一层 ppid)
+# ④ vault 报错 0 行、unstable restarts 0
+# ⑤ 🔴 舰团真的回来了:近 5 分钟心跳数 vs 升级前,以及节点侧 task.ack 是否继续产生
+```
+
+**第 ⑤ 条最重要** —— 前四条只证明「进程是新的」,只有它证明「舰团没被搞崩」。
+
+## 回滚
+
+把 `RUNTIME_DIR` 指回上一个目录,`pm2 restart`。**旧目录一律不删。**
+
+## 混版风险(必读)
+
+`docs/release/versioning-and-compatibility.md` 的 **C2 契约**:
+Hub 协议(注册 / SSE 事件 key / task envelope / `protocolVersion`)是
+agent-node ↔ commhub-server 的耦合面,**改协议要 bump `protocolVersion` + hub 加向后兼容**。
+
+所以升 Hub 时节点通常还是旧版 —— **这是预期状态,不是事故**,但必须验:
+升级后节点侧 `task.ack` 事件要继续产生,且不出现「任务卡在 running/delivered 超过 5 分钟」。

--- a/docs/tests/report-hub-upgrade-preview29.txt
+++ b/docs/tests/report-hub-upgrade-preview29.txt
@@ -1,0 +1,71 @@
+生产 Hub 升级演练报告 — 0.9.0-preview.27 → 0.9.0-preview.29
+=============================================================
+日期      2026-08-13 00:58 – 01:10(UTC 16:58 – 17:10)
+对象      pm2 app `commhub-hub`,全网唯一的生产 Hub
+载荷      #698(peer reply 终结原任务,服务端半边:删掉 `liveSse < 1` 这个 capability 条件)
+          #697 / #699 的服务端部分
+
+这是 deploy/ 下第一份【真做过】的演练报告。其余几份(dashboard / tunnel / docs-site)
+均如实标注为「未演练」。
+
+回滚坐标(升级前记录)
+---------------------
+pm2 app        commhub-hub  (pid 3676384, uptime 35h, restarts 12)
+script         ~/.local/bin/hub-daemon.sh
+RUNTIME_DIR    $HOME/.commhub/runtime-v33-upload-bridge-17b8223f
+version        0.9.0-preview.27
+sessions       213
+
+备份
+----
+脚本   ~/.local/bin/hub-daemon.sh.bak-preview27-20260813-005811
+DB     ~/.commhub/commhub.db.bak-prehubupgrade-20260813-005811  (VACUUM INTO,非 cp)
+       PRAGMA integrity_check = ok
+       sessions = 213   tasks = 24081   大小 210M
+
+旁路验证(生产未受影响)
+------------------------
+端口   127.0.0.1:9291        库  /tmp/hubverify3.db(备份的副本,非生产库)
+起来   ~6s
+health {"ok":true,"version":"0.9.0-preview.29",...,"sessions_count":213}
+数据   GET /api/status 正确返回真实 session 列表
+其他   retention sweep 正常执行(telemetry=948)
+验完   按精确 PID 停止,验证库已删除
+
+切换
+----
+只改 RUNTIME_DIR 一行 → runtime-v34-preview29
+并按脚本自身惯例追加变更历史 + 回滚目标
+bash -n 通过
+pm2 restart commhub-hub          【不带 --update-env】
+
+结果
+----
+停机时长        ~6 秒
+新 pid          274158
+cmdline         bun ~/.commhub/runtime-v34-preview29/.../bin/commhub.ts   ← 权威核验
+health          version 0.9.0-preview.29, sessions_count 213, sse_connections 103
+祖先链          274158 ← 58349 (PM2) ← 1 (systemd)   非孤儿
+vault 报错      0 行            ← 证明 saved-env 未丢
+unstable        0
+
+舰团健康(升级前 → 后)
+-----------------------
+近 5 分钟心跳   108 → 106      (近 2 分钟同样 106,说明持续在跳而非残留)
+SSE 连接        —   → 103      (舰团已重连)
+
+混版验证(旧节点 × 新 Hub)—— 这是 #698 独审反复攻的场景
+--------------------------------------------------------
+升级后 9 分钟窗口:
+  任务终态      acked 6 / replied 1 / failed 1
+  卡在 running 或 delivered 超过 5 分钟 = 0     ← #698 的症状,未出现
+  节点侧 task.ack 事件 = 7,涉及 3 个不同节点   ← 旧节点持续正常工作
+注:节点仍为 agent-node 2.4.13(latest 稳定线),Hub 已到 preview 线。
+    按 C2 契约这是预期的混版状态,不是事故。
+
+未覆盖
+------
+- 未做真实回滚演练(回滚路径是推出来的,没执行过)
+- 未升级任何节点 —— 那是稳定线→预览线的通道迁移,属于单独的发布决策
+- #698 的 agent-node 半边(legacy 回退改成 terminal send_reply)尚未上线,
+  因此「任务卡在 running」应减轻但不会完全消失


### PR DESCRIPTION
`deploy/` 下现有的三份 runbook(dashboard / tunnel / docs-site)都如实标着「**未演练**」,因为没有一份在空机上重建过。

**这一份不一样:今晚真做过。** 生产 Hub 从 `0.9.0-preview.27` 升到 `0.9.0-preview.29`,所以报告记的是**实际执行和测量到的**,不是「应该能行」。

## 新增两个文件

- `deploy/hub/README.md` —— 换版本 runbook
- `docs/tests/report-hub-upgrade-preview29.txt` —— 演练报告

## runbook 里几条容易踩错的

- **只有一行选版本**(`RUNTIME_DIR`),它指向固化安装目录而不是 `bunx` —— 因为 `bunx` 从 `/tmp` 执行,**任何 `/tmp` 清理都会让生产在下次重启时起不来**
- 🔴 **`pm2 restart` 不能带 `--update-env`** —— 带了会丢 saved-env 里的 `ANET_HUB_SECRET_VAULT_KEY`,之后所有 vault 操作抛 `vault_master_key_missing`。检查方式:重启后日志里该关键字出现 **0 次**
- 🔴 **旁路验证必须用 DB 的副本**,不能碰生产库
- **验证有五条,只有第五条算数** —— 前四条(cmdline / health / 祖先链 / restarts)只证明「进程是新的」,**只有「舰团心跳 + 节点侧 `task.ack` 继续产生」证明舰团没被搞崩**

## 实测数据

```
停机           ~6 秒
cmdline        指向 runtime-v34-preview29        ← 权威核验,不看 pm2 状态
health         0.9.0-preview.29, 213 sessions, 103 SSE
祖先链         274158 ← 58349(PM2)← 1           非孤儿
vault 报错     0 行                              saved-env 保住了
心跳           升级前 108 → 后 106(近 2 分钟同样 106,持续在跳不是残留)
```

## 混版结果(#698 独审反复攻的那个场景,这次是在生产上看到的)

升 Hub 必然留下节点在旧 runtime。升级后 9 分钟:

```
任务终态                                acked 6 / replied 1 / failed 1
卡在 running 或 delivered 超 5 分钟      0        ← #698 的症状,未出现
节点侧 task.ack 事件                     7,涉及 3 个不同节点
```

节点仍是 `agent-node 2.4.13`(latest 稳定线),Hub 已到 preview 线 —— 按 **C2 契约**这是预期的混版状态,不是事故。

## 明确未覆盖

- **未做真实回滚演练** —— 回滚路径是推出来的,没执行过
- **未升级任何节点** —— 那是稳定线 → 预览线的**通道迁移**,属单独的发布决策
- **#698 的 agent-node 半边尚未上线**,所以「任务卡在 running」应减轻但**不会完全消失**
