### PR TITLE
fix(cli): route `anet daemon --help` to the daemon help instead of the global one

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -13103,6 +13103,22 @@ if (args.slice(1).some((a) => a === "--help" || a === "-h")) {
     case "grok":
       console.log("Usage: anet grok attach <node>");
       break;
+    case "daemon":
+      // #717 — daemonCommand() already prints its own subcommand help for
+      // bare `anet daemon`, but this intercept ran first and bounced to the
+      // global printHelp(), so `anet daemon --help` showed the top-level
+      // command list. A user following the near-universal `<cmd> --help`
+      // convention concluded `anet daemon` had no subcommands and never
+      // found init/start/up/list. Drop the help flag and let daemonCommand
+      // take the bare-invocation path, which is the help it already has.
+      {
+        for (const flag of ["--help", "-h"]) {
+          const i = args.indexOf(flag);
+          if (i >= 0) args.splice(i, 1);
+        }
+      }
+      await daemonCommand();
+      process.exit(0);
     case "node":
       // #144 — if it's `anet node loop --help` specifically, delegate
       // to nodeLoopCommand so the user sees the loop-specific help


### PR DESCRIPTION
Fixes #717。

## 根因不在 daemon,在上游的通用 help 拦截

`daemonCommand()` **本来就会**为不带参数的 `anet daemon` 打印一份像样的子命令列表。

问题是用户实际会敲的是 `anet daemon --help`,而它先撞上 **#215 的通用 `--help` 拦截** —— 那个 switch 里**没有 `daemon` 这一支**,于是落到 `printHelp()`,打出一屏顶级命令。

从那一屏里能得出的合理结论是「`anet daemon` 没有子命令」,所以 `init` / `start` / `up` / `list` **实际上无法被发现**。

## 这和 #240 是同一个形状

`anet hub --help` 曾经因为完全相同的原因**藏掉了 hub/stop/status**,读起来像那些路由被删了。#240 的修法就是给拦截加 per-subcommand 分支。

## 🔴 不能靠削弱拦截来修

#215 存在的理由写在它自己的注释里:没有它的时候,`anet token create --help` 会**真签一个 token**,`anet run --help` 会**真起一个 SSE 监听**,`anet hub start --help` 会**真把 hub 起起来**。

所以这里是**加一个 case**,不是放松拦截 —— 那条「看 help 不产生副作用」的性质必须保住。

改动:剥掉 help flag 后委派给 `daemonCommand()` 走不带参数那条路(它已有的帮助),`exit 0`,不进业务逻辑。

## 🔴 未在本地验证

这个 worktree 没有 `node_modules`,`bun build` 停在 `Could not resolve: "@inquirer/prompts"` —— **是环境不是改动**。

不宣称本地检查通过,交给 CI。
