### PR TITLE
test(qa): align replies with original task senders

### DIFF
--- a/tests/qa-dash-08-cross-account-views/run.sh
+++ b/tests/qa-dash-08-cross-account-views/run.sh
@@ -90,7 +90,7 @@ ARG=$(jq -nc --arg net "$ALICE_NET" \
 TASK_ID=$(mcp_call "$ALICE_NTOK" "send_task" "$ARG" | jq -r '.message_id')
 [[ -n "$TASK_ID" && "$TASK_ID" != "null" ]] || { echo "FAIL: no task id"; exit 1; }
 ARG=$(jq -nc --arg t "$TASK_ID" \
-  '{alias:"alice",text:"alice-private-reply-text",in_reply_to:$t,status:"replied",from_session:"alice-secret-agent"}')
+  '{alias:"alice-secret-agent",text:"alice-private-reply-text",in_reply_to:$t,status:"replied",from_session:"alice-secret-agent"}')
 mcp_call "$ALICE_NTOK" "send_reply" "$ARG" | jq -e '.ok == true' >/dev/null \
   || { echo "FAIL: alice send_reply"; exit 1; }
 

--- a/tests/qa-hub-09-task-state-machine/run.sh
+++ b/tests/qa-hub-09-task-state-machine/run.sh
@@ -58,7 +58,7 @@ send_task() {
   local utok="$1" net="$2" alias="$3" text="$4"
   curl -fsS -X POST "$HUB_BASE/api/task" \
     -H "Authorization: Bearer $utok" -H 'Content-Type: application/json' \
-    -d "{\"alias\":\"$alias\",\"task\":\"$text\",\"priority\":\"normal\",\"network_id\":\"$net\"}" \
+    -d "{\"alias\":\"$alias\",\"task\":\"$text\",\"priority\":\"normal\",\"network_id\":\"$net\",\"from\":\"admin\"}" \
     | jq -r '.message_id'
 }
 

--- a/tests/qa-node-02-success-reply/run.sh
+++ b/tests/qa-node-02-success-reply/run.sh
@@ -86,7 +86,7 @@ echo "$RS" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status not o
 echo "[5] admin sends task to mock-echo"
 TASK_RESP=$(curl -fsS -X POST "$HUB_BASE/api/task" \
   -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' \
-  -d "{\"alias\":\"mock-echo\",\"task\":\"ping-r6\",\"priority\":\"normal\",\"network_id\":\"$NET_ID\"}")
+  -d "{\"alias\":\"mock-echo\",\"task\":\"ping-r6\",\"priority\":\"normal\",\"network_id\":\"$NET_ID\",\"from\":\"admin\"}")
 TASK_ID=$(echo "$TASK_RESP" | jq -r '.message_id')
 [[ -n "$TASK_ID" && "$TASK_ID" != "null" ]] || { echo "FAIL: no task id, resp=$TASK_RESP"; exit 1; }
 echo "  task_id=$TASK_ID"


### PR DESCRIPTION
## Summary

- align three QA fixtures with the peer-reply ownership contract introduced by #698
- preserve the original task sender explicitly for REST-created tasks
- target node-origin self-tasks back to their actual sender alias

## Root cause

The product correctly rejects a reply whose target alias differs from the original task sender (`reply_target_mismatch`). Three QA fixtures still encoded the pre-#698 shape:

- `qa-hub-09` and `qa-node-02` created REST tasks without `from`, so the server recorded the sender as `api` while the fixture replied to `admin`;
- `qa-dash-08` created a task from `alice-secret-agent` but replied to `alice`.

This is a test-fixture correction only. No product, package, dist, or production files change.

## Validation

Source base: `2c172c7536f9081199bb8ea92dae8890e3714bb1`

```text
sg docker -c 'bash scripts/qa.sh --l1'
13/13 suites PASS
ALL PASS in 117s
```

The tested tree and this commit were compared byte-for-byte for all three changed files before push.

## Release relationship

This is intentionally separate from release PR #719. Merge and release decisions remain independent; this PR does not publish packages or alter production.
