### PR TITLE
fix(ci): release-tag 这个 job 从来没跑过,而它跑起来会立刻死在参数上 (#875)

### DIFF
--- a/.github/workflows/published-artifact-drift.yml
+++ b/.github/workflows/published-artifact-drift.yml
@@ -37,6 +37,21 @@ on:
     # the same minute as every other scheduled job on the runners.
     - cron: '17 3 * * *'
   workflow_dispatch:
+    # release-tag 需要三个参数（它校验的是「tag 剥出的 commit == 打包用的 commit」，
+    # 而"打包用的 commit"只有发版的人知道，定时跑推不出来）。留空则跳过该 job。
+    inputs:
+      release_repo:
+        description: 'release-tag: owner/name（留空则跳过 release-tag 这个 job）'
+        required: false
+        default: ''
+      release_tag:
+        description: 'release-tag: tag 名，例如 v1.2.3'
+        required: false
+        default: ''
+      build_sha:
+        description: 'release-tag: 打包用的完整 commit SHA'
+        required: false
+        default: ''
   push:
     branches: [main]
     paths:
@@ -65,15 +80,41 @@ jobs:
           esac
 
   release-tag:
-    # Only meaningful when a tag is what triggered us, or on demand.
-    if: github.event_name == 'workflow_dispatch'
+    # 🔴 两处此前都是错的，而且互相遮掩：
+    #
+    #   (1) 原注释说「when a tag is what triggered us, or on demand」——
+    #       但这个 workflow 的 push 触发只写了 `branches: [main]`，**没有 tags**。
+    #       那半个说法从来不成立。
+    #   (2) 原来那行是 `bash scripts/verify-release-tag.sh`，**一个参数都没传**，
+    #       而脚本第一行就是 `REPO="${1:?repo, e.g. owner/name}"` ——
+    #       真跑起来会立刻死在 `line 16: 1: repo, e.g. owner/name`，
+    #       和「tag 真的漂了」在 job 状态上都是一个红。
+    #
+    # 因为 (1) 让它从来没被触发过，(2) 就一直没人发现。实测：published artifact
+    # drift 最近 3 次运行，这个 job 全部 skipped。
+    #
+    # 为什么不做成定时跑：脚本校验的是「tag 剥出的 commit == 打包用的 commit」，
+    # 而"打包用的 commit"只有发版的人手上有，定时跑推不出来。所以它只能是
+    # on-demand，参数从 workflow_dispatch inputs 来。
+    if: github.event_name == 'workflow_dispatch' && inputs.release_repo != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: verify release tags point at the commit they were built from
-        run: bash scripts/verify-release-tag.sh
+        run: |
+          set -euo pipefail
+          # 三个都必须非空 —— 缺一个就让它明确失败，而不是让脚本吐
+          # `${1:?...}` 那种看起来像脚本坏了的信息。
+          : "${RELEASE_REPO:?release_repo is required}"
+          : "${RELEASE_TAG:?release_tag is required}"
+          : "${BUILD_SHA:?build_sha is required}"
+          bash scripts/verify-release-tag.sh "$RELEASE_REPO" "$RELEASE_TAG" "$BUILD_SHA"
+        env:
+          RELEASE_REPO: ${{ inputs.release_repo }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          BUILD_SHA: ${{ inputs.build_sha }}
 
   docs-site-drift:
     # anet.sh 没有接 git 自动部署:合并进 main 不会让站点更新,必须有人手动


### PR DESCRIPTION
## 怎么发现的

在核 #875 时,我跑了 `verify-published-pins.sh preview` —— **漂移仍在**(已发布 `2.3.0-preview.39` 里是 `2.5.0-preview.28`,main 是 `.31`)。

顺手看了这道门现在接在哪:它**已经**接进了每日的 `published artifact drift`(#862 修过了)。于是去看这个 workflow 的运行历史:

```
32099305416  failure  push       2026-08-18T04:28:59Z
32097496305  failure  schedule   2026-08-18T03:59:59Z
32045184548  failure  push       2026-08-17T16:20:44Z
```

逐个 job:

```
published-pins   →  failure   (就是 #875 那条漂移,真的)
docs-site-drift  →  failure   (站点落后 5 页,真的)
release-tag      →  skipped   ← 三次全部 skipped
```

## 🔴 两处错误互相遮掩

**(1) 触发面:注释说的那一半不存在。**

```yaml
release-tag:
  # Only meaningful when a tag is what triggered us, or on demand.
  if: github.event_name == 'workflow_dispatch'
```

而这个 workflow 的 push 触发是:

```yaml
push:
  branches: [main]      # ← 没有 tags
```

「when a tag is what triggered us」**从来不成立**。它只能靠人点一下 `workflow_dispatch`。

**(2) 调用方式:一个参数都没传,而脚本要三个。**

```yaml
run: bash scripts/verify-release-tag.sh
```

```bash
REPO="${1:?repo, e.g. owner/name}"
TAG="${2:?tag}"
BUILD_SHA="${3:?完整的构建 commit SHA}"
```

实跑:

```
$ bash scripts/verify-release-tag.sh
scripts/verify-release-tag.sh: line 16: 1: repo, e.g. owner/name
退出码=1
```

⇒ **因为 (1) 让它从来没被触发,(2) 就一直没人发现。** 而且如果哪天有人点了 dispatch,它会红 —— **红的原因是参数没传,而这和「tag 真的漂了」在 job 状态上都只是一个红**。

这个 workflow 自己的头部注释写着「靠人记住不够,做成可复跑的检查」。**它下面这个 job 正好把那句话又犯了一遍。**

## 改法

参数从 `workflow_dispatch` inputs 来,三个都非空才跑:

```yaml
if: github.event_name == 'workflow_dispatch' && inputs.release_repo != ''
```

step 里显式 `: "${VAR:?...}"` —— 缺参数时报的是**你少传了什么**,而不是一句看起来像脚本坏了的 `${1:?...}`。

**为什么不做成定时跑**:脚本校验的是「tag 剥出的 commit == 打包用的 commit」,而**「打包用的 commit」只有发版的人手上有**,定时跑推不出来。这一点写进注释了,免得下一个人以为是漏配。

## 红绿都亲手见过

对这个仓真实存在的 tag `v2.4.11`:

```
匹配的 sha    → rc=0   PASS: v2.4.11 -> 1239eb7d… == 构建 commit
故意错的 sha  → rc=1   FAIL: tag 未绑定构建 commit
不存在的 tag  → rc=1   FAIL: tag 在远端不存在
```

**先见红再见绿,两头都验过** —— 只见红不能区分「判据在工作」和「它对什么都红」。

## 门(先 `git add` 再跑)

```
check-workflow-structure.py   rc=0
check-action-pins.py          rc=0
check-doc-symbol-anchors.py   rc=0
check-no-memory-slugs.py      rc=0
check-home-path-baseline.py   rc=0
check-qa-trigger-coverage.py  rc=0
check-l1-paths-sync.py        rc=0
```

## 本 PR 不解决 #875 本身

pin 漂移(`.28` vs `.31`)要发一个新的 `@preview` 才能消,那是发版的事。本条只让**那个每天都在跑的 workflow 里第三个 job 真的能跑**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
