### PR TITLE
ci(hub): 接入 6 条真绿的 hub 类孤儿 —— build-arg 名从 Dockerfile 里读，不硬编码

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -64,6 +64,12 @@ on:
       - 'tests/test660-explicit-prod-db-optin/**'
       - 'tests/test661-explicit-bootstrap-db/**'
       - 'tests/test683-hub-lifecycle-watcher/**'
+      - 'tests/qa-hub-17-rename-canonicalization/**'
+      - 'tests/qa-hub-19-login-guard/**'
+      - 'tests/test635-daemon-private-state/**'
+      - 'tests/test643-transient-hub-legacy-repair/**'
+      - 'tests/test671-task-runtime-evidence-hub/**'
+      - 'tests/test688-owner-gated-schedule-hub/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -126,6 +132,12 @@ on:
       - 'tests/test660-explicit-prod-db-optin/**'
       - 'tests/test661-explicit-bootstrap-db/**'
       - 'tests/test683-hub-lifecycle-watcher/**'
+      - 'tests/qa-hub-17-rename-canonicalization/**'
+      - 'tests/qa-hub-19-login-guard/**'
+      - 'tests/test635-daemon-private-state/**'
+      - 'tests/test643-transient-hub-legacy-repair/**'
+      - 'tests/test671-task-runtime-evidence-hub/**'
+      - 'tests/test688-owner-gated-schedule-hub/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -625,3 +637,46 @@ jobs:
             -t anet-${{ matrix.suite }} \
             -f tests/${{ matrix.suite }}/Dockerfile .
           docker run --rm -e ARTIFACT_DIR=/tmp/art anet-${{ matrix.suite }}
+
+  hub-orphan-gates:
+    # 名字说得出它管什么：改名规范化 / 登录闸 / daemon 私有状态 / 遗留修复 / 任务证据 / owner 门控调度。
+    name: hub semantics + guards (Docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - qa-hub-17-rename-canonicalization
+          - qa-hub-19-login-guard
+          - test635-daemon-private-state
+          - test643-transient-hub-legacy-repair
+          - test671-task-runtime-evidence-hub
+          - test688-owner-gated-schedule-hub
+    steps:
+      - uses: actions/checkout@v4
+
+      # 🔴 **从 Dockerfile 里读 ARG 名，不硬编码**。这六个套件有四种形状：
+      #     qa-hub-17 / qa-hub-19        无 ARG
+      #     test643 / test688            SOURCE_COMMIT
+      #     test635                      TEST635_SOURCE_COMMIT
+      #     test671                      TEST671_SOURCE_COMMIT
+      #   我在 test638 上栽过一次：它的 ARG 叫 `TEST639_SOURCE_COMMIT`（目录 638、变量 639），
+      #   我按 `SOURCE_COMMIT` 传，套件报
+      #     FAIL: source provenance mismatch image=unset expected=unset
+      #   —— 那是**调用错了**，不是套件坏了。硬编码 ARG 名会让这类误用反复发生。
+      #
+      #   ⚠️ 不加 `--network none`：基线就是这么跑的，不写没验证过的变体
+      #      （test631 那次 rc=1 就是我自己加这个限制造成的）。
+      - name: Build + run ${{ matrix.suite }}
+        run: |
+          set -euo pipefail
+          DF="tests/${{ matrix.suite }}/Dockerfile"
+          BUILD_ARGS=()
+          while read -r name; do
+            [ -n "$name" ] && BUILD_ARGS+=(--build-arg "$name=$GITHUB_SHA")
+          done < <(grep -oE '^ARG [A-Z0-9_]+' "$DF" | awk '{print $2}')
+          echo "detected build args: ${BUILD_ARGS[*]:-(none)}"
+          docker build "${BUILD_ARGS[@]}" -t "anet-${{ matrix.suite }}" -f "$DF" .
+          docker run --rm -e EXPECTED_SOURCE_COMMIT="$GITHUB_SHA" \
+            -e ARTIFACT_DIR=/tmp/art "anet-${{ matrix.suite }}"


### PR DESCRIPTION
## 基线（`origin/main` = `a6770d70`，本地 Docker，均**未碰生产**）

    qa-hub-17-rename-canonicalization   rc=0  PASS
        结论行：rename canonicalization blocks stale report_status and
                redirects send_task/send_message/REST task
    qa-hub-19-login-guard               rc=0  PASS（10/min 限流 + 用户名锁定 + 锁定过期）
    test635-daemon-private-state        rc=0  PASS
        MUTATION_RED: preread-repair rc=1
        MUTATION_RED: writer-bypass  rc=1
    test643-transient-hub-legacy-repair rc=0  PASS
    test671-task-runtime-evidence-hub   rc=0  pass=14 fail=0
        MUTATION_RED: clear-task-lifetime-evidence-on-retry rc=1
        MUTATION_RED: unlink-scheduler-task-id             rc=1
        MUTATION_RED: unlink-rest-task-id                  rc=1
    test688-owner-gated-schedule-hub    rc=0  10 tests / 0 fail / 77 expect

六条都是**真绿**，其中两条共带 **5 条见证红**，所以直接做阻塞门，**不套 known-failure 棘轮**
（给真绿的套件套棘轮，只会让它以后真变红时不红）。

## 🔴 这个 PR 里唯一值得细看的一处：build-arg 名不硬编码

这六个套件有**四种形状**：

    qa-hub-17 / qa-hub-19        无 ARG
    test643 / test688            SOURCE_COMMIT
    test635                      TEST635_SOURCE_COMMIT
    test671                      TEST671_SOURCE_COMMIT

所以 step 里是**从 Dockerfile 读**：

    while read -r name; do
      [ -n "$name" ] && BUILD_ARGS+=(--build-arg "$name=$GITHUB_SHA")
    done < <(grep -oE '^ARG [A-Z0-9_]+' "$DF" | awk '{print $2}')
    echo "detected build args: ${BUILD_ARGS[*]:-(none)}"

**为什么不硬编码**：我在 `test638-server-aggregate-isolation` 上栽过一次 ——
它的 ARG 叫 **`TEST639_SOURCE_COMMIT`**（目录 638、变量 639），我按 `SOURCE_COMMIT` 传，套件报

    FAIL: source provenance mismatch image=unset expected=unset

**那是调用错了，不是套件坏了。** 硬编码会让这类误用反复发生，
而且它的报错长得像「套件有问题」—— 最容易把人引向修一个没坏的东西。

那行 `echo "detected build args"` 是故意留的：**下次再出这种事，日志里直接看得见传了什么。**

## ⚠️ 不加 `--network none`

基线就是这么跑的。我在 test631 上踩过：断网让它 `rc=1`，
**那是跑法造成的红，不是套件缺陷**。不往 workflow 里写没验证过的变体。

## 触发路径

六个套件目录都加进 `pull_request` / `push` 两处。
**存在、挂上、会被触发是三件事**，今晚栽过一次（#1017 改了 test225 的夹具，
27 个 check 全绿而 CI 从没执行过它）。

## 本地已验

那段 ARG 检测逻辑我拿**真 Dockerfile** 跑过一遍，四种形状都解析正确；
step 的 bash 片段也过了 `bash -n`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)