### PR TITLE
fix(test647): 变异存活时静默终止——让它说出是哪条、并指明这是覆盖洞

### DIFF
--- a/tests/test647-rest-explicit-columns/run.sh
+++ b/tests/test647-rest-explicit-columns/run.sh
@@ -35,6 +35,20 @@ cp server/src/server.ts /tmp/test647-server.ts
 cp server/src/auth.ts /tmp/test647-auth.ts
 cp server/src/scheduled-tasks.ts /tmp/test647-scheduled-tasks.ts
 
+# 🔴 2026-08-19（#1096）：原来这里是裸的 `test "$X_rc" -ne 0`。
+#    在 set -e 下，变异**存活**（rc=0）会让脚本当场终止，**一个字都不打** ——
+#    日志停在上一行 echo 的标题上，读的人看不出是哪条变异活下来了、也看不出是不是脚本崩了。
+#    实测：L3b 的变异存活，整个套件的输出就停在
+#    「L3b witnessed-red: network membership SELECT-star leaks future column」这一行。
+#    下面这个函数把「静默死亡」换成一句能定位的话。判据的宽严一点没变。
+mutation_must_be_red() { # $1=变异名 $2=rc $3=那次运行的日志
+  if [ "$2" -ne 0 ]; then return 0; fi
+  echo "FAIL: mutation '$1' SURVIVED (rc=0) —— 这条变异没有被任何测试抓到，是**覆盖洞**，不是脚本错误" >&2
+  echo "      变异后的运行日志尾部：" >&2
+  tail -6 "$3" >&2 || true
+  exit 1
+}
+
 echo "L3a witnessed-red: task list SELECT-star leaks future column"
 sed -i 's/SELECT ${TASK_REST_SELECT} FROM tasks WHERE 1=1/SELECT * FROM tasks WHERE 1=1/' server/src/server.ts
 grep -Fq 'SELECT * FROM tasks WHERE 1=1' server/src/server.ts
@@ -42,7 +56,7 @@ set +e
 run_shape_test /tmp/test647-mut-task.db >/tmp/test647-mut-task.log 2>&1
 task_rc=$?
 set -e
-test "$task_rc" -ne 0
+mutation_must_be_red task-rest-select-star "$task_rc" /tmp/test647-mut-task.log
 grep -Fq 'future_internal_only' /tmp/test647-mut-task.log
 echo "MUTATION_RED: task-rest-select-star rc=$task_rc"
 cp /tmp/test647-server.ts server/src/server.ts
@@ -54,7 +68,7 @@ set +e
 run_shape_test /tmp/test647-mut-network.db >/tmp/test647-mut-network.log 2>&1
 network_rc=$?
 set -e
-test "$network_rc" -ne 0
+mutation_must_be_red network-rest-select-star "$network_rc" /tmp/test647-mut-network.log
 grep -Fq 'future_internal_only' /tmp/test647-mut-network.log
 echo "MUTATION_RED: network-rest-select-star rc=$network_rc"
 cp /tmp/test647-auth.ts server/src/auth.ts
@@ -66,7 +80,7 @@ set +e
 run_shape_test /tmp/test647-mut-schedule.db >/tmp/test647-mut-schedule.log 2>&1
 schedule_rc=$?
 set -e
-test "$schedule_rc" -ne 0
+mutation_must_be_red schedule-rest-select-star "$schedule_rc" /tmp/test647-mut-schedule.log
 grep -Fq 'future_internal_only' /tmp/test647-mut-schedule.log
 echo "MUTATION_RED: schedule-rest-select-star rc=$schedule_rc"
 cp /tmp/test647-scheduled-tasks.ts server/src/scheduled-tasks.ts


### PR DESCRIPTION
按构建成本跑孤儿时撞到：这个套件在 `origin/main` 上 `rc=1`，
**而日志里一个 `FAIL` 都没有** —— 输出停在
`L3b witnessed-red: network membership SELECT-star leaks future column` 这一行就结束了。

## 用 `bash -x` 追出来的最后几条

    + sed -i 's/…/SELECT n.*, nm.role as member_role/' server/src/auth.ts   ← 变异打上了
    + grep -Fq 'SELECT n.*, nm.role as member_role' server/src/auth.ts      ← 确认打上了
    + run_shape_test /tmp/test647-mut-network.db
    + network_rc=0                                                          ← **变异存活**
    + test 0 -ne 0                                                          ← 死在这里，静默

`test "$X_rc" -ne 0` 在 `set -e` 下失败时**不打印任何东西**。

⇒ **「变异存活（真覆盖洞）」和「脚本自己崩了」在输出上完全一样，而处置相反。**

## 改动

三处裸 `test "$X_rc" -ne 0` → `mutation_must_be_red()`，存活时打印：

    FAIL: mutation 'network-rest-select-star' SURVIVED (rc=0)
          —— 这条变异没有被任何测试抓到，是**覆盖洞**，不是脚本错误
          变异后的运行日志尾部：…

**判据的宽严一点没变**，`rc` 仍然是 1。

## 🔴 改完仍然是红的，而且应该红

那条变异**真的存活**。根因我查到了，但**本 PR 不修**：

    被变异的是 server/src/auth.ts:549 的 getUserAllNetworks()
    它只在两处可达：
      server/src/server.ts:985   GET /api/auth/me
      server/src/server.ts:1165  GET /api/networks 的**三元 else 分支**
                                 （if 分支走 :1156-1162 的内联查询）

而 `server/src/rest-explicit-columns-http.test.ts` 只打 `/api/networks`，
且它的用户走 **if 分支** ⇒ **两条可达路径一条都没被覆盖。**

⇒ 要补的是**产品测试**（给 `/api/auth/me` 或非 admin 视角加一条 shape 断言）。
**把这条变异删掉才是把洞盖回去** —— 不做。