### PR TITLE
docs(app-shells): 补交叉引用 —— 「没人验过 mac」只对 Dashboard 那个壳成立

### DIFF
--- a/docs-site/docs/en/guide/app-shells.md
+++ b/docs-site/docs/en/guide/app-shells.md
@@ -75,6 +75,22 @@ Three things worth knowing:
 **Until someone builds them on the matching platform, this page will not claim the macOS or
 Windows installers work.**
 
+::: tip That sentence is only about the Dashboard shell
+There is a **second, independent client line**:
+[`sleep2agi/agent-network-app`](https://github.com/sleep2agi/agent-network-app)
+(`desktop/` + `src-tauri/`, Tauri). It has its own packaging pipeline, and **its macOS job runs
+on a real `macos-14` runner**, producing a `.dmg` and an `.app` zip. It has succeeded
+(most recently 2026-06-17).
+
+So the answer to "is there a Mac installer" is **yes** — just not from the shell this page
+describes. Both lines currently coexist; this page does not judge which one is the main line.
+See [issue #233](https://github.com/sleep2agi/agent-network/issues/233).
+
+**Windows is the one genuinely empty cell across all three repositories**: no workflow anywhere
+builds for Windows. The Dashboard's `electron-builder.json` does *configure* a `win: nsis`
+target, but no CI runs it — **a configured target is not a produced artifact.**
+:::
+
 ## Which one should I use
 
 - Just want it on your phone → **PWA**, no build step at all;

--- a/docs-site/docs/guide/app-shells.md
+++ b/docs-site/docs/guide/app-shells.md
@@ -67,6 +67,19 @@ npm run app:desktop:pack                                                  # 打�
 
 **macOS / Windows 的安装包，在有人在对应平台上真打出来之前，本页不会声称它们可用。**
 
+::: tip 上面这句只针对 Dashboard 那个壳
+还有**另一条独立的客户端线**：[`sleep2agi/agent-network-app`](https://github.com/sleep2agi/agent-network-app)
+（`desktop/` + `src-tauri/`，Tauri）。它有自己的打包流水线，**其中 macOS 那条是在真的
+`macos-14` runner 上跑的**，产出 `.dmg` 与 `.app` zip，实测成功过（最近一次 2026-06-17）。
+
+所以「有没有 Mac 安装包」这个问题的答案是**有**，只是不在本页说的这个壳里。
+两条线目前并存，本页不判断哪条是主线 —— 见 [issue #233](https://github.com/sleep2agi/agent-network/issues/233)。
+
+**Windows 是三个仓里唯一真正为零的那格**：所有 workflow 里都没有 Windows 打包。
+Dashboard 的 `electron-builder.json` 里**配置**了 `win: nsis`，但没有任何 CI 跑它 ——
+**配置存在不等于产物存在。**
+:::
+
 ## 我该用哪一种
 
 - 只是想在手机上看看 → **PWA**，不需要任何构建；


### PR DESCRIPTION
承 #1013。那条 PR 里我在页面上写了：

> **macOS / Windows 的安装包，在有人在对应平台上真打出来之前，本页不会声称它们可用。**

**那句对 Dashboard 那个壳是准确的，但读者会把它读成「整个项目都没有 Mac 安装包」—— 而那是错的。**

## 实测到的事实

复核 [#233](https://github.com/sleep2agi/agent-network/issues/233) 时查到：
[`sleep2agi/agent-network-app`](https://github.com/sleep2agi/agent-network-app)（`desktop/` + `src-tauri/`，Tauri）
有自己的打包流水线，其中 `.github/workflows/desktop-tauri.yml`：

```yaml
runs-on: macos-14
...
cp src-tauri/target/release/bundle/dmg/*.dmg out/
ditto -c -k --keepParent "src-tauri/target/release/bundle/macos/Agent Network.app" \
  out/AgentNetwork-tauri-arm64-mac.zip
```

运行记录：**成功 3 次，最近 2026-06-17**。

⇒ 「有没有 Mac 安装包」的答案是**有**，只是不在这一页说的那个壳里。两条线目前并存，
本页不判断哪条是主线 —— 那要 #233 的 owner 定。

## 同时把 Windows 那格写准

**它是三个仓里唯一真正为零的**：所有 workflow 里都没有 Windows 打包。

```bash
# agent-network / agent-network-dashboard / agent-network-app 的所有 workflow
# 搜 windows-latest|windows-20|nsis|.msi|.exe   → 三个仓全部无命中
```

Dashboard 的 `electron-builder.json` 里**配置**了 `win: nsis`，但**没有任何 CI 跑它** ——
**配置存在不等于产物存在。**

## 为什么必须补这一句

我自己写的那一页，因为只聚焦在我动过的那个壳上，**造成了一个新的信息不对称**：读者会
以为 Mac 那条路还没开始。这和这一页最初要解决的问题（三种壳存在、但 anet.sh 上一个字
都没有）是**同一类错误，只是方向相反**。

## 验证

中英两版都补。`docs-integrity` / `doc-symbol-pins` / `no-memory-slugs` /
`no-escaped-comments` 全 rc=0，**并且真跑了一次 `vitepress build`**（rc=0，38.93s）。
