### PR TITLE
fix(release): repair preview.43 gate and docs claims

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
             node:24-slim bash -c '
               set -euo pipefail
               apt-get update -qq && apt-get install -y --no-install-recommends \
-                bash curl ca-certificates jq expect util-linux procps > /dev/null
+                bash curl ca-certificates jq expect util-linux procps unzip > /dev/null
               rm -rf /var/lib/apt/lists/*
 
               # bun is required by anet hub start (commhub-server is bun-only)
@@ -392,7 +392,11 @@ jobs:
           # Spot-check that Install section actually contains the gated version
           # — catches stale notes where someone copied an old file but forgot
           # to bump the version inside.
-          install_block=$(echo "$notes_body" | awk '/^## Install/,/^## /' | head -50)
+          install_block=$(echo "$notes_body" | awk '
+            found && /^## / { exit }
+            /^## Install$/ { found=1 }
+            found { print }
+          ' | head -50)
           echo "$install_block" | grep -qE "@$GATED_VER\b" \
             || { echo "::error::'## Install' section in $src does not mention @$GATED_VER"; exit 1; }
 

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.40 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.43 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -95,7 +95,7 @@ The first `anet hub start` prints the admin credentials once:
 | channel | printed password |
 |---|---|
 | `latest` = `2.2.21` | the fixed string `anethub` |
-| `preview` = `2.3.0-preview.40` | a **random** string like `anet-232412de5bb54c058cff32`, with a change-on-first-login notice |
+| `preview` = `2.3.0-preview.43` | a **random** string like `anet-232412de5bb54c058cff32`, with a change-on-first-login notice |
 
 So the `anethub` below **only holds on stable**. **Anyone who copies this page instead of reading their own startup output will fail to log in on preview.**
 The credentials are also written to `~/.anet/server/admin-utok.json`.
@@ -131,7 +131,7 @@ On stable, `anet node create` lists **4 production runtimes** (`claude-agent-sdk
 Start the node:
 
 ::: warning Fresh install + claude-agent-sdk / codex-sdk? Install agent-node first
-These runtimes depend on the `agent-node` package. The first `node start` triggers an npx auto-fetch that takes ~1 minute, but on **stable `@latest` (currently `2.2.21`) and preview `≤ 2.3.0-preview.37`** the startup check **doesn't wait for it** and exits with `agent-node is not installed or cannot report a version` (reproduced on real hardware — [#450](https://github.com/sleep2agi/agent-network/issues/450) is the precise filing, #237 is the umbrella). **Root fix** is [PR #239](https://github.com/sleep2agi/agent-network/pull/239) (commit `1eff3a4d`, merged 2026-06-28); Vincent's 2026-08-09 audit verified the fix in an isolated Docker probe on `2.3.0-preview.38` reaching SSE connected. **The current `@preview` (`2.3.0-preview.40`) contains this fix; `@latest` does not** — [#450](https://github.com/sleep2agi/agent-network/issues/450) is still `open` pending 4 acceptance gates before latest promotion. **Workarounds** (in verified-strength order): upgrade to `@sleep2agi/agent-network@preview`; or stay on `@latest` but pre-install `agent-node` so the binary is already there:
+These runtimes depend on the `agent-node` package. The first `node start` triggers an npx auto-fetch that takes ~1 minute, but on **stable `@latest` (currently `2.2.21`) and preview `≤ 2.3.0-preview.37`** the startup check **doesn't wait for it** and exits with `agent-node is not installed or cannot report a version` (reproduced on real hardware — [#450](https://github.com/sleep2agi/agent-network/issues/450) is the precise filing, #237 is the umbrella). **Root fix** is [PR #239](https://github.com/sleep2agi/agent-network/pull/239) (commit `1eff3a4d`, merged 2026-06-28); Vincent's 2026-08-09 audit verified the fix in an isolated Docker probe on `2.3.0-preview.38` reaching SSE connected. **The current `@preview` (`2.3.0-preview.43`) contains this fix; `@latest` does not** — [#450](https://github.com/sleep2agi/agent-network/issues/450) is still `open` pending 4 acceptance gates before latest promotion. **Workarounds** (in verified-strength order): upgrade to `@sleep2agi/agent-network@preview`; or stay on `@latest` but pre-install `agent-node` so the binary is already there:
 
 ```bash
 npm install -g @sleep2agi/agent-node

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.40 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.43 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -94,7 +94,7 @@ anet hub dashboard
 | 通道 | 打印出来的密码 |
 |---|---|
 | `latest` = `2.2.21` | 固定的 `anethub` |
-| `preview` = `2.3.0-preview.40` | **随机串**,形如 `anet-232412de5bb54c058cff32`,并提示首次登录后要改 |
+| `preview` = `2.3.0-preview.43` | **随机串**,形如 `anet-232412de5bb54c058cff32`,并提示首次登录后要改 |
 
 所以下面命令里的 `anethub` **只在 stable 上成立**。**照抄这一页而不看自己那次启动输出的人,在 preview 上一定登不进去。**
 凭据也落在 `~/.anet/server/admin-utok.json`。
@@ -130,7 +130,7 @@ stable 版 `anet node create` 列出正式版的 runtime（`claude-agent-sdk` / 
 启动节点：
 
 ::: warning 全新安装选了 claude-agent-sdk / codex-sdk？先装 agent-node
-这两个 runtime 依赖 `agent-node` 包。首次 `node start` 的 npx 自动拉取需要约 1 分钟，而 **stable `@latest`（当前 `2.2.21`）与 preview `≤ 2.3.0-preview.37`** 的启动检查**不等它拉完**就报 `agent-node is not installed or cannot report a version` 退出（真机复现，[#450](https://github.com/sleep2agi/agent-network/issues/450) 精确立案，#237 为同族）。**根因修复**见 [PR #239](https://github.com/sleep2agi/agent-network/pull/239)（commit `1eff3a4d`, merged 2026-06-28），Vincent 2026-08-09 audit 在 `2.3.0-preview.38` 隔离 Docker 里 verified 抵达 SSE connected；**当前 `@preview` (`2.3.0-preview.40`) 已含此 fix，`@latest` 未含** —— [#450](https://github.com/sleep2agi/agent-network/issues/450) 仍 `open`，因 promote 到 latest 待 4 项 acceptance gate 真绿。**变通**（按 verified 强度）：升到 `@sleep2agi/agent-network@preview`；或用 `@latest` 但先跑一句让二进制预先就位：
+这两个 runtime 依赖 `agent-node` 包。首次 `node start` 的 npx 自动拉取需要约 1 分钟，而 **stable `@latest`（当前 `2.2.21`）与 preview `≤ 2.3.0-preview.37`** 的启动检查**不等它拉完**就报 `agent-node is not installed or cannot report a version` 退出（真机复现，[#450](https://github.com/sleep2agi/agent-network/issues/450) 精确立案，#237 为同族）。**根因修复**见 [PR #239](https://github.com/sleep2agi/agent-network/pull/239)（commit `1eff3a4d`, merged 2026-06-28），Vincent 2026-08-09 audit 在 `2.3.0-preview.38` 隔离 Docker 里 verified 抵达 SSE connected；**当前 `@preview` (`2.3.0-preview.43`) 已含此 fix，`@latest` 未含** —— [#450](https://github.com/sleep2agi/agent-network/issues/450) 仍 `open`，因 promote 到 latest 待 4 项 acceptance gate 真绿。**变通**（按 verified 强度）：升到 `@sleep2agi/agent-network@preview`；或用 `@latest` 但先跑一句让二进制预先就位：
 
 ```bash
 npm install -g @sleep2agi/agent-node


### PR DESCRIPTION
## Summary
- install `unzip` before bootstrapping Bun in the clean release smoke image
- extract the Install section without terminating on its own heading
- update bilingual getting-started preview claims to the published `.43`

## Verification
- `check-doc-version-claims.py --selftest`
- exact preview.43 doc-claim check
- Gate 3 Install-block extraction and exact-version assertion
- release workflow YAML parse

Follow-up to the report-only gate after publishing `@sleep2agi/agent-network@2.3.0-preview.43`; npm `preview` is already `.43`, while `latest` remains unchanged.