### PR TITLE
docs(deploy): process-inventory 覆盖非 pm2 进程(此前看起来完整、实际漏了两个)

### DIFF
--- a/deploy/fleet/process-inventory.json
+++ b/deploy/fleet/process-inventory.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
   "captured_at": "2026-08-13",
-  "process_manager": "pm2",
+  "process_manager": "pm2 + systemd + unsupervised",
   "apps": [
     {
       "name": "commhub-hub",
       "kind": "hub",
       "authority": "deploy/hub/hub-daemon.sh",
-      "recovery_status": "repo-authority-proposed-in-pr-738"
+      "recovery_status": "repo-authority-present"
     },
     {
       "name": "anet-dashboard",
@@ -32,6 +32,22 @@
       "kind": "external-service",
       "authority": null,
       "recovery_status": "not-covered-external-repository-and-commit-unknown"
+    },
+    {
+      "name": "frpc",
+      "kind": "tunnel",
+      "manager": "systemd(system)",
+      "authority": "deploy/tunnel/frpc.service",
+      "recovery_status": "repo-authority-present"
+    },
+    {
+      "name": "frpc-visitor",
+      "kind": "tunnel",
+      "manager": "none",
+      "authority": null,
+      "recovery_status": "not-covered-runs-from-tmp-without-supervisor",
+      "note": "cwd=/tmp/frp_<ver>_linux_amd64,父进程是普通 bash。/tmp 清理会连二进制带配置一起删,且用相对路径无法原地重启。详见 deploy/tunnel/README.md。"
     }
-  ]
+  ],
+  "scope_note": "此前本清单只覆盖 pm2。生产上还有 systemd 托管的 frpc,以及一个完全无 supervisor、跑在 /tmp 的 frpc visitor —— 它们同样属于「机器没了要能重建」的范围,故一并登记。"
 }


### PR DESCRIPTION
`#778` 四条链演练做完后,核对**清单与现实**,两处要改。

## 1. 一处过期状态

```
commhub-hub  recovery_status = "repo-authority-proposed-in-pr-738"
```

而 `#738` 已于 2026-08-12 合并,`deploy/hub/hub-daemon.sh` 与
`deploy/hub/ecosystem.config.cjs` **都已在 `main` 上**(实测 `git cat-file -e` 通过)。
改为 `repo-authority-present`。

## 2. 清单只覆盖 pm2,而生产不止 pm2

原 `process_manager: "pm2"`。但生产上还有:

| 进程 | 托管方式 | 权威副本 |
|---|---|---|
| `frpc` | systemd(system) | `deploy/tunnel/frpc.service`(`#783` 刚入仓) |
| `frpc-visitor` | **无** | ❌ 无,cwd 在 `/tmp`,父进程是普通 bash |

它们同样属于「机器没了要能重建」的范围。
**漏掉它们会让这份清单看起来完整、实际不完整** —— 而这份清单正是别人判断
「还有什么没覆盖」的依据。

已一并登记,并给 `frpc-visitor` 写明失效方式(`/tmp` 清理会连二进制带配置一起删,
相对路径导致无法原地重启)。

## 交叉核对(执行过,不是推断)

```
清单里有、pm2 没有  →  ['frpc', 'frpc-visitor']   ← 预期,它们不归 pm2 管
pm2 有、清单没有    →  []                          ← 无遗漏
systemctl is-active frpc          → active
pgrep -f frpc-visitor.toml        → 在
```

**两个方向都查了**:只查「清单是否有多余项」会漏掉未登记的进程,
只查「pm2 是否有未登记项」会漏掉非 pm2 的那两个。

## 自检

JSON 可解析,`apps` 由 5 条增至 7 条。
**本次只改清单文件,没有改动任何进程。**
