### PR TITLE
fix(channel): 插件侧同一行 JSON.parse 仍在销毁真错误 —— #1102 只修了两份中的一份

### DIFF
--- a/agent-network/src/channel-plugin-error-masking.test.ts
+++ b/agent-network/src/channel-plugin-error-masking.test.ts
@@ -1,8 +1,12 @@
+// 🔴 这个文件测的是 channel/ 里的东西,却放在 agent-network/src/ 下 —— 是故意的。
+// check-test-file-coverage 这道门抓到:channel/ 不在任何聚合门的扫描范围里,
+// 放在那边的测试「加了也不会有人跑」。而本文件四条断言里三条本来就是按路径读
+// 文件,不依赖所在包,所以挪进被覆盖的根是等价的 —— 且从此真的会被 CI 跑到。
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
 import { parseCommhubToolResult } from "./commhub-response.js";
 
-describe("channel plugin: commhub response parsing", () => {
+describe("channel plugin (channel/commhub-channel.ts) error masking", () => {
   test("an isError body never throws — the real reason survives", () => {
     // The exact shape that burned four days: hub rejects on Zod validation and
     // returns a human-readable string. JSON.parse'ing it threw, and the throw
@@ -23,8 +27,8 @@ describe("channel plugin: commhub response parsing", () => {
     // This file exists only because channel/ is an independent package that
     // cannot import from agent-network. Duplication is WHY the bug survived
     // #1102 — so make drift fail here rather than in production four days later.
-    const a = readFileSync(new URL("./commhub-response.ts", import.meta.url), "utf8");
-    const b = readFileSync(new URL("../agent-network/src/commhub-response.ts", import.meta.url), "utf8");
+    const a = readFileSync(new URL("../../channel/commhub-response.ts", import.meta.url), "utf8");
+    const b = readFileSync(new URL("./commhub-response.ts", import.meta.url), "utf8");
     expect(a).toBe(b);
   });
 
@@ -32,7 +36,7 @@ describe("channel plugin: commhub response parsing", () => {
     // The helper being correct proves nothing if commhub-channel.ts never calls
     // it. #1102 fixed the identical line in agent-network and this copy stayed
     // broken for four days precisely because nothing looked at the CALL SITE.
-    const src = readFileSync(new URL("./commhub-channel.ts", import.meta.url), "utf8");
+    const src = readFileSync(new URL("../../channel/commhub-channel.ts", import.meta.url), "utf8");
     expect(src).not.toContain("JSON.parse(json.result.content[0].text)");
     expect(src).toContain("parseCommhubToolResult(json)");
   });

--- a/channel/commhub-channel.ts
+++ b/channel/commhub-channel.ts
@@ -12,6 +12,7 @@
  *   COMMHUB_URL, COMMHUB_TOKEN
  */
 
+import { parseCommhubToolResult } from "./commhub-response.js";
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { hostname } from "os";
@@ -231,7 +232,12 @@ async function callCommHub(toolName: string, args: Record<string, unknown>): Pro
     const dataLine = text.split("\n").find((l) => l.startsWith("data: "));
     if (dataLine) {
       const json = JSON.parse(dataLine.slice(6));
-      return json?.result?.content?.[0]?.text ? JSON.parse(json.result.content[0].text) : json;
+      // #1100 二份 — 这一行在 agent-network/src/node-server.ts 里已由 #1102 修掉,
+      // 而这份副本没有,于是修好的是开发者读的那份,留下的是节点真正跑的那份:
+      // TM智空马 连续四天只看到 `JSON Parse error: Unexpected identifier "MCP"`,
+      // 对 4 个不同 task_id、idem_ 与 UUID 两种来源全部失败,而真错误(hub 的
+      // Zod 参数校验拒绝)在这一行被销毁 —— 它让所有不同的错误长成同一个样子。
+      return parseCommhubToolResult(json);
     }
     return { ok: false, error: "no response" };
   } catch (e: any) {

--- a/channel/commhub-response.test.ts
+++ b/channel/commhub-response.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { parseCommhubToolResult } from "./commhub-response.js";
+
+describe("channel plugin: commhub response parsing", () => {
+  test("an isError body never throws — the real reason survives", () => {
+    // The exact shape that burned four days: hub rejects on Zod validation and
+    // returns a human-readable string. JSON.parse'ing it threw, and the throw
+    // reached the agent as `JSON Parse error: Unexpected identifier "MCP"` —
+    // every distinct failure wearing the same face.
+    const env = { result: { isError: true, content: [{ type: "text", text: 'MCP error -32602: Invalid arguments for tool send_reply' }] } };
+    const out = parseCommhubToolResult(env);
+    expect(out.ok).toBe(false);
+    expect(String(out.error)).toContain("-32602");
+  });
+
+  test("a normal JSON body still parses", () => {
+    const env = { result: { content: [{ type: "text", text: JSON.stringify({ ok: true, message_id: "abc" }) }] } };
+    expect(parseCommhubToolResult(env)).toEqual({ ok: true, message_id: "abc" });
+  });
+
+  test("the two copies of this helper stay byte-identical", () => {
+    // This file exists only because channel/ is an independent package that
+    // cannot import from agent-network. Duplication is WHY the bug survived
+    // #1102 — so make drift fail here rather than in production four days later.
+    const a = readFileSync(new URL("./commhub-response.ts", import.meta.url), "utf8");
+    const b = readFileSync(new URL("../agent-network/src/commhub-response.ts", import.meta.url), "utf8");
+    expect(a).toBe(b);
+  });
+
+  test("the channel plugin's own call site uses the helper, not a raw JSON.parse", () => {
+    // The helper being correct proves nothing if commhub-channel.ts never calls
+    // it. #1102 fixed the identical line in agent-network and this copy stayed
+    // broken for four days precisely because nothing looked at the CALL SITE.
+    const src = readFileSync(new URL("./commhub-channel.ts", import.meta.url), "utf8");
+    expect(src).not.toContain("JSON.parse(json.result.content[0].text)");
+    expect(src).toContain("parseCommhubToolResult(json)");
+  });
+});

--- a/channel/commhub-response.ts
+++ b/channel/commhub-response.ts
@@ -1,0 +1,36 @@
+// #1100 — parse a commhub MCP `tools/call` response envelope into a plain
+// result object, WITHOUT ever throwing on a non-JSON or isError body.
+//
+// Bug this fixes: the old inline logic did
+//   `content[0].text ? JSON.parse(content[0].text) : json`
+// unconditionally. A commhub tool that fails input validation comes back
+// as an isError result whose text is a human-readable STRING, e.g.
+//   "MCP error -32602: … Too big: expected number to be <=100 at progress"
+// JSON.parse'ing that threw, and the throw surfaced to the caller as an
+// opaque `-32603 JSON Parse error: Unexpected identifier "MCP"` — a
+// parameter-range error wearing a protocol-error mask, which sends
+// debugging to the wrong layer (the reporter chased task text / MCP link
+// for three retries before isolating `progress > 100`).
+//
+// Contract: the returned value is ALWAYS a plain object; error paths yield
+// `{ ok: false, error: <readable message> }` so the caller can read WHY
+// the call was rejected. Pure + side-effect free so it is unit-testable
+// without importing node-server.ts (which connects a stdio transport at
+// module load).
+export function parseCommhubToolResult(json: any): any {
+  const contentText = json?.result?.content?.[0]?.text;
+  if (contentText != null && contentText !== "") {
+    // isError → the text is an error STRING, not JSON. Surface it as a
+    // structured error instead of parsing (and throwing on) it.
+    if (json.result.isError) return { ok: false, error: contentText };
+    // Success payloads are JSON-stringified by commhub tools; still never
+    // let a non-JSON body throw — degrade to a readable structured error.
+    try { return JSON.parse(contentText); }
+    catch { return { ok: false, error: contentText }; }
+  }
+  // JSON-RPC error envelope (no result.content) — surface readably too.
+  if (json?.error) {
+    return { ok: false, error: `commhub error: ${typeof json.error === "string" ? json.error : JSON.stringify(json.error)}` };
+  }
+  return json;
+}

--- a/tests/test745-agent-network-unit-ci/Dockerfile
+++ b/tests/test745-agent-network-unit-ci/Dockerfile
@@ -25,6 +25,10 @@ COPY agent-node/package.json ./agent-node/package.json
 # tests/feishu-envelope-compat.test.ts 跨包 import agent-node 的 runtime 源码。
 COPY agent-node/src ./agent-node/src
 COPY agent-network ./agent-network
+# channel-plugin-error-masking.test.ts 逐字节比对 channel/ 里的插件源码。
+# 没有这行时容器里不存在 channel/,那两条断言红的理由是「文件读不到」,
+# 而输出长得像「副本不一致」—— 修的是取集层,不是判据。(#1149 首航红因)
+COPY channel ./channel
 COPY tests/test745-agent-network-unit-ci/run.sh ./tests/test745-agent-network-unit-ci/run.sh
 
 ARG SOURCE_COMMIT


### PR DESCRIPTION
## 同义副本

#1102 把 `agent-network/src/node-server.ts:324` 换成了 `parseCommhubToolResult`。合并后我在 main 上 grep,那行**还剩一份**:

```
origin/main:channel/commhub-channel.ts:234
  return json?.result?.content?.[0]?.text ? JSON.parse(json.result.content[0].text) : json;
```

## 生产实证

节点 `TM智空马` 连续四天答不回 Dashboard,admin 同一个问题问了三遍。

| 读数 | 值 |
|---|---|
| 它对多少个不同 task_id 调 `commhub_reply` | 4 个,**全部失败** |
| 失败文本 | `JSON Parse error: Unexpected identifier "MCP"`(每次都一样) |
| 短到一行的消息 | 同样失败 ⇒ 不是载荷 |
| `report_status` / `send_task` | 正常 ⇒ 不是通道断 |
| 任务来源(它自己换的轴) | `idem_`(Dashboard)与 UUID(节点)**两种都失败** ⇒ 整条路径不通 |
| hub 侧 `send_reply` 计数 | 该节点 **1** 次(对照 `TM智空负责人` 59、全网 5959,**带正控**) |

🔴 **而它撞的是没修的那一份**:该节点不是 `agent-node` 进程 —— 本机 60 个 `agent-node` 进程**无一**在用它的 config(config 文件在磁盘上)。**修好的是开发者读的那份,留下的是节点真正跑的那份。**

## 为什么加漂移门
`channel/` 是独立包,不能 import agent-network,helper 只能复制。**而复制正是这个 bug 活下来的原因**,所以加一条「两份必须逐字相同」的测试,让漂移在这里红,而不是四天后在生产红。

## 见证红(双向)
```
调用侧改回旧写法    ⇒ 3 pass 1 fail
两份副本产生漂移    ⇒ 3 pass 1 fail
基线 / 还原         ⇒ 4 pass 0 fail   (还原后逐字相同)
```

🔴 **其中「调用侧」那条是补的。** 我先写的三条只测 helper,而 helper 是复制来的、本来就对 —— **即使 `commhub-channel.ts` 还在用旧 `JSON.parse`,那三条照样全绿**。判据没错,漏的是取集没覆盖真正要判的对象。这和本 bug 逃过 #1102 是同一个形状。

## 界限
- 本 PR **只**修错误销毁,**不**修底层那个 `-32602`。真错误现在会显形,定性要等它显形之后。
- `TM智空马` 要用上,还需**发版 + 该节点重启**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)