### PR TITLE
fix(hub): bun-only 机器不再通过前置检查后才失败,且报错不再归因于 PATH

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -5704,7 +5704,21 @@ async function serverCommand() {
       // The post-spawn 15s /health poll then a Bun-missing check (see
       // ~30 lines down) cannot rescue this — spawn ENOENT throws before
       // the poll loop ever runs.
-      if (!commandExists("bunx") && !commandExists("bun")) {
+      // 🔴 判据必须等于**真实需求**。下面唯一的启动方式是 `spawn("bunx", …)`
+      // (cli.ts 内 commhub-server 只有这一个 spawn 点),所以「有 bun 就放行」是错的:
+      // bun 单独从来不够。原来的 OR 会让 bun-only 的机器通过前置检查,
+      // 然后在 spawn 处失败,并报「it disappeared from PATH」—— 而它从来没在过。
+      // 实测:release zip 装的 bun 不带 bunx;只加一条 bunx 软链,hub 立刻起来(#766)。
+      if (!commandExists("bunx")) {
+        // bun 在、bunx 不在 —— 这是最常见也最容易被误诊的一种,单独给话术。
+        if (commandExists("bun")) {
+          console.error(`\n  ❌ 找到了 bun,但没有 bunx —— anet hub start 用 \`bunx\` 启动 commhub-server。`);
+          console.error(`\n     bunx 通常由官方安装器创建。补一条即可:`);
+          console.error(`       ln -s "$(command -v bun)" "$(dirname "$(command -v bun)")/bunx"`);
+          console.error(`\n     或改用带 bunx 的安装方式:  npm i -g bun`);
+          console.error(`\n     Then re-run: anet hub start\n`);
+          process.exit(1);
+        }
         console.error(`\n  ❌ anet hub start requires the Bun runtime (commhub-server is bun-only — uses Bun.serve + bun:sqlite, no Node fallback).`);
         console.error(`\n     Install Bun first:`);
         // 刻意不给 `curl … | bash` 一行流:那正是 #729/#733/#743 在修的 fail-open
@@ -5734,7 +5748,9 @@ async function serverCommand() {
       // preflight's UX promise. Log + exit gracefully.
       child.on("error", (err: any) => {
         if (err?.code === "ENOENT") {
-          console.error(`\n  ❌ Failed to spawn bunx — it disappeared from PATH after the preflight check.`);
+          console.error(`\n  ❌ Failed to spawn bunx.`);
+          // 不再说 "disappeared from PATH":那条归因会把人引去查 PATH 与
+          // 「谁卸载了 bun」,而绝大多数情况是这台机器从来没有过 bunx(#766)。
           console.error(`     This usually means Bun was uninstalled or PATH changed mid-process.`);
           console.error(`     Try: which bunx && bunx --version`);
         } else {


### PR DESCRIPTION
`cli.ts` 里 commhub-server 只有**一个** spawn 点:

```js
child = spawn("bunx", serverArgs, { env, stdio: "inherit" });   // cli.ts:5729
```

所以「有 `bun` 就放行」是错的 —— **`bun` 单独从来不够**。原来的守卫:

```js
if (!commandExists("bunx") && !commandExists("bun"))   // 任一存在即放行
```

会让 bun-only 的机器**通过前置检查**,然后在 spawn 处失败并报:

```
❌ Failed to spawn bunx — it disappeared from PATH after the preflight check.
```

而 `bunx` **从来就没在过**。这条归因会把人引去查 PATH 和「谁卸载了 bun」。

## 改动(两处,都不新增启动路径)

1. 前置检查改为 `!commandExists("bunx")`,并对 **bun 在、bunx 不在** 这一最常见、
   最易误诊的情形单独给话术 + 可直接执行的补救;
2. spawn 失败文案去掉 `disappeared from PATH` 的归因。

## 验证:三个场景,**隔离容器**里真跑

> 本机跑不了 —— `127.0.0.1:9200` 是生产 hub,探针会短路成 `already running`,
> **被测分支根本不执行**。我今天已经在这上面栽过一次,这次直接进容器。

| 场景 | 结果 |
|---|---|
| A `bun` 在 / `bunx` 不在 | 新的精确报错 + `ln -s` 补救 |
| B 两个都没有 | 落到**原有**通用提示,行为未变 |
| **C `bunx` 在** | **越过前置,进入 `Starting CommHub Server…` 并开始拉依赖** |

**C 是关键对照**:收紧一道前置检查,最大的风险是把本来能用的机器挡在外面。
没有 C,A 的绿是没有意义的。

场景 A 的容器用 GitHub release zip 装 bun(zip 里**只有 `bun`、不带 `bunx`**),
不是人为构造 —— 这正是现实中会踩到的装法,也是本仓最近新增镜像采用的装法。

## 未采纳的另一种设计(留给 owner)

也可以在缺 `bunx` 时回退到 `bun x`。那会**新增一条启动路径**,属于设计取舍。
本 PR 不做 —— 只把「晚失败 + 错归因」变成「早失败 + 说真话」。

## 附:这条也修正了我自己前面的工作

`#761` / `#764` 我把 `anet -v` 的探测**对齐到了这道守卫**。守卫既然是错的,
那份自报在 bun-only 机器上也会误报「✓ Bun」。本 PR 只改 hub start 这一侧;
自报侧要不要跟着改,取决于上面那个设计取舍,等定了一起动。
