### PR TITLE
docs(deploy): pin Hub Bun recovery version

### DIFF
--- a/deploy/hub/README.md
+++ b/deploy/hub/README.md
@@ -18,10 +18,14 @@
 # 0. bun —— hub-daemon.sh 对它是硬依赖,缺了会 fail-closed 停在
 #    「找不到 bun」。这一步此前只写在脚本注释里,不在步骤里(#778)。
 #
-#    🔴 装在 nvm 的**当前 node** 下,因为脚本优先解析
-#       ~/.nvm/versions/node/<ver>/bin/bun —— 换 node 版本后需要重装。
-npm i -g bun                      # 或按 https://bun.sh/docs/installation
-command -v bun && bun --version   # 记下路径:换 node 版本后要重来
+#    当前生产用 nvm 的 npm 安装,所以 binary 落在当前 node 的 bin 下；换
+#    node 版本后通常要重装。若采用其它布局,必须让 command -v bun 可见,
+#    或在 hub.env 显式设置可执行的 BUN_BIN。
+BUN_VERSION=1.3.14
+npm i -g "bun@$BUN_VERSION"
+BUN_BIN="$(command -v bun)"
+test -x "$BUN_BIN"
+test "$("$BUN_BIN" --version)" = "$BUN_VERSION"  # 版本不符即停,不拿 future latest 冒充当前运行时
 #    (不要用 `curl … | bash` 一行流:管道退出码只反映 consumer,
 #     curl 失败会被吞掉 —— 见 #729 / #733 / #743。)
 


### PR DESCRIPTION
## Why

PR #779 added the missing Bun recovery step, but its unpinned npm install command would fetch a future latest release. That means a rebuilt server would not reproduce the currently deployed runtime.

This append-only follow-up pins Bun 1.3.14, fails closed when the resolved executable reports another version, and documents the real hub-daemon.sh resolution contract: PATH or an explicit BUN_BIN are valid; the current nvm layout is not mandatory.

Prior review finding: https://github.com/sleep2agi/agent-network/pull/779#issuecomment-5273703687

## Scope

- One documentation file: deploy/hub/README.md
- No product code, package, database, secret, or production mutation
- Base: d9c4a1b936e0b64e59dd7a1cad6732dedc8a7874
- Source: 727bedb8e2cc145ce3d277a34ab9d0b0eff3bbd0

## Verification

- git diff --check: PASS
- exact changed-file denominator: 1/1
- Docker node:20-bookworm-slim executed the documented npm install and fail-closed version checks
- observed: BUN_PIN_PASS path=/usr/local/bin/bun version=1.3.14
- log SHA256: 80cdc18d2c4cc72ea432b134174edce027cb90039948fe16f62f67b95d02355f

## Boundaries

This PR documents recovery only. It does not install Bun on production, change hub.env, restart Hub, publish packages, or claim that databases/secrets are reproducible from Git.