### PR TITLE
fix(ci): slug 守卫报分母并拒绝零覆盖(实测:空目录扫描与干净通过输出逐字相同)

### DIFF
--- a/.github/scripts/check-no-memory-slugs.py
+++ b/.github/scripts/check-no-memory-slugs.py
@@ -88,6 +88,7 @@ ALLOWLIST_PATH_PREFIXES = (
 
 def scan(root: Path) -> list[tuple[str, int, str]]:
     findings: list[tuple[str, int, str]] = []
+    scanned = 0
     for dirpath, dirnames, filenames in os.walk(root):
         # Mutate dirnames in-place so os.walk doesn't descend into pruned dirs.
         dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
@@ -106,10 +107,11 @@ def scan(root: Path) -> list[tuple[str, int, str]]:
                 text = path.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
+            scanned += 1
             for lineno, line in enumerate(text.splitlines(), start=1):
                 for match in SLUG_RE.finditer(line):
                     findings.append((rel, lineno, match.group(0)))
-    return findings
+    return findings, scanned
 
 
 def main() -> int:
@@ -117,7 +119,22 @@ def main() -> int:
     if not root.exists():
         print(f"error: scan root does not exist: {root}", file=sys.stderr)
         return 2
-    findings = scan(root)
+    findings, scanned = scan(root)
+    # 🔴 报分母。"0 处违规" 只有在 "读了 N 个文件" 旁边才有意义:
+    #    扫了 0 个文件与扫了几千个干净文件,原本打印的是**逐字相同**的一行 OK。
+    #    实测(2026-08-13):对一个空目录跑本脚本 → rc=0 + "OK: no internal
+    #    memory-slug references found",与真正的干净通过无法区分。
+    print(f"scanned {scanned} file(s) under {root}")
+    if scanned == 0:
+        # 这道门守的是"内部 memory slug 不得泄漏进公开仓"这条红线。
+        # 零覆盖的守卫与坏掉的守卫无法区分,所以零覆盖必须是失败。
+        print(
+            "FAIL: scanned 0 files — the scan scope is empty. "
+            "Either the root is wrong or the include/exclude rules now match nothing; "
+            "a zero-scope guard cannot be distinguished from a broken one.",
+            file=sys.stderr,
+        )
+        return 3
     if not findings:
         print("OK: no internal memory-slug references found")
         return 0


### PR DESCRIPTION
这道门守的是一条红线:**内部 memory slug 不得泄漏进公开仓**。
但它对自己的扫描范围是盲的。**实测,不是推断:**

```
python3 .github/scripts/check-no-memory-slugs.py <空目录>
→ rc=0
  OK: no internal memory-slug references found     ← 与真正的干净通过逐字相同
```

include/exclude 规则一旦坏掉、或 root 传错,这道门会在**零覆盖**下继续显示绿色,
而「红线失去保护」这件事不会留下任何痕迹。

**对照(证明它不是死的,只是 scope 盲)**:同一脚本对含 `[[slug]]` 的目录
→ `rc=1` 并正确报出 `README.md:1: [[feedback_some_internal_slug]]`。
所以问题**特指零覆盖**,不是守卫本身失效。

## 改动

- `scan()` 统计实际读取的文件数并返回;
- `main()` 打印 `scanned N file(s) under <root>`;
- `scanned == 0` → 报错并 `return 3`。

## 验证:四个方向,全部真跑

| 方向 | rc | 输出 |
|---|---|---|
| A 空目录(零覆盖) | **3** | 明确说明为何拒绝 |
| **B 含违规** | **1** | ← **本职未被弄坏(关键对照)** |
| C 干净,1 个文件 | 0 | `scanned 1 file(s)` |
| **D 真仓库** | 0 | **`scanned 898 file(s)`** |

**D 这一行是这个 PR 的意义所在**:以前 CI 里扫了 898 个文件还是 0 个,
输出完全一样;现在这个数字在日志里,任何一次范围塌陷都会立刻显形。

## 这不是新发明的纪律,是补齐

`tests/scripts/lint-no-hardcoded-from-session.py` **早就这么做了** ——
target 缺失即失败、逐文件打印行数、最后报总分母。它的注释写得比我清楚:

> *A missing target means the guard silently stops checking it, which is how a
> scope bug turns into a vacuous pass. Fail loudly instead.*
>
> *a guard that reads 0 lines and a guard that reads 12000 clean ones both print "OK" otherwise.*

本 PR 只是把同一条纪律补到这道门上。同批还有 #754(sync 脚本)与 #755(发版 Gate 2)。
