### PR TITLE
fix(agent-node): 拒绝 claude-code-cli 时说清它住在哪 (#909)

### DIFF
--- a/agent-node/src/claude-code-cli-help-text.test.ts
+++ b/agent-node/src/claude-code-cli-help-text.test.ts
@@ -10,9 +10,9 @@ import { join } from "path";
 
 const CLI = join(import.meta.dir, "cli.ts");
 
-function help(): Promise<string> {
+function run(args: string[]): Promise<string> {
   return new Promise((resolve) => {
-    const child = spawn("bun", [CLI, "--help"], { stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn("bun", [CLI, ...args], { stdio: ["ignore", "pipe", "pipe"] });
     let out = "";
     const t = setTimeout(() => { try { child.kill("SIGKILL"); } catch { /* gone */ } resolve(out); }, 15_000);
     child.stdout.on("data", (d) => { out += String(d); });
@@ -21,6 +21,8 @@ function help(): Promise<string> {
     child.on("error", () => { clearTimeout(t); resolve(out); });
   });
 }
+
+const help = () => run(["--help"]);
 
 describe("#909 agent-node --help does not present claude-code-cli as a directly-passable runtime", () => {
   test("the `--runtime <type>` value list omits claude-code-cli (agent-node does not accept it)", async () => {
@@ -39,5 +41,27 @@ describe("#909 agent-node --help does not present claude-code-cli as a directly-
     expect(out).toMatch(/不能直接传给 agent-node|not by passing --runtime to agent-node/);
     // 🔴 the whole point of the correction: it must NOT be described as a gap/unimplemented.
     expect(out).not.toMatch(/not yet implemented|no execution lane|known gap/);
+  }, 20_000);
+});
+
+// 🔴 #917 修了 --help,却把同一句错话留在了**用户真正撞上的那一处**:
+//    RUNTIME_MAP 的拒绝分支只会说 `Unsupported runtime "claude-code-cli"`。
+//    对这个二进制而言「unsupported」是真的,对产品而言是假的 —— 它已实现、
+//    有 e2e、在出货,只是住在 launcher 里。说「unsupported」会把人推去找一个
+//    不存在的 runtime,而不是推去隔壁那条命令。
+describe("#909 rejecting claude-code-cli says where it actually lives", () => {
+  test("it does not call claude-code-cli unsupported, and names `anet node start`", async () => {
+    const out = await run(["--alias", "t", "--runtime", "claude-code-cli"]);
+    expect(out).toContain("anet node start");
+    expect(out).toMatch(/does not run through agent-node/);
+    // 🔴 这是本条的核心断言:那个词不能出现在 claude-code-cli 这一句里。
+    expect(out).not.toMatch(/Unsupported runtime "claude-code-cli"/);
+  }, 20_000);
+
+  test("负对照 —— 真正不存在的 runtime 仍然走原来那句", async () => {
+    const out = await run(["--alias", "t", "--runtime", "definitely-not-a-runtime"]);
+    expect(out).toMatch(/Unsupported runtime "definitely-not-a-runtime"/);
+    // 不该把特判泄漏到别的名字上
+    expect(out).not.toMatch(/anet node start/);
   }, 20_000);
 });

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -461,6 +461,18 @@ const RUNTIME_MAP: Record<string, string> = {
 //    (The `--help` above lists it only in the Runtime section, marked as anet-provided, for exactly this reason.)
 if (!Object.prototype.hasOwnProperty.call(RUNTIME_MAP, rawRuntime)) {
   const supported = [...new Set(Object.keys(RUNTIME_MAP))].join(", ");
+  // 🔴 `claude-code-cli` needs its own sentence. "Unsupported" is true of THIS
+  //    binary and false of the product: it is implemented, tested and shipping —
+  //    in the launcher (`anet node start`), not here. #909 already fixed the
+  //    `--help` text and the comment above; this line was the same claim left in
+  //    the one place a user actually hits it. Telling them "unsupported" sends
+  //    them looking for a runtime that does not exist instead of one command over.
+  if (rawRuntime === "claude-code-cli") {
+    console.error(`[${ALIAS}] "claude-code-cli" does not run through agent-node — it is provided and launched by \`anet\` itself.`);
+    console.error(`[${ALIAS}] Use: anet node start <node>   (with runtime "claude-code-cli" in that node's config.json)`);
+    console.error(`[${ALIAS}] Runtimes agent-node can take directly: ${supported}`);
+    process.exit(1);
+  }
   console.error(`[${ALIAS}] Unsupported runtime "${rawRuntime}". Supported: ${supported}`);
   process.exit(1);
 }

--- a/docs/stale-issue-review.md
+++ b/docs/stale-issue-review.md
@@ -139,12 +139,18 @@ agent-node/src/cli.ts:3450               … Cross-machine artifact distribution
 
 `tests/test846-doc-claims` 会读下面这个清单,逐条打开那个文件的那一行,确认它包含声称的子串。行号一漂就红。
 
+<!-- 🔴 2026-08-18：这三条 agent-node/src/cli.ts 的行号被 #950 撞漂了 —— 那个 PR 在
+     ~:462 处插了 12 行，下面所有行号整体 +12（3468→3480 / 4291→4303 / 2388→2400）。
+     数字对得上插入量，所以是纯位移，不是内容变了。
+     这正是 #857 用「符号锚点」替换行号 pin 想解决的那件事，而这份清单还是行号制：
+     任何在上方的插入都会让它红，而红的原因和「文档说错了」在输出上长得一样。
+     换成符号锚点要动 tests/test846-doc-claims 的判据，属于另一条。 -->
 ```doc-claims
 server/src/db.ts :: 393 :: ADD COLUMN team
 agent-network/bin/cli.ts :: 5151 :: dangerously-load-development-channels
-agent-node/src/cli.ts :: 3468 :: video_gen
-agent-node/src/cli.ts :: 4291 :: Expose CURRENT_TASK_ID
-agent-node/src/cli.ts :: 2388 :: total_cost_usd
+agent-node/src/cli.ts :: 3480 :: video_gen
+agent-node/src/cli.ts :: 4303 :: Expose CURRENT_TASK_ID
+agent-node/src/cli.ts :: 2400 :: total_cost_usd
 agent-node/src/feishu-tool-deny.ts :: 250 :: bubblewrap
 server/src/tools.ts :: 3899 :: list_providers
 server/src/server.ts :: 9 :: addNetworkScope


### PR DESCRIPTION
## 今天第三次撞见同一个形状

| # | 修好的 | 留下的 |
|---|---|---|
| #941 | `deploy/docs-site/README.md` 开头「不要用 `age:` 判据」 | 55 行后的清单里第一条还是 `grep -i '^age:'` |
| #948 | `cli.ts` 注释「The default is NOT channel-matched」 | stderr + 中英文档里同一句错话 |
| **本条** | `--help` 不再把 claude-code-cli 列成可直接传的 runtime(#917) | **用户真正撞上的那句拒绝消息** |

🔴 **共同点:修的是读的人是开发者的那一份,留下的是用户会撞上的那一句。**

## 现状

```
$ agent-node --alias t --runtime claude-code-cli
[t] Unsupported runtime "claude-code-cli". Supported: claude-agent-sdk, claude-sdk, ...
```

**「unsupported」对这个二进制是真的,对产品是假的。** `claude-code-cli` 已实现、有 e2e(`qa-180-rename-ghost`)、在出货 —— 执行道在 launcher(`agent-network/bin/cli.ts` ~`:5096`,`anet node start` → `launchAgent` → 真的 `claude` CLI)。

跟一个用户说「unsupported」,**是把他推去找一个不存在的 runtime,而不是推去隔壁那条命令**。

## 改后

```
[t] "claude-code-cli" does not run through agent-node — it is provided and launched by `anet` itself.
[t] Use: anet node start <node>   (with runtime "claude-code-cli" in that node's config.json)
[t] Runtimes agent-node can take directly: claude-agent-sdk, claude-sdk, ...
```

**行为一个字没变** —— 仍然 `exit 1`,`RUNTIME_MAP` 一个键都没加。(加键会让 CLI-login 用户被静默降级到 SDK 通道 —— 那正是那段注释已经警告过的事。)

## 红绿都亲手见过

测试加在 #917 建的 `agent-node/src/claude-code-cli-help-text.test.ts` 里:

```
用 origin/main 的 cli.ts 跑  →  1 fail
    Expected to contain: "anet node start"
    Received: "[t] Unsupported runtime \"claude-code-cli\". Supported: …"

用本 PR 的 cli.ts 跑         →  4 pass / 12 expect()
```

**先见红再见绿** —— 只见绿区分不出「断言在工作」和「断言对什么都过」。

带一条**负对照**:真正不存在的 runtime 仍走原来那句,且**不泄漏** `anet node start`(防止特判溢出到别的名字上)。

## 门(先 `git add` 再跑)

```
check-doc-symbol-anchors.py    rc=0
check-no-memory-slugs.py       rc=0
check-home-path-baseline.py    rc=0
check-public-script-safety.py  rc=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
