### PR TITLE
ci(docs): 相对链接检查从 docs/qa 扩到整个 docs（取集 96/6 → 287/170，起点 0 findings）

### DIFF
--- a/.github/scripts/check-docs-integrity.py
+++ b/.github/scripts/check-docs-integrity.py
@@ -23,16 +23,25 @@ that touches the file, and nothing tells anyone. Measured 2026-08-17: of six suc
 links, `cli.ts#L61` (documented as `PINNED_SERVER_VERSION`) now lands on
 `} from "../src/opencode-preset";` and `cli.ts#L2589` on a line of help text.
 
-Deliberately NOT extended to the rest of docs/: `docs-site/docs/api/mcp-tools.md`
+Deliberately NOT extended to `docs-site/`: `docs-site/docs/api/mcp-tools.md`
 carries 44 of these and all 44 are still in range with plausible content, i.e.
 they are maintained. Reddening on ~100 maintained links would make this a
 backlog canary that dies the day the backlog clears.
 
-Scope is deliberately narrow and stated: UTF-8 validity across every tracked
-.md, link resolution for docs/qa/** only (where the defect was found), and the
-changelog anchor rule. Widening the link check to all docs is a separate
-decision — some files link to generated or gitignored paths, and a guard that
-cries wolf gets disabled.
+🔴 2026-08-18 — the link scope WAS widened, from `docs/qa/` to all of `docs/`.
+The original objection ("widening this would cry wolf") was about a backlog that
+no longer exists: #976 cleared the last 8 broken relative links under `docs/`,
+so the widened scope starts at **0 findings**. That is the whole condition —
+a gate that goes green on day one reddens only when something is newly broken,
+which is the opposite of a backlog canary.
+
+`docs-site/` stays out on purpose, and not for backlog reasons: it is a VitePress
+site, so `/guide/feishu` there is a router route, not a path. Its dead links are
+checked by `vitepress build` itself (fatal by default; wired into CI in #966).
+🔴 Confusing those two cost me a measurement earlier the same day: a hand-written
+scanner that resolved site-absolute routes against the filesystem reported **671**
+broken links where the real build reports **0**. Hence the split — filesystem
+rules for `docs/`, the product's own build for `docs-site/`.
 
 Fail-closed: an empty file list exits 2 rather than reporting a clean run.
 """
@@ -59,6 +68,25 @@ import sys
 MD_LINK = re.compile(r"\]\(([^)\s]+)\)")
 
 
+FENCE = re.compile(r"^[ \t]*(?:```|~~~).*?$.*?^[ \t]*(?:```|~~~)[ \t]*$",
+                   re.MULTILINE | re.DOTALL)
+CODE_SPAN = re.compile(r"`[^`\n]*`")
+
+
+def strip_code(body: str) -> str:
+    """把围栏代码块和行内代码替换成等长空白。
+
+    🔴 markdown 里 `` `](x)` `` 不是链接,是**代码**。扩大扫描范围之后立刻撞上一例:
+    docs/sop/methodology.md 里有一行模板 `` `[→ #<issue> 评论](<url>)` ``,
+    整段在反引号里 —— 它不该被当成断链,但正则看不出反引号。
+
+    替换成**等长空白**而不是删掉,是为了让报错里的位置信息不漂。
+    """
+    def blank(m: "re.Match[str]") -> str:
+        return re.sub(r"[^\n]", " ", m.group(0))
+    return CODE_SPAN.sub(blank, FENCE.sub(blank, body))
+
+
 def is_repo_relative(target: str) -> bool:
     """True for link targets that must resolve to a file in this repo.
 
@@ -69,7 +97,9 @@ def is_repo_relative(target: str) -> bool:
     if not target or target.startswith(("http://", "https://", "#", "mailto:", "/")):
         return False
     return True
-LINK_SCOPE = "docs/qa"
+# 🔴 从 `docs/qa` 扩到 `docs` —— 见文件头。扩之前 #976 先把 docs/ 下最后 8 条断链清掉,
+#    所以扩完的起点是 0 findings,不是一堆存量。
+LINK_SCOPE = "docs"
 CHANGELOG_GLOB = "changelog.md"
 MAIN_LINE_ANCHOR = re.compile(r"blob/main/[\w./-]+#L\d+")
 
@@ -110,7 +140,7 @@ def main() -> int:
     for f in scoped:
         body = open(f, encoding="utf-8", errors="replace").read()
         base = os.path.dirname(f)
-        for target in MD_LINK.findall(body):
+        for target in MD_LINK.findall(strip_code(body)):
             if not is_repo_relative(target):
                 continue
             links += 1
@@ -169,6 +199,24 @@ def selftest() -> int:
         ("in-page anchor excluded", "#anchor" not in found),
         ("site-absolute route excluded", "/guide/feishu" not in found),
         ("exactly the four repo-relative targets", len(found) == 4),
+    ]
+
+    # 🔴 剥代码这一层也要钉。扩大范围当天就撞上一例:模板里整段写在反引号里的
+    #    `[→ #<issue> 评论](<url>)` 被当成断链。剥掉代码之后 288 → 287,
+    #    **只少了这一条** —— 分母几乎没动,说明这层没有顺手放过别的东西。
+    BT = chr(96)
+    coded = (
+        "inline " + BT + "[t](<url>)" + BT + " must not count\n"
+        "real [r](v0-summary.md) must still count\n"
+        + BT*3 + "\n[f](fenced.md)\n" + BT*3 + "\n"
+    )
+    stripped = strip_code(coded)
+    after = [t for t in MD_LINK.findall(stripped) if is_repo_relative(t)]
+    cases += [
+        ("行内代码里的链接不算", "<url>" not in after),
+        ("围栏代码块里的链接不算", "fenced.md" not in after),
+        ("🔴 代码之外的真链接仍然算（不是把整页跳过了）", "v0-summary.md" in after),
+        ("剥代码只剥代码：行数不变", stripped.count("\n") == coded.count("\n")),
     ]
     bad = [name for name, ok in cases if not ok]
     for name, ok in cases:


### PR DESCRIPTION
接 #976。**先清干净,再扩范围** —— 这两步的顺序是这条 PR 的全部理由。

## 起点是 0,不是一堆存量

```
扩之前   docs/qa/     96 条相对链接 ·   6 个文件
扩之后   docs/       287 条相对链接 · 170 个文件 ·  0 findings
```

`check-docs-integrity.py` 的文件头原本写着**不要扩**:

> Widening the link check to all docs is a separate decision — some files link to
> generated or gitignored paths, and **a guard that cries wolf gets disabled**.

**那个顾虑是对的,但它针对的是"扩完会红一片"。** #976 已经把 `docs/` 下最后 8 条断链清掉,所以**现在扩完是绿的** —— 一道第一天就绿的门,只会在**新坏了东西**的时候红,这正好是 backlog canary 的反面。

## 🔴 见证:同一条断链,旧范围放行、新范围拦下

在 `docs/runbooks/`(`docs/qa/` 之外)加一条 `[坏链](./definitely-not-here.md)`:

```
【扩之前】
checked 361 tracked .md …; 96 relative link(s) across 6 file(s) under docs/qa/
no problems.
rc=0                              ← 放行

【本 PR】
::error file=docs/runbooks/feishu-channel-ops.md::relative link './definitely-not-here.md'
        resolves to 'docs/runbooks/definitely-not-here.md', which does not exist
checked 361 tracked .md …; 288 relative link(s) across 170 file(s) under docs/
rc=1                              ← 拦下

还原后 rc=0，工作树干净
```

**取集从 96/6 变成 287/170。** 判据一个字没改 —— 变的是**被判的东西**。

## 扩范围当天就撞上一个假阳性,顺手补了一层

扩完第一次跑,唯一的 finding 是**我自己在 #976 里写的那行模板**:

```
- 链接到 detailed analysis: `[→ #<issue> 评论](<url>)` ← 模板占位,写的时候换成真 URL
```

整段在反引号里 —— **markdown 里那不是链接,是代码**,但正则看不出反引号。

所以加了 `strip_code()`:把围栏代码块和行内代码替换成**等长空白**(等长是为了让报错里的位置不漂),再抽链接。

🔴 **这一层最需要证明的是"它没有顺手放过别的东西"。两个数字:**

- **288 → 287。只少了一条**,正是上面那个占位符。
- selftest 新增 4 条,其中一条专门钉「**代码之外的真链接仍然算**」—— 否则一个"跳过整页"的实现也能让门变绿。

```
collector selftest: 12/12 ok
```

## `docs-site/` 为什么仍然不在范围里(而且不是因为存量)

它是 **VitePress 站点**:`/guide/feishu` 在那里是**路由**,不是路径。它的死链由 `vitepress build` 自己判(默认致命,#966 已接进 CI)。

🔴 **把这两者搞混,同一天让我量错过一次**:一个手写扫描器把站点绝对路由按文件系统解析,报出 **671 条断链**,而真实构建是 **0**。所以现在是明确分工 —— **`docs/` 用文件系统规则,`docs-site/` 用产品自己的构建**,两边都不靠我手写的判据。这段理由写进文件头了。

## 核验

```
python3 .github/scripts/check-docs-integrity.py --selftest   12/12
python3 .github/scripts/check-docs-integrity.py              rc=0
```

(workflow 里这两条都已经在跑,`.github/workflows/docs-integrity.yml:53-54`。)
