### PR TITLE
fix(ci): 数组解析被注释里的 `)` 截断 —— 一道门 exit 2,孪生的那道静默把 11 算成 7

### DIFF
--- a/.github/scripts/check-l1-paths-sync.py
+++ b/.github/scripts/check-l1-paths-sync.py
@@ -39,9 +39,32 @@ QA_SH = "scripts/qa.sh"
 QA_YML = ".github/workflows/qa.yml"
 
 
+def _strip_comments(text: str) -> str:
+    """去掉每行的 `#` 注释。
+
+    🔴 这不是洁癖,是一个**取集**缺陷的修复。下面的数组正则用 `[^)]*`,
+    它在遇到第一个 `)` 时停下 —— 而 bash 数组里**注释是合法的**,注释里出现
+    `)` 也是合法的:
+
+        L1_TESTS=(
+          # (注册这一步不是可选的 —— 一个没被调用的套件等于不存在。)
+          "test823-l1-concurrency-cap"
+          ...
+        )
+
+    正则在那个中文注释的 `)` 处截断,捕获到的内容里**一个套件名都没有**,
+    于是 `l1_suites()` 返回 [] —— 判据完全正确,取集塌了。
+
+    这次它 fail-closed(exit 2「parse regression」)所以被看见了。同一个洞
+    如果长在一个「没找到就当没有」的检查里,就是一片安静的假绿。
+    数组里的元素不会含 `#`(套件名是 kebab-case),所以按行剥注释是安全的。
+    """
+    return "\n".join(line.split("#", 1)[0] for line in text.split("\n"))
+
+
 def l1_suites(text: str) -> list[str]:
     """Suite names from qa.sh's L1_TESTS array."""
-    m = re.search(r"L1_TESTS=\(([^)]*)\)", text, re.S)
+    m = re.search(r"L1_TESTS=\(([^)]*)\)", _strip_comments(text), re.S)
     if not m:
         return []
     return re.findall(r'"([^"]+)"', m.group(1))
@@ -116,6 +139,18 @@ def selftest() -> int:
     }
     cases = [
         ("L1_TESTS parsed in full", l1_suites(sh) == ["qa-a", "test-b"]),
+        # 🔴 见 _strip_comments:数组里一条**含右括号的注释**会让 `[^)]*` 提前截断,
+        # 捕获内容里一个套件名都没有。这条夹具照着实际撞红的那次写(#835 往
+        # L1_TESTS 里加了一行「(注册这一步不是可选的 …)」)。
+        (
+            "注释里的 ) 不截断数组",
+            l1_suites('L1_TESTS=(\n  # (注册不是可选的)\n  "qa-a"\n  "test-b"\n)\n')
+            == ["qa-a", "test-b"],
+        ),
+        (
+            "数组后面别处的 ) 不影响",
+            l1_suites('L1_TESTS=(\n  "qa-a"\n)\nfoo() { :; }\n') == ["qa-a"],
+        ),
         ("missing array yields empty (→ exit 2 upstream)", l1_suites("no array here") == []),
         ("paths read from on.pull_request", len(pr_paths(yml)) == 3),
         ("bare `on:` parsed as True still works", len(pr_paths({True: yml["on"]})) == 3),

--- a/.github/scripts/check-qa-trigger-coverage.py
+++ b/.github/scripts/check-qa-trigger-coverage.py
@@ -31,9 +31,32 @@ TESTS_DIR = Path("tests")
 WORKFLOWS = Path(".github/workflows")
 
 
+def _strip_comments(text: str) -> str:
+    """去掉每行的 `#` 注释。
+
+    🔴 这不是洁癖,是一个**取集**缺陷的修复。下面的数组正则用 `[^)]*`,
+    它在遇到第一个 `)` 时停下 —— 而 bash 数组里**注释是合法的**,注释里出现
+    `)` 也是合法的:
+
+        L1_TESTS=(
+          # (注册这一步不是可选的 —— 一个没被调用的套件等于不存在。)
+          "test823-l1-concurrency-cap"
+          ...
+        )
+
+    正则在那个中文注释的 `)` 处截断,捕获到的内容里**一个套件名都没有**,
+    于是 `l1_suites()` 返回 [] —— 判据完全正确,取集塌了。
+
+    这次它 fail-closed(exit 2「parse regression」)所以被看见了。同一个洞
+    如果长在一个「没找到就当没有」的检查里,就是一片安静的假绿。
+    数组里的元素不会含 `#`(套件名是 kebab-case),所以按行剥注释是安全的。
+    """
+    return "\n".join(line.split("#", 1)[0] for line in text.split("\n"))
+
+
 def bash_array(text: str, name: str) -> list[str]:
     """Entries of a `NAME=( "a" "b" )` bash array, or [] when absent."""
-    m = re.search(rf"{name}=\(([^)]*)\)", text, re.S)
+    m = re.search(rf"{name}=\(([^)]*)\)", _strip_comments(text), re.S)
     return re.findall(r'"([^"]+)"', m.group(1)) if m else []
 
 


### PR DESCRIPTION
fix(ci): bash 数组解析器被注释里的 `)` 截断 —— 一道门 exit 2,它的孪生兄弟静默判绿

两个 checker 用同一个正则从 `scripts/qa.sh` 里取数组:

    re.search(rf"{name}=\(([^)]*)\)", text, re.S)

`[^)]*` 在**第一个** `)` 处停下。而 bash 数组里注释是合法的,注释里出现 `)`
也是合法的。#835 往 L1_TESTS 顶部加了一行:

    L1_TESTS=(
      # (注册这一步不是可选的 —— 一个没被任何东西调用的套件等于不存在。)
      "test823-l1-concurrency-cap"
      ...

正则在那个 `)` 处截断,捕获内容里**一个套件名都没有**。

🔴 **判据完全正确,塌的是取集。**

## 两道门吃同一个洞,表现完全不同 —— 这才是要紧的部分

把那行注释注入 `origin/main` 的 qa.sh,A/B 跑:

| checker | 未修复 | 修复后 |
|---|---|---|
| `check-l1-paths-sync.py` | **exit 2**「found no L1_TESTS entries — parse regression, refusing to pass」 | rc=0,17 个套件 |
| `check-qa-trigger-coverage.py` | **rc=0**,`CI-executed: 7` | rc=0,`CI-executed: 11` |

**第二个静默判绿,并且把 11 个套件悄悄算成了 7 个** —— 少的正是
test686 / test746 / test765 / test766(它们只出现在 L1_TESTS 里)。
它照常打印「all 7 CI-executed test directory/ies can re-trigger qa.yml」,
**一句真话,建立在一个塌掉的分母上。**

同一个 bug,一个 fail-closed 所以被看见,一个 fail-open 所以不会。
**看见它的那个救了另一个** —— 否则 trigger-coverage 会带着 7/11 的分母
一直绿下去,而它存在的全部意义就是那个分母。

## 修法

加 `_strip_comments()`:按行剥掉 `#` 之后的内容再匹配。数组元素是 kebab-case
的套件名,不含 `#`,按行剥是安全的。

## 见红

selftest 加两条夹具(照着实际撞红的那行写),然后把 `_strip_comments` 变成
恒等函数(`return text`)验证它们真的守着这件事:

    正常:  selftest: 10/10 ok                     rc=0
    变异:  FAIL 注释里的 ) 不截断数组  → 1 case(s) rc=1

另一条「数组后面别处的 `)` 不影响」用来钉住剥注释没有把范围放宽。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>