### PR TITLE
ci(grok): 接入 test219-grok-copresence —— 311 条共存核心断言，此前 CI 引用数为 0

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -58,6 +58,7 @@ on:
       - 'tests/test233-grok-main-integration/**'
       - 'tests/test234-grok-profile-disclosure/**'
       - 'tests/test235-grok-mcp-outbound-only/**'
+      - 'tests/test219-grok-copresence/**'
   push:
     branches: [main]
     paths:
@@ -106,6 +107,7 @@ on:
       - 'tests/test233-grok-main-integration/**'
       - 'tests/test234-grok-profile-disclosure/**'
       - 'tests/test235-grok-mcp-outbound-only/**'
+      - 'tests/test219-grok-copresence/**'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
 # updated rapidly. main pushes run independently.
@@ -477,3 +479,21 @@ jobs:
             -f tests/test235-grok-mcp-outbound-only/Dockerfile .
           docker run --rm --network none -e ARTIFACT_DIR=/tmp/art \
             anet-test235-grok-mcp-outbound-only
+
+      # 🔴 这个套件是本批里最重的一格 —— 它一次跑 **311 个测试**：
+      #     Summary: PASS (311 tests, 0 failures; all validation ran inside Docker)
+      #     PASS: FIFO/human arbitration + final reply + approval + reconnect + single bridge + liveness
+      #   覆盖的是共存运行时的核心行为(FIFO 仲裁 / 最终回复 / 审批 / 重连 / 单桥 / 存活判定)，
+      #   而对着 origin/main 数，它的 CI 引用数是 **0** —— 一次都没跑过。
+      #   这不是「有些测试没跑」，是「共存核心行为的 311 条断言没跑」。
+      #
+      #   直接做阻塞门，不套 known-failure 棘轮：基线跑过，它是**真绿**的。
+      #   `--network none -e ARTIFACT_DIR=/tmp/art` 是那次基线用的**同一条命令**，
+      #   不往 workflow 里写没验证过的变体。
+      - name: Build + run test219-grok-copresence
+        run: |
+          docker build --build-arg SOURCE_COMMIT="$GITHUB_SHA" \
+            -t anet-test219-grok-copresence \
+            -f tests/test219-grok-copresence/Dockerfile .
+          docker run --rm --network none -e ARTIFACT_DIR=/tmp/art \
+            anet-test219-grok-copresence


### PR DESCRIPTION
## 这一格是本批里最重的

基线跑（`--network none`，`git archive` 上下文）：

    run rc=0
    PASS: FIFO/human arbitration + final reply + approval + reconnect + single bridge + liveness
    PASS: agent-node + anet CLI builds
    Summary: PASS (311 tests, 0 failures; all validation ran inside Docker)

对着 `origin/main` 数它在 CI 里的引用：

    test219-grok-copresence   CI 引用=0

**311 个测试，覆盖的是共存运行时的核心行为** ——
FIFO 仲裁 / 最终回复 / 审批 / 重连 / 单桥 / 存活判定 —— 一次都没在 CI 上跑过。

这条比「孤儿套件有 N 个」这种计数有力得多：
不是「有些测试没跑」，是**共存核心行为的 311 条断言没跑**。
而且今晚已经有实测样本证明，一个长期不跑的套件**真绿和假绿输出逐字相同**
（test225：旧夹具硬写的常量恰好等于旧审计硬写的期望值，两个错误互相同意）。

注意它 `run.sh` 只有 72 行 —— 真正的 311 个测试在 Docker 里的另一层跑，
所以「套件小」和「覆盖少」不是一回事，按行数判断会看错。

## 判据选择

**直接做阻塞门，不套 known-failure 棘轮。** 基线证明它是真绿的；
棘轮是给「已经红、但必须先接进来才知道真绿假绿」的情况用的（test225 那种）。
**给一个真绿的套件套棘轮，只会让它以后真变红时不红。**

## 命令是实测过的原样

`--network none -e ARTIFACT_DIR=/tmp/art` 就是跑基线时用的那一条 ——
不往 workflow 里写没验证过的变体。（它的 Dockerfile 是 `COPY . /workspace`，
ENTRYPOINT 相对 WORKDIR，构建需要完整仓上下文。）

## 触发路径

`tests/test219-grok-copresence/**` 加进 `pull_request` 与 `push` 两处。
**job 存在、挂上、会被触发是三件事** —— 这条今晚栽过一次（#1017 改了 test225 的夹具，
27 个 check 全绿而 CI 从没执行过它）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)