### PR TITLE
test(test654): 4 条变异都没验「变异是否真的生效」——而且这里不能用 grep 写法

### DIFF
--- a/tests/test654-dashboard-managed-launch/run.sh
+++ b/tests/test654-dashboard-managed-launch/run.sh
@@ -27,6 +27,20 @@ expect_red(){
   if "$@" >"$ART/$name.log" 2>&1; then bad "mutation $name stayed green"; else ok "mutation $name witnessed red"; fi
 }
 
+# 🔴 变异必须真的改动文件，否则算【测试锚点过期】而不是产品缺陷。
+#    为什么这里**不能**用本仓另一种常见写法 `grep -F '<变异后的形态>' <文件>`：
+#      · 下面第一条变异把 `input.healthy && record.source === … && record.source_key === …`
+#        换成 `input.healthy` —— **变异后的形态是原文的子串**，grep 它变异前也命中，
+#        那会是一个恒真的守卫；
+#      · 后两条是**删行**（`sed -i '0,/…/{//d;}'`），压根没有「变异后的形态」可 grep。
+#    ⇒ 这四条只能比对「文件有没有变」。每条变异前本来就已经 cp 了一份 .orig，直接用它。
+assert_mutated(){ # $1=目标文件 $2=变异前的副本
+  cmp -s "$1" "$2" || return 0
+  bad "mutation did not change $1 —— 【测试锚点过期】，不是产品缺陷"
+  printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
+  exit 1
+}
+
 cleanup_pids=()
 cleanup(){
   for pid in "${cleanup_pids[@]:-}"; do
@@ -243,20 +257,24 @@ else bad "missing-inspector guard failed"; fi
 echo "== L6 witnessed-red mutations =="
 cp "$ROOT/agent-network/src/dashboard-managed-process.ts" "$WORK/dashboard-managed-process.ts.orig"
 sed -i 's/input\.healthy && record\.source === input\.desiredSource && record\.source_key === input\.desiredSourceKey/input.healthy/' "$ROOT/agent-network/src/dashboard-managed-process.ts"
+assert_mutated "$ROOT/agent-network/src/dashboard-managed-process.ts" "$WORK/dashboard-managed-process.ts.orig"
 expect_red version-gate bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
 cp "$WORK/dashboard-managed-process.ts.orig" "$ROOT/agent-network/src/dashboard-managed-process.ts"
 sed -i 's/if (!record) return { action: "refuse", reason: `port ${input.port} is occupied by an unmanaged process (pid ${pid})` };/if (!record) return { action: "terminate_owned_stale", pid, reason: "unhealthy" };/' "$ROOT/agent-network/src/dashboard-managed-process.ts"
+assert_mutated "$ROOT/agent-network/src/dashboard-managed-process.ts" "$WORK/dashboard-managed-process.ts.orig"
 expect_red unmanaged-gate bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
 cp "$WORK/dashboard-managed-process.ts.orig" "$ROOT/agent-network/src/dashboard-managed-process.ts"
 bun test "$ROOT/agent-network/src/dashboard-managed-process.test.ts"
 
 cp "$CLI" "$WORK/cli.ts.orig"
 sed -i '0,/if (!revalidateExactManagedDashboard(pid, port, expectedRecord)) return false;/{//d;}' "$CLI"
+assert_mutated "$CLI" "$WORK/cli.ts.orig"
 expect_red birth-recheck run_birth_race 33106 "$ART/birth-recheck-inner.log"
 cp "$WORK/cli.ts.orig" "$CLI"
 
 cp "$CLI" "$WORK/cli.ts.orig"
 sed -i '0,/if (!revalidateExactManagedDashboard(pid, port, expectedRecord)) return false;/{//d;}' "$CLI"
+assert_mutated "$CLI" "$WORK/cli.ts.orig"
 expect_red foreign-reuse-recheck run_foreign_reuse_race 33108 "$ART/foreign-reuse-recheck-inner.log"
 cp "$WORK/cli.ts.orig" "$CLI"
 


### PR DESCRIPTION
承接 #1077 / #1078。**这个套件是「同一个属性、不同的正确写法」最清楚的一个例子。**

## 为什么是它

`origin/main` 上同时具备 `expect_red` 和 `sed` 变异的孤儿只有 3 个，
它 sed 最多（4 条），也是唯一**一处守卫都没有**的。
`#1078` 里我因此**没有先接它进 CI** —— 先接只会把「有覆盖」的假象固定下来。

## 🔴 这里不能照搬 `grep -F '<变异后的形态>'`

本仓多数套件用那个写法，但在这四条上它是错的：

    第 1 条  `input.healthy && record.source === … && record.source_key === …`
             → `input.healthy`
             ⇒ **变异后的形态是原文的子串**，grep 它在变异前也命中 ⇒ **恒真的守卫**

    第 3、4 条  `sed -i '0,/…/{//d;}'` —— **删行**
             ⇒ 压根没有「变异后的形态」可 grep

⇒ 只能比对「文件有没有变」。而每条变异前本来就已经 `cp` 了一份 `.orig`，直接用它。

## 一个细节：`exit 1` 之前仍然打印 RESULT 行

    assert_mutated(){
      cmp -s "$1" "$2" || return 0
      bad "mutation did not change $1 —— 【测试锚点过期】，不是产品缺陷"
      printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"
      exit 1
    }

否则「取不到 trailer」会被上层读成**「没跑」**而不是**「有问题」**——
这两件在输出上很容易混，而它们的处置相反。

## 实测（本机 docker，`TEST654_SOURCE_COMMIT` 已钉）

    正常                                   rc=0   RESULT pass=14 fail=0，四条见证红全成立
    把 revalidateExactManagedDashboard 锚点改过期  rc=1
      FAIL mutation did not change /repo/agent-network/bin/cli.ts
           ——【测试锚点过期】，不是产品缺陷
      RESULT pass=12 fail=1

      version-gate          正常✓ 变异✓   ← 在改动点之前，不受影响
      unmanaged-gate        正常✓ 变异✓
      birth-recheck         正常✓ 变异✗   ← 恰好停在新守卫上
      foreign-reuse-recheck 正常✓ 变异✗

    耗时 build 104s + run 39s

## 本 PR 不做的事

**不登记它进 CI。** 先补守卫、再登记，顺序不反。登记是下一个 PR。