### PR TITLE
ci: 加一道门盯住「跑什么」和「什么时候跑」两份清单不同步(#860 的失效已发生过一次,且不会自曝)

### DIFF
--- a/.github/scripts/check-l1-paths-sync.py
+++ b/.github/scripts/check-l1-paths-sync.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Every suite qa.sh runs must also be a `paths:` trigger of the workflow that runs it.
+
+Two lists decide different halves of one thing, and nothing keeps them in sync:
+
+  scripts/qa.sh          `L1_TESTS`                  — WHAT gets run
+  .github/workflows/qa.yml  `on.pull_request.paths`  — WHEN it gets run
+
+Add a suite to L1_TESTS and forget the paths entry, and the gate is blind to that
+suite forever: editing it does not trigger the workflow that runs it. That failure
+has already happened once here (#860, three suites: test686 / test765 / test766).
+
+🔴 It leaves no trace that would expose it. The gate keeps passing, the suite keeps
+being maintained, and the only way to notice is to line the two lists up and compare
+them — which is what this script does. A drift like this is invisible precisely
+because nothing about a green run distinguishes "ran and passed" from "was never
+eligible to run".
+
+Deliberately dependency-free and unconditional: no `paths:` filter of its own, no
+Docker, milliseconds. That is not an accident — a guard that watches trigger
+coverage must not itself be gated on a path, or a change to the thing it watches
+can slip past it (same reasoning as check-qa-trigger-coverage.py and
+check-action-pins.py).
+
+Fail-closed: if either list comes back empty, that is a parse regression, not a
+clean run — exit 2 rather than reporting success over an empty denominator.
+"""
+import fnmatch
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("::error::PyYAML is not available — cannot parse the workflow, refusing to pass")
+    sys.exit(2)
+
+QA_SH = "scripts/qa.sh"
+QA_YML = ".github/workflows/qa.yml"
+
+
+def l1_suites(text: str) -> list[str]:
+    """Suite names from qa.sh's L1_TESTS array."""
+    m = re.search(r"L1_TESTS=\(([^)]*)\)", text, re.S)
+    if not m:
+        return []
+    return re.findall(r'"([^"]+)"', m.group(1))
+
+
+def pr_paths(doc: dict) -> list[str]:
+    # YAML 1.1 parses a bare `on:` key as the boolean True, so accept both.
+    on = doc.get("on") or doc.get(True) or {}
+    pr = on.get("pull_request") or {}
+    return list(pr.get("paths") or [])
+
+
+def covered(suite: str, paths: list[str]) -> bool:
+    """Would a change inside tests/<suite>/ match any of the workflow's paths?
+
+    Checked against a concrete file rather than the directory: GitHub matches
+    `paths:` against changed FILE paths, so `tests/x/**` must be tested with
+    something under it, not with `tests/x/`.
+    """
+    probe = f"tests/{suite}/run.sh"
+    for p in paths:
+        if fnmatch.fnmatch(probe, p) or fnmatch.fnmatch(probe, p.replace("**", "*")):
+            return True
+    return False
+
+
+def main() -> int:
+    try:
+        sh = open(QA_SH, encoding="utf-8").read()
+        doc = yaml.safe_load(open(QA_YML, encoding="utf-8"))
+    except FileNotFoundError as e:
+        print(f"::error::{e.filename} is missing — scope regression, refusing to pass")
+        return 2
+
+    suites = l1_suites(sh)
+    paths = pr_paths(doc)
+
+    if not suites:
+        print(f"::error::found no L1_TESTS entries in {QA_SH} — parse regression, refusing to pass")
+        return 2
+    if not paths:
+        print(f"::error::found no on.pull_request.paths in {QA_YML} — parse regression, refusing to pass")
+        return 2
+
+    missing = [s for s in suites if not covered(s, paths)]
+    for s in missing:
+        print(
+            f"::error file={QA_SH}::L1 suite '{s}' is run by qa.sh but no `paths:` entry in "
+            f"{QA_YML} matches tests/{s}/. Editing that suite will not trigger the workflow "
+            f"that runs it, and nothing else would report that. Add `tests/{s}/**` to "
+            f"on.pull_request.paths."
+        )
+
+    print(f"checked {len(suites)} L1 suite(s) against {len(paths)} path pattern(s) in {QA_YML}")
+    if missing:
+        print(f"\n{len(missing)} suite(s) run without a matching trigger.")
+        return 1
+    print("every L1 suite has a matching trigger.")
+    return 0
+
+
+def selftest() -> int:
+    """Pin the two parsers, because that is where this gate would go blind.
+
+    If `l1_suites` silently returns [] the run above exits 2 — but if it returns a
+    SUBSET, the gate passes while checking fewer suites than exist, and the output
+    is indistinguishable from a real clean run except for one count nobody reads.
+    """
+    sh = 'x=1\nL1_TESTS=(\n  "qa-a"\n  "test-b"   # trailing comment\n)\necho hi\n'
+    yml = {
+        "on": {"pull_request": {"paths": ["tests/qa-*/**", "tests/test-b/**", "scripts/qa.sh"]}},
+    }
+    cases = [
+        ("L1_TESTS parsed in full", l1_suites(sh) == ["qa-a", "test-b"]),
+        ("missing array yields empty (→ exit 2 upstream)", l1_suites("no array here") == []),
+        ("paths read from on.pull_request", len(pr_paths(yml)) == 3),
+        ("bare `on:` parsed as True still works", len(pr_paths({True: yml["on"]})) == 3),
+        ("glob pattern covers a suite", covered("qa-a", pr_paths(yml))),
+        ("explicit pattern covers a suite", covered("test-b", pr_paths(yml))),
+        ("uncovered suite is reported", not covered("test-c", pr_paths(yml))),
+        ("dir-only probe would false-negative — we probe a file", covered("test-b", ["tests/test-b/**"])),
+    ]
+    bad = [n for n, ok in cases if not ok]
+    for n, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {n}")
+    if bad:
+        print(f"::error::selftest failed: {len(bad)} case(s)")
+        return 1
+    print(f"selftest: {len(cases)}/{len(cases)} ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(selftest() if "--selftest" in sys.argv else main())

--- a/.github/workflows/l1-paths-sync.yml
+++ b/.github/workflows/l1-paths-sync.yml
@@ -1,0 +1,32 @@
+# scripts/qa.sh decides WHICH L1 suites run; qa.yml's `paths:` decides WHEN the
+# workflow that runs them fires. Nothing keeps those two lists in sync, and the
+# drift is silent: a suite added to L1_TESTS without a matching `paths:` entry is
+# never triggered by edits to itself, while the gate keeps reporting green.
+#
+# That already happened once (#860 — test686 / test765 / test766).
+#
+# 🔴 No `paths:` filter here, on purpose. This guard watches trigger coverage; if
+# it were itself gated on a path, a change to the very files it watches could slip
+# past it. Same reasoning as action-pins.yml and qa-trigger-coverage.yml — and it
+# is what makes this job a candidate for a required check (#828), since it reports
+# on every pull request rather than only on the ones that touch certain files.
+
+name: lint (L1 trigger sync)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    # Unique across the repo — a check name is the only identifier a branch
+    # protection rule can name (#916).
+    name: l1-paths-sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Parsers first: if either list stops being readable, the scan below would
+      # still print a count and exit 0 on an empty denominator.
+      - run: python3 .github/scripts/check-l1-paths-sync.py --selftest
+      - run: python3 .github/scripts/check-l1-paths-sync.py


### PR DESCRIPTION
两份清单各决定一件事,而**没有任何机制保证它们同步**:

```
scripts/qa.sh              L1_TESTS                — 跑什么
.github/workflows/qa.yml   on.pull_request.paths   — 什么时候跑
```

往 `L1_TESTS` 加一个套件、忘了加 `paths` 条目 ⇒ **改那个套件不会触发跑它的 workflow**,而门一直是绿的、套件也一直有人维护。

**#860 记录的正是这个失效**,涉及 `test686` / `test765` / `test766` 三个套件(现已各自补上 paths 条目,我实测 17/17 命中)。

## 🔴 它不留任何可以自曝的痕迹

一次绿色运行里,**「跑过并通过」和「压根没被触发」长得完全一样** —— 没有计数、没有告警、没有任何字节的差别。唯一能发现它的方式,是把两份清单对起来比一次。

这也是为什么它能活到被 #860 单独开一条 issue 才被看见。

## 证据(真仓数据,先红后绿)

| 场景 | exit | 输出 |
|---|---|---|
| A 未变异 | **0** | `every L1 suite has a matching trigger` |
| B 从 `pull_request.paths` 删掉 test686 | **1** | 只点名 test686,**分母 14→13** |
| C 把 `L1_TESTS` 数组改名(解析失效) | **2** | `parse regression, refusing to pass` |
| D `scripts/qa.sh` 缺失 | **2** | `scope regression, refusing to pass` |

**B 的变异带断言确认过不是 no-op** —— 第一次锚点命中 **2 次**(`push` 和 `pull_request` 各有一条相同的 paths),assert 直接失败,改成只删 `pull_request` 块里那一条才生效。**要不是那句 assert,我会删掉一条 push 的 paths 然后以为门没反应。**

**C/D 是 fail-closed**:分母塌陷时红,而不是「检查了 0 个套件,全部通过」。

## 为什么没有 `paths:` 过滤

这道门看的就是**触发覆盖面**;如果它自己被 paths 门住,**改它监视的那些文件反而可能绕过它**(和 `action-pins.yml` / `qa-trigger-coverage.yml` 同一条理由,那两个文件的注释里也写着)。

副作用正好是我们要的:**它在每个 PR 上都跑** —— 这让它成为 **#828** 里可以设成 required check 的候选。目前能设 required 的只有 `no hardcoded from_session` 一道,因为其余无条件跑的门在存量 PR 上还没有对应的 check 名。

## 两个来自今晚的教训已经落进去

- job 名 `l1-paths-sync` **全仓唯一**(#916:check 名是分支保护里**唯一能写的标识符**,四个 job 都叫 `scan` 时 required 无法指名)
- `--selftest` 排在真扫描**之前**,钉的是**两个解析器** —— 它们静默返回**子集**时,扫描仍会打印一个计数并 exit 0(#911 那道门就是这么瞎了 16 条链接的)