### PR TITLE
ci(public-script-safety): TLS 规则吃不下粘连短选项 —— `curl -fsSLk` 在 main 上是放行的

### DIFF
--- a/.github/scripts/check-public-script-safety.py
+++ b/.github/scripts/check-public-script-safety.py
@@ -45,10 +45,24 @@ KILL = re.compile(r"\b(pkill|killall)\b(?P<args>[^\n;&|]*)")
 USER_SCOPED = re.compile(r"-u\s+\S")
 # TLS verification is the only thing standing between the reader and a tampered
 # download, and these scripts are meant to be piped straight into bash.
+# 🔴 curl 的短选项是**可以粘连**的，所以不能只认「以 k 开头的那一段」。
+#    2026-08-19 实测这道门在 main 上的表现：
+#        curl -k …            抓到
+#        curl --insecure …    抓到
+#        curl -fsSLk …        **放行**   ← 而这正是最现实的一种写法
+#    往一行已有的 `curl -fsSL https://…` 上加一个字母 `k`，这道门看不见 ——
+#    关掉证书校验**不破坏任何东西**，只是把「你下到的是我们发的东西」这个前提
+#    悄悄取消了，而这个管道的另一头正以用户权限执行。
+#
+#    另外补两个同类开关（同样实测过在 main 上放行）：
+#        npm config set strict-ssl false
+#        GIT_SSL_NO_VERIFY=1 git clone …
 INSECURE_TLS = re.compile(
-    r"\b(?:curl\b[^\n;&|]*?(?:\s-{1,2}(?:k|insecure)\b)"
+    r"\b(?:curl\b[^\n;&|]*?\s-(?:-insecure\b|[A-Za-z]*k[A-Za-z]*(?=\s|$))"
     r"|wget\b[^\n;&|]*?--no-check-certificate\b"
-    r"|(?:NODE_TLS_REJECT_UNAUTHORIZED|PYTHONHTTPSVERIFY)\s*=\s*0)"
+    r"|(?:NODE_TLS_REJECT_UNAUTHORIZED|PYTHONHTTPSVERIFY)\s*=\s*0"
+    r"|strict-ssl[\s=]+false"
+    r"|GIT_SSL_NO_VERIFY\s*=\s*(?:1|true))"
 )
 
 


### PR DESCRIPTION
## 这道门守的是什么

`https://anet.sh/<name>` 那几个**给人 `curl … | bash` 的脚本**(`install.sh` / `agent-only.sh` / `hub-only.sh` / …)。

## 🔴 今天在 main 上的实测表现

```
curl -k …                          抓到
curl --insecure …                  抓到
curl -fsSL --insecure …            抓到
wget --no-check-certificate …      抓到
NODE_TLS_REJECT_UNAUTHORIZED=0 …   抓到
PYTHONHTTPSVERIFY=0 …              抓到

curl -fsSLk …                      🔴 放行
npm config set strict-ssl false    🔴 放行
GIT_SSL_NO_VERIFY=1 git clone …    🔴 放行
```

**第一条最要紧。** curl 的短选项**可以粘连** —— 往一行已有的 `curl -fsSL https://…` 上**加一个字母 `k`** 就够了。而原正则要求那一段**以 k 开头**:

```python
r"\b(?:curl\b[^\n;&|]*?(?:\s-{1,2}(?:k|insecure)\b)"
```

`-fsSLk` 以 `f` 开头 ⇒ 看不见。

🔴 **关掉证书校验不破坏任何东西** —— 它只是把「你下到的是我们发的东西」这个前提悄悄取消了,**而这个管道的另一头正以用户权限执行 `bash`**。这就是为什么它比同一道门里那两条(`rm -rf` / 无 `-u` 的 `pkill`)更隐蔽:那两条会让人立刻发现出事了,这条不会。

## 见证(A/B,同一个变异)

把 `docs-site/docs/public/agent-only.sh:53` 那行**真实命令**改成 `curl -fsSLk`:

```
改之前那版规则   0 findings                                        rc=0   ← 放行
本 PR 这版       ::error file=…agent-only.sh,line=53::
                 [tls-verification-disabled] curl -fsSLk https://…
                 1 finding                                          rc=1
还原后                                                              rc=0
```

实扫 main:`scanned 6 public script(s) … 0 findings` —— **起点是绿的**。

## 🔴 第一次变异我打在了注释行上

`agent-only.sh:6` 是 `#   curl -fsSL https://anet.sh/agent-only.sh | \`。我的 `sed '0,/curl -fsSL/'` 命中的是它。

**sha 变了、门没红** —— 我差点据此判成「新规则也抓不到」。而这道门**本来就不该判注释**。

⇒ **变异必须打在被判据管的那类行上;字节变了不等于打中了。**

(今晚第三次栽在这件事上:#984 那次打偏了 gap 测试守的字符串、#985 那次被我自己写的注释吸走。)

## 判定矩阵 13 条全对,含 4 条负控

```
放行  curl -fsSL https://x/install.sh
放行  curl -sSf https://x
放行  echo 'kick off'                          ← 含字母 k
放行  curl -fsSL https://k.example.com/x.sh    ← 主机名里有 k
```

**负控是必要的**:一个「只要出现字母 k 就报」的实现同样能通过前面那 9 条。

## 来源与范围

来自 #856 清单里的 `fix/public-script-tls-guard`。**核完发现它和 main 上现有的规则互为补集**:

```
main 有而它没有    PYTHONHTTPSVERIFY
它有而 main 没有   strict-ssl false ／ GIT_SSL_NO_VERIFY
粘连短选项         只有它考虑到了
```

⇒ **所以这不是「落地那条分支」,是把两边的覆盖面合到一起。** 这也是我这几轮反复说的那件事的又一例:**一条旧分支既不是「已被取代」也不是「原样可用」,要逐条比。**