### PR TITLE
ci: pin Bun in the always-on rename-ghost gate

### DIFF
--- a/docs/tests/report-test728-qa180-pinned-bun.txt
+++ b/docs/tests/report-test728-qa180-pinned-bun.txt
@@ -1,0 +1,83 @@
+# test728 — pin Bun in the active rename-ghost E2E gate
+
+Date: 2026-08-13 (Asia/Shanghai)
+Issue: https://github.com/sleep2agi/agent-network/issues/728
+Base: d4283a229dbdcd85d0e4ceb9f715c84607a521b4
+Source commit: eb16765c6f2d39872cdd12635226c03cc473c11c
+Image: sha256:bffa2ea7463ab1c13bfab718dbe75ef39ab102f8200d171c7da8dd4e3adcfea9
+
+## Result
+
+PASS. The only remaining `bun.sh` Dockerfile directly built by every pull
+request's GitHub E2E workflow now copies Bun from the reviewed digest-pinned
+1.3.14 image instead of executing the mutable network installer.
+
+The exact-source image completed the real rename-ghost regression:
+
+```
+issue #180 rename ghost e2e — PASS=20 FAIL=0
+```
+
+Both foreground and tmux-detached rename lanes completed. In each lane the
+old alias disappeared, the new alias process was alive, and no old-alias MCP
+subprocess remained.
+
+The Dockerfile also verifies both executable entry points during build:
+
+```
+test "$(bun --version)" = "1.3.14"
+test "$(bunx --version)" = "1.3.14"
+```
+
+## Supply-chain witnessed red
+
+An ephemeral copy of the source Dockerfile changed only the Bun image digest
+to 64 zeroes. Building the same context failed before any test layer with:
+
+```
+MUTATION_RC=1
+oven/bun:1.3.14@sha256:0000...0000: not found
+failed to resolve source metadata
+```
+
+This shows the digest is consumed by Docker's source resolver and is not a
+decorative comment or unused build argument.
+
+## Current denominator
+
+A current-main read found 30 remaining Dockerfiles containing a bun.sh/curl
+installer:
+
+- 15 directories named `tests/qa-*`;
+- 15 historical directories named `tests/test*`;
+- 0 overlap with `scripts/qa.sh`'s active L1 list (that denominator was
+  already closed by #762);
+- 1 direct GitHub workflow build: `tests/qa-180-rename-ghost/Dockerfile`.
+
+This change intentionally fixes that single always-on CI member first. It
+does not mechanically rewrite the 29 ad-hoc or historical suites before
+their invocation and compatibility requirements are classified.
+
+## Scope and provenance
+
+The source commit changes exactly one file:
+`tests/qa-180-rename-ghost/Dockerfile`. The base file's retry/fail-closed
+bun.sh block is replaced by one digest-pinned stage, one binary copy, a bunx
+symlink, and two exact-version assertions. No product source, workflow,
+package metadata, or production file changes.
+
+The full run log SHA256 is
+`285afa9b513b6ccefef93cabf8eb6ad12c8a7fc2068a3169cf90e95a66c07c2a`.
+It contains random test IDs and timings and is diagnostic, not claimed to be
+reproducible.
+
+## Honest limits
+
+- Issue #728 remains open for the other 29 non-L1 Dockerfiles.
+- The runtime image is digest-pinned, but `node:22-bookworm-slim` remains a
+  moving tag inherited from the existing Dockerfile; this PR does not claim
+  the entire image is byte-reproducible.
+- The E2E uses a mock Claude process and does not prove real-vendor behavior;
+  that is an existing limit of the rename-ghost suite.
+- No npm package, GitHub release, node, production service, database,
+  credential, or repository setting was changed.

--- a/tests/qa-180-rename-ghost/Dockerfile
+++ b/tests/qa-180-rename-ghost/Dockerfile
@@ -13,6 +13,8 @@
 #
 # Install path identical to qa-rfc026/qa-rfc027 (local source, no npm
 # @preview) per RFC-024 教训.
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun-runtime
+
 FROM node:22-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -21,38 +23,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
-# bun 安装:重试 + fail-closed。与 tests/qa-cli-01-hub-start/Dockerfile 同一写法(#733)。
-#
-# 原来是 `curl -fsSL https://bun.sh/install | bash`,有两个坑:
-#   1. Docker 用 /bin/sh 执行,没有 pipefail —— 管道的退出码只反映 bash(consumer),
-#      curl(producer)失败会被吃掉,层照样通过;
-#   2. 光靠事后 `test -x` 也分不清「本次装成功」和「上一次失败尝试留下的二进制」。
-# 所以这里先把安装脚本下载到临时文件,curl 成功才执行,两步都成功才置 installed=1,
-# 最后要求 installed=1 且二进制存在 —— 否则构建失败,不放行。
-#
-# 触发这次修改的实证:2026-08-13 本门在 PR #740 上红,失败原因正是
-#   process "/bin/sh -c curl -fsSL https://bun.sh/install | bash" ... exit code: 1
-# 这个门是 hard-fail 型(失败即红,不是 report-only),所以上游 bun.sh 的任何抖动
-# 都会让每一个 PR 亮红。
-# 🔴 措辞更正:main **没有 branch protection**
-#    (GET /repos/…/branches/main/protection → 404 "Branch not protected"),
-#    所以它并不由机制阻止合并 —— 拦住的是纪律,不是 GitHub。
-#    原注释写「卡住每一个 PR」,把「会亮红」说成了「合不了」,不准确。
-RUN installed=0; \
-    for i in 1 2 3; do \
-      rm -f /tmp/bun-install.sh; \
-      if curl -fsSL https://bun.sh/install -o /tmp/bun-install.sh \
-          && bash /tmp/bun-install.sh; then \
-        installed=1; \
-        break; \
-      fi; \
-      echo "bun install attempt $i failed; retrying in $((i*5))s"; \
-      sleep $((i*5)); \
-    done; \
-    rm -f /tmp/bun-install.sh; \
-    test "$installed" = 1 && test -x "$HOME/.bun/bin/bun" \
-      || { echo "bun install failed after 3 attempts"; exit 1; }
-ENV PATH="/root/.bun/bin:${PATH}"
+# This job runs on every PR and must not depend on the mutable bun.sh installer.
+# Copy the reviewed Bun 1.3.14 binary from the same digest-pinned image used by
+# the active L1 suites, then fail closed on both bun and bunx versions.
+COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun
+RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx \
+    && test "$(bun --version)" = "1.3.14" \
+    && test "$(bunx --version)" = "1.3.14"
 
 WORKDIR /app
 


### PR DESCRIPTION
## What changed

- replace the mutable `bun.sh` installer in the always-on rename-ghost E2E Dockerfile with the reviewed digest-pinned `oven/bun:1.3.14` binary
- verify both `bun` and `bunx` report exactly `1.3.14` during the image build
- preserve the existing Node 22 runtime and the full rename-ghost behavior suite

## Why this member first

Current main still has 30 non-L1 Dockerfiles containing bun.sh/curl installers: 15 `qa-*` and 15 historical `test*`. None overlap active `scripts/qa.sh --l1`, but `tests/qa-180-rename-ghost/Dockerfile` is the only one directly built by every pull request's E2E workflow. This PR fixes that always-on member without mechanically rewriting the other 29 before their invocation/compatibility requirements are classified.

## Frozen coordinates

- base: `d4283a229dbdcd85d0e4ceb9f715c84607a521b4`
- source: `eb16765c6f2d39872cdd12635226c03cc473c11c`
- report-only: `93508ea391e54f8fe4a8f0796b3be2f42e78f38c`
- exact image: `sha256:bffa2ea7463ab1c13bfab718dbe75ef39ab102f8200d171c7da8dd4e3adcfea9`

## Validation

The exact-source image completed the real Docker regression:

```text
issue #180 rename ghost e2e — PASS=20 FAIL=0
```

A supply-chain mutation changed only the Bun image digest to 64 zeroes. Docker failed closed at source resolution (`MUTATION_RC=1`, digest not found), proving the digest is a bearing input rather than decorative text.

## Honest limits

- #728 remains open for the other 29 non-L1 Dockerfiles
- the Bun stage is digest-pinned; the inherited `node:22-bookworm-slim` stage remains a moving tag, so the complete image is not claimed byte-reproducible
- no package release, production change, repository setting, or credential change

Refs #728
