### PR TITLE
chore(privacy): 移除公开仓里唯一一个真实的非属主用户名（#894 复核：不是 13 个，是 1 个）

### DIFF
--- a/agent-network/src/project-key.ts
+++ b/agent-network/src/project-key.ts
@@ -9,9 +9,9 @@
 //      each other under ~/.claude/;
 //   2. Windows callers don't crash — the previous `cwd.replace(/\//g, "-")`
 //      left backslash and drive colon in the key, and `mkdirSync` on
-//      `~/.claude/channels/commhub/C:\Users\wenxing_hu3/.env` ENOENTs on
-//      Windows because `:` is illegal in a path segment. Reported by
-//      user wenxing_hu3 against preview.18;
+//      `~/.claude/channels/commhub/C:\Users\your_user/.env` ENOENTs on
+//      Windows because `:` is illegal in a path segment. Reported by a
+//      user against preview.18;
 //   3. POSIX behavior is preserved for keys that were already unaffected
 //      (`/home/vansin/agent-orchestra` still becomes
 //      `-home-vansin-agent-orchestra`). Paths that contain `.` on POSIX

--- a/agent-network/tests/project-key.test.ts
+++ b/agent-network/tests/project-key.test.ts
@@ -3,7 +3,7 @@
 // User report (preview.18): `anet create` crashes on Windows because
 // `cwd.replace(/\//g, "-")` only substituted POSIX `/`. On Windows the
 // resulting key still contains `\` and drive `:`, and mkdirSync on
-// `~/.claude/channels/commhub/C:\Users\wenxing_hu3/.env` ENOENTs
+// `~/.claude/channels/commhub/C:\Users\your_user/.env` ENOENTs
 // (drive colon is illegal in a path segment).
 //
 // The fix adopts claude-code's own <sanitized-cwd> scheme (verified
@@ -25,7 +25,7 @@ import { encodeCwd } from "../src/project-key";
 describe("encodeCwd (Windows P0)", () => {
   test("Windows: drive letter + backslashes → alnum-dash-underscore segment", () => {
     // The reproducing case from the user report.
-    expect(encodeCwd("C:\\Users\\wenxing_hu3")).toBe("C--Users-wenxing_hu3");
+    expect(encodeCwd("C:\\Users\\your_user")).toBe("C--Users-your_user");
   });
 
   test("Windows: nested backslashes collapse individually (no consecutive-dash squashing)", () => {
@@ -65,8 +65,8 @@ describe("encodeCwd (Windows P0)", () => {
       .toBe("-home-vansin-ai-insight--claude-worktrees-feat-404-suggestions");
   });
 
-  test("preserves underscores (usernames like wenxing_hu3 stay readable)", () => {
-    expect(encodeCwd("/home/wenxing_hu3/proj")).toBe("-home-wenxing_hu3-proj");
+  test("preserves underscores (usernames like your_user stay readable)", () => {
+    expect(encodeCwd("/home/your_user/proj")).toBe("-home-your_user-proj");
   });
 
   test("preserves hyphens (agent-orchestra is not mangled)", () => {

--- a/docs/home-path-baseline.txt
+++ b/docs/home-path-baseline.txt
@@ -12,7 +12,7 @@ agent-network/src/batch-workdir.test.ts	3
 agent-network/src/grok-copresence-profile.test.ts	5
 agent-network/src/project-key.ts	1
 agent-network/src/tmux-pane-prompt.test.ts	1
-agent-network/tests/project-key.test.ts	7
+agent-network/tests/project-key.test.ts	6
 agent-node/src/runtime/fetch-attachment.ts	1
 agent-node/tests/feishu-tool-deny.test.ts	2
 agent-node/tests/rfc-030-copresence-observer.ts	2


### PR DESCRIPTION
Refs #894。这个 PR 只做**一件**事:把公开仓里唯一一个真实的非属主用户名换掉。

## 🔴 先说复核结果:「13 个不同的真实用户名」这个说法不成立

我在 `origin/main`(`01ec6e79`)上把所有 `/home/<name>/` 与 `/Users/<name>/` 的 `<name>` 全部取出来分类:

```
不同名字: 23   总命中: 266
```

按性质分:

| 类别 | 命中 | 例 |
|---|---|---|
| **属主本人的公开 handle** | 133 | 仓主的 GitHub 用户名,本来就是公开信息 |
| **容器 / CI / 服务账号** | 60 | `bun` 27 · `preview` 18 · `node` 10 · `runner` 2 · `anet` / `hub` / `agent` / `private` |
| **占位符** | 72 | `tester` 26 · `user` 10 · `youruser` 8 · `someone` / `foo` / `example` / `testuser` / `test` / `operator` / 单字母 |
| 🔴 **真实的、非属主的人** | **1** | 一个 Windows 用户在 preview.18 上报崩溃时留下的家目录名 |

⇒ **需要处理的是 1 个,不是 13 个。** 这个数字改变的是优先级和做法:如果真是 13 个真人的用户名散在 70 个文件里,那是一次大扫除;实际是**一处定点清理**,剩下的 197 次命中里没有一次泄露任何人的身份。

(我的扫描口径比门宽 —— 门有 `NOT_A_PERSON` 白名单,还跳过 ≤2 字符的名字,所以它报 199/69 而我数到 266/23。上面这张表用的是我的宽口径,**故意的**:分类要先看见全部,再决定哪些不算。)

## 那一个在哪、怎么改的

它出现在两个跟踪文件里 —— 一条注释、一个测试夹具、一条测试名。**这里不复述那个字符串**(公开仓)。

替换成 `your_user`,挑它有两个具体理由:

1. 那条测试测的**正是下划线要被保留**(`preserves underscores (usernames like … stay readable)`),所以替代品**必须带下划线**,不能随便换成 `alice`。
2. `your_user` 已经在 `.github/scripts/check-home-path-baseline.py` 的 `NOT_A_PERSON` 里,所以这一处**从此不再计入**,楼层是真的往下走了,而不是换个名字继续占着位置。

注释里「Reported by user `<名字>` against preview.18」改成不点名 —— **保留事实**(一个真实用户在 preview.18 上报的 Windows 崩溃,这是这段代码存在的理由),**去掉身份**。

## 核验

```
bun test agent-network/tests/project-key.test.ts
  12 pass / 0 fail / 15 expect() calls

python3 .github/scripts/check-home-path-baseline.py
  199 → 198 person-looking path(s);  rc=0

全仓 grep 那个名字 → 0 命中
```

## 基线跟着往下走了

门自己会提示:

```
note: 1 file(s) now carry fewer than the baseline allows — lower their numbers in
docs/home-path-baseline.txt so the floor ratchets down and cannot silently refill.
```

所以 `agent-network/tests/project-key.test.ts` 的基线从 `7` 改成 `6`。**不改的话楼层留在旧位置,以后可以悄悄回填** —— 那正是 `docs/home-path-baseline.txt` 头部自己写的那条规矩。

## 剩下的 197 次要不要清

**这个 PR 不碰。** 它们不泄露身份,而且其中相当一部分躺在**证据类文档**里(实测记录、报告、命令原文)——改动那些等于改动证据本身。要不要清、按什么口径清,是 #894 该讨论的事,不该塞进一个定点修复里。
