### PR TITLE
test(e2e): suite 报 0 ran 时,把它自己的输出打出来

### DIFF
--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -26,6 +26,22 @@ run_suite() {
     TOTAL_FAIL=$((TOTAL_FAIL + 1))
     SUITES+=("$STATUS $NAME: SKIPPED/CRASHED (0 ran — Results line missing, suite likely exited early)")
     echo "  $STATUS WARNING: 0 ran (suite crashed or Results line missing)"
+    # 🔴 0 ran 时把 suite 自己的输出吐出来。
+    #
+    #    这个分支此前只说「它崩了」，不说崩在哪 —— 而 OUTPUT 是被捕获的，
+    #    于是唯一知道原因的那份内容被丢掉了。2026-08-18 一次 PR 让 5 个 suite
+    #    同时 0 ran，日志里「━━━ Base E2E ━━━」和「⚠️ 0 ran」之间**一行都没有**，
+    #    排查只能靠猜。
+    #
+    #    只在 0 ran 这条路径上打印，正常/失败路径都不受影响：绿的时候不刷屏，
+    #    而真的崩了时，日志里第一次有了可读的原因。
+    #    尾部 40 行足够看到 shell 的最后一句错；开头 10 行用来分辨
+    #    「一开始就没起来」和「跑到一半死了」——两者的下一步完全不同。
+    echo "  ── suite 自己的输出（前 10 行）──"
+    printf '%s\n' "$OUTPUT" | head -10 | sed 's/^/  | /'
+    echo "  ── suite 自己的输出（后 40 行）──"
+    printf '%s\n' "$OUTPUT" | tail -40 | sed 's/^/  | /'
+    echo "  ── 输出共 $(printf '%s\n' "$OUTPUT" | wc -l) 行 ──"
     echo ""
     return
   fi


### PR DESCRIPTION
## 起因:今天我自己撞上了这个盲区

一条 PR 让 7 个 suite 里 **5 个同时 `0 ran`**。日志长这样:

```
━━━ Base E2E (137) ━━━
  ⚠️ WARNING: 0 ran (suite crashed or Results line missing)

━━━ V3 Auth (25) ━━━
  ✅ 25 passed, 0 failed
```

🔴 **「━━━ Base E2E ━━━」和「⚠️ 0 ran」之间一行都没有。**

而 `run_suite` 里明明有:

```sh
OUTPUT=$(eval "$CMD" 2>&1)
```

⇒ **唯一知道原因的那份内容被捕获了,然后在 0-ran 分支上被丢掉。**

我为此排除了三个候选(构建里的 `cp`、垫片本身、shebang),**每一个都花了一次 Docker 往返,而答案本来就在那段被丢掉的输出里。**

## 改动

只在 `TOTAL_RUN -eq 0` 这条路径上打印。**绿的时候不刷屏,正常失败路径也不受影响。**

## 为什么是「前 10 行 + 后 40 行」而不是只取尾部

```
一开始就没起来   →  头部有线索（command not found / 连不上 hub / 权限）
跑到一半死了     →  尾部有线索（最后一个断言、shell 的最后一句错）
```

**这两者的下一步完全不同,而只看尾部分不出来。**

## 本地验证(红绿都跑了)

**红** —— 合成一个 `exit 127` 且不打 Results 行的 suite:

```
━━━ Fake (99) ━━━
  ⚠️ WARNING: 0 ran (suite crashed or Results line missing)
  ── suite 自己的输出（前 10 行）──
  | starting fake suite
  | connecting...
  | FATAL: anet: command not found
  ── suite 自己的输出（后 40 行）──
  | …
  ── 输出共 3 行 ──
```

**绿(负对照)** —— 正常 suite(`Results: 5 passed, 0 failed`):输出与改动前**逐字相同**。

## 与 #928 / #924 同一根线

`#928` 是「摘要说 `0 pass 1 fail`,真相是 5 个只注册到 1 个」;`#924` 是「suite 早退,而诊断文案指向超时」。**这条补的是它们共同缺的那一格:崩了的时候,把它自己说过的话留下来。**

## 门

```
check-public-script-safety.py  rc=0
check-no-memory-slugs.py       rc=0
check-home-path-baseline.py    rc=0
check-doc-symbol-anchors.py    rc=0
check-workflow-structure.py    rc=0
bash -n tests/test-all.sh      OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
