### PR TITLE
fix(ci): make Bun installer retries fail closed

### DIFF
--- a/tests/qa-cli-01-hub-start/Dockerfile
+++ b/tests/qa-cli-01-hub-start/Dockerfile
@@ -10,12 +10,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-ce
 # Note this only removes the transient half. The install is still unpinned and
 # unverified, so what lands in the image depends on what bun.sh serves that
 # day; pinning across all 43 test images is tracked separately in #728.
-RUN for i in 1 2 3; do \
-      curl -fsSL https://bun.sh/install | bash && break; \
+RUN installed=0; \
+    for i in 1 2 3; do \
+      rm -f /tmp/bun-install.sh; \
+      if curl -fsSL https://bun.sh/install -o /tmp/bun-install.sh \
+          && bash /tmp/bun-install.sh; then \
+        installed=1; \
+        break; \
+      fi; \
       echo "bun install attempt $i failed; retrying in $((i*5))s"; \
       sleep $((i*5)); \
     done; \
-    test -x "$HOME/.bun/bin/bun" || { echo "bun install failed after 3 attempts"; exit 1; }
+    rm -f /tmp/bun-install.sh; \
+    test "$installed" = 1 && test -x "$HOME/.bun/bin/bun" \
+      || { echo "bun install failed after 3 attempts"; exit 1; }
 ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app


### PR DESCRIPTION
Follow-up to merged #729 and its source-side review comment.

## Root cause

The merged retry still used:

```sh
curl -fsSL https://bun.sh/install | bash && break
```

Docker executes this under `/bin/sh` without `pipefail`, so the condition sees only `bash`'s status. A failed producer can be masked by a successful empty consumer. The final `test -x` also cannot distinguish this run from a binary left behind by a prior failed installer attempt.

## Fix

- download the installer into a fresh temporary file;
- execute it only after curl succeeds;
- set `installed=1` only when both download and installer return success;
- require both that success flag and the executable before the layer can pass;
- remove the temporary installer between attempts and after the loop.

This deliberately does not pin Bun; #728 owns that broader decision.

## Validation

Deterministic shell controls:

```text
OLD_PIPELINE_FETCH_FAILURE_WITH_PREEXISTING_BINARY rc=0 (false success reproduced)
NEW_PIPELINE_FETCH_FAILURE_WITH_PREEXISTING_BINARY rc=1
NEW_PIPELINE_INSTALLER_FAILURE_AFTER_WRITING_BINARY rc=1
```

Real Docker behavior:

```text
docker build -f tests/qa-cli-01-hub-start/Dockerfile .  PASS
docker run <image>                                      PASS qa-cli-01 hub-start
```

Scope is exactly one test Dockerfile. No product, package, dist, production, TLS trust, or registry tag changes.
