### PR TITLE
fix(privacy): slug 门只认下划线,连字符整类漏过 —— 而记忆条目的 name: 就是连字符;修完当场抓到 2 条真泄漏

### DIFF
--- a/.github/scripts/check-no-memory-slugs.py
+++ b/.github/scripts/check-no-memory-slugs.py
@@ -37,12 +37,24 @@ import re
 import sys
 from pathlib import Path
 
-# `\[\[(feedback|project|reference|user)_[a-z0-9_-]+\]\]`
+# `\[\[(feedback|project|reference|user)[_-][a-z0-9_-]+\]\]`
 # - leading `\[\[` to require the memory-link shape (not arbitrary `[x]`)
 # - one of the four category prefixes (the agent memory types)
-# - underscore separator + slug body (kebab/snake/digit chars)
+# - 分隔符是 `[_-]`,**两种都收** —— 见下
 # - closing `\]\]`
-SLUG_RE = re.compile(r"\[\[(feedback|project|reference|user)_[a-z0-9_-]+(?:\.md)?\]\]")
+#
+# 🔴 2026-08-18:分隔符原来只写了 `_`,于是**连字符形式整类漏过**:
+#
+#     [[feedback_kebab_probe_underscore]]   → 拦住   rc=1
+#     [[feedback-kebab-probe-hyphen]]       → **放行** rc=0
+#
+#   (用真脚本实测的,不是读正则读出来的。)
+#
+#   而这不是一个边缘写法 —— **记忆条目自己的 `name:` 字段用的就是连字符形式**
+#   (`name: feedback-a-bug-plus-a-lucky-fact-looks-exactly-like-correct`)。
+#   也就是说:**最自然的引用方式(把 name: 的值抄进 [[ ]])恰好是这道门看不见的那一种。**
+#   一道隐私门,漏的正是最可能出现的写法。
+SLUG_RE = re.compile(r"\[\[(feedback|project|reference|user)[_-][a-z0-9_-]+(?:\.md)?\]\]")
 
 # .sh / .py 同样是公开仓里可见的文件,此前不在覆盖内 —— 实测 2026-08-13,
 # 三处真 slug 就藏在 tests/ 下的 shell 脚本里,门扫 898 个文件却看不见它们。

--- a/docs/demos/pr-review-room-proposal.md
+++ b/docs/demos/pr-review-room-proposal.md
@@ -7,7 +7,7 @@
 > **Changelog：**
 > - v1：初版 5 agent + docker-compose 草案
 > - v2：通信龙 review 通过 — 砍 dispatcher agent / 切 CLI 模式 / 清理流程对齐 debate
-> - **v3：通信龙 pivot ack — 加 §UX 反馈 (在控感) + §测试规格（Vincent 2026-05-12 定调 "用户能掌控多 agent + 充分测试"，refs [[feedback-demo-quality-over-count]]）**
+> - **v3：通信龙 pivot ack — 加 §UX 反馈 (在控感) + §测试规格（Vincent 2026-05-12 定调 "用户能掌控多 agent + 充分测试"——即「宁可少做几个、每个都做扎实」,不以数量论）**
 
 ## 一句话定位
 

--- a/docs/demos/standup-room-proposal.md
+++ b/docs/demos/standup-room-proposal.md
@@ -7,7 +7,7 @@
 > **Changelog：**
 > - v1：初版 5 agent 草案
 > - v2：通信龙 review 通过 — 3 review 问题答（参数化 reporter / 砍 probe / b+a 输出）+ 关键设计 ack
-> - **v3：通信龙 pivot ack — 加 §UX 反馈 (在控感) + §测试规格（Vincent 2026-05-12 定调 "用户能掌控多 agent + 充分测试"，refs [[feedback-demo-quality-over-count]]）**
+> - **v3：通信龙 pivot ack — 加 §UX 反馈 (在控感) + §测试规格（Vincent 2026-05-12 定调 "用户能掌控多 agent + 充分测试"——即「宁可少做几个、每个都做扎实」,不以数量论）**
 >
 > Backlog：refs [#25](https://github.com/sleep2agi/agent-network/issues/25) demo backlog 第 2 项（通信龙 选择优先级 #2，PASS 「AI 新闻编辑室」因模式与 translation-pipeline 重合）
 


### PR DESCRIPTION
fix(privacy): slug 门只认下划线,漏掉整类连字符写法 —— 而记忆条目的 name: 就是连字符

## 缺陷

    SLUG_RE = re.compile(r"\[\[(feedback|project|reference|user)_[a-z0-9_-]+…\]\]")
                                                              ↑ 只有 `_`

用**真脚本**实测(不是读正则读出来的):

    [[feedback_kebab_probe_underscore]]   → 拦住   rc=1
    [[feedback-kebab-probe-hyphen]]       → **放行** rc=0

🔴 而这不是一个边缘写法 —— **记忆条目自己的 `name:` 字段用的就是连字符形式**:

    name: feedback-a-bug-plus-a-lucky-fact-looks-exactly-like-correct

**最自然的引用方式(把 `name:` 的值抄进 `[[ ]]`)恰好是这道门看不见的那一种。**
一道隐私门,漏的正是最可能出现的写法。

## 修完立刻在 main 上抓到两条**真泄漏**

    docs/demos/standup-room-proposal.md:10   [[feedback-demo-quality-over-count]]
    docs/demos/pr-review-room-proposal.md:10 同上

我核过这两条**不在** `ALLOWLIST_PATH_PREFIXES` 覆盖的五棵树里
(`docs/sop/` `docs/rfcs/` `docs/research/` `docs/troubleshooting/` `docs/tests/`)——
也就是说它们**本来就在这道门的强制范围内,只是因为分隔符而看不见**。
(那 5 棵树里另有 ~57 条是**已知并有意延后**的历史引用,不在本次范围。)

按门自己给的处置方式改写:去掉 `[[slug]]` 形式,把意图直接写出来 ——
`refs [[feedback-demo-quality-over-count]]` → `即「宁可少做几个、每个都做扎实」,不以数量论`。

## 验

    分隔符 `_` 的探针  → rc=1（仍然拦)
    分隔符 `-` 的探针  → rc=1（现在也拦)
    干净树             → rc=0，"no internal memory-slug references found"

**误报回归**:改完在全仓 1230 个在扫描范围内的文件上重跑,rc=0 —— 新正则没有误伤任何现存内容。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>