### PR TITLE
docs(node-server): 回 peer 需要两个动作 —— 现行规则只写了唤醒那一半

### DIFF
--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -161,7 +161,11 @@ const mcp = new Server(
           `Messages from CommHub arrive as <channel source="commhub" task_id="..." priority="..." from="...">`,
           `These are tasks dispatched by the hub or other sessions via the CommHub Server.`,
           `Reply routing (IMPORTANT — the tool you pick determines whether the receiver actually gets woken up):`,
-          `  • If the sender is another agent node (from CommHub, from your peer's session alias), reply with commhub_send_task(alias="<their alias>", task="<your reply>"). This creates a new routable task that wakes the peer via new_task SSE so they process it. commhub_reply does NOT wake agent peers — they'd only see it on the next inbox poll (Vincent 2026-07-28 全网规则).`,
+          `  • If the sender is another agent node, replying takes TWO actions — send_task wakes them but does NOT close the task you were sent:`,
+          `      1. commhub_send_task(alias="<their alias>", task="<your reply>") — wakes the peer via new_task SSE. commhub_reply does NOT wake agent peers (Vincent 2026-07-28 全网规则).`,
+          `      2. commhub_reply(task_id="<the task_id you were sent>", status="completed") — terminalizes the ORIGINAL task.`,
+          `    Skip step 2 and the peer wakes up, but their task stays "delivered" forever: they will keep re-reporting "still awaiting reply". The Hub does NOT redeliver — that repetition comes from the peer's own logic, so only closing the task stops it.`,
+          `    If your runtime has commhub_send_peer_reply, it does both in one call (RFC-030). Check your own tool list for it — do not infer it from a version number.`,
           `  • Only use commhub_reply when the sender is the Dashboard/UI (task_id came from a browser chat). Use status="completed" (terminal) so send_reply routes it, updates the task row (Dashboard displays it), and emits new_reply SSE for the live Dashboard viewer. Non-terminal status (in_progress/blocked/error) just updates your session status and does NOT reach the Dashboard.`,
           `You can also use commhub_report_status to update your session status.`,
           `Session alias: ${ALIAS}`,
@@ -175,7 +179,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
       name: "commhub_reply",
-      description: "Reply to a Dashboard/UI-originated CommHub task. ⚠ For agent-to-agent replies use commhub_send_task instead — commhub_reply does NOT wake agent peers via SSE (Vincent 2026-07-28 全网规则). status=\"completed\" (terminal) routes to send_reply and emits new_reply SSE for the live Dashboard; non-terminal status (in_progress/blocked/error) only updates session status (report_status) and does NOT reach the Dashboard.",
+      description: "Reply to a Dashboard/UI-originated CommHub task, AND close an agent-to-agent task you were sent. ⚠ For agent peers this does not replace commhub_send_task — it does NOT wake them (Vincent 2026-07-28 全网规则) — but it IS what terminalizes the original task, so a peer reply needs both: send_task to wake, then commhub_reply(status=\"completed\") to close. status=\"completed\" (terminal) routes to send_reply and emits new_reply SSE for the live Dashboard; non-terminal status (in_progress/blocked/error) only updates session status (report_status) and does NOT reach the Dashboard.",
       inputSchema: {
         type: "object" as const,
         properties: {


### PR DESCRIPTION
现行 instructions 写的是「回 agent peer 用 `commhub_send_task`（reply 不唤醒）」。**这句是对的，保留**；它缺的是后半句：**`send_task` 不关闭原任务。**

## 源码依据

```
server/src/tools.ts:1254-1262 + 1381
  send_task 只是把新任务【挂在】父任务下（写 parent_task_id），
  全程没有任何 UPDATE 改父任务 status   ⇒ 唤醒 ✅ 关闭 ❌

server/src/tools.ts:846（在 send_reply 里）
  chainReplyToParent(...) 沿 parent 链向上最多 5 层标成 replied  ⇒ 关闭 ✅ 唤醒 ❌
```

⇒ 于是**每一次 agent 间回复都留下一条永不关闭的任务**：对方被唤醒了，而它那条任务停在 `delivered`，于是它按自己的逻辑反复回报「仍待回执」。

🔴 而 **Hub 不重投**：`server/src/task-lifecycle-watcher.ts` 只在 30s/60s 各写**一次**警告事件（`ON CONFLICT(task_id, event_key) DO NOTHING`）。所以那种重复**不是 Hub 投的，是对方节点自己发的** —— 只有真正关闭任务才能止住。

## 顺序是刻意的：两步法在前，一步法在后

较新的 runtime 有 `commhub_send_peer_reply` 可一步完成（`server/src/tools.ts:1822`，RFC-030）。但本次把**两步法写在前面**：

若先写一步法，读者找不到那个工具时**没有任何提示**告诉他「那你就用两步法」，他更可能得出「我这里坏了」或「等升级」。**把「我没有」读成「我不该做」**，会把一个立刻可用的替代路径变成一个**等待状态**，而等待状态不产生任何异常信号。

⇒ 通则：文档同时给出「新做法」与「兼容做法」时，**永远把所有人都能用的那条放前面**。

并写明「有没有那个工具要**查自己的工具表**，不要从版本号推」—— 版本号是**关于能力的断言**，工具表是**能力本身**。

## 范围：只改这两处

它们由 Hub **注入每个节点的上下文** ⇒ 所有节点下次连上就读到，**新加入的节点也会读到**，不需要任何人记得去读某份 md。

🔴 同一条规则在仓里另有 **20 处衍生副本**。**本 PR 不动它们** —— 一次大扫除的 diff 没人逐行看，容易夹带。而那一轮的目标也不该是「把 20 处改对」，应该是**让衍生副本指向单一真源而不是复述它**：改对 20 处只解决这一次，改成指向才解决所有将来的次数。

## 验证

纯文本改动，**不改变任何执行路径**。`npx tsc --noEmit -p .` rc=0 —— 并确认它真的扫到了（`--listFiles` 476 个文件，含 `src/node-server.ts`），不是空跑的绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
