### PR TITLE
fix(tests): test-npm-install 3/7 → 10/10 —— 7 条失败只有 3 个独立根因，且都不是回归

### DIFF
--- a/docs/test-suite-orphan-baseline.txt
+++ b/docs/test-suite-orphan-baseline.txt
@@ -19,7 +19,6 @@ qa-rfc024-config-apply
 qa-rfc026-create-node
 qa-rfc027-stop-delete
 qa-rfc028-provider-probe
-test-npm-install
 test-npm-security
 test-rfc029-pr1-registration
 test-rfc029-pr2-acp-shim

--- a/tests/test-npm-install/NOT-IN-CI.md
+++ b/tests/test-npm-install/NOT-IN-CI.md
@@ -1,0 +1,72 @@
+# 为什么 test-npm-install 不进 per-PR CI
+
+Verified: 2026-08-19
+Revisit-when: Dockerfile 第 6 行不再是 `npm i -g @sleep2agi/*@preview`——
+              即被测对象从「已发布的 npm preview」变成「本仓构建产物」时，
+              它就该进 qa.sh 的 L1_TESTS，并删掉本文件。
+
+## 理由：被测对象是**混合**的，其中一半不是这次提交
+
+⚠️ 这里要说准，别照抄 test-npm-api 的理由 —— 我第一版就写错了，写成
+「它测的不是这次提交」，实际只对了一半：
+
+```
+Dockerfile:6  RUN npm i -g @sleep2agi/commhub-server@preview @sleep2agi/agent-node@preview
+Dockerfile:7  COPY agent-network/ /app/agent-network/
+run.sh:6      ANET="bun /app/agent-network/bin/cli.ts"
+```
+
+| 组件 | 来源 | 属于这次提交？ |
+|---|---|---|
+| `anet` CLI | 仓内源码 | ✅ 是 |
+| `commhub-server` / `agent-node` | npm `@preview` | ❌ 否 |
+
+⇒ 它**确实**能覆盖 `agent-network/` 的改动，但它连的服务端是**已发布的 preview**：
+- PR 改了 `server/` ⇒ 这道门看不见；
+- 别人发了一版 preview ⇒ 它在**无关的 PR 上**变红。
+
+一道绿和红都部分取决于「仓外何时发版」的门，不适合当 per-PR 判据。
+它是**发版验证件**：验证「已发布的服务端 + 当前 CLI」端到端还能跑通。
+
+## 本次修了什么（它在 main 上是 3 passed / 7 failed）
+
+7 条失败**只有 2 个独立根因**，其余 5 条是级联：
+
+### ① 逐字相等的版本钉子，随发版必然腐烂
+
+```bash
+[ "$PKG_VER" = "0.5.0-preview.28" ]      # 实测已经是 0.9.0-preview.29
+```
+
+Dockerfile 装的是**移动 tag** `@preview`，所以任何精确版本钉子都会过期。
+🔴 **版本/计数类断言要写成地板或形状，不能写逐字相等 —— 否则「变好」也会把门打红。**
+这个套件的真实意图是「npm 包装得上且能用」，不是「必须是某一版」。
+
+### ② 被测对象被 `bunx` 换掉了，且用固定 sleep 当就绪
+
+```bash
+bunx @sleep2agi/commhub-server > /tmp/npm-install-server.log 2>&1 &
+sleep 4
+```
+
+`bunx` 在**运行时**再拉一份，而 Dockerfile 已经 `npm i -g` 装好了 ——
+本套件要验的正是「装上的那份能用」，`bunx` 把被测对象换成了另一份（还依赖运行时网络）。
+
+实测：用**已安装的** `commhub-server` 起，`/health` 返回 **200**，
+banner 打出 `CommHub MCP Server v0.9.0-preview.29`。
+⇒ 「server failed to start」是**假失败**，产品没问题，后面 5 条 anet 失败全是它的级联。
+
+固定 `sleep 4` 也换成了轮询 `/health` 响应体（最多 30s）——
+**判据用 /health 的响应体，不用启动横幅：横幅先于就绪打印。**
+
+### ③ `--runtime http-api` 已被产品移除
+
+```
+[anet] Refusing to create node: unsupported runtime "http-api"; expected one of:
+claude-agent-sdk, claude-code-cli, codex-sdk, codex-app-server,
+grok-build-acp, grok-build-cli, opencode-cli
+```
+
+同 #1106 那两条的形状：产品加了运行时白名单，套件写在它之前，**不是回归**。
+换成受支持的 `claude-agent-sdk`（create 阶段不需要外部二进制，实测 rc=0）。
+产品对未知 runtime 是**硬拒**的，所以这条断言在白名单再次变动时仍会变红。

--- a/tests/test-npm-install/run.sh
+++ b/tests/test-npm-install/run.sh
@@ -17,15 +17,31 @@ echo ""
 echo "1. Package versions..."
 commhub-server --help 2>&1 | head -5 >/tmp/commhub-help.txt || true
 PKG_VER=$(npm list -g @sleep2agi/commhub-server --depth=0 2>/dev/null | awk -F'@sleep2agi/commhub-server@' '/@sleep2agi\/commhub-server@/ {print $2; exit}')
-[ "$PKG_VER" = "0.5.0-preview.28" ] && pass "commhub-server preview.28 installed" || fail "commhub-server version: ${PKG_VER:-missing}"
+# 🔴 原来这里是逐字相等：[ "$PKG_VER" = "0.5.0-preview.28" ]。
+# Dockerfile 装的是移动 tag @preview，所以这个钉子必然随发版腐烂 ——
+# 实测已经是 0.9.0-preview.29，包正常前进反而把门打红。
+# 版本类断言要写成【地板/形状】而不是逐字相等，否则「变好」也会红。
+# 这个套件的真实意图是「npm 包装得上且能用」，不是「必须是某一版」。
+[[ "$PKG_VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] \
+  && pass "commhub-server installed (version=$PKG_VER)" \
+  || fail "commhub-server version unusable: ${PKG_VER:-missing}"
 $ANET -v 2>&1 | grep -q "anet v" && pass "anet version available" || fail "anet version missing"
 agent-node --version 2>&1 | grep -q "agent-node" && pass "agent-node version available" || fail "agent-node version missing"
 echo ""
 
 echo "2. Start server..."
-bunx @sleep2agi/commhub-server > /tmp/npm-install-server.log 2>&1 &
-sleep 4
-curl -s "$BASE/health" | grep -q '"ok":true' && pass "server started from npm package" || fail "server failed to start"
+# 🔴 原来是 `bunx @sleep2agi/commhub-server` —— 它在【运行时】再去拉一份，
+# 而 Dockerfile 第 6 行已经 `npm i -g` 装好了。本套件要验的正是「装上的那份能用」，
+# bunx 反而把被测对象换成了另一份（且依赖运行时网络）。改用已安装的二进制。
+# 实测：用已安装的 commhub-server 起，/health 返回 200，banner 打出 v0.9.0-preview.29。
+commhub-server --port 9200 > /tmp/npm-install-server.log 2>&1 &
+# 🔴 原来是固定 sleep 4。改成轮询就绪，而且判据是 /health 的响应体，不是启动横幅
+#（横幅先于就绪打印）。最多等 30s。
+for _ in $(seq 1 30); do
+  curl -s "$BASE/health" 2>/dev/null | grep -q '"ok":true' && break
+  sleep 1
+done
+curl -s "$BASE/health" | grep -q '"ok":true' && pass "server started from npm package" || { tail -5 /tmp/npm-install-server.log; fail "server failed to start"; }
 echo ""
 
 echo "3. anet init..."
@@ -44,8 +60,16 @@ echo "$LOGIN" | grep -Eqi "logged in|login successful|token|network" && pass "an
 echo ""
 
 echo "6. anet create..."
-CREATE=$($ANET create test-bot --runtime http-api 2>&1 || true)
-echo "$CREATE" | grep -Eqi "created|config.json|test-bot" && pass "anet node create test-bot --runtime http-api" || { echo "$CREATE"; fail "anet node create failed"; }
+# 🔴 原来是 --runtime http-api。产品已经不支持它，报错原文：
+#   [anet] Refusing to create node: unsupported runtime "http-api"; expected one of:
+#   claude-agent-sdk, claude-code-cli, codex-sdk, codex-app-server,
+#   grok-build-acp, grok-build-cli, opencode-cli
+# 不是回归 —— 产品加了运行时白名单、套件写在它之前（同 #1106 那两条的形状）。
+# 换成受支持且 create 阶段不需要外部二进制的 claude-agent-sdk（实测 rc=0）。
+# 注意别把它改成「随便什么都算过」：产品对未知 runtime 是硬拒的，
+# 所以这条断言仍然会在白名单再次变动时变红，这正是我们要的。
+CREATE=$($ANET create test-bot --runtime claude-agent-sdk 2>&1 || true)
+echo "$CREATE" | grep -Eqi "created|config.json|test-bot" && pass "anet node create test-bot --runtime claude-agent-sdk" || { echo "$CREATE"; fail "anet node create failed"; }
 echo ""
 
 echo "7. anet network ls..."


### PR DESCRIPTION
它在 main 上是 `3 passed / 7 failed`。**7 条里 5 条是级联**，真正独立的根因只有 3 个，而且**都不是回归** —— 都是产品前进、套件写在它之前。

## ① 逐字相等的版本钉子

```bash
[ "$PKG_VER" = "0.5.0-preview.28" ]      # 实测已经是 0.9.0-preview.29
```

Dockerfile 装的是**移动 tag** `@preview`，任何精确版本钉子都会过期。

🔴 **版本/计数类断言要写地板或形状，不能写逐字相等 —— 否则「变好」也会把门打红。**

## ② `bunx` 把被测对象换掉了，且拿固定 sleep 当就绪

```bash
bunx @sleep2agi/commhub-server > /tmp/npm-install-server.log 2>&1 &
sleep 4
```

`bunx` 在**运行时**再拉一份，而 `Dockerfile:6` 已经 `npm i -g` 装好了 —— 本套件要验的正是「装上的那份能用」。

实测：用**已安装的** `commhub-server` 起，`/health` 返回 **200**（banner: `CommHub MCP Server v0.9.0-preview.29`）⇒ **「server failed to start」是假失败**，后面 5 条 anet 失败全是它的级联。

改用已安装二进制 + 轮询 `/health` **响应体**（最多 30s）。🔴 判据用响应体不用启动横幅 —— **横幅先于就绪打印**。

## ③ `--runtime http-api` 已被产品移除

```
[anet] Refusing to create node: unsupported runtime "http-api"; expected one of:
claude-agent-sdk, claude-code-cli, codex-sdk, codex-app-server,
grok-build-acp, grok-build-cli, opencode-cli
```

同 #1106 那两条的形状。换成受支持的 `claude-agent-sdk`（实测 rc=0）。产品对未知 runtime 是**硬拒**的，所以这条断言在白名单再次变动时仍会红 —— 没有退化成「随便什么都算过」。

## 证据（干净 worktree，`--no-cache`）

```
修前 3 passed, 7 failed  →  修后 10 passed, 0 failed
```

## ⚠️ 不进 per-PR CI，而这个理由我第一版写错了

我先照抄了 `test-npm-api` 的说法「它测的不是这次提交」——**只对了一半**，已在 `NOT-IN-CI.md` 更正：

| 组件 | 来源 | 属于这次提交？ |
|---|---|---|
| `anet` CLI (`ANET="bun /app/agent-network/bin/cli.ts"`) | 仓内源码 | ✅ 是 |
| `commhub-server` / `agent-node` | npm `@preview` | ❌ 否 |

⇒ 它**确实**能覆盖 `agent-network/` 的改动，但连的服务端是已发布 preview：PR 改 `server/` 它看不见；别人发 preview 它在**无关 PR** 上红。一道绿和红都部分取决于「仓外何时发版」的门，不适合当 per-PR 判据。

孤儿地板 **78 → 77**（exempt +1，**不是新接了一条 CI**）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
