### PR TITLE
docs(deploy): pin weixin recovery coordinate

### DIFF
--- a/deploy/fleet/process-inventory.json
+++ b/deploy/fleet/process-inventory.json
@@ -24,16 +24,16 @@
     {
       "name": "weixin-listen",
       "kind": "external-service",
-      "authority": "github.com/vansin/weixin-bot (PRIVATE, 个人账号,不在 sleep2agi 组)",
+      "authority": "https://github.com/vansin/weixin-bot",
       "recovery_status": "code-in-external-private-repo-secrets-not-covered",
-      "note": "代码已知且已推送:本地 HEAD == 远端 main(fda9105a…),scripts/listen.js 与 scripts/admin.js 均已纳入 git。仍未覆盖:① 仓在个人账号且 PRIVATE,组织级恢复不含它;② 运行依赖 .env(键名含 ADMIN_TOKEN / CDN_OSS_* 等,未跟踪、不该入仓);③ session.json、.mcp.json、部分二维码图片未跟踪,仅存在于本机。"
+      "note": "2026-08-13 盘点时远端 main 指向 fda9105a184c6eda0276780f6f03593980ff4e1d,scripts/listen.js 与 scripts/admin.js 均已纳入 git。仍未覆盖:① 仓在个人账号且 PRIVATE,不在 sleep2agi 组,组织级恢复不含它;② 运行依赖 .env(键名含 ADMIN_TOKEN / CDN_OSS_* 等,未跟踪、不该入仓);③ session.json、.mcp.json、部分二维码图片未跟踪,仅存在于本机。"
     },
     {
       "name": "weixin-admin",
       "kind": "external-service",
-      "authority": "github.com/vansin/weixin-bot (PRIVATE, 个人账号,不在 sleep2agi 组)",
+      "authority": "https://github.com/vansin/weixin-bot",
       "recovery_status": "code-in-external-private-repo-secrets-not-covered",
-      "note": "代码已知且已推送:本地 HEAD == 远端 main(fda9105a…),scripts/listen.js 与 scripts/admin.js 均已纳入 git。仍未覆盖:① 仓在个人账号且 PRIVATE,组织级恢复不含它;② 运行依赖 .env(键名含 ADMIN_TOKEN / CDN_OSS_* 等,未跟踪、不该入仓);③ session.json、.mcp.json、部分二维码图片未跟踪,仅存在于本机。"
+      "note": "2026-08-13 盘点时远端 main 指向 fda9105a184c6eda0276780f6f03593980ff4e1d,scripts/listen.js 与 scripts/admin.js 均已纳入 git。仍未覆盖:① 仓在个人账号且 PRIVATE,不在 sleep2agi 组,组织级恢复不含它;② 运行依赖 .env(键名含 ADMIN_TOKEN / CDN_OSS_* 等,未跟踪、不该入仓);③ session.json、.mcp.json、部分二维码图片未跟踪,仅存在于本机。"
     },
     {
       "name": "frpc",


### PR DESCRIPTION
## Why

PR #786 correctly narrowed the weixin recovery gap, but it merged four seconds after review feedback and retained two coordinate defects:

- an abbreviated commit with an ellipsis cannot serve as an immutable checkout coordinate;
- the authority field mixes a repository locator with free-form ownership commentary.

Prior review: https://github.com/sleep2agi/agent-network/pull/786#issuecomment-5273832869

## Fix

- authority becomes the canonical repository URL: https://github.com/vansin/weixin-bot
- the note records the full observed remote-main commit `fda9105a184c6eda0276780f6f03593980ff4e1d`
- the observation is timestamped so a moving main branch is not mistaken for a frozen version
- PRIVATE/personal-account/non-organization limitations remain explicit in the note

## Independent source evidence

GitHub API read-only checks confirmed the repository is private with default branch main, current main resolves to the recorded full SHA, and both scripts/listen.js and scripts/admin.js exist at that revision.

## Scope and verification

- one JSON documentation/inventory file; 4 additions / 4 deletions
- Docker JSON/contract check: `INVENTORY_COORDINATE_PASS apps=2`
- no secret values, product code, production configuration, process restart, or deployment

This does not make the external private repository or its secrets organization-recoverable; it only makes the known code coordinate precise and machine-usable.