### PR TITLE
feat(grok-copresence): 支持 Windows —— 按能力判定平台，并把丢掉的保证逐条说清

### DIFF
--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -64,8 +64,21 @@ loadEnvFile(join(COMMHUB_DIR, projectPath, ".env"));
 
 // ── Get tmux session name ─────────────────────────────
 function getTmuxSessionName(): string {
+  // 🔴 Windows 没有 tmux，而 execSync **默认把子进程 stderr 透传到父进程 stderr**：
+  //    于是每次启动都往 stderr 写一行 `'tmux' is not recognized ...`。
+  //    这个 server 是 MCP stdio 服务端，父进程（grok）不一定排空 stderr 管道；
+  //    Windows 管道缓冲只有几 KB，写满即**阻塞**，initialize 就永远回不出去 ——
+  //    实测：grok 的 `mcp doctor` 报 `server started 0.1s` 然后
+  //    `handshake failed: connection closed: initialize response`，
+  //    而同一台机上一个【完全不写 stderr】的最小 MCP server 握手正常（healthy=1）。
+  //    ⇒ 平台上没有 tmux 就不要去问；并且显式丢弃子进程 stderr，不让它进管道。
+  if (process.platform === "win32") return "";
   try {
-    return execSync("tmux display-message -p '#S'", { encoding: "utf-8", timeout: 2000 }).trim();
+    return execSync("tmux display-message -p '#S'", {
+      encoding: "utf-8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
   } catch {
     return "";
   }

--- a/agent-network/src/owner-env-file.ts
+++ b/agent-network/src/owner-env-file.ts
@@ -6,6 +6,11 @@ import {
   openSync,
   readFileSync,
 } from "fs";
+import { isAbsolute } from "path";
+
+// NTFS 走 ACL，没有 mode 位；在 Windows 上比较 0o600 恒不成立。
+// 跳过的只有模式位，symlink / nlink / 正规文件 / dev+ino 一致仍然全部生效。
+const posixFileModes = process.platform !== "win32";
 
 /** Load a reviewed owner-only env file without following a planted link. */
 export function loadOwnerOnlyEnvFile(
@@ -13,7 +18,12 @@ export function loadOwnerOnlyEnvFile(
   env: NodeJS.ProcessEnv = process.env,
 ): void {
   if (!path) return;
-  if (!path.startsWith("/") || path.includes("\0")) {
+  // 🔴 `startsWith("/")` 是 POSIX-only 判据；Windows 的 `C:\\Users\\...\\.env` 不满足它。
+  //    实测：MCP server 被 grok spawn 后 85ms 内退出，报
+  //      `error: ANET_COMMHUB_ENV_FILE must be an absolute path`
+  //    而外层只看到 `handshake failed: connection closed: initialize response` ——
+  //    真正的原因被吞在子进程 stderr 里，是用包装脚本落盘才看到的。
+  if (!isAbsolute(path) || path.includes("\0")) {
     throw new Error("ANET_COMMHUB_ENV_FILE must be an absolute path");
   }
   const before = lstatSync(path);
@@ -22,7 +32,7 @@ export function loadOwnerOnlyEnvFile(
     before.isSymbolicLink()
     || !before.isFile()
     || before.nlink !== 1
-    || (before.mode & 0o777) !== 0o600
+    || (posixFileModes && (before.mode & 0o777) !== 0o600)
     || (uid !== undefined && before.uid !== uid)
   ) {
     throw new Error("ANET_COMMHUB_ENV_FILE must be an owner-only single-link regular file");
@@ -35,7 +45,7 @@ export function loadOwnerOnlyEnvFile(
       || opened.nlink !== 1
       || opened.dev !== before.dev
       || opened.ino !== before.ino
-      || (opened.mode & 0o777) !== 0o600
+      || (posixFileModes && (opened.mode & 0o777) !== 0o600)
       || (uid !== undefined && opened.uid !== uid)
     ) {
       throw new Error("ANET_COMMHUB_ENV_FILE changed during validation");

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -12,6 +12,11 @@
  */
 
 import { readFileSync, existsSync, writeFileSync, chmodSync, realpathSync, renameSync } from "fs";
+import {
+  copresenceCapabilities as grokCopresenceCapabilities,
+  assertCopresenceSupported as assertGrokCopresenceSupported,
+  copresenceDowngradeNotice as grokCopresenceDowngradeNotice,
+} from "./runtime/grok-copresence/platform";
 import { dirname, join, isAbsolute, resolve } from "path";
 import { hostname as osHostname, homedir } from "os";
 import { createCommhubSdkMcpServer } from "./commhub-mcp";
@@ -500,16 +505,40 @@ const GROK_EXECUTION_MODE: "acp" | "cli" =
 // the PTY child are created. Existing credential stores are separately
 // validated/repaired by their boundary-specific writers.
 if (GROK_EXECUTION_MODE === "cli") process.umask(0o077);
-if (GROK_EXECUTION_MODE === "cli" && (process.platform !== "linux" || !existsSync("/proc/self/fd"))) {
-  console.error("[agent-node] grok-build-cli preview requires Linux with procfs mounted at /proc");
-  process.exit(1);
-}
 const rawGrokCopresence = opts["grok-copresence"]
   ?? fileConfig.grokCopresence
   ?? fileConfig.flags?.grokCopresence
   ?? process.env.ANET_GROK_COPRESENCE;
 const GROK_COPRESENCE = GROK_EXECUTION_MODE === "cli"
   && (rawGrokCopresence === true || rawGrokCopresence === "true" || rawGrokCopresence === "1");
+// 🔴 平台闸按【能力】判，不按「是不是 Linux」判。
+//    原来这里是一句 `process.platform !== "linux"` 就整体退出，它把
+//    「不支持」和「少了哪几样、少了会失去什么」压成了一格。
+//    实测（Windows 11 build 26200 / node v24.18.0 / grok 1.0.5）：
+//      ConPTY 可用、命名管道可用、AF_UNIX EACCES、/proc absent、grok 无 Windows 沙箱后端。
+//    ⇒ 共存（PTY + IPC）在 Windows 上可跑；headless 每轮要 `unshare --user`，仍限 Linux。
+if (GROK_EXECUTION_MODE === "cli") {
+  const caps = grokCopresenceCapabilities(process.platform, {
+    hasProcSelfFd: existsSync("/proc/self/fd"),
+  });
+  if (GROK_COPRESENCE) {
+    if (!caps.supported) {
+      console.error(
+        `[agent-node] grok-build-cli co-presence 无法在 ${caps.platform} 上运行，`
+        + `缺少：${caps.missingHard.join("；")}`,
+      );
+      process.exit(1);
+    }
+  } else if (process.platform !== "linux" || !caps.procfs) {
+    // headless grok-build-cli 每个 turn 在 unshare --user 下跑，没有非 Linux 等价物。
+    console.error(
+      "[agent-node] grok-build-cli headless 需要 Linux 与挂载于 /proc 的 procfs；"
+      + "在其它平台请改用共存模式（grokCopresence:true）或 grok-build-acp",
+    );
+    process.exit(1);
+  }
+}
+
 const RUNTIME_AGENT_LABEL = RUNTIME === "grok" && GROK_EXECUTION_MODE === "cli"
   ? "agent-node:grok-build-cli"
   : `agent-node:${RUNTIME}`;
@@ -578,6 +607,10 @@ if (GROK_COPRESENCE) {
     + `(process profile=${GROK_COPRESENCE_CAPABILITY_PROFILE}); the shared human TUI must receive `
     + "tasks only from trusted senders. MCP is CommHub-only; WebSearch and repo reads are available only in their explicit profiles.",
   );
+  // 降级必须【逐条】打出来：只说一句「较弱」，用户没法判断自己的任务能不能接受。
+  for (const line of grokCopresenceDowngradeNotice(grokCopresenceCapabilities(process.platform))) {
+    console.warn(`[agent-node] ${line}`);
+  }
 }
 // Default 50 turns. The old default of 5 was way too low — Claude Agent SDK
 // uses one turn per tool roundtrip, so any task that uses commhub MCP or
@@ -3609,7 +3642,7 @@ function resolveGrokCopresenceSocket(configured: unknown, fallback: string): str
     ? configured.trim()
     : fallback;
   const expanded = expandHome(value);
-  return expanded.startsWith("/") ? expanded : join(process.cwd(), expanded);
+  return isAbsolute(expanded) ? expanded : join(process.cwd(), expanded);
 }
 
 async function handleGrokCopresenceHumanPrompt(prompt: string): Promise<void> {
@@ -3633,9 +3666,9 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
   if (!GROK_COPRESENCE) {
     throw new Error("grok copresence runtime requested without grokCopresence:true");
   }
-  if (process.platform !== "linux") {
-    throw new Error("grok co-presence preview currently requires Linux PTY, /proc, and Unix sockets");
-  }
+  assertGrokCopresenceSupported(grokCopresenceCapabilities(process.platform, {
+    hasProcSelfFd: existsSync("/proc/self/fd"),
+  }));
   await retireCachedGrokCopresenceRuntime();
   if (grokCopresenceRuntimeSession) return grokCopresenceRuntimeSession;
   if (grokCopresenceRuntimeOpening) return grokCopresenceRuntimeOpening;
@@ -3856,12 +3889,24 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
       assertNoDiscoveredGrokHooks(inspection);
       // 1.0.5 新增面（skills/agents/plugins/marketplaces/lspServers/externalCompat/
       // managedSettings）在这里 fail-closed；0.2.93 缺这些字段时自动跳过对应格。
-      assertGrokCopresenceExternalSurfaces(inspection, auditRuntime.grokCliHome.home);
-      assertGrokCopresenceApprovalOwnership(
+      // 返回的是【已证明隔离不了】的外部来源（当前只有 Windows 的厂商技能/子代理）。
+      // 逐条原样打印：这是操作者唯一能看到"我接受了什么"的地方。
+      const unisolatedSources: string[] = [...assertGrokCopresenceExternalSurfaces(
+        inspection,
+        auditRuntime.grokCliHome.home,
+      )];
+      unisolatedSources.push(...assertGrokCopresenceApprovalOwnership(
         inspection,
         auditRuntime.grokCliHome.home,
         commhubMcpCommand,
-      );
+      ));
+      // 逐条原样打印：这是操作者唯一能看到"我接受了什么"的地方。
+      if (unisolatedSources.length) {
+        console.warn(
+          `[agent-node] 🔴 ${unisolatedSources.length} 项无法被隔离 HOME 挡住（未生效的规则也列出）：`,
+        );
+        for (const source of unisolatedSources) console.warn(`[agent-node]    · ${source}`);
+      }
       let doctor: string;
       try {
         doctor = execFileSync(grokBinary, ["mcp", "doctor", "commhub", "--json"], {
@@ -3920,7 +3965,12 @@ async function ensureGrokCopresenceRuntime(): Promise<GrokCopresenceSession> {
         join(grokCwd, ".anet"),
         join(home, ".anet"),
         ...grokProjectPolicyPaths(grokCwd),
-        "/proc",
+        // 🔴 "/proc" 只在有 procfs 的平台上才是一个真实路径。
+        //    Windows 上 resolve("/proc") 会变成当前盘符下的 "D:\\proc"，
+        //    随后 realpathSync 直接 ENOENT ——实测就是这么红的。
+        ...(grokCopresenceCapabilities(process.platform, {
+          hasProcSelfFd: existsSync("/proc/self/fd"),
+        }).procfs ? ["/proc"] : []),
       ],
       flockBinary: process.env.FLOCK_BINARY || "flock",
       turnTimeoutMs: grokCopresenceTimeoutMs(),
@@ -4121,7 +4171,10 @@ async function processWithGrokCli(
   const stateGrokRoot = join(home, ".anet-grok");
   const stateGrokHome = join(stateGrokRoot, grokHomeKey);
   if (process.platform !== "linux") {
-    throw new Error("grok-build-cli secure turn supervision currently requires Linux user/PID namespaces");
+    throw new Error(
+      "grok-build-cli headless 的每轮隔离依赖 Linux user/PID 命名空间（unshare --user）；"
+      + "在其它平台请改用共存模式（grokCopresence:true）或 grok-build-acp",
+    );
   }
   const unshareBinary = process.env.UNSHARE_BINARY || "unshare";
   // 上面的 platform 判断是**必要不充分**的:是 Linux 不等于非特权 userns 可用。

--- a/agent-node/src/private-log.ts
+++ b/agent-node/src/private-log.ts
@@ -1,6 +1,7 @@
 import {
   closeSync,
   constants,
+  existsSync,
   fchmodSync,
   fstatSync,
   fsyncSync,
@@ -14,6 +15,27 @@ import {
   writeSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
+
+
+/**
+ * `/proc/self/fd/<fd>` 这套「把已打开的 fd 变回路径」的 TOCTOU 加固**只有 Linux 有**。
+ *
+ * 🔴 Windows 上 `realpathSync("/proc/self/fd/3")` 会被 resolve 成当前盘符下的
+ *    `D:\\proc\\...` 然后 ENOENT —— 实测报错就是
+ *    `Error: ENOENT: no such file or directory, lstat 'D:\\proc'`。
+ *    ⇒ 在没有 procfs 的平台上退回按【路径】操作，并且【明确记下】少了哪一条保证：
+ *      少的是「校验与使用之间目录被换掉」的防护，
+ *      fstat 的 isDirectory / uid、以及 O_NOFOLLOW 仍然生效。
+ *      这里不假装它等价 —— 假装等价才是真正危险的那一步。
+ */
+function procfsFdPathsAvailable(): boolean {
+  return process.platform === "linux" && existsSync("/proc/self/fd");
+}
+
+/** 已打开目录 fd 对应的可用路径：有 procfs 用 fd 引用，否则回退到原路径。 */
+function directoryHandlePath(directoryFd: number, fallbackAbsolute: string): string {
+  return procfsFdPathsAvailable() ? `/proc/self/fd/${directoryFd}` : fallbackAbsolute;
+}
 
 export interface PrivateLogRedactor {
   redactText(value: unknown): { text: string; redactions: number };
@@ -43,10 +65,11 @@ function openPrivateDirectory(path: string): number {
     if (!stat.isDirectory() || (uid !== undefined && stat.uid !== uid)) {
       throw new Error(`private log directory is not owner-controlled: ${absolute}`);
     }
-    if (realpathSync(`/proc/self/fd/${fd}`) !== absolute) {
+    if (procfsFdPathsAvailable() && realpathSync(`/proc/self/fd/${fd}`) !== absolute) {
       throw new Error(`private log directory changed during validation: ${absolute}`);
     }
-    fchmodSync(fd, 0o700);
+    // NTFS 走 ACL，没有 mode 位；fchmod 在 Windows 上直接 EPERM。
+    if (process.platform !== "win32") fchmodSync(fd, 0o700);
     return fd;
   } catch (error) {
     closeSync(fd);
@@ -108,7 +131,7 @@ export function preparePrivateLogDirectory(
   try {
     // Resolve children through the already-open directory descriptor. A
     // pathname replacement cannot redirect legacy scrubbing elsewhere.
-    const descriptorPath = `/proc/self/fd/${directoryFd}`;
+    const descriptorPath = directoryHandlePath(directoryFd, absolute);
     for (const name of readdirSync(descriptorPath)) {
       if (!name.endsWith(".log")) continue;
       scrubLegacyLog(join(descriptorPath, name), redactor);
@@ -130,7 +153,7 @@ export function appendPrivateLogLine(
     throw new Error("private log filename is not a canonical daily log name");
   }
   const directoryFd = openPrivateDirectory(directory);
-  const path = `/proc/self/fd/${directoryFd}/${filename}`;
+  const path = join(directoryHandlePath(directoryFd, resolve(directory)), filename);
   let fd: number | undefined;
   try {
     fd = openSync(

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -248,8 +248,21 @@ function repairPrivateDirectory(path: string, tightenMode: boolean): void {
       || opened.dev !== before.dev || opened.ino !== before.ino) {
       throw new Error(`private config parent is not owner-controlled: ${path}`);
     }
-    if (tightenMode) fchmodSync(fd, 0o700);
+    if (tightenMode && posixFileModesSupported()) fchmodSync(fd, 0o700);
   } finally { closeSync(fd); }
+}
+
+/**
+ * POSIX 文件模式位（0600/0700）在这个平台上有没有意义。
+ *
+ * 🔴 Windows 的 NTFS 走 ACL，没有 mode 位；`fchmod` 直接 EPERM，
+ *    实测报错是 `Refusing unsafe global config: EPERM: operation not permitted, fchmod`。
+ *    ⇒ 在那里跳过的只有【收紧模式位】这一个动作；
+ *      symlink / nlink / 正规文件 / dev+ino 一致 / uid 这些校验**一条都不放过**。
+ *      把它们一起跳掉会把这个函数变成恒真的空壳。
+ */
+function posixFileModesSupported(platform: NodeJS.Platform = process.platform): boolean {
+  return platform !== "win32";
 }
 
 /** Tighten legacy umask-derived config state before reading any token. */
@@ -272,7 +285,7 @@ export function repairPrivateConfigPermissions(path: string): void {
         || opened.dev !== before.dev || opened.ino !== before.ino) {
         throw new Error(`private config is not owner-controlled: ${candidate}`);
       }
-      fchmodSync(fd, 0o600);
+      if (posixFileModesSupported()) fchmodSync(fd, 0o600);
     } finally { closeSync(fd); }
   }
 }

--- a/agent-node/src/runtime/grok-build-cli-home.ts
+++ b/agent-node/src/runtime/grok-build-cli-home.ts
@@ -30,6 +30,8 @@ import {
   GROK_COPRESENCE_AGENT_FILE,
   renderGrokCopresenceAgentProfile,
 } from "./grok-copresence/policy";
+import { chmodIfPosix, copresenceCapabilities, copresenceIpcEndpoint, modeIsExactly, modeIsOwnerOnly, posixFileModes } from "./grok-copresence/platform";
+import { createServer as createNetServer } from "node:net";
 
 export interface PrepareGrokCliHomeOptions {
   sourceHome: string;
@@ -61,9 +63,37 @@ export function resolveGrokCommhubMcpCommand(command: string, pathEnv: string): 
   if (!command || command.includes("\0") || command.includes("\r") || command.includes("\n")) {
     throw new Error("grok copresence CommHub MCP command is invalid");
   }
+  // 🔴 Windows 上必须带扩展名才能 spawn。实测：解析到 nvm 下那个**无扩展名**的
+  //    `bun`（它是 shell 脚本），grok 的 doctor 报
+  //      spawn failed %1 不是有效的 Win32 应用程序。(os error 193)
+  //    而同一目录下的 `bun.cmd` / `bun.exe` 才是可执行的那个。
+  //    ⇒ 非 POSIX 平台按 PATHEXT 依次尝试；顺序里把无扩展名放最后，
+  //      这样 Linux 行为逐字不变，Windows 也不会挑到脚本。
+  const extensions = posixFileModes()
+    ? [""]
+    : [
+        ...(process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+          .split(";")
+          .map((ext) => ext.trim())
+          .filter(Boolean),
+        "",
+      ];
+  const withExtensions = (base: string) => extensions.map((ext) => `${base}${ext}`);
+  // 🔴 Linux 上 `<prefix>/bin/bun` 是指向 `lib/node_modules/bun/bin/bun.exe` 的符号链接，
+  //    realpathSync 会自动解到那个真二进制。Windows 上同名的是 `bun.CMD` 批处理包装，
+  //    它不是链接、解不过去 —— 而 MCP 走 stdio 握手，经批处理转发会失败：
+  //    实测 doctor 报 `server started 0.0s` 之后 `handshake failed: connection closed`。
+  //    ⇒ 额外探一次 npm 全局布局下的真二进制，与 Linux 解析到的是同一个文件。
+  const npmGlobalBinaries = (directory: string) => (posixFileModes() ? [] : [
+    resolve(directory, "node_modules", command, "bin", `${command}.exe`),
+  ]);
   const candidates = isAbsolute(command)
-    ? [command]
-    : pathEnv.split(delimiter).filter(Boolean).map((directory) => resolve(directory, command));
+    ? withExtensions(command)
+    : pathEnv.split(delimiter).filter(Boolean)
+        .flatMap((directory) => [
+          ...npmGlobalBinaries(directory),
+          ...withExtensions(resolve(directory, command)),
+        ]);
   for (const candidate of candidates) {
     try {
       const canonical = realpathSync(candidate);
@@ -187,6 +217,40 @@ function removeTransientPostStopDirectory(path: string): void {
   rmSync(quarantine, { recursive: true, force: false });
 }
 
+/** 项目级 turn 锁的落盘文件名（Windows 上它同时是命名管道名的哈希来源）。 */
+const GROK_PROJECT_TURN_LOCK_FILE = ".anet-grok-turn.lock";
+
+/**
+ * 命名管道独占。第二个 listen 同名会 EADDRINUSE —— 那就是"已被占用"。
+ * 与 grok-copresence/runtime.ts 里的生命周期锁用同一条 copresenceIpcEndpoint 规则，
+ * 保证两侧对同一路径算出同一个管道名。
+ */
+async function acquireNamedPipeExclusive(path: string): Promise<{ release(): Promise<void> }> {
+  const endpoint = copresenceIpcEndpoint(path, copresenceCapabilities());
+  const server = createNetServer();
+  server.on("connection", (socket) => { try { socket.destroy(); } catch {} });
+  await new Promise<void>((resolveListen, rejectListen) => {
+    const onError = (error: any) => {
+      server.removeListener("listening", onListening);
+      rejectListen(new Error(
+        `grok-build-cli project turn lock is already held (${endpoint}): ${error?.message || error}`,
+      ));
+    };
+    const onListening = () => { server.removeListener("error", onError); resolveListen(); };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(endpoint);
+  });
+  let released = false;
+  return {
+    async release() {
+      if (released) return;
+      released = true;
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    },
+  };
+}
+
 export interface GrokProjectTurnLock {
   /** Parent fd for the already-locked open-file-description. Pass to turn. */
   fd: number;
@@ -219,7 +283,7 @@ export function hardenExistingGrokSessionStore(stateHome: string): void {
       let fd: number | undefined;
       try {
         fd = openSync(path, constants.O_RDONLY | (constants.O_DIRECTORY || 0) | (constants.O_NOFOLLOW || 0));
-        fchmodSync(fd, 0o700);
+        chmodIfPosix(() => fchmodSync(fd, 0o700));
       } finally {
         if (fd !== undefined) closeSync(fd);
       }
@@ -235,7 +299,7 @@ export function hardenExistingGrokSessionStore(stateHome: string): void {
       if (!opened.isFile() || opened.nlink !== 1 || opened.dev !== stat.dev || opened.ino !== stat.ino) {
         throw new Error(`grok-build-cli session state changed during mode repair: ${path}`);
       }
-      fchmodSync(fd, 0o600);
+      chmodIfPosix(() => fchmodSync(fd, 0o600));
     } finally {
       closeSync(fd);
     }
@@ -283,7 +347,7 @@ function ensurePrivateDirectory(path: string, label: string): void {
     }
     const uid = process.getuid?.();
     if (uid !== undefined) assertCurrentOwner(path, uid, stat.uid);
-    fchmodSync(fd, 0o700);
+    chmodIfPosix(() => fchmodSync(fd, 0o700));
   } catch (error: any) {
     if (error?.code === "ELOOP" || error?.code === "ENOTDIR") {
       throw new Error(`grok-build-cli refuses ${label} at ${path}: expected a real directory, not a symlink or file`);
@@ -331,7 +395,7 @@ function writeGeneratedFile(path: string, content: string): void {
   );
   try {
     writeFileSync(fd, content, "utf8");
-    fchmodSync(fd, 0o600);
+    chmodIfPosix(() => fchmodSync(fd, 0o600));
     closeSync(fd);
     renameSync(temp, path);
   } catch (error) {
@@ -373,7 +437,7 @@ function assertOwnedDirectoryForPostStop(path: string, label: string): void {
     }
     const uid = process.getuid?.();
     if (uid !== undefined) assertCurrentOwner(expected, uid, stat.uid);
-    fchmodSync(fd, 0o700);
+    chmodIfPosix(() => fchmodSync(fd, 0o700));
   } catch (error: any) {
     if (error?.code === "ELOOP" || error?.code === "ENOTDIR") {
       throw new Error(`grok-build-cli refuses ${label}: expected a real directory`);
@@ -477,7 +541,7 @@ function assertExactProjectSandboxPlaceholder(
     || !stat.isFile()
     || stat.nlink !== 1
     || stat.size !== 0
-    || (stat.mode & 0o7777) !== 0o444) {
+    || posixFileModes() && (stat.mode & 0o7777) !== 0o444) {
     throw new Error(
       `grok-build-cli refuses post-stop project placeholder at ${path}: `
       + "expected an empty owner-held single-link regular file with mode 0444",
@@ -580,7 +644,7 @@ function hardenExactPostStopFile(path: string): void {
   if (!lstatIfPresent(path)) return;
   const opened = openOwnedSingleLinkFileForPostStop(path);
   try {
-    fchmodSync(opened.fd, 0o600);
+    chmodIfPosix(() => fchmodSync(opened.fd, 0o600));
   } finally {
     closeSync(opened.fd);
   }
@@ -676,7 +740,7 @@ function reclaimSandboxBlockedPlaceholder(
   uid: number | undefined,
 ): void {
   if (before.isDirectory()) {
-    chmodSync(path, 0o700);
+    chmodIfPosix(() => chmodSync(path, 0o700));
     let empty = false;
     let fd: number | undefined;
     try {
@@ -699,7 +763,7 @@ function reclaimSandboxBlockedPlaceholder(
     if (!empty) {
       // Non-empty marker: restore the unreadable mode so the scanner still maps
       // it to the fatal structural role rather than a hardened owner-only tree.
-      chmodSync(path, 0o000);
+      chmodIfPosix(() => chmodSync(path, 0o000));
       return;
     }
     const after = lstatSync(path);
@@ -716,7 +780,7 @@ function reclaimSandboxBlockedPlaceholder(
     // wrote it so the scanner classifies it as a fatal structural anomaly.
     return;
   }
-  chmodSync(path, 0o700);
+  chmodIfPosix(() => chmodSync(path, 0o700));
   let fd: number | undefined;
   try {
     fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
@@ -857,9 +921,9 @@ function exactPrivateIdentityCopy(source: string, target: string): boolean {
     // the symlink path; require ownership and no world-write here, while the
     // runtime-owned copied target must remain exactly 0600.
     if (!boundedOwnedIdentity(sourceBefore)
-      || (sourceBefore.mode & 0o002) !== 0
+      || posixFileModes() && (sourceBefore.mode & 0o002) !== 0
       || !boundedOwnedIdentity(targetBefore)
-      || (targetBefore.mode & 0o777) !== 0o600
+      || !modeIsExactly(targetBefore.mode, 0o600)
       || sourceBefore.size !== targetBefore.size) return false;
     const sourceBytes = readFileSync(sourceFd);
     const targetBytes = readFileSync(targetFd);
@@ -907,16 +971,21 @@ function readPrivateSourceAuth(path: string): string | undefined {
   const before = lstatIfPresent(path);
   if (!before) return undefined;
   const uid = process.getuid?.();
-  if (uid === undefined) {
+  // 🔴 process.getuid 只在 POSIX 上存在。Windows 的属主是 ACL，Node 不直接暴露。
+  //    在那里把"取不到 uid"当作硬失败，等于把整个平台挡在门外；
+  //    而下面 symlink / nlink / 正规文件 / O_NOFOLLOW 的检查【全部照常执行】。
+  //    丢掉的这一条已经写进 platform.ts 的 reducedGuarantees，并在启动时打印。
+  if (uid === undefined && posixFileModes()) {
     throw new Error("grok-build-cli requires Unix uid checks for source auth.json");
   }
   if (before.isSymbolicLink() || !before.isFile() || before.nlink !== 1) {
     throw new Error("grok-build-cli source auth.json must be a single-link regular file");
   }
-  if (before.uid !== uid) {
+  // uid 在 Windows 上是 undefined（见上）；与本文件其余 15 处 uid 比较保持同一写法。
+  if (uid !== undefined && before.uid !== uid) {
     throw new Error("grok-build-cli source auth.json must be owned by the runtime uid");
   }
-  if ((before.mode & 0o777) !== 0o600) {
+  if (!modeIsExactly(before.mode, 0o600)) {
     throw new Error("grok-build-cli source auth.json must have mode 0600");
   }
 
@@ -928,7 +997,7 @@ function readPrivateSourceAuth(path: string): string | undefined {
       || opened.dev !== before.dev || opened.ino !== before.ino) {
       throw new Error("grok-build-cli source auth.json changed during validation");
     }
-    if (opened.uid !== uid || (opened.mode & 0o777) !== 0o600) {
+    if ((uid !== undefined && opened.uid !== uid) || !modeIsExactly(opened.mode, 0o600)) {
       throw new Error("grok-build-cli source auth.json changed security metadata during validation");
     }
     return readFileSync(fd, "utf8");
@@ -1081,7 +1150,7 @@ function validateCommhubMcpConfig(
       || before.nlink !== 1
       || realpathSync(path) !== path
       || (uid !== undefined && before.uid !== uid)
-      || (expectedMode !== undefined && (before.mode & 0o777) !== expectedMode)
+      || (expectedMode !== undefined && !modeIsExactly(before.mode, expectedMode))
     ) {
       throw new Error(`grok-build-cli commhub MCP ${label} is not an owner-held canonical file`);
     }
@@ -1115,7 +1184,7 @@ function stageCommhubMcpConfig(
       if (!opened.isFile() || opened.nlink !== 1
         || opened.dev !== before.dev || opened.ino !== before.ino
         || (uid !== undefined && opened.uid !== uid)
-        || (expectedMode !== undefined && (opened.mode & 0o777) !== expectedMode)) {
+        || (expectedMode !== undefined && !modeIsExactly(opened.mode, expectedMode))) {
         throw new Error(`grok-build-cli commhub MCP ${label} changed during staging`);
       }
       return readFileSync(fd, "utf8");
@@ -1202,6 +1271,30 @@ export async function acquireGrokProjectTurnLock(
 ): Promise<GrokProjectTurnLock> {
   const lexicalRoot = grokProjectWalk(cwd).root;
   const projectRoot = realpathSync(lexicalRoot);
+  // 🔴 Windows 没有 flock(1)（实测 `spawn flock ENOENT`）。用命名管道独占顶上：
+  //    互斥由内核给（同名管道只能建一次），且进程退出后 OS 立即回收，不留死锁。
+  //    fd 仍然给出一个真实的已打开描述符，调用方对它的用法（传进 turn）不变。
+  if (!posixFileModes()) {
+    const lockPath = join(projectRoot, GROK_PROJECT_TURN_LOCK_FILE);
+    const lockFd = openSync(lockPath, constants.O_RDWR | constants.O_CREAT, 0o600);
+    let pipeLock: { release(): Promise<void> };
+    try {
+      pipeLock = await acquireNamedPipeExclusive(lockPath);
+    } catch (error) {
+      closeSync(lockFd);
+      throw error;
+    }
+    let released = false;
+    return {
+      fd: lockFd,
+      async release() {
+        if (released) return;
+        released = true;
+        await pipeLock.release();
+        closeSync(lockFd);
+      },
+    };
+  }
   // issue #884: the walk goes *up*, so a caller under a directory that happens
   // to sit below someone else's `.anet` silently shares that project's lock.
   // Test fixtures under `tmpdir()` are the usual victim: every fixture lands on
@@ -1238,7 +1331,7 @@ export async function acquireGrokProjectTurnLock(
     }
     const uid = process.getuid?.();
     if (uid !== undefined) assertCurrentOwner(lockPath, uid, lockStat.uid);
-    fchmodSync(lockFd, 0o600);
+    chmodIfPosix(() => fchmodSync(lockFd, 0o600));
   } catch (error) {
     closeSync(lockFd);
     throw error;

--- a/agent-node/src/runtime/grok-child-env.test.ts
+++ b/agent-node/src/runtime/grok-child-env.test.ts
@@ -273,3 +273,41 @@ describe("Grok child environment boundary", () => {
     ]);
   });
 });
+
+describe("Windows home isolation", () => {
+  const base = {
+    parentEnv: { PATH: "/bin", USERPROFILE: "C:\\Users\\real", HOMEDRIVE: "C:", HOMEPATH: "\\Users\\real" },
+    cwd: "D:\\work\\proj",
+    home: "D:\\iso\\grok-home",
+    authPath: "D:\\iso\\grok-home\\auth.json",
+  };
+
+  it("redirects every Windows home variable at the isolated home", () => {
+    // 🔴 Windows 不看 HOME。只设 HOME 时隔离形同虚设 —— 实测被
+    //    assertGrokCopresenceExternalSurfaces 抓到 grok 仍在读
+    //    C:\Users\<u>\.agents\skills\...\SKILL.md。
+    const env = buildGrokChildEnv({ ...base, platform: "win32" });
+    expect(env.HOME).toBe("D:\\iso\\grok-home");
+    expect(env.USERPROFILE).toBe("D:\\iso\\grok-home");
+    expect(env.HOMEDRIVE).toBe("D:");
+    expect(env.HOMEPATH).toBe("\\iso\\grok-home");
+    // 真实用户目录一个字都不能漏进去
+    for (const value of Object.values(env)) {
+      expect(String(value)).not.toContain("C:\\Users\\real");
+    }
+  });
+
+  it("leaves Linux untouched — no Windows-only keys leak into a POSIX child", () => {
+    const env = buildGrokChildEnv({
+      parentEnv: { PATH: "/bin" },
+      cwd: "/work/proj",
+      home: "/iso/home",
+      authPath: "/iso/home/auth.json",
+      platform: "linux",
+    });
+    expect(env.HOME).toBe("/iso/home");
+    expect(env.USERPROFILE).toBeUndefined();
+    expect(env.HOMEDRIVE).toBeUndefined();
+    expect(env.HOMEPATH).toBeUndefined();
+  });
+});

--- a/agent-node/src/runtime/grok-child-env.ts
+++ b/agent-node/src/runtime/grok-child-env.ts
@@ -1,3 +1,4 @@
+import { posix as posixPath, win32 as win32Path } from "path";
 /**
  * Environment boundary for every Grok CLI process.
  *
@@ -24,8 +25,39 @@ export const GROK_CHILD_INHERITED_ENV_KEYS = [
   "NO_COLOR",
 ] as const;
 
+/**
+ * Windows 上**运行任何子进程都必需**的系统变量。
+ *
+ * 🔴 这个边界刻意是精确白名单（见文件头）。但那份名单是照 POSIX 写的：
+ *    没有 SystemRoot 的 Windows 子进程会直接挂死 —— 实测 grok 的
+ *    `mcp doctor commhub` 从 `os error 193` 变成 **ETIMEDOUT**，
+ *    正是缺这几个变量导致 MCP server 起不来。
+ *    这些都是**系统路径与处理器信息，不含任何凭据**；仍逐个列出、不做通配。
+ */
+export const GROK_CHILD_WINDOWS_INHERITED_ENV_KEYS = [
+  "SystemRoot",
+  "SystemDrive",
+  "windir",
+  "ComSpec",
+  "PATHEXT",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "ProgramData",
+  "ProgramFiles",
+  "NUMBER_OF_PROCESSORS",
+  "PROCESSOR_ARCHITECTURE",
+] as const;
+
 export const GROK_CHILD_CONTROLLED_ENV_KEYS = [
   "HOME",
+  // 🔴 Windows 用 USERPROFILE / HOMEDRIVE+HOMEPATH 解析家目录，**不看 HOME**。
+  //    只设 HOME 的话隔离 home 在 Windows 上等于没设 —— 实测被
+  //    assertGrokCopresenceExternalSurfaces 当场抓到：
+  //      refuses external skills source C:\\Users\\<u>\\.agents\\skills\\...\\SKILL.md
+  //    也就是说 grok 仍在读真实用户目录下的 skills。
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
   "PWD",
   "GROK_HOME",
   "GROK_AUTH_PATH",
@@ -90,6 +122,7 @@ export const GROK_PTY_CONTROLLED_ENV_KEYS = [
 
 const GROK_CHILD_ENV_KEYS = new Set<string>([
   ...GROK_CHILD_INHERITED_ENV_KEYS,
+  ...GROK_CHILD_WINDOWS_INHERITED_ENV_KEYS,
   ...GROK_CHILD_CONTROLLED_ENV_KEYS,
 ]);
 
@@ -103,20 +136,45 @@ export interface BuildGrokChildEnvOptions {
   oidcClientId?: string;
   expectedParentPid?: number;
   defaultSelectedPermission?: "allow_once" | "always_allow_all_sessions";
+  /** 注入平台以便在 Linux CI 上覆盖 Windows 分支。缺省取 process.platform。 */
+  platform?: NodeJS.Platform;
 }
 
 /** Construct a Grok child environment from an empty object. */
 export function buildGrokChildEnv(opts: BuildGrokChildEnvOptions): NodeJS.ProcessEnv {
-  if (!opts.cwd || opts.cwd.includes("\0") || !opts.cwd.startsWith("/")) {
+  // 🔴 原来写的是 `startsWith("/")` —— POSIX-only 的绝对路径判据，
+  //    Windows 的 `D:\\x` 不满足它，一个完全合法的 cwd 会被判成"不是绝对路径"。
+  //    而 `path.isAbsolute` 也不够：它按【当前运行平台】判，
+  //    于是在 Linux CI 上给它一个 Windows 路径会答 false ——
+  //    这一条是被本文件的测试红出来的，不是想出来的。
+  //    ⇒ 显式按目标平台选约定，判据自己说清它在用哪一套。
+  const targetPlatform = opts.platform ?? process.platform;
+  const isAbsoluteForTarget = targetPlatform === "win32"
+    ? win32Path.isAbsolute
+    : posixPath.isAbsolute;
+  if (!opts.cwd || opts.cwd.includes("\0") || !isAbsoluteForTarget(opts.cwd)) {
     throw new Error("Grok child environment requires an absolute cwd");
   }
   const env: NodeJS.ProcessEnv = {};
-  for (const key of GROK_CHILD_INHERITED_ENV_KEYS) {
+  const inherited = targetPlatform === "win32"
+    ? [...GROK_CHILD_INHERITED_ENV_KEYS, ...GROK_CHILD_WINDOWS_INHERITED_ENV_KEYS]
+    : GROK_CHILD_INHERITED_ENV_KEYS;
+  for (const key of inherited) {
     const value = opts.parentEnv[key];
     if (value !== undefined && value !== "") env[key] = value;
   }
 
   env.HOME = opts.home;
+  if (targetPlatform === "win32") {
+    // 三个都要设：Node 的 os.homedir() 在 Windows 上依次看 USERPROFILE、
+    // 然后 HOMEDRIVE+HOMEPATH；漏掉任何一个都会让隔离在某条路径上失效。
+    env.USERPROFILE = opts.home;
+    const drive = opts.home.length >= 2 && opts.home[1] === ":" ? opts.home.slice(0, 2) : "";
+    if (drive) {
+      env.HOMEDRIVE = drive;
+      env.HOMEPATH = opts.home.slice(2) || "\\";
+    }
+  }
   // dash exports PWD when the headless launcher enters /bin/sh. Seed the
   // exact expected value so that wrapper behavior cannot silently widen the
   // final child environment.
@@ -160,8 +218,17 @@ export function buildGrokChildEnv(opts: BuildGrokChildEnvOptions): NodeJS.Proces
 }
 
 /** Construct a helper-process environment from an empty object. */
-export function buildGrokHelperEnv(parentEnv: NodeJS.ProcessEnv): Record<string, string> {
+export function buildGrokHelperEnv(
+  parentEnv: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): Record<string, string> {
   const env: Record<string, string> = {};
+  if (platform === "win32") {
+    for (const key of GROK_CHILD_WINDOWS_INHERITED_ENV_KEYS) {
+      const value = parentEnv[key];
+      if (value !== undefined && value !== "") env[key] = value;
+    }
+  }
   for (const key of GROK_HELPER_INHERITED_ENV_KEYS) {
     const value = parentEnv[key];
     if (value !== undefined && value !== "") env[key] = value;

--- a/agent-node/src/runtime/grok-copresence/attach.ts
+++ b/agent-node/src/runtime/grok-copresence/attach.ts
@@ -6,6 +6,13 @@ import {
   type Stats,
 } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
+import {
+  copresenceCapabilities,
+  copresenceEndpointIsFilesystemPath,
+  copresenceIpcEndpoint,
+  modeIsExactly,
+  modeIsOwnerOnly,
+} from "./platform";
 import { dirname, isAbsolute, resolve } from "node:path";
 
 export const GROK_COPRESENCE_ATTACH_PROTOCOL = "anet-grok-copresence-attach";
@@ -160,19 +167,28 @@ class AttachServer implements GrokCopresenceAttachServer {
       };
       this.server.once("error", onError);
       this.server.once("listening", onListening);
-      this.server.listen(this.socketPath);
+      // 路径仍按路径用（锁文件、哈希键），只有真正 bind 的这一刻换成平台端点：
+      // Linux 逐字沿用原 Unix socket 路径；Windows 换成按完整路径哈希出的命名管道。
+      this.server.listen(copresenceIpcEndpoint(this.socketPath, copresenceCapabilities()));
     });
 
     try {
-      chmodSync(this.socketPath, 0o600);
-      const stat = lstatSync(this.socketPath);
-      if (!stat.isSocket() || stat.isSymbolicLink()) {
-        throw new Error("Grok attach endpoint is not a real Unix socket");
+      // 🔴 命名管道不在文件系统里：这里的 chmod / lstat / isSocket / dev+ino
+      //    全部是针对【Unix socket 文件】的校验，对管道逐条都不成立
+      //    （实测第一条就 `ENOENT: chmod '...\\run\\attach.sock'`）。
+      //    互斥与生命周期由管道命名空间本身保证：同名只能被一个进程创建，
+      //    进程退出 OS 立即回收 —— 这一格不是"跳过检查"，是"检查对象不同"。
+      if (copresenceEndpointIsFilesystemPath(copresenceCapabilities())) {
+        chmodSync(this.socketPath, 0o600);
+        const stat = lstatSync(this.socketPath);
+        if (!stat.isSocket() || stat.isSymbolicLink()) {
+          throw new Error("Grok attach endpoint is not a real Unix socket");
+        }
+        if (!modeIsOwnerOnly(stat.mode)) {
+          throw new Error("Grok attach Unix socket must be owner-only (0600)");
+        }
+        this.identity = { dev: stat.dev, ino: stat.ino };
       }
-      if ((stat.mode & 0o077) !== 0) {
-        throw new Error("Grok attach Unix socket must be owner-only (0600)");
-      }
-      this.identity = { dev: stat.dev, ino: stat.ino };
       this.started = true;
     } catch (error) {
       await this.stopListeningAfterStartFailure();
@@ -525,6 +541,12 @@ function assertSafeSocketLocation(socketPath: string): void {
   if (!isAbsolute(socketPath) || resolve(socketPath) !== socketPath) {
     throw new Error("Grok attach socket path must be absolute and normalized");
   }
+  // 🔴 Windows：端点是【命名管道】而不是文件系统里的 socket 文件，
+  //    所以下面这组 lstat / uid / 0700 校验对它没有意义 —— 它们的保护对象
+  //    （别人能不能在同目录里塞一个同名 socket）在管道命名空间里不存在。
+  //    实测：AF_UNIX 在 Windows 上 EACCES，命名管道 ok。
+  //    父目录本身仍然由 ensurePrivateRuntimeDirectory 建成受控目录（锁文件放那儿）。
+  if (!copresenceEndpointIsFilesystemPath(copresenceCapabilities())) return;
   const parent = dirname(socketPath);
   const parentStat = lstatSync(parent);
   if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
@@ -536,7 +558,7 @@ function assertSafeSocketLocation(socketPath: string): void {
   if (typeof process.getuid !== "function" || parentStat.uid !== process.getuid()) {
     throw new Error("Grok attach socket parent must be owned by the current uid");
   }
-  if ((parentStat.mode & 0o077) !== 0) {
+  if (!modeIsOwnerOnly(parentStat.mode)) {
     throw new Error("Grok attach socket parent must be owner-only (0700)");
   }
 

--- a/agent-node/src/runtime/grok-copresence/platform.test.ts
+++ b/agent-node/src/runtime/grok-copresence/platform.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertCopresenceSupported,
+  chmodIfPosix,
+  modeIsExactly,
+  modeIsOwnerOnly,
+  posixFileModes,
+  copresenceCapabilities,
+  copresenceDowngradeNotice,
+  copresenceEndpointIsFilesystemPath,
+  copresenceIpcEndpoint,
+} from "./platform";
+
+describe("grok copresence platform capabilities", () => {
+  test("linux keeps every guarantee and the existing Unix socket path verbatim", () => {
+    const caps = copresenceCapabilities("linux");
+    expect(caps.supported).toBe(true);
+    expect(caps.ipc).toBe("unix-socket");
+    expect(caps.kernelSandbox).toBe(true);
+    expect(caps.reducedGuarantees).toEqual([]);
+    // 🔴 Linux 上端点必须【逐字】等于原来的路径 —— 这条防的是「顺手把所有平台
+    //    都改成管道」这种回归：那会让既有 Linux 部署的 socket 路径全变。
+    expect(copresenceIpcEndpoint("/run/x/leader.sock", caps)).toBe("/run/x/leader.sock");
+    expect(copresenceEndpointIsFilesystemPath(caps)).toBe(true);
+    expect(copresenceDowngradeNotice(caps)).toEqual([]);
+    expect(caps.homeIsolationHidesVendorSkills).toBe(true);
+  });
+
+  test("linux without /proc is refused, and the error names what is missing", () => {
+    const caps = copresenceCapabilities("linux", { hasProcSelfFd: false });
+    expect(caps.supported).toBe(false);
+    expect(caps.missingHard).toEqual(["/proc/self/fd"]);
+    expect(() => assertCopresenceSupported(caps)).toThrow("/proc/self/fd");
+  });
+
+  test("windows is supported over a named pipe, and says exactly what it loses", () => {
+    const caps = copresenceCapabilities("win32");
+    expect(caps.supported).toBe(true);
+    expect(caps.ipc).toBe("named-pipe");
+    // 实测：AF_UNIX 在 Windows 上 EACCES，命名管道 ok。
+    expect(copresenceEndpointIsFilesystemPath(caps)).toBe(false);
+    expect(caps.kernelSandbox).toBe(false);
+    expect(caps.procfs).toBe(false);
+    expect(caps.posixFileModes).toBe(false);
+    expect(caps.missingHard).toEqual([]);
+    expect(caps.reducedGuarantees.length).toBe(4);
+    expect(caps.homeIsolationHidesVendorSkills).toBe(false);
+    const notice = copresenceDowngradeNotice(caps);
+    // 🔴 降级必须是【逐条】打出来的，不能只说一句"较弱" ——
+    //    用户要能判断"我这个任务能不能接受丢这三样"。
+    expect(notice.length).toBe(1 + 4 + 1);
+    expect(notice.join("\n")).toContain("没有内核层强制");
+    expect(notice.join("\n")).toContain("Landlock/Seatbelt");
+    expect(notice.join("\n")).toContain("unshare");
+    // 仍然生效的那半也必须写出来，否则读者会以为什么都没了。
+    expect(notice.join("\n")).toContain("--agent profile + --deny");
+    // 🔴 "隔离 HOME 挡不住厂商技能"这条必须出现在横幅里 —— 它是实测出来的，
+    //    而且是操作者唯一能看到"我接受了什么"的地方。
+    expect(notice.join("\n")).toContain(".agents/.claude");
+  });
+
+  test("named pipe names are namespaced by the full path, not by the basename", () => {
+    const caps = copresenceCapabilities("win32");
+    const a = copresenceIpcEndpoint("C:\\Users\\u\\.anet-grok\\node-a\\run\\leader.sock", caps);
+    const b = copresenceIpcEndpoint("C:\\Users\\u\\.anet-grok\\node-b\\run\\leader.sock", caps);
+    // 🔴 管道命名空间是【全机器全局】的：两个节点的 leader.sock 同名，
+    //    若按 basename 命名就会互相抢。这条钉住"按完整路径哈希"。
+    expect(a).not.toBe(b);
+    for (const name of [a, b]) {
+      expect(name.startsWith("\\\\.\\pipe\\anet-grok-")).toBe(true);
+      expect(name).toMatch(/^\\\\\.\\pipe\\anet-grok-[0-9a-f]{32}$/);
+    }
+    // 同一路径必须稳定（恢复代要能重连同一个管道）
+    expect(copresenceIpcEndpoint("C:\\x\\leader.sock", caps))
+      .toBe(copresenceIpcEndpoint("C:\\x\\leader.sock", caps));
+  });
+
+  test("an unverified platform is refused rather than silently downgraded", () => {
+    const caps = copresenceCapabilities("darwin");
+    expect(caps.supported).toBe(false);
+    expect(() => assertCopresenceSupported(caps)).toThrow("darwin");
+    // fail-closed 的方向：没验过的平台走"拒绝"，不是走"当成 Windows 那套降级跑"。
+    expect(caps.reducedGuarantees).toEqual([]);
+  });
+});
+
+describe("POSIX file-mode predicates", () => {
+  test("mode assertions still判事 on POSIX and go silent only where modes do not exist", () => {
+    expect(posixFileModes("linux")).toBe(true);
+    expect(posixFileModes("darwin")).toBe(true);
+    expect(posixFileModes("win32")).toBe(false);
+    // 🔴 这一格是被变异测试逼出来的：把 posixFileModes 改成恒真时，
+    //    原来的测试全绿 —— 说明没有任何断言在看它。
+    // Linux：0o600 必须【恰好】相等，0o644 要红。
+    expect(modeIsExactly(0o100600, 0o600)).toBe(true);
+    expect(modeIsExactly(0o100644, 0o600)).toBe(false);
+    expect(modeIsOwnerOnly(0o40700)).toBe(true);
+    expect(modeIsOwnerOnly(0o40750)).toBe(false);
+  });
+
+  test("chmod is a no-op exactly where mode bits do not exist, and runs everywhere else", () => {
+    let ran = 0;
+    chmodIfPosix(() => { ran += 1; }, "linux");
+    expect(ran).toBe(1);
+    chmodIfPosix(() => { ran += 1; }, "darwin");
+    expect(ran).toBe(2);
+    // Windows 上 fchmod 会 EPERM（实测 `Refusing unsafe global config: EPERM ... fchmod`）
+    chmodIfPosix(() => { ran += 1; }, "win32");
+    expect(ran).toBe(2);
+  });
+});

--- a/agent-node/src/runtime/grok-copresence/platform.ts
+++ b/agent-node/src/runtime/grok-copresence/platform.ts
@@ -1,0 +1,183 @@
+/**
+ * 共存运行时的**平台能力**。
+ *
+ * 🔴 这个模块存在的理由：原来是一句 `process.platform !== "linux"` 就整体拒绝。
+ *    那句话把「不支持」和「少了哪几样、少了会失去什么」压成了一格 ——
+ *    用户看到的只有「requires Linux」，既不知道差什么，也不知道换个平台会丢什么保证。
+ *
+ * 实测（2026-08-20，Windows 11 build 26200 + node v24.18.0 + grok 1.0.5）：
+ *   · node-pty / ConPTY  ⇒ 可用（spawn cmd.exe 拿到了带 ANSI 的 PTY_OK）
+ *   · 命名管道           ⇒ 可用
+ *   · AF_UNIX            ⇒ EACCES（同一进程里命名管道成功）⇒ Windows 必须走命名管道
+ *   · /proc              ⇒ absent
+ *   · 内核沙箱           ⇒ **grok 自己就不支持**：它的 Platform Support 表只有
+ *                          Linux/Landlock 与 macOS/Seatbelt，没有 Windows
+ */
+import { createHash } from "crypto";
+
+export type CopresenceIpc = "unix-socket" | "named-pipe";
+
+export interface CopresenceCapabilities {
+  readonly platform: NodeJS.Platform;
+  /** 能不能跑共存。false 时 missingHard 说明缺什么。 */
+  readonly supported: boolean;
+  readonly ipc: CopresenceIpc;
+  /** deny 列表是否由内核强制（Landlock/Seatbelt）。 */
+  readonly kernelSandbox: boolean;
+  /** /proc 是否可用（父 pid / fd 校验依赖它）。 */
+  readonly procfs: boolean;
+  /** POSIX 文件模式位（0700/0600）是否有意义。 */
+  readonly posixFileModes: boolean;
+  /** 硬缺口：非空即不支持。 */
+  readonly missingHard: readonly string[];
+  /**
+   * 隔离 HOME 能不能真的挡住厂商技能/子代理的发现。
+   *
+   * 🔴 Linux：能 —— 改 HOME 后 `grok inspect --json` 的 skills 归零。
+   * 🔴 Windows：**不能**。实测同一台机、同一个 grok 1.0.5，
+   *    把 USERPROFILE / HOME / HOMEDRIVE / HOMEPATH / GROK_HOME 全部重定向之后：
+   *      真实家目录 ⇒ skills=53，外部来源 53
+   *      隔离家目录 ⇒ skills=31，外部来源 31（仍是 C:\Users\<u>\.agents\skills\...）
+   *    也就是说 grok 在 Windows 上不按环境变量解析 `.agents`。
+   *    ⇒ 这一格不能靠"把断言放松"糊过去：断言仍然拒绝一切可隔离的外部来源，
+   *      只对【已证明隔离不了】的这一类改为**逐条列出并在启动时打印**。
+   */
+  readonly homeIsolationHidesVendorSkills: boolean;
+  /** 软缺口：能跑，但**失去**这些保证。必须对用户明说。 */
+  readonly reducedGuarantees: readonly string[];
+}
+
+export interface CopresenceCapabilityProbe {
+  /** /proc/self/fd 是否存在。注入以便测试，不去碰真实文件系统。 */
+  readonly hasProcSelfFd: boolean;
+}
+
+export function copresenceCapabilities(
+  platform: NodeJS.Platform = process.platform,
+  probe?: CopresenceCapabilityProbe,
+): CopresenceCapabilities {
+  if (platform === "linux") {
+    // Linux 上 /proc 是硬前提：父 pid / fd 校验、以及 unshare 的 uid_map 都要它。
+    const procfs = probe?.hasProcSelfFd ?? true;
+    return {
+      platform,
+      supported: procfs,
+      ipc: "unix-socket",
+      kernelSandbox: true,
+      procfs,
+      posixFileModes: true,
+      homeIsolationHidesVendorSkills: true,
+      missingHard: procfs ? [] : ["/proc/self/fd"],
+      reducedGuarantees: [],
+    };
+  }
+  if (platform === "win32") {
+    return {
+      platform,
+      supported: true,
+      ipc: "named-pipe",
+      kernelSandbox: false,
+      procfs: false,
+      posixFileModes: false,
+      homeIsolationHidesVendorSkills: false,
+      missingHard: [],
+      // 🔴 这三条是**真的丢了**，不是措辞问题。写在这里是为了让启动横幅逐条打出来。
+      reducedGuarantees: [
+        "内核强制的 deny 路径（Landlock/Seatbelt）—— grok 在 Windows 上没有沙箱后端",
+        "每轮 unshare --user 的用户命名空间隔离",
+        "基于 /proc 的父进程与 fd 校验、POSIX 0700/0600 文件模式、以及 uid 属主核对",
+        "隔离 HOME 对厂商技能无效：grok 仍会读取真实用户目录下的 .agents/.claude 技能"
+        + "（实测重定向全部家目录变量后依旧读到），它们的【指令文本】会进入上下文",
+      ],
+    };
+  }
+  return {
+    platform,
+    supported: false,
+    ipc: "unix-socket",
+    kernelSandbox: false,
+    procfs: false,
+    posixFileModes: false,
+    homeIsolationHidesVendorSkills: false,
+    missingHard: [`平台 ${platform} 尚未验证过共存所需的 PTY / IPC / 隔离原语`],
+    reducedGuarantees: [],
+  };
+}
+
+export function assertCopresenceSupported(caps: CopresenceCapabilities): void {
+  if (caps.supported) return;
+  throw new Error(
+    `grok co-presence 无法在 ${caps.platform} 上运行，缺少：${caps.missingHard.join("；")}`,
+  );
+}
+
+/**
+ * IPC 端点路径。
+ *
+ * Linux 仍是原来的 Unix socket 文件路径（保持既有行为逐字不变）；
+ * Windows 返回命名管道名 —— 🔴 管道名不是文件系统路径，
+ * 所以调用方不能对它做 lstat / mode / realpath 那套校验。
+ */
+export function copresenceIpcEndpoint(
+  unixPath: string,
+  caps: CopresenceCapabilities,
+): string {
+  if (caps.ipc === "unix-socket") return unixPath;
+  // 用完整路径的哈希做管道名：管道命名空间是全局的，必须避免不同节点/不同 home 撞名。
+  const digest = createHash("sha256").update(unixPath).digest("hex").slice(0, 32);
+  return `\\\\.\\pipe\\anet-grok-${digest}`;
+}
+
+/** 端点是不是文件系统路径（决定要不要做 lstat/mode/owner 那组校验）。 */
+export function copresenceEndpointIsFilesystemPath(caps: CopresenceCapabilities): boolean {
+  return caps.ipc === "unix-socket";
+}
+
+/** 启动横幅要逐条打出来的降级说明；无降级时返回空数组。 */
+export function copresenceDowngradeNotice(caps: CopresenceCapabilities): readonly string[] {
+  if (!caps.reducedGuarantees.length) return [];
+  return [
+    `🔴 ${caps.platform} 上的 grok 共存【没有内核层强制】。仍然生效的是 grok 自己的`
+    + `固定工具清单（--agent profile + --deny），失去的是：`,
+    ...caps.reducedGuarantees.map((line) => `   · ${line}`),
+    "   ⇒ 只在受信任的任务与受信任的网络里使用。",
+  ];
+}
+
+/** 这个平台上 POSIX 模式位有没有意义（NTFS 走 ACL，没有 mode 位）。 */
+export function posixFileModes(platform: NodeJS.Platform = process.platform): boolean {
+  return platform !== "win32";
+}
+
+/**
+ * 「模式位必须【恰好】是 expected」。
+ *
+ * 🔴 无模式位的平台上这一条恒真 —— 而这**正是**要写成函数的理由：
+ *    散落在各处的 `(stat.mode & 0o777) !== 0o600` 如果各自加 `platform !== "win32"`，
+ *    迟早漏一处；而漏掉的那处在 Windows 上会把合法文件误拒。
+ *    同样重要的是：跳过的**只有模式位**，symlink / nlink / uid / dev+ino
+ *    那些检查一条都不放过。
+ */
+export function modeIsExactly(mode: number, expected: number): boolean {
+  return !posixFileModes() || (mode & 0o777) === expected;
+}
+
+/** 「除属主外无任何权限位」。无模式位的平台恒真，理由同上。 */
+export function modeIsOwnerOnly(mode: number): boolean {
+  return !posixFileModes() || (mode & 0o077) === 0;
+}
+
+/**
+ * chmod / fchmod 包装：无模式位的平台上是 no-op。
+ *
+ * 🔴 Windows 上 `fchmod` 直接 EPERM（实测：
+ *    `Refusing unsafe global config: EPERM: operation not permitted, fchmod`），
+ *    而这些调用点的目的是"收紧"权限 —— 在一个没有权限位的文件系统上，
+ *    收紧无从谈起。跳过它不会放宽任何东西；不跳过则整条路径直接崩。
+ */
+export function chmodIfPosix(
+  apply: () => void,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (posixFileModes(platform)) apply();
+}

--- a/agent-node/src/runtime/grok-copresence/policy.ts
+++ b/agent-node/src/runtime/grok-copresence/policy.ts
@@ -9,6 +9,7 @@ import {
 } from "fs";
 import { dirname, join, resolve } from "path";
 import { readPinnedGrokCopresenceCapabilityProfile } from "./profile-selection";
+import { modeIsExactly, modeIsOwnerOnly } from "./platform";
 
 /**
  * Pinned Grok 0.2.93 ignores `--tools` in its interactive TUI.  The preview
@@ -107,7 +108,7 @@ export function assertGrokCopresenceAgentProfile(profilePath: string, grokHome: 
     before.isSymbolicLink()
     || !before.isFile()
     || before.nlink !== 1
-    || (before.mode & 0o777) !== 0o600
+    || !modeIsExactly(before.mode, 0o600)
     || (uid !== undefined && before.uid !== uid)
   ) {
     throw new Error("grok copresence agent profile is not an owner-only regular file");
@@ -120,7 +121,7 @@ export function assertGrokCopresenceAgentProfile(profilePath: string, grokHome: 
       || opened.nlink !== 1
       || opened.dev !== before.dev
       || opened.ino !== before.ino
-      || (opened.mode & 0o777) !== 0o600
+      || !modeIsExactly(opened.mode, 0o600)
       || (uid !== undefined && opened.uid !== uid)
       || readFileSync(fd, "utf8") !== renderGrokCopresenceAgentProfile()
     ) {

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -14,9 +14,20 @@ import {
   type Stats,
 } from "fs";
 import { dirname, isAbsolute, join, resolve } from "path";
+import {
+  assertCopresenceSupported,
+  copresenceCapabilities,
+  copresenceEndpointIsFilesystemPath,
+  copresenceIpcEndpoint,
+  type CopresenceCapabilities,
+  modeIsExactly,
+  modeIsOwnerOnly,
+} from "./platform";
+import { createServer as createNetServer } from "node:net";
 import { setTimeout as delay } from "timers/promises";
 import { StringDecoder } from "string_decoder";
 import { startGrokAttachServer, type GrokAttachServer } from "./attach";
+import { resolveGrokCommhubMcpCommand } from "../grok-build-cli-home";
 import { describeStuckPhase } from "./stuck-phase-alarm";
 import { describeBlockedKey } from "./blocked-key-name";
 import {
@@ -458,16 +469,23 @@ export function buildGrokCopresenceArgs(opts: BuildGrokCopresenceArgsOptions): s
   );
   for (const path of opts.protectedPaths ?? []) {
     if (path) {
-      if (!isAbsolute(path) || /[\0\r\n\\*?()[\]{},]/.test(path)) {
+      // 🔴 反斜杠在这条判据里被列为不安全字符（它在规则语法里可能当转义符），
+      //    而它恰恰是 Windows 的路径分隔符 —— 于是每一个 Windows 保护路径都被误拒。
+      //    解法不是把 `\\` 放行（那会真的引入转义歧义），而是**归一成正斜杠**：
+      //    Windows 接受 `C:/Users/...` 形式，归一之后这条判据一字不改地继续成立。
+      const rulePath = isAbsolute(path) && !copresenceEndpointIsFilesystemPath(copresenceCapabilities())
+        ? path.replace(/\\/g, "/")
+        : path;
+      if (!isAbsolute(path) || /[\0\r\n\\*?()[\]{},]/.test(rulePath)) {
         throw new Error("grok copresence protected path cannot be represented safely as a permission rule");
       }
       args.push(
-        "--deny", `Read(${path})`,
-        "--deny", `Read(${path}/**)`,
-        "--deny", `Grep(${path})`,
-        "--deny", `Grep(${path}/**)`,
-        "--deny", `Edit(${path})`,
-        "--deny", `Edit(${path}/**)`,
+        "--deny", `Read(${rulePath})`,
+        "--deny", `Read(${rulePath}/**)`,
+        "--deny", `Grep(${rulePath})`,
+        "--deny", `Grep(${rulePath}/**)`,
+        "--deny", `Edit(${rulePath})`,
+        "--deny", `Edit(${rulePath}/**)`,
       );
     }
   }
@@ -513,13 +531,15 @@ export function assertGrokCopresenceFeatures(help: string): void {
 export function assertGrokCopresenceExternalSurfaces(
   inspectionJson: string,
   isolatedGrokHome: string,
-): void {
+  caps: CopresenceCapabilities = copresenceCapabilities(),
+): readonly string[] {
   let inspection: Record<string, unknown>;
   try {
     inspection = JSON.parse(inspectionJson) as Record<string, unknown>;
   } catch {
     throw new Error("grok copresence inspect is not valid JSON");
   }
+  const unisolated: string[] = [];
   const allowedRoot = resolve(isolatedGrokHome);
   const insideHome = (p: string) => {
     const c = resolve(p);
@@ -585,12 +605,21 @@ export function assertGrokCopresenceExternalSurfaces(
       const path = typeof raw === "string" && isAbsolute(raw) ? raw : undefined;
       if (path === undefined) continue; // builtin / 类型标签 / 无磁盘来源
       if (!insideHome(path)) {
+        // 🔴 skills / agents 在 Windows 上【已证明隔离不了】（重定向全部家目录变量后
+        //    grok 仍读 C:\Users\<u>\.agents\skills\...）。不放松其它类别，也不假装
+        //    它被挡住了：逐条收集，由调用方在启动横幅原样打印。
+        //    平台一旦能隔离（Linux），同样的条目仍是硬拒。
+        if (!caps.homeIsolationHidesVendorSkills && (field === "skills" || field === "agents")) {
+          unisolated.push(`${field}: ${resolve(path)}`);
+          continue;
+        }
         throw new Error(
           `grok copresence refuses external ${field} source ${resolve(path)}; the fixed tool inventory must stay runtime-owned`,
         );
       }
     }
   }
+  return unisolated;
 }
 
 /**
@@ -667,7 +696,9 @@ export function assertGrokCopresenceApprovalOwnership(
   //    这个不一致由 #1004 落了生成侧、#1010 摘了审计侧造成（见 #1016）。
   //    默认值 "bun" 只为兼容尚未传参的调用点；生产路径必须显式传。
   expectedCommhubCommand = "bun",
-): void {
+  caps: CopresenceCapabilities = copresenceCapabilities(),
+): readonly string[] {
+  const unisolated: string[] = [];
   let inspection: Record<string, unknown>;
   try {
     const parsed = JSON.parse(inspectionJson) as unknown;
@@ -710,8 +741,24 @@ export function assertGrokCopresenceApprovalOwnership(
   if (!Number.isSafeInteger(record.loaded) || record.loaded !== 0 || record.sources.length !== 0) {
     throw new Error("grok copresence refuses preloaded permission rules; approvals must stay human-owned");
   }
-  if (!Array.isArray(record.skipped) || record.skipped.length !== 0) {
+  if (!Array.isArray(record.skipped)) {
     throw new Error("grok copresence inspect reports skipped or unknown permission rules");
+  }
+  if (record.skipped.length !== 0) {
+    // 🔴 `skipped` 是【grok 没能理解、因而没有生效】的规则；上面 `loaded !== 0`
+    //    与 `sources.length !== 0` 那两格仍然硬拒——真正被加载的规则一条都不许有。
+    //    而在隔离挡不住厂商配置的平台（Windows 实测：sources=[] loaded=0，
+    //    却仍读到 `permissions.allow: PowerShell(npm ls *)` / `unknown tool prefix`），
+    //    把"没生效的规则"也判成致命，等于把整个平台挡在门外，
+    //    却并没有拦住任何**已生效**的东西。⇒ 改为逐条列出。
+    if (caps.homeIsolationHidesVendorSkills) {
+      throw new Error("grok copresence inspect reports skipped or unknown permission rules");
+    }
+    for (const entry of record.skipped as any[]) {
+      const rule = entry && typeof entry === "object" ? entry.rule : entry;
+      const reason = entry && typeof entry === "object" ? entry.reason : "";
+      unisolated.push(`permission rule (未生效): ${String(rule)}${reason ? ` — ${reason}` : ""}`);
+    }
   }
   for (const field of ["mcpServerAllowlist", "marketplaceAllowlist"] as const) {
     if (!Array.isArray(record[field]) || record[field].length !== 0) {
@@ -765,6 +812,7 @@ export function assertGrokCopresenceApprovalOwnership(
   if (modeValues.some((value) => value.trim().toLowerCase() !== "default")) {
     throw new Error("grok copresence inspect reports an unknown or non-default permission mode");
   }
+  return unisolated;
 }
 
 export function grokSessionDirectory(grokHome: string, cwd: string, sessionId: string): string {
@@ -959,9 +1007,7 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
 
   async open(): Promise<void> {
     if (this.opened) return;
-    if (process.platform !== "linux") {
-      throw new Error("grok co-presence preview currently requires Linux PTY, /proc, and Unix sockets");
-    }
+    assertCopresenceSupported(copresenceCapabilities());
     assertSessionId(this.sessionId);
     assertSocketPath(this.leaderSocket, "leader");
     assertSocketPath(this.attachSocket, "attach");
@@ -1246,7 +1292,14 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     this.leaderOwnerNonce = randomUUID();
     this.tuiComposerReady = false;
     this.tuiReadinessBuffer = "";
-    const binary = this.opts.binary ?? "grok";
+    // 🔴 node-pty 在 Windows 上要【带扩展名的完整路径】：传裸名 `grok` 会得到
+    //    `Error: File not found:`（文件名是空的，报错本身也不说是哪个）。
+    //    复用 grok-build-cli-home 里那个已经处理了 PATHEXT 与 npm 真二进制的解析器，
+    //    保证 TUI 与 MCP 两条路径用同一套解析规则，不会一边能找到一边找不到。
+    const rawBinary = this.opts.binary ?? "grok";
+    const binary = copresenceEndpointIsFilesystemPath(copresenceCapabilities())
+      ? rawBinary
+      : resolveGrokCommhubMcpCommand(rawBinary, String(this.spawnEnv.PATH || process.env.PATH || ""));
     const args = buildGrokCopresenceArgs({
       cwd: this.opts.cwd,
       sessionId: this.sessionId,
@@ -3134,7 +3187,7 @@ class SafeJsonlTail {
     if (
       !stat.isFile()
       || (allowUnlinked ? stat.nlink > 1 : stat.nlink !== 1)
-      || (stat.mode & 0o077) !== 0
+      || !modeIsOwnerOnly(stat.mode)
       || (this.uid !== undefined && stat.uid !== this.uid)
     ) {
       throw jsonlTailBoundaryError(
@@ -3194,7 +3247,7 @@ class SafeJsonlTail {
       stat.isSymbolicLink()
       || !stat.isFile()
       || stat.nlink !== 1
-      || (stat.mode & 0o077) !== 0
+      || !modeIsOwnerOnly(stat.mode)
     ) {
       throw jsonlTailBoundaryError(
         safeJsonlTailFailureSubcode(this.source, "statNonRegular"),
@@ -3259,11 +3312,49 @@ class GrokUnsafeRecoveryApprovalError extends GrokCopresenceFailure {
   constructor(message: string) { super("approval_boundary", message); }
 }
 
+/**
+ * Windows 的生命周期锁：命名管道独占。
+ *
+ * 🔴 flock(1) 是外部二进制，Windows 上没有（实测 `spawn flock ENOENT`）。
+ *    用命名管道做互斥，它在两个性质上**优于**锁文件：
+ *      · 互斥由内核给：同名管道只能被一个进程创建，第二个 listen 直接 EADDRINUSE
+ *      · 无残留：进程崩了 OS 立刻回收管道名，不会留下"看起来被持有"的死锁文件
+ *    管道名由锁文件的【完整路径】哈希而来，与 Linux 侧一一对应、不会跨节点撞名。
+ */
+async function acquireNamedPipeLifetimeLock(path: string): Promise<LifetimeLock> {
+  const endpoint = copresenceIpcEndpoint(path, copresenceCapabilities());
+  const server = createNetServer();
+  server.on("connection", (socket) => { try { socket.destroy(); } catch {} });
+  await new Promise<void>((resolveListen, rejectListen) => {
+    const onError = (error: unknown) => {
+      server.removeListener("listening", onListening);
+      rejectListen(new Error(
+        `copresence lock is already held or unavailable (${endpoint}): ${errorMessage(error)}`,
+      ));
+    };
+    const onListening = () => { server.removeListener("error", onError); resolveListen(); };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(endpoint);
+  });
+  let released = false;
+  return {
+    async release() {
+      if (released) return;
+      released = true;
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+    },
+  };
+}
+
 async function acquireLifetimeLock(
   path: string,
   flockBinary: string,
   holderParentEnv: NodeJS.ProcessEnv,
 ): Promise<LifetimeLock> {
+  if (!copresenceEndpointIsFilesystemPath(copresenceCapabilities())) {
+    return acquireNamedPipeLifetimeLock(path);
+  }
   const fd = openSync(path, constants.O_RDWR | constants.O_CREAT | (constants.O_NOFOLLOW || 0), 0o600);
   let expectedDev = 0;
   let expectedIno = 0;
@@ -3391,10 +3482,13 @@ function ensurePrivateRuntimeDirectory(path: string): void {
   }
   const uid = process.getuid?.();
   if (uid !== undefined && stat.uid !== uid) throw new Error(`Grok copresence runtime directory owner mismatch: ${path}`);
-  if ((stat.mode & 0o077) !== 0) throw new Error(`Grok copresence runtime directory must be mode 0700: ${path}`);
+  if (!modeIsOwnerOnly(stat.mode)) throw new Error(`Grok copresence runtime directory must be mode 0700: ${path}`);
 }
 
 function assertAbsentSocketPath(path: string, label: string): void {
+  // 命名管道不落在文件系统里，lstat 恒 ENOENT —— 这个检查在 Windows 上零分辨力，
+  // 与其留一个恒真的断言（看起来在把关、实际不判事），不如明确跳过。
+  if (!copresenceEndpointIsFilesystemPath(copresenceCapabilities())) return;
   try {
     const stat = lstatSync(path);
     if (stat.isSymbolicLink()) throw new Error(`${label} socket may not be a symlink: ${path}`);
@@ -3442,6 +3536,9 @@ async function waitForOwnedUnixSocket(path: string, timeoutMs: number): Promise<
 
 function assertSocketPath(path: string, label: string): void {
   if (!isAbsolute(path) || resolve(path) !== path) throw new Error(`${label} socket path must be absolute and normalized`);
+  // sun_path 的 108 字节上限是 Unix socket 独有的；命名管道没有这个限制，
+  // 在 Windows 上照搬会把合法路径误拒（用户目录一深就超）。
+  if (!copresenceEndpointIsFilesystemPath(copresenceCapabilities())) return;
   if (Buffer.byteLength(path) > UNIX_SOCKET_PATH_MAX_BYTES) throw new Error(`${label} socket path is too long for a Unix socket`);
 }
 


### PR DESCRIPTION
## 起因
`grok-build-cli` 共存此前对非 Linux 一刀切拒绝：

    agent-node/src/cli.ts:503   process.platform !== "linux" ⇒ process.exit(1)
    agent-node/src/cli.ts:3636  throw "requires Linux PTY, /proc, and Unix sockets"
    runtime.ts:962              同上

那句话把「不支持」和「少了哪几样、少了会失去什么」压成一格：用户只看到
"requires Linux"，既不知道差什么，也不知道换平台会丢什么保证。

## 先量后改（Windows 11 build 26200 / node v24.18.0 / grok 1.0.5 (5115b46bc9)）
    ConPTY (node-pty)  ⇒ 可用（spawn cmd.exe 拿到带 ANSI 的 PTY_OK）
    命名管道            ⇒ 可用
    AF_UNIX            ⇒ EACCES（同进程内命名管道成功）
    /proc              ⇒ absent
    内核沙箱            ⇒ **grok 自己就不支持**：Platform Support 表只有
                          Linux/Landlock 与 macOS/Seatbelt，没有 Windows

⇒ 机械层面可行，内核强制层面不可行。而共存的「固定工具清单」是靠 grok 的
`--agent profile + --deny` 挡的、不是靠内核沙箱 —— 那部分在 Windows 上照常生效。

## 改了什么
新增 `agent-node/src/runtime/grok-copresence/platform.ts`：把平台判定变成**能力模型**
（ipc / kernelSandbox / procfs / posixFileModes / homeIsolationHidesVendorSkills），
不支持时报错要**说出缺什么**，能跑但有损失时**逐条打印**。

按能力分流的具体点（每一处都是实测红出来的，不是预防性改动）：
· IPC：Windows 走命名管道（按完整路径哈希命名，避免跨节点撞名）
· 生命周期锁 / 项目 turn 锁：flock(1) 在 Windows 不存在（`spawn flock ENOENT`）
  ⇒ 改用命名管道独占。它比锁文件更好：互斥由内核给，进程崩了 OS 立即回收，无残留
· POSIX 模式位：10 处 `(mode & 0o777) !== 0o600` 与 10 处 chmod 统一走谓词
  （NTFS 走 ACL，fchmod 直接 EPERM）
· uid：两处**没有** `uid !== undefined` 守卫的比较补齐（与同文件其余 15 处写法一致）
· `/proc`：protectedPaths 里的 "/proc" 在 Windows 会 resolve 成 `D:\proc` 然后 ENOENT
· private-log 的 `/proc/self/fd/<fd>` TOCTOU 加固：无 procfs 时退回按路径操作
· 绝对路径判据：`startsWith("/")` → 按**目标平台**选 `win32.isAbsolute`/`posix.isAbsolute`
  （单纯换成 `path.isAbsolute` 不够：它按【当前运行平台】判，Linux CI 上给 Windows 路径答 false
   —— 这条是被本次新增的测试红出来的）
· 子进程环境：补 Windows 必需的系统变量（SystemRoot/ComSpec/PATHEXT/APPDATA…）
  —— 缺它们时 MCP server 起不来，实测从 `os error 193` 变成 **ETIMEDOUT**
· 家目录隔离：Windows 用 USERPROFILE/HOMEDRIVE/HOMEPATH 解析家目录，**不看 HOME**
· MCP 命令解析：按 PATHEXT 试扩展名，并探 npm 全局真二进制
  （Linux 上 `bin/bun` 是指向 `node_modules/bun/bin/bun.exe` 的符号链接、realpath 能解到；
   Windows 上同名的是 `bun.CMD` 批处理，经它转发 stdio 握手会失败）
· 保护路径 → 权限规则：反斜杠被判据列为不安全字符（它在规则语法里可能是转义符），
  解法不是放行它，而是**归一为正斜杠**，判据一字不改
· attach：命名管道不在文件系统里，chmod/lstat/isSocket/dev+ino 这组校验对象不同 ⇒ 分流
· `agent-network/src/owner-env-file.ts`：`startsWith("/")` 与两处模式位同样按平台
· `agent-network/src/node-server.ts`：Windows 不去调 tmux，且显式丢弃子进程 stderr
  （execSync 默认把它透传到父进程 stderr，而这是个 MCP stdio 服务端）

## 🔴 一条【无法达成】的保证，写进代码并在启动时逐条打印
隔离 HOME 在 Windows 上**挡不住厂商技能发现**。实测同机同 build，把
USERPROFILE / HOME / HOMEDRIVE / HOMEPATH / GROK_HOME **全部**重定向之后：

    真实家目录 ⇒ skills=53，外部来源 53
    隔离家目录 ⇒ skills=31，外部来源 31（仍是 C:\Users\<u>\.agents\skills\...）

处置不是"把断言放松让它变绿"（那正是把要判的东西移出取集）：
· 可隔离的外部来源（plugins/marketplaces/lspServers/mcpServers）**仍然硬拒**
· 已生效的权限规则（loaded/sources 非空）**仍然硬拒**
· 已证明隔离不了的（skills/agents、以及**未生效**的 skipped 规则）⇒ **逐条列出**，
  启动时原样打印路径。操作者要能看见自己接受了什么。

## 端到端（Windows 11，真机）
    [grok-copresence] TUI ready session=753468ae attach=C:\Users\...\run\attach.sock
    [grok-copresence] grok 1.0.5 (5115b46bc9); attach with anet grok attach win-grok-tui
    已注册到 CommHub
    [loops] HTTP MCP server bound to http://127.0.0.1:65529/mcp
    SSE connected
hub 侧独立复核（读本机 hub 日志，不看节点自己的输出）：
    10:40:33 win-grok-tui (sdk-n_wi) → report_status: blocked [net]
    10:40:33 win-grok-tui → get_inbox: 0 pending messages
MCP：`grok mcp doctor commhub` 从 `handshake failed: connection closed` 变为
    healthy=1 failing=0 · handshake OK protocol 2025-11-25 · 4 tools discovered

## 验证
· agent-node 全量 **1330 pass / 0 fail（98 个文件）**
· 新增 platform.test.ts 7 条；变异 **5 条全部见证红**、还原全绿
  🔴 其中一条最初【存活】（posixFileModes 恒真 ⇒ 全绿），说明没有断言在看它 —— 已补测试，
     复验该变异现在 5 pass / 2 fail
· Linux 行为逐字不变：端点仍是原 Unix socket 路径、`--leader` 仍下发、
  模式位与 uid 校验一条不少（测试里对这一点有专门断言）

按内容搜过（按改动文件求交集，不按文本搜）：三个主要文件在 60 个 open PR 中零命中。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>