### PR TITLE
chore(docs): point the desktop updater at 0.2.31

### DIFF
--- a/docs-site/docs/public/desktop/update/latest.json
+++ b/docs-site/docs/public/desktop/update/latest.json
@@ -1,27 +1,27 @@
 {
-  "version": "0.2.30",
-  "notes": "Signed macOS and Windows desktop update. Publish this draft only after installation smoke tests pass.",
-  "pub_date": "2026-08-23T21:15:43.139Z",
+  "version": "0.2.31",
+  "notes": "Signed and notarized desktop update for macOS (Apple Silicon) and Windows (x64). Existing installations can update in place; new installations use the assets below.",
+  "pub_date": "2026-08-24T02:07:09.112Z",
   "platforms": {
     "darwin-aarch64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlpFdytIZlRhNC9oVjJEaXJIUDlLQnYvQS82SVdBYU16SEtRNlBYUFJtT296Q3EzN3l6WFRZZFQyaksydWRoVng0N3Y5SFk5T0hHb0w1ZzQwV3lmSXdNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NTM0CWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6Cm1obnJCNDVVcDJISzFGNGRPYVRJVHdzSkxJd1JIWUxVOGhVS21jM01vWVNZQnorNHVQYWM1M3kvMHFnRW9mMlh4WC9mU0VrQmwwYStrZGpGZ1oxdkFRPT0K",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526646988"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TmZ0U09EVEJhclVpV1pkVXFudlZNM1FZVTF1NDdtcHBDSURnaC9VaXFaU0lITjBJNDRGSGxMWkVTTDlRa1l1S1d3dzJPbkE2cHE1RG82bkJPcm9FTmdjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MDIxCWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6CnJXMU1TaFI1eGFlemVjVy9SbmRTMGcycEh2UUw4bXBEM0c3bEh5S24xRGM5ZlcxdVNJQk4xdHQ3elhtK0NBQlh1REVxdXBHdWczWDZIcDhHNjF6SkJBPT0K",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526919324"
     },
     "darwin-aarch64-app": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlpFdytIZlRhNC9oVjJEaXJIUDlLQnYvQS82SVdBYU16SEtRNlBYUFJtT296Q3EzN3l6WFRZZFQyaksydWRoVng0N3Y5SFk5T0hHb0w1ZzQwV3lmSXdNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NTM0CWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6Cm1obnJCNDVVcDJISzFGNGRPYVRJVHdzSkxJd1JIWUxVOGhVS21jM01vWVNZQnorNHVQYWM1M3kvMHFnRW9mMlh4WC9mU0VrQmwwYStrZGpGZ1oxdkFRPT0K",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526646988"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TmZ0U09EVEJhclVpV1pkVXFudlZNM1FZVTF1NDdtcHBDSURnaC9VaXFaU0lITjBJNDRGSGxMWkVTTDlRa1l1S1d3dzJPbkE2cHE1RG82bkJPcm9FTmdjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MDIxCWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6CnJXMU1TaFI1eGFlemVjVy9SbmRTMGcycEh2UUw4bXBEM0c3bEh5S24xRGM5ZlcxdVNJQk4xdHQ3elhtK0NBQlh1REVxdXBHdWczWDZIcDhHNjF6SkJBPT0K",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526919324"
     },
     "windows-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlN0Y3FFdmdBR05IaFBINGJzR0p5OGxDaWJmSFVkbnNhUmQ2V2Q2b09yOUpkWUdBSEh4OW9vdFNhWGpmQjRXSEprN2U5bDRDTkhFTndibE1KR3NWdlFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NzM3CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzBfeDY0LXNldHVwLmV4ZQplWWhYaVJiSCtVN2ZZZ0NFVStDS3pmV2cxZUtmQkd4UE8vN2RUQlZqRU1rWTRvMVBRL3NsWnV4cnU1QXNuYkxZUDgzVzJHeEVmbkxSQ2lRdU5scVFEQT09Cg==",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526649405"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlZZSW9VTGRCZ1JsM0hCYUl4RStJbTArbmdpYmJXTUpwREU0V0I2SnZBT3JmTGFWZjBab3N2UjBPVXZyd0FXcHAyL0tPVHp0MmN3Y0xlY3V1M0VwWEFrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MjIzCWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzFfeDY0LXNldHVwLmV4ZQpYL3lGaGJBSkhIUkIwYlJtVStpdTNOZ29pRWpLeWhNNkt6VE8yNDdod3MxdFJtOVZsWEtIQ2dwVCs0TDNrZkhXUUxSL0ZLRXo3VDJLYnFBY3pBT3hBUT09Cg==",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526922884"
     },
     "windows-x86_64-nsis": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlN0Y3FFdmdBR05IaFBINGJzR0p5OGxDaWJmSFVkbnNhUmQ2V2Q2b09yOUpkWUdBSEh4OW9vdFNhWGpmQjRXSEprN2U5bDRDTkhFTndibE1KR3NWdlFRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NzM3CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzBfeDY0LXNldHVwLmV4ZQplWWhYaVJiSCtVN2ZZZ0NFVStDS3pmV2cxZUtmQkd4UE8vN2RUQlZqRU1rWTRvMVBRL3NsWnV4cnU1QXNuYkxZUDgzVzJHeEVmbkxSQ2lRdU5scVFEQT09Cg==",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526649405"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlZZSW9VTGRCZ1JsM0hCYUl4RStJbTArbmdpYmJXTUpwREU0V0I2SnZBT3JmTGFWZjBab3N2UjBPVXZyd0FXcHAyL0tPVHp0MmN3Y0xlY3V1M0VwWEFrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MjIzCWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzFfeDY0LXNldHVwLmV4ZQpYL3lGaGJBSkhIUkIwYlJtVStpdTNOZ29pRWpLeWhNNkt6VE8yNDdod3MxdFJtOVZsWEtIQ2dwVCs0TDNrZkhXUUxSL0ZLRXo3VDJLYnFBY3pBT3hBUT09Cg==",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526922884"
     },
     "windows-x86_64-msi": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TldCZmFIcWg1dFhKOGlrL1Z0RWhFYTRvb0t5UWp0Um9pNTZCbFh0THB2aUVMVVdDaVF5YmptalI0d2FaYjN5RThiaHZqTXdxT0djMEJLRER0eDh1ekFFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTE5NzM3CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzBfeDY0X2VuLVVTLm1zaQpLTFliTUd0STNManNncTBzSVpQQ3BML2NmTlZsczJDY08zeCtNalJjQSt0RURCVUVKWXBaRVAzS2hCc0FFRWlWZlhCM0g1S3I0VHMvSys0WWNQK09Bdz09Cg==",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526649361"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlNrV2dBS240VzJ5eE1DRFpxd0dXNExmMEN3UG1tMHVmaHM0MmFWZWhoMTk2L2lFd3hGdGUxSnBhZ3lPdC80U0c3MnF3M0pzUUtBSnduZSt3UjE2ekFnPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MjIzCWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzFfeDY0X2VuLVVTLm1zaQpWcStxTkhxQS9pTmhlSVFMOG1pZy84bzBOUG9HcXIvQTNEMjlhWkVYS204SW9wYk8xNkFpS09hcXFrUCtHV1R6amlwWml2YTIyQ1p2dDZNc2lhR0VDUT09Cg==",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526922810"
     }
   }
 }


### PR DESCRIPTION
Points the served desktop updater manifest at **0.2.31**.

## Source of the file

Downloaded **anonymously, with no token**, from the published release asset:

```
env -u GITHUB_TOKEN -u GH_TOKEN curl -H 'Accept: application/octet-stream' -L \
  https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526922959
```

and written in verbatim. The served file and the release asset are now
**byte-identical** (`md5 74ff3f9222e252070f902dd032643ef1`), where previously
they were merely semantically equivalent with different formatting — that gap is
the drift risk filed as agent-network-app#125.

## Verified before writing

- `version` = `0.2.31`
- 5 platform entries — `darwin-aarch64`, `darwin-aarch64-app`, `windows-x86_64`,
  `windows-x86_64-nsis`, `windows-x86_64-msi` — **each carries a signature**
- every asset URL resolves to an asset of release `375394792`
  (`desktop-v0.2.31`): `526919324` app.tar.gz, `526922884` setup.exe,
  `526922810` msi
- `notes` is user-facing text, with none of the maintainer wording that shipped
  in 0.2.30

## Ordering

The release is already **public** (published `2026-08-24T02:11:44Z`, tag
`desktop-v0.2.31` → `054ed937bfd35fe82ab8c15d4b943d79161c1b3e`), and its assets
were confirmed to fetch anonymously (302 → 200, exact content-length). That
order matters: a draft release's assets are not anonymously downloadable, so
syncing the manifest first would hand every client an update pointing at
something it cannot fetch.

## Gate

```
$ node docs-site/scripts/check-desktop-update-route.mjs
desktop updater static manifest: 0.2.31 ok
```

按内容搜过:`0.2.31` ⇒ 零命中;`latest.json` / `desktop/update` ⇒ 命中 #1160、#1154、#1155(均已合并,分别是改直出路由、建更新端点、首页下载区,与本次同步无关)。

## Note

Merging this does not put it online — the `docs-site` Vercel project is not
connected to git. The deploy is a separate manual step, per
`deploy/docs-site/README.md`.
