### PR TITLE
fix(agent-node): pass /goal and /loop through unchanged

### DIFF
--- a/agent-node/src/goals/routing.test.ts
+++ b/agent-node/src/goals/routing.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   appendDashboardNativeScheduleNotice,
   appendLegacyScheduledGoalNotice,
-  DASHBOARD_NATIVE_SCHEDULE_NOTICE,
-  LEGACY_ANET_SCHEDULE_NOTICE,
   prepareDashboardNativeSlashReply,
   shouldCreateScheduledGoal,
 } from "./routing";
@@ -25,10 +23,10 @@ describe("shouldCreateScheduledGoal — Dashboard native slash pass-through", ()
     }
   });
 
-  test("non-Dashboard traffic retains /goal and /loop during the compatibility window", () => {
+  test("non-Dashboard /goal and /loop also pass through unchanged", () => {
     for (const runtime of RUNTIMES) {
-      expect(shouldCreateScheduledGoal("/goal 1h update docs", runtime, false)).toBe(true);
-      expect(shouldCreateScheduledGoal("/loop 1h update docs", runtime, false)).toBe(true);
+      expect(shouldCreateScheduledGoal("/goal 1h update docs", runtime, false)).toBe(false);
+      expect(shouldCreateScheduledGoal("/loop 1h update docs", runtime, false)).toBe(false);
       expect(shouldCreateScheduledGoal("/agoal 1h update docs", runtime, false)).toBe(true);
       expect(shouldCreateScheduledGoal("/aloop 1h update docs", runtime, false)).toBe(true);
     }
@@ -44,12 +42,10 @@ describe("shouldCreateScheduledGoal — Dashboard native slash pass-through", ()
   });
 });
 
-describe("appendLegacyScheduledGoalNotice", () => {
-  test("non-Dashboard /goal and /loop replies carry a deterministic migration notice", () => {
-    expect(appendLegacyScheduledGoalNotice("created", "/goal 5m work", false))
-      .toBe(`${LEGACY_ANET_SCHEDULE_NOTICE}\n\ncreated`);
-    expect(appendLegacyScheduledGoalNotice("failed", "/loop 5m work", false))
-      .toBe(`${LEGACY_ANET_SCHEDULE_NOTICE}\n\nfailed`);
+describe("native slash replies stay unchanged", () => {
+  test("non-Dashboard /goal and /loop replies are not rewritten", () => {
+    expect(appendLegacyScheduledGoalNotice("native", "/goal 5m work", false)).toBe("native");
+    expect(appendLegacyScheduledGoalNotice("native", "/loop 5m work", false)).toBe("native");
   });
 
   test("new namespaced commands, Dashboard pass-through, and near matches are not warned", () => {
@@ -60,17 +56,17 @@ describe("appendLegacyScheduledGoalNotice", () => {
     expect(appendLegacyScheduledGoalNotice("plain", "/looper 5m work", false)).toBe("plain");
   });
 
-  test("the migration notice is first so the outer reply cap cannot truncate it", () => {
+  test("long native replies are preserved exactly", () => {
     const reply = appendLegacyScheduledGoalNotice("x".repeat(2_500), "/goal 5m work", false);
-    expect(reply.slice(0, 2_000)).toContain(LEGACY_ANET_SCHEDULE_NOTICE);
+    expect(reply).toBe("x".repeat(2_500));
   });
 });
 
-describe("Dashboard native slash migration notice", () => {
-  test("interval-shaped /goal and /loop replies explain that ANet scheduling moved to /aloop", () => {
+describe("Dashboard native slash pass-through", () => {
+  test("interval-shaped /goal and /loop replies are unchanged", () => {
     for (const command of ["/goal 5m work", "/loop 每小时 work"]) {
       expect(appendDashboardNativeScheduleNotice("native reply", command, true))
-        .toBe(`${DASHBOARD_NATIVE_SCHEDULE_NOTICE}\n\nnative reply`);
+        .toBe("native reply");
     }
   });
 
@@ -81,7 +77,7 @@ describe("Dashboard native slash migration notice", () => {
     expect(appendDashboardNativeScheduleNotice("legacy", "/loop 5m work", false)).toBe("legacy");
   });
 
-  test("the notice survives low-value filtering and the outer reply cap", () => {
+  test("ordinary reply filtering remains unchanged", () => {
     const prepared = prepareDashboardNativeSlashReply(
       "收到",
       "/loop 5m work",
@@ -90,20 +86,12 @@ describe("Dashboard native slash migration notice", () => {
       (text) => text === "收到",
     );
     expect(prepared.shouldDeliver).toBe(true);
-    expect(prepared.text).toContain(DASHBOARD_NATIVE_SCHEDULE_NOTICE);
+    expect(prepared.text).toBe("收到");
     expect(appendDashboardNativeScheduleNotice("x".repeat(2_500), "/goal 5m work", true)
-      .slice(0, 2_000)).toContain(DASHBOARD_NATIVE_SCHEDULE_NOTICE);
+    ).toBe("x".repeat(2_500));
   });
 
-  // 🔴 上一条用 messageType:"task"，于是 `humanDashboardRequest` 为真，
-  //    `failed || humanDashboardRequest || !isLowValueReply(text)` 在第二项就短路 ——
-  //    `isLowValueReply` 根本没被求值。所以尽管那条测试名叫
-  //    "the notice survives low-value filtering"，它**测不到低价值过滤**。
-  //    要让第三项真的被求值，必须同时满足：有通知(interactiveDashboardTask=true)
-  //    且不是 human 直连(messageType 不是 task/broadcast)。
-  //    2026-08-19 实测：把 `isLowValueReply(text)` 改成 `isLowValueReply(replyText)`
-  //    后整个套件仍然全绿，就是缺了这一格。
-  test("low-value filtering judges the notice-prefixed text, not the raw model reply", () => {
+  test("non-task low-value replies remain filtered without rewriting", () => {
     const prepared = prepareDashboardNativeSlashReply(
       "收到",
       "/loop 5m work",
@@ -112,12 +100,11 @@ describe("Dashboard native slash migration notice", () => {
       (text) => text === "收到",
     );
 
-    expect(prepared.text).toBe(`${DASHBOARD_NATIVE_SCHEDULE_NOTICE}\n\n收到`);
-    // 判据在这一行：拿【原始回复】判低价值会把该发的迁移通知一起吞掉。
-    expect(prepared.shouldDeliver).toBe(true);
+    expect(prepared.text).toBe("收到");
+    expect(prepared.shouldDeliver).toBe(false);
   });
 
-  test("failed native replies still surface the migration notice and the failure", () => {
+  test("failed native replies surface without rewriting", () => {
     const prepared = prepareDashboardNativeSlashReply(
       "native failed",
       "/loop 5m work",
@@ -126,7 +113,7 @@ describe("Dashboard native slash migration notice", () => {
       () => false,
     );
     expect(prepared.shouldDeliver).toBe(true);
-    expect(prepared.text).toBe(`${DASHBOARD_NATIVE_SCHEDULE_NOTICE}\n\nnative failed`);
+    expect(prepared.text).toBe("native failed");
   });
 });
 

--- a/agent-node/src/goals/routing.ts
+++ b/agent-node/src/goals/routing.ts
@@ -1,5 +1,3 @@
-import { parseGoalCommand } from "./parser";
-
 export type GoalRoutingRuntime = "claude" | "codex" | "grok" | "opencode" | "codex-app-server";
 
 export interface ReplyMessageProvenance {
@@ -8,7 +6,6 @@ export interface ReplyMessageProvenance {
 }
 
 const ANET_SCHEDULE_COMMAND_RE = /^\s*\/(?:agoal|aloop)\b/i;
-const LEGACY_SCHEDULE_COMMAND_RE = /^\s*\/(?:goal|loop)\b/i;
 
 export const LEGACY_ANET_SCHEDULE_NOTICE =
   "提示：/goal 和 /loop 仅在非 Dashboard 路径处于兼容期；Agent Network 定时请改用 /aloop <间隔> <任务>。";
@@ -23,28 +20,25 @@ export const DASHBOARD_NATIVE_SCHEDULE_NOTICE =
  * `/goal` and `/loop` pass through to the target runtime for every runtime
  * bucket. Agent Network commands use `/agoal` and `/aloop` instead.
  *
- * Non-Dashboard traffic retains `/goal` + `/loop` temporarily so existing
- * node-to-node automations do not silently change behavior. The caller adds a
- * deterministic migration notice through appendLegacyScheduledGoalNotice().
+ * `/goal` and `/loop` always belong to the target runtime, regardless of
+ * transport provenance. Only the namespaced `/agoal` and `/aloop` commands
+ * select Agent Network scheduling.
  */
 export function shouldCreateScheduledGoal(
   content: string,
   _runtime: GoalRoutingRuntime,
-  interactiveDashboardTask: boolean,
+  _interactiveDashboardTask: boolean,
 ): boolean {
-  if (ANET_SCHEDULE_COMMAND_RE.test(content || "")) return true;
-  if (!LEGACY_SCHEDULE_COMMAND_RE.test(content || "")) return false;
-  return !interactiveDashboardTask;
+  return ANET_SCHEDULE_COMMAND_RE.test(content || "");
 }
 
-/** Add a visible compatibility warning to old non-Dashboard scheduler names. */
+/** Kept as a compatibility export; native slash replies are never rewritten. */
 export function appendLegacyScheduledGoalNotice(
   replyText: string,
-  content: string,
-  interactiveDashboardTask: boolean,
+  _content: string,
+  _interactiveDashboardTask: boolean,
 ): string {
-  if (interactiveDashboardTask || !LEGACY_SCHEDULE_COMMAND_RE.test(content || "")) return replyText;
-  return `${LEGACY_ANET_SCHEDULE_NOTICE}\n\n${replyText}`;
+  return replyText;
 }
 
 /**
@@ -55,12 +49,10 @@ export function appendLegacyScheduledGoalNotice(
  */
 export function appendDashboardNativeScheduleNotice(
   replyText: string,
-  content: string,
-  interactiveDashboardTask: boolean,
+  _content: string,
+  _interactiveDashboardTask: boolean,
 ): string {
-  if (!interactiveDashboardTask || !LEGACY_SCHEDULE_COMMAND_RE.test(content || "")) return replyText;
-  if (!parseGoalCommand(content).ok) return replyText;
-  return `${DASHBOARD_NATIVE_SCHEDULE_NOTICE}\n\n${replyText}`;
+  return replyText;
 }
 
 /** Compose the Dashboard migration notice before ordinary reply filtering. */

--- a/docs/tests/test760-artifacts/report-test760-native-goal-passthrough.txt
+++ b/docs/tests/test760-artifacts/report-test760-native-goal-passthrough.txt
@@ -1,0 +1,44 @@
+# test760 — native /goal and /loop pass-through
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/inbox-dispatch.test.ts:
+(pass) isInteractiveDashboardTask > accepts a Hub-authenticated dashboard chat task [0.53ms]
+(pass) isInteractiveDashboardTask > pre-stamp admin rows stay FIFO because aliases are not auth facts [3.47ms]
+(pass) isInteractiveDashboardTask > rejects node-authenticated spoofing, malformed ids, and plain messages [0.51ms]
+(pass) dispatchInboxBatch > awaited batches preserve legacy runtime serialization [2.25ms]
+(pass) dispatchInboxBatch > a later SSE snapshot enters while the first detached turn is still running [2.31ms]
+(pass) dispatchInboxBatch > the real serialized drain lane can fetch a later SSE snapshot before the active turn ends [1.39ms]
+(pass) dispatchInboxBatch > detached completion failures remain observable [1.47ms]
+(pass) dispatchInboxBatch > settling detached work emits a wake for the next Hub inbox window [1.52ms]
+(pass) dispatchInboxBatch > a throwing settle callback cannot strand queued N+1 work [1.54ms]
+(pass) dispatchInboxBatch > same-tick duplicate kicks claim one row exactly once [0.44ms]
+(pass) dispatchInboxBatch > bounded admission waits N+1 and starts it after a slot settles [2.28ms]
+(pass) dispatchInboxBatch > durable reply drain waits until detached Codex rows finish [0.09ms]
+(pass) dispatchInboxBatch > active Codex direct delivery and durable drain send one reply, not two [11.73ms]
+
+agent-node/src/goals/routing.test.ts:
+(pass) shouldCreateScheduledGoal — Dashboard native slash pass-through > authenticated Dashboard /goal and /loop pass through for every agent-node runtime [0.23ms]
+(pass) shouldCreateScheduledGoal — Dashboard native slash pass-through > authenticated Dashboard /agoal and /aloop always select the ANet scheduler [0.09ms]
+(pass) shouldCreateScheduledGoal — Dashboard native slash pass-through > non-Dashboard /goal and /loop also pass through unchanged [0.14ms]
+(pass) shouldCreateScheduledGoal — Dashboard native slash pass-through > near matches and slash text away from the start never select the scheduler [0.18ms]
+(pass) native slash replies stay unchanged > non-Dashboard /goal and /loop replies are not rewritten [0.09ms]
+(pass) native slash replies stay unchanged > new namespaced commands, Dashboard pass-through, and near matches are not warned [0.07ms]
+(pass) native slash replies stay unchanged > long native replies are preserved exactly [0.07ms]
+(pass) Dashboard native slash pass-through > interval-shaped /goal and /loop replies are unchanged [0.14ms]
+(pass) Dashboard native slash pass-through > ordinary native commands, namespaced commands, and non-Dashboard paths are untouched [0.07ms]
+(pass) Dashboard native slash pass-through > ordinary reply filtering remains unchanged [0.18ms]
+(pass) Dashboard native slash pass-through > non-task low-value replies remain filtered without rewriting [0.07ms]
+(pass) Dashboard native slash pass-through > failed native replies surface without rewriting [0.05ms]
+(pass) reply filtering uses authenticated message provenance > a short presence reply to an authenticated Dashboard human task is delivered [0.10ms]
+(pass) reply filtering uses authenticated message provenance > the same low-value class remains filtered for agent-to-agent tasks [0.07ms]
+(pass) reply filtering uses authenticated message provenance > a provenance flag cannot bypass filtering for a non-task message type [0.07ms]
+
+ 28 pass
+ 0 fail
+ 116 expect() calls
+Ran 28 tests across 2 files. [133.00ms]
+Bundled 279 modules in 159ms
+
+  agent-node-cli.js  2.0 MB  (entry point)
+
+RESULT: PASS

--- a/tests/test760-native-goal-passthrough/Dockerfile
+++ b/tests/test760-native-goal-passthrough/Dockerfile
@@ -1,0 +1,9 @@
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
+
+WORKDIR /workspace
+COPY agent-node/package.json ./agent-node/package.json
+RUN cd agent-node && bun install --ignore-scripts
+COPY agent-node ./agent-node
+COPY tests/test760-native-goal-passthrough ./tests/test760-native-goal-passthrough
+RUN chmod 0755 /workspace/tests/test760-native-goal-passthrough/run.sh
+ENTRYPOINT ["/workspace/tests/test760-native-goal-passthrough/run.sh"]

--- a/tests/test760-native-goal-passthrough/run.sh
+++ b/tests/test760-native-goal-passthrough/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPORT=/artifacts/report-test760-native-goal-passthrough.txt
+mkdir -p /artifacts
+exec > >(tee "$REPORT") 2>&1
+
+echo "# test760 — native /goal and /loop pass-through"
+bun test agent-node/src/goals/routing.test.ts agent-node/src/inbox-dispatch.test.ts
+
+grep -Fq 'return ANET_SCHEDULE_COMMAND_RE.test(content || "");' agent-node/src/goals/routing.ts
+if grep -Eq 'LEGACY_SCHEDULE_COMMAND_RE.*test' agent-node/src/goals/routing.ts; then
+  echo "FAIL: legacy /goal or /loop can still select the scheduler"
+  exit 1
+fi
+
+bun build agent-node/src/cli.ts --outfile /tmp/agent-node-cli.js --target node \
+  --external @anthropic-ai/claude-agent-sdk \
+  --external '@anthropic-ai/claude-agent-sdk-*' \
+  --external @openai/codex-sdk \
+  --external node-pty
+test -s /tmp/agent-node-cli.js
+echo "RESULT: PASS"


### PR DESCRIPTION
## Summary
- reserve ANet scheduling for `/agoal` and `/aloop` only
- pass `/goal` and `/loop` unchanged to every target runtime on every transport
- remove compatibility reply rewriting

## Verification
- focused Bun routing/inbox tests: 28 passed
- Docker test760: PASS
- production agent-node CLI bundle: PASS

Docker report: `docs/tests/test760-artifacts/report-test760-native-goal-passthrough.txt`