### PR TITLE
fix(ci): doc-symbol-anchors 只扫 docs/docs-site —— 103 个 `.md` 看不见（含 README / CLAUDE / SECURITY）

### DIFF
--- a/.github/scripts/check-doc-symbol-anchors.py
+++ b/.github/scripts/check-doc-symbol-anchors.py
@@ -105,8 +105,18 @@ DOC_ROOTS = ("docs/", "docs-site/")
 
 
 def tracked_markdown(repo: Path) -> list[str]:
+    """全仓被跟踪的 .md。
+
+    🔴 2026-08-19：这里原本限定 `-- docs docs-site`，于是 **103 个 .md 从来没被扫过**
+    （`README.md` / `CLAUDE.md` / `AGENTS.md` / `SECURITY.md` / `.github/**` …）。
+    当时门外一个「搜 + 反引号符号」锚点都没有，所以没漏掉真问题 —— 但约定一旦被用到
+    这些文件里，这道门看不见。**盲区在取集，不在判据。**
+
+    隔壁 `check-docs-integrity.py:107` 就是现成写法：全仓 `git ls-files "*.md"`
+    加一条「取集为空就拒绝通过」。这里照抄。
+    """
     out = subprocess.run(
-        ["git", "ls-files", "-z", "--", "docs", "docs-site"],
+        ["git", "ls-files", "-z", "--", "*.md"],
         cwd=repo, capture_output=True, text=True, check=True,
     ).stdout
     return sorted(p for p in out.split("\0") if p.endswith(".md"))
@@ -205,7 +215,10 @@ def run(repo: Path) -> int:
 # selftest
 #
 # 🔴 夹具里的锚点用字符串拼接造,不写成字面量 —— 否则这个文件自己会被
-#    真实扫描当成 docs 命中(它不在 docs/ 下,但同类门吃过这个亏,留个明示)。
+#    真实扫描命中。
+# ⚠️ 2026-08-19 更正:原注释说「它不在 docs/ 下」,那个理由**在取集放宽到全仓之后不再成立**。
+#    现在真正的理由是:tracked_markdown() 只收 `.md`,而本文件是 `.py`。
+#    字符串拼接仍然该留 —— 但别再靠「不在 docs/ 下」这个已经过期的前提。
 # ---------------------------------------------------------------------------
 def selftest() -> int:
     SEARCH = "搜"
@@ -218,6 +231,26 @@ def selftest() -> int:
         return "[`x`](https://github.com/o/r/blob/main/" + target + ")"
 
     cases: list[tuple[str, bool, str]] = []
+
+    # ── 取集自检:这道门的坏法是「圈错扫哪些文件」,判据再准也救不回来。 ──
+    # 2026-08-19 之前它只扫 `-- docs docs-site`,103 个 .md(README/CLAUDE/AGENTS/
+    # SECURITY/.github/**)从来没被扫过。夹具建一个真 git 仓,走 tracked_markdown()。
+    import tempfile as _tf
+    with _tf.TemporaryDirectory() as _td:
+        _root = Path(_td)
+        for rel in ("README.md", "docs/a.md", "docs-site/b.md",
+                    "agent-node/notes.md", ".github/PULL_REQUEST_TEMPLATE.md",
+                    "docs/not-markdown.txt"):
+            f = _root / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("x\n", encoding="utf-8")
+        for cmd in (["git", "init", "-q"], ["git", "add", "-A"]):
+            subprocess.run(cmd, cwd=_root, check=True, capture_output=True, text=True)
+        got = set(tracked_markdown(_root))
+        want = {"README.md", "docs/a.md", "docs-site/b.md",
+                "agent-node/notes.md", ".github/PULL_REQUEST_TEMPLATE.md"}
+        cases.append(("取集:全仓 .md 都收(含 docs/ 之外)", got == want, f"got={sorted(got)}"))
+        cases.append(("取集:非 .md 不收", "docs/not-markdown.txt" not in got, ""))
 
     def check(name: str, line: str, src_map: dict[str, str], want_problem: bool) -> None:
         probs, n = scan_text("docs/f.md", line)


### PR DESCRIPTION
来自 #1066 的审计。**盲区在取集，不在判据** —— 和 #1065 / #1067 同一类。

## 问题

    .github/scripts/check-doc-symbol-anchors.py:107-112（改前）
      def tracked_markdown(repo: Path) -> list[str]:
          out = subprocess.run(
              ["git", "ls-files", "-z", "--", "docs", "docs-site"],
                                              ↑ **只有这两个目录**
          ).stdout
          return sorted(p for p in out.split("\0") if p.endswith(".md"))

实测（`origin/main` = `35a37167`）：

    全仓被跟踪的 .md   **371**
    这道门扫得到       **268**
    🔴 扫不到          **103**   ← README.md / CLAUDE.md / AGENTS.md / SECURITY.md / .github/**

## 当前不漏 —— 这一格我追到底了

用**门自己的判据** `ANCHOR = 搜\s*`([^`]+)`` 量：

    门内 268 个，含 ANCHOR 的 **11** 个   ← 已知阳性，量具有效
    门外 103 个，含 ANCHOR 的 **0** 个

⇒ 是「**没人守**」，不是「**已失守**」。但这套锚点约定一旦被写进 `README.md` 或
`CONTRIBUTING.md`，这道门**看不见**。

## 修法不用新发明 —— 隔壁文件里就有

    .github/scripts/check-docs-integrity.py:107-116
      def tracked(pathspec: str) -> list[str]:
          out = subprocess.run(["git", "ls-files", pathspec], …)
          return [f for f in out.stdout.split("\n") if f.endswith(".md")]
      …
      md = tracked("*.md")
      if not md:
          print("::error::git ls-files '*.md' returned nothing — scope regression, refusing to pass")
          return 2

**同一个目录、同样扫 markdown，一道门做对了、另一道没有。** 这里照抄它的范围写法。

## 改了什么

**① 范围放宽到全仓 `*.md`**，起因写进 docstring。

**② 自测补取集夹具** —— 原来 8 条用例全在喂判据（`scan_text` / `anchor` / `link`），
**没有一条碰 `tracked_markdown()`**。新夹具**建一个真 git 仓**再走它：

    README.md · docs/a.md · docs-site/b.md · agent-node/notes.md
    .github/PULL_REQUEST_TEMPLATE.md   → **都该收**
    docs/not-markdown.txt              → **不该收**

**③ 顺手更正一条被我这次改动弄过期的注释**（`:217-218`）：

    改前： # 真实扫描当成 docs 命中(它不在 docs/ 下,但同类门吃过这个亏,留个明示)
    改后： # ⚠️ 2026-08-19 更正:原注释说「它不在 docs/ 下」,那个理由**在取集放宽到全仓之后不再成立**。
           #    现在真正的理由是:tracked_markdown() 只收 `.md`,而本文件是 `.py`。

**字符串拼接仍然该留，但理由变了。** 留着一条前提已失效的注释，比没有注释更容易误导下一个人。

## 见证红 → 见证绿，而且**只红该红的那一条**

自测 10/10 不算数。把范围改回 `-- docs docs-site`（对真代码变异）：

    FAIL 取集:全仓 .md 都收(含 docs/ 之外)   [got=['docs-site/b.md', 'docs/a.md']]
    selftest: 9/10 ok        rc=1

**另一条取集用例「非 .md 不收」正确保持绿** —— 收窄目录不破坏那个性质。
⇒ 新夹具钉的正是这个盲区，**没有误伤**。
复原后 `10/10  rc=0`，`diff` 确认文件**逐字复原**。

## 基线不动

    checked 82 symbol anchor(s) across **371** tracked doc(s); 82 resolved to a readable source file
    every symbol anchor exists in the file it names.        rc=0

范围 268 → 371，**没有引入任何新问题**，与「门外 0 个锚点」的测量一致。
⇒ 和 #1067 一样，**这个 PR 不改任何地板数字**，纯粹补齐视野。

🤖 Generated with [Claude Code](https://claude.com/claude-code)