### PR TITLE
docs(qa): 去掉速查块里过期的 ~93s / ~80s（#871；另两处已在 main 上修好）

### DIFF
--- a/docs/qa/v0-summary.md
+++ b/docs/qa/v0-summary.md
@@ -66,11 +66,30 @@
 ## 一键跑 + CI
 
 ```bash
-bash scripts/qa.sh           # 全跑 ~93s warm
-bash scripts/qa.sh --l0      # 只 L0 ~0.1s
-bash scripts/qa.sh --l1      # 只 L1 docker ~80s
+bash scripts/qa.sh           # 全跑
+bash scripts/qa.sh --l0      # 只 L0（单测，毫秒级）
+bash scripts/qa.sh --l1      # 只 L1（每个套件一次 docker build + run）
 bash scripts/qa.sh --list    # 列测试名
 ```
+
+> 🔴 **这几行原来带着 `~93s` / `~80s`,已经去掉 —— 不是排版,是它们会骗人。**
+>
+> 上面「一句话」那段的 `~93s` 明确标了是 **2026-05 首次测量的墙钟值**,那是**记录**,
+> 保留没问题。但这个速查块是**照抄用的**,它旁边的秒数读起来像「现在就是这么久」。
+> **同一句过期的话,写在说明里和写在用户会复制的那一行里,代价不一样** ——
+> 前者读者会连着上下文一起读到日期,后者他只会看见那个数。
+>
+> L1 的耗时随 `scripts/qa.sh` 里 `L1_TESTS` 的成员数走,而那个数一直在涨:
+> 写下最早那个「~16s」时是 **3** 个(见 #871),`ce0c99ab` 上是 **22** 个。
+> 每个成员各要一次 `docker build` + `docker run`。
+>
+> 要知道**你这台机、这个 Docker 缓存状态下**是多久:
+>
+> ```bash
+> time bash scripts/qa.sh
+> # L1 当前成员数（自己数，不要信这里写死的数字）：
+> bash -c 'source <(sed -n "/^L1_TESTS=(/,/^)/p" scripts/qa.sh); echo "${#L1_TESTS[@]}"'
+> ```
 
 [.github/workflows/qa.yml](../../.github/workflows/qa.yml) **report-only**，PR + push to main 触发，不阻塞合并。
 CI 真实抓 race ≥4 次（每次都是新 hub-bootstrap 后 auth race，固化 retry pattern）。


### PR DESCRIPTION
Closes #871。

## 复核:三处里两处已经修好了

`origin/main` = `ce0c99ab`:

| issue 报的 | 现状 |
|---|---|
| `docs/qa/README.md` 写 `~16s warm` | **已修** —— 死数字已去掉,改成「要知道现在多久就跑一次 `time bash scripts/qa.sh`」 |
| `docs/qa/strategy.md:50` 写 `~16s warm` | **已修** —— `grep 16s` 在 `docs/qa/strategy.md` 上零命中 |
| `docs/qa/v0-summary.md` 写 `~93s` / `~80s` | 🔴 **仍然如此** |

所以这个 PR 只补最后一格。

## 🔴 但这一格里有一个区分,值得说清楚

`v0-summary.md` **顶部那个 `~93s` 我没有动**:

```
本地一键跑 ~93s（**2026-05 首次测量的墙钟值**；…你这台机上的真值跑 `time bash scripts/qa.sh`），CI ~40s。
```

它**标了日期、标了条件、还告诉你怎么量自己的** —— 那是一条**记录**,记录一个过去的测量不需要跟着现在走。

要改的是下面这个**速查块**:

```bash
bash scripts/qa.sh           # 全跑 ~93s warm
bash scripts/qa.sh --l1      # 只 L1 docker ~80s
```

**它是照抄用的。** 秒数就贴在注释里,读起来像「现在就是这么久」,而且读者复制这一行的时候根本不会往上翻到那句「2026-05 首次测量」。

🔴 **同一句过期的话,写在说明里和写在用户会复制的那一行里,代价不一样。** 前者读者会连着上下文一起读到日期;后者他只会看见那个数。

(今天在 #873 上撞到的是同一个形状:那份文档不只是漏标 preview,**它还专门教用户去敲一条在 `latest` 上不存在的命令**。)

## 数字为什么一定会过期

L1 的耗时随 `scripts/qa.sh` 里 `L1_TESTS` 的成员数走,每个成员各要一次 `docker build` + `docker run`。而那个数一直在涨:

```
写下最早那个「~16s」时（b4c3b291，2026-05-12）    3
#871 立案时                                      17
ce0c99ab（今天）                                 22
```

所以改法是**不再写死秒数**,改成给一条能自己数出来的命令。

## 那条命令我逐字跑过

```
$ bash -c 'source <(sed -n "/^L1_TESTS=(/,/^)/p" scripts/qa.sh); echo "${#L1_TESTS[@]}"'
22
```

🔴 **我第一次不是这么写的。** 我先用正则去抓 `L1_TESTS=( … )`,抓出来 **4** 个,内容全是中文注释片段 —— **自造解析器又一次量错了对象**。改成让 `bash` 自己 `source` 那一段,才拿到 22。文档里给的是后一条。

## 核验

```
doc-symbol-anchors   rc=0
docs-integrity       rc=0
no-memory-slugs      rc=0
home-path-baseline   rc=0
```
