### PR TITLE
ci(hub): 接入 test735-hub-daemon-rebuild —— 守全军团单点的 fail-closed 测试，此前 CI 引用为 0

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -60,6 +60,8 @@ on:
       - 'tests/test235-grok-mcp-outbound-only/**'
       - 'tests/test219-grok-copresence/**'
       - 'tests/test605-grok-startup-model-label/**'
+      - 'tests/test735-hub-daemon-rebuild/**'
+      - 'deploy/hub/hub-daemon.sh'
   push:
     branches: [main]
     paths:
@@ -110,6 +112,8 @@ on:
       - 'tests/test235-grok-mcp-outbound-only/**'
       - 'tests/test219-grok-copresence/**'
       - 'tests/test605-grok-startup-model-label/**'
+      - 'tests/test735-hub-daemon-rebuild/**'
+      - 'deploy/hub/hub-daemon.sh'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
 # updated rapidly. main pushes run independently.
@@ -509,3 +513,37 @@ jobs:
             -f tests/test605-grok-startup-model-label/Dockerfile .
           docker run --rm --network none -e ARTIFACT_DIR=/tmp/art \
             anet-test605-grok-startup-model-label
+
+  hub-daemon-gate:
+    # 🔴 单独一个 job，不塞进 grok-green-suites —— 那个名字会对它包含的内容说谎。
+    #    （改已有 job 的名字会动分支保护里的 required check，风险更高，所以新开。）
+    name: hub daemon fail-closed (Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # 这一格守的是**全军团单点**：`deploy/hub/hub-daemon.sh` 是生产 CommHub 的启动脚本
+      # （pm2 守着；脚本自己的头里记着 2026-07-29 那次误杀导致 95 个 agent 掉线）。
+      # test735 覆盖的正是它的 fail-closed 约束：
+      #   assert_missing_secret_rejected   缺 vault 密钥必须拒绝启动
+      #   assert_occupied_port_rejected    端口已被监听必须拒绝（防第二个 hub 抢同一个 DB）
+      #   assert_missing_ss_rejected       看不见端口就拒绝启动
+      #   assert_missing_runtime_rejected / assert_missing_bun_rejected / assert_success_path
+      #
+      # 对着 origin/main 数，它此前的 CI 引用是 **0** —— 这份测试从没在 CI 上跑过。
+      #
+      # 基线（Docker、--network none，不碰生产 hub）：
+      #   L1 HUB_DAEMON_REBUILD_PASS
+      #   MUTATION_RED vault-gate-removed      ← 自带见证红：去掉 vault 闸门它会红
+      #   RESULT: PASS
+      # 真绿 + 自带变异，所以直接做阻塞门，不套 known-failure 棘轮。
+      #
+      # `--network none -e ARTIFACT_DIR=/tmp/art` 是跑基线时用的**同一条命令**。
+      - name: Build + run test735-hub-daemon-rebuild
+        run: |
+          docker build --build-arg SOURCE_COMMIT="$GITHUB_SHA" \
+            -t anet-test735-hub-daemon-rebuild \
+            -f tests/test735-hub-daemon-rebuild/Dockerfile .
+          docker run --rm --network none -e ARTIFACT_DIR=/tmp/art \
+            anet-test735-hub-daemon-rebuild


### PR DESCRIPTION
## 它守的是什么

`deploy/hub/hub-daemon.sh` 是**生产 CommHub 的启动脚本**（pm2 守着）。
脚本自己的文件头记着它为什么存在：

    2026-07-29 09:46 被误杀后 95 个 agent 掉线，只能靠人巡检发现。

`tests/test735-hub-daemon-rebuild/` 覆盖的正是它的 fail-closed 约束：

    assert_success_path
    assert_missing_secret_rejected      缺 vault 密钥必须拒绝启动
    assert_missing_runtime_rejected
    assert_missing_ss_rejected          看不见端口就拒绝启动
    assert_occupied_port_rejected       端口已被监听必须拒绝（防第二个 hub 抢同一个 DB）
    assert_missing_bun_rejected

**而对着 `origin/main` 数，它的 CI 引用是 0**，在孤儿基线里，也没有 `NOT-IN-CI.md`。
⇒ 全军团单点的启动脚本，有一份覆盖全部 fail-closed 约束的测试，**从没在 CI 上跑过**。

## 基线（Docker、`--network none`，不碰生产 hub）

    build rc=0
    run  rc=0
      L1 HUB_DAEMON_REBUILD_PASS
      MUTATION_RED vault-gate-removed
      RESULT: PASS

**它自带一条见证红**：`MUTATION_RED vault-gate-removed` —— 去掉 vault 闸门它会红。
一个自己证明过「闸门真的咬得动」的套件，质量比只报 PASS 的高。

真绿 + 自带变异 ⇒ **直接做阻塞门，不套 known-failure 棘轮**。
（棘轮是给「已经红但必须先接进来」用的；给真绿的套件套棘轮，只会让它以后真变红时不红。）

## 为什么单独开一个 job 而不是塞进 `grok-green-suites`

那个 job 名会**对它包含的内容说谎** —— test735 和 grok 无关。
改已有 job 的名字会动分支保护里的 required check，风险更高，所以新开一个：

    hub-daemon-gate / name: hub daemon fail-closed (Docker)

## 触发路径

除了 `tests/test735-hub-daemon-rebuild/**`，还加了 **`deploy/hub/hub-daemon.sh`** 本身 ——
改被测对象时这道门必须跑。**job 存在、挂上、会被触发是三件事**，
这条今晚栽过一次（#1017 改了 test225 的夹具，27 个 check 全绿而 CI 从没执行过它）。

## 我没有做的事

`deploy/hub/hub-daemon.sh` 本身我**一行都没跑**。它管的是生产中枢，
验证全部在容器里、通过 test735 走。

顺带记一句：这个脚本第 20–21 行自己写着

    端口/DB 可由环境变量覆盖 —— 这样旁路验证跑的是**同一个脚本**，
    而不是一个长得像它的副本（否则验证等于没验证）

**它是被设计成可安全验证的**，test735 用的正是这条路。这份设计意图值得保住。

🤖 Generated with [Claude Code](https://claude.com/claude-code)