### PR TITLE
fix(ci): 把 #996/#997 里写进注释的字面 \uXXXX 解回中文，并加一道门

### DIFF
--- a/.github/scripts/check-no-escaped-comments.py
+++ b/.github/scripts/check-no-escaped-comments.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Python 注释里不许出现字面 `\\uXXXX`。
+
+2026-08-18 我自己在 #996 / #997 里连着两次写出这种注释，合进了 main：
+
+    # \\u5df2\\u77e5\\u7f3a\\u53e3\\uff0c\\u5199\\u5728\\u8fd9\\u91cc…
+
+同一个 `\\uXXXX` 出现在**字符串字面量**里是对的 —— Python 在解析时就把它解成了字符，
+selftest 打印出来的中文完全正常。**只有注释不会被任何东西解码**，它原样躺在那里。
+于是这个错的两副面孔里，被修掉的那份（字符串）本来就没坏，而留下来的那份
+（注释）恰恰是唯一给人读的。
+
+判据用 tokenize 取 COMMENT token，不用正则扫行 —— 行里可能同时有
+`"# \\u4e0d\\u662f\\u811a\\u672c"` 这样**字符串内的** `#`，按行 grep 会把它当注释误报。
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import subprocess
+import sys
+import tokenize
+from pathlib import Path
+
+ESC = re.compile(r"\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}")
+
+
+def main() -> int:
+    r = subprocess.run(["git", "ls-files", "*.py"], capture_output=True, text=True)
+    files = [f for f in r.stdout.split("\n") if f]
+    # 分母承重：一个文件都没取到时不能报绿。
+    if not files:
+        print("::error::git ls-files '*.py' 一个都没返回 —— 取集坏了，不当作通过")
+        return 2
+
+    bad = 0
+    for rel in files:
+        p = Path(rel)
+        try:
+            src = p.read_text(encoding="utf-8")
+            toks = list(tokenize.generate_tokens(io.StringIO(src).readline))
+        except (OSError, SyntaxError, tokenize.TokenError, UnicodeDecodeError):
+            continue
+        for t in toks:
+            if t.type == tokenize.COMMENT and ESC.search(t.string):
+                bad += 1
+                print(f"::error file={rel},line={t.start[0]}::注释里有字面 "
+                      f"\\uXXXX，它不会被任何东西解码：{t.string[:70]}")
+
+    print(f"scanned {len(files)} python file(s); {bad} escaped comment(s).")
+    if bad:
+        print("    注释直接写字符。字符串字面量里的 \\uXXXX 是对的，不要一起改。")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-public-script-safety.py
+++ b/.github/scripts/check-public-script-safety.py
@@ -165,10 +165,10 @@ SELFTEST = [
     ("pgrep -f agent-node >/dev/null && echo running", 0),
     ("rm -rf /usr/local/lib", 1),
     ("rm -rf ~/.anet ~/.commhub 2>/dev/null", 0),
-    # \u5df2\u77e5\u7f3a\u53e3\uff0c\u5199\u5728\u8fd9\u91cc\u800c\u4e0d\u662f\u9759\u9ed8\u653e\u5bbd\uff1aOURS \u91cc\u5b58\u7684\u662f `~/.anet` \u8fd9\u4e00\u79cd\u62fc\u6cd5\uff0c
-    # \u6240\u4ee5\u540c\u4e00\u4e2a\u76ee\u5f55\u5199\u6210 `$HOME/.anet` \u4f1a\u88ab\u5f53\u6210\u5916\u90e8\u8def\u5f84\u62a5\u51fa\u6765\u3002
-    # \u76ee\u524d 6 \u4e2a\u811a\u672c\u5168\u7528 `~/`\uff0c\u6240\u4ee5\u4e0d\u4f1a\u78b0\u5230\uff1b\u771f\u8981\u6539\u5f97\u8ba4\u4e24\u79cd\u62fc\u6cd5\uff0c\u90a3\u662f\u53e6\u4e00\u6761
-    # \u6539\u52a8\uff08\u548c\u672c\u6b21\u7ed9 kill \u52a0\u65b0\u5f62\u6001\u4e00\u6837\uff0c\u4e0d\u987a\u624b\u505a\uff09\u3002\u5148\u628a\u73b0\u72b6\u9489\u4f4f\u3002
+    # 已知缺口，写在这里而不是静默放宽：OURS 里存的是 `~/.anet` 这一种拼法，
+    # 所以同一个目录写成 `$HOME/.anet` 会被当成外部路径报出来。
+    # 目前 6 个脚本全用 `~/`，所以不会碰到；真要改得认两种拼法，那是另一条
+    # 改动（和本次给 kill 加新形态一样，不顺手做）。先把现状钉住。
     ('rm -rf "$HOME/.anet/tmp"', 1),
     ("curl -k https://example.com/x.sh | bash", 1),
     ("curl -fsSL https://example.com/x.sh | bash", 0),
@@ -176,16 +176,16 @@ SELFTEST = [
 ]
 
 
-# \u53d6\u96c6\u90a3\u4e00\u5c42\u7684\u6b63\u53cd\u4f8b\u3002\u4e0a\u9762\u90a3\u5f20\u8868\u53ea\u80fd\u9a8c\u5224\u636e\uff08\u7ed9\u5b83\u4e00\u884c\u3001\u770b\u5b83\u62a5\u4e0d\u62a5\uff09\uff0c
-# \u800c #996 \u4e4b\u524d\u90a3\u4e2a\u5b9e\u6d4b\u51fa\u6765\u7684\u7f3a\u53e3\u4e0d\u5728\u5224\u636e\u91cc\uff0c\u5728\u300c\u600e\u4e48\u62ff\u5230\u8981\u5224\u7684\u4e1c\u897f\u300d\u91cc\u3002
-# \u8fd9\u4e24\u5c42\u5f97\u5206\u5f00\u9489\uff1a\u5224\u636e\u5168\u5bf9\u3001\u53d6\u96c6\u6f0f\u4e00\u4e2a\u6587\u4ef6\uff0c\u8f93\u51fa\u4e5f\u662f\u4e00\u7247\u7eff\u3002
+# 取集那一层的正反例。上面那张表只能验判据（给它一行、看它报不报），
+# 而 #996 之前那个实测出来的缺口不在判据里，在「怎么拿到要判的东西」里。
+# 这两层得分开钉：判据全对、取集漏一个文件，输出也是一片绿。
 COLLECT_SELFTEST = [
     ("install.sh", "#!/bin/bash\n", True),
-    ("community/evil.sh", "#!/bin/bash\n", True),          # \u5b50\u76ee\u5f55\u4e00\u6837\u4f1a\u88ab\u670d\u51fa\u53bb
-    ("bootstrap", "#!/usr/bin/env bash\n", True),          # \u65e0\u540e\u7f00\uff0c\u4f46 curl \u2026 | bash \u7167\u8dd1
+    ("community/evil.sh", "#!/bin/bash\n", True),          # 子目录一样会被服出去
+    ("bootstrap", "#!/usr/bin/env bash\n", True),          # 无后缀，但 curl … | bash 照跑
     ("deep/a/b/x.sh", "#!/bin/sh\n", True),
     ("notes.md", "# \u4e0d\u662f\u811a\u672c\n", False),
-    ("README.txt", "just a note\nrm -rf /etc\n", False),   # \u6ca1 shebang\uff0c\u4e0d\u6536
+    ("README.txt", "just a note\nrm -rf /etc\n", False),   # 没 shebang，不收
     ("logo.svg", "<svg/>\n", False),
 ]
 

--- a/.github/workflows/no-escaped-comments.yml
+++ b/.github/workflows/no-escaped-comments.yml
@@ -1,0 +1,32 @@
+# Python 注释里不许出现字面 `\uXXXX`。
+#
+# 2026-08-18 我在 #996 / #997 里连着两次写出这种注释并合进了 main。同一个
+# `\uXXXX` 写在**字符串字面量**里是对的（Python 解析时就解成了字符，selftest
+# 打印的中文完全正常），**只有注释不会被任何东西解码**。于是这个错的两副面孔里，
+# 看起来没问题的那份本来就没问题，而躺在那里的那份恰恰是唯一给人读的。
+#
+# 判据在 .github/scripts/check-no-escaped-comments.py，用 tokenize 取 COMMENT
+# token，不按行 grep —— 行里可能有字符串内的 `#`。
+
+name: lint (no escaped comments)
+
+on:
+  # 与本仓其它守卫一致：刻意不加 paths。带 paths 的 workflow 在不匹配的 PR 上
+  # 不产生 check-run，永远做不了 required check。
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  no-escaped-comments:
+    # 全仓唯一的 job name —— 分支保护里的 required check 只能按这个名字写。
+    name: no-escaped-comments
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # 打印扫过的文件数，并在取集为空时退 2 —— "0 escaped" 不能和 "根本没跑" 同形。
+      - run: python3 .github/scripts/check-no-escaped-comments.py


### PR DESCRIPTION
**我自己的回归。** #996 / #997 合进 main 的 `.github/scripts/check-public-script-safety.py` 里，
有 10 条注释长这样：

```
# 已知缺口，写在这里…
```

## 为什么只有一半坏了

同一个 `\uXXXX` 出现在**字符串字面量**里是对的 —— Python 解析时就把它解成了字符，
selftest 打印的 `SELFTEST 漏报:` / `COLLECT 漏收:` 中文完全正常。**只有注释不会被任何
东西解码。**

这个错的两副面孔里，看起来可疑的那份（字符串）本来就没坏，而原样躺着的那份（注释）
恰恰是**唯一给人读的** —— 那些注释的全部意义就是解释为什么判据这么写。

## 改动只碰注释

用 `tokenize` 取 COMMENT token 的精确位置来替换，不按行正则（行里可能有字符串内的 `#`）。

证据：去掉 COMMENT / NL 之后的 token 流，改前改后 **1385 == 1385 且逐字相同**。
行为复验 `selftest 18/18` / `collect-selftest 7/7` / `0 findings across 6 script(s)`，与改前一致。

## 顺带加一道门

今晚第二次写出这种注释了，不加会有第三次。`.github/scripts/check-no-escaped-comments.py`
同样用 tokenize，不按行 grep —— 本仓真实存在字符串内的 `#`：

```python
("notes.md", "# 不是脚本\n", False),
```

| | 结果 |
|---|---|
| 绿起点 | `scanned 32 python file(s); 0 escaped comment(s).` rc=0 |
| 见红 | 把 main 上那份未修的放回来 → `10 escaped comment(s)` rc=1 |
| 负控 | 一个文件里字符串写 `"停"`、注释写正常中文 → 0 报，且分母 32→**33**（证明它确实进了取集，不是被跳过） |

workflow 沿用本仓惯例：不加 `paths`（带 paths 的 workflow 在不匹配的 PR 上不产生
check-run，永远做不了 required check），job name 全仓唯一。