### PR TITLE
docs(codex): state interactive picker release boundary

### DIFF
--- a/docs-site/docs/en/guide/codex-copresence.md
+++ b/docs-site/docs/en/guide/codex-copresence.md
@@ -57,6 +57,10 @@ A Codex thread inherits its working directory from the **app-server process cwd*
 
 `codex-cli` in the interactive runtime menu means co-presence mode: selecting it writes `codexCopresence: true` immediately, with no second question. `codex-sdk` is the headless Codex worker. Scripts can use the equivalent `anet node create codex-human --runtime codex-cli`; the older `--runtime codex-app-server --copresence` form remains compatible.
 
+::: warning Release channel
+This interactive choice has passed a real PTY test on `main` and will ship in **preview.42 or later**. The current npm `2.3.0-preview.41` does not yet include the `codex-cli` alias; on that version, use `anet node create codex-human --runtime codex-app-server --copresence` for now.
+:::
+
 Startup creates three tmux sessions carrying one shared identity marker:
 
 | Session | Role |

--- a/docs-site/docs/guide/codex-copresence.md
+++ b/docs-site/docs/guide/codex-copresence.md
@@ -57,6 +57,10 @@ Codex thread 的工作目录继承自 **app-server 进程启动时的 cwd**，�
 
 交互菜单里的 `codex-cli` 就是共存模式：选中后直接写入 `codexCopresence: true`，不再要求第二次选择。`codex-sdk` 是后台无头 Codex 节点。脚本可使用等价命令 `anet node create codex-human --runtime codex-cli`；旧的 `--runtime codex-app-server --copresence` 继续兼容。
 
+::: warning 发布渠道
+这个交互选项已在 `main` 通过真实 PTY 测试，将随 **preview.42 或更高版本**发布。当前 npm `2.3.0-preview.41` 尚未包含 `codex-cli` 别名；该版本请暂用 `anet node create codex-human --runtime codex-app-server --copresence`。
+:::
+
 启动会创建三个带同一身份标记的 tmux session：
 
 | Session | 作用 |


### PR DESCRIPTION
Clarifies that the tested interactive `codex-cli` picker is on main and will ship in preview.42+, while current preview.41 users must use the compatible legacy command. Docker VitePress build passes.