### PR TITLE
ci: 把 test236 从孤儿基线挪进 L1（孤儿地板 97 → 96）

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -30,6 +30,7 @@ on:
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
       # ~160 dirs under tests/ are not run by any workflow, so listing them
       # would only look like coverage.
+      - 'tests/test236-dashboard-codex-goal/**'
       - 'tests/test292-e2e-hard-gate/**'
       - 'tests/test686-rest-shape-golden/**'
       - 'tests/test765-batch-runtime-gate/**'
@@ -144,6 +145,7 @@ on:
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
       # ~160 dirs under tests/ are not run by any workflow, so listing them
       # would only look like coverage.
+      - 'tests/test236-dashboard-codex-goal/**'
       - 'tests/test292-e2e-hard-gate/**'
       - 'tests/test686-rest-shape-golden/**'
       - 'tests/test765-batch-runtime-gate/**'

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -51,7 +51,6 @@ test227-opencode-tui-copresence
 test228-opencode-inbox-concurrency
 test23-codex-telegram
 test230-opencode-sender-label
-test236-dashboard-codex-goal
 test24-codex-commander
 test25-agent-telegram
 test26-network-scope

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -72,6 +72,12 @@ L1_TESTS=(
   "qa-hub-07-sse-reconnect"
   "qa-hub-08-restart-persistence"
   "qa-hub-09-task-state-machine"
+  # 2026-08-19 补注册。它一直是孤儿(docs/test-suite-orphan-baseline.txt),
+  # 而在此之前套件里有 3 处字面量随一次改名过期(#1072):1 条 production grep
+  # 0 命中、2 条变异锚点 0 命中 ⇒ 变异是 no-op。修好之后它有三条成立的见证红,
+  # 才够格进这里 —— **先让它真的能红，再让 CI 跑它**。
+  # 按 qa.sh 的真实调法(docker run --rm，不挂 /artifacts)实测 rc=0。
+  "test236-dashboard-codex-goal"
   # 2026-08-18 补注册 —— 这四个是 #863 修好的那批(commit 61f7203a,「静默失效 6 周」
   # 实跑 4/4 从红到绿),但修完之后**没有注册到任何地方**,于是回到了同一个位置:
   # 没有任何东西会跑它们。#861 的实测把最后一个未知量补上了。


### PR DESCRIPTION
承接 #1072。**先让它真的能红，再让 CI 跑它。**

## 它一直是孤儿

`origin/main` 上 23 个 workflow 文件 + `scripts/qa.sh` 里提到 `test236` 的：**0 处**。
CI 全绿也不会碰它。（对照 `test292`：`e2e-docker.yml` 1 · `qa-trigger-coverage.yml` 1 · `qa.yml` 2）

## 之前不该登记

`#1072` 实测：1 条 production grep 0 命中、2 条变异锚点 0 命中 ⇒ 变异是 no-op。
一个变异不会变异的套件登记进 CI，只会把「有覆盖」这个假象固定下来。
`#1072` 合入后它有三条成立的见证红，才够格。

## 三处一起改，少一处就是「名字在但不跑」

    ① scripts/qa.sh                        L1_TESTS 加一条  ← 真正被执行的地方
    ② .github/workflows/qa.yml             paths 两处      ← 否则改这个测试不会重跑跑它的门
    ③ docs/test-suite-orphan-baseline.txt  删掉这一行

⚠️ 顺带记一条**本 PR 不改**的事：登记门认的是「套件名出现在 `qa.sh` + 所有 workflow 的
任意位置」——**纯子串匹配**。那意味着一句注释里提到套件名就算「已登记」。
**存在 / 挂上 / 会被触发是三件事，这个门只判第一件。** 另开。

## 实测

    登记门   suites=205 registered=102→103 orphans=97→96 baseline=96 new=0
    qa.sh --list  能看到 tests/test236-dashboard-codex-goal/（L1 共 23 条）

按 `qa.sh` 的**真实调法**跑（`docker run --rm`，**不挂 `/artifacts`**
—— 我先前两次是挂了卷跑的，那不是 CI 的调法）：`rc=0`，三条见证红全在。

耗时（🔴 warm 是误导，`qa.sh` 自己的注释就记着这个坑）：

    warm  build   0s + run  2s =   2s
    冷    build 119s + run 10s = **129s**   ← CI runner 是冷的

L1 并行跑（上限 `nproc`），所以不是给墙钟直接加 129s，但构建工作量是实打实的。