### PR TITLE
docs(deploy): dashboard ecosystem 没有 cwd 是有意的——在跑的那个值是「谁在哪敲的 pm2 start」,不是配置

### DIFF
--- a/deploy/dashboard/ecosystem.config.cjs
+++ b/deploy/dashboard/ecosystem.config.cjs
@@ -27,6 +27,17 @@ module.exports = {
       min_uptime: 45000,
       max_restarts: 20,
       exp_backoff_restart_delay: 200,
+      // 没有 cwd 是**有意的**,别照着在跑的进程补。
+      //
+      // 2026-08-18 逐字段比对 `pm2 jlist` 与本文件时,cwd 是唯一一处真实差异:
+      // 在跑的 anet-dashboard 的 pm_cwd 是 /home/vansin/agent-orchestra。那不是
+      // 一个被选择的值,是**当初谁在哪个目录敲的 `pm2 start`** —— 一个仓库检出
+      // 路径,换台机器就不存在。把它写进来会让本文件在别的机器上直接失效。
+      //
+      // 判据是脚本本身:dash-start.sh 里没有任何 `cd`、没有任何相对路径依赖
+      // (唯一一处 `cd` 出现在一句 echo 的提示文案里),所以它与 cwd 无关。
+      // 对比 deploy/hub/ecosystem.config.cjs —— 那里的 cwd 是真需要的,而且
+      // 写成 join(home, ".commhub") 而不是绝对路径。
     },
   ],
 };


### PR DESCRIPTION
#892 收尾。逐字段比对 `pm2 jlist` 与 `deploy/*/ecosystem.config.cjs` 后,`cwd` 是唯一一处真实差异 —— 而它**不该被“修”**。

在跑的 `pm_cwd` = `/home/vansin/agent-orchestra`,那是一个**仓库检出路径**,换台机器就不存在。下一个做同样比对的人会看到「仓里缺 cwd」并很自然地补上,补上的那一刻这个文件就在别的机器上失效了。

判据写的是**脚本本身**而不是观测到的值:`dash-start.sh` 没有任何 `cd`、没有任何相对路径依赖(唯一一处 `cd` 在一句 echo 的提示文案里)。对照 hub 那份 —— 那里的 `cwd` 是真需要的,且写成 `join(home, ".commhub")` 而不是绝对路径。

验证:`node -e require(...)` 解析通过,`min_uptime` 仍为 45000、`cwd` 仍为 undefined(纯注释改动,行为零变化)。