### PR TITLE
ci: pin setup-bun version across workflows

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
 
       - name: Install agent-network dependencies
         working-directory: agent-network

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -21,6 +21,7 @@ on:
       - '.github/workflows/qa.yml'
       - 'tests/test725-agent-node-unit-ci/**'
       - 'tests/test745-agent-network-unit-ci/**'
+      - 'tests/test746-setup-bun-pin/**'
   push:
     branches: [main]
     paths:
@@ -32,6 +33,7 @@ on:
       - '.github/workflows/qa.yml'
       - 'tests/test725-agent-node-unit-ci/**'
       - 'tests/test745-agent-network-unit-ci/**'
+      - 'tests/test746-setup-bun-pin/**'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
 # updated rapidly. main pushes run independently.
@@ -83,6 +85,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
 
       - name: Show QA test inventory
         run: bash scripts/qa.sh --list

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
 
       - name: Resolve target package + version
         id: resolve

--- a/docs/tests/report-test746-setup-bun-pin.txt
+++ b/docs/tests/report-test746-setup-bun-pin.txt
@@ -1,0 +1,90 @@
+# test746 — pin setup-bun across active workflows
+
+Date: 2026-08-13 (Asia/Shanghai)
+Issue: https://github.com/sleep2agi/agent-network/issues/746
+Base: 92d9612949a4207eae4facab2b337c1f23de65e0
+Source commit: c15df58f58a8a4bae2d637504b4ec98320a49aca
+Image: sha256:a8faddf90133b9f68280792e5045f89722f8c33c16a848d7370669f6896d331c
+Image label: org.opencontainers.image.revision=c15df58f58a8a4bae2d637504b4ec98320a49aca
+
+## Result
+
+PASS. Every active `oven-sh/setup-bun@v2` step in the repository's workflow
+domain now explicitly selects Bun 1.3.14. Two runs of the exact source image
+produced byte-identical logs:
+
+```
+setup_bun_occurrences=3 expected_version=1.3.14
+e2e-docker.yml.jobs.e2e.steps[1] bun-version=1.3.14
+qa.yml.jobs.qa.steps[1] bun-version=1.3.14
+release.yml.jobs.build-tarball.steps[1] bun-version=1.3.14
+L1 SETUP_BUN_PIN_PASS
+MUTATION_RED release-pin-removed
+RESULT: PASS
+```
+
+Both run logs have SHA256
+`abda2b39247e0d1bf1f079fa5d2c1208881a2938eebbc237a08a8bc8440f9d8c`.
+
+## Denominator and witnessed red
+
+The gate parses every `.yml` and `.yaml` file directly under
+`.github/workflows/`, recursively finds every step whose exact action is
+`oven-sh/setup-bun@v2`, and requires:
+
+- exactly three occurrences; and
+- `with.bun-version` to equal `1.3.14` for every occurrence.
+
+The runner first proves the unmodified baseline green. It then copies the
+workflow domain into an ephemeral directory, requires one exact mutation
+target in `release.yml`, removes only that step's version pin, and verifies a
+non-empty byte change. The mutated parser run must fail with both the affected
+filename and the named mismatch:
+
+```
+release.yml.jobs.build-tarball.steps[1] bun-version=None, expected 1.3.14
+```
+
+`scripts/qa.sh` includes this suite in active L1, passes the full source SHA,
+and `.github/workflows/qa.yml` covers changes to the suite on both pull
+requests and main pushes. The QA workflow remains report-only; absent branch
+protection, a red result is a signal rather than a GitHub-enforced merge ban.
+
+## Corrections while establishing the gate
+
+The first Docker run failed before the product assertion because the
+`python:3.12-slim-bookworm` image resolves `python3` to `/usr/local/bin`, while
+Debian's `python3-yaml` package installs for `/usr/bin/python3`. The runner now
+uses `/usr/bin/python3` explicitly. A second attempt exposed that the helper
+redirected only stdout, leaving the named mutation error outside its evidence
+log; the helper now captures stdout and stderr together. Neither failed
+attempt was recorded as a passing gate.
+
+## Provenance
+
+Four files copied into the exact image have the same SHA256 as their source
+files:
+
+```
+MATCH tests/test746-setup-bun-pin/run.sh
+MATCH .github/workflows/e2e-docker.yml
+MATCH .github/workflows/qa.yml
+MATCH .github/workflows/release.yml
+PROVENANCE total=4 fail=0
+```
+
+The source commit is a direct child of the recorded base, and the fetched
+`origin/main` was still exactly the recorded base when the image was built.
+
+## Honest limits
+
+- This change fixes the unpinned-version half of #746. It does not add retry,
+  caching, checksum verification inside the third-party action, or a manual
+  fallback for setup-bun download failures. Issue #746 must remain open for
+  that remaining reliability work.
+- The action reference remains `oven-sh/setup-bun@v2`; this gate pins the Bun
+  runtime version, not the action implementation to a commit SHA.
+- The test statically verifies workflow configuration in Docker. It does not
+  emulate GitHub-hosted runner networking or tool-cache behavior.
+- No package was published and no production service, node, database,
+  repository setting, credential, or branch protection was changed.

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -73,6 +73,7 @@ L1_TESTS=(
   "test686-rest-shape-golden"
   "test765-batch-runtime-gate"
   "test766-bunx-preflight"
+  "test746-setup-bun-pin"
 )
 
 if [[ "${1:-}" == "--list" ]]; then
@@ -149,6 +150,8 @@ if [[ $RUN_L1 -eq 1 ]]; then
       build_args="--build-arg TEST765_SOURCE_COMMIT=$(git rev-parse HEAD)"
     elif [[ "$t" == "test766-bunx-preflight" ]]; then
       build_args="--build-arg TEST766_SOURCE_COMMIT=$(git rev-parse HEAD)"
+    elif [[ "$t" == "test746-setup-bun-pin" ]]; then
+      build_args="--build-arg TEST746_SOURCE_COMMIT=$(git rev-parse HEAD)"
     fi
     if ! dockerrun "docker build -q $build_args -t anet-$t -f tests/$t/Dockerfile ." >/tmp/qa-l1-$t-build.log 2>&1; then
       fail "L1 $t — build failed, see /tmp/qa-l1-$t-build.log"

--- a/tests/test746-setup-bun-pin/Dockerfile
+++ b/tests/test746-setup-bun-pin/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim-bookworm
+
+ARG TEST746_SOURCE_COMMIT=dev
+ENV TEST746_SOURCE_COMMIT=$TEST746_SOURCE_COMMIT
+LABEL org.opencontainers.image.revision=$TEST746_SOURCE_COMMIT
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-yaml \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY .github/workflows ./.github/workflows
+COPY tests/test746-setup-bun-pin/run.sh ./run.sh
+RUN chmod 0755 ./run.sh
+
+CMD ["bash", "./run.sh"]

--- a/tests/test746-setup-bun-pin/run.sh
+++ b/tests/test746-setup-bun-pin/run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_VERSION=1.3.14
+ROOT=/app
+WORKFLOWS="$ROOT/.github/workflows"
+
+[[ "${TEST746_SOURCE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]] || {
+  echo 'FAIL: TEST746_SOURCE_COMMIT must be one full lowercase Git SHA' >&2
+  exit 1
+}
+
+assert_setup_bun_pins() {
+  local workflows="$1" log="$2"
+  WORKFLOWS="$workflows" EXPECTED_VERSION="$EXPECTED_VERSION" /usr/bin/python3 - <<'PY' >"$log" 2>&1
+import glob
+import os
+import sys
+import yaml
+
+root = os.environ["WORKFLOWS"]
+expected = os.environ["EXPECTED_VERSION"]
+found = []
+bad = []
+
+def walk(value, path):
+    if isinstance(value, dict):
+        if value.get("uses") == "oven-sh/setup-bun@v2":
+            version = (value.get("with") or {}).get("bun-version")
+            found.append((path, version))
+            if str(version) != expected:
+                bad.append((path, version))
+        for key, child in value.items():
+            walk(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            walk(child, f"{path}[{index}]")
+
+for filename in sorted(glob.glob(os.path.join(root, "*.yml")) + glob.glob(os.path.join(root, "*.yaml"))):
+    with open(filename, "r", encoding="utf-8") as handle:
+        walk(yaml.safe_load(handle), os.path.basename(filename))
+
+print(f"setup_bun_occurrences={len(found)} expected_version={expected}")
+for path, version in found:
+    print(f"{path} bun-version={version}")
+
+if len(found) != 3:
+    print(f"FAIL: expected exactly 3 setup-bun occurrences, found {len(found)}", file=sys.stderr)
+    sys.exit(1)
+if bad:
+    for path, version in bad:
+        print(f"FAIL: {path} bun-version={version!r}, expected {expected}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+BASELINE_LOG=/tmp/test746-baseline.log
+assert_setup_bun_pins "$WORKFLOWS" "$BASELINE_LOG"
+cat "$BASELINE_LOG"
+grep -Fxq 'setup_bun_occurrences=3 expected_version=1.3.14' "$BASELINE_LOG"
+echo 'L1 SETUP_BUN_PIN_PASS'
+
+MUTANT_ROOT=/tmp/test746-mutant
+mkdir -p "$MUTANT_ROOT"
+cp -R "$WORKFLOWS" "$MUTANT_ROOT/workflows"
+TARGET="$MUTANT_ROOT/workflows/release.yml"
+before="$(sha256sum "$TARGET" | cut -d' ' -f1)"
+/usr/bin/python3 - "$TARGET" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+target = "        with:\n          bun-version: 1.3.14\n"
+if text.count(target) != 1:
+    raise SystemExit("mutation target count changed")
+path.write_text(text.replace(target, "", 1))
+PY
+after="$(sha256sum "$TARGET" | cut -d' ' -f1)"
+[[ "$before" != "$after" ]] || { echo 'MUTATION_NOOP release-pin-removed'; exit 1; }
+
+MUTATION_LOG=/tmp/test746-mutation.log
+if assert_setup_bun_pins "$MUTANT_ROOT/workflows" "$MUTATION_LOG" 2>&1; then
+  echo 'MUTATION_SURVIVED release-pin-removed'
+  exit 1
+fi
+grep -Fq 'release.yml' "$MUTATION_LOG"
+grep -Fq 'bun-version=None, expected 1.3.14' "$MUTATION_LOG"
+echo 'MUTATION_RED release-pin-removed'
+echo 'RESULT: PASS'


### PR DESCRIPTION
## What changed

- pin Bun `1.3.14` in all three active `oven-sh/setup-bun@v2` workflow steps (`e2e-docker`, `qa`, and `release`)
- add a Docker L1 gate that parses the complete workflow domain, requires the full three-occurrence denominator, and rejects any missing or different `bun-version`
- wire the gate into active QA path coverage and preserve its exact-image evidence

## Why

Issue #746 recorded repeated setup-bun download failures and unpinned workflow behavior. This PR closes only the version-drift half: the same workflow could no longer silently select a newer Bun release. Retry/cache/manual fallback work remains open in #746.

## Frozen coordinates

- base: `92d9612949a4207eae4facab2b337c1f23de65e0`
- source: `c15df58f58a8a4bae2d637504b4ec98320a49aca`
- report-only: `649009eedd9630ec6ec9d354ac8c9c933598ce71`
- exact image: `sha256:a8faddf90133b9f68280792e5045f89722f8c33c16a848d7370669f6896d331c`

## Validation

Two exact-image runs produced identical output and identical log digest:

```text
setup_bun_occurrences=3 expected_version=1.3.14
L1 SETUP_BUN_PIN_PASS
MUTATION_RED release-pin-removed
RESULT: PASS
```

- run log SHA256 (both runs): `abda2b39247e0d1bf1f079fa5d2c1208881a2938eebbc237a08a8bc8440f9d8c`
- image/source byte provenance: `4/4 MATCH`
- named mutation: remove only `release.yml`'s version pin; gate fails on `release.yml ... bun-version=None, expected 1.3.14`

## Honest limits

- does not add retry, caching, a manual fallback, or independent checksum verification for setup-bun downloads
- does not pin the action implementation itself from `@v2` to a commit SHA
- does not publish packages or change production, repository settings, credentials, or branch protection

Refs #746
