### PR TITLE
test(opencode): #739 覆盖 cwd 在包信任判定中的作用(含 mutation 证据,不含修复)

### DIFF
--- a/agent-network/src/opencode-package-binary.test.ts
+++ b/agent-network/src/opencode-package-binary.test.ts
@@ -190,3 +190,68 @@ describe("validateOpencodePackageBinary", () => {
     })).toThrow("unsafe file ownership or mode");
   });
 });
+
+// #739 — cwd 参与信任判定,而这一点此前没有任何测试覆盖。
+//
+// 🔴 本 describe 里带「缺陷现状」标记的断言记录的是**当前行为,不是期望行为**。
+//    修 #739 时它们应当转红 —— 那正是它们存在的意义:让修复有一个红→绿的信号,
+//    而不是靠人回来重读 issue。
+//
+// 实测复现(同一容器镜像,只改 cwd,包/版本/PATH/二进制路径全部相同):
+//   cwd=/            ❌ project/node-local opencode-ai package payload is not trusted
+//   cwd=/usr/local   ❌ 同上
+//   cwd=/tmp         ✅ smoke passed
+//   cwd=/root        ✅ smoke passed
+describe("#739 cwd 参与信任判定", () => {
+  test("缺陷现状:cwd 为文件系统根时,禁止根含 / —— 与任何包路径都重叠", () => {
+    // 机制层面的事实:discoverOpencodeForbiddenRoots 无条件把 cwd 本身放进结果集。
+    expect(discoverOpencodeForbiddenRoots("/")).toContain("/");
+  });
+
+  test("缺陷现状:cwd=/ 时,一个各方面都合法的包也会被拒", () => {
+    const fixture = makePackage(safeTestBase());
+
+    // 基线对照 —— 先证明这个 fixture 本身是可信的,否则下面的红是无意义的:
+    // 如果它本来就不合法,再怎么改 forbiddenRoots 都会失败,断言就成了同义反复。
+    expect(validateOpencodePackageBinary(fixture.binary, {
+      expectedVersion: "1.18.1",
+    })).toBe(fixture.binary);
+
+    // 只多传一个 forbiddenRoots: ["/"],同一个 fixture 就被拒了。
+    // 变量只有这一个,所以拒因确实来自 cwd,不是来自包本身。
+    expect(() => validateOpencodePackageBinary(fixture.binary, {
+      expectedVersion: "1.18.1",
+      forbiddenRoots: ["/"],
+    })).toThrow("project/node-local");
+  });
+
+  test("缺陷现状:cwd 是全局安装前缀的祖先时,全局安装的包被判成项目本地", () => {
+    // 复刻 `npm i -g` 的形状:<prefix>/lib/node_modules/opencode-ai,
+    // 而用户恰好在 <prefix> 或其祖先下执行 anet(容器里 cwd=/usr/local 就是这种)。
+    const prefix = join(safeTestBase(), "usr-local");
+    mkdirSync(join(prefix, "lib"), { recursive: true, mode: 0o755 });
+    const fixture = makePackage(join(prefix, "lib"));
+
+    expect(validateOpencodePackageBinary(fixture.binary, {
+      expectedVersion: "1.18.1",
+    })).toBe(fixture.binary);
+
+    expect(() => validateOpencodePackageBinary(fixture.binary, {
+      expectedVersion: "1.18.1",
+      forbiddenRoots: [prefix],
+    })).toThrow("project/node-local");
+  });
+
+  test("这条守卫要防的东西必须继续被防住(修 #739 时不许放宽它)", () => {
+    // 这一条**不是**缺陷现状,是必须永远为真的安全属性:
+    // checkout 里放一个同版本的 opencode-ai 冒充者,必须被拒。
+    // 任何针对 #739 的放宽如果让这条转绿→红,那个修法就是错的。
+    const project = join(safeTestBase(), "project");
+    mkdirSync(project, { mode: 0o700 });
+    const impostor = makePackage(project);
+    expect(() => validateOpencodePackageBinary(impostor.binary, {
+      expectedVersion: "1.18.1",
+      forbiddenRoots: [project],
+    })).toThrow("project/node-local");
+  });
+});


### PR DESCRIPTION
把 #739 的复现从我的会话里搬进仓库 —— 它此前只活在一次性的容器实验里。

## 这个模块此前的覆盖缺口

`opencode-package-binary.test.ts` 原有 9 条测试,覆盖得相当扎实:
同版本冒充者、monorepo 边界、`./bin` 两种拼写、伪造 metadata、world-writable、符号链接 package.json。

**但没有任何一条覆盖 cwd** —— 而 cwd 恰恰参与信任判定(`discoverOpencodeForbiddenRoots(cwd)`
无条件把 cwd 本身放进禁止根)。这就是 #739 能一直存在的原因。

## 新增 4 条

3 条标记为**「缺陷现状」**:它们记录的是当前行为,**不是期望行为**。

> 修 #739 时它们应当转红。那正是它们存在的意义 —— 让修复有一个红→绿的信号,
> 而不是靠人回来重读 issue 才知道自己改对了没有。

第 4 条**不是**缺陷现状,是必须永远为真的安全属性:checkout 里的同版本 `opencode-ai`
冒充者必须被拒。**任何针对 #739 的放宽如果让这条转红,那个修法就是错的。**
这条守卫防的是「同版本凭据窃取 shim 抢在 PATH 前面」,不能为了修 cwd 把它一起放掉。

## mutation 证据

绿本身不是证据,所以做了两次解耦 mutation:

| mutation | 结果 |
|---|---|
| A:去掉 `new Set([start])` 里的 `start`(即「cwd 不再无条件进禁止根」) | **2 fail** —— 新增第 1 条 + 一条既有 |
| B:`pathsOverlap` 恒 `false`(即守卫失效) | **6 fail** —— 新增第 2/3/4 条 + 三条既有 |
| 还原 | **13 pass / 0 fail** |

两次 mutation 注入前都先核过 **diff 非空**(A=4 行,B=3 行),
避免 sed 目标不存在导致的 no-op 假红;B 用 python 定位函数体并断言目标存在,找不到就直接停。

## 基线对照

第 2/3 条各自先证明**同一个 fixture 在不传 `forbiddenRoots` 时是可信的**,
再只多传一个 `forbiddenRoots` 让它转红。**变量只有这一个**,
所以拒因确实来自 cwd,而不是 fixture 本身有问题 —— 否则断言就成了同义反复。

## 不包含什么

**没有修 #739。** 收紧到什么程度是安全取舍,方向写在 issue 里,归属 owner。
这个 PR 只保证:那个修法落地时,有一组会说话的测试在等着它。
