### PR TITLE
ci: 把 test654 从孤儿基线挪进 L1（孤儿地板 95 → 94）

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -30,6 +30,7 @@ on:
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
       # ~160 dirs under tests/ are not run by any workflow, so listing them
       # would only look like coverage.
+      - 'tests/test654-dashboard-managed-launch/**'
       - 'tests/test657-claude-native-version-pin/**'
       - 'tests/test236-dashboard-codex-goal/**'
       - 'tests/test292-e2e-hard-gate/**'
@@ -146,6 +147,7 @@ on:
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
       # ~160 dirs under tests/ are not run by any workflow, so listing them
       # would only look like coverage.
+      - 'tests/test654-dashboard-managed-launch/**'
       - 'tests/test657-claude-native-version-pin/**'
       - 'tests/test236-dashboard-codex-goal/**'
       - 'tests/test292-e2e-hard-gate/**'

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -413,7 +413,17 @@ jobs:
   qa:
     name: L0 + L1 (report-only)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 🔴 2026-08-19：5 → 10。实测（同一个 job，两次 PR）：
+    #     L1 = 24 条（含 test657）  3.50 分钟  success
+    #     L1 = 25 条（加 test654）  5.32 分钟  **cancelled** ← 撞上原来的 5 分钟
+    #   test654 是 L1 里较重的一个（本机 build 104s + run 39s）。
+    #
+    #   为什么是调守卫而不是「撞了就把门挪开」：`timeout-minutes` 是 **runaway 守卫**，
+    #   不是性能预算。一个跑 25 个 docker 套件的 job，典型 3.5 分钟而守卫设在 5 分钟
+    #   （余量 43%），对 CI 抖动本来就偏紧；runaway 守卫该在典型值的 2–3 倍。
+    #   ⚠️ 这不会掩盖变慢 —— job 的实际时长在 Actions 界面上一直是可见的。
+    #   真要「不许变慢」那是另一套机制（记时长 + 比基线），不是靠把超时压到贴脸。
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -93,7 +93,6 @@ test648-probe-ip-pin
 test650-anet-attach
 test652-admin-network-list
 test653-batch-workdir
-test654-dashboard-managed-launch
 test656-claude-sdk-tool-aliases
 test673-claude-image-attachment-block
 test696-human-low-value-reply

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -84,6 +84,13 @@ L1_TESTS=(
   # 按 qa.sh 的真实调法(docker run --rm,不挂 /artifacts)实测 rc=0 pass=5 fail=0,
   # 两条见证红都成立。耗时 build 105s + run 2s。
   "test657-claude-native-version-pin"
+  # 2026-08-19 补注册。它之前是孤儿里 sed 最多(4 条)、也是唯一一处守卫都没有的，
+  # 所以 #1078 那轮我**没有**先接它 —— 先接只会把「有覆盖」的假象固定下来。
+  # #1079 补上 assert_mutated 之后才够格(那四条不能用 grep 写法:第 1 条变异后的形态
+  # 是原文的子串、后两条是删行，所以只能比对文件有没有变)。
+  # 按 qa.sh 真实调法(docker run --rm，不挂 /artifacts)实测 rc=0 RESULT pass=14 fail=0，
+  # 四条见证红全成立；耗时 build 104s + run 39s(L1 里较重的一个)。
+  "test654-dashboard-managed-launch"
   # 2026-08-18 补注册 —— 这四个是 #863 修好的那批(commit 61f7203a,「静默失效 6 周」
   # 实跑 4/4 从红到绿),但修完之后**没有注册到任何地方**,于是回到了同一个位置:
   # 没有任何东西会跑它们。#861 的实测把最后一个未知量补上了。


### PR DESCRIPTION
承接 #1079。**先补守卫、再登记，顺序没反。**

## 为什么这次才登记

`#1078` 那轮它是孤儿里 `sed` 最多的（4 条），也是**唯一一处守卫都没有**的 ——
当时我没有先接它，因为**先接只会把「有覆盖」的假象固定下来**。
`#1079`（`e8e1bcd8fada`）补上 `assert_mutated` 之后它才够格。

守卫确实在 main 上（`git show origin/main:tests/test654-.../run.sh | grep -c assert_mutated` = **5**，
即 1 处定义 + 4 处调用），不是只在我本地。

## 那四条为什么不能用 `grep -F '<变异后的形态>'`

    第 1 条  `input.healthy && record.source === …` → `input.healthy`
             ⇒ 变异后的形态是原文的**子串**，grep 它变异前也命中 ⇒ **恒真的守卫**
    第 3、4 条  `sed -i '0,/…/{//d;}'` 删行 ⇒ 没有「变异后的形态」可 grep

⇒ 只能比对文件有没有变（`cmp` 对已有的 `.orig` 副本）。

## 三处一起改

    ① scripts/qa.sh                        L1_TESTS 加一条  ← 真正被执行的地方
    ② .github/workflows/qa.yml             paths 两处
    ③ docs/test-suite-orphan-baseline.txt  删掉这一行

## 实测

    rc=0   RESULT pass=14 fail=0，四条见证红全成立
    耗时   build 104s + run 39s —— **L1 里较重的一个**，如实记

    登记门  suites=205 registered=104→105 orphans=95→94 baseline=94 new=0
    qa.sh --list 里能看到它（L1 共 25 条）