### PR TITLE
feat(hub): get_all_status 支持按 alias 过滤,并说清 summary 数的是什么 (#824)

### DIFF
--- a/server/src/alias-filter.test.ts
+++ b/server/src/alias-filter.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test";
+import { parseAliasFilter } from "./alias-filter";
+
+test("no filter given means no filtering, not an empty match", () => {
+  for (const raw of [undefined, null, "", "   ", ",", " , , "]) {
+    const f = parseAliasFilter(raw as any);
+    expect(f.aliases).toEqual([]);
+    expect(f.sql).toBe("");
+  }
+});
+
+test("a single alias produces one placeholder", () => {
+  const f = parseAliasFilter("TM门户马");
+  expect(f.aliases).toEqual(["TM门户马"]);
+  expect(f.sql).toBe(" AND alias IN (?)");
+});
+
+test("several aliases keep their order and count", () => {
+  const f = parseAliasFilter("A站内容,A站内容牛,hub");
+  expect(f.aliases).toEqual(["A站内容", "A站内容牛", "hub"]);
+  expect(f.sql).toBe(" AND alias IN (?,?,?)");
+});
+
+test("surrounding whitespace is trimmed", () => {
+  expect(parseAliasFilter(" a , b ").aliases).toEqual(["a", "b"]);
+});
+
+// The point of the module. A trailing comma must not become `alias = ''`,
+// which matches nothing and reads exactly like "those nodes do not exist".
+test("blank entries are dropped, never turned into a match-nothing term", () => {
+  const f = parseAliasFilter("a,,b,");
+  expect(f.aliases).toEqual(["a", "b"]);
+  expect(f.sql).toBe(" AND alias IN (?,?)");
+  expect(f.aliases).not.toContain("");
+});
+
+test("a filter of only commas is the same as no filter — it must not silently match zero rows", () => {
+  const f = parseAliasFilter(",,,");
+  expect(f.sql).toBe("");
+});
+
+test("placeholder count always equals alias count, so params can never misalign", () => {
+  for (const raw of ["a", "a,b", "a,,b", " a , b , c ", ",x,"]) {
+    const f = parseAliasFilter(raw);
+    expect((f.sql.match(/\?/g) ?? []).length).toBe(f.aliases.length);
+  }
+});
+
+test("aliases are passed through verbatim — no globbing, no case folding", () => {
+  const f = parseAliasFilter("A站内容,a站内容");
+  expect(f.aliases).toEqual(["A站内容", "a站内容"]);
+  expect(f.sql).not.toContain("LIKE");
+});
+
+// Wiring: the tool must actually use this module, and must say what its
+// `summary` counted — a caller who asked about three aliases and gets back
+// "idle: 96" can easily read the 96 as being about their three.
+import { readFileSync } from "fs";
+import { join } from "path";
+
+test("get_all_status uses parseAliasFilter and declares what summary counted", () => {
+  const source = readFileSync(join(import.meta.dir, "tools.ts"), "utf8");
+  const a = source.indexOf('"get_all_status"');
+  expect(a).toBeGreaterThan(-1);
+  const body = source.slice(a, source.indexOf('server.tool(', a + 10));
+  expect(body).toContain("filter_alias");
+  expect(body).toContain("parseAliasFilter(filter_alias)");
+  expect(body).toContain("summary_scope");
+  expect(body).toContain("sessions_returned");
+  // The alias list must go through parameters, never be interpolated.
+  expect(body).not.toMatch(/alias IN \(\$\{/);
+});

--- a/server/src/alias-filter.ts
+++ b/server/src/alias-filter.ts
@@ -1,0 +1,32 @@
+// Parse the `filter_alias` argument of `get_all_status` into an exact-match
+// IN list.
+//
+// Why this exists at all: on a 222-session hub the unfiltered response is about
+// 259 KB — past what an MCP client accepts in one result. A caller who wanted
+// the status of three specific nodes could not get it from the tool, and had to
+// go around it to the REST API. The filter is the fix; this module is the part
+// of it worth pinning, because the interesting behaviour is what happens to the
+// inputs that are not a clean alias.
+//
+// Blank entries are DROPPED rather than matched. A trailing comma would
+// otherwise produce `alias = ''`, which matches no row — and "no rows" reads
+// exactly like "those nodes do not exist". The failure and the true answer
+// would be indistinguishable to the caller, which is the thing to avoid.
+
+export interface AliasFilter {
+  /** Exact aliases to match. Empty means "no alias filtering". */
+  aliases: string[];
+  /** SQL fragment to append, or "" when there is nothing to filter on. */
+  sql: string;
+}
+
+export function parseAliasFilter(raw: string | undefined | null): AliasFilter {
+  const aliases = (raw ?? "")
+    .split(",")
+    .map(a => a.trim())
+    .filter(Boolean);
+  return {
+    aliases,
+    sql: aliases.length > 0 ? ` AND alias IN (${aliases.map(() => "?").join(",")})` : "",
+  };
+}

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
+import { parseAliasFilter } from "./alias-filter.js";
 import { createHash } from "node:crypto";
 import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken, syncScheduledRunForTask } from "./db.js";
 import { getSSEStats, pushEvent, pushNetworkObserverEvent } from "./push.js";
@@ -1104,16 +1105,25 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
   server.tool(
     "get_all_status",
-    "Get status of all sessions. Hub uses this for the patrol loop.",
+    "Get status of all sessions. Hub uses this for the patrol loop. " +
+      "Pass filter_alias (comma-separated) when you only care about specific " +
+      "nodes — the unfiltered result is one row per session with 31 columns and " +
+      "is large enough on a real fleet that callers cannot read it.",
     {
       filter_status: z.string().max(50).optional(),
       filter_server: z.string().max(200).optional(),
+      // 2026-08-17: on a 222-session hub the unfiltered response is ~259 KB, past
+      // what an MCP client can take in one result — so the caller that wanted the
+      // status of THREE nodes could not get it from this tool at all. The patrol
+      // loop still wants everything, hence optional rather than required.
+      filter_alias: z.string().max(2000).optional()
+        .describe("One alias, or several separated by commas. Exact matches only."),
       network_id: z.string().max(200).optional().describe("Filter by network"),
     },
-    async ({ filter_status, filter_server, network_id: netId }) => {
+    async ({ filter_status, filter_server, filter_alias, network_id: netId }) => {
       const readScope = resolveReadScope(netId);
       if (readScope.denied) return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: readScope.denied }) }] };
-      console.log(`[${ts()}] hub → get_all_status${filter_status ? ": filter=" + filter_status : ""}${readScope.networkId ? " net=" + readScope.networkId.slice(0, 12) : ""}`);
+      console.log(`[${ts()}] hub → get_all_status${filter_status ? ": filter=" + filter_status : ""}${filter_alias ? " alias=" + filter_alias.slice(0, 80) : ""}${readScope.networkId ? " net=" + readScope.networkId.slice(0, 12) : ""}`);
 
       // Round-2/4 review ③: stale-marking moved to startStaleSessionSweeper()
       // (background timer, ~60s cadence). Read path no longer fires UPDATE.
@@ -1122,20 +1132,42 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       sql = addReadScope(sql, params, readScope);
       if (filter_status) { sql += " AND status = ?"; params.push(filter_status); }
       if (filter_server) { sql += " AND server = ?"; params.push(filter_server); }
+      const aliasFilter = parseAliasFilter(filter_alias);
+      const aliases = aliasFilter.aliases;
+      if (aliasFilter.sql) {
+        sql += aliasFilter.sql;
+        params.push(...aliases);
+      }
       sql += " ORDER BY updated_at DESC";
       const sessions = db.all(sql, ...params);
 
+      // `summary` has always counted every session in the read scope, ignoring
+      // filter_status / filter_server — and now filter_alias. That is fine for
+      // the patrol loop, but a caller who asked about three aliases and gets
+      // back three rows plus "idle: 96" can easily read the 96 as being about
+      // their three. A count that does not say what it counted invites exactly
+      // that. So the response now says so, rather than the semantics changing
+      // under existing callers.
       const summaryParams: any[] = [];
       let summarySql = "SELECT status, COUNT(*) as count FROM sessions WHERE 1=1";
       summarySql = addReadScope(summarySql, summaryParams, readScope);
       summarySql += " GROUP BY status";
       const summary = db.all(summarySql, ...summaryParams);
 
+      const filtered = !!(filter_status || filter_server || aliases.length > 0);
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({ ok: true, sessions, summary }),
+            text: JSON.stringify({
+              ok: true,
+              sessions,
+              summary,
+              summary_scope: filtered
+                ? "every session in the read scope — NOT narrowed by the filters applied to `sessions`"
+                : "every session in the read scope",
+              sessions_returned: sessions.length,
+            }),
           },
         ],
       };


### PR DESCRIPTION
见提交信息。起因是我自己撞的:这个 hub 有 222 个 session,`get_all_status` 的完整响应约 **259 KB**,超过 MCP 客户端单次结果能收的量 —— 于是**想查三个节点状态的调用方,从这个工具里根本拿不到**,只能绕去 REST API。

**空条目被丢弃而不是参与匹配。** 尾逗号否则会产生 `alias = ''`,它匹配不到任何行 —— 而「没有行」读起来和「那些节点不存在」**完全一样**。调用方分不出这是失败还是真答案。这就是为什么解析逻辑单独成模块并有 9 条测试,包括「占位符个数恒等于 alias 个数,参数不可能错位」和「全是逗号 = 不过滤,而不是匹配零行」。

另外加了 `summary_scope` 和 `sessions_returned`:`summary` 一直是数读取范围内的全部 session、忽略过滤条件(这对巡检循环是对的)—— 但一个只问了三个 alias 的调用方拿到三行 + `idle: 96`,很容易把 96 读成是这三个的。**与其改动既有语义,不如让这个数字自己说清它数的是什么。**

🔴 **一条与本 PR 无关但需要有人看的**:`server/src/task-lifecycle-watcher.test.ts` **在 main 上今天就是红的**("startHub owns a live watcher timer instead of relying on import side effects",expected 0 received 1)。我在同一棵树里换成 main 的 `tools.ts` 跑同一个文件,失败方式逐字相同。项目自己的 runner 两边都是 **937 pass / 1 fail**。