### PR TITLE
docs: shouldSkipMessage 行号 pin 改钉不可变 commit —— 它今晚漂了 8 次

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -196,7 +196,7 @@ if (["new_task", "broadcast"].includes(ev.type)) {
 |---|------|--------|------|
 | 1 | sendReply 用 send_message | agent-node | ✅ v1.4.2 |
 | 2 | SSE 只响应 new_task / broadcast | agent-node | ✅ [cli.ts:1102 `["new_task", "broadcast"].includes(ev.type)`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L1102)；`new_reply` 单独走日志记录 cli.ts:1106 |
-| 3 | 低价值消息过滤 | agent-node | ✅ v1.4.0；当前在 [cli.ts:4725 `shouldSkipMessage`](https://github.com/sleep2agi/agent-network/blob/main/agent-node/src/cli.ts#L4725) |
+| 3 | 低价值消息过滤 | agent-node | ✅ v1.4.0；截至 [`04f37800` 的 cli.ts:4725 `shouldSkipMessage`](https://github.com/sleep2agi/agent-network/blob/04f37800/agent-node/src/cli.ts#L4725) |
 | 4 | CLAUDE.md 不对 message 回复 | 各项目 CLAUDE.md | ✅ R195 chain 模板已加 |
 | 5 | developer_instructions 安静规则 | agent-node | ✅ v1.4.1 |
 


### PR DESCRIPTION
## 事实

    4639 → 4662 → 4669 → 4691 → 4695 → 4713 → 4725 → 4728

八个值，对应 #987 / #1004 / #1006 / #1010 / #1017 / #1007 / #1023 / #1039。
规律：**任何往 `agent-node/src/cli.ts` 第 4600 行以上插代码的 PR 都会让它漂**，
那个 PR 就要多跑一轮 CI。这是每次都付的成本，不是偶发。

## 为什么现在才能这么修

`#1024` 里我提过「改成不可变 SHA」，但**当时实测证明它不成立** ——
`check-doc-symbol-pins.py` 的正则捕获了 ref 却从没用过那个捕获组，
SHA 和 `main` 一视同仁，一律拿工作树解析。单变量 A/B 两边逐字相同。

`#1025` 让脚本认了 ref（SHA pin 用 `git show <ref>:<path>` 取那个版本判）。
**这条路是那之后才通的。** 所以本 PR 是 #1025 的下游，不是 #1024 那个被推翻的提案的重提。

## 改动

    - ✅ v1.4.0；当前在 [cli.ts:4725 `shouldSkipMessage`](.../blob/main/agent-node/src/cli.ts#L4725)
    + ✅ v1.4.0；截至 [`04f37800` 的 cli.ts:4725 `shouldSkipMessage`](.../blob/04f37800/agent-node/src/cli.ts#L4725)

**「当前在」也一起改成「截至 `<sha>`」** —— 这不是措辞洁癖：
钉到某个 commit 之后，「当前」这个词就不再被那个链接支持了。
只改链接不改这句话，等于用一个更稳的 pin 去支撑一句更弱的真话。

## 验证：两个方向都见证过，而且**判定数始终是 5**

    未漂时                                rc=0  扫到 15  判定 5  跳过 10  漂移 0
    往 cli.ts 插 3 行（过去 8 次红的场景）  rc=0  扫到 15  判定 5  跳过 10  漂移 0   ← 不再红
    把 pin 的行号改成 100（错的）          rc=1  扫到 15  判定 5  跳过 10  漂移 1   ← 门仍然咬得动
    还原                                  rc=0

**第三行是本 PR 最该看的**：如果这个改法让门不再对错误 pin 判红，那就是把对象移出了取集 ——
「让门变绿」而不是「把问题修好」。它没有：判定数一次都没掉，错的 pin 照样红。

`docs-site` 取集同时核过：扫到 28 / 判定 8 / 跳过 20 / 漂移 0（#1025 之后它才在取集里）。

## 一个操作上的插曲，记一下

我第一次建 worktree 时目录已存在，`git worktree add` 失败 —— **但后面的 `cd` 成功进了那个陈旧目录**，
于是我在一份完全不相干的树上跑了检查，得到 `cli.ts:836` 和 `rc=2`。
**命令失败了，后续步骤照跑。** 后来加了 `cd ... || exit` 并先打印 HEAD 核对才发现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)