### PR TITLE
docs(site): link Android v0.2.34 download

### DIFF
--- a/docs-site/docs/en/index.md
+++ b/docs-site/docs/en/index.md
@@ -51,10 +51,10 @@ features:
     <div class="download-note">Android is a test-signed package requiring Android 7.0 or newer; iOS ships through TestFlight.</div>
   </div>
   <div class="download-grid">
-    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/mobile-v0.2.32/AgentNetwork-0.2.32-android.apk"><span class="download-platform">Android</span><strong>Download .apk</strong><small>Android 7.0+ · 76.3 MB</small><span class="download-arrow">↓</span></a>
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/mobile-v0.2.34/AgentNetwork-0.2.34-android.apk"><span class="download-platform">Android</span><strong>Download .apk</strong><small>Android 7.0+ · 76.4 MB</small><span class="download-arrow">↓</span></a>
     <div class="download-card download-card-pending" aria-disabled="true"><span class="download-platform">iOS</span><strong>TestFlight in review</strong><small>Public testing link coming soon</small></div>
   </div>
-  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">Release notes and checksums</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">Advanced: audit .ipa and SHA256SUMS</a></p>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.34">Release notes and checksum</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">Advanced: 0.2.32 audit .ipa and SHA256SUMS</a></p>
   <p class="release-links">The iOS <code>.ipa</code> is App Store distribution-signed, published for auditing only — it <strong>cannot be sideloaded</strong>. Wait for TestFlight.</p>
 </section>
 

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -55,14 +55,14 @@ features:
     <div class="download-note">Android 为测试签名安装包，需 Android 7.0 及以上；iOS 通过 TestFlight 分发。</div>
   </div>
   <div class="download-grid">
-    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/mobile-v0.2.32/AgentNetwork-0.2.32-android.apk">
-      <span class="download-platform">Android</span><strong>下载 .apk</strong><small>Android 7.0+ · 76.3 MB</small><span class="download-arrow">↓</span>
+    <a class="download-card download-card-primary" href="https://github.com/sleep2agi/agent-network-app/releases/download/mobile-v0.2.34/AgentNetwork-0.2.34-android.apk">
+      <span class="download-platform">Android</span><strong>下载 .apk</strong><small>Android 7.0+ · 76.4 MB</small><span class="download-arrow">↓</span>
     </a>
     <div class="download-card download-card-pending" aria-disabled="true">
       <span class="download-platform">iOS</span><strong>TestFlight 处理中</strong><small>公开测试链接即将开放</small>
     </div>
   </div>
-  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">查看版本说明与校验信息</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">高级：审计用 .ipa 与 SHA256SUMS</a></p>
+  <p class="release-links"><a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.34">查看版本说明与校验信息</a> · <a href="https://github.com/sleep2agi/agent-network-app/releases/tag/mobile-v0.2.32">高级：0.2.32 审计用 .ipa 与 SHA256SUMS</a></p>
   <p class="release-links">iOS 的 <code>.ipa</code> 是 App Store distribution 签名，供审计比对，<strong>不能直接侧载安装</strong>；请等 TestFlight 开放。</p>
 </section>
 


### PR DESCRIPTION
## Summary

- update the Chinese and English Android download cards from mobile-v0.2.32 to mobile-v0.2.34
- show the real APK size (76.4 MB)
- keep the older 0.2.32 iOS audit link explicit because mobile-v0.2.34 contains Android only

## Verification

- `mobile-v0.2.34` is a published prerelease targeting app commit `46591b54d6cdbb7f4eea78a22b11124452110d39`
- APK asset: `AgentNetwork-0.2.34-android.apk`, 76,411,669 bytes
- SHA-256: `fea460f8d7b9e38b95a76314c43795f0cfa71e8e85df26ed20fd48ea3ec68f24`
- Docker `tests/qa-frontdoor-docs`: PASS, including VitePress production build and bilingual homepage checks