### PR TITLE
ci: 接入 4 条实跑确认的套件（见证红 9/6/6/26 条）—— 孤儿 97 → 93

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -110,6 +110,10 @@ on:
       - 'tests/test596-goal-loop-docs/**'
       - 'tests/test638-server-aggregate-isolation/**'
       - 'tests/test681-explicit-lifecycle/**'
+      - 'tests/test689-owner-schedule-agent/**'
+      - 'tests/test690-scheduled-run-terminal/**'
+      - 'tests/test693-agent-local-upload/**'
+      - 'tests/test697-codex-default-model/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -218,6 +222,10 @@ on:
       - 'tests/test596-goal-loop-docs/**'
       - 'tests/test638-server-aggregate-isolation/**'
       - 'tests/test681-explicit-lifecycle/**'
+      - 'tests/test689-owner-schedule-agent/**'
+      - 'tests/test690-scheduled-run-terminal/**'
+      - 'tests/test693-agent-local-upload/**'
+      - 'tests/test697-codex-default-model/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
       - 'agent-node/src/cli.ts'
@@ -773,6 +781,10 @@ jobs:
           - test596-goal-loop-docs
           - test638-server-aggregate-isolation
           - test681-explicit-lifecycle
+          - test689-owner-schedule-agent
+          - test690-scheduled-run-terminal
+          - test693-agent-local-upload
+          - test697-codex-default-model
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -98,11 +98,7 @@ test654-dashboard-managed-launch
 test656-claude-sdk-tool-aliases
 test657-claude-native-version-pin
 test673-claude-image-attachment-block
-test689-owner-schedule-agent
-test690-scheduled-run-terminal
-test693-agent-local-upload
 test696-human-low-value-reply
-test697-codex-default-model
 test698-atomic-peer-reply
 test7-config
 test702-primary-network


### PR DESCRIPTION
在钉住、建好后不做任何 git 操作的独立 worktree 里实跑确认。

    test689-owner-schedule-agent    见证红 ×9   （树 d2dd7d1a）
      witnessed-red: cron-alias-gate / process-level-gate / shared-parser-drift
      18 pass 0 fail 84 expect()

    test690-scheduled-run-terminal  见证红 ×6   （树 d2dd7d1a）
      MUTATION_RED: exact-task-binding rc=1
      L4 witnessed-red: exact network binding is load-bearing
      MUTATION_RED: exact-network-binding rc=1
      9 pass 0 fail 28 expect()

    test693-agent-local-upload      见证红 ×6   （树 29f64b65）
      witnessed-red name=nul-guard-removed rc=1
      witnessed-red name=same-fd-toctou-regressed rc=1
      witnessed-red name=bounded-read-slurp-regressed rc=1
      download_ok 70 · cross_network_denied 404 · L2_PASS

    test697-codex-default-model     见证红 ×26  （树 29f64b65）
      MUTATION_RED explicit-runtime-model-ignored     layer=L7e rc=1
      MUTATION_RED persisted-runtime-model-ignored    layer=L7e rc=1
      MUTATION_RED environment-runtime-model-ignored  layer=L7f rc=1
      MUTATION_RED non-codex-runtime-default-injected layer=L7g rc=1

## 见证红的写法计到第十种了

    witnessed-red name=<X> rc=1        ← test693，第 10 种
    MUTATION_RED <X> layer=L7e rc=1    ← test697，带 layer 字段

跑批脚本那个「见证红=N」计数器对前九种里的好几种显示 **0**。
**早就不再往里加写法** —— 现在的做法是：计数行之后**无条件打印一段不过滤的原始尾部**，
靠「计数和原文对不上」发现问题，再读全文或读控制流定性。

## 孤儿地板 97 → 93

名单由门自己算（`improved = baseline - orphans`），删行时断言「删掉行数 == improved 条数」：

    suites=198 registered=100 exempt=5 (oldest 0d) orphans=93 baseline=93 new=0

注册数破百。

🤖 Generated with [Claude Code](https://claude.com/claude-code)