### PR TITLE
fix(cli): #909 step 1 — claude-code-cli reports a known gap, not a typo (agent-node + launcher)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2431,6 +2431,20 @@ function assertStartCompatibility(runtime: RuntimeName) {
     return;
   }
 
+  // #909 — `claude-code-cli` is provisioned here (Claude Code CLI install + `claude auth login`
+  // + PATH check) but agent-node has NO execution lane for it yet. Refuse cleanly at start,
+  // BEFORE launchAgent spawns agent-node — otherwise the user installs the CLI, logs in, and then
+  // hits a bare "Unsupported runtime" from agent-node that is byte-identical to a typo. This also
+  // closes a gap in this very guard: its purpose is to stop an unsupported agent-node from silently
+  // selecting another runtime, yet the early-return below skipped the one provisioned runtime that
+  // most needed it (a guard existing and being wired is not the same as it firing on this input).
+  if (runtime === "claude-code-cli") {
+    console.error(`[anet] Runtime "claude-code-cli" is not yet implemented in agent-node (no execution lane) — known gap, see #909.`);
+    console.error(`[anet] It is provisioned here (Claude Code CLI + \`claude auth login\`), but starting a node with it is not wired yet.`);
+    console.error(`[anet] Use --runtime claude-agent-sdk for now.`);
+    process.exit(1);
+  }
+
   if (runtime !== "codex-sdk" && runtime !== "claude-agent-sdk") return;
 
   const versions = detectInstalledPackages();

--- a/agent-network/src/claude-code-cli-launcher-refusal.test.ts
+++ b/agent-network/src/claude-code-cli-launcher-refusal.test.ts
@@ -1,0 +1,73 @@
+// #909 — `claude-code-cli` is provisioned by the anet launcher (it installs @anthropic-ai/claude-code
+// and requires `claude` in PATH), but agent-node has no execution lane for it. The launcher's
+// `assertStartCompatibility` guard exists precisely to stop an unsupported agent-node from silently
+// selecting another runtime — yet its early-return `if (runtime !== "codex-sdk" && !== "claude-agent-sdk")`
+// skipped the one provisioned runtime that most needed it (grok-build-cli and opencode-cli were covered).
+//
+// 🔴 The judge here is the one thing that makes this test worth writing: agent-node ALSO fails on this
+// runtime (its own #909 branch), so "start failed" is true whether or not the LAUNCHER caught it. This
+// test must prove the refusal happened AT THE LAUNCHER, BEFORE agent-node was spawned — not that
+// something downstream died. The distinguisher is the wording that is unique to each layer:
+//   launcher  (bin/cli.ts, assertStartCompatibility):  "…provisioned HERE (Claude Code CLI…"
+//   agent-node (src/cli.ts):                           "…provisioned BY `anet`…" / "Unsupported runtime"
+// If the launcher branch is removed, the early-return lets launchAgent spawn agent-node, and the output
+// flips to agent-node's wording — which these assertions catch.
+//
+// Behavioral (spawns the real launcher with a real profile), matching the failure the user hit: install
+// the CLI, log in, `anet node start`, and only then get told — in typo-shaped words — the runtime is bad.
+
+import { describe, expect, test } from "bun:test";
+import { spawn } from "child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "..", "bin", "cli.ts");
+
+function runStart(runtime: string, timeoutMs = 30_000): Promise<{ out: string; code: number | null }> {
+  const sb = mkdtempSync(join(tmpdir(), "anet-909L-"));
+  const home = mkdtempSync(join(tmpdir(), "anet-909L-home-"));
+  const nodeDir = join(sb, ".anet", "nodes", "p909launcher");
+  mkdirSync(nodeDir, { recursive: true });
+  // nodesDir() = <cwd>/.anet/nodes — a minimal profile is enough to reach assertStartCompatibility.
+  writeFileSync(
+    join(nodeDir, "config.json"),
+    JSON.stringify({ node_id: "p909launcher", alias: "p909launcher", runtime, hub: "http://127.0.0.1:9" }),
+  );
+  return new Promise((resolve) => {
+    const child = spawn("bun", [CLI, "node", "start", "p909launcher"], {
+      cwd: sb,
+      env: { PATH: process.env.PATH ?? "", HOME: home },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "", settled = false;
+    const finish = (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(t);
+      try { child.kill("SIGKILL"); } catch { /* gone */ }
+      rmSync(sb, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+      resolve({ out, code });
+    };
+    const t = setTimeout(() => finish(null), timeoutMs);
+    child.stdout.on("data", (d) => { out += String(d); });
+    child.stderr.on("data", (d) => { out += String(d); });
+    child.on("exit", (c) => finish(c));
+    child.on("error", () => finish(null));
+  });
+}
+
+describe("#909 claude-code-cli is refused AT THE LAUNCHER, before agent-node is spawned", () => {
+  test("🔴🔴 refusal is the launcher's (provisioned HERE), and agent-node is never reached", async () => {
+    const r = await runStart("claude-code-cli");
+    expect(r.code).not.toBe(0);
+    // The refusal is the launcher's own #909 branch…
+    expect(r.out).toContain("#909");
+    expect(r.out).toContain("provisioned here"); // unique to bin/cli.ts's assertStartCompatibility branch
+    // …and agent-node was NOT spawned: neither its generic typo error nor its OWN #909 wording appears.
+    // Removing the launcher branch flips both of these (early-return → launchAgent → agent-node wording).
+    expect(r.out).not.toContain(`Unsupported runtime "claude-code-cli"`);
+    expect(r.out).not.toContain("provisioned by `anet`");
+  }, 45_000);
+});

--- a/agent-network/src/claude-code-cli-launcher-refusal.test.ts
+++ b/agent-network/src/claude-code-cli-launcher-refusal.test.ts
@@ -65,9 +65,14 @@ describe("#909 claude-code-cli is refused AT THE LAUNCHER, before agent-node is 
     // The refusal is the launcher's own #909 branch…
     expect(r.out).toContain("#909");
     expect(r.out).toContain("provisioned here"); // unique to bin/cli.ts's assertStartCompatibility branch
-    // …and agent-node was NOT spawned: neither its generic typo error nor its OWN #909 wording appears.
-    // Removing the launcher branch flips both of these (early-return → launchAgent → agent-node wording).
+    // …and agent-node was NOT spawned. 🔴 The robust check is STRUCTURAL, not wording-coupled
+    // (通信龙): agent-node prefixes ALL its output with `[<ALIAS>]`; the launcher uses `[anet]` (and
+    // names the node only in quotes, `"p909launcher"`). So if agent-node started at all, the bracketed
+    // `[p909launcher]` prefix appears. This survives any future rewording of agent-node's messages —
+    // notably step 2, when the lane is built and agent-node's #909 wording changes; a negative assertion
+    // coupled to that wording would silently go green there while agent-node was in fact spawned.
+    expect(r.out).not.toContain("[p909launcher]");
+    // belt: agent-node's generic typo error is stable-shaped, so keep it too.
     expect(r.out).not.toContain(`Unsupported runtime "claude-code-cli"`);
-    expect(r.out).not.toContain("provisioned by `anet`");
   }, 45_000);
 });

--- a/agent-node/src/claude-code-cli-honest-error.test.ts
+++ b/agent-node/src/claude-code-cli-honest-error.test.ts
@@ -1,0 +1,97 @@
+// #909 — `--runtime claude-code-cli` is provisioned by `anet` (it installs @anthropic-ai/claude-code
+// and requires `claude` in PATH), but agent-node has NO execution lane for it. Before this fix it hit
+// the generic "Unsupported runtime" — BYTE-IDENTICAL to a typo — so a user who ran `anet` all the way
+// through install+login was told, in the same words as a misspelling, that their runtime was unknown.
+//
+// The judge here is NOT "did it fail?" (it failed before and after — no lane either way). The judge is
+// "does agent-node distinguish this KNOWN, provisioned-but-unimplemented runtime from an UNKNOWN typo?"
+// So the load-bearing assertion is that the two stderrs are NOT equal, plus a positive control that a
+// real runtime trips neither branch (otherwise a "report unimplemented for everything" impl would also
+// make the not-equal assertion pass while breaking real starts).
+//
+// Drives the REAL CLI entrypoint (spawned `src/cli.ts`), mirroring #491's harness — a helper-level test
+// would not prove the user-visible output actually differs.
+
+import { describe, expect, test } from "bun:test";
+import { spawn } from "child_process";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "cli.ts");
+const DEAD_HUB = "http://127.0.0.1:9"; // nothing listens; a valid runtime fails harmlessly AFTER the banner
+
+interface RunResult { stdout: string; stderr: string; code: number | null }
+
+function runCli(args: string[], timeoutMs = 15_000): Promise<RunResult> {
+  const sandbox = mkdtempSync(join(tmpdir(), "anet-909-"));
+  const home = mkdtempSync(join(tmpdir(), "anet-909-home-"));
+  return new Promise<RunResult>((resolve) => {
+    const child = spawn("bun", [CLI, ...args], {
+      cwd: sandbox,
+      env: { PATH: process.env.PATH ?? "", HOME: home, COMMHUB_URL: DEAD_HUB, RUNTIME: "" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "", stderr = "", settled = false;
+    const finish = (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try { child.kill("SIGKILL"); } catch { /* gone */ }
+      rmSync(sandbox, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+      resolve({ stdout, stderr, code });
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    child.stdout.on("data", (d) => { stdout += String(d); if (/\n\s*hub:/.test(stdout)) finish(null); });
+    child.stderr.on("data", (d) => { stderr += String(d); });
+    child.on("exit", (code) => finish(code));
+    child.on("error", () => finish(null));
+  });
+}
+
+describe("#909 claude-code-cli reports a KNOWN gap, not a typo", () => {
+  test("🔴🔴 claude-code-cli and a typo get DIFFERENT treatment, not the same template with a name swap", async () => {
+    const known = await runCli(["--alias", "p909", "--runtime", "claude-code-cli"]);
+    const bogus = await runCli(["--alias", "p909", "--runtime", "bogus-xyz-not-a-runtime"]);
+    // Both fail closed…
+    expect(known.code).not.toBe(0);
+    expect(bogus.code).not.toBe(0);
+    // …but comparing the raw stderrs is too weak: the generic error ECHOES the runtime name, so
+    // `Unsupported runtime "claude-code-cli"` vs `…"bogus-xyz…"` already differ by the name alone —
+    // that "difference" existed WITH the bug. #909 is about TREATMENT: a documented, provisioned
+    // runtime must not get the same TEMPLATE as a typo. So normalize the echoed name out, then assert
+    // the templates still differ. Pre-fix both normalize to the identical "Unsupported runtime <R>…"
+    // line → this assertion fails (catches the bug); post-fix claude-code-cli is the distinct #909
+    // message → they differ.
+    const norm = (s: string, name: string) => s.split(name).join("<RUNTIME>");
+    expect(norm(known.stderr, "claude-code-cli")).not.toBe(norm(bogus.stderr, "bogus-xyz-not-a-runtime"));
+  }, 30_000);
+
+  test("claude-code-cli names the gap (#909, not-a-typo) and points at a working runtime", async () => {
+    const r = await runCli(["--alias", "p909", "--runtime", "claude-code-cli"]);
+    const out = r.stdout + r.stderr;
+    expect(out).toContain("#909");
+    expect(out).toMatch(/not yet implemented|known gap|not a typo/);
+    expect(out).toContain("claude-agent-sdk"); // tells the user what to use now
+    // It must NOT masquerade as the generic unknown-runtime error.
+    expect(out).not.toContain(`Unsupported runtime "claude-code-cli"`);
+  }, 30_000);
+
+  test("a genuinely unknown runtime still gets the generic 'Unsupported runtime' error", async () => {
+    const r = await runCli(["--alias", "p909", "--runtime", "bogus-xyz-not-a-runtime"]);
+    const out = r.stdout + r.stderr;
+    expect(out).toContain("Unsupported runtime");
+    expect(out).toContain("bogus-xyz-not-a-runtime");
+    expect(out).not.toContain("#909"); // the typo path must not claim to be a known gap
+  }, 30_000);
+
+  test("🔴 positive control: a real runtime trips NEITHER branch (the honest error must not over-fire)", async () => {
+    // Without this, an impl that reported "unimplemented" for every runtime would make the
+    // not-equal assertion above pass while breaking real starts.
+    const r = await runCli(["--alias", "p909", "--runtime", "claude-agent-sdk"]);
+    const out = r.stdout + r.stderr;
+    expect(out).not.toContain("#909");
+    expect(out).not.toContain("Unsupported runtime");
+  }, 30_000);
+});

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -451,6 +451,16 @@ const RUNTIME_MAP: Record<string, string> = {
   // `codex-app-server` (canonical) / `codex-tui` / `codex-appserver`.
   "codex-app-server": "codex-app-server", "codex-appserver": "codex-app-server", "codex-tui": "codex-app-server",
 };
+// #909 — `claude-code-cli` is provisioned by `anet` (it installs @anthropic-ai/claude-code
+// and requires `claude` in PATH) but has NO execution lane in agent-node yet. Report the gap
+// by name instead of the generic "Unsupported runtime" below, which is byte-identical to a typo
+// and sends users chasing a spelling error that isn't there. This is a distinct branch from
+// "unrecognized" on purpose: the fix for the missing lane is a separate step (a new bucket, not
+// an alias to "claude"=SDK, which would silently downgrade CLI-login users to the SDK channel).
+if (rawRuntime === "claude-code-cli") {
+  console.error(`[${ALIAS}] Runtime "claude-code-cli" is provisioned by \`anet\` but not yet implemented in agent-node (no execution lane). This is a known gap, not a typo — see #909. Use --runtime claude-agent-sdk for now.`);
+  process.exit(1);
+}
 if (!Object.prototype.hasOwnProperty.call(RUNTIME_MAP, rawRuntime)) {
   const supported = [...new Set(Object.keys(RUNTIME_MAP))].join(", ");
   console.error(`[${ALIAS}] Unsupported runtime "${rawRuntime}". Supported: ${supported}`);


### PR DESCRIPTION
Closes #909 (step 1 of 2 — honest error now; execution lane is a separate step).

## The bug: `claude-code-cli` is a half-built runtime, and its failure is byte-shaped like a typo

`claude-code-cli` is **provisioned** by the anet launcher (installs `@anthropic-ai/claude-code`, requires `claude` in PATH, prompts `claude auth login`) and is a first-class `RuntimeName` in `normalize-runtime.ts` (`canonicalizeRuntime` *preserves* it — "someone meant to ship this" is in the code, not a guess). But **agent-node has no execution lane for it** — no `RUNTIME_MAP` key, no `runtime/` lane; the only "claude" lane is the SDK. So a user who runs `anet` all the way through install + login is told, in words identical to a misspelling, that their runtime is unknown — and goes chasing a typo that isn't there.

Two layers were broken:
1. **agent-node** (`src/cli.ts`): `claude-code-cli` fell through to the generic `Unsupported runtime` — the same template as `bogus-xyz`.
2. **anet launcher** (`bin/cli.ts`): `assertStartCompatibility` verifies agent-node capability for `opencode-cli` and `grok-build-cli` (refusing cleanly if unsupported), but its early-return `if (runtime !== "codex-sdk" && runtime !== "claude-agent-sdk") return;` skipped `claude-code-cli` — **the one provisioned runtime the guard most needed to cover.** So the launcher spawned agent-node, which died downstream. (A guard *existing* and being *wired* is not the same as it *firing* on this input.)

## The fix (step 1): tell the truth at both layers — do NOT alias to the SDK

🔴 Deliberately **not** `RUNTIME_MAP["claude-code-cli"] = "claude"` — the "claude" bucket is the SDK, so aliasing would silently downgrade CLI-login users to the SDK channel (the #478 silent-degradation, via a new entrance). Building the real lane is **step 2** (a *new* bucket that spawns the `claude` CLI reusing login state, with a test asserting CLI-not-SDK).

- **agent-node**: a named branch before the generic check → distinct message naming the gap + `#909` + what to use now.
- **launcher**: a `claude-code-cli` branch in `assertStartCompatibility`, *before* the early-return, that refuses cleanly at **start** — before `launchAgent` spawns agent-node — and closes the guard's own gap.

## Side-by-side (the thing to look at first)

**agent-node** (`bun agent-node/src/cli.ts --alias p909 --runtime <X>`):

| runtime | stderr |
|---|---|
| `claude-code-cli` (before) | `[p909] Unsupported runtime "claude-code-cli". Supported: claude-agent-sdk, …` ← typo template |
| **`claude-code-cli` (after)** | `[p909] Runtime "claude-code-cli" is provisioned by \`anet\` but not yet implemented in agent-node (no execution lane). This is a known gap, not a typo — see #909. Use --runtime claude-agent-sdk for now.` |
| `bogus-xyz` (unchanged) | `[p909] Unsupported runtime "bogus-xyz". Supported: claude-agent-sdk, …` ← a real typo still gets the generic error |

**launcher** (`anet node start <claude-code-cli node>`):

| | behaviour |
|---|---|
| before | `assertStartCompatibility` early-returns → `launchAgent` spawns agent-node → agent-node dies with the bare typo error |
| **after** | `[anet] Runtime "claude-code-cli" is not yet implemented in agent-node (no execution lane) — known gap, see #909.` / `[anet] It is provisioned here (Claude Code CLI + \`claude auth login\`), but starting a node with it is not wired yet.` / `[anet] Use --runtime claude-agent-sdk for now.` — **caught at the launcher; agent-node is never spawned.** |

## Judges (why each test earns its place)

The judge is **not** "did it fail?" — it failed before *and* after (no lane either way). So the tests pin the two things that actually distinguish fixed from broken:

- **agent-node** (`claude-code-cli-honest-error.test.ts`, spawns the real CLI):
  - 🔴🔴 `claude-code-cli` and a typo get **different treatment**, not the same template with a name swap. (Raw stderr already differs by the echoed name even *with* the bug, so the load-bearing assertion **normalizes the runtime name out** and asserts the templates still differ — pre-fix both normalize to the same `Unsupported runtime <R>` line.)
  - Positive control: a **real** runtime (`claude-agent-sdk`) trips **neither** branch — otherwise a "report unimplemented for everything" impl would pass the not-equal assertion while breaking real starts.
- **launcher** (`claude-code-cli-launcher-refusal.test.ts`, spawns the real launcher with a real profile):
  - 🔴🔴 the refusal is the **launcher's** (`provisioned **here**`), and agent-node is **never reached** (no `Unsupported runtime`, no agent-node's own `provisioned **by** \`anet\``). This is the "caught at the launcher, not downstream" assertion — removing the launcher branch flips the wording to agent-node's, which the test catches.

**Witnessed-red** (both, reverting only the relevant branch): agent-node → 2 assertions fail (treatment-compare + names-gap); launcher → the `provisioned here` assertion fails (agent-node gets reached). Restored → green.

## Scope

Step 1 only: honest errors, **no execution lane built**. The now-correct messages say "not yet implemented" — the lane itself (step 2) is a separate PR (new bucket, spawn `claude` CLI reusing login state, CLI-not-SDK test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
