### PR TITLE
fix(test629): MCP 清单门看不见 `registerTool` 风格的注册 —— 41 → 46，并接进 CI

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -70,6 +70,7 @@ on:
       - 'tests/test643-transient-hub-legacy-repair/**'
       - 'tests/test671-task-runtime-evidence-hub/**'
       - 'tests/test688-owner-gated-schedule-hub/**'
+      - 'tests/test629-mcp-schema-policy/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -138,6 +139,7 @@ on:
       - 'tests/test643-transient-hub-legacy-repair/**'
       - 'tests/test671-task-runtime-evidence-hub/**'
       - 'tests/test688-owner-gated-schedule-hub/**'
+      - 'tests/test629-mcp-schema-policy/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -653,6 +655,7 @@ jobs:
           - test643-transient-hub-legacy-repair
           - test671-task-runtime-evidence-hub
           - test688-owner-gated-schedule-hub
+          - test629-mcp-schema-policy
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -121,7 +121,6 @@ test618-claude-vendor-env
 test621-test384-layer-isolation
 test624-task-cursor-pagination
 test625-explicit-env-crlf
-test629-mcp-schema-policy
 test632-honest-sse-recovery
 test633-doctor-locale
 test637-database-url-guard

--- a/tests/test629-mcp-schema-policy/probe.ts
+++ b/tests/test629-mcp-schema-policy/probe.ts
@@ -10,16 +10,16 @@ function assert(condition: unknown, message: string): asserts condition {
 const expectedTools = [
   "submit_skill", "list_skills", "get_skill", "review_skill",
   "report_status", "report_completion", "get_inbox", "ack_inbox",
-  "get_all_status", "get_session_status", "send_task", "send_message",
-  "send_reply", "send_ack", "retry_task", "get_task", "list_tasks",
+  "mark_tasks_runtime_submitted", "mark_tasks_consumed", "get_all_status", "get_session_status",
+  "send_task", "send_message", "send_reply", "send_peer_reply",
+  "send_ack", "retry_task", "get_task", "list_tasks",
   "cancel_task", "reassign_task", "broadcast", "get_completions",
-  "update_node_config", "get_config_update", "ack_config_update",
-  "restart_node", "list_host_supervisors", "create_node",
-  "get_create_request", "ack_create_request", "stop_node", "delete_node",
-  "get_stop_request", "ack_stop_request", "list_my_children",
-  "upsert_network_secret", "list_network_secrets", "upsert_provider",
-  "list_providers", "probe_provider_model", "get_probe_results",
-  "get_probe_request",
+  "update_node_config", "get_config_update", "ack_config_update", "restart_node",
+  "list_host_supervisors", "create_node", "get_create_request", "ack_create_request",
+  "stop_node", "delete_node", "get_stop_request", "ack_stop_request",
+  "list_my_children", "upsert_network_secret", "list_network_secrets", "upsert_provider",
+  "update_provider", "list_providers", "probe_provider_model", "get_probe_results",
+  "get_probe_request", "ack_probe_request",
 ];
 
 const toolsSource = readFileSync("src/tools.ts", "utf8");
@@ -27,11 +27,11 @@ const sdkVersion = JSON.parse(
   readFileSync("node_modules/@modelcontextprotocol/sdk/package.json", "utf8"),
 ).version as string;
 assert(/^1\.(?:29|30)\./.test(sdkVersion), `real MCP SDK version is recorded (${sdkVersion})`);
-const registeredTools = [...toolsSource.matchAll(/server\.tool\(\s*\n\s*"([^"]+)"/g)]
+const registeredTools = [...toolsSource.matchAll(/server\.(?:tool|registerTool)\(\s*\n\s*"([^"]+)"/g)]
   .map(match => match[1]);
 assert(
   JSON.stringify(registeredTools) === JSON.stringify(expectedTools),
-  "all 41 production MCP registrations are explicitly inventoried in source order",
+  `all ${expectedTools.length} production MCP registrations are explicitly inventoried in source order`,
 );
 
 // This is the production registration style today: a raw Zod shape passed to
@@ -87,6 +87,6 @@ assert(
   "telemetry wrapper preserves the current stripped handler contract",
 );
 
-console.log("inventory_count=41");
+console.log(`inventory_count=${expectedTools.length}`);
 console.log(`sdk_version=${sdkVersion}`);
 console.log("recommended_policy=observe-key-shape-then-strip");

--- a/tests/test629-mcp-schema-policy/run.sh
+++ b/tests/test629-mcp-schema-policy/run.sh
@@ -16,8 +16,25 @@ if [[ "$inventory_rc" -eq 0 ]]; then
   echo "MUTATION_FALSE_GREEN: unreviewed tool escaped the explicit inventory" >&2
   exit 1
 fi
-grep -Fq "all 41 production MCP registrations are explicitly inventoried" /tmp/test629-inventory-red.log
+grep -Fq "all 46 production MCP registrations are explicitly inventoried" /tmp/test629-inventory-red.log
 echo "MUTATION_RED: unreviewed-tool-inventory rc=${inventory_rc}"
+
+# 第二条变异：registerTool 风格。
+# 门原来的正则只认 `server.tool(`，所以 update_provider / ack_probe_request 这两个
+# 用 server.registerTool( 注册的生产工具**结构上永远看不见** —— 判据没问题，瞎在取集。
+# 上面那条变异只能证明 server.tool( 那条路还活着，证明不了这条。
+cp src/tools.ts /tmp/test629-tools.ts
+printf '\nserver.registerTool(\n  "mutation_registertool_style",\n' >> src/tools.ts
+set +e
+bun test629/probe.ts >/tmp/test629-registertool-red.log 2>&1
+registertool_rc=$?
+set -e
+cp /tmp/test629-tools.ts src/tools.ts
+if [[ "$registertool_rc" -eq 0 ]]; then
+  echo "MUTATION_FALSE_GREEN: registerTool-style registration is invisible to the inventory" >&2
+  exit 1
+fi
+echo "MUTATION_RED: registertool-style-inventory rc=${registertool_rc}"
 
 bun test629/probe.ts
 echo "RESULT: PASS"


### PR DESCRIPTION
关 #1045。但 issue 说的「41 → 44」只是这件事的一半。

## 真实状态是 41 → 46，而那道门**最多只能看到 44**

`tests/test629-mcp-schema-policy/probe.ts` 的取集正则是：

    /server\.tool\(\s*\n\s*"([^"]+)"/g

`server/src/tools.ts` 里有 **两个生产工具用 `server.registerTool(` 注册**，
这条正则**结构上永远匹配不到它们**：

    server/src/tools.ts:3761   update_provider
    server/src/tools.ts:4052   ack_probe_request
                               "Schema is STRICT whitelist (no error_message; v3 R3 LOCK). RFC-028."

所以门报的「漂了 3 条」是**判据在正确工作**的那一半；
另外 2 条是**取集的盲区** —— 无论 tools.ts 怎么变，这道门都不会提它们一个字。
`ack_probe_request` 还是明确写着 STRICT whitelist / v3 R3 LOCK 的那类。

    清单 expectedTools        41
    门原来的取集              44   （漂 3：mark_tasks_runtime_submitted / mark_tasks_consumed / send_peer_reply）
    实际生产注册              46   （+ update_provider / ack_probe_request）

## 改了什么

1. **取集**：`server\.(?:tool|registerTool)\(` —— 两种注册风格都收，按**文件位置**排序
   （断言比的是 source order，混进来之后顺序必须按文件位置而不是按风格分组）
2. **清单**：补齐 5 个。这 5 个我逐个看了描述才加的 ——
   清单的语义是「逐个审过」，光为了让门变绿而加名字，等于把门改成墙纸。
3. **写死的数字改成算出来的**：
   - `probe.ts:34` 断言消息 `all 41 …` → `` `all ${expectedTools.length} …` ``
   - `probe.ts:90` `inventory_count=41` → `` `inventory_count=${expectedTools.length}` ``
   - `run.sh:19` 那句 `grep -Fq "all 41 …"` —— **同一句话有三份副本**，
     漏掉 run.sh 那份的话，改完清单反而会红在 grep 上。

## 见证红 → 见证绿（都是 Docker 实跑，贴原文）

**A. origin/main（`e413a297`）上未修的样子** — rc=1：

    error: FAIL: all 41 production MCP registrations are explicitly inventoried in source order
          at assert (/workspace/server/test629/probe.ts:6:29)

**B. 本 PR** — rc=0：

    source_commit=e413a29702211e70ae623cb3a41e1d57e319ed77
    MUTATION_RED: unreviewed-tool-inventory     rc=1
    MUTATION_RED: registertool-style-inventory  rc=1     ← 新增
    inventory_count=46
    sdk_version=1.30.0
    RESULT: PASS

新增的第二条变异（`run.sh`）往 tools.ts 追加一个 **`server.registerTool(` 风格**的假注册。
不加这条的话，取集的修复**没有任何门保护** —— 原来那条变异用的是 `server.tool(` 风格，
只能证明那条路还活着，证明不了新加的这条。

## 一个副产品观察：基线已经红的变异测试，什么都证明不了

A 那次（未修的 main）**也打印了 `MUTATION_RED: unreviewed-tool-inventory rc=1`**。
但那个 rc=1 是因为 probe 本来就红（41≠44），**不是因为变异被检测到**。
变异测试要有意义，前提是**变异前那次是绿的**。这条在 main 上已经不成立一段时间了 ——
而它是孤儿，所以没人看见。

## 顺带

`test629-mcp-schema-policy` 接进 `hub-orphan-gates` matrix（第 7 条），
`pull_request` / `push` 两处触发路径都加了。孤儿地板 138 → 137：

    suites=198 registered=57 exempt=4 (oldest 0d) orphans=137 baseline=137 new=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)