### PR TITLE
ci: 接入第六批 4 条实跑确认的套件 —— 孤儿 101 → 97

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -106,6 +106,9 @@ on:
       - 'tests/test166-task-diagnostics/**'
       - 'tests/test365-nonimage-read-attachments/**'
       - 'tests/test585-codex-runtime-singleflight/**'
+      - 'tests/test586-codex-successor-reconcile/**'
+      - 'tests/test596-goal-loop-docs/**'
+      - 'tests/test638-server-aggregate-isolation/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -210,6 +213,9 @@ on:
       - 'tests/test166-task-diagnostics/**'
       - 'tests/test365-nonimage-read-attachments/**'
       - 'tests/test585-codex-runtime-singleflight/**'
+      - 'tests/test586-codex-successor-reconcile/**'
+      - 'tests/test596-goal-loop-docs/**'
+      - 'tests/test638-server-aggregate-isolation/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -761,6 +767,9 @@ jobs:
           - test166-task-diagnostics
           - test365-nonimage-read-attachments
           - test585-codex-runtime-singleflight
+          - test586-codex-successor-reconcile
+          - test596-goal-loop-docs
+          - test638-server-aggregate-isolation
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -109,6 +109,7 @@ on:
       - 'tests/test586-codex-successor-reconcile/**'
       - 'tests/test596-goal-loop-docs/**'
       - 'tests/test638-server-aggregate-isolation/**'
+      - 'tests/test681-explicit-lifecycle/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -216,6 +217,7 @@ on:
       - 'tests/test586-codex-successor-reconcile/**'
       - 'tests/test596-goal-loop-docs/**'
       - 'tests/test638-server-aggregate-isolation/**'
+      - 'tests/test681-explicit-lifecycle/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -770,6 +772,7 @@ jobs:
           - test586-codex-successor-reconcile
           - test596-goal-loop-docs
           - test638-server-aggregate-isolation
+          - test681-explicit-lifecycle
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -98,7 +98,6 @@ test654-dashboard-managed-launch
 test656-claude-sdk-tool-aliases
 test657-claude-native-version-pin
 test673-claude-image-attachment-block
-test681-explicit-lifecycle
 test689-owner-schedule-agent
 test690-scheduled-run-terminal
 test693-agent-local-upload

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -84,14 +84,11 @@ test573-codex-turn-reconcile
 test575-opencode-reply-ownership
 test583-dashboard-chat-idempotency
 test584-dashboard-codex-delivery
-test586-codex-successor-reconcile
 test587-codex-start-relative-timeout
 test588-codex-turn-clientid-rebind
-test596-goal-loop-docs
 test6-networks
 test608-claude-cli-dependency
 test616-feishu-docker-bootstrap
-test638-server-aggregate-isolation
 test647-rest-explicit-columns
 test648-probe-ip-pin
 test650-anet-attach


### PR DESCRIPTION
在钉住的独立 worktree 里实跑确认，逐条贴原文。

    test586-codex-successor-reconcile   见证红 ×4（由控制流保证，见下）
    test596-goal-loop-docs              PASS: witnessed-red all-runtime Dashboard pass-through
                                        docs mutation rc=1
    test638-server-aggregate-isolation  L6: deletion of per-file DB split is witnessed-red
                                        run1_db_maps=72 · slug_collision_rc=2
                                        mutation_unique_db_paths=1 · RESULT: PASS
    test681-explicit-lifecycle          WITNESSED_RED timeout-default rc=1
                                        WITNESSED_RED poll-default rc=1
                                        WITNESSED_RED stale-30-default rc=1
                                        WITNESSED_RED stale-60-default rc=1

## test586 的 4 条见证红是**推出来的，不是看出来的**

它的输出尾部有一行 ` 1 fail`，同时又打 `RESULT: PASS`。
这个形状值得停一下 —— 我先怀疑是「吞掉失败的假绿」。**没有再跑一次**，而是读控制流：

    tests/test586-codex-successor-reconcile/run.sh
      15  for mutation_name in aggregate_active_shortcut missing_turn_fail_open \
                               wrong_turn_attribution drain_during_successor; do
      19    if bun test ./src/runtime/codex-app-server-bridge.test.ts >"$mutation" 2>&1; then
      22      echo "RESULT: FAIL mutation-survived $mutation_name"; exit 1
      25    echo "WITNESSED-RED: $mutation_name"
      26    tail -18 "$mutation"        ← ` 1 fail` 是这里打出来的：变异运行的日志
      36  echo "RESULT: PASS"

**变异之后测试仍然通过 ⇒ exit 1。** 所以第 36 行只有 4 条变异全部死掉才走得到。
⇒ `rc=0` + `RESULT: PASS` **在逻辑上蕴含 4 条见证红**。

读输出只能说「这次是这样」；读控制流能说「这一行为什么必然存在，以及它不存在时会发生什么」。

## 顺带记一个数：见证红的写法已经见到 9 种

    MUTATION_RED: <name> rc=1
    MUTATION_RED: <name> rc=3 rebound-hit=1
    PASS mutation <name> witnessed red
    PASS witnessed red — <描述>
    mutation=<name> rc=1 witnessed-red
    WITNESSED-RED <name> rc=1
    WITNESSED-RED: <name>
    WITNESSED_RED <name> rc=1            ← test681（本 PR）
    MUTATION RESULT: PASS=6 FAIL=0

跑批脚本里那个「见证红=N」的计数器对其中好几种显示 **0**。
**已经不再往里加写法** —— 每加一种只是把盲区挪到下一种。
现在的做法是：计数行之后**无条件打印一段不过滤的原始尾部**，
靠「计数和原文对不上」发现问题，再读全文或读控制流定性。

## test638 顺带验证了一个已经修掉的坑

它的 ARG 叫 **`TEST639_SOURCE_COMMIT`**（目录 638、变量 639）。
早些时候我按 `SOURCE_COMMIT` 传，套件报 provenance mismatch，我差点当成套件缺陷。
现在跑批脚本从 Dockerfile 自动读 ARG 名，这次一次就过 —— **不再依赖记性**。

## 孤儿地板 101 → 97

名单由门自己算（`improved = baseline - orphans`），删行时断言「删掉行数 == improved 条数」：

    suites=198 registered=96 exempt=5 (oldest 0d) orphans=97 baseline=97 new=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
