### PR TITLE
fix(home-path-gate): 不再要求结尾斜杠 + 加根边界；基线随覆盖面重算 198→218

### DIFF
--- a/.github/scripts/check-home-path-baseline.py
+++ b/.github/scripts/check-home-path-baseline.py
@@ -32,7 +32,24 @@ import sys
 
 BASELINE = "docs/home-path-baseline.txt"
 
-HOME_PATH = re.compile(r"/home/([A-Za-z0-9._-]+)/")
+# 🔴 两处修正（2026-08-19，实测 origin/main 3fd3e4bb）：
+#
+# ① **不再要求结尾斜杠。** 旧写法 `/home/([A-Za-z0-9._-]+)/` 漏掉 38 处 / 20 个文件，
+#    而漏掉的恰恰是这个门最该看见的形状：
+#        tests/test736-pm2-fleet-rebuild/Dockerfile:22  ENV HOME=/home/<名>
+#        tests/test736-pm2-fleet-rebuild/Dockerfile:19  chown -R <名>:<名> /home/<名>
+#        agent-network/src/grok-copresence-profile.test.ts  HOME: "/home/<名>"
+#    这些位置对棘轮是**隐形**的 —— 在那儿新增一条，门不会发现。
+#    旧 selftest 有一条 `regex needs the trailing slash` 把这个行为**钉成了正确的**；
+#    本次把那条钉改掉，并在下面用两条新夹具钉住新行为。
+#
+# ② **加根边界。** 旧写法会把 `/runtime/home/x/`、`$case_root/home/.anet` 里的
+#    `/home/` 也算进来 —— 那不是系统家目录。实测 198 处计入里有 **18 处是这类误报**。
+#
+# ⇒ 净效果：计入 198 → 218（+38 真命中，−18 误报）。**基线随之重算。**
+#    地板变高不是「更宽容」，是**看见的东西变多了**；这两个数写在这里，
+#    是为了让下一个人能判断它该不该再变。
+HOME_PATH = re.compile(r"(?<![A-Za-z0-9._-])/home/([A-Za-z0-9._-]+)")
 
 # Names that are documentation placeholders or machine accounts rather than a
 # person. Kept explicit (and covered by --selftest) because the count moves when
@@ -63,7 +80,7 @@ def scan() -> tuple[dict[str, int], int]:
     tracked = [f for f in listing if f]
 
     out = subprocess.run(
-        ["git", "grep", "-InE", r"/home/[A-Za-z0-9._-]+/"],
+        ["git", "grep", "-InE", r"(^|[^A-Za-z0-9._-])/home/[A-Za-z0-9._-]+"],
         capture_output=True, text=True, check=False,
     ).stdout
 
@@ -155,7 +172,13 @@ def selftest() -> int:
         ("two letters do not", not is_person("ab")),
         ("three letters do", is_person("abc")),
         ("regex finds the name between slashes", HOME_PATH.findall(f"cd {home}zqxjkv{slash}work") == ["zqxjkv"]),
-        ("regex needs the trailing slash", HOME_PATH.findall(f"{home}zqxjkv") == []),
+        # 🔴 这三条替换掉旧的 `regex needs the trailing slash` —— 那条钉住的是
+        # 一个会漏掉 `ENV HOME=/home/<名>` 的行为。
+        ("a path with no trailing slash still counts", HOME_PATH.findall(f"{home}zqxjkv") == ["zqxjkv"]),
+        ("a home dir nested under another path does not count",
+         HOME_PATH.findall(f"{slash}runtime{home}zqxjkv{slash}x") == []),
+        ("a var-rooted home dir does not count",
+         HOME_PATH.findall(f"$case_root{home}zqxjkv") == []),
         ("two paths on one line are both found", len(HOME_PATH.findall(f"{home}aaa{slash}x {home}bbb{slash}y")) == 2),
     ]
     bad = [n for n, ok in cases if not ok]

--- a/docs/home-path-baseline.txt
+++ b/docs/home-path-baseline.txt
@@ -1,15 +1,27 @@
-# 每行:<文件>\t<该文件里 /home/<人名>/ 的出现次数>
+# 每行:<文件>\t<该文件里 /home/<人名> 的出现次数>
 # 这是一个**上限**,不是目标。它存在的意义是让「新增」变红,而不是让「存量」变红——
 # 一道只因积压而红的门,等积压清完就再也不会红,到时没人知道它还有没有效。
 # 清理某个文件之后,把它这一行的数字改小(或整行删掉),楼层就只会往下走、不会悄悄回填。
-# 生成于 origin/main,2026-08-18:203 次 / 71 文件 / 共扫 2000 个跟踪文件。
+#
+# 🔴 2026-08-19 重算,因为**判据的覆盖面变了**,不是因为存量变多了:
+#   ① 不再要求结尾斜杠 ⇒ 多看见 38 处 / 20 个文件(`ENV HOME=/home/<名>`、
+#      `chown -R <名>:<名> /home/<名>` 这类恰好是这个门最该看见的形状,原先隐形)
+#   ② 加了根边界     ⇒ 去掉 18 处误报(`/runtime/home/x/`、`$case_root/home/.anet`
+#      里的 `/home/` 不是系统家目录)
+#   净效果 198 → 218。**地板变高 = 看见的东西变多,不是更宽容。**
+#   下一次有人想再动这两个数,请先读 .github/scripts/check-home-path-baseline.py
+#   里 HOME_PATH 上方那段注释。
+# 生成于 origin/main 3fd3e4bb,2026-08-19:218 次 / 76 文件 / 共扫 2090 个跟踪文件。
+.github/scripts/check-no-memory-slugs.py	1
+AGENTS.md	1
+agent-network/bin/cli.ts	1
 agent-network/docs/lessons/2026-05-28-mcp-json-shared-identity-pollution.md	3
 agent-network/docs/tests/report-grok-build-capability.txt	4
 agent-network/scripts/README.md	3
 agent-network/scripts/opencode-node-start.sh	4
 agent-network/scripts/pm2-opencode.config.cjs	3
-agent-network/src/batch-workdir.test.ts	3
-agent-network/src/grok-copresence-profile.test.ts	5
+agent-network/src/batch-workdir.test.ts	8
+agent-network/src/grok-copresence-profile.test.ts	13
 agent-network/src/project-key.ts	1
 agent-network/src/tmux-pane-prompt.test.ts	1
 agent-network/tests/project-key.test.ts	6
@@ -26,8 +38,8 @@ docs/anet-codex-remote-control-plan.md	1
 docs/codex-cli-direct-comm-research.md	1
 docs/grok-build-runtime.md	2
 docs/research/codex-sdk-goal-feasibility.md	1
-docs/research/grok-video-gen-capability-probe.en.md	3
-docs/research/grok-video-gen-capability-probe.md	3
+docs/research/grok-video-gen-capability-probe.en.md	4
+docs/research/grok-video-gen-capability-probe.md	4
 docs/research/grok-x-search-capability-probe.en.md	1
 docs/research/grok-x-search-capability-probe.md	1
 docs/research/intern-tool-calling-investigation.md	1
@@ -35,6 +47,7 @@ docs/research/sdk-concurrency-investigation.md	1
 docs/rfcs/RFC-005-codex-code-cli-runtime.md	1
 docs/runbooks/opencode-tui-copresence.md	1
 docs/sdk-upgrade-2026-05-12-baseline.md	4
+docs/tests/p-214-wave2-harness/Dockerfile.7fix	1
 docs/tests/p-498-reply-warning/witnessed-red.txt	1
 docs/tests/p-517-mcp-write-scope/witnessed-red-p2-ghost.txt	3
 docs/tests/p-517-mcp-write-scope/witnessed-red-pins-sabotage.txt	21
@@ -48,27 +61,30 @@ docs/tests/report-test227-live-uat.txt	1
 docs/tests/report-test227.txt	2
 docs/tests/report-test229-opencode-final-review-packet.txt	1
 docs/tests/report-test231-grok-socket-sandbox-green.txt	2
-docs/tests/report-test231-grok-socket-sandbox-red.txt	2
+docs/tests/report-test231-grok-socket-sandbox-red.txt	4
 docs/tests/report-test231-grok-socket-sandbox-summary.txt	1
 docs/tests/report-test232-live-uat.txt	1
 docs/tests/report-test386.txt	2
 docs/tests/report-test573.txt	2
 docs/tests/report-test653-batch-workdir.txt	1
 docs/tests/report-test735-hub-daemon-rebuild.txt	1
+docs/troubleshooting/rm-rf-incident-2026-06-16.md	2
 server/src/uploads.test.ts	1
+tests/lib/safe-rm.sh	2
+tests/qa-222-cross-host-attachments/Dockerfile	1
 tests/test-rename-identity/lib/helpers.sh	1
 tests/test225-grok-preview-package-live/auth-evidence-diagnostic.test.mjs	1
-tests/test225-grok-preview-package-live/run.sh	3
-tests/test231-grok-socket-sandbox/run.sh	7
+tests/test231-grok-socket-sandbox/run.sh	10
+tests/test231-grok-socket-sandbox/socket-path.ts	1
+tests/test232-grok-xsearch-process-profile/run-tui.sh	1
 tests/test380-gateway-topology-probe/docker-compose.yml	1
 tests/test383-thinking-only-fallback/docker-compose.yml	1
-tests/test386-opencode-agent-node-gate/Dockerfile	9
-tests/test386-opencode-agent-node-gate/nonroot-real-package.ts	11
-tests/test653-batch-workdir/run.sh	9
+tests/test386-opencode-agent-node-gate/Dockerfile	11
+tests/test386-opencode-agent-node-gate/nonroot-real-package.ts	12
 tests/test698-atomic-peer-reply/cli-wiring-e2e.ts	2
 tests/test698-atomic-peer-reply/legacy-cli-failure-e2e.ts	1
 tests/test698-atomic-peer-reply/legacy-wire-e2e.ts	2
-tests/test735-hub-daemon-rebuild/run.sh	6
-tests/test736-pm2-fleet-rebuild/Dockerfile	2
-tests/test736-pm2-fleet-rebuild/run.sh	1
-tests/test765-batch-runtime-gate/run.sh	2
+tests/test735-hub-daemon-rebuild/Dockerfile	1
+tests/test735-hub-daemon-rebuild/run.sh	2
+tests/test736-pm2-fleet-rebuild/Dockerfile	4
+tests/test736-pm2-fleet-rebuild/run.sh	2


### PR DESCRIPTION
在 `origin/main` 3fd3e4bb 上实测的数字，不是转述。

## 缺口

    现行判据计入            198 处 / 69 文件
    🔴 因【缺结尾斜杠】隐形    38 处 / 20 文件
    🔴 计入里本身是误报        18 处

隐形的那批**恰好是这个门最该看见的形状**：

    tests/test736-pm2-fleet-rebuild/Dockerfile:22   ENV HOME=/home/<名>
    tests/test736-pm2-fleet-rebuild/Dockerfile:19   chown -R <名>:<名> /home/<名>
    agent-network/src/grok-copresence-profile.test.ts   HOME: "/home/<名>"

误报那批不是系统家目录：`/runtime/home/auth.json`、`$case_root/home/.anet`。

## ⚠️ 这不是补一个疏忽，是推翻一条**被钉住的**行为

旧 selftest 里有：

```python
("regex needs the trailing slash", HOME_PATH.findall(f"{home}zqxjkv") == []),
```

**有人明确把「要求结尾斜杠」写成了正确行为。** 本 PR 改掉这条钉，理由写在
`HOME_PATH` 上方的注释里：`ENV HOME=/home/<名>` 是真实的家目录路径，
它不带结尾斜杠只是因为它是路径末尾。

取集层的 `git grep -InE` 也一起放宽了。**判据放宽而取集不放宽，
候选行根本取不到 —— 门会「看起来修好了但一条都不报」**，
而那种绿和真绿在输出上逐字相同。

## 基线 198 → 218，整份重算

**地板变高 = 看见的东西变多，不是更宽容。**
重算同时兑现了门自己要求的「往下棘轮」——4 个文件的数字降了：

    test653-batch-workdir/run.sh          9 → 0   ← 全是 $case_root/home/ 误报
    test225-grok-preview-package-live/run.sh 3 → 0
    test765-batch-runtime-gate/run.sh     2 → 0
    test735-hub-daemon-rebuild/run.sh     6 → 2

## 见证红（探针 `git add` 过 —— `git ls-files` 看不见未跟踪文件）

    A  新增【无结尾斜杠】 /home/zqxjkv    改后 rc=1 ✅
       同一个探针在 origin/main 的判据下  **看不到** ← 缺口坐实
    B  新增【有结尾斜杠】 /home/zqxjkv/   改后 rc=1 ✅  旧能力没丢
    清理后 rc=0，零残留

`--selftest` 13/13（新增 3 条钉住新行为，删掉 1 条钉住旧行为的）。

## 我没做的事

**没有清理任何一处存量。** 本 PR 只改门的覆盖面和基线，一个 `/home/<名>` 都没删 ——
清理是另一件事，而且删错地方会让事故记录失去可复现性
（`docs/troubleshooting/rm-rf-incident-2026-06-16.md` 里那两处真实路径是载荷）。
