### PR TITLE
feat(channel): let agents attach files instead of pasting the file_id

### DIFF
--- a/agent-network/src/channel-task-trace.ts
+++ b/agent-network/src/channel-task-trace.ts
@@ -6,6 +6,10 @@ export async function sendChannelTaskWithTrace(input: {
   priority?: string;
   fromAlias: string;
   networkId?: string | null;
+  /** Structured task metadata forwarded verbatim, e.g. { attachments: [...] }.
+   *  Omitted from the outbound body when absent, so a call without it is
+   *  unchanged. */
+  meta?: Record<string, unknown>;
 }, deps: {
   send: (args: Record<string, unknown>) => Promise<any>;
   log: (line: string) => void;
@@ -32,6 +36,7 @@ export async function sendChannelTaskWithTrace(input: {
       task: input.task,
       priority: input.priority || "normal",
       from_session: input.fromAlias,
+      ...(input.meta ? { meta: input.meta } : {}),
     });
     const taskId = result?.task_id || result?.message_id || result?.id || null;
     if (result?.ok === false || result?.error) emit("failed", taskId, result?.error || "commhub rejected task");

--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -32,6 +32,12 @@ import {
   channelAttachmentCacheDir,
   downloadChannelAttachments,
 } from "./channel-attachments";
+import {
+  ATTACHMENTS_SCHEMA,
+  attachmentsField,
+  attachmentsMeta,
+  normalizeOutboundAttachments,
+} from "./outbound-attachments";
 import { sendChannelTaskWithTrace } from "./channel-task-trace";
 
 // ── .env loader helper ────────────────────────────────
@@ -208,6 +214,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
             enum: ["completed", "failed", "cancelled", "blocked", "error", "in_progress"],
             description: "Task outcome: completed/failed/cancelled for final results, blocked/error/in_progress for status updates",
           },
+          attachments: ATTACHMENTS_SCHEMA,
         },
         required: ["text"],
       },
@@ -237,6 +244,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
           alias: { type: "string", description: "Target session alias" },
           task: { type: "string", description: "Task content" },
           priority: { type: "string", enum: ["high", "normal", "low"], description: "Priority (default: normal)" },
+          attachments: ATTACHMENTS_SCHEMA,
         },
         required: ["alias", "task"],
       },
@@ -351,7 +359,13 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req: any) => {
   }
 
   if (name === "commhub_reply") {
-    const { task_id, text, status } = args as any;
+    const { task_id, text, status, attachments } = args as any;
+    // Fail the call rather than dropping a malformed list: an attachment that
+    // silently vanishes is indistinguishable from one that was never sent.
+    const parsed = normalizeOutboundAttachments(attachments);
+    if (!parsed.ok) {
+      return { content: [{ type: "text", text: JSON.stringify({ ok: false, error: parsed.error }) }] };
+    }
     // V2: terminal statuses use send_reply to close task lifecycle
     if (status === "completed" || status === "failed" || status === "cancelled") {
       const replyStatus = status === "completed" ? "replied" : status;
@@ -362,6 +376,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req: any) => {
         in_reply_to: task_id || undefined,
         status: replyStatus,
         from_session: ALIAS,
+        ...attachmentsField(parsed.attachments),
       });
       if (task_id) taskOriginators.delete(task_id);
       return { content: [{ type: "text", text: JSON.stringify(result) }] };
@@ -390,11 +405,16 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req: any) => {
   }
 
   if (name === "commhub_send_task") {
-    const { alias, task, priority } = args as any;
+    const { alias, task, priority, attachments } = args as any;
+    const parsedTaskAttachments = normalizeOutboundAttachments(attachments);
+    if (!parsedTaskAttachments.ok) {
+      return { content: [{ type: "text", text: JSON.stringify({ ok: false, error: parsedTaskAttachments.error }) }] };
+    }
     const result = await sendChannelTaskWithTrace({
       alias: String(alias || ""), task: String(task || ""), priority,
       fromAlias: ALIAS,
       networkId: process.env.ANET_NETWORK_ID || ANET_CONFIG.network_id || null,
+      ...attachmentsMeta(parsedTaskAttachments.attachments),
     }, {
       send: (sendArgs) => callCommHub("send_task", sendArgs),
       log: (line) => process.env.ANET_TASK_TRACE_FORMAT === "json"

--- a/agent-network/src/outbound-attachments.test.ts
+++ b/agent-network/src/outbound-attachments.test.ts
@@ -1,0 +1,116 @@
+// run: bun src/outbound-attachments.test.ts
+//
+// The load-bearing assertion is the LAST one: with no attachments the request
+// body must be byte-identical to what it was before this module existed. Every
+// reply on the network goes through that path, so a change there is a change to
+// everything.
+import fs from "node:fs";
+import {
+  ATTACHMENTS_SCHEMA,
+  attachmentsField,
+  attachmentsMeta,
+  normalizeOutboundAttachments,
+} from "./outbound-attachments";
+
+const server = fs
+  .readFileSync(new URL("./node-server.ts", import.meta.url), "utf8")
+  .replace(/\r\n?/g, "\n");
+const trace = fs
+  .readFileSync(new URL("./channel-task-trace.ts", import.meta.url), "utf8")
+  .replace(/\r\n?/g, "\n");
+
+const ok = (v: unknown) => (normalizeOutboundAttachments(v) as any).attachments;
+const err = (v: unknown) => (normalizeOutboundAttachments(v) as any).error ?? "";
+
+const ID_A = "e697d597107f418ba1fe7d71e9464b98";
+const ID_B = "dc6c8fe2f16e46c0969e3bcff3d03cf4";
+
+const checks: Array<[string, boolean]> = [
+  // ── absent input must change nothing ──
+  ["undefined is not an error", normalizeOutboundAttachments(undefined).ok === true],
+  ["null is not an error", normalizeOutboundAttachments(null).ok === true],
+  ["empty array is not an error", normalizeOutboundAttachments([]).ok === true],
+  ["no attachments adds no field at all", JSON.stringify(attachmentsField([])) === "{}"],
+  ["no attachments adds no meta at all", JSON.stringify(attachmentsMeta([])) === "{}"],
+
+  // ── the shapes a caller actually types ──
+  ["a bare file_id string is accepted", ok([ID_A])[0].file_id === ID_A],
+  ["a bare string still gets type:file", ok([ID_A])[0].type === "file"],
+  ["an object with file_id is accepted", ok([{ file_id: ID_A }])[0].file_id === ID_A],
+  ["name/mime/size are carried through",
+    (() => {
+      const a = ok([{ file_id: ID_A, name: "chart.png", mime: "image/png", size: 238909 }])[0];
+      return a.name === "chart.png" && a.mime === "image/png" && a.size === 238909;
+    })()],
+  ["two different files are both kept", ok([ID_A, ID_B]).length === 2],
+
+  // ── rejections ──
+  ["a non-array is rejected", err("not-an-array").includes("must be an array")],
+  ["a missing file_id is rejected", err([{ name: "x.png" }]).includes("file_id")],
+  ["a malformed file_id is rejected", err([{ file_id: "../../etc/passwd" }]).includes("file_id")],
+  ["a too-short file_id is rejected", err(["abc"]).includes("file_id")],
+  ["the rejection names the index", err([ID_A, { name: "x" }]).includes("[1]")],
+  ["a duplicate file_id is rejected", err([ID_A, ID_A]).includes("duplicate")],
+  ["more than 10 is rejected",
+    err(Array.from({ length: 11 }, (_, i) => ID_A.slice(0, -2) + String(i).padStart(2, "0")))
+      .includes("too many")],
+
+  // ── malformed optional hints are dropped, not fatal: they never change WHICH
+  //    file is fetched, only its label ──
+  ["a numeric name is dropped, not rejected",
+    (() => { const a = ok([{ file_id: ID_A, name: 42 }]); return a.length === 1 && a[0].name === undefined; })()],
+  ["a negative size is dropped, not rejected",
+    (() => { const a = ok([{ file_id: ID_A, size: -5 }]); return a.length === 1 && a[0].size === undefined; })()],
+
+  // ── the two carriers differ: reply is top-level, send_task is under meta ──
+  ["reply carries attachments at the top level",
+    JSON.parse(JSON.stringify(attachmentsField(ok([ID_A])))).attachments[0].file_id === ID_A],
+  ["send_task carries them under meta",
+    JSON.parse(JSON.stringify(attachmentsMeta(ok([ID_A])))).meta.attachments[0].file_id === ID_A],
+  ["send_task preserves other meta keys",
+    (() => {
+      const m: any = attachmentsMeta(ok([ID_A]), { trace: "abc" });
+      return m.meta.trace === "abc" && m.meta.attachments.length === 1;
+    })()],
+  ["meta alone survives when there are no attachments",
+    (() => { const m: any = attachmentsMeta([], { trace: "abc" }); return m.meta.trace === "abc" && !m.meta.attachments; })()],
+
+  // ── wiring: the shim must expose AND forward, not just import ──
+  ["node-server declares attachments on commhub_reply",
+    /commhub_reply[\s\S]{0,900}?attachments:\s*ATTACHMENTS_SCHEMA/.test(server)],
+  ["node-server declares attachments on commhub_send_task",
+    /commhub_send_task[\s\S]{0,900}?attachments:\s*ATTACHMENTS_SCHEMA/.test(server)],
+  ["the reply path forwards them to send_reply",
+    /send_reply[\s\S]{0,400}?\.\.\.attachmentsField\(/.test(server)],
+  // Declaring the schema is not sending it: the task path hands `meta` to
+  // sendChannelTaskWithTrace, which must both accept and forward it or the
+  // attachment vanishes between the tool and the Hub.
+  ["the task path builds meta from the parsed list",
+    /sendChannelTaskWithTrace[\s\S]{0,400}?\.\.\.attachmentsMeta\(/.test(server)],
+  ["sendChannelTaskWithTrace accepts meta",
+    /meta\?:\s*Record<string,\s*unknown>;/.test(trace)],
+  ["sendChannelTaskWithTrace forwards meta to the Hub",
+    /deps\.send\(\{[\s\S]{0,300}?\.\.\.\(input\.meta \? \{ meta: input\.meta \} : \{\}\)/.test(trace)],
+  ["a malformed list fails the call instead of being dropped",
+    /normalizeOutboundAttachments\([\s\S]{0,200}?if\s*\(!\w+\.ok\)/.test(server)],
+
+  // ── schema copy: it exists to steer agents away from pasting ids into text ──
+  ["the schema tells agents not to paste the id into the text",
+    /instead of writing the file_id into the message text/.test(ATTACHMENTS_SCHEMA.description)],
+  ["the schema names file_id as required",
+    (ATTACHMENTS_SCHEMA.items.required as string[]).includes("file_id")],
+
+  // 🔴 The one that guards everything else: a call with no attachments must
+  //    produce exactly the body it produced before this module existed.
+  ["a reply without attachments is byte-identical to before",
+    JSON.stringify({ alias: "api", text: "hi", status: "replied", ...attachmentsField([]) })
+      === JSON.stringify({ alias: "api", text: "hi", status: "replied" })],
+];
+
+let pass = 0;
+for (const [name, good] of checks) {
+  if (!good) throw new Error(`FAIL: ${name}`);
+  pass += 1;
+  console.log(`PASS: ${name}`);
+}
+console.log(`outbound attachments: ${pass} checks passed`);

--- a/agent-network/src/outbound-attachments.ts
+++ b/agent-network/src/outbound-attachments.ts
@@ -1,0 +1,133 @@
+// Agents can upload a file (`commhub_upload_file` → file_id) but have no way to
+// ATTACH it to what they send. `commhub_reply` and `commhub_send_task` never
+// took an `attachments` argument and never forwarded one, so the only way to
+// get a file to the Dashboard was to paste the id into the message text:
+//
+//     图片 file_id: e697d597107f418ba1fe7d71e9464b98
+//     取回: GET /api/files/e697d597107f418ba1fe7d71e9464b98 (需 Bearer)
+//
+// which is exactly what the Desktop renders — internal retrieval instructions
+// as prose, no thumbnail, no download (agent-network-app#173).
+//
+// The Hub already accepts them: `send_reply` has a top-level `attachments`
+// param and `send_task` reads `meta.attachments`, both persisted into
+// `meta_json`. Inbound is handled too (channel-attachments.ts downloads and
+// surfaces them). Only the outbound half of this node's MCP shim was missing.
+//
+// This module is the pure half: shape-check and normalize what a caller hands
+// us, so the two call sites stay three lines each and the rules are testable
+// without a Hub.
+
+/** One attachment as the Hub stores it. `file_id` comes from commhub_upload_file. */
+export interface OutboundAttachment {
+  type: "file";
+  file_id: string;
+  name?: string;
+  mime?: string;
+  size?: number;
+}
+
+export type NormalizeResult =
+  | { ok: true; attachments: OutboundAttachment[] }
+  | { ok: false; error: string };
+
+/** Same shape the Hub validates against — reject here so the caller gets a
+ *  useful message instead of a rejected write it has to interpret. */
+const FILE_ID = /^[A-Za-z0-9_-]{8,64}$/;
+const MAX_ATTACHMENTS = 10;
+
+/**
+ * Normalize caller-supplied attachments into what the Hub expects.
+ *
+ * Absent input is not an error and yields no `attachments` key at all — a call
+ * without attachments must produce a byte-identical request to before this
+ * existed, or every existing reply changes behaviour the day this ships.
+ */
+export function normalizeOutboundAttachments(input: unknown): NormalizeResult {
+  if (input === undefined || input === null) return { ok: true, attachments: [] };
+  if (!Array.isArray(input)) {
+    return { ok: false, error: "attachments must be an array of { file_id, name?, mime?, size? }" };
+  }
+  if (input.length > MAX_ATTACHMENTS) {
+    return { ok: false, error: `too many attachments (${input.length} > ${MAX_ATTACHMENTS})` };
+  }
+
+  const out: OutboundAttachment[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < input.length; i += 1) {
+    const raw = input[i];
+    // A bare string is the shape people reach for first — accept it rather than
+    // making them wrap a single id in an object.
+    const item = typeof raw === "string" ? { file_id: raw } : raw;
+    if (!item || typeof item !== "object") {
+      return { ok: false, error: `attachments[${i}] must be a file_id string or an object` };
+    }
+
+    const fileId = (item as any).file_id;
+    if (typeof fileId !== "string" || !FILE_ID.test(fileId)) {
+      return {
+        ok: false,
+        error: `attachments[${i}].file_id must be the id returned by commhub_upload_file (8-64 chars of A-Za-z0-9_-), got ${JSON.stringify(fileId)}`,
+      };
+    }
+    // The same file twice would render twice; the caller almost never means it.
+    if (seen.has(fileId)) {
+      return { ok: false, error: `attachments[${i}].file_id is a duplicate: ${fileId}` };
+    }
+    seen.add(fileId);
+
+    const entry: OutboundAttachment = { type: "file", file_id: fileId };
+    const name = (item as any).name;
+    const mime = (item as any).mime;
+    const size = (item as any).size;
+    // Optional fields are carried through only when usable — a malformed hint
+    // is dropped rather than rejected, because it never changes WHICH file the
+    // Dashboard fetches, only how it labels it.
+    if (typeof name === "string" && name.trim()) entry.name = name.trim().slice(0, 200);
+    if (typeof mime === "string" && mime.trim()) entry.mime = mime.trim().slice(0, 100);
+    if (Number.isFinite(size) && (size as number) >= 0) entry.size = Math.floor(size as number);
+    out.push(entry);
+  }
+
+  return { ok: true, attachments: out };
+}
+
+/**
+ * Spread into a Hub request body. Empty → `{}`, so a call with no attachments
+ * is unchanged from before this module existed.
+ */
+export function attachmentsField(attachments: readonly OutboundAttachment[]): Record<string, unknown> {
+  return attachments.length ? { attachments: attachments.map((a) => ({ ...a })) } : {};
+}
+
+/** `send_task` carries them under `meta`, not at the top level. */
+export function attachmentsMeta(
+  attachments: readonly OutboundAttachment[],
+  existingMeta?: unknown,
+): Record<string, unknown> {
+  const base = existingMeta && typeof existingMeta === "object" && !Array.isArray(existingMeta)
+    ? { ...(existingMeta as Record<string, unknown>) }
+    : undefined;
+  if (!attachments.length) return base ? { meta: base } : {};
+  return { meta: { ...(base ?? {}), attachments: attachments.map((a) => ({ ...a })) } };
+}
+
+/** Shared wording for the two tool schemas, so they cannot drift apart. */
+export const ATTACHMENTS_SCHEMA = {
+  type: "array" as const,
+  description:
+    "Optional files to attach. Each item is a file_id from commhub_upload_file, or { file_id, name?, mime?, size? }. " +
+    "Attach files this way instead of writing the file_id into the message text — the Dashboard renders attachments as " +
+    "thumbnails with a download entry, but renders a pasted file_id as plain prose (agent-network-app#173).",
+  items: {
+    type: "object" as const,
+    properties: {
+      file_id: { type: "string", description: "The file_id returned by commhub_upload_file" },
+      name: { type: "string", description: "Display name, e.g. chart.png" },
+      mime: { type: "string", description: "MIME type, e.g. image/png" },
+      size: { type: "number", description: "Size in bytes" },
+    },
+    required: ["file_id"],
+  },
+};

--- a/docs-site/docs/api/mcp-tools.md
+++ b/docs-site/docs/api/mcp-tools.md
@@ -302,6 +302,7 @@ send_task({
 | `status` | enum | | `replied`（默认）/ `failed` / `cancelled` |
 | `from_session` | string | | 发送者标识（默认 "hub"） |
 | `network_id` | string | | Network 范围。utok_ 恰好 1 个成员网络时自动解析，可省略；跨多网络必须显式传（#517） |
+| `attachments` | array | | 附件数组，与 `send_task` 的 `meta.attachments` 对等。每项 `{ type:"file", file_id, name?, mime?, size? }`，写入 `tasks.meta_json` 与 `inbox.meta_json`。`file_id` 来自 `commhub_upload_file`（#507） |
 
 **返回值**：
 

--- a/docs-site/docs/en/api/mcp-tools.md
+++ b/docs-site/docs/en/api/mcp-tools.md
@@ -302,6 +302,7 @@ Reply to a task. Links to the original task_id and does not trigger the recipien
 | `status` | enum | | `replied` (default) / `failed` / `cancelled` |
 | `from_session` | string | | Sender identifier (default "hub") |
 | `network_id` | string | | Network scope. Auto-resolved for utok_ callers with exactly one membership — optional then; required when the caller spans multiple networks (#517) |
+| `attachments` | array | | Attachment array; parity with `send_task`'s `meta.attachments`. Each item `{ type:"file", file_id, name?, mime?, size? }`, persisted into `tasks.meta_json` and `inbox.meta_json`. `file_id` comes from `commhub_upload_file` (#507) |
 
 **Response**:
 


### PR DESCRIPTION
Agent 能上传文件拿到 `file_id`，却**没有任何办法把它附加到消息上**。`commhub_reply` 和 `commhub_send_task` 从来不接受也不转发 `attachments`，于是唯一的办法是把 id 写进正文：

```
图片 file_id: e697d597107f418ba1fe7d71e9464b98
取回: GET /api/files/e697d597107f418ba1fe7d71e9464b98 (需 Bearer)
```

桌面端就把这段内部取回指令当散文渲染——没有缩略图、没有下载入口。这正是 `agent-network-app#173` 的截图内容。**那条消息是我今天发的**，这个缺口因此暴露。

## Hub 早就支持，缺的只有这一半

| 方向 | 状态 |
|---|---|
| Hub `send_reply` | ✅ 顶层 `attachments` 参数，写进 `meta_json`（`tools.ts:1487`） |
| Hub `send_task` | ✅ 读 `meta.attachments`（`tools.ts:1192`） |
| 入站（hub → agent） | ✅ `channel-attachments.ts` 下载并呈现 |
| **出站（agent → hub）** | 🔴 **完全没有** |

所以这不是 App 渲染层的问题——**结构化附件从来没被发出去过**。

## 改动

新增 `outbound-attachments.ts`（纯函数）：

- 接受**裸 file_id 字符串**或 `{file_id, name?, mime?, size?}` —— 只发一个文件时不必包成对象
- 拒绝：非数组、缺失/畸形 `file_id`、重复 id、超过 10 个；错误消息**点明是第几项**
- `name`/`mime`/`size` 畸形时**丢弃而非拒绝** —— 它们不改变取回哪个文件，只影响标签
- 两个载体不同：reply 是顶层 `attachments`，send_task 在 `meta.attachments` 下

## 一个差点静默吞掉附件的地方

`sendChannelTaskWithTrace` 的入参类型里**没有 `meta`**，也不转发它。我第一版把 `...attachmentsMeta(...)` spread 进去，测试仍然全绿——因为我只断言了「schema 声明了附件」，没断言「它真的被送出去」。

附件会在工具和 Hub 之间**无声消失**。已修：签名加 `meta`、`deps.send` 转发，并补了两条专门的断言：

```
["sendChannelTaskWithTrace accepts meta", …]
["sendChannelTaskWithTrace forwards meta to the Hub", …]
```

## 最要紧的那条断言

```ts
["a reply without attachments is byte-identical to before",
  JSON.stringify({ alias: "api", text: "hi", status: "replied", ...attachmentsField([]) })
    === JSON.stringify({ alias: "api", text: "hi", status: "replied" })],
```

全网每一条回复都走这条路径。不带附件时请求体必须与本模块存在之前**逐字节相同**，否则这个改动等于改了所有人的行为。

## 验证

`bun src/outbound-attachments.test.ts` → **33 checks passed**

五次变异（每个目标断言唯一命中，真副本）：

| 变异 | 退出码 | 报出的断言 |
|---|---|---|
| 回复路径不再转发附件 | 1 | `the reply path forwards them to send_reply` |
| task 发送器不转发 meta | 1 | `sendChannelTaskWithTrace forwards meta to the Hub` |
| 放宽 file_id 校验 | 1 | `a malformed file_id is rejected` |
| 空附件也塞 key | 1 | `no attachments adds no field at all` |
| 重复 file_id 不再拒绝 | 1 | `a duplicate file_id is rejected` |

邻居测试：`channel-attachments.test.ts` 8/8、`node-server-channel-meta.test.ts` 4/4。

类型检查：本机缺 `@types/node`，`origin/main` 与本分支**都是 1138 条报错、差值 0**，我改的三个文件（`outbound-attachments.ts` / `.test.ts` / `channel-task-trace.ts`）**零报错**。

## 未验证

Desktop 端的实际渲染。这个 PR 让附件**能被发出**并落进 `meta_json`；App 是否把 `meta.attachments` 渲染成缩略图属于 `agent-network-app#173` 的另一半，需要真机验收。

Refs sleep2agi/agent-network-app#173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
