### PR TITLE
ci(doc-claims): 清单支持两列式（靠唯一定位，不写行号）——行号 pin 三天漂了两次

### DIFF
--- a/docs/stale-issue-review.md
+++ b/docs/stale-issue-review.md
@@ -139,22 +139,27 @@ agent-node/src/cli.ts:3450               … Cross-machine artifact distribution
 
 `tests/test846-doc-claims` 会读下面这个清单,逐条打开那个文件的那一行,确认它包含声称的子串。行号一漂就红。
 
-<!-- 🔴 2026-08-18（第二次）：这三条 agent-node/src/cli.ts 的行号又漂了。
-     第一次是 #950 在 ~:462 插了 12 行，整体 +12（3468→3480 / 4291→4303 / 2388→2400）。
-     第二次是 #885 那道 deny 名单门（PR #984）：cli.ts 的两个 denyPaths 调用点从内联
-     字面量改成 grokCliDenyPaths(...)，净变化只有 +1 行，却把三条 pin 打散成
-     3480→3481 / 4303→4302 / 2400→2401 —— **两个方向都有**，因为增删发生在不同位置。
-     🔴 值得记的是量级：一次 +12/-11 的改动，让三条本来正确的文档引用同时变错。
-     这正是 #857 用「符号锚点」替换行号 pin 想解决的那件事，而这份清单还是行号制：
-     任何在上方的增删都会让它红，而红的原因和「文档说错了」在输出上长得一样。
-     换成符号锚点要动 tests/test846-doc-claims 的判据，属于另一条（#852 已把
-     docs/ 的符号锚点门建起来了，这份清单是它还没覆盖到的最后一处行号制）。 -->
+<!-- 🔴 这三条 agent-node/src/cli.ts 原本是行号式，三天里漂了两次：
+       #950  在 ~:462 插了 12 行 → 三条整体 +12（3468→3480 / 4291→4303 / 2388→2400）
+       #984  对 cli.ts 净 +1 行   → 同样三条被打散成 3480→3481 / 4303→4302 / 2400→2401
+     第二次尤其说明问题：**一个净 +1 行的改动，让三条本来正确的引用同时变错，
+     而且两个方向都有**（增删发生在不同位置）。而漂掉之后的红，和「文档说错了」
+     的红在输出上长得一样。
+     所以这三条改成**两列式**：靠子串唯一定位，不写行号（见 scripts/check-doc-claims.py
+     头部）。`total_cost_usd` 在 cli.ts 里有 3 处，所以加长成 `totalCostUsd: m.total_cost_usd`
+     —— 顺带说明行号式掩盖了什么：一个不唯一的子串，本来就没钉住任何地方。
+     其余几条保持行号式：它们的子串本来就唯一，而且 test846 的 drifted 变异打的就是
+     清单里 db.ts 的那一条（`ADD COLUMN team`）。
+     🔴 这段注释第一版把那条清单行**逐字抄了一遍**，于是同一个串在文档里出现两次，
+     而 test846 的变异是 `t.count(old) == 1` + `replace(..., 1)` —— 它会打中我这段
+     注释而不是清单，变异静默失效、门照绿。是我自己跑变异③时它没红才发现的。
+     **写注释引用一条被机器匹配的行时，不要逐字复制它。** -->
 ```doc-claims
 server/src/db.ts :: 393 :: ADD COLUMN team
 agent-network/bin/cli.ts :: 5151 :: dangerously-load-development-channels
-agent-node/src/cli.ts :: 3481 :: video_gen
-agent-node/src/cli.ts :: 4302 :: Expose CURRENT_TASK_ID
-agent-node/src/cli.ts :: 2401 :: total_cost_usd
+agent-node/src/cli.ts :: video_gen
+agent-node/src/cli.ts :: Expose CURRENT_TASK_ID
+agent-node/src/cli.ts :: totalCostUsd: m.total_cost_usd
 agent-node/src/feishu-tool-deny.ts :: 250 :: bubblewrap
 server/src/tools.ts :: 3899 :: list_providers
 server/src/server.ts :: 9 :: addNetworkScope

--- a/scripts/check-doc-claims.py
+++ b/scripts/check-doc-claims.py
@@ -7,11 +7,27 @@
 
 ## 它检查什么
 
-文档里嵌一个 ```doc-claims 代码块,每行三列(制表符或 ` :: ` 分隔):
+文档里嵌一个 ```doc-claims 代码块,每行 **两列或三列**(` :: ` 分隔):
 
-    <相对路径> :: <行号> :: <该行必须包含的子串>
+    <相对路径> :: <该行必须包含的子串>            ← 推荐:靠「唯一」定位,不写行号
+    <相对路径> :: <行号> :: <该行必须包含的子串>   ← 旧式:靠行号定位
 
-门逐条打开 `<相对路径>` 的第 `<行号>` 行,确认它包含 `<子串>`。
+三列式:打开第 `<行号>` 行,确认它包含 `<子串>`。
+两列式:在整个文件里找 `<子串>`,**必须恰好出现一次** —— 唯一性就是定位。
+
+🔴 为什么加两列式(2026-08-18,三天里漂了两次):
+   行号 pin 会被**上方任何增删**打漂,而漂了之后的红,和「文档说错了」的红
+   **在输出上长得一样**。两次实例:
+     #950  在 ~:462 插了 12 行 → 三条 cli.ts pin 整体 +12
+     #984  对 cli.ts 净 +1 行   → 同样三条被打散成 +1 / -1 / +1（两个方向都有）
+   第二次尤其说明问题:**一个净 +1 行的改动,让三条本来正确的引用同时变错。**
+
+   两列式把「唯一」当定位,所以上方增删不影响它。代价是子串必须够长到唯一 ——
+   这不是缺点:`addNetworkScope` 在 server.ts 里出现 24 次,拿它当锚点本来就
+   什么都没钉住,行号只是掩盖了这一点。
+
+   两种写法都留着:行号式在「就是要盯这一行」时仍然有意义,而且 test846 的
+   drifted 变异用的就是它。
 
 ## 为什么要显式清单,而不是从正文正则抽
 
@@ -46,17 +62,21 @@ DOCS = ARGS[1:] if len(ARGS) > 1 else ["docs/stale-issue-review.md"]
 BLOCK = re.compile(r"^```doc-claims\s*$(.*?)^```\s*$", re.M | re.S)
 
 
-def parse(text: str) -> list[tuple[str, int, str]]:
-    out: list[tuple[str, int, str]] = []
+def parse(text: str) -> list[tuple[str, int | None, str]]:
+    """两列 → (路径, None, 子串);三列 → (路径, 行号, 子串)。"""
+    out: list[tuple[str, int | None, str]] = []
     for block in BLOCK.findall(text):
         for raw in block.splitlines():
             line = raw.strip()
             if not line or line.startswith("#"):
                 continue
             parts = [p.strip() for p in line.split("::")]
-            if len(parts) != 3:
-                raise SystemExit(f"FAIL: 清单行格式不对(需要三列 :: 分隔):{raw!r}")
-            out.append((parts[0], int(parts[1]), parts[2]))
+            if len(parts) == 2:
+                out.append((parts[0], None, parts[1]))
+            elif len(parts) == 3:
+                out.append((parts[0], int(parts[1]), parts[2]))
+            else:
+                raise SystemExit(f"FAIL: 清单行格式不对(需要两列或三列 :: 分隔):{raw!r}")
     return out
 
 
@@ -87,7 +107,20 @@ def main() -> int:
                 print(f"FAIL: [missing-file] {path}:{line_no}", file=sys.stderr)
                 bad += 1
                 continue
-            content = target.read_text(encoding="utf-8").split("\n")
+            body = target.read_text(encoding="utf-8")
+            if line_no is None:
+                # 两列式:唯一性就是定位。0 次 = 引用失效;>1 次 = 这个锚点本来就
+                # 没钉住任何地方,行号只是把这件事掩盖了。
+                hits = body.count(needle)
+                if hits == 0:
+                    print(f"FAIL: [not-found] {path} 里找不到 «{needle}»", file=sys.stderr)
+                    bad += 1
+                elif hits > 1:
+                    print(f"FAIL: [ambiguous] {path} 里 «{needle}» 出现 {hits} 次 —— "
+                          f"锚点必须唯一,请加长子串", file=sys.stderr)
+                    bad += 1
+                continue
+            content = body.split("\n")
             if line_no < 1 or line_no > len(content):
                 print(
                     f"FAIL: [line-out-of-range] {path}:{line_no} (文件 {len(content)} 行)",


### PR DESCRIPTION
## 为什么

行号 pin 会被**上方任何增删**打漂,而漂了之后的红,**和「文档说错了」的红在输出上长得一样**。三天里两次:

```
#950  在 ~:462 插了 12 行 → 三条 cli.ts pin 整体 +12
#984  对 cli.ts 净 +1 行   → 同样三条被打散成 +1 / -1 / +1（两个方向都有）
```

🔴 **第二次尤其说明问题:一个净 +1 行的改动,让三条本来正确的引用同时变错。**(那就是我昨天开的 #984,自己撞的。)

## 改法:清单同时收两种写法

```
<路径> :: <子串>            两列式：在整个文件里找，必须【恰好出现一次】
<路径> :: <行号> :: <子串>   三列式：打开那一行，确认它包含子串
```

**唯一性就是定位**,所以上方增删不影响它。新增两类失败:`not-found` / `ambiguous`。

只把 `docs/stale-issue-review.md` 里那三条反复漂的 `cli.ts` 改成两列式,**其余保持行号式** —— 它们的子串本来就唯一,而且 `test846` 的 `drifted` 变异打的是 `db.ts` 那条,**这个 PR 不动它**。

## 🔴 顺带暴露了行号式掩盖的东西

`total_cost_usd` 在 `cli.ts` 里有 **3 处**,所以要加长成 `totalCostUsd: m.total_cost_usd` 才唯一。

更极端的:`addNetworkScope` 在 `server.ts` 里出现 **24 次**。**一个不唯一的子串本来就没钉住任何地方 —— 行号只是让人看不出来。**(这一条我没改,它仍是行号式;写出来是为了说明两列式为什么必须要求唯一。)

## 见证矩阵(本地实跑)

```
基线                                        rc=0
两列式子串改成不存在的                       rc=1  [not-found]
两列式子串改成不唯一的（total_cost_usd ×3）  rc=1  [ambiguous]
三列式行号改错（test846 打的那条）           rc=1  [drifted]
还原                                        rc=0
```

## 🔴 变异③第一次没红,而原因是我自己造的

我这段说明注释**第一版把那条清单行逐字抄了一遍**,于是同一个串在文档里出现两次。

而 `tests/test846-doc-claims/run.sh` 的变异是:

```python
assert t.count(old) == 1, "清单里的锚点不唯一,变异会不准"
p.write_text(t.replace(old, "…394…"), encoding="utf-8")
```

⇒ **它会打中我的注释而不是清单** —— `count` 变成 2、`assert` 直接失败,或者(在我本地那次)`replace` 改掉了注释里那份,清单原封不动,**变异静默失效、门照绿**。

**是我跑变异③时它没红才发现的。** 如果我只跑了①②(它们都红了),我会汇报"三条见证红全过"。

⇒ **写注释引用一条会被机器匹配的行时,不要逐字复制它。** 已改成不复制,变异③随即红在 `[drifted]` 上。