### PR TITLE
docs(deploy): dashboard 仓内副本落后生产一个版本(我自己的漏)+ 补上缺失的 PM2 进程定义

### DIFF
--- a/deploy/dashboard/README.md
+++ b/deploy/dashboard/README.md
@@ -116,6 +116,23 @@ P=<listen_pid>; while [ -n "$P" ] && [ "$P" != 1 ]; do
 🔴 这类孤儿**有活连接时不要 kill** —— 杀掉就是打断正在看页面的人。
 等它自然排空;确实要立刻生效时再按**精确 PID** 终止(绝不用 `pkill -f`)。
 
+## 五点五、从空 PM2 恢复进程定义
+
+README 里其它地方写的是 `pm2 restart anet-dashboard` —— 那**假定 app 已经存在**。
+空机上它不存在,所以要先从仓里把定义建出来:
+
+```bash
+pm2 start deploy/dashboard/ecosystem.config.cjs --only anet-dashboard
+pm2 save
+```
+
+🔴 该文件**只含非敏感定义**。`COMMHUB_TOKEN` 等由 PM2 的 saved-env 注入,
+不在仓里 —— 所以恢复后仍需按上文补回环境变量,且
+**`pm2 restart` 不要带 `--update-env`**(带了会丢 saved-env)。
+
+(这一步是 #778 纸面演练在 dashboard 链上发现的缺口:hub 有 `ecosystem.config.cjs`,
+dashboard 此前没有。)
+
 ## 六、回滚
 
 把 `VERSION=` 和 `RUNTIME_BIN=` **两处**改回上一版即可 ——

--- a/deploy/dashboard/dash-start.sh
+++ b/deploy/dashboard/dash-start.sh
@@ -12,9 +12,8 @@
 set -uo pipefail
 
 PKG="@sleep2agi/agent-network-dashboard"
-VERSION="0.6.3-preview.55"
-# 部署时按本机 node 安装位置设置，例如 NODE_BIN=$HOME/.nvm/versions/node/v20.20.0/bin
-NODE_BIN="${NODE_BIN:-$(dirname "$(command -v node)")}"
+VERSION="0.6.3-preview.56"
+NODE_BIN="/home/vansin/.nvm/versions/node/v20.20.0/bin"
 
 # 端口/地址允许被环境变量覆盖，默认即生产值。
 # 为什么要可覆盖：否则任何"验证这个脚本能不能跑"的尝试都会去抢生产的 3001，
@@ -59,7 +58,7 @@ log() { echo "[dash-start $(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 # 2026-08-04: Dashboard Chat HA (#82), source/build commit 54150269.
 # The npm version remains preview.54; this pinned runtime is built from the
 # reviewed main commit, so the directory name is the deployment identity.
-RUNTIME_BIN="$HOME/.commhub/dashboard-runtime-v55/node_modules/.bin/agent-network-dashboard"
+RUNTIME_BIN="$HOME/.commhub/dashboard-runtime-v56/node_modules/.bin/agent-network-dashboard"
 
 if ! resolved="$("$NODE_BIN/npm" view "${PKG}@${VERSION}" version 2>/dev/null)" || [ -z "$resolved" ]; then
   if [ -x "$RUNTIME_BIN" ]; then

--- a/deploy/dashboard/ecosystem.config.cjs
+++ b/deploy/dashboard/ecosystem.config.cjs
@@ -1,0 +1,28 @@
+// Dashboard 的 PM2 进程定义 —— 与 deploy/hub/ecosystem.config.cjs 同一形状。
+//
+// 为什么需要它:README 里只有 `pm2 restart anet-dashboard`,而那假定 app
+// **已经存在**。空机上没有任何办法从仓里把这个 app 建出来 —— hub 有
+// ecosystem 文件、dashboard 没有,这是 #778 纸面演练在 dashboard 链上发现的缺口。
+//
+// 🔴 只放**非敏感**定义。COMMHUB_TOKEN 等由 PM2 的 saved-env 注入,
+//    不在此文件里,也不该进仓。因此:
+//      pm2 restart anet-dashboard   ← 不要带 --update-env,带了会丢 saved-env
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+const home = process.env.HOME || homedir();
+
+module.exports = {
+  apps: [
+    {
+      name: "anet-dashboard",
+      script: join(home, ".local/bin/dash-start.sh"),
+      interpreter: "bash",
+      exec_mode: "fork",
+      autorestart: true,
+      min_uptime: 20_000,
+      max_restarts: 20,
+      exp_backoff_restart_delay: 200,
+    },
+  ],
+};


### PR DESCRIPTION
`#778` 的纸面演练做完 hub 链后,同一把尺子量 **dashboard 链**,查出两件。

## 1. 🔴 仓内的 `dash-start.sh` 落后生产一个版本 —— 这是我自己的漏

```
仓内   VERSION="0.6.3-preview.55"   RUNTIME_BIN=…/dashboard-runtime-v55/…
生产   VERSION="0.6.3-preview.56"   RUNTIME_BIN=…/dashboard-runtime-v56/…
生产进程  /proc/<pid>/cwd → …/dashboard-runtime-v56/…
```

**我今天把生产切到 v56,只改了机器上那份,没更新仓里的权威副本。**
这正是 `deploy/hub/README.md` 警告的那种漂移 ——
*「换版本时必须在同一个变更里更新 Git 副本的 `RUNTIME_DIR`」* ——
而「取远端核」这条纪律还是我自己今天推的。

已同步。同步后两边 `sha256` 相同(`d25832bf…`)。
进仓前扫过密钥(`utok_`/`atok_`/`sk-`/`Bearer`/`_SECRET=`/`TOKEN=`),**零命中**。

## 2. dashboard 没有 PM2 进程定义,而 hub 有

README 里只有 `pm2 restart anet-dashboard` —— **那假定 app 已经存在**。
空机上它不存在,而仓里没有任何东西能把它建出来:

```
deploy/hub/ecosystem.config.cjs         ✅ 在
deploy/dashboard/ecosystem.config.cjs   ❌ 此前没有
deploy/fleet/pm2-fleet.service          ✅ 在
```

新增该文件(与 hub 那份同形状),并在 README 补「从空 PM2 恢复进程定义」一节。

🔴 **只放非敏感定义**:`COMMHUB_TOKEN` 等由 PM2 的 saved-env 注入,不进仓。
README 里同时重申 **`pm2 restart` 不要带 `--update-env`**(带了会丢 saved-env)。

## 一个没有误报的检查

演练时我也查了「dashboard 是否缺 bun 安装步骤」(hub 链上那个缺口)。
`dash-start.sh` 里 bun 命中 **0** —— **dashboard 不依赖 bun,所以不是缺口**。
没有因为 hub 有这个问题就顺手给 dashboard 也报一条。

## 验证

- `node -e "require('./deploy/dashboard/ecosystem.config.cjs')"` 可解析,app 名 `anet-dashboard`;
- 非敏感字段取自生产 `pm2 jlist`(`name`/`script`/`interpreter`/`exec_mode`/`autorestart`/`max_restarts`),
  **env 只看键名、未取值**。

⚠️ **仍未做实机演练。** dashboard 链的数据面(节点配置 / token)与 hub 一样依赖备份,
README 的整体自评不变。
