### PR TITLE
fix(cli): bun 指引的其余三处一并收口(#761 只修了我自己引入的那一处)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -5707,7 +5707,10 @@ async function serverCommand() {
       if (!commandExists("bunx") && !commandExists("bun")) {
         console.error(`\n  ❌ anet hub start requires the Bun runtime (commhub-server is bun-only — uses Bun.serve + bun:sqlite, no Node fallback).`);
         console.error(`\n     Install Bun first:`);
-        console.error(`       curl -fsSL https://bun.sh/install | bash`);
+        // 刻意不给 `curl … | bash` 一行流:那正是 #729/#733/#743 在修的 fail-open
+        // 形状(管道退出码只反映 consumer)。CI 里当缺陷修,就不该在 CLI 里教用户。
+        console.error(`       npm i -g bun`);
+        console.error(`       # 或按 https://bun.sh/docs/installation 安装`);
         console.error(`       # restart your shell so PATH picks up ~/.bun/bin`);
         console.error(`\n     Then re-run: anet hub start`);
         console.error(`\n     More info: https://bun.sh/install\n`);
@@ -5754,10 +5757,15 @@ async function serverCommand() {
         // commhub-server is TypeScript w/ a bun shebang; it requires Bun.
         // Most Node-only systems hit this exact failure.
         let bunInstalled = false;
-        try { execSync("command -v bun", { stdio: "pipe" }); bunInstalled = true; } catch {}
+        // 判据与上面那道守卫同源:bunx **或** bun 任一存在即可。
+        // 只探 bun 会在 bunx-only 的 PATH 上假报(同 #761 修的那处)。
+        for (const probe of ["command -v bun", "command -v bunx"]) {
+          try { execSync(probe, { stdio: "pipe" }); bunInstalled = true; break; } catch {}
+        }
         if (!bunInstalled) {
           console.error(`  ❌ Bun is required to run commhub-server. Install with:`);
-          console.error(`     curl -fsSL https://bun.sh/install | bash`);
+          console.error(`     npm i -g bun`);
+          console.error(`     # 或按 https://bun.sh/docs/installation 安装`);
           console.error(`     # then re-run: anet hub start`);
         } else {
           console.error(`  ❌ Server failed to start. Check the bunx output above for the real error.`);
@@ -8508,11 +8516,13 @@ function selfUpgradeDetached(channel: ReleaseChannel): never {
   console.log(`[anet]   Log: ${errLog}`);
   console.log(`[anet]   When npm finishes, open a NEW terminal (or 'source ~/.bashrc') and run \`anet --version\` to verify ${channel}.`);
   console.log(`[anet]   The current shell's \`anet\` binary will keep pointing at the old version until you do.`);
-  if (!commandExists("bun")) {
+  // 同源判据:hub start 的守卫接受 bunx **或** bun,这里必须一致,
+  // 否则 bunx-only 的机器会收到一条「will fail」的假警报(同 #761)。
+  if (!commandExists("bun") && !commandExists("bunx")) {
     // #214 P2.7 — anet hub start needs bun (commhub-server is bun-only).
     // Surface this now so users don't hit it on next `anet hub start`.
     console.log(`[anet]   note: bun is not installed; \`anet hub start\` will fail without it.`);
-    console.log(`[anet]         Install: curl -fsSL https://bun.sh/install | bash`);
+    console.log(`[anet]         Install: npm i -g bun  (或 https://bun.sh/docs/installation)`);
   }
   console.log(`[anet]   (Use \`anet upgrade --no-auto-self\` next time if you prefer to manage the install yourself.)`);
   try {


### PR DESCRIPTION
`#761` 修了 `anet -v` 那一处之后,我按「**改之前先 grep 所有同类点**」复查,
发现 `cli.ts` 里还有**三处**在教用户跑裸 `curl -fsSL https://bun.sh/install | bash`:

```
5710  hub start 守卫的 "Install Bun first"
5760  hub start 内部的二次检查
8515  upgrade 路径上的提前告知
```

**这三处比我早存在** —— `#761` 只修了我自己引入的那一处,是不完整的。

## 而且其中两处带着同一个 bug

`5760` 和 `8515` 用**单条件**判断(`command -v bun` / `commandExists("bun")`),
而 hub start 的真守卫是:

```js
if (!commandExists("bunx") && !commandExists("bun"))   // 任一存在即放行
```

所以 **bunx-only 的机器会收到「will fail」的假警报** —— 与 `#761` 修的是同一个缺陷,
只是位置不同。

## 五处一起改

| 处 | 改什么 |
|---|---|
| 5710 / 5760 / 8515 | 文案 → `npm i -g bun`(有校验、可回滚)+ 官方安装页 |
| 5760 / 8515 | 判据 → 与守卫同源(`bunx` **或** `bun`) |

## 验证

```
cli.ts 里裸 curl … | bash 清零        grep 真退出码 rc=1
bunx-only PATH 实测                  ✓ Bun (via bunx) v1.3.14   ← 无假报
两个都没有时                          输出里已无 curl … | bash
回归 bun test src/                    433 pass / 3 fail,与 main 基线同样三条既有失败,无新增
```

## 过程记录

改这五处时我**四次猜错缩进**,四次都被「替换前断言命中 1 次」拦下,
没有产生静默 no-op。第四次之后改成**先把五处锚点全部断言通过、再统一写盘** ——
避免「前四处改了、第五处失败」的半改状态。
(那次异常确实中止在写盘之前,文件未受影响,已核实。)
