### PR TITLE
fix(cli): --batch 不再静默丢弃 --runtime,提示不再只推荐走不通的 --preset

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -3878,6 +3878,20 @@ async function createCommand(idOverride?: string) {
   // (issue #55, Vincent 4335). All other create flows fall through to the
   // existing single-node create path below.
   if (!idOverride && args.includes("--batch")) {
+    // 🔴 --batch 向导的 runtime **只**来自 VENDORS 表(cli.ts 内 findVendorByModel /
+    // resolveVendorSelection / selectVendorAndModel 三个入口全读它),而该表只能产出
+    // claude-agent-sdk / claude-code-cli / codex-sdk。所以 --runtime 在这条路上
+    // 会被**静默丢弃**,用户显式表达的意图无声消失,然后掉进一个表达不了该运行时的向导。
+    // 与其丢弃,不如明说二者不能同用,并指向真正可用的写法(#765)。
+    if (args.includes("--runtime")) {
+      console.error(`\n  ❌ --batch 与 --runtime 不能同用。`);
+      console.error(`\n     --batch 多节点向导的运行时只能来自内置 vendor 预设`);
+      console.error(`     (claude-agent-sdk / claude-code-cli / codex-sdk),它无法表达`);
+      console.error(`     opencode-cli、grok-build-acp、grok-build-cli、codex-app-server。`);
+      console.error(`\n     要指定这些运行时,去掉 --batch,按单节点创建:`);
+      console.error(`       anet node create <name> --runtime <runtime>\n`);
+      process.exit(1);
+    }
     return await createBatchWizardCommand();
   }
   const id = idOverride || args[1];
@@ -12327,7 +12341,13 @@ async function createBatchWizardCommand() {
     const sel = await selectVendorAndModel();
     if (!sel) {
       closeRL();
-      console.error(`[anet] vendor selector 不可用（非交互终端？用 --preset <model-id> 指定）。`);
+      // 原文案无条件推荐 --preset,但 --preset 只能选到 VENDORS 表里的运行时;
+      // 对 opencode-cli / grok-build-* / codex-app-server,--preset **永远无解**,
+      // 照着提示反复试是走不通的(#765)。所以把另一条真正可用的路一起给出来。
+      console.error(`[anet] vendor selector 不可用（非交互终端？）。`);
+      console.error(`[anet]   预设运行时(claude-agent-sdk / claude-code-cli / codex-sdk):用 --preset <model-id>`);
+      console.error(`[anet]   其它运行时(opencode-cli / grok-build-acp / grok-build-cli / codex-app-server):`);
+      console.error(`[anet]     去掉 --batch,用 anet node create <name> --runtime <runtime>`);
       return;
     }
     runtime = sel.runtime; model = sel.model; baseUrl = sel.baseUrl;


### PR DESCRIPTION
`#765` 的两条修法。**不新增能力,只是不再撒谎。**

## 问题

`--batch` 向导的 runtime **只**来自 `VENDORS` 表
(`findVendorByModel` / `resolveVendorSelection` / `selectVendorAndModel` 三个入口全读它),
而该表只能产出 `claude-agent-sdk` / `claude-code-cli` / `codex-sdk`。

后果两条:

1. **用户显式传的 `--runtime opencode-cli` 被静默丢弃**,然后掉进一个表达不了该运行时的向导 ——
   意图无声消失,没有任何提示;
2. **失败提示无条件推荐 `--preset <model-id>`**,而 `--preset` 对
   `opencode-cli` / `grok-build-acp` / `grok-build-cli` / `codex-app-server` **永远无解**。
   照着提示反复试是走不通的。

## 改动

- `--batch` 与 `--runtime` 同时出现 → **明确报冲突**,并给出真正可用的写法:
  `anet node create <name> --runtime <runtime>`;
- vendor selector 失败提示**分两类给路**:预设运行时用 `--preset`,
  其余四个明确告诉用户去掉 `--batch`。

## 验证:隔离容器

> 本机会撞生产 hub 而短路,按今天定的规则(依赖「某物不存在」的验证默认进容器)直接进容器。

| 场景 | 结果 |
|---|---|
| A `--batch` + `--runtime` | 明确冲突报错 + 可用替代写法 |
| **B 只有 `--batch`** | **行为不变,照旧进向导** ← 关键对照 |

**B 是这个 PR 的安全边界**:改一个入口的参数校验,最大的风险是把本来能用的
`--batch` 流程也弄坏。没有 B,A 的绿不说明问题。

产物 grep:新文案三处命中,旧的无条件 `--preset` 文案**清零**。

## 范围

`--runtime` 在**非 batch** 路径上一直是可用的(`cli.ts:3886` 的 usage 字符串列出全部七个运行时)。
本 PR **不改那条路**,只是不再让 `--batch` 把它吃掉。
