### PR TITLE
fix(ci): rename-ghost 硬门的 bun 安装改为 fail-closed(它今天正卡着 #740)

### DIFF
--- a/tests/qa-180-rename-ghost/Dockerfile
+++ b/tests/qa-180-rename-ghost/Dockerfile
@@ -21,7 +21,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://bun.sh/install | bash
+# bun 安装:重试 + fail-closed。与 tests/qa-cli-01-hub-start/Dockerfile 同一写法(#733)。
+#
+# 原来是 `curl -fsSL https://bun.sh/install | bash`,有两个坑:
+#   1. Docker 用 /bin/sh 执行,没有 pipefail —— 管道的退出码只反映 bash(consumer),
+#      curl(producer)失败会被吃掉,层照样通过;
+#   2. 光靠事后 `test -x` 也分不清「本次装成功」和「上一次失败尝试留下的二进制」。
+# 所以这里先把安装脚本下载到临时文件,curl 成功才执行,两步都成功才置 installed=1,
+# 最后要求 installed=1 且二进制存在 —— 否则构建失败,不放行。
+#
+# 触发这次修改的实证:2026-08-13 本门在 PR #740 上红,失败原因正是
+#   process "/bin/sh -c curl -fsSL https://bun.sh/install | bash" ... exit code: 1
+# 这是硬门(非 report-only),所以上游 bun.sh 的任何抖动都会卡住每一个 PR。
+RUN installed=0; \
+    for i in 1 2 3; do \
+      rm -f /tmp/bun-install.sh; \
+      if curl -fsSL https://bun.sh/install -o /tmp/bun-install.sh \
+          && bash /tmp/bun-install.sh; then \
+        installed=1; \
+        break; \
+      fi; \
+      echo "bun install attempt $i failed; retrying in $((i*5))s"; \
+      sleep $((i*5)); \
+    done; \
+    rm -f /tmp/bun-install.sh; \
+    test "$installed" = 1 && test -x "$HOME/.bun/bin/bun" \
+      || { echo "bun install failed after 3 attempts"; exit 1; }
 ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app


### PR DESCRIPTION
`rename-ghost-gate` 是**硬门**(非 report-only),而它的 Dockerfile 还在用裸管道装 bun:

```dockerfile
RUN curl -fsSL https://bun.sh/install | bash
```

两个坑与 #733 修的完全一致:

1. Docker 用 `/bin/sh` 执行,**没有 `pipefail`** —— 管道的退出码只反映 `bash`(consumer),
   `curl`(producer)失败会被吃掉,层照样通过;
2. 事后补一个 `test -x` 也不够,它**分不清「本次装成功」和「上一次失败尝试留下的二进制」**。

## 触发本次修改的实证

不是预防性改动。2026-08-13,本门在 PR **#740** 上红,失败原因逐字如下:

```
ERROR: failed to build: failed to solve:
process "/bin/sh -c curl -fsSL https://bun.sh/install | bash"
did not complete successfully: exit code: 1
```

**因为是硬门,上游 `bun.sh` 的任何抖动都会卡住每一个 PR** —— #740 是个只加测试的 PR,
和 bun 毫无关系,照样被拦下。

顺带一提,同一天同一类故障命中了**三个不同的点**:
`tests/qa-cli-01-hub-start/Dockerfile`(#729 → #733 已修)、
`oven-sh/setup-bun@v2` 从 GitHub releases 下载时 503、
以及本 PR 修的这个。

## 验证(双向,都是真 `docker build`)

| 方向 | 结果 |
|---|---|
| 正常 | `build rc=0`,且**镜像里 `bun --version` = 1.3.14 @ `/root/.bun/bin/bun`** |
| 失败 | 把 URL 换成 404 路径 → 重试 3 次后 `build rc=1`(fail-closed 成立) |

正常方向特意**进容器跑了 `bun --version`**,而不是只看「构建通过」——
这一层原本的失败模式就是「层过了但 bun 不在」,只验层是验不出来的。
失败方向注入前核过 **diff 非空(12 行)**,避免 sed 没命中造成的 no-op 假红。

## 范围

**只改这一个正在卡人的硬门。** 全仓还有 43 个 Dockerfile 用同样的裸管道写法
(`git grep -l 'bun.sh/install' -- '**/Dockerfile'` = 44,其中已加固的只有 `qa-cli-01`)。
统一处理归 **#728**,那需要 owner 先定「要不要连 bun 版本一起钉死」,不在本 PR 范围内。
