### PR TITLE
docs(security): 醒目标注 `latest`(0.8.8)的 /health 会向匿名调用方泄露在线 agent —— 修复已在仓里躺了 20 天

### DIFF
--- a/docs-site/docs/concepts/security.md
+++ b/docs-site/docs/concepts/security.md
@@ -40,6 +40,31 @@ graph TB
 网络绑定和 membership 由 Server 强制检查。`api_tokens.scope` 会被记录，但当前权限判定主要依赖 token 的用户/网络绑定与 `network_members`，不要把 `scope` 字符串单独当作授权证明。
 :::
 
+
+## 🔴 已知:`latest` 通道的 `/health` 会向匿名调用方泄露在线 agent
+
+::: danger 不要不带版本地跑 `bunx @sleep2agi/commhub-server`
+不带版本会解析到 npm 的 `latest` dist-tag,而 **`latest` 目前是 `0.8.8`(发布于 2026-06-24)**。
+
+`0.8.8` 的匿名 `GET /health` 会**返回每个活跃 SSE 连接的 `{networkId}:{alias}` 明细** ——
+不需要任何 token。脱敏修复是
+[`7bacb729`](https://github.com/sleep2agi/agent-network/commit/7bacb729)(`security(#473)`,**2026-07-29**),
+比 `0.8.8` 晚 **35 天**,所以 `0.8.8` 不含它。
+
+**改用固定版本或 preview 通道:**
+
+```bash
+bunx --bun @sleep2agi/commhub-server@preview      # 已含脱敏修复
+```
+
+或走受支持的路径 `anet hub start`(它按 `PINNED_SERVER_VERSION` 拉固定版本,不走 `latest`)。
+
+自查:`curl -sS http://<host>:9200/health | jq 'has("sse_sessions")'` —— 返回 `true` 就是受影响的版本。
+:::
+
+回归测试见 `server/src/health-redaction.test.ts`(在 main 上)。
+本节记录的是**发布通道**的状态,不是代码的状态 —— 代码里这个问题 2026-07-29 就修了。
+
 ## 认证（Authentication）
 
 ### Token 体系

--- a/docs-site/docs/deploy/npm.md
+++ b/docs-site/docs/deploy/npm.md
@@ -114,6 +114,25 @@ anet node start my-agent
 
 CommHub Server 通过独立包运行：
 
+::: danger 不要不带版本地跑 `bunx @sleep2agi/commhub-server`
+不带版本会解析到 npm 的 `latest` dist-tag,而 **`latest` 目前是 `0.8.8`(发布于 2026-06-24)**。
+
+`0.8.8` 的匿名 `GET /health` 会**返回每个活跃 SSE 连接的 `{networkId}:{alias}` 明细** ——
+不需要任何 token。脱敏修复是
+[`7bacb729`](https://github.com/sleep2agi/agent-network/commit/7bacb729)(`security(#473)`,**2026-07-29**),
+比 `0.8.8` 晚 **35 天**,所以 `0.8.8` 不含它。
+
+**改用固定版本或 preview 通道:**
+
+```bash
+bunx --bun @sleep2agi/commhub-server@preview      # 已含脱敏修复
+```
+
+或走受支持的路径 `anet hub start`(它按 `PINNED_SERVER_VERSION` 拉固定版本,不走 `latest`)。
+
+自查:`curl -sS http://<host>:9200/health | jq 'has("sse_sessions")'` —— 返回 `true` 就是受影响的版本。
+:::
+
 ```bash
 bunx @sleep2agi/commhub-server
 ```

--- a/docs-site/docs/en/concepts/security.md
+++ b/docs-site/docs/en/concepts/security.md
@@ -40,6 +40,30 @@ graph TB
 The server enforces network binding and membership. `api_tokens.scope` is recorded, but current authorization primarily relies on the token's user/network binding and `network_members`; do not treat the `scope` string alone as proof of permission.
 :::
 
+
+## 🔴 Known: the `latest` channel's `/health` discloses live agents to anonymous callers
+
+::: danger Do not run `bunx @sleep2agi/commhub-server` without a version
+Without a version this resolves to the npm `latest` dist-tag, and **`latest` is currently `0.8.8` (published 2026-06-24)**.
+
+On `0.8.8` an anonymous `GET /health` **returns the `{networkId}:{alias}` of every live SSE connection** — no token required.
+The redaction fix is [`7bacb729`](https://github.com/sleep2agi/agent-network/commit/7bacb729) (`security(#473)`, **2026-07-29**),
+**35 days after** `0.8.8` shipped, so `0.8.8` does not contain it.
+
+**Pin a version, or use the preview channel:**
+
+```bash
+bunx --bun @sleep2agi/commhub-server@preview      # contains the redaction fix
+```
+
+Or use the supported path, `anet hub start`, which pulls the version in `PINNED_SERVER_VERSION` rather than `latest`.
+
+Self-check: `curl -sS http://<host>:9200/health | jq 'has("sse_sessions")'` — `true` means you are on an affected build.
+:::
+
+The regression test lives at `server/src/health-redaction.test.ts` (on `main`).
+This section describes the state of a **release channel**, not of the code — the code was fixed on 2026-07-29.
+
 ## Authentication
 
 ### Token System

--- a/docs-site/docs/en/deploy/npm.md
+++ b/docs-site/docs/en/deploy/npm.md
@@ -114,6 +114,24 @@ anet node start my-agent
 
 CommHub Server runs from its standalone package:
 
+::: danger Do not run `bunx @sleep2agi/commhub-server` without a version
+Without a version this resolves to the npm `latest` dist-tag, and **`latest` is currently `0.8.8` (published 2026-06-24)**.
+
+On `0.8.8` an anonymous `GET /health` **returns the `{networkId}:{alias}` of every live SSE connection** — no token required.
+The redaction fix is [`7bacb729`](https://github.com/sleep2agi/agent-network/commit/7bacb729) (`security(#473)`, **2026-07-29**),
+**35 days after** `0.8.8` shipped, so `0.8.8` does not contain it.
+
+**Pin a version, or use the preview channel:**
+
+```bash
+bunx --bun @sleep2agi/commhub-server@preview      # contains the redaction fix
+```
+
+Or use the supported path, `anet hub start`, which pulls the version in `PINNED_SERVER_VERSION` rather than `latest`.
+
+Self-check: `curl -sS http://<host>:9200/health | jq 'has("sse_sessions")'` — `true` means you are on an affected build.
+:::
+
 ```bash
 bunx @sleep2agi/commhub-server
 ```

--- a/server/README.md
+++ b/server/README.md
@@ -11,6 +11,23 @@ The supported path is to install the `anet` CLI (`@sleep2agi/agent-network`) and
 
 ## Quick start (verified)
 
+> ⚠️ **Do not run `bunx @sleep2agi/commhub-server` without a version**
+> Without a version this resolves to the npm `latest` dist-tag, and **`latest` is currently `0.8.8` (published 2026-06-24)**.
+> 
+> On `0.8.8` an anonymous `GET /health` **returns the `{networkId}:{alias}` of every live SSE connection** — no token required.
+> The redaction fix is [`7bacb729`](https://github.com/sleep2agi/agent-network/commit/7bacb729) (`security(#473)`, **2026-07-29**),
+> **35 days after** `0.8.8` shipped, so `0.8.8` does not contain it.
+> 
+> **Pin a version, or use the preview channel:**
+> 
+> ```bash
+> bunx --bun @sleep2agi/commhub-server@preview      # contains the redaction fix
+> ```
+> 
+> Or use the supported path, `anet hub start`, which pulls the version in `PINNED_SERVER_VERSION` rather than `latest`.
+> 
+> Self-check: `curl -sS http://<host>:9200/health | jq 'has("sse_sessions")'` — `true` means you are on an affected build.
+
 ```bash
 # Recommended — through the anet CLI
 npm install -g @sleep2agi/agent-network


### PR DESCRIPTION
docs(security): 醒目标注 `latest` 通道的 /health 会向匿名调用方泄露在线 agent

## 事实(三条都是命令输出)

    $ git log -1 7bacb729
    7bacb729  2026-07-29  security(#473): /health 移除 SSE 会话键明细,明细移入需鉴权端点 (#482)

    $ registry.npmjs.org/@sleep2agi/commhub-server
      0.8.8 发布于 2026-06-24T08:45:24.610Z
      dist-tags: latest=0.8.8   preview=0.9.0-preview.29

    $ curl 本机在跑的 hub（0.9.0-preview.29）/health | jq keys
      …没有 sse_sessions,有 limits…

**脱敏修复落于 2026-07-29,而 `latest` 指向的 `0.8.8` 发布于 2026-06-24 —— 早 35 天。**
所以 `latest` 至今是一个**匿名 `GET /health` 会返回每个活跃 SSE 连接
`{networkId}:{alias}` 明细**的版本。回归测试 `server/src/health-redaction.test.ts` 在 main 上。

## 为什么这不是「文档小改」

仓里有 **6 处文档命令**教人 `bunx @sleep2agi/commhub-server` **不带版本** ——
不带版本就解析到 `latest` = `0.8.8`。也就是说**照着文档做,就会跑到受影响的版本上**。

    docs-site/docs/deploy/npm.md
    docs-site/docs/en/deploy/npm.md
    server/README.md              ×3
    docs-site/docs/{,en/}guide/architecture.md

本次在**三个最可能被读到的位置**加醒目告示(中英各一份 + npm 包 README):
`deploy/npm.md`、`concepts/security.md`、`server/README.md`。

告示里给了**可执行的替代**(`@preview`,或走 `anet hub start` 的 PIN 版)和
**一条自查命令**:

    curl -sS http://<host>:9200/health | jq 'has("sse_sessions")'   # true = 受影响

## 🔴 这个 PR 不解决问题,只是让它可见

真正的修法是把 `latest` 推到含修复的版本 —— **那需要发布权限,不在本 PR 范围内**。
本 PR 只做「在用户会读到的地方,把已知状态说出来」,这一步不需要任何发布权限。
`concepts/security.md` 里那一段特意写明:**这一节描述的是发布通道的状态,不是代码的状态
—— 代码 2026-07-29 就修了。**

合并前跑过:check-docs-integrity / check-doc-symbol-anchors /
check-doc-source-pins / check-no-memory-slugs 全部 OK。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>