### PR TITLE
fix: 我的 #1019 JSON import 打断了两个镜像的 cli.ts 构建 —— 并把这两个套件接进 CI

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -61,6 +61,9 @@ on:
       - 'tests/test219-grok-copresence/**'
       - 'tests/test605-grok-startup-model-label/**'
       - 'tests/test735-hub-daemon-rebuild/**'
+      - 'tests/test631-private-config-permissions/**'
+      - 'tests/test646-config-node-id-precedence/**'
+      - 'agent-node/src/cli.ts'
       - 'deploy/hub/hub-daemon.sh'
   push:
     branches: [main]
@@ -113,6 +116,9 @@ on:
       - 'tests/test219-grok-copresence/**'
       - 'tests/test605-grok-startup-model-label/**'
       - 'tests/test735-hub-daemon-rebuild/**'
+      - 'tests/test631-private-config-permissions/**'
+      - 'tests/test646-config-node-id-precedence/**'
+      - 'agent-node/src/cli.ts'
       - 'deploy/hub/hub-daemon.sh'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
@@ -547,3 +553,35 @@ jobs:
             -f tests/test735-hub-daemon-rebuild/Dockerfile .
           docker run --rm --network none -e ARTIFACT_DIR=/tmp/art \
             anet-test735-hub-daemon-rebuild
+
+  private-config-gates:
+    # 独立 job：这两个套件守的是**凭据落盘的私有写入边界**，和 grok / hub 都不是一回事，
+    # 名字必须说得出它管什么。
+    name: private config write boundary (Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # 🔴 test631 的判据里有一段「生产路径清单」，逐条点名每一个直写路径，
+      #   原文写着理由：a new bypass cannot hide behind an aggregate green count.
+      #   它还自带两条见证红：private-mode / startup-repair。
+      #
+      #   ⚠️ **不要加 `--network none`**。它有一段要真起节点（isolated HOME + unreachable Hub），
+      #      断网会让它 rc=1 —— 那是**跑法造成的红**，不是套件缺陷。我踩过一次。
+      - name: Build + run test631-private-config-permissions
+        run: |
+          docker build --build-arg TEST631_SOURCE_COMMIT="$GITHUB_SHA" \
+            -t anet-test631-private-config-permissions \
+            -f tests/test631-private-config-permissions/Dockerfile .
+          docker run --rm -e ARTIFACT_DIR=/tmp/art \
+            anet-test631-private-config-permissions
+
+      # 自带见证红：MUTATION_RED: env-first-precedence
+      - name: Build + run test646-config-node-id-precedence
+        run: |
+          docker build --build-arg SOURCE_COMMIT="$GITHUB_SHA" \
+            -t anet-test646-config-node-id-precedence \
+            -f tests/test646-config-node-id-precedence/Dockerfile .
+          docker run --rm --network none -e ARTIFACT_DIR=/tmp/art \
+            anet-test646-config-node-id-precedence

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1009,6 +1009,9 @@ import { appendFileSync, mkdirSync } from "fs";
 // 用 import 而不是运行时读 package.json:`bun build --minify` 会把 JSON
 // 在**构建期**内联,于是这个常量表示的是「这份 dist 是从哪个版本构建出来的」——
 // 正是我们想问的那件事。运行时去找 package.json 反而会受安装布局影响。
+// 🔴 给写 Dockerfile 的人：**任何构建 cli.ts 的镜像都必须同时拷 agent-node/package.json**，
+//    只拷 src/ 会 `error: Could not resolve: "../package.json"`。
+//    这条不是假设 —— test631 / test646 就是这么红的（它们当时都不在 CI 里，所以没人看见）。
 import agentNodePackage from "../package.json";
 const AGENT_NODE_VERSION: string = agentNodePackage.version;
 const PRIVATE_LOG_DIR = GROK_EXECUTION_MODE === "cli"

--- a/tests/test631-private-config-permissions/Dockerfile
+++ b/tests/test631-private-config-permissions/Dockerfile
@@ -2,6 +2,12 @@ FROM oven/bun:1.3.14
 WORKDIR /work
 COPY agent-network/src ./agent-network/src
 COPY agent-network/bin ./agent-network/bin
+# 🔴 必须和 agent-node/src 一起拷 —— `agent-node/src/cli.ts` 里有
+#     import agentNodePackage from "../package.json";   （#1019）
+#   bun build 在**构建期**内联它；只拷 src 会让 `bun build src/cli.ts` 直接失败：
+#     error: Could not resolve: "../package.json"
+#   本仓 16 个会构建 cli.ts 的镜像里，14 个本来就拷了它，这是补齐剩下的。
+COPY agent-node/package.json ./agent-node/package.json
 COPY agent-node/src ./agent-node/src
 COPY tests/test631-private-config-permissions/run.sh /run.sh
 ARG TEST631_SOURCE_COMMIT=unknown

--- a/tests/test646-config-node-id-precedence/Dockerfile
+++ b/tests/test646-config-node-id-precedence/Dockerfile
@@ -3,6 +3,12 @@ WORKDIR /workspace
 
 COPY agent-network/src ./agent-network/src
 COPY agent-network/bin ./agent-network/bin
+# 🔴 必须和 agent-node/src 一起拷 —— `agent-node/src/cli.ts` 里有
+#     import agentNodePackage from "../package.json";   （#1019）
+#   bun build 在**构建期**内联它；只拷 src 会让 `bun build src/cli.ts` 直接失败：
+#     error: Could not resolve: "../package.json"
+#   本仓 16 个会构建 cli.ts 的镜像里，14 个本来就拷了它，这是补齐剩下的。
+COPY agent-node/package.json ./agent-node/package.json
 COPY agent-node/src ./agent-node/src
 COPY tests/test646-config-node-id-precedence/run.sh /run.sh
 


### PR DESCRIPTION
## 🔴 这是我今晚自己造成的回归

`#1023`（我的 #1019 版本号上报修，合入 `347aed3b`）加了这一行：

    agent-node/src/cli.ts
      import agentNodePackage from "../package.json";

它引入了一个 **`src/` 之外的构建期依赖**。而两个测试镜像**只拷 `agent-node/src`**，
于是在 `origin/main` 上**构建直接失败**：

    error: Could not resolve: "../package.json"
        at /work/agent-node/src/cli.ts:1012:30

受影响的是 `tests/test631-private-config-permissions` 和 `tests/test646-config-node-id-precedence`。

**为什么没人发现：这两个套件的 CI 引用都是 0。**
我整晚在讲「一个长期不跑的套件，真绿和假绿输出逐字相同」——
这次它反过来咬我：**一个不跑的套件，连「它红了」都没人知道。**

## 修法

给这 2 个 Dockerfile 补 `COPY agent-node/package.json`，并在 `cli.ts` 那行 import 上方
写下给后来人的约束（含真实报错原文）：

    // 🔴 给写 Dockerfile 的人：**任何构建 cli.ts 的镜像都必须同时拷 agent-node/package.json**，
    //    只拷 src/ 会 `error: Could not resolve: "../package.json"`。
    //    这条不是假设 —— test631 / test646 就是这么红的（它们当时都不在 CI 里，所以没人看见）。

**为什么不是「去掉那个 import」**：本仓 16 个会构建 `cli.ts` 的镜像里 **14 个本来就拷了 package.json**，
补齐剩下 2 个是往多数派靠；而构建期内联的语义（「这份 dist 是从哪个版本构建的」）正是 #1019 要的。

## 顺手把这两个套件接进 CI

它们现在都是**真绿且各自带见证红**：

    test631  93 pass / 0 fail
             MUTATION_RED: private-mode rc=1
             MUTATION_RED: startup-repair rc=1
             RESULT: PASS
    test646  MUTATION_RED: env-first-precedence rc=1
             RESULT: PASS

test631 的判据里有一段**生产路径清单**，逐条点名每个直写路径，run.sh 原文写着理由：

    a new bypass cannot hide behind an aggregate green count.

新 job 名 `private config write boundary (Docker)` —— 它守的是**凭据落盘的私有写入边界**，
和 grok / hub 都不是一回事，**job 名必须说得出它管什么**。

## ⚠️ 一条写进 workflow 注释的坑（我踩过）

**test631 不能加 `--network none`。** 它有一段要真起节点（isolated HOME + unreachable Hub），
断网会让它 `rc=1` —— **那是跑法造成的红，不是套件缺陷**。
我第一次就是这么误判的，去掉之后它 `RESULT: PASS` 且两条见证红都跑了。

## 触发路径

`tests/test631-.../**`、`tests/test646-.../**`，**以及 `agent-node/src/cli.ts` 本身** ——
改被测对象时这两道门必须跑。**存在、挂上、会被触发是三件事。**

## 顺带记两个我自己的量错（都发生在查这个问题的过程里）

1. 我先报「**6 个**镜像受影响」—— 真数是 **2**。我数的是「拷了 src 却没拷 package.json」，
   而真正受影响的是「**会构建 cli.ts**」的那些。
2. 我一度「定位到失败的断言」是 `env 直写不再带 mode 0o600/wx` ——
   **那是我手工复现时 `eval` 吃掉了内层双引号**。照 run.sh 原样重跑，全部清单断言都过。
   **差点报出一个不存在的安全回归。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)