### PR TITLE
fix(anet): anet register / login 失败时不该返回 0 —— 首次安装那串命令会一路走过去

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -10481,14 +10481,20 @@ async function registerCommand() {
       if (h.ok) { hub = "http://127.0.0.1:9200"; gc.hub = hub; saveGlobal(gc); console.log(`[anet] 检测到本地 CommHub: ${hub}`); }
     } catch {}
   }
-  if (!hub) { console.error("未找到 CommHub Server。请先运行: anet hub start"); return; }
+  // 🔴 exit(1), not return. `anet register && anet login && anet node create` is
+  //    the documented first-run chain, and a command that prints an error while
+  //    exiting 0 lets the chain walk straight past the failure. Measured on a
+  //    clean machine with the hub down: register and login both returned 0,
+  //    while init and node create returned 1 — loginCommand even mixed both
+  //    conventions internally (its bad-password path already exits 1).
+  if (!hub) { console.error("未找到 CommHub Server。请先运行: anet hub start"); process.exit(1); }
 
   const username = opts.username || opts.user || await ask("Username");
   const password = opts.password || opts.pass || await ask("Password (min 6)");
   const email = opts.email || ((opts.username || opts.user) ? "" : await ask("Email (optional)"));
   closeRL();
 
-  if (!username || !password) { console.error("Username and password required."); return; }
+  if (!username || !password) { console.error("Username and password required."); process.exit(1); }
 
   // Auto-include server auth token for registration
   const serverToken = serverAuthTokenFromConfig(sc) || getToken();
@@ -10502,7 +10508,7 @@ async function registerCommand() {
       body: JSON.stringify({ username, password, email: email || undefined }),
     }).then(r => r.json() as any);
 
-    if (!res.ok) { console.error(`Registration failed: ${res.error}`); return; }
+    if (!res.ok) { console.error(`Registration failed: ${res.error}`); process.exit(1); }
 
     // Auto-login
     gc.token = res.token;
@@ -10516,7 +10522,7 @@ async function registerCommand() {
     console.log(`[anet] Registered and logged in as ${res.user.username}`);
     if (gc.network_name) console.log(`[anet] Default network: ${gc.network_name}`);
     console.log(`[anet] Token saved to ~/.anet/config.json`);
-  } catch (e: any) { console.error(friendlyError(e)); }
+  } catch (e: any) { console.error(friendlyError(e)); process.exit(1); }
 }
 
 // ── login/logout/whoami ──
@@ -10528,7 +10534,7 @@ async function loginCommand() {
   // don't have to run a separate `anet init` step. If supplied, persist it
   // to gc.hub so subsequent commands work.
   const hub = opts.hub || gc.hub;
-  if (!hub) { console.error("No hub configured. Pass --hub <url> or run 'anet init' first."); return; }
+  if (!hub) { console.error("No hub configured. Pass --hub <url> or run 'anet init' first."); process.exit(1); }
   if (opts.hub && opts.hub !== gc.hub) {
     gc.hub = opts.hub;
     saveGlobal(gc);
@@ -10538,14 +10544,14 @@ async function loginCommand() {
   if (opts.token) {
     try {
       const res = await fetch(`${hub}/api/auth/me`, { headers: { Authorization: `Bearer ${opts.token}` } }).then(r => r.json() as any);
-      if (!res.ok) { console.error(`Invalid token: ${res.error}`); return; }
+      if (!res.ok) { console.error(`Invalid token: ${res.error}`); process.exit(1); }
       gc.token = opts.token;
       gc.user = res.user;
       gc.network_id = res.current_network;
       saveGlobal(gc);
       console.log(`[anet] Logged in as ${res.user.username} (token)`);
       console.log(`[anet] Network: ${res.current_network || "none"}`);
-    } catch (e: any) { console.error(friendlyError(e)); }
+    } catch (e: any) { console.error(friendlyError(e)); process.exit(1); }
     return;
   }
 
@@ -10554,7 +10560,7 @@ async function loginCommand() {
   const password = opts.password || opts.pass || await ask("Password");
   closeRL();
 
-  if (!username || !password) { console.error("Username and password required."); return; }
+  if (!username || !password) { console.error("Username and password required."); process.exit(1); }
 
   let res: any;
   try {
@@ -10567,7 +10573,7 @@ async function loginCommand() {
     // Network / DNS / connection error — show the friendly hint, not the
     // first-time-login guidance (auth-fail guidance below is for 401 only).
     console.error(`❌ Cannot reach hub: ${friendlyError(e)}`);
-    return;
+    process.exit(1);
   }
 
   if (!res?.ok) {
@@ -10652,7 +10658,7 @@ async function loginCommand() {
     if (gc.network_name) console.log(`   network: ${gc.network_name}`);
     console.log(`   token saved to ~/.anet/config.json`);
     console.log(`✅ Login successful — next: anet status / anet node create my-agent`);
-  } catch (e: any) { console.error(friendlyError(e)); }
+  } catch (e: any) { console.error(friendlyError(e)); process.exit(1); }
 }
 
 function logoutCommand() {

--- a/tests/test750-codex-copresence-onecommand/run.sh
+++ b/tests/test750-codex-copresence-onecommand/run.sh
@@ -223,6 +223,28 @@ grep -qF -e 'did not bind' "$WORK/withflag.start" \
   || fail "start failed without naming what did not come up"
 pass "an incomplete start exits non-zero and names the step that failed"
 
+log "[L9] the first-run chain must not walk past its own failures"
+# 🔴 `anet register && anet login && anet node create` is the documented first
+#    run. Measured on a clean machine with no hub reachable: register and login
+#    printed an error and exited 0, while init and node create exited 1 — so a
+#    setup script (or a person checking $?) sails past the first failure and
+#    only learns something is wrong three commands later, at a command that is
+#    not the one that broke.
+#
+#    Uses a hub URL nothing is listening on, so the failure is the connection,
+#    not credentials.
+DEADHUB="http://127.0.0.1:9" 
+for cmd in "register --username x1 --password pass123456" "login --username x1 --password pass123456"; do
+  set +e
+  # shellcheck disable=SC2086
+  $CLI $cmd --hub "$DEADHUB" >"$WORK/firstrun.log" 2>&1
+  rc=$?
+  set -e
+  cat "$WORK/firstrun.log" >>"$REPORT"
+  [ "$rc" -ne 0 ] || fail "anet ${cmd%% *} exited 0 against an unreachable hub — the first-run chain would continue"
+done
+pass "register and login report failure through their exit code"
+
 PASSED=$(grep -c '^PASS: ' "$REPORT" || true)
 FAILED=$(grep -c '^FAIL: ' "$REPORT" || true)
 log "Summary: PASS ($PASSED groups, $FAILED failures; all validation ran inside Docker)"


### PR DESCRIPTION
## 起因

拿**已发布的 preview.41** 在一台干净机器上按文档的首次使用路径走了一遍，而不是在这台什么都齐的机器上。

## 测量（无管道干扰，直接取 rc，hub 连不上）

```
anet login        rc=0   "No hub configured. Pass --hub <url> or run 'anet init' first."
anet register     rc=0   "未找到 CommHub Server。请先运行: anet hub start"
anet init         rc=1   "❌ Cannot reach http://127.0.0.1:9200: fetch failed"
anet node create  rc=1
```

四条里两条**报着错却返回成功**，而那两条恰恰是首次安装脚本会串起来的：

```bash
anet register && anet login && anet node create      # 前两条失败也照走
```

用户于是在**第三条**才看到第一个错误 —— `node create` 说「Not logged in」。这话是真的，但**它不是坏掉的那一环**。我自己的探针就是这么被骗的：login 返回 0，真实失败到 create 才浮出来。

`loginCommand` 内部本来就两种口径并存 —— 密码错那条 `process.exit(1)`，其余全 `return`。现在两个命令的每条错误分支都非零退出。

## 🔴 第一版我修漏了，是新加的 L9 当场抓到的

第一版只改了「**没配 hub**」能到达的分支。而带 `--hub` 指向一个死端口时，控制流走的是函数末尾的

```js
} catch (e: any) { console.error(friendlyError(e)); }     // 没有 return,函数正常结束 ⇒ exit 0
```

**这才是真人走的路径**（hub 配了、但没起）。L9 立刻红：

```
FAIL: anet register exited 0 against an unreachable hub — the first-run chain would continue
```

补完之后我做了一次全分支扫描断言：两个命令里**不再有任何 `console.error` 分支能以 0 退出**。

## 测试

test750 加 L9「首次安装那串命令不得走过自己的失败」，先红后绿。

```
test750  10 组 / 0 失败
单测     546 pass / 0 fail
门       doc-symbol-pins OK(15/5/10/0) · test-file-coverage OK
```

## 相关

这是 #1134 那条「启动失败却返回 0」的同一类 —— **退出码对结果说谎**。#1134 打在共存启动上，这条打在首次安装上。合并后我会重发一版 preview 并**再在干净容器里从零走一遍**。