### PR TITLE
docs(codex): document one-command TUI start and resume

### DIFF
--- a/docs-site/docs/en/guide/codex-copresence.md
+++ b/docs-site/docs/en/guide/codex-copresence.md
@@ -32,7 +32,7 @@ anet --help
 - The recommended one-command path also needs `bash` and **tmux 3.2+**. It currently targets POSIX environments such as Linux/WSL; for native Windows, use the [manual shared-WebSocket path](#native-windows-or-advanced-adoption-manual-shared-websocket).
 - The node must have a network-scoped `ntok_`. Run `anet doctor --fix` for an old node with no token, or recreate it.
 
-## Recommended: first-class `--copresence`
+## Recommended: choose co-presence at creation, then start or resume with one command
 
 ```bash
 # 0. From an external clean shell, enter the project the node should operate on
@@ -42,10 +42,10 @@ cd /path/to/project
 for v in $(env | sed -n 's/^\(COMMHUB_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$v"; done
 
 # 1. Create a preview-runtime node
-anet node create codex-human --runtime codex-app-server
+anet node create codex-human --runtime codex-app-server --copresence
 
 # 2. Start the app-server, bridge, and attachable Codex TUI
-anet node start codex-human --copresence
+anet node start codex-human
 
 # 3. Enter the shared human/agent TUI
 tmux attach -t =codex-human
@@ -53,7 +53,9 @@ tmux attach -t =codex-human
 
 A Codex thread inherits its working directory from the **app-server process cwd**, not the bridge cwd. `cd` into the target project **before** `--copresence`. On Linux, verify with `readlink /proc/<app-server-pid>/cwd`; checking only the bridge is insufficient.
 
-`--copresence` creates three tmux sessions carrying one shared identity marker:
+`create --copresence` records the choice in the node profile. After that, plain `node start` rebuilds the same co-presence topology after a stop or interruption; the flag does not need to be repeated. For an existing node, run `anet node start codex-human --copresence` once and later starts can use the plain command.
+
+Startup creates three tmux sessions carrying one shared identity marker:
 
 | Session | Role |
 |---|---|
@@ -92,7 +94,7 @@ If a bridge has been disconnected for a long time and prints “run `anet node s
 anet node stop codex-human
 cd /path/to/project
 for v in $(env | sed -n 's/^\(COMMHUB_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$v"; done
-anet node start codex-human --copresence
+anet node start codex-human
 ```
 
 This is not theoretical: the production node `TM副责人` ran a silent duplicate for about two days, and `A站副责人` did so for about nine days after operators followed the generic hint ([#535](https://github.com/sleep2agi/agent-network/issues/535)).

--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -64,7 +64,7 @@ Rows tagged `(preview)` below are **preview-only** and not selectable on stable.
 - **Reuse a Claude subscription / smoothest first-time path** → `claude-code-cli` (zero config after `claude auth login`)
 - **Writing copy / translation / analysis (programmatic) / using a domestic Chinese model** → `claude-agent-sdk` + pick the matching vendor in the wizard
 - **Writing code / running commands** → `codex-sdk`
-- **Human and Agent sharing one Codex TUI/thread** → preview `codex-app-server` + `anet node start <alias> --copresence` ([full guide](/en/guide/codex-copresence))
+- **Human and Agent sharing one Codex TUI/thread** → preview `codex-app-server`; pass `--copresence` once at creation, then `anet node start <alias>` starts or resumes it ([full guide](/en/guide/codex-copresence))
 - **Using xAI Grok Build** → `grok-build-acp` ([detailed runtime guide ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md))
 - **Use the public sst/opencode CLI as a multi-vendor front-end (unified session/auth)** → `opencode-cli` (needs the local `opencode` CLI + an Anthropic/OpenAI env key, [RFC-029](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-029-opencode-runtime-integration.md))
 - **Reach a vendor that's NOT in the built-in list** (GLM / Kimi / OpenRouter / vLLM / SiliconFlow / Qwen ...) → `claude-agent-sdk` + pick `custom` in the vendor submenu + `ANTHROPIC_BASE_URL`
@@ -417,12 +417,12 @@ The recommended co-presence entry point is the preview CLI command, not hand-edi
 ```bash
 cd /path/to/project
 for v in $(env | sed -n 's/^\(COMMHUB_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$v"; done
-anet node create codexbridge --runtime codex-app-server
-anet node start codexbridge --copresence
+anet node create codexbridge --runtime codex-app-server --copresence
+anet node start codexbridge
 tmux attach -t =codexbridge
 ```
 
-It orchestrates a dedicated app-server, bridge, and TUI together and defaults to read-only. See [Codex TUI Co-presence](/en/guide/codex-copresence) for permissions, recovery, stop behavior, and the native-Windows manual WebSocket path.
+The create-time choice is remembered. Plain `start` then orchestrates a dedicated app-server, bridge, and TUI together—including recovery after interruption—and defaults to read-only. See [Codex TUI Co-presence](/en/guide/codex-copresence) for permissions, recovery, stop behavior, and the native-Windows manual WebSocket path.
 
 **① Owned (default)** — the node spawns its own app-server and creates a fresh thread. Multiple codex-app-server nodes are fully independent:
 

--- a/docs-site/docs/guide/codex-copresence.md
+++ b/docs-site/docs/guide/codex-copresence.md
@@ -32,7 +32,7 @@ anet --help
 - 推荐的一键共存路径还需要 `bash` 和 **tmux 3.2+**。当前以 Linux/WSL 等 POSIX 环境为目标；原生 Windows 请用下方的[手工共享 WS 路径](#原生-windows-或高级接管手工共享-ws)。
 - 节点必须持有 network-scoped `ntok_`。旧节点缺 token 时先运行 `anet doctor --fix`，或重新创建节点。
 
-## 推荐：一等 `--copresence` 路径
+## 推荐：创建时选定共存，之后一键启动/恢复
 
 ```bash
 # 0. 在外部干净 shell 中进入节点要操作的项目
@@ -42,10 +42,10 @@ cd /path/to/project
 for v in $(env | sed -n 's/^\(COMMHUB_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$v"; done
 
 # 1. 创建 preview runtime 节点
-anet node create codex-human --runtime codex-app-server
+anet node create codex-human --runtime codex-app-server --copresence
 
 # 2. 一键启动 app-server、bridge 和可 attach 的 Codex TUI
-anet node start codex-human --copresence
+anet node start codex-human
 
 # 3. 进入人机共用的 TUI
 tmux attach -t =codex-human
@@ -53,7 +53,9 @@ tmux attach -t =codex-human
 
 Codex thread 的工作目录继承自 **app-server 进程启动时的 cwd**，不是 bridge 的 cwd；因此要在运行 `--copresence` **之前**先 `cd` 到目标项目。Linux 上可用 `readlink /proc/<app-server-pid>/cwd` 复核，不能只检查 bridge。
 
-`--copresence` 会创建三个带同一身份标记的 tmux session：
+`create --copresence` 会把选择写入节点配置；此后普通 `node start`（包括停止或中断后的恢复）都会重建同一套共存拓扑，无需重复 flag。旧节点也可第一次运行 `anet node start codex-human --copresence`，CLI 会记住选择，后续同样只需 `anet node start codex-human`。
+
+启动会创建三个带同一身份标记的 tmux session：
 
 | Session | 作用 |
 |---|---|
@@ -91,7 +93,7 @@ anet node stop codex-human
 anet node stop codex-human
 cd /path/to/project
 for v in $(env | sed -n 's/^\(COMMHUB_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$v"; done
-anet node start codex-human --copresence
+anet node start codex-human
 ```
 
 这不是理论风险：生产节点 `TM副责人` 因此静默重复运行约 2 天，`A站副责人` 则持续约 9 天（[#535](https://github.com/sleep2agi/agent-network/issues/535)）。

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -64,7 +64,7 @@
 - **想白嫖 Claude 订阅 / 新手最省事** → `claude-code-cli` (`claude auth login` 后 0 配置)
 - **写文案 / 翻译 / 分析 (编程式) / 接国产模型** → `claude-agent-sdk` + 在 wizard 里选对应 vendor
 - **写代码 / 跑命令** → `codex-sdk`
-- **人和 Agent 共用一个 Codex TUI/thread** → preview `codex-app-server` + `anet node start <alias> --copresence`（[完整指南](/guide/codex-copresence)）
+- **人和 Agent 共用一个 Codex TUI/thread** → preview `codex-app-server`；创建时加一次 `--copresence`，之后 `anet node start <alias>` 即可启动或恢复（[完整指南](/guide/codex-copresence)）
 - **用 xAI Grok Build** → `grok-build-acp` ([详细 runtime 指南 ↗](https://github.com/sleep2agi/agent-network/blob/main/docs/grok-build-runtime.md))
 - **想用公版 sst/opencode CLI 当多 vendor 前端（统一 session/auth）** → `opencode-cli`（需本机装 `opencode` CLI + Anthropic/OpenAI env key，[RFC-029](https://github.com/sleep2agi/agent-network/blob/main/docs/rfcs/RFC-029-opencode-runtime-integration.md)）
 - **接国产 / 非内置 vendor** (GLM / Kimi / OpenRouter / vLLM / SiliconFlow / 通义千问 等) → `claude-agent-sdk` + 在 vendor 子菜单选 `自定义 (custom)` + `ANTHROPIC_BASE_URL`
@@ -437,12 +437,12 @@ anet node start  →  spawn agent-node 子进程（runtime=codex-app-server）
 ```bash
 cd /path/to/project
 for v in $(env | sed -n 's/^\(COMMHUB_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$v"; done
-anet node create codexbridge --runtime codex-app-server
-anet node start codexbridge --copresence
+anet node create codexbridge --runtime codex-app-server --copresence
+anet node start codexbridge
 tmux attach -t =codexbridge
 ```
 
-它统一编排独立 app-server、bridge 与 TUI，默认只读。完整权限、恢复、停止与原生 Windows 手工 WS 步骤见 [Codex TUI 人机共存](/guide/codex-copresence)。
+创建时的 `--copresence` 会被记住；之后普通 `start`（含中断后的恢复）统一编排独立 app-server、bridge 与 TUI，默认只读。完整权限、恢复、停止与原生 Windows 手工 WS 步骤见 [Codex TUI 人机共存](/guide/codex-copresence)。
 
 **① 独占（默认）** —— 节点自己起 app-server + 新建 thread。多个 codex-app-server 节点互不干扰：
 

--- a/docs/tests/report-test750.txt
+++ b/docs/tests/report-test750.txt
@@ -1,0 +1,20 @@
+# test750 — Codex TUI one-command create/start/resume journey
+
+Date: 2026-08-21 (Asia/Shanghai)
+Source: 0efa63a6
+Environment: isolated Docker container; no host Codex or anet state mounted
+
+Command:
+
+    sg docker -c 'docker build -t anet-test750 -f tests/test750-codex-copresence-onecommand/Dockerfile . && docker run --rm anet-test750'
+
+Result: PASS — 6 groups, 0 failures.
+
+- L0 isolated environment: PASS
+- L1 profile and preflight decisions: PASS (38 assertions)
+- L2 create persists the co-presence choice: PASS
+- L3 plain `anet node start <name>` routes a recorded node to the TUI stack: PASS
+- L4 one-off `--copresence` remains compatible and is remembered: PASS
+- L5 read-only default and explicitly remembered full-access posture: PASS
+
+The resume behavior uses the same plain `node start` path after stop/interruption; the persisted `codexCopresence` profile field selects the co-presence stack without requiring the flag again.


### PR DESCRIPTION
## Summary

- document create-time `--copresence` persistence
- show plain `anet node start <alias>` for later starts and recovery
- synchronize Chinese and English Codex/runtime guides
- record Docker test750 evidence

## Verification

- test750: PASS (6 groups, 38 decision assertions, 0 failures)
- VitePress production build in Docker: PASS
