### PR TITLE
fix(release): 同步脚本区分「已同步」与「注册目标已消失」(现有一处已静默失效)

### DIFF
--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -199,6 +199,26 @@ npm view @sleep2agi/<pkg>@preview version
 ```
 
 **判据是「远端 main 上是什么」，不是「我提了 bump PR」。**
+
+#### ③ 枚举版本位要用注册表，不要手写
+
+上面的 ①② 是**手写的子集**，而手写子集会漏 —— 2026-08-13 就漏了一处
+（`agent-network/src/opencode-agent-node-pair.ts`，详见 #745）。
+权威枚举在 `scripts/sync-pinned-versions.sh` 顶部的 `register` 区：
+
+```bash
+./scripts/sync-pinned-versions.sh <pkg> <新版本>     # 默认 dry-run
+# 🔴 非零退出 = 注册表里有目标已从文件里消失，这份清单不再覆盖它们。
+#    此时不要把它的输出当作"所有版本位都已同步"的证据。
+```
+
+🔴 **但注册表不等于全集。** 有些 pin 是**故意不自动同步**的：
+
+| pin | 为什么不自动同步 |
+|---|---|
+| `agent-network/src/opencode-agent-node-pair.ts` | 它的语义是「**已验证可共存**的精确配对」，不是「当前版本」。自动跟随会把那条 `intentionally fails when either package is bumped independently` 的绊线抹平 —— 该配对必须**重新验证过**才能改。见 #745。 |
+
+所以 Step 10 的完整做法是：**跑一遍注册表同步（看它是否非零退出）+ 单独确认上表里的手动 pin**。
 实测踩过：bump PR 开着没合的那段时间，npm 上 server 已经是新版，
 但 `main` 上 `PINNED_SERVER_VERSION` 还是旧版——**任何人从 main 切一次版，
 CLI 都会去拉旧 server，这次发版等于白发，且不产生任何报错**。

--- a/scripts/sync-pinned-versions.sh
+++ b/scripts/sync-pinned-versions.sh
@@ -110,6 +110,8 @@ sed_escape() {
 ESCAPED_VERSION="$(sed_escape "$NEW_VERSION")"
 
 CHANGED_FILES=()
+# 注册表里"已不存在的目标"计数;>0 时脚本以非零退出,让漂移可见而不是静默。
+MISSING_TARGETS=0
 
 # md / ts 通用模板：把 `@sleep2agi/<pkg>@<old>` 替换成新版本。
 # pkg 字面值不带尾随字符歧义（agent-network vs agent-network-dashboard），所以加 `[^a-zA-Z0-9_-]`
@@ -143,6 +145,18 @@ apply_or_preview() {
   local after
   after="$(sed "$sed_expr" "$file")"
   if [[ "$before" == "$after" ]]; then
+    # 🔴 "无变化" 有两种完全不同的原因,旧版把它们混成同一行 `unchanged:`:
+    #   (a) 目标在,且已经是目标版本            → 真的没事
+    #   (b) 目标**根本不在这个文件里**(被删/改名) → 注册表已与现实脱节
+    # (b) 读起来像 (a),于是这份清单会静默失去覆盖 —— 而 RELEASE-SOP
+    # 恰恰让人把它当作"硬编码版本位"的权威枚举。实例:
+    # `agent-network/bin/cli.ts:PINNED_DASHBOARD_VERSION` 已从 cli.ts 消失,
+    # 但注册表里还留着,同步时只会打印一行 unchanged。
+    if [[ -n "${3:-}" ]] && ! grep -q "const ${3} = " "$file"; then
+      echo "  🔴 MISSING TARGET: $file 里找不到 \`const ${3} = ...\` —— 注册表已过期"
+      MISSING_TARGETS=$((MISSING_TARGETS + 1))
+      return
+    fi
     echo "  unchanged: $file"
     return
   fi
@@ -177,7 +191,7 @@ for target in "${TARGETS[@]}"; do
     const_name="${target#*:}"
     echo ""
     echo "[$PKG → $file ($const_name)]"
-    apply_or_preview "$file" "$(ts_pinned_pattern "$const_name")"
+    apply_or_preview "$file" "$(ts_pinned_pattern "$const_name")" "$const_name"
   else
     echo ""
     echo "[$PKG → $target]"
@@ -204,4 +218,15 @@ if [[ "$MODE" == "apply" ]]; then
 else
   echo "dry-run 完成。如果上面 diff 看着对，加 --apply 实跑。"
   echo "  ./scripts/sync-pinned-versions.sh $PKG $NEW_VERSION --apply"
+fi
+
+# 注册表与现实脱节时以非零退出。理由:RELEASE-SOP 让人把这份注册表当作
+# "硬编码版本位"的权威枚举,所以它失去覆盖必须是**可见**的,而不是一行
+# 读起来像"已经是对的"的 unchanged。
+if [[ "$MISSING_TARGETS" -gt 0 ]]; then
+  echo ""
+  echo "🔴 $MISSING_TARGETS 个注册目标在文件里已不存在 —— 这份注册表不再覆盖它们。"
+  echo "   要么把常量改回来,要么从本脚本顶部的 register 区删掉那一行。"
+  echo "   在此之前不要把本脚本的输出当作'所有版本位都已同步'的证据。"
+  exit 6
 fi


### PR DESCRIPTION
`apply_or_preview` 在 sed 无变化时一律打印 `unchanged: <file>`。
但「无变化」有**两种完全不同的原因**:

```
(a) 目标在,且已经是目标版本                → 真的没事
(b) 目标根本不在这个文件里(被删 / 改名)     → 注册表已与现实脱节
```

**(b) 读起来像 (a)**,于是这份注册表会**静默失去覆盖** ——
而 `RELEASE-SOP` 恰恰让人把它当作「硬编码版本位」的权威枚举。

## 这不是假想,现在就有一个

```
scripts/sync-pinned-versions.sh:84
  register "@sleep2agi/agent-network-dashboard" "agent-network/bin/cli.ts:PINNED_DASHBOARD_VERSION"

但 PINNED_DASHBOARD_VERSION 已从 cli.ts 消失 —— 全仓只剩
.github/workflows/release.yml 的 case 分支和历史文档里的提及。
```

同步 dashboard 版本时,脚本只会打印一行 `unchanged: agent-network/bin/cli.ts`,
看起来像「已经是对的」。

## 改动

const 形式的目标,若 `const <NAME> = ` 在文件里**根本不存在** →
打印 `🔴 MISSING TARGET` 并计数;计数 >0 时脚本以 **exit 6** 结束。

## 验证:三个方向,**真退出码**

不是 `cmd | tail` 之后读 `$?`(那读到的是 `tail` 的)。

| 场景 | rc | MISSING 行 | 说明 |
|---|---|---|---|
| dashboard(注册目标已消失) | **6** | 1 | 漂移被暴露 |
| commhub-server(目标在,且已是目标版本) | **0** | 0 | 仍打印 `unchanged` |
| agent-node(只有 md 目标,不走 const 分支) | **0** | 0 | 未误伤 |

**第二行是关键对照**:如果没有它,这个改动很可能把每一次「已经同步好了」
都变成误报,让每次发版都卡在一个假警报上。

## 同时补 RELEASE-SOP Step 10 的第 ③ 条

Step 10 原本的 ①② 是我**手写的子集** —— 而手写子集会漏,2026-08-13 就漏了一处
(`opencode-agent-node-pair.ts`,见 #745)。现在指向注册表,并明确写出
**故意不自动同步**的 pin:

> `opencode-agent-node-pair.ts` 的语义是「**已验证可共存**的精确配对」,不是「当前版本」。
> 自动跟随会把那条 *intentionally fails when either package is bumped independently*
> 的绊线抹平 —— 该配对必须**重新验证过**才能改。

所以完整做法是:**跑注册表同步(看是否非零退出)+ 单独确认手动 pin**。
