### PR TITLE
docs: 修正 #750 —— 我把 preview 的行为当成现状写进了公开文档(latest 用户仍是裸崩)

### DIFF
--- a/docs-site/docs/deploy/clean-server.md
+++ b/docs-site/docs/deploy/clean-server.md
@@ -16,7 +16,10 @@
 | **Bun** | ≥ 1.2.0 | `npm i -g bun` 或 `curl -fsSL https://bun.sh/install \| bash` |
 
 ::: warning Bun 必装
-`commhub-server` 是 Bun-shebang TypeScript（用 `bunx --bun` 起），**没装 Bun 时 `anet hub start` 会在启动前被拦下**，报 `❌ anet hub start requires the Bun runtime` 并以退出码 1 结束。是新机部署 8 坑里第 1 坑；[#235](https://github.com/sleep2agi/agent-network/issues/235) 之前它是裸崩 `spawn bunx ENOENT`，现在不会了。
+`commhub-server` 是 Bun-shebang TypeScript（用 `bunx --bun` 起），**没装 Bun 时 `anet hub start` 一定失败**，是新机部署 8 坑里第 1 坑。表现分两条线:
+
+- **latest(当前 `2.2.21`)**:裸崩 `Error: spawn bunx ENOENT` + Node 堆栈——[#235](https://github.com/sleep2agi/agent-network/issues/235) 的 preflight **尚未进入 latest**;
+- **preview(`2.3.0-preview.x`)**:启动前被拦下，报 `❌ anet hub start requires the Bun runtime`，退出码 1。
 
 验证：
 ```bash

--- a/docs-site/docs/en/deploy/clean-server.md
+++ b/docs-site/docs/en/deploy/clean-server.md
@@ -16,7 +16,10 @@ It is **not** for users who already have anet installed — that's [Getting Star
 | **Bun** | ≥ 1.2.0 | `npm i -g bun` or `curl -fsSL https://bun.sh/install \| bash` |
 
 ::: warning Bun is non-optional
-`commhub-server` is Bun-shebang TypeScript (launched via `bunx --bun`). **Without Bun, `anet hub start` is refused before it launches anything**, printing `❌ anet hub start requires the Bun runtime` and exiting with code 1. This is bug #1 from the fresh-server retro; before [#235](https://github.com/sleep2agi/agent-network/issues/235) it hard-crashed with `spawn bunx ENOENT`, which it no longer does.
+`commhub-server` is Bun-shebang TypeScript (launched via `bunx --bun`). **Without Bun, `anet hub start` always fails** — bug #1 from the fresh-server retro. How it fails depends on the channel:
+
+- **latest (currently `2.2.21`)**: a bare `Error: spawn bunx ENOENT` plus a Node stack trace — the [#235](https://github.com/sleep2agi/agent-network/issues/235) preflight **has not reached latest yet**;
+- **preview (`2.3.0-preview.x`)**: refused before launch with `❌ anet hub start requires the Bun runtime`, exit code 1.
 
 Verify:
 ```bash

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -15,7 +15,9 @@ Skip this page and go to the [Upgrade Guide](/en/guide/upgrade) (usually `anet u
 **Prerequisites** (install both):
 
 - **Node.js ≥ 22.13.0**
-- **Bun ≥ 1.2.0** — install with `npm i -g bun` (or `curl -fsSL https://bun.sh/install | bash`). Step 2's `anet hub start` launches `commhub-server` via `bunx`, so **without Bun that step is refused before launch** with `❌ anet hub start requires the Bun runtime` (exit code 1, not a crash). After installing, `bun --version` should print a version.
+- **Bun ≥ 1.2.0** — install with `npm i -g bun` (or `curl -fsSL https://bun.sh/install | bash`). Step 2's `anet hub start` launches `commhub-server` via `bunx`, so **without Bun that step always fails**, but how depends on the channel:
+  · **latest (currently `2.2.21`)**: a bare `Error: spawn bunx ENOENT` plus a Node stack trace;
+  · **preview (`2.3.0-preview.x`)**: refused before launch with `❌ anet hub start requires the Bun runtime` (exit code 1). After installing, `bun --version` should print a version.
 
 With both installed, `commhub-server` / `agent-node` are auto-fetched on first use — you don't install them manually.
 

--- a/docs-site/docs/en/troubleshooting.md
+++ b/docs-site/docs/en/troubleshooting.md
@@ -26,7 +26,7 @@ Before sharing logs, remove tokens, API keys, passwords, cookies, complete envir
 
 ### `requires the Bun runtime` / `spawn bunx ENOENT` / Bun not found
 
-Current versions refuse before launch with a clear message:
+The **preview** channel (`2.3.0-preview.x`) refuses before launch with a clear message:
 
 ```
 ❌ anet hub start requires the Bun runtime (commhub-server is bun-only …)

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -15,7 +15,9 @@
 **前置**（两个都要装）：
 
 - **Node.js ≥ 22.13.0**
-- **Bun ≥ 1.2.0** —— 装法 `npm i -g bun`（或 `curl -fsSL https://bun.sh/install | bash`）。第 2 步 `anet hub start` 底层用 `bunx` 起 `commhub-server`，**没装 Bun 时第 2 步会在启动前被拦下**，报 `❌ anet hub start requires the Bun runtime`（退出码 1，不是崩溃）。装完 `bun --version` 应有输出。
+- **Bun ≥ 1.2.0** —— 装法 `npm i -g bun`（或 `curl -fsSL https://bun.sh/install | bash`）。第 2 步 `anet hub start` 底层用 `bunx` 起 `commhub-server`，**没装 Bun 时第 2 步一定失败**，但表现分两条线:
+  · **latest(当前 `2.2.21`)**:裸崩 `Error: spawn bunx ENOENT` + Node 堆栈；
+  · **preview(`2.3.0-preview.x`)**:启动前被拦下，报 `❌ anet hub start requires the Bun runtime`（退出码 1）。装完 `bun --version` 应有输出。
 
 这俩装好就行；`commhub-server` / `agent-node` 首次用时自动拉取，不用手动装。
 

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -26,13 +26,17 @@ anet logs <alias> --follow
 
 ### `requires the Bun runtime` / `spawn bunx ENOENT` / 找不到 Bun
 
-当前版本会在启动前拦下并给出明确提示：
+**preview 线**(`2.3.0-preview.x`)会在启动前拦下并给出明确提示：
 
 ```
 ❌ anet hub start requires the Bun runtime (commhub-server is bun-only …)
 ```
 
-退出码 1。`spawn bunx ENOENT` 是 [#235](https://github.com/sleep2agi/agent-network/issues/235) **之前**的旧表现，这里保留这个字样是方便从旧版本搜过来的人找到本节。
+退出码 1。
+
+🔴 **latest 线(当前 `2.2.21`)还没有这道 preflight** —— 那里仍是裸崩 `Error: spawn bunx ENOENT` + Node 堆栈。所以下面这个字样对 latest 用户是**现在时**,不是历史。
+
+`spawn bunx ENOENT` 是 [#235](https://github.com/sleep2agi/agent-network/issues/235) **之后在 preview 上**才消失的表现，这里保留这个字样是方便从旧版本搜过来的人找到本节。
 
 Agent Network CLI 需要 Node.js ≥ 22.13，Hub 需要 Bun ≥ 1.2：
 


### PR DESCRIPTION
## 我在 `#750` 里把 preview 的行为当成现状写进了公开文档,而且已经上线

`#750` 我把「没装 Bun 会怎样」改成:

> 会在启动前被拦下,报 `❌ anet hub start requires the Bun runtime` …
> `#235` **之前**它是裸崩 `spawn bunx ENOENT`,**现在不会了**

**这对 `latest` 用户是错的。**

## 实测(干净容器,`npm i -g @sleep2agi/agent-network@latest` —— 即默认安装)

```
anet -v          → 旧输出,没有 "Required to run a hub on this machine"

anet hub start   → Error: spawn bunx ENOENT
                       at ChildProcess._handle.onexit (node:internal/child_process:285:19)
                       …Node 堆栈…
```

`#235` 的 preflight **只在 preview 线上**:

```
latest    agent-network 2.2.21
preview   agent-network 2.3.0-preview.39
```

默认 `npm i -g` 装到 2.2.21,所以**裸崩对多数用户是现在时,不是历史**。

## 改动

把这个判断按**发布通道**分开写(中英各二处 + troubleshooting 补一句
「latest 线还没有这道 preflight」),不再用「当前版本 / 现在不会了」这类
把 `main` 当现状的措辞。

## 🔴 我为什么会犯这个错

验证时我用的是**本地 worktree 里的 `cli.ts`**(即 `main`),而不是用户真正装到的包。
`main == preview`,但 `preview ≠ latest` —— 中间隔着一整个 minor。

判据(仓里已有同类记忆,我没照做):**文档服务的是已发布版本,不是 `main`。**
凡是写「现在的行为是 X」,验证必须落在 `npm i -g <pkg>@latest` 的真实产物上。

而且必须**跑二进制**,不能 grep `dist/` —— 发布产物是 minified 的,grep 会假阴性。
这次我先踩了这个:`latest` 和 `preview` 两边 grep 都得到 0 命中,
才意识到方法不对,换成在容器里真跑 CLI 才拿到结论。

## 合并后需要部署

🔴 `docs-site` 不自动部署。合并后我会跟一次 `vercel --prod` 并**按内容验证**
(这次要验的是「两条线都写到了」,不是「页面 200」)。
