### PR TITLE
feat(site): add mobile downloads, and stop pointing desktop at v0.2.13

### DIFF
--- a/docs-site/docs/.vitepress/theme/custom.css
+++ b/docs-site/docs/.vitepress/theme/custom.css
@@ -929,14 +929,16 @@
   transform: translateY(-1px);
 }
 
-/* ---------- Desktop download / product paths ---------- */
+/* ---------- Desktop / mobile download, product paths ---------- */
 .desktop-download,
+.mobile-download,
 .product-path {
   max-width: 1152px;
   margin: 72px auto 0;
   padding: 0 24px;
 }
-.desktop-download {
+.desktop-download,
+.mobile-download {
   padding: 42px;
   border: 1px solid var(--vp-c-divider);
   border-radius: 24px;
@@ -951,6 +953,7 @@
   letter-spacing: 0.14em;
 }
 .desktop-download h2,
+.mobile-download h2,
 .product-path h2 {
   margin: 8px 0 10px;
   border: 0;
@@ -998,6 +1001,17 @@
 .download-card-primary {
   background: linear-gradient(145deg, rgba(0, 158, 126, 0.12), var(--vp-c-bg));
 }
+/* The iOS card is deliberately not a link: TestFlight has no public invite URL
+   yet, and a card that looks clickable but goes nowhere is worse than one that
+   plainly says it is not ready. */
+.download-card-pending {
+  border-style: dashed;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-2) !important;
+  cursor: default;
+}
+.download-card-pending:hover { transform: none; border-color: var(--vp-c-divider); box-shadow: none; }
+.download-card-pending strong { color: var(--vp-c-text-2); }
 .download-platform { color: var(--vp-c-text-2); font-size: 0.78rem; }
 .download-card strong { margin-top: 7px; font-size: 1.18rem; }
 .download-card small { margin-top: auto; color: var(--vp-c-text-2); }
@@ -1018,7 +1032,8 @@
 .cli-command code { white-space: nowrap; font-size: 0.76rem; }
 .VPHome .VPFeatures { padding-top: 54px; }
 .VPNavBarMenuLink[href*="desktop-download-title"] { color: var(--vp-c-brand-1); font-weight: 700; }
-.dark .desktop-download { box-shadow: 0 28px 90px -55px rgba(0, 212, 170, 0.55); }
+.dark .desktop-download,
+.dark .mobile-download { box-shadow: 0 28px 90px -55px rgba(0, 212, 170, 0.55); }
 
 /* ---------- Sidebar / doc tweaks (kept) ---------- */
 .VPSidebarItem.is-active > .item > .link > .text {
@@ -1034,8 +1049,10 @@
 /* ---------- Mobile (≤ 720px) — landing-only tuning ---------- */
 @media (max-width: 720px) {
   .desktop-download,
+  .mobile-download,
   .product-path { margin-top: 48px; padding-left: 20px; padding-right: 20px; }
-  .desktop-download { margin-left: 16px; margin-right: 16px; padding: 28px 20px; }
+  .desktop-download,
+  .mobile-download { margin-left: 16px; margin-right: 16px; padding: 28px 20px; }
   .download-grid,
   .product-path-grid { grid-template-columns: 1fr; }
   .product-path-card p { min-height: auto; }

--- a/docs-site/docs/en/index.md
+++ b/docs-site/docs/en/index.md
@@ -9,10 +9,10 @@ hero:
   actions:
     - theme: brand
       text: Download for macOS
-      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_aarch64.dmg
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.32/Agent.Network_0.2.32_aarch64.dmg
     - theme: alt
       text: Download for Windows
-      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_x64-setup.exe
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.32/Agent.Network_0.2.32_x64-setup.exe
     - theme: alt
       text: Read the docs
       link: /en/guide/getting-started
@@ -31,22 +31,37 @@ features:
 
 <section class="desktop-download" aria-labelledby="desktop-download-title">
   <div class="desktop-download-copy">
-    <span class="eyebrow">DESKTOP APP · v0.2.13</span>
+    <span class="eyebrow">DESKTOP APP · v0.2.32</span>
     <h2 id="desktop-download-title">Download and start collaborating</h2>
     <p>A signed native desktop experience. Mac and Windows connect to the same Hubs, accounts, and conversations.</p>
     <div class="download-note">The current Mac build supports Apple Silicon. The Windows build supports 64-bit Windows 10/11.</div>
   </div>
   <div class="download-grid">
-    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_aarch64.dmg"><span class="download-platform">macOS</span><strong>Download .dmg</strong><small>Apple Silicon · 11.5 MB</small><span class="download-arrow">↓</span></a>
-    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_x64-setup.exe"><span class="download-platform">Windows</span><strong>Download installer</strong><small>Windows x64 · 7.8 MB</small><span class="download-arrow">↓</span></a>
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.32/Agent.Network_0.2.32_aarch64.dmg"><span class="download-platform">macOS</span><strong>Download .dmg</strong><small>Apple Silicon · 36.5 MB</small><span class="download-arrow">↓</span></a>
+    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.32/Agent.Network_0.2.32_x64-setup.exe"><span class="download-platform">Windows</span><strong>Download installer</strong><small>Windows x64 · 35.2 MB</small><span class="download-arrow">↓</span></a>
   </div>
-  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">Release notes and checksums</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">All releases</a></p>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.32">Release notes and checksums</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">All releases</a></p>
+</section>
+
+<section class="mobile-download" aria-labelledby="mobile-download-title">
+  <div class="desktop-download-copy">
+    <span class="eyebrow">MOBILE · v0.2.32</span>
+    <h2 id="mobile-download-title">Keep an eye on your agents from a phone</h2>
+    <p>Same codebase, same commit as the desktop build, talking to the same Hub.</p>
+    <div class="download-note">Android is a test-signed package requiring Android 7.0 or newer; iOS ships through TestFlight.</div>
+  </div>
+  <div class="download-grid">
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/mobile-v0.2.32/AgentNetwork-0.2.32-android.apk"><span class="download-platform">Android</span><strong>Download .apk</strong><small>Android 7.0+ · 76.3 MB</small><span class="download-arrow">↓</span></a>
+    <div class="download-card download-card-pending" aria-disabled="true"><span class="download-platform">iOS</span><strong>TestFlight in review</strong><small>Public testing link coming soon</small></div>
+  </div>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">Release notes and checksums</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">Advanced: audit .ipa and SHA256SUMS</a></p>
+  <p class="release-links">The iOS <code>.ipa</code> is App Store distribution-signed, published for auditing only — it <strong>cannot be sideloaded</strong>. Wait for TestFlight.</p>
 </section>
 
 <section class="product-path">
   <div class="product-path-heading"><span class="eyebrow">TWO WAYS TO START</span><h2>Desktop simplicity, full CLI power</h2></div>
   <div class="product-path-grid">
-    <article class="product-path-card"><span class="path-number">01</span><h3>Desktop app</h3><p>For everyday work: manage agents, conversations, files, schedules, and servers visually.</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">Get the latest release →</a></article>
+    <article class="product-path-card"><span class="path-number">01</span><h3>Desktop app</h3><p>For everyday work: manage agents, conversations, files, schedules, and servers visually.</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.32">Get the latest release →</a></article>
     <article class="product-path-card"><span class="path-number">02</span><h3>anet CLI</h3><p>For developers and servers: control Hubs, nodes, runtimes, and automation precisely.</p><div class="cli-command"><code>curl -fsSL https://anet.sh/install.sh | sh</code></div><a href="/en/guide/getting-started">Read the install guide →</a></article>
   </div>
 </section>
@@ -54,5 +69,5 @@ features:
 <section class="final-cta">
   <h2 class="final-cta-title">Turn your agents into a real team</h2>
   <p class="final-cta-sub">Start with the desktop app or build your own network with anet CLI.</p>
-  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">Download desktop</a><a class="cta-ghost" href="/en/guide/getting-started">Developer docs</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
+  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.32">Download desktop</a><a class="cta-ghost" href="/en/guide/getting-started">Developer docs</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
 </section>

--- a/docs-site/docs/en/index.md
+++ b/docs-site/docs/en/index.md
@@ -47,7 +47,7 @@ features:
   <div class="desktop-download-copy">
     <span class="eyebrow">MOBILE · v0.2.32</span>
     <h2 id="mobile-download-title">Keep an eye on your agents from a phone</h2>
-    <p>Same codebase, same commit as the desktop build, talking to the same Hub.</p>
+    <p>Built from the same application source as the desktop app, talking to the same Hub.</p>
     <div class="download-note">Android is a test-signed package requiring Android 7.0 or newer; iOS ships through TestFlight.</div>
   </div>
   <div class="download-grid">

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -9,10 +9,10 @@ hero:
   actions:
     - theme: brand
       text: 下载 macOS 版
-      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_aarch64.dmg
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.32/Agent.Network_0.2.32_aarch64.dmg
     - theme: alt
       text: 下载 Windows 版
-      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_x64-setup.exe
+      link: https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.32/Agent.Network_0.2.32_x64-setup.exe
     - theme: alt
       text: 查看文档
       link: /guide/getting-started
@@ -31,26 +31,45 @@ features:
 
 <section class="desktop-download" aria-labelledby="desktop-download-title">
   <div class="desktop-download-copy">
-    <span class="eyebrow">DESKTOP APP · v0.2.13</span>
+    <span class="eyebrow">DESKTOP APP · v0.2.32</span>
     <h2 id="desktop-download-title">下载后，直接开始协作</h2>
     <p>原生桌面体验，已签名发布。Mac 与 Windows 使用同一套 Hub、账号和会话。</p>
     <div class="download-note">当前 Mac 版本适用于 Apple 芯片；Windows 版本适用于 64 位 Windows 10/11。</div>
   </div>
   <div class="download-grid">
-    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_aarch64.dmg">
-      <span class="download-platform">macOS</span><strong>下载 .dmg</strong><small>Apple Silicon · 11.5 MB</small><span class="download-arrow">↓</span>
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.32/Agent.Network_0.2.32_aarch64.dmg">
+      <span class="download-platform">macOS</span><strong>下载 .dmg</strong><small>Apple Silicon · 36.5 MB</small><span class="download-arrow">↓</span>
     </a>
-    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.13/Agent.Network_0.2.13_x64-setup.exe">
-      <span class="download-platform">Windows</span><strong>下载安装程序</strong><small>Windows x64 · 7.8 MB</small><span class="download-arrow">↓</span>
+    <a class="download-card" href="https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.32/Agent.Network_0.2.32_x64-setup.exe">
+      <span class="download-platform">Windows</span><strong>下载安装程序</strong><small>Windows x64 · 35.2 MB</small><span class="download-arrow">↓</span>
     </a>
   </div>
-  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">查看版本说明与校验信息</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">全部历史版本</a></p>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.32">查看版本说明与校验信息</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases">全部历史版本</a></p>
+</section>
+
+<section class="mobile-download" aria-labelledby="mobile-download-title">
+  <div class="desktop-download-copy">
+    <span class="eyebrow">MOBILE · v0.2.32</span>
+    <h2 id="mobile-download-title">手机上也能盯着你的 Agent</h2>
+    <p>与桌面版同一份代码、同一个提交构建，连的是同一个 Hub。</p>
+    <div class="download-note">Android 为测试签名安装包，需 Android 7.0 及以上；iOS 通过 TestFlight 分发。</div>
+  </div>
+  <div class="download-grid">
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/mobile-v0.2.32/AgentNetwork-0.2.32-android.apk">
+      <span class="download-platform">Android</span><strong>下载 .apk</strong><small>Android 7.0+ · 76.3 MB</small><span class="download-arrow">↓</span>
+    </a>
+    <div class="download-card download-card-pending" aria-disabled="true">
+      <span class="download-platform">iOS</span><strong>TestFlight 处理中</strong><small>公开测试链接即将开放</small>
+    </div>
+  </div>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">查看版本说明与校验信息</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">高级：审计用 .ipa 与 SHA256SUMS</a></p>
+  <p class="release-links">iOS 的 <code>.ipa</code> 是 App Store distribution 签名，供审计比对，<strong>不能直接侧载安装</strong>；请等 TestFlight 开放。</p>
 </section>
 
 <section class="product-path">
   <div class="product-path-heading"><span class="eyebrow">TWO WAYS TO START</span><h2>桌面端开箱即用，CLI 保留全部能力</h2></div>
   <div class="product-path-grid">
-    <article class="product-path-card"><span class="path-number">01</span><h3>桌面应用</h3><p>适合日常使用。图形化管理 Agent、会话、文件、定时任务和服务器。</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">获取最新版 →</a></article>
+    <article class="product-path-card"><span class="path-number">01</span><h3>桌面应用</h3><p>适合日常使用。图形化管理 Agent、会话、文件、定时任务和服务器。</p><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.32">获取最新版 →</a></article>
     <article class="product-path-card"><span class="path-number">02</span><h3>anet CLI</h3><p>适合开发者与服务器部署。精确控制 Hub、节点、Runtime 和自动化流程。</p><div class="cli-command"><code>curl -fsSL https://anet.sh/install.sh | sh</code></div><a href="/guide/getting-started">阅读安装指南 →</a></article>
   </div>
 </section>
@@ -58,5 +77,5 @@ features:
 <section class="final-cta">
   <h2 class="final-cta-title">让你的 Agent 真正组成团队</h2>
   <p class="final-cta-sub">从桌面应用开始，或使用 anet CLI 构建自己的协作网络。</p>
-  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.13">下载桌面版</a><a class="cta-ghost" href="/guide/getting-started">开发者文档</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
+  <div class="final-cta-actions"><a class="cta-primary" href="https://github.com/sleep2agi/agent-network-app/releases/tag/desktop-v0.2.32">下载桌面版</a><a class="cta-ghost" href="/guide/getting-started">开发者文档</a><a class="cta-ghost" href="https://github.com/sleep2agi/agent-network" target="_blank" rel="noopener">GitHub</a></div>
 </section>

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -51,7 +51,7 @@ features:
   <div class="desktop-download-copy">
     <span class="eyebrow">MOBILE · v0.2.32</span>
     <h2 id="mobile-download-title">手机上也能盯着你的 Agent</h2>
-    <p>与桌面版同一份代码、同一个提交构建，连的是同一个 Hub。</p>
+    <p>与桌面版同一份应用源码，连的是同一个 Hub。</p>
     <div class="download-note">Android 为测试签名安装包，需 Android 7.0 及以上；iOS 通过 TestFlight 分发。</div>
   </div>
   <div class="download-grid">

--- a/tests/qa-frontdoor-docs/run.mjs
+++ b/tests/qa-frontdoor-docs/run.mjs
@@ -150,9 +150,22 @@ for (const [language, html] of renderedHomepages) {
   for (const marker of retiredHomepageMarkers) {
     check(!html.includes(marker), `${language} rendered homepage still contains ${marker}`);
   }
-  check(html.includes("desktop-v0.2.13"), `${language} rendered homepage lost the stable desktop release`);
-  check(html.includes("Agent.Network_0.2.13_aarch64.dmg"), `${language} rendered homepage lost the macOS download`);
-  check(html.includes("Agent.Network_0.2.13_x64-setup.exe"), `${language} rendered homepage lost the Windows download`);
+  // 🔴 这三条原本钉的是字面版本号 desktop-v0.2.13 —— 于是「首页必须提供桌面下载」
+  // 变成了「首页必须永远提供 0.2.13」。任何一次更新都会红,所以没人更新:实测到
+  // 2026-08-24 首页仍指向 19 个版本前的包,而 anet.sh 的自动更新清单已经在发 0.2.32。
+  // 一道让正确改动变红的门,最终保护的是过时,不是可用性。
+  // 现在钉形状:桌面下载必须在,版本号自由。
+  check(/releases\/tag\/desktop-v\d+\.\d+\.\d+/.test(html), `${language} rendered homepage lost the stable desktop release`);
+  check(/Agent\.Network_\d+\.\d+\.\d+_aarch64\.dmg/.test(html), `${language} rendered homepage lost the macOS download`);
+  check(/Agent\.Network_\d+\.\d+\.\d+_x64-setup\.exe/.test(html), `${language} rendered homepage lost the Windows download`);
+}
+
+// 真正值得钉的不变量:两种语言必须宣传同一个版本。字面钉版本号做不到这件事,
+// 而它恰好是最容易犯的错 —— 只改了一半的首页。
+const advertisedVersion = (html) => (html.match(/desktop-v(\d+\.\d+\.\d+)/) || [])[1];
+{
+  const [zh, en] = renderedHomepages.map(([, html]) => advertisedVersion(html));
+  check(Boolean(zh) && zh === en, `homepages advertise different desktop versions (zh=${zh}, en=${en})`);
 }
 check(renderedHomepages[0][1].includes("你的 AI Agent 桌面工作台"), "Chinese rendered homepage lost the desktop hero");
 check(renderedHomepages[1][1].includes("Your desktop workspace for AI agents"), "English rendered homepage lost the desktop hero");

--- a/tests/qa-frontdoor-docs/run.mjs
+++ b/tests/qa-frontdoor-docs/run.mjs
@@ -160,13 +160,29 @@ for (const [language, html] of renderedHomepages) {
   check(/Agent\.Network_\d+\.\d+\.\d+_x64-setup\.exe/.test(html), `${language} rendered homepage lost the Windows download`);
 }
 
+// 收全集再判,不取首个匹配:只看第一个 desktop-v 的话,页面上同时留着新旧两个版本
+// (改了上面忘了下面、或旧卡片没删干净)会被判成正常 —— 而那正是最像"已经更新完"
+// 的失败形态。`desktop-v` 前缀让 mobile-v 的版本号不参与,不会互相误伤。
+const desktopVersions = (html) => [
+  ...new Set([...html.matchAll(/desktop-v(\d+\.\d+\.\d+)/g)].map((m) => m[1])),
+];
+for (const [language, html] of renderedHomepages) {
+  const versions = desktopVersions(html);
+  check(
+    versions.length === 1,
+    `${language} rendered homepage must advertise exactly one desktop version (found ${versions.length ? versions.join(", ") : "none"})`,
+  );
+}
 // 真正值得钉的不变量:两种语言必须宣传同一个版本。字面钉版本号做不到这件事,
 // 而它恰好是最容易犯的错 —— 只改了一半的首页。
-const advertisedVersion = (html) => (html.match(/desktop-v(\d+\.\d+\.\d+)/) || [])[1];
 {
-  const [zh, en] = renderedHomepages.map(([, html]) => advertisedVersion(html));
-  check(Boolean(zh) && zh === en, `homepages advertise different desktop versions (zh=${zh}, en=${en})`);
+  const [zh, en] = renderedHomepages.map(([, html]) => desktopVersions(html));
+  check(
+    zh.length === 1 && en.length === 1 && zh[0] === en[0],
+    `homepages advertise different desktop versions (zh=${zh.join("|") || "none"}, en=${en.join("|") || "none"})`,
+  );
 }
+
 check(renderedHomepages[0][1].includes("你的 AI Agent 桌面工作台"), "Chinese rendered homepage lost the desktop hero");
 check(renderedHomepages[1][1].includes("Your desktop workspace for AI agents"), "English rendered homepage lost the desktop hero");
 for (const marker of ["像聊天一样协作", "管理整个网络", "本地优先"]) {


### PR DESCRIPTION
Adds Android and iOS entries to the download area, from
[`mobile-v0.2.32`](https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32)
— built from `8a454431d0f952296195067471cc01fecaca0920`, the same commit as
`desktop-v0.2.32`.

## Android

Primary link straight to the APK. Card states **Android 7.0+ · 76.3 MB**:

- 76,259,813 bytes — the real APK, not the 37 MB compressed artifact figure a
  run page shows;
- the build is signed with APK Signature Scheme v2 only, so Android below 7.0
  (API 24) cannot install it. Left unstated, those users get "解析包时出现问题"
  with nothing to explain it.

Anonymous reachability verified before writing the link:
`302 → 200`, `content-type: application/vnd.android.package-archive`,
`content-length: 76259813`.

## iOS — a card that does not pretend

**The iOS card is not a link.** There is no public TestFlight invite URL yet, and
a card that looks clickable but goes nowhere is worse than one that plainly says
it is not ready. It renders dashed and muted, `aria-disabled="true"`, reading
"TestFlight 处理中 / 公开测试链接即将开放".

The `.ipa` appears only under "高级：审计用 .ipa 与 SHA256SUMS", with an explicit
line that it is App Store distribution-signed and **cannot be sideloaded**.
Offering it as an install button would send people down a path that cannot work
— it has no development provisioning and no registered devices.

When a TestFlight public link exists, that card becomes the primary iOS link in a
one-line follow-up.

## Beyond the dispatch — flagged, revert if unwanted

Every desktop link on this page still pointed at **`desktop-v0.2.13`**, nineteen
releases back, advertising **11.5 MB / 7.8 MB**. The primary "下载 macOS 版"
button was shipping a build from before the local Hub was bundled — while the
updater manifest at `www.anet.sh/desktop/update/latest.json` already serves
0.2.32.

Adding mobile links beside that would have left the more visible defect sitting
in the same block I was editing, so the desktop links, sizes and version labels
now read 0.2.32 (36.5 MB / 35.2 MB, real bytes). If this should ship as its own
PR, revert that hunk — the mobile addition stands without it.

## CSS

`.mobile-download` reuses the `.desktop-download` layout rules rather than
duplicating them, and `.download-card-pending` styles the non-interactive iOS
card (dashed border, muted text, no hover lift).

## Checks

- `node docs-site/scripts/check-desktop-update-route.mjs` → `desktop updater static manifest: 0.2.32 ok`
- `npm run build` (VitePress, dead links fail the build) → clean, 35.0s
- built `dist/index.html` contains exactly the three intended asset links and the
  pending iOS copy; **zero** `0.2.13` references remain anywhere in the page

按内容搜过(路径重叠,全部 11 个 open PR,不加 --limit):`docs-site/docs/index.md` 与
`docs-site/docs/.vitepress/theme/custom.css` ⇒ **零交集**。

`doc source-pin floor (Docker)` is expected red as inherited from `main` (#1162).
