### PR TITLE
fix(#1019): 节点上报自己的版本号 —— 判据落在 Hub 真返回的那一行，不是源码里那一行

### DIFF
--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1000,6 +1000,17 @@ if (TELEGRAM_CHANNELS.length > 0 && RUNTIME !== "codex" && RUNTIME !== "codex-ap
 
 // ── 日志：终端 + 文件 ──
 import { appendFileSync, mkdirSync } from "fs";
+
+// #1019 —— 节点自己的版本号。sessions.version 这一列一直是空的:
+// 服务端早就收(report_status 的 schema 里有 `version`)也早就写
+// (`version = COALESCE(?9, sessions.version)`),缺的只有这一半 —— 节点从来不发。
+// 后果是「哪些节点还跑着旧码」这个问题在 Hub 上没有任何数据能答。
+//
+// 用 import 而不是运行时读 package.json:`bun build --minify` 会把 JSON
+// 在**构建期**内联,于是这个常量表示的是「这份 dist 是从哪个版本构建出来的」——
+// 正是我们想问的那件事。运行时去找 package.json 反而会受安装布局影响。
+import agentNodePackage from "../package.json";
+const AGENT_NODE_VERSION: string = agentNodePackage.version;
 const PRIVATE_LOG_DIR = GROK_EXECUTION_MODE === "cli"
   ? preparePrivateLogDirectory(LOG_DIR, persistenceRedactorHandle)
   : LOG_DIR;
@@ -1280,6 +1291,7 @@ const register = async () => {
     resume_id: RESUME_ID, alias, status: "idle",
     server: osHostname(), hostname: osHostname(),
     agent: RUNTIME_AGENT_LABEL, project_dir: process.cwd(),
+    version: AGENT_NODE_VERSION,
     node_id: NODE_ID || undefined,
     node_name: NODE_NAME || undefined,
     session_id: activeSessionId,
@@ -2855,7 +2867,7 @@ async function ensureCodexStdio(): Promise<import("./runtime/codex-stdio-client"
   });
   client.on("error", (err: Error) => log(`[codex-stdio] subprocess error: ${err.message}`));
   client.start({ cwd: process.cwd() });
-  await client.request("initialize", { clientInfo: { name: "anet/agent-node", version: "2.3.10" } });
+  await client.request("initialize", { clientInfo: { name: "anet/agent-node", version: AGENT_NODE_VERSION } });
   codexStdio = client;
   return client;
 }

--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -196,7 +196,7 @@ if (["new_task", "broadcast"].includes(ev.type)) {
 |---|------|--------|------|
 | 1 | sendReply 用 send_message | agent-node | ✅ v1.4.2 |
 | 2 | SSE 只响应 new_task / broadcast | agent-node | ✅ [cli.ts:1102 `["new_task", "broadcast"].includes(ev.type)`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L1102)；`new_reply` 单独走日志记录 cli.ts:1106 |
-| 3 | 低价值消息过滤 | agent-node | ✅ v1.4.0；当前在 [cli.ts:4713 `shouldSkipMessage`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L4713) |
+| 3 | 低价值消息过滤 | agent-node | ✅ v1.4.0；当前在 [cli.ts:4725 `shouldSkipMessage`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L4725) |
 | 4 | CLAUDE.md 不对 message 回复 | 各项目 CLAUDE.md | ✅ R195 chain 模板已加 |
 | 5 | developer_instructions 安静规则 | agent-node | ✅ v1.4.1 |
 

--- a/tests/test225-grok-preview-package-live/run.sh
+++ b/tests/test225-grok-preview-package-live/run.sh
@@ -1788,7 +1788,15 @@ jq -e '.agent == "agent-node:grok-build-cli"' \
   || fail "Hub session did not retain the registered grok-build-cli agent identity"
 jq -e '.status == "idle"' <<<"$STATUS_ROW" >/dev/null \
   || fail "Hub session was not idle after the replied task"
-pass "Hub session registration reports agent-node:grok-build-cli"
+# 🔴 #1019 —— 判的是 Hub 那一行里的**数据**,不是源码里有没有写那一行。
+#    sessions.version 长期为空(一次只读快照:223/225 是 null)。服务端一直是收也写的:
+#    report_status 的 schema 里有 `version`,upsert 里 `version = COALESCE(?9, sessions.version)`。
+#    缺的只有节点不发这一半 —— 而「源码里加了一行 version:」和「那一行真的到了库里」
+#    是两件事,COALESCE 意味着漏发时旧值会被静默保留,看起来和"没变化"一模一样。
+#    所以判据必须落在 /api/status 真返回的那一行上。
+jq -e --arg v "$AGENT_NODE_VERSION" '.version == $v' <<<"$STATUS_ROW" >/dev/null \
+  || fail "Hub session did not record the node's own agent-node version (expected $AGENT_NODE_VERSION, got $(jq -r '.version // "null"' <<<"$STATUS_ROW"))"
+pass "Hub session registration reports agent-node:grok-build-cli and its own version"
 
 log "[L3] exact child-env and persisted-output checks"
 grep -Fq "CANDIDATE_PACKUMENT version=$AGENT_NODE_VERSION" "$LOCAL_REGISTRY_LOG" \


### PR DESCRIPTION
Closes #1019

## 先更正 issue 正文里我自己的判断

我在 #1019 正文写「字段存在，没人写」，读起来像整条链路都没接上。在 `origin/main` 上核过，**不对**。
服务端**两头早就就绪**：

收 —— `server/src/tools.ts` 的 `report_status` 入参 schema：

    version: z.string().max(100).optional().describe("Agent version"),

写 —— `server/src/tools.ts:656` 的 sessions upsert：

    project_dir = COALESCE(?8, sessions.project_dir), version = COALESCE(?9, sessions.version),

缺的**只有客户端那一半**：`agent-node/src/cli.ts` 的注册载荷里没有 `version`。

这个更正让问题变小（改一处而不是三处），但**也让它更该警惕**：
`COALESCE` 意味着漏发时旧值被静默保留。对一个从来没被写过的列，
「漏发」和「值没变化」在库里**长得完全一样** —— 空多久都不会有人被提醒。

## 改动一：节点发自己的版本

    import agentNodePackage from "../package.json";
    const AGENT_NODE_VERSION: string = agentNodePackage.version;

用 import 不用运行时读文件：`bun build --minify` 在**构建期**内联它，
于是这个常量表示的是「这份 dist 是从哪个版本构建出来的」—— 正是要问的那件事。
运行时去找 `package.json` 反而会受安装布局影响。

**在真产物里验过，不是推断**：

    package.json version = 2.5.0-preview.31
    dist/cli.js 里该串出现次数 = 1
    dist/cli.js 里旧的 2.3.10  = 0

顺带修掉了 `agent-node/src/cli.ts` 那处写死的 `clientInfo: { ..., version: "2.3.10" }`
（包版本早就是 `2.5.0-preview.31`，那是唯一一个真在发版本号的地方，而它是个不会跟着改的常量）。

## 改动二：判据落在数据上，不在声明上

我在 #1019 里写的验收判据是「不要只判源码里有那一行，要判数据」。那我自己得先遵守。
判据加在 `tests/test225-grok-preview-package-live/run.sh` 的 L2，紧跟已有的 agent 身份断言：

    jq -e --arg v "$AGENT_NODE_VERSION" '.version == $v' <<<"$STATUS_ROW" >/dev/null \
      || fail "Hub session did not record the node's own agent-node version (...)"

`$STATUS_ROW` 来自容器内真起的 Hub 的 `/api/status`，是**数据**。

## 验证：真跑了 test225（`git archive` 上下文，源 commit `7d2ee6d3`）

报告原文里新的那条：

    PASS: Hub session registration reports agent-node:grok-build-cli and its own version

FAIL 集合仍是已知的那 2 条（#1020 / #1021），PASS 仍是 8 条 —— 没有引入新伤，也没有减少覆盖。

（`git archive` 只含已提交内容，所以是先提交再跑的。这是「本地跑门前先 `git add`」那条的更强版本。）

## 一句必须说清楚的限度

这条修好之后，「哪些节点还跑着旧码」**第一次会有数据能答** ——
但**只对修好之后重启过的节点有效**。现有节点在重启前 `version` 仍是 null。
所以它不能替代「发 preview 之前先确认谁需要升级」，只能让下一次不再瞎。

🤖 Generated with [Claude Code](https://claude.com/claude-code)