### PR TITLE
docs(deploy): frpc.service 入仓 + 登记跑在 /tmp 且无 supervisor 的第二个 frpc

### DIFF
--- a/deploy/tunnel/README.md
+++ b/deploy/tunnel/README.md
@@ -20,7 +20,16 @@
 
 1. 装 `frpc`(与 frps 服务端**大版本一致**),放 `/usr/local/bin/frpc`
 2. `cp frpc.example.toml ~/.frp/frpc.toml`,填 `FRP_SERVER_ADDR` / `FRP_AUTH_TOKEN`
-3. 起进程:`frpc -c ~/.frp/frpc.toml`(建议交给 systemd 或 pm2,别裸跑)
+3. 起进程 —— **unit 已在仓里**,不要自己现编:
+
+   ```bash
+   sudo install -m 644 deploy/tunnel/frpc.service /etc/systemd/system/frpc.service
+   sudo systemctl daemon-reload && sudo systemctl enable --now frpc
+   systemctl show frpc -p MainPID -p ActiveState -p UnitFileState   # 期望 active + enabled
+   ```
+
+   (`frpc.service` 只含 `ExecStart` 与配置文件路径,**不含任何凭据** ——
+   凭据在 `~/.frp/frpc.toml` 里,见下方「密钥」一节。)
 4. Caddy:把 `caddy.example` 的片段填好域名后并入 `Caddyfile`,`caddy reload`
 5. 验证:两个入口都能取到同一份静态文件,且 `Last-Modified` 相同
 
@@ -28,6 +37,30 @@
 
 `FRP_SERVER_ADDR` 与 `FRP_AUTH_TOKEN` **不入库**。
 只记录名称与获取方式:向部署属主索取,或从密钥库读取;轮换时两端同步更新。
+
+## 🔴 第二个 frpc:visitor(**当前 NOT COVERED,且跑在 /tmp**)
+
+本机上除了上面那个 systemd 托管的 frpc,还有**第二个**:
+
+```
+./frpc -c ./frpc-visitor.toml
+  cwd    /tmp/frp_0.61.1_linux_amd64          ← 在 /tmp
+  父进程  一个普通 bash,不是 systemd / pm2   ← 没有 supervisor
+  启动于  2026-07-17                          ← 已这样跑了很久
+```
+
+配置是 frp 的 `[[visitors]]` 段(`type` / `serverName` / `bindAddr` / `bindPort` /
+`secretKey` 等键)。
+
+**为什么这条要单独写出来:**
+
+- 它**不受任何 supervisor 管**,进程没了不会自愈;
+- 它跑在 `/tmp` —— **任何 `/tmp` 清理都会连二进制带配置一起删掉**,
+  而且因为用的是相对路径,连重启命令都不再有效;
+- 本文件此前**完全没提它**,拓扑图里也没有 —— 仅凭本仓重建不出这一条通路。
+
+**本条只是登记现状,没有改动它**(改动它属于生产变更)。
+补齐之前,「仅凭 repo 重建公网入口」对这条通路**不成立**。
 
 ## 未演练
 

--- a/deploy/tunnel/frpc.service
+++ b/deploy/tunnel/frpc.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=frp client
+After=network.target
+[Service]
+Type=simple
+User=vansin
+ExecStart=/usr/local/bin/frpc -c /home/vansin/.frp/frpc.toml
+Restart=always
+RestartSec=3
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
`#778` 纸面演练**第四条链(tunnel)**,也是最后一条。查出两件。

## 1. `frpc.service` 只存在于机器上

```
/etc/systemd/system/frpc.service    UnitFileState=enabled  ActiveState=active  MainPID=550174
仓里                                 ❌ 没有
```

README 第 3 步原本只说「建议交给 systemd 或 pm2,**别裸跑**」——
但仓里没有那个 unit,空机重建时只能自己现编一个。

已入仓,并把第 3 步改成引用它 + 给出验证命令。
该文件只含 `ExecStart` 与配置路径,**进仓前扫过 `token`/`secret`/`password`/`key`,零命中** ——
凭据在 `~/.frp/frpc.toml`,不进仓。

## 2. 🔴 还有第二个 frpc,跑在 `/tmp`,没有 supervisor

```
./frpc -c ./frpc-visitor.toml
  cwd     /tmp/frp_0.61.1_linux_amd64      ← 在 /tmp
  父进程   一个普通 bash,不是 systemd / pm2  ← 没有 supervisor
  启动于   2026-07-17                       ← 已这样跑了近一个月
```

配置是 frp 的 `[[visitors]]` 段。**三个问题叠在一起:**

- 不受任何 supervisor 管,进程没了**不会自愈**;
- 跑在 `/tmp` —— 任何 `/tmp` 清理会**连二进制带配置一起删**,
  而且用的是相对路径,连重启命令都不再有效;
- README 与拓扑图里**完全没提它** —— 仅凭本仓重建不出这条通路。

这与 `deploy/dashboard/README.md` 里记的那次事故是同一形状
(启动脚本曾在 `/tmp`,任何清理都会让它在下次重启时起不来)。

**本 PR 只登记现状,没有改动那个进程** —— 改它属于生产变更。

## 自检

- 代码围栏配平;
- 只读了 visitor 配置的**键名**(`type`/`serverName`/`bindAddr`/`secretKey` 等)用于说明角色,
  **未读取、也未记录任何值**。

## 四条链演练完成

| 链 | 缺口 | PR |
|---|---|---|
| hub | bun 安装步骤没写 | `#779` ✅ |
| dashboard | 仓内副本落后生产一版(我自己的漏)+ 缺 PM2 定义 | `#780` ✅ |
| fleet | 只查看 linger 不启用 | `#782` ✅ |
| **tunnel** | **unit 不在仓 + /tmp 里的第二个 frpc 未登记** | **本 PR** |

⚠️ 四条**全部是纸面演练**,没有实机重建。
vault key、数据、以及本 PR 登记的 visitor 通路仍是断链 ——
「仅凭 repo 恢复」目前**不成立**,这一点四份 README 都各自写明。
