### PR TITLE
ci: 把 test657 从孤儿基线挪进 L1（孤儿地板 96 → 95）

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -30,6 +30,7 @@ on:
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
       # ~160 dirs under tests/ are not run by any workflow, so listing them
       # would only look like coverage.
+      - 'tests/test657-claude-native-version-pin/**'
       - 'tests/test236-dashboard-codex-goal/**'
       - 'tests/test292-e2e-hard-gate/**'
       - 'tests/test686-rest-shape-golden/**'
@@ -145,6 +146,7 @@ on:
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
       # ~160 dirs under tests/ are not run by any workflow, so listing them
       # would only look like coverage.
+      - 'tests/test657-claude-native-version-pin/**'
       - 'tests/test236-dashboard-codex-goal/**'
       - 'tests/test292-e2e-hard-gate/**'
       - 'tests/test686-rest-shape-golden/**'

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -95,7 +95,6 @@ test652-admin-network-list
 test653-batch-workdir
 test654-dashboard-managed-launch
 test656-claude-sdk-tool-aliases
-test657-claude-native-version-pin
 test673-claude-image-attachment-block
 test696-human-low-value-reply
 test7-config

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -78,6 +78,12 @@ L1_TESTS=(
   # 才够格进这里 —— **先让它真的能红，再让 CI 跑它**。
   # 按 qa.sh 的真实调法(docker run --rm，不挂 /artifacts)实测 rc=0。
   "test236-dashboard-codex-goal"
+  # 2026-08-19 补注册。孤儿，但它本来就够格:两条 sed 变异后面都紧跟
+  # `grep -F '<变异后形态>' … >/dev/null`(锚点过期会当场红,而不是让变异变成 no-op),
+  # 且 :23-25 拿 resolver 的输出和【真实已安装的 SDK 版本】比,不是自证。
+  # 按 qa.sh 的真实调法(docker run --rm,不挂 /artifacts)实测 rc=0 pass=5 fail=0,
+  # 两条见证红都成立。耗时 build 105s + run 2s。
+  "test657-claude-native-version-pin"
   # 2026-08-18 补注册 —— 这四个是 #863 修好的那批(commit 61f7203a,「静默失效 6 周」
   # 实跑 4/4 从红到绿),但修完之后**没有注册到任何地方**,于是回到了同一个位置:
   # 没有任何东西会跑它们。#861 的实测把最后一个未知量补上了。


### PR DESCRIPTION
承接 #1074（test236 那次）。**挑它不是因为它排第一，是因为它本来就够格。**

## 它够格在哪

    两条 sed 变异后面都紧跟 `grep -F '<变异后形态>' … >/dev/null`
      ⇒ 锚点过期会**当场红**，而不是让变异悄悄变成 no-op
         —— 这正是 #1072 在 test236 上踩过、#1077 在 test600/test660 上补过的那一格
    run.sh:23-25 拿 resolver 的输出和【真实已安装的 SDK 版本】比，不是自证
    结尾 `RESULT pass=N fail=N` + `[[ "$FAIL" -eq 0 ]]`

在 `origin/main`(e9f660de) 上，**同时具备 `expect_red` 和 `sed` 变异的孤儿只有 3 个**：

| 孤儿 | expect_red | sed | 「变异是否生效」的守卫 |
|---|---|---|---|
| **test657-claude-native-version-pin** | 3 | 2 | **2** ✅ |
| test654-dashboard-managed-launch | 5 | 4 | 🔴 **0** |
| test656-claude-sdk-tool-aliases | 3 | 1 | 1 |

test654 条目最多但一处守卫都没有 —— **先把它接进 CI 只会把「有覆盖」的假象固定下来**，
所以先接 test657。（test654 是下一个候选，但要先补守卫。）

## 三处一起改，少一处就是「名字在但不跑」

    ① scripts/qa.sh                        L1_TESTS 加一条  ← 真正被执行的地方
    ② .github/workflows/qa.yml             paths 两处      ← 否则改这个测试不会重跑跑它的门
    ③ docs/test-suite-orphan-baseline.txt  删掉这一行

## 实测（按 `qa.sh` 的真实调法 `docker run --rm`，**不挂 `/artifacts`**）

    rc=0   pass=5 fail=0
    PASS resolver matches real installed SDK 0.3.235
    PASS mutation unpin-native-version witnessed red
    PASS mutation bypass-installed-version witnessed red
    耗时 build 105s + run 2s

    登记门  suites=205 registered=103→104 orphans=96→95 baseline=95 new=0
    qa.sh --list 里能看到它（L1 共 24 条）