### PR TITLE
docs(cli): 「默认按 channel 匹配」这句注释和代码相反,而且 #61 那个 TODO 的到期条件早就满足了

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1539,6 +1539,25 @@ function getAnetVersion(): string {
 // promote 0.4.5 → @latest 后 swap anet@latest 路径回 @latest (🅗1)。
 // TODO(#61 phase-2): swap anet@latest fallback "preview" → "latest" once
 //   @sleep2agi/agent-network-dashboard promotes 0.4.5 stable.
+//
+// 🔴 2026-08-18 — that condition passed a long time ago and nobody re-checked
+// it. Measured against the live registry today:
+//
+//     latest  = 0.6.0
+//     preview = 0.6.3-preview.56
+//
+// The blocker this fallback was written for (latest pinned at 0.4.2 while
+// preview had 0.4.5) no longer exists; `latest` is now many minors past the
+// version the TODO waits for. The fallback outlived its own stated expiry.
+//
+// It is NOT flipped here on purpose: doing so changes what every stable-channel
+// user's `anet hub dashboard` fetches (0.6.0 instead of 0.6.3-preview.56), and
+// whether 0.6.0 is feature-complete enough is a product call, not a cleanup.
+// See #866 for the numbers and the decision.
+//
+// The general shape, worth naming: a temporary workaround that WRITES DOWN its
+// expiry condition is better than one that doesn't — but only if someone
+// re-reads it. Nothing re-evaluates a condition stored in a comment.
 function dashboardReleaseTag(): string {
   const envOverride = process.env.ANET_DASHBOARD_VERSION;
   if (envOverride) return envOverride;
@@ -6299,8 +6318,19 @@ async function serverCommand() {
       ...(dashboardToken ? { COMMHUB_AUTH_TOKEN: dashboardToken } : {}),
     };
 
-    // Default stays channel-matched (see #61 + dashboardReleaseTag). A global
-    // binary is used only after the explicit ANET_DASHBOARD_LOCAL=1 opt-in.
+    // 🔴 The default is NOT channel-matched — this comment used to say it was.
+    // dashboardReleaseTag() returns "preview" for every caller (see its own
+    // comment for the #61 reason), so a user on the stable `anet` channel gets
+    // the preview Dashboard. That is a deliberate temporary decision, but the
+    // sentence here claimed the opposite and was the only thing most readers
+    // of this call site would see.
+    //
+    // The runtime output is honest — the spawn line below prints the actual
+    // `@${tag}` — so this was a comment that disagreed with both the code and
+    // the program's own output.
+    //
+    // A global binary is used only after the explicit ANET_DASHBOARD_LOCAL=1
+    // opt-in.
     cleanStaleNpxDashboardTemp(); // #89 — self-heal npx cache before spawn
     console.log(globalOptIn
       ? `[anet] spawning explicit global Dashboard ${globalBinary} (anet ${getAnetVersion() || "unknown"})`


### PR DESCRIPTION
两处**纯注释**改动,零可执行行变化(diff 里新增行全部是 `//`,删除的两行也是)。`bun build` 通过。

## 一、`bin/cli.ts:6302` 的注释在说谎

```
// Default stays channel-matched (see #61 + dashboardReleaseTag).
```

`dashboardReleaseTag()` 对**每一个**调用者都返回 `"preview"` —— 所以 stable channel 的 `anet` 用户拿到的是 **preview** Dashboard。这是有意的临时决定(函数自己的注释把 #61 的理由写得很清楚),但**调用点这句话说的正好相反**,而它是大多数读到这里的人唯一会看到的说明。

运行时输出本身是诚实的(下面那行 spawn 打印真实的 `@${tag}`)—— 所以这是一句**同时和代码、和程序自己的输出都不一致**的注释。

## 二、#61 phase-2 那个 TODO 的条件早就满足了,没人回头看

TODO 写的是「等 promote **0.4.5** stable 后 swap」。今天对着 live registry 量:

```
latest  = 0.6.0
preview = 0.6.3-preview.56
```

它当初为之存在的阻塞(latest 停在 0.4.2、preview 才有 0.4.5)**已经不存在** —— latest 已经比 TODO 等的那个版本高好几个 minor。**这个「临时」方案活过了它自己写下的到期条件。**

🔴 **没有在本 PR 里翻转它**:翻转会改变每个 stable 用户 `anet hub dashboard` 拉到的东西(0.6.0 而不是 0.6.3-preview.56),而 0.6.0 功能够不够是**产品决定不是清理**。数字和决定记在 #866。

## 值得单独命名的形状

**一个把到期条件写下来的临时方案,比不写的好 —— 但只在有人回头读它的前提下。没有任何东西会去重新评估一个存在注释里的条件。**