### PR TITLE
fix(test): 把 message-lifecycle 移出 bun test 的 glob（#889；我原计划的修法会把红换成跑了 6% 的假绿）

### DIFF
--- a/agent-node/tests/archive/message-lifecycle.integration.mjs
+++ b/agent-node/tests/archive/message-lifecycle.integration.mjs
@@ -5,11 +5,27 @@
  * 前置：CommHub Server 在 9210 端口运行
  *   PORT=9210 bun run server/src/index.ts
  *
- * 运行：node tests/message-lifecycle.test.mjs
+ * 运行：node tests/archive/message-lifecycle.integration.mjs
+ *
+ * 🔴 文件名里**不带 `.test.`** 是有意的。它原名 `message-lifecycle.test.mjs`，
+ *    于是被 `bun test` 的默认 glob 捞进套件 —— 而它是个顶层脚本，末尾有
+ *    `process.exit(failed > 0 ? 1 : 0)`。**在被 runner 加载的文件里调
+ *    process.exit 会杀掉整个 runner。**
+ *    实测:把前置检查改成"跳过时 process.exit(0)"之后，整套件只跑到第 7 个
+ *    文件就结束，却给出 rc=0 —— 108 个文件里 6% 都不到，外面看是一片绿。
+ *    它一直没炸，只是因为每次都先崩在 TypeError 上，**从没执行到那一行**。
+ *    ⇒ 这个文件本来就该按它自己文档说的那样用 node 单独跑。
  */
 
 const HUB = "http://127.0.0.1:9210";
-const HEADERS = { "Content-Type": "application/json", Accept: "application/json, text/event-stream" };
+// 这个 hub 现在是要鉴权的(`security: "secured"`, `v3_auth: true`)。本文件写于鉴权之前，
+// 一直不带凭据地调 API，于是每次都拿 401、读回空数组。给它一个 token 入口。
+const HUB_TOKEN = process.env.ANET_TEST_HUB_TOKEN || "";
+const HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+  ...(HUB_TOKEN ? { Authorization: `Bearer ${HUB_TOKEN}` } : {}),
+};
 
 let passed = 0;
 let failed = 0;
@@ -49,12 +65,41 @@ async function getStatus(alias) {
 
 function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
-// ── Check CommHub is running ──
+// ── 前置:hub 得**用得了**，不只是"有人接 TCP" ──
+//
+// 🔴 原来这里是 `try { await fetch(HUB + "/health") } catch { exit(1) }`。
+//    两处不成立:
+//      - `fetch` **只在网络层出错才 throw** —— 401 / 500 都不 throw；
+//      - `/health` 是免鉴权的，稳定返 200。
+//    所以它实际只验证了"有人接 TCP"，放行了一个本测试根本用不了的 hub，
+//    然后在 200 行开外崩成 `undefined is not an object`，
+//    报出来的东西和真因(401)毫无关系。
+//    ⇒ 前置必须打一个**需要鉴权**的端点，并按状态码分开三种结局。
+function skip(reason, hint) {
+  console.log("╔═══════════════════════════════════════════╗");
+  console.log("║  SKIPPED — 依赖未就绪，未执行任何断言     ║");
+  console.log("╚═══════════════════════════════════════════╝");
+  console.log(`  原因: ${reason}`);
+  console.log(`  如何跑起来: ${hint}`);
+  // 依赖没备好不是产品缺陷 —— 报红会训练人忽略这一行。
+  // 但**必须吵**:上面那三行是无条件打印的，不存在"安静地跳过"。
+  process.exit(0);
+}
+
+let preflight;
 try {
-  await fetch(`${HUB}/health`);
+  preflight = await fetch(`${HUB}/api/status`, { headers: HEADERS });
 } catch {
-  console.error(`CommHub not running on ${HUB}. Start with: PORT=9210 bun run server/src/index.ts`);
-  process.exit(1);
+  skip(`CommHub 不在 ${HUB} 上`, `PORT=9210 bun run server/src/index.ts`);
+}
+if (preflight.status === 401) {
+  skip(
+    `${HUB} 活着但拒绝本测试的凭据(HTTP 401)`,
+    `ANET_TEST_HUB_TOKEN=<user token> node tests/archive/message-lifecycle.test.mjs`,
+  );
+}
+if (!preflight.ok) {
+  skip(`${HUB}/api/status 返回 HTTP ${preflight.status}`, `先确认那个 hub 是本测试预期的版本`);
 }
 
 console.log("╔═══════════════════════════════════════════╗");
@@ -238,8 +283,8 @@ for (let i = 0; i < 3; i++) {
 await sleep(500);
 const inbox4 = await getInbox(AGENT);
 assert(inbox4.length === 3, `3 条 task 入 inbox: ${inbox4.length}`);
-assert(inbox4[0].content === "task 0", "顺序正确: task 0");
-assert(inbox4[2].content === "task 2", "顺序正确: task 2");
+assert(inbox4[0]?.content === "task 0", "顺序正确: task 0");
+assert(inbox4[2]?.content === "task 2", "顺序正确: task 2");
 await ackAll(AGENT);
 
 // Test 7: auto-compact 阈值 (单元测试)


### PR DESCRIPTION
Closes #889。

## 🔴 先说清楚:这条 PR 的改动不是我写的,是我**先在仓里找到、复核后 rebase 上来**的

我本来打算按 #889 正文里建议的两条自己动手:①前置检查改成打需要鉴权的端点 ②给结构性断言加 `process.exit(1)` 让它别级联崩。

**开分支的时候撞上一条同名的本地分支,上面已经有一个提交在做这件事了**(落后 main 100 个提交、从未推送)。我去读了它 —— **它比我打算写的对,而且我那版会踩上一个它已经踩过的坑。**

## 我差点引入的问题

那个提交的原文写着:

> **在被 runner 加载的文件里调 `process.exit` 会杀掉整个 runner。**
> 实测:把前置检查改成"跳过时 `process.exit(0)`"之后,整套件只跑到第 7 个文件就结束,却给出 `rc=0` —— 108 个文件里 6% 都不到,**外面看是一片绿**。

**我计划里的 `assertOrStop(...) { … process.exit(1) }` 正是这个形状。** 我会把一个吵闹的红换成一个跑了不到 6% 的假绿。

而这个机关**本来就在文件里**(末尾一直有 `process.exit(failed > 0 ? 1 : 0)`),只是**每次都先崩在 TypeError 上,从没执行到那一行** —— 修掉崩溃反而会激活它。

## 它的修法

这个文件的头部自己就写着「运行:`node tests/…`」——**它本来就是独立集成脚本**,只是名字里带 `.test.` 才被 `bun test` 的默认 glob 捞进套件。

⇒ **改名移出 glob**(`message-lifecycle.test.mjs` → `message-lifecycle.integration.mjs`),`process.exit` 的机关随之消失,脚本本身照常可用。同时补了 `ANET_TEST_HUB_TOKEN` 入口,让它对一个 secured hub 也能真跑。

## 我在今天的 main 上重新验证了

**① bun 自己说它不再被捞:**

```
$ bun test tests/archive/
The following filters did not match any test files …
303 files were searched [16.00ms]
note: Tests need ".test", "_test_", ".spec" or "_spec_" in the filename
```

**② 正控 —— 把同一份文件复制成 `x.test.mjs` 就会被捞到**,而且新的前置检查打印的是:

```
║  SKIPPED — 依赖未就绪，未执行任何断言     ║
  原因: CommHub 不在 http://127.0.0.1:9210 上
  如何跑起来: PORT=9210 bun run server/src/index.ts
```

不是原来那句 `undefined is not an object (evaluating 'inbox4[0].content')`。

**③ CI 的分母没被动到:**

```
agent-node/src 下 *.test.ts        92   （test725 下限 80）
agent-node/tests 顶层 *.test.ts     6   （test725 下限 5）
```

改名的文件在 `tests/archive/` 子目录、且不再带 `.test.`,**两个计数都不受影响**。

**④ `node --check` 通过。**

## 顺带查了一遍同族,结论是干净的

我担心别处也有"会被 glob 捞到 + 顶层 `process.exit`"的组合,扫了 `agent-node/src` + `server/src` + `agent-network/src` 的 `*.test.ts`,拿到 7 个候选。**逐个看完:全部在模板字符串里**——它们是给假二进制用的 stub 脚本(`#!/usr/bin/env bun … process.exit(0)`),不是测试文件自己的顶层调用。

**候选 7 个,真问题 0 个。** 记在这里是因为「grep 到了」和「有问题」是两件事,而这次正好是前者。
