### PR TITLE
chore(release): bump agent-network to 2.3.0-preview.45

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.44",
+  "version": "2.3.0-preview.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.44",
+      "version": "2.3.0-preview.45",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.44",
+  "version": "2.3.0-preview.45",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.44";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.45";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.33";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs/tests/report-agent-network-preview45-pack.txt
+++ b/docs/tests/report-agent-network-preview45-pack.txt
@@ -1,0 +1,90 @@
+# @sleep2agi/agent-network 2.3.0-preview.45 — local pack evidence
+
+Status: PASS (local preparation only; not pushed, published, or installed globally)
+
+Source boundary
+
+- Exact base: `d829ef570096ea60f31f60d8bcab7e9522ba1a7b`
+- Release version: `2.3.0-preview.45`
+- Paired runtime: `@sleep2agi/agent-node@2.5.0-preview.33` (unchanged)
+- Changed release inputs: `agent-network/package.json`, the two root-version
+  fields in `agent-network/package-lock.json`, and
+  `PAIRED_AGENT_NETWORK_VERSION` in
+  `agent-network/src/opencode-agent-node-pair.ts`.
+- Compatibility export `OPENCODE_AGENT_NETWORK_VERSION` aliases the shared
+  constant, and the generated declaration exposes both as preview.45.
+
+SOP dry-run boundary
+
+Command:
+
+`./scripts/sync-pinned-versions.sh @sleep2agi/agent-network 2.3.0-preview.45`
+
+Result: exit 0, but the old script reported the shared-pair source as
+`unchanged`. Its registered name is the compatibility alias
+`OPENCODE_AGENT_NETWORK_VERSION`, while the literal now lives in
+`PAIRED_AGENT_NETWORK_VERSION`; therefore this dry-run is not evidence that
+the pair bump happened. The release diff and generated declarations were
+checked directly instead. No `--apply` was used.
+
+Container
+
+- Base: `node:22-bookworm-slim`
+- Node: `v22.23.2`
+- Bun: `1.3.14` (pinned archive + checksum)
+- Image: `sha256:e00ed7a14319c37b2ecd2b95a84ec8be5749d16a7225b55f8fa17e5edfac76a7`
+
+Build and pack
+
+The release package was explicitly built before packing. A diagnostic direct
+`npm pack` without a preceding build produced only LICENSE/README/package.json;
+`prepublishOnly` does not make that direct-pack shape safe. That artifact was
+discarded as evidence. The accepted command sequence was:
+
+`npm run build && npm pack --json --pack-destination /out`
+
+Accepted pack result:
+
+- id: `@sleep2agi/agent-network@2.3.0-preview.45`
+- filename: `sleep2agi-agent-network-2.3.0-preview.45.tgz`
+- size: `1,706,566` bytes
+- unpacked size: `5,135,560` bytes
+- entries: `77`
+- sha1 (npm): `997ccbd845accc5a04530fe5126bd0405ef1cc76`
+- sha256: `8ed8e13a4dae60afc25e3f2bc6ff47acfb54a9aa4e1f8b9648dae875a42e9122`
+- integrity: `sha512-QsTMg8e/jLaLbmmVrDcw/lMNUUhbFuSwD3lzht2ie/pCJXoXT23G0SGMwQ0NwrcSJqZaraNSQnB+qWK7nMlFew==`
+
+Tar inspection confirmed these required entries:
+
+- `package/dist/bin/anet.cjs`
+- `package/dist/bin/cli.js`
+- `package/dist/src/codex-copresence-recovery.d.ts`
+- `package/dist/src/opencode-agent-node-pair.d.ts`
+- `package/package.json`
+
+The packed declaration contains exact literals:
+
+- `PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.45"`
+- `OPENCODE_AGENT_NETWORK_VERSION = "2.3.0-preview.45"`
+- `PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.33"`
+- `PAIRED_AGENT_NODE_SPEC = "@sleep2agi/agent-node@2.5.0-preview.33"`
+
+Clean local install (not global)
+
+In a fresh temporary npm project inside the same Node 22 container:
+
+`npm install --ignore-scripts /out/sleep2agi-agent-network-2.3.0-preview.45.tgz @sleep2agi/agent-node@2.5.0-preview.33`
+
+Observed:
+
+- `anet v2.3.0-preview.45`
+- `agent-node v2.5.0-preview.33`
+- agent-node help advertises `codex-app-server`
+- neither package was installed under the container global npm prefix
+
+Final boundary
+
+This evidence is for the exact local base plus the stated release diff. It
+must be regenerated after rebasing onto the eventual merged main. Nothing was
+pushed, no PR was opened, no npm package or dist-tag was changed, and the host
+global npm installation was untouched.

--- a/docs/tests/report-agent-network-preview45-pack.txt
+++ b/docs/tests/report-agent-network-preview45-pack.txt
@@ -26,6 +26,14 @@ Result: exit 0. The corrected registry enumerated the writable
 preview.45. The stale `OPENCODE_*` compatibility alias is no longer treated as
 a writable release target. No `--apply` was used.
 
+The first CI run exposed a release-self collision in the new gate: its fixture
+version was pinned to preview.45, so this actual preview.45 bump could not
+produce the required `WOULD-WRITE`. The suite now derives a different next
+patch version from the checked-out `PAIRED_AGENT_NETWORK_VERSION` literal.
+The exact minimal Docker suite passed all six checks, including the stale-alias
+and old-pipeline witnessed-red cases. This makes the gate reusable for future
+versions instead of teaching it the next release number.
+
 Container
 
 - Base: `node:22-bookworm-slim`

--- a/docs/tests/report-agent-network-preview45-pack.txt
+++ b/docs/tests/report-agent-network-preview45-pack.txt
@@ -1,10 +1,11 @@
 # @sleep2agi/agent-network 2.3.0-preview.45 — local pack evidence
 
-Status: PASS (local preparation only; not pushed, published, or installed globally)
+Status: PASS on the final post-hygiene main (not published or installed globally)
 
 Source boundary
 
-- Exact base: `d829ef570096ea60f31f60d8bcab7e9522ba1a7b`
+- Exact base: `1e09f26de61d0d07f31732f04c07be3a4174cfd8`
+- Source commit under test: `b03e269a6faeb25e6cf974f7b2ec1849f478feb5`
 - Release version: `2.3.0-preview.45`
 - Paired runtime: `@sleep2agi/agent-node@2.5.0-preview.33` (unchanged)
 - Changed release inputs: `agent-network/package.json`, the two root-version
@@ -20,19 +21,17 @@ Command:
 
 `./scripts/sync-pinned-versions.sh @sleep2agi/agent-network 2.3.0-preview.45`
 
-Result: exit 0, but the old script reported the shared-pair source as
-`unchanged`. Its registered name is the compatibility alias
-`OPENCODE_AGENT_NETWORK_VERSION`, while the literal now lives in
-`PAIRED_AGENT_NETWORK_VERSION`; therefore this dry-run is not evidence that
-the pair bump happened. The release diff and generated declarations were
-checked directly instead. No `--apply` was used.
+Result: exit 0. The corrected registry enumerated the writable
+`PAIRED_AGENT_NETWORK_VERSION` literal and reported it unchanged at
+preview.45. The stale `OPENCODE_*` compatibility alias is no longer treated as
+a writable release target. No `--apply` was used.
 
 Container
 
 - Base: `node:22-bookworm-slim`
 - Node: `v22.23.2`
 - Bun: `1.3.14` (pinned archive + checksum)
-- Image: `sha256:e00ed7a14319c37b2ecd2b95a84ec8be5749d16a7225b55f8fa17e5edfac76a7`
+- Recovery/build image: `sha256:ce79cfebccb3dd6a85091df890f9cb705ca3eadc0a25c0d8f0f8617c5f304554`
 
 Build and pack
 
@@ -47,12 +46,11 @@ Accepted pack result:
 
 - id: `@sleep2agi/agent-network@2.3.0-preview.45`
 - filename: `sleep2agi-agent-network-2.3.0-preview.45.tgz`
-- size: `1,706,566` bytes
-- unpacked size: `5,135,560` bytes
+- size: `1,704,820` bytes
+- unpacked size: `5,136,227` bytes
 - entries: `77`
-- sha1 (npm): `997ccbd845accc5a04530fe5126bd0405ef1cc76`
-- sha256: `8ed8e13a4dae60afc25e3f2bc6ff47acfb54a9aa4e1f8b9648dae875a42e9122`
-- integrity: `sha512-QsTMg8e/jLaLbmmVrDcw/lMNUUhbFuSwD3lzht2ie/pCJXoXT23G0SGMwQ0NwrcSJqZaraNSQnB+qWK7nMlFew==`
+- sha256: `559b21db4221da1d0b796a9888075adb27a26b613e209d52ddf0e8480fc4b0e3`
+- integrity: `sha512-13P1WSfliyg7wx1GkcTP2yJGMBBcWxNkFySablDghOASLBqbM3lca/2SCN1b65eF/TNWpgAsyiehNgSV6kUdwA==`
 
 Tar inspection confirmed these required entries:
 
@@ -84,7 +82,6 @@ Observed:
 
 Final boundary
 
-This evidence is for the exact local base plus the stated release diff. It
-must be regenerated after rebasing onto the eventual merged main. Nothing was
-pushed, no PR was opened, no npm package or dist-tag was changed, and the host
-global npm installation was untouched.
+This evidence is for the exact final main plus the stated release diff. No npm
+package or dist-tag was changed, and the host global npm installation was
+untouched.

--- a/docs/tests/report-agent-network-preview45-recovery.txt
+++ b/docs/tests/report-agent-network-preview45-recovery.txt
@@ -1,13 +1,14 @@
 # @sleep2agi/agent-network 2.3.0-preview.45 — recovery release gate
 
-Status: PASS on exact local preparation base
+Status: PASS on exact final post-hygiene main
 
 Environment
 
-- Base commit: `d829ef570096ea60f31f60d8bcab7e9522ba1a7b`
+- Base commit: `1e09f26de61d0d07f31732f04c07be3a4174cfd8`
+- Source commit under test: `b03e269a6faeb25e6cf974f7b2ec1849f478feb5`
 - Node: `v22.23.2`
 - Bun: `1.3.14`
-- Docker image: `sha256:e00ed7a14319c37b2ecd2b95a84ec8be5749d16a7225b55f8fa17e5edfac76a7`
+- Docker image: `sha256:ce79cfebccb3dd6a85091df890f9cb705ca3eadc0a25c0d8f0f8617c5f304554`
 
 Test 1178
 
@@ -50,7 +51,6 @@ recovery snapshot, topology audit, and the exact preview.45/preview.33 pair.
 
 Release boundary
 
-This is not publication evidence. The branch has not been pushed, no PR was
-opened, npm was not published, no dist-tag moved, and no global npm package was
-modified. Rebase onto the final merged main and rerun every gate before a Draft
-PR or publish action.
+This is not publication evidence. npm was not published, no dist-tag moved,
+and no global npm package was modified. These gates were rerun after rebasing
+onto the final merged main and are suitable for the Draft release PR.

--- a/docs/tests/report-agent-network-preview45-recovery.txt
+++ b/docs/tests/report-agent-network-preview45-recovery.txt
@@ -1,0 +1,56 @@
+# @sleep2agi/agent-network 2.3.0-preview.45 — recovery release gate
+
+Status: PASS on exact local preparation base
+
+Environment
+
+- Base commit: `d829ef570096ea60f31f60d8bcab7e9522ba1a7b`
+- Node: `v22.23.2`
+- Bun: `1.3.14`
+- Docker image: `sha256:e00ed7a14319c37b2ecd2b95a84ec8be5749d16a7225b55f8fa17e5edfac76a7`
+
+Test 1178
+
+The Node 22 + Bun container ran
+`tests/test1178-codex-upgrade-recovery/run.sh` with the release bump present.
+
+Result:
+
+- 14 tests passed, 0 failed, 41 assertions
+- exact resume/read identity and persisted-history verification passed
+- failure to verify resume remained fail-closed and never called
+  `thread/start`
+- the authoritative snapshot happened only after the active writer quiesced
+- nested session state retained relative path, byte size, and sha256 evidence
+- symlink escape from CODEX_HOME was rejected
+- the redacted recovery metadata boundary excluded credentials
+- stale PATH globals were ignored
+- the immutable paired runtime remained agent-node preview.33
+- missing `codex-app-server` capability failed closed
+- TypeScript typecheck and production bundle passed
+
+Pair unit gate
+
+`src/opencode-agent-node-pair.test.ts` contributed 6 passing tests:
+
+- package and shared constant agree on network preview.45
+- agent-node remains preview.33
+- stale preview.32 PATH global cannot shadow the immutable pair
+- missing codex-app-server capability is rejected
+- only an exact package-owned entrypoint with safe modes is admitted
+- a project-local impersonator is skipped
+
+Packed recovery surface
+
+Tar inspection confirmed both
+`dist/src/codex-copresence-recovery.d.ts` and
+`dist/src/opencode-agent-node-pair.d.ts`. The declarations expose the shared
+quiesce-before-snapshot boundary, exact resume/read verification, redacted
+recovery snapshot, topology audit, and the exact preview.45/preview.33 pair.
+
+Release boundary
+
+This is not publication evidence. The branch has not been pushed, no PR was
+opened, npm was not published, no dist-tag moved, and no global npm package was
+modified. Rebase onto the final merged main and rerun every gate before a Draft
+PR or publish action.

--- a/tests/test1183-sync-pinned-dryrun/run.sh
+++ b/tests/test1183-sync-pinned-dryrun/run.sh
@@ -2,7 +2,20 @@
 set -euo pipefail
 
 SCRIPT="scripts/sync-pinned-versions.sh"
-TARGET="2.3.0-preview.45"
+# The suite must always exercise a real version difference, including when the
+# release under test happens to be the version that was current when this gate
+# was introduced. Derive a syntactically valid next patch from the checked-out
+# package instead of pinning a future release literal in the test itself.
+TARGET="$(node -e '
+  const fs = require("node:fs");
+  const source = fs.readFileSync("agent-network/src/opencode-agent-node-pair.ts", "utf8");
+  const literal = /PAIRED_AGENT_NETWORK_VERSION\s*=\s*"([^"]+)"/.exec(source);
+  if (!literal) throw new Error("missing PAIRED_AGENT_NETWORK_VERSION literal");
+  const current = literal[1];
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(current);
+  if (!match) throw new Error(`unexpected package version: ${current}`);
+  console.log(`${match[1]}.${match[2]}.${Number(match[3]) + 1}-preview.0`);
+')"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "PASS: $*"; }


### PR DESCRIPTION
## Scope

Release-only bump for the merged Codex co-presence recovery work:

- `@sleep2agi/agent-network`: `2.3.0-preview.44` → `2.3.0-preview.45`
- immutable pair constant: `PAIRED_AGENT_NETWORK_VERSION` → preview.45
- `@sleep2agi/agent-node` remains exactly `2.5.0-preview.33`
- no `latest` dist-tag movement

## Final-main evidence

Base is exact main `1e09f26de61d0d07f31732f04c07be3a4174cfd8`, after both release-hygiene PRs:

- #1183 corrected the writable `PAIRED_*` registry and dry-run gate (96/96 green before merge)
- #1184 added persistent package/lock equality checks and aligned agent-node preview.33 (93/93 green before merge)

Docker on the release source commit:

- test1178: 14/14, 41 expectations, typecheck + production bundle PASS
- immutable pair unit: 6/6 PASS
- production build + npm pack: 77 files, 1,704,820 bytes, sha256 `559b21db4221da1d0b796a9888075adb27a26b613e209d52ddf0e8480fc4b0e3`
- clean temporary install: `anet v2.3.0-preview.45` + `agent-node v2.5.0-preview.33`
- no global npm modification

## Post-merge release boundary

After all PR checks pass and this exact PR is squash-merged, rebuild/pack from exact merged main, publish only:

```bash
cd agent-network
npm publish --tag preview
```

Then verify registry `preview=.45`, `latest` unchanged, and install the exact `.45/.33` pair in a clean Node 22 environment. Real node upgrade must retain the existing `CODEX_HOME`, exact thread id and persisted history; resume verification failure is fail-closed and must not create a fresh thread.
