### PR TITLE
test(docs): raise the doc-source-pin floor to 111 for the update manifest

### DIFF
--- a/tests/test831-doc-source-pins/run.sh
+++ b/tests/test831-doc-source-pins/run.sh
@@ -119,10 +119,25 @@ broken=$(printf '%s' "$out" | sed -nE 's/^broken_pins=([0-9]+)$/\1/p')
 #
 # 抬的是**分母**(110 > 108),覆盖面变大不是变小。反过来那种「把数改小让门变绿」
 # 的动作要当红线看:分母变小意味着有文件被移出取集,而假绿和真绿的输出逐字相同。
-[[ "$files" -eq 110 ]] || fail "预期扫 110 个文档文件(= git ls-files 的结果),实际 $files"
+#
+# 2026-08-25:110 → 111。新增一个文档文件:
+#     docs-site/docs/public/desktop/update/latest.json
+# 同一批(4ef14e2f..HEAD)其实新增了两个文件,另一个是
+# docs-site/scripts/check-desktop-update-route.mjs —— 它**不计入**,因为 `.mjs`
+# 不在 SCANNED_SUFFIXES(.md/.ts/.tsx/.js/.json/.vue)里。110+1=111 对得上。
+# 又是**只有 `files` 变了**:实测 uniq 仍 11、occ 仍 28 —— 这正是预期,latest.json
+# 是发版生成的产物(version/notes/pub_date/platforms 签名与下载地址),里面一个
+# `#L` 锚点都没有。
+#
+# 为什么不是"把它排除掉":`docs/public/` **本来就在取集里**,当前已有 5 个
+# public 文件被扫(skillhub 的 catalog.json、两份 SKILL.md、两份 metadata.json),
+# 其中 SKILL.md 是真正的文档正文。排除 public/ 会一次性砍掉 6 个已覆盖文件,
+# 那是"改扫描范围让门变绿",与上面那条红线是同一个动作。
+# 该文件后续发版是**原地修改**同一路径,不会再次改变计数。
+[[ "$files" -eq 111 ]] || fail "预期扫 111 个文档文件(= git ls-files 的结果),实际 $files"
 [[ "$uniq"  -eq 11  ]] || fail "预期 11 个唯一 pin,实际 $uniq"
 [[ "$occ"   -eq 28 ]] || fail "预期 28 处原始出现,实际 $occ"
-echo "  OK  walk 路径与 git 路径给出同一份清单(110 文件 / 11 唯一 pin / 28 处)"
+echo "  OK  walk 路径与 git 路径给出同一份清单(111 文件 / 11 唯一 pin / 28 处)"
 
 # ---------------------------------------------------------------------------
 # L1 — 干净树上必须绿


### PR DESCRIPTION
`doc source-pin floor (Docker)` 在 main 上一直是红的。我今天复审 #1165 时独立撞到它：新 head、上一个 head、以及 **main 自己（`7e8e08a8`）都是 failure**，失败行与 #1162 里贴的逐字相同。

一道对所有 PR 都红的门，等于这道门失效 —— 下一次真正的 pin 回归会混在这片常态红里没人分得出来。

## 多出来的那个文件是什么

`110` 是在 `4ef14e2f`（2026-08-19）定下的。那之后 `docs-site/` 下新增了两个文件：

| 文件 | 是否计入 |
|---|---|
| `docs-site/docs/public/desktop/update/latest.json` | ✅ 计入（`.json` 在 `SCANNED_SUFFIXES` 里） |
| `docs-site/scripts/check-desktop-update-route.mjs` | ❌ 不计入（`.mjs` 不在 `.md/.ts/.tsx/.js/.json/.vue` 里） |

110 + 1 = 111，对得上。

`latest.json` 是发版生成的产物（version / notes / pub_date / platforms 的签名与下载地址），里面**一个 `#L` 锚点都没有** —— 所以三个数里只有分母动了：

```
scanned_doc_files=111      ← 期望 110
unique_pins=11             ← 不变
pin_occurrences=28         ← 不变
```

这正是 run.sh 账本里前两次抬升（106→108、108→110）记录的同一个证据形态：**只有 `files` 变，另外两个不变本身就是证据**。

## 为什么是「抬」不是「排除」

`docs/public/` **本来就在取集里**：当前已有 5 个 public 文件被扫 —— skillhub 的 `catalog.json`、两份 `SKILL.md`、两份 `metadata.json`，其中 `SKILL.md` 是真正的文档正文。排除 `public/` 会一次性砍掉 6 个已覆盖文件来换一道门变绿，那正是账本注释里写成红线的那个动作（「分母变小意味着有文件被移出取集，而假绿和真绿的输出逐字相同」）。

后续发版是**原地修改**同一路径，不会再次改变计数。

## 我没有做的一件事

一开始我想把 `-eq` 改成 `-ge`（门的名字就叫 *floor*，直觉上该是下限）。读了 `run.sh:110-112` 的注释才没做——那里写得很明确：

> 这道断言正是这么用的：**加文档要把分母显式抬上来，而不能让它自己长**

等号是刻意的，改成 `-ge` 会毁掉这个性质。所以我照原样加了一条账本条目。

## 验证（本机 Docker，与 CI 同一条命令）

见证对，两次都用 `docker run --rm --network none`：

| | 结果 |
|---|---|
| 改前（`main`，`fcea821d`） | `FAIL: 预期扫 110 个文档文件(= git ls-files 的结果),实际 111` · exit **1** |
| 改后（本 PR） | `RESULT: PASS` · exit **0** |

改后那次 **L2–L7 的全部 witnessed-red 变异仍各自变红**（new-out-of-range-pin / stale-baseline-entry / broadcast-anchored-to-ack-inbox / write-baseline-refuses-new-failure 等），说明分母抬升没有削弱这道门的任何一条判据。

## 与 #1167 的关系

#1167（@vansin）**独立得出了完全相同的结论** —— 同样定位到这个 static updater JSON、同样只抬已验证的分母、同样保持 11 unique / 28 occurrences 不变。它被关闭的理由是范围调整（"scope was corrected to sleep2agi/agent-network-app issues only"），不是判断有误。

本 PR 比它窄：只动 `tests/test831-doc-source-pins/run.sh` 一个文件，**不含 #1163 的 deploy README 部分**（那是另一件事，应当单独处理）。门在 main 上仍是红的，所以这条还需要落地。

Refs #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
