### PR TITLE
fix(cli): anet -v 声明 Bun 前置(此前唯一的硬前置在自报信息里是隐形的)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1720,6 +1720,10 @@ function detectInstalledPackages() {
     commhubServer: detectCommandVersion("commhub-server", "commhub-server", "global"),
     claude: detectCommandVersion("claude", "claude CLI"),
     codex: detectCommandVersion("codex", "codex CLI"),
+    // Bun 不是「可选运行时」,它是本机跑 hub 的硬前置:`anet hub start` 在
+    // 缺 bun/bunx 时直接 process.exit(1)(见 hub start 里的前置校验)。
+    // 此前自报里完全不提它,用户只能撞上去才知道 —— 这正是本次要修的。
+    bun: detectCommandVersion("bun", "Bun"),
   };
 
   if (versions.agentNode.state !== "ok") {
@@ -1743,6 +1747,16 @@ function formatLazyComponent(pkg: DetectedVersion): string {
   if (pkg.state === "ok" && pkg.version) return `✓ ${pkg.displayName} v${pkg.version}`;
   if (pkg.state === "unknown") return `✓ ${pkg.displayName} installed`;
   return `○ ${pkg.displayName} — not installed yet (will fetch via npx on first use)`;
+}
+
+/** Bun 的自报行。与 formatOptionalRuntime 分开,因为缺失时的语义完全不同:
+ *  可选运行时缺了只是少一种 runtime,Bun 缺了 `anet hub start` 直接失败,
+ *  所以这里要给出可直接执行的安装命令,而不是一句 "only needed for …"。 */
+function formatRequiredBun(pkg: DetectedVersion): string {
+  if (pkg.state === "ok" && pkg.version) return `✓ ${pkg.displayName} v${pkg.version}`;
+  if (pkg.state === "unknown") return `✓ ${pkg.displayName} installed`;
+  return `✗ ${pkg.displayName} not found — \`anet hub start\` will fail without it `
+    + `(commhub-server is bun-only). Install: curl -fsSL https://bun.sh/install | bash`;
 }
 
 function formatOptionalRuntime(pkg: DetectedVersion, reason: string): string {
@@ -1782,6 +1796,11 @@ function printVersionReport() {
   }
   console.log(`  ${formatLazyComponent(versions.commhubServer)}`);
 
+  // Bun 单独一节,不能混进 "Optional runtimes" —— 它不是可选的。
+  // 措辞限定在「本机跑 hub」:节点连远程 hub 不需要 Bun,说成笼统必需是过度声称。
+  console.log("\nRequired to run a hub on this machine:");
+  console.log(`  ${formatRequiredBun(versions.bun)}`);
+
   console.log("\nOptional runtimes (install only what you'll use):");
   console.log(`  ${formatOptionalRuntime(versions.claude, "the claude-code-cli runtime")}`);
   console.log(`  ${formatOptionalRuntime(versions.codex, "the codex-sdk runtime")}`);
@@ -1791,6 +1810,11 @@ function printVersionReport() {
     console.log("\nNothing is broken — components are fetched the first time you run:");
     console.log("  anet hub start          # bootstraps commhub-server");
     console.log("  anet node start <name>  # bootstraps agent-node");
+    // 缺 Bun 时上面这句会误导:`anet hub start` 不会「自动拉取后正常工作」,
+    // 它会在前置校验处 exit 1。所以这里必须把话收回来。
+    if (!isInstalled(versions.bun)) {
+      console.log("\n  ⚠️  but `anet hub start` will not succeed until Bun is installed — see above.");
+    }
     console.log("\nDocs: https://anet.sh/guide/getting-started");
   }
 }


### PR DESCRIPTION
## 问题

`anet -v` 此前只列 "Optional runtimes"(claude / codex),**完全不提 Bun** ——
而 `anet hub start` 对 Bun 是**硬要求**,缺了直接 `process.exit(1)`(`cli.ts` 的 hub start 前置校验)。

更糟的是,组件缺失时它会说:

```
Nothing is broken — components are fetched the first time you run:
  anet hub start          # bootstraps commhub-server
```

**没有 Bun 时这句是错的。** `anet hub start` 不会「自动拉取后正常工作」,它会在前置校验处退出。
唯一的硬前置在自报信息里是隐形的,用户只能撞上去才知道。

(文档侧 #720 已经写清了三条前置链,CLI 自报没跟上。)

## 怎么发现的

分流 #444 时,把它的 `onboarding-cli-smoke.test.ts` 摘到当前 main 上跑,
其中一条 `version/setup-facing report declares the Bun prerequisite` 不通过。
那个 PR 落后 422 个 commit,但**这条断言指出的缺口至今还在**。

## 改了什么

- `detectInstalledPackages` 增加 bun 探测;
- 新增独立一节 **"Required to run a hub on this machine"**,不混进 Optional ——
  两者缺失语义完全不同:可选运行时缺了只是少一种 runtime,Bun 缺了 hub 起不来;
- 缺失时给**可直接执行的安装命令**,而不是一句 "only needed for …";
- 组件缺失 **且** Bun 缺失时,把 "Nothing is broken" 那句收回来。

措辞刻意限定在「**本机跑 hub**」:节点连远程 hub 并不需要 Bun,说成笼统「必需」是过度声称。

## 验证:三个分支都真跑了

| 分支 | 输出 |
|---|---|
| A 有 Bun | `✓ Bun v1.3.14` |
| B 无 Bun、组件在 | `✗ Bun not found — anet hub start will fail without it … Install: curl -fsSL https://bun.sh/install \| bash` |
| C 无 Bun、组件也缺 | 上述 + `⚠️ but anet hub start will not succeed until Bun is installed — see above.` |

B/C 用剥掉 PATH 的方式构造(`env PATH=<只含 sh 的临时目录>`),不是 mock。
输出自检**无中文**(面向用户文案保持英文)。

## 回归

改动前后 `bun test src/` 均为 **433 pass / 3 fail**,且是**同样三条测试名** —— 零新增失败。

⚠️ 那 3 条是 `main` 上**既有**的红,与本改动无关。其中一条值得单独看:
`OpenCode agent-node release pairing > pins the exact versions being released together`
—— 它是一条**故意设置的绊线**(源码注释:*the unit test intentionally fails when either
package is bumped independently*),现在正红着,说明 pin 与已发布版本失同步。
我另开条目跟踪,不在本 PR 范围内。
