### PR TITLE
fix(ci): pin Bun for qa-cli-02

### DIFF
--- a/docs/tests/report-qa-cli-02-pinned-bun.txt
+++ b/docs/tests/report-qa-cli-02-pinned-bun.txt
@@ -1,0 +1,50 @@
+# qa-cli-02 pinned Bun evidence
+
+Date: 2026-08-13 (Asia/Shanghai)
+Base: 43137f68fcc4f709e11ec39b8809cde6f527e6c3
+Source: ae33b8688216cdbb462ce2ca3d56c73f4d703031
+
+## Trigger
+
+PR #757's unchanged L0/L1 workflow failed twice at the same build layer:
+
+    tests/qa-cli-02-network-create/Dockerfile:4
+    RUN curl -fsSL https://bun.sh/install | bash
+    exit code: 1
+
+All other L1 suites in both attempts passed. This is one concrete member of
+the unpinned installer denominator tracked by #728; it is not attributed to
+PR #757 product bytes.
+
+## Change
+
+Only the qa-cli-02 Dockerfile changes in the source commit. It installs Bun
+1.3.14 from the versioned GitHub release archive, retries fail-closed, verifies
+the archive with sha256sum --check --strict, creates the bunx argv-0 symlink,
+and verifies both bun and bunx report the exact version.
+
+The checksum was independently read from the upstream Bun v1.3.14
+SHASUMS256.txt entry for bun-linux-x64.zip:
+
+    951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
+
+## Docker evidence
+
+- Exact image: sha256:3dc61c6bbe4bbb6729954a3c27573d532b161c06605d68e7918e14d0636b33bd
+- Archive verification printed: /tmp/bun-linux-x64.zip: OK
+- Full qa-cli-02 lifecycle: PASS
+- Runner log SHA256: 59cb0e146aa8a71e686f251516d2274d78174722d9dabdde015974f461544bd5
+- Wrong-checksum control: Docker build rc=1 at sha256sum, with
+  "computed checksum did NOT match"
+
+The first diagnostic archive-only build omitted the bunx symlink. Its image
+built, but the real lifecycle correctly failed when anet's preflight could not
+spawn bunx. The final source adds and version-checks that symlink; the complete
+network-create lifecycle then passes. This correction is included to avoid
+misrepresenting a successful binary download as a successful user journey.
+
+## Scope boundary
+
+No npm package, release, production process, configuration, database, secret,
+or repository setting was changed. This fixes one Dockerfile only; the
+remaining #728 denominator stays open.

--- a/tests/qa-cli-02-network-create/Dockerfile
+++ b/tests/qa-cli-02-network-create/Dockerfile
@@ -1,8 +1,24 @@
 FROM node:20-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-certificates jq unzip procps && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+
+ARG BUN_VERSION=1.3.14
+ARG BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
+
+# Pin and verify the exact archive instead of executing today's bun.sh output.
+# This check is a fail-closed CI signal; repository policy, not branch
+# protection, is what prevents maintainers from merging while it is red.
+RUN curl --fail --silent --show-error --location \
+      --retry 3 --retry-delay 2 --retry-all-errors \
+      "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" \
+      --output /tmp/bun-linux-x64.zip \
+  && echo "${BUN_LINUX_X64_SHA256}  /tmp/bun-linux-x64.zip" | sha256sum --check --strict \
+  && unzip -j /tmp/bun-linux-x64.zip 'bun-linux-x64/bun' -d /usr/local/bin \
+  && chmod 0755 /usr/local/bin/bun \
+  && ln -s bun /usr/local/bin/bunx \
+  && test "$(bun --version)" = "$BUN_VERSION" \
+  && test "$(bunx --version)" = "$BUN_VERSION" \
+  && rm -f /tmp/bun-linux-x64.zip
 
 WORKDIR /app
 COPY tests/qa-cli-02-network-create/run.sh /app/run.sh


### PR DESCRIPTION
## Outcome

Pins and verifies Bun for `qa-cli-02-network-create`, the unchanged L1 image that failed twice while PR #757 ran.

This is a narrow partial fix for #728. It does not close the remaining unpinned Dockerfile denominator.

## Frozen coordinates

- base used by source: `43137f68fcc4f709e11ec39b8809cde6f527e6c3`
- source: `ae33b8688216cdbb462ce2ca3d56c73f4d703031`
- report-only head: `69527dc9dd20d6945b6fa4b5b743c992067a690f`
- current main at push: `05d4b73e9efe42421700e56e163164759a361eb0`
- source delta: exactly `tests/qa-cli-02-network-create/Dockerfile`
- source → report delta: exactly `docs/tests/report-qa-cli-02-pinned-bun.txt`
- virtual merge against current main: no conflict markers

## Why

The PR #757 L0/L1 job failed twice at the unchanged layer:

```text
RUN curl -fsSL https://bun.sh/install | bash
exit code: 1
```

In each attempt every other L1 suite passed. Retrying did not make this member hermetic.

The replacement:

- pins Bun `1.3.14`;
- uses the versioned GitHub release archive with three fail-closed retries;
- verifies upstream SHA256 `951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f` using `sha256sum --check --strict`;
- installs and checks both `bun` and the required `bunx` argv-0 symlink.

The checksum was independently read from Bun v1.3.14 `SHASUMS256.txt`, not copied only from another test.

## Docker evidence

- image: `sha256:3dc61c6bbe4bbb6729954a3c27573d532b161c06605d68e7918e14d0636b33bd`
- archive verification: `/tmp/bun-linux-x64.zip: OK`
- complete qa-cli-02 lifecycle: `PASS qa-cli-02 network-create`
- runner log SHA256: `59cb0e146aa8a71e686f251516d2274d78174722d9dabdde015974f461544bd5`
- witnessed red: all-zero checksum build exited 1 at `sha256sum`, reporting `computed checksum did NOT match`

The first archive-only diagnostic omitted `bunx`: the image built, but the real lifecycle failed at the anet preflight. The final source creates and version-checks `bunx`; the complete journey then passes.

## Boundary

No package publication, release, production process/config/database, secret, or repository setting was changed. This PR remains Draft pending CI and independent review.
