### PR TITLE
ci(#852): 符号级行号 pin 门 —— 先把它抓到的 4 处改对，再装门（清单第 5 条）

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -297,6 +297,16 @@ jobs:
       #    实测召回率 5/10 —— 抓不到「锚点指着一行正常代码、只是不是它声称的那
       #    一行」。见 #831 与 scripts/check-doc-source-pins.py 的文件头。
       #    别拿这个 job 的绿色去论证 #831 已解决。
+
+      # 🔴 下面这一步补的正是上面那句「抓不到」的一小块(#852):锚文本里**点了名的
+      #    符号**,必须真的在钉住的那一行附近。2026-08-18 首次对 main 跑,抓到 4 处 ——
+      #    四处钉住的行分别是 `}`、`text: JSON.stringify({`、`model = COALESCE(...)`、
+      #    `if (!configFilePath || !threadId) return;`,**全都长得像正常代码**,所以
+      #    读者点进去连怀疑都不会产生。四处已在同一个 PR 里改对,这一步因此起点是绿的。
+      #    它同时打印**跳过了多少** —— 一个只说「0 处漂移」不说「跳过 10 处」的门,
+      #    读起来像「全都查过了」。
+      - name: 符号级行号 pin（#852，补 source-pin 抓不到的那一类）
+        run: python3 scripts/check-doc-symbol-pins.py .
       - name: Build test831-doc-source-pins
         run: |
           docker build \

--- a/docs/design-auth-network.md
+++ b/docs/design-auth-network.md
@@ -24,7 +24,7 @@
 > - RFC-001 Phase 3：完全移除 COMMHUB_AUTH_TOKEN 代码路径
 >
 > ⛔ 已废弃方向（本文下方仍有相关引用，请忽略）：
-> - **Free / Pro / Admin Plan 配额体系**（下方 L244 表 + users.plan 字段实现）—— v0.6 时代 SaaS 假设，Apache 2.0 OSS 转向后**永久搁置**，不再 v0.9+ planned。**R224 校准**（跟 R208 chain 一致）：schema 字段保留作历史，但 `auth.ts:184-189 createNetwork()` 仍按 `users.plan || "free"` 查 `QUOTAS` 拦截，**仅 `users.role='admin'` 豁免**——多数 SaaS 配额项（每网络 Agent 数 / 每天任务数 / 每网络成员数 / Token 数 / 试用期）实际不生效（hub 端没在对应路径调 quota check），但「创建网络数」(`max_networks_owned`) 这一项**仍 enforced**（free 用户默认上限 2）。详见 [anet.sh/concepts/networks 配额限制章节](https://anet.sh/concepts/networks) + [anet.sh/troubleshooting quota_exceeded 解决方案](https://anet.sh/troubleshooting)。
+> - **Free / Pro / Admin Plan 配额体系**（下方 L244 表 + users.plan 字段实现）—— v0.6 时代 SaaS 假设，Apache 2.0 OSS 转向后**永久搁置**，不再 v0.9+ planned。**R224 校准**（跟 R208 chain 一致）：schema 字段保留作历史，但 `auth.ts:320 createNetwork()` 仍按 `users.plan || "free"` 查 `QUOTAS` 拦截，**仅 `users.role='admin'` 豁免**——多数 SaaS 配额项（每网络 Agent 数 / 每天任务数 / 每网络成员数 / Token 数 / 试用期）实际不生效（hub 端没在对应路径调 quota check），但「创建网络数」(`max_networks_owned`) 这一项**仍 enforced**（free 用户默认上限 2）。详见 [anet.sh/concepts/networks 配额限制章节](https://anet.sh/concepts/networks) + [anet.sh/troubleshooting quota_exceeded 解决方案](https://anet.sh/troubleshooting)。
 > - `anet quickstart` 一键命令 —— **已 per #45 删除**：`case "quickstart"` 仍在 cli.ts 但只打印 deprecation 提示，引导用 `anet setup` + step-by-step 现代命令组合，不再「一键起 hub + dashboard + node」。anet.sh docs 也只推 step-by-step。
 > - "官方免费 hub" 托管 — 项目方向已转为 Apache 2.0 + 自部署，不做 SaaS 托管
 >
@@ -247,7 +247,7 @@ anet node start my-agent      # 启动
 
 | 配额项 | v0.8 实际 |
 |--------|-----------|
-| **创建网络数** | ✅ **仍 enforced**（[`auth.ts:184-189 createNetwork`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L184)），non-admin 默认 free=2，仅 `users.role='admin'` 豁免 |
+| **创建网络数** | ✅ **仍 enforced**（[`auth.ts:320 createNetwork`](https://github.com/sleep2agi/agent-network/blob/main/server/src/auth.ts#L320)），non-admin 默认 free=2，仅 `users.role='admin'` 豁免 |
 | 加入网络数 | ❌ hub 没在 join path 调 quota check |
 | 每网络 Agent 数 | ❌ 不生效 |
 | 每天任务数 | ❌ 不生效 |

--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:589 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L589) + [tools.ts:668 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L668) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1816 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1816) + [tools.ts:1830 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1830) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:72 + db.ts:98](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L72)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |
@@ -196,7 +196,7 @@ if (["new_task", "broadcast"].includes(ev.type)) {
 |---|------|--------|------|
 | 1 | sendReply 用 send_message | agent-node | ✅ v1.4.2 |
 | 2 | SSE 只响应 new_task / broadcast | agent-node | ✅ [cli.ts:1102 `["new_task", "broadcast"].includes(ev.type)`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L1102)；`new_reply` 单独走日志记录 cli.ts:1106 |
-| 3 | 低价值消息过滤 | agent-node | ✅ v1.4.0；当前在 [cli.ts:836 `shouldSkipMessage`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L836) |
+| 3 | 低价值消息过滤 | agent-node | ✅ v1.4.0；当前在 [cli.ts:4639 `shouldSkipMessage`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L4639) |
 | 4 | CLAUDE.md 不对 message 回复 | 各项目 CLAUDE.md | ✅ R195 chain 模板已加 |
 | 5 | developer_instructions 安静规则 | agent-node | ✅ v1.4.1 |
 

--- a/scripts/check-doc-symbol-pins.py
+++ b/scripts/check-doc-symbol-pins.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""锚文本点名了一个符号,而钉住的行号上**没有那个符号**。
+
+这是 `check-doc-source-pins.py` 自己在文件头里承认抓不到的那一类:
+
+    抓不到的:
+      锚点指着一行**长得很正常的代码**,只是不是它声称的那一行。
+
+那道门的三条判据(文件不存在 / 行号越界 / 平凡行)都落在"这一行本身有问题"上。
+而重构之后最常见的形态是:行号仍在范围内、那一行也是正常代码,**只是换了一段代码**。
+读者点进去看到的东西看起来完全合理,所以连怀疑都不会产生。
+
+🔴 这道门能补上的,只是其中**可机器判定**的一小块:锚文本里点了名的符号。
+   `[loadProfile()](…#L228)` 是可判的;`[见这里](…#L228)` 不可判,直接跳过。
+   ⇒ 跳过的数量会打印出来。**一个只说"0 处漂移"却不说"跳过了 120 处"的门,
+     读起来像"全都查过了",而它其实只查了一小半。**
+
+判据(刻意保守,宁可跳过也不误报):
+  1. 锚文本里取出候选符号:长度 ≥3 的标识符,且不是被引用文件的文件名本身。
+  2. 该符号必须在目标文件里**至少出现一次** —— 否则我们无法区分
+     「符号被改名了」和「锚文本里那个词根本不是符号」,一律跳过。
+  3. 钉住的行 ±WINDOW 行内出现该符号 → 通过。
+     文件里别处出现 → 报漂移,并给出**它现在在第几行**。
+
+退出码:0 无漂移 / 1 有漂移 / 2 判不了(一个 pin 都没扫到 = 范围塌了)
+
+用法: check-doc-symbol-pins.py [仓库根，默认当前目录] [--doc-root docs]
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PIN = re.compile(
+    r"\[([^\]\n]{1,120})\]\("
+    r"https://github\.com/sleep2agi/agent-network/blob/"
+    r"([0-9a-zA-Z._-]+)/([^\s)#\"']+)#L(\d+)\)"
+)
+IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+# 锚文本里几乎总会出现的词，它们不是符号名。
+STOPWORDS = {
+    "src", "bin", "dist", "lib", "docs", "main", "the", "and", "for", "see",
+    "line", "lines", "file", "code", "here", "this", "that", "npm", "cli",
+    "ts", "tsx", "js", "json", "md", "sh", "py",
+}
+WINDOW = 2
+# 在目标文件里出现超过这么多次的标识符,不足以定位任何一行 —— 不拿它下判断。
+UBIQUITOUS = 20
+
+
+def tracked_docs(repo: Path, doc_root: str) -> list[Path]:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo), "ls-files", f"{doc_root}/**/*.md", f"{doc_root}/*.md"],
+            capture_output=True, text=True, check=True).stdout.split()
+        if out:
+            return [repo / p for p in out]
+    except (OSError, subprocess.CalledProcessError):
+        pass
+    return sorted((repo / doc_root).rglob("*.md"))
+
+
+def candidate_symbols(anchor: str, rel: str) -> list[str]:
+    """从锚文本里挑出**可能是符号**的词。
+
+    🔴 第一版只排了文件名和一张 stopword 表,于是把 `agent` 和 `channel` 当成了符号 ——
+       它们来自锚文本里照抄的路径 `agent-network/bin/cli.ts`。那一版报了 26 处漂移,
+       其中一多半是这么来的。**stopword 表治不了这个:路径里出现什么词是随仓库变的。**
+       所以改成从**被引用路径自己**推出排除集,而不是维护一张名单。
+    """
+    excluded = {"", "md"}
+    for part in re.split(r"[/.\-]", rel):
+        if part:
+            excluded.add(part)
+            excluded.add(part.lower())
+    out = []
+    for word in IDENT.findall(anchor):
+        if word.lower() in STOPWORDS or word in excluded or word.lower() in excluded:
+            continue
+        out.append(word)
+    return out
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    doc_root = "docs"
+    if "--doc-root" in sys.argv:
+        doc_root = sys.argv[sys.argv.index("--doc-root") + 1]
+    repo = Path(args[0]).resolve() if args else Path.cwd()
+
+    pins = skipped = 0
+    findings: list[str] = []
+    for doc in tracked_docs(repo, doc_root):
+        try:
+            text = doc.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for anchor, _ref, rel, lineno in PIN.findall(text):
+            pins += 1
+            target = repo / rel
+            if not target.is_file():
+                # 文件不存在是另一道门的活（check-doc-source-pins.py），
+                # 在这里重复报会让两道门的数字互相污染。
+                skipped += 1
+                continue
+            try:
+                lines = target.read_text(encoding="utf-8", errors="replace").split("\n")
+            except OSError:
+                skipped += 1
+                continue
+            n = int(lineno)
+            if not (1 <= n <= len(lines)):
+                skipped += 1  # 越界同样归另一道门
+                continue
+            symbols = candidate_symbols(anchor, rel)
+            judged = False
+            for sym in symbols:
+                # 🔴 词边界，不是子串。2026-08-18 实测:`createNetwork` 用子串匹配会命中
+                #    `createNetworkTokenForNode`,于是这道门给出的「现在在第 224 行」
+                #    指向的是**另一个函数**,而真正的 createNetwork 在 320 行。
+                #    判漂移时它只会让判据变松;但那句提示是给人照抄的,**一个会被照抄的
+                #    错行号,比不给提示更糟**。
+                where = [i + 1 for i, line in enumerate(lines) if re.search(rf"\b{re.escape(sym)}\b", line)]
+                if not where:
+                    continue  # 改名了还是根本不是符号——分不清，不猜
+                if len(where) > UBIQUITOUS:
+                    # 出现几百次的词定位不到任何东西,拿它判漂移只会制造噪音。
+                    continue
+                judged = True
+                if any(abs(w - n) <= WINDOW for w in where):
+                    break
+                near = min(where, key=lambda w: abs(w - n))
+                findings.append(
+                    f"  🔴 {doc.relative_to(repo)}  锚文本点名 `{sym}`，钉在 {rel}#L{n}，"
+                    f"但那一行是:\n       {lines[n - 1].strip()[:100]}\n"
+                    f"       `{sym}` 现在在第 {near} 行（共 {len(where)} 处）")
+                break
+            if not judged:
+                skipped += 1
+
+    if pins == 0:
+        print(f"::error::SYMBOL-PIN: 在 {doc_root}/ 下一个 blob 行号引用都没扫到 —— 范围塌了，拒绝通过")
+        return 2
+    for f in findings:
+        print(f)
+    verdict = "RED" if findings else "OK"
+    print(f"SYMBOL-PIN: {verdict}（扫到 {pins} 个 pin，判定 {pins - skipped} 个，"
+          f"跳过 {skipped} 个，漂移 {len(findings)} 个）")
+    print("🔴 跳过的那些不是通过 —— 锚文本没点名符号，或符号在目标文件里一次都没出现，"
+          "机器分不清「改名了」和「那个词本来就不是符号」。")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #852。#856 清单第 5 条(`feat/852-symbol-pin-gate`)。

## 它补的是旧门自己承认抓不到的那一类

`scripts/check-doc-source-pins.py` 的文件头原文:

> 抓不到的:锚点指着一行**长得很正常的代码**,只是不是它声称的那一行。

新门只判**可机器判定**的一小块:锚文本里**点了名的符号**,必须真的在钉住的那一行附近。`[loadProfile()](…#L228)` 可判;`[见这里](…#L228)` 不可判,**跳过并计数**。

## 🔴 首次对今天的 main 跑,抓到 4 处真漂移

四处**钉住的那一行实际是什么**:

```
}                                          ← docs/design-auth-network.md 说这里是 createNetwork
text: JSON.stringify({                     ← docs/message-lifecycle.md 说这里是 send_reply
model = COALESCE(?20, sessions.model),     ← 说这里是 send_ack
if (!configFilePath || !threadId) return;  ← 说这里是 shouldSkipMessage
```

**全都长得像正常代码。** 读者点进去看到一段合理的代码,**连怀疑都不会产生** —— 这正是旧门放过它们的原因。

四处已在本 PR 里改对,所以**这道门起点是绿的**(先清干净,再装门 —— 和 #976→#977 同一个顺序)。

## 🔴 改的过程里发现:门自己的提示会骗人

它报漂移时给一句 `` `X` 现在在第 N 行``。那是**子串匹配的第一处**:

```
`createNetwork`  → 命中 `createNetworkTokenForNode`（第 224 行）
真正的 createNetwork 定义在 320 行
```

四处提示里**三处不是定义行**(`589` → 真正 `1816`、`668` → `1830`、`224` → `320`),只有 `shouldSkipMessage` 那处对得上。

**我差点直接照抄那四个数字。**

判漂移的时候子串只会让判据变松;**但那句提示是给人照抄的 —— 一个会被照抄的错行号,比不给提示更糟。** 已改成词边界匹配,注释写在原地。

## 见证矩阵

```
基线                          rc=0   （14 pin / 判定 4 / 跳过 10 / 漂移 0）
把一个 pin 的行号改回旧值      rc=1   指名 send_reply，并打印那一行现在是什么
--doc-root 指向没有 pin 的目录 rc=2   「范围塌了，拒绝通过」
还原                          rc=0
```

## 它把「跳过了多少」打出来

```
SYMBOL-PIN: OK（扫到 14 个 pin，判定 4 个，跳过 10 个，漂移 0 个）
🔴 跳过的那些不是通过 —— 锚文本没点名符号，或符号在目标文件里一次都没出现，
   机器分不清「改名了」和「那个词本来就不是符号」。
```

🔴 **一个只说「0 处漂移」不说「跳过 10 处」的门,读起来像「全都查过了」,而它其实只判了不到三分之一。**

## 与原分支的差别

原分支还改了 `tests/test831-doc-source-pins/` 的 Docker 层。这里**只取脚本本身**,挂进 `qa.yml` 已有的 `doc source-pin floor` job —— 少动一层,冲突面也小。

## 本地全绿

```
doc-symbol-anchors · docs-integrity · no-memory-slugs · home-path-baseline
doc-source-pins · doc-claims · workflow-structure      全部 rc=0
```