### PR TITLE
ci: 让 docs-site 在 CI 里真的构建一次（死链/skillhub catalog 目前只有 Vercel 部署会发现）

### DIFF
--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -1,0 +1,83 @@
+# docs-site 必须真的构建得出来。
+#
+# 2026-08-18 —— 仓里没有任何 CI 跑过 `vitepress build`。三条工作流的名字里带
+# docs-site,但它们做的是别的事:qa.yml 只是把 `docs-site/**` 列进 paths 触发器,
+# public-script-safety 看 public/ 下的脚本,published-artifact-drift 跑
+# check-docs-site-drift.py(比对已发布产物,不构建)。
+#
+# 也就是说,**唯一会构建这个站点的地方是 Vercel 的部署**。构建失败的第一个知情者
+# 是「线上没更新」,而不是 PR 上的一个红叉。
+#
+# 🔴 这道门抓的主要是死链,而死链检查不是我加的判据 —— 是 VitePress 自带的、
+#    默认开启的(config.ts 没有 ignoreDeadLinks)。实测过它确实会红:
+#
+#      把 docs-site/docs/api/mcp-tools.md 里 `](/troubleshooting)` 改成
+#      `](/definitely-not-a-page-xyz)`:
+#
+#        (!) Found dead link /definitely-not-a-page-xyz in file api/mcp-tools.md
+#        [vitepress] 1 dead link(s) found.
+#        ✗ Build failed in 24.43s        rc=1
+#
+#    改回去之后 rc=0、build complete in 37.45s。**见证红在见证绿之前。**
+#
+# 🔴 顺带一句方法论,因为我今天在这上面栽了一次:我先自己写了个"相对链接是否
+#    存在"的扫描器,它报了 **671 条断链**。真跑 `vitepress build` 是 **0 条**。
+#    我那个判据把 `/concepts/task-lifecycle` 这种**站点绝对路由**当成了文件系统
+#    相对路径 —— 数字不是算错的,是量错了对象。所以这里跑的是产品自己的构建,
+#    不是我重写一遍它的判据。
+#
+# 🔴 起点是绿的,不是积压金丝雀:main 上 build rc=0 / 0 dead links / 95 个页面。
+#    红了就意味着刚刚有东西被改坏。
+#
+# 关于 paths 过滤:刻意不加。`npm run build` 的全部输入都在 docs-site/ 下
+# (prebuild 的 build-public-skillhub.mjs 只读 docs-site/docs/public/skillhub/),
+# 所以按 `docs-site/**` 过滤在**触发**上是正确的 —— 但带 paths 的工作流在分支保护里
+# 做不成 required check(它不触发时会永远停在 "Expected — Waiting for status")。
+# 这道门将来要能被设成必需,所以宁可每个 PR 都跑这两分钟。
+
+name: docs-site build
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    # 这个 name 是分支保护里 required check 唯一能写的标识符,必须全仓唯一。
+    name: docs-site-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install (locked)
+        run: npm ci
+        working-directory: docs-site
+
+      # 🔴 顺序不能反。`npm run build` 的 prebuild 会**重新生成** catalog.json,
+      #    生成之后再检查就永远一致 —— 那是一道恒真的门。所以先拿仓里提交的
+      #    那一份对源目录做校验,再让 build 去覆盖它。
+      - name: skillhub catalog is current (before build regenerates it)
+        run: npm run skillhub:check
+        working-directory: docs-site
+
+      - name: vitepress build (dead links are fatal by default)
+        run: npm run build
+        working-directory: docs-site
+
+      # 分母承重:上面那步在 docs/ 被清空时**也会 rc=0** —— 0 个页面、0 条死链,
+      # 打印出来和真绿几乎一样。把「磁盘上有几篇 md」和「渲染出几个 html」绑在一起。
+      - name: rendered-page denominator
+        run: |
+          set -euo pipefail
+          md=$(git ls-files docs-site/docs | grep -c '\.md$')
+          html=$(find docs-site/docs/.vitepress/dist -name '*.html' | wc -l | tr -d ' ')
+          echo "tracked_md=$md rendered_html=$html"
+          FLOOR=80
+          [ "$md" -ge "$FLOOR" ] || { echo "FAIL: only $md tracked .md under docs-site/docs, floor is $FLOOR" >&2; exit 1; }
+          [ "$html" -ge "$md" ] || { echo "FAIL: rendered $html page(s) but $md .md exist — 渲染范围塌了" >&2; exit 1; }


### PR DESCRIPTION
## 这道门补的是哪一格

仓里**没有任何 CI 跑过 `vitepress build`**。三条工作流的名字里带 `docs-site`,但它们做的是别的事:

| 工作流 | 它对 docs-site 做的事 |
|---|---|
| `qa.yml` | 只是把 `docs-site/**` 列进 **paths 触发器** |
| `public-script-safety.yml` | 看 `docs-site/docs/public/**` 下的脚本 |
| `published-artifact-drift.yml` | 跑 `check-docs-site-drift.py` —— 比对已发布产物,**不构建** |

```
$ grep -rn "vitepress build\|npm run build" .github/
（无输出）
```

也就是说,**唯一会构建这个站点的地方是 Vercel 的部署**。构建失败的第一个知情者是「线上没更新」,而不是 PR 上的一个红叉。

## 判据不是我写的 —— 是 VitePress 自带的

`docs-site/docs/.vitepress/config.ts` 没有 `ignoreDeadLinks`,所以死链默认致命。**见证红在见证绿之前:**

把 `docs-site/docs/api/mcp-tools.md` 里 `](/troubleshooting)` 改成一个不存在的路由:

```
(!) Found dead link /definitely-not-a-page-xyz in file api/mcp-tools.md
✗ Build failed in 24.43s
[vitepress] 1 dead link(s) found.
rc=1
```

改回去(`sha256` 确认字节复原):

```
build complete in 37.45s        rc=0
tracked_md=94 rendered_html=95
```

## 🔴 顺带记一条方法:我差点用自己写的判据代替这道门

我先自己写了个「相对链接是否存在」的扫描器,它报了 **671 条断链**。真跑 `vitepress build` 是 **0 条**。

我那个判据把 `/concepts/task-lifecycle` 这种**站点绝对路由**当成了文件系统相对路径。**数字不是算错的,是量错了对象。** 671 和 0 差了两个数量级,大到我不可能忽略;要是它报的是 3 条,我大概就直接开 issue 去"修"那三条了。

所以这个 job 跑的是 `npm run build` 本身。

## 两处刻意的选择

**① `skillhub:check` 必须在 `build` 之前。**
`npm run build` 的 `prebuild` 会**重新生成** `catalog.json`。生成之后再检查它是否 current,那是一道**恒真**的门。所以先拿仓里提交的那一份对源目录校验,再让 build 去覆盖。(这条 check 目前也没有被任何 CI 跑过,本机实测 `PASS (2 entries, catalog current)`。)

**② 不加 `paths` 过滤。**
`npm run build` 的全部输入都在 `docs-site/` 下(prebuild 只读 `docs-site/docs/public/skillhub/`),所以按 `docs-site/**` 过滤在**触发**上是正确的。但带 `paths` 的工作流在分支保护里**做不成 required check** —— 不触发时会永远停在 `Expected — Waiting for status`。这道门将来要能被设成必需,所以宁可每个 PR 都跑这两分钟。

## 分母承重

`docs-site/docs` 被清空时,`vitepress build` **照样 rc=0** —— 0 个页面、0 条死链,打印出来和真绿几乎一样。所以最后一步把「磁盘上有几篇 md」和「渲染出几个 html」绑在一起,并加了一个**绝对下限 80**(当前 94/95)—— 只比两个数相等,抓得到「渲染器跳过了文件」,抓不到「文件被删了」,因为分母会跟着现实一起缩水。

## 起点是绿的

main 上 `build rc=0` / 0 dead links / 95 个页面。**它不是积压金丝雀** —— 红了就意味着刚刚有东西被改坏,而不是「还有一堆没清」。

## 关联

- #887(相对链接失效)—— 那条的 docs-site 一半在这道门下从此会自己红;`docs/qa/` 那一半仍由 `check-docs-integrity.py` 管(它的相对链接范围只有 `docs/qa/` 下 6 个文件 / 96 条链接)。
- #861(194 个测试套件只有 21 个被 CI 引用)—— 同一类:**东西存在,但没有任何东西会去跑它。**
