### PR TITLE
fix(tests): 3 个套件 source safe-rm.sh 但 Dockerfile 没 COPY 它

### DIFF
--- a/tests/test18-error-paths/Dockerfile
+++ b/tests/test18-error-paths/Dockerfile
@@ -5,6 +5,7 @@ COPY server/ server/
 RUN cd server && bun install
 COPY agent-network/ agent-network/
 RUN cd agent-network && bun install
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 COPY tests/test18-error-paths/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 ENV COMMHUB_AUTH_TOKEN=test-auth-token

--- a/tests/test21-quickstart-ux/Dockerfile
+++ b/tests/test21-quickstart-ux/Dockerfile
@@ -5,6 +5,7 @@ COPY server/ server/
 RUN cd server && bun install
 COPY agent-network/ agent-network/
 RUN cd agent-network && bun install
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 COPY tests/test21-quickstart-ux/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 ENV COMMHUB_AUTH_TOKEN=test-auth-token

--- a/tests/test31-claude-code-cli-resume/Dockerfile
+++ b/tests/test31-claude-code-cli-resume/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash nodejs npm
     rm -rf /var/lib/apt/lists/*
 
 COPY agent-network/ agent-network/
+COPY tests/lib/safe-rm.sh /lib/safe-rm.sh
 COPY tests/test31-claude-code-cli-resume/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 


### PR DESCRIPTION
safe-rm 守卫横扫时给 run.sh 加了 `source .../../lib/safe-rm.sh`，但这 3 个套件的 Dockerfile 没一并加 COPY。

`run.sh` 落在 `/app/run.sh` ⇒ `../lib/` 解析成 `/lib/` ⇒ 那里什么都没有 ⇒ `set -e` 下第 17 行直接终止。

**origin/main 实测**（`tests/test31-claude-code-cli-resume`）：
```
/app/run.sh: line 17: /app/../lib/safe-rm.sh: No such file or directory
rc=1
```

🔴 报错点名了两样东西：**缺什么**（safe-rm.sh）和**从哪找的**（`/app/../lib/`）。缺陷在后半句——文件在仓里，是**落点**不对。修法用 `tests/qa-hub-16-rest-task-api/Dockerfile:14` 那个已实测跑通的写法。

## 🔴 证据分级（这三个并没有一起变绿）

| 套件 | 状态 | 依据 |
|---|---|---|
| test31 | ✅ 第一层已验证 | 修前 rc=1 死在第 17 行；修后 build=0，safe-rm 报错消失，跑进产品逻辑 |
| test18 | ⚠️ **未验证** | build 死在**更早的第 7 行**，走不到我加的第 8 行 |
| test21 | ⚠️ **未验证** | 同上 |

**test31 修后仍然 rc=1**，死在第二层——产品新增了 TTY 守卫（`claude-code-cli requires an interactive TTY on stdin`），套件写在它之前。本 PR **只修第一层**，第二层另开 issue，不在这里顺手改。

**test18/test21** 的 build 失败与 safe-rm 无关：
```
gyp ERR! stack Error: not found: make
error: install script from "node-pty" exited with 1
```
`node-pty` 缺 prebuilt、需要 `make` 重编译，而镜像里没有。这条 COPY 对它们**必要且正确**（bun install 修好后必然撞同一个坑），但**我无法用一次运行证明它生效**——如实标注，不并入已验证的那条。

## 怎么找到的

我发现自己一直在用一个**落后 origin/main 988 提交**的共享检出跑孤儿套件（189 个套件与 main 有差异），于是改成对着 origin/main 复核，才看见这个。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
