### PR TITLE
fix(test656): 逐字版本钉让依赖正常前进就判红——改成地板

### DIFF
--- a/tests/test656-claude-sdk-tool-aliases/run.sh
+++ b/tests/test656-claude-sdk-tool-aliases/run.sh
@@ -28,13 +28,28 @@ cd "$ROOT/agent-node"
 TYPE_PROBE=.test656-sdk-type-probe.ts
 cp "$TEST/sdk-type-probe.ts" "$TYPE_PROBE"
 SDK_VERSION=$(bun -e 'console.log((await Bun.file("node_modules/@anthropic-ai/claude-agent-sdk/package.json").json()).version)')
-[[ "$SDK_VERSION" == 0.3.226 ]] && ok "clean install resolved claude-agent-sdk 0.3.226" || bad "unexpected SDK $SDK_VERSION"
+# 🔴 这里原本是**逐字相等** `== 0.3.226`。agent-node/package.json 写的是 `^0.3.226`
+#    (caret 范围)，而本套件的 Dockerfile 只拷 package.json、**不拷 package-lock.json**
+#    ⇒ `bun install` 每次解析到当时最新的 0.3.x。上游发到 0.3.235 之后这条就红了，
+#    而红的原因是**依赖正常前进**，不是契约破了。实测 2026-08-19：FAIL unexpected SDK 0.3.235，
+#    其余 7 条(含两条见证红)全绿。
+#
+#    改成**地板**。放宽它不丢覆盖，因为真正验契约的是下面第 34 行的 tsc 类型探针
+#    (`Options.toolAliases` 在不在)，而本套件自己那条 `expect_red sdk-type-contract`
+#    ——把 SDK 降到 0.2.141 后 tsc 必须红——**就是「类型探针是承重的」的现成证据**。
+#    ⇒ 版本号只是代理指标，类型探针才是判据；代理指标该是地板，判据不动。
+MIN_SDK=0.3.226
+if [[ "$(printf '%s\n%s\n' "$MIN_SDK" "$SDK_VERSION" | sort -V | head -1)" == "$MIN_SDK" ]]; then
+  ok "clean install resolved claude-agent-sdk $SDK_VERSION (>= $MIN_SDK)"
+else
+  bad "SDK $SDK_VERSION 低于最低要求 $MIN_SDK"
+fi
 bun test src/claude-tool-aliases.test.ts
 ok "exact alias unit contract"
 ./node_modules/.bin/tsc --noEmit --skipLibCheck --moduleResolution bundler --module preserve --target ES2022 "$TYPE_PROBE"
-ok "SDK 0.3.226 publishes Options.toolAliases"
+ok "SDK $SDK_VERSION publishes Options.toolAliases"
 bun run build >/dev/null
-ok "agent-node bundle builds against SDK 0.3.226"
+ok "agent-node bundle builds against SDK $SDK_VERSION"
 
 export ANTHROPIC_BASE_URL="http://127.0.0.1:$PORT"
 export ANTHROPIC_API_KEY=test656-fake-key


### PR DESCRIPTION
**这个套件在 `origin/main`(e8e1bcd8) 上现在就是红的，我是先预测、后跑出来的。**

## 现状

    FAIL unexpected SDK 0.3.235
    RESULT pass=7 fail=1

其余 7 条全绿（含两条见证红）。唯一失败：

```bash
[[ "$SDK_VERSION" == 0.3.226 ]] && ok … || bad "unexpected SDK $SDK_VERSION"
```

`agent-node/package.json` 写的是 `^0.3.226`（**caret 范围**），
而本套件的 Dockerfile **只拷 `package.json`、不拷 `package-lock.json`**
⇒ `bun install` 每次解析到当时最新的 0.3.x。

⇒ 上游发到 0.3.235 之后这条就红了，**而红的原因是依赖正常前进，不是契约破了。**
和 `#1071` 在 test292 上修掉的「逐字相等」同一类：**一个惩罚正常前进的判据。**

## 改成地板，而且**不丢覆盖** —— 证据是这个套件自己给的

真正验契约的是 `run.sh:34` 的 tsc 类型探针（`Options.toolAliases` 在不在）。
而它自己那条 `expect_red sdk-type-contract` —— 把 SDK 降到 0.2.141 后 tsc 必须红 ——
**就是「类型探针是承重的」的现成证明**。

⇒ **版本号只是代理指标，类型探针才是判据。代理指标该是地板，判据一点没动。**

## 地板判据的边界校准（用会打到边界的值，不是用生产那个）

    0.3.226  通过（相等）
    0.3.235  通过
    0.4.0    通过
    1.0.0    通过
    0.3.9    🔴 拒绝  ← **字符串比较会把 "0.3.9" > "0.3.226" 判成通过**，`sort -V` 才对
    0.2.141  🔴 拒绝  ← 降级变异必须仍在地板之下

## 顺带

两处把版本写死在文案里的改成打印实际版本，否则日志会说
`SDK 0.3.226 publishes Options.toolAliases` 而实际跑的是 0.3.235。

## 改后实测

    rc=0   RESULT pass=8 fail=0
    PASS clean install resolved claude-agent-sdk 0.3.235 (>= 0.3.226)
    PASS mutation alias-injection witnessed red
    PASS mutation sdk-type-contract witnessed red     ← 覆盖没丢

## 本 PR 不做的事

**不登记它进 CI。** 它现在还是孤儿；先修红、再登记，顺序不反（同 #1079 → #1081）。