### PR TITLE
fix(cli): help 补上 batch / config / opencode / token(文档有、help 无)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2579,6 +2579,15 @@ Daemon (host_supervisor — required by the dashboard's node-creation wizard):
   anet daemon start <name>      Start an existing daemon
   anet daemon list              List locally-configured daemons
 
+Config & tokens:
+  anet config get|set <k> [v]   Read/write node or global config
+  anet token ls|create|revoke   Manage API tokens
+  anet batch <file>             Run a batch spec (multi-node)
+
+OpenCode:
+  anet opencode upgrade-pin <v> Verify + pin the exact opencode-ai release
+  anet opencode auth-login <n>  API-key login for an opencode-cli node
+
 Other:
   anet import [alias]           Import sessions from CommHub
   anet register                  Create new account


### PR DESCRIPTION
`#774`:文档(`getting-started.md` + `cli.md`)记载了这些命令,`anet <cmd> --help` 也确认
它们**存在**,但 `anet --help` 的清单里没有 —— 只看 help 的用户发现不了。

其中 `anet opencode` 是运行时相关、`anet token` 是凭据管理,都不是边缘功能。

## 改动

```
Config & tokens:
  anet config get|set <k> [v]   Read/write node or global config
  anet token ls|create|revoke   Manage API tokens
  anet batch <file>             Run a batch spec (multi-node)

OpenCode:
  anet opencode upgrade-pin <v> Verify + pin the exact opencode-ai release
  anet opencode auth-login <n>  API-key login for an opencode-cli node
```

## 验证

| 检查 | 结果 |
|---|---|
| 真跑 `anet --help` | `batch` 1 / `config` 1 / `opencode` 2 / `token` 1 命中 |
| 🔴 **反向验:写进 help 的子命令是否都存在** | `config get` / `token ls` / `batch` / `opencode upgrade-pin` / `opencode auth-login` —— **五个全部存在** |
| 回归 | 见下 |

**反向验这一条必须做**:补 help 的风险是反过来让 help 说谎 ——
列一个不存在的命令,比不列更糟。

## 回归:基线现测,不用旧数字

```
当前 origin/main   436 tests · 2 fail · 1323 expects
本 PR              436 tests · 2 fail · 1323 expects   ← 逐字相同,零新增失败
```

我原先记的基线是 `3 fail` —— 那是今天早些时候的 `main`。
**今天合了多个 PR,基线会漂,所以必须在当前 `origin/main` 上重测**,
而不是拿几小时前的数字比。

## 附:`#774` 我报错了一个

原 issue 列了 5 个,其中 **`anet daemon` 是我搞错的** ——
它在 `main` 上早已列入 help(`Daemon (host_supervisor …)` 那一节),只是还没进 `latest`。
我拿 `latest` 的缺失当成了代码缺陷。已在 issue 里更正,本 PR 只处理真正缺的 4 个。
