### PR TITLE
[草稿·须排在 #1032/#1034 之后] ci: 一份豁免必须自己写明「什么时候该撤销」和「上次复核是哪天」

### DIFF
--- a/.github/scripts/check-test-suite-registration.py
+++ b/.github/scripts/check-test-suite-registration.py
@@ -41,12 +41,48 @@ from __future__ import annotations
 
 import pathlib
 import subprocess
+import re
 import sys
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
 TESTS = REPO / "tests"
 BASELINE = REPO / "docs" / "test-suite-orphan-baseline.txt"
 EXEMPT_MARKER = "NOT-IN-CI.md"
+# 超过这个天数的豁免只打 note（不判红，理由见 exemption_meta 上方注释）。
+EXEMPT_STALE_DAYS = 30
+
+# 🔴 一份豁免必须自己写明「什么时候该被撤销」和「上次核实是哪天」。
+#
+#    起因是 agent-network/bin/cli.ts 里那条 workaround 上的一句话：
+#        a temporary workaround that WRITES DOWN its expiry condition is better
+#        than one that doesn't — but only if someone re-reads it.
+#        Nothing re-evaluates a condition stored in a comment.
+#
+#    我今晚写的 4 份 NOT-IN-CI.md 正是这个形状：撤销条件写在 markdown 里，
+#    没有任何东西会重新评估它们。所以在这里加两条机械约束：
+#
+#    ① 缺 `Verified:` / `Revisit-when:` → **红**。
+#       一份不写撤销条件的豁免是无限期豁免，和「新增孤儿」是同一类问题，红得一致。
+#    ② 陈旧 → **只打 note，不红**。
+#       按日期判红是「定时炸弹」：它会在某个和这件事无关的 PR 上炸，
+#       然后被那个人顺手加个豁免绕过去 —— 那比不检查更糟。
+#       改成把**每份豁免的天数打进每次都会出现的汇总行** ——
+#       一个在 CI 日志里每次都看得见的数字，比一份没人打开的 markdown 有效。
+VERIFIED_RE = re.compile(r"^Verified:\s*(\d{4}-\d{2}-\d{2})\s*$", re.M)
+REVISIT_RE = re.compile(r"^Revisit-when:\s*(\S.*)$", re.M)
+
+
+def exemption_meta(path):
+    """读一份 NOT-IN-CI.md 的机械头。返回 (verified_date|None, revisit|None)。"""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return (None, None)
+    v = VERIFIED_RE.search(text)
+    r = REVISIT_RE.search(text)
+    return (v.group(1) if v else None, r.group(1).strip() if r else None)
+
+
 
 
 def read(p: pathlib.Path) -> str:
@@ -121,18 +157,54 @@ def main() -> int:
     registered, exempt, orphans = c["registered"], c["exempt"], c["orphans"]
     new_orphans, improved = c["new"], c["improved"]
 
+    # 每份豁免的元数据：缺头 → 红；陈旧 → note。天数进汇总行,每次都看得见。
+    from datetime import date
+    today = date.today()
+    exempt_ages, exempt_missing = [], []
+    for s in exempt:
+        verified, revisit = exemption_meta(TESTS / s / EXEMPT_MARKER)
+        if not verified or not revisit:
+            exempt_missing.append((s, verified, revisit))
+            continue
+        try:
+            y, m, d = (int(x) for x in verified.split("-"))
+            exempt_ages.append((s, (today - date(y, m, d)).days))
+        except ValueError:
+            exempt_missing.append((s, verified, revisit))
+
+    oldest = f" (oldest {max(a for _, a in exempt_ages)}d)" if exempt_ages else ""
     print(f"suites={len(all_suites)} registered={len(registered)} "
-          f"exempt={len(exempt)} orphans={len(orphans)} "
+          f"exempt={len(exempt)}{oldest} orphans={len(orphans)} "
           f"baseline={len(base)} new={len(new_orphans)}")
+
+    for s, verified, revisit in exempt_missing:
+        missing = []
+        if not verified:
+            missing.append("`Verified: YYYY-MM-DD`（上次真跑过它是哪天）")
+        if not revisit:
+            missing.append("`Revisit-when: ...`（什么条件成立时该撤销这份豁免）")
+        print(f"::error file=tests/{s}/{EXEMPT_MARKER}::"
+              f"豁免缺少机械头：{' 和 '.join(missing)}。"
+              f"一份不写撤销条件的豁免是**无限期**豁免 —— 它和「新增孤儿」是同一类问题："
+              f"都没有回答「谁、在什么条件下，会重新看它一眼」。")
+    for s, age in sorted(exempt_ages, key=lambda x: -x[1]):
+        if age > EXEMPT_STALE_DAYS:
+            print(f"note: 豁免 {s} 已 {age} 天未复核（阈值 {EXEMPT_STALE_DAYS} 天）—— "
+                  f"重跑一次并更新 Verified:，或按它自己写的 Revisit-when: 撤销它。"
+                  f"**这条只提示不判红**：按日期判红会在无关的 PR 上炸，然后被顺手绕过。")
 
     if improved:
         print(f"note: {len(improved)} 个套件已不再是孤儿，把它们从 "
               f"{BASELINE.relative_to(REPO)} 里删掉，楼层只降不回填：{', '.join(improved[:8])}"
               + (" …" if len(improved) > 8 else ""))
 
-    if not new_orphans:
+    if not new_orphans and not exempt_missing:
         print("no new unregistered test suite.")
         return 0
+
+    if exempt_missing and not new_orphans:
+        print(f"\n{len(exempt_missing)} 份豁免没有回答「什么条件下该撤销它」。")
+        return 1
 
     for s in new_orphans:
         print(f"::error file=tests/{s}/run.sh::新增的测试套件 `{s}` 不会被任何 CI 跑到。"

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -25,8 +25,6 @@ qa-rfc026-create-node
 qa-rfc027-stop-delete
 qa-rfc028-provider-probe
 test-goal-cli
-test-grok-build-acp-runtime
-test-grok-build-capability
 test-npm-api
 test-npm-install
 test-npm-security

--- a/tests/test-grok-build-acp-runtime/NOT-IN-CI.md
+++ b/tests/test-grok-build-acp-runtime/NOT-IN-CI.md
@@ -1,5 +1,12 @@
 # 为什么 test-grok-build-acp-runtime 不进 CI
 
+<!-- 🔴 下面两行是**机器读的**。散文里写撤销条件没有用 —— 没有任何东西会重新
+     评估一个存在于注释/正文里的条件（这句话是仓里 dashboardReleaseTag() 上方的原话）。
+     check-test-suite-registration.py 缺这两行会判红，并把 Verified 的天数
+     打进每次都会出现的汇总行。-->
+Verified: 2026-08-19
+Revisit-when: 满足任一 —— (a) 套件在缺凭据时以**非 0**退出；(b) 报告里带分母（执行 N / 跳过 M / 共 K），让「一条都没跑」在输出里可见；(c) CI 上有了安全提供 Grok 凭据的通道。
+
 **它在没有凭据时 `rc=0`，但一条断言都不执行。**
 
 ## 实测（2026-08-19，`origin/main` = `55e86d1c`，本地 Docker）

--- a/tests/test-grok-build-capability/NOT-IN-CI.md
+++ b/tests/test-grok-build-capability/NOT-IN-CI.md
@@ -1,5 +1,12 @@
 # 为什么 test-grok-build-capability 不进 CI
 
+<!-- 🔴 下面两行是**机器读的**。散文里写撤销条件没有用 —— 没有任何东西会重新
+     评估一个存在于注释/正文里的条件（这句话是仓里 dashboardReleaseTag() 上方的原话）。
+     check-test-suite-registration.py 缺这两行会判红，并把 Verified 的天数
+     打进每次都会出现的汇总行。-->
+Verified: 2026-08-19
+Revisit-when: #1033 修好之后 —— 末尾加 `[ "$FAIL" -eq 0 ] || exit 1`，并把 run.sh:194 / :210 那两处 `exit 0` 换成同一条判据。在退出码能承载 $FAIL 之前，接它进 CI 没有任何意义。
+
 **它打印 `FAIL:` 然后退出 0 —— 这个套件在任何输入下都不可能失败。** 见 #1033。
 
 ## 实测（2026-08-19，`origin/main` = `55e86d1c`，本地 Docker）

--- a/tests/test231-grok-socket-sandbox/NOT-IN-CI.md
+++ b/tests/test231-grok-socket-sandbox/NOT-IN-CI.md
@@ -1,5 +1,12 @@
 # 为什么 test231-grok-socket-sandbox 不进 CI
 
+<!-- 🔴 下面两行是**机器读的**。散文里写撤销条件没有用 —— 没有任何东西会重新
+     评估一个存在于注释/正文里的条件（这句话是仓里 dashboardReleaseTag() 上方的原话）。
+     check-test-suite-registration.py 缺这两行会判红，并把 Verified 的天数
+     打进每次都会出现的汇总行。-->
+Verified: 2026-08-19
+Revisit-when: CI 上有了**不带凭据**的方式拿到钉住版本的 Grok 二进制（例如可公开下载的产物 + 公布的校验和）——那时这份豁免就该撤掉。
+
 **它需要宿主挂载 `/host-grok/grok-0.2.93` —— 而 CI runner 上没有，也不该有。**
 
 ## 实测（2026-08-19，`origin/main` = `55e86d1c`，本地 Docker）

--- a/tests/test232-grok-xsearch-process-profile/NOT-IN-CI.md
+++ b/tests/test232-grok-xsearch-process-profile/NOT-IN-CI.md
@@ -1,5 +1,12 @@
 # 为什么 test232-grok-xsearch-process-profile 不进 CI
 
+<!-- 🔴 下面两行是**机器读的**。散文里写撤销条件没有用 —— 没有任何东西会重新
+     评估一个存在于注释/正文里的条件（这句话是仓里 dashboardReleaseTag() 上方的原话）。
+     check-test-suite-registration.py 缺这两行会判红，并把 Verified 的天数
+     打进每次都会出现的汇总行。-->
+Verified: 2026-08-19
+Revisit-when: CI 上有了安全提供真 Grok 登录凭据的通道，或套件改成不依赖 /host-grok/auth.json 也能断言其被测行为。
+
 **它需要宿主挂载 `/host-grok/auth.json` —— 而 CI runner 上没有，也不该有。**
 
 ## 实测（2026-08-19，`origin/main` = `55e86d1c`，本地 Docker）


### PR DESCRIPTION
## 起因：仓里一句话，正好说中我今晚自己做的事

`agent-network/bin/cli.ts` 里 `dashboardReleaseTag()` 上方那段注释（`origin/main`）：

    The general shape, worth naming: a temporary workaround that WRITES DOWN its
    expiry condition is better than one that doesn't — but only if someone
    re-reads it. Nothing re-evaluates a condition stored in a comment.

我今晚写了 4 份 `NOT-IN-CI.md`（#1032 / #1034），每一份都认真写了「什么时候该撤销这份豁免」——
**全部写在 markdown 里，没有任何东西会重新评估它们。** 和上面这句批评的是同一个形状。

而当前判据只有一条：`tests/<dir>/NOT-IN-CI.md` **存在** → OK。
文件里写什么、写没写、多久没看过，一概不问。

## 改动：两条机械约束，一红一 note，分开是有理由的

### ① 缺机械头 → **红**

要求每份 `NOT-IN-CI.md` 含：

    Verified: YYYY-MM-DD          上次真跑过它是哪天
    Revisit-when: <一句话>         什么条件成立时该撤销这份豁免

**一份不写撤销条件的豁免是无限期豁免** —— 它和「新增孤儿」是同一类问题：
都没有回答「谁、在什么条件下，会重新看它一眼」。所以红得和新增孤儿一致。

### ② 陈旧 → **只打 note，不红**

**按日期判红是「定时炸弹」**：它会在某个和这件事完全无关的 PR 上炸，
然后被那个人顺手加个豁免绕过去 —— **那比不检查更糟**。

改成把每份豁免的天数打进**每次都会出现的汇总行**：

    suites=199 registered=39 exempt=1 (oldest 230d) orphans=159 baseline=164 new=0

一个在每次 CI 日志里都看得见的数字，比一份没人打开的 markdown 有效得多。
超阈值再补一条 note 说清该怎么办。

## 见证：三条路径都造出来验过（临时夹具，跑完删掉）

    A) NOT-IN-CI.md 无头        rc=1
       ::error file=tests/test998-exempt-probe/NOT-IN-CI.md::豁免缺少机械头：`Verified: ...` 和 `Revisit-when: ...`
       1 份豁免没有回答「什么条件下该撤销它」。

    B) 补齐两行                 rc=0    exempt=1 (oldest 0d)   no new unregistered test suite.

    C) Verified 改成 2026-01-01 rc=0    exempt=1 (oldest 230d)
       note: 豁免 test998-exempt-probe 已 230 天未复核（阈值 30 天）—— 重跑一次并更新 Verified:，
             或按它自己写的 Revisit-when: 撤销它。**这条只提示不判红**

## 🔴 为什么开草稿：顺序不能反

我那 4 份 `NOT-IN-CI.md` 还在 **#1032 / #1034** 里没合，它们**都缺这两行头**。
如果本 PR 先合，那两个 PR 一落地就会红。

**必须排在 #1032 / #1034 之后**，并在本 PR 里给那 4 份文件补上 `Verified:` / `Revisit-when:`。
它们的 `Revisit-when:` 内容我在写那些文件时已经用散文写过了，这一步只是把它变成机器读得到的形状。

（这和 #1024 是同一条纪律：先让判据认得新形状，再扩大取集；反了会造出一批假红。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)