### PR TITLE
fix(install.sh): 别把每一种失败都归因给 registry (#868)

### DIFF
--- a/docs-site/docs/public/install.sh
+++ b/docs-site/docs/public/install.sh
@@ -47,10 +47,35 @@ say ""
 
 # --- Install ---
 say "${CYAN}>${RESET} Installing ${YELLOW}@sleep2agi/agent-network${RESET} globally..."
-npm install -g @sleep2agi/agent-network >/dev/null 2>&1 || {
-  say "${YELLOW}!${RESET} Default registry failed, retrying via npmmirror..."
-  npm install -g @sleep2agi/agent-network --registry https://registry.npmmirror.com
-}
+# Keep the first attempt's stderr. It used to be discarded with `2>&1` to
+# /dev/null and EVERY failure was then reported as "Default registry failed" —
+# so a permission error, a full disk, or an unsupported Node version all told
+# the reader to blame the registry, and the npmmirror retry failed the same way
+# a moment later. The reader was left with a confident, wrong story.
+NPM_LOG="$(mktemp -t anet-install.XXXXXX)"
+if ! npm install -g @sleep2agi/agent-network >"$NPM_LOG" 2>&1; then
+  # Only claim "registry" when the output actually looks like a fetch problem.
+  # Anything else is shown verbatim, because a wrong diagnosis sends the reader
+  # somewhere there is nothing to find.
+  if grep -qiE 'ETIMEDOUT|ENOTFOUND|ECONNRESET|ECONNREFUSED|EAI_AGAIN|network|registry|fetch failed|socket hang up' "$NPM_LOG"; then
+    say "${YELLOW}!${RESET} Default registry looks unreachable, retrying via npmmirror..."
+    if ! npm install -g @sleep2agi/agent-network --registry https://registry.npmmirror.com; then
+      say ""
+      say "${YELLOW}!${RESET} The mirror failed too. First attempt said:"
+      tail -n 20 "$NPM_LOG" >&2
+      rm -f "$NPM_LOG"
+      fail "npm install failed against both registries — see the output above."
+    fi
+  else
+    say ""
+    say "${YELLOW}!${RESET} npm install failed, and it does not look like a registry problem."
+    say "  Retrying a different registry would fail the same way, so here is what npm said:"
+    tail -n 20 "$NPM_LOG" >&2
+    rm -f "$NPM_LOG"
+    fail "npm install failed — see the output above."
+  fi
+fi
+rm -f "$NPM_LOG"
 
 # --- Verify ---
 if ! command -v anet >/dev/null 2>&1; then


### PR DESCRIPTION
公开安装脚本里这两行:
```sh
npm install -g @sleep2agi/agent-network >/dev/null 2>&1 || {
  say "Default registry failed, retrying via npmmirror..."
```
**两行里两个问题**:第一次尝试的 stderr 进了 `/dev/null`,然后**不管出什么错都宣布是 registry 的问题**。权限错误、磁盘满、Node 版本不对 —— 全都被告知去怪 registry,而 npmmirror 的重试片刻后会以同样方式失败。**读者拿到一个笃定但错误的故事,而真正的原因一点痕迹都没留下。**

现在输出被保留,而且**只有当输出看起来真像取包问题时才敢说 registry**(ETIMEDOUT / ENOTFOUND / ECONNRESET / ECONNREFUSED / EAI_AGAIN / network / registry / fetch failed / socket hang up)。其他情况**原样打印**,并明说「换个 registry 重试会以同样方式失败」。如果走了镜像路径且镜像也失败,**把第一次的输出也打出来** —— 否则镜像的错会替换掉原来的错,真正的原因就没了。

**用 stub 过的 npm 对真脚本双向实测**:
| 输入 | 新版 |
|---|---|
| EACCES | 「does not look like a registry problem」· **不重试镜像** · EACCES 展示给读者 |
| ETIMEDOUT | 「looks unreachable, retrying via npmmirror」· 镜像再失败时打出「The mirror failed too」+ 第一次的输出 |

**同一个 stub 打 main 上那份**:EACCES 情况下打印「Default registry failed」,而且**从头到尾没出现过 EACCES 这个词**。

(顺带记一笔:我搭 stub 时第一版假 `node` 没实现 `-p`,于是脚本在版本检查处退出并打印「Node.js >= 22.13 required (current: v22.13.0)」—— 一句自相矛盾的话。**那是量具在说话,不是脚本**。值得记下来,因为读者遇到这句一定会当成产品 bug 报上来。)