### PR TITLE
ci: 把 test656 从孤儿基线挪进 L1（孤儿地板 94 → 93）

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -30,6 +30,7 @@ on:
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
       # ~160 dirs under tests/ are not run by any workflow, so listing them
       # would only look like coverage.
+      - 'tests/test656-claude-sdk-tool-aliases/**'
       - 'tests/test654-dashboard-managed-launch/**'
       - 'tests/test657-claude-native-version-pin/**'
       - 'tests/test236-dashboard-codex-goal/**'
@@ -147,6 +148,7 @@ on:
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other
       # ~160 dirs under tests/ are not run by any workflow, so listing them
       # would only look like coverage.
+      - 'tests/test656-claude-sdk-tool-aliases/**'
       - 'tests/test654-dashboard-managed-launch/**'
       - 'tests/test657-claude-native-version-pin/**'
       - 'tests/test236-dashboard-codex-goal/**'

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -93,7 +93,6 @@ test648-probe-ip-pin
 test650-anet-attach
 test652-admin-network-list
 test653-batch-workdir
-test656-claude-sdk-tool-aliases
 test673-claude-image-attachment-block
 test696-human-low-value-reply
 test7-config

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -91,6 +91,15 @@ L1_TESTS=(
   # 按 qa.sh 真实调法(docker run --rm，不挂 /artifacts)实测 rc=0 RESULT pass=14 fail=0，
   # 四条见证红全成立；耗时 build 104s + run 39s(L1 里较重的一个)。
   "test654-dashboard-managed-launch"
+  # 2026-08-19 补注册。它此前是孤儿**而且在 main 上就是红的** ——
+  # `[[ "$SDK_VERSION" == 0.3.226 ]]` 是逐字相等，而 package.json 是 `^0.3.226`、
+  # 本套件 Dockerfile 不拷 lockfile ⇒ 解析到当时最新的 0.3.x，上游发到 0.3.235 就红。
+  # #1082 改成地板之后才够格（先修红、再登记）。
+  # 实测（按 qa.sh 真实调法 docker run --rm，不挂 /artifacts）：rc=0 RESULT pass=8 fail=0。
+  # 🔴 耗时按**冷构建**记：build 107s + run 33s = 140s（warm 只有 37s，会误导）。
+  # 推算：L1 24 条=3.50min → 25 条=5.32min；再加这个同量级的 ≈7min，
+  # 在 qa.yml:414 那个 10 分钟守卫内（那个守卫上一轮刚从 5 调到 10，原因见该处注释）。
+  "test656-claude-sdk-tool-aliases"
   # 2026-08-18 补注册 —— 这四个是 #863 修好的那批(commit 61f7203a,「静默失效 6 周」
   # 实跑 4/4 从红到绿),但修完之后**没有注册到任何地方**,于是回到了同一个位置:
   # 没有任何东西会跑它们。#861 的实测把最后一个未知量补上了。


### PR DESCRIPTION
承接 #1082。**先修红、再登记，顺序没反。**

## 它此前是孤儿，**而且在 main 上就是红的**

    [[ "$SDK_VERSION" == 0.3.226 ]]   ← 逐字相等

`agent-node/package.json` 是 `^0.3.226`，本套件 Dockerfile **只拷 `package.json`、不拷 lockfile**
⇒ `bun install` 解析到当时最新的 0.3.x，上游发到 0.3.235 就红。
`#1082`（`a79a857147c7`）改成地板之后才够格。

## 三处一起改

    ① scripts/qa.sh                        L1_TESTS 加一条  ← 真正被执行的地方
    ② .github/workflows/qa.yml             paths 两处
    ③ docs/test-suite-orphan-baseline.txt  删掉这一行

## 实测

    rc=0   RESULT pass=8 fail=0
    含 mutation alias-injection / sdk-type-contract 两条见证红

## 🔴 耗时按**冷构建**记，因为上一轮我在这里栽过

    冷   build 107s + run 33s = **140s**
    warm build  12s + run 25s =    37s   ← 差 ~4 倍，**而 CI runner 是冷的**

上一轮我没量冷的数字，把 test654 加进 L1 之后**撞了 5 分钟超时**
（那个守卫已在 `qa.yml:414` 调到 10，注释里写了实测依据）。

推算：L1 24 条 = 3.50min → 25 条 = 5.32min；再加这个同量级的 **≈7min**，在 10 分钟守卫内。

    登记门  suites=205 registered=105→106 orphans=94→93 baseline=93 new=0
    qa.sh --list 里能看到它（L1 共 26 条）