### PR TITLE
docs(qa): 2026-W19 周报不是合法 UTF-8(已绊倒两个扫描脚本),修成可读并标出截断处

### DIFF
--- a/docs/qa/weekly/2026-W19.md
+++ b/docs/qa/weekly/2026-W19.md
@@ -1,5 +1,15 @@
 # anet QA 周报 — 2026-05-12 11:45 UTC
 
+> **编者注（2026-08-14）**：本文件自 `be6c3dee`(2026-05-12) 提交时起就不是合法 UTF-8 ——
+> 有三行在写入时被按字节截断,把一个汉字切成了半个。文件只有这一次提交,
+> 历史里没有完好版本,**被截掉的后半句已永久丢失**。
+>
+> 这次只做两件事:把三处坏字节换成显式标记 `〔原文在此处被截断，内容已丢失〕`,
+> 使文件成为合法 UTF-8。**没有猜写任何丢失的内容。**
+>
+> 为什么值得改:它已经绊倒过两个按 UTF-8 读全目录的脚本(见 #857、#772 的记录)——
+> 任何 `Path.read_text()` 走到这里都会抛 UnicodeDecodeError 而中断整次扫描。
+
 _自动生成 by [scripts/qa-status.sh](../../scripts/qa-status.sh)_
 
 ## 测试库当前状态
@@ -34,17 +44,17 @@ _自动生成 by [scripts/qa-status.sh](../../scripts/qa-status.sh)_
 - `qa-hub-06-token-revoke` — [tests/qa-hub-06-token-revoke/](../../tests/qa-hub-06-token-revoke/)
   _派生 token 是否随母 token 失效，是 fleet-management 类工具的核心契约。_
 - `qa-hub-07-sse-reconnect` — [tests/qa-hub-07-sse-reconnect/](../../tests/qa-hub-07-sse-reconnect/)
-  _这个测试 pin 关键契约：「断开期间的任务不能丢」—— 通过 getinbox 拿，�_
+  _这个测试 pin 关键契约：「断开期间的任务不能丢」—— 通过 getinbox 拿，〔原文在此处被截断，内容已丢失〕_
 - `qa-hub-08-restart-persistence` — [tests/qa-hub-08-restart-persistence/](../../tests/qa-hub-08-restart-persistence/)
   _这条测试 pin 三个持久化契约：session 行、inbox/task 行、ntok 验证。_
 - `qa-hub-09-task-state-machine` — [tests/qa-hub-09-task-state-machine/](../../tests/qa-hub-09-task-state-machine/)
   _- `replied` 分支：[NODE-02](../qa-node-02-success-reply/) R6 已测_
 - `qa-node-02-success-reply` — [tests/qa-node-02-success-reply/](../../tests/qa-node-02-success-reply/)
-  _但成功路径（status=replied + result 文本回填）没单独测。真 LLM 烧钱不可取�_
+  _但成功路径（status=replied + result 文本回填）没单独测。真 LLM 烧钱不可取〔原文在此处被截断，内容已丢失〕_
 - `qa-node-03b-task-events` — [tests/qa-node-03b-task-events/](../../tests/qa-node-03b-task-events/)
   _「这个 task 经历了什么、谁动的」。之前完全没人测。_
 - `qa-ut-01-auth-tokens` — [tests/qa-ut-01-auth-tokens/](../../tests/qa-ut-01-auth-tokens/)
-  _[R5 (HUB-06)](../qa-hub-06-token-revoke/) 在 E2E 层覆盖了撤销，但生成/解析的形�_
+  _[R5 (HUB-06)](../qa-hub-06-token-revoke/) 在 E2E 层覆盖了撤销，但生成/解析的形〔原文在此处被截断，内容已丢失〕_
 - `qa-ut-02-password-dict` — [tests/qa-ut-02-password-dict/](../../tests/qa-ut-02-password-dict/)
   _补一层 ms 级单测，PR 改 dict 文件能秒拦截 regression — 不必等慢的 E2E 跑完。_
 - `qa-ut-03-auth-validate` — [tests/qa-ut-03-auth-validate/](../../tests/qa-ut-03-auth-validate/)


### PR DESCRIPTION
## 问题

`docs/qa/weekly/2026-W19.md` **不是合法 UTF-8**,而且从它诞生那天起就不是。

```
$ git log --follow -- docs/qa/weekly/2026-W19.md
be6c3dee 2026-05-12 test(qa): R22 — Plan B (CI badge + CONTRIBUTING) + Plan E (qa-status.sh 周报脚手架)
```

**只有这一次提交,且那一版就已非法** —— 历史里没有完好版本可回。

三处坏字节,签名一致:多字节汉字被从中间切断,残留一个 `_`:

```
pos=2467  e4 b8 5f   …通过 getinbox 拿，⟪坏⟫
pos=3080  ef 5f 0a   …真 LLM 烧钱不可取⟪坏⟫
pos=3453  e7 5f 0a   …但生成/解析的形⟪坏⟫
```

三行分别在第 48 / 56 / 68 个字符处断掉,**后半句没了**。看起来是当初某个按字节
截断的写入过程干的(周报是 `qa-status.sh` 脚手架生成的)。

## 为什么值得改

它已经绊倒过两个按 UTF-8 读全目录的脚本(#857 做文档 pin 盘点时一次,
#772 量 slug 暴露面时又一次)。任何

```python
for p in pathlib.Path("docs").rglob("*.md"):
    p.read_text(encoding="utf-8")     # ← 走到这里抛 UnicodeDecodeError
```

都会在这里中断**整次扫描**,而报错信息是「position 2467 的字节非法」这种
和业务毫无关系的东西 —— 第一次撞上时很难联想到是某份周报坏了。
用 `errors="ignore"` 绕过则会在写回时损坏文件,不是解法。

## 这次做了什么

1. 三处坏字节换成显式标记 `〔原文在此处被截断，内容已丢失〕`;
2. 顶部加一段编者注,说明来龙去脉。

## 🔴 没有做什么

**没有猜写任何丢失的内容。** 三处截断的后半句无从恢复,与其编一个读起来通顺的
句子填上(那会让一份 QA 记录变成半真半假的东西),不如把「这里丢了」如实写出来。

## 验证

```
改后按 UTF-8 读完 docs/ 下全部 168 个 md 文件      无异常
.github/scripts/check-no-memory-slugs.py 全树      scanned 1186 file(s)  OK
```
