### PR TITLE
fix(test236): 3 处字面量随改名过期；变异改成「必须真的改动文件」

### DIFF
--- a/agent-node/src/goals/routing.test.ts
+++ b/agent-node/src/goals/routing.test.ts
@@ -95,6 +95,28 @@ describe("Dashboard native slash migration notice", () => {
       .slice(0, 2_000)).toContain(DASHBOARD_NATIVE_SCHEDULE_NOTICE);
   });
 
+  // 🔴 上一条用 messageType:"task"，于是 `humanDashboardRequest` 为真，
+  //    `failed || humanDashboardRequest || !isLowValueReply(text)` 在第二项就短路 ——
+  //    `isLowValueReply` 根本没被求值。所以尽管那条测试名叫
+  //    "the notice survives low-value filtering"，它**测不到低价值过滤**。
+  //    要让第三项真的被求值，必须同时满足：有通知(interactiveDashboardTask=true)
+  //    且不是 human 直连(messageType 不是 task/broadcast)。
+  //    2026-08-19 实测：把 `isLowValueReply(text)` 改成 `isLowValueReply(replyText)`
+  //    后整个套件仍然全绿，就是缺了这一格。
+  test("low-value filtering judges the notice-prefixed text, not the raw model reply", () => {
+    const prepared = prepareDashboardNativeSlashReply(
+      "收到",
+      "/loop 5m work",
+      { messageType: "message", interactiveDashboardTask: true },
+      false,
+      (text) => text === "收到",
+    );
+
+    expect(prepared.text).toBe(`${DASHBOARD_NATIVE_SCHEDULE_NOTICE}\n\n收到`);
+    // 判据在这一行：拿【原始回复】判低价值会把该发的迁移通知一起吞掉。
+    expect(prepared.shouldDeliver).toBe(true);
+  });
+
   test("failed native replies still surface the migration notice and the failure", () => {
     const prepared = prepareDashboardNativeSlashReply(
       "native failed",

--- a/tests/test236-dashboard-codex-goal/run.sh
+++ b/tests/test236-dashboard-codex-goal/run.sh
@@ -14,6 +14,24 @@ run() {
   "$@" 2>&1 | tee -a "$REPORT"
 }
 
+# 🔴 变异必须真的改动文件，否则算【锚点过期】而不是产品缺陷。
+#    为什么不预先 grep 锚点：锚点里含 `\\n` 这类转义，在 grep -F / sed / shell 引号
+#    三层里的含义不同，判据本身就会成为 bug 源。**直接量「文件改没改」不需要任何转义。**
+#    背景（2026-08-19 实测 origin/main）：3 条锚点里 2 条 0 命中 ——
+#    一次改名把 Codex/INTERVAL 换成了 Native/SCHEDULE，本文件的字面量没跟上。
+#    sed 打不中时是 **no-op** ⇒ 产品没被改坏 ⇒ 测试绿 ⇒ 下面那句
+#    `FAIL: ... stayed green` 照样会打，套件确实红了 —— **但那句红话指错了层**：
+#    它把人指向产品，而该改的是这个文件。这个函数把它变成一句指对层的红话。
+mutate() { # $1=目标文件 $2=sed 表达式（原样透传，不经二次解析）
+  cp "$1" /tmp/pre-mutation.snapshot
+  sed -i "$2" "$1"
+  if cmp -s /tmp/pre-mutation.snapshot "$1"; then
+    printf 'FAIL: 变异未改动 %s —— 【测试锚点过期】，不是产品缺陷\n' "$1" | tee -a "$REPORT"
+    printf '  sed: %s\n' "$2" | tee -a "$REPORT"
+    exit 1
+  fi
+}
+
 printf '%s\n' \
   '# test236 — Dashboard /goal reaches shared Codex TUI' \
   "source_commit=$SOURCE_COMMIT" \
@@ -28,7 +46,7 @@ run production-wiring bash -ceu '
   cli=/workspace/agent-node/src/cli.ts
   grep -Fq "const interactiveDashboardTask = isInteractiveDashboardTask(msg);" "$cli"
   grep -Fq "shouldCreateScheduledGoal(persistenceSafeContent, RUNTIME, interactiveDashboardTask)" "$cli"
-  grep -Fq "const preparedReply = prepareDashboardCodexGoalReply(" "$cli"
+  grep -Fq "const preparedReply = prepareDashboardNativeSlashReply(" "$cli"
   grep -Fq "if (!preparedReply.shouldDeliver)" "$cli"
   grep -Fq "interactiveDashboardTask," "$cli"
 '
@@ -47,8 +65,7 @@ run production-build bash -ceu '
 # leaving the test unchanged. The screenshot's interval-free `/goal` must be
 # intercepted again, so the focused routing test has to fail.
 cp /workspace/agent-node/src/goals/routing.ts /tmp/routing.original.ts
-sed -i 's/return !(runtime === "codex-app-server" && interactiveDashboardTask);/return true;/' \
-  /workspace/agent-node/src/goals/routing.ts
+mutate /workspace/agent-node/src/goals/routing.ts 's/return !interactiveDashboardTask;/return true;/'
 set +e
 bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/mutation.out 2>&1
 mutation_rc=$?
@@ -66,8 +83,7 @@ run restored-green bun test /workspace/agent-node/src/goals/routing.test.ts
 # Witnessed-red: keep the routing exception but remove the deterministic
 # interval notice from the successful reply. The ambiguity regression must be
 # observable even though the goal itself still reaches Codex.
-sed -i 's/return `${DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE}\\n\\n${replyText}`;/return replyText;/' \
-  /workspace/agent-node/src/goals/routing.ts
+mutate /workspace/agent-node/src/goals/routing.ts 's/return `${DASHBOARD_NATIVE_SCHEDULE_NOTICE}\\n\\n${replyText}`;/return replyText;/'
 set +e
 bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/notice-mutation.out 2>&1
 notice_mutation_rc=$?
@@ -85,8 +101,7 @@ run final-green bun test /workspace/agent-node/src/goals/routing.test.ts
 # Witnessed-red: evaluate low-value status against the raw model text instead
 # of the notice-prefixed text. A model reply of "收到" would then suppress the
 # required interval warning.
-sed -i 's/!isLowValueReply(text)/!isLowValueReply(replyText)/' \
-  /workspace/agent-node/src/goals/routing.ts
+mutate /workspace/agent-node/src/goals/routing.ts 's/!isLowValueReply(text)/!isLowValueReply(replyText)/'
 set +e
 bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/order-mutation.out 2>&1
 order_mutation_rc=$?


### PR DESCRIPTION
关闭 #1056 的一部分。**在 `origin/main` 3fd3e4bb 上实测得到的数字，不是转述。**

## 事实：一次改名扫过了产品，套件的字面量没跟上

`agent-node/src/goals/routing.ts` 与 `cli.ts` 里 `Codex`/`INTERVAL` 被改名成
`Native`/`SCHEDULE`。本套件里 4 处字面量有 3 处因此 0 命中：

| 位置 | 字面量 | 在 main 上命中 |
|---|---|---|
| `production-wiring` grep | `prepareDashboardCodexGoalReply(` | **0**（现名 `prepareDashboardNativeSlashReply`）|
| 变异锚点 ① | `return !(runtime === "codex-app-server" && interactiveDashboardTask);` | **0**（现为 `return !interactiveDashboardTask;`）|
| 变异锚点 ② | `DASHBOARD_CODEX_GOAL_INTERVAL_NOTICE` | **0**（现为 `DASHBOARD_NATIVE_SCHEDULE_NOTICE`）|
| 变异锚点 ③ | `!isLowValueReply(text)` | 1 ✅ |

## 🔴 先说清楚这**不是**一个静默漏洞 —— 守卫是有效的

`sed` 打不中时是 **no-op** ⇒ 产品没被改坏 ⇒ 测试绿 ⇒ `mutation_rc=0` ⇒
已有的守卫照样打印 `FAIL: deleting the Dashboard Codex /goal exception stayed green`
并 `exit 1`。**套件是响亮红的。**

问题在**那句红话指错了层**：它说的是「产品的例外被删了还是绿的」，
而真相是「锚点在源码里已经不存在了」。按它去查会去改 `routing.ts`（没坏），
该改的是本文件。

## 改法：不预先 grep 锚点，而是量「这次变异到底改动文件没有」

```bash
mutate() { # $1=目标文件 $2=sed 表达式（原样透传）
  cp "$1" /tmp/pre-mutation.snapshot
  sed -i "$2" "$1"
  if cmp -s /tmp/pre-mutation.snapshot "$1"; then
    printf 'FAIL: 变异未改动 %s —— 【测试锚点过期】，不是产品缺陷\n' "$1" | tee -a "$REPORT"
    printf '  sed: %s\n' "$2" | tee -a "$REPORT"
    exit 1
  fi
}
```

**为什么不写成「先 `grep -F` 锚点，再 `sed`」**：锚点里含 `\\n`，
它在 `grep -F` / `sed` / shell 引号这三层里的含义不同 —— 我第一版就是这么写的，
生成出来的锚点带了 `\\\\n`，**判据自己会变成 bug 源**。
`cmp` 量的是「文件改没改」，不需要任何转义，而且它是**那件事本身**，不是它的附带特征。

三条 `sed` 表达式**逐字未变**（单引号原样透传给 `sed -i "$2"`）。

## 校准（拿已知答案对）

```
=== 修好的 3 条锚点（已知答案：应改动文件）===
  rc=0 改动行=2   return !interactiveDashboardTask; → return true;
  rc=0 改动行=2   DASHBOARD_NATIVE_SCHEDULE_NOTICE 那条
  rc=0 改动行=2   !isLowValueReply(text) → (replyText)
=== 过期的 2 条旧锚点（已知答案：no-op）===
  rc=9 改动行=0   FAIL: 变异未改动 … ——【测试锚点过期】，不是产品缺陷
  rc=9 改动行=0   同上
```

## ⚠️ 我没做的事

**没有在本机跑 docker 套件**（要 build 镜像，本机磁盘 92%）。
上面只是把 `mutate` 函数单独拿出来对着真实的 `routing.ts` 校准。
**套件整体是否转绿，以 CI 为准 —— 在 CI 绿之前这条不算「已修」。**
