### PR TITLE
feat(grok): grok 共存 TUI 支持 macOS —— 在一台真 Mac mini 上从头跑通

### DIFF
--- a/agent-node/src/runtime/grok-copresence/platform.test.ts
+++ b/agent-node/src/runtime/grok-copresence/platform.test.ts
@@ -75,10 +75,35 @@ describe("grok copresence platform capabilities", () => {
       .toBe(copresenceIpcEndpoint("C:\\x\\leader.sock", caps));
   });
 
-  test("an unverified platform is refused rather than silently downgraded", () => {
+  test("darwin is supported over a Unix socket, and says exactly what it loses", () => {
+    // 实测(2026-08-21, Apple M4 / Darwin 25.3.0 / grok 1.0.5):
+    //   AF_UNIX + chmod 0600 + PTY 都可用；/proc 不存在；
+    //   隔离 HOME 挡不住厂商技能(真实 122 → 隔离 89)；
+    //   🔴 而决定性的一格是 grok 在 macOS 上 leaderless —— 跑一次 grok,
+    //      TUI 正常起来而 ~/.grok/leader.sock 与 leader.lock 都没被创建。
+    //      因此 leader-lifecycle.ts 那条 /proc 身份链不会被进入(与 win32 同路径)。
     const caps = copresenceCapabilities("darwin");
+    expect(caps.supported).toBe(true);
+    expect(caps.ipc).toBe("unix-socket");     // 比 win32 好：不是 named-pipe
+    expect(caps.posixFileModes).toBe(true);   // 比 win32 好：0600 真的生效
+    expect(caps.procfs).toBe(false);
+    expect(caps.kernelSandbox).toBe(false);
+    expect(caps.homeIsolationHidesVendorSkills).toBe(false);
+    expect(caps.missingHard).toEqual([]);
+    // 丢了什么必须逐条说得出来，不能只是"支持"。
+    expect(caps.reducedGuarantees.length).toBe(4);
+    expect(caps.reducedGuarantees.join("\n")).toContain("environ");
+    expect(caps.reducedGuarantees.join("\n")).toContain("122");
+  });
+
+  test("an unverified platform is still refused rather than silently downgraded", () => {
+    // 🔴 这条原来拿 darwin 当例子。darwin 被实测验证后,那个夹具就把
+    //    "未验证 ⇒ 拒绝" 这条规则**编码在了一个不再未验证的平台上** ——
+    //    它会随着 darwin 转正而静默失去意义(从红变绿,输出逐字相同)。
+    //    换成一个确实没有被评估过的平台，规则本身才继续被守着。
+    const caps = copresenceCapabilities("freebsd");
     expect(caps.supported).toBe(false);
-    expect(() => assertCopresenceSupported(caps)).toThrow("darwin");
+    expect(() => assertCopresenceSupported(caps)).toThrow("freebsd");
     // fail-closed 的方向：没验过的平台走"拒绝"，不是走"当成 Windows 那套降级跑"。
     expect(caps.reducedGuarantees).toEqual([]);
   });

--- a/agent-node/src/runtime/grok-copresence/platform.ts
+++ b/agent-node/src/runtime/grok-copresence/platform.ts
@@ -71,6 +71,46 @@ export function copresenceCapabilities(
       reducedGuarantees: [],
     };
   }
+  if (platform === "darwin") {
+    // 实测于 2026-08-21,Apple M4 / macOS(Darwin 25.3.0) / grok 1.0.5:
+    //
+    //   /proc/self/fd            不存在
+    //   AF_UNIX bind+listen      可用,lstat 认得 S_ISSOCK
+    //   chmod 0600               生效(0o600)
+    //   PTY (openpty)            可用,从属端 isatty=true
+    //   隔离 HOME 挡厂商技能      挡不住:真实家目录 skills=122,隔离家目录 skills=89
+    //                            —— 与 Windows 同一结论(53→31),非零即挡不住
+    //
+    // 🔴 关键的那一格:grok 在 macOS 上是 **leaderless**。同一台机跑 `grok`,
+    //    TUI 正常起来(Grok 4.6 / Grok Build 1.0.5),而 ~/.grok/leader.sock 与
+    //    leader.lock **都没有被创建**(Linux 上两者都在)。因此 leader-lifecycle.ts
+    //    那条建立在 /proc/net/unix + /proc/<pid>/{exe,cmdline,environ} 上的
+    //    身份链在这里根本不会被进入 —— 和 win32 走的是同一条 leaderless 路径。
+    //
+    //    这一格必须实测,不能推断:macOS 上**读不到另一个进程的 environ**
+    //    (ps -E / ps eww 对自己刚启动的子进程也读不到),所以那条链如果真的
+    //    会被进入,它是**无法忠实移植的**,而不是"换个 API 就行"。
+    return {
+      platform,
+      supported: true,
+      ipc: "unix-socket",
+      kernelSandbox: false,
+      procfs: false,
+      posixFileModes: true,
+      homeIsolationHidesVendorSkills: false,
+      missingHard: [],
+      // 🔴 与 win32 那份一样,这些是**真的丢了**,不是措辞问题。
+      reducedGuarantees: [
+        "内核强制的 deny 路径 —— grok inspect 在 macOS 上不报告任何沙箱后端"
+        + "(系统有 /usr/bin/sandbox-exec,但没有证据表明 grok 使用它)",
+        "每轮 unshare --user 的用户命名空间隔离(Linux 专用)",
+        "基于 /proc 的父进程与 fd 校验 —— macOS 无 /proc,且**读不到别的进程的"
+        + " environ**,所以这一格不是降级而是不可得",
+        "隔离 HOME 对厂商技能无效:实测同机 grok 1.0.5,真实家目录 skills=122、"
+        + "隔离家目录 skills=89,它们的【指令文本】仍会进入上下文",
+      ],
+    };
+  }
   if (platform === "win32") {
     return {
       platform,

--- a/agent-node/src/runtime/grok-copresence/runtime.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.ts
@@ -659,6 +659,20 @@ export const GROK_COPRESENCE_VERIFIED_BUILDS: ReadonlyMap<string, GrokVerifiedBu
   //   · Leader：sandbox 与 leader 模式在 1.0.5 上互斥 ⇒ autoLeader=false（见上）
   ["grok 1.0.5 (5115b46bc9)", { autoLeader: false }],
   ["grok 1.0.5 (5115b46bc9) [stable]", { autoLeader: false }],
+  // 2026-08-21 验证 grok 1.0.5 (5115b46bc909) —— macOS(Apple M4 / Darwin 25.3.0)。
+  // 与上面那条是同一源码提交(5115b46bc9 是 5115b46bc909 的前缀),但**这张表按
+  // 版本串精确匹配是有道理的**:同一份源码在不同平台上行为并不相同,下面第②条就是。
+  //   · `grok inspect --json` 仍提供审计要的全部字段(17 个顶层键)
+  //   · 🔴 隔离 HOME 下【并非全为空】:skills=89、agents=3(真实家目录为 skills=122)。
+  //        Linux 上这一格是"全为空",macOS 上不是 —— 与 Windows 同一结论。
+  //        因此 copresenceCapabilities("darwin").homeIsolationHidesVendorSkills=false,
+  //        并在 reducedGuarantees 里逐条列出;这不是"放松断言",是**如实登记已失去的保证**。
+  //   · `--leader` 在 help 里;`--no-memory` / `--no-auto-update` 与 Linux 一样是隐藏 flag
+  //   · TUI 能起来:同机 `grok` 起 TUI 正常(Grok 4.6 / Grok Build 1.0.5)
+  //   · 🔴 grok 在 macOS 上是 leaderless —— 跑一次 grok 之后 ~/.grok/leader.sock 与
+  //        leader.lock 都没有被创建(Linux 上两者都在)。autoLeader 沿用 false。
+  ["grok 1.0.5 (5115b46bc909)", { autoLeader: false }],
+  ["grok 1.0.5 (5115b46bc909) [stable]", { autoLeader: false }],
 ]);
 
 /** 该 build 的已验证能力；未验证的 build 返回 undefined。 */
@@ -1297,7 +1311,14 @@ class GrokCopresenceRuntime implements GrokCopresenceRuntimeSession {
     //    复用 grok-build-cli-home 里那个已经处理了 PATHEXT 与 npm 真二进制的解析器，
     //    保证 TUI 与 MCP 两条路径用同一套解析规则，不会一边能找到一边找不到。
     const rawBinary = this.opts.binary ?? "grok";
-    const binary = copresenceEndpointIsFilesystemPath(copresenceCapabilities())
+    // 🔴 这里原来按【端点是不是文件系统路径】决定要不要解析,也就是"只有 Windows
+    //    才解析"。那个条件和它要解决的问题无关:裸名能不能被 spawn,取决于**子进程
+    //    的 PATH**,不取决于 IPC 用的是 unix socket 还是 named pipe。
+    //    实测(macOS,Apple M4):grok 装在 ~/.grok/bin,而 PTY 的受控 env 里没有它,
+    //    于是裸名 `grok` 让 node-pty 抛 `posix_spawnp failed` —— 报错既不说是哪个
+    //    文件,也不说是 PATH 的问题。改成按"是不是绝对路径"判断:绝对路径直接用
+    //    (于是 GROK_BINARY 这个既有覆盖真的生效),裸名一律解析,三个平台同一套规则。
+    const binary = isAbsolute(rawBinary)
       ? rawBinary
       : resolveGrokCommhubMcpCommand(rawBinary, String(this.spawnEnv.PATH || process.env.PATH || ""));
     const args = buildGrokCopresenceArgs({

--- a/agent-node/src/runtime/grok-copresence/verified-builds.test.ts
+++ b/agent-node/src/runtime/grok-copresence/verified-builds.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import {
+  GROK_COPRESENCE_VERIFIED_BUILDS,
+  assertGrokCopresenceVersion,
+  grokBuildAutoLeader,
+} from "./runtime.js";
+import { copresenceCapabilities } from "./platform.js";
+
+describe("grok co-presence verified builds", () => {
+  test("the macOS 1.0.5 build is registered — measured on an Apple M4", () => {
+    // Exact string matters: this table matches verbatim, and the same source
+    // commit prints a different hash length per platform. 5115b46bc9 (linux) is
+    // a prefix of 5115b46bc909 (darwin) — same commit, different builds.
+    expect(GROK_COPRESENCE_VERIFIED_BUILDS.has("grok 1.0.5 (5115b46bc909)")).toBe(true);
+    expect(() => assertGrokCopresenceVersion("grok 1.0.5 (5115b46bc909)")).not.toThrow();
+  });
+
+  test("darwin 1.0.5 keeps autoLeader=false, like the linux build of the same commit", () => {
+    // grok is leaderless on macOS: after running it, ~/.grok/leader.sock and
+    // leader.lock are both absent (both present on linux).
+    expect(grokBuildAutoLeader("grok 1.0.5 (5115b46bc909)")).toBe(false);
+  });
+
+  test("an unregistered build is still refused, and the message names what it saw", () => {
+    // The allowlist is the point: a build nobody verified must not run a shared
+    // TUI just because its version number looks close enough.
+    expect(() => assertGrokCopresenceVersion("grok 1.0.6 (deadbeef)")).toThrow("grok 1.0.6 (deadbeef)");
+    expect(() => assertGrokCopresenceVersion("")).toThrow("empty version");
+  });
+
+  test("🔴 the darwin registration and the darwin capability row tell the SAME story", () => {
+    // The build note says isolated HOME does NOT empty out on macOS
+    // (skills=89, agents=3 against 122 on the real home). If the capability row
+    // ever claimed isolation works there, the two would contradict each other
+    // and only one of them is what the runtime actually enforces.
+    expect(copresenceCapabilities("darwin").homeIsolationHidesVendorSkills).toBe(false);
+    expect(copresenceCapabilities("darwin").supported).toBe(true);
+  });
+});


### PR DESCRIPTION
## 起因
要把 `Mac打包狗` 起成 **TUI 共存版本**。agent-node 此前对 darwin 是**默认拒绝分支**:

```
平台 darwin 尚未验证过共存所需的 PTY / IPC / 隔离原语
```

**不是评估过不行,是从没被评估过。** 这次逐条实测(Apple M4 / Darwin 25.3.0 / grok 1.0.5),读数写进代码。

## 实测:darwin 的形状 ≈ win32,还更好

| | linux | win32 | **darwin(本 PR)** |
|---|---|---|---|
| IPC | unix-socket | named-pipe | **unix-socket** |
| POSIX 0600 | ✅ | ❌ | **✅** |
| /proc | ✅ | ❌ | ❌ |
| 隔离 HOME 挡厂商技能 | ✅ | ❌(53→31) | **❌(122→89)** |

🔴 **决定性的一格:grok 在 macOS 上 leaderless。** 同机跑一次 `grok`,TUI 正常起来而 `~/.grok/leader.sock` 与 `leader.lock` **都没被创建**(Linux 上两者都在)。因此 `leader-lifecycle.ts` 那条建立在 `/proc/net/unix` + `/proc/<pid>/{exe,cmdline,environ}` 上的身份链**根本不会被进入**(与 win32 同路径)。

这一格**必须实测**:macOS 上**读不到另一个进程的 environ**(`ps -E` / `ps eww` 对自己刚启动的子进程也读不到)。那条链若真会被进入,它是**无法忠实移植的** —— 不是"换个 API 就行"。

## 三处改动
1. `platform.ts` 加 darwin 分支,`reducedGuarantees` 逐条列出**真的丢了**的四项(含上面那个 122→89)。
2. 白名单登记 `grok 1.0.5 (5115b46bc909)`。与 linux 的 `5115b46bc9` 是同一提交(前缀关系),但**这张表按版本串精确匹配是有道理的**:同源在不同平台行为不同。**并补了这张表的第一组测试 —— 它此前一条断言都没有。**
3. TUI 二进制解析不再按平台分叉:原来"只有 Windows 才把裸名解析成绝对路径",而**裸名能不能 spawn 取决于子进程的 PATH,与 IPC 类型无关**。改成按"是不是绝对路径"判断,`GROK_BINARY` 这个既有覆盖于是真的生效。

## 真机跑通(2026-08-21 20:32)
```
[anet] ① node READY — attach socket live at …/run/attach.sock
[anet] ② TUI tmux=Mac打包狗 ready to attach
[anet] ✅ 共存节点 Mac打包狗 就绪
```
attach 进去是真 grok TUI(`Grok 4.6` / `sandbox:anet-…-workspace` / `❯`),socket `srw-------` (0600),**hub 侧确认有 SSE 投递通道**。

## 🔴 三个环境前提(代码修不了,要进文档)
1. **`flock` 必须是 util-linux 版。** brew 的 `flock` 是 discoteq 0.4.0,参数不兼容,报 `flock holder exited before acquisition (64: …directory [-c] command…)` —— **那截文本正是 discoteq 的 usage**。用 `brew install util-linux`。
2. `grok` 不在净化 PATH 里时给 `GROK_BINARY` 绝对路径(改动③之后才真的生效)。
3. 🔴 **node-pty 必须为当前 Node 构建过。** 该机 Node v25.8.2,node-pty 的 `build/Release` **整个目录不存在**,于是**每一次 pty spawn 都失败,包括 `/bin/echo`** —— 而报错只有一句 `posix_spawnp failed`,既不说哪个文件也不说原因,把人引向 grok/PATH。`npm rebuild node-pty` 报成功但什么也没产出;要 `npx node-gyp rebuild`。构建出 `pty.node` + `spawn-helper` 后 5 个 spawn 用例全通。

## 见证红
7 个变异各自产生不同的红(darwin 改回不支持 / 改成 named-pipe / 丢 POSIX 模式 / 删一条 reducedGuarantee / 删白名单登记 / autoLeader 翻 true / 白名单校验整个关掉),还原后逐字相同。

`grok-copresence` 全量 **178 pass / 0 fail**;仓级全量 **1333 pass / 0 fail**。

## 界限
- 一并把 `platform.test.ts` 里那条「未验证平台应被拒绝」的夹具从 `darwin` 换成 `freebsd` —— darwin 转正后,那个夹具会把规则**编码在一个不再未验证的平台上**,从红变绿且输出逐字相同。
- 不改 attach 协议、不改 leader、不动 Linux 与 Windows 两支。

🤖 Generated with [Claude Code](https://claude.com/claude-code)