### PR TITLE
docs(deploy): fleet runbook 补 enable-linger(此前只查看不启用,而没它开机链静默失效)

### DIFF
--- a/deploy/fleet/README.md
+++ b/deploy/fleet/README.md
@@ -31,7 +31,15 @@ test "$(git hash-object deploy/fleet/pm2-fleet-boot.sh)" = \
 systemd-analyze --user verify "$HOME/.config/systemd/user/pm2-fleet.service"
 systemctl --user daemon-reload
 systemctl --user enable pm2-fleet.service
-loginctl show-user "$USER" -p Linger
+
+# 🔴 linger 是这条链能否在开机时起来的**前提**,不是可选项。
+#    pm2-fleet.service 是 **user** unit(WantedBy=default.target):没有 linger,
+#    user manager 只在该用户登录期间存在 —— 机器重启后没人登录,单元根本不会跑,
+#    而 `systemctl --user is-enabled` 仍然显示 enabled,看不出问题。
+#    此前这里只有下面那条 show-user(**查看**),没有启用步骤:
+#    照着走会看到 Linger=no,然后手册没有下一句。
+loginctl enable-linger "$USER"
+loginctl show-user "$USER" -p Linger      # 必须是 Linger=yes
 ```
 
 Do not start the unit until the process inventory and recovery inputs below are


### PR DESCRIPTION
`#778` 纸面演练的**第三条链(fleet)**。

## 缺口:只查看,不启用

安装序列里有:

```bash
systemctl --user enable pm2-fleet.service
loginctl show-user "$USER" -p Linger        # ← 只是「查看」
```

**空机照着走,会看到 `Linger=no`,然后手册没有下一句。**

## 为什么这是必需项而不是可选项

`pm2-fleet.service` 是 **user** unit(`WantedBy=default.target`)。
没有 linger,user manager 只在该用户**登录期间**存在 ——
机器重启后没人登录,单元根本不会跑。

🔴 而 `systemctl --user is-enabled` **仍然显示 enabled** ——
从状态上看不出任何问题,整条开机自愈链会**静默失效**。

## 佐证:这不是我臆想的必需项

- 公开安装脚本 `hub-only.sh` 里就有 `loginctl enable-linger`(changelog 有记);
- `docs-site/docs/deploy/daemon.md` 专门警告
  *「只运行 `loginctl enable-linger` 不会创建 PM2 的 systemd unit」* ——
  **仓里早就知道这一步,只是 fleet runbook 漏了。**

## 影响面

本机现状 `Linger=yes`(实测),**生产不受影响**。
这是**空机重建**路径上的缺口,不是当前故障。

## 自检

`enable` 步骤 1 处、`show-user` 查看步骤 1 处、代码围栏配平。

## 四条链的演练进度

| 链 | 状态 |
|---|---|
| hub | ✅ 演练完,缺口(bun 安装)已补 → `#779` |
| dashboard | ✅ 演练完,两处已补 → `#780`(含我自己留下的 v55/v56 漂移) |
| **fleet** | ✅ **本 PR** |
| tunnel + docs-site | ⬜ 下一轮 |

⚠️ 四条都仍是**纸面**演练,没有实机重建。
