### PR TITLE
fix(test292-ok): 那道「没有弱断言」的门恒真——它的正则一行都匹配不到

### DIFF
--- a/tests/test292-e2e-ok-assertions/run.sh
+++ b/tests/test292-e2e-ok-assertions/run.sh
@@ -30,7 +30,16 @@ import re
 import sys
 
 text = Path(sys.argv[1]).read_text()
-print(sum(bool(re.search(r"grep -q ['\"]ok['\"]", line)) for line in text.splitlines()))
+# 🔴 2026-08-19：原正则是 r"grep -q ['\"]ok['\"]" —— 它要求引号后**紧跟** ok
+# 再**紧跟**收尾引号。而 docker-e2e.sh 里的真实形态是：
+#     echo "$X" | grep -q '"ok":true' && pass ... || fail ...
+# 引号后第一个字符是 `"` 不是 `o`，且 ok 后面是 `":` 不是收尾引号。
+# ⇒ 实测：原正则命中 **0** 行，真实形态有 **14** 行。
+#   `WEAK_COUNT` 因此结构性恒为 0，下面那句
+#   "docker-e2e has no weak grep-ok assertions" 是**恒真**的，这道门永远不可能红。
+# 🔴 而它的见证红夹具用的是 `grep -q 'ok'`（正则**能**匹配的字面形态）——
+#   变异在夹具上自证，对真实对象一次都没生效。
+print(sum(bool(re.search(r"""grep -q ['"]"ok":true['"]""", line)) for line in text.splitlines()))
 PY
 )
 echo "weak_assertions=$WEAK_COUNT"
@@ -63,18 +72,49 @@ expect_not_ok "JSON-RPC error is not success" "$RPC_ERROR"
 expect_not_ok "malformed response fails closed" 'not-json ok'
 expect_not_ok "empty response fails closed" ''
 
-if [[ "$WEAK_COUNT" == "0" ]]; then
-  pass "docker-e2e has no weak grep-ok assertions"
+# 🔴 棘轮，不是 ==0。修好正则之后这个数是 14，直接要求 0 会让本套件恒红；
+#   而把它改回「恒真的 0」等于把刚发现的洞盖回去。⇒ 只许降不许升，目标 0。
+WEAK_CEILING=14
+if [[ "$WEAK_COUNT" -le "$WEAK_CEILING" ]]; then
+  if [[ "$WEAK_COUNT" -lt "$WEAK_CEILING" ]]; then
+    pass "weak grep-ok assertions down to $WEAK_COUNT (ceiling $WEAK_CEILING) —— 请把 WEAK_CEILING 调到 $WEAK_COUNT"
+  else
+    pass "weak grep-ok assertions held at $WEAK_COUNT (ceiling $WEAK_CEILING, 目标 0)"
+  fi
 else
   fail "docker-e2e still has $WEAK_COUNT weak grep-ok assertions"
 fi
 
+# 🔴 2026-08-19：这里原本是 `[[ "$ROBUST_CALLS" == "16" ]]` —— **逐字相等**，
+#    而且它的 pass 文案写的是「**all** 16 legacy success assertions use the structured parser」。
+#    两处都有问题：
+#
+#    ① 逐字相等：有人多写一条结构化断言（17 > 16，是**改进**）就判红。
+#       实测就是这么红的：`FAIL: expected 16 structured response assertions, got 17`。
+#       （同一形状 #1071 在 test292-e2e-residual-fixtures 上修过。）
+#
+#    ② 🔴 更要紧的是那句「all」是**假的**。数出「有 16 个结构化的」
+#       **推不出**「全部都是结构化的」—— 这条判据从来没检查过「还剩几个没转」。
+#       实测 2026-08-19 origin/main：
+#           结构化  response_json_ok "$…"        17 处
+#           未转    … | grep -q '"ok":true'      **14 处**
+#       也就是 31 条里有 14 条（45%）根本不是结构化的。
+#
+#    而未转的那个写法确实更弱 —— 它是**子串匹配**。实测两种判定相反的载荷：
+#        {"ok":false,"detail":{"ok":true}}   裸 grep 通过 / response_json_ok 拒绝
+#        garbage "ok":true garbage           裸 grep 通过 / response_json_ok 拒绝
+#    ⇒ 一个明确失败的响应、以及一段根本不是 JSON 的文本，都会被裸 grep 放行。
+#
+#    改法：结构化数改**地板**（越多越好，不该判红）；
+#          未转数改**棘轮**（只许降不许升），并把「应当降到 0」写在这里。
 ROBUST_CALLS=$(grep -c 'response_json_ok "\$' "$ROOT/tests/docker-e2e.sh" || true)
-if [[ "$ROBUST_CALLS" == "16" ]]; then
-  pass "all 16 legacy success assertions use the structured parser"
+ROBUST_FLOOR=17
+if [[ "$ROBUST_CALLS" -ge "$ROBUST_FLOOR" ]]; then
+  pass "structured response assertions: $ROBUST_CALLS (floor $ROBUST_FLOOR)"
 else
-  fail "expected 16 structured response assertions, got $ROBUST_CALLS"
+  fail "structured response assertions dropped to $ROBUST_CALLS (floor $ROBUST_FLOOR) —— 有人把结构化断言改回去了"
 fi
+
 
 MUT=$(mktemp -d /tmp/test292-mut.XXXXXX)
 trap 'safe_rm_rf "$MUT"' EXIT


### PR DESCRIPTION
这个孤儿**在 `origin/main` 上就是红的**。我按构建成本挑最便宜的孤儿跑时撞到的。

表面红因是逐字计数（`expected 16 …, got 17`），但查下去有个更大的。

## 🔴 `WEAK_COUNT` 的正则对真实文件命中 0 行

```python
re.search(r"grep -q ['\"]ok['\"]", line)
```

它要求引号后**紧跟** `ok` 再**紧跟**收尾引号。而 `tests/docker-e2e.sh` 里的真实形态是：

```bash
echo "$X" | grep -q '"ok":true' && pass ... || fail ...
```

引号后第一个字符是 `"` 不是 `o`，且 `ok` 后面是 `":` 不是收尾引号。

    旧正则命中     **0** 行
    真实形态       **14** 行

⇒ `WEAK_COUNT` **结构性恒为 0**，那句 `docker-e2e has no weak grep-ok assertions`
**恒真** —— **这道门永远不可能红。**

🔴 而它的见证红夹具用的是 `grep -q 'ok'`（正则**能**匹配的字面形态）——
**变异在夹具上自证，对真实对象一次都没生效。**

## 这 14 处确实更弱（子串匹配），不是风格问题

    {"ok":false,"detail":{"ok":true}}   裸 grep 通过 / response_json_ok 拒绝
    garbage "ok":true garbage           裸 grep 通过 / response_json_ok 拒绝

⇒ **一个明确失败的响应、以及一段根本不是 JSON 的文本，都会被裸 grep 放行。**

## 改动

- 修 `WEAK_COUNT` 的正则 ⇒ 它现在数得到真实形态（14）
- `== 0` 改**棘轮** `<= 14`（只许降不许升，目标 0）
  —— 直接要求 0 会让本套件恒红；**而改回「恒真的 0」等于把刚发现的洞盖回去**
- 结构化断言数 `== 16` 改**地板** `>= 17`（多写结构化断言是**改进**，不该判红；
  同一形状 `#1071` 在 `test292-e2e-residual-fixtures` 上修过）
- 顺带删掉我中途加的第二套计数口径 —— **同一件事只留一个口径**

## 见证红（往 `docker-e2e.sh` 加第 15 条弱断言）

    新正则  15 > ceiling 14  ⇒ rc=1  FAIL: docker-e2e still has 15 weak grep-ok assertions
    旧正则  命中 0，判据 ==0 ⇒ **仍然绿**，新增的弱断言**完全不可见**

改后正常跑：`rc=0  RESULT: 11 passed, 0 failed`，`weak_assertions=14`。

## 本 PR 不做的事

**不登记它进 CI**，也**不动那 14 处**（把 `docker-e2e.sh` 转成结构化解析是另一件事，
每一处都要单独验）。先修红、再登记。