### PR TITLE
fix(grok-copresence): 让被挡的键说出它是哪个键（#882；清单第 4 条）

### DIFF
--- a/agent-node/src/runtime/grok-copresence/blocked-key-name.test.ts
+++ b/agent-node/src/runtime/grok-copresence/blocked-key-name.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { describeBlockedKey } from "./blocked-key-name";
+
+describe("describeBlockedKey", () => {
+  test("names the legacy control byte for Ctrl+P and says what Grok uses it for", () => {
+    // 0x10 is what a terminal without the CSI-u protocol sends for Ctrl+P, and
+    // it is what issue #882 observed being blocked as "unknown editor control
+    // key".
+    expect(describeBlockedKey(Buffer.from([0x10]))).toBe("Ctrl+P (Grok's command palette)");
+  });
+
+  test("names Ctrl+P when it arrives CSI-u encoded", () => {
+    // ESC [ 112 ; 5 u — codepoint 112 is "p", modifier 5 is ctrl (mask+1).
+    expect(describeBlockedKey(Buffer.from("\x1b[112;5u", "binary")))
+      .toBe("Ctrl+P (Grok's command palette)");
+  });
+
+  test("names CSI-u Ctrl+M as the model picker", () => {
+    // The whole point of issue #882's follow-up: on a CSI-u terminal Ctrl+M is
+    // distinguishable from Enter and lands on the unknown-sequence route, so
+    // this is the one place the proxy can tell a human why the model picker
+    // never opened.
+    expect(describeBlockedKey(Buffer.from("\x1b[109;5u", "binary")))
+      .toBe("Ctrl+M (Grok's model picker; it shares a byte with Enter)");
+  });
+
+  test("does not call a plain Tab 'Ctrl+I'", () => {
+    // 0x09 reaches the same blocked route as Ctrl+P, and naming it Ctrl+I would
+    // report a key the human did not press.
+    expect(describeBlockedKey(Buffer.from([0x09]))).toBe("Tab (same byte as Ctrl+I)");
+  });
+
+  test("says Enter and Ctrl+M share one byte", () => {
+    expect(describeBlockedKey(Buffer.from([0x0d])))
+      .toBe("Enter (same byte as Ctrl+M, Grok's model picker)");
+  });
+
+  test("reads the CSI-u modifier as a bitmask plus one, not as a raw mask", () => {
+    // modifier 2 = shift only. Read naively as a mask, 2 has no ctrl bit either,
+    // so the revealing case is modifier 3 (alt): raw-mask reading sees bit 0b10
+    // and, if the code tested `modifiers & 4`, would still say no — the case
+    // that separates the two readings is 4, which as a mask *does* carry 0b100
+    // but as mask+1 means alt+shift with no ctrl.
+    expect(describeBlockedKey(Buffer.from("\x1b[112;4u", "binary"))).toBeNull();
+    expect(describeBlockedKey(Buffer.from("\x1b[112;2u", "binary"))).toBeNull();
+    // 6 = ctrl+shift (mask 0b101) still counts as ctrl.
+    expect(describeBlockedKey(Buffer.from("\x1b[112;6u", "binary")))
+      .toBe("Ctrl+P (Grok's command palette)");
+  });
+
+  test("returns null rather than guessing", () => {
+    expect(describeBlockedKey(Buffer.alloc(0))).toBeNull();
+    expect(describeBlockedKey(Buffer.from("\x1b[A", "binary"))).toBeNull(); // arrow key
+    expect(describeBlockedKey(Buffer.from("\x1b[999;5u", "binary"))).toBeNull(); // not a letter
+    expect(describeBlockedKey(Buffer.from([0x1b]))).toBeNull();
+    expect(describeBlockedKey(Buffer.from("a", "binary"))).toBeNull(); // ordinary text
+  });
+
+  test("names an undocumented control key without inventing a purpose", () => {
+    expect(describeBlockedKey(Buffer.from([0x14]))).toBe("Ctrl+T");
+  });
+});

--- a/agent-node/src/runtime/grok-copresence/blocked-key-name.ts
+++ b/agent-node/src/runtime/grok-copresence/blocked-key-name.ts
@@ -1,0 +1,99 @@
+/**
+ * Name the key that the co-presence composer gate just refused to forward.
+ *
+ * Why this exists (issue #882): the gate is correct, but its two catch-all
+ * routes report `unknown editor control key` / `unknown terminal control
+ * sequence`.  Both are true and neither is usable.  A human who pressed Ctrl+P
+ * to open Grok's command palette reads a message about "unknown" keys and has
+ * no way to learn that the key exists, that the proxy owns the decision, or
+ * that nothing is broken on their end.
+ *
+ * The key names below are not guesses.  Grok 0.2.93 ships its own keybinding
+ * help inside the pinned binary; read out of
+ * `~/.commhub/grok-pins/0.2.93/grok` on 2026-08-16 it says:
+ *
+ *     ### Always available
+ *     Command palette:  Ctrl+P or ?
+ *     Model picker:     Ctrl+M (from scrollback)
+ *     Cancel:           Ctrl+C (see Escape table)
+ *     Always-approve:   Ctrl+O
+ *
+ * 🔴 `Ctrl+M` is `0x0d`, i.e. the *same byte* as Enter.  In a terminal that
+ * sends legacy control bytes the proxy therefore consumes it as a submit and it
+ * can never reach the TUI as Ctrl+M — no gate fires and no warning is emitted,
+ * so the model picker is unreachable in a way that leaves no trace at all.  A
+ * terminal speaking the CSI-u ("kitty") keyboard protocol does distinguish it
+ * (`ESC [ 109 ; 5 u`), and that form lands on the unknown-sequence route, which
+ * is exactly where naming it pays off.
+ *
+ * Deliberately conservative: return `null` whenever the bytes cannot be named
+ * with certainty, so the caller keeps its existing generic message.  This
+ * module decides *wording only* — it must never be consulted for whether to
+ * forward anything.
+ */
+
+/** What the vendor's own help says each key does. Keys are `Ctrl+<LETTER>`. */
+const VENDOR_DOCUMENTED_PURPOSE: Readonly<Record<string, string>> = Object.freeze({
+  "Ctrl+P": "Grok's command palette",
+  "Ctrl+M": "Grok's model picker; it shares a byte with Enter",
+  "Ctrl+O": "Grok's always-approve toggle",
+});
+
+/** `ESC [ <codepoint> ; <modifiers> u` — the CSI-u / kitty keyboard encoding. */
+const CSI_U = /^\x1b\[(\d+)(?:;(\d+))?u/;
+
+/**
+ * CSI-u modifiers are encoded as a bitmask **plus one**: 1 = none, 2 = shift,
+ * 3 = alt, 5 = ctrl, 9 = super.  Reading the raw number as a mask (a natural
+ * mistake) would report Shift+X as a control key.
+ */
+const CSI_U_CTRL_BIT = 0b100;
+
+/**
+ * Four control bytes are also produced by a plain, unmodified key, so calling
+ * them `Ctrl+<letter>` would name a key the human did not press.  Say both.
+ */
+const LEGACY_KEY_COLLISION: Readonly<Record<number, string>> = Object.freeze({
+  0x08: "Backspace (same byte as Ctrl+H)",
+  0x09: "Tab (same byte as Ctrl+I)",
+  0x0a: "Enter (same byte as Ctrl+J)",
+  0x0d: "Enter (same byte as Ctrl+M, Grok's model picker)",
+});
+
+function nameControlByte(byte: number): string | null {
+  const collision = LEGACY_KEY_COLLISION[byte];
+  if (collision) return collision;
+  // 0x01..0x1a map onto Ctrl+A..Ctrl+Z. 0x00 and 0x1b..0x1f have terminal
+  // meanings (NUL, ESC, field separators) that no user "pressed" as a letter.
+  if (byte < 0x01 || byte > 0x1a) return null;
+  return `Ctrl+${String.fromCharCode(byte + 0x40)}`;
+}
+
+function decorate(name: string): string {
+  const purpose = VENDOR_DOCUMENTED_PURPOSE[name];
+  return purpose ? `${name} (${purpose})` : name;
+}
+
+/**
+ * Return a human-readable name for the key at the start of `data`, or `null`
+ * when it cannot be named.  Only the first key is considered; callers block on
+ * the first offending byte anyway.
+ */
+export function describeBlockedKey(data: Buffer): string | null {
+  if (!data.length) return null;
+
+  const csiU = CSI_U.exec(data.toString("binary"));
+  if (csiU) {
+    const codepoint = Number(csiU[1]);
+    const modifiers = csiU[2] === undefined ? 1 : Number(csiU[2]);
+    if (!Number.isFinite(codepoint) || !Number.isFinite(modifiers)) return null;
+    if (((modifiers - 1) & CSI_U_CTRL_BIT) === 0) return null;
+    // CSI-u carries the *unshifted* codepoint, so Ctrl+P arrives as 112 ("p").
+    if (codepoint < 0x61 || codepoint > 0x7a) return null;
+    return decorate(`Ctrl+${String.fromCharCode(codepoint).toUpperCase()}`);
+  }
+
+  if (data[0] === 0x1b) return null; // some other escape sequence; not a named key
+  const name = nameControlByte(data[0]);
+  return name === null ? null : decorate(name);
+}

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -18,6 +18,7 @@ import { setTimeout as delay } from "timers/promises";
 import { StringDecoder } from "string_decoder";
 import { startGrokAttachServer, type GrokAttachServer } from "./attach";
 import { describeStuckPhase } from "./stuck-phase-alarm";
+import { describeBlockedKey } from "./blocked-key-name";
 import {
   newGrokJsonlState,
   flushPendingGrokNetworkReply,
@@ -1532,7 +1533,13 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
           // Unknown CSI/SS3/Alt sequences include enhanced keyboard encodings
           // such as CSI-u, which can represent Ctrl+O or a slash without those
           // raw bytes. Never forward them to the policy-owning TUI.
-          this.warnBlockedPermissionModeChange("unknown terminal control sequence");
+          // issue #882: keep the decision identical and only make it legible.
+          // A CSI-u terminal encodes Ctrl+M distinctly, so this is the one
+          // route where the unreachable model picker can be named at all.
+          const namedSequence = describeBlockedKey(remainder);
+          this.warnBlockedPermissionModeChange(
+            namedSequence ?? "unknown terminal control sequence",
+          );
           return;
         }
       }
@@ -1542,8 +1549,12 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
         && nextControl < 0x20
         && ![0x03, 0x08, 0x0a, 0x0d, 0x15].includes(nextControl);
       if (unmodelledEditorControl) {
+        // Name it before advancing past it. "unknown editor control key" is
+        // true but unusable: a human who pressed Ctrl+P to open Grok's command
+        // palette learns nothing about which key the proxy owns (issue #882).
+        const namedControl = describeBlockedKey(input.subarray(offset));
         offset += 1;
-        this.warnBlockedPermissionModeChange("unknown editor control key");
+        this.warnBlockedPermissionModeChange(namedControl ?? "unknown editor control key");
         continue;
       }
       if (this.arbitration.phase === "idle") this.transition({ type: "human_input_started" });


### PR DESCRIPTION
Refs #882。#856 那份清单的**第 4 条**(`fix/882-name-the-blocked-key`,1 提交 3 文件)。

## 它补的是什么

闸门的两条兜底路径报的是 `unknown editor control key` 和 `unknown terminal control sequence`。

**两句都是真的,而且都没用**:一个按了 `Ctrl+P` 想开 Grok 命令面板的人,**从这句话里看不出代理占用了哪个键,也看不出自己这边并没有坏**。

改完之后消息会点名那个键、以及 Grok 拿它做什么:

```
Command palette:  Ctrl+P 或 ?
Model picker:     Ctrl+M
Always-approve:   Ctrl+O
```

**`describeBlockedKey()` 是纯措辞** —— 挡/放的决定逐字节不变,而且**当字节无法确定地命名时它返回 `null`,保留旧消息**。

## 一个我觉得最值钱的观察(原作者的)

> `Ctrl+M` 是 `0x0d` —— **和 Enter 同一个字节**。所以在传统终端上,代理把它当提交消费掉,**模型选择器根本够不到,而且一行日志都没有**。CSI-u 终端能区分它,那种形态会落到 unknown-sequence 那条路 —— **那是代理唯一能把这件事说出来的地方。**

`Tab`(`0x09`)走同一条路,被命名成 `Tab` 而不是 `Ctrl+I`。

## 我在今天的 main 上重验

**① 那条被写进去的事实还成立吗**(这是我这几轮挑分支的判据):

> 键名来自 **Grok 0.2.93 自己的 keybinding 帮助**,从钉死的二进制里读出来的,不是猜的。

今天 main 上 `agent-node/src/runtime/grok-copresence/runtime.ts:465-466` 仍然是:

```
observed !== "grok 0.2.93 (f00f96316d)"
&& observed !== "grok 0.2.93 (f00f96316d) [stable]"
```

⇒ **钉的还是同一版,那份键名仍然对应正在跑的那个二进制。**(我今天早些时候在 #969 里刚实测过这个 pin:`curl … | bash -s 0.2.93` 装出来的 `grok --version` 逐字是 `grok 0.2.93 (f00f96316d)`。)

**② cherry-pick 有一处冲突,而且是我自己 20 分钟前造的**:

```
<<<<<<< HEAD
import { describeStuckPhase } from "./stuck-phase-alarm";     ← #982（我上一轮合的）
=======
import { describeBlockedKey } from "./blocked-key-name";       ← 本条
>>>>>>>
```

**两条分支在同一行加 import。** 解法是两个都留。**这也说明清单里那 22 条彼此会撞 —— 落地顺序本身就是信息。**

**③ 测试:**
```
$ TMPDIR=<隔离目录> bun test src/runtime/grok-copresence/
153 pass / 0 fail / 764 expect() calls   （11 个文件，比合 #982 前多 1 个文件 8 条）
```

**④ 见证红 —— 让 `describeBlockedKey` 恒返 `null`(等价于回到旧的笼统消息):**
```
(fail) names the legacy control byte for Ctrl+P and says what Grok uses it for
(fail) names Ctrl+P when it arrives CSI-u encoded
(fail) names CSI-u Ctrl+M as the model picker
(fail) does not call a plain Tab 'Ctrl+I'
```
还原后工作树干净。

## 今天第四次撞上同一个形状

```
#884  busy 报错不说是哪把锁
#943  failed=false 不说能力被拒
#870  queued 不说卡了多久
#882  「unknown control key」不说是哪个键
```

**共同点:分辨所需的事实在现场已经有了,只是没被写进人会读的那一行。** 四条都不改行为,只改那一行说什么。