### PR TITLE
test(e2e): 0 ran 时同时记下退出码,并把它翻译成下一步

### DIFF
--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -15,6 +15,16 @@ run_suite() {
   local CMD="$2"
   echo "━━━ $NAME ━━━"
   OUTPUT=$(eval "$CMD" 2>&1)
+  # 🔴 退出码必须在这里取:下一条命令就会覆盖 $?。
+  #    2026-08-18:5 个 suite 同时 0 ran，加了输出转储（上一条改动）之后仍然
+    # 看不出死因——它们各自只打印了自己的横幅就没了，没有任何错误行。
+  #    「正常退出但没打 Results」和「被信号打死」在输出上完全一样，
+  #    而这两者的下一步完全不同。退出码是唯一能分开它们的东西：
+  #      0     跑完了但没产出 Results 行（解析/格式问题）
+  #      1-125 脚本自己 exit 的
+  #      127   command not found
+  #      >128  被信号打死（128+N，如 137=SIGKILL、143=SIGTERM）
+  SUITE_RC=$?
   PASS=$(echo "$OUTPUT" | grep -oP '\d+(?= passed)' | tail -1)
   FAIL=$(echo "$OUTPUT" | grep -oP '\d+(?= failed)' | tail -1)
   PASS=${PASS:-0}; FAIL=${FAIL:-0}
@@ -41,7 +51,15 @@ run_suite() {
     printf '%s\n' "$OUTPUT" | head -10 | sed 's/^/  | /'
     echo "  ── suite 自己的输出（后 40 行）──"
     printf '%s\n' "$OUTPUT" | tail -40 | sed 's/^/  | /'
-    echo "  ── 输出共 $(printf '%s\n' "$OUTPUT" | wc -l) 行 ──"
+    echo "  ── 输出共 $(printf '%s\n' "$OUTPUT" | wc -l) 行，退出码 $SUITE_RC ──"
+    if [ "$SUITE_RC" -gt 128 ]; then
+      echo "  🔴 退出码 $SUITE_RC > 128 ⇒ 它是被信号打死的（SIG$((SUITE_RC - 128))），不是自己退的。"
+      echo "     查谁发的信号，而不是查它自己的逻辑。"
+    elif [ "$SUITE_RC" -eq 127 ]; then
+      echo "  🔴 退出码 127 ⇒ command not found。查 PATH / 那个命令装没装上。"
+    elif [ "$SUITE_RC" -eq 0 ]; then
+      echo "  🔴 退出码 0 但没有 Results 行 ⇒ 它跑完了，是产出格式的问题，不是崩溃。"
+    fi
     echo ""
     return
   fi


### PR DESCRIPTION
## #959 之后我仍然看不出死因

把 suite 自己的输出打出来之后,拿到的是这个:

```
━━━ Base E2E (137) ━━━
  ⚠️ WARNING: 0 ran
  ── suite 自己的输出（前 10 行）──
  | =========================================
  |   anet Docker E2E Test Suite
  | =========================================
  | 1. Starting CommHub server...
  | [commhub] database: /root/.commhub/commhub.db
  | error: Failed to start server. Is port 9200 in use?      ← 这条是噪音，见下
  ── 输出共 13 行 ──
```

**5 个 suite 各自只打印了自己的横幅就没了,没有任何错误行。**

(那条 `EADDRINUSE` 是**噪音**:`test-all.sh` 的 `reset_server()` 已经在 9200 上起了一个,而 `docker-e2e.sh:19` 还会再背景起一个 —— 它必然 EADDRINUSE、必然退出,然后 suite 用已有的那个继续。这是设计如此,`reset_server` 上面那段注释写了。)

## 缺的那一格

**「正常退出但没打 Results」和「被信号打死」在输出上完全一样。** 而这两者的下一步完全不同:

```
0     跑完了但没产出 Results 行  → 产出格式问题，不是崩溃
127   command not found          → 查 PATH / 那个命令装没装上
>128  被信号打死（128+N）        → 查谁发的信号，不是查它自己的逻辑
```

**退出码是唯一能把它们分开的东西,而 `run_suite` 此前一个字都没记。**

## 🔴 `SUITE_RC=$?` 的位置是有讲究的

必须**紧跟**在 `OUTPUT=$(eval "$CMD" 2>&1)` 后面 —— **下一条命令就会覆盖 `$?`**。

这正是这个仓今天已经踩过两次的坑(`cmd | tail; echo $?` 抓的是 `tail` 的退出码)。写在这里是为了让下一个改这个函数的人看见。

## 三态本地验证

```
kill -9 $$                → 退出码 137 → 🔴 被信号打死（SIG9），不是自己退的
不存在的命令 + exit 127   → 退出码 127 → 🔴 command not found
exit 0 且不打 Results     → 退出码 0   → 🔴 跑完了，是产出格式的问题
```

**三种都真跑过,不是照着写的。**

## 它要回答的那个具体问题

`#958` 的 5 个 suite 现在是「横幅之后什么都没有」。加上退出码之后,下一次复跑就能直接分辨:

- 是它们**自己 exit 了**(那就查脚本逻辑),
- 还是**被打死了**(那就查是谁 —— 而 `test-all.sh` 里确实有 `kill -KILL "$SERVER_PID"`)。

**在能分辨之前,我不打算继续猜 #958 的根因。**

## 门

```
check-public-script-safety.py  rc=0
check-no-memory-slugs.py       rc=0
check-home-path-baseline.py    rc=0
check-workflow-structure.py    rc=0
bash -n tests/test-all.sh      OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
