### PR TITLE
fix(ci): bun-install-pin 的取集只认前缀式 Dockerfile —— 7 个 `*.Dockerfile` 看不见

### DIFF
--- a/.github/scripts/check-bun-install-pin.py
+++ b/.github/scripts/check-bun-install-pin.py
@@ -67,8 +67,18 @@ PINNED_HINTS = (
 
 
 def is_dockerfile(path: str) -> bool:
+    """哪些文件算 Dockerfile。
+
+    🔴 2026-08-19：这里原本只认前缀式（`Dockerfile` / `Dockerfile.mock`），
+    **后缀式 `<name>.Dockerfile` 一个都不收** —— 实测漏了 7 个，全在
+    `agent-network/tests/docker-e2e/`（`playwright.Dockerfile` 等）。
+    当时那 7 个都没用 `bun.sh/install`，所以没漏掉真问题，但只要有人往里面加一句
+    `curl bun.sh/install`，这道门看不见。**盲区在取集，不在判据。**
+    """
     name = Path(path).name
-    return name == "Dockerfile" or name.startswith("Dockerfile.")
+    return (name == "Dockerfile"
+            or name.startswith("Dockerfile.")
+            or name.endswith(".Dockerfile"))
 
 
 def is_pinned(text: str) -> bool:
@@ -97,6 +107,20 @@ def selftest() -> int:
     # 🔴 负向:压根不装 bun 的 Dockerfile 不该被这道门碰到
     ck("不引用安装器 → 不判", "FROM node:22\nRUN npm ci", False)
     ck("只提到 bun 这个词 → 不判", "# bun is faster\nFROM node:22", False)
+
+    # ── 取集自检：这道门的坏法是「圈错哪些文件算 Dockerfile」，
+    #    而判据 unpinned() 再准也救不回来。夹具直接喂 is_dockerfile()。
+    def ckname(path, want):
+        got = is_dockerfile(path)
+        cases.append((f"取集 {path}", got == want, f"got={got} want={want}"))
+
+    ckname("Dockerfile", True)
+    ckname("tests/x/Dockerfile", True)
+    ckname("tests/x/Dockerfile.mock", True)          # 前缀式
+    ckname("tests/x/playwright.Dockerfile", True)    # 🔴 后缀式,2026-08-19 之前漏
+    ckname("tests/x/Dockerfile.harness", True)
+    ckname("tests/x/dockerfile-notes.md", False)     # 名字里有 dockerfile 但不是
+    ckname("tests/x/README.md", False)
 
     for n, ok, d in cases:
         print(f"  {'ok  ' if ok else 'FAIL'} {n}   [{d}]")


### PR DESCRIPTION
来自 #1066 的审计。**盲区在取集，不在判据。**

## 问题

    .github/scripts/check-bun-install-pin.py:69-71（改前）
      def is_dockerfile(path: str) -> bool:
          name = Path(path).name
          return name == "Dockerfile" or name.startswith("Dockerfile.")

前缀式（`Dockerfile.mock`）收，**后缀式（`playwright.Dockerfile`）不收**。实测：

    is_dockerfile 收 **226** 个
    文件名含 "Dockerfile" 的 **233** 个
    🔴 差 **7** 个，全在 `agent-network/tests/docker-e2e/`：
       agent-node.Dockerfile · dashboard.Dockerfile · playwright.Dockerfile
       issue-88 / issue-115 / issue-117 / issue-122.Dockerfile

## 当时没漏掉真问题 —— 这一格我追到底了

用**门自己的** `USES_INSTALLER` 逐个查那 7 个：

    门内 226 个里，用 `bun.sh/install` 的 **38** 个   ← 已知阳性，量具有效
    门外 7 个里，用 `bun.sh/install` 的 **0** 个

⇒ 是「**没人守**」，不是「**已失守**」。
但只要有人往 `agent-network/tests/docker-e2e/playwright.Dockerfile` 里
加一句 `curl bun.sh/install`，这道门**看不见**。

## 改了什么

**① `is_dockerfile` 加一条后缀式**，并把起因写进 docstring（下一个人不必重新考古）。

**② 自测补取集夹具** —— 这是 #1066 里我自己提的要求：
原来的 6 条用例全在喂 `unpinned()`（判据），**没有一条碰 `is_dockerfile()`（取集）**。

    ckname("tests/x/Dockerfile.mock", True)          # 前缀式
    ckname("tests/x/playwright.Dockerfile", True)    # 🔴 后缀式，本次之前漏
    ckname("tests/x/dockerfile-notes.md", False)     # 名字里有 dockerfile 但不是
    ckname("tests/x/README.md", False)

## 见证红 → 见证绿

自测 13/13 **不算数**。把 `is_dockerfile` 改回原样（对真代码变异）：

    FAIL 取集 tests/x/playwright.Dockerfile   [got=False want=True]
    selftest: 12/13 ok        rc=1

**只有后缀式那一条红**，其余 12 条不动 —— 说明新夹具钉的正是这个盲区，没有误伤。
复原后 `13/13  rc=0`，`diff` 确认文件**逐字复原**。

## 基线不动

    scanned 233 tracked Dockerfile(s); 37 still install bun unpinned; baseline lists 37
    no new unpinned bun installer.        rc=0

取集从 226 扩到 233，**没有引入任何新违规**，与「那 7 个都没用 installer」的测量一致。
⇒ **这个 PR 不改任何地板数字**，纯粹是把门的视野补齐。

## 它自己那条空取集守卫我保留了

    :117-119
      if not dockerfiles:
          print("FAIL: 一个 Dockerfile 都没扫到 —— 取集塌了,拒绝通过", file=sys.stderr)
          return 2

防的是「0 命中被读成 0 问题」。和 `check-docs-integrity.py` 的同款写法，是本仓的好范例。

🤖 Generated with [Claude Code](https://claude.com/claude-code)