### PR TITLE
ci(security): 接入 4 个「安全/凭据」类孤儿，并修掉其中一个的夹具

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -64,6 +64,10 @@ on:
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
+      - 'tests/test630-file-download-header-auth/**'
+      - 'tests/test634-windows-secret-guidance/**'
+      - 'tests/test623-feishu-scrub-health/**'
+      - 'tests/test30-v0.8-auth-deprecation/**'
       - 'deploy/hub/hub-daemon.sh'
   push:
     branches: [main]
@@ -119,6 +123,10 @@ on:
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
+      - 'tests/test630-file-download-header-auth/**'
+      - 'tests/test634-windows-secret-guidance/**'
+      - 'tests/test623-feishu-scrub-health/**'
+      - 'tests/test30-v0.8-auth-deprecation/**'
       - 'deploy/hub/hub-daemon.sh'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
@@ -585,3 +593,40 @@ jobs:
             -f tests/test646-config-node-id-precedence/Dockerfile .
           docker run --rm --network none -e ARTIFACT_DIR=/tmp/art \
             anet-test646-config-node-id-precedence
+  security-orphan-gates:
+    # 名字说得出它管什么：这四个套件守的是**鉴权 / 凭据下发 / 泄漏清洗**这一族。
+    name: auth + secret hygiene (Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      # 🔴 这一批**都不加 `--network none`** —— 基线就是这么跑的。
+      #   我在 test631 上踩过一次：断网让它 rc=1，那是**跑法造成的红**，不是套件缺陷。
+      #   不往 workflow 里写没验证过的变体。
+      - name: Build + run test630-file-download-header-auth
+        run: |
+          docker build --build-arg SOURCE_COMMIT="$GITHUB_SHA" -t anet-test630 \
+            -f tests/test630-file-download-header-auth/Dockerfile .
+          docker run --rm -e ARTIFACT_DIR=/tmp/art anet-test630
+
+      # 它的见证红做的正是 `sed 's/platform === "win32"/false/g'` ——
+      # 「把 win32 分支改成恒假会不会被发现」这件事由它守着。
+      - name: Build + run test634-windows-secret-guidance
+        run: |
+          docker build --build-arg SOURCE_COMMIT="$GITHUB_SHA" -t anet-test634 \
+            -f tests/test634-windows-secret-guidance/Dockerfile .
+          docker run --rm -e ARTIFACT_DIR=/tmp/art anet-test634
+
+      - name: Build + run test623-feishu-scrub-health
+        run: |
+          docker build --build-arg SOURCE_COMMIT="$GITHUB_SHA" -t anet-test623 \
+            -f tests/test623-feishu-scrub-health/Dockerfile .
+          docker run --rm -e ARTIFACT_DIR=/tmp/art anet-test623
+
+      # 它此前 rc=1，红在 Dockerfile 没拷 tests/lib/safe-rm.sh（本 PR 一并补上）。
+      - name: Build + run test30-v0.8-auth-deprecation
+        run: |
+          docker build --build-arg SOURCE_COMMIT="$GITHUB_SHA" -t anet-test30 \
+            -f tests/test30-v0.8-auth-deprecation/Dockerfile .
+          docker run --rm -e ARTIFACT_DIR=/tmp/art anet-test30

--- a/tests/test30-v0.8-auth-deprecation/Dockerfile
+++ b/tests/test30-v0.8-auth-deprecation/Dockerfile
@@ -5,6 +5,11 @@ RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app
+# 🔴 run.sh 第 10 行 source 的是 `$(dirname $0)/../lib/safe-rm.sh` ——
+#   在 WORKDIR /app 下解析成 `/lib/safe-rm.sh`。不拷它，套件起手就死：
+#     /app/run.sh: line 10: /app/../lib/safe-rm.sh: No such file or directory
+#   本仓 23 个套件的 Dockerfile 用的都是下面这一行，这是补齐它。
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 COPY tests/test30-v0.8-auth-deprecation/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 


### PR DESCRIPTION
## 起点：对 154 条孤儿做的风险分诊

    安全/凭据    12 条   ← 本 PR 处理其中 4 条
    单点/中枢    20 条   （test735 已在 #1038 接入）
    发布/供应链   5 条
    数据正确性    3 条
    其余        114 条

先跑基线再决定接不接 —— 这条今晚验证过：套件的**行数和覆盖无关**
（72 行的 test219 是 311 个测试，472 行的另一个一条断言都不执行）。

## 基线（`origin/main` = `5cf10ed6`，本地 Docker）

    test630-file-download-header-auth   rc=0  RESULT: PASS   20 个测试
    test634-windows-secret-guidance     rc=0  RESULT: PASS    3 个测试
    test623-feishu-scrub-health         rc=0  RESULT: PASS   10 个测试
    test30-v0.8-auth-deprecation        rc=1  ← 夹具问题，本 PR 修掉

## test30 的红：报错点名了两样，关键在后半句

    /app/run.sh: line 10: /app/../lib/safe-rm.sh: No such file or directory

「缺什么」是 `safe-rm.sh`，「**从哪找的**」是 `/app/../lib/` = `/lib/`。
而它的 Dockerfile **根本没拷这个文件**。

修法不用发明 —— **本仓 23 个套件的 Dockerfile 用的都是同一行**：

    COPY tests/lib/safe-rm.sh /lib/safe-rm.sh

补上之后实测 `PASS test30 v0.8 auth deprecation`。

## 为什么不套 known-failure 棘轮

四个现在都是**真绿**。棘轮是给「已经红、但必须先接进来才知道真绿假绿」的情况用的；
**给真绿的套件套棘轮，只会让它以后真变红时不红。**

## 🔴 一条写进 workflow 注释的坑

**这一批都不加 `--network none`** —— 基线就是这么跑的。
我在 test631 上踩过一次：断网让它 `rc=1`，**那是跑法造成的红，不是套件缺陷**。
不往 workflow 里写没验证过的变体。

## job 名

`auth + secret hygiene (Docker)` —— 今晚第三次因为「名字必须说得出它管什么」
而新开 job 而不是塞进已有的（前两次：hub daemon、private config write boundary）。

## 触发路径

四个套件目录都加进 `pull_request` / `push` 两处。
**存在、挂上、会被触发是三件事**，今晚栽过一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)