### PR TITLE
fix(release): preserve outer smoke quoting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
               # `anet --version` intentionally prints a first-line version plus
               # component diagnostics. Parse only that contract line; flattening
               # the whole output also deleted every letter "v" from prereleases.
-              ver=$(anet --version | sed -n '1{s/^anet v//;p;q;}')
+              ver=$(anet --version | sed -n "1{s/^anet v//;p;q;}")
               echo "anet --version → $ver (expected $GATED_VER)"
               [ "$ver" = "$GATED_VER" ] \
                 || { echo "::error::version mismatch — anet says $ver, gating $GATED_VER"; exit 1; }


### PR DESCRIPTION
Use a double-quoted sed program inside the release smoke outer single-quoted `bash -c` body. Verified by replaying the complete outer quoting shape against multi-line `anet --version` output and parsing the workflow YAML.