### PR TITLE
fix(ci): rm -rf 守卫验证扫描范围并报分母(2>/dev/null 会吞掉「目录不存在」)

### DIFF
--- a/tests/scripts/lint-no-bare-rm-rf.sh
+++ b/tests/scripts/lint-no-bare-rm-rf.sh
@@ -39,6 +39,31 @@ cd "$REPO_ROOT"
 
 PATTERN='rm -rf [^/]*\$[A-Za-z_{]'
 
+# 🔴 先确认扫描范围非空,再谈"没找到违规"。
+#
+# 下面的 grep 带 `2>/dev/null`,所以扫描根一旦改名/移走,报错会被吞掉,
+# violations 为空,脚本直接打印 "✓ clean" 并 exit 0 —— 与"真的没有违规"
+# **输出完全一样**。这道门守的是 2026-06-16 那次 $HOME 回落到真实
+# /home/<user>、把项目目录抹掉的事故,零覆盖地显示绿色是不可接受的。
+#
+# 同族纪律见 tests/scripts/lint-no-hardcoded-from-session.py:
+# "a guard that reads 0 lines and a guard that reads 12000 clean ones
+#  both print OK otherwise"。
+SCAN_ROOTS=(tests agent-network/tests)
+for d in "${SCAN_ROOTS[@]}"; do
+  [ -d "$d" ] || {
+    echo "❌ [lint-no-bare-rm-rf] scan root missing: $d — 范围已变,更新 SCAN_ROOTS" >&2
+    exit 3
+  }
+done
+SCANNED=$(find "${SCAN_ROOTS[@]}" \
+  \( -name node_modules -o -name dist -o -name .git \) -prune -o \
+  -type f \( -name '*.sh' -o -name '*.bash' -o -name '*.zsh' \) -print 2>/dev/null | wc -l | tr -d ' ')
+if [ "${SCANNED:-0}" -eq 0 ]; then
+  echo "❌ [lint-no-bare-rm-rf] 扫描到 0 个 shell 文件 —— 零覆盖的守卫与坏掉的守卫无法区分,拒绝通过。" >&2
+  exit 3
+fi
+
 violations=$(grep -rnE \
   --include='*.sh' --include='*.bash' --include='*.zsh' \
   --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git \
@@ -65,5 +90,6 @@ if [ -n "$violations" ]; then
   exit 1
 fi
 
-echo "✓ [lint-no-bare-rm-rf] clean — no bare rm -rf \$VAR in tests/ or agent-network/tests/"
+# 报分母:"0 处违规" 只有在 "读了 N 个文件" 旁边才有意义。
+echo "✓ [lint-no-bare-rm-rf] clean — scanned $SCANNED shell file(s) in ${SCAN_ROOTS[*]}, no bare rm -rf \$VAR"
 exit 0


### PR DESCRIPTION
这道门守的是 **2026-06-16 那次事故**(`$HOME` 回落到真实 `/home/<user>`,抹掉了项目目录)。
但它对自己的扫描范围是盲的:

```sh
grep -rnE … tests/ agent-network/tests/ 2>/dev/null
```

`2>/dev/null` 会**吞掉「目录不存在」的报错**。扫描根一旦改名或移走,
`violations` 为空 → 打印 `✓ clean` → `exit 0`,与「真的没有违规」输出完全一样。

## 改动

- 先逐个确认 `SCAN_ROOTS` 存在,不存在即 `exit 3` —— 不再依赖那条被吞掉的 grep 报错;
- 统计实际参与扫描的 shell 文件数,为 0 → `exit 3`;
- 成功文案报分母。

## 验证:四个方向真跑

| 方向 | rc | 输出 |
|---|---|---|
| A 真仓库 | 0 | `scanned **251** shell file(s)` |
| B 扫描根被改名 | **3** | 明确指出是哪个根不见了 |
| C′ 只有守卫自己一个 `.sh` | 0 | 分母 **1** ← 证明计数器真在数,不是恒大 |
| **D 放入真违规文件** | **1** | 正确报出 `tests/bad.sh:3` ← **本职未被弄坏** |

## 🔴 一处诚实标注

「扫描到 0 个 shell 文件」这个分支**目前不可达** ——
守卫自身就是 `tests/scripts/` 下的一个 `.sh`,只要它还在原位,分母至少为 1。

保留它是**纵深防御**(例如将来 `--include` 规则改动),
但我不会把它说成「已验证会触发的路径」。C′ 用例验的是**计数器本身正确**,
不是那个分支 —— 一个恒返回大数的计数器同样能让 A 通过。

## 同批

`#754`(sync 脚本)、`#755`(发版 Gate 2)、`#756`(slug 守卫)。
参照实现是 `tests/scripts/lint-no-hardcoded-from-session.py`,它早就这么做了。
