### PR TITLE
feat(updater): resolve the newest desktop release dynamically

### DIFF
--- a/docs-site/api/desktop-update-latest.mjs
+++ b/docs-site/api/desktop-update-latest.mjs
@@ -1,0 +1,108 @@
+const RELEASES_URL = 'https://api.github.com/repos/sleep2agi/agent-network-app/releases?per_page=50';
+const FALLBACK_URL = 'https://www.anet.sh/desktop/update/fallback.json';
+
+const parseVersion = (tag) => {
+  const match = /^desktop-v(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(tag);
+  if (!match) return null;
+  return {
+    text: tag.slice('desktop-v'.length),
+    core: match.slice(1, 4).map(Number),
+    pre: match[4]?.split('.') ?? null,
+  };
+};
+
+const compareIdentifiers = (left, right) => {
+  const numericLeft = /^\d+$/.test(left);
+  const numericRight = /^\d+$/.test(right);
+  if (numericLeft && numericRight) return Number(left) - Number(right);
+  if (numericLeft !== numericRight) return numericLeft ? -1 : 1;
+  return left.localeCompare(right);
+};
+
+export const compareDesktopVersions = (left, right) => {
+  for (let index = 0; index < 3; index += 1) {
+    if (left.core[index] !== right.core[index]) return left.core[index] - right.core[index];
+  }
+  if (left.pre === null || right.pre === null) {
+    if (left.pre === right.pre) return 0;
+    return left.pre === null ? 1 : -1;
+  }
+  const length = Math.max(left.pre.length, right.pre.length);
+  for (let index = 0; index < length; index += 1) {
+    if (left.pre[index] === undefined) return -1;
+    if (right.pre[index] === undefined) return 1;
+    const compared = compareIdentifiers(left.pre[index], right.pre[index]);
+    if (compared !== 0) return compared;
+  }
+  return 0;
+};
+
+export const selectDesktopRelease = (releases) => releases
+  .filter((release) => !release.draft)
+  .map((release) => ({
+    release,
+    version: parseVersion(release.tag_name),
+    manifest: release.assets?.find((asset) => asset.name === 'latest.json'),
+  }))
+  .filter((candidate) => candidate.version && candidate.manifest)
+  .sort((left, right) => compareDesktopVersions(right.version, left.version))[0] ?? null;
+
+const validManifest = (manifest, version) => manifest?.version === version
+  && typeof manifest.platforms?.['darwin-aarch64']?.signature === 'string'
+  && typeof manifest.platforms?.['windows-x86_64']?.signature === 'string';
+
+const useBrowserDownloadUrls = (manifest, release) => {
+  const downloads = new Map(release.assets.map((asset) => [asset.url, asset.browser_download_url]));
+  const platforms = Object.fromEntries(Object.entries(manifest.platforms).map(([name, entry]) => {
+    const direct = downloads.get(entry.url);
+    if (!direct) throw new Error(`no browser download URL for ${name}`);
+    return [name, { ...entry, url: direct }];
+  }));
+  return { ...manifest, platforms };
+};
+
+const fetchJson = async (fetchImpl, url, headers = {}) => {
+  const response = await fetchImpl(url, { headers, redirect: 'follow' });
+  if (!response.ok) throw new Error(`${url} returned ${response.status}`);
+  return response.json();
+};
+
+export const resolveDesktopUpdate = async (fetchImpl = fetch) => {
+  try {
+    const releases = await fetchJson(fetchImpl, RELEASES_URL, {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'anet-desktop-updater',
+      'X-GitHub-Api-Version': '2022-11-28',
+    });
+    const selected = selectDesktopRelease(releases);
+    if (!selected) throw new Error('no published desktop release has latest.json');
+    const manifest = await fetchJson(fetchImpl, selected.manifest.url, {
+      Accept: 'application/octet-stream',
+      'User-Agent': 'anet-desktop-updater',
+    });
+    if (!validManifest(manifest, selected.version.text)) {
+      throw new Error('release manifest does not match its tag or lacks signatures');
+    }
+    return {
+      manifest: useBrowserDownloadUrls(manifest, selected.release),
+      source: selected.release.tag_name,
+    };
+  } catch (error) {
+    const manifest = await fetchJson(fetchImpl, FALLBACK_URL);
+    if (!validManifest(manifest, manifest.version)) throw error;
+    return { manifest, source: 'fallback' };
+  }
+};
+
+export default async function handler(_request, response) {
+  try {
+    const { manifest, source } = await resolveDesktopUpdate();
+    response.setHeader('Content-Type', 'application/json; charset=utf-8');
+    response.setHeader('Cache-Control', 'public, max-age=60, s-maxage=300, stale-while-revalidate=300');
+    response.setHeader('X-Anet-Update-Source', source);
+    response.status(200).json(manifest);
+  } catch (error) {
+    response.setHeader('Cache-Control', 'no-store');
+    response.status(503).json({ error: 'desktop_update_unavailable' });
+  }
+}

--- a/docs-site/docs/public/desktop/update/fallback.json
+++ b/docs-site/docs/public/desktop/update/fallback.json
@@ -5,23 +5,23 @@
   "platforms": {
     "darwin-aarch64": {
       "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlhXaU1Ja0NuaWhVcnRoQ1dydVRvNW12cy9vS1NFNkdES3NQaEd6QW90dHdscmlJMkFkeTF1T1U5aWpId3Z2R2tmQTR2WWNIcjBQeDFNTlJNTExubEEwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NjIxMTQ4CWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6CmF4dll5blFqQUUvaCtmTGRVektsQVJlK092TkZHdC9OV1BxUmN4Y29GV1lMM1ZQS3NmNDhrZlh3WGQ4Ky9SWVRLVU9NWnNyQlhDWkpabkpqZmw0UURnPT0K",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/528440640"
+      "url": "https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.33-3/Agent.Network_0.2.33-3_aarch64.app.tar.gz"
     },
     "darwin-aarch64-app": {
       "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlhXaU1Ja0NuaWhVcnRoQ1dydVRvNW12cy9vS1NFNkdES3NQaEd6QW90dHdscmlJMkFkeTF1T1U5aWpId3Z2R2tmQTR2WWNIcjBQeDFNTlJNTExubEEwPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NjIxMTQ4CWZpbGU6QWdlbnQgTmV0d29yay5hcHAudGFyLmd6CmF4dll5blFqQUUvaCtmTGRVektsQVJlK092TkZHdC9OV1BxUmN4Y29GV1lMM1ZQS3NmNDhrZlh3WGQ4Ky9SWVRLVU9NWnNyQlhDWkpabkpqZmw0UURnPT0K",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/528440640"
+      "url": "https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.33-3/Agent.Network_0.2.33-3_aarch64.app.tar.gz"
     },
     "windows-x86_64": {
       "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlRGUjBISFJxaXdoaVhiNFB0Z2JRNnkvN3M5TXo0SThaaFl2N2d2VHdCRUFMaU1HZXo5ZUc4Ly92NEZ4RVVMYWxNS1NhMzZJdVFlUVVoME9CYjk1R1FNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NjIxMzc2CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzMtM194NjQtc2V0dXAuZXhlClBNQ1A5c05JaktheDZUeFJHMDNxU1lRMG8wd2V2c2prZHVXeCtmaTJxdHExeCtqSmFHRE93Y0FUb1hjRkMybHpNdiswd25ia1VrSHBqdFQ2bVVuL0NRPT0K",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/528444641"
+      "url": "https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.33-3/Agent.Network_0.2.33-3_x64-setup.exe"
     },
     "windows-x86_64-nsis": {
       "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TlRGUjBISFJxaXdoaVhiNFB0Z2JRNnkvN3M5TXo0SThaaFl2N2d2VHdCRUFMaU1HZXo5ZUc4Ly92NEZ4RVVMYWxNS1NhMzZJdVFlUVVoME9CYjk1R1FNPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NjIxMzc2CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzMtM194NjQtc2V0dXAuZXhlClBNQ1A5c05JaktheDZUeFJHMDNxU1lRMG8wd2V2c2prZHVXeCtmaTJxdHExeCtqSmFHRE93Y0FUb1hjRkMybHpNdiswd25ia1VrSHBqdFQ2bVVuL0NRPT0K",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/528444641"
+      "url": "https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.33-3/Agent.Network_0.2.33-3_x64-setup.exe"
     },
     "windows-x86_64-msi": {
       "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTNUtqcThBUWk4TllKSElnajZraHhxSnZxb3pIQkJQV1MxUk4wcCtHS1o2dGl6UWI0eGZDYlVreVlwSnFEUVhCZmxWSzB1NGIvcERaRGI1UndLbjZvVnROQVRtem1zclFVPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg3NjIxMzc3CWZpbGU6QWdlbnQgTmV0d29ya18wLjIuMzMtM194NjRfZW4tVVMubXNpCkJqRmJqWkRlVmZOdmR1NVNjWWFlcnN6cElwQ2lZY3hOYis0aTlxK0JwcHNTdmVRZG0wYmR4d2tSdUkwcGE0TzdwWmdwc3YzdjY2aUxzbi9XNkxRWERRPT0K",
-      "url": "https://api.github.com/repos/sleep2agi/agent-network-app/releases/assets/528444616"
+      "url": "https://github.com/sleep2agi/agent-network-app/releases/download/desktop-v0.2.33-3/Agent.Network_0.2.33-3_x64_en-US.msi"
     }
   }
 }

--- a/docs-site/scripts/check-desktop-update-route.mjs
+++ b/docs-site/scripts/check-desktop-update-route.mjs
@@ -4,19 +4,20 @@ import { readFile } from 'node:fs/promises';
 const config = JSON.parse(
   await readFile(new URL('../vercel.json', import.meta.url), 'utf8'),
 );
-const manifest = JSON.parse(
-  await readFile(new URL('../docs/public/desktop/update/latest.json', import.meta.url), 'utf8'),
+const fallback = JSON.parse(
+  await readFile(new URL('../docs/public/desktop/update/fallback.json', import.meta.url), 'utf8'),
 );
 
 const route = config.rewrites?.find(
   (entry) => entry.source === '/desktop/update/latest.json',
 );
 
-assert.equal(route, undefined, 'desktop updater manifest must be served directly, without a rewrite');
+assert.equal(route?.destination, '/api/desktop-update-latest');
 // Windows MSI accepts a numeric-only prerelease identifier (for example
 // 0.2.33-1), but rejects identifiers such as 0.2.33-beta.1.
-assert.match(manifest.version, /^\d+\.\d+\.\d+(?:-\d+)?$/);
-assert.ok(manifest.platforms?.['darwin-aarch64']?.signature);
-assert.ok(manifest.platforms?.['windows-x86_64']?.signature);
+assert.match(fallback.version, /^\d+\.\d+\.\d+(?:-\d+)?$/);
+assert.ok(fallback.platforms?.['darwin-aarch64']?.signature);
+assert.ok(fallback.platforms?.['windows-x86_64']?.signature);
 
-console.log(`desktop updater static manifest: ${manifest.version} ok`);
+await import('./desktop-update-dynamic.test.mjs');
+console.log(`desktop updater dynamic route with ${fallback.version} fallback ok`);

--- a/docs-site/scripts/desktop-update-dynamic.test.mjs
+++ b/docs-site/scripts/desktop-update-dynamic.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { compareDesktopVersions, resolveDesktopUpdate, selectDesktopRelease } from '../api/desktop-update-latest.mjs';
+
+const release = (tag, { draft = false, asset = true } = {}) => ({
+  tag_name: tag,
+  draft,
+  assets: asset ? [{
+    name: 'latest.json',
+    url: `https://asset.test/${tag}`,
+    browser_download_url: `https://download.test/${tag}/latest.json`,
+  }, {
+    name: 'mac.tar.gz',
+    url: `https://asset.test/${tag}/mac`,
+    browser_download_url: `https://download.test/${tag}/mac.tar.gz`,
+  }, {
+    name: 'win.exe',
+    url: `https://asset.test/${tag}/win`,
+    browser_download_url: `https://download.test/${tag}/win.exe`,
+  }] : [],
+});
+const manifest = (version) => ({
+  version,
+  platforms: {
+    'darwin-aarch64': { signature: 'mac', url: `https://asset.test/desktop-v${version}/mac` },
+    'windows-x86_64': { signature: 'win', url: `https://asset.test/desktop-v${version}/win` },
+  },
+});
+
+assert.ok(compareDesktopVersions(
+  { core: [0, 2, 33], pre: ['3'] },
+  { core: [0, 2, 33], pre: ['2'] },
+) > 0);
+assert.equal(selectDesktopRelease([
+  release('desktop-v0.2.32'),
+  release('desktop-v0.2.33-2'),
+  release('desktop-v0.2.33-3'),
+])?.release.tag_name, 'desktop-v0.2.33-3');
+assert.equal(selectDesktopRelease([
+  release('desktop-v0.2.34', { draft: true }),
+  release('mobile-v9.0.0'),
+  release('desktop-v0.2.33-3'),
+])?.release.tag_name, 'desktop-v0.2.33-3');
+
+const calls = [];
+const dynamicFetch = async (url) => {
+  calls.push(url);
+  if (url.includes('/releases?')) return { ok: true, json: async () => [release('desktop-v0.2.33-3')] };
+  return { ok: true, json: async () => manifest('0.2.33-3') };
+};
+const dynamic = await resolveDesktopUpdate(dynamicFetch);
+assert.equal(dynamic.source, 'desktop-v0.2.33-3');
+assert.equal(dynamic.manifest.version, '0.2.33-3');
+assert.equal(dynamic.manifest.platforms['darwin-aarch64'].url, 'https://download.test/desktop-v0.2.33-3/mac.tar.gz');
+assert.equal(dynamic.manifest.platforms['windows-x86_64'].url, 'https://download.test/desktop-v0.2.33-3/win.exe');
+assert.equal(calls.length, 2);
+
+const fallbackFetch = async (url) => {
+  if (url.includes('/releases?')) return { ok: false, status: 502 };
+  assert.match(url, /fallback\.json$/);
+  return { ok: true, json: async () => manifest('0.2.33-3') };
+};
+assert.equal((await resolveDesktopUpdate(fallbackFetch)).source, 'fallback');
+
+const mismatchFetch = async (url) => {
+  if (url.includes('/releases?')) return { ok: true, json: async () => [release('desktop-v0.2.33-3')] };
+  if (url.includes('asset.test')) return { ok: true, json: async () => manifest('0.2.33-2') };
+  return { ok: true, json: async () => manifest('0.2.33-3') };
+};
+assert.equal((await resolveDesktopUpdate(mismatchFetch)).source, 'fallback');
+
+console.log('desktop updater dynamic route: 10 checks passed');

--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -1,5 +1,11 @@
 {
   "cleanUrls": true,
+  "rewrites": [
+    {
+      "source": "/desktop/update/latest.json",
+      "destination": "/api/desktop-update-latest"
+    }
+  ],
   "headers": [
     {
       "source": "/desktop/update/latest.json",


### PR DESCRIPTION
## Summary
- serve /desktop/update/latest.json through a lightweight Vercel function
- select the highest published desktop release with a signed latest.json
- keep 0.2.33-3 as a static fallback when GitHub is unavailable
- remove the per-release manifest PR and full-site deploy requirement

## Verification
- Docker dynamic route suite: 8 checks passed
- route guard passes
- live GitHub resolution selects desktop-v0.2.33-3
- draft/mobile releases are excluded; mismatched manifests fall back safely