### PR TITLE
test(#167): watcher 那条把定长 sleep 换成轮询 —— 4.0s sleep 装在 5.0s 预算里,CI 实测已红一次

### DIFF
--- a/server/src/task-lifecycle-watcher.test.ts
+++ b/server/src/task-lifecycle-watcher.test.ts
@@ -45,6 +45,26 @@ afterAll(() => {
   try { server?.stop(true); } catch {}
 });
 
+/**
+ * 轮询到 `ready()` 为真,或到期抛错。
+ *
+ * 定长 sleep 的问题不是「慢」,是**报错报在错的层**:超时之后测试红在
+ * 「事件没写」这条断言上,读的人会去查 watcher,而真实原因可能是子进程
+ * 还没起来。这里到期时把那句话直接说出来。
+ */
+async function waitUntil(ready: () => boolean, timeoutMs: number, what: string | null): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (ready()) return;
+    if (Date.now() >= deadline) {
+      // what === null:到期本身就是期望结果(调用方随后自己断言),不抛。
+      if (what === null) return;
+      throw new Error(`timed out after ${timeoutMs}ms: ${what}`);
+    }
+    await Bun.sleep(25);
+  }
+}
+
 describe("#167 Hub delivered-stale lifecycle watcher", () => {
   test("30s/60s thresholds are exact and non-delivered tasks stay silent", () => {
     const first = recordDeliveredStaleEvents(NOW);
@@ -132,7 +152,14 @@ describe("#167 Hub delivered-stale lifecycle watcher", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    await Bun.sleep(800);
+    // 这里**不**等「hub 就绪」——因为没有一个只有 hub 起来了才成立的廉价判据:
+    // db 文件在上面那步 init 里就已经存在了,拿它当条件的话这个等待恒真,等于没等。
+    // 真正需要「hub 起来了」的是下面那条断言,而它已经改成轮询到目标状态,
+    // hub 起得慢只是让它多等几轮。
+    //
+    // 这一步保留的是原来那条断言的原意:**子进程没有立刻崩**。所以只给它一个
+    // 短窗口,并且如果它在窗口内退出就立刻停下来报错,不用把 800ms 睡满。
+    await waitUntil(() => child.exitCode !== null, 800, null);
     expect(child.exitCode).toBeNull();
 
     const taskId = "stale-live-wiring";
@@ -147,14 +174,23 @@ describe("#167 Hub delivered-stale lifecycle watcher", () => {
       expect(childDb.query<{ count: number }, [string]>(
         "SELECT COUNT(*) AS count FROM task_events WHERE task_id = ?1",
       ).get(taskId)!.count).toBe(0);
-      await Bun.sleep(3_200);
-      expect(childDb.query<{ count: number }, [string]>(
+      // 巡检周期是 COMMHUB_DELIVERED_STALE_PATROL_MS=25ms —— 事件在插入后
+      // 几十毫秒内就该出现。原来这里是定长 sleep(3_200),纯粹是余量:
+      // 4.0s 的 sleep 装在 bun 默认的 5.0s 单测预算里,只剩 1s 给两次进程启动。
+      // 实测在 CI 上被这一条打红过(#798 让这个文件第一次进 CI 才暴露)。
+      // 改成「轮询到目标状态,或到期报错」:常态下快 ~60 倍,慢的时候等得起。
+      const countStale = () => childDb.query<{ count: number }, [string]>(
         "SELECT COUNT(*) AS count FROM task_events WHERE task_id = ?1 AND event_type = 'task.warning.delivered_stale_30s'",
-      ).get(taskId)!.count).toBe(1);
+      ).get(taskId)!.count;
+      await waitUntil(() => countStale() === 1, 20_000,
+        "watcher did not write the delivered_stale_30s event");
+      expect(countStale()).toBe(1);
     } finally {
       childDb.close();
       try { child.kill("SIGTERM"); } catch {}
       await child.exited;
     }
-  });
+    // 🔴 显式超时:这一条要起两个真 bun 进程,bun 默认的 5s 对它不成立。
+    // 上面两处已改成轮询,常态用不到这个上限;它只保证「慢」不会被报成「坏」。
+  }, 30_000);
 });


### PR DESCRIPTION
test(#167): 定长 sleep 换成轮询 —— 4.0s 的 sleep 装在 bun 默认 5.0s 预算里

`startHub owns a live watcher timer` 这一条在 CI 上红了一次:

    (fail) startHub owns a live watcher timer ... [5000.57ms]
      ^ this test timed out after 5000ms.
     4 pass  1 fail   Ran 5 tests across 1 file.

它不是偶发慢,是**结构上就没有余量**:两处定长 `Bun.sleep(800)` + `Bun.sleep(3_200)`
合计 4.0s,而 bun 每条测试默认预算 5.0s —— 剩 1.0s 要装下两次 bun 进程启动
(`bun -e import db.js` 初始化 + `bun run server/src/index.ts` 起一个真 hub)。
本机够,CI 里(冷 bun、Docker、72 个文件排队)不够。

改动:

1. **等事件那处改成轮询**。巡检周期是 `COMMHUB_DELIVERED_STALE_PATROL_MS=25`,
   事件在插入后几十毫秒就该出现,3_200ms 纯粹是余量。轮询后常态快 ~60 倍,
   慢的时候等得起(上限 20s)。

2. **等进程那处不假装在等就绪**。
   🔴 我第一版写的是「等到 db 文件存在」—— 而那个文件在上一步 init 里就已经
   建好了,条件恒真,等于没等。**一个不是目标状态独有的等待条件,和没有等待
   是一回事,但读起来像有。** 现在这里只保留原断言的原意(子进程没有立刻崩):
   在 800ms 窗口内轮询「它是否退出了」,一退出就立刻停下,不睡满。

3. **给这条加显式 30s 超时**。它要起两个真进程,默认 5s 对它本来就不成立。
   前两处改完常态用不到这个上限;它只保证「慢」不会被报成「坏」。

`waitUntil` 到期时把**在等什么**写进异常消息 —— 定长 sleep 超时最坏的地方不是慢,
是红落在「事件没写」这条断言上,读的人会去查 watcher,而真实原因可能是 hub 还没起来。

为什么现在才暴露:这个文件**从来没进过 CI**,直到 #798 把 server/src 下 72 个
测试全接进去。

⚠️ 本地没跑:这条会 `bun run server/src/index.ts` 起一个真 hub,不在宿主机上跑。
仅做了转译检查(`bun build --external '*'` → Bundled 1 module,rc=0)。
**判据是 CI 里的 `server unit (Docker, non-root)`。**

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>