### PR TITLE
fix(cli): a failed login exits non-zero, and stops advertising a password that no longer exists

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -6253,7 +6253,7 @@ Options:
 Options:
   --port <port>      Port (default: 9200 for server, 3000 for dashboard)
   --username <user>  Bootstrap admin username
-  --password <pass>  Bootstrap admin password (default: anethub)
+  --password <pass>  Bootstrap admin password (default: a random anet-xxxx, printed once)
 
 Example:
   anet hub start                     # Start server + bootstrap admin account
@@ -9866,14 +9866,19 @@ async function loginCommand() {
       console.error(`👉 首次用这个 hub? 试一下:`);
       console.error(`     anet register                              # 在 hub 上建新账号`);
       console.error("");
-      console.error(`👉 自己刚起的本地 hub? 默认 admin:`);
-      console.error(`     anet login --username admin --password anethub`);
+      console.error(`👉 自己刚起的本地 hub?`);
+      console.error(`     密码是 anet hub start 启动时【打印过一次】的随机串(形如 anet-xxxxxxxx),`);
+      console.error(`     不是固定的 anethub —— 见 #261 P0-2。翻一下 hub 的启动输出。`);
+      console.error(`     管理员凭据落在: ~/.anet/server/admin-utok.json`);
       console.error("");
       console.error(`👉 自己 hub 忘了密码? 在 hub host 上跑:`);
       console.error(`     # 必须在 hub server 那台机器上跑 (--i-am-on-the-hub-host 是 safety flag, 防误删别人 DB):`);
       console.error(`     anet hub admin reset-user --username admin --i-am-on-the-hub-host true`);
     }
-    return;
+    // A failed login used to `return`, which exits 0. Any script, CI step or
+    // deploy automation that ran `anet login` therefore continued as if it
+    // had succeeded. Fail loudly enough for a shell to notice.
+    process.exit(1);
   }
   // res.ok === true from here — login succeeded.
   try {


### PR DESCRIPTION
Fixes #716。两个缺陷在同一条路径上,都是在干净机器上跑 daemon 流程时撞到的。

## 🔴 缺陷 B(更严重):失败却 exit 0

失败分支以 `return` 结束,所以 `anet login` 打完「❌ Login failed」之后**退出码是 0**。

**任何脚本、CI 步骤、部署自动化都会当作成功继续往下走** —— 而它们恰恰是唯一读不到那行错误信息的消费者。

改成 `process.exit(1)`。

## 缺陷 A:提示指向一个已经不存在的密码

失败后的提示是:

```
👉 自己刚起的本地 hub? 默认 admin:
     anet login --username admin --password anethub     ← 就是刚刚失败的这条
```

这个字面量在 **#261 P0-2** 就失效了 —— 当时的理由写在代码注释里:固定的 `anethub` 意味着**一个公网 hub 可以被一条 curl 接管**。所以 `anet hub start` 现在生成 `anet-<22 位十六进制>`、**只打印一次**、并在 DB 里标记强制轮换。

**但这条提示没跟着改**,于是在刚起的 hub 上,它把首次用户送进死循环:照做 → 失败 → 又看到同一条提示。

改成指向密码**真正在的地方**:hub 的启动输出,以及 `~/.anet/server/admin-utok.json`。
`--password` 的 help 文案(`default: anethub`)同样是旧的,一并更正。

## 实测证据(#716 里有完整复现)

```
$ anet login --hub http://127.0.0.1:9200 --username admin --password anethub
❌ Login failed: invalid username or password
exit=0                                        ← 缺陷 B

hub 侧直接打 API 确认该账号确实不存在:
POST /api/auth/login → {"ok":false,"error":"invalid username or password"}
```

## 🔴 未在本地验证

这个 worktree 没有 `node_modules`,`tsc` 与 `bun build` 都跑不起来 —— bun 报的是
`Could not resolve: "@inquirer/prompts"`,**是环境不是改动**。

我**不宣称本地检查通过**,验证交给 CI。(顺带:我第一次写检查时用了
`timeout ... | tail -4 && echo "✅ 通过"`,tsc 二进制不存在但管道成功,`&&` 照样走到了 echo ——
一个 fail-open 的自检。已改成显式取 `PIPESTATUS[0]` 并按退出码判定。)
