### PR TITLE
fix(cli): correct top-level help contracts

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2580,13 +2580,14 @@ Daemon (host_supervisor — required by the dashboard's node-creation wizard):
   anet daemon list              List locally-configured daemons
 
 Config & tokens:
-  anet config get|set <k> [v]   Read/write node or global config
+  anet config [path|json]       Show config summary, path, or raw JSON
   anet token ls|create|revoke   Manage API tokens
-  anet batch <file>             Run a batch spec (multi-node)
+  anet batch <verb> [prefix]    Manage groups created by create --batch
 
 OpenCode:
   anet opencode upgrade-pin <v> Verify + pin the exact opencode-ai release
-  anet opencode auth-login <n>  API-key login for an opencode-cli node
+  anet opencode auth-login <n> --provider <anthropic|openai>
+                                API-key login for an opencode-cli node
 
 Other:
   anet import [alias]           Import sessions from CommHub

--- a/agent-network/src/top-level-help-contract.test.ts
+++ b/agent-network/src/top-level-help-contract.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "..", "bin", "cli.ts");
+
+function realHelp(...args: string[]) {
+  const home = mkdtempSync(join(tmpdir(), "anet-top-help-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "anet-top-help-cwd-"));
+  try {
+    return spawnSync("bun", [CLI, ...args], {
+      cwd,
+      env: { PATH: process.env.PATH ?? "", HOME: home },
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+describe("top-level help matches the implemented command parsers", () => {
+  test("advertises only the implemented config and batch shapes", () => {
+    const result = realHelp("--help");
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("anet config [path|json]");
+    expect(result.stdout).toContain("anet batch <verb> [prefix]");
+    expect(result.stdout).not.toContain("anet config get|set");
+    expect(result.stdout).not.toContain("anet batch <file>");
+  });
+
+  test("includes the provider required by opencode auth-login", () => {
+    const result = realHelp("--help");
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(
+      "anet opencode auth-login <n> --provider <anthropic|openai>",
+    );
+  });
+});


### PR DESCRIPTION
## Why

PR #776 merged three top-level help entries that do not match the implemented parsers. The current main therefore advertises config get/set and batch <file>, neither of which exists, and omits the required provider option for opencode auth-login.

Prior review finding: https://github.com/sleep2agi/agent-network/pull/776#issuecomment-5273708954

## Fix

- advertise the implemented config [path|json] forms
- advertise batch lifecycle verbs for groups created by create --batch
- include the required --provider <anthropic|openai> argument
- add a real-CLI subprocess regression test that rejects the two nonexistent spellings

No new product command is introduced to make the old wording true.

## Scope

- Base: 3787eb0d
- Source: 76e96df72ec2d80d2789f59302a3ec0a203e2053
- Two files: the CLI help text and its behavior test
- No package publish, production mutation, DB change, config change, or secret

## Docker verification

oven/bun:1.3.14, isolated copy with dependencies installed:
- 2 pass / 0 fail / 9 expect
- witnessed red: mutating the config help back to config get|set makes the named expectation fail with Expected to contain: anet config [path|json]

The first container attempt stopped before tests because the minimal image lacked Python for node-pty; after adding python3/make/g++ the same test ran green. This is recorded as an environment setup failure, not a product failure.