### PR TITLE
ci(privacy): slug 门**扫 .sh 却不被 .sh 触发**(999/2032 个文件改动叫不醒它);两道隐私门去掉 paths

### DIFF
--- a/.github/workflows/no-memory-slugs.yml
+++ b/.github/workflows/no-memory-slugs.yml
@@ -15,39 +15,22 @@
 name: lint (no internal memory-slug leak)
 
 on:
+  # 🔴 刻意不加 paths 过滤。原来这里列了 12 条(`**/*.ts` `**/*.md` `**/*.yml` …),
+  # 而**脚本自己扫的后缀集合里还有 `.sh` 和 `.py`** —— 它们不在触发列表里。
+  # 实测这个缺口的大小:仓里 2032 个跟踪文件中,**改动它不会触发这道门**的有 999 个,
+  # 其中 `.sh` 288 个、`.py` 22 个 —— 而这两类**正是脚本会扫的**。
+  #
+  # 也就是说:一个只改 .sh 的 PR 里,内部记忆 slug 可以直接进公开仓,
+  # 而这道门**不是判错,是压根不会被触发**。
+  #
+  # 去掉过滤同时解决第二件事:带 paths 的 workflow 在不匹配的 PR 上不产生 check-run,
+  # 于是**永远做不了 required check**(会卡在 Expected — Waiting for status)。
+  # 这是一道隐私门,应当能进 required。
+  #
+  # 代价实测:main 上最近三次运行 11s / 10s / 14s。
   pull_request:
-    paths:
-      - '**/*.ts'
-      - '**/*.tsx'
-      - '**/*.js'
-      - '**/*.jsx'
-      - '**/*.mjs'
-      - '**/*.cjs'
-      - '**/*.md'
-      - '**/*.yml'
-      - '**/*.yaml'
-      - '.github/scripts/check-no-memory-slugs.py'
-      - '.github/workflows/no-memory-slugs.yml'
-      - '.github/scripts/requirements-workflow-structure.txt'
   push:
     branches: [main]
-    paths:
-      - '**/*.ts'
-      - '**/*.tsx'
-      - '**/*.js'
-      - '**/*.jsx'
-      - '**/*.mjs'
-      - '**/*.cjs'
-      - '**/*.md'
-      - '**/*.yml'
-      - '**/*.yaml'
-      - '.github/scripts/check-no-memory-slugs.py'
-      - '.github/workflows/no-memory-slugs.yml'
-      - '.github/scripts/requirements-workflow-structure.txt'
-
-concurrency:
-  group: lint-slugs-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   no-memory-slugs:

--- a/.github/workflows/public-script-safety.yml
+++ b/.github/workflows/public-script-safety.yml
@@ -13,17 +13,15 @@
 name: lint (public script safety)
 
 on:
+  # 🔴 同样刻意不加 paths。原来只在 `docs-site/docs/public/**` 变化时触发 ——
+  # 而这道门要防的是「公开仓里出现危险脚本」,**危险脚本不会只出现在那一个目录**。
+  # 去掉过滤后它对每个 PR 都跑,也才具备做 required check 的资格
+  # (带 paths 的 workflow 在不匹配的 PR 上不产生 check-run,会永远挂在 Expected)。
+  #
+  # 代价实测:main 上最近三次运行 11s / 13s / 9s。
   pull_request:
-    paths:
-      - 'docs-site/docs/public/**'
-      - '.github/scripts/check-public-script-safety.py'
-      - '.github/workflows/public-script-safety.yml'
   push:
     branches: [main]
-    paths:
-      - 'docs-site/docs/public/**'
-      - '.github/scripts/check-public-script-safety.py'
-      - '.github/workflows/public-script-safety.yml'
 
 jobs:
   scan:


### PR DESCRIPTION
ci(privacy): 两道隐私门去掉 paths 过滤 —— 其中一道**扫 .sh 却不被 .sh 触发**

## 🔴 `no-memory-slugs` 有一个可量化的缺口:扫描范围 ⊄ 触发范围

脚本扫的后缀集合(`check-no-memory-slugs.py:49`)包含 **`.sh` 和 `.py`**:

    EXTENSIONS = {".ts",".tsx",".js",".jsx",".mjs",".cjs",".md",".yml",".yaml",".sh",".py"}

而 workflow 的 `paths:` 列表**没有** `**/*.sh`、也没有 `**/*.py`。

⇒ **一个只改 `.sh` 的 PR,内部记忆 slug 可以直接进公开仓 —— 这道门不是判错,是压根不会被触发。**

缺口大小实测:

    仓内跟踪文件 2032,其中「改动它不会触发这道门」的有 999
       .sh    288      ← 脚本会扫
       .py     22      ← 脚本会扫
       .txt   237 / (无后缀) 252 / .json 53 …（这些脚本本来也不扫,不构成缺口)

## 见红:缺口的两半各自证明

**半一 —— 脚本确实会扫 `.sh`**(往 `scripts/leak-demo.sh` 里放一个内部 slug):

    FAIL: found 1 internal memory-slug reference(s)
      scripts/leak-demo.sh:2: [[feedback_…]]
    rc=1

**半二 —— 旧的 paths 不会因为这个文件触发**:

    fnmatch('scripts/leak-demo.sh', 旧 paths) → False
    fnmatch('agent-node/x.py',      旧 paths) → False

**两半合起来:门有能力抓到它,但永远不会被叫醒去抓。**

## 顺带解决第二件:带 paths 的 workflow **永远做不了 required check**

不匹配的 PR 上它不产生 check-run,GitHub 会永远显示 `Expected — Waiting for status`,
把那个 PR 卡死。所以 main 的 7 道 required 里进不去这两道 —— 而它们是**隐私/安全**门。

去掉 paths 之后两件事一起解决:**不再有触发缺口,且具备做 required 的资格。**

`public-script-safety` 同理:它原来只在 `docs-site/docs/public/**` 变化时触发,
而「公开仓里出现危险脚本」这件事**不会只发生在那一个目录**。

## 代价

main 上最近三次运行:

    no-memory-slugs        11s / 10s / 14s
    public-script-safety   11s / 13s / 9s

**每个 PR 多约 25 秒 runner 时间。** 若 CI 额度紧张需要回退,把 `paths:` 加回去即可 ——
但请连同上面那个 999/2032 的缺口一起权衡。

`check-workflow-structure` 通过;两个脚本在干净树上都是 OK。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>