### PR TITLE
ci: 把 test292-e2e-ok-assertions 挪进 L1（孤儿地板 90 → 89）

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -32,6 +32,7 @@ on:
       # would only look like coverage.
       - 'tests/qa-ut-01-auth-tokens/**'
       - 'tests/qa-ut-02-password-dict/**'
+      - 'tests/test292-e2e-ok-assertions/**'
       - 'tests/qa-ut-03-auth-validate/**'
       - 'tests/test656-claude-sdk-tool-aliases/**'
       - 'tests/test654-dashboard-managed-launch/**'
@@ -153,6 +154,7 @@ on:
       # would only look like coverage.
       - 'tests/qa-ut-01-auth-tokens/**'
       - 'tests/qa-ut-02-password-dict/**'
+      - 'tests/test292-e2e-ok-assertions/**'
       - 'tests/qa-ut-03-auth-validate/**'
       - 'tests/test656-claude-sdk-tool-aliases/**'
       - 'tests/test654-dashboard-managed-launch/**'

--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -61,7 +61,6 @@ test29-network-alias
 test292-e2e-agent-registration
 test292-e2e-contract-drift
 test292-e2e-identity-fixtures
-test292-e2e-ok-assertions
 test292-e2e-rename-command
 test292-e2e-residual-fixtures
 test3-security

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -109,6 +109,12 @@ L1_TESTS=(
   "qa-ut-01-auth-tokens"
   "qa-ut-02-password-dict"
   "qa-ut-03-auth-validate"
+  # 2026-08-19 补注册。它此前是孤儿**而且在 main 上就是红的**，
+  # 而红的表面原因（逐字计数 16 vs 17）底下藏着一道**恒真的门**：
+  # WEAK_COUNT 的正则对真实文件命中 0 行，那句
+  # "docker-e2e has no weak grep-ok assertions" 永远不可能红（#1088 修）。
+  # 修好之后 rc=0、weak_assertions=14（真实值），才够格接进来。
+  "test292-e2e-ok-assertions"
   # 2026-08-18 补注册 —— 这四个是 #863 修好的那批(commit 61f7203a,「静默失效 6 周」
   # 实跑 4/4 从红到绿),但修完之后**没有注册到任何地方**,于是回到了同一个位置:
   # 没有任何东西会跑它们。#861 的实测把最后一个未知量补上了。


### PR DESCRIPTION
承接 #1088。**先修红、再登记，顺序没反。**

它此前是孤儿**而且在 main 上就是红的**。表面红因是逐字计数
（`expected 16 structured response assertions, got 17`），底下藏着一道**恒真的门**：

    WEAK_COUNT 的正则   r"grep -q ['\"]ok['\"]"   对真实文件命中 **0** 行
    真实形态            grep -q '"ok":true'       **14** 行

⇒ `docker-e2e has no weak grep-ok assertions` **永远不可能红**。`#1088` 修掉了。

## 登记前在 main(`59abc60a`) 上实测确认它真的绿（**不凭「我修了」**）

    rc=0   weak_assertions=14   RESULT: 11 passed, 0 failed   run 2s

## 三处一起改

    ① scripts/qa.sh                        L1_TESTS 加一条  ← 真正被执行的地方
    ② .github/workflows/qa.yml             paths 两处
    ③ docs/test-suite-orphan-baseline.txt  删掉这一行

    登记门  suites=205 registered=109→110 orphans=90→89 baseline=89 new=0

## ⚠️ 接进来之后它会做什么

**持续盯住那 14 处弱断言不许再涨**（棘轮，目标 0）——
**在此之前那个数字对任何人都不可见**（因为它恒为 0）。