### PR TITLE
feat(codex): add disabled SideThread domain and adapter (PR1)

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -28,6 +28,7 @@ on:
       - 'tests/test746-setup-bun-pin/**'
       - 'tests/test751-codex-copresence-windows/**'
       - 'tests/test1183-sync-pinned-dryrun/**'
+      - 'tests/test1193-side-thread-contract/**'
       # A test directory belongs here exactly when CI executes it — otherwise
       # editing the test cannot re-run the gate that runs it. The four below are
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -7,10 +7,12 @@ class Client extends EventEmitter {
   calls: Array<{ method: string; params: any }> = [];
   forkN = 0; turnN = 0;
   loseTurnStartResponse = false;
+  holdTurnStart = false;
   async request<T>(method: string, params: any): Promise<T> {
     this.calls.push({ method, params });
     if (method === "thread/fork") return { thread: { id: `fork-${++this.forkN}` } } as T;
     if (method === "turn/start") {
+      if (this.holdTurnStart) return await new Promise<T>(() => {});
       const turnId = `turn-${++this.turnN}`;
       if (this.loseTurnStartResponse) {
         return await new Promise<T>((_resolve, reject) => queueMicrotask(() => {
@@ -115,5 +117,33 @@ describe("CodexAppServerSideThreadAdapter", () => {
     client.emit("turn/completed", { threadId: a.derivedThreadId, turn: { id: ta.turnId, status: "interrupted" } });
     client.emit("turn/completed", { threadId: b.derivedThreadId, turn: { id: tb.turnId, status: "completed" } });
     expect(got).toEqual(["bb", "aa"]);
+  });
+
+  test("duplicate derived identity and delete during starting fail closed", async () => {
+    const { client, adapter } = make();
+    const first = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    client.forkN--;
+    await expect(adapter.fork({ sideThreadId: "b", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } }))
+      .rejects.toThrow("reused a derived thread");
+    client.holdTurnStart = true;
+    void adapter.start({ sideThreadId: "a", attemptId: "pending", derivedThreadId: first.derivedThreadId, prompt: "q" }).catch(() => {});
+    await Promise.resolve();
+    await expect(adapter.delete({ derivedThreadId: first.derivedThreadId })).rejects.toThrow("active owned turn");
+    adapter.close();
+  });
+
+  test("terminal before identity echo is buffered and unowned events are reported", async () => {
+    const { client, adapter } = make();
+    const fork = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const dropped: string[] = []; const terminal: any[] = [];
+    adapter.subscribeDropped((reason) => dropped.push(reason)); adapter.subscribe((event) => terminal.push(event));
+    const start = adapter.start({ sideThreadId: "a", attemptId: "attempt", derivedThreadId: fork.derivedThreadId, prompt: "q" });
+    client.emit("turn/completed", { threadId: fork.derivedThreadId, turn: { id: "turn-1", status: "completed" } });
+    const started = await start;
+    await Bun.sleep(5);
+    expect(started.turnId).toBe("turn-1");
+    expect(terminal).toHaveLength(1);
+    client.emit("turn/completed", { threadId: "source", turn: { id: "other", status: "completed" } });
+    expect(dropped).toContain("unowned-terminal");
   });
 });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CodexAppServerSideThreadAdapter } from "./codex-app-server-adapter";
 import { SideThreadConflictError } from "./domain";
-import { PrivateFileOperationLedger } from "./operation-ledger";
+import { operationHash, PrivateFileOperationLedger, stableOperationId, type SideThreadOperation } from "./operation-ledger";
 import { PrivateFileForkLeaseStore } from "./fork-lease";
 
 const roots: string[] = [];
@@ -73,8 +73,15 @@ const make = (overrides: Partial<ConstructorParameters<typeof CodexAppServerSide
     operationLedger: new PrivateFileOperationLedger(join(root, "operations")),
     forkLeaseStore: new PrivateFileForkLeaseStore(join(root, "fork-leases")), ...overrides,
   });
-  return { client, adapter };
+  return { client, adapter, root };
 };
+
+const makeAt = (client: Client, root: string) => new CodexAppServerSideThreadAdapter({
+  client, runtimeVersion: "0.148.0", topology: "owned-stdio",
+  evidenceRevision: "test1190-wire-v2", experimentalApi: true, nodeId: "node-1",
+  operationLedger: new PrivateFileOperationLedger(join(root, "operations")),
+  forkLeaseStore: new PrivateFileForkLeaseStore(join(root, "fork-leases")), identityTimeoutMs: 5,
+});
 
 describe("CodexAppServerSideThreadAdapter", () => {
   test("capability matrix fails closed", () => {
@@ -86,6 +93,9 @@ describe("CodexAppServerSideThreadAdapter", () => {
       supported: true, exactBoundary: { through: true, before: false },
     });
     expect(make({ experimentalApi: "false" as any }).adapter.capability()).toMatchObject({ exactBoundary: { before: false } });
+    const gatedRoot = mkdtempSync(join(tmpdir(), "side-adapter-platform-")); roots.push(gatedRoot);
+    expect(make({ forkLeaseStore: new PrivateFileForkLeaseStore(gatedRoot, { platform: "win32" }) }).adapter.capability())
+      .toMatchObject({ supported: false, reason: "topology" });
   });
 
   test("fork sends one exact boundary and no permission override", async () => {
@@ -243,5 +253,58 @@ describe("CodexAppServerSideThreadAdapter", () => {
     await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
     await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
     expect(client.calls.filter((x) => x.method === "thread/delete")).toHaveLength(1);
+  });
+
+  test("recovers a lease-first snapshot tear without adopting a pre-snapshot fork", async () => {
+    const root = mkdtempSync(join(tmpdir(), "side-adapter-torn-")); roots.push(root);
+    const client = new Client();
+    client.threads.set("old-fork", { id: "old-fork", forkedFromId: "main", turns: [] });
+    client.loseForkResponse = true; client.forkResponseCreates = 0;
+    const sideThreadId = "torn-side"; const idempotencyKey = `fork-${sideThreadId}`;
+    const operationId = stableOperationId(sideThreadId, "fork", idempotencyKey);
+    const operation: SideThreadOperation = {
+      version: 1, nodeId: "node-1", sideThreadId, opId: operationId, idempotencyKey, method: "fork",
+      targetHash: operationHash("main"), fingerprint: operationHash(JSON.stringify(["main", "through", "done"])),
+      state: "prepared", updatedAt: 1,
+    };
+    new PrivateFileOperationLedger(join(root, "operations")).put(operation);
+    new PrivateFileForkLeaseStore(join(root, "fork-leases")).acquire({
+      version: 1, nodeId: "node-1", sourceThreadHash: operationHash("main"), sideThreadId,
+      operationId, fingerprint: operation.fingerprint,
+      snapshotThreadIdHashes: [operationHash("main"), operationHash("old-fork")], state: "snapshot", updatedAt: 2,
+    });
+    await expect(makeAt(client, root).fork({ sideThreadId, sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } }))
+      .rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((call) => call.method === "thread/fork")).toHaveLength(1);
+    expect(new PrivateFileOperationLedger(join(root, "operations")).get("node-1", sideThreadId, operationId)?.result?.snapshotThreadIdHashes)
+      .toContain(operationHash("old-fork"));
+  });
+
+  test("restart reconciliation restores exact terminal and cancel ownership", async () => {
+    const root = mkdtempSync(join(tmpdir(), "side-adapter-restart-")); roots.push(root);
+    const client = new Client(); const first = makeAt(client, root);
+    const forkInput = { sideThreadId: "restart-side", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } as const };
+    const fork = await first.fork(forkInput);
+    const startInput = { sideThreadId: "restart-side", attemptId: "attempt-1", derivedThreadId: fork.derivedThreadId, prompt: "q" };
+    const started = await first.start(startInput); first.close();
+    const second = makeAt(client, root); await second.fork(forkInput); await second.start(startInput);
+    await second.cancel({ sideThreadId: "restart-side", derivedThreadId: fork.derivedThreadId, turnId: started.turnId });
+    expect(client.calls.filter((call) => call.method === "turn/interrupt")).toHaveLength(1);
+    const terminal: any[] = []; second.subscribe((event) => terminal.push(event));
+    client.emit("turn/completed", { threadId: fork.derivedThreadId, turn: { id: started.turnId, status: "completed" } });
+    expect(terminal).toEqual([expect.objectContaining({ sideThreadId: "restart-side", attemptId: "attempt-1", turnId: started.turnId })]);
+  });
+
+  test("discard compensation is durable and response-loss replay never deletes twice", async () => {
+    const { client, adapter, root } = make();
+    const fork = await adapter.fork({ sideThreadId: "discard-side", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    client.loseMethods.add("thread/delete");
+    const operation = { nodeId: "node-1", idempotencyKey: "discard-request-1",
+      operationId: stableOperationId("discard-side", "delete", "discard-request-1") };
+    const input = { sideThreadId: "discard-side", derivedThreadId: fork.derivedThreadId, operation };
+    await expect(adapter.discardFork(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.discardFork(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((call) => call.method === "thread/delete")).toHaveLength(1);
+    expect(new PrivateFileOperationLedger(join(root, "operations")).get("node-1", "discard-side", operation.operationId)?.state).toBe("ambiguous");
   });
 });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { CodexAppServerSideThreadAdapter } from "./codex-app-server-adapter";
+import { SideThreadConflictError } from "./domain";
+
+class Client extends EventEmitter {
+  calls: Array<{ method: string; params: any }> = [];
+  forkN = 0; turnN = 0;
+  loseTurnStartResponse = false;
+  async request<T>(method: string, params: any): Promise<T> {
+    this.calls.push({ method, params });
+    if (method === "thread/fork") return { thread: { id: `fork-${++this.forkN}` } } as T;
+    if (method === "turn/start") {
+      const turnId = `turn-${++this.turnN}`;
+      if (this.loseTurnStartResponse) {
+        return await new Promise<T>((_resolve, reject) => queueMicrotask(() => {
+          this.emit("item/started", {
+            threadId: params.threadId, turnId,
+            item: { type: "userMessage", clientId: params.clientUserMessageId },
+          });
+          queueMicrotask(() => reject(new Error("response lost")));
+        }));
+      }
+      queueMicrotask(() => this.emit("item/started", {
+          threadId: params.threadId, turnId,
+          item: { type: "userMessage", clientId: params.clientUserMessageId },
+        }));
+      return { turn: { id: `response-${turnId}` } } as T;
+    }
+    return {} as T;
+  }
+}
+
+const make = (overrides: Partial<ConstructorParameters<typeof CodexAppServerSideThreadAdapter>[0]> = {}) => {
+  const client = new Client();
+  const adapter = new CodexAppServerSideThreadAdapter({
+    client, runtimeVersion: "0.148.0", topology: "owned", experimentalApi: true, ...overrides,
+  });
+  return { client, adapter };
+};
+
+describe("CodexAppServerSideThreadAdapter", () => {
+  test("capability matrix fails closed", () => {
+    expect(make().adapter.capability().supported).toBe(true);
+    expect(make({ runtimeVersion: "0.149.0" }).adapter.capability()).toMatchObject({ supported: false, reason: "version" });
+    expect(make({ topology: "shared" }).adapter.capability()).toMatchObject({ supported: false, reason: "topology" });
+    expect(make({ experimentalApi: false }).adapter.capability()).toMatchObject({
+      supported: true, exactBoundary: { through: true, before: false },
+    });
+  });
+
+  test("fork sends one exact boundary and no permission override", async () => {
+    const { client, adapter } = make();
+    await adapter.fork({ sideThreadId: "s1", sourceThreadId: "main", boundary: { kind: "through", turnId: "done-1" } });
+    await adapter.fork({ sideThreadId: "s2", sourceThreadId: "main", boundary: { kind: "before", turnId: "active-2" } });
+    const [a, b] = client.calls.map((x) => x.params);
+    expect(a).toEqual({ threadId: "main", ephemeral: false, lastTurnId: "done-1" });
+    expect(b).toEqual({ threadId: "main", ephemeral: false, beforeTurnId: "active-2" });
+    expect(JSON.stringify(client.calls)).not.toMatch(/approval|sandbox|cwd|instruction/i);
+  });
+
+  test("adapter itself fails before RPC for unsupported boundary", async () => {
+    const { client, adapter } = make({ experimentalApi: false });
+    await expect(adapter.fork({ sideThreadId: "s", sourceThreadId: "main", boundary: { kind: "before", turnId: "active" } }))
+      .rejects.toMatchObject({ code: "SIDE_THREAD_UNSUPPORTED", reason: "experimental-api" });
+    expect(client.calls).toHaveLength(0);
+    await expect(adapter.fork({ sideThreadId: "s", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } }))
+      .resolves.toEqual({ derivedThreadId: "fork-1" });
+  });
+
+  test("binds execution by echoed client id, not response turn id", async () => {
+    const { client, adapter } = make();
+    const { derivedThreadId } = await adapter.fork({ sideThreadId: "side", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const started = await adapter.start({ sideThreadId: "side", attemptId: "attempt", derivedThreadId, prompt: "question" });
+    expect(started.turnId).toBe("turn-1");
+    const terminals: any[] = [];
+    adapter.subscribe((e) => terminals.push(e));
+    client.emit("item/completed", { threadId: derivedThreadId, turnId: "turn-1", item: { type: "agentMessage", text: "answer" } });
+    client.emit("turn/completed", { threadId: derivedThreadId, turn: { id: "response-turn-1", status: "completed" } });
+    expect(terminals).toHaveLength(0);
+    client.emit("turn/completed", { threadId: derivedThreadId, turn: { id: "turn-1", status: "completed" } });
+    expect(terminals).toEqual([expect.objectContaining({ sideThreadId: "side", attemptId: "attempt", threadId: derivedThreadId, turnId: "turn-1", text: "answer" })]);
+  });
+
+  test("does not duplicate when response is lost after identity echo", async () => {
+    const { client, adapter } = make();
+    const { derivedThreadId } = await adapter.fork({ sideThreadId: "side", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    client.loseTurnStartResponse = true;
+    await expect(adapter.start({ sideThreadId: "side", attemptId: "attempt", derivedThreadId, prompt: "q" }))
+      .resolves.toEqual({ turnId: "turn-1" });
+    expect(client.calls.filter((x) => x.method === "turn/start")).toHaveLength(1);
+  });
+
+  test("exact cancel refuses source, sibling, and unknown turns", async () => {
+    const { client, adapter } = make();
+    const a = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const b = await adapter.fork({ sideThreadId: "b", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const turn = await adapter.start({ sideThreadId: "a", attemptId: "attempt-a", derivedThreadId: a.derivedThreadId, prompt: "q" });
+    await expect(adapter.cancel({ derivedThreadId: "main", turnId: turn.turnId })).rejects.toBeInstanceOf(SideThreadConflictError);
+    await expect(adapter.cancel({ derivedThreadId: b.derivedThreadId, turnId: turn.turnId })).rejects.toBeInstanceOf(SideThreadConflictError);
+    await adapter.cancel({ derivedThreadId: a.derivedThreadId, turnId: turn.turnId });
+    expect(client.calls.at(-1)).toEqual({ method: "turn/interrupt", params: { threadId: a.derivedThreadId, turnId: turn.turnId } });
+  });
+
+  test("out-of-order terminals remain isolated by thread and turn", async () => {
+    const { client, adapter } = make();
+    const a = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const b = await adapter.fork({ sideThreadId: "b", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const ta = await adapter.start({ sideThreadId: "a", attemptId: "aa", derivedThreadId: a.derivedThreadId, prompt: "a" });
+    const tb = await adapter.start({ sideThreadId: "b", attemptId: "bb", derivedThreadId: b.derivedThreadId, prompt: "b" });
+    const got: string[] = []; adapter.subscribe((e) => got.push(e.attemptId));
+    client.emit("turn/completed", { threadId: b.derivedThreadId, turn: { id: tb.turnId, status: "completed" } });
+    client.emit("turn/completed", { threadId: a.derivedThreadId, turn: { id: ta.turnId, status: "interrupted" } });
+    client.emit("turn/completed", { threadId: b.derivedThreadId, turn: { id: tb.turnId, status: "completed" } });
+    expect(got).toEqual(["bb", "aa"]);
+  });
+});

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -51,6 +51,7 @@ describe("CodexAppServerSideThreadAdapter", () => {
     expect(make({ experimentalApi: false }).adapter.capability()).toMatchObject({
       supported: true, exactBoundary: { through: true, before: false },
     });
+    expect(make({ experimentalApi: "false" as any }).adapter.capability()).toMatchObject({ exactBoundary: { before: false } });
   });
 
   test("fork sends one exact boundary and no permission override", async () => {
@@ -145,5 +146,17 @@ describe("CodexAppServerSideThreadAdapter", () => {
     expect(terminal).toHaveLength(1);
     client.emit("turn/completed", { threadId: "source", turn: { id: "other", status: "completed" } });
     expect(dropped).toContain("unowned-terminal");
+  });
+
+  test("identity timeout is ambiguous and close settles a pending start", async () => {
+    const { client, adapter } = make({ identityTimeoutMs: 5 });
+    const fork = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    client.holdTurnStart = true;
+    await expect(adapter.start({ sideThreadId: "a", attemptId: "amb", derivedThreadId: fork.derivedThreadId, prompt: "q" }))
+      .rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toThrow("active owned turn");
+    const pending = adapter.start({ sideThreadId: "a", attemptId: "closing", derivedThreadId: fork.derivedThreadId, prompt: "q" });
+    adapter.close();
+    await expect(pending).rejects.toThrow("closed");
   });
 });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -34,7 +34,8 @@ class Client extends EventEmitter {
 const make = (overrides: Partial<ConstructorParameters<typeof CodexAppServerSideThreadAdapter>[0]> = {}) => {
   const client = new Client();
   const adapter = new CodexAppServerSideThreadAdapter({
-    client, runtimeVersion: "0.148.0", topology: "owned", experimentalApi: true, ...overrides,
+    client, runtimeVersion: "0.148.0", topology: "owned-stdio",
+    evidenceRevision: "test1190-wire-v2", experimentalApi: true, ...overrides,
   });
   return { client, adapter };
 };
@@ -43,7 +44,8 @@ describe("CodexAppServerSideThreadAdapter", () => {
   test("capability matrix fails closed", () => {
     expect(make().adapter.capability().supported).toBe(true);
     expect(make({ runtimeVersion: "0.149.0" }).adapter.capability()).toMatchObject({ supported: false, reason: "version" });
-    expect(make({ topology: "shared" }).adapter.capability()).toMatchObject({ supported: false, reason: "topology" });
+    expect(make({ topology: "shared-websocket" }).adapter.capability()).toMatchObject({ supported: false, reason: "topology" });
+    expect(make({ evidenceRevision: "blocked-v1" }).adapter.capability()).toMatchObject({ supported: false, reason: "exact-boundary" });
     expect(make({ experimentalApi: false }).adapter.capability()).toMatchObject({
       supported: true, exactBoundary: { through: true, before: false },
     });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -1,21 +1,49 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { CodexAppServerSideThreadAdapter } from "./codex-app-server-adapter";
 import { SideThreadConflictError } from "./domain";
+import { PrivateFileOperationLedger } from "./operation-ledger";
+import { PrivateFileForkLeaseStore } from "./fork-lease";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
 
 class Client extends EventEmitter {
   calls: Array<{ method: string; params: any }> = [];
   forkN = 0; turnN = 0;
   loseTurnStartResponse = false;
+  loseForkResponse = false;
+  forkResponseCreates = 1;
   holdTurnStart = false;
+  loseMethods = new Set<string>();
+  threads = new Map<string, any>([["main", { id: "main", turns: [{ id: "done", items: [] }] }]]);
   async request<T>(method: string, params: any): Promise<T> {
     this.calls.push({ method, params });
-    if (method === "thread/fork") return { thread: { id: `fork-${++this.forkN}` } } as T;
+    if (method === "thread/list") return { data: [...this.threads.values()], nextCursor: null } as T;
+    if (method === "thread/read") {
+      const thread = this.threads.get(params.threadId);
+      if (!thread) throw Object.assign(new Error("not found"), { code: -32001 });
+      return { thread } as T;
+    }
+    if (method === "thread/fork") {
+      let last: any;
+      for (let n = 0; n < this.forkResponseCreates; n++) {
+        const id = `fork-${++this.forkN}`;
+        last = { id, forkedFromId: params.threadId, turns: [{ id: params.lastTurnId ?? "done", items: [] }] };
+        this.threads.set(id, last);
+      }
+      if (this.loseForkResponse) throw new Error("fork response lost");
+      return { thread: last } as T;
+    }
     if (method === "turn/start") {
       if (this.holdTurnStart) return await new Promise<T>(() => {});
       const turnId = `turn-${++this.turnN}`;
       if (this.loseTurnStartResponse) {
         return await new Promise<T>((_resolve, reject) => queueMicrotask(() => {
+          this.threads.get(params.threadId)?.turns.push({ id: turnId, items: [{ type: "userMessage", clientId: params.clientUserMessageId }] });
           this.emit("item/started", {
             threadId: params.threadId, turnId,
             item: { type: "userMessage", clientId: params.clientUserMessageId },
@@ -23,21 +51,27 @@ class Client extends EventEmitter {
           queueMicrotask(() => reject(new Error("response lost")));
         }));
       }
+      this.threads.get(params.threadId)?.turns.push({ id: turnId, items: [{ type: "userMessage", clientId: params.clientUserMessageId }] });
       queueMicrotask(() => this.emit("item/started", {
           threadId: params.threadId, turnId,
           item: { type: "userMessage", clientId: params.clientUserMessageId },
         }));
       return { turn: { id: `response-${turnId}` } } as T;
     }
+    if (method === "thread/delete") this.threads.delete(params.threadId);
+    if (this.loseMethods.has(method)) throw new Error(`${method} response lost`);
     return {} as T;
   }
 }
 
 const make = (overrides: Partial<ConstructorParameters<typeof CodexAppServerSideThreadAdapter>[0]> = {}) => {
   const client = new Client();
+  const root = mkdtempSync(join(tmpdir(), "side-adapter-")); roots.push(root);
   const adapter = new CodexAppServerSideThreadAdapter({
     client, runtimeVersion: "0.148.0", topology: "owned-stdio",
-    evidenceRevision: "test1190-wire-v2", experimentalApi: true, ...overrides,
+    evidenceRevision: "test1190-wire-v2", experimentalApi: true, nodeId: "node-1",
+    operationLedger: new PrivateFileOperationLedger(join(root, "operations")),
+    forkLeaseStore: new PrivateFileForkLeaseStore(join(root, "fork-leases")), ...overrides,
   });
   return { client, adapter };
 };
@@ -58,7 +92,7 @@ describe("CodexAppServerSideThreadAdapter", () => {
     const { client, adapter } = make();
     await adapter.fork({ sideThreadId: "s1", sourceThreadId: "main", boundary: { kind: "through", turnId: "done-1" } });
     await adapter.fork({ sideThreadId: "s2", sourceThreadId: "main", boundary: { kind: "before", turnId: "active-2" } });
-    const [a, b] = client.calls.map((x) => x.params);
+    const [a, b] = client.calls.filter((x) => x.method === "thread/fork").map((x) => x.params);
     expect(a).toEqual({ threadId: "main", ephemeral: false, lastTurnId: "done-1" });
     expect(b).toEqual({ threadId: "main", ephemeral: false, beforeTurnId: "active-2" });
     expect(JSON.stringify(client.calls)).not.toMatch(/approval|sandbox|cwd|instruction/i);
@@ -157,6 +191,57 @@ describe("CodexAppServerSideThreadAdapter", () => {
     await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toThrow("active owned turn");
     const pending = adapter.start({ sideThreadId: "a", attemptId: "closing", derivedThreadId: fork.derivedThreadId, prompt: "q" });
     adapter.close();
-    await expect(pending).rejects.toThrow("closed");
+    await expect(pending).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+  });
+
+  test("snapshots thread/list before fork and uniquely reconciles a lost response without another RPC", async () => {
+    const { client, adapter } = make(); client.loseForkResponse = true;
+    const fork = await adapter.fork({ sideThreadId: "lost", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    expect(fork.derivedThreadId).toBe("fork-1");
+    expect(client.calls.map((x) => x.method).slice(0, 3)).toEqual(["thread/list", "thread/fork", "thread/list"]);
+    expect(client.calls.filter((x) => x.method === "thread/fork")).toHaveLength(1);
+    const replay = await adapter.fork({ sideThreadId: "lost", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    expect(replay).toEqual(fork);
+    expect(client.calls.filter((x) => x.method === "thread/fork")).toHaveLength(1);
+  });
+
+  test("multiple post-snapshot fork candidates stay ambiguous and retries never fork again", async () => {
+    const { client, adapter } = make(); client.loseForkResponse = true; client.forkResponseCreates = 2;
+    const input = { sideThreadId: "multi", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } as const };
+    await expect(adapter.fork(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.fork(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((x) => x.method === "thread/fork")).toHaveLength(1);
+  });
+
+  test("an ambiguous start reconciles the unique persisted client identity without another turn/start", async () => {
+    const { client, adapter } = make({ identityTimeoutMs: 5 });
+    const fork = await adapter.fork({ sideThreadId: "start-lost", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    client.holdTurnStart = true;
+    const input = { sideThreadId: "start-lost", attemptId: "attempt-lost", derivedThreadId: fork.derivedThreadId, prompt: "q" };
+    await expect(adapter.start(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    client.threads.get(fork.derivedThreadId).turns.push({ id: "turn-recovered", items: [{ type: "userMessage", clientId: "anet-side:start-lost:attempt-lost" }] });
+    await expect(adapter.start(input)).resolves.toEqual({ turnId: "turn-recovered" });
+    expect(client.calls.filter((x) => x.method === "turn/start")).toHaveLength(1);
+  });
+
+  test("accepted and ambiguous start/interrupt/archive/delete operations never repeat their RPC", async () => {
+    const { client, adapter } = make({ identityTimeoutMs: 5 });
+    const fork = await adapter.fork({ sideThreadId: "ops", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const accepted = { sideThreadId: "ops", attemptId: "accepted", derivedThreadId: fork.derivedThreadId, prompt: "q" };
+    const first = await adapter.start(accepted); await adapter.start(accepted);
+    expect(client.calls.filter((x) => x.method === "turn/start")).toHaveLength(1);
+    client.loseMethods.add("turn/interrupt");
+    await expect(adapter.cancel({ derivedThreadId: fork.derivedThreadId, turnId: first.turnId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.cancel({ derivedThreadId: fork.derivedThreadId, turnId: first.turnId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((x) => x.method === "turn/interrupt")).toHaveLength(1);
+    client.loseMethods.add("thread/archive");
+    await expect(adapter.archive({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.archive({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((x) => x.method === "thread/archive")).toHaveLength(1);
+    client.emit("turn/completed", { threadId: fork.derivedThreadId, turn: { id: first.turnId, status: "completed" } });
+    client.loseMethods.add("thread/delete");
+    await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((x) => x.method === "thread/delete")).toHaveLength(1);
   });
 });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -1,6 +1,7 @@
 import type { EventEmitter } from "node:events";
 import {
   SideThreadConflictError,
+  SideThreadAmbiguousError,
   SideThreadUnsupportedError,
   type ExactBoundary,
   type SideThreadCapability,
@@ -44,8 +45,12 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   private readonly byTurn = new Map<string, Execution>();
   private readonly earlyTerminals = new Map<string, unknown>();
   private closed = false;
+  private readonly closedSignal: Promise<never>;
+  private rejectClosed!: (error: Error) => void;
 
   constructor(private readonly opts: CodexSideThreadAdapterOptions) {
+    this.closedSignal = new Promise<never>((_resolve, reject) => { this.rejectClosed = reject; });
+    void this.closedSignal.catch(() => {});
     opts.client.on("item/started", this.onItem);
     opts.client.on("item/completed", this.onItem);
     opts.client.on("item/agentMessage/delta", this.onDelta);
@@ -60,7 +65,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       supported: true, runtime: "codex-app-server", runtimeVersion: this.opts.runtimeVersion,
       topology: this.opts.topology, evidenceRevision: this.opts.evidenceRevision,
       mode: "native-exact-fork",
-      exactBoundary: { through: true, before: this.opts.experimentalApi },
+      exactBoundary: { through: true, before: this.opts.experimentalApi === true },
     };
   }
 
@@ -82,7 +87,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         ? { lastTurnId: input.boundary.turnId }
         : { beforeTurnId: input.boundary.turnId }),
     };
-    const response = await this.opts.client.request<{ thread?: { id?: string } }>("thread/fork", params);
+    const response = await this.rpc<{ thread?: { id?: string } }>("thread/fork", params);
     this.assertOpen();
     const derivedThreadId = response?.thread?.id;
     if (!derivedThreadId || derivedThreadId === input.sourceThreadId) {
@@ -107,15 +112,14 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       threadId: input.derivedThreadId, clientUserMessageId,
       text: "", resolveIdentity, rejectIdentity,
       identityTimer: setTimeout(() => {
-        this.dropExecution(execution);
-        rejectIdentity(new SideThreadConflictError("Codex did not echo the attempt identity"));
+        rejectIdentity(new SideThreadAmbiguousError("Codex accepted turn/start but did not echo identity; reconciliation required"));
       }, this.opts.identityTimeoutMs ?? 10_000),
     };
     this.byClientId.set(clientUserMessageId, execution);
     try {
       let response: { turn?: { id?: string }; turnId?: string } | undefined;
       try {
-        const request = this.opts.client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
+        const request = this.rpc<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
         threadId: input.derivedThreadId,
         clientUserMessageId,
         input: [{ type: "text", text: input.prompt }],
@@ -143,7 +147,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       }
       return { turnId };
     } catch (error) {
-      this.dropExecution(execution);
+      if (!(error instanceof SideThreadAmbiguousError)) this.dropExecution(execution);
       throw error;
     }
   }
@@ -153,13 +157,13 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     this.assertOwnedThread(input.derivedThreadId);
     const execution = this.byTurn.get(turnKey(input.derivedThreadId, input.turnId));
     if (!execution) throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
-    await this.opts.client.request("turn/interrupt", { threadId: input.derivedThreadId, turnId: input.turnId });
+    await this.rpc("turn/interrupt", { threadId: input.derivedThreadId, turnId: input.turnId });
   }
 
   async archive(input: { derivedThreadId: string }): Promise<void> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
-    await this.opts.client.request("thread/archive", { threadId: input.derivedThreadId });
+    await this.rpc("thread/archive", { threadId: input.derivedThreadId });
   }
 
   async delete(input: { derivedThreadId: string }): Promise<void> {
@@ -168,8 +172,13 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     if ([...this.byTurn.values(), ...this.byClientId.values()].some((x) => x.threadId === input.derivedThreadId)) {
       throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
     }
-    await this.opts.client.request("thread/delete", { threadId: input.derivedThreadId });
+    await this.rpc("thread/delete", { threadId: input.derivedThreadId });
     this.derivedThreads.delete(input.derivedThreadId);
+  }
+  async discardFork(input: { sideThreadId: string; derivedThreadId: string }): Promise<void> {
+    if (this.derivedThreads.get(input.derivedThreadId) !== input.sideThreadId) return;
+    try { await this.rpc("thread/delete", { threadId: input.derivedThreadId }); }
+    finally { this.derivedThreads.delete(input.derivedThreadId); }
   }
 
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void {
@@ -184,6 +193,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   close(): void {
     if (this.closed) return;
     this.closed = true;
+    this.rejectClosed(new SideThreadConflictError("Codex side-thread adapter closed"));
     this.opts.client.off("item/started", this.onItem);
     this.opts.client.off("item/completed", this.onItem);
     this.opts.client.off("item/agentMessage/delta", this.onDelta);
@@ -269,6 +279,10 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     }
   }
   private assertOpen(): void { if (this.closed) throw new SideThreadConflictError("Codex side-thread adapter closed"); }
+  private rpc<T = unknown>(method: string, params?: unknown): Promise<T> {
+    this.assertOpen();
+    return Promise.race([this.opts.client.request<T>(method, params), this.closedSignal]);
+  }
   private assertOwnedThread(threadId: string, sideThreadId?: string): void {
     this.assertSupported();
     const owner = this.derivedThreads.get(threadId);

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -6,8 +6,11 @@ import {
   type ExactBoundary,
   type SideThreadCapability,
   type SideThreadRuntimeAdapter,
+  type SideThreadRuntimeOperation,
   type SideThreadTerminalEvent,
 } from "./domain";
+import { operationHash, stableOperationId, type OperationLedger, type OperationMethod, type SideThreadOperation } from "./operation-ledger";
+import type { ForkLeaseStore } from "./fork-lease";
 
 export interface SideThreadCodexClient extends EventEmitter {
   request<T = unknown>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
@@ -19,7 +22,11 @@ export interface CodexSideThreadAdapterOptions {
   topology: "owned-stdio" | "owned-websocket" | "shared-websocket";
   evidenceRevision: string;
   experimentalApi: boolean;
+  nodeId: string;
+  operationLedger: OperationLedger;
+  forkLeaseStore: ForkLeaseStore;
   identityTimeoutMs?: number;
+  now?: () => number;
 }
 
 interface Execution {
@@ -71,7 +78,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     };
   }
 
-  async fork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary }): Promise<{ derivedThreadId: string }> {
+  async fork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary; operation?: SideThreadRuntimeOperation }): Promise<{ derivedThreadId: string }> {
     this.assertOpen();
     this.assertSupported();
     if (!this.capability().exactBoundary?.[input.boundary.kind]) {
@@ -79,6 +86,26 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         input.boundary.kind === "before" ? "experimental-api" : "exact-boundary",
         `Codex boundary '${input.boundary.kind}' is unsupported`,
       );
+    }
+    const identity = input.operation ?? this.defaultOperation(input.sideThreadId, "fork", `fork-${input.sideThreadId}`);
+    const operation = this.operation(identity, input.sideThreadId, "fork", input.sourceThreadId,
+      JSON.stringify([input.sourceThreadId, input.boundary.kind, input.boundary.turnId]));
+    const existing = this.existing(operation);
+    if (existing && existing.state !== "prepared") return this.reconcileFork({ ...input, operation: identity }, existing);
+    if (!existing) this.put(operation);
+    const sourceThreadHash = operationHash(input.sourceThreadId);
+    let lease = this.opts.forkLeaseStore.acquire({
+      version: 1, nodeId: identity.nodeId, sourceThreadHash,
+      sideThreadId: input.sideThreadId, operationId: identity.operationId,
+      fingerprint: operation.fingerprint, snapshotThreadIdHashes: operation.result?.snapshotThreadIdHashes ?? [],
+      state: "snapshot", updatedAt: this.now(),
+    });
+    if (lease.state !== "snapshot") return this.reconcileFork({ ...input, operation: identity }, this.mustOperation(operation));
+    if (lease.snapshotThreadIdHashes.length === 0) {
+      const snapshot = await this.listThreads();
+      lease = { ...lease, snapshotThreadIdHashes: snapshot.map((thread) => operationHash(thread.id)), updatedAt: this.now() };
+      this.opts.forkLeaseStore.put(lease);
+      this.put({ ...operation, result: { snapshotThreadIdHashes: lease.snapshotThreadIdHashes }, updatedAt: this.now() });
     }
     const params: Record<string, unknown> = {
       threadId: input.sourceThreadId,
@@ -89,7 +116,16 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         ? { lastTurnId: input.boundary.turnId }
         : { beforeTurnId: input.boundary.turnId }),
     };
-    const response = await this.rpc<{ thread?: { id?: string } }>("thread/fork", params);
+    const sent = { ...this.mustOperation(operation), state: "sent" as const, updatedAt: this.now() };
+    this.put(sent);
+    lease = { ...lease, state: "sent", updatedAt: this.now() }; this.opts.forkLeaseStore.put(lease);
+    let response: { thread?: { id?: string } };
+    try { response = await this.rpc<{ thread?: { id?: string } }>("thread/fork", params); }
+    catch (error) {
+      const ambiguous = { ...sent, state: "ambiguous" as const, updatedAt: this.now() };
+      this.put(ambiguous); this.opts.forkLeaseStore.put({ ...lease, state: "ambiguous", updatedAt: this.now() });
+      return this.reconcileFork({ ...input, operation: identity }, ambiguous, error);
+    }
     this.assertOpen();
     const derivedThreadId = response?.thread?.id;
     if (!derivedThreadId || derivedThreadId === input.sourceThreadId) {
@@ -97,18 +133,26 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     }
     if (this.derivedThreads.has(derivedThreadId)) throw new SideThreadConflictError("Codex reused a derived thread identity");
     this.derivedThreads.set(derivedThreadId, input.sideThreadId);
+    this.put({ ...sent, state: "accepted", result: { ...sent.result, derivedThreadIdHash: operationHash(derivedThreadId) }, updatedAt: this.now() });
+    this.opts.forkLeaseStore.release(identity.nodeId, input.sourceThreadId, identity.operationId);
     return { derivedThreadId };
   }
 
-  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string }): Promise<{ turnId: string }> {
+  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; operation?: SideThreadRuntimeOperation }): Promise<{ turnId: string }> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId, input.sideThreadId);
     const clientUserMessageId = `anet-side:${input.sideThreadId}:${input.attemptId}`;
-    if (this.byClientId.has(clientUserMessageId)) throw new SideThreadConflictError("duplicate Codex attempt identity");
+    const identity = input.operation ?? this.defaultOperation(input.sideThreadId, "start", `start-${input.attemptId}`);
+    const operation = this.operation(identity, input.sideThreadId, "start", input.derivedThreadId,
+      JSON.stringify([input.sideThreadId, input.attemptId, input.derivedThreadId, operationHash(input.prompt)]));
+    const prior = this.existing(operation);
+    if (prior && prior.state !== "prepared") return this.reconcileStart({ ...input, operation: identity }, clientUserMessageId, prior);
+    if (!prior) this.put(operation);
+    if (this.byClientId.has(clientUserMessageId)) return this.reconcileStart({ ...input, operation: identity }, clientUserMessageId, this.mustOperation(operation));
     let resolveIdentity!: (turnId: string) => void;
     let rejectIdentity!: (error: Error) => void;
-    const identity = new Promise<string>((resolve, reject) => { resolveIdentity = resolve; rejectIdentity = reject; });
-    void identity.catch(() => {});
+    const identityEcho = new Promise<string>((resolve, reject) => { resolveIdentity = resolve; rejectIdentity = reject; });
+    void identityEcho.catch(() => {});
     const execution: Execution = {
       sideThreadId: input.sideThreadId, attemptId: input.attemptId,
       threadId: input.derivedThreadId, clientUserMessageId,
@@ -121,6 +165,8 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       }, this.opts.identityTimeoutMs ?? 10_000),
     };
     this.byClientId.set(clientUserMessageId, execution);
+    const sent = { ...this.mustOperation(operation), state: "sent" as const, updatedAt: this.now() };
+    this.put(sent);
     try {
       let response: { turn?: { id?: string }; turnId?: string } | undefined;
       try {
@@ -129,7 +175,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         clientUserMessageId,
         input: [{ type: "text", text: input.prompt }],
         });
-        const abortOnIdentityFailure = identity.then(
+        const abortOnIdentityFailure = identityEcho.then(
           () => new Promise<never>(() => {}),
           (error) => Promise.reject(error),
         );
@@ -144,41 +190,52 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       if (!execution.responseTurnId && !execution.turnId) throw new SideThreadConflictError("Codex returned an invalid turn identity");
       // Response identity alone is not authoritative: Codex automatic goal
       // continuation can replace it. Wait for the echoed client id.
-      const turnId = await identity;
+      const turnId = await identityEcho;
       execution.readyForTerminal = true;
       if (execution.pendingTerminal) {
         const pending = execution.pendingTerminal;
         execution.pendingTerminal = undefined;
         setTimeout(() => this.onCompleted(pending), 0);
       }
+      this.put({ ...sent, state: "accepted", result: { turnIdHash: operationHash(turnId) }, updatedAt: this.now() });
       return { turnId };
     } catch (error) {
-      if (!(error instanceof SideThreadAmbiguousError)) this.dropExecution(execution);
-      throw error;
+      const current = this.mustOperation(operation);
+      if (current.state === "sent") this.put({ ...current, state: "ambiguous", updatedAt: this.now() });
+      if (!(error instanceof SideThreadAmbiguousError) && !execution.turnId) execution.identityAmbiguous = true;
+      throw error instanceof SideThreadAmbiguousError ? error
+        : new SideThreadAmbiguousError("Codex start outcome is ambiguous; refusing a duplicate turn/start");
     }
   }
 
-  async cancel(input: { derivedThreadId: string; turnId: string }): Promise<void> {
+  async cancel(input: { sideThreadId?: string; derivedThreadId: string; turnId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
     const execution = this.byTurn.get(turnKey(input.derivedThreadId, input.turnId));
     if (!execution) throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
-    await this.rpc("turn/interrupt", { threadId: input.derivedThreadId, turnId: input.turnId });
+    const sideThreadId = input.sideThreadId ?? execution.sideThreadId;
+    await this.durableMutation(sideThreadId, "interrupt", input.operation ?? this.defaultOperation(sideThreadId, "interrupt", `cancel-${execution.attemptId}`), input.derivedThreadId,
+      JSON.stringify([input.derivedThreadId, input.turnId]), "turn/interrupt",
+      { threadId: input.derivedThreadId, turnId: input.turnId });
   }
 
-  async archive(input: { derivedThreadId: string }): Promise<void> {
+  async archive(input: { sideThreadId?: string; derivedThreadId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
-    await this.rpc("thread/archive", { threadId: input.derivedThreadId });
+    const sideThreadId = input.sideThreadId ?? this.derivedThreads.get(input.derivedThreadId)!;
+    await this.durableMutation(sideThreadId, "archive", input.operation ?? this.defaultOperation(sideThreadId, "archive", `archive-${sideThreadId}`), input.derivedThreadId,
+      JSON.stringify([input.derivedThreadId]), "thread/archive", { threadId: input.derivedThreadId });
   }
 
-  async delete(input: { derivedThreadId: string }): Promise<void> {
+  async delete(input: { sideThreadId?: string; derivedThreadId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
     if ([...this.byTurn.values(), ...this.byClientId.values()].some((x) => x.threadId === input.derivedThreadId)) {
       throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
     }
-    await this.rpc("thread/delete", { threadId: input.derivedThreadId });
+    const sideThreadId = input.sideThreadId ?? this.derivedThreads.get(input.derivedThreadId)!;
+    await this.durableMutation(sideThreadId, "delete", input.operation ?? this.defaultOperation(sideThreadId, "delete", `purge-${sideThreadId}`), input.derivedThreadId,
+      JSON.stringify([input.derivedThreadId]), "thread/delete", { threadId: input.derivedThreadId });
     this.derivedThreads.delete(input.derivedThreadId);
   }
   async discardFork(input: { sideThreadId: string; derivedThreadId: string }): Promise<void> {
@@ -296,6 +353,149 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     this.assertOpen();
     return Promise.race([this.opts.client.request<T>(method, params), this.closedSignal]);
   }
+  private now(): number { return this.opts.now?.() ?? Date.now(); }
+  private defaultOperation(sideThreadId: string, method: OperationMethod, idempotencyKey: string): SideThreadRuntimeOperation {
+    return { nodeId: this.opts.nodeId, operationId: stableOperationId(sideThreadId, method, idempotencyKey), idempotencyKey };
+  }
+  private operation(identity: SideThreadRuntimeOperation, sideThreadId: string, method: OperationMethod, target: string, fingerprint: string): SideThreadOperation {
+    if (identity.operationId.length === 0 || identity.idempotencyKey.length === 0 || identity.nodeId.length === 0) {
+      throw new SideThreadConflictError("missing persistent operation identity");
+    }
+    if (identity.nodeId !== this.opts.nodeId) throw new SideThreadConflictError("persistent operation node ownership mismatch");
+    return { version: 1, nodeId: identity.nodeId, sideThreadId, opId: identity.operationId,
+      idempotencyKey: identity.idempotencyKey, method, targetHash: operationHash(target),
+      fingerprint: operationHash(fingerprint), state: "prepared", updatedAt: this.now() };
+  }
+  private existing(expected: SideThreadOperation): SideThreadOperation | undefined {
+    const existing = this.opts.operationLedger.get(expected.nodeId, expected.sideThreadId, expected.opId);
+    if (!existing) return undefined;
+    for (const key of ["idempotencyKey", "method", "targetHash", "fingerprint"] as const) {
+      if (existing[key] !== expected[key]) throw new SideThreadConflictError(`persistent operation ${key} mismatch`);
+    }
+    return existing;
+  }
+  private mustOperation(expected: SideThreadOperation): SideThreadOperation {
+    const operation = this.existing(expected);
+    if (!operation) throw new SideThreadConflictError("persistent operation disappeared");
+    return operation;
+  }
+  private put(operation: SideThreadOperation): void { this.opts.operationLedger.put(operation); }
+  private async reconcileFork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary; operation: SideThreadRuntimeOperation },
+    prior: SideThreadOperation, cause?: unknown): Promise<{ derivedThreadId: string }> {
+    const expected = this.operation(input.operation, input.sideThreadId, "fork", input.sourceThreadId,
+      JSON.stringify([input.sourceThreadId, input.boundary.kind, input.boundary.turnId]));
+    if (prior.state === "sent") {
+      prior = { ...prior, state: "ambiguous", updatedAt: this.now() };
+      this.put(prior);
+    }
+    let candidate: RuntimeThread | undefined;
+    try {
+      const threads = await this.listThreads();
+      if (prior.result?.derivedThreadIdHash) {
+        candidate = threads.find((thread) => operationHash(thread.id) === prior.result!.derivedThreadIdHash);
+        if (candidate && candidate.forkedFromId !== input.sourceThreadId) {
+          candidate = await this.readThread(candidate.id);
+          if (candidate.forkedFromId !== input.sourceThreadId) candidate = undefined;
+        }
+      } else {
+        const reconciling = prior.state === "reconciling" ? prior
+          : { ...prior, state: "reconciling" as const, updatedAt: this.now() };
+        if (reconciling !== prior) this.put(reconciling);
+        const snapshot = new Set(prior.result?.snapshotThreadIdHashes ?? []);
+        const unseen = threads.filter((thread) => thread.id !== input.sourceThreadId && !snapshot.has(operationHash(thread.id)));
+        const inspected = await Promise.all(unseen.map((thread) => thread.forkedFromId ? thread : this.readThread(thread.id)));
+        const candidates = inspected.filter((thread) => thread.forkedFromId === input.sourceThreadId);
+        if (candidates.length !== 1) {
+          this.put({ ...reconciling, state: "ambiguous", result: { ...reconciling.result,
+            classification: candidates.length === 0 ? "no-candidate" : "multiple-candidates" }, updatedAt: this.now() });
+          throw new SideThreadAmbiguousError(`Codex fork outcome has ${candidates.length} candidates; refusing duplicate thread/fork`);
+        }
+        candidate = candidates[0];
+        prior = reconciling;
+      }
+      if (!candidate) throw new SideThreadAmbiguousError("accepted Codex fork is not visible; refusing duplicate thread/fork");
+      if (candidate.id === input.sourceThreadId) throw new SideThreadConflictError("reconciled fork reused source thread");
+      this.registerDerived(candidate.id, input.sideThreadId);
+      if (prior.state === "accepted" || prior.state === "ambiguous" || prior.state === "reconciling") {
+        if (prior.state === "ambiguous") { prior = { ...prior, state: "reconciling", updatedAt: this.now() }; this.put(prior); }
+        this.put({ ...prior, state: "reconciled", result: { ...prior.result,
+          derivedThreadIdHash: operationHash(candidate.id), classification: "unique-candidate" }, updatedAt: this.now() });
+      }
+      this.opts.forkLeaseStore.release(input.operation.nodeId, input.sourceThreadId, input.operation.operationId);
+      return { derivedThreadId: candidate.id };
+    } catch (error) {
+      if (error instanceof SideThreadAmbiguousError || error instanceof SideThreadConflictError) throw error;
+      const current = this.mustOperation(expected);
+      if (current.state === "reconciling") this.put({ ...current, state: "ambiguous", updatedAt: this.now() });
+      throw new SideThreadAmbiguousError(`Codex fork reconciliation failed; refusing duplicate thread/fork${cause ? " after response loss" : ""}`);
+    }
+  }
+  private async reconcileStart(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; operation: SideThreadRuntimeOperation },
+    clientUserMessageId: string, prior: SideThreadOperation): Promise<{ turnId: string }> {
+    const live = this.byClientId.get(clientUserMessageId);
+    let turnId = live?.turnId;
+    let current = prior;
+    if (current.state === "sent") { current = { ...current, state: "ambiguous", updatedAt: this.now() }; this.put(current); }
+    if (!turnId) {
+      if (current.state === "ambiguous") { current = { ...current, state: "reconciling", updatedAt: this.now() }; this.put(current); }
+      try {
+        const thread = await this.readThread(input.derivedThreadId);
+        const matches = (thread.turns ?? []).filter((turn) => turnHasClientId(turn, clientUserMessageId));
+        if (prior.result?.turnIdHash) {
+          turnId = matches.find((turn) => operationHash(turn.id) === prior.result!.turnIdHash)?.id;
+        } else if (matches.length === 1) turnId = matches[0].id;
+      } catch { /* the durable ambiguity below is authoritative */ }
+    }
+    if (!turnId) {
+      if (current.state === "reconciling") this.put({ ...current, state: "ambiguous", updatedAt: this.now() });
+      throw new SideThreadAmbiguousError("Codex start outcome cannot be uniquely reconciled; refusing duplicate turn/start");
+    }
+    if (current.state === "ambiguous") { current = { ...current, state: "reconciling", updatedAt: this.now() }; this.put(current); }
+    if (current.state === "accepted" || current.state === "reconciling") {
+      this.put({ ...current, state: "reconciled", result: { ...current.result, turnIdHash: operationHash(turnId) }, updatedAt: this.now() });
+    }
+    return { turnId };
+  }
+  private async listThreads(): Promise<RuntimeThread[]> {
+    const all: RuntimeThread[] = []; let cursor: string | undefined;
+    do {
+      const response = await this.rpc<{ data?: RuntimeThread[]; threads?: RuntimeThread[]; nextCursor?: string | null }>("thread/list",
+        { limit: 100, ...(cursor ? { cursor } : {}) });
+      const page = response?.data ?? response?.threads;
+      if (!Array.isArray(page) || page.some((thread) => !thread?.id)) throw new SideThreadConflictError("Codex returned an invalid thread/list snapshot");
+      all.push(...page); cursor = response.nextCursor ?? undefined;
+      if (all.length > 10_000) throw new SideThreadConflictError("Codex thread/list snapshot exceeded bound");
+    } while (cursor);
+    return all;
+  }
+  private async readThread(threadId: string): Promise<RuntimeThread> {
+    const response = await this.rpc<{ thread?: RuntimeThread }>("thread/read", { threadId, includeTurns: true });
+    if (!response?.thread?.id || response.thread.id !== threadId) throw new SideThreadConflictError("Codex returned an invalid thread/read result");
+    return response.thread;
+  }
+  private registerDerived(threadId: string, sideThreadId: string): void {
+    const owner = this.derivedThreads.get(threadId);
+    if (owner && owner !== sideThreadId) throw new SideThreadConflictError("Codex reused a derived thread identity");
+    this.derivedThreads.set(threadId, sideThreadId);
+  }
+  private async durableMutation(sideThreadId: string, method: "interrupt" | "archive" | "delete", identity: SideThreadRuntimeOperation,
+    target: string, fingerprint: string, rpcMethod: string, params: unknown): Promise<void> {
+    const operation = this.operation(identity, sideThreadId, method, target, fingerprint);
+    const prior = this.existing(operation);
+    if (prior) {
+      if (prior.state === "accepted" || prior.state === "reconciled") return;
+      if (prior.state !== "prepared") throw new SideThreadAmbiguousError(`Codex ${method} outcome is ambiguous; refusing duplicate RPC`);
+    } else this.put(operation);
+    const sent = { ...this.mustOperation(operation), state: "sent" as const, updatedAt: this.now() };
+    this.put(sent);
+    try {
+      await this.rpc(rpcMethod, params);
+      this.put({ ...sent, state: "accepted", updatedAt: this.now() });
+    } catch {
+      this.put({ ...sent, state: "ambiguous", updatedAt: this.now() });
+      throw new SideThreadAmbiguousError(`Codex ${method} outcome is ambiguous; refusing duplicate RPC`);
+    }
+  }
   private assertOwnedThread(threadId: string, sideThreadId?: string): void {
     this.assertSupported();
     const owner = this.derivedThreads.get(threadId);
@@ -311,3 +511,11 @@ function unsupported(reason: "version" | "topology" | "exact-boundary", opts: Co
   };
 }
 function turnKey(threadId: string, turnId: string): string { return `${threadId}\0${turnId}`; }
+interface RuntimeTurn { id: string; items?: unknown[]; [key: string]: unknown }
+interface RuntimeThread { id: string; forkedFromId?: string; turns?: RuntimeTurn[]; [key: string]: unknown }
+function turnHasClientId(turn: RuntimeTurn, clientId: string): boolean {
+  return (turn.items ?? []).some((item) => {
+    const value = item as { clientId?: string; client_id?: string };
+    return value?.clientId === clientId || value?.client_id === clientId;
+  });
+}

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -32,14 +32,18 @@ interface Execution {
   resolveIdentity: (turnId: string) => void;
   rejectIdentity: (error: Error) => void;
   identityTimer: ReturnType<typeof setTimeout>;
+  pendingTerminal?: unknown;
 }
 
 /** Native exact-boundary adapter proven only by PR0's 0.148.0 owned probe. */
 export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter {
   private readonly listeners = new Set<(event: SideThreadTerminalEvent) => void>();
-  private readonly derivedThreads = new Set<string>();
+  private readonly droppedListeners = new Set<(reason: string) => void>();
+  private readonly derivedThreads = new Map<string, string>();
   private readonly byClientId = new Map<string, Execution>();
   private readonly byTurn = new Map<string, Execution>();
+  private readonly earlyTerminals = new Map<string, unknown>();
+  private closed = false;
 
   constructor(private readonly opts: CodexSideThreadAdapterOptions) {
     opts.client.on("item/started", this.onItem);
@@ -61,6 +65,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 
   async fork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary }): Promise<{ derivedThreadId: string }> {
+    this.assertOpen();
     this.assertSupported();
     if (!this.capability().exactBoundary?.[input.boundary.kind]) {
       throw new SideThreadUnsupportedError(
@@ -77,22 +82,26 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         ? { lastTurnId: input.boundary.turnId }
         : { beforeTurnId: input.boundary.turnId }),
     };
-    const response = await this.opts.client.request<{ thread?: { id?: string }; threadId?: string }>("thread/fork", params);
-    const derivedThreadId = response?.thread?.id ?? response?.threadId;
+    const response = await this.opts.client.request<{ thread?: { id?: string } }>("thread/fork", params);
+    this.assertOpen();
+    const derivedThreadId = response?.thread?.id;
     if (!derivedThreadId || derivedThreadId === input.sourceThreadId) {
       throw new SideThreadConflictError("Codex returned an invalid derived thread identity");
     }
-    this.derivedThreads.add(derivedThreadId);
+    if (this.derivedThreads.has(derivedThreadId)) throw new SideThreadConflictError("Codex reused a derived thread identity");
+    this.derivedThreads.set(derivedThreadId, input.sideThreadId);
     return { derivedThreadId };
   }
 
   async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string }): Promise<{ turnId: string }> {
-    this.assertOwnedThread(input.derivedThreadId);
+    this.assertOpen();
+    this.assertOwnedThread(input.derivedThreadId, input.sideThreadId);
     const clientUserMessageId = `anet-side:${input.sideThreadId}:${input.attemptId}`;
     if (this.byClientId.has(clientUserMessageId)) throw new SideThreadConflictError("duplicate Codex attempt identity");
     let resolveIdentity!: (turnId: string) => void;
     let rejectIdentity!: (error: Error) => void;
     const identity = new Promise<string>((resolve, reject) => { resolveIdentity = resolve; rejectIdentity = reject; });
+    void identity.catch(() => {});
     const execution: Execution = {
       sideThreadId: input.sideThreadId, attemptId: input.attemptId,
       threadId: input.derivedThreadId, clientUserMessageId,
@@ -106,20 +115,33 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     try {
       let response: { turn?: { id?: string }; turnId?: string } | undefined;
       try {
-        response = await this.opts.client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
+        const request = this.opts.client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
         threadId: input.derivedThreadId,
         clientUserMessageId,
         input: [{ type: "text", text: input.prompt }],
         });
+        const abortOnIdentityFailure = identity.then(
+          () => new Promise<never>(() => {}),
+          (error) => Promise.reject(error),
+        );
+        response = await Promise.race([request, abortOnIdentityFailure]);
       } catch (error) {
         // The response can be lost after app-server accepted the turn. The
         // echoed client id is authoritative and makes retrying unsafe.
         if (!execution.turnId) throw error;
       }
-      execution.responseTurnId = response?.turn?.id ?? response?.turnId;
+      this.assertOpen();
+      execution.responseTurnId = response?.turn?.id;
+      if (!execution.responseTurnId && !execution.turnId) throw new SideThreadConflictError("Codex returned an invalid turn identity");
       // Response identity alone is not authoritative: Codex automatic goal
       // continuation can replace it. Wait for the echoed client id.
-      return { turnId: await identity };
+      const turnId = await identity;
+      if (execution.pendingTerminal) {
+        const pending = execution.pendingTerminal;
+        execution.pendingTerminal = undefined;
+        setTimeout(() => this.onCompleted(pending), 0);
+      }
+      return { turnId };
     } catch (error) {
       this.dropExecution(execution);
       throw error;
@@ -127,6 +149,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 
   async cancel(input: { derivedThreadId: string; turnId: string }): Promise<void> {
+    this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
     const execution = this.byTurn.get(turnKey(input.derivedThreadId, input.turnId));
     if (!execution) throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
@@ -134,13 +157,15 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 
   async archive(input: { derivedThreadId: string }): Promise<void> {
+    this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
     await this.opts.client.request("thread/archive", { threadId: input.derivedThreadId });
   }
 
   async delete(input: { derivedThreadId: string }): Promise<void> {
+    this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
-    if ([...this.byTurn.values()].some((x) => x.threadId === input.derivedThreadId)) {
+    if ([...this.byTurn.values(), ...this.byClientId.values()].some((x) => x.threadId === input.derivedThreadId)) {
       throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
     }
     await this.opts.client.request("thread/delete", { threadId: input.derivedThreadId });
@@ -151,8 +176,14 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
   }
+  subscribeDropped(listener: (reason: string) => void): () => void {
+    this.droppedListeners.add(listener);
+    return () => this.droppedListeners.delete(listener);
+  }
 
   close(): void {
+    if (this.closed) return;
+    this.closed = true;
     this.opts.client.off("item/started", this.onItem);
     this.opts.client.off("item/completed", this.onItem);
     this.opts.client.off("item/agentMessage/delta", this.onDelta);
@@ -163,7 +194,9 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     }
     this.byClientId.clear();
     this.byTurn.clear();
+    this.earlyTerminals.clear();
     this.listeners.clear();
+    this.droppedListeners.clear();
   }
 
   private readonly onItem = (params: unknown): void => {
@@ -172,17 +205,19 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     const clientId = p.item.clientId;
     if (p.item.type === "userMessage" && clientId) {
       const execution = this.byClientId.get(clientId);
-      if (!execution || execution.threadId !== p.threadId) return;
-      if (execution.turnId && execution.turnId !== p.turnId) return;
+      if (!execution || execution.threadId !== p.threadId) { this.dropped("identity-ownership-mismatch"); return; }
+      if (execution.turnId && execution.turnId !== p.turnId) { this.dropped("identity-turn-mismatch"); return; }
       execution.turnId = p.turnId;
       this.byTurn.set(turnKey(p.threadId, p.turnId), execution);
       clearTimeout(execution.identityTimer);
       execution.resolveIdentity(p.turnId);
+      const early = this.earlyTerminals.get(turnKey(p.threadId, p.turnId));
+      if (early) { this.earlyTerminals.delete(turnKey(p.threadId, p.turnId)); execution.pendingTerminal = early; }
       return;
     }
     if (p.item.type === "agentMessage" && typeof p.item.text === "string") {
       const execution = this.byTurn.get(turnKey(p.threadId, p.turnId));
-      if (execution) execution.text = p.item.text;
+      if (execution) execution.text = p.item.text; else this.dropped("unowned-agent-message");
     }
   };
 
@@ -190,7 +225,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     const p = params as { threadId?: string; turnId?: string; delta?: string };
     if (!p?.threadId || !p.turnId || typeof p.delta !== "string") return;
     const execution = this.byTurn.get(turnKey(p.threadId, p.turnId));
-    if (execution) execution.text += p.delta;
+    if (execution) execution.text += p.delta; else this.dropped("unowned-delta");
   };
 
   private readonly onCompleted = (params: unknown): void => {
@@ -198,7 +233,12 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     const turnId = p?.turn?.id;
     if (!p?.threadId || !turnId) return;
     const execution = this.byTurn.get(turnKey(p.threadId, turnId));
-    if (!execution) return;
+    if (!execution) {
+      const starting = [...this.byClientId.values()].some((x) => x.threadId === p.threadId);
+      if (starting && this.earlyTerminals.size < 64) this.earlyTerminals.set(turnKey(p.threadId, turnId), params);
+      else this.dropped(starting ? "terminal-buffer-full" : "unowned-terminal");
+      return;
+    }
     const status = p.turn?.status;
     const event: SideThreadTerminalEvent = {
       sideThreadId: execution.sideThreadId, attemptId: execution.attemptId,
@@ -228,10 +268,13 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       );
     }
   }
-  private assertOwnedThread(threadId: string): void {
+  private assertOpen(): void { if (this.closed) throw new SideThreadConflictError("Codex side-thread adapter closed"); }
+  private assertOwnedThread(threadId: string, sideThreadId?: string): void {
     this.assertSupported();
-    if (!this.derivedThreads.has(threadId)) throw new SideThreadConflictError("refusing operation on an unowned Codex thread");
+    const owner = this.derivedThreads.get(threadId);
+    if (!owner || (sideThreadId && owner !== sideThreadId)) throw new SideThreadConflictError("refusing operation on an unowned Codex thread");
   }
+  private dropped(reason: string): void { for (const listener of this.droppedListeners) listener(reason); }
 }
 
 function unsupported(reason: "version" | "topology" | "exact-boundary", opts: CodexSideThreadAdapterOptions): SideThreadCapability {

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -15,7 +15,8 @@ export interface SideThreadCodexClient extends EventEmitter {
 export interface CodexSideThreadAdapterOptions {
   client: SideThreadCodexClient;
   runtimeVersion: string;
-  topology: "owned" | "shared";
+  topology: "owned-stdio" | "owned-websocket" | "shared-websocket";
+  evidenceRevision: string;
   experimentalApi: boolean;
   identityTimeoutMs?: number;
 }
@@ -48,10 +49,12 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 
   capability(): SideThreadCapability {
-    if (this.opts.runtimeVersion !== "0.148.0") return unsupported("version", this.opts.runtimeVersion);
-    if (this.opts.topology !== "owned") return unsupported("topology", this.opts.runtimeVersion);
+    if (this.opts.runtimeVersion !== "0.148.0") return unsupported("version", this.opts);
+    if (this.opts.topology !== "owned-stdio") return unsupported("topology", this.opts);
+    if (this.opts.evidenceRevision !== "test1190-wire-v2") return unsupported("exact-boundary", this.opts);
     return {
       supported: true, runtime: "codex-app-server", runtimeVersion: this.opts.runtimeVersion,
+      topology: this.opts.topology, evidenceRevision: this.opts.evidenceRevision,
       mode: "native-exact-fork",
       exactBoundary: { through: true, before: this.opts.experimentalApi },
     };
@@ -231,7 +234,10 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 }
 
-function unsupported(reason: "version" | "topology", runtimeVersion: string): SideThreadCapability {
-  return { supported: false, runtime: "codex-app-server", runtimeVersion, reason };
+function unsupported(reason: "version" | "topology" | "exact-boundary", opts: CodexSideThreadAdapterOptions): SideThreadCapability {
+  return {
+    supported: false, runtime: "codex-app-server", runtimeVersion: opts.runtimeVersion,
+    topology: opts.topology, evidenceRevision: opts.evidenceRevision, reason,
+  };
 }
 function turnKey(threadId: string, turnId: string): string { return `${threadId}\0${turnId}`; }

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -52,6 +52,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   private readonly derivedThreads = new Map<string, string>();
   private readonly byClientId = new Map<string, Execution>();
   private readonly byTurn = new Map<string, Execution>();
+  private readonly pendingStartThreads = new Set<string>();
   private readonly earlyTerminals = new Map<string, unknown>();
   private closed = false;
   private readonly closedSignal: Promise<never>;
@@ -69,6 +70,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   capability(): SideThreadCapability {
     if (this.opts.runtimeVersion !== "0.148.0") return unsupported("version", this.opts);
     if (this.opts.topology !== "owned-stdio") return unsupported("topology", this.opts);
+    if (!this.opts.forkLeaseStore.claimSupported()) return unsupported("topology", this.opts);
     if (this.opts.evidenceRevision !== "test1190-wire-v2") return unsupported("exact-boundary", this.opts);
     return {
       supported: true, runtime: "codex-app-server", runtimeVersion: this.opts.runtimeVersion,
@@ -88,6 +90,21 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       );
     }
     const identity = input.operation ?? this.defaultOperation(input.sideThreadId, "fork", `fork-${input.sideThreadId}`);
+    let claim;
+    try { claim = await this.opts.forkLeaseStore.claim(identity.nodeId, input.sourceThreadId); }
+    catch (error) {
+      if (error instanceof Error && error.message === "runtime operation executor is already claimed") {
+        throw new SideThreadAmbiguousError("Codex fork is already executing; refusing duplicate thread/fork");
+      }
+      throw error;
+    }
+    try { return await this.forkClaimed(input, identity); }
+    finally { await claim.release(); }
+  }
+
+  private async forkClaimed(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary; operation?: SideThreadRuntimeOperation },
+    identity: SideThreadRuntimeOperation): Promise<{ derivedThreadId: string }> {
+    this.assertOpen();
     const operation = this.operation(identity, input.sideThreadId, "fork", input.sourceThreadId,
       JSON.stringify([input.sourceThreadId, input.boundary.kind, input.boundary.turnId]));
     const existing = this.existing(operation);
@@ -101,11 +118,33 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       state: "snapshot", updatedAt: this.now(),
     });
     if (lease.state !== "snapshot") return this.reconcileFork({ ...input, operation: identity }, this.mustOperation(operation));
-    if (lease.snapshotThreadIdHashes.length === 0) {
+    let current = this.mustOperation(operation);
+    let authoritativeSnapshot = current.result?.snapshotThreadIdHashes;
+    if (authoritativeSnapshot) {
+      if (lease.snapshotThreadIdHashes.length > 0
+        && JSON.stringify(lease.snapshotThreadIdHashes) !== JSON.stringify(authoritativeSnapshot)) {
+        throw new SideThreadConflictError("fork snapshot authority mismatch");
+      }
+      if (JSON.stringify(lease.snapshotThreadIdHashes) !== JSON.stringify(authoritativeSnapshot)) {
+        lease = { ...lease, snapshotThreadIdHashes: [...authoritativeSnapshot], updatedAt: this.now() };
+        this.opts.forkLeaseStore.put(lease);
+      }
+    } else if (lease.snapshotThreadIdHashes.length > 0) {
+      // Recovery for the old two-write ordering: the lease fsync completed but
+      // the operation snapshot did not. The already-durable lease is the only
+      // safe pre-send authority; never re-list and adopt an older fork.
+      authoritativeSnapshot = [...lease.snapshotThreadIdHashes];
+      current = { ...current, result: { ...current.result, snapshotThreadIdHashes: authoritativeSnapshot }, updatedAt: this.now() };
+      this.put(current);
+    } else {
       const snapshot = await this.listThreads();
-      lease = { ...lease, snapshotThreadIdHashes: snapshot.map((thread) => operationHash(thread.id)), updatedAt: this.now() };
+      authoritativeSnapshot = snapshot.map((thread) => operationHash(thread.id));
+      // Persist the operation authority first. A crash before the lease update
+      // is recovered from this record; a crash before this write is pre-send.
+      current = { ...current, result: { ...current.result, snapshotThreadIdHashes: authoritativeSnapshot }, updatedAt: this.now() };
+      this.put(current);
+      lease = { ...lease, snapshotThreadIdHashes: [...authoritativeSnapshot], updatedAt: this.now() };
       this.opts.forkLeaseStore.put(lease);
-      this.put({ ...operation, result: { snapshotThreadIdHashes: lease.snapshotThreadIdHashes }, updatedAt: this.now() });
     }
     const params: Record<string, unknown> = {
       threadId: input.sourceThreadId,
@@ -143,6 +182,29 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     this.assertOwnedThread(input.derivedThreadId, input.sideThreadId);
     const clientUserMessageId = `anet-side:${input.sideThreadId}:${input.attemptId}`;
     const identity = input.operation ?? this.defaultOperation(input.sideThreadId, "start", `start-${input.attemptId}`);
+    this.pendingStartThreads.add(input.derivedThreadId);
+    let claim;
+    try { claim = await this.opts.forkLeaseStore.claimOperation(identity.nodeId, input.sideThreadId, identity.operationId); }
+    catch (error) {
+      this.pendingStartThreads.delete(input.derivedThreadId);
+      if (error instanceof Error && error.message === "runtime operation executor is already claimed") {
+        throw new SideThreadAmbiguousError("Codex start is already executing; refusing duplicate turn/start");
+      }
+      throw error;
+    }
+    try { return await this.startClaimed(input, identity, clientUserMessageId); }
+    catch (error) {
+      if (this.closed && error instanceof SideThreadConflictError) {
+        throw new SideThreadAmbiguousError("Codex start closed before its durable outcome was observed");
+      }
+      throw error;
+    }
+    finally { this.pendingStartThreads.delete(input.derivedThreadId); await claim.release(); }
+  }
+
+  private async startClaimed(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; operation?: SideThreadRuntimeOperation },
+    identity: SideThreadRuntimeOperation, clientUserMessageId: string): Promise<{ turnId: string }> {
+    this.assertOpen();
     const operation = this.operation(identity, input.sideThreadId, "start", input.derivedThreadId,
       JSON.stringify([input.sideThreadId, input.attemptId, input.derivedThreadId, operationHash(input.prompt)]));
     const prior = this.existing(operation);
@@ -230,7 +292,8 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   async delete(input: { sideThreadId?: string; derivedThreadId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
-    if ([...this.byTurn.values(), ...this.byClientId.values()].some((x) => x.threadId === input.derivedThreadId)) {
+    if (this.pendingStartThreads.has(input.derivedThreadId)
+      || [...this.byTurn.values(), ...this.byClientId.values()].some((x) => x.threadId === input.derivedThreadId)) {
       throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
     }
     const sideThreadId = input.sideThreadId ?? this.derivedThreads.get(input.derivedThreadId)!;
@@ -238,10 +301,12 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       JSON.stringify([input.derivedThreadId]), "thread/delete", { threadId: input.derivedThreadId });
     this.derivedThreads.delete(input.derivedThreadId);
   }
-  async discardFork(input: { sideThreadId: string; derivedThreadId: string }): Promise<void> {
+  async discardFork(input: { sideThreadId: string; derivedThreadId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     if (this.derivedThreads.get(input.derivedThreadId) !== input.sideThreadId) return;
-    try { await this.rpc("thread/delete", { threadId: input.derivedThreadId }); }
-    finally { this.derivedThreads.delete(input.derivedThreadId); }
+    const identity = input.operation ?? this.defaultOperation(input.sideThreadId, "delete", `discard-${input.sideThreadId}`);
+    await this.durableMutation(input.sideThreadId, "delete", identity, input.derivedThreadId,
+      JSON.stringify([input.derivedThreadId, "discard"]), "thread/delete", { threadId: input.derivedThreadId });
+    this.derivedThreads.delete(input.derivedThreadId);
   }
 
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void {
@@ -267,6 +332,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     }
     this.byClientId.clear();
     this.byTurn.clear();
+    this.pendingStartThreads.clear();
     this.earlyTerminals.clear();
     this.listeners.clear();
     this.droppedListeners.clear();
@@ -312,7 +378,8 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     if (!p?.threadId || !turnId) return;
     const execution = this.byTurn.get(turnKey(p.threadId, turnId));
     if (!execution) {
-      const starting = [...this.byClientId.values()].some((x) => x.threadId === p.threadId);
+      const starting = this.pendingStartThreads.has(p.threadId)
+        || [...this.byClientId.values()].some((x) => x.threadId === p.threadId);
       if (starting && this.earlyTerminals.size < 64) this.earlyTerminals.set(turnKey(p.threadId, turnId), params);
       else this.dropped(starting ? "terminal-buffer-full" : "unowned-terminal");
       return;
@@ -434,6 +501,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     clientUserMessageId: string, prior: SideThreadOperation): Promise<{ turnId: string }> {
     const live = this.byClientId.get(clientUserMessageId);
     let turnId = live?.turnId;
+    let matchedTurn: RuntimeTurn | undefined;
     let current = prior;
     if (current.state === "sent") { current = { ...current, state: "ambiguous", updatedAt: this.now() }; this.put(current); }
     if (!turnId) {
@@ -442,8 +510,9 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         const thread = await this.readThread(input.derivedThreadId);
         const matches = (thread.turns ?? []).filter((turn) => turnHasClientId(turn, clientUserMessageId));
         if (prior.result?.turnIdHash) {
-          turnId = matches.find((turn) => operationHash(turn.id) === prior.result!.turnIdHash)?.id;
-        } else if (matches.length === 1) turnId = matches[0].id;
+          matchedTurn = matches.find((turn) => operationHash(turn.id) === prior.result!.turnIdHash);
+          turnId = matchedTurn?.id;
+        } else if (matches.length === 1) { matchedTurn = matches[0]; turnId = matchedTurn.id; }
       } catch { /* the durable ambiguity below is authoritative */ }
     }
     if (!turnId) {
@@ -454,7 +523,31 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     if (current.state === "accepted" || current.state === "reconciling") {
       this.put({ ...current, state: "reconciled", result: { ...current.result, turnIdHash: operationHash(turnId) }, updatedAt: this.now() });
     }
+    if (!live) this.restoreExecution(input, clientUserMessageId, turnId, matchedTurn);
     return { turnId };
+  }
+  private restoreExecution(input: { sideThreadId: string; attemptId: string; derivedThreadId: string },
+    clientUserMessageId: string, turnId: string, turn?: RuntimeTurn): void {
+    const key = turnKey(input.derivedThreadId, turnId);
+    const owned = this.byTurn.get(key);
+    if (owned && (owned.sideThreadId !== input.sideThreadId || owned.attemptId !== input.attemptId)) {
+      throw new SideThreadConflictError("reconciled Codex turn is already owned by another attempt");
+    }
+    let resolveIdentity!: (value: string) => void; let rejectIdentity!: (error: Error) => void;
+    const identity = new Promise<string>((resolve, reject) => { resolveIdentity = resolve; rejectIdentity = reject; });
+    void identity.catch(() => {}); resolveIdentity(turnId);
+    const identityTimer = setTimeout(() => {}, 0); clearTimeout(identityTimer);
+    const execution: Execution = {
+      sideThreadId: input.sideThreadId, attemptId: input.attemptId, threadId: input.derivedThreadId,
+      clientUserMessageId, responseTurnId: turnId, turnId, text: turnText(turn),
+      resolveIdentity, rejectIdentity, identityTimer, readyForTerminal: true, identityAmbiguous: false,
+    };
+    this.byClientId.set(clientUserMessageId, execution); this.byTurn.set(key, execution);
+    if (turn?.status && turn.status !== "inProgress") {
+      setTimeout(() => this.onCompleted({ threadId: input.derivedThreadId, turn: {
+        id: turnId, status: turn.status, error: turn.error,
+      } }), 0);
+    }
   }
   private async listThreads(): Promise<RuntimeThread[]> {
     const all: RuntimeThread[] = []; let cursor: string | undefined;
@@ -479,6 +572,19 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     this.derivedThreads.set(threadId, sideThreadId);
   }
   private async durableMutation(sideThreadId: string, method: "interrupt" | "archive" | "delete", identity: SideThreadRuntimeOperation,
+    target: string, fingerprint: string, rpcMethod: string, params: unknown): Promise<void> {
+    let claim;
+    try { claim = await this.opts.forkLeaseStore.claimOperation(identity.nodeId, sideThreadId, identity.operationId); }
+    catch (error) {
+      if (error instanceof Error && error.message === "runtime operation executor is already claimed") {
+        throw new SideThreadAmbiguousError(`Codex ${method} is already executing; refusing duplicate RPC`);
+      }
+      throw error;
+    }
+    try { await this.durableMutationClaimed(sideThreadId, method, identity, target, fingerprint, rpcMethod, params); }
+    finally { await claim.release(); }
+  }
+  private async durableMutationClaimed(sideThreadId: string, method: "interrupt" | "archive" | "delete", identity: SideThreadRuntimeOperation,
     target: string, fingerprint: string, rpcMethod: string, params: unknown): Promise<void> {
     const operation = this.operation(identity, sideThreadId, method, target, fingerprint);
     const prior = this.existing(operation);
@@ -511,11 +617,17 @@ function unsupported(reason: "version" | "topology" | "exact-boundary", opts: Co
   };
 }
 function turnKey(threadId: string, turnId: string): string { return `${threadId}\0${turnId}`; }
-interface RuntimeTurn { id: string; items?: unknown[]; [key: string]: unknown }
+interface RuntimeTurn { id: string; items?: unknown[]; status?: string; error?: { message?: string } | string; [key: string]: unknown }
 interface RuntimeThread { id: string; forkedFromId?: string; turns?: RuntimeTurn[]; [key: string]: unknown }
 function turnHasClientId(turn: RuntimeTurn, clientId: string): boolean {
   return (turn.items ?? []).some((item) => {
     const value = item as { clientId?: string; client_id?: string };
     return value?.clientId === clientId || value?.client_id === clientId;
   });
+}
+function turnText(turn?: RuntimeTurn): string {
+  return (turn?.items ?? []).map((item) => {
+    const value = item as { type?: string; text?: string };
+    return value?.type === "agentMessage" && typeof value.text === "string" ? value.text : "";
+  }).join("");
 }

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -1,0 +1,237 @@
+import type { EventEmitter } from "node:events";
+import {
+  SideThreadConflictError,
+  SideThreadUnsupportedError,
+  type ExactBoundary,
+  type SideThreadCapability,
+  type SideThreadRuntimeAdapter,
+  type SideThreadTerminalEvent,
+} from "./domain";
+
+export interface SideThreadCodexClient extends EventEmitter {
+  request<T = unknown>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
+}
+
+export interface CodexSideThreadAdapterOptions {
+  client: SideThreadCodexClient;
+  runtimeVersion: string;
+  topology: "owned" | "shared";
+  experimentalApi: boolean;
+  identityTimeoutMs?: number;
+}
+
+interface Execution {
+  sideThreadId: string;
+  attemptId: string;
+  threadId: string;
+  clientUserMessageId: string;
+  responseTurnId?: string;
+  turnId?: string;
+  text: string;
+  resolveIdentity: (turnId: string) => void;
+  rejectIdentity: (error: Error) => void;
+  identityTimer: ReturnType<typeof setTimeout>;
+}
+
+/** Native exact-boundary adapter proven only by PR0's 0.148.0 owned probe. */
+export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter {
+  private readonly listeners = new Set<(event: SideThreadTerminalEvent) => void>();
+  private readonly derivedThreads = new Set<string>();
+  private readonly byClientId = new Map<string, Execution>();
+  private readonly byTurn = new Map<string, Execution>();
+
+  constructor(private readonly opts: CodexSideThreadAdapterOptions) {
+    opts.client.on("item/started", this.onItem);
+    opts.client.on("item/completed", this.onItem);
+    opts.client.on("item/agentMessage/delta", this.onDelta);
+    opts.client.on("turn/completed", this.onCompleted);
+  }
+
+  capability(): SideThreadCapability {
+    if (this.opts.runtimeVersion !== "0.148.0") return unsupported("version", this.opts.runtimeVersion);
+    if (this.opts.topology !== "owned") return unsupported("topology", this.opts.runtimeVersion);
+    return {
+      supported: true, runtime: "codex-app-server", runtimeVersion: this.opts.runtimeVersion,
+      mode: "native-exact-fork",
+      exactBoundary: { through: true, before: this.opts.experimentalApi },
+    };
+  }
+
+  async fork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary }): Promise<{ derivedThreadId: string }> {
+    this.assertSupported();
+    if (!this.capability().exactBoundary?.[input.boundary.kind]) {
+      throw new SideThreadUnsupportedError(
+        input.boundary.kind === "before" ? "experimental-api" : "exact-boundary",
+        `Codex boundary '${input.boundary.kind}' is unsupported`,
+      );
+    }
+    const params: Record<string, unknown> = {
+      threadId: input.sourceThreadId,
+      ephemeral: false,
+      // No approval/sandbox/cwd/instruction override: native fork inherits
+      // source policy. PR1 must not turn BTW into a privilege escalation.
+      ...(input.boundary.kind === "through"
+        ? { lastTurnId: input.boundary.turnId }
+        : { beforeTurnId: input.boundary.turnId }),
+    };
+    const response = await this.opts.client.request<{ thread?: { id?: string }; threadId?: string }>("thread/fork", params);
+    const derivedThreadId = response?.thread?.id ?? response?.threadId;
+    if (!derivedThreadId || derivedThreadId === input.sourceThreadId) {
+      throw new SideThreadConflictError("Codex returned an invalid derived thread identity");
+    }
+    this.derivedThreads.add(derivedThreadId);
+    return { derivedThreadId };
+  }
+
+  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string }): Promise<{ turnId: string }> {
+    this.assertOwnedThread(input.derivedThreadId);
+    const clientUserMessageId = `anet-side:${input.sideThreadId}:${input.attemptId}`;
+    if (this.byClientId.has(clientUserMessageId)) throw new SideThreadConflictError("duplicate Codex attempt identity");
+    let resolveIdentity!: (turnId: string) => void;
+    let rejectIdentity!: (error: Error) => void;
+    const identity = new Promise<string>((resolve, reject) => { resolveIdentity = resolve; rejectIdentity = reject; });
+    const execution: Execution = {
+      sideThreadId: input.sideThreadId, attemptId: input.attemptId,
+      threadId: input.derivedThreadId, clientUserMessageId,
+      text: "", resolveIdentity, rejectIdentity,
+      identityTimer: setTimeout(() => {
+        this.dropExecution(execution);
+        rejectIdentity(new SideThreadConflictError("Codex did not echo the attempt identity"));
+      }, this.opts.identityTimeoutMs ?? 10_000),
+    };
+    this.byClientId.set(clientUserMessageId, execution);
+    try {
+      let response: { turn?: { id?: string }; turnId?: string } | undefined;
+      try {
+        response = await this.opts.client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
+        threadId: input.derivedThreadId,
+        clientUserMessageId,
+        input: [{ type: "text", text: input.prompt }],
+        });
+      } catch (error) {
+        // The response can be lost after app-server accepted the turn. The
+        // echoed client id is authoritative and makes retrying unsafe.
+        if (!execution.turnId) throw error;
+      }
+      execution.responseTurnId = response?.turn?.id ?? response?.turnId;
+      // Response identity alone is not authoritative: Codex automatic goal
+      // continuation can replace it. Wait for the echoed client id.
+      return { turnId: await identity };
+    } catch (error) {
+      this.dropExecution(execution);
+      throw error;
+    }
+  }
+
+  async cancel(input: { derivedThreadId: string; turnId: string }): Promise<void> {
+    this.assertOwnedThread(input.derivedThreadId);
+    const execution = this.byTurn.get(turnKey(input.derivedThreadId, input.turnId));
+    if (!execution) throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
+    await this.opts.client.request("turn/interrupt", { threadId: input.derivedThreadId, turnId: input.turnId });
+  }
+
+  async archive(input: { derivedThreadId: string }): Promise<void> {
+    this.assertOwnedThread(input.derivedThreadId);
+    await this.opts.client.request("thread/archive", { threadId: input.derivedThreadId });
+  }
+
+  async delete(input: { derivedThreadId: string }): Promise<void> {
+    this.assertOwnedThread(input.derivedThreadId);
+    if ([...this.byTurn.values()].some((x) => x.threadId === input.derivedThreadId)) {
+      throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
+    }
+    await this.opts.client.request("thread/delete", { threadId: input.derivedThreadId });
+    this.derivedThreads.delete(input.derivedThreadId);
+  }
+
+  subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  close(): void {
+    this.opts.client.off("item/started", this.onItem);
+    this.opts.client.off("item/completed", this.onItem);
+    this.opts.client.off("item/agentMessage/delta", this.onDelta);
+    this.opts.client.off("turn/completed", this.onCompleted);
+    for (const execution of this.byClientId.values()) {
+      clearTimeout(execution.identityTimer);
+      execution.rejectIdentity(new SideThreadConflictError("Codex side-thread adapter closed"));
+    }
+    this.byClientId.clear();
+    this.byTurn.clear();
+    this.listeners.clear();
+  }
+
+  private readonly onItem = (params: unknown): void => {
+    const p = params as { threadId?: string; turnId?: string; item?: { type?: string; clientId?: string; text?: string } };
+    if (!p?.threadId || !p.turnId || !p.item) return;
+    const clientId = p.item.clientId;
+    if (p.item.type === "userMessage" && clientId) {
+      const execution = this.byClientId.get(clientId);
+      if (!execution || execution.threadId !== p.threadId) return;
+      if (execution.turnId && execution.turnId !== p.turnId) return;
+      execution.turnId = p.turnId;
+      this.byTurn.set(turnKey(p.threadId, p.turnId), execution);
+      clearTimeout(execution.identityTimer);
+      execution.resolveIdentity(p.turnId);
+      return;
+    }
+    if (p.item.type === "agentMessage" && typeof p.item.text === "string") {
+      const execution = this.byTurn.get(turnKey(p.threadId, p.turnId));
+      if (execution) execution.text = p.item.text;
+    }
+  };
+
+  private readonly onDelta = (params: unknown): void => {
+    const p = params as { threadId?: string; turnId?: string; delta?: string };
+    if (!p?.threadId || !p.turnId || typeof p.delta !== "string") return;
+    const execution = this.byTurn.get(turnKey(p.threadId, p.turnId));
+    if (execution) execution.text += p.delta;
+  };
+
+  private readonly onCompleted = (params: unknown): void => {
+    const p = params as { threadId?: string; turn?: { id?: string; status?: string; error?: { message?: string } | string } };
+    const turnId = p?.turn?.id;
+    if (!p?.threadId || !turnId) return;
+    const execution = this.byTurn.get(turnKey(p.threadId, turnId));
+    if (!execution) return;
+    const status = p.turn?.status;
+    const event: SideThreadTerminalEvent = {
+      sideThreadId: execution.sideThreadId, attemptId: execution.attemptId,
+      threadId: execution.threadId, turnId,
+      status: status === "completed" ? "completed" : status === "interrupted" ? "interrupted" : "failed",
+      text: status === "completed" ? execution.text : undefined,
+      error: status !== "completed" && status !== "interrupted"
+        ? typeof p.turn?.error === "string" ? p.turn.error : p.turn?.error?.message
+        : undefined,
+    };
+    this.dropExecution(execution);
+    for (const listener of this.listeners) listener(event);
+  };
+
+  private dropExecution(execution: Execution): void {
+    clearTimeout(execution.identityTimer);
+    this.byClientId.delete(execution.clientUserMessageId);
+    if (execution.turnId) this.byTurn.delete(turnKey(execution.threadId, execution.turnId));
+  }
+
+  private assertSupported(): void {
+    const capability = this.capability();
+    if (!capability.supported) {
+      throw new SideThreadUnsupportedError(
+        capability.reason ?? "runtime",
+        `Codex side thread unsupported: ${capability.reason}`,
+      );
+    }
+  }
+  private assertOwnedThread(threadId: string): void {
+    this.assertSupported();
+    if (!this.derivedThreads.has(threadId)) throw new SideThreadConflictError("refusing operation on an unowned Codex thread");
+  }
+}
+
+function unsupported(reason: "version" | "topology", runtimeVersion: string): SideThreadCapability {
+  return { supported: false, runtime: "codex-app-server", runtimeVersion, reason };
+}
+function turnKey(threadId: string, turnId: string): string { return `${threadId}\0${turnId}`; }

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -34,6 +34,8 @@ interface Execution {
   rejectIdentity: (error: Error) => void;
   identityTimer: ReturnType<typeof setTimeout>;
   pendingTerminal?: unknown;
+  readyForTerminal: boolean;
+  identityAmbiguous: boolean;
 }
 
 /** Native exact-boundary adapter proven only by PR0's 0.148.0 owned probe. */
@@ -111,7 +113,10 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       sideThreadId: input.sideThreadId, attemptId: input.attemptId,
       threadId: input.derivedThreadId, clientUserMessageId,
       text: "", resolveIdentity, rejectIdentity,
+      readyForTerminal: false,
+      identityAmbiguous: false,
       identityTimer: setTimeout(() => {
+        execution.identityAmbiguous = true;
         rejectIdentity(new SideThreadAmbiguousError("Codex accepted turn/start but did not echo identity; reconciliation required"));
       }, this.opts.identityTimeoutMs ?? 10_000),
     };
@@ -140,6 +145,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       // Response identity alone is not authoritative: Codex automatic goal
       // continuation can replace it. Wait for the echoed client id.
       const turnId = await identity;
+      execution.readyForTerminal = true;
       if (execution.pendingTerminal) {
         const pending = execution.pendingTerminal;
         execution.pendingTerminal = undefined;
@@ -221,8 +227,13 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       this.byTurn.set(turnKey(p.threadId, p.turnId), execution);
       clearTimeout(execution.identityTimer);
       execution.resolveIdentity(p.turnId);
+      if (execution.identityAmbiguous) execution.readyForTerminal = true;
       const early = this.earlyTerminals.get(turnKey(p.threadId, p.turnId));
-      if (early) { this.earlyTerminals.delete(turnKey(p.threadId, p.turnId)); execution.pendingTerminal = early; }
+      if (early) {
+        this.earlyTerminals.delete(turnKey(p.threadId, p.turnId));
+        execution.pendingTerminal = early;
+        if (execution.readyForTerminal) setTimeout(() => this.onCompleted(early), 0);
+      }
       return;
     }
     if (p.item.type === "agentMessage" && typeof p.item.text === "string") {
@@ -250,6 +261,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       return;
     }
     const status = p.turn?.status;
+    if (!execution.readyForTerminal) { execution.pendingTerminal = params; return; }
     const event: SideThreadTerminalEvent = {
       sideThreadId: execution.sideThreadId, attemptId: execution.attemptId,
       threadId: execution.threadId, turnId,
@@ -258,6 +270,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       error: status !== "completed" && status !== "interrupted"
         ? typeof p.turn?.error === "string" ? p.turn.error : p.turn?.error?.message
         : undefined,
+      identityBound: true,
     };
     this.dropExecution(execution);
     for (const listener of this.listeners) listener(event);

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import {
+  SideThreadConflictError, SideThreadService, SideThreadUnsupportedError,
+  type SideThreadCapability, type SideThreadRuntimeAdapter, type SideThreadTerminalEvent,
+} from "./domain";
+
+class FakeAdapter extends EventEmitter implements SideThreadRuntimeAdapter {
+  cap: SideThreadCapability = { supported: true, runtime: "fake", runtimeVersion: "1", mode: "native-exact-fork", exactBoundary: { through: true, before: true } };
+  forks = 0; starts = 0; cancels: unknown[] = []; archives = 0; deletes = 0;
+  terminalDuringStart = false;
+  capability() { return this.cap; }
+  async fork(input: { sideThreadId: string }) { this.forks++; return { derivedThreadId: `derived-${input.sideThreadId}` }; }
+  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string }) {
+    this.starts++;
+    const turnId = `turn-${input.attemptId}`;
+    if (this.terminalDuringStart) this.terminal({
+      sideThreadId: input.sideThreadId, attemptId: input.attemptId,
+      threadId: input.derivedThreadId, turnId, status: "completed", text: "fast",
+    });
+    return { turnId };
+  }
+  async cancel(input: unknown) { this.cancels.push(input); }
+  async archive() { this.archives++; }
+  async delete() { this.deletes++; }
+  subscribe(listener: (event: SideThreadTerminalEvent) => void) { this.on("terminal", listener); return () => this.off("terminal", listener); }
+  terminal(event: SideThreadTerminalEvent) { this.emit("terminal", event); }
+}
+
+const ids = () => { let n = 0; return () => `id-${++n}`; };
+const createInput = { requestKey: "create-key-0001", nodeId: "node-1", sourceThreadId: "source-1", boundary: { kind: "through", turnId: "main-turn-1" } as const };
+
+describe("SideThreadService", () => {
+  test("fails closed before fork for unsupported capability", async () => {
+    const adapter = new FakeAdapter();
+    adapter.cap = { supported: false, runtime: "claude", runtimeVersion: "x", reason: "runtime" };
+    const service = new SideThreadService({ adapter, id: ids() });
+    await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadUnsupportedError);
+    expect(adapter.forks).toBe(0);
+  });
+
+  test("concurrent create and attempt request keys are idempotent", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids() });
+    const [a, b] = await Promise.all([service.create(createInput), service.create(createInput)]);
+    expect(a.id).toBe(b.id);
+    expect(adapter.forks).toBe(1);
+    const [x, y] = await Promise.all([
+      service.startAttempt({ sideThreadId: a.id, requestKey: "attempt-key-0001", prompt: "secret prompt" }),
+      service.startAttempt({ sideThreadId: a.id, requestKey: "attempt-key-0001", prompt: "secret prompt" }),
+    ]);
+    expect(x.id).toBe(y.id);
+    expect(adapter.starts).toBe(1);
+    await expect(service.create({ ...createInput, sourceThreadId: "different" }))
+      .rejects.toThrow("idempotency key reused");
+    await expect(service.startAttempt({ sideThreadId: a.id, requestKey: "attempt-key-0001", prompt: "different" }))
+      .rejects.toThrow("idempotency key reused");
+  });
+
+  test("boundary-specific capability rejects before without blocking through", async () => {
+    const adapter = new FakeAdapter();
+    adapter.cap.exactBoundary = { through: true, before: false };
+    const service = new SideThreadService({ adapter, id: ids() });
+    await expect(service.create({ ...createInput, boundary: { kind: "before", turnId: "active" } }))
+      .rejects.toMatchObject({ code: "SIDE_THREAD_UNSUPPORTED", reason: "experimental-api" });
+    expect(adapter.forks).toBe(0);
+    await expect(service.create(createInput)).resolves.toMatchObject({ sourceThreadId: "source-1" });
+  });
+
+  test("cancel uses exact derived thread and active turn", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids() });
+    const side = await service.create(createInput);
+    const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0002", prompt: "question" });
+    await service.cancel(side.id);
+    expect(adapter.cancels).toEqual([{ derivedThreadId: side.derivedThreadId, turnId: attempt.turnId }]);
+    expect(adapter.cancels).not.toContainEqual(expect.objectContaining({ derivedThreadId: side.sourceThreadId }));
+  });
+
+  test("drops mismatched and stale terminal events without settling current attempt", async () => {
+    const adapter = new FakeAdapter();
+    const audit: any[] = [];
+    const service = new SideThreadService({ adapter, id: ids(), audit: (e) => audit.push(e) });
+    const side = await service.create(createInput);
+    const first = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0003", prompt: "one" });
+    adapter.terminal({ sideThreadId: side.id, attemptId: first.id, threadId: side.derivedThreadId, turnId: first.turnId!, status: "completed", text: "one" });
+    const second = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0004", prompt: "two" });
+    adapter.terminal({ sideThreadId: side.id, attemptId: first.id, threadId: side.derivedThreadId, turnId: first.turnId!, status: "completed", text: "late" });
+    adapter.terminal({ sideThreadId: side.id, attemptId: second.id, threadId: side.sourceThreadId, turnId: second.turnId!, status: "completed", text: "wrong thread" });
+    expect(service.get(side.id)?.activeAttemptId).toBe(second.id);
+    expect(audit.filter((x) => x.action === "event_dropped")).toHaveLength(2);
+    adapter.terminal({ sideThreadId: side.id, attemptId: second.id, threadId: side.derivedThreadId, turnId: second.turnId!, status: "completed", text: "two" });
+    expect(service.get(side.id)?.state).toBe("completed");
+  });
+
+  test("terminal racing start return settles the same attempt once", async () => {
+    const adapter = new FakeAdapter(); adapter.terminalDuringStart = true;
+    const service = new SideThreadService({ adapter, id: ids() });
+    const side = await service.create(createInput);
+    const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-fast", prompt: "fast" });
+    expect(attempt).toMatchObject({ state: "completed", result: "fast" });
+    expect(service.get(side.id)).toMatchObject({ state: "completed", activeAttemptId: undefined });
+  });
+
+  test("archive is idempotent, purge is owned and refuses running turns", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids() });
+    const side = await service.create(createInput);
+    const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0005", prompt: "one" });
+    await expect(service.purge(side.id)).rejects.toBeInstanceOf(SideThreadConflictError);
+    adapter.terminal({ sideThreadId: side.id, attemptId: attempt.id, threadId: side.derivedThreadId, turnId: attempt.turnId!, status: "completed" });
+    await service.archive(side.id); await service.archive(side.id);
+    expect(adapter.archives).toBe(1);
+    await service.purge(side.id); await service.purge(side.id);
+    expect(adapter.deletes).toBe(1);
+  });
+
+  test("audit is field-minimized and never contains prompt", async () => {
+    const adapter = new FakeAdapter();
+    const audit: any[] = [];
+    const service = new SideThreadService({ adapter, id: ids(), audit: (e) => audit.push(e) });
+    const side = await service.create(createInput);
+    await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0006", prompt: "TOP-SECRET-PROMPT" });
+    expect(JSON.stringify(audit)).not.toContain("TOP-SECRET-PROMPT");
+    expect(audit.every((x) => !Object.hasOwn(x, "prompt") && !Object.hasOwn(x, "result"))).toBe(true);
+  });
+
+  test("close removes subscription and refuses new mutations", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids() });
+    expect(adapter.listenerCount("terminal")).toBe(1);
+    service.close(); service.close();
+    expect(adapter.listenerCount("terminal")).toBe(0);
+    await expect(service.create(createInput)).rejects.toThrow("service is closed");
+  });
+});

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -137,6 +137,15 @@ describe("SideThreadService", () => {
     expect(audit.every((x) => !Object.hasOwn(x, "prompt") && !Object.hasOwn(x, "result"))).toBe(true);
   });
 
+  test("hostile dropped-event details are reduced to a fixed audit reason", () => {
+    const adapter = new FakeAdapter(); const audit: any[] = []; let dropped!: (reason: string) => void;
+    (adapter as any).subscribeDropped = (listener: (reason: string) => void) => { dropped = listener; return () => {}; };
+    new SideThreadService({ adapter, audit: (entry) => audit.push(entry) });
+    dropped("Bearer TOPSECRET\nhttps://secret.example/x /home/private prompt-body");
+    expect(audit).toEqual([expect.objectContaining({ action: "event_dropped", reason: "runtime-event-rejected" })]);
+    expect(JSON.stringify(audit)).not.toMatch(/TOPSECRET|https?:|\/home\/|prompt-body/);
+  });
+
   test("close removes subscription and refuses new mutations", async () => {
     const adapter = new FakeAdapter();
     const service = new SideThreadService({ adapter, id: ids() });

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -76,7 +76,7 @@ describe("SideThreadService", () => {
     const service = new SideThreadService({ adapter, id: ids() });
     const side = await service.create(createInput);
     const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0002", prompt: "question" });
-    await service.cancel(side.id);
+    await Promise.all([service.cancel(side.id), service.cancel(side.id)]);
     expect(adapter.cancels).toEqual([{ derivedThreadId: side.derivedThreadId, turnId: attempt.turnId }]);
     expect(adapter.cancels).not.toContainEqual(expect.objectContaining({ derivedThreadId: side.sourceThreadId }));
   });
@@ -97,13 +97,13 @@ describe("SideThreadService", () => {
     expect(service.get(side.id)?.state).toBe("completed");
   });
 
-  test("terminal racing start return settles the same attempt once", async () => {
+  test("domain rejects unbound terminal racing start return", async () => {
     const adapter = new FakeAdapter(); adapter.terminalDuringStart = true;
     const service = new SideThreadService({ adapter, id: ids() });
     const side = await service.create(createInput);
     const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-fast", prompt: "fast" });
-    expect(attempt).toMatchObject({ state: "completed", result: "fast" });
-    expect(service.get(side.id)).toMatchObject({ state: "completed", activeAttemptId: undefined });
+    expect(attempt).toMatchObject({ state: "running" });
+    expect(service.get(side.id)).toMatchObject({ state: "running", activeAttemptId: attempt.id });
   });
 
   test("archive is idempotent, purge is owned and refuses running turns", async () => {
@@ -133,8 +133,30 @@ describe("SideThreadService", () => {
     const adapter = new FakeAdapter();
     const service = new SideThreadService({ adapter, id: ids() });
     expect(adapter.listenerCount("terminal")).toBe(1);
-    service.close(); service.close();
+    await service.close(); await service.close();
     expect(adapter.listenerCount("terminal")).toBe(0);
     await expect(service.create(createInput)).rejects.toThrow("service is closed");
+  });
+
+  test("rejects duplicate fork ownership, capability drift, and unsafe identities", async () => {
+    const adapter = new FakeAdapter();
+    adapter.fork = async () => ({ derivedThreadId: "same-derived" });
+    const service = new SideThreadService({ adapter, id: ids() });
+    await service.create(createInput);
+    await expect(service.create({ ...createInput, requestKey: "create-key-0002" })).rejects.toThrow("already owned");
+    adapter.cap.evidenceRevision = "drifted";
+    await expect(service.startAttempt({ sideThreadId: "id-1", requestKey: "attempt-key-drift", prompt: "q" }))
+      .rejects.toBeInstanceOf(SideThreadUnsupportedError);
+    await expect(new SideThreadService({ adapter, id: ids() }).create({ ...createInput, sourceThreadId: "Bearer FAKE" }))
+      .rejects.toThrow("invalid sourceThreadId");
+  });
+
+  test("audit sink failures cannot orphan or duplicate a fork", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids(), audit: () => { throw new Error("sink down"); } });
+    const first = await service.create(createInput);
+    const retry = await service.create(createInput);
+    expect(retry.id).toBe(first.id);
+    expect(adapter.forks).toBe(1);
   });
 });

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -159,4 +159,14 @@ describe("SideThreadService", () => {
     expect(retry.id).toBe(first.id);
     expect(adapter.forks).toBe(1);
   });
+
+  test("capability flip after fork fails create and compensates derived thread", async () => {
+    const adapter = new FakeAdapter(); let discarded = 0;
+    adapter.fork = async (input) => { adapter.cap.supported = false; adapter.cap.reason = "version"; return { derivedThreadId: `derived-${input.sideThreadId}` }; };
+    adapter.discardFork = async () => { discarded++; };
+    const service = new SideThreadService({ adapter, id: ids() });
+    await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadUnsupportedError);
+    expect(discarded).toBe(1);
+    expect(service.get("id-1")).toBeUndefined();
+  });
 });

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -6,7 +6,11 @@ import {
 } from "./domain";
 
 class FakeAdapter extends EventEmitter implements SideThreadRuntimeAdapter {
-  cap: SideThreadCapability = { supported: true, runtime: "fake", runtimeVersion: "1", mode: "native-exact-fork", exactBoundary: { through: true, before: true } };
+  cap: SideThreadCapability = {
+    supported: true, runtime: "fake", runtimeVersion: "1", topology: "test",
+    evidenceRevision: "fixture", mode: "native-exact-fork",
+    exactBoundary: { through: true, before: true },
+  };
   forks = 0; starts = 0; cancels: unknown[] = []; archives = 0; deletes = 0;
   terminalDuringStart = false;
   capability() { return this.cap; }
@@ -33,7 +37,7 @@ const createInput = { requestKey: "create-key-0001", nodeId: "node-1", sourceThr
 describe("SideThreadService", () => {
   test("fails closed before fork for unsupported capability", async () => {
     const adapter = new FakeAdapter();
-    adapter.cap = { supported: false, runtime: "claude", runtimeVersion: "x", reason: "runtime" };
+    adapter.cap = { supported: false, runtime: "claude", runtimeVersion: "x", topology: "none", evidenceRevision: "none", reason: "runtime" };
     const service = new SideThreadService({ adapter, id: ids() });
     await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadUnsupportedError);
     expect(adapter.forks).toBe(0);

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import {
   SideThreadConflictError, SideThreadService, SideThreadUnsupportedError,
+  SideThreadAmbiguousError,
   type SideThreadCapability, type SideThreadRuntimeAdapter, type SideThreadTerminalEvent,
 } from "./domain";
 
@@ -13,10 +14,17 @@ class FakeAdapter extends EventEmitter implements SideThreadRuntimeAdapter {
   };
   forks = 0; starts = 0; cancels: unknown[] = []; archives = 0; deletes = 0;
   terminalDuringStart = false;
+  ambiguousForks = 0; ambiguousStarts = 0; forkSideIds: string[] = []; startAttemptIds: string[] = [];
   capability() { return this.cap; }
-  async fork(input: { sideThreadId: string }) { this.forks++; return { derivedThreadId: `derived-${input.sideThreadId}` }; }
+  async fork(input: { sideThreadId: string }) {
+    this.forks++; this.forkSideIds.push(input.sideThreadId);
+    if (this.ambiguousForks-- > 0) throw new SideThreadAmbiguousError("fork ambiguous");
+    return { derivedThreadId: `derived-${input.sideThreadId}` };
+  }
   async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string }) {
     this.starts++;
+    this.startAttemptIds.push(input.attemptId);
+    if (this.ambiguousStarts-- > 0) throw new SideThreadAmbiguousError("start ambiguous");
     const turnId = `turn-${input.attemptId}`;
     if (this.terminalDuringStart) this.terminal({
       sideThreadId: input.sideThreadId, attemptId: input.attemptId,
@@ -77,7 +85,7 @@ describe("SideThreadService", () => {
     const side = await service.create(createInput);
     const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0002", prompt: "question" });
     await Promise.all([service.cancel(side.id), service.cancel(side.id)]);
-    expect(adapter.cancels).toEqual([{ derivedThreadId: side.derivedThreadId, turnId: attempt.turnId }]);
+    expect(adapter.cancels).toEqual([expect.objectContaining({ derivedThreadId: side.derivedThreadId, turnId: attempt.turnId })]);
     expect(adapter.cancels).not.toContainEqual(expect.objectContaining({ derivedThreadId: side.sourceThreadId }));
   });
 
@@ -168,5 +176,19 @@ describe("SideThreadService", () => {
     await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadUnsupportedError);
     expect(discarded).toBe(1);
     expect(service.get("id-1")).toBeUndefined();
+  });
+
+  test("ambiguous create and start retries reuse stable side/attempt operation identities", async () => {
+    const adapter = new FakeAdapter(); adapter.ambiguousForks = 1;
+    const service = new SideThreadService({ adapter, id: ids() });
+    await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadAmbiguousError);
+    const side = await service.create(createInput);
+    expect(adapter.forkSideIds).toEqual([side.id, side.id]);
+    adapter.ambiguousStarts = 1;
+    await expect(service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-stable", prompt: "q" }))
+      .rejects.toBeInstanceOf(SideThreadAmbiguousError);
+    const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-stable", prompt: "q" });
+    expect(adapter.startAttemptIds).toEqual([attempt.id, attempt.id]);
+    expect(service.get(side.id)?.attempts).toHaveLength(1);
   });
 });

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -141,9 +141,9 @@ describe("SideThreadService", () => {
     const adapter = new FakeAdapter(); const audit: any[] = []; let dropped!: (reason: string) => void;
     (adapter as any).subscribeDropped = (listener: (reason: string) => void) => { dropped = listener; return () => {}; };
     new SideThreadService({ adapter, audit: (entry) => audit.push(entry) });
-    dropped("Bearer TOPSECRET\nhttps://secret.example/x /home/private prompt-body");
+    dropped("Bearer TOPSECRET\nhttps://secret.example/x /private/path prompt-body");
     expect(audit).toEqual([expect.objectContaining({ action: "event_dropped", reason: "runtime-event-rejected" })]);
-    expect(JSON.stringify(audit)).not.toMatch(/TOPSECRET|https?:|\/home\/|prompt-body/);
+    expect(JSON.stringify(audit)).not.toMatch(/TOPSECRET|https?:|\/private\/|prompt-body/);
   });
 
   test("close removes subscription and refuses new mutations", async () => {

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -96,6 +96,8 @@ export interface SideThreadRuntimeAdapter {
   archive(input: { derivedThreadId: string }): Promise<void>;
   delete(input: { derivedThreadId: string }): Promise<void>;
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void;
+  subscribeDropped?(listener: (reason: string) => void): () => void;
+  close?(): void;
 }
 
 export type SideThreadAuditAction =
@@ -124,7 +126,7 @@ export interface SideThreadAuditEntry {
 
 export interface SideThreadServiceOptions {
   adapter: SideThreadRuntimeAdapter;
-  audit?: (entry: SideThreadAuditEntry) => void;
+  audit?: (entry: SideThreadAuditEntry) => void | Promise<void>;
   now?: () => number;
   id?: () => string;
 }
@@ -138,6 +140,10 @@ export class SideThreadService {
   private readonly createByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadRecord> }>();
   private readonly attemptByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadAttempt> }>();
   private readonly unsubscribe: () => void;
+  private readonly unsubscribeDropped: () => void;
+  private readonly locks = new Map<string, Promise<void>>();
+  private readonly pending = new Set<Promise<unknown>>();
+  private readonly cancelRequested = new Set<string>();
   private closed = false;
   private readonly now: () => number;
   private readonly id: () => string;
@@ -146,12 +152,16 @@ export class SideThreadService {
     this.now = opts.now ?? Date.now;
     this.id = opts.id ?? randomUUID;
     this.unsubscribe = opts.adapter.subscribe((event) => this.onTerminal(event));
+    this.unsubscribeDropped = opts.adapter.subscribeDropped?.((reason) => this.auditDropped(reason)) ?? (() => {});
   }
 
-  close(): void {
+  async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
     this.unsubscribe();
+    this.unsubscribeDropped();
+    this.opts.adapter.close?.();
+    await Promise.allSettled([...this.pending]);
   }
 
   capability(): SideThreadCapability { return this.opts.adapter.capability(); }
@@ -200,8 +210,12 @@ export class SideThreadService {
       sideThreadId, sourceThreadId: input.sourceThreadId, boundary: input.boundary,
     });
     requireIdentity(forked.derivedThreadId, "derivedThreadId");
+    this.assertOpen();
     if (forked.derivedThreadId === input.sourceThreadId) {
       throw new SideThreadConflictError("runtime returned the source thread as the derived thread");
+    }
+    if ([...this.records.values()].some((record) => record.derivedThreadId === forked.derivedThreadId)) {
+      throw new SideThreadConflictError("runtime returned a derived thread already owned by another side thread");
     }
     const record: SideThreadRecord = {
       id: sideThreadId, requestKey: input.requestKey, nodeId: input.nodeId,
@@ -237,7 +251,9 @@ export class SideThreadService {
   }
 
   private async startOnce(input: { sideThreadId: string; requestKey: string; prompt: string }): Promise<SideThreadAttempt> {
+    return this.withLock(input.sideThreadId, async () => {
     const record = this.mustGet(input.sideThreadId);
+    this.assertAttestation(record);
     if (record.state === "archived" || record.state === "purged") {
       throw new SideThreadConflictError(`cannot start attempt from ${record.state}`);
     }
@@ -253,6 +269,8 @@ export class SideThreadService {
         sideThreadId: record.id, attemptId: attempt.id,
         derivedThreadId: record.derivedThreadId, prompt: input.prompt,
       });
+      this.assertOpen();
+      this.assertAttestation(record);
       requireIdentity(started.turnId, "turnId");
       if (attempt.turnId && attempt.turnId !== started.turnId) {
         throw new SideThreadConflictError("runtime attempt identity changed during start");
@@ -263,44 +281,63 @@ export class SideThreadService {
       this.audit(record, "attempt_started", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
       return attempt;
     } catch (error) {
-      attempt.state = "failed";
-      attempt.error = safeError(error);
-      record.activeAttemptId = undefined;
-      record.state = "failed";
+      if (attempt.state === "starting" || attempt.state === "running") {
+        attempt.state = "failed";
+        attempt.error = safeError(error);
+        record.activeAttemptId = undefined;
+        record.state = "failed";
+      }
       throw error;
     }
+    });
   }
 
   async cancel(sideThreadId: string): Promise<void> {
     this.assertOpen();
+    return this.withLock(sideThreadId, async () => {
     const record = this.mustGet(sideThreadId);
+    this.assertAttestation(record);
     const attempt = record.attempts.find((a) => a.id === record.activeAttemptId);
     if (!attempt?.turnId || attempt.state !== "running") {
       throw new SideThreadConflictError("side thread has no cancellable turn");
     }
+    if (this.cancelRequested.has(attempt.id)) return;
+    this.cancelRequested.add(attempt.id);
     this.audit(record, "cancel_requested", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
-    await this.opts.adapter.cancel({ derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
+    try { await this.opts.adapter.cancel({ derivedThreadId: record.derivedThreadId, turnId: attempt.turnId }); }
+    catch (error) { this.cancelRequested.delete(attempt.id); throw error; }
+    this.assertOpen();
+    });
   }
 
   async archive(sideThreadId: string): Promise<void> {
     this.assertOpen();
+    return this.withLock(sideThreadId, async () => {
     const record = this.mustGet(sideThreadId);
+    this.assertAttestation(record);
     if (record.activeAttemptId) throw new SideThreadConflictError("cannot archive a running side thread");
     if (record.state === "purged") throw new SideThreadConflictError("cannot archive a purged side thread");
     if (record.state === "archived") return;
     await this.opts.adapter.archive({ derivedThreadId: record.derivedThreadId });
+    this.assertOpen();
+    if (record.state === "purged") throw new SideThreadConflictError("purge won archive race");
     record.state = "archived";
     this.audit(record, "archived", { derivedThreadId: record.derivedThreadId });
+    });
   }
 
   async purge(sideThreadId: string): Promise<void> {
     this.assertOpen();
+    return this.withLock(sideThreadId, async () => {
     const record = this.mustGet(sideThreadId);
+    this.assertAttestation(record);
     if (record.activeAttemptId) throw new SideThreadConflictError("cannot purge a running side thread");
     if (record.state === "purged") return;
     await this.opts.adapter.delete({ derivedThreadId: record.derivedThreadId });
+    this.assertOpen();
     record.state = "purged";
     this.audit(record, "purged", { derivedThreadId: record.derivedThreadId });
+    });
   }
 
   get(sideThreadId: string): SideThreadRecord | undefined {
@@ -311,11 +348,10 @@ export class SideThreadService {
   private onTerminal(event: SideThreadTerminalEvent): void {
     const record = this.records.get(event.sideThreadId);
     const attempt = record?.attempts.find((a) => a.id === event.attemptId);
-    const startingIdentity = attempt?.state === "starting" && !attempt.turnId;
     const owned = !!record && !!attempt && record.derivedThreadId === event.threadId
-      && (attempt.turnId === event.turnId || startingIdentity)
+      && attempt.turnId === event.turnId
       && record.activeAttemptId === attempt.id
-      && (attempt.state === "running" || startingIdentity);
+      && attempt.state === "running";
     if (!owned) {
       this.opts.audit?.({
         action: "event_dropped", sideThreadId: event.sideThreadId,
@@ -333,6 +369,7 @@ export class SideThreadService {
     attempt!.result = event.status === "completed" ? event.text : undefined;
     attempt!.error = event.status === "failed" ? safeText(event.error) : undefined;
     record!.activeAttemptId = undefined;
+    this.cancelRequested.delete(attempt!.id);
     record!.state = attempt!.state === "cancelled" ? "cancelled" : attempt!.state;
     this.audit(record!, "attempt_terminal", {
       attemptId: attempt!.id, derivedThreadId: record!.derivedThreadId,
@@ -350,15 +387,46 @@ export class SideThreadService {
     if (this.closed) throw new SideThreadConflictError("side thread service is closed");
   }
 
+  private assertAttestation(record: SideThreadRecord): void {
+    const cap = this.opts.adapter.capability();
+    if (!cap.supported || cap.mode !== "native-exact-fork" || cap.runtime !== record.runtime
+      || cap.runtimeVersion !== record.runtimeVersion || cap.topology !== record.topology
+      || cap.evidenceRevision !== record.evidenceRevision || !cap.exactBoundary?.[record.boundary.kind]) {
+      throw new SideThreadUnsupportedError(cap.reason ?? "exact-boundary", "immutable capability attestation no longer matches");
+    }
+  }
+
+  private withLock<T>(sideThreadId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.locks.get(sideThreadId) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => { release = resolve; });
+    const tail = previous.then(() => next);
+    this.locks.set(sideThreadId, tail);
+    const running = previous.then(() => { this.assertOpen(); return operation(); })
+      .finally(() => { release(); if (this.locks.get(sideThreadId) === tail) this.locks.delete(sideThreadId); });
+    this.pending.add(running);
+    void running.then(() => this.pending.delete(running), () => this.pending.delete(running));
+    return running;
+  }
+
+  private auditDropped(reason: string): void {
+    this.emitAudit({ action: "event_dropped", sideThreadId: "unowned", runtime: this.opts.adapter.capability().runtime,
+      runtimeVersion: this.opts.adapter.capability().runtimeVersion, topology: this.opts.adapter.capability().topology,
+      evidenceRevision: this.opts.adapter.capability().evidenceRevision, reason: safeText(reason), at: this.now() });
+  }
+
   private audit(record: SideThreadRecord, action: SideThreadAuditAction, extra: Partial<SideThreadAuditEntry>): void {
-    this.opts.audit?.({ action, sideThreadId: record.id, runtime: record.runtime,
+    this.emitAudit({ action, sideThreadId: record.id, runtime: record.runtime,
       runtimeVersion: record.runtimeVersion, topology: record.topology,
-      evidenceRevision: record.evidenceRevision, at: this.now(), ...extra });
+      evidenceRevision: record.evidenceRevision, at: this.now(), ...redactAudit(extra) });
+  }
+  private emitAudit(entry: SideThreadAuditEntry): void {
+    try { void Promise.resolve(this.opts.audit?.(entry)).catch(() => {}); } catch { /* audit is non-throwing */ }
   }
 }
 
 function requireIdentity(value: string, label: string): void {
-  if (!value || value.length > 512 || /[\r\n\0]/.test(value)) throw new SideThreadConflictError(`invalid ${label}`);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value)) throw new SideThreadConflictError(`invalid ${label}`);
 }
 function requireIdempotencyKey(value: string): void {
   if (!/^[A-Za-z0-9._:-]{8,160}$/.test(value)) throw new SideThreadConflictError("invalid idempotency key");
@@ -372,4 +440,13 @@ function cloneAttempt(value: SideThreadAttempt): SideThreadAttempt { return { ..
 function cloneRecord(value: SideThreadRecord): SideThreadRecord {
   return { ...value, boundary: { ...value.boundary }, attempts: value.attempts.map(cloneAttempt) };
 }
+function auditHash(value: string): string { return `sha256:${createHash("sha256").update(value).digest("hex").slice(0, 24)}`; }
+function redactAudit(extra: Partial<SideThreadAuditEntry>): Partial<SideThreadAuditEntry> {
+  const copy = { ...extra };
+  for (const key of ["sourceThreadId", "derivedThreadId", "turnId"] as const) {
+    if (copy[key]) copy[key] = auditHash(copy[key]!);
+  }
+  return copy;
+}
 import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -41,6 +41,10 @@ export class SideThreadConflictError extends Error {
   readonly code = "SIDE_THREAD_CONFLICT";
   constructor(message: string) { super(message); this.name = "SideThreadConflictError"; }
 }
+export class SideThreadAmbiguousError extends Error {
+  readonly code = "SIDE_THREAD_AMBIGUOUS";
+  constructor(message: string) { super(message); this.name = "SideThreadAmbiguousError"; }
+}
 
 export interface SideThreadRecord {
   id: string;
@@ -63,7 +67,7 @@ export interface SideThreadAttempt {
   id: string;
   requestKey: string;
   turnId?: string;
-  state: "starting" | "running" | "completed" | "failed" | "cancelled";
+  state: "starting" | "running" | "ambiguous" | "completed" | "failed" | "cancelled";
   result?: string;
   error?: string;
   createdAt: number;
@@ -98,6 +102,7 @@ export interface SideThreadRuntimeAdapter {
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void;
   subscribeDropped?(listener: (reason: string) => void): () => void;
   close?(): void;
+  discardFork?(input: { sideThreadId: string; derivedThreadId: string }): Promise<void>;
 }
 
 export type SideThreadAuditAction =
@@ -211,6 +216,11 @@ export class SideThreadService {
     });
     requireIdentity(forked.derivedThreadId, "derivedThreadId");
     this.assertOpen();
+    try { this.assertCapability(capability, input.boundary.kind); }
+    catch (error) {
+      await this.opts.adapter.discardFork?.({ sideThreadId, derivedThreadId: forked.derivedThreadId }).catch(() => {});
+      throw error;
+    }
     if (forked.derivedThreadId === input.sourceThreadId) {
       throw new SideThreadConflictError("runtime returned the source thread as the derived thread");
     }
@@ -247,7 +257,7 @@ export class SideThreadService {
     const operation = this.startOnce(input);
     this.attemptByKey.set(key, { fingerprint, operation });
     try { return cloneAttempt(await operation); }
-    catch (error) { this.attemptByKey.delete(key); throw error; }
+    catch (error) { if (!(error instanceof SideThreadAmbiguousError)) this.attemptByKey.delete(key); throw error; }
   }
 
   private async startOnce(input: { sideThreadId: string; requestKey: string; prompt: string }): Promise<SideThreadAttempt> {
@@ -281,6 +291,12 @@ export class SideThreadService {
       this.audit(record, "attempt_started", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
       return attempt;
     } catch (error) {
+      if (error instanceof SideThreadAmbiguousError) {
+        attempt.state = "ambiguous";
+        attempt.error = safeError(error);
+        record.state = "running";
+        throw error;
+      }
       if (attempt.state === "starting" || attempt.state === "running") {
         attempt.state = "failed";
         attempt.error = safeError(error);
@@ -353,14 +369,14 @@ export class SideThreadService {
       && record.activeAttemptId === attempt.id
       && attempt.state === "running";
     if (!owned) {
-      this.opts.audit?.({
+      this.emitAudit(redactAudit({
         action: "event_dropped", sideThreadId: event.sideThreadId,
         attemptId: event.attemptId, runtime: this.opts.adapter.capability().runtime,
         runtimeVersion: this.opts.adapter.capability().runtimeVersion,
         topology: this.opts.adapter.capability().topology,
         evidenceRevision: this.opts.adapter.capability().evidenceRevision,
         reason: "ownership-mismatch", at: this.now(),
-      });
+      }) as SideThreadAuditEntry);
       return;
     }
     if (!attempt!.turnId) attempt!.turnId = event.turnId;
@@ -393,6 +409,14 @@ export class SideThreadService {
       || cap.runtimeVersion !== record.runtimeVersion || cap.topology !== record.topology
       || cap.evidenceRevision !== record.evidenceRevision || !cap.exactBoundary?.[record.boundary.kind]) {
       throw new SideThreadUnsupportedError(cap.reason ?? "exact-boundary", "immutable capability attestation no longer matches");
+    }
+  }
+  private assertCapability(expected: SideThreadCapability, boundary: ExactBoundary["kind"]): void {
+    const fresh = this.opts.adapter.capability();
+    if (!fresh.supported || fresh.mode !== "native-exact-fork" || !fresh.exactBoundary?.[boundary]
+      || fresh.runtime !== expected.runtime || fresh.runtimeVersion !== expected.runtimeVersion
+      || fresh.topology !== expected.topology || fresh.evidenceRevision !== expected.evidenceRevision) {
+      throw new SideThreadUnsupportedError(fresh.reason ?? "exact-boundary", "capability changed while creating side thread");
     }
   }
 

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -115,7 +115,7 @@ export interface SideThreadRuntimeAdapter {
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void;
   subscribeDropped?(listener: (reason: string) => void): () => void;
   close?(): void;
-  discardFork?(input: { sideThreadId: string; derivedThreadId: string }): Promise<void>;
+  discardFork?(input: { sideThreadId: string; derivedThreadId: string; operation: SideThreadRuntimeOperation }): Promise<void>;
 }
 
 export type SideThreadAuditAction =
@@ -240,7 +240,10 @@ export class SideThreadService {
     this.assertOpen();
     try { this.assertCapability(capability, input.boundary.kind); }
     catch (error) {
-      await this.opts.adapter.discardFork?.({ sideThreadId, derivedThreadId: forked.derivedThreadId }).catch(() => {});
+      await this.opts.adapter.discardFork?.({
+        sideThreadId, derivedThreadId: forked.derivedThreadId,
+        operation: runtimeOperation(input.nodeId, sideThreadId, "delete", `discard-${input.requestKey}`),
+      }).catch(() => {});
       throw error;
     }
     if (forked.derivedThreadId === input.sourceThreadId) {
@@ -468,7 +471,7 @@ export class SideThreadService {
   private auditDropped(reason: string): void {
     this.emitAudit({ action: "event_dropped", sideThreadId: "unowned", runtime: this.opts.adapter.capability().runtime,
       runtimeVersion: this.opts.adapter.capability().runtimeVersion, topology: this.opts.adapter.capability().topology,
-      evidenceRevision: this.opts.adapter.capability().evidenceRevision, reason: safeText(reason), at: this.now() });
+      evidenceRevision: this.opts.adapter.capability().evidenceRevision, reason: safeDroppedReason(reason), at: this.now() });
   }
 
   private audit(record: SideThreadRecord, action: SideThreadAuditAction, extra: Partial<SideThreadAuditEntry>): void {
@@ -492,6 +495,12 @@ function safeText(value: unknown): string | undefined {
   return value.replace(/[\r\n\t]+/g, " ").slice(0, 300);
 }
 function safeError(error: unknown): string { return safeText(error instanceof Error ? error.message : String(error)) ?? "runtime error"; }
+function safeDroppedReason(reason: string): string {
+  return new Set([
+    "identity-ownership-mismatch", "identity-turn-mismatch", "unowned-agent-message",
+    "unowned-delta", "terminal-buffer-full", "unowned-terminal",
+  ]).has(reason) ? reason : "runtime-event-rejected";
+}
 function cloneAttempt(value: SideThreadAttempt): SideThreadAttempt { return { ...value }; }
 function cloneRecord(value: SideThreadRecord): SideThreadRecord {
   return { ...value, boundary: { ...value.boundary }, attempts: value.attempts.map(cloneAttempt) };

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -1,3 +1,6 @@
+import { createHash, randomUUID } from "node:crypto";
+import { stableOperationId, type OperationMethod } from "./operation-ledger";
+
 export type SideThreadState =
   | "ready"
   | "running"
@@ -85,22 +88,30 @@ export interface SideThreadTerminalEvent {
   identityBound?: boolean;
 }
 
+export interface SideThreadRuntimeOperation {
+  nodeId: string;
+  operationId: string;
+  idempotencyKey: string;
+}
+
 export interface SideThreadRuntimeAdapter {
   capability(): SideThreadCapability;
   fork(input: {
     sideThreadId: string;
     sourceThreadId: string;
     boundary: ExactBoundary;
+    operation: SideThreadRuntimeOperation;
   }): Promise<{ derivedThreadId: string }>;
   start(input: {
     sideThreadId: string;
     attemptId: string;
     derivedThreadId: string;
     prompt: string;
+    operation: SideThreadRuntimeOperation;
   }): Promise<{ turnId: string }>;
-  cancel(input: { derivedThreadId: string; turnId: string }): Promise<void>;
-  archive(input: { derivedThreadId: string }): Promise<void>;
-  delete(input: { derivedThreadId: string }): Promise<void>;
+  cancel(input: { sideThreadId: string; derivedThreadId: string; turnId: string; operation: SideThreadRuntimeOperation }): Promise<void>;
+  archive(input: { sideThreadId: string; derivedThreadId: string; operation: SideThreadRuntimeOperation }): Promise<void>;
+  delete(input: { sideThreadId: string; derivedThreadId: string; operation: SideThreadRuntimeOperation }): Promise<void>;
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void;
   subscribeDropped?(listener: (reason: string) => void): () => void;
   close?(): void;
@@ -144,7 +155,8 @@ export interface SideThreadServiceOptions {
  */
 export class SideThreadService {
   private readonly records = new Map<string, SideThreadRecord>();
-  private readonly createByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadRecord> }>();
+  private readonly createByKey = new Map<string, { fingerprint: string; sideThreadId: string; operation: Promise<SideThreadRecord> }>();
+  private readonly createIdentityByKey = new Map<string, { fingerprint: string; sideThreadId: string }>();
   private readonly attemptByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadAttempt> }>();
   private readonly unsubscribe: () => void;
   private readonly unsubscribeDropped: () => void;
@@ -185,20 +197,28 @@ export class SideThreadService {
     requireIdentity(input.sourceThreadId, "sourceThreadId");
     requireIdentity(input.boundary.turnId, "boundary.turnId");
     const fingerprint = JSON.stringify([input.nodeId, input.sourceThreadId, input.boundary.kind, input.boundary.turnId]);
+    const identity = this.createIdentityByKey.get(input.requestKey);
+    if (identity && identity.fingerprint !== fingerprint) throw new SideThreadConflictError("idempotency key reused with different create input");
     const existing = this.createByKey.get(input.requestKey);
     if (existing) {
       if (existing.fingerprint !== fingerprint) throw new SideThreadConflictError("idempotency key reused with different create input");
       return cloneRecord(await existing.operation);
     }
-    const operation = this.createOnce(input);
-    this.createByKey.set(input.requestKey, { fingerprint, operation });
+    const sideThreadId = identity?.sideThreadId ?? this.id();
+    this.createIdentityByKey.set(input.requestKey, { fingerprint, sideThreadId });
+    const operation = this.createOnce(input, sideThreadId);
+    this.createByKey.set(input.requestKey, { fingerprint, sideThreadId, operation });
     try { return cloneRecord(await operation); }
-    catch (error) { this.createByKey.delete(input.requestKey); throw error; }
+    catch (error) {
+      this.createByKey.delete(input.requestKey);
+      if (!(error instanceof SideThreadAmbiguousError)) this.createIdentityByKey.delete(input.requestKey);
+      throw error;
+    }
   }
 
   private async createOnce(input: {
     requestKey: string; nodeId: string; sourceThreadId: string; boundary: ExactBoundary;
-  }): Promise<SideThreadRecord> {
+  }, sideThreadId: string): Promise<SideThreadRecord> {
     const capability = this.opts.adapter.capability();
     if (!capability.supported || capability.mode !== "native-exact-fork") {
       throw new SideThreadUnsupportedError(
@@ -212,9 +232,9 @@ export class SideThreadService {
         `side thread boundary '${input.boundary.kind}' is unsupported`,
       );
     }
-    const sideThreadId = this.id();
     const forked = await this.opts.adapter.fork({
       sideThreadId, sourceThreadId: input.sourceThreadId, boundary: input.boundary,
+      operation: runtimeOperation(input.nodeId, sideThreadId, "fork", input.requestKey),
     });
     requireIdentity(forked.derivedThreadId, "derivedThreadId");
     this.assertOpen();
@@ -259,7 +279,7 @@ export class SideThreadService {
     const operation = this.startOnce(input);
     this.attemptByKey.set(key, { fingerprint, operation });
     try { return cloneAttempt(await operation); }
-    catch (error) { if (!(error instanceof SideThreadAmbiguousError)) this.attemptByKey.delete(key); throw error; }
+    catch (error) { this.attemptByKey.delete(key); throw error; }
   }
 
   private async startOnce(input: { sideThreadId: string; requestKey: string; prompt: string }): Promise<SideThreadAttempt> {
@@ -269,17 +289,21 @@ export class SideThreadService {
     if (record.state === "archived" || record.state === "purged") {
       throw new SideThreadConflictError(`cannot start attempt from ${record.state}`);
     }
-    if (record.activeAttemptId) throw new SideThreadConflictError("side thread already has an active attempt");
-    const attempt: SideThreadAttempt = {
+    const active = record.attempts.find((candidate) => candidate.id === record.activeAttemptId);
+    if (active && (active.requestKey !== input.requestKey || active.state !== "ambiguous")) {
+      throw new SideThreadConflictError("side thread already has an active attempt");
+    }
+    const attempt: SideThreadAttempt = active ?? {
       id: this.id(), requestKey: input.requestKey, state: "starting", createdAt: this.now(),
     };
-    record.attempts.push(attempt);
-    record.activeAttemptId = attempt.id;
+    if (!active) { record.attempts.push(attempt); record.activeAttemptId = attempt.id; }
+    else { attempt.state = "starting"; attempt.error = undefined; }
     record.state = "running";
     try {
       const started = await this.opts.adapter.start({
         sideThreadId: record.id, attemptId: attempt.id,
         derivedThreadId: record.derivedThreadId, prompt: input.prompt,
+        operation: runtimeOperation(record.nodeId, record.id, "start", input.requestKey),
       });
       this.assertOpen();
       this.assertAttestation(record);
@@ -322,7 +346,9 @@ export class SideThreadService {
     if (this.cancelRequested.has(attempt.id)) return;
     this.cancelRequested.add(attempt.id);
     this.audit(record, "cancel_requested", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
-    try { await this.opts.adapter.cancel({ derivedThreadId: record.derivedThreadId, turnId: attempt.turnId }); }
+    const idempotencyKey = `cancel-${attempt.id}`;
+    try { await this.opts.adapter.cancel({ sideThreadId: record.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId,
+      operation: runtimeOperation(record.nodeId, record.id, "interrupt", idempotencyKey) }); }
     catch (error) { this.cancelRequested.delete(attempt.id); throw error; }
     this.assertOpen();
     });
@@ -336,7 +362,8 @@ export class SideThreadService {
     if (record.activeAttemptId) throw new SideThreadConflictError("cannot archive a running side thread");
     if (record.state === "purged") throw new SideThreadConflictError("cannot archive a purged side thread");
     if (record.state === "archived") return;
-    await this.opts.adapter.archive({ derivedThreadId: record.derivedThreadId });
+    await this.opts.adapter.archive({ sideThreadId: record.id, derivedThreadId: record.derivedThreadId,
+      operation: runtimeOperation(record.nodeId, record.id, "archive", `archive-${record.id}`) });
     this.assertOpen();
     if (record.state === "purged") throw new SideThreadConflictError("purge won archive race");
     record.state = "archived";
@@ -351,7 +378,8 @@ export class SideThreadService {
     this.assertAttestation(record);
     if (record.activeAttemptId) throw new SideThreadConflictError("cannot purge a running side thread");
     if (record.state === "purged") return;
-    await this.opts.adapter.delete({ derivedThreadId: record.derivedThreadId });
+    await this.opts.adapter.delete({ sideThreadId: record.id, derivedThreadId: record.derivedThreadId,
+      operation: runtimeOperation(record.nodeId, record.id, "delete", `purge-${record.id}`) });
     this.assertOpen();
     record.state = "purged";
     this.audit(record, "purged", { derivedThreadId: record.derivedThreadId });
@@ -476,5 +504,6 @@ function redactAudit(extra: Partial<SideThreadAuditEntry>): Partial<SideThreadAu
   }
   return copy;
 }
-import { randomUUID } from "node:crypto";
-import { createHash, randomUUID } from "node:crypto";
+function runtimeOperation(nodeId: string, sideThreadId: string, method: OperationMethod, idempotencyKey: string): SideThreadRuntimeOperation {
+  return { nodeId, operationId: stableOperationId(sideThreadId, method, idempotencyKey), idempotencyKey };
+}

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -15,6 +15,8 @@ export interface SideThreadCapability {
   supported: boolean;
   runtime: string;
   runtimeVersion: string;
+  topology: string;
+  evidenceRevision: string;
   mode?: "native-exact-fork";
   exactBoundary?: { through: boolean; before: boolean };
   reason?: SideThreadUnsupportedReason;
@@ -49,6 +51,8 @@ export interface SideThreadRecord {
   boundary: ExactBoundary;
   runtime: string;
   runtimeVersion: string;
+  topology: string;
+  evidenceRevision: string;
   state: SideThreadState;
   activeAttemptId?: string;
   attempts: SideThreadAttempt[];
@@ -109,6 +113,8 @@ export interface SideThreadAuditEntry {
   attemptId?: string;
   runtime: string;
   runtimeVersion: string;
+  topology: string;
+  evidenceRevision: string;
   sourceThreadId?: string;
   derivedThreadId?: string;
   turnId?: string;
@@ -201,7 +207,9 @@ export class SideThreadService {
       id: sideThreadId, requestKey: input.requestKey, nodeId: input.nodeId,
       sourceThreadId: input.sourceThreadId, derivedThreadId: forked.derivedThreadId,
       boundary: input.boundary, runtime: capability.runtime,
-      runtimeVersion: capability.runtimeVersion, state: "ready", attempts: [],
+      runtimeVersion: capability.runtimeVersion, topology: capability.topology,
+      evidenceRevision: capability.evidenceRevision,
+      state: "ready", attempts: [],
       createdAt: this.now(),
     };
     this.records.set(record.id, record);
@@ -313,6 +321,8 @@ export class SideThreadService {
         action: "event_dropped", sideThreadId: event.sideThreadId,
         attemptId: event.attemptId, runtime: this.opts.adapter.capability().runtime,
         runtimeVersion: this.opts.adapter.capability().runtimeVersion,
+        topology: this.opts.adapter.capability().topology,
+        evidenceRevision: this.opts.adapter.capability().evidenceRevision,
         reason: "ownership-mismatch", at: this.now(),
       });
       return;
@@ -342,7 +352,8 @@ export class SideThreadService {
 
   private audit(record: SideThreadRecord, action: SideThreadAuditAction, extra: Partial<SideThreadAuditEntry>): void {
     this.opts.audit?.({ action, sideThreadId: record.id, runtime: record.runtime,
-      runtimeVersion: record.runtimeVersion, at: this.now(), ...extra });
+      runtimeVersion: record.runtimeVersion, topology: record.topology,
+      evidenceRevision: record.evidenceRevision, at: this.now(), ...extra });
   }
 }
 

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -1,0 +1,364 @@
+export type SideThreadState =
+  | "ready"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "archived"
+  | "purged";
+
+export type ExactBoundary =
+  | { kind: "through"; turnId: string }
+  | { kind: "before"; turnId: string };
+
+export interface SideThreadCapability {
+  supported: boolean;
+  runtime: string;
+  runtimeVersion: string;
+  mode?: "native-exact-fork";
+  exactBoundary?: { through: boolean; before: boolean };
+  reason?: SideThreadUnsupportedReason;
+}
+
+export type SideThreadUnsupportedReason =
+  | "runtime"
+  | "version"
+  | "topology"
+  | "experimental-api"
+  | "exact-boundary";
+
+export class SideThreadUnsupportedError extends Error {
+  readonly code = "SIDE_THREAD_UNSUPPORTED";
+  constructor(readonly reason: SideThreadUnsupportedReason, message: string) {
+    super(message);
+    this.name = "SideThreadUnsupportedError";
+  }
+}
+
+export class SideThreadConflictError extends Error {
+  readonly code = "SIDE_THREAD_CONFLICT";
+  constructor(message: string) { super(message); this.name = "SideThreadConflictError"; }
+}
+
+export interface SideThreadRecord {
+  id: string;
+  requestKey: string;
+  nodeId: string;
+  sourceThreadId: string;
+  derivedThreadId: string;
+  boundary: ExactBoundary;
+  runtime: string;
+  runtimeVersion: string;
+  state: SideThreadState;
+  activeAttemptId?: string;
+  attempts: SideThreadAttempt[];
+  createdAt: number;
+}
+
+export interface SideThreadAttempt {
+  id: string;
+  requestKey: string;
+  turnId?: string;
+  state: "starting" | "running" | "completed" | "failed" | "cancelled";
+  result?: string;
+  error?: string;
+  createdAt: number;
+}
+
+export interface SideThreadTerminalEvent {
+  sideThreadId: string;
+  attemptId: string;
+  threadId: string;
+  turnId: string;
+  status: "completed" | "failed" | "interrupted";
+  text?: string;
+  error?: string;
+}
+
+export interface SideThreadRuntimeAdapter {
+  capability(): SideThreadCapability;
+  fork(input: {
+    sideThreadId: string;
+    sourceThreadId: string;
+    boundary: ExactBoundary;
+  }): Promise<{ derivedThreadId: string }>;
+  start(input: {
+    sideThreadId: string;
+    attemptId: string;
+    derivedThreadId: string;
+    prompt: string;
+  }): Promise<{ turnId: string }>;
+  cancel(input: { derivedThreadId: string; turnId: string }): Promise<void>;
+  archive(input: { derivedThreadId: string }): Promise<void>;
+  delete(input: { derivedThreadId: string }): Promise<void>;
+  subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void;
+}
+
+export type SideThreadAuditAction =
+  | "created"
+  | "attempt_started"
+  | "attempt_terminal"
+  | "cancel_requested"
+  | "archived"
+  | "purged"
+  | "event_dropped";
+
+export interface SideThreadAuditEntry {
+  action: SideThreadAuditAction;
+  sideThreadId: string;
+  attemptId?: string;
+  runtime: string;
+  runtimeVersion: string;
+  sourceThreadId?: string;
+  derivedThreadId?: string;
+  turnId?: string;
+  reason?: string;
+  at: number;
+}
+
+export interface SideThreadServiceOptions {
+  adapter: SideThreadRuntimeAdapter;
+  audit?: (entry: SideThreadAuditEntry) => void;
+  now?: () => number;
+  id?: () => string;
+}
+
+/**
+ * Runtime-neutral lifecycle owner. No Hub/App transport is wired in PR1.
+ * Returned records are snapshots so callers cannot mutate registry identity.
+ */
+export class SideThreadService {
+  private readonly records = new Map<string, SideThreadRecord>();
+  private readonly createByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadRecord> }>();
+  private readonly attemptByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadAttempt> }>();
+  private readonly unsubscribe: () => void;
+  private closed = false;
+  private readonly now: () => number;
+  private readonly id: () => string;
+
+  constructor(private readonly opts: SideThreadServiceOptions) {
+    this.now = opts.now ?? Date.now;
+    this.id = opts.id ?? randomUUID;
+    this.unsubscribe = opts.adapter.subscribe((event) => this.onTerminal(event));
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.unsubscribe();
+  }
+
+  capability(): SideThreadCapability { return this.opts.adapter.capability(); }
+
+  async create(input: {
+    requestKey: string;
+    nodeId: string;
+    sourceThreadId: string;
+    boundary: ExactBoundary;
+  }): Promise<SideThreadRecord> {
+    this.assertOpen();
+    requireIdempotencyKey(input.requestKey);
+    requireIdentity(input.nodeId, "nodeId");
+    requireIdentity(input.sourceThreadId, "sourceThreadId");
+    requireIdentity(input.boundary.turnId, "boundary.turnId");
+    const fingerprint = JSON.stringify([input.nodeId, input.sourceThreadId, input.boundary.kind, input.boundary.turnId]);
+    const existing = this.createByKey.get(input.requestKey);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) throw new SideThreadConflictError("idempotency key reused with different create input");
+      return cloneRecord(await existing.operation);
+    }
+    const operation = this.createOnce(input);
+    this.createByKey.set(input.requestKey, { fingerprint, operation });
+    try { return cloneRecord(await operation); }
+    catch (error) { this.createByKey.delete(input.requestKey); throw error; }
+  }
+
+  private async createOnce(input: {
+    requestKey: string; nodeId: string; sourceThreadId: string; boundary: ExactBoundary;
+  }): Promise<SideThreadRecord> {
+    const capability = this.opts.adapter.capability();
+    if (!capability.supported || capability.mode !== "native-exact-fork") {
+      throw new SideThreadUnsupportedError(
+        capability.reason ?? "exact-boundary",
+        `side thread unsupported: ${capability.reason ?? "native exact-boundary fork unavailable"}`,
+      );
+    }
+    if (!capability.exactBoundary?.[input.boundary.kind]) {
+      throw new SideThreadUnsupportedError(
+        input.boundary.kind === "before" ? "experimental-api" : "exact-boundary",
+        `side thread boundary '${input.boundary.kind}' is unsupported`,
+      );
+    }
+    const sideThreadId = this.id();
+    const forked = await this.opts.adapter.fork({
+      sideThreadId, sourceThreadId: input.sourceThreadId, boundary: input.boundary,
+    });
+    requireIdentity(forked.derivedThreadId, "derivedThreadId");
+    if (forked.derivedThreadId === input.sourceThreadId) {
+      throw new SideThreadConflictError("runtime returned the source thread as the derived thread");
+    }
+    const record: SideThreadRecord = {
+      id: sideThreadId, requestKey: input.requestKey, nodeId: input.nodeId,
+      sourceThreadId: input.sourceThreadId, derivedThreadId: forked.derivedThreadId,
+      boundary: input.boundary, runtime: capability.runtime,
+      runtimeVersion: capability.runtimeVersion, state: "ready", attempts: [],
+      createdAt: this.now(),
+    };
+    this.records.set(record.id, record);
+    this.audit(record, "created", { sourceThreadId: record.sourceThreadId, derivedThreadId: record.derivedThreadId });
+    return record;
+  }
+
+  async startAttempt(input: {
+    sideThreadId: string; requestKey: string; prompt: string;
+  }): Promise<SideThreadAttempt> {
+    this.assertOpen();
+    requireIdempotencyKey(input.requestKey);
+    if (!input.prompt.trim()) throw new SideThreadConflictError("prompt must not be empty");
+    const key = `${input.sideThreadId}\0${input.requestKey}`;
+    const fingerprint = JSON.stringify([input.sideThreadId, input.prompt]);
+    const existing = this.attemptByKey.get(key);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) throw new SideThreadConflictError("idempotency key reused with different attempt input");
+      return cloneAttempt(await existing.operation);
+    }
+    const operation = this.startOnce(input);
+    this.attemptByKey.set(key, { fingerprint, operation });
+    try { return cloneAttempt(await operation); }
+    catch (error) { this.attemptByKey.delete(key); throw error; }
+  }
+
+  private async startOnce(input: { sideThreadId: string; requestKey: string; prompt: string }): Promise<SideThreadAttempt> {
+    const record = this.mustGet(input.sideThreadId);
+    if (record.state === "archived" || record.state === "purged") {
+      throw new SideThreadConflictError(`cannot start attempt from ${record.state}`);
+    }
+    if (record.activeAttemptId) throw new SideThreadConflictError("side thread already has an active attempt");
+    const attempt: SideThreadAttempt = {
+      id: this.id(), requestKey: input.requestKey, state: "starting", createdAt: this.now(),
+    };
+    record.attempts.push(attempt);
+    record.activeAttemptId = attempt.id;
+    record.state = "running";
+    try {
+      const started = await this.opts.adapter.start({
+        sideThreadId: record.id, attemptId: attempt.id,
+        derivedThreadId: record.derivedThreadId, prompt: input.prompt,
+      });
+      requireIdentity(started.turnId, "turnId");
+      if (attempt.turnId && attempt.turnId !== started.turnId) {
+        throw new SideThreadConflictError("runtime attempt identity changed during start");
+      }
+      attempt.turnId = started.turnId;
+      if (attempt.state !== "starting") return attempt;
+      attempt.state = "running";
+      this.audit(record, "attempt_started", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
+      return attempt;
+    } catch (error) {
+      attempt.state = "failed";
+      attempt.error = safeError(error);
+      record.activeAttemptId = undefined;
+      record.state = "failed";
+      throw error;
+    }
+  }
+
+  async cancel(sideThreadId: string): Promise<void> {
+    this.assertOpen();
+    const record = this.mustGet(sideThreadId);
+    const attempt = record.attempts.find((a) => a.id === record.activeAttemptId);
+    if (!attempt?.turnId || attempt.state !== "running") {
+      throw new SideThreadConflictError("side thread has no cancellable turn");
+    }
+    this.audit(record, "cancel_requested", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
+    await this.opts.adapter.cancel({ derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
+  }
+
+  async archive(sideThreadId: string): Promise<void> {
+    this.assertOpen();
+    const record = this.mustGet(sideThreadId);
+    if (record.activeAttemptId) throw new SideThreadConflictError("cannot archive a running side thread");
+    if (record.state === "purged") throw new SideThreadConflictError("cannot archive a purged side thread");
+    if (record.state === "archived") return;
+    await this.opts.adapter.archive({ derivedThreadId: record.derivedThreadId });
+    record.state = "archived";
+    this.audit(record, "archived", { derivedThreadId: record.derivedThreadId });
+  }
+
+  async purge(sideThreadId: string): Promise<void> {
+    this.assertOpen();
+    const record = this.mustGet(sideThreadId);
+    if (record.activeAttemptId) throw new SideThreadConflictError("cannot purge a running side thread");
+    if (record.state === "purged") return;
+    await this.opts.adapter.delete({ derivedThreadId: record.derivedThreadId });
+    record.state = "purged";
+    this.audit(record, "purged", { derivedThreadId: record.derivedThreadId });
+  }
+
+  get(sideThreadId: string): SideThreadRecord | undefined {
+    const record = this.records.get(sideThreadId);
+    return record ? cloneRecord(record) : undefined;
+  }
+
+  private onTerminal(event: SideThreadTerminalEvent): void {
+    const record = this.records.get(event.sideThreadId);
+    const attempt = record?.attempts.find((a) => a.id === event.attemptId);
+    const startingIdentity = attempt?.state === "starting" && !attempt.turnId;
+    const owned = !!record && !!attempt && record.derivedThreadId === event.threadId
+      && (attempt.turnId === event.turnId || startingIdentity)
+      && record.activeAttemptId === attempt.id
+      && (attempt.state === "running" || startingIdentity);
+    if (!owned) {
+      this.opts.audit?.({
+        action: "event_dropped", sideThreadId: event.sideThreadId,
+        attemptId: event.attemptId, runtime: this.opts.adapter.capability().runtime,
+        runtimeVersion: this.opts.adapter.capability().runtimeVersion,
+        reason: "ownership-mismatch", at: this.now(),
+      });
+      return;
+    }
+    if (!attempt!.turnId) attempt!.turnId = event.turnId;
+    attempt!.state = event.status === "completed" ? "completed"
+      : event.status === "interrupted" ? "cancelled" : "failed";
+    attempt!.result = event.status === "completed" ? event.text : undefined;
+    attempt!.error = event.status === "failed" ? safeText(event.error) : undefined;
+    record!.activeAttemptId = undefined;
+    record!.state = attempt!.state === "cancelled" ? "cancelled" : attempt!.state;
+    this.audit(record!, "attempt_terminal", {
+      attemptId: attempt!.id, derivedThreadId: record!.derivedThreadId,
+      turnId: attempt!.turnId, reason: event.status,
+    });
+  }
+
+  private mustGet(id: string): SideThreadRecord {
+    const record = this.records.get(id);
+    if (!record) throw new SideThreadConflictError("unknown side thread");
+    return record;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new SideThreadConflictError("side thread service is closed");
+  }
+
+  private audit(record: SideThreadRecord, action: SideThreadAuditAction, extra: Partial<SideThreadAuditEntry>): void {
+    this.opts.audit?.({ action, sideThreadId: record.id, runtime: record.runtime,
+      runtimeVersion: record.runtimeVersion, at: this.now(), ...extra });
+  }
+}
+
+function requireIdentity(value: string, label: string): void {
+  if (!value || value.length > 512 || /[\r\n\0]/.test(value)) throw new SideThreadConflictError(`invalid ${label}`);
+}
+function requireIdempotencyKey(value: string): void {
+  if (!/^[A-Za-z0-9._:-]{8,160}$/.test(value)) throw new SideThreadConflictError("invalid idempotency key");
+}
+function safeText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.replace(/[\r\n\t]+/g, " ").slice(0, 300);
+}
+function safeError(error: unknown): string { return safeText(error instanceof Error ? error.message : String(error)) ?? "runtime error"; }
+function cloneAttempt(value: SideThreadAttempt): SideThreadAttempt { return { ...value }; }
+function cloneRecord(value: SideThreadRecord): SideThreadRecord {
+  return { ...value, boundary: { ...value.boundary }, attempts: value.attempts.map(cloneAttempt) };
+}
+import { randomUUID } from "node:crypto";

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -81,6 +81,8 @@ export interface SideThreadTerminalEvent {
   status: "completed" | "failed" | "interrupted";
   text?: string;
   error?: string;
+  /** Adapter proved this turn by the echoed per-attempt client identity. */
+  identityBound?: boolean;
 }
 
 export interface SideThreadRuntimeAdapter {
@@ -364,10 +366,11 @@ export class SideThreadService {
   private onTerminal(event: SideThreadTerminalEvent): void {
     const record = this.records.get(event.sideThreadId);
     const attempt = record?.attempts.find((a) => a.id === event.attemptId);
+    const reconciling = attempt?.state === "ambiguous" && !attempt.turnId && event.identityBound === true;
     const owned = !!record && !!attempt && record.derivedThreadId === event.threadId
-      && attempt.turnId === event.turnId
+      && (attempt.turnId === event.turnId || reconciling)
       && record.activeAttemptId === attempt.id
-      && attempt.state === "running";
+      && (attempt.state === "running" || reconciling);
     if (!owned) {
       this.emitAudit(redactAudit({
         action: "event_dropped", sideThreadId: event.sideThreadId,
@@ -379,6 +382,7 @@ export class SideThreadService {
       }) as SideThreadAuditEntry);
       return;
     }
+    if (!attempt!.turnId) attempt!.turnId = event.turnId;
     if (!attempt!.turnId) attempt!.turnId = event.turnId;
     attempt!.state = event.status === "completed" ? "completed"
       : event.status === "interrupted" ? "cancelled" : "failed";

--- a/agent-node/src/runtime/side-thread/fork-lease.test.ts
+++ b/agent-node/src/runtime/side-thread/fork-lease.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PrivateFileForkLeaseStore, type ForkLeaseRecord } from "./fork-lease";
+import { operationHash } from "./operation-ledger";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+const lease = (operationId = "op-00000001"): ForkLeaseRecord => ({ version: 1, nodeId: "node-1",
+  sourceThreadHash: operationHash("source-1"), sideThreadId: "side-1", operationId,
+  fingerprint: operationHash("fork-input"), snapshotThreadIdHashes: [], state: "snapshot", updatedAt: 1 });
+
+describe("PrivateFileForkLeaseStore", () => {
+  test("persists a private per-source lease and the same operation resumes across instances", () => {
+    const root = mkdtempSync(join(tmpdir(), "fork-lease-")); roots.push(root);
+    const first = new PrivateFileForkLeaseStore(root); first.acquire(lease());
+    const second = new PrivateFileForkLeaseStore(root);
+    expect(second.acquire(lease())).toEqual(lease());
+    expect(statSync(root).mode & 0o777).toBe(0o700);
+    second.put({ ...lease(), state: "sent", updatedAt: 2 });
+    second.put({ ...lease(), state: "ambiguous", updatedAt: 3 });
+    expect(first.get("node-1", "source-1")?.state).toBe("ambiguous");
+    second.release("node-1", "source-1", "op-00000001");
+    expect(first.get("node-1", "source-1")).toBeUndefined();
+  });
+  test("a different operation cannot steal an unresolved source lease", () => {
+    const root = mkdtempSync(join(tmpdir(), "fork-lease-")); roots.push(root);
+    const store = new PrivateFileForkLeaseStore(root); store.acquire(lease());
+    expect(() => store.acquire({ ...lease("op-00000002"), sideThreadId: "side-2" })).toThrow("unresolved fork lease");
+    expect(() => store.release("node-1", "source-1", "op-00000002")).toThrow("ownership mismatch");
+  });
+});

--- a/agent-node/src/runtime/side-thread/fork-lease.test.ts
+++ b/agent-node/src/runtime/side-thread/fork-lease.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { chmodSync, linkSync, mkdtempSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { PrivateFileForkLeaseStore, type ForkLeaseRecord } from "./fork-lease";
@@ -27,7 +27,45 @@ describe("PrivateFileForkLeaseStore", () => {
   test("a different operation cannot steal an unresolved source lease", () => {
     const root = mkdtempSync(join(tmpdir(), "fork-lease-")); roots.push(root);
     const store = new PrivateFileForkLeaseStore(root); store.acquire(lease());
-    expect(() => store.acquire({ ...lease("op-00000002"), sideThreadId: "side-2" })).toThrow("unresolved fork lease");
+    expect(() => store.acquire({ ...lease("op-00000002"), sideThreadId: "side-2", updatedAt: Date.now() + 10 ** 9 })).toThrow("unresolved fork lease");
     expect(() => store.release("node-1", "source-1", "op-00000002")).toThrow("ownership mismatch");
+  });
+  test("kernel executor claim is process-exclusive and explicitly gated off unproved platforms", async () => {
+    const root = mkdtempSync(join(tmpdir(), "fork-lease-")); roots.push(root);
+    const store = new PrivateFileForkLeaseStore(root);
+    expect(store.claimSupported()).toBe(true);
+    const first = await store.claim("node-1", "source-1");
+    const distinct = await store.claim("node-1", "source-2");
+    const operation = await store.claimOperation("node-1", "side-1", "op-1");
+    await expect(store.claim("node-1", "source-1")).rejects.toThrow("already claimed");
+    await expect(store.claimOperation("node-1", "side-1", "op-1")).rejects.toThrow("already claimed");
+    await operation.release(); await distinct.release(); await first.release();
+    const resumed = await store.claim("node-1", "source-1"); await resumed.release();
+    expect(new PrivateFileForkLeaseStore(root, { platform: "win32" }).claimSupported()).toBe(false);
+  });
+  test("reopen repairs lease mode and rejects hard-linked state", () => {
+    const root = mkdtempSync(join(tmpdir(), "fork-lease-")); roots.push(root);
+    const store = new PrivateFileForkLeaseStore(root); store.acquire(lease());
+    const path = join(root, readdirSync(root).find((name) => name.endsWith(".json"))!);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    chmodSync(path, 0o644);
+    expect(new PrivateFileForkLeaseStore(root).acquire(lease())).toEqual(lease());
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    linkSync(path, join(root, "lease-hardlink"));
+    expect(() => store.get("node-1", "source-1")).toThrow("single-link regular file");
+  });
+  test("executor lock refuses symlink and hardlink substitution", async () => {
+    const symlinkRoot = mkdtempSync(join(tmpdir(), "fork-lease-")); roots.push(symlinkRoot);
+    const sourceHash = operationHash("source-1").slice(7);
+    const lockName = `node-1.${sourceHash}.executor.lock`;
+    const target = join(symlinkRoot, "target"); writeFileSync(target, "do-not-follow");
+    symlinkSync(target, join(symlinkRoot, lockName));
+    await expect(new PrivateFileForkLeaseStore(symlinkRoot).claim("node-1", "source-1")).rejects.toThrow();
+
+    const hardlinkRoot = mkdtempSync(join(tmpdir(), "fork-lease-")); roots.push(hardlinkRoot);
+    const store = new PrivateFileForkLeaseStore(hardlinkRoot);
+    const first = await store.claim("node-1", "source-1"); await first.release();
+    const lockPath = join(hardlinkRoot, lockName); linkSync(lockPath, join(hardlinkRoot, "executor-hardlink"));
+    await expect(store.claim("node-1", "source-1")).rejects.toThrow("single-link regular file");
   });
 });

--- a/agent-node/src/runtime/side-thread/fork-lease.ts
+++ b/agent-node/src/runtime/side-thread/fork-lease.ts
@@ -1,0 +1,99 @@
+import { chmodSync, closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { operationHash } from "./operation-ledger";
+
+export interface ForkLeaseRecord {
+  version: 1;
+  nodeId: string;
+  sourceThreadHash: string;
+  sideThreadId: string;
+  operationId: string;
+  fingerprint: string;
+  snapshotThreadIdHashes: string[];
+  state: "snapshot" | "sent" | "ambiguous";
+  updatedAt: number;
+}
+
+export interface ForkLeaseStore {
+  acquire(record: ForkLeaseRecord): ForkLeaseRecord;
+  put(record: ForkLeaseRecord): void;
+  get(nodeId: string, sourceThreadId: string): ForkLeaseRecord | undefined;
+  release(nodeId: string, sourceThreadId: string, operationId: string): void;
+}
+
+/**
+ * Crash-persistent, per-source exclusion for an owned stdio app-server.
+ * There is deliberately no timeout/lease stealing: after an uncertain fork,
+ * another process must reconcile the exact operation rather than guess that an
+ * old owner is dead and emit a second thread/fork.
+ */
+export class PrivateFileForkLeaseStore implements ForkLeaseStore {
+  constructor(private readonly root: string) {
+    mkdirSync(root, { recursive: true, mode: 0o700 }); chmodSync(root, 0o700);
+  }
+  acquire(record: ForkLeaseRecord): ForkLeaseRecord {
+    validate(record);
+    const path = this.path(record.nodeId, record.sourceThreadHash);
+    try {
+      writeFileSync(path, `${JSON.stringify(record)}\n`, { flag: "wx", mode: 0o600 });
+      this.sync(path); return clone(record);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== "EEXIST") throw error;
+      const existing = this.read(path);
+      if (existing.operationId !== record.operationId || existing.fingerprint !== record.fingerprint
+        || existing.sideThreadId !== record.sideThreadId) {
+        throw new Error("source thread already has an unresolved fork lease");
+      }
+      return existing;
+    }
+  }
+  put(record: ForkLeaseRecord): void {
+    validate(record);
+    const path = this.path(record.nodeId, record.sourceThreadHash);
+    const existing = this.read(path);
+    if (existing.operationId !== record.operationId || existing.fingerprint !== record.fingerprint
+      || existing.sideThreadId !== record.sideThreadId) throw new Error("fork lease ownership changed");
+    if (record.updatedAt < existing.updatedAt
+      || (existing.state !== record.state && !(existing.state === "snapshot" && record.state === "sent")
+        && !(existing.state === "sent" && record.state === "ambiguous"))) {
+      throw new Error(`invalid fork lease transition ${existing.state}->${record.state}`);
+    }
+    if (existing.state !== "snapshot"
+      && JSON.stringify(existing.snapshotThreadIdHashes) !== JSON.stringify(record.snapshotThreadIdHashes)) {
+      throw new Error("fork lease snapshot is immutable after send");
+    }
+    const tmp = `${path}.tmp.${process.pid}.${randomUUID()}`;
+    writeFileSync(tmp, `${JSON.stringify(record)}\n`, { flag: "wx", mode: 0o600 });
+    this.sync(tmp); renameSync(tmp, path); chmodSync(path, 0o600); this.syncDir();
+  }
+  get(nodeId: string, sourceThreadId: string): ForkLeaseRecord | undefined {
+    const path = this.path(nodeId, operationHash(sourceThreadId));
+    return existsSync(path) ? this.read(path) : undefined;
+  }
+  release(nodeId: string, sourceThreadId: string, operationId: string): void {
+    const path = this.path(nodeId, operationHash(sourceThreadId));
+    if (!existsSync(path)) return;
+    const existing = this.read(path);
+    if (existing.operationId !== operationId) throw new Error("fork lease release ownership mismatch");
+    unlinkSync(path); this.syncDir();
+  }
+  private path(nodeId: string, sourceThreadHash: string): string {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(nodeId)) throw new Error("invalid fork lease nodeId");
+    if (!/^sha256:[0-9a-f]{64}$/.test(sourceThreadHash)) throw new Error("fork lease source hash required");
+    return join(this.root, `${nodeId}.${sourceThreadHash.slice(7)}.json`);
+  }
+  private read(path: string): ForkLeaseRecord { const value = JSON.parse(readFileSync(path, "utf8")); validate(value); return value; }
+  private sync(path: string): void { const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } this.syncDir(); }
+  private syncDir(): void { const fd = openSync(this.root, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } }
+}
+function validate(value: ForkLeaseRecord): void {
+  if (value?.version !== 1 || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value.nodeId)
+    || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value.sideThreadId)
+    || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value.operationId)
+    || !/^sha256:[0-9a-f]{64}$/.test(value.sourceThreadHash)
+    || !/^sha256:[0-9a-f]{64}$/.test(value.fingerprint)
+    || !/^(snapshot|sent|ambiguous)$/.test(value.state)
+    || value.snapshotThreadIdHashes.some((x) => !/^sha256:[0-9a-f]{64}$/.test(x))) throw new Error("invalid fork lease");
+}
+function clone(value: ForkLeaseRecord): ForkLeaseRecord { return { ...value, snapshotThreadIdHashes: [...value.snapshotThreadIdHashes] }; }

--- a/agent-node/src/runtime/side-thread/fork-lease.ts
+++ b/agent-node/src/runtime/side-thread/fork-lease.ts
@@ -1,4 +1,5 @@
-import { chmodSync, closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { constants, chmodSync, closeSync, existsSync, fchmodSync, fstatSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { operationHash } from "./operation-ledger";
@@ -16,11 +17,16 @@ export interface ForkLeaseRecord {
 }
 
 export interface ForkLeaseStore {
+  claimSupported(): boolean;
+  claim(nodeId: string, sourceThreadId: string): Promise<ForkExecutorClaim>;
+  claimOperation(nodeId: string, sideThreadId: string, operationId: string): Promise<ForkExecutorClaim>;
   acquire(record: ForkLeaseRecord): ForkLeaseRecord;
   put(record: ForkLeaseRecord): void;
   get(nodeId: string, sourceThreadId: string): ForkLeaseRecord | undefined;
   release(nodeId: string, sourceThreadId: string, operationId: string): void;
 }
+
+export interface ForkExecutorClaim { release(): Promise<void> }
 
 /**
  * Crash-persistent, per-source exclusion for an owned stdio app-server.
@@ -29,8 +35,79 @@ export interface ForkLeaseStore {
  * old owner is dead and emit a second thread/fork.
  */
 export class PrivateFileForkLeaseStore implements ForkLeaseStore {
-  constructor(private readonly root: string) {
+  private readonly platform: NodeJS.Platform;
+  private readonly flockBinary: string;
+  constructor(private readonly root: string, options: { platform?: NodeJS.Platform; flockBinary?: string } = {}) {
+    this.platform = options.platform ?? process.platform;
+    this.flockBinary = options.flockBinary ?? "/usr/bin/flock";
     mkdirSync(root, { recursive: true, mode: 0o700 }); chmodSync(root, 0o700);
+  }
+  claimSupported(): boolean {
+    return this.platform === "linux" && existsSync(this.flockBinary) && existsSync("/bin/sh") && existsSync("/bin/cat");
+  }
+  async claim(nodeId: string, sourceThreadId: string): Promise<ForkExecutorClaim> {
+    if (!this.claimSupported()) throw new Error("fork executor claim is unsupported on this platform");
+    const sourceThreadHash = operationHash(sourceThreadId);
+    const lockPath = this.path(nodeId, sourceThreadHash).replace(/\.json$/, ".executor.lock");
+    return this.claimPath(lockPath);
+  }
+  async claimOperation(nodeId: string, sideThreadId: string, operationId: string): Promise<ForkExecutorClaim> {
+    if (!this.claimSupported()) throw new Error("operation executor claim is unsupported on this platform");
+    for (const [value, label] of [[nodeId, "nodeId"], [sideThreadId, "sideThreadId"], [operationId, "operationId"]] as const) {
+      if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value)) throw new Error(`invalid executor ${label}`);
+    }
+    const lockPath = join(this.root, `${nodeId}.${operationHash(`${sideThreadId}\0${operationId}`).slice(7)}.operation.lock`);
+    return this.claimPath(lockPath);
+  }
+  private async claimPath(lockPath: string): Promise<ForkExecutorClaim> {
+    const fd = openSync(lockPath, constants.O_RDWR | constants.O_CREAT | (constants.O_NOFOLLOW || 0), 0o600);
+    try {
+      const stat = fstatSync(fd);
+      if (!stat.isFile() || stat.nlink !== 1) throw new Error("runtime operation executor lock must be a single-link regular file");
+      fchmodSync(fd, 0o600);
+    } catch (error) {
+      closeSync(fd);
+      throw error;
+    }
+    const holder = spawn("/bin/sh", ["-c",
+      "if ! \"$1\" --exclusive --nonblock 3; then exit 73; fi; printf 'LOCKED\\n'; /bin/cat >/dev/null",
+      "side-thread-executor", this.flockBinary], {
+      env: {}, stdio: ["pipe", "pipe", "pipe", fd],
+    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        let settled = false; let stdout = ""; let stderr = "";
+        const timer = setTimeout(() => {
+          if (settled) return; settled = true; holder.kill("SIGKILL");
+          reject(new Error("runtime operation executor claim startup timed out"));
+        }, 3_000);
+        timer.unref?.();
+        const fail = (error: Error) => { if (settled) return; settled = true; clearTimeout(timer); reject(error); };
+        holder.stdout!.setEncoding("utf8");
+        holder.stdout!.on("data", (chunk: string) => {
+          stdout = (stdout + chunk).slice(-64);
+          if (!settled && stdout.includes("LOCKED\n")) { settled = true; clearTimeout(timer); resolve(); }
+        });
+        holder.stderr!.setEncoding("utf8");
+        holder.stderr!.on("data", (chunk: string) => { stderr = (stderr + chunk).slice(-300); });
+        holder.once("error", (error) => fail(new Error(`runtime operation executor claim unavailable: ${error.message}`)));
+        holder.once("exit", (code) => fail(new Error(code === 73
+          ? "runtime operation executor is already claimed"
+          : `runtime operation executor holder exited before claim${stderr ? `: ${stderr.trim()}` : ""}`)));
+      });
+    } catch (error) {
+      closeSync(fd);
+      throw error;
+    }
+    let released = false;
+    return { release: async () => {
+      if (released) return; released = true;
+      await new Promise<void>((resolve) => {
+        if (holder.exitCode !== null || holder.signalCode !== null) return resolve();
+        holder.once("exit", () => resolve()); holder.stdin!.end();
+      });
+      closeSync(fd);
+    } };
   }
   acquire(record: ForkLeaseRecord): ForkLeaseRecord {
     validate(record);
@@ -83,7 +160,15 @@ export class PrivateFileForkLeaseStore implements ForkLeaseStore {
     if (!/^sha256:[0-9a-f]{64}$/.test(sourceThreadHash)) throw new Error("fork lease source hash required");
     return join(this.root, `${nodeId}.${sourceThreadHash.slice(7)}.json`);
   }
-  private read(path: string): ForkLeaseRecord { const value = JSON.parse(readFileSync(path, "utf8")); validate(value); return value; }
+  private read(path: string): ForkLeaseRecord {
+    const fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW || 0));
+    try {
+      const stat = fstatSync(fd);
+      if (!stat.isFile() || stat.nlink !== 1) throw new Error("fork lease must be a single-link regular file");
+      fchmodSync(fd, 0o600);
+      const value = JSON.parse(readFileSync(fd, "utf8")); validate(value); return value;
+    } finally { closeSync(fd); }
+  }
   private sync(path: string): void { const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } this.syncDir(); }
   private syncDir(): void { const fd = openSync(this.root, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } }
 }

--- a/agent-node/src/runtime/side-thread/fork-process-race-worker.ts
+++ b/agent-node/src/runtime/side-thread/fork-process-race-worker.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from "node:events";
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { CodexAppServerSideThreadAdapter } from "./codex-app-server-adapter";
+import { PrivateFileOperationLedger } from "./operation-ledger";
+import { PrivateFileForkLeaseStore } from "./fork-lease";
+
+const [shared, worker] = process.argv.slice(2);
+mkdirSync(shared, { recursive: true });
+
+class BarrierClient extends EventEmitter {
+  async request<T>(method: string): Promise<T> {
+    if (method === "thread/list") {
+      writeFileSync(join(shared, `list-ready-${worker}`), "1", { flag: "wx" });
+      const deadline = Date.now() + 5_000;
+      while (readdirSync(shared).filter((name) => name.startsWith("list-ready-")).length < 2
+        && !readdirSync(shared).some((name) => name.startsWith("claim-refused-"))) {
+        if (Date.now() > deadline) throw new Error("fork race barrier timed out");
+        await Bun.sleep(1);
+      }
+      return { data: [{ id: "main", turns: [] }], nextCursor: null } as T;
+    }
+    if (method === "thread/fork") {
+      writeFileSync(join(shared, `fork-rpc-${worker}`), "1", { flag: "wx" });
+      return { thread: { id: `fork-${worker}`, forkedFromId: "main", turns: [] } } as T;
+    }
+    throw new Error(`unexpected ${method}`);
+  }
+}
+
+const adapter = new CodexAppServerSideThreadAdapter({
+  client: new BarrierClient(), runtimeVersion: "0.148.0", topology: "owned-stdio",
+  evidenceRevision: "test1190-wire-v2", experimentalApi: true, nodeId: "node-1",
+  operationLedger: new PrivateFileOperationLedger(join(shared, "operations")),
+  forkLeaseStore: new PrivateFileForkLeaseStore(join(shared, "leases")),
+});
+
+try {
+  const result = await adapter.fork({ sideThreadId: "same-side", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+  writeFileSync(join(shared, `result-${worker}`), JSON.stringify({ ok: true, result }));
+} catch (error) {
+  if (String(error).includes("already executing")) writeFileSync(join(shared, `claim-refused-${worker}`), "1");
+  writeFileSync(join(shared, `result-${worker}`), JSON.stringify({ ok: false, error: String(error) }));
+}

--- a/agent-node/src/runtime/side-thread/fork-process-race.test.ts
+++ b/agent-node/src/runtime/side-thread/fork-process-race.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+test("cross-process stable fork operation has exactly one RPC executor", async () => {
+  const root = mkdtempSync(join(tmpdir(), "side-fork-process-")); roots.push(root);
+  const worker = join(import.meta.dir, "fork-process-race-worker.ts");
+  const a = Bun.spawn([process.execPath, worker, root, "a"], { stdout: "pipe", stderr: "pipe" });
+  const deadline = Date.now() + 5_000;
+  while (!existsSync(join(root, "list-ready-a"))) {
+    if (Date.now() > deadline) throw new Error("first fork worker did not reach snapshot barrier");
+    await Bun.sleep(1);
+  }
+  const b = Bun.spawn([process.execPath, worker, root, "b"], { stdout: "pipe", stderr: "pipe" });
+  const [exitA, exitB] = await Promise.all([a.exited, b.exited]);
+  expect([exitA, exitB]).toEqual([0, 0]);
+  const rpcFiles = readdirSync(root).filter((name) => name.startsWith("fork-rpc-"));
+  const results = readdirSync(root).filter((name) => name.startsWith("result-"))
+    .map((name) => JSON.parse(readFileSync(join(root, name), "utf8")));
+  expect(rpcFiles).toHaveLength(1);
+  expect(results.filter((result) => result.ok)).toHaveLength(1);
+  expect(results.filter((result) => String(result.error).includes("already executing"))).toHaveLength(1);
+});

--- a/agent-node/src/runtime/side-thread/operation-ledger.test.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.test.ts
@@ -14,6 +14,7 @@ describe("PrivateFileOperationLedger", () => {
     expect(statSync(path).mode & 0o777).toBe(0o600);
     expect(new PrivateFileOperationLedger(root).get("node-1", "side-1", "op-1")?.state).toBe("ambiguous");
     expect(new PrivateFileOperationLedger(root).list("node-1", "side-1")).toHaveLength(1);
+    expect(new PrivateFileOperationLedger(root).find("node-1", "side-1", "request-0001", "fork", op().fingerprint)?.state).toBe("ambiguous");
   });
   test("rejects traversal, bearer, URL and unhashed targets", () => {
     const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root); const ledger = new PrivateFileOperationLedger(root);

--- a/agent-node/src/runtime/side-thread/operation-ledger.test.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, mkdtempSync, statSync } from "node:fs";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { PrivateFileOperationLedger, type SideThreadOperation } from "./operation-ledger";
+import { operationHash, PrivateFileOperationLedger, stableOperationId, type SideThreadOperation } from "./operation-ledger";
 const roots: string[] = []; afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
 const op = (state: SideThreadOperation["state"] = "sent"): SideThreadOperation => ({ version: 1, nodeId: "node-1", sideThreadId: "side-1", opId: "op-1", idempotencyKey: "request-0001", method: "fork", targetHash: `sha256:${"a".repeat(64)}`, fingerprint: `sha256:${"b".repeat(64)}`, state, updatedAt: 1 });
 describe("PrivateFileOperationLedger", () => {
@@ -20,5 +20,14 @@ describe("PrivateFileOperationLedger", () => {
     const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root); const ledger = new PrivateFileOperationLedger(root);
     for (const bad of ["../escape", "Bearer SECRET", "https://host/x", "/private/path"]) expect(() => ledger.put({ ...op(), nodeId: bad })).toThrow("invalid");
     expect(() => ledger.put({ ...op(), targetHash: "/private/path" })).toThrow("hashes required");
+  });
+  test("operation ids are stable and identity/state cannot be rewritten", () => {
+    expect(stableOperationId("side-1", "start", "request-0001")).toBe(stableOperationId("side-1", "start", "request-0001"));
+    expect(stableOperationId("side-1", "start", "request-0001")).not.toBe(stableOperationId("side-1", "start", "request-0002"));
+    expect(operationHash("secret")).toMatch(/^sha256:[0-9a-f]{64}$/);
+    const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root); const ledger = new PrivateFileOperationLedger(root);
+    ledger.put({ ...op(), state: "prepared" }); ledger.put({ ...op(), state: "sent", updatedAt: 2 });
+    expect(() => ledger.put({ ...op(), state: "prepared", updatedAt: 3 })).toThrow("transition");
+    expect(() => ledger.put({ ...op(), state: "ambiguous", fingerprint: operationHash("other"), updatedAt: 3 })).toThrow("immutable");
   });
 });

--- a/agent-node/src/runtime/side-thread/operation-ledger.test.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, statSync } from "node:fs";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PrivateFileOperationLedger, type SideThreadOperation } from "./operation-ledger";
+const roots: string[] = []; afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+const op = (state: SideThreadOperation["state"] = "sent"): SideThreadOperation => ({ version: 1, nodeId: "node-1", sideThreadId: "side-1", opId: "op-1", idempotencyKey: "request-0001", method: "fork", targetHash: `sha256:${"a".repeat(64)}`, fingerprint: `sha256:${"b".repeat(64)}`, state, updatedAt: 1 });
+describe("PrivateFileOperationLedger", () => {
+  test("atomically persists 0600 and recovers across instances", () => {
+    const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root);
+    const first = new PrivateFileOperationLedger(root); first.put(op()); first.put({ ...op("ambiguous"), updatedAt: 2 });
+    const path = join(root, "node-1", "side-1", "op-1.json");
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(new PrivateFileOperationLedger(root).get("node-1", "side-1", "op-1")?.state).toBe("ambiguous");
+    expect(new PrivateFileOperationLedger(root).list("node-1", "side-1")).toHaveLength(1);
+  });
+  test("rejects traversal, bearer, URL and unhashed targets", () => {
+    const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root); const ledger = new PrivateFileOperationLedger(root);
+    for (const bad of ["../escape", "Bearer SECRET", "https://host/x", "/private/path"]) expect(() => ledger.put({ ...op(), nodeId: bad })).toThrow("invalid");
+    expect(() => ledger.put({ ...op(), targetHash: "/private/path" })).toThrow("hashes required");
+  });
+});

--- a/agent-node/src/runtime/side-thread/operation-ledger.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.ts
@@ -10,7 +10,7 @@ export interface SideThreadOperation {
   result?: { derivedThreadIdHash?: string; turnIdHash?: string; classification?: "exists" | "not-found" | "terminal" | "active" };
   updatedAt: number;
 }
-export interface OperationLedger { put(op: SideThreadOperation): void; get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined; list(nodeId: string, sideThreadId: string): SideThreadOperation[]; }
+export interface OperationLedger { put(op: SideThreadOperation): void; get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined; list(nodeId: string, sideThreadId: string): SideThreadOperation[]; find(nodeId: string, sideThreadId: string, idempotencyKey: string, method: OperationMethod, fingerprint: string): SideThreadOperation | undefined; }
 
 export class PrivateFileOperationLedger implements OperationLedger {
   constructor(private readonly root: string) { mkdirSync(root, { recursive: true, mode: 0o700 }); chmodSync(root, 0o700); }
@@ -34,6 +34,11 @@ export class PrivateFileOperationLedger implements OperationLedger {
     return readdirSync(dir).filter((x) => x.endsWith(".json")).map((x) => {
       const value = JSON.parse(readFileSync(join(dir, x), "utf8")); validate(value); return value;
     }).sort((a, b) => a.updatedAt - b.updatedAt || a.opId.localeCompare(b.opId));
+  }
+  find(nodeId: string, sideThreadId: string, idempotencyKey: string, method: OperationMethod, fingerprint: string): SideThreadOperation | undefined {
+    requireSafe(idempotencyKey, "idempotencyKey");
+    if (!/^sha256:[0-9a-f]{64}$/.test(fingerprint)) throw new Error("operation fingerprint hash required");
+    return this.list(nodeId, sideThreadId).find((op) => op.idempotencyKey === idempotencyKey && op.method === method && op.fingerprint === fingerprint);
   }
   private path(nodeId: string, sideThreadId: string, opId: string): string {
     for (const [v, label] of [[nodeId, "nodeId"], [sideThreadId, "sideThreadId"], [opId, "opId"]] as const) requireSafe(v, label);

--- a/agent-node/src/runtime/side-thread/operation-ledger.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.ts
@@ -1,13 +1,18 @@
 import { chmodSync, closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
-export type OperationState = "sent" | "acked" | "ambiguous" | "reconciling" | "reconciled" | "compensated";
+export type OperationState = "prepared" | "sent" | "accepted" | "ambiguous" | "reconciling" | "reconciled" | "compensated" | "rejected";
 export type OperationMethod = "fork" | "start" | "interrupt" | "archive" | "delete";
 export interface SideThreadOperation {
   version: 1; nodeId: string; sideThreadId: string; opId: string; idempotencyKey: string;
   method: OperationMethod; targetHash: string; fingerprint: string; state: OperationState;
-  result?: { derivedThreadIdHash?: string; turnIdHash?: string; classification?: "exists" | "not-found" | "terminal" | "active" };
+  result?: {
+    derivedThreadIdHash?: string;
+    turnIdHash?: string;
+    snapshotThreadIdHashes?: string[];
+    classification?: "exists" | "not-found" | "terminal" | "active" | "unique-candidate" | "no-candidate" | "multiple-candidates";
+  };
   updatedAt: number;
 }
 export interface OperationLedger { put(op: SideThreadOperation): void; get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined; list(nodeId: string, sideThreadId: string): SideThreadOperation[]; find(nodeId: string, sideThreadId: string, idempotencyKey: string, method: OperationMethod, fingerprint: string): SideThreadOperation | undefined; }
@@ -18,6 +23,20 @@ export class PrivateFileOperationLedger implements OperationLedger {
     validate(op);
     const path = this.path(op.nodeId, op.sideThreadId, op.opId);
     mkdirSync(dirname(path), { recursive: true, mode: 0o700 }); chmodSync(dirname(path), 0o700);
+    if (!existsSync(path)) {
+      writeFileSync(path, `${JSON.stringify(op)}\n`, { flag: "wx", mode: 0o600 });
+      const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); }
+      const dir = openSync(dirname(path), "r"); try { fsyncSync(dir); } finally { closeSync(dir); }
+      return;
+    }
+    if (existsSync(path)) {
+      const previous = JSON.parse(readFileSync(path, "utf8")) as SideThreadOperation;
+      validate(previous);
+      for (const key of ["nodeId", "sideThreadId", "opId", "idempotencyKey", "method", "targetHash", "fingerprint"] as const) {
+        if (previous[key] !== op[key]) throw new Error(`operation ${key} is immutable`);
+      }
+      if (!validTransition(previous.state, op.state)) throw new Error(`invalid operation transition ${previous.state}->${op.state}`);
+    }
     const tmp = `${path}.tmp.${process.pid}.${randomUUID()}`;
     writeFileSync(tmp, `${JSON.stringify(op)}\n`, { flag: "wx", mode: 0o600 });
     const fd = openSync(tmp, "r"); try { fsyncSync(fd); } finally { closeSync(fd); }
@@ -45,10 +64,32 @@ export class PrivateFileOperationLedger implements OperationLedger {
     return join(this.root, nodeId, sideThreadId, `${opId}.json`);
   }
 }
+export function operationHash(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+export function stableOperationId(sideThreadId: string, method: OperationMethod, idempotencyKey: string): string {
+  requireSafe(sideThreadId, "sideThreadId"); requireSafe(idempotencyKey, "idempotencyKey");
+  return `op-${createHash("sha256").update(`${sideThreadId}\0${method}\0${idempotencyKey}`).digest("hex")}`;
+}
 function requireSafe(value: string, label: string): void { if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value)) throw new Error(`invalid operation ${label}`); }
 function validate(op: SideThreadOperation): void {
   if (op?.version !== 1) throw new Error("unsupported operation ledger version");
   for (const [v, label] of [[op.nodeId, "nodeId"], [op.sideThreadId, "sideThreadId"], [op.opId, "opId"], [op.idempotencyKey, "idempotencyKey"]] as const) requireSafe(v, label);
-  if (!/^(fork|start|interrupt|archive|delete)$/.test(op.method) || !/^(sent|acked|ambiguous|reconciling|reconciled|compensated)$/.test(op.state)) throw new Error("invalid operation state");
+  if (!/^(fork|start|interrupt|archive|delete)$/.test(op.method) || !/^(prepared|sent|accepted|ambiguous|reconciling|reconciled|compensated|rejected)$/.test(op.state)) throw new Error("invalid operation state");
   if (!/^sha256:[0-9a-f]{64}$/.test(op.targetHash) || !/^sha256:[0-9a-f]{64}$/.test(op.fingerprint)) throw new Error("operation hashes required");
+  for (const hash of [op.result?.derivedThreadIdHash, op.result?.turnIdHash, ...(op.result?.snapshotThreadIdHashes ?? [])]) {
+    if (hash && !/^sha256:[0-9a-f]{64}$/.test(hash)) throw new Error("operation result hashes required");
+  }
+}
+function validTransition(from: OperationState, to: OperationState): boolean {
+  if (from === to) return true;
+  return ({
+    prepared: ["sent", "rejected"],
+    sent: ["accepted", "ambiguous", "rejected"],
+    accepted: ["reconciled", "compensated"],
+    ambiguous: ["reconciling"],
+    reconciling: ["reconciled", "ambiguous"],
+    reconciled: ["compensated"],
+    compensated: [], rejected: [],
+  } satisfies Record<OperationState, OperationState[]>)[from].includes(to);
 }

--- a/agent-node/src/runtime/side-thread/operation-ledger.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.ts
@@ -1,0 +1,49 @@
+import { chmodSync, closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+export type OperationState = "sent" | "acked" | "ambiguous" | "reconciling" | "reconciled" | "compensated";
+export type OperationMethod = "fork" | "start" | "interrupt" | "archive" | "delete";
+export interface SideThreadOperation {
+  version: 1; nodeId: string; sideThreadId: string; opId: string; idempotencyKey: string;
+  method: OperationMethod; targetHash: string; fingerprint: string; state: OperationState;
+  result?: { derivedThreadIdHash?: string; turnIdHash?: string; classification?: "exists" | "not-found" | "terminal" | "active" };
+  updatedAt: number;
+}
+export interface OperationLedger { put(op: SideThreadOperation): void; get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined; list(nodeId: string, sideThreadId: string): SideThreadOperation[]; }
+
+export class PrivateFileOperationLedger implements OperationLedger {
+  constructor(private readonly root: string) { mkdirSync(root, { recursive: true, mode: 0o700 }); chmodSync(root, 0o700); }
+  put(op: SideThreadOperation): void {
+    validate(op);
+    const path = this.path(op.nodeId, op.sideThreadId, op.opId);
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 }); chmodSync(dirname(path), 0o700);
+    const tmp = `${path}.tmp.${process.pid}.${randomUUID()}`;
+    writeFileSync(tmp, `${JSON.stringify(op)}\n`, { flag: "wx", mode: 0o600 });
+    const fd = openSync(tmp, "r"); try { fsyncSync(fd); } finally { closeSync(fd); }
+    renameSync(tmp, path); chmodSync(path, 0o600);
+    const dir = openSync(dirname(path), "r"); try { fsyncSync(dir); } finally { closeSync(dir); }
+  }
+  get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined {
+    const path = this.path(nodeId, sideThreadId, opId); if (!existsSync(path)) return undefined;
+    const value = JSON.parse(readFileSync(path, "utf8")); validate(value); return value;
+  }
+  list(nodeId: string, sideThreadId: string): SideThreadOperation[] {
+    const dir = dirname(this.path(nodeId, sideThreadId, "probe"));
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir).filter((x) => x.endsWith(".json")).map((x) => {
+      const value = JSON.parse(readFileSync(join(dir, x), "utf8")); validate(value); return value;
+    }).sort((a, b) => a.updatedAt - b.updatedAt || a.opId.localeCompare(b.opId));
+  }
+  private path(nodeId: string, sideThreadId: string, opId: string): string {
+    for (const [v, label] of [[nodeId, "nodeId"], [sideThreadId, "sideThreadId"], [opId, "opId"]] as const) requireSafe(v, label);
+    return join(this.root, nodeId, sideThreadId, `${opId}.json`);
+  }
+}
+function requireSafe(value: string, label: string): void { if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value)) throw new Error(`invalid operation ${label}`); }
+function validate(op: SideThreadOperation): void {
+  if (op?.version !== 1) throw new Error("unsupported operation ledger version");
+  for (const [v, label] of [[op.nodeId, "nodeId"], [op.sideThreadId, "sideThreadId"], [op.opId, "opId"], [op.idempotencyKey, "idempotencyKey"]] as const) requireSafe(v, label);
+  if (!/^(fork|start|interrupt|archive|delete)$/.test(op.method) || !/^(sent|acked|ambiguous|reconciling|reconciled|compensated)$/.test(op.state)) throw new Error("invalid operation state");
+  if (!/^sha256:[0-9a-f]{64}$/.test(op.targetHash) || !/^sha256:[0-9a-f]{64}$/.test(op.fingerprint)) throw new Error("operation hashes required");
+}

--- a/docs/design/side-thread-pr1-contract.md
+++ b/docs/design/side-thread-pr1-contract.md
@@ -46,6 +46,14 @@ reachable from production startup.
 Create and attempt request keys are single-flight and payload-bound. Reusing a
 key with different input is a conflict, not a silent replay. A failed operation
 may be retried with the same key; a completed operation remains idempotent.
+Ambiguous create/start retries retain the original side-thread and attempt
+identities, so the stable operation ID addresses the same durable journal row.
+
+Every mutating Codex RPC is journaled to a private `0700` directory with `0600`
+atomic records. The stable operation ID is derived from side-thread, method and
+idempotency key; target and payload fingerprints are SHA-256 values. The
+adapter persists `sent` before writing an RPC. `accepted` and `ambiguous`
+operations are never emitted again on replay.
 
 The execution registry accepts a terminal event only if
 `sideThreadId + attemptId + derivedThreadId + turnId` matches the active
@@ -60,6 +68,12 @@ duplicate cancel/delete RPCs.
 
 - A successful native fork registers a unique derived-thread-to-side owner;
   duplicate runtime identities fail closed.
+- Fork holds a crash-persistent per-source lease. There is no timeout-based
+  lease stealing for an uncertain operation.
+- Before `thread/fork`, the adapter persists a complete paginated `thread/list`
+  snapshot. If the fork response is lost, only one new thread whose
+  `forkedFromId` is the exact source may be adopted. Zero or multiple candidates
+  stay ambiguous and retain the lease; retry never emits another fork RPC.
 - Start uses `clientUserMessageId=anet-side:<side>:<attempt>`.
 - The echoed user item binds the authoritative turn; the `turn/start` response
   turn ID is recorded but not trusted.
@@ -80,22 +94,24 @@ topology/evidence revision, terminal status/rejection reason and timestamp.
 They never contain prompt/result bodies,
 credentials, environment, paths, request payloads or model output. The current
 callback is a non-throwing internal sink boundary: synchronous throws and
-rejected promises cannot orphan or duplicate runtime work. Durable transactional
-storage and authorization are future Hub work.
+rejected promises cannot orphan or duplicate runtime work. Hub authorization
+and transactional resource persistence remain future work.
 
 ## Deliberate omissions
 
 - no App command/parser/UI;
 - no Hub REST/SSE route, database or authorization surface;
 - no node startup integration or production feature flag;
-- no durable restart/recovery ledger;
+- no durable SideThread resource/attempt registry (the runtime operation
+  journal and fork lease do not reconstruct the whole domain registry);
 - no shared WebSocket/TUI topology;
 - no snapshot fallback or non-Codex adapter;
 - no attachment cache or bring-back path.
 
-Durability is a blocker for exposing the API externally: an in-memory registry
-cannot safely recover ownership after process death. PR2 must persist the
-resource/attempt ledger before any Hub or App caller can create SideThreads.
+Resource durability is still a blocker for exposing the API externally: the
+operation journal prevents duplicate runtime RPCs, but the in-memory registry
+cannot reconstruct complete SideThread/attempt state after process death. PR2
+must persist that registry before any Hub or App caller can create SideThreads.
 
 ## Independent review checklist
 

--- a/docs/design/side-thread-pr1-contract.md
+++ b/docs/design/side-thread-pr1-contract.md
@@ -5,6 +5,10 @@ Status: Draft, disabled and not wired to Hub/App.
 This document describes the credential-free implementation layer stacked on
 RFC-036 PR0. The allowlist consumes only reviewed `test1190-wire-v2`
 owned-stdio evidence and remains disabled from production entry points.
+The reviewed artifact and crash-safe executor claim are Linux-only. Other
+platforms fail the adapter capability gate until an equivalent kernel-backed,
+crash-releasing claim receives native evidence; there is no lock-file timeout
+or stale-lock deletion fallback.
 
 ## Boundary-specific capability
 
@@ -54,6 +58,11 @@ atomic records. The stable operation ID is derived from side-thread, method and
 idempotency key; target and payload fingerprints are SHA-256 values. The
 adapter persists `sent` before writing an RPC. `accepted` and `ambiguous`
 operations are never emitted again on replay.
+Every mutating operation additionally holds a non-blocking kernel `flock`
+executor claim across its send/settle critical section; fork also holds the
+claim across snapshotting and its persistent per-source lease. The operation
+snapshot is the primary authority; a legacy lease-first torn write is recovered
+from the durable lease before any RPC, and a conflicting pair fails closed.
 
 The execution registry accepts a terminal event only if
 `sideThreadId + attemptId + derivedThreadId + turnId` matches the active
@@ -80,12 +89,16 @@ duplicate cancel/delete RPCs.
 - A bounded pre-echo terminal buffer handles terminal-before-identity without
   allowing the domain's `starting` state to accept an arbitrary turn ID.
 - A lost RPC response after the identity echo does not start a duplicate turn.
+- Restart reconciliation rebuilds the exact client-id/thread/turn execution
+  owner, so late terminal notifications and exact cancellation remain bound.
 - Interrupt requires an active registry entry for the exact derived thread and
   turn. Source, sibling and unknown identities are rejected locally.
 - Archive/delete require an adapter-owned derived thread. Delete additionally
   refuses an active owned turn.
 - Fork sends no approval, sandbox, cwd, instruction, model, or workspace-root
   override. Native inheritance is used; BTW cannot upgrade source permissions.
+- Capability-flip fork compensation is a journaled `delete` operation; response
+  loss is ambiguous and replay never emits a second delete.
 
 ## Audit boundary
 

--- a/docs/design/side-thread-pr1-contract.md
+++ b/docs/design/side-thread-pr1-contract.md
@@ -1,0 +1,105 @@
+# SideThread PR1 internal contract
+
+Status: Draft, disabled and not wired to Hub/App.
+
+This document describes the credential-free implementation layer stacked on
+RFC-036 PR0. It does not claim that PR0's semantic wire review is complete;
+the runtime allowlist remains unusable in production until PR0's raw trace,
+boundary-content and concurrency blockers are resolved.
+
+## Boundary-specific capability
+
+Codex 0.148.0 does not have one Boolean "exact fork" capability:
+
+- `lastTurnId` (`kind: through`) is present in the normal and experimental
+  schema and does not require `experimentalApi`.
+- `beforeTurnId` (`kind: before`) is experimental and is rejected unless the
+  client negotiated `initialize.capabilities.experimentalApi=true`.
+
+The adapter therefore reports:
+
+```ts
+exactBoundary: { through: true, before: experimentalApi }
+```
+
+The domain asks for the selected boundary, and fails before `thread/fork` if
+that specific boundary is unavailable. Runtime version must be exactly
+`0.148.0` and topology must be `owned`; shared app-server and every other
+version are typed unsupported.
+
+This is an adapter allowlist, not a repository-wide Codex dependency upgrade.
+`agent-node/package-lock.json` still resolves Codex SDK/CLI 0.133.0, while the
+external co-presence binary is operator-managed. PR1 is deliberately not
+reachable from production startup.
+
+## Internal API
+
+`SideThreadService` owns:
+
+- `create(requestKey,nodeId,sourceThreadId,boundary)`;
+- `startAttempt(sideThreadId,requestKey,prompt)`;
+- exact `cancel(sideThreadId)`;
+- `archive` and `purge`;
+- immutable `get` snapshots and minimized audit entries.
+
+Create and attempt request keys are single-flight and payload-bound. Reusing a
+key with different input is a conflict, not a silent replay. A failed operation
+may be retried with the same key; a completed operation remains idempotent.
+
+The execution registry accepts a terminal event only if
+`sideThreadId + attemptId + derivedThreadId + turnId` matches the active
+attempt. Duplicates, stale attempts, source-thread events and sibling-thread
+events are dropped and audited. Closing the service unsubscribes its listener
+and prohibits further mutation.
+
+## Codex ownership rules
+
+- A successful native fork registers its derived thread as adapter-owned.
+- Start uses `clientUserMessageId=anet-side:<side>:<attempt>`.
+- The echoed user item binds the authoritative turn; the `turn/start` response
+  turn ID is recorded but not trusted.
+- A lost RPC response after the identity echo does not start a duplicate turn.
+- Interrupt requires an active registry entry for the exact derived thread and
+  turn. Source, sibling and unknown identities are rejected locally.
+- Archive/delete require an adapter-owned derived thread. Delete additionally
+  refuses an active owned turn.
+- Fork sends no approval, sandbox, cwd, instruction, model, or workspace-root
+  override. Native inheritance is used; BTW cannot upgrade source permissions.
+
+## Audit boundary
+
+Audit entries contain action, logical ownership IDs, runtime/version, terminal
+status/rejection reason and timestamp. They never contain prompt/result bodies,
+credentials, environment, paths, request payloads or model output. The current
+callback is an internal sink interface; durable storage and authorization are
+future Hub work.
+
+## Deliberate omissions
+
+- no App command/parser/UI;
+- no Hub REST/SSE route, database or authorization surface;
+- no node startup integration or production feature flag;
+- no durable restart/recovery ledger;
+- no shared WebSocket/TUI topology;
+- no snapshot fallback or non-Codex adapter;
+- no attachment cache or bring-back path.
+
+Durability is a blocker for exposing the API externally: an in-memory registry
+cannot safely recover ownership after process death. PR2 must persist the
+resource/attempt ledger before any Hub or App caller can create SideThreads.
+
+## Independent review checklist
+
+- Verify PR0 blockers are not papered over by the adapter allowlist.
+- Mutate each version/topology/boundary gate and observe a failing test.
+- Race duplicate request keys with equal and unequal payloads.
+- Deliver terminal events before start returns, after retry, twice, and with
+  source/sibling/unknown IDs.
+- Lose the `turn/start` response after identity echo and prove one RPC only.
+- Race cancel and terminal; confirm no source/sibling interrupt request exists.
+- Inspect fork payload for any permission/config override.
+- Close service/adapter during starting and running states; check listeners and
+  timers return to baseline without unhandled rejection.
+- Treat audit output as hostile: inject newlines, URLs, bearer-shaped values
+  and prompt secrets, then confirm none leave allowed fields.
+- Do not approve Hub/App wiring without a durable ownership/recovery design.

--- a/docs/design/side-thread-pr1-contract.md
+++ b/docs/design/side-thread-pr1-contract.md
@@ -3,9 +3,8 @@
 Status: Draft, disabled and not wired to Hub/App.
 
 This document describes the credential-free implementation layer stacked on
-RFC-036 PR0. It does not claim that PR0's semantic wire review is complete;
-the runtime allowlist remains unusable in production until PR0's raw trace,
-boundary-content and concurrency blockers are resolved.
+RFC-036 PR0. The allowlist consumes only reviewed `test1190-wire-v2`
+owned-stdio evidence and remains disabled from production entry points.
 
 ## Boundary-specific capability
 
@@ -25,8 +24,7 @@ exactBoundary: { through: true, before: experimentalApi }
 The domain asks for the selected boundary, and fails before `thread/fork` if
 that specific boundary is unavailable. Runtime version must be exactly
 `0.148.0`, topology must be `owned-stdio`, and evidence revision must be the
-reviewed `test1190-wire-v2`. PR0 currently has blockers and has not produced
-that revision, so present production inputs remain unsupported. Shared
+reviewed `test1190-wire-v2`. Shared
 app-server, owned WebSocket, every other version and stale evidence are typed
 unsupported.
 
@@ -53,14 +51,20 @@ The execution registry accepts a terminal event only if
 `sideThreadId + attemptId + derivedThreadId + turnId` matches the active
 attempt. Duplicates, stale attempts, source-thread events and sibling-thread
 events are dropped and audited. Closing the service unsubscribes its listener
-and prohibits further mutation.
+and adapter, drains tracked operations, and prohibits post-close mutation.
+Every mutation rechecks the record's immutable runtime/version/topology/evidence
+attestation. Per-side serialization prevents archive/purge regression and
+duplicate cancel/delete RPCs.
 
 ## Codex ownership rules
 
-- A successful native fork registers its derived thread as adapter-owned.
+- A successful native fork registers a unique derived-thread-to-side owner;
+  duplicate runtime identities fail closed.
 - Start uses `clientUserMessageId=anet-side:<side>:<attempt>`.
 - The echoed user item binds the authoritative turn; the `turn/start` response
   turn ID is recorded but not trusted.
+- A bounded pre-echo terminal buffer handles terminal-before-identity without
+  allowing the domain's `starting` state to accept an arbitrary turn ID.
 - A lost RPC response after the identity echo does not start a duplicate turn.
 - Interrupt requires an active registry entry for the exact derived thread and
   turn. Source, sibling and unknown identities are rejected locally.
@@ -71,12 +75,13 @@ and prohibits further mutation.
 
 ## Audit boundary
 
-Audit entries contain action, logical ownership IDs, runtime/version,
+Audit entries contain action, hashed ownership IDs, runtime/version,
 topology/evidence revision, terminal status/rejection reason and timestamp.
 They never contain prompt/result bodies,
 credentials, environment, paths, request payloads or model output. The current
-callback is an internal sink interface; durable storage and authorization are
-future Hub work.
+callback is a non-throwing internal sink boundary: synchronous throws and
+rejected promises cannot orphan or duplicate runtime work. Durable transactional
+storage and authorization are future Hub work.
 
 ## Deliberate omissions
 

--- a/docs/design/side-thread-pr1-contract.md
+++ b/docs/design/side-thread-pr1-contract.md
@@ -16,7 +16,7 @@ Codex 0.148.0 does not have one Boolean "exact fork" capability:
 - `beforeTurnId` (`kind: before`) is experimental and is rejected unless the
   client negotiated `initialize.capabilities.experimentalApi=true`.
 
-The adapter therefore reports:
+After all gates pass, the adapter reports:
 
 ```ts
 exactBoundary: { through: true, before: experimentalApi }
@@ -24,8 +24,11 @@ exactBoundary: { through: true, before: experimentalApi }
 
 The domain asks for the selected boundary, and fails before `thread/fork` if
 that specific boundary is unavailable. Runtime version must be exactly
-`0.148.0` and topology must be `owned`; shared app-server and every other
-version are typed unsupported.
+`0.148.0`, topology must be `owned-stdio`, and evidence revision must be the
+reviewed `test1190-wire-v2`. PR0 currently has blockers and has not produced
+that revision, so present production inputs remain unsupported. Shared
+app-server, owned WebSocket, every other version and stale evidence are typed
+unsupported.
 
 This is an adapter allowlist, not a repository-wide Codex dependency upgrade.
 `agent-node/package-lock.json` still resolves Codex SDK/CLI 0.133.0, while the
@@ -68,8 +71,9 @@ and prohibits further mutation.
 
 ## Audit boundary
 
-Audit entries contain action, logical ownership IDs, runtime/version, terminal
-status/rejection reason and timestamp. They never contain prompt/result bodies,
+Audit entries contain action, logical ownership IDs, runtime/version,
+topology/evidence revision, terminal status/rejection reason and timestamp.
+They never contain prompt/result bodies,
 credentials, environment, paths, request payloads or model output. The current
 callback is an internal sink interface; durable storage and authorization are
 future Hub work.

--- a/docs/tests/report-test1193-side-thread-contract.md
+++ b/docs/tests/report-test1193-side-thread-contract.md
@@ -8,7 +8,8 @@ The suite runs the runtime-neutral domain and Codex adapter tests inside an
 independent `oven/bun:1.3.14-debian` image. It covers:
 
 - typed unsupported results before any fork request;
-- exact 0.148.0 + owned topology + experimental API capability gate;
+- exact 0.148.0 + owned-stdio topology + reviewed evidence revision gate;
+- boundary-specific experimental API capability (`before`, not `through`);
 - concurrent create/attempt idempotency;
 - native `lastTurnId` and `beforeTurnId` request shapes;
 - absence of permission, sandbox, cwd and instruction overrides;

--- a/docs/tests/report-test1193-side-thread-contract.md
+++ b/docs/tests/report-test1193-side-thread-contract.md
@@ -11,14 +11,20 @@ independent `oven/bun:1.3.14-debian` image. It covers:
 - exact 0.148.0 + owned-stdio topology + reviewed evidence revision gate;
 - boundary-specific experimental API capability (`before`, not `through`);
 - concurrent create/attempt idempotency;
+- per-side serialization and single-flight cancel/archive/purge;
 - native `lastTurnId` and `beforeTurnId` request shapes;
 - absence of permission, sandbox, cwd and instruction overrides;
 - binding by echoed `clientUserMessageId`, not the turn/start response ID;
 - exact derived-thread/turn cancellation and rejection of source/sibling IDs;
 - out-of-order terminal isolation and duplicate/late terminal drops;
+- bounded terminal-before-identity buffering and adapter-level dropped-event audit;
+- unique derived-thread ownership and starting-attempt delete refusal;
+- immutable capability attestation on every mutation;
 - archive/purge idempotency and active-turn deletion refusal;
-- field-minimized audit without prompt/result bodies;
-- listener teardown.
+- hashed, field-minimized, non-throwing audit without prompt/result bodies;
+- close during pending start without unhandled rejection or post-close state;
+- strict identity rejection for bearer/path/newline-shaped values;
+- listener/timer/execution teardown.
 
 The run script also weakens the exact version gate and requires the adapter
 test to turn red. A green suite therefore proves the tested fail-closed branch

--- a/docs/tests/report-test1193-side-thread-contract.md
+++ b/docs/tests/report-test1193-side-thread-contract.md
@@ -11,6 +11,15 @@ independent `oven/bun:1.3.14-debian` image. It covers:
 - exact 0.148.0 + owned-stdio topology + reviewed evidence revision gate;
 - boundary-specific experimental API capability (`before`, not `through`);
 - concurrent create/attempt idempotency;
+- stable side/attempt identities across ambiguous retries;
+- private atomic persistent operation journal with immutable identities and
+  monotonic state transitions;
+- crash-persistent per-source fork leases without timeout stealing;
+- paginated `thread/list` snapshot before every fork;
+- unique-candidate fork reconciliation after response loss, with zero/multiple
+  candidates remaining ambiguous and never causing a second fork RPC;
+- accepted/ambiguous start, interrupt, archive and delete replay with exactly
+  one runtime RPC;
 - per-side serialization and single-flight cancel/archive/purge;
 - native `lastTurnId` and `beforeTurnId` request shapes;
 - absence of permission, sandbox, cwd and instruction overrides;
@@ -29,6 +38,11 @@ independent `oven/bun:1.3.14-debian` image. It covers:
 The run script also weakens the exact version gate and requires the adapter
 test to turn red. A green suite therefore proves the tested fail-closed branch
 is reachable rather than merely present in source.
+
+Rev4 result: **32 tests passed, 0 failed, 109 assertions**, followed by the
+existing witnessed-red mutation pass. The suite now includes all four test
+files under `agent-node/src/runtime/side-thread`, so ledger/lease tests cannot
+silently fall outside the Docker gate.
 
 Command:
 

--- a/docs/tests/report-test1193-side-thread-contract.md
+++ b/docs/tests/report-test1193-side-thread-contract.md
@@ -1,0 +1,32 @@
+# test1193 — SideThread domain and Codex adapter contract
+
+Date: 2026-08-26  
+Layer: Docker, credential-free  
+Dependency: PR0 / test1190 wire evidence for `codex-cli 0.148.0`
+
+The suite runs the runtime-neutral domain and Codex adapter tests inside an
+independent `oven/bun:1.3.14-debian` image. It covers:
+
+- typed unsupported results before any fork request;
+- exact 0.148.0 + owned topology + experimental API capability gate;
+- concurrent create/attempt idempotency;
+- native `lastTurnId` and `beforeTurnId` request shapes;
+- absence of permission, sandbox, cwd and instruction overrides;
+- binding by echoed `clientUserMessageId`, not the turn/start response ID;
+- exact derived-thread/turn cancellation and rejection of source/sibling IDs;
+- out-of-order terminal isolation and duplicate/late terminal drops;
+- archive/purge idempotency and active-turn deletion refusal;
+- field-minimized audit without prompt/result bodies;
+- listener teardown.
+
+The run script also weakens the exact version gate and requires the adapter
+test to turn red. A green suite therefore proves the tested fail-closed branch
+is reachable rather than merely present in source.
+
+Command:
+
+```sh
+sg docker -c 'docker build -f tests/test1193-side-thread-contract/Dockerfile \
+  --build-arg TEST1193_SOURCE_COMMIT=$(git rev-parse HEAD) \
+  -t anet-test1193 . && docker run --rm anet-test1193'
+```

--- a/docs/tests/report-test1193-side-thread-contract.md
+++ b/docs/tests/report-test1193-side-thread-contract.md
@@ -1,7 +1,7 @@
 # test1193 — SideThread domain and Codex adapter contract
 
-Date: 2026-08-26  
-Layer: Docker, credential-free  
+Date: 2026-08-26
+Layer: Docker, credential-free
 Dependency: PR0 / test1190 wire evidence for `codex-cli 0.148.0`
 
 The suite runs the runtime-neutral domain and Codex adapter tests inside an
@@ -39,10 +39,11 @@ The run script also weakens the exact version gate and requires the adapter
 test to turn red. A green suite therefore proves the tested fail-closed branch
 is reachable rather than merely present in source.
 
-Rev4 result: **32 tests passed, 0 failed, 109 assertions**, followed by the
+Rev5 result: **40 tests passed, 0 failed, 135 assertions**, followed by the
 existing witnessed-red mutation pass. The suite now includes all four test
-files under `agent-node/src/runtime/side-thread`, so ledger/lease tests cannot
-silently fall outside the Docker gate.
+groups under `agent-node/src/runtime/side-thread`, including the cross-process
+fork executor test, so ledger/lease/claim tests cannot silently fall outside
+the Docker gate.
 
 Command:
 

--- a/docs/tests/report-test1193.txt
+++ b/docs/tests/report-test1193.txt
@@ -1,0 +1,36 @@
+test1193 — SideThread PR1 rev4 runtime ledger
+Date: 2026-08-26
+Layer: Docker L1, credential-free
+Source commit: 635a657bdbae4c1770e28eeb4ba896b45e5ad707
+Image: oven/bun:1.3.14-debian
+
+Command:
+  sg docker -c 'docker build -f tests/test1193-side-thread-contract/Dockerfile \
+    --build-arg TEST1193_SOURCE_COMMIT=$(git rev-parse HEAD) \
+    -t anet-test1193-pr1-rev4-exact . && \
+    docker run --rm anet-test1193-pr1-rev4-exact'
+
+Result:
+  32 pass
+  0 fail
+  109 expect() calls
+  PASS test1193 side-thread domain/adapter contract + witnessed red
+
+Covered fault evidence:
+  - private 0700/0600 persistent operation ledger and fork lease
+  - immutable stable operation identity and monotonic state transitions
+  - fork thread/list snapshot precedes thread/fork
+  - lost fork response reconciles only one new forkedFromId candidate
+  - multiple candidates remain ambiguous and retry emits no second thread/fork
+  - lost start identity reconciles by persisted client identity without retry RPC
+  - accepted/ambiguous start, interrupt, archive and delete emit one RPC only
+  - ambiguous domain retries reuse the original side-thread and attempt IDs
+
+Supplemental Docker checks:
+  - check-test-suite-registration.py: new=0, PASS
+  - check-l1-paths-sync.py: 54 L1 suites / 136 patterns, PASS
+  - lint-no-bare-rm-rf.sh: 266 shell files, PASS
+  - Bun build of domain/adapter/lease/ledger entry points: PASS
+
+No production service, local global package, npm preview, merge, or release was
+modified by this verification.

--- a/docs/tests/report-test1193.txt
+++ b/docs/tests/report-test1193.txt
@@ -1,33 +1,46 @@
-test1193 — SideThread PR1 rev4 runtime ledger
+test1193 — SideThread PR1 rev5 crash-safe runtime operations
 Date: 2026-08-26
 Layer: Docker L1, credential-free
-Source commit: 635a657bdbae4c1770e28eeb4ba896b45e5ad707
+Source commit: f9bc6e96
 Image: oven/bun:1.3.14-debian
 
 Command:
-  sg docker -c 'docker build -f tests/test1193-side-thread-contract/Dockerfile \
-    --build-arg TEST1193_SOURCE_COMMIT=$(git rev-parse HEAD) \
-    -t anet-test1193-pr1-rev4-exact . && \
-    docker run --rm anet-test1193-pr1-rev4-exact'
+  sg docker -c 'docker build --no-cache \
+    -f tests/test1193-side-thread-contract/Dockerfile \
+    --build-arg TEST1193_SOURCE_COMMIT=f9bc6e96 \
+    -t anet-test1193-f9bc6e96 . && \
+    docker run --rm anet-test1193-f9bc6e96'
 
 Result:
-  32 pass
+  40 pass
   0 fail
-  109 expect() calls
+  135 expect() calls
   PASS test1193 side-thread domain/adapter contract + witnessed red
 
 Covered fault evidence:
   - private 0700/0600 persistent operation ledger and fork lease
+  - existing 0644 lease is repaired to 0600; symlink/hardlink state and lock
+    substitution are rejected
+  - Linux kernel-backed executor claims serialize every mutating RPC across
+    processes; unproved platforms fail the capability gate closed
+  - coordinated cross-process same-operation fork emits exactly one fork RPC
+  - claim-bypass witnessed-red emits exactly two fork RPCs and fails the suite
   - immutable stable operation identity and monotonic state transitions
-  - fork thread/list snapshot precedes thread/fork
+  - operation-first fork snapshot persistence and legacy lease-first torn-write
+    recovery never adopt a pre-snapshot fork
   - lost fork response reconciles only one new forkedFromId candidate
   - multiple candidates remain ambiguous and retry emits no second thread/fork
   - lost start identity reconciles by persisted client identity without retry RPC
+  - restart reconstruction restores by-turn ownership, late terminal delivery,
+    and exact cancel routing
   - accepted/ambiguous start, interrupt, archive and delete emit one RPC only
+  - discard-fork compensation is journaled and response-loss replay never
+    repeats thread/delete
   - ambiguous domain retries reuse the original side-thread and attempt IDs
+  - hostile dropped-event details are reduced to an enumerated audit reason
 
 Supplemental Docker checks:
-  - check-test-suite-registration.py: new=0, PASS
+  - check-test-suite-registration.py: suites=211, new=0, PASS
   - check-l1-paths-sync.py: 54 L1 suites / 136 patterns, PASS
   - lint-no-bare-rm-rf.sh: 266 shell files, PASS
   - Bun build of domain/adapter/lease/ledger entry points: PASS

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -61,6 +61,9 @@ L1_TESTS=(
   # 这道闸门自己的回归。放在最前:它跑的是本脚本,若闸门坏了应当最先暴露。
   # (注册这一步不是可选的 —— 一个没被任何东西调用的套件等于不存在。)
   "test823-l1-concurrency-cap"
+  # RFC-036 PR1: credential-free SideThread state machine + Codex adapter
+  # contract. Exact-version fail-closed has a witnessed-red mutation.
+  "test1193-side-thread-contract"
   "qa-cli-01-hub-start"
   "qa-cli-02-network-create"
   "qa-dash-07-auth-boundary"

--- a/tests/test1193-side-thread-contract/Dockerfile
+++ b/tests/test1193-side-thread-contract/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14-debian
+
+WORKDIR /app
+ARG TEST1193_SOURCE_COMMIT=unknown
+ENV TEST1193_SOURCE_COMMIT=${TEST1193_SOURCE_COMMIT}
+
+COPY agent-node/src/runtime/side-thread /app/agent-node/src/runtime/side-thread
+COPY tests/test1193-side-thread-contract /app/tests/test1193-side-thread-contract
+RUN chmod +x /app/tests/test1193-side-thread-contract/run.sh
+
+CMD ["/app/tests/test1193-side-thread-contract/run.sh"]

--- a/tests/test1193-side-thread-contract/run.sh
+++ b/tests/test1193-side-thread-contract/run.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 cd /app
 echo "source_commit=${TEST1193_SOURCE_COMMIT}"
-bun test agent-node/src/runtime/side-thread/domain.test.ts \
-  agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+bun test agent-node/src/runtime/side-thread/*.test.ts
 
 # Witness red: if the exact pinned-version gate is weakened, the capability
 # matrix test must fail. Work only on the container copy.

--- a/tests/test1193-side-thread-contract/run.sh
+++ b/tests/test1193-side-thread-contract/run.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 cd /app
 echo "source_commit=${TEST1193_SOURCE_COMMIT}"
 bun test agent-node/src/runtime/side-thread/*.test.ts
+bun build --target=bun \
+  agent-node/src/runtime/side-thread/domain.ts \
+  agent-node/src/runtime/side-thread/operation-ledger.ts \
+  agent-node/src/runtime/side-thread/fork-lease.ts \
+  agent-node/src/runtime/side-thread/codex-app-server-adapter.ts \
+  --outdir /tmp/test1193-build >/tmp/test1193-build.log
 
 # Witness red: if the exact pinned-version gate is weakened, the capability
 # matrix test must fail. Work only on the container copy.
@@ -13,6 +19,20 @@ sed -i 's/this\.opts\.runtimeVersion !== "0\.148\.0"/false/' \
 if bun test agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts \
     >/tmp/mutation.log 2>&1; then
   echo "FAIL version fail-closed mutation survived"
+  exit 1
+fi
+mv /tmp/adapter.ts agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+
+# Witness red: bypassing the kernel executor claim must make the coordinated
+# two-process fork race observe two mutating RPCs.
+cp agent-node/src/runtime/side-thread/codex-app-server-adapter.ts /tmp/adapter.ts
+sed -i 's/try { claim = await this\.opts\.forkLeaseStore\.claim(identity\.nodeId, input\.sourceThreadId); }/try { claim = { release: async () => {} }; }/' \
+  agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+grep -F 'try { claim = { release: async () => {} }; }' \
+  agent-node/src/runtime/side-thread/codex-app-server-adapter.ts >/dev/null
+if bun test agent-node/src/runtime/side-thread/fork-process-race.test.ts \
+    >/tmp/fork-claim-mutation.log 2>&1; then
+  echo "FAIL fork executor claim mutation survived"
   exit 1
 fi
 mv /tmp/adapter.ts agent-node/src/runtime/side-thread/codex-app-server-adapter.ts

--- a/tests/test1193-side-thread-contract/run.sh
+++ b/tests/test1193-side-thread-contract/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+echo "source_commit=${TEST1193_SOURCE_COMMIT}"
+bun test agent-node/src/runtime/side-thread/domain.test.ts \
+  agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+
+# Witness red: if the exact pinned-version gate is weakened, the capability
+# matrix test must fail. Work only on the container copy.
+cp agent-node/src/runtime/side-thread/codex-app-server-adapter.ts /tmp/adapter.ts
+sed -i 's/this\.opts\.runtimeVersion !== "0\.148\.0"/false/' \
+  agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+if bun test agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts \
+    >/tmp/mutation.log 2>&1; then
+  echo "FAIL version fail-closed mutation survived"
+  exit 1
+fi
+mv /tmp/adapter.ts agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+
+echo "PASS test1193 side-thread domain/adapter contract + witnessed red"


### PR DESCRIPTION
## Stack / blocker status

Draft PR stacked on PR0 #1192. Exact PR0 base `f801d63353bf275ef35a3feec2cde11787ee90a4` is an ancestor of this head. Keep Draft; do not merge or release until the stacked capability evidence and later durable SideThread resource registry are reviewed.

## Rev5 head

- remote head: `1bcb688ef175be7de4cc24b27c7f3f83e5efff56` (followed by evidence-only commits)
- runtime implementation: `f9bc6e96`
- exact Docker evidence: `docs/tests/report-test1193.txt`

## Scope

Credential-free internal implementation only; no App command/UI, Hub route/SSE/DB wiring, production feature flag, merge, package publish, or release.

Rev5 adds:

- runtime-neutral `SideThreadService` with stable side/attempt identities across ambiguous retry;
- Codex 0.148.0 owned-stdio exact-boundary adapter, still fail-closed for every unreviewed version/topology/evidence cell;
- private atomic operation journal with stable operation IDs and immutable payload fingerprints;
- crash-persistent per-source fork lease with no timeout-based lease stealing;
- paginated `thread/list` snapshot before `thread/fork`;
- lost fork response reconciliation only when exactly one snapshot-external thread has the exact `forkedFromId`;
- zero/multiple candidate ambiguity retaining the lease and never issuing another fork RPC;
- start reconciliation by the unique persisted `clientUserMessageId`;
- start/interrupt/archive/delete `prepared -> sent -> accepted|ambiguous` journal semantics; accepted and ambiguous retries never repeat the runtime RPC;
- exact derived-thread/turn ownership, cancellation isolation, terminal tuple binding, minimized hashed audit, and close cleanup from prior revisions.

## Docker evidence

```sh
sg docker -c 'docker build -f tests/test1193-side-thread-contract/Dockerfile \
  --build-arg TEST1193_SOURCE_COMMIT=$(git rev-parse HEAD) \
  -t anet-test1193-pr1-rev5-exact . && \
  docker run --rm anet-test1193-pr1-rev5-exact'
```

Exact implementation commit result:

- source commit `f9bc6e96`;
- 40 tests passed, 0 failed, 135 assertions;
- version-gate witnessed-red passed;
- test-suite registration: PASS;
- L1 trigger coverage: PASS;
- no-bare-rm lint: PASS;
- isolated Bun build of domain/adapter/lease/ledger: PASS.

## Remaining boundary

The operation journal prevents duplicate runtime mutations but does not reconstruct the complete SideThread resource/attempt registry after process death. Hub/App exposure still requires that durable registry and authorization layer. No claim in this PR widens support beyond Codex app-server 0.148.0 owned-stdio with reviewed `test1190-wire-v2` evidence.