### PR TITLE
fix(grok-build-cli): 让 busy 报错说出它拿的是哪把锁（#884；来自一条躺了两天从未推送的本地分支）

### DIFF
--- a/agent-node/src/runtime/grok-build-cli-home.test.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.test.ts
@@ -1392,6 +1392,13 @@ describe("prepareGrokCliHome", () => {
     let busy = "";
     try { await acquireGrokProjectTurnLock(alias); } catch (error: any) { busy = error?.message || String(error); }
     expect(busy).toContain("project is busy");
+    // issue #884: "busy" alone points at a process to kill. When the root came
+    // from walking *up* out of the caller's directory, the message has to say
+    // which lock it took and where the root came from — that is the whole
+    // difference between a 5-minute fix and an hour of hunting.
+    expect(busy).toContain(join(project, ".anet", ".grok-build-cli-turn.lock"));
+    expect(busy).toContain("resolved by walking up from");
+    expect(busy).toContain("#884");
     await first.release();
     const second = await acquireGrokProjectTurnLock(alias);
     await second.release();

--- a/agent-node/src/runtime/grok-build-cli-home.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.ts
@@ -1113,6 +1113,21 @@ export async function acquireGrokProjectTurnLock(
 ): Promise<GrokProjectTurnLock> {
   const lexicalRoot = grokProjectWalk(cwd).root;
   const projectRoot = realpathSync(lexicalRoot);
+  // issue #884: the walk goes *up*, so a caller under a directory that happens
+  // to sit below someone else's `.anet` silently shares that project's lock.
+  // Test fixtures under `tmpdir()` are the usual victim: every fixture lands on
+  // one lock and they serialize against each other. Remember whether the root
+  // came from above the caller so the busy message can say so — "project is
+  // busy" on its own sends people hunting for a process to kill.
+  // The walk returns `cwd` itself or one of its ancestors, so plain inequality
+  // is the whole test. Resolving `cwd` can throw if it was removed underneath
+  // us; that is not worth failing a lock over, so fall back to "not above".
+  let rootIsAboveCaller = false;
+  try {
+    rootIsAboveCaller = realpathSync(cwd) !== projectRoot;
+  } catch {
+    rootIsAboveCaller = false;
+  }
   const projectStat = statSync(projectRoot);
   if (!projectStat.isDirectory()) throw new Error(`grok-build-cli project root is not a directory: ${projectRoot}`);
 
@@ -1184,7 +1199,8 @@ export async function acquireGrokProjectTurnLock(
       holder.once("exit", (code) => {
         if (!settled) {
           fail(code === 1
-            ? "grok-build-cli project is busy; concurrent turns are refused"
+            ? `grok-build-cli project is busy; concurrent turns are refused (lock ${lockPath}${
+              rootIsAboveCaller ? `, resolved by walking up from ${cwd} — see issue #884` : ""})`
             : `grok-build-cli flock holder exited before acquisition (${code ?? "signal"}${stderr ? `: ${stderr.trim()}` : ""})`);
         }
       });


### PR DESCRIPTION
Refs #884。

## 🔴 这个改动不是我写的 —— 它在一条**从未推送**的本地分支上躺了两天

上一轮我数了本地分支池:**768 条里 22 条带着从未落地的提交,而它们指向的 issue 现在还开着**(清单发在 #856)。这是从那份清单里挑的**最小一条**,把它 rebase 到今天的 main 上落地。

原提交 `b6af4d49`(2026-08-16),2 个文件 `+24 / -1`。

## 它改的是什么

```
改前   grok-build-cli project is busy; concurrent turns are refused
改后   grok-build-cli project is busy; concurrent turns are refused
       (lock <路径>, resolved by walking up from <cwd> — see issue #884)
```

**「busy」这个词把人指向"去找一个进程杀掉"。** 真实原因通常是:项目根的查找是**往上走**的,于是一个位于别人 `.anet` 之下的调用者**静默共享了那个项目的锁** —— `tmpdir()` 下的测试夹具是最常见的受害者,**每个夹具都落到同一把锁上,然后互相串行**。

原作者在提交信息里写了一段我觉得值得原样引的话:

> #884 already documents this and gives the workaround. **It did not help me**: on 2026-08-16 I hit the same 42 red tests, saw an unrelated `Could not resolve "undici"` in the same output, and attributed the whole thing to missing dependencies. **The rule was written down correctly and I was looking somewhere else.** So put it in the line people actually read.

⇒ **规则写在 issue 里没用,得写在人真正会读的那一行 —— 也就是报错本身。**

## 我在今天的 main 上重新验了

**① cherry-pick 干净落地**(`origin/main = a55ea02e`),无冲突。

**② 测试通过:**
```
$ TMPDIR=<隔离目录> bun test src/runtime/grok-build-cli-home.test.ts
39 pass / 0 fail / 287 expect() calls
```

**③ 见证红 —— 把提示语抹掉,断言必须红:**
```
(fail) prepareGrokCliHome > flocks the canonical project inode across symlink aliases and releases cleanly
38 pass / 1 fail
rc=1
```
还原后工作树干净。**变异前先断言替换目标只出现 1 次,所以这不是一次 no-op 编辑假装通过。**

(隔离 `TMPDIR` 是必须的 —— 见 #865:测试和真实节点共用 `/tmp` 全局锁。这条 issue 和 #884 是同一个根:**锁的作用域比人以为的大**。)

## 为什么这条可以直接落,而清单上别的不行

上一轮我说过那 22 条**不能机械 rebase**,因为里面有**两天前核对的事实断言**。

**这一条不含事实断言。** 它是**措辞改动**:锁的判定逻辑一个字没改,新增的只有 `lockPath` 和 `rootIsAboveCaller` 两个**运行时事实**拼进错误串 —— 它们由代码当场算出,不是谁在 8 月 16 日核对过的结论。

⇒ **判断一条旧分支能不能直接落,看的不是它有多小,是它有没有把「当时核对的事实」写死进去。** 这条没有,所以它可以;`docs/886-rfc022-review-corrections` 只有 1 个提交 1 个文件,但它把「#247 已经做掉某件事」写进了文档,所以它不行。
