### PR TITLE
fix(tests): outbound 工具集断言改为从真相源派生(#816 —— 门是错的,而且没人跑)

### DIFF
--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -13,6 +13,7 @@
  */
 
 import { readFileSync, existsSync } from "fs";
+import { OUTBOUND_TOOL_NAMES } from "./outbound-tool-names";
 import { randomUUID } from "crypto";
 import { join } from "path";
 import { hostname } from "os";
@@ -169,12 +170,6 @@ const mcp = new Server(
 );
 
 // ── Tools ───────────────────────────────────────────
-const OUTBOUND_TOOL_NAMES = new Set([
-  "commhub_send_task",
-  "commhub_send_message",
-  "commhub_get_all_status",
-  "commhub_upload_file",
-]);
 
 mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [

--- a/agent-network/src/outbound-tool-names.test.ts
+++ b/agent-network/src/outbound-tool-names.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { OUTBOUND_TOOL_NAMES } from "./outbound-tool-names";
+
+test("the outbound set contains every tool a node-server exposes in outbound-only mode", () => {
+  expect([...OUTBOUND_TOOL_NAMES].sort()).toEqual([
+    "commhub_get_all_status",
+    "commhub_send_message",
+    "commhub_send_task",
+    "commhub_upload_file",
+  ]);
+});
+
+test("importing the constant does not boot a server", () => {
+  // node-server.ts opens an MCP stdio connection and starts an SSE listener on
+  // import. A test that reads the list must not pay for that, or it fails for
+  // reasons unrelated to what it tests.
+  // Strip comments first. This is the second time tonight an absence-assertion
+  // tripped on prose that quotes the thing being forbidden — the header of that
+  // module explains the boot problem by quoting an import statement. Assert
+  // about the code.
+  const raw = readFileSync(join(import.meta.dir, "outbound-tool-names.ts"), "utf8");
+  const code = raw.split("\n").filter(l => !l.trim().startsWith("//")).join("\n");
+  expect(code).not.toContain("import ");
+  expect(code).not.toMatch(/require\(/);
+});
+
+test("node-server.ts consumes the shared constant rather than redeclaring it", () => {
+  const src = readFileSync(join(import.meta.dir, "node-server.ts"), "utf8");
+  expect(src).toContain('from "./outbound-tool-names"');
+  // A second declaration is the drift this module exists to prevent.
+  expect(src).not.toMatch(/const OUTBOUND_TOOL_NAMES\s*=\s*new Set/);
+});
+
+test("test235's harness derives its expectation instead of copying the names", () => {
+  const harness = readFileSync(
+    join(import.meta.dir, "..", "..", "tests", "test235-grok-mcp-outbound-only", "socket-harness.ts"),
+    "utf8",
+  );
+  expect(harness).toContain('from "../../agent-network/src/outbound-tool-names"');
+  expect(harness).toContain("[...OUTBOUND_TOOL_NAMES].sort()");
+  // The old copy asserted exactly three names and went stale when the fourth
+  // shipped; nothing noticed, because no CI job runs test235.
+  expect(harness).not.toContain('JSON.stringify(["commhub_send_task", "commhub_send_message", "commhub_get_all_status"])');
+});

--- a/agent-network/src/outbound-tool-names.test.ts
+++ b/agent-network/src/outbound-tool-names.test.ts
@@ -35,35 +35,26 @@ test("node-server.ts consumes the shared constant rather than redeclaring it", (
   expect(src).not.toMatch(/const OUTBOUND_TOOL_NAMES\s*=\s*new Set/);
 });
 
-test.skipIf(!existsSync(HARNESS))("test235's harness derives its expectation instead of copying the names", () => {
-  const harness = readFileSync(HARNESS, "utf8");
-  expect(harness).toContain('from "../../agent-network/src/outbound-tool-names"');
-  expect(harness).toContain("[...OUTBOUND_TOOL_NAMES].sort()");
-  // The old copy asserted exactly three names and went stale when the fourth
-  // shipped; nothing noticed, because no CI job runs test235.
-  expect(harness).not.toContain('JSON.stringify(["commhub_send_task", "commhub_send_message", "commhub_get_all_status"])');
-});
-
-// 🔴 Why skipIf rather than a plain test: this file also runs inside
-// tests/test745-agent-network-unit-ci, whose image copies ONLY agent-network/
-// (plus agent-node/package.json and its own run.sh). Reaching across to
-// tests/test235-.../socket-harness.ts passes on a full checkout and fails with
-// ENOENT in that container — which is exactly what happened on the first CI run
-// of this branch.
+// 🔴 The harness assertion used to live here and does not any more.
 //
-// Skipping when the file is absent is a fail-open, so it is paired with a check
-// that says so out loud instead of quietly reporting a pass: in a full checkout
-// the file must be there, and its absence there is a real regression.
-test("the harness assertion is not silently skipped in a full checkout", () => {
-  const fullCheckout = existsSync(join(import.meta.dir, "..", "..", "tests"));
-  if (fullCheckout) {
-    expect(existsSync(HARNESS)).toBe(true);
-  } else {
-    // Package-scoped container. Say which assertion did not run, so a green
-    // here is never mistaken for "the harness was checked".
-    console.warn(
-      "[outbound-tool-names.test] tests/ is not present — the socket-harness " +
-      "assertion did NOT run in this image. It runs on a full checkout.",
-    );
-  }
-});
+// tests/test745-agent-network-unit-ci's image copies ONLY agent-network/ (plus
+// agent-node/package.json and its own run.sh), so reading
+// tests/test235-.../socket-harness.ts from this suite is ENOENT there. I tried
+// two ways to be clever about that and got both wrong:
+//
+//   1. read it unconditionally      → ENOENT in the container
+//   2. skip when `tests/` is absent → the container HAS a `tests/` directory
+//                                     (test745's own run.sh lives in it), so the
+//                                     probe said "full checkout" and asserted
+//                                     anyway
+//
+// The second failure is the same mistake twice: probing an incidental feature
+// ("is there a tests/ directory") instead of the thing itself. Rather than build
+// a third detector, this suite now asserts only what is inside its own package.
+//
+// The consequence is stated rather than papered over: NOTHING gates the fact
+// that socket-harness.ts derives its expectation from OUTBOUND_TOOL_NAMES. That
+// is not a new gap introduced here — no workflow and neither of qa.sh's L0/L1
+// lists runs test235 at all, which is why its assertion could be wrong on main
+// for as long as it was. Wiring test235 into CI is the fix for that, and it is a
+// separate change: it needs a real hub and a socket harness, not a unit runner.

--- a/agent-network/src/outbound-tool-names.test.ts
+++ b/agent-network/src/outbound-tool-names.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { join } from "path";
+
+const HARNESS = join(import.meta.dir, "..", "..", "tests", "test235-grok-mcp-outbound-only", "socket-harness.ts");
 import { OUTBOUND_TOOL_NAMES } from "./outbound-tool-names";
 
 test("the outbound set contains every tool a node-server exposes in outbound-only mode", () => {
@@ -33,14 +35,35 @@ test("node-server.ts consumes the shared constant rather than redeclaring it", (
   expect(src).not.toMatch(/const OUTBOUND_TOOL_NAMES\s*=\s*new Set/);
 });
 
-test("test235's harness derives its expectation instead of copying the names", () => {
-  const harness = readFileSync(
-    join(import.meta.dir, "..", "..", "tests", "test235-grok-mcp-outbound-only", "socket-harness.ts"),
-    "utf8",
-  );
+test.skipIf(!existsSync(HARNESS))("test235's harness derives its expectation instead of copying the names", () => {
+  const harness = readFileSync(HARNESS, "utf8");
   expect(harness).toContain('from "../../agent-network/src/outbound-tool-names"');
   expect(harness).toContain("[...OUTBOUND_TOOL_NAMES].sort()");
   // The old copy asserted exactly three names and went stale when the fourth
   // shipped; nothing noticed, because no CI job runs test235.
   expect(harness).not.toContain('JSON.stringify(["commhub_send_task", "commhub_send_message", "commhub_get_all_status"])');
+});
+
+// 🔴 Why skipIf rather than a plain test: this file also runs inside
+// tests/test745-agent-network-unit-ci, whose image copies ONLY agent-network/
+// (plus agent-node/package.json and its own run.sh). Reaching across to
+// tests/test235-.../socket-harness.ts passes on a full checkout and fails with
+// ENOENT in that container — which is exactly what happened on the first CI run
+// of this branch.
+//
+// Skipping when the file is absent is a fail-open, so it is paired with a check
+// that says so out loud instead of quietly reporting a pass: in a full checkout
+// the file must be there, and its absence there is a real regression.
+test("the harness assertion is not silently skipped in a full checkout", () => {
+  const fullCheckout = existsSync(join(import.meta.dir, "..", "..", "tests"));
+  if (fullCheckout) {
+    expect(existsSync(HARNESS)).toBe(true);
+  } else {
+    // Package-scoped container. Say which assertion did not run, so a green
+    // here is never mistaken for "the harness was checked".
+    console.warn(
+      "[outbound-tool-names.test] tests/ is not present — the socket-harness " +
+      "assertion did NOT run in this image. It runs on a full checkout.",
+    );
+  }
 });

--- a/agent-network/src/outbound-tool-names.ts
+++ b/agent-network/src/outbound-tool-names.ts
@@ -1,0 +1,21 @@
+// The exact set of tools a node-server exposes in outbound-only mode.
+//
+// It lives in its own module for one reason: tests need to assert against it,
+// and importing node-server.ts to read a constant BOOTS THE SERVER — it opens
+// an MCP stdio connection and starts an SSE listener on import. Verified by
+// doing exactly that: `bun -e 'import { OUTBOUND_TOOL_NAMES } from
+// "./src/node-server.ts"'` printed `[commhub] MCP stdio connected` before it
+// printed the constant. A test harness that boots a live server just to read a
+// list is a harness that fails for reasons unrelated to what it tests.
+//
+// Why a shared constant at all: tests/test235-grok-mcp-outbound-only asserted a
+// hard-coded copy of three names. `commhub_upload_file` shipped in #693 and made
+// it four, so that assertion has been wrong on main — and nothing reported it,
+// because no workflow and neither qa.sh list runs test235.
+
+export const OUTBOUND_TOOL_NAMES = new Set([
+  "commhub_send_task",
+  "commhub_send_message",
+  "commhub_get_all_status",
+  "commhub_upload_file",
+]);

--- a/tests/test235-grok-mcp-outbound-only/socket-harness.ts
+++ b/tests/test235-grok-mcp-outbound-only/socket-harness.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { OUTBOUND_TOOL_NAMES } from "../../agent-network/src/outbound-tool-names";
 
 type RpcMessage = { id?: number; method?: string; result?: any; error?: any; params?: any };
 
@@ -207,7 +208,21 @@ try {
   await sendRpc({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} } as any);
   const listed = await waitForId(2);
   const toolNames = listed.result?.tools?.map((tool: any) => tool.name) || [];
-  assert(JSON.stringify(toolNames) === JSON.stringify(["commhub_send_task", "commhub_send_message", "commhub_get_all_status"]), "exact three outbound tools");
+  // 🔴 The expected set comes from the source of truth, not from a copy.
+  //
+  // This line used to hard-code three names. `OUTBOUND_TOOL_NAMES` in
+  // agent-network/src/node-server.ts has carried FOUR since commhub_upload_file
+  // shipped (#693), so the assertion has been wrong on main — and nothing
+  // reported it, because no workflow and neither qa.sh list runs test235. A
+  // gate that is wrong and unrun is indistinguishable from a gate that passes.
+  //
+  // Sorted on both sides: the assertion is about WHICH tools are exposed, not
+  // about the order the server happens to register them in.
+  const expectedOutbound = [...OUTBOUND_TOOL_NAMES].sort();
+  assert(
+    JSON.stringify([...toolNames].sort()) === JSON.stringify(expectedOutbound),
+    `outbound tool set must equal OUTBOUND_TOOL_NAMES (${expectedOutbound.join(", ")}); got ${[...toolNames].sort().join(", ") || "<none>"}`,
+  );
 
   await Bun.sleep(350);
   assert(state.sseOpened === 1, "only outer owner opens SSE");


### PR DESCRIPTION
见提交信息。

**三件事凑齐了**:`OUTBOUND_TOOL_NAMES` 现在是 **4 个**(`commhub_upload_file` 在 #693 就上了)、`socket-harness.ts:210` 写死 **3 个**、而 **test235 不在任何 workflow 也不在 qa.sh 的 L0/L1 里** —— 所以这个错误的断言一直没人发现。**一道错的、且没人跑的门,和一道通过的门无法区分。**

这是今晚**同一形状的第三例**(前两例:qa.yml 的 path filter 漏掉它自己会跑的测试、两个零调用者的 verify 脚本)。

常量抽成独立文件而不是从 node-server.ts export,理由是实测出来的:**import node-server.ts 拿常量会把服务器启动起来**
```
$ bun -e 'import { OUTBOUND_TOOL_NAMES } from "./src/node-server.ts"; …'
[commhub] MCP stdio connected
[commhub] starting SSE listener...
  OUTBOUND_TOOL_NAMES: commhub_get_all_status, …
```
一个为了读清单而开真 MCP 连接的 harness,会因为与被测无关的原因失败。我写这个修复时就撞到了。

断言两边都排序:它问的是**暴露了哪些工具**,不是服务器注册它们的顺序 —— 顺序敏感的比较会把一次重排变成一个谜之失败。

**一条署名说明**:这条我最初报成「不复现」。我 grep 的是**新工具名**,当然搜不到 —— 断言钉的是**旧的三个**、根本不提 upload_file。是通信团队的分诊节点核出来并指到 `socket-harness.ts:210` 的。**探针要瞄断言本身,不是瞄症状。**