### PR TITLE
ci(#924): e2e 硬门说出「某个套件压根没跑」，而不是笼统的「用例数不够」

### DIFF
--- a/tests/lib/e2e-hard-gate.sh
+++ b/tests/lib/e2e-hard-gate.sh
@@ -30,8 +30,28 @@ failed=${BASH_REMATCH[2]}
 echo "runner exit code: $RUNNER_RC"
 echo "$total_line"
 
+# 🔴 先看有没有套件**压根没跑**，再看总数够不够（#924）。
+#
+# 这两件事在 `passed < MIN_PASS` 这一句里长得一模一样：
+#     ① 某个套件早退了（Results 行缺失，0 ran）—— 基础设施/时序问题
+#     ② 有人删了一个测试            —— 代码问题
+# 而下限余量只有 1（MIN_PASS=283，稳定值 284），所以两者都会红在同一句
+# 「incomplete regression: N passes is below minimum 283」上，读日志的人分不出
+# 该去查 Docker 还是去查 diff。
+#
+# runner 其实已经把答案打印出来了（tests/test-all.sh:37 那行 SKIPPED/CRASHED），
+# 只是这道门从来没看过它。看一眼就够。
+mapfile -t crashed_lines < <(grep -F 'SKIPPED/CRASHED' "$LOG_FILE" || true)
+if (( ${#crashed_lines[@]} > 0 )); then
+  echo "ERROR: ${#crashed_lines[@]} suite(s) never ran — this is NOT a missing test, it is a suite that exited early:" >&2
+  printf '  %s\n' "${crashed_lines[@]}" >&2
+  echo "  ⇒ 去查那个套件的容器/时序，不要去 diff 里找被删掉的测试。" >&2
+  exit 1
+fi
+
 if (( passed < MIN_PASS )); then
   echo "ERROR: incomplete regression: $passed passes is below minimum $MIN_PASS" >&2
+  echo "  没有套件报 SKIPPED/CRASHED，所以这多半是【用例数真的少了】，不是某个套件没跑。" >&2
   exit 1
 fi
 if (( failed > 0 )); then

--- a/tests/test292-e2e-hard-gate/run.sh
+++ b/tests/test292-e2e-hard-gate/run.sh
@@ -47,6 +47,9 @@ printf 'Final Report\nTOTAL: 283 passed, 1 failed\n' > "$TMP_DIR/red.log"
 printf 'Final Report\nTOTAL: 282 passed, 0 failed\n' > "$TMP_DIR/short.log"
 printf 'Final Report\nno total here\n' > "$TMP_DIR/missing.log"
 printf 'TOTAL: 283 passed, 0 failed\nTOTAL: malformed\n' > "$TMP_DIR/duplicate.log"
+# #924 —— 「某个套件压根没跑」和「用例数真的少了」必须红在不同的话上。
+# 两条夹具的 TOTAL 都低于下限，旧门对它们说的是同一句 below minimum。
+printf 'Final Report\n⚠️ Loop runtime e2e (20): SKIPPED/CRASHED (0 ran — Results line missing, suite likely exited early)\nTOTAL: 263 passed, 0 failed\n' > "$TMP_DIR/crashed.log"
 
 expect_file_contains "$WORKFLOW" 'tests/lib/run-piped-command.sh' 'workflow uses the tested pipeline wrapper'
 expect_file_contains "$WORKFLOW" 'tests/lib/e2e-hard-gate.sh' 'workflow invokes the tested hard gate'
@@ -82,6 +85,26 @@ else
 fi
 expect_gate_red "$TMP_DIR/missing.log" 0 'missing TOTAL fails closed'
 expect_gate_red "$TMP_DIR/duplicate.log" 0 'duplicate or malformed TOTAL fails closed'
+
+# 🔴 #924：不只是「要红」，是「红得说得出是哪一种」。
+# short.log（用例真的少了）和 crashed.log（套件没跑）在旧门里是同一句话。
+expect_gate_red "$TMP_DIR/crashed.log" 0 'a suite that never ran fails closed'
+# 🔴 先把输出收进变量再判，不要 `bash "$GATE" … | grep -q`：
+#    本文件顶上是 `set -euo pipefail`，而 $GATE 在这些用例里**本来就该非零退出**，
+#    pipefail 会把那个 1 当成整条管道的结果 —— 于是 grep 明明命中了，`if` 仍然走
+#    else 分支。第一版就是这么写的，结果 25 PASS / 1 FAIL，而那一条 FAIL 是假的。
+crashed_out=$(bash "$GATE" "$TMP_DIR/crashed.log" 0 2>&1 || true)
+if printf '%s' "$crashed_out" | grep -Fq 'never ran'; then
+  pass 'a crashed suite is named as such, not reported as a missing test'
+else
+  fail 'a crashed suite is named as such, not reported as a missing test'
+fi
+short_out=$(bash "$GATE" "$TMP_DIR/short.log" 0 2>&1 || true)
+if printf '%s' "$short_out" | grep -Fq 'never ran'; then
+  fail 'a genuinely short count must NOT be blamed on a crashed suite'
+else
+  pass 'a genuinely short count must NOT be blamed on a crashed suite'
+fi
 expect_gate_red "$TMP_DIR/green.log" '' 'missing runner status fails closed'
 expect_gate_red "$TMP_DIR/green.log" tee_failed_1 'tee failure status fails closed'
 


### PR DESCRIPTION
Refs #924。

## 问题:下限余量只有 1,于是两件性质完全不同的事红在同一句话上

```
tests/lib/e2e-hard-gate.sh:6   readonly MIN_PASS=283
实际稳定值                       284      ⇒ 余量 = 1
```

**旧门对两条夹具的原话(实跑,不是推断):**

```
crashed.log    ERROR: incomplete regression: 263 passes is below minimum 283
onefewer.log   ERROR: incomplete regression: 282 passes is below minimum 283
```

| 夹具 | 真实原因 | 该去查什么 |
|---|---|---|
| `crashed.log` | 某个套件早退了(`0 ran`) | 容器 / 时序 |
| `onefewer.log` | 用例数真的少了 | diff |

🔴 **读日志的人分不出该查哪边。** 而 #924 记录的那次真实事故正是前者(`Loop runtime e2e (20): SKIPPED/CRASHED (0 ran)`)。

## 修法:runner 早就把答案打印出来了,这道门没看

`tests/test-all.sh:37`:

```sh
SUITES+=("$STATUS $NAME: SKIPPED/CRASHED (0 ran — Results line missing, suite likely exited early)")
```

**门只读 `TOTAL:` 那一行,从来没看过它。** 加一次 grep,并把它排在 `MIN_PASS` 判定**之前**。

## 改后三种情况各说各的

```
green      rc=0   PASS: full Docker E2E regression is complete and green

crashed    rc=1   ERROR: 1 suite(s) never ran — this is NOT a missing test,
                         it is a suite that exited early:
                     ⚠️ Loop runtime e2e (20): SKIPPED/CRASHED (0 ran …)
                   ⇒ 去查那个套件的容器/时序，不要去 diff 里找被删掉的测试。

onefewer   rc=1   ERROR: incomplete regression: 282 passes is below minimum 283
                     没有套件报 SKIPPED/CRASHED，所以这多半是【用例数真的少了】，
                     不是某个套件没跑。
```

## 契约补了三条,第三条是关键

```
expect_gate_red  crashed.log                     要红
crashed 的输出里有 'never ran'                    红得说得出是「套件没跑」
🔴 short.log 的输出里【不能】有 'never ran'        真的少了用例时不许赖到套件头上
```

**第三条防的是判据写宽** —— 只断言「crashed 会红」的话,**一个恒说 `never ran` 的实现也能过**。

## 🔴 我写这三条断言时自己踩了 pipefail

第一版:

```sh
if bash "$GATE" "$TMP_DIR/crashed.log" 0 2>&1 | grep -Fq 'never ran'; then
```

`$GATE` 在这些用例里**本来就该非零退出**,而文件顶上是 `set -euo pipefail` —— 它把那个 `1` 当成整条管道的结果,**于是 grep 明明命中了,`if` 仍然走 else 分支**。

跑出来 `RESULT: PASS=25 FAIL=1`,**而那条 FAIL 是假的**。改成先收进变量再 grep。

**今晚第二次栽在 pipefail 上**(上一次是 test831 的 SIGPIPE,#989 里修的)。区别是:上一次是别人写的,这一次是我自己刚写的 —— **同一天、同一个坑、知道它存在,照样在新代码里又写了一遍。**

## 核验

```
ROOT=<worktree> bash tests/test292-e2e-hard-gate/run.sh
RESULT: PASS=26 FAIL=0
bash -n  两个文件都过
```

## 它没有做什么

**没有动 `MIN_PASS=283`。** 余量为 1 这件事本身(#924 的另一半)仍然成立 —— 那是要不要把下限改成按套件分别设的问题,**属于另一条**。这个 PR 只让红的时候说得出是哪一种。