### PR TITLE
test(ci): gate complete agent-network unit domain

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -20,6 +20,7 @@ on:
       - 'docs/qa/**'
       - '.github/workflows/qa.yml'
       - 'tests/test725-agent-node-unit-ci/**'
+      - 'tests/test745-agent-network-unit-ci/**'
   push:
     branches: [main]
     paths:
@@ -30,6 +31,7 @@ on:
       - 'scripts/qa.sh'
       - '.github/workflows/qa.yml'
       - 'tests/test725-agent-node-unit-ci/**'
+      - 'tests/test745-agent-network-unit-ci/**'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
 # updated rapidly. main pushes run independently.
@@ -38,6 +40,23 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  agent-network-unit:
+    name: agent-network unit (Docker, non-root)
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build exact agent-network unit image
+        run: |
+          docker build \
+            --build-arg SOURCE_COMMIT="$GITHUB_SHA" \
+            -t anet-test745-agent-network-unit \
+            -f tests/test745-agent-network-unit-ci/Dockerfile .
+
+      - name: Run complete agent-network unit domain
+        run: docker run --rm anet-test745-agent-network-unit
+
   agent-node-unit:
     name: agent-node unit (Docker, non-root)
     runs-on: ubuntu-latest

--- a/agent-network/src/claude-vendor-env-wiring.test.ts
+++ b/agent-network/src/claude-vendor-env-wiring.test.ts
@@ -38,5 +38,6 @@ test("the dotenv writer itself reuses the side-effect-free planner", () => {
   expect(writerStart).toBeGreaterThan(0);
   expect(planner).toBeGreaterThan(0);
   expect(body.indexOf("process.env[refName] = value")).toBeGreaterThan(planner);
-  expect(body.indexOf("writeFileSync(dotenvPath, body")).toBeGreaterThan(planner);
+  expect(body.indexOf('writeOpencodePrivateProfileFile(nodeDir, ".env", body)')).toBeGreaterThan(planner);
+  expect(body.indexOf("atomicWritePrivateFile(dotenvPath, body)")).toBeGreaterThan(planner);
 });

--- a/agent-network/src/copresence-identity.real.test.ts
+++ b/agent-network/src/copresence-identity.real.test.ts
@@ -277,9 +277,14 @@ describe("REAL /proc integration (Linux only)", () => {
       });
       if (res.kind !== "success") console.log("[F] reap logs:\n" + logs.join("\n") + "\ndetail=" + res.detail);
       expect(res.kind).toBe("success");
-      // And the processes are actually gone — "success" must mean reality.
-      const gone = await waitFor(() => carriers.every((p) => !alive(p)), 3000);
-      expect(gone).toBe(true);
+      // And no carrier remains executable. A minimal container's PID 1 may
+      // leave an orphaned child as a zombie indefinitely; kill(pid, 0) still
+      // sees that PID even though state Z has no executable process behind it.
+      const noLiveCarrier = await waitFor(
+        () => carriers.every((p) => !alive(p) || readState(p) === "Z"),
+        3000,
+      );
+      expect(noLiveCarrier).toBe(true);
       expect(scanEnvironForMarker(enumer, uuid)).toEqual([]);
     } finally {
       killTree(spawned);

--- a/agent-network/src/opencode-copresence-cli.test.ts
+++ b/agent-network/src/opencode-copresence-cli.test.ts
@@ -46,7 +46,7 @@ describe("OpenCode co-presence CLI wiring", () => {
   test("the generic --copresence dispatcher selects OpenCode by stored runtime", () => {
     const dispatch = cli.indexOf('if (copresenceRuntime === "opencode-cli")');
     expect(dispatch).toBeGreaterThan(-1);
-    expect(cli.slice(dispatch, dispatch + 240)).toContain("startOpencodeCopresenceOrchestration(id)");
+    expect(cli.slice(dispatch, dispatch + 240)).toContain("startOpencodeCopresenceOrchestration(id, opts.hub)");
   });
 
   test("operator help names the create, attach, and stop commands", () => {

--- a/docs/tests/report-test745-agent-network-unit-ci.txt
+++ b/docs/tests/report-test745-agent-network-unit-ci.txt
@@ -1,0 +1,122 @@
+# test745 — complete agent-network unit CI signal
+
+Date: 2026-08-13 (Asia/Shanghai)
+Issue: https://github.com/sleep2agi/agent-network/issues/745
+Base: 1f4cbf49cf1b03ba3dd9d7ea81c2778b318d0cce
+Source commit: b4e13f45f032dbcf12ffc0b1d0c736571385702b
+Image: sha256:484e6b482816e36daf0a05385b7d09944786661eba17da973ff2c329fe7ce415
+Image env: TEST745_SOURCE_COMMIT=b4e13f45f032dbcf12ffc0b1d0c736571385702b
+
+## Result
+
+PASS. The complete `agent-network/src/**/*.test.ts` domain now has a
+dedicated Docker/non-root CI signal, parallel to the existing agent-node
+unit job.
+
+Two exact-image runs produced the same aggregate result:
+
+```
+test_files=46
+438 pass
+0 fail
+1333 expect() calls
+Ran 438 tests across 46 files.
+MUTATION_RED stale-config-help rc=1
+RESULT: PASS
+```
+
+The image uses Bun 1.3.14 from the pinned release archive with SHA256
+`951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f`.
+The suite runs as uid 1000 and includes Git and Python because current tests
+exercise real Git worktrees and real Linux `/proc` fixtures.
+
+## Baseline corrections required before the aggregate signal could be honest
+
+Current main initially produced `435 pass / 3 fail / 1331 expect` after Git
+was present. (A first environment probe without Git produced `432/6`; the
+three extra failures were exact `Executable not found in $PATH: "git"`
+errors and were not classified as product or test failures.)
+
+The remaining three failures were stale or environment-incorrect tests, not
+product regressions:
+
+1. The dotenv wiring test still required the retired direct
+   `writeFileSync(dotenvPath, body...)` shape. Production now uses both
+   `writeOpencodePrivateProfileFile(...)` and `atomicWritePrivateFile(...)`.
+   The test now requires both post-planner write paths.
+2. The OpenCode co-presence wiring test required the old one-argument call.
+   Production now forwards the operator's hub override as
+   `startOpencodeCopresenceOrchestration(id, opts.hub)`; the test now pins
+   that stronger contract.
+3. The real `/proc` reap test used `kill(pid, 0)` as its sole death test.
+   Minimal container PID 1 may retain an orphaned child in state `Z`, where
+   the PID exists but no executable process remains. Production already
+   treats zombies as non-live during marker scans. The assertion now requires
+   every carrier to be absent or state `Z`, and separately still requires the
+   marker scan to be empty.
+
+No product source file changed.
+
+## Witnessed red
+
+After the aggregate green run, the runner changes the single production help
+line `anet config [path|json]` back to the previously incorrect
+`anet config get|set` form. It verifies an exact one-occurrence target and a
+non-empty byte change, then runs the real subprocess help-contract test.
+
+The mutated run exits non-zero at the named assertion:
+
+```
+Expected to contain: "anet config [path|json]"
+MUTATION_RED stale-config-help rc=1
+```
+
+The baseline aggregate run occurs before the mutation, so a self-red or an
+unrelated startup failure cannot satisfy this gate.
+
+## CI wiring
+
+`.github/workflows/qa.yml` adds `agent-network unit (Docker, non-root)` and
+path coverage for `tests/test745-agent-network-unit-ci/**`. The job builds
+with `SOURCE_COMMIT=$GITHUB_SHA` and the runner rejects a missing or non-full
+SHA.
+
+The repository's QA workflow remains report-only and main currently has no
+branch protection. A red check is a visible signal, not a GitHub-enforced
+merge prohibition; governance enforcement remains tracked separately by
+#725.
+
+## Provenance
+
+Five files copied from the exact image matched `git show <source>:<path>`
+byte-for-byte:
+
+```
+MATCH agent-network/src/claude-vendor-env-wiring.test.ts
+MATCH agent-network/src/copresence-identity.real.test.ts
+MATCH agent-network/src/opencode-copresence-cli.test.ts
+MATCH agent-network/bin/cli.ts
+MATCH tests/test745-agent-network-unit-ci/run.sh
+PROVENANCE total=5 fail=0
+```
+
+Artifact digests (diagnostic logs contain timing and are not claimed to be
+reproducible):
+
+```
+4d07008e8f578775c4c9115267b32d489e8d957bee71e589bf377bc938ad70e2  test745-exact-build.log
+c213dba3132db08d41e70fcaa5a752aa0a89c1bb6b2452e3d9897446bc182dab  test745-exact-run1.log
+39f282f0fc77106060abe05b91aaecbe21fc0c64fe7170a1a329baf65a8c6dfc  test745-exact-run2.log
+```
+
+## Honest limits
+
+- This is the complete agent-network unit domain, not Hub/network/package
+  Docker E2E and not a production rollout.
+- The Docker build still needs network access for the pinned Bun archive and
+  `npm ci`; failure remains fail-closed.
+- The witnessed mutation proves the aggregate image consumes production
+  source and detects a named contract regression. It does not claim mutation
+  coverage for every one of the 438 tests.
+- No release, deployment, repository setting, token, or production state was
+  changed.

--- a/tests/test745-agent-network-unit-ci/Dockerfile
+++ b/tests/test745-agent-network-unit-ci/Dockerfile
@@ -1,0 +1,35 @@
+ARG SOURCE_COMMIT
+FROM node:22-bookworm-slim
+ARG BUN_VERSION=1.3.14
+ARG BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash build-essential ca-certificates curl git python3 unzip util-linux \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail --silent --show-error --location \
+      --retry 3 --retry-delay 2 --retry-all-errors \
+      "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" \
+      --output /tmp/bun-linux-x64.zip \
+  && echo "${BUN_LINUX_X64_SHA256}  /tmp/bun-linux-x64.zip" | sha256sum --check --strict \
+  && unzip -j /tmp/bun-linux-x64.zip 'bun-linux-x64/bun' -d /usr/local/bin \
+  && chmod 0755 /usr/local/bin/bun \
+  && test "$(bun --version)" = "$BUN_VERSION" \
+  && rm -f /tmp/bun-linux-x64.zip
+
+WORKDIR /workspace
+COPY agent-network/package.json agent-network/package-lock.json ./agent-network/
+RUN cd agent-network && npm ci
+
+COPY agent-node/package.json ./agent-node/package.json
+COPY agent-network ./agent-network
+COPY tests/test745-agent-network-unit-ci/run.sh ./tests/test745-agent-network-unit-ci/run.sh
+
+ARG SOURCE_COMMIT
+ENV TEST745_SOURCE_COMMIT=$SOURCE_COMMIT
+
+RUN chmod 0755 ./tests/test745-agent-network-unit-ci/run.sh \
+  && install -d -o node -g node -m 0700 "/run/user/$(id -u node)" \
+  && chown -R node:node /workspace
+
+ENTRYPOINT ["bash", "tests/test745-agent-network-unit-ci/run.sh"]

--- a/tests/test745-agent-network-unit-ci/run.sh
+++ b/tests/test745-agent-network-unit-ci/run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=/workspace
+SOURCE_COMMIT=${TEST745_SOURCE_COMMIT:-}
+[[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "FAIL: SOURCE_COMMIT must be one full lowercase Git SHA" >&2
+  exit 1
+}
+
+echo "# test745 — complete agent-network unit domain"
+echo "source_commit=$SOURCE_COMMIT"
+echo "bun=$(bun --version) node=$(node --version) git=$(git --version) uid=$(id -u node)"
+
+test_files=$(find "$ROOT/agent-network/src" -type f -name '*.test.ts' | wc -l | tr -d ' ')
+[[ "$test_files" =~ ^[1-9][0-9]*$ ]] || {
+  echo "FAIL: agent-network test-file denominator is empty" >&2
+  exit 1
+}
+echo "test_files=$test_files"
+
+echo "[L0] full agent-network/src unit suite as non-root"
+runuser -u node -- env HOME=/home/node \
+  bash -lc 'cd /workspace/agent-network && bun test src/' \
+  2>&1 | tee /tmp/test745-green.log
+
+grep -Eq '^[[:space:]]*[1-9][0-9]* pass$' /tmp/test745-green.log || {
+  echo "FAIL: non-empty pass denominator missing" >&2
+  exit 1
+}
+grep -Eq '^[[:space:]]*0 fail$' /tmp/test745-green.log || {
+  echo "FAIL: aggregate suite did not finish with zero failures" >&2
+  exit 1
+}
+grep -Eq 'Ran [1-9][0-9]* tests across [1-9][0-9]* files\.' /tmp/test745-green.log || {
+  echo "FAIL: aggregate test/file summary missing" >&2
+  exit 1
+}
+
+echo "[L1] witnessed-red: top-level config help must match the implemented parser"
+TARGET='  anet config [path|json]       Show config summary, path, or raw JSON'
+MUTATED='  anet config get|set          Inspect or edit config'
+before=$(sha256sum "$ROOT/agent-network/bin/cli.ts" | cut -d' ' -f1)
+python3 - "$ROOT/agent-network/bin/cli.ts" "$TARGET" "$MUTATED" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text()
+target, replacement = sys.argv[2], sys.argv[3]
+if source.count(target) != 1:
+    raise SystemExit("mutation target count changed")
+path.write_text(source.replace(target, replacement, 1))
+PY
+after=$(sha256sum "$ROOT/agent-network/bin/cli.ts" | cut -d' ' -f1)
+[[ "$before" != "$after" ]] || {
+  echo "FAIL: mutation was a byte no-op" >&2
+  exit 1
+}
+
+set +e
+runuser -u node -- env HOME=/home/node \
+  bash -lc 'cd /workspace/agent-network && bun test src/top-level-help-contract.test.ts' \
+  >/tmp/test745-mutation.log 2>&1
+mutation_rc=$?
+set -e
+[[ "$mutation_rc" -ne 0 ]] || {
+  cat /tmp/test745-mutation.log
+  echo "FAIL: stale config-help mutation survived" >&2
+  exit 1
+}
+grep -Fq 'Expected to contain: "anet config [path|json]"' /tmp/test745-mutation.log || {
+  cat /tmp/test745-mutation.log
+  echo "FAIL: mutation red did not reach the named help-contract assertion" >&2
+  exit 1
+}
+
+grep -F 'Expected to contain: "anet config [path|json]"' /tmp/test745-mutation.log
+echo "MUTATION_RED stale-config-help rc=$mutation_rc"
+echo "RESULT: PASS"


### PR DESCRIPTION
Closes #745.

## Frozen coordinates

- base: `1f4cbf49cf1b03ba3dd9d7ea81c2778b318d0cce`
- source: `b4e13f45f032dbcf12ffc0b1d0c736571385702b`
- report-only head: `951d28aa42d1cdd6b685265d8b1dd4d602c663ea`
- exact image: `sha256:484e6b482816e36daf0a05385b7d09944786661eba17da973ff2c329fe7ce415`

## What changes

- adds a dedicated Docker/non-root CI job for the complete `agent-network/src/**/*.test.ts` domain;
- pins Bun 1.3.14 by release-archive SHA and includes the real Git/Python fixture prerequisites;
- repairs three pre-existing false-red tests so the aggregate signal starts from an honest green baseline;
- adds a named witnessed-red mutation against the real top-level CLI help contract.

No product source, release, deployment, repository setting, token, or production state changes.

## Evidence

Two exact-image runs were stable:

```text
test_files=46
438 pass
0 fail
1333 expect() calls
Ran 438 tests across 46 files.
Expected to contain: "anet config [path|json]"
MUTATION_RED stale-config-help rc=1
RESULT: PASS
```

Image-to-source byte provenance: `5/5 MATCH` for the three corrected tests, production `cli.ts`, and the runner. Full evidence and honest limits are in `docs/tests/report-test745-agent-network-unit-ci.txt`.

## Governance boundary

This adds a visible red/green signal. The QA workflow remains report-only and main has no branch protection, so it does not turn process discipline into a GitHub-enforced merge prohibition; that separate governance gap remains tracked by #725.
