### PR TITLE
test(test224): 「网络已禁用」以前是一句声明,现在是一条断言(#814)

### DIFF
--- a/tests/test224-grok-preview-security/run.sh
+++ b/tests/test224-grok-preview-security/run.sh
@@ -71,7 +71,21 @@ scan_tree_for_markers() {
 
 log "# test224 — Grok preview credential and package gate"
 log "date: $(date -Is)"
-log "network: disabled by runner"
+# 🔴 这一行以前是 `log "network: disabled by runner"` —— 一句**声明**,不是断言。
+# 它挨着的每一条(`[ ! -e "$ROOT/.git" ] || fail …`)都真的在验,只有它在复述一个
+# 别人应该做过的事。而 [L2] 那一步的全部意义是「在没有网络的情况下构建」——
+# 如果 runner 忘了 `--network none`,那一步照样绿,而它证明的东西并不成立。
+#
+# 判据用直接观察:`--network none` 的容器里 /sys/class/net 只有 lo。
+# 有任何第二个接口,就说明这一轮的「无网络」前提是假的,后面的绿都不作数。
+net_ifaces=$(ls /sys/class/net 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
+if [ -z "$net_ifaces" ]; then
+  fail "cannot read /sys/class/net — cannot establish whether the network is off; refusing to claim it is"
+fi
+if [ "$net_ifaces" != "lo" ]; then
+  fail "network is NOT disabled: /sys/class/net has [$net_ifaces], expected only [lo]. Run this suite with --network none; [L2] claims to build without network and that claim is void here."
+fi
+pass "network is off (verified: /sys/class/net = [$net_ifaces])"
 log "source_commit=$SOURCE_COMMIT"
 
 log "[L0] isolated, synthetic-only environment"


### PR DESCRIPTION
`tests/test224-grok-preview-security/run.sh` 里有这么一行:

```sh
log "network: disabled by runner"
```

它挨着的每一条都**真的在验**:

```sh
[ ! -e "$ROOT/.git" ]   || fail "image contains repository metadata"
[ ! -e /root/.grok ]    || fail "image contains a Grok home"
[ ! -e /root/.anet ]    || fail "image contains an anet home"
```

**只有它在复述一个别人应该做过的事。**

## 为什么这一句要紧

`[L2]` 那一步的标题就是 **「build candidate package payloads without network」**。它的全部意义在于「在没有网络的情况下也能构建」—— 如果 runner 忘了 `--network none`,**那一步照样绿,而它证明的东西并不成立**。

🔴 **忘记加那个 flag 与正确加了它,产出的证据逐字相同。** 这正是 #814 说的:「忘了 `--network none` 也会产出绿色证据」。

## 改法:直接观察,不复述

```sh
net_ifaces=$(ls /sys/class/net 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')
if [ -z "$net_ifaces" ]; then
  fail "cannot read /sys/class/net — cannot establish whether the network is off; refusing to claim it is"
fi
if [ "$net_ifaces" != "lo" ]; then
  fail "network is NOT disabled: /sys/class/net has [$net_ifaces], expected only [lo]. …"
fi
pass "network is off (verified: /sys/class/net = [$net_ifaces])"
```

`--network none` 的容器里 `/sys/class/net` 只有 `lo` —— 这是**对那件事本身的观察**,不是它的附带特征(比如「某次 DNS 查询失败了」,那种探针可能因为别的原因失败而给出假的安心)。

**两个方向都收**:
- 读不到 `/sys/class/net` 时 **拒绝声称网络是关的**(fail-closed,而不是「看不见就是没有」);
- 看到第二个接口时**点名它**,并说明**后面的绿因此不作数**。

## 验证

本机(有网的宿主)对照:

```
$ ls /sys/class/net
docker0 eth0 lo
```

→ 这条断言在这里会**红**,并打印 `[docker0 eth0 lo]`。也就是说它不是一条只会绿的装饰。

`bash -n` 通过。

## 一件我**没有**在本 PR 里做的事

test224 目前**不被任何 CI 引用**(#861 统计的 180 个孤儿之一);**PR #803** 正在把它注册进 `qa.sh`。

本 PR **只修判据,不改注册状态**。理由:**一道会被跑的假断言,和一道不会被跑的真断言,前者更危险** —— 前者会主动生产错误的信心,后者只是没产生信心。先修前者,注册的事归 #803。