### PR TITLE
feat(docs): host desktop updater endpoint on anet.sh

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -12,7 +12,8 @@
     "skillhub:check": "node scripts/build-public-skillhub.mjs --check",
     "prebuild": "npm run skillhub:build",
     "build": "vitepress build docs",
-    "preview": "vitepress preview docs"
+    "preview": "vitepress preview docs",
+    "test:update-route": "node scripts/check-desktop-update-route.mjs"
   },
   "keywords": [
     "agent-network",

--- a/docs-site/scripts/check-desktop-update-route.mjs
+++ b/docs-site/scripts/check-desktop-update-route.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const config = JSON.parse(
+  await readFile(new URL('../vercel.json', import.meta.url), 'utf8'),
+);
+
+const route = config.rewrites?.find(
+  (entry) => entry.source === '/desktop/update/latest.json',
+);
+
+assert.ok(route, 'desktop updater route must exist');
+assert.equal(
+  route.destination,
+  'https://github.com/sleep2agi/agent-network-app/releases/latest/download/latest.json',
+  'desktop updater route must target the signed stable release manifest',
+);
+
+console.log('desktop updater route: ok');

--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -1,3 +1,20 @@
 {
-  "cleanUrls": true
+  "cleanUrls": true,
+  "rewrites": [
+    {
+      "source": "/desktop/update/latest.json",
+      "destination": "https://github.com/sleep2agi/agent-network-app/releases/latest/download/latest.json"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/desktop/update/latest.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=60, s-maxage=300, stale-while-revalidate=300"
+        }
+      ]
+    }
+  ]
 }

--- a/docs/tests/report-desktop-update-endpoint.txt
+++ b/docs/tests/report-desktop-update-endpoint.txt
@@ -1,0 +1,20 @@
+Agent Network desktop updater endpoint
+=====================================
+
+Endpoint: https://anet.sh/desktop/update/latest.json
+Origin: https://github.com/sleep2agi/agent-network-app/releases/latest/download/latest.json
+
+The endpoint is a Vercel rewrite. The stable URL belongs to anet.sh while the
+signed manifest and update binaries remain on GitHub Releases.
+
+Validation command:
+  sg docker -c 'tests/test-desktop-update-endpoint/run.sh'
+
+Expected checks:
+  - updater rewrite exists and targets the signed stable release manifest
+  - VitePress production build succeeds
+
+Result (2026-08-22): PASS
+  - desktop updater route: ok
+  - VitePress client/server build: ok
+  - VitePress page rendering: ok

--- a/tests/test-desktop-update-endpoint/Dockerfile
+++ b/tests/test-desktop-update-endpoint/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/docs-site
+COPY docs-site/package.json docs-site/package-lock.json ./
+RUN npm ci
+COPY docs-site/ ./
+
+CMD ["sh", "-c", "npm run test:update-route && npm run build"]

--- a/tests/test-desktop-update-endpoint/NOT-IN-CI.md
+++ b/tests/test-desktop-update-endpoint/NOT-IN-CI.md
@@ -1,0 +1,19 @@
+# Why this suite is not registered in the global L1 matrix
+
+Verified: 2026-08-22
+Revisit-when: the docs-site build workflow stops covering every `docs-site/**` change or the updater endpoint gains server-side logic beyond a Vercel rewrite.
+
+This is a focused, one-time deployment-contract verification for the anet.sh
+desktop updater rewrite. The repository's existing `docs-site build` workflow
+already runs the production VitePress build for every change under
+`docs-site/**`; duplicating the full dependency install and site build in the
+global L1 matrix would add cost without covering a distinct runtime boundary.
+
+Run it locally before changing the updater route:
+
+```sh
+sg docker -c 'tests/test-desktop-update-endpoint/run.sh'
+```
+
+The lightweight route assertion remains available as
+`npm run test:update-route` from `docs-site/`.

--- a/tests/test-desktop-update-endpoint/run.sh
+++ b/tests/test-desktop-update-endpoint/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -eu
+
+docker build -f tests/test-desktop-update-endpoint/Dockerfile -t anet-desktop-update-endpoint .
+docker run --rm anet-desktop-update-endpoint


### PR DESCRIPTION
## Summary
- expose a stable `https://anet.sh/desktop/update/latest.json` updater endpoint
- proxy the signed stable manifest from `agent-network-app` GitHub Releases
- add a focused route contract check and isolated Docker/VitePress build suite

## Verification
- `sg docker -c 'tests/test-desktop-update-endpoint/run.sh'`\n- route contract passed\n- full VitePress production build passed\n\n## Dependency\nMerge/deploy this routing PR before publishing the first auto-update-enabled desktop release from sleep2agi/agent-network-app#56.