### PR TITLE
fix(cli): 起/停这几条路不再宣布没量过的成功

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -672,6 +672,16 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
     process.exit(1);
   }
+  // The OpenCode co-presence twin checks its TUI session before calling the
+  // node ready; this path did not, so `③ TUI … ready to attach` and the 就绪
+  // line below were printed on the strength of `new-session` not throwing. A
+  // TUI that exits during startup (bad codex binary, unusable CODEX_HOME) left
+  // both lines saying ready. Keep the two paths aligned.
+  if (!tmuxSessionRunning(tuiSession)) {
+    console.error(`[anet] ❌ TUI tmux session ${tuiSession} exited during startup.`);
+    console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
+    process.exit(1);
+  }
   console.log(`[anet] ③ TUI tmux=${tuiSession} ready to attach`);
 
   // #P3fix复审 finding #5 — best-effort marker-file update with bridge/tui
@@ -688,6 +698,16 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
       tui:    harvestSession(tuiSession),
     });
   } catch { /* best-effort observability update; appsrv-only marker still governs reap */ }
+
+  // 就绪 covers three tmux sessions, so it has to be true of all three at the
+  // moment it is printed — ① proved itself by its listening line, but that was
+  // several seconds and two spawns ago.
+  const dead = [appsrvSession, bridgeSession, tuiSession].filter(s => !tmuxSessionRunning(s));
+  if (dead.length > 0) {
+    console.error(`[anet] ❌ 共存节点 ${displayName} 没起来 — 这些 tmux 会话已经不在了: ${dead.join(", ")}`);
+    console.error(`[anet]    Cleanup: anet node stop ${shellQuote(displayName)}`);
+    process.exit(1);
+  }
 
   const hubBase = opts.hub.replace(/\/+$/, "");
   console.log("");
@@ -5416,6 +5436,19 @@ async function startCommand() {
   const inner = forceNewSession
     ? `anet node start ${shellQuote(alias)} --new-session${innerHub}`
     : `anet node start ${shellQuote(alias)}${innerHub}`;
+
+  // Same refuse-before-spawning check the --accept-dev-channels path does. The
+  // liveness poll below cannot substitute for it: tmux registers the session
+  // before the inner command has finished failing, so an unstartable node
+  // sails through the 2 s window and the session is gone a moment later —
+  // measured as `✅ tmux session "X" started detached` + exit 0 for a runtime
+  // this build does not support.
+  try {
+    resolveStartProfile(resolved.id, resolved.profile);
+  } catch (error: any) {
+    console.error(`[anet] ❌ Refusing to start node ${JSON.stringify(alias)}: ${error?.message || error}`);
+    process.exit(1);
+  }
 
   const headless = !process.stdin.isTTY;
   if (headless) {

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -96,6 +96,7 @@ import {
 import { parseCliOptions, positionalArgs } from "../src/cli-args";
 import { parseTokenCreateName } from "../src/token-cli";
 import { findExactTmuxSession, parseTmuxSessions } from "../src/tmux-attach";
+import { classifyPanePrompt, extractStartFailureReason } from "../src/tmux-pane-prompt";
 import { diagnoseLocale, formatLocaleSource } from "../src/locale-diagnostic";
 import {
   formatSecretAssignment,
@@ -5307,6 +5308,21 @@ async function startCommand() {
     const inner = forceNewSession
       ? `anet node start ${shellQuote(alias)} --new-session${innerHub}`
       : `anet node start ${shellQuote(alias)}${innerHub}`;
+    // Refuse here, in the caller, for anything the inner `anet node start`
+    // would refuse on. Detaching first and discovering it afterwards is how
+    // this path used to lie: tmux happily creates a session, the inner command
+    // exits 1 a moment later, tmux reaps the session, and the reason dies with
+    // the pane. resolveStartProfile is the same check launchAgent runs, so the
+    // message the user gets is the real one, on stderr, with exit 1.
+    try {
+      resolveStartProfile(resolved.id, resolved.profile);
+    } catch (error: any) {
+      console.error(`[anet] ❌ Refusing to start node ${JSON.stringify(alias)}: ${error?.message || error}`);
+      process.exit(1);
+    }
+    // verifyNodeUp reads .anet/nodes/<id>/.pid; a pid left behind by an earlier
+    // run would otherwise be mistaken for this launch's process.
+    rmSync(join(nodesDir(), resolved.id, ".pid"), { force: true });
     try {
       execFileSync(
         "tmux",
@@ -5319,12 +5335,42 @@ async function startCommand() {
     }
     // Concurrently watch the new tmux pane and send Enter when the
     // dev-channels prompt appears. Returns false if the prompt never
-    // shows within the window — that's a non-claude node or a node that
-    // came up past the prompt already; either way we're done.
+    // shows within the window — that's a non-claude node, a node that came up
+    // past the prompt already, or a node that died. Which of those it was is
+    // decided below by looking at the node, not by assuming.
     const dismissed = await dismissDevChannelPrompt(alias, 45_000);
+
+    // Everything above only proves tmux accepted a command. Whether a node is
+    // actually running is a separate fact, and it has to be measured:
+    // `tmux new-session -d` succeeds even when the inner `anet node start`
+    // refuses and exits 1 a moment later, so printing success here on the
+    // strength of the spawn call used to report dead nodes as started. Batch
+    // callers believed it — a 97-node restore on 2026-08-17 reported 64/64 up
+    // when 6 had never started, and the two outputs were byte-identical.
+    const verdict = await verifyNodeUp(resolved.id, 20_000);
+    if (!verdict.ok) {
+      // The pane is the only place the inner command's own words survive, and
+      // only while tmux has not reaped the session yet — so read it first and
+      // fall back to the pid-based verdict when it is already gone.
+      const paneReason = capturePaneReason(alias);
+      console.error(`[anet] ❌ node "${alias}" did not start — ${paneReason || verdict.reason}`);
+      if (paneReason) console.error(`[anet]    (${verdict.reason})`);
+      // Deliberately do NOT kill the session. A node stuck on a prompt is
+      // rescued by one keypress, and a runtime that comes up without writing
+      // .pid would be destroyed here for failing a check it never opted into —
+      // an 89-node fleet is not the place to act on a guess. But say plainly
+      // that the session outlives this failure, because `tmux has-session` is
+      // the criterion batch callers use and it will answer yes for this node.
+      if (tmuxSessionRunning(alias)) {
+        console.error(`[anet]    tmux session "${alias}" is still up — attach and look: tmux attach -t ${shellQuote(alias)}`);
+        console.error(`[anet]    (\`tmux has-session\` will say yes for it; this exit code is the one that means "started")`);
+      }
+      console.error(`[anet]    debug: anet logs ${shellQuote(alias)}  |  anet info ${shellQuote(alias)}`);
+      process.exit(1);
+    }
     console.log(
-      `[anet] ✅ node "${alias}" started detached (tmux session live; ` +
-        `dev-channels prompt ${dismissed ? "auto-confirmed" : "did not appear within 45 s"}).`,
+      `[anet] ✅ node "${alias}" started detached (${verdict.reason}; ` +
+        `dev-channels prompt ${dismissed ? "auto-confirmed" : "did not appear"}).`,
     );
     return;
   }
@@ -7735,18 +7781,42 @@ async function verifySpawnedNodes(spawned: ProjectNode[], failed: { alias: strin
 // send a single Enter to confirm it. Detection-gated — if the prompt never
 // appears (non-claude node, already past it) nothing is ever sent, so a stray
 // Enter can never land on a normal Claude UI. Best-effort.
+//
+// A workspace Claude Code has not seen before shows its folder-trust prompt
+// BEFORE the dev-channels one. This watcher used to know only the dev-channels
+// markers, so it spent its whole window staring at a trust prompt it would not
+// answer; the dev-channels prompt then appeared after the window had already
+// closed and nobody ever confirmed it. The node hung silently and the hub
+// showed it offline — the failure mode looked identical to a node that was
+// merely slow. So: answer the trust prompt too, and restart the clock when we
+// do, because the window is meant to bound how long we wait for ONE prompt,
+// not how long the whole trust-then-channels sequence takes.
 async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
+  let deadline = Date.now() + timeoutMs;
+  let trustAnswered = false;
   while (Date.now() < deadline) {
     let pane = "";
     try {
-      pane = execFileSync("tmux", ["capture-pane", "-p", "-t", sessionName], { encoding: "utf-8" }).toString();
+      // Discard tmux's stderr: polling a session that has already exited is a
+      // normal outcome here, and letting `can't find pane: X` through made the
+      // CLI print an alarming line right before an unrelated verdict.
+      pane = execFileSync("tmux", ["capture-pane", "-p", "-t", sessionName], {
+        encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
+      }).toString();
     } catch {
       return false;  // session gone / tmux error — nothing to confirm
     }
-    // Both markers are unique to this exact prompt — they cannot appear
-    // incidentally in normal Claude Code UI or agent output.
-    if (pane.includes("I am using this for local development") || pane.includes("Loading development channels")) {
+    const prompt = classifyPanePrompt(pane);
+    if (prompt === "folder-trust" && !trustAnswered) {
+      // Settle briefly so Ink's input handler is fully attached, then accept.
+      await new Promise(r => setTimeout(r, 700));
+      try { execFileSync("tmux", ["send-keys", "-t", sessionName, "Enter"], { stdio: "ignore" }); } catch {}
+      trustAnswered = true;
+      deadline = Date.now() + timeoutMs;  // fresh window for the prompt we came for
+      await new Promise(r => setTimeout(r, 1000));
+      continue;
+    }
+    if (prompt === "dev-channels") {
       // Prompt is rendered and waiting. Settle briefly so Ink's input handler
       // is fully attached, then confirm with a single Enter.
       await new Promise(r => setTimeout(r, 700));
@@ -7756,6 +7826,19 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
     await new Promise(r => setTimeout(r, 1000));
   }
   return false;  // prompt never appeared within the window
+}
+
+// Read a dead/live pane and turn it into the reason the start failed. Used only
+// on the failure path, where the pane holds the inner command's own words.
+function capturePaneReason(sessionName: string): string | null {
+  try {
+    const pane = execFileSync("tmux", ["capture-pane", "-p", "-t", sessionName], {
+      encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
+    }).toString();
+    return extractStartFailureReason(pane);
+  } catch {
+    return null;  // session already reaped — caller falls back to a generic reason
+  }
 }
 
 // #176 — concurrently auto-confirm the dev-channels prompt for the just-spawned

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -98,6 +98,7 @@ import { parseTokenCreateName } from "../src/token-cli";
 import { findExactTmuxSession, parseTmuxSessions } from "../src/tmux-attach";
 import { classifyPanePrompt, extractStartFailureReason } from "../src/tmux-pane-prompt";
 import { describeUnsafePath } from "../src/unsafe-package-path-reason";
+import { describeUmaskRisk, judgeUmask, rejectedPayloads } from "../src/package-mode-preflight";
 import { diagnoseLocale, formatLocaleSource } from "../src/locale-diagnostic";
 import {
   formatSecretAssignment,
@@ -13069,6 +13070,39 @@ async function migrateNode(id: string, opts: { hub: string; utok: string; networ
   return { ok: true, changes };
 }
 
+// Read the process umask without leaving it changed: POSIX only exposes it via
+// a set-and-return call, so set it to something arbitrary, keep the old value,
+// and immediately put it back.
+function readProcessUmask(): number {
+  const previous = process.umask(0o022);
+  process.umask(previous);
+  return previous;
+}
+
+// Payloads npm/npx already extracted for @sleep2agi/agent-node. Read-only scan
+// of local caches; doctor must never fetch, so an empty result means "nothing
+// extracted yet", not "safe".
+function findExtractedAgentNodePayloads(): { path: string; uid: number; mode: number }[] {
+  const roots: string[] = [];
+  const npxRoot = join(homedir(), ".npm", "_npx");
+  if (existsSync(npxRoot)) {
+    for (const entry of readdirSync(npxRoot)) {
+      roots.push(join(npxRoot, entry, "node_modules", "@sleep2agi", "agent-node"));
+    }
+  }
+  const out: { path: string; uid: number; mode: number }[] = [];
+  for (const root of roots) {
+    for (const rel of [["dist", "cli.js"], ["package.json"]]) {
+      const path = join(root, ...rel);
+      try {
+        const st = statSync(path);
+        if (st.isFile()) out.push({ path, uid: st.uid, mode: st.mode });
+      } catch { /* not extracted here */ }
+    }
+  }
+  return out;
+}
+
 async function doctorCommand() {
   const fix = args.includes("--fix");
   console.log(`\nanet doctor — System Diagnostic${fix ? " (auto-fix mode)" : ""}\n`);
@@ -13093,6 +13127,29 @@ async function doctorCommand() {
       "System locale",
       `${source} is not UTF-8; Unicode aliases and tmux output may be corrupted. Fix: export LANG=C.UTF-8 LC_ALL=C.UTF-8`,
     );
+  }
+
+  // The grok-build-cli / opencode-cli payload check refuses any resolved
+  // agent-node whose mode has a group- or other-write bit. npm creates files
+  // as `0o666 & ~umask`, so a stock Debian/Ubuntu umask of 0002 guarantees
+  // 0775/0664 and guarantees the refusal — which surfaces to the operator as
+  // "Incompatible grok-build-cli runtime" and says nothing about umask. Say it
+  // here, before anyone spends an evening on it. Local state only: the process
+  // umask plus whatever is already extracted; doctor never fetches.
+  const umaskVerdict = judgeUmask(readProcessUmask());
+  const umaskRisk = describeUmaskRisk(umaskVerdict);
+  if (umaskRisk) warning("Package file modes", umaskRisk);
+  const extracted = findExtractedAgentNodePayloads();
+  const rejected = rejectedPayloads(extracted, process.getuid?.() ?? 0);
+  if (rejected.length > 0) {
+    warning(
+      "Resolved agent-node payload",
+      `${rejected.length} already-extracted file(s) would be rejected right now, e.g. ` +
+      `${rejected[0].path} (mode ${(rejected[0].mode & 0o777).toString(8)}). ` +
+      `Fix: chmod -R g-w,o-w ${dirname(dirname(rejected[0].path))}`,
+    );
+  } else if (extracted.length > 0) {
+    check("Resolved agent-node payload", true, `${extracted.length} file(s) pass the mode check`);
   }
 
   // 2. Hub connectivity

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -99,6 +99,7 @@ import { findExactTmuxSession, parseTmuxSessions } from "../src/tmux-attach";
 import { classifyPanePrompt, extractStartFailureReason } from "../src/tmux-pane-prompt";
 import { describeUnsafePath } from "../src/unsafe-package-path-reason";
 import { describeUmaskRisk, judgeUmask, rejectedPayloads } from "../src/package-mode-preflight";
+import { exactSession } from "../src/tmux-exact-target";
 import { diagnoseLocale, formatLocaleSource } from "../src/locale-diagnostic";
 import {
   formatSecretAssignment,
@@ -142,8 +143,15 @@ function adminUtokPath() { return join(home, ".anet", "server", "admin-utok.json
 function dashboardLaunchRecordPath(port: string | number) { return join(home, ".anet", "server", `dashboard-${port}.json`); }
 function nodesDir() { return join(process.cwd(), ".anet", "nodes"); }
 function shellQuote(value: string): string { return `'${value.replace(/'/g, `'\\''`)}'`; }
-function killTmuxSession(sessionName: string) {
-  try { execFileSync("tmux", ["kill-session", "-t", sessionName], { stdio: "pipe" }); } catch {}
+/** Kill a session and report whether it is actually gone afterwards. */
+function killTmuxSession(sessionName: string): boolean {
+  try { execFileSync("tmux", ["kill-session", "-t", exactSession(sessionName)], { stdio: "pipe" }); } catch {}
+  // Asking is not killing. `kill-session` failing is swallowed on purpose (a
+  // session that is already gone is the common case and not an error), which
+  // means the only way to know is to look afterwards — otherwise `node stop`
+  // prints "tmux(tui) killed" and notifies the hub offline while the session
+  // is still running.
+  return !tmuxSessionRunning(sessionName);
 }
 function startNodeTmuxSession(sessionName: string, alias: string) {
   // #117 helper used by `anet project up/restart` + the debate/social/PR-review
@@ -152,7 +160,7 @@ function startNodeTmuxSession(sessionName: string, alias: string) {
   execFileSync("tmux", ["new-session", "-d", "-s", sessionName, `anet node start ${shellQuote(alias)}`], { stdio: "pipe" });
 }
 function tmuxSessionRunning(name: string): boolean {
-  try { execFileSync("tmux", ["has-session", "-t", name], { stdio: "pipe" }); return true; }
+  try { execFileSync("tmux", ["has-session", "-t", exactSession(name)], { stdio: "pipe" }); return true; }
   catch { return false; }
 }
 // #122 — gate auto-tmux on tmux actually being installed. The CLI never
@@ -204,7 +212,7 @@ function waitForTmuxPaneText(sessionName: string, needle: string, timeoutMs: num
   return new Promise((resolve) => {
     const poll = () => {
       try {
-        const out = execFileSync("tmux", ["capture-pane", "-t", sessionName, "-p"], {
+        const out = execFileSync("tmux", ["capture-pane", "-t", exactSession(sessionName), "-p"], {
           stdio: ["ignore", "pipe", "pipe"], encoding: "utf8",
         });
         if (out.includes(needle)) { resolve(true); return; }
@@ -772,7 +780,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
   if (!existsSync(attachScript)) {
     let tail = "";
     try {
-      tail = execFileSync("tmux", ["capture-pane", "-p", "-t", bridgeSession, "-S", "-80"], {
+      tail = execFileSync("tmux", ["capture-pane", "-p", "-t", exactSession(bridgeSession), "-S", "-80"], {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       }).slice(-3_000);
@@ -7643,9 +7651,24 @@ Stop a running agent node.
   const tmuxTuiKilled = allowLegacyTmuxNameSweep && tmuxSessionRunning(copresenceSessions.tui);
   const tmuxAppsrvKilled = allowLegacyTmuxNameSweep && tmuxSessionRunning(copresenceSessions.appsrv);
   const tmuxBridgeKilled = allowLegacyTmuxNameSweep && tmuxSessionRunning(copresenceSessions.bridge);
-  if (tmuxTuiKilled) killTmuxSession(copresenceSessions.tui);
-  if (tmuxAppsrvKilled) killTmuxSession(copresenceSessions.appsrv);
-  if (tmuxBridgeKilled) killTmuxSession(copresenceSessions.bridge);
+  // The three flags above say a session WAS running, which is the condition for
+  // trying. Whether the kill landed is a second question, and reporting the
+  // first as if it answered the second is how "Stopped X (tmux(tui) killed)"
+  // could print over a session that is still up.
+  const stillUp: string[] = [];
+  for (const [wanted, session] of [
+    [tmuxTuiKilled, copresenceSessions.tui],
+    [tmuxAppsrvKilled, copresenceSessions.appsrv],
+    [tmuxBridgeKilled, copresenceSessions.bridge],
+  ] as Array<[boolean, string]>) {
+    if (wanted && !killTmuxSession(session)) stillUp.push(session);
+  }
+  if (stillUp.length > 0) {
+    console.error(`[anet] ❌ tmux kill-session did not take for: ${stillUp.join(", ")}`);
+    console.error(`[anet]    "${displayName}" is NOT stopped; the hub was not notified offline.`);
+    console.error(`[anet]    Look: tmux attach -t ${shellQuote(`=${stillUp[0]}`)}`);
+    process.exit(1);
+  }
   const tmuxKilled = identityTeardownKilled || tmuxTuiKilled || tmuxAppsrvKilled || tmuxBridgeKilled;
   const stopResult = allowLegacyTmuxNameSweep
     ? await stopNode(resolved.id)
@@ -7845,7 +7868,7 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
       // Discard tmux's stderr: polling a session that has already exited is a
       // normal outcome here, and letting `can't find pane: X` through made the
       // CLI print an alarming line right before an unrelated verdict.
-      pane = execFileSync("tmux", ["capture-pane", "-p", "-t", sessionName], {
+      pane = execFileSync("tmux", ["capture-pane", "-p", "-t", exactSession(sessionName)], {
         encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
       }).toString();
     } catch {
@@ -7855,7 +7878,7 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
     if (prompt === "folder-trust" && !trustAnswered) {
       // Settle briefly so Ink's input handler is fully attached, then accept.
       await new Promise(r => setTimeout(r, 700));
-      try { execFileSync("tmux", ["send-keys", "-t", sessionName, "Enter"], { stdio: "ignore" }); } catch {}
+      try { execFileSync("tmux", ["send-keys", "-t", exactSession(sessionName), "Enter"], { stdio: "ignore" }); } catch {}
       trustAnswered = true;
       deadline = Date.now() + timeoutMs;  // fresh window for the prompt we came for
       await new Promise(r => setTimeout(r, 1000));
@@ -7865,7 +7888,7 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
       // Prompt is rendered and waiting. Settle briefly so Ink's input handler
       // is fully attached, then confirm with a single Enter.
       await new Promise(r => setTimeout(r, 700));
-      try { execFileSync("tmux", ["send-keys", "-t", sessionName, "Enter"], { stdio: "ignore" }); } catch {}
+      try { execFileSync("tmux", ["send-keys", "-t", exactSession(sessionName), "Enter"], { stdio: "ignore" }); } catch {}
       return true;
     }
     await new Promise(r => setTimeout(r, 1000));
@@ -7877,7 +7900,7 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
 // on the failure path, where the pane holds the inner command's own words.
 function capturePaneReason(sessionName: string): string | null {
   try {
-    const pane = execFileSync("tmux", ["capture-pane", "-p", "-t", sessionName], {
+    const pane = execFileSync("tmux", ["capture-pane", "-p", "-t", exactSession(sessionName)], {
       encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
     }).toString();
     return extractStartFailureReason(pane);

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -97,6 +97,7 @@ import { parseCliOptions, positionalArgs } from "../src/cli-args";
 import { parseTokenCreateName } from "../src/token-cli";
 import { findExactTmuxSession, parseTmuxSessions } from "../src/tmux-attach";
 import { classifyPanePrompt, extractStartFailureReason } from "../src/tmux-pane-prompt";
+import { describeUnsafePath } from "../src/unsafe-package-path-reason";
 import { diagnoseLocale, formatLocaleSource } from "../src/locale-diagnostic";
 import {
   formatSecretAssignment,
@@ -2279,7 +2280,17 @@ function resolvePreviewAgentNodeEntrypoint(resolverEnv: NodeJS.ProcessEnv): stri
   for (const path of [entrypoint, packageJsonPath]) {
     const stat = statSync(path);
     if (!stat.isFile() || (uid !== undefined && stat.uid !== uid) || (stat.mode & 0o022) !== 0) {
-      throw new Error("resolved agent-node package has unsafe ownership or mode");
+      // Name the condition that fired. "unsafe ownership or mode" sent every
+      // reader looking at ownership, while on a stock Debian/Ubuntu box
+      // (umask 0002 → npm extracts 0775/0664) it is always the group-write
+      // bit — which is why grok-build-cli was unstartable on this machine
+      // and the error said nothing about umask.
+      throw new Error(
+        stat.isFile()
+          ? `resolved agent-node package has unsafe ownership or mode — ` +
+            describeUnsafePath(path, { uid: stat.uid, mode: stat.mode, processUid: uid ?? stat.uid })
+          : `${path} is not a regular file`,
+      );
     }
   }
   return entrypoint;

--- a/agent-network/src/node-start-accept-dev-channels-wiring.test.ts
+++ b/agent-network/src/node-start-accept-dev-channels-wiring.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const source = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+
+// The `--accept-dev-channels` branch, isolated, so these assertions cannot be
+// satisfied by an unrelated part of a 13k-line file.
+function acceptDevChannelsBranch(): string {
+  const start = source.indexOf("if (wantAcceptDevChannels) {");
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf("// --tmux path:", start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+test("the detached start refuses before spawning when the profile is unstartable", () => {
+  const branch = acceptDevChannelsBranch();
+  // Discovering this after detaching is what lost the reason: tmux reaps the
+  // session and the refusal goes with it.
+  const preflight = branch.indexOf("resolveStartProfile(");
+  const spawn = branch.indexOf('"new-session"');
+  expect(preflight).toBeGreaterThan(-1);
+  expect(spawn).toBeGreaterThan(-1);
+  expect(preflight).toBeLessThan(spawn);
+  expect(branch).toContain("Refusing to start node");
+});
+
+test("success is claimed only after verifyNodeUp, and failure exits non-zero", () => {
+  const branch = acceptDevChannelsBranch();
+  const verify = branch.indexOf("await verifyNodeUp(");
+  const success = branch.indexOf("started detached");
+  expect(verify).toBeGreaterThan(-1);
+  expect(success).toBeGreaterThan(verify);
+  expect(branch).toContain("process.exit(1)");
+});
+
+test("the success line no longer asserts a live tmux session it never checked", () => {
+  // The old text said "(tmux session live; …)" purely on the strength of the
+  // spawn call returning — that sentence was true for dead nodes too.
+  expect(acceptDevChannelsBranch()).not.toContain("tmux session live");
+});
+
+test("a failed start never kills the session, but says the session outlives it", () => {
+  const branch = acceptDevChannelsBranch();
+  // Killing on a failed check would destroy a node that is one keypress from
+  // working, or a runtime that comes up without writing .pid.
+  expect(branch).not.toContain("kill-session");
+  // `tmux has-session` is the criterion batch callers use, so a leftover
+  // session is a trap unless the failure output names it.
+  expect(branch).toContain("tmuxSessionRunning(alias)");
+  expect(branch).toContain("tmux attach -t");
+});
+
+test("pane classification and failure-reason extraction come from the tested module", () => {
+  expect(source).toContain(
+    'import { classifyPanePrompt, extractStartFailureReason } from "../src/tmux-pane-prompt";',
+  );
+  // Inline marker matching is what let the watcher miss the folder-trust
+  // prompt; keep the markers in one tested place.
+  expect(source).not.toContain('pane.includes("Loading development channels")');
+});
+
+test("the prompt watcher answers folder-trust and then waits afresh for dev-channels", () => {
+  const start = source.indexOf("async function dismissDevChannelPrompt(");
+  expect(start).toBeGreaterThan(-1);
+  const fn = source.slice(start, source.indexOf("\n}", start));
+  expect(fn).toContain('prompt === "folder-trust"');
+  // Without a fresh deadline the trust prompt eats the window and the prompt
+  // we actually came for is never answered.
+  expect(fn).toContain("deadline = Date.now() + timeoutMs");
+  expect(fn).not.toContain("const deadline =");
+});

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -16,6 +16,7 @@ import {
 import type { Stats } from "fs";
 import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } from "path";
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
+import { describeUnsafePath } from "./unsafe-package-path-reason";
 
 export const OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.39";
 export const OPENCODE_AGENT_NODE_VERSION = "2.5.0-preview.31";
@@ -53,6 +54,16 @@ function assertSafePackagePath(path: string, kind: "file" | "directory"): Stats 
     // while ACL review is left to the OS/npm install boundary.
     || (process.platform !== "win32" && !opencodeOwnedPathModeIsSafe(stat))
   ) {
+    // Same reasoning as the grok resolver: on a stock Debian/Ubuntu box the
+    // condition that fires is the group-write bit npm inherits from umask
+    // 0002, and a message that leads with "ownership" sends the reader to the
+    // wrong place. Shape/symlink failures keep their own wording.
+    if (kind === "file" && stat.isFile() && !stat.isSymbolicLink() && process.platform !== "win32") {
+      throw new Error(
+        `resolved agent-node package has unsafe ownership or mode — ` +
+        describeUnsafePath(path, { uid: stat.uid, mode: stat.mode, processUid: process.getuid?.() ?? stat.uid }),
+      );
+    }
     throw new Error("resolved agent-node package has unsafe ownership or mode");
   }
   return stat;

--- a/agent-network/src/package-mode-preflight.test.ts
+++ b/agent-network/src/package-mode-preflight.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { describeUmaskRisk, judgeUmask, rejectedPayloads } from "./package-mode-preflight";
+
+// A umask BIT SET means "withhold". Getting this backwards is the whole reason
+// this module exists as a tested function rather than an inline expression.
+test("0002 — the Debian/Ubuntu default this machine runs — leaks group-write", () => {
+  const v = judgeUmask(0o002);
+  expect(v.willProduceUnsafeModes).toBe(true);
+  expect(v.leaks).toEqual(["group"]);
+  expect(v.umaskOctal).toBe("0002");
+});
+
+test("0022 withholds both write bits, so a fresh fetch passes the check", () => {
+  const v = judgeUmask(0o022);
+  expect(v.willProduceUnsafeModes).toBe(false);
+  expect(v.leaks).toEqual([]);
+  expect(describeUmaskRisk(v)).toBeNull();
+});
+
+test("0000 leaks both, and says so", () => {
+  const v = judgeUmask(0o000);
+  expect(v.leaks).toEqual(["group", "other"]);
+  expect(describeUmaskRisk(v)).toContain("group and other-writable");
+});
+
+test("0077 is stricter than needed and still passes", () => {
+  expect(judgeUmask(0o077).willProduceUnsafeModes).toBe(false);
+});
+
+test("the advice names both runtimes and the misleading symptom", () => {
+  const msg = describeUmaskRisk(judgeUmask(0o002))!;
+  expect(msg).toContain("grok-build-cli");
+  expect(msg).toContain("opencode-cli");
+  // The operator sees this string, not the mode check — connecting the two is
+  // the entire point of surfacing it in doctor.
+  expect(msg).toContain("Incompatible runtime");
+  expect(msg).toContain("umask 0022");
+});
+
+const ME = 1000;
+
+test("an already-extracted 0775/0664 payload is reported as rejected", () => {
+  const found = rejectedPayloads([
+    { path: "/n/dist/cli.js", uid: ME, mode: 0o775 },
+    { path: "/n/package.json", uid: ME, mode: 0o664 },
+  ], ME);
+  expect(found).toHaveLength(2);
+});
+
+test("a correctly-extracted payload is not reported", () => {
+  expect(rejectedPayloads([
+    { path: "/n/dist/cli.js", uid: ME, mode: 0o755 },
+    { path: "/n/package.json", uid: ME, mode: 0o644 },
+  ], ME)).toHaveLength(0);
+});
+
+test("someone else's payload is rejected even at a safe mode", () => {
+  expect(rejectedPayloads([{ path: "/n/dist/cli.js", uid: 0, mode: 0o755 }], ME)).toHaveLength(1);
+});
+
+test("nothing extracted yet reports nothing — absence is not a pass", () => {
+  expect(rejectedPayloads([], ME)).toHaveLength(0);
+});

--- a/agent-network/src/package-mode-preflight.ts
+++ b/agent-network/src/package-mode-preflight.ts
@@ -1,0 +1,66 @@
+// Preflight for the condition that made grok-build-cli and opencode-cli
+// unstartable on this machine without ever naming itself.
+//
+// Both runtimes resolve their agent-node payload through npm/npx and then
+// refuse to execute it unless `(mode & 0o022) === 0`. npm creates files with
+// `0o666 & ~umask` (and 0o777 & ~umask for executables), so on a stock
+// Debian/Ubuntu box — where umask is 0002 because every user gets a private
+// group — every fetch lands at 0775/0664 and every start dies. The check is
+// correct; what was missing is anyone telling the operator BEFORE they hit it.
+//
+// So `anet doctor` can answer it from local state alone: no network, no npx
+// run, just the process umask and whatever payload is already extracted.
+
+export interface UmaskVerdict {
+  /** Will a freshly npm-extracted payload fail the (mode & 0o022) === 0 check? */
+  willProduceUnsafeModes: boolean;
+  /** Octal umask string as an operator would type it. */
+  umaskOctal: string;
+  /** Which write bits this umask fails to mask off. */
+  leaks: Array<"group" | "other">;
+}
+
+/**
+ * Read a umask value the way the package check will experience it.
+ *
+ * A umask bit SET means "withhold this permission". So group-write is withheld
+ * only when 0o020 is set in the umask; umask 0002 withholds other-write and
+ * nothing else, which is exactly the failing case.
+ */
+export function judgeUmask(umask: number): UmaskVerdict {
+  const leaks: Array<"group" | "other"> = [];
+  if ((umask & 0o020) === 0) leaks.push("group");
+  if ((umask & 0o002) === 0) leaks.push("other");
+  return {
+    willProduceUnsafeModes: leaks.length > 0,
+    umaskOctal: "0" + (umask & 0o777).toString(8).padStart(3, "0"),
+    leaks,
+  };
+}
+
+/** One line for `anet doctor`, or null when there is nothing to say. */
+export function describeUmaskRisk(verdict: UmaskVerdict): string | null {
+  if (!verdict.willProduceUnsafeModes) return null;
+  const who = verdict.leaks.join(" and ");
+  return `umask is ${verdict.umaskOctal}, so npm extracts packages ${who}-writable. ` +
+    `grok-build-cli and opencode-cli refuse to execute a payload in that state, and the ` +
+    `refusal reads as an "Incompatible runtime" error. Start those runtimes under ` +
+    `\`umask 0022\`, or run \`chmod -R g-w,o-w\` on the resolved package root.`;
+}
+
+export interface ExtractedPayload {
+  path: string;
+  uid: number;
+  mode: number;
+}
+
+/**
+ * Which already-extracted payloads would be rejected right now.
+ *
+ * Reports facts about copies that exist on disk; it never fetches. An empty
+ * result means "nothing extracted yet", which is not the same as "safe" — the
+ * umask verdict is what speaks to the next fetch.
+ */
+export function rejectedPayloads(payloads: ExtractedPayload[], processUid: number): ExtractedPayload[] {
+  return payloads.filter(p => p.uid !== processUid || (p.mode & 0o022) !== 0);
+}

--- a/agent-network/src/start-paths-verify-before-claiming.test.ts
+++ b/agent-network/src/start-paths-verify-before-claiming.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const source = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+
+function slice(from: string, to: string): string {
+  const a = source.indexOf(from);
+  expect(a).toBeGreaterThan(-1);
+  const b = source.indexOf(to, a);
+  expect(b).toBeGreaterThan(a);
+  return source.slice(a, b);
+}
+
+// `anet node start <alias> --tmux`, headless branch. Its bounded has-session
+// poll cannot catch an unstartable config: tmux registers the session before
+// the inner command finishes failing, so the poll saw a session that was gone
+// seconds later. Measured on 2026-08-17 with an unsupported runtime —
+// `✅ tmux session "e2e-bogus" started detached` and exit 0.
+test("--tmux refuses an unstartable profile instead of spawning and polling", () => {
+  // Scope matters here: the --accept-dev-channels branch has its own preflight
+  // a few hundred lines above, and a check anchored loosely enough to find that
+  // one passes whether or not this path was ever fixed. Slice the --tmux path
+  // itself — from where it resolves the alias to where it goes headless.
+  const tmuxPath = slice("// --tmux path: resolve alias", "const headless = !process.stdin.isTTY;");
+  expect(tmuxPath).toContain("resolveStartProfile(resolved.id, resolved.profile);");
+  expect(tmuxPath).toContain("Refusing to start node");
+  // And the spawn must still be downstream of it.
+  const headlessBranch = slice("const headless = !process.stdin.isTTY;", "// TTY-present path:");
+  expect(headlessBranch).toContain('✅ tmux session');
+  expect(headlessBranch).not.toContain("resolveStartProfile(");
+});
+
+// The codex co-presence launcher spawns three tmux sessions and then declares
+// the node 就绪. Only ① proved itself (it waits for the app-server's listening
+// line); ② and ③ were assumed. Its OpenCode twin already checked its TUI
+// session before the same claim — the two paths should not disagree about
+// whether "ready" is measured.
+test("codex co-presence checks its TUI session before calling it ready to attach", () => {
+  const block = slice("// ── piece ③ codex TUI", "[anet] ③ TUI tmux=");
+  expect(block).toContain("tmuxSessionRunning(tuiSession)");
+});
+
+test("codex co-presence proves all three sessions are alive at the moment it prints 就绪", () => {
+  const block = slice("// ── piece ③ codex TUI", "✅ 共存节点");
+  expect(block).toContain("[appsrvSession, bridgeSession, tuiSession]");
+  expect(block).toContain("tmuxSessionRunning(s)");
+  expect(block).toContain("process.exit(1)");
+});
+
+test("the OpenCode twin still guards its own TUI (the pattern being matched)", () => {
+  const block = slice("✅ OpenCode 共存节点", "attach:");
+  expect(source).toContain("if (!tmuxSessionRunning(tuiSession)) {");
+  expect(block.length).toBeGreaterThan(0);
+});

--- a/agent-network/src/tmux-exact-target.test.ts
+++ b/agent-network/src/tmux-exact-target.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { execFileSync } from "child_process";
+import { ensureExactSession, exactSession, isExactTarget } from "./tmux-exact-target";
+
+test("a session name becomes an exact target", () => {
+  expect(exactSession("A站内容")).toBe("=A站内容");
+});
+
+test("an already-exact target is not double-prefixed", () => {
+  expect(isExactTarget("=A站内容")).toBe(true);
+  expect(ensureExactSession("=A站内容")).toBe("=A站内容");
+  expect(ensureExactSession("A站内容")).toBe("=A站内容");
+});
+
+test("no shell quoting is added — these go to tmux as argv, not through a shell", () => {
+  expect(exactSession("name with spaces")).toBe("=name with spaces");
+  expect(exactSession("it's")).toBe("=it's");
+});
+
+// The reason the helper exists, proven against the real tmux on this machine
+// rather than asserted. Skipped where tmux is unavailable (CI containers).
+function tmuxAvailable(): boolean {
+  try { execFileSync("tmux", ["-V"], { stdio: "pipe" }); return true; } catch { return false; }
+}
+
+const PREFIX = "anet-exacttest";
+const SIBLING = `${PREFIX}-sibling`;
+
+function killQuiet(target: string) {
+  try { execFileSync("tmux", ["kill-session", "-t", target], { stdio: "pipe" }); } catch { /* already gone */ }
+}
+
+test.skipIf(!tmuxAvailable())("bare -t prefix-matches a sibling; =name does not", () => {
+  killQuiet(exactSession(SIBLING));
+  killQuiet(exactSession(PREFIX));
+  execFileSync("tmux", ["new-session", "-d", "-s", SIBLING, "sleep 60"], { stdio: "pipe" });
+  try {
+    // Only the sibling exists. The bare name must not be treated as "found".
+    let bareSaysRunning = false;
+    try { execFileSync("tmux", ["has-session", "-t", PREFIX], { stdio: "pipe" }); bareSaysRunning = true; } catch {}
+    expect(bareSaysRunning).toBe(true);   // this is the bug being guarded against
+
+    let exactSaysRunning = false;
+    try { execFileSync("tmux", ["has-session", "-t", exactSession(PREFIX)], { stdio: "pipe" }); exactSaysRunning = true; } catch {}
+    expect(exactSaysRunning).toBe(false); // the fix
+
+    // And the exact target must not reap the sibling.
+    killQuiet(exactSession(PREFIX));
+    let siblingAlive = false;
+    try { execFileSync("tmux", ["has-session", "-t", exactSession(SIBLING)], { stdio: "pipe" }); siblingAlive = true; } catch {}
+    expect(siblingAlive).toBe(true);
+  } finally {
+    killQuiet(exactSession(SIBLING));
+  }
+});

--- a/agent-network/src/tmux-exact-target.ts
+++ b/agent-network/src/tmux-exact-target.ts
@@ -1,0 +1,47 @@
+// tmux `-t` resolves a session name by PREFIX unless the name is written
+// `=name`. Every human-facing string in this CLI already spells the exact form
+// (`tmux attach -t '=<alias>'`, with a comment explaining why) — but every tmux
+// command the CLI actually ran passed the bare name.
+//
+// Measured on this machine 2026-08-17, with only `zz-honest-probe-extra` alive:
+//
+//   tmux has-session -t zz-honest-probe    → success   (wrong: it is not running)
+//   tmux has-session -t =zz-honest-probe   → failure   (right)
+//   tmux kill-session -t zz-honest-probe   → killed zz-honest-probe-extra
+//
+// The live fleet has four such pairs — A站内容/A站内容牛, A站数据/A站数据牛,
+// P站测试/P站测试牛, P站运维/P站运维牛 — so this is not hypothetical here:
+//
+//   * `has-session` false-positives, so `node start` reports "already running —
+//     skipping spawn" for a node that is down, and never starts it.
+//   * `kill-session` reaps the sibling, and `node stop` reports success.
+//   * `send-keys` would deliver an Enter into the sibling's Claude UI.
+//
+// One helper, used at every call site, so the rule lives in the code that acts
+// rather than only in the strings that describe it.
+
+/**
+ * Exact-match tmux target for a session name.
+ *
+ * tmux treats a leading `=` as "this exact name, no prefix matching". Names are
+ * passed to tmux as argv entries, never through a shell, so no quoting belongs
+ * here — callers that build a copy-pasteable command for a human should shell-
+ * quote the result themselves.
+ */
+export function exactSession(name: string): string {
+  return `=${name}`;
+}
+
+/**
+ * True when this target is already pinned to an exact session.
+ *
+ * Applying the prefix twice would look for a session literally named `=x`.
+ */
+export function isExactTarget(target: string): boolean {
+  return target.startsWith("=");
+}
+
+/** Idempotent form, for call sites that may receive either shape. */
+export function ensureExactSession(nameOrTarget: string): string {
+  return isExactTarget(nameOrTarget) ? nameOrTarget : exactSession(nameOrTarget);
+}

--- a/agent-network/src/tmux-pane-prompt.test.ts
+++ b/agent-network/src/tmux-pane-prompt.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test";
+import { classifyPanePrompt, extractStartFailureReason } from "./tmux-pane-prompt";
+
+// Captured from a real `tmux capture-pane -p` while Claude Code 2.1.147 was
+// waiting on the folder-trust prompt in a workspace it had not seen before —
+// the exact state that stalled TM智空负责人 on 2026-08-17.
+const FOLDER_TRUST_PANE = `
+╭──────────────────────────────────────────────╮
+│ Do you trust the files in this folder?       │
+│                                              │
+│ /home/vansin/ai-insight                      │
+│                                              │
+│ ❯ 1. Yes, I trust this folder                │
+│   2. No, exit                                │
+╰──────────────────────────────────────────────╯
+`;
+
+const DEV_CHANNELS_PANE = `
+ WARNING: Loading development channels from server:commhub
+ I am using this for local development and I trust its author
+
+ Press Enter to confirm
+`;
+
+const NORMAL_CLAUDE_PANE = `
+← commhub · 通信龙: [重启后探针] 请只回一行
+● Calling commhub… (ctrl+o to expand)
+❯
+  ⏵⏵ bypass permissions on (shift+tab to cycle)
+`;
+
+test("folder-trust prompt is recognised as its own prompt, not as dev-channels", () => {
+  expect(classifyPanePrompt(FOLDER_TRUST_PANE)).toBe("folder-trust");
+});
+
+test("dev-channels prompt is still recognised", () => {
+  expect(classifyPanePrompt(DEV_CHANNELS_PANE)).toBe("dev-channels");
+});
+
+test("a normal Claude Code pane matches no prompt, so no Enter is ever sent", () => {
+  expect(classifyPanePrompt(NORMAL_CLAUDE_PANE)).toBeNull();
+});
+
+test("an empty / still-booting pane matches no prompt", () => {
+  expect(classifyPanePrompt("")).toBeNull();
+  expect(classifyPanePrompt("\n\n  \n")).toBeNull();
+});
+
+// The prompts are sequential, so a capture holding both means trust is already
+// answered and its text is merely still on screen. Reporting "folder-trust"
+// there would make a watcher that already answered trust sit out the rest of
+// its window and never confirm dev-channels — the original hang, reintroduced.
+test("when both prompts are in one capture the later one wins, not the leftover", () => {
+  expect(classifyPanePrompt(FOLDER_TRUST_PANE + DEV_CHANNELS_PANE)).toBe("dev-channels");
+});
+
+// The refusal that actually happened: 5 grok co-presence nodes on a published
+// anet whose whitelist has no grok-build-cli.
+const REFUSAL_PANE = `
+[anet] Refusing to start node "指挥狗": unsupported runtime "grok-build-cli"; expected one of: claude-agent-sdk, claude-code-cli, codex-sdk, codex-app-server, grok-build-acp, opencode-cli
+`;
+
+test("the refusal line is pulled out of a dead pane, with the [anet] prefix stripped", () => {
+  const reason = extractStartFailureReason(REFUSAL_PANE);
+  expect(reason).toContain('unsupported runtime "grok-build-cli"');
+  expect(reason).toContain("Refusing to start node");
+  expect(reason?.startsWith("[anet]")).toBe(false);
+});
+
+// The noise below the refusal is the part that matters: tmux keeps printing
+// after the inner command dies, so "just take the last line" would report a
+// shell prompt or an npm notice as the reason the node failed.
+test("the refusal is picked over unrelated scrollback both above and below it", () => {
+  const pane = [
+    "warning: something noisy happened earlier",
+    "npm notice a new version is available",
+    REFUSAL_PANE.trim(),
+    "",
+    "npm notice Run npm install -g npm@11.0.0 to update",
+    "vansin@toodadev3:~$ ",
+  ].join("\n");
+  expect(extractStartFailureReason(pane)).toContain("unsupported runtime");
+});
+
+test("an ❌ line is reported without its prefix decorations", () => {
+  const reason = extractStartFailureReason(`[anet] ❌ --accept-dev-channels requires tmux (used for PTY).`);
+  expect(reason).toBe("--accept-dev-channels requires tmux (used for PTY).");
+});
+
+test("a crash with no anet refusal falls back to the last non-empty line", () => {
+  const pane = "booting…\nnode:internal/modules: Cannot find module '@inquirer/prompts'\n\n";
+  expect(extractStartFailureReason(pane)).toBe(
+    "node:internal/modules: Cannot find module '@inquirer/prompts'",
+  );
+});
+
+test("an empty pane yields no reason, so the caller cannot print an invented one", () => {
+  expect(extractStartFailureReason("")).toBeNull();
+  expect(extractStartFailureReason("   \n\n ")).toBeNull();
+});

--- a/agent-network/src/tmux-pane-prompt.ts
+++ b/agent-network/src/tmux-pane-prompt.ts
@@ -1,0 +1,81 @@
+// Pane-content classification for the detached-tmux start path.
+//
+// Two independent problems put this logic here instead of inline in cli.ts:
+//
+//  1. `anet node start <alias> --accept-dev-channels` watches the pane for
+//     Claude Code's dev-channels prompt and confirms it. But a workspace that
+//     has never been trusted shows the folder-trust prompt FIRST. The watcher
+//     only knew the dev-channels markers, so it spun until its window expired
+//     while a different prompt sat on screen — the node then hung forever and
+//     the hub showed it offline. Measured 2026-08-17 restoring 97 nodes:
+//     TM智空负责人 died exactly this way and needed two manual Enters.
+//
+//  2. When the inner `anet node start` refuses (unsupported runtime, bad
+//     config) the pane holds the only copy of the real reason, and tmux tears
+//     the session down moments later. Reading that reason out of the pane is
+//     what lets the caller report the refusal instead of a timeout.
+//
+// Pure string in / verdict out, so both are testable without tmux.
+
+/** A prompt the watcher knows how to answer, or null. */
+export type PanePrompt = "dev-channels" | "folder-trust";
+
+// Markers are chosen to be unique to their prompt: none of them can appear
+// incidentally in normal Claude Code UI chrome or in agent output, so a
+// detection can never send a stray Enter into a live session.
+const DEV_CHANNEL_MARKERS = [
+  "I am using this for local development",
+  "Loading development channels",
+];
+
+const FOLDER_TRUST_MARKERS = [
+  "Yes, I trust this folder",
+  "Do you trust the files in this folder?",
+];
+
+/**
+ * Which known prompt (if any) the pane is currently blocking on.
+ *
+ * Dev-channels is checked FIRST, even though it appears second in time. The two
+ * prompts are sequential — trust, then channels — so a capture showing both
+ * means the trust prompt is already answered and only its text is still sitting
+ * in the pane. Classifying that as "folder-trust" would make a watcher that has
+ * already answered trust ignore the prompt it was waiting for, and the node
+ * would hang exactly as if the fix had never been made. Preferring the later
+ * prompt keeps a stale line of scrollback from outranking the live prompt.
+ */
+export function classifyPanePrompt(pane: string): PanePrompt | null {
+  if (DEV_CHANNEL_MARKERS.some(m => pane.includes(m))) return "dev-channels";
+  if (FOLDER_TRUST_MARKERS.some(m => pane.includes(m))) return "folder-trust";
+  return null;
+}
+
+// Lines the inner `anet node start` prints when it declines to start. Matching
+// on the message anet itself emits (rather than on "some line containing
+// error") keeps an unrelated warning in the scrollback from being reported as
+// the cause of death.
+const REFUSAL_PATTERNS = [
+  /^\[anet\] Refusing to start.*$/m,
+  /^\[anet\] ❌.*$/m,
+  /^Node "[^"]*" not found\..*$/m,
+  /^Error: .*$/m,
+];
+
+/**
+ * Best-effort one-line explanation of why a detached start died, taken from the
+ * dead pane's own output.
+ *
+ * Returns null when the pane holds nothing that looks like a refusal — the
+ * caller must then fall back to a generic message rather than inventing one.
+ */
+export function extractStartFailureReason(pane: string): string | null {
+  for (const re of REFUSAL_PATTERNS) {
+    const m = pane.match(re);
+    if (m) return m[0].replace(/^\[anet\]\s*(❌\s*)?/, "").trim();
+  }
+  // No recognised refusal — fall back to the last non-empty line, which for an
+  // uncaught crash is usually the error itself.
+  const lines = pane.split("\n").map(l => l.trimEnd()).filter(l => l.trim() !== "");
+  const last = lines[lines.length - 1];
+  return last ? last.trim() : null;
+}

--- a/agent-network/src/unsafe-package-path-reason.test.ts
+++ b/agent-network/src/unsafe-package-path-reason.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { classifyUnsafePath, describeUnsafePath } from "./unsafe-package-path-reason";
+
+const ME = 1000;
+
+// Exactly what `npx -y @sleep2agi/agent-node@preview` left on this machine on
+// 2026-08-17, measured with stat: umask 0002 → dist/cli.js 0775, package.json
+// 0664, both owned by uid 1000. Owner is fine; only the group-write bit fails.
+const NPM_EXTRACTED_BIN = { uid: ME, mode: 0o775, processUid: ME };
+const NPM_EXTRACTED_JSON = { uid: ME, mode: 0o664, processUid: ME };
+
+test("the condition that actually fires on a umask-0002 box is group-write, not ownership", () => {
+  expect(classifyUnsafePath(NPM_EXTRACTED_BIN)).toBe("group-writable");
+  expect(classifyUnsafePath(NPM_EXTRACTED_JSON)).toBe("group-writable");
+});
+
+test("a correctly-extracted package passes", () => {
+  expect(classifyUnsafePath({ uid: ME, mode: 0o755, processUid: ME })).toBeNull();
+  expect(classifyUnsafePath({ uid: ME, mode: 0o644, processUid: ME })).toBeNull();
+});
+
+test("someone else's payload is reported as ownership, and outranks the mode bits", () => {
+  expect(classifyUnsafePath({ uid: 0, mode: 0o777, processUid: ME })).toBe("owner");
+});
+
+test("world-writable is called out separately from group-writable", () => {
+  expect(classifyUnsafePath({ uid: ME, mode: 0o666, processUid: ME })).toBe("world-writable");
+  expect(classifyUnsafePath({ uid: ME, mode: 0o757, processUid: ME })).toBe("world-writable");
+});
+
+test("the message names the path, the mode, and umask — the thing the old text hid", () => {
+  const msg = describeUnsafePath("/home/x/.npm/_npx/aa/node_modules/@sleep2agi/agent-node/dist/cli.js", NPM_EXTRACTED_BIN);
+  expect(msg).toContain("/dist/cli.js");
+  expect(msg).toContain("775");
+  expect(msg).toContain("group-writable");
+  expect(msg).toContain("umask");
+  expect(msg).toContain("chmod -R g-w,o-w");
+});
+
+test("an ownership failure does not send the reader chasing umask", () => {
+  const msg = describeUnsafePath("/opt/pkg/dist/cli.js", { uid: 0, mode: 0o755, processUid: ME });
+  expect(msg).toContain("uid 0");
+  expect(msg).not.toContain("umask");
+});
+
+test("the mode is printed octal and zero-padded, so 0644 never reads as 420", () => {
+  expect(describeUnsafePath("/p", { uid: ME, mode: 0o066, processUid: ME })).toContain("066");
+});

--- a/agent-network/src/unsafe-package-path-reason.ts
+++ b/agent-network/src/unsafe-package-path-reason.ts
@@ -1,0 +1,60 @@
+// Why a resolved agent-node payload failed the supply-chain path check.
+//
+// The check itself is not the problem — refusing to execute a package that
+// someone else can rewrite is right. The problem was the sentence it printed:
+// "resolved agent-node package has unsafe ownership or mode" names ownership
+// first and never mentions the condition that actually fires on a stock
+// Debian/Ubuntu box.
+//
+// Measured on this machine 2026-08-17: `umask` is 0002, so npm extracts the
+// package with dist/cli.js at 0775 and package.json at 0664. Owner is correct.
+// `0o775 & 0o022 === 0o020` — the group-write bit alone fails the check, and
+// every grok-build-cli start died at that line reading
+// `Incompatible grok-build-cli runtime.` Removing the group/other write bits
+// let the same command run all the way through to the agent-node process.
+//
+// So: say which condition failed, on which path, with which mode, and what to
+// do about it. Pure function of a stat-like shape so it can be tested without
+// a filesystem.
+
+export interface PathModeFacts {
+  /** Owner uid of the path. */
+  uid: number;
+  /** Permission bits (st_mode & 0o777). */
+  mode: number;
+  /** uid of the process doing the check. */
+  processUid: number;
+}
+
+export type UnsafePathReason = "owner" | "group-writable" | "world-writable" | null;
+
+/** Which condition makes this path unsafe to execute from, if any. */
+export function classifyUnsafePath(facts: PathModeFacts): UnsafePathReason {
+  if (facts.uid !== facts.processUid) return "owner";
+  if ((facts.mode & 0o002) !== 0) return "world-writable";
+  if ((facts.mode & 0o020) !== 0) return "group-writable";
+  return null;
+}
+
+/**
+ * Operator-facing explanation. Names the path, the offending bits, and the
+ * command that fixes it — a message that says only "unsafe" leaves the reader
+ * guessing between four different conditions.
+ */
+export function describeUnsafePath(path: string, facts: PathModeFacts): string {
+  const reason = classifyUnsafePath(facts);
+  const mode = (facts.mode & 0o777).toString(8).padStart(3, "0");
+  switch (reason) {
+    case "owner":
+      return `${path} is owned by uid ${facts.uid}, not by this process (uid ${facts.processUid}) — ` +
+        `refusing to execute a payload another account can rewrite`;
+    case "world-writable":
+      return `${path} is mode ${mode} (world-writable) — refusing to execute a payload anyone can rewrite`;
+    case "group-writable":
+      return `${path} is mode ${mode} (group-writable) — refusing to execute a payload the group can rewrite. ` +
+        `This is usually your umask: on Debian/Ubuntu \`umask 0002\` makes npm extract packages 0775/0664. ` +
+        `Fix with \`chmod -R g-w,o-w <package root>\`, or run the start under \`umask 0022\` so the next fetch is clean`;
+    default:
+      return `${path} passed the ownership and mode check`;
+  }
+}


### PR DESCRIPTION
## 为什么

2026-08-17 掉电后恢复 97 个节点,我按 `anet node start` 的回执记账,报出「64/64 全部成功」——
**实际只起来 58 个**。6 个从没起来,连一行日志都没写。死节点和活节点的输出**逐字相同**。

一个连自己有没有把事情做成都说不准的命令行,批量场景里不可用。这个 PR 把起/停这几条路上
「没量过就宣布成功」的地方全部改成「量过才说」,并把同一类缺陷提前拦在 `anet doctor` 里。

## 五个提交

### 1. `4b3cb92e` — `--accept-dev-channels` 两个假绿

**假绿 A:成功是假设出来的。** `tmux new-session -d` 一返回就打
`✅ node "X" started detached (tmux session live; …)` 并 exit 0。那句 "tmux session live"
从没验证过 —— 内层 `anet node start` 可能下一秒因 runtime 不受支持退出 1,tmux 随即回收会话。
上一行就是 `can't find pane: X`,它照打 ✅。

改成:起不来的配置**在 spawn 之前**就拒绝(用 `launchAgent` 同一个 `resolveStartProfile`,
所以给出的是真话);成功只在 `verifyNodeUp` 通过后宣布 —— 那正是 `project up` 已经在用的判据;
成功行**带证据**(`pid 431975 alive`),不再宣称没验过的 `tmux session live`。

**假绿 B:45 秒自动应答窗口答错了框。** 没被信任过的工作区,Claude Code 先弹
`Do you trust the files in this folder?`;watcher 只认 dev-channels 的字样,于是盯着一个
它不会答的框把窗口耗完,后出现的 dev-channels 框永远没人答 —— 节点静默卡死、hub 显示 offline。
(`TM智空负责人` 就是这么死的,手动连按两次回车才起来。)

改成:信任框也答,答完**重置计时** —— 窗口本来就该约束「等一个框」,不是「等完整条链」。

失败时**故意不杀 tmux 会话**:卡在确认框的节点离能用只差一次回车,而某个不写 `.pid` 的
runtime 会因为没参与的检查被杀掉。但失败输出会明说会话还在、`has-session` 会对它说是、
该用哪个判据。

隔离工作区实测(内层 agent 用桩):

| 场景 | 原版 | 本 PR |
|---|---|---|
| runtime 不认识 | `✅ started detached` exit **0** | 拒绝在 spawn 前,原话进 stderr,exit **1** |
| 起来就死 | `✅ started detached` exit **0** | `❌ did not start —` 带 pane 里的真实原因,exit **1** |
| 信任框→dev-channels | `✅` exit 0,**46 秒,节点卡住没 pid** | `✅` exit 0,**5 秒,pid 活着,两框都答了** |
| 卡在未知确认框 | `✅` exit 0 | `❌` exit 1,把卡住那行**原样打给你** |

### 2. `b99526d0` — 同类审计:`--tmux` + codex 共存

把 cli.ts 里 **54 处 `✅` 断言**分类查了一遍。**大部分是量过的** —— `hub start` 打 `/health`、
dashboard launcher 扫 listener pid、共存的 ① app-server 等 `listening on:` 那行才说 READY。
两处不是:

- **`node start --tmux`** 有个 2 秒 `has-session` 轮询,把这当证据。不是证据:tmux 在内层命令
  「失败完」之前就登记好会话了。实测不支持的 runtime → `✅ tmux session "X" started detached`
  exit **0**,两秒后会话就没了。用同一个「spawn 前拒绝」修好。
  它那句窄断言(说**会话**起来了,不是节点)**留着没动** —— 那句是真话,而且这条路不答确认框,
  本来就没资格承诺节点能用。
- **codex 共存 `✅ 共存节点 X 就绪`** 起三个 tmux 会话,只有 ① 自证过。而它的
  **OpenCode 双胞胎早就在同一句话之前检查 TUI 会话** —— 两条同源路径对「就绪要不要量」
  意见不一致。现在一致了,就绪要求三个会话在打印那一刻都活着。

### 3. `ec7a3b3c` — 报错说清是 umask,不是属主

追查 5 个 grok 共存节点为什么起不来时挖出来的,**和 grok 无关**:

```
umask                                            0002
npx -y @sleep2agi/agent-node@preview   dist/cli.js 0775, package.json 0664
校验                                    (mode & 0o022) !== 0  → 拒绝
0o775 & 0o022                          = 0o020   ← 只有组写位
操作者看到的     [anet] Incompatible grok-build-cli runtime.
                [anet] resolved agent-node package has unsafe ownership or mode
```

属主自始至终是对的。那句话把 ownership 放最前面,把排查往属主上引。
`chmod g-w,o-w` 之后同一条命令**一路跑进 agent-node 进程**,只在连测试用的假 hub 时报
ConnectionRefused —— 这才算归因。

**校验本身不动**(拒绝执行「组内他人能改写」的载荷是对的,anet 也无从知道这台机器的组只有一个人)。
改的是它现在会说清楚:哪个路径、八进制 mode、四个条件里哪个触发、通常元凶是
Debian/Ubuntu 默认 umask,并给两条修法。**属主类失败故意不提 umask**,免得带偏方向。

两个调用点共用同一个纯模块:cli.ts 的 grok preview resolver,和 OpenCode 配对校验
——后者执行同一条规则,会产生同一个死胡同。

### 4. `f64fb802` — `anet doctor` 提前预检这个条件

更好的报错只帮到**已经卡住的人**。doctor 只用本地状态就能提前看见 —— **不联网、不 fetch**:

```
⚠  Package file modes: umask is 0002, so npm extracts packages group-writable.
   grok-build-cli and opencode-cli refuse to execute a payload in that state,
   and the refusal reads as an "Incompatible runtime" error.
   Start those runtimes under `umask 0022`, or run `chmod -R g-w,o-w` …
⚠  Resolved agent-node payload: 2 already-extracted file(s) would be rejected
   right now, e.g. …/@sleep2agi/agent-node/dist/cli.js (mode 775).
   Fix: chmod -R g-w,o-w …/@sleep2agi/agent-node
```

umask 的**位置上表示「扣掉」**,判据读起来跟症状相反 —— 正因为容易写反,`judgeUmask` 做成
被测函数而不是内联表达式,0002/0022/0000/0077 各钉一条。读 umask 只能靠 POSIX 的
「设了再返回」,helper 立刻放回旧值并用第二次读复查相等。
扫描只看**已解出来的**副本,所以「空」意味着「还没 fetch 过」,**不等于安全**。

### 5. `8032b906` — tmux 目标要精确:裸 `-t` 会前缀命中兄弟节点

代码库自己早就知道这个坑,**但只写在给人看的字符串里**:每一句提示都是
`tmux attach -t '=<alias>'`(OpenCode 共存那处还专门写了注释解释为什么),
而**它真正执行的 8 个 tmux 调用全部用裸名字**。

实测(只有 `zz-honest-probe-extra` 活着时):

```
tmux has-session -t zz-honest-probe    → 成功   ← 它根本没在跑
tmux has-session -t =zz-honest-probe   → 失败   ← 正确
tmux kill-session -t zz-honest-probe   → 杀掉了 zz-honest-probe-extra
```

那台机器 89 个在跑会话里**有 4 对真实前缀碰撞**(`A站内容`/`A站内容牛` 一类)。三个后果:

1. `has-session` 假阳性 → `node start --accept-dev-channels` 打印
   `already running — skipping spawn`、exit 0、**节点根本没起**。已端到端复现:只有兄弟会话
   在跑时,`origin/main` 跳过 spawn 不留 pid;本 PR 正常启动且兄弟毫发无伤。
2. `kill-session` 杀掉兄弟节点,而 `node stop` 报告成功。
3. **`send-keys` 把回车送进兄弟节点的 Claude 界面** —— 最糟,因为确认框 watcher 是无人值守触发的。

八处(kill-session、has-session、capture-pane ×4、send-keys ×2)统一走一个 helper。

`killTmuxSession` 另外**返回「到底没了没有」**:它吞掉 kill 失败是故意的(会话已退出是常态),
所以唯一的办法是事后再看一眼;`node stop` 据此拒绝报告一个它没做到的停止,而不是拿
**杀之前**那次探测当结论、然后去通知 hub 下线。

**紧迫度更正**:tmux 在精确名存在时优先命中精确名(实测),所以那 4 对**当前休眠**。
它武装的条件是短名节点挂掉而 `X牛` 还在 —— 也就是**下一次崩溃或重启时发作**,
正是最需要 `node start` 说真话的时刻。不是正在烧,是潜伏。

## 验证

- **478 测试全过,0 失败;`tsc --noEmit` 干净。**
- 新增 4 个测试文件、37 条断言。**每一条都对未修改的文件见过红**:
  - `tmux-pane-prompt`:两次变异(删信任框识别 / 删拒绝行提取)各自把对应测试变红。
    其中一条我发现夹具太松 —— 噪声只加在拒绝行**上面**,`take the last line` 也能过;
    把噪声加到**下面**之后才真正见红。
  - `node-start-accept-dev-channels-wiring`:6 条对 `origin/main` **6 红**。
  - `start-paths-verify-before-claiming`:第一版 `--tmux` 那条**对未修改文件是绿的**
    —— 锚点写松了,它找到的是**另一条分支**上的 preflight。按 `--tmux` 自身代码段
    重新切片后,4 条里 3 条对 `origin/main` 和对本 PR 上一个提交**都红**;
    第 4 条是 OpenCode 双胞胎的对照,三边都绿(参照物,不是改动)。
  - `tmux-exact-target`:含一条对**真 tmux** 的集成测试,自己的 `anet-exacttest*` 命名并自清。
- 全程在隔离工作区 + 自建桩里跑,**89 个在跑节点一个没碰**(前后 `tmux ls` 均 89)。

## 没验到的

**codex 共存那条(提交 2 的后半)没能端到端验证** —— 需要能用的 codex,而这个账号额度
2026-08-20 11:29 才恢复。改动是照抄 OpenCode 双胞胎的形状,且只在会话确实不存在时新增
一条失败路径。**不当它已验收。**
