### PR TITLE
test(686): 让 L1 变异段的每一条判据自己说话（实测三种不同原因的输出逐字相同、0 字节）

### DIFF
--- a/tests/test686-rest-shape-golden/run.sh
+++ b/tests/test686-rest-shape-golden/run.sh
@@ -56,12 +56,44 @@ bun test server/src/rest-explicit-columns-http.test.ts >/tmp/test686-mutation.lo
 mutation_rc=$?
 set -e
 cp /tmp/rest-projections.orig server/src/rest-projections.ts
-test "$mutation_rc" -ne 0
-grep -Fq 'task list and task detail expose the same explicit contract' /tmp/test686-mutation.log
-grep -Fq 'created_at' /tmp/test686-mutation.log
-# 🔴 变异那一轮同样要断分母:如果那一轮压根没跑起来,它也会「红」——
-# 而那是一个为了错误的理由变红的 witnessed-red,证明不了变异被抓住。
+
+# 🔴 2026-08-18:这一段原本是三条**裸的** `test` / `grep -Fq`,在 `set -e` 下
+#   失败时**一个字都不打印**。CI 上真的这么红过一次(run 32122847303):日志停在
+#   上面那行 echo,后面什么都没有 —— 看的人无法知道是「变异没让它红」还是
+#   「grep 没匹配上」还是「那一轮压根没跑起来」,三种原因的输出**逐字相同**。
+#
+#   雪上加霜的是变异那一轮的输出被重定向进了容器内的 /tmp/test686-mutation.log,
+#   而 qa.yml 的失败转储只 `tail` 宿主上的 /tmp/qa-*.log ——**装着原因的那个文件
+#   不在转储范围里**。所以每一条判据现在都自己说话,并且自己把日志尾巴打出来。
+#
+#   正确写法本来就在隔壁:tests/test725-agent-node-unit-ci/run.sh 的变异段
+#   在 FAIL 之前先 `cat` 变异日志。这里只是把同一条规矩补上。
+dump_mutation() {
+  echo "  ── 变异那一轮的输出(后 30 行)── /tmp/test686-mutation.log" >&2
+  tail -30 /tmp/test686-mutation.log >&2 || echo "  (这个文件读不出来)" >&2
+}
+
+# 🔴 分母先断。原来它排在两条 grep 后面,顺序是反的:那一轮如果压根没跑起来
+#   (bun 起不来、编译失败),`mutation_rc != 0` 会**因为错误的理由**通过第一条,
+#   然后 grep 失败 —— 报出来的症状指向「变异没被抓住」,而真相是「这一轮不作数」。
+#   62-63 行原来的注释已经写明了这个担心,只是断言放晚了一步。
 assert_ran_enough /tmp/test686-mutation.log L1
+
+if [ "$mutation_rc" -eq 0 ]; then
+  echo "L1 FAIL: 变异之后测试仍然全过(rc=0) —— 这道门抓不住它自己声称抓得住的东西" >&2
+  dump_mutation
+  exit 1
+fi
+if ! grep -Fq 'task list and task detail expose the same explicit contract' /tmp/test686-mutation.log; then
+  echo "L1 FAIL: 变异让它红了,但红的不是那条指名的用例 —— 可能是为了别的理由红的" >&2
+  dump_mutation
+  exit 1
+fi
+if ! grep -Fq 'created_at' /tmp/test686-mutation.log; then
+  echo "L1 FAIL: 失败信息里没有出现 created_at —— 变异删掉的正是这个键,断言没打中它" >&2
+  dump_mutation
+  exit 1
+fi
 printf 'mutation=drop-task-created-at rc=%s witnessed-red\n' "$mutation_rc"
 
 echo "L2: restored production projection remains green"


### PR DESCRIPTION
## 起因:今天 CI 上真的这么红过一次

`run 32122847303`(在 PR #967 上)。`L0 + L1` 红了,日志停在:

```
[L0] ran=5 (min 5)
L1: removing a previously public task key must turn red
```

**后面什么都没有。**

`tests/test686-rest-shape-golden/run.sh` 那一段是三条**裸的** `test` / `grep -Fq`,在 `set -e` 下失败时**一个字都不打印**:

```sh
test "$mutation_rc" -ne 0
grep -Fq 'task list and task detail expose the same explicit contract' /tmp/test686-mutation.log
grep -Fq 'created_at' /tmp/test686-mutation.log
```

于是看的人分不出到底是哪一种:

| | 含义 | 该找谁 |
|---|---|---|
| (a) `mutation_rc = 0` | 变异之后测试**仍然全过** —— 这道门抓不住它自己声称抓得住的东西 | 门坏了 |
| (b) 第一条 grep 不中 | 红了,但**红的不是那条指名的用例** | 可能是环境 |
| (c) 第二条 grep 不中 | 失败信息里**没出现 `created_at`** —— 断言没打中被删的那个键 | 断言写松了 |
| (d) 那一轮压根没跑起来 | 这一轮的红**不作数** | 基础设施 |

## 🔴 实测:旧版三种原因的输出**逐字相同**

把 L1 段抽成夹具,喂三种不同的合成日志:

```
== 旧版 B  rc=1  输出字节数=0  内容=[]
== 旧版 D  rc=1  输出字节数=0  内容=[]
== 旧版 E  rc=1  输出字节数=0  内容=[]
```

**三个不同的根因,`rc=1` + 0 字节。** 在 CI 里它们是同一片沉默。

## 雪上加霜的一格

变异那一轮的输出被重定向进**容器内**的 `/tmp/test686-mutation.log`,而 `.github/workflows/qa.yml:284` 的失败转储只 `tail` **宿主上**的 `/tmp/qa-*.log`:

```yaml
for f in /tmp/qa-*.log; do
  echo "================ $f ================"
  tail -60 "$f"
done
```

⇒ **装着原因的那个文件不在转储范围里。**

好在 `scripts/qa.sh:255` 把容器的 stdout **和 stderr** 一起收进 `qa-l1-<t>-run.log`:

```sh
(dockerrun "docker run --rm anet-$t" >/tmp/qa-l1-$t-run.log 2>&1) &
```

所以改成**往 stderr 说话**就能到达读日志的人眼前,不需要动 qa.yml 的转储范围。

## 顺带修一个顺序问题

分母断言 `assert_ran_enough ... L1` 原来排在两条 grep **后面**。那一轮如果压根没跑起来(bun 起不来、编译失败),`mutation_rc != 0` 会**因为错误的理由**通过第一条,然后 grep 失败 —— 报出来的症状指向「变异没被抓住」,而真相是「这一轮不作数」。

原文件 62-63 行的注释**已经写明了这个担心**:

```
# 🔴 变异那一轮同样要断分母:如果那一轮压根没跑起来,它也会「红」——
# 而那是一个为了错误的理由变红的 witnessed-red,证明不了变异被抓住。
```

只是断言放晚了一步。**这条本来就在这个文件里,只是没被一致地应用。**

## 见证矩阵(六种,每条各说各的)

```
A 正常见证红              rc=0
B 变异没红(rc=0)          rc=1  「L1 FAIL: 变异之后测试仍然全过(rc=0) —— 这道门抓不住它自己声称抓得住的东西」
C 分母塌了(Ran 1)         rc=1  「[L1] 只注册到 1 个测试,下限是 5 —— 分母塌了,这一轮的绿/红都不作数」
D 红了但不是那条用例      rc=1  「L1 FAIL: 红的不是那条指名的用例 —— 可能是为了别的理由红的」
E 没提 created_at         rc=1  「L1 FAIL: 失败信息里没有出现 created_at —— 断言没打中它」
F bun 起不来              rc=1  「[L1] 没能从输出里读到 'Ran N tests' —— 判不了跑了几个,拒绝通过」
```

每一条红都附带变异日志的后 30 行。`sh -n` 通过(仍然是 POSIX `sh`,没有引入 bash 特性)。

## 这个 PR **不**修什么

它**不修偶发本身**。`test686` 为什么会在 L1 阶段挂,那是 #928 那一格的事,而且我这次也答不上来 —— 因为日志里根本没有原因,这正是本 PR 要解决的问题。

**下一次它再红的时候,日志会说出是哪一种。**

## 复核过的前提

- 我的改动**碰不到** `test686`:那次红的 PR #967 的 diff 是 1 个 python 脚本 + 2 个 workflow + 2 个 markdown;`test686` 测的是 `server/src/rest-projections.ts` 的 REST 投影,**没有任何调用关系**
- 近 12 次 `qa.yml` 运行里,只有那一次是 `test686` 红;05:58 那次 main 红的是**另一个 job**(`doc source-pin floor`)。**所以我没有把它称作「已知偶发」** —— 它在近期样本里只出现过一次
