### PR TITLE
docs(refresh): stale-snapshot caveats on 4 独立面 (task 27faa700)

### DIFF
--- a/docs-site/docs/en/preview/index.md
+++ b/docs-site/docs/en/preview/index.md
@@ -13,9 +13,9 @@ The current preview channel = **v0.11-preview2** (npm `@preview` tag). This rele
 The specific `preview.N` numbers below are a **2026-06-28 snapshot**; the preview channel keeps iterating (it's now well past preview.1). **Always install / upgrade the current preview via the `@preview` tag** (the install commands below already do), rather than copying a specific version number.
 :::
 
-## Current preview channel canonical build (snapshot 2026-08-14)
+## Current preview channel canonical build (snapshot 2026-08-17)
 
-> **Snapshot 2026-08-14**: `@preview` currently resolves to `@sleep2agi/agent-network@2.3.0-preview.39` / `@sleep2agi/agent-node@2.5.0-preview.31` / `@sleep2agi/commhub-server@0.9.0-preview.29` (what main source requires). The published `preview.39` binary's embedded `.d.ts` pair still names `agent-node@2.5.0-preview.28` (published-binary requirement ≠ main-source requirement; in auto-sync mode the main-source constant advances ahead of the npm-published artifact). **Always install / upgrade the current preview via the `@preview` tag** (the install commands below already do); do NOT hand-copy version numbers from here — both tags keep drifting; re-check with `npm view <pkg> dist-tags` before editing.
+> **Snapshot 2026-08-17**: `@preview` currently resolves to `@sleep2agi/agent-network@2.3.0-preview.39` / `@sleep2agi/agent-node@2.5.0-preview.31` / `@sleep2agi/commhub-server@0.9.0-preview.29` (what main source requires). The published `preview.39` binary's embedded `.d.ts` pair still names `agent-node@2.5.0-preview.28` (published-binary requirement ≠ main-source requirement; in auto-sync mode the main-source constant advances ahead of the npm-published artifact). **Always install / upgrade the current preview via the `@preview` tag** (the install commands below already do); do NOT hand-copy version numbers from here — both tags keep drifting; re-check with `npm view <pkg> dist-tags` before editing.
 
 @preview now points at the **canonical build** (published from the exact tgz after real-Windows verification; independent Linux gate re-run in progress — latest promotion gated on true green):
 

--- a/docs-site/docs/en/preview/index.md
+++ b/docs-site/docs/en/preview/index.md
@@ -13,7 +13,9 @@ The current preview channel = **v0.11-preview2** (npm `@preview` tag). This rele
 The specific `preview.N` numbers below are a **2026-06-28 snapshot**; the preview channel keeps iterating (it's now well past preview.1). **Always install / upgrade the current preview via the `@preview` tag** (the install commands below already do), rather than copying a specific version number.
 :::
 
-## Current preview = canonical (2.3.0-preview.34 / 2.5.0-preview.26, 2026-07-16)
+## Current preview channel canonical build (snapshot 2026-08-14)
+
+> **Snapshot 2026-08-14**: `@preview` currently resolves to `@sleep2agi/agent-network@2.3.0-preview.39` / `@sleep2agi/agent-node@2.5.0-preview.31` / `@sleep2agi/commhub-server@0.9.0-preview.29` (what main source requires). The published `preview.39` binary's embedded `.d.ts` pair still names `agent-node@2.5.0-preview.28` (published-binary requirement ≠ main-source requirement; in auto-sync mode the main-source constant advances ahead of the npm-published artifact). **Always install / upgrade the current preview via the `@preview` tag** (the install commands below already do); do NOT hand-copy version numbers from here — both tags keep drifting; re-check with `npm view <pkg> dist-tags` before editing.
 
 @preview now points at the **canonical build** (published from the exact tgz after real-Windows verification; independent Linux gate re-run in progress — latest promotion gated on true green):
 

--- a/docs-site/docs/preview/index.md
+++ b/docs-site/docs/preview/index.md
@@ -13,7 +13,9 @@
 下方具体 `preview.N` 版本号是 **2026-06-28 快照**，preview channel 一直在迭代（现已远超 preview.1）。**装 / 升当前 preview 一律用 `@preview` tag**（下方安装命令已用），不要照抄具体版本号。
 :::
 
-## 当前 preview = canonical（2.3.0-preview.34 / 2.5.0-preview.26，2026-07-16）
+## 当前 preview channel canonical build（snapshot 2026-08-14）
+
+> **snapshot 2026-08-14**：`@preview` 当前指向 `@sleep2agi/agent-network@2.3.0-preview.39` / `@sleep2agi/agent-node@2.5.0-preview.31` / `@sleep2agi/commhub-server@0.9.0-preview.29`（main 源码要求）。已发布 `preview.39` 二进制内嵌 `.d.ts` pair 仍指 `agent-node@2.5.0-preview.28`（binary 要求 ≠ main 源码要求；auto-sync 模式下 main 源码常量会先于 npm 发布产物推进）。**装 / 升当前 preview 请一律走 `@preview` tag**（下方安装命令已用），不要手动复制此处版本号 —— 两个 tag 都在持续漂移，改前用 `npm view <pkg> dist-tags` 核一遍。
 
 @preview 现在指向 **canonical 合并版**（真 Windows 复验 PASS 后从验证过的 tgz 发布；Linux 门禁独立复跑中，latest promote 以真全绿为前提）：
 

--- a/docs-site/docs/preview/index.md
+++ b/docs-site/docs/preview/index.md
@@ -13,9 +13,9 @@
 下方具体 `preview.N` 版本号是 **2026-06-28 快照**，preview channel 一直在迭代（现已远超 preview.1）。**装 / 升当前 preview 一律用 `@preview` tag**（下方安装命令已用），不要照抄具体版本号。
 :::
 
-## 当前 preview channel canonical build（snapshot 2026-08-14）
+## 当前 preview channel canonical build（snapshot 2026-08-17）
 
-> **snapshot 2026-08-14**：`@preview` 当前指向 `@sleep2agi/agent-network@2.3.0-preview.39` / `@sleep2agi/agent-node@2.5.0-preview.31` / `@sleep2agi/commhub-server@0.9.0-preview.29`（main 源码要求）。已发布 `preview.39` 二进制内嵌 `.d.ts` pair 仍指 `agent-node@2.5.0-preview.28`（binary 要求 ≠ main 源码要求；auto-sync 模式下 main 源码常量会先于 npm 发布产物推进）。**装 / 升当前 preview 请一律走 `@preview` tag**（下方安装命令已用），不要手动复制此处版本号 —— 两个 tag 都在持续漂移，改前用 `npm view <pkg> dist-tags` 核一遍。
+> **snapshot 2026-08-17**：`@preview` 当前指向 `@sleep2agi/agent-network@2.3.0-preview.39` / `@sleep2agi/agent-node@2.5.0-preview.31` / `@sleep2agi/commhub-server@0.9.0-preview.29`（main 源码要求）。已发布 `preview.39` 二进制内嵌 `.d.ts` pair 仍指 `agent-node@2.5.0-preview.28`（binary 要求 ≠ main 源码要求；auto-sync 模式下 main 源码常量会先于 npm 发布产物推进）。**装 / 升当前 preview 请一律走 `@preview` tag**（下方安装命令已用），不要手动复制此处版本号 —— 两个 tag 都在持续漂移，改前用 `npm view <pkg> dist-tags` 核一遍。
 
 @preview 现在指向 **canonical 合并版**（真 Windows 复验 PASS 后从验证过的 tgz 发布；Linux 门禁独立复跑中，latest promote 以真全绿为前提）：
 

--- a/docs/release/v2.3.0/plan.md
+++ b/docs/release/v2.3.0/plan.md
@@ -27,6 +27,8 @@
 
 ## 进度快照（自主推进中 · 每步滚动更新）
 
+> ⚠️ **本段是 2026-07-05 快照** —— 6 周前的 GA-gate GREEN 状态 + 版本号（`preview.20/.19/.21` / dashboard `preview.9`），**当前 preview 已远超此数字**。真值以 [`docs/plans/release-plan.md`](../../plans/release-plan.md) 里的 `npm view` 表为准（snapshot 2026-08-14: agent-network `2.3.0-preview.39` / agent-node `2.5.0-preview.31` / commhub-server `0.9.0-preview.29`）。本段仅保留作 GA-gate 里程碑历史锚点。
+>
 > 最后更新：2026-07-05（北京）· **🟢 GA-gate GREEN (23/23) — GA-ready, 等 Vincent 拍 latest**: agent-network 2.3.0-preview.20 / agent-node 2.5.0-preview.19 / commhub-server 0.9.0-preview.21 / dashboard **0.6.3-preview.9**· Vincent msg9799 自主执行模式。
 > **2026-07-05 dashboard #393 迭代**：Vincent 真机反馈 → 供应商预设目录（DeepSeek/MiniMax/GLM/Claude 选一下 base_url 自动填 + 模型勾选 + 只填 key）已发 **preview.8**，型号修对（DeepSeek v4-pro/flash · MiniMax api.minimaxi.com+M2.7 · Claude opus-4-8/sonnet-5/haiku-4-5）发 **preview.9**（GLM 待 Vincent 给准型号）。**同时把线上 dm.vansin.top 实例从卡死的 preview.4（僵尸占 :3001 崩溃循环 34k 次）救活并升到 preview.9**。dashboard PR #35。
 > **📌 详细滚动进度追踪 → [tracking issue #403](https://github.com/sleep2agi/agent-network/issues/403)**（本 plan 是总文档/spec，详细每步日志记在 issue，二者互链）。

--- a/docs/release/v2.3.0/plan.md
+++ b/docs/release/v2.3.0/plan.md
@@ -27,7 +27,7 @@
 
 ## 进度快照（自主推进中 · 每步滚动更新）
 
-> ⚠️ **本段是 2026-07-05 快照** —— 6 周前的 GA-gate GREEN 状态 + 版本号（`preview.20/.19/.21` / dashboard `preview.9`），**当前 preview 已远超此数字**。真值以 [`docs/plans/release-plan.md`](../../plans/release-plan.md) 里的 `npm view` 表为准（snapshot 2026-08-14: agent-network `2.3.0-preview.39` / agent-node `2.5.0-preview.31` / commhub-server `0.9.0-preview.29`）。本段仅保留作 GA-gate 里程碑历史锚点。
+> ⚠️ **本段是 2026-07-05 快照** —— 6 周前的 GA-gate GREEN 状态 + 版本号（`preview.20/.19/.21` / dashboard `preview.9`），**当前 preview 已远超此数字**。真值以 [`docs/plans/release-plan.md`](../../plans/release-plan.md) 里的 `npm view` 表为准（snapshot 2026-08-17: agent-network `2.3.0-preview.39` / agent-node `2.5.0-preview.31` / commhub-server `0.9.0-preview.29`）。本段仅保留作 GA-gate 里程碑历史锚点。
 >
 > 最后更新：2026-07-05（北京）· **🟢 GA-gate GREEN (23/23) — GA-ready, 等 Vincent 拍 latest**: agent-network 2.3.0-preview.20 / agent-node 2.5.0-preview.19 / commhub-server 0.9.0-preview.21 / dashboard **0.6.3-preview.9**· Vincent msg9799 自主执行模式。
 > **2026-07-05 dashboard #393 迭代**：Vincent 真机反馈 → 供应商预设目录（DeepSeek/MiniMax/GLM/Claude 选一下 base_url 自动填 + 模型勾选 + 只填 key）已发 **preview.8**，型号修对（DeepSeek v4-pro/flash · MiniMax api.minimaxi.com+M2.7 · Claude opus-4-8/sonnet-5/haiku-4-5）发 **preview.9**（GLM 待 Vincent 给准型号）。**同时把线上 dm.vansin.top 实例从卡死的 preview.4（僵尸占 :3001 崩溃循环 34k 次）救活并升到 preview.9**。dashboard PR #35。

--- a/docs/release/versioning-and-compatibility.md
+++ b/docs/release/versioning-and-compatibility.md
@@ -34,11 +34,14 @@ dashboard 跟 commhub 的 REST 契约（C3）要版本约束——纳入本文�
 
 > 每次「一起测过」的组合记一行。装的时候四列尽量取同一行。四个都是 npm 包，dashboard 列也记 npm 版本。
 
+> ⚠️ **前三行是 2026-06 preview 迭代期的历史快照**（数字 `preview.14/.18/.19/.20`，已远早于当前 preview 头）。当前已发布 preview 数字见 [`docs/plans/release-plan.md`](../plans/release-plan.md) 与 `npm view <pkg> dist-tags` 实测；下面单独加一行 **已发布 preview 头（snapshot 2026-08-14）** 作为最新真值参考。
+
 | 组合 | agent-network | agent-node | commhub-server | dashboard | 状态 |
 |------|--------------|-----------|----------------|-----------|------|
-| 当前线上飞书舰队 | 2.3.0-preview.18 | 2.5.0-preview.18 | 0.9.0-preview.14 | 0.6.3-preview.4 | ✅ 实跑中（#383 rescue + Kimi） |
-| 已发布 preview 头 | 2.3.0-preview.19 | 2.5.0-preview.18 | 0.9.0-preview.20 | 0.6.3-preview.4 | ⚠️ 未整体 e2e，agent-node 不含 opencode |
-| 下一发（含 opencode） | 2.3.0-preview.20 | 2.5.0-preview.19 | 0.9.0-preview.20 | 0.6.3-preview.4 | 🔜 待切（见 §6，dashboard 本发不动） |
+| 当前线上飞书舰队（2026-06 快照） | 2.3.0-preview.18 | 2.5.0-preview.18 | 0.9.0-preview.14 | 0.6.3-preview.4 | ✅ 当时实跑中（#383 rescue + Kimi）；生产真机版号请复核 |
+| 已发布 preview 头（2026-06 快照） | 2.3.0-preview.19 | 2.5.0-preview.18 | 0.9.0-preview.20 | 0.6.3-preview.4 | ⚠️ 未整体 e2e，agent-node 不含 opencode |
+| 下一发（2026-06 快照，含 opencode） | 2.3.0-preview.20 | 2.5.0-preview.19 | 0.9.0-preview.20 | 0.6.3-preview.4 | 🔜 待切（见 §6，dashboard 本发不动） |
+| **已发布 preview 头（snapshot 2026-08-14）** | **2.3.0-preview.39** | **2.5.0-preview.31** | **0.9.0-preview.29** | 0.6.3-preview（浮动） | ⚠️ `npm view @preview` 实测；`preview.39` 二进制内嵌 `.d.ts` pair 仍指 `agent-node@2.5.0-preview.28`（main-源码 vs binary 差） |
 | v2.3.0 GA 目标 | 2.3.0 | 2.5.0 | 0.9.0 | 0.7.0（含 #260） | 🎯 整行测绿才升 |
 | latest（稳定线） | 2.2.21 | 2.4.13 | 0.8.8 | 0.6.x | ✅ 旧稳定，无 opencode/无 #383 |
 

--- a/docs/release/versioning-and-compatibility.md
+++ b/docs/release/versioning-and-compatibility.md
@@ -34,14 +34,14 @@ dashboard 跟 commhub 的 REST 契约（C3）要版本约束——纳入本文�
 
 > 每次「一起测过」的组合记一行。装的时候四列尽量取同一行。四个都是 npm 包，dashboard 列也记 npm 版本。
 
-> ⚠️ **前三行是 2026-06 preview 迭代期的历史快照**（数字 `preview.14/.18/.19/.20`，已远早于当前 preview 头）。当前已发布 preview 数字见 [`docs/plans/release-plan.md`](../plans/release-plan.md) 与 `npm view <pkg> dist-tags` 实测；下面单独加一行 **已发布 preview 头（snapshot 2026-08-14）** 作为最新真值参考。
+> ⚠️ **前三行是 2026-06 preview 迭代期的历史快照**（数字 `preview.14/.18/.19/.20`，已远早于当前 preview 头）。当前已发布 preview 数字见 [`docs/plans/release-plan.md`](../plans/release-plan.md) 与 `npm view <pkg> dist-tags` 实测；下面单独加一行 **已发布 preview 头（snapshot 2026-08-17）** 作为最新真值参考。
 
 | 组合 | agent-network | agent-node | commhub-server | dashboard | 状态 |
 |------|--------------|-----------|----------------|-----------|------|
 | 当前线上飞书舰队（2026-06 快照） | 2.3.0-preview.18 | 2.5.0-preview.18 | 0.9.0-preview.14 | 0.6.3-preview.4 | ✅ 当时实跑中（#383 rescue + Kimi）；生产真机版号请复核 |
 | 已发布 preview 头（2026-06 快照） | 2.3.0-preview.19 | 2.5.0-preview.18 | 0.9.0-preview.20 | 0.6.3-preview.4 | ⚠️ 未整体 e2e，agent-node 不含 opencode |
 | 下一发（2026-06 快照，含 opencode） | 2.3.0-preview.20 | 2.5.0-preview.19 | 0.9.0-preview.20 | 0.6.3-preview.4 | 🔜 待切（见 §6，dashboard 本发不动） |
-| **已发布 preview 头（snapshot 2026-08-14）** | **2.3.0-preview.39** | **2.5.0-preview.31** | **0.9.0-preview.29** | 0.6.3-preview（浮动） | ⚠️ `npm view @preview` 实测；`preview.39` 二进制内嵌 `.d.ts` pair 仍指 `agent-node@2.5.0-preview.28`（main-源码 vs binary 差） |
+| **已发布 preview 头（snapshot 2026-08-17）** | **2.3.0-preview.39** | **2.5.0-preview.31** | **0.9.0-preview.29** | 0.6.3-preview（浮动） | ⚠️ `npm view @preview` 实测；`preview.39` 二进制内嵌 `.d.ts` pair 仍指 `agent-node@2.5.0-preview.28`（main-源码 vs binary 差） |
 | v2.3.0 GA 目标 | 2.3.0 | 2.5.0 | 0.9.0 | 0.7.0（含 #260） | 🎯 整行测绿才升 |
 | latest（稳定线） | 2.2.21 | 2.4.13 | 0.8.8 | 0.6.x | ✅ 旧稳定，无 opencode/无 #383 |
 

--- a/docs/runbooks/feishu-channel-ops.md
+++ b/docs/runbooks/feishu-channel-ops.md
@@ -14,8 +14,8 @@
 |---|---|
 | 容器 | `anet-feishu-local`（docker，CMD 靠 entrypoint + `tail -f`） |
 | 节点 alias | `TMWork小助手`（**唯一** feishu 连接；2026-07-01 从 `feishu-local` 改的，见 §12 rename history） |
-| agent-network | `2.3.0-preview.17`（部署时值，含 #362 inbound file download + 官方 #324 图片修复；当前 preview 头 2026-08-14 快照为 `2.3.0-preview.39`，见 [`release-plan.md`](../plans/release-plan.md)） |
-| agent-node | `2.5.0-preview.16`（部署时值；当前 preview 头 2026-08-14 快照为 `2.5.0-preview.31`） |
+| agent-network | `2.3.0-preview.17`（部署时值，含 #362 inbound file download + 官方 #324 图片修复；当前 preview 头 2026-08-17 快照为 `2.3.0-preview.39`，见 [`release-plan.md`](../plans/release-plan.md)） |
+| agent-node | `2.5.0-preview.16`（部署时值；当前 preview 头 2026-08-17 快照为 `2.5.0-preview.31`） |
 | 补丁 | **无**（跑官方发布版） |
 | app | `<cli_...>`（TMWork小助手） |
 | model | `MiniMax-M3`，endpoint `https://api.minimaxi.com/anthropic` |

--- a/docs/runbooks/feishu-channel-ops.md
+++ b/docs/runbooks/feishu-channel-ops.md
@@ -8,14 +8,14 @@
 
 ## 0. TL;DR
 
-飞书 bot = agent-node fork 一个 worker，用飞书 `@larksuiteoapi/node-sdk` 的 **WSClient 长连接**收事件，跑在 **claude-agent-sdk** runtime。当前生产实例：
+飞书 bot = agent-node fork 一个 worker，用飞书 `@larksuiteoapi/node-sdk` 的 **WSClient 长连接**收事件，跑在 **claude-agent-sdk** runtime。当前生产实例（**as-of 2026-07-01 部署快照** — 生产真机版号请到部署机 `docker exec anet-feishu-local anet -v` 复核；本页 IM 运维交接后写死数已过期风险高）：
 
 | 项 | 值 |
 |---|---|
 | 容器 | `anet-feishu-local`（docker，CMD 靠 entrypoint + `tail -f`） |
 | 节点 alias | `TMWork小助手`（**唯一** feishu 连接；2026-07-01 从 `feishu-local` 改的，见 §12 rename history） |
-| agent-network | `2.3.0-preview.17`（含 #362 inbound file download + 官方 #324 图片修复） |
-| agent-node | `2.5.0-preview.16` |
+| agent-network | `2.3.0-preview.17`（部署时值，含 #362 inbound file download + 官方 #324 图片修复；当前 preview 头 2026-08-14 快照为 `2.3.0-preview.39`，见 [`release-plan.md`](../plans/release-plan.md)） |
+| agent-node | `2.5.0-preview.16`（部署时值；当前 preview 头 2026-08-14 快照为 `2.5.0-preview.31`） |
 | 补丁 | **无**（跑官方发布版） |
 | app | `<cli_...>`（TMWork小助手） |
 | model | `MiniMax-M3`，endpoint `https://api.minimaxi.com/anthropic` |


### PR DESCRIPTION
Follow-up to PR #869 (merged 2026-08-17). Doc-only, no behavior changes.

Covers the "独立面" in the task 27faa700 review — the 4 stale-version /
stale-snapshot sites that #869 did not touch (author: 通信文档马 for
通信龙's file-refresh line).

## Version facts (`npm view <pkg> dist-tags` @ 2026-08-17)

|         | latest         | preview                         |
|---------|----------------|---------------------------------|
| agent-network  | 2.2.21   | 2.3.0-preview.39                |
| agent-node     | 2.4.13   | 2.5.0-preview.31                |
| commhub-server | 0.8.8    | 0.9.0-preview.29                |

Numbers unchanged since the 2026-08-14 authoring pass. **These numbers are
snapshots, not promises — the `@preview` and `@latest` tags on npm keep
drifting; re-read via `npm view <pkg> dist-tags` before quoting elsewhere.**

## ⚠️ Precise-pairing caveat (this is the core value of this PR)

`main` 源码 `OPENCODE_AGENT_NODE_VERSION` **leads** the version constants
embedded in already-published `preview.N` binaries.

Concrete: 通信龙 tested 2026-08-17 evening — installed the current
`@preview` (`@sleep2agi/agent-network@2.3.0-preview.39`), and that binary
complained it wanted `@sleep2agi/agent-node@2.5.0-preview.28` — NOT the
`preview.31` that `main` source currently pins. They installed `.28` and
`opencode-指挥狗` came up. (In auto-sync mode, the main-source constant
gets bumped independently of the npm-published artifact, so the two
disagree until the next preview is cut.)

**Every place that says "precise pairing = X + Y" must therefore state
whether that is a "main-source requirement" or an "already-published
binary requirement".** These pages now do:

  - `docs-site/docs/preview/index.md:16` + `docs-site/docs/en/preview/index.md:16`
    — section heading was hardcoded `2.3.0-preview.34 / 2.5.0-preview.26,
    2026-07-16`; replaced with `snapshot 2026-08-17` + a paragraph that
    (a) names the 2026-08-17 numbers, (b) labels them "main-source
    requirement", and (c) notes the embedded `.d.ts` pair in `preview.39`
    still names `agent-node preview.28`.
  - `docs/release/versioning-and-compatibility.md:37-45` — added a new
    "已发布 preview 头 (snapshot 2026-08-17)" row with the same caveat.

## Per-file changes (5 files, +17 -8)

### 1. `docs-site/docs/preview/index.md:16` + `docs-site/docs/en/preview/index.md:16`
Section heading `## 当前 preview = canonical (2.3.0-preview.34 / 2.5.0-preview.26，2026-07-16)`
was 6 weeks stale AND readers copy from it. Now `## 当前 preview channel
canonical build（snapshot 2026-08-17）` + one paragraph carrying the real
2026-08-17 numbers, the main-source-vs-published-binary caveat, and the
`@preview` tag install reminder. English mirrored.

### 2. `docs/release/v2.3.0/plan.md:30`
GA-gate GREEN snapshot from 2026-07-05 quoted `preview.20 / .19 / .21` +
dashboard `preview.9` — 6 weeks stale. Added one warning line above the
`最后更新` block pointing at `release-plan.md` as live source with the
2026-08-17 numbers. The `2026-07-05` line kept intact for GA-gate
milestone history.

### 3. `docs/release/versioning-and-compatibility.md:37-45`
Compatibility matrix's first three rows quoted `preview.14 / .18 / .19 /
.20` fleet snapshots. Prepended a warning line saying these are 2026-06
historical snapshots, renamed each of the three rows to append `(2026-06
快照)`, and added one new row `已发布 preview 头 (snapshot 2026-08-17)`
with the real numbers + Fact-1 pairing caveat. `latest (稳定线)` and
`v2.3.0 GA 目标` rows unchanged (still correct).

### 4. `docs/runbooks/feishu-channel-ops.md:11-18`
Runbook TL;DR quoted deployed feishu-bot as `agent-network preview.17 /
agent-node preview.16` — these are deployment-time values (owner is
now 通信IM马, not me), so kept literal but appended `(部署时值; 当前 preview
头 2026-08-17 快照为 preview.39 / preview.31, 见 release-plan.md)` to
each row, plus a section-header note directing the operator to run
`docker exec anet-feishu-local anet -v` to verify actual deployed
version. No live probe by this PR — only added the recipe.

## Not touched here (Q2 段行为句缺版本, 单独任务追)

The Q2 pass found 18 behavior-sentence lines missing a `since v X` anchor
(e.g. `README.md:50` 一次性随机密码, `getting-started.md:97` "当前版本"
without a version). Each needs `git log -S` to nail the exact preview.N.
Highest-priority two (README:50 password + getting-started:97 + issue
#450) are already scheduled and will land in a follow-up PR — this PR
does not touch them so it stays reviewable.

Also NOT touched: `docs/RELEASE-SOP.md:232 / :243` (SOP internal, owner
decides wording), `docs/grok-build-runtime.md:111 (v0.10.11 anchor)`
(Q2 item 16, will land with the follow-up).

## New facts from 通信龙 2026-08-17 that this PR does NOT yet document

**PR #895 fixed `anet node start` false-`✅` bug**; **PR #896 fixed
`anet project up / project restart` exit-code lie**. Both merged into
main. **Neither has been cut into an npm release yet** — so for anyone
on `@preview` (currently `2.3.0-preview.39`), the trap still exists:
`exit 0` + stdout `✅` does NOT mean the node started. Real check:
`tmux has-session -t "=<alias>"` (the `=` is required — bare alias is
prefix match). This will be added to `README.md`, `docs-site/docs/deploy/clean-server.md`,
etc. in the follow-up PR, worded to make clear #895 / #896 are in main
but not yet in npm.

## Verification

- `git diff origin/main...HEAD --stat` — 5 files, +17 -8 as above; rebased
  cleanly onto `6c58a9ab` (`#869` merge commit), no conflicts.
- `git grep 2026-08-14` on the 5 touched files: 0 hits post-bump.
- `git grep 2026-08-17` on the 5 touched files: 9 hits (all authored here).