### PR TITLE
docs(CLAUDE.md): 「退出码不要穿过管道」补两副面孔；并写明为什么不把它做成门（量过：22 条候选、0 条缺陷）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,39 @@ cmd || exit 1                    # ✓
 的工具** —— 三个用例全打印 `rc=0`，真实退出码是 `1/1/0`。
 **一个会说谎的退出码，会先骗过写检查的人。**
 
+🔴 **同一天又撞到它的另外两副面孔，都在 `set -euo pipefail` 的脚本里：**
+
+**(a) `… | head -N` 会被 SIGPIPE 打死。** `head` 读够就退出、关掉管道，上游
+`sort`/`find` 拿到 SIGPIPE → **退出码 141**，pipefail 传出来，`set -e` 打死脚本。
+
+```bash
+VICTIM=$(find "$ROOT/docs-site" -name '*.md' | sort | head -1)   # ✗ 141
+_list=$(find "$ROOT/docs-site" -name '*.md' | sort); VICTIM=${_list%%$'\n'*}   # ✓
+grep -n -m1 PATTERN file                                          # ✓ 代替 grep|head -1
+```
+
+它**平时是绿的**（输出小的时候 `sort` 写完就退出了），红的时候**和真失败长得一样**：
+同一个 job 名、同样没有断言输出、同样一个非零退出码。见 #990。
+
+**(b) `if <预期会失败的命令> | grep -q X; then` 会把「命中」判成「没命中」。**
+pipefail 让整条管道继承那个非零退出码，于是 `grep` 明明找到了，`if` 仍然走 else。
+
+```bash
+if bash "$GATE" bad.log 0 2>&1 | grep -Fq 'never ran'; then   # ✗ 恒 false
+out=$(bash "$GATE" bad.log 0 2>&1 || true)                     # ✓ 先收进变量
+if printf '%s' "$out" | grep -Fq 'never ran'; then
+```
+
+**这一条是我在给「判据要说得清红的是哪一种」写测试时,自己写出来的** ——
+跑出 `PASS=25 FAIL=1`，而那条 FAIL 是假的。
+
+🔴 **为什么没有把它做成一道门（量过才决定的）：** 全仓 258 个 `.sh` 里 159 个设了
+pipefail，`if … | grep -q` 形态 **22 条**；逐条看完，**没有一条是缺陷** —— 8 条生产者是
+`echo/printf`（恒 0），其余 14 条里 `pgrep|grep -q .`、`find … | grep -q .` 这类
+「生产者失败」和「grep 没命中」含义相同，行为恰好一致。**唯一真正踩坑的那一条是我
+当晚新写的。** 一道 22 条全是误报的门，会在第一周就被人关掉。
+**所以这条留在这里靠读，而不是靠门。**
+
 **③ 跑那道门本身，别自造它的判据。**
 
 当天两次把数字数错：用自造的后缀白名单数测试文件（漏了 `.mts`，11 个数成 5 个）；


### PR DESCRIPTION
`CLAUDE.md` 的复核纪律第 ② 条原来只写了一种形态:`cmd | tail; echo $?`。

**同一天又撞到两种,都在 `set -euo pipefail` 的脚本里,而且都不长那个样子。**

## (a) `… | head -N` 会被 SIGPIPE 打死

`head` 读够就退出、关掉管道,上游 `sort`/`find` 拿到 SIGPIPE → **退出码 141** → pipefail 传出来 → `set -e` 打死脚本。

```bash
VICTIM=$(find "$ROOT/docs-site" -name '*.md' | sort | head -1)                 # ✗ 141
_list=$(find "$ROOT/docs-site" -name '*.md' | sort); VICTIM=${_list%%$'\n'*}   # ✓
grep -n -m1 PATTERN file                                                       # ✓ 代替 grep|head -1
```

🔴 **它平时是绿的**(输出小的时候 `sort` 写完就退出了),**红的时候和真失败长得一样**:同一个 job 名、同样没有断言输出、同样一个非零退出码。

⇒ 两种最省事的处置都会错:当真缺陷查(查一个不存在的东西)/ 当抖动重跑(大概率绿,雷继续躺着)。见 #990、PR #989。

## (b) `if <预期会失败的命令> | grep -q X; then` 把「命中」判成「没命中」

```bash
if bash "$GATE" bad.log 0 2>&1 | grep -Fq 'never ran'; then   # ✗ 恒 false
out=$(bash "$GATE" bad.log 0 2>&1 || true)                     # ✓
if printf '%s' "$out" | grep -Fq 'never ran'; then
```

**这一条是我在给「判据要说得清红的是哪一种」写测试时,自己写出来的** —— 跑出 `PASS=25 FAIL=1`,**而那条 FAIL 是假的**(PR #992)。

## 🔴 为什么没把它做成一道门 —— 量过才决定的

```
258 个 .sh，其中 159 个设了 pipefail
`if … | grep -q` 形态                     22 条
逐条看完，真缺陷                            0 条
   8 条  生产者是 echo/printf（恒 0，安全）
  14 条  pgrep | grep -q . ／ find … | grep -q . 这类
         「生产者失败」和「grep 没命中」含义相同，行为恰好一致
```

**唯一真正踩坑的那一条是我当晚新写的,而且已经修了。**

⇒ **一道 22 条全是误报的门,会在第一周就被人关掉** —— 那比没有门更糟,因为它会顺手带走大家对同名检查的信任。**所以这条留在文档里靠读,不做成门。**

(这也是今晚第二次「量完之后决定不做」:另一次是 `doc-symbol-anchors` 的标记词要不要收 `grep` —— 实测 77 → 145 锚点、32 条不过,而那 32 条**没有一条是坏锚点**,于是撤回。PR #979。)

## 这条 PR 只改注释

`CLAUDE.md` 一个文件。三道相关的门本地跑过:`no-memory-slugs` / `home-path-baseline` / `docs-integrity` 全 `rc=0`。