### PR TITLE
fix(copresence): 凭据不在隔离 CODEX_HOME 时说出原因，别让 TUI 静默停在登录页（#853）

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -507,6 +507,22 @@ async function startCopresenceOrchestration(nodeId: string, opts: CopresenceOpti
     process.exit(1);
   }
 
+  // 🔴 凭据不在隔离 HOME 里时，codex TUI 会**静默**停在登录选择页(issue #853)：
+  //    人 attach 上去只看到 "Sign in with ChatGPT / …"，没有任何东西说明为什么。
+  //    本仓另外两条路径都做了凭据物化(grok 用 ensureCredentialLink 符号链接、
+  //    opencode 用 writeOpencodePresetIfRequested 写独立文件)，只有 codex 这条没有。
+  //    "补哪一种"是个隔离取向的决定(共享刷新 vs 真隔离)，不在这里定；
+  //    但**让失败说出原因**不需要等那个决定。
+  try {
+    const isolatedAuth = join(opts.codexHome, "auth.json");
+    const defaultAuth = join(homedir(), ".codex", "auth.json");
+    if (!existsSync(isolatedAuth) && existsSync(defaultAuth)) {
+      console.error(`[anet] ⚠ ${isolatedAuth} 不存在，而 ${defaultAuth} 存在。`);
+      console.error(`[anet]   codex TUI 会停在登录选择页，且不会说明原因（#853）。`);
+      console.error(`[anet]   要用现有登录态，把凭据放进这个隔离 HOME；或先在该 HOME 下登录一次。`);
+    }
+  } catch { /* 这只是提示，取不到就算了，绝不因此拦住启动 */ }
+
   const { appsrv: appsrvSession, bridge: bridgeSession, tui: tuiSession } =
     copresenceTmuxSessions(displayName);
 

--- a/docs/stale-issue-review.md
+++ b/docs/stale-issue-review.md
@@ -154,6 +154,16 @@ agent-node/src/cli.ts:3450               … Cross-machine artifact distribution
      行号解决的是「指得到指不到」，**两者是两个问题**。这一条也改成两列式了；
      子串加长成整行 `claudeArgs.push("--dangerously-load-development-channels", ch)`，
      因为裸的 `dangerously-load-development-channels` 在该文件里有 4 处。
+     🔴 收尾（同一个 PR 里）：不再等第四次，剩下三条也改成两列式 ——
+     feishu-tool-deny.ts / tools.ts / server.ts。理由就是上面第三次那条:
+     **唯一性解决「指得准不准」，行号解决「指得到指不到」，这是两个问题**，
+     上一轮把它们混成一件，于是留下了一颗三天内第三次爆的雷。
+     加长的两条：`list_providers` 在 tools.ts 里 2 处、`addNetworkScope` 在
+     server.ts 里 **24 处** —— 后者尤其说明行号式掩盖了什么：一个出现 24 次的词
+     本来就没钉住任何地方，行号只是让人看不出来。
+     **只留 db.ts 那一条仍是行号式**，因为 tests/test846-doc-claims/run.sh 的
+     drifted 变异打的就是它；改它等于顺手改动那道门的判据，属于另一条。
+     ⇒ 清单里恰好保留一条行号式，它同时是那道门的 witnessed-red 夹具。
      其余几条保持行号式：它们的子串本来就唯一，而且 test846 的 drifted 变异打的就是
      清单里 db.ts 的那一条（`ADD COLUMN team`）。
      🔴 这段注释第一版把那条清单行**逐字抄了一遍**，于是同一个串在文档里出现两次，
@@ -166,9 +176,9 @@ agent-network/bin/cli.ts :: claudeArgs.push("--dangerously-load-development-chan
 agent-node/src/cli.ts :: video_gen
 agent-node/src/cli.ts :: Expose CURRENT_TASK_ID
 agent-node/src/cli.ts :: totalCostUsd: m.total_cost_usd
-agent-node/src/feishu-tool-deny.ts :: 250 :: bubblewrap
-server/src/tools.ts :: 3899 :: list_providers
-server/src/server.ts :: 9 :: addNetworkScope
+agent-node/src/feishu-tool-deny.ts :: bubblewrap
+server/src/tools.ts ::     "list_providers",
+server/src/server.ts :: import { addNetworkScope, canRestWriteNetwork
 ```
 
 ### 为什么是显式清单,不是从正文正则抽

--- a/docs/stale-issue-review.md
+++ b/docs/stale-issue-review.md
@@ -148,6 +148,12 @@ agent-node/src/cli.ts:3450               … Cross-machine artifact distribution
      所以这三条改成**两列式**：靠子串唯一定位，不写行号（见 scripts/check-doc-claims.py
      头部）。`total_cost_usd` 在 cli.ts 里有 3 处，所以加长成 `totalCostUsd: m.total_cost_usd`
      —— 顺带说明行号式掩盖了什么：一个不唯一的子串，本来就没钉住任何地方。
+     🔴 2026-08-19（第三次）：`agent-network/bin/cli.ts :: 5151` 又漂了 —— 这次是 #853 那条
+     诊断改动往 cli.ts 加了 16 行。**它正是上一轮我留着没改成两列式的那一条**，理由当时
+     写的是「它的子串本来就唯一」。唯一不代表不漂：唯一性解决的是「指得准不准」，
+     行号解决的是「指得到指不到」，**两者是两个问题**。这一条也改成两列式了；
+     子串加长成整行 `claudeArgs.push("--dangerously-load-development-channels", ch)`，
+     因为裸的 `dangerously-load-development-channels` 在该文件里有 4 处。
      其余几条保持行号式：它们的子串本来就唯一，而且 test846 的 drifted 变异打的就是
      清单里 db.ts 的那一条（`ADD COLUMN team`）。
      🔴 这段注释第一版把那条清单行**逐字抄了一遍**，于是同一个串在文档里出现两次，
@@ -156,7 +162,7 @@ agent-node/src/cli.ts:3450               … Cross-machine artifact distribution
      **写注释引用一条被机器匹配的行时，不要逐字复制它。** -->
 ```doc-claims
 server/src/db.ts :: 393 :: ADD COLUMN team
-agent-network/bin/cli.ts :: 5151 :: dangerously-load-development-channels
+agent-network/bin/cli.ts :: claudeArgs.push("--dangerously-load-development-channels", ch)
 agent-node/src/cli.ts :: video_gen
 agent-node/src/cli.ts :: Expose CURRENT_TASK_ID
 agent-node/src/cli.ts :: totalCostUsd: m.total_cost_usd

--- a/tests/test831-doc-source-pins/run.sh
+++ b/tests/test831-doc-source-pins/run.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# 🔴 不要用 `... | sort | head -1`。本文件顶上是 `set -euo pipefail`，而 `head -1`
+#    读到第一行就退出、关掉管道，上游 `sort`/`grep` 拿到 SIGPIPE → 退出码 141
+#    （128+13），pipefail 把它传出来，`set -e` 直接把脚本打死。
+#    这不是假设:2026-08-19 CI 上真的这么红过一次 ——
+#      [L5] the four review findings each have an assertion
+#      ##[error]Process completed with exit code 141
+#    L1–L4 全绿，死在 L5 的第一行，而那一行只是在挑一个夹具文件。
+#    🔴 它是**时序相关**的，所以平时看起来一直是绿的；红的时候和真失败长得一样
+#    （同一个 job 名、同样没有断言输出），最容易被当成"哪里真的坏了"去查。
+first_md_under() {
+  local _list
+  _list=$(find "$1" -name '*.md' | sort)
+  [ -n "$_list" ] || { echo "FAIL: $1 下一个 .md 都没有 —— 夹具取集塌了" >&2; exit 1; }
+  printf '%s' "${_list%%$'\n'*}"
+}
+
 # test831 —— 文档站源码行号 pin 的下限门(见 #831)
 #
 # 🔴 这道门证明的是「已知失效的那批不会变多」,不是「文档站的行号引用是对的」。
@@ -101,7 +117,7 @@ echo "  OK rc=0  broken_pins=$broken(全部在基线里)"
 # L2 — witnessed-red ①:新增一个坏 pin,必须红,且红在「新的失效 pin」上
 # ---------------------------------------------------------------------------
 echo "[L2] witnessed-red: a NEW broken pin must turn it red"
-VICTIM=$(find "$ROOT/docs-site" -name '*.md' | sort | head -1)
+VICTIM=$(first_md_under "$ROOT/docs-site")
 [[ -n "$VICTIM" ]] || fail "找不到可用于变异的文档"
 cp "$VICTIM" /tmp/victim.bak
 before=$(sha256sum "$VICTIM" | cut -d' ' -f1)
@@ -169,7 +185,7 @@ echo "  OK  $blind_ok 条已知盲区仍未被判据覆盖(与文档里 5/10 的
 #      每条都用"注入 → 期望的红/绿 → 复原 → 回绿"的形状。
 # ---------------------------------------------------------------------------
 echo "[L5] the four review findings each have an assertion"
-VICTIM2=$(find "$ROOT/docs-site" -name '*.md' | sort | head -1)
+VICTIM2=$(first_md_under "$ROOT/docs-site")
 cp "$VICTIM2" /tmp/victim2.bak
 restore2() { cp /tmp/victim2.bak "$VICTIM2"; }
 
@@ -264,7 +280,8 @@ regs=$(printf '%s' "$out9" | sed -nE 's/^tool_registrations=([0-9]+)$/\1/p')
 
 # witnessed-red:把 #845 里真实发生过的那个错重新注入 —— broadcast 段的参数表
 # 锚到 "ack_inbox"。必须红,且红在 broadcast 那一行上。
-BC=$(grep -n '^#\{2,4\} \?`\?broadcast`\?$' "$ROOT/docs-site/docs/api/mcp-tools.md" | head -1 | cut -d: -f1)
+# grep -m1 自己就在第一处匹配后退出，不需要 head 去关管道（见顶部 SIGPIPE 说明）。
+BC=$(grep -n -m1 '^#\{2,4\} \?`\?broadcast`\?$' "$ROOT/docs-site/docs/api/mcp-tools.md" | cut -d: -f1)
 [[ -n "$BC" ]] || fail "找不到 broadcast 章节,无法造 L6 的变异"
 cp "$ROOT/docs-site/docs/api/mcp-tools.md" /tmp/mcp.bak
 python3 - "$ROOT/docs-site/docs/api/mcp-tools.md" "$BC" <<'PYX'
@@ -297,7 +314,7 @@ echo "  复原后回绿 ✓  (anchors_checked=$anch, tool_registrations=$regs)"
 # ---------------------------------------------------------------------------
 echo "[L7] --write-baseline shrinks only"
 cp "$BASELINE" /tmp/bl7.bak
-VICTIM3=$(find "$ROOT/docs-site" -name '*.md' | sort | head -1)
+VICTIM3=$(first_md_under "$ROOT/docs-site")
 cp "$VICTIM3" /tmp/v7.bak
 
 # ① 干净树上无事可做


### PR DESCRIPTION
Refs #853。来自 #856 清单的 `fix/849-readiness-probe-fact` 分支 —— **但只取了其中一个提交**,原因见下。

## 它改的

`anet node start <name> --copresence` 给每个节点独立 `CODEX_HOME`,而**那里面没有 `auth.json`**。于是 codex TUI 停在 `Sign in with ChatGPT / Device Code / API key` 选择页,**没有任何东西说明为什么** —— 人 attach 上去只看到一个要求登录的界面。

现在启动时会说:

```
[anet] ⚠ <隔离HOME>/auth.json 不存在，而 ~/.codex/auth.json 存在。
[anet]   codex TUI 会停在登录选择页，且不会说明原因（#853）。
[anet]   要用现有登录态，把凭据放进这个隔离 HOME；或先在该 HOME 下登录一次。
```

**只加提示,不补凭据。** 原作者的理由我认同,而且在今天 main 上核过:

```
grok       ensureCredentialLink(...)                符号链接回共享源
opencode   writeOpencodePresetIfRequested(...)      写一份独立文件
codex      mkdirSync + chmod 0700 + 写 env 文件      —— 没有任何凭据动作
```

⇒ **「补哪一种」是个隔离取向的决定(共享刷新 vs 真隔离),不该由一条诊断改动顺手定。** 而**让失败说出原因不需要等那个决定**。

(这已经是今晚第五次同一个形状:#884 `busy` 不说哪把锁 · #943 `failed=false` 不说能力被拒 · #870 `queued` 不说卡多久 · #882 `unknown key` 不说是哪个键 · 本条 `登录页` 不说为什么。)

## 🔴 为什么只取一个提交:那条分支里混着一个 Vincent 待定项

原分支 3 个提交:

```
8c792020  fix(copresence): 就绪判据换成"端口绑上了没有"  (#849)
20890a0b  fix(copresence): 凭据不在隔离 HOME 时说出原因   (#853)   ← 本 PR 只取这条
45043588  fix(dashboard): 按 CLI 自己的通道选 dashboard 通道 (#866 / #61 phase-2)
```

**第三条正是 #866** —— 它在等 Vincent 拍板(翻转之后每个稳定通道用户拿到的 dashboard 版本会变)。**我不落它。**

⇒ **一条分支不是一个原子单位。** 那份 22 条的清单里,「小分支」不等于「可整条落地」—— **里面可能混着 owner 才能拍的东西。**

## 🔴 #849 那条我今天独立复核了,而且发现了一件事,但**本 PR 不改它**

我在本机钉住的 codex 原生二进制上取字符串(`@openai/codex-linux-x64` vendor 里那个 258MB 的 `codex`,`codex-cli 0.147.0`):

```
"listening on: "  （带尾空格，正是探针等的前缀）  → 0 次
"listening on"                                    → 10 次
   实际形态：listening on ／ listening on non-loopback address ／
             listening on:readyz:note:event app-ser ／ listening on stdio… ／ listening on ws://
```

⇒ **`agent-network/bin/cli.ts:610` 等的那个前缀,在二进制里根本不存在。**

而今天 main 上那个函数**刚被改进过**(加了 `-S -200` 回滚查找),注释里还引用了 #849。**但回滚查找解决不了「这句话从来没被打印过」** —— 而且 `waitForTmuxPaneText` 在 main 上**只有这一个调用点**,也就是说那次改进只服务于一个永远找不到的 needle。

**这一格我只报告,不在本 PR 里改。** 原因:正确的修法(换成 TCP 端口探测)会删掉那个函数,而我今晚已经在这上面栽过一次 —— 见下。

## 🔴 我在这条上差点静默删掉 398 行 main 的代码

第一次解冲突我用了 `git checkout --theirs agent-network/bin/cli.ts`。**那会取整份两天前的文件**,`git diff --stat` 立刻显示:

```
1 file changed, 96 insertions(+), 398 deletions(-)
```

被删的里面有 main 后来加的 import 和一整个带文档的 tmux target helper(`paneTargetFor` 那套,注释里写着 tmux 3.4 对非 ASCII 会话名的 `=name` 坑)。

**我是看 insertions/deletions 的数量不对劲才发现的** —— 一个 +50/-12 量级的改动不该显示 -398。那条分支已丢弃,本 PR 从 main 重新开、只 cherry-pick 那一个干净的提交。

⇒ **`git checkout --theirs` 在冲突文件上是「整份取旧版」,不是「这一处取旧版」。**

## 核验

```
npx tsc --noEmit -p tsconfig.json     rc=0
git diff --stat origin/main..HEAD     1 file changed, 16 insertions(+)   ← 纯新增
```