### PR TITLE
docs(refresh): Q2 anchors — random password + #450 + Fact-2 (#895/#896) notes

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -41,13 +41,17 @@ anet node create my-bot
 anet node start my-bot
 ```
 
-Verify: `curl http://127.0.0.1:9200/health` should return JSON containing `"ok":true`.
+Verify the Hub is up: `curl http://127.0.0.1:9200/health` should return JSON containing `"ok":true`.
+
+> **⚠️ Check that the node really started — don't rely on `anet node start`'s stdout `✅`**: `exit 0` plus a printed `✅ node "…" started detached (tmux session live)` does **not** mean the node came up. On **versions predating [#895](https://github.com/sleep2agi/agent-network/pull/895)** (including today's npm `@preview` = `2.3.0-preview.39`; **#895 has landed on `main` but is not yet released to npm**) the detached path can lie. Real check: `tmux has-session -t "=<alias>"` returns 0 (**the `=` is required** — a bare alias is a prefix match and can go green on the wrong session). For bulk launches use `anet project up`; its exit code is trustworthy since [#896](https://github.com/sleep2agi/agent-network/pull/896) (also awaiting an npm release).
 
 Open `http://localhost:3000` and dispatch work from the Dashboard.
 
 The default administrator account is `admin` / `anethub`. **Any public deployment must run `anet passwd` immediately after login** — otherwise anyone who scans the port can walk in.
 
-> Preview builds (`@preview`) behave differently: the first `anet hub start` prints a one-time random password. It is shown once, so save it right then.
+> **Since `@sleep2agi/agent-network@2.2.22-preview.4`** (2026-06-28, PR [#264](https://github.com/sleep2agi/agent-network/pull/264) fixing [#261](https://github.com/sleep2agi/agent-network/issues/261) P0-2), preview builds print a **one-time random password** on the first `anet hub start` — shown once (save it right then); the first login forces a password change.
+>
+> **The stable `@latest` (currently `2.2.21`) and older `preview ≤ 2.2.22-preview.3` still ship with the fixed default `admin` / `anethub`** — run `anet passwd` right after logging in.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,17 @@ anet node create my-bot
 anet node start my-bot
 ```
 
-验证：`curl http://127.0.0.1:9200/health` 返回的 JSON 应包含 `"ok":true`。
+验证 Hub 起来了：`curl http://127.0.0.1:9200/health` 返回的 JSON 应包含 `"ok":true`。
+
+> **⚠️ 判断节点真起来 —— 别只看 `anet node start` 的 stdout `✅`**：`exit 0` + 打印 `✅ node "…" started detached (tmux session live)` **不代表节点真起来**。**含 [#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本**（包括当前 npm `@preview` = `2.3.0-preview.39`；**#895 已合入 main 但尚未发 npm**）在 detached 场景可能假报。真判据：`tmux has-session -t "=<alias>"` 返回 0（**`=` 必须**，裸名字是前缀匹配会误报绿）。批量场景用 `anet project up`，其退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信（同样待 npm 发布）。
 
 打开 `http://localhost:3000`，从 Dashboard 给 Agent 派任务。
 
 默认管理员用户名是 `admin`，初始密码是 `anethub`。**任何公网部署都必须登录后立即运行 `anet passwd` 改密**，否则被扫到端口就能进。
 
-> 预览版（`@preview`）行为不同：首次 `anet hub start` 会打印一次性随机密码，只显示这一次，请当场保存。
+> **自 `@sleep2agi/agent-network@2.2.22-preview.4`**（2026-06-28, PR [#264](https://github.com/sleep2agi/agent-network/pull/264) 修 [#261](https://github.com/sleep2agi/agent-network/issues/261) P0-2）**起**，预览版 `@preview` 首次 `anet hub start` 打印**一次性随机密码**（只显示这一次，请当场保存；首次登录会强制改密）。
+>
+> **stable `@latest`（当前 `2.2.21`）与更早的 preview `≤ 2.2.22-preview.3` 仍是固定默认 `admin` / `anethub`** —— 登录后必须立即 `anet passwd`。
 
 ## 能做什么
 

--- a/docs-site/docs/deploy/clean-server.md
+++ b/docs-site/docs/deploy/clean-server.md
@@ -296,6 +296,10 @@ anet 暂未 ship 官方 `--daemon` flag，下面给两条可选路径：tmux 临
 - 每个节点: `tmux new -s anet-<alias>` + `anet node start <alias>`
 - 想接 `@reboot` crontab 也行，但 PATH / nvm 这些非交互 shell 问题要先解决（见 [第 0 节 nvm 提示](#_0-前置)）
 
+::: tip 复核节点真起来 —— 别只看 stdout ✅
+起完每个节点跑一条：`tmux has-session -t "=<alias>"; echo $?` 应输出 `0`（**`=` 必须**，裸名字是前缀匹配会命中别的 session 假报绿）。**[#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本**（含当前 npm `@preview` = `2.3.0-preview.39`；**#895 已合入 main, 未发 npm**）在 detached 场景可能打 `✅ started detached (tmux session live)` `exit 0` 但 tmux 里没进程。批量起用 `anet project up`，退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信（同样待 npm 发布）。
+:::
+
 ### 7.2 systemd unit（生产 / 开机自启）
 
 下面这套 unit 文件**未经官方测试**、按你的实际 `node` 路径（`which anet`）+ 运行用户改一下就能用。改完跑 `systemctl daemon-reload` + `enable --now`。
@@ -367,7 +371,8 @@ sudo systemctl status anet-hub anet-node@my-bot
 | 2 | `anet node create` 选完 runtime → `FATAL: TypeError: fetch failed` | 建节点要连本地 hub，但 hub 没起（多半因为坑 1） | 另开终端先 `anet hub start`，再回这条重试。**[#237](https://github.com/sleep2agi/agent-network/issues/237)** 主条跟进给 fetch 分类报错 |
 | 3 | 一路 Enter 落到要填 vendor + API Key 的复杂路径 | runtime 菜单默认高亮 `claude-agent-sdk`，不是最易上手的 `claude-code-cli` | 建节点时**手动选 `claude-code-cli`**（已 `claude auth login` 直接复用订阅）。中断 vendor 选择如果留下半成品节点，用 `anet node delete <alias>` 清掉重来 |
 | 4 | 建完节点 Telegram 不工作，但向导开头说"optional Telegram channel" | 向导根本不问 Telegram，那行是误导文案 | Telegram 用 `anet channel add telegram <node> --bot-token <tok> --allow <uid>` 单独配（见 [第 6 节](#_6-配-telegram-channel-可选)） |
-| 5 | `anet node start` (codex-sdk / claude-agent-sdk) → `agent-node is not installed or cannot report a version` | npx 懒加载没拉到 `@sleep2agi/agent-node` | `npm i -g @sleep2agi/agent-node`；然后 `agent-node --version` 应输出 |
+| 5 | `anet node start` (codex-sdk / claude-agent-sdk) → `agent-node is not installed or cannot report a version` | npx 懒加载没拉到 `@sleep2agi/agent-node`；bug 存于 `@latest` (2.2.21) 与 preview ≤ 2.3.0-preview.37 | 短路: `npm i -g @sleep2agi/agent-node` 让二进制就位；长期: 升到 `@sleep2agi/agent-network@preview`（含 [PR #239](https://github.com/sleep2agi/agent-network/pull/239) fix, `1eff3a4d`, 2026-06-28）。issue [#450](https://github.com/sleep2agi/agent-network/issues/450) 仍 open —— 待 4 项 gate 后 promote latest |
+| 5.5 | `anet node start` 打 `✅ started detached (tmux session live)` `exit 0`，但 `tmux ls` 找不到 session、进程也不在 | detached 路径的假绿 bug；存于含 [#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本，含 npm `@preview` = `2.3.0-preview.39`（**#895 已合 main 未发 npm**） | 真判据: `tmux has-session -t "=<alias>"; echo $?` 应输 `0`（`=` 必须）。批量场景用 `anet project up`（退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信，同待 npm 发布）。装含 fix 的构建前，用 has-session 复核每次启动 |
 | 6 | `claude-code-cli` 节点起来后卡 offline / pane 卡在确认框 | Claude Code 的 `--dangerously-load-development-channels` 确认框等人按 Enter | 用 tmux 前台跑一次手动按 `1` + Enter；后续就不弹了 |
 | 7 | systemd / cron / 新用户启动报一连串 `command not found` | nvm + Bun 各自按用户装，非交互 shell 不加载 | 把 node/npm/bun 软链到 `/usr/local/bin/`，或启动脚本里显式 `source ~/.nvm/nvm.sh` |
 | 8 | 机器重启全部掉线 | hub + 节点都靠手动 tmux 挂着 | 配 systemd 开机自启，参考 [§7.2 systemd unit](#_7-2-systemd-unit-生产-开机自启) 里的模板 |

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -98,7 +98,7 @@ On stable, `anet node create` lists **4 production runtimes** (`claude-agent-sdk
 Start the node:
 
 ::: warning Fresh install + claude-agent-sdk / codex-sdk? Install agent-node first
-These runtimes depend on the `agent-node` package. The first `node start` triggers an npx auto-fetch that takes ~1 minute, but the current startup check **doesn't wait for it** and exits with `agent-node is not installed or cannot report a version` (reproduced on real hardware, [#450](https://github.com/sleep2agi/agent-network/issues/450) (precise filing; #237 is the umbrella)). Run this once before starting:
+These runtimes depend on the `agent-node` package. The first `node start` triggers an npx auto-fetch that takes ~1 minute, but on **stable `@latest` (currently `2.2.21`) and preview `≤ 2.3.0-preview.37`** the startup check **doesn't wait for it** and exits with `agent-node is not installed or cannot report a version` (reproduced on real hardware — [#450](https://github.com/sleep2agi/agent-network/issues/450) is the precise filing, #237 is the umbrella). **Root fix** is [PR #239](https://github.com/sleep2agi/agent-network/pull/239) (commit `1eff3a4d`, merged 2026-06-28); Vincent's 2026-08-09 audit verified the fix in an isolated Docker probe on `2.3.0-preview.38` reaching SSE connected. **The current `@preview` (`2.3.0-preview.39`) contains this fix; `@latest` does not** — [#450](https://github.com/sleep2agi/agent-network/issues/450) is still `open` pending 4 acceptance gates before latest promotion. **Workarounds** (in verified-strength order): upgrade to `@sleep2agi/agent-network@preview`; or stay on `@latest` but pre-install `agent-node` so the binary is already there:
 
 ```bash
 npm install -g @sleep2agi/agent-node

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -98,7 +98,7 @@ stable 版 `anet node create` 列出正式版的 runtime（`claude-agent-sdk` / 
 启动节点：
 
 ::: warning 全新安装选了 claude-agent-sdk / codex-sdk？先装 agent-node
-这两个 runtime 依赖 `agent-node` 包。首次 `node start` 的 npx 自动拉取需要约 1 分钟，当前版本的启动检查**不等它拉完**就报 `agent-node is not installed or cannot report a version` 退出（真机复现，[#450](https://github.com/sleep2agi/agent-network/issues/450) 精确立案，#237 为同族）。先跑一句再启动即可：
+这两个 runtime 依赖 `agent-node` 包。首次 `node start` 的 npx 自动拉取需要约 1 分钟，而 **stable `@latest`（当前 `2.2.21`）与 preview `≤ 2.3.0-preview.37`** 的启动检查**不等它拉完**就报 `agent-node is not installed or cannot report a version` 退出（真机复现，[#450](https://github.com/sleep2agi/agent-network/issues/450) 精确立案，#237 为同族）。**根因修复**见 [PR #239](https://github.com/sleep2agi/agent-network/pull/239)（commit `1eff3a4d`, merged 2026-06-28），Vincent 2026-08-09 audit 在 `2.3.0-preview.38` 隔离 Docker 里 verified 抵达 SSE connected；**当前 `@preview` (`2.3.0-preview.39`) 已含此 fix，`@latest` 未含** —— [#450](https://github.com/sleep2agi/agent-network/issues/450) 仍 `open`，因 promote 到 latest 待 4 项 acceptance gate 真绿。**变通**（按 verified 强度）：升到 `@sleep2agi/agent-network@preview`；或用 `@latest` 但先跑一句让二进制预先就位：
 
 ```bash
 npm install -g @sleep2agi/agent-node


### PR DESCRIPTION
Follow-up to PR #898 (task 27faa700 line). Doc-only, no behavior changes. 5 files, +20 -7.

## What this PR does

Nails down two `TBD 追溯` anchors that PR #898 explicitly deferred, and adds a distinct-shape note about **PR #895 / #896 landed in main but NOT yet in npm** — the trap those PRs fix still exists for anyone on `@preview` today.

## Anchors nailed

### 1) README.md:50 + README.en.md:50 — 一次性随机密码 anchor

Verified via `git log -S "defaultPassIsRandom"` + `git show <SHA>:agent-network/package.json`:

- Introducing commit: `3e4e190c` (PR #264 fixing #261 P0-2), merged **2026-06-28**
- First npm-published preview containing the behavior: **`@sleep2agi/agent-network@2.2.22-preview.4`**
- All subsequent `2.3.0-preview.0..39` inherit
- Stable `@latest` is `2.2.21` — pre-dates the fix. **`@latest` users still get the fixed default `admin` / `anethub`**
- Older preview `≤ 2.2.22-preview.3` also pre-dates the fix

Rewrote both README lines to state the anchor version, PR/issue links, and the explicit "you are still on the fixed default if you're on @latest 2.2.21 or preview ≤ 2.2.22-preview.3" caveat.

### 2) docs-site/docs/{,en/}guide/getting-started.md:97 — #450 anchor

Verified via `gh issue view 450 --repo sleep2agi/agent-network --json state,closedAt,stateReason,body`:

- Issue **[#450](https://github.com/sleep2agi/agent-network/issues/450)** is `OPEN` (not closed).
- Root fix landed in PR **[#239](https://github.com/sleep2agi/agent-network/pull/239)** commit `1eff3a4d` on **2026-06-28**.
- Vincent's 2026-08-09 audit (comment `5230885645`) verified the fix in an isolated Docker probe on `agent-network@2.3.0-preview.38` reaching SSE connected.
- #450 stays open pending 4 acceptance gates before promoting to latest.
- **Current `@preview` (`2.3.0-preview.39`) has the fix; `@latest` (`2.2.21`) still ships the bug.**

Rewrote the warning block on both zh and en getting-started to name that split explicitly and provide the workaround (upgrade to preview OR pre-install agent-node globally).

**Method note for audit trail**: PR #239's title only names `#237`, not `#450` — so the standard `gh pr list --search "fixes:#450"` returns nothing. The link is only recoverable via `git log -S` on the error string. Worth remembering as a fork/subagent brief pattern for future anchor hunts.

## Fact-2 notes (通信龙 D1-D3) — #895 / #896 in main NOT yet in npm

- **PR [#895](https://github.com/sleep2agi/agent-network/pull/895)** (`f565e9b8`): fixed `anet node start` false-`✅` / false-`started detached (tmux session live)` in detached scenarios. Merged to main.
- **PR [#896](https://github.com/sleep2agi/agent-network/pull/896)** (`40574a02`): fixed `anet project up / project restart` exit-code lie. Merged to main.

**Neither is on npm yet** — so for anyone on `@preview` (currently `2.3.0-preview.39`), the trap still exists. Real check remains `tmux has-session -t \"=<alias>\"` — the `=` is required (bare alias is a prefix match and can go green on the wrong session).

Added this in three places:

1. `README.md` + `README.en.md` quickstart — right after the `curl /health` verify, before the "open localhost:3000" line, so the first-run reader sees the caveat while their brain is still on `anet node start`.
2. `docs-site/docs/deploy/clean-server.md` §7.1 — right below the `tmux new -s anet-<alias> + anet node start <alias>` recipe.
3. `docs-site/docs/deploy/clean-server.md` §故障排查表 — added a new row `5.5` (`✅ printed but tmux session not there`) with the diagnostic recipe.

## Not touched (per current scope)

- `docs/version/0.11.0/feature-audit.md:33` (D4) — the audit row already correctly reports the bug and its `✅` refers to `anet node create` (wizard), not `anet node start`; no misleading claim to correct.
- The 6-10 `anet node start` command samples in `docs-site/docs/deploy/npm.md`, `.../concepts/networks.md`, `.../concepts/tokens.md` — pure command demos with no success-criteria text; the central note in `clean-server.md` §故障排查表 is where they land.
- Q2 leftovers (16 lines: `multi-model.md`, `agent-node.md`, `batch.md`, `dashboard.md`, `feishu.md`, `runtimes.md`, `upgrade.md`, `RELEASE-SOP.md`, etc.) still carry `TBD 追溯`. Each needs a targeted `git log -S` pass. Scheduled for subsequent follow-ups so this PR stays reviewable.

## Version facts (`npm view <pkg> dist-tags` 2026-08-18)

|         | latest         | preview                         |
|---------|----------------|---------------------------------|
| agent-network  | 2.2.21   | 2.3.0-preview.39                |
| agent-node     | 2.4.13   | 2.5.0-preview.31                |
| commhub-server | 0.8.8    | 0.9.0-preview.29                |

Unchanged since PR #898's 2026-08-17 authoring pass. **Snapshots, not promises.**

## Verification

```
$ git diff origin/main...HEAD --stat
 README.en.md                               | 8 ++++++--
 README.md                                  | 8 ++++++--
 docs-site/docs/deploy/clean-server.md      | 7 ++++++-
 docs-site/docs/en/guide/getting-started.md | 2 +-
 docs-site/docs/guide/getting-started.md    | 2 +-
 5 files changed, 20 insertions(+), 7 deletions(-)

$ git grep -c '2.2.22-preview.4' README.md README.en.md
README.en.md:1
README.md:1

$ git grep -c '1eff3a4d' docs-site/docs/{,en/}guide/getting-started.md
docs-site/docs/en/guide/getting-started.md:1
docs-site/docs/guide/getting-started.md:1

$ git grep -c '#895' README.md README.en.md docs-site/docs/deploy/clean-server.md
README.en.md:1
README.md:1
docs-site/docs/deploy/clean-server.md:2
```