### PR TITLE
fix(cli): 首次 start 懒取 agent-node 失败时把 npx 说的话丢掉了(#450)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2305,8 +2305,26 @@ function resolvePreviewAgentNodeEntrypoint(resolverEnv: NodeJS.ProcessEnv): stri
         env: resolverEnv,
       },
     );
-  } catch {
-    throw new Error("could not install and resolve @sleep2agi/agent-node@preview");
+  } catch (e: any) {
+    // 🔴 这里以前是 `catch { throw new Error("could not install and resolve …") }`
+    // —— 把 npx 说的话整个丢掉。而这是**全新安装的第一次 start** 必经的一步
+    // (agent-node 按设计由 npx 懒取,见 checkRuntimeDependency 里那句 note),
+    // 所以它失败时用户拿到的是一句没有原因的话,而真正的原因就在被丢掉的 stderr 里:
+    // registry 不可达 / 权限 / 磁盘满 / 120s 超时 —— 每一种的下一步动作都不同。
+    //
+    // 同一个形状在 docs-site/docs/public/install.sh 上修过一次(#908):那次是
+    // `>/dev/null 2>&1` 吞掉首次尝试的 stderr,然后把每一种失败都叙述成
+    // 「registry 失败」。这里更进一步 —— 它连一个猜测都不给。
+    const detail = [e?.stderr, e?.stdout, e?.message]
+      .map((v: unknown) => (typeof v === "string" ? v : v ? String(v) : ""))
+      .find((v: string) => v.trim().length > 0) ?? "";
+    const trimmed = detail.trim().split(/\r?\n/).slice(-8).join("\n").slice(0, 1200);
+    const isTimeout = e?.code === "ETIMEDOUT" || e?.signal === "SIGTERM";
+    throw new Error(
+      `could not install and resolve @sleep2agi/agent-node@preview`
+      + (isTimeout ? ` (npx exceeded the 120s budget)` : ``)
+      + (trimmed ? `\n--- npx said ---\n${trimmed}` : `\n(npx produced no output — check that \`npx\` itself works)`),
+    );
   }
 
   const lines = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);


### PR DESCRIPTION
`resolvePreviewAgentNodeEntrypoint` 原来是:

```ts
} catch {
  throw new Error("could not install and resolve @sleep2agi/agent-node@preview");
}
```

`execFileSync` 明明 `stdio: [..., "pipe", "pipe"]` 抓了 stderr,**而 catch 把它整个丢掉**。

🔴 **这是全新安装第一次 `anet node start` 的必经之路** —— agent-node 按设计由 npx 懒取(`checkRuntimeDependency` 里那句 `note: agent-node will be lazy-fetched via npx on first start (this is normal)` 就是在说它)。

所以它失败时,用户拿到的是一句**没有原因**的话,而真正的原因就在被丢掉的 stderr 里:**registry 不可达 / 权限 / 磁盘满 / 120s 超时 —— 每一种的下一步动作都不同。**

## stub 掉 npx(让它报 EACCES)实测对照

```
修前:could not install and resolve @sleep2agi/agent-node@preview

修后:could not install and resolve @sleep2agi/agent-node@preview
     --- npx said ---
     npm error code EACCES
     npm error syscall mkdir
     npm error path /usr/lib/node_modules/@sleep2agi
```

## 同一个形状,今晚第二次

`docs-site/docs/public/install.sh` 上修过一次(**#908**):那次是 `>/dev/null 2>&1` 吞掉首次尝试的 stderr,然后把**每一种**失败都叙述成「registry 失败」。

**这里更进一步 —— 它连一个猜测都不给。**

## 三处细节

- **超时单独点名**(`npx exceeded the 120s budget`)—— 120s 超时和 npx 报错在原来那句话里**完全一样**;
- npx 一个字都没输出时明说 `(npx produced no output — check that \`npx\` itself works)`,而不是留一句空原因;
- stderr 只取**最后 8 行**、截断到 1200 字符 —— 够定位,不刷屏。

`bun build` 通过。