### PR TITLE
fix(codex): pass /goal through to TUI

### DIFF
--- a/agent-node/src/goals/routing.test.ts
+++ b/agent-node/src/goals/routing.test.ts
@@ -26,12 +26,23 @@ describe("shouldCreateScheduledGoal — Dashboard native slash pass-through", ()
   });
 
   test("non-Dashboard traffic retains /goal and /loop during the compatibility window", () => {
-    for (const runtime of RUNTIMES) {
+    for (const runtime of RUNTIMES.filter((value) => value !== "codex-app-server")) {
       expect(shouldCreateScheduledGoal("/goal 1h update docs", runtime, false)).toBe(true);
       expect(shouldCreateScheduledGoal("/loop 1h update docs", runtime, false)).toBe(true);
       expect(shouldCreateScheduledGoal("/agoal 1h update docs", runtime, false)).toBe(true);
       expect(shouldCreateScheduledGoal("/aloop 1h update docs", runtime, false)).toBe(true);
     }
+  });
+
+  test("Codex TUI /goal passes through even when Dashboard provenance is absent", () => {
+    expect(shouldCreateScheduledGoal("/goal 好好设计本地数据存储规范", "codex-app-server", false)).toBe(false);
+    expect(shouldCreateScheduledGoal("  /GOAL resume the previous session", "codex-app-server", false)).toBe(false);
+  });
+
+  test("Codex TUI keeps explicit ANet scheduling and legacy /loop compatibility", () => {
+    expect(shouldCreateScheduledGoal("/agoal 5m update docs", "codex-app-server", false)).toBe(true);
+    expect(shouldCreateScheduledGoal("/aloop 5m update docs", "codex-app-server", false)).toBe(true);
+    expect(shouldCreateScheduledGoal("/loop 5m update docs", "codex-app-server", false)).toBe(true);
   });
 
   test("near matches and slash text away from the start never select the scheduler", () => {

--- a/agent-node/src/goals/routing.ts
+++ b/agent-node/src/goals/routing.ts
@@ -9,6 +9,7 @@ export interface ReplyMessageProvenance {
 
 const ANET_SCHEDULE_COMMAND_RE = /^\s*\/(?:agoal|aloop)\b/i;
 const LEGACY_SCHEDULE_COMMAND_RE = /^\s*\/(?:goal|loop)\b/i;
+const NATIVE_CODEX_GOAL_COMMAND_RE = /^\s*\/goal\b/i;
 
 export const LEGACY_ANET_SCHEDULE_NOTICE =
   "提示：/goal 和 /loop 仅在非 Dashboard 路径处于兼容期；Agent Network 定时请改用 /aloop <间隔> <任务>。";
@@ -19,9 +20,14 @@ export const DASHBOARD_NATIVE_SCHEDULE_NOTICE =
 /**
  * Select the Agent Network scheduled-goal path.
  *
- * Authenticated Dashboard chat owns the unprefixed vendor command namespace:
- * `/goal` and `/loop` pass through to the target runtime for every runtime
- * bucket. Agent Network commands use `/agoal` and `/aloop` instead.
+ * Codex TUI owns `/goal` regardless of message provenance. CommHub relays do
+ * not always carry Dashboard metadata (for example older desktop clients and
+ * node-to-node forwarding), so provenance is not a safe routing boundary for
+ * a native Codex command. Agent Network scheduling remains explicitly under
+ * `/agoal` and `/aloop`.
+ *
+ * Authenticated Dashboard chat additionally owns the unprefixed vendor
+ * command namespace for every runtime: `/goal` and `/loop` pass through.
  *
  * Non-Dashboard traffic retains `/goal` + `/loop` temporarily so existing
  * node-to-node automations do not silently change behavior. The caller adds a
@@ -29,11 +35,12 @@ export const DASHBOARD_NATIVE_SCHEDULE_NOTICE =
  */
 export function shouldCreateScheduledGoal(
   content: string,
-  _runtime: GoalRoutingRuntime,
+  runtime: GoalRoutingRuntime,
   interactiveDashboardTask: boolean,
 ): boolean {
   if (ANET_SCHEDULE_COMMAND_RE.test(content || "")) return true;
   if (!LEGACY_SCHEDULE_COMMAND_RE.test(content || "")) return false;
+  if (runtime === "codex-app-server" && NATIVE_CODEX_GOAL_COMMAND_RE.test(content || "")) return false;
   return !interactiveDashboardTask;
 }
 

--- a/docs/tests/report-test-codex-goal-passthrough.txt
+++ b/docs/tests/report-test-codex-goal-passthrough.txt
@@ -1,0 +1,24 @@
+# Codex TUI /goal passthrough regression
+
+Date: 2026-08-22
+Base: origin/main 126e74ccb998cc6380bc02b609319cc587de8bfc
+Environment: Docker, test725-agent-node-unit-ci, Bun 1.3.14, Node v22.23.2
+
+Behavior under test:
+- codex-app-server `/goal ...` bypasses Agent Network scheduling even without Dashboard provenance.
+- `/agoal` and `/aloop` still select Agent Network scheduling.
+- legacy non-Dashboard `/loop` behavior is unchanged.
+- non-Codex runtime compatibility behavior is unchanged.
+
+Commands:
+- `sg docker -c 'docker build ... tests/test725-agent-node-unit-ci/Dockerfile .'`
+- `sg docker -c 'docker run --rm anet-test725-goal'`
+- `sg docker -c "docker run --rm --entrypoint bash anet-test725-goal -lc 'cd /workspace/agent-node && npm run build'"`
+
+Results:
+- agent-node/src: 1339 pass, 0 fail, 99/99 test files.
+- agent-node/tests: 6/6 files executed, 0 failed.
+- witnessed-red attachment mutation gate: PASS.
+- agent-node production build: PASS (cli.js and upload-file-mcp-stdio.js bundled).
+
+RESULT: PASS


### PR DESCRIPTION
## Summary
- route Codex TUI `/goal` directly to the native runtime regardless of Dashboard provenance
- retain `/agoal` and `/aloop` as explicit Agent Network scheduler commands
- preserve legacy non-Dashboard `/loop` and non-Codex compatibility behavior

## Verification
- Docker test725 complete agent-node domain: 1339 pass, 0 fail across 99 files
- agent-node/tests: 6/6 files, 0 failed
- Docker production build: pass
- report: `docs/tests/report-test-codex-goal-passthrough.txt`