### PR TITLE
fix(release): parse anet version contract line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,10 @@ jobs:
                 || { echo "::error::npm install -g failed"; cat /tmp/install.log; exit 1; }
 
               # case 1 — version matches tag
-              ver=$(anet --version | tr -d "v\n ")
+              # `anet --version` intentionally prints a first-line version plus
+              # component diagnostics. Parse only that contract line; flattening
+              # the whole output also deleted every letter "v" from prereleases.
+              ver=$(anet --version | sed -n '1{s/^anet v//;p;q;}')
               echo "anet --version → $ver (expected $GATED_VER)"
               [ "$ver" = "$GATED_VER" ] \
                 || { echo "::error::version mismatch — anet says $ver, gating $GATED_VER"; exit 1; }


### PR DESCRIPTION
The release smoke flattened all multi-line `anet --version` diagnostics and deleted every letter `v`, so it rejected the correct preview version. Parse only the first `anet v...` contract line.

Verified with the real multi-line output shape and YAML parsing. Follow-up to #1145 and the preview.43 report-only gate.