### PR TITLE
docs(grok): 写清怎么装到钉死的 0.2.93（#876；顺带实测 stable 已从 1.0.4 走到 1.0.5）

### DIFF
--- a/docs/grok-build-cli-preview.md
+++ b/docs/grok-build-cli-preview.md
@@ -41,7 +41,28 @@ the explicit preview policy; it remains a blocker to claiming production or
 
 - Linux with procfs mounted at `/proc` (including `/proc/self/fd`).
 - `@sleep2agi/agent-network` from the `preview` channel once the candidate is published.
-- The exact Grok CLI build `grok 0.2.93 (f00f96316d)`; the known stable installer may append ` [stable]` to that output.
+- The exact Grok CLI build `grok 0.2.93 (f00f96316d)`. The co-presence runtime also accepts the
+  ` [stable]` suffix on that same build — see
+  [`runtime.ts`](../agent-node/src/runtime/grok-copresence/runtime.ts) —— 搜 `requires exactly grok`.
+  (Symbol anchor, not a line number: #857 replaced 13 line pins here after finding **13 of 13 had drifted**.)
+
+  🔴 **The unversioned installer does not give you this build.** `https://x.ai/cli/stable` returned
+  `1.0.4` when #876 was filed and `1.0.5` on 2026-08-18 — it keeps moving, and the pin does not.
+  Pass the version explicitly:
+
+  ```bash
+  curl -fsSL https://x.ai/cli/install.sh | bash -s 0.2.93
+  grok --version   # must print: grok 0.2.93 (f00f96316d)
+  ```
+
+  `bash -s <version>` is the installer's own first positional argument (`TARGET="$1"`), so this is the
+  supported path rather than a hand-assembled artifact URL. Measured 2026-08-18 in an isolated `HOME`:
+  the command above printed `Grok 0.2.93 installed to …/.grok/bin/grok`, and `grok --version` printed
+  `grok 0.2.93 (f00f96316d)` — byte-identical to the pinned string.
+
+  🔴 That installer performs **no checksum verification** of what it downloads (`grep -nE 'sha256|checksum'`
+  on it returns nothing). That is xAI's installer, not ours; it is stated here so the trust boundary is
+  explicit rather than assumed.
 - A completed Grok CLI login for the same operating-system user that runs `anet`.
 - Two terminals on the same machine and user account: one owns the node process; one attaches to its local TUI socket.
 - A trusted CommHub and trusted task senders.
@@ -243,7 +264,14 @@ fallback if the native TUI path fails.
 
 ## Common errors
 
-`grok copresence requires exactly grok 0.2.93 (f00f96316d)` means the installed Grok binary is not the captured build. Install the pinned build; do not bypass the check.
+`grok copresence requires exactly grok 0.2.93 (f00f96316d)` means the installed Grok binary is not the
+captured build — most often because the unversioned installer was used and it now ships a much newer
+stable. Install the pinned build; do not bypass the check:
+
+```bash
+curl -fsSL https://x.ai/cli/install.sh | bash -s 0.2.93
+grok --version   # grok 0.2.93 (f00f96316d)
+```
 
 `Node ... uses legacy headless grok-build-cli mode` means the profile was created with `--grok-headless`. Create a new co-presence profile explicitly rather than editing socket/session fields by hand.
 

--- a/docs/grok-build-runtime.md
+++ b/docs/grok-build-runtime.md
@@ -25,6 +25,13 @@ curl -fsSL https://x.ai/cli/install.sh | bash
 grok
 ```
 
+🔴 This unversioned installer is correct **for `grok-build-acp`, which this document covers** — that
+runtime is not pinned to a specific Grok build. It is **not** correct for the `grok-build-cli`
+co-presence runtime, which fails closed on anything other than `grok 0.2.93 (f00f96316d)`. If you are
+setting up co-presence, install the pinned build instead (`bash -s 0.2.93`) — see
+[grok-build-cli-preview.md](./grok-build-cli-preview.md). The two documents were individually correct
+and jointly misleading; see #876.
+
 The xAI Build documentation describes Grok Build as usable through an interactive TUI, headless scripts, or ACP integrations. It also documents `grok inspect` for checking discovered config, skills, plugins, hooks, and MCP servers.
 
 References:


### PR DESCRIPTION
Closes #876.

## 前提我在 `origin/main`(`2e2e1ff0`)上逐条复核了,而且有一条**比 issue 写的更严重**

| issue 说 | 我实测 |
|---|---|
| 官方 stable = `1.0.4` | **`1.0.5`**(2026-08-18 `curl -s https://x.ai/cli/stable`) |
| 文档里没有任何地方教怎么装 0.2.93 | 确认:`grep -nE 'grok-0\.2\.93\|x\.ai/cli/grok-' docs/ docs-site/` **零命中** |
| `docs/grok-build-cli-preview.md:44` 那句现在时断言还在 | 确认,逐字未改 |
| 排障段只说"要装" | 确认:`:246` 是 `Install the pinned build; do not bypass the check.`,**没说怎么装** |

🔴 **stable 从 1.0.4 走到 1.0.5,正好说明这不是一次性的错**:那句话是在 stable 恰好等于 0.2.93 的那天写下的,**它当时是真的**,然后世界往前走了,而句子留在原地。所以修法里我**没有**写死"现在 stable 是 X" —— 那样只是把过期时间往后推一格。

## 修法:不是 issue 建议的手拼 URL

那条 issue 建议直连产物:`curl -fsSL -o grok https://x.ai/cli/grok-0.2.93-linux-x86_64`。**能用**(我 `curl -sI` 过,`HTTP/2 200`),但它绕过了安装器的平台探测、PATH 设置和 fallback 源。

**官方安装器自己就收版本参数** —— 我把它拉下来读了:

```
18:  TARGET="$1"
190: if [ -n "$TARGET" ]; then
191:     version="$TARGET"
```

所以走它支持的那条路:

```bash
curl -fsSL https://x.ai/cli/install.sh | bash -s 0.2.93
grok --version   # grok 0.2.93 (f00f96316d)
```

## 实测(隔离 `HOME`,没有碰我自己的环境)

```
$ HOME=<隔离目录> bash install.sh 0.2.93
  Downloading grok 0.2.93...
Grok 0.2.93 installed to <隔离目录>/.grok/bin/grok

$ grok --version
grok 0.2.93 (f00f96316d)
```

**与运行时钉死的串逐字相同**(`agent-node/src/runtime/grok-copresence/runtime.ts` —— 搜 `requires exactly grok`)。

顺带一个观察:我这次装出来的**没有** ` [stable]` 后缀,而运行时两种都收。原文那句 "the known stable installer may append ` [stable]`" 因此是"可能"而不是"一定" —— 改写后的措辞跟着改了。

## 另外补了两件原文没说的事

**① 那个安装器不做校验和。** 对它 `grep -nE 'sha256|checksum'` **零命中**。这是 xAI 的安装器不是我们的,写出来是为了让**信任边界显式**,而不是默认没人问。

**② `docs/grok-build-runtime.md` 那条不带版本的安装命令,对它自己讲的 `grok-build-acp` 是对的** —— 那条路不受这个钉子约束。所以我**没有改它的指令**,只加了交叉引用。

🔴 **这正是 #876 最难缠的地方:两份文档各自都没写错,合起来读才会把人带沟里。** 一份说"共存要精确 0.2.93",另一份说"这样装 Grok",读者把两句拼起来就得到"照装即可"。这类缺陷不在任何一份文档的**内部**,所以逐份 review 是看不见的。

## 引用用符号锚点不用行号

`#857` 把这个仓的 13 条行号 pin 换成符号锚点时,实测 **13 条全部已漂**(`loadProfile` 文档写 228 实际 1274)。所以我新加的引用直接用符号锚点。

## 仓里现有的门,本地全跑过

```
doc-symbol-anchors     rc=0   75 anchors / 264 docs（+1，就是我新加的那条）
docs-integrity         rc=0
doc-source-pins        rc=0   没有新增行号 pin
doc-version-claims     rc=0
home-path-baseline     rc=0
no-memory-slugs        rc=0
```
