### PR TITLE
docs: 两处通道标注与实测不符,方向相反 (#873)

### DIFF
--- a/docs-site/docs/en/guide/cli.md
+++ b/docs-site/docs/en/guide/cli.md
@@ -200,8 +200,8 @@ The following commands exist in the current preview and must not be presented as
 
 | Command | Purpose |
 |---|---|
-| `anet daemon up [name]` | Create and start a `host_supervisor` |
-| `anet daemon init <name>` / `start <name>` / `list` | Manage local daemons |
+| `anet daemon up [name]` | Create and start a `host_supervisor` — **preview channel only** |
+| `anet daemon init <name>` / `start <name>` / `list` | Manage local daemons — **preview channel only** |
 | `anet node start <name> --copresence` | Start Codex app-server, bridge, and shared TUI |
 | `anet opencode ...` | Manage the preview OpenCode integration |
 

--- a/docs-site/docs/en/guide/grok-copresence.md
+++ b/docs-site/docs/en/guide/grok-copresence.md
@@ -1,7 +1,18 @@
 # Grok Co-presence TUI (not released)
 
 ::: danger Not currently available
-`grok-build-cli` and `anet grok attach` are **not included in npm `latest` or `preview`**. Do not follow older instructions that run `anet node create ... --runtime grok-build-cli`; current published packages do not contain this path.
+Do not follow older instructions for the `grok-build-cli` runtime path — do not run `anet node create ... --runtime grok-build-cli`.
+
+🔴 **Correction (measured 2026-08-18)**: this page used to say `anet grok attach` is "not included in npm `latest` or `preview`". The second half does not hold. Running the real published binaries:
+
+```
+latest  2.2.21              anet grok attach → Unknown: grok
+preview 2.3.0-preview.39    anet grok attach → Usage: anet grok attach <node>
+```
+
+⇒ **The command does exist on `preview`** — it is only missing from `latest`.
+**But "the command exists" is not "this co-presence path works"** — only command registration was verified, not end-to-end usability.
+The rest of this page still holds: it is being requalified, do not treat it as released.
 :::
 
 The repository has a candidate implementation for sharing one Grok TUI between a human and network tasks, but it is still being requalified and is not a released feature. Follow [Issue #537](https://github.com/sleep2agi/agent-network/issues/537) and [Draft PR #538](https://github.com/sleep2agi/agent-network/pull/538) for status and test evidence.

--- a/docs-site/docs/guide/cli.md
+++ b/docs-site/docs/guide/cli.md
@@ -200,8 +200,8 @@ Channel 配置不会热加载，修改后需要重启节点。`anet channel add 
 
 | 命令 | 作用 |
 |---|---|
-| `anet daemon up [name]` | 创建并启动 `host_supervisor` |
-| `anet daemon init <name>` / `start <name>` / `list` | 管理本机 daemon |
+| `anet daemon up [name]` | 创建并启动 `host_supervisor` —— **仅 preview 通道** |
+| `anet daemon init <name>` / `start <name>` / `list` | 管理本机 daemon —— **仅 preview 通道** |
 | `anet node start <name> --copresence` | 启动 Codex app-server、桥和共享 TUI |
 | `anet opencode ...` | 管理 OpenCode preview 集成 |
 

--- a/docs-site/docs/guide/grok-copresence.md
+++ b/docs-site/docs/guide/grok-copresence.md
@@ -1,7 +1,18 @@
 # Grok 人机共存 TUI（未发布）
 
 ::: danger 当前不可用
-`grok-build-cli` 和 `anet grok attach` **尚未进入 npm `latest` 或 `preview`**。不要照旧文档执行 `anet node create ... --runtime grok-build-cli`；当前发布包不包含这条路径。
+`grok-build-cli` 这条 runtime 路径**不要照旧文档使用** —— 不要执行 `anet node create ... --runtime grok-build-cli`。
+
+🔴 **更正(2026-08-18 实测)**:原文写「`anet grok attach` 尚未进入 `latest` 或 `preview`」,**后半句不成立**。用真包跑二进制:
+
+```
+latest  2.2.21              anet grok attach → Unknown: grok
+preview 2.3.0-preview.39    anet grok attach → Usage: anet grok attach <node>
+```
+
+⇒ **这个命令在 `preview` 里是存在的**,只是 `latest` 里没有。
+**但「命令存在」不等于「这条共存路径可用」** —— 我只验到命令注册,没有验端到端可用性。
+本页其余的告诫仍然成立:它仍在重新验收,不要当已发布功能用。
 :::
 
 项目中已有让人和网络任务共享同一个 Grok TUI 的候选实现，但它仍在重新验收，不能视为已发布功能。进度与实测证据见 [Issue #537](https://github.com/sleep2agi/agent-network/issues/537) 和 [Draft PR #538](https://github.com/sleep2agi/agent-network/pull/538)。


### PR DESCRIPTION
## 证据:用真包跑二进制(dist 是混淆产物,grep 不算数)

```
latest  2.2.21              anet daemon        → Unknown command "daemon". Did you mean: anet demo?
                            anet daemon init   → Unknown command "daemon". …
                            anet attach        → Unknown: attach
                            anet grok attach   → Unknown: grok

preview 2.3.0-preview.39    anet daemon        → Usage: anet daemon <subcommand> [name] [options]
                            anet daemon init   → 未找到 CommHub Server。请先运行: anet hub start
                            anet attach        → Usage: anet attach <node-name>
                            anet grok attach   → Usage: anet grok attach <node>
```

## 错误一:把 preview-only 的能力当现状教

`guide/cli.md:203-204` 列了 `anet daemon up/init/start/list`,**没有 preview 标注**。

🔴 而**同一张表**的 `:206` 是:

```
| `anet opencode ...` | 管理 OpenCode preview 集成 |
```

⇒ **这份文档是有标注习惯的,只是 daemon 这两行漏了。不是体例问题,是漏标。** 中英两版都补上「**仅 preview 通道**」。

## 错误二:方向相反 —— 说「也不在 preview」,而它在

`grok-copresence.md` 开头:

> `grok-build-cli` 和 `anet grok attach` **尚未进入 npm `latest` 或 `preview`**。

**后半句不成立** —— preview 上 `anet grok attach` 给的是 `Usage:`,不是 `Unknown:`。

## 🔴 改法刻意保守,并且我写明了没验什么

只更正「**命令在不在 preview 里**」这一句,并在正文里明写:

> **「命令存在」不等于「这条共存路径可用」** —— 我只验到**命令注册**,没有验端到端可用性。

本页其余告诫(仍在重新验收、不要当已发布功能用、不要跑 `--runtime grok-build-cli`)**一个字没动**。

**把「命令存在」直接读成「功能可用」,正是这条 issue 另一半错误的来源** —— 我不打算在纠正它的时候犯同一个方向相反的错。

## 范围

中英四处同步(`guide/cli.md` ×2、`guide/grok-copresence.md` ×2)。**不改任何代码。**

## 门(先 `git add` 再跑)

```
check-doc-symbol-anchors.py    rc=0
check-no-memory-slugs.py       rc=0
check-home-path-baseline.py    rc=0
check-public-script-safety.py  rc=0
check-docs-integrity.py        rc=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
