### PR TITLE
fix(hub): stop labeling authenticated REST messages as api

### DIFF
--- a/docs/tests/report-rest-authenticated-sender-2026-08-23.md
+++ b/docs/tests/report-rest-authenticated-sender-2026-08-23.md
@@ -1,0 +1,19 @@
+# REST authenticated sender attribution — 2026-08-23
+
+## Scope
+
+`POST /api/task` now uses the authenticated username when a user-token caller
+omits `from`. Explicit legacy `from` values remain supported, node tokens stay
+bound to their node alias, and an auth context with no resolvable identity keeps
+the legacy `api` fallback.
+
+## Docker verification
+
+- Image: `tests/test798-server-unit-ci/Dockerfile`
+- Runtime: Bun 1.3.14, Node.js 22.23.2, non-root uid 1000
+- Server test files discovered: 72
+- Server test files executed: 72
+- Failed files: 0
+- Witnessed-red mutation: registration password floor weakening failed as expected
+- Result: PASS
+

--- a/server/src/rest-identity.test.ts
+++ b/server/src/rest-identity.test.ts
@@ -60,7 +60,16 @@ describe("REST from_session identity binding", () => {
     })).toEqual({ ok: true, fromSession: "admin" });
   });
 
-  test("user token with no from still defaults to 'api'", () => {
+  test("user token with no from defaults to the authenticated username", () => {
+    expect(resolveRestFromSession({
+      token: UTOK,
+      tokenName: null,
+      authenticatedUsername: "admin",
+      requestedFrom: undefined,
+    })).toEqual({ ok: true, fromSession: "admin" });
+  });
+
+  test("legacy user auth without a username still falls back to 'api'", () => {
     expect(resolveRestFromSession({
       token: UTOK,
       tokenName: null,

--- a/server/src/rest-identity.ts
+++ b/server/src/rest-identity.ts
@@ -21,6 +21,8 @@ export interface RestIdentityInput {
   token: string;
   /** `api_tokens.name`; for node tokens it is `node:<alias>`. */
   tokenName: string | null | undefined;
+  /** Username resolved from the authenticated token. */
+  authenticatedUsername?: string | null;
   /** Caller-supplied `body.from`. */
   requestedFrom: unknown;
 }
@@ -69,11 +71,16 @@ export function resolveRestFromSession(input: RestIdentityInput): RestIdentityRe
     return { ok: true, fromSession: "api" };
   }
 
-  // Not a node token: unchanged behaviour. The Dashboard legitimately posts as
-  // its logged-in user; tightening that is a separate change with its own
-  // compatibility surface.
+  // A user-token client normally does not need to repeat its identity in every
+  // request. Prefer an explicit, backwards-compatible claim when present;
+  // otherwise attribute the task to the authenticated username. Falling back
+  // to the transport label `api` is reserved for legacy auth contexts where
+  // the server genuinely has no user identity.
   if (!alias) {
-    return { ok: true, fromSession: requested || "api" };
+    const authenticatedUsername = typeof input.authenticatedUsername === "string"
+      ? input.authenticatedUsername.trim()
+      : "";
+    return { ok: true, fromSession: requested || authenticatedUsername || "api" };
   }
 
   // Node token claiming somebody else — refuse rather than silently rewrite,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2263,6 +2263,7 @@ return Bun.serve({
       const identity = resolveRestFromSession({
         token: requestToken(req),
         tokenName: restAuth?.tokenName,
+        authenticatedUsername: restAuth?.username,
         requestedFrom: body.from,
       });
       if (!identity.ok) {


### PR DESCRIPTION
## Summary
- default `POST /api/task` sender attribution to the authenticated username when `from` is omitted
- keep explicit legacy sender claims backwards compatible
- preserve node-token alias binding and the `api` fallback only for auth contexts without a resolvable identity
- add regression tests and a Docker verification report

## Why
Desktop and Dashboard REST sends omitted `from`, so CommHub persisted their sender as the transport label `api`. The Messages view then honestly rendered many misleading `api → node` rows.

## Verification
- full server unit domain in `tests/test798-server-unit-ci/Dockerfile`
- 72/72 server test files passed as non-root with isolated databases
- witnessed-red mutation passed
