### PR TITLE
fix(test292-residual): 计数判据从「逐字相等」改成「地板」—— 给底层加测试不该让门变红

### DIFF
--- a/tests/test292-e2e-residual-fixtures/run.sh
+++ b/tests/test292-e2e-residual-fixtures/run.sh
@@ -11,25 +11,48 @@ fail() { FAIL=$((FAIL + 1)); echo "FAIL: $*" >&2; }
 mkdir -p "$WORK"
 echo "source_commit=$TEST292_RESIDUAL_SOURCE_COMMIT"
 
+# 🔴 2026-08-19：这里原本是 `grep -Fq "Results: <N> passed, 0 failed"` —— **逐字相等**。
+#    实测后果：底层 test-networks.sh 从 26 条涨到 27 条 ⇒ 本套件判红，
+#    而它的尾部明明写着 `27 passed, **0 failed**`。**给底层加一条测试 = 让这个门变红。**
+#    ⇒ 改成地板：**failed 必须为 0，passed 必须 ≥ 地板**。地板只升不降。
+#    （本仓既有同款写法：tests/test225-grok-preview-package-live/check-known-failures.py:25 的 PASS_FLOOR）
+#
+#    ⚠️ 当时四组的实测值是 27 / 12 / 47 / 21，只有 networks 与旧期望不符；
+#       另外三组换地板**不是因为它们现在有问题**，是因为将来任何一条被加测试时会重演同一个红。
 run_green() {
-  local name=$1 script=$2 expected=$3 log="$WORK/$1.log"
-  if timeout 420 bash "$script" >"$log" 2>&1 && grep -Fq "$expected" "$log"; then
-    pass "$name: $expected"
+  local name=$1 script=$2 floor=$3 log="$WORK/$1.log"
+  if ! timeout 420 bash "$script" >"$log" 2>&1; then
+    tail -80 "$log" >&2 || true
+    fail "$name: 脚本本身非零退出"
+    return
+  fi
+  local trailer passed failed
+  trailer=$(grep -E 'Results: [0-9]+ passed, [0-9]+ failed' "$log" | tail -1)
+  if [[ -z "$trailer" ]]; then
+    tail -80 "$log" >&2 || true
+    # 🔴 取不到 trailer 绝不当成通过 —— 那是「没跑」不是「没问题」
+    fail "$name: 没有找到 Results 行(取集塌了,拒绝通过)"
+    return
+  fi
+  passed=$(sed -E 's/.*Results: ([0-9]+) passed.*/\1/' <<<"$trailer")
+  failed=$(sed -E 's/.*, ([0-9]+) failed.*/\1/' <<<"$trailer")
+  if [[ "$failed" -eq 0 && "$passed" -ge "$floor" ]]; then
+    pass "$name: $passed passed / 0 failed (floor $floor)"
   else
     tail -80 "$log" >&2 || true
-    fail "$name did not reach its exact green trailer"
+    fail "$name: $trailer (要求 failed=0 且 passed>=$floor)"
   fi
 }
 
 # Layered green: cheap isolation and install paths first, then the real
 # scheduler windows. A failed prerequisite stops this exact evidence run.
-run_green networks /app/test-networks.sh "Results: 26 passed, 0 failed"
+run_green networks /app/test-networks.sh 27
 [[ $FAIL -eq 0 ]] || exit 1
-run_green npm-pack /app/test-loop-npm-pack.sh "Results: 12 passed, 0 failed"
+run_green npm-pack /app/test-loop-npm-pack.sh 12
 [[ $FAIL -eq 0 ]] || exit 1
-run_green self-mgmt /app/test-loop-self-mgmt.sh "Results: 47 passed, 0 failed"
+run_green self-mgmt /app/test-loop-self-mgmt.sh 47
 [[ $FAIL -eq 0 ]] || exit 1
-run_green runtime /app/test-loop-runtime.sh "Results: 21 passed, 0 failed"
+run_green runtime /app/test-loop-runtime.sh 21
 
 # Witnessed-red 1: if A becomes the bootstrap admin again, its visibility is
 # intentionally wider and the ordinary-user isolation assertion must fail.


### PR DESCRIPTION
修 #1070。

## 问题（改前）

    tests/test292-e2e-residual-fixtures/run.sh:14-22
      run_green() {
        local name=$1 script=$2 expected=$3 log="$WORK/$1.log"
        if timeout 420 bash "$script" >"$log" 2>&1 && grep -Fq "$expected" "$log"; then

    :26  run_green networks /app/test-networks.sh "**Results: 26 passed, 0 failed**"

实测：底层 `test-networks.sh` 已经是 **27 passed, 0 failed**
⇒ 本套件判红，**而它的尾部明明写着 `0 failed`**。

🔴 **给底层加一条测试 = 让这个门变红。改善被判成退步。**

## 四组实测（本次改动的地板取自这组读数）

| 底层脚本 | 旧期望 | **实测** |
|---|---|---|
| `test-networks.sh` | 26 | **27 passed, 0 failed** |
| `test-loop-npm-pack.sh` | 12 | **12 passed, 0 failed** |
| `test-loop-self-mgmt.sh` | 47 | **47 passed, 0 failed** |
| `test-loop-runtime.sh` | 21 | **21 passed, 0 failed** |

**四组全部 `0 failed`，只有 `networks` 一条与旧期望不符。**
另外三组一起换地板 **不是因为它们现在有问题**，是因为将来任何一条被加测试时会重演同一个红。

## 改成什么

    failed 必须为 0，且 passed 必须 ≥ 地板；地板只升不降

并补了两条改前没有的防线：

    ① 脚本自身非零退出 → 明确报「脚本本身非零退出」，不与判据失败混为一谈
    ② 🔴 **取不到 `Results` 行 → 判红**，报「取集塌了,拒绝通过」
       —— 「没跑」不能被读成「没问题」

（本仓既有同款写法：`tests/test225-grok-preview-package-live/check-known-failures.py:25` 的 `PASS_FLOOR`。）

## 判据本身已验穿：**6 条桩用例**

`run_green` 是**从改后的真文件里正则抽出来的**（不是手打副本），再喂桩脚本：

    ✅ 地板=27，实测 27              → 通过
    ✅ **加测试到 28 → 不再变红**      ← **本次修复的核心**
    ✅ 退回 26（低于地板）            → 红
    ✅ 有 1 条失败（passed 够）       → 红
    ✅ **取不到 Results 行**          → 红（不当成通过）
    ✅ 脚本自身非零退出               → 红

## ⚠️ 完整套件的实跑仍在进行中

桩验证只证明**判据对**，不证明**套件会绿** —— 今天我在另一个套件上刚栽过这一步：
grep 全中之后仍然红在更后面的一步。
**整套 4 组 + 3 条见证红的实跑已启动（约 7 分钟），结果出来我会贴在本 PR 下。**
**在那之前请不要合。**

## 本 PR 没有动的东西

    :27 `[[ $FAIL -eq 0 ]] || exit 1` 这个 fail-fast **保留** ——
    它是「分层绿：先跑便宜的隔离与安装路径，再跑真实调度窗口」的设计，
    改不改是另一个决定，不该混在这个 PR 里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)