### PR TITLE
docs(api): correct health and node-delete response facts

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -34,7 +34,6 @@ curl http://localhost:9200/health
   "transport": "streamable-http",
   "sessions_count": 0,
   "sse_connections": 0,
-  "sse_sessions": {},
   "auth": "user-token",
   "security": "secured",
   "tmux": "disabled",
@@ -44,6 +43,10 @@ curl http://localhost:9200/health
   "uptime": 3600
 }
 ```
+
+未认证请求只返回上述聚合数据，不包含 `sse_sessions`。携带有效 token 时：
+- system-admin、legacy master 或 DEV_OPEN 调用方可看到完整 `sse_sessions`；
+- 普通 `utok_` / `ntok_` 只看到其有权访问网络的 session；无网络成员关系时返回空对象。
 
 ::: tip `license` 字段是 v0.6 legacy
 `license: "trial"` 是 v0.6 时代 14 天试用机制的残留字段，Apache 2.0 OSS 后**不再作为商业功能门控**（自部署没有"过期"概念）。`send_task` 路径仍跑 trial 检查仅为后向兼容（verify [`server/src/tools.ts:521`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L521) `license_expired` 仍 emit），若命中见 [troubleshooting](/troubleshooting)。**v0.9.x / v0.10.x scope 都未动**（Recovery & Observability 主题为先），整段移除排到 v0.11+ / 未排期。
@@ -707,7 +710,7 @@ curl http://localhost:9200/api/nodes \
 
 > [源码 ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
-删除节点（hub server 端）—— 从 `nodes` 表删持久身份 + 从 `sessions` 表删运行时心跳记录（同一个 transaction），并往 alias channel + network channel 推 `node_deleted` SSE 事件让 dashboard 实时刷新。配套 PR #86「node delete cascade and node_deleted SSE」。
+删除节点（hub server 端）—— 从 `nodes` 表删持久身份 + 从 `sessions` 表删运行时心跳记录（同一个 transaction），并向 alias channel 推 `node_deleted` SSE 事件。配套 PR #86「node delete cascade and node_deleted SSE」。
 
 ```bash
 # :ref 接受 node_id / node_name / alias 任一（URL-encoded）
@@ -734,9 +737,7 @@ curl -X DELETE "http://localhost:9200/api/nodes/%E4%BB%A3%E7%A0%811%E5%8F%B7" \
 }
 ```
 
-**SSE 副作用**：删完往**两个 SSE channel** 推 `node_deleted` event（[`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）：
-- `alias` 自身的 SSE channel（如果还有订阅者）
-- 该 `network_id` 的 user 级 SSE channel（每个网络成员都能立刻看到）
+**SSE 副作用**：删完只向 `alias` 自身的 SSE channel 推 `node_deleted` event（如果还有订阅者）。当前 handler 没有向 network/user channel 再推一份；客户端不能依赖第二条删除广播。
 
 ```json
 // node_deleted SSE event payload
@@ -907,7 +908,7 @@ curl "http://localhost:9200/api/server/$(python3 -c 'import urllib.parse; print(
   "hostname": "dev-machine",
   "ip": "192.168.1.42",
   "agent_count": 7,
-  "alert_level": "ok",
+  "alert_level": "green",
   "alerts": [],
   "latest": {
     "cpu_load_1min": 0.42,
@@ -933,8 +934,8 @@ curl "http://localhost:9200/api/server/$(python3 -c 'import urllib.parse; print(
 |------|------|
 | `host` | 请求路径里传入的 host 值 |
 | `agent_count` | 该 host 上活跃 session 数（窗口取最新一行的 `COUNT(*) OVER ()`）|
-| `alert_level` | `ok` / `warn` / `critical`（取 `serverAlertLevel(latest)` 计算；v0.10.2+ 加 `disk_avail_gb < 1 → critical` / `< 5 → warn` 触发，verify [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)）|
-| `alerts` | 当前命中告警列表，`alert_level != ok` 时非空 |
+| `alert_level` | `green` / `yellow` / `red`（取 `serverAlertLevel(latest)` 计算；`disk_avail_gb < 1 → red` / `< 5 → yellow`）|
+| `alerts` | 当前命中告警列表，`alert_level != green` 时非空 |
 | `latest` | 该 host 最近一次心跳的瞬时 telemetry（CPU / mem / disk + `last_seen`）|
 | `latest.disk_total_gb` / `disk_used_gb` / `disk_avail_gb` | **v0.10.2 起**（agent-node `2.4.1+`，[`host-telemetry.ts readDiskStats()`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/host-telemetry.ts)）—— 通过 `execFileSync('df', ['-k', '/'])` 采样，POSIX `-k` Linux + macOS 同 parse 路径；Windows / 解析失败 graceful `null`（dashboard 渲染 `—` 不误导成 0）。老 agent (`< 2.4.1`) 不带字段时三字段都 `null` |
 | `history.5m` | 最近 5min，**1 min bucket**（取自 `agent_telemetry` 历史表）|

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -34,7 +34,6 @@ curl http://localhost:9200/health
   "transport": "streamable-http",
   "sessions_count": 0,
   "sse_connections": 0,
-  "sse_sessions": {},
   "auth": "user-token",
   "security": "secured",
   "tmux": "disabled",
@@ -44,6 +43,12 @@ curl http://localhost:9200/health
   "uptime": 3600
 }
 ```
+
+Anonymous requests receive only the aggregate fields above and do not include
+`sse_sessions`. With a valid token, a system admin, legacy master, or DEV_OPEN
+caller can receive the full map; regular `utok_` / `ntok_` callers receive only
+sessions from networks they may access (or an empty object when they belong to
+none).
 
 ::: tip The `license` field is a v0.6 legacy
 `license: "trial"` is a leftover from the v0.6 era 14-day trial mechanism. After the Apache 2.0 OSS transition it is **no longer a commercial feature gate** (self-hosted has no notion of "expired"). The `send_task` path still runs the trial check only for backward compatibility (verify [`server/src/tools.ts:521`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L521) where `license_expired` is still emitted); if you hit it, see [troubleshooting](/en/troubleshooting). **The v0.9.x and v0.10.x scopes did not touch this** (Recovery & Observability took priority); full removal is queued for v0.11+ / unscheduled.
@@ -707,7 +712,7 @@ The `nodes` table is **persistent node identity** (written at creation, deleted 
 
 > [View source ↗](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)
 
-Delete a node from the hub server side — removes the persistent identity row in `nodes` and the heartbeat row in `sessions` (same transaction), and pushes a `node_deleted` SSE event to the alias channel and the network channel so dashboards refresh in real time. Shipped via PR #86 "node delete cascade and node_deleted SSE".
+Delete a node from the hub server side — removes the persistent identity row in `nodes` and the heartbeat row in `sessions` (same transaction), then pushes a `node_deleted` SSE event to the alias channel. Shipped via PR #86 "node delete cascade and node_deleted SSE".
 
 ```bash
 # :ref accepts node_id / node_name / alias (URL-encoded)
@@ -734,9 +739,10 @@ curl -X DELETE "http://localhost:9200/api/nodes/%E4%BB%A3%E7%A0%811%E5%8F%B7" \
 }
 ```
 
-**SSE side effect**: after the delete, a `node_deleted` event is pushed to **two SSE channels** ([`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)):
-- The alias's own SSE channel (if any subscribers remain)
-- The user-level SSE channel for the `network_id` (so every network member sees the deletion immediately)
+**SSE side effect**: after deletion, `node_deleted` is pushed only to the
+alias's own SSE channel (if a listener remains). The current handler does not
+emit a second network/user-channel deletion event; clients must not depend on
+one.
 
 ```json
 // node_deleted SSE event payload
@@ -844,7 +850,7 @@ curl "http://localhost:9200/api/server/$(python3 -c 'import urllib.parse; print(
   "hostname": "dev-machine",
   "ip": "192.168.1.42",
   "agent_count": 7,
-  "alert_level": "ok",
+  "alert_level": "green",
   "alerts": [],
   "latest": {
     "cpu_load_1min": 0.42,
@@ -870,8 +876,8 @@ curl "http://localhost:9200/api/server/$(python3 -c 'import urllib.parse; print(
 |------|------|
 | `host` | The host value from the request path |
 | `agent_count` | Active session count on this host (window over the latest row's `COUNT(*) OVER ()`) |
-| `alert_level` | `ok` / `warn` / `critical` (computed by `serverAlertLevel(latest)`; from v0.10.2 onwards, `disk_avail_gb < 1` triggers `critical` and `< 5` triggers `warn` — verify [`server/src/server.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/server.ts)) |
-| `alerts` | Active alert list, non-empty when `alert_level != ok` |
+| `alert_level` | `green` / `yellow` / `red` (computed by `serverAlertLevel(latest)`; `disk_avail_gb < 1` triggers `red` and `< 5` triggers `yellow`) |
+| `alerts` | Active alert list, non-empty when `alert_level != green` |
 | `latest` | Most recent heartbeat instant telemetry (CPU / mem / disk + `last_seen`) |
 | `latest.disk_total_gb` / `disk_used_gb` / `disk_avail_gb` | **Available from v0.10.2** (agent-node `2.4.1+`, [`host-telemetry.ts readDiskStats()`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/host-telemetry.ts)) — sampled via `execFileSync('df', ['-k', '/'])`; the POSIX `-k` flag shares one parse path across Linux + macOS; on Windows or parse failure, all three fields gracefully fall back to `null` (the dashboard renders `—` rather than a misleading `0`). Older agents (`< 2.4.1`) emit `null` for all three. |
 | `history.5m` | Last 5 min, **1 min bucket** (from the `agent_telemetry` history table) |

--- a/docs/tests/report-546-rest-factual-corrections.txt
+++ b/docs/tests/report-546-rest-factual-corrections.txt
@@ -1,0 +1,47 @@
+# PR #546 current-main factual correction replay
+
+Date: 2026-08-13 (Asia/Shanghai)
+
+## Coordinates
+
+- Base: `b7d1289bc67081ab597f17fba7034506394757ce`
+- Source: `c011a0601a08ad823ef746dd5e14bb5a8b243218`
+- Changed source files: `docs-site/docs/api/rest.md`,
+  `docs-site/docs/en/api/rest.md`
+
+## Corrections verified against current source
+
+1. Anonymous `GET /health` omits `sse_sessions`. Authenticated callers may
+   receive a full or network-filtered map according to their principal.
+2. `DELETE /api/nodes/:ref` calls `pushEvent(node.alias, ...)` once. The
+   handler does not emit a second network/user-channel deletion event.
+3. `serverAlertLevel()` returns `green`, `yellow`, or `red`; the REST examples
+   and field descriptions no longer claim `ok`, `warn`, or `critical`.
+
+Static negative scan over both pages found zero occurrences of the retired
+two-channel and old alert-level claims. Positive scans found the corrected
+bilingual descriptions and response examples.
+
+## Docker documentation build
+
+The first attempted command used a nonexistent `docs-site/Dockerfile` and
+failed before building. It is not counted as evidence. The successful run used
+the repository's existing Bun/VitePress Docker authority:
+
+```sh
+sg docker -c 'docker build -t anet-docs546:c011a060 -f tests/test596-goal-loop-docs/Dockerfile .'
+sg docker -c 'docker run --rm --entrypoint bash anet-docs546:c011a060 -ceu "cd /workspace/docs-site && bun run build"'
+```
+
+Result: VitePress client/server bundles and rendered pages completed
+successfully in `39.91s`. The existing large-chunk warning remains non-fatal.
+
+## Scope and limits
+
+- Documentation and report only; no server code, API, schema, database,
+  package, production config, or deployment changed.
+- This is a narrow replay of the still-valid factual corrections from old PR
+  #546. It does not resurrect that branch's deletion-heavy full rewrite.
+- The Docker build proves the changed Markdown renders; it does not deploy the
+  docs site.
+


### PR DESCRIPTION
## Outcome

Narrow current-main replay of the factual corrections from old PR #546 that #737 did not cover:

- anonymous `/health` no longer falsely shows `sse_sessions`; authenticated scope is documented;
- node deletion no longer claims a second network/user SSE broadcast that the handler does not emit;
- server health uses the actual `green / yellow / red` values, not `ok / warn / critical`.

## Coordinates

- Base: `b7d1289bc67081ab597f17fba7034506394757ce`
- Source: `c011a0601a08ad823ef746dd5e14bb5a8b243218`
- Report-only head: `b9246297fa4aeb324e37894fd1a39e868f1df601` (full SHA is the PR HEAD)

## Verification

- source-backed positive and negative scans over both bilingual pages;
- `git diff --check`;
- repository-authoritative Bun/VitePress Docker build completed successfully (`39.91s`).

The first attempted path `docs-site/Dockerfile` does not exist and failed before build; it is explicitly not claimed as evidence.

## Scope

Two REST Markdown files plus one report. No API/runtime/schema/DB/package/deployment change. Draft pending CI and independent review. Once this replacement lands, old #546 can be closed as superseded while preserving its history.