### PR TITLE
fix(tests): 把 opencode 配对版本改成从源码常量派生(照 SOP 发版会必然变红)

### DIFF
--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -31,6 +31,22 @@ R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md`
 ~~例外（保留快照）：sdk-deep-dive.md L14 用 `agent-node@2.3.1-preview.0` 做 snapshot pin~~ —— **R367 (2026-05-14) 已取消该例外**：[`docs-site/docs/guide/sdk-deep-dive.md` L14](https://github.com/sleep2agi/agent-network/blob/main/docs-site/docs/guide/sdk-deep-dive.md#L14) 的 `cli.ts:NNN` 行号引用改成「对照 GitHub `main` 校准」（不再 pin 具体 preview 版本），跟其余 doc 一致。现在 **没有 docs 还 pin npm 版本号**了。
 :::
 
+::: tip R? 校准（2026-08-17）：测试套件里的版本号已改为「从源码常量派生」，不再需要 release sync
+
+`tests/test386-opencode-agent-node-gate` 与 `tests/test384-opencode-local-package-e2e` 原先各自
+硬编码了 `OPENCODE_AGENT_NETWORK_VERSION` / `OPENCODE_AGENT_NODE_VERSION` 这一对
+（test386 有 5 处断言 + 3 处夹具，test384 有 run.sh 默认值 + Dockerfile ARG）。
+
+走 preview.40 的 dry-run 时发现：**sync 脚本会升常量，但不碰这些文件，所以照本 SOP 发版
+必然产生一个红**——而最省力的「修法」是把断言里的数字改成新的，那等于让测试永远只抄一遍
+当前值、不再检查任何东西。
+
+现在它们在运行时从 `agent-network/src/opencode-agent-node-pair.ts` 读常量（读不到就
+fail-closed，不拿空串去 grep——空串 grep 恒真会把断言变成永远通过），夹具的 `version`
+由 run.sh 在使用前改写。**不要把它们加进 Live versions 表**：加进去等于给已经自洽的东西
+再钉一份，反而会漂。
+:::
+
 ### B. Frozen snapshots（永不动）
 
 每条记录都是某个历史时刻的快照，跟着 release sync 改反而失真。

--- a/tests/test384-opencode-local-package-e2e/Dockerfile
+++ b/tests/test384-opencode-local-package-e2e/Dockerfile
@@ -1,8 +1,13 @@
 FROM node:22-bookworm-slim
 
 ARG OPENCODE_VERSION=1.18.1
-ARG AGENT_NETWORK_VERSION=2.3.0-preview.39
-ARG AGENT_NODE_VERSION=2.5.0-preview.31
+# 🔴 故意留空:下面 line 72-73 把这两个 ARG 灌进 ENV *_UNDER_TEST,而 run.sh 用
+#    ${*_UNDER_TEST:-<从源码常量派生>}。ARG 一旦有硬编码默认值,ENV 就永远非空,
+#    run.sh 的派生分支永远不会执行 —— 那个"改成派生"的修改会是一次空转,而且
+#    表现和生效完全一样(测试照跑照绿,只是测的是上一个版本)。
+#    留空 → ENV 为空 → :- 走派生。要测特定版本仍可 --build-arg 显式覆盖。
+ARG AGENT_NETWORK_VERSION=
+ARG AGENT_NODE_VERSION=
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       bash ca-certificates curl jq procps python3 python3-pexpect ripgrep unzip \

--- a/tests/test384-opencode-local-package-e2e/run.sh
+++ b/tests/test384-opencode-local-package-e2e/run.sh
@@ -14,8 +14,16 @@ ADMIN_PASSWORD='Test384-Strong-Password!'
 LIVE_ALIAS=wizard-openai
 FREE_MODEL="${OPENCODE_FREE_MODEL:-opencode/deepseek-v4-flash-free}"
 EXPECTED_OPENCODE="${OPENCODE_VERSION_UNDER_TEST:-1.18.1}"
-EXPECTED_NETWORK="${AGENT_NETWORK_VERSION_UNDER_TEST:-2.3.0-preview.39}"
-EXPECTED_NODE="${AGENT_NODE_VERSION_UNDER_TEST:-2.5.0-preview.31}"
+# 默认值从源码常量派生,不写死:release 升常量时这里跟着走,不需要有人记得改。
+# (2026-08-17:走 RELEASE-SOP 的 preview.40 dry-run 时发现 sync 脚本不碰这个文件,
+#  于是照 SOP 发版会让这里默认测到上一个版本 —— 测的是旧产物,却看起来在测新版。)
+PAIR_SRC=/repo/agent-network/src/opencode-agent-node-pair.ts
+SRC_NETWORK=$(sed -n 's/^export const OPENCODE_AGENT_NETWORK_VERSION = "\([^"]*\)";$/\1/p' "$PAIR_SRC" 2>/dev/null)
+SRC_NODE=$(sed -n 's/^export const OPENCODE_AGENT_NODE_VERSION = "\([^"]*\)";$/\1/p' "$PAIR_SRC" 2>/dev/null)
+EXPECTED_NETWORK="${AGENT_NETWORK_VERSION_UNDER_TEST:-${SRC_NETWORK}}"
+EXPECTED_NODE="${AGENT_NODE_VERSION_UNDER_TEST:-${SRC_NODE}}"
+[ -n "$EXPECTED_NETWORK" ] || { echo "FAIL: cannot resolve expected agent-network version" >&2; exit 1; }
+[ -n "$EXPECTED_NODE" ]    || { echo "FAIL: cannot resolve expected agent-node version" >&2; exit 1; }
 REAL_PATH="$PATH"
 FAKE_BIN_DIR=/test384/fake-bin
 FAKE_CANONICAL_BIN=/test384/fake-global/node_modules/opencode-ai/bin/opencode.exe

--- a/tests/test386-opencode-agent-node-gate/bin/npx
+++ b/tests/test386-opencode-agent-node-gate/bin/npx
@@ -2,9 +2,15 @@
 set -eu
 
 printf '%s\n' "$*" > /tmp/test386-npx-args
+# 期望的 spec 由 run.sh 从源码常量导出,不写死版本号:release 一升常量,
+# 写死的夹具就和被测代码对不上,而"改夹具去迎合新值"等于让夹具永远只抄当前值。
+if [ -z "${EXPECT_NODE_SPEC:-}" ]; then
+  printf '%s\n' "EXPECT_NODE_SPEC not exported by run.sh — refusing to guess" >&2
+  exit 65
+fi
 if [ "$#" -eq 3 ] \
   && [ "$1" = "-y" ] \
-  && [ "$2" = "@sleep2agi/agent-node@2.5.0-preview.31" ] \
+  && [ "$2" = "$EXPECT_NODE_SPEC" ] \
   && [ "$3" = "--print-entrypoint" ]; then
   printf '%s\n' '/test/exact-global/node_modules/@sleep2agi/agent-node/dist/cli.js'
   exit 0

--- a/tests/test386-opencode-agent-node-gate/exact-node/package.json
+++ b/tests/test386-opencode-agent-node-gate/exact-node/package.json
@@ -1,4 +1,5 @@
 {
+  "_note": "run.sh 在用它之前会把 version 改写成 agent-network/src/opencode-agent-node-pair.ts 里 OPENCODE_AGENT_NODE_VERSION 的当前值。这里这个数字只是占位,不要手动改它去追常量。",
   "name": "@sleep2agi/agent-node",
   "version": "2.5.0-preview.31",
   "type": "module",

--- a/tests/test386-opencode-agent-node-gate/project-agent-node/package.json
+++ b/tests/test386-opencode-agent-node-gate/project-agent-node/package.json
@@ -1,4 +1,5 @@
 {
+  "_note": "run.sh 在用它之前会把 version 改写成 agent-network/src/opencode-agent-node-pair.ts 里 OPENCODE_AGENT_NODE_VERSION 的当前值。这里这个数字只是占位,不要手动改它去追常量。",
   "name": "@sleep2agi/agent-node",
   "version": "2.5.0-preview.31",
   "type": "module",

--- a/tests/test386-opencode-agent-node-gate/run.sh
+++ b/tests/test386-opencode-agent-node-gate/run.sh
@@ -29,6 +29,45 @@ write_opencode_binding() {
     '
 }
 
+# 🔴 这两个版本号从源码常量派生,不写死。
+#
+# 之前 5 处断言各自硬编码了 `2.3.0-preview.39` / `2.5.0-preview.31`。它们断言的
+# 恰恰是 opencodeExactPairInstallCommand() 用这两个常量生成的字符串,所以每次
+# release 升常量,这 5 条 grep -Fq 就会一起红 —— 而修它的最省力办法是把断言里的
+# 数字改成新的,那等于让测试永远只是抄一遍当前值,不再检查任何东西。
+#
+# 2026-08-17 走 RELEASE-SOP 的 preview.40 dry-run 时撞到这一点:sync 脚本会升
+# 常量,但不碰这个文件,于是照 SOP 发版必然产生一个红。
+#
+# 派生 + fail-closed:读不到常量就直接失败,不能静默拿空串去 grep(空串 grep 恒真,
+# 那会把这几条断言变成永远通过)。
+PAIR_SRC=/repo/agent-network/src/opencode-agent-node-pair.ts
+[ -f "$PAIR_SRC" ] || fail "cannot find $PAIR_SRC — refusing to assert against an unknown pair"
+EXPECT_NETWORK=$(sed -n 's/^export const OPENCODE_AGENT_NETWORK_VERSION = "\([^"]*\)";$/\1/p' "$PAIR_SRC")
+EXPECT_NODE=$(sed -n 's/^export const OPENCODE_AGENT_NODE_VERSION = "\([^"]*\)";$/\1/p' "$PAIR_SRC")
+[ -n "$EXPECT_NETWORK" ] || fail "could not read OPENCODE_AGENT_NETWORK_VERSION from $PAIR_SRC"
+[ -n "$EXPECT_NODE" ]    || fail "could not read OPENCODE_AGENT_NODE_VERSION from $PAIR_SRC"
+printf -- '- expected pair (from source): agent-network@%s + agent-node@%s\n' \
+  "$EXPECT_NETWORK" "$EXPECT_NODE" >> "$REPORT"
+
+# 夹具里的版本号同样从常量派生。它们代表「被信任的那个确切版本」,写死的话
+# release 一升常量,夹具就不再是「确切版本」,而这个失败看起来像产品坏了。
+export EXPECT_NODE_SPEC="@sleep2agi/agent-node@$EXPECT_NODE"
+for fixture in /repo/tests/test386-opencode-agent-node-gate/exact-node/package.json \
+               /repo/tests/test386-opencode-agent-node-gate/project-agent-node/package.json; do
+  [ -f "$fixture" ] || fail "fixture missing: $fixture"
+  tmp=$(mktemp)
+  EXPECT_NODE="$EXPECT_NODE" node -e '
+    const fs = require("fs");
+    const p = process.argv[1];
+    const j = JSON.parse(fs.readFileSync(p, "utf8"));
+    j.version = process.env.EXPECT_NODE;
+    fs.writeFileSync(process.argv[2], JSON.stringify(j, null, 2) + "\n");
+  ' "$fixture" "$tmp" || fail "could not rewrite fixture version: $fixture"
+  mv "$tmp" "$fixture"
+done
+printf -- '- fixtures pinned to agent-node@%s\n' "$EXPECT_NODE" >> "$REPORT"
+
 printf '# Test 386 — opencode-cli stale agent-node launch gate\n\n' >> "$REPORT"
 printf -- '- date: %s\n' "$(date -Iseconds)" >> "$REPORT"
 
@@ -217,7 +256,7 @@ jq -e '
 [ ! -e /tmp/test386-profile-coverage ] \
   || fail "profile NODE_V8_COVERAGE wrote outside the node state boundary"
 [ ! -e /tmp/test386-npx-args ] || fail "exact global resolution unexpectedly executed npx"
-grep -Fq 'using installed exact @sleep2agi/agent-node@2.5.0-preview.31' \
+grep -Fq "using installed exact @sleep2agi/agent-node@$EXPECT_NODE" \
   /tmp/test386-success.log || fail "exact installed agent-node diagnostic is missing"
 pass "stale global bypassed; later exact global received protected PATH/binary/version/base; npx was not executed"
 
@@ -294,7 +333,7 @@ mask_log < /tmp/test386-project-explicit.log >> "$REPORT"
   || fail "explicit project-local rejection unexpectedly launched another agent-node"
 [ ! -e /tmp/test386-npx-args ] \
   || fail "explicit project-local rejection unexpectedly executed npx"
-grep -Fq 'ANET_AGENT_NODE_BIN is not the exact trusted @sleep2agi/agent-node@2.5.0-preview.31' \
+grep -Fq "ANET_AGENT_NODE_BIN is not the exact trusted @sleep2agi/agent-node@$EXPECT_NODE" \
   /tmp/test386-project-explicit.log \
   || fail "explicit project-local rejection omitted the exact-pair diagnostic"
 grep -Fq 'project/node-local agent-node package payload is not trusted' \
@@ -336,7 +375,7 @@ jq -e '.executable == "/test/exact-global/node_modules/@sleep2agi/agent-node/dis
   /tmp/test386-exact-preview-launch.json >/dev/null \
   || fail "capable-looking preview.21 was not bypassed for the later exact global"
 [ ! -e /tmp/test386-npx-args ] || fail "preview.21 bypass unexpectedly executed npx"
-pass "capable-looking global preview.21 rejected; later exact global preview.31 launched without npx"
+pass "capable-looking global preview.21 rejected; later exact global $EXPECT_NODE launched without npx"
 
 # An explicit override is not permission to bypass the exact release pair.
 rm -rf /tmp/test386-work-explicit /tmp/test386-home-explicit \
@@ -362,7 +401,7 @@ mask_log < /tmp/test386-explicit.log >> "$REPORT"
 [ "$explicit_rc" -ne 0 ] || fail "stale explicit agent-node override unexpectedly started"
 [ ! -e /tmp/test386-stale-capable-global-was-launched ] \
   || fail "stale explicit preview.21 was launched"
-grep -Fq 'ANET_AGENT_NODE_BIN is not the exact trusted @sleep2agi/agent-node@2.5.0-preview.31' \
+grep -Fq "ANET_AGENT_NODE_BIN is not the exact trusted @sleep2agi/agent-node@$EXPECT_NODE" \
   /tmp/test386-explicit.log \
   || fail "explicit override exact-version diagnostic is missing"
 pass "ANET_AGENT_NODE_BIN cannot bypass the exact hardened pair"
@@ -395,7 +434,7 @@ mask_log < /tmp/test386-fail.log >> "$REPORT"
 grep -Fq 'automatic npx execution is disabled for opencode-cli' \
   /tmp/test386-fail.log \
   || fail "hard-fail omitted the disabled-npx diagnostic"
-grep -Fq 'npm install -g @sleep2agi/agent-network@2.3.0-preview.39 @sleep2agi/agent-node@2.5.0-preview.31' \
+grep -Fq "npm install -g @sleep2agi/agent-network@$EXPECT_NETWORK @sleep2agi/agent-node@$EXPECT_NODE" \
   /tmp/test386-fail.log \
   || fail "hard-fail omitted the exact dual-package install command"
 grep -Fq 'Refusing to start: an unsupported agent-node could silently select another runtime.' \


### PR DESCRIPTION
见提交信息。核心:走 RELEASE-SOP 的 preview.40 dry-run 时发现 sync 脚本会升常量但不碰测试,而 `test386:398` 用 `grep -Fq` 断言的正是**由那两个常量生成的**安装命令 —— **照 SOP 发版必然产生一个红**,而最省力的「修法」是把断言里的数字改成新的,那等于让测试永远只抄一遍当前值。

九处硬编码(test386 五处断言 + 三处夹具,test384 默认值 + Dockerfile ARG)全部改为运行时从 `agent-network/src/opencode-agent-node-pair.ts` 读常量,**读不到就 fail-closed** —— 不能拿空串去 `grep -Fq`,空串恒匹配会把五条断言变成永远通过。

两个「改了等于没改」的坑,一并记在提交信息里:Dockerfile 的 ARG 默认值非空会让 ENV 永远非空、`:-` 的派生分支永远不执行(修改与空转外观完全一致);假 npx 的比对值改成环境变量后必须 fail-closed,否则未设时会掉进 `unexpected npx arguments`,读起来像产品坏了而不是夹具坏了。

RELEASE-SOP 加了校准段:**这两个套件故意不进 Live versions 表** —— 它们现在自洽了,登记进去等于再钉一份、反而会漂。