### PR TITLE
fix(docs): serve desktop updater manifest directly

### DIFF
--- a/docs-site/docs/public/desktop/update/latest.json
+++ b/docs-site/docs/public/desktop/update/latest.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.2.30",
+  "notes": "Signed macOS and Windows desktop update. Publish this draft only after installation smoke tests pass.",
+  "pub_date": "2026-08-23T21:15:43.139Z",
+  "platforms": {
+    "darwin-aarch64": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlpFdytIZlRhNC9oVjJEaXJIUDlLQnYvQS82SVdBYU16SEtRNlBYUFJtT296Q3EzN3l6WFRZZFQyaksydWRoVng0N3Y5SFk5T0hHb0w1ZzQwV3lmSXdNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NTM0CWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6Cm1obnJCNDVVcDJISzFGNGRPYVRJVHdzSkxJd1JIWUxVOGhVS21jM01vWVNZQnorNHVQYWM1M3kvMHFnRW9mMlh4WC9mU0VrQmwwYStrZGpGZ1oxdkFRPT0K",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526646988"
+    },
+    "darwin-aarch64-app": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlpFdytIZlRhNC9oVjJEaXJIUDlLQnYvQS82SVdBYU16SEtRNlBYUFJtT296Q3EzN3l6WFRZZFQyaksydWRoVng0N3Y5SFk5T0hHb0w1ZzQwV3lmSXdNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NTM0CWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6Cm1obnJCNDVVcDJISzFGNGRPYVRJVHdzSkxJd1JIWUxVOGhVS21jM01vWVNZQnorNHVQYWM1M3kvMHFnRW9mMlh4WC9mU0VrQmwwYStrZGpGZ1oxdkFRPT0K",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526646988"
+    },
+    "windows-x86_64": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlN0Y3FFdmdBR05IaFBINGJzR0p5OGxDaWJmSFVkbnNhUmQ2V2Q2b09yOUpkWUdBSEh4OW9vdFNhWGpmQjRXSEprN2U5bDRDTkhFTndibE1KR3NWdlFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NzM3CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzBfeDY0LXNldHVwLmV4ZQplWWhYaVJiSCtVN2ZZZ0NFVStDS3pmV2cxZUtmQkd4UE8vN2RUQlZqRU1rWTRvMVBRL3NsWnV4cnU1QXNuYkxZUDgzVzJHeEVmbkxSQ2lRdU5scVFEQT09Cg==",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526649405"
+    },
+    "windows-x86_64-nsis": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlN0Y3FFdmdBR05IaFBINGJzR0p5OGxDaWJmSFVkbnNhUmQ2V2Q2b09yOUpkWUdBSEh4OW9vdFNhWGpmQjRXSEprN2U5bDRDTkhFTndibE1KR3NWdlFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NzM3CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzBfeDY0LXNldHVwLmV4ZQplWWhYaVJiSCtVN2ZZZ0NFVStDS3pmV2cxZUtmQkd4UE8vN2RUQlZqRU1rWTRvMVBRL3NsWnV4cnU1QXNuYkxZUDgzVzJHeEVmbkxSQ2lRdU5scVFEQT09Cg==",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526649405"
+    },
+    "windows-x86_64-msi": {
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TldCZmFIcWg1dFhKOGlrL1Z0RWhFYTRvb0t5UWp0Um9pNTZCbFh0THB2aUVMVVdDaVF5YmptalI0d2FaYjN5RThiaHZqTXdxT0djMEJLRER0eDh1ekFFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NzM3CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzBfeDY0X2VuLVVTLm1zaQpLTFliTUd0STNManNncTBzSVpQQ3BML2NmTlZsczJDY08zeCtNalJjQSt0RURCVUVKWXBaRVAzS2hCc0FFRWlWZlhCM0g1S3I0VHMvSys0WWNQK09Bdz09Cg==",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526649361"
+    }
+  }
+}

--- a/docs-site/scripts/check-desktop-update-route.mjs
+++ b/docs-site/scripts/check-desktop-update-route.mjs
@@ -4,16 +4,17 @@ import { readFile } from 'node:fs/promises';
 const config = JSON.parse(
   await readFile(new URL('../vercel.json', import.meta.url), 'utf8'),
 );
+const manifest = JSON.parse(
+  await readFile(new URL('../docs/public/desktop/update/latest.json', import.meta.url), 'utf8'),
+);
 
 const route = config.rewrites?.find(
   (entry) => entry.source === '/desktop/update/latest.json',
 );
 
-assert.ok(route, 'desktop updater route must exist');
-assert.equal(
-  route.destination,
-  'https://github.com/sleep2agi/agent-network-app/releases/latest/download/latest.json',
-  'desktop updater route must target the signed stable release manifest',
-);
+assert.equal(route, undefined, 'desktop updater manifest must be served directly, without a rewrite');
+assert.match(manifest.version, /^\d+\.\d+\.\d+$/);
+assert.ok(manifest.platforms?.['darwin-aarch64']?.signature);
+assert.ok(manifest.platforms?.['windows-x86_64']?.signature);
 
-console.log('desktop updater route: ok');
+console.log(`desktop updater static manifest: ${manifest.version} ok`);

--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -1,11 +1,5 @@
 {
   "cleanUrls": true,
-  "rewrites": [
-    {
-      "source": "/desktop/update/latest.json",
-      "destination": "https://github.com/sleep2agi/agent-network-app/releases/latest/download/latest.json"
-    }
-  ],
   "headers": [
     {
       "source": "/desktop/update/latest.json",


### PR DESCRIPTION
## Summary
- publish the signed desktop v0.2.30 updater manifest under `docs/public/desktop/update/`
- remove the Vercel rewrite to GitHub so anet.sh serves the manifest directly
- update the route check to require a static signed Mac/Windows manifest

## Docker verification
- `npm run test:update-route`
- `npm run build`
- built output contains `/desktop/update/latest.json` with version 0.2.30

After deployment, `https://anet.sh/desktop/update/latest.json` must return HTTP 200 directly rather than redirecting.