### PR TITLE
docs(deploy): 标明 anet daemon 只在 preview 上存在（#873 的另一半；另两处已在 main 上修好）

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -24,8 +24,24 @@ PM2、systemd、cron 看门狗不能同时管理同一个 Hub。多个守护者�
 而 `anet daemon init` / `up` 是**另一件事** —— 创建并启动一个
 `host_supervisor` 节点(RFC-026)。两者名字相近、做的事不同。
 
-另外 `anet daemon --help` 目前会打出全局帮助;要看子命令请直接敲
-`anet daemon`(不带参数)。
+🔴 **而且 `anet daemon` 只在 `preview` 通道上存在。** 按文档站首推的 `install.sh`
+装到的是 `latest`,在它上面敲这条命令得到的是:
+
+```
+$ anet daemon
+Unknown command "daemon". Did you mean: anet demo?
+（退出码 1）
+```
+
+实测 2026-08-18,用 npm 上真正的 `@sleep2agi/agent-network@2.2.21`(当时的 `latest`)
+跑二进制得到 —— 不是读 dist 猜的(那是字符串表混淆产物,grep 不作数)。
+`preview`(当时 `2.3.0-preview.39`)上同一条命令打印 `Usage: anet daemon <subcommand> …`。
+
+**所以下面这句只在 preview 上成立:** `anet daemon --help` 目前会打出全局帮助;
+要看子命令请直接敲 `anet daemon`(不带参数)。在 `latest` 上你会拿到上面那个
+`Unknown command` —— **那不是你装错了。**
+
+需要 `anet daemon` 的话,先切到 preview 通道:`npm i -g @sleep2agi/agent-network@preview`。
 :::
 
 ## 推荐入口

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -26,8 +26,26 @@ This page is about **keeping the Hub alive with PM2** (`anet hub start`).
 `anet daemon init` / `up` is a different thing: it creates and starts a
 `host_supervisor` node (RFC-026). Similar names, different jobs.
 
-Also note `anet daemon --help` currently prints the global help — run
-`anet daemon` with no arguments to see its subcommands.
+🔴 **`anet daemon` only exists on the `preview` channel.** The `install.sh` this site
+recommends installs `latest`, where the command prints:
+
+```
+$ anet daemon
+Unknown command "daemon". Did you mean: anet demo?
+(exit code 1)
+```
+
+Measured 2026-08-18 by running the binary from the real npm tarball of
+`@sleep2agi/agent-network@2.2.21` (`latest` at the time) — not by reading `dist`, which
+is string-array-obfuscated and cannot be grepped for this. On `preview`
+(`2.3.0-preview.39` at the time) the same command prints `Usage: anet daemon <subcommand> …`.
+
+**So the next sentence only holds on preview:** `anet daemon --help` currently prints the
+global help — run `anet daemon` with no arguments to see its subcommands. On `latest` you
+get the `Unknown command` above — **that is not a broken install.**
+
+If you need `anet daemon`, switch channels first:
+`npm i -g @sleep2agi/agent-network@preview`.
 :::
 
 ## Recommended entry point


### PR DESCRIPTION
#873 报了两处**方向相反**的文档错误。我在 `origin/main`(`01ec6e79`)上逐条核了:

| issue 报的 | main 上的现状 |
|---|---|
| `docs-site/docs/guide/cli.md:203-204` 没标 preview | **已修** —— 现在写着「**仅 preview 通道**」 |
| `docs-site/docs/guide/grok-copresence.md` 说 grok attach「尚未进入 preview」 | **已修** —— 开头有一段「更正(2026-08-18 实测)」 |
| `docs-site/docs/deploy/daemon.md` 把 `anet daemon` 当现状教 | 🔴 **仍然如此** |

所以这个 PR 只补最后一格。

## 这一格为什么值得单独修

那个 `::: warning` 框不但没标 preview,**还专门教用户敲这条命令**:

```
另外 `anet daemon --help` 目前会打出全局帮助;要看子命令请直接敲
`anet daemon`(不带参数)。
```

用户路径:按文档站首推的 `install.sh` 装到的是 `latest` → 读这页 → 敲 `anet daemon`
→ `Unknown command` → **他会以为是自己装错了**,因为文档刚刚教他这么敲。

**一句把人引向死路、然后让他怀疑自己的指令,比一句单纯过期的话更贵。**

## 我自己跑了,没有照抄 issue 的结论

```
$ npm pack @sleep2agi/agent-network@2.2.21 --prefer-online
$ HOME=<隔离目录> node package/dist/bin/cli.js daemon
Unknown command "daemon". Did you mean: anet demo?
rc=1

# 正控 —— 同一个二进制、同一个隔离 HOME
$ ... --version
anet v2.2.21
```

🔴 **必须跑二进制。** `dist/bin/cli.js` 是 `javascript-obfuscator` 的字符串表产物,对它
`grep daemon` 恒为 0 命中 —— **那个 0 什么都不证明**,阴性结论不可采信。这也是 #873 本身
在方法一栏就写明的。

(`npm view @sleep2agi/agent-network dist-tags` 今天仍是 `latest=2.2.21` / `preview=2.3.0-preview.39`,
所以 issue 当时的测量到现在依然成立 —— 这一格我也查了,没有默认它还成立。)

## 改法

中英两份都补上:preview-only 的事实 + `latest` 上的**真实输出** + 一句「**那不是你装错了**」+ 切通道的命令。

原文那句「要看子命令请直接敲 `anet daemon`」**没有删掉**,而是标明它**只在 preview 上成立** ——
因为在 preview 上它确实是对的、也确实有用。

## 体例

同一份文档里 `anet opencode ...` 那行本来就带 preview 标注,`guide/cli.md` 的表格也已经在用
「**仅 preview 通道**」。**所以这不是体例缺失,是漏标** —— 按既有体例补,不自创写法。

## 核验

```
vitepress build          rc=0   build complete in 37.50s   95 页
doc-symbol-anchors       rc=0
docs-integrity           rc=0
doc-version-claims       rc=0
home-path-baseline       rc=0
no-memory-slugs          rc=0
```
