### PR TITLE
chore(guard): 审完两棵文档树并从内存 slug 门的豁免里删掉（同一变异：旧门放行 / 新门拦下，分母 1243→1256）

### DIFF
--- a/.github/scripts/check-no-memory-slugs.py
+++ b/.github/scripts/check-no-memory-slugs.py
@@ -117,10 +117,13 @@ SELF_ALLOWLIST = {
 ALLOWLIST_PATH_PREFIXES = (
     "docs/sop/",
     "docs/rfcs/",
-    "docs/research/",
-    "docs/troubleshooting/",
     "docs/tests/",
 )
+# 2026-08-18 —— `docs/research/`(3 条)与 `docs/troubleshooting/`(2 条)已审完并清空,
+# 两条前缀从此删除,这两棵树从现在起真的被这道门覆盖。
+# 剩下三棵各自的存量:docs/sop/ 24 · docs/rfcs/ 24 · docs/tests/ 4。
+# 🔴 只往下走。**要加回一条前缀,等于说「这棵树又可以泄漏了」** —— 那不是维护动作,
+#    是把已经收回来的覆盖面重新让出去,应该单独立案而不是顺手加。
 
 
 # 🔴 这道门的 FAIL 输出会**原样打印命中的那一段**，而 GitHub Actions 的日志

--- a/docs/research/grok-x-search-capability-probe.en.md
+++ b/docs/research/grok-x-search-capability-probe.en.md
@@ -25,7 +25,7 @@ Erratum 2's "two-tier" split came from R83's trace where the LLM made 17 `run_te
 **Corrective decisions**:
 - ✅ Delete `demos/grok-x-search/fetcher/` + `.env.x.example` — the entire twitterapi.io template
 - ✅ Scenario doc rewritten from "two-tier" to "single native tier + honest boundary + if-you-really-need-faves-integrate-yourself"
-- ✅ RFC-021 §14 banks the lesson: "schema-introspection is necessary but not sufficient"; agent-action E2E is the final gate for capability claims (third occurrence of the same pattern, [[feedback_schema_introspection_not_capability_proof]])
+- ✅ RFC-021 §14 banks the lesson: "schema-introspection is necessary but not sufficient"; agent-action E2E is the final gate for capability claims (third occurrence of the same pattern — schema introspection proves a tool is *declared*, never that invoking it does anything)
 - ❌ **Do not ship any specific third-party X commercial API adapter as the anet default** — users integrate per their needs
 
 ---

--- a/docs/research/grok-x-search-capability-probe.md
+++ b/docs/research/grok-x-search-capability-probe.md
@@ -25,7 +25,7 @@ Erratum 2 的"两档"分级源自 R83 trace 看 LLM 调了 17 次 `run_terminal_
 **修正决策**:
 - ✅ 删 `demos/grok-x-search/fetcher/` + `.env.x.example` 整套 twitterapi.io 模板
 - ✅ scenario doc 改 "两档" 为 "单档 native + 诚实边界 + 如果你真要 faves 集成自己写"
-- ✅ RFC-021 §14 banked: "schema-introspection 是必要但不充分", agent-action E2E 才是 capability claim final gate (第 3 次同模式 lesson, [[feedback_schema_introspection_not_capability_proof]])
+- ✅ RFC-021 §14 banked: "schema-introspection 是必要但不充分", agent-action E2E 才是 capability claim final gate (第 3 次同模式 —— schema 自省只能证明某个工具**被声明了**,永远证明不了调用它会发生什么)
 - ❌ **不 ship 任何特定第三方 X 商业 API 适配作 anet 默认** — 用户按需自集成
 
 ---

--- a/docs/research/intern-tool-calling-code-trace.md
+++ b/docs/research/intern-tool-calling-code-trace.md
@@ -180,4 +180,5 @@ node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts:1233–1238   ToolsField pr
 - SDK马's curl A/B + hotfix validation: [`docs/research/intern-tool-calling-investigation.md`](./intern-tool-calling-investigation.md)
 - The #101 root-cause fix that ships with the TOOLS_PRESET sentinel: [issue #101](https://github.com/sleep2agi/agent-network/issues/101)
 - The #130 hotfix scope: [issue #130](https://github.com/sleep2agi/agent-network/issues/130)
-- The vendor table source of truth (Vincent 4227 verify-with-real-call SOP): [`feedback_vendor_verify_before_hardcode`](../../agent-orchestra/memory/feedback_vendor_verify_before_hardcode.md)
+- The vendor table source of truth is Vincent's verify-with-a-real-call SOP: **do not hardcode a vendor's
+  capability table from its docs — issue one real call and record what came back.**

--- a/docs/troubleshooting/rm-rf-incident-2026-06-16.md
+++ b/docs/troubleshooting/rm-rf-incident-2026-06-16.md
@@ -64,5 +64,7 @@ Two-layer:
 - `tests/lib/safe-rm.sh` (defense)
 - `tests/scripts/lint-no-bare-rm-rf.sh` (regression prevention)
 - `docs/rfcs/RFC-023-destructive-command-guardrail.md` (LLM Bash tool variant)
-- `[[feedback_no_host_test_nodes]]` (sibling red line — "don't run test nodes on the host")
-- `[[feedback_default_flags]]` (`--dangerouslySkipPermissions` default)
+- Sibling red line: **don't run test nodes on the host** — they get a real HOME and a real
+  working tree, so a destructive command inside one is a destructive command on the machine.
+- Sibling red line: `--dangerouslySkipPermissions` **must not be a default** — it removes the
+  last thing standing between a generated command and the filesystem.


### PR DESCRIPTION
## 这个 PR 做的是那个文件头自己要求的事

`.github/scripts/check-no-memory-slugs.py` 的豁免清单上方写着:

```
# REMOVE entries from this list as their backing tree is audited.
```

我审了其中最小的两棵树,清空后把这两条前缀删掉。

```
docs/research/         3 条  →  0   ← 前缀已删
docs/troubleshooting/  2 条  →  0   ← 前缀已删
docs/sop/             24 条        仍豁免
docs/rfcs/            24 条        仍豁免
docs/tests/            4 条        仍豁免
```

## 🔴 见证:同一个变异，改之前那版门放行，改之后拦下

在 `docs/troubleshooting/rm-rf-incident-2026-06-16.md` 末尾加一条内部 slug 引用:

```
【改之前那版门】
scanned 1243 file(s)
OK: no internal memory-slug references found
rc=0                                     ← 放行

【本 PR 这版】
FAIL: found 1 internal memory-slug reference(s). …must not leak into public OSS files…
  docs/troubleshooting/rm-rf-incident-2026-06-16.md:72: <命中的那条>
scanned 1256 file(s)
rc=1                                     ← 拦下

还原后 rc=0，工作树干净
```

**分母也跟着动了:1243 → 1256(+13 个文件)。** 这一条比"红了"更能说明覆盖面真的变宽了 —— **一道门的判据没变、被判的东西变多了,才是覆盖面变化**;只看红/绿分不出"判据变严"和"取集变大"。

## 那 5 条是怎么处理的

不是删掉引用了事,是**把 slug 换成它指的那句话**。门要防的是**内部指针泄漏进公开文件**,而不是禁止这些经验出现在文档里 —— 指针对外人毫无意义,内容才有。

例如那条 `rm -rf` 事故记录原本只列了两个内部条目名,现在写成:

> - Sibling red line: **don't run test nodes on the host** — they get a real HOME and a real
>   working tree, so a destructive command inside one is a destructive command on the machine.
> - Sibling red line: `--dangerouslySkipPermissions` **must not be a default** — it removes the
>   last thing standing between a generated command and the filesystem.

**外部读者第一次读到就能用了**,而原来那两行对他们等于空行。

顺带修掉一条**断链**:`docs/research/intern-tool-calling-code-trace.md:183` 那个引用指向 `../../agent-orchestra/memory/…`,**那是仓外的私有目录** —— 既是断链,也正是这道门要防的形状。改成直接把那条 SOP 写出来。

## 🔴 我在做这件事的路上量错了一次,记在这里

我先自己复现了一遍门的逻辑去数各棵树的命中,得出「有 13 条在豁免之外却没被拦」—— 看起来像**门有 scope bug**。

真跑门:`scanned 1243 / 0 findings / rc=0`。

差异全部来自 `SELF_ALLOWLIST` —— **门自己的脚本和它的 workflow**,那两个文件按设计就写着这些形状。我的复现漏了这一层。

**门是对的,我的复现是错的。** 这是我今天第四次自造判据量错对象(前三次:自写链接扫描器报 671 条断链而真实 0 条;jq 把进行中的 `""` 当成 failing;正则抓 `L1_TESTS` 抓出 4 个中文注释片段)。**四次的偏差方向完全一致:我的复现总是比真判据更松,于是"发现"了不存在的问题。** 所以最后这份 PR 里的每个数字都来自门本身,不是来自我的复现。

## 一个观察,本 PR 不动

这道门 FAIL 时会**原样打印命中的 slug**,而公开仓的 Actions 日志是公开的。文件头已经为 `/home/<user>/` 这一类做了脱敏并解释了理由;slug 没有脱,因为不打印出来就没法定位。**这是一个真实的取舍,不是遗漏** —— 提一句是因为它和文件头讨论的是同一件事,要改应当单独立案。

## 核验

```
python3 .github/scripts/check-no-memory-slugs.py   rc=0   scanned 1256
```
