### PR TITLE
ci(query-token-ratchet): 取集改 rglob —— server/src/shared/ 在这道安全棘轮外面

### DIFF
--- a/.github/scripts/check-query-token-ratchet.py
+++ b/.github/scripts/check-query-token-ratchet.py
@@ -88,7 +88,15 @@ def read_sources() -> dict[str, str]:
         return {}
     return {
         str(p): p.read_text(encoding="utf-8", errors="replace")
-        for p in sorted(SRC_DIR.glob("*.ts"))
+        # 🔴 rglob，不是 glob。2026-08-18 实测（当时是非递归）：顶层 105 个 .ts，
+        # 递归 111 个 —— `server/src/shared/` 下那 6 个在这道棘轮外面。
+        # 棘轮的输出是一个**数**（bypassing_helper=11），所以一个写在子目录里、
+        # 直读 `?token=` 的新调用点不会把数抬高：它根本不在分母里，打印出来的
+        # 和真绿逐字相同。分母从同一个 glob 算，永远自洽，也永远看不见 glob 外面。
+        # 放宽后分母 36 → 39（shared/ 那 6 个里 3 个是 .test.ts，本来就排除；
+        # 剩下 3 个非测试文件今天一条命中都没有），三个计数一个不变，绿起点，
+        # 基线不动。
+        for p in sorted(SRC_DIR.rglob("*.ts"))
         if not p.name.endswith(".test.ts")
     }
 


### PR DESCRIPTION
类审计 12 个守卫脚本的取集方式时发现的第三处，也是唯一一处落在**安全**门上的。

## 缺口

`server/src` 顶层 **105** 个 `.ts`，递归 **111** 个 —— `server/src/shared/` 下那 6 个
从来没进过这道棘轮。

## 为什么这处比另外两处更值得先修

**棘轮的输出是一个数**（`bypassing_helper=11`，只许减不许增）。一个写在子目录里、
直读 `?token=` 的新调用点**不会把这个数抬高 —— 它根本不在分母里**，门照样打印
`query-token surface did not grow`。凭据进访问日志和 Referer 这件事（#501）可以就这么
悄悄扩大，而没有任何计数异动去提醒任何人。

## A/B

在 `server/src/shared/` 放一个直读 `url.searchParams.get("token")` 的文件：

| | 输出 | rc |
|---|---|---|
| 新门 | `scanned 40 … bypassing_helper=12 (baseline 11)` + `::error::12 call sites read ?token= directly…` | 1 |
| 旧门 | `scanned 36 … bypassing_helper=11 (baseline 11)`<br>`query-token surface did not grow; existing opt-outs are intact.` | **0** |

## 绿起点

分母 36 → **39**，三个计数一个不变（`inside_helper=1` / `bypassing_helper=11` /
`allowQueryToken:false = 2`），基线不需要动。`--selftest 6/6 ok` 不变。

39 不是 40 —— `shared/` 那 6 个里 3 个是 `.test.ts`，本来就被排除。

## 同一次审计里**不改**的那些

- `action-pins` / `workflow-structure` / `qa-trigger-coverage` 用非递归 glob 是**对的**：
  GitHub Actions 自己就不递归（`.github/workflows` 下 0 个子目录，顶层 20 == 递归 20）。
- `check-published-build-paths` 的 `*.tgz` 来自 `npm pack`，产物是平的。

取集方式要匹配被扫对象的**真实语义**，不是「递归一律更安全」。