### PR TITLE
fix(#1083): 诊断读法补上「能力档」——「没走到」和「不会走到」不能共用一个 code

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3045,6 +3045,28 @@ return Bun.serve({
       const targetSession = db.get<{ alias: string; status: string }>(targetSql, ...targetParams);
       const targetAlias = targetSession?.alias ?? canonicalTarget ?? String(task.to_name ?? "");
       const liveSseConnections = getSSEStats().sessions[`${taskNetworkId || "global"}:${targetAlias}`] ?? 0;
+      // 🔴 #1083：这个目标【历史上有没有报过任何一次】运行时证据。
+      //   只用 Hub 自己已有的数据算，不需要 agent 侧任何改动。
+      //   为空时 runtime_submitted_at/consumed_at 是「不会走到」而不是「还没走到」，
+      //   两者处置相反（别等去接线 vs 等）。参数编号沿用上面 targetSql 的写法。
+      const evidenceParams: unknown[] = [];
+      let evidenceSql = "SELECT 1 AS seen FROM tasks WHERE runtime_submitted_at IS NOT NULL AND ";
+      if (task.to_node_id) {
+        evidenceSql += "to_node_id = ?1";
+        evidenceParams.push(task.to_node_id);
+      } else {
+        evidenceSql += "to_node_id IS NULL AND to_name = ?1";
+        evidenceParams.push(canonicalTarget ?? String(task.to_name ?? ""));
+      }
+      if (taskNetworkId) {
+        evidenceSql += " AND network_id = ?2";
+        evidenceParams.push(taskNetworkId);
+      } else {
+        evidenceSql += " AND network_id IS NULL";
+      }
+      evidenceSql += " LIMIT 1";
+      const targetEverReportedRuntimeEvidence =
+        Boolean(db.get<{ seen: number }>(evidenceSql, ...evidenceParams));
       const diagnostic = diagnoseTask({
         status: String(task.status ?? "unknown"),
         runtimeSubmittedAt: typeof task.runtime_submitted_at === "string" ? task.runtime_submitted_at : null,
@@ -3052,6 +3074,7 @@ return Bun.serve({
         targetSessionStatus: targetSession?.status ?? null,
         targetSessionExists: Boolean(targetSession),
         liveSseConnections,
+        targetEverReportedRuntimeEvidence,
       });
       return withCors(req, Response.json({ ok: true, task, diagnostic }));
     }

--- a/server/src/task-diagnostic.test.ts
+++ b/server/src/task-diagnostic.test.ts
@@ -69,8 +69,41 @@ describe("#166 evidence-only task diagnostics", () => {
         live_sse_connections: 1,
         runtime_submitted: false,
         runtime_consumed: false,
+        // 🔴 #1083 新增。这里保持 toEqual（整形断言）而**不**退化成 toMatchObject ——
+        //    隔壁那条测试的名字就是 "without widening the evidence"，
+        //    这个严格性是故意的：它防的正是「有人往 evidence 里悄悄加字段」。
+        //    加宽了就把新字段写进来，不是把断言放松。
+        target_ever_reported_runtime_evidence: null,
       },
     });
+  });
+
+  // 🔴 #1083：【时序】与【能力】必须落在不同的 code 上。
+  //    实测背景：一个**确实回了长信**的任务与一个**毫无回音**的任务，
+  //    在旧实现下 diagnostic 逐字相同（都是 lifecycle_progress_without_runtime_evidence
+  //    + inspect_runtime）⇒ 鉴别力 = 0。
+  test("a target that never reported runtime evidence gets its own code, not inspect_runtime", () => {
+    const d = diagnoseTask(base({ status: "acked", targetEverReportedRuntimeEvidence: false }));
+    expect(d.code).toBe("runtime_evidence_channel_absent");
+    expect(d.action_hint).toBe("wire_runtime_evidence");
+    expect(d.evidence.target_ever_reported_runtime_evidence).toBe(false);
+  });
+
+  test("a target that HAS reported evidence before keeps the timing-flavoured code", () => {
+    const d = diagnoseTask(base({ status: "acked", targetEverReportedRuntimeEvidence: true }));
+    expect(d.code).toBe("lifecycle_progress_without_runtime_evidence");
+    expect(d.action_hint).toBe("inspect_runtime");
+  });
+
+  // 「Hub 没算这一项」不等于「没报过」—— 不知道就不改判。
+  test("an unknown capability (null / omitted) does not change the old verdict", () => {
+    const omitted = diagnoseTask(base({ status: "acked" }));
+    const explicitNull = diagnoseTask(base({ status: "acked", targetEverReportedRuntimeEvidence: null }));
+    for (const d of [omitted, explicitNull]) {
+      expect(d.code).toBe("lifecycle_progress_without_runtime_evidence");
+      expect(d.action_hint).toBe("inspect_runtime");
+      expect(d.evidence.target_ever_reported_runtime_evidence).toBeNull();
+    }
   });
 
   test("normalizes invalid SSE counts without widening the evidence", () => {

--- a/server/src/task-diagnostic.ts
+++ b/server/src/task-diagnostic.ts
@@ -8,6 +8,10 @@ export type TaskDiagnosticCode =
   | "target_session_offline"
   | "target_no_live_sse"
   | "lifecycle_progress_without_runtime_evidence"
+  // 🔴 #1083：与上一条的区别是【时序】vs【能力】。上一条说的是「还没走到那一步」，
+  //    这一条说的是「这个目标从来没有报过任何一次运行时证据」——它不会走到。
+  //    两者处置相反：前者【等】，后者【别等，去接线】。
+  | "runtime_evidence_channel_absent"
   | "delivered_waiting_for_agent";
 
 export type TaskDiagnosticAction =
@@ -16,7 +20,8 @@ export type TaskDiagnosticAction =
   | "check_target_registration"
   | "restore_target"
   | "restore_sse"
-  | "inspect_agent_queue";
+  | "inspect_agent_queue"
+  | "wire_runtime_evidence";
 
 export interface TaskDiagnosticInput {
   status: string;
@@ -25,6 +30,18 @@ export interface TaskDiagnosticInput {
   targetSessionStatus: string | null;
   targetSessionExists: boolean;
   liveSseConnections: number;
+  /**
+   * 🔴 #1083：这个目标节点【历史上是否报过任何一次】运行时证据。
+   * `false` = 从来没报过 ⇒ `runtime_submitted_at`/`consumed_at` 为空**推不出**「没消费」，
+   *           它只说明这条证据通道不存在。
+   * `null`/省略 = Hub 没算这一项 ⇒ 保持旧行为（不因为「不知道」就改判）。
+   *
+   * 背景：RFC-035 §75 要求 agent-node 接线上报，但 agent 侧至今没有实现
+   * （`grep -rn runtime_evidence agent-node/src/ agent-network/src/` = 0 命中），
+   * 于是这两列对所有任务恒为 NULL。实测后果：一个**确实回了长信**的任务
+   * 与一个**毫无回音**的任务，diagnostic 读数逐字相同 ⇒ 鉴别力 = 0。
+   */
+  targetEverReportedRuntimeEvidence?: boolean | null;
 }
 
 export interface TaskDiagnostic {
@@ -37,6 +54,8 @@ export interface TaskDiagnostic {
     live_sse_connections: number;
     runtime_submitted: boolean;
     runtime_consumed: boolean;
+    /** `null` = Hub 没算这一项；`false` = 该目标从来没报过运行时证据。 */
+    target_ever_reported_runtime_evidence: boolean | null;
   };
 }
 
@@ -55,6 +74,8 @@ export function diagnoseTask(input: TaskDiagnosticInput): TaskDiagnostic {
     live_sse_connections: liveSseConnections,
     runtime_submitted: Boolean(input.runtimeSubmittedAt),
     runtime_consumed: Boolean(input.consumedAt),
+    target_ever_reported_runtime_evidence:
+      input.targetEverReportedRuntimeEvidence ?? null,
   };
 
   let code: TaskDiagnosticCode;
@@ -78,8 +99,16 @@ export function diagnoseTask(input: TaskDiagnosticInput): TaskDiagnostic {
     code = "target_no_live_sse";
     action_hint = "restore_sse";
   } else if (input.status === "acked" || input.status === "running") {
-    code = "lifecycle_progress_without_runtime_evidence";
-    action_hint = "inspect_runtime";
+    // 🔴 #1083：这里原本只有一档，于是【还没走到】和【不会走到】共用同一个 code
+    //    和同一个 action_hint(`inspect_runtime`)。后者被支去查一个没坏的东西。
+    //    只有在 Hub **确知**该目标从未报过证据时才改判；`null`(没算) 保持旧行为。
+    if (input.targetEverReportedRuntimeEvidence === false) {
+      code = "runtime_evidence_channel_absent";
+      action_hint = "wire_runtime_evidence";
+    } else {
+      code = "lifecycle_progress_without_runtime_evidence";
+      action_hint = "inspect_runtime";
+    }
   } else {
     code = "delivered_waiting_for_agent";
     action_hint = "inspect_agent_queue";


### PR DESCRIPTION
关闭 #1083 的一半（B 路：先让读法诚实；A 路补 agent 侧接线是另一件事）。

## 缺陷

实测（TMCode 线带**正控**做的）：一个**确实回了长信**的任务，与一个**毫无回音**的任务，
`GET /api/tasks/<id>` 的 diagnostic 读数**逐字相同**：

    code        = lifecycle_progress_without_runtime_evidence
    action_hint = inspect_runtime

⇒ **一条判据在两种相反的真相下读出同一个值 ⇒ 鉴别力 = 0。**

## 根因不在「字段为空」，在**读法表少一档**

    grep -rn 'runtime_evidence' agent-node/src/ agent-network/src/ agent-network/bin/ → **0 命中**

`runtime_submitted_at`/`consumed_at` 只有 Hub 侧工具会写，**agent 侧从没接线**
（`RFC-035:77` 原文：*"The agent-node wiring **must** preserve this minimum evidence strength"*）。

于是 RFC §92 那张表的 `NULL/NULL` 档 —— 它写的是
「still before the vendor runtime boundary」，一个**时序**解释 ——
被**结构**情形（这个运行时从来不上报）共用了。**而两者处置相反：等 vs 别等去接线。**

## 改法（不动 agent 侧）

    新 code   runtime_evidence_channel_absent
    新 hint   wire_runtime_evidence
    新入参   targetEverReportedRuntimeEvidence?: boolean | null
               false      ⇒ 走新 code（Hub **确知**该目标从没报过）
               null/省略  ⇒ 保持旧行为（**不因为「不知道」就改判**）

`server.ts` 用 Hub **自己已有的数据**算它：该 `to_node` 历史上有没有过
`runtime_submitted_at IS NOT NULL` 的任务。

## 🔴 关于那条被改红的既有测试

它用 `toEqual` 做**整形断言**，而隔壁一条的名字就是
`"normalizes invalid SSE counts **without widening the evidence**"` ——
**这个严格性是故意的**，防的正是「有人往 evidence 里悄悄加字段」。

我确实加宽了 evidence，所以**把新字段写进断言，而不是把 `toEqual` 放水成 `toMatchObject`**。

新增 3 条测试：`false` 走新 code ／ `true` 保持旧 code ／ `null` 与省略都不改判。

    bun test server/src/task-diagnostic.test.ts → **9 pass 0 fail**

## ⚠️ 我没能在本机跑的那条

`server/src/task-diagnostic-http.test.ts` 在我的 worktree 里跑不了
（没有 `server/node_modules`，报 `Cannot find module '@modelcontextprotocol/sdk/...'`）。
**同一条测试在未改动的 `origin/main` 上红得一模一样** ⇒ 环境缺口，不是本改动。以 CI 为准。