### PR TITLE
fix(release): Gate 2 报分母并拒绝零覆盖审计(现在只审 3 个里的 1 个,却说 all)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,8 @@ jobs:
           [ -f "$cli" ] || { echo "::error::no $cli — cannot audit pins"; exit 1; }
 
           missing=0
+          audited=0
+          audited_names=""
           while IFS=$'\t' read -r var ver; do
             case "$var" in
               PINNED_SERVER_VERSION)    pkg='@sleep2agi/commhub-server' ;;
@@ -303,6 +305,8 @@ jobs:
               *) continue ;;
             esac
             echo "audit $var=$ver → $pkg"
+            audited=$((audited+1))
+            audited_names="$audited_names $var"
             if ! npm view "$pkg@$ver" version > /dev/null 2>&1; then
               echo "::error::$var=$ver not published on npm for $pkg"
               missing=$((missing+1))
@@ -311,7 +315,20 @@ jobs:
                    | sed -E 's/.*PINNED_(SERVER|NODE|DASHBOARD)_VERSION[^"]*"([^"]+)".*/PINNED_\1_VERSION\t\2/')
 
           [ "$missing" -eq 0 ] || { echo "::error::$missing PINNED_* pin(s) point at unpublished versions"; exit 1; }
-          echo "✅ Gate 2 — all PINNED_* versions exist on npm"
+          # 🔴 命中为零时这道门是**恒真**的:grep 找不到任何 pin,循环一次都不跑,
+          #    missing 保持 0,然后打印一行 ✅。而「这个仓不再钉任何版本」与
+          #    「grep 坏了 / 常量被改名」在输出上完全一样 —— 而后者正是本门要防的
+          #    #194 类 bug 的温床。所以零覆盖必须是失败,不是通过。
+          if [ "$audited" -eq 0 ]; then
+            echo "::error::Gate 2 audited 0 pins — no PINNED_*_VERSION matched in $cli."
+            echo "::error::Either the constants were renamed/removed, or the grep no longer matches."
+            echo "::error::A zero-scope audit cannot be distinguished from a broken one; refusing to pass."
+            exit 1
+          fi
+          # 报分母:成功文案必须说清**审了哪几个**,而不是笼统说 "all PINNED_*"。
+          # 这道门按设计只审 cli.ts 里真实存在的 pin(见上方注释),
+          # 所以「全部通过」永远只对被审的那几个成立。
+          echo "✅ Gate 2 — $audited pin(s) audited and published on npm:$audited_names"
 
   gate-3-release-notes:
     name: gate 3 — release notes shape (Install + Upgrade)


### PR DESCRIPTION
Gate 2 打印:

```
✅ Gate 2 — all PINNED_* versions exist on npm
```

但它只审 **grep 在 `cli.ts` 里恰好命中的那些 pin**。现状:

```
PINNED_SERVER_VERSION      在   → 被审
PINNED_NODE_VERSION        不在 → 静默跳过
PINNED_DASHBOARD_VERSION   不在 → 静默跳过
```

## 先说清楚:我不动那个「有意设计」

该段上方的注释写得很明确 —— *"Gate 2 audits only what's wired in, no false
'missing PINNED_DASHBOARD' alarms"*。**这个取舍是对的,本 PR 不碰它。**

问题在另外两处:

1. **成功文案声称的范围大于实际验证的范围。** 说 "all PINNED_*",实际是 1 个。
2. 🔴 **命中为零时这道门恒真。** grep 找不到任何 pin,循环一次都不跑,
   `missing` 保持 0,照样打印 ✅。
   而「这个仓不再钉任何版本」与「常量被改名 / grep 不再匹配」**在输出上完全一样** ——
   后者恰恰是本门要防的 #194 类 bug 的温床。

今天已经掉了两个(`NODE` / `DASHBOARD`)。再掉一个,这道门就在零覆盖下继续显示绿色。

## 改动

- 统计 `audited` 与 `audited_names`;
- `audited == 0` → 报错并 `exit 1`(**零覆盖的审计与坏掉的审计无法区分,拒绝通过**);
- 成功文案改成报分母:`N pin(s) audited and published on npm: <名字>`。

## 验证:把 Gate 2 的 shell 段从 YAML 里抽出来真跑

配假 `npm` 构造五种情形:

| 情形 | rc | 输出 |
|---|---|---|
| A 1 个 pin(= 现状) | 0 | `1 pin(s) audited … PINNED_SERVER_VERSION` |
| B 0 个 pin(常量被改名) | **1** | 三行 error 说明为何拒绝 |
| C 3 个 pin 都在 | 0 | 分母 3,三个名字都列出 |
| **D pin 指向未发布版本** | **1** | ← **本职未被弄坏** |
| **E `cli.ts` 缺失** | **1** | ← 原有行为保留 |

**D/E 是刻意做的对照:改一道门最大的风险是把它改松。**
本 PR 只加严「零覆盖」这一种情形,其余判定标准一律不动。

## 附:一处过时的注释(仅标注,不在本 PR 处理)

注释用 *"dashboard is Vercel-deployed, not pinned in CLI"* 解释为什么没有
`PINNED_DASHBOARD_VERSION`。但 dashboard **现在是 npm 包** ——
生产跑的是 `~/.commhub/dashboard-runtime-vNN/` 下固化的 npm 安装。
所以这个理由已经不成立了。**要不要重新引入该 pin 是产品决策**,不在本 PR 范围。
