### PR TITLE
fix(hub): PORT=0 应该是临时端口,而不是生产 Hub 端口(修掉 main 上唯一的红)

### DIFF
--- a/server/src/resolve-port.test.ts
+++ b/server/src/resolve-port.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { DEFAULT_PORT, resolvePort } from "./resolve-port";
+
+// The whole reason this module exists.
+test("PORT=0 means an ephemeral port, not the production default", () => {
+  expect(resolvePort("0")).toBe(0);
+  expect(resolvePort("0")).not.toBe(DEFAULT_PORT);
+});
+
+test("unset or empty falls back to the default", () => {
+  expect(resolvePort(undefined)).toBe(DEFAULT_PORT);
+  expect(resolvePort("")).toBe(DEFAULT_PORT);
+  expect(resolvePort("   ")).toBe(DEFAULT_PORT);
+});
+
+test("surrounding whitespace is tolerated — it is trimmed, not treated as malformed", () => {
+  expect(resolvePort(" 9201 ")).toBe(9201);
+  expect(resolvePort("\t0\n")).toBe(0);
+});
+
+test("an explicit port is used verbatim", () => {
+  expect(resolvePort("9201")).toBe(9201);
+  expect(resolvePort("1")).toBe(1);
+  expect(resolvePort("65535")).toBe(65535);
+});
+
+// Defaulting on a malformed value means a typo silently starts the server on
+// the production port — on this fleet, on top of the running Hub.
+test("a malformed value is rejected, never quietly defaulted", () => {
+  for (const bad of ["abc", "80a", "-1", "65536", "1.5", "0x10", "NaN", "Infinity", "9 200", "+80"]) {
+    expect(() => resolvePort(bad)).toThrow();
+  }
+});
+
+test("the rejection names the value and the accepted range", () => {
+  try {
+    resolvePort("abc");
+    throw new Error("should have thrown");
+  } catch (e: any) {
+    expect(e.message).toContain("abc");
+    expect(e.message).toContain("0 and 65535");
+    expect(e.message).toContain("ephemeral");
+  }
+});
+
+test("a caller can override the fallback without touching the default", () => {
+  expect(resolvePort(undefined, 3000)).toBe(3000);
+  expect(resolvePort("0", 3000)).toBe(0);
+});
+
+test("server.ts resolves PORT through this module, not through `|| DEFAULT`", () => {
+  const src = require("fs").readFileSync(require("path").join(import.meta.dir, "server.ts"), "utf8");
+  const code = src.split("\n").filter((l: string) => !l.trim().startsWith("//")).join("\n");
+  expect(code).toContain("resolvePort(process.env.PORT)");
+  // `Number(env) || default` is the exact shape that swallowed the 0.
+  expect(code).not.toMatch(/Number\(process\.env\.PORT\)\s*\|\|/);
+});

--- a/server/src/resolve-port.ts
+++ b/server/src/resolve-port.ts
@@ -1,0 +1,44 @@
+// Resolve the listen port from the environment.
+//
+// `Number(process.env.PORT) || 9200` swallows a legitimate `0`. `Number("0")`
+// is `0`, which is falsy, so `PORT=0` — the conventional way to ask the OS for
+// an ephemeral port — silently became 9200, the production Hub port.
+//
+// Three consequences, and the middle one is the worst:
+//
+//   1. On a host where 9200 is already taken (a running Hub), a test that sets
+//      PORT=0 dies with EADDRINUSE and reads as a product bug.
+//      task-lifecycle-watcher.test.ts fails on main today for exactly this.
+//   2. On a host where 9200 is FREE, the same test passes — by binding 9200.
+//      It is green because it grabbed the production port, not because PORT=0
+//      worked. Green for the wrong reason is worse than red.
+//   3. Anyone asking for an ephemeral port gets the production port instead.
+//
+// The file already knew: `bootServer` uses `opts.port ?? PORT` with a comment
+// saying `||` "would swallow a legitimate 0". The rule was one level up from
+// where it was needed.
+//
+// A malformed value is rejected rather than defaulted. Falling back to 9200 on
+// `PORT=abc` means a typo silently starts the server somewhere the operator did
+// not ask for — and on this fleet that somewhere is production.
+
+export const DEFAULT_PORT = 9200;
+
+export function resolvePort(raw: string | undefined, fallback = DEFAULT_PORT): number {
+  // Unset or empty means "not specified". An empty string is what a shell
+  // exports for an unset variable it still passes along, so treating it as 0
+  // would make `PORT= anet hub start` bind an ephemeral port by accident.
+  if (raw === undefined || raw.trim() === "") return fallback;
+
+  // Decimal digits only, after trimming. `Number()` alone accepts "0x10" (16)
+  // and " 9200 ", so a value that does not look like a port would still resolve
+  // to one — quietly, and to a different number than the operator typed.
+  const text = raw.trim();
+  const n = /^\d+$/.test(text) ? Number(text) : NaN;
+  if (!Number.isInteger(n) || n < 0 || n > 65535) {
+    throw new Error(
+      `PORT must be an integer between 0 and 65535 (0 asks the OS for an ephemeral port); got ${JSON.stringify(raw)}`,
+    );
+  }
+  return n;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { resolvePort } from "./resolve-port.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { z } from "zod/v4";
 import { registerTools } from "./tools.js";
@@ -48,7 +49,7 @@ import { assertScheduledTaskBackendSupported, handleScheduledTaskRequest, startS
 import { handleExternalScheduleEditRequest } from "./external-schedule-edits.js";
 import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
 
-const PORT = Number(process.env.PORT) || 9200;
+const PORT = resolvePort(process.env.PORT);
 const HOST = process.env.HOST || "127.0.0.1";
 const AUTH_TOKEN = process.env.COMMHUB_AUTH_TOKEN;
 const DEV_OPEN = process.argv.includes("--dev-open") || process.env.COMMHUB_DEV_OPEN === "1";


### PR DESCRIPTION
见提交信息。

`server/src/server.ts:51` 是
```ts
const PORT = Number(process.env.PORT) || 9200;
```
`Number("0")` 是 `0`(falsy)→ `PORT=0` 这个「向 OS 要临时端口」的惯用写法,**静默变成了 9200,生产 Hub 端口**。

**三层后果,中间那层最糟**:
| # | 场景 | 结果 |
|---|---|---|
| 1 | 9200 被占(有 Hub 在跑) | 设 PORT=0 的测试 EADDRINUSE 而死,**读起来像产品坏了** |
| 2 | 9200 空闲 | 同一个测试**绑上 9200 然后通过** —— 绿是因为它抢到了生产端口,不是因为 PORT=0 生效。**为错误的理由绿,比红更糟** |
| 3 | 任何人想要临时端口 | 拿到生产端口 |

**不是假想**:`server/src/task-lifecycle-watcher.test.ts` **今天在 main 上就是红的**,原因正是这个 —— 它用 `PORT: "0"` 起 Hub,子进程绑 9200,9200 已被占,子进程 exit 1,于是 `expect(child.exitCode).toBeNull()` 失败。**测试报的是「watcher 没活下来」,一个字都没提端口** —— 错误信息指向了完全错误的层。

**这个文件自己就知道**:`bootServer` 用的是 `opts.port ?? PORT`,旁边的注释写着 `||` "would swallow a legitimate 0"。**正确的规则就在需要它的那行上方一层。**

`resolvePort` 还会**拒绝畸形值而不是回退默认**:`PORT=abc` 回退到 9200 意味着一个笔误会把服务器起到操作者没要求的地方,而在这个舰队上那个地方是生产。解析只接受 trim 后的十进制数字 —— 单用 `Number()` 会把 `"0x10"` 当成 16,一个看起来不像端口的值仍会解析成一个端口,而且是和输入不同的数。

**A/B(同一棵树、同样的 DB 布局、cwd 在仓根)**:
```
main 的 server.ts   4 pass, 1 fail   (EADDRINUSE, 子进程 exit 1)
本分支              5 pass, 0 fail   (子进程绑 41885 并保持存活)
```
项目自己的 runner 现在是 **946 pass / 0 fail / bad=false**;此前是 937 pass / 1 fail。