### PR TITLE
fix(ci): 孤儿门的 suites() 只认 run.sh —— 7 个套件从未被它见过（地板 91 → 97 是补债，不是退步）

### DIFF
--- a/.github/scripts/check-test-suite-registration.py
+++ b/.github/scripts/check-test-suite-registration.py
@@ -92,11 +92,29 @@ def read(p: pathlib.Path) -> str:
         return ""
 
 
-def suites() -> list[str]:
-    if not TESTS.is_dir():
+def is_suite_dir(d: pathlib.Path) -> bool:
+    """一个目录算不算「测试套件」。
+
+    🔴 2026-08-19：这里原本只认 `run.sh`，于是 7 个真套件**从来没被这道门见过** ——
+    既不会被报成孤儿，也不在打印的 `suites=N` 分母里。它们的入口分别是
+    `Dockerfile`（qa-ut-0*/qa-*-docs）、`Dockerfile.*`+`docker-compose.yml`
+    （test380-gateway-topology-probe）、`run-all.sh`（test-rename-identity，另有 Dockerfile）。
+
+    **盲区在取集，不在判据** —— classify() 一直是对的，只是它拿不到这些名字。
+    `helpers` / `lib` / `scripts` 三个支持目录三种入口都没有，仍然被排除。
+    """
+    if (d / "run.sh").exists() or (d / "docker-compose.yml").exists():
+        return True
+    return any(f.is_file() and (f.name == "Dockerfile" or f.name.startswith("Dockerfile."))
+               for f in d.iterdir())
+
+
+def suites(tests_dir: pathlib.Path | None = None) -> list[str]:
+    # tests_dir 可注入：selftest 要能对**取集本身**做夹具，见 selftest()。
+    root = TESTS if tests_dir is None else tests_dir
+    if not root.is_dir():
         return []
-    return sorted(d.name for d in TESTS.iterdir()
-                  if d.is_dir() and (d / "run.sh").exists())
+    return sorted(d.name for d in root.iterdir() if d.is_dir() and is_suite_dir(d))
 
 
 def registration_blob() -> str:
@@ -217,7 +235,14 @@ def main() -> int:
 
 
 def selftest() -> int:
-    """判据自检。绿和「取集坏了」打印出来是两码事，这里把两者都钉住。"""
+    """判据自检 + **取集自检**。
+
+    🔴 2026-08-19：这句 docstring 原本就写着「两者都钉住」，但代码只钉了判据 ——
+    下面的 classify 用例把名字**直接喂进去**，从不经过 suites()；而且每个夹具都写了
+    run.sh，所以即便经过也测不出「只认 run.sh」这个盲区。
+    **一句没兑现的承诺，长在最能阻止别人复查的位置上。**
+    真实后果：7 个套件从来没被这道门见过（issue #1064）。
+    """
     import tempfile
     cases = [
         # (目录名, 是否出现在注册表, 是否有 NOT-IN-CI.md, 是否在基线, 期望判为新孤儿)
@@ -241,6 +266,28 @@ def selftest() -> int:
             if got != want:
                 bad += 1
                 print(f"SELFTEST 失配: {name} got={got} want={want}")
+    # ── 取集自检：夹具走 suites()，不直接喂名字 ──────────────────
+    # 每条只放一种入口文件，钉住「哪些形状算套件」。
+    collect_cases = [
+        ("c-run",       ["run.sh"],                              True),
+        ("c-docker",    ["Dockerfile"],                          True),   # qa-ut-0* / qa-*-docs
+        ("c-compose",   ["docker-compose.yml"],                  True),   # test383
+        ("c-dockerdot", ["Dockerfile.harness"],                  True),   # test380-gateway
+        ("c-support",   ["helper.sh", "README.md"],              False),  # lib / scripts / helpers
+    ]
+    with tempfile.TemporaryDirectory() as td2:
+        root = pathlib.Path(td2)
+        for name, files, _ in collect_cases:
+            (root / name).mkdir(parents=True, exist_ok=True)
+            for f in files:
+                (root / name / f).write_text("x\n", encoding="utf-8")
+        got_names = set(suites(root))
+        for name, _, want in collect_cases:
+            if (name in got_names) != want:
+                bad += 1
+                print(f"SELFTEST 取集失配: {name} collected={name in got_names} want={want}")
+    cases = cases + collect_cases
+
     print(f"selftest {len(cases) - bad}/{len(cases)}")
     return 1 if bad else 0
 

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -103,3 +103,9 @@ test7-config
 test702-primary-network
 test8-runtime
 test9-permissions
+qa-core-docs
+qa-frontdoor-docs
+qa-ut-01-auth-tokens
+qa-ut-02-password-dict
+qa-ut-03-auth-validate
+test-rename-identity

--- a/tests/test380-gateway-topology-probe/NOT-IN-CI.md
+++ b/tests/test380-gateway-topology-probe/NOT-IN-CI.md
@@ -1,0 +1,34 @@
+# test380-gateway-topology-probe 不进 CI
+
+Verified: 2026-08-19
+Revisit-when: 有人给它加了「判据」——即某个观测为坏时 `exit 1`，而不只是写进报告。
+
+## 为什么
+
+**它是诊断探针，不是门。** 和 `tests/test380-daemon-telemetry-probe/NOT-IN-CI.md`
+是完全同一个形状：发现全部通过 `raw` 写进 `$REPORT`，**退出码不认这些发现**。
+
+`tests/test380-gateway-topology-probe/daemon-run.sh` 共 356 行，
+`exit 1` 只出现在 **setup 失败**处：
+
+    :80   [[ "$UTOK" == utok_* ]]        || { rec "register" "FAILED: $ADMIN"; exit 1; }
+    :84   [[ -n "$NET_ID" ]]             || { rec "network"  "FAILED: $NET";   exit 1; }
+    :88   [[ "$DEMO_HOST_TOK" == ntok_* ]] || { rec "mint"   "FAILED";         exit 1; }
+
+结尾没有任何基于观测的判定，只是把报告打出来：
+
+    raw "  So 'hub 400' means the client omitted network_id — NOT that no daemons"
+    raw "  exist. If prod dashboard reports hub 400 in the create-node wizard,"
+    …
+    echo "===== REPORT ====="
+    cat "$REPORT"
+
+⇒ **接成阻塞门的话，它无论探到什么都是绿的。**
+
+它作为**排障工具**有价值：值班时手动跑一次，能一次性拿到 hub↔daemon 拓扑、
+`list_host_supervisors` 的返回、以及 `hub 400` 到底是「客户端没带 network_id」
+还是「真的没有 daemon」。但那是工具，不是门。
+
+（这条目录此前**连被这道门看见的资格都没有** —— `suites()` 只认 `run.sh`，
+而它的入口是 `docker-compose.yml` + `daemon-run.sh`。取集放宽后它会落进 exempt，
+位置才对。见 issue #1064。）


### PR DESCRIPTION
关 #1064。

## 问题

    .github/scripts/check-test-suite-registration.py（改前）
      def suites() -> list[str]:
          return sorted(d.name for d in TESTS.iterdir()
                        if d.is_dir() and (d / "run.sh").exists())

**只认 `run.sh`。** 入口叫别的名字的套件，这道门**从来没见过它们** ——
既不会被报成孤儿，也不在它打印的 `suites=198` 分母里。

    tests/ 下目录总数     208
    门看得见（有 run.sh） 198     ← 就是它打印的 suites=198
    看不见                 10     ← 其中 3 个是支持目录，**7 个是真套件**

**盲区在取集，不在判据。** `classify()` 一直是对的，只是它拿不到这些名字。

## 🔴 为什么它能活这么久：自测的 docstring 承诺了取集，代码没兑现

    :219-220（改前）
      def selftest() -> int:
          """判据自检。绿和「取集坏了」打印出来是两码事，这里把两者都钉住。"""
                                                            ↑ 「两者都钉住」
    :236   (d / "run.sh").write_text("#!/bin/bash\n", …)     ← 每个夹具都有 run.sh
    :240   got = name in classify([name], blob, …)["new"]
                              ↑ 名字直接喂进去，**从不调用 suites()**

判据那一半其实做得很扎实（workflow 注释里有变异实测：去掉 NOT-IN-CI.md 豁免 → selftest 4/5）。
**取集那一半只在 docstring 里被承诺了。** 而任何人看到「自测在 CI 里跑 + 说取集也钉住了」，
都会认为这块有人守着 —— **那句承诺本身，就是让人不再去查的东西。**

## 改了什么

**① 取集放宽**（`run.sh` / `docker-compose.yml` / `Dockerfile` / `Dockerfile.*`）：

    198 → 205（正好收进那 7 条）
    helpers / lib / scripts 三个支持目录三种入口都没有，仍然被排除

**② `suites()` 可注入 `tests_dir`** —— 只为一件事：让自测能对**取集本身**做夹具。

**③ 自测真的覆盖取集**，5 条形状夹具，**走 `suites()` 而不是直接喂名字**：

    c-run       run.sh                → 应收
    c-docker    Dockerfile            → 应收（qa-ut-0* / qa-*-docs）
    c-compose   docker-compose.yml    → 应收（test383）
    c-dockerdot Dockerfile.harness    → 应收（test380-gateway）
    c-support   helper.sh + README.md → **不应收**（lib / scripts / helpers）

**④ `test380-gateway-topology-probe` 补 `NOT-IN-CI.md`** —— 它是**探针不是门**：
356 行里 `exit 1` 只在 setup 失败处（`:80` register / `:84` network / `:88` mint），
发现全部通过 `raw` 写进报告、退出码不认。和 `test380-daemon-telemetry-probe`
（`#1049` 已豁免）完全同一形状。**接成阻塞门的话，它无论探到什么都是绿的。**

## 见证红 → 见证绿

光看自测 10/10 不算数。对**真代码**做变异（把取集改回只认 `run.sh`）：

    SELFTEST 取集失配: c-docker    collected=False want=True
    SELFTEST 取集失配: c-compose   collected=False want=True
    SELFTEST 取集失配: c-dockerdot collected=False want=True
    selftest 7/10        rc=1

复原后 `selftest 10/10  rc=0`，且 `diff` 确认文件**逐字复原**。

## 地板 91 → 97 是**补债，不是退步**

    suites=205 registered=102 exempt=6 (oldest 0d) orphans=97 baseline=97 new=0   rc=0

新增的 6 条**本来就存在、只是这道门看不见**：

    qa-core-docs · qa-frontdoor-docs · qa-ut-01-auth-tokens
    qa-ut-02-password-dict · qa-ut-03-auth-validate · test-rename-identity

（第 7 条 `test380-gateway-topology-probe` 落进 exempt，不是 orphan —— **位置才对**。）

本仓「楼层只降不回填」的立场针对的是**同一取集范围内**的退步。
这次是取集范围本身扩大，把看不见的债显式记上 —— **不记才是退步。**

⚠️ 这 6 条的覆盖情况我在 #1064 里逐条追到了内容层，结论差别很大：

    qa-ut-01/02/03      内容其实在 `scripts/qa.sh --l0` 里跑着，只是封装目录不可见  影响最小
    qa-frontdoor-docs   真门 · 无人跑 · **当前三条断言全过**（已实测）              没人守，非已失守
    qa-core-docs        真门 · 无人跑 · 会 fetch 5 个外部 URL                      接入前需决定挂在哪
    test-rename-identity 真门 · 无人跑 · 14 用例齐全 · 用 fake-grok 不碰真上游       **最值得接的一条**

🤖 Generated with [Claude Code](https://claude.com/claude-code)