### PR TITLE
ci: 新增的 Dockerfile 不许再用未钉版本的 bun.sh/install (#728)

### DIFF
--- a/.github/scripts/check-bun-install-pin.py
+++ b/.github/scripts/check-bun-install-pin.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""新增的 Dockerfile 不许再用未钉版本的 `bun.sh/install`。
+
+背景(#728)
+==========
+
+`curl -fsSL https://bun.sh/install | bash` 装到什么版本**取决于构建那一刻上游是什么**。
+同一个 commit 在不同时间构建,会跑在不同字节上 —— 而这类差异**只在出问题时才被发现**,
+且第一反应永远是"代码变了吗",不是"bun 变了吗"。
+
+仓里已经有做对的样板(`tests/test679-task-trace/Dockerfile`):
+
+    ARG BUN_VERSION=1.3.14
+    ARG BUN_LINUX_X64_SHA256=951ee2…
+    RUN curl --fail … --retry 3 … "…/bun-v${BUN_VERSION}/bun-linux-x64.zip" -o /tmp/bun.zip \\
+     && echo "${BUN_LINUX_X64_SHA256}  /tmp/bun.zip" | sha256sum -c - …
+
+🔴 这道门**不要求存量清零**,理由与 `check-home-path-baseline.py` 头注写的同一条
+===========================================================================
+
+实测(2026-08-18,origin/main):**38 个 Dockerfile 引用 `bun.sh/install`,其中只有 1 个钉了。**
+
+一道要求"37 个全清"的门,会从第一天起就是红的;而**一道只因积压而红的门,等积压清完
+就再也不会红,到时没人知道它还有没有效**。所以基线制:**今天这 37 个记在案,新增的才红。**
+
+清理是欢迎的 —— 清掉一个就把它从基线里删掉,楼层只往下走、不会悄悄回填。
+
+判据
+====
+
+对每个 tracked 的 Dockerfile(含 `Dockerfile.*` 变体):
+
+  引用了 bun.sh/install  且  没有任何钉版本的证据  ⇒ 未钉
+
+"钉版本的证据"任一即可(**故意写宽**:目的是挡"什么都没做",不是规定唯一写法):
+  - `BUN_VERSION` / `BUN_INSTALL_VERSION` 之类的版本变量
+  - `bun-v<数字>` 形式的下载 URL
+  - `sha256`(校验和)
+
+分母承重
+========
+
+🔴 扫到 0 个 Dockerfile,或基线文件读不到 ⇒ exit 2。
+"没有新增违规"和"根本没扫到"必须长得不一样。
+
+用法
+====
+
+    python3 .github/scripts/check-bun-install-pin.py
+    python3 .github/scripts/check-bun-install-pin.py --selftest
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+BASELINE = "docs/bun-install-pin-baseline.txt"
+
+USES_INSTALLER = re.compile(r"bun\.sh/install")
+PINNED_HINTS = (
+    re.compile(r"BUN_VERSION|BUN_INSTALL_VERSION"),
+    re.compile(r"bun-v[0-9]"),
+    re.compile(r"(?i)sha256"),
+)
+
+
+def is_dockerfile(path: str) -> bool:
+    name = Path(path).name
+    return name == "Dockerfile" or name.startswith("Dockerfile.")
+
+
+def is_pinned(text: str) -> bool:
+    return any(p.search(text) for p in PINNED_HINTS)
+
+
+def uses_installer(text: str) -> bool:
+    return bool(USES_INSTALLER.search(text))
+
+
+def unpinned(text: str) -> bool:
+    return uses_installer(text) and not is_pinned(text)
+
+
+def selftest() -> int:
+    cases = []
+
+    def ck(name, text, want):
+        got = unpinned(text)
+        cases.append((name, got == want, f"got={got} want={want}"))
+
+    ck("裸装 → 未钉", "RUN curl -fsSL https://bun.sh/install | bash", True)
+    ck("带 BUN_VERSION → 已钉", "ARG BUN_VERSION=1.3.14\nRUN curl https://bun.sh/install | bash", False)
+    ck("带 sha256 → 已钉", "RUN curl https://bun.sh/install | bash && sha256sum -c -", False)
+    ck("下载 URL 带 bun-v → 已钉", "RUN curl .../bun-v1.3.14/bun-linux-x64.zip", False)
+    # 🔴 负向:压根不装 bun 的 Dockerfile 不该被这道门碰到
+    ck("不引用安装器 → 不判", "FROM node:22\nRUN npm ci", False)
+    ck("只提到 bun 这个词 → 不判", "# bun is faster\nFROM node:22", False)
+
+    for n, ok, d in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {n}   [{d}]")
+    bad = sum(1 for _n, ok, _d in cases if not ok)
+    print(f"selftest: {len(cases) - bad}/{len(cases)} ok")
+    return 1 if bad else 0
+
+
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+
+    repo = Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True, check=True).stdout.strip())
+    tracked = subprocess.run(["git", "ls-files", "-z"], cwd=repo,
+                             capture_output=True, text=True, check=True).stdout.split("\0")
+    dockerfiles = sorted(p for p in tracked if p and is_dockerfile(p))
+    if not dockerfiles:
+        print("FAIL: 一个 Dockerfile 都没扫到 —— 取集塌了,拒绝通过", file=sys.stderr)
+        return 2
+
+    base_path = repo / BASELINE
+    if not base_path.is_file():
+        print(f"FAIL: 读不到基线 {BASELINE} —— 拒绝通过", file=sys.stderr)
+        return 2
+    known = {ln.strip() for ln in base_path.read_text(encoding="utf-8").split("\n")
+             if ln.strip() and not ln.startswith("#")}
+
+    current = set()
+    for f in dockerfiles:
+        try:
+            text = (repo / f).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if unpinned(text):
+            current.add(f)
+
+    new = sorted(current - known)
+    fixed = sorted(known - current)
+
+    print(f"scanned {len(dockerfiles)} tracked Dockerfile(s); "
+          f"{len(current)} still install bun unpinned; baseline lists {len(known)}")
+    if fixed:
+        print(f"note: {len(fixed)} file(s) got pinned — 把它们从 {BASELINE} 里删掉,楼层只往下走:")
+        for f in fixed:
+            print(f"  - {f}")
+    if new:
+        for f in new:
+            print(f"::error file={f}::新增了未钉版本的 `bun.sh/install`。"
+                  f"照 tests/test679-task-trace/Dockerfile 的样板钉 BUN_VERSION + sha256。")
+        print(f"\n{len(new)} new unpinned file(s).")
+        return 1
+    print("no new unpinned bun installer.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/bun-install-pin.yml
+++ b/.github/workflows/bun-install-pin.yml
@@ -1,0 +1,31 @@
+# 新增的 Dockerfile 不许再用未钉版本的 `bun.sh/install`。见 #728。
+#
+# 🔴 刻意不加 paths 过滤。
+#
+#   这道门要挡的是「有人新写了一个 Dockerfile」,而新 Dockerfile 可能出现在任何目录
+#   （实测 225 个 tracked Dockerfile 散在 tests/ docker/ docs/ deploy/ 下）。
+#   按路径过滤等于提前假设它们会出现在哪儿 —— 而那正是「改扫描范围让门悄悄失效」的形状。
+#   脚本本身不联网、跑完不到一秒，省这点没有意义。
+#
+#   另一个理由:带 paths 过滤的 workflow **结构上当不了 required check** ——
+#   它在不匹配的 PR 上根本不产生 check，分支保护会永远停在 "Expected — Waiting for status"。
+
+name: lint (bun install pin)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    # 这个 name 是 GitHub 上 check 的名字，也是分支保护里 required check 唯一能写的
+    # 标识符，必须全仓唯一。
+    name: bun-install-pin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # 先跑判据自检。这道门最可能的坏法不是判据写错，是**一个 Dockerfile 都没扫到**
+      # 然后打印一片绿 —— 那种假绿和真绿逐字相同。主程序对此 exit 2 而不是 exit 0。
+      - run: python3 .github/scripts/check-bun-install-pin.py --selftest
+      - run: python3 .github/scripts/check-bun-install-pin.py

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ docs/dashboard-screenshots/
 
 # RFC-030 live demo (hub db + node config w/ ntok — never commit)
 .demo/
+
+# 🔴 本仓的门都是 .github/scripts/*.py。用 `python3 <script>` 跑不会产生 __pycache__，
+#    但只要有人 import 它们（生成基线、写 selftest、在别的脚本里复用判据）就会产生。
+#    2026-08-18 我生成 bun-pin 基线时就撞了一次 —— 当时是手动 rm 掉的，
+#    而「靠人记得手动删」不是一个能长期成立的安排。
+__pycache__/
+*.pyc

--- a/docs/bun-install-pin-baseline.txt
+++ b/docs/bun-install-pin-baseline.txt
@@ -1,0 +1,43 @@
+# 每行一个：**当前**仍用未钉版本 `bun.sh/install` 的 Dockerfile。
+# 这是一个**上限**，不是目标。它存在的意义是让「新增」变红，而不是让「存量」变红——
+# 一道只因积压而红的门，等积压清完就再也不会红，到时没人知道它还有没有效。
+# 钉好某个文件之后，把它这一行删掉，楼层就只会往下走、不会悄悄回填。
+# 生成于 origin/main，2026-08-18：37 个未钉 / 共扫 225 个 Dockerfile。
+# 样板见 tests/test679-task-trace/Dockerfile（BUN_VERSION + sha256sum -c + --retry）。
+docker/feishu/Dockerfile
+docs/tests/p-214-dim12-harness/Dockerfile.node22
+docs/tests/p-214-dim12-harness/Dockerfile.node24
+docs/tests/p-214-dim12-harness/Dockerfile.upgrade
+docs/tests/p-214-wave2-harness/Dockerfile.7fix
+docs/tests/p-214-wave2-harness/Dockerfile.node22
+docs/tests/p-214-wave2-harness/Dockerfile.node24
+docs/tests/p-214-wave2-harness/Dockerfile.upgrade
+docs/tests/p-ga2-compat-repro/Dockerfile.aligned
+docs/tests/p-ga2-compat-repro/Dockerfile.mixed
+tests/qa-222-cross-host-attachments/Dockerfile
+tests/qa-anet-daemon-cmd/Dockerfile
+tests/qa-hub-10-network-scope-regressions/Dockerfile
+tests/qa-hub-11-node-delete-sse/Dockerfile
+tests/qa-hub-12-servers-endpoint/Dockerfile
+tests/qa-hub-13-server-health-agents/Dockerfile
+tests/qa-hub-16-rest-task-api/Dockerfile
+tests/qa-hub-18-delivery-semantics/Dockerfile
+tests/qa-hub-19-login-guard/Dockerfile
+tests/qa-node-04-codex-app-server-reply-routing/Dockerfile
+tests/qa-rfc024-config-apply/Dockerfile
+tests/qa-rfc026-create-node/Dockerfile
+tests/qa-rfc027-stop-delete/Dockerfile
+tests/qa-rfc028-provider-probe/Dockerfile
+tests/test-goal-cli/Dockerfile
+tests/test-grok-build-acp-runtime/Dockerfile
+tests/test185-external-schedules/Dockerfile
+tests/test219-grok-copresence/Dockerfile
+tests/test225-grok-preview-package-live/Dockerfile
+tests/test28-demo-debate-v2.1.2/Dockerfile
+tests/test28-pr-review-room/Dockerfile
+tests/test30-v0.8-auth-deprecation/Dockerfile
+tests/test380-daemon-telemetry-probe/Dockerfile
+tests/test384-opencode-local-package-e2e/Dockerfile
+tests/test466-codex-copresence-p3/Dockerfile
+tests/test673-claude-image-attachment-block/Dockerfile
+tests/test681-explicit-lifecycle/Dockerfile


### PR DESCRIPTION
## 数字(用门自己的判据数的,不是自造)

```
scanned 225 tracked Dockerfile(s); 37 still install bun unpinned; baseline lists 37
```

**225 个 Dockerfile 里 38 个引用 `bun.sh/install`,只有 1 个钉了版本**(`tests/test679-task-trace/Dockerfile`)。

## 🔴 为什么是基线制,而不是要求清零

一道要求「37 个全清」的门,**会从第一天起就是红的**。而这个仓自己在 `check-home-path-baseline.py` 头注里把后果写透了:

> 一道只因积压而红的门,等积压清完就再也不会红,**到时没人知道它还有没有效**。

所以:**今天这 37 个记在案,新增的才红。** 清掉一个就从基线里删一行 —— 楼层只往下走、不会悄悄回填(门会主动提示你去删)。

## 判据故意写宽

`BUN_VERSION` / `bun-v<数字>` 的下载 URL / `sha256` —— **任一即可**。

**目的是挡「什么都没做」,不是规定唯一写法。** 一道在正当写法上常红的门只会教会所有人忽略它。

## 四态实测

```
基线就位                      rc=0   37/37 对上
新增一个未钉的 Dockerfile      rc=1   ::error 指名文件 + 指向样板
把它钉上（加 BUN_VERSION）     rc=0
基线文件读不到                 rc=2   不是 rc=0 ← 分母承重
```

**selftest 6 条**,含**两条负向**:

```
ok  不引用安装器 → 不判        FROM node:22 / RUN npm ci
ok  只提到 bun 这个词 → 不判   # bun is faster
```

## workflow 刻意不加 `paths` 过滤,两个理由

1. **这道门要挡的是「有人新写了一个 Dockerfile」,而新 Dockerfile 可能出现在任何目录** —— 实测 225 个散在 `tests/` `docker/` `docs/` `deploy/` 下。按路径过滤等于提前假设它们会出现在哪儿,**那正是「改扫描范围让门悄悄失效」的形状**。
2. **带 `paths` 过滤的 workflow 结构上当不了 required check** —— 它在不匹配的 PR 上根本不产生 check,分支保护会永远停在 `Expected — Waiting for status`。

脚本不联网,跑完不到一秒。

## 门

```
check-workflow-structure.py    rc=0
check-action-pins.py           rc=0
check-public-script-safety.py  rc=0
check-no-memory-slugs.py       rc=0
check-home-path-baseline.py    rc=0
check-doc-symbol-anchors.py    rc=0
```

## 不在本 PR 范围

**37 个存量一个都没改。** 那是逐个的构建改动,每个都要单独验「改前改后产出等价」(样板那个文件的注释里就记了这一步:「隔离验证过:改前改后都得到 bun 1.3.14、同在 `/root/.bun/bin/bun`,产出等价」)。**先止血,再清创。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
