### PR TITLE
docs(deploy): hub runbook 补上 bun 安装(纸面演练里唯一走不下去的一步)

### DIFF
--- a/deploy/hub/README.md
+++ b/deploy/hub/README.md
@@ -15,6 +15,16 @@
 副本的 `RUNTIME_DIR` 和变更历史，不能只改服务器孤本。
 
 ```bash
+# 0. bun —— hub-daemon.sh 对它是硬依赖,缺了会 fail-closed 停在
+#    「找不到 bun」。这一步此前只写在脚本注释里,不在步骤里(#778)。
+#
+#    🔴 装在 nvm 的**当前 node** 下,因为脚本优先解析
+#       ~/.nvm/versions/node/<ver>/bin/bun —— 换 node 版本后需要重装。
+npm i -g bun                      # 或按 https://bun.sh/docs/installation
+command -v bun && bun --version   # 记下路径:换 node 版本后要重来
+#    (不要用 `curl … | bash` 一行流:管道退出码只反映 consumer,
+#     curl 失败会被吞掉 —— 见 #729 / #733 / #743。)
+
 install -d -m 700 "$HOME/.local/bin" "$HOME/.commhub"
 install -m 700 deploy/hub/hub-daemon.sh "$HOME/.local/bin/hub-daemon.sh"
 


### PR DESCRIPTION
`#778` 的纸面重建演练结论:只看仓从空机走到 hub 可服务,**8 步里 5 步覆盖、
2 步已明确标 NOT COVERED(vault key / 数据)、1 步是缺口**。本 PR 补那一步。

## 缺口

`hub-daemon.sh` 对 bun 是**硬依赖**,缺了会 fail-closed 停在:

```
找不到 bun：<path>
```

但整份 runbook **没有任何一步说 bun 怎么装** ——
`grep -i bun deploy/hub/README.md` 的命中全是「用 bun 跑某某命令」。
空机照仓走会停在那里,而手册在这一步没有下一句。

顺带:脚本注释里其实写了「bun 是通过 nvm 下的 npm 装的」——
**那就是安装方法,只是躺在注释里、不在步骤里。**

## 改动

补成「空机安装」的第 0 步,并把两件此前只在注释里的事写进步骤:

1. **装在 nvm 的当前 node 下** —— 脚本优先解析
   `~/.nvm/versions/node/<ver>/bin/bun`,换 node 版本后需要重装;
2. **不要用 `curl … | bash` 一行流** —— 管道退出码只反映 consumer,
   `curl` 失败会被吞掉。这正是 `#729` / `#733` / `#743` 一整条线在修的形状,
   在自家 runbook 里教它就说不过去了。

## 自检

```
演练清单五项全部命中   bun 安装 / 固化安装 / 脚本安装 / PM2 定义 / vault 标注
唯一的一行流写法       只出现在告诫语里,不是操作步骤
代码围栏               10 行,配平
```

## ⚠️ 不改变 README 的整体自评

vault key 与数据仍是断链。
「**已知正确的操作手册,不是已验证的灾难恢复方案**」这句**依然准确** ——
本 PR 只补上软件面最后一个未写步骤,**没有做实机演练**,
也没有把演练结论升级成「可恢复」。
