### PR TITLE
fix(test587/test588): 变异锚点随一次改名过期——两个孤儿套件同一个根因

### DIFF
--- a/tests/test587-codex-start-relative-timeout/mutate.ts
+++ b/tests/test587-codex-start-relative-timeout/mutate.ts
@@ -1,3 +1,8 @@
+// 🔴 2026-08-19（#1095）：产品把 `startResponseTimer` 改名成 `armResponseIdleTimer`，
+//   而且 onStarted 之后的上下文也从 `// A shared app-server WebSocket` 变成了 `const onActivity`。
+//   本文件的变异锚点还停在旧名字上 ⇒ replaceExact 命中 0 次 ⇒ 套件红在
+//   `expected one anchor ... found 0`。**守卫是对的、红得也准确**，是锚点过期。
+//   实测：全仓只剩本文件和另一个套件的 mutate.ts 还在用旧名，产品里 startResponseTimer 出现 0 次。
 import { readFileSync, writeFileSync } from "node:fs";
 
 const mutation = process.argv[2];
@@ -23,8 +28,8 @@ switch (mutation) {
   case "ignore_started_event":
     replaceExact(
       runtimePath,
-      `      startResponseTimer();\n    };\n\n    // A shared app-server WebSocket`,
-      `      void ev;\n    };\n\n    // A shared app-server WebSocket`,
+      `      armResponseIdleTimer();\n    };\n    const onActivity`,
+      `      void ev;\n    };\n    const onActivity`,
     );
     break;
   case "wrong_task_arms_timer":
@@ -37,8 +42,11 @@ switch (mutation) {
   case "omit_bridge_started_event":
     replaceExact(
       bridgePath,
-      `    this.emit("task_started", { taskId: input.taskId, turnId, steered: false });`,
-      `    void turnId;`,
+      // 🔴 #1095：产品这段从单行 { taskId: input.taskId, turnId, ... } 改成了多行
+      //   { taskId: pending.taskId, ... }。正确的锚点**隔壁 test588 已经有了**
+      //   （tests/test588-codex-turn-clientid-rebind/mutate.ts 的同名 case），照抄它，不另发明。
+      `    this.emit("task_started", {\n      taskId: pending.taskId,\n      turnId: pending.turnId,\n      steered: false,\n    });`,
+      `    void pending;`,
     );
     break;
   case "omit_steer_started_event":

--- a/tests/test588-codex-turn-clientid-rebind/mutate.ts
+++ b/tests/test588-codex-turn-clientid-rebind/mutate.ts
@@ -1,3 +1,8 @@
+// 🔴 2026-08-19（#1095）：产品把 `startResponseTimer` 改名成 `armResponseIdleTimer`，
+//   而且 onStarted 之后的上下文也从 `// A shared app-server WebSocket` 变成了 `const onActivity`。
+//   本文件的变异锚点还停在旧名字上 ⇒ replaceExact 命中 0 次 ⇒ 套件红在
+//   `expected one anchor ... found 0`。**守卫是对的、红得也准确**，是锚点过期。
+//   实测：全仓只剩本文件和另一个套件的 mutate.ts 还在用旧名，产品里 startResponseTimer 出现 0 次。
 import { readFileSync, writeFileSync } from "node:fs";
 
 const mutation = process.argv[2];
@@ -56,14 +61,14 @@ switch (mutation) {
     );
     break;
   case "timer_at_submission":
-    replaceExact(runtimePath, `    bridge.on("task_started", onStarted);`, `    bridge.on("task_started", onStarted);\n    startResponseTimer();`);
+    replaceExact(runtimePath, `    bridge.on("task_started", onStarted);`, `    bridge.on("task_started", onStarted);\n    armResponseIdleTimer();`);
     break;
   case "ignore_started_event":
-    replaceExact(runtimePath, `      startResponseTimer();\n    };\n\n    // A shared app-server WebSocket`, `      void ev;\n    };\n\n    // A shared app-server WebSocket`);
+    replaceExact(runtimePath, `      armResponseIdleTimer();\n    };\n    const onActivity`, `      void ev;\n    };\n    const onActivity`);
     break;
   case "identity_defer_unbounded":
-    replaceExact(runtimePath, `      startResponseTimer();\n    };\n\n    // A shared app-server WebSocket`, `      void ev;\n    };\n\n    // A shared app-server WebSocket`);
-    replaceExact(runtimePath, `        if (r.started) startResponseTimer();`, `        if (false && r.started) startResponseTimer();`);
+    replaceExact(runtimePath, `      armResponseIdleTimer();\n    };\n    const onActivity`, `      void ev;\n    };\n    const onActivity`);
+    replaceExact(runtimePath, `        if (r.started) armResponseIdleTimer();`, `        if (false && r.started) armResponseIdleTimer();`);
     break;
   case "wrong_task_arms_timer":
     replaceExact(runtimePath, `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (ev.taskId !== opts.taskId) return;`, `    const onStarted = (ev: { taskId: string; turnId: string; steered?: boolean }) => {\n      if (false && ev.taskId !== opts.taskId) return;`);
@@ -84,7 +89,7 @@ switch (mutation) {
   case "omit_left_fifo_response_fallback":
     replaceExact(
       runtimePath,
-      `        log(\`[codex-app-server] queue deadline reached after task left FIFO; arming response timeout for \${opts.taskId}\`);\n        startResponseTimer();\n        return;`,
+      `        log(\`[codex-app-server] queue deadline reached after task left FIFO; arming response timeout for \${opts.taskId}\`);\n        armResponseIdleTimer();\n        return;`,
       `        log(\`[codex-app-server] queue deadline reached after task left FIFO; response timeout omitted by mutation\`);\n        return;`,
     );
     break;


### PR DESCRIPTION
按构建成本逐个跑孤儿时撞到的：**两个套件在 `origin/main` 上都红，红话一模一样**。

    error: ignore_started_event: expected one anchor in
           ./src/runtime/codex-app-server/runtime.ts, found 0
    FAIL mutation-anchor ignore_started_event

**守卫是对的、红得也准确** —— 它明说「期望一个锚点，找到 0 个」，
指向的是**测试自己的锚点**，不是产品。

## 根因：一次改名

    startResponseTimer   在 agent-node/src 里出现 **0** 次
    armResponseIdleTimer 出现 **5** 次
    全仓只剩这两个 mutate.ts 还在用旧名

且 `onStarted` 之后的上下文也从 `// A shared app-server WebSocket` 变成了 `const onActivity`。

## 🔴 先枚举，再修 —— 一次跑只能发现一条

每跑一次 ~2 分钟，而一次只暴露一条过期锚点。所以我把两个文件里**全部 30 个
`replaceExact` 锚点**抠出来，逐个对 `agent-node/src` 数命中。**3 条 0 命中**：

    test587  ignore_started_event            （改名）
    test587  omit_bridge_started_event       （产品那段从单行 { taskId: input.taskId, ... }
                                              改成多行 { taskId: pending.taskId, ... }）
    test588  omit_left_fifo_response_fallback（同一次改名的第 3 处）

🔴 `test587` 的 `omit_bridge_started_event` **正确写法隔壁 `test588` 的同名 case 已经有了**
（它命中 1 次）—— 照抄，不另发明。

## 🔴 复核时我的量具自己错了一次

Python 的 `unicode_escape` **解不了 TS 模板串里的 `\${`**，把一条好锚点报成 0 命中。
改用 **Node 原生求值模板串**重数 —— **30 个锚点全部恰好命中 1 次**。

⇒ **不猜转义，让语言自己的解析器来。**

## 改后实测

    test587-codex-start-relative-timeout   rc=0  RESULT: PASS
    test588-codex-turn-clientid-rebind     rc=0  RESULT: PASS

## 本 PR 不做的事

**不登记它们进 CI** —— 先修红、再登记。