### PR TITLE
chore(deps): agent-network lockfile 把 hono 推过修复线(4.12.25 → 4.13.1,清 6 条告警)

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -2140,9 +2140,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/docs/tests/report-test745-agent-network-unit-ci.txt
+++ b/docs/tests/report-test745-agent-network-unit-ci.txt
@@ -2,8 +2,50 @@
 
 Date: 2026-08-13 (Asia/Shanghai)
 Issue: https://github.com/sleep2agi/agent-network/issues/745
-Base: 1f4cbf49cf1b03ba3dd9d7ea81c2778b318d0cce
-Source commit: b4e13f45f032dbcf12ffc0b1d0c736571385702b
+Source commit: 507bae6f9045aca6dab07009140e060066cb6936
+
+本文件记录两次跑。上面这个是当前的那次(#842,hono 推过修复线之后);
+建门那次(source b4e13f45 / Base 1f4cbf49)完整保留在文末附录里。
+
+## hono 推过修复线之后的重跑(#842)
+
+审查指出:#842 改了 agent-network/package-lock.json,而 test745 用 npm ci 装
+依赖 —— 也就是说这次改动**改变了这道门实际跑的依赖图**,而这份报告当时仍记着
+b4e13f45 那版镜像。仓里因此没有「新锁的 hono 制品跑绿了」的留存证据。指控成立。
+
+- image: `anet-test745:507bae6f-exact`
+- image id: `sha256:ac8b956ab01a21e1fbc6fd801e99e2ff64e9655508497887f07314e9fa468ba8`
+- 镜像内读回 `TEST745_SOURCE_COMMIT=507bae6f9045aca6dab07009140e060066cb6936`
+- 🔴 **镜像内实际装到的 hono = 4.13.1**(不是从 lockfile 推的,是进容器读
+  `node_modules/hono/package.json`)。这一步是这次改动的**主张本身** ——
+  「lockfile 把 hono 推过了 4.12.34」只有在容器里看到 4.13.1 才算证到。
+  **套件全绿不证明它**:lockfile 改了而构建缓存没失效、或 Dockerfile 没 COPY
+  lockfile,都会给出一模一样的 438 绿。
+
+```text
+source_commit=507bae6f9045aca6dab07009140e060066cb6936
+ 438 pass
+ 0 fail
+ 1333 expect() calls
+Ran 438 tests across 46 files. [4.34s]
+executed_files=46 discovered_files=46
+MUTATION_RED stale-config-help rc=1
+RESULT: PASS
+退出码 0
+```
+
+本次运行日志摘要:`5db43c0ff9299d8cc1983ef700dfc2545b68d28881d6e6462e6f97aa02ffff1e`。它标识这一次运行,不作为来源凭据。
+
+分母承重仍成立:`executed_files=46 discovered_files=46` —— 跑过的文件数等于
+磁盘上的数,没有因为依赖变动而少跑。
+
+> ⚠️ 这份报告的 source commit 指向 `507bae6f`,而提交这份报告本身会产生一个
+> 更新的 commit。二者之间只差这一个文件。
+
+---
+
+## 附录:建门那次(source b4e13f45 / Base 1f4cbf49)
+
 Image: sha256:484e6b482816e36daf0a05385b7d09944786661eba17da973ff2c329fe7ce415
 Image env: TEST745_SOURCE_COMMIT=b4e13f45f032dbcf12ffc0b1d0c736571385702b
 


### PR DESCRIPTION
关 #840。

## 改了什么

`agent-network/package-lock.json` 把 hono 从 **4.12.25 → 4.13.1**。就这一个包。

改动刻意做成最小(`npm update hono --package-lock-only`,不整体刷新 lockfile),实测波及范围:

```
版本变化 = 1   新增 = 0   移除 = 0
  hono  4.12.25 → 4.13.1
agent-network/package-lock.json | 6 +++---   (3 insertions, 3 deletions)
```

308 个包里只有它一个动了。

## 清掉的告警:6 条(不是 3 条)

我开 #840 时只列了 #104/#105/#106。全量枚举后是 6 条,全部挂在这个 manifest 上:

| # | 级别 | 修复于 | 4.13.1 |
|---|---|---|---|
| 106 | medium | 4.12.34 | ✔ |
| 105 | low | 4.12.34 | ✔ |
| 104 | medium | 4.12.34 | ✔ |
| 60 | medium | 4.12.27 | ✔ |
| 59 | medium | 4.12.27 | ✔ |
| 58 | medium | 4.12.27 | ✔ |

漏掉的 #58/#59/#60 创建于 2026-07-24,修复线更低(4.12.27),我第一次只筛了最近那批。已在 issue 里更正。

## 🔴 这不是安全修复,别在 release notes 里写成安全修复

两条理由:

1. **实际暴露面为零。** 这些告警分别需要 `hono/jsx` 的 `memo()` / `cx()` / per-request context、`hono/proxy`、`hono/language`、API Gateway v1 adapter。而仓里 **576 个 tracked `.ts`/`.tsx` 对 `hono` 零引用**(大小写不敏感)—— 它是经 `@modelcontextprotocol/sdk → hono ^4.11.4` 传递进来的,没有任何一行代码用它。
2. **lockfile 不随 npm 包发布。** 消费者 `npm i` 时重新解析,所以这个改动**不改变已发布包的用户拿到的依赖**,只影响本仓与 CI 的构建。

## 验证

`tests/test745-agent-network-unit-ci` —— 它用 `npm ci` 且 COPY lockfile,所以改动会真正生效。

**先证明版本真的换了**(进容器看,不是从 lockfile 推的):

```
installed_hono=4.13.1
```

这一步不能省:套件全绿本身**不证明** hono 被换掉了。

然后是套件本身,`SOURCE_COMMIT` 用的是含本次改动的 SHA:

```
source_commit=507bae6f9045aca6dab07009140e060066cb6936
 438 pass
 0 fail
Ran 438 tests across 46 files. [4.29s]
executed_files=46 discovered_files=46
MUTATION_RED stale-config-help rc=1
RESULT: PASS       退出码 0
```
