### PR TITLE
docs(mcp-tools): status 回答的是「上次上报时是什么」——实测 idle 有三种现实，task 可能是你自己的回声

### DIFF
--- a/docs-site/docs/api/mcp-tools.md
+++ b/docs-site/docs/api/mcp-tools.md
@@ -577,6 +577,27 @@ send_task({
 `get_all_status` 走 `SELECT * FROM sessions`（[`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) 搜 `SELECT * FROM sessions WHERE 1=1`，无 JOIN）。`sessions` 表 schema（[`db.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts) 搜 `CREATE TABLE IF NOT EXISTS sessions` + V2 migration [`db.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts) 搜 `ALTER TABLE sessions ADD COLUMN`）**有 `model` 列** —— V2 migration `ALTER TABLE sessions ADD COLUMN model`，且 `report_status` 的 `sessions` upsert 无条件写 `sessions.model = COALESCE(model, 旧值)`（[`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) 在 `report_status` 段搜 `INSERT INTO sessions`（写这几列的是 `report_status`，不是本节这个 tool） 与 `model = COALESCE(?20, sessions.model)`）。所以 `get_all_status` 直接返回每个 session 的 `model`（agent 没传 `model` 参数时为 `null`）。`nodes` 表里也有一份 `model`（传 `node_id` 时由 `report_status` 同步），是更持久的来源。`summary` 是按 status 分组的全 scope 计数（同 `list_tasks` 的 `stats`）。
 :::
 
+
+::: danger 🔴 `status` 回答的是「它上次上报时是什么」,不是「它现在在不在干活」
+`sessions.status` / `progress` **只在节点主动调 `report_status` 的那一刻更新**([`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) 在 `report_status` 段搜 `INSERT INTO sessions`),`report_completion` 会把它复位成 idle([`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) 在 `report_completion` 段搜 `UPDATE sessions SET status = 'idle', task = NULL, progress = 0`)。
+
+**中间没有任何东西会替节点改它。** 所以 `status: "idle"` 至少对应三种现实:
+
+| | 现实 | 面板长相 |
+|---|---|---|
+| ① | 真的空闲 | `idle` |
+| ② | 收到了任务但没消费(卡死 / 循环没醒) | `idle` |
+| ③ | **正在跑一个长任务,中途不上报** | `idle` |
+
+🔴 **实测(2026-08-18)**:一个节点连续 75 分钟显示 `status=idle` / `progress=100` / 心跳每次都 <2.5 分钟,而它自己回执说那段时间一直在跑一条长同步线 —— **落在 ③**。
+
+**`task` 更容易误读:它可能是发送方自己写上去的。** `send_task` 在自己的事务里就把任务前 200 字盖到目标 session 上([`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) 在 `send_task` 段搜 `UPDATE sessions SET task = ?1`);`report_status` 也能写同一列(`COALESCE`,不传就保留旧值)。
+
+⇒ **在 `task` 里看到你刚发的内容,只证明 hub 记下了你发过,不证明节点读到了。那是你自己动作的回声。**
+
+**要判断一个节点在不在干活,只有一种在结构上答得了的办法:发一条要回执的消息,看它回不回。** 状态面板答不了这个 —— 不是数据不够新,是这些字段的写入时机决定了它们答不了。
+:::
+
 ---
 
 ### get_session_status

--- a/docs-site/docs/en/api/mcp-tools.md
+++ b/docs-site/docs/en/api/mcp-tools.md
@@ -577,6 +577,29 @@ Get all session statuses. Sessions without a heartbeat for over 10 minutes are a
 `get_all_status` runs `SELECT * FROM sessions` ([`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) — grep `SELECT * FROM sessions WHERE 1=1`, no JOIN). The `sessions` table schema ([`db.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts) — grep `CREATE TABLE IF NOT EXISTS sessions` + V2 migration [`db.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts) — grep `ALTER TABLE sessions ADD COLUMN`) **has a `model` column** — the V2 migration runs `ALTER TABLE sessions ADD COLUMN model`, and `report_status`'s `sessions` upsert unconditionally writes `sessions.model = COALESCE(model, old)` ([`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) — grep `INSERT INTO sessions` inside `report_status` (these columns are written by `report_status`, not by the tool documented in this section) and `model = COALESCE(?20, sessions.model)`). So `get_all_status` returns each session's `model` directly (`null` if the agent never passed a `model` parameter). The `nodes` table also keeps a copy of `model` (synced by `report_status` when `node_id` is passed) as the more durable source. `summary` is the status-grouped count over the entire scope (same as `list_tasks`'s `stats`).
 :::
 
+
+::: danger 🔴 `status` answers "what it last reported", not "is it working right now"
+`sessions.status` / `progress` are updated **only at the moment a node calls `report_status`**
+([`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) 搜 `INSERT INTO sessions` inside `report_status`), and `report_completion`
+resets them to idle ([`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) 搜 `UPDATE sessions SET status = 'idle', task = NULL, progress = 0` inside `report_completion`).
+
+**Nothing in between updates it on the node's behalf.** So `status: "idle"` covers at least three different realities:
+
+| | Reality | What the panel shows |
+|---|---|---|
+| ① | Genuinely idle | `idle` |
+| ② | Got a task but never consumed it (wedged / loop not waking) | `idle` |
+| ③ | **Running a long task and not reporting mid-way** | `idle` |
+
+🔴 **Measured 2026-08-18**: a node showed `status=idle` / `progress=100` with a heartbeat under 2.5 minutes old for 75 straight minutes, and its own reply said it had been running a long sync the whole time — case ③.
+
+**`task` is even easier to misread: it may be something the *sender* wrote.** `send_task` stamps the first 200 chars of the task onto the target session inside its own transaction ([`tools.ts`](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts) 搜 `UPDATE sessions SET task = ?1` inside `send_task`); `report_status` can write the same column too (`COALESCE` — omitting it keeps the old value).
+
+⇒ **Seeing your own text in `task` proves the hub recorded that you sent it. It does not prove the node read it. That is the echo of your own action.**
+
+**There is exactly one structurally sound way to tell whether a node is working: send something that requires a reply, and see whether it replies.** The status panel cannot answer this — not because the data is stale, but because of *when* these columns are written.
+:::
+
 ---
 
 ### get_session_status


### PR DESCRIPTION
Refs #914(「发出去的任务没有任何办法查状态」)。

## 起因不是读文档,是今天真的去判一个节点是死是活

有人问我另一个节点是不是挂了。我拉状态、看到 `status=idle` + 新鲜心跳,**差点给出一个字**。为了给准,我把 `sessions` 那几列的**写入时机**逐个读了源码 —— 结论比"数据不够新"严重得多。

## 三列,三个不同的写入方

| 列 | 谁写 | 什么时候 |
|---|---|---|
| `status` / `progress` | **节点** | 只在它主动调 `report_status` 的那一刻;`report_completion` 复位成 idle |
| `task` | 🔴 **hub(`send_task`)** + 节点(`report_status`,`COALESCE`) | `send_task` 在自己的事务里就把任务前 200 字盖到目标 session 上 |

**中间没有任何东西会替节点改 `status`。**

## ⇒ `status: "idle"` 至少对应三种现实

| | 现实 | 面板长相 |
|---|---|---|
| ① | 真的空闲 | `idle` |
| ② | 收到了任务但没消费(卡死 / 循环没醒) | `idle` |
| ③ | **正在跑一个长任务,中途不上报** | `idle` |

🔴 **实测(2026-08-18)**:一个节点连续 **75 分钟**显示 `status=idle` / `progress=100` / 心跳每次都 **<2.5 分钟**,而它自己的回执说那段时间**一直在跑一条长同步线** —— 落在 ③。

我上一轮还只写到「① 和 ② 共有」。**第三种是这次实测出来的,而它恰恰是最容易被误判成"节点没在干活"的那一种。**

## ⇒ `task` 那一列更容易误读

我第二次拉状态时,在目标节点的 `task` 里看到了**我自己那条探针的原文**。第一反应是「任务到它手上了」。

然后我读到 `send_task` 的事务里有这一行:

```
UPDATE sessions SET task = ?1, updated_at = datetime('now') WHERE alias = ?2
```

🔴 **那是 hub 在派发那一刻自己写的。我看到的是我自己动作的回声,不是节点的任何回应。**

## 所以文档里现在直说

> **要判断一个节点在不在干活,只有一种在结构上答得了的办法:发一条要回执的消息,看它回不回。**
> 状态面板答不了这个 —— **不是数据不够新,是这些字段的写入时机决定了它们答不了。**

这条对 #914 是直接相关的:那条 issue 讲「发出去的任务没法查状态」,而本 PR 说明的是**为什么现有的这几列填不上那个缺口**。

## 锚点按本仓两道门的规矩写

跨 tool 的引用全部用「**在 `<tool>` 段搜**」显式限定(这正是 `check-mcp-tool-anchor-sections.py` 存在的理由 —— 锚串确实存在但落在别的 tool 段,是它抓的那一类)。

```
check-mcp-tool-anchor-sections   70/70   rc=0
doc-symbol-anchors               83/83   rc=0   （+6 就是新加的这两段）
docs-integrity                            rc=0
vitepress build                           rc=0  build complete in 36.97s
```

中英两份都加了。
