### PR TITLE
fix(docs): 两条深度算错一级的死链(目标文件一直在)

### DIFF
--- a/docs/release/v2.3.0/RELEASE-NOTES.md
+++ b/docs/release/v2.3.0/RELEASE-NOTES.md
@@ -35,7 +35,7 @@
 - ACP 内核活体已跑通 **free model**（真 ACP session + 真流式 + 真计费 token + 子进程真收）。真 vendor（Anthropic/OpenAI）活体 + 正式主打**留到后续**。
 
 ## 升级 / 部署注意
-- **Channel 编辑走 restart-tier**：应用通道变更会触发节点 `exit(75)` 重启，**需要外部 supervisor 拉回进程**（`anet node start` / host_supervisor daemon / systemd `Restart=always` / docker `restart:always`）。手动 spawn（裸 `nohup`）的节点没 supervisor 不会自动重启。详见 [troubleshooting/remote-node-cli-login](../../docs-site/docs/troubleshooting/remote-node-cli-login.md) 与 RFC-024 §6.7.1。
+- **Channel 编辑走 restart-tier**：应用通道变更会触发节点 `exit(75)` 重启，**需要外部 supervisor 拉回进程**（`anet node start` / host_supervisor daemon / systemd `Restart=always` / docker `restart:always`）。手动 spawn（裸 `nohup`）的节点没 supervisor 不会自动重启。详见 [troubleshooting/remote-node-cli-login](../../../docs-site/docs/troubleshooting/remote-node-cli-login.md) 与 RFC-024 §6.7.1。
 - **多机 auth**：跨机建节点优先走 **API key 路线**（key 跟 config/vault 走）；claude-code-cli 订阅登录态机器绑定不可移植，远程 host 需各自 `claude login`。
 
 ## 验证

--- a/docs/tests/p-grok-demos-qa/report.md
+++ b/docs/tests/p-grok-demos-qa/report.md
@@ -68,7 +68,7 @@ Both git tree and filesystem confirm: `fetcher/` directory, `.env.x.example`, an
 > Verified: 5/5 `curl -I` HTTP 200 against the URLs the LLM returned for "find @sama's recent AGI posts" in the [E2E probe report].
 
 **README line 84** (verbatim):
-> All five URLs return HTTP 200 — see [`basic-urls.txt`](../../docs/tests/p-grok-native-xsearch-e2e/basic-urls.txt) for the verbatim list.
+> All five URLs return HTTP 200 — see [`basic-urls.txt`](../p-grok-native-xsearch-e2e/basic-urls.txt) for the verbatim list.
 
 **Live 2026-06-06 re-verify:**
 ```


### PR DESCRIPTION
全仓扫 `docs/` 的 296 条仓内相对链接后分类,这两条属于**目标存在、路径写错** —— 全部死链里唯一能确定性修好的一类。

```
docs/release/v2.3.0/RELEASE-NOTES.md
  ../../docs-site/…  →  ../../../docs-site/…      少一级,落到 docs/docs-site/
docs/tests/p-grok-demos-qa/report.md
  ../../docs/tests/p-grok-native-xsearch-e2e/basic-urls.txt
    →  ../p-grok-native-xsearch-e2e/basic-urls.txt  多绕一层,落到 docs/docs/tests/
```

改完当场核过两条都解析到真实文件。

**其余死链不在本 PR**:它们指向的东西**确实不存在**(已删的测试报告、从未提交的 RFC-017、仓外的私有 memory 目录),改路径解决不了,需要各自单独决定是补文件还是删链接。分类明细发在 #887。