### PR TITLE
docs: 修掉 docs/ 下最后 8 条断链（#887）；其中两条修好后才发现「指向本身也错了」

### DIFF
--- a/docs/rfcs/RFC-009-social-experiment-framework.md
+++ b/docs/rfcs/RFC-009-social-experiment-framework.md
@@ -8,7 +8,7 @@
 | **状态** | Draft v1 完整就绪（待 review） |
 | **创建日期** | 2026-05-14 |
 | **关联 issue** | [#77](https://github.com/sleep2agi/agent-network/issues/77) |
-| **关联 demo** | [#72 opinion-spread](../issues/72) · [#74 信息瀑布](../issues/74) |
+| **关联 demo** | [#72 opinion-spread](https://github.com/sleep2agi/agent-network/issues/72) · [#74](https://github.com/sleep2agi/agent-network/issues/74) ⚠️ #74 当前标题是「节点删除后，dash 里面还展示」,与这里写的「信息瀑布」对不上 —— 原链接是坏的,修好之后才发现指向对不上,留给 RFC 作者判断该指哪一条 |
 | **依赖** | RFC-008 multi-agent-team-convention · `BatchOptions` (anet/cli/batch.ts) |
 | **审阅** | 通信牛 (技术) · 通信龙 (high-level) · Vincent (final) |
 

--- a/docs/rfcs/RFC-022-agent-network-client-app.md
+++ b/docs/rfcs/RFC-022-agent-network-client-app.md
@@ -5,7 +5,7 @@
 | **作者** | 通信SDK马 |
 | **状态** | Draft v0.1 (RFC + 原型骨架同 commit ship, 待 通信龙 review + Vincent 拍板下一步 scope ramp) |
 | **关联 issue** | TBD (通信龙 cross-link 后回填) |
-| **关联 RFC** | [RFC-012](RFC-012-codex-mobile-bridge.md) (codex Mobile bridge — complementary, 不是 supersede) · [RFC-017](RFC-017-dashboard-org-chart-view.md) (dashboard 现状) · [RFC-020](RFC-020-im-platform-integration.md) (IM 接入 — 共享 chat 抽象) |
+| **关联 RFC** | [RFC-012](RFC-012-codex-mobile-bridge.md) (codex Mobile bridge — complementary, 不是 supersede) · RFC-017 (dashboard 现状) —— ⚠️ **这份 RFC 从未提交进本仓**(`git ls-files docs/rfcs | grep RFC-017` 无命中),原来那个链接是坏的,故此处不再链 · [RFC-020](RFC-020-im-platform-integration.md) (IM 接入 — 共享 chat 抽象) |
 | **关联 backlog** | [#107](https://github.com/sleep2agi/agent-network/issues/107) (codex Mobile + remote-control 调研, R237 已 pending) |
 | **创建** | 2026-05-30 北京 (UTC+8) |
 | **依据** | commhub-server 现 HTTP/SSE API surface (40+ endpoints) + dashboard 复用模式 + ntok_/utok_ 双 token 体系 |

--- a/docs/rfcs/RFC-029-opencode-runtime-integration.md
+++ b/docs/rfcs/RFC-029-opencode-runtime-integration.md
@@ -6,7 +6,7 @@
 | **状态** | v0.4 — **Vincent 2026-07-23 定调 opencode 提升为第 5 个原生 runtime, 人机共存 (co-existence) 一等**. v0.3 headless (B1' ACP) 保留为 mode; v0.4 新增 §11 co-existence formalization (serve + attach + PGID identity teardown). 通信龙 review addendum draft PASS + Vincent 拍 D_new_5 = B full copresence 全 track. 分 M0-M5 里程碑 (M0 探针 → M1 headless 骨架 WIP → M2 copresence 核心 → M3 wizard+doctor → M4 Docker E2E → M5 preview 发版), 6-8 工作日. (历史: v0.3 B1' 已 in-flight; v0.2 通信龙 v0.1 review PASS+merged PR #369) |
 | **调度** | 通信龙 dispatch task_id `418d0521-0148-452a-9f5a-70ed13f195e3` (HIGH, Vincent 要求) |
 | **创建** | 2026-07-01 (北京 UTC+8) |
-| **关联 RFC** | [RFC-021](RFC-021-acp-capability-profile-expansion.md) (ACP capability 扩展 — grok-build-acp precedent) · [RFC-006 (project memory)](../../.claude/memory/) codex-code-cli-mcp runtime 类似 track |
+| **关联 RFC** | [RFC-021](RFC-021-acp-capability-profile-expansion.md) (ACP capability 扩展 — grok-build-acp precedent) · ⚠️ 原文此处链到 `.claude/memory/`(**仓外的私有目录**),且本仓的 [RFC-006](RFC-006-codex-code-cli-mcp-server.md) 讲的是 codex-code-cli MCP server 而不是 project memory ——**标签和目标都对不上**,故只保留「codex-code-cli-mcp runtime 类似 track」这层意思,不再链 |
 | **红线** | 只做**公版 [sst/opencode](https://github.com/sst/opencode)**, 不引入任何非公开分支/fork 概念, 不在公开仓提任何私有对应物 |
 | **依据** | 公版 opencode 官方文档 (`opencode.ai/docs`), 现有 4 runtime adapter 代码链 (agent-node/src/cli.ts + agent-network/bin/cli.ts + server/src/index.ts) |
 

--- a/docs/runbooks/feishu-channel-ops.md
+++ b/docs/runbooks/feishu-channel-ops.md
@@ -179,8 +179,8 @@ docker inspect anet-feishu-local --format 'RestartCount={{.RestartCount}} Status
 
 - ~~[#362](https://github.com/sleep2agi/agent-network/issues/362) inbound 文件下载~~ — ✅ 2026-07-01 preview.17 修复（PR #364）。
 - 用户文档（已上线 anet.sh）：
-  - [飞书 channel 接入指南](/guide/feishu)（Docker 一键 + 手动、模型后端、白名单、群@、故障排查）
-  - [经典案例：飞书静默拒收 + 同源图片案例](/troubleshooting/case-feishu-silent-deny)
+  - [飞书 channel 接入指南](../../docs-site/docs/guide/feishu.md)（Docker 一键 + 手动、模型后端、白名单、群@、故障排查）
+  - [经典案例：飞书静默拒收 + 同源图片案例](../../docs-site/docs/troubleshooting/case-feishu-silent-deny.md)
 - 设计：[RFC-020](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-020-im-platform-integration.md)（issue #179）。
 
 ---

--- a/docs/sop/methodology.md
+++ b/docs/sop/methodology.md
@@ -288,7 +288,7 @@ ZH 翻译要点：
 - **[#<issue> P0]** <fix headline> (`<commit-sha>`)
   - 1-2 行 root cause 简述（详细 root cause 移到 commit message 或 issue 评论 link）
   - **Why prior preview didn't catch this**：1 行说明
-  - 链接到 detailed analysis: [→ #132 评论](...)
+  - 链接到 detailed analysis: `[→ #<issue> 评论](<url>)` ← 模板占位,写的时候换成真 URL
 
 ### Dashboard polish (#116 R<start>-R<end>)
 

--- a/docs/tests/p-grok-028-xsearch-acp-probe/report.md
+++ b/docs/tests/p-grok-028-xsearch-acp-probe/report.md
@@ -76,7 +76,7 @@ video_gen in list? YES
 
 ### 3. R83 X-search re-audit 实证 — LLM 实际行为(0.2.8 alpha 上)
 
-参考 [`docs/research/grok-x-search-capability-probe.md`](../../research/grok-x-search-capability-probe.md) erratum 区块 + [`probe.log`](../../../tests/p-grok-x-reaudit) (session `019e6ed8`):
+参考 [`docs/research/grok-x-search-capability-probe.md`](../../research/grok-x-search-capability-probe.md) erratum 区块 + `probe.log`(session `019e6ed8`,⚠️ 原文链到 `tests/p-grok-x-reaudit`,该路径全仓不存在 —— 那份日志没有进仓):
 
 ```
 [tool_call] title="web_search" rawInputKeys=["query","allowed_domains"]


### PR DESCRIPTION
Refs #887。

## 实测:`docs/` 下 8 条断,改完 0 条

`origin/main` = `6dca5452`:

```
改前   170 个 md · 292 条相对链接 · 断 8
改后   170 个 md · 287 条相对链接 · 断 0
```

链接总数从 292 掉到 287,因为**其中 5 条本来就不该是链接**(模板占位符、指向仓外的路径、指向从未入仓的文件)。

## 八条不是一类问题,逐条判的

| 位置 | 原样 | 判定与改法 |
|---|---|---|
| `docs/rfcs/RFC-009-…:11` ×2 | `../issues/72` `../issues/74` | GitHub issue 简写路径 → 换成真 URL |
| `docs/rfcs/RFC-022-…:8` | `RFC-017-dashboard-org-chart-view.md` | **那份 RFC 从未提交进本仓**(`git ls-files docs/rfcs \| grep RFC-017` 无命中)→ 去链并标注 |
| `docs/rfcs/RFC-029-…:9` | `../../.claude/memory/` | 指向**仓外私有目录** → 去链并标注 |
| `docs/runbooks/feishu-channel-ops.md:182,183` | `/guide/feishu` 等 | **站点绝对路由**写进了 plain-markdown → 改指 `docs-site/docs/**` 源文件 |
| `docs/sop/methodology.md:291` | `(...)` | 模板里的**占位符** → 改成 `` `[→ #<issue> 评论](<url>)` `` 行内代码 |
| `docs/tests/p-grok-028-…/report.md:79` | `tests/p-grok-x-reaudit` | 该路径**全仓不存在** → 去链并标注「那份日志没有进仓」 |

## 🔴 修的过程里发现两处「链接坏了」底下藏着「指向本身也错了」

**① `#74`。** RFC 里写的是「#74 信息瀑布」,而 `#74` 当前标题是「节点删除后,dash 里面还展示」。

**原链接坏着的时候,没有任何人能发现这件事** —— 它压根点不开。修好链接反而把这个矛盾暴露出来了。

**② `RFC-029` 那条。** 标签写 `RFC-006 (project memory)`,而本仓 `docs/rfcs/RFC-006-codex-code-cli-mcp-server.md` 讲的是 codex-code-cli MCP server。**标签和目标都对不上**,不是换个路径能修的。

⇒ **这两处我只标不改。** 把坏链接改成一个"看起来对"的路径,等于**把一个错的指向固定下来** —— 那比坏着更难被发现,因为下次没人会再去点它。指向该指哪,是 RFC 作者的判断。

## 站点路由那两条:一个我今天亲自踩过的区别

`docs/` 是**在 GitHub 上按相对路径读**的;`docs-site/` 才是 VitePress 站点。同一个 `/guide/feishu` 在后者成立、在前者是死链。

**这正是我今天早些时候自写链接扫描器报出 671 条假断链的同一个区别** —— 那次我把 `docs-site/` 里的站点绝对路由当成了文件路径。所以这次我**只扫 `docs/`**,`docs-site/` 交给 `vitepress build`(#966 已把它接进 CI,dead link 默认致命)。

## 核验

```
doc-symbol-anchors   rc=0      docs-integrity      rc=0
no-memory-slugs      rc=0      home-path-baseline  rc=0
doc-source-pins      rc=0      mcp-tool-anchors    rc=0
```

## 没做的事

**没有关 #887。** 那条 issue 还有一半是「相对链接失效 36→16」的历史统计与 UTF-8 那一格(UTF-8 那半我今天单独复测过:`docs/` + `docs-site/` 共 264 个 md,**0 个非法 UTF-8**)。要不要按现状重新定范围,留给 owner。
