### PR TITLE
feat(grok): add strict repo-read co-presence profile

### DIFF
--- a/agent-network/src/grok-copresence-disclosure.test.ts
+++ b/agent-network/src/grok-copresence-disclosure.test.ts
@@ -22,8 +22,23 @@ describe("grok co-presence disclosure", () => {
     expect(text).not.toContain("No filesystem, shell, web,");
   });
 
+  test("repo-read profile reports only sandboxed project reads", () => {
+    const disclosure = grokCopresenceDisclosure(["Read", "Grep", "Glob"], "new");
+    const text = disclosure.lines.join("\n");
+    expect(disclosure.profile).toBe("repo-read");
+    expect(text).toContain("[todo_write,search_tool,use_tool,read_file,grep,list_dir]");
+    expect(text).toContain("strict sandbox");
+    expect(text).toContain("essential system paths");
+    expect(text).toContain("protected credential paths");
+    expect(text).toContain("shell, writes, web/media");
+    expect(text).not.toContain("web_search is enabled");
+  });
+
   test("near-match tools are disclosed as invalid rather than a reviewed profile", () => {
-    for (const tools of [["websearch"], ["WebSearch", "Bash"], [" WebSearch"]]) {
+    for (const tools of [
+      ["websearch"], ["WebSearch", "Bash"], [" WebSearch"],
+      ["Read", "Glob", "Grep"], ["Read", "Grep"],
+    ]) {
       const disclosure = grokCopresenceDisclosure(tools, "configured");
       expect(disclosure.profile).toBe("invalid");
       expect(disclosure.lines.join("\n")).toContain("startup will fail closed");

--- a/agent-network/src/grok-copresence-disclosure.ts
+++ b/agent-network/src/grok-copresence-disclosure.ts
@@ -1,12 +1,12 @@
 export type GrokCopresenceSessionDisclosure = "configured" | "new" | "resume";
 
 export type GrokCopresenceDisclosure = {
-  profile: "commhub-only" | "x-search" | "invalid";
+  profile: "commhub-only" | "x-search" | "repo-read" | "invalid";
   lines: readonly string[];
 };
 
 /**
- * Describe only the two exact tool profiles accepted by the pinned Grok TUI
+ * Describe only the exact tool profiles accepted by the pinned Grok TUI
  * runtime. This is deliberately exact: a near-miss must never be presented as
  * either reviewed capability set.
  */
@@ -16,6 +16,10 @@ export function grokCopresenceDisclosure(
 ): GrokCopresenceDisclosure {
   const configured = Array.isArray(tools) ? tools : [];
   const xSearch = configured.length === 1 && configured[0] === "WebSearch";
+  const repoRead = configured.length === 3
+    && configured[0] === "Read"
+    && configured[1] === "Grep"
+    && configured[2] === "Glob";
   const defaultProfile = configured.length === 0;
 
   const lines: string[] = [];
@@ -24,6 +28,10 @@ export function grokCopresenceDisclosure(
     profile = "x-search";
     lines.push("Configured profile: x-search; fixed tools: [todo_write,search_tool,use_tool,web_search].");
     lines.push("General web_search is enabled; WebFetch, filesystem, shell, media, project/host MCP, and subagents remain unavailable.");
+  } else if (repoRead) {
+    profile = "repo-read";
+    lines.push("Configured profile: repo-read; fixed tools: [todo_write,search_tool,use_tool,read_file,grep,list_dir].");
+    lines.push("Read-only filesystem access uses Grok's strict sandbox (project tree plus essential system paths); protected credential paths, shell, writes, web/media, and subagents remain unavailable.");
   } else if (defaultProfile) {
     profile = "commhub-only";
     lines.push("Configured profile: commhub-only; fixed tools: [todo_write,search_tool,use_tool].");
@@ -31,7 +39,7 @@ export function grokCopresenceDisclosure(
   } else {
     profile = "invalid";
     lines.push("Configured tools do not match a supported exact Grok co-presence profile; startup will fail closed.");
-    lines.push("Supported profiles are [] and [WebSearch]; custom or near-match tool names are not accepted.");
+    lines.push('Supported profiles are [], [WebSearch], and [Read,Grep,Glob]; custom, reordered, or near-match tool names are not accepted.');
   }
 
   if (session === "new") {

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -71,6 +71,7 @@ import { resolveGrokAcpTimeout } from "./runtime/grok-build-acp/timeout-resolve"
 import {
   GROK_COPRESENCE_PROFILE_ENV,
   selectGrokCopresenceCapabilityProfile,
+  selectGrokCopresenceSandboxProfile,
 } from "./runtime/grok-copresence/profile-selection";
 import {
   defaultNpmInstall,
@@ -549,7 +550,7 @@ if (GROK_COPRESENCE) {
   console.warn(
     `[agent-node] EXPERIMENTAL/DANGEROUS grok-build-cli co-presence is enabled `
     + `(process profile=${GROK_COPRESENCE_CAPABILITY_PROFILE}); the shared human TUI must receive `
-    + "tasks only from trusted senders. MCP is CommHub-only; WebSearch is available only in the explicit x-search profile.",
+    + "tasks only from trusted senders. MCP is CommHub-only; WebSearch and repo reads are available only in their explicit profiles.",
   );
 }
 // Default 50 turns. The old default of 5 was way too low — Claude Agent SDK
@@ -3569,7 +3570,7 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
       );
     }
     // The generic tools option is not forwarded. It was already reduced at
-    // process boot to one of two exact profiles; any other value failed before
+    // process boot to one exact runtime-owned profile; any other value failed before
     // the runtime module was loaded.
     if (
       MAX_TURNS_CLI !== undefined
@@ -3745,9 +3746,15 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
       alias: currentAlias(),
       model: MODEL || undefined,
       agentProfile: grokCliHome.copresenceAgentProfile,
-      // The runtime always approves its fixed three-tool profile. Filesystem,
-      // shell, web, host/project MCP and subagent capabilities remain absent.
-      sandboxProfile: grokCliHome.workspaceProfile,
+      // Repo-read is the only profile with filesystem tools. Pinned 0.2.93
+      // documents workspace as read-everywhere, so repo-read must use the
+      // kernel-enforced strict base (CWD + essential system paths). A resumed
+      // workspace session cannot change sandbox and therefore requires an
+      // explicit new session before repo-read can start.
+      sandboxProfile: selectGrokCopresenceSandboxProfile(
+        GROK_COPRESENCE_CAPABILITY_PROFILE,
+        grokCliHome,
+      ),
       protectedPaths: [
         grokCliHome.home,
         grokCliHome.commhubCredentialDir || "",
@@ -5853,7 +5860,7 @@ if (AUTH_TOKEN) {
 }
 
 // #101 fix: log resolved toolset shape. Co-presence reduces the generic config
-// to one of two runtime-owned process profiles verified for the pinned TUI.
+// to one runtime-owned process profile verified for the pinned TUI.
 const requestedToolsSummary =
   Array.isArray(TOOLS)
     ? (TOOLS.length ? `[${TOOLS.join(",")}]` : "(none)")
@@ -5861,7 +5868,9 @@ const requestedToolsSummary =
 log(`  tools:   ${GROK_COPRESENCE
   ? GROK_COPRESENCE_CAPABILITY_PROFILE === "x-search"
     ? "fixed x-search profile [todo_write,search_tool,use_tool,web_search] (general web; no web-fetch/filesystem/shell/media/subagents)"
-    : "fixed commhub-only profile [todo_write,search_tool,use_tool] (no filesystem/shell/web/media/subagents)"
+    : GROK_COPRESENCE_CAPABILITY_PROFILE === "repo-read"
+      ? "fixed repo-read profile [todo_write,search_tool,use_tool,read_file,grep,list_dir] (strict CWD reads; no shell/write/web/media/subagents)"
+      : "fixed commhub-only profile [todo_write,search_tool,use_tool] (no filesystem/shell/web/media/subagents)"
   : requestedToolsSummary}`);
 log(`  channels:${[
   TELEGRAM_CHANNELS.length ? `telegram(${TELEGRAM_CHANNELS.map(ch => ch.dir).join(",")})` : "",

--- a/agent-node/src/runtime/grok-build-cli-home.test.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.test.ts
@@ -96,6 +96,7 @@ describe("prepareGrokCliHome", () => {
 
     expect(first).toEqual(second);
     expect(first.readOnlyProfile).toMatch(/^anet-[a-f0-9]{24}-read-only$/);
+    expect(first.strictProfile).toMatch(/^anet-[a-f0-9]{24}-strict$/);
     expect(first.authPath).toBe(join(sourceHome, "auth.json"));
     expect(first.oidcIssuer).toBe("https://auth.example.test");
     expect(first.oidcClientId).toBe("client-123");
@@ -115,6 +116,7 @@ describe("prepareGrokCliHome", () => {
     expect(sandbox).toContain(secretDir);
     expect(sandbox).toContain(join(sourceHome, "auth.json"));
     expect(sandbox).toContain('extends = "read-only"');
+    expect(sandbox).toContain('extends = "strict"');
     expect(sandbox).toContain('extends = "workspace"');
   });
 
@@ -808,7 +810,7 @@ describe("prepareGrokCliHome", () => {
     expect(config).toContain('[ui]\ndefault_selected_permission = "always_allow_all_sessions"');
     expect(config).toContain("remember_tool_approvals = true");
     expect(config).toContain("[mcp_servers.commhub]");
-    expect(config).toContain('command = "bun"');
+    expect(config).toMatch(/command = ".*\/bun(?:\.exe)?"/);
     const stagedServer = join(stateHome, "runtime-mcp", "node-server.js");
     const stagedEnv = join(dirname(dirname(stateHome)), ".anet-grok-credentials", basename(stateHome), ".env");
     expect(config).toContain(`args = [${JSON.stringify(stagedServer)}]`);
@@ -820,6 +822,12 @@ describe("prepareGrokCliHome", () => {
     expect(statSync(stagedEnv).mode & 0o777).toBe(0o600);
     expect(config).toContain('COMMHUB_ALIAS = "指挥狗"');
     expect(config).not.toContain("ntok_test");
+    const strictSandbox = readFileSync(join(stateHome, "sandbox.toml"), "utf8");
+    const strictBlock = strictSandbox.split('extends = "strict"')[1]?.split("[profiles.")[0] || "";
+    const command = config.match(/^command = (.+)$/m)?.[1] || "";
+    expect(strictBlock).toContain(JSON.stringify(sourceHome));
+    expect(strictBlock).toContain(JSON.stringify(dirname(stagedEnv)));
+    expect(strictBlock).toContain(command);
     expect(readFileSync(join(stateHome, "requirements.toml"), "utf8"))
       .toBe("[ui]\ndisable_bypass_permissions_mode = false\n");
     const trustStore = join(stateHome, "trusted_folders.toml");

--- a/agent-node/src/runtime/grok-build-cli-home.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.ts
@@ -4,6 +4,7 @@ import {
   chmodSync,
   closeSync,
   constants,
+  accessSync,
   existsSync,
   fchmodSync,
   fstatSync,
@@ -22,7 +23,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "fs";
-import { basename, dirname, isAbsolute, join, parse, relative, resolve } from "path";
+import { basename, delimiter, dirname, isAbsolute, join, parse, relative, resolve } from "path";
 import { homedir } from "os";
 import { buildGrokHelperEnv } from "./grok-child-env";
 import {
@@ -49,12 +50,17 @@ export interface GrokCommhubMcpConfig {
   resumeId: string;
 }
 
+interface StagedGrokCommhubMcpConfig extends GrokCommhubMcpConfig {
+  command: string;
+}
+
 export interface GrokCliHome {
   home: string;
   authPath: string;
   oidcIssuer?: string;
   oidcClientId?: string;
   readOnlyProfile: string;
+  strictProfile: string;
   workspaceProfile: string;
   /** Absolute runtime-owned profile passed through the TUI-effective --agent flag. */
   copresenceAgentProfile?: string;
@@ -1042,7 +1048,7 @@ function stageCommhubMcpConfig(
   config: GrokCommhubMcpConfig,
   stateRoot: string,
   stateHome: string,
-): { config: GrokCommhubMcpConfig; credentialDir: string } {
+): { config: StagedGrokCommhubMcpConfig; credentialDir: string } {
   const readStable = (path: string, label: string, expectedMode?: number): string => {
     const before = lstatSync(path);
     const fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
@@ -1073,9 +1079,30 @@ function stageCommhubMcpConfig(
   ensurePrivateDirectory(credentialDir, "commhub MCP credential directory");
   const serverPath = join(runtimeDir, "node-server.js");
   const envFile = join(credentialDir, ".env");
+  const command = resolvePinnedRuntimeExecutable("bun");
   writeGeneratedFile(serverPath, readStable(config.serverPath, "server"));
   writeGeneratedFile(envFile, readStable(config.envFile, "environment", 0o600));
-  return { config: { ...config, serverPath, envFile }, credentialDir };
+  return { config: { ...config, command, serverPath, envFile }, credentialDir };
+}
+
+function resolvePinnedRuntimeExecutable(name: string): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+    throw new Error("grok-build-cli MCP runtime executable name is invalid");
+  }
+  for (const entry of (process.env.PATH || "").split(delimiter)) {
+    if (!entry || !isAbsolute(entry)) continue;
+    const candidate = join(entry, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      const canonical = realpathSync(candidate);
+      const stat = statSync(canonical);
+      const uid = process.getuid?.();
+      if (!stat.isFile() || (stat.mode & 0o022) !== 0
+        || (uid !== undefined && stat.uid !== uid && stat.uid !== 0)) continue;
+      return canonical;
+    } catch {}
+  }
+  throw new Error(`grok-build-cli cannot resolve a trusted ${name} executable for CommHub MCP`);
 }
 
 function trustedProjectDirectory(projectCwd: string, protectedPaths: readonly string[]): string {
@@ -1337,6 +1364,7 @@ export function prepareGrokCliHome(opts: PrepareGrokCliHomeOptions): GrokCliHome
   }
 
   const readOnlyProfile = `${profileId}-read-only`;
+  const strictProfile = `${profileId}-strict`;
   const workspaceProfile = `${profileId}-workspace`;
   const existingSecretPaths = resolvedDenyPaths.filter((path) => existsSync(path));
   if (!existingSecretPaths.length) {
@@ -1388,7 +1416,7 @@ export function prepareGrokCliHome(opts: PrepareGrokCliHomeOptions): GrokCliHome
     "",
     ...(commhubMcp ? [
       "[mcp_servers.commhub]",
-      'command = "bun"',
+      `command = ${JSON.stringify(commhubMcp.command)}`,
       `args = [${JSON.stringify(commhubMcp.serverPath)}]`,
       `env = { ANET_COMMHUB_ENV_FILE = ${JSON.stringify(commhubMcp.envFile)}, ANET_COMMHUB_MODE = "outbound-only", COMMHUB_ALIAS = ${JSON.stringify(commhubMcp.alias)}, COMMHUB_RESUME_ID = ${JSON.stringify(commhubMcp.resumeId)} }`,
       "enabled = true",
@@ -1447,7 +1475,7 @@ export function prepareGrokCliHome(opts: PrepareGrokCliHomeOptions): GrokCliHome
 
   if (opts.useLeader === true) {
     // This runtime deliberately uses the pinned CLI's always-approve mode for
-    // its fixed three-tool profile. Keep the user-tier requirements file from
+    // its exact runtime-owned profile. Keep the user-tier requirements file from
     // accidentally disabling that mode.
     writeGeneratedFile(join(stateHome, "requirements.toml"), [
       "[ui]",
@@ -1459,6 +1487,15 @@ export function prepareGrokCliHome(opts: PrepareGrokCliHomeOptions): GrokCliHome
   writeGeneratedFile(join(stateHome, "sandbox.toml"), [
     `[profiles.${JSON.stringify(readOnlyProfile)}]`,
     'extends = "read-only"',
+    `deny = [${denyToml}]`,
+    "",
+    `[profiles.${JSON.stringify(strictProfile)}]`,
+    'extends = "strict"',
+    `read_only = [${[
+      sourceHome,
+      ...(commhubMcp ? [commhubMcp.command] : []),
+      ...(stagedCommhubMcp ? [stagedCommhubMcp.credentialDir] : []),
+    ].map((path) => JSON.stringify(path)).join(", ")}]`,
     `deny = [${denyToml}]`,
     "",
     `[profiles.${JSON.stringify(workspaceProfile)}]`,
@@ -1487,6 +1524,7 @@ export function prepareGrokCliHome(opts: PrepareGrokCliHomeOptions): GrokCliHome
     ...(oidcIssuer && oidcClientId ? { oidcIssuer, oidcClientId } : {}),
     ...(stagedCommhubMcp ? { commhubCredentialDir: stagedCommhubMcp.credentialDir } : {}),
     readOnlyProfile,
+    strictProfile,
     workspaceProfile,
     ...(opts.useLeader === true ? { copresenceAgentProfile } : {}),
   };

--- a/agent-node/src/runtime/grok-copresence/policy.ts
+++ b/agent-node/src/runtime/grok-copresence/policy.ts
@@ -15,16 +15,19 @@ import { readPinnedGrokCopresenceCapabilityProfile } from "./profile-selection";
  * therefore uses one runtime-owned agent profile and verifies the effective
  * request inventory independently.  The two MCP dispatcher tools are useful
  * only because startup separately proves that exactly one runtime-owned
- * `commhub` server was discovered.  Filesystem, process, web/media, subagent,
- * and scheduler tools remain absent.
+ * `commhub` server was discovered. The repo-read profile adds only the three
+ * read-only project tools; process, write, web/media, subagent, and scheduler
+ * tools remain absent, while protected credential paths stay hard-denied.
  */
 export const GROK_COPRESENCE_CAPABILITY_PROFILE = readPinnedGrokCopresenceCapabilityProfile();
 export const GROK_COPRESENCE_WEB_SEARCH_ENABLED = GROK_COPRESENCE_CAPABILITY_PROFILE === "x-search";
+export const GROK_COPRESENCE_REPO_READ_ENABLED = GROK_COPRESENCE_CAPABILITY_PROFILE === "repo-read";
 export const GROK_COPRESENCE_EFFECTIVE_TOOLS = Object.freeze([
   "todo_write",
   "search_tool",
   "use_tool",
   ...(GROK_COPRESENCE_WEB_SEARCH_ENABLED ? ["web_search"] : []),
+  ...(GROK_COPRESENCE_REPO_READ_ENABLED ? ["read_file", "grep", "list_dir"] : []),
 ]);
 
 export const GROK_COPRESENCE_AGENT_NAME = "anet-copresence-preview";
@@ -44,7 +47,9 @@ export function renderGrokCopresenceAgentProfile(): string {
     "---",
     GROK_COPRESENCE_WEB_SEARCH_ENABLED
       ? `${GROK_COPRESENCE_PROFILE_MARKER}: Answer the current user directly. The runtime-owned outbound-only commhub MCP integration and general web_search are available; do not claim inbound CommHub, lifecycle/presence ownership, filesystem, shell, web-fetch/media, or subagent access. Web search is not an x.com-only network sandbox.`
-      : `${GROK_COPRESENCE_PROFILE_MARKER}: Answer the current user directly. Only the runtime-owned outbound-only commhub MCP integration is available; do not claim inbound CommHub, lifecycle/presence ownership, filesystem, shell, web/media, or subagent access.`,
+      : GROK_COPRESENCE_REPO_READ_ENABLED
+        ? `${GROK_COPRESENCE_PROFILE_MARKER}: Answer the current user directly. The runtime-owned outbound-only commhub MCP integration plus read_file, grep, and list_dir are available under Grok's strict sandbox: project tree plus essential system paths only; protected credential paths remain denied. Do not claim shell, write/edit, web/media, lifecycle/presence ownership, or subagent access.`
+        : `${GROK_COPRESENCE_PROFILE_MARKER}: Answer the current user directly. Only the runtime-owned outbound-only commhub MCP integration is available; do not claim inbound CommHub, lifecycle/presence ownership, filesystem, shell, web/media, or subagent access.`,
     "",
   ].join("\n");
 }

--- a/agent-node/src/runtime/grok-copresence/profile-process-probe.ts
+++ b/agent-node/src/runtime/grok-copresence/profile-process-probe.ts
@@ -4,6 +4,12 @@ import {
   GROK_COPRESENCE_EFFECTIVE_TOOLS,
   renderGrokCopresenceAgentProfile,
 } from "./policy";
+import { selectGrokCopresenceSandboxProfile } from "./profile-selection";
+
+const sandboxProfile = selectGrokCopresenceSandboxProfile(
+  GROK_COPRESENCE_CAPABILITY_PROFILE,
+  { workspaceProfile: "anet-test232-workspace", strictProfile: "anet-test232-strict" },
+);
 
 const args = buildGrokCopresenceArgs({
   cwd: "/workspace/project",
@@ -11,7 +17,7 @@ const args = buildGrokCopresenceArgs({
   resume: false,
   leaderSocket: "/tmp/anet-test232/leader.sock",
   agentProfile: "/runtime/anet-copresence-preview.md",
-  sandboxProfile: "anet-test232-workspace",
+  sandboxProfile,
   protectedPaths: ["/runtime/private"],
 });
 const automaticTool = (tool: string, turnOwner: "human" | "network") => isGrokPreviewAutomaticResolution({
@@ -33,14 +39,16 @@ const automaticTool = (tool: string, turnOwner: "human" | "network") => isGrokPr
 process.stdout.write(JSON.stringify({
   profile: GROK_COPRESENCE_CAPABILITY_PROFILE,
   tools: GROK_COPRESENCE_EFFECTIVE_TOOLS,
+  sandboxProfile,
   args,
   renderedProfile: renderGrokCopresenceAgentProfile(),
-  automaticWebSearch: {
-    human: automaticTool("web_search", "human"),
-    network: automaticTool("web_search", "network"),
-  },
-  webSearchNearMisses: [
+  automaticTools: Object.fromEntries(GROK_COPRESENCE_EFFECTIVE_TOOLS.map((tool) => [tool, {
+    human: automaticTool(tool, "human"),
+    network: automaticTool(tool, "network"),
+  }])),
+  toolNearMisses: [
     "web_search2", "WebSearch", " web_search", "web_search ", "web-search",
     "web_search\n", "ｗｅｂ＿ｓｅａｒｃｈ", "not_web_search",
+    "read_file2", "Read", "read-file", " grep", "list_dir ", "list_directory",
   ].map((tool) => [tool, automaticTool(tool, "network")]),
 }) + "\n");

--- a/agent-node/src/runtime/grok-copresence/profile-process.test.ts
+++ b/agent-node/src/runtime/grok-copresence/profile-process.test.ts
@@ -6,13 +6,14 @@ import { GROK_COPRESENCE_PROFILE_ENV } from "./profile-selection";
 interface ProbeResult {
   profile: string;
   tools: string[];
+  sandboxProfile: string;
   args: string[];
   renderedProfile: string;
-  automaticWebSearch: { human: boolean; network: boolean };
-  webSearchNearMisses: Array<[string, boolean]>;
+  automaticTools: Record<string, { human: boolean; network: boolean }>;
+  toolNearMisses: Array<[string, boolean]>;
 }
 
-function probe(profile: "commhub-only" | "x-search"): ProbeResult {
+function probe(profile: "commhub-only" | "x-search" | "repo-read"): ProbeResult {
   const child = spawnSync(process.execPath, [join(import.meta.dir, "profile-process-probe.ts")], {
     encoding: "utf8",
     env: { ...process.env, [GROK_COPRESENCE_PROFILE_ENV]: profile },
@@ -22,33 +23,56 @@ function probe(profile: "commhub-only" | "x-search"): ProbeResult {
 }
 
 describe("Grok co-presence profile is pinned for the whole process", () => {
-  test("same input yields two exact, non-overlapping process capabilities", () => {
+  test("same input yields three exact, non-overlapping process capabilities", () => {
     const restricted = probe("commhub-only");
     const xSearch = probe("x-search");
+    const repoRead = probe("repo-read");
 
     expect(restricted.profile).toBe("commhub-only");
     expect(restricted.tools).toEqual(["todo_write", "search_tool", "use_tool"]);
+    expect(restricted.sandboxProfile).toBe("anet-test232-workspace");
     expect(restricted.args).toContain("--disable-web-search");
     expect(restricted.renderedProfile).not.toContain("  - web_search");
-    expect(restricted.automaticWebSearch).toEqual({ human: false, network: false });
+    expect(restricted.automaticTools).toEqual({
+      todo_write: { human: true, network: true },
+      search_tool: { human: true, network: true },
+      use_tool: { human: true, network: true },
+    });
 
     expect(xSearch.profile).toBe("x-search");
     expect(xSearch.tools).toEqual(["todo_write", "search_tool", "use_tool", "web_search"]);
+    expect(xSearch.sandboxProfile).toBe("anet-test232-workspace");
     expect(xSearch.args).not.toContain("--disable-web-search");
     expect(xSearch.renderedProfile).toContain("  - web_search");
     expect(xSearch.renderedProfile).toContain("not an x.com-only network sandbox");
-    expect(xSearch.automaticWebSearch).toEqual({ human: true, network: true });
-    expect(xSearch.webSearchNearMisses).toEqual([
+    expect(xSearch.automaticTools.web_search).toEqual({ human: true, network: true });
+
+    expect(repoRead.profile).toBe("repo-read");
+    expect(repoRead.tools).toEqual([
+      "todo_write", "search_tool", "use_tool", "read_file", "grep", "list_dir",
+    ]);
+    expect(repoRead.sandboxProfile).toBe("anet-test232-strict");
+    expect(repoRead.args).toContain("--disable-web-search");
+    expect(repoRead.renderedProfile).toContain("strict sandbox");
+    for (const tool of ["read_file", "grep", "list_dir"]) {
+      expect(repoRead.automaticTools[tool]).toEqual({ human: true, network: true });
+    }
+
+    expect(repoRead.toolNearMisses).toEqual([
       ["web_search2", false], ["WebSearch", false], [" web_search", false],
       ["web_search ", false], ["web-search", false], ["web_search\n", false],
       ["ｗｅｂ＿ｓｅａｒｃｈ", false], ["not_web_search", false],
+      ["read_file2", false], ["Read", false], ["read-file", false], [" grep", false],
+      ["list_dir ", false], ["list_directory", false],
     ]);
 
-    for (const result of [restricted, xSearch]) {
+    for (const result of [restricted, xSearch, repoRead]) {
       const denied = result.args.flatMap((value, index) => result.args[index - 1] === "--deny" ? [value] : []);
       expect(denied).toContain("Bash");
       expect(denied).toContain("Write");
       expect(denied).toContain("WebFetch");
+      expect(denied).toContain("Read(/runtime/private)");
+      expect(denied).toContain("Grep(/runtime/private/**)");
     }
   });
 });

--- a/agent-node/src/runtime/grok-copresence/profile-selection.test.ts
+++ b/agent-node/src/runtime/grok-copresence/profile-selection.test.ts
@@ -3,15 +3,18 @@ import {
   GROK_COPRESENCE_PROFILE_ENV,
   readPinnedGrokCopresenceCapabilityProfile,
   selectGrokCopresenceCapabilityProfile,
+  selectGrokCopresenceSandboxProfile,
 } from "./profile-selection";
 
 describe("Grok co-presence process capability profile", () => {
-  test("accepts only the two exact startup profiles", () => {
+  test("accepts only the exact startup profiles", () => {
     expect(selectGrokCopresenceCapabilityProfile(undefined)).toBe("commhub-only");
     expect(selectGrokCopresenceCapabilityProfile([])).toBe("commhub-only");
     expect(selectGrokCopresenceCapabilityProfile(["WebSearch"])).toBe("x-search");
+    expect(selectGrokCopresenceCapabilityProfile(["Read", "Grep", "Glob"])).toBe("repo-read");
     for (const tools of [
       ["web_search"], ["WebSearch", "WebFetch"], ["WebSearch "], ["all"], ["Read"],
+      ["Read", "Glob", "Grep"], ["Read", "Grep"], ["Read", "Grep", "Glob", "WebSearch"],
     ]) {
       expect(() => selectGrokCopresenceCapabilityProfile(tools)).toThrow("exact tools profile");
     }
@@ -24,9 +27,19 @@ describe("Grok co-presence process capability profile", () => {
     expect(readPinnedGrokCopresenceCapabilityProfile({
       [GROK_COPRESENCE_PROFILE_ENV]: "x-search",
     })).toBe("x-search");
+    expect(readPinnedGrokCopresenceCapabilityProfile({
+      [GROK_COPRESENCE_PROFILE_ENV]: "repo-read",
+    })).toBe("repo-read");
     expect(readPinnedGrokCopresenceCapabilityProfile({})).toBe("commhub-only");
     expect(() => readPinnedGrokCopresenceCapabilityProfile({
       [GROK_COPRESENCE_PROFILE_ENV]: "human-turn",
     })).toThrow("invalid");
+  });
+
+  test("uses the strict sandbox only for repo-read", () => {
+    const profiles = { workspaceProfile: "anet-workspace", strictProfile: "anet-strict" };
+    expect(selectGrokCopresenceSandboxProfile("commhub-only", profiles)).toBe("anet-workspace");
+    expect(selectGrokCopresenceSandboxProfile("x-search", profiles)).toBe("anet-workspace");
+    expect(selectGrokCopresenceSandboxProfile("repo-read", profiles)).toBe("anet-strict");
   });
 });

--- a/agent-node/src/runtime/grok-copresence/profile-selection.ts
+++ b/agent-node/src/runtime/grok-copresence/profile-selection.ts
@@ -1,19 +1,30 @@
 export const GROK_COPRESENCE_PROFILE_ENV = "ANET_INTERNAL_GROK_COPRESENCE_PROFILE";
 
-export type GrokCopresenceCapabilityProfile = "commhub-only" | "x-search";
+export type GrokCopresenceCapabilityProfile = "commhub-only" | "x-search" | "repo-read";
+
+export interface GrokCopresenceSandboxProfiles {
+  workspaceProfile: string;
+  strictProfile: string;
+}
 
 /**
  * Resolve once while agent-node boots. Co-presence deliberately does not
- * accept a general tool allowlist: the only opt-in is the reviewed WebSearch
- * profile, represented by the CLI's canonical Claude-style tool name.
+ * accept a general tool allowlist. Each opt-in is one reviewed, exact profile
+ * represented by canonical Claude-style tool names.
  */
 export function selectGrokCopresenceCapabilityProfile(
   tools: readonly string[] | undefined,
 ): GrokCopresenceCapabilityProfile {
   if (tools === undefined || tools.length === 0) return "commhub-only";
   if (tools.length === 1 && tools[0] === "WebSearch") return "x-search";
+  if (
+    tools.length === 3
+    && tools[0] === "Read"
+    && tools[1] === "Grep"
+    && tools[2] === "Glob"
+  ) return "repo-read";
   throw new Error(
-    'grok copresence supports only the exact tools profile ["WebSearch"] or an omitted tools field',
+    'grok copresence supports only the exact tools profiles ["WebSearch"], ["Read","Grep","Glob"], or an omitted tools field',
   );
 }
 
@@ -23,6 +34,17 @@ export function readPinnedGrokCopresenceCapabilityProfile(
 ): GrokCopresenceCapabilityProfile {
   const value = env[GROK_COPRESENCE_PROFILE_ENV];
   if (value === undefined || value === "") return "commhub-only";
-  if (value === "commhub-only" || value === "x-search") return value;
+  if (value === "commhub-only" || value === "x-search" || value === "repo-read") return value;
   throw new Error("grok copresence process capability profile is invalid");
+}
+
+/**
+ * Repo reads require Grok's kernel-enforced strict base. Pinned 0.2.93
+ * documents the workspace base as read-everywhere.
+ */
+export function selectGrokCopresenceSandboxProfile(
+  profile: GrokCopresenceCapabilityProfile,
+  profiles: GrokCopresenceSandboxProfiles,
+): string {
+  return profile === "repo-read" ? profiles.strictProfile : profiles.workspaceProfile;
 }

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -2101,7 +2101,7 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
         }
       } else if (isAutomaticApprovalLifecycleEvent(event)) {
         // Expected for the pinned `--always-approve` launch. Explicit deny
-        // rules and the fixed three-tool profile remain authoritative.
+        // rules and the exact runtime-owned profile remain authoritative.
         continue;
       }
     }

--- a/docs/tests/report-grok-copresence-repo-read-stage2.txt
+++ b/docs/tests/report-grok-copresence-repo-read-stage2.txt
@@ -1,0 +1,130 @@
+# Grok TUI co-presence repo-read stage-2 evidence
+
+Date: 2026-08-13 (Asia/Shanghai)
+
+## Provenance
+
+source_commit=8929fc281022c89eed42975a40480ed4f13045fe
+base_commit=034f00647d42d38d5086d7fc057eb7824a441791
+image_id=sha256:4113ccef12abba0c42117154feab00ea54b121720b4b68e806a5ae3b5eb3a7af
+image_tag=anet-grok-repo-read:8929fc28
+dockerfile=tests/test725-agent-node-unit-ci/Dockerfile
+
+The image was built from `git archive`-equivalent source at the exact source
+commit with `SOURCE_COMMIT` set to that same commit. No live node, global npm
+package, production database, or production configuration was changed.
+
+Pinned Grok TUI under behavioral test:
+
+```
+path=/home/vansin/.grok/bin/grok-0.2.93
+sha256=4e0738d3b5550f3c842bc0ae69f468815c6329c008a110d0c27a694dc3401135
+```
+
+## Intended boundary
+
+The new profile is admitted only for the exact configured tool vector:
+
+```
+["Read", "Grep", "Glob"]
+```
+
+It maps to the process-owned `repo-read` profile and to a generated Grok
+custom strict sandbox. The model-visible tools are exactly:
+
+```
+todo_write search_tool use_tool read_file grep list_dir
+```
+
+There is no shell, file-write, web, media, or subagent tool in this profile.
+Reordered, missing, additional, whitespace-mutated, or otherwise near-match
+configuration vectors fail closed.
+
+The custom strict profile gives the kernel sandbox read access to the project
+and only the runtime dependencies needed to start the pinned Grok binary and
+CommHub MCP. Grok permission rules separately deny model access to protected
+credential paths. `repo-read` is never selected per turn; it is pinned once at
+process startup. Because Grok resume does not change the sandbox, enabling the
+profile requires a new Grok session.
+
+## Docker verification
+
+Exact-source complete agent-node unit domain, non-root, Bun 1.3.14:
+
+```
+1282 pass
+0 fail
+4398 expect() calls
+Ran 1282 tests across 91 files. [116.90s]
+MUTATION_RED readable-attachment-runtime-disconnected rc=1
+RESULT: PASS
+```
+
+Targeted repo-read verification in the same exact-source image:
+
+```
+agent-node targeted: 43 pass / 0 fail / 349 expect
+agent-node build: PASS
+agent-network disclosure: 5 pass / 0 fail / 30 expect
+agent-network tsc --noEmit: PASS
+```
+
+Named witnessed-red mutation on the exact-source image changed only the
+repo-read selector from the strict profile to the workspace profile:
+
+```
+2 pass
+1 fail
+Expected: "anet-strict"
+Received: "anet-workspace"
+MUTATION_RC=1
+```
+
+This proves that the new test is carrying the strict-selection behavior rather
+than merely observing a non-zero mutation exit.
+
+## Real pinned-vendor sandbox observations
+
+All probes used an isolated Debian container with synthetic project, outside,
+and credential markers. No host repository or unrelated host credential store
+was mounted.
+
+1. Headless, without a PTY, pinned Grok 0.2.93 reported `ApplyFailed` and
+   `enforced=false` because `/dev/tty` was absent; an outside read then
+   succeeded. This is a fail-open vendor behavior and is why this feature is
+   restricted to true TUI co-presence with a PTY.
+2. With a PTY and the built-in strict profile, Grok reported `ProfileApplied`
+   and `enforced=true`; the project was readable and an outside sibling read
+   was denied with `FsViolation`. Authentication outside the project was also
+   unavailable, so the process waited for OAuth.
+3. With a custom strict profile granting the runtime read-only access to the
+   synthetic auth directory, plus explicit Grok permission denies for that
+   directory, Grok authenticated, read the project marker, denied the outside
+   sibling, and did not emit the credential marker.
+4. With a production-shaped custom strict profile and a non-empty kernel deny,
+   an ordinary Docker container where bubblewrap could not establish the
+   namespace exited non-zero. It did not silently run unsandboxed.
+5. The same profile in a privileged but otherwise isolated fixture reported
+   `ProfileApplied`, `enforced=true`, read the project marker, denied the
+   outside marker, denied the kernel-protected credential marker, and denied
+   the auth path through Grok's permission rules.
+
+No real credential value was printed or copied into this report. Marker values
+were synthetic.
+
+## Honest limits / rollout gate
+
+- NOT COVERED: production CommHub MCP startup under this strict profile using
+  the live staged binary, canonical Bun path, and live token-bound MCP.
+- NOT COVERED: a live Dashboard-origin task proving repo read plus CommHub
+  reply in the same TUI session.
+- NOT COVERED: independent adversarial review of this source/report pair.
+- NOT COVERED: non-Linux and multi-architecture execution; Linux is the current
+  deployment target.
+- The live `通信狗` node remains on its previously validated `x-search` profile.
+  It was not restarted or upgraded by this work.
+- No rollout is authorized by this report. A pilot requires backup and rollback
+  coordinates, a fresh Grok session, observed `ProfileApplied` with
+  `enforced=true`, exact tool inventory, inside/outside/credential behavioral
+  probes, and a real CommHub round trip before deeper participation.
+


### PR DESCRIPTION
## What changed

- adds an exact `repo-read` Grok TUI co-presence capability profile admitted only by `tools=["Read","Grep","Glob"]`
- maps repo-read to a generated custom strict Grok sandbox while the existing commhub-only and x-search profiles stay on the workspace sandbox
- exposes only `read_file`, `grep`, and `list_dir` in addition to the existing fixed TUI control tools; no shell, write, web, media, or subagent capability
- pins trusted runtime dependencies needed by the strict sandbox and keeps model access to credential paths denied
- adds process-isolation, near-match, disclosure, runtime-home, and sandbox-selection tests
- records exact-source Docker, witnessed-red, and pinned Grok 0.2.93 behavioral evidence

## Why

The live `通信狗` node currently has true Grok TUI + CommHub co-presence but cannot inspect repository source. Granting generic `Read/Grep/Glob` under Grok's workspace sandbox would be unsafe because pinned Grok 0.2.93 documents that profile as read-everywhere. This change makes repository reading a separate, startup-pinned profile backed by the strict kernel sandbox.

## Validation

Source: `8929fc281022c89eed42975a40480ed4f13045fe`

Report-only: `94d89dfa08c386ad9157ecc12eeee62c3e5d94fd`

Image: `sha256:4113ccef12abba0c42117154feab00ea54b121720b4b68e806a5ae3b5eb3a7af`

- exact-source non-root Docker agent-node domain: `1282 pass / 0 fail / 4398 expect / 91 files`
- existing aggregate witnessed-red: PASS
- repo-read strict-selection mutation: `2 pass / 1 fail`, named `Expected: "anet-strict" / Received: "anet-workspace"`
- targeted agent-node: `43 pass / 0 fail / 349 expect`, build PASS
- agent-network disclosure: `5 pass / 0 fail / 30 expect`, typecheck PASS
- real pinned Grok 0.2.93 isolated fixture: PTY custom strict profile applied with `enforced=true`; project read succeeded; outside, kernel-denied credential marker, and auth reads were denied

Full evidence and honest limits: `docs/tests/report-grok-copresence-repo-read-stage2.txt`.

## Rollout status

Draft only. This PR does not authorize merge or deployment. The live `通信狗` node was not restarted or changed and remains on x-search. A live pilot still requires independent adversarial review, backup/rollback coordinates, a fresh Grok session, observed `ProfileApplied enforced=true`, exact tool inventory, behavioral containment probes, and a real CommHub round trip.

## Stack dependency

This draft and the #813 Grok MCP-readiness candidate both modify `agent-node/src/cli.ts` and `grok-build-cli-home.ts`. The current #820 source is **not** a descendant of the #813 WIP source. Do not merge the two independently. #813 must first freeze its real product-path missing-Bun/green-recovery gate; #820 must then be restacked on that exact source and prove that canonical Bun resolution plus the real Grok doctor remain intact. A conflict resolution that keeps the strict repo-read profile but drops the #813 readiness preflight is a regression.
