### PR TITLE
fix(channel): 入站消息带上 created_at,并写明 task_id 装的是 inbox 行 id

### DIFF
--- a/agent-network/src/channel-meta.ts
+++ b/agent-network/src/channel-meta.ts
@@ -1,0 +1,35 @@
+// Pure: one inbound inbox row → the meta Claude Code renders as `<channel …>`
+// attributes. Split out of node-server.ts because importing that module boots
+// an SSE listener and registers against the live Hub — a test that reaches for
+// this function must not do that.
+/** One inbound inbox row → the meta Claude Code renders as `<channel …>` attrs.
+ *
+ * Pure so the attribute set is assertable; it used to be inline in the SSE
+ * handler, where nothing could see it. */
+export function inboundChannelMeta(msg: {
+  id: string;
+  from_session?: string | null;
+  priority?: string | null;
+  created_at?: string | null;
+}): Record<string, string> {
+  return {
+    sender: msg.from_session || "hub",
+    sender_id: "commhub",
+    user: msg.from_session || "hub", // Claude Code 用 meta.user 显示 "commhub · {user}"
+    // NOTE: this carries the inbox ROW id (get_inbox's `id`), not the logical
+    // `tasks.task_id` the name suggests. That distinction is the only thing
+    // separating a Hub re-queue from a node re-read: retry_task inserts a NEW
+    // inbox row (fresh uuid) carrying the SAME logical task_id, so this value
+    // CHANGES on a Hub re-queue and stays identical when the node re-fetches
+    // one still-unacked row. Renaming would break send_reply routing
+    // (taskOriginators and ack_inbox are both keyed on msg.id) — document it.
+    task_id: msg.id,
+    priority: msg.priority || "normal",
+    // Hub already returns created_at from get_inbox; it was fetched and then
+    // dropped here. Without it a 30-hour-old unacked row and a message sent one
+    // second ago read identically on arrival, so a delayed re-read is invisible
+    // from the receiving side. The telegram channel on this same surface has
+    // carried `ts` all along.
+    ts: String(msg.created_at ?? ""),
+  };
+}

--- a/agent-network/src/node-server-channel-meta.test.ts
+++ b/agent-network/src/node-server-channel-meta.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { inboundChannelMeta } from "./channel-meta.js";
+
+// The row shape get_inbox actually returns (commhub-server 0.9.0-preview.29,
+// tools.ts: SELECT id, type, priority, content, context, from_session,
+// created_at, network_id, meta_json, … FROM inbox WHERE acked = 0).
+const row = {
+  id: "f34a68a5-4506-4c3c-95d2-6484e9798a23",
+  from_session: "TMCode负责人",
+  priority: "high",
+  created_at: "2026-08-19 19:45:13",
+};
+
+describe("inbound channel meta", () => {
+  test("carries the Hub-side creation time", () => {
+    // Without this the receiver cannot tell a 30-hour-old unacked row from a
+    // message sent one second ago: both arrive with the same attribute set.
+    expect(inboundChannelMeta(row).ts).toBe("2026-08-19 19:45:13");
+  });
+
+  test("task_id carries the inbox ROW id, which is what discriminates re-queue from re-read", () => {
+    // retry_task inserts a new inbox row (fresh uuid, same logical task_id), so
+    // a Hub re-queue changes this value while a node re-read does not. A row
+    // that also carried a differing logical task_id must not shadow it.
+    expect(inboundChannelMeta({ ...row, task_id: "some-logical-task-id" } as any).task_id)
+      .toBe("f34a68a5-4506-4c3c-95d2-6484e9798a23");
+  });
+
+  test("a row with no created_at degrades to empty, never to the string 'undefined'", () => {
+    // "undefined" would render as a plausible-looking attribute value and be
+    // parsed as a real timestamp by anything downstream.
+    expect(inboundChannelMeta({ id: "x" }).ts).toBe("");
+  });
+
+  test("keeps the attributes send_reply routing already depends on", () => {
+    const m = inboundChannelMeta(row);
+    expect(m.sender).toBe("TMCode负责人");
+    expect(m.sender_id).toBe("commhub");
+    expect(m.user).toBe("TMCode负责人");
+    expect(m.priority).toBe("high");
+  });
+});

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -12,6 +12,7 @@
  *   COMMHUB_URL, COMMHUB_TOKEN
  */
 
+import { inboundChannelMeta } from "./channel-meta.js";
 import { readFileSync, existsSync } from "fs";
 import { OUTBOUND_TOOL_NAMES } from "./outbound-tool-names";
 import { randomUUID } from "crypto";
@@ -33,6 +34,8 @@ import {
 import { sendChannelTaskWithTrace } from "./channel-task-trace";
 
 // ── .env loader helper ────────────────────────────────
+
+
 function loadEnvFile(path: string): void {
   if (!existsSync(path)) return;
   for (const line of readFileSync(path, "utf-8").split("\n")) {
@@ -171,7 +174,8 @@ const mcp = new Server(
           `Use commhub_send_task for peer results; commhub_send_message is non-lifecycle chat.`,
         ].join("\n")
       : [
-          `Messages from CommHub arrive as <channel source="commhub" task_id="..." priority="..." from="...">`,
+          `Messages from CommHub arrive as <channel source="commhub" sender="..." task_id="..." priority="..." ts="...">`,
+          `  task_id is the inbox row id (changes when the Hub re-queues, identical when the node re-reads); ts is the Hub-side creation time.`,
           `These are tasks dispatched by the hub or other sessions via the CommHub Server.`,
           `Reply routing (IMPORTANT — the tool you pick determines whether the receiver actually gets woken up):`,
           `  • If the sender is another agent node, replying takes TWO actions — send_task wakes them but does NOT close the task you were sent:`,
@@ -592,13 +596,7 @@ async function handleSSEEvent(event: any) {
           // cache/fetch implementation hits an unexpected host error.
           log(`attachment resolver failed unexpectedly; preserving text-only task: ${error instanceof Error ? error.message : String(error)}`);
         }
-        const meta: Record<string, string> = {
-          sender: msg.from_session || "hub",
-          sender_id: "commhub",
-          user: msg.from_session || "hub", // Claude Code 用 meta.user 显示 "commhub · {user}"
-          task_id: msg.id,
-          priority: msg.priority || "normal",
-        };
+        const meta = inboundChannelMeta(msg);
         // V2: remember who sent this task so send_reply knows the target
         taskOriginators.set(msg.id, msg.from_session || "hub");
 


### PR DESCRIPTION
## 起因
`TMCode负责人` 拿到一个带硬时刻的样本:一条 `2026-08-19T19:45:13Z` 发出的消息,在收件方 `2026-08-21` 的会话里到达,且到达 2 次(≈29.5h 延迟 + 重复 1 次)。

## 两件事,同一处修

**① `created_at` 被取到手又丢掉。** hub 的 `get_inbox` 返回里含 `created_at`(生产 commhub-server 0.9.0-preview.29,`tools.ts:888`),`node-server.ts` 构造 meta 时没抄。后果不是"不方便":收件方那侧,**一条挂了 30 小时的未 ack 行和一秒前刚发的消息,到达时属性集完全相同**,延迟与重复只能靠发件方留台账才发现。同一渲染面上 telegram 一路一直在透 `ts`(实测 9288/9289),commhub 一路 0/13482 —— 这不是"渲染层拿不到上游字段"。

**② `task_id` 装的不是 task_id。** meta 里 `task_id: msg.id` 用的是 **inbox 行 id**(`SELECT id FROM inbox`),不是 `tasks.task_id`;`msg.task_id` 在整个文件里从未被使用。而这正是唯一能分开两种成因的量:

| | inbox 行 id | 逻辑 task_id |
|---|---|---|
| hub 重新入队(`retry_task`,`tools.ts:1861` 插 `uuidv4()` 新行) | **变** | 不变 |
| 节点重读同一未 ack 行 | 不变 | 不变 |

三个 agent(含我)都把它读成逻辑 task_id,并据此判定"收件方手上的量鉴别力为 0"——**实际上鉴别力是满的**。改名会打断 `send_reply` 路由(`taskOriginators` 与 `ack_inbox` 都以 `msg.id` 为键),所以写注释不改名。

## 顺带
MCP 说明串写的属性集是 `from="..."`,而代码从来没发过 `from`(发的是 `sender`/`sender_id`/`user`)。说明串是 agent 唯一会读的那份。

## 为什么抽成纯函数
meta 构造原先埋在 SSE handler 里,**没有东西看得见它**。而直接 `import` `node-server.ts` 会启动 SSE 监听器并以本节点身份注册到线上 hub(我第一版测试实测:hub 上多出一个 SSE 客户端并 `report offline`)。所以拆到 `channel-meta.ts`,测试不碰入口。

## 见证红(双向)
```
删掉 ts                    ⇒ 2 pass 2 fail
task_id 改读逻辑 task_id    ⇒ 3 pass 1 fail
去掉 ?? "" 兜底             ⇒ 3 pass 1 fail   (否则渲染出 ts="undefined")
基线 / 还原                 ⇒ 4 pass 0 fail   (还原后与备份逐字相同)
tsc --noEmit               ⇒ 干净
```

## 界限
- **没有**碰生产 DB,没有跑那条 `SELECT`。判定「节点重读」靠的是:`get_inbox` 无副作用(`WHERE acked = 0`,取完不标记)+ `retry_task` 全日志 26 次最后一次 `2026-08-14` + 收件方消费节奏(08-19 84 次 → 08-20 5 次)+ 上面那张表。
- 这个 PR **不**改投递语义,只补属性与注释。重复投递本身(两条流/两个同名进程各取一次)没修,那是另一件事。

🤖 Generated with [Claude Code](https://claude.com/claude-code)