### PR TITLE
test(grok-cli): 给 sandbox deny 名单加一道门（#885；缺口本身写成一条会红的断言，清单第 3 条）

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -87,6 +87,7 @@ import {
 } from "./runtime/grok-build-acp/resume-hint";
 import { CurrentAliasResolver } from "./runtime/current-alias";
 import { delegationTargetExists } from "./runtime/delegation-precheck";
+import { grokCliDenyPaths } from "./runtime/grok-cli-deny-paths";
 import {
   isRateLimitOrQuotaError,
   quotaRemediationHint,
@@ -3667,12 +3668,11 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
           alias: currentAlias(),
           resumeId: `grok-cli-${NODE_ID || grokHomeKey}`,
         },
-        denyPaths: [
-          join(grokCwd, ".anet"),
-          join(home, ".anet"),
-          configFilePath || "",
-          join(grokCwd, ".mcp.json"),
-        ],
+        denyPaths: grokCliDenyPaths({
+          projectCwd: grokCwd,
+          userHome: home,
+          nodeConfigPath: configFilePath,
+        }),
       });
       const env = buildGrokChildEnv({
         parentEnv: process.env,
@@ -4021,12 +4021,11 @@ async function processWithGrokCli(
       stateRoot: stateGrokRoot,
       stateHome: stateGrokHome,
       projectCwd: grokCwd,
-      denyPaths: [
-        join(grokCwd, ".anet"),
-        join(home, ".anet"),
-        configFilePath || "",
-        join(grokCwd, ".mcp.json"),
-      ],
+      denyPaths: grokCliDenyPaths({
+        projectCwd: grokCwd,
+        userHome: home,
+        nodeConfigPath: configFilePath,
+      }),
     });
     // Build from an empty object. The worker never receives CommHub identity,
     // routing state, arbitrary config envRef values, or ambient cloud creds.

--- a/agent-node/src/runtime/grok-cli-deny-paths.test.ts
+++ b/agent-node/src/runtime/grok-cli-deny-paths.test.ts
@@ -10,12 +10,12 @@ describe("grokCliDenyPaths", () => {
   test("hides the two .anet directories, the node config, and project .mcp.json", () => {
     expect(grokCliDenyPaths({
       projectCwd: "/srv/project",
-      userHome: "/home/dev",
-      nodeConfigPath: "/home/dev/.anet/nodes/n1/config.json",
+      userHome: "/home/user",
+      nodeConfigPath: "/home/user/.anet/nodes/n1/config.json",
     })).toEqual([
       "/srv/project/.anet",
-      "/home/dev/.anet",
-      "/home/dev/.anet/nodes/n1/config.json",
+      "/home/user/.anet",
+      "/home/user/.anet/nodes/n1/config.json",
       "/srv/project/.mcp.json",
     ]);
   });
@@ -24,7 +24,7 @@ describe("grokCliDenyPaths", () => {
     // prepareGrokCliHome filters falsy entries; the caller has always passed
     // `configFilePath || ""`, so preserve that shape rather than quietly
     // changing the arity of what the callee receives.
-    const paths = grokCliDenyPaths({ projectCwd: "/srv/p", userHome: "/home/d" });
+    const paths = grokCliDenyPaths({ projectCwd: "/srv/p", userHome: "/home/user" });
     expect(paths).toHaveLength(4);
     expect(paths[2]).toBe("");
   });
@@ -42,8 +42,8 @@ describe("grokCliDenyPaths", () => {
     // reviewed as a behaviour change.
     const paths = grokCliDenyPaths({
       projectCwd: "/srv/p",
-      userHome: "/home/d",
-      nodeConfigPath: "/home/d/.anet/nodes/n1/config.json",
+      userHome: "/home/user",
+      nodeConfigPath: "/home/user/.anet/nodes/n1/config.json",
     });
     expect(paths.some((p) => p.includes(".anet-grok"))).toBe(false);
   });

--- a/agent-node/src/runtime/grok-cli-deny-paths.test.ts
+++ b/agent-node/src/runtime/grok-cli-deny-paths.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { grokCliDenyPaths } from "./grok-cli-deny-paths";
+
+const CLI_SOURCE = join(import.meta.dir, "..", "cli.ts");
+
+describe("grokCliDenyPaths", () => {
+  test("hides the two .anet directories, the node config, and project .mcp.json", () => {
+    expect(grokCliDenyPaths({
+      projectCwd: "/srv/project",
+      userHome: "/home/dev",
+      nodeConfigPath: "/home/dev/.anet/nodes/n1/config.json",
+    })).toEqual([
+      "/srv/project/.anet",
+      "/home/dev/.anet",
+      "/home/dev/.anet/nodes/n1/config.json",
+      "/srv/project/.mcp.json",
+    ]);
+  });
+
+  test("keeps a placeholder when the node has no config file", () => {
+    // prepareGrokCliHome filters falsy entries; the caller has always passed
+    // `configFilePath || ""`, so preserve that shape rather than quietly
+    // changing the arity of what the callee receives.
+    const paths = grokCliDenyPaths({ projectCwd: "/srv/p", userHome: "/home/d" });
+    expect(paths).toHaveLength(4);
+    expect(paths[2]).toBe("");
+  });
+
+  test("🔴 issue #885: the isolated GROK_HOME is NOT denied — this is the open gap", () => {
+    // This test exists to make the gap *visible and unchangeable in silence*,
+    // not to bless it. The isolated state home (`<stateGrokRoot>/<key>`) holds
+    // the generated sandbox.toml, requirements.toml, and an `agent_id`
+    // credential link, and an approved write tool can currently reach all of
+    // them.
+    //
+    // When someone adds it, this assertion fails and forces them to state the
+    // decision here. That is the point: #885 declined to ship the one-line fix
+    // precisely because no test watched this list, so the fix could not be
+    // reviewed as a behaviour change.
+    const paths = grokCliDenyPaths({
+      projectCwd: "/srv/p",
+      userHome: "/home/d",
+      nodeConfigPath: "/home/d/.anet/nodes/n1/config.json",
+    });
+    expect(paths.some((p) => p.includes(".anet-grok"))).toBe(false);
+  });
+});
+
+describe("cli.ts call sites", () => {
+  const source = readFileSync(CLI_SOURCE, "utf8");
+
+  test("every denyPaths argument comes from grokCliDenyPaths", () => {
+    // 🔴 The defect class this guards is "one of the two call sites drifts".
+    // Asserting only that the helper is imported would pass while a literal
+    // array sat next to it, so assert on the *shape at the call site*: after
+    // `denyPaths:` there must be a call to the helper, never an array literal.
+    const literals = source.match(/denyPaths:\s*\[/g) ?? [];
+    expect(literals).toHaveLength(0);
+
+    const viaHelper = source.match(/denyPaths:\s*grokCliDenyPaths\(/g) ?? [];
+    // Both spawn paths (the co-presence leader and prepareRuntime) must be
+    // covered. If a third appears, this number is meant to be updated
+    // deliberately rather than by accident.
+    expect(viaHelper).toHaveLength(2);
+  });
+});

--- a/agent-node/src/runtime/grok-cli-deny-paths.ts
+++ b/agent-node/src/runtime/grok-cli-deny-paths.ts
@@ -1,0 +1,33 @@
+import { join } from "path";
+
+/**
+ * The one place that decides which paths a Grok CLI node hides from its
+ * model tools.
+ *
+ * Why this is its own function (issue #885): `cli.ts` built this array inline,
+ * twice, as two identical literals — and **nothing tested either of them**.
+ * The sandbox mechanism below (`prepareGrokCliHome` → `sandbox.toml`) is well
+ * covered, but that coverage tests the *callee*: it takes whatever `denyPaths`
+ * it is handed and writes them out faithfully. A caller that forgot a path
+ * would sail through every one of those tests. Reviewing the mechanism cannot
+ * catch a caller bug; only a test that looks at what the caller passes can.
+ *
+ * So: one function, one test file, and both call sites go through here.
+ */
+export interface GrokCliDenyPathsInput {
+  /** The project directory Grok is trusted in. */
+  readonly projectCwd: string;
+  /** The operating-system user's home directory. */
+  readonly userHome: string;
+  /** The node's own config file, when it has one. */
+  readonly nodeConfigPath?: string;
+}
+
+export function grokCliDenyPaths(input: GrokCliDenyPathsInput): string[] {
+  return [
+    join(input.projectCwd, ".anet"),
+    join(input.userHome, ".anet"),
+    input.nodeConfigPath || "",
+    join(input.projectCwd, ".mcp.json"),
+  ];
+}

--- a/docs/stale-issue-review.md
+++ b/docs/stale-issue-review.md
@@ -139,18 +139,22 @@ agent-node/src/cli.ts:3450               … Cross-machine artifact distribution
 
 `tests/test846-doc-claims` 会读下面这个清单,逐条打开那个文件的那一行,确认它包含声称的子串。行号一漂就红。
 
-<!-- 🔴 2026-08-18：这三条 agent-node/src/cli.ts 的行号被 #950 撞漂了 —— 那个 PR 在
-     ~:462 处插了 12 行，下面所有行号整体 +12（3468→3480 / 4291→4303 / 2388→2400）。
-     数字对得上插入量，所以是纯位移，不是内容变了。
+<!-- 🔴 2026-08-18（第二次）：这三条 agent-node/src/cli.ts 的行号又漂了。
+     第一次是 #950 在 ~:462 插了 12 行，整体 +12（3468→3480 / 4291→4303 / 2388→2400）。
+     第二次是 #885 那道 deny 名单门（PR #984）：cli.ts 的两个 denyPaths 调用点从内联
+     字面量改成 grokCliDenyPaths(...)，净变化只有 +1 行，却把三条 pin 打散成
+     3480→3481 / 4303→4302 / 2400→2401 —— **两个方向都有**，因为增删发生在不同位置。
+     🔴 值得记的是量级：一次 +12/-11 的改动，让三条本来正确的文档引用同时变错。
      这正是 #857 用「符号锚点」替换行号 pin 想解决的那件事，而这份清单还是行号制：
-     任何在上方的插入都会让它红，而红的原因和「文档说错了」在输出上长得一样。
-     换成符号锚点要动 tests/test846-doc-claims 的判据，属于另一条。 -->
+     任何在上方的增删都会让它红，而红的原因和「文档说错了」在输出上长得一样。
+     换成符号锚点要动 tests/test846-doc-claims 的判据，属于另一条（#852 已把
+     docs/ 的符号锚点门建起来了，这份清单是它还没覆盖到的最后一处行号制）。 -->
 ```doc-claims
 server/src/db.ts :: 393 :: ADD COLUMN team
 agent-network/bin/cli.ts :: 5151 :: dangerously-load-development-channels
-agent-node/src/cli.ts :: 3480 :: video_gen
-agent-node/src/cli.ts :: 4303 :: Expose CURRENT_TASK_ID
-agent-node/src/cli.ts :: 2400 :: total_cost_usd
+agent-node/src/cli.ts :: 3481 :: video_gen
+agent-node/src/cli.ts :: 4302 :: Expose CURRENT_TASK_ID
+agent-node/src/cli.ts :: 2401 :: total_cost_usd
 agent-node/src/feishu-tool-deny.ts :: 250 :: bubblewrap
 server/src/tools.ts :: 3899 :: list_providers
 server/src/server.ts :: 9 :: addNetworkScope


### PR DESCRIPTION
Refs #885。来自 #856 那份清单的**第三条**(`test/885-deny-gate`,1 提交 3 文件),rebase 到今天的 main。

## 🔴 它不是修复,是把「这个修复能不能被评审」这件事先建起来

#885 已经验证了**隔离的 GROK_HOME 不在任何 sandbox deny profile 里**,试了那个一行修复,然后**撤回了** —— 理由是:

```
grok-copresence 套件     165 pass   ← 完全不碰 cli.ts 和 denyPaths
grok-build-cli-home 套件  41 pass   ← 测的是被调方，它忠实地写下别人递给它的任何东西
```

🔴 **一个漏了某条路径的调用方,能顺利通过关于这套机制的每一个测试。** 所以那个修复**没法作为行为变更被评审** —— 评审机制抓不到调用方的 bug,只有一个"看调用方传了什么"的测试才能。

**撤回是对的,理由也是对的。这个提交建的就是那道缺掉的门。**

## 三处设计,我逐条核过

**① `grokCliDenyPaths()` 成为唯一决定这份名单的地方。** 今天 main 上 `cli.ts` 有两个调用点(`:3670` / `:4024`),都是**内联的字面量数组**;改完两处都走这个函数。**名单本身逐字节不变**,包括 `configFilePath || ""` 那个占位,所以 `prepareGrokCliHome` 收到的元数不变。

**② 调用点测试断言的是"形状"而不是"有没有 import"。** `零个 denyPaths: [ 字面量` + `恰好两个 denyPaths: grokCliDenyPaths(`。
🔴 **只检查 helper 被 import 了,会在旁边躺着一个字面量数组的情况下照样通过。**

**③ 有一条测试把缺口本身说出来:**

```
test("🔴 issue #885: the isolated GROK_HOME is NOT denied — this is the open gap", …)
  expect(paths.some((p) => p.includes(".anet-grok"))).toBe(false);
```

**它不是在祝福这个缺口,是让它无法在沉默中被改变** —— 谁把那条路径加进去,这条断言就红,**逼他把决定写下来**,而不是悄悄落地。

## 我在今天的 main 上重验(两次见证红)

```
cherry-pick 无冲突（base 6839887a）
改后调用点：cli.ts:3671 / :4024 都是 grokCliDenyPaths({
新测试：4 pass / 0 fail

【变异 A】把一个调用点改回字面量数组（模拟"有人绕过 helper"）
  (fail) cli.ts call sites > every denyPaths argument comes from grokCliDenyPaths
  3 pass / 1 fail

【变异 B】往名单里加一条含 `.anet-grok` 的路径（模拟"有人悄悄修了 #885"）
  (fail) hides the two .anet directories, the node config, and project .mcp.json
  (fail) keeps a placeholder when the node has no config file
  (fail) 🔴 issue #885: the isolated GROK_HOME is NOT denied — this is the open gap
  1 pass / 3 fail

两次还原后工作树均干净
```

**说明一格我第一次做错了**:我最初的变异 B 加的是 `.anet/grok-home`,**只触发了"名单必须逐字相同"那两条,没触发 gap 那条** —— 因为 gap 测试守的字符串是 `.anet-grok`。换成真正含那个串的路径,三条一起红。**变异要打中你声称它守的那件事,不是打中它附近。**

## 这条为什么能直接落(按 #981 定的判据)

它**不含"当时核对的事实"**:名单来自入参、断言来自代码形状,**没有一句依赖 8 月 16 日某次核查的结论**。缺口那条断言的是**当前代码的事实**,而且它本身就是"一旦事实变了就红"的设计。

## 它没有做什么

**没有关闭 #885 的那个缺口。** 隔离的 GROK_HOME 仍然不在 deny 名单里 —— 该不该加、加了对 sandbox.toml 生成有什么影响,是 owner 的安全判断。**这个 PR 只保证:那个决定从此不能在沉默中发生。**
