### PR TITLE
fix(test235): 容器布局与仓库同构 —— 修好之后接进 CI（第 6 个 grok 套件）

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -57,6 +57,7 @@ on:
       - 'tests/test225-grok-preview-package-live/**'
       - 'tests/test233-grok-main-integration/**'
       - 'tests/test234-grok-profile-disclosure/**'
+      - 'tests/test235-grok-mcp-outbound-only/**'
   push:
     branches: [main]
     paths:
@@ -104,6 +105,7 @@ on:
       - 'tests/test225-grok-preview-package-live/**'
       - 'tests/test233-grok-main-integration/**'
       - 'tests/test234-grok-profile-disclosure/**'
+      - 'tests/test235-grok-mcp-outbound-only/**'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
 # updated rapidly. main pushes run independently.
@@ -461,3 +463,17 @@ jobs:
             -f tests/test234-grok-profile-disclosure/Dockerfile .
           docker run --rm --network none -e ARTIFACT_DIR=/tmp/art \
             anet-test234-grok-profile-disclosure
+
+      # 这个套件此前基线是**红**的，红在相对 import 够不着 agent-network
+      # （容器把它拷到 /test235，而 `../../` 从那里解析成 `/`）。
+      # 本 PR 把容器布局改成与仓库同构之后它是真绿的：
+      #   Summary: PASS (real MCP child; zero long-lived Hub sockets; 40/40 outer ownership; 12 outbound calls; mutation red)
+      # 自带一条见证红：PASS: witnessed-red outbound-only mutation rc=1
+      # `--network none` 同样是**实测过**的那条命令。
+      - name: Build + run test235-grok-mcp-outbound-only
+        run: |
+          docker build --build-arg SOURCE_COMMIT="$GITHUB_SHA" \
+            -t anet-test235-grok-mcp-outbound-only \
+            -f tests/test235-grok-mcp-outbound-only/Dockerfile .
+          docker run --rm --network none -e ARTIFACT_DIR=/tmp/art \
+            anet-test235-grok-mcp-outbound-only

--- a/tests/test235-grok-mcp-outbound-only/Dockerfile
+++ b/tests/test235-grok-mcp-outbound-only/Dockerfile
@@ -9,7 +9,15 @@ RUN cd /workspace/agent-network && bun install --ignore-scripts
 COPY agent-network /workspace/agent-network
 COPY agent-node /workspace/agent-node
 COPY docs/grok-build-cli-preview.md /workspace/docs/grok-build-cli-preview.md
-COPY tests/test235-grok-mcp-outbound-only /test235
-RUN chmod 755 /test235/run.sh
+# 🔴 套件必须落在**与仓库同构**的位置。socket-harness.ts 里写的是
+#     import { OUTBOUND_TOOL_NAMES } from "../../agent-network/src/outbound-tool-names";
+#    这个相对路径在仓里（tests/test235-.../socket-harness.ts）指向仓根，是对的。
+#    原来这里拷到 `/test235`，于是 `../../` 解析成 `/`，去找 `/agent-network` ——
+#    而上面把它拷到了 `/workspace/agent-network`。报错是
+#        error: Cannot find module '../../agent-network/src/outbound-tool-names' from '/test235/socket-harness.ts'
+#    注意：**不是没拷进来**（第 9 行拷了），是拷到了相对路径够不着的地方。
+#    我第一次就把它误判成「Dockerfile 没拷这个文件」了。
+COPY tests/test235-grok-mcp-outbound-only /workspace/tests/test235-grok-mcp-outbound-only
+RUN chmod 755 /workspace/tests/test235-grok-mcp-outbound-only/run.sh
 
-ENTRYPOINT ["bash", "/test235/run.sh"]
+ENTRYPOINT ["bash", "/workspace/tests/test235-grok-mcp-outbound-only/run.sh"]

--- a/tests/test235-grok-mcp-outbound-only/run.sh
+++ b/tests/test235-grok-mcp-outbound-only/run.sh
@@ -28,7 +28,7 @@ run production-build bun build /workspace/agent-network/src/node-server.ts \
   --outfile /tmp/node-server.js --target bun
 
 run production-socket-harness env MCP_BUNDLE=/tmp/node-server.js \
-  bun /test235/socket-harness.ts
+  bun /workspace/tests/test235-grok-mcp-outbound-only/socket-harness.ts
 
 # Witnessed-red: remove the exact runtime mode gate while leaving the harness
 # unchanged. The MCP then registers presence and opens its own SSE connection;
@@ -40,7 +40,7 @@ run mutation-build bun build /workspace/agent-network/src/node-server.ts \
   --outfile /tmp/node-server-mutated.js --target bun
 cp /tmp/node-server-original.ts /workspace/agent-network/src/node-server.ts
 set +e
-EXPECT_MUTATION=1 MCP_BUNDLE=/tmp/node-server-mutated.js bun /test235/socket-harness.ts > /tmp/mutation.out 2>&1
+EXPECT_MUTATION=1 MCP_BUNDLE=/tmp/node-server-mutated.js bun /workspace/tests/test235-grok-mcp-outbound-only/socket-harness.ts > /tmp/mutation.out 2>&1
 mutation_rc=$?
 set -e
 cat /tmp/mutation.out | tee -a "$REPORT"


### PR DESCRIPTION
## 先更正我自己上一轮的判断

我上一轮报过「test235 红是因为 Dockerfile 没把 `agent-network/src/outbound-tool-names` 拷进镜像」。
**那是错的。** 核过之后：

    Dockerfile:9   COPY agent-network /workspace/agent-network     ← 拷了
    git ls-tree origin/main agent-network/src/outbound-tool-names.ts  ← 文件在仓里

真因是**相对路径解析不匹配**。`socket-harness.ts:12`：

    import { OUTBOUND_TOOL_NAMES } from "../../agent-network/src/outbound-tool-names";

这个路径在仓里（`tests/test235-.../socket-harness.ts`）指向仓根，是对的。
但 Dockerfile 原来把套件拷到 `/test235`，于是 `../../` 从那里解析成 `/`，
去找 `/agent-network` —— 而它在 `/workspace/agent-network`。报错原文：

    error: Cannot find module '../../agent-network/src/outbound-tool-names' from '/test235/socket-harness.ts'

**不是没拷进来，是拷到了相对路径够不着的地方。** 差一个字，修法完全不同：
按我原来的判断会去加一条多余的 COPY，而真正该改的是**落点**。

## 修法：让容器布局与仓库同构

    - COPY tests/test235-grok-mcp-outbound-only /test235
    + COPY tests/test235-grok-mcp-outbound-only /workspace/tests/test235-grok-mcp-outbound-only

`run.sh` 里 2 处 `/test235/` 引用同步改掉。这样 `../../agent-network` 在容器里
解析到 `/workspace/agent-network` —— 和它在仓里的语义完全一致，
以后再加相对 import 也不会踩同一个坑。

## 验证：真跑

    docker build --build-arg SOURCE_COMMIT=8df7cfa1 -f .../Dockerfile <archive-ctx>   rc=0
    docker run --rm --network none -e ARTIFACT_DIR=/tmp/art t235fix                    rc=0

    PASS: witnessed-red outbound-only mutation rc=1
    Summary: PASS (real MCP child; zero long-lived Hub sockets; 40/40 outer ownership; 12 outbound calls; mutation red)

它自带一条见证红（`witnessed-red outbound-only mutation rc=1`），质量不错。

## 顺带接进 CI —— 第 6 个 grok 套件

接的理由和前几个同一条：对着 `origin/main` 数，12 个 grok 套件里此前只有 5 个在 CI
（test224 / test225 / test813 / test233 / test234）。**一个长期不跑的套件，真绿和假绿输出逐字相同。**

- 直接做**阻塞门**，不套 known-failure 棘轮 —— 它现在是真绿的，
  给真绿的套件套棘轮只会让它以后真变红时不红。
- `--network none` 和 `-e ARTIFACT_DIR=/tmp/art` 都是上面那条**实测过的命令原样**，
  不写未验证的变体。
- 触发路径 `pull_request` / `push` 两处都加了 —— **存在、挂上、会被触发是三件事**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)