### PR TITLE
docs(rfc-022): 把「现有入口」那一行里的 Vercel 地址标掉 (#829)

### DIFF
--- a/docs/rfcs/RFC-022-agent-network-client-app.md
+++ b/docs/rfcs/RFC-022-agent-network-client-app.md
@@ -37,7 +37,16 @@
 > "在外面用手机给通信工程马派任务,看他干完了没;晚上回家用电脑接着看他干。" (Vincent 7010 telegram)
 
 现有 anet 用户端入口:
-- **dashboard** (`agent-network-dashboard.vercel.app`) — Next.js, 公开只读 + 管理员私有, 但**没有 chat UI**, 只 list + observability
+- **dashboard** — Next.js, 公开只读 + 管理员私有, 但**没有 chat UI**, 只 list + observability
+
+  > 🔴 **本行原来把 `agent-network-dashboard.vercel.app` 写成了这个入口的地址,那是错的(#829)。**
+  > 项目自营的生产 Dashboard 是**自托管**的(`Caddy :3000 / frpc :3100 → 127.0.0.1:3001`,
+  > pm2 托管),拓扑见 `deploy/dashboard/README.md`;仓库政策不写死真实域名。
+  > `agent-network-dashboard.vercel.app` **不是它**,也不是任何面向外部用户的 SaaS 入口 ——
+  > 判断线上状态时不要用它。判断方法见 `CLAUDE.md`「项目信息 → Dashboard:分三种,别混」。
+  >
+  > (下文 §「生产域名建议」和「待定问题」里仍然提到这个域名 —— **那两处是提案,不是现状陈述**,
+  > 保留原样。这条告示只改这一处:**它当时是在描述"现有入口"**。)
 - **MCP tools** (`commhub_send_task` 等) — 走 Claude Code / codex MCP server 配置, **要装 CLI 才能用**
 - **CLI** (`anet send`) — 同上, 要装
 - **IM 接入**(RFC-020 飞书/WhatsApp/企微/Slack) — 走第三方 IM, 用户**必须先有该 IM 账号 + bot 安装**


### PR DESCRIPTION
## 背景

#829 说 `CLAUDE.md` 把 `agent-network-dashboard.vercel.app` 当成项目 Dashboard 的地址。**那一半已经在 `main` 上修完了** —— 现在是「Dashboard:**分三种,别混**」外加三条实际的判断命令(`pm2 jlist` 看 status、Caddy admin 查实际路由、直连 `:3001` 绕开入口层),并且已经写明「`Age` 是缓存年龄,不等于部署年龄」。

**剩下的一半在 RFC-022。** 它有 3 处提到这个域名,但**这 3 处的性质不一样**。

## 只改 1 处,另外 2 处刻意不改

| 行 | 上下文 | 改不改 | 为什么 |
|---|---|---|---|
| `:40` | 标题「**现有** anet 用户端入口」下面 | ✅ **改** | 这是**现状陈述** —— 它断言那个域名就是 dashboard 的地址,而实际生产 Dashboard 是自托管的 |
| `:240` | §生产域名建议 | ❌ 不改 | **提案**:讨论的正是「新域名 vs 复用这个」 |
| `:264` | §待定问题 | ❌ 不改 | **提案**:同上,是一个待拍板的选项 |

🔴 **提案引用一个候选域名没有错;把它写成现状才有错。** 判据只对「说明 / 现状陈述」成立,对「记录和提案」不成立 —— 一刀切地把 3 处都改掉,会把一个还没拍板的技术选项从文档里抹掉。

## 改法

在 `:40` 那行原地留一段告示,说清三件事:它不是什么、真的是什么(自托管拓扑 + `deploy/dashboard/README.md`)、去哪儿看判断方法(`CLAUDE.md`)。并**在告示里点明下文那两处是提案、保留原样**,免得下一个人来"顺手清干净"。

## 本地核验

退出码不经管道取:

```
check-doc-symbol-anchors.py --selftest   rc=0
check-doc-symbol-anchors.py              rc=0
check-no-memory-slugs.py                 rc=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
