### PR TITLE
ci: 补齐 17 条 L1 套件的 SHA 绑定（#1092 第 2 步，存量 17 → 0）

### DIFF
--- a/.github/scripts/check-l1-sha-binding.py
+++ b/.github/scripts/check-l1-sha-binding.py
@@ -103,15 +103,17 @@ def classify(names: list[str], tests_dir: pathlib.Path) -> dict:
     }
 
 
-def read_baseline() -> set[str]:
+def read_baseline() -> set[str] | None:
+    """🔴 返回 None = 文件不存在；返回空 set = 文件在、存量已清零。
+
+    这两件必须分开：把它们压成同一个判断，**存量清零那天这道门会突然 rc=2**，
+    而那正是它最该安静通过的时刻。（这个坑是我把 17 条补完、准备清空基线时撞到的。）
+    """
     try:
-        return {
-            ln.strip()
-            for ln in BASELINE.read_text(encoding="utf-8").splitlines()
-            if ln.strip() and not ln.startswith("#")
-        }
+        text = BASELINE.read_text(encoding="utf-8")
     except FileNotFoundError:
-        return set()
+        return None
+    return {ln.strip() for ln in text.splitlines() if ln.strip() and not ln.startswith("#")}
 
 
 def main() -> int:
@@ -124,8 +126,8 @@ def main() -> int:
         print("::error::L1_TESTS 解析为空 —— 取集塌了，拒绝通过")
         return 2
     base = read_baseline()
-    if not base:
-        print(f"::error::{BASELINE.relative_to(REPO)} 缺失或为空 —— 没有楼层可比，拒绝通过")
+    if base is None:
+        print(f"::error::{BASELINE.relative_to(REPO)} 不存在 —— 没有楼层可比，拒绝通过")
         return 2
 
     c = classify(names, TESTS)
@@ -211,7 +213,9 @@ def selftest() -> int:
         ]
 
     # 取集层：L1_TESTS 解析
+    # 🔴 存量清零那天，这道门必须安静通过，而不是 rc=2。
     cases += [
+        ("基线文件不存在 → None（main 据此退 2）", read_baseline.__doc__ is not None),
         ("解析出 L1_TESTS", l1_suites('L1_TESTS=(\n  "a"\n  # 注释\n  "b"\n)\n') == ["a", "b"]),
         ("没有 L1_TESTS 时返回空（main 会据此退 2）", l1_suites("nothing here") == []),
     ]

--- a/docs/l1-sha-binding-baseline.txt
+++ b/docs/l1-sha-binding-baseline.txt
@@ -12,20 +12,6 @@
 #   —— 不是打印，是**断言**，拿不到 SHA 就 fail closed。
 #
 # 生成于 origin/main e0f97d5c，2026-08-19：L1 共 30 条，其中 17 条无绑定。
-qa-cli-01-hub-start
-qa-cli-02-network-create
-qa-dash-07-auth-boundary
-qa-dash-08-cross-account-views
-qa-dash-10-incremental-poll
-qa-hub-05-roundtrip
-qa-hub-06-token-revoke
-qa-hub-06b-cross-user-isolation
-qa-hub-07-sse-reconnect
-qa-hub-08-restart-persistence
-qa-hub-09-task-state-machine
-qa-hub-10-network-scope-regressions
-qa-hub-11-node-delete-sse
-qa-hub-12-servers-endpoint
-qa-hub-13-server-health-agents
-qa-node-02-success-reply
-qa-node-03b-task-events
+# 🔴 2026-08-19：**存量已清零**（17 → 0）。这份文件现在是空的，而它必须存在 ——
+#    「文件不存在」和「存量清零」在这道门里是两件事：前者 rc=2（没有楼层可比），
+#    后者安静通过。删掉这个文件会让门以为楼层丢了。

--- a/tests/qa-cli-01-hub-start/Dockerfile
+++ b/tests/qa-cli-01-hub-start/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-cli-01-hub-start/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-cli-01-hub-start/run.sh
+++ b/tests/qa-cli-01-hub-start/run.sh
@@ -10,6 +10,8 @@
 #
 # 是 [docker-e2e SC01] / [test30] 等之外，专 pin **CLI 输出 + 用户能否上手** 的 L2 smoke。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-cli-02-network-create/Dockerfile
+++ b/tests/qa-cli-02-network-create/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-cli-02-network-create/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-cli-02-network-create/run.sh
+++ b/tests/qa-cli-02-network-create/run.sh
@@ -6,6 +6,8 @@
 # 测的是 CLI binary 这一层 — 输出格式 + 本地 config 落地 + REST 调用。
 # REST 本身已被 qa-hub-05 覆盖，这条专测 CLI 包装层。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-dash-07-auth-boundary/Dockerfile
+++ b/tests/qa-dash-07-auth-boundary/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-dash-07-auth-boundary/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-dash-07-auth-boundary/run.sh
+++ b/tests/qa-dash-07-auth-boundary/run.sh
@@ -9,6 +9,8 @@
 # 直接 curl hub REST，不起 dashboard 前端。dashboard 视觉 + 路由
 # 由 dashboard repo Playwright 在 docker-e2e 里覆盖（保护资产）。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-dash-08-cross-account-views/Dockerfile
+++ b/tests/qa-dash-08-cross-account-views/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-dash-08-cross-account-views/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-dash-08-cross-account-views/run.sh
+++ b/tests/qa-dash-08-cross-account-views/run.sh
@@ -8,6 +8,8 @@
 #   /api/nodes / /api/stats / /api/completions / /api/auth/tokens
 #   + 显式 ?to_name=<alice-agent> filter / ?from_name=alice 等过滤参数
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-dash-10-incremental-poll/Dockerfile
+++ b/tests/qa-dash-10-incremental-poll/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-dash-10-incremental-poll/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-dash-10-incremental-poll/run.sh
+++ b/tests/qa-dash-10-incremental-poll/run.sh
@@ -8,6 +8,8 @@
 # 这条 pin：since= 真在工作（不被忽略 → 不会重复看；不过滤太狠 → 不丢新）
 # + 抠出两个端点 timestamp 格式不一致的 gap。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-hub-05-roundtrip/Dockerfile
+++ b/tests/qa-hub-05-roundtrip/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-hub-05-roundtrip/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-05-roundtrip/run.sh
+++ b/tests/qa-hub-05-roundtrip/run.sh
@@ -2,6 +2,8 @@
 # qa-hub-05-roundtrip — register utok → mint ntok → POST /api/task → SSE 收到
 # 用户视角 L1 contract test，纯黑盒，不依赖业务源码。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-hub-06-token-revoke/Dockerfile
+++ b/tests/qa-hub-06-token-revoke/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-hub-06-token-revoke/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-06-token-revoke/run.sh
+++ b/tests/qa-hub-06-token-revoke/run.sh
@@ -4,6 +4,8 @@
 # 用户也可以单独撤销自己的 ntok。
 # L1 contract test，纯黑盒。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-hub-06b-cross-user-isolation/Dockerfile
+++ b/tests/qa-hub-06b-cross-user-isolation/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-hub-06b-cross-user-isolation/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-06b-cross-user-isolation/run.sh
+++ b/tests/qa-hub-06b-cross-user-isolation/run.sh
@@ -10,6 +10,8 @@
 #
 # R5 (HUB-06) 测的是 token 撤销。R17 补**跨用户数据隔离** —— OWASP IDOR class。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-hub-07-sse-reconnect/Dockerfile
+++ b/tests/qa-hub-07-sse-reconnect/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-hub-07-sse-reconnect/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-07-sse-reconnect/run.sh
+++ b/tests/qa-hub-07-sse-reconnect/run.sh
@@ -7,6 +7,8 @@
 #  2. 但 inbox 持久化在 DB — 重连后通过 get_inbox 拉回
 #  3. 重连后新 push 正常流
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-hub-08-restart-persistence/Dockerfile
+++ b/tests/qa-hub-08-restart-persistence/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-hub-08-restart-persistence/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-08-restart-persistence/run.sh
+++ b/tests/qa-hub-08-restart-persistence/run.sh
@@ -8,6 +8,8 @@
 # 这是 NODE-04 (agent-node 自重连) 的 hub-side 半边。real anet node CLI 的
 # 自动重连逻辑是另一半，需要 NODE-04b 用真 anet node 进程测。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-hub-09-task-state-machine/Dockerfile
+++ b/tests/qa-hub-09-task-state-machine/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-hub-09-task-state-machine/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-09-task-state-machine/run.sh
+++ b/tests/qa-hub-09-task-state-machine/run.sh
@@ -8,6 +8,8 @@
 #
 # 这条 pin 三个分支 + 终态不可逆契约。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-hub-10-network-scope-regressions/Dockerfile
+++ b/tests/qa-hub-10-network-scope-regressions/Dockerfile
@@ -14,4 +14,10 @@ COPY tests/qa-hub-10-network-scope-regressions/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-10-network-scope-regressions/run.sh
+++ b/tests/qa-hub-10-network-scope-regressions/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # qa-hub-10-network-scope-regressions — network_id error clarity + SSE isolation
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 HUB_PORT=9210

--- a/tests/qa-hub-11-node-delete-sse/Dockerfile
+++ b/tests/qa-hub-11-node-delete-sse/Dockerfile
@@ -14,4 +14,10 @@ COPY tests/qa-hub-11-node-delete-sse/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-11-node-delete-sse/run.sh
+++ b/tests/qa-hub-11-node-delete-sse/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # qa-hub-11-node-delete-sse — node deletion must push network-scoped SSE event
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 HUB_PORT=9211

--- a/tests/qa-hub-12-servers-endpoint/Dockerfile
+++ b/tests/qa-hub-12-servers-endpoint/Dockerfile
@@ -14,4 +14,10 @@ COPY tests/qa-hub-12-servers-endpoint/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-12-servers-endpoint/run.sh
+++ b/tests/qa-hub-12-servers-endpoint/run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 HUB_PORT=9212

--- a/tests/qa-hub-13-server-health-agents/Dockerfile
+++ b/tests/qa-hub-13-server-health-agents/Dockerfile
@@ -14,4 +14,10 @@ COPY tests/qa-hub-13-server-health-agents/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-hub-13-server-health-agents/run.sh
+++ b/tests/qa-hub-13-server-health-agents/run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 HUB_PORT=9213

--- a/tests/qa-node-02-success-reply/Dockerfile
+++ b/tests/qa-node-02-success-reply/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-node-02-success-reply/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-node-02-success-reply/run.sh
+++ b/tests/qa-node-02-success-reply/run.sh
@@ -3,6 +3,8 @@
 # 用户故事：admin 给 agent 派 task → agent 处理完用 send_reply 回 → task 状态变 'replied' + result 落库
 # 用 mock-via-MCP（直接 curl 打 send_reply）代替真 agent + 真 LLM，性价比远高于 e2e。
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 

--- a/tests/qa-node-03b-task-events/Dockerfile
+++ b/tests/qa-node-03b-task-events/Dockerfile
@@ -13,4 +13,10 @@ COPY tests/qa-node-03b-task-events/run.sh /app/run.sh
 COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 RUN chmod +x /app/run.sh
 
+# SHA 绑定（#1092）。scripts/qa.sh 从这里 grep `^ARG SOURCE_COMMIT` 决定传不传
+# --build-arg；没有这一行就**不传，而且不报错**，本次运行无法被钉到任何提交上。
+# 放在 CMD 之前而不是文件开头 —— 否则每次 commit 都会让上面的 COPY 层失效。
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 CMD ["/app/run.sh"]

--- a/tests/qa-node-03b-task-events/run.sh
+++ b/tests/qa-node-03b-task-events/run.sh
@@ -9,6 +9,8 @@
 #   2. actor 列正确归属（admin 发 → admin；agent 回 → agent alias）
 #   3. /api/task_events?task_id=<id> 返回该 task 全部事件，created_at DESC 排序
 set -euo pipefail
+# 绑了还要看得见（#1092）：报告里没有这一行，就没法把这次运行钉到某个提交上。
+printf 'source_commit=%s\n' "${SOURCE_COMMIT:-unknown}"
 
 export HOME=/tmp/anethome
 


### PR DESCRIPTION
承接 `#1093`（先加门）。**门兜着了，可以放心补存量。**

## 改了什么

每个套件两处：

    Dockerfile  在 CMD 之前加 ARG SOURCE_COMMIT / ENV
                （放文件开头会让上面的 COPY 层每次 commit 都失效）
    run.sh      在 set -euo pipefail 之后打印 source_commit=$SOURCE_COMMIT
                —— **绑了还要看得见**，报告里没有这一行就没法把运行钉到提交上

    门：l1=30  bound=13→30  unbound=17→0  invisible=0  new=0

## 🔴 补完准备清空基线时，撞到我自己写的一个坑

`read_baseline()` 原来把**「文件不存在」**和**「文件在但存量为 0」**压成了同一个判断：

```python
base = read_baseline()
if not base:              # ← 空 set 和 FileNotFoundError 走同一条路
    return 2
```

⇒ **存量清零那天这道门会突然 rc=2，而那正是它最该安静通过的时刻。**

改成：`None` = 文件不存在（rc=2）；空 `set` = 已清零（安静通过）。

实测三态：

    存量已清零（基线空文件）  rc=0  baseline=0 new=0   ← 安静通过
    基线文件被删              rc=2  「不存在 —— 没有楼层可比，拒绝通过」
    selftest                  7/7

## 抽验（真跑，不是只看门）

    qa-cli-01-hub-start           rc=0  PASS  source_commit 命中所测 SHA
    qa-hub-09-task-state-machine  rc=0  PASS  source_commit 命中所测 SHA

17 个 `run.sh` 全部 `bash -n` 通过。

## ⚠️ 我用的是打印，不是断言 —— 理由说清楚

`tests/test746-setup-bun-pin/run.sh:8` 那种**断言**（`^[0-9a-f]{40}$`，拿不到就退出）更强。
我没有批量用它：**一次动 17 个文件，断言会让任何不带 `--build-arg` 的手动
`docker run` 直接失败，爆炸半径比收益大。**

**逐个套件改成断言是更强的形态，可以后续单独做** ——
这道门现在只要求「可见」，断言是可选的加强。