### PR TITLE
test: 3 处 sed 变异没有验「变异是否真的生效」——补上本仓已有的写法

### DIFF
--- a/tests/test600-public-skillhub/run.sh
+++ b/tests/test600-public-skillhub/run.sh
@@ -28,6 +28,7 @@ cp -a docs-site/docs/public/skillhub "$case_root/docs-site/docs/public/"
 
 cp -a "$case_root" /tmp/test600-license
 sed -i 's/"Apache-2.0"/"UNLICENSED"/' /tmp/test600-license/docs-site/docs/public/skillhub/skills/skill-writing-guide/1.0.0/metadata.json
+grep -F '"UNLICENSED"' /tmp/test600-license/docs-site/docs/public/skillhub/skills/skill-writing-guide/1.0.0/metadata.json >/dev/null
 expect_red "unsupported license is rejected" node /tmp/test600-license/scripts/build-public-skillhub.mjs
 
 cp -a "$case_root" /tmp/test600-secret

--- a/tests/test660-explicit-prod-db-optin/run.sh
+++ b/tests/test660-explicit-prod-db-optin/run.sh
@@ -84,6 +84,7 @@ cp /tmp/test660-db-adapter.orig server/src/db-adapter.ts
 
 cp server/src/index.ts /tmp/test660-index.orig
 sed -i 's/process.env.COMMHUB_SERVER = "1";/\/\/ mutation: server capability removed/' server/src/index.ts
+grep -F '// mutation: server capability removed' server/src/index.ts >/dev/null
 expect_red remove-index-optin bash -c '
   mutation_home=$(mktemp -d /tmp/test660-index-mutation.XXXXXX)
   env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER HOME="$mutation_home" PORT=25662 HOST=127.0.0.1 COMMHUB_DEV_OPEN=1 \
@@ -104,6 +105,7 @@ cp /tmp/test660-index.orig server/src/index.ts
 
 cp server/bin/commhub.ts /tmp/test660-bin.orig
 sed -i 's/process.env.COMMHUB_SERVER = "1";/\/\/ mutation: server capability removed/' server/bin/commhub.ts
+grep -F '// mutation: server capability removed' server/bin/commhub.ts >/dev/null
 expect_red remove-bin-optin bash -c '
   mutation_home=$(mktemp -d /tmp/test660-bin-mutation.XXXXXX)
   env -u COMMHUB_DB -u DATABASE_URL -u COMMHUB_SERVER HOME="$mutation_home" \


### PR DESCRIPTION
承接 #1072 / #1075。**这个 PR 的数字是我数错三次之后才对的，过程比结论值得看。**

## 缺口

test236 出过一次：一次改名让变异锚点 0 命中 ⇒ `sed` 是 no-op ⇒ 产品没被改坏 ⇒
测试绿 ⇒ `expect_red` 打出一句**指向产品**的红话（而该改的是测试文件）。

本仓**绝大多数套件早就防了这件事**，写法是 `sed` 之后紧跟一行：

    grep -F '<变异后的形态>' <文件> >/dev/null

真正缺这一步的只有 **3 处**：

    tests/test600-public-skillhub/run.sh          license 那条 sed
                                                  （另两个变异是 printf 追加，不会 no-op）
    tests/test660-explicit-prod-db-optin/run.sh   server/src/index.ts 与 server/bin/commhub.ts 两条
                                                  🔴 同一个文件的第一条 sed **已经有** grep -F，
                                                     只是没被一致应用

补的就是邻居已经在用的那一行，**没有引入任何新写法**。

## 🔴 我数错了三次，每次都是「只认一种写法」

    第 1 次  数「有没有 assert_changed」      → 得出 1/27
    第 2 次  数「有没有 rc=$? + -eq 0」       → 把 test689/test813 标成没守卫（它们守得更强）
    第 3 次  数「sed 附近有没有 grep -...q」  → 漏掉 test659，因为它写的是 `grep -F ... >/dev/null`
                                                **差一个字母**

最终 3 处是**逐个读原文**得到的。**三次收敛没有一次来自更好的正则。**

## 实测（本机 docker，按各自 Dockerfile 的 build-arg 钉 SOURCE_COMMIT）

**test600**

    正常                                  rc=0   RESULT: PASS (12 checks)
    把 "Apache-2.0" 锚点改成过期的         rc=1   日志停在
      `PASS witnessed-red: unsupported license is rejected` **之前**

**test660**

    正常                                  rc=0   RESULT pass=8 fail=0
    把 index.ts 那条锚点改成过期的         rc=1
      `remove-default-path-guard witnessed red`  正常✓ 变异✓（在我改的那处之前，不受影响）
      `remove-index-optin        witnessed red`  正常✓ 变异✗  ← 恰好停在新守卫上
      `remove-bin-optin          witnessed red`  正常✓ 变异✗

⇒ 两处都**在那句会误导人的 `expect_red` 之前**就停下，并且不影响前面已经成立的见证红。

## 我没做的事

没有把 `assert_changed` 铺开、没有统一写法、没有碰其余 25 个套件 ——
它们已经用 `grep -F` 防住了这件事，**改它们只会制造分歧**。