### PR TITLE
chore(release): @sleep2agi/agent-network 2.3.0-preview.43

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.42",
+  "version": "2.3.0-preview.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.42",
+      "version": "2.3.0-preview.43",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.42",
+  "version": "2.3.0-preview.43",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.42";
+export const OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.43";
 export const OPENCODE_AGENT_NODE_VERSION = "2.5.0-preview.32";
 export const OPENCODE_AGENT_NODE_SPEC =
   `@sleep2agi/agent-node@${OPENCODE_AGENT_NODE_VERSION}`;

--- a/docs/tests/release-v2.3.0-preview.43.md
+++ b/docs/tests/release-v2.3.0-preview.43.md
@@ -1,0 +1,37 @@
+# @sleep2agi/agent-network 2.3.0-preview.43 — release notes
+
+This preview adds native Windows support for the interactive Codex co-presence
+workflow. `codex-cli` remains a non-default picker choice and starts the Codex
+TUI alongside Agent Network. Restarting the node resumes its existing Codex
+thread instead of creating a replacement node or conversation.
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.43
+anet node create
+```
+
+Choose `codex-cli — Codex 共存 TUI` in the interactive runtime picker, then use
+`anet node start <name>`. Windows uses its native console/ConPTY path and does
+not require tmux; Linux and macOS retain the tmux path.
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.43
+anet node stop <name>
+anet node start <name>
+```
+
+The restart reuses the node's stored `codexThreadId`. Existing `atok_` tokens
+remain supported.
+
+## Verification
+
+- Native Windows ConPTY E2E: interactive create and `codex-cli` selection,
+  start/TUI/stop, then restart/TUI/stop; exactly one `thread/start` and one
+  `thread/resume`, both TUI launches on the same thread.
+- Linux Docker E2E: one-command interactive picker and co-presence flow passed.
+- Legacy `atok_` authentication, unit, security, docs, and complete repository
+  QA gates passed before merge.


### PR DESCRIPTION
## Summary
- publish native Windows Codex co-presence support as preview.43
- synchronize the pinned agent-network version
- add exact install and upgrade release notes

## Verification
- Docker test750: 10 groups, 0 failures
- Docker test751 portable Windows logic: 14 pass, 0 fail
- Docker typecheck and production build
- npm pack and clean Node 22 container install with real TTY version smoke
- feature PR #1143 full CI green, including native Windows ConPTY create/start/restart/resume E2E

This release remains on the `preview` dist-tag; it does not promote `latest`.