### PR TITLE
ci: 加一道门——L1 套件必须能把自己的运行钉到一个提交上（#1092 第 1 步）

### DIFF
--- a/.github/scripts/check-l1-sha-binding.py
+++ b/.github/scripts/check-l1-sha-binding.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""L1 套件必须能把自己的运行钉到一个提交上。
+
+## 背景（#1092）
+
+`scripts/qa.sh` 从每个套件的 Dockerfile 里 grep `^ARG (SOURCE_COMMIT|TESTn_SOURCE_COMMIT)`
+决定要不要传 `--build-arg`（qa.sh 里那段注释自己写了这个形状的危险）。
+没有这一行的套件就**不传** —— 而它**不报错**，输出看起来一切正常。
+
+2026-08-19 在 origin/main 上数：30 条 L1 里 **17 条**没有这一行。
+⇒ 这 17 条的输出无法被钉到任何一个提交上。
+
+## 🔴 这道门不要求清零，和 check-test-suite-registration.py 是同一个理由
+
+要求清零的门第一天就是红的；而**一道只因积压而红的门，等积压清完就再也不会红，
+到时没人知道它还有没有效**。所以基线里记着今天这 17 个，门只对**新增的**未绑定套件变红。
+
+## 最强的形态在仓里已经有了
+
+`tests/test746-setup-bun-pin/run.sh:8`：
+
+    [[ "${TEST746_SOURCE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]] || {
+      echo 'FAIL: TEST746_SOURCE_COMMIT must be one full lowercase Git SHA' >&2
+
+**它不是打印，是断言 —— 拿不到 SHA 就 fail closed。** 补 17 条时建议照这个写。
+
+## 🔴 取集层的两个坑，是我自己踩过之后写进自检的
+
+写这道门之前我先手写过一个一次性脚本去数同样的东西，它错了两次，**都在取集层**：
+
+  ① 我写了 `f.name != "Dockerfile"` 去排除 Dockerfile ——
+     而 qa-ut-01/02/03 的 SHA 打印**恰恰写在 Dockerfile 的 CMD 里** ⇒ 被判成「哑的」；
+  ② 修好之后仍把 test746 判成哑的 —— 因为我 grep 的是小写 `source_commit`，
+     而它用的是大写 `TEST746_SOURCE_COMMIT` ⇒ **差一个大小写**。
+
+两次都不是判据错。**而两次都是靠「我手上恰好有正确答案」发现的，不是靠脚本自曝。**
+所以下面 `selftest()` 里这两条夹具不是装饰：**它们是这个脚本唯一会自曝这两类错的地方。**
+"""
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+QA_SH = REPO / "scripts" / "qa.sh"
+TESTS = REPO / "tests"
+BASELINE = REPO / "docs" / "l1-sha-binding-baseline.txt"
+
+# ARG 行：qa.sh 用的就是这个口径，故意保持逐字一致（判据不该有第二个版本）
+ARG_RE = re.compile(r"^ARG (SOURCE_COMMIT|TEST[0-9]+_SOURCE_COMMIT)", re.M)
+# 🔴 大小写不敏感 —— 坑 ②。变量名是大写、打印出来的键是小写，两种都要认。
+VISIBLE_RE = re.compile(r"source_commit", re.I)
+# 🔴 坑 ③（我的 selftest 自己抓到的）：`ARG/ENV/LABEL ... SOURCE_COMMIT` 这些**声明行**
+#    本身就含这个串。把它们算进「可见」，任何有 ARG 的套件都会自动「可见」
+#    ⇒ invisible 恒为空 ⇒ 又是一道恒真的判据。
+#    要找的是 SHA 被**用**（打印/断言），不是被**声明**。
+DECLARE_RE = re.compile(r"^\s*(ARG|ENV|LABEL)\b.*SOURCE_COMMIT.*$", re.M | re.I)
+
+
+def l1_suites(qa_sh_text: str) -> list[str]:
+    """从 qa.sh 里取 L1_TESTS。可注入，selftest 用它验取集层本身。"""
+    m = re.search(r"L1_TESTS=\((.*?)\n\)", qa_sh_text, re.S)
+    if not m:
+        return []
+    return re.findall(r'^\s*"([^"]+)"', m.group(1), re.M)
+
+
+def suite_texts(suite_dir: pathlib.Path) -> str:
+    """套件目录下**所有**文件的内容拼起来 —— 🔴 包含 Dockerfile（坑 ①）。"""
+    out = []
+    if not suite_dir.is_dir():
+        return ""
+    for f in sorted(suite_dir.rglob("*")):
+        if not f.is_file():
+            continue
+        try:
+            text = f.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        # 声明行剥掉 —— 见 DECLARE_RE 上方注释（坑 ③）
+        out.append(DECLARE_RE.sub("", text))
+    return "\n".join(out)
+
+
+def classify(names: list[str], tests_dir: pathlib.Path) -> dict:
+    bound, unbound, invisible, missing_dir = [], [], [], []
+    for n in names:
+        d = tests_dir / n
+        df = d / "Dockerfile"
+        if not df.exists():
+            missing_dir.append(n)
+            continue
+        if not ARG_RE.search(df.read_text(encoding="utf-8", errors="ignore")):
+            unbound.append(n)
+            continue
+        bound.append(n)
+        if not VISIBLE_RE.search(suite_texts(d)):
+            invisible.append(n)
+    return {
+        "bound": bound,
+        "unbound": unbound,
+        "invisible": invisible,
+        "missing_dockerfile": missing_dir,
+    }
+
+
+def read_baseline() -> set[str]:
+    try:
+        return {
+            ln.strip()
+            for ln in BASELINE.read_text(encoding="utf-8").splitlines()
+            if ln.strip() and not ln.startswith("#")
+        }
+    except FileNotFoundError:
+        return set()
+
+
+def main() -> int:
+    if not QA_SH.exists():
+        print("::error::scripts/qa.sh 不存在 —— 取集塌了，拒绝通过")
+        return 2
+    names = l1_suites(QA_SH.read_text(encoding="utf-8"))
+    if not names:
+        # 🔴 取不到 L1_TESTS 绝不当成通过：那是「没跑」不是「没问题」。
+        print("::error::L1_TESTS 解析为空 —— 取集塌了，拒绝通过")
+        return 2
+    base = read_baseline()
+    if not base:
+        print(f"::error::{BASELINE.relative_to(REPO)} 缺失或为空 —— 没有楼层可比，拒绝通过")
+        return 2
+
+    c = classify(names, TESTS)
+    new = [n for n in c["unbound"] if n not in base]
+    improved = sorted(base - set(c["unbound"]))
+
+    for n in new:
+        print(
+            f"::error file=tests/{n}/Dockerfile::新增的 L1 套件没有 SHA 绑定。"
+            f"scripts/qa.sh 靠 `^ARG SOURCE_COMMIT` 决定传不传 --build-arg，"
+            f"没有它就不传**而且不报错**，这次运行无法被钉到任何提交上。"
+            f"最强写法见 tests/test746-setup-bun-pin/run.sh:8（断言 40 位小写十六进制，拿不到就退出）。"
+        )
+    for n in c["invisible"]:
+        print(
+            f"::error file=tests/{n}/Dockerfile::有 ARG SOURCE_COMMIT 但套件里"
+            f"从不出现 source_commit —— 绑定了却**没人看得见**，与没绑定等效。"
+        )
+    for n in c["missing_dockerfile"]:
+        print(f"::error::L1 里的 {n} 没有 Dockerfile —— qa.sh 构建不了它")
+
+    print(
+        f"l1={len(names)} bound={len(c['bound'])} unbound={len(c['unbound'])} "
+        f"invisible={len(c['invisible'])} baseline={len(base)} new={len(new)}"
+    )
+    if improved:
+        print(
+            f"note: {len(improved)} 个套件已经补上绑定 —— 请把它们从 "
+            f"{BASELINE.relative_to(REPO)} 里删掉，楼层才只降不回填。"
+        )
+    if new or c["invisible"] or c["missing_dockerfile"]:
+        return 1
+    print("no new L1 suite runs without SHA binding.")
+    return 0
+
+
+def selftest() -> int:
+    """🔴 这两条夹具对应我自己踩过的两个取集错，不是装饰。"""
+    import tempfile
+
+    cases = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+
+        # 坑 ①：SHA 的打印**只**写在 Dockerfile 的 CMD 里（qa-ut-01/02/03 就是这样）。
+        a = root / "suite-print-in-dockerfile"
+        a.mkdir()
+        (a / "Dockerfile").write_text(
+            'FROM x\nARG SOURCE_COMMIT=unknown\nENV SOURCE_COMMIT=$SOURCE_COMMIT\n'
+            'CMD ["sh","-c","printf \'source_commit=%s\\n\' \\"$SOURCE_COMMIT\\"; exec true"]\n',
+            encoding="utf-8",
+        )
+        # 坑 ②：只用**大写**变量名，从不出现小写 source_commit（test746 就是这样）。
+        b = root / "suite-uppercase-only"
+        b.mkdir()
+        (b / "Dockerfile").write_text(
+            "FROM x\nARG TEST999_SOURCE_COMMIT=dev\nENV TEST999_SOURCE_COMMIT=$TEST999_SOURCE_COMMIT\n",
+            encoding="utf-8",
+        )
+        (b / "run.sh").write_text(
+            '[[ "${TEST999_SOURCE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]] || exit 1\n',
+            encoding="utf-8",
+        )
+        # 真的没有绑定
+        c = root / "suite-unbound"
+        c.mkdir()
+        (c / "Dockerfile").write_text("FROM x\nCMD true\n", encoding="utf-8")
+        # 有 ARG 但通篇不出现 SHA —— 这才是真正的「哑绑定」
+        d = root / "suite-silent"
+        d.mkdir()
+        (d / "Dockerfile").write_text("FROM x\nARG SOURCE_COMMIT=unknown\nCMD true\n", encoding="utf-8")
+
+        res = classify(
+            ["suite-print-in-dockerfile", "suite-uppercase-only", "suite-unbound", "suite-silent"],
+            root,
+        )
+        cases += [
+            ("Dockerfile 里的打印算数（坑①）", "suite-print-in-dockerfile" not in res["invisible"]),
+            ("大写变量名算数（坑②）", "suite-uppercase-only" not in res["invisible"]),
+            ("真的没绑定要被抓到", res["unbound"] == ["suite-unbound"]),
+            ("哑绑定要被抓到", res["invisible"] == ["suite-silent"]),
+        ]
+
+    # 取集层：L1_TESTS 解析
+    cases += [
+        ("解析出 L1_TESTS", l1_suites('L1_TESTS=(\n  "a"\n  # 注释\n  "b"\n)\n') == ["a", "b"]),
+        ("没有 L1_TESTS 时返回空（main 会据此退 2）", l1_suites("nothing here") == []),
+    ]
+
+    bad = [n for n, ok in cases if not ok]
+    for n, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'} {n}")
+    if bad:
+        print(f"::error::selftest failed: {len(bad)} case(s)")
+        return 1
+    print(f"selftest: {len(cases)}/{len(cases)} ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(selftest() if "--selftest" in sys.argv else main())

--- a/.github/workflows/l1-sha-binding.yml
+++ b/.github/workflows/l1-sha-binding.yml
@@ -1,0 +1,37 @@
+# L1 套件必须能把自己的运行钉到一个提交上。
+#
+# #1092 的普查（2026-08-19，origin/main）：30 条 L1 里 **17 条**的 Dockerfile 没有
+# `ARG SOURCE_COMMIT`。scripts/qa.sh 靠 grep 这一行决定传不传 --build-arg，
+# 没有它就**不传，而且不报错** —— 那 17 条的输出无法被钉到任何一个提交上。
+#
+# 这道门不清理存量（docs/l1-sha-binding-baseline.txt 记着今天这 17 条），
+# 只**止住增量**。理由和 check-test-suite-registration.py 完全一样：
+# 一道只因积压而红的门，等积压清完就再也不会红，到时没人知道它还有没有效。
+
+name: lint (L1 SHA binding)
+
+on:
+  # 与本仓其它守卫一致：刻意不加 paths。带 paths 的 workflow 在不匹配的 PR 上
+  # 不产生 check-run，永远做不了 required check。
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  l1-sha-binding:
+    # 全仓唯一的 job name —— required check 只能按这个名字写。
+    name: l1-sha-binding
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # 判据自检先跑。它的两条夹具对应作者自己踩过的两个**取集**错
+      # （排除了 Dockerfile / 大小写不匹配），第三条对应自检自己抓到的恒真判据
+      # （ARG 声明行本身含 SOURCE_COMMIT ⇒ 任何有 ARG 的套件都会自动「可见」）。
+      - run: python3 .github/scripts/check-l1-sha-binding.py --selftest
+      # 打印 l1/bound/unbound/invisible/baseline/new 六个数；
+      # L1_TESTS 解析为空或基线缺失时退 2 —— 绿不能和「根本没跑」同形。
+      - run: python3 .github/scripts/check-l1-sha-binding.py

--- a/docs/l1-sha-binding-baseline.txt
+++ b/docs/l1-sha-binding-baseline.txt
@@ -1,0 +1,31 @@
+# L1 套件「无 SHA 绑定」的存量基线 —— 棘轮，不是豁免清单
+#
+# 判据：不在这份名单里的 L1 套件，Dockerfile 必须有 `ARG SOURCE_COMMIT`
+#       （或 `ARG TESTn_SOURCE_COMMIT`）。多出任何一条 → 红（新伤）。
+#       名单里的补上了 → 不红，但会打印「请把它删掉」，楼层只降不回填。
+#
+# 🔴 为什么不要求清零：一道只因积压而红的门，等积压清完就再也不会红，
+#    到时没人知道它还有没有效。同 docs/test-suite-orphan-baseline.txt。
+#
+# 补的时候照 tests/test746-setup-bun-pin/run.sh:8 那个最强写法：
+#   [[ "${TESTn_SOURCE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]] || exit 1
+#   —— 不是打印，是**断言**，拿不到 SHA 就 fail closed。
+#
+# 生成于 origin/main e0f97d5c，2026-08-19：L1 共 30 条，其中 17 条无绑定。
+qa-cli-01-hub-start
+qa-cli-02-network-create
+qa-dash-07-auth-boundary
+qa-dash-08-cross-account-views
+qa-dash-10-incremental-poll
+qa-hub-05-roundtrip
+qa-hub-06-token-revoke
+qa-hub-06b-cross-user-isolation
+qa-hub-07-sse-reconnect
+qa-hub-08-restart-persistence
+qa-hub-09-task-state-machine
+qa-hub-10-network-scope-regressions
+qa-hub-11-node-delete-sse
+qa-hub-12-servers-endpoint
+qa-hub-13-server-health-agents
+qa-node-02-success-reply
+qa-node-03b-task-events


### PR DESCRIPTION
`#1092` 第 1 步。**先加门，再补存量** —— 只补不加门，下一个新套件照样会漏。

## 缺口

30 条 L1 里 **17 条**的 Dockerfile 没有 `ARG SOURCE_COMMIT`。
`scripts/qa.sh` 靠 grep 这一行决定传不传 `--build-arg`，
没有它就**不传，而且不报错** ⇒ 那 17 条的输出无法被钉到任何一个提交上。

基线 `docs/l1-sha-binding-baseline.txt` 记着今天这 17 条，门只对**新增的**变红
（同 `check-test-suite-registration.py`：**一道只因积压而红的门，等积压清完就再也不会红**）。

补存量时的最强写法仓里已经有了，不用发明 ——
`tests/test746-setup-bun-pin/run.sh:8` 断言 `^[0-9a-f]{40}$`，**拿不到 SHA 就 fail closed**。

## 🔴 这道门的取集层带三条自检夹具，全部来自我自己踩的坑

写这道门之前我先手写过一个一次性脚本数同样的东西，**它错了两次，都在取集层**：

    ① `f.name != "Dockerfile"` ——
       而 qa-ut-01/02/03 的 SHA 打印**恰恰写在 Dockerfile 的 CMD 里** ⇒ 被误判成哑绑定
    ② 修好之后仍误判 test746 —— 我 grep 小写 `source_commit`，
       它用大写 `TEST746_SOURCE_COMMIT` ⇒ **差一个大小写**

**两次都是靠「我手上恰好有正确答案」发现的，不是靠脚本自曝。**
所以我把它们写成了夹具。然后：

    ③ 🔴 **这一条是 selftest 自己抓到的**：`ARG/ENV/LABEL ... SOURCE_COMMIT`
       这些**声明行本身**就含这个串。算进「可见」的话，
       **任何有 ARG 的套件都会自动可见 ⇒ invisible 恒为空 ⇒ 又是一道恒真的判据。**
       改成先剥掉声明行再判。

⇒ 为坑 ①② 写的夹具，抓出了一个我还不知道的坑 ③。

## 见证红（三态）

    新增无 ARG 的 L1 套件       rc=1  new=1
    补上 ARG 但通篇不出现 SHA   rc=1  invisible=1   ← **恒真判据原本会放过这一格**
    再把 SHA 打出来             rc=0

基线缺失 / `L1_TESTS` 解析为空 → **rc=2**（绿不能和「根本没跑」同形）。

## 现状

    l1=30 bound=13 unbound=17 invisible=0 baseline=17 new=0   rc=0
    selftest 6/6
    check-workflow-structure.py ✅   check-action-pins.py ✅

## 顺带一个我没改的

`.github/workflows/` 里 job name `gated-tarball` 出现 **2 次**，
而本仓约定是「全仓唯一的 job name —— required check 只能按这个名字写」。
**这是既有的，不是本 PR 引入的**，我没动它。