### PR TITLE
test(fleet): make recovery inventory boundary semantic

### DIFF
--- a/docs/tests/report-test793-inventory-boundary.txt
+++ b/docs/tests/report-test793-inventory-boundary.txt
@@ -1,0 +1,51 @@
+Test 793 — semantic fleet inventory boundary
+Date: 2026-08-13
+
+Verdict: PASS
+
+Coordinates
+- Base: 446ae57bc89d64c4fa7c8b698633aae29fed1179
+- Source under test: 603f93db2708c55d54c8521a822a63c225e80505
+- Image: sha256:4f926b6f25ea10ab871e3bc2b75fea9bd69b8cd4ee9fb89cae1f7273d43e0a03
+- Image label org.opencontainers.image.revision: 603f93db2708c55d54c8521a822a63c225e80505
+
+Scope
+- Changed only tests/test736-pm2-fleet-rebuild/run.sh.
+- Replaced stale numeric inventory assertions with semantic assertions.
+- No production inventory, launcher, service unit, runtime, or deployment file changed.
+
+Semantic boundary
+- schema_version is 1 and apps is a non-empty array;
+- app names are non-empty and unique;
+- every app has non-empty name, kind, and recovery_status;
+- external services have a canonical GitHub repository URL or explicitly carry a not-covered recovery status;
+- null authority and notes that say recovery is not covered remain paired with an explicit not-covered status;
+- secret-looking JSON field names and common token/credential value shapes are rejected.
+
+Docker result (two consecutive runs)
+  L1 PM2_FLEET_REBUILD_PASS
+  MUTATION_RED live-fleet-noop-removed
+  MUTATION_RED malformed-jlist-as-empty
+  MUTATION_RED missing-recovery-status
+  MUTATION_RED secret-like-field
+  RESULT: PASS
+
+The two run logs are byte-identical:
+- run 1 sha256: 9f2811425ee9ba2b111815f78ad711fa530b1446a336243e7f52e75643a57612
+- run 2 sha256: 9f2811425ee9ba2b111815f78ad711fa530b1446a336243e7f52e75643a57612
+- build log sha256: 0757940f2fc3d4de06e88bb339b71342af7fa0eb34b902f373917c7bd87f3eff
+
+Witnessed-red details
+- missing-recovery-status appends an external-service fixture without recovery_status; the baseline inventory assertion rejects it.
+- secret-like-field appends an api_token field with a fabricated ghp_ fixture value; both the key and value policy reject it.
+- The unmodified inventory suite runs before mutations, so a pre-existing red cannot be counted as a mutation red.
+
+Byte provenance
+- Image /app/run.sh sha256: 2dd6c90abcac347e78d9633cf6015b87d135245f7573809aae7da000292142c4
+- git show SOURCE:tests/test736-pm2-fleet-rebuild/run.sh sha256: 2dd6c90abcac347e78d9633cf6015b87d135245f7573809aae7da000292142c4
+- Result: 1/1 MATCH
+
+Honest limits
+- This gate validates the committed inventory contract; it does not prove external private repositories, secrets, databases, or host-local state are recoverable.
+- A canonical GitHub URL proves machine-locatable code authority, not access, backup, or secret availability.
+- The token-pattern scan is a tripwire for common credential shapes, not a general-purpose secret scanner.

--- a/tests/test736-pm2-fleet-rebuild/run.sh
+++ b/tests/test736-pm2-fleet-rebuild/run.sh
@@ -132,10 +132,42 @@ assert_unit_shape() {
 }
 
 assert_inventory_boundary() {
-  jq -e '.schema_version == 1 and (.apps | length) == 5' "$INVENTORY" >/dev/null
-  jq -e '[.apps[] | select(.kind == "external-service" and .authority == null)] | length == 2' "$INVENTORY" >/dev/null
-  jq -e '[.apps[] | select(.recovery_status | startswith("not-covered"))] | length == 2' "$INVENTORY" >/dev/null
-  jq -e '[paths(scalars) as $p | ($p[-1] | tostring) | select(test("token|secret|password"; "i"))] | length == 0' "$INVENTORY" >/dev/null
+  local inventory="${1:-$INVENTORY}"
+  jq -e '
+    .schema_version == 1
+    and ((.apps | type) == "array" and (.apps | length) > 0)
+    and ([.apps[].name] as $names
+      | ($names | length) == ($names | unique | length))
+    and all(.apps[];
+      ((.name | type) == "string" and (.name | length) > 0)
+      and ((.kind | type) == "string" and (.kind | length) > 0)
+      and ((.recovery_status | type) == "string" and (.recovery_status | length) > 0))
+    and all(.apps[] | select(.kind == "external-service");
+      (((.authority | type) == "string")
+        and (.authority | test("^https://github\\.com/[^/]+/[^/]+/?$")))
+      or (.authority == null and (.recovery_status | contains("not-covered"))))
+    and all(.apps[] | select(.authority == null);
+      (.recovery_status | contains("not-covered")))
+    and all(.apps[] | select((.note? // "") | test("未覆盖|NOT COVERED"; "i"));
+      (.recovery_status | contains("not-covered")))
+    and ([paths as $p
+      | ($p[-1] | tostring)
+      | select(test("token|secret|password|credential|api[_-]?key"; "i"))]
+      | length == 0)
+    and ([.. | strings
+      | select(test("(gh[pousr]_|ntok_|utok_|atok_|Bearer\\s+|sk-[A-Za-z0-9]|https?://[^/@\\s]+:[^/@\\s]+@)"; "i"))]
+      | length == 0)
+  ' "$inventory" >/dev/null
+}
+
+expect_inventory_red() {
+  local name="$1" inventory="$2" log
+  log="$ROOT/$name.log"
+  if assert_inventory_boundary "$inventory" >"$log" 2>&1; then
+    echo "MUTATION_SURVIVED $name"
+    return 1
+  fi
+  echo "MUTATION_RED $name"
 }
 
 run_suite() {
@@ -179,4 +211,14 @@ if assert_malformed_jlist_rejected "$MUTANT_PARSE"; then
   exit 1
 fi
 echo 'MUTATION_RED malformed-jlist-as-empty'
+
+MUTANT_INVENTORY_MISSING="$ROOT/inventory-missing-recovery-status.json"
+jq '.apps += [{"name":"fixture-missing-recovery","kind":"external-service","authority":"https://github.com/example/fixture"}]' \
+  "$INVENTORY" > "$MUTANT_INVENTORY_MISSING"
+expect_inventory_red missing-recovery-status "$MUTANT_INVENTORY_MISSING"
+
+MUTANT_INVENTORY_SECRET="$ROOT/inventory-secret-field.json"
+jq '.apps[0].api_token = "ghp_fixture_secret_must_be_rejected"' \
+  "$INVENTORY" > "$MUTANT_INVENTORY_SECRET"
+expect_inventory_red secret-like-field "$MUTANT_INVENTORY_SECRET"
 echo 'RESULT: PASS'


### PR DESCRIPTION
Closes #793.

## Scope

- replace stale `5 / 2 / 2` inventory counts with stable semantic assertions;
- require unique app names and non-empty recovery classification;
- require external services to expose a canonical GitHub authority or explicitly remain `not-covered`;
- reject secret-looking JSON fields and common credential value shapes;
- add witnessed-red fixtures for missing recovery classification and leaked credentials.

No production inventory, launcher, service unit, runtime, or deployment file changes.

## Frozen coordinates

- base: `446ae57bc89d64c4fa7c8b698633aae29fed1179`
- source: `603f93db2708c55d54c8521a822a63c225e80505`
- report-only head: `09fab62f549dfb3af46f39c66b27a4a48707c65f`
- image: `sha256:4f926b6f25ea10ab871e3bc2b75fea9bd69b8cd4ee9fb89cae1f7273d43e0a03`

## Docker evidence

Two consecutive runs on the frozen source produced the same output:

```text
L1 PM2_FLEET_REBUILD_PASS
MUTATION_RED live-fleet-noop-removed
MUTATION_RED malformed-jlist-as-empty
MUTATION_RED missing-recovery-status
MUTATION_RED secret-like-field
RESULT: PASS
```

Both run logs: `sha256:9f2811425ee9ba2b111815f78ad711fa530b1446a336243e7f52e75643a57612`.

Image `/app/run.sh` matches `git show source:tests/test736-pm2-fleet-rebuild/run.sh` byte-for-byte (`sha256:2dd6c90abcac347e78d9633cf6015b87d135245f7573809aae7da000292142c4`).

## Honest limits

This validates the committed inventory contract. It does not prove private-repository access, backups, secrets, databases, or host-local state are recoverable. The credential-pattern check is a tripwire, not a general secret scanner.
