### PR TITLE
ci: 接入 3 条实跑确认的套件（各带 4/3/5 条见证红）—— 孤儿 104 → 101

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -103,6 +103,9 @@ on:
       - 'tests/test625-explicit-env-crlf/**'
       - 'tests/test632-honest-sse-recovery/**'
       - 'tests/test633-doctor-locale/**'
+      - 'tests/test166-task-diagnostics/**'
+      - 'tests/test365-nonimage-read-attachments/**'
+      - 'tests/test585-codex-runtime-singleflight/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -204,6 +207,9 @@ on:
       - 'tests/test625-explicit-env-crlf/**'
       - 'tests/test632-honest-sse-recovery/**'
       - 'tests/test633-doctor-locale/**'
+      - 'tests/test166-task-diagnostics/**'
+      - 'tests/test365-nonimage-read-attachments/**'
+      - 'tests/test585-codex-runtime-singleflight/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -752,6 +758,9 @@ jobs:
           - test625-explicit-env-crlf
           - test632-honest-sse-recovery
           - test633-doctor-locale
+          - test166-task-diagnostics
+          - test365-nonimage-read-attachments
+          - test585-codex-runtime-singleflight
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -35,7 +35,6 @@ test13-multi-channel
 test14-agent-node
 test15-telegram-mock
 test16-channel-plugin
-test166-task-diagnostics
 test17-user-journey
 test18-error-paths
 test185-external-schedules
@@ -72,7 +71,6 @@ test31-claude-code-cli-resume
 test313-test-all-v3-fixtures
 test32-agent-network-shell-spawn-audit
 test34-playwright-discovery
-test365-nonimage-read-attachments
 test383-thinking-only-fallback
 test384-opencode-local-package-e2e
 test386-opencode-agent-node-gate
@@ -86,7 +84,6 @@ test573-codex-turn-reconcile
 test575-opencode-reply-ownership
 test583-dashboard-chat-idempotency
 test584-dashboard-codex-delivery
-test585-codex-runtime-singleflight
 test586-codex-successor-reconcile
 test587-codex-start-relative-timeout
 test588-codex-turn-clientid-rebind


### PR DESCRIPTION
在钉住的独立 worktree（`d0b9684d`）里实跑确认，逐条贴原文。

    test166-task-diagnostics            见证红 ×4
      mutation=terminal-precedence rc=1 witnessed-red
      mutation=runtime-consumed-precedence rc=1 witnessed-red
      mutation=no-sse-gate rc=1 witnessed-red
      mutation=cross-network-sse rc=1 witnessed-red
      10 pass / 0 fail / 22 expect() · RESULT: PASS

    test365-nonimage-read-attachments   见证红 ×3
      WITNESSED-RED channel-extension-allowlist-weakened rc=1
      WITNESSED-RED runtime-extension-allowlist-weakened rc=1
      WITNESSED-RED sender-path-enters-read-prompt rc=1
      MUTATION RESULT: PASS=6 FAIL=0 · RESULT: PASS

    test585-codex-runtime-singleflight  见证红 ×5
      WITNESSED-RED: bypass_singleflight / sticky_rejected_open / bypass_cli_wiring
                     publish_dead_session / stale_exit_clears_new
      41 pass / 0 fail / 110 expect() · BUILD: PASS · RESULT: PASS

## ⚠️ 这三条差点被我自己的读数漏掉或误判

我的批处理脚本有一列「见证红」计数，它 grep 的是几种固定写法。这三条命中的是**新写法**：

    test166   mutation=<name> rc=1 witnessed-red      连字符，且 `mutation=` 在前
    test365   WITNESSED-RED <name> rc=1               全大写连字符，无冒号
    test585   WITNESSED-RED: <name>                   全大写连字符，带冒号

计数器对这三条**全部显示 0**。加起来今晚见证红一共出现了 **8 种写法**。

**我不再往计数器里加写法了** —— 每加一种只是把盲区平移到下一种。
改成在计数行之后**无条件打印一段完全不过滤的原始尾部**，靠「计数和原文对不上」来发现问题。

## 但「不过滤的尾部」也只是一个窗口，不是答案

test585 的不过滤尾部里有一行 ` 1 fail`，我一度以为抓到了一个**吞掉失败的假绿**。
读完整输出才知道：**那 5 处 `1 fail` 全部出自变异运行** ——
每条 `WITNESSED-RED: <name>` 后面跟的就是「被改坏之后应该挂」的那一次。
真正的运行是第 50-53 行的 `41 pass / 0 fail`。

⇒ 正确的做法是**两步**：不过滤的尾部负责**提示异常**，读全文负责**定性**。
只看尾部那几行，会把变异里预期的失败读成缺陷。

## 孤儿地板 104 → 101

名单由门自己算，删行时断言「删掉行数 == improved 条数」：

    suites=198 registered=92 exempt=5 (oldest 0d) orphans=101 baseline=101 new=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)