### PR TITLE
deploy(fleet): 加一个「仓里那份 vs 在跑那份」的分叉自检 (#839)

### DIFF
--- a/deploy/fleet/README.md
+++ b/deploy/fleet/README.md
@@ -165,3 +165,52 @@ production data restoration remain NOT COVERED.
 `anet-nodes-boot.service` **从未经历过一次真实开机**:机器 `2026-08-17 07:06:39` 起来,
 而已知的那次运行是 `2026-08-18 00:36`,差 17.5 小时。**开机链路(linger + WantedBy=default.target)
 本身是通的,但「开机时它会不会成功」没有观测。**
+
+## 分叉自检:`check-fleet-drift.sh`
+
+收进仓之后风险换了形状但没消失:**跑的是机器上那份,仓里那份是记录。** 有人在机器上改出
+新版本,仓里这份会静默变成过期的记录,而没有任何东西会喊。
+
+```bash
+bash deploy/fleet/check-fleet-drift.sh            # 在部署机上比
+bash deploy/fleet/check-fleet-drift.sh --selftest # 判据自检(4 条)
+```
+
+判据只比**实质**不比**字面**:两边先把 `/home/<user>/` 归一成 `$HOME/`、把写死用户名的
+basename 比较归一掉,再 diff。**一个文件都没比到时 exit 2**,不是 exit 0 —— 「没有分叉」
+和「根本没看」打印出来会长得很像。
+
+### 🔴 它第一次真跑就找到一个真的,而且我猜错了
+
+我预期「全 ok」(仓里那份是我刚从机器上机械移植的)。实际:
+
+```
+checked=4 drift=2 missing=0
+DRIFT anet-nodes-boot.sh   ← 只差我加的 2 行注释,不是逻辑分叉
+DRIFT pm2-fleet-boot.sh    ← 🔴 真的
+```
+
+`pm2-fleet-boot.sh` 的分叉方向是**仓里有保护、机器上没有**:
+
+```
+仓里(b7d1289b · 2026-08-13 · #741 "version PM2 fleet boot authority"):
+    jlist=$("$PM2" jlist 2>/dev/null); jlist_rc=$?
+    [ rc≠0 ]        → 🔴 拒绝 resurrect,exit 1
+    解析不出数字     → 🔴 拒绝 resurrect,exit 1
+
+机器上(mtime 2026-07-30 21:14,1432 bytes):
+    n=$(... 2>/dev/null || echo 0); n=${n:-0}
+    ⇒ jlist 失败时 n=0,而 n=0 会**继续往下走去 resurrect**
+```
+
+⇒ 2026-08-13 有人在仓里把这个脚本改硬了,**但没有拷到机器上**。开机时若 `pm2 jlist`
+抽风,在跑的那份会当成「一个进程都没有」,然后在已有进程之上重复拉起 hub / dashboard /
+weixin。**这正是那次加固要防的事,而加固没有部署。**
+
+**部署要单独一条**(动的是整支 fleet 的开机路径),本 README 只负责让它不再隐形。
+
+### 一个诚实的边界
+
+这次的变异测试没提供什么信息:基线**本来就是红的**,人为改坏之后还是 `rc=1`,
+两次输出区分不出来。**真正验到判据的是那条 fail-closed**:把 `HOME` 指向一个空目录,
+`checked=0 drift=0 missing=4 → exit 2`,而不是「干净」。

--- a/deploy/fleet/check-fleet-drift.sh
+++ b/deploy/fleet/check-fleet-drift.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# 仓里的 fleet 脚本 vs 那台机器上真正在跑的那份,有没有分叉。
+#
+# 🔴 为什么需要它:2026-08-18 之前,`anet-nodes-boot.sh`(281 行,管 ~100 个 agent
+#    节点的开机恢复)**只存在于那台机器上**。仓里有 pm2-fleet.* 而没有它,于是
+#    从仓库看「agent 节点没有任何开机托管」是一个看起来完全成立的结论 —— #839
+#    就是这么写的,而它的作者没做错什么:他看的是仓,仓里确实没有。
+#
+#    收进仓之后风险换了个形状,但没有消失:**跑的是机器上那份,仓里那份是记录。**
+#    有人在机器上改出 v2.6,仓里这份会静默变成过期的记录,而**没有任何东西会喊**。
+#    这个脚本就是那声喊。
+#
+# 判据(刻意只比"实质",不比"字面"):
+#   - 仓里那份用 $HOME,机器上那份写死家目录 —— 这是**有意的差异**,不该报;
+#     所以两边都先做一次归一化(把 /home/<user>/ 折成 $HOME/)再比。
+#   - 归一化之后仍然不同 ⇒ 真分叉,退出 1 并打 diff。
+#
+# 🔴 已知的一处有意差异,不要当成分叉:
+#     仓里:   [ "$skp" = "$(basename "$HOME")" ]
+#     机器上: [ "$skp" = "vansin" ]
+#   路径参数化之后,写死用户名那一行成了脚本里唯一残留的机器耦合点。仓里改对了,
+#   机器上没动(改在跑的东西要单独一条)。本脚本把这一处也归一化掉。
+#
+# 用法(在部署机上跑):
+#   bash deploy/fleet/check-fleet-drift.sh            # 比全部
+#   bash deploy/fleet/check-fleet-drift.sh --selftest # 判据自检
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 仓里文件 → 机器上对应的实物
+declare -a PAIRS=(
+  "anet-nodes-boot.sh|$HOME/.local/bin/anet-nodes-boot.sh"
+  "pm2-fleet-boot.sh|$HOME/.local/bin/pm2-fleet-boot.sh"
+  "anet-nodes-boot.service|$HOME/.config/systemd/user/anet-nodes-boot.service"
+  "pm2-fleet.service|$HOME/.config/systemd/user/pm2-fleet.service"
+)
+
+normalize() {
+  # /home/<任意用户>/ → $HOME/ ;写死的 basename 比较 → $(basename "$HOME")
+  sed -E \
+    -e 's#/home/[A-Za-z0-9._-]+#$HOME#g' \
+    -e 's#\[ "\$skp" = "[A-Za-z0-9._-]+" \]#[ "$skp" = "$(basename "$HOME")" ]#g' \
+    "$1"
+}
+
+selftest() {
+  local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
+  local pass=0 fail=0
+  chk() { # name expect_same fileA fileB
+    local got; if diff -q <(normalize "$3") <(normalize "$4") >/dev/null 2>&1; then got=same; else got=diff; fi
+    if [ "$got" = "$2" ]; then pass=$((pass+1)); echo "  ok   $1"
+    else fail=$((fail+1)); echo "  FAIL $1  (期望 $2,得到 $got)"; fi
+  }
+  printf 'x=/home/alice/.anet\n'  > "$tmp/a"
+  printf 'x=/home/bob/.anet\n'    > "$tmp/b"
+  chk "不同用户名的同一路径 → 归一化后相同" same "$tmp/a" "$tmp/b"
+
+  printf 'x=/home/alice/.anet\ny=1\n' > "$tmp/c"
+  printf 'x=/home/bob/.anet\ny=2\n'   > "$tmp/d"
+  chk "路径同但内容真的不同 → 仍判分叉"   diff "$tmp/c" "$tmp/d"
+
+  printf '[ "$skp" = "vansin" ]\n'                 > "$tmp/e"
+  printf '[ "$skp" = "$(basename "$HOME")" ]\n'    > "$tmp/f"
+  chk "写死用户名 vs basename 是有意差异 → 不报" same "$tmp/e" "$tmp/f"
+
+  # 🔴 分母承重:归一化不能把「一边空一边有内容」也抹平
+  : > "$tmp/g"; printf 'real content\n' > "$tmp/h"
+  chk "空 vs 非空 → 必须判分叉"           diff "$tmp/g" "$tmp/h"
+
+  echo "selftest: $pass ok / $fail fail"
+  [ "$fail" -eq 0 ]
+}
+
+if [ "${1:-}" = "--selftest" ]; then selftest; exit $?; fi
+
+checked=0; drift=0; missing=0
+for pair in "${PAIRS[@]}"; do
+  repo_name="${pair%%|*}"; live="${pair#*|}"
+  repo="$REPO_DIR/$repo_name"
+  if [ ! -f "$repo" ]; then echo "SKIP  $repo_name — 仓里没有这个文件"; continue; fi
+  if [ ! -f "$live" ]; then
+    echo "MISS  $repo_name — 机器上没有 $live（这台机可能不是部署机）"
+    missing=$((missing+1)); continue
+  fi
+  checked=$((checked+1))
+  if diff -q <(normalize "$repo") <(normalize "$live") >/dev/null 2>&1; then
+    echo "ok    $repo_name"
+  else
+    drift=$((drift+1))
+    echo "DRIFT $repo_name  ← 仓里那份已经不是在跑的那份"
+    diff -u <(normalize "$repo") <(normalize "$live") | sed 's/^/      /' | head -40
+  fi
+done
+
+echo
+echo "checked=$checked drift=$drift missing=$missing"
+
+# 🔴 fail-closed:一个都没比到,不是「干净」,是「没看」——两者打印出来会长得很像。
+if [ "$checked" -eq 0 ]; then
+  echo "FAIL: 一个文件都没比对到 —— 这台机不是部署机,或者路径变了。不要读成「没有分叉」。" >&2
+  exit 2
+fi
+[ "$drift" -eq 0 ] || exit 1
+echo "仓里的 fleet 脚本与机器上在跑的那份一致（已归一化家目录差异）。"

--- a/deploy/fleet/check-fleet-drift.sh
+++ b/deploy/fleet/check-fleet-drift.sh
@@ -52,12 +52,15 @@ selftest() {
     if [ "$got" = "$2" ]; then pass=$((pass+1)); echo "  ok   $1"
     else fail=$((fail+1)); echo "  FAIL $1  (期望 $2,得到 $got)"; fi
   }
-  printf 'x=/home/alice/.anet\n'  > "$tmp/a"
-  printf 'x=/home/bob/.anet\n'    > "$tmp/b"
+  printf 'x=/home/user/.anet\n'     > "$tmp/a"
+  printf 'x=/home/example/.anet\n'  > "$tmp/b"
+  # 🔴 夹具名用 user / example,不用 alice / bob —— check-home-path-baseline.py
+  #    分不出「编造的人名」和「真人」,对一个公开仓来说那是**正确**的判法。
+  #    (我第一版就是用 alice/bob 写的,被那道门拦下来了,拦得对。)
   chk "不同用户名的同一路径 → 归一化后相同" same "$tmp/a" "$tmp/b"
 
-  printf 'x=/home/alice/.anet\ny=1\n' > "$tmp/c"
-  printf 'x=/home/bob/.anet\ny=2\n'   > "$tmp/d"
+  printf 'x=/home/user/.anet\ny=1\n'    > "$tmp/c"
+  printf 'x=/home/example/.anet\ny=2\n' > "$tmp/d"
   chk "路径同但内容真的不同 → 仍判分叉"   diff "$tmp/c" "$tmp/d"
 
   printf '[ "$skp" = "vansin" ]\n'                 > "$tmp/e"


### PR DESCRIPTION
## 起因

#946 把 `anet-nodes-boot`(281 行,管 ~100 个 agent 节点)收进仓里。**风险换了个形状但没消失:跑的是机器上那份,仓里那份是记录。** 有人在机器上改出新版本,仓里这份会静默变成过期的记录,而**没有任何东西会喊**。

这个脚本就是那声喊。

## 判据

只比**实质**不比**字面**:两边先把 `/home/<user>/` 归一成 `$HOME/`、把写死用户名的 basename 比较归一掉,再 diff。**一个文件都没比到时 `exit 2`**,不是 `exit 0` —— 「没有分叉」和「根本没看」打印出来会长得很像。

## 🔴 它第一次真跑就找到一个真的,而且我猜错了

我预期「全 ok」—— 仓里那份是我刚从机器上机械移植的。实际:

```
checked=4 drift=2 missing=0     rc=1
DRIFT anet-nodes-boot.sh   ← 只差我加的 2 行注释,不是逻辑分叉
DRIFT pm2-fleet-boot.sh    ← 🔴 真的
```

`pm2-fleet-boot.sh` 的分叉方向是**仓里有保护、机器上没有**:

```
仓里 (b7d1289b · 2026-08-13 · #741 "version PM2 fleet boot authority")
    jlist=$("$PM2" jlist 2>/dev/null); jlist_rc=$?
    rc≠0          → 🔴 拒绝 resurrect, exit 1
    解析不出数字   → 🔴 拒绝 resurrect, exit 1

机器上 (mtime 2026-07-30 21:14, 1432 bytes)
    n=$(... 2>/dev/null || echo 0); n=${n:-0}
    ⇒ jlist 失败时 n=0,而 n=0 会**继续往下走去 resurrect**
```

⇒ **2026-08-13 有人在仓里把这个脚本改硬了,但没有拷到机器上。** 开机时若 `pm2 jlist` 抽风,在跑的那份会当成「一个进程都没有」,然后在**已有进程之上**重复拉起 hub / dashboard / weixin。

**这正是那次加固要防的事,而加固没有部署 —— 已经 5 天。**

**本 PR 不部署任何东西**(动的是整支 fleet 的开机路径,要单独一条,而且要人点头)。

## 验证

```
bash -n                                OK
--selftest                             4 ok / 0 fail
真跑                                    checked=4 drift=2 missing=0 → rc=1
HOME 指向空目录（分母塌陷)               checked=0 → rc=2,不是 rc=0
check-home-path-baseline.py            rc=0
check-public-script-safety.py          rc=0
check-doc-symbol-anchors.py            rc=0
check-no-memory-slugs.py               rc=0
```

selftest 的四条,第四条是分母承重:

```
ok  不同用户名的同一路径 → 归一化后相同
ok  路径同但内容真的不同 → 仍判分叉
ok  写死用户名 vs basename 是有意差异 → 不报
ok  空 vs 非空 → 必须判分叉          ← 归一化不能把「一边空」也抹平
```

## 🔴 一个诚实的边界

**这次的变异测试没提供什么信息。** 基线**本来就是红的**,我人为改坏之后还是 `rc=1` —— **两次输出区分不出来**。

真正验到判据的是那条 fail-closed:把 `HOME` 指向一个空目录,得到 `checked=0 drift=0 missing=4 → exit 2`,而不是一片「干净」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
