### PR TITLE
ci: 接入第三批 7 条自带见证红的套件 —— 孤儿 111 → 104（test647 因 #1051 不接）

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -96,6 +96,10 @@ on:
       - 'tests/test613-codex-dead-endpoint/**'
       - 'tests/test614-rest-single-network/**'
       - 'tests/test615-network-name/**'
+      - 'tests/test617-feishu-ws-readiness/**'
+      - 'tests/test618-claude-vendor-env/**'
+      - 'tests/test621-test384-layer-isolation/**'
+      - 'tests/test624-task-cursor-pagination/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -190,6 +194,10 @@ on:
       - 'tests/test613-codex-dead-endpoint/**'
       - 'tests/test614-rest-single-network/**'
       - 'tests/test615-network-name/**'
+      - 'tests/test617-feishu-ws-readiness/**'
+      - 'tests/test618-claude-vendor-env/**'
+      - 'tests/test621-test384-layer-isolation/**'
+      - 'tests/test624-task-cursor-pagination/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -731,6 +739,10 @@ jobs:
           - test613-codex-dead-endpoint
           - test614-rest-single-network
           - test615-network-name
+          - test617-feishu-ws-readiness
+          - test618-claude-vendor-env
+          - test621-test384-layer-isolation
+          - test624-task-cursor-pagination
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -100,6 +100,9 @@ on:
       - 'tests/test618-claude-vendor-env/**'
       - 'tests/test621-test384-layer-isolation/**'
       - 'tests/test624-task-cursor-pagination/**'
+      - 'tests/test625-explicit-env-crlf/**'
+      - 'tests/test632-honest-sse-recovery/**'
+      - 'tests/test633-doctor-locale/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -198,6 +201,9 @@ on:
       - 'tests/test618-claude-vendor-env/**'
       - 'tests/test621-test384-layer-isolation/**'
       - 'tests/test624-task-cursor-pagination/**'
+      - 'tests/test625-explicit-env-crlf/**'
+      - 'tests/test632-honest-sse-recovery/**'
+      - 'tests/test633-doctor-locale/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -743,6 +749,9 @@ jobs:
           - test618-claude-vendor-env
           - test621-test384-layer-isolation
           - test624-task-cursor-pagination
+          - test625-explicit-env-crlf
+          - test632-honest-sse-recovery
+          - test633-doctor-locale
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -94,9 +94,6 @@ test596-goal-loop-docs
 test6-networks
 test608-claude-cli-dependency
 test616-feishu-docker-bootstrap
-test625-explicit-env-crlf
-test632-honest-sse-recovery
-test633-doctor-locale
 test638-server-aggregate-isolation
 test647-rest-explicit-columns
 test648-probe-ip-pin

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -94,10 +94,6 @@ test596-goal-loop-docs
 test6-networks
 test608-claude-cli-dependency
 test616-feishu-docker-bootstrap
-test617-feishu-ws-readiness
-test618-claude-vendor-env
-test621-test384-layer-isolation
-test624-task-cursor-pagination
 test625-explicit-env-crlf
 test632-honest-sse-recovery
 test633-doctor-locale


### PR DESCRIPTION
全部在钉住的独立 worktree 里**实跑**过（`TREE_HEAD=375876a4` / `7174ef7e`），逐条贴原文。

    test617-feishu-ws-readiness      ready-authority / reconnect-health / worker-nonzero-exit
    test618-claude-vendor-env        create-vendor-env-wiring
    test621-test384-layer-isolation  hold-open-layer-cancel
    test624-task-cursor-pagination   ×5（same-second-cursor / invalid-cursor / compound-validation …）
    test625-explicit-env-crlf        dotenv-writer-crlf（injected dotenv line witnessed）
    test632-honest-sse-recovery      duplicate-start-guidance / production-hook-bypass
    test633-doctor-locale            locale-detection / doctor-wiring

## test647 **不接** —— 它在 main 上是真红，已开 #1051

`test647-rest-explicit-columns` 在 `7174ef7e` 上 rc=1。**先排除了是我自己造成的**：
我这批跑的中途切过一次树，传进去的 `EXPECTED_SOURCE_COMMIT` 和树对不上，
所以用**一致的 provenance 重跑了一次** —— 仍然 rc=1，不是我的问题。

真因（`bash -x` 定位）：L3b 的变异打在 `server/src/auth.ts:551` 的 `getUserAllNetworks()`，
而 L2 打的端点走的是 `server/src/server.ts:1140` 里内联的 `SELECT ${NETWORK_REST_SELECT} FROM networks`。
**被测端点根本不调那个函数，所以变异恒绿。** 细节和排除过程都在 #1051。

红的套件不接进 CI —— 接了要么让 main 红，要么得给它套棘轮，
而**给一个「判据本身失效」的套件套棘轮，等于把问题固化下来**。

## 孤儿地板 111 → 104

名单由门自己算，删行时断言「删掉行数 == improved 条数」：

    suites=198 registered=89 exempt=5 (oldest 0d) orphans=104 baseline=104 new=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)