### PR TITLE
docs(runtimes): 写明 opencode-cli 默认跑不了 bash（#943 上游；文档里 opencodeUnsafeTools 此前零命中）

### DIFF
--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -28,6 +28,34 @@ Rows tagged `(preview)` below are **preview-only** and not selectable on stable.
 
 > ⚠️ **`opencode-cli` is preview-channel only** (RFC-029, still iterating): npm **latest does not include it yet** — after installing latest, `anet node create` shows only the production runtimes (`claude-code-cli` / `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`). It lands in latest once stable.
 
+> 🔴 **By default it cannot run `bash` — that is the design, not a fault.** `opencode-cli`'s safe
+> default disables **every local tool**: `bash` / `read` / `glob` / `grep` / `edit` / `write` /
+> `list` / `task` / `skill`, plus `question` (unattended, it would wait forever for an interactive
+> answer). So a task that says "run this command" is one this node **has no capability to execute**.
+>
+> The policy lives in [`child-env.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/runtime/opencode-acp/child-env.ts) — 搜 `buildOpencodePermissionPolicy` (`搜` is this repo's machine-checked anchor marker, i.e. "search for"); the ACP and copresence paths read the same switch
+> (`agent-node/src/cli.ts`).
+>
+> ```
+> flags.opencodeUnsafeTools = true    ← enables local tools; trusted tasks only
+> ```
+>
+> `anet node create` prints the policy on the spot (verbatim):
+>
+> ```
+> [anet]    Built-in disabled: bash / read / glob / grep / edit / write / list / task / skill / question
+> [anet]    Cwd:      external disposable workspace (removed after child exit)
+> [anet]    Intended for communication and text-only tasks.
+> ```
+>
+> ⚠️ **Enabling it is not a sandbox** — the product's own wording is `This is not a security
+> sandbox; use Docker/VM for process and filesystem isolation.`
+>
+> **Why this needs its own paragraph**: a missing capability does not look like a failure in the
+> result. See [#943](https://github.com/sleep2agi/agent-network/issues/943) — a task needing `bash`
+> came back as **raw, unexecuted tool-call text**, recorded by the hub as `failed=false`
+> (completed normally). **The dispatcher only finds out by reading the content.**
+
 > OpenCode's built-in Anthropic client sends `x-api-key`. Anthropic-compatible gateways that accept only Bearer authentication, such as Kimi coding, return 401 on that preset; use an OpenCode plugin or custom path that supports the gateway's authentication instead.
 
 > Agent Node does not read environment variables literally named `TOOLS` or `SYSTEM_PROMPT`. Set tools with `--tools` or config `tools`, and the system prompt with `--prompt` or config `systemPrompt`.

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -28,6 +28,34 @@
 
 > ⚠️ **`opencode-cli` 仅 preview 渠道**（RFC-029 迭代中）：npm **latest 尚未包含**——装 latest 后 `anet node create` 选单只有正式版的那几个 runtime（`claude-code-cli` / `claude-agent-sdk` / `codex-sdk` / `grok-build-acp`）。稳定后再进 latest。
 
+> 🔴 **默认它跑不了 `bash`,这不是坏了,是设计。** `opencode-cli` 的安全默认把**全部本机工具**
+> 关掉 —— `bash` / `read` / `glob` / `grep` / `edit` / `write` / `list` / `task` / `skill`,外加
+> `question`(无人值守下它会永远等一个交互回答)。所以派给它「跑一条命令」这类任务时,
+> 它**没有能力执行**。
+>
+> 判据在 [`child-env.ts`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/runtime/opencode-acp/child-env.ts) —— 搜 `buildOpencodePermissionPolicy`;
+> ACP 与 copresence 两条路径读的是同一个开关(`agent-node/src/cli.ts`)。
+>
+> ```
+> flags.opencodeUnsafeTools = true    ← 打开本机工具；仅用于可信任务
+> ```
+>
+> `anet node create` 当场会把这条政策打印出来(逐字):
+>
+> ```
+> [anet]    Built-in disabled: bash / read / glob / grep / edit / write / list / task / skill / question
+> [anet]    Cwd:      external disposable workspace (removed after child exit)
+> [anet]    Intended for communication and text-only tasks.
+> ```
+>
+> ⚠️ **开了之后不是沙箱** —— 产品自己的措辞是 `This is not a security sandbox; use Docker/VM
+> for process and filesystem isolation.`
+>
+> **为什么值得单独写一段**:能力缺失在结果里长得不像「做不到」。见
+> [#943](https://github.com/sleep2agi/agent-network/issues/943) —— 一个需要 `bash` 的任务回来的是
+> 一段**没被执行的工具调用原文**,而 hub 侧记的是 `failed=false`(正常完成)。
+> **派工的人只有读了内容才知道它其实没干活。**
+
 > OpenCode 内置 Anthropic client 发送 `x-api-key`。只接受 Bearer 的 Anthropic 兼容网关（例如 Kimi coding）会返回 401；这类网关要使用支持对应鉴权的 OpenCode plugin 或自定义路径，不能直接套内置 Anthropic preset。
 
 > Agent Node 不读取名为 `TOOLS` 或 `SYSTEM_PROMPT` 的环境变量。工具列表请用 `--tools` 或配置项 `tools`；系统提示词请用 `--prompt` 或配置项 `systemPrompt`。


### PR DESCRIPTION
Refs #943(上游那一格)。

## 文档缺的是什么

`docs-site/**/guide/runtimes.md` 把 `opencode-cli` 怎么装、怎么选 vendor、要哪个 env key 都写了,**唯独没说它默认没有任何本机工具**。

```
$ git grep -ln "opencodeUnsafeTools" -- docs docs-site
（零命中）
```

## 判据是从 `origin/main`(`9d818c81`)读出来的

```ts
// agent-node/src/runtime/opencode-acp/child-env.ts
/** Local-capability tools disabled by the preview's safe default. */
export const OPENCODE_LOCAL_TOOL_KEYS = [
  "bash", "read", "glob", "grep", "edit", "write", "list", "task", "skill", …
] as const;

export function buildOpencodePermissionPolicy(unsafeTools: boolean) {
  return { "*": unsafeTools ? "allow" : "deny", ...toolMap(unsafeTools ? "allow" : "deny"), …
```

```ts
// agent-node/src/cli.ts:3047 与 :3116 —— ACP 与 copresence 两条路径同一个开关
unsafeTools: fileConfig.flags?.opencodeUnsafeTools === true,
```

⇒ **派给它「跑一条命令」这类任务时,它没有能力执行。**

## 为什么值得单独一段,而不是往表格里塞一格

🔴 **能力缺失在结果里长得不像「做不到」。**

#943 实测:一个需要 `bash` 的任务,回来的是**没被执行的工具调用原文**,而 hub 侧记的是 `failed=false`(正常完成)。**派工的人只有读了内容才知道它其实没干活** —— 任何按状态/计数的看板视角都看不到。

所以这一段的重点不是"有个开关",是**"这个默认会让失败看起来像成功"**。

## 文档里贴的是产品原文

那三行是 `anet node create` 当场打印的(`agent-network/bin/cli.ts:3364-3368`),**不是我转述的版本** —— 用户看到的和文档写的必须逐字一致。同时保留了产品自己的那句免责:

> `This is not a security sandbox; use Docker/VM for process and filesystem isolation.`

## 🔴 两处过程,写在 commit 里也放这里

**① 我自己参与落地的那道门抓住了我自己。**

第一版被 `doc-symbol-anchors` 拦下:

```
::error file=docs-site/docs/guide/runtimes.md,line=36::symbol anchor
  `buildOpencodePermissionPolicy` — no source link precedes this anchor
```

补上指向 `child-env.ts` 的链接后 **77/77** 通过。

**② 我一度想顺手把那道门的 `搜` 扩成 `(?:搜|grep)`**,好让英文页不必写中文标记。实测:

```
锚点 77 → 145，32 条不过
```

**那会当场造出一个积压门** —— 正是今天 #976 → #977 那条链要避免的形状(**先清干净,再扩范围**)。所以**撤回了**,改为在英文页里说明 `搜` 是本仓的机器可检标记。

要扩它,得先像 #976 那样把那 32 条清完,再另开一条 PR。**不在这条里顺手做。**

## 核验

```
vitepress build        rc=0   build complete in 36.98s   95 页
doc-symbol-anchors     rc=0   77/77
docs-integrity         rc=0   287 links / 170 files under docs/
no-memory-slugs        rc=0
doc-version-claims     rc=0
```
