### PR TITLE
fix(cli): #909 — agent-node --help no longer lists claude-code-cli as a directly-passable runtime

### DIFF
--- a/agent-node/src/claude-code-cli-help-text.test.ts
+++ b/agent-node/src/claude-code-cli-help-text.test.ts
@@ -1,0 +1,43 @@
+// #909 (corrected) — claude-code-cli's execution lane lives in the LAUNCHER (agent-network/bin/cli.ts,
+// `anet node start` → spawns the real `claude` CLI), NOT in agent-node. So agent-node's --help must not
+// present it as a `--runtime` value you pass to agent-node (agent-node correctly rejects it at RUNTIME_MAP —
+// that rejection is NOT touched here; this is a help-text fix only). It stays documented, but marked as
+// anet-provided. Do NOT assert on the launcher here, and do NOT claim it's unimplemented — it is.
+
+import { describe, expect, test } from "bun:test";
+import { spawn } from "child_process";
+import { join } from "path";
+
+const CLI = join(import.meta.dir, "cli.ts");
+
+function help(): Promise<string> {
+  return new Promise((resolve) => {
+    const child = spawn("bun", [CLI, "--help"], { stdio: ["ignore", "pipe", "pipe"] });
+    let out = "";
+    const t = setTimeout(() => { try { child.kill("SIGKILL"); } catch { /* gone */ } resolve(out); }, 15_000);
+    child.stdout.on("data", (d) => { out += String(d); });
+    child.stderr.on("data", (d) => { out += String(d); });
+    child.on("exit", () => { clearTimeout(t); resolve(out); });
+    child.on("error", () => { clearTimeout(t); resolve(out); });
+  });
+}
+
+describe("#909 agent-node --help does not present claude-code-cli as a directly-passable runtime", () => {
+  test("the `--runtime <type>` value list omits claude-code-cli (agent-node does not accept it)", async () => {
+    const out = await help();
+    const line = out.split(/\r?\n/).find((l) => /--runtime <type>/.test(l)) ?? "";
+    expect(line).not.toContain("claude-code-cli");
+    // positive control: it still offers the runtimes agent-node DOES accept (didn't strip the whole list).
+    expect(line).toContain("claude-agent-sdk");
+    expect(line).toContain("codex-sdk");
+  }, 20_000);
+
+  test("it stays documented, marked anet-provided — and is NOT called unimplemented (it is implemented)", async () => {
+    const out = await help();
+    expect(out).toContain("claude-code-cli"); // still in the Runtime section
+    expect(out).toContain("anet node start"); // says how it is actually started
+    expect(out).toMatch(/不能直接传给 agent-node|not by passing --runtime to agent-node/);
+    // 🔴 the whole point of the correction: it must NOT be described as a gap/unimplemented.
+    expect(out).not.toMatch(/not yet implemented|no execution lane|known gap/);
+  }, 20_000);
+});

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -200,7 +200,8 @@ for (let i = 0; i < argv.length; i++) {
 选项:
   --config <path>     配置文件 (.anet/nodes/<name>/config.json)
   --alias <name>      Agent 别名 / CommHub alias (必需)
-  --runtime <type>    claude-agent-sdk (default) | claude-code-cli | codex-sdk | codex-app-server | grok-build-acp | grok-build-cli | opencode-cli
+  --runtime <type>    claude-agent-sdk (default) | codex-sdk | codex-app-server | grok-build-acp | grok-build-cli | opencode-cli
+                      (claude-code-cli is NOT here: it runs via \`anet node start\`, not by passing --runtime to agent-node — see the Runtime section)
   --model <name>      AI 模型 (codex 默认: ${DEFAULT_CODEX_MODEL}, claude-agent-sdk 默认: claude-sonnet-4-6)
   --hub <url>         CommHub URL
   --tools <list>      工具列表，逗号分隔 ("all" = 全部)
@@ -215,7 +216,7 @@ for (let i = 0; i < argv.length; i++) {
 
 Runtime:
   claude-agent-sdk  Claude Agent SDK — Claude/MiniMax/Anthropic 兼容 API
-  claude-code-cli   Claude Code CLI — 复用 Claude Code 登录态
+  claude-code-cli   Claude Code CLI — 由 \`anet\` 提供并启动(\`anet node start\`);不能直接传给 agent-node
   codex-sdk         Codex SDK — GPT-5.4，复用 codex 登录态
   codex-app-server  Codex app-server — Codex TUI bridge
   grok-build-acp    Grok Build ACP — xAI Grok Build via "grok agent stdio"
@@ -452,6 +453,12 @@ const RUNTIME_MAP: Record<string, string> = {
   // `codex-app-server` (canonical) / `codex-tui` / `codex-appserver`.
   "codex-app-server": "codex-app-server", "codex-appserver": "codex-app-server", "codex-tui": "codex-app-server",
 };
+// 🔴 `claude-code-cli` is intentionally NOT a key here (#909). Its execution lane lives in the LAUNCHER
+//    (`agent-network/bin/cli.ts` — `anet node start` → launchAgent → spawns the real `claude` CLI, ~:5096)
+//    and never routes through agent-node. So agent-node rejecting it below is CORRECT behaviour, not a gap
+//    — do NOT "fix" it by adding a key. Aliasing it to "claude" would silently run the SDK instead of the
+//    CLI (CLI-login users downgraded to the SDK channel). The e2e that owns this path is qa-180-rename-ghost.
+//    (The `--help` above lists it only in the Runtime section, marked as anet-provided, for exactly this reason.)
 if (!Object.prototype.hasOwnProperty.call(RUNTIME_MAP, rawRuntime)) {
   const supported = [...new Set(Object.keys(RUNTIME_MAP))].join(", ");
   console.error(`[${ALIAS}] Unsupported runtime "${rawRuntime}". Supported: ${supported}`);


### PR DESCRIPTION
Corrected scope of #909 (口径 by 通信龙). The original premise ("unimplemented runtime") was **wrong** — `claude-code-cli`'s execution lane lives in the **launcher** (`agent-network/bin/cli.ts` — `anet node start` → launchAgent → spawns the real `claude` CLI, ~`:5096`) and never routes through agent-node. So agent-node rejecting it at `RUNTIME_MAP` is **correct**, not a gap. The only real defect was cosmetic: agent-node's own `--help` listed `claude-code-cli` among the `--runtime <type>` values you pass to agent-node, which sent users chasing a spelling error.

## Change — help-text only, no execution path touched
- `--runtime <type>` value list: drop `claude-code-cli` (agent-node doesn't accept it) + a one-line pointer.
- Runtime section: keep it documented but marked **「由 `anet` 提供并启动（`anet node start`）；不能直接传给 agent-node」** — **NOT** "not yet implemented" (it *is* implemented, in the launcher).
- A pinning comment at `RUNTIME_MAP` so the next reader doesn't re-derive the same wrong "missing key" conclusion from the `--help` ↔ `RUNTIME_MAP` mismatch (points at `bin/cli.ts:5096` + `qa-180-rename-ghost`).
- 🔴 `RUNTIME_MAP` and its generic rejection are **unchanged** — that rejection is the correct behaviour and is kept (`agent-node --runtime claude-code-cli` still → `Unsupported runtime`).

## Test (light — no over-design; no launcher assertions; RUNTIME_MAP untouched)
`--help` omits `claude-code-cli` from the passable list (positive control: still lists `claude-agent-sdk`/`codex-sdk`, so the list wasn't stripped), stays documented as anet-provided, and is **not** described as a gap. Witnessed-red on revert. agent-node domain: **1290/0**.

Supersedes the **closed #915**, which was built on the wrong premise (its launcher branch blocked the shipping `qa-180-rename-ghost` e2e). See #909 for the corrected analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)