### PR TITLE
test(npm-api): #1106 修两条红 —— 断言数 20 → 22（不是消掉断言）

### DIFF
--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -19,7 +19,6 @@ qa-rfc024-config-apply
 qa-rfc026-create-node
 qa-rfc027-stop-delete
 qa-rfc028-provider-probe
-test-npm-api
 test-npm-install
 test-npm-security
 test-rfc029-pr1-registration

--- a/tests/test-npm-api/NOT-IN-CI.md
+++ b/tests/test-npm-api/NOT-IN-CI.md
@@ -1,0 +1,49 @@
+# 为什么 test-npm-api 不进 per-PR CI
+
+Verified: 2026-08-19
+Revisit-when: run.sh 第 30 行不再是 `npm install -g @sleep2agi/*@preview`——
+              也就是这套断言的对象从「已发布的 npm preview」变成「本仓构建产物」时，
+              它就该进 qa.sh 的 L1_TESTS，并删掉本文件。
+
+## 理由：它测的不是这次提交
+
+```
+run.sh:30  npm install -g @sleep2agi/agent-network@preview \
+                          @sleep2agi/agent-node@preview \
+                          @sleep2agi/commhub-server@preview
+```
+
+⇒ 它起的 `commhub-server` 是**已发布到 npm 的 preview 版本**，不是 PR 里的代码。
+把它挂进 per-PR CI 会造出一道**量错对象**的门：
+
+- PR 改了 `server/src/tools.ts` → 这道门**看不见**（跑的是 npm 上那份）；
+- 别人发了一版 preview → 这道门在**与之无关的 PR 上**变红。
+
+两种情况下它的绿和红都不对应被审的那次改动。**一道在错误对象上开合的门，
+比没有门更糟**：它会让人以为这条路径被覆盖了。
+
+它还依赖 npm registry 网络可达（本机实测 build+run ≈ 60s+120s，其中绝大部分是
+`npm install`）——这是第二个理由，但不是主要理由。
+
+## 那它是什么
+
+**发版验证件**：验证「已发布的三个包装上之后，端到端还能跑通」。
+它该在发版流程里跑，由发版的人看，而不是在每个 PR 上跑。
+
+## 本次（#1106）改了什么
+
+它在 main 上一直是红的（21 条里 2 条失败），而且**两条都不是回归**：
+
+1. `from_session_identity_mismatch` —— 产品新增了 ntok_ 身份守卫
+   (`server/src/tools.ts:29-33`)，套件写在它之前；
+2. utok 调 /mcp 期望 403，实际 200 —— V3 有意变更，理由写在
+   `server/src/server.ts:725-728`（Dashboard 以用户身份登录，挡掉 utok_ 它就没法发任务）。
+
+🔴 两条最省事的修法（让 send_task 直接能过、把 403 改成 200）都会让它变绿，
+   但会**删掉仅有的两条安全断言**。本次改的方向相反 —— 断言数 20 → 22：
+
+- ntok_ happy path 用与令牌绑定一致的 from_session（能过），
+  **并新增**一条负向断言：换成别的别名必须被 `from_session_identity_mismatch` 拒绝；
+- 把「utok 连不上」换成**现在真实存在的那条边界**：utok 能调 /mcp，但只能触及
+  自己有权限的 network。配一条**正控**（同 token 写自己加入的网络必须成功），
+  这样「被拒」不会被误读成「边界生效」——若请求本身坏了，正控会一起红。

--- a/tests/test-npm-api/run.sh
+++ b/tests/test-npm-api/run.sh
@@ -84,16 +84,52 @@ echo ""
 
 echo "7. Use ntok to call MCP send_task"
 mcp_report_ntok='{"jsonrpc":"2.0","id":0,"method":"tools/call","params":{"name":"report_status","arguments":{"resume_id":"npm-api-test","alias":"npm-bot","status":"idle","network_id":"'"$TEST_NET_ID"'"}}}'
-mcp_send_ntok='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_task","arguments":{"alias":"npm-bot","task":"hello from npm api test","from_session":"npm-test","network_id":"'"$TEST_NET_ID"'"}}}'
+# ntok_ 是身份边界：from_session 必须等于令牌绑定的节点别名（这里 node_name=npm-bot）。
+# 守卫原文见 server/src/tools.ts:29-33 fromIdentityMismatchReply。
+mcp_send_ntok='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_task","arguments":{"alias":"npm-bot","task":"hello from npm api test","from_session":"npm-bot","network_id":"'"$TEST_NET_ID"'"}}}'
+# 同一条调用，只把 from_session 换成别的节点 —— 这是负向用例，必须被拒。
+mcp_spoof_ntok='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"send_task","arguments":{"alias":"npm-bot","task":"spoofed sender","from_session":"npm-test","network_id":"'"$TEST_NET_ID"'"}}}'
 NTOK_REPORT=$(curl -s -X POST "$BASE/mcp" -H "Authorization: Bearer $OWNER_NTOK" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d "$mcp_report_ntok")
 echo "$NTOK_REPORT" | grep -q 'ok\\":true' && pass "ntok report_status works" || fail "ntok report_status"
 NTOK_MCP=$(curl -s -X POST "$BASE/mcp" -H "Authorization: Bearer $OWNER_NTOK" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d "$mcp_send_ntok")
 echo "$NTOK_MCP" | grep -q 'ok\\":true' && pass "ntok send_task works" || fail "ntok send_task"
+
+# 负向：ntok_ 不能冒充别的节点。与上一条唯一的差别就是 from_session。
+NTOK_SPOOF=$(curl -s -X POST "$BASE/mcp" -H "Authorization: Bearer $OWNER_NTOK" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d "$mcp_spoof_ntok")
+echo "$NTOK_SPOOF" | grep -q 'from_session_identity_mismatch' \
+  && pass "ntok cannot spoof another node via from_session" \
+  || fail "ntok from_session spoof NOT rejected: $(echo "$NTOK_SPOOF" | head -c 200)"
 echo ""
 
-echo "8. Use utok to call MCP -> expect 403"
+echo "8. utok 可以调 /mcp（V3 有意），但只能触及自己有权限的 network"
+# 这里【不】断言 utok 被 403 挡掉。理由写在改动现场 server/src/server.ts:725-728：
+#   Dashboard 是以「用户」身份登录的，挡掉 utok_ 它就无法调用 send_task。
+# 边界没有消失，它从「传输层拒绝」挪到了「工具层按 network 作用域裁剪」。
+# 所以下面断言的是那条【现在真实存在】的边界，而不是「连不上」。
 UTOK_STATUS=$(curl -s -o /tmp/npm-api-utok-mcp.txt -w "%{http_code}" -X POST "$BASE/mcp" -H "$OWNER_AUTH" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d "$mcp_send_ntok")
-[ "$UTOK_STATUS" = "403" ] && pass "utok blocked from MCP" || fail "utok MCP expected 403 got $UTOK_STATUS"
+[ "$UTOK_STATUS" = "200" ] && pass "utok reaches /mcp (V3: transport no longer blocks utok)" || fail "utok /mcp expected 200 got $UTOK_STATUS"
+
+# npmmember 加入了 TEST_NET_ID，但在 OWNER_NET_ID（owner 注册时的默认网络）上没有任何角色。
+# 下面两条是一组 A/B：同一个 token、同一个工具、同一段 task，【只有 network_id 不同】。
+# 正控（能过）存在的意义：若拒绝那条是因为请求本身坏了，这条也会一起红，
+# 于是「被拒」就不会被误读成「边界生效」。
+mcp_send_own='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"send_task","arguments":{"alias":"npm-bot","task":"member scope probe","network_id":"'"$TEST_NET_ID"'"}}}'
+mcp_send_foreign='{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"send_task","arguments":{"alias":"npm-bot","task":"member scope probe","network_id":"'"$OWNER_NET_ID"'"}}}'
+
+MEMBER_OWN=$(curl -s -X POST "$BASE/mcp" -H "$MEMBER_AUTH" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d "$mcp_send_own")
+echo "$MEMBER_OWN" | grep -q 'ok\\":true' \
+  && pass "utok CAN write to a network it joined (positive control)" \
+  || fail "utok write to joined network failed: $(echo "$MEMBER_OWN" | head -c 200)"
+
+MEMBER_FOREIGN=$(curl -s -X POST "$BASE/mcp" -H "$MEMBER_AUTH" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d "$mcp_send_foreign")
+# 断言这一层【自己】返回的那个错误码，不是任何一种「被拒了」。
+# 守卫原文 server/src/tools.ts:95：
+#   return role ? { networkId: clientNetId, networkIds: null }
+#                : { denied: "access denied to requested network" };
+# 写死 access_denied 而不是宽松匹配 /denied/：后者会把「请求本身坏了」也读成「边界生效」。
+echo "$MEMBER_FOREIGN" | grep -q 'access_denied' \
+  && pass "utok CANNOT write to a network it has no role on (access_denied)" \
+  || fail "cross-network write NOT denied by access_denied: $(echo "$MEMBER_FOREIGN" | head -c 200)"
 echo ""
 
 echo "9. Check /api/status and /api/tasks"


### PR DESCRIPTION
关闭 #1106 提出的问题。**核心：这两条红最省事的修法都会把仅有的两条安全断言删掉，本 PR 方向相反。**

## main 上的两条红，都不是回归

| # | 现象 | 真因（原文位置） |
|---|---|---|
| ① | `send_task` 返回 `from_session_identity_mismatch` | 产品新增 ntok_ 身份守卫 `server/src/tools.ts:29-33`，套件写在它之前 |
| ② | utok 调 `/mcp` 期望 403，实际 200 | V3 有意变更，理由写在改动现场 `server/src/server.ts:725-728`：Dashboard 以「用户」身份登录，挡掉 utok_ 它就无法调用 send_task |

## 🔴 为什么不按最省事的方式修

```
把 send_task 改成「能过」      ⇒ 删掉了对新守卫的唯一覆盖
把 = "403" 改成 = "200"       ⇒ 从「验证一条边界」退化成「验证 HTTP 通了」
```

两种改法都会让它变绿，而且看起来都很合理。判断标准：**改完之后，这条测试原来能拦住的东西，还拦不拦得住？**

## 本 PR 怎么改的（断言数 20 → 22）

- **①** happy path 用与令牌绑定一致的 `from_session`（能过），**并新增**一条负向断言：换成别的别名必须被 `from_session_identity_mismatch` 拒绝。
- **②** 「utok 连不上」换成**现在真实存在的那条边界**：utok 能调 `/mcp`（200），但只能触及自己有权限的 network（`access_denied`，守卫原文 `server/src/tools.ts:95`）。
- 配一条**正控**：同一个 token、同一个工具、同一段 task，**只有 `network_id` 不同**，写自己加入的网络必须成功。若「被拒」那条是因为请求本身坏了，正控会一起红 ⇒ 拒绝不会被误读成「边界生效」。

## 证据（本机 docker 实测，非 CI）

```
修后：            22 passed, 0 failed   (rc=0)
见证红（变异）：   21 passed, 1 failed   (rc=1)
                  变异 = 把负向用例的 from_session 改回与令牌一致
                  失败的正是新增那条断言 ⇒ 它不是恒真
```

中途我预测错误码是 `permission_denied`，实测是 `access_denied`。**没有把断言放松成 `/denied/`**，而是按 `tools.ts:95` 的原文钉死具体错误码——宽松匹配会把「请求本身坏了」也读成「边界生效」。

## 🔴 它不进 per-PR CI，理由写进了 `tests/test-npm-api/NOT-IN-CI.md`

`run.sh:30` 装的是**已发布的 `@preview`**，不是本次提交。挂进 per-PR CI 会造出一道**量错对象**的门：

- PR 改了 `server/` → 这道门看不见（跑的是 npm 上那份）
- 别人发了一版 preview → 这道门在**无关的 PR 上**变红

它是**发版验证件**，该在发版流程里跑。撤销条件写在 `Revisit-when:` 里（对象从 npm preview 变成仓内构建时就该进 L1）。

**所以要说清楚：本 PR 的修复不受 per-PR CI 把关**，上面的绿是我本机 docker 实测的。

孤儿地板 81 → 80，但这是 **exempt 6 → 7**（补了撤销条件的豁免），**不是新接了一条 CI**。

Refs #1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
