### PR TITLE
docs(ci): 更正 qa-180 注释 —— 「卡住每一个 PR」不成立(main 无 branch protection)

### DIFF
--- a/tests/qa-180-rename-ghost/Dockerfile
+++ b/tests/qa-180-rename-ghost/Dockerfile
@@ -32,7 +32,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 #
 # 触发这次修改的实证:2026-08-13 本门在 PR #740 上红,失败原因正是
 #   process "/bin/sh -c curl -fsSL https://bun.sh/install | bash" ... exit code: 1
-# 这是硬门(非 report-only),所以上游 bun.sh 的任何抖动都会卡住每一个 PR。
+# 这个门是 hard-fail 型(失败即红,不是 report-only),所以上游 bun.sh 的任何抖动
+# 都会让每一个 PR 亮红。
+# 🔴 措辞更正:main **没有 branch protection**
+#    (GET /repos/…/branches/main/protection → 404 "Branch not protected"),
+#    所以它并不由机制阻止合并 —— 拦住的是纪律,不是 GitHub。
+#    原注释写「卡住每一个 PR」,把「会亮红」说成了「合不了」,不准确。
 RUN installed=0; \
     for i in 1 2 3; do \
       rm -f /tmp/bun-install.sh; \


### PR DESCRIPTION
`#743` 合并进来的注释里有一句不准确的表述,由通信牛的只读复核抓出来:

```
# 这是硬门(非 report-only),所以上游 bun.sh 的任何抖动都会卡住每一个 PR。
```

「**卡住**」不成立。`main` 没有 branch protection:

```
GET /repos/sleep2agi/agent-network/branches/main/protection
→ 404 "Branch not protected"
```

这个门失败时只会让 PR **亮红**,并不由机制阻止合并 —— 拦住的是纪律,不是 GitHub。
把「会亮红」说成「合不了」会让人**高估现有的保护**。

## 我要认的部分

我当时发现这个措辞问题后,**只在 PR 评论里更正,没有改代码里的注释** ——
于是不准确的表述原样合进了 main。**评论不等于改正**:
读代码的人看到的是注释,不是那条评论。

## 验证

```
git diff 全部改动行均为注释      grep 真退出码判定(rc=1 = 无非注释改动),不是管道
docker build -f tests/qa-180-rename-ghost/Dockerfile .   rc=0
```

第二条不是多余的 —— 注释也可能破坏 `RUN` 的 `\` 续行,所以仍然真构建了一次。
