### PR TITLE
[草稿·需 Windows 实机验证] fix(#874): Windows 上跳过 fchmod —— 现在 preview 在 Windows 上任何 runtime 都起不来

### DIFF
--- a/agent-node/src/runtime/config-apply.test.ts
+++ b/agent-node/src/runtime/config-apply.test.ts
@@ -203,6 +203,47 @@ describe("#472 private config permissions", () => {
     expect(mode(path)).toBe(0o600);
   });
 
+  // 🔴 #874 —— Windows 上 fchmodSync 抛 EPERM，fail-closed 把所有 runtime 挡死。
+  //    我没有 Windows 机器，所以**注入 platform** 来验分支被走到，
+  //    而不是拿「我试过了」当证据。这两条测的是：
+  //      · win32 分支不再抛（改之前这里会 throw，节点因此起不来）
+  //      · POSIX 分支的行为**一个字节都没变**（下面那条是现有测试的 win32 对照）
+  test("#874 win32: does not throw, and leaves modes untouched", () => {
+    const parent = join(scratch, ".anet", "nodes", "n_win");
+    mkdirSync(parent, { recursive: true });
+    const path = join(parent, "config.json");
+    writeFileSync(path, JSON.stringify({ token: "ntok_win" }));
+    chmodSync(parent, 0o775);
+    chmodSync(path, 0o664);
+
+    // 🔴 这一行在 Linux 上几乎是免费的 —— `fchmodSync` 在这里本来就不会抛。
+    //    它记录意图，但**不承重**。
+    expect(() => repairPrivateConfigPermissions(path, "win32")).not.toThrow();
+
+    // 🔴 承重的是下面两行：win32 分支**确实跳过了 chmod**（撤掉守卫后正是这里红）。
+    //    必须说清它证明了什么、没证明什么：
+    //      证明了 —— platform="win32" 时不再调用 fchmod
+    //      **没证明** —— 在真 Windows 上不再抛 EPERM（那要一台 Windows 机）
+    //    Windows 上没有 mode 收紧保证，但那不是本次改动造成的：
+    //    改之前是崩掉，从来没有过「在 Windows 上收紧成功」这个状态。
+    expect(mode(parent)).toBe(0o775);
+    expect(mode(path)).toBe(0o664);
+  });
+
+  test("#874 posix branch is unchanged (same fixture, platform=linux)", () => {
+    const parent = join(scratch, ".anet", "nodes", "n_posix");
+    mkdirSync(parent, { recursive: true });
+    const path = join(parent, "config.json");
+    writeFileSync(path, JSON.stringify({ token: "ntok_posix" }));
+    chmodSync(parent, 0o775);
+    chmodSync(path, 0o664);
+
+    repairPrivateConfigPermissions(path, "linux");
+
+    expect(mode(parent)).toBe(0o700);
+    expect(mode(path)).toBe(0o600);
+  });
+
   test("backup atomically replaces a legacy broad .prev", () => {
     const path = join(scratch, "config.json");
     writeFileSync(path, JSON.stringify({ token: "ntok_fresh" }), { mode: 0o600 });

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -234,7 +234,23 @@ function isManagedAnetDirectory(path: string): boolean {
   return resolve(path).split(sep).includes(".anet");
 }
 
-function repairPrivateDirectory(path: string, tightenMode: boolean): void {
+// 🔴 #874 —— Windows 上 `fchmodSync` 抛 EPERM，而这段是 fail-closed，
+//    于是 `agent-node@preview` 在 Windows 上**任何 runtime 都起不来**：
+//        [agent-node] Refusing unsafe global config: EPERM: operation not permitted, fchmod
+//    （`@latest` 正常 —— 是 preview 相对 latest 的回归。）
+//
+//    只跳过 `fchmodSync` 这一步，别的一个都不动：
+//      · symlink / 非目录 / 非普通文件 / nlink 的拒绝    —— 保留（跨平台都有意义）
+//      · 打开后用 fstat 复核 dev+ino 与 lstat 一致        —— 保留（防 TOCTOU 换靶）
+//      · uid 相等                                        —— 原本就用 `uid !== undefined` 守着，
+//                                                           Windows 上 `process.getuid` 不存在，本来就跳过
+//    **Windows 上因此没有 mode 收紧保证** —— 但那不是本次改动造成的：
+//    POSIX mode 在 Windows 上本来就不是权限模型（Node 的 chmod 在那里只认只读位）。
+//    改之前是「崩掉」，改之后是「不收紧」；从没有过「在 Windows 上收紧成功」这个状态。
+//
+//    platform 做成可注入，是为了能在 Linux 上验 win32 分支 ——
+//    我没有 Windows 机器，不能拿「我试过了」当证据。
+function repairPrivateDirectory(path: string, tightenMode: boolean, platform: NodeJS.Platform = process.platform): void {
   const before = lstatSync(path);
   if (before.isSymbolicLink() || !before.isDirectory()) {
     throw new Error(`private config refuses non-directory or linked parent: ${path}`);
@@ -248,15 +264,15 @@ function repairPrivateDirectory(path: string, tightenMode: boolean): void {
       || opened.dev !== before.dev || opened.ino !== before.ino) {
       throw new Error(`private config parent is not owner-controlled: ${path}`);
     }
-    if (tightenMode) fchmodSync(fd, 0o700);
+    if (tightenMode && platform !== "win32") fchmodSync(fd, 0o700);
   } finally { closeSync(fd); }
 }
 
 /** Tighten legacy umask-derived config state before reading any token. */
-export function repairPrivateConfigPermissions(path: string): void {
+export function repairPrivateConfigPermissions(path: string, platform: NodeJS.Platform = process.platform): void {
   if (!existsSync(path) && !existsSync(`${path}.prev`)) return;
   const parent = dirname(path);
-  repairPrivateDirectory(parent, isManagedAnetDirectory(parent));
+  repairPrivateDirectory(parent, isManagedAnetDirectory(parent), platform);
   for (const candidate of [path, `${path}.prev`]) {
     if (!existsSync(candidate)) continue;
     const before = lstatSync(candidate);
@@ -272,7 +288,7 @@ export function repairPrivateConfigPermissions(path: string): void {
         || opened.dev !== before.dev || opened.ino !== before.ino) {
         throw new Error(`private config is not owner-controlled: ${candidate}`);
       }
-      fchmodSync(fd, 0o600);
+      if (platform !== "win32") fchmodSync(fd, 0o600);
     } finally { closeSync(fd); }
   }
 }


### PR DESCRIPTION
Refs #874

## 🔴 先说这个 PR **不能**证明什么

**我没有 Windows 机器，这个改动没有在真 Windows 上跑过。**
所以它开成草稿。合它之前需要有人在 `vanisn`（或任意 Windows）上实测。

我的测试证明的是「`platform="win32"` 时不再调用 `fchmod`」，
**不是**「在 Windows 上不再抛 EPERM」—— 后者要一台 Windows 机。
见下面「见证红红在哪」一节，那里说清了哪条断言承重、哪条不承重。

## 问题（#874 的原文）

    npx -y @sleep2agi/agent-node@preview --runtime grok-build-cli --alias probe-win
      → [agent-node] Refusing unsafe global config: EPERM: operation not permitted, fchmod
    npx -y @sleep2agi/agent-node@preview --runtime codex-app-server --alias probe-win2
      → 同一条错误        ← 不是 grok 专有，任何 runtime 都一样
    npx -y @sleep2agi/agent-node@latest --runtime codex-sdk --alias probe-win3
      → 正常走到鉴权      ← latest 正常

**preview 相对 latest 的回归，Windows 上完全不可用。**

## 改法：只动有证据的那一处

`agent-node/src/runtime/config-apply.ts` 里两处 `fchmodSync` 加平台守卫，
**其余一个字不动**：

| 检查 | 处置 | 理由 |
|---|---|---|
| symlink / 非目录 / 非普通文件 / `nlink !== 1` 拒绝 | **保留** | 跨平台都有意义 |
| 打开后 `fstat` 复核 `dev`+`ino` 与 `lstat` 一致 | **保留** | 防 TOCTOU 换靶 |
| `uid` 相等 | **不变** | 原本就用 `uid !== undefined` 守着；Windows 上 `process.getuid` 不存在，本来就跳过 |
| `fchmodSync(fd, 0o700/0o600)` | **win32 跳过** | 就是它抛 EPERM |

**Windows 上因此没有 mode 收紧保证 —— 但那不是本次改动造成的。**
POSIX mode 在 Windows 上本来就不是权限模型（Node 的 `chmod` 在那里只认只读位）。
改之前是**崩掉**，改之后是**不收紧**；**从来没有过「在 Windows 上收紧成功」这个状态。**

`platform` 做成可注入的默认参数（`= process.platform`），是为了能在 Linux 上验 win32 分支 ——
不是为了让调用方去传它。生产调用点一处都没改。

## 验证：见证红红在哪（这一段是本 PR 最该看的）

加了两条测试。撤掉守卫（模拟修复前）后：

    (fail) #472 private config permissions > #874 win32: does not throw, and leaves modes untouched
    219 |     expect(() => repairPrivateConfigPermissions(path, "win32")).not.toThrow();
    223 |     expect(mode(parent)).toBe(0o775);
    error: expect(received).toBe(expected)
    rc=1

**它红在 `expect(mode(parent)).toBe(0o775)`，不是红在 `not.toThrow()`。**
因为 Linux 上 `fchmodSync` 根本不会抛 —— 那条 `not.toThrow()` 在这里几乎是免费的，
它记录意图但**不承重**。承重的是 mode 未被改动这一条。

所以这条测试的准确含义是：**win32 分支确实跳过了 chmod**。
它**不能**替代真 Windows 上的一次运行。

还加了一条 POSIX 对照（同一份夹具、`platform="linux"`），断言收紧行为一个字节没变：
`parent → 0o700`、`file → 0o600`。

    还原守卫后：87 pass / 0 fail（`agent-node/src/runtime/config-apply.test.ts`）

## 为什么开草稿而不是直接合

这段是**安全边界**代码，而且是 fail-closed 设计。
放宽 fail-closed 的任何一步都该由能对这个边界负责的人点头，
不该因为「测试绿了」就自动通过 —— 何况这里的绿并不覆盖真正的目标平台。

**合并前的验收建议**：在 Windows 上跑

    npx -y @sleep2agi/agent-node@<本分支构建> --runtime codex-sdk --alias probe-win

预期：不再出现 `Refusing unsafe global config: EPERM ... fchmod`，能走到鉴权那一步
（和 `@latest` 现在的行为一致）。

## 为什么这条现在值得排期

`agent-network-app` 的 Windows 安装包已经能打出来了（main 上 `event=push` 自动跑，
产物 `windows-x64 12.27MB` 实测下载过）。**包能装，但里面的节点在 Windows 上起不来** ——
这条是「打一个极简 Win app」那条线上目前唯一的功能性阻断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)