### PR TITLE
test(rest): anchor current wire keys independently

### DIFF
--- a/docs/tests/report-test686-rest-shape-golden.txt
+++ b/docs/tests/report-test686-rest-shape-golden.txt
@@ -1,0 +1,61 @@
+# test686 — current-main independent REST response-key golden
+
+Date: 2026-08-13 (Asia/Shanghai)
+
+## Provenance
+
+- Base commit: `b7d1289bc67081ab597f17fba7034506394757ce`
+- Source commit under test: `0d25347c4cb701938beac54c2c02b05b8ec78962`
+- Exact Docker image: `sha256:9f1482df133e25799df5e59ff89cdf2c6d2082b9b5b801c16afa14e9215ec756`
+- Runner log SHA256: `2967f366a21d0024649d6f28943f02b5093d31ec4f50e05ec578c30d3a8cf5e4`
+- Bun image: `oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4`
+
+The runner-log digest identifies one execution; it is not source provenance.
+The source commit is the authority for the production test and Docker fixture.
+
+## Why this current-main replay exists
+
+The earlier PR #686 correctly identified a self-derived-test problem: the HTTP
+test imported the same projection arrays used by production SQL, so deleting a
+public key could change both the response and the expected value and remain
+green. That branch predated the public `external_schedules` session key and
+could not be merged as-is.
+
+This source replays the narrow fix on current main. The static wire golden now
+includes `external_schedules`, and the new Docker suite is explicitly listed in
+`scripts/qa.sh`'s `L1_TESTS`; it is not an unreferenced test directory.
+
+## Results
+
+Exact command:
+
+```sh
+sg docker -c 'docker build --build-arg TEST686_SOURCE_COMMIT=0d25347c4cb701938beac54c2c02b05b8ec78962 -t anet-test686:0d25347c-exact -f tests/test686-rest-shape-golden/Dockerfile .'
+sg docker -c 'docker run --rm anet-test686:0d25347c-exact'
+```
+
+- L0 independent golden: `5 pass / 0 fail / 30 expect()`
+- L1 mutation `drop-task-created-at`: `rc=1 witnessed-red`
+- L2 restored source: `5 pass / 0 fail / 30 expect()`
+- Final runner status: `RESULT: PASS`, exit `0`
+
+The mutation removes `tasks.created_at` from the production projection. The
+test remains anchored to the independent static response-key golden, so the
+task list/detail contract test fails and names `created_at`. The runner rejects
+a missing or duplicate mutation anchor and rejects a byte-identical mutation.
+
+## Scope and honest limits
+
+- Test, Docker fixture, QA inventory, and report only; no production runtime,
+  API implementation, schema, database, package publication, or deployment is
+  changed.
+- The golden covers the seven response shapes exercised by
+  `rest-explicit-columns-http.test.ts`; it is not a claim that every REST route
+  has a static key golden.
+- An intentional future public wire-key addition must update this golden in the
+  same reviewed change. An unreviewed projection narrowing must turn this test
+  red.
+- At report creation time the exact local Docker gate passed. GitHub PR CI had
+  not yet run; CI status must be reviewed separately and must not be inferred
+  from this report.
+

--- a/docs/tests/report-test686-rest-shape-golden.txt
+++ b/docs/tests/report-test686-rest-shape-golden.txt
@@ -5,9 +5,9 @@ Date: 2026-08-13 (Asia/Shanghai)
 ## Provenance
 
 - Base commit: `b7d1289bc67081ab597f17fba7034506394757ce`
-- Source commit under test: `0d25347c4cb701938beac54c2c02b05b8ec78962`
-- Exact Docker image: `sha256:9f1482df133e25799df5e59ff89cdf2c6d2082b9b5b801c16afa14e9215ec756`
-- Runner log SHA256: `2967f366a21d0024649d6f28943f02b5093d31ec4f50e05ec578c30d3a8cf5e4`
+- Source commit under test: `f41b3d4b57cd34f1b09dd8aa72d35b34f2b0be8a`
+- Exact Docker image: `sha256:81a7b9b8d0f01ed3c65e517bd1cef6728b0672495513c8963321dd507810ca54`
+- Runner log SHA256: `491972910fde8fc009f4ecc339d46affb4725965d826698de55195ebbd02ced5`
 - Bun image: `oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4`
 
 The runner-log digest identifies one execution; it is not source provenance.
@@ -30,14 +30,16 @@ includes `external_schedules`, and the new Docker suite is explicitly listed in
 Exact command:
 
 ```sh
-sg docker -c 'docker build --build-arg TEST686_SOURCE_COMMIT=0d25347c4cb701938beac54c2c02b05b8ec78962 -t anet-test686:0d25347c-exact -f tests/test686-rest-shape-golden/Dockerfile .'
-sg docker -c 'docker run --rm anet-test686:0d25347c-exact'
+sg docker -c 'docker build --build-arg TEST686_SOURCE_COMMIT=f41b3d4b57cd34f1b09dd8aa72d35b34f2b0be8a -t anet-test686:f41b3d4b57cd34f1b09dd8aa72d35b34f2b0be8a -f tests/test686-rest-shape-golden/Dockerfile .'
+sg docker -c 'docker run --rm anet-test686:f41b3d4b57cd34f1b09dd8aa72d35b34f2b0be8a'
 ```
 
 - L0 independent golden: `5 pass / 0 fail / 30 expect()`
 - L1 mutation `drop-task-created-at`: `rc=1 witnessed-red`
 - L2 restored source: `5 pass / 0 fail / 30 expect()`
 - Final runner status: `RESULT: PASS`, exit `0`
+- Full `scripts/qa.sh --l1`: all 14 suites passed in 89 seconds, including
+  `test686-rest-shape-golden (RESULT: PASS)`.
 
 The mutation removes `tasks.created_at` from the production projection. The
 test remains anchored to the independent static response-key golden, so the
@@ -55,7 +57,16 @@ a missing or duplicate mutation anchor and rejects a byte-identical mutation.
 - An intentional future public wire-key addition must update this golden in the
   same reviewed change. An unreviewed projection narrowing must turn this test
   red.
-- At report creation time the exact local Docker gate passed. GitHub PR CI had
-  not yet run; CI status must be reviewed separately and must not be inferred
-  from this report.
+- The first GitHub PR run exposed the missing QA build argument described
+  below. The corrected source passed the exact Docker gate and the full local
+  L1 path; the new-head GitHub result must still be reviewed separately.
 
+## CI integration correction
+
+The first PR run built this suite through the generic QA loop without passing
+`TEST686_SOURCE_COMMIT`. The container correctly failed closed at startup with
+the default value `unknown`, before any product assertion ran. The source fix
+keeps that fail-closed guard and teaches `scripts/qa.sh` to pass the checked-out
+Git HEAD only for this suite. A subsequent full local L1 run exercised the same
+QA path and passed all 14 suites; the new GitHub run remains the authoritative
+remote CI result.

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -70,6 +70,7 @@ L1_TESTS=(
   "qa-hub-09-task-state-machine"
   "qa-node-02-success-reply"
   "qa-node-03b-task-events"
+  "test686-rest-shape-golden"
 )
 
 if [[ "${1:-}" == "--list" ]]; then

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -140,7 +140,11 @@ if [[ $RUN_L1 -eq 1 ]]; then
   for t in "${L1_TESTS[@]}"; do
     # Build (cached if recent)
     note "build $t"
-    if ! dockerrun "docker build -q -t anet-$t -f tests/$t/Dockerfile ." >/tmp/qa-l1-$t-build.log 2>&1; then
+    build_args=""
+    if [[ "$t" == "test686-rest-shape-golden" ]]; then
+      build_args="--build-arg TEST686_SOURCE_COMMIT=$(git rev-parse HEAD)"
+    fi
+    if ! dockerrun "docker build -q $build_args -t anet-$t -f tests/$t/Dockerfile ." >/tmp/qa-l1-$t-build.log 2>&1; then
       fail "L1 $t — build failed, see /tmp/qa-l1-$t-build.log"
       FAILED=$((FAILED+1))
       continue

--- a/server/src/rest-explicit-columns-http.test.ts
+++ b/server/src/rest-explicit-columns-http.test.ts
@@ -2,15 +2,6 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  AUDIT_LOG_REST_COLUMNS,
-  COMPLETION_REST_COLUMNS,
-  NETWORK_REST_COLUMNS,
-  SESSION_REST_COLUMNS,
-  TASK_EVENT_REST_COLUMNS,
-  TASK_REST_COLUMNS,
-  SCHEDULED_TASK_STORAGE_COLUMNS,
-} from "./rest-projections.js";
 
 const PRIVATE_DB_DIR = mkdtempSync(join(tmpdir(), "anet-rest-columns-"));
 process.env.COMMHUB_DB ||= join(PRIVATE_DB_DIR, "hub.db");
@@ -24,6 +15,54 @@ let networkId = "";
 const INTERNAL_SENTINEL = "future_internal_only";
 const sortedKeys = (value: Record<string, unknown>): string[] => Object.keys(value).sort();
 const sorted = (values: readonly string[]): string[] => [...values].sort();
+
+// Independent wire-contract golden. Do not derive these expectations from
+// rest-projections.ts: doing so makes a deleted projection column disappear
+// from both the response and the expected value, producing a false green.
+const GOLDEN_RESPONSE_KEYS = {
+  networkList: [
+    "network_id", "network_name", "owner_id", "description", "settings",
+    "created_at", "updated_at", "visibility", "max_members", "member_role", "name",
+  ],
+  networkDetail: [
+    "network_id", "network_name", "owner_id", "description", "settings",
+    "created_at", "updated_at", "visibility", "max_members",
+  ],
+  statusSession: [
+    "resume_id", "alias", "tmux_name", "server", "ip", "hostname", "agent",
+    "project_dir", "version", "status", "task", "output", "progress", "score",
+    "cpu_load_1min", "cpu_cores", "mem_total_gb", "mem_used_gb", "mem_avail_gb",
+    "disk_total_gb", "disk_used_gb", "disk_avail_gb", "process_rss_bytes",
+    "process_rss_mb", "process_cpu_pct", "process_uptime_seconds",
+    "process_in_flight_count", "network_id", "registered_at", "updated_at",
+    "node_id", "session_id", "config_path", "channels", "last_seen_at", "model",
+    "external_schedules", "runtime", "host", "process_telemetry",
+  ],
+  task: [
+    "task_id", "from_node_id", "from_name", "to_node_id", "to_name", "priority",
+    "status", "content", "result", "in_reply_to", "requires_response", "scope",
+    "created_at", "delivered_at", "started_at", "runtime_submitted_at", "consumed_at",
+    "completed_at", "expires_at", "network_id", "parent_task_id", "meta_json",
+  ],
+  audit: [
+    "id", "user_id", "username", "action", "target_type", "target_id", "detail",
+    "ip", "network_id", "created_at",
+  ],
+  taskEvent: [
+    "id", "task_id", "from_status", "to_status", "event_type", "actor", "detail",
+    "created_at", "network_id",
+  ],
+  completion: [
+    "id", "session_name", "task", "result", "artifacts", "score",
+    "duration_minutes", "network_id", "completed_at",
+  ],
+  scheduledTask: [
+    "schedule_id", "network_id", "name", "target_node_id", "target_alias",
+    "task_content", "priority", "schedule_type", "timezone", "overlap_policy",
+    "misfire_policy", "status", "next_run_at", "last_run_at", "revision",
+    "created_at", "updated_at", "schedule",
+  ],
+} as const;
 
 async function api(path: string): Promise<any> {
   const response = await fetch(`${base}${path}`, {
@@ -97,51 +136,50 @@ describe("#311 REST response projections are stable across future ALTER TABLE", 
   test("network list and detail preserve their existing public keys", async () => {
     const list = await api("/api/networks");
     const row = list.networks.find((item: any) => item.network_id === networkId);
-    expect(sortedKeys(row)).toEqual(sorted([...NETWORK_REST_COLUMNS, "member_role", "name"]));
+    expect(sortedKeys(row)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.networkList));
     expect(row[INTERNAL_SENTINEL]).toBeUndefined();
 
     const detail = await api(`/api/networks/${networkId}`);
-    expect(sortedKeys(detail.network)).toEqual(sorted(NETWORK_REST_COLUMNS));
+    expect(sortedKeys(detail.network)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.networkDetail));
     expect(detail.network[INTERNAL_SENTINEL]).toBeUndefined();
   });
 
   test("full status preserves telemetry compatibility without storage drift", async () => {
     const body = await api(`/api/status?network_id=${networkId}`);
     const row = body.sessions.find((item: any) => item.alias === "rest-shape-node");
-    expect(sortedKeys(row)).toEqual(sorted([...SESSION_REST_COLUMNS, "runtime", "host", "process_telemetry"]));
+    expect(sortedKeys(row)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.statusSession));
     expect(row[INTERNAL_SENTINEL]).toBeUndefined();
     expect(row.external_schedules).toEqual({ observed_at: "2026-08-10T02:00:00.000Z", schedules: [] });
   });
 
   test("task list and task detail expose the same explicit contract", async () => {
     const list = await api(`/api/tasks?network_id=${networkId}&task_id=task-rest-shape&skip_stats=1`);
-    expect(sortedKeys(list.tasks[0])).toEqual(sorted(TASK_REST_COLUMNS));
+    expect(sortedKeys(list.tasks[0])).toEqual(sorted(GOLDEN_RESPONSE_KEYS.task));
     expect(list.tasks[0][INTERNAL_SENTINEL]).toBeUndefined();
 
     const detail = await api(`/api/tasks/task-rest-shape?network_id=${networkId}`);
-    expect(sortedKeys(detail.task)).toEqual(sorted(TASK_REST_COLUMNS));
+    expect(sortedKeys(detail.task)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.task));
     expect(detail.task[INTERNAL_SENTINEL]).toBeUndefined();
   });
 
   test("audit, task-event, and completion rows are explicit", async () => {
     const audit = await api("/api/audit-log?action=shape_action");
-    expect(sortedKeys(audit.logs[0])).toEqual(sorted(AUDIT_LOG_REST_COLUMNS));
+    expect(sortedKeys(audit.logs[0])).toEqual(sorted(GOLDEN_RESPONSE_KEYS.audit));
     expect(audit.logs[0][INTERNAL_SENTINEL]).toBeUndefined();
 
     const events = await api(`/api/task_events?network_id=${networkId}&task_id=task-rest-shape`);
-    expect(sortedKeys(events.events[0])).toEqual(sorted(TASK_EVENT_REST_COLUMNS));
+    expect(sortedKeys(events.events[0])).toEqual(sorted(GOLDEN_RESPONSE_KEYS.taskEvent));
     expect(events.events[0][INTERNAL_SENTINEL]).toBeUndefined();
 
     const completions = await api(`/api/completions?network_id=${networkId}&since=2000-01-01T00:00:00.000Z`);
-    expect(sortedKeys(completions.completions[0])).toEqual(sorted(COMPLETION_REST_COLUMNS));
+    expect(sortedKeys(completions.completions[0])).toEqual(sorted(GOLDEN_RESPONSE_KEYS.completion));
     expect(completions.completions[0][INTERNAL_SENTINEL]).toBeUndefined();
   });
 
   test("scheduled-task decoding keeps storage-only identity and JSON private", async () => {
     const body = await api(`/api/scheduled-tasks?network_id=${networkId}`);
     const row = body.schedules.find((item: any) => item.schedule_id === "schedule-rest-shape");
-    const publicColumns = SCHEDULED_TASK_STORAGE_COLUMNS.filter((key) => key !== "created_by" && key !== "schedule_json");
-    expect(sortedKeys(row)).toEqual(sorted([...publicColumns, "schedule"]));
+    expect(sortedKeys(row)).toEqual(sorted(GOLDEN_RESPONSE_KEYS.scheduledTask));
     expect(row.created_by).toBeUndefined();
     expect(row.schedule_json).toBeUndefined();
     expect(row[INTERNAL_SENTINEL]).toBeUndefined();

--- a/tests/test686-rest-shape-golden/Dockerfile
+++ b/tests/test686-rest-shape-golden/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+
+COPY server/package.json ./server/package.json
+RUN cd server && bun install --ignore-scripts
+COPY server ./server
+COPY tests/test686-rest-shape-golden ./tests/test686-rest-shape-golden
+
+ARG TEST686_SOURCE_COMMIT=unknown
+ENV TEST686_SOURCE_COMMIT=$TEST686_SOURCE_COMMIT
+
+RUN chmod 0755 tests/test686-rest-shape-golden/run.sh
+ENTRYPOINT ["/workspace/tests/test686-rest-shape-golden/run.sh"]

--- a/tests/test686-rest-shape-golden/mutate.mjs
+++ b/tests/test686-rest-shape-golden/mutate.mjs
@@ -1,0 +1,14 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const path = process.argv[2];
+if (!path) throw new Error("usage: mutate.mjs <rest-projections.ts>");
+
+const source = readFileSync(path, "utf8");
+const anchor = '  "created_at", "delivered_at", "started_at", "runtime_submitted_at", "consumed_at", "completed_at", "expires_at",';
+const replacement = '  "delivered_at", "started_at", "runtime_submitted_at", "consumed_at", "completed_at", "expires_at",';
+if (source.split(anchor).length - 1 !== 1) {
+  throw new Error("expected exactly one task created_at projection anchor");
+}
+const mutated = source.replace(anchor, replacement);
+if (mutated === source) throw new Error("projection mutation was byte-identical");
+writeFileSync(path, mutated);

--- a/tests/test686-rest-shape-golden/run.sh
+++ b/tests/test686-rest-shape-golden/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+test "${TEST686_SOURCE_COMMIT:-unknown}" != unknown
+cd /workspace
+
+echo "L0: independent golden remains green"
+bun test server/src/rest-explicit-columns-http.test.ts
+
+cp server/src/rest-projections.ts /tmp/rest-projections.orig
+bun tests/test686-rest-shape-golden/mutate.mjs server/src/rest-projections.ts
+cmp -s server/src/rest-projections.ts /tmp/rest-projections.orig && {
+  echo "projection mutation was byte-identical" >&2
+  exit 1
+}
+
+echo "L1: removing a previously public task key must turn red"
+set +e
+bun test server/src/rest-explicit-columns-http.test.ts >/tmp/test686-mutation.log 2>&1
+mutation_rc=$?
+set -e
+cp /tmp/rest-projections.orig server/src/rest-projections.ts
+test "$mutation_rc" -ne 0
+grep -Fq 'task list and task detail expose the same explicit contract' /tmp/test686-mutation.log
+grep -Fq 'created_at' /tmp/test686-mutation.log
+printf 'mutation=drop-task-created-at rc=%s witnessed-red\n' "$mutation_rc"
+
+echo "L2: restored production projection remains green"
+bun test server/src/rest-explicit-columns-http.test.ts
+
+printf 'source_commit=%s\n' "$TEST686_SOURCE_COMMIT"
+printf 'RESULT: PASS\n'


### PR DESCRIPTION
## Outcome

Replays the useful part of #686 on current `main`: the REST shape test now owns an independent static wire-key golden instead of importing the same projection arrays used by production SQL.

- Source freeze: `f41b3d4b57cd34f1b09dd8aa72d35b34f2b0be8a`
- Report-only head: `a66ca32fd77461153bbf82571e2139eb92682f32`
- Base: `b7d1289bc67081ab597f17fba7034506394757ce`
- Exact image: `sha256:81a7b9b8d0f01ed3c65e517bd1cef6728b0672495513c8963321dd507810ca54`

## Why the old draft is not mergeable as-is

PR #686 captured the right test-design problem but predates the public `external_schedules` session key. Its golden is therefore stale. This replay includes that key and does not hand-resolve the old branch.

## Real gate integration

`tests/test686-rest-shape-golden` is explicitly added to `scripts/qa.sh`'s `L1_TESTS`. The PR CI must demonstrate that this suite actually runs; the existence of a Dockerfile alone is not treated as coverage.

Exact Docker evidence:

- independent golden: `5 pass / 0 fail / 30 expect()`
- mutation `drop-task-created-at`: `rc=1 witnessed-red`
- restored source: `5 pass / 0 fail / 30 expect()`
- runner: `RESULT: PASS`, exit 0
- full local `scripts/qa.sh --l1`: all 14 suites passed in 89 seconds
- runner-log SHA256: `491972910fde8fc009f4ecc339d46affb4725965d826698de55195ebbd02ced5`

The first PR CI run correctly failed closed because the generic QA build did
not pass `TEST686_SOURCE_COMMIT`; the container exited at `unknown` before any
product assertion. The new source passes the checked-out Git HEAD only for this
suite and keeps the fail-closed container guard.

## Scope

Six files: test assertion, focused Docker fixture, the QA build/inventory
integration, and report. No API implementation, schema, runtime, database,
package publication, or deployment change.

Draft pending CI and independent review. Do not merge #686 and this PR together; after this replacement lands, #686 can be closed as superseded with history preserved.
