### PR TITLE
fix(updater): never cache the latest manifest

### DIFF
--- a/docs-site/api/desktop-update-latest.mjs
+++ b/docs-site/api/desktop-update-latest.mjs
@@ -98,7 +98,10 @@ export default async function handler(_request, response) {
   try {
     const { manifest, source } = await resolveDesktopUpdate();
     response.setHeader('Content-Type', 'application/json; charset=utf-8');
-    response.setHeader('Cache-Control', 'public, max-age=60, s-maxage=300, stale-while-revalidate=300');
+    // Manual update checks must never reuse a manifest fetched before a new
+    // release was published. A cached old manifest is indistinguishable from
+    // "already up to date" to the Tauri updater.
+    response.setHeader('Cache-Control', 'no-store, max-age=0');
     response.setHeader('X-Anet-Update-Source', source);
     response.status(200).json(manifest);
   } catch (error) {

--- a/docs-site/scripts/desktop-update-dynamic.test.mjs
+++ b/docs-site/scripts/desktop-update-dynamic.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import { compareDesktopVersions, resolveDesktopUpdate, selectDesktopRelease } from '../api/desktop-update-latest.mjs';
 
 const release = (tag, { draft = false, asset = true } = {}) => ({
@@ -68,4 +69,9 @@ const mismatchFetch = async (url) => {
 };
 assert.equal((await resolveDesktopUpdate(mismatchFetch)).source, 'fallback');
 
-console.log('desktop updater dynamic route: 10 checks passed');
+const handlerSource = fs.readFileSync(new URL('../api/desktop-update-latest.mjs', import.meta.url), 'utf8');
+const vercelConfig = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
+assert.match(handlerSource, /setHeader\('Cache-Control', 'no-store, max-age=0'\)/);
+assert.equal(vercelConfig.headers[0].headers[0].value, 'no-store, max-age=0');
+
+console.log('desktop updater dynamic route: 12 checks passed');

--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -12,7 +12,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=60, s-maxage=300, stale-while-revalidate=300"
+          "value": "no-store, max-age=0"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- mark the dynamic desktop update manifest `no-store, max-age=0` in both the function and Vercel route headers
- prevent a manual update check from receiving the manifest cached before a release was published
- add guards for both header sources

## Verification
- Docker: `desktop updater dynamic route: 12 checks passed`
- live incident: the route previously returned cached responses with `age` greater than its advertised browser max-age, causing `0.2.33-3` to report up-to-date immediately after `0.2.34` was published.