### PR TITLE
fix(docs): changelog 不该按行号锚进 main —— 那种链接在构造上必然腐烂

### DIFF
--- a/.github/scripts/check-docs-integrity.py
+++ b/.github/scripts/check-docs-integrity.py
@@ -15,10 +15,24 @@ Both were live in docs/qa/weekly/2026-W19.md on 2026-08-17:
 Neither shows up in a build: Markdown has no compiler, so a dead link and a live
 one look the same until a reader clicks. Both are cheap to check mechanically.
 
+A third, narrower rule: no line-anchored `blob/main/...#L<n>` links inside the
+changelogs. A changelog entry describes a state that was true at some past
+release; a `#L` anchor into `main` resolves against today's code. Those two
+facts are incompatible by construction — the link is wrong after the next commit
+that touches the file, and nothing tells anyone. Measured 2026-08-17: of six such
+links, `cli.ts#L61` (documented as `PINNED_SERVER_VERSION`) now lands on
+`} from "../src/opencode-preset";` and `cli.ts#L2589` on a line of help text.
+
+Deliberately NOT extended to the rest of docs/: `docs-site/docs/api/mcp-tools.md`
+carries 44 of these and all 44 are still in range with plausible content, i.e.
+they are maintained. Reddening on ~100 maintained links would make this a
+backlog canary that dies the day the backlog clears.
+
 Scope is deliberately narrow and stated: UTF-8 validity across every tracked
-.md, link resolution for docs/qa/** only (where the defect was found). Widening
-the link check to all docs is a separate decision — some files link to generated
-or gitignored paths, and a guard that cries wolf gets disabled.
+.md, link resolution for docs/qa/** only (where the defect was found), and the
+changelog anchor rule. Widening the link check to all docs is a separate
+decision — some files link to generated or gitignored paths, and a guard that
+cries wolf gets disabled.
 
 Fail-closed: an empty file list exits 2 rather than reporting a clean run.
 """
@@ -29,6 +43,8 @@ import sys
 
 RELATIVE_LINK = re.compile(r"\]\((\.{1,2}/[^)\s]*)")
 LINK_SCOPE = "docs/qa"
+CHANGELOG_GLOB = "changelog.md"
+MAIN_LINE_ANCHOR = re.compile(r"blob/main/[\w./-]+#L\d+")
 
 
 def tracked(pathspec: str) -> list[str]:
@@ -75,8 +91,24 @@ def main() -> int:
                 print(f"::error file={f}::relative link '{target}' resolves to "
                       f"'{resolved}', which does not exist")
 
+    # 3. Changelogs must not line-anchor into main.
+    changelogs = [f for f in md if f.endswith("/" + CHANGELOG_GLOB) or f == CHANGELOG_GLOB]
+    if not changelogs:
+        print(f"::error::no tracked {CHANGELOG_GLOB} found — scope regression, refusing to pass")
+        return 2
+    anchors = 0
+    for f in changelogs:
+        for m in MAIN_LINE_ANCHOR.finditer(open(f, encoding="utf-8", errors="replace").read()):
+            problems += 1
+            anchors += 1
+            print(f"::error file={f}::`{m.group(0)}` line-anchors into main from a changelog. "
+                  f"The entry describes a past release; the anchor resolves against today's "
+                  f"code, so it is wrong after the next commit that touches that file and "
+                  f"nothing reports it. Link the file without `#L`, and name the symbol.")
+
     print(f"checked {len(md)} tracked .md for UTF-8 validity; "
-          f"{links} relative link(s) across {len(scoped)} file(s) under {LINK_SCOPE}/")
+          f"{links} relative link(s) across {len(scoped)} file(s) under {LINK_SCOPE}/; "
+          f"{len(changelogs)} changelog(s) for main line-anchors ({anchors} found)")
 
     if problems:
         print(f"\n{problems} problem(s).")

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -658,7 +658,7 @@ v0.10.4 Vincent 紧急 ship 跳过 测试团队 Docker smoke gate（不在生产
 - `HostTelemetry` interface 加 `disk_total_gb` / `disk_used_gb` / `disk_avail_gb`，`getHostTelemetry()` 通过 `toGb()` 同 mem/cpu 同 path 合成
 - **Backward compat**：老 server 端 schema silent-drop unknown keys；agent / server 可独立升
 
-接 [RFC-014](https://github.com/sleep2agi/agent-network/issues/99) — `/api/server/:host/health` 响应现在带 disk 三字段 + 24h 分桶 history 也含 `disk_avail_min` / `disk_used_max`；`alert_level` 加 `disk < 1GB critical / < 5GB warn` 触发（[`server/src/index.ts:253-258`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L253)）。
+接 [RFC-014](https://github.com/sleep2agi/agent-network/issues/99) — `/api/server/:host/health` 响应现在带 disk 三字段 + 24h 分桶 history 也含 `disk_avail_min` / `disk_used_max`；`alert_level` 加 `disk < 1GB critical / < 5GB warn` 触发（[`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)（当时在 253-258 行；行号已漂，按当时的符号名搜））。
 
 测试团队 Docker Linux smoke 3/3 PASS（disk 299.8 GB total / 216 used / 71.5 avail，alert green，backward compat verified）。
 
@@ -710,7 +710,7 @@ anet project restart                             # 重启项目（拉新 agent-n
 
 ### Fix
 
-[`agent-network/bin/cli.ts:61` `PINNED_SERVER_VERSION`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L61) 跨 v0.9.x + v0.10.0 promote 漏 bump，仍 hardcode `0.8.0` —— `anet hub start` 实际 `bunx --bun @sleep2agi/commhub-server@0.8.0` 启服务（[cli.ts:2589](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L2589)），跑的是老 server 不是 v0.10.0 ship 的 `0.8.2`。直接影响：
+[`agent-network/bin/cli.ts` 的 `PINNED_SERVER_VERSION`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)（当时在 61 行） 跨 v0.9.x + v0.10.0 promote 漏 bump，仍 hardcode `0.8.0` —— `anet hub start` 实际 `bunx --bun @sleep2agi/commhub-server@0.8.0` 启服务（[`cli.ts` 里 `anet hub start` 的 `bunx --bun @sleep2agi/commhub-server@…` 那处](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)（当时在 2589 行）），跑的是老 server 不是 v0.10.0 ship 的 `0.8.2`。直接影响：
 
 - [#99](https://github.com/sleep2agi/agent-network/issues/99) 守护节点 endpoint family `GET /api/server/:host/health` + `GET /api/server/:host/agents` 在 0.8.0 不存在 → **404**
 - [#142](https://github.com/sleep2agi/agent-network/issues/142) server schema align `process_telemetry` 字段在 0.8.0 没接 → 老 schema silent-drop 字段

--- a/docs-site/docs/en/changelog.md
+++ b/docs-site/docs/en/changelog.md
@@ -657,7 +657,7 @@ See the [v0.10.3 release notes](https://github.com/sleep2agi/agent-network/relea
 - `HostTelemetry` interface gains `disk_total_gb` / `disk_used_gb` / `disk_avail_gb`; `getHostTelemetry()` composes disk via `toGb()` on the same path as mem/cpu
 - **Backward compat**: older servers silently drop unknown keys; agents and servers upgrade independently
 
-Wires through [RFC-014](https://github.com/sleep2agi/agent-network/issues/99) — `GET /api/server/:host/health` now returns disk's three fields, the 24h bucketed history includes `disk_avail_min` / `disk_used_max`, and `alert_level` adds `disk < 1GB critical / < 5GB warn` triggers ([`server/src/index.ts:253-258`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts#L253)).
+Wires through [RFC-014](https://github.com/sleep2agi/agent-network/issues/99) — `GET /api/server/:host/health` now returns disk's three fields, the 24h bucketed history includes `disk_avail_min` / `disk_used_max`, and `alert_level` adds `disk < 1GB critical / < 5GB warn` triggers ([`server/src/index.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/index.ts)（当时在 253-258 行；行号已漂，按当时的符号名搜）).
 
 Test lead Docker Linux smoke 3/3 PASS (disk 299.8 GB total / 216 used / 71.5 avail, alert green, backward compat verified).
 
@@ -709,7 +709,7 @@ Release flow follows the [v0.9.0 split-brain lessons #126](https://github.com/sl
 
 ### Fix
 
-[`agent-network/bin/cli.ts:61` `PINNED_SERVER_VERSION`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L61) was never bumped across the v0.9.x + v0.10.0 promotes — it stayed hardcoded at `0.8.0`. That meant `anet hub start` was actually running `bunx --bun @sleep2agi/commhub-server@0.8.0` ([cli.ts:2589](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts#L2589)) — the old server, not the v0.10.0-shipped `0.8.2`. Direct impact:
+[`agent-network/bin/cli.ts` 的 `PINNED_SERVER_VERSION`](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)（当时在 61 行） was never bumped across the v0.9.x + v0.10.0 promotes — it stayed hardcoded at `0.8.0`. That meant `anet hub start` was actually running `bunx --bun @sleep2agi/commhub-server@0.8.0` ([`cli.ts` 里 `anet hub start` 的 `bunx --bun @sleep2agi/commhub-server@…` 那处](https://github.com/sleep2agi/agent-network/blob/main/agent-network/bin/cli.ts)（当时在 2589 行）) — the old server, not the v0.10.0-shipped `0.8.2`. Direct impact:
 
 - The [#99](https://github.com/sleep2agi/agent-network/issues/99) per-server daemon endpoints `GET /api/server/:host/health` + `GET /api/server/:host/agents` don't exist in 0.8.0 → **404**
 - [#142](https://github.com/sleep2agi/agent-network/issues/142) server schema alignment for `process_telemetry` isn't wired in 0.8.0 → the older schema silently drops the field


### PR DESCRIPTION
见提交信息。核心:**changelog 条目描述的是过去某个发布时为真的状态,而 `blob/main/<file>#L<n>` 解析的是今天的代码** —— 这两件事在构造上不相容,链接在下一次改动那个文件之后就错了,而且没有任何东西会报。

实测(不是推断)两条:
```
cli.ts#L61    文档里说是 PINNED_SERVER_VERSION
              现在落在  } from "../src/opencode-preset";
cli.ts#L2589  文档里说是 anet hub start 里 bunx commhub-server 那行
              现在落在  anet project restart 的帮助文本
```

改成:链接到文件但**去掉锚点**,并**点名符号** —— 符号才是读者能搜的东西。原行号保留在括号里作为历史上下文(写下时它是真的,说明这一点比删掉有用)。这跟 RELEASE-SOP 里 R367 的先例一致。

**故意只覆盖 changelog。** `docs-site/docs/api/mcp-tools.md` 有 44 条同类锚点,**44 条全部在范围内且内容像样** —— 它们是被维护的,因为那页描述的是当前行为而不是过去的发布。一道会对约 100 条被维护的链接变红的门,是靠积压撑红的金丝雀,积压一清它就死,而且会训练所有人忽略它。

门的三态都跑过:修好的树 exit 0(2 个 changelog、0 条锚点);main 的 changelog exit 1 且逐条指名;`CHANGELOG_GLOB` 指向不存在的文件名 → **exit 2**,而不是对着空集干净通过。