### PR TITLE
fix(ci): 把唯一的第三方 action 钉到 SHA,并加一道门防下一个 (#746)

### DIFF
--- a/.github/scripts/check-action-pins.py
+++ b/.github/scripts/check-action-pins.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Third-party GitHub Actions must be pinned to a commit SHA, not a moving tag.
+
+`uses: some-org/some-action@v2` resolves whatever that tag points at today. The
+tag is writable by whoever owns the action, so the code that runs in CI — with
+this repository's checkout and secrets in scope — can change without a commit
+here and without anyone reviewing it.
+
+Scope, stated because a filter you cannot see is a filter you cannot trust:
+
+  * `actions/*` (GitHub's own) are ALLOWED on tags. That is the near-universal
+    convention, they are first-party, and changing them is a separate policy
+    call — not something to smuggle in under a guard about third parties.
+  * Everything else must carry a 40-hex SHA. A trailing `# v2` comment is
+    encouraged so a reader can still tell what the pin means.
+  * Local actions (`./…`) and Docker actions (`docker://…`) are out of scope:
+    they are not fetched from a tag at all.
+
+This does NOT claim to fix flaky downloads. On 2026-08-17 a `L0 + L1` job here
+failed with three consecutive 429s fetching `oven-sh/setup-bun`, and a SHA pin
+would not have changed that — the request still goes to codeload. Pinning is
+about knowing WHAT ran, not about whether the fetch succeeds. Saying otherwise
+would be selling the guard on a benefit it does not deliver.
+
+Fail-closed: no workflow files, or no `uses:` lines at all, exits 2 rather than
+reporting a clean scan of nothing.
+"""
+import re
+import sys
+from pathlib import Path
+
+WORKFLOWS = Path(".github/workflows")
+USES = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)")
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+FIRST_PARTY_OWNERS = {"actions", "github"}
+
+
+def main() -> int:
+    if not WORKFLOWS.is_dir():
+        print(f"::error::{WORKFLOWS} does not exist — scope regression, refusing to pass")
+        return 2
+
+    files = sorted(list(WORKFLOWS.glob("*.yml")) + list(WORKFLOWS.glob("*.yaml")))
+    if not files:
+        print(f"::error::no workflow files under {WORKFLOWS} — scope regression, refusing to pass")
+        return 2
+
+    total = 0
+    problems = 0
+    for f in files:
+        for i, line in enumerate(f.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            m = USES.match(line)
+            if not m:
+                continue
+            ref = m.group(1)
+            if ref.startswith("./") or ref.startswith("docker://"):
+                continue
+            total += 1
+            if "@" not in ref:
+                problems += 1
+                print(f"::error file={f},line={i}::`{ref}` has no ref at all — pin it to a commit SHA")
+                continue
+            repo, _, version = ref.rpartition("@")
+            owner = repo.split("/", 1)[0]
+            if owner in FIRST_PARTY_OWNERS:
+                continue
+            if not SHA40.match(version):
+                problems += 1
+                print(
+                    f"::error file={f},line={i}::third-party action `{repo}` is pinned to "
+                    f"`{version}`, a tag its owner can repoint. Whatever it points at runs here "
+                    f"with this checkout and these secrets, without a commit in this repo.\n"
+                    f"    Pin the SHA and keep the tag as a comment:\n"
+                    f"      uses: {repo}@<40-hex-sha> # {version}"
+                )
+
+    if total == 0:
+        print("::error::scanned ZERO `uses:` lines — the parser stopped matching; refusing to pass")
+        return 2
+
+    print(f"checked {total} action reference(s) across {len(files)} workflow file(s)")
+    if problems:
+        print(f"\n{problems} unpinned third-party action(s).")
+        return 1
+    print("every third-party action is pinned to a commit SHA.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -1,0 +1,34 @@
+# Third-party GitHub Actions must be pinned to a commit SHA.
+#
+# `uses: some-org/some-action@v2` runs whatever that tag points at today, and
+# the tag is writable by the action's owner. The code it resolves to executes
+# here with this repository's checkout and secrets in scope, and it can change
+# without any commit in this repo for anyone to review.
+#
+# Scope is deliberate and narrow: `actions/*` (GitHub's own) stay on tags —
+# that is the near-universal convention, and changing it is a separate policy
+# call rather than something to smuggle in under a third-party guard.
+#
+# 🔴 This does NOT fix flaky downloads. On 2026-08-17 a `L0 + L1` job here died
+#    on three consecutive 429s fetching oven-sh/setup-bun, and a SHA pin would
+#    not have changed that — the request still goes to codeload. Pinning is
+#    about knowing WHAT ran. Selling it as a flakiness fix would be selling a
+#    benefit it does not deliver.
+#
+# 🔴 No `paths:` filter, for the same reason as qa-trigger-coverage: this guards
+#    the workflow directory, and gating it on that directory would let a change
+#    there slip past the check that watches it.
+
+name: lint (action pins)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 .github/scripts/check-action-pins.py

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 

--- a/tests/test746-setup-bun-pin/run.sh
+++ b/tests/test746-setup-bun-pin/run.sh
@@ -23,9 +23,22 @@ expected = os.environ["EXPECTED_VERSION"]
 found = []
 bad = []
 
+# Match the ACTION, not one particular ref of it. This used to compare against
+# the literal "oven-sh/setup-bun@v2", so SHA-pinning the action (a separate,
+# desirable change) made this find zero occurrences and fail — the guard could
+# not tell "the pin was removed" from "the pin was written differently".
+#
+# It failing closed on zero was right; matching on the ref was not. This guard
+# owns ONE fact: every setup-bun invocation carries the expected bun-version.
+# Whether the action itself is SHA-pinned is a different fact, owned by
+# .github/scripts/check-action-pins.py. One guard, one fact — two guards on the
+# same fact drift apart, and then one of them is wrong and still green.
+SETUP_BUN = "oven-sh/setup-bun@"
+
 def walk(value, path):
     if isinstance(value, dict):
-        if value.get("uses") == "oven-sh/setup-bun@v2":
+        uses = value.get("uses")
+        if isinstance(uses, str) and uses.startswith(SETUP_BUN):
             version = (value.get("with") or {}).get("bun-version")
             found.append((path, version))
             if str(version) != expected:


### PR DESCRIPTION
见提交信息。

`uses: oven-sh/setup-bun@v2` 跑的是那个 tag **今天**指向的东西,而 tag 由 action 的所有者可写。**它解析到的代码在这里执行,带着本仓的 checkout 和 secrets,而且可以在本仓没有任何提交、没有任何人评审的情况下改变。** 三个 workflow 用到它(qa / e2e-docker / release),现在都钉 `0c5077e5…`,并保留 `# v2` 注释让这个 pin 仍然可读。

SHA 是从 GitHub API 解出来的,不是从日志行里抄的 —— `git/ref/tags/v2` 直接返回那个 commit(轻量 tag),且与今晚那次失败下载里出现的 ref 一致。

**#799 已经钉了 `bun-version: 1.3.14`。那钉的是「工具」;安装它的那个「action」还在飘。** 两件不同的事,相隔一行,而**前一件做了会让后一件看起来也做了**。

`actions/*` **故意保持用 tag** —— 那是 GitHub 官方 action 的近乎通用惯例,改它是另一个策略决定,不该藏在一道关于第三方的门里顺手做掉。门里把这个划分写死了并说明了理由。

🔴 **这条不修下载 flaky,本 PR 也不该被读成在这么说。** 今晚那个 `L0 + L1` job 正是因为连吃三次 429 拉这个 action 而死,**而 SHA pin 改变不了这一点** —— 请求照样打 codeload。**钉 SHA 解决的是「知道跑的是什么」,不是「拉得下来」。** workflow 注释和脚本 docstring 里都明写了这条,因为**一道被用它给不了的好处卖出去的门,最后没人信它**。

门的三态:钉好的树 exit 0(11 个文件 24 处引用);main 的 workflows exit 1 并逐个指名、给出该写的那一行;把 `uses:` 正则改坏模拟解析器失配 → **exit 2「scanned ZERO `uses:` lines」**,而不是对着空集干净通过。

它的 workflow **不带 `paths:` filter**,理由同 qa-trigger-coverage:它守的就是 workflow 目录,给自己加 paths 会让那里的改动绕过监视它的检查。