### PR TITLE
docs(refresh): channel-neutral wording + real npm preview matrix (issue #639)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,11 @@
 ## 项目结构
 
 - `server/src/` — CommHub Server (Bun + SQLite)
-- `agent-network/bin/cli.ts` — anet CLI (39 命令)
-- `agent-node/src/cli.ts` — Agent 运行时 (4 runtime: claude-agent-sdk / claude-code-cli / codex-sdk / grok-build-acp)
+- `agent-network/bin/cli.ts` — anet CLI (完整命令清单以 [`docs-site/docs/guide/cli.md`](./docs-site/docs/guide/cli.md) 为准；数字会漂，不硬编)
+- `agent-node/src/cli.ts` — Agent 运行时
+  - **stable 4 runtime**：`claude-code-cli` / `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`
+  - **`@preview` 额外**：`codex-app-server` / `opencode-cli`
+  - `grok-build-cli` 仍在开发，尚未发布任何通道
 - `tests/testN-xxx/` — 独立 Docker 测试套件 (每个有 Dockerfile + run.sh)
 - `docs/` — 设计文档 + 测试报告
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > **⚠️ 本文件为历史归档（2026-04 之前的 v1.0.0-preview.x 系列开发日志）**
 >
-> 2026-04 后版本号体系重新规划，去掉"v1.0.0-preview"的过度承诺改用 v0.6 / v0.7 / v0.8 / v0.9 / v0.10 渐进发布。**当前 stable 是 v0.10.11（2026-05-28 通过 npm `latest` tag 发布，v0.8.1 是 OSS 首发版本）**。
+> 2026-04 后版本号体系重新规划，去掉"v1.0.0-preview"的过度承诺改用 v0.6 / v0.7 / v0.8 / v0.9 / v0.10 渐进发布。**当前 stable 以 npm `latest` 与 [docs-site/docs/changelog.md](./docs-site/docs/changelog.md) 为准；完整版本矩阵见 [docs/version/README.md](./docs/version/README.md)（本文件归档时对应锚点 v0.10.15）。v0.8.1 是 OSS 首发版本。**
 >
 > **认准的更新日志**：[docs-site/docs/changelog.md](./docs-site/docs/changelog.md) 或 [anet.sh/changelog](https://anet.sh/changelog) — 包含 v0.6.x ~ v0.10.x 全部 release notes，含本次 OSS 发布。
 >

--- a/README.en.md
+++ b/README.en.md
@@ -54,6 +54,7 @@ The default administrator account is `admin` / `anethub`. **Any public deploymen
 - **Connect different agents:** Claude Code, Claude Agent SDK, Codex, and Grok Build can share one network.
 - **Discover and delegate:** agents find teammates through MCP; the Hub delivers tasks over SSE.
 - **Keep control of your data:** the Hub, Dashboard, and SQLite data run on hardware you control.
+- **Preview channel adds more:** `@preview` also exposes **Codex TUI co-presence** and **OpenCode** (`codex-app-server` / `opencode-cli` runtimes) — see the [Runtime page](https://anet.sh/en/guide/runtimes).
 
 ```text
 Agent A  ──task──▶  CommHub  ──SSE──▶  Agent B

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ anet node start my-bot
 - **连接不同 Agent**：Claude Code、Claude Agent SDK、Codex、Grok Build 可加入同一个网络。
 - **自动发现和派活**：Agent 通过 MCP 发现队友，Hub 通过 SSE 实时分发任务。
 - **数据由你掌控**：Hub、Dashboard 和 SQLite 数据运行在你控制的机器上。
+- **预览通道额外能力**：`@preview` 还可用 **Codex TUI 共存** 与 **OpenCode**（`codex-app-server` / `opencode-cli` 两个 runtime），详见 [Runtime 页](https://anet.sh/guide/runtimes)。
 
 ```text
 Agent A  ──任务──▶  CommHub  ──SSE──▶  Agent B

--- a/docs-site/docs/en/guide/architecture.md
+++ b/docs-site/docs/en/guide/architecture.md
@@ -201,7 +201,7 @@ CommHub provides 17 core MCP Tools for agents, in two groups:
 
 ### Database Design
 
-SQLite with WAL mode, 14 tables:
+SQLite with WAL mode, 20+ tables (sessions / tasks / nodes / users / networks / SkillHub / providers / vault etc.; exact count floats with schema version):
 
 ```mermaid
 erDiagram

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -47,8 +47,12 @@ anet hub start
 
 The hub listens on `http://127.0.0.1:9200` by default, the SQLite DB lives at `~/.commhub/commhub.db`, and the default admin account **admin / anethub** is created automatically.
 
+::: warning `@preview` prints a **one-time random password** on first start
+This page describes the npm `latest` channel. On `@preview` (`npm install -g @sleep2agi/agent-network@preview`) the first `anet hub start` **prints a freshly generated random password once** (shown once, not recoverable later); log in with it, then `anet passwd` to your own strong password. **Do NOT hard-code `anethub` for preview** — the fixed password only holds on `latest`.
+:::
+
 ::: warning Change the password before going public
-The default `admin / anethub` is for local quickstart only. **Any `--host 0.0.0.0` public deployment must `anet passwd` to a strong password immediately.**
+The default `admin / anethub` is for local quickstart only (latest channel). **Any `--host 0.0.0.0` public deployment must `anet passwd` to a strong password immediately.** Preview channel has no fixed password — see the note above.
 :::
 
 ::: tip Stop / status

--- a/docs-site/docs/guide/architecture.md
+++ b/docs-site/docs/guide/architecture.md
@@ -10,7 +10,7 @@
 graph TB
     subgraph "服务器（1 台）"
         S["CommHub Server<br/>消息路由 + 任务管理<br/>端口 9200"]
-        DB[(SQLite WAL<br/>14 张表)]
+        DB[(SQLite WAL<br/>20+ 张表)]
         S --- DB
     end
 
@@ -88,7 +88,7 @@ graph TB
         SSE["/events/:alias<br/>SSE 实时推送"]
         REST["/api/*<br/>REST API"]
         AUTH[Auth Module<br/>Token + Rate Limit]
-        DB[(SQLite WAL<br/>14 张表)]
+        DB[(SQLite WAL<br/>20+ 张表)]
     end
 
     subgraph "Agent 节点"
@@ -201,7 +201,7 @@ CommHub 为 agent 提供 17 个核心 MCP Tools，分为两组：
 
 ### 数据库设计
 
-SQLite WAL 模式，14 张表：
+SQLite WAL 模式，20+ 张表（含 sessions / tasks / nodes / users / networks / SkillHub / providers / vault 等，实数按 schema 版本浮动）：
 
 ```mermaid
 erDiagram

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -47,8 +47,12 @@ anet hub start
 
 启动后默认监听 `http://127.0.0.1:9200`, SQLite 数据库在 `~/.commhub/commhub.db`, 自动创建默认管理员 **admin / anethub**。
 
+::: warning `@preview` 首次启动打印**一次性随机密码**
+本文档描述的是 npm `latest` 通道的行为。`@preview` (`npm install -g @sleep2agi/agent-network@preview`) 首次 `anet hub start` 会**打印一次生成的随机密码**（只显示一次，之后无处查回），登录后用 `anet passwd` 改成自己的强密码。**preview 上不要写死 `anethub`**——固定密码只在 `latest` 通道成立。
+:::
+
 ::: warning 公网部署立刻改密
-默认 `admin / anethub` 仅本机用。任何 `--host 0.0.0.0` 公网部署立刻 `anet passwd` 改强密码。
+默认 `admin / anethub` 仅本机用（latest 通道）。任何 `--host 0.0.0.0` 公网部署立刻 `anet passwd` 改强密码。preview 通道无固定密码，见上一条。
 :::
 
 ::: tip 停止 / 查看状态

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,26 +26,30 @@ agent-network/
 └── README.md
 ```
 
+> ⚠️ 上面这棵目录树写于 V2 早期，**已不完整**（例如未列 `dist/bin/cli.cjs`、preview 期新增的 runtime 拆分文件等）。**以仓库当前实际布局为准**（`git ls-tree HEAD -- agent-network/`），本树只作历史背景。
+
 **设计原则**：client.ts 是核心（零外部依赖），server.ts 是薄包装（委托给 `../../server/src/index.ts`），cli.ts 是粘合层。
 
-### 四个 runtime
+### Runtime 列表
 
-Profile 的 `runtime` 字段有四个取值。其中 **`claude-agent-sdk` / `codex-sdk` / `grok-build-acp` 由 `@sleep2agi/agent-node` 驱动**（agent-node 的 `RUNTIME_MAP` 见 `agent-node/src/cli.ts`）；**`claude-code-cli` 不走 agent-node** —— `anet node start` 直接 spawn 本机 `claude` 二进制：
+Profile 的 `runtime` 字段：**stable 4 runtime + preview 额外 2 runtime**。**`claude-agent-sdk` / `codex-sdk` / `grok-build-acp` / `codex-app-server` / `opencode-cli` 由 `@sleep2agi/agent-node` 驱动**（`RUNTIME_MAP` 见 `agent-node/src/cli.ts`）；**`claude-code-cli` 不走 agent-node** —— `anet node start` 直接 spawn 本机 `claude` 二进制。**权威表（stable + preview）以 [anet.sh/guide/runtimes](https://anet.sh/guide/runtimes) 为准**，下面只作背景速览：
 
-| Runtime | 说明 | 模型 |
+| Runtime | 通道 | 说明 |
 |------|------|------|
-| `claude-agent-sdk`（**默认**） | Anthropic Claude Agent SDK + Anthropic 兼容 API | Claude / MiniMax / DeepSeek / GLM / Kimi / 书生 / 小米 MiMo / OpenRouter 等（完整 provider 表见 [anet.sh / multi-model](https://anet.sh/guide/multi-model)） |
-| `codex-sdk` | OpenAI Codex SDK | OpenAI Codex（最新 model id 查官方文档） |
-| `claude-code-cli` | Claude Code CLI（要 Claude Pro 订阅） | Claude（通过本地 CLI 调用） |
-| `grok-build-acp` | xAI Grok Build ACP server（spawn 本机 `grok` 二进制 + ACP 协议） | xAI Grok（grok-build 系列；[详细 runtime 指南 ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md)） |
+| `claude-code-cli` | stable | Claude Code CLI（用本机 Claude Pro/Team/Max 订阅，零配置最稳） |
+| `claude-agent-sdk` | stable | Anthropic Agent SDK + 任意 Anthropic 兼容 endpoint（provider 表见 [anet.sh / multi-model](https://anet.sh/guide/multi-model)） |
+| `codex-sdk` | stable | OpenAI Codex SDK（`codex login`） |
+| `grok-build-acp` | stable | xAI Grok Build ACP server（`grok login`） |
+| `codex-app-server` | preview | Codex app-server 桥接（RFC-030 in-flight） |
+| `opencode-cli` | preview | OpenCode CLI 共存（RFC-029 in-flight） |
 
-Profile 中通过 `runtime` 字段选择。早期文档里的 `claude-code` / `codex` / `agent-sdk` 已重命名（doctor `anet doctor --fix` 自动迁移）。
+早期文档里的 `claude-code` / `codex` / `agent-sdk` 已重命名（`anet doctor --fix` 自动迁移）。
 
 > R268 校准：原本这里另列了一段 4 行「支持的模型列表」(MiniMax M2.7 / 书生 Intern-S1-Pro / Claude / Codex)，跟上方 runtime 表重复且写死了 `M2.7` 这种快速 rotate 的版本号（违反 R175/R245/R253/R257 chain「doc 不 pin model 版本」规则）。删；完整 provider × runtime 列表见上表 + [anet.sh / multi-model](https://anet.sh/guide/multi-model)。
 
 ### 隔离策略
 
-agent-node 调 claude-agent-sdk 的 `query()` 时传 `settingSources: []`，隔离 SDK 防止读取用户全局配置（[`agent-node/src/cli.ts:558-598`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L558)）：
+agent-node 调 claude-agent-sdk 的 `query()` 时传 `settingSources: []`，隔离 SDK 防止读取用户全局配置（[`agent-node/src/cli.ts:558-598`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts)）：
 
 ```typescript
 const options = {
@@ -76,7 +80,7 @@ for await (const message of query({ prompt, options })) { /* ... */ }
 默认值（hub=http://127.0.0.1:9200, runtime=claude-agent-sdk）
 ```
 
-verify [`cli.ts:228 loadProfile`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L228):
+verify [`cli.ts:228 loadProfile`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts):
 ```ts
 const p = join(nodesDir(), id, "config.json");  // .anet/nodes/<id>/config.json
 ```
@@ -121,7 +125,7 @@ const p = join(nodesDir(), id, "config.json");  // .anet/nodes/<id>/config.json
 
 > 上例是 `anet node create 开发马 --runtime claude-agent-sdk --model <id>`（已登录）实际生成的最小集。条件字段：`teammateMode`（仅 `claude-code-cli`）、`session`（仅 `claude-code-cli` 或 `--session`）、`maxTurns`（仅 `--max-turns`）、`tools`（仅 `--tools`）；`logLevel` 是 **top-level** 字段（不在 `flags` 里），且 `createCommand` 不写它（用户可选加）。
 
-verify [`cli.ts:246-273 saveProfile`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L246):
+verify [`cli.ts:246-273 saveProfile`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts):
 ```ts
 const toSave: Record<string, any> = {
   anet_version, node_id, node_name, runtime,
@@ -191,7 +195,7 @@ anet server [--port 9200] [--token xxx] [--db path] [--cors origins]
 
 ### `anet setup`
 
-R511 校准：旧 doc 写「`anet setup --hub --alias --type`，配置新 Agent 加入网络」是 V2 早期签名 —— 当前 `anet setup`（[`cli.ts:556 setupCommand`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L556)）是**交互式 runtime 依赖安装器**，不带参数，也不写网络配置（入网走 `anet node create`）。
+R511 校准：旧 doc 写「`anet setup --hub --alias --type`，配置新 Agent 加入网络」是 V2 早期签名 —— 当前 `anet setup`（[`cli.ts:556 setupCommand`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)）是**交互式 runtime 依赖安装器**，不带参数，也不写网络配置（入网走 `anet node create`）。
 
 ```bash
 anet setup
@@ -207,7 +211,7 @@ anet setup
 
 ### `anet run`
 
-R511 校准：旧 doc 写的 `[--handler script.ts]` flag + 「handler 协议」是 V2 设计草稿，**当前不存在**。当前 `anet run`（[`cli.ts:2044 runCommand`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L2044)）是用 Client SDK 起的**极简 standalone SSE agent**：连 hub、监听 task、自动 echo「收到」回复 —— **不跑 LLM**，区别于 `anet node start`（跑真实 AI runtime）。
+R511 校准：旧 doc 写的 `[--handler script.ts]` flag + 「handler 协议」是 V2 设计草稿，**当前不存在**。当前 `anet run`（[`cli.ts:2044 runCommand`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)）是用 Client SDK 起的**极简 standalone SSE agent**：连 hub、监听 task、自动 echo「收到」回复 —— **不跑 LLM**，区别于 `anet node start`（跑真实 AI runtime）。
 
 ```bash
 anet run --alias <name> [--hub <url>]
@@ -309,11 +313,11 @@ await startServer({
 
 ## 5. Channel 插件自动配置 — R221 校准
 
-`anet node start` 检测到 `runtime: "claude-code-cli"` 时，自动确保 Channel 插件可用（[`cli.ts:1644 ensureMcpJson`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L1644)）：
+`anet node start` 检测到 `runtime: "claude-code-cli"` 时，自动确保 Channel 插件可用（[`cli.ts:1644 ensureMcpJson`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)）：
 
 1. 从 npm 包 (`dist/src/node-server.js` 优先 / `src/node-server.ts` 兜底) 复制到 `{项目}/.anet/node-server.js`（**注意：是 `.js` 不是 `.ts`** —— [R216 chain](https://github.com/sleep2agi/agent-network/issues/10#issuecomment-4438192170)）
 2. 安装依赖（`@modelcontextprotocol/sdk ^1.12.0` 通过 `bun install`）
-3. 写入 `.mcp.json`：`commhub → .anet/node-server.js`（[cli.ts:1724](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L1724)）
+3. 写入 `.mcp.json`：`commhub → .anet/node-server.js`（[cli.ts:1724](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)）
 
 ```
 {项目}/
@@ -323,9 +327,9 @@ await startServer({
     └── package.json         # @modelcontextprotocol/sdk ^1.12.0
 ```
 
-已配置过且内容一致直接跳过（compare-by-content：`if (src !== dst) writeFileSync(...)`，[cli.ts:1679-1680](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L1679)）。`anet init project` 也做同样的事（另外还写 CLAUDE.md）。
+已配置过且内容一致直接跳过（compare-by-content：`if (src !== dst) writeFileSync(...)`，[cli.ts:1679-1680](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)）。`anet init project` 也做同样的事（另外还写 CLAUDE.md）。
 
-R221 校准：原 doc 写「`runtime: "claude-code"`」+「`.anet/node-server.ts`」+「`.mcp.json args:[".anet/node-server.ts"]`」三处都是 V2 早期命名/文件名，当前 runtime name 是 `claude-code-cli`（[RuntimeName type cli.ts:145](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L145)），落盘文件名是 `.js`。
+R221 校准：原 doc 写「`runtime: "claude-code"`」+「`.anet/node-server.ts`」+「`.mcp.json args:[".anet/node-server.ts"]`」三处都是 V2 早期命名/文件名，当前 runtime name 是 `claude-code-cli`（[RuntimeName type cli.ts:145](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)），落盘文件名是 `.js`。
 
 ---
 
@@ -443,9 +447,9 @@ R223 校准：旧 doc 只写 `bun build src/client.ts bin/cli.ts --outdir dist -
 - ⚠️ 旧 `COMMHUB_AUTH_TOKEN` 仅 `/api/*` 读类兼容（v1.0 移除）
 
 ### 配置安全 — R223 校准
-- `~/.anet/server/admin-utok.json` 自动 chmod 600（[`cli.ts:105-111 saveAdminUtok`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L105) `writeFileSync(..., {mode: 0o600})` + `chmodSync(..., 0o600)`，v0.8 bootstrap 写入 admin token）
-- `~/.anet/server/config.json` 自动 chmod 600（[`cli.ts:89-95 saveServerConfig`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L89)）
-- ⚠️ `~/.anet/config.json` **不是 600** —— [`cli.ts:77-81 saveGlobal`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L77) 用默认 `writeFileSync` 无 mode 选项，实际权限通常 `644` (`rw-r--r--`)。在多用户机器上其他本地用户可读你的 utok_。**单用户 host 影响有限，多用户共享 host 建议手动 `chmod 600 ~/.anet/config.json`**（v0.9 RFC 待修）
+- `~/.anet/server/admin-utok.json` 自动 chmod 600（[`cli.ts:105-111 saveAdminUtok`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) `writeFileSync(..., {mode: 0o600})` + `chmodSync(..., 0o600)`，v0.8 bootstrap 写入 admin token）
+- `~/.anet/server/config.json` 自动 chmod 600（[`cli.ts:89-95 saveServerConfig`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)）
+- ⚠️ `~/.anet/config.json` **不是 600** —— [`cli.ts:77-81 saveGlobal`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) 用默认 `writeFileSync` 无 mode 选项，实际权限通常 `644` (`rw-r--r--`)。在多用户机器上其他本地用户可读你的 utok_。**单用户 host 影响有限，多用户共享 host 建议手动 `chmod 600 ~/.anet/config.json`**（v0.9 RFC 待修）
 - 项目 `.anet/nodes/<alias>/config.json` 不应包含 token（放全局配置；R222 chain 说明项目 config 用 hub/token 字段覆盖全局是 advanced use case）
 - `.anet/` 应加入 `.gitignore` 防止提交
 
@@ -517,7 +521,7 @@ R256 校准：旧 doc 用 `send_task(hub, result)` 回复任务结果 —— 这
 
 ## 10. Web Dashboard
 
-> **R220 校准（2026-05-13）**：本节的「内置轻量 UI」+「`http://YOUR_IP:9200/dashboard`」是 V2 早期设计草稿，**v0.8 实际未实现** —— commhub-server `server/src/index.ts` 没有 `/dashboard` 路由（[全 source grep `/dashboard` 0 hit](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）。当前**唯一 Dashboard 是独立的 Next.js 包 `@sleep2agi/agent-network-dashboard`**，通过 `anet hub dashboard` 子命令拉起（[`agent-network/bin/cli.ts:2386`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L2386) `sub === "dashboard"` 分支，默认端口 3000；版本不再 hardcode pin —— [`dashboardReleaseTag()` cli.ts:347](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L347) 默认拉 `@preview` tag，可用 `ANET_DASHBOARD_VERSION` env 覆盖，跟 anet release channel 对齐 — 见 #61）。最新部署方式见 [anet.sh/guide/dashboard](https://anet.sh/guide/dashboard)。下面的「两种 Dashboard」/「内置 UI 设计原则」/「实现方案」/「HTML 结构」全是 V2 设计草稿，仅保留历史背景，**当前不适用**。
+> **R220 校准（2026-05-13）**：本节的「内置轻量 UI」+「`http://YOUR_IP:9200/dashboard`」是 V2 早期设计草稿，**v0.8 实际未实现** —— commhub-server `server/src/index.ts` 没有 `/dashboard` 路由（[全 source grep `/dashboard` 0 hit](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)）。当前**唯一 Dashboard 是独立的 Next.js 包 `@sleep2agi/agent-network-dashboard`**，通过 `anet hub dashboard` 子命令拉起（[`agent-network/bin/cli.ts:2386`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) `sub === "dashboard"` 分支，默认端口 3000；版本不再 hardcode pin —— [`dashboardReleaseTag()` cli.ts:347](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts) 默认拉 `@preview` tag，可用 `ANET_DASHBOARD_VERSION` env 覆盖，跟 anet release channel 对齐 — 见 #61）。最新部署方式见 [anet.sh/guide/dashboard](https://anet.sh/guide/dashboard)。下面的「两种 Dashboard」/「内置 UI 设计原则」/「实现方案」/「HTML 结构」全是 V2 设计草稿，仅保留历史背景，**当前不适用**。
 
 ### 当前 Dashboard
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,6 +87,9 @@ anet node create my-agent --runtime claude-code-cli
 | `claude-code-cli` **⭐ recommended** | Claude Code CLI (reuses your subscription) | `npm i -g @anthropic-ai/claude-code` + `claude auth login` (Claude Pro/Team/Max) — zero config, most stable |
 | `claude-agent-sdk` | Anthropic / MiniMax / DeepSeek / GLM / Kimi / InternLM / Xiaomi MiMo / OpenRouter (any Anthropic-compatible endpoint) | API key in env or via `anet node create` prompts; on `latest`, first `node start` needs `agent-node` installed first ([#450](https://github.com/sleep2agi/agent-network/issues/450)) |
 | `codex-sdk` | Codex | `codex login` |
+| `grok-build-acp` | xAI Grok Build (ACP) | `grok login` |
+
+`@preview` additionally exposes `codex-app-server` and `opencode-cli`. The authoritative full runtime table (stable + preview) is at [anet.sh/guide/runtimes](https://anet.sh/guide/runtimes).
 
 For the full provider endpoint table (each provider's `ANTHROPIC_BASE_URL` etc.), see [docs-site/guide/multi-model](https://anet.sh/guide/multi-model).
 
@@ -131,7 +134,7 @@ anet token revoke x  # Revoke a token
 ## Managing Agents
 
 ```bash
-anet ls              # List all nodes + status
+anet node ls         # List all nodes + status
 anet info my-agent   # Detailed node info
 anet logs my-agent   # View agent logs
 anet node stop my-agent   # Stop agent

--- a/docs/plans/release-plan.md
+++ b/docs/plans/release-plan.md
@@ -2,14 +2,16 @@
 
 > **各版本的迭代范围（冻结的功能清单）** 见 [docs/version/](../version/)：[版本矩阵](../version/README.md) · [v0.11.0](../version/0.11.0/) · [v0.10.16](../version/0.10.16/)。本文只保留通道状态与政策。
 
-> 最后更新：2026-07-16。Owner：release ops。版本号**怎么读**（npm 版号 vs bundle tag 两套体系）见 [versioning](../../docs-site/docs/guide/versioning.md)。
+> 最后更新：2026-08-14（`npm view` 实测）。Owner：release ops。版本号**怎么读**（npm 版号 vs bundle tag 两套体系）见 [versioning](../../docs-site/docs/guide/versioning.md)。
 
 ## 当前已发布状态
 
-| 通道 | @sleep2agi/agent-network | @sleep2agi/agent-node | 说明 |
-|---|---|---|---|
-| **latest**（稳定） | 2.2.21 | 2.4.13 | 4 个 runtime；⚠ 带 Windows 跨盘 `anet --version` 崩溃（#446） |
-| **preview** | **2.3.0-preview.34** | **2.5.0-preview.26** | canonical：全部 Windows 修复 + codex-app-server flag + OpenCode 1.18.1。真 Windows 复验 PASS；Linux 门禁 1-6 已真绿、7 终跑中。⚠️ 审计新发现 stop 孤儿窗 P0（OpenCode 节点 stop 可留 detached ACP 孤儿），修复 draft 在途（evidence pair .35/.27）。**promote 解冻 = 7/7 真绿 + 孤儿窗修复合入并复跑受影响门禁**。另：picker 实为 6-way |
+**这张表是 `npm view <pkg> dist-tags` 的映射**，浮动。改前用 `npm view` 核一遍。
+
+| 通道 | @sleep2agi/agent-network | @sleep2agi/agent-node | @sleep2agi/commhub-server | 说明 |
+|---|---|---|---|---|
+| **latest**（稳定） | 2.2.21 | 2.4.13 | 0.8.8 | 4 个 stable runtime；⚠ 带 Windows 跨盘 `anet --version` 崩溃（#446） |
+| **preview** | **2.3.0-preview.39** | **2.5.0-preview.31** | **0.9.0-preview.29** | 迭代中：Windows 修复 + `codex-app-server` flag + OpenCode `1.18.1`。preview 还额外暴露 `codex-app-server` / `opencode-cli` 两个 runtime。**promote 门禁** = 全 Linux 门禁真绿 + Windows 复验 PASS + 审计发现的 stop 孤儿窗（OpenCode 节点 stop 可留 detached ACP 孤儿）修复合入并复跑受影响门禁。 |
 
 ## 进行中 → 下一个 preview（canonical，`.34` / `.26`）
 

--- a/docs/version/0.11.0/README.md
+++ b/docs/version/0.11.0/README.md
@@ -2,7 +2,7 @@
 
 > 包版本映射：agent-network 2.3.0 / agent-node 2.5.0 / commhub-server 0.9.0 / dashboard 0.7.0（见 [版本矩阵](../README.md)）。
 
-> 状态：进行中（preview 泡验期）。**发布锚点：世界人工智能大会（WAIC，7 月下旬）前完成 promote——v0.11.0 就是 WAIC 发布物**（[WAIC 发布规划](./waic-release.md)）。
+> 状态：进行中（preview 泡验期）。**~~发布锚点：世界人工智能大会（WAIC，7 月下旬）前完成 promote~~**（**过期**：WAIC 7 月下旬窗口已过）——当前 promote 状态见下面的进度快照 + [release-plan](../../plans/release-plan.md)；WAIC 相关背景与决策档案见 [WAIC 发布规划](./waic-release.md)。
 >
 > ## 🎯 本版最大目标：**收敛与可靠，不是新功能**
 >
@@ -16,20 +16,19 @@
 > 下表的"功能"多数是**收敛既有在飞项**（RFC-029/030 早已开工），不是新开口子。真正的新功能一律排下一版。
 > **范围已冻结**：不在下表里的功能一律排 2.4.0+，防失控。新想法 → 开 issue 打 `2.4.0-candidate` 标签，不插队。
 
-## 📍 进度快照（2026-07-16 晚）
+## 📍 进度快照（2026-08-14 · npm view 实测）
 
-**一句话：核心已发布在泡验（preview .34/.26），发布后自审又抓出一批真问题正在修，promote 冻结中——收口期。**
+**一句话：canonical preview 已推进至 .39/.31，`npm view <pkg>@preview` 是当前口径；promote 仍冻结。**
 
 | 线 | 状态 |
 |---|---|
 | 功能盘点（0号工作流） | ✅ 收官：7 旅程全结论（[记分板](./feature-audit.md)）+1 盲区补记（daemon 向导） |
-| canonical 发布 | ✅ `.34`/`.26` 已上 @preview（真 Windows 复验过；latest 未动） |
-| Linux 七套门禁 | 1-6 ✅ 真绿；**7 ❌ 抓出真 P1**（#457 rename 缺 0700）——三处测试期望滞后已全修，最后剩的是真 bug，说明门禁在干活 |
-| 修复批 `.35`/`.27`（进行中，owner: release ops） | 四合一：stop 孤儿窗 P0 + create git-gate + batch fail-closed + rename-0700（#457）；draft PR 后全套重跑门禁 |
+| canonical 发布 | 🔄 `npm view @preview`：agent-network `2.3.0-preview.39` / agent-node `2.5.0-preview.31` / commhub-server `0.9.0-preview.29` |
+| Linux 七套门禁 | 1-6 ✅ 真绿；7 曾抓出 #457 rename 缺 0700，修复批已进 preview 链——门禁在干活 |
+| 修复批（进行中，owner: release ops） | 四合一：stop 孤儿窗 P0 + create git-gate + batch fail-closed + rename-0700（#457）；draft PR 后全套重跑门禁 |
 | dashboard | #15/#36/#37 三绿键 PR 等"合"；P0 痛点批（长消息折叠+密度+底部锚定增量）随后；hub 翻页游标已立案 #459 |
 | promote latest | 🔒 冻结。解冻 = 7/7 真绿（含修复批重跑）+ Windows 复验 |
-| 本日 issue 台账 | #446-#459 共 14 个，全带复现证据；其中 #446 已修已发已验 |
-| WAIC | 锚点不变（[发布规划](./waic-release.md)）；关键路径 = 修复批 → 门禁 → promote |
+| WAIC 锚点 | ⚠️ **过期**（7 月下旬窗口已过）；档案在 [发布规划](./waic-release.md)；关键路径不变 = 修复批 → 门禁 → promote |
 
 ## 0号工作流（本版核心）：现有功能靠谱度盘点 ✅ 走查阶段收官（2026-07-16）
 

--- a/docs/version/README.md
+++ b/docs/version/README.md
@@ -6,11 +6,13 @@
 
 ## 版本矩阵
 
+> preview 一行是 `npm view <pkg>@preview version` 的映射（浮动）；每次改前用 `npm view` 核一遍。最后回填时间：2026-08-14。
+
 | 整体版本 | 状态 | agent-network | agent-node | commhub-server | dashboard | 规划 |
 |---|---|---|---|---|---|---|
 | **v0.10.15** | 当前 stable | 2.2.21 | 2.4.13 | 0.8.8 | 0.6.0 | —（已发布） |
 | **v0.10.16** | 热修·筹备 | 2.2.22（待发） | 2.4.13 | 0.8.8 | 0.6.0 | [plan](./0.10.16/) |
-| **v0.11.0** | 迭代中（**canonical preview .34/.26 已发布**） | 2.3.0-preview.34 | 2.5.0-preview.26 | 0.9.0（现 preview） | 0.7.0（现 0.6.3-preview） | [plan](./0.11.0/) |
+| **v0.11.0** | 迭代中（preview 泡验期） | 2.3.0-preview.39（现 preview） | 2.5.0-preview.31（现 preview） | 0.9.0-preview.29（现 preview） | 0.7.0（现 0.6.3-preview） | [plan](./0.11.0/) |
 
 ## 规则
 

--- a/server/README.md
+++ b/server/README.md
@@ -74,6 +74,8 @@ authoritative. Pinning versions here goes stale on every release and nobody come
 | `list_tasks` | Task list, filterable by `network_id` |
 | `get_completions` | Completion history |
 
+> The table above lists the 17 **collaboration-core** tools. Node lifecycle / provider ops tools ship on the same MCP surface — the authoritative full list is [docs-site/docs/api/mcp-tools.md](../docs-site/docs/api/mcp-tools.md). Don't read the count above as "17 tools total".
+
 ## REST API
 
 The server exposes ~33 endpoints across health, auth, networks, and observability surfaces. The endpoints in use today by the verified flow are:

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sleep2agi/commhub-server",
   "version": "0.9.0-preview.29",
-  "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and 17 MCP tools.",
+  "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
Doc-only refresh from 通信狗 review (issue #639). No behavior changes,
no runtime/config edits — every touched file is markdown or a
`package.json` `description` field.

Author alias: 通信文档马

## Version facts sourced from npm at commit time

Verified via `npm view <pkg> dist-tags` on 2026-08-14:

|         | latest         | preview                         |
|---------|----------------|---------------------------------|
| agent-network   | 2.2.21   | 2.3.0-preview.39                |
| agent-node      | 2.4.13   | 2.5.0-preview.31                |
| commhub-server  | 0.8.8    | 0.9.0-preview.29                |

Local `anet -v` at authoring time: `v2.3.0-preview.38 / 2.4.13 / 0.8.8`.

## Changed (9 items across 15 files, +71 -46)

### P0-1 CHANGELOG.md banner
- Drop hardcoded `当前 stable 是 v0.10.11` (out of date).
- Point readers at npm `latest` + `docs-site/docs/changelog.md` as the
  live source; keep v0.10.15 archival anchor and v0.8.1 OSS-first note.

### P0-2 docs/getting-started.md
- Runtime table gains `grok-build-acp` row (needs `grok login`).
- Note that `@preview` additionally ships `codex-app-server` and
  `opencode-cli`; authoritative full runtime table is
  `anet.sh/guide/runtimes`.
- `anet ls` → `anet node ls` (matches current CLI).

### P0-3 docs-site/docs/{,en/}guide/getting-started.md
- Add a preview-channel warning next to the admin/anethub line:
  `@preview` prints a one-time random password on first
  `anet hub start`; do not hard-code `anethub`. Wording mirrors
  README.

### P0-4 AGENTS.md 项目结构
- Drop `39 命令` / `4 runtime` hardcoded counts (both drift).
- Point at `docs-site/docs/guide/cli.md` as canonical CLI list.
- Split runtimes into stable (4: claude-code-cli / claude-agent-sdk /
  codex-sdk / grok-build-acp) + preview extra (2: codex-app-server /
  opencode-cli); mark `grok-build-cli` as unreleased in any channel.

### P0-5 docs/version + docs/plans/release-plan.md
- `docs/version/README.md`, `docs/plans/release-plan.md`,
  `docs/version/0.11.0/README.md` backfill preview matrix from
  `npm view <pkg>@preview` (was pinned at .34/.26/.20 — now
  .39/.31/.29). Added timestamp + reminder to re-check `npm view`
  before editing.
- WAIC 7-月-下旬 anchor is out of the window; strike-through the
  completed date, keep the archival link to waic-release.md, and
  replace with 'current promote status per release-plan'.
- `release-plan.md` defaults table gains a commhub-server column so
  readers see all three packages, not just two.

### P1-6 docs-site/docs/{,en/}guide/architecture.md
- `14 张表` → `20+ 张表(含 sessions / tasks / nodes / users /
  networks / SkillHub / providers / vault 等，实数按 schema
  版本浮动)`; EN mirrors it. Fixes both mermaid diagrams and prose.

### P1-7 docs/architecture.md
- Runtime paragraph now says 'stable 4 + preview 2' and points at
  `anet.sh/guide/runtimes` as authoritative.
- 14 `cli.ts#L<line>` deep anchors defanged — link kept, line
  number dropped (they rot every release; function name in link
  text preserves intent).
- Directory tree gains an '已不完整，以仓库实际为准' note.

### P1-8 server/package.json + server/README.md
- `server/package.json` `description` now says `MCP tools (17
  collaboration-core + node/provider ops tools; authoritative list
  at docs-site/docs/api/mcp-tools.md)` — was `and 17 MCP tools`
  (readers took it as the total).
- `server/README.md` MCP section gains one line saying the 17 in
  the table are the collaboration-core subset; full list at
  `docs-site/docs/api/mcp-tools.md`.

### P1-9 README.md + README.en.md
- '能做什么' / 'What it does' gain one bullet pointing at
  Codex TUI co-presence and OpenCode as preview-channel additions
  with a link to the Runtime page.

## Not touched (per review scope)

- `docs/v3-postgresql-design.md` archive banner (do not edit)
- upgrade-v2 archive banner (do not edit)
- grok-copresence danger banner (do not edit)
- runtimes 官方表 (canonical, do not edit)

## Verification (grep after commit)

- `14 张表` remaining in `docs-site/docs/guide/architecture.md`: 0
- `39 命令` remaining in `AGENTS.md`: 0
- `cli.ts#L<n>` deep anchors in `docs/architecture.md`: 0
- bare `anet ls` in `docs/getting-started.md`: 0

Closes #639