### PR TITLE
fix(guard): memory 泄漏门只认 [[slug]] 形状 —— 修复已存在 2 天,一直没进 main

### DIFF
--- a/.github/scripts/check-no-memory-slugs.py
+++ b/.github/scripts/check-no-memory-slugs.py
@@ -56,6 +56,29 @@ from pathlib import Path
 #   一道隐私门,漏的正是最可能出现的写法。
 SLUG_RE = re.compile(r"\[\[(feedback|project|reference|user)[_-][a-z0-9_-]+(?:\.md)?\]\]")
 
+# 🔴 同一个泄漏，换一种写法就绕过了上面那条。2026-08-16 实测:本仓有四处
+#    指向私有 memory 库的引用，**一处都没被上面那条命中** —— 因为它们不是
+#    `[[slug]]`，而是 markdown 链接和反引号路径:
+#      docs/research/…:183   [`feedback_…`](../../agent-orchestra/memory/feedback_….md)
+#      docs/rfcs/RFC-029…:9  [RFC-006 (project memory)](../../.claude/memory/)
+#      docs/sop/methodology.md:555      `~/.claude/projects/-home-…/memory/`
+#      docs/team-collab-playbook.md:368 `/home/<user>/.claude/projects/…/memory/MEMORY.md`
+#    前三处在 ALLOWLIST 树里(那是有意的历史豁免)，**第四处不在** ——
+#    它带着完整绝对路径和用户名，躺在一个本该被这道门守着的文件里，而门是绿的。
+#
+#    教训:一条按**形状**写的判据，只挡得住那个形状。同一件事换个语法就穿过去，
+#    而且穿过去的时候门还是绿的 —— 绿在这里的含义是"没有那个形状"，
+#    不是"没有那件事"。
+#
+#    这条只认**memory 库路径**这一种形态，故意不去认"任何绝对家目录"：
+#    后者全仓 114 处，绝大多数是正当的(测试夹具 /home/tester、
+#    agent-network/scripts 里记录的真实部署路径)。一道在正当写法上常红的门，
+#    只会教会所有人忽略它的输出 —— 那笔账在 oss-readiness-report 里另记。
+MEMORY_PATH_RE = re.compile(
+    r"(?:~|/home/[^/\s]+|/Users/[^/\s]+)?/?\.claude/(?:projects/[^/\s`)]+/)?memory/"
+    r"|agent-orchestra/memory/"
+)
+
 # .sh / .py 同样是公开仓里可见的文件,此前不在覆盖内 —— 实测 2026-08-13,
 # 三处真 slug 就藏在 tests/ 下的 shell 脚本里,门扫 898 个文件却看不见它们。
 EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".md", ".yml", ".yaml", ".sh", ".py"}
@@ -100,6 +123,26 @@ ALLOWLIST_PATH_PREFIXES = (
 )
 
 
+# 🔴 这道门的 FAIL 输出会**原样打印命中的那一段**，而 GitHub Actions 的日志
+#    在公开仓里是**公开的**。命中的路径里带着机器用户名(`/home/<user>/…`)——
+#    也就是说，一道防泄漏的门，会在报告泄漏的同时把它印进一个公开日志。
+#    脱敏放在**入 findings 之前**，不是打印前:只要原值进过列表，
+#    后面任何一处打印都可能漏掉那层处理。
+#    ⚠️ 第一版只脱了 `/home/<user>/` 这一种写法，跑出来是
+#       `/home/<user>/.claude/projects/-home-vansin-agent-orchestra/memory/`
+#       —— **同一个用户名在同一个串里出现了两次**，Claude 的 project 目录名
+#       就是把家目录路径用连字符编码了一遍。脱掉看得见的那处，剩下的那处
+#       长得不像路径，就被漏掉了。
+#       **脱一半和没脱，在"用户名有没有进公开日志"这件事上是同一个结果。**
+_HOME_RE = re.compile(r"(?<![A-Za-z0-9])(home|Users)([/-])[^/\s-]+")
+
+
+def redact(snippet: str) -> str:
+    """把家目录用户名换掉。两种写法都要:路径形 `/home/x/`，和 Claude
+    project 目录名里连字符编码的那份 `-home-x-agent-…`。"""
+    return _HOME_RE.sub(r"\1\2<user>", snippet)
+
+
 def scan(root: Path) -> list[tuple[str, int, str]]:
     findings: list[tuple[str, int, str]] = []
     scanned = 0
@@ -123,8 +166,9 @@ def scan(root: Path) -> list[tuple[str, int, str]]:
                 continue
             scanned += 1
             for lineno, line in enumerate(text.splitlines(), start=1):
-                for match in SLUG_RE.finditer(line):
-                    findings.append((rel, lineno, match.group(0)))
+                for regex in (SLUG_RE, MEMORY_PATH_RE):
+                    for match in regex.finditer(line):
+                        findings.append((rel, lineno, redact(match.group(0))))
     return findings, scanned
 
 
@@ -156,7 +200,7 @@ def main() -> int:
         f"FAIL: found {len(findings)} internal memory-slug reference(s). "
         "These are private agent-memory pointers and must not leak into "
         "public OSS files — rewrite the comment to convey the intent "
-        "directly without the [[slug]] form.",
+        "directly without the [[slug]] form or a path into the memory store.",
         file=sys.stderr,
     )
     for rel, lineno, snippet in findings:

--- a/.github/scripts/check-no-memory-slugs.py
+++ b/.github/scripts/check-no-memory-slugs.py
@@ -138,7 +138,7 @@ _HOME_RE = re.compile(r"(?<![A-Za-z0-9])(home|Users)([/-])[^/\s-]+")
 
 
 def redact(snippet: str) -> str:
-    """把家目录用户名换掉。两种写法都要:路径形 `/home/x/`，和 Claude
+    """把家目录用户名换掉。两种写法都要:路径形 `/home/<user>/`，和 Claude
     project 目录名里连字符编码的那份 `-home-x-agent-…`。"""
     return _HOME_RE.sub(r"\1\2<user>", snippet)
 
@@ -208,5 +208,48 @@ def main() -> int:
     return 1
 
 
+
+# ---------------------------------------------------------------------------
+# selftest —— 没有它,这道门的「更宽了」是一句无法验证的话。
+#
+# 🔴 为什么用合成串而不是提交夹具文件:一个含真实形状的夹具文件**自己就是命中**,
+#    提交进来要么让门永远红,要么得进 allowlist —— 而进了 allowlist 就再也
+#    测不到它。所以夹具在代码里造,不落盘。
+#
+# 三条红夹具的形状,来自 2026-08-16 在本仓实测到的三种真实写法
+# (它们当时**一条都没被 SLUG_RE 命中**):
+#     markdown 链接 / 反引号裸路径 / 带用户名的绝对路径
+# ---------------------------------------------------------------------------
+def _selftest() -> int:
+    cases = []
+
+    def ck(name, text, want_hit):
+        hit = bool(SLUG_RE.search(text)) or bool(MEMORY_PATH_RE.search(text))
+        ok = hit == want_hit
+        cases.append((name, ok, f"hit={hit} want={want_hit}"))
+
+    # —— 红:四种形状都必须命中 ——
+    ck("[[slug]] 原形",              "见 [[" + "feedback_no_test_on_prod]]", True)
+    ck("markdown 链接指向 memory 库", "see [m](../.claude/memory/x.md)", True)
+    ck("反引号裸路径(~ 开头)",        "见 `~/.claude/memory/MEMORY.md`", True)
+    ck("绝对路径带用户名",            "见 `/home/someone/.claude/projects/-home-someone-x/memory/MEMORY.md`", True)
+    ck("agent-orchestra/memory/ 形态", "(../../agent-orchestra/memory/feedback_x.md)", True)
+
+    # —— 绿:这些**不该**命中,否则门会在正当写法上常红,然后被所有人忽略 ——
+    ck("普通家目录路径(与 memory 无关)", "/home/testuser/project/src/main.ts", False)
+    ck("普通 .claude 配置路径",          "~/.claude/settings.json", False)
+    ck("只是提到 memory 这个词",         "the agent memory design is documented here", False)
+    ck("别的 memory 目录",               "src/memory/store.ts", False)
+
+    for n, ok, d in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {n}   [{d}]")
+    bad = sum(1 for _n, ok, _d in cases if not ok)
+    print(f"selftest: {len(cases) - bad}/{len(cases)} ok")
+    return 1 if bad else 0
+
+
 if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        sys.exit(_selftest())
+
     sys.exit(main())

--- a/docs/home-path-baseline.txt
+++ b/docs/home-path-baseline.txt
@@ -35,7 +35,6 @@ docs/research/sdk-concurrency-investigation.md	1
 docs/rfcs/RFC-005-codex-code-cli-runtime.md	1
 docs/runbooks/opencode-tui-copresence.md	1
 docs/sdk-upgrade-2026-05-12-baseline.md	4
-docs/team-collab-playbook.md	1
 docs/tests/p-498-reply-warning/witnessed-red.txt	1
 docs/tests/p-517-mcp-write-scope/witnessed-red-p2-ghost.txt	3
 docs/tests/p-517-mcp-write-scope/witnessed-red-pins-sabotage.txt	21

--- a/docs/team-collab-playbook.md
+++ b/docs/team-collab-playbook.md
@@ -365,4 +365,4 @@ Vincent 报"拓扑图丑" → 一边开 #112 修一处一边开 #113 修一处 �
 ---
 
 *维护：通信龙 · 团队：anet*
-*相关 memory：见 `/home/vansin/.claude/projects/-home-vansin-agent-orchestra/memory/MEMORY.md`*
+*相关 memory：维护者本地的 agent 记忆库（不在本仓内，路径随机器而异）*


### PR DESCRIPTION
## 🔴 这个修复不是新写的 —— 它 2026-08-16 就 commit 了,在两条分支上,**从没进过 main**

```
2b612140  2026-08-16T12:15:36+08:00
fix(guard): memory 泄漏门只认 [[slug]] 形状——同一件事写成路径就穿过去了

git merge-base --is-ancestor 2b612140 origin/main   →  ⬜ 不在 main 上
git branch -a --contains 2b612140                   →  fix/860-qa-paths
                                                       integration/tip-2026-08-16
```

`git cherry-pick -x 2b612140` **干净应用**,零冲突。

## 而它守的那件事,此刻就在公开仓的 main 上

`docs/team-collab-playbook.md:368`(脱敏后):

```
*相关 memory：见 `/home/<user>/.claude/projects/-home-<user>-agent-orchestra/memory/MEMORY.md`*
```

**同一个用户名在同一行里出现两次** —— 一次在 `/home/<user>/`,一次被编码进 project 目录名。

A/B(同一棵 `origin/main` 的树):

```
main 现在的判据   →  rc=0    "OK: no internal memory-slug references found"
2b612140 的判据   →  rc=1    docs/team-collab-playbook.md:368
```

🔴 **绿在这里的含义是「没有那个形状」,不是「没有那件事」。**

## 我补的两件事

### ① selftest(9 条)—— 否则「更宽了」是一句无法验证的话

三条红夹具的形状来自 2026-08-16 实测到的三种真实写法(**当时一条都没被 `SLUG_RE` 命中**):

```
ok  [[slug]] 原形
ok  markdown 链接指向 memory 库
ok  反引号裸路径(~ 开头)
ok  绝对路径带用户名
ok  agent-orchestra/memory/ 形态
```

四条绿夹具钉住它**不该**在正当写法上红:

```
ok  普通家目录路径(与 memory 无关)     /home/testuser/project/src/main.ts
ok  普通 .claude 配置路径              ~/.claude/settings.json
ok  只是提到 memory 这个词
ok  别的 memory 目录                   src/memory/store.ts
```

**一道在正当写法上常红的门,只会教会所有人忽略它的输出。**

🔴 **夹具用合成串造,不落盘。** 一个含真实形状的夹具**文件**自己就是命中 —— 提交进来要么让门永远红,要么得进 allowlist,**而进了 allowlist 就再也测不到它**。

**变异验证**:把 `MEMORY_PATH_RE` 改成永不命中 → selftest **rc=1,3 条 FAIL**;还原 → **rc=0**。

### ② `home-path-baseline` 红了,而且红得对

它指出**我自己新写的 selftest** 里 `/home/tester/...` 不在 `NOT_A_PERSON` 白名单里。**对一个公开仓来说那是正确判法** —— 它分不出「我编的名字」和「真人」。统一成 `<user>` / `testuser`。

同时 `docs/team-collab-playbook.md` 从 1 降到 0,按 baseline 规则整行删:

```
200 次 / 70 文件  →  199 次 / 69 文件
```

**这是今天这道门第三次拦住我。** 它是结实的。

## 归属

原 commit 作者不是我;我只做了 cherry-pick + selftest + 占位名统一。红夹具的形状与 `通信文档马` 今天独立构造的三种完全一致 —— **两条独立路径指向同一个洞。**

## 门(先 `git add` 再跑)

```
check-no-memory-slugs.py --selftest   rc=0   9/9
check-no-memory-slugs.py              rc=0
check-home-path-baseline.py           rc=0   199 / 69
check-public-script-safety.py         rc=0
check-doc-symbol-anchors.py           rc=0
check-docs-integrity.py               rc=0
check-workflow-structure.py           rc=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
