### PR TITLE
fix(cli): project up / restart 的退出码要反映节点是否真的起来了

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -7763,6 +7763,33 @@ function parseStaggerMs(): number {
   return Math.round(n * 1000);
 }
 
+/**
+ * Make the exit code agree with the summary that was just printed.
+ *
+ * `project up` / `project restart` already measure each node with
+ * verifySpawnedNodes and print every failure — the TEXT was honest. The exit
+ * code was not: both returned normally, so a run that brought up 60 of 74 nodes
+ * exited 0. Any caller that scripts this (a boot-time sweep, CI, a watchdog)
+ * therefore had to re-derive the outcome itself, and one that trusted `$?` was
+ * told the fleet was fine. Same defect class as #895's single-node path, one
+ * level up.
+ *
+ * `invalid` counts too: a node whose config cannot start was never attempted,
+ * so reporting success would hide it just as effectively as a crash.
+ */
+function exitFromProjectOutcome(
+  failed: { alias: string; reason: string }[],
+  invalid: { alias: string; reason: string }[] = [],
+) {
+  if (failed.length === 0 && invalid.length === 0) return;
+  console.error(
+    `[anet] ❌ exiting non-zero: ${failed.length} node(s) failed to come up` +
+      (invalid.length ? `, ${invalid.length} with unstartable config` : "") +
+      ` — see the list above.`,
+  );
+  process.exit(1);
+}
+
 function printProjectSummary(
   total: number,
   up: number,
@@ -7994,6 +8021,7 @@ async function projectUp(invokedAs = "anet project up") {
     autoConfirmDevChannels(spawned),
   ]);
   printProjectSummary(nodes.length, alreadyUp + started, failed, invalid);
+  exitFromProjectOutcome(failed, invalid);
 }
 
 async function projectRestart() {
@@ -8050,6 +8078,7 @@ async function projectRestart() {
     autoConfirmDevChannels(spawned),
   ]);
   printProjectSummary(nodes.length, started, failed, invalid);
+  exitFromProjectOutcome(failed, invalid);
 }
 
 async function projectDown() {

--- a/agent-network/src/project-outcome-exit-code.test.ts
+++ b/agent-network/src/project-outcome-exit-code.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const source = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+
+function fn(name: string): string {
+  const a = source.indexOf(`async function ${name}(`);
+  expect(a).toBeGreaterThan(-1);
+  const b = source.indexOf("\nasync function ", a + 10);
+  expect(b).toBeGreaterThan(a);
+  return source.slice(a, b);
+}
+
+// `project up` and `project restart` measure every node (verifySpawnedNodes)
+// and print every failure, so their OUTPUT was already honest. Their exit code
+// was not: both returned normally, so a run that brought up 60 of 74 nodes
+// exited 0. That is what forces every scripted caller — a boot sweep, CI, a
+// watchdog — to re-derive the outcome instead of reading `$?`.
+test("project up exits non-zero when nodes failed to come up", () => {
+  const body = fn("projectUp");
+  const summary = body.indexOf("printProjectSummary(");
+  const gate = body.indexOf("exitFromProjectOutcome(");
+  expect(summary).toBeGreaterThan(-1);
+  expect(gate).toBeGreaterThan(summary);   // report first, then set the code
+});
+
+test("project restart carries the same gate", () => {
+  const body = fn("projectRestart");
+  expect(body).toContain("exitFromProjectOutcome(");
+});
+
+test("the gate counts unstartable configs too, not only crashes", () => {
+  const a = source.indexOf("function exitFromProjectOutcome(");
+  expect(a).toBeGreaterThan(-1);
+  const body = source.slice(a, source.indexOf("\nfunction printProjectSummary(", a));
+  // A node whose config cannot start was never attempted; calling that success
+  // hides it exactly as well as a crash does.
+  expect(body).toContain("invalid.length");
+  expect(body).toContain("failed.length === 0");
+  expect(body).toContain("process.exit(1)");
+});
+
+test("a fully successful run still returns normally", () => {
+  const a = source.indexOf("function exitFromProjectOutcome(");
+  const body = source.slice(a, source.indexOf("\nfunction printProjectSummary(", a));
+  // The early return is what keeps the happy path at exit 0; without it every
+  // successful project up would start failing.
+  expect(body).toMatch(/if \(failed\.length === 0 && invalid\.length === 0\) return;/);
+});
+
+test("the failure line points at the list the operator just saw", () => {
+  const a = source.indexOf("function exitFromProjectOutcome(");
+  const body = source.slice(a, source.indexOf("\nfunction printProjectSummary(", a));
+  expect(body).toContain("exiting non-zero");
+  expect(body).toContain("see the list above");
+});


### PR DESCRIPTION
## 为什么

#895 的后续,同一类缺陷往上一层 —— 而这一层才是自动化真正调用的入口。

`anet project up` **已经**用 `verifySpawnedNodes` 逐个量过节点、并把每条失败都打印出来了,所以它的**输出是诚实的** —— 不像单节点那条路,它从没把死节点说成起来了。它没做的是**设退出码**:`projectUp` 和 `projectRestart` 都正常返回,于是**一次「74 个节点起来 60 个」的运行退出码是 0**。

这件事有实际后果,因为这是脚本调用的那个入口。我在复审一个给本机 ~74 个 agent 节点做的开机 sweep 脚本时,让它**用 post-flight 的 tmux 审计而不是 `$?`** 来判成败;后来才发现这个选择是**承重的而不是风格问题**:

```
$ grep -c 'process.exit' <projectUp 函数体>
0
```

任何信 `$?` 的看门狗或 CI 步骤,都会被告知舰队一切正常。

## 改法

```ts
printProjectSummary(nodes.length, alreadyUp + started, failed, invalid);
exitFromProjectOutcome(failed, invalid);      // ← 新增
```

- **门在 `printProjectSummary` 之后**,所以操作者仍然先拿到完整清单,再看到进程退出。
- **`invalid` 也算失败**。一个 config 起不来的节点**根本没被尝试过**,退出 0 对它的掩盖程度和崩溃一模一样。
- **干净的运行提前返回,退出码仍是 0** —— 否则每一次成功的 `project up` 都会开始报错。

## 验证

- 5 条断言**对 `f565e9b8`(合入 #895 后的 main)全部 5 红**,在本 PR 全绿。
- 包内 **483 测试全过**,`tsc --noEmit` 干净。
- 其中一条断言专门钉住 happy path 的提前返回 —— 防止后人把这道门写成「无条件 exit 1」。

## 这条为什么值得单独一个 PR

#895 修的是「CLI 说了没量过的话」。这一条不同:**话是真的,退出码是假的**。两者的读者不一样 —— 前者骗人,后者骗脚本。今天这台机器掉电后 97 个节点是人手一个个起回来的,而开机自愈方案要挂的正是 `project up`;它的退出码必须能承重。
