### PR TITLE
docs: 孤儿楼层 154 → 151（test631 / test646 / test735 已接进 CI）

### DIFF
--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -127,7 +127,6 @@ test624-task-cursor-pagination
 test625-explicit-env-crlf
 test629-mcp-schema-policy
 test630-file-download-header-auth
-test631-private-config-permissions
 test632-honest-sse-recovery
 test633-doctor-locale
 test634-windows-secret-guidance
@@ -135,7 +134,6 @@ test635-daemon-private-state
 test637-database-url-guard
 test638-server-aggregate-isolation
 test643-transient-hub-legacy-repair
-test646-config-node-id-precedence
 test647-rest-explicit-columns
 test648-probe-ip-pin
 test649-token-cli
@@ -162,7 +160,6 @@ test697-codex-default-model
 test698-atomic-peer-reply
 test7-config
 test702-primary-network
-test735-hub-daemon-rebuild
 test736-pm2-fleet-rebuild
 test8-runtime
 test9-permissions


### PR DESCRIPTION
门自己点名的三条：

    note: 3 个套件已不再是孤儿，把它们从 docs/test-suite-orphan-baseline.txt 里删掉，楼层只降不回填：
          test631-private-config-permissions, test646-config-node-id-precedence, test735-hub-daemon-rebuild

删的就是这三条，脚本里 `assert` 了差值 == 3，一条不多一条不少。

    改前  suites=198 registered=43 exempt=4 orphans=151 baseline=154 new=0   （note 提示要降）
    改后  suites=198 registered=43 exempt=4 orphans=151 baseline=151 new=0   rc=0，note 消失

## 降完之后验它还咬得动

**光把基线改小然后看到绿，证明不了门还活着。** 造一个新孤儿：

    $ mkdir tests/test997-floor-probe && ... && git add    # 门用 git ls-files，未跟踪的看不见
    1 个新增套件没有回答「谁会跑它」。   rc=1
    还原后 rc=0

## 今晚这条楼层的轨迹

    164 → 157 → 156 → 154 → 151

每一格都由门自己点名、脚本 assert 差值。**楼层只降不回填。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)