### PR TITLE
ci: 发版时校验上手指南里写死的通道版本号（release gate 4，report-only）

### DIFF
--- a/.github/workflows/docs-site-build.yml
+++ b/.github/workflows/docs-site-build.yml
@@ -55,6 +55,16 @@ jobs:
         with:
           node-version: '22'
 
+      # 结构自检,放在 npm ci 之前 —— 它不需要依赖,而且失败得比构建快得多。
+      # 判据只有两条:戳还在(整块被删掉时 exit 2,不许报绿),以及每条戳声明的
+      # 版本号在正文里真的出现过(抓「改了戳没改表格」)。
+      # 「戳等于正在发的那个版本」是 release gate 的 gate 4 在管,不在这里 ——
+      # 文档变假的时刻是发版,不是改文档。
+      - name: getting-started 版本断言戳（结构自检）
+        run: |
+          python3 scripts/check-doc-version-claims.py --selftest
+          python3 scripts/check-doc-version-claims.py
+
       - name: Install (locked)
         run: npm ci
         working-directory: docs-site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,9 +398,32 @@ jobs:
 
           echo "✅ Gate 3 — release notes contain both Install + Upgrade for v$GATED_VER ($src)"
 
+  gate-4-doc-version-claims:
+    name: gate 4 — 上手指南里的版本断言
+    needs: build-tarball
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+
+      # getting-started.md 里有一整套**带版本号的行为断言**(某个版本上第一条命令
+      # 会怎样)。它们今天是真的(#952 逐条实跑过),但在发版那一刻同时变假,而且
+      # 是往最糟的方向:新用户会读到「stable 上第一条命令会裸崩」,而那时 stable
+      # 已经修好了。一句劝退用户的假话比一个过期的版本号严重得多。
+      #
+      # 🔴 门挂在这里而不是每个 PR 上,是因为**文档变假的时刻是「有人发了新版本」,
+      #    不是「有人改了文档」**。挂在 PR 上的话,在最需要它的那类动作上永远不响。
+      #    (结构自检 —— 戳存在、戳和正文一致 —— 另外挂在 docs-site-build 上。)
+      - run: python3 scripts/check-doc-version-claims.py --selftest
+      - name: Assert getting-started's version claims match what is being published
+        run: |
+          python3 scripts/check-doc-version-claims.py \
+            --package '${{ needs.build-tarball.outputs.package }}' \
+            --version '${{ needs.build-tarball.outputs.version }}'
+
   verdict:
     name: verdict (aggregate)
-    needs: [gate-1-install-smoke, gate-2-pinned-audit, gate-3-release-notes]
+    needs: [gate-1-install-smoke, gate-2-pinned-audit, gate-3-release-notes, gate-4-doc-version-claims]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -410,10 +433,12 @@ jobs:
           g1='${{ needs.gate-1-install-smoke.result }}'
           g2='${{ needs.gate-2-pinned-audit.result }}'
           g3='${{ needs.gate-3-release-notes.result }}'
+          g4='${{ needs.gate-4-doc-version-claims.result }}'
           echo "Gate 1 (install smoke):  $g1"
           echo "Gate 2 (PINNED audit):   $g2"
           echo "Gate 3 (release notes):  $g3"
-          if [ "$g1" = success ] && [ "$g2" = success ] && [ "$g3" = success ]; then
+          echo "Gate 4 (doc version claims): $g4"
+          if [ "$g1" = success ] && [ "$g2" = success ] && [ "$g3" = success ] && [ "$g4" = success ]; then
             echo "✅ RELEASE GATE CLEAN — safe to npm publish (or promote to @latest)"
           else
             echo "::warning::release gate has at least one failure — review before publishing"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -1,5 +1,14 @@
 # Getting Started (5 steps)
 
+<!-- 🔴 Two machine-readable stamps, read by scripts/check-doc-version-claims.py; invisible when rendered.
+     This page makes several **version-scoped behavioural claims** (what the very first command does on a
+     given version). They all become false the moment a new version ships. The release gate compares the
+     version being published against these stamps and blocks the release, listing every line to update.
+     Change the prose, change the stamp — the gate also fails when the two disagree.
+     Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
+<!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.39 -->
+
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
 ::: tip Fastest path (recommended) — zero config if you have a Claude subscription

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -1,5 +1,13 @@
 # 上手指南（5 步跑通）
 
+<!-- 🔴 下面这两条戳被 scripts/check-doc-version-claims.py 读取,渲染出来看不见。
+     本页有多处**带版本号的行为断言**(某个版本上第一条命令会怎样),它们在发版那一刻
+     同时变假。release gate 会拿正在发的版本和这两条戳比对,不一致就拦下发布并列出
+     每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
+     只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
+<!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.39 -->
+
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
 ::: tip 最快路径（推荐）— 有 Claude 订阅就 0 配置

--- a/scripts/check-doc-version-claims.py
+++ b/scripts/check-doc-version-claims.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""上手指南里写死的通道版本号,必须和真正要发的那个版本对上。
+
+为什么需要这道门
+================
+
+`docs-site/**/guide/getting-started.md` 里有一整套**带版本号的行为断言** —— 不是"某某
+版本存在",而是"**在这个版本上会发生什么**":
+
+    · **latest(当前 `2.2.21`)**:裸崩 `Error: spawn bunx ENOENT` + Node 堆栈
+    | `latest` = `2.2.21` | 固定的 `anethub` |
+    | `preview` = `2.3.0-preview.39` | **随机串**,形如 `anet-...` |
+
+这些句子**今天是真的**(#952 里逐条实跑过)。但它们在**下一次发版的那一刻**同时变假,
+而且是往最糟的方向变假:新用户会读到"stable 上第一条命令会裸崩",而那时 stable 已经修好了。
+**一句劝退用户的假话,比一句过期的版本号严重得多。**
+
+🔴 这道门的触发点是刻意选的:**它跑在 release gate 里,不是每个 PR 上。**
+   文档变假的时刻不是"有人改了文档",是"有人发了一个新版本"。把门挂在 PR 上,
+   在最需要它的那一类动作上永远不会响。
+
+判据
+====
+
+文档顶部带一块**机器可读的戳**(HTML 注释,渲染出来看不见):
+
+    <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
+
+两种模式:
+
+  **结构模式**(无参数,PR/push 上跑)
+    - 每个待检文档至少有 1 条戳,否则 exit 2(戳被整块删掉 = 门失效,不能报绿)
+    - 每条戳声明的 version 字符串,必须在**同一个文件的正文里真的出现过**
+      —— 抓"戳更新了但表格没改"
+
+  **发版模式**(`--package P --version V`,release gate 里跑)
+    - 由 V 是不是预发布版(含 `-`)推出 channel:有 `-` → preview,没有 → latest
+    - 该 (package, channel) 下的每一条戳,version 必须等于 V
+    - 红了的时候,把**文件里所有出现旧版本串的行**都打出来 —— 修法是机械的
+
+这道门不保证什么
+================
+
+它只管**被戳标记的那些**版本号。文档里还有大量**历史性**的版本引用(`≤ 2.3.0-preview.37`、
+"`2.3.0-preview.38` 里 verified"),那些**本来就该保持不变** —— 它们讲的是历史,不是现状。
+把两者分开的唯一办法是让作者标出来,所以才有戳。**没戳的地方它看不见,这是设计,不是漏洞。**
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+DOCS = [
+    "docs-site/docs/guide/getting-started.md",
+    "docs-site/docs/en/guide/getting-started.md",
+]
+
+STAMP = re.compile(
+    r"<!--\s*version-claim:\s*package=([A-Za-z0-9@/._-]+)\s+"
+    r"channel=([a-z]+)\s+version=([0-9A-Za-z.+-]+)\s*-->"
+)
+
+
+def channel_of(version: str) -> str:
+    return "preview" if "-" in version else "latest"
+
+
+def parse(text: str) -> list[tuple[int, str, str, str]]:
+    out = []
+    for lineno, line in enumerate(text.split("\n"), 1):
+        for m in STAMP.finditer(line):
+            out.append((lineno, m.group(1), m.group(2), m.group(3)))
+    return out
+
+
+def run(repo: Path, package: str | None, version: str | None) -> int:
+    problems = 0
+    total_stamps = 0
+    for rel in DOCS:
+        path = repo / rel
+        if not path.is_file():
+            print(f"::error::待检文档不存在: {rel}")
+            return 2
+        text = path.read_text(encoding="utf-8")
+        stamps = parse(text)
+        if not stamps:
+            print(f"::error file={rel}::0 条 version-claim 戳 —— 判据没变,是取集塌了")
+            return 2
+        total_stamps += len(stamps)
+
+        for lineno, pkg, chan, ver in stamps:
+            if channel_of(ver) != chan:
+                print(f"::error file={rel},line={lineno}::戳自相矛盾: version={ver} "
+                      f"看起来是 {channel_of(ver)} 通道,但 channel={chan}")
+                problems += 1
+            # 戳必须能在正文里落地,否则就是一条只对自己成立的声明
+            body = "\n".join(l for i, l in enumerate(text.split("\n"), 1) if i != lineno)
+            if ver not in body:
+                print(f"::error file={rel},line={lineno}::戳说 {chan}={ver},"
+                      f"但正文里一次都没出现这个串 —— 戳更新了正文没改?")
+                problems += 1
+
+            if package and version and pkg == package and chan == channel_of(version):
+                if ver != version:
+                    print(f"::error file={rel},line={lineno}::正在发 {package}@{version}"
+                          f"({chan} 通道),而文档仍然断言 {chan}={ver}")
+                    problems += 1
+                    for i, l in enumerate(text.split("\n"), 1):
+                        if ver in l and i != lineno:
+                            print(f"    {rel}:{i}: {l.strip()[:120]}")
+
+    print(f"checked {total_stamps} version-claim stamp(s) across {len(DOCS)} doc(s)"
+          + (f"; releasing {package}@{version} ({channel_of(version)})" if package and version else ""))
+    if problems:
+        print(f"\n{problems} problem(s).")
+        print("修法:把上面列出的每一行改成新版本上实测的行为,再更新对应的戳。")
+        print("🔴 不要只改戳 —— 戳和正文不一致时这道门也会红(那正是它的第二条判据)。")
+        return 1
+    print("每一条被标记的版本断言都指着正在发的那个版本。")
+    return 0
+
+
+def selftest() -> int:
+    OPEN, CLOSE = "<!" + "--", "--" + ">"
+
+    def stamp(pkg: str, chan: str, ver: str) -> str:
+        return f"{OPEN} version-claim: package={pkg} channel={chan} version={ver} {CLOSE}"
+
+    cases = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        cases.append((name, ok, detail))
+
+    s = parse(stamp("agent-network", "latest", "2.2.21"))
+    check("戳能被解析", s == [(1, "agent-network", "latest", "2.2.21")], repr(s))
+    check("没有戳的文本解析出 0 条(上游据此 exit 2)", parse("普通正文") == [])
+    check("预发布版判成 preview", channel_of("2.3.0-preview.39") == "preview")
+    check("正式版判成 latest", channel_of("2.2.21") == "latest")
+    check("build 元数据不算预发布", channel_of("2.2.21+build.7") == "latest")
+    # 一行里两条戳(中英同表)也要都拿到
+    two = parse(stamp("agent-network", "latest", "1.0.0") + " " + stamp("agent-node", "preview", "1.0.0-preview.1"))
+    check("一行两条戳都被收下", len(two) == 2, f"got {len(two)}")
+
+    for name, ok, detail in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}" + (f"   [{detail}]" if detail and not ok else ""))
+    bad = sum(1 for _n, ok, _d in cases if not ok)
+    print(f"selftest: {len(cases) - bad}/{len(cases)} ok")
+    return 1 if bad else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--package")
+    ap.add_argument("--version")
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+    if bool(args.package) != bool(args.version):
+        print("::error::--package 和 --version 必须一起给", file=sys.stderr)
+        return 2
+    repo = Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True, check=True).stdout.strip())
+    return run(repo, args.package, args.version)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 这道门抓的是什么

`docs-site/docs/guide/getting-started.md`(中英两份)里有一整套**带版本号的行为断言** —— 不是「某个版本存在」,而是「**在这个版本上第一条命令会怎样**」:

```
· **latest(当前 `2.2.21`)**:裸崩 `Error: spawn bunx ENOENT` + Node 堆栈；
| `latest` = `2.2.21` | 固定的 `anethub` |
| `preview` = `2.3.0-preview.39` | **随机串**,形如 `anet-232412de5bb54c058cff32` |
```

这些句子**今天是真的** —— #952 里逐条在干净容器里实跑过。但它们会在**下一次发版的那一刻**同时变假,而且是往最糟的方向变假:

🔴 **新用户会读到「stable 上第一条命令会裸崩」,而那时 stable 已经修好了。** 一句劝退用户的假话,比一个过期的版本号严重得多。

`latest` 已经冻结 55 天,所以这几行现在还准。**这道门要接的正是解冻的那一刻。**

## 判据

文档顶部加一块机器可读的戳(HTML 注释,**渲染出来看不见** —— 实测 `dist/guide/getting-started.html` 里 `version-claim` 出现 **0** 次):

```
<!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.39 -->
```

两种模式:

| 模式 | 挂在哪 | 判据 |
|---|---|---|
| **结构** | `docs-site-build`(每个 PR) | 戳整块被删 → **exit 2**;戳声明的版本号在正文里一次都没出现 → exit 1 |
| **发版** | `release.yml` **gate 4** | 由版本号推通道(含 `-` → preview),该通道下每条戳必须等于正在发的那个版本 |

🔴 **发版模式刻意不挂在 PR 上。** 文档变假的时刻是「**有人发了一个新版本**」,不是「有人改了文档」。挂在 PR 上,在最需要它的那一类动作上**永远不会被触发** —— 门存在、判据也对,但不响。

🔴 **和 verdict 现有的立场保持一致:report-only,不阻断发布。** 那个 job 的注释写着 `Non-blocking: report-only by design (see header). Maintainer decides.` —— 新加的检查不该比产品对同一件事的既有姿态更严。

## 实测矩阵(见证红在见证绿之前)

```
发 agent-network@2.3.0             → rc=1，两个 locale 各列出 3 行待改
发 agent-network@2.2.21            → rc=0
发 agent-network@2.3.0-preview.40  → rc=1
发 agent-node@9.9.9（本页没有它的戳）→ rc=0    ← 不误伤别的包
只改戳不改正文                      → rc=1「戳更新了正文没改?」
selftest                            → 6/6 ok
```

红的时候它把**每一行**都打出来,修法是机械的:

```
::error file=docs-site/docs/guide/getting-started.md,line=8::正在发 agent-network@2.3.0(latest 通道),而文档仍然断言 latest=2.2.21
    docs-site/docs/guide/getting-started.md:27: · **latest(当前 `2.2.21`)**:裸崩 `Error: spawn bunx ENOENT` + Node 堆栈；
    docs-site/docs/guide/getting-started.md:96: | `latest` = `2.2.21` | 固定的 `anethub` |
    docs-site/docs/guide/getting-started.md:133: …stable `@latest`（当前 `2.2.21`）与 preview `≤ 2.3.0-preview.37`…
```

## 🔴 它不管什么(写在脚本文件头里)

**只看被戳标记的那些版本号。** 文档里还有大量**历史性**的版本引用 —— `≤ 2.3.0-preview.37`、「`2.3.0-preview.38` 里 verified」—— 那些**本来就该保持不变**,它们讲的是历史不是现状。

我一开始想让它扫全部版本号字面量,写到一半发现那样会把上面这些正确的历史引用判成红。**把"现状断言"和"历史引用"分开的唯一办法是让作者标出来** —— 所以才有戳,而不是去解析散文。没标的地方它看不见,**这是设计,不是漏洞**。

## 副作用核验

- `vitepress build` 仍 `rc=0` / `build complete in 38.36s` / **95 个页面**(与加戳前一致)
- 仓里现有的门本地全跑过:`doc-symbol-anchors` 74/264 · `docs-integrity` 361 · `workflow-structure` 20 workflow/35 job · `qa-trigger-coverage` · `l1-paths-sync` · `home-path-baseline` · `test-file-coverage` 247/244 · `no-memory-slugs` —— **全部 rc=0**

## 关联

- #952(照文档装 latest 的新用户第一条命令就崩)—— 那条的结论是「唯一修法是发一个新的 `latest`」。**这道门就是为那次发版准备的**:发的时候它会指着这几行说「这些话现在不成立了」。
