### PR TITLE
fix(agent-node): 节点日志把 vendor 的 success 当成自己的结论——一个什么都没产出的节点连打三行 success

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -97,6 +97,7 @@ import {
   formatClassificationForUser,
   formatClassificationForLog,
 } from "./runtime/classify-result";
+import { formatAttemptOutcome } from "./runtime/attempt-log-outcome";
 import { withTimeout, TimeoutError, resolveTimeoutMs } from "./util/timeout";
 import { superviseChild } from "./util/supervise-child";
 import {
@@ -2360,19 +2361,29 @@ async function processWithClaude(
             if (m.type === "result") {
               const dt = Date.now() - t0;
               const u = m.usage || {};
-              log(`[claude] ${m.subtype} | ${dt}ms | $${m.total_cost_usd?.toFixed(4) || "?"} | in=${u.input_tokens || 0} out=${u.output_tokens || 0} | turns=${m.num_turns}${attempt > 0 ? ` | attempt=${attempt + 1}` : ""}`);
-              if (m.subtype === "success") {
-                // #261 P1 redirect (2026-06-28) — delegate to classifyRuntimeResult
-                // which folds the empty-result rule from #267 + the in=0 & out=0
-                // & cost=0 silent-reject rule into one decision shared with
-                // codex / grok. Pre-fix `m.result || "任务完成"` silently
-                // rebranded an empty vendor reply as "task complete" — the M3
-                // incident shape. Now a non-success classification surfaces a
-                // soft-fail string the upstream caller can act on.
-                const cls = classifyRuntimeResult(
-                  { result: m.result, usage: m.usage, totalCostUsd: m.total_cost_usd },
-                  { baseUrl: process.env.ANTHROPIC_BASE_URL },
-                );
+              // #261 P1 redirect (2026-06-28) — delegate to classifyRuntimeResult
+              // which folds the empty-result rule from #267 + the in=0 & out=0
+              // & cost=0 silent-reject rule into one decision shared with
+              // codex / grok. Pre-fix `m.result || "任务完成"` silently
+              // rebranded an empty vendor reply as "task complete" — the M3
+              // incident shape. Now a non-success classification surfaces a
+              // soft-fail string the upstream caller can act on.
+              //
+              // Computed BEFORE the log line on purpose: it used to sit after,
+              // so the line printed the vendor's `subtype` verbatim. A node
+              // pointed at a nonexistent model logged `success | $0.0000 | in=0
+              // out=0` three times in a row and then `✗ all 3 attempts failed`
+              // (TMCode副责人, 2026-08-18). The verdict already existed one line
+              // below; it just wasn't the thing being printed.
+              const cls =
+                m.subtype === "success"
+                  ? classifyRuntimeResult(
+                      { result: m.result, usage: m.usage, totalCostUsd: m.total_cost_usd },
+                      { baseUrl: process.env.ANTHROPIC_BASE_URL },
+                    )
+                  : null;
+              log(`[claude] ${formatAttemptOutcome(m.subtype, cls)} | ${dt}ms | $${m.total_cost_usd?.toFixed(4) || "?"} | in=${u.input_tokens || 0} out=${u.output_tokens || 0} | turns=${m.num_turns}${attempt > 0 ? ` | attempt=${attempt + 1}` : ""}`);
+              if (m.subtype === "success" && cls) {
                 if (cls.kind === "success") {
                   inner = m.result;
                 } else {

--- a/agent-node/src/runtime/attempt-log-outcome.test.ts
+++ b/agent-node/src/runtime/attempt-log-outcome.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { formatAttemptOutcome } from "./attempt-log-outcome";
+import { classifyRuntimeResult } from "./classify-result";
+
+describe("formatAttemptOutcome", () => {
+  it("passes the vendor's own label through when the vendor did not claim success", () => {
+    // Nothing to contradict — `error_max_turns` is already honest.
+    expect(formatAttemptOutcome("error_max_turns", null)).toBe("error_max_turns");
+    expect(formatAttemptOutcome("error_during_execution", null)).toBe("error_during_execution");
+  });
+
+  it("says success only when the node's own classifier agrees", () => {
+    expect(formatAttemptOutcome("success", { kind: "success" })).toBe("success");
+  });
+
+  it("does not print a bare 'success' when the node rejected the turn", () => {
+    const line = formatAttemptOutcome("success", { kind: "soft-fail-empty" });
+    // The point of the module: a log grep for a successful turn must not match.
+    expect(line).not.toBe("success");
+    expect(line).toContain("rejected");
+    expect(line).toContain("soft-fail-empty");
+    // The vendor's claim is kept, so the reader can tell this was a rejected
+    // claim of success rather than a plain vendor-side error.
+    expect(line).toContain("success");
+  });
+
+  it("names which kind of rejection it was", () => {
+    expect(formatAttemptOutcome("success", { kind: "soft-fail-quota" })).toContain("soft-fail-quota");
+    expect(formatAttemptOutcome("success", { kind: "error" })).toContain("rejected:error");
+  });
+});
+
+describe("the live incident this module exists for", () => {
+  // TMCode副责人, 2026-08-18 02:09 — a node configured with a model name that
+  // does not exist. Numbers below are the ones the pane actually printed.
+  const observed = { result: "", usage: { input_tokens: 0, output_tokens: 0 }, totalCostUsd: 0 };
+
+  it("classifies the observed turn as a rejection", () => {
+    // Assert the premise, not just the conclusion: if this ever starts coming
+    // back "success", the log line below would be honest and this whole module
+    // would be pointless — so pin it.
+    expect(classifyRuntimeResult(observed, {}).kind).not.toBe("success");
+  });
+
+  it("would have printed a line that does not claim success", () => {
+    const cls = classifyRuntimeResult(observed, {});
+    const line = formatAttemptOutcome("success", cls);
+    expect(line).not.toBe("success");
+    expect(line.startsWith("success→rejected:")).toBe(true);
+  });
+
+  it("keeps the old behaviour reachable when the turn is genuinely fine", () => {
+    const good = { result: "done", usage: { input_tokens: 120, output_tokens: 40 }, totalCostUsd: 0.01 };
+    expect(formatAttemptOutcome("success", classifyRuntimeResult(good, {}))).toBe("success");
+  });
+});

--- a/agent-node/src/runtime/attempt-log-outcome.ts
+++ b/agent-node/src/runtime/attempt-log-outcome.ts
@@ -1,0 +1,51 @@
+// What the attempt line in the node log is allowed to say.
+//
+// Observed on a live node (TMCode副责人, 2026-08-18 02:09), three consecutive
+// attempts against a model name that does not exist:
+//
+//   [claude] success | 1927ms  | $0.0000 | in=0 out=0 | turns=1
+//   [claude] attempt 1/3 errored: … There's an issue with the selected model …
+//   [claude] success | 7833ms  | $0.0000 | in=0 out=0 | turns=1 | attempt=2
+//   [claude] attempt 2/3 errored: …
+//   [claude] success | 18185ms | $0.0000 | in=0 out=0 | turns=1 | attempt=3
+//   [claude] ✗ all 3 attempts failed; last: errored: …
+//
+// The word `success` there is the VENDOR's `result.subtype`, printed verbatim.
+// The node's own verdict — reached one line later by classifyRuntimeResult,
+// which folds the in=0 & out=0 & cost=0 silent-reject rule — was "this turn
+// produced nothing". So the line that a log reader sees first says success,
+// and the line that is true says the opposite.
+//
+// 🔴 The behaviour was already correct: the classifier rejected all three
+// attempts and the task was reported as failed. Only the LOG lied. That is the
+// worse half to leave broken, because anything that judges node health by
+// grepping logs gets a green from a node that produced nothing at all — and a
+// false green is byte-identical to a true one.
+//
+// This module does not re-derive "did it work". It takes the classification the
+// node already computed and states it. Re-implementing the criterion here would
+// give us two definitions of success that can drift apart, which is the same
+// class of defect one level down.
+
+import type { ClassificationResult } from "./classify-result";
+
+/**
+ * First field of the per-attempt result line.
+ *
+ * @param vendorSubtype the runtime SDK's own `result.subtype`
+ * @param classification the node's verdict, or `null` when the node did not
+ *        classify this turn (i.e. the vendor did not claim success, so there is
+ *        nothing to contradict and the vendor's word is passed through).
+ */
+export function formatAttemptOutcome(
+  vendorSubtype: string,
+  classification: ClassificationResult | null,
+): string {
+  // Vendor did not claim success → its own label is already the honest one
+  // (`error_max_turns`, `error_during_execution`, …).
+  if (!classification) return vendorSubtype;
+  if (classification.kind === "success") return "success";
+  // Vendor said success, the node disagreed. Say both, so a reader can tell
+  // this is a rejection of a claimed success rather than a plain vendor error.
+  return `${vendorSubtype}→rejected:${classification.kind}`;
+}


### PR DESCRIPTION
## 现场(活节点,不是构造的)

`TMCode副责人` 被派了一个任务,它的模型名 `gpt-5.6-sol` 不存在。pane 里连续三次:

```
[02:09:33] [claude] session=6bd0d446 model=gpt-5.6-sol attempt=1
[02:09:34] [claude] success | 1927ms  | $0.0000 | in=0 out=0 | turns=1
[02:09:34] [claude] attempt 1/3 errored: … There's an issue with the selected model (gpt-5.6-sol)
[02:09:39] [claude] session=6bd0d446 model=gpt-5.6-sol attempt=2
[02:09:40] [claude] success | 7833ms  | $0.0000 | in=0 out=0 | turns=1 | attempt=2
[02:09:40] [claude] attempt 2/3 errored: …
[02:09:50] [claude] success | 18185ms | $0.0000 | in=0 out=0 | turns=1 | attempt=3
[02:09:50] [claude] ✗ all 3 attempts failed; last: errored: …
```

**三次 `success`,三次紧跟着 errored。** 而且每次都是 `$0.0000 | in=0 out=0` —— 模型根本没被调用过。

## 那个 `success` 是谁说的

是 **vendor 的 `result.subtype`,原样打印**(`cli.ts:2363`)。

节点**自己的**判定在**下一行**才算:`classifyRuntimeResult`,它有一条 `in=0 & out=0 & cost=0 → soft-fail-empty` 的静默拒绝规则,判的正是「这一轮什么都没产出」。

## 🔴 行为一直是对的,只有日志在说谎 —— 而这半边更该修

三次都被判失败、任务如实上报为 `failed`、`✗ all 3 attempts failed` 也打了。**产品逻辑没错。**

但**任何按日志判节点健康的东西,会从一个什么都没产出的节点拿到绿色**。而这种假绿和真绿**逐字相同** —— 一台正常干活的节点打的也是 `[claude] success | …`。分辨它们要读到下一行,而下一行在 grep 的窗口之外。

这也正好是这仓里反复出现的那个形状:**正确的规则就在同一个文件里,离出错点几行,只是没用在需要它的那一行。** `classifyRuntimeResult` 是 #261 为了「vendor 说成功但其实什么都没返回」这件事引进的 —— 当时修了**行为**,没修**日志**。

## 改法

把 `classifyRuntimeResult` 提到日志行**之前**算(它本来就在下一行,不是新增调用),日志打节点自己的结论。

新模块 `formatAttemptOutcome` **不重新推导「成不成功」** —— 重新实现判据会造出两个可以漂移的 success 定义,那是同一类缺陷降一层。它只是把已算出的判定说出来:

| vendor 说 | 节点判 | 打印 |
|---|---|---|
| 非 success(`error_max_turns` 等) | 不判 | 原样透传(vendor 的标签本来就诚实) |
| `success` | 认同 | `success` |
| `success` | 否决 | `success→rejected:soft-fail-empty` |

保留 vendor 的原话,是为了让读日志的人分得清**「一次被否决的成功声明」**和**「一次普通的 vendor 报错」** —— 这两者的处置完全不同(前者要去查 vendor 为什么空手而归,后者看报错就够)。

## 验证

- 新单测 **7 pass**
- 🔴 **变异验证**:把 `if (!classification) return vendorSubtype` 短路成 `if (true)`(确认过不是 no-op),**7 条里 3 条转红**;还原后 7 pass。只见绿不算 —— 一道永远绿的门和一道判对了所以绿的门,输出逐字相同。
- 测试里有一条**断前提**而不是断结论:`classifyRuntimeResult(观测到的那组数字).kind !== "success"`。如果哪天分类器开始把这组数判成成功,那日志行就变诚实了、这个模块也就没意义了 —— 所以把前提钉住。
- `agent-node` 全量:**1288 pass / 0 fail**(92 文件)
- `bun build` 通过,并核了新逻辑**确实进了产物**(`grep -c 'rejected:' dist/cli.js` = 1)—— 打得进包才算修到用户身上。

## 不在本 PR 范围内的两件事(已另记)

1. `TMCode副责人` 自己起不来(模型名不存在)。它在 `get_all_status` 里是 `idle`,**派活的那一刻才暴露**。日志侧修好之后,这类节点会在日志里如实显示 `success→rejected:…` 而不是 `success`。
2. 同一 pane 第一行是 `Resuming session … [codex-app-server]`,而任务走的是 `[claude]` 通道 —— **声明的 runtime 和实际执行道不一致**,`gpt-5.6-sol` 这个 codex 系模型名被带进了 claude 通道。这是另一个缺陷,单独查。