### PR TITLE
fix(ci): e2e verdict 区分「没轮到跑」与「跑了但超时」(旧文案把人引去查测试超时)

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -50,6 +50,8 @@ jobs:
       # Preserve the Docker runner's real exit status across tee, then make the
       # following step enforce both that status and the structured TOTAL line.
       - name: Run full regression (hard-gated)
+        # id 供下面的 verdict 区分「跑了但没产出退出码」与「压根没轮到它跑」。
+        id: run
         run: |
           bash tests/lib/run-piped-command.sh \
             /tmp/e2e-output.log \
@@ -73,10 +75,26 @@ jobs:
           if [ -s /tmp/e2e-output.log ]; then
             awk '/Final Report/,/^$/' /tmp/e2e-output.log | tail -20
           fi
-          [ -s /tmp/e2e-exit-code ] || {
-            echo "::error::runner exit-code file missing — test timed out or did not start"
+          # 这一步是 if: always(),所以前面任何一步失败时它也会跑。
+          # 缺 exit-code 文件有两种完全不同的原因,旧文案把它们混成一句
+          #   "test timed out or did not start"
+          # —— 读到的人会去查测试超时,而真因往往在两三步之前
+          # (实测:Setup Bun 从 GitHub releases 拉 bun 时 503,见 #746)。
+          # 这里用 steps.run.outcome 把两种情况分开报。
+          if [ ! -s /tmp/e2e-exit-code ]; then
+            case "${{ steps.run.outcome }}" in
+              skipped)
+                echo "::error::the regression step never ran — an earlier step in this job failed."
+                echo "::error::Look ABOVE this step (Setup Bun / dependency install / docker build), not at the tests."
+                echo "::error::This is NOT a test timeout."
+                ;;
+              *)
+                echo "::error::the regression step ran (outcome: ${{ steps.run.outcome }}) but produced no exit-code file"
+                echo "::error::— it timed out or was killed. Check the 12-minute step timeout and the tail of the run log."
+                ;;
+            esac
             exit 1
-          }
+          fi
           bash tests/lib/e2e-hard-gate.sh \
             /tmp/e2e-output.log \
             "$(cat /tmp/e2e-exit-code)"


### PR DESCRIPTION
`#746` 三条建议里成本最低、且不需要任何取舍决策的那一条。

## 问题

`Enforce full regression verdict` 是 `if: always()`,前面**任何**一步失败它都会跑。
缺 exit-code 文件时,旧文案只有一句:

```
::error::runner exit-code file missing — test timed out or did not start
```

两种完全不同的原因被压成一句,而**读到的人会去查测试超时** —— 真因往往在两三步之前。

## 这不是假想

`#746` 记录的实测:`Setup Bun` 从 GitHub releases 拉 bun 时 503,
`Run full regression` **根本没轮到跑**,最终 Actions UI 上红的却是这句「test timed out」。

我自己就被它引偏过一次,翻到两步之前才看见 `Unexpected HTTP response: 503`。
今天这个下载点在三个 workflow 上一共红了三次,所以这条文案的误导是会重复发生的。

## 改法

给 regression step 加 `id: run`,用 `steps.run.outcome` 把两种情况分开:

| outcome | 报什么 |
|---|---|
| `skipped` | 明说是**上游 step 失败**,指路 `Look ABOVE this step`,并直说 `This is NOT a test timeout` |
| 其他 | 带上 outcome,提示查 12 分钟 step 超时与 run log 尾部 |

## 验证

```
YAML 解析通过,e2e job 8 个 step,id: run 生效
三种 outcome 分支(skipped / failure / success)逐一真跑 → 文案正确,均 exit 1
happy path(exit-code 文件存在)→ 不进失败分支,继续落到 e2e-hard-gate.sh
空文件 → 仍判为缺失,与旧 [ -s ] 语义一致
```

最后两条是特意验的:**这一步是硬门,改它的风险是把门改松。**
所以既验了「该红的仍然红」,也验了「该放行的仍然放行」,以及与旧写法的语义等价。

## 不包含什么

`#746` 的另外两条 —— 钉 `bun-version`、给 `setup-bun` 加重试(或换成手动安装 + 重试)——
涉及下载方式与第三方 action 的供应链取舍,归 owner,不在本 PR。
本 PR **不改任何门的判定标准**,只改文案与分支判断。
