### PR TITLE
docs(getting-started): 密码从自己那次 hub start 的输出里取 (#952)

### DIFF
--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -69,7 +69,31 @@ Open terminal #2, **keep it running**:
 anet hub dashboard
 ```
 
-Open `http://localhost:3000` in your browser and log in with `admin / anethub`.
+Open `http://localhost:3000` in your browser and log in as `admin` with **the password your own `anet hub start` printed**.
+
+::: warning Take the password from your own `anet hub start` output — do not copy it from this page
+The first `anet hub start` prints the admin credentials once:
+
+```
+✅ Admin account created
+   username: admin
+   password: <the string printed there>
+   Store this password now; it will not be shown again.
+```
+
+**That string depends on which version you installed** (measured 2026-08-18):
+
+| channel | printed password |
+|---|---|
+| `latest` = `2.2.21` | the fixed string `anethub` |
+| `preview` = `2.3.0-preview.39` | a **random** string like `anet-232412de5bb54c058cff32`, with a change-on-first-login notice |
+
+So the `anethub` below **only holds on stable**. **Anyone who copies this page instead of reading their own startup output will fail to log in on preview.**
+The credentials are also written to `~/.anet/server/admin-utok.json`.
+
+🔴 Also: **`anet login` currently exits 0 even when it fails** (both `latest` and `preview`; fixed on main — see #716 / #722).
+⇒ **Do not use `anet login && <next step>` to decide whether login worked** — it will carry on after a failure. Confirm with `anet whoami`.
+:::
 
 In terminal #3, log the CLI in too (so subsequent `anet node ...` commands carry the credentials):
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -69,7 +69,31 @@ anet hub start
 anet hub dashboard
 ```
 
-浏览器访问 `http://localhost:3000`, 用 `admin / anethub` 登录。
+浏览器访问 `http://localhost:3000`, 用 `admin` 加**你自己那次 `anet hub start` 打印的密码**登录。
+
+::: warning 密码从 `anet hub start` 的输出里取,不要照抄这里
+`anet hub start` 第一次跑的时候会打印一次管理员凭据:
+
+```
+✅ Admin account created
+   username: admin
+   password: <这里打印的那个串>
+   Store this password now; it will not be shown again.
+```
+
+**那个串取决于你装的是哪个版本**(实测 2026-08-18):
+
+| 通道 | 打印出来的密码 |
+|---|---|
+| `latest` = `2.2.21` | 固定的 `anethub` |
+| `preview` = `2.3.0-preview.39` | **随机串**,形如 `anet-232412de5bb54c058cff32`,并提示首次登录后要改 |
+
+所以下面命令里的 `anethub` **只在 stable 上成立**。**照抄这一页而不看自己那次启动输出的人,在 preview 上一定登不进去。**
+凭据也落在 `~/.anet/server/admin-utok.json`。
+
+🔴 另外:**`anet login` 失败时目前仍然退出码 0**(`latest` 与 `preview` 都是,修复已在 main 上,见 #716 / #722)。
+⇒ **不要用 `anet login && 下一步` 来判断登录成功** —— 它会在失败时继续往下走。用 `anet whoami` 确认。
+:::
 
 第三个终端给 CLI 也登录一次（后续 `anet node ...` 命令带凭证）：
 


### PR DESCRIPTION
## 实测:同一条文档命令,两个通道结果相反

干净容器(`node:22-slim` + bun),严格照 `getting-started` 走:

```
latest  2.2.21              hub 打印  password: anethub                → login 成功
preview 2.3.0-preview.39    hub 打印  password: anet-232412de5bb54c…   → 文档给的 anethub 必然失败
```

preview 的 hub 横幅:

```
✅ Admin account created
   username: admin
   password: anet-232412de5bb54c058cff32
   ⚠ This is a random bootstrap password — you'll be asked to change it on first login.
```

## 🔴 关键:**这一页今天是对的**,所以不能简单改掉

`latest` 的 hub 仍然用固定的 `anethub`。**把文档改成随机串,会立刻让今天的 stable 用户读到错的。**

⇒ 改成一条**两个版本都成立**的指令:**从你自己那次 `anet hub start` 的输出里取**,并把两个通道现在各打印什么列成表,让读者能对上自己屏幕上看到的东西。

**它会在 latest 被推上去的那一刻自动仍然正确** —— 这正是这条改动想要的性质。

## 同一个告示框里还写了一条会咬人的

> 🔴 **`anet login` 失败时目前仍然退出码 0**(`latest` 与 `preview` 都是;修复已在 main 上,见 #716 / #722)。
> ⇒ **不要用 `anet login && <下一步>` 判断登录成功** —— 它会在失败时继续走下去。用 `anet whoami` 确认。

**这一条不是抄来的。** 我自己的探针脚本就写成了 `anet login && ok "login rc=0"`,于是它对 preview 打印了 **`✅ login rc=0`** —— 而那次登录其实失败了,下一步 `anet node create` 报 `Not logged in` 才露馅。

**一个会说谎的退出码,会先骗过写检查的人。** 所以它值得写在用户第一次会用到它的那一页上,而不是只留在 issue 里。

## 中英两份同步改

不改行为、不改任何代码。

## 门(先 `git add` 再跑)

```
check-doc-symbol-anchors.py    rc=0
check-no-memory-slugs.py       rc=0
check-home-path-baseline.py    rc=0
check-public-script-safety.py  rc=0
check-docs-integrity.py        rc=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
