### PR TITLE
fix(cli): #744 follow-up — bunx-only PATH 假报 + 文案里的裸 curl|bash

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1723,7 +1723,19 @@ function detectInstalledPackages() {
     // Bun 不是「可选运行时」,它是本机跑 hub 的硬前置:`anet hub start` 在
     // 缺 bun/bunx 时直接 process.exit(1)(见 hub start 里的前置校验)。
     // 此前自报里完全不提它,用户只能撞上去才知道 —— 这正是本次要修的。
-    bun: detectCommandVersion("bun", "Bun"),
+    // 🔴 判据必须与 hub 守卫同源。守卫是
+    //     if (!commandExists("bunx") && !commandExists("bun"))
+    // —— **任一存在即放行**。所以只探 `bun` 会在「只有 bunx」的 PATH 上
+    // 假报 "hub start will fail",而实际 hub 能起来。假警报比不报更糟:
+    // 它会让人去装一个本来就不需要装的东西,并开始怀疑其它自报信息。
+    // (通信牛在 #744 源码审里指出,已复验:cli.ts 的守卫确实是 OR。)
+    bun: (() => {
+      const direct = detectCommandVersion("bun", "Bun");
+      if (direct.state === "ok" || direct.state === "unknown") return direct;
+      // bun 不在 PATH 但 bunx 在 —— 守卫会放行,自报也必须放行。
+      const viaBunx = detectCommandVersion("bunx", "Bun (via bunx)");
+      return viaBunx.state === "ok" || viaBunx.state === "unknown" ? viaBunx : direct;
+    })(),
   };
 
   if (versions.agentNode.state !== "ok") {
@@ -1755,8 +1767,14 @@ function formatLazyComponent(pkg: DetectedVersion): string {
 function formatRequiredBun(pkg: DetectedVersion): string {
   if (pkg.state === "ok" && pkg.version) return `✓ ${pkg.displayName} v${pkg.version}`;
   if (pkg.state === "unknown") return `✓ ${pkg.displayName} installed`;
+  // 🔴 这里刻意**不**给 `curl … | bash` 一行流。
+  // 那正是 #729/#733/#743/#728 一整条线在修的 fail-open 形状:
+  // 管道的退出码只反映 consumer,producer(curl)失败会被吞掉。
+  // 我们自己在 CI 里把它当缺陷修掉,就不该在 CLI 里教用户这么做。
+  // 给包管理器安装(有校验、可回滚)+ 官方安装页,由用户选。
   return `✗ ${pkg.displayName} not found — \`anet hub start\` will fail without it `
-    + `(commhub-server is bun-only). Install: curl -fsSL https://bun.sh/install | bash`;
+    + `(commhub-server is bun-only). Install with: npm i -g bun `
+    + `— or follow https://bun.sh/docs/installation`;
 }
 
 function formatOptionalRuntime(pkg: DetectedVersion, reason: string): string {


### PR DESCRIPTION
`#744` 已经合了,但源码审在合并后指出两条 correctness。**两条都成立**,我复验后修。

## ① 探测口径与 hub 守卫不同源 → bunx-only PATH 上假报

守卫(`cli.ts:5689`):

```js
if (!commandExists("bunx") && !commandExists("bun")) {   // 任一存在即放行
```

而我写的自报只探 `bun`。所以在**只有 `bunx`** 的 PATH 上,
`anet -v` 会说 `✗ Bun not found — anet hub start will fail`,
而实际 `anet hub start` **能起来**。

🔴 **假警报比不报更糟**:它让人去装一个本来不需要装的东西,
并且从此开始怀疑这份自报里的其它每一行。

修法是让两者同源:先探 `bun`,不在再探 `bunx`,任一命中即视为满足。

## ② 我自己教了那个 fail-open 形状

原文案:

```
Install: curl -fsSL https://bun.sh/install | bash
```

这**正是** `#729` → `#733` → `#743` → `#728` 一整条线在修的东西 ——
管道的退出码只反映 consumer,`curl` 失败会被吞掉。

**我们在 CI 里把它当缺陷修掉,就不该在 CLI 里教用户这么做。**
改成 `npm i -g bun`(有校验、可回滚)+ 官方安装页,让用户自己选。

## 验证:三个 PATH 场景,真跑

| 场景 | 输出 |
|---|---|
| A 有 `bun` | `✓ Bun v1.3.14` |
| **B 只有 `bunx`** | **`✓ Bun (via bunx) v1.3.14`** ← 假报已修 |
| C 两个都没有 | `✗ … Install with: npm i -g bun — or follow https://bun.sh/docs/installation` |

并确认输出里**已无** `curl … | bash`。

回归:`bun test src/` 与 main 基线一致(433 pass / 3 fail,同样三条既有失败),**无新增失败**。

## 一句自评

这两条都是我在 `#744` 里亲手写进去的,而第 ② 条尤其不该发生 ——
我当天就在修同一个形状的四个 PR。**在别处认得出的缺陷,在自己新写的代码里没认出来。**
