### PR TITLE
docs(deploy): weixin 两条改为精确未覆盖范围(代码其实已推送,真正缺的是账号归属与 secret)

### DIFF
--- a/deploy/fleet/process-inventory.json
+++ b/deploy/fleet/process-inventory.json
@@ -24,14 +24,16 @@
     {
       "name": "weixin-listen",
       "kind": "external-service",
-      "authority": null,
-      "recovery_status": "not-covered-external-repository-and-commit-unknown"
+      "authority": "github.com/vansin/weixin-bot (PRIVATE, 个人账号,不在 sleep2agi 组)",
+      "recovery_status": "code-in-external-private-repo-secrets-not-covered",
+      "note": "代码已知且已推送:本地 HEAD == 远端 main(fda9105a…),scripts/listen.js 与 scripts/admin.js 均已纳入 git。仍未覆盖:① 仓在个人账号且 PRIVATE,组织级恢复不含它;② 运行依赖 .env(键名含 ADMIN_TOKEN / CDN_OSS_* 等,未跟踪、不该入仓);③ session.json、.mcp.json、部分二维码图片未跟踪,仅存在于本机。"
     },
     {
       "name": "weixin-admin",
       "kind": "external-service",
-      "authority": null,
-      "recovery_status": "not-covered-external-repository-and-commit-unknown"
+      "authority": "github.com/vansin/weixin-bot (PRIVATE, 个人账号,不在 sleep2agi 组)",
+      "recovery_status": "code-in-external-private-repo-secrets-not-covered",
+      "note": "代码已知且已推送:本地 HEAD == 远端 main(fda9105a…),scripts/listen.js 与 scripts/admin.js 均已纳入 git。仍未覆盖:① 仓在个人账号且 PRIVATE,组织级恢复不含它;② 运行依赖 .env(键名含 ADMIN_TOKEN / CDN_OSS_* 等,未跟踪、不该入仓);③ session.json、.mcp.json、部分二维码图片未跟踪,仅存在于本机。"
     },
     {
       "name": "frpc",


### PR DESCRIPTION
清单里 `weixin-listen` / `weixin-admin` 一直标着
`not-covered-external-repository-and-commit-unknown`。查过之后,**「未知」这部分已经不成立**。

## 查到的(只读,未推送、未改动)

```
仓         github.com/vansin/weixin-bot   PRIVATE,个人账号,不在 sleep2agi 组
本地 HEAD  fda9105a…  ==  远端 main       ← 代码是推上去的,不是孤本
生产脚本   scripts/listen.js / scripts/admin.js   均已纳入 git
未提交的 20 项  主要是 public/qr_cards/*.png 图片资产,不是代码
```

## 仍然没覆盖的三条(这才是真正要解决的)

1. **仓在个人账号且 PRIVATE** —— 组织级恢复不含它;
2. **运行依赖 `.env`**(键名含 `ADMIN_TOKEN` / `CDN_OSS_*` 等),未跟踪、**也不该入仓**;
3. `session.json` / `.mcp.json` / 部分二维码图片未跟踪,**仅存在于本机**。

## 为什么值得改这一行

原状态把「代码在哪」和「secret 在哪」混成了一句「未知」。

🔴 **「未知」会让人以为要去找代码 —— 而代码其实好好地在远端。
真正要解决的是账号归属与 secret 备份。**
把未覆盖的范围说准,后面接手的人才知道该做什么。

## 自检

- JSON 可解析(`apps` 7 条);
- **只写了 `.env` 的键名**,`grep` 确认文件里没有任何凭据值;
- **未推送、未修改 `weixin-bot` 仓,也没有碰那两个进程**(它们已连续运行 89 天)。
