### PR TITLE
fix(installer): hub-only.sh 已知道 bun 没装上,却不告诉用户

### DIFF
--- a/docs-site/docs/public/hub-only.sh
+++ b/docs-site/docs/public/hub-only.sh
@@ -89,6 +89,21 @@ if [ "$(id -u)" -eq 0 ]; then
     [ -x "$USER_BUN" ] && cp "$USER_BUN" /usr/local/bin/bun && chmod +x /usr/local/bin/bun
   fi
 
+  # `|| true` 是有意的:非 root 用户装 bun 允许失败,不该让整个安装中止。
+  # 但**失败后保持沉默不是有意的** —— 上面这步已经知道 bun 在不在,
+  # 却什么都不说,脚本继续往下并宣告安装完成。用户要等到
+  # `anet hub start` 才会撞上 "requires the Bun runtime"。
+  # commhub-server 是 bun-only,所以这里必须明说,并给出可执行的补救。
+  if ! command -v bun >/dev/null 2>&1; then
+    echo ""
+    echo "  [!] Bun 未能自动安装 —— commhub-server 是 bun-only,"
+    echo "      在装上之前 'anet hub start' 不会成功。"
+    echo "      补救(任选其一):"
+    echo "        npm i -g bun"
+    echo "        或按 https://bun.sh/docs/installation 安装后重跑本脚本"
+    echo ""
+  fi
+
   if [ "$AUTOSTART" = "1" ] || [ "$AUTOSTART" = "true" ]; then
     echo "[root 4/4] enable-linger ($USERNAME systemd 不依赖登录)..."
     loginctl enable-linger "$USERNAME"


### PR DESCRIPTION
这是**线上给 root 用户 `pipe` 进 bash 的公开安装脚本**
(`https://anet.sh/hub-only.sh`,当前返回 200)。

```sh
su - "$USERNAME" -c 'curl -fsSL https://bun.sh/install | bash' >/dev/null 2>&1 || true
USER_BUN="/home/$USERNAME/.bun/bin/bun"
[ -x "$USER_BUN" ] && cp "$USER_BUN" /usr/local/bin/bun && chmod +x /usr/local/bin/bun
```

`|| true` 是**有意的** —— 非 root 用户装 bun 允许失败,不该让整个安装中止。
**本 PR 不动它。**

问题在于**失败之后保持沉默**:第 89 行的 `[ -x "$USER_BUN" ]` 已经知道 bun 在不在了,
却什么都不说,脚本继续往下走并**宣告安装完成**。
用户要等到 `anet hub start` 才会撞上 `requires the Bun runtime` ——
那条文案本身很好(#235),但那已经是下一步了,而且是在用户以为装完之后。

`commhub-server` 是 bun-only,这个前置在安装脚本里必须明说。

## 改动

安装块之后加一次 `command -v bun` 检查,缺失时打印可执行的补救。
**不改变退出码,不中止安装** —— 只是把一个脚本**已经掌握、却没告诉用户**的事实说出来。

| 分支 | 行为 |
|---|---|
| bun 存在 | 静默 —— 正常路径不打扰用户 |
| bun 缺失 | 打印补救(`npm i -g bun` 或官方安装页) |

`bash -n` 通过。

## 🔴 我在过程中收回的一个错误判断

我最初以为第 83 行是 fail-open:

```sh
curl -fsSL https://deb.nodesource.com/setup_22.x | bash - >/dev/null 2>&1
apt-get install -y -qq nodejs >/dev/null
```

理由是「管道吞掉 curl 失败,下一行照常执行」。**这个判断不成立。**

脚本第 32 行有 `set -euo pipefail`。实测复现:

```
set -euo pipefail; (exit 22) | bash -c "true" >/dev/null 2>&1; echo after
→ 脚本 rc=22,"after" 没有打印
```

所以那一处是 **fail-closed**,本 PR 不动它。

真正 fail-open 的只有带 `|| true` 的那一处,而它的 `|| true` 又是有意的 ——
所以最终修的是**沉默**,不是那个管道。**先验语义再动手,和先动手再解释,结论完全不同。**
