### PR TITLE
fix(runtime): reconcile CommHub inbox without SSE

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -148,6 +148,7 @@ on:
       - 'tests/test697-codex-default-model/**'
       - 'tests/test698-atomic-peer-reply/**'
       - 'tests/test750-codex-copresence-onecommand/**'
+      - 'tests/test1179-commhub-inbox-reconcile/**'
       - 'tests/test736-pm2-fleet-rebuild/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
@@ -294,6 +295,7 @@ on:
       - 'tests/test697-codex-default-model/**'
       - 'tests/test698-atomic-peer-reply/**'
       - 'tests/test750-codex-copresence-onecommand/**'
+      - 'tests/test1179-commhub-inbox-reconcile/**'
       - 'tests/test736-pm2-fleet-rebuild/**'
       - 'tests/test631-private-config-permissions/**'
       - 'tests/test646-config-node-id-precedence/**'
@@ -870,6 +872,7 @@ jobs:
           - test697-codex-default-model
           - test698-atomic-peer-reply
           - test750-codex-copresence-onecommand
+          - test1179-commhub-inbox-reconcile
           - test736-pm2-fleet-rebuild
     steps:
       - uses: actions/checkout@v4

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -40,6 +40,7 @@ import { bumpFailure, resetFailure, applyAutoPause, resolveMaxConsecutiveFailure
 import { formatSelfLoopsBlock } from "./goals/format";
 import { startTelegramWatchdog } from "./telegram-watchdog";
 import { sseAbandonGuidance } from "./sse-recovery-guidance";
+import { resolveInboxReconcileMs } from "./inbox-reconcile";
 import {
   appendReadableAttachmentPaths,
   attachmentDescriptorsForRuntime,
@@ -6155,6 +6156,17 @@ try {
 }
 scheduleWorkInboxDrain();
 scheduleInformationalInboxDrain();
+// SSE is the low-latency doorbell, not the source of truth. Periodically pull
+// CommHub as a fallback so a dropped doorbell, a reconnect race, or an event
+// received during a long runtime turn cannot leave durable inbox rows unseen.
+// The existing drain lanes are single-flight, dirty-rerun, retry/backoff
+// arbiters, so timer and SSE triggers cannot duplicate task execution.
+const inboxReconcileMs = resolveInboxReconcileMs(process.env.COMMHUB_INBOX_RECONCILE_MS);
+log(`  inbox reconciliation: SSE + every ${inboxReconcileMs}ms`);
+setInterval(() => {
+  scheduleWorkInboxDrain();
+  scheduleInformationalInboxDrain();
+}, inboxReconcileMs);
 // RFC-024 — fire a reportStatus immediately on startup so the
 // config_snapshot reaches the hub right after register(), instead of
 // waiting up to 3 minutes for the periodic timer below to fire. Hub

--- a/agent-node/src/inbox-reconcile.test.ts
+++ b/agent-node/src/inbox-reconcile.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import {
+  DEFAULT_INBOX_RECONCILE_MS,
+  resolveInboxReconcileMs,
+} from './inbox-reconcile';
+
+describe('CommHub inbox reconciliation', () => {
+  test('uses a bounded default and rejects unsafe intervals', () => {
+    expect(resolveInboxReconcileMs(undefined)).toBe(DEFAULT_INBOX_RECONCILE_MS);
+    expect(resolveInboxReconcileMs('')).toBe(DEFAULT_INBOX_RECONCILE_MS);
+    expect(resolveInboxReconcileMs('999')).toBe(DEFAULT_INBOX_RECONCILE_MS);
+    expect(resolveInboxReconcileMs('wat')).toBe(DEFAULT_INBOX_RECONCILE_MS);
+    expect(resolveInboxReconcileMs('2500')).toBe(2500);
+  });
+
+  test('the node periodically schedules both durable inbox lanes', () => {
+    const cli = readFileSync(new URL('./cli.ts', import.meta.url), 'utf8');
+    const timer = cli.match(/setInterval\(\(\) => \{\s*scheduleWorkInboxDrain\(\);\s*scheduleInformationalInboxDrain\(\);\s*\}, inboxReconcileMs\);/s);
+    expect(timer).not.toBeNull();
+  });
+
+  test('polling reuses the same coalescing lanes as SSE', () => {
+    const cli = readFileSync(new URL('./cli.ts', import.meta.url), 'utf8');
+    expect(cli.match(/scheduleWorkInboxDrain\(\)/g)?.length).toBeGreaterThanOrEqual(4);
+    expect(cli).toContain('createInboxDrainLane');
+  });
+});

--- a/agent-node/src/inbox-reconcile.ts
+++ b/agent-node/src/inbox-reconcile.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_INBOX_RECONCILE_MS = 15_000;
+export const MIN_INBOX_RECONCILE_MS = 1_000;
+
+export function resolveInboxReconcileMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_INBOX_RECONCILE_MS;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < MIN_INBOX_RECONCILE_MS) {
+    return DEFAULT_INBOX_RECONCILE_MS;
+  }
+  return value;
+}

--- a/docs/tests/report-test1179-commhub-inbox-reconcile.txt
+++ b/docs/tests/report-test1179-commhub-inbox-reconcile.txt
@@ -1,0 +1,32 @@
+Test 1179 — CommHub inbox reconciliation fallback
+
+Objective
+- Preserve SSE as the low-latency path while periodically pulling the durable
+  CommHub inbox when an SSE doorbell is lost or arrives during a long turn.
+- Reuse the existing single-flight dirty-rerun lanes; do not create a second
+  inbox consumer or duplicate task execution.
+
+Contract
+- Default reconciliation interval: 15 seconds.
+- COMMHUB_INBOX_RECONCILE_MS may raise/change it, but invalid, fractional, or
+  sub-second values fail back to the bounded default.
+- Each tick schedules both work tasks and the informational copresence lane.
+- Existing inbox row IDs, inflight claims, ACKs and detached Codex dispatcher
+  remain the deduplication and completion authority.
+
+Verification
+- Focused Bun suites: inbox reconciliation + real inbox drain/dispatcher.
+- Production bundle: clean.
+- Docker suite: tests/test1179-commhub-inbox-reconcile/Dockerfile.
+- Docker image: anet-test1179:dev; 16 pass, 0 fail, 39 expectations.
+
+Witnessed red
+- Removing the informational-lane schedule from the periodic tick fails
+  `the node periodically schedules both durable inbox lanes` (2 pass/1 fail).
+
+Boundary
+- Polling cannot preempt a model turn by itself. Authenticated Codex
+  app-server turn/steer remains the real-time insertion path; polling closes
+  missed-doorbell and reconnect gaps.
+- Outbound task status remains queryable through CommHub get_task/list_tasks;
+  this change concerns reliable inbound discovery only.

--- a/tests/test1179-commhub-inbox-reconcile/Dockerfile
+++ b/tests/test1179-commhub-inbox-reconcile/Dockerfile
@@ -1,0 +1,8 @@
+FROM oven/bun:1.3.14
+WORKDIR /workspace
+COPY agent-node/package.json agent-node/package-lock.json ./agent-node/
+RUN cd agent-node && bun install --frozen-lockfile
+COPY agent-node ./agent-node
+COPY tests/test1179-commhub-inbox-reconcile/run.sh ./run.sh
+RUN chmod +x ./run.sh
+CMD ["./run.sh"]

--- a/tests/test1179-commhub-inbox-reconcile/run.sh
+++ b/tests/test1179-commhub-inbox-reconcile/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+cd /workspace
+bun test agent-node/src/inbox-reconcile.test.ts agent-node/src/inbox-dispatch.test.ts
+cd agent-node
+bun run build


### PR DESCRIPTION
Closes #1179.\n\nAdds a 15-second authoritative inbox reconciliation fallback while retaining SSE/turn-steer as the low-latency path. The timer reuses the existing work and informational single-flight dirty-rerun lanes, preserving inflight ID dedup, ACK ordering, retry/backoff, and Codex dispatcher behavior.\n\nDocker: `anet-test1179:dev`, 16 pass / 0 fail / 39 expectations; production bundles clean. Witnessed-red removes the informational lane from the tick and fails its named assertion.\n\nBoundary: polling closes missed-doorbell/reconnect gaps but cannot by itself preempt an active model turn.