### PR TITLE
ops(qa): record which registry versions L1 resolved, so a red is attributable

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -116,6 +116,24 @@ fi
 
 if [[ $RUN_L1 -eq 1 ]]; then
   sec "L1 — Docker contract tests (用户视角，并行)"
+
+  # L1 的多数用例在容器里 `npm install -g @sleep2agi/<pkg>@preview`,也就是说
+  # 它们测的是【此刻 registry 上 preview 指向什么】,不是【这个 commit 是什么】。
+  #
+  # 后果实测过(#726):main 在 bec372c8 上 L1 全绿;之后没有任何 commit 变动,
+  # 只因为有人发布了新的 preview,同一份代码的 L1 就红了。反方向同样成立 ——
+  # 一个真把东西改坏的 PR,只要 @preview 还指着旧的好版本,它照样能绿。
+  #
+  # 把三个包此刻解析到的版本记下来,这样任何一次红都能立刻区分
+  # 「代码改坏了」还是「registry 动了」。这里【只记录不改行为】——
+  # 是否改成钉死版本涉及 49 个测试文件的语义,留给单独决定。
+  {
+    echo "L1 registry snapshot @ $(date -u +%FT%TZ)"
+    for pkg in agent-network agent-node commhub-server; do
+      v=$(npm view "@sleep2agi/$pkg" dist-tags.preview 2>/dev/null || echo "?")
+      echo "  @sleep2agi/$pkg@preview -> $v"
+    done
+  } | tee /tmp/qa-l1-registry-snapshot.txt
   pids=()
   declare -A pid_to_test
   for t in "${L1_TESTS[@]}"; do


### PR DESCRIPTION
针对 #726-B。**只加记录,不改任何测试行为。**

## 问题

L1 的多数用例在容器里跑 `npm install -g @sleep2agi/<pkg>@preview` —— 也就是说**它们测的是「此刻 registry 上 preview 指向什么」,不是「这个 commit 是什么」**。

这不是推测,是实测到的(#726):

```
bec372c8   L1 全绿
（之后只合了两个纯文档 PR,且被 path filter 跳过,QA 根本没跑）
（期间有人发布了新的 preview）
之后任何 PR   L1 红          ← 同一份代码
```

🔴 **反方向更糟**:一个**真把东西改坏**的 PR,只要 `@preview` 还指着旧的好版本,**它照样能绿**。

## 改动

在 L1 阶段开头打印三个包此刻解析到的版本,并留一份到 `/tmp/qa-l1-registry-snapshot.txt`:

```
L1 registry snapshot @ 2026-08-12T22:30:00Z
  @sleep2agi/agent-network@preview -> 2.3.0-preview.39
  @sleep2agi/agent-node@preview -> 2.5.0-preview.31
  @sleep2agi/commhub-server@preview -> 0.9.0-preview.29
```

**这不会让测试变得 hermetic**,它让失败**可归因** —— 而缺的正是这一点:一行就能区分「代码改坏了」和「registry 动了」,不用去 bisect 一堆根本没碰过该行为的 commit。我今晚就在这上面绕了几个小时。

## 刻意没做的

**没有把版本钉死。** 有 **49 个测试文件**引用 `@preview`,改变它们安装什么就是改变它们的语义 —— 那是发布契约属主的决定,不该作为一个日志改动的副作用。

## 验证

`bash -n` 通过;那段取版本的逻辑单独试跑过,输出如上。
