### PR TITLE
chore(docs): point the desktop updater at 0.2.32

### DIFF
--- a/docs-site/docs/public/desktop/update/latest.json
+++ b/docs-site/docs/public/desktop/update/latest.json
@@ -1,27 +1,27 @@
 {
-  "version": "0.2.31",
+  "version": "0.2.32",
   "notes": "Signed and notarized desktop update for macOS (Apple Silicon) and Windows (x64). Existing installations can update in place; new installations use the assets below.",
-  "pub_date": "2026-08-24T02:07:09.112Z",
+  "pub_date": "2026-08-24T04:37:25.430Z",
   "platforms": {
     "darwin-aarch64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TmZ0U09EVEJhclVpV1pkVXFudlZNM1FZVTF1NDdtcHBDSURnaC9VaXFaU0lITjBJNDRGSGxMWkVTTDlRa1l1S1d3dzJPbkE2cHE1RG82bkJPcm9FTmdjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MDIxCWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6CnJXMU1TaFI1eGFlemVjVy9SbmRTMGcycEh2UUw4bXBEM0c3bEh5S24xRGM5ZlcxdVNJQk4xdHQ3elhtK0NBQlh1REVxdXBHdWczWDZIcDhHNjF6SkJBPT0K",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526919324"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TmZ3dE1Cem9DczNjWjN4WVJCVWVpcEtJRkYxdUhqQXd2NGpBVEVDQWQrY3NXWWVsMzVqOGlQYkJPY1JWMmFuajlua01nWmpEWG1pT2o1eU1UdUVBbEFnPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTQ2MDQwCWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6Ci9Mc2pkSGpvUjgzRnpCZ3h0M20wVmgyR0dBVGpoS0pFUUpiVjFjaGpDRUp6Qm0zc3dzdFBxWHp6YVhKMVFHcjV2aHg1VkhDeXFQRG9NYkp1UndCc0NBPT0K",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/527085503"
     },
     "darwin-aarch64-app": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TmZ0U09EVEJhclVpV1pkVXFudlZNM1FZVTF1NDdtcHBDSURnaC9VaXFaU0lITjBJNDRGSGxMWkVTTDlRa1l1S1d3dzJPbkE2cHE1RG82bkJPcm9FTmdjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MDIxCWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6CnJXMU1TaFI1eGFlemVjVy9SbmRTMGcycEh2UUw4bXBEM0c3bEh5S24xRGM5ZlcxdVNJQk4xdHQ3elhtK0NBQlh1REVxdXBHdWczWDZIcDhHNjF6SkJBPT0K",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526919324"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TmZ3dE1Cem9DczNjWjN4WVJCVWVpcEtJRkYxdUhqQXd2NGpBVEVDQWQrY3NXWWVsMzVqOGlQYkJPY1JWMmFuajlua01nWmpEWG1pT2o1eU1UdUVBbEFnPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTQ2MDQwCWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6Ci9Mc2pkSGpvUjgzRnpCZ3h0M20wVmgyR0dBVGpoS0pFUUpiVjFjaGpDRUp6Qm0zc3dzdFBxWHp6YVhKMVFHcjV2aHg1VkhDeXFQRG9NYkp1UndCc0NBPT0K",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/527085503"
     },
     "windows-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlZZSW9VTGRCZ1JsM0hCYUl4RStJbTArbmdpYmJXTUpwREU0V0I2SnZBT3JmTGFWZjBab3N2UjBPVXZyd0FXcHAyL0tPVHp0MmN3Y0xlY3V1M0VwWEFrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MjIzCWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzFfeDY0LXNldHVwLmV4ZQpYL3lGaGJBSkhIUkIwYlJtVStpdTNOZ29pRWpLeWhNNkt6VE8yNDdod3MxdFJtOVZsWEtIQ2dwVCs0TDNrZkhXUUxSL0ZLRXo3VDJLYnFBY3pBT3hBUT09Cg==",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526922884"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TmRwbkd0VUZBRXJUVjgxci9iVUdESzhERE1OOHNuN0xPWDdyRFdGTExhQ1BjQTNoT2wyci9PRjVyZjNUT3h4YTl0SGZvNmt4aWR1RllXZ1doYUVRc1FVPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTQ2MjM5CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzJfeDY0LXNldHVwLmV4ZQpacFB2eU5ZMG5ySUZRVy9DN3czR2tJU2ZRSmJpZkliVExCTHBtYVd2QnpUTXhjYWpEUy8zaStXZGZjNkxkVzZ2ZU1DcE9IMS85OFdKVUV2cDh3UE5CZz09Cg==",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/527088814"
     },
     "windows-x86_64-nsis": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlZZSW9VTGRCZ1JsM0hCYUl4RStJbTArbmdpYmJXTUpwREU0V0I2SnZBT3JmTGFWZjBab3N2UjBPVXZyd0FXcHAyL0tPVHp0MmN3Y0xlY3V1M0VwWEFrPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MjIzCWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzFfeDY0LXNldHVwLmV4ZQpYL3lGaGJBSkhIUkIwYlJtVStpdTNOZ29pRWpLeWhNNkt6VE8yNDdod3MxdFJtOVZsWEtIQ2dwVCs0TDNrZkhXUUxSL0ZLRXo3VDJLYnFBY3pBT3hBUT09Cg==",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526922884"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TmRwbkd0VUZBRXJUVjgxci9iVUdESzhERE1OOHNuN0xPWDdyRFdGTExhQ1BjQTNoT2wyci9PRjVyZjNUT3h4YTl0SGZvNmt4aWR1RllXZ1doYUVRc1FVPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTQ2MjM5CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzJfeDY0LXNldHVwLmV4ZQpacFB2eU5ZMG5ySUZRVy9DN3czR2tJU2ZRSmJpZkliVExCTHBtYVd2QnpUTXhjYWpEUy8zaStXZGZjNkxkVzZ2ZU1DcE9IMS85OFdKVUV2cDh3UE5CZz09Cg==",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/527088814"
     },
     "windows-x86_64-msi": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlNrV2dBS240VzJ5eE1DRFpxd0dXNExmMEN3UG1tMHVmaHM0MmFWZWhoMTk2L2lFd3hGdGUxSnBhZ3lPdC80U0c3MnF3M0pzUUtBSnduZSt3UjE2ekFnPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTM3MjIzCWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzFfeDY0X2VuLVVTLm1zaQpWcStxTkhxQS9pTmhlSVFMOG1pZy84bzBOUG9HcXIvQTNEMjlhWkVYS204SW9wYk8xNkFpS09hcXFrUCtHV1R6amlwWml2YTIyQ1p2dDZNc2lhR0VDUT09Cg==",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/526922810"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlJnMnpxU2JEVXVhc1Z1OEFsSXJFdjZVMnJkZWkzR21pUUFqdVRNcDlucE1Ga3BpZFBubXVLYitPWUo0UnV1MEwyV1lXTHlEVDBkS0xKSU1raTVHS3drPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NTQ2MjM5CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzJfeDY0X2VuLVVTLm1zaQpXaHRJdTFzcEJTZnVXNFF2cENGaERrQkR2NEJtMVg1aWZHcXgvODFOSi90clhORVMzZVB0czFFR2ZXVWVYSlVLWEtGMUNYSTlRbXAzSVljRXhuMHpDQT09Cg==",
+      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/527088748"
     }
   }
 }


### PR DESCRIPTION
Points the served desktop updater manifest at **0.2.32**, which carries the fix
for `已送达 ✓` appearing under messages the viewer did not send.

## Source

Downloaded **anonymously, with no token**, from the published release asset and
written in verbatim:

```
env -u GITHUB_TOKEN -u GH_TOKEN curl -H 'Accept: application/octet-stream' -L \
  https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/527088907
```

Served file and release asset are **byte-identical**
(`md5 860758124b7ba5f7c9b25fccf140103f`), the same discipline adopted for 0.2.31.

## Verified before writing

- `version` = `0.2.32`
- 5 platform entries, **each with a signature**
- every asset URL resolves to an asset of the published `desktop-v0.2.32`
  release: `527085503` app.tar.gz, `527088814` setup.exe, `527088748` msi

## Ordering

The release is already public (`2026-08-24T04:41:10Z`, tag `desktop-v0.2.32` →
`ee43181ed6635e98584122c66f2291115a1e0959`), and its assets were confirmed to
fetch anonymously (302 → 200, exact content-length) before this sync. A draft
release's assets are not anonymously downloadable, so the reverse order would
hand every client an update pointing at something it cannot fetch.

## Gate

```
$ node docs-site/scripts/check-desktop-update-route.mjs
desktop updater static manifest: 0.2.32 ok
```

## Duplicate check

Path overlap against **all 11 open PRs** (no result limit), on
`docs-site/docs/public/desktop/update/latest.json`: **零命中** — no open PR
touches this file.

## Known inherited failure

`doc source-pin floor (Docker)` is expected to fail here as it does on `main`:
the gate expects 110 tracked doc files and finds 111, unrelated to this
single-file modification. Tracked in #1162, with both run links and the
identical failure line recorded there.

## Note

Merging this does not put it online — the `docs-site` Vercel project is not
connected to git; deployment is a separate manual step.
