### PR TITLE
test(ci): 给 src/ 补绝对下限 —— 两道门都放行「大量删除测试文件」(#817)

### DIFF
--- a/tests/test725-agent-node-unit-ci/run.sh
+++ b/tests/test725-agent-node-unit-ci/run.sh
@@ -13,6 +13,20 @@ echo "source_commit=$SOURCE_COMMIT"
 echo "bun=$(bun --version) node=$(node --version) uid=$(id -u node)"
 command -v crontab >/dev/null || { echo "FAIL: crontab dependency missing" >&2; exit 1; }
 
+# #817:这道门原本连 src 的分母都没有 —— 只有一行 `bun test src/`,
+# 删光测试文件它也不会红。补上分母 + 绝对下限,和 test745 对齐。
+test_files=$(find "$ROOT/agent-node/src" -type f -name '*.test.ts' | wc -l | tr -d ' ')
+[[ "$test_files" =~ ^[1-9][0-9]*$ ]] || {
+  echo "FAIL: agent-node test-file denominator is empty" >&2
+  exit 1
+}
+echo "test_files=$test_files"
+AGENT_NODE_SRC_FLOOR=80
+[[ "$test_files" -ge "$AGENT_NODE_SRC_FLOOR" ]] || {
+  echo "FAIL: only $test_files test file(s) under agent-node/src, floor is $AGENT_NODE_SRC_FLOOR" >&2
+  exit 1
+}
+
 echo "[L0] full agent-node/src unit suite as non-root"
 runuser -u node -- env HOME=/home/node \
   bash -lc 'cd /workspace/agent-node && bun test src/' \
@@ -24,6 +38,15 @@ grep -Eq '^[[:space:]]*[1-9][0-9]* pass$' /tmp/test725-green.log || {
 }
 grep -Eq '^[[:space:]]*0 fail$' /tmp/test725-green.log || {
   echo "FAIL: aggregate suite did not finish with zero failures" >&2
+  exit 1
+}
+
+# 把「磁盘上有几个」和「bun 跑了几个」绑在一起:范围被悄悄收窄(glob 改了、
+# 测试挪进子目录、bun 配置多了个 exclude)时自己变红。
+executed=$(grep -Eo 'across [0-9]+ files' /tmp/test725-green.log | grep -Eo '[0-9]+' | tail -1)
+echo "executed_files=${executed:-unknown} discovered_files=$test_files"
+[[ -n "$executed" && "$executed" -ge "$test_files" ]] || {
+  echo "FAIL: bun executed ${executed:-?} file(s) but $test_files exist under src/" >&2
   exit 1
 }
 

--- a/tests/test745-agent-network-unit-ci/run.sh
+++ b/tests/test745-agent-network-unit-ci/run.sh
@@ -19,6 +19,16 @@ test_files=$(find "$ROOT/agent-network/src" -type f -name '*.test.ts' | wc -l | 
 }
 echo "test_files=$test_files"
 
+# 🔴 绝对下限:上面那条 `[[ "$test_files" =~ ^[1-9][0-9]*$ ]]` 只要求分母非零,
+# 下面 :L0 的 `executed >= test_files` 也只能抓「runner 少跑了文件」—— 两个数
+# 会跟着现实一起缩水。#817 实测:删掉 46 个 src 测试里的 40 个,test_files=6、
+# executed=6,这道门照样 PASS rc=0。所以真删了测试就故意改这个数。
+AGENT_NETWORK_SRC_FLOOR=40
+[[ "$test_files" -ge "$AGENT_NETWORK_SRC_FLOOR" ]] || {
+  echo "FAIL: only $test_files test file(s) under agent-network/src, floor is $AGENT_NETWORK_SRC_FLOOR" >&2
+  exit 1
+}
+
 echo "[L0] full agent-network/src unit suite as non-root"
 runuser -u node -- env HOME=/home/node \
   bash -lc 'cd /workspace/agent-network && bun test src/' \


### PR DESCRIPTION
修 #817。

## 问题

两道聚合单测门都放行「测试文件被大量删除」。#817 的实测:`origin/main` 上删掉
46 个 `agent-network/src/*.test.ts` 里的 40 个,test745 仍然

```
test_files=6  executed_files=6  RESULT: PASS  rc=0
```

原因是分母和执行数**会跟着现实一起缩水**。`executed >= test_files` 能抓的是
「runner 少跑了文件」,抓不到「文件没了」—— 两边同时变成 6,断言照样成立。

test725 更彻底:它连 `src` 的分母都没有,只有一行 `bun test src/`。

## 改动

```
test745  加 AGENT_NETWORK_SRC_FLOOR=40   （磁盘上现有 46 个）
test725  补 src 分母 + AGENT_NODE_SRC_FLOOR=80（现有 91 个）
         并照 test745 的形状补上 executed >= discovered
```

下限是**「大量删除」的绊线,不是精确计数**:留了少量余量给正常增删,
真要删测试就得故意改这个数 —— 目的是让「删测试」这件事必须在 diff 里显形,
而不是悄悄让门的范围缩水。

## 见证红

把插入的块**逐字抽出来**跑(`ROOT` 指向构造的目录树):

```
文件齐 46 / 91         → OK test_files=46 / OK test_files=91
按 #817 删到只剩 6 个   → FAIL: only 6 test file(s) under agent-network/src, floor is 40
                          FAIL: only 6 test file(s) under agent-node/src, floor is 80
```

🔴 **说清楚这次没做什么**:上面跑的是抽出来的 floor 块,**不是在 Docker 里跑完整的门**。
完整门要构建镜像,本机磁盘 93%,我没有在未确认的情况下起构建。
floor 本身是纯 bash 算术 + `find | wc -l`,抽出来跑和在门里跑是同一段代码;
但「完整门在容器里端到端仍然绿」这一格,要 CI 来填。

## 和 #800 的关系

不重叠,别混:

| | `src/` | `tests/` |
|---|---|---|
| #800(已开) | — | `AGENT_NETWORK_TESTS_FLOOR=15` / `AGENT_NODE_TESTS_FLOOR=5` |
| 本 PR | `AGENT_NETWORK_SRC_FLOOR=40` / `AGENT_NODE_SRC_FLOOR=80` + test725 的分母 | — |

#800 的范围写的是「让两个门覆盖 `tests/` 目录」,所以 `src/` 的下限单独开在这里。
两个 PR 都改 `run.sh`,合并时注意先后顺序会有上下文冲突(插入点不同,内容不冲突)。
