### PR TITLE
ops: version production Hub launcher recovery

### DIFF
--- a/deploy/hub/README.md
+++ b/deploy/hub/README.md
@@ -7,6 +7,49 @@
 (`0.9.0-preview.27 → 0.9.0-preview.29`),证据见 `docs/tests/report-hub-upgrade-preview29.txt`。
 这是 `deploy/` 下目前唯一不是「未演练」的一份。
 
+## Git 权威副本与空机安装
+
+生产机上的 `~/.local/bin/hub-daemon.sh` 是**部署副本**；权威源是本目录的
+[`hub-daemon.sh`](./hub-daemon.sh)。PM2 的非敏感进程定义在
+[`ecosystem.config.cjs`](./ecosystem.config.cjs)。换版本时必须在同一个变更里更新 Git
+副本的 `RUNTIME_DIR` 和变更历史，不能只改服务器孤本。
+
+```bash
+install -d -m 700 "$HOME/.local/bin" "$HOME/.commhub"
+install -m 700 deploy/hub/hub-daemon.sh "$HOME/.local/bin/hub-daemon.sh"
+
+# 部署后必须证明机器副本等于 Git 权威；不是只看 bash -n。
+test "$(git hash-object deploy/hub/hub-daemon.sh)" = \
+     "$(git hash-object "$HOME/.local/bin/hub-daemon.sh")"
+bash -n "$HOME/.local/bin/hub-daemon.sh"
+```
+
+### secret 与数据不在 Git
+
+`$HOME/.commhub/hub.env` 必须是 owner-only（建议 `0600`），至少提供非空的
+`ANET_HUB_SECRET_VAULT_KEY`。**只记录变量名，不把值提交到仓库、PM2 配置或日志。**
+它是解密既有 vault 密文所需的恢复材料：空机恢复必须从独立加密备份或由网络 owner
+安全交付**原值**；若只重新生成一个新值，旧密文不会恢复。该恢复材料的具体保险库记录名
+目前仍是 NOT COVERED，补齐前不得宣称数据恢复闭环。
+
+生产 SQLite 内容同样不在 Git。用本 runbook 的 `VACUUM INTO` 一致性备份恢复，或接受
+空库后重新注册节点；不得把活跃 WAL 库当普通文件 `cp`。
+
+### 从空 PM2 恢复进程定义
+
+先完成 sibling runtime 安装、`hub.env`/DB 恢复和上面的 launcher 安装，再执行：
+
+```bash
+pm2 start deploy/hub/ecosystem.config.cjs --only commhub-hub
+pm2 save
+```
+
+当前生产定义的非敏感坐标是：`bash` interpreter、fork mode、autorestart、
+`min_uptime=20000`、`max_restarts=20`、指数退避起点 `200ms`、cwd=`~/.commhub`。
+环境值由 launcher 的 `hub.env` 加载，不复制进 ecosystem 文件。
+
+恢复后仍必须跑下文五条验证；`pm2 online` 不是恢复成功判据。
+
 ## 拓扑
 
 ```

--- a/deploy/hub/ecosystem.config.cjs
+++ b/deploy/hub/ecosystem.config.cjs
@@ -1,0 +1,20 @@
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+const home = process.env.HOME || homedir();
+
+module.exports = {
+  apps: [
+    {
+      name: "commhub-hub",
+      script: join(home, ".local/bin/hub-daemon.sh"),
+      cwd: join(home, ".commhub"),
+      interpreter: "bash",
+      exec_mode: "fork",
+      autorestart: true,
+      min_uptime: 20_000,
+      max_restarts: 20,
+      exp_backoff_restart_delay: 200,
+    },
+  ],
+};

--- a/deploy/hub/hub-daemon.sh
+++ b/deploy/hub/hub-daemon.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# CommHub 生产中枢启动脚本（供 pm2 守护）
+#
+# 由来：hub 是全军团单点，此前是裸 nohup 进程 + cron 看门狗。
+# 2026-07-29 09:46 被误杀后 95 个 agent 掉线，只能靠人巡检发现。
+# dashboard 有 pm2 所以同类事故能自愈，hub 反而没有 —— 这是结构性缺陷。
+#
+# 本脚本同时修掉一个潜伏更久的问题：
+#   原 start-hub.sh 用 `bunx --bun @sleep2agi/commhub-server@<版本>`，
+#   实际执行的二进制落在 /tmp/bunx-1000-.../node_modules/.bin/commhub-server。
+#   **生产中枢在从 /tmp 里跑。** 任何 /tmp 清理都会让下一次启动直接失败，
+#   而"当前进程还活着"完全掩盖这一点（同 dashboard 那次 /tmp/dash-start.sh）。
+#   这里改为跑 ~/.commhub/runtime 下的固化安装，不在启动路径上碰网络和 /tmp。
+#
+# 设计约束：
+#   1. 缺 vault 密钥 → 拒绝启动（fail-closed）。带着空密钥起来会让密文静默解不开，
+#      比起不来更难查。
+#   2. 端口已被监听 → 拒绝启动。绝不允许第二个 hub 抢同一个 DB。
+#   3. 预检失败一律"慢速失败"，给 pm2 退避留时间，不要空转锤日志。
+#   4. 端口/DB 可由环境变量覆盖 —— 这样旁路验证跑的是**同一个脚本**，
+#      而不是一个长得像它的副本（否则验证等于没验证）。
+
+set -uo pipefail
+
+# 版本切换点。回滚就是把这一行指回上一个 runtime-vNN 目录并重启 —— 旧目录保留不删。
+# 2026-07-30 06:1x: runtime-v22 → runtime-v23
+#   内容 = #500 文件下载归属校验（P0 活漏洞）+ #497 节点属性 + #502/#504 回复规则
+# 2026-07-30 09:5x: runtime-v23 → runtime-v24
+#   内容 = #505 /health 的 sse_sessions 按 network_members 租户隔离
+#          修的是我关 #473 泄漏时造成的回归：dashboard 整页显示 197 节点全离线
+#   回滚目标 = runtime-v23（0.9.0-preview.23），目录仍在
+# 2026-07-30 11:3x: runtime-v24 → runtime-v25（0.9.0-preview.25）
+#   内容 = #509/#510 文件下载改用索引里记的 date_bucket，不再用运行时时钟
+#          症状：blob 按 uploads/YYYY-MM-DD/ 分目录存，读的时候却拿「今天」去拼路径，
+#          于是**过了午夜，前一天上传的文件全部 404**。Vincent 那个 PPT 打不开、
+#          大小异常，就是客户端把 404 的响应体当成文件存下来了。
+#   证据链 = 独立验证者在 oven/bun:1.2.22 容器里跑打包产物：前置门 + Door 3 + Door 4 全过；
+#            被验 SHA c9e0aff6 与 main 上 squash 后的 781df0e8 tree 完全相同
+#            (4a29701545fd60d80537f84a9954d984dadeb530)，所以验的就是这份代码
+#   回滚目标 = runtime-v24（0.9.0-preview.24），目录仍在
+# 2026-08-01 02:1x: runtime-v25 → runtime-v26（0.9.0-preview.26；#550 avatar 同源相对路径校验放宽 /avatars/<name>.<ext>）
+#   旁路验证 :9226 独立 COMMHUB_DB=/tmp 六用例全过（相对/绝对/js:/protocol-rel/traversal/null）
+#   回滚目标 = runtime-v25（0.9.0-preview.25），目录仍在
+# 2026-08-04 07:5x: runtime-v26 → runtime-v27-dashboard-delivery-bb41d94f
+#   内容 = #571 REST 身份绑定 + #575 durable idempotency + #577 Dashboard→Codex TUI auth stamp/steer
+#   证据 = Test584 Docker PASS；高位端口实跑 ntok spoof=403、同 client_request_id 仅一行
+#   回滚目标 = runtime-v26（0.9.0-preview.26），脚本备份 hub-daemon.sh.before-dashboard-delivery-20260804
+
+# 2026-08-11: runtime-v32-run-terminal-d5199bc9 → runtime-v33-upload-bridge-17b8223f
+#   内容 = #693 agent controlled local upload → Hub file_id bridge (Vincent GO)
+#   回滚目标 = runtime-v32-run-terminal-d5199bc9，目录仍在；hub-daemon 备份见 rollback-693-*
+# 2026-08-13 00:5x: runtime-v33 → runtime-v34-preview29(0.9.0-preview.29;含 #698 peer-reply 终结原任务、#697 model 注入)
+#   回滚目标 = runtime-v33-upload-bridge-17b8223f(0.9.0-preview.27),目录仍在
+RUNTIME_DIR="$HOME/.commhub/runtime-v34-preview29"
+ENTRY="$RUNTIME_DIR/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
+ENV_FILE="${HUB_ENV_FILE:-$HOME/.commhub/hub.env}"
+# bun 解析：显式路径优先，其次走 PATH。
+# 注意 bun 是通过 nvm 下的 npm 装的，路径里带 node 版本号
+# (~/.nvm/versions/node/vX/bin/bun) —— **升级 node 会让这个路径失效**。
+# 所以不硬编死一个路径，找不到就 fail-closed 报出来，而不是静默起不来。
+_resolve_bun() {
+  [ -n "${BUN_BIN:-}" ] && { echo "$BUN_BIN"; return; }
+  local nvm_bun="$HOME/.nvm/versions/node/v20.20.0/bin/bun"
+  [ -x "$nvm_bun" ] && { echo "$nvm_bun"; return; }
+  command -v bun 2>/dev/null && return
+  # 兜底：扫 nvm 下任意 node 版本里的 bun，容忍 node 升级
+  local found
+  found=$(ls -1 "$HOME"/.nvm/versions/node/*/bin/bun 2>/dev/null | tail -1)
+  [ -n "$found" ] && echo "$found"
+}
+BUN_BIN="$(_resolve_bun)"
+
+# 可覆盖，默认即生产值
+export HOST="${HOST:-0.0.0.0}"
+export PORT="${PORT:-9200}"
+
+log() { echo "[hub-daemon $(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+fail_slow() {
+  log "🔴 预检失败：$*"
+  log "不启动。修好后 pm2 会自动重试。"
+  sleep 30
+  exit 1
+}
+
+# --- 预检 1：bun 可执行 ---
+[ -x "$BUN_BIN" ] || fail_slow "找不到 bun：$BUN_BIN"
+
+# --- 预检 2：固化安装存在（不依赖 /tmp、不依赖启动时联网）---
+[ -f "$ENTRY" ] || fail_slow "固化安装缺失：$ENTRY（在 $RUNTIME_DIR 跑 npm install 重建）"
+
+# --- 预检 3：vault 密钥必须存在且非空（fail-closed）---
+[ -f "$ENV_FILE" ] || fail_slow "缺少 $ENV_FILE，无法取得 vault 密钥"
+if ! grep -q '^ANET_HUB_SECRET_VAULT_KEY=.\+' "$ENV_FILE"; then
+  fail_slow "$ENV_FILE 里没有非空的 ANET_HUB_SECRET_VAULT_KEY"
+fi
+
+# --- 预检 4：端口必须没人监听，否则会起出第二个 hub 抢同一个 DB ---
+#
+# 🔴 这道门原本写成 `ss -tln 2>/dev/null | grep -q ...`，是**fail-open** 的：
+#    ss 不在 PATH 时，`2>/dev/null` 把 "command not found" 吞掉 → 管道里是空输出
+#    → grep 不匹配 → 判定"端口空闲" → 照常放行启动。
+#    **这道门唯一的目的就是不许起第二个 hub 抢同一个 DB，静默失效正好把它废掉。**
+#    独立复核实测：端口明明被占，脚本仍打印"预检通过"并 exec（生产当前 PATH 不触发，
+#    风险在换机 / 换基础镜像 / PATH 被精简的 spawn 环境）。
+#    改法：显式解析 ss，找不到就 fail-closed，而不是当作"端口空闲"。
+# SS_BIN 可由环境变量覆盖，理由同 PORT/DB：旁路验证必须跑**这个脚本本身**。
+#
+# 🔴 显式覆盖必须是权威的，不能再回退。
+#    第一版写成「覆盖了但不可执行 → 回退 /usr/bin/ss」，结果是：
+#    我拿 SS_BIN=/nonexistent/ss 去验"ss 缺失会不会 fail-closed"，
+#    脚本默默回退到真的 ss，打印"预检通过"—— **我根本没测到那条分支，
+#    却差点当成验过了。** 一道无法被转红的门，等于没验过。
+#    顺带这也是更正确的行为：被静默忽略的显式覆盖本身就是个陷阱。
+if [ -n "${SS_BIN:-}" ]; then
+  [ -x "$SS_BIN" ] || fail_slow "显式指定的 SS_BIN 不可执行：$SS_BIN（不回退，拒绝在看不见端口的情况下启动）"
+else
+  SS_BIN="$(command -v ss 2>/dev/null || true)"
+  [ -x "$SS_BIN" ] || SS_BIN=/usr/bin/ss
+  [ -x "$SS_BIN" ] || fail_slow "找不到 ss，无法判断端口是否被占用 —— 拒绝在看不见的情况下启动"
+fi
+if "$SS_BIN" -tln 2>/dev/null | grep -q ":${PORT}[[:space:]]"; then
+  fail_slow "端口 ${PORT} 已被监听 —— 已有 hub 在跑，拒绝启动第二个"
+fi
+
+# 载入密钥。用 set -a 而非 export $(...)：后者在 grep 没命中时会裸 export 整个环境。
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+log "预检通过：entry=${ENTRY}"
+log "监听 ${HOST}:${PORT}，DB=${COMMHUB_DB:-<默认 ~/.commhub/commhub.db>}"
+
+exec "$BUN_BIN" "$ENTRY"

--- a/docs/tests/report-test735-hub-daemon-rebuild.txt
+++ b/docs/tests/report-test735-hub-daemon-rebuild.txt
@@ -1,0 +1,59 @@
+Test 735 — production Hub launcher Git authority and rebuild gate
+================================================================
+Captured: 2026-08-12T18:59:49Z
+
+Coordinates
+-----------
+SOURCE_COMMIT=83fe6c1fb4583e65787358c5502d6c0c62021964
+Base=c7ac3c200bc067a1512d84885c743cd2f31c7e80
+Image=sha256:0dfd45d3171bb6479dca9b2db35cced1e7e03ebfce51b104190329239d36da71
+Image label org.opencontainers.image.revision=83fe6c1fb4583e65787358c5502d6c0c62021964
+Exact runner log SHA256=3c2dc0e9870e8447f1e869de3fc8ea6c793fc7fc9729a5eaec37e9271706b593
+
+Live-to-Git capture
+-------------------
+At capture time, the production deployment copy
+`/home/vansin/.local/bin/hub-daemon.sh` and the new Git authority
+`deploy/hub/hub-daemon.sh` were byte-identical:
+
+  SHA256 34c66d06ff3ab15538d2debb203b6a8b88277dab7b15ad1c5e6fff72cd1024d4
+
+This is a read-only capture. The production launcher, PM2 process, runtime,
+database, and secrets were not changed.
+
+Docker gate
+-----------
+The suite ran as a non-root user in `node:22-bookworm-slim` and exercised the
+real launcher against isolated fake runtime, env, bun, socket inspection, and
+port state. It verified:
+
+- success starts the pinned sibling runtime with the requested host/port;
+- a missing vault key is rejected before bun starts;
+- missing runtime, missing explicit `ss`, missing bun, and occupied port fail;
+- the checked-in PM2 definition retains the captured non-secret process shape;
+- deleting the vault-key gate is a byte-changing witnessed-red mutation.
+
+Exact output:
+
+  L1 HUB_DAEMON_REBUILD_PASS
+  MUTATION_RED vault-gate-removed
+  RESULT: PASS
+
+Image-to-source provenance
+--------------------------
+Files copied back out of the exact image matched `git show SOURCE_COMMIT:<path>`
+byte for byte:
+
+  MATCH 34c66d06ff3ab15538d2debb203b6a8b88277dab7b15ad1c5e6fff72cd1024d4 deploy/hub/hub-daemon.sh
+  MATCH 650b3e1364e6a077d88312c00641bff7202773f33ff9a7c8fc034f1e1add95d5 deploy/hub/ecosystem.config.cjs
+  MATCH c8d821b824969b58a7dc68d6fa4825dde827b0b275ed480f7ddaf1b56786d642 tests/test735-hub-daemon-rebuild/run.sh
+
+Honest limits
+-------------
+- No production deployment or PM2 restart was performed.
+- No live database restore or full empty-host recovery was performed.
+- Database contents are backup material, not Git-reproducible source.
+- The vault-key value is intentionally absent from Git. The exact encrypted
+  backup/vault record name remains NOT COVERED and must be supplied by owner.
+- The Docker test proves launcher behavior and process-definition shape; it
+  does not claim that `pm2 online` alone proves a restored Hub is usable.

--- a/tests/test735-hub-daemon-rebuild/Dockerfile
+++ b/tests/test735-hub-daemon-rebuild/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:22-bookworm-slim
+
+ARG SOURCE_COMMIT=dev
+LABEL org.opencontainers.image.revision=$SOURCE_COMMIT
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash coreutils grep \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --shell /bin/bash tester
+
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
+COPY deploy/hub/hub-daemon.sh /app/deploy/hub/hub-daemon.sh
+COPY deploy/hub/ecosystem.config.cjs /app/deploy/hub/ecosystem.config.cjs
+COPY tests/test735-hub-daemon-rebuild/run.sh /app/run.sh
+RUN chmod 0755 /app/deploy/hub/hub-daemon.sh /app/run.sh
+
+USER tester
+ENV HOME=/home/tester
+WORKDIR /app
+CMD ["bash", "/app/run.sh"]

--- a/tests/test735-hub-daemon-rebuild/run.sh
+++ b/tests/test735-hub-daemon-rebuild/run.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+set -euo pipefail
+
+source /lib/safe-rm.sh
+
+SCRIPT=/app/deploy/hub/hub-daemon.sh
+ROOT="/tmp/test735-$$"
+trap 'safe_rm_rf "$ROOT"' EXIT
+
+new_fixture() {
+  local name="$1"
+  local dir="$ROOT/$name"
+  safe_rm_rf "$dir"
+  mkdir -p \
+    "$dir/home/.commhub/runtime-v34-preview29/node_modules/@sleep2agi/commhub-server/bin" \
+    "$dir/fake-bin"
+  : > "$dir/home/.commhub/runtime-v34-preview29/node_modules/@sleep2agi/commhub-server/bin/commhub.ts"
+  printf 'ANET_HUB_SECRET_VAULT_KEY=test-fixture-only\n' > "$dir/hub.env"
+
+  cat > "$dir/fake-bin/bun" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" > "$FAKE_BUN_LOG"
+test "${ANET_HUB_SECRET_VAULT_KEY:-}" = test-fixture-only
+EOF
+  cat > "$dir/fake-bin/ss" <<'EOF'
+#!/bin/bash
+if [ "${FAKE_SS_OCCUPIED:-0}" = 1 ]; then
+  printf 'LISTEN 0 128 0.0.0.0:%s 0.0.0.0:*\n' "$PORT"
+fi
+EOF
+  cat > "$dir/fake-bin/sleep" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+  chmod 0755 "$dir/fake-bin/bun" "$dir/fake-bin/ss" "$dir/fake-bin/sleep"
+  printf '%s\n' "$dir"
+}
+
+invoke() {
+  local script="$1"
+  local dir="$2"
+  shift 2
+  env \
+    HOME="$dir/home" \
+    PATH="$dir/fake-bin:/usr/bin:/bin" \
+    BUN_BIN="${BUN_BIN_OVERRIDE:-$dir/fake-bin/bun}" \
+    SS_BIN="${SS_BIN_OVERRIDE:-$dir/fake-bin/ss}" \
+    FAKE_SS_OCCUPIED="${FAKE_SS_OCCUPIED:-0}" \
+    HUB_ENV_FILE="$dir/hub.env" \
+    FAKE_BUN_LOG="$dir/bun.log" \
+    HOST=127.0.0.1 \
+    PORT=19299 \
+    COMMHUB_DB="$dir/verify.db" \
+    "$@" \
+    bash "$script" > "$dir/output.log" 2>&1
+}
+
+assert_success_path() {
+  local script="$1"
+  local dir
+  dir="$(new_fixture success)"
+  invoke "$script" "$dir"
+  test -s "$dir/bun.log"
+  grep -Fq "$dir/home/.commhub/runtime-v34-preview29/node_modules/@sleep2agi/commhub-server/bin/commhub.ts" "$dir/bun.log"
+  grep -Fq '预检通过' "$dir/output.log"
+  grep -Fq '监听 127.0.0.1:19299' "$dir/output.log"
+}
+
+assert_missing_secret_rejected() {
+  local script="$1"
+  local dir rc
+  dir="$(new_fixture missing-secret)"
+  : > "$dir/hub.env"
+  set +e
+  invoke "$script" "$dir"
+  rc=$?
+  set -e
+  test "$rc" -ne 0
+  test ! -e "$dir/bun.log"
+  grep -Fq '没有非空的 ANET_HUB_SECRET_VAULT_KEY' "$dir/output.log"
+}
+
+assert_missing_runtime_rejected() {
+  local script="$1"
+  local dir rc
+  dir="$(new_fixture missing-runtime)"
+  safe_rm_rf "$dir/home/.commhub/runtime-v34-preview29"
+  set +e
+  invoke "$script" "$dir"
+  rc=$?
+  set -e
+  test "$rc" -ne 0
+  test ! -e "$dir/bun.log"
+  grep -Fq '固化安装缺失' "$dir/output.log"
+}
+
+assert_missing_ss_rejected() {
+  local script="$1"
+  local dir rc
+  dir="$(new_fixture missing-ss)"
+  set +e
+  SS_BIN_OVERRIDE="$dir/does-not-exist" invoke "$script" "$dir"
+  rc=$?
+  set -e
+  test "$rc" -ne 0
+  test ! -e "$dir/bun.log"
+  grep -Fq '显式指定的 SS_BIN 不可执行' "$dir/output.log"
+}
+
+assert_occupied_port_rejected() {
+  local script="$1"
+  local dir rc
+  dir="$(new_fixture occupied-port)"
+  set +e
+  FAKE_SS_OCCUPIED=1 invoke "$script" "$dir"
+  rc=$?
+  set -e
+  test "$rc" -ne 0
+  test ! -e "$dir/bun.log"
+  grep -Fq '端口 19299 已被监听' "$dir/output.log"
+}
+
+assert_missing_bun_rejected() {
+  local script="$1"
+  local dir rc
+  dir="$(new_fixture missing-bun)"
+  set +e
+  BUN_BIN_OVERRIDE="$dir/does-not-exist" invoke "$script" "$dir"
+  rc=$?
+  set -e
+  test "$rc" -ne 0
+  test ! -e "$dir/bun.log"
+  grep -Fq '找不到 bun' "$dir/output.log"
+}
+
+assert_ecosystem_shape() {
+  node - <<'EOF'
+const config = require("/app/deploy/hub/ecosystem.config.cjs");
+const app = config.apps?.[0];
+if (!app || app.name !== "commhub-hub") process.exit(1);
+if (app.script !== "/home/tester/.local/bin/hub-daemon.sh") process.exit(1);
+if (app.cwd !== "/home/tester/.commhub") process.exit(1);
+if (app.interpreter !== "bash" || app.exec_mode !== "fork") process.exit(1);
+if (app.autorestart !== true || app.min_uptime !== 20_000 || app.max_restarts !== 20) process.exit(1);
+if (app.exp_backoff_restart_delay !== 200) process.exit(1);
+EOF
+}
+
+run_suite() {
+  local script="$1"
+  bash -n "$script"
+  assert_success_path "$script"
+  assert_missing_secret_rejected "$script"
+  assert_missing_runtime_rejected "$script"
+  assert_missing_ss_rejected "$script"
+  assert_occupied_port_rejected "$script"
+  assert_missing_bun_rejected "$script"
+  assert_ecosystem_shape
+}
+
+run_suite "$SCRIPT"
+echo 'L1 HUB_DAEMON_REBUILD_PASS'
+
+MUTANT="$ROOT/hub-daemon-no-vault-gate.sh"
+cp "$SCRIPT" "$MUTANT"
+before="$(sha256sum "$MUTANT" | cut -d' ' -f1)"
+sed -i "s/if ! grep -q '\^ANET_HUB_SECRET_VAULT_KEY=.\\+' \"\$ENV_FILE\"; then/if false; then/" "$MUTANT"
+after="$(sha256sum "$MUTANT" | cut -d' ' -f1)"
+test "$before" != "$after" || { echo 'MUTATION_NOOP vault-gate-removed'; exit 1; }
+
+if assert_missing_secret_rejected "$MUTANT"; then
+  echo 'MUTATION_SURVIVED vault-gate-removed'
+  exit 1
+fi
+echo 'MUTATION_RED vault-gate-removed'
+echo 'RESULT: PASS'


### PR DESCRIPTION
Closes #735.

## Scope

- versions the byte-identical production Hub launcher at `deploy/hub/hub-daemon.sh`;
- adds the non-secret PM2 process definition and an empty-host recovery runbook;
- adds a non-root Docker behavior gate with a witnessed-red vault-gate mutation;
- records exact, report-only evidence without changing production.

## Frozen coordinates

- source: `83fe6c1fb4583e65787358c5502d6c0c62021964`
- report-only: `ecbc8acc7ee89726c3dfe3ef5c9056126a1cb8e6`
- base at source creation: `c7ac3c200bc067a1512d84885c743cd2f31c7e80`
- exact image: `sha256:0dfd45d3171bb6479dca9b2db35cced1e7e03ebfce51b104190329239d36da71`
- runner log SHA256: `3c2dc0e9870e8447f1e869de3fc8ea6c793fc7fc9729a5eaec37e9271706b593`

The image label pins the full source commit. Three files copied back from the
image matched source byte-for-byte. The production deployment copy and Git
launcher both had SHA256
`34c66d06ff3ab15538d2debb203b6a8b88277dab7b15ad1c5e6fff72cd1024d4`
at capture time.

## Gate

```text
L1 HUB_DAEMON_REBUILD_PASS
MUTATION_RED vault-gate-removed
RESULT: PASS
```

## Recovery boundary

Git contains the launcher, non-secret process shape, and recovery procedure.
It intentionally does not contain the Hub vault key or SQLite contents. The
database must come from a consistent backup or nodes must be re-registered.
The exact encrypted backup/vault record name is explicitly `NOT COVERED`.

No production file, PM2 process, runtime, database, or secret was changed.
Current-main virtual merge-tree was conflict-free before push.
