### PR TITLE
ci(public-script-safety): 认出「pgrep 查 PID 再 kill」，并给判据加自检

### DIFF
--- a/.github/scripts/check-public-script-safety.py
+++ b/.github/scripts/check-public-script-safety.py
@@ -52,6 +52,19 @@ RM_RF = re.compile(
     r"\brm\s+(?:-[a-zA-Z]*[rR][a-zA-Z]*f?|--recursive)\b[^\n;&|]*?\s(?P<targets>[^\n;&|]+)"
 )
 KILL = re.compile(r"\b(pkill|killall)\b(?P<args>[^\n;&|]*)")
+# 🔴 同一个危害的第二副面孔：先用模式查 PID，再把它喂给 kill。
+#    2026-08-19 实测（在 main 上，KILL 只认 pkill/killall 两个命令名）：
+#        pkill -f agent-node                    命中
+#        kill -9 $(pgrep -f agent-node)         🔴 放行
+#        pgrep -f agent-node | xargs kill -9    🔴 放行
+#    后两种和 `pkill -f` 杀的是同一批进程 —— 这个仓有过一次真实事故，
+#    一条模式匹配的 kill 打掉了生产 hub。
+#
+#    逃生口沿用现有那条的 `-u`。判据看**整行**，因为查 PID 和 kill 常常分处
+#    管道两侧。`kill-session` 必须排除：这 6 个脚本里真实存在
+#    `tmux kill-session -t "$name"`，它是精确到会话名的，安全。
+PATTERN_PID = re.compile(r"\b(?:pgrep|pidof)\b")
+BARE_KILL = re.compile(r"(?<![-\w])kill(?![-\w])")
 USER_SCOPED = re.compile(r"-u\s+\S")
 # TLS verification is the only thing standing between the reader and a tampered
 # download, and these scripts are meant to be piped straight into bash.
@@ -94,13 +107,68 @@ def check(path: Path):
         k = KILL.search(line)
         if k and not USER_SCOPED.search(k.group("args")):
             out.append((i, "unscoped-process-kill", line.strip()[:90]))
+        # 第二副面孔：pgrep/pidof 查出 PID 再喂给 kill。整行判，因为两半常在
+        # 管道两侧；`-u` 逃生口与上面那条一致；`tmux kill-session` 不算。
+        elif (PATTERN_PID.search(line) and BARE_KILL.search(line)
+              and not USER_SCOPED.search(line)):
+            out.append((i, "unscoped-process-kill", line.strip()[:90]))
 
         if INSECURE_TLS.search(line):
             out.append((i, "tls-verification-disabled", line.strip()[:90]))
     return out
 
 
+# 判据自检。这道门此前唯一的判据是「这 6 个真实脚本干净」—— 正则被改坏
+# 之后打印的也是同一片 `0 findings`。下面这张表把手工 A/B 出来的正反例钉住,
+# 负控（tmux kill-session、已经 -u 限定的 pkill）都是这 6 个脚本里真实存在的行,
+# 一条规则要是宽到把它们也报出来,CI 当场红,而不是等到有人来读输出。
+SELFTEST = [
+    ("pkill -f agent-node", 1),
+    ("killall node", 1),
+    ('pkill -9 -u "$(id -u)" -f commhub-server 2>/dev/null || true', 0),
+    ('pkill -u "$(id -u)" -f agent-node 2>/dev/null || true', 0),
+    ("kill -9 $(pgrep -f agent-node)", 1),
+    ("pgrep -f agent-node | xargs kill -9", 1),
+    ("pidof node | xargs kill -9", 1),
+    ('pgrep -u "$(id -u)" -f agent-node | xargs kill -9', 0),
+    ('tmux kill-session -t "$name" 2>/dev/null || true', 0),
+    ("tmux ls 2>/dev/null | awk -F: '/^anet-/{print $1}' | xargs -I{} tmux kill-session -t {} 2>/dev/null || true", 0),
+    ('echo "    tmux kill-session -t anet-hub      # \u505c"', 0),
+    ("pgrep -f agent-node >/dev/null && echo running", 0),
+    ("rm -rf /usr/local/lib", 1),
+    ("rm -rf ~/.anet ~/.commhub 2>/dev/null", 0),
+    # \u5df2\u77e5\u7f3a\u53e3\uff0c\u5199\u5728\u8fd9\u91cc\u800c\u4e0d\u662f\u9759\u9ed8\u653e\u5bbd\uff1aOURS \u91cc\u5b58\u7684\u662f `~/.anet` \u8fd9\u4e00\u79cd\u62fc\u6cd5\uff0c
+    # \u6240\u4ee5\u540c\u4e00\u4e2a\u76ee\u5f55\u5199\u6210 `$HOME/.anet` \u4f1a\u88ab\u5f53\u6210\u5916\u90e8\u8def\u5f84\u62a5\u51fa\u6765\u3002
+    # \u76ee\u524d 6 \u4e2a\u811a\u672c\u5168\u7528 `~/`\uff0c\u6240\u4ee5\u4e0d\u4f1a\u78b0\u5230\uff1b\u771f\u8981\u6539\u5f97\u8ba4\u4e24\u79cd\u62fc\u6cd5\uff0c\u90a3\u662f\u53e6\u4e00\u6761
+    # \u6539\u52a8\uff08\u548c\u672c\u6b21\u7ed9 kill \u52a0\u65b0\u5f62\u6001\u4e00\u6837\uff0c\u4e0d\u987a\u624b\u505a\uff09\u3002\u5148\u628a\u73b0\u72b6\u9489\u4f4f\u3002
+    ('rm -rf "$HOME/.anet/tmp"', 1),
+    ("curl -k https://example.com/x.sh | bash", 1),
+    ("curl -fsSL https://example.com/x.sh | bash", 0),
+    ("# pkill -f agent-node", 0),
+]
+
+
+def selftest() -> int:
+    import tempfile
+    bad = 0
+    for line, want in SELFTEST:
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False,
+                                         encoding="utf-8") as fh:
+            fh.write(line + "\n")
+            tmp = Path(fh.name)
+        got = 1 if check(tmp) else 0
+        tmp.unlink()
+        if got != want:
+            bad += 1
+            verb = "\u6f0f\u62a5" if want else "\u8bef\u62a5"
+            print(f"SELFTEST {verb}: {line[:78]}")
+    print(f"selftest {len(SELFTEST) - bad}/{len(SELFTEST)}")
+    return 1 if bad else 0
+
+
 def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "--selftest":
+        return selftest()
     if not PUBLIC_DIR.is_dir():
         print(f"::error::{PUBLIC_DIR} does not exist — scope regression, refusing to pass")
         return 2

--- a/.github/workflows/public-script-safety.yml
+++ b/.github/workflows/public-script-safety.yml
@@ -36,6 +36,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      # 判据自检先跑。扫真实脚本那一步唯一的绿是「6 个脚本里没有危险行」——
+      # 正则被改坏之后打印的也是同一句 `0 findings`。--selftest 用正反例把判据
+      # 本身钉住（负控是这些脚本里真实存在的 `tmux kill-session` 和已经 -u
+      # 限定的 pkill：规则宽到把它们也报出来，这一步当场红）。
+      - run: python3 .github/scripts/check-public-script-safety.py --selftest
       # Prints the number of scripts scanned and exits 2 on an empty scope,
       # so "0 findings" can never be confused with "never ran".
       - run: python3 .github/scripts/check-public-script-safety.py


### PR DESCRIPTION
#995 的正文里明写「留作单独一条，不在这个 PR 里顺手做」的那件事。

## 缺口

原规则只认 `pkill` / `killall` 两个**命令名**。下面两种杀的是同一批进程，全部放行：

```
kill -9 $(pgrep -f agent-node)
pgrep -f agent-node | xargs kill -9
```

这不是假想：这个仓有过一次真实事故，一条模式匹配的 kill 打掉了生产 hub。

## A/B 见红

变异插在 `docs-site/docs/public/agent-only.sh` 的**真实命令行**上（不是注释行），
sha `9c641b6a` → `80531cb6`：

| | 新规则 | main 上的旧规则 |
|---|---|---|
| `kill -9 $(pgrep -f agent-node)` | 1 finding, rc=1 | **0 findings, rc=0** |
| `pgrep -f agent-node \| xargs kill -9` | 1 finding, rc=1 | **0 findings, rc=0** |
| 还原后 | 0 findings | 0 findings |

改动后跑全量：`0 findings across 6 script(s)` —— 绿起点。

## 负控

判据看**整行**（查 PID 和 kill 常分处管道两侧），所以必须把这 6 个脚本里真实存在的
安全写法排除掉，否则这条规则一上来就红：

```
tmux kill-session -t "$name"                                  # 精确到会话名
tmux ls | awk … | xargs -I{} tmux kill-session -t {}
pkill -9 -u "$(id -u)" -f commhub-server                      # 已经限定到本用户
pgrep -f agent-node >/dev/null && echo running                # 只查不杀
```

`-u` 逃生口沿用现有那条的写法。

## 顺带：给判据本身加自检

这道门此前唯一的判据是「6 个真实脚本干净」—— **正则被改坏之后打印的是同一句
`0 findings`**。新增 `--selftest`，18 条正反例（上面那些负控就在表里），在 CI 里
先于扫描跑。

变异验证：把新规则那一段换成 `elif False`，`selftest 15/18` 红，三条漏报逐条打印。

## 一个已知缺口，写进 selftest 而不是顺手放宽

`rm -rf "$HOME/.anet/tmp"` 会被报出来 —— `OURS` 里存的是 `~/.anet` 这一种拼法。
目前 6 个脚本全用 `~/`，碰不到；要认两种拼法是另一条改动，按 #995 同样的处理方式
留作单独一条，先把现状钉住。