### PR TITLE
ci(grok): 最后两个套件写 NOT-IN-CI.md —— 它们 rc=0 但零条断言，接进 CI 会得到永远绿的空门

### DIFF
--- a/tests/test-grok-build-acp-runtime/NOT-IN-CI.md
+++ b/tests/test-grok-build-acp-runtime/NOT-IN-CI.md
@@ -1,0 +1,42 @@
+# 为什么 test-grok-build-acp-runtime 不进 CI
+
+**它在没有凭据时 `rc=0`，但一条断言都不执行。**
+
+## 实测（2026-08-19，`origin/main` = `55e86d1c`，本地 Docker）
+
+    docker run --rm --network none -e ARTIFACT_DIR=/tmp/art <img>
+      # Grok Build ACP runtime E2E
+      SKIP: no GROK_CODE_XAI_API_KEY and no /host-grok/auth.json
+    rc=0
+
+统计：`SKIP=1  PASS=0  FAIL=0`。**整个套件就是一次 skip。**
+
+## 为什么不接（这个理由和 test231 / test232 不一样）
+
+test231 / test232 同样缺凭据，但它们**红**：
+
+    test231:  FAIL: real binary is not pinned Grok 0.2.93        rc=1
+    test232:  cp: cannot stat '/host-grok/auth.json'              rc=1
+
+**红是可读的信号** —— 门红了，人会去看为什么。
+而这个套件是 `rc=0` 且零条断言：接成阻塞门会得到一道**永远绿、什么都没断言**的门。
+
+**那比不接更糟。** 不接，至少还留着「它没被跑过」这个已知欠账；
+接了，就变成一条「已覆盖」的假记录 —— 而假记录和真覆盖在 CI 面板上长得一样。
+
+## 本地怎么真跑
+
+    # 二选一：给环境变量，或挂载 auth 缓存
+    docker run --rm -e GROK_CODE_XAI_API_KEY=... -e ARTIFACT_DIR=/tmp/art <img>
+    docker run --rm -v /path/to/grok:/host-grok:ro -e ARTIFACT_DIR=/tmp/art <img>
+
+## 什么时候该撤销这份豁免
+
+任一条成立即可：
+
+1. 套件改成**缺凭据时以非 0 退出**（那样它就变成和 test231/test232 同一类，
+   可以按「有理由的豁免」重新评估，或接进一条带凭据的专用 lane）；
+2. 报告里加上**分母**（`执行 N / 跳过 M / 共 K`），让「一条都没跑」在输出里可见；
+3. CI 上有了安全提供 Grok 凭据的通道。
+
+见 #1033（同族问题：`test-grok-build-capability` 的 `FAIL` 计数器是只写的）。

--- a/tests/test-grok-build-capability/NOT-IN-CI.md
+++ b/tests/test-grok-build-capability/NOT-IN-CI.md
@@ -1,0 +1,53 @@
+# 为什么 test-grok-build-capability 不进 CI
+
+**它打印 `FAIL:` 然后退出 0 —— 这个套件在任何输入下都不可能失败。** 见 #1033。
+
+## 实测（2026-08-19，`origin/main` = `55e86d1c`，本地 Docker）
+
+    docker run --rm --network none -e ARTIFACT_DIR=/tmp/art <img>
+      WARN: grok install - installer failed with status 6
+      FAIL: grok install - grok binary not found after installer
+      SKIP: auth source - no GROK_CODE_XAI_API_KEY and no mounted ~/.grok/auth.json
+      WARN: permission default - could not confirm --always-approve flag from help
+      SKIP: headless auth smoke - requires env token or mounted auth cache
+      SKIP: ACP stdio - requires env token or mounted auth cache
+      SKIP: ACP resume - requires env token or mounted auth cache
+      SKIP: temp repo file edit - requires env token or mounted auth cache
+    rc=0
+
+统计：`SKIP=5  WARN=2  FAIL=1  PASS=0`。**零条 PASS，而且带着一条 FAIL 退出 0。**
+
+## 机制
+
+`run.sh` 里：
+
+    :15   FAIL=0
+    :39   fail() { FAIL=$((FAIL + 1)) ...
+    :158    fail "grok install" "grok binary not found after installer"
+
+计数器有，`fail()` 也确实在累加。**但文件末尾没有任何一处读 `$FAIL`** ——
+最后几行是一串 `warn` 分支。另外 `:194` / `:210` 各有一个 `exit 0`，
+在缺凭据时直接从中间退出。
+
+所以 `FAIL:` 那一行只是打给人看的字符串，不影响退出码。
+
+## 为什么不接
+
+按 `rc` 接成阻塞门 = 一道**永远绿**的门，而且它绿的时候正在打印 `FAIL:`。
+这比「没接」更糟：没接留着的是一个已知欠账，接了留下的是一条**假的覆盖记录**。
+
+## 本地怎么真跑
+
+    docker run --rm -e GROK_CODE_XAI_API_KEY=... -e ARTIFACT_DIR=/tmp/art <img>
+    # 或挂载 auth 缓存
+    docker run --rm -v /path/to/grok:/host-grok:ro -e ARTIFACT_DIR=/tmp/art <img>
+
+## 什么时候该撤销这份豁免
+
+**#1033 修好之后**，也就是至少满足：
+
+1. 末尾加 `[ "$FAIL" -eq 0 ] || exit 1`，并把 `:194` / `:210` 那两处 `exit 0`
+   换成同一条判据；
+2. 报告里带分母（`执行 N / 跳过 M / 共 K`）。
+
+在退出码能承载 `$FAIL` 之前，把它接进 CI 没有任何意义。


### PR DESCRIPTION
## 实测（`origin/main` = `55e86d1c`，本地 Docker，`--network none`）

    test-grok-build-acp-runtime      rc=0   SKIP=1  PASS=0
    test-grok-build-capability       rc=0   SKIP=5  WARN=2  FAIL=1  PASS=0

第二个的输出里有：

    FAIL: grok install - grok binary not found after installer

**它打印了一条 FAIL，然后退出 0。** 见 #1033 —— `run.sh:15` 的 `FAIL` 计数器由
`fail()` 累加，但**末尾没有任何一处读它**，另有两处 `exit 0`。这个套件在任何输入下都退出 0。

## 为什么这两个的豁免理由和 test231 / test232 **不一样**

test231 / test232 同样缺凭据，但它们**红**：

    test231:  FAIL: real binary is not pinned Grok 0.2.93     rc=1
    test232:  cp: cannot stat '/host-grok/auth.json'          rc=1

**红是可读的信号** —— 门红了人会去看为什么，所以给它们写豁免是「先记账，将来能跑再接」。

而这两个是 `rc=0` 且**零条断言**。按 `rc` 接成阻塞门会得到一道
**永远绿、什么都没断言**的门 —— **那比不接更糟**：
不接留着的是「它没被跑过」这个已知欠账；接了留下的是一条**假的覆盖记录**，
而假覆盖和真覆盖在 CI 面板上长得一模一样。

表面相似性是「都缺凭据」，真正的差别是**能不能传递任何信息**。

## 两份说明各自写了撤销条件

- `test-grok-build-acp-runtime`：缺凭据时改成非 0 退出 / 报告里加分母 / CI 有安全的凭据通道，任一即可重评。
- `test-grok-build-capability`：**#1033 修好之后** —— 末尾加 `[ "$FAIL" -eq 0 ] || exit 1`，
  并把那两处 `exit 0` 换成同一条判据；在退出码能承载 `$FAIL` 之前接它没有任何意义。

两份都写了本地怎么带凭据真跑。

## 计数

    改前  note: 4 个套件已不再是孤儿
    改后  note: 6 个套件已不再是孤儿

`exempt` 这一格从今晚之前的 **0**（`EXEMPT_MARKER` 在
`.github/scripts/check-test-suite-registration.py:49` 早就有，但全仓一个都没用过）
增加到 4。基线楼层的下调放在 #1032 里做，本 PR 不动它 —— 避免两条 PR 同时改同一个文件。

## 收口

至此 **12 个 grok 套件全部有过一次真实基线**（此前 9 个从没在任何地方跑过）：

    在 CI（阻塞门）  test224 test225 test813 test233 test234 test235 test219 test605
    有理由的豁免      test231 test232 test-grok-build-acp-runtime test-grok-build-capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)