### PR TITLE
test(ci): 把 test745 的执行文件数绑到磁盘上的分母(现在跑 2/46 也是绿的)

### DIFF
--- a/tests/test745-agent-network-unit-ci/run.sh
+++ b/tests/test745-agent-network-unit-ci/run.sh
@@ -37,6 +37,17 @@ grep -Eq 'Ran [1-9][0-9]* tests across [1-9][0-9]* files\.' /tmp/test745-green.l
   exit 1
 }
 
+# 上面那条只要求"跑过的文件数非零" —— 磁盘上有 46 个、bun 只跑了 1 个,
+# 它照样绿。test_files 这个分母算出来了却没承重,而"跑了 1 个全绿"和
+# "跑了 46 个全绿"打印出来是同一片绿色。把两个数绑在一起,让范围被悄悄
+# 收窄(glob 改了、测试挪进子目录、bun 配置多了个 exclude)这件事自己变红。
+executed=$(grep -Eo 'across [0-9]+ files' /tmp/test745-green.log | grep -Eo '[0-9]+' | tail -1)
+echo "executed_files=${executed:-unknown} discovered_files=$test_files"
+[[ -n "$executed" && "$executed" -ge "$test_files" ]] || {
+  echo "FAIL: bun executed ${executed:-?} file(s) but $test_files exist under src/" >&2
+  exit 1
+}
+
 echo "[L1] witnessed-red: top-level config help must match the implemented parser"
 TARGET='  anet config [path|json]       Show config summary, path, or raw JSON'
 MUTATED='  anet config get|set          Inspect or edit config'


### PR DESCRIPTION
`#791` 落地的 `test745` 已经算出了磁盘上的分母 `test_files`(46),但只用它判「非空」;
执行侧只要求 `Ran N tests across M files.` 里的 **M 非零**。

于是:**bun 实际只跑了 46 个里的 2 个,这道门照样 `RESULT: PASS`。**
分母算出来了却不承重,而「跑了 2 个全绿」和「跑了 46 个全绿」打印出来是同一片绿色。

改成 `executed >= test_files`。

## A/B 实测

范围 `origin/main@f8b9675d`。两版 `run.sh` 施加**同一处**收窄
(`bun test src/` → `bun test src/im/`,该目录下 2 个测试文件),其余完全不动:

| | rc | 结果 |
|---|---|---|
| 旧门 + 收窄 | 0 | `RESULT: PASS` ← 44 个文件没跑,门是绿的 |
| 新门 + 收窄 | 1 | `FAIL: bun executed 2 file(s) but 46 exist under src/` |

不收窄时新门正常绿:`executed_files=46 discovered_files=46` / `RESULT: PASS`。

## 一处诚实的边界

收窄到**恰好 1 个文件**时旧门本来就能拦下 —— bun 打印的是 `across 1 file.`(单数),
不匹配它那条要求 `files` 的正则。所以这个缺口只在收窄到 **≥2 个文件**时成立。

我第一次的 A/B 用的就是单文件,两版红在同一条更早的断言上,**不构成证据**;
换成 2 文件才拿到真实差异。写在这里免得复核的人重走这条弯路。

## NOT COVERED

- 只绑了「执行数 ≥ 磁盘数」,没绑「执行的就是磁盘上那些文件」—— 理论上仍可能
  跑了 46 个别的文件。要堵这个得比对文件名清单,成本高于收益,先记下不做。
