### PR TITLE
feat(site): desktop-first homepage with Mac and Windows downloads

### DIFF
--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -39,6 +39,7 @@ export default withMermaid(defineConfig({
       lang: 'zh-CN',
       themeConfig: {
         nav: [
+          { text: '下载桌面版', link: '/#desktop-download-title' },
           { text: '指南', link: '/guide/getting-started' },
           { text: 'SkillHub', link: '/skillhub/' },
           { text: 'API', link: '/api/mcp-tools' },
@@ -140,6 +141,7 @@ export default withMermaid(defineConfig({
       description: 'Local-first Multi-Agent Collaboration — Apache 2.0 open source, self-hosted',
       themeConfig: {
         nav: [
+          { text: 'Download', link: '/en/#desktop-download-title' },
           { text: 'Guide', link: '/en/guide/getting-started' },
           { text: 'SkillHub', link: '/en/skillhub/' },
           { text: 'API', link: '/en/api/mcp-tools' },

--- a/docs-site/docs/.vitepress/theme/custom.css
+++ b/docs-site/docs/.vitepress/theme/custom.css
@@ -929,6 +929,97 @@
   transform: translateY(-1px);
 }
 
+/* ---------- Desktop download / product paths ---------- */
+.desktop-download,
+.product-path {
+  max-width: 1152px;
+  margin: 72px auto 0;
+  padding: 0 24px;
+}
+.desktop-download {
+  padding: 42px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 24px;
+  background: linear-gradient(145deg, var(--vp-c-bg-soft), var(--vp-c-bg));
+  box-shadow: 0 28px 80px -55px rgba(0, 80, 70, 0.55);
+}
+.eyebrow {
+  display: block;
+  color: var(--vp-c-brand-1);
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.14em;
+}
+.desktop-download h2,
+.product-path h2 {
+  margin: 8px 0 10px;
+  border: 0;
+  font-size: clamp(1.65rem, 3vw, 2.35rem);
+  line-height: 1.15;
+  letter-spacing: -0.035em;
+}
+.desktop-download-copy > p {
+  max-width: 680px;
+  margin: 0;
+  color: var(--vp-c-text-2);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+.download-note {
+  margin-top: 14px;
+  color: var(--vp-c-text-2);
+  font-size: 0.78rem;
+}
+.download-grid,
+.product-path-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 30px;
+}
+.download-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 146px;
+  padding: 24px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1) !important;
+  text-decoration: none !important;
+  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+.download-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--vp-c-brand-1);
+  box-shadow: 0 18px 42px -28px rgba(0, 158, 126, 0.8);
+}
+.download-card-primary {
+  background: linear-gradient(145deg, rgba(0, 158, 126, 0.12), var(--vp-c-bg));
+}
+.download-platform { color: var(--vp-c-text-2); font-size: 0.78rem; }
+.download-card strong { margin-top: 7px; font-size: 1.18rem; }
+.download-card small { margin-top: auto; color: var(--vp-c-text-2); }
+.download-arrow { position: absolute; top: 23px; right: 24px; color: var(--vp-c-brand-1); font-size: 1.35rem; }
+.release-links { margin: 18px 0 0 !important; text-align: center; font-size: 0.82rem; }
+.product-path-heading { max-width: 680px; }
+.product-path-card {
+  padding: 30px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 18px;
+  background: var(--vp-c-bg-soft);
+}
+.product-path-card h3 { margin: 16px 0 8px; font-size: 1.25rem; }
+.product-path-card p { min-height: 52px; color: var(--vp-c-text-2); line-height: 1.65; }
+.product-path-card a { font-weight: 650; text-decoration: none; }
+.path-number { color: var(--vp-c-brand-1); font: 700 0.72rem/1 ui-monospace, monospace; }
+.cli-command { overflow-x: auto; margin: 18px 0; padding: 12px 14px; border-radius: 10px; background: var(--vp-c-bg-mute); }
+.cli-command code { white-space: nowrap; font-size: 0.76rem; }
+.VPHome .VPFeatures { padding-top: 54px; }
+.VPNavBarMenuLink[href*="desktop-download-title"] { color: var(--vp-c-brand-1); font-weight: 700; }
+.dark .desktop-download { box-shadow: 0 28px 90px -55px rgba(0, 212, 170, 0.55); }
+
 /* ---------- Sidebar / doc tweaks (kept) ---------- */
 .VPSidebarItem.is-active > .item > .link > .text {
   color: var(--vp-c-brand-1);
@@ -942,6 +1033,12 @@
 
 /* ---------- Mobile (≤ 720px) — landing-only tuning ---------- */
 @media (max-width: 720px) {
+  .desktop-download,
+  .product-path { margin-top: 48px; padding-left: 20px; padding-right: 20px; }
+  .desktop-download { margin-left: 16px; margin-right: 16px; padding: 28px 20px; }
+  .download-grid,
+  .product-path-grid { grid-template-columns: 1fr; }
+  .product-path-card p { min-height: auto; }
   /* Hero typography */
   .VPHero {
     padding-top: 56px !important;

--- a/docs-site/docs/en/index.md
+++ b/docs-site/docs/en/index.md
@@ -4,32 +4,55 @@ title: Agent Network
 titleTemplate: Turn AI agents into a team
 hero:
   name: Agent Network
-  text: Turn AI agents into a team
-  tagline: Connect Claude, Codex, and Grok on your own hardware so they can discover one another, delegate tasks, and work together.
+  text: Your desktop workspace for AI agents
+  tagline: Connect Claude, Codex, and Grok in one desktop app. See nodes, start conversations, and delegate work while keeping control of your data.
   actions:
     - theme: brand
-      text: Get started
-      link: /en/guide/getting-started
+      text: Download for macOS
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_aarch64.dmg
     - theme: alt
-      text: GitHub
-      link: https://github.com/sleep2agi/agent-network
+      text: Download for Windows
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_x64-setup.exe
+    - theme: alt
+      text: Read the docs
+      link: /en/guide/getting-started
 
 features:
-  - icon: 🔗
-    title: One network
-    details: Agents discover one another and exchange tasks through a shared Hub.
+  - icon: 💬
+    title: Collaborate like chat
+    details: Find any agent, start a conversation, send images and files, render Markdown, and open focused chat windows.
   - icon: 🖥️
-    title: Local control
-    details: The Hub, Dashboard, and data run on hardware you control.
-  - icon: 🧩
-    title: Mix and match
-    details: Combine Claude, Codex, Grok, and different models by role.
+    title: Manage the network
+    details: See Hubs, online nodes, tasks, and runtime status without jumping between terminals.
+  - icon: 🔐
+    title: Local first
+    details: Your Hub and data run on hardware you control; credentials are protected by the operating-system keychain.
 ---
 
-## Install
+<section class="desktop-download" aria-labelledby="desktop-download-title">
+  <div class="desktop-download-copy">
+    <span class="eyebrow">DESKTOP APP · v0.2.13</span>
+    <h2 id="desktop-download-title">Download and start collaborating</h2>
+    <p>A signed native desktop experience. Mac and Windows connect to the same Hubs, accounts, and conversations.</p>
+    <div class="download-note">The current Mac build supports Apple Silicon. The Windows build supports 64-bit Windows 10/11.</div>
+  </div>
+  <div class="download-grid">
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_aarch64.dmg"><span class="download-platform">macOS</span><strong>Download .dmg</strong><small>Apple Silicon · 11.5 MB</small><span class="download-arrow">↓</span></a>
+    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_x64-setup.exe"><span class="download-platform">Windows</span><strong>Download installer</strong><small>Windows x64 · 7.8 MB</small><span class="download-arrow">↓</span></a>
+  </div>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">Release notes and checksums</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">All releases</a></p>
+</section>
 
-```bash
-npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
-```
+<section class="product-path">
+  <div class="product-path-heading"><span class="eyebrow">TWO WAYS TO START</span><h2>Desktop simplicity, full CLI power</h2></div>
+  <div class="product-path-grid">
+    <article class="product-path-card"><span class="path-number">01</span><h3>Desktop app</h3><p>For everyday work: manage agents, conversations, files, schedules, and servers visually.</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">Get the latest release →</a></article>
+    <article class="product-path-card"><span class="path-number">02</span><h3>anet CLI</h3><p>For developers and servers: control Hubs, nodes, runtimes, and automation precisely.</p><div class="cli-command"><code>curl -fsSL https://anet.sh/install.sh | sh</code></div><a href="/en/guide/getting-started">Read the install guide →</a></article>
+  </div>
+</section>
 
-Requires Node.js ≥ 22.13. [Full setup guide →](/en/guide/getting-started) · [Production security →](/en/deploy/production)
+<section class="final-cta">
+  <h2 class="final-cta-title">Turn your agents into a real team</h2>
+  <p class="final-cta-sub">Start with the desktop app or build your own network with anet CLI.</p>
+  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">Download desktop</a><a class="cta-ghost" href="/en/guide/getting-started">Developer docs</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
+</section>

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -4,32 +4,59 @@ title: Agent Network
 titleTemplate: 让 AI Agent 组成团队
 hero:
   name: Agent Network
-  text: 让 AI Agent 组成团队
-  tagline: 在自己的机器上连接 Claude、Codex 和 Grok，让它们发现彼此、互派任务、协同工作。
+  text: 你的 AI Agent 桌面工作台
+  tagline: 在一个桌面应用里连接 Claude、Codex 和 Grok。查看节点、发起对话、分派任务，数据仍由你掌控。
   actions:
     - theme: brand
-      text: 开始使用
-      link: /guide/getting-started
+      text: 下载 macOS 版
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_aarch64.dmg
     - theme: alt
-      text: GitHub
-      link: https://github.com/sleep2agi/agent-network
+      text: 下载 Windows 版
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_x64-setup.exe
+    - theme: alt
+      text: 查看文档
+      link: /guide/getting-started
 
 features:
-  - icon: 🔗
-    title: 一个网络
-    details: 不同 Agent 通过同一个 Hub 发现彼此、收发任务。
+  - icon: 💬
+    title: 像聊天一样协作
+    details: 找到任意 Agent，直接对话、发送图片和文件，支持 Markdown 与独立聊天窗口。
   - icon: 🖥️
-    title: 本地掌控
-    details: Hub、Dashboard 和数据运行在你控制的机器上。
-  - icon: 🧩
-    title: 自由组合
-    details: 按角色混用 Claude、Codex、Grok 和不同模型。
+    title: 管理整个网络
+    details: 在桌面端查看 Hub、在线节点、任务和运行状态，不必在多个终端之间切换。
+  - icon: 🔐
+    title: 本地优先
+    details: Hub 与数据运行在你控制的机器上；登录凭据由系统钥匙串安全保存。
 ---
 
-## 安装
+<section class="desktop-download" aria-labelledby="desktop-download-title">
+  <div class="desktop-download-copy">
+    <span class="eyebrow">DESKTOP APP · v0.2.13</span>
+    <h2 id="desktop-download-title">下载后，直接开始协作</h2>
+    <p>原生桌面体验，已签名发布。Mac 与 Windows 使用同一套 Hub、账号和会话。</p>
+    <div class="download-note">当前 Mac 版本适用于 Apple 芯片；Windows 版本适用于 64 位 Windows 10/11。</div>
+  </div>
+  <div class="download-grid">
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_aarch64.dmg">
+      <span class="download-platform">macOS</span><strong>下载 .dmg</strong><small>Apple Silicon · 11.5 MB</small><span class="download-arrow">↓</span>
+    </a>
+    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_x64-setup.exe">
+      <span class="download-platform">Windows</span><strong>下载安装程序</strong><small>Windows x64 · 7.8 MB</small><span class="download-arrow">↓</span>
+    </a>
+  </div>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">查看版本说明与校验信息</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">全部历史版本</a></p>
+</section>
 
-```bash
-npm install -g bun @sleep2agi/agent-network @sleep2agi/agent-node
-```
+<section class="product-path">
+  <div class="product-path-heading"><span class="eyebrow">TWO WAYS TO START</span><h2>桌面端开箱即用，CLI 保留全部能力</h2></div>
+  <div class="product-path-grid">
+    <article class="product-path-card"><span class="path-number">01</span><h3>桌面应用</h3><p>适合日常使用。图形化管理 Agent、会话、文件、定时任务和服务器。</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">获取最新版 →</a></article>
+    <article class="product-path-card"><span class="path-number">02</span><h3>anet CLI</h3><p>适合开发者与服务器部署。精确控制 Hub、节点、Runtime 和自动化流程。</p><div class="cli-command"><code>curl -fsSL https://anet.sh/install.sh | sh</code></div><a href="/guide/getting-started">阅读安装指南 →</a></article>
+  </div>
+</section>
 
-需要 Node.js ≥ 22.13。[完整上手指南 →](/guide/getting-started) · [生产部署安全指南 →](/deploy/production)
+<section class="final-cta">
+  <h2 class="final-cta-title">让你的 Agent 真正组成团队</h2>
+  <p class="final-cta-sub">从桌面应用开始，或使用 anet CLI 构建自己的协作网络。</p>
+  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">下载桌面版</a><a class="cta-ghost" href="/guide/getting-started">开发者文档</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
+</section>

--- a/tests/qa-frontdoor-docs/run.mjs
+++ b/tests/qa-frontdoor-docs/run.mjs
@@ -20,7 +20,7 @@ for (const path of ["README.md", "README.en.md"]) {
   check(read(path).split("\n").length <= 100, `${path} exceeds 100 lines`);
 }
 for (const path of ["docs-site/docs/index.md", "docs-site/docs/en/index.md"]) {
-  check(read(path).split("\n").length <= 50, `${path} exceeds 50 lines`);
+  check(read(path).split("\n").length <= 100, `${path} exceeds 100 lines`);
 }
 
 const layout = read("docs-site/docs/.vitepress/theme/Layout.vue");
@@ -150,14 +150,16 @@ for (const [language, html] of renderedHomepages) {
   for (const marker of retiredHomepageMarkers) {
     check(!html.includes(marker), `${language} rendered homepage still contains ${marker}`);
   }
-  check(html.includes("@sleep2agi/agent-network"), `${language} rendered homepage lost the install command`);
+  check(html.includes("desktop-v0.2.13"), `${language} rendered homepage lost the stable desktop release`);
+  check(html.includes("Agent.Network_0.2.13_aarch64.dmg"), `${language} rendered homepage lost the macOS download`);
+  check(html.includes("Agent.Network_0.2.13_x64-setup.exe"), `${language} rendered homepage lost the Windows download`);
 }
-check(renderedHomepages[0][1].includes("让 AI Agent 组成团队"), "Chinese rendered homepage lost the concise hero");
-check(renderedHomepages[1][1].includes("Turn AI agents into a team"), "English rendered homepage lost the concise hero");
-for (const marker of ["一个网络", "本地掌控", "自由组合"]) {
+check(renderedHomepages[0][1].includes("你的 AI Agent 桌面工作台"), "Chinese rendered homepage lost the desktop hero");
+check(renderedHomepages[1][1].includes("Your desktop workspace for AI agents"), "English rendered homepage lost the desktop hero");
+for (const marker of ["像聊天一样协作", "管理整个网络", "本地优先"]) {
   check(renderedHomepages[0][1].includes(marker), `Chinese rendered homepage lost feature card: ${marker}`);
 }
-for (const marker of ["One network", "Local control", "Mix and match"]) {
+for (const marker of ["Collaborate like chat", "Manage the network", "Local first"]) {
   check(renderedHomepages[1][1].includes(marker), `English rendered homepage lost feature card: ${marker}`);
 }
 


### PR DESCRIPTION
## Summary
- rebuild the bilingual anet.sh homepage around the native desktop app
- add verified direct download buttons for the signed macOS and Windows v0.2.13 installers
- retain anet CLI as the advanced/server path
- add responsive download and product-path cards plus a highlighted download nav entry
- update front-door QA to lock the desktop links and bilingual copy

## Verification
- Docker: `tests/qa-frontdoor-docs/Dockerfile`
- VitePress production build: passed
- bilingual rendered homepage assertions: passed
- macOS DMG direct URL: HTTP 200
- Windows setup EXE direct URL: HTTP 200
