### PR TITLE
fix(cli): 就绪探针只看 tmux 可见区——一行日志把「listening on」顶走就等满 25s 判失败(#849)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -238,7 +238,15 @@ function waitForTmuxPaneText(sessionName: string, needle: string, timeoutMs: num
       try {
         const paneTarget = tmuxPaneTarget(sessionName);
         if (!paneTarget) return false;
-        const out = execFileSync("tmux", ["capture-pane", "-t", paneTarget, "-p"], {
+        // 🔴 `-S -200`:不带它,capture-pane 只返回**当前可见区**。
+        // 一行「listening on: …」被后续日志顶出屏幕之后,这个轮询就再也看不到它了,
+        // 于是等满 timeout 判失败 —— 而服务其实早就绑上了(#849 实测 1.1s 绑上、
+        // 25s 判失败)。本地复现:同一个 pane,先打 needle 再刷 200 行日志,
+        //   capture-pane -p          → includes = false
+        //   capture-pane -p -S -500  → includes = true
+        // 这个函数找的是**一次性出现过**的那一行,不是「此刻屏幕上有什么」,
+        // 所以它必须看回滚。(同文件 :810 早就带了 `-S -80`——正确写法一直在。)
+        const out = execFileSync("tmux", ["capture-pane", "-t", paneTarget, "-p", "-S", "-200"], {
           stdio: ["ignore", "pipe", "pipe"], encoding: "utf8",
         });
         if (out.includes(needle)) { resolve(true); return; }
@@ -7962,6 +7970,12 @@ async function dismissDevChannelPrompt(sessionName: string, timeoutMs: number): 
       // Discard tmux's stderr: polling a session that has already exited is a
       // normal outcome here, and letting `can't find pane: X` through made the
       // CLI print an alarming line right before an unrelated verdict.
+      //
+      // 🔴 这里**故意不加 `-S`**,和 #849 修的那两处相反 —— 因为问题不同:
+      // 那两处找的是「**曾经出现过**的一行」(就绪信号 / 失败原因),必须看回滚;
+      // 这里判的是「**此刻屏幕上有没有一个等人回答的提示框**」。加上回滚,一个
+      // 早就被答掉、已经滚走的提示框会被重新识别成待处理,于是往一个并没有显示
+      // 它的会话里 send-keys。**同一个 flag,这三处里两处该加、一处不该。**
       pane = execFileSync("tmux", ["capture-pane", "-p", "-t", paneTarget], {
         encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
       }).toString();
@@ -7996,7 +8010,10 @@ function capturePaneReason(sessionName: string): string | null {
   try {
     const paneTarget = tmuxPaneTarget(sessionName);
     if (!paneTarget) return null;  // session already reaped
-    const pane = execFileSync("tmux", ["capture-pane", "-p", "-t", paneTarget], {
+    // 🔴 同 #849:找的是「**曾经出现过**的那一行拒绝原因」,不是「此刻屏幕上有什么」。
+    // 一个已经死掉的 pane,它的报错很可能已被后续输出顶出可见区 —— 不带 `-S` 就会
+    // 拿到 null,调用方回退到一句泛化的失败文案,而真正的原因明明还在回滚里。
+    const pane = execFileSync("tmux", ["capture-pane", "-p", "-t", paneTarget, "-S", "-200"], {
       encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
     }).toString();
     return extractStartFailureReason(pane);


### PR DESCRIPTION
## 根因

`waitForTmuxPaneText` 用的是:

```ts
execFileSync("tmux", ["capture-pane", "-t", paneTarget, "-p"], …)
```

🔴 **不带 `-S` 时,`capture-pane` 只返回当前可见区。**

app-server 打完 `listening on: <ws>` 之后如果还有任何输出,那一行滚出屏幕,这个 400ms 轮询就**再也看不到它**,于是等满 25s 报 `did not bind within 25s` —— **而服务早就绑上了**。

本条实测的 **「1.1s 绑上、25s 判失败」** 和这个机制完全吻合。

## 本地复现(同一个 pane,先打 needle 再刷 200 行日志)

```
capture-pane -p            → includes(needle) = false
capture-pane -p -S -500    → includes(needle) = true
```

判据就是 `-S`。**这个函数找的是「曾经出现过一次」的那一行,不是「此刻屏幕上有什么」。**

(顺带排除掉一个我先怀疑的方向:pane 目标用的是 `tmuxPaneTarget()` 坐标形式,**不是** `=name` —— 非 ASCII 会话名那个老问题(#901)在这里**不成立**。)

## 🔴 同一个 flag,四处调用里两处该加、一处不该、一处早就加了

| 位置 | 它在找什么 | 处置 |
|---|---|---|
| `:249` `waitForTmuxPaneText` | **曾出现过**的就绪信号 | **加 `-S -200`** ← 本条 |
| `:818` bridge 尾部日志 | **曾出现过**的上下文 | 早就有 `-S -80` ✅ |
| `:8016` `capturePaneReason` | **曾出现过**的失败原因 | **加 `-S -200`** |
| `:7979` dev-channels 自动应答 | **此刻屏幕上**有没有提示框 | 🔴 **故意不加** |

**`:818` 说明正确写法一直在同一个文件里** —— 只是没用在需要它的另外两处。这是这个仓今晚反复出现的形状。

**`:8016` 值得单独说**:一个已死 pane 的报错常被后续输出顶走;拿不到就回退成一句泛化的失败文案,**而真正的原因还在回滚里**。用户看到「启动失败」而不是「它自己说的那句拒绝理由」。

**`:7979` 我刻意没改,并在旁边写下了理由** —— 加上回滚,一个**早被答掉、已经滚走**的提示框会被重新识别成待处理,于是往一个并没有显示它的会话里 `send-keys`。**免得下一个人看到「三处有 `-S`、一处没有」就顺手补齐。**

## 验证

- `bun build` 通过
- `tmux-pane-prompt` + `tmux-exact-target` 单测 **14/14**
- 四处调用点的最终状态已逐条列在 commit message 里

## 一个过程上的记录

我这次改动分三步,**第二步的锚点断言失败、整个脚本中止,而我一度以为它已经写进去了** —— 是回头 `grep` 四个调用点才发现 `:8016` 根本没变。

**`assert 锚点命中 == 1` 挡住了一次静默 no-op,但它挡不住我对「上一步成功了」的假设。** 改完之后重新 grep 一遍,才是那一步真正的收尾。