### PR TITLE
ci(test225): 接进 CI —— 判据是「已知失败不许变多」，因为它之前那个绿被证实是假绿

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -375,11 +375,32 @@ jobs:
       # 这一步**预期非 0** —— test225 现在有 2 条已知失败(#1020 / #1021)。
       # 判定不在这里,在下一步的棘轮。所以这里必须容错,
       # 但报告必须真的产出来,否则下一步会因为「报告不存在」而红(那是对的)。
+      # 🔴 产物目录这一步踩了两个坑,都写在这里,别再照抄回去:
+      #
+      #    ① 把宿主目录挂进 /artifacts —— 容器是 `USER node`(uid 1000),
+      #       而 runner 上 $RUNNER_TEMP 属主是 uid 1001,挂进去写不了,套件报
+      #           FAIL: could not atomically create a private report
+      #       并且**一个报告都不产出**,棘轮只能看到「报告不存在」。
+      #       我本地跑这一版是绿的,纯粹因为宿主 uid 恰好也是 1000 ——
+      #       绿依赖了一个偶然的 uid 巧合,换台机器就红。
+      #
+      #    ② 干脆不挂卷 —— 也不行,只是换个错法:node 用户在 `/` 下建不了目录
+      #           mkdir: cannot create directory '/artifacts': Permission denied
+      #
+      #    所以把 ARTIFACT_DIR 指到容器内 node 自己的目录,再 cp 出来。
+      #    /test225-work 在 Dockerfile 里 chown 给了 node,而且不触碰 run.sh 的守卫
+      #    (禁止 $HOME / $WORK 子树、/tmp/test225-*、/ 及其祖先 —— 都不沾)。
       - name: Run test225 (预期红;判定交给棘轮)
         run: |
-          mkdir -p "$RUNNER_TEMP/art225"
-          docker run --rm -v "$RUNNER_TEMP/art225:/artifacts" anet-test225-grok-preview \
+          set -uo pipefail
+          docker run --name test225-run -e ARTIFACT_DIR=/test225-work/artifacts \
+            anet-test225-grok-preview \
             || echo "  (套件退出码非 0 —— 这一步不判定,继续)"
+          mkdir -p "$RUNNER_TEMP/art225"
+          docker cp test225-run:/test225-work/artifacts/. "$RUNNER_TEMP/art225/" \
+            || echo "::warning::无法从容器取出产物 —— 下一步会因报告不存在而红,那是对的"
+          docker rm -f test225-run >/dev/null 2>&1 || true
+          ls -la "$RUNNER_TEMP/art225/" || true
 
       # 🔴 判据在这里,不在上一步。
       #    比的是 FAIL 的**集合**不是个数:实测里有一组 FAIL 个数同样是 2、

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -51,6 +51,10 @@ on:
       - 'scripts/check-doc-source-pins.py'
       - 'tests/test831-doc-source-pins/**'
       - 'tests/test813-grok-mcp-readiness/**'
+      # 🔴 加这一条的直接原因:#1017 改了 test225 的夹具,27 个 check 全绿,
+      #    而 CI 从头到尾没有执行过这个套件。job 存在、挂上、会被触发是三件事,
+      #    漏的就是第三件。
+      - 'tests/test225-grok-preview-package-live/**'
   push:
     branches: [main]
     paths:
@@ -92,6 +96,10 @@ on:
       - 'scripts/check-doc-source-pins.py'
       - 'tests/test831-doc-source-pins/**'
       - 'tests/test813-grok-mcp-readiness/**'
+      # 🔴 加这一条的直接原因:#1017 改了 test225 的夹具,27 个 check 全绿,
+      #    而 CI 从头到尾没有执行过这个套件。job 存在、挂上、会被触发是三件事,
+      #    漏的就是第三件。
+      - 'tests/test225-grok-preview-package-live/**'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
 # updated rapidly. main pushes run independently.
@@ -335,3 +343,60 @@ jobs:
 
       - name: Run test831-doc-source-pins
         run: docker run --rm --network none anet-test831-doc-source-pins
+
+  test225-known-failures:
+    name: test225 known-failure ratchet (Docker)
+    runs-on: ubuntu-latest
+    # 完整跑一次 ~8 分钟(装依赖 + 起容器内 Hub + 真 tmux attach)。
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # 需要完整历史才能 git archive 出一个不可变上下文。
+          fetch-depth: 0
+
+      # 🔴 test225 **不能**用 `docker build ... .` 那种可变检出上下文 ——
+      #    它自己第一件事就是拦下来:
+      #        FAIL: test225 build context must come from git archive, not a mutable checkout
+      #    因为 source-commit.txt 里是 `$Format:%H$`,只有 git archive 会替换它。
+      #    照抄别的 job 的写法会在这里立刻红,而且红得让人以为是套件坏了。
+      - name: Build test225 from an immutable git-archive context
+        run: |
+          set -euo pipefail
+          CTX=$(mktemp -d)
+          git archive "$GITHUB_SHA" | tar -x -C "$CTX"
+          test "$(cat "$CTX/tests/test225-grok-preview-package-live/source-commit.txt")" = "$GITHUB_SHA" \
+            || { echo "::error::git archive 没有替换 source-commit.txt —— export-subst 没生效"; exit 1; }
+          docker build \
+            --build-arg SOURCE_COMMIT="$GITHUB_SHA" \
+            -t anet-test225-grok-preview \
+            -f "$CTX/tests/test225-grok-preview-package-live/Dockerfile" "$CTX"
+
+      # 这一步**预期非 0** —— test225 现在有 2 条已知失败(#1020 / #1021)。
+      # 判定不在这里,在下一步的棘轮。所以这里必须容错,
+      # 但报告必须真的产出来,否则下一步会因为「报告不存在」而红(那是对的)。
+      - name: Run test225 (预期红;判定交给棘轮)
+        run: |
+          mkdir -p "$RUNNER_TEMP/art225"
+          docker run --rm -v "$RUNNER_TEMP/art225:/artifacts" anet-test225-grok-preview \
+            || echo "  (套件退出码非 0 —— 这一步不判定,继续)"
+
+      # 🔴 判据在这里,不在上一步。
+      #    比的是 FAIL 的**集合**不是个数:实测里有一组 FAIL 个数同样是 2、
+      #    内容却完全不同({auth evidence, attach socket} vs {auth evidence, Feishu}),
+      #    只比个数会得出「没差别」。
+      #    另外有一条 PASS 地板,防的是「构建成功但立刻崩掉」——
+      #    那种运行产出 0 个 FAIL,而 0 个 FAIL 在只比 FAIL 的判据下是最漂亮的绿。
+      - name: 棘轮 —— FAIL 集合必须等于已知基线
+        run: |
+          python3 tests/test225-grok-preview-package-live/check-known-failures.py \
+            "$RUNNER_TEMP/art225/report-test225.txt" \
+            tests/test225-grok-preview-package-live/known-failures.txt
+
+      - name: 保留报告(失败时最有用的那份)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test225-report
+          path: ${{ runner.temp }}/art225/
+          if-no-files-found: warn

--- a/tests/test225-grok-preview-package-live/check-known-failures.py
+++ b/tests/test225-grok-preview-package-live/check-known-failures.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""把 test225 的报告和已知失败基线对一遍。
+
+为什么是棘轮不是「跑通/跑不通」：
+test225 现在是红的（2 条，见 #1020 / #1021），但它长期不在 CI 里。
+实测已证明它之前那个绿是**假绿** —— 旧夹具硬写 target="bun"，
+恰好等于旧审计硬写的期望值，两个错误互相同意（三方单变量实验见 #861 评论）。
+所以「等它修好再接进来」是错的顺序：正因为没人跑，才分不出真绿假绿。
+
+判据：
+  · 报告里出现基线之外的 FAIL   -> 退出 1（新伤）
+  · 基线里某条不再出现          -> 不退 1，打印提示（修好是好事，不该被门拦）
+  · PASS 条数低于地板           -> 退出 1（0-count：套件根本没跑到那些层）
+
+最后一条是分母断言。没有它，一个「构建成功但立刻崩掉」的运行会产出
+0 个 FAIL —— 而 0 个 FAIL 在只比 FAIL 的判据下是最漂亮的绿。
+"""
+import re
+import sys
+from pathlib import Path
+
+# 地板取自实测：b732d5ef 与 78ed67c7 两次完整运行都是 8 个 PASS。
+# 取 7 留一格，是为了让「某一层被合法地合并/改名」不至于立刻误报，
+# 但仍然拦得住「只跑了 L0 就崩了」（那种情况 PASS 只有 2）。
+PASS_FLOOR = 7
+
+FAIL_RE = re.compile(r"^FAIL:\s*(.+?)\s*$", re.M)
+PASS_RE = re.compile(r"^PASS:", re.M)
+
+
+def load_baseline(path: Path) -> list[str]:
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: check-known-failures.py <report.txt> <known-failures.txt>", file=sys.stderr)
+        return 2
+    report_path, baseline_path = Path(sys.argv[1]), Path(sys.argv[2])
+    if not report_path.is_file():
+        print(f"FAIL: 报告不存在:{report_path} —— 套件没产出报告等同于没跑", file=sys.stderr)
+        return 1
+
+    report = report_path.read_text(encoding="utf-8")
+    actual = [m.strip() for m in FAIL_RE.findall(report)]
+    baseline = load_baseline(baseline_path)
+    passes = len(PASS_RE.findall(report))
+
+    print(f"  pass_lines={passes} (floor={PASS_FLOOR})")
+    print(f"  fail_lines={len(actual)} baseline_entries={len(baseline)}")
+
+    rc = 0
+
+    if passes < PASS_FLOOR:
+        print(f"FAIL: PASS 只有 {passes} 条,低于地板 {PASS_FLOOR} —— 套件没跑到该跑的层,"
+              f"这时候 FAIL 少不代表好", file=sys.stderr)
+        rc = 1
+
+    # 比集合不比计数。三方实验里有一组 FAIL 个数同样是 2,内容却完全不同
+    # ({auth evidence, attach socket} vs {auth evidence, Feishu});
+    # 只比数量会得出「没差别」这个错误结论。
+    new = [f for f in actual if f not in baseline]
+    gone = [b for b in baseline if b not in actual]
+
+    for f in new:
+        print(f"FAIL: 基线之外的新失败:{f}", file=sys.stderr)
+        rc = 1
+
+    for g in gone:
+        # 修好了。不红 —— 让门去拦一个改进,会让人倾向于不修。
+        print(f"  NOTE: 基线里这条不再出现,可以从 known-failures.txt 删掉了:{g}")
+
+    if rc == 0 and not new:
+        print(f"  OK: FAIL 集合与基线一致({len(actual)} 条),没有新伤。")
+        print(f"  注意:这**不**表示 test225 是绿的。它现在有 {len(baseline)} 条已知失败,")
+        print(f"        每条都挂着 issue。这道门守的是「不要再多」,不是「已经没有」。")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test225-grok-preview-package-live/known-failures.txt
+++ b/tests/test225-grok-preview-package-live/known-failures.txt
@@ -1,0 +1,20 @@
+# test225 已知失败基线 —— 棘轮，不是豁免清单
+#
+# 这个文件存在的理由：test225 现在是红的（2 条），但它在 CI 之外待了太久，
+# 期间没人知道它是真绿还是假绿。实测已经证明它之前那个绿是**假绿**：
+# 旧夹具硬写 target="bun"，恰好等于旧审计硬写的期望值，两个错误互相同意。
+# （三方单变量实验见 #861 / #1011 的评论。）
+#
+# 所以先把它接进 CI，判据是「FAIL 集合等于下面这份」：
+#   · 多出任何一条  → 红（新伤）
+#   · 少了任何一条  → 不红，但会打印「该更新基线了」（修好是好事，不该被门拦住）
+#
+# 每一条都必须有一个 issue，否则这里就变成了一张藏东西的清单。
+#
+# 条目 -> issue：
+#   real auth evidence scan failed ...          -> #1021
+#   installed candidate Feishu refusal ...      -> #1020
+#
+# ---- 条目：FAIL 后面那句原文，逐字 ----
+real auth evidence scan failed; closed target-role diagnostic retained
+installed candidate Feishu refusal lacked the fixed explanation


### PR DESCRIPTION
## 起因

#1017 改了 `tests/test225-grok-preview-package-live/fake-grok.mjs`，**27 个 check 全绿**。
但对着 `origin/main` 数，12 个 grok 套件只有 2 个在 CI 里（test224、test813），**test225 不在**。
改了一个套件的夹具，CI 从头到尾没有执行过它。

## 为什么不等它修好再接

手动跑它是红的（2 条），且不是新伤 —— A/B 到 `78ed67c7` FAIL 集合逐字相同。
真正的理由是：**它之前那个绿是假绿**。单变量实验（只换夹具，产品不动）：

| 组合 | 报告里那条关键路径 | 走到哪 |
|---|---|---|
| 旧产品 `78ed67c7` + 旧夹具 | `PASS: create -> start -> register -> Hub task -> real tmux attach live render -> reply` | 跑完 L4 |
| 旧产品 `78ed67c7` + **诚实夹具** | 该条消失 → `FAIL: attach socket did not appear through npx preview fallback` | **停在 L2** |
| 新产品 `b732d5ef` + 诚实夹具 | `PASS: create -> start -> register -> Hub task -> real tmux attach live render -> reply` | 跑完 L4 |

旧夹具硬写 `target: "bun"`，恰好等于旧审计硬写的期望值 `"bun"` —— 两个错误互相同意，
审计放行、节点起来、测试打 PASS。**假绿那一行和真绿那一行逐字相同。**
（详见 #861 / #1011 的评论。）

所以「等它修好再接进来」是错的顺序：正因为没人跑，才分不出真绿假绿。

## 判据（棘轮，不是「必须全绿」）

`tests/test225-grok-preview-package-live/check-known-failures.py`

- 出现基线之外的 FAIL → 退 1
- 基线里某条不再出现 → **不**退 1，打印「可以删了」（让门去拦一个改进，会让人倾向于不修）
- PASS 低于地板 7 → 退 1 —— 分母断言，防的是「构建成功但立刻崩掉」那种运行：
  它产出 **0 个 FAIL**，而 0 个 FAIL 在只比 FAIL 的判据下是最漂亮的绿

**比集合不比计数。**

## 验证：先见红，再见绿，两个红因各自独立报出

拿三份**真实产出的报告**跑（不是构造的夹具）：

    main b732d5ef      pass_lines=8 fail_lines=2  ->  rc=0
    基线 78ed67c7      pass_lines=8 fail_lines=2  ->  rc=0
    交叉实验            pass_lines=4 fail_lines=2  ->  rc=1
        FAIL: PASS 只有 4 条,低于地板 7 —— 套件没跑到该跑的层,这时候 FAIL 少不代表好
        FAIL: 基线之外的新失败:attach socket did not appear through npx preview fallback

第三行是关键样本：`fail_lines=2` 与 `baseline_entries=2` **计数相等**，门仍然判红。

## 两处容易照抄错的，写进注释了

1. test225 **拒绝**可变检出上下文（`source-commit.txt` 是 `$Format:%H$`，只有 `git archive` 会替换）。
   照抄别的 job 的 `docker build ... .` 会立刻红，且红得像是套件坏了。
   这个 job 先 `git archive` 出不可变上下文，并断言替换真的发生了。
2. 跑套件那一步**预期非 0**，必须容错；判定在下一步。但报告必须真产出来 ——
   否则棘轮会因为「报告不存在」而红，那是对的。

## 触发路径

`tests/test225-grok-preview-package-live/**` 加进 `pull_request` 与 `push` 两处 paths。
**job 存在、挂上、会被触发是三件事**，这次漏的就是第三件。

## 基线两条都挂了 issue

- #1021 — auth evidence 门在同一 phase 被调两次、两个不同 outcome
- #1020 — 配了飞书通道的节点退出码非 0 但没打那句固定说明（17 条退出路径都满足判据前一半）

`known-failures.txt` 里写明了「每条都必须有 issue，否则这里就变成一张藏东西的清单」。

## 成本

这个 job 完整跑一次约 8 分钟（装依赖 + 容器内 Hub + 真 tmux attach），`timeout-minutes: 25`。
触发路径已收窄到该套件目录，不是每个 PR 都跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)