### PR TITLE
fix(ci): retry the bun install so a transient fetch stops reading as a test failure

### DIFF
--- a/tests/qa-cli-01-hub-start/Dockerfile
+++ b/tests/qa-cli-01-hub-start/Dockerfile
@@ -1,7 +1,21 @@
 FROM node:20-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-certificates jq unzip procps && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://bun.sh/install | bash
+# The bun installer downloads the release from github.com; a single hiccup
+# there fails the whole image build, and the resulting CI red reads as if the
+# code under test broke (#728 — this exact line took three L1 images down and
+# blocked merges repeatedly). Retry with backoff so a transient fetch does not
+# masquerade as a test failure.
+#
+# Note this only removes the transient half. The install is still unpinned and
+# unverified, so what lands in the image depends on what bun.sh serves that
+# day; pinning across all 43 test images is tracked separately in #728.
+RUN for i in 1 2 3; do \
+      curl -fsSL https://bun.sh/install | bash && break; \
+      echo "bun install attempt $i failed; retrying in $((i*5))s"; \
+      sleep $((i*5)); \
+    done; \
+    test -x "$HOME/.bun/bin/bun" || { echo "bun install failed after 3 attempts"; exit 1; }
 ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app


### PR DESCRIPTION
针对 #728 的**最小、可验证的一半**。

## 问题

`curl -fsSL https://bun.sh/install | bash` 从 github.com 拉发布包,**一次抖动就让整个镜像构建失败**。CI 报出来的是:

```
✗ L1 qa-cli-01-hub-start — build failed
```

**这读起来像是被测代码坏了。** 今晚它两次挡住了 [#727](https://github.com/sleep2agi/agent-network/pull/727) —— 而那个 PR 的唯一改动是 `scripts/qa.sh` 里的一行日志,不可能影响任何被测行为。

更贵的是:我因此去追一个**并不存在**的产品根因,连写三个错误结论、挂了 P1、一度建议暂缓发版(完整弯路记在 [#726](https://github.com/sleep2agi/agent-network/issues/726))。

## 改动

三次重试 + 递增退避,然后**显式检查二进制是否真的在**:

```dockerfile
RUN for i in 1 2 3; do \
      curl -fsSL https://bun.sh/install | bash && break; \
      echo "bun install attempt $i failed; retrying in $((i*5))s"; \
      sleep $((i*5)); \
    done; \
    test -x "$HOME/.bun/bin/bun" || { echo "bun install failed after 3 attempts"; exit 1; }
```

🔴 **最后那行 `test -x` 是关键**:没有它,重试三次全失败后 `RUN` 仍然退出 0,镜像照样构建成功,直到运行时才炸在「command not found」上 —— 那才是真正难查的形态。**加重试的同时必须加终态检查,否则是把一个响亮的失败换成一个安静的失败。**

## 刻意只改一个文件

**只改这个一直在挡路的 Dockerfile。** 安装仍然**不钉版本、不校验**,所以镜像里落的是哪个 bun 仍取决于 bun.sh 当天给什么 —— **在 43 个测试镜像上钉版本会改变这些镜像的内容**,那是属主的决定,不该作为一个重试补丁的副作用。#728 继续跟踪那一半。

## 验证

本地真构建并运行:

```
docker build -f tests/qa-cli-01-hub-start/Dockerfile .   → 成功
docker run --rm --entrypoint bash <image> -c 'bun --version'
  1.3.14
```
