### PR TITLE
ci(public-script-safety): rm 规则只认小写 r —— `rm -Rf` / `rm --recursive` 在 main 上是放行的

### DIFF
--- a/.github/scripts/check-public-script-safety.py
+++ b/.github/scripts/check-public-script-safety.py
@@ -40,7 +40,17 @@ PUBLIC_DIR = Path("docs-site/docs/public")
 OURS = ("~/.anet", "~/.commhub", "~/anodes/.anet",
         "~/.npm-global/lib/node_modules/@sleep2agi", "~/.anet-grok")
 
-RM_RF = re.compile(r"\brm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+(?P<targets>[^\n;&|]+)")
+# 🔴 同一个 `rm -rf` 可以写成好几种样子，而原正则只认小写 r 的短选项。
+#    2026-08-19 实测（在 main 上）：
+#        rm -rf /tmp/x   rm -fr /tmp/x   rm -rvf /tmp/x   rm -r -f /tmp/x   → 命中
+#        rm -Rf /tmp/x                                                       → 🔴 放行
+#        rm --recursive --force /tmp/x                                       → 🔴 放行
+#    `-R` 是 `-r` 的大写形式（POSIX 就有，macOS 文档里用的正是它），不是什么冷僻写法；
+#    长选项同理。这和 TLS 那条的 `curl -fsSLk` 是同一个毛病：**判据认的是某一种拼法，
+#    不是那个命令**。
+RM_RF = re.compile(
+    r"\brm\s+(?:-[a-zA-Z]*[rR][a-zA-Z]*f?|--recursive)\b[^\n;&|]*?\s(?P<targets>[^\n;&|]+)"
+)
 KILL = re.compile(r"\b(pkill|killall)\b(?P<args>[^\n;&|]*)")
 USER_SCOPED = re.compile(r"-u\s+\S")
 # TLS verification is the only thing standing between the reader and a tampered


### PR DESCRIPTION
接 #994。那条修的是 TLS 规则认不出粘连短选项(`curl -fsSLk`)。**同一道门里的 `rm` 规则有同一个毛病**,所以顺着查了一遍。

## 实测(2026-08-19,`origin/main`)

```
rm -rf /tmp/x                    命中
rm -fr /tmp/x                    命中
rm -rvf /tmp/x                   命中
rm -r -f /tmp/x                  命中
rm -Rf /tmp/x                    🔴 放行
rm --recursive --force /tmp/x    🔴 放行
```

原正则:

```python
RM_RF = re.compile(r"\brm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+(?P<targets>[^\n;&|]+)")
```

`[a-zA-Z]*r[a-zA-Z]*` 里那个 **`r` 是写死的小写**。

🔴 **`-R` 是 `-r` 的大写形式(POSIX 就有,macOS 的 `rm` 文档用的正是它),不是冷僻写法。** 长选项同理。

⇒ **和 TLS 那条是同一个病:判据认的是某一种拼法,不是那个命令。**

## 见证(A/B,同一个变异,打在真实命令行上)

往 `docs-site/docs/public/agent-only.sh` 的一条真实命令前插入 `rm -Rf /var/lib/apt/lists`(先用 sha 确认变异真的应用了):

```
旧规则   0 findings                                                 rc=0   ← 放行
本 PR    ::error file=…agent-only.sh,line=53::
         [rm-rf-outside-product] /var/lib/apt/lists                 rc=1
还原                                                                rc=0
```

实扫 main:`scanned 6 public script(s) … 0 findings` —— **起点是绿的**。

## 判定矩阵 10 条全对,含负控

```
放行  rm -f /tmp/one-file      ← 只删单个文件，没有 -r/-R
放行  rm /tmp/one-file
```

**负控是必要的**:一个「看到 `rm` 就报」的实现同样能通过前面那 7 条。

## 🔴 同一次排查里发现、但本 PR **不动**的一格

`pkill` 那条规则只认 `pkill` / `killall` 两个命令名,而下面两种是**同样的危害**:

```
kill -9 $(pgrep -f agent-node)         放行
pgrep -f agent-node | xargs kill -9    放行
```

(这个仓有过一次真实事故:一条模式匹配的 kill 打掉了生产 hub。)

**但那是给这道门加一个新的命令形态,不是把现有规则的拼法认全** —— 而且要不要沿用 `-u` 那个逃生口需要判断。

⇒ **留作单独一条,不在这个 PR 里顺手做。** 今晚我已经因为「顺手扩一下」撤回过一次(#979),这次先把范围说清楚。