### PR TITLE
chore(guard): 审完 docs/tests 并删掉第三条豁免前缀（分母 1256→1322，同一变异旧门放行/新门拦下）

### DIFF
--- a/.github/scripts/check-no-memory-slugs.py
+++ b/.github/scripts/check-no-memory-slugs.py
@@ -117,11 +117,12 @@ SELF_ALLOWLIST = {
 ALLOWLIST_PATH_PREFIXES = (
     "docs/sop/",
     "docs/rfcs/",
-    "docs/tests/",
 )
-# 2026-08-18 —— `docs/research/`(3 条)与 `docs/troubleshooting/`(2 条)已审完并清空,
-# 两条前缀从此删除,这两棵树从现在起真的被这道门覆盖。
-# 剩下三棵各自的存量:docs/sop/ 24 · docs/rfcs/ 24 · docs/tests/ 4。
+# 2026-08-18 —— 三棵树已审完并清空,前缀依次删除:
+#   docs/research/(3 条) · docs/troubleshooting/(2 条) · docs/tests/(4 条)
+# 剩下两棵的存量:docs/sop/ 24 · docs/rfcs/ 24。这两棵大得多,
+# 而且 RFC 里有相当一部分是「某个决定的来源就是那条记录」——清它们要先想清楚
+# 替代写法,不是顺手能做完的,所以留在这里。
 # 🔴 只往下走。**要加回一条前缀,等于说「这棵树又可以泄漏了」** —— 那不是维护动作,
 #    是把已经收回来的覆盖面重新让出去,应该单独立案而不是顺手加。
 

--- a/docs/tests/p-grok-0229-image-to-video/report.md
+++ b/docs/tests/p-grok-0229-image-to-video/report.md
@@ -27,4 +27,4 @@ Result: **fired cleanly on first try, ~1m5s turn.** Output:
 1. `imagine` skill in `0.2.29` exposes `image_gen` / `image_edit` / `image_to_video` / `reference_to_video`.
 2. The video demo (`demos/grok-video-gen/`) flow = `image_to_video`, **works reliably on `0.2.29`** (first-try fire, real output).
 3. Demo README updated: correct tool name (`image_to_video`, not `video_gen`/`grok-imagine-video`), state it is image-conditioned (no text-to-video), and replace "alpha flaky" with "verified reliable on `0.2.29`; pin to `0.2.29`+".
-4. Lesson reinforced: capability claims pinned to one CLI version + one test angle age fast; re-verify live on the current version. ([[feedback_schema_introspection_not_capability_proof]])
+4. Lesson reinforced: capability claims pinned to one CLI version + one test angle age fast; re-verify live on the current version. (same pattern as the X-search probe: schema introspection proves a tool is *declared*, never that invoking it does anything)

--- a/docs/tests/p-grok-028-regression-verify/report.md
+++ b/docs/tests/p-grok-028-regression-verify/report.md
@@ -15,7 +15,7 @@
 | **#204 preview.6 HTTP MCP transport (HTTP variant in ACP session/new mcpServers)** | ✅ HOLD | R75 + R77 + R83 三次 0.2.8 alpha session 接受了 HTTP variant payload, ACP `session/new` 不返 -32602 |
 | **#204 preview.7 isolated cwd + grok-isolated-cwd helper** | ✅ HOLD | bun test 11/11 pass (`grok-isolated-cwd.test.ts`); R75 image-to-video probe 的 mp4 落在隔离 cwd 的 grok session 目录 (`~/.grok/sessions/%2Ftmp%2Fp205-img2vid-v2/.../videos/1.mp4`) — 隔离机制端到端 work |
 
-**结论**: 0.2.8 alpha **可以放心 ship**, 但 Vincent 升 stable 之前**仍 hold preview** (per [[feedback_release_preview_first]] + [[feedback_vendor_verify_before_hardcode]])。
+**结论**: 0.2.8 alpha **可以放心 ship**, 但 Vincent 升 stable 之前**仍 hold preview** (两条既定纪律:**先发 preview 并由 Vincent 亲自 UAT,再谈 stable**;以及 **vendor 能力表不照抄文档,发一次真实调用再记录返回**)。
 
 ## 验证矩阵
 
@@ -74,7 +74,7 @@ Ran 87 tests across 8 files. [656.00ms]
 - ❌ 不起 Docker compose 2 节点跑端到端 (heavy, host harness 涵盖)
 - ❌ 不连本机产线 commhub
 - ❌ 不浪费新 LLM quota tick (existing R75 + R77 + R83 已是 0.2.8 alpha 充分证据)
-- ❌ 不 ship preview (per [[feedback_release_preview_first]] — 等 0.2.8 stable + Vincent 自己 UAT pass)
+- ❌ 不 ship preview (纪律:先发 preview 并由 Vincent 亲自 UAT —— 等 0.2.8 stable + Vincent 自己 UAT pass)
 
 ## 后续建议 (P3 / 后续触发)
 

--- a/docs/tests/p212-send-task-storm/report.md
+++ b/docs/tests/p212-send-task-storm/report.md
@@ -110,7 +110,7 @@ LLM 看到这个结构化 error 后, 中文 hint 可以直接 reason / rewrite �
 
 ## 不做的事 (per 红线)
 
-- ❌ 不本机起测试节点(per [[feedback_no_host_test_nodes]])
+- ❌ 不本机起测试节点(红线:测试节点不在宿主上起 —— 它拿到的是真 HOME 和真工作树)
 - ❌ A站Grok 保持停机不动
 - ❌ 不连 prod hub
 - ❌ 不擅自改 grok session 状态文件


### PR DESCRIPTION
接 #973。同一条路子,清掉第三棵树。

```
docs/research/         3 条 → 0    #973 已删前缀
docs/troubleshooting/  2 条 → 0    #973 已删前缀
docs/tests/            4 条 → 0    ← 本 PR 删前缀
docs/sop/             24 条        仍豁免
docs/rfcs/            24 条        仍豁免
```

## 🔴 见证:同一个变异,旧门放行、新门拦下

在 `docs/tests/p212-send-task-storm/report.md` 末尾加一条内部 slug 引用:

```
【#973 那版门】
scanned 1256 file(s)
OK: no internal memory-slug references found
rc=0                                    ← 放行

【本 PR 这版】
FAIL: found 1 internal memory-slug reference(s). …must not leak into public OSS files…
  docs/tests/p212-send-task-storm/report.md:137: <命中的那条>
scanned 1322 file(s)
rc=1                                    ← 拦下

还原后 rc=0，工作树干净
```

**分母 1256 → 1322(+66 个文件)。** `docs/tests/` 是三棵里文件最多的一棵 —— 条目只有 4 条,但**被这道门看见的文件多了 66 个**。这两个数字必须分开看:**「违规多少」和「覆盖多少」是两件事**,只盯前者会把一棵大树当成小事。

## 那 4 条怎么改的

和 #973 一样:**把指针换成它指的那句话**,不是删掉了事。

- `p-grok-028-regression-verify/report.md:18` 原本 `(per <两个内部条目>)` → 写成两条纪律本身:「**先发 preview 并由 Vincent 亲自 UAT,再谈 stable**」「**vendor 能力表不照抄文档,发一次真实调用再记录返回**」
- `p212-send-task-storm/report.md:113` 原本 `(per <一个内部条目>)` → 「**红线:测试节点不在宿主上起 —— 它拿到的是真 HOME 和真工作树**」
- `p-grok-0229-image-to-video/report.md:30` → 「schema 自省只能证明某个工具**被声明了**,永远证明不了调用它会发生什么」

这几份是**测试报告**,读者往往是几个月后来复盘的人。原来那几行对他们等于空行 —— 现在他们不用去任何别处就能读懂当时为什么那样决定。

## 剩下两棵为什么不在这个 PR 里

`docs/sop/` 24 条、`docs/rfcs/` 24 条。它们大得多,而且 **RFC 里有相当一部分是「某个决定的来源就是那条记录」** —— 清它们要先想清楚替代写法(是把内容抄进来,还是改成"这个决定来自一次事故复盘"这样的泛指),那不是顺手能做完的判断。理由写进脚本注释了,不是默默留着。

## 核验

```
python3 .github/scripts/check-no-memory-slugs.py   rc=0   scanned 1322
```
