### PR TITLE
fix(ci): 让 CI 真会跑的测试能重触发自己那道门,并加一道防漂回去的门

### DIFF
--- a/.github/scripts/check-public-script-safety.py
+++ b/.github/scripts/check-public-script-safety.py
@@ -15,7 +15,15 @@ On 2026-07-31 four such scripts were found to contain, between them:
 
 All four were found by hand. This guard exists so the next one is not.
 
-Scope note: only two rules, both unambiguous. A guard that cries wolf gets
+  * (added 2026-08-17) nothing yet — this third rule is preventive. Every one
+    of these scripts is fetched over https and piped into bash, so TLS
+    verification is the reader's only defence against a tampered download.
+    `curl -k` / `--insecure` / `wget --no-check-certificate` removes it, which
+    is why it belongs with the other two rather than with human review: there
+    is no legitimate reason for a script published at a public https URL to
+    skip verifying that URL.
+
+Scope note: three rules, all unambiguous. A guard that cries wolf gets
 disabled, and then it protects nothing. Deliberately NOT flagged here:
   * printing a documented default password (correct for the stable channel,
     which is what these scripts install)
@@ -35,6 +43,13 @@ OURS = ("~/.anet", "~/.commhub", "~/anodes/.anet",
 RM_RF = re.compile(r"\brm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+(?P<targets>[^\n;&|]+)")
 KILL = re.compile(r"\b(pkill|killall)\b(?P<args>[^\n;&|]*)")
 USER_SCOPED = re.compile(r"-u\s+\S")
+# TLS verification is the only thing standing between the reader and a tampered
+# download, and these scripts are meant to be piped straight into bash.
+INSECURE_TLS = re.compile(
+    r"\b(?:curl\b[^\n;&|]*?(?:\s-{1,2}(?:k|insecure)\b)"
+    r"|wget\b[^\n;&|]*?--no-check-certificate\b"
+    r"|(?:NODE_TLS_REJECT_UNAUTHORIZED|PYTHONHTTPSVERIFY)\s*=\s*0)"
+)
 
 
 def check(path: Path):
@@ -55,6 +70,9 @@ def check(path: Path):
         k = KILL.search(line)
         if k and not USER_SCOPED.search(k.group("args")):
             out.append((i, "unscoped-process-kill", line.strip()[:90]))
+
+        if INSECURE_TLS.search(line):
+            out.append((i, "tls-verification-disabled", line.strip()[:90]))
     return out
 
 
@@ -81,14 +99,30 @@ def main():
         print(f"0 findings across {len(scripts)} script(s).")
         return 0
 
+    # Keyed by rule, not by an if/else that falls through: a new rule reaching
+    # the `else` branch would print another rule's remediation, which is worse
+    # than printing none — the reader follows advice for a problem they do not
+    # have. (Caught exactly that while adding the TLS rule.)
+    HINTS = {
+        "rm-rf-outside-product":
+            "path is not owned by this product — wiping it damages unrelated "
+            "tools on the user's machine. Remove it, or narrow to a path we own.",
+        "unscoped-process-kill":
+            "pattern-matched kill hits same-named processes owned by anyone. "
+            'Scope it: pkill -u "$(id -u)" -f ...',
+        "tls-verification-disabled":
+            "this script is fetched over https and piped into bash; skipping "
+            "certificate verification removes the reader's only protection "
+            "against a tampered download. Drop the flag.",
+    }
+    unknown = sorted({rule for _, _, rule, _ in findings} - HINTS.keys())
+    if unknown:
+        print(f"::error::rule(s) with no remediation text: {', '.join(unknown)} — "
+              "add one to HINTS rather than letting it borrow another rule's advice")
+        return 2
+
     for s, line_no, rule, text in findings:
-        if rule == "rm-rf-outside-product":
-            hint = ("path is not owned by this product — wiping it damages unrelated "
-                    "tools on the user's machine. Remove it, or narrow to a path we own.")
-        else:
-            hint = ("pattern-matched kill hits same-named processes owned by anyone. "
-                    'Scope it: pkill -u "$(id -u)" -f ...')
-        print(f"::error file={s},line={line_no}::[{rule}] {text}\n    {hint}")
+        print(f"::error file={s},line={line_no}::[{rule}] {text}\n    {HINTS[rule]}")
 
     print(f"\n{len(findings)} finding(s) across {len(scripts)} scanned script(s).")
     return 1

--- a/.github/scripts/check-qa-trigger-coverage.py
+++ b/.github/scripts/check-qa-trigger-coverage.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Every test CI actually runs must also be able to re-trigger the workflow that runs it.
+
+`.github/workflows/qa.yml` fires on a path filter. A test directory that CI
+executes but that is missing from that filter can be edited without the gate
+re-running — the change ships against whatever the gate last said, and the
+output looks identical to a gate that passed on the new code.
+
+Found on 2026-08-17: three of the four test directories reached through
+`scripts/qa.sh` L1_TESTS were outside the filter (test686-rest-shape-golden,
+test765-batch-runtime-gate, test766-bunx-preflight), plus test292-e2e-hard-gate
+which a workflow references by path. The reason it was easy to miss is that
+`tests/` holds ~166 directories and only a handful are wired into CI at all, so
+"most tests are not in the filter" is the normal, correct state and hides the
+few that should be.
+
+Deliberately NOT flagged: the ~160 directories no workflow executes. Listing
+them would grow the filter without adding a single gate, and a filter that
+triggers on unrun tests reads like coverage it does not have.
+
+Scope is fail-closed: if the workflow, qa.sh, or tests/ cannot be found, this
+exits 2 rather than reporting a clean run against nothing.
+"""
+import re
+import sys
+from pathlib import Path
+
+QA_YML = Path(".github/workflows/qa.yml")
+QA_SH = Path("scripts/qa.sh")
+TESTS_DIR = Path("tests")
+WORKFLOWS = Path(".github/workflows")
+
+
+def bash_array(text: str, name: str) -> list[str]:
+    """Entries of a `NAME=( "a" "b" )` bash array, or [] when absent."""
+    m = re.search(rf"{name}=\(([^)]*)\)", text, re.S)
+    return re.findall(r'"([^"]+)"', m.group(1)) if m else []
+
+
+def main() -> int:
+    for p in (QA_YML, QA_SH, TESTS_DIR):
+        if not p.exists():
+            print(f"::error::{p} not found — scope regression, refusing to pass")
+            return 2
+
+    test_dirs = {d.name for d in TESTS_DIR.iterdir() if d.is_dir() and d.name.startswith("test")}
+    if not test_dirs:
+        print(f"::error::no test directories under {TESTS_DIR} — scope regression, refusing to pass")
+        return 2
+
+    qa_sh = QA_SH.read_text(encoding="utf-8", errors="replace")
+    # L1 entries name the directory bare (no `tests/` prefix); L0 entries name
+    # source files, so only the ones that resolve to a real test dir count.
+    executed = {e for e in bash_array(qa_sh, "L1_TESTS") + bash_array(qa_sh, "L0_TESTS")
+                if e in test_dirs}
+
+    # Anything a workflow references by path is executed too.
+    for wf in sorted(list(WORKFLOWS.glob("*.yml")) + list(WORKFLOWS.glob("*.yaml"))):
+        body = wf.read_text(encoding="utf-8", errors="replace")
+        # A path filter entry is not a reference to running it — strip those
+        # first, or every listed dir would look self-justifying.
+        body = re.sub(r"^\s*-\s*'tests/[^']+'\s*$", "", body, flags=re.M)
+        executed |= {m.rstrip("/") for m in re.findall(r"tests/(test[\w.\-]+)", body)} & test_dirs
+
+    if not executed:
+        print("::error::no CI-executed test directories detected — the parser probably "
+              "stopped matching qa.sh or the workflows; refusing to pass")
+        return 2
+
+    covered = set(re.findall(r"tests/(test[\w.\-]+)/\*\*", QA_YML.read_text(encoding="utf-8")))
+    gap = sorted(executed - covered)
+
+    print(f"tests/ directories: {len(test_dirs)} · CI-executed: {len(executed)} · "
+          f"in qa.yml path filter: {len(covered)}")
+
+    if gap:
+        for d in gap:
+            print(f"::error file={QA_YML}::tests/{d} is executed by CI but missing from the "
+                  f"qa.yml path filter — editing it will not re-run its own gate.\n"
+                  f"    Add:  - 'tests/{d}/**'")
+        print(f"\n{len(gap)} executed test directory/ies outside the trigger filter.")
+        return 1
+
+    stale = sorted(covered - executed)
+    if stale:
+        # Not a failure: a dir may be listed ahead of being wired up. But say it,
+        # because a filter entry for something CI never runs is coverage theatre.
+        print("note: in the filter but not executed by CI (harmless, but not coverage): "
+              + ", ".join(stale))
+
+    print(f"all {len(executed)} CI-executed test directory/ies can re-trigger qa.yml.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/qa-trigger-coverage.yml
+++ b/.github/workflows/qa-trigger-coverage.yml
@@ -1,0 +1,34 @@
+# Keep qa.yml's path filter in sync with the tests CI actually runs.
+#
+# qa.yml fires on a path filter. A test directory that CI executes but that is
+# missing from the filter can be edited without its own gate re-running — the
+# change ships against whatever the gate last said, and the run looks exactly
+# like a gate that passed on the new code.
+#
+# Found on 2026-08-17: four such directories (test292-e2e-hard-gate,
+# test686-rest-shape-golden, test765-batch-runtime-gate, test766-bunx-preflight).
+# Easy to miss because tests/ holds ~166 directories and only a handful are
+# wired into CI, so "most tests are absent from the filter" is the correct
+# normal state — which is what hid the few that should not be.
+#
+# 🔴 This workflow deliberately has NO `paths:` filter. It is the guard for a
+#    path filter; gating it on paths would let a change to qa.yml's filter or to
+#    scripts/qa.sh L1_TESTS slip past the very check that watches them, and it
+#    would be the same class of blind spot the guard exists to catch.
+#
+# Python rather than an in-yml bash loop, per the team's CI-guard pattern
+# (same reasoning as public-script-safety.yml and no-memory-slugs.yml).
+
+name: lint (qa trigger coverage)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 .github/scripts/check-qa-trigger-coverage.py

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -22,6 +22,15 @@ on:
       - 'tests/test725-agent-node-unit-ci/**'
       - 'tests/test745-agent-network-unit-ci/**'
       - 'tests/test746-setup-bun-pin/**'
+      # A test directory belongs here exactly when CI executes it — otherwise
+      # editing the test cannot re-run the gate that runs it. The four below are
+      # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
+      # ~160 dirs under tests/ are not run by any workflow, so listing them
+      # would only look like coverage.
+      - 'tests/test292-e2e-hard-gate/**'
+      - 'tests/test686-rest-shape-golden/**'
+      - 'tests/test765-batch-runtime-gate/**'
+      - 'tests/test766-bunx-preflight/**'
   push:
     branches: [main]
     paths:
@@ -34,6 +43,15 @@ on:
       - 'tests/test725-agent-node-unit-ci/**'
       - 'tests/test745-agent-network-unit-ci/**'
       - 'tests/test746-setup-bun-pin/**'
+      # A test directory belongs here exactly when CI executes it — otherwise
+      # editing the test cannot re-run the gate that runs it. The four below are
+      # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
+      # ~160 dirs under tests/ are not run by any workflow, so listing them
+      # would only look like coverage.
+      - 'tests/test292-e2e-hard-gate/**'
+      - 'tests/test686-rest-shape-golden/**'
+      - 'tests/test765-batch-runtime-gate/**'
+      - 'tests/test766-bunx-preflight/**'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
 # updated rapidly. main pushes run independently.

--- a/deploy/dashboard/ecosystem.config.cjs
+++ b/deploy/dashboard/ecosystem.config.cjs
@@ -20,7 +20,11 @@ module.exports = {
       interpreter: "bash",
       exec_mode: "fork",
       autorestart: true,
-      min_uptime: 20_000,
+      // min_uptime 必须大于「进程失败退出所需时间」。低于它，PM2 会把这次启动
+      // 算成功、不计入失败，backoff 永不触发 —— 崩溃循环看起来像正常重启。
+      // 这里原本是 20_000，比 docs-site/docs/deploy/daemon.md 记录的 45000 小，
+      // 照本仓重建出来的 dashboard 会正好落进那个盲区。对齐到 45000。
+      min_uptime: 45000,
       max_restarts: 20,
       exp_backoff_restart_delay: 200,
     },


### PR DESCRIPTION
四条来自 open issue 分诊的发现,**每一条都先在 `origin/main` 上核实过才动手**。其中两条的数字和 issue 里报的不一样,值得记下来。

## 1. qa.yml 的 path filter 漏了 CI 真的会跑的测试(#860)

qa.yml 靠 path filter 触发。有四个 CI 会执行的目录不在 filter 里 —— 改这些测试**无法重跑它自己那道门**,而那次运行看起来和「门在新代码上通过了」**一模一样**:

```
tests/test292-e2e-hard-gate        (被某个 workflow 按路径引用)
tests/test686-rest-shape-golden    ┐
tests/test765-batch-runtime-gate   ├ 经 scripts/qa.sh 的 L1_TESTS 执行
tests/test766-bunx-preflight       ┘
```

**#860 报了 3 个,漏了 `test292-e2e-hard-gate`。而我自己第一次扫也数错了,方向相反** —— 我的正则匹配 `tests/testNNN`,而 `L1_TESTS` 里写的是**裸目录名**,所以完全没看见它们,一度得出「CI 只跑 4 个」的错结论。

`tests/` 下另外约 160 个目录**没有任何 workflow 执行它们**,故意不加进 filter:给不会跑的测试加触发路径,读起来像覆盖面,其实一点门都没多。

## 2. 加一道门防它漂回去

`.github/scripts/check-qa-trigger-coverage.py` 断言「每个 CI 会执行的测试目录都在 filter 里」。三种行为都实测过:

| 输入 | 退出码 | 输出 |
|---|---|---|
| 修好的仓 | **0** | `all 7 CI-executed test dirs can re-trigger qa.yml` |
| `f565e9b8` 的 qa.yml | **1** | 逐个指名那 4 个,并给出该加的那行 |
| 把 `L1_TESTS` 改名(模拟分母塌陷) | **2** | `no CI-executed test directories detected` |

**第三条最重要**:解析器一旦不再匹配,诚实的答案是「我看不到分母了」,不是「对着空集干净通过」。

它的 workflow **故意不带 `paths:` filter**。它守的就是一个 path filter;给它自己加 paths,会让「改 qa.yml 的 filter」或「改 L1_TESTS」这两件事绕过监视它们的检查 —— **正是它存在要抓的那类盲区**。

## 3. 公开脚本安全:补 TLS 校验规则(#890)

`check-public-script-safety.py` 拦 `rm -rf` 打到非自有路径、拦 unscoped `pkill`,但对 `curl -k` / `--insecure` / `wget --no-check-certificate` / `NODE_TLS_REJECT_UNAUTHORIZED=0` **一条规则都没有**。这些脚本是**从 https 拉下来直接管道进 bash** 的,TLS 校验是读者对抗「下载内容被篡改」的唯一防线;一个发布在公开 https URL 上的脚本,没有任何正当理由跳过校验它自己那个 URL。这符合该文件自己定的「只收无歧义规则」的门槛。**当前零命中 —— 这条是防未来的。**

加的时候撞到一个报告 bug:提示语是 if/else 选的,而 `else` 分支属于 kill 规则,所以**每条 TLS 命中都打印了关于 `pkill -u` 的建议**。现在提示语按规则查表,未知规则直接 exit 2 —— **把读者指向一个他没有的问题,比不给建议更糟**。

用真退出码验的(不走管道 —— 走管道 `$?` 抓到的是最后一个命令):已知该红的夹具 → **exit 1**,三种写法各自给对提示,注释行正确忽略;真实仓 6 个脚本 → **exit 0**。

## 4. dashboard 的 min_uptime(#892)

`deploy/dashboard/ecosystem.config.cjs` 是 `min_uptime: 20_000`,而 `docs-site/docs/deploy/daemon.md` 记的是 `45000` **并且解释了为什么**:低于「进程失败退出所需时间」时,PM2 会把这次启动算成功、不计入失败,backoff 永不触发 —— **崩溃循环看起来像正常重启**。照本仓重建出来的 dashboard 正好落进那个盲区。已对齐到 45000,理由写在旁边;`node -e require(...)` 确认仍能解析。
