### PR TITLE
chore(release): @sleep2agi/agent-network 2.3.0-preview.42

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.41",
+  "version": "2.3.0-preview.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.41",
+      "version": "2.3.0-preview.42",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.41",
+  "version": "2.3.0-preview.42",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.41";
+export const OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.42";
 export const OPENCODE_AGENT_NODE_VERSION = "2.5.0-preview.32";
 export const OPENCODE_AGENT_NODE_SPEC =
   `@sleep2agi/agent-node@${OPENCODE_AGENT_NODE_VERSION}`;

--- a/docs-site/docs/en/guide/codex-copresence.md
+++ b/docs-site/docs/en/guide/codex-copresence.md
@@ -58,7 +58,7 @@ A Codex thread inherits its working directory from the **app-server process cwd*
 `codex-cli` in the interactive runtime menu means co-presence mode: selecting it writes `codexCopresence: true` immediately, with no second question. `codex-sdk` is the headless Codex worker. Scripts can use the equivalent `anet node create codex-human --runtime codex-cli`; the older `--runtime codex-app-server --copresence` form remains compatible.
 
 ::: warning Release channel
-This interactive choice has passed a real PTY test on `main` and will ship in **preview.42 or later**. The current npm `2.3.0-preview.41` does not yet include the `codex-cli` alias; on that version, use `anet node create codex-human --runtime codex-app-server --copresence` for now.
+This interactive choice has passed a real PTY test on `main` and ships in **preview.42**. After installing or upgrading to preview, you can select `codex-cli` directly from the interactive menu.
 :::
 
 Startup creates three tmux sessions carrying one shared identity marker:

--- a/docs-site/docs/guide/codex-copresence.md
+++ b/docs-site/docs/guide/codex-copresence.md
@@ -58,7 +58,7 @@ Codex thread 的工作目录继承自 **app-server 进程启动时的 cwd**，�
 交互菜单里的 `codex-cli` 就是共存模式：选中后直接写入 `codexCopresence: true`，不再要求第二次选择。`codex-sdk` 是后台无头 Codex 节点。脚本可使用等价命令 `anet node create codex-human --runtime codex-cli`；旧的 `--runtime codex-app-server --copresence` 继续兼容。
 
 ::: warning 发布渠道
-这个交互选项已在 `main` 通过真实 PTY 测试，将随 **preview.42 或更高版本**发布。当前 npm `2.3.0-preview.41` 尚未包含 `codex-cli` 别名；该版本请暂用 `anet node create codex-human --runtime codex-app-server --copresence`。
+这个交互选项已在 `main` 通过真实 PTY 测试，并已随 **preview.42** 发布。安装或升级 preview 后，即可在交互菜单中直接选择 `codex-cli`。
 :::
 
 启动会创建三个带同一身份标记的 tmux session：

--- a/docs/tests/release-v2.3.0-preview.42.md
+++ b/docs/tests/release-v2.3.0-preview.42.md
@@ -1,0 +1,39 @@
+# @sleep2agi/agent-network 2.3.0-preview.42 — release notes
+
+本版把 Codex 共存模式直接放进 `anet node create` 的交互式 runtime 菜单。
+`codex-cli` **不是默认选项**；用户主动选择它时，会直接记录共存模式，不再出现第二次模式询问。
+`codex-sdk` 仍是后台无头运行时。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.42
+```
+
+## Upgrade
+
+```bash
+anet upgrade
+# 或仅升级 preview CLI
+npm install -g @sleep2agi/agent-network@preview
+```
+
+## 交互行为
+
+```bash
+anet node create codex-human
+# 在 runtime 菜单中主动选择：codex-cli — Codex 共存 TUI
+anet node start codex-human
+```
+
+- 选择 `codex-cli` 会自动写入 `codexCopresence: true`。
+- 不会把 `codex-cli` 设为默认项。
+- 不会再额外询问 headless / co-presence 模式。
+- 显式命令 `--runtime codex-cli` 行为相同。
+- 旧命令 `--runtime codex-app-server --copresence` 保持兼容。
+
+## Verification (pre-publish)
+
+- `test750`：Docker 内真实 PTY 发送方向键和 Enter，验证交互菜单选择、配置落盘和普通 `node start` 路由；**10 groups / 80 assertions / 0 failures**。
+- `agent-network` typecheck/build：Docker 内通过。
+- `npm pack`：Docker 内成功生成 `@sleep2agi/agent-network@2.3.0-preview.42` tarball；发布前还会从合并后的精确 `origin/main` 重新打包并安装烟测。


### PR DESCRIPTION
Ships the interactive Codex co-presence picker from #1139. Choosing codex-cli explicitly enables co-presence; it is not the default and there is no second mode prompt.\n\nDocker verification: test750 10 groups / 80 assertions / 0 failures; agent-network typecheck, build, and npm pack passed.\n\nPublishes agent-network only to the preview tag; latest is unchanged.