### PR TITLE
fix(#1085): send_reply alias 改可选，缺失时从 in_reply_to 反推目标 — 消除 -32602

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1845 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1845) + [tools.ts:1857 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1857) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1873 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1873) + [tools.ts:1887 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1887) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:72 + db.ts:98](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L72)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/send-reply-alias-optional.test.ts
+++ b/server/src/send-reply-alias-optional.test.ts
@@ -1,0 +1,131 @@
+// #1085 — send_reply must not require `alias` when `in_reply_to` is set.
+//
+// Symptom (deployed SDK-runtime nodes): `mcp__commhub__send_reply(task_id,
+// text)` → `-32602 Invalid input: expected string, received undefined at
+// alias`. That is the HUB's Zod schema rejecting a required `alias` the
+// client never sent — the request dies before the handler runs, so the
+// original task is never terminalized and its inbox row stays unacked
+// (pending inflation).
+//
+// Fix (two parts, both in tools.ts):
+//   1. `replyToolSchema.alias` → optional (stops the MCP-layer Zod -32602).
+//   2. `handleReply` derives the target from the in_reply_to task's
+//      `from_name` when alias is omitted — the target was always knowable
+//      from the task the hub already looks up, so the param was redundant.
+//
+// This suite drives the registered handler directly (MCP Zod layer is
+// exercised separately by the framework), so it pins part (2): omit alias
+// → derive → reply lands on the original sender; omit both → clean error.
+//
+// 改坏报红 gate: revert the derive block (require alias again) and
+// "alias omitted → derives to original sender" flips to a resolve failure.
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { db } from "./db.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "./tools.js";
+
+const NET_ID = "net_1085";
+const USER_ID = "u_1085";
+const NODE_ID = "node_1085";
+const AGENT_ALIAS = "worker-1085";
+const ORIGIN_ALIAS = "boss-1085"; // the task's from_name — the derive target
+const AGENT_TOK_ID = "tok_1085";
+
+interface ToolHandler {
+  (args: any, extra?: any): Promise<{ content: Array<{ type: "text"; text: string }> }>;
+}
+interface Reply { ok?: boolean; message_id?: string; error?: string; message?: string; [k: string]: unknown; }
+
+function cleanup() {
+  for (const t of ["tasks", "inbox", "task_events", "sessions", "nodes", "api_tokens", "network_members", "networks"]) {
+    try { db.run(`DELETE FROM ${t} WHERE network_id = ?1`, [NET_ID]); } catch {}
+  }
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [USER_ID]); } catch {}
+}
+beforeEach(cleanup);
+afterAll(cleanup);
+
+function seed(): { taskId: string } {
+  db.run(`INSERT INTO users (user_id, username, password_hash, role, created_at) VALUES (?1, ?2, 'x', 'user', datetime('now'))`, [USER_ID, USER_ID]);
+  db.run(`INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?2, ?3, datetime('now'))`, [NET_ID, NET_ID, USER_ID]);
+  db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))`, [USER_ID, NET_ID]);
+  db.run(`INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, created_at, updated_at, lifecycle_state) VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now'), 'active')`, [NODE_ID, AGENT_ALIAS, AGENT_ALIAS, NET_ID, `host-${AGENT_ALIAS}`]);
+  db.run(`INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at) VALUES (?1, ?2, 'idle', ?3, ?4, datetime('now'), datetime('now'))`, [`res_${AGENT_ALIAS}`, AGENT_ALIAS, NODE_ID, NET_ID]);
+  // The reply TARGET session (the task originator). Its alias is what the
+  // handler must derive from the task's from_name.
+  db.run(`INSERT INTO sessions (resume_id, alias, status, network_id, updated_at, last_seen_at) VALUES (?1, ?2, 'idle', ?3, datetime('now'), datetime('now'))`, [`res_${ORIGIN_ALIAS}`, ORIGIN_ALIAS, NET_ID]);
+  // A task from ORIGIN_ALIAS → the worker. Replying to it should land on
+  // ORIGIN_ALIAS even when the caller omits alias.
+  const taskId = `task_1085_${Date.now()}${Math.floor(Math.random() * 1000)}`;
+  db.run(`INSERT INTO tasks (task_id, from_name, to_name, status, content, requires_response, created_at, delivered_at, expires_at, network_id, priority) VALUES (?1, ?2, ?3, 'delivered', 'do the thing', 'reply', datetime('now'), datetime('now'), datetime('now', '+1 hour'), ?4, 'normal')`, [taskId, ORIGIN_ALIAS, AGENT_ALIAS, NET_ID]);
+  return { taskId };
+}
+
+async function getHandler(): Promise<ToolHandler> {
+  const server = new McpServer({ name: "test", version: "0" });
+  const tools: Record<string, ToolHandler> = {};
+  const originalTool = (server as any).tool.bind(server);
+  (server as any).tool = (name: string, ...rest: any[]) => {
+    const handler = rest[rest.length - 1];
+    if (typeof handler === "function") tools[name] = handler;
+    return originalTool(name, ...rest);
+  };
+  registerTools(server, {
+    enforceNetworkId: NET_ID,
+    enforceUserId: USER_ID,
+    callerAlias: AGENT_ALIAS,
+    callerTokenIsNetwork: true,
+    callerTokenId: AGENT_TOK_ID,
+  } as any);
+  const handler = tools.send_reply;
+  if (!handler) throw new Error("send_reply handler not registered");
+  return handler;
+}
+
+async function call(h: ToolHandler, args: any): Promise<Reply> {
+  return JSON.parse((await h(args)).content[0].text) as Reply;
+}
+
+describe("#1085 send_reply — alias optional, derived from in_reply_to", () => {
+  test("alias OMITTED + in_reply_to set → derives target from task from_name, reply lands on originator", async () => {
+    const { taskId } = seed();
+    const h = await getHandler();
+    const r = await call(h, { in_reply_to: taskId, text: "done", status: "replied", from_session: AGENT_ALIAS });
+    expect(r.ok).toBe(true);
+    // The reply inbox row must be addressed to the derived originator.
+    const row = db.get<{ session_name: string; in_reply_to: string }>(
+      "SELECT session_name, in_reply_to FROM inbox WHERE id = ?1", [r.message_id],
+    );
+    expect(row?.session_name).toBe(ORIGIN_ALIAS);
+    expect(row?.in_reply_to).toBe(taskId);
+    // And the original task is terminalized (no longer pending).
+    const task = db.get<{ status: string }>("SELECT status FROM tasks WHERE task_id = ?1", [taskId]);
+    expect(task?.status).toBe("replied");
+  });
+
+  test("alias EXPLICIT still works (unchanged path)", async () => {
+    const { taskId } = seed();
+    const h = await getHandler();
+    const r = await call(h, { alias: ORIGIN_ALIAS, in_reply_to: taskId, text: "done", from_session: AGENT_ALIAS });
+    expect(r.ok).toBe(true);
+    const row = db.get<{ session_name: string }>("SELECT session_name FROM inbox WHERE id = ?1", [r.message_id]);
+    expect(row?.session_name).toBe(ORIGIN_ALIAS);
+  });
+
+  test("alias OMITTED + no in_reply_to → clean error, not a crash", async () => {
+    seed();
+    const h = await getHandler();
+    const r = await call(h, { text: "orphan reply", from_session: AGENT_ALIAS });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("reply_target_required");
+  });
+
+  test("alias OMITTED + in_reply_to points at nonexistent task → resolve error", async () => {
+    seed();
+    const h = await getHandler();
+    const r = await call(h, { in_reply_to: "task_does_not_exist_1085", text: "x", from_session: AGENT_ALIAS });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("reply_target_unresolved");
+  });
+});

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1534,7 +1534,15 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
 
   // ── V2/V3 reply primitives ──
   const replyToolSchema = {
-      alias: z.string().min(1).max(200).describe("Target session alias"),
+      // #1085 — alias is OPTIONAL: when omitted (or empty) and `in_reply_to`
+      // is set, the hub derives the target from the original task's
+      // `from_name` (it already SELECTs that task by in_reply_to below).
+      // The SDK-runtime bridge (agent-node/src/commhub-mcp.ts) exposes
+      // send_reply as (task_id, text, status) with NO alias, so before this
+      // it always sent alias=undefined → -32602 "expected string, received
+      // undefined at alias". The target was already knowable from the task,
+      // so requiring the caller to pass it was a redundant-param trap.
+      alias: z.string().min(1).max(200).optional().describe("Target session alias — optional; derived from in_reply_to's task sender when omitted"),
       text: z.string().min(1).max(10000).describe("Reply content"),
       in_reply_to: z.string().max(200).optional().describe("Original task/message ID"),
       status: z.enum(["replied", "failed", "cancelled"]).optional().default("replied").describe("Task outcome"),
@@ -1585,9 +1593,29 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         : meta;
       const metaJson = normalizeMetaJson(mergedMeta);
 
-      const canonicalReplyTarget = resolveCanonicalAlias(effectiveNetId, alias);
+      // #1085 — derive the reply target when the caller omitted `alias`.
+      // The original task's `from_name` IS the reply target; the hub knows
+      // it from `in_reply_to`. Without this, an SDK-runtime send_reply
+      // (schema has no alias) died with -32602 before reaching this handler.
+      let effectiveAlias: string | undefined =
+        (typeof alias === "string" && alias.trim()) ? alias : undefined;
+      if (!effectiveAlias) {
+        if (!in_reply_to) {
+          return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "reply_target_required", message: "alias omitted and no in_reply_to to derive it from" }) }] };
+        }
+        const derivParams: any[] = [in_reply_to];
+        let derivSql = "SELECT from_name FROM tasks WHERE task_id = ?1";
+        derivSql = addScope(derivSql, derivParams, effectiveNetId);
+        const derived = db.get<{ from_name: string }>(derivSql, ...derivParams);
+        if (!derived?.from_name) {
+          return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "reply_target_unresolved", message: `alias omitted and could not derive target from in_reply_to (${in_reply_to})` }) }] };
+        }
+        effectiveAlias = derived.from_name;
+      }
+
+      const canonicalReplyTarget = resolveCanonicalAlias(effectiveNetId, effectiveAlias);
       const replyTargetAlias = canonicalReplyTarget.alias;
-      console.log(`[${ts()}] ${from_session} → send_reply (${replyStatus}) → ${replyTargetAlias}: ${text.slice(0, 60)}${attachmentsResult.attachments.length ? ` [+${attachmentsResult.attachments.length} attachments]` : ""}${canonicalReplyTarget.renamed ? ` [renamed from ${alias}]` : ""}`);
+      console.log(`[${ts()}] ${from_session} → send_reply (${replyStatus}) → ${replyTargetAlias}: ${text.slice(0, 60)}${attachmentsResult.attachments.length ? ` [+${attachmentsResult.attachments.length} attachments]` : ""}${canonicalReplyTarget.renamed ? ` [renamed from ${effectiveAlias}]` : ""}`);
       const id = uuidv4();
       const replyTargetNodeId = resolveNodeIdForAlias(replyTargetAlias, effectiveNetId);
       // RFC-027 §2.3 inbox-enqueue lifecycle guard (PR1.1 site 3/6).


### PR DESCRIPTION
Closes #1085.

## 问题
某些客户端调 send_reply → `-32602 Invalid input: expected string, received undefined at alias`。这是 hub 侧 Zod schema 因 `alias` 必填、而客户端没传 alias 而拒绝，请求在进 handler body 前就死 → 原任务不终态化 → 其 inbox 行不 ack → pending 虚高。

## 根因定位（已在 #1085 公开更正一处引用错）
现网 origin/main 的 SDK bridge send_reply schema 已带 alias+in_reply_to；报此错的是旧部署版 agent-node。本 PR 从 hub 侧根治该错误类，不依赖客户端版本。

## 修复
- `replyToolSchema.alias` → optional（停掉 MCP 层 -32602 Zod 拒绝）。
- `handleReply`：alias 省略且有 in_reply_to 时，从原任务 `from_name` 反推目标（hub 本就按 in_reply_to SELECT 了那条任务，参数冗余）。省略且无 in_reply_to → `reply_target_required`；in_reply_to 不存在 → `reply_target_unresolved`。显式 alias 老路径逐字节不变。
- 新增 send-reply-alias-optional.test.ts 4 用例，过改坏报红（去掉反推块→alias 省略 3 条转红）。

## 本地验证（以 CI 为准）
既有 reply 套件全绿（send-reply-attachments/peer-reply-atomic/peer-reply-capability/send-reply-agent-warning）；全量 bun test src/ 候选独有 fail=0。
