### PR TITLE
feat(grok-copresence): 让「忙」和「卡死 44 分钟」在日志里长得不一样（#870；清单第 2 条）

### DIFF
--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -17,6 +17,7 @@ import { dirname, isAbsolute, join, resolve } from "path";
 import { setTimeout as delay } from "timers/promises";
 import { StringDecoder } from "string_decoder";
 import { startGrokAttachServer, type GrokAttachServer } from "./attach";
+import { describeStuckPhase } from "./stuck-phase-alarm";
 import {
   newGrokJsonlState,
   flushPendingGrokNetworkReply,
@@ -662,6 +663,10 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
   readonly attachSocket: string;
 
   private arbitration = newGrokCopresenceState();
+  // issue #870: when the arbitration phase entered its current value. Only
+  // moved on an actual phase change, so receiving a task while busy cannot
+  // reset the clock that is supposed to reveal being stuck.
+  private phaseSince = Date.now();
   private logState: GrokJsonlState = newGrokJsonlState();
   private pty: GrokPtyLike | null = null;
   private activeTui: GrokTuiGeneration | null = null;
@@ -937,7 +942,23 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
       // attach socket can claim the composer before network injection.
       setImmediate(() => this.scheduleNetworkIfIdle());
       this.broadcastState();
-      if (wasBusy) this.log(`[grok-copresence] queued network task ${opts.taskId}`);
+      if (wasBusy) {
+        // issue #870: `queued network task <id>` on its own reads exactly like
+        // an ordinary busy node. The two facts that separate "busy" from
+        // "stuck" — which phase, and for how long — were already known here and
+        // were simply not being said.
+        const phaseAgeMs = Date.now() - this.phaseSince;
+        this.log(`[grok-copresence] queued network task ${opts.taskId} `
+          + `(phase=${this.arbitration.phase}, ${Math.round(phaseAgeMs / 1000)}s in phase, `
+          + `${this.arbitration.queue.length} queued)`);
+        const stuck = describeStuckPhase({
+          phase: this.arbitration.phase,
+          phaseAgeMs,
+          alreadyQueued: Math.max(0, this.arbitration.queue.length - 1),
+          taskTimeoutMs: timeoutMs,
+        });
+        if (stuck) this.warn(`[grok-copresence] ${stuck}`);
+      }
     });
   }
 
@@ -2188,8 +2209,10 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
   }
 
   private transition(event: GrokCopresenceEvent) {
+    const previousPhase = this.arbitration.phase;
     const result = reduceGrokCopresenceState(this.arbitration, event);
     this.arbitration = result.state;
+    if (result.state.phase !== previousPhase) this.phaseSince = Date.now();
     if (result.accepted && event.type === "schedule_network") {
       this.activeTurnTerminalEventSeen = false;
     } else if (result.accepted && event.type === "human_input_submitted") {

--- a/agent-node/src/runtime/grok-copresence/stuck-phase-alarm.test.ts
+++ b/agent-node/src/runtime/grok-copresence/stuck-phase-alarm.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { describeStuckPhase, STUCK_PHASE_WARN_MS } from "./stuck-phase-alarm";
+
+const base = { phase: "network_turn", phaseAgeMs: 0, alreadyQueued: 0, taskTimeoutMs: 300_000 };
+
+describe("describeStuckPhase", () => {
+  test("says nothing while idle, no matter how long", () => {
+    // An idle runtime that has been idle for a day is not stuck; it is idle.
+    expect(describeStuckPhase({ ...base, phase: "idle", phaseAgeMs: 86_400_000 })).toBeNull();
+  });
+
+  test("says nothing for an ordinary long turn", () => {
+    // The measured slow tail on these nodes is tens of seconds (#891). A
+    // warning that fires there would be noise, and noise gets ignored, which
+    // costs more than the missing warning did.
+    expect(describeStuckPhase({ ...base, phaseAgeMs: 35_000 })).toBeNull();
+    expect(describeStuckPhase({ ...base, phaseAgeMs: STUCK_PHASE_WARN_MS - 1 })).toBeNull();
+  });
+
+  test("fires at the threshold and names the phase, the wait, and the issue", () => {
+    const msg = describeStuckPhase({ ...base, phaseAgeMs: STUCK_PHASE_WARN_MS });
+    expect(msg).toContain("phase=network_turn");
+    expect(msg).toContain("2m");
+    expect(msg).toContain("#870");
+    // It must say the outcome, not just the state — "stuck" without "your task
+    // will fail in 300s" leaves the reader with nothing to decide.
+    expect(msg).toContain("300s");
+  });
+
+  test("fires before the first task's own timeout, not with it", () => {
+    // 🔴 The whole point: a warning delivered at the same moment as the
+    // failure teaches nothing. Assert the ordering rather than the constant.
+    expect(STUCK_PHASE_WARN_MS).toBeLessThan(base.taskTimeoutMs);
+  });
+
+  test("counts the tasks already waiting", () => {
+    const msg = describeStuckPhase({ ...base, phaseAgeMs: 600_000, alreadyQueued: 3 });
+    expect(msg).toContain("3 task(s) already waiting");
+    const alone = describeStuckPhase({ ...base, phaseAgeMs: 600_000, alreadyQueued: 0 });
+    expect(alone).not.toContain("already waiting");
+  });
+
+  test("refuses to guess on a non-finite age", () => {
+    expect(describeStuckPhase({ ...base, phaseAgeMs: Number.NaN })).toBeNull();
+    expect(describeStuckPhase({ ...base, phaseAgeMs: Number.POSITIVE_INFINITY })).toBeNull();
+  });
+
+  test("does not claim it will recover", () => {
+    // The runtime has no recovery path for this state (#870), and a message
+    // that implies one would send people away to wait it out.
+    const msg = describeStuckPhase({ ...base, phaseAgeMs: 900_000 }) ?? "";
+    expect(msg).toContain("no automatic recovery");
+  });
+});

--- a/agent-node/src/runtime/grok-copresence/stuck-phase-alarm.ts
+++ b/agent-node/src/runtime/grok-copresence/stuck-phase-alarm.ts
@@ -1,0 +1,54 @@
+/**
+ * Decide whether a queued-but-never-injected network task looks like issue
+ * #870, and say so in words a human can act on.
+ *
+ * #870: injection is gated on `arbitration.phase === "idle"`, and a task
+ * timeout deliberately does **not** reset the phase — the shared TUI turn may
+ * genuinely still be running, and forcing idle would allow a concurrent
+ * injection. That reasoning is sound. The consequence is that if the
+ * `turn_ended` boundary is never observed, the runtime stays busy forever and
+ * every later task queues until its own 300 s timeout, with no recovery path.
+ *
+ * The observed incident (2026-08-14, 通信狗) is 44 minutes of complete silence
+ * during which every health signal was green: both sockets present, five child
+ * processes, a fresh `idle` timestamp on the hub. The only visible trace was
+ * `queued network task <id>` with no matching `injected` line — which reads
+ * exactly like an ordinary busy node.
+ *
+ * 🔴 This module deliberately does **not** decide to recover. Forcing idle is a
+ * concurrency decision about a shared TUI and does not belong in a diagnostic.
+ * What it removes is the silence: the difference between "busy" and "stuck" is
+ * already knowable at queue time, and nothing was saying it.
+ */
+
+export interface StuckPhaseInput {
+  /** Current arbitration phase; `"idle"` can never be stuck by definition. */
+  readonly phase: string;
+  /** Milliseconds spent in the current phase. */
+  readonly phaseAgeMs: number;
+  /** Tasks already waiting, not counting the one being queued now. */
+  readonly alreadyQueued: number;
+  /** Per-task timeout, so the message can say what happens next. */
+  readonly taskTimeoutMs: number;
+}
+
+/**
+ * Fire well before the first task's own timeout — a warning that arrives with
+ * the failure teaches nothing. Two minutes is short enough to precede the
+ * observed 300 s timeout and long enough that an ordinary long turn (the
+ * measured slow tail on these nodes is tens of seconds) does not trip it.
+ */
+export const STUCK_PHASE_WARN_MS = 120_000;
+
+export function describeStuckPhase(input: StuckPhaseInput): string | null {
+  if (input.phase === "idle") return null;
+  if (!Number.isFinite(input.phaseAgeMs) || input.phaseAgeMs < STUCK_PHASE_WARN_MS) return null;
+  const minutes = Math.floor(input.phaseAgeMs / 60_000);
+  const queued = input.alreadyQueued > 0
+    ? `${input.alreadyQueued} task(s) already waiting behind it; `
+    : "";
+  return `arbitration has been phase=${input.phase} for ${minutes}m without reaching idle — `
+    + `${queued}network tasks cannot be injected until a turn_ended boundary arrives, and each `
+    + `will fail after ${Math.round(input.taskTimeoutMs / 1000)}s. This is the shape of issue #870; `
+    + `there is no automatic recovery from it.`;
+}


### PR DESCRIPTION
Refs #870。来自 #856 那份清单的**第二条**(`feat/870-stuck-phase-alarm`,1 提交 3 文件),rebase 到今天的 main。

## 它补的是什么

一个排队的网络任务只打一行 `queued network task <id>`。

🔴 **那一行在「节点正在跑一轮」和「节点已经卡死 44 分钟」两种情况下逐字相同。** 2026-08-14 那次事故就是这个样子:

> 每一个健康信号都是绿的 —— 两个 socket、五个子进程、hub 上一个新鲜的 `idle` 时间戳 —— 而两个任务排进去、从没被注入,各自在自己的 300s 超时上失败。

**分开「忙」和「卡」的那两个事实,在打那一行的时候就已经在手里了,只是没被说出来。** 现在日志带上**当前 phase、在这个 phase 里待了多久、队列深度**;超过阈值再补一条警告,点名状态、接下来会发生什么、以及 issue 号。

## 设计上四个我认为值得指出的选择(都是原作者的)

- `describeStuckPhase()` 是**纯函数、吃毫秒数**,所以它的测试是确定性的,不依赖时钟。
- `phaseSince` **只在真的换 phase 时才动** —— 于是「忙着的时候又收到一个任务」不会重置那个本来用来暴露卡死的计时器。
- 阈值 120s **低于** 300s 的任务超时是故意的:**一条和失败同时到达的警告什么都教不了。** 而测试断言的是**这个先后关系**,不是那个常量。
- 普通的长回合不能触发它。这些节点实测的慢尾是**几十秒**(#891),所以 35s 被断言为静默。

🔴 **刻意没做的事:自动恢复。** 把 phase 重置成 idle 是一个关于**共享 TUI 的并发决定**,现有代码注释解释了超时路径为什么拒绝这么做,那个理由今天仍然成立。**一个诊断不是推翻它的地方。** 所以警告里直说「没有自动恢复」,免得被读成「等一会就好了」。

## 我在今天的 main 上重新核了

**① 那条被写进去的事实还成立吗** —— 这是我这轮挑分支的判据(见 #981):

```
agent-node/src/cli.ts:630 / :661 / :3553 / :4080   → 300_000 仍是默认超时
agent-node/src/runtime/grok-copresence/runtime.ts:958
    taskTimeoutMs: timeoutMs        ← 运行时传的是【实时值】，不是写死的 300s
```

⇒ **它没有把「300s」焊进逻辑**,只在测试夹具里用它当一个具体数。**这正是它能直接落、而 `docs/886-…` 不能的原因** —— 后者把「#247 已经做掉某件事」写死进了文档。

**② cherry-pick 干净落地**,无冲突。

**③ 测试全绿:**
```
$ TMPDIR=<隔离目录> bun test src/runtime/grok-copresence/
145 pass / 0 fail / 750 expect() calls   （10 个文件）
```

**④ 见证红 —— 把阈值推到任务超时之上(120_000 → 999_000):**
```
(fail) describeStuckPhase > fires at the threshold and names the phase, the wait, and the issue
(fail) describeStuckPhase > fires before the first task's own timeout, not with it
(fail) describeStuckPhase > counts the tasks already waiting
(fail) describeStuckPhase > does not claim it will recover
3 pass / 4 fail
```
其中第二条正是那个**先后关系**断言。还原后工作树干净。

## 为什么这类改动值得单独落

它**不修任何 bug**,它只是让一行日志说出它本来就知道的事。

🔴 而今天我已经在三个不同的地方撞上同一个形状:#884 的 `busy` 报错不说是哪把锁、#943 的 `failed=false` 不说能力被拒、这条的 `queued` 不说卡了多久。**共同点是:分辨所需的事实在现场已经有了,只是没被写进人会读的那一行。**
