### PR TITLE
fix(qa-anet-daemon-cmd): 等待条件不是目标状态 —— PASS=34 FAIL=8 → PASS=42 FAIL=0；接入 6 条；test380 标为探针

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -71,6 +71,12 @@ on:
       - 'tests/test671-task-runtime-evidence-hub/**'
       - 'tests/test688-owner-gated-schedule-hub/**'
       - 'tests/test629-mcp-schema-policy/**'
+      - 'tests/qa-anet-daemon-cmd/**'
+      - 'tests/qa-hub-16-rest-task-api/**'
+      - 'tests/qa-node-04-codex-app-server-reply-routing/**'
+      - 'tests/test599-skillhub/**'
+      - 'tests/test600-public-skillhub/**'
+      - 'tests/test659-codex-appserver-activity-timeout/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -140,6 +146,12 @@ on:
       - 'tests/test671-task-runtime-evidence-hub/**'
       - 'tests/test688-owner-gated-schedule-hub/**'
       - 'tests/test629-mcp-schema-policy/**'
+      - 'tests/qa-anet-daemon-cmd/**'
+      - 'tests/qa-hub-16-rest-task-api/**'
+      - 'tests/qa-node-04-codex-app-server-reply-routing/**'
+      - 'tests/test599-skillhub/**'
+      - 'tests/test600-public-skillhub/**'
+      - 'tests/test659-codex-appserver-activity-timeout/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -656,6 +668,12 @@ jobs:
           - test671-task-runtime-evidence-hub
           - test688-owner-gated-schedule-hub
           - test629-mcp-schema-policy
+          - qa-anet-daemon-cmd
+          - qa-hub-16-rest-task-api
+          - qa-node-04-codex-app-server-reply-routing
+          - test599-skillhub
+          - test600-public-skillhub
+          - test659-codex-appserver-activity-timeout
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -14,10 +14,7 @@
 
 qa-222-cross-host-attachments
 qa-517-mcp-write-scope
-qa-anet-daemon-cmd
-qa-hub-16-rest-task-api
 qa-hub-18-delivery-semantics
-qa-node-04-codex-app-server-reply-routing
 qa-rfc024-config-apply
 qa-rfc026-create-node
 qa-rfc027-stop-delete
@@ -78,7 +75,6 @@ test336-feishu-bridge-wire
 test34-playwright-discovery
 test344-ack-transport-zod
 test365-nonimage-read-attachments
-test380-daemon-telemetry-probe
 test383-thinking-only-fallback
 test384-opencode-local-package-e2e
 test386-opencode-agent-node-gate
@@ -100,9 +96,7 @@ test586-codex-successor-reconcile
 test587-codex-start-relative-timeout
 test588-codex-turn-clientid-rebind
 test596-goal-loop-docs
-test599-skillhub
 test6-networks
-test600-public-skillhub
 test602-scheduled-misfire
 test604-scheduled-task-edit
 test606-node-start-help
@@ -135,7 +129,6 @@ test653-batch-workdir
 test654-dashboard-managed-launch
 test656-claude-sdk-tool-aliases
 test657-claude-native-version-pin
-test659-codex-appserver-activity-timeout
 test673-claude-image-attachment-block
 test681-explicit-lifecycle
 test689-owner-schedule-agent

--- a/tests/qa-anet-daemon-cmd/run.sh
+++ b/tests/qa-anet-daemon-cmd/run.sh
@@ -139,7 +139,17 @@ done
 
 # CRITICAL: post-#337, hub /api/nodes returns role field extracted from config_snapshot.
 # This is the integration that unblocks the dashboard's role-based daemon discovery (#24).
-HUB_ROLE=$(curl -sS "$HUB_BASE/api/nodes?node_id=$NID_AFTER" -H "Authorization: Bearer $UTOK" | jq -r '.nodes[0].role')
+# 等待条件必须是**目标状态本身**，不能是它的前置条件。
+# register() 只建 nodes 行；role 住在 config_snapshot 里，由紧随其后**异步**发出的
+# reportStatus 补上（agent-node/src/cli.ts:6054-6061 的 RFC-024 注释写明了这个顺序）。
+# 原来只等「node_id 出现在 /api/nodes」就立刻读 .role，会落进这两者之间的窗口，
+# 读到 role=null —— 产品没坏，是断言早了一步。实测：只改这个循环，
+# PASS=34 FAIL=8 → PASS=42 FAIL=0。
+for _ in $(seq 1 30); do
+  HUB_ROLE=$(curl -sS "$HUB_BASE/api/nodes?node_id=$NID_AFTER" -H "Authorization: Bearer $UTOK" | jq -r '.nodes[0].role')
+  [[ "$HUB_ROLE" == "host_supervisor" ]] && break
+  sleep 1
+done
 [[ "$HUB_ROLE" == "host_supervisor" ]] && ok "hub /api/nodes returns role=host_supervisor (post-#337 integration真)" || bad "hub role='$HUB_ROLE' expected host_supervisor"
 
 # Dashboard-style discovery: rows.find(r => r.role === 'host_supervisor') succeeds

--- a/tests/test380-daemon-telemetry-probe/NOT-IN-CI.md
+++ b/tests/test380-daemon-telemetry-probe/NOT-IN-CI.md
@@ -1,0 +1,31 @@
+# test380-daemon-telemetry-probe 不进 CI
+
+Verified: 2026-08-19
+Revisit-when: 有人给它加了「判据」——即某个观测为坏时 `exit 1`，而不只是写进报告。
+
+## 为什么
+
+**它是诊断探针，不是门。** 它的发现全部通过 `raw` 写进 `$REPORT`，
+**退出码不认这些发现**；只有 setup 失败（hub /health、register、network、mint token）
+才 `exit 1`。所以把它当阻塞门接进 CI 的话，**它无论探到什么都是绿的**。
+
+原文（`tests/test380-daemon-telemetry-probe/run.sh:258-263`）：
+
+    if [[ "$SNAPSHOT_SET" == "NO" ]]; then
+      raw ""
+      raw "  ▶ nodes.config_snapshot is unset even after 8s wait."
+      raw "    Immediate reportStatus() at cli.ts:4095 either failed silently or hasn't fired yet."
+      raw "    This directly explains list_host_supervisors returning 0 → create-node wizard 'hub 400'."
+    fi
+
+`raw` 之后没有 `exit`。这一段是**条件文案**，不是观测结果 ——
+2026-08-19 在 `e413a297` 上实跑，走的是另一个分支：
+
+    nodes.config_snapshot = YES
+      "role": "host_supervisor",
+    ▶ heartbeat reached hub and cpu/mem are present → register()'s host: payload lands.
+
+（顺带：文案里的 `cli.ts:4095` 已经漂了，今天那段在 `agent-node/src/cli.ts:6054-6061`。）
+
+它作为**排障工具**是有价值的，值班时手动跑一次能一次性拿到
+/proc、心跳、host 遥测列、config_snapshot 四层读数。但那是工具，不是门。


### PR DESCRIPTION
## 一、`qa-anet-daemon-cmd` 的 8 条 FAIL 是**一个根因**

    ✗ hub role='null' expected host_supervisor      ← 根因
    ✗ dashboard discovery would still fail          ┐
    ✗ MCP list_host_supervisors failed: {"ok":true,"daemons":[],"count":0}
    ✗ daemons[0].alias missing                      ├ 全是它的下游
    ✗ runtimes_supported missing:                   │
    ✗ alert_level missing/bad: null                 │
    ✗ REST endpoint failed: {"ok":true,"daemons":[],"count":0}
    ✗ REST keys missing runtimes_supported:         ┘

`FAIL=8` 夸大了实际问题数 —— 一件事在结果里占了八行。

### 产品没坏，是断言早了一步

`register()` 只建 `nodes` 行；`role` 住在 `config_snapshot` 里，
由**紧随其后异步发出**的 `reportStatus` 补上。原文
（`agent-node/src/cli.ts:6054-6061`）：

    // RFC-024 — fire a reportStatus immediately on startup so the
    // config_snapshot reaches the hub right after register(), instead of
    // waiting up to 3 minutes for the periodic timer below to fire.
    reportStatus("idle").catch(...)

而套件的等待循环只等「`node_id` 出现在 `/api/nodes`」，然后**立刻**读 `.role` ——
**等待条件是目标状态的前置条件，不是目标状态本身**，于是落进两者之间的窗口。

### 实验能自我证伪

只把那个循环改成轮询 `role == host_supervisor`（**判据一个字没放松**；
产品真坏的话会轮询 30 秒超时、依然红）：

    PASS=34 FAIL=8   →   PASS=42 FAIL=0   rc=0
    ✓ hub /api/nodes returns role=host_supervisor (post-#337 integration真)

### 独立佐证：`test380` 实测 `config_snapshot = YES`

在 `e413a297` 上跑 `test380-daemon-telemetry-probe`：

    nodes.config_snapshot = YES
      "role": "host_supervisor",
    ▶ heartbeat reached hub and cpu/mem are present → register()'s host: payload lands.

产品这条链路是通的。

## 二、`test380` **不接 CI** —— 它是探针，不是门

新增 `tests/test380-daemon-telemetry-probe/NOT-IN-CI.md`。

它的发现全部通过 `raw` 写进 `$REPORT`，**退出码不认这些发现**；
只有 setup 失败（`/health`、register、network、mint）才 `exit 1`。
**接进 CI 当阻塞门的话，它无论探到什么都是绿的。**

⚠️ 我自己在这里差点栽一次：`run.sh:258-263` 有一段

    ▶ nodes.config_snapshot is unset even after 8s wait.
      Immediate reportStatus() at cli.ts:4095 either failed silently or hasn't fired yet.
      This directly explains list_host_supervisors returning 0 → create-node wizard 'hub 400'.

我一度把它当成 test380 的**观测结果**，据此认为「等了 8 秒还没有，不像竞态」。
但那是 `if [[ "$SNAPSHOT_SET" == "NO" ]]` 里的**条件文案**，
今天实跑走的是另一个分支（上面的 `= YES`）—— **它根本没执行**。
一段没被执行的 `raw` 和一条真实读数，在日志里长得一模一样。

（那段文案里的 `cli.ts:4095` 也已经漂了，今天在 `agent-node/src/cli.ts:6054-6061`。）

## 三、接入 6 条真绿

全部在一棵**全程不动**的 worktree（HEAD=`e413a297`）里复跑过，
带时间戳、与更早那批被我弄脏的结果逐条比对一致：

    qa-anet-daemon-cmd                        PASS=42 FAIL=0（本 PR 修好后）
    qa-hub-16-rest-task-api                   rc=0  PASS
    qa-node-04-codex-app-server-reply-routing rc=0  PASS
    test599-skillhub                          rc=0  RESULT: PASS + 见证红 ×2
    test600-public-skillhub                   rc=0  RESULT: PASS (12 checks)
    test659-codex-appserver-activity-timeout  rc=0  pass=6 fail=0 + 见证红 ×3

`hub-orphan-gates` matrix 7 → 13 条，`pull_request` / `push` 两处触发路径都加。

孤儿地板 **137 → 130**（test380 从孤儿变豁免，exempt 4 → 5）：

    suites=198 registered=63 exempt=5 (oldest 0d) orphans=130 baseline=130 new=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)