### PR TITLE
release: agent-network 2.3.0-preview.40 / agent-node 2.5.0-preview.32（grok 1.0.5 + Windows）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@
 - `agent-network/bin/cli.ts` — anet CLI (完整命令清单以 [`docs-site/docs/guide/cli.md`](./docs-site/docs/guide/cli.md) 为准；数字会漂，不硬编)
 - `agent-node/src/cli.ts` — Agent 运行时
   - **stable `@latest` runtime**（以 npm `--help` 为准，勿背版本号）：`claude-agent-sdk` / `codex-sdk` / `grok-build-acp`
-  - **`@preview` 额外**（2026-08-18 实测 `agent-node@2.5.0-preview.31`）：`claude-code-cli` / `codex-app-server` / `grok-build-cli` / `opencode-cli`
+  - **`@preview` 额外**（2026-08-20 实测 `agent-node@2.5.0-preview.32`）：`claude-code-cli` / `codex-app-server` / `grok-build-cli` / `opencode-cli`
   - `anet grok attach` 在 `@preview` CLI 有命令；`@latest` 返回 `Unknown: grok`。Hub 不得把死 TUI 报成 idle（见 #1005）
 - `tests/testN-xxx/` — 独立 Docker 测试套件 (每个有 Dockerfile + run.sh)
 - `docs/` — 设计文档 + 测试报告

--- a/README.en.md
+++ b/README.en.md
@@ -43,7 +43,7 @@ anet node start my-bot
 
 Verify the Hub is up: `curl http://127.0.0.1:9200/health` should return JSON containing `"ok":true`.
 
-> **⚠️ Check that the node really started — don't rely on `anet node start`'s stdout `✅`**: `exit 0` plus a printed `✅ node "…" started detached (tmux session live)` does **not** mean the node came up. On **versions predating [#895](https://github.com/sleep2agi/agent-network/pull/895)** (including today's npm `@preview` = `2.3.0-preview.39`; **#895 has landed on `main` but is not yet released to npm**) the detached path can lie. Real check: `tmux has-session -t "=<alias>"` returns 0 (**the `=` is required** — a bare alias is a prefix match and can go green on the wrong session). For bulk launches use `anet project up`; its exit code is trustworthy since [#896](https://github.com/sleep2agi/agent-network/pull/896) (also awaiting an npm release).
+> **⚠️ Check that the node really started — don't rely on `anet node start`'s stdout `✅`**: `exit 0` plus a printed `✅ node "…" started detached (tmux session live)` does **not** mean the node came up. On **versions predating [#895](https://github.com/sleep2agi/agent-network/pull/895)** (**fixed as of `2.3.0-preview.40`**; #895 landed 2026-08-17 and ships in preview.40) the detached path can lie. Real check: `tmux has-session -t "=<alias>"` returns 0 (**the `=` is required** — a bare alias is a prefix match and can go green on the wrong session). For bulk launches use `anet project up`; its exit code is trustworthy since [#896](https://github.com/sleep2agi/agent-network/pull/896) (also shipping in `2.3.0-preview.40`).
 
 Open `http://localhost:3000` and dispatch work from the Dashboard.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ anet node start my-bot
 
 验证 Hub 起来了：`curl http://127.0.0.1:9200/health` 返回的 JSON 应包含 `"ok":true`。
 
-> **⚠️ 判断节点真起来 —— 别只看 `anet node start` 的 stdout `✅`**：`exit 0` + 打印 `✅ node "…" started detached (tmux session live)` **不代表节点真起来**。**含 [#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本**（包括当前 npm `@preview` = `2.3.0-preview.39`；**#895 已合入 main 但尚未发 npm**）在 detached 场景可能假报。真判据：`tmux has-session -t "=<alias>"` 返回 0（**`=` 必须**，裸名字是前缀匹配会误报绿）。批量场景用 `anet project up`，其退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信（同样待 npm 发布）。
+> **⚠️ 判断节点真起来 —— 别只看 `anet node start` 的 stdout `✅`**：`exit 0` + 打印 `✅ node "…" started detached (tmux session live)` **不代表节点真起来**。**含 [#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本**（**`2.3.0-preview.40` 起已修**；#895 于 2026-08-17 合入，随 preview.40 发布）在 detached 场景可能假报。真判据：`tmux has-session -t "=<alias>"` 返回 0（**`=` 必须**，裸名字是前缀匹配会误报绿）。批量场景用 `anet project up`，其退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信（同样随 `2.3.0-preview.40` 发布）。
 
 打开 `http://localhost:3000`，从 Dashboard 给 Agent 派任务。
 

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.39",
+  "version": "2.3.0-preview.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.39",
+      "version": "2.3.0-preview.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.39",
+  "version": "2.3.0-preview.40",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.39";
-export const OPENCODE_AGENT_NODE_VERSION = "2.5.0-preview.31";
+export const OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.40";
+export const OPENCODE_AGENT_NODE_VERSION = "2.5.0-preview.32";
 export const OPENCODE_AGENT_NODE_SPEC =
   `@sleep2agi/agent-node@${OPENCODE_AGENT_NODE_VERSION}`;
 

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.31",
+  "version": "2.5.0-preview.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.31",
+      "version": "2.5.0-preview.32",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.31",
+  "version": "2.5.0-preview.32",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/deploy/clean-server.md
+++ b/docs-site/docs/deploy/clean-server.md
@@ -297,7 +297,7 @@ anet 暂未 ship 官方 `--daemon` flag，下面给两条可选路径：tmux 临
 - 想接 `@reboot` crontab 也行，但 PATH / nvm 这些非交互 shell 问题要先解决（见 [第 0 节 nvm 提示](#_0-前置)）
 
 ::: tip 复核节点真起来 —— 别只看 stdout ✅
-起完每个节点跑一条：`tmux has-session -t "=<alias>"; echo $?` 应输出 `0`（**`=` 必须**，裸名字是前缀匹配会命中别的 session 假报绿）。**[#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本**（含当前 npm `@preview` = `2.3.0-preview.39`；**#895 已合入 main, 未发 npm**）在 detached 场景可能打 `✅ started detached (tmux session live)` `exit 0` 但 tmux 里没进程。批量起用 `anet project up`，退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信（同样待 npm 发布）。
+起完每个节点跑一条：`tmux has-session -t "=<alias>"; echo $?` 应输出 `0`（**`=` 必须**，裸名字是前缀匹配会命中别的 session 假报绿）。**[#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本**（**`2.3.0-preview.40` 起已修**；#895 于 2026-08-17 合入，随 preview.40 发布）在 detached 场景可能打 `✅ started detached (tmux session live)` `exit 0` 但 tmux 里没进程。批量起用 `anet project up`，退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信（随 preview.40 发布）。
 :::
 
 ### 7.2 systemd unit（生产 / 开机自启）
@@ -372,7 +372,7 @@ sudo systemctl status anet-hub anet-node@my-bot
 | 3 | 一路 Enter 落到要填 vendor + API Key 的复杂路径 | runtime 菜单默认高亮 `claude-agent-sdk`，不是最易上手的 `claude-code-cli` | 建节点时**手动选 `claude-code-cli`**（已 `claude auth login` 直接复用订阅）。中断 vendor 选择如果留下半成品节点，用 `anet node delete <alias>` 清掉重来 |
 | 4 | 建完节点 Telegram 不工作，但向导开头说"optional Telegram channel" | 向导根本不问 Telegram，那行是误导文案 | Telegram 用 `anet channel add telegram <node> --bot-token <tok> --allow <uid>` 单独配（见 [第 6 节](#_6-配-telegram-channel-可选)） |
 | 5 | `anet node start` (codex-sdk / claude-agent-sdk) → `agent-node is not installed or cannot report a version` | npx 懒加载没拉到 `@sleep2agi/agent-node`；bug 存于 `@latest` (2.2.21) 与 preview ≤ 2.3.0-preview.37 | 短路: `npm i -g @sleep2agi/agent-node` 让二进制就位；长期: 升到 `@sleep2agi/agent-network@preview`（含 [PR #239](https://github.com/sleep2agi/agent-network/pull/239) fix, `1eff3a4d`, 2026-06-28）。issue [#450](https://github.com/sleep2agi/agent-network/issues/450) 仍 open —— 待 4 项 gate 后 promote latest |
-| 5.5 | `anet node start` 打 `✅ started detached (tmux session live)` `exit 0`，但 `tmux ls` 找不到 session、进程也不在 | detached 路径的假绿 bug；存于含 [#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本，含 npm `@preview` = `2.3.0-preview.39`（**#895 已合 main 未发 npm**） | 真判据: `tmux has-session -t "=<alias>"; echo $?` 应输 `0`（`=` 必须）。批量场景用 `anet project up`（退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信，同待 npm 发布）。装含 fix 的构建前，用 has-session 复核每次启动 |
+| 5.5 | `anet node start` 打 `✅ started detached (tmux session live)` `exit 0`，但 `tmux ls` 找不到 session、进程也不在 | detached 路径的假绿 bug；存于含 [#895](https://github.com/sleep2agi/agent-network/pull/895) 之前的版本，**`2.3.0-preview.40` 起已修**（#895 随 preview.40 发布） | 真判据: `tmux has-session -t "=<alias>"; echo $?` 应输 `0`（`=` 必须）。批量场景用 `anet project up`（退出码自 [#896](https://github.com/sleep2agi/agent-network/pull/896) 起可信，随 preview.40 发布）。装含 fix 的构建前，用 has-session 复核每次启动 |
 | 6 | `claude-code-cli` 节点起来后卡 offline / pane 卡在确认框 | Claude Code 的 `--dangerously-load-development-channels` 确认框等人按 Enter | 用 tmux 前台跑一次手动按 `1` + Enter；后续就不弹了 |
 | 7 | systemd / cron / 新用户启动报一连串 `command not found` | nvm + Bun 各自按用户装，非交互 shell 不加载 | 把 node/npm/bun 软链到 `/usr/local/bin/`，或启动脚本里显式 `source ~/.nvm/nvm.sh` |
 | 8 | 机器重启全部掉线 | hub + 节点都靠手动 tmux 挂着 | 配 systemd 开机自启，参考 [§7.2 systemd unit](#_7-2-systemd-unit-生产-开机自启) 里的模板 |

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.39 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.40 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -95,7 +95,7 @@ The first `anet hub start` prints the admin credentials once:
 | channel | printed password |
 |---|---|
 | `latest` = `2.2.21` | the fixed string `anethub` |
-| `preview` = `2.3.0-preview.39` | a **random** string like `anet-232412de5bb54c058cff32`, with a change-on-first-login notice |
+| `preview` = `2.3.0-preview.40` | a **random** string like `anet-232412de5bb54c058cff32`, with a change-on-first-login notice |
 
 So the `anethub` below **only holds on stable**. **Anyone who copies this page instead of reading their own startup output will fail to log in on preview.**
 The credentials are also written to `~/.anet/server/admin-utok.json`.
@@ -131,7 +131,7 @@ On stable, `anet node create` lists **4 production runtimes** (`claude-agent-sdk
 Start the node:
 
 ::: warning Fresh install + claude-agent-sdk / codex-sdk? Install agent-node first
-These runtimes depend on the `agent-node` package. The first `node start` triggers an npx auto-fetch that takes ~1 minute, but on **stable `@latest` (currently `2.2.21`) and preview `≤ 2.3.0-preview.37`** the startup check **doesn't wait for it** and exits with `agent-node is not installed or cannot report a version` (reproduced on real hardware — [#450](https://github.com/sleep2agi/agent-network/issues/450) is the precise filing, #237 is the umbrella). **Root fix** is [PR #239](https://github.com/sleep2agi/agent-network/pull/239) (commit `1eff3a4d`, merged 2026-06-28); Vincent's 2026-08-09 audit verified the fix in an isolated Docker probe on `2.3.0-preview.38` reaching SSE connected. **The current `@preview` (`2.3.0-preview.39`) contains this fix; `@latest` does not** — [#450](https://github.com/sleep2agi/agent-network/issues/450) is still `open` pending 4 acceptance gates before latest promotion. **Workarounds** (in verified-strength order): upgrade to `@sleep2agi/agent-network@preview`; or stay on `@latest` but pre-install `agent-node` so the binary is already there:
+These runtimes depend on the `agent-node` package. The first `node start` triggers an npx auto-fetch that takes ~1 minute, but on **stable `@latest` (currently `2.2.21`) and preview `≤ 2.3.0-preview.37`** the startup check **doesn't wait for it** and exits with `agent-node is not installed or cannot report a version` (reproduced on real hardware — [#450](https://github.com/sleep2agi/agent-network/issues/450) is the precise filing, #237 is the umbrella). **Root fix** is [PR #239](https://github.com/sleep2agi/agent-network/pull/239) (commit `1eff3a4d`, merged 2026-06-28); Vincent's 2026-08-09 audit verified the fix in an isolated Docker probe on `2.3.0-preview.38` reaching SSE connected. **The current `@preview` (`2.3.0-preview.40`) contains this fix; `@latest` does not** — [#450](https://github.com/sleep2agi/agent-network/issues/450) is still `open` pending 4 acceptance gates before latest promotion. **Workarounds** (in verified-strength order): upgrade to `@sleep2agi/agent-network@preview`; or stay on `@latest` but pre-install `agent-node` so the binary is already there:
 
 ```bash
 npm install -g @sleep2agi/agent-node

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.39 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.40 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -94,7 +94,7 @@ anet hub dashboard
 | 通道 | 打印出来的密码 |
 |---|---|
 | `latest` = `2.2.21` | 固定的 `anethub` |
-| `preview` = `2.3.0-preview.39` | **随机串**,形如 `anet-232412de5bb54c058cff32`,并提示首次登录后要改 |
+| `preview` = `2.3.0-preview.40` | **随机串**,形如 `anet-232412de5bb54c058cff32`,并提示首次登录后要改 |
 
 所以下面命令里的 `anethub` **只在 stable 上成立**。**照抄这一页而不看自己那次启动输出的人,在 preview 上一定登不进去。**
 凭据也落在 `~/.anet/server/admin-utok.json`。
@@ -130,7 +130,7 @@ stable 版 `anet node create` 列出正式版的 runtime（`claude-agent-sdk` / 
 启动节点：
 
 ::: warning 全新安装选了 claude-agent-sdk / codex-sdk？先装 agent-node
-这两个 runtime 依赖 `agent-node` 包。首次 `node start` 的 npx 自动拉取需要约 1 分钟，而 **stable `@latest`（当前 `2.2.21`）与 preview `≤ 2.3.0-preview.37`** 的启动检查**不等它拉完**就报 `agent-node is not installed or cannot report a version` 退出（真机复现，[#450](https://github.com/sleep2agi/agent-network/issues/450) 精确立案，#237 为同族）。**根因修复**见 [PR #239](https://github.com/sleep2agi/agent-network/pull/239)（commit `1eff3a4d`, merged 2026-06-28），Vincent 2026-08-09 audit 在 `2.3.0-preview.38` 隔离 Docker 里 verified 抵达 SSE connected；**当前 `@preview` (`2.3.0-preview.39`) 已含此 fix，`@latest` 未含** —— [#450](https://github.com/sleep2agi/agent-network/issues/450) 仍 `open`，因 promote 到 latest 待 4 项 acceptance gate 真绿。**变通**（按 verified 强度）：升到 `@sleep2agi/agent-network@preview`；或用 `@latest` 但先跑一句让二进制预先就位：
+这两个 runtime 依赖 `agent-node` 包。首次 `node start` 的 npx 自动拉取需要约 1 分钟，而 **stable `@latest`（当前 `2.2.21`）与 preview `≤ 2.3.0-preview.37`** 的启动检查**不等它拉完**就报 `agent-node is not installed or cannot report a version` 退出（真机复现，[#450](https://github.com/sleep2agi/agent-network/issues/450) 精确立案，#237 为同族）。**根因修复**见 [PR #239](https://github.com/sleep2agi/agent-network/pull/239)（commit `1eff3a4d`, merged 2026-06-28），Vincent 2026-08-09 audit 在 `2.3.0-preview.38` 隔离 Docker 里 verified 抵达 SSE connected；**当前 `@preview` (`2.3.0-preview.40`) 已含此 fix，`@latest` 未含** —— [#450](https://github.com/sleep2agi/agent-network/issues/450) 仍 `open`，因 promote 到 latest 待 4 项 acceptance gate 真绿。**变通**（按 verified 强度）：升到 `@sleep2agi/agent-network@preview`；或用 `@latest` 但先跑一句让二进制预先就位：
 
 ```bash
 npm install -g @sleep2agi/agent-node

--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -74,7 +74,7 @@ R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md`
 >
 > | 包 | latest | preview | 为什么是它 |
 > |---|---|---|---|
-> | `@sleep2agi/agent-network` | `2.2.21` | `2.3.0-preview.39` | **preflight 实现在 `agent-network/bin/cli.ts`,上表断言核的就是它** |
+> | `@sleep2agi/agent-network` | `2.2.21` | `2.3.0-preview.40` | **preflight 实现在 `agent-network/bin/cli.ts`,上表断言核的就是它** |
 > | `@sleep2agi/commhub-server` | `0.8.8` | `0.9.0-preview.29` | 只在 preflight 通过之后才相关,**不是上表断言的坐标** |
 >
 > 我第一版在这里记的是 commhub-server 的版本 —— **记错了包**。被核的是 CLI 的

--- a/docs/tests/release-v2.3.0-preview.40.md
+++ b/docs/tests/release-v2.3.0-preview.40.md
@@ -1,0 +1,82 @@
+# v2.3.0-preview.40 / agent-node 2.5.0-preview.32 — release notes
+
+grok 共存（`grok-build-cli`）这一版做完两件事：**收录 grok 1.0.5**，以及**支持 Windows**。
+两者此前都完全跑不通 —— 不是"体验不好"，是 `anet node create --runtime grok-build-cli`
+之后 `anet node start` 必定失败。
+
+## Install · `@sleep2agi/agent-network@2.3.0-preview.40` · `@sleep2agi/agent-node@2.5.0-preview.32` · `@sleep2agi/commhub-server@0.9.0-preview.29`
+
+```bash
+# CLI（用户入口）
+npm install -g @sleep2agi/agent-network@2.3.0-preview.40
+
+# 每个 agent 的运行时（向导会自动取；写死版本便于可复现部署）
+npm install -g @sleep2agi/agent-node@2.5.0-preview.32
+
+# commhub server —— `anet hub start` 会自动取；只在直接用 CLI 时才需显式安装
+npm install -g @sleep2agi/commhub-server@0.9.0-preview.29
+```
+
+## Upgrade
+
+```bash
+anet upgrade
+# 或按包升级
+npm install -g @sleep2agi/agent-network@preview @sleep2agi/agent-node@preview
+# commhub 在下次 `anet hub start` 时自动刷新
+```
+
+## Headline 1 — grok 1.0.5 可用（此前被版本门硬拒）
+
+版本门从「**恰好等于** `grok 0.2.93 (f00f96316d)`」改为**已验证 build 白名单**。
+刻意不做版本区间比较：新 build 会改 PTY / 审批菜单 / Leader 契约，区间会让没验过的 build 自动通过。
+
+🔴 收录 1.0.5 的关键发现：**1.0.5 的交互式 TUI 不再自动拉起 Leader**。
+厂商文档 `18-sandbox.md` 原文：请求非 `off` 的 sandbox profile 时
+"The agent runs **in-process**, not through the shared leader … but **still refuses the leader**"。
+而共存永远请求 sandbox ⇒ 那个 build 上永远没有 Leader。
+实测三组佐证：等 10s / 等 60s / 一个普通已认证 `grok` TUI 跑 25s —— 都没有 socket。
+
+⇒ 把「TUI 会不会自动起 Leader」做成 **per-build 能力**，无 Leader 的 build 跳过等待与绑定，
+并**反向 fail-closed**：声明无 Leader 的 build 上若真出现 socket，直接报错。
+
+## Headline 2 — Windows 支持（`grok-build-cli` 共存）
+
+原来是一句 `process.platform !== "linux"` 整体拒绝。现在是**能力模型**
+（ipc / kernelSandbox / procfs / posixFileModes / homeIsolationHidesVendorSkills）：
+不支持时报错**说出缺什么**，能跑但有损失时**逐条打印**。
+
+Windows 实测（Windows 11 build 26200 / node v24.18.0 / grok 1.0.5）：
+```
+[grok-copresence] TUI ready session=… attach=…\run\attach.sock
+已注册到 CommHub · SSE connected
+```
+具体改动：命名管道替代 Unix socket 与 flock、PATHEXT + npm 真二进制解析、
+Windows 家目录三件套隔离、Windows 必需系统环境变量、保护路径归一为正斜杠、
+POSIX 模式位与 uid 校验按平台分流。
+
+## 🔴 Windows 上一条【无法达成】的保证（启动时逐条打印）
+
+隔离 HOME **挡不住厂商技能发现**。实测把 `USERPROFILE`/`HOME`/`HOMEDRIVE`/`HOMEPATH`/`GROK_HOME`
+全部重定向后，`grok inspect --json` 仍读到 `C:\Users\<u>\.agents\skills\...`。
+
+处置不是放松断言：
+- 可隔离的外部来源（plugins / marketplaces / lspServers / mcpServers）**仍然硬拒**
+- 已生效的权限规则（`loaded` / `sources` 非空）**仍然硬拒**
+- 已证明隔离不了的（skills / agents、以及**未生效**的 skipped 规则）⇒ **逐条列出路径**并在启动时打印
+
+## 其它
+
+- `$HOME` 里 `anet node create` 出来的共存节点此前**无法启动**（注册表是 cwd 相对，
+  而 folder trust 拒绝 `$HOME`）⇒ cwd 不可授信时回退到节点自有目录，并同步搬运 MCP 载荷
+- 跨厂商兼容矩阵从 4 格补到 13 格（实测 `13/13 → 0/13`）
+- 新增 1.0.5 发现面的 fail-closed 断言：`skills` / `agents` / `plugins` /
+  `marketplaces` / `lspServers` / `externalCompat` / `managedSettings*`
+
+## Verification (pre-publish)
+
+- agent-node 全量 **1330 pass / 0 fail（98 个文件）**
+- 变异测试：Linux 那批 6 条、Windows 那批 5 条，**全部见证红、还原全绿**
+  （其中一条最初存活 ⇒ 说明没有断言在看它 ⇒ 补测试后复验会红）
+- 端到端：Linux `create → start → attach` 全通；Windows `TUI ready + 注册 + SSE connected`
+- 两侧都做了 **hub 日志独立复核**，不只看节点自己的输出


### PR DESCRIPTION
内容是已合入 main 的 #1127（grok 1.0.5 收录）与 #1128（Windows 支持）。
本提交只做两件事：bump 两个包的版本号 + 补发版说明。

PINNED_SERVER_VERSION = "0.9.0-preview.29" 与 npm 上 commhub-server 的 preview
一致，未改动（Gate 2 审的就是这一格）。
anet 拉 agent-node 走的是 @preview 【标签】而非固定版本，所以发布后会被自动取到。

发版说明按 Gate 3 的形状写：同时含 ## Install（新用户 npm install -g）
与 ## Upgrade（老用户 anet upgrade）两段。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>