### PR TITLE
fix(ci): e2e-docker 的 push 触发器漏了 branches: [main] —— 每个 PR 都把最贵的 job 跑两遍,且两个 run 同名让 required check 无法指定

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -1,7 +1,23 @@
 name: Docker E2E Tests
 
 on:
+  # 🔴 `branches: [main]` 不是可选的装饰 —— 没有它,这个 workflow 会在**任何**分支
+  # 的 push 上跑,于是每个 PR 都跑两遍:一遍 push、一遍 pull_request。
+  #
+  # 实测(2026-08-17,同一分支 fix/909-help-text-agent-node):run #2327 与 #2328
+  # 是同一个 commit 的两次完整 e2e,各约 10 分钟,结论相同。
+  #
+  # 三个代价:
+  #   1. 全仓最贵的 job 跑两遍;
+  #   2. PR 的等待时间由「最慢的一次」变成「两次都跑完」——合并前要多等一轮;
+  #   3. 两次都产出名为 `e2e` 的 check,**分支保护的 required check 只能按名字指定**,
+  #      两个同名 run 让「哪一个必须绿」无法确定。这和 #916 修掉的四个 job 都叫
+  #      `scan` 是同一类问题,只是这次重名发生在同一个 workflow 的两个触发器之间。
+  #
+  # 仓里其它 workflow(qa.yml / action-pins.yml / lint-from-session.yml …)的 push
+  # 触发器全部写了 `branches: [main]`,只有这个漏了。
   push:
+    branches: [main]
     paths:
       - 'agent-network/**'
       - 'agent-node/**'


### PR DESCRIPTION
`on.push` 没有 `branches:` 限制 ⇒ 它在**任何**分支的 push 上都跑,加上 `on.pull_request`,**每个 PR 分支上同一个 commit 会跑两次完整 e2e**。

## 实测

同一分支 `fix/909-help-text-agent-node`,2026-08-17:

| run | 事件 | 时长 | 结论 |
|---|---|---|---|
| #2327 | 其一 | ~10 min | success |
| #2328 | 其二 | ~10 min | success |

同一个 commit,两次完整 e2e,结论相同。

## 三个代价

1. **全仓最贵的 job 跑两遍。**
2. **PR 的等待时间从「最慢的一次」变成「两次都跑完」。** 今晚 #918 就卡在这上面 —— 一个 `e2e` 已经 success,另一个还 `in_progress`,又等了几分钟。
3. 🔴 **两次都产出名为 `e2e` 的 check,而分支保护的 required check 只能按名字指定** —— 两个同名 run 让「哪一个必须绿」无法确定。

第 3 点和 **#916** 修掉的「四个 workflow 的 job 都叫 `scan`」是**同一类问题**,只是这次重名发生在**同一个 workflow 的两个触发器之间**。#828 要把门装上牙齿,这类重名是绕不过去的前置。

## 为什么这不是一个待讨论的策略变更

仓里**其它每一个** workflow 的 push 触发器都写了 `branches: [main]`:

```
qa.yml                push.branches=[main]
action-pins.yml       push.branches=[main]
lint-from-session.yml push.branches=[main]
e2e-docker.yml        push.branches=None    ← 只有这个
```

**这是把唯一一个不一致的地方对齐到既有约定**,不是引入新规则。

`paths` 过滤一字未动(push 6 条 / pull_request 4 条,已用 `yaml.safe_load` 核过;jobs 仍是 `e2e` + `rename-ghost-gate`)。