### PR TITLE
fix(dashboard): 「channel-matched」还留在用户看得见的那句话里 (#866)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -6279,7 +6279,10 @@ async function serverCommand() {
     const globalBinary = globalOptIn ? resolveGlobalDashboardBinary() : null;
     if (globalOptIn && !globalBinary) {
       console.error(`[anet] ANET_DASHBOARD_LOCAL=1 requested the global Dashboard, but agent-network-dashboard is not on PATH.`);
-      console.error(`[anet] Install it explicitly or unset ANET_DASHBOARD_LOCAL to keep channel-matched npx startup.`);
+      // 🔴 NOT "channel-matched" — dashboardReleaseTag() returns "preview" for
+      //    every caller. The comment at the spawn site was corrected already;
+      //    this string is the same false claim in the one place a *user* reads it.
+      console.error(`[anet] Install it explicitly, or unset ANET_DASHBOARD_LOCAL to fall back to npx @sleep2agi/agent-network-dashboard@${tag} (currently "${tag}" for every CLI channel).`);
       process.exit(1);
     }
     const launchSource: DashboardLaunchSource = globalOptIn ? "global" : "npx";

--- a/docs-site/docs/en/guide/dashboard.md
+++ b/docs-site/docs/en/guide/dashboard.md
@@ -315,7 +315,11 @@ anet -v                                    # should show 2.3.0-preview.N (curren
 anet hub dashboard                          # npx auto-pulls the current preview version
 ```
 
-The default mode still starts the channel-matched release through `npx`. The CLI only replaces a stale `npx` Dashboard that it previously recorded and whose PID, birth fingerprint, and command all match exactly. It refuses automatic termination when the port belongs to an unknown process, inspection is incomplete, or a global install is in use. It never uses `pkill`, `killall`, or process-name prefix matching.
+The default mode still starts through `npx` — but **it does not pull a release matched to your CLI channel**.
+`dashboardReleaseTag()` returns `preview` for every caller (see the table at the top of this page), so
+**a user on the stable CLI channel also gets the preview Dashboard**. Pin a version with `ANET_DASHBOARD_VERSION`.
+(A deliberate temporary decision — see #866. This sentence used to claim the opposite of what the code does.)
+ The CLI only replaces a stale `npx` Dashboard that it previously recorded and whose PID, birth fingerprint, and command all match exactly. It refuses automatic termination when the port belongs to an unknown process, inspection is incomplete, or a global install is in use. It never uses `pkill`, `killall`, or process-name prefix matching.
 
 To reuse a global installation from PATH, explicitly set `ANET_DASHBOARD_LOCAL=1`. That Dashboard remains operator-managed; rerunning the command does not kill or replace it.
 

--- a/docs-site/docs/guide/dashboard.md
+++ b/docs-site/docs/guide/dashboard.md
@@ -314,7 +314,11 @@ anet -v                                    # 应显示 2.3.0-preview.N（当前 
 anet hub dashboard                          # 自动 npx 拉当前 preview 版本
 ```
 
-默认模式继续按 CLI 通道通过 `npx` 启动匹配版本。CLI 只会自动替换自己记录的、PID/启动时间/命令均精确匹配的旧 `npx` Dashboard；端口由未知进程占用、检查信息不完整或使用全局安装时都会拒绝自动终止。不会使用 `pkill`、`killall` 或进程名前缀匹配。
+默认模式继续通过 `npx` 启动 —— 但**它拉的不是「与你的 CLI 通道匹配」的版本**。
+`dashboardReleaseTag()` 对每一个调用者都返回 `preview`(见本页开头那张表),所以
+**装了稳定版 CLI 的用户起出来的也是 preview Dashboard**。要固定版本用 `ANET_DASHBOARD_VERSION`。
+(这是一个有意的临时决定,见 #866;这里原来写的是「按通道匹配」,与代码不符。)
+CLI 只会自动替换自己记录的、PID/启动时间/命令均精确匹配的旧 `npx` Dashboard；端口由未知进程占用、检查信息不完整或使用全局安装时都会拒绝自动终止。不会使用 `pkill`、`killall` 或进程名前缀匹配。
 
 需要复用 PATH 中的全局安装时，必须显式设置 `ANET_DASHBOARD_LOCAL=1`。全局 Dashboard 由操作者管理；再次运行命令不会自动杀掉或替换它。
 


### PR DESCRIPTION
## 已经修好的那一半

`cli.ts:6350` 现在写得很好:

```ts
// 🔴 The default is NOT channel-matched — this comment used to say it was.
// dashboardReleaseTag() returns "preview" for every caller …
```

## 🔴 没修的那一半:同一句错话,在**用户会读到**的地方

```
agent-network/bin/cli.ts:6282             ← stderr,用户唯一会看见的那处
docs-site/docs/guide/dashboard.md:317     ← 中文文档
docs-site/docs/en/guide/dashboard.md:318  ← 英文文档
```

原句(stderr):

> `[anet] Install it explicitly or unset ANET_DASHBOARD_LOCAL to keep channel-matched npx startup.`

**修的是开发者读的注释,留下的是用户读的字符串。**

## 两份文档还自相矛盾 —— 对的和错的在同一个文件里

| 行 | 说什么 |
|---|---|
| `:9`(表格) | ✅ 「`tag` 由 `dashboardReleaseTag()` 决定:**默认 `@preview`**」 |
| `:317`/`:318` | ❌ 「默认模式继续**按 CLI 通道**通过 `npx` 启动**匹配版本**」 |

读到哪一句,取决于读者滚到哪一行。

## 行为没变

仍是无条件 `preview` —— **那是有意的临时决定,本 PR 不动它**。这条只让**说明等于事实**:

```
@sleep2agi/agent-network            latest 2.2.21   preview 2.3.0-preview.39
@sleep2agi/agent-network-dashboard  latest 0.6.0    preview 0.6.3-preview.56
```

⇒ 装 `latest` CLI 的用户,起出来的是 `0.6.3-preview.56`。新的 stderr 直接把这件事说出来:

> `… or unset ANET_DASHBOARD_LOCAL to fall back to npx @sleep2agi/agent-network-dashboard@${tag} (currently "preview" for every CLI channel).`

## 有一处**刻意不改**

```
docs/tests/report-test654-dashboard-managed-launch.txt:14
- Default behavior remains channel-matched `npx` startup.
```

那是一份**测试记录**,写的是当时观察到的行为。**判据只对「说明」成立,对「记录」不成立** —— 改它会让证据不再等于当时发生的事。(同 #944 里「现状陈述 vs 提案」的那条线。)

## 验证

```
check-doc-symbol-anchors.py    rc=0
check-no-memory-slugs.py       rc=0
check-home-path-baseline.py    rc=0
check-public-script-safety.py  rc=0
check-l1-paths-sync.py         rc=0
check-qa-trigger-coverage.py   rc=0
```

🔴 **本地没有 tsc**(worktree 未装依赖),所以类型检查这一格**我没在本地跑过** —— 靠 CI 的 `agent-network unit (Docker, non-root)`。手工确认的部分:新字符串里的 `${tag}` 声明在 `6278`、使用在 `6285`,同一块作用域内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
