### PR TITLE
fix(ci): 四个 workflow 的 job 全叫 scan——required 里没法指名,统计覆盖率会把四道门算成一道

### DIFF
--- a/.github/workflows/action-pins.yml
+++ b/.github/workflows/action-pins.yml
@@ -28,6 +28,11 @@ on:
 
 jobs:
   scan:
+    # 这个 name 就是 GitHub 上那个 check 的名字，也是分支保护里 required check
+    # 唯一能写的标识符。它必须全仓唯一 —— 2026-08-18 之前，四个 workflow 的
+    # job 全叫 `scan`，于是四道门在 check 列表里挤成同一个名字：required 里
+    # 写 `scan` 指的是哪一道无法确定，而按名字统计覆盖率会把四道门算成一道。
+    name: action-pins
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -38,6 +38,11 @@ on:
 
 jobs:
   scan:
+    # 这个 name 就是 GitHub 上那个 check 的名字，也是分支保护里 required check
+    # 唯一能写的标识符。它必须全仓唯一 —— 2026-08-18 之前，四个 workflow 的
+    # job 全叫 `scan`，于是四道门在 check 列表里挤成同一个名字：required 里
+    # 写 `scan` 指的是哪一道无法确定，而按名字统计覆盖率会把四道门算成一道。
+    name: docs-integrity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/public-script-safety.yml
+++ b/.github/workflows/public-script-safety.yml
@@ -27,6 +27,11 @@ on:
 
 jobs:
   scan:
+    # 这个 name 就是 GitHub 上那个 check 的名字，也是分支保护里 required check
+    # 唯一能写的标识符。它必须全仓唯一 —— 2026-08-18 之前，四个 workflow 的
+    # job 全叫 `scan`，于是四道门在 check 列表里挤成同一个名字：required 里
+    # 写 `scan` 指的是哪一道无法确定，而按名字统计覆盖率会把四道门算成一道。
+    name: public-script-safety
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/qa-trigger-coverage.yml
+++ b/.github/workflows/qa-trigger-coverage.yml
@@ -28,6 +28,11 @@ on:
 
 jobs:
   scan:
+    # 这个 name 就是 GitHub 上那个 check 的名字，也是分支保护里 required check
+    # 唯一能写的标识符。它必须全仓唯一 —— 2026-08-18 之前，四个 workflow 的
+    # job 全叫 `scan`，于是四道门在 check 列表里挤成同一个名字：required 里
+    # 写 `scan` 指的是哪一道无法确定，而按名字统计覆盖率会把四道门算成一道。
+    name: qa-trigger-coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub 上一个 check 的名字取自 job 的 `name:`(没有就取 job id),而这是**分支保护 required check 里唯一能写的标识符**。

本 PR 之前,这四个 workflow 的 job **全叫 `scan`**:

```
action-pins.yml:scan
docs-integrity.yml:scan
public-script-safety.yml:scan
qa-trigger-coverage.yml:scan
```

## 两个后果

**1. required 里写 `scan`,指的是哪一道无法确定。**

而这四道里有**两道恰好是无 `paths:` 过滤、每个 PR 都跑的**(`action-pins`、`qa-trigger-coverage`)—— 它们本来是全仓最适合当 required 的候选,却因为重名而写不进去。

**2. 🔴 按 check 名统计覆盖率,会把四道门算成一道。**

我在 #828 里贴的那张覆盖表就是这么统计的 —— `scan 14/15` 那一行**其实是四道不同的门被折叠成了一行**,而它们各自的 `paths:` 过滤完全不同。那一行是错的,已在 issue 里更正。

这也是同一个形状的又一例:**量具把四个对象合并成一个之后,输出看起来完全正常** —— 一行、一个数、一个百分比,没有任何地方提示"这里其实是四样东西"。

## 改动

只有一处:给这四个 job 各加一个唯一的 `name:`,并把理由写在旁边,免得下一个新建 workflow 的人又写 `scan`。

其余字段一字未动 —— 用 `yaml.safe_load` 逐个核过 `runs-on` / `steps` 数 / `run` 命令都在:

```
action-pins           name='action-pins'          steps=2  run=['… check-action-pins.py']
docs-integrity        name='docs-integrity'       steps=3  run=['… --selftest', '… check-docs-integrity.py']
public-script-safety  name='public-script-safety' steps=3  run=['… check-public-script-safety.py']
qa-trigger-coverage   name='qa-trigger-coverage'  steps=2  run=['… check-qa-trigger-coverage.py']
```

## 🔴 中途发现分支落后 main 一个提交,差点静默删掉别人的东西

第一次提交时我的分支基于一个稍旧的 `origin/main`,而 #911 刚给 `docs-integrity.yml` 加了 `--selftest` 那一步。我改的是同一个文件的**另一处**(job 名),两边都是纯新增 —— **这种情况下 git 完全可能干净合并,而 selftest 那一步就没了**。

发现方式是在 push 之后主动比了一次「main 上有我没有的」:`git show origin/main:… | grep -c selftest` = 1,我分支上 = 0。已 rebase,rebase 后两处都在(见上表 `docs-integrity steps=3`)。

**纯新增的改动一样会撞键;而它撞掉东西的时候不会有冲突提示。**

## 这条落地之后,#828 的路径变短了

不再需要造一个聚合 job。`action-pins` 和 `qa-trigger-coverage` 本来就无条件在每个 PR 上跑,重名解决之后**它们可以直接被设成 required**,不需要新机制。