### PR TITLE
chore(fleet): pm2-fleet-boot.sh 的三处家目录参数化,基线随之下调 (#894)

### DIFF
--- a/deploy/fleet/pm2-fleet-boot.sh
+++ b/deploy/fleet/pm2-fleet-boot.sh
@@ -6,8 +6,11 @@
 #    理由：resurrect 打在活着的 pm2 上可能拉出重复进程，而这些进程占 9200/3001 端口。
 #    有了这个守卫，本单元在任何时刻手动 start 都安全 —— 也才能在不重启整机的前提下真验证。
 set -uo pipefail
-export PATH="/home/vansin/.nvm/versions/node/v20.20.0/bin:$PATH"
-PM2="/home/vansin/.nvm/versions/node/v20.20.0/bin/pm2"
+# 🔴 路径参数化（#894）：原来三处写死了那台机的家目录。nvm 版本仍然钉死 ——
+#    钉的是 node 版本（可重现性），不是钉某个人的家目录。
+NODE_BIN="${ANET_NODE_BIN:-$HOME/.nvm/versions/node/v20.20.0/bin}"
+export PATH="$NODE_BIN:$PATH"
+PM2="$NODE_BIN/pm2"
 log() { echo "[pm2-fleet-boot $(date '+%F %T')] $*"; }
 
 jlist=$("$PM2" jlist 2>/dev/null)
@@ -16,7 +19,7 @@ if [ "$jlist_rc" -ne 0 ]; then
   log "🔴 pm2 jlist 失败（rc=$jlist_rc），无法确认现有进程数；拒绝 resurrect"
   exit 1
 fi
-n=$(printf '%s' "$jlist" | "/home/vansin/.nvm/versions/node/v20.20.0/bin/node" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const v=JSON.parse(s);if(!Array.isArray(v))throw new Error("not array");process.stdout.write(String(v.length))}catch{process.exit(2)}})')
+n=$(printf '%s' "$jlist" | "$NODE_BIN/node" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const v=JSON.parse(s);if(!Array.isArray(v))throw new Error("not array");process.stdout.write(String(v.length))}catch{process.exit(2)}})')
 parse_rc=$?
 if [ "$parse_rc" -ne 0 ] || ! [[ "$n" =~ ^[0-9]+$ ]]; then
   log "🔴 pm2 jlist 返回无法解析的进程清单；拒绝 resurrect"

--- a/docs/home-path-baseline.txt
+++ b/docs/home-path-baseline.txt
@@ -19,7 +19,6 @@ agent-node/tests/rfc-030-copresence-observer.ts	2
 channel/commhub-channel.ts	1
 deploy/dashboard/dash-start.sh	1
 deploy/dashboard/ecosystem.config.cjs	1
-deploy/fleet/pm2-fleet-boot.sh	3
 deploy/tunnel/frpc.service	1
 docs/anet-codex-code-cli-design.md	1
 docs/anet-codex-mcp-server-plan.md	1


### PR DESCRIPTION
## 为什么先动这一个文件

`#894` 的量级我今天复跑了一遍(**带 ref**,不带会搜到落后的工作树):

```
git grep -lE '/home/[a-z][a-z0-9_-]+/' origin/main | wc -l
74            ← issue 记的是 70
```

**方向在涨。** 而那道基线门守的是「**不许更差**」—— 它不会自己把存量清掉,存量得一件件动。

挑 `deploy/fleet/pm2-fleet-boot.sh` 先动,因为它**同时是两类问题**:

- **隐私**:公开仓里写死了某个人的家目录;
- **可移植性**:它是**开机拉起整支 pm2 军团**的脚本 —— 换一台机器直接不工作。

## 改动只有路径

```diff
-export PATH="/home/<user>/.nvm/versions/node/v20.20.0/bin:$PATH"
-PM2="/home/<user>/.nvm/versions/node/v20.20.0/bin/pm2"
-… "/home/<user>/.nvm/versions/node/v20.20.0/bin/node" …
+NODE_BIN="${ANET_NODE_BIN:-$HOME/.nvm/versions/node/v20.20.0/bin}"
+export PATH="$NODE_BIN:$PATH"
+PM2="$NODE_BIN/pm2"
+… "$NODE_BIN/node" …
```

🔴 **nvm 的版本仍然钉死** —— 钉的是 **node 版本(可重现性)**,不是钉**某个人的家目录**。这两件事被写在同一个字符串里,所以容易一起被当成「硬编码」清掉;只该清后者。

留了 `ANET_NODE_BIN` 覆盖口子给 node 装在别处的机器。

`set -u` 下若 `HOME` 未设置,这一行会**直接报错退出**而不是拼出一个错路径 —— 那是想要的方向。

## 基线下调(不是加白名单)

`docs/home-path-baseline.txt` 里那一行从 `3` **整行删掉**(按该文件头注释的说明:清零就整行删,楼层只往下走)。

```
scanned 2038 tracked file(s); 200 person-looking /home/ path(s) across 70 file(s)
no file is above its baseline.

（203 次 / 71 文件  →  200 次 / 70 文件）
```

## 🔴 一个副作用,我说清楚

这会让 `deploy/fleet/check-fleet-drift.sh` 报的那处 diff **变大** —— 仓里那份现在和机器上那份多了一层写法差异。

**但它本来就是红的**,红的真因(`08-13` 那次 `pm2 jlist` 失败守卫**没拷到机器上**,见 #947)一点没变。

⇒ **正确的收尾仍然是把仓里那份部署上去,而不是让仓迁就机器。** 我没有为了让这道门变绿而回退改动 —— 那会把一个真问题藏起来。

自检(改完之后回归了我今天写的那道门):

```
check-fleet-drift.sh --selftest   rc=0   4 ok / 0 fail
check-fleet-drift.sh              rc=1   checked=4 drift=2 missing=0
   → pm2-fleet-boot 的 diff 里，jlist 加固那一段仍然在最显眼的位置
```

## 门

```
check-home-path-baseline.py    rc=0
check-public-script-safety.py  rc=0
check-doc-symbol-anchors.py    rc=0
check-no-memory-slugs.py       rc=0
check-workflow-structure.py    rc=0
bash -n deploy/fleet/pm2-fleet-boot.sh   OK
```

**本 PR 不部署任何东西。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
