### PR TITLE
docs(qa): 给 CI 侧的实测成本,并写全它的条件 (#871)

### DIFF
--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -28,6 +28,41 @@ bash scripts/qa.sh --list    # 列测试名 + 文件路径
 
 [.github/workflows/qa.yml](../../.github/workflows/qa.yml) — PR / push to main 时自动跑（路径过滤）。
 
+### CI 侧的实测成本（2026-08-18，`L1_TESTS` = 22 个套件）
+
+上面那段说的是「你这台机」。**CI 是另一个对象,数字不能互相套用** —— 所以单独记一次,
+并且把条件写全,否则下次它又会变成一个没人知道怎么来的死数字:
+
+```
+job            L0 + L1 (report-only)      GitHub Actions ubuntu-latest
+最近 8 次 main  137 / 151 / 157 / 158 / 165 / 177 / 180 / 188 s     中位 162s
+job 预算        timeout 300 s              最长的一次仍余 37%
+L1 并发上限     4                          日志里那行 `· L1 并发上限 = 4（0 = 不限;用 QA_L1_MAX_PAR 覆盖）`
+Docker 缓存     冷                          GHA runner 每次都是干净的
+L1 成员数       22                          `bash scripts/qa.sh --list` 可自数
+```
+
+🔴 **给的是区间不是单点,这是有意的。** 8 次里最短 137s、最长 188s,**差 37%** ——
+只报中间那一个数,下一个人拿它当基线时会以为自己的运行「异常慢」。
+
+🔴 **别把这个数和本机的对照。** 三处不同:CI 每次冷启动(要重新 build 镜像)、
+run 阶段有 4 路并行、而 `qa.sh` 的 **build 是串行的**。同一份脚本在两种环境下
+的耗时结构完全不一样。
+
+**怎么自己重新量(不要抄上面这个数):**
+
+```bash
+# 取最近一次 main 上的该 job 时长
+gh run list --workflow=qa.yml --branch=main --limit 5 --json databaseId --jq '.[].databaseId' |
+while read id; do
+  gh api "repos/sleep2agi/agent-network/actions/runs/$id/jobs" \
+    --jq '.jobs[] | select(.name|test("L0 . L1")) | "\(.name) \(.started_at) \(.completed_at)"'
+done
+```
+
+⚠️ **要 step 的时长就取 `.steps[]`,不要拿 job 时长去比 step 上的 `timeout-minutes`** ——
+job 里还含 checkout / Setup Bun / 依赖安装,那些不受那个上限管(#924 上踩过两次)。
+
 **Report-only**：失败时 PR 显示红 ✕，但**不阻塞合并**（branch protection 未加这个 check）。
 目的是让大家看见结果，不当拦路虎。详见 [strategy.md §4](strategy.md#4-ci-gate渐进三档)。
 


### PR DESCRIPTION
## #871 的核心已经修过了,这条补的是它没覆盖的另一半

`docs/qa/README.md` 现在已经把「~16s warm」这类死数字去掉,改成:

> 三个数字都没说明自己量的是什么条件,所以谁都不能拿来对照。已把死数字去掉 —— **要知道现在多久,就跑一次** `time bash scripts/qa.sh`。

**这是对的处理。** 但 issue 里还说了一句:

> `~16s` 会让人以为「顺手全跑一遍」几乎免费,从而在本地跳过、或**在设计 CI 时低估这一步的成本**。

而 README 的「CI 自动跑」那一节,**对成本一个字都没有**。这条补它。

## 加的是实测,而且条件写全

```
job            L0 + L1 (report-only)      GitHub Actions ubuntu-latest
最近 8 次 main  137 / 151 / 157 / 158 / 165 / 177 / 180 / 188 s     中位 162s
job 预算        timeout 300 s              最长的一次仍余 37%
L1 并发上限     4
Docker 缓存     冷（GHA runner 每次都是干净的）
L1 成员数       22
```

## 🔴 三个刻意的选择

**① 给区间,不给单点。** 8 次里最短 137s、最长 188s,**差 37%**。只报中间那个数,下一个人拿它当基线时会以为自己的运行「异常慢」。

**② 明写「别拿它和本机对照」。** 三处不同:CI 每次**冷启动**(要重新 build 镜像)、run 阶段 **4 路并行**、而 `qa.sh` 的 **build 是串行的**。同一份脚本在两种环境下的耗时结构完全不一样 —— **这正是这条 issue 一开始那两个数(16s vs 93s)互相打架的根因:谁都没说自己量的是什么。**

**③ 附了重新量的命令,而且我真跑过一次确认它能用:**

```
L0 + L1 (report-only) 2026-08-18T05:58:32Z 2026-08-18T06:01:29Z
L0 + L1 (report-only) 2026-08-18T05:27:44Z 2026-08-18T05:30:22Z
```

**不贴跑不通的命令。**

## 顺带带上一条从 #924 学到的提醒

> ⚠️ 要 step 的时长就取 `.steps[]`,**不要拿 job 时长去比 step 上的 `timeout-minutes`** —— job 里还含 checkout / Setup Bun / 依赖安装,那些不受那个上限管。

那条 issue 上这个坑一天踩了两次(作者一次、我一次),写在这里省下一次。

## 门(先 `git add` 再跑)

```
check-doc-symbol-anchors.py    rc=0
check-no-memory-slugs.py       rc=0
check-home-path-baseline.py    rc=0
check-public-script-safety.py  rc=0
check-docs-integrity.py        rc=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
