### PR TITLE
fix(cli): 回归修复 —— pane 类 tmux 命令不能用 =name(中文会话名解析不到)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -7979,11 +7979,25 @@ function capturePaneReason(sessionName: string): string | null {
 // claude-code-cli nodes (only those carry a `server:` channel and hit the
 // prompt), so `node start --all` / `project up|restart` stay zero-interaction.
 async function autoConfirmDevChannels(spawned: ProjectNode[]): Promise<void> {
-  const claudeNodes = spawned.filter(n =>
-    n.profile && normalizeRuntime(n.profile) === "claude-code-cli" &&
-    !!n.profile.channels?.some(c => c.startsWith("server:")));
-  if (claudeNodes.length === 0) return;
-  await Promise.all(claudeNodes.map(n => dismissDevChannelPrompt(n.alias, 45000)));
+  // What decides whether the prompt appears is the `server:` channel, NOT the
+  // runtime. This filter used to also require runtime === "claude-code-cli",
+  // which silently excluded every claude-agent-sdk node — and `claude-code`
+  // normalizes to claude-agent-sdk, so legacy-named nodes were excluded too.
+  // Those nodes then sat on the confirm box forever during `project up` /
+  // `node start --all`, with no watcher ever looking at them.
+  //
+  // The same file already had the correct predicate: the #494 warning on the
+  // `--tmux` path keys purely on `server:` channels with no runtime test. Two
+  // places deciding the same question, one of them narrower, and the narrow one
+  // was the one doing the work.
+  //
+  // Widening is safe because dismissDevChannelPrompt is detection-gated: it
+  // sends Enter only when the prompt's exact text is on screen, so a node that
+  // never shows it simply times out without a keystroke being sent.
+  const promptedNodes = spawned.filter(n =>
+    !!n.profile?.channels?.some(c => typeof c === "string" && c.startsWith("server:")));
+  if (promptedNodes.length === 0) return;
+  await Promise.all(promptedNodes.map(n => dismissDevChannelPrompt(n.alias, 45000)));
 }
 
 async function projectCommand() {

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -99,7 +99,7 @@ import { findExactTmuxSession, parseTmuxSessions } from "../src/tmux-attach";
 import { classifyPanePrompt, extractStartFailureReason } from "../src/tmux-pane-prompt";
 import { describeUnsafePath } from "../src/unsafe-package-path-reason";
 import { describeUmaskRisk, judgeUmask, rejectedPayloads } from "../src/package-mode-preflight";
-import { exactSession } from "../src/tmux-exact-target";
+import { exactSession, PANE_LIST_FORMAT, paneTargetFor } from "../src/tmux-exact-target";
 import { diagnoseLocale, formatLocaleSource } from "../src/locale-diagnostic";
 import {
   formatSecretAssignment,
@@ -143,6 +143,30 @@ function adminUtokPath() { return join(home, ".anet", "server", "admin-utok.json
 function dashboardLaunchRecordPath(port: string | number) { return join(home, ".anet", "server", `dashboard-${port}.json`); }
 function nodesDir() { return join(process.cwd(), ".anet", "nodes"); }
 function shellQuote(value: string): string { return `'${value.replace(/'/g, `'\\''`)}'`; }
+/**
+ * Pane target (`<session>:<window>.<pane>`) for a session, or null.
+ *
+ * 🔴 Do NOT use `=name` for capture-pane / send-keys. tmux 3.4 resolves `=name`
+ *    for session-targeting commands but not for pane-targeting ones when the
+ *    name is non-ASCII, and this fleet's session names are nearly all Chinese:
+ *
+ *      capture-pane -t '=zz中文探针'  → rc=1  can't find pane
+ *      capture-pane -t 'zz中文探针'   → rc=0
+ *
+ *    So the exact form for a pane is the coordinate, with the session matched by
+ *    string equality in our own code rather than by tmux's prefix rules.
+ */
+function tmuxPaneTarget(sessionName: string): string | null {
+  try {
+    const out = execFileSync("tmux", ["list-panes", "-a", "-F", PANE_LIST_FORMAT], {
+      encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
+    }).toString();
+    return paneTargetFor(out, sessionName);
+  } catch {
+    return null;  // no server / no panes
+  }
+}
+
 /** Kill a session and report whether it is actually gone afterwards. */
 function killTmuxSession(sessionName: string): boolean {
   try { execFileSync("tmux", ["kill-session", "-t", exactSession(sessionName)], { stdio: "pipe" }); } catch {}
@@ -212,7 +236,9 @@ function waitForTmuxPaneText(sessionName: string, needle: string, timeoutMs: num
   return new Promise((resolve) => {
     const poll = () => {
       try {
-        const out = execFileSync("tmux", ["capture-pane", "-t", exactSession(sessionName), "-p"], {
+        const paneTarget = tmuxPaneTarget(sessionName);
+        if (!paneTarget) return false;
+        const out = execFileSync("tmux", ["capture-pane", "-t", paneTarget, "-p"], {
           stdio: ["ignore", "pipe", "pipe"], encoding: "utf8",
         });
         if (out.includes(needle)) { resolve(true); return; }
@@ -780,10 +806,11 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
   if (!existsSync(attachScript)) {
     let tail = "";
     try {
-      tail = execFileSync("tmux", ["capture-pane", "-p", "-t", exactSession(bridgeSession), "-S", "-80"], {
+      const bridgePane = tmuxPaneTarget(bridgeSession);
+      tail = bridgePane ? execFileSync("tmux", ["capture-pane", "-p", "-t", bridgePane, "-S", "-80"], {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
-      }).slice(-3_000);
+      }).slice(-3_000) : "";
     } catch {}
     killTmuxSession(bridgeSession);
     console.error(`[anet] ❌ OpenCode copresence server did not produce its attach launcher within 30s.`);
@@ -7891,11 +7918,21 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
   let trustAnswered = false;
   while (Date.now() < deadline) {
     let pane = "";
+    // Resolve the pane coordinate each iteration: the session may not have a
+    // pane yet on the first poll, and a coordinate captured once could go stale.
+    const paneTarget = tmuxPaneTarget(sessionName);
+    if (!paneTarget) {
+      // No pane for this exact session — it has not appeared yet, or it exited.
+      // Keep waiting rather than declaring the prompt absent; the deadline ends
+      // the loop.
+      await new Promise(r => setTimeout(r, 1000));
+      continue;
+    }
     try {
       // Discard tmux's stderr: polling a session that has already exited is a
       // normal outcome here, and letting `can't find pane: X` through made the
       // CLI print an alarming line right before an unrelated verdict.
-      pane = execFileSync("tmux", ["capture-pane", "-p", "-t", exactSession(sessionName)], {
+      pane = execFileSync("tmux", ["capture-pane", "-p", "-t", paneTarget], {
         encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
       }).toString();
     } catch {
@@ -7905,7 +7942,7 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
     if (prompt === "folder-trust" && !trustAnswered) {
       // Settle briefly so Ink's input handler is fully attached, then accept.
       await new Promise(r => setTimeout(r, 700));
-      try { execFileSync("tmux", ["send-keys", "-t", exactSession(sessionName), "Enter"], { stdio: "ignore" }); } catch {}
+      try { execFileSync("tmux", ["send-keys", "-t", paneTarget, "Enter"], { stdio: "ignore" }); } catch {}
       trustAnswered = true;
       deadline = Date.now() + timeoutMs;  // fresh window for the prompt we came for
       await new Promise(r => setTimeout(r, 1000));
@@ -7915,7 +7952,7 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
       // Prompt is rendered and waiting. Settle briefly so Ink's input handler
       // is fully attached, then confirm with a single Enter.
       await new Promise(r => setTimeout(r, 700));
-      try { execFileSync("tmux", ["send-keys", "-t", exactSession(sessionName), "Enter"], { stdio: "ignore" }); } catch {}
+      try { execFileSync("tmux", ["send-keys", "-t", paneTarget, "Enter"], { stdio: "ignore" }); } catch {}
       return true;
     }
     await new Promise(r => setTimeout(r, 1000));
@@ -7927,7 +7964,9 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
 // on the failure path, where the pane holds the inner command's own words.
 function capturePaneReason(sessionName: string): string | null {
   try {
-    const pane = execFileSync("tmux", ["capture-pane", "-p", "-t", exactSession(sessionName)], {
+    const paneTarget = tmuxPaneTarget(sessionName);
+    if (!paneTarget) return null;  // session already reaped
+    const pane = execFileSync("tmux", ["capture-pane", "-p", "-t", paneTarget], {
       encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
     }).toString();
     return extractStartFailureReason(pane);

--- a/agent-network/src/tmux-exact-target.ts
+++ b/agent-network/src/tmux-exact-target.ts
@@ -45,3 +45,61 @@ export function isExactTarget(target: string): boolean {
 export function ensureExactSession(nameOrTarget: string): string {
   return isExactTarget(nameOrTarget) ? nameOrTarget : exactSession(nameOrTarget);
 }
+
+// ── pane targeting ────────────────────────────────────────────────────────
+//
+// 🔴 `=name` works for SESSION-targeting commands but NOT for pane-targeting
+//    ones when the session name is non-ASCII. Measured on tmux 3.4 with a
+//    session literally named `zz中文探针`:
+//
+//      tmux has-session   -t 'zz中文探针'   rc=0     -t '=zz中文探针'   rc=0  ✅
+//      tmux kill-session  -t 'zz中文探针'   rc=0     -t '=zz中文探针'   rc=0  ✅
+//      tmux capture-pane  -t 'zz中文探针'   rc=0     -t '=zz中文探针'   rc=1  ❌ can't find pane
+//      tmux send-keys     -t 'zz中文探针'   rc=0     -t '=zz中文探针'   rc=1  ❌ can't find pane
+//
+//    This fleet's session names are overwhelmingly Chinese, so applying the
+//    `=` prefix to capture-pane/send-keys silently disabled both: capture-pane
+//    throws, the prompt watcher treats that as "session gone" and gives up, and
+//    the dev-channels box is never confirmed. That is worse than the prefix
+//    ambiguity the prefix was added to fix.
+//
+// The exact-and-portable form for a pane is the coordinate
+// `<session>:<window>.<pane>`, which tmux resolves without prefix matching and
+// which works for non-ASCII names. Get it by listing panes and matching the
+// session name EXACTLY in code, where string equality is unambiguous — rather
+// than asking tmux to disambiguate for us.
+
+/** One row of `tmux list-panes -a -F '#{session_name}\t#{window_index}.#{pane_index}'`. */
+export interface PaneRow {
+  session: string;
+  /** `window.pane`, e.g. `0.0`. */
+  coord: string;
+}
+
+export function parsePaneRows(listOutput: string): PaneRow[] {
+  const rows: PaneRow[] = [];
+  for (const line of listOutput.split("\n")) {
+    if (!line) continue;
+    // Split on the LAST tab: a session name may itself contain a tab only if
+    // someone worked hard at it, and the coordinate never does.
+    const i = line.lastIndexOf("\t");
+    if (i <= 0) continue;
+    rows.push({ session: line.slice(0, i), coord: line.slice(i + 1).trim() });
+  }
+  return rows;
+}
+
+/**
+ * Pane target for a session, or null when that exact session has no pane.
+ *
+ * Matching is exact string equality on the session name — the whole point is to
+ * not hand tmux a name it might prefix-match, and to not hand it a `=` form it
+ * cannot resolve for non-ASCII names.
+ */
+export function paneTargetFor(listOutput: string, sessionName: string): string | null {
+  const row = parsePaneRows(listOutput).find(r => r.session === sessionName);
+  return row ? `${sessionName}:${row.coord}` : null;
+}
+
+/** The format string the two functions above expect. */
+export const PANE_LIST_FORMAT = "#{session_name}\t#{window_index}.#{pane_index}";

--- a/agent-network/src/tmux-pane-target.test.ts
+++ b/agent-network/src/tmux-pane-target.test.ts
@@ -81,3 +81,31 @@ test("cli.ts sends pane commands to coordinates and session commands to the = fo
   expect(source).toContain('["kill-session", "-t", exactSession(sessionName)]');
   expect(source).toContain('["has-session", "-t", exactSession(name)]');
 });
+
+// The dev-channels auto-confirm used to filter on runtime, not on the thing
+// that actually causes the prompt.
+test("auto-confirm selects nodes by their server: channel, not by runtime", () => {
+  const source = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+  const a = source.indexOf("async function autoConfirmDevChannels(");
+  expect(a).toBeGreaterThan(-1);
+  const raw = source.slice(a, source.indexOf("\n}", a));
+  // Strip comments before asserting absence: the explanation of the old,
+  // narrower predicate quotes it verbatim, and a prefix-free `toContain` would
+  // match the comment and fail on the fixed code. Assert about the code.
+  const body = raw.split("\n").filter(l => !l.trim().startsWith("//")).join("\n");
+  expect(body).toContain('startsWith("server:")');
+  // A runtime test here excluded every claude-agent-sdk node — and `claude-code`
+  // normalizes to claude-agent-sdk, so legacy names were excluded too.
+  expect(body).not.toContain('=== "claude-code-cli"');
+  expect(body).not.toContain("normalizeRuntime(");
+});
+
+test("the #494 warning and the auto-confirm agree on the predicate", () => {
+  const source = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+  // Both must key on server: channels. Two places answering the same question
+  // with different rules is how the narrow one silently did the work.
+  const warn = source.indexOf("this node loads dev channels");
+  expect(warn).toBeGreaterThan(-1);
+  const warnGuard = source.slice(Math.max(0, warn - 300), warn);
+  expect(warnGuard).toContain('startsWith("server:")');
+});

--- a/agent-network/src/tmux-pane-target.test.ts
+++ b/agent-network/src/tmux-pane-target.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test";
+import { execFileSync } from "child_process";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { PANE_LIST_FORMAT, exactSession, paneTargetFor, parsePaneRows } from "./tmux-exact-target";
+
+const LIST = [
+  "A站Grok\t0.0",
+  "A站内容\t0.0",
+  "A站内容牛\t0.0",
+  "SDK马\t0.0",
+  "hub\t0.1",
+].join("\n") + "\n";
+
+test("a pane target is the coordinate, never the = form", () => {
+  expect(paneTargetFor(LIST, "SDK马")).toBe("SDK马:0.0");
+  // The `=` form is for session-targeting commands only; handing it to
+  // capture-pane/send-keys fails outright for non-ASCII names.
+  expect(paneTargetFor(LIST, "SDK马")).not.toContain("=");
+});
+
+test("session matching is exact — a prefix sibling never wins", () => {
+  expect(paneTargetFor(LIST, "A站内容")).toBe("A站内容:0.0");
+  expect(paneTargetFor(LIST, "A站内容牛")).toBe("A站内容牛:0.0");
+});
+
+test("a session with no pane resolves to null rather than to something nearby", () => {
+  expect(paneTargetFor(LIST, "A站内容牛牛")).toBeNull();
+  expect(paneTargetFor(LIST, "")).toBeNull();
+  expect(paneTargetFor("", "SDK马")).toBeNull();
+});
+
+test("non-zero window/pane indexes are carried through", () => {
+  expect(paneTargetFor(LIST, "hub")).toBe("hub:0.1");
+});
+
+test("rows split on the last tab, so the coordinate is never mistaken for the name", () => {
+  const rows = parsePaneRows("odd\tname\t1.2\n");
+  expect(rows).toEqual([{ session: "odd\tname", coord: "1.2" }]);
+});
+
+test("malformed rows are dropped, not turned into a target", () => {
+  expect(parsePaneRows("no-tab-here\n\t0.0\n")).toEqual([]);
+});
+
+// The regression this file exists to prevent, measured against the real tmux.
+// Skipped where tmux is unavailable.
+function tmuxAvailable(): boolean {
+  try { execFileSync("tmux", ["-V"], { stdio: "pipe" }); return true; } catch { return false; }
+}
+
+const S = "anet-panetarget-中文-test";
+
+test.skipIf(!tmuxAvailable())("real tmux: '=name' fails for capture-pane on a non-ASCII session, the coordinate works", () => {
+  try { execFileSync("tmux", ["kill-session", "-t", exactSession(S)], { stdio: "pipe" }); } catch {}
+  execFileSync("tmux", ["new-session", "-d", "-s", S, "sleep 60"], { stdio: "pipe" });
+  try {
+    // has-session accepts the = form even for non-ASCII…
+    expect(() => execFileSync("tmux", ["has-session", "-t", exactSession(S)], { stdio: "pipe" })).not.toThrow();
+    // …but capture-pane does not. This is the whole reason for the coordinate.
+    expect(() => execFileSync("tmux", ["capture-pane", "-p", "-t", exactSession(S)], { stdio: "pipe" })).toThrow();
+
+    const out = execFileSync("tmux", ["list-panes", "-a", "-F", PANE_LIST_FORMAT], { encoding: "utf-8" }).toString();
+    const coord = paneTargetFor(out, S);
+    expect(coord).toBe(`${S}:0.0`);
+    expect(() => execFileSync("tmux", ["capture-pane", "-p", "-t", coord!], { stdio: "pipe" })).not.toThrow();
+  } finally {
+    try { execFileSync("tmux", ["kill-session", "-t", exactSession(S)], { stdio: "pipe" }); } catch {}
+  }
+});
+
+test("cli.ts sends pane commands to coordinates and session commands to the = form", () => {
+  const source = readFileSync(join(import.meta.dir, "..", "bin", "cli.ts"), "utf8");
+  // Pane-targeting commands must not carry exactSession(...).
+  for (const cmd of ['"capture-pane"', '"send-keys"']) {
+    const lines = source.split("\n").filter(l => l.includes(cmd) && l.includes("-t"));
+    expect(lines.length).toBeGreaterThan(0);
+    for (const l of lines) expect(l).not.toContain("exactSession(");
+  }
+  // Session-targeting commands must keep it.
+  expect(source).toContain('["kill-session", "-t", exactSession(sessionName)]');
+  expect(source).toContain('["has-session", "-t", exactSession(name)]');
+});


### PR DESCRIPTION
🔴 **这是我在 #895 里引入并已合入 main 的回归。**

#895 把 8 处裸 `-t <name>` 改成 `-t =<name>` 来消除前缀匹配。**这对「会话类命令」是对的,对「pane 类命令」是错的。**

## 实测(tmux 3.4,会话名字面就叫 `zz中文探针`)

| 命令 | `-t 'zz中文探针'` | `-t '=zz中文探针'` |
|---|---|---|
| `has-session` | rc=0 | **rc=0** ✅ |
| `kill-session` | rc=0 | **rc=0** ✅ |
| `capture-pane` | rc=0 | **rc=1 `can't find pane`** ❌ |
| `send-keys` | rc=0 | **rc=1 `can't find pane`** ❌ |

本舰队的会话名**几乎全是中文**,所以 #895 实际上**把 dev-channels 确认框的自动应答对几乎每个节点都关掉了**:`capture-pane` 抛异常 → watcher 把它读成「会话没了」→ 立即 return false → 确认框永远没人答 → 节点永远坐在那儿。

**这比 `=` 想修的那个前缀歧义更糟,而且正是 #895 后半部分存在要消除的同一种失败模式。**

## 在一个活节点上抓到的

`SDK马` 当时正坐在 dev-channels 框上、pid 活着:

```
capture-pane -t '=SDK马'      → rc!=0
capture-pane -t 'SDK马:0.0'   → rc=0,16 行,确认框可见
```

## 改法

pane 的**精确且可移植**形式是坐标 `<session>:<window>.<pane>`。取法是列出所有 pane,**在我们自己的代码里用字符串相等匹配会话名** —— 既无歧义又与编码无关,而不是把消歧这件事交给 tmux 的前缀规则。

`has-session` / `kill-session` **保留 `=name`**:它们对非 ASCII 接受这个形式,而且仍然需要那道前缀防护。

watcher 现在**每次轮询都重新解析坐标**,不缓存:会话在第一次迭代时可能还没有 pane,而**「还没有 pane」不能被当成「确认框不存在」** —— 它继续等,由 deadline 决定何时放弃。

## 验证

- 那条 wiring 断言对 `f565e9b8..7752437f`(即含 #895/#897 的 main)**见红**,在本 PR 绿
- 纯解析器钉住了:前缀兄弟、不存在的会话、非零 window/pane 下标、畸形行
- **另有一个集成测试**会真的建一个非 ASCII 会话并断言上表那个 rc 差异 —— 所以这条不可能再静默回归
- 包内 **491 测试全过**,`tsc --noEmit` 干净

## 教训

`=` 前缀这条规则我是从一条 2026-08-04 的记录里拿来的,而那条记录**同一段里就写着「`=name` 对中文会话名会失败,要用坐标」**。我用了前半句,漏了后半句 —— 而这台机器上几乎所有会话名都命中后半句的条件。
