### PR TITLE
ops: version PM2 fleet boot authority

### DIFF
--- a/agent-network/scripts/README.md
+++ b/agent-network/scripts/README.md
@@ -11,7 +11,7 @@ The startup recipe for an opencode agent-node under pm2 supervision. Source of t
 
 `opencode-node-start.sh` here is **the source of truth**. Reviews land against this copy. But **pm2 references** `/home/vansin/.local/bin/opencode-node-start.sh`, **not this file**.
 
-The reason ([issue #526 same class](../../docs/tests/p-526-rename-ghost-harness/README.md), same lesson): any pm2/systemd/cron path that points inside a git worktree becomes a booby trap. When the branch merges, the worktree is cleaned; the reference goes dead; the daemon fails silently on next restart (`pm2 list` still shows the app). We put the *runtime* copy at `~/.local/bin/` alongside the other host daemons (`dash-start.sh`, `hub-daemon.sh`, `pm2-fleet-boot.sh`) so this class of failure is out of scope.
+The reason ([issue #526 same class](../../docs/tests/p-526-rename-ghost-harness/README.md), same lesson): any pm2/systemd/cron path that points inside a git worktree becomes a booby trap. When the branch merges, the worktree is cleaned; the reference goes dead; the daemon fails silently on next restart (`pm2 list` still shows the app). We put the *runtime* copy at `~/.local/bin/` alongside the other host daemons (`dash-start.sh`, `hub-daemon.sh`, `pm2-fleet-boot.sh`) so this class of failure is out of scope. Their Git authorities live under `deploy/`; the fleet boot chain and its data/secret boundary are documented in [`deploy/fleet/README.md`](../../deploy/fleet/README.md).
 
 ## Install / upgrade
 

--- a/deploy/fleet/README.md
+++ b/deploy/fleet/README.md
@@ -95,6 +95,11 @@ and unit, verify their hashes, `daemon-reload`, and rerun the same behavior
 checks. Never use `pm2 kill`, broad `pkill`, or an `ExecStop` that tears down the
 whole fleet as a rollback shortcut.
 
+The checked-in launcher deliberately fails closed when `pm2 jlist` fails or
+returns malformed JSON. It must never translate an unknown PM2 state into an
+empty fleet and call `resurrect`; issue #742 records the captured production
+defect that led to this guard.
+
 ## Honest status
 
 The boot script behavior is exercised by the Docker gate in

--- a/deploy/fleet/README.md
+++ b/deploy/fleet/README.md
@@ -1,0 +1,103 @@
+# PM2 fleet boot — Git authority and recovery boundary
+
+This directory versions the non-secret boot chain that was previously present
+only on the production host:
+
+```text
+systemd --user pm2-fleet.service
+  -> ~/.local/bin/pm2-fleet-boot.sh
+  -> pm2 resurrect (only when the live PM2 list is empty)
+```
+
+The host files are deployment copies. The files here are the reviewable Git
+authority. Installing them does **not** authorize a restart or a fleet upgrade.
+
+## Install the software-side boot chain
+
+The current production recipe is deliberately pinned to user `vansin`, NVM
+Node `v20.20.0`, and its PM2 binary. A different recovery user or Node layout
+requires an explicit reviewed change; do not silently rewrite paths during an
+incident.
+
+```bash
+install -d -m 700 "$HOME/.local/bin" "$HOME/.config/systemd/user"
+install -m 755 deploy/fleet/pm2-fleet-boot.sh \
+  "$HOME/.local/bin/pm2-fleet-boot.sh"
+install -m 644 deploy/fleet/pm2-fleet.service \
+  "$HOME/.config/systemd/user/pm2-fleet.service"
+
+test "$(git hash-object deploy/fleet/pm2-fleet-boot.sh)" = \
+     "$(git hash-object "$HOME/.local/bin/pm2-fleet-boot.sh")"
+systemd-analyze --user verify "$HOME/.config/systemd/user/pm2-fleet.service"
+systemctl --user daemon-reload
+systemctl --user enable pm2-fleet.service
+loginctl show-user "$USER" -p Linger
+```
+
+Do not start the unit until the process inventory and recovery inputs below are
+ready. `RemainAfterExit=yes` means an active/exited unit only proves that the
+oneshot completed once; it does not prove every PM2 app is healthy.
+
+## `dump.pm2` is sensitive backup state, not Git configuration
+
+PM2's generated `~/.pm2/dump.pm2` contains much more than app names and script
+paths. It can persist the daemon's inherited environment, including
+secret-bearing variables. Therefore:
+
+- never commit, paste, or attach the dump to a public issue;
+- store it only as an encrypted owner-controlled backup with restrictive file
+  permissions;
+- restore secret values from their vault/owner source, never from Git;
+- after recovery, recreate apps from their repository authorities where
+  possible, complete behavior checks, and only then run `pm2 save`.
+
+The exact encrypted backup record name for the dump and node configs is
+**NOT COVERED**. Until an owner supplies it, Git-only recovery is incomplete.
+
+## Current non-secret inventory
+
+[`process-inventory.json`](./process-inventory.json) records the five captured
+PM2 app names and their authority status without copying args, environment, or
+tokens. It is a review inventory, not an executable secret store.
+
+- Hub and Dashboard launchers belong to this repository.
+- The representative OpenCode node has a repository process recipe, but its
+  identity, token, node config, and session state require encrypted backup or
+  fresh registration.
+- `weixin-listen` and `weixin-admin` point outside this repository. Their exact
+  repository and build commit are **NOT COVERED**; do not claim full fleet
+  reconstruction until that ownership link is filled.
+
+## Recovery and verification order
+
+1. Install the pinned Node/PM2 version and the files above.
+2. Restore each service from its listed repository authority. Restore data and
+   node identity only from approved encrypted backups, or re-register cleanly.
+3. Create/start one app at a time from its ecosystem definition. Do not import
+   an unreviewed historical dump merely because it exists.
+4. Verify real behavior: Hub health and session count; Dashboard external route
+   and version; node identity plus a routed task/reply; external service owner
+   checks. `pm2 online` alone is insufficient.
+5. Run `pm2 save`, record its encrypted-backup coordinate, then start/enable
+   the bootstrap unit.
+6. Re-run the behavior checks after a controlled PM2 daemon restart before
+   declaring the recovery exercised.
+
+## Upgrade and rollback
+
+Before changing any runtime, record per app: current package/runtime version,
+launcher/config path, PID, and behavior result. Upgrade no more than ten nodes
+per batch. If a node does not resume heartbeat within ten minutes, stop the
+batch and restore its prior runtime/launcher while preserving config/session.
+
+The boot-chain rollback is byte-based: restore the prior checked-in launcher
+and unit, verify their hashes, `daemon-reload`, and rerun the same behavior
+checks. Never use `pm2 kill`, broad `pkill`, or an `ExecStop` that tears down the
+whole fleet as a rollback shortcut.
+
+## Honest status
+
+The boot script behavior is exercised by the Docker gate in
+`tests/test736-pm2-fleet-rebuild/`. A full empty-host production recovery has
+not been performed. External Weixin authority, secret backup record names, and
+production data restoration remain NOT COVERED.

--- a/deploy/fleet/pm2-fleet-boot.sh
+++ b/deploy/fleet/pm2-fleet-boot.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# 开机把 pm2 军团拉回来（commhub-hub / anet-dashboard / weixin-*）。
+# 由 ~/.config/systemd/user/pm2-fleet.service 调用（user 单元 + linger，无需 sudo）。
+#
+# 🔴 幂等设计：pm2 里已经有进程就直接 no-op 退出。
+#    理由：resurrect 打在活着的 pm2 上可能拉出重复进程，而这些进程占 9200/3001 端口。
+#    有了这个守卫，本单元在任何时刻手动 start 都安全 —— 也才能在不重启整机的前提下真验证。
+set -uo pipefail
+export PATH="/home/vansin/.nvm/versions/node/v20.20.0/bin:$PATH"
+PM2="/home/vansin/.nvm/versions/node/v20.20.0/bin/pm2"
+log() { echo "[pm2-fleet-boot $(date '+%F %T')] $*"; }
+
+n=$("$PM2" jlist 2>/dev/null | "/home/vansin/.nvm/versions/node/v20.20.0/bin/node" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{console.log(JSON.parse(s).length)}catch{console.log(0)}})' 2>/dev/null || echo 0)
+n=${n:-0}
+if [ "$n" -gt 0 ] 2>/dev/null; then
+  log "pm2 已有 $n 个进程在跑 → no-op 退出（不做 resurrect，避免重复拉起占端口）"
+  exit 0
+fi
+DUMP="${PM2_HOME:-$HOME/.pm2}/dump.pm2"
+if [ ! -f "$DUMP" ]; then
+  log "🔴 没有 $DUMP，恢复不出任何东西；需要先在活着的系统上跑一次 pm2 save"
+  exit 1
+fi
+log "pm2 无进程 → resurrect"
+"$PM2" resurrect
+rc=$?
+log "resurrect 退出码 $rc"
+"$PM2" list --no-color 2>/dev/null | sed 's/^/    /'
+exit $rc

--- a/deploy/fleet/pm2-fleet-boot.sh
+++ b/deploy/fleet/pm2-fleet-boot.sh
@@ -10,8 +10,18 @@ export PATH="/home/vansin/.nvm/versions/node/v20.20.0/bin:$PATH"
 PM2="/home/vansin/.nvm/versions/node/v20.20.0/bin/pm2"
 log() { echo "[pm2-fleet-boot $(date '+%F %T')] $*"; }
 
-n=$("$PM2" jlist 2>/dev/null | "/home/vansin/.nvm/versions/node/v20.20.0/bin/node" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{console.log(JSON.parse(s).length)}catch{console.log(0)}})' 2>/dev/null || echo 0)
-n=${n:-0}
+jlist=$("$PM2" jlist 2>/dev/null)
+jlist_rc=$?
+if [ "$jlist_rc" -ne 0 ]; then
+  log "🔴 pm2 jlist 失败（rc=$jlist_rc），无法确认现有进程数；拒绝 resurrect"
+  exit 1
+fi
+n=$(printf '%s' "$jlist" | "/home/vansin/.nvm/versions/node/v20.20.0/bin/node" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const v=JSON.parse(s);if(!Array.isArray(v))throw new Error("not array");process.stdout.write(String(v.length))}catch{process.exit(2)}})')
+parse_rc=$?
+if [ "$parse_rc" -ne 0 ] || ! [[ "$n" =~ ^[0-9]+$ ]]; then
+  log "🔴 pm2 jlist 返回无法解析的进程清单；拒绝 resurrect"
+  exit 1
+fi
 if [ "$n" -gt 0 ] 2>/dev/null; then
   log "pm2 已有 $n 个进程在跑 → no-op 退出（不做 resurrect，避免重复拉起占端口）"
   exit 0

--- a/deploy/fleet/pm2-fleet.service
+++ b/deploy/fleet/pm2-fleet.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=pm2 fleet resurrect (commhub-hub / anet-dashboard / weixin-*)
+Documentation=https://github.com/sleep2agi/agent-network
+# 🔴 这里故意不写 After/Wants=network-online.target：那是 system manager 的
+#    target，user manager 里不存在（`systemctl --user status network-online.target`
+#    → "could not be found"）。写了不报错但是**无效的**，会让人以为有网络就绪
+#    保证。hub 绑 0.0.0.0:9200、dashboard 绑 127.0.0.1:3001，都只需要接口存在
+#    而不需要"网络在线"，所以不需要这个排序；真需要时应在脚本里显式等待。
+After=basic.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=%h/.local/bin/pm2-fleet-boot.sh
+# 🔴 故意不设 ExecStop：systemd 停这个单元时绝不能顺手杀掉整支军团。
+#    pm2 官方生成的单元带 ExecStop=pm2 kill，那是一把上了膛的枪 —— 一次误 stop
+#    就是 hub + dashboard + weixin 全灭。开机拉起是我们要的，拆掉不是。
+TimeoutStartSec=180
+
+[Install]
+WantedBy=default.target

--- a/deploy/fleet/process-inventory.json
+++ b/deploy/fleet/process-inventory.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "captured_at": "2026-08-13",
+  "process_manager": "pm2",
+  "apps": [
+    {
+      "name": "commhub-hub",
+      "kind": "hub",
+      "authority": "deploy/hub/hub-daemon.sh",
+      "recovery_status": "repo-authority-proposed-in-pr-738"
+    },
+    {
+      "name": "anet-dashboard",
+      "kind": "dashboard",
+      "authority": "deploy/dashboard/dash-start.sh",
+      "recovery_status": "repo-authority-present"
+    },
+    {
+      "name": "opencode-node-测试1号",
+      "kind": "agent-node",
+      "authority": "agent-network/scripts/pm2-opencode.config.cjs",
+      "recovery_status": "software-recreatable-node-config-requires-backup-or-registration"
+    },
+    {
+      "name": "weixin-listen",
+      "kind": "external-service",
+      "authority": null,
+      "recovery_status": "not-covered-external-repository-and-commit-unknown"
+    },
+    {
+      "name": "weixin-admin",
+      "kind": "external-service",
+      "authority": null,
+      "recovery_status": "not-covered-external-repository-and-commit-unknown"
+    }
+  ]
+}

--- a/docs/tests/report-test736-pm2-fleet-rebuild.txt
+++ b/docs/tests/report-test736-pm2-fleet-rebuild.txt
@@ -1,23 +1,29 @@
 Test 736 — PM2 fleet boot Git authority and recovery boundary
 ==============================================================
-Captured: 2026-08-12T19:13:31Z
+Captured: 2026-08-12T19:17:14Z
 
 Coordinates
 -----------
 Base=3b03ca117040c21b358fa027092fdf4080ce111c
-SOURCE_COMMIT=d9342bc5eb65496d07e76df4f64846f094e9ea04
-Image=sha256:f85368c9d35427b22b764e3041dfdc236424725565f1bc09f104b32e483d0e0d
-Image label org.opencontainers.image.revision=d9342bc5eb65496d07e76df4f64846f094e9ea04
-Exact runner log SHA256=1f2e8a9b718541812eeac48ec6c59aca21b9e416370ebbf45ebfa220ff62c383
+SOURCE_COMMIT=21f8424e59e745ea549ee23156d8b0375f86cb7c
+Image=sha256:20a747bd2630527f27436bae243185865e418bdb8df51831f2ea95e50f32e8c1
+Image label org.opencontainers.image.revision=21f8424e59e745ea549ee23156d8b0375f86cb7c
+Exact runner log SHA256=bffb6a0b1b68a2e0ebea415a497e94a51b472af7095d560acf9f95c551eaf42e
 
 Read-only production-shape capture
 ----------------------------------
 No process, systemd unit, PM2 state, config, database, or secret was changed.
 
-The production deployment copies and Git authorities were byte-identical at
-capture time:
+The initial captured production launcher and source commit `d9342bc5` were
+byte-identical at SHA256
+`1f80e8c722ab2b2d962e8a080d631a8c9dbf15a0f6a03e4af3b711931b502863`.
+Self-review then proved that malformed/failed `pm2 jlist` was treated as an
+empty daemon and could call `resurrect` over a live fleet (issue #742). The
+frozen source above adds a fail-closed guard and therefore intentionally no
+longer claims launcher byte identity with the undeployed production copy.
 
-  MATCH 1f80e8c722ab2b2d962e8a080d631a8c9dbf15a0f6a03e4af3b711931b502863 deploy/fleet/pm2-fleet-boot.sh
+The production systemd unit and Git authority remained byte-identical:
+
   MATCH 37ec1dcba738180bd4e3fe1f8a04d753ce17f3b1b76a29f006dcb25e424aca13 deploy/fleet/pm2-fleet.service
 
 The user systemd unit was active/exited and enabled, with linger enabled. Its
@@ -39,31 +45,37 @@ an isolated fake PM2 binary and no production credentials. It verified:
 - an already-live PM2 list is a strict no-op even when a dump exists;
 - an empty PM2 list without a dump fails loudly;
 - an empty PM2 list with a dump invokes `resurrect` exactly once;
+- failed or malformed `pm2 jlist` exits non-zero without invoking resurrect;
 - the systemd unit has the captured safe shape and no fleet-wide ExecStop;
 - the inventory has exactly five entries and honestly retains two external
   NOT COVERED authorities;
 - removing the live-fleet no-op guard is a byte-changing witnessed-red
-  mutation that attempts resurrection instead of passing the baseline.
+  mutation that attempts resurrection instead of passing the baseline;
+- converting malformed JSON back into count zero is a second witnessed-red
+  mutation.
 
 Exact result:
 
   L1 PM2_FLEET_REBUILD_PASS
   MUTATION_RED live-fleet-noop-removed
+  MUTATION_RED malformed-jlist-as-empty
   RESULT: PASS
 
 Image-to-source provenance
 --------------------------
 Files copied back from the exact image matched the frozen source byte for byte:
 
-  MATCH 1f80e8c722ab2b2d962e8a080d631a8c9dbf15a0f6a03e4af3b711931b502863 deploy/fleet/pm2-fleet-boot.sh
+  MATCH b1a1aaa78ef735a7f0f904d5abf07a49a88c0c143caa4a54401cd4d9225b0ac3 deploy/fleet/pm2-fleet-boot.sh
   MATCH 37ec1dcba738180bd4e3fe1f8a04d753ce17f3b1b76a29f006dcb25e424aca13 deploy/fleet/pm2-fleet.service
   MATCH 20c1ac2b5854c80272e37fd56659f6d15ce620405b6fbc26791d37b80237f1b5 deploy/fleet/process-inventory.json
-  MATCH f757bf62f6bb4b87ded8611613c31e8fb46133abd1f7db56beb2bdd188f5adf9 tests/test736-pm2-fleet-rebuild/run.sh
+  MATCH 34b6cb14a4d02baa8d3ab1b03c3984d2f4cc006200516a6b5d11774850a92ace tests/test736-pm2-fleet-rebuild/run.sh
 
 Honest limits
 -------------
 - No full empty-host recovery, real systemd start, PM2 daemon restart, node
   restart, or production rollout was performed.
+- The production deployment copy still has the fail-open `jlist` behavior at
+  capture time. Merging this source is not a deployment authorization.
 - `dump.pm2`, node configs/sessions, databases, and secret values are not
   Git-reproducible source. They require approved encrypted backup or fresh
   registration.

--- a/docs/tests/report-test736-pm2-fleet-rebuild.txt
+++ b/docs/tests/report-test736-pm2-fleet-rebuild.txt
@@ -1,0 +1,75 @@
+Test 736 — PM2 fleet boot Git authority and recovery boundary
+==============================================================
+Captured: 2026-08-12T19:13:31Z
+
+Coordinates
+-----------
+Base=3b03ca117040c21b358fa027092fdf4080ce111c
+SOURCE_COMMIT=d9342bc5eb65496d07e76df4f64846f094e9ea04
+Image=sha256:f85368c9d35427b22b764e3041dfdc236424725565f1bc09f104b32e483d0e0d
+Image label org.opencontainers.image.revision=d9342bc5eb65496d07e76df4f64846f094e9ea04
+Exact runner log SHA256=1f2e8a9b718541812eeac48ec6c59aca21b9e416370ebbf45ebfa220ff62c383
+
+Read-only production-shape capture
+----------------------------------
+No process, systemd unit, PM2 state, config, database, or secret was changed.
+
+The production deployment copies and Git authorities were byte-identical at
+capture time:
+
+  MATCH 1f80e8c722ab2b2d962e8a080d631a8c9dbf15a0f6a03e4af3b711931b502863 deploy/fleet/pm2-fleet-boot.sh
+  MATCH 37ec1dcba738180bd4e3fe1f8a04d753ce17f3b1b76a29f006dcb25e424aca13 deploy/fleet/pm2-fleet.service
+
+The user systemd unit was active/exited and enabled, with linger enabled. Its
+shape is oneshot + RemainAfterExit, calls the persistent launcher, and has no
+ExecStop that could tear down the fleet.
+
+The safe PM2 inventory contained five online app names: `commhub-hub`,
+`anet-dashboard`, `opencode-node-测试1号`, `weixin-listen`, and
+`weixin-admin`. Only non-secret names and process-authority paths were captured.
+The generated PM2 dump was not copied: inspection of keys (not values) proved
+that it persists inherited environment fields, including secret-bearing
+variables, so it is sensitive backup state rather than Git configuration.
+
+Docker gate
+-----------
+The exact source ran as non-root user `vansin` in `node:22-bookworm-slim` with
+an isolated fake PM2 binary and no production credentials. It verified:
+
+- an already-live PM2 list is a strict no-op even when a dump exists;
+- an empty PM2 list without a dump fails loudly;
+- an empty PM2 list with a dump invokes `resurrect` exactly once;
+- the systemd unit has the captured safe shape and no fleet-wide ExecStop;
+- the inventory has exactly five entries and honestly retains two external
+  NOT COVERED authorities;
+- removing the live-fleet no-op guard is a byte-changing witnessed-red
+  mutation that attempts resurrection instead of passing the baseline.
+
+Exact result:
+
+  L1 PM2_FLEET_REBUILD_PASS
+  MUTATION_RED live-fleet-noop-removed
+  RESULT: PASS
+
+Image-to-source provenance
+--------------------------
+Files copied back from the exact image matched the frozen source byte for byte:
+
+  MATCH 1f80e8c722ab2b2d962e8a080d631a8c9dbf15a0f6a03e4af3b711931b502863 deploy/fleet/pm2-fleet-boot.sh
+  MATCH 37ec1dcba738180bd4e3fe1f8a04d753ce17f3b1b76a29f006dcb25e424aca13 deploy/fleet/pm2-fleet.service
+  MATCH 20c1ac2b5854c80272e37fd56659f6d15ce620405b6fbc26791d37b80237f1b5 deploy/fleet/process-inventory.json
+  MATCH f757bf62f6bb4b87ded8611613c31e8fb46133abd1f7db56beb2bdd188f5adf9 tests/test736-pm2-fleet-rebuild/run.sh
+
+Honest limits
+-------------
+- No full empty-host recovery, real systemd start, PM2 daemon restart, node
+  restart, or production rollout was performed.
+- `dump.pm2`, node configs/sessions, databases, and secret values are not
+  Git-reproducible source. They require approved encrypted backup or fresh
+  registration.
+- The exact encrypted backup/vault record names remain NOT COVERED.
+- The two Weixin processes point outside this repository; their repository and
+  exact build commit remain NOT COVERED.
+- The Hub launcher authority is separately proposed by PR #738 in this source
+  snapshot. This PR must not claim it is merged until that external state is
+  verified.

--- a/tests/test736-pm2-fleet-rebuild/Dockerfile
+++ b/tests/test736-pm2-fleet-rebuild/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22-bookworm-slim
+
+ARG SOURCE_COMMIT=dev
+LABEL org.opencontainers.image.revision=$SOURCE_COMMIT
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash coreutils jq \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --shell /bin/bash vansin \
+    && mkdir -p /home/vansin/.nvm/versions/node/v20.20.0/bin \
+    && ln -s /usr/local/bin/node /home/vansin/.nvm/versions/node/v20.20.0/bin/node
+
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
+COPY deploy/fleet/pm2-fleet-boot.sh /app/deploy/fleet/pm2-fleet-boot.sh
+COPY deploy/fleet/pm2-fleet.service /app/deploy/fleet/pm2-fleet.service
+COPY deploy/fleet/process-inventory.json /app/deploy/fleet/process-inventory.json
+COPY tests/test736-pm2-fleet-rebuild/run.sh /app/run.sh
+RUN chmod 0755 /app/deploy/fleet/pm2-fleet-boot.sh /app/run.sh \
+    && chown -R vansin:vansin /home/vansin
+
+USER vansin
+ENV HOME=/home/vansin
+WORKDIR /app
+CMD ["bash", "/app/run.sh"]

--- a/tests/test736-pm2-fleet-rebuild/run.sh
+++ b/tests/test736-pm2-fleet-rebuild/run.sh
@@ -16,11 +16,18 @@ install_fake_pm2() {
 set -euo pipefail
 case "${1:-}" in
   jlist)
-    if [ "${FAKE_PM2_COUNT:-0}" -gt 0 ]; then
-      printf '[{"name":"existing"}]\n'
-    else
-      printf '[]\n'
-    fi
+    case "${FAKE_PM2_JLIST_MODE:-valid}" in
+      error) exit 9 ;;
+      malformed) printf '{not-json\n' ;;
+      valid)
+        if [ "${FAKE_PM2_COUNT:-0}" -gt 0 ]; then
+          printf '[{"name":"existing"}]\n'
+        else
+          printf '[]\n'
+        fi
+        ;;
+      *) exit 10 ;;
+    esac
     ;;
   resurrect)
     printf 'resurrect\n' >> "$FAKE_PM2_LOG"
@@ -51,6 +58,7 @@ invoke() {
     PM2_HOME="$dir/pm2" \
     FAKE_PM2_LOG="$dir/pm2.log" \
     FAKE_PM2_COUNT="${FAKE_PM2_COUNT:-0}" \
+    FAKE_PM2_JLIST_MODE="${FAKE_PM2_JLIST_MODE:-valid}" \
     "$@" \
     bash "$script" > "$dir/output.log" 2>&1
 }
@@ -86,6 +94,32 @@ assert_empty_pm2_resurrects_once() {
   grep -Fq 'resurrect 退出码 0' "$dir/output.log"
 }
 
+assert_jlist_error_rejected() {
+  local script="$1" dir rc
+  dir="$(fixture jlist-error)"
+  printf '[]\n' > "$dir/pm2/dump.pm2"
+  set +e
+  FAKE_PM2_JLIST_MODE=error invoke "$script" "$dir"
+  rc=$?
+  set -e
+  test "$rc" -ne 0
+  test ! -e "$dir/pm2.log"
+  grep -Fq '无法确认现有进程数；拒绝 resurrect' "$dir/output.log"
+}
+
+assert_malformed_jlist_rejected() {
+  local script="$1" dir rc
+  dir="$(fixture malformed-jlist)"
+  printf '[]\n' > "$dir/pm2/dump.pm2"
+  set +e
+  FAKE_PM2_JLIST_MODE=malformed invoke "$script" "$dir"
+  rc=$?
+  set -e
+  test "$rc" -ne 0
+  test ! -e "$dir/pm2.log"
+  grep -Fq '无法解析的进程清单；拒绝 resurrect' "$dir/output.log"
+}
+
 assert_unit_shape() {
   grep -Fxq 'Type=oneshot' "$UNIT"
   grep -Fxq 'RemainAfterExit=yes' "$UNIT"
@@ -110,6 +144,8 @@ run_suite() {
   assert_existing_processes_noop "$script"
   assert_missing_dump_fails "$script"
   assert_empty_pm2_resurrects_once "$script"
+  assert_jlist_error_rejected "$script"
+  assert_malformed_jlist_rejected "$script"
   assert_unit_shape
   assert_inventory_boundary
 }
@@ -130,4 +166,17 @@ if assert_existing_processes_noop "$MUTANT"; then
   exit 1
 fi
 echo 'MUTATION_RED live-fleet-noop-removed'
+
+MUTANT_PARSE="$ROOT/pm2-fleet-malformed-as-empty.sh"
+cp "$SCRIPT" "$MUTANT_PARSE"
+before="$(sha256sum "$MUTANT_PARSE" | cut -d' ' -f1)"
+sed -i 's/catch{process.exit(2)}/catch{process.stdout.write("0")}/' "$MUTANT_PARSE"
+after="$(sha256sum "$MUTANT_PARSE" | cut -d' ' -f1)"
+test "$before" != "$after" || { echo 'MUTATION_NOOP malformed-jlist-as-empty'; exit 1; }
+
+if assert_malformed_jlist_rejected "$MUTANT_PARSE"; then
+  echo 'MUTATION_SURVIVED malformed-jlist-as-empty'
+  exit 1
+fi
+echo 'MUTATION_RED malformed-jlist-as-empty'
 echo 'RESULT: PASS'

--- a/tests/test736-pm2-fleet-rebuild/run.sh
+++ b/tests/test736-pm2-fleet-rebuild/run.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /lib/safe-rm.sh
+
+SCRIPT=/app/deploy/fleet/pm2-fleet-boot.sh
+UNIT=/app/deploy/fleet/pm2-fleet.service
+INVENTORY=/app/deploy/fleet/process-inventory.json
+PM2_BIN=/home/vansin/.nvm/versions/node/v20.20.0/bin/pm2
+ROOT="/tmp/test736-$$"
+trap 'safe_rm_rf "$ROOT"' EXIT
+
+install_fake_pm2() {
+  cat > "$PM2_BIN" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  jlist)
+    if [ "${FAKE_PM2_COUNT:-0}" -gt 0 ]; then
+      printf '[{"name":"existing"}]\n'
+    else
+      printf '[]\n'
+    fi
+    ;;
+  resurrect)
+    printf 'resurrect\n' >> "$FAKE_PM2_LOG"
+    ;;
+  list)
+    printf 'fake list\n'
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+  chmod 0755 "$PM2_BIN"
+}
+
+fixture() {
+  local name="$1"
+  local dir="$ROOT/$name"
+  safe_rm_rf "$dir"
+  mkdir -p "$dir/pm2"
+  printf '%s\n' "$dir"
+}
+
+invoke() {
+  local script="$1"
+  local dir="$2"
+  shift 2
+  env \
+    HOME=/home/vansin \
+    PM2_HOME="$dir/pm2" \
+    FAKE_PM2_LOG="$dir/pm2.log" \
+    FAKE_PM2_COUNT="${FAKE_PM2_COUNT:-0}" \
+    "$@" \
+    bash "$script" > "$dir/output.log" 2>&1
+}
+
+assert_existing_processes_noop() {
+  local script="$1" dir
+  dir="$(fixture existing)"
+  printf '[]\n' > "$dir/pm2/dump.pm2"
+  FAKE_PM2_COUNT=1 invoke "$script" "$dir"
+  test ! -e "$dir/pm2.log"
+  grep -Fq '已有 1 个进程在跑' "$dir/output.log"
+}
+
+assert_missing_dump_fails() {
+  local script="$1" dir rc
+  dir="$(fixture missing-dump)"
+  set +e
+  invoke "$script" "$dir"
+  rc=$?
+  set -e
+  test "$rc" -ne 0
+  test ! -e "$dir/pm2.log"
+  grep -Fq '恢复不出任何东西' "$dir/output.log"
+}
+
+assert_empty_pm2_resurrects_once() {
+  local script="$1" dir
+  dir="$(fixture resurrect)"
+  printf '[]\n' > "$dir/pm2/dump.pm2"
+  invoke "$script" "$dir"
+  test "$(wc -l < "$dir/pm2.log")" -eq 1
+  grep -Fxq 'resurrect' "$dir/pm2.log"
+  grep -Fq 'resurrect 退出码 0' "$dir/output.log"
+}
+
+assert_unit_shape() {
+  grep -Fxq 'Type=oneshot' "$UNIT"
+  grep -Fxq 'RemainAfterExit=yes' "$UNIT"
+  grep -Fxq 'ExecStart=%h/.local/bin/pm2-fleet-boot.sh' "$UNIT"
+  grep -Fxq 'After=basic.target' "$UNIT"
+  if grep -Eq '^(ExecStop|Wants=network-online.target|After=network-online.target)' "$UNIT"; then
+    echo 'UNSAFE_SYSTEMD_SHAPE'
+    return 1
+  fi
+}
+
+assert_inventory_boundary() {
+  jq -e '.schema_version == 1 and (.apps | length) == 5' "$INVENTORY" >/dev/null
+  jq -e '[.apps[] | select(.kind == "external-service" and .authority == null)] | length == 2' "$INVENTORY" >/dev/null
+  jq -e '[.apps[] | select(.recovery_status | startswith("not-covered"))] | length == 2' "$INVENTORY" >/dev/null
+  jq -e '[paths(scalars) as $p | ($p[-1] | tostring) | select(test("token|secret|password"; "i"))] | length == 0' "$INVENTORY" >/dev/null
+}
+
+run_suite() {
+  local script="$1"
+  bash -n "$script"
+  assert_existing_processes_noop "$script"
+  assert_missing_dump_fails "$script"
+  assert_empty_pm2_resurrects_once "$script"
+  assert_unit_shape
+  assert_inventory_boundary
+}
+
+install_fake_pm2
+run_suite "$SCRIPT"
+echo 'L1 PM2_FLEET_REBUILD_PASS'
+
+MUTANT="$ROOT/pm2-fleet-resurrects-live-fleet.sh"
+cp "$SCRIPT" "$MUTANT"
+before="$(sha256sum "$MUTANT" | cut -d' ' -f1)"
+sed -i 's/if \[ "$n" -gt 0 \] 2>\/dev\/null; then/if false; then/' "$MUTANT"
+after="$(sha256sum "$MUTANT" | cut -d' ' -f1)"
+test "$before" != "$after" || { echo 'MUTATION_NOOP live-fleet-noop-removed'; exit 1; }
+
+if assert_existing_processes_noop "$MUTANT"; then
+  echo 'MUTATION_SURVIVED live-fleet-noop-removed'
+  exit 1
+fi
+echo 'MUTATION_RED live-fleet-noop-removed'
+echo 'RESULT: PASS'


### PR DESCRIPTION
Advances #736 but intentionally does **not** close it.

Closes #742 by making an unknown/malformed PM2 state fail closed before
`resurrect`.

## What becomes reconstructable

- the captured production `pm2-fleet-boot.sh` launcher plus a reviewed
  fail-closed correction for its `pm2 jlist` ambiguity;
- the production user-systemd unit, also byte-identical;
- a non-secret five-app authority inventory;
- install, validation, upgrade, rollback, backup, and re-registration
  boundaries;
- an isolated non-root Docker behavior gate and witnessed-red mutation.

## Frozen coordinates

- source: `21f8424e59e745ea549ee23156d8b0375f86cb7c`
- report-only: `17cbc2e7ba623ba37c45ebad3282ef87924b1f00`
- base: `3b03ca117040c21b358fa027092fdf4080ce111c`
- image: `sha256:20a747bd2630527f27436bae243185865e418bdb8df51831f2ea95e50f32e8c1`
- runner log SHA256: `bffb6a0b1b68a2e0ebea415a497e94a51b472af7095d560acf9f95c551eaf42e`

```text
L1 PM2_FLEET_REBUILD_PASS
MUTATION_RED live-fleet-noop-removed
MUTATION_RED malformed-jlist-as-empty
RESULT: PASS
```

Four files copied back from the exact image matched the frozen source byte for
byte. The production systemd unit remains byte-identical. The launcher was
initially captured byte-identically, then intentionally hardened in source;
that corrected launcher has not been deployed. Current-main virtual merge-tree
was conflict-free before push.

## Why this does not close #736

- `dump.pm2` is generated sensitive backup state and can persist inherited
  environment; it is deliberately not committed or attached.
- exact encrypted backup/vault record names are still NOT COVERED;
- the two external Weixin processes still lack a repository + exact commit
  authority link;
- PR #738 separately proposes the Hub launcher authority and is not claimed
  merged in this snapshot;
- no empty-host production recovery or process restart was performed.

No production launcher, systemd unit, PM2 process/state, config, database,
node, runtime, or secret was changed.
