### PR TITLE
fix(#1020): test225 从「长期 2 条 FAIL」变成全绿 —— 真因是夹具把 config 放在 /tmp 下，产品是对的

### DIFF
--- a/tests/test225-grok-preview-package-live/check-known-failures.py
+++ b/tests/test225-grok-preview-package-live/check-known-failures.py
@@ -78,8 +78,15 @@ def main() -> int:
 
     if rc == 0 and not new:
         print(f"  OK: FAIL 集合与基线一致({len(actual)} 条),没有新伤。")
-        print(f"  注意:这**不**表示 test225 是绿的。它现在有 {len(baseline)} 条已知失败,")
-        print(f"        每条都挂着 issue。这道门守的是「不要再多」,不是「已经没有」。")
+        # 🔴 原来这里无条件打印「这不表示 test225 是绿的」。
+        #    在**全部修好**那一刻,那句话就是假的 —— 而那恰恰是最该说清楚的一刻。
+        #    一个在成功路径上说假话的提示,比没有提示更糟:它会让人以为还有欠账。
+        if not actual and not baseline:
+            print("  这次报告里 0 条 FAIL,基线也是空的 —— test225 现在是真绿的。")
+            print("  这道门从此守的是「不许出现新的失败」。")
+        else:
+            print(f"  注意:这**不**表示 test225 是绿的。它现在有 {len(baseline)} 条已知失败,")
+            print(f"        每条都挂着 issue。这道门守的是「不要再多」,不是「已经没有」。")
     return rc
 
 

--- a/tests/test225-grok-preview-package-live/known-failures.txt
+++ b/tests/test225-grok-preview-package-live/known-failures.txt
@@ -4,23 +4,26 @@
 #   · 多出任何一条  → 红（新伤）
 #   · 少了任何一条  → 不红，但会打印「该更新基线了」（修好是好事，不该被门拦住）
 #
-# 每一条都必须有一个 issue，否则这里就变成了一张藏东西的清单。
+# ---- 现在这份是**空的**。2026-08-19 全量跑：Summary: PASS，0 条 FAIL，11 条 PASS ----
 #
-# ---- 本次变更（2026-08-19）----
-# 删掉两条：
+# 曾经在这里、已经删掉的三条，各自的去向：
+#
 #   "real auth evidence scan failed; closed target-role diagnostic retained"
-#       **它根本不是失败**。那是两处**负向自检**的预期输出:自检把 stdout 重定向到了
-#       捕获文件,但 `log()` 是 `printf | tee -a "$REPORT"` —— tee 无视 stdout 重定向,
-#       照样写进共享报告。我当初照着这行建了基线并挂了 #1021,那条基线是错的。
-#       已在同一 PR 里给两处自检的子 shell 加 `REPORT=/dev/null`。
+#       **它从来就不是失败**。那是两处负向自检的预期输出:自检把 stdout 重定向到了
+#       捕获文件,但 `log()` 是 `printf | tee -a "$REPORT"` —— tee 无视 stdout 重定向。
+#       我当初照着这行建了基线并挂了 #1021,那条基线是错的。已给自检子 shell 加
+#       `REPORT=/dev/null`。
+#
 #   "installed candidate Feishu refusal lacked the fixed explanation"
 #       已修（#1020）。真因是夹具把 config 放在 /tmp 下,节点在走到飞书拒绝**之前**
 #       就先拒绝了配置本身（父目录属 root,不是 owner-controlled）。产品是对的。
 #
-# 加一条：见下。
+#   "headless node survived a node stop that reported success (#1027)"
+#       **只观测到一次,后续跑没有复现**（那次同时跑着 2~3 个容器,可能是资源竞争）。
+#       没有稳定复现之前不放进基线 —— 基线里放一条偶发项,会让它「消失」时看起来像修好了。
+#       #1027 仍然 open,而且 `wait_pid_gone` 的上界留着:再发生一次,
+#       10 秒内就会带着幸存进程的 cmdline 报出来,而不是静默挂死 25 分钟。
 #
-# 条目 -> issue：
-#   headless node survived a node stop ...   -> #1027
+# 加新条目时：每一条都必须有一个 issue，否则这里就变成了一张藏东西的清单。
 #
-# ---- 条目：FAIL 后面那句原文，逐字 ----
-headless node survived a node stop that reported success (#1027)
+# ---- 条目：FAIL 后面那句原文，逐字（当前无） ----

--- a/tests/test225-grok-preview-package-live/known-failures.txt
+++ b/tests/test225-grok-preview-package-live/known-failures.txt
@@ -1,20 +1,26 @@
 # test225 已知失败基线 —— 棘轮，不是豁免清单
 #
-# 这个文件存在的理由：test225 现在是红的（2 条），但它在 CI 之外待了太久，
-# 期间没人知道它是真绿还是假绿。实测已经证明它之前那个绿是**假绿**：
-# 旧夹具硬写 target="bun"，恰好等于旧审计硬写的期望值，两个错误互相同意。
-# （三方单变量实验见 #861 / #1011 的评论。）
-#
-# 所以先把它接进 CI，判据是「FAIL 集合等于下面这份」：
+# 判据：「FAIL 集合等于下面这份」
 #   · 多出任何一条  → 红（新伤）
 #   · 少了任何一条  → 不红，但会打印「该更新基线了」（修好是好事，不该被门拦住）
 #
 # 每一条都必须有一个 issue，否则这里就变成了一张藏东西的清单。
 #
+# ---- 本次变更（2026-08-19）----
+# 删掉两条：
+#   "real auth evidence scan failed; closed target-role diagnostic retained"
+#       **它根本不是失败**。那是两处**负向自检**的预期输出:自检把 stdout 重定向到了
+#       捕获文件,但 `log()` 是 `printf | tee -a "$REPORT"` —— tee 无视 stdout 重定向,
+#       照样写进共享报告。我当初照着这行建了基线并挂了 #1021,那条基线是错的。
+#       已在同一 PR 里给两处自检的子 shell 加 `REPORT=/dev/null`。
+#   "installed candidate Feishu refusal lacked the fixed explanation"
+#       已修（#1020）。真因是夹具把 config 放在 /tmp 下,节点在走到飞书拒绝**之前**
+#       就先拒绝了配置本身（父目录属 root,不是 owner-controlled）。产品是对的。
+#
+# 加一条：见下。
+#
 # 条目 -> issue：
-#   real auth evidence scan failed ...          -> #1021
-#   installed candidate Feishu refusal ...      -> #1020
+#   headless node survived a node stop ...   -> #1027
 #
 # ---- 条目：FAIL 后面那句原文，逐字 ----
-real auth evidence scan failed; closed target-role diagnostic retained
-installed candidate Feishu refusal lacked the fixed explanation
+headless node survived a node stop that reported success (#1027)

--- a/tests/test225-grok-preview-package-live/run.sh
+++ b/tests/test225-grok-preview-package-live/run.sh
@@ -1950,12 +1950,28 @@ if env -i HOME="$HOME" PATH="$PATH" GROK_BINARY="$FAKE_GROK" \
   > "$FEISHU_LOG" 2>&1; then
   fail "installed candidate accepted an unsupported Feishu channel"
 fi
-grep -Fq 'grok-build-cli preview currently refuses Feishu channels' "$FEISHU_LOG" \
-  || fail "installed candidate Feishu refusal lacked the fixed explanation"
+# 🔴 #1020 —— 顺序:凭据扫描必须排在功能断言**之前**。
+#    原来那句 `grep -Fq ... || fail` 排在两条 scan_fixed_file 前面,而 `fail()` 是
+#    `log "FAIL: $*"; exit 1` —— 一旦那句 grep 不过(它已经红了至少两个 commit),
+#    这两条**安全检查根本不会执行**。也就是说:在唯一一种「拒绝路径没按预期走完」的
+#    现实里,我们恰好放弃了检查它有没有把凭据打进日志。
+#    把安全检查挡在功能检查后面,等于让功能回归顺手关掉安全回归。
 scan_fixed_file /tmp/test225-markers "$FEISHU_LOG" \
   || fail "Feishu refusal output exposed a synthetic credential marker"
 scan_fixed_file /tmp/test225-live-credentials "$FEISHU_LOG" \
   || fail "Feishu refusal output exposed a Hub credential"
+if ! grep -Fq 'grok-build-cli preview currently refuses Feishu channels' "$FEISHU_LOG"; then
+  # 到这里为止,上面两条扫描已经证明这份日志里没有凭据 —— 所以可以安全地把
+  # 产品自己打的那几行原样带出来。只带 `[agent-node] ` 前缀的行:
+  # 它们是产品的错误消息,而拒绝语句之前有 **17 处** process.exit(1),
+  # 「退出码非 0」这半边判据被其中任意一条满足,区分不出是哪一条。
+  # 不带这几行的话,这条 FAIL 只能说明「不是因为飞书被拒而退的」,不能说明因为什么。
+  log "diagnostic: feishu_refusal actual [agent-node] output follows (credential-scanned above)"
+  grep -F '[agent-node] ' "$FEISHU_LOG" | head -5 | while IFS= read -r line; do
+    log "  | $line"
+  done
+  fail "installed candidate Feishu refusal lacked the fixed explanation"
+fi
 [ "$(matching_process_count '/test225/fake-grok.mjs')" -eq 0 ] \
   || fail "Feishu refusal started Grok before closing the channel boundary"
 safe_rm_rf "$FEISHU_DIR" "$FEISHU_CONFIG" "$FEISHU_LOG"

--- a/tests/test225-grok-preview-package-live/run.sh
+++ b/tests/test225-grok-preview-package-live/run.sh
@@ -885,6 +885,28 @@ fail_if_task_terminal_error() {
   fail "$label reached a terminal error before a valid reply"
 }
 
+# 🔴 #1027 —— 等一个**本脚本自己起的** PID 退出,带上界。
+#    原来那行是 `wait "$HEADLESS_PID" 2>/dev/null || true`,**没有任何上界**。
+#    实测:`anet node stop` 对非 tmux 启动的节点会打印
+#        [anet] "<alias>" is not running locally (server notified offline)
+#    **并返回 0** —— 于是 stop_node_checked 认为停成功,往下走到 wait,
+#    而那个进程根本没被停,wait 永远不返回。在 CI 上这会把 job 的超时耗光,
+#    而且**不产出任何诊断**:报告停在 `[L4] ...` 那一行,既没 FAIL 也没 PASS,
+#    看起来像「跑到一半机器炸了」。
+#    这里只把静默挂死换成有上界、带证据的失败;`anet node stop` 该不该在没停掉的
+#    情况下通知服务端 offline,是产品侧的决定,不在本套件里改。
+wait_pid_gone() {
+  local pid=$1 tries=$2 i cmd
+  for ((i = 0; i < tries; i++)); do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.1
+  done
+  # 还活着 —— 把它是什么打出来。这正是我当初必须 docker exec 进容器手挖的东西。
+  cmd=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || echo "(cmdline 读不到)")
+  log "diagnostic: pid $pid 在 stop 之后仍存活 ${tries} × 0.1s —— cmdline: $cmd"
+  return 1
+}
+
 stop_node_checked() {
   local alias label output
   alias=$1
@@ -1460,7 +1482,16 @@ chmod 600 "$REAL_AUTH_PATTERNS" "$REAL_AUTH_UNSAFE_PATTERNS" \
   "$REAL_AUTH_METADATA_MANIFEST"
 real_turn_scan_inputs_valid \
   || fail "auth evidence role self-test scan inputs are not owner-only"
-if (trap - EXIT; HOME="$AUTH_ROLE_SELFTEST/home"; export HOME; \
+# 🔴 REPORT=/dev/null —— 这两段是**负向自检**:故意喂一份合成的失败夹具,
+#    断言这道门必须失败。它们已经把 stdout 重定向到 $AUTH_ROLE_* 捕获文件了,
+#    但 `log()` 是 `printf | tee -a "$REPORT"` —— **tee 无视 stdout 重定向**,
+#    照样往共享报告里追加。于是自检那句预期中的
+#        FAIL: real auth evidence scan failed; closed target-role diagnostic retained
+#    出现在 report-test225.txt 里,读起来和一次真失败**逐字相同**。
+#    (我自己就照它建了一条 known-failures 基线并挂了 issue —— 那条基线是错的。)
+#    tee 的目标是变量,所以在子 shell 里改掉它就够了;stdout 仍然照常被捕获,
+#    下面那些 grep/jq 断言不受影响。
+if (trap - EXIT; REPORT=/dev/null; HOME="$AUTH_ROLE_SELFTEST/home"; export HOME; \
   run_real_auth_evidence_gate final_scan \
   "$AUTH_ROLE_CURRENT_HOME" "$AUTH_ROLE_SESSION_ID" "$AUTH_ROLE_CWD" \
   "$AUTH_ROLE_LEADER" "$AUTH_ROLE_ATTACH" \
@@ -1495,7 +1526,8 @@ printf '%s\n' clean >"$AUTH_ROLE_SESSION_DIR/chat_history.jsonl"
 printf '%s\n' clean >"$AUTH_ROLE_CURRENT_HOME/unreviewed.data"
 safe_rm_rf "$AUTH_ROLE_PRIOR_HOME"
 rm -f "$AUTH_ROLE_SESSION_DIR/agent_id" "$AUTH_ROLE_CURRENT_HOME/unreviewed.link"
-if ! (trap - EXIT; HOME="$AUTH_ROLE_SELFTEST/home"; export HOME; \
+# 同上:这一段也是自检(验 WARNING 分支),同样不该写进共享报告。
+if ! (trap - EXIT; REPORT=/dev/null; HOME="$AUTH_ROLE_SELFTEST/home"; export HOME; \
   run_real_auth_evidence_gate final_scan \
   "$AUTH_ROLE_CURRENT_HOME" "$AUTH_ROLE_SESSION_ID" "$AUTH_ROLE_CWD" \
   "$AUTH_ROLE_LEADER" "$AUTH_ROLE_ATTACH" \
@@ -2019,7 +2051,8 @@ scan_fixed_file /tmp/test225-markers "$HEADLESS_LOG" \
 scan_fixed_file /tmp/test225-live-credentials "$HEADLESS_LOG" \
   || fail "headless start output exposed a Hub credential"
 stop_node_checked "$HEADLESS_ALIAS" headless
-wait "$HEADLESS_PID" 2>/dev/null || true
+wait_pid_gone "$HEADLESS_PID" 100 \
+  || fail "headless node survived a node stop that reported success (#1027)"
 HEADLESS_PID=""
 rm -f "$HEADLESS_LOG"
 pass "persisted co-presence true/false and socket identities override stale ambient env"

--- a/tests/test225-grok-preview-package-live/run.sh
+++ b/tests/test225-grok-preview-package-live/run.sh
@@ -120,7 +120,18 @@ node /test225/artifact-report.mjs "$REPORT" \
   || { printf 'FAIL: could not atomically create a private report\n' >&2; exit 1; }
 
 log() { printf '%s\n' "$*" | tee -a "$REPORT"; }
-fail() { log "FAIL: $*"; exit 1; }
+# 🔴 #1026 —— fail() 退出整个套件,于是它下游的判据本次一条都不会跑。
+#    这件事以前在报告里**完全不可见**:报告只说「FAIL: xxx」,读起来像
+#    「其余都查过了」。实测这个套件长期红在第 1954 行 / 共 2482 行 ——
+#    下游 527 行、85 条断言(其中 30 条涉凭据)从未执行,而报告一个字都没提。
+#    ${BASH_LINENO[0]} 是**调用方**的行号(不是 fail 自己的),所以这个数就是
+#    早停的确切位置。这不修 fail-fast 本身,只是让它丢掉的量变成可见的。
+TOTAL_LINES=$(wc -l < "$0")
+fail() {
+  log "FAIL: $*"
+  log "diagnostic: 早停于 run.sh:${BASH_LINENO[0]} / 共 ${TOTAL_LINES} 行 —— 该行之后的判据本次**未执行**,不是通过"
+  exit 1
+}
 pass() { log "PASS: $*"; }
 
 PROJECT_SANDBOX_PLACEHOLDER_NAMES=(.grok .claude .cursor .mcp.json .envrc)
@@ -1935,7 +1946,15 @@ rm -f "$GLOBAL_INSTALL_LOG"
 # forked worker or Grok TUI starts, with a fixed explanation and no channel
 # credential in output.
 FEISHU_DIR=/tmp/test225-feishu-refused
-FEISHU_CONFIG=/tmp/test225-feishu-refused-config.json
+# 🔴 #1020 真因 —— 这份 config 原来直接放在 /tmp 下,于是节点**在走到飞书拒绝之前**
+#    就先拒绝了配置本身:
+#        [agent-node] Refusing unsafe config state: private config parent is not owner-controlled: /tmp
+#    产品那条检查在 agent-node/src/runtime/config-apply.ts:256,只看**直接父目录**
+#    (`const parent = dirname(path)`),判据是 `opened.uid !== uid` ——
+#    /tmp 属 root(0),容器里进程是 node(1000),所以必然不过。**产品是对的。**
+#    本套件其它 config 一直放在 $WORK 下(`CONFIG="$WORK/.anet/nodes/$ALIAS/config.json"`,
+#    $WORK 建出来就 chmod 700),只有这一份是例外。按本文件自己的约定改回去。
+FEISHU_CONFIG="$WORK/test225-feishu-refused-config.json"
 FEISHU_LOG=/tmp/test225-feishu-refused.raw.log
 mkdir -p "$FEISHU_DIR"
 chmod 700 "$FEISHU_DIR"


### PR DESCRIPTION
Closes #1020

## 结果先说

    Summary: PASS
    package_e2e=PASS · npx_preview_fallback=PASS · global_agent_node_resume=PASS
    0 条 FAIL · 11 条 PASS（L0–L6 全跑完）

在这之前它长期是 2 条 FAIL，而且 L4 **在第 1954 行就早停**，下游 527 行、85 条断言从未执行。
PASS 从 8 条涨到 11 条 —— 涨的正是 #1026 里点名的那 3 条下游断言。

## 四处改动，各自解决什么

### ① #1020 真因：夹具把 config 放在 `/tmp` 下

诊断是这一步自己打出来的（先做了 ② 才拿得到）：

    | [agent-node] Refusing unsafe config state: private config parent is not owner-controlled: /tmp

**产品是对的。** `agent-node/src/runtime/config-apply.ts:256` 只看直接父目录
（`const parent = dirname(path)`），判据是父目录 uid == 进程 uid；
`/tmp` 属 root(0)、容器里进程是 node(1000)，必然不过。

而本套件其它 config 一直在 `$WORK` 下
（`CONFIG="$WORK/.anet/nodes/$ALIAS/config.json"`，`$WORK` 建出来就 `chmod 700`），
**只有飞书这一份是例外**。按本文件自己的约定改回去。

节点因此在走到「拒绝飞书通道」**之前**就退了 —— 而判据的前一半
`if cmd; then fail "accepted"; fi` 被 `:976` 之前的 **17 处 `process.exit(1)`** 中任意一条满足，
所以它确实拿到了一次「拒绝」，只是不是它想验的那次。

### ② 让失败自己说原因（凭据扫描前置）

原来那三行是 grep 在前、两条 `scan_fixed_file` 凭据泄漏扫描在后。
grep 红了至少两个 commit，所以那两条**安全检查从来没执行过** ——
恰恰是在「拒绝路径没按预期走完」这唯一一种现实里，放弃了检查有没有把凭据写进日志。
**把安全检查挡在功能检查后面，等于让一次功能回归顺手关掉一次安全回归。**

调正顺序之后，grep 失败时把产品自己打的 `[agent-node] ` 行带出来（≤5 行）。
这一步安全**正因为**扫描已经先跑过 —— 顺序反过来就不能这么做。

### ③ 自检不再污染共享报告（修正我自己建错的基线）

`run.sh:1472` / `:1508` 两处是**负向自检**：喂合成失败夹具，断言这道门必须失败。
它们已经把 stdout 重定向到捕获文件，但 `log()` 是 `printf | tee -a "$REPORT"` ——
**tee 无视 stdout 重定向**，照样写进共享报告。于是自检那句预期中的

    FAIL: real auth evidence scan failed; closed target-role diagnostic retained

出现在报告里，和一次真失败**逐字相同**。我当初照着它建了 known-failures 基线并挂了 #1021 ——
**那条基线是错的**。修法是在两处自检的子 shell 里加 `REPORT=/dev/null`。

证据：自检的 jq 断言期望 `.scanOutcome == "mixed"` 和 `"scan_error"`，
而报告里那两条 diagnostic 的 outcome 恰好就是这两个。

### ④ `wait` 加上界（#1027）+ `fail` 打印早停位置（#1026 的一半）

`stop_node_checked` 之后原来是 `wait "$HEADLESS_PID" 2>/dev/null || true`，**没有任何上界**。
实测过一次：`anet node stop` 对非 tmux 启动的节点打印

    [anet] "preview-grok-headless-225" is not running locally (server notified offline)

**并返回 0** —— 于是往下走到 `wait`，而进程根本没被停。在 CI 上这会耗光 job 超时，
**且不产出任何诊断**：报告停在 `[L4] ...` 那行，既没 FAIL 也没 PASS。

现在换成有上界的 `wait_pid_gone`，超时会把幸存进程的 cmdline 打进报告 ——
那正是我当初必须 `docker exec` 进容器手挖的东西。两个分支都拿探针见证过
（存活 rc=1 且打出 cmdline；已退 rc=0）。

`fail()` 现在还会打印 `早停于 run.sh:N / 共 M 行`，让早停丢掉的量在报告里可见（#1026）。

## known-failures.txt 清空了 —— 减三条，加零条

三条的去向都写在文件里：一条**从来就不是失败**（③）、一条**已修**（①）、
一条**只观测到一次、后续没复现**（#1027，那次同时跑着 2~3 个容器，可能是资源竞争）。

**没稳定复现的不放进基线** —— 基线里放一条偶发项，会让它「消失」时看起来像修好了。
#1027 仍然 open，而 `wait_pid_gone` 的上界留着：再发生一次，10 秒内带证据报出来。

## 顺带修掉我自己那道门在成功路径上说的一句假话

棘轮原来无条件打印「这**不**表示 test225 是绿的」。在**全部修好**那一刻，那句话是假的 ——
而那恰恰是最该说清楚的一刻。一个在成功路径上说假话的提示比没有提示更糟：它让人以为还有欠账。

现在基线为空且 0 FAIL 时改说：

    这次报告里 0 条 FAIL,基线也是空的 —— test225 现在是真绿的。
    这道门从此守的是「不许出现新的失败」。

**见证红**（基线空了之后新失败必须判红）：把一条 PASS 变异成 FAIL →

    FAIL: 基线之外的新失败:installed-package stop/resume removes exact pinned project sandbox placeholders
    >>> rc=1

## 验证

全量 test225 在 `git archive` 上下文里真跑（源 commit `07786e5b`），
`ARTIFACT_DIR` 走容器内路径 + `docker cp` 取产物（不挂宿主目录，避开 uid 耦合）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)