### PR TITLE
test(qa): 把 qa-hub-10..13 补进 L1_TESTS (#861)

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -72,6 +72,24 @@ L1_TESTS=(
   "qa-hub-07-sse-reconnect"
   "qa-hub-08-restart-persistence"
   "qa-hub-09-task-state-machine"
+  # 2026-08-18 补注册 —— 这四个是 #863 修好的那批(commit 61f7203a,「静默失效 6 周」
+  # 实跑 4/4 从红到绿),但修完之后**没有注册到任何地方**,于是回到了同一个位置:
+  # 没有任何东西会跑它们。#861 的实测把最后一个未知量补上了。
+  #
+  # 实测(通信IM马,隔离 tree,顺序 build+run):
+  #   warm cache   10:7+6  11:1+3  12:1+4  13:7+6   合计 35s
+  #   🔴 warm 是误导 —— 四个共享 node:20-slim + apt + bun.sh + `bun install server/`
+  #      的层。单独用 --no-cache 测 qa-hub-10 是 **22s**(比 warm 的 7s 多 15s)。
+  #      CI 冷跑的形状是「第一个 ~22s,后 3 个各 1-7s,4 个 run 合计 19s」⇒ 约 44-50s。
+  #   L0+L1 job 近 4 次 main 实测 137-165s / 预算 300s ⇒ 加完约 181-215s,余 85-119s。
+  #
+  # 依赖:这四个**不需要活 hub、不需要外网、不需要凭据**。每个 run.sh 自己在
+  # loopback 上起 hub(端口 9210/9211/9212/9213 写死互不撞),跑完 trap kill 掉自己的
+  # HUB_PID。run 阶段完全离网;build 阶段要外网(bun.sh + apt),与既有套件同形。
+  "qa-hub-10-network-scope-regressions"
+  "qa-hub-11-node-delete-sse"
+  "qa-hub-12-servers-endpoint"
+  "qa-hub-13-server-health-agents"
   "qa-node-02-success-reply"
   "qa-node-03b-task-events"
   "test686-rest-shape-golden"


### PR DESCRIPTION
## 这四个套件今天早上刚被修好,然后回到了原位

`61f7203a`（#863,今天 05:54)标题是「修四个静默失效 6 周的 e2e 套件 —— 实跑 4/4 从红到绿」。修完之后**它们没有被注册到任何地方**:

```
qa-hub-10-network-scope-regressions   qa.sh=0  workflow=0
qa-hub-11-node-delete-sse             qa.sh=0  workflow=0
qa-hub-12-servers-endpoint            qa.sh=0  workflow=0
qa-hub-13-server-health-agents        qa.sh=0  workflow=0
```

而它们的兄弟 `qa-hub-05` … `qa-hub-09` **就在 `L1_TESTS` 里**。`qa.sh` 里那行注释说得准:**「一个没被任何东西调用的套件等于不存在。」**

## 挡住这一步的一直是一个未知量:塞不塞得下

`L0 + L1` job 预算 **300s**,近 4 次 `main` 实测 **165 / 137 / 157 / 150s**,余量只有 **135–163s**,而 `qa.sh` 的 build 是**串行**的。当初 test224/597/679 就是因为这个被挡在 L1 外面、改走独立 job。

**实测补上了这个数**（通信IM马,隔离 tree,`git archive origin/main` @ `5785d949`,顺序计时）:

```
套件                                   build_s  run_s  结果
qa-hub-10-network-scope-regressions       7       6    pass
qa-hub-11-node-delete-sse                 1       3    pass
qa-hub-12-servers-endpoint                1       4    pass
qa-hub-13-server-health-agents            7       6    pass
                             warm 合计 = 35 s
```

🔴 **warm 的 35s 是误导,测的人自己指出来了**:四个共享 `node:20-slim` + apt + `bun.sh` + `bun install server/` 的层,只有 13 的 `bc` apt 层不同。单独 `--no-cache` 测 `qa-hub-10` 是 **22s**（warm 是 7s,差 15s)。

按冷跑形状估:第一个 ~22s、后三个各 1–7s、四个 run 合计 19s ⇒ **约 44–50s 增量**,加完约 **181–215s**,余 **85–119s**。

## 依赖答复(这条比秒数更重要)

**这四个不需要活 hub、不需要外网、不需要凭据。** 每个 `run.sh` 自己在 loopback 起 hub（端口 `9210/9211/9212/9213` 写死互不撞),`curl 127.0.0.1:$HUB_PORT/api/auth/register` 本地建用户,跑完 `trap` kill 掉自己的 `HUB_PID`。**run 阶段完全离网**;build 阶段要外网(bun.sh + apt),与既有 L1 套件同形。

## 不需要动 workflow

`qa.yml` 的 paths 已有 `tests/qa-*/**`。逐条 `fnmatch` 验过,四个都能被触发 —— 所以这次**没有** #860 那个「注册了但触发不到」的坑。

## 本地核验(退出码不经管道取)

```
check-l1-paths-sync.py         rc=0   checked 22 L1 suite(s) against 28 path pattern(s); every L1 suite has a matching trigger
check-qa-trigger-coverage.py   rc=0
check-workflow-structure.py    rc=0
check-doc-symbol-anchors.py    rc=0
check-no-memory-slugs.py       rc=0
check-public-script-safety.py  rc=0
```

## 🔴 这个 PR 自己会验它自己 —— 合之前我看这一格

上面的 **44–50s 是估算**,不是实测的 CI 数字:它由「一次 `--no-cache` 单套件测量」外推而来。**本 PR 的 `L0 + L1` job 跑出来的时长就是真值。**

判据写死:**若本 PR 的 L0+L1 > 240s(预算的 80%),不合,改走独立 job。**

## 顺带一个观察(不在本 PR 范围)

测的人提了一句值得记下来:这四个跑起来这么便宜(run 阶段 3–6s、完全离网、自起 loopback hub),那 `tests/` 下另外 164 个是同类还是重量级?**如果多数是同类,L1 现在这份白名单反而是过度保守的。** 这属于 #861 说的「需要一次分类」,不在本 PR 解决。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
