### PR TITLE
docs: 修正「没装 Bun 会怎样」—— #235 已消灭裸崩,文档还在承诺它

### DIFF
--- a/docs-site/docs/deploy/clean-server.md
+++ b/docs-site/docs/deploy/clean-server.md
@@ -16,7 +16,7 @@
 | **Bun** | ≥ 1.2.0 | `npm i -g bun` 或 `curl -fsSL https://bun.sh/install \| bash` |
 
 ::: warning Bun 必装
-`commhub-server` 是 Bun-shebang TypeScript（用 `bunx --bun` 起），**没装 Bun 直接 `anet hub start` 会裸崩 `spawn bunx ENOENT`**。是新机部署 8 坑里第 1 坑。
+`commhub-server` 是 Bun-shebang TypeScript（用 `bunx --bun` 起），**没装 Bun 时 `anet hub start` 会在启动前被拦下**，报 `❌ anet hub start requires the Bun runtime` 并以退出码 1 结束。是新机部署 8 坑里第 1 坑；[#235](https://github.com/sleep2agi/agent-network/issues/235) 之前它是裸崩 `spawn bunx ENOENT`，现在不会了。
 
 验证：
 ```bash

--- a/docs-site/docs/en/deploy/clean-server.md
+++ b/docs-site/docs/en/deploy/clean-server.md
@@ -16,7 +16,7 @@ It is **not** for users who already have anet installed — that's [Getting Star
 | **Bun** | ≥ 1.2.0 | `npm i -g bun` or `curl -fsSL https://bun.sh/install \| bash` |
 
 ::: warning Bun is non-optional
-`commhub-server` is Bun-shebang TypeScript (launched via `bunx --bun`). **Without Bun, `anet hub start` will hard-crash with `spawn bunx ENOENT`** — this is bug #1 from the fresh-server retro.
+`commhub-server` is Bun-shebang TypeScript (launched via `bunx --bun`). **Without Bun, `anet hub start` is refused before it launches anything**, printing `❌ anet hub start requires the Bun runtime` and exiting with code 1. This is bug #1 from the fresh-server retro; before [#235](https://github.com/sleep2agi/agent-network/issues/235) it hard-crashed with `spawn bunx ENOENT`, which it no longer does.
 
 Verify:
 ```bash

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -15,7 +15,7 @@ Skip this page and go to the [Upgrade Guide](/en/guide/upgrade) (usually `anet u
 **Prerequisites** (install both):
 
 - **Node.js ≥ 22.13.0**
-- **Bun ≥ 1.2.0** — install with `npm i -g bun` (or `curl -fsSL https://bun.sh/install | bash`). Step 2's `anet hub start` launches `commhub-server` via `bunx`, so **without Bun the very first step crashes with `spawn bunx ENOENT`**. After installing, `bun --version` should print a version.
+- **Bun ≥ 1.2.0** — install with `npm i -g bun` (or `curl -fsSL https://bun.sh/install | bash`). Step 2's `anet hub start` launches `commhub-server` via `bunx`, so **without Bun that step is refused before launch** with `❌ anet hub start requires the Bun runtime` (exit code 1, not a crash). After installing, `bun --version` should print a version.
 
 With both installed, `commhub-server` / `agent-node` are auto-fetched on first use — you don't install them manually.
 

--- a/docs-site/docs/en/troubleshooting.md
+++ b/docs-site/docs/en/troubleshooting.md
@@ -24,7 +24,15 @@ Before sharing logs, remove tokens, API keys, passwords, cookies, complete envir
 
 ## Installation and startup
 
-### `spawn bunx ENOENT` / Bun not found
+### `requires the Bun runtime` / `spawn bunx ENOENT` / Bun not found
+
+Current versions refuse before launch with a clear message:
+
+```
+❌ anet hub start requires the Bun runtime (commhub-server is bun-only …)
+```
+
+and exit with code 1. `spawn bunx ENOENT` is the **pre-[#235](https://github.com/sleep2agi/agent-network/issues/235)** behaviour — the string is kept in this heading so people arriving from older versions still find this section.
 
 Agent Network CLI requires Node.js ≥ 22.13, and the Hub requires Bun ≥ 1.2:
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -15,7 +15,7 @@
 **前置**（两个都要装）：
 
 - **Node.js ≥ 22.13.0**
-- **Bun ≥ 1.2.0** —— 装法 `npm i -g bun`（或 `curl -fsSL https://bun.sh/install | bash`）。第 2 步 `anet hub start` 底层用 `bunx` 起 `commhub-server`，**没装 Bun 第一步就会崩 `spawn bunx ENOENT`**。装完 `bun --version` 应有输出。
+- **Bun ≥ 1.2.0** —— 装法 `npm i -g bun`（或 `curl -fsSL https://bun.sh/install | bash`）。第 2 步 `anet hub start` 底层用 `bunx` 起 `commhub-server`，**没装 Bun 时第 2 步会在启动前被拦下**，报 `❌ anet hub start requires the Bun runtime`（退出码 1，不是崩溃）。装完 `bun --version` 应有输出。
 
 这俩装好就行；`commhub-server` / `agent-node` 首次用时自动拉取，不用手动装。
 

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -24,7 +24,15 @@ anet logs <alias> --follow
 
 ## 安装和启动
 
-### `spawn bunx ENOENT` / 找不到 Bun
+### `requires the Bun runtime` / `spawn bunx ENOENT` / 找不到 Bun
+
+当前版本会在启动前拦下并给出明确提示：
+
+```
+❌ anet hub start requires the Bun runtime (commhub-server is bun-only …)
+```
+
+退出码 1。`spawn bunx ENOENT` 是 [#235](https://github.com/sleep2agi/agent-network/issues/235) **之前**的旧表现，这里保留这个字样是方便从旧版本搜过来的人找到本节。
 
 Agent Network CLI 需要 Node.js ≥ 22.13，Hub 需要 Bun ≥ 1.2：
 


### PR DESCRIPTION
anet.sh 至今在多处用**现在时**声称:没装 Bun 时 `anet hub start` 会裸崩 `spawn bunx ENOENT`。
**这是 #235 之前的行为,而 #235 正是为了消灭它。**

## 代码侧的真实行为

`agent-network/bin/cli.ts:5652-5672`,在 `if (!serverAlreadyRunning)` 分支内:

```js
if (!commandExists("bunx") && !commandExists("bun")) {
  console.error(`\n  ❌ anet hub start requires the Bun runtime (commhub-server is bun-only …)`);
  …
  process.exit(1);
}
```

那段代码的注释自己写了动机:

> **#235** — Preflight bun/bunx presence BEFORE spawn. … Without this check, `spawn("bunx", ...)`
> emits an ENOENT 'error' event with no listener → Node crashes … **user-hostile and misdirects
> troubleshooting toward Node internals instead of the actual missing dependency**.

也就是说,**文档现在指的正是那个被特意消灭掉的错误串**。

## 分三类处理,不是全局替换

| 位置 | 处理 | 理由 |
|---|---|---|
| `guide/getting-started.md`(中英)<br>`deploy/clean-server.md:19`(中英) | 改为真实文案 + 退出码 1,并注明 #235 之前才是裸崩 | 现在时的**错误声称** |
| `troubleshooting.md:27`(中英) | **保留** `spawn bunx ENOENT` 字样,标题改为 `requires the Bun runtime` / `spawn bunx ENOENT`,正文首段给出当前真实输出 | 那个串是**搜索锚点** —— 从旧版本搜过来的人靠它找到本节,删掉等于把他们挡在门外 |
| `deploy/clean-server.md:363` | **不动** | 它是那次部署的**复盘表**,记录当时踩到的历史现象;而且「修复」列本来就写着 #235 给了 preflight + 友好提示,语境正确 |

## 验证

`docs-site` 本地 `npm run build` 通过(该项目未设 `ignoreDeadLinks`,有死链即 fail)。

## 发现路径

核 #744(`anet -v` 不声明 Bun 前置)时顺带查了文档,结果发现**文档其实是声明了前置的** ——
缺的是 CLI 自报。但文档对「缺了会怎样」的描述停在了 #235 之前。

两件事合起来看:前置这件事上,**CLI 少说了一半,文档多说了一半**。

## 合并后需要手动部署

🔴 `docs-site` 没接 git 自动部署,合并**不等于上线**(见 `deploy/docs-site/README.md`
与 #734 给 RELEASE-SOP Step 9 加的那条)。我会在合并后跟一次 `vercel --prod` 并验内容。
