### PR TITLE
fix(ci): slug 守卫覆盖 .sh/.py —— 三处真 slug 一直藏在 898 个文件的扫描范围之外

### DIFF
--- a/.github/scripts/check-no-memory-slugs.py
+++ b/.github/scripts/check-no-memory-slugs.py
@@ -44,7 +44,9 @@ from pathlib import Path
 # - closing `\]\]`
 SLUG_RE = re.compile(r"\[\[(feedback|project|reference|user)_[a-z0-9_-]+(?:\.md)?\]\]")
 
-EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".md", ".yml", ".yaml"}
+# .sh / .py 同样是公开仓里可见的文件,此前不在覆盖内 —— 实测 2026-08-13,
+# 三处真 slug 就藏在 tests/ 下的 shell 脚本里,门扫 898 个文件却看不见它们。
+EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".md", ".yml", ".yaml", ".sh", ".py"}
 
 # Walk-relative dir names to prune entirely.
 SKIP_DIRS = {

--- a/tests/docker-e2e-loop-npm-pack.sh
+++ b/tests/docker-e2e-loop-npm-pack.sh
@@ -5,8 +5,8 @@
 # .tgz artifact that `npm publish` uploads, so installing from .tgz
 # proves the user-install path WITHOUT needing to actually publish to
 # the registry. This catches "source builds work but the user's npm
-# install is broken" regressions (per [[feedback_docker_smoke_gate_before_ship]]
-# / [[feedback_anet_node_behavior_stale_install]]).
+# install is broken" regressions (per 「发版前必须过 Docker 冒烟门」这条判据
+# / 「旧的全局安装会让 anet 行为与文档不符」那类事故).
 #
 # Pass criteria:
 #   1. npm pack succeeds for agent-network, agent-node, server

--- a/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh
+++ b/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh
@@ -154,7 +154,7 @@ GRANDCHILDREN=$(pgrep -P "$CHILD_PID" 2>/dev/null || echo "")
 if [[ -n "$GRANDCHILDREN" ]]; then
   ok "child has live grandchild agent-node process(es): $GRANDCHILDREN (full process tree intact)"
 else
-  bad "child has NO grandchild — starter alive but agent-node process missing (the [[feedback_commit_presence_not_functional_proof]] pattern: 'alive' != 'wired')"
+  bad "child has NO grandchild — starter alive but agent-node process missing (the 「提交存在不等于功能可用」这条判据 pattern: 'alive' != 'wired')"
 fi
 
 note "Stage 7 — send-task三连 third leg:真 dispatch + verify child processes"


### PR DESCRIPTION
这个仓是 **PUBLIC**,slug 守卫存在、今天刚补过分母(`#756`),但 `EXTENSIONS` 是:

```python
{".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".md", ".yml", ".yaml"}
```

**没有 `.sh` / `.py`。** 而三处真的内部 memory slug 正好都在 `tests/` 下的 shell 脚本里:

```
tests/docker-e2e-loop-npm-pack.sh:8,9
tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh:157
```

门每次报 `scanned 898 files, OK` —— **而这三处从不在那 898 里**。

## 改动

1. `EXTENSIONS` 增加 `.sh` / `.py`;
2. 三处 slug 换成它所指的判据原意(slug 是纯指针,信息零损失)。

## 解耦对照:单一变量是 `EXTENSIONS`

| 场景 | rc | 输出 |
|---|---|---|
| B 新覆盖 + 在 `.sh` 里注入一处真 slug | **1** | 报出 `docker-e2e-loop-npm-pack.sh:200` |
| **C 旧覆盖 + 同一处注入** | **0** | `scanned 898` —— **静默漏掉** |
| 还原 | 0 | `scanned 1176`,OK |

**C 是这个 PR 的证据**:同一处注入,只把 `EXTENSIONS` 改回去就漏掉了。
缺口是真的,不是假想。分母 898 → 1176,多出的正是新覆盖的 `.sh` / `.py`。

## 顺带确认两件不该动的

- 门的 `SLUG_RE` 是 `\[\[(feedback|project|reference|user)_…\]\]`,**要求四个前缀之一** ——
  所以 `agent-network/src/im/feishu/outbound-marker.ts` 里的 `"text [[marker]]\n"`
  (飞书外发标记的字面格式)**不会误报**。我一开始用宽模式扫时它亮了红,
  查过才确认是我的模式粗、不是门有问题;
- 门自身的模式说明已在 `SELF_ALLOWLIST` 里,扩覆盖不会让它自己红。

## 与同批的关系

同一天在三个仓做同一件事:`#756`(本仓补分母)、`dashboard#25`(补上缺失的门 + 清 2 处泄漏)、
本 PR(补覆盖 + 清 3 处泄漏)。三个仓的 slug 门现在才算齐。
