### PR TITLE
docs(api): REST 源码链接指向 server.ts,并修正登录 429 的真实响应体

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -11,14 +11,14 @@ CommHub Server 提供 REST API 供 Dashboard、CLI 和第三方系统调用。
 | 内容类型 | `application/json` |
 | 编码 | UTF-8 |
 | Endpoint 数 | 30+（**13 类**：[公开 1](#公开端点) · [认证 5](#认证端点) · [网络 5](#网络端点) · [数据查询 10](#数据查询端点) · [任务派发 2](#任务派发端点) · [MCP 1](#mcp-端点) · [SSE 1](#sse-端点) · [Token 管理 4](#token-管理端点) · [网络成员 6](#网络成员端点) · [文件 2](#文件端点) · [节点改名 3](#节点改名端点-rfc-010) · [Tmux 调试 3 (opt-in)](#tmux-调试端点-opt-in) · [Legacy 2](#legacy-端点-v0-6-时代-oss-后不再演进)） |
-| 全 endpoint source | [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) |
+| 全 endpoint source | [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) |
 
 ## 公开端点
 
 ### GET /health
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 健康检查，不需要认证。
 
@@ -56,7 +56,7 @@ curl http://localhost:9200/health
 ### POST /api/auth/register
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 注册新用户。第一个注册的用户自动成为管理员。
 
@@ -112,7 +112,7 @@ curl -X POST http://localhost:9200/api/auth/register \
 | 400 | `password must be at least 8 characters` | 第二个起注册用户密码 < 8 |
 | 400 | `password must be at least 4 characters` | 首位用户（bootstrap admin）密码 < 4 |
 | 400 | `password is too common` | 命中弱密码字典（[`password-dict.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/password-dict.ts)，首位用户豁免） |
-| 429 | `too many requests, try again later` | 超过 30/分 IP rate limit（[`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)；localhost 豁免，详见 [安全 — IP rate limit](/concepts/security#ip-级别限制)）|
+| 429 | `too many requests, try again later` | 超过 30/分 IP rate limit（[`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)；localhost 豁免，详见 [安全 — IP rate limit](/concepts/security#ip-级别限制)）|
 
 **速率限制**：30 次/分钟 per IP。
 
@@ -121,7 +121,7 @@ curl -X POST http://localhost:9200/api/auth/register \
 ### POST /api/auth/login
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 用户登录。
 
@@ -159,16 +159,27 @@ curl -X POST http://localhost:9200/api/auth/login \
 | 状态 | `error` 值 | 触发条件 |
 |------|------------|---------|
 | 401 | `invalid username or password` | 用户名不存在 **或** 密码哈希不匹配（[`auth.ts:99-100`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L99) 故意把两种错误合并成同一文案，避免 username enumeration）；server 同时写 `login_failed` audit |
-| 429 | `too many attempts, try again later` | 超过 10/分 IP rate limit（[`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)；触发时写 `login_rate_limited` audit + clientIP）|
+| 429 | `rate_limited` | 超过 10/分 IP rate limit（[`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)；触发时写 `login_rate_limited` audit + clientIP）|
 
 **速率限制**：10 次/分钟 per IP。
+
+429 的**完整响应体**（`error` 字段是 `rate_limited`，不是文案本身）：
+
+```json
+{ "ok": false, "error": "rate_limited",
+  "message": "Too many login attempts. Try again later.",
+  "retry_after_ms": 42000 }
+```
+
+同时返回 `Retry-After` 响应头（秒，由 `retry_after_ms` 向上取整）。
+按 `error` 字段判定，不要匹配 `message` 文案。
 
 ---
 
 ### GET /api/auth/me
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取当前用户信息。
 
@@ -204,7 +215,7 @@ curl http://localhost:9200/api/auth/me \
 ### PUT /api/auth/me
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 修改个人信息。
 
@@ -222,7 +233,7 @@ curl -X PUT http://localhost:9200/api/auth/me \
 | `display_name` | string | | 显示名 |
 | `email` | string | | 邮箱 |
 
-只更新提供的字段（[server/src/index.ts](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 用 `if (body.X)` 条件 SQL）；`username` / `role` / `password` **不**通过此 endpoint 修改。
+只更新提供的字段（[server/src/server.ts](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) 用 `if (body.X)` 条件 SQL）；`username` / `role` / `password` **不**通过此 endpoint 修改。
 
 **响应**（成功）：
 
@@ -239,7 +250,7 @@ curl -X PUT http://localhost:9200/api/auth/me \
 }
 ```
 
-**常见 4xx**（verify [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）：
+**常见 4xx**（verify [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）：
 
 | 状态 | `error` 值 | 触发条件 |
 |------|------------|---------|
@@ -247,7 +258,7 @@ curl -X PUT http://localhost:9200/api/auth/me \
 | 401 | `token required` / `invalid token` | 缺/无效 utok_ |
 
 ::: info 字段缺失不报错
-如果只传 `display_name` 而省略 `email`（或两者都不传），server 不会报 400 —— [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 用 `if (body.X)` 条件累加 SQL，全部省略时只 re-SELECT user 返回。**无字段长度校验**（v0.9.x / v0.10.x 都未动，schema-level 校验排到 v0.11+ / 未排期）。
+如果只传 `display_name` 而省略 `email`（或两者都不传），server 不会报 400 —— [`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) 用 `if (body.X)` 条件累加 SQL，全部省略时只 re-SELECT user 返回。**无字段长度校验**（v0.9.x / v0.10.x 都未动，schema-level 校验排到 v0.11+ / 未排期）。
 :::
 
 ---
@@ -255,7 +266,7 @@ curl -X PUT http://localhost:9200/api/auth/me \
 ### POST /api/auth/password
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 修改密码。
 
@@ -280,10 +291,10 @@ curl -X POST http://localhost:9200/api/auth/password \
 }
 ```
 
-`revoked` 字段是**其他设备**上被撤销的 utok\_/atok\_ 数量（不含本次调用方自己的 token，那个是 index.ts L490 单独撤销的）。
+`revoked` 字段是**其他设备**上被撤销的 utok\_/atok\_ 数量（不含本次调用方自己的 token，那个由 `server.ts` 改密处理函数里的 `revokeToken(resolved.user.user_id, resolved.tokenId)` 单独撤销）。
 
-**关键副作用** (verify [`auth.ts:267-282 changePassword + revokeOtherUserTokens`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L267) + [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)):
-1. **当前调用方的 `utok_`** (`resolved.tokenId`) 立即撤销（[`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) `revokeToken(...)` 显式删）
+**关键副作用** (verify [`auth.ts:267-282 changePassword + revokeOtherUserTokens`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L267) + [`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)):
+1. **当前调用方的 `utok_`** (`resolved.tokenId`) 立即撤销（[`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) `revokeToken(...)` 显式删）
 2. **其他设备的所有 `utok_` / `atok_`** 同步撤销（[`auth.ts:269-270`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L269) `DELETE ... WHERE user_id=? AND network_id IS NULL AND token_id != ?currentTokenId` 一锅端）—— 计数返回到 `revoked` 字段
 3. **`ntok_` 不受影响**（`revokeOtherUserTokens` 只删 `network_id IS NULL` 的 token，agent node 用 `ntok_` 跑着的不会被改密打断；跟 [account-system 改密码副作用](/guide/account-system#修改密码) ZH 描述一致）
 4. **新 `utok_`** (`issued.token`) 颁发给调用方作为响应返回 —— 调用方应立即用新 token 覆盖本地存储
@@ -312,7 +323,7 @@ curl -X POST http://localhost:9200/api/auth/password \
 ### GET /api/networks
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取用户所属的所有网络。
 
@@ -350,7 +361,7 @@ curl http://localhost:9200/api/networks \
 ### POST /api/networks
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 创建新网络。
 
@@ -386,7 +397,7 @@ curl -X POST http://localhost:9200/api/networks \
 
 ### GET /api/networks/:id
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取网络详情（含成员身份校验：必须是该 network 成员或系统 admin，否则 403）。
 
@@ -422,13 +433,13 @@ curl http://localhost:9200/api/networks/net_abc123 \
 }
 ```
 
-`network` 对象 9 字段 = `SELECT * FROM networks WHERE network_id = ?1` ([`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) 完整 schema (含 v3 migration `visibility` + `max_members`)。`settings` 字段保留作未来 per-network JSON 配置，目前为 `null`。`stats.tasks` 按 status 聚合（同 [GET /api/stats](#get-api-stats) 内嵌结构）。
+`network` 对象 9 字段 = `SELECT * FROM networks WHERE network_id = ?1` ([`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)) 完整 schema (含 v3 migration `visibility` + `max_members`)。`settings` 字段保留作未来 per-network JSON 配置，目前为 `null`。`stats.tasks` 按 status 聚合（同 [GET /api/stats](#get-api-stats) 内嵌结构）。
 
 ---
 
 ### PUT /api/networks/:id
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 重命名网络（仅 owner）。
 
@@ -466,7 +477,7 @@ curl -X PUT http://localhost:9200/api/networks/net_abc123 \
 
 ### DELETE /api/networks/:id
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 删除网络（仅 owner，必须无活跃 session）。
 
@@ -498,7 +509,7 @@ curl -X DELETE http://localhost:9200/api/networks/net_abc123 \
 ### GET /api/status
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取所有 session 状态。
 
@@ -540,14 +551,14 @@ curl "http://localhost:9200/api/status?network_id=net_xxx" \
 }
 ```
 
-`summary` 字段是按 status 聚合的计数（[`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）：`working` 类把 `working / blocked / error / waiting_input / running / busy` 都归一进去；`offline` 类是 server 端 `updated_at` 落后 10 分钟的 session（每次 GET 实时计算并写回 DB）；其他算 `idle`。
+`summary` 字段是按 status 聚合的计数（[`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）：`working` 类把 `working / blocked / error / waiting_input / running / busy` 都归一进去；`offline` 类是 server 端 `updated_at` 落后 10 分钟的 session（每次 GET 实时计算并写回 DB）；其他算 `idle`。
 
 ---
 
 ### GET /api/tasks
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取任务列表。
 
@@ -609,7 +620,7 @@ curl "http://localhost:9200/api/tasks?status=running&limit=10" \
 ### GET /api/task/{task_id}
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 按 `task_id` 取**单个任务**的完整记录。路径同时接受 `/api/task/<id>` 与 `/api/tasks/<id>`（末尾 `s` 可选）。
 
@@ -644,7 +655,7 @@ curl http://localhost:9200/api/task/<task_id> \
 ### GET /api/nodes
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取节点列表（持久化节点信息，区别于 session 的临时状态）。
 
@@ -694,7 +705,7 @@ curl http://localhost:9200/api/nodes \
 
 ### DELETE /api/nodes/:ref
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 删除节点（hub server 端）—— 从 `nodes` 表删持久身份 + 从 `sessions` 表删运行时心跳记录（同一个 transaction），并往 alias channel + network channel 推 `node_deleted` SSE 事件让 dashboard 实时刷新。配套 PR #86「node delete cascade and node_deleted SSE」。
 
@@ -708,7 +719,7 @@ curl -X DELETE "http://localhost:9200/api/nodes/%E4%BB%A3%E7%A0%811%E5%8F%B7" \
   -H "Authorization: Bearer ntok_xxx"
 ```
 
-**路径参数**：`:ref` 在 server 端 [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 用 OR 拼 `node_id = ? OR node_name = ? OR alias = ?` 找节点（网络作用域过滤后取 `updated_at DESC` 第一条）。
+**路径参数**：`:ref` 在 server 端 [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) 用 OR 拼 `node_id = ? OR node_name = ? OR alias = ?` 找节点（网络作用域过滤后取 `updated_at DESC` 第一条）。
 
 **响应**（成功，200）：
 
@@ -723,7 +734,7 @@ curl -X DELETE "http://localhost:9200/api/nodes/%E4%BB%A3%E7%A0%811%E5%8F%B7" \
 }
 ```
 
-**SSE 副作用**：删完往**两个 SSE channel** 推 `node_deleted` event（[`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）：
+**SSE 副作用**：删完往**两个 SSE channel** 推 `node_deleted` event（[`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）：
 - `alias` 自身的 SSE channel（如果还有订阅者）
 - 该 `network_id` 的 user 级 SSE channel（每个网络成员都能立刻看到）
 
@@ -813,7 +824,7 @@ curl -X PUT "http://localhost:9200/api/nodes/n_abc12345/avatar" \
 
 ### GET /api/servers
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 按**物理服务器**（`hostname` + `ip`）聚合 agent 列表 + host 实时遥测，给 dashboard 「服务器侧栏」用。Refs [issue #119](https://github.com/sleep2agi/agent-network/issues/119)。
 
@@ -862,7 +873,7 @@ host telemetry 由 agent-node 在每次 `report_status` 时带上（[issue #119]
 
 ### GET /api/server/:host/health
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) · v0.10.0 / `commhub-server@0.8.2`
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · v0.10.0 / `commhub-server@0.8.2`
 
 取**单台物理服务器**的当前健康快照 + 24h 分桶历史 telemetry。Refs [issue #99](https://github.com/sleep2agi/agent-network/issues/99)（守护节点 Phase 1 scaffold）。
 
@@ -922,13 +933,13 @@ curl "http://localhost:9200/api/server/$(python3 -c 'import urllib.parse; print(
 |------|------|
 | `host` | 请求路径里传入的 host 值 |
 | `agent_count` | 该 host 上活跃 session 数（窗口取最新一行的 `COUNT(*) OVER ()`）|
-| `alert_level` | `ok` / `warn` / `critical`（取 `serverAlertLevel(latest)` 计算；v0.10.2+ 加 `disk_avail_gb < 1 → critical` / `< 5 → warn` 触发，verify [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）|
+| `alert_level` | `ok` / `warn` / `critical`（取 `serverAlertLevel(latest)` 计算；v0.10.2+ 加 `disk_avail_gb < 1 → critical` / `< 5 → warn` 触发，verify [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）|
 | `alerts` | 当前命中告警列表，`alert_level != ok` 时非空 |
 | `latest` | 该 host 最近一次心跳的瞬时 telemetry（CPU / mem / disk + `last_seen`）|
 | `latest.disk_total_gb` / `disk_used_gb` / `disk_avail_gb` | **v0.10.2 起**（agent-node `2.4.1+`，[`host-telemetry.ts readDiskStats()`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/host-telemetry.ts)）—— 通过 `execFileSync('df', ['-k', '/'])` 采样，POSIX `-k` Linux + macOS 同 parse 路径；Windows / 解析失败 graceful `null`（dashboard 渲染 `—` 不误导成 0）。老 agent (`< 2.4.1`) 不带字段时三字段都 `null` |
 | `history.5m` | 最近 5min，**1 min bucket**（取自 `agent_telemetry` 历史表）|
 | `history.1h` | 最近 1h，**5 min bucket** |
-| `history.24h` | 最近 24h，**1 hour bucket**；v0.10.2 起 bucket 内附 `disk_avail_min` / `disk_used_max` 字段（极值聚合，verify [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）|
+| `history.24h` | 最近 24h，**1 hour bucket**；v0.10.2 起 bucket 内附 `disk_avail_min` / `disk_used_max` 字段（极值聚合，verify [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）|
 
 **404**：`{ "ok": false, "error": "server not found" }` —— 该 host 没有任何（活跃或离线）session 命中。
 
@@ -938,7 +949,7 @@ curl "http://localhost:9200/api/server/$(python3 -c 'import urllib.parse; print(
 
 ### GET /api/server/:host/agents
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) · v0.10.0 / `commhub-server@0.8.2`
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · v0.10.0 / `commhub-server@0.8.2`
 
 取**单台服务器上的 agent 列表** + per-agent 进程 telemetry（rss / cpu / uptime / in-flight count）。Refs [issue #99](https://github.com/sleep2agi/agent-network/issues/99) + [issue #142](https://github.com/sleep2agi/agent-network/issues/142) per-agent process telemetry。
 
@@ -1001,7 +1012,7 @@ curl http://localhost:9200/api/server/dev-machine/agents \
 ### GET /api/messages
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取最近 inbox 消息列表。
 
@@ -1047,7 +1058,7 @@ curl "http://localhost:9200/api/messages?limit=100" \
 }
 ```
 
-字段对照 server SELECT ([`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) `id, session_name as to_alias, from_session as from_alias, type, priority, content, created_at, network_id` —— 主键字段是 `id` 不是 `message_id`，含 `priority` + `network_id` 两个之前 doc 漏掉的字段。
+字段对照 server SELECT ([`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)) `id, session_name as to_alias, from_session as from_alias, type, priority, content, created_at, network_id` —— 主键字段是 `id` 不是 `message_id`，含 `priority` + `network_id` 两个之前 doc 漏掉的字段。
 
 ::: info 当前 schema 限制
 SELECT 暂未包含 `in_reply_to` 字段；轮询匹配回复消息时按 `from_alias` + `type='reply'` + recency 启发式匹配（详见 `cli.ts` 注释）。
@@ -1058,7 +1069,7 @@ SELECT 暂未包含 `in_reply_to` 字段；轮询匹配回复消息时按 `from_
 ### GET /api/completions
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取完成记录（agent 通过 `report_completion` MCP 工具写入的总结性记录，跟 `tasks` 表 `status='replied'` 的简单 reply 不同）。
 
@@ -1104,7 +1115,7 @@ curl "http://localhost:9200/api/completions?since=2026-04-12T00:00:00Z" \
 ### GET /api/task_events
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取任务状态变更日志（task 生命周期审计）。每次 task `status` 变化 server 都会插一行，是排查「任务卡住 / 谁改了状态」的主要数据源。
 
@@ -1121,7 +1132,7 @@ curl "http://localhost:9200/api/task_events?task_id=t_a1b2c3d4" \
 | `network_id` | 按网络过滤（绑了 `ntok_` 时此参数被强制覆盖为 token 自带的 network）|
 | `limit` | 最大条数（默认 50，最大 500） |
 
-> `network_id` 不在 task_events handler 本体里读，而是所有 REST 端点统一走 [`resolveRestNetworkScope` (index.ts)](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)：`utok_` 调用可传 `network_id` 指定网络（校验 membership），`ntok_` 调用强制锁到 token 绑定的 network，system admin 可查任意网络。
+> `network_id` 不在 task_events handler 本体里读，而是所有 REST 端点统一走 [`resolveRestNetworkScope` (server.ts)](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)：`utok_` 调用可传 `network_id` 指定网络（校验 membership），`ntok_` 调用强制锁到 token 绑定的 network，system admin 可查任意网络。
 
 **响应**：
 
@@ -1159,7 +1170,7 @@ curl "http://localhost:9200/api/task_events?task_id=t_a1b2c3d4" \
 ### GET /api/stats
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取统计数据。
 
@@ -1196,9 +1207,9 @@ curl http://localhost:9200/api/stats \
 
 ### GET /api/server-logs
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
-读 hub 进程内**内存环形 buffer** 里的最近 N 行 console 日志（debug 用）。**仅 `users.role = 'admin'` 系统 admin 可调**（跟 [GET /api/users](#get-api-users) / [GET /api/audit-log](#get-api-audit-log) 同款 system-admin gate，注意**不是网络级 admin**）。Buffer 容量默认 500 行（由 `COMMHUB_LOG_RING` env 调，[`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）。
+读 hub 进程内**内存环形 buffer** 里的最近 N 行 console 日志（debug 用）。**仅 `users.role = 'admin'` 系统 admin 可调**（跟 [GET /api/users](#get-api-users) / [GET /api/audit-log](#get-api-audit-log) 同款 system-admin gate，注意**不是网络级 admin**）。Buffer 容量默认 500 行（由 `COMMHUB_LOG_RING` env 调，[`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）。
 
 ```bash
 curl "http://localhost:9200/api/server-logs?limit=100" \
@@ -1225,7 +1236,7 @@ curl "http://localhost:9200/api/server-logs?limit=100" \
 }
 ```
 
-按时间**倒序**返回（最新在最前）；每行 `line` 截断到 4000 字符（[`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）。**进程重启 buffer 清空** —— 这不是持久化日志，要持久化日志做 stdout/journald 重定向。
+按时间**倒序**返回（最新在最前）；每行 `line` 截断到 4000 字符（[`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）。**进程重启 buffer 清空** —— 这不是持久化日志，要持久化日志做 stdout/journald 重定向。
 
 **4xx**：
 
@@ -1239,9 +1250,9 @@ curl "http://localhost:9200/api/server-logs?limit=100" \
 ### GET /api/audit-log
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
-获取审计日志。**权限：所有已认证用户都可调，但非**系统 admin** 只能看到自己的 log 行**（server 端走 `users.role !== 'admin'` 自动加 `WHERE user_id = <caller>` 过滤，见 [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）。系统 admin (`users.role = 'admin'`) 看全部 + 可用 `user_id` 参数过滤任意用户。
+获取审计日志。**权限：所有已认证用户都可调，但非**系统 admin** 只能看到自己的 log 行**（server 端走 `users.role !== 'admin'` 自动加 `WHERE user_id = <caller>` 过滤，见 [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）。系统 admin (`users.role = 'admin'`) 看全部 + 可用 `user_id` 参数过滤任意用户。
 
 ::: warning 不是网络级 admin/owner
 这里的 "admin" 指 `users.role='admin'`（**系统级**，首位注册用户默认是），**不是**网络级别的 `owner / admin / member / viewer`。详见 [GET /api/users](#get-api-users) 同款区分。
@@ -1300,7 +1311,7 @@ POST `/api/networks` 不调 `logAudit`，所以 audit_log 里**不会**有 `crea
 ### GET /api/users
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取所有用户列表（仅**系统 admin** —— 即 `users.role = 'admin'`，跟网络级别的 `owner / admin / member / viewer` 角色不同）。
 
@@ -1352,7 +1363,7 @@ REST 版的 `send_task` / `broadcast`（非 MCP 路径，适合 webhook / 反代
 
 ### POST /api/task
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 REST 版 `send_task`：往指定 alias 的 inbox 投递任务 + 写 tasks 表 + SSE 推 `new_task`。
 
@@ -1368,7 +1379,7 @@ curl -X POST http://localhost:9200/api/task \
   }'
 ```
 
-**请求体**（verify [`TaskSchema`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）：
+**请求体**（verify [`TaskSchema`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）：
 
 | 字段 | 类型 | 必需 | 说明 |
 |------|------|:----:|------|
@@ -1378,7 +1389,7 @@ curl -X POST http://localhost:9200/api/task \
 | `from` | string | | 发送者标识（默认 `"api"`） |
 | `network_id` | string | | 目标 network（utok\_ 调用时；ntok\_ 调用强制绑定） |
 | `parent_task_id` | string | | 用于自动回串结果的父任务 ID；没有权威当前任务 ID 时应省略。 |
-| `ttl_seconds` | number | | 过期秒数（默认 3600；非 schema 字段，server 在 [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 直接取 `body.ttl_seconds`） |
+| `ttl_seconds` | number | | 过期秒数（默认 3600；非 schema 字段，server 在 [`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) 直接取 `body.ttl_seconds`） |
 
 **响应**（成功）：
 
@@ -1426,11 +1437,11 @@ SSE 连接数，以及权威 runtime submission/consumption 时间戳。它不�
 | 403 | `access denied to requested network` | utok\_ 调用方不是 `network_id` 成员 |
 | 403 | `permission_denied` | 角色不足（viewer 不能写）|
 
-**不**写 audit log（[`/api/task` 处理函数 index.ts](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 没有 `logAudit` 调用，跟 `POST /api/networks` 的「不写」一致）；成功后给 target alias 推送 `new_task` SSE 事件。
+**不**写 audit log（[`/api/task` 处理函数 server.ts](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) 没有 `logAudit` 调用，跟 `POST /api/networks` 的「不写」一致）；成功后给 target alias 推送 `new_task` SSE 事件。
 
 ### POST /api/broadcast
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 REST 版 `broadcast`：往一组 session 的 inbox 同步广播 + 给每个 SSE 推 `broadcast`。
 
@@ -1444,7 +1455,7 @@ curl -X POST http://localhost:9200/api/broadcast \
   }'
 ```
 
-**请求体**（verify [`BroadcastSchema`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）：
+**请求体**（verify [`BroadcastSchema`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）：
 
 | 字段 | 类型 | 必需 | 说明 |
 |------|------|:----:|------|
@@ -1452,7 +1463,7 @@ curl -X POST http://localhost:9200/api/broadcast \
 | `filter_server` | string | | 只发给指定 `server` 字段的 session |
 | `filter_status` | string | | 只发给指定 status 的 session（如 `idle` / `working`） |
 
-> 跟 MCP [`broadcast`](mcp-tools#broadcast) 同款字段；`from_session` 不是参数，server 端硬编码 `'api'`（[`index.ts` — `POST /api/broadcast` handler](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 跟 MCP 版的 `'hub'` 不同）。
+> 跟 MCP [`broadcast`](mcp-tools#broadcast) 同款字段；`from_session` 不是参数，server 端硬编码 `'api'`（[`server.ts` — `POST /api/broadcast` handler](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) 跟 MCP 版的 `'hub'` 不同）。
 
 **响应**（成功）：
 
@@ -1480,7 +1491,7 @@ curl -X POST http://localhost:9200/api/broadcast \
 
 ### POST /mcp
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 MCP Streamable HTTP 端点，Agent 通过此端点调用 MCP Tools。
 
@@ -1506,7 +1517,7 @@ curl -X POST http://localhost:9200/mcp \
 
 ### GET /events/:name
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 SSE 实时推送端点，客户端通过长连接接收事件。路径段 `:name` 是一个**通用 channel 名**（源码里叫 `:session`）：Agent 用自己的 **node alias** 订阅、Dashboard 用 **username** 订阅 user channel。SSE 层本身是 per-channel-name 的 `Map`（[`push.ts:11` `clients`](https://github.com/sleep2agi/agent-network/blob/main/server/src/push.ts#L11)），不区分 alias / username —— `pushEvent(name, ...)` 推给谁取决于谁注册了那个 name（如 `node.renamed` 同时推 alias 流和成员 username channel，见下表）。
 
@@ -1600,7 +1611,7 @@ data: {"type":"new_reply","task_id":"t_abc","message_id":"m_def","from":"代码1
 ### POST /api/auth/node-token
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 为某个节点创建网络绑定的 `ntok_`。`anet node create` 会自动调用它，写入到 `.anet/nodes/<node-name>/config.json` 的 `token` 字段。
 
@@ -1622,7 +1633,7 @@ curl -X POST http://localhost:9200/api/auth/node-token \
 
 `token` 是该 `(node_name, network_id)` 组合的 `ntok_`，hub 端强制 binding——agent 用这个 token 调 MCP 时，server 自动锁定到 `network_id`，跨网络访问拒绝。详见 [Token 概念 — ntok_](/concepts/tokens#_2-ntok-agent-的-token-每个-agent-一个)。
 
-**常见 4xx**（verify [`auth.ts createNetworkTokenForNode()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`index.ts` route](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）：
+**常见 4xx**（verify [`auth.ts createNetworkTokenForNode()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`server.ts` route](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）：
 
 | 状态 | `error` 值 | 触发条件 |
 |------|------------|---------|
@@ -1634,7 +1645,7 @@ curl -X POST http://localhost:9200/api/auth/node-token \
 ### POST /api/auth/tokens
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 创建 API Token。
 
@@ -1670,7 +1681,7 @@ curl -X POST http://localhost:9200/api/auth/tokens \
 ### GET /api/auth/tokens
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 列出用户的所有 Token。
 
@@ -1709,7 +1720,7 @@ curl http://localhost:9200/api/auth/tokens \
 
 ### DELETE /api/auth/tokens/:id
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 撤销 Token（hub 端立即吊销，跟 `anet logout` 仅本机清 token 区别开）。
 
@@ -1738,7 +1749,7 @@ curl -X DELETE http://localhost:9200/api/auth/tokens/tok_xxx \
 
 ### GET /api/networks/:id/members
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 获取网络成员列表（仅 owner / admin）。
 
@@ -1775,7 +1786,7 @@ curl http://localhost:9200/api/networks/net_xxx/members \
 
 ### POST /api/networks/:id/members
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 添加网络成员（owner / admin only；通常 invite 流程更顺，[POST /api/networks/:id/invite](#post-api-networks-id-invite) 创建邀请码让对方自行加入）。
 
@@ -1811,7 +1822,7 @@ curl -X POST http://localhost:9200/api/networks/net_xxx/members \
 
 ### PUT /api/networks/:id/members/:user_id
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 修改成员角色（仅 owner，不能修改 owner 自己的角色）。
 
@@ -1847,7 +1858,7 @@ curl -X PUT http://localhost:9200/api/networks/net_xxx/members/u_def456 \
 
 ### DELETE /api/networks/:id/members/:user_id
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 移除成员（owner / admin only，不能移除 owner 自己）。
 
@@ -1875,7 +1886,7 @@ curl -X DELETE http://localhost:9200/api/networks/net_xxx/members/u_def456 \
 
 ### POST /api/networks/:id/invite
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 创建邀请码。
 
@@ -1903,12 +1914,12 @@ curl -X POST http://localhost:9200/api/networks/net_xxx/invite \
 }
 ```
 
-**常见 4xx**（verify [`auth.ts createInvite()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`index.ts` route handler](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）：
+**常见 4xx**（verify [`auth.ts createInvite()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`server.ts` route handler](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）：
 
 | 状态 | `error` 值 | 触发条件 |
 |------|------------|---------|
 | 400 | `invalid role` | `role` 不是 `admin` / `member` / `viewer` 之一 |
-| 403 | `not a member of this network` | 调用者本身不在该网络（[`index.ts` callerRole gate](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)） |
+| 403 | `not a member of this network` | 调用者本身不在该网络（[`server.ts` callerRole gate](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)） |
 | 403 | `owner/admin required` | 调用者是 `member` / `viewer`，无权 issue 邀请码 |
 
 接收方用 `anet network join inv_abc123def456` 或 `POST /api/networks/join` 加入。`invite_code` 是 `inv_` 前缀 + 12 字符（`auth.ts:346` `slice(0, 12)`）。
@@ -1916,7 +1927,7 @@ curl -X POST http://localhost:9200/api/networks/net_xxx/invite \
 ### POST /api/networks/join
 
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 用邀请码加入网络。
 
@@ -1956,7 +1967,7 @@ curl -X POST http://localhost:9200/api/networks/join \
 
 ### POST /api/upload
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 上传一个文件，返回可下载的 `url`。
 
@@ -1983,7 +1994,7 @@ curl -X POST http://localhost:9200/api/upload \
 文件下载只接受 `Authorization: Bearer ...` 请求头。出于凭据泄漏防护，
 此端点不接受 `?token=` URL 参数（包括 `HEAD` 请求）。
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 下载 `POST /api/upload` 返回的文件。始终强制 `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff`（浏览器不 inline 渲染，防 XSS）。
 
@@ -2025,7 +2036,7 @@ curl -OJ http://localhost:9200/api/files/<file_id> -H "Authorization: Bearer uto
 
 ### POST /api/node-rename/prepare
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 PHASE 1：登记一笔改名事务（old node 不动，全程可回滚）。成功后写 `node_rename_prepared` audit。
 
@@ -2045,7 +2056,7 @@ curl -X POST http://localhost:9200/api/node-rename/prepare \
 
 ### POST /api/node-rename/commit
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 PHASE 2 C1：提交改名事务（CommHub 路由切到 `new_alias`）。成功后写 `node_rename_committed` audit。
 
@@ -2059,7 +2070,7 @@ body `{ txn_id }` 必填（缺则 400）。
 
 ### POST /api/node-rename/abort
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 回滚改名事务（C1 之前调用，old node 恢复原状）。成功后写 `node_rename_aborted` audit。
 
@@ -2076,12 +2087,12 @@ body `{ txn_id }` 必填（缺则 400）。
 ## Tmux 调试端点（opt-in）
 
 ::: warning 默认关闭
-仅在 `COMMHUB_ENABLE_TMUX=1` 启动 hub 时启用（[`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）。**默认全部返回 404 `tmux disabled`**。启用后还需 (a) 调用方 IP 在 `COMMHUB_TMUX_ALLOWLIST` 允许范围（逗号分隔，默认仅 localhost；verify [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）+ (b) `users.role='admin'` system-admin auth。设计意图：让 hub 主机上的 agent tmux session 暴露给同机的 dev / dashboard 调试，**绝不要在公网开**。公网部署 hardening 步骤见 [生产部署 §5 tmux 控制面已关闭](/deploy/production#_5-确认-tmux-控制面已关闭)。
+仅在 `COMMHUB_ENABLE_TMUX=1` 启动 hub 时启用（[`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）。**默认全部返回 404 `tmux disabled`**。启用后还需 (a) 调用方 IP 在 `COMMHUB_TMUX_ALLOWLIST` 允许范围（逗号分隔，默认仅 localhost；verify [`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）+ (b) `users.role='admin'` system-admin auth。设计意图：让 hub 主机上的 agent tmux session 暴露给同机的 dev / dashboard 调试，**绝不要在公网开**。公网部署 hardening 步骤见 [生产部署 §5 tmux 控制面已关闭](/deploy/production#_5-确认-tmux-控制面已关闭)。
 :::
 
 ### GET /api/tmux/:name
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 抓取指定 tmux session 当前 pane 末尾 N 行输出（`tmux capture-pane -t <name> -p` 包装）。
 
@@ -2104,7 +2115,7 @@ curl "http://localhost:9200/api/tmux/anet-node-代码1号?lines=50" \
 
 ### POST /api/tmux/:name/send
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 往指定 tmux session 注入按键（`tmux send-keys -t <name> "<text>" Enter` 包装）。
 
@@ -2134,7 +2145,7 @@ curl -X POST "http://localhost:9200/api/tmux/anet-node-代码1号/send" \
 
 ### GET /ws/tmux/:name
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 WebSocket 端点 —— 实时流式推送指定 tmux session 的 pane 输出。是 `GET /api/tmux/:name` 的 live 版本：HTTP 那个是一次性 `capture-pane`，这个是连上后持续 stream。鉴权门控跟上面两个 HTTP 端点**完全一致**（走同一个 `requireTmuxAccess` —— `COMMHUB_ENABLE_TMUX=1` + IP 在 `COMMHUB_TMUX_ALLOWLIST` 内 + `users.role='admin'` auth；任一不满足在 WS upgrade 前就被拒）。
 
@@ -2154,7 +2165,7 @@ v0.8 起项目转 Apache 2.0 开源 + 自部署，没有官方付费 license。�
 
 ### GET /api/license
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 查 `licenses` 表第一行（按 `created_at` 升序），返回 trial / pro 状态 + 剩余天数。
 
@@ -2181,9 +2192,9 @@ curl http://localhost:9200/api/license
 
 ### POST /api/license/activate
 
-> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
-注入 pro license key（[`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) 只校验 `key.startsWith('anet-') && length >= 16`，**没真正的服务端校验**）。删除原有 license 行 + 写新 pro license（限额 50 agent / 10 network / 10000 task/day，过期 365 天）。
+注入 pro license key（[`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) 只校验 `key.startsWith('anet-') && length >= 16`，**没真正的服务端校验**）。删除原有 license 行 + 写新 pro license（限额 50 agent / 10 network / 10000 task/day，过期 365 天）。
 
 ```bash
 curl -X POST http://localhost:9200/api/license/activate \

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -11,14 +11,14 @@ CommHub Server provides a REST API for Dashboard, CLI, and third-party system in
 | Content Type | `application/json` |
 | Encoding | UTF-8 |
 | Endpoint count | 30+ across **13 groups**: [Public 1](#public-endpoints) · [Auth 5](#auth-endpoints) · [Network 5](#network-endpoints) · [Data Query 10](#data-query-endpoints) · [Task Dispatch 2](#task-dispatch-endpoints) · [MCP 1](#mcp-endpoint) · [SSE 1](#sse-endpoint) · [Token Management 4](#token-management-endpoints) · [Network Members 6](#network-member-endpoints) · [Files 2](#file-endpoints) · [Node Rename 3](#node-rename-endpoints-rfc-010) · [Tmux Debug 3 (opt-in)](#tmux-debug-endpoints-opt-in) · [Legacy 2](#legacy-endpoints-v0-6-era-—-frozen-in-oss) |
-| Full endpoint source | [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) |
+| Full endpoint source | [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) |
 
 ## Public Endpoints
 
 ### GET /health
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Health check, no authentication required.
 
@@ -56,7 +56,7 @@ curl http://localhost:9200/health
 ### POST /api/auth/register
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Register a new user. The first user registered automatically becomes admin.
 
@@ -112,7 +112,7 @@ The `user` object's 5 fields match [`server/src/auth.ts:7-13`](https://github.co
 | 400 | `password must be at least 8 characters` | Non-bootstrap user password < 8 |
 | 400 | `password must be at least 4 characters` | First user (bootstrap admin) password < 4 |
 | 400 | `password is too common` | Hits the weak-password dictionary ([`password-dict.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/password-dict.ts); bootstrap admin is exempt) |
-| 429 | `too many requests, try again later` | Exceeded 30/min IP rate limit ([`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts); localhost is exempt — see [Security — IP rate limits](/en/concepts/security#per-ip-limits)) |
+| 429 | `too many requests, try again later` | Exceeded 30/min IP rate limit ([`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts); localhost is exempt — see [Security — IP rate limits](/en/concepts/security#per-ip-limits)) |
 
 **Rate limit**: 30 requests/minute per IP.
 
@@ -121,7 +121,7 @@ The `user` object's 5 fields match [`server/src/auth.ts:7-13`](https://github.co
 ### POST /api/auth/login
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 User login.
 
@@ -159,16 +159,27 @@ The `user` object's 5 fields match the register response (note `email` may be `n
 | Status | `error` value | Trigger |
 |------|------------|---------|
 | 401 | `invalid username or password` | Username doesn't exist **or** password hash mismatch ([`auth.ts:99-100`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L99) intentionally collapses both into the same message to avoid username enumeration); the server also writes a `login_failed` audit row |
-| 429 | `too many attempts, try again later` | Exceeded 10/min IP rate limit ([`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts); on hit the server writes a `login_rate_limited` audit row with the client IP) |
+| 429 | `rate_limited` | Exceeded 10/min IP rate limit ([`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts); on hit the server writes a `login_rate_limited` audit row with the client IP) |
 
 **Rate limit**: 10 requests/minute per IP.
+
+Full 429 **response body** (the `error` field is `rate_limited` — it is not the prose message):
+
+```json
+{ "ok": false, "error": "rate_limited",
+  "message": "Too many login attempts. Try again later.",
+  "retry_after_ms": 42000 }
+```
+
+A `Retry-After` header is also returned (in seconds, `retry_after_ms` rounded up).
+Match on the `error` field, not on `message`.
 
 ---
 
 ### GET /api/auth/me
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get current user info.
 
@@ -204,7 +215,7 @@ curl http://localhost:9200/api/auth/me \
 ### PUT /api/auth/me
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Update personal info.
 
@@ -222,7 +233,7 @@ curl -X PUT http://localhost:9200/api/auth/me \
 | `display_name` | string | | Display name |
 | `email` | string | | Email |
 
-Only the provided fields are updated ([server/src/index.ts](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) uses conditional SQL with `if (body.X)`); `username` / `role` / `password` are **not** mutable through this endpoint.
+Only the provided fields are updated ([server/src/server.ts](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) uses conditional SQL with `if (body.X)`); `username` / `role` / `password` are **not** mutable through this endpoint.
 
 **Response** (success):
 
@@ -239,7 +250,7 @@ Only the provided fields are updated ([server/src/index.ts](https://github.com/s
 }
 ```
 
-**Common 4xx errors** (verify [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)):
+**Common 4xx errors** (verify [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)):
 
 | Status | `error` value | Trigger |
 |------|------------|---------|
@@ -247,7 +258,7 @@ Only the provided fields are updated ([server/src/index.ts](https://github.com/s
 | 401 | `token required` / `invalid token` | Missing / invalid utok_ |
 
 ::: info Missing fields are not an error
-If you supply only `display_name` and omit `email` (or omit both), the server does not return 400 — [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) builds the SQL conditionally with `if (body.X)`. When everything is omitted it just re-SELECTs and returns the user as-is. **No field-length validation** here (the v0.9.x and v0.10.x scopes did not touch this; schema-level checks are queued for v0.11+ / unscheduled).
+If you supply only `display_name` and omit `email` (or omit both), the server does not return 400 — [`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) builds the SQL conditionally with `if (body.X)`. When everything is omitted it just re-SELECTs and returns the user as-is. **No field-length validation** here (the v0.9.x and v0.10.x scopes did not touch this; schema-level checks are queued for v0.11+ / unscheduled).
 :::
 
 ---
@@ -255,7 +266,7 @@ If you supply only `display_name` and omit `email` (or omit both), the server do
 ### POST /api/auth/password
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Change password.
 
@@ -280,10 +291,10 @@ curl -X POST http://localhost:9200/api/auth/password \
 }
 ```
 
-`revoked` is the number of utok\_/atok\_ tokens on **other devices** that were just revoked (it does **not** include the caller's own token — that one is revoked separately at index.ts L490).
+`revoked` is the number of utok\_/atok\_ tokens on **other devices** that were just revoked (it does **not** include the caller's own token — that one is revoked separately by `revokeToken(resolved.user.user_id, resolved.tokenId)` in the password-change handler in `server.ts`).
 
-**Key side effects** (verify [`auth.ts:267-282 changePassword + revokeOtherUserTokens`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L267) + [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)):
-1. **The caller's `utok_`** (`resolved.tokenId`) is revoked immediately ([`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) `revokeToken(...)` explicit delete)
+**Key side effects** (verify [`auth.ts:267-282 changePassword + revokeOtherUserTokens`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L267) + [`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)):
+1. **The caller's `utok_`** (`resolved.tokenId`) is revoked immediately ([`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) `revokeToken(...)` explicit delete)
 2. **All other devices' `utok_` / `atok_`** are also revoked in one shot ([`auth.ts:269-270`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L269) `DELETE ... WHERE user_id=? AND network_id IS NULL AND token_id != ?currentTokenId`) — the count is returned in the `revoked` field
 3. **`ntok_` tokens are unaffected** (`revokeOtherUserTokens` filters on `network_id IS NULL`, so agent nodes using `ntok_` keep running through a password change; matches the [account-system / Change Password](/en/guide/account-system#change-password) narrative)
 4. **A fresh `utok_`** (`issued.token`) is minted for the caller and returned in this response — the caller must overwrite local storage with the new token right away
@@ -312,7 +323,7 @@ Password-strength validation reuses `validatePasswordStrength()` from register (
 ### GET /api/networks
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get all networks the user belongs to.
 
@@ -350,7 +361,7 @@ Each row in `networks` has 10 fields: the 9 `networks` table columns ([`server/s
 ### POST /api/networks
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Create a new network.
 
@@ -386,7 +397,7 @@ curl -X POST http://localhost:9200/api/networks \
 
 ### GET /api/networks/:id
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get network details (membership check: caller must be a member of the network or a system admin, otherwise 403).
 
@@ -422,13 +433,13 @@ curl http://localhost:9200/api/networks/net_abc123 \
 }
 ```
 
-The `network` object has 9 fields = `SELECT * FROM networks WHERE network_id = ?1` ([`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)), including the v3 migrations `visibility` + `max_members`. The `settings` column is reserved for future per-network JSON config and is currently always `null`. `stats.tasks` is aggregated by status (same shape as the nested `tasks.by_status` in [GET /api/stats](#get-api-stats)).
+The `network` object has 9 fields = `SELECT * FROM networks WHERE network_id = ?1` ([`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)), including the v3 migrations `visibility` + `max_members`. The `settings` column is reserved for future per-network JSON config and is currently always `null`. `stats.tasks` is aggregated by status (same shape as the nested `tasks.by_status` in [GET /api/stats](#get-api-stats)).
 
 ---
 
 ### PUT /api/networks/:id
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Rename a network (owner only).
 
@@ -466,7 +477,7 @@ Writes audit log `action='network_renamed'`; the `detail` column records the new
 
 ### DELETE /api/networks/:id
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Delete a network (owner only, must have no active sessions).
 
@@ -498,7 +509,7 @@ Writes audit log `action='network_deleted'`.
 ### GET /api/status
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get all session statuses.
 
@@ -540,14 +551,14 @@ curl "http://localhost:9200/api/status?network_id=net_xxx" \
 }
 ```
 
-The `summary` field is a count aggregated by status ([`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)): the `working` bucket collapses `working / blocked / error / waiting_input / running / busy`; `offline` is sessions whose `updated_at` is older than 10 minutes (the server recomputes this on every GET and writes back to the DB); everything else counts as `idle`.
+The `summary` field is a count aggregated by status ([`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)): the `working` bucket collapses `working / blocked / error / waiting_input / running / busy`; `offline` is sessions whose `updated_at` is older than 10 minutes (the server recomputes this on every GET and writes back to the DB); everything else counts as `idle`.
 
 ---
 
 ### GET /api/tasks
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get task list.
 
@@ -609,7 +620,7 @@ Field mapping follows the `tasks` table schema ([`server/src/db.ts`](https://git
 ### GET /api/task/{task_id}
 
 
-> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Fetch the full record of a **single task** by `task_id`. The path accepts both `/api/task/<id>` and `/api/tasks/<id>` (trailing `s` optional).
 
@@ -644,7 +655,7 @@ curl http://localhost:9200/api/task/<task_id> \
 ### GET /api/nodes
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get node list (persistent node info, distinct from session's transient state).
 
@@ -694,7 +705,7 @@ The `nodes` table is **persistent node identity** (written at creation, deleted 
 
 ### DELETE /api/nodes/:ref
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Delete a node from the hub server side — removes the persistent identity row in `nodes` and the heartbeat row in `sessions` (same transaction), and pushes a `node_deleted` SSE event to the alias channel and the network channel so dashboards refresh in real time. Shipped via PR #86 "node delete cascade and node_deleted SSE".
 
@@ -708,7 +719,7 @@ curl -X DELETE "http://localhost:9200/api/nodes/%E4%BB%A3%E7%A0%811%E5%8F%B7" \
   -H "Authorization: Bearer ntok_xxx"
 ```
 
-**Path parameter**: at [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts), the server resolves `:ref` via `node_id = ? OR node_name = ? OR alias = ?` (filtered to the network scope, then ordered by `updated_at DESC LIMIT 1`).
+**Path parameter**: at [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts), the server resolves `:ref` via `node_id = ? OR node_name = ? OR alias = ?` (filtered to the network scope, then ordered by `updated_at DESC LIMIT 1`).
 
 **Response** (success, 200):
 
@@ -723,7 +734,7 @@ curl -X DELETE "http://localhost:9200/api/nodes/%E4%BB%A3%E7%A0%811%E5%8F%B7" \
 }
 ```
 
-**SSE side effect**: after the delete, a `node_deleted` event is pushed to **two SSE channels** ([`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)):
+**SSE side effect**: after the delete, a `node_deleted` event is pushed to **two SSE channels** ([`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)):
 - The alias's own SSE channel (if any subscribers remain)
 - The user-level SSE channel for the `network_id` (so every network member sees the deletion immediately)
 
@@ -749,7 +760,7 @@ This REST endpoint only removes the hub-side `nodes` / `sessions` rows; it does 
 
 ### GET /api/servers
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Aggregate agents by **physical server** (`hostname` + `ip`) and return live host telemetry — used by the dashboard's "Servers" sidebar. Refs [issue #119](https://github.com/sleep2agi/agent-network/issues/119).
 
@@ -798,7 +809,7 @@ Host telemetry is reported by agent-node on every `report_status` call ([issue #
 
 ### GET /api/server/:host/health
 
-> [source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) · v0.10.0 / `commhub-server@0.8.2`
+> [source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · v0.10.0 / `commhub-server@0.8.2`
 
 Returns the **current health snapshot of a single physical server** plus 24h-bucketed telemetry history. Refs [issue #99](https://github.com/sleep2agi/agent-network/issues/99) (per-server daemon Phase 1 scaffold).
 
@@ -859,13 +870,13 @@ curl "http://localhost:9200/api/server/$(python3 -c 'import urllib.parse; print(
 |------|------|
 | `host` | The host value from the request path |
 | `agent_count` | Active session count on this host (window over the latest row's `COUNT(*) OVER ()`) |
-| `alert_level` | `ok` / `warn` / `critical` (computed by `serverAlertLevel(latest)`; from v0.10.2 onwards, `disk_avail_gb < 1` triggers `critical` and `< 5` triggers `warn` — verify [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) |
+| `alert_level` | `ok` / `warn` / `critical` (computed by `serverAlertLevel(latest)`; from v0.10.2 onwards, `disk_avail_gb < 1` triggers `critical` and `< 5` triggers `warn` — verify [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)) |
 | `alerts` | Active alert list, non-empty when `alert_level != ok` |
 | `latest` | Most recent heartbeat instant telemetry (CPU / mem / disk + `last_seen`) |
 | `latest.disk_total_gb` / `disk_used_gb` / `disk_avail_gb` | **Available from v0.10.2** (agent-node `2.4.1+`, [`host-telemetry.ts readDiskStats()`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/host-telemetry.ts)) — sampled via `execFileSync('df', ['-k', '/'])`; the POSIX `-k` flag shares one parse path across Linux + macOS; on Windows or parse failure, all three fields gracefully fall back to `null` (the dashboard renders `—` rather than a misleading `0`). Older agents (`< 2.4.1`) emit `null` for all three. |
 | `history.5m` | Last 5 min, **1 min bucket** (from the `agent_telemetry` history table) |
 | `history.1h` | Last 1 h, **5 min bucket** |
-| `history.24h` | Last 24 h, **1 hour bucket**; from v0.10.2, each bucket also carries `disk_avail_min` / `disk_used_max` extreme-aggregation fields (verify [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) |
+| `history.24h` | Last 24 h, **1 hour bucket**; from v0.10.2, each bucket also carries `disk_avail_min` / `disk_used_max` extreme-aggregation fields (verify [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)) |
 
 **404**: `{ "ok": false, "error": "server not found" }` — no (active or offline) session matches the host.
 
@@ -875,7 +886,7 @@ curl "http://localhost:9200/api/server/$(python3 -c 'import urllib.parse; print(
 
 ### GET /api/server/:host/agents
 
-> [source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) · v0.10.0 / `commhub-server@0.8.2`
+> [source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) · v0.10.0 / `commhub-server@0.8.2`
 
 Returns the **agent list on a single server** plus per-agent process telemetry (rss / cpu / uptime / in-flight count). Refs [issue #99](https://github.com/sleep2agi/agent-network/issues/99) + [issue #142](https://github.com/sleep2agi/agent-network/issues/142) per-agent process telemetry.
 
@@ -938,7 +949,7 @@ curl http://localhost:9200/api/server/dev-machine/agents \
 ### GET /api/messages
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get recent inbox messages.
 
@@ -984,7 +995,7 @@ curl "http://localhost:9200/api/messages?limit=100" \
 }
 ```
 
-Field mapping to the server `SELECT` ([`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) `id, session_name as to_alias, from_session as from_alias, type, priority, content, created_at, network_id` — the primary key is `id` (not `message_id`); the response also includes `priority` + `network_id`, which earlier doc omitted.
+Field mapping to the server `SELECT` ([`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)) `id, session_name as to_alias, from_session as from_alias, type, priority, content, created_at, network_id` — the primary key is `id` (not `message_id`); the response also includes `priority` + `network_id`, which earlier doc omitted.
 
 ::: info Current schema caveat
 The SELECT doesn't include `in_reply_to` yet; reply-polling uses a heuristic of `from_alias` + `type='reply'` + recency (see comment at `cli.ts`).
@@ -995,7 +1006,7 @@ The SELECT doesn't include `in_reply_to` yet; reply-polling uses a heuristic of 
 ### GET /api/completions
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get completion records (summary records written via the `report_completion` MCP tool — distinct from a simple `tasks` row with `status='replied'`).
 
@@ -1041,7 +1052,7 @@ The `artifacts` field is a JSON string (agent-defined schema); consumers must `J
 ### GET /api/task_events
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get the task-state-change audit log (task lifecycle). Every time a task's `status` changes the server inserts one row — this is the primary data source for "where is this task stuck / who changed the status".
 
@@ -1058,7 +1069,7 @@ curl "http://localhost:9200/api/task_events?task_id=t_a1b2c3d4" \
 | `network_id` | Filter by network (when an `ntok_` is bound, this parameter is overridden by the token's network) |
 | `limit` | Max items (default 50, max 500) |
 
-> `network_id` isn't read inside the task_events handler itself — every REST endpoint goes through [`resolveRestNetworkScope` (index.ts)](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts): a `utok_` caller may pass `network_id` to target a network (membership is verified), an `ntok_` caller is forcibly scoped to the token's bound network, and a system admin may inspect any network.
+> `network_id` isn't read inside the task_events handler itself — every REST endpoint goes through [`resolveRestNetworkScope` (server.ts)](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts): a `utok_` caller may pass `network_id` to target a network (membership is verified), an `ntok_` caller is forcibly scoped to the token's bound network, and a system admin may inspect any network.
 
 **Response**:
 
@@ -1096,7 +1107,7 @@ Events are sorted `created_at DESC` (newest first). `actor` is the originator of
 ### GET /api/stats
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get aggregate statistics.
 
@@ -1133,9 +1144,9 @@ curl http://localhost:9200/api/stats \
 
 ### GET /api/server-logs
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
-Read the last N lines from the hub process's **in-memory console-log ring buffer** (debug aid). **`users.role = 'admin'` only** (same system-admin gate as [GET /api/users](#get-api-users) / [GET /api/audit-log](#get-api-audit-log) — **not** the per-network admin role). Buffer capacity defaults to 500 lines and is configurable via `COMMHUB_LOG_RING` ([`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)).
+Read the last N lines from the hub process's **in-memory console-log ring buffer** (debug aid). **`users.role = 'admin'` only** (same system-admin gate as [GET /api/users](#get-api-users) / [GET /api/audit-log](#get-api-audit-log) — **not** the per-network admin role). Buffer capacity defaults to 500 lines and is configurable via `COMMHUB_LOG_RING` ([`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)).
 
 ```bash
 curl "http://localhost:9200/api/server-logs?limit=100" \
@@ -1162,7 +1173,7 @@ curl "http://localhost:9200/api/server-logs?limit=100" \
 }
 ```
 
-Sorted **newest first**; each `line` is truncated to 4000 chars ([`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)). **The buffer is cleared on process restart** — this is not persistent storage. For durable logs, redirect stdout to a file or journald.
+Sorted **newest first**; each `line` is truncated to 4000 chars ([`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)). **The buffer is cleared on process restart** — this is not persistent storage. For durable logs, redirect stdout to a file or journald.
 
 **4xx errors**:
 
@@ -1176,9 +1187,9 @@ Sorted **newest first**; each `line` is truncated to 4000 chars ([`index.ts`](ht
 ### GET /api/audit-log
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
-Get the audit log. **Permissions: any authenticated user can call this endpoint, but non-**system admin** callers only see their own log rows** (the server adds `WHERE user_id = <caller>` automatically when `users.role !== 'admin'` — see [`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)). System admin (`users.role = 'admin'`) sees everything and can filter by any `user_id`.
+Get the audit log. **Permissions: any authenticated user can call this endpoint, but non-**system admin** callers only see their own log rows** (the server adds `WHERE user_id = <caller>` automatically when `users.role !== 'admin'` — see [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)). System admin (`users.role = 'admin'`) sees everything and can filter by any `user_id`.
 
 ::: warning Not the network-level admin/owner role
 "admin" here means `users.role='admin'` (**system-level**, the first registered user by default) — **not** the per-network `owner / admin / member / viewer` roles. Same distinction as [GET /api/users](#get-api-users).
@@ -1237,7 +1248,7 @@ POST `/api/networks` does not call `logAudit`, so audit_log will **never** conta
 ### GET /api/users
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get the list of all users (**system admin** only — i.e. `users.role = 'admin'`, distinct from per-network `owner / admin / member / viewer` roles).
 
@@ -1289,7 +1300,7 @@ REST equivalents of the `send_task` / `broadcast` MCP tools (non-MCP path, suita
 
 ### POST /api/task
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 REST version of `send_task`: writes inbox + tasks rows for a target alias and pushes `new_task` over SSE.
 
@@ -1305,7 +1316,7 @@ curl -X POST http://localhost:9200/api/task \
   }'
 ```
 
-**Request body** (verify [`TaskSchema`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)):
+**Request body** (verify [`TaskSchema`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)):
 
 | Field | Type | Required | Description |
 |------|------|:----:|------|
@@ -1315,7 +1326,7 @@ curl -X POST http://localhost:9200/api/task \
 | `from` | string | | Sender identifier (default `"api"`) |
 | `network_id` | string | | Target network (utok\_ caller; ntok\_ is force-bound) |
 | `parent_task_id` | string | | Parent task for automatic reply chaining. Omit it when no authoritative current task id is available. |
-| `ttl_seconds` | number | | Expiry in seconds (default 3600). Not part of the schema — server reads it directly from `body.ttl_seconds` at [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts). |
+| `ttl_seconds` | number | | Expiry in seconds (default 3600). Not part of the schema — server reads it directly from `body.ttl_seconds` at [`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts). |
 
 **Response** (success):
 
@@ -1371,7 +1382,7 @@ A `new_task` SSE event is pushed to the target alias on success.
 
 ### POST /api/broadcast
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 REST version of `broadcast`: writes inbox rows for a group of sessions and pushes `broadcast` SSE events.
 
@@ -1385,7 +1396,7 @@ curl -X POST http://localhost:9200/api/broadcast \
   }'
 ```
 
-**Request body** (verify [`BroadcastSchema`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)):
+**Request body** (verify [`BroadcastSchema`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)):
 
 | Field | Type | Required | Description |
 |------|------|:----:|------|
@@ -1393,7 +1404,7 @@ curl -X POST http://localhost:9200/api/broadcast \
 | `filter_server` | string | | Only deliver to sessions whose `server` field matches |
 | `filter_status` | string | | Only deliver to sessions in the given status (e.g. `idle` / `working`) |
 
-> Same field set as the MCP [`broadcast`](mcp-tools#broadcast) tool. `from_session` is **not** a parameter — the server hard-codes `'api'` ([`index.ts` — `POST /api/broadcast` handler](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts); the MCP version uses `'hub'`).
+> Same field set as the MCP [`broadcast`](mcp-tools#broadcast) tool. `from_session` is **not** a parameter — the server hard-codes `'api'` ([`server.ts` — `POST /api/broadcast` handler](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts); the MCP version uses `'hub'`).
 
 **Response** (success):
 
@@ -1421,7 +1432,7 @@ curl -X POST http://localhost:9200/api/broadcast \
 
 ### POST /mcp
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 MCP Streamable HTTP endpoint. Agents call MCP Tools through this endpoint.
 
@@ -1447,7 +1458,7 @@ curl -X POST http://localhost:9200/mcp \
 
 ### GET /events/:name
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 SSE real-time push endpoint. Clients receive events via a long-lived connection. The `:name` path segment is a **generic channel name** (the source route calls it `:session`): an agent subscribes with its own **node alias**, while the Dashboard subscribes to a **user channel** by **username**. The SSE layer itself is just a per-channel-name `Map` ([`push.ts:11` `clients`](https://github.com/sleep2agi/agent-network/blob/main/server/src/push.ts#L11)) — it does not distinguish alias from username; `pushEvent(name, ...)` reaches whoever registered that name (e.g. `node.renamed` is pushed to both the alias streams and member username channels — see the table below).
 
@@ -1496,7 +1507,7 @@ data: {"type":"new_task","inbox_count":1,"priority":"high","from":"commander"}
 ### POST /api/auth/node-token
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Create a network-bound `ntok_` for a node. `anet node create` calls this automatically and writes the result into `.anet/nodes/<node-name>/config.json` `token` field.
 
@@ -1518,7 +1529,7 @@ curl -X POST http://localhost:9200/api/auth/node-token \
 
 The `token` is the `ntok_` for that `(node_name, network_id)` pair. The hub force-binds the `network_id` to the token — when an agent calls MCP with this token, the server locks operations to that network and rejects cross-network access. See [Tokens — ntok_](/en/concepts/tokens) for more.
 
-**Common 4xx errors** (verify [`auth.ts createNetworkTokenForNode()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`index.ts` route](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)):
+**Common 4xx errors** (verify [`auth.ts createNetworkTokenForNode()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`server.ts` route](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)):
 
 | Status | `error` value | Trigger |
 |------|------------|---------|
@@ -1530,7 +1541,7 @@ The `token` is the `ntok_` for that `(node_name, network_id)` pair. The hub forc
 ### POST /api/auth/tokens
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Create an API token.
 
@@ -1566,7 +1577,7 @@ See [Token system](/en/concepts/tokens) for the full picture.
 ### GET /api/auth/tokens
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 List all user tokens.
 
@@ -1605,7 +1616,7 @@ The 6 fields per row map directly to [`auth.ts:209-213`](https://github.com/slee
 
 ### DELETE /api/auth/tokens/:id
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Revoke a token (immediate server-side invalidation — distinct from `anet logout` which only clears the local token).
 
@@ -1634,7 +1645,7 @@ Writes audit log `action='token_revoked'`. After revocation, the next request us
 
 ### GET /api/networks/:id/members
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Get network member list (owner / admin only).
 
@@ -1671,7 +1682,7 @@ curl http://localhost:9200/api/networks/net_xxx/members \
 
 ### POST /api/networks/:id/members
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Add a member to the network (owner / admin only; the invite flow is usually smoother — see [POST /api/networks/:id/invite](#post-api-networks-id-invite) to issue a code that the recipient can redeem).
 
@@ -1707,7 +1718,7 @@ Writes audit log `action='member_added'`; the `detail` column records `<user_id>
 
 ### PUT /api/networks/:id/members/:user_id
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Change a member's role (owner only; cannot change the owner's own role).
 
@@ -1743,7 +1754,7 @@ Writes audit log `action='member_role_changed'`; the `detail` column records `<u
 
 ### DELETE /api/networks/:id/members/:user_id
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Remove a member (owner / admin only; cannot remove the owner).
 
@@ -1771,7 +1782,7 @@ Writes audit log `action='member_removed'`; the `detail` column records `<user_i
 
 ### POST /api/networks/:id/invite
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Create an invite code.
 
@@ -1799,12 +1810,12 @@ curl -X POST http://localhost:9200/api/networks/net_xxx/invite \
 }
 ```
 
-**Common 4xx errors** (verify [`auth.ts createInvite()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`index.ts` route handler](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)):
+**Common 4xx errors** (verify [`auth.ts createInvite()`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts) + [`server.ts` route handler](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)):
 
 | Status | `error` value | Trigger |
 |------|------------|---------|
 | 400 | `invalid role` | `role` is not one of `admin` / `member` / `viewer` |
-| 403 | `not a member of this network` | Caller is not a member of the network ([`index.ts` callerRole gate](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) |
+| 403 | `not a member of this network` | Caller is not a member of the network ([`server.ts` callerRole gate](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)) |
 | 403 | `owner/admin required` | Caller is `member` / `viewer` — cannot issue invites |
 
 The recipient joins via `anet network join inv_abc123def456` or `POST /api/networks/join`. `invite_code` is `inv_` prefix + 12 characters (`auth.ts:346` `slice(0, 12)`).
@@ -1812,7 +1823,7 @@ The recipient joins via `anet network join inv_abc123def456` or `POST /api/netwo
 ### POST /api/networks/join
 
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Join a network with an invite code.
 
@@ -1852,7 +1863,7 @@ Attachment (image, etc.) upload / download — backs Dashboard image sending, co
 
 ### POST /api/upload
 
-> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Uploads a file and returns a downloadable `url`.
 
@@ -1880,7 +1891,7 @@ File downloads accept only the `Authorization: Bearer ...` header. To prevent
 credential leakage, this endpoint rejects `?token=` URL authentication for both
 `GET` and `HEAD` requests.
 
-> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Downloads a file returned by `POST /api/upload`. Always forces `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff` (the browser won't inline-render it — XSS defense).
 
@@ -1922,7 +1933,7 @@ Errors usually return this shape:
 
 ### POST /api/node-rename/prepare
 
-> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 PHASE 1: register a rename transaction (old node untouched, fully rollbackable). On success writes a `node_rename_prepared` audit row.
 
@@ -1942,7 +1953,7 @@ curl -X POST http://localhost:9200/api/node-rename/prepare \
 
 ### POST /api/node-rename/commit
 
-> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 PHASE 2 C1: commit the rename transaction (CommHub routing switches to `new_alias`). On success writes a `node_rename_committed` audit row.
 
@@ -1956,7 +1967,7 @@ body `{ txn_id }` is required (missing → 400).
 
 ### POST /api/node-rename/abort
 
-> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [Source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Roll back the rename transaction (called before C1; old node restored). On success writes a `node_rename_aborted` audit row.
 
@@ -1973,12 +1984,12 @@ body `{ txn_id }` is required (missing → 400).
 ## Tmux Debug Endpoints (opt-in)
 
 ::: warning Off by default
-Only available when the hub is started with `COMMHUB_ENABLE_TMUX=1` ([`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)). **Otherwise all paths return 404 `tmux disabled`**. Even when enabled, you still need (a) the caller IP to be inside `COMMHUB_TMUX_ALLOWLIST` (comma-separated, defaults to localhost only; verify [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)) and (b) `users.role = 'admin'` system-admin auth. Intended use: expose tmux sessions running agents on the hub machine to local devs / Dashboard. **Never expose on the public internet.** Public-deploy hardening: [Production §5 Verify tmux control plane is off](/en/deploy/production#_5-verify-the-tmux-control-plane-is-off).
+Only available when the hub is started with `COMMHUB_ENABLE_TMUX=1` ([`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)). **Otherwise all paths return 404 `tmux disabled`**. Even when enabled, you still need (a) the caller IP to be inside `COMMHUB_TMUX_ALLOWLIST` (comma-separated, defaults to localhost only; verify [`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)) and (b) `users.role = 'admin'` system-admin auth. Intended use: expose tmux sessions running agents on the hub machine to local devs / Dashboard. **Never expose on the public internet.** Public-deploy hardening: [Production §5 Verify tmux control plane is off](/en/deploy/production#_5-verify-the-tmux-control-plane-is-off).
 :::
 
 ### GET /api/tmux/:name
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Capture the tail of a tmux session's current pane (`tmux capture-pane -t <name> -p` wrapper).
 
@@ -2001,7 +2012,7 @@ curl "http://localhost:9200/api/tmux/anet-node-coder-1?lines=50" \
 
 ### POST /api/tmux/:name/send
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Send keys into a tmux session (`tmux send-keys -t <name> "<text>" Enter` wrapper).
 
@@ -2031,7 +2042,7 @@ curl -X POST "http://localhost:9200/api/tmux/anet-node-coder-1/send" \
 
 ### GET /ws/tmux/:name
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 WebSocket endpoint — live-streams a tmux session's pane output. It's the live counterpart of `GET /api/tmux/:name`: the HTTP one is a one-shot `capture-pane`, this one keeps streaming once connected. Auth gating is **identical** to the two HTTP endpoints above (same `requireTmuxAccess` — `COMMHUB_ENABLE_TMUX=1` + caller IP in `COMMHUB_TMUX_ALLOWLIST` + `users.role='admin'` auth; any failure is rejected before the WS upgrade).
 
@@ -2051,7 +2062,7 @@ Since v0.8 the project is Apache 2.0 open-source + self-hosted — there is no o
 
 ### GET /api/license
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
 Reads the first row of the `licenses` table (by `created_at` ascending) and returns trial / pro status with `days_left`.
 
@@ -2078,9 +2089,9 @@ curl http://localhost:9200/api/license
 
 ### POST /api/license/activate
 
-> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)
+> [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
-Inject a pro license key. [`index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts) only checks that `key.startsWith('anet-') && length >= 16` — **there is no real server-side validation**. The endpoint deletes any existing license row and writes a fresh pro license (limits 50 agents / 10 networks / 10000 tasks/day, expires in 365 days).
+Inject a pro license key. [`server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts) only checks that `key.startsWith('anet-') && length >= 16` — **there is no real server-side validation**. The endpoint deletes any existing license row and writes a fresh pro license (limits 50 agents / 10 networks / 10000 tasks/day, expires in 365 days).
 
 ```bash
 curl -X POST http://localhost:9200/api/license/activate \


### PR DESCRIPTION
在**当前 main** 上重做 #546 的发现。原分支 `behind=171`,直接 rebase 代价大且那个文件早已面目全非;
发现本身至今有效,所以重做而不是复活分支。原作者的判断成立,这个 PR 归功于那次分流。

## 1. 157 处「源码 ↗」链接指向的是一个 15 行的空壳

前提已核实(取自 `origin/main`,不是本地 checkout):

```
server/src/index.ts    15 行,注释写着 "Run-entry shim (#438 corrective, 方案 C)"
                       内容只有 process.env.COMMHUB_SERVER = "1" + 动态 import server.js
server/src/server.ts   3373 行  ← 真正的实现
```

也就是说读者在 anet.sh 的 REST API 页面上点「源码 ↗」,落到的是一个不含任何 endpoint 逻辑的启动垫片。
中文站 79 处 + 英文站 78 处,全部改指 `server/src/server.ts`。

**有意没动的一处**:`agent-network/tests/docker-e2e/README.md` 里
「Bun runs the local `server/src/index.ts` source」—— 那句说的是**运行入口**,跑 index.ts 就是跑 hub,是对的。
一并 sed 掉会把正确的句子改错。

## 2. 顺带发现一处响应体失真(这条比链接更值钱)

文档写登录限流 429 的 error 是 `too many attempts, try again later`。
但这个字符串**在整个 `server/src/` 里都不存在**。实际返回(`server.ts:947`):

```json
{ "ok": false, "error": "rate_limited",
  "message": "Too many login attempts. Try again later.",
  "retry_after_ms": 42000 }
```

外加 `Retry-After` 响应头。**照文档匹配 `error` 字段的客户端会直接失配**,
而且文档完全没提 `retry_after_ms` 和 `Retry-After`。已改成真实形状,
并写明「按 `error` 字段判定,不要匹配 `message` 文案」。

对照:30/分那条 `too many requests, try again later` 与 `server.ts:929` **一致**,没动。

## 3. 钉行号是它变陈旧的原因

原文写「那个是 index.ts L490 单独撤销的」—— 文件和行号**都**已失效。
真实位置是 `server.ts:1022`,在改密处理函数里。
改成钉符号 `revokeToken(resolved.user.user_id, resolved.tokenId)` + 所在处理函数,不再钉行号。

## 自检

```
两文件 index.ts 引用清零                     grep rc=1(真退出码,非管道)
两文件 'too many attempts' 清零              grep rc=1
文档新承诺的每个字符串反向验在 server.ts 存在:
  rate_limited 3 / "Too many login attempts. Try again later." 1
  retry_after_ms 5 / Retry-After 3 / "too many requests, try again later" 1
docs-site 本地 npm run build                通过(该项目未设 ignoreDeadLinks,有死链即 fail)
```

🔴 合并后**站点不会自动更新**,需要手动 `vercel --prod`(见 `deploy/docs-site/README.md`,
以及刚合的 #734 给 RELEASE-SOP Step 9 加的那条)。我会在合并后跟一次部署并验内容。
