### PR TITLE
fix(ci,docs): docs-integrity 看不见「裸文件名」相对链接——分母少 16 条,作用域里仅有的两条坏链都在里面

### DIFF
--- a/.github/scripts/check-docs-integrity.py
+++ b/.github/scripts/check-docs-integrity.py
@@ -41,7 +41,34 @@ import re
 import subprocess
 import sys
 
-RELATIVE_LINK = re.compile(r"\]\((\.{1,2}/[^)\s]*)")
+# Every markdown link target, then filter. The earlier version matched only
+# targets that begin `./` or `../`, which is not "a relative link" — it is one
+# way of spelling one. A bare `](v0-summary.md)` is equally relative and was
+# invisible to this gate.
+#
+# 🔴 That blind spot lived in how the gate COLLECTED, not in what it judged, so
+# nothing about the output looked wrong: the run printed a link count, said "no
+# problems", and exited 0 — byte-identical to a genuinely clean run. Measured on
+# 2026-08-18: 16 of the 96 in-scope relative links were bare filenames, and both
+# of the broken links in docs/qa/ were among the 16. The gate had been reporting
+# "80 relative link(s)" as if that were the denominator.
+#
+# It stayed invisible because the file this gate was written from (W19, 2026-08-17)
+# happened to spell all 24 of its links with `../`. A fixture that exercises one
+# spelling cannot reveal that the other spelling is unhandled.
+MD_LINK = re.compile(r"\]\(([^)\s]+)\)")
+
+
+def is_repo_relative(target: str) -> bool:
+    """True for link targets that must resolve to a file in this repo.
+
+    Excluded: absolute URLs, in-page anchors, mail links, and site-absolute
+    routes (`/guide/feishu`) — the last are resolved by the docs site's router,
+    not the filesystem, so checking them here would report noise as rot.
+    """
+    if not target or target.startswith(("http://", "https://", "#", "mailto:", "/")):
+        return False
+    return True
 LINK_SCOPE = "docs/qa"
 CHANGELOG_GLOB = "changelog.md"
 MAIN_LINE_ANCHOR = re.compile(r"blob/main/[\w./-]+#L\d+")
@@ -83,7 +110,9 @@ def main() -> int:
     for f in scoped:
         body = open(f, encoding="utf-8", errors="replace").read()
         base = os.path.dirname(f)
-        for target in RELATIVE_LINK.findall(body):
+        for target in MD_LINK.findall(body):
+            if not is_repo_relative(target):
+                continue
             links += 1
             resolved = os.path.normpath(os.path.join(base, target.split("#")[0]))
             if not os.path.exists(resolved):
@@ -117,5 +146,41 @@ def main() -> int:
     return 0
 
 
+def selftest() -> int:
+    """Pin the collector, because that is where this gate was blind.
+
+    Not the judge — `os.path.exists` was never the problem. What failed was the
+    step before it: deciding which strings on the page are links this gate owns.
+    A guard whose collector silently drops a whole spelling reports a smaller
+    denominator and a clean run, and both look exactly like success.
+    """
+    page = (
+        "see [a](v0-summary.md) and [b](../qa/x.md) and [c](./y.md)\n"
+        "[d](https://example.com/z.md) [e](#anchor) [f](/guide/feishu)\n"
+        "[g](v0-summary.md#some-anchor)\n"
+    )
+    found = [t for t in MD_LINK.findall(page) if is_repo_relative(t)]
+    cases = [
+        ("bare filename is collected", "v0-summary.md" in found),
+        ("bare filename with anchor is collected", "v0-summary.md#some-anchor" in found),
+        ("../ form still collected", "../qa/x.md" in found),
+        ("./ form still collected", "./y.md" in found),
+        ("absolute URL excluded", "https://example.com/z.md" not in found),
+        ("in-page anchor excluded", "#anchor" not in found),
+        ("site-absolute route excluded", "/guide/feishu" not in found),
+        ("exactly the four repo-relative targets", len(found) == 4),
+    ]
+    bad = [name for name, ok in cases if not ok]
+    for name, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}")
+    if bad:
+        print(f"::error::collector selftest failed: {len(bad)} case(s)")
+        return 1
+    print(f"collector selftest: {len(cases)}/{len(cases)} ok")
+    return 0
+
+
 if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        sys.exit(selftest())
     sys.exit(main())

--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -41,4 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Collector first. If this gate stops seeing a whole spelling of relative
+      # link, the scan below still prints a count and still exits 0 — a false
+      # green byte-identical to a real one. That happened: bare `](file.md)`
+      # targets were invisible, and both broken links in scope were among them.
+      - run: python3 .github/scripts/check-docs-integrity.py --selftest
       - run: python3 .github/scripts/check-docs-integrity.py

--- a/docs/qa/weekly/2026-W19.md
+++ b/docs/qa/weekly/2026-W19.md
@@ -53,9 +53,9 @@ _自动生成 by [scripts/qa-status.sh](../../../scripts/qa-status.sh)_
 ## 累计抠出的 SDK 设计 finding
 
 - Tests with GAP-style sections: **5**
-- Canonical count (rows in [v0-summary.md](v0-summary.md#累计抠出的-11-条-sdk-设计-finding) findings table): **11**
+- Canonical count (rows in [v0-summary.md](../v0-summary.md#累计抠出的-11-条-sdk-设计-finding) findings table): **11**
 
-完整清单见 [docs/qa/v0-summary.md](v0-summary.md#累计抠出的-11-条-sdk-设计-finding)。
+完整清单见 [docs/qa/v0-summary.md](../v0-summary.md#累计抠出的-11-条-sdk-设计-finding)。
 
 ## 本地 `bash scripts/qa.sh` 实测
 


### PR DESCRIPTION
## 这道门的链接正则匹配的不是「相对链接」,是它的一种写法

```python
RELATIVE_LINK = re.compile(r"\]\((\.{1,2}/[^)\s]*)")
```

`](v0-summary.md)` 同样是相对链接,而这道门**从来没看见过它**。

## 实测(2026-08-18,`docs/qa/` 作用域内)

| | 数 |
|---|---|
| 门宣称检查的 | **80** |
| 实际的仓内相对链接 | **96** |
| 它看不见的「裸文件名」 | **16** |
| 作用域内真正的坏链 | **2** —— 🔴 **两条都在那 16 条里** |

门打印 `80 relative link(s)`、`no problems`、`exit 0`。**和一次真正干净的运行逐字相同。**

## 盲区在「怎么把要判的东西收集起来」,不在判据

`os.path.exists` 从来没错过。错的是它**之前**那一步 —— 决定页面上哪些字符串是这道门该管的链接。

**一个收集器悄悄漏掉一整种写法,产出的是一个更小的分母和一次干净的运行,而这两件事都长得像成功。**

它能藏住,是因为写这道门时依据的那个文件(`2026-W19.md`, 2026-08-17)**恰好把 24 条链接全写成了 `../`**。**一个只演练了一种写法的夹具,无法暴露另一种写法没被处理** —— 夹具选得越贴近当时那个 bug,越容易把别的写法一起排除掉。

## 被暴露出来的那两条坏链

```
docs/qa/weekly/2026-W19.md:56  [v0-summary.md](v0-summary.md#…)
docs/qa/weekly/2026-W19.md:58  [docs/qa/v0-summary.md](v0-summary.md#…)
```

文件在 `docs/qa/v0-summary.md`,而 W19 在 `docs/qa/weekly/` —— **href 少了一级**。第二条尤其说明问题:**链接文字写的是正确路径 `docs/qa/v0-summary.md`,href 是错的** —— 读者看到的那半是对的,点下去的那半是错的。

## 改动

1. **收集改为「先全取、再排除」**。排除 `http(s)` / `#锚点` / `mailto` / **站点绝对路由**(`/guide/feishu`)—— 最后一类由 docs 站的路由解析,不是文件系统,判它会把噪声报成腐烂。
2. 修好那两条链接。
3. 新增 `--selftest` **钉住收集器**,并在 workflow 里**排在真扫描之前**。

## 证据顺序:先红后绿,而且红是在真仓上红的

```
# 修完门、还没修链接
::error file=docs/qa/weekly/2026-W19.md::relative link 'v0-summary.md#…' resolves to
  'docs/qa/weekly/v0-summary.md', which does not exist        ← ×2
checked 359 tracked .md …; 96 relative link(s) across 6 file(s) …
2 problem(s).                                                  exit=1

# 修完链接
checked 359 tracked .md …; 96 relative link(s) across 6 file(s) …
no problems.                                                   exit=0
```

**分母 80→96 是这次修复的主要产出**,`2 problem(s)` 只是它顺带露出来的东西。

`--selftest` 的变异验证:把正则**退回旧写法**,8 条里 **3 条转红**(`bare filename is collected` / `bare filename with anchor is collected` / `exactly the four repo-relative targets`),其余 5 条保持绿 —— 说明它红得**精准**,不是一改就全红。

## 为什么 selftest 排在真扫描前面

真扫描**永远能给出一个数字和一个 exit 0**。收集器坏掉时它照常这么做。所以先问「这道门还看得见东西吗」,再问「它看到的东西有没有问题」。