### PR TITLE
fix(grok): 修我今天造成的审计/生成不一致 —— 审计与夹具两半一起落（#1016 / #1011）

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -3784,7 +3784,11 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
         );
       }
       assertNoDiscoveredGrokHooks(inspection);
-      assertGrokCopresenceApprovalOwnership(inspection, auditRuntime.grokCliHome.home);
+      assertGrokCopresenceApprovalOwnership(
+        inspection,
+        auditRuntime.grokCliHome.home,
+        commhubMcpCommand,
+      );
       let doctor: string;
       try {
         doctor = execFileSync(grokBinary, ["mcp", "doctor", "commhub", "--json"], {

--- a/agent-node/src/runtime/grok-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.test.ts
@@ -335,6 +335,24 @@ describe("Grok copresence launch and injection policy", () => {
     expect(() => assertGrokCopresenceApprovalOwnership(JSON.stringify({
       ...cleanInspection,
     }), home)).not.toThrow();
+    // 🔴 #1016：产品生成的 config.toml 里 command 是 realpath 之后的绝对路径，
+    //    而钉死的 grok 0.2.93 把 target 逐字报成那个 command（2026-08-19 容器内实测）。
+    //    所以审计必须和「产品自己算出来的命令」比，不能和裸 "bun" 比。
+    //    下面第三条是 #1016 那个不一致本身：target 是裸 "bun" 而产品算出的是绝对路径。
+    const absoluteBun = "/opt/anet/bin/bun";
+    const absoluteInspection = {
+      ...cleanInspection,
+      mcpServers: [{ ...cleanInspection.mcpServers[0], target: absoluteBun }],
+    };
+    expect(() => assertGrokCopresenceApprovalOwnership(
+      JSON.stringify(absoluteInspection), home, absoluteBun,
+    )).not.toThrow();
+    expect(() => assertGrokCopresenceApprovalOwnership(
+      JSON.stringify(absoluteInspection), home, "/somewhere/else/bun",
+    )).toThrow("runtime-owned commhub");
+    expect(() => assertGrokCopresenceApprovalOwnership(
+      JSON.stringify(cleanInspection), home, absoluteBun,
+    )).toThrow("runtime-owned commhub");
     expect(() => assertGrokCopresenceApprovalOwnership(JSON.stringify({
       ...cleanInspection,
       permissions: {

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -484,6 +484,17 @@ export function assertGrokCopresenceVersion(version: string): void {
 export function assertGrokCopresenceApprovalOwnership(
   inspectionJson: string,
   isolatedGrokHome: string,
+  // 🔴 2026-08-19：这一格必须是**产品自己算出来的那个命令**，不能写死。
+  //    实测（钉死的 grok 0.2.93，容器内 --network none）：
+  //        config.toml:  command = "/usr/local/bin/fake-bun"
+  //        grok inspect --json →  "target": "/usr/local/bin/fake-bun"
+  //    target 逐字等于 config.toml 的 command。而生成侧
+  //    grok-build-cli-home.ts 的 resolveGrokCommhubMcpCommand() 只可能返回
+  //    realpath 之后的绝对路径（或抛错），所以拿裸 "bun" 去比**永远不成立**。
+  //
+  //    这个不一致由 #1004 落了生成侧、#1010 摘了审计侧造成（见 #1016）。
+  //    默认值 "bun" 只为兼容尚未传参的调用点；生产路径必须显式传。
+  expectedCommhubCommand = "bun",
 ): void {
   let inspection: Record<string, unknown>;
   try {
@@ -547,7 +558,10 @@ export function assertGrokCopresenceApprovalOwnership(
   if (
     commhubRecord.name !== "commhub"
     || commhubRecord.transport !== "stdio"
-    || commhubRecord.target !== "bun"
+    // resolve() 两侧各做一次：生成侧写进 config.toml 的已是 canonical 绝对路径
+    // （grok-build-cli-home.ts:1067 强制 realpathSync(command) === command），
+    // 所以这里只需防 "/a/./b" 这类等价写法，不需要再解一次符号链接。
+    || resolve(String(commhubRecord.target || "")) !== resolve(expectedCommhubCommand)
     || !source
     || typeof source !== "object"
     || Array.isArray(source)

--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -196,7 +196,7 @@ if (["new_task", "broadcast"].includes(ev.type)) {
 |---|------|--------|------|
 | 1 | sendReply 用 send_message | agent-node | ✅ v1.4.2 |
 | 2 | SSE 只响应 new_task / broadcast | agent-node | ✅ [cli.ts:1102 `["new_task", "broadcast"].includes(ev.type)`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L1102)；`new_reply` 单独走日志记录 cli.ts:1106 |
-| 3 | 低价值消息过滤 | agent-node | ✅ v1.4.0；当前在 [cli.ts:4691 `shouldSkipMessage`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L4691) |
+| 3 | 低价值消息过滤 | agent-node | ✅ v1.4.0；当前在 [cli.ts:4695 `shouldSkipMessage`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L4695) |
 | 4 | CLAUDE.md 不对 message 回复 | 各项目 CLAUDE.md | ✅ R195 chain 模板已加 |
 | 5 | developer_instructions 安静规则 | agent-node | ✅ v1.4.1 |
 

--- a/tests/test225-grok-preview-package-live/fake-grok.mjs
+++ b/tests/test225-grok-preview-package-live/fake-grok.mjs
@@ -89,14 +89,29 @@ if (argv.includes("--help")) {
 
 if (argv[0] === "inspect" && argv.includes("--json")) {
   recordEnvironment("inspect");
+  // 🔴 target 必须从 config.toml 的 command 读出来，**不能写死**。
+  //    2026-08-19 拿钉死的 grok 0.2.93 离线实测（容器里 --network none）：
+  //        config.toml:  command = "/usr/local/bin/fake-bun"
+  //        grok inspect --json →  "target": "/usr/local/bin/fake-bun"
+  //    也就是 target 就是 command，逐字、绝对路径、不含 args。
+  //
+  //    这里原来写死成 `"bun"`。后果不是「夹具不够真」，是**它让一个真实的不一致
+  //    在 CI 里永远看不见**：审计要求 target === "bun"，夹具就报 "bun"，两者恒相符，
+  //    而产品生成的 config.toml 里是绝对路径 —— 三者里只有夹具和审计互相同意。
+  //    #1016 那条 P0 就是这么被藏住的（详见 #1011）。
+  const inspectConfigPath = `${process.env.GROK_HOME}/config.toml`;
+  const inspectTarget = parseTomlJsonValue(
+    fs.readFileSync(inspectConfigPath, "utf8"),
+    "command",
+  );
   process.stdout.write(JSON.stringify({
     hooks: [],
     plugins: [],
     mcpServers: [{
       name: "commhub",
       transport: "stdio",
-      target: "bun",
-      source: { type: "configToml", path: `${process.env.GROK_HOME}/config.toml` },
+      target: inspectTarget,
+      source: { type: "configToml", path: inspectConfigPath },
     }],
     lspServers: [],
     agents: [


### PR DESCRIPTION
修 #1016，同时修 #1011。**这是我今天自己造成的回归**，不是历史遗留。

## 我造成了什么

| | 提交 | 做了什么 |
|---|---|---|
| **#1004** | `89a6164e` 今天 | 生成侧从硬编码 `'command = "bun"'` 换成 `resolveGrokCommhubMcpCommand()` 的返回值 —— **realpath 之后的绝对路径** |
| **#1010** | `f1208449` 今天 | 我把 `7914755a fix(grok): bind MCP audit to resolved Bun path` **外科式摘掉了** —— 而那正是同一次改动的**审计侧** |

⇒ main 停在一对不匹配的半边：**生成侧写绝对路径，审计侧要求裸 `"bun"`。**

🔴 我在 #1010 摘它时给的理由（「它让产品拒绝自己生成的配置」）**方向反了**：
真正会拒绝的是**缺了它**。我读到的那次 CI 红来自**夹具**，不来自产品。

## 真 grok 报什么（实测，不是推断）

容器里装钉死的 `0.2.93`、`--network none` 离线（宿主那份是 `1.0.5`，且其符号链接被
**63 个在跑节点**共用，没有动）：

```
容器内 grok --version → grok 0.2.93 (f00f96316d)
config.toml:  command = "/usr/local/bin/fake-bun"

$ grok inspect --json
"mcpServers": [{ "name":"commhub", "transport":"stdio",
                 "target":"/usr/local/bin/fake-bun",
                 "source":{"type":"configToml","path":"/tmp/gh/config.toml"} }]
```

⇒ **`target` 逐字等于 config.toml 的 `command`。** 而生成侧那个解析器**只可能**返回
realpath 之后的绝对路径或抛错（`grok-build-cli-home.ts:60`）⇒ **拿裸 `"bun"` 比永远不成立。**

> 顺带记一条防坑：同一件事三条命令三种形状 —— `mcp doctor --json` 顶层是 `sources`/`servers`，
> 它的 `target` 是 **command + args 空格拼串**；`mcp list --json` 的字段叫 `command` 不叫 `target`。
> **拿错一条就会得出错的结论。**

## 两件必须一起落 —— 分开落任一半，就是我今天犯的错

**① 审计侧** `agent-node/src/runtime/grok-copresence/runtime.ts`

```diff
-    || commhubRecord.target !== "bun"
+    || resolve(String(commhubRecord.target || "")) !== resolve(expectedCommhubCommand)
```

新增第三参数 `expectedCommhubCommand`（默认 `"bun"` **仅**为兼容尚未传参的调用点），
`agent-node/src/cli.ts` 的生产调用点显式传 `commhubMcpCommand`。

**② 夹具** `tests/test225-grok-preview-package-live/fake-grok.mjs`

```diff
-      target: "bun",
+      target: inspectTarget,      // ← 从它自己声称的 configToml 里读 command
```

不修 ②，①会**再一次**「看起来让 test813 红」，而红的仍然是夹具。

🔴 **原来那个写死的 `"bun"` 不是「夹具不够真」，是它让一个真实的不一致在 CI 里永远看不见**：
审计要 `"bun"`、夹具就报 `"bun"`，两者**恒相符**，而产品写的是绝对路径 ——
**绿的不是「产品对」，是两个我自己写的东西互相同意。** #1016 就是这么被藏住的。

## 见红 / 见绿

`runtime.test.ts` 加三条，第三条就是 #1016 那个不一致本身：

```
target=绝对路径, expected=同一个绝对路径   → 不抛
target=绝对路径, expected=另一个绝对路径   → 抛 "runtime-owned commhub"
target=裸 "bun", expected=绝对路径         → 抛      ← #1016 本身
```

```
bun test src/runtime/grok-copresence/runtime.test.ts        54 pass  0 fail
把审计退回 main 的写法（target !== "bun"）再跑             53 pass  1 fail   ← 见红
还原                                                        54 pass  0 fail
```

原有 5 条断言仍传 2 个参数、其夹具 `target` 是 `"bun"` ⇒ 默认值让它们照旧通过，**向后兼容**。

## 没做的，写清楚

- `bun build` 通过（276 modules），但**它不做类型检查**，只证明能打包。本机取不到可用的
  tsc（`npx tsc@5` / `typescript@5.9` 都失败），**类型检查交给 CI**。
- **test813 的 Docker 套件交给 CI 跑 —— 那才是这次改动真正的验收点**（它同时覆盖夹具与审计）。
- `docs/message-lifecycle.md` 的 `shouldSkipMessage` 行号 4691 → 4695（本次给 `cli.ts` 加了 3 行）。