### PR TITLE
test(ci): pin #765 batch/runtime conflict behavior

### DIFF
--- a/docs/tests/report-test765-batch-runtime-gate.txt
+++ b/docs/tests/report-test765-batch-runtime-gate.txt
@@ -1,0 +1,155 @@
+# test765 — batch/runtime conflict behavior gate
+
+Date: 2026-08-13 (Asia/Shanghai)
+Base commit: 33b58211f2b96b201eb610c231311eb23a20fd84
+SOURCE_COMMIT: f4875c23131fcfc4e63306bd7061446a8b81f8e7
+Scope: test/CI-only; no product, package, dist, deployment, configuration, or database changes
+
+## Result
+
+PASS.
+
+The committed gate closes the remaining evidence gap for issue #765 while
+testing the product behavior already merged by PR #769:
+
+1. the real CLI entry `create --batch --runtime opencode-cli` exits nonzero,
+   prints the usable non-batch runtime command, and creates no node config;
+2. plain `create --batch` still reaches the selector-unavailable fallback,
+   distinguishes preset-supported runtimes from the non-batch path, and
+   creates no node config;
+3. three product mutations each turn the named behavior red.
+
+## Exact focused Docker run
+
+Command shape:
+
+```text
+docker build \
+  --build-arg TEST765_SOURCE_COMMIT=f4875c23131fcfc4e63306bd7061446a8b81f8e7 \
+  -t anet-test765:f4875c23 \
+  -f tests/test765-batch-runtime-gate/Dockerfile .
+docker run --rm anet-test765:f4875c23
+```
+
+Result:
+
+```text
+source_commit=f4875c23131fcfc4e63306bd7061446a8b81f8e7
+PASS conflicting flags fail fast and plain batch retains truthful fallback
+PASS agent-network production build
+PASS mutation conflict-guard-removed witnessed red at its named behavior
+PASS mutation plain-batch-wrongly-rejected witnessed red at its named behavior
+PASS mutation fallback-loses-nonbatch-route witnessed red at its named behavior
+RESULT pass=5 fail=0
+FOCUSED_RC=0 WALL_SECONDS=52
+```
+
+Focused runner log SHA256:
+
+```text
+ba10bf87a0902cceb74d87a36b4b62849a2b4acd8ba037effc1838f1fef416f6
+```
+
+This log digest records this run; it is not claimed reproducible because build
+logs contain timing and progress output.
+
+## Active L1 denominator
+
+`bash scripts/qa.sh --l1` ran the complete active L1 list after registering
+test765. The registry snapshot was:
+
+```text
+@sleep2agi/agent-network@preview -> 2.3.0-preview.39
+@sleep2agi/agent-node@preview -> 2.5.0-preview.31
+@sleep2agi/commhub-server@preview -> 0.9.0-preview.29
+```
+
+All 16 active suites passed, including:
+
+```text
+L1 test686-rest-shape-golden (RESULT: PASS)
+L1 test765-batch-runtime-gate (RESULT pass=5 fail=0)
+L1 test766-bunx-preflight (RESULT pass=4 fail=0)
+ALL PASS in 130s
+L1_RC=0 WALL_SECONDS=131
+```
+
+Full L1 log SHA256:
+
+```text
+e39e1e8e8be67cf06da044a26057a6d2144d0853450be86ac90c6a8536c9b091
+```
+
+This digest likewise records this run and is not claimed reproducible.
+
+## Mutation evidence
+
+The mutations operate on the production CLI inside the ephemeral Docker
+filesystem and restore the original source after each case:
+
+- `conflict-guard-removed`: changes the sole runtime conflict guard to
+  `false && ...`; the conflicting invocation no longer exits at the guard and
+  the conflict probe turns red.
+- `plain-batch-wrongly-rejected`: changes it to `true || ...`; plain batch is
+  incorrectly rejected and the plain-batch probe turns red.
+- `fallback-loses-nonbatch-route`: replaces the usable non-batch command with
+  another `--preset` instruction; the guidance assertion turns red.
+
+Every mutation first requires its exact production target to occur once and
+then verifies the changed bytes are present. The baseline probes run before
+mutation, so the witnessed-red cases are not baseline-self-red.
+
+## Image/source provenance
+
+Exact image ID:
+
+```text
+sha256:ddd672f958446f4b7f15b94d2a272739b6f13126410fd8f0eecd76d292e68e00
+```
+
+Image environment includes:
+
+```text
+TEST765_SOURCE_COMMIT=f4875c23131fcfc4e63306bd7061446a8b81f8e7
+```
+
+Files copied back from the image and compared to SOURCE_COMMIT worktree:
+
+```text
+Dockerfile ae4cf500a592930acf15e17029c2ea0d0d96bd8b8980d5e0f3e336851246f7b3 MATCH
+README.md  1e822fee7eb62aa07663488e06f578aa500327627665f8ac7a038aa470bebb6f MATCH
+run.sh     7b72ef66fd4a15e511737ece4d37d393fd2fcef11a3665e0008d93bae5556e09 MATCH
+TOTAL=3 FAIL=0
+```
+
+`scripts/qa.sh` is the host-side L1 dispatcher and is not copied into the
+focused image; its behavior is evidenced by the complete 16-suite L1 run.
+
+## Corrections made while establishing the gate
+
+- Redirecting an interactive selector from `/dev/null` did not reach fallback:
+  Bun rendered the selector and exited 0. That was rejected as evidence.
+- Sending SIGINT to a FIFO-backed selector produced exit 130, also without
+  reaching the fallback. That nonexistent behavior was not encoded in the
+  gate.
+- Removing `@inquirer/prompts` made Bun fail during module linking before the
+  CLI branch ran. The final fixture instead provides the same exported module
+  surface and makes `select()` throw, so the real production catch and fallback
+  execute. The original installed package is restored after every probe.
+- An initial full-L1 command guessed a nonexistent `tests/qa/Dockerfile` and
+  failed before testing. It was discarded; the recorded full run uses the
+  repository's actual `bash scripts/qa.sh --l1` entrypoint.
+
+## Honest limits
+
+- This PR does not change or re-decide the #765 product behavior; it only
+  commits the missing behavior gate.
+- The selector-unavailable case uses a controlled dependency fixture. It does
+  not claim that every non-TTY environment makes Inquirer throw.
+- The suite does not test an operator completing the interactive vendor picker;
+  that is outside the #765 conflict/fallback contract.
+- Most older L1 suites resolve published preview packages. Their exact versions
+  are therefore recorded above; test765 itself copies and runs this commit's
+  source.
+- No production host, token, package release, database, or deployment was
+  touched.

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -71,6 +71,7 @@ L1_TESTS=(
   "qa-node-02-success-reply"
   "qa-node-03b-task-events"
   "test686-rest-shape-golden"
+  "test765-batch-runtime-gate"
   "test766-bunx-preflight"
 )
 
@@ -144,6 +145,8 @@ if [[ $RUN_L1 -eq 1 ]]; then
     build_args=""
     if [[ "$t" == "test686-rest-shape-golden" ]]; then
       build_args="--build-arg TEST686_SOURCE_COMMIT=$(git rev-parse HEAD)"
+    elif [[ "$t" == "test765-batch-runtime-gate" ]]; then
+      build_args="--build-arg TEST765_SOURCE_COMMIT=$(git rev-parse HEAD)"
     elif [[ "$t" == "test766-bunx-preflight" ]]; then
       build_args="--build-arg TEST766_SOURCE_COMMIT=$(git rev-parse HEAD)"
     fi

--- a/tests/test765-batch-runtime-gate/Dockerfile
+++ b/tests/test765-batch-runtime-gate/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
+
+WORKDIR /repo
+ARG TEST765_SOURCE_COMMIT=unknown
+ENV TEST765_SOURCE_COMMIT=$TEST765_SOURCE_COMMIT
+
+COPY agent-network/package.json /repo/agent-network/package.json
+RUN cd /repo/agent-network && bun install --ignore-scripts
+
+COPY agent-network /repo/agent-network
+COPY tests/lib /repo/tests/lib
+COPY tests/test765-batch-runtime-gate /repo/tests/test765-batch-runtime-gate
+RUN chmod +x /repo/tests/test765-batch-runtime-gate/run.sh
+
+CMD ["bash", "/repo/tests/test765-batch-runtime-gate/run.sh"]

--- a/tests/test765-batch-runtime-gate/README.md
+++ b/tests/test765-batch-runtime-gate/README.md
@@ -1,0 +1,14 @@
+# test765 — batch/runtime conflict behavior gate
+
+Pins the two product behaviors merged by PR #769:
+
+1. `create --batch --runtime <value>` fails before create side effects and
+   points to the usable single-node `--runtime` command;
+2. plain `create --batch` still reaches the existing selector-unavailable
+   fallback, whose guidance distinguishes preset-supported runtimes from the
+   non-batch runtime path.
+
+Three witnessed-red mutations remove the conflict guard, over-widen it to
+reject every batch invocation, and regress the fallback to an unusable
+`--preset`-only instruction. The suite runs the real production CLI entry and
+is registered in the active `scripts/qa.sh` L1 list.

--- a/tests/test765-batch-runtime-gate/run.sh
+++ b/tests/test765-batch-runtime-gate/run.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT=/repo
+ART=/artifacts
+PASS=0
+FAIL=0
+mkdir -p "$ART"
+source "$ROOT/tests/lib/safe-rm.sh"
+
+ok(){ PASS=$((PASS+1)); printf 'PASS %s\n' "$*"; }
+bad(){ FAIL=$((FAIL+1)); printf 'FAIL %s\n' "$*"; }
+
+prepare_home(){
+  local case_root=$1
+  mkdir -p "$case_root/home/.anet"
+  chmod 0700 "$case_root/home/.anet"
+  printf '%s\n' \
+    '{"hub":"http://127.0.0.1:19179","token":"fixture-token","user":{"user_id":"fixture-user","username":"tester","role":"admin"},"network_id":"fixture-net","network_name":"test765"}' \
+    > "$case_root/home/.anet/config.json"
+  chmod 0600 "$case_root/home/.anet/config.json"
+}
+
+probe_conflict(){
+  local case_root log rc
+  case_root=$(mktemp -d /tmp/test765-conflict.XXXXXX)
+  log="$case_root/cli.log"
+  prepare_home "$case_root"
+
+  set +e
+  HOME="$case_root/home" timeout 10 /usr/local/bin/bun \
+    "$ROOT/agent-network/bin/cli.ts" create --batch --runtime opencode-cli \
+    </dev/null >"$log" 2>&1
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq 0 ]] \
+    || ! grep -Fq -- '--batch 与 --runtime 不能同用' "$log" \
+    || ! grep -Fq -- 'anet node create <name> --runtime <runtime>' "$log" \
+    || grep -Fq -- 'vendor selector 不可用' "$log" \
+    || find "$case_root/home/.anet" -path '*/nodes/*/config.json' -print -quit | grep -q .; then
+    printf 'CONFLICT_PROBE_WRONG rc=%s\n' "$rc" >&2
+    cat "$log" >&2
+    safe_rm_rf "$case_root"
+    return 1
+  fi
+  safe_rm_rf "$case_root"
+}
+
+probe_plain_batch(){
+  local case_root log prompts_dir disabled_prompts_dir rc
+  case_root=$(mktemp -d /tmp/test765-plain.XXXXXX)
+  log="$case_root/cli.log"
+  prompts_dir="$ROOT/agent-network/node_modules/@inquirer/prompts"
+  disabled_prompts_dir="$ROOT/agent-network/node_modules/@inquirer/prompts.test765-disabled"
+  prepare_home "$case_root"
+  [[ -d "$prompts_dir" ]]
+  [[ ! -e "$disabled_prompts_dir" ]]
+  mv "$prompts_dir" "$disabled_prompts_dir"
+  mkdir "$prompts_dir"
+  printf '%s\n' \
+    '{"name":"@inquirer/prompts","type":"module","exports":"./index.js"}' \
+    > "$prompts_dir/package.json"
+  printf '%s\n' \
+    'export async function select() { throw new Error("test765 selector unavailable"); }' \
+    'export async function checkbox() { throw new Error("test765 checkbox unavailable"); }' \
+    'export async function confirm() { throw new Error("test765 confirm unavailable"); }' \
+    'export async function input() { throw new Error("test765 input unavailable"); }' \
+    > "$prompts_dir/index.js"
+  set +e
+  HOME="$case_root/home" timeout 10 /usr/local/bin/bun \
+    "$ROOT/agent-network/bin/cli.ts" create --batch \
+    </dev/null >"$log" 2>&1
+  rc=$?
+  set -e
+  rm "$prompts_dir/package.json" "$prompts_dir/index.js"
+  rmdir "$prompts_dir"
+  mv "$disabled_prompts_dir" "$prompts_dir"
+
+  if [[ "$rc" -ne 0 ]] \
+    || grep -Fq -- '--batch 与 --runtime 不能同用' "$log" \
+    || ! grep -Fq -- 'vendor selector 不可用' "$log" \
+    || ! grep -Fq -- '预设运行时(claude-agent-sdk / claude-code-cli / codex-sdk):用 --preset <model-id>' "$log" \
+    || ! grep -Fq -- '去掉 --batch,用 anet node create <name> --runtime <runtime>' "$log" \
+    || find "$case_root/home/.anet" -path '*/nodes/*/config.json' -print -quit | grep -q .; then
+    printf 'PLAIN_BATCH_PROBE_WRONG rc=%s\n' "$rc" >&2
+    cat "$log" >&2
+    safe_rm_rf "$case_root"
+    return 1
+  fi
+  safe_rm_rf "$case_root"
+}
+
+probe_all(){
+  probe_conflict
+  probe_plain_batch
+}
+
+expect_red(){
+  local name=$1; shift
+  if "$@" >"$ART/$name.log" 2>&1; then
+    bad "mutation $name survived"
+  else
+    tail -60 "$ART/$name.log"
+    ok "mutation $name witnessed red at its named behavior"
+  fi
+}
+
+printf 'source_commit=%s\n' "${TEST765_SOURCE_COMMIT:-unknown}"
+cd "$ROOT"
+
+probe_all
+ok "conflicting flags fail fast and plain batch retains truthful fallback"
+
+(cd agent-network && bun run build)
+ok "agent-network production build"
+
+cp agent-network/bin/cli.ts /tmp/test765-cli.orig
+
+target='if (args.includes("--runtime")) {'
+[[ "$(grep -Fc "$target" agent-network/bin/cli.ts)" -eq 1 ]]
+sed -i 's/if (args.includes("--runtime")) {/if (false \&\& args.includes("--runtime")) {/' agent-network/bin/cli.ts
+grep -Fq 'if (false && args.includes("--runtime")) {' agent-network/bin/cli.ts
+expect_red conflict-guard-removed probe_conflict
+cp /tmp/test765-cli.orig agent-network/bin/cli.ts
+
+[[ "$(grep -Fc "$target" agent-network/bin/cli.ts)" -eq 1 ]]
+sed -i 's/if (args.includes("--runtime")) {/if (true || args.includes("--runtime")) {/' agent-network/bin/cli.ts
+grep -Fq 'if (true || args.includes("--runtime")) {' agent-network/bin/cli.ts
+expect_red plain-batch-wrongly-rejected probe_plain_batch
+cp /tmp/test765-cli.orig agent-network/bin/cli.ts
+
+fallback='console.error(`[anet]     去掉 --batch,用 anet node create <name> --runtime <runtime>`);'
+[[ "$(grep -Fc "$fallback" agent-network/bin/cli.ts)" -eq 1 ]]
+sed -i 's#console.error(`\[anet\]     去掉 --batch,用 anet node create <name> --runtime <runtime>`);#console.error(`[anet]     请改用 --preset <model-id>`);#' agent-network/bin/cli.ts
+grep -Fq 'console.error(`[anet]     请改用 --preset <model-id>`);' agent-network/bin/cli.ts
+expect_red fallback-loses-nonbatch-route probe_plain_batch
+cp /tmp/test765-cli.orig agent-network/bin/cli.ts
+
+printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Outcome

Adds the missing committed behavior gate for #765. Product behavior already landed in #769; this PR is strictly test/CI/report-only.

## Frozen coordinates

- base used for exact source run: `33b58211f2b96b201eb610c231311eb23a20fd84`
- source: `f4875c23131fcfc4e63306bd7061446a8b81f8e7`
- report-only head: `ae223f89c242990e0422a17cb7c572bd1dd1243e`
- exact image: `sha256:ddd672f958446f4b7f15b94d2a272739b6f13126410fd8f0eecd76d292e68e00`
- focused gate: `5 pass / 0 fail`, including `3/3` witnessed-red mutations
- active L1: `16/16` suites PASS in 130s
- image/source provenance: `3/3 MATCH`

After the evidence freeze, main advanced to `328f86c0` via #771. It touches only the slug checker and two unrelated shell fixtures; none of this PR's five files changed, and the virtual merge is conflict-free. The frozen evidence still corresponds byte-for-byte to this PR's source files.

## Behavior pinned

1. real CLI `create --batch --runtime opencode-cli` fails nonzero before node-config side effects and prints the usable non-batch command;
2. plain `create --batch` still reaches the selector-unavailable fallback and preserves both preset and non-batch guidance;
3. removing the guard, over-widening it, or deleting the usable fallback route each turns the named probe red.

The dependency fixture supplies the real `@inquirer/prompts` export surface but makes `select()` throw. This executes the production catch/fallback. It does **not** claim that every non-TTY environment makes Inquirer throw.

## Scope

Changed files are limited to:

- `scripts/qa.sh`
- `tests/test765-batch-runtime-gate/{Dockerfile,README.md,run.sh}`
- `docs/tests/report-test765-batch-runtime-gate.txt`

No product, dist, package, deployment, configuration, token, database, or production-host change.

Full evidence and discarded false-probe corrections are in the committed report.

Relates to #765. Do not close #765 until this gate is independently reviewed and merged.
