### PR TITLE
fix(docs,ci): 修 W19 编码与死链、给矛盾耗时标条件、把两个没人调的验证脚本挂上

### DIFF
--- a/.github/scripts/check-docs-integrity.py
+++ b/.github/scripts/check-docs-integrity.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Two kinds of silent rot in tracked Markdown: unreadable bytes and dead links.
+
+Both were live in docs/qa/weekly/2026-W19.md on 2026-08-17:
+
+  * three multi-byte characters truncated mid-sequence, so the file could not be
+    decoded as UTF-8 at all. Every reader's tool renders that as a replacement
+    glyph or an error, and the three damaged sentences each lost their last
+    character. The damage pattern (`_italic text_` with the character before the
+    closing `_` eaten) suggests a truncating edit, not a bad encoding.
+  * all 24 relative links resolved to paths that do not exist — the file sits
+    three levels deep and the links were written for two, so every one of them
+    pointed inside docs/ instead of at the repo root.
+
+Neither shows up in a build: Markdown has no compiler, so a dead link and a live
+one look the same until a reader clicks. Both are cheap to check mechanically.
+
+Scope is deliberately narrow and stated: UTF-8 validity across every tracked
+.md, link resolution for docs/qa/** only (where the defect was found). Widening
+the link check to all docs is a separate decision — some files link to generated
+or gitignored paths, and a guard that cries wolf gets disabled.
+
+Fail-closed: an empty file list exits 2 rather than reporting a clean run.
+"""
+import os
+import re
+import subprocess
+import sys
+
+RELATIVE_LINK = re.compile(r"\]\((\.{1,2}/[^)\s]*)")
+LINK_SCOPE = "docs/qa"
+
+
+def tracked(pathspec: str) -> list[str]:
+    out = subprocess.run(["git", "ls-files", pathspec], capture_output=True, text=True)
+    return [f for f in out.stdout.split("\n") if f.endswith(".md")]
+
+
+def main() -> int:
+    md = tracked("*.md")
+    if not md:
+        print("::error::git ls-files '*.md' returned nothing — scope regression, refusing to pass")
+        return 2
+
+    problems = 0
+
+    # 1. Every tracked .md must decode as UTF-8.
+    for f in md:
+        try:
+            open(f, "rb").read().decode("utf-8")
+        except UnicodeDecodeError as e:
+            problems += 1
+            print(f"::error file={f}::not valid UTF-8 at byte {e.start} ({e.reason}). "
+                  f"A truncated multi-byte character renders as a replacement glyph for "
+                  f"every reader and silently drops text.")
+        except OSError as e:
+            problems += 1
+            print(f"::error file={f}::cannot read: {e}")
+
+    # 2. Relative links inside the scoped subtree must resolve.
+    scoped = [f for f in md if f.startswith(LINK_SCOPE + "/")]
+    if not scoped:
+        print(f"::error::no tracked .md under {LINK_SCOPE}/ — scope regression, refusing to pass")
+        return 2
+
+    links = 0
+    for f in scoped:
+        body = open(f, encoding="utf-8", errors="replace").read()
+        base = os.path.dirname(f)
+        for target in RELATIVE_LINK.findall(body):
+            links += 1
+            resolved = os.path.normpath(os.path.join(base, target.split("#")[0]))
+            if not os.path.exists(resolved):
+                problems += 1
+                print(f"::error file={f}::relative link '{target}' resolves to "
+                      f"'{resolved}', which does not exist")
+
+    print(f"checked {len(md)} tracked .md for UTF-8 validity; "
+          f"{links} relative link(s) across {len(scoped)} file(s) under {LINK_SCOPE}/")
+
+    if problems:
+        print(f"\n{problems} problem(s).")
+        return 1
+    print("no problems.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -1,0 +1,44 @@
+# Catch the two kinds of Markdown rot that no build step can see.
+#
+# On 2026-08-17, docs/qa/weekly/2026-W19.md had three multi-byte characters
+# truncated mid-sequence (the file would not decode as UTF-8 at all, and each
+# damaged sentence silently lost its last character) and all 24 of its relative
+# links resolved to paths that do not exist — the file sits three levels deep
+# and the links were written for two.
+#
+# Markdown has no compiler, so a dead link and a live one render the same until
+# a reader clicks. Both problems are mechanical to detect and were invisible to
+# every existing gate.
+#
+# Starts green: after the repair, all 359 tracked .md files decode cleanly and
+# all 80 relative links under docs/qa/ resolve. This is deliberately not a
+# backlog canary — it only reddens on new damage, so a red here always means
+# something just broke rather than something is still on the pile.
+#
+# Scope note (stated because a filter you cannot see is a filter you cannot
+# trust): UTF-8 validity is checked across EVERY tracked .md; link resolution is
+# checked for docs/qa/** only, where the defect was found. Widening the link
+# check repo-wide is a separate call — some pages link to generated or ignored
+# paths, and a guard that cries wolf gets turned off.
+
+name: lint (docs integrity)
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/scripts/check-docs-integrity.py'
+      - '.github/workflows/docs-integrity.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - '.github/scripts/check-docs-integrity.py'
+      - '.github/workflows/docs-integrity.yml'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 .github/scripts/check-docs-integrity.py

--- a/.github/workflows/published-artifact-drift.yml
+++ b/.github/workflows/published-artifact-drift.yml
@@ -1,0 +1,75 @@
+# Run the two verifiers that already existed and that nothing called.
+#
+# scripts/verify-published-pins.sh and scripts/verify-release-tag.sh were both
+# committed, both executable, both documented with the incident that motivated
+# them — and `grep -rl` across .github/ and scripts/ found ZERO callers. A guard
+# that is never invoked protects nothing, and its presence in the tree reads as
+# if the risk were covered.
+#
+# Running verify-published-pins.sh by hand on 2026-08-17, for the first time,
+# reported a live drift on its first invocation:
+#
+#   ❌ OPENCODE_AGENT_NODE_VERSION 期望 2.5.0-preview.31,
+#      产物里是: 2.5.0-preview.28
+#   1 个 pin 与已发布产物不一致 —— main 修了但用户装到的包没修
+#
+# That is the exact distinction the script's own header says bit this repo three
+# times in one day, and it had been sitting undetected in the published preview.
+#
+# Why scheduled rather than per-PR: it inspects the PUBLISHED artifact, which a
+# PR does not change, and it needs the npm registry. Running it on every PR
+# would add a network dependency to every merge while telling us nothing new
+# about the PR. Once a day plus manual dispatch matches what it measures.
+#
+# 🔴 Exit codes are mapped deliberately, because "could not measure" and
+#    "measured and it is fine" must not collapse into the same green:
+#      0 → pass
+#      1 → fail (real drift)
+#      2 → fail-soft with a loud notice (registry unreachable — NOT evidence of
+#          agreement; the run reports that it could not measure)
+#      3 → fail (zero pins compared — the script went blind)
+
+name: published artifact drift
+
+on:
+  schedule:
+    # 03:17 UTC. Off the hour and off :00/:30 so this repo does not pile onto
+    # the same minute as every other scheduled job on the runners.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/verify-published-pins.sh'
+      - 'scripts/verify-release-tag.sh'
+      - '.github/workflows/published-artifact-drift.yml'
+
+jobs:
+  published-pins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: verify published pins match source
+        run: |
+          set +e
+          bash scripts/verify-published-pins.sh preview
+          rc=$?
+          set -e
+          case "$rc" in
+            0) echo "pins agree with the published preview artifact." ;;
+            2) echo "::warning::could not fetch the published artifact (rc=2). This run"\
+                    "did NOT verify anything — treat it as unknown, not as agreement." ; exit 1 ;;
+            3) echo "::error::the verifier compared ZERO pins (rc=3) — it went blind." ; exit 1 ;;
+            *) echo "::error::published artifact drifted from source (rc=$rc)." ; exit 1 ;;
+          esac
+
+  release-tag:
+    # Only meaningful when a tag is what triggered us, or on demand.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: verify release tags point at the commit they were built from
+        run: bash scripts/verify-release-tag.sh

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -6,11 +6,21 @@
 ## 一键跑
 
 ```bash
-bash scripts/qa.sh           # L0 + L1 全跑 (~16s warm)
+bash scripts/qa.sh           # L0 + L1 全跑
 bash scripts/qa.sh --l0      # 只跑 L0 单测 (~0.1s)
-bash scripts/qa.sh --l1      # 只跑 L1 contract 测试 (~16s)
+bash scripts/qa.sh --l1      # 只跑 L1 contract 测试
 bash scripts/qa.sh --list    # 列测试名 + 文件路径
 ```
+
+> **关于耗时**:本页此前写「~16s warm」,`v0-summary.md` 写「本地一键 ~93s」,
+> 而 `v0-summary.md` 自己那张逐条表加起来是 **156s**。三个数字都没说明自己量的是
+> 什么条件,所以谁都不能拿来对照。已把死数字去掉 —— **要知道现在多久,就跑一次**:
+>
+> ```bash
+> time bash scripts/qa.sh          # 你这台机、这个 Docker 缓存状态下的真实耗时
+> ```
+>
+> 156s 是**逐条串行相加**;低于它的墙钟数意味着有并行。冷启动(需要拉镜像)会显著更久。
 
 退出码：`0` 全过；`1` 至少一个 fail；`2` 环境问题（docker 不可用等）。
 

--- a/docs/qa/strategy.md
+++ b/docs/qa/strategy.md
@@ -47,7 +47,7 @@
 
 | 档 | 触发点 | 跑什么 | 阻塞合并？ | 状态 |
 |----|--------|--------|-----------|------|
-| **1** | PR + push to main（路径过滤） | `bash scripts/qa.sh` = L0 + L1（~16s warm，GH Actions ~1-2min 含 setup） | **否，仅报告** | ✅ R8 上线 [.github/workflows/qa.yml](../../.github/workflows/qa.yml) |
+| **1** | PR + push to main（路径过滤） | `bash scripts/qa.sh` = L0 + L1（耗时随机器与 Docker 缓存状态变化，跑 `time bash scripts/qa.sh` 实测；GH Actions ~1-2min 含 setup） | **否，仅报告** | ✅ R8 上线 [.github/workflows/qa.yml](../../.github/workflows/qa.yml) |
 | 2 | 主路径文件变更（auth.ts / db.ts / cli.ts） | L0 + L1 contract | 否（先观察稳定性） | 未启用，待 R10+ |
 | 3 | Release tag | 全套 L0+L1+L2+L3 | **是** | 未启用，等本地稳了再谈 |
 

--- a/docs/qa/v0-summary.md
+++ b/docs/qa/v0-summary.md
@@ -7,7 +7,7 @@
 
 **16 条 R 系列 QA 测试 + CI workflow 上线 + 11 条 SDK 设计 finding 抠出。**
 3 persona 用户视角包圆（CLI / commhub / dashboard），1 persona 用户视角 4/6（agent-node），代码视角 3/5。
-本地一键跑 ~93s，CI ~40s。不改任何业务代码。
+本地一键跑 ~93s（**2026-05 首次测量的墙钟值**；下面逐条表串行相加是 156s，差额来自并行。你这台机上的真值跑 `time bash scripts/qa.sh`），CI ~40s。不改任何业务代码。
 
 ## 测试库（16 条 R 系列 + 历史保护资产）
 

--- a/docs/qa/weekly/2026-W19.md
+++ b/docs/qa/weekly/2026-W19.md
@@ -1,6 +1,6 @@
 # anet QA 周报 — 2026-05-12 11:45 UTC
 
-_自动生成 by [scripts/qa-status.sh](../../scripts/qa-status.sh)_
+_自动生成 by [scripts/qa-status.sh](../../../scripts/qa-status.sh)_
 
 ## 测试库当前状态
 
@@ -12,43 +12,43 @@ _自动生成 by [scripts/qa-status.sh](../../scripts/qa-status.sh)_
 
 ## L0 单测列表
 
-- `auth-tokens` — 25 expect call(s) — [server/src/auth-tokens.test.ts](../../server/src/auth-tokens.test.ts)
-- `auth-validate` — 23 expect call(s) — [server/src/auth-validate.test.ts](../../server/src/auth-validate.test.ts)
-- `password-dict` — 15 expect call(s) — [server/src/password-dict.test.ts](../../server/src/password-dict.test.ts)
+- `auth-tokens` — 25 expect call(s) — [server/src/auth-tokens.test.ts](../../../server/src/auth-tokens.test.ts)
+- `auth-validate` — 23 expect call(s) — [server/src/auth-validate.test.ts](../../../server/src/auth-validate.test.ts)
+- `password-dict` — 15 expect call(s) — [server/src/password-dict.test.ts](../../../server/src/password-dict.test.ts)
 
 ## L1 contract 测试列表
 
-- `qa-cli-01-hub-start` — [tests/qa-cli-01-hub-start/](../../tests/qa-cli-01-hub-start/)
+- `qa-cli-01-hub-start` — [tests/qa-cli-01-hub-start/](../../../tests/qa-cli-01-hub-start/)
   _banner / port / 凭证文件落地 / 幂等性 任一坏都让新用户卡住。_
-- `qa-cli-02-network-create` — [tests/qa-cli-02-network-create/](../../tests/qa-cli-02-network-create/)
+- `qa-cli-02-network-create` — [tests/qa-cli-02-network-create/](../../../tests/qa-cli-02-network-create/)
   _- 非交互登录（`--username/--password`）_
-- `qa-dash-07-auth-boundary` — [tests/qa-dash-07-auth-boundary/](../../tests/qa-dash-07-auth-boundary/)
+- `qa-dash-07-auth-boundary` — [tests/qa-dash-07-auth-boundary/](../../../tests/qa-dash-07-auth-boundary/)
   _攻击者可以 curl 直接打 hub。这条测试枚举 dashboard 调的所有端点 + SSE + MCP，_
-- `qa-dash-08-cross-account-views` — [tests/qa-dash-08-cross-account-views/](../../tests/qa-dash-08-cross-account-views/)
-  _[R17 HUB-06b](../qa-hub-06b-cross-user-isolation/) 覆盖了 `/api/networks` `/api/tasks`（无 filt_
-- `qa-dash-10-incremental-poll` — [tests/qa-dash-10-incremental-poll/](../../tests/qa-dash-10-incremental-poll/)
+- `qa-dash-08-cross-account-views` — [tests/qa-dash-08-cross-account-views/](../../../tests/qa-dash-08-cross-account-views/)
+  _[R17 HUB-06b](../../../tests/qa-hub-06b-cross-user-isolation/) 覆盖了 `/api/networks` `/api/tasks`（无 filt_
+- `qa-dash-10-incremental-poll` — [tests/qa-dash-10-incremental-poll/](../../../tests/qa-dash-10-incremental-poll/)
   _所以 dashboard 实际用增量轮询：每隔 N 秒打 `?since=<lastseen>` 拿新数据。_
-- `qa-hub-05-roundtrip` — [tests/qa-hub-05-roundtrip/](../../tests/qa-hub-05-roundtrip/)
-- `qa-hub-06b-cross-user-isolation` — [tests/qa-hub-06b-cross-user-isolation/](../../tests/qa-hub-06b-cross-user-isolation/)
+- `qa-hub-05-roundtrip` — [tests/qa-hub-05-roundtrip/](../../../tests/qa-hub-05-roundtrip/)
+- `qa-hub-06b-cross-user-isolation` — [tests/qa-hub-06b-cross-user-isolation/](../../../tests/qa-hub-06b-cross-user-isolation/)
   _即使 bob 知道 alice 的 networkid（IDOR），也不能直接调 alice 的 API。_
-- `qa-hub-06-token-revoke` — [tests/qa-hub-06-token-revoke/](../../tests/qa-hub-06-token-revoke/)
+- `qa-hub-06-token-revoke` — [tests/qa-hub-06-token-revoke/](../../../tests/qa-hub-06-token-revoke/)
   _派生 token 是否随母 token 失效，是 fleet-management 类工具的核心契约。_
-- `qa-hub-07-sse-reconnect` — [tests/qa-hub-07-sse-reconnect/](../../tests/qa-hub-07-sse-reconnect/)
-  _这个测试 pin 关键契约：「断开期间的任务不能丢」—— 通过 getinbox 拿，�_
-- `qa-hub-08-restart-persistence` — [tests/qa-hub-08-restart-persistence/](../../tests/qa-hub-08-restart-persistence/)
+- `qa-hub-07-sse-reconnect` — [tests/qa-hub-07-sse-reconnect/](../../../tests/qa-hub-07-sse-reconnect/)
+  _这个测试 pin 关键契约：「断开期间的任务不能丢」—— 通过 getinbox 拿，⟨原文此处被截断:1 个多字节字符不完整,内容不可恢复 —— 标注于 2026-08-17⟩_
+- `qa-hub-08-restart-persistence` — [tests/qa-hub-08-restart-persistence/](../../../tests/qa-hub-08-restart-persistence/)
   _这条测试 pin 三个持久化契约：session 行、inbox/task 行、ntok 验证。_
-- `qa-hub-09-task-state-machine` — [tests/qa-hub-09-task-state-machine/](../../tests/qa-hub-09-task-state-machine/)
-  _- `replied` 分支：[NODE-02](../qa-node-02-success-reply/) R6 已测_
-- `qa-node-02-success-reply` — [tests/qa-node-02-success-reply/](../../tests/qa-node-02-success-reply/)
-  _但成功路径（status=replied + result 文本回填）没单独测。真 LLM 烧钱不可取�_
-- `qa-node-03b-task-events` — [tests/qa-node-03b-task-events/](../../tests/qa-node-03b-task-events/)
+- `qa-hub-09-task-state-machine` — [tests/qa-hub-09-task-state-machine/](../../../tests/qa-hub-09-task-state-machine/)
+  _- `replied` 分支：[NODE-02](../../../tests/qa-node-02-success-reply/) R6 已测_
+- `qa-node-02-success-reply` — [tests/qa-node-02-success-reply/](../../../tests/qa-node-02-success-reply/)
+  _但成功路径（status=replied + result 文本回填）没单独测。真 LLM 烧钱不可取⟨原文此处被截断:1 个多字节字符不完整,内容不可恢复 —— 标注于 2026-08-17⟩_
+- `qa-node-03b-task-events` — [tests/qa-node-03b-task-events/](../../../tests/qa-node-03b-task-events/)
   _「这个 task 经历了什么、谁动的」。之前完全没人测。_
-- `qa-ut-01-auth-tokens` — [tests/qa-ut-01-auth-tokens/](../../tests/qa-ut-01-auth-tokens/)
-  _[R5 (HUB-06)](../qa-hub-06-token-revoke/) 在 E2E 层覆盖了撤销，但生成/解析的形�_
-- `qa-ut-02-password-dict` — [tests/qa-ut-02-password-dict/](../../tests/qa-ut-02-password-dict/)
+- `qa-ut-01-auth-tokens` — [tests/qa-ut-01-auth-tokens/](../../../tests/qa-ut-01-auth-tokens/)
+  _[R5 (HUB-06)](../../../tests/qa-hub-06-token-revoke/) 在 E2E 层覆盖了撤销，但生成/解析的形⟨原文此处被截断:1 个多字节字符不完整,内容不可恢复 —— 标注于 2026-08-17⟩_
+- `qa-ut-02-password-dict` — [tests/qa-ut-02-password-dict/](../../../tests/qa-ut-02-password-dict/)
   _补一层 ms 级单测，PR 改 dict 文件能秒拦截 regression — 不必等慢的 E2E 跑完。_
-- `qa-ut-03-auth-validate` — [tests/qa-ut-03-auth-validate/](../../tests/qa-ut-03-auth-validate/)
-  _[test30 step 3](../test30-v0.8-auth-deprecation) E2E 只测 2 个弱密码，UT-03 测 14+ 个 + 边_
+- `qa-ut-03-auth-validate` — [tests/qa-ut-03-auth-validate/](../../../tests/qa-ut-03-auth-validate/)
+  _[test30 step 3](../../../tests/test30-v0.8-auth-deprecation) E2E 只测 2 个弱密码，UT-03 测 14+ 个 + 边_
 
 ## 累计抠出的 SDK 设计 finding
 


### PR DESCRIPTION
四条来自 open issue 分诊,每条都先在 `origin/main` 核实过。**其中两条比 issue 说的更大。**

## 1. `docs/qa/weekly/2026-W19.md` 根本不能按 UTF-8 解码(#887)

被截断的多字节字符是 **3 个,不是 1 个**。issue 报了第一处;修好第一处才露出第二处,修好第二处才露出第三处。

损坏形状高度一致 —— 每一处都是 `_斜体文字_`,被吃掉的是**闭合 `_` 之前的最后一个字**。这指向一次截断式编辑,不是编码问题。

**丢掉的字不可恢复,所以我标注而不猜。** 这是 QA 周报,编一个「看起来合理」的字比承认少了一个字更糟。

## 2. …而它那 24 条相对链接**全部**是死的(#872)

不是「有几条打错了」:**0/24 能解析**。文件在三层深,链接是按两层写的,所以每个 `../../` 都落在 `docs/` 里而不是仓根;另有 4 条用单层 `../` 指向实际在 `tests/` 下的目录。

现在 **24/24 全部解析成功** —— 是把每一条拿去和文件系统对了一遍,不是看 diff 觉得对。

## 3. `docs/qa` 的耗时数字自相矛盾,而且是**三个**方向(#871)

```
docs/qa/README.md          ~16s warm
docs/qa/strategy.md        ~16s warm
docs/qa/v0-summary.md      ~93s 本地, ~40s CI
v0-summary 自己那张逐条表,加起来:   156s
```

issue 说「统一成一个」。**一个都不能选** —— 因为**没有任何一个说明自己量的是什么条件**:warm 还是 cold、串行还是并行、哪台机器。156s 串行对上 93s 墙钟,只说明有并行而没人写下来。

所以 README 和 strategy 里的死数字删掉,换成 `time bash scripts/qa.sh`,外加唯一一条一直成立的事实:**逐条表串行相加是 156s,低于它的墙钟数意味着有并行,冷启动会更久**。v0-summary 保留 93s,但标明是 **2026-05 的一次测量**。

## 4. `verify-published-pins.sh` 和 `verify-release-tag.sh` 零调用者(#862)

两个都已提交、都可执行、头部都写着「为什么需要它」和当初的事故 —— 而 `grep -rl` 扫 `.github/` 和 `scripts/`,**一个调用者都没有**。**一道没人调的门保护不了任何东西**,而它躺在仓里读起来像「这个风险已经有人管了」。

**我把 `verify-published-pins.sh` 手工跑了第一次,它第一次运行就失败了**:

```
❌ OPENCODE_AGENT_NODE_VERSION 期望 2.5.0-preview.31,
   产物里是: 2.5.0-preview.28
1 个 pin 与已发布产物不一致 —— main 修了但用户装到的包没修
```

**这正是它自己头部写的那条「一天之内咬了三次」的区分**,活在已发布的 preview 里、没被发现。(同一晚我手工独立确认过:装 preview.39 时它自己要求 `agent-node preview.28`,而 main 源码常量写的是 `preview.31`。)

现在改为**每日定时 + 手动触发**,并且**退出码是刻意映射的**,好让「量不到」不跟「量过了没问题」collapse 成同一个绿:

| rc | 含义 | 处理 |
|---|---|---|
| 0 | pin 一致 | pass |
| 1 | 真漂移 | fail |
| 2 | 取不到产物(registry 不可达) | **fail 并打 notice 说明「这次什么都没验证」** |
| 3 | 比较了零个 pin(脚本瞎了) | fail |

不做 per-PR:它检查的是**已发布产物**,而 PR 不改变已发布产物;每个 PR 都跑只会给合并加一个网络依赖,却说不出关于这个 PR 的任何新信息。

## 给前两条加一道门

`.github/scripts/check-docs-integrity.py` 检查**全部 tracked `.md`** 的 UTF-8 合法性,以及 `docs/qa/**` 的相对链接可解析性。三种行为都实测过:

| 输入 | 退出码 | 输出 |
|---|---|---|
| 修好的树 | **0** | `checked 359 tracked .md; 80 relative link(s) across 6 file(s)` |
| `f565e9b8` 的 W19 | **1** | 25 条 `::error` 逐条指名 |
| `LINK_SCOPE` 指向不存在的目录 | **2** | `scope regression, refusing to pass` |

**它从第一天就是绿的**,所以不是靠积压撑红的那种门 —— 这里一旦红,一定是刚坏的。链接检查只覆盖 `docs/qa/` 并且**明说**:别处有页面链接到生成物路径,而一道会乱叫的门最后会被关掉。
