### PR TITLE
test(qa-hub): 修四个静默失效 6 周的 e2e 套件 —— 实跑 4/4 从红到绿 (#861)

### DIFF
--- a/tests/qa-hub-10-network-scope-regressions/run.sh
+++ b/tests/qa-hub-10-network-scope-regressions/run.sh
@@ -41,6 +41,21 @@ register_user() {
     -d "{\"username\":\"$username\",\"password\":\"$password\"}"
 }
 
+# #203/#376 之后,report_status 的 alias 必须与 token 绑定的 alias 一致
+# (server.ts:733 从 api_tokens.name='node:<alias>' 推导 callerAlias;
+#  注册时拿到的 network_token 名字不是 node:…，会回落成**用户名**，
+#  于是用它上报任意 alias 一律 alias_identity_mismatch)。
+# 所以每个要上报的 alias 都得先铸一个属于它自己的 node token。
+# 取法与已注册且长期绿的 qa-hub-05-roundtrip 完全一致。
+node_token() {
+  local utok="$1" net="$2" alias="$3" tok
+  tok=$(curl -fsS -X POST "$HUB_BASE/api/auth/node-token" \
+    -H "Authorization: Bearer $utok" -H 'Content-Type: application/json' \
+    -d "{\"network_id\":\"$net\",\"node_name\":\"$alias\"}" | jq -r '.token // empty')
+  [[ "$tok" == ntok_* ]] || { echo "FAIL: node_token($alias) shape wrong: $tok" >&2; exit 1; }
+  printf '%s' "$tok"
+}
+
 wait_for_log() {
   local pattern="$1" file="$2" label="$3"
   for _ in {1..30}; do
@@ -88,16 +103,26 @@ ARG_A=$(jq -nc --arg net "$NET_A" \
   '{resume_id:"00000000-aaaa-bbbb-cccc-000000000010",alias:"shared-agent",status:"idle",network_id:$net}')
 ARG_B=$(jq -nc --arg net "$NET_B" \
   '{resume_id:"00000000-aaaa-bbbb-cccc-000000000011",alias:"shared-agent",status:"idle",network_id:$net}')
-RS_A=$(mcp_call "$NTOK_A" "report_status" "$ARG_A")
-RS_B=$(mcp_call "$NTOK_B" "report_status" "$ARG_B")
+# 同一个 alias 在两个网络里各自独立 —— 这正是本套件要测的语义。
+# #203 之后它仍然成立,只是每个网络里的那个同名节点要各自持有自己的 token。
+NODE_TOK_A=$(node_token "$UTOK_A" "$NET_A" "shared-agent")
+NODE_TOK_B=$(node_token "$UTOK_B" "$NET_B" "shared-agent")
+RS_A=$(mcp_call "$NODE_TOK_A" "report_status" "$ARG_A")
+RS_B=$(mcp_call "$NODE_TOK_B" "report_status" "$ARG_B")
 echo "$RS_A" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status A: $RS_A"; exit 1; }
 echo "$RS_B" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status B: $RS_B"; exit 1; }
 
-echo "[3] utok send_task without network_id returns actionable missing-network message"
+# 🔴 这一步原本断言的是「utok 不带 network_id 发送 → permission_denied: network_id required」。
+# 那个报错本身是 bug,已被 #517 有意去掉 —— 该 issue 的标题就是
+# 「节点发消息报 permission_denied: network_id required,而工具 schema 没有这个入参
+#  (一晚三个节点抄送全部静默失败)」。修法是:单网络的 utok 自动解析出唯一那个网络。
+# 所以断言跟着改成新的正确行为(参照 #804 / test682:产品有意改掉的东西,
+# 该改的是断言而不是把行为改回去)。
+echo "[3] single-network utok send_task auto-resolves the network (#517)"
 NO_NET_ARGS=$(jq -nc '{alias:"shared-agent",task:"missing-network-id",from_session:"alice-dashboard"}')
 NO_NET=$(mcp_call "$UTOK_A" "send_task" "$NO_NET_ARGS")
-echo "$NO_NET" | jq -e '.ok == false and .error == "permission_denied" and (.message | contains("network_id required"))' >/dev/null || {
-  echo "FAIL: expected network_id required error, got: $NO_NET"
+echo "$NO_NET" | jq -e '.ok == true and (.message_id | type == "string")' >/dev/null || {
+  echo "FAIL: single-network utok should auto-resolve and deliver, got: $NO_NET"
   exit 1
 }
 if echo "$NO_NET" | jq -r '.message // ""' | grep -q "Viewer role"; then
@@ -121,8 +146,12 @@ wait_for_log '"type":"connected"' /tmp/sse-b.log "SSE B connected"
 echo "[5] task push in network A must not leak to network B"
 : >/tmp/sse-a.log
 : >/tmp/sse-b.log
+# send 侧有一道与 report_status 对称的检查(tools.ts 注释:fromIdentityMismatchReply,test198):
+# 用 network token 发送时,from_session 必须等于该 token 绑定的 alias。
+# 所以发送方也要有属于自己的 node token —— 这样断言里的 "from":"alpha-sender" 原样成立。
+SENDER_TOK_A=$(node_token "$UTOK_A" "$NET_A" "alpha-sender")
 TASK_A=$(jq -nc '{alias:"shared-agent",task:"alpha-only",from_session:"alpha-sender"}')
-SEND_A=$(mcp_call "$NTOK_A" "send_task" "$TASK_A")
+SEND_A=$(mcp_call "$SENDER_TOK_A" "send_task" "$TASK_A")
 echo "$SEND_A" | jq -e '.ok == true' >/dev/null || { echo "FAIL: send_task A: $SEND_A"; exit 1; }
 wait_for_log '"from":"alpha-sender"' /tmp/sse-a.log "network A task push"
 assert_no_log '"from":"alpha-sender"' /tmp/sse-b.log "network A task push leaked to B"
@@ -130,8 +159,9 @@ assert_no_log '"from":"alpha-sender"' /tmp/sse-b.log "network A task push leaked
 echo "[6] task push in network B must not leak to network A"
 : >/tmp/sse-a.log
 : >/tmp/sse-b.log
+SENDER_TOK_B=$(node_token "$UTOK_B" "$NET_B" "beta-sender")
 TASK_B=$(jq -nc '{alias:"shared-agent",task:"beta-only",from_session:"beta-sender"}')
-SEND_B=$(mcp_call "$NTOK_B" "send_task" "$TASK_B")
+SEND_B=$(mcp_call "$SENDER_TOK_B" "send_task" "$TASK_B")
 echo "$SEND_B" | jq -e '.ok == true' >/dev/null || { echo "FAIL: send_task B: $SEND_B"; exit 1; }
 wait_for_log '"from":"beta-sender"' /tmp/sse-b.log "network B task push"
 assert_no_log '"from":"beta-sender"' /tmp/sse-a.log "network B task push leaked to A"

--- a/tests/qa-hub-11-node-delete-sse/run.sh
+++ b/tests/qa-hub-11-node-delete-sse/run.sh
@@ -41,6 +41,21 @@ register_user() {
     -d "{\"username\":\"$username\",\"password\":\"$password\"}"
 }
 
+# #203/#376 之后,report_status 的 alias 必须与 token 绑定的 alias 一致
+# (server.ts:733 从 api_tokens.name='node:<alias>' 推导 callerAlias;
+#  注册时拿到的 network_token 名字不是 node:…，会回落成**用户名**，
+#  于是用它上报任意 alias 一律 alias_identity_mismatch)。
+# 所以每个要上报的 alias 都得先铸一个属于它自己的 node token。
+# 取法与已注册且长期绿的 qa-hub-05-roundtrip 完全一致。
+node_token() {
+  local utok="$1" net="$2" alias="$3" tok
+  tok=$(curl -fsS -X POST "$HUB_BASE/api/auth/node-token" \
+    -H "Authorization: Bearer $utok" -H 'Content-Type: application/json' \
+    -d "{\"network_id\":\"$net\",\"node_name\":\"$alias\"}" | jq -r '.token // empty')
+  [[ "$tok" == ntok_* ]] || { echo "FAIL: node_token($alias) shape wrong: $tok" >&2; exit 1; }
+  printf '%s' "$tok"
+}
+
 wait_for_log() {
   local pattern="$1" file="$2" label="$3"
   for _ in {1..30}; do
@@ -88,8 +103,12 @@ ARG_A=$(jq -nc --arg net "$NET_A" \
   '{resume_id:"00000000-aaaa-bbbb-cccc-000000000074",alias:"delete-me",status:"idle",network_id:$net,node_id:"node-a-74",node_name:"delete-me",agent:"agent-node:claude-agent",model:"test-model"}')
 ARG_B=$(jq -nc --arg net "$NET_B" \
   '{resume_id:"00000000-aaaa-bbbb-cccc-000000000075",alias:"delete-me",status:"idle",network_id:$net,node_id:"node-b-74",node_name:"delete-me",agent:"agent-node:claude-agent",model:"test-model"}')
-RS_A=$(mcp_call "$NTOK_A" "report_status" "$ARG_A")
-RS_B=$(mcp_call "$NTOK_B" "report_status" "$ARG_B")
+# 同一 alias 在两个网络各产生一条独立 node 行 —— 本套件要测的语义。
+# #203 之后每个网络里的那个同名节点要各自持有自己的 token(见 node_token 注释)。
+NODE_TOK_A=$(node_token "$UTOK_A" "$NET_A" "delete-me")
+NODE_TOK_B=$(node_token "$UTOK_B" "$NET_B" "delete-me")
+RS_A=$(mcp_call "$NODE_TOK_A" "report_status" "$ARG_A")
+RS_B=$(mcp_call "$NODE_TOK_B" "report_status" "$ARG_B")
 echo "$RS_A" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status A: $RS_A"; exit 1; }
 echo "$RS_B" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status B: $RS_B"; exit 1; }
 

--- a/tests/qa-hub-12-servers-endpoint/run.sh
+++ b/tests/qa-hub-12-servers-endpoint/run.sh
@@ -38,6 +38,30 @@ register_user() {
     -d "{\"username\":\"$username\",\"password\":\"$password\"}"
 }
 
+# #203/#376 之后,report_status 的 alias 必须与 token 绑定的 alias 一致
+# (server.ts:733 从 api_tokens.name='node:<alias>' 推导 callerAlias;
+#  注册时拿到的 network_token 名字不是 node:…，会回落成**用户名**，
+#  于是用它上报任意 alias 一律 alias_identity_mismatch)。
+# 所以每个要上报的 alias 都得先铸一个属于它自己的 node token。
+# 取法与已注册且长期绿的 qa-hub-05-roundtrip 完全一致。
+node_token() {
+  local utok="$1" net="$2" alias="$3" tok
+  tok=$(curl -fsS -X POST "$HUB_BASE/api/auth/node-token" \
+    -H "Authorization: Bearer $utok" -H 'Content-Type: application/json' \
+    -d "{\"network_id\":\"$net\",\"node_name\":\"$alias\"}" | jq -r '.token // empty')
+  [[ "$tok" == ntok_* ]] || { echo "FAIL: node_token($alias) shape wrong: $tok" >&2; exit 1; }
+  printf '%s' "$tok"
+}
+
+# 每次 report_status 都以「args 里那个 alias 自己的 node token」发出。
+# 直接从 args 取 alias,循环/多 alias 的调用点不必逐个改,也不会漏。
+report_as() {
+  local utok="$1" net="$2" args="$3" alias tok
+  alias=$(printf '%s' "$args" | jq -r '.alias')
+  tok=$(node_token "$utok" "$net" "$alias")
+  mcp_call "$tok" report_status "$args"
+}
+
 echo "[0] start local hub from repository source"
 safe_rm_rf "$HOME/.commhub" "$HOME/.anet/server"
 cd /app/server
@@ -65,19 +89,19 @@ ARG_A2=$(jq -nc --arg net "$NET_A" '{resume_id:"119-a-2",alias:"agent-a2",status
 ARG_A3=$(jq -nc --arg net "$NET_A" '{resume_id:"119-a-3",alias:"agent-a3",status:"idle",network_id:$net,host:{hostname:"box-b",ip:"10.0.0.11",cpu_load_1min:null,cpu_cores:4,mem_total_gb:16.0,mem_used_gb:2.0,mem_avail_gb:14.0}}')
 ARG_A4=$(jq -nc --arg net "$NET_A" '{resume_id:"119-a-4",alias:"agent-a4",status:"idle",network_id:$net,host:{hostname:"box-a",ip:"127.0.0.1",cpu_load_1min:null,cpu_cores:null,mem_total_gb:null,mem_used_gb:null,mem_avail_gb:null}}')
 for args in "$ARG_A1"; do
-  out=$(mcp_call "$NTOK_A" report_status "$args")
+  out=$(report_as "$UTOK_A" "$NET_A" "$args")
   echo "$out" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status A: $out"; exit 1; }
 done
 # Ensure "latest host metrics" has a deterministic timestamp newer than A1.
 sleep 1.1
 for args in "$ARG_A2" "$ARG_A3" "$ARG_A4"; do
-  out=$(mcp_call "$NTOK_A" report_status "$args")
+  out=$(report_as "$UTOK_A" "$NET_A" "$args")
   echo "$out" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status A: $out"; exit 1; }
 done
 
 echo "[3] report same hostname/ip in network B to verify REST network isolation"
 ARG_B1=$(jq -nc --arg net "$NET_B" '{resume_id:"119-b-1",alias:"agent-b1",status:"idle",network_id:$net,host:{hostname:"box-a",ip:"10.0.0.10",cpu_load_1min:9.9,cpu_cores:64,mem_total_gb:128.0,mem_used_gb:64.0,mem_avail_gb:64.0}}')
-out=$(mcp_call "$NTOK_B" report_status "$ARG_B1")
+out=$(report_as "$UTOK_B" "$NET_B" "$ARG_B1")
 echo "$out" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status B: $out"; exit 1; }
 
 echo "[4] /api/servers aggregates network A only"

--- a/tests/qa-hub-13-server-health-agents/run.sh
+++ b/tests/qa-hub-13-server-health-agents/run.sh
@@ -40,6 +40,30 @@ register_user() {
     -d "{\"username\":\"$username\",\"password\":\"$password\"}"
 }
 
+# #203/#376 之后,report_status 的 alias 必须与 token 绑定的 alias 一致
+# (server.ts:733 从 api_tokens.name='node:<alias>' 推导 callerAlias;
+#  注册时拿到的 network_token 名字不是 node:…，会回落成**用户名**，
+#  于是用它上报任意 alias 一律 alias_identity_mismatch)。
+# 所以每个要上报的 alias 都得先铸一个属于它自己的 node token。
+# 取法与已注册且长期绿的 qa-hub-05-roundtrip 完全一致。
+node_token() {
+  local utok="$1" net="$2" alias="$3" tok
+  tok=$(curl -fsS -X POST "$HUB_BASE/api/auth/node-token" \
+    -H "Authorization: Bearer $utok" -H 'Content-Type: application/json' \
+    -d "{\"network_id\":\"$net\",\"node_name\":\"$alias\"}" | jq -r '.token // empty')
+  [[ "$tok" == ntok_* ]] || { echo "FAIL: node_token($alias) shape wrong: $tok" >&2; exit 1; }
+  printf '%s' "$tok"
+}
+
+# 每次 report_status 都以「args 里那个 alias 自己的 node token」发出。
+# 直接从 args 取 alias,循环/多 alias 的调用点不必逐个改,也不会漏。
+report_as() {
+  local utok="$1" net="$2" args="$3" alias tok
+  alias=$(printf '%s' "$args" | jq -r '.alias')
+  tok=$(node_token "$utok" "$net" "$alias")
+  mcp_call "$tok" report_status "$args"
+}
+
 wait_for_log() {
   local pattern="$1" file="$2" label="$3"
   for _ in {1..30}; do
@@ -87,16 +111,16 @@ ARG_A1=$(jq -nc --arg net "$NET_A" \
   '{resume_id:"140-a-1",alias:"hero-a1",status:"idle",task:"standby",progress:10,agent:"agent-node:claude",model:"intern-s1-pro",network_id:$net,host:{hostname:"hero-box",ip:"10.10.0.5",cpu_load_1min:1.0,cpu_cores:4,mem_total_gb:16,mem_used_gb:15.2,mem_avail_gb:0.8,disk_total_gb:100,disk_used_gb:92,disk_avail_gb:8},process_telemetry:{rss_bytes:123456789,rss_mb:117.7,cpu_pct:12.5,uptime_seconds:100,in_flight_count:0}}')
 ARG_A2=$(jq -nc --arg net "$NET_A" \
   '{resume_id:"140-a-2",alias:"hero-a2",status:"working",task:"compute",progress:66,agent:"agent-node:codex",model:"gpt-5.4",network_id:$net,host:{hostname:"hero-box",ip:"10.10.0.5",cpu_load_1min:3.6,cpu_cores:4,mem_total_gb:16,mem_used_gb:15.6,mem_avail_gb:0.4,disk_total_gb:100,disk_used_gb:99.2,disk_avail_gb:0.8},process_telemetry:{rss_bytes:223456789,rss_mb:213.1,cpu_pct:80.1,uptime_seconds:200,in_flight_count:2}}')
-out=$(mcp_call "$NTOK_A" report_status "$ARG_A1")
+out=$(report_as "$UTOK_A" "$NET_A" "$ARG_A1")
 echo "$out" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status A1: $out"; exit 1; }
 sleep 1.1
-out=$(mcp_call "$NTOK_A" report_status "$ARG_A2")
+out=$(report_as "$UTOK_A" "$NET_A" "$ARG_A2")
 echo "$out" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status A2: $out"; exit 1; }
 
 echo "[3] report same host in network B to guard cross-network scope"
 ARG_B1=$(jq -nc --arg net "$NET_B" \
   '{resume_id:"140-b-1",alias:"hero-b1",status:"idle",network_id:$net,host:{hostname:"hero-box",ip:"10.10.0.5",cpu_load_1min:0.1,cpu_cores:64,mem_total_gb:128,mem_used_gb:8,mem_avail_gb:120,disk_total_gb:1000,disk_used_gb:100,disk_avail_gb:900},process_telemetry:{rss:999,cpu_pct:1,uptime_seconds:9,in_flight_count:0}}')
-out=$(mcp_call "$NTOK_B" report_status "$ARG_B1")
+out=$(report_as "$UTOK_B" "$NET_B" "$ARG_B1")
 echo "$out" | jq -e '.ok == true' >/dev/null || { echo "FAIL: report_status B1: $out"; exit 1; }
 
 echo "[4] /api/server/:host/health exposes latest alert + history for network A only"
@@ -141,7 +165,7 @@ echo "$STATUS_A" | jq -e '.ok == true and (.sessions[] | select(.alias=="hero-a2
 echo "[5b] old clients without process_telemetry surface nulls"
 LEGACY_ARG=$(jq -nc --arg net "$NET_A" \
   '{resume_id:"140-legacy",alias:"legacy-agent",status:"idle",network_id:$net,host:{hostname:"legacy-box",ip:"10.10.0.6",cpu_load_1min:0.1,cpu_cores:2,mem_total_gb:4,mem_used_gb:1,mem_avail_gb:3}}')
-out=$(mcp_call "$NTOK_A" report_status "$LEGACY_ARG")
+out=$(report_as "$UTOK_A" "$NET_A" "$LEGACY_ARG")
 echo "$out" | jq -e '.ok == true' >/dev/null || { echo "FAIL: legacy report_status: $out"; exit 1; }
 LEGACY_AGENTS=$(curl -fsS "$HUB_BASE/api/server/legacy-box/agents?network_id=$NET_A" -H "Authorization: Bearer $UTOK_A")
 echo "$LEGACY_AGENTS" | jq -e '.ok == true and .agents[0].process_telemetry.rss_bytes == null and .agents[0].process_telemetry.cpu_pct == null and .agents[0].process_telemetry.in_flight_count == null' >/dev/null || {
@@ -159,8 +183,11 @@ echo "$SERVERS_A" | jq -e 'type=="array" and length==2 and (.[] | select(.hostna
 }
 
 echo "[7] /api/messages returns promptly after task write"
+# send 侧对称检查(fromIdentityMismatchReply):用 network token 发送时
+# from_session 必须等于该 token 绑定的 alias,所以发送方也要有自己的 node token。
+SENDER_TOK=$(node_token "$UTOK_A" "$NET_A" "dashboard-smoke")
 TASK_A=$(jq -nc '{alias:"hero-a1",task:"message-smoke",from_session:"dashboard-smoke"}')
-SEND_A=$(mcp_call "$NTOK_A" send_task "$TASK_A")
+SEND_A=$(mcp_call "$SENDER_TOK" send_task "$TASK_A")
 echo "$SEND_A" | jq -e '.ok == true' >/dev/null || { echo "FAIL: send_task for messages: $SEND_A"; exit 1; }
 MESSAGES_A=$(curl -fsS --max-time 2 "$HUB_BASE/api/messages?network_id=$NET_A&limit=10" -H "Authorization: Bearer $UTOK_A")
 echo "$MESSAGES_A" | jq -e '.ok == true and (.messages[] | select(.from_alias=="dashboard-smoke" and .to_alias=="hero-a1"))' >/dev/null || {
@@ -180,7 +207,7 @@ wait_for_log '"type":"connected"' /tmp/sse-a.log "SSE A connected"
 wait_for_log '"type":"connected"' /tmp/sse-b.log "SSE B connected"
 STATUS_UPDATE_ARG=$(jq -nc --arg net "$NET_A" \
   '{resume_id:"140-a-1",alias:"hero-a1",status:"idle",progress:11,agent:"agent-node:claude",network_id:$net,host:{hostname:"hero-box",ip:"10.10.0.5",cpu_load_1min:1.1,cpu_cores:4,mem_total_gb:16,mem_used_gb:15.1,mem_avail_gb:0.9,disk_total_gb:100,disk_used_gb:92,disk_avail_gb:8},process_telemetry:{rss_bytes:133456789,rss_mb:127.3,cpu_pct:13.5,uptime_seconds:110,in_flight_count:1}}')
-out=$(mcp_call "$NTOK_A" report_status "$STATUS_UPDATE_ARG")
+out=$(report_as "$UTOK_A" "$NET_A" "$STATUS_UPDATE_ARG")
 echo "$out" | jq -e '.ok == true' >/dev/null || { echo "FAIL: status update report_status: $out"; exit 1; }
 wait_for_log '"type":"status_update"' /tmp/sse-a.log "status update SSE"
 wait_for_log '"process_telemetry"' /tmp/sse-a.log "process telemetry SSE"


### PR DESCRIPTION
修 #861 里实测确认的那四个套件。**四个都从红跑到绿**,证据在下面。

## 背景:它们红了 6 周,而没人知道

#861 里对它们做过实跑:`4/4 退出码 1`,全部死在第 2 步,错误完全相同
(`alias_identity_mismatch`)。原因是产品在它们**最后一次改动之后 4 天**
(`925da933` / #203 / #376,2026-07-02)收紧了 `report_status` 的 token→alias 绑定。

没有任何 workflow 或 `qa.sh` 会跑它们,所以这次硬化没有触发任何信号。

## 三处独立的漂移

| # | 漂移 | 处理 |
|---|---|---|
| ① | `report_status` 要求 alias 等于 token 绑定的 alias(#203/#376) | 加 `node_token()`,为每个 alias 铸自己的 node token |
| ② | send 侧对称检查:`from_session` 也必须匹配 | 发送方同样持有自己的 node token |
| ③ | qa-hub-10 第 3 步**断言的是一个已被 #517 有意修掉的 bug** | **改断言**(唯一被改的一条) |

③ 值得单说:原断言是「utok 不带 `network_id` 发送 → `permission_denied: network_id required`」。
而 #517 的标题就是

> 节点发消息报 `permission_denied: network_id required`,而工具 schema 没有这个入参
> (**一晚三个节点抄送全部静默失败**)

——那个报错本身是 bug,#517 的修法是单网络 utok 自动解析。
所以这里按 #804 / test682 的处理方式**改断言**,而不是把行为改回去。

取 token 的写法不是我发明的,与**已注册且长期绿**的 `qa-hub-05-roundtrip` 完全一致:

```bash
curl -fsS -X POST "$HUB_BASE/api/auth/node-token" \
  -H "Authorization: Bearer $UTOK" \
  -d "{\"network_id\":\"$NET\",\"node_name\":\"$ALIAS\"}"
```

## 🔴 一个我猜错、被实跑纠正的假设

我原本怀疑 qa-hub-13 的端点被改名了(`/api/server/:host/health` vs `/api/server-health/:host`),
依据是 `git grep '/api/server/'` 在 `server.ts` 里 **0 命中**。证据看起来很硬。

**结论是错的。** 修完之后那两步直接过了:

```
[4] /api/server/:host/health exposes latest alert + history for network A only   ✓
[5] /api/server/:host/agents exposes per-agent details and process telemetry     ✓
```

静态比对给出的是「哪里可疑」,不是「实际会怎样」。这条我也写进了 #861。

## 验证

exact `origin/main` 上构建 + 运行,跑完逐个删镜像:

```
qa-hub-10  rc=0  PASS network scope regressions (#67 message ✓ / #54 SSE isolation ✓)   7 步
qa-hub-11  rc=0  PASS node-delete-sse (#74 node_deleted push ✓ / network isolation ✓)   5 步
qa-hub-12  rc=0  PASS servers endpoint (#119 host telemetry aggregation ✓)              5 步
qa-hub-13  rc=0  PASS server health/agents endpoints (#140 Hero 1+2 ✓)                  9 步
```

🔴 **这些断言此前一次都没被执行过** —— 四个套件全部倒在第 2 步。
也就是说:这不是「让红变绿」,是让它们**第一次真正跑起来**。

## 本 PR 不做注册

按 #861 里定的次序:先修好、确认能绿,**再**决定要不要进 `L1_TESTS`
(那会影响 CI 时长,是另一个取舍)。若决定注册,`tests/qa-*/**` 已在 `qa.yml` 的
paths 里,不需要改 paths(见 #860)。

## 覆盖的东西

```
qa-hub-10  同一 alias 跨网络的消息/SSE 隔离（#67 / #54）
qa-hub-11  node_deleted 的网络作用域推送 + 残留行清理（#74）
qa-hub-12  /api/servers 主机聚合与网络作用域（#119）
qa-hub-13  /api/server/:host/health + /agents 的按网络隔离（#140）
```

其中两条是安全相关的作用域隔离 —— 而它们在过去 6 周里没有守住任何东西。
