### PR TITLE
chore(release): @sleep2agi/agent-network 2.3.0-preview.41

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.40",
+  "version": "2.3.0-preview.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.40",
+      "version": "2.3.0-preview.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",
@@ -15,7 +15,7 @@
         "puppeteer-core": "^24.10.2"
       },
       "bin": {
-        "anet": "dist/bin/cli.js"
+        "anet": "dist/bin/anet.cjs"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.40",
+  "version": "2.3.0-preview.41",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.40";
+export const OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.41";
 export const OPENCODE_AGENT_NODE_VERSION = "2.5.0-preview.32";
 export const OPENCODE_AGENT_NODE_SPEC =
   `@sleep2agi/agent-node@${OPENCODE_AGENT_NODE_VERSION}`;


### PR DESCRIPTION
按 `docs/RELEASE-SOP.md` 走的版本同步提交。发 **preview** 通道，不动 latest。

## 这一版带什么

| PR | 内容 |
|---|---|
| #1131 | `anet node start <名字>` 一条命令起 codex 共存 TUI；节点自己的 sandbox 姿态不再被静默丢弃 |
| #1132 | 整套启动 SOP 程序化：CODEX_HOME 状态自动铺（轮换后重铺）、升级提示继承、`就绪` 改成「能接活」而不是「三个 tmux 会话存在」 |
| #1133 | 缺的依赖一次报全并给可执行命令；回环 hub 自启（远端一律不代起） |
| #1134 | 🔴 `anet node start --copresence` 可能**什么都没起还返回 0** —— `waitForTmuxPaneText` 在 pane 还列不出来时放弃轮询，Promise 永不落定，node 以 0 退出。**只要 tmux server 不是热的就命中**，即干净机器上的第一个节点。另修：三处仍按 #766 之前的 OR 预测 bunx 守卫，让 bun-only 机器以为自己齐了 |

## 版本同步

`sync-pinned-versions.sh` dry-run 命中 **1 处**（`OPENCODE_AGENT_NETWORK_VERSION`），apply 后与 `package.json` 一致。

`agent-node` **不动** —— 自 `2.5.0-preview.32` 以来没有任何提交改过它（`git log ab8ac7c6..main -- agent-node/` 零输出）。

## lockfile 里一处顺手修正，单独说明

`package-lock.json` 之前写 `"anet": "dist/bin/cli.js"`，而 `package.json` 和**已发布的 npm 元数据**都是 `dist/bin/anet.cjs`。npm 的 bin 解析读 package.json 不读 lock，所以线上没受影响；`npm install` 把 lock 拉回一致。

## 发版前已跑

```
test750  9 组 / 0 失败      test766  4 pass / 0 fail(两条变异仍能红)
单测     546 pass / 0 fail   CI #1134  93 全绿
门       doc-symbol-pins OK(15/5/10/0) · bun-install-pin OK · coverage OK
```

合并后 `npm publish --tag preview`，然后**在干净容器里按真人路径从零验证一遍**（`npm i -g` → init → create → start），再报结果。