### PR TITLE
fix(#1100): CLI channel 不再把参数错误包成 -32603 — isError/非JSON body 返回结构化错误

### DIFF
--- a/agent-network/src/commhub-response.test.ts
+++ b/agent-network/src/commhub-response.test.ts
@@ -1,0 +1,63 @@
+// #1100 — parseCommhubToolResult must never throw, and must surface a
+// readable error on the isError path (a parameter-range rejection must
+// NOT masquerade as a -32603 protocol error).
+//
+// 改坏报红 gate: revert parseCommhubToolResult to the old
+//   `content[0].text ? JSON.parse(content[0].text) : json`
+// and the "isError → structured error (no throw)" test flips from a
+// clean object to a thrown SyntaxError.
+
+import { describe, expect, test } from "bun:test";
+import { parseCommhubToolResult } from "./commhub-response";
+
+// The EXACT envelope the live hub returns for report_status({progress:101}),
+// captured 2026-08-19 (reproduced against 127.0.0.1:9200).
+const HUB_PROGRESS_ERROR = {
+  result: {
+    content: [{
+      type: "text",
+      text: "MCP error -32602: Input validation error: Invalid arguments for tool report_status: Too big: expected number to be <=100 at progress",
+    }],
+    isError: true,
+  },
+  jsonrpc: "2.0",
+  id: 2,
+};
+
+describe("#1100 parseCommhubToolResult", () => {
+  test("isError result → structured {ok:false,error} carrying the readable message, does NOT throw", () => {
+    let out: any;
+    expect(() => { out = parseCommhubToolResult(HUB_PROGRESS_ERROR); }).not.toThrow();
+    expect(out.ok).toBe(false);
+    // The rejection reason must survive — it names the offending field.
+    expect(out.error).toContain("progress");
+    expect(out.error).toContain("<=100");
+    // And it must NOT look like a protocol/parse error.
+    expect(out.error).not.toContain("JSON Parse");
+    expect(out.error).not.toContain("-32603");
+  });
+
+  test("success JSON payload still parses to an object", () => {
+    const ok = { result: { content: [{ type: "text", text: '{"ok":true,"inbox_count":3}' }], isError: false }, jsonrpc: "2.0", id: 2 };
+    expect(parseCommhubToolResult(ok)).toEqual({ ok: true, inbox_count: 3 });
+  });
+
+  test("success text that isn't JSON degrades to a structured error, does NOT throw", () => {
+    const weird = { result: { content: [{ type: "text", text: "plain not-json body" }], isError: false }, jsonrpc: "2.0", id: 2 };
+    let out: any;
+    expect(() => { out = parseCommhubToolResult(weird); }).not.toThrow();
+    expect(out).toEqual({ ok: false, error: "plain not-json body" });
+  });
+
+  test("JSON-RPC error envelope (no result.content) → readable structured error", () => {
+    const envErr = { error: { code: -32600, message: "Invalid Request" }, jsonrpc: "2.0", id: 2 };
+    const out = parseCommhubToolResult(envErr);
+    expect(out.ok).toBe(false);
+    expect(out.error).toContain("Invalid Request");
+  });
+
+  test("plain result with no content passes through", () => {
+    const plain = { result: { ok: true, inbox_count: 0 }, jsonrpc: "2.0", id: 2 };
+    expect(parseCommhubToolResult(plain)).toEqual({ result: { ok: true, inbox_count: 0 }, jsonrpc: "2.0", id: 2 });
+  });
+});

--- a/agent-network/src/commhub-response.ts
+++ b/agent-network/src/commhub-response.ts
@@ -1,0 +1,36 @@
+// #1100 — parse a commhub MCP `tools/call` response envelope into a plain
+// result object, WITHOUT ever throwing on a non-JSON or isError body.
+//
+// Bug this fixes: the old inline logic did
+//   `content[0].text ? JSON.parse(content[0].text) : json`
+// unconditionally. A commhub tool that fails input validation comes back
+// as an isError result whose text is a human-readable STRING, e.g.
+//   "MCP error -32602: … Too big: expected number to be <=100 at progress"
+// JSON.parse'ing that threw, and the throw surfaced to the caller as an
+// opaque `-32603 JSON Parse error: Unexpected identifier "MCP"` — a
+// parameter-range error wearing a protocol-error mask, which sends
+// debugging to the wrong layer (the reporter chased task text / MCP link
+// for three retries before isolating `progress > 100`).
+//
+// Contract: the returned value is ALWAYS a plain object; error paths yield
+// `{ ok: false, error: <readable message> }` so the caller can read WHY
+// the call was rejected. Pure + side-effect free so it is unit-testable
+// without importing node-server.ts (which connects a stdio transport at
+// module load).
+export function parseCommhubToolResult(json: any): any {
+  const contentText = json?.result?.content?.[0]?.text;
+  if (contentText != null && contentText !== "") {
+    // isError → the text is an error STRING, not JSON. Surface it as a
+    // structured error instead of parsing (and throwing on) it.
+    if (json.result.isError) return { ok: false, error: contentText };
+    // Success payloads are JSON-stringified by commhub tools; still never
+    // let a non-JSON body throw — degrade to a readable structured error.
+    try { return JSON.parse(contentText); }
+    catch { return { ok: false, error: contentText }; }
+  }
+  // JSON-RPC error envelope (no result.content) — surface readably too.
+  if (json?.error) {
+    return { ok: false, error: `commhub error: ${typeof json.error === "string" ? json.error : JSON.stringify(json.error)}` };
+  }
+  return json;
+}

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -14,6 +14,7 @@
 
 import { readFileSync, existsSync } from "fs";
 import { OUTBOUND_TOOL_NAMES } from "./outbound-tool-names";
+import { parseCommhubToolResult } from "./commhub-response";
 import { randomUUID } from "crypto";
 import { join } from "path";
 import { hostname } from "os";
@@ -304,7 +305,10 @@ async function callCommHub(toolName: string, args: Record<string, unknown>): Pro
   const dataLine = text.split("\n").find((l) => l.startsWith("data: "));
   if (dataLine) {
     const json = JSON.parse(dataLine.slice(6));
-    return json?.result?.content?.[0]?.text ? JSON.parse(json.result.content[0].text) : json;
+    // #1100 — never let an isError / non-JSON body throw here (see
+    // commhub-response.ts). Returns a structured {ok:false,error} instead
+    // of surfacing an opaque -32603 that hides the real cause.
+    return parseCommhubToolResult(json);
   }
   return { ok: false, error: "no response" };
 }


### PR DESCRIPTION
Closes #1100.

## 问题（TM智空马 实测）
`commhub_report_status({progress:101})` → `-32603 JSON Parse error: Unexpected identifier "MCP"`。逐项隔离触发条件是 progress>100。

## 根因（已对 127.0.0.1:9200 实测复现坐实）
hub Zod 拒 progress>100，表面成 isError 结果 `content[0].text="MCP error -32602: … Too big … at progress"`（可读字符串非 JSON）。CLI channel `callCommHub`（node-server.ts）无条件 `JSON.parse` 它 → 抛 → 未捕获 → 被包成 -32603，把"progress 超范围"真因盖掉。一个参数越界错误戴着协议错误的面具，把人支去查错的那一层（报告者三次改 task 文本才隔离到 progress>100）。

## 修复
- 抽 `parseCommhubToolResult` 为纯函数模块 `commhub-response.ts`（无 import 副作用——node-server.ts 在 import 时连 stdio，直接 import 没法单测）。契约：永远返回普通对象、错误路径给 `{ok:false,error}`、绝不 throw。
- `callCommHub` 改调它：isError/非 JSON body/JSON-RPC error 一律返回结构化可读错误。
- 新增 commhub-response.test.ts 5 用例，过改坏报红（换回旧盲 parse→3 条转红），夹带实测捕获的真实错误信封。

## 范围
CLI channel 专属崩溃；SDK bridge（commhub-mcp.ts）已把 isError 透传成可读文本、不盲 parse、不受影响。

注：分支名 fix/1090 是建 worktree 时还不知 issue 号，代码内 refs 均为 #1100。
