### PR TITLE
refactor(test236): 用本仓已有的 assert_changed，别再造第三种写法

### DIFF
--- a/tests/test236-dashboard-codex-goal/run.sh
+++ b/tests/test236-dashboard-codex-goal/run.sh
@@ -15,19 +15,22 @@ run() {
 }
 
 # 🔴 变异必须真的改动文件，否则算【锚点过期】而不是产品缺陷。
-#    为什么不预先 grep 锚点：锚点里含 `\\n` 这类转义，在 grep -F / sed / shell 引号
-#    三层里的含义不同，判据本身就会成为 bug 源。**直接量「文件改没改」不需要任何转义。**
+#    这个 helper 的名字和形状**沿用本仓已有的写法**（tests/test689-owner-schedule-agent/run.sh:41），
+#    而不是再发明一个 —— 本仓已有 27 个套件用 expect_red 断言「变异让测试变红」，
+#    但只有 1 个（test689）同时断言「变异真的改动了文件」。这里补上第 2 个。
+#
+#    为什么不预先 grep 锚点：锚点里含 `\n` 这类转义，在 grep -F / sed / shell 引号
+#    三层里的含义不同，判据本身就会成为 bug 源。**比对 sha256 不需要任何转义。**
 #    背景（2026-08-19 实测 origin/main）：3 条锚点里 2 条 0 命中 ——
 #    一次改名把 Codex/INTERVAL 换成了 Native/SCHEDULE，本文件的字面量没跟上。
-#    sed 打不中时是 **no-op** ⇒ 产品没被改坏 ⇒ 测试绿 ⇒ 下面那句
+#    sed 打不中时是 no-op ⇒ 产品没被改坏 ⇒ 测试绿 ⇒ 下面那句
 #    `FAIL: ... stayed green` 照样会打，套件确实红了 —— **但那句红话指错了层**：
-#    它把人指向产品，而该改的是这个文件。这个函数把它变成一句指对层的红话。
-mutate() { # $1=目标文件 $2=sed 表达式（原样透传，不经二次解析）
-  cp "$1" /tmp/pre-mutation.snapshot
-  sed -i "$2" "$1"
-  if cmp -s /tmp/pre-mutation.snapshot "$1"; then
-    printf 'FAIL: 变异未改动 %s —— 【测试锚点过期】，不是产品缺陷\n' "$1" | tee -a "$REPORT"
-    printf '  sed: %s\n' "$2" | tee -a "$REPORT"
+#    它把人指向产品，而该改的是这个文件。
+assert_changed() {  # $1=目标文件 $2=变异前的 sha256
+  local after
+  after="$(sha256sum "$1" | cut -d' ' -f1)"
+  if [[ "$after" == "$2" ]]; then
+    printf 'FAIL: 变异后文件逐字未变 %s —— 【测试锚点过期】，不是产品缺陷\n' "$1" | tee -a "$REPORT"
     exit 1
   fi
 }
@@ -65,7 +68,9 @@ run production-build bash -ceu '
 # leaving the test unchanged. The screenshot's interval-free `/goal` must be
 # intercepted again, so the focused routing test has to fail.
 cp /workspace/agent-node/src/goals/routing.ts /tmp/routing.original.ts
-mutate /workspace/agent-node/src/goals/routing.ts 's/return !interactiveDashboardTask;/return true;/'
+_pre="$(sha256sum /workspace/agent-node/src/goals/routing.ts | cut -d' ' -f1)"
+sed -i 's/return !interactiveDashboardTask;/return true;/' /workspace/agent-node/src/goals/routing.ts
+assert_changed /workspace/agent-node/src/goals/routing.ts "$_pre"
 set +e
 bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/mutation.out 2>&1
 mutation_rc=$?
@@ -83,7 +88,9 @@ run restored-green bun test /workspace/agent-node/src/goals/routing.test.ts
 # Witnessed-red: keep the routing exception but remove the deterministic
 # interval notice from the successful reply. The ambiguity regression must be
 # observable even though the goal itself still reaches Codex.
-mutate /workspace/agent-node/src/goals/routing.ts 's/return `${DASHBOARD_NATIVE_SCHEDULE_NOTICE}\\n\\n${replyText}`;/return replyText;/'
+_pre="$(sha256sum /workspace/agent-node/src/goals/routing.ts | cut -d' ' -f1)"
+sed -i 's/return `${DASHBOARD_NATIVE_SCHEDULE_NOTICE}\\n\\n${replyText}`;/return replyText;/' /workspace/agent-node/src/goals/routing.ts
+assert_changed /workspace/agent-node/src/goals/routing.ts "$_pre"
 set +e
 bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/notice-mutation.out 2>&1
 notice_mutation_rc=$?
@@ -101,7 +108,9 @@ run final-green bun test /workspace/agent-node/src/goals/routing.test.ts
 # Witnessed-red: evaluate low-value status against the raw model text instead
 # of the notice-prefixed text. A model reply of "收到" would then suppress the
 # required interval warning.
-mutate /workspace/agent-node/src/goals/routing.ts 's/!isLowValueReply(text)/!isLowValueReply(replyText)/'
+_pre="$(sha256sum /workspace/agent-node/src/goals/routing.ts | cut -d' ' -f1)"
+sed -i 's/!isLowValueReply(text)/!isLowValueReply(replyText)/' /workspace/agent-node/src/goals/routing.ts
+assert_changed /workspace/agent-node/src/goals/routing.ts "$_pre"
 set +e
 bun test /workspace/agent-node/src/goals/routing.test.ts > /tmp/order-mutation.out 2>&1
 order_mutation_rc=$?


### PR DESCRIPTION
承接 #1072。**这个 PR 修的是我自己两小时前引入的一个分歧写法。**

## 我数了一遍，发现本仓早就有这个东西

    tests/test689-owner-schedule-agent/run.sh:41   assert_changed()   ← sha256 比对
    27 个套件用 expect_red（断言「变异让测试变红」）
    🔴 只有 1 个（test689）同时断言「变异真的改动了文件」

⇒ 我在 #1072 里加的 `mutate()` 是本仓的**第三种**写法。改掉，沿用 test689 的
名字和形状，只保留我那句更具诊断性的红话。

## 🔴 顺带自曝一次量错

我先用「有没有 `rc=$?` 捕获 + `-eq 0` 守卫」筛出「变异了但不检查是否变红」的套件，
表里把 `test689` 和 `test813` 标成了 🔴「没有守卫」。

读原文之后：**它们的守卫比没被标红的那些更强**，只是封装成了命名 helper：

    test689:  assert_changed "$CONTROL" "$ORIG_CONTROL"
              expect_red command-fingerprint bash -lc "…"
    test813:  expect_red stale-three-tool-doctor 'readiness failed: 3 tools discovered' \
                sed -i 's/"4 tools discovered"/"3 tools discovered"/' …   ← 还断言了**红的理由**

**判据只认一种写法时，漏掉的往往正是写得更好的那些。**
这也是我这轮没有把那张表当结论、而是逐个读原文的原因。

## 实测

    正常跑                rc=0，3 条见证红全在
    把一条锚点改成过期的   rc=1，打出：
      FAIL: 变异后文件逐字未变 /workspace/agent-node/src/goals/routing.ts
            —— 【测试锚点过期】，不是产品缺陷

（test236 已在 L1，见 #1074，所以这次 CI 会真的跑它。）

## 一个我**没做**的事

没有把 `assert_changed` 铺到另外 26 个用 `expect_red` 的套件。
那是一次跨 26 个文件的改动，每个套件的结构不同，值得单独一个 PR 并逐个真跑。
**1/27 这个数字先记在这里。**