### PR TITLE
feat(hub): add durable SideThread API contract

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -29,6 +29,9 @@ on:
       - 'tests/test751-codex-copresence-windows/**'
       - 'tests/test1183-sync-pinned-dryrun/**'
       - 'tests/test1193-side-thread-contract/**'
+      - 'tests/test1195-side-thread-hub-contract/**'
+      - 'tests/test1195-side-thread-hub-security/**'
+      - 'tests/test1195-side-thread-hub-race/**'
       # A test directory belongs here exactly when CI executes it — otherwise
       # editing the test cannot re-run the gate that runs it. The four below are
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -28,6 +28,7 @@ on:
       - 'tests/test746-setup-bun-pin/**'
       - 'tests/test751-codex-copresence-windows/**'
       - 'tests/test1183-sync-pinned-dryrun/**'
+      - 'tests/test1193-side-thread-contract/**'
       # A test directory belongs here exactly when CI executes it — otherwise
       # editing the test cannot re-run the gate that runs it. The four below are
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -7,10 +7,12 @@ class Client extends EventEmitter {
   calls: Array<{ method: string; params: any }> = [];
   forkN = 0; turnN = 0;
   loseTurnStartResponse = false;
+  holdTurnStart = false;
   async request<T>(method: string, params: any): Promise<T> {
     this.calls.push({ method, params });
     if (method === "thread/fork") return { thread: { id: `fork-${++this.forkN}` } } as T;
     if (method === "turn/start") {
+      if (this.holdTurnStart) return await new Promise<T>(() => {});
       const turnId = `turn-${++this.turnN}`;
       if (this.loseTurnStartResponse) {
         return await new Promise<T>((_resolve, reject) => queueMicrotask(() => {
@@ -115,5 +117,33 @@ describe("CodexAppServerSideThreadAdapter", () => {
     client.emit("turn/completed", { threadId: a.derivedThreadId, turn: { id: ta.turnId, status: "interrupted" } });
     client.emit("turn/completed", { threadId: b.derivedThreadId, turn: { id: tb.turnId, status: "completed" } });
     expect(got).toEqual(["bb", "aa"]);
+  });
+
+  test("duplicate derived identity and delete during starting fail closed", async () => {
+    const { client, adapter } = make();
+    const first = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    client.forkN--;
+    await expect(adapter.fork({ sideThreadId: "b", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } }))
+      .rejects.toThrow("reused a derived thread");
+    client.holdTurnStart = true;
+    void adapter.start({ sideThreadId: "a", attemptId: "pending", derivedThreadId: first.derivedThreadId, prompt: "q" }).catch(() => {});
+    await Promise.resolve();
+    await expect(adapter.delete({ derivedThreadId: first.derivedThreadId })).rejects.toThrow("active owned turn");
+    adapter.close();
+  });
+
+  test("terminal before identity echo is buffered and unowned events are reported", async () => {
+    const { client, adapter } = make();
+    const fork = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const dropped: string[] = []; const terminal: any[] = [];
+    adapter.subscribeDropped((reason) => dropped.push(reason)); adapter.subscribe((event) => terminal.push(event));
+    const start = adapter.start({ sideThreadId: "a", attemptId: "attempt", derivedThreadId: fork.derivedThreadId, prompt: "q" });
+    client.emit("turn/completed", { threadId: fork.derivedThreadId, turn: { id: "turn-1", status: "completed" } });
+    const started = await start;
+    await Bun.sleep(5);
+    expect(started.turnId).toBe("turn-1");
+    expect(terminal).toHaveLength(1);
+    client.emit("turn/completed", { threadId: "source", turn: { id: "other", status: "completed" } });
+    expect(dropped).toContain("unowned-terminal");
   });
 });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { CodexAppServerSideThreadAdapter } from "./codex-app-server-adapter";
+import { SideThreadConflictError } from "./domain";
+
+class Client extends EventEmitter {
+  calls: Array<{ method: string; params: any }> = [];
+  forkN = 0; turnN = 0;
+  loseTurnStartResponse = false;
+  async request<T>(method: string, params: any): Promise<T> {
+    this.calls.push({ method, params });
+    if (method === "thread/fork") return { thread: { id: `fork-${++this.forkN}` } } as T;
+    if (method === "turn/start") {
+      const turnId = `turn-${++this.turnN}`;
+      if (this.loseTurnStartResponse) {
+        return await new Promise<T>((_resolve, reject) => queueMicrotask(() => {
+          this.emit("item/started", {
+            threadId: params.threadId, turnId,
+            item: { type: "userMessage", clientId: params.clientUserMessageId },
+          });
+          queueMicrotask(() => reject(new Error("response lost")));
+        }));
+      }
+      queueMicrotask(() => this.emit("item/started", {
+          threadId: params.threadId, turnId,
+          item: { type: "userMessage", clientId: params.clientUserMessageId },
+        }));
+      return { turn: { id: `response-${turnId}` } } as T;
+    }
+    return {} as T;
+  }
+}
+
+const make = (overrides: Partial<ConstructorParameters<typeof CodexAppServerSideThreadAdapter>[0]> = {}) => {
+  const client = new Client();
+  const adapter = new CodexAppServerSideThreadAdapter({
+    client, runtimeVersion: "0.148.0", topology: "owned", experimentalApi: true, ...overrides,
+  });
+  return { client, adapter };
+};
+
+describe("CodexAppServerSideThreadAdapter", () => {
+  test("capability matrix fails closed", () => {
+    expect(make().adapter.capability().supported).toBe(true);
+    expect(make({ runtimeVersion: "0.149.0" }).adapter.capability()).toMatchObject({ supported: false, reason: "version" });
+    expect(make({ topology: "shared" }).adapter.capability()).toMatchObject({ supported: false, reason: "topology" });
+    expect(make({ experimentalApi: false }).adapter.capability()).toMatchObject({
+      supported: true, exactBoundary: { through: true, before: false },
+    });
+  });
+
+  test("fork sends one exact boundary and no permission override", async () => {
+    const { client, adapter } = make();
+    await adapter.fork({ sideThreadId: "s1", sourceThreadId: "main", boundary: { kind: "through", turnId: "done-1" } });
+    await adapter.fork({ sideThreadId: "s2", sourceThreadId: "main", boundary: { kind: "before", turnId: "active-2" } });
+    const [a, b] = client.calls.map((x) => x.params);
+    expect(a).toEqual({ threadId: "main", ephemeral: false, lastTurnId: "done-1" });
+    expect(b).toEqual({ threadId: "main", ephemeral: false, beforeTurnId: "active-2" });
+    expect(JSON.stringify(client.calls)).not.toMatch(/approval|sandbox|cwd|instruction/i);
+  });
+
+  test("adapter itself fails before RPC for unsupported boundary", async () => {
+    const { client, adapter } = make({ experimentalApi: false });
+    await expect(adapter.fork({ sideThreadId: "s", sourceThreadId: "main", boundary: { kind: "before", turnId: "active" } }))
+      .rejects.toMatchObject({ code: "SIDE_THREAD_UNSUPPORTED", reason: "experimental-api" });
+    expect(client.calls).toHaveLength(0);
+    await expect(adapter.fork({ sideThreadId: "s", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } }))
+      .resolves.toEqual({ derivedThreadId: "fork-1" });
+  });
+
+  test("binds execution by echoed client id, not response turn id", async () => {
+    const { client, adapter } = make();
+    const { derivedThreadId } = await adapter.fork({ sideThreadId: "side", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const started = await adapter.start({ sideThreadId: "side", attemptId: "attempt", derivedThreadId, prompt: "question" });
+    expect(started.turnId).toBe("turn-1");
+    const terminals: any[] = [];
+    adapter.subscribe((e) => terminals.push(e));
+    client.emit("item/completed", { threadId: derivedThreadId, turnId: "turn-1", item: { type: "agentMessage", text: "answer" } });
+    client.emit("turn/completed", { threadId: derivedThreadId, turn: { id: "response-turn-1", status: "completed" } });
+    expect(terminals).toHaveLength(0);
+    client.emit("turn/completed", { threadId: derivedThreadId, turn: { id: "turn-1", status: "completed" } });
+    expect(terminals).toEqual([expect.objectContaining({ sideThreadId: "side", attemptId: "attempt", threadId: derivedThreadId, turnId: "turn-1", text: "answer" })]);
+  });
+
+  test("does not duplicate when response is lost after identity echo", async () => {
+    const { client, adapter } = make();
+    const { derivedThreadId } = await adapter.fork({ sideThreadId: "side", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    client.loseTurnStartResponse = true;
+    await expect(adapter.start({ sideThreadId: "side", attemptId: "attempt", derivedThreadId, prompt: "q" }))
+      .resolves.toEqual({ turnId: "turn-1" });
+    expect(client.calls.filter((x) => x.method === "turn/start")).toHaveLength(1);
+  });
+
+  test("exact cancel refuses source, sibling, and unknown turns", async () => {
+    const { client, adapter } = make();
+    const a = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const b = await adapter.fork({ sideThreadId: "b", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const turn = await adapter.start({ sideThreadId: "a", attemptId: "attempt-a", derivedThreadId: a.derivedThreadId, prompt: "q" });
+    await expect(adapter.cancel({ derivedThreadId: "main", turnId: turn.turnId })).rejects.toBeInstanceOf(SideThreadConflictError);
+    await expect(adapter.cancel({ derivedThreadId: b.derivedThreadId, turnId: turn.turnId })).rejects.toBeInstanceOf(SideThreadConflictError);
+    await adapter.cancel({ derivedThreadId: a.derivedThreadId, turnId: turn.turnId });
+    expect(client.calls.at(-1)).toEqual({ method: "turn/interrupt", params: { threadId: a.derivedThreadId, turnId: turn.turnId } });
+  });
+
+  test("out-of-order terminals remain isolated by thread and turn", async () => {
+    const { client, adapter } = make();
+    const a = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const b = await adapter.fork({ sideThreadId: "b", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const ta = await adapter.start({ sideThreadId: "a", attemptId: "aa", derivedThreadId: a.derivedThreadId, prompt: "a" });
+    const tb = await adapter.start({ sideThreadId: "b", attemptId: "bb", derivedThreadId: b.derivedThreadId, prompt: "b" });
+    const got: string[] = []; adapter.subscribe((e) => got.push(e.attemptId));
+    client.emit("turn/completed", { threadId: b.derivedThreadId, turn: { id: tb.turnId, status: "completed" } });
+    client.emit("turn/completed", { threadId: a.derivedThreadId, turn: { id: ta.turnId, status: "interrupted" } });
+    client.emit("turn/completed", { threadId: b.derivedThreadId, turn: { id: tb.turnId, status: "completed" } });
+    expect(got).toEqual(["bb", "aa"]);
+  });
+});

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -51,6 +51,7 @@ describe("CodexAppServerSideThreadAdapter", () => {
     expect(make({ experimentalApi: false }).adapter.capability()).toMatchObject({
       supported: true, exactBoundary: { through: true, before: false },
     });
+    expect(make({ experimentalApi: "false" as any }).adapter.capability()).toMatchObject({ exactBoundary: { before: false } });
   });
 
   test("fork sends one exact boundary and no permission override", async () => {
@@ -145,5 +146,17 @@ describe("CodexAppServerSideThreadAdapter", () => {
     expect(terminal).toHaveLength(1);
     client.emit("turn/completed", { threadId: "source", turn: { id: "other", status: "completed" } });
     expect(dropped).toContain("unowned-terminal");
+  });
+
+  test("identity timeout is ambiguous and close settles a pending start", async () => {
+    const { client, adapter } = make({ identityTimeoutMs: 5 });
+    const fork = await adapter.fork({ sideThreadId: "a", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    client.holdTurnStart = true;
+    await expect(adapter.start({ sideThreadId: "a", attemptId: "amb", derivedThreadId: fork.derivedThreadId, prompt: "q" }))
+      .rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toThrow("active owned turn");
+    const pending = adapter.start({ sideThreadId: "a", attemptId: "closing", derivedThreadId: fork.derivedThreadId, prompt: "q" });
+    adapter.close();
+    await expect(pending).rejects.toThrow("closed");
   });
 });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -34,7 +34,8 @@ class Client extends EventEmitter {
 const make = (overrides: Partial<ConstructorParameters<typeof CodexAppServerSideThreadAdapter>[0]> = {}) => {
   const client = new Client();
   const adapter = new CodexAppServerSideThreadAdapter({
-    client, runtimeVersion: "0.148.0", topology: "owned", experimentalApi: true, ...overrides,
+    client, runtimeVersion: "0.148.0", topology: "owned-stdio",
+    evidenceRevision: "test1190-wire-v2", experimentalApi: true, ...overrides,
   });
   return { client, adapter };
 };
@@ -43,7 +44,8 @@ describe("CodexAppServerSideThreadAdapter", () => {
   test("capability matrix fails closed", () => {
     expect(make().adapter.capability().supported).toBe(true);
     expect(make({ runtimeVersion: "0.149.0" }).adapter.capability()).toMatchObject({ supported: false, reason: "version" });
-    expect(make({ topology: "shared" }).adapter.capability()).toMatchObject({ supported: false, reason: "topology" });
+    expect(make({ topology: "shared-websocket" }).adapter.capability()).toMatchObject({ supported: false, reason: "topology" });
+    expect(make({ evidenceRevision: "blocked-v1" }).adapter.capability()).toMatchObject({ supported: false, reason: "exact-boundary" });
     expect(make({ experimentalApi: false }).adapter.capability()).toMatchObject({
       supported: true, exactBoundary: { through: true, before: false },
     });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
@@ -1,21 +1,49 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { CodexAppServerSideThreadAdapter } from "./codex-app-server-adapter";
 import { SideThreadConflictError } from "./domain";
+import { PrivateFileOperationLedger } from "./operation-ledger";
+import { PrivateFileForkLeaseStore } from "./fork-lease";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
 
 class Client extends EventEmitter {
   calls: Array<{ method: string; params: any }> = [];
   forkN = 0; turnN = 0;
   loseTurnStartResponse = false;
+  loseForkResponse = false;
+  forkResponseCreates = 1;
   holdTurnStart = false;
+  loseMethods = new Set<string>();
+  threads = new Map<string, any>([["main", { id: "main", turns: [{ id: "done", items: [] }] }]]);
   async request<T>(method: string, params: any): Promise<T> {
     this.calls.push({ method, params });
-    if (method === "thread/fork") return { thread: { id: `fork-${++this.forkN}` } } as T;
+    if (method === "thread/list") return { data: [...this.threads.values()], nextCursor: null } as T;
+    if (method === "thread/read") {
+      const thread = this.threads.get(params.threadId);
+      if (!thread) throw Object.assign(new Error("not found"), { code: -32001 });
+      return { thread } as T;
+    }
+    if (method === "thread/fork") {
+      let last: any;
+      for (let n = 0; n < this.forkResponseCreates; n++) {
+        const id = `fork-${++this.forkN}`;
+        last = { id, forkedFromId: params.threadId, turns: [{ id: params.lastTurnId ?? "done", items: [] }] };
+        this.threads.set(id, last);
+      }
+      if (this.loseForkResponse) throw new Error("fork response lost");
+      return { thread: last } as T;
+    }
     if (method === "turn/start") {
       if (this.holdTurnStart) return await new Promise<T>(() => {});
       const turnId = `turn-${++this.turnN}`;
       if (this.loseTurnStartResponse) {
         return await new Promise<T>((_resolve, reject) => queueMicrotask(() => {
+          this.threads.get(params.threadId)?.turns.push({ id: turnId, items: [{ type: "userMessage", clientId: params.clientUserMessageId }] });
           this.emit("item/started", {
             threadId: params.threadId, turnId,
             item: { type: "userMessage", clientId: params.clientUserMessageId },
@@ -23,21 +51,27 @@ class Client extends EventEmitter {
           queueMicrotask(() => reject(new Error("response lost")));
         }));
       }
+      this.threads.get(params.threadId)?.turns.push({ id: turnId, items: [{ type: "userMessage", clientId: params.clientUserMessageId }] });
       queueMicrotask(() => this.emit("item/started", {
           threadId: params.threadId, turnId,
           item: { type: "userMessage", clientId: params.clientUserMessageId },
         }));
       return { turn: { id: `response-${turnId}` } } as T;
     }
+    if (method === "thread/delete") this.threads.delete(params.threadId);
+    if (this.loseMethods.has(method)) throw new Error(`${method} response lost`);
     return {} as T;
   }
 }
 
 const make = (overrides: Partial<ConstructorParameters<typeof CodexAppServerSideThreadAdapter>[0]> = {}) => {
   const client = new Client();
+  const root = mkdtempSync(join(tmpdir(), "side-adapter-")); roots.push(root);
   const adapter = new CodexAppServerSideThreadAdapter({
     client, runtimeVersion: "0.148.0", topology: "owned-stdio",
-    evidenceRevision: "test1190-wire-v2", experimentalApi: true, ...overrides,
+    evidenceRevision: "test1190-wire-v2", experimentalApi: true, nodeId: "node-1",
+    operationLedger: new PrivateFileOperationLedger(join(root, "operations")),
+    forkLeaseStore: new PrivateFileForkLeaseStore(join(root, "fork-leases")), ...overrides,
   });
   return { client, adapter };
 };
@@ -58,7 +92,7 @@ describe("CodexAppServerSideThreadAdapter", () => {
     const { client, adapter } = make();
     await adapter.fork({ sideThreadId: "s1", sourceThreadId: "main", boundary: { kind: "through", turnId: "done-1" } });
     await adapter.fork({ sideThreadId: "s2", sourceThreadId: "main", boundary: { kind: "before", turnId: "active-2" } });
-    const [a, b] = client.calls.map((x) => x.params);
+    const [a, b] = client.calls.filter((x) => x.method === "thread/fork").map((x) => x.params);
     expect(a).toEqual({ threadId: "main", ephemeral: false, lastTurnId: "done-1" });
     expect(b).toEqual({ threadId: "main", ephemeral: false, beforeTurnId: "active-2" });
     expect(JSON.stringify(client.calls)).not.toMatch(/approval|sandbox|cwd|instruction/i);
@@ -157,6 +191,57 @@ describe("CodexAppServerSideThreadAdapter", () => {
     await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toThrow("active owned turn");
     const pending = adapter.start({ sideThreadId: "a", attemptId: "closing", derivedThreadId: fork.derivedThreadId, prompt: "q" });
     adapter.close();
-    await expect(pending).rejects.toThrow("closed");
+    await expect(pending).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+  });
+
+  test("snapshots thread/list before fork and uniquely reconciles a lost response without another RPC", async () => {
+    const { client, adapter } = make(); client.loseForkResponse = true;
+    const fork = await adapter.fork({ sideThreadId: "lost", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    expect(fork.derivedThreadId).toBe("fork-1");
+    expect(client.calls.map((x) => x.method).slice(0, 3)).toEqual(["thread/list", "thread/fork", "thread/list"]);
+    expect(client.calls.filter((x) => x.method === "thread/fork")).toHaveLength(1);
+    const replay = await adapter.fork({ sideThreadId: "lost", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    expect(replay).toEqual(fork);
+    expect(client.calls.filter((x) => x.method === "thread/fork")).toHaveLength(1);
+  });
+
+  test("multiple post-snapshot fork candidates stay ambiguous and retries never fork again", async () => {
+    const { client, adapter } = make(); client.loseForkResponse = true; client.forkResponseCreates = 2;
+    const input = { sideThreadId: "multi", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } as const };
+    await expect(adapter.fork(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.fork(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((x) => x.method === "thread/fork")).toHaveLength(1);
+  });
+
+  test("an ambiguous start reconciles the unique persisted client identity without another turn/start", async () => {
+    const { client, adapter } = make({ identityTimeoutMs: 5 });
+    const fork = await adapter.fork({ sideThreadId: "start-lost", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    client.holdTurnStart = true;
+    const input = { sideThreadId: "start-lost", attemptId: "attempt-lost", derivedThreadId: fork.derivedThreadId, prompt: "q" };
+    await expect(adapter.start(input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    client.threads.get(fork.derivedThreadId).turns.push({ id: "turn-recovered", items: [{ type: "userMessage", clientId: "anet-side:start-lost:attempt-lost" }] });
+    await expect(adapter.start(input)).resolves.toEqual({ turnId: "turn-recovered" });
+    expect(client.calls.filter((x) => x.method === "turn/start")).toHaveLength(1);
+  });
+
+  test("accepted and ambiguous start/interrupt/archive/delete operations never repeat their RPC", async () => {
+    const { client, adapter } = make({ identityTimeoutMs: 5 });
+    const fork = await adapter.fork({ sideThreadId: "ops", sourceThreadId: "main", boundary: { kind: "through", turnId: "done" } });
+    const accepted = { sideThreadId: "ops", attemptId: "accepted", derivedThreadId: fork.derivedThreadId, prompt: "q" };
+    const first = await adapter.start(accepted); await adapter.start(accepted);
+    expect(client.calls.filter((x) => x.method === "turn/start")).toHaveLength(1);
+    client.loseMethods.add("turn/interrupt");
+    await expect(adapter.cancel({ derivedThreadId: fork.derivedThreadId, turnId: first.turnId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.cancel({ derivedThreadId: fork.derivedThreadId, turnId: first.turnId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((x) => x.method === "turn/interrupt")).toHaveLength(1);
+    client.loseMethods.add("thread/archive");
+    await expect(adapter.archive({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.archive({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((x) => x.method === "thread/archive")).toHaveLength(1);
+    client.emit("turn/completed", { threadId: fork.derivedThreadId, turn: { id: first.turnId, status: "completed" } });
+    client.loseMethods.add("thread/delete");
+    await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(adapter.delete({ derivedThreadId: fork.derivedThreadId })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(client.calls.filter((x) => x.method === "thread/delete")).toHaveLength(1);
   });
 });

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -1,6 +1,7 @@
 import type { EventEmitter } from "node:events";
 import {
   SideThreadConflictError,
+  SideThreadAmbiguousError,
   SideThreadUnsupportedError,
   type ExactBoundary,
   type SideThreadCapability,
@@ -44,8 +45,12 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   private readonly byTurn = new Map<string, Execution>();
   private readonly earlyTerminals = new Map<string, unknown>();
   private closed = false;
+  private readonly closedSignal: Promise<never>;
+  private rejectClosed!: (error: Error) => void;
 
   constructor(private readonly opts: CodexSideThreadAdapterOptions) {
+    this.closedSignal = new Promise<never>((_resolve, reject) => { this.rejectClosed = reject; });
+    void this.closedSignal.catch(() => {});
     opts.client.on("item/started", this.onItem);
     opts.client.on("item/completed", this.onItem);
     opts.client.on("item/agentMessage/delta", this.onDelta);
@@ -60,7 +65,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       supported: true, runtime: "codex-app-server", runtimeVersion: this.opts.runtimeVersion,
       topology: this.opts.topology, evidenceRevision: this.opts.evidenceRevision,
       mode: "native-exact-fork",
-      exactBoundary: { through: true, before: this.opts.experimentalApi },
+      exactBoundary: { through: true, before: this.opts.experimentalApi === true },
     };
   }
 
@@ -82,7 +87,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         ? { lastTurnId: input.boundary.turnId }
         : { beforeTurnId: input.boundary.turnId }),
     };
-    const response = await this.opts.client.request<{ thread?: { id?: string } }>("thread/fork", params);
+    const response = await this.rpc<{ thread?: { id?: string } }>("thread/fork", params);
     this.assertOpen();
     const derivedThreadId = response?.thread?.id;
     if (!derivedThreadId || derivedThreadId === input.sourceThreadId) {
@@ -107,15 +112,14 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       threadId: input.derivedThreadId, clientUserMessageId,
       text: "", resolveIdentity, rejectIdentity,
       identityTimer: setTimeout(() => {
-        this.dropExecution(execution);
-        rejectIdentity(new SideThreadConflictError("Codex did not echo the attempt identity"));
+        rejectIdentity(new SideThreadAmbiguousError("Codex accepted turn/start but did not echo identity; reconciliation required"));
       }, this.opts.identityTimeoutMs ?? 10_000),
     };
     this.byClientId.set(clientUserMessageId, execution);
     try {
       let response: { turn?: { id?: string }; turnId?: string } | undefined;
       try {
-        const request = this.opts.client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
+        const request = this.rpc<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
         threadId: input.derivedThreadId,
         clientUserMessageId,
         input: [{ type: "text", text: input.prompt }],
@@ -143,7 +147,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       }
       return { turnId };
     } catch (error) {
-      this.dropExecution(execution);
+      if (!(error instanceof SideThreadAmbiguousError)) this.dropExecution(execution);
       throw error;
     }
   }
@@ -153,13 +157,13 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     this.assertOwnedThread(input.derivedThreadId);
     const execution = this.byTurn.get(turnKey(input.derivedThreadId, input.turnId));
     if (!execution) throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
-    await this.opts.client.request("turn/interrupt", { threadId: input.derivedThreadId, turnId: input.turnId });
+    await this.rpc("turn/interrupt", { threadId: input.derivedThreadId, turnId: input.turnId });
   }
 
   async archive(input: { derivedThreadId: string }): Promise<void> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
-    await this.opts.client.request("thread/archive", { threadId: input.derivedThreadId });
+    await this.rpc("thread/archive", { threadId: input.derivedThreadId });
   }
 
   async delete(input: { derivedThreadId: string }): Promise<void> {
@@ -168,8 +172,13 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     if ([...this.byTurn.values(), ...this.byClientId.values()].some((x) => x.threadId === input.derivedThreadId)) {
       throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
     }
-    await this.opts.client.request("thread/delete", { threadId: input.derivedThreadId });
+    await this.rpc("thread/delete", { threadId: input.derivedThreadId });
     this.derivedThreads.delete(input.derivedThreadId);
+  }
+  async discardFork(input: { sideThreadId: string; derivedThreadId: string }): Promise<void> {
+    if (this.derivedThreads.get(input.derivedThreadId) !== input.sideThreadId) return;
+    try { await this.rpc("thread/delete", { threadId: input.derivedThreadId }); }
+    finally { this.derivedThreads.delete(input.derivedThreadId); }
   }
 
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void {
@@ -184,6 +193,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   close(): void {
     if (this.closed) return;
     this.closed = true;
+    this.rejectClosed(new SideThreadConflictError("Codex side-thread adapter closed"));
     this.opts.client.off("item/started", this.onItem);
     this.opts.client.off("item/completed", this.onItem);
     this.opts.client.off("item/agentMessage/delta", this.onDelta);
@@ -269,6 +279,10 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     }
   }
   private assertOpen(): void { if (this.closed) throw new SideThreadConflictError("Codex side-thread adapter closed"); }
+  private rpc<T = unknown>(method: string, params?: unknown): Promise<T> {
+    this.assertOpen();
+    return Promise.race([this.opts.client.request<T>(method, params), this.closedSignal]);
+  }
   private assertOwnedThread(threadId: string, sideThreadId?: string): void {
     this.assertSupported();
     const owner = this.derivedThreads.get(threadId);

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -6,8 +6,11 @@ import {
   type ExactBoundary,
   type SideThreadCapability,
   type SideThreadRuntimeAdapter,
+  type SideThreadRuntimeOperation,
   type SideThreadTerminalEvent,
 } from "./domain";
+import { operationHash, stableOperationId, type OperationLedger, type OperationMethod, type SideThreadOperation } from "./operation-ledger";
+import type { ForkLeaseStore } from "./fork-lease";
 
 export interface SideThreadCodexClient extends EventEmitter {
   request<T = unknown>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
@@ -19,7 +22,11 @@ export interface CodexSideThreadAdapterOptions {
   topology: "owned-stdio" | "owned-websocket" | "shared-websocket";
   evidenceRevision: string;
   experimentalApi: boolean;
+  nodeId: string;
+  operationLedger: OperationLedger;
+  forkLeaseStore: ForkLeaseStore;
   identityTimeoutMs?: number;
+  now?: () => number;
 }
 
 interface Execution {
@@ -71,7 +78,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     };
   }
 
-  async fork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary }): Promise<{ derivedThreadId: string }> {
+  async fork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary; operation?: SideThreadRuntimeOperation }): Promise<{ derivedThreadId: string }> {
     this.assertOpen();
     this.assertSupported();
     if (!this.capability().exactBoundary?.[input.boundary.kind]) {
@@ -79,6 +86,26 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         input.boundary.kind === "before" ? "experimental-api" : "exact-boundary",
         `Codex boundary '${input.boundary.kind}' is unsupported`,
       );
+    }
+    const identity = input.operation ?? this.defaultOperation(input.sideThreadId, "fork", `fork-${input.sideThreadId}`);
+    const operation = this.operation(identity, input.sideThreadId, "fork", input.sourceThreadId,
+      JSON.stringify([input.sourceThreadId, input.boundary.kind, input.boundary.turnId]));
+    const existing = this.existing(operation);
+    if (existing && existing.state !== "prepared") return this.reconcileFork({ ...input, operation: identity }, existing);
+    if (!existing) this.put(operation);
+    const sourceThreadHash = operationHash(input.sourceThreadId);
+    let lease = this.opts.forkLeaseStore.acquire({
+      version: 1, nodeId: identity.nodeId, sourceThreadHash,
+      sideThreadId: input.sideThreadId, operationId: identity.operationId,
+      fingerprint: operation.fingerprint, snapshotThreadIdHashes: operation.result?.snapshotThreadIdHashes ?? [],
+      state: "snapshot", updatedAt: this.now(),
+    });
+    if (lease.state !== "snapshot") return this.reconcileFork({ ...input, operation: identity }, this.mustOperation(operation));
+    if (lease.snapshotThreadIdHashes.length === 0) {
+      const snapshot = await this.listThreads();
+      lease = { ...lease, snapshotThreadIdHashes: snapshot.map((thread) => operationHash(thread.id)), updatedAt: this.now() };
+      this.opts.forkLeaseStore.put(lease);
+      this.put({ ...operation, result: { snapshotThreadIdHashes: lease.snapshotThreadIdHashes }, updatedAt: this.now() });
     }
     const params: Record<string, unknown> = {
       threadId: input.sourceThreadId,
@@ -89,7 +116,16 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         ? { lastTurnId: input.boundary.turnId }
         : { beforeTurnId: input.boundary.turnId }),
     };
-    const response = await this.rpc<{ thread?: { id?: string } }>("thread/fork", params);
+    const sent = { ...this.mustOperation(operation), state: "sent" as const, updatedAt: this.now() };
+    this.put(sent);
+    lease = { ...lease, state: "sent", updatedAt: this.now() }; this.opts.forkLeaseStore.put(lease);
+    let response: { thread?: { id?: string } };
+    try { response = await this.rpc<{ thread?: { id?: string } }>("thread/fork", params); }
+    catch (error) {
+      const ambiguous = { ...sent, state: "ambiguous" as const, updatedAt: this.now() };
+      this.put(ambiguous); this.opts.forkLeaseStore.put({ ...lease, state: "ambiguous", updatedAt: this.now() });
+      return this.reconcileFork({ ...input, operation: identity }, ambiguous, error);
+    }
     this.assertOpen();
     const derivedThreadId = response?.thread?.id;
     if (!derivedThreadId || derivedThreadId === input.sourceThreadId) {
@@ -97,18 +133,26 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     }
     if (this.derivedThreads.has(derivedThreadId)) throw new SideThreadConflictError("Codex reused a derived thread identity");
     this.derivedThreads.set(derivedThreadId, input.sideThreadId);
+    this.put({ ...sent, state: "accepted", result: { ...sent.result, derivedThreadIdHash: operationHash(derivedThreadId) }, updatedAt: this.now() });
+    this.opts.forkLeaseStore.release(identity.nodeId, input.sourceThreadId, identity.operationId);
     return { derivedThreadId };
   }
 
-  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string }): Promise<{ turnId: string }> {
+  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; operation?: SideThreadRuntimeOperation }): Promise<{ turnId: string }> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId, input.sideThreadId);
     const clientUserMessageId = `anet-side:${input.sideThreadId}:${input.attemptId}`;
-    if (this.byClientId.has(clientUserMessageId)) throw new SideThreadConflictError("duplicate Codex attempt identity");
+    const identity = input.operation ?? this.defaultOperation(input.sideThreadId, "start", `start-${input.attemptId}`);
+    const operation = this.operation(identity, input.sideThreadId, "start", input.derivedThreadId,
+      JSON.stringify([input.sideThreadId, input.attemptId, input.derivedThreadId, operationHash(input.prompt)]));
+    const prior = this.existing(operation);
+    if (prior && prior.state !== "prepared") return this.reconcileStart({ ...input, operation: identity }, clientUserMessageId, prior);
+    if (!prior) this.put(operation);
+    if (this.byClientId.has(clientUserMessageId)) return this.reconcileStart({ ...input, operation: identity }, clientUserMessageId, this.mustOperation(operation));
     let resolveIdentity!: (turnId: string) => void;
     let rejectIdentity!: (error: Error) => void;
-    const identity = new Promise<string>((resolve, reject) => { resolveIdentity = resolve; rejectIdentity = reject; });
-    void identity.catch(() => {});
+    const identityEcho = new Promise<string>((resolve, reject) => { resolveIdentity = resolve; rejectIdentity = reject; });
+    void identityEcho.catch(() => {});
     const execution: Execution = {
       sideThreadId: input.sideThreadId, attemptId: input.attemptId,
       threadId: input.derivedThreadId, clientUserMessageId,
@@ -121,6 +165,8 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       }, this.opts.identityTimeoutMs ?? 10_000),
     };
     this.byClientId.set(clientUserMessageId, execution);
+    const sent = { ...this.mustOperation(operation), state: "sent" as const, updatedAt: this.now() };
+    this.put(sent);
     try {
       let response: { turn?: { id?: string }; turnId?: string } | undefined;
       try {
@@ -129,7 +175,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         clientUserMessageId,
         input: [{ type: "text", text: input.prompt }],
         });
-        const abortOnIdentityFailure = identity.then(
+        const abortOnIdentityFailure = identityEcho.then(
           () => new Promise<never>(() => {}),
           (error) => Promise.reject(error),
         );
@@ -144,41 +190,52 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       if (!execution.responseTurnId && !execution.turnId) throw new SideThreadConflictError("Codex returned an invalid turn identity");
       // Response identity alone is not authoritative: Codex automatic goal
       // continuation can replace it. Wait for the echoed client id.
-      const turnId = await identity;
+      const turnId = await identityEcho;
       execution.readyForTerminal = true;
       if (execution.pendingTerminal) {
         const pending = execution.pendingTerminal;
         execution.pendingTerminal = undefined;
         setTimeout(() => this.onCompleted(pending), 0);
       }
+      this.put({ ...sent, state: "accepted", result: { turnIdHash: operationHash(turnId) }, updatedAt: this.now() });
       return { turnId };
     } catch (error) {
-      if (!(error instanceof SideThreadAmbiguousError)) this.dropExecution(execution);
-      throw error;
+      const current = this.mustOperation(operation);
+      if (current.state === "sent") this.put({ ...current, state: "ambiguous", updatedAt: this.now() });
+      if (!(error instanceof SideThreadAmbiguousError) && !execution.turnId) execution.identityAmbiguous = true;
+      throw error instanceof SideThreadAmbiguousError ? error
+        : new SideThreadAmbiguousError("Codex start outcome is ambiguous; refusing a duplicate turn/start");
     }
   }
 
-  async cancel(input: { derivedThreadId: string; turnId: string }): Promise<void> {
+  async cancel(input: { sideThreadId?: string; derivedThreadId: string; turnId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
     const execution = this.byTurn.get(turnKey(input.derivedThreadId, input.turnId));
     if (!execution) throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
-    await this.rpc("turn/interrupt", { threadId: input.derivedThreadId, turnId: input.turnId });
+    const sideThreadId = input.sideThreadId ?? execution.sideThreadId;
+    await this.durableMutation(sideThreadId, "interrupt", input.operation ?? this.defaultOperation(sideThreadId, "interrupt", `cancel-${execution.attemptId}`), input.derivedThreadId,
+      JSON.stringify([input.derivedThreadId, input.turnId]), "turn/interrupt",
+      { threadId: input.derivedThreadId, turnId: input.turnId });
   }
 
-  async archive(input: { derivedThreadId: string }): Promise<void> {
+  async archive(input: { sideThreadId?: string; derivedThreadId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
-    await this.rpc("thread/archive", { threadId: input.derivedThreadId });
+    const sideThreadId = input.sideThreadId ?? this.derivedThreads.get(input.derivedThreadId)!;
+    await this.durableMutation(sideThreadId, "archive", input.operation ?? this.defaultOperation(sideThreadId, "archive", `archive-${sideThreadId}`), input.derivedThreadId,
+      JSON.stringify([input.derivedThreadId]), "thread/archive", { threadId: input.derivedThreadId });
   }
 
-  async delete(input: { derivedThreadId: string }): Promise<void> {
+  async delete(input: { sideThreadId?: string; derivedThreadId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
     if ([...this.byTurn.values(), ...this.byClientId.values()].some((x) => x.threadId === input.derivedThreadId)) {
       throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
     }
-    await this.rpc("thread/delete", { threadId: input.derivedThreadId });
+    const sideThreadId = input.sideThreadId ?? this.derivedThreads.get(input.derivedThreadId)!;
+    await this.durableMutation(sideThreadId, "delete", input.operation ?? this.defaultOperation(sideThreadId, "delete", `purge-${sideThreadId}`), input.derivedThreadId,
+      JSON.stringify([input.derivedThreadId]), "thread/delete", { threadId: input.derivedThreadId });
     this.derivedThreads.delete(input.derivedThreadId);
   }
   async discardFork(input: { sideThreadId: string; derivedThreadId: string }): Promise<void> {
@@ -296,6 +353,149 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     this.assertOpen();
     return Promise.race([this.opts.client.request<T>(method, params), this.closedSignal]);
   }
+  private now(): number { return this.opts.now?.() ?? Date.now(); }
+  private defaultOperation(sideThreadId: string, method: OperationMethod, idempotencyKey: string): SideThreadRuntimeOperation {
+    return { nodeId: this.opts.nodeId, operationId: stableOperationId(sideThreadId, method, idempotencyKey), idempotencyKey };
+  }
+  private operation(identity: SideThreadRuntimeOperation, sideThreadId: string, method: OperationMethod, target: string, fingerprint: string): SideThreadOperation {
+    if (identity.operationId.length === 0 || identity.idempotencyKey.length === 0 || identity.nodeId.length === 0) {
+      throw new SideThreadConflictError("missing persistent operation identity");
+    }
+    if (identity.nodeId !== this.opts.nodeId) throw new SideThreadConflictError("persistent operation node ownership mismatch");
+    return { version: 1, nodeId: identity.nodeId, sideThreadId, opId: identity.operationId,
+      idempotencyKey: identity.idempotencyKey, method, targetHash: operationHash(target),
+      fingerprint: operationHash(fingerprint), state: "prepared", updatedAt: this.now() };
+  }
+  private existing(expected: SideThreadOperation): SideThreadOperation | undefined {
+    const existing = this.opts.operationLedger.get(expected.nodeId, expected.sideThreadId, expected.opId);
+    if (!existing) return undefined;
+    for (const key of ["idempotencyKey", "method", "targetHash", "fingerprint"] as const) {
+      if (existing[key] !== expected[key]) throw new SideThreadConflictError(`persistent operation ${key} mismatch`);
+    }
+    return existing;
+  }
+  private mustOperation(expected: SideThreadOperation): SideThreadOperation {
+    const operation = this.existing(expected);
+    if (!operation) throw new SideThreadConflictError("persistent operation disappeared");
+    return operation;
+  }
+  private put(operation: SideThreadOperation): void { this.opts.operationLedger.put(operation); }
+  private async reconcileFork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary; operation: SideThreadRuntimeOperation },
+    prior: SideThreadOperation, cause?: unknown): Promise<{ derivedThreadId: string }> {
+    const expected = this.operation(input.operation, input.sideThreadId, "fork", input.sourceThreadId,
+      JSON.stringify([input.sourceThreadId, input.boundary.kind, input.boundary.turnId]));
+    if (prior.state === "sent") {
+      prior = { ...prior, state: "ambiguous", updatedAt: this.now() };
+      this.put(prior);
+    }
+    let candidate: RuntimeThread | undefined;
+    try {
+      const threads = await this.listThreads();
+      if (prior.result?.derivedThreadIdHash) {
+        candidate = threads.find((thread) => operationHash(thread.id) === prior.result!.derivedThreadIdHash);
+        if (candidate && candidate.forkedFromId !== input.sourceThreadId) {
+          candidate = await this.readThread(candidate.id);
+          if (candidate.forkedFromId !== input.sourceThreadId) candidate = undefined;
+        }
+      } else {
+        const reconciling = prior.state === "reconciling" ? prior
+          : { ...prior, state: "reconciling" as const, updatedAt: this.now() };
+        if (reconciling !== prior) this.put(reconciling);
+        const snapshot = new Set(prior.result?.snapshotThreadIdHashes ?? []);
+        const unseen = threads.filter((thread) => thread.id !== input.sourceThreadId && !snapshot.has(operationHash(thread.id)));
+        const inspected = await Promise.all(unseen.map((thread) => thread.forkedFromId ? thread : this.readThread(thread.id)));
+        const candidates = inspected.filter((thread) => thread.forkedFromId === input.sourceThreadId);
+        if (candidates.length !== 1) {
+          this.put({ ...reconciling, state: "ambiguous", result: { ...reconciling.result,
+            classification: candidates.length === 0 ? "no-candidate" : "multiple-candidates" }, updatedAt: this.now() });
+          throw new SideThreadAmbiguousError(`Codex fork outcome has ${candidates.length} candidates; refusing duplicate thread/fork`);
+        }
+        candidate = candidates[0];
+        prior = reconciling;
+      }
+      if (!candidate) throw new SideThreadAmbiguousError("accepted Codex fork is not visible; refusing duplicate thread/fork");
+      if (candidate.id === input.sourceThreadId) throw new SideThreadConflictError("reconciled fork reused source thread");
+      this.registerDerived(candidate.id, input.sideThreadId);
+      if (prior.state === "accepted" || prior.state === "ambiguous" || prior.state === "reconciling") {
+        if (prior.state === "ambiguous") { prior = { ...prior, state: "reconciling", updatedAt: this.now() }; this.put(prior); }
+        this.put({ ...prior, state: "reconciled", result: { ...prior.result,
+          derivedThreadIdHash: operationHash(candidate.id), classification: "unique-candidate" }, updatedAt: this.now() });
+      }
+      this.opts.forkLeaseStore.release(input.operation.nodeId, input.sourceThreadId, input.operation.operationId);
+      return { derivedThreadId: candidate.id };
+    } catch (error) {
+      if (error instanceof SideThreadAmbiguousError || error instanceof SideThreadConflictError) throw error;
+      const current = this.mustOperation(expected);
+      if (current.state === "reconciling") this.put({ ...current, state: "ambiguous", updatedAt: this.now() });
+      throw new SideThreadAmbiguousError(`Codex fork reconciliation failed; refusing duplicate thread/fork${cause ? " after response loss" : ""}`);
+    }
+  }
+  private async reconcileStart(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; operation: SideThreadRuntimeOperation },
+    clientUserMessageId: string, prior: SideThreadOperation): Promise<{ turnId: string }> {
+    const live = this.byClientId.get(clientUserMessageId);
+    let turnId = live?.turnId;
+    let current = prior;
+    if (current.state === "sent") { current = { ...current, state: "ambiguous", updatedAt: this.now() }; this.put(current); }
+    if (!turnId) {
+      if (current.state === "ambiguous") { current = { ...current, state: "reconciling", updatedAt: this.now() }; this.put(current); }
+      try {
+        const thread = await this.readThread(input.derivedThreadId);
+        const matches = (thread.turns ?? []).filter((turn) => turnHasClientId(turn, clientUserMessageId));
+        if (prior.result?.turnIdHash) {
+          turnId = matches.find((turn) => operationHash(turn.id) === prior.result!.turnIdHash)?.id;
+        } else if (matches.length === 1) turnId = matches[0].id;
+      } catch { /* the durable ambiguity below is authoritative */ }
+    }
+    if (!turnId) {
+      if (current.state === "reconciling") this.put({ ...current, state: "ambiguous", updatedAt: this.now() });
+      throw new SideThreadAmbiguousError("Codex start outcome cannot be uniquely reconciled; refusing duplicate turn/start");
+    }
+    if (current.state === "ambiguous") { current = { ...current, state: "reconciling", updatedAt: this.now() }; this.put(current); }
+    if (current.state === "accepted" || current.state === "reconciling") {
+      this.put({ ...current, state: "reconciled", result: { ...current.result, turnIdHash: operationHash(turnId) }, updatedAt: this.now() });
+    }
+    return { turnId };
+  }
+  private async listThreads(): Promise<RuntimeThread[]> {
+    const all: RuntimeThread[] = []; let cursor: string | undefined;
+    do {
+      const response = await this.rpc<{ data?: RuntimeThread[]; threads?: RuntimeThread[]; nextCursor?: string | null }>("thread/list",
+        { limit: 100, ...(cursor ? { cursor } : {}) });
+      const page = response?.data ?? response?.threads;
+      if (!Array.isArray(page) || page.some((thread) => !thread?.id)) throw new SideThreadConflictError("Codex returned an invalid thread/list snapshot");
+      all.push(...page); cursor = response.nextCursor ?? undefined;
+      if (all.length > 10_000) throw new SideThreadConflictError("Codex thread/list snapshot exceeded bound");
+    } while (cursor);
+    return all;
+  }
+  private async readThread(threadId: string): Promise<RuntimeThread> {
+    const response = await this.rpc<{ thread?: RuntimeThread }>("thread/read", { threadId, includeTurns: true });
+    if (!response?.thread?.id || response.thread.id !== threadId) throw new SideThreadConflictError("Codex returned an invalid thread/read result");
+    return response.thread;
+  }
+  private registerDerived(threadId: string, sideThreadId: string): void {
+    const owner = this.derivedThreads.get(threadId);
+    if (owner && owner !== sideThreadId) throw new SideThreadConflictError("Codex reused a derived thread identity");
+    this.derivedThreads.set(threadId, sideThreadId);
+  }
+  private async durableMutation(sideThreadId: string, method: "interrupt" | "archive" | "delete", identity: SideThreadRuntimeOperation,
+    target: string, fingerprint: string, rpcMethod: string, params: unknown): Promise<void> {
+    const operation = this.operation(identity, sideThreadId, method, target, fingerprint);
+    const prior = this.existing(operation);
+    if (prior) {
+      if (prior.state === "accepted" || prior.state === "reconciled") return;
+      if (prior.state !== "prepared") throw new SideThreadAmbiguousError(`Codex ${method} outcome is ambiguous; refusing duplicate RPC`);
+    } else this.put(operation);
+    const sent = { ...this.mustOperation(operation), state: "sent" as const, updatedAt: this.now() };
+    this.put(sent);
+    try {
+      await this.rpc(rpcMethod, params);
+      this.put({ ...sent, state: "accepted", updatedAt: this.now() });
+    } catch {
+      this.put({ ...sent, state: "ambiguous", updatedAt: this.now() });
+      throw new SideThreadAmbiguousError(`Codex ${method} outcome is ambiguous; refusing duplicate RPC`);
+    }
+  }
   private assertOwnedThread(threadId: string, sideThreadId?: string): void {
     this.assertSupported();
     const owner = this.derivedThreads.get(threadId);
@@ -311,3 +511,11 @@ function unsupported(reason: "version" | "topology" | "exact-boundary", opts: Co
   };
 }
 function turnKey(threadId: string, turnId: string): string { return `${threadId}\0${turnId}`; }
+interface RuntimeTurn { id: string; items?: unknown[]; [key: string]: unknown }
+interface RuntimeThread { id: string; forkedFromId?: string; turns?: RuntimeTurn[]; [key: string]: unknown }
+function turnHasClientId(turn: RuntimeTurn, clientId: string): boolean {
+  return (turn.items ?? []).some((item) => {
+    const value = item as { clientId?: string; client_id?: string };
+    return value?.clientId === clientId || value?.client_id === clientId;
+  });
+}

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -32,14 +32,18 @@ interface Execution {
   resolveIdentity: (turnId: string) => void;
   rejectIdentity: (error: Error) => void;
   identityTimer: ReturnType<typeof setTimeout>;
+  pendingTerminal?: unknown;
 }
 
 /** Native exact-boundary adapter proven only by PR0's 0.148.0 owned probe. */
 export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter {
   private readonly listeners = new Set<(event: SideThreadTerminalEvent) => void>();
-  private readonly derivedThreads = new Set<string>();
+  private readonly droppedListeners = new Set<(reason: string) => void>();
+  private readonly derivedThreads = new Map<string, string>();
   private readonly byClientId = new Map<string, Execution>();
   private readonly byTurn = new Map<string, Execution>();
+  private readonly earlyTerminals = new Map<string, unknown>();
+  private closed = false;
 
   constructor(private readonly opts: CodexSideThreadAdapterOptions) {
     opts.client.on("item/started", this.onItem);
@@ -61,6 +65,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 
   async fork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary }): Promise<{ derivedThreadId: string }> {
+    this.assertOpen();
     this.assertSupported();
     if (!this.capability().exactBoundary?.[input.boundary.kind]) {
       throw new SideThreadUnsupportedError(
@@ -77,22 +82,26 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         ? { lastTurnId: input.boundary.turnId }
         : { beforeTurnId: input.boundary.turnId }),
     };
-    const response = await this.opts.client.request<{ thread?: { id?: string }; threadId?: string }>("thread/fork", params);
-    const derivedThreadId = response?.thread?.id ?? response?.threadId;
+    const response = await this.opts.client.request<{ thread?: { id?: string } }>("thread/fork", params);
+    this.assertOpen();
+    const derivedThreadId = response?.thread?.id;
     if (!derivedThreadId || derivedThreadId === input.sourceThreadId) {
       throw new SideThreadConflictError("Codex returned an invalid derived thread identity");
     }
-    this.derivedThreads.add(derivedThreadId);
+    if (this.derivedThreads.has(derivedThreadId)) throw new SideThreadConflictError("Codex reused a derived thread identity");
+    this.derivedThreads.set(derivedThreadId, input.sideThreadId);
     return { derivedThreadId };
   }
 
   async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string }): Promise<{ turnId: string }> {
-    this.assertOwnedThread(input.derivedThreadId);
+    this.assertOpen();
+    this.assertOwnedThread(input.derivedThreadId, input.sideThreadId);
     const clientUserMessageId = `anet-side:${input.sideThreadId}:${input.attemptId}`;
     if (this.byClientId.has(clientUserMessageId)) throw new SideThreadConflictError("duplicate Codex attempt identity");
     let resolveIdentity!: (turnId: string) => void;
     let rejectIdentity!: (error: Error) => void;
     const identity = new Promise<string>((resolve, reject) => { resolveIdentity = resolve; rejectIdentity = reject; });
+    void identity.catch(() => {});
     const execution: Execution = {
       sideThreadId: input.sideThreadId, attemptId: input.attemptId,
       threadId: input.derivedThreadId, clientUserMessageId,
@@ -106,20 +115,33 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     try {
       let response: { turn?: { id?: string }; turnId?: string } | undefined;
       try {
-        response = await this.opts.client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
+        const request = this.opts.client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
         threadId: input.derivedThreadId,
         clientUserMessageId,
         input: [{ type: "text", text: input.prompt }],
         });
+        const abortOnIdentityFailure = identity.then(
+          () => new Promise<never>(() => {}),
+          (error) => Promise.reject(error),
+        );
+        response = await Promise.race([request, abortOnIdentityFailure]);
       } catch (error) {
         // The response can be lost after app-server accepted the turn. The
         // echoed client id is authoritative and makes retrying unsafe.
         if (!execution.turnId) throw error;
       }
-      execution.responseTurnId = response?.turn?.id ?? response?.turnId;
+      this.assertOpen();
+      execution.responseTurnId = response?.turn?.id;
+      if (!execution.responseTurnId && !execution.turnId) throw new SideThreadConflictError("Codex returned an invalid turn identity");
       // Response identity alone is not authoritative: Codex automatic goal
       // continuation can replace it. Wait for the echoed client id.
-      return { turnId: await identity };
+      const turnId = await identity;
+      if (execution.pendingTerminal) {
+        const pending = execution.pendingTerminal;
+        execution.pendingTerminal = undefined;
+        setTimeout(() => this.onCompleted(pending), 0);
+      }
+      return { turnId };
     } catch (error) {
       this.dropExecution(execution);
       throw error;
@@ -127,6 +149,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 
   async cancel(input: { derivedThreadId: string; turnId: string }): Promise<void> {
+    this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
     const execution = this.byTurn.get(turnKey(input.derivedThreadId, input.turnId));
     if (!execution) throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
@@ -134,13 +157,15 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 
   async archive(input: { derivedThreadId: string }): Promise<void> {
+    this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
     await this.opts.client.request("thread/archive", { threadId: input.derivedThreadId });
   }
 
   async delete(input: { derivedThreadId: string }): Promise<void> {
+    this.assertOpen();
     this.assertOwnedThread(input.derivedThreadId);
-    if ([...this.byTurn.values()].some((x) => x.threadId === input.derivedThreadId)) {
+    if ([...this.byTurn.values(), ...this.byClientId.values()].some((x) => x.threadId === input.derivedThreadId)) {
       throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
     }
     await this.opts.client.request("thread/delete", { threadId: input.derivedThreadId });
@@ -151,8 +176,14 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
   }
+  subscribeDropped(listener: (reason: string) => void): () => void {
+    this.droppedListeners.add(listener);
+    return () => this.droppedListeners.delete(listener);
+  }
 
   close(): void {
+    if (this.closed) return;
+    this.closed = true;
     this.opts.client.off("item/started", this.onItem);
     this.opts.client.off("item/completed", this.onItem);
     this.opts.client.off("item/agentMessage/delta", this.onDelta);
@@ -163,7 +194,9 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     }
     this.byClientId.clear();
     this.byTurn.clear();
+    this.earlyTerminals.clear();
     this.listeners.clear();
+    this.droppedListeners.clear();
   }
 
   private readonly onItem = (params: unknown): void => {
@@ -172,17 +205,19 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     const clientId = p.item.clientId;
     if (p.item.type === "userMessage" && clientId) {
       const execution = this.byClientId.get(clientId);
-      if (!execution || execution.threadId !== p.threadId) return;
-      if (execution.turnId && execution.turnId !== p.turnId) return;
+      if (!execution || execution.threadId !== p.threadId) { this.dropped("identity-ownership-mismatch"); return; }
+      if (execution.turnId && execution.turnId !== p.turnId) { this.dropped("identity-turn-mismatch"); return; }
       execution.turnId = p.turnId;
       this.byTurn.set(turnKey(p.threadId, p.turnId), execution);
       clearTimeout(execution.identityTimer);
       execution.resolveIdentity(p.turnId);
+      const early = this.earlyTerminals.get(turnKey(p.threadId, p.turnId));
+      if (early) { this.earlyTerminals.delete(turnKey(p.threadId, p.turnId)); execution.pendingTerminal = early; }
       return;
     }
     if (p.item.type === "agentMessage" && typeof p.item.text === "string") {
       const execution = this.byTurn.get(turnKey(p.threadId, p.turnId));
-      if (execution) execution.text = p.item.text;
+      if (execution) execution.text = p.item.text; else this.dropped("unowned-agent-message");
     }
   };
 
@@ -190,7 +225,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     const p = params as { threadId?: string; turnId?: string; delta?: string };
     if (!p?.threadId || !p.turnId || typeof p.delta !== "string") return;
     const execution = this.byTurn.get(turnKey(p.threadId, p.turnId));
-    if (execution) execution.text += p.delta;
+    if (execution) execution.text += p.delta; else this.dropped("unowned-delta");
   };
 
   private readonly onCompleted = (params: unknown): void => {
@@ -198,7 +233,12 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     const turnId = p?.turn?.id;
     if (!p?.threadId || !turnId) return;
     const execution = this.byTurn.get(turnKey(p.threadId, turnId));
-    if (!execution) return;
+    if (!execution) {
+      const starting = [...this.byClientId.values()].some((x) => x.threadId === p.threadId);
+      if (starting && this.earlyTerminals.size < 64) this.earlyTerminals.set(turnKey(p.threadId, turnId), params);
+      else this.dropped(starting ? "terminal-buffer-full" : "unowned-terminal");
+      return;
+    }
     const status = p.turn?.status;
     const event: SideThreadTerminalEvent = {
       sideThreadId: execution.sideThreadId, attemptId: execution.attemptId,
@@ -228,10 +268,13 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       );
     }
   }
-  private assertOwnedThread(threadId: string): void {
+  private assertOpen(): void { if (this.closed) throw new SideThreadConflictError("Codex side-thread adapter closed"); }
+  private assertOwnedThread(threadId: string, sideThreadId?: string): void {
     this.assertSupported();
-    if (!this.derivedThreads.has(threadId)) throw new SideThreadConflictError("refusing operation on an unowned Codex thread");
+    const owner = this.derivedThreads.get(threadId);
+    if (!owner || (sideThreadId && owner !== sideThreadId)) throw new SideThreadConflictError("refusing operation on an unowned Codex thread");
   }
+  private dropped(reason: string): void { for (const listener of this.droppedListeners) listener(reason); }
 }
 
 function unsupported(reason: "version" | "topology" | "exact-boundary", opts: CodexSideThreadAdapterOptions): SideThreadCapability {

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -15,7 +15,8 @@ export interface SideThreadCodexClient extends EventEmitter {
 export interface CodexSideThreadAdapterOptions {
   client: SideThreadCodexClient;
   runtimeVersion: string;
-  topology: "owned" | "shared";
+  topology: "owned-stdio" | "owned-websocket" | "shared-websocket";
+  evidenceRevision: string;
   experimentalApi: boolean;
   identityTimeoutMs?: number;
 }
@@ -48,10 +49,12 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 
   capability(): SideThreadCapability {
-    if (this.opts.runtimeVersion !== "0.148.0") return unsupported("version", this.opts.runtimeVersion);
-    if (this.opts.topology !== "owned") return unsupported("topology", this.opts.runtimeVersion);
+    if (this.opts.runtimeVersion !== "0.148.0") return unsupported("version", this.opts);
+    if (this.opts.topology !== "owned-stdio") return unsupported("topology", this.opts);
+    if (this.opts.evidenceRevision !== "test1190-wire-v2") return unsupported("exact-boundary", this.opts);
     return {
       supported: true, runtime: "codex-app-server", runtimeVersion: this.opts.runtimeVersion,
+      topology: this.opts.topology, evidenceRevision: this.opts.evidenceRevision,
       mode: "native-exact-fork",
       exactBoundary: { through: true, before: this.opts.experimentalApi },
     };
@@ -231,7 +234,10 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
   }
 }
 
-function unsupported(reason: "version" | "topology", runtimeVersion: string): SideThreadCapability {
-  return { supported: false, runtime: "codex-app-server", runtimeVersion, reason };
+function unsupported(reason: "version" | "topology" | "exact-boundary", opts: CodexSideThreadAdapterOptions): SideThreadCapability {
+  return {
+    supported: false, runtime: "codex-app-server", runtimeVersion: opts.runtimeVersion,
+    topology: opts.topology, evidenceRevision: opts.evidenceRevision, reason,
+  };
 }
 function turnKey(threadId: string, turnId: string): string { return `${threadId}\0${turnId}`; }

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -1,0 +1,237 @@
+import type { EventEmitter } from "node:events";
+import {
+  SideThreadConflictError,
+  SideThreadUnsupportedError,
+  type ExactBoundary,
+  type SideThreadCapability,
+  type SideThreadRuntimeAdapter,
+  type SideThreadTerminalEvent,
+} from "./domain";
+
+export interface SideThreadCodexClient extends EventEmitter {
+  request<T = unknown>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
+}
+
+export interface CodexSideThreadAdapterOptions {
+  client: SideThreadCodexClient;
+  runtimeVersion: string;
+  topology: "owned" | "shared";
+  experimentalApi: boolean;
+  identityTimeoutMs?: number;
+}
+
+interface Execution {
+  sideThreadId: string;
+  attemptId: string;
+  threadId: string;
+  clientUserMessageId: string;
+  responseTurnId?: string;
+  turnId?: string;
+  text: string;
+  resolveIdentity: (turnId: string) => void;
+  rejectIdentity: (error: Error) => void;
+  identityTimer: ReturnType<typeof setTimeout>;
+}
+
+/** Native exact-boundary adapter proven only by PR0's 0.148.0 owned probe. */
+export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter {
+  private readonly listeners = new Set<(event: SideThreadTerminalEvent) => void>();
+  private readonly derivedThreads = new Set<string>();
+  private readonly byClientId = new Map<string, Execution>();
+  private readonly byTurn = new Map<string, Execution>();
+
+  constructor(private readonly opts: CodexSideThreadAdapterOptions) {
+    opts.client.on("item/started", this.onItem);
+    opts.client.on("item/completed", this.onItem);
+    opts.client.on("item/agentMessage/delta", this.onDelta);
+    opts.client.on("turn/completed", this.onCompleted);
+  }
+
+  capability(): SideThreadCapability {
+    if (this.opts.runtimeVersion !== "0.148.0") return unsupported("version", this.opts.runtimeVersion);
+    if (this.opts.topology !== "owned") return unsupported("topology", this.opts.runtimeVersion);
+    return {
+      supported: true, runtime: "codex-app-server", runtimeVersion: this.opts.runtimeVersion,
+      mode: "native-exact-fork",
+      exactBoundary: { through: true, before: this.opts.experimentalApi },
+    };
+  }
+
+  async fork(input: { sideThreadId: string; sourceThreadId: string; boundary: ExactBoundary }): Promise<{ derivedThreadId: string }> {
+    this.assertSupported();
+    if (!this.capability().exactBoundary?.[input.boundary.kind]) {
+      throw new SideThreadUnsupportedError(
+        input.boundary.kind === "before" ? "experimental-api" : "exact-boundary",
+        `Codex boundary '${input.boundary.kind}' is unsupported`,
+      );
+    }
+    const params: Record<string, unknown> = {
+      threadId: input.sourceThreadId,
+      ephemeral: false,
+      // No approval/sandbox/cwd/instruction override: native fork inherits
+      // source policy. PR1 must not turn BTW into a privilege escalation.
+      ...(input.boundary.kind === "through"
+        ? { lastTurnId: input.boundary.turnId }
+        : { beforeTurnId: input.boundary.turnId }),
+    };
+    const response = await this.opts.client.request<{ thread?: { id?: string }; threadId?: string }>("thread/fork", params);
+    const derivedThreadId = response?.thread?.id ?? response?.threadId;
+    if (!derivedThreadId || derivedThreadId === input.sourceThreadId) {
+      throw new SideThreadConflictError("Codex returned an invalid derived thread identity");
+    }
+    this.derivedThreads.add(derivedThreadId);
+    return { derivedThreadId };
+  }
+
+  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string }): Promise<{ turnId: string }> {
+    this.assertOwnedThread(input.derivedThreadId);
+    const clientUserMessageId = `anet-side:${input.sideThreadId}:${input.attemptId}`;
+    if (this.byClientId.has(clientUserMessageId)) throw new SideThreadConflictError("duplicate Codex attempt identity");
+    let resolveIdentity!: (turnId: string) => void;
+    let rejectIdentity!: (error: Error) => void;
+    const identity = new Promise<string>((resolve, reject) => { resolveIdentity = resolve; rejectIdentity = reject; });
+    const execution: Execution = {
+      sideThreadId: input.sideThreadId, attemptId: input.attemptId,
+      threadId: input.derivedThreadId, clientUserMessageId,
+      text: "", resolveIdentity, rejectIdentity,
+      identityTimer: setTimeout(() => {
+        this.dropExecution(execution);
+        rejectIdentity(new SideThreadConflictError("Codex did not echo the attempt identity"));
+      }, this.opts.identityTimeoutMs ?? 10_000),
+    };
+    this.byClientId.set(clientUserMessageId, execution);
+    try {
+      let response: { turn?: { id?: string }; turnId?: string } | undefined;
+      try {
+        response = await this.opts.client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
+        threadId: input.derivedThreadId,
+        clientUserMessageId,
+        input: [{ type: "text", text: input.prompt }],
+        });
+      } catch (error) {
+        // The response can be lost after app-server accepted the turn. The
+        // echoed client id is authoritative and makes retrying unsafe.
+        if (!execution.turnId) throw error;
+      }
+      execution.responseTurnId = response?.turn?.id ?? response?.turnId;
+      // Response identity alone is not authoritative: Codex automatic goal
+      // continuation can replace it. Wait for the echoed client id.
+      return { turnId: await identity };
+    } catch (error) {
+      this.dropExecution(execution);
+      throw error;
+    }
+  }
+
+  async cancel(input: { derivedThreadId: string; turnId: string }): Promise<void> {
+    this.assertOwnedThread(input.derivedThreadId);
+    const execution = this.byTurn.get(turnKey(input.derivedThreadId, input.turnId));
+    if (!execution) throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
+    await this.opts.client.request("turn/interrupt", { threadId: input.derivedThreadId, turnId: input.turnId });
+  }
+
+  async archive(input: { derivedThreadId: string }): Promise<void> {
+    this.assertOwnedThread(input.derivedThreadId);
+    await this.opts.client.request("thread/archive", { threadId: input.derivedThreadId });
+  }
+
+  async delete(input: { derivedThreadId: string }): Promise<void> {
+    this.assertOwnedThread(input.derivedThreadId);
+    if ([...this.byTurn.values()].some((x) => x.threadId === input.derivedThreadId)) {
+      throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
+    }
+    await this.opts.client.request("thread/delete", { threadId: input.derivedThreadId });
+    this.derivedThreads.delete(input.derivedThreadId);
+  }
+
+  subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  close(): void {
+    this.opts.client.off("item/started", this.onItem);
+    this.opts.client.off("item/completed", this.onItem);
+    this.opts.client.off("item/agentMessage/delta", this.onDelta);
+    this.opts.client.off("turn/completed", this.onCompleted);
+    for (const execution of this.byClientId.values()) {
+      clearTimeout(execution.identityTimer);
+      execution.rejectIdentity(new SideThreadConflictError("Codex side-thread adapter closed"));
+    }
+    this.byClientId.clear();
+    this.byTurn.clear();
+    this.listeners.clear();
+  }
+
+  private readonly onItem = (params: unknown): void => {
+    const p = params as { threadId?: string; turnId?: string; item?: { type?: string; clientId?: string; text?: string } };
+    if (!p?.threadId || !p.turnId || !p.item) return;
+    const clientId = p.item.clientId;
+    if (p.item.type === "userMessage" && clientId) {
+      const execution = this.byClientId.get(clientId);
+      if (!execution || execution.threadId !== p.threadId) return;
+      if (execution.turnId && execution.turnId !== p.turnId) return;
+      execution.turnId = p.turnId;
+      this.byTurn.set(turnKey(p.threadId, p.turnId), execution);
+      clearTimeout(execution.identityTimer);
+      execution.resolveIdentity(p.turnId);
+      return;
+    }
+    if (p.item.type === "agentMessage" && typeof p.item.text === "string") {
+      const execution = this.byTurn.get(turnKey(p.threadId, p.turnId));
+      if (execution) execution.text = p.item.text;
+    }
+  };
+
+  private readonly onDelta = (params: unknown): void => {
+    const p = params as { threadId?: string; turnId?: string; delta?: string };
+    if (!p?.threadId || !p.turnId || typeof p.delta !== "string") return;
+    const execution = this.byTurn.get(turnKey(p.threadId, p.turnId));
+    if (execution) execution.text += p.delta;
+  };
+
+  private readonly onCompleted = (params: unknown): void => {
+    const p = params as { threadId?: string; turn?: { id?: string; status?: string; error?: { message?: string } | string } };
+    const turnId = p?.turn?.id;
+    if (!p?.threadId || !turnId) return;
+    const execution = this.byTurn.get(turnKey(p.threadId, turnId));
+    if (!execution) return;
+    const status = p.turn?.status;
+    const event: SideThreadTerminalEvent = {
+      sideThreadId: execution.sideThreadId, attemptId: execution.attemptId,
+      threadId: execution.threadId, turnId,
+      status: status === "completed" ? "completed" : status === "interrupted" ? "interrupted" : "failed",
+      text: status === "completed" ? execution.text : undefined,
+      error: status !== "completed" && status !== "interrupted"
+        ? typeof p.turn?.error === "string" ? p.turn.error : p.turn?.error?.message
+        : undefined,
+    };
+    this.dropExecution(execution);
+    for (const listener of this.listeners) listener(event);
+  };
+
+  private dropExecution(execution: Execution): void {
+    clearTimeout(execution.identityTimer);
+    this.byClientId.delete(execution.clientUserMessageId);
+    if (execution.turnId) this.byTurn.delete(turnKey(execution.threadId, execution.turnId));
+  }
+
+  private assertSupported(): void {
+    const capability = this.capability();
+    if (!capability.supported) {
+      throw new SideThreadUnsupportedError(
+        capability.reason ?? "runtime",
+        `Codex side thread unsupported: ${capability.reason}`,
+      );
+    }
+  }
+  private assertOwnedThread(threadId: string): void {
+    this.assertSupported();
+    if (!this.derivedThreads.has(threadId)) throw new SideThreadConflictError("refusing operation on an unowned Codex thread");
+  }
+}
+
+function unsupported(reason: "version" | "topology", runtimeVersion: string): SideThreadCapability {
+  return { supported: false, runtime: "codex-app-server", runtimeVersion, reason };
+}
+function turnKey(threadId: string, turnId: string): string { return `${threadId}\0${turnId}`; }

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -34,6 +34,8 @@ interface Execution {
   rejectIdentity: (error: Error) => void;
   identityTimer: ReturnType<typeof setTimeout>;
   pendingTerminal?: unknown;
+  readyForTerminal: boolean;
+  identityAmbiguous: boolean;
 }
 
 /** Native exact-boundary adapter proven only by PR0's 0.148.0 owned probe. */
@@ -111,7 +113,10 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       sideThreadId: input.sideThreadId, attemptId: input.attemptId,
       threadId: input.derivedThreadId, clientUserMessageId,
       text: "", resolveIdentity, rejectIdentity,
+      readyForTerminal: false,
+      identityAmbiguous: false,
       identityTimer: setTimeout(() => {
+        execution.identityAmbiguous = true;
         rejectIdentity(new SideThreadAmbiguousError("Codex accepted turn/start but did not echo identity; reconciliation required"));
       }, this.opts.identityTimeoutMs ?? 10_000),
     };
@@ -140,6 +145,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       // Response identity alone is not authoritative: Codex automatic goal
       // continuation can replace it. Wait for the echoed client id.
       const turnId = await identity;
+      execution.readyForTerminal = true;
       if (execution.pendingTerminal) {
         const pending = execution.pendingTerminal;
         execution.pendingTerminal = undefined;
@@ -221,8 +227,13 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       this.byTurn.set(turnKey(p.threadId, p.turnId), execution);
       clearTimeout(execution.identityTimer);
       execution.resolveIdentity(p.turnId);
+      if (execution.identityAmbiguous) execution.readyForTerminal = true;
       const early = this.earlyTerminals.get(turnKey(p.threadId, p.turnId));
-      if (early) { this.earlyTerminals.delete(turnKey(p.threadId, p.turnId)); execution.pendingTerminal = early; }
+      if (early) {
+        this.earlyTerminals.delete(turnKey(p.threadId, p.turnId));
+        execution.pendingTerminal = early;
+        if (execution.readyForTerminal) setTimeout(() => this.onCompleted(early), 0);
+      }
       return;
     }
     if (p.item.type === "agentMessage" && typeof p.item.text === "string") {
@@ -250,6 +261,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       return;
     }
     const status = p.turn?.status;
+    if (!execution.readyForTerminal) { execution.pendingTerminal = params; return; }
     const event: SideThreadTerminalEvent = {
       sideThreadId: execution.sideThreadId, attemptId: execution.attemptId,
       threadId: execution.threadId, turnId,
@@ -258,6 +270,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       error: status !== "completed" && status !== "interrupted"
         ? typeof p.turn?.error === "string" ? p.turn.error : p.turn?.error?.message
         : undefined,
+      identityBound: true,
     };
     this.dropExecution(execution);
     for (const listener of this.listeners) listener(event);

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import {
+  SideThreadConflictError, SideThreadService, SideThreadUnsupportedError,
+  type SideThreadCapability, type SideThreadRuntimeAdapter, type SideThreadTerminalEvent,
+} from "./domain";
+
+class FakeAdapter extends EventEmitter implements SideThreadRuntimeAdapter {
+  cap: SideThreadCapability = { supported: true, runtime: "fake", runtimeVersion: "1", mode: "native-exact-fork", exactBoundary: { through: true, before: true } };
+  forks = 0; starts = 0; cancels: unknown[] = []; archives = 0; deletes = 0;
+  terminalDuringStart = false;
+  capability() { return this.cap; }
+  async fork(input: { sideThreadId: string }) { this.forks++; return { derivedThreadId: `derived-${input.sideThreadId}` }; }
+  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string }) {
+    this.starts++;
+    const turnId = `turn-${input.attemptId}`;
+    if (this.terminalDuringStart) this.terminal({
+      sideThreadId: input.sideThreadId, attemptId: input.attemptId,
+      threadId: input.derivedThreadId, turnId, status: "completed", text: "fast",
+    });
+    return { turnId };
+  }
+  async cancel(input: unknown) { this.cancels.push(input); }
+  async archive() { this.archives++; }
+  async delete() { this.deletes++; }
+  subscribe(listener: (event: SideThreadTerminalEvent) => void) { this.on("terminal", listener); return () => this.off("terminal", listener); }
+  terminal(event: SideThreadTerminalEvent) { this.emit("terminal", event); }
+}
+
+const ids = () => { let n = 0; return () => `id-${++n}`; };
+const createInput = { requestKey: "create-key-0001", nodeId: "node-1", sourceThreadId: "source-1", boundary: { kind: "through", turnId: "main-turn-1" } as const };
+
+describe("SideThreadService", () => {
+  test("fails closed before fork for unsupported capability", async () => {
+    const adapter = new FakeAdapter();
+    adapter.cap = { supported: false, runtime: "claude", runtimeVersion: "x", reason: "runtime" };
+    const service = new SideThreadService({ adapter, id: ids() });
+    await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadUnsupportedError);
+    expect(adapter.forks).toBe(0);
+  });
+
+  test("concurrent create and attempt request keys are idempotent", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids() });
+    const [a, b] = await Promise.all([service.create(createInput), service.create(createInput)]);
+    expect(a.id).toBe(b.id);
+    expect(adapter.forks).toBe(1);
+    const [x, y] = await Promise.all([
+      service.startAttempt({ sideThreadId: a.id, requestKey: "attempt-key-0001", prompt: "secret prompt" }),
+      service.startAttempt({ sideThreadId: a.id, requestKey: "attempt-key-0001", prompt: "secret prompt" }),
+    ]);
+    expect(x.id).toBe(y.id);
+    expect(adapter.starts).toBe(1);
+    await expect(service.create({ ...createInput, sourceThreadId: "different" }))
+      .rejects.toThrow("idempotency key reused");
+    await expect(service.startAttempt({ sideThreadId: a.id, requestKey: "attempt-key-0001", prompt: "different" }))
+      .rejects.toThrow("idempotency key reused");
+  });
+
+  test("boundary-specific capability rejects before without blocking through", async () => {
+    const adapter = new FakeAdapter();
+    adapter.cap.exactBoundary = { through: true, before: false };
+    const service = new SideThreadService({ adapter, id: ids() });
+    await expect(service.create({ ...createInput, boundary: { kind: "before", turnId: "active" } }))
+      .rejects.toMatchObject({ code: "SIDE_THREAD_UNSUPPORTED", reason: "experimental-api" });
+    expect(adapter.forks).toBe(0);
+    await expect(service.create(createInput)).resolves.toMatchObject({ sourceThreadId: "source-1" });
+  });
+
+  test("cancel uses exact derived thread and active turn", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids() });
+    const side = await service.create(createInput);
+    const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0002", prompt: "question" });
+    await service.cancel(side.id);
+    expect(adapter.cancels).toEqual([{ derivedThreadId: side.derivedThreadId, turnId: attempt.turnId }]);
+    expect(adapter.cancels).not.toContainEqual(expect.objectContaining({ derivedThreadId: side.sourceThreadId }));
+  });
+
+  test("drops mismatched and stale terminal events without settling current attempt", async () => {
+    const adapter = new FakeAdapter();
+    const audit: any[] = [];
+    const service = new SideThreadService({ adapter, id: ids(), audit: (e) => audit.push(e) });
+    const side = await service.create(createInput);
+    const first = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0003", prompt: "one" });
+    adapter.terminal({ sideThreadId: side.id, attemptId: first.id, threadId: side.derivedThreadId, turnId: first.turnId!, status: "completed", text: "one" });
+    const second = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0004", prompt: "two" });
+    adapter.terminal({ sideThreadId: side.id, attemptId: first.id, threadId: side.derivedThreadId, turnId: first.turnId!, status: "completed", text: "late" });
+    adapter.terminal({ sideThreadId: side.id, attemptId: second.id, threadId: side.sourceThreadId, turnId: second.turnId!, status: "completed", text: "wrong thread" });
+    expect(service.get(side.id)?.activeAttemptId).toBe(second.id);
+    expect(audit.filter((x) => x.action === "event_dropped")).toHaveLength(2);
+    adapter.terminal({ sideThreadId: side.id, attemptId: second.id, threadId: side.derivedThreadId, turnId: second.turnId!, status: "completed", text: "two" });
+    expect(service.get(side.id)?.state).toBe("completed");
+  });
+
+  test("terminal racing start return settles the same attempt once", async () => {
+    const adapter = new FakeAdapter(); adapter.terminalDuringStart = true;
+    const service = new SideThreadService({ adapter, id: ids() });
+    const side = await service.create(createInput);
+    const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-fast", prompt: "fast" });
+    expect(attempt).toMatchObject({ state: "completed", result: "fast" });
+    expect(service.get(side.id)).toMatchObject({ state: "completed", activeAttemptId: undefined });
+  });
+
+  test("archive is idempotent, purge is owned and refuses running turns", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids() });
+    const side = await service.create(createInput);
+    const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0005", prompt: "one" });
+    await expect(service.purge(side.id)).rejects.toBeInstanceOf(SideThreadConflictError);
+    adapter.terminal({ sideThreadId: side.id, attemptId: attempt.id, threadId: side.derivedThreadId, turnId: attempt.turnId!, status: "completed" });
+    await service.archive(side.id); await service.archive(side.id);
+    expect(adapter.archives).toBe(1);
+    await service.purge(side.id); await service.purge(side.id);
+    expect(adapter.deletes).toBe(1);
+  });
+
+  test("audit is field-minimized and never contains prompt", async () => {
+    const adapter = new FakeAdapter();
+    const audit: any[] = [];
+    const service = new SideThreadService({ adapter, id: ids(), audit: (e) => audit.push(e) });
+    const side = await service.create(createInput);
+    await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0006", prompt: "TOP-SECRET-PROMPT" });
+    expect(JSON.stringify(audit)).not.toContain("TOP-SECRET-PROMPT");
+    expect(audit.every((x) => !Object.hasOwn(x, "prompt") && !Object.hasOwn(x, "result"))).toBe(true);
+  });
+
+  test("close removes subscription and refuses new mutations", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids() });
+    expect(adapter.listenerCount("terminal")).toBe(1);
+    service.close(); service.close();
+    expect(adapter.listenerCount("terminal")).toBe(0);
+    await expect(service.create(createInput)).rejects.toThrow("service is closed");
+  });
+});

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -76,7 +76,7 @@ describe("SideThreadService", () => {
     const service = new SideThreadService({ adapter, id: ids() });
     const side = await service.create(createInput);
     const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0002", prompt: "question" });
-    await service.cancel(side.id);
+    await Promise.all([service.cancel(side.id), service.cancel(side.id)]);
     expect(adapter.cancels).toEqual([{ derivedThreadId: side.derivedThreadId, turnId: attempt.turnId }]);
     expect(adapter.cancels).not.toContainEqual(expect.objectContaining({ derivedThreadId: side.sourceThreadId }));
   });
@@ -97,13 +97,13 @@ describe("SideThreadService", () => {
     expect(service.get(side.id)?.state).toBe("completed");
   });
 
-  test("terminal racing start return settles the same attempt once", async () => {
+  test("domain rejects unbound terminal racing start return", async () => {
     const adapter = new FakeAdapter(); adapter.terminalDuringStart = true;
     const service = new SideThreadService({ adapter, id: ids() });
     const side = await service.create(createInput);
     const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-fast", prompt: "fast" });
-    expect(attempt).toMatchObject({ state: "completed", result: "fast" });
-    expect(service.get(side.id)).toMatchObject({ state: "completed", activeAttemptId: undefined });
+    expect(attempt).toMatchObject({ state: "running" });
+    expect(service.get(side.id)).toMatchObject({ state: "running", activeAttemptId: attempt.id });
   });
 
   test("archive is idempotent, purge is owned and refuses running turns", async () => {
@@ -133,8 +133,30 @@ describe("SideThreadService", () => {
     const adapter = new FakeAdapter();
     const service = new SideThreadService({ adapter, id: ids() });
     expect(adapter.listenerCount("terminal")).toBe(1);
-    service.close(); service.close();
+    await service.close(); await service.close();
     expect(adapter.listenerCount("terminal")).toBe(0);
     await expect(service.create(createInput)).rejects.toThrow("service is closed");
+  });
+
+  test("rejects duplicate fork ownership, capability drift, and unsafe identities", async () => {
+    const adapter = new FakeAdapter();
+    adapter.fork = async () => ({ derivedThreadId: "same-derived" });
+    const service = new SideThreadService({ adapter, id: ids() });
+    await service.create(createInput);
+    await expect(service.create({ ...createInput, requestKey: "create-key-0002" })).rejects.toThrow("already owned");
+    adapter.cap.evidenceRevision = "drifted";
+    await expect(service.startAttempt({ sideThreadId: "id-1", requestKey: "attempt-key-drift", prompt: "q" }))
+      .rejects.toBeInstanceOf(SideThreadUnsupportedError);
+    await expect(new SideThreadService({ adapter, id: ids() }).create({ ...createInput, sourceThreadId: "Bearer FAKE" }))
+      .rejects.toThrow("invalid sourceThreadId");
+  });
+
+  test("audit sink failures cannot orphan or duplicate a fork", async () => {
+    const adapter = new FakeAdapter();
+    const service = new SideThreadService({ adapter, id: ids(), audit: () => { throw new Error("sink down"); } });
+    const first = await service.create(createInput);
+    const retry = await service.create(createInput);
+    expect(retry.id).toBe(first.id);
+    expect(adapter.forks).toBe(1);
   });
 });

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -159,4 +159,14 @@ describe("SideThreadService", () => {
     expect(retry.id).toBe(first.id);
     expect(adapter.forks).toBe(1);
   });
+
+  test("capability flip after fork fails create and compensates derived thread", async () => {
+    const adapter = new FakeAdapter(); let discarded = 0;
+    adapter.fork = async (input) => { adapter.cap.supported = false; adapter.cap.reason = "version"; return { derivedThreadId: `derived-${input.sideThreadId}` }; };
+    adapter.discardFork = async () => { discarded++; };
+    const service = new SideThreadService({ adapter, id: ids() });
+    await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadUnsupportedError);
+    expect(discarded).toBe(1);
+    expect(service.get("id-1")).toBeUndefined();
+  });
 });

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -6,7 +6,11 @@ import {
 } from "./domain";
 
 class FakeAdapter extends EventEmitter implements SideThreadRuntimeAdapter {
-  cap: SideThreadCapability = { supported: true, runtime: "fake", runtimeVersion: "1", mode: "native-exact-fork", exactBoundary: { through: true, before: true } };
+  cap: SideThreadCapability = {
+    supported: true, runtime: "fake", runtimeVersion: "1", topology: "test",
+    evidenceRevision: "fixture", mode: "native-exact-fork",
+    exactBoundary: { through: true, before: true },
+  };
   forks = 0; starts = 0; cancels: unknown[] = []; archives = 0; deletes = 0;
   terminalDuringStart = false;
   capability() { return this.cap; }
@@ -33,7 +37,7 @@ const createInput = { requestKey: "create-key-0001", nodeId: "node-1", sourceThr
 describe("SideThreadService", () => {
   test("fails closed before fork for unsupported capability", async () => {
     const adapter = new FakeAdapter();
-    adapter.cap = { supported: false, runtime: "claude", runtimeVersion: "x", reason: "runtime" };
+    adapter.cap = { supported: false, runtime: "claude", runtimeVersion: "x", topology: "none", evidenceRevision: "none", reason: "runtime" };
     const service = new SideThreadService({ adapter, id: ids() });
     await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadUnsupportedError);
     expect(adapter.forks).toBe(0);

--- a/agent-node/src/runtime/side-thread/domain.test.ts
+++ b/agent-node/src/runtime/side-thread/domain.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import {
   SideThreadConflictError, SideThreadService, SideThreadUnsupportedError,
+  SideThreadAmbiguousError,
   type SideThreadCapability, type SideThreadRuntimeAdapter, type SideThreadTerminalEvent,
 } from "./domain";
 
@@ -13,10 +14,17 @@ class FakeAdapter extends EventEmitter implements SideThreadRuntimeAdapter {
   };
   forks = 0; starts = 0; cancels: unknown[] = []; archives = 0; deletes = 0;
   terminalDuringStart = false;
+  ambiguousForks = 0; ambiguousStarts = 0; forkSideIds: string[] = []; startAttemptIds: string[] = [];
   capability() { return this.cap; }
-  async fork(input: { sideThreadId: string }) { this.forks++; return { derivedThreadId: `derived-${input.sideThreadId}` }; }
+  async fork(input: { sideThreadId: string }) {
+    this.forks++; this.forkSideIds.push(input.sideThreadId);
+    if (this.ambiguousForks-- > 0) throw new SideThreadAmbiguousError("fork ambiguous");
+    return { derivedThreadId: `derived-${input.sideThreadId}` };
+  }
   async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string }) {
     this.starts++;
+    this.startAttemptIds.push(input.attemptId);
+    if (this.ambiguousStarts-- > 0) throw new SideThreadAmbiguousError("start ambiguous");
     const turnId = `turn-${input.attemptId}`;
     if (this.terminalDuringStart) this.terminal({
       sideThreadId: input.sideThreadId, attemptId: input.attemptId,
@@ -77,7 +85,7 @@ describe("SideThreadService", () => {
     const side = await service.create(createInput);
     const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-0002", prompt: "question" });
     await Promise.all([service.cancel(side.id), service.cancel(side.id)]);
-    expect(adapter.cancels).toEqual([{ derivedThreadId: side.derivedThreadId, turnId: attempt.turnId }]);
+    expect(adapter.cancels).toEqual([expect.objectContaining({ derivedThreadId: side.derivedThreadId, turnId: attempt.turnId })]);
     expect(adapter.cancels).not.toContainEqual(expect.objectContaining({ derivedThreadId: side.sourceThreadId }));
   });
 
@@ -168,5 +176,19 @@ describe("SideThreadService", () => {
     await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadUnsupportedError);
     expect(discarded).toBe(1);
     expect(service.get("id-1")).toBeUndefined();
+  });
+
+  test("ambiguous create and start retries reuse stable side/attempt operation identities", async () => {
+    const adapter = new FakeAdapter(); adapter.ambiguousForks = 1;
+    const service = new SideThreadService({ adapter, id: ids() });
+    await expect(service.create(createInput)).rejects.toBeInstanceOf(SideThreadAmbiguousError);
+    const side = await service.create(createInput);
+    expect(adapter.forkSideIds).toEqual([side.id, side.id]);
+    adapter.ambiguousStarts = 1;
+    await expect(service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-stable", prompt: "q" }))
+      .rejects.toBeInstanceOf(SideThreadAmbiguousError);
+    const attempt = await service.startAttempt({ sideThreadId: side.id, requestKey: "attempt-key-stable", prompt: "q" });
+    expect(adapter.startAttemptIds).toEqual([attempt.id, attempt.id]);
+    expect(service.get(side.id)?.attempts).toHaveLength(1);
   });
 });

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -96,6 +96,8 @@ export interface SideThreadRuntimeAdapter {
   archive(input: { derivedThreadId: string }): Promise<void>;
   delete(input: { derivedThreadId: string }): Promise<void>;
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void;
+  subscribeDropped?(listener: (reason: string) => void): () => void;
+  close?(): void;
 }
 
 export type SideThreadAuditAction =
@@ -124,7 +126,7 @@ export interface SideThreadAuditEntry {
 
 export interface SideThreadServiceOptions {
   adapter: SideThreadRuntimeAdapter;
-  audit?: (entry: SideThreadAuditEntry) => void;
+  audit?: (entry: SideThreadAuditEntry) => void | Promise<void>;
   now?: () => number;
   id?: () => string;
 }
@@ -138,6 +140,10 @@ export class SideThreadService {
   private readonly createByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadRecord> }>();
   private readonly attemptByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadAttempt> }>();
   private readonly unsubscribe: () => void;
+  private readonly unsubscribeDropped: () => void;
+  private readonly locks = new Map<string, Promise<void>>();
+  private readonly pending = new Set<Promise<unknown>>();
+  private readonly cancelRequested = new Set<string>();
   private closed = false;
   private readonly now: () => number;
   private readonly id: () => string;
@@ -146,12 +152,16 @@ export class SideThreadService {
     this.now = opts.now ?? Date.now;
     this.id = opts.id ?? randomUUID;
     this.unsubscribe = opts.adapter.subscribe((event) => this.onTerminal(event));
+    this.unsubscribeDropped = opts.adapter.subscribeDropped?.((reason) => this.auditDropped(reason)) ?? (() => {});
   }
 
-  close(): void {
+  async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
     this.unsubscribe();
+    this.unsubscribeDropped();
+    this.opts.adapter.close?.();
+    await Promise.allSettled([...this.pending]);
   }
 
   capability(): SideThreadCapability { return this.opts.adapter.capability(); }
@@ -200,8 +210,12 @@ export class SideThreadService {
       sideThreadId, sourceThreadId: input.sourceThreadId, boundary: input.boundary,
     });
     requireIdentity(forked.derivedThreadId, "derivedThreadId");
+    this.assertOpen();
     if (forked.derivedThreadId === input.sourceThreadId) {
       throw new SideThreadConflictError("runtime returned the source thread as the derived thread");
+    }
+    if ([...this.records.values()].some((record) => record.derivedThreadId === forked.derivedThreadId)) {
+      throw new SideThreadConflictError("runtime returned a derived thread already owned by another side thread");
     }
     const record: SideThreadRecord = {
       id: sideThreadId, requestKey: input.requestKey, nodeId: input.nodeId,
@@ -237,7 +251,9 @@ export class SideThreadService {
   }
 
   private async startOnce(input: { sideThreadId: string; requestKey: string; prompt: string }): Promise<SideThreadAttempt> {
+    return this.withLock(input.sideThreadId, async () => {
     const record = this.mustGet(input.sideThreadId);
+    this.assertAttestation(record);
     if (record.state === "archived" || record.state === "purged") {
       throw new SideThreadConflictError(`cannot start attempt from ${record.state}`);
     }
@@ -253,6 +269,8 @@ export class SideThreadService {
         sideThreadId: record.id, attemptId: attempt.id,
         derivedThreadId: record.derivedThreadId, prompt: input.prompt,
       });
+      this.assertOpen();
+      this.assertAttestation(record);
       requireIdentity(started.turnId, "turnId");
       if (attempt.turnId && attempt.turnId !== started.turnId) {
         throw new SideThreadConflictError("runtime attempt identity changed during start");
@@ -263,44 +281,63 @@ export class SideThreadService {
       this.audit(record, "attempt_started", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
       return attempt;
     } catch (error) {
-      attempt.state = "failed";
-      attempt.error = safeError(error);
-      record.activeAttemptId = undefined;
-      record.state = "failed";
+      if (attempt.state === "starting" || attempt.state === "running") {
+        attempt.state = "failed";
+        attempt.error = safeError(error);
+        record.activeAttemptId = undefined;
+        record.state = "failed";
+      }
       throw error;
     }
+    });
   }
 
   async cancel(sideThreadId: string): Promise<void> {
     this.assertOpen();
+    return this.withLock(sideThreadId, async () => {
     const record = this.mustGet(sideThreadId);
+    this.assertAttestation(record);
     const attempt = record.attempts.find((a) => a.id === record.activeAttemptId);
     if (!attempt?.turnId || attempt.state !== "running") {
       throw new SideThreadConflictError("side thread has no cancellable turn");
     }
+    if (this.cancelRequested.has(attempt.id)) return;
+    this.cancelRequested.add(attempt.id);
     this.audit(record, "cancel_requested", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
-    await this.opts.adapter.cancel({ derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
+    try { await this.opts.adapter.cancel({ derivedThreadId: record.derivedThreadId, turnId: attempt.turnId }); }
+    catch (error) { this.cancelRequested.delete(attempt.id); throw error; }
+    this.assertOpen();
+    });
   }
 
   async archive(sideThreadId: string): Promise<void> {
     this.assertOpen();
+    return this.withLock(sideThreadId, async () => {
     const record = this.mustGet(sideThreadId);
+    this.assertAttestation(record);
     if (record.activeAttemptId) throw new SideThreadConflictError("cannot archive a running side thread");
     if (record.state === "purged") throw new SideThreadConflictError("cannot archive a purged side thread");
     if (record.state === "archived") return;
     await this.opts.adapter.archive({ derivedThreadId: record.derivedThreadId });
+    this.assertOpen();
+    if (record.state === "purged") throw new SideThreadConflictError("purge won archive race");
     record.state = "archived";
     this.audit(record, "archived", { derivedThreadId: record.derivedThreadId });
+    });
   }
 
   async purge(sideThreadId: string): Promise<void> {
     this.assertOpen();
+    return this.withLock(sideThreadId, async () => {
     const record = this.mustGet(sideThreadId);
+    this.assertAttestation(record);
     if (record.activeAttemptId) throw new SideThreadConflictError("cannot purge a running side thread");
     if (record.state === "purged") return;
     await this.opts.adapter.delete({ derivedThreadId: record.derivedThreadId });
+    this.assertOpen();
     record.state = "purged";
     this.audit(record, "purged", { derivedThreadId: record.derivedThreadId });
+    });
   }
 
   get(sideThreadId: string): SideThreadRecord | undefined {
@@ -311,11 +348,10 @@ export class SideThreadService {
   private onTerminal(event: SideThreadTerminalEvent): void {
     const record = this.records.get(event.sideThreadId);
     const attempt = record?.attempts.find((a) => a.id === event.attemptId);
-    const startingIdentity = attempt?.state === "starting" && !attempt.turnId;
     const owned = !!record && !!attempt && record.derivedThreadId === event.threadId
-      && (attempt.turnId === event.turnId || startingIdentity)
+      && attempt.turnId === event.turnId
       && record.activeAttemptId === attempt.id
-      && (attempt.state === "running" || startingIdentity);
+      && attempt.state === "running";
     if (!owned) {
       this.opts.audit?.({
         action: "event_dropped", sideThreadId: event.sideThreadId,
@@ -333,6 +369,7 @@ export class SideThreadService {
     attempt!.result = event.status === "completed" ? event.text : undefined;
     attempt!.error = event.status === "failed" ? safeText(event.error) : undefined;
     record!.activeAttemptId = undefined;
+    this.cancelRequested.delete(attempt!.id);
     record!.state = attempt!.state === "cancelled" ? "cancelled" : attempt!.state;
     this.audit(record!, "attempt_terminal", {
       attemptId: attempt!.id, derivedThreadId: record!.derivedThreadId,
@@ -350,15 +387,46 @@ export class SideThreadService {
     if (this.closed) throw new SideThreadConflictError("side thread service is closed");
   }
 
+  private assertAttestation(record: SideThreadRecord): void {
+    const cap = this.opts.adapter.capability();
+    if (!cap.supported || cap.mode !== "native-exact-fork" || cap.runtime !== record.runtime
+      || cap.runtimeVersion !== record.runtimeVersion || cap.topology !== record.topology
+      || cap.evidenceRevision !== record.evidenceRevision || !cap.exactBoundary?.[record.boundary.kind]) {
+      throw new SideThreadUnsupportedError(cap.reason ?? "exact-boundary", "immutable capability attestation no longer matches");
+    }
+  }
+
+  private withLock<T>(sideThreadId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.locks.get(sideThreadId) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => { release = resolve; });
+    const tail = previous.then(() => next);
+    this.locks.set(sideThreadId, tail);
+    const running = previous.then(() => { this.assertOpen(); return operation(); })
+      .finally(() => { release(); if (this.locks.get(sideThreadId) === tail) this.locks.delete(sideThreadId); });
+    this.pending.add(running);
+    void running.then(() => this.pending.delete(running), () => this.pending.delete(running));
+    return running;
+  }
+
+  private auditDropped(reason: string): void {
+    this.emitAudit({ action: "event_dropped", sideThreadId: "unowned", runtime: this.opts.adapter.capability().runtime,
+      runtimeVersion: this.opts.adapter.capability().runtimeVersion, topology: this.opts.adapter.capability().topology,
+      evidenceRevision: this.opts.adapter.capability().evidenceRevision, reason: safeText(reason), at: this.now() });
+  }
+
   private audit(record: SideThreadRecord, action: SideThreadAuditAction, extra: Partial<SideThreadAuditEntry>): void {
-    this.opts.audit?.({ action, sideThreadId: record.id, runtime: record.runtime,
+    this.emitAudit({ action, sideThreadId: record.id, runtime: record.runtime,
       runtimeVersion: record.runtimeVersion, topology: record.topology,
-      evidenceRevision: record.evidenceRevision, at: this.now(), ...extra });
+      evidenceRevision: record.evidenceRevision, at: this.now(), ...redactAudit(extra) });
+  }
+  private emitAudit(entry: SideThreadAuditEntry): void {
+    try { void Promise.resolve(this.opts.audit?.(entry)).catch(() => {}); } catch { /* audit is non-throwing */ }
   }
 }
 
 function requireIdentity(value: string, label: string): void {
-  if (!value || value.length > 512 || /[\r\n\0]/.test(value)) throw new SideThreadConflictError(`invalid ${label}`);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value)) throw new SideThreadConflictError(`invalid ${label}`);
 }
 function requireIdempotencyKey(value: string): void {
   if (!/^[A-Za-z0-9._:-]{8,160}$/.test(value)) throw new SideThreadConflictError("invalid idempotency key");
@@ -372,4 +440,13 @@ function cloneAttempt(value: SideThreadAttempt): SideThreadAttempt { return { ..
 function cloneRecord(value: SideThreadRecord): SideThreadRecord {
   return { ...value, boundary: { ...value.boundary }, attempts: value.attempts.map(cloneAttempt) };
 }
+function auditHash(value: string): string { return `sha256:${createHash("sha256").update(value).digest("hex").slice(0, 24)}`; }
+function redactAudit(extra: Partial<SideThreadAuditEntry>): Partial<SideThreadAuditEntry> {
+  const copy = { ...extra };
+  for (const key of ["sourceThreadId", "derivedThreadId", "turnId"] as const) {
+    if (copy[key]) copy[key] = auditHash(copy[key]!);
+  }
+  return copy;
+}
 import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -41,6 +41,10 @@ export class SideThreadConflictError extends Error {
   readonly code = "SIDE_THREAD_CONFLICT";
   constructor(message: string) { super(message); this.name = "SideThreadConflictError"; }
 }
+export class SideThreadAmbiguousError extends Error {
+  readonly code = "SIDE_THREAD_AMBIGUOUS";
+  constructor(message: string) { super(message); this.name = "SideThreadAmbiguousError"; }
+}
 
 export interface SideThreadRecord {
   id: string;
@@ -63,7 +67,7 @@ export interface SideThreadAttempt {
   id: string;
   requestKey: string;
   turnId?: string;
-  state: "starting" | "running" | "completed" | "failed" | "cancelled";
+  state: "starting" | "running" | "ambiguous" | "completed" | "failed" | "cancelled";
   result?: string;
   error?: string;
   createdAt: number;
@@ -98,6 +102,7 @@ export interface SideThreadRuntimeAdapter {
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void;
   subscribeDropped?(listener: (reason: string) => void): () => void;
   close?(): void;
+  discardFork?(input: { sideThreadId: string; derivedThreadId: string }): Promise<void>;
 }
 
 export type SideThreadAuditAction =
@@ -211,6 +216,11 @@ export class SideThreadService {
     });
     requireIdentity(forked.derivedThreadId, "derivedThreadId");
     this.assertOpen();
+    try { this.assertCapability(capability, input.boundary.kind); }
+    catch (error) {
+      await this.opts.adapter.discardFork?.({ sideThreadId, derivedThreadId: forked.derivedThreadId }).catch(() => {});
+      throw error;
+    }
     if (forked.derivedThreadId === input.sourceThreadId) {
       throw new SideThreadConflictError("runtime returned the source thread as the derived thread");
     }
@@ -247,7 +257,7 @@ export class SideThreadService {
     const operation = this.startOnce(input);
     this.attemptByKey.set(key, { fingerprint, operation });
     try { return cloneAttempt(await operation); }
-    catch (error) { this.attemptByKey.delete(key); throw error; }
+    catch (error) { if (!(error instanceof SideThreadAmbiguousError)) this.attemptByKey.delete(key); throw error; }
   }
 
   private async startOnce(input: { sideThreadId: string; requestKey: string; prompt: string }): Promise<SideThreadAttempt> {
@@ -281,6 +291,12 @@ export class SideThreadService {
       this.audit(record, "attempt_started", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
       return attempt;
     } catch (error) {
+      if (error instanceof SideThreadAmbiguousError) {
+        attempt.state = "ambiguous";
+        attempt.error = safeError(error);
+        record.state = "running";
+        throw error;
+      }
       if (attempt.state === "starting" || attempt.state === "running") {
         attempt.state = "failed";
         attempt.error = safeError(error);
@@ -353,14 +369,14 @@ export class SideThreadService {
       && record.activeAttemptId === attempt.id
       && attempt.state === "running";
     if (!owned) {
-      this.opts.audit?.({
+      this.emitAudit(redactAudit({
         action: "event_dropped", sideThreadId: event.sideThreadId,
         attemptId: event.attemptId, runtime: this.opts.adapter.capability().runtime,
         runtimeVersion: this.opts.adapter.capability().runtimeVersion,
         topology: this.opts.adapter.capability().topology,
         evidenceRevision: this.opts.adapter.capability().evidenceRevision,
         reason: "ownership-mismatch", at: this.now(),
-      });
+      }) as SideThreadAuditEntry);
       return;
     }
     if (!attempt!.turnId) attempt!.turnId = event.turnId;
@@ -393,6 +409,14 @@ export class SideThreadService {
       || cap.runtimeVersion !== record.runtimeVersion || cap.topology !== record.topology
       || cap.evidenceRevision !== record.evidenceRevision || !cap.exactBoundary?.[record.boundary.kind]) {
       throw new SideThreadUnsupportedError(cap.reason ?? "exact-boundary", "immutable capability attestation no longer matches");
+    }
+  }
+  private assertCapability(expected: SideThreadCapability, boundary: ExactBoundary["kind"]): void {
+    const fresh = this.opts.adapter.capability();
+    if (!fresh.supported || fresh.mode !== "native-exact-fork" || !fresh.exactBoundary?.[boundary]
+      || fresh.runtime !== expected.runtime || fresh.runtimeVersion !== expected.runtimeVersion
+      || fresh.topology !== expected.topology || fresh.evidenceRevision !== expected.evidenceRevision) {
+      throw new SideThreadUnsupportedError(fresh.reason ?? "exact-boundary", "capability changed while creating side thread");
     }
   }
 

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -1,3 +1,6 @@
+import { createHash, randomUUID } from "node:crypto";
+import { stableOperationId, type OperationMethod } from "./operation-ledger";
+
 export type SideThreadState =
   | "ready"
   | "running"
@@ -85,22 +88,30 @@ export interface SideThreadTerminalEvent {
   identityBound?: boolean;
 }
 
+export interface SideThreadRuntimeOperation {
+  nodeId: string;
+  operationId: string;
+  idempotencyKey: string;
+}
+
 export interface SideThreadRuntimeAdapter {
   capability(): SideThreadCapability;
   fork(input: {
     sideThreadId: string;
     sourceThreadId: string;
     boundary: ExactBoundary;
+    operation: SideThreadRuntimeOperation;
   }): Promise<{ derivedThreadId: string }>;
   start(input: {
     sideThreadId: string;
     attemptId: string;
     derivedThreadId: string;
     prompt: string;
+    operation: SideThreadRuntimeOperation;
   }): Promise<{ turnId: string }>;
-  cancel(input: { derivedThreadId: string; turnId: string }): Promise<void>;
-  archive(input: { derivedThreadId: string }): Promise<void>;
-  delete(input: { derivedThreadId: string }): Promise<void>;
+  cancel(input: { sideThreadId: string; derivedThreadId: string; turnId: string; operation: SideThreadRuntimeOperation }): Promise<void>;
+  archive(input: { sideThreadId: string; derivedThreadId: string; operation: SideThreadRuntimeOperation }): Promise<void>;
+  delete(input: { sideThreadId: string; derivedThreadId: string; operation: SideThreadRuntimeOperation }): Promise<void>;
   subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void;
   subscribeDropped?(listener: (reason: string) => void): () => void;
   close?(): void;
@@ -144,7 +155,8 @@ export interface SideThreadServiceOptions {
  */
 export class SideThreadService {
   private readonly records = new Map<string, SideThreadRecord>();
-  private readonly createByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadRecord> }>();
+  private readonly createByKey = new Map<string, { fingerprint: string; sideThreadId: string; operation: Promise<SideThreadRecord> }>();
+  private readonly createIdentityByKey = new Map<string, { fingerprint: string; sideThreadId: string }>();
   private readonly attemptByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadAttempt> }>();
   private readonly unsubscribe: () => void;
   private readonly unsubscribeDropped: () => void;
@@ -185,20 +197,28 @@ export class SideThreadService {
     requireIdentity(input.sourceThreadId, "sourceThreadId");
     requireIdentity(input.boundary.turnId, "boundary.turnId");
     const fingerprint = JSON.stringify([input.nodeId, input.sourceThreadId, input.boundary.kind, input.boundary.turnId]);
+    const identity = this.createIdentityByKey.get(input.requestKey);
+    if (identity && identity.fingerprint !== fingerprint) throw new SideThreadConflictError("idempotency key reused with different create input");
     const existing = this.createByKey.get(input.requestKey);
     if (existing) {
       if (existing.fingerprint !== fingerprint) throw new SideThreadConflictError("idempotency key reused with different create input");
       return cloneRecord(await existing.operation);
     }
-    const operation = this.createOnce(input);
-    this.createByKey.set(input.requestKey, { fingerprint, operation });
+    const sideThreadId = identity?.sideThreadId ?? this.id();
+    this.createIdentityByKey.set(input.requestKey, { fingerprint, sideThreadId });
+    const operation = this.createOnce(input, sideThreadId);
+    this.createByKey.set(input.requestKey, { fingerprint, sideThreadId, operation });
     try { return cloneRecord(await operation); }
-    catch (error) { this.createByKey.delete(input.requestKey); throw error; }
+    catch (error) {
+      this.createByKey.delete(input.requestKey);
+      if (!(error instanceof SideThreadAmbiguousError)) this.createIdentityByKey.delete(input.requestKey);
+      throw error;
+    }
   }
 
   private async createOnce(input: {
     requestKey: string; nodeId: string; sourceThreadId: string; boundary: ExactBoundary;
-  }): Promise<SideThreadRecord> {
+  }, sideThreadId: string): Promise<SideThreadRecord> {
     const capability = this.opts.adapter.capability();
     if (!capability.supported || capability.mode !== "native-exact-fork") {
       throw new SideThreadUnsupportedError(
@@ -212,9 +232,9 @@ export class SideThreadService {
         `side thread boundary '${input.boundary.kind}' is unsupported`,
       );
     }
-    const sideThreadId = this.id();
     const forked = await this.opts.adapter.fork({
       sideThreadId, sourceThreadId: input.sourceThreadId, boundary: input.boundary,
+      operation: runtimeOperation(input.nodeId, sideThreadId, "fork", input.requestKey),
     });
     requireIdentity(forked.derivedThreadId, "derivedThreadId");
     this.assertOpen();
@@ -259,7 +279,7 @@ export class SideThreadService {
     const operation = this.startOnce(input);
     this.attemptByKey.set(key, { fingerprint, operation });
     try { return cloneAttempt(await operation); }
-    catch (error) { if (!(error instanceof SideThreadAmbiguousError)) this.attemptByKey.delete(key); throw error; }
+    catch (error) { this.attemptByKey.delete(key); throw error; }
   }
 
   private async startOnce(input: { sideThreadId: string; requestKey: string; prompt: string }): Promise<SideThreadAttempt> {
@@ -269,17 +289,21 @@ export class SideThreadService {
     if (record.state === "archived" || record.state === "purged") {
       throw new SideThreadConflictError(`cannot start attempt from ${record.state}`);
     }
-    if (record.activeAttemptId) throw new SideThreadConflictError("side thread already has an active attempt");
-    const attempt: SideThreadAttempt = {
+    const active = record.attempts.find((candidate) => candidate.id === record.activeAttemptId);
+    if (active && (active.requestKey !== input.requestKey || active.state !== "ambiguous")) {
+      throw new SideThreadConflictError("side thread already has an active attempt");
+    }
+    const attempt: SideThreadAttempt = active ?? {
       id: this.id(), requestKey: input.requestKey, state: "starting", createdAt: this.now(),
     };
-    record.attempts.push(attempt);
-    record.activeAttemptId = attempt.id;
+    if (!active) { record.attempts.push(attempt); record.activeAttemptId = attempt.id; }
+    else { attempt.state = "starting"; attempt.error = undefined; }
     record.state = "running";
     try {
       const started = await this.opts.adapter.start({
         sideThreadId: record.id, attemptId: attempt.id,
         derivedThreadId: record.derivedThreadId, prompt: input.prompt,
+        operation: runtimeOperation(record.nodeId, record.id, "start", input.requestKey),
       });
       this.assertOpen();
       this.assertAttestation(record);
@@ -322,7 +346,9 @@ export class SideThreadService {
     if (this.cancelRequested.has(attempt.id)) return;
     this.cancelRequested.add(attempt.id);
     this.audit(record, "cancel_requested", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
-    try { await this.opts.adapter.cancel({ derivedThreadId: record.derivedThreadId, turnId: attempt.turnId }); }
+    const idempotencyKey = `cancel-${attempt.id}`;
+    try { await this.opts.adapter.cancel({ sideThreadId: record.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId,
+      operation: runtimeOperation(record.nodeId, record.id, "interrupt", idempotencyKey) }); }
     catch (error) { this.cancelRequested.delete(attempt.id); throw error; }
     this.assertOpen();
     });
@@ -336,7 +362,8 @@ export class SideThreadService {
     if (record.activeAttemptId) throw new SideThreadConflictError("cannot archive a running side thread");
     if (record.state === "purged") throw new SideThreadConflictError("cannot archive a purged side thread");
     if (record.state === "archived") return;
-    await this.opts.adapter.archive({ derivedThreadId: record.derivedThreadId });
+    await this.opts.adapter.archive({ sideThreadId: record.id, derivedThreadId: record.derivedThreadId,
+      operation: runtimeOperation(record.nodeId, record.id, "archive", `archive-${record.id}`) });
     this.assertOpen();
     if (record.state === "purged") throw new SideThreadConflictError("purge won archive race");
     record.state = "archived";
@@ -351,7 +378,8 @@ export class SideThreadService {
     this.assertAttestation(record);
     if (record.activeAttemptId) throw new SideThreadConflictError("cannot purge a running side thread");
     if (record.state === "purged") return;
-    await this.opts.adapter.delete({ derivedThreadId: record.derivedThreadId });
+    await this.opts.adapter.delete({ sideThreadId: record.id, derivedThreadId: record.derivedThreadId,
+      operation: runtimeOperation(record.nodeId, record.id, "delete", `purge-${record.id}`) });
     this.assertOpen();
     record.state = "purged";
     this.audit(record, "purged", { derivedThreadId: record.derivedThreadId });
@@ -476,5 +504,6 @@ function redactAudit(extra: Partial<SideThreadAuditEntry>): Partial<SideThreadAu
   }
   return copy;
 }
-import { randomUUID } from "node:crypto";
-import { createHash, randomUUID } from "node:crypto";
+function runtimeOperation(nodeId: string, sideThreadId: string, method: OperationMethod, idempotencyKey: string): SideThreadRuntimeOperation {
+  return { nodeId, operationId: stableOperationId(sideThreadId, method, idempotencyKey), idempotencyKey };
+}

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -15,6 +15,8 @@ export interface SideThreadCapability {
   supported: boolean;
   runtime: string;
   runtimeVersion: string;
+  topology: string;
+  evidenceRevision: string;
   mode?: "native-exact-fork";
   exactBoundary?: { through: boolean; before: boolean };
   reason?: SideThreadUnsupportedReason;
@@ -49,6 +51,8 @@ export interface SideThreadRecord {
   boundary: ExactBoundary;
   runtime: string;
   runtimeVersion: string;
+  topology: string;
+  evidenceRevision: string;
   state: SideThreadState;
   activeAttemptId?: string;
   attempts: SideThreadAttempt[];
@@ -109,6 +113,8 @@ export interface SideThreadAuditEntry {
   attemptId?: string;
   runtime: string;
   runtimeVersion: string;
+  topology: string;
+  evidenceRevision: string;
   sourceThreadId?: string;
   derivedThreadId?: string;
   turnId?: string;
@@ -201,7 +207,9 @@ export class SideThreadService {
       id: sideThreadId, requestKey: input.requestKey, nodeId: input.nodeId,
       sourceThreadId: input.sourceThreadId, derivedThreadId: forked.derivedThreadId,
       boundary: input.boundary, runtime: capability.runtime,
-      runtimeVersion: capability.runtimeVersion, state: "ready", attempts: [],
+      runtimeVersion: capability.runtimeVersion, topology: capability.topology,
+      evidenceRevision: capability.evidenceRevision,
+      state: "ready", attempts: [],
       createdAt: this.now(),
     };
     this.records.set(record.id, record);
@@ -313,6 +321,8 @@ export class SideThreadService {
         action: "event_dropped", sideThreadId: event.sideThreadId,
         attemptId: event.attemptId, runtime: this.opts.adapter.capability().runtime,
         runtimeVersion: this.opts.adapter.capability().runtimeVersion,
+        topology: this.opts.adapter.capability().topology,
+        evidenceRevision: this.opts.adapter.capability().evidenceRevision,
         reason: "ownership-mismatch", at: this.now(),
       });
       return;
@@ -342,7 +352,8 @@ export class SideThreadService {
 
   private audit(record: SideThreadRecord, action: SideThreadAuditAction, extra: Partial<SideThreadAuditEntry>): void {
     this.opts.audit?.({ action, sideThreadId: record.id, runtime: record.runtime,
-      runtimeVersion: record.runtimeVersion, at: this.now(), ...extra });
+      runtimeVersion: record.runtimeVersion, topology: record.topology,
+      evidenceRevision: record.evidenceRevision, at: this.now(), ...extra });
   }
 }
 

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -1,0 +1,364 @@
+export type SideThreadState =
+  | "ready"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "archived"
+  | "purged";
+
+export type ExactBoundary =
+  | { kind: "through"; turnId: string }
+  | { kind: "before"; turnId: string };
+
+export interface SideThreadCapability {
+  supported: boolean;
+  runtime: string;
+  runtimeVersion: string;
+  mode?: "native-exact-fork";
+  exactBoundary?: { through: boolean; before: boolean };
+  reason?: SideThreadUnsupportedReason;
+}
+
+export type SideThreadUnsupportedReason =
+  | "runtime"
+  | "version"
+  | "topology"
+  | "experimental-api"
+  | "exact-boundary";
+
+export class SideThreadUnsupportedError extends Error {
+  readonly code = "SIDE_THREAD_UNSUPPORTED";
+  constructor(readonly reason: SideThreadUnsupportedReason, message: string) {
+    super(message);
+    this.name = "SideThreadUnsupportedError";
+  }
+}
+
+export class SideThreadConflictError extends Error {
+  readonly code = "SIDE_THREAD_CONFLICT";
+  constructor(message: string) { super(message); this.name = "SideThreadConflictError"; }
+}
+
+export interface SideThreadRecord {
+  id: string;
+  requestKey: string;
+  nodeId: string;
+  sourceThreadId: string;
+  derivedThreadId: string;
+  boundary: ExactBoundary;
+  runtime: string;
+  runtimeVersion: string;
+  state: SideThreadState;
+  activeAttemptId?: string;
+  attempts: SideThreadAttempt[];
+  createdAt: number;
+}
+
+export interface SideThreadAttempt {
+  id: string;
+  requestKey: string;
+  turnId?: string;
+  state: "starting" | "running" | "completed" | "failed" | "cancelled";
+  result?: string;
+  error?: string;
+  createdAt: number;
+}
+
+export interface SideThreadTerminalEvent {
+  sideThreadId: string;
+  attemptId: string;
+  threadId: string;
+  turnId: string;
+  status: "completed" | "failed" | "interrupted";
+  text?: string;
+  error?: string;
+}
+
+export interface SideThreadRuntimeAdapter {
+  capability(): SideThreadCapability;
+  fork(input: {
+    sideThreadId: string;
+    sourceThreadId: string;
+    boundary: ExactBoundary;
+  }): Promise<{ derivedThreadId: string }>;
+  start(input: {
+    sideThreadId: string;
+    attemptId: string;
+    derivedThreadId: string;
+    prompt: string;
+  }): Promise<{ turnId: string }>;
+  cancel(input: { derivedThreadId: string; turnId: string }): Promise<void>;
+  archive(input: { derivedThreadId: string }): Promise<void>;
+  delete(input: { derivedThreadId: string }): Promise<void>;
+  subscribe(listener: (event: SideThreadTerminalEvent) => void): () => void;
+}
+
+export type SideThreadAuditAction =
+  | "created"
+  | "attempt_started"
+  | "attempt_terminal"
+  | "cancel_requested"
+  | "archived"
+  | "purged"
+  | "event_dropped";
+
+export interface SideThreadAuditEntry {
+  action: SideThreadAuditAction;
+  sideThreadId: string;
+  attemptId?: string;
+  runtime: string;
+  runtimeVersion: string;
+  sourceThreadId?: string;
+  derivedThreadId?: string;
+  turnId?: string;
+  reason?: string;
+  at: number;
+}
+
+export interface SideThreadServiceOptions {
+  adapter: SideThreadRuntimeAdapter;
+  audit?: (entry: SideThreadAuditEntry) => void;
+  now?: () => number;
+  id?: () => string;
+}
+
+/**
+ * Runtime-neutral lifecycle owner. No Hub/App transport is wired in PR1.
+ * Returned records are snapshots so callers cannot mutate registry identity.
+ */
+export class SideThreadService {
+  private readonly records = new Map<string, SideThreadRecord>();
+  private readonly createByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadRecord> }>();
+  private readonly attemptByKey = new Map<string, { fingerprint: string; operation: Promise<SideThreadAttempt> }>();
+  private readonly unsubscribe: () => void;
+  private closed = false;
+  private readonly now: () => number;
+  private readonly id: () => string;
+
+  constructor(private readonly opts: SideThreadServiceOptions) {
+    this.now = opts.now ?? Date.now;
+    this.id = opts.id ?? randomUUID;
+    this.unsubscribe = opts.adapter.subscribe((event) => this.onTerminal(event));
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.unsubscribe();
+  }
+
+  capability(): SideThreadCapability { return this.opts.adapter.capability(); }
+
+  async create(input: {
+    requestKey: string;
+    nodeId: string;
+    sourceThreadId: string;
+    boundary: ExactBoundary;
+  }): Promise<SideThreadRecord> {
+    this.assertOpen();
+    requireIdempotencyKey(input.requestKey);
+    requireIdentity(input.nodeId, "nodeId");
+    requireIdentity(input.sourceThreadId, "sourceThreadId");
+    requireIdentity(input.boundary.turnId, "boundary.turnId");
+    const fingerprint = JSON.stringify([input.nodeId, input.sourceThreadId, input.boundary.kind, input.boundary.turnId]);
+    const existing = this.createByKey.get(input.requestKey);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) throw new SideThreadConflictError("idempotency key reused with different create input");
+      return cloneRecord(await existing.operation);
+    }
+    const operation = this.createOnce(input);
+    this.createByKey.set(input.requestKey, { fingerprint, operation });
+    try { return cloneRecord(await operation); }
+    catch (error) { this.createByKey.delete(input.requestKey); throw error; }
+  }
+
+  private async createOnce(input: {
+    requestKey: string; nodeId: string; sourceThreadId: string; boundary: ExactBoundary;
+  }): Promise<SideThreadRecord> {
+    const capability = this.opts.adapter.capability();
+    if (!capability.supported || capability.mode !== "native-exact-fork") {
+      throw new SideThreadUnsupportedError(
+        capability.reason ?? "exact-boundary",
+        `side thread unsupported: ${capability.reason ?? "native exact-boundary fork unavailable"}`,
+      );
+    }
+    if (!capability.exactBoundary?.[input.boundary.kind]) {
+      throw new SideThreadUnsupportedError(
+        input.boundary.kind === "before" ? "experimental-api" : "exact-boundary",
+        `side thread boundary '${input.boundary.kind}' is unsupported`,
+      );
+    }
+    const sideThreadId = this.id();
+    const forked = await this.opts.adapter.fork({
+      sideThreadId, sourceThreadId: input.sourceThreadId, boundary: input.boundary,
+    });
+    requireIdentity(forked.derivedThreadId, "derivedThreadId");
+    if (forked.derivedThreadId === input.sourceThreadId) {
+      throw new SideThreadConflictError("runtime returned the source thread as the derived thread");
+    }
+    const record: SideThreadRecord = {
+      id: sideThreadId, requestKey: input.requestKey, nodeId: input.nodeId,
+      sourceThreadId: input.sourceThreadId, derivedThreadId: forked.derivedThreadId,
+      boundary: input.boundary, runtime: capability.runtime,
+      runtimeVersion: capability.runtimeVersion, state: "ready", attempts: [],
+      createdAt: this.now(),
+    };
+    this.records.set(record.id, record);
+    this.audit(record, "created", { sourceThreadId: record.sourceThreadId, derivedThreadId: record.derivedThreadId });
+    return record;
+  }
+
+  async startAttempt(input: {
+    sideThreadId: string; requestKey: string; prompt: string;
+  }): Promise<SideThreadAttempt> {
+    this.assertOpen();
+    requireIdempotencyKey(input.requestKey);
+    if (!input.prompt.trim()) throw new SideThreadConflictError("prompt must not be empty");
+    const key = `${input.sideThreadId}\0${input.requestKey}`;
+    const fingerprint = JSON.stringify([input.sideThreadId, input.prompt]);
+    const existing = this.attemptByKey.get(key);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) throw new SideThreadConflictError("idempotency key reused with different attempt input");
+      return cloneAttempt(await existing.operation);
+    }
+    const operation = this.startOnce(input);
+    this.attemptByKey.set(key, { fingerprint, operation });
+    try { return cloneAttempt(await operation); }
+    catch (error) { this.attemptByKey.delete(key); throw error; }
+  }
+
+  private async startOnce(input: { sideThreadId: string; requestKey: string; prompt: string }): Promise<SideThreadAttempt> {
+    const record = this.mustGet(input.sideThreadId);
+    if (record.state === "archived" || record.state === "purged") {
+      throw new SideThreadConflictError(`cannot start attempt from ${record.state}`);
+    }
+    if (record.activeAttemptId) throw new SideThreadConflictError("side thread already has an active attempt");
+    const attempt: SideThreadAttempt = {
+      id: this.id(), requestKey: input.requestKey, state: "starting", createdAt: this.now(),
+    };
+    record.attempts.push(attempt);
+    record.activeAttemptId = attempt.id;
+    record.state = "running";
+    try {
+      const started = await this.opts.adapter.start({
+        sideThreadId: record.id, attemptId: attempt.id,
+        derivedThreadId: record.derivedThreadId, prompt: input.prompt,
+      });
+      requireIdentity(started.turnId, "turnId");
+      if (attempt.turnId && attempt.turnId !== started.turnId) {
+        throw new SideThreadConflictError("runtime attempt identity changed during start");
+      }
+      attempt.turnId = started.turnId;
+      if (attempt.state !== "starting") return attempt;
+      attempt.state = "running";
+      this.audit(record, "attempt_started", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
+      return attempt;
+    } catch (error) {
+      attempt.state = "failed";
+      attempt.error = safeError(error);
+      record.activeAttemptId = undefined;
+      record.state = "failed";
+      throw error;
+    }
+  }
+
+  async cancel(sideThreadId: string): Promise<void> {
+    this.assertOpen();
+    const record = this.mustGet(sideThreadId);
+    const attempt = record.attempts.find((a) => a.id === record.activeAttemptId);
+    if (!attempt?.turnId || attempt.state !== "running") {
+      throw new SideThreadConflictError("side thread has no cancellable turn");
+    }
+    this.audit(record, "cancel_requested", { attemptId: attempt.id, derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
+    await this.opts.adapter.cancel({ derivedThreadId: record.derivedThreadId, turnId: attempt.turnId });
+  }
+
+  async archive(sideThreadId: string): Promise<void> {
+    this.assertOpen();
+    const record = this.mustGet(sideThreadId);
+    if (record.activeAttemptId) throw new SideThreadConflictError("cannot archive a running side thread");
+    if (record.state === "purged") throw new SideThreadConflictError("cannot archive a purged side thread");
+    if (record.state === "archived") return;
+    await this.opts.adapter.archive({ derivedThreadId: record.derivedThreadId });
+    record.state = "archived";
+    this.audit(record, "archived", { derivedThreadId: record.derivedThreadId });
+  }
+
+  async purge(sideThreadId: string): Promise<void> {
+    this.assertOpen();
+    const record = this.mustGet(sideThreadId);
+    if (record.activeAttemptId) throw new SideThreadConflictError("cannot purge a running side thread");
+    if (record.state === "purged") return;
+    await this.opts.adapter.delete({ derivedThreadId: record.derivedThreadId });
+    record.state = "purged";
+    this.audit(record, "purged", { derivedThreadId: record.derivedThreadId });
+  }
+
+  get(sideThreadId: string): SideThreadRecord | undefined {
+    const record = this.records.get(sideThreadId);
+    return record ? cloneRecord(record) : undefined;
+  }
+
+  private onTerminal(event: SideThreadTerminalEvent): void {
+    const record = this.records.get(event.sideThreadId);
+    const attempt = record?.attempts.find((a) => a.id === event.attemptId);
+    const startingIdentity = attempt?.state === "starting" && !attempt.turnId;
+    const owned = !!record && !!attempt && record.derivedThreadId === event.threadId
+      && (attempt.turnId === event.turnId || startingIdentity)
+      && record.activeAttemptId === attempt.id
+      && (attempt.state === "running" || startingIdentity);
+    if (!owned) {
+      this.opts.audit?.({
+        action: "event_dropped", sideThreadId: event.sideThreadId,
+        attemptId: event.attemptId, runtime: this.opts.adapter.capability().runtime,
+        runtimeVersion: this.opts.adapter.capability().runtimeVersion,
+        reason: "ownership-mismatch", at: this.now(),
+      });
+      return;
+    }
+    if (!attempt!.turnId) attempt!.turnId = event.turnId;
+    attempt!.state = event.status === "completed" ? "completed"
+      : event.status === "interrupted" ? "cancelled" : "failed";
+    attempt!.result = event.status === "completed" ? event.text : undefined;
+    attempt!.error = event.status === "failed" ? safeText(event.error) : undefined;
+    record!.activeAttemptId = undefined;
+    record!.state = attempt!.state === "cancelled" ? "cancelled" : attempt!.state;
+    this.audit(record!, "attempt_terminal", {
+      attemptId: attempt!.id, derivedThreadId: record!.derivedThreadId,
+      turnId: attempt!.turnId, reason: event.status,
+    });
+  }
+
+  private mustGet(id: string): SideThreadRecord {
+    const record = this.records.get(id);
+    if (!record) throw new SideThreadConflictError("unknown side thread");
+    return record;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new SideThreadConflictError("side thread service is closed");
+  }
+
+  private audit(record: SideThreadRecord, action: SideThreadAuditAction, extra: Partial<SideThreadAuditEntry>): void {
+    this.opts.audit?.({ action, sideThreadId: record.id, runtime: record.runtime,
+      runtimeVersion: record.runtimeVersion, at: this.now(), ...extra });
+  }
+}
+
+function requireIdentity(value: string, label: string): void {
+  if (!value || value.length > 512 || /[\r\n\0]/.test(value)) throw new SideThreadConflictError(`invalid ${label}`);
+}
+function requireIdempotencyKey(value: string): void {
+  if (!/^[A-Za-z0-9._:-]{8,160}$/.test(value)) throw new SideThreadConflictError("invalid idempotency key");
+}
+function safeText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.replace(/[\r\n\t]+/g, " ").slice(0, 300);
+}
+function safeError(error: unknown): string { return safeText(error instanceof Error ? error.message : String(error)) ?? "runtime error"; }
+function cloneAttempt(value: SideThreadAttempt): SideThreadAttempt { return { ...value }; }
+function cloneRecord(value: SideThreadRecord): SideThreadRecord {
+  return { ...value, boundary: { ...value.boundary }, attempts: value.attempts.map(cloneAttempt) };
+}
+import { randomUUID } from "node:crypto";

--- a/agent-node/src/runtime/side-thread/domain.ts
+++ b/agent-node/src/runtime/side-thread/domain.ts
@@ -81,6 +81,8 @@ export interface SideThreadTerminalEvent {
   status: "completed" | "failed" | "interrupted";
   text?: string;
   error?: string;
+  /** Adapter proved this turn by the echoed per-attempt client identity. */
+  identityBound?: boolean;
 }
 
 export interface SideThreadRuntimeAdapter {
@@ -364,10 +366,11 @@ export class SideThreadService {
   private onTerminal(event: SideThreadTerminalEvent): void {
     const record = this.records.get(event.sideThreadId);
     const attempt = record?.attempts.find((a) => a.id === event.attemptId);
+    const reconciling = attempt?.state === "ambiguous" && !attempt.turnId && event.identityBound === true;
     const owned = !!record && !!attempt && record.derivedThreadId === event.threadId
-      && attempt.turnId === event.turnId
+      && (attempt.turnId === event.turnId || reconciling)
       && record.activeAttemptId === attempt.id
-      && attempt.state === "running";
+      && (attempt.state === "running" || reconciling);
     if (!owned) {
       this.emitAudit(redactAudit({
         action: "event_dropped", sideThreadId: event.sideThreadId,
@@ -379,6 +382,7 @@ export class SideThreadService {
       }) as SideThreadAuditEntry);
       return;
     }
+    if (!attempt!.turnId) attempt!.turnId = event.turnId;
     if (!attempt!.turnId) attempt!.turnId = event.turnId;
     attempt!.state = event.status === "completed" ? "completed"
       : event.status === "interrupted" ? "cancelled" : "failed";

--- a/agent-node/src/runtime/side-thread/fork-lease.test.ts
+++ b/agent-node/src/runtime/side-thread/fork-lease.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PrivateFileForkLeaseStore, type ForkLeaseRecord } from "./fork-lease";
+import { operationHash } from "./operation-ledger";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+const lease = (operationId = "op-00000001"): ForkLeaseRecord => ({ version: 1, nodeId: "node-1",
+  sourceThreadHash: operationHash("source-1"), sideThreadId: "side-1", operationId,
+  fingerprint: operationHash("fork-input"), snapshotThreadIdHashes: [], state: "snapshot", updatedAt: 1 });
+
+describe("PrivateFileForkLeaseStore", () => {
+  test("persists a private per-source lease and the same operation resumes across instances", () => {
+    const root = mkdtempSync(join(tmpdir(), "fork-lease-")); roots.push(root);
+    const first = new PrivateFileForkLeaseStore(root); first.acquire(lease());
+    const second = new PrivateFileForkLeaseStore(root);
+    expect(second.acquire(lease())).toEqual(lease());
+    expect(statSync(root).mode & 0o777).toBe(0o700);
+    second.put({ ...lease(), state: "sent", updatedAt: 2 });
+    second.put({ ...lease(), state: "ambiguous", updatedAt: 3 });
+    expect(first.get("node-1", "source-1")?.state).toBe("ambiguous");
+    second.release("node-1", "source-1", "op-00000001");
+    expect(first.get("node-1", "source-1")).toBeUndefined();
+  });
+  test("a different operation cannot steal an unresolved source lease", () => {
+    const root = mkdtempSync(join(tmpdir(), "fork-lease-")); roots.push(root);
+    const store = new PrivateFileForkLeaseStore(root); store.acquire(lease());
+    expect(() => store.acquire({ ...lease("op-00000002"), sideThreadId: "side-2" })).toThrow("unresolved fork lease");
+    expect(() => store.release("node-1", "source-1", "op-00000002")).toThrow("ownership mismatch");
+  });
+});

--- a/agent-node/src/runtime/side-thread/fork-lease.ts
+++ b/agent-node/src/runtime/side-thread/fork-lease.ts
@@ -1,0 +1,99 @@
+import { chmodSync, closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { operationHash } from "./operation-ledger";
+
+export interface ForkLeaseRecord {
+  version: 1;
+  nodeId: string;
+  sourceThreadHash: string;
+  sideThreadId: string;
+  operationId: string;
+  fingerprint: string;
+  snapshotThreadIdHashes: string[];
+  state: "snapshot" | "sent" | "ambiguous";
+  updatedAt: number;
+}
+
+export interface ForkLeaseStore {
+  acquire(record: ForkLeaseRecord): ForkLeaseRecord;
+  put(record: ForkLeaseRecord): void;
+  get(nodeId: string, sourceThreadId: string): ForkLeaseRecord | undefined;
+  release(nodeId: string, sourceThreadId: string, operationId: string): void;
+}
+
+/**
+ * Crash-persistent, per-source exclusion for an owned stdio app-server.
+ * There is deliberately no timeout/lease stealing: after an uncertain fork,
+ * another process must reconcile the exact operation rather than guess that an
+ * old owner is dead and emit a second thread/fork.
+ */
+export class PrivateFileForkLeaseStore implements ForkLeaseStore {
+  constructor(private readonly root: string) {
+    mkdirSync(root, { recursive: true, mode: 0o700 }); chmodSync(root, 0o700);
+  }
+  acquire(record: ForkLeaseRecord): ForkLeaseRecord {
+    validate(record);
+    const path = this.path(record.nodeId, record.sourceThreadHash);
+    try {
+      writeFileSync(path, `${JSON.stringify(record)}\n`, { flag: "wx", mode: 0o600 });
+      this.sync(path); return clone(record);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== "EEXIST") throw error;
+      const existing = this.read(path);
+      if (existing.operationId !== record.operationId || existing.fingerprint !== record.fingerprint
+        || existing.sideThreadId !== record.sideThreadId) {
+        throw new Error("source thread already has an unresolved fork lease");
+      }
+      return existing;
+    }
+  }
+  put(record: ForkLeaseRecord): void {
+    validate(record);
+    const path = this.path(record.nodeId, record.sourceThreadHash);
+    const existing = this.read(path);
+    if (existing.operationId !== record.operationId || existing.fingerprint !== record.fingerprint
+      || existing.sideThreadId !== record.sideThreadId) throw new Error("fork lease ownership changed");
+    if (record.updatedAt < existing.updatedAt
+      || (existing.state !== record.state && !(existing.state === "snapshot" && record.state === "sent")
+        && !(existing.state === "sent" && record.state === "ambiguous"))) {
+      throw new Error(`invalid fork lease transition ${existing.state}->${record.state}`);
+    }
+    if (existing.state !== "snapshot"
+      && JSON.stringify(existing.snapshotThreadIdHashes) !== JSON.stringify(record.snapshotThreadIdHashes)) {
+      throw new Error("fork lease snapshot is immutable after send");
+    }
+    const tmp = `${path}.tmp.${process.pid}.${randomUUID()}`;
+    writeFileSync(tmp, `${JSON.stringify(record)}\n`, { flag: "wx", mode: 0o600 });
+    this.sync(tmp); renameSync(tmp, path); chmodSync(path, 0o600); this.syncDir();
+  }
+  get(nodeId: string, sourceThreadId: string): ForkLeaseRecord | undefined {
+    const path = this.path(nodeId, operationHash(sourceThreadId));
+    return existsSync(path) ? this.read(path) : undefined;
+  }
+  release(nodeId: string, sourceThreadId: string, operationId: string): void {
+    const path = this.path(nodeId, operationHash(sourceThreadId));
+    if (!existsSync(path)) return;
+    const existing = this.read(path);
+    if (existing.operationId !== operationId) throw new Error("fork lease release ownership mismatch");
+    unlinkSync(path); this.syncDir();
+  }
+  private path(nodeId: string, sourceThreadHash: string): string {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(nodeId)) throw new Error("invalid fork lease nodeId");
+    if (!/^sha256:[0-9a-f]{64}$/.test(sourceThreadHash)) throw new Error("fork lease source hash required");
+    return join(this.root, `${nodeId}.${sourceThreadHash.slice(7)}.json`);
+  }
+  private read(path: string): ForkLeaseRecord { const value = JSON.parse(readFileSync(path, "utf8")); validate(value); return value; }
+  private sync(path: string): void { const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } this.syncDir(); }
+  private syncDir(): void { const fd = openSync(this.root, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } }
+}
+function validate(value: ForkLeaseRecord): void {
+  if (value?.version !== 1 || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value.nodeId)
+    || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value.sideThreadId)
+    || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value.operationId)
+    || !/^sha256:[0-9a-f]{64}$/.test(value.sourceThreadHash)
+    || !/^sha256:[0-9a-f]{64}$/.test(value.fingerprint)
+    || !/^(snapshot|sent|ambiguous)$/.test(value.state)
+    || value.snapshotThreadIdHashes.some((x) => !/^sha256:[0-9a-f]{64}$/.test(x))) throw new Error("invalid fork lease");
+}
+function clone(value: ForkLeaseRecord): ForkLeaseRecord { return { ...value, snapshotThreadIdHashes: [...value.snapshotThreadIdHashes] }; }

--- a/agent-node/src/runtime/side-thread/operation-ledger.test.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.test.ts
@@ -14,6 +14,7 @@ describe("PrivateFileOperationLedger", () => {
     expect(statSync(path).mode & 0o777).toBe(0o600);
     expect(new PrivateFileOperationLedger(root).get("node-1", "side-1", "op-1")?.state).toBe("ambiguous");
     expect(new PrivateFileOperationLedger(root).list("node-1", "side-1")).toHaveLength(1);
+    expect(new PrivateFileOperationLedger(root).find("node-1", "side-1", "request-0001", "fork", op().fingerprint)?.state).toBe("ambiguous");
   });
   test("rejects traversal, bearer, URL and unhashed targets", () => {
     const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root); const ledger = new PrivateFileOperationLedger(root);

--- a/agent-node/src/runtime/side-thread/operation-ledger.test.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, mkdtempSync, statSync } from "node:fs";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { PrivateFileOperationLedger, type SideThreadOperation } from "./operation-ledger";
+import { operationHash, PrivateFileOperationLedger, stableOperationId, type SideThreadOperation } from "./operation-ledger";
 const roots: string[] = []; afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
 const op = (state: SideThreadOperation["state"] = "sent"): SideThreadOperation => ({ version: 1, nodeId: "node-1", sideThreadId: "side-1", opId: "op-1", idempotencyKey: "request-0001", method: "fork", targetHash: `sha256:${"a".repeat(64)}`, fingerprint: `sha256:${"b".repeat(64)}`, state, updatedAt: 1 });
 describe("PrivateFileOperationLedger", () => {
@@ -20,5 +20,14 @@ describe("PrivateFileOperationLedger", () => {
     const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root); const ledger = new PrivateFileOperationLedger(root);
     for (const bad of ["../escape", "Bearer SECRET", "https://host/x", "/private/path"]) expect(() => ledger.put({ ...op(), nodeId: bad })).toThrow("invalid");
     expect(() => ledger.put({ ...op(), targetHash: "/private/path" })).toThrow("hashes required");
+  });
+  test("operation ids are stable and identity/state cannot be rewritten", () => {
+    expect(stableOperationId("side-1", "start", "request-0001")).toBe(stableOperationId("side-1", "start", "request-0001"));
+    expect(stableOperationId("side-1", "start", "request-0001")).not.toBe(stableOperationId("side-1", "start", "request-0002"));
+    expect(operationHash("secret")).toMatch(/^sha256:[0-9a-f]{64}$/);
+    const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root); const ledger = new PrivateFileOperationLedger(root);
+    ledger.put({ ...op(), state: "prepared" }); ledger.put({ ...op(), state: "sent", updatedAt: 2 });
+    expect(() => ledger.put({ ...op(), state: "prepared", updatedAt: 3 })).toThrow("transition");
+    expect(() => ledger.put({ ...op(), state: "ambiguous", fingerprint: operationHash("other"), updatedAt: 3 })).toThrow("immutable");
   });
 });

--- a/agent-node/src/runtime/side-thread/operation-ledger.test.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, statSync } from "node:fs";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PrivateFileOperationLedger, type SideThreadOperation } from "./operation-ledger";
+const roots: string[] = []; afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+const op = (state: SideThreadOperation["state"] = "sent"): SideThreadOperation => ({ version: 1, nodeId: "node-1", sideThreadId: "side-1", opId: "op-1", idempotencyKey: "request-0001", method: "fork", targetHash: `sha256:${"a".repeat(64)}`, fingerprint: `sha256:${"b".repeat(64)}`, state, updatedAt: 1 });
+describe("PrivateFileOperationLedger", () => {
+  test("atomically persists 0600 and recovers across instances", () => {
+    const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root);
+    const first = new PrivateFileOperationLedger(root); first.put(op()); first.put({ ...op("ambiguous"), updatedAt: 2 });
+    const path = join(root, "node-1", "side-1", "op-1.json");
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(new PrivateFileOperationLedger(root).get("node-1", "side-1", "op-1")?.state).toBe("ambiguous");
+    expect(new PrivateFileOperationLedger(root).list("node-1", "side-1")).toHaveLength(1);
+  });
+  test("rejects traversal, bearer, URL and unhashed targets", () => {
+    const root = mkdtempSync(join(tmpdir(), "side-ledger-")); roots.push(root); const ledger = new PrivateFileOperationLedger(root);
+    for (const bad of ["../escape", "Bearer SECRET", "https://host/x", "/private/path"]) expect(() => ledger.put({ ...op(), nodeId: bad })).toThrow("invalid");
+    expect(() => ledger.put({ ...op(), targetHash: "/private/path" })).toThrow("hashes required");
+  });
+});

--- a/agent-node/src/runtime/side-thread/operation-ledger.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.ts
@@ -10,7 +10,7 @@ export interface SideThreadOperation {
   result?: { derivedThreadIdHash?: string; turnIdHash?: string; classification?: "exists" | "not-found" | "terminal" | "active" };
   updatedAt: number;
 }
-export interface OperationLedger { put(op: SideThreadOperation): void; get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined; list(nodeId: string, sideThreadId: string): SideThreadOperation[]; }
+export interface OperationLedger { put(op: SideThreadOperation): void; get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined; list(nodeId: string, sideThreadId: string): SideThreadOperation[]; find(nodeId: string, sideThreadId: string, idempotencyKey: string, method: OperationMethod, fingerprint: string): SideThreadOperation | undefined; }
 
 export class PrivateFileOperationLedger implements OperationLedger {
   constructor(private readonly root: string) { mkdirSync(root, { recursive: true, mode: 0o700 }); chmodSync(root, 0o700); }
@@ -34,6 +34,11 @@ export class PrivateFileOperationLedger implements OperationLedger {
     return readdirSync(dir).filter((x) => x.endsWith(".json")).map((x) => {
       const value = JSON.parse(readFileSync(join(dir, x), "utf8")); validate(value); return value;
     }).sort((a, b) => a.updatedAt - b.updatedAt || a.opId.localeCompare(b.opId));
+  }
+  find(nodeId: string, sideThreadId: string, idempotencyKey: string, method: OperationMethod, fingerprint: string): SideThreadOperation | undefined {
+    requireSafe(idempotencyKey, "idempotencyKey");
+    if (!/^sha256:[0-9a-f]{64}$/.test(fingerprint)) throw new Error("operation fingerprint hash required");
+    return this.list(nodeId, sideThreadId).find((op) => op.idempotencyKey === idempotencyKey && op.method === method && op.fingerprint === fingerprint);
   }
   private path(nodeId: string, sideThreadId: string, opId: string): string {
     for (const [v, label] of [[nodeId, "nodeId"], [sideThreadId, "sideThreadId"], [opId, "opId"]] as const) requireSafe(v, label);

--- a/agent-node/src/runtime/side-thread/operation-ledger.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.ts
@@ -1,13 +1,18 @@
 import { chmodSync, closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
-export type OperationState = "sent" | "acked" | "ambiguous" | "reconciling" | "reconciled" | "compensated";
+export type OperationState = "prepared" | "sent" | "accepted" | "ambiguous" | "reconciling" | "reconciled" | "compensated" | "rejected";
 export type OperationMethod = "fork" | "start" | "interrupt" | "archive" | "delete";
 export interface SideThreadOperation {
   version: 1; nodeId: string; sideThreadId: string; opId: string; idempotencyKey: string;
   method: OperationMethod; targetHash: string; fingerprint: string; state: OperationState;
-  result?: { derivedThreadIdHash?: string; turnIdHash?: string; classification?: "exists" | "not-found" | "terminal" | "active" };
+  result?: {
+    derivedThreadIdHash?: string;
+    turnIdHash?: string;
+    snapshotThreadIdHashes?: string[];
+    classification?: "exists" | "not-found" | "terminal" | "active" | "unique-candidate" | "no-candidate" | "multiple-candidates";
+  };
   updatedAt: number;
 }
 export interface OperationLedger { put(op: SideThreadOperation): void; get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined; list(nodeId: string, sideThreadId: string): SideThreadOperation[]; find(nodeId: string, sideThreadId: string, idempotencyKey: string, method: OperationMethod, fingerprint: string): SideThreadOperation | undefined; }
@@ -18,6 +23,20 @@ export class PrivateFileOperationLedger implements OperationLedger {
     validate(op);
     const path = this.path(op.nodeId, op.sideThreadId, op.opId);
     mkdirSync(dirname(path), { recursive: true, mode: 0o700 }); chmodSync(dirname(path), 0o700);
+    if (!existsSync(path)) {
+      writeFileSync(path, `${JSON.stringify(op)}\n`, { flag: "wx", mode: 0o600 });
+      const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); }
+      const dir = openSync(dirname(path), "r"); try { fsyncSync(dir); } finally { closeSync(dir); }
+      return;
+    }
+    if (existsSync(path)) {
+      const previous = JSON.parse(readFileSync(path, "utf8")) as SideThreadOperation;
+      validate(previous);
+      for (const key of ["nodeId", "sideThreadId", "opId", "idempotencyKey", "method", "targetHash", "fingerprint"] as const) {
+        if (previous[key] !== op[key]) throw new Error(`operation ${key} is immutable`);
+      }
+      if (!validTransition(previous.state, op.state)) throw new Error(`invalid operation transition ${previous.state}->${op.state}`);
+    }
     const tmp = `${path}.tmp.${process.pid}.${randomUUID()}`;
     writeFileSync(tmp, `${JSON.stringify(op)}\n`, { flag: "wx", mode: 0o600 });
     const fd = openSync(tmp, "r"); try { fsyncSync(fd); } finally { closeSync(fd); }
@@ -45,10 +64,32 @@ export class PrivateFileOperationLedger implements OperationLedger {
     return join(this.root, nodeId, sideThreadId, `${opId}.json`);
   }
 }
+export function operationHash(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+export function stableOperationId(sideThreadId: string, method: OperationMethod, idempotencyKey: string): string {
+  requireSafe(sideThreadId, "sideThreadId"); requireSafe(idempotencyKey, "idempotencyKey");
+  return `op-${createHash("sha256").update(`${sideThreadId}\0${method}\0${idempotencyKey}`).digest("hex")}`;
+}
 function requireSafe(value: string, label: string): void { if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value)) throw new Error(`invalid operation ${label}`); }
 function validate(op: SideThreadOperation): void {
   if (op?.version !== 1) throw new Error("unsupported operation ledger version");
   for (const [v, label] of [[op.nodeId, "nodeId"], [op.sideThreadId, "sideThreadId"], [op.opId, "opId"], [op.idempotencyKey, "idempotencyKey"]] as const) requireSafe(v, label);
-  if (!/^(fork|start|interrupt|archive|delete)$/.test(op.method) || !/^(sent|acked|ambiguous|reconciling|reconciled|compensated)$/.test(op.state)) throw new Error("invalid operation state");
+  if (!/^(fork|start|interrupt|archive|delete)$/.test(op.method) || !/^(prepared|sent|accepted|ambiguous|reconciling|reconciled|compensated|rejected)$/.test(op.state)) throw new Error("invalid operation state");
   if (!/^sha256:[0-9a-f]{64}$/.test(op.targetHash) || !/^sha256:[0-9a-f]{64}$/.test(op.fingerprint)) throw new Error("operation hashes required");
+  for (const hash of [op.result?.derivedThreadIdHash, op.result?.turnIdHash, ...(op.result?.snapshotThreadIdHashes ?? [])]) {
+    if (hash && !/^sha256:[0-9a-f]{64}$/.test(hash)) throw new Error("operation result hashes required");
+  }
+}
+function validTransition(from: OperationState, to: OperationState): boolean {
+  if (from === to) return true;
+  return ({
+    prepared: ["sent", "rejected"],
+    sent: ["accepted", "ambiguous", "rejected"],
+    accepted: ["reconciled", "compensated"],
+    ambiguous: ["reconciling"],
+    reconciling: ["reconciled", "ambiguous"],
+    reconciled: ["compensated"],
+    compensated: [], rejected: [],
+  } satisfies Record<OperationState, OperationState[]>)[from].includes(to);
 }

--- a/agent-node/src/runtime/side-thread/operation-ledger.ts
+++ b/agent-node/src/runtime/side-thread/operation-ledger.ts
@@ -1,0 +1,49 @@
+import { chmodSync, closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+export type OperationState = "sent" | "acked" | "ambiguous" | "reconciling" | "reconciled" | "compensated";
+export type OperationMethod = "fork" | "start" | "interrupt" | "archive" | "delete";
+export interface SideThreadOperation {
+  version: 1; nodeId: string; sideThreadId: string; opId: string; idempotencyKey: string;
+  method: OperationMethod; targetHash: string; fingerprint: string; state: OperationState;
+  result?: { derivedThreadIdHash?: string; turnIdHash?: string; classification?: "exists" | "not-found" | "terminal" | "active" };
+  updatedAt: number;
+}
+export interface OperationLedger { put(op: SideThreadOperation): void; get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined; list(nodeId: string, sideThreadId: string): SideThreadOperation[]; }
+
+export class PrivateFileOperationLedger implements OperationLedger {
+  constructor(private readonly root: string) { mkdirSync(root, { recursive: true, mode: 0o700 }); chmodSync(root, 0o700); }
+  put(op: SideThreadOperation): void {
+    validate(op);
+    const path = this.path(op.nodeId, op.sideThreadId, op.opId);
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 }); chmodSync(dirname(path), 0o700);
+    const tmp = `${path}.tmp.${process.pid}.${randomUUID()}`;
+    writeFileSync(tmp, `${JSON.stringify(op)}\n`, { flag: "wx", mode: 0o600 });
+    const fd = openSync(tmp, "r"); try { fsyncSync(fd); } finally { closeSync(fd); }
+    renameSync(tmp, path); chmodSync(path, 0o600);
+    const dir = openSync(dirname(path), "r"); try { fsyncSync(dir); } finally { closeSync(dir); }
+  }
+  get(nodeId: string, sideThreadId: string, opId: string): SideThreadOperation | undefined {
+    const path = this.path(nodeId, sideThreadId, opId); if (!existsSync(path)) return undefined;
+    const value = JSON.parse(readFileSync(path, "utf8")); validate(value); return value;
+  }
+  list(nodeId: string, sideThreadId: string): SideThreadOperation[] {
+    const dir = dirname(this.path(nodeId, sideThreadId, "probe"));
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir).filter((x) => x.endsWith(".json")).map((x) => {
+      const value = JSON.parse(readFileSync(join(dir, x), "utf8")); validate(value); return value;
+    }).sort((a, b) => a.updatedAt - b.updatedAt || a.opId.localeCompare(b.opId));
+  }
+  private path(nodeId: string, sideThreadId: string, opId: string): string {
+    for (const [v, label] of [[nodeId, "nodeId"], [sideThreadId, "sideThreadId"], [opId, "opId"]] as const) requireSafe(v, label);
+    return join(this.root, nodeId, sideThreadId, `${opId}.json`);
+  }
+}
+function requireSafe(value: string, label: string): void { if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/.test(value)) throw new Error(`invalid operation ${label}`); }
+function validate(op: SideThreadOperation): void {
+  if (op?.version !== 1) throw new Error("unsupported operation ledger version");
+  for (const [v, label] of [[op.nodeId, "nodeId"], [op.sideThreadId, "sideThreadId"], [op.opId, "opId"], [op.idempotencyKey, "idempotencyKey"]] as const) requireSafe(v, label);
+  if (!/^(fork|start|interrupt|archive|delete)$/.test(op.method) || !/^(sent|acked|ambiguous|reconciling|reconciled|compensated)$/.test(op.state)) throw new Error("invalid operation state");
+  if (!/^sha256:[0-9a-f]{64}$/.test(op.targetHash) || !/^sha256:[0-9a-f]{64}$/.test(op.fingerprint)) throw new Error("operation hashes required");
+}

--- a/contracts/side-thread/v1/README.md
+++ b/contracts/side-thread/v1/README.md
@@ -1,0 +1,16 @@
+# SideThread HTTP contract v1
+
+This directory is the authoritative, vendorable wire contract shared by the
+Hub and App. Public JSON uses `sideThreadId`/`question`; internal
+`side_chat_id`/`question_text` names never cross the HTTP or SSE boundary.
+
+Routes are `POST /api/side-threads`, `GET /api/side-threads`,
+`GET /api/side-threads/:sideThreadId`, `GET /:sideThreadId/events`, and
+`POST /:sideThreadId/{cancel,retry,archive,purge,bring-back}`. Capability is
+`GET /api/side-threads/capability` with `alias` or `nodeId`, plus `networkId`,
+`sourceThreadId`, `boundaryKind`, and `boundaryTurnId`.
+
+Create and retry bodies call owner-readable text `question`. Optional record
+fields are always present as JSON `null`; optional error correlation fields
+are absent. A supported capability always includes its exact `context`.
+Only a completed bring-back receipt makes `broughtBack` true.

--- a/contracts/side-thread/v1/golden.json
+++ b/contracts/side-thread/v1/golden.json
@@ -1,0 +1,148 @@
+{
+  "contractVersion": 1,
+  "nullablePolicy": "Optional projection fields are present with JSON null; optional error correlation fields are absent.",
+  "sideThreadActions": ["create", "get", "cancel", "retry", "archive", "purge"],
+  "requests": {
+    "capabilityQuery": {
+      "alias": "node-a",
+      "networkId": "net_a",
+      "sourceThreadId": "source_thread",
+      "boundaryKind": "through",
+      "boundaryTurnId": "source_turn"
+    },
+    "create": {
+      "requestKey": "create-request-0001",
+      "networkId": "net_a",
+      "nodeId": "node_a",
+      "sourceThreadId": "source_thread",
+      "boundary": { "kind": "through", "turnId": "source_turn" },
+      "question": "Original question",
+      "attachments": [{ "fileId": "file_ref_0001" }]
+    },
+    "retry": {
+      "requestKey": "retry-request-0001",
+      "question": "Try again",
+      "attachments": [{ "fileId": "file_ref_0001" }]
+    },
+    "bringBack": {
+      "requestKey": "bring-request-0001",
+      "attemptId": "sat_1",
+      "destinationThreadId": "source_thread"
+    }
+  },
+  "capabilityResponse": {
+    "ok": true,
+    "capability": {
+      "enabled": true,
+      "supported": true,
+      "mode": "native-exact-fork",
+      "runtime": "codex",
+      "runtimeVersion": "0.148.0",
+      "topology": "owned-stdio",
+      "evidenceRevision": "reviewed",
+      "exactBoundary": { "through": true, "before": true },
+      "reason": null,
+      "context": {
+        "networkId": "net_a",
+        "nodeId": "node_a",
+        "sourceThreadId": "source_thread",
+        "boundary": { "kind": "through", "turnId": "source_turn" }
+      }
+    }
+  },
+  "sideThreadEnvelope": {
+    "ok": true,
+    "sideThread": {
+      "sideThreadId": "sth_1",
+      "requestKey": "create-request-0001",
+      "networkId": "net_a",
+      "nodeId": "node_a",
+      "sourceThreadId": "source_thread",
+      "question": "Original question",
+      "title": "Original question",
+      "boundary": { "kind": "through", "turnId": "source_turn" },
+      "threadId": "derived_thread",
+      "state": "running",
+      "activeAttemptId": "sat_1",
+      "capability": {
+        "runtime": "codex",
+        "runtimeVersion": "0.148.0",
+        "topology": "owned-stdio",
+        "evidenceRevision": "reviewed"
+      },
+      "attachments": [{ "fileId": "file_ref_0001" }],
+      "attempts": [
+        {
+          "attemptId": "sat_1",
+          "requestKey": "create-request-0001",
+          "parentAttemptId": null,
+          "threadId": "derived_thread",
+          "turnId": "turn_1",
+          "state": "running",
+          "result": null,
+          "error": null,
+          "attachments": [{ "fileId": "file_ref_0001" }],
+          "broughtBack": false,
+          "createdAt": 1700000000000,
+          "updatedAt": 1700000000001
+        }
+      ],
+      "bringBacks": [],
+      "operations": [
+        {
+          "operationId": "sop_fork",
+          "attemptId": "sat_1",
+          "kind": "fork",
+          "requestKey": "create-request-0001",
+          "state": "completed",
+          "threadId": "derived_thread",
+          "turnId": null,
+          "errorCode": null,
+          "createdAt": 1700000000000,
+          "updatedAt": 1700000000001
+        },
+        {
+          "operationId": "sop_start",
+          "attemptId": "sat_1",
+          "kind": "start",
+          "requestKey": "create-request-0001",
+          "state": "completed",
+          "threadId": "derived_thread",
+          "turnId": "turn_1",
+          "errorCode": null,
+          "createdAt": 1700000000001,
+          "updatedAt": 1700000000002
+        }
+      ],
+      "createdAt": 1700000000000,
+      "updatedAt": 1700000000002
+    }
+  },
+  "listResponse": { "ok": true, "sideThreads": [], "count": 0 },
+  "bringBackResponse": {
+    "ok": true,
+    "bringBack": {
+      "bringBackId": "sbb_1",
+      "destinationTurnId": "destination_turn"
+    }
+  },
+  "ambiguousError": {
+    "ok": false,
+    "error": "SIDE_THREAD_AMBIGUOUS",
+    "message": "runtime acceptance is ambiguous; reconcile this stable operation before retrying",
+    "operationId": "sop_start",
+    "sideThreadId": "sth_1",
+    "attemptId": "sat_1"
+  },
+  "sseEvent": {
+    "eventId": 1,
+    "sideThreadId": "sth_1",
+    "attemptId": "sat_1",
+    "threadId": "derived_thread",
+    "turnId": "turn_1",
+    "type": "attempt.running",
+    "state": "running",
+    "reason": null,
+    "createdAt": 1700000000002
+  }
+}

--- a/contracts/side-thread/v1/golden.json
+++ b/contracts/side-thread/v1/golden.json
@@ -24,6 +24,9 @@
       "question": "Try again",
       "attachments": [{ "fileId": "file_ref_0001" }]
     },
+    "cancel": { "requestKey": "cancel-request-0001" },
+    "archive": { "requestKey": "archive-request-0001" },
+    "purge": { "requestKey": "purge-request-0001" },
     "bringBack": {
       "requestKey": "bring-request-0001",
       "attemptId": "sat_1",

--- a/contracts/side-thread/v1/schema.json
+++ b/contracts/side-thread/v1/schema.json
@@ -199,6 +199,154 @@
         "updatedAt": { "type": "number" }
       }
     },
+    "createRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requestKey",
+        "networkId",
+        "nodeId",
+        "sourceThreadId",
+        "boundary",
+        "question"
+      ],
+      "properties": {
+        "requestKey": { "type": "string" },
+        "networkId": { "type": "string" },
+        "nodeId": { "type": "string" },
+        "sourceThreadId": { "type": "string" },
+        "boundary": { "$ref": "#/$defs/boundary" },
+        "question": { "type": "string" },
+        "attachments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attachment" }
+        }
+      }
+    },
+    "retryRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requestKey", "question"],
+      "properties": {
+        "requestKey": { "type": "string" },
+        "question": { "type": "string" },
+        "attachments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attachment" }
+        }
+      }
+    },
+    "bringBackRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requestKey", "destinationThreadId"],
+      "properties": {
+        "requestKey": { "type": "string" },
+        "destinationThreadId": { "type": "string" },
+        "attemptId": { "type": "string" }
+      }
+    },
+    "capabilityResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "capability"],
+      "properties": {
+        "ok": { "const": true },
+        "capability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "supported",
+            "mode",
+            "runtime",
+            "runtimeVersion",
+            "topology",
+            "evidenceRevision",
+            "exactBoundary",
+            "reason",
+            "context"
+          ],
+          "properties": {
+            "enabled": { "const": true },
+            "supported": { "type": "boolean" },
+            "mode": { "type": ["string", "null"] },
+            "runtime": { "type": ["string", "null"] },
+            "runtimeVersion": { "type": ["string", "null"] },
+            "topology": { "type": ["string", "null"] },
+            "evidenceRevision": { "type": ["string", "null"] },
+            "exactBoundary": { "type": ["object", "null"] },
+            "reason": { "type": ["string", "null"] },
+            "context": { "type": ["object", "null"] }
+          }
+        }
+      }
+    },
+    "sideThreadResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "sideThread"],
+      "properties": {
+        "ok": { "const": true },
+        "sideThread": { "$ref": "#/$defs/sideThread" }
+      }
+    },
+    "sideThreadsResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "sideThreads", "count"],
+      "properties": {
+        "ok": { "const": true },
+        "sideThreads": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/sideThread" }
+        },
+        "count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "bringBackResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "bringBack"],
+      "properties": {
+        "ok": { "const": true },
+        "bringBack": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["bringBackId", "destinationTurnId"],
+          "properties": {
+            "bringBackId": { "type": "string" },
+            "destinationTurnId": { "type": "string" }
+          }
+        }
+      }
+    },
+    "sseEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eventId",
+        "sideThreadId",
+        "attemptId",
+        "threadId",
+        "turnId",
+        "type",
+        "state",
+        "reason",
+        "createdAt"
+      ],
+      "properties": {
+        "eventId": { "type": "integer" },
+        "sideThreadId": { "type": "string" },
+        "attemptId": { "type": ["string", "null"] },
+        "threadId": { "type": ["string", "null"] },
+        "turnId": { "type": ["string", "null"] },
+        "type": { "type": "string" },
+        "state": { "type": ["string", "null"] },
+        "reason": { "type": ["string", "null"] },
+        "createdAt": { "type": "number" }
+      }
+    },
     "error": {
       "type": "object",
       "additionalProperties": false,

--- a/contracts/side-thread/v1/schema.json
+++ b/contracts/side-thread/v1/schema.json
@@ -236,6 +236,12 @@
         }
       }
     },
+    "actionRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requestKey"],
+      "properties": { "requestKey": { "type": "string" } }
+    },
     "bringBackRequest": {
       "type": "object",
       "additionalProperties": false,

--- a/contracts/side-thread/v1/schema.json
+++ b/contracts/side-thread/v1/schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-network.local/contracts/side-thread/v1/schema.json",
+  "title": "CommHub SideThread public HTTP contract v1",
+  "$defs": {
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "turnId"],
+      "properties": {
+        "kind": { "enum": ["through", "before"] },
+        "turnId": { "type": "string" }
+      }
+    },
+    "attachment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId"],
+      "properties": { "fileId": { "type": "string" } }
+    },
+    "recordCapability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtime", "runtimeVersion", "topology", "evidenceRevision"],
+      "properties": {
+        "runtime": { "type": ["string", "null"] },
+        "runtimeVersion": { "type": ["string", "null"] },
+        "topology": { "type": ["string", "null"] },
+        "evidenceRevision": { "type": ["string", "null"] }
+      }
+    },
+    "attempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attemptId",
+        "requestKey",
+        "parentAttemptId",
+        "threadId",
+        "turnId",
+        "state",
+        "result",
+        "error",
+        "attachments",
+        "broughtBack",
+        "createdAt",
+        "updatedAt"
+      ],
+      "properties": {
+        "attemptId": { "type": "string" },
+        "requestKey": { "type": "string" },
+        "parentAttemptId": { "type": ["string", "null"] },
+        "threadId": { "type": ["string", "null"] },
+        "turnId": { "type": ["string", "null"] },
+        "state": {
+          "enum": [
+            "starting",
+            "running",
+            "completed",
+            "failed",
+            "cancelled",
+            "ambiguous",
+            "reconciling"
+          ]
+        },
+        "result": { "type": ["string", "null"] },
+        "error": { "type": ["string", "null"] },
+        "attachments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attachment" }
+        },
+        "broughtBack": { "type": "boolean" },
+        "createdAt": { "type": "number" },
+        "updatedAt": { "type": "number" }
+      }
+    },
+    "bringBack": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bringBackId",
+        "attemptId",
+        "requestKey",
+        "destinationThreadId",
+        "destinationTurnId",
+        "state",
+        "broughtBack",
+        "createdAt",
+        "updatedAt",
+        "completedAt"
+      ],
+      "properties": {
+        "bringBackId": { "type": "string" },
+        "attemptId": { "type": "string" },
+        "requestKey": { "type": "string" },
+        "destinationThreadId": { "type": "string" },
+        "destinationTurnId": { "type": ["string", "null"] },
+        "state": { "enum": ["starting", "completed", "failed"] },
+        "broughtBack": { "type": "boolean" },
+        "createdAt": { "type": "number" },
+        "updatedAt": { "type": "number" },
+        "completedAt": { "type": ["number", "null"] }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operationId",
+        "attemptId",
+        "kind",
+        "requestKey",
+        "state",
+        "threadId",
+        "turnId",
+        "errorCode",
+        "createdAt",
+        "updatedAt"
+      ],
+      "properties": {
+        "operationId": { "type": "string" },
+        "attemptId": { "type": ["string", "null"] },
+        "kind": {
+          "enum": ["fork", "start", "cancel", "archive", "purge", "bring-back"]
+        },
+        "requestKey": { "type": "string" },
+        "state": {
+          "enum": ["pending", "ambiguous", "reconciling", "completed", "failed"]
+        },
+        "threadId": { "type": ["string", "null"] },
+        "turnId": { "type": ["string", "null"] },
+        "errorCode": { "type": ["string", "null"] },
+        "createdAt": { "type": "number" },
+        "updatedAt": { "type": "number" }
+      }
+    },
+    "sideThread": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sideThreadId",
+        "requestKey",
+        "networkId",
+        "nodeId",
+        "sourceThreadId",
+        "question",
+        "title",
+        "boundary",
+        "threadId",
+        "state",
+        "activeAttemptId",
+        "capability",
+        "attachments",
+        "attempts",
+        "bringBacks",
+        "operations",
+        "createdAt",
+        "updatedAt"
+      ],
+      "properties": {
+        "sideThreadId": { "type": "string" },
+        "requestKey": { "type": "string" },
+        "networkId": { "type": "string" },
+        "nodeId": { "type": "string" },
+        "sourceThreadId": { "type": "string" },
+        "question": { "type": "string" },
+        "title": { "type": "string" },
+        "boundary": { "$ref": "#/$defs/boundary" },
+        "threadId": { "type": ["string", "null"] },
+        "state": {
+          "enum": [
+            "creating",
+            "running",
+            "completed",
+            "failed",
+            "cancelled",
+            "ambiguous",
+            "reconciling",
+            "archived",
+            "purged"
+          ]
+        },
+        "activeAttemptId": { "type": ["string", "null"] },
+        "capability": { "$ref": "#/$defs/recordCapability" },
+        "attachments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attachment" }
+        },
+        "attempts": { "type": "array", "items": { "$ref": "#/$defs/attempt" } },
+        "bringBacks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/bringBack" }
+        },
+        "operations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/operation" }
+        },
+        "createdAt": { "type": "number" },
+        "updatedAt": { "type": "number" }
+      }
+    },
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "error", "message"],
+      "properties": {
+        "ok": { "const": false },
+        "error": { "type": "string" },
+        "message": { "type": "string" },
+        "operationId": { "type": "string" },
+        "sideThreadId": { "type": "string" },
+        "attemptId": { "type": "string" }
+      }
+    }
+  }
+}

--- a/docs/design/side-thread-pr1-contract.md
+++ b/docs/design/side-thread-pr1-contract.md
@@ -46,6 +46,14 @@ reachable from production startup.
 Create and attempt request keys are single-flight and payload-bound. Reusing a
 key with different input is a conflict, not a silent replay. A failed operation
 may be retried with the same key; a completed operation remains idempotent.
+Ambiguous create/start retries retain the original side-thread and attempt
+identities, so the stable operation ID addresses the same durable journal row.
+
+Every mutating Codex RPC is journaled to a private `0700` directory with `0600`
+atomic records. The stable operation ID is derived from side-thread, method and
+idempotency key; target and payload fingerprints are SHA-256 values. The
+adapter persists `sent` before writing an RPC. `accepted` and `ambiguous`
+operations are never emitted again on replay.
 
 The execution registry accepts a terminal event only if
 `sideThreadId + attemptId + derivedThreadId + turnId` matches the active
@@ -60,6 +68,12 @@ duplicate cancel/delete RPCs.
 
 - A successful native fork registers a unique derived-thread-to-side owner;
   duplicate runtime identities fail closed.
+- Fork holds a crash-persistent per-source lease. There is no timeout-based
+  lease stealing for an uncertain operation.
+- Before `thread/fork`, the adapter persists a complete paginated `thread/list`
+  snapshot. If the fork response is lost, only one new thread whose
+  `forkedFromId` is the exact source may be adopted. Zero or multiple candidates
+  stay ambiguous and retain the lease; retry never emits another fork RPC.
 - Start uses `clientUserMessageId=anet-side:<side>:<attempt>`.
 - The echoed user item binds the authoritative turn; the `turn/start` response
   turn ID is recorded but not trusted.
@@ -80,22 +94,24 @@ topology/evidence revision, terminal status/rejection reason and timestamp.
 They never contain prompt/result bodies,
 credentials, environment, paths, request payloads or model output. The current
 callback is a non-throwing internal sink boundary: synchronous throws and
-rejected promises cannot orphan or duplicate runtime work. Durable transactional
-storage and authorization are future Hub work.
+rejected promises cannot orphan or duplicate runtime work. Hub authorization
+and transactional resource persistence remain future work.
 
 ## Deliberate omissions
 
 - no App command/parser/UI;
 - no Hub REST/SSE route, database or authorization surface;
 - no node startup integration or production feature flag;
-- no durable restart/recovery ledger;
+- no durable SideThread resource/attempt registry (the runtime operation
+  journal and fork lease do not reconstruct the whole domain registry);
 - no shared WebSocket/TUI topology;
 - no snapshot fallback or non-Codex adapter;
 - no attachment cache or bring-back path.
 
-Durability is a blocker for exposing the API externally: an in-memory registry
-cannot safely recover ownership after process death. PR2 must persist the
-resource/attempt ledger before any Hub or App caller can create SideThreads.
+Resource durability is still a blocker for exposing the API externally: the
+operation journal prevents duplicate runtime RPCs, but the in-memory registry
+cannot reconstruct complete SideThread/attempt state after process death. PR2
+must persist that registry before any Hub or App caller can create SideThreads.
 
 ## Independent review checklist
 

--- a/docs/design/side-thread-pr1-contract.md
+++ b/docs/design/side-thread-pr1-contract.md
@@ -1,0 +1,105 @@
+# SideThread PR1 internal contract
+
+Status: Draft, disabled and not wired to Hub/App.
+
+This document describes the credential-free implementation layer stacked on
+RFC-036 PR0. It does not claim that PR0's semantic wire review is complete;
+the runtime allowlist remains unusable in production until PR0's raw trace,
+boundary-content and concurrency blockers are resolved.
+
+## Boundary-specific capability
+
+Codex 0.148.0 does not have one Boolean "exact fork" capability:
+
+- `lastTurnId` (`kind: through`) is present in the normal and experimental
+  schema and does not require `experimentalApi`.
+- `beforeTurnId` (`kind: before`) is experimental and is rejected unless the
+  client negotiated `initialize.capabilities.experimentalApi=true`.
+
+The adapter therefore reports:
+
+```ts
+exactBoundary: { through: true, before: experimentalApi }
+```
+
+The domain asks for the selected boundary, and fails before `thread/fork` if
+that specific boundary is unavailable. Runtime version must be exactly
+`0.148.0` and topology must be `owned`; shared app-server and every other
+version are typed unsupported.
+
+This is an adapter allowlist, not a repository-wide Codex dependency upgrade.
+`agent-node/package-lock.json` still resolves Codex SDK/CLI 0.133.0, while the
+external co-presence binary is operator-managed. PR1 is deliberately not
+reachable from production startup.
+
+## Internal API
+
+`SideThreadService` owns:
+
+- `create(requestKey,nodeId,sourceThreadId,boundary)`;
+- `startAttempt(sideThreadId,requestKey,prompt)`;
+- exact `cancel(sideThreadId)`;
+- `archive` and `purge`;
+- immutable `get` snapshots and minimized audit entries.
+
+Create and attempt request keys are single-flight and payload-bound. Reusing a
+key with different input is a conflict, not a silent replay. A failed operation
+may be retried with the same key; a completed operation remains idempotent.
+
+The execution registry accepts a terminal event only if
+`sideThreadId + attemptId + derivedThreadId + turnId` matches the active
+attempt. Duplicates, stale attempts, source-thread events and sibling-thread
+events are dropped and audited. Closing the service unsubscribes its listener
+and prohibits further mutation.
+
+## Codex ownership rules
+
+- A successful native fork registers its derived thread as adapter-owned.
+- Start uses `clientUserMessageId=anet-side:<side>:<attempt>`.
+- The echoed user item binds the authoritative turn; the `turn/start` response
+  turn ID is recorded but not trusted.
+- A lost RPC response after the identity echo does not start a duplicate turn.
+- Interrupt requires an active registry entry for the exact derived thread and
+  turn. Source, sibling and unknown identities are rejected locally.
+- Archive/delete require an adapter-owned derived thread. Delete additionally
+  refuses an active owned turn.
+- Fork sends no approval, sandbox, cwd, instruction, model, or workspace-root
+  override. Native inheritance is used; BTW cannot upgrade source permissions.
+
+## Audit boundary
+
+Audit entries contain action, logical ownership IDs, runtime/version, terminal
+status/rejection reason and timestamp. They never contain prompt/result bodies,
+credentials, environment, paths, request payloads or model output. The current
+callback is an internal sink interface; durable storage and authorization are
+future Hub work.
+
+## Deliberate omissions
+
+- no App command/parser/UI;
+- no Hub REST/SSE route, database or authorization surface;
+- no node startup integration or production feature flag;
+- no durable restart/recovery ledger;
+- no shared WebSocket/TUI topology;
+- no snapshot fallback or non-Codex adapter;
+- no attachment cache or bring-back path.
+
+Durability is a blocker for exposing the API externally: an in-memory registry
+cannot safely recover ownership after process death. PR2 must persist the
+resource/attempt ledger before any Hub or App caller can create SideThreads.
+
+## Independent review checklist
+
+- Verify PR0 blockers are not papered over by the adapter allowlist.
+- Mutate each version/topology/boundary gate and observe a failing test.
+- Race duplicate request keys with equal and unequal payloads.
+- Deliver terminal events before start returns, after retry, twice, and with
+  source/sibling/unknown IDs.
+- Lose the `turn/start` response after identity echo and prove one RPC only.
+- Race cancel and terminal; confirm no source/sibling interrupt request exists.
+- Inspect fork payload for any permission/config override.
+- Close service/adapter during starting and running states; check listeners and
+  timers return to baseline without unhandled rejection.
+- Treat audit output as hostile: inject newlines, URLs, bearer-shaped values
+  and prompt secrets, then confirm none leave allowed fields.
+- Do not approve Hub/App wiring without a durable ownership/recovery design.

--- a/docs/design/side-thread-pr1-contract.md
+++ b/docs/design/side-thread-pr1-contract.md
@@ -3,9 +3,8 @@
 Status: Draft, disabled and not wired to Hub/App.
 
 This document describes the credential-free implementation layer stacked on
-RFC-036 PR0. It does not claim that PR0's semantic wire review is complete;
-the runtime allowlist remains unusable in production until PR0's raw trace,
-boundary-content and concurrency blockers are resolved.
+RFC-036 PR0. The allowlist consumes only reviewed `test1190-wire-v2`
+owned-stdio evidence and remains disabled from production entry points.
 
 ## Boundary-specific capability
 
@@ -25,8 +24,7 @@ exactBoundary: { through: true, before: experimentalApi }
 The domain asks for the selected boundary, and fails before `thread/fork` if
 that specific boundary is unavailable. Runtime version must be exactly
 `0.148.0`, topology must be `owned-stdio`, and evidence revision must be the
-reviewed `test1190-wire-v2`. PR0 currently has blockers and has not produced
-that revision, so present production inputs remain unsupported. Shared
+reviewed `test1190-wire-v2`. Shared
 app-server, owned WebSocket, every other version and stale evidence are typed
 unsupported.
 
@@ -53,14 +51,20 @@ The execution registry accepts a terminal event only if
 `sideThreadId + attemptId + derivedThreadId + turnId` matches the active
 attempt. Duplicates, stale attempts, source-thread events and sibling-thread
 events are dropped and audited. Closing the service unsubscribes its listener
-and prohibits further mutation.
+and adapter, drains tracked operations, and prohibits post-close mutation.
+Every mutation rechecks the record's immutable runtime/version/topology/evidence
+attestation. Per-side serialization prevents archive/purge regression and
+duplicate cancel/delete RPCs.
 
 ## Codex ownership rules
 
-- A successful native fork registers its derived thread as adapter-owned.
+- A successful native fork registers a unique derived-thread-to-side owner;
+  duplicate runtime identities fail closed.
 - Start uses `clientUserMessageId=anet-side:<side>:<attempt>`.
 - The echoed user item binds the authoritative turn; the `turn/start` response
   turn ID is recorded but not trusted.
+- A bounded pre-echo terminal buffer handles terminal-before-identity without
+  allowing the domain's `starting` state to accept an arbitrary turn ID.
 - A lost RPC response after the identity echo does not start a duplicate turn.
 - Interrupt requires an active registry entry for the exact derived thread and
   turn. Source, sibling and unknown identities are rejected locally.
@@ -71,12 +75,13 @@ and prohibits further mutation.
 
 ## Audit boundary
 
-Audit entries contain action, logical ownership IDs, runtime/version,
+Audit entries contain action, hashed ownership IDs, runtime/version,
 topology/evidence revision, terminal status/rejection reason and timestamp.
 They never contain prompt/result bodies,
 credentials, environment, paths, request payloads or model output. The current
-callback is an internal sink interface; durable storage and authorization are
-future Hub work.
+callback is a non-throwing internal sink boundary: synchronous throws and
+rejected promises cannot orphan or duplicate runtime work. Durable transactional
+storage and authorization are future Hub work.
 
 ## Deliberate omissions
 

--- a/docs/design/side-thread-pr1-contract.md
+++ b/docs/design/side-thread-pr1-contract.md
@@ -16,7 +16,7 @@ Codex 0.148.0 does not have one Boolean "exact fork" capability:
 - `beforeTurnId` (`kind: before`) is experimental and is rejected unless the
   client negotiated `initialize.capabilities.experimentalApi=true`.
 
-The adapter therefore reports:
+After all gates pass, the adapter reports:
 
 ```ts
 exactBoundary: { through: true, before: experimentalApi }
@@ -24,8 +24,11 @@ exactBoundary: { through: true, before: experimentalApi }
 
 The domain asks for the selected boundary, and fails before `thread/fork` if
 that specific boundary is unavailable. Runtime version must be exactly
-`0.148.0` and topology must be `owned`; shared app-server and every other
-version are typed unsupported.
+`0.148.0`, topology must be `owned-stdio`, and evidence revision must be the
+reviewed `test1190-wire-v2`. PR0 currently has blockers and has not produced
+that revision, so present production inputs remain unsupported. Shared
+app-server, owned WebSocket, every other version and stale evidence are typed
+unsupported.
 
 This is an adapter allowlist, not a repository-wide Codex dependency upgrade.
 `agent-node/package-lock.json` still resolves Codex SDK/CLI 0.133.0, while the
@@ -68,8 +71,9 @@ and prohibits further mutation.
 
 ## Audit boundary
 
-Audit entries contain action, logical ownership IDs, runtime/version, terminal
-status/rejection reason and timestamp. They never contain prompt/result bodies,
+Audit entries contain action, logical ownership IDs, runtime/version,
+topology/evidence revision, terminal status/rejection reason and timestamp.
+They never contain prompt/result bodies,
 credentials, environment, paths, request payloads or model output. The current
 callback is an internal sink interface; durable storage and authorization are
 future Hub work.

--- a/docs/design/side-thread-pr2-hub-contract.md
+++ b/docs/design/side-thread-pr2-hub-contract.md
@@ -1,0 +1,40 @@
+# SideThread PR2 Hub contract
+
+Status: Draft, feature-gated, stacked on PR1 #1194. This change is not an
+authorization to merge or release.
+
+The Hub owns durable SideThread records, attempts, operation receipts,
+bring-back receipts, and metadata-only events. `question_text` and result text
+are returned only through an exact owner/node authorization projection. Audit
+and SSE events contain identifiers, state, and allow-listed reason codes but
+never question/result bodies or runtime exception text.
+
+The runtime boundary is `SideThreadExecutionPort`. It exposes only verified
+native exact-fork operations and has no task/inbox/FIFO method. The default
+adapter returns `SIDE_THREAD_UNSUPPORTED`; the HTTP surface is additionally
+guarded by `COMMHUB_ENABLE_SIDE_THREADS=1`.
+
+Every runtime mutation has a stable `operationId` and a durable operation row.
+An accepted request followed by response loss becomes `ambiguous` and returns
+`SIDE_THREAD_AMBIGUOUS` with correlation IDs. Replaying the same request key
+does not issue a second RPC. A later authoritative event may reconcile an
+ambiguous start using the exact `(sideThreadId, attemptId, threadId, turnId)`
+ownership tuple.
+
+Public wire names and nullability are frozen in
+`contracts/side-thread/v1/schema.json` and `golden.json`. Public JSON uses
+`sideThreadId` and `question`; DB/domain `side_chat_id` names do not leak.
+Only completed bring-back receipts set `broughtBack=true`, and a unique DB
+constraint prevents a second write to the same attempt/destination even when
+the caller supplies a new request key.
+
+The capability endpoint requires the requested source thread and exact
+boundary in addition to the authorized node. A supported response echoes that
+context. This prevents a generic runtime capability from being mistaken for
+evidence that one particular exact-boundary fork is supported.
+
+Stack dependency: PR1 rev4 supplies the native runtime adapter's persistent
+fork lease, pre-fork snapshot/reconciliation, and runtime operation journal.
+PR2 remains decoupled through the execution port; production wiring must map
+the Hub's stable operation identity into that adapter and must never substitute
+ordinary task delivery.

--- a/docs/rfcs/RFC-036-btw-side-thread.md
+++ b/docs/rfcs/RFC-036-btw-side-thread.md
@@ -1,0 +1,163 @@
+# RFC-036: `/btw` Codex side thread (PR0 capability contract)
+
+| Field | Value |
+|---|---|
+| Status | **Draft — probe evidence only; no product/API implementation authorized** |
+| Tracking | `sleep2agi/agent-network-app#175` |
+| Protocol baseline | `codex-cli 0.148.0`, exact npm pin |
+| Evidence | `tests/test1190-codex-btw-wire-probe`, `docs/tests/report-test1190-codex-btw-wire-probe.md` |
+
+## 1. Decision
+
+`/btw` is a separate side-chat resource. It is not a task priority, a steer,
+or a second request on the node's persistent main thread. PR0 does not add a
+slash command, REST endpoint, queue row, or UI. It freezes and probes the
+Codex app-server wire contract that a later implementation may use.
+
+The first supported adapter may be `codex-app-server` only. Every other
+runtime, and every Codex version/capability combination not proven by the
+probe, is `unsupported`. A caller must receive that result before a Hub inbox
+row is created. Falling back to ordinary `send_task`, high priority, or
+`turn/steer` is forbidden.
+
+## 2. Proven 0.148.0 wire behavior
+
+The Docker live probe uses the real vendor binary and an isolated authenticated
+`CODEX_HOME`; it does not mock JSON-RPC.
+
+| Question | Observed result |
+|---|---|
+| Exact fork through a completed turn while a later source turn runs | `thread/fork {threadId,lastTurnId}` succeeds |
+| Fork immediately before the active turn | `thread/fork {threadId,beforeTurnId}` succeeds |
+| Use the active turn as inclusive boundary | rejected with JSON-RPC `-32600` |
+| Source + two forked threads active together | supported by the app-server |
+| Interrupt one fork with exact `(threadId,turnId)` | target becomes `interrupted`; sibling and source complete |
+| Archive | succeeds; archived thread remains readable |
+| Delete | succeeds; subsequent `thread/read` is rejected (`-32600`) |
+
+`beforeTurnId` and the tested exact-boundary surface require the client to
+declare `initialize.capabilities.experimentalApi=true`. Without that opt-in,
+the server rejects the request even though the generated experimental schema
+contains the field. Therefore a version comparison or schema grep alone is
+not a capability check.
+
+These findings apply only to the exact Linux npm artifact pinned in the suite.
+They do not prove behavior for 0.147, future versions, shared app-server
+topology, Codex SDK, or another runtime.
+
+## 3. Minimum future resource model
+
+```ts
+type SideChat = {
+  id: string;
+  nodeId: string;
+  sourceThreadId: string;
+  boundary: { kind: "through" | "before"; turnId: string };
+  derivedThreadId: string;
+  runtime: "codex-app-server";
+  runtimeVersion: "0.148.0";
+  capabilityMode: "native-fork";
+  state: "creating" | "running" | "completed" | "failed" |
+         "cancelled" | "archived" | "purged";
+  activeAttempt?: { attemptId: string; turnId: string };
+};
+```
+
+Hub/agent-node owns this state and the runtime connection. App clients render
+it. Event ownership requires the complete tuple
+`(sideChatId, attemptId, derivedThreadId, turnId)`. A missing or mismatched
+member is dropped and audited; it must never fall back to "current thread",
+"current turn", selected chat, or most recent request.
+
+The fork boundary must be selected from an authoritative `thread/read`, never
+from an App-side conversation cache. While a source turn is active, the safe
+default is the last terminal turn (`lastTurnId`) or equivalently the active
+turn's `beforeTurnId`. If the server cannot prove either identifier, creation
+fails closed.
+
+## 4. Cancellation and retention invariants
+
+- Cancellation is exactly `turn/interrupt {derivedThreadId, derivedTurnId}`.
+  No shared `AbortController`, bridge-global active turn, or source turn ID may
+  be used.
+- Retry creates a new `attemptId` and turn ID. Terminal notifications for an
+  older attempt cannot settle the newer attempt.
+- `archive` is reversible/retained state, not deletion. UI must say archived.
+- `delete` is allowed only after terminal state and an ownership check proving
+  the thread was created for this SideChat.
+- Purge may remove only SideChat-owned caches and attachment references. A
+  shared source file or content-addressed upload requires reference counting;
+  path-prefix deletion is forbidden.
+- Closing a panel is not cancellation. Process/socket/listener/timer cleanup
+  is separate from persisted thread retention.
+
+## 5. Capability negotiation
+
+The future adapter must run a startup capability gate containing all of:
+
+1. exact runtime name and version allowlist;
+2. successful initialization with `experimentalApi` explicitly negotiated;
+3. method/field schema match against the reviewed golden;
+4. topology match (`owned` versus `shared` is a separate evidence cell);
+5. a runtime health probe that does not mutate the main thread.
+
+Any unknown value returns structured `unsupported`; it does not enqueue.
+Removing the experimental requirement or widening the version range needs a
+new live capture and independent review.
+
+## 6. PR sequence after PR0
+
+- PR1: internal SideChat protocol/state machine and fail-closed capability API;
+  no App command.
+- PR2: Codex adapter with durable ownership ledger, recovery, cancellation,
+  archive and purge guards.
+- PR3: Hub endpoints/events, authorization and audit redaction.
+- PR4: shared App state/reducer and desktop/mobile presentation.
+- PR5: explicit bring-back with idempotency and provenance.
+
+Each stage stays disabled until the preceding Docker layer passes.
+
+## 7. Acceptance red lines
+
+- Source turn receives no steer, interrupt, pause, or BTW item.
+- Source `thread/read` contains no BTW question or answer by default.
+- Two BTW attempts may complete out of order without cross-settlement.
+- Cancelling one derived turn leaves source and sibling terminal status intact.
+- Unsupported runtime/version produces no task, inbox, turn, or local outbox row.
+- Bring-back is explicit, idempotent, provenance-labelled, and the only write
+  into the main conversation.
+- Stress teardown returns listener, timer, socket, child and active-turn counts
+  to baseline.
+- Desktop and mobile use one lifecycle reducer; platform shells cannot define
+  their own state transitions.
+
+## 8. Mandatory third-party review checklist
+
+The reviewer must inspect raw/sanitized wire evidence and attempt fault
+injection, not only the happy-path assertions.
+
+- [ ] Verify npm version is exact and golden changes cannot pass under `latest`.
+- [ ] Verify `experimentalApi` is negotiated and missing capability fails closed.
+- [ ] Verify boundary IDs come from authoritative source thread state.
+- [ ] Race source completion against both fork variants; reject ambiguous point.
+- [ ] Race cancel against completion and retry; old terminal cannot settle new attempt.
+- [ ] Confirm all notifications are filtered by side/attempt/thread/turn tuple.
+- [ ] Kill transport during fork/start/interrupt and inspect recovery ownership.
+- [ ] Test owned and shared app-server separately; do not infer parity.
+- [ ] Confirm approvals, sandbox, cwd, instructions and workspace roots inherited
+      or overridden exactly as documented, without privilege escalation.
+- [ ] Confirm audit excludes auth tokens, prompt bodies, environment secrets and
+      private filesystem paths.
+- [ ] Confirm archive and delete labels match real semantics.
+- [ ] Prove purge ownership and attachment reference counting with shared files.
+- [ ] Measure listener/timer/socket/process/thread counts after repeated failures.
+- [ ] Confirm unsupported runtimes never enter normal priority/FIFO/steer paths.
+- [ ] Confirm desktop and mobile exercise the same reducer contract.
+
+## 9. Non-goals of this draft
+
+No fallback snapshot design is approved. A new-thread snapshot can leak system
+instructions, secrets, tool output, absolute paths and attachments, and cannot
+claim native-fork equivalence without a separate whitelist and probe suite.
+No UI design, automatic write-back, cross-runtime parity, merge or release is
+part of PR0.

--- a/docs/rfcs/RFC-036-btw-side-thread.md
+++ b/docs/rfcs/RFC-036-btw-side-thread.md
@@ -4,7 +4,7 @@
 |---|---|
 | Status | **Draft — probe evidence only; no product/API implementation authorized** |
 | Tracking | `sleep2agi/agent-network-app#175` |
-| Protocol baseline | `codex-cli 0.148.0`, exact npm pin |
+| Protocol baseline | probe-only `codex-cli 0.148.0`, exact npm pin; repository `agent-node` remains on `@openai/codex-sdk 0.133.0` |
 | Evidence | `tests/test1190-codex-btw-wire-probe`, `docs/tests/report-test1190-codex-btw-wire-probe.md` |
 
 ## 1. Decision
@@ -27,21 +27,25 @@ The Docker live probe uses the real vendor binary and an isolated authenticated
 
 | Question | Observed result |
 |---|---|
-| Exact fork through a completed turn while a later source turn runs | `thread/fork {threadId,lastTurnId}` succeeds |
-| Fork immediately before the active turn | `thread/fork {threadId,beforeTurnId}` succeeds |
+| Exact fork through a completed turn while a later source turn runs | `thread/fork {threadId,lastTurnId}` yields exactly the source turns through that turn |
+| Fork immediately before the active turn | `thread/fork {threadId,beforeTurnId}` excludes that active turn and yields the same exact prefix |
 | Use the active turn as inclusive boundary | rejected with JSON-RPC `-32600` |
-| Source + two forked threads active together | supported by the app-server |
+| Source + two forked threads active together | all three are observed `active` before cancellation; monotonic events prove cancellation precedes all three terminals |
 | Interrupt one fork with exact `(threadId,turnId)` | target becomes `interrupted`; sibling and source complete |
-| Archive | succeeds; archived thread remains readable |
-| Delete | succeeds; subsequent `thread/read` is rejected (`-32600`) |
+| Two successful forks finish out of creation order | supported; the second-created fast fork completes before the first-created slow fork |
+| Archive/unarchive | both succeed and the restored thread remains readable |
+| Delete isolation | deleted sibling becomes unreadable while source and another derived thread remain readable |
 
-`beforeTurnId` and the tested exact-boundary surface require the client to
-declare `initialize.capabilities.experimentalApi=true`. Without that opt-in,
-the server rejects the request even though the generated experimental schema
-contains the field. Therefore a version comparison or schema grep alone is
-not a capability check.
+`lastTurnId` is present in both the normal and experimental generated schemas
+and does not require experimental API negotiation. `beforeTurnId` is present
+only in the experimental schema and requires
+`initialize.capabilities.experimentalApi=true`. The gate records these as
+separate capabilities; it must not hard-code one conclusion for both fork
+forms.
 
 These findings apply only to the exact Linux npm artifact pinned in the suite.
+That 0.148.0 allowlist is evidence for this probe, not an upgrade or unified
+pin for the repository's 0.133.0 Codex SDK dependency.
 They do not prove behavior for 0.147, future versions, shared app-server
 topology, Codex SDK, or another runtime.
 
@@ -56,6 +60,8 @@ type SideChat = {
   derivedThreadId: string;
   runtime: "codex-app-server";
   runtimeVersion: "0.148.0";
+  topology: "owned-stdio";
+  evidenceRevision: "test1190-wire-v2";
   capabilityMode: "native-fork";
   state: "creating" | "running" | "completed" | "failed" |
          "cancelled" | "archived" | "purged";
@@ -96,14 +102,15 @@ fails closed.
 The future adapter must run a startup capability gate containing all of:
 
 1. exact runtime name and version allowlist;
-2. successful initialization with `experimentalApi` explicitly negotiated;
+2. exact per-field negotiation (`lastTurnId` normal; `beforeTurnId`
+   experimental), with unsupported combinations rejected;
 3. method/field schema match against the reviewed golden;
 4. topology match (`owned` versus `shared` is a separate evidence cell);
 5. a runtime health probe that does not mutate the main thread.
 
 Any unknown value returns structured `unsupported`; it does not enqueue.
-Removing the experimental requirement or widening the version range needs a
-new live capture and independent review.
+Changing field negotiation or widening the version range needs a new live
+capture and independent review.
 
 ## 6. PR sequence after PR0
 
@@ -137,9 +144,15 @@ The reviewer must inspect raw/sanitized wire evidence and attempt fault
 injection, not only the happy-path assertions.
 
 - [ ] Verify npm version is exact and golden changes cannot pass under `latest`.
-- [ ] Verify `experimentalApi` is negotiated and missing capability fails closed.
+- [ ] Verify normal and experimental schemas independently: `lastTurnId` is
+      normal while `beforeTurnId` is experimental and fails closed without it.
 - [ ] Verify boundary IDs come from authoritative source thread state.
 - [ ] Race source completion against both fork variants; reject ambiguous point.
+- [ ] Inspect authoritative `thread/read` turn sets and `forkedFromId`; RPC
+      success alone is not boundary evidence.
+- [ ] Require a monotonic event trace proving all three threads active together,
+      cancellation before every terminal, and two successful forks finishing
+      in reverse creation order.
 - [ ] Race cancel against completion and retry; old terminal cannot settle new attempt.
 - [ ] Confirm all notifications are filtered by side/attempt/thread/turn tuple.
 - [ ] Kill transport during fork/start/interrupt and inspect recovery ownership.

--- a/docs/tests/report-test1190-codex-btw-wire-probe.md
+++ b/docs/tests/report-test1190-codex-btw-wire-probe.md
@@ -1,0 +1,57 @@
+# test1190 — Codex `/btw` app-server wire probe
+
+Date: 2026-08-26  
+Source: PR0 branch based on `origin/main` `aca3a926`  
+Vendor artifact: `@openai/codex@0.148.0` (`codex-cli 0.148.0`)  
+Environment: Docker `node:22-bookworm-slim`; isolated copied `CODEX_HOME`
+
+## Commands
+
+Schema/golden gate (credential-free):
+
+```sh
+sg docker -c 'docker build -f tests/test1190-codex-btw-wire-probe/Dockerfile -t anet-test1190 .'
+sg docker -c 'docker run --rm anet-test1190'
+```
+
+Live gate uses an authenticated, disposable `CODEX_HOME` mount. Credentials
+were not printed or committed:
+
+```sh
+sg docker -c 'docker run --rm -e BTW_LIVE_PROBE=1 \
+  -e CODEX_HOME=/codex-home -v <disposable-home>:/codex-home anet-test1190'
+```
+
+## Result
+
+Both gates passed. The normalized live golden records no thread IDs, turn IDs,
+prompt output, credentials or filesystem paths.
+
+```json
+{
+  "exactCompletedBoundary": true,
+  "exactBeforeActiveBoundary": true,
+  "activeLastTurnFailsClosed": true,
+  "cancelledOnlyDerived": true,
+  "siblingCompleted": true,
+  "sourceCompleted": true,
+  "archiveIsNotDelete": true,
+  "deletedCannotRead": true
+}
+```
+
+Raw semantic observations are frozen in
+`tests/test1190-codex-btw-wire-probe/golden/live-result.json`. Exact fork
+boundary requires `initialize.capabilities.experimentalApi=true`; omission was
+observed to fail with `-32600` and is a mandatory fail-closed gate.
+
+## Limits
+
+- Authentication is required for real model turns, so default CI runs the
+  schema golden only. A protected credentialed job must run the live gate on
+  version/golden changes.
+- This proves the owned stdio app-server topology only. Shared WebSocket/TUI
+  topology remains unsupported for `/btw` until separately probed.
+- It proves protocol 0.148.0 only, not a semver range.
+- It does not implement SideChat storage, API, App UI, fallback snapshot,
+  write-back, archive policy or purge.

--- a/docs/tests/report-test1190-codex-btw-wire-probe.md
+++ b/docs/tests/report-test1190-codex-btw-wire-probe.md
@@ -3,7 +3,7 @@
 Date: 2026-08-26  
 Source: PR0 branch based on `origin/main` `aca3a926`  
 Vendor artifact: `@openai/codex@0.148.0` (`codex-cli 0.148.0`)  
-Environment: Docker `node:22-bookworm-slim`; isolated copied `CODEX_HOME`
+Environment: Docker `node:22-bookworm-slim`; sentinel-marked disposable `CODEX_HOME`
 
 ## Commands
 
@@ -14,36 +14,44 @@ sg docker -c 'docker build -f tests/test1190-codex-btw-wire-probe/Dockerfile -t 
 sg docker -c 'docker run --rm anet-test1190'
 ```
 
-Live gate uses an authenticated, disposable `CODEX_HOME` mount. Credentials
-were not printed or committed:
+Live gate uses an authenticated, disposable `CODEX_HOME` mount containing the
+checked-in sentinel value `test1190-disposable-v2`. The guarded cleanup also
+removes root-owned files written by the container. Credentials were not
+printed or committed:
 
 ```sh
 sg docker -c 'docker run --rm -e BTW_LIVE_PROBE=1 \
-  -e CODEX_HOME=/codex-home -v <disposable-home>:/codex-home anet-test1190'
+  -e CODEX_HOME=/codex-home -e REPORT_DIR=/out \
+  -v <disposable-home>:/codex-home -v <report-dir>:/out anet-test1190'
 ```
 
 ## Result
 
-Both gates passed. The normalized live golden records no thread IDs, turn IDs,
-prompt output, credentials or filesystem paths.
+Both gates passed. The normal and experimental protocol schemas are generated
+separately. The live gate records an inspectable sanitized wire trace with
+monotonic sequence numbers and logical aliases only: no UUIDs, prompt bodies,
+credentials, or filesystem paths.
 
 ```json
 {
-  "exactCompletedBoundary": true,
-  "exactBeforeActiveBoundary": true,
-  "activeLastTurnFailsClosed": true,
-  "cancelledOnlyDerived": true,
-  "siblingCompleted": true,
-  "sourceCompleted": true,
-  "archiveIsNotDelete": true,
-  "deletedCannotRead": true
+  "evidenceRevision": "test1190-wire-v2",
+  "topology": "owned-stdio",
+  "sourceWasActiveAtFork": true,
+  "authoritativeForkTurnSets": true,
+  "threeWayActiveBeforeCancel": true,
+  "cancelPrecedesSourceAndSiblingTerminal": true,
+  "successfulForksCompleteOutOfCreationOrder": true,
+  "unarchiveReadable": true,
+  "deleteLeavesSourceAndSiblingReadable": true
 }
 ```
 
-Raw semantic observations are frozen in
-`tests/test1190-codex-btw-wire-probe/golden/live-result.json`. Exact fork
-boundary requires `initialize.capabilities.experimentalApi=true`; omission was
-observed to fail with `-32600` and is a mandatory fail-closed gate.
+Semantic observations are frozen in `golden/live-result.json`; request,
+response, Thread, Turn, and notification shapes are frozen in
+`golden/schema-result.json`. `lastTurnId` is normal API; `beforeTurnId` alone
+requires experimental negotiation. The suite also reruns a witnessed-red
+variant that deliberately lets the source finish before forking and requires
+the probe to fail with `WITNESS_RED: source was not active at fork boundary`.
 
 ## Limits
 
@@ -52,6 +60,8 @@ observed to fail with `-32600` and is a mandatory fail-closed gate.
   version/golden changes.
 - This proves the owned stdio app-server topology only. Shared WebSocket/TUI
   topology remains unsupported for `/btw` until separately probed.
-- It proves protocol 0.148.0 only, not a semver range.
+- It proves the exact 0.148.0 Linux npm artifact only, not a semver range. This
+  is a probe allowlist, not a repository-wide upgrade from the agent-node
+  Codex SDK lock at 0.133.0.
 - It does not implement SideChat storage, API, App UI, fallback snapshot,
   write-back, archive policy or purge.

--- a/docs/tests/report-test1193-side-thread-contract.md
+++ b/docs/tests/report-test1193-side-thread-contract.md
@@ -8,7 +8,8 @@ The suite runs the runtime-neutral domain and Codex adapter tests inside an
 independent `oven/bun:1.3.14-debian` image. It covers:
 
 - typed unsupported results before any fork request;
-- exact 0.148.0 + owned topology + experimental API capability gate;
+- exact 0.148.0 + owned-stdio topology + reviewed evidence revision gate;
+- boundary-specific experimental API capability (`before`, not `through`);
 - concurrent create/attempt idempotency;
 - native `lastTurnId` and `beforeTurnId` request shapes;
 - absence of permission, sandbox, cwd and instruction overrides;

--- a/docs/tests/report-test1193-side-thread-contract.md
+++ b/docs/tests/report-test1193-side-thread-contract.md
@@ -11,14 +11,20 @@ independent `oven/bun:1.3.14-debian` image. It covers:
 - exact 0.148.0 + owned-stdio topology + reviewed evidence revision gate;
 - boundary-specific experimental API capability (`before`, not `through`);
 - concurrent create/attempt idempotency;
+- per-side serialization and single-flight cancel/archive/purge;
 - native `lastTurnId` and `beforeTurnId` request shapes;
 - absence of permission, sandbox, cwd and instruction overrides;
 - binding by echoed `clientUserMessageId`, not the turn/start response ID;
 - exact derived-thread/turn cancellation and rejection of source/sibling IDs;
 - out-of-order terminal isolation and duplicate/late terminal drops;
+- bounded terminal-before-identity buffering and adapter-level dropped-event audit;
+- unique derived-thread ownership and starting-attempt delete refusal;
+- immutable capability attestation on every mutation;
 - archive/purge idempotency and active-turn deletion refusal;
-- field-minimized audit without prompt/result bodies;
-- listener teardown.
+- hashed, field-minimized, non-throwing audit without prompt/result bodies;
+- close during pending start without unhandled rejection or post-close state;
+- strict identity rejection for bearer/path/newline-shaped values;
+- listener/timer/execution teardown.
 
 The run script also weakens the exact version gate and requires the adapter
 test to turn red. A green suite therefore proves the tested fail-closed branch

--- a/docs/tests/report-test1193-side-thread-contract.md
+++ b/docs/tests/report-test1193-side-thread-contract.md
@@ -11,6 +11,15 @@ independent `oven/bun:1.3.14-debian` image. It covers:
 - exact 0.148.0 + owned-stdio topology + reviewed evidence revision gate;
 - boundary-specific experimental API capability (`before`, not `through`);
 - concurrent create/attempt idempotency;
+- stable side/attempt identities across ambiguous retries;
+- private atomic persistent operation journal with immutable identities and
+  monotonic state transitions;
+- crash-persistent per-source fork leases without timeout stealing;
+- paginated `thread/list` snapshot before every fork;
+- unique-candidate fork reconciliation after response loss, with zero/multiple
+  candidates remaining ambiguous and never causing a second fork RPC;
+- accepted/ambiguous start, interrupt, archive and delete replay with exactly
+  one runtime RPC;
 - per-side serialization and single-flight cancel/archive/purge;
 - native `lastTurnId` and `beforeTurnId` request shapes;
 - absence of permission, sandbox, cwd and instruction overrides;
@@ -29,6 +38,11 @@ independent `oven/bun:1.3.14-debian` image. It covers:
 The run script also weakens the exact version gate and requires the adapter
 test to turn red. A green suite therefore proves the tested fail-closed branch
 is reachable rather than merely present in source.
+
+Rev4 result: **32 tests passed, 0 failed, 109 assertions**, followed by the
+existing witnessed-red mutation pass. The suite now includes all four test
+files under `agent-node/src/runtime/side-thread`, so ledger/lease tests cannot
+silently fall outside the Docker gate.
 
 Command:
 

--- a/docs/tests/report-test1193-side-thread-contract.md
+++ b/docs/tests/report-test1193-side-thread-contract.md
@@ -1,0 +1,32 @@
+# test1193 — SideThread domain and Codex adapter contract
+
+Date: 2026-08-26  
+Layer: Docker, credential-free  
+Dependency: PR0 / test1190 wire evidence for `codex-cli 0.148.0`
+
+The suite runs the runtime-neutral domain and Codex adapter tests inside an
+independent `oven/bun:1.3.14-debian` image. It covers:
+
+- typed unsupported results before any fork request;
+- exact 0.148.0 + owned topology + experimental API capability gate;
+- concurrent create/attempt idempotency;
+- native `lastTurnId` and `beforeTurnId` request shapes;
+- absence of permission, sandbox, cwd and instruction overrides;
+- binding by echoed `clientUserMessageId`, not the turn/start response ID;
+- exact derived-thread/turn cancellation and rejection of source/sibling IDs;
+- out-of-order terminal isolation and duplicate/late terminal drops;
+- archive/purge idempotency and active-turn deletion refusal;
+- field-minimized audit without prompt/result bodies;
+- listener teardown.
+
+The run script also weakens the exact version gate and requires the adapter
+test to turn red. A green suite therefore proves the tested fail-closed branch
+is reachable rather than merely present in source.
+
+Command:
+
+```sh
+sg docker -c 'docker build -f tests/test1193-side-thread-contract/Dockerfile \
+  --build-arg TEST1193_SOURCE_COMMIT=$(git rev-parse HEAD) \
+  -t anet-test1193 . && docker run --rm anet-test1193'
+```

--- a/docs/tests/report-test1193.txt
+++ b/docs/tests/report-test1193.txt
@@ -1,0 +1,36 @@
+test1193 — SideThread PR1 rev4 runtime ledger
+Date: 2026-08-26
+Layer: Docker L1, credential-free
+Source commit: 635a657bdbae4c1770e28eeb4ba896b45e5ad707
+Image: oven/bun:1.3.14-debian
+
+Command:
+  sg docker -c 'docker build -f tests/test1193-side-thread-contract/Dockerfile \
+    --build-arg TEST1193_SOURCE_COMMIT=$(git rev-parse HEAD) \
+    -t anet-test1193-pr1-rev4-exact . && \
+    docker run --rm anet-test1193-pr1-rev4-exact'
+
+Result:
+  32 pass
+  0 fail
+  109 expect() calls
+  PASS test1193 side-thread domain/adapter contract + witnessed red
+
+Covered fault evidence:
+  - private 0700/0600 persistent operation ledger and fork lease
+  - immutable stable operation identity and monotonic state transitions
+  - fork thread/list snapshot precedes thread/fork
+  - lost fork response reconciles only one new forkedFromId candidate
+  - multiple candidates remain ambiguous and retry emits no second thread/fork
+  - lost start identity reconciles by persisted client identity without retry RPC
+  - accepted/ambiguous start, interrupt, archive and delete emit one RPC only
+  - ambiguous domain retries reuse the original side-thread and attempt IDs
+
+Supplemental Docker checks:
+  - check-test-suite-registration.py: new=0, PASS
+  - check-l1-paths-sync.py: 54 L1 suites / 136 patterns, PASS
+  - lint-no-bare-rm-rf.sh: 266 shell files, PASS
+  - Bun build of domain/adapter/lease/ledger entry points: PASS
+
+No production service, local global package, npm preview, merge, or release was
+modified by this verification.

--- a/docs/tests/report-test1195-side-thread-hub.txt
+++ b/docs/tests/report-test1195-side-thread-hub.txt
@@ -1,12 +1,12 @@
 SideThread Hub PR2 Docker evidence
 Date: 2026-08-26 Asia/Shanghai
-Tested source commit: 72fe67b983c390e77cb81a461739886b4e85cb61
+Tested source commit: a07effabd9e5b752e9a094681d52af5c6f646284
 Stack base: c0981ecc26b8b570ff29a30da2d926fdc8ec4a09 (PR #1194 rev4)
 
 Layer 1 — contract
   image: anet-test1195-contract-final
   result: PASS
-  tests: 7 pass, 0 fail, 30 assertions
+  tests: 7 pass, 0 fail, 31 assertions
   witnessed-red: native exact-fork mode gate mutation rejected
   includes schema/golden projection drift check
 
@@ -27,7 +27,7 @@ Layer 3 — races/faults
   uniqueness, response-loss ambiguity/reconciliation, and no-repeat
   cancel/archive/purge RPCs
 
-Total final Docker evidence: 21 pass, 0 fail, 109 assertions, 3 witnessed-red.
+Total final Docker evidence: 21 pass, 0 fail, 110 assertions, 3 witnessed-red.
 
 Preflight:
   check-test-suite-registration.py PASS (no new unregistered suite)

--- a/docs/tests/report-test1195-side-thread-hub.txt
+++ b/docs/tests/report-test1195-side-thread-hub.txt
@@ -1,17 +1,18 @@
 SideThread Hub PR2 Docker evidence
 Date: 2026-08-26 Asia/Shanghai
-Tested source commit: a07effabd9e5b752e9a094681d52af5c6f646284
+Tested source commit: 0744c312f9188278f243d4266ddd8acab8493c7b
 Stack base: c0981ecc26b8b570ff29a30da2d926fdc8ec4a09 (PR #1194 rev4)
 
 Layer 1 — contract
-  image: anet-test1195-contract-final
+  image: anet-test1195-contract-actions
   result: PASS
-  tests: 7 pass, 0 fail, 31 assertions
+  tests: 8 pass, 0 fail, 35 assertions
   witnessed-red: native exact-fork mode gate mutation rejected
-  includes schema/golden projection drift check
+  includes schema/golden projection drift check and caller requestKey coverage
+  for every mutating POST action
 
 Layer 2 — auth/SSE security
-  image: anet-test1195-security-final
+  image: anet-test1195-security-actions
   result: PASS
   tests: 5 pass, 0 fail, 19 assertions
   witnessed-red: query-string token acceptance mutation rejected
@@ -19,7 +20,7 @@ Layer 2 — auth/SSE security
   and no-FIFO unsupported behavior
 
 Layer 3 — races/faults
-  image: anet-test1195-race-final
+  image: anet-test1195-race-actions
   result: PASS
   tests: 9 pass, 0 fail, 60 assertions
   witnessed-red: weakened four-tuple runtime event ownership mutation rejected
@@ -27,7 +28,14 @@ Layer 3 — races/faults
   uniqueness, response-loss ambiguity/reconciliation, and no-repeat
   cancel/archive/purge RPCs
 
-Total final Docker evidence: 21 pass, 0 fail, 110 assertions, 3 witnessed-red.
+Total final Docker evidence: 22 pass, 0 fail, 114 assertions, 3 witnessed-red.
+
+Complete server unit domain:
+  image: anet-test798-pr1196-actions
+  result: PASS
+  discovered/executed files: 74/74, failed files: 0
+  witnessed-red: weakened registration password floor rejected
+  confirms the schema/golden fixture is present in the CI image
 
 Preflight:
   check-test-suite-registration.py PASS (no new unregistered suite)

--- a/docs/tests/report-test1195-side-thread-hub.txt
+++ b/docs/tests/report-test1195-side-thread-hub.txt
@@ -37,6 +37,16 @@ Complete server unit domain:
   witnessed-red: weakened registration password floor rejected
   confirms the schema/golden fixture is present in the CI image
 
+Aggregate isolation CI image:
+  image: anet-test638-pr1196-exact
+  tested fix commit: c207d3538d4f28d774f165c9eebac46ae732772c
+  result: PASS
+  aggregate: 74 files, 984 pass, 0 fail, 3235 assertions
+  covers normal/reverse concurrent aggregate order, syscall DB isolation,
+  nonzero/timeout/signal/missing-summary/spawn/slug witnessed-red, and the
+  per-file DB isolation mutation
+  root cause fixed: test638 now explicitly copies contracts/side-thread/v1
+
 Preflight:
   check-test-suite-registration.py PASS (no new unregistered suite)
   check-l1-paths-sync.py PASS

--- a/docs/tests/report-test1195-side-thread-hub.txt
+++ b/docs/tests/report-test1195-side-thread-hub.txt
@@ -1,0 +1,42 @@
+SideThread Hub PR2 Docker evidence
+Date: 2026-08-26 Asia/Shanghai
+Tested source commit: 72fe67b983c390e77cb81a461739886b4e85cb61
+Stack base: c0981ecc26b8b570ff29a30da2d926fdc8ec4a09 (PR #1194 rev4)
+
+Layer 1 — contract
+  image: anet-test1195-contract-final
+  result: PASS
+  tests: 7 pass, 0 fail, 30 assertions
+  witnessed-red: native exact-fork mode gate mutation rejected
+  includes schema/golden projection drift check
+
+Layer 2 — auth/SSE security
+  image: anet-test1195-security-final
+  result: PASS
+  tests: 5 pass, 0 fail, 19 assertions
+  witnessed-red: query-string token acceptance mutation rejected
+  covers owner hydration, opaque cross-owner reads, node binding, metadata-only SSE,
+  and no-FIFO unsupported behavior
+
+Layer 3 — races/faults
+  image: anet-test1195-race-final
+  result: PASS
+  tests: 9 pass, 0 fail, 60 assertions
+  witnessed-red: weakened four-tuple runtime event ownership mutation rejected
+  covers terminal-before-ACK, cross-coordinator claims, retry lineage, bring-back
+  uniqueness, response-loss ambiguity/reconciliation, and no-repeat
+  cancel/archive/purge RPCs
+
+Total final Docker evidence: 21 pass, 0 fail, 109 assertions, 3 witnessed-red.
+
+Preflight:
+  check-test-suite-registration.py PASS (no new unregistered suite)
+  check-l1-paths-sync.py PASS
+  lint-no-bare-rm-rf.sh PASS
+  git diff --check PASS
+  server.ts minimal diff: 83 additions, 0 deletions ignoring EOL whitespace
+
+An earlier race image attempt failed before test collection because its
+Dockerfile omitted the vendored golden fixture. Commit 72fe67b9 added that
+explicit COPY; all three layers above were then rebuilt and rerun against the
+same exact source commit. No failed pre-fix run is counted as evidence.

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -64,6 +64,11 @@ L1_TESTS=(
   # RFC-036 PR1: credential-free SideThread state machine + Codex adapter
   # contract. Exact-version fail-closed has a witnessed-red mutation.
   "test1193-side-thread-contract"
+  # #175 PR2: Hub contract, authenticated HTTP/SSE security, and lifecycle
+  # races are separate Docker layers. Each has its own witnessed-red mutation.
+  "test1195-side-thread-hub-contract"
+  "test1195-side-thread-hub-security"
+  "test1195-side-thread-hub-race"
   "qa-cli-01-hub-start"
   "qa-cli-02-network-create"
   "qa-dash-07-auth-boundary"

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -61,6 +61,9 @@ L1_TESTS=(
   # 这道闸门自己的回归。放在最前:它跑的是本脚本,若闸门坏了应当最先暴露。
   # (注册这一步不是可选的 —— 一个没被任何东西调用的套件等于不存在。)
   "test823-l1-concurrency-cap"
+  # RFC-036 PR1: credential-free SideThread state machine + Codex adapter
+  # contract. Exact-version fail-closed has a witnessed-red mutation.
+  "test1193-side-thread-contract"
   "qa-cli-01-hub-start"
   "qa-cli-02-network-create"
   "qa-dash-07-auth-boundary"

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -48,6 +48,8 @@ import { diagnoseTask } from "./task-diagnostic.js";
 import { assertScheduledTaskBackendSupported, handleScheduledTaskRequest, startScheduledTaskScheduler } from "./scheduled-tasks.js";
 import { handleExternalScheduleEditRequest } from "./external-schedule-edits.js";
 import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
+import { SIDE_THREAD_FEATURE_FLAG, SideThreadCoordinator, SideThreadPortRegistry, SideThreadStore, type SideThreadActor, type SideThreadAttachmentRef, type SideThreadExecutionPort } from "./side-thread.js";
+import { handleSideThreadHttpRequest } from "./side-thread-http.js";
 
 const PORT = resolvePort(process.env.PORT);
 const HOST = process.env.HOST || "127.0.0.1";
@@ -62,6 +64,18 @@ const TMUX_ALLOWLIST = new Set(
     .filter(Boolean)
 );
 let masterTokenDeprecationLogged = false;
+
+// #175 PR2 starts fail-closed. Only a verified native adapter can be installed;
+// the execution port deliberately has no ordinary task/FIFO delivery method.
+export const sideThreadPortRegistry = new SideThreadPortRegistry();
+export function installSideThreadExecutionPort(port: SideThreadExecutionPort): () => void {
+  return sideThreadPortRegistry.install(port);
+}
+const sideThreadCoordinator = new SideThreadCoordinator(new SideThreadStore(db), sideThreadPortRegistry, {
+  enabled: process.env[SIDE_THREAD_FEATURE_FLAG] === "1",
+  authorizeNode: (actor, networkId, nodeId) => authorizeSideThreadNode(actor, networkId, nodeId),
+  authorizeAttachment: (actor, networkId, ref) => authorizeSideThreadAttachment(actor, networkId, ref),
+});
 
 if (AUTH_TOKEN) {
   console.warn("[commhub] COMMHUB_AUTH_TOKEN is deprecated and will be removed in v1.0. See RFC-001.");
@@ -235,6 +249,25 @@ function resolveRequestAuth(req: Request, options: RequestTokenOptions = {}): { 
   return { userId: resolved.user.user_id, networkId: resolved.networkId, username: resolved.user.username, tokenName: resolved.tokenName, tokenId: resolved.tokenId };
 }
 
+function resolveSideThreadActor(req: Request, auth: ReturnType<typeof resolveRequestAuth>, isAdmin: boolean): SideThreadActor | null {
+  // Legacy master and DEV_OPEN cannot own durable records because neither
+  // supplies a stable per-user identity for later window hydration.
+  if (!auth?.userId || !auth.tokenId) return null;
+  const nodeCredential = requestToken(req).startsWith("ntok_");
+  const tokenRow = nodeCredential
+    ? db.get<{ bound_node_id: string | null }>("SELECT bound_node_id FROM api_tokens WHERE token_id = ?1", auth.tokenId)
+    : null;
+  return {
+    userId: auth.userId,
+    username: auth.username,
+    tokenId: auth.tokenId,
+    kind: nodeCredential ? "node" : "user",
+    ...(auth.networkId ? { boundNetworkId: auth.networkId } : {}),
+    ...(tokenRow?.bound_node_id ? { boundNodeId: tokenRow.bound_node_id } : {}),
+    isAdmin,
+  };
+}
+
 // #503 — the credential kinds that authorization decisions branch on.
 // Resolved once per request at the handler, so the authz helpers stay
 // pure functions of (principal, entry) and every credential kind is a
@@ -335,6 +368,46 @@ export function authorizeFileDownload(
   // tightening the local-dev carve-out.
   if (entry.ownerId === null && DEV_OPEN) return true;
   return false;
+}
+
+function authorizeSideThreadNode(actor: SideThreadActor, networkId: string, nodeId: string): boolean {
+  const node = db.get<{ network_id: string | null; owner_user_id: string | null }>(
+    "SELECT network_id, owner_user_id FROM nodes WHERE node_id = ?1", nodeId,
+  );
+  if (!node || node.network_id !== networkId) return false;
+  if (!getUserNetworkRole(actor.userId, networkId)) return false;
+  if (!node.owner_user_id || node.owner_user_id !== actor.userId) return false;
+  if (actor.boundNetworkId && actor.boundNetworkId !== networkId) return false;
+  if (actor.kind === "node" && actor.boundNodeId !== nodeId) return false;
+  return true;
+}
+
+function resolveSideThreadCapabilityTarget(input: { actor: SideThreadActor; alias?: string; nodeId?: string; networkId?: string }): { nodeId: string; networkId: string } | undefined {
+  if ((!input.alias && !input.nodeId) || (input.alias && input.nodeId)) return undefined;
+  const networkId = input.actor.boundNetworkId ?? input.networkId;
+  const params: unknown[] = [input.nodeId ?? input.alias];
+  let sql = input.nodeId
+    ? "SELECT node_id,network_id FROM nodes WHERE node_id=?1"
+    : "SELECT node_id,network_id FROM nodes WHERE alias=?1";
+  if (networkId) { params.push(networkId); sql += " AND network_id=?2"; }
+  const authorized = db.all<{ node_id: string; network_id: string | null }>(sql, ...params)
+    .filter(row => !!row.network_id && authorizeSideThreadNode(input.actor, row.network_id, row.node_id));
+  if (authorized.length !== 1) return undefined;
+  return { nodeId: authorized[0].node_id, networkId: authorized[0].network_id! };
+}
+
+function authorizeSideThreadAttachment(actor: SideThreadActor, networkId: string, ref: SideThreadAttachmentRef): boolean {
+  if (!FILE_ID_REGEX.test(ref.fileId)) return false;
+  const path = indexEntryPath(ref.fileId);
+  if (!path || !existsSync(path)) return false;
+  try {
+    const entry = JSON.parse(readFileSync(path, "utf8"));
+    if (!validateIndexEntry(entry) || entry.file_id !== ref.fileId) return false;
+    if (entry.network_id !== networkId || entry.owner_id !== actor.userId) return false;
+    if (!isValidCalendarBucket(entry.date_bucket)) return false;
+    const storage = pathForExistingBlob(entry.date_bucket, entry.file_id, entry.ext);
+    return isPathInsideUploadsRoot(storage.absolutePath) && existsSync(storage.absolutePath);
+  } catch { return false; }
 }
 
 type ByteRange =
@@ -1442,6 +1515,16 @@ return Bun.serve({
     if (restScope.denied) {
       return withCors(req, Response.json({ ok: false, error: restScope.denied }, { status: 403 }));
     }
+
+    const sideThreadResponse = await handleSideThreadHttpRequest({
+      req,
+      url,
+      // Durable prompts/results never accept query-string credentials.
+      actor: resolveSideThreadActor(req, resolveRequestAuth(req, { allowQueryToken: false }), isAdmin),
+      coordinator: sideThreadCoordinator,
+      resolveCapabilityTarget: resolveSideThreadCapabilityTarget,
+    });
+    if (sideThreadResponse) return withCors(req, sideThreadResponse);
 
     // RFC-036 owner-gated host schedule edits. This handler independently
     // verifies exact node ownership and node-token binding; network admin is

--- a/server/src/side-thread-http-integration.test.ts
+++ b/server/src/side-thread-http-integration.test.ts
@@ -1,0 +1,229 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  SideThreadExecutionPort,
+  SideThreadRuntimeEvent,
+} from "./side-thread.js";
+
+const suffix = randomUUID().replace(/-/g, "");
+const dbPath = `/tmp/anet-side-thread-http-${suffix}.db`;
+const ownerToken = `utok_${suffix}`;
+const otherToken = `utok_other_${suffix}`;
+const nodeToken = `ntok_${suffix}`;
+let hub: any;
+let db: any;
+let detachPort: () => void = () => {};
+let base = "";
+
+class HttpFakePort implements SideThreadExecutionPort {
+  listeners = new Set<(event: SideThreadRuntimeEvent) => void>();
+  capability() {
+    return {
+      supported: true,
+      mode: "native-exact-fork" as const,
+      runtime: "codex",
+      runtimeVersion: "0.148.0",
+      topology: "owned-stdio",
+      evidenceRevision: "reviewed",
+      exactBoundary: { through: true, before: true },
+    };
+  }
+  async fork(input: any) {
+    return { threadId: `derived_${input.sideChatId}` };
+  }
+  async start(input: any) {
+    return { turnId: `turn_${input.attemptId}` };
+  }
+  async cancel() {}
+  async archive() {}
+  async purge() {}
+  async bringBack() {
+    return { destinationTurnId: "destination_turn" };
+  }
+  subscribe(listener: (event: SideThreadRuntimeEvent) => void) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+}
+
+function hash(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+function headers(token = ownerToken) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.COMMHUB_DB = dbPath;
+  process.env.COMMHUB_ENABLE_SIDE_THREADS = "1";
+  delete process.env.DATABASE_URL;
+  const dbModule = await import("./db.js");
+  db = dbModule.db;
+  db.run(
+    "INSERT INTO users (user_id,username,password_hash,role) VALUES ('usr_owner','owner','x','user')",
+  );
+  db.run(
+    "INSERT INTO users (user_id,username,password_hash,role) VALUES ('usr_other','other','x','user')",
+  );
+  db.run(
+    "INSERT INTO networks (network_id,network_name,owner_id) VALUES ('net_a','A','usr_owner')",
+  );
+  db.run(
+    "INSERT INTO network_members (network_id,user_id,role) VALUES ('net_a','usr_owner','owner')",
+  );
+  db.run(
+    "INSERT INTO network_members (network_id,user_id,role) VALUES ('net_a','usr_other','member')",
+  );
+  db.run(
+    "INSERT INTO nodes (node_id,node_name,alias,network_id,owner_user_id) VALUES ('node_a','node-a','node-a','net_a','usr_owner')",
+  );
+  db.run(
+    "INSERT INTO nodes (node_id,node_name,alias,network_id,owner_user_id) VALUES ('node_b','node-b','node-b','net_a','usr_owner')",
+  );
+  db.run(
+    "INSERT INTO api_tokens (token_id,token_hash,user_id,name,scope) VALUES ('tok_owner',?1,'usr_owner','owner','user')",
+    [hash(ownerToken)],
+  );
+  db.run(
+    "INSERT INTO api_tokens (token_id,token_hash,user_id,name,scope) VALUES ('tok_other',?1,'usr_other','other','user')",
+    [hash(otherToken)],
+  );
+  db.run(
+    "INSERT INTO api_tokens (token_id,token_hash,user_id,network_id,name,scope,bound_node_id) VALUES ('tok_node',?1,'usr_owner','net_a','node:node-a','network','node_a')",
+    [hash(nodeToken)],
+  );
+  const serverModule = await import("./server.js");
+  detachPort = serverModule.installSideThreadExecutionPort(new HttpFakePort());
+  hub = serverModule.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${hub.port}`;
+});
+
+afterAll(() => {
+  detachPort();
+  try {
+    hub?.stop(true);
+  } catch {}
+  try {
+    db?.close();
+  } catch {}
+});
+
+describe("SideThread authenticated Hub HTTP", () => {
+  let sideChatId = "";
+  test("POST create and GET hydrate the complete question", async () => {
+    const response = await fetch(`${base}/api/side-threads`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        requestKey: "http-create-0001",
+        networkId: "net_a",
+        nodeId: "node_a",
+        sourceThreadId: "source_thread",
+        boundary: { kind: "through", turnId: "source_turn" },
+        prompt: "完整原问题\n第二行",
+      }),
+    });
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as any;
+    sideChatId = body.sideThread.sideThreadId;
+    expect(body.sideThread).toMatchObject({
+      requestKey: "http-create-0001",
+      question: "完整原问题\n第二行",
+      title: "完整原问题",
+      state: "running",
+    });
+    const hydrated = await fetch(`${base}/api/side-threads/${sideChatId}`, {
+      headers: headers(),
+    });
+    expect(((await hydrated.json()) as any).sideThread.question).toBe(
+      "完整原问题\n第二行",
+    );
+    const listed = await fetch(
+      `${base}/api/side-threads?network_id=net_a&limit=20`,
+      { headers: headers() },
+    );
+    expect(await listed.json()).toMatchObject({
+      count: 1,
+      sideThreads: [{ question: "完整原问题\n第二行", bringBacks: [] }],
+    });
+  });
+
+  test("cross-owner and query-token reads cannot recover the question", async () => {
+    const cross = await fetch(`${base}/api/side-threads/${sideChatId}`, {
+      headers: headers(otherToken),
+    });
+    expect(cross.status).toBe(404);
+    expect(JSON.stringify(await cross.json())).not.toContain("完整原问题");
+    const crossList = await fetch(`${base}/api/side-threads`, {
+      headers: headers(otherToken),
+    });
+    const crossListBody = await crossList.json();
+    expect(crossListBody).toMatchObject({ count: 0, sideThreads: [] });
+    expect(JSON.stringify(crossListBody)).not.toContain("完整原问题");
+    const queryOnly = await fetch(
+      `${base}/api/side-threads/${sideChatId}?token=${ownerToken}`,
+    );
+    expect(queryOnly.status).toBe(401);
+  });
+
+  test("SSE replays metadata without question/result bodies", async () => {
+    const response = await fetch(
+      `${base}/api/side-threads/${sideChatId}/events`,
+      { headers: { Authorization: `Bearer ${ownerToken}` } },
+    );
+    expect(response.status).toBe(200);
+    const reader = response.body!.getReader();
+    const chunk = await reader.read();
+    const text = new TextDecoder().decode(chunk.value);
+    await reader.cancel();
+    expect(text).toContain("side_thread");
+    expect(text).toContain("sideThreadId");
+    expect(text).not.toContain("sideChatId");
+    expect(text).not.toContain("完整原问题");
+  });
+
+  test("node token is bound to its exact node", async () => {
+    const response = await fetch(`${base}/api/side-threads`, {
+      method: "POST",
+      headers: headers(nodeToken),
+      body: JSON.stringify({
+        request_key: "http-create-node2",
+        network_id: "net_a",
+        node_id: "node_b",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "must fail",
+      }),
+    });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error: "SIDE_THREAD_NOT_FOUND",
+    });
+  });
+
+  test("removing the verified port yields typed unsupported, never a task row", async () => {
+    detachPort();
+    const before = db.get("SELECT COUNT(*) AS n FROM tasks").n;
+    const response = await fetch(`${base}/api/side-threads`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        request_key: "http-no-port-01",
+        network_id: "net_a",
+        node_id: "node_a",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "no fallback",
+      }),
+    });
+    expect(response.status).toBe(501);
+    expect(await response.json()).toMatchObject({
+      error: "SIDE_THREAD_UNSUPPORTED",
+    });
+    expect(db.get("SELECT COUNT(*) AS n FROM tasks").n).toBe(before);
+  });
+});

--- a/server/src/side-thread-http.ts
+++ b/server/src/side-thread-http.ts
@@ -1,0 +1,503 @@
+import {
+  SIDE_THREAD_API_ACTIONS,
+  SIDE_THREAD_API_ROOT,
+  SideThreadCoordinator,
+  SideThreadError,
+  type SideThreadActor,
+  type SideThreadRecord,
+} from "./side-thread.js";
+
+export interface SideThreadHttpContext {
+  req: Request;
+  url: URL;
+  actor: SideThreadActor | null;
+  coordinator: SideThreadCoordinator;
+  resolveCapabilityTarget?: (input: {
+    actor: SideThreadActor;
+    alias?: string;
+    nodeId?: string;
+    networkId?: string;
+  }) => { nodeId: string; networkId: string } | undefined;
+}
+
+export async function handleSideThreadHttpRequest(
+  ctx: SideThreadHttpContext,
+): Promise<Response | null> {
+  const root = ctx.url.pathname === SIDE_THREAD_API_ROOT;
+  const capabilityPath =
+    ctx.url.pathname === `${SIDE_THREAD_API_ROOT}/capability`;
+  const match = ctx.url.pathname.match(
+    new RegExp(
+      `^${SIDE_THREAD_API_ROOT}/([^/]+)(?:/(${SIDE_THREAD_API_ACTIONS.join("|")}))?$`,
+    ),
+  );
+  if (!root && !capabilityPath && !match) return null;
+  if (!ctx.coordinator.isEnabled())
+    return json({ ok: false, error: "SIDE_THREAD_DISABLED" }, 404);
+  if (!ctx.actor)
+    return json({ ok: false, error: "SIDE_THREAD_AUTH_REQUIRED" }, 401);
+
+  try {
+    if (capabilityPath) {
+      if (ctx.req.method !== "GET") return methodNotAllowed("GET");
+      const target = ctx.resolveCapabilityTarget?.({
+        actor: ctx.actor,
+        alias: query(ctx.url, "alias"),
+        nodeId: query(ctx.url, "nodeId", "node_id"),
+        networkId: query(ctx.url, "networkId", "network_id"),
+      });
+      if (!target)
+        throw new SideThreadError(
+          "SIDE_THREAD_NOT_FOUND",
+          "node not found",
+          404,
+        );
+      const sourceThreadId = requiredQueryIdentity(ctx.url, "sourceThreadId");
+      const boundaryKind = query(ctx.url, "boundaryKind");
+      const boundaryTurnId = requiredQueryIdentity(ctx.url, "boundaryTurnId");
+      if (boundaryKind !== "through" && boundaryKind !== "before")
+        throw new SideThreadError(
+          "SIDE_THREAD_INVALID_CONTEXT",
+          "boundaryKind must be through or before",
+          400,
+        );
+      const boundary = { kind: boundaryKind, turnId: boundaryTurnId } as const;
+      const capability = await ctx.coordinator.capability(
+        ctx.actor,
+        target.networkId,
+        target.nodeId,
+        boundary,
+      );
+      return json({
+        ok: true,
+        capability: serializeCapability(capability, {
+          networkId: target.networkId,
+          nodeId: target.nodeId,
+          sourceThreadId,
+          boundary,
+        }),
+      });
+    }
+    if (root && ctx.req.method === "GET") {
+      const rawLimit = ctx.url.searchParams.get("limit");
+      const limit = rawLimit === null ? undefined : parseLimit(rawLimit);
+      if (rawLimit !== null && limit === null)
+        throw new SideThreadError(
+          "SIDE_THREAD_INVALID_LIMIT",
+          "invalid list limit",
+          400,
+        );
+      const records = ctx.coordinator.list(ctx.actor, {
+        networkId: query(ctx.url, "networkId", "network_id"),
+        nodeId: query(ctx.url, "nodeId", "node_id"),
+        limit: limit ?? undefined,
+      });
+      return json({
+        ok: true,
+        sideThreads: records.map(serialize),
+        count: records.length,
+      });
+    }
+    if (root && ctx.req.method === "POST") {
+      const body = await requestJson(ctx.req);
+      const record = await ctx.coordinator.create(ctx.actor, {
+        requestKey: field(body, "requestKey", "request_key"),
+        networkId: field(body, "networkId", "network_id"),
+        nodeId: field(body, "nodeId", "node_id"),
+        sourceThreadId: field(body, "sourceThreadId", "source_thread_id"),
+        boundary: {
+          kind: body.boundary?.kind,
+          turnId: field(body.boundary, "turnId", "turn_id"),
+        },
+        prompt: field(body, "question", "prompt"),
+        attachments: mapAttachments(body.attachments),
+      });
+      return json({ ok: true, sideThread: serialize(record) }, 201);
+    }
+    if (root) return methodNotAllowed("GET, POST");
+
+    const sideChatId = decodeSegment(match![1]);
+    const action = match![2];
+    if (!action && ctx.req.method === "GET") {
+      return json({
+        ok: true,
+        sideThread: serialize(ctx.coordinator.get(ctx.actor, sideChatId)),
+      });
+    }
+    if (!action) return methodNotAllowed("GET");
+
+    if (action === "events" && ctx.req.method === "GET") {
+      // Authorize before opening a long-lived stream. A non-owner gets the
+      // same 404 as an unknown id and cannot infer another user's side chat.
+      ctx.coordinator.get(ctx.actor, sideChatId);
+      const headerCursor = ctx.req.headers.get("Last-Event-ID");
+      const queryCursor = ctx.url.searchParams.get("after");
+      const after = parseCursor(headerCursor ?? queryCursor);
+      if (after === null)
+        throw new SideThreadError(
+          "SIDE_THREAD_INVALID_CURSOR",
+          "invalid event cursor",
+          400,
+        );
+      return sideThreadEventStream(
+        ctx.coordinator,
+        ctx.actor,
+        sideChatId,
+        after,
+      );
+    }
+
+    if (ctx.req.method !== "POST") return methodNotAllowed("POST");
+    if (action === "cancel") {
+      return json({
+        ok: true,
+        sideThread: serialize(
+          await ctx.coordinator.cancel(ctx.actor, sideChatId),
+        ),
+      });
+    }
+    if (action === "archive") {
+      return json({
+        ok: true,
+        sideThread: serialize(
+          await ctx.coordinator.archive(ctx.actor, sideChatId),
+        ),
+      });
+    }
+    if (action === "purge") {
+      return json({
+        ok: true,
+        sideThread: serialize(
+          await ctx.coordinator.purge(ctx.actor, sideChatId),
+        ),
+      });
+    }
+    const body = await requestJson(ctx.req);
+    if (action === "retry") {
+      return json({
+        ok: true,
+        sideThread: serialize(
+          await ctx.coordinator.retry(ctx.actor, sideChatId, {
+            requestKey: field(body, "requestKey", "request_key"),
+            prompt: field(body, "question", "prompt"),
+            attachments:
+              body.attachments === undefined
+                ? undefined
+                : mapAttachments(body.attachments),
+          }),
+        ),
+      });
+    }
+    const broughtBack = await ctx.coordinator.bringBack(ctx.actor, sideChatId, {
+      requestKey: field(body, "requestKey", "request_key"),
+      destinationThreadId: field(
+        body,
+        "destinationThreadId",
+        "destination_thread_id",
+      ),
+      attemptId: field(body, "attemptId", "attempt_id"),
+    });
+    return json({ ok: true, bringBack: broughtBack });
+  } catch (error) {
+    if (error instanceof SideThreadError) {
+      return json(
+        {
+          ok: false,
+          error: error.code,
+          message: error.message,
+          ...(error.operationId ? { operationId: error.operationId } : {}),
+          ...(error.sideChatId ? { sideThreadId: error.sideChatId } : {}),
+          ...(error.attemptId ? { attemptId: error.attemptId } : {}),
+        },
+        error.status,
+      );
+    }
+    return json({ ok: false, error: "SIDE_THREAD_INTERNAL_ERROR" }, 500);
+  }
+}
+
+function serialize(record: SideThreadRecord) {
+  const completedBringBackAttempts = new Set(
+    record.bringBacks
+      .filter((receipt) => receipt.state === "completed")
+      .map((receipt) => receipt.attemptId),
+  );
+  return {
+    sideThreadId: record.sideChatId,
+    requestKey: record.requestKey,
+    networkId: record.networkId,
+    nodeId: record.nodeId,
+    sourceThreadId: record.sourceThreadId,
+    question: record.question,
+    title: record.question.split(/\r?\n/, 1)[0].slice(0, 120),
+    boundary: { kind: record.boundary.kind, turnId: record.boundary.turnId },
+    threadId: record.threadId ?? null,
+    state: record.state,
+    activeAttemptId: record.activeAttemptId ?? null,
+    capability: {
+      runtime: record.runtime ?? null,
+      runtimeVersion: record.runtimeVersion ?? null,
+      topology: record.topology ?? null,
+      evidenceRevision: record.evidenceRevision ?? null,
+    },
+    attachments: record.attachments.map((a) => ({ fileId: a.fileId })),
+    attempts: record.attempts.map((a) => ({
+      attemptId: a.attemptId,
+      requestKey: a.requestKey,
+      parentAttemptId: a.parentAttemptId ?? null,
+      threadId: a.threadId ?? null,
+      turnId: a.turnId ?? null,
+      state: a.state,
+      result: a.result ?? null,
+      error: a.error ?? null,
+      attachments: a.attachments.map((attachment) => ({
+        fileId: attachment.fileId,
+      })),
+      broughtBack: completedBringBackAttempts.has(a.attemptId),
+      createdAt: a.createdAt,
+      updatedAt: a.updatedAt,
+    })),
+    bringBacks: record.bringBacks.map((receipt) => ({
+      bringBackId: receipt.bringBackId,
+      attemptId: receipt.attemptId,
+      requestKey: receipt.requestKey,
+      destinationThreadId: receipt.destinationThreadId,
+      destinationTurnId: receipt.destinationTurnId ?? null,
+      state: receipt.state,
+      broughtBack: receipt.state === "completed",
+      createdAt: receipt.createdAt,
+      updatedAt: receipt.updatedAt,
+      completedAt: receipt.completedAt ?? null,
+    })),
+    operations: record.operations.map((operation) => ({
+      operationId: operation.operationId,
+      attemptId: operation.attemptId ?? null,
+      kind: operation.kind,
+      requestKey: operation.requestKey,
+      state: operation.state,
+      threadId: operation.threadId ?? null,
+      turnId: operation.turnId ?? null,
+      errorCode: operation.errorCode ?? null,
+      createdAt: operation.createdAt,
+      updatedAt: operation.updatedAt,
+    })),
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+function serializeCapability(
+  capability: Awaited<ReturnType<SideThreadCoordinator["capability"]>>,
+  context: {
+    networkId: string;
+    nodeId: string;
+    sourceThreadId: string;
+    boundary: { kind: "through" | "before"; turnId: string };
+  },
+) {
+  return {
+    enabled: true,
+    supported: capability.supported,
+    mode: capability.mode ?? null,
+    runtime: capability.runtime ?? null,
+    runtimeVersion: capability.runtimeVersion ?? null,
+    topology: capability.topology ?? null,
+    evidenceRevision: capability.evidenceRevision ?? null,
+    exactBoundary: capability.exactBoundary ?? null,
+    reason: capability.reason ?? null,
+    context: capability.supported ? context : null,
+  };
+}
+
+function sideThreadEventStream(
+  coordinator: SideThreadCoordinator,
+  actor: SideThreadActor,
+  sideChatId: string,
+  after: number,
+): Response {
+  const encoder = new TextEncoder();
+  let unsubscribe = () => {};
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  let closed = false;
+  const cleanup = () => {
+    if (closed) return;
+    closed = true;
+    unsubscribe();
+    if (heartbeat) clearInterval(heartbeat);
+  };
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      start(controller) {
+        const send = (
+          event: ReturnType<SideThreadCoordinator["listEvents"]>[number],
+        ) => {
+          if (closed) return;
+          if ((controller.desiredSize ?? -262_145) < -262_144) {
+            cleanup();
+            try {
+              controller.close();
+            } catch {}
+            return;
+          }
+          try {
+            controller.enqueue(
+              encoder.encode(
+                `id: ${event.eventId}\nevent: side_thread\ndata: ${JSON.stringify(serializeEvent(event))}\n\n`,
+              ),
+            );
+          } catch {
+            cleanup();
+          }
+        };
+        for (const event of coordinator.listEvents(actor, sideChatId, after))
+          send(event);
+        if (closed) return;
+        unsubscribe = coordinator.subscribe(sideChatId, send);
+        heartbeat = setInterval(() => {
+          if ((controller.desiredSize ?? -262_145) < -262_144) {
+            cleanup();
+            try {
+              controller.close();
+            } catch {}
+            return;
+          }
+          try {
+            controller.enqueue(encoder.encode(": keepalive\n\n"));
+          } catch {
+            cleanup();
+          }
+        }, 30_000);
+      },
+      cancel() {
+        cleanup();
+      },
+    },
+    { highWaterMark: 64 * 1024, size: (chunk) => chunk.byteLength },
+  );
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+function serializeEvent(
+  event: ReturnType<SideThreadCoordinator["listEvents"]>[number],
+) {
+  return {
+    eventId: event.eventId,
+    sideThreadId: event.sideChatId,
+    attemptId: event.attemptId ?? null,
+    threadId: event.threadId ?? null,
+    turnId: event.turnId ?? null,
+    type: event.type,
+    state: event.state ?? null,
+    reason: event.reason ?? null,
+    createdAt: event.createdAt,
+  };
+}
+
+function mapAttachments(value: unknown): Array<{ fileId: string }> | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value))
+    throw new SideThreadError(
+      "SIDE_THREAD_CONFLICT",
+      "invalid attachments",
+      409,
+    );
+  return value.map((entry: any) => {
+    if (!entry || typeof entry !== "object")
+      return { fileId: undefined as any };
+    // Do not forward path/url/name fields even temporarily. The coordinator
+    // rejects the original shape when extra keys are present.
+    const allowed = Object.keys(entry).every(
+      (key) => key === "fileId" || key === "file_id",
+    );
+    return allowed
+      ? { fileId: field(entry, "fileId", "file_id") }
+      : { ...(entry as any), fileId: field(entry, "fileId", "file_id") };
+  });
+}
+
+function field(value: any, camel: string, legacy: string): any {
+  return value?.[camel] ?? value?.[legacy];
+}
+
+function query(url: URL, camel: string, legacy?: string): string | undefined {
+  return (
+    url.searchParams.get(camel) ??
+    (legacy ? url.searchParams.get(legacy) : null) ??
+    undefined
+  );
+}
+
+function requiredQueryIdentity(url: URL, name: string): string {
+  const value = query(url, name);
+  if (!value || value.length > 512 || /[\r\n\0]/.test(value))
+    throw new SideThreadError(
+      "SIDE_THREAD_INVALID_CONTEXT",
+      `invalid ${name}`,
+      400,
+    );
+  return value;
+}
+
+async function requestJson(req: Request): Promise<any> {
+  const contentType = req.headers.get("Content-Type") ?? "";
+  if (!/^application\/json(?:;|$)/i.test(contentType)) {
+    throw new SideThreadError(
+      "SIDE_THREAD_INVALID_BODY",
+      "application/json required",
+      415,
+    );
+  }
+  try {
+    const value = await req.json();
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new SideThreadError(
+        "SIDE_THREAD_INVALID_BODY",
+        "JSON object required",
+        400,
+      );
+    }
+    return value;
+  } catch {
+    throw new SideThreadError("SIDE_THREAD_INVALID_BODY", "invalid JSON", 400);
+  }
+}
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new SideThreadError(
+      "SIDE_THREAD_NOT_FOUND",
+      "side chat not found",
+      404,
+    );
+  }
+}
+function parseCursor(value: string | null): number | null {
+  if (value === null || value === "") return 0;
+  if (!/^\d+$/.test(value)) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) ? n : null;
+}
+function parseLimit(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) && n >= 1 && n <= 100 ? n : null;
+}
+function json(body: unknown, status = 200): Response {
+  return Response.json(body, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+function methodNotAllowed(allow: string): Response {
+  return Response.json(
+    { ok: false, error: "SIDE_THREAD_METHOD_NOT_ALLOWED" },
+    { status: 405, headers: { Allow: allow } },
+  );
+}

--- a/server/src/side-thread-http.ts
+++ b/server/src/side-thread-http.ts
@@ -148,11 +148,13 @@ export async function handleSideThreadHttpRequest(
     }
 
     if (ctx.req.method !== "POST") return methodNotAllowed("POST");
+    const body = await requestJson(ctx.req);
+    const requestKey = field(body, "requestKey", "request_key");
     if (action === "cancel") {
       return json({
         ok: true,
         sideThread: serialize(
-          await ctx.coordinator.cancel(ctx.actor, sideChatId),
+          await ctx.coordinator.cancel(ctx.actor, sideChatId, { requestKey }),
         ),
       });
     }
@@ -160,7 +162,7 @@ export async function handleSideThreadHttpRequest(
       return json({
         ok: true,
         sideThread: serialize(
-          await ctx.coordinator.archive(ctx.actor, sideChatId),
+          await ctx.coordinator.archive(ctx.actor, sideChatId, { requestKey }),
         ),
       });
     }
@@ -168,17 +170,16 @@ export async function handleSideThreadHttpRequest(
       return json({
         ok: true,
         sideThread: serialize(
-          await ctx.coordinator.purge(ctx.actor, sideChatId),
+          await ctx.coordinator.purge(ctx.actor, sideChatId, { requestKey }),
         ),
       });
     }
-    const body = await requestJson(ctx.req);
     if (action === "retry") {
       return json({
         ok: true,
         sideThread: serialize(
           await ctx.coordinator.retry(ctx.actor, sideChatId, {
-            requestKey: field(body, "requestKey", "request_key"),
+            requestKey,
             prompt: field(body, "question", "prompt"),
             attachments:
               body.attachments === undefined
@@ -189,7 +190,7 @@ export async function handleSideThreadHttpRequest(
       });
     }
     const broughtBack = await ctx.coordinator.bringBack(ctx.actor, sideChatId, {
-      requestKey: field(body, "requestKey", "request_key"),
+      requestKey,
       destinationThreadId: field(
         body,
         "destinationThreadId",

--- a/server/src/side-thread.test.ts
+++ b/server/src/side-thread.test.ts
@@ -356,7 +356,9 @@ describe("SideThread Hub contract", () => {
         text: "won race",
       });
     };
-    const after = await f.coordinator.cancel(owner, r.sideChatId);
+    const after = await f.coordinator.cancel(owner, r.sideChatId, {
+      requestKey: "cancel-key-race1",
+    });
     expect(after.state).toBe("completed");
     expect(after.attempts[0].result).toBe("won race");
     expect(
@@ -408,9 +410,13 @@ describe("SideThread Hub contract", () => {
       cancelEntered();
       await cancelGate;
     };
-    const firstCancel = f.coordinator.cancel(owner, created.sideChatId);
+    const firstCancel = f.coordinator.cancel(owner, created.sideChatId, {
+      requestKey: "cancel-key-cross1",
+    });
     await cancelStarted;
-    const concurrent = await second.cancel(owner, created.sideChatId);
+    const concurrent = await second.cancel(owner, created.sideChatId, {
+      requestKey: "cancel-key-cross1",
+    });
     expect(concurrent.state).toBe("running");
     expect(f.port.calls.cancel).toBe(1);
     releaseCancel();
@@ -429,10 +435,14 @@ describe("SideThread Hub contract", () => {
       archiveEntered();
       await archiveGate;
     };
-    const firstArchive = f.coordinator.archive(owner, created.sideChatId);
+    const firstArchive = f.coordinator.archive(owner, created.sideChatId, {
+      requestKey: "archive-key-cross1",
+    });
     await archiveStarted;
     await expect(
-      second.archive(owner, created.sideChatId),
+      second.archive(owner, created.sideChatId, {
+        requestKey: "archive-key-cross1",
+      }),
     ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
     expect(f.port.calls.archive).toBe(1);
     releaseArchive();
@@ -480,7 +490,9 @@ describe("SideThread Hub contract", () => {
     const r = await f.coordinator.create(owner, createInput());
     const a = r.attempts[0];
     await expect(
-      f.coordinator.archive(owner, r.sideChatId),
+      f.coordinator.archive(owner, r.sideChatId, {
+        requestKey: "archive-key-running1",
+      }),
     ).rejects.toMatchObject({
       code: "SIDE_THREAD_CONFLICT",
     });
@@ -492,15 +504,27 @@ describe("SideThread Hub contract", () => {
       status: "completed",
       text: "done",
     });
-    expect((await f.coordinator.archive(owner, r.sideChatId)).state).toBe(
-      "archived",
-    );
-    expect((await f.coordinator.archive(owner, r.sideChatId)).state).toBe(
-      "archived",
-    );
-    expect((await f.coordinator.purge(owner, r.sideChatId)).state).toBe(
-      "purged",
-    );
+    expect(
+      (
+        await f.coordinator.archive(owner, r.sideChatId, {
+          requestKey: "archive-key-0001",
+        })
+      ).state,
+    ).toBe("archived");
+    expect(
+      (
+        await f.coordinator.archive(owner, r.sideChatId, {
+          requestKey: "archive-key-0001",
+        })
+      ).state,
+    ).toBe("archived");
+    expect(
+      (
+        await f.coordinator.purge(owner, r.sideChatId, {
+          requestKey: "purge-key-0001",
+        })
+      ).state,
+    ).toBe("purged");
     const purged = f.coordinator.get(owner, r.sideChatId);
     expect(purged.question).toBe("");
     expect(purged.attachments).toEqual([]);
@@ -663,13 +687,17 @@ describe("SideThread Hub contract", () => {
     );
     let cancelOperationId = "";
     try {
-      await cancelFixture.coordinator.cancel(owner, running.sideChatId);
+      await cancelFixture.coordinator.cancel(owner, running.sideChatId, {
+        requestKey: "cancel-key-lost1",
+      });
     } catch (error) {
       expect(error).toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
       cancelOperationId = (error as SideThreadError).operationId!;
     }
     await expect(
-      cancelFixture.coordinator.cancel(owner, running.sideChatId),
+      cancelFixture.coordinator.cancel(owner, running.sideChatId, {
+        requestKey: "cancel-key-lost1",
+      }),
     ).rejects.toMatchObject({
       code: "SIDE_THREAD_AMBIGUOUS",
       operationId: cancelOperationId,
@@ -698,13 +726,17 @@ describe("SideThread Hub contract", () => {
       });
       let operationId = "";
       try {
-        await current.coordinator[action](owner, record.sideChatId);
+        await current.coordinator[action](owner, record.sideChatId, {
+          requestKey: `${action}-key-lost1`,
+        });
       } catch (error) {
         operationId = (error as SideThreadError).operationId!;
         expect(error).toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
       }
       await expect(
-        current.coordinator[action](owner, record.sideChatId),
+        current.coordinator[action](owner, record.sideChatId, {
+          requestKey: `${action}-key-lost1`,
+        }),
       ).rejects.toMatchObject({
         code: "SIDE_THREAD_AMBIGUOUS",
         operationId,
@@ -718,6 +750,7 @@ describe("SideThread HTTP contract", () => {
   test("authoritative vendorable golden fixtures cannot drift from HTTP projection", async () => {
     expect(Object.keys(contractSchema.$defs).sort()).toEqual(
       [
+        "actionRequest",
         "attachment",
         "attempt",
         "boundary",
@@ -839,6 +872,40 @@ describe("SideThread HTTP contract", () => {
       coordinator: f.coordinator,
     });
     expect(denied?.status).toBe(404);
+  });
+
+  test("every mutating action binds the caller requestKey into its durable operation", async () => {
+    const f = fixture();
+    const record = await f.coordinator.create(owner, createInput());
+    for (const action of ["cancel", "archive", "purge"] as const) {
+      const request = new Request(
+        `http://hub/api/side-threads/${record.sideChatId}/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(contractGolden.requests[action]),
+        },
+      );
+      const response = await handleSideThreadHttpRequest({
+        req: request,
+        url: new URL(request.url),
+        actor: owner,
+        coordinator: f.coordinator,
+      });
+      expect(response?.status).toBe(200);
+    }
+    const hydrated = f.coordinator.get(owner, record.sideChatId);
+    expect(
+      hydrated.operations
+        .filter((operation) =>
+          ["cancel", "archive", "purge"].includes(operation.kind),
+        )
+        .map((operation) => [operation.kind, operation.requestKey]),
+    ).toEqual([
+      ["cancel", contractGolden.requests.cancel.requestKey],
+      ["archive", contractGolden.requests.archive.requestKey],
+      ["purge", contractGolden.requests.purge.requestKey],
+    ]);
   });
 
   test("disabled surface is 404 before auth and unsupported adapter is typed 501", async () => {

--- a/server/src/side-thread.test.ts
+++ b/server/src/side-thread.test.ts
@@ -19,6 +19,12 @@ const contractGolden = JSON.parse(
     "utf8",
   ),
 );
+const contractSchema = JSON.parse(
+  readFileSync(
+    new URL("../../contracts/side-thread/v1/schema.json", import.meta.url),
+    "utf8",
+  ),
+);
 
 function jsonShape(value: unknown): unknown {
   if (value === null) return null;
@@ -710,6 +716,26 @@ describe("SideThread Hub contract", () => {
 
 describe("SideThread HTTP contract", () => {
   test("authoritative vendorable golden fixtures cannot drift from HTTP projection", async () => {
+    expect(Object.keys(contractSchema.$defs).sort()).toEqual(
+      [
+        "attachment",
+        "attempt",
+        "boundary",
+        "bringBack",
+        "bringBackRequest",
+        "bringBackResponse",
+        "capabilityResponse",
+        "createRequest",
+        "error",
+        "operation",
+        "recordCapability",
+        "retryRequest",
+        "sideThread",
+        "sideThreadResponse",
+        "sideThreadsResponse",
+        "sseEvent",
+      ].sort(),
+    );
     const f = fixture();
     const capabilityReq = new Request(
       "http://hub/api/side-threads/capability?alias=node-a&networkId=net_a&sourceThreadId=source_thread&boundaryKind=through&boundaryTurnId=source_turn",

--- a/server/src/side-thread.test.ts
+++ b/server/src/side-thread.test.ts
@@ -1,0 +1,919 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { readFileSync } from "node:fs";
+import { SQLiteAdapter } from "./db-adapter.js";
+import {
+  SideThreadCoordinator,
+  SideThreadError,
+  SideThreadStore,
+  UnsupportedSideThreadPort,
+  type SideThreadActor,
+  type SideThreadExecutionPort,
+  type SideThreadRuntimeEvent,
+} from "./side-thread.js";
+import { handleSideThreadHttpRequest } from "./side-thread-http.js";
+
+const contractGolden = JSON.parse(
+  readFileSync(
+    new URL("../../contracts/side-thread/v1/golden.json", import.meta.url),
+    "utf8",
+  ),
+);
+
+function jsonShape(value: unknown): unknown {
+  if (value === null) return null;
+  if (Array.isArray(value)) return value.map(jsonShape);
+  if (typeof value === "object")
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        jsonShape(entry),
+      ]),
+    );
+  return typeof value;
+}
+
+const owner: SideThreadActor = {
+  userId: "usr_owner",
+  username: "owner",
+  tokenId: "tok_owner_1",
+  kind: "user",
+};
+const stranger: SideThreadActor = {
+  userId: "usr_other",
+  username: "other",
+  tokenId: "tok_other_1",
+  kind: "user",
+};
+const nodeActor: SideThreadActor = {
+  userId: "usr_owner",
+  username: "owner",
+  tokenId: "tok_node_1",
+  kind: "node",
+  boundNetworkId: "net_a",
+  boundNodeId: "node_a",
+};
+
+class FakePort implements SideThreadExecutionPort {
+  listeners = new Set<(event: SideThreadRuntimeEvent) => void>();
+  calls = { fork: 0, start: 0, cancel: 0, archive: 0, purge: 0, bringBack: 0 };
+  turn = 0;
+  onStart?: (
+    input: Parameters<SideThreadExecutionPort["start"]>[0],
+    turnId: string,
+  ) => void;
+  capability() {
+    return {
+      supported: true,
+      mode: "native-exact-fork" as const,
+      runtime: "codex",
+      runtimeVersion: "0.148.0",
+      topology: "owned-stdio",
+      evidenceRevision: "reviewed",
+      exactBoundary: { through: true, before: true },
+    };
+  }
+  async fork(input: Parameters<SideThreadExecutionPort["fork"]>[0]) {
+    this.calls.fork++;
+    return { threadId: `derived_${input.sideChatId}` };
+  }
+  async start(input: Parameters<SideThreadExecutionPort["start"]>[0]) {
+    this.calls.start++;
+    const turnId = `turn_${++this.turn}`;
+    this.onStart?.(input, turnId);
+    return { turnId };
+  }
+  async cancel() {
+    this.calls.cancel++;
+  }
+  async archive() {
+    this.calls.archive++;
+  }
+  async purge() {
+    this.calls.purge++;
+  }
+  async bringBack() {
+    this.calls.bringBack++;
+    return { destinationTurnId: `destination_${this.calls.bringBack}` };
+  }
+  subscribe(listener: (event: SideThreadRuntimeEvent) => void) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  emit(event: SideThreadRuntimeEvent) {
+    for (const listener of this.listeners) listener(event);
+  }
+}
+
+const closers: Array<() => void> = [];
+afterEach(() => {
+  while (closers.length) closers.pop()!();
+});
+
+function fixture(
+  options: {
+    enabled?: boolean;
+    port?: SideThreadExecutionPort;
+    attachment?: (fileId: string) => boolean;
+  } = {},
+) {
+  const raw = new Database(":memory:");
+  const db = new SQLiteAdapter(raw);
+  const store = new SideThreadStore(db);
+  const port = options.port ?? new FakePort();
+  let serial = 0;
+  const coordinator = new SideThreadCoordinator(store, port, {
+    enabled: options.enabled ?? true,
+    authorizeNode: (actor, networkId, nodeId) =>
+      actor.userId === owner.userId &&
+      networkId === "net_a" &&
+      nodeId === "node_a" &&
+      (actor.kind !== "node" || actor.boundNodeId === nodeId),
+    authorizeAttachment: (_actor, networkId, ref) =>
+      networkId === "net_a" && (options.attachment?.(ref.fileId) ?? true),
+    now: () => 1_700_000_000_000 + serial,
+    id: () => `id${++serial}`,
+  });
+  closers.push(
+    () => coordinator.close(),
+    () => db.close(),
+  );
+  return { db, store, port: port as FakePort, coordinator };
+}
+
+function createInput(overrides: Record<string, unknown> = {}) {
+  return {
+    requestKey: "create-key-0001",
+    networkId: "net_a",
+    nodeId: "node_a",
+    sourceThreadId: "source_thread",
+    boundary: { kind: "through" as const, turnId: "source_turn_5" },
+    prompt: "原问题第一行\n完整问题必须跨窗口保留",
+    attachments: [{ fileId: "file_ref_0001" }],
+    ...overrides,
+  };
+}
+
+describe("SideThread Hub contract", () => {
+  test("feature flag and missing runtime adapter fail closed without a FIFO fallback", async () => {
+    const disabled = fixture({ enabled: false });
+    await expect(
+      disabled.coordinator.create(owner, createInput()),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_DISABLED", status: 404 });
+    expect(disabled.port.calls.fork).toBe(0);
+
+    const unsupported = fixture({ port: new UnsupportedSideThreadPort() });
+    await expect(
+      unsupported.coordinator.create(owner, createInput()),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_UNSUPPORTED", status: 501 });
+    expect(
+      unsupported.db.get<{ n: number }>("SELECT COUNT(*) n FROM side_chats")?.n,
+    ).toBe(0);
+
+    const unverified = new FakePort();
+    unverified.capability = () => ({
+      supported: true,
+      runtime: "codex",
+      runtimeVersion: "unknown",
+      topology: "shared",
+      evidenceRevision: "unreviewed",
+      exactBoundary: { through: true, before: true },
+    });
+    const unverifiedFixture = fixture({ port: unverified });
+    await expect(
+      unverifiedFixture.coordinator.create(owner, createInput()),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_UNSUPPORTED", status: 501 });
+    expect(unverified.calls.fork).toBe(0);
+  });
+
+  test("create is payload-bound idempotent and stores exact four-part ownership", async () => {
+    const f = fixture();
+    const first = await f.coordinator.create(owner, createInput());
+    const replay = await f.coordinator.create(owner, createInput());
+    expect(replay.sideChatId).toBe(first.sideChatId);
+    expect(f.port.calls).toMatchObject({ fork: 1, start: 1 });
+    expect(first.state).toBe("running");
+    expect(first.attempts[0]).toMatchObject({
+      attemptId: first.activeAttemptId,
+      threadId: first.threadId,
+      turnId: "turn_1",
+      state: "running",
+    });
+    await expect(
+      f.coordinator.create(owner, createInput({ prompt: "different" })),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+  });
+
+  test("cross-window hydration returns the complete owner question and cross-owner reads are opaque", async () => {
+    const f = fixture();
+    const created = await f.coordinator.create(owner, createInput());
+    f.coordinator.close();
+    const reopened = new SideThreadCoordinator(
+      new SideThreadStore(f.db),
+      f.port,
+      {
+        enabled: true,
+        authorizeNode: (actor, networkId, nodeId) =>
+          actor.userId === owner.userId &&
+          networkId === "net_a" &&
+          nodeId === "node_a",
+        authorizeAttachment: () => true,
+      },
+    );
+    closers.push(() => reopened.close());
+    expect(reopened.get(owner, created.sideChatId).question).toBe(
+      createInput().prompt,
+    );
+    expect(() => reopened.get(stranger, created.sideChatId)).toThrow(
+      new SideThreadError("SIDE_THREAD_NOT_FOUND", "side chat not found", 404),
+    );
+    expect(() =>
+      reopened.get({ ...nodeActor, boundNodeId: "node_b" }, created.sideChatId),
+    ).toThrow();
+  });
+
+  test("attachments accept authorized fileId references only", async () => {
+    const f = fixture({ attachment: (id) => id === "file_ref_0001" });
+    await f.coordinator.create(owner, createInput());
+    await expect(
+      f.coordinator.create(
+        owner,
+        createInput({
+          requestKey: "create-key-0002",
+          attachments: [{ fileId: "file_missing_01" }],
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_ATTACHMENT_NOT_FOUND" });
+    await expect(
+      f.coordinator.create(
+        owner,
+        createInput({
+          requestKey: "create-key-0003",
+          attachments: [{ fileId: "file_ref_0001", path: "/etc/passwd" }],
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+  });
+
+  test("terminal events require sideChatId + attemptId + threadId + turnId", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const a = r.attempts[0];
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.sourceThreadId,
+      turnId: a.turnId!,
+      status: "completed",
+      text: "wrong source",
+    });
+    expect(f.coordinator.get(owner, r.sideChatId).state).toBe("running");
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: "turn_sibling",
+      status: "completed",
+      text: "wrong turn",
+    });
+    expect(f.coordinator.get(owner, r.sideChatId).state).toBe("running");
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: a.turnId!,
+      status: "completed",
+      text: "answer",
+    });
+    expect(f.coordinator.get(owner, r.sideChatId)).toMatchObject({
+      state: "completed",
+      activeAttemptId: undefined,
+      attempts: [{ state: "completed", result: "answer" }],
+    });
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: a.turnId!,
+      status: "failed",
+      error: "late",
+    });
+    expect(f.coordinator.get(owner, r.sideChatId).state).toBe("completed");
+    expect(
+      f.coordinator
+        .listEvents(owner, r.sideChatId)
+        .filter((e) => e.type === "runtime_event.dropped"),
+    ).toHaveLength(3);
+  });
+
+  test("a terminal event arriving before start returns settles once", async () => {
+    const f = fixture();
+    f.port.onStart = (input, turnId) =>
+      f.port.emit({
+        sideChatId: input.sideChatId,
+        attemptId: input.attemptId,
+        threadId: input.threadId,
+        turnId,
+        status: "completed",
+        text: "fast",
+      });
+    const r = await f.coordinator.create(owner, createInput());
+    expect(r).toMatchObject({
+      state: "completed",
+      activeAttemptId: undefined,
+      attempts: [{ state: "completed", turnId: "turn_1", result: "fast" }],
+    });
+    expect(
+      f.coordinator
+        .listEvents(owner, r.sideChatId)
+        .filter((e) => e.type === "attempt.terminal"),
+    ).toHaveLength(1);
+    expect(
+      f.coordinator
+        .listEvents(owner, r.sideChatId)
+        .filter((e) => e.type === "attempt.running"),
+    ).toHaveLength(0);
+  });
+
+  test("cancel is exact and cannot regress a terminal race", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const a = r.attempts[0];
+    f.port.cancel = async () => {
+      f.port.calls.cancel++;
+      f.port.emit({
+        sideChatId: r.sideChatId,
+        attemptId: a.attemptId,
+        threadId: r.threadId!,
+        turnId: a.turnId!,
+        status: "completed",
+        text: "won race",
+      });
+    };
+    const after = await f.coordinator.cancel(owner, r.sideChatId);
+    expect(after.state).toBe("completed");
+    expect(after.attempts[0].result).toBe("won race");
+    expect(
+      f.coordinator
+        .listEvents(owner, r.sideChatId)
+        .filter((e) => e.type === "attempt.cancelled"),
+    ).toHaveLength(0);
+  });
+
+  test("cross-coordinator create and cancel claims execute the runtime once", async () => {
+    const f = fixture();
+    let forkEntered!: () => void;
+    const entered = new Promise<void>((resolve) => (forkEntered = resolve));
+    let releaseFork!: () => void;
+    const forkGate = new Promise<void>((resolve) => (releaseFork = resolve));
+    f.port.fork = async (input) => {
+      f.port.calls.fork++;
+      forkEntered();
+      await forkGate;
+      return { threadId: `derived_${input.sideChatId}` };
+    };
+    const second = new SideThreadCoordinator(f.store, f.port, {
+      enabled: true,
+      authorizeNode: (actor, networkId, nodeId) =>
+        actor.userId === owner.userId &&
+        networkId === "net_a" &&
+        nodeId === "node_a",
+      authorizeAttachment: () => true,
+    });
+    closers.push(() => second.close());
+    const firstCreate = f.coordinator.create(owner, createInput());
+    await entered;
+    const replay = await second.create(owner, createInput());
+    expect(replay.state).toBe("creating");
+    releaseFork();
+    const created = await firstCreate;
+    expect(f.port.calls.fork).toBe(1);
+
+    let cancelEntered!: () => void;
+    const cancelStarted = new Promise<void>(
+      (resolve) => (cancelEntered = resolve),
+    );
+    let releaseCancel!: () => void;
+    const cancelGate = new Promise<void>(
+      (resolve) => (releaseCancel = resolve),
+    );
+    f.port.cancel = async () => {
+      f.port.calls.cancel++;
+      cancelEntered();
+      await cancelGate;
+    };
+    const firstCancel = f.coordinator.cancel(owner, created.sideChatId);
+    await cancelStarted;
+    const concurrent = await second.cancel(owner, created.sideChatId);
+    expect(concurrent.state).toBe("running");
+    expect(f.port.calls.cancel).toBe(1);
+    releaseCancel();
+    expect((await firstCancel).state).toBe("cancelled");
+
+    let archiveEntered!: () => void;
+    const archiveStarted = new Promise<void>(
+      (resolve) => (archiveEntered = resolve),
+    );
+    let releaseArchive!: () => void;
+    const archiveGate = new Promise<void>(
+      (resolve) => (releaseArchive = resolve),
+    );
+    f.port.archive = async () => {
+      f.port.calls.archive++;
+      archiveEntered();
+      await archiveGate;
+    };
+    const firstArchive = f.coordinator.archive(owner, created.sideChatId);
+    await archiveStarted;
+    await expect(
+      second.archive(owner, created.sideChatId),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+    expect(f.port.calls.archive).toBe(1);
+    releaseArchive();
+    expect((await firstArchive).state).toBe("archived");
+  });
+
+  test("retry persists parent attempt lineage and blocks concurrent active retries", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const first = r.attempts[0];
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: first.attemptId,
+      threadId: r.threadId!,
+      turnId: first.turnId!,
+      status: "failed",
+      error: "boom",
+    });
+    const retried = await f.coordinator.retry(owner, r.sideChatId, {
+      requestKey: "retry-key-0001",
+      prompt: "try again",
+    });
+    expect(retried.attempts[1]).toMatchObject({
+      parentAttemptId: first.attemptId,
+      state: "running",
+      threadId: r.threadId,
+      turnId: "turn_2",
+    });
+    await expect(
+      f.coordinator.retry(owner, r.sideChatId, {
+        requestKey: "retry-key-0002",
+        prompt: "parallel",
+      }),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+    const replay = await f.coordinator.retry(owner, r.sideChatId, {
+      requestKey: "retry-key-0001",
+      prompt: "try again",
+    });
+    expect(replay.attempts).toHaveLength(2);
+    expect(f.port.calls.start).toBe(2);
+  });
+
+  test("archive/purge are terminal-safe and idempotent", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const a = r.attempts[0];
+    await expect(
+      f.coordinator.archive(owner, r.sideChatId),
+    ).rejects.toMatchObject({
+      code: "SIDE_THREAD_CONFLICT",
+    });
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: a.turnId!,
+      status: "completed",
+      text: "done",
+    });
+    expect((await f.coordinator.archive(owner, r.sideChatId)).state).toBe(
+      "archived",
+    );
+    expect((await f.coordinator.archive(owner, r.sideChatId)).state).toBe(
+      "archived",
+    );
+    expect((await f.coordinator.purge(owner, r.sideChatId)).state).toBe(
+      "purged",
+    );
+    const purged = f.coordinator.get(owner, r.sideChatId);
+    expect(purged.question).toBe("");
+    expect(purged.attachments).toEqual([]);
+    expect(purged.attempts[0].result).toBeUndefined();
+    expect(f.port.calls).toMatchObject({ archive: 1, purge: 1 });
+  });
+
+  test("bring-back is completed-attempt-only and payload-bound idempotent", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const a = r.attempts[0];
+    await expect(
+      f.coordinator.bringBack(owner, r.sideChatId, {
+        requestKey: "bring-key-0001",
+        destinationThreadId: "source_thread",
+      }),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: a.turnId!,
+      status: "completed",
+      text: "answer",
+    });
+    const one = await f.coordinator.bringBack(owner, r.sideChatId, {
+      requestKey: "bring-key-0001",
+      destinationThreadId: "source_thread",
+    });
+    const replay = await f.coordinator.bringBack(owner, r.sideChatId, {
+      requestKey: "bring-key-0001",
+      destinationThreadId: "source_thread",
+    });
+    expect(replay).toEqual(one);
+    expect(f.port.calls.bringBack).toBe(1);
+    const differentRequest = await f.coordinator.bringBack(
+      owner,
+      r.sideChatId,
+      {
+        requestKey: "bring-key-0002",
+        destinationThreadId: "source_thread",
+      },
+    );
+    expect(differentRequest).toEqual(one);
+    expect(f.port.calls.bringBack).toBe(1);
+    await expect(
+      f.coordinator.bringBack(owner, r.sideChatId, {
+        requestKey: "bring-key-0003",
+        destinationThreadId: "other_thread",
+      }),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+
+    f.coordinator.close();
+    const reopened = new SideThreadCoordinator(f.store, f.port, {
+      enabled: true,
+      authorizeNode: (actor, networkId, nodeId) =>
+        actor.userId === owner.userId &&
+        networkId === "net_a" &&
+        nodeId === "node_a",
+      authorizeAttachment: () => true,
+    });
+    closers.push(() => reopened.close());
+    const hydrated = reopened.get(owner, r.sideChatId);
+    expect(hydrated.bringBacks).toHaveLength(1);
+    expect(hydrated.bringBacks[0]).toMatchObject({
+      attemptId: a.attemptId,
+      destinationThreadId: "source_thread",
+      destinationTurnId: one.destinationTurnId,
+      requestKey: "bring-key-0001",
+      state: "completed",
+    });
+    expect(hydrated.bringBacks[0].completedAt).toBeNumber();
+    expect(reopened.list(owner)).toHaveLength(1);
+    expect(reopened.list(stranger)).toHaveLength(0);
+  });
+
+  test("response loss is durable ambiguous and reconciles without a second start RPC", async () => {
+    const port = new FakePort();
+    let accepted: Parameters<SideThreadExecutionPort["start"]>[0] | undefined;
+    port.start = async (input) => {
+      port.calls.start++;
+      accepted = input;
+      throw Object.assign(new Error("secret transport detail"), {
+        code: "SIDE_THREAD_RESPONSE_LOST",
+      });
+    };
+    const f = fixture({ port });
+    await expect(
+      f.coordinator.create(owner, createInput()),
+    ).rejects.toMatchObject({
+      code: "SIDE_THREAD_AMBIGUOUS",
+      operationId: expect.stringMatching(/^sop_/),
+    });
+    const ambiguous = f.store.getByCreateKey(owner, "create-key-0001")!.record;
+    const startOperation = ambiguous.operations.find(
+      (operation) => operation.kind === "start",
+    )!;
+    expect(ambiguous).toMatchObject({
+      requestKey: "create-key-0001",
+      state: "ambiguous",
+      attempts: [{ state: "ambiguous" }],
+    });
+    expect(startOperation).toMatchObject({
+      operationId: accepted!.operationId,
+      state: "ambiguous",
+      errorCode: "SIDE_THREAD_RESPONSE_LOST",
+    });
+    expect(await f.coordinator.create(owner, createInput())).toMatchObject({
+      sideChatId: ambiguous.sideChatId,
+      state: "ambiguous",
+    });
+    expect(port.calls).toMatchObject({ fork: 1, start: 1 });
+
+    f.coordinator.close();
+    const reopened = new SideThreadCoordinator(f.store, port, {
+      enabled: true,
+      authorizeNode: (actor, networkId, nodeId) =>
+        actor.userId === owner.userId &&
+        networkId === "net_a" &&
+        nodeId === "node_a",
+    });
+    closers.push(() => reopened.close());
+    port.emit({
+      sideChatId: ambiguous.sideChatId,
+      attemptId: accepted!.attemptId,
+      threadId: accepted!.threadId,
+      turnId: "turn_authoritative",
+      status: "completed",
+      text: "authoritative answer",
+    });
+    const reconciled = reopened.get(owner, ambiguous.sideChatId);
+    expect(reconciled).toMatchObject({
+      state: "completed",
+      attempts: [{ state: "completed", result: "authoritative answer" }],
+    });
+    expect(
+      reconciled.operations.find((operation) => operation.kind === "start"),
+    ).toMatchObject({ state: "completed", turnId: "turn_authoritative" });
+    expect(port.calls.start).toBe(1);
+    expect(
+      JSON.stringify(reopened.listEvents(owner, ambiguous.sideChatId)),
+    ).not.toContain("secret transport detail");
+  });
+
+  test("ambiguous cancel/archive/purge keep stable claims and never issue a second RPC", async () => {
+    const lose = () =>
+      Object.assign(new Error("accepted but ACK lost"), {
+        code: "SIDE_THREAD_RESPONSE_LOST",
+      });
+
+    const cancelPort = new FakePort();
+    cancelPort.cancel = async () => {
+      cancelPort.calls.cancel++;
+      throw lose();
+    };
+    const cancelFixture = fixture({ port: cancelPort });
+    const running = await cancelFixture.coordinator.create(
+      owner,
+      createInput(),
+    );
+    let cancelOperationId = "";
+    try {
+      await cancelFixture.coordinator.cancel(owner, running.sideChatId);
+    } catch (error) {
+      expect(error).toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+      cancelOperationId = (error as SideThreadError).operationId!;
+    }
+    await expect(
+      cancelFixture.coordinator.cancel(owner, running.sideChatId),
+    ).rejects.toMatchObject({
+      code: "SIDE_THREAD_AMBIGUOUS",
+      operationId: cancelOperationId,
+    });
+    expect(cancelPort.calls.cancel).toBe(1);
+
+    for (const action of ["archive", "purge"] as const) {
+      const port = new FakePort();
+      port[action] = async () => {
+        port.calls[action]++;
+        throw lose();
+      };
+      const current = fixture({ port });
+      const record = await current.coordinator.create(
+        owner,
+        createInput({ requestKey: `create-key-${action}` }),
+      );
+      const attempt = record.attempts[0];
+      port.emit({
+        sideChatId: record.sideChatId,
+        attemptId: attempt.attemptId,
+        threadId: record.threadId!,
+        turnId: attempt.turnId!,
+        status: "completed",
+        text: "done",
+      });
+      let operationId = "";
+      try {
+        await current.coordinator[action](owner, record.sideChatId);
+      } catch (error) {
+        operationId = (error as SideThreadError).operationId!;
+        expect(error).toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+      }
+      await expect(
+        current.coordinator[action](owner, record.sideChatId),
+      ).rejects.toMatchObject({
+        code: "SIDE_THREAD_AMBIGUOUS",
+        operationId,
+      });
+      expect(port.calls[action]).toBe(1);
+    }
+  });
+});
+
+describe("SideThread HTTP contract", () => {
+  test("authoritative vendorable golden fixtures cannot drift from HTTP projection", async () => {
+    const f = fixture();
+    const capabilityReq = new Request(
+      "http://hub/api/side-threads/capability?alias=node-a&networkId=net_a&sourceThreadId=source_thread&boundaryKind=through&boundaryTurnId=source_turn",
+    );
+    const capability = await handleSideThreadHttpRequest({
+      req: capabilityReq,
+      url: new URL(capabilityReq.url),
+      actor: owner,
+      coordinator: f.coordinator,
+      resolveCapabilityTarget: () => ({ nodeId: "node_a", networkId: "net_a" }),
+    });
+    expect(await capability!.json()).toEqual(contractGolden.capabilityResponse);
+
+    const request = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(contractGolden.requests.create),
+    });
+    const created = await handleSideThreadHttpRequest({
+      req: request,
+      url: new URL(request.url),
+      actor: owner,
+      coordinator: f.coordinator,
+    });
+    expect(jsonShape(await created!.json())).toEqual(
+      jsonShape(contractGolden.sideThreadEnvelope),
+    );
+    const empty = fixture();
+    const listReq = new Request("http://hub/api/side-threads");
+    const listed = await handleSideThreadHttpRequest({
+      req: listReq,
+      url: new URL(listReq.url),
+      actor: owner,
+      coordinator: empty.coordinator,
+    });
+    expect(await listed!.json()).toEqual(contractGolden.listResponse);
+  });
+
+  test("routes use the stable REST shape and return owner-readable question", async () => {
+    const f = fixture();
+    const req = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        requestKey: "create-key-http1",
+        networkId: "net_a",
+        nodeId: "node_a",
+        sourceThreadId: "source_thread",
+        boundary: { kind: "through", turnId: "source_turn" },
+        prompt: "full question",
+        attachments: [{ fileId: "file_ref_0001" }],
+      }),
+    });
+    const created = await handleSideThreadHttpRequest({
+      req,
+      url: new URL(req.url),
+      actor: owner,
+      coordinator: f.coordinator,
+    });
+    expect(created?.status).toBe(201);
+    const body = (await created!.json()) as any;
+    expect(body.sideThread).toMatchObject({
+      requestKey: "create-key-http1",
+      question: "full question",
+      title: "full question",
+      state: "running",
+    });
+    const getReq = new Request(
+      `http://hub/api/side-threads/${body.sideThread.sideThreadId}`,
+    );
+    const got = await handleSideThreadHttpRequest({
+      req: getReq,
+      url: new URL(getReq.url),
+      actor: owner,
+      coordinator: f.coordinator,
+    });
+    expect(((await got!.json()) as any).sideThread.question).toBe(
+      "full question",
+    );
+    const listReq = new Request("http://hub/api/side-threads?network_id=net_a");
+    const listed = await handleSideThreadHttpRequest({
+      req: listReq,
+      url: new URL(listReq.url),
+      actor: owner,
+      coordinator: f.coordinator,
+    });
+    expect((await listed!.json()) as any).toMatchObject({
+      count: 1,
+      sideThreads: [
+        {
+          question: "full question",
+          bringBacks: [],
+          operations: expect.any(Array),
+        },
+      ],
+    });
+    const denied = await handleSideThreadHttpRequest({
+      req: getReq,
+      url: new URL(getReq.url),
+      actor: stranger,
+      coordinator: f.coordinator,
+    });
+    expect(denied?.status).toBe(404);
+  });
+
+  test("disabled surface is 404 before auth and unsupported adapter is typed 501", async () => {
+    const off = fixture({ enabled: false });
+    const getReq = new Request("http://hub/api/side-threads/anything");
+    expect(
+      (
+        await handleSideThreadHttpRequest({
+          req: getReq,
+          url: new URL(getReq.url),
+          actor: null,
+          coordinator: off.coordinator,
+        })
+      )?.status,
+    ).toBe(404);
+    const unsupported = fixture({ port: new UnsupportedSideThreadPort() });
+    const req = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        request_key: "create-key-http2",
+        network_id: "net_a",
+        node_id: "node_a",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "question",
+      }),
+    });
+    const response = await handleSideThreadHttpRequest({
+      req,
+      url: new URL(req.url),
+      actor: owner,
+      coordinator: unsupported.coordinator,
+    });
+    expect(response?.status).toBe(501);
+    expect(await response!.json()).toMatchObject({
+      error: "SIDE_THREAD_UNSUPPORTED",
+    });
+  });
+
+  test("capability flips and ambiguous runtime identities are typed failures", async () => {
+    const flippedPort = new FakePort();
+    flippedPort.fork = async () => {
+      const error = new Error("capability disappeared");
+      (error as any).code = "SIDE_THREAD_UNSUPPORTED";
+      throw error;
+    };
+    const flipped = fixture({ port: flippedPort });
+    const flipReq = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        request_key: "create-key-flip1",
+        network_id: "net_a",
+        node_id: "node_a",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "flip",
+      }),
+    });
+    const flipResponse = await handleSideThreadHttpRequest({
+      req: flipReq,
+      url: new URL(flipReq.url),
+      actor: owner,
+      coordinator: flipped.coordinator,
+    });
+    expect(flipResponse?.status).toBe(501);
+    expect(await flipResponse!.json()).toMatchObject({
+      error: "SIDE_THREAD_UNSUPPORTED",
+    });
+
+    const ambiguousPort = new FakePort();
+    ambiguousPort.fork = async () => ({ threadId: undefined as any });
+    const ambiguous = fixture({ port: ambiguousPort });
+    const ambiguousReq = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        request_key: "create-key-ambig1",
+        network_id: "net_a",
+        node_id: "node_a",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "ambiguous",
+      }),
+    });
+    const ambiguousResponse = await handleSideThreadHttpRequest({
+      req: ambiguousReq,
+      url: new URL(ambiguousReq.url),
+      actor: owner,
+      coordinator: ambiguous.coordinator,
+    });
+    expect(ambiguousResponse?.status).toBe(202);
+    expect(await ambiguousResponse!.json()).toMatchObject({
+      error: "SIDE_THREAD_AMBIGUOUS",
+      operationId: expect.stringMatching(/^sop_/),
+      sideThreadId: expect.stringMatching(/^sch_/),
+      attemptId: expect.stringMatching(/^sat_/),
+    });
+    expect(
+      ambiguous.store.getByCreateKey(owner, "create-key-ambig1")?.record.state,
+    ).toBe("ambiguous");
+  });
+});

--- a/server/src/side-thread.ts
+++ b/server/src/side-thread.ts
@@ -1,0 +1,2203 @@
+import { createHash, randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import type { DbAdapter } from "./db-adapter.js";
+
+export const SIDE_THREAD_FEATURE_FLAG = "COMMHUB_ENABLE_SIDE_THREADS";
+export const SIDE_THREAD_API_ROOT = "/api/side-threads";
+export const SIDE_THREAD_EVENTS_SUFFIX = "/events";
+export const SIDE_THREAD_API_ACTIONS = [
+  "cancel",
+  "retry",
+  "archive",
+  "purge",
+  "bring-back",
+  SIDE_THREAD_EVENTS_SUFFIX.slice(1),
+] as const;
+
+export type SideThreadState =
+  | "creating"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "ambiguous"
+  | "reconciling"
+  | "archived"
+  | "purged";
+export type SideThreadAttemptState =
+  | "starting"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "ambiguous"
+  | "reconciling";
+export type SideThreadBoundary =
+  { kind: "through"; turnId: string } | { kind: "before"; turnId: string };
+
+export interface SideThreadActor {
+  userId: string;
+  username: string;
+  tokenId: string;
+  kind: "user" | "node";
+  boundNetworkId?: string;
+  boundNodeId?: string;
+  isAdmin?: boolean;
+}
+
+export interface SideThreadAttachmentRef {
+  fileId: string;
+}
+
+export interface SideThreadCapability {
+  supported: boolean;
+  mode?: "native-exact-fork";
+  runtime?: string;
+  runtimeVersion?: string;
+  topology?: string;
+  evidenceRevision?: string;
+  exactBoundary?: { through: boolean; before: boolean };
+  reason?: string;
+}
+
+export interface SideThreadRuntimeEvent {
+  sideChatId: string;
+  attemptId: string;
+  threadId: string;
+  turnId: string;
+  status: "completed" | "failed" | "interrupted";
+  text?: string;
+  error?: string;
+}
+
+/**
+ * The only bridge from Hub state into a runtime. Implementations must use a
+ * native exact-boundary side-thread mechanism. Ordinary task/inbox/FIFO
+ * delivery is deliberately absent from this interface.
+ */
+export interface SideThreadExecutionPort {
+  capability(
+    nodeId: string,
+  ): Promise<SideThreadCapability> | SideThreadCapability;
+  fork(input: {
+    operationId: string;
+    requestKey: string;
+    sideChatId: string;
+    nodeId: string;
+    sourceThreadId: string;
+    boundary: SideThreadBoundary;
+  }): Promise<{ threadId: string }>;
+  start(input: {
+    operationId: string;
+    requestKey: string;
+    sideChatId: string;
+    attemptId: string;
+    nodeId: string;
+    threadId: string;
+    prompt: string;
+    attachments: SideThreadAttachmentRef[];
+  }): Promise<{ turnId: string }>;
+  cancel(input: {
+    operationId: string;
+    sideChatId: string;
+    attemptId: string;
+    nodeId: string;
+    threadId: string;
+    turnId: string;
+  }): Promise<void>;
+  archive(input: {
+    operationId: string;
+    sideChatId: string;
+    nodeId: string;
+    threadId: string;
+  }): Promise<void>;
+  purge(input: {
+    operationId: string;
+    sideChatId: string;
+    nodeId: string;
+    threadId: string;
+  }): Promise<void>;
+  bringBack(input: {
+    operationId: string;
+    sideChatId: string;
+    attemptId: string;
+    nodeId: string;
+    sourceThreadId: string;
+    sourceTurnId: string;
+    destinationThreadId: string;
+    requestKey: string;
+    text: string;
+  }): Promise<{ destinationTurnId: string }>;
+  subscribe(listener: (event: SideThreadRuntimeEvent) => void): () => void;
+}
+
+export class SideThreadError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly status: number,
+    readonly operationId?: string,
+    readonly sideChatId?: string,
+    readonly attemptId?: string,
+  ) {
+    super(message);
+    this.name = "SideThreadError";
+  }
+}
+
+export class UnsupportedSideThreadPort implements SideThreadExecutionPort {
+  capability(): SideThreadCapability {
+    return { supported: false, reason: "runtime-adapter-unavailable" };
+  }
+  private unsupported(): never {
+    throw new SideThreadError(
+      "SIDE_THREAD_UNSUPPORTED",
+      "verified native SideThread adapter is unavailable",
+      501,
+    );
+  }
+  async fork(): Promise<never> {
+    return this.unsupported();
+  }
+  async start(): Promise<never> {
+    return this.unsupported();
+  }
+  async cancel(): Promise<never> {
+    return this.unsupported();
+  }
+  async archive(): Promise<never> {
+    return this.unsupported();
+  }
+  async purge(): Promise<never> {
+    return this.unsupported();
+  }
+  async bringBack(): Promise<never> {
+    return this.unsupported();
+  }
+  subscribe(): () => void {
+    return () => {};
+  }
+}
+
+/**
+ * Process-local adapter seam. Production starts unsupported; a node/runtime
+ * integration may install one verified adapter explicitly. Replacing it also
+ * rewires terminal-event subscribers, so the coordinator never subscribes to
+ * an untracked transport.
+ */
+export class SideThreadPortRegistry implements SideThreadExecutionPort {
+  private delegate: SideThreadExecutionPort = new UnsupportedSideThreadPort();
+  private readonly listeners = new Set<
+    (event: SideThreadRuntimeEvent) => void
+  >();
+  private detach: () => void = () => {};
+  install(port: SideThreadExecutionPort): () => void {
+    this.detach();
+    this.delegate = port;
+    this.detach = port.subscribe((event) => {
+      for (const listener of this.listeners) listener(event);
+    });
+    return () => {
+      if (this.delegate !== port) return;
+      this.detach();
+      this.detach = () => {};
+      this.delegate = new UnsupportedSideThreadPort();
+    };
+  }
+  capability(nodeId: string) {
+    return this.delegate.capability(nodeId);
+  }
+  fork(input: Parameters<SideThreadExecutionPort["fork"]>[0]) {
+    return this.delegate.fork(input);
+  }
+  start(input: Parameters<SideThreadExecutionPort["start"]>[0]) {
+    return this.delegate.start(input);
+  }
+  cancel(input: Parameters<SideThreadExecutionPort["cancel"]>[0]) {
+    return this.delegate.cancel(input);
+  }
+  archive(input: Parameters<SideThreadExecutionPort["archive"]>[0]) {
+    return this.delegate.archive(input);
+  }
+  purge(input: Parameters<SideThreadExecutionPort["purge"]>[0]) {
+    return this.delegate.purge(input);
+  }
+  bringBack(input: Parameters<SideThreadExecutionPort["bringBack"]>[0]) {
+    return this.delegate.bringBack(input);
+  }
+  subscribe(listener: (event: SideThreadRuntimeEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+}
+
+export interface SideThreadRecord {
+  sideChatId: string;
+  requestKey: string;
+  networkId: string;
+  nodeId: string;
+  ownerUserId: string;
+  sourceThreadId: string;
+  /** Owner-readable original BTW question, durably restored across windows. */
+  question: string;
+  boundary: SideThreadBoundary;
+  threadId?: string;
+  state: SideThreadState;
+  activeAttemptId?: string;
+  runtime?: string;
+  runtimeVersion?: string;
+  topology?: string;
+  evidenceRevision?: string;
+  attachments: SideThreadAttachmentRef[];
+  attempts: SideThreadAttemptRecord[];
+  bringBacks: SideThreadBringBackRecord[];
+  operations: SideThreadOperationRecord[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SideThreadAttemptRecord {
+  attemptId: string;
+  requestKey: string;
+  parentAttemptId?: string;
+  threadId?: string;
+  turnId?: string;
+  state: SideThreadAttemptState;
+  result?: string;
+  error?: string;
+  attachments: SideThreadAttachmentRef[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SideThreadBringBackRecord {
+  bringBackId: string;
+  attemptId: string;
+  requestKey: string;
+  destinationThreadId: string;
+  destinationTurnId?: string;
+  state: "starting" | "completed" | "failed";
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface SideThreadOperationRecord {
+  operationId: string;
+  attemptId?: string;
+  kind: "fork" | "start" | "cancel" | "archive" | "purge" | "bring-back";
+  requestKey: string;
+  state: "pending" | "ambiguous" | "reconciling" | "completed" | "failed";
+  threadId?: string;
+  turnId?: string;
+  errorCode?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SideThreadEventRecord {
+  eventId: number;
+  sideChatId: string;
+  attemptId?: string;
+  threadId?: string;
+  turnId?: string;
+  type: string;
+  state?: string;
+  reason?: string;
+  createdAt: number;
+}
+
+export function installSideThreadSchema(database: DbAdapter): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS side_chats (
+      side_chat_id       TEXT PRIMARY KEY,
+      network_id         TEXT NOT NULL,
+      node_id            TEXT NOT NULL,
+      owner_user_id      TEXT NOT NULL,
+      created_by_token_id TEXT NOT NULL,
+      create_request_key TEXT NOT NULL,
+      create_fingerprint TEXT NOT NULL,
+      source_thread_id   TEXT NOT NULL,
+      question_text      TEXT NOT NULL,
+      boundary_kind      TEXT NOT NULL CHECK(boundary_kind IN ('through','before')),
+      boundary_turn_id   TEXT NOT NULL,
+      derived_thread_id  TEXT,
+      state              TEXT NOT NULL,
+      active_attempt_id  TEXT,
+      lifecycle_operation TEXT,
+      runtime            TEXT,
+      runtime_version    TEXT,
+      topology           TEXT,
+      evidence_revision  TEXT,
+      attachments_json   TEXT NOT NULL DEFAULT '[]',
+      created_at         INTEGER NOT NULL,
+      updated_at         INTEGER NOT NULL,
+      archived_at        INTEGER,
+      purged_at          INTEGER,
+      UNIQUE(owner_user_id, create_request_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_side_chats_owner_network
+      ON side_chats(owner_user_id, network_id, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_side_chats_node
+      ON side_chats(node_id, state, updated_at DESC);
+
+    CREATE TABLE IF NOT EXISTS side_chat_attempts (
+      attempt_id         TEXT PRIMARY KEY,
+      side_chat_id       TEXT NOT NULL,
+      parent_attempt_id  TEXT,
+      request_key        TEXT NOT NULL,
+      request_fingerprint TEXT NOT NULL,
+      prompt_hash        TEXT NOT NULL,
+      attachments_json   TEXT NOT NULL DEFAULT '[]',
+      thread_id          TEXT,
+      turn_id            TEXT,
+      cancel_requested_at INTEGER,
+      state              TEXT NOT NULL,
+      result_text        TEXT,
+      error_text         TEXT,
+      created_at         INTEGER NOT NULL,
+      updated_at         INTEGER NOT NULL,
+      UNIQUE(side_chat_id, request_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_side_attempts_chat_time
+      ON side_chat_attempts(side_chat_id, created_at, attempt_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_side_attempt_active
+      ON side_chat_attempts(side_chat_id)
+      WHERE state IN ('starting','running');
+
+    CREATE TABLE IF NOT EXISTS side_chat_events (
+      event_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+      side_chat_id  TEXT NOT NULL,
+      attempt_id    TEXT,
+      thread_id     TEXT,
+      turn_id       TEXT,
+      event_type    TEXT NOT NULL,
+      state         TEXT,
+      reason        TEXT,
+      created_at    INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_side_events_chat_id
+      ON side_chat_events(side_chat_id, event_id);
+
+    CREATE TABLE IF NOT EXISTS side_chat_operations (
+      operation_id       TEXT PRIMARY KEY,
+      side_chat_id       TEXT NOT NULL,
+      attempt_id         TEXT,
+      operation_kind     TEXT NOT NULL,
+      request_key        TEXT NOT NULL,
+      request_fingerprint TEXT NOT NULL,
+      state              TEXT NOT NULL,
+      thread_id          TEXT,
+      turn_id            TEXT,
+      error_code         TEXT,
+      created_at         INTEGER NOT NULL,
+      updated_at         INTEGER NOT NULL,
+      UNIQUE(side_chat_id, operation_kind, request_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_side_operations_chat_time
+      ON side_chat_operations(side_chat_id, created_at, operation_id);
+
+    CREATE TABLE IF NOT EXISTS side_chat_bring_backs (
+      bring_back_id       TEXT PRIMARY KEY,
+      side_chat_id        TEXT NOT NULL,
+      attempt_id          TEXT NOT NULL,
+      owner_user_id       TEXT NOT NULL,
+      request_key         TEXT NOT NULL,
+      request_fingerprint TEXT NOT NULL,
+      destination_thread_id TEXT NOT NULL,
+      destination_turn_id TEXT,
+      state               TEXT NOT NULL,
+      error_text          TEXT,
+      created_at          INTEGER NOT NULL,
+      updated_at          INTEGER NOT NULL,
+      completed_at        INTEGER,
+      UNIQUE(side_chat_id, request_key)
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_side_bring_back_destination
+      ON side_chat_bring_backs(side_chat_id, attempt_id, destination_thread_id);
+  `);
+  // Additive development migration for databases created by an earlier PR2
+  // draft before cross-coordinator cancel claiming was introduced.
+  try {
+    database.exec(
+      "ALTER TABLE side_chat_attempts ADD COLUMN cancel_requested_at INTEGER",
+    );
+  } catch (error: any) {
+    if (!/duplicate column|already exists/i.test(error?.message ?? ""))
+      throw error;
+  }
+  try {
+    database.exec(
+      "ALTER TABLE side_chat_attempts ADD COLUMN attachments_json TEXT NOT NULL DEFAULT '[]'",
+    );
+  } catch (error: any) {
+    if (!/duplicate column|already exists/i.test(error?.message ?? ""))
+      throw error;
+  }
+  try {
+    database.exec(
+      "ALTER TABLE side_chat_bring_backs ADD COLUMN completed_at INTEGER",
+    );
+  } catch (error: any) {
+    if (!/duplicate column|already exists/i.test(error?.message ?? ""))
+      throw error;
+  }
+  try {
+    database.exec("ALTER TABLE side_chats ADD COLUMN lifecycle_operation TEXT");
+  } catch (error: any) {
+    if (!/duplicate column|already exists/i.test(error?.message ?? ""))
+      throw error;
+  }
+}
+
+type SideChatRow = {
+  side_chat_id: string;
+  create_request_key: string;
+  network_id: string;
+  node_id: string;
+  owner_user_id: string;
+  source_thread_id: string;
+  question_text: string;
+  boundary_kind: "through" | "before";
+  boundary_turn_id: string;
+  derived_thread_id: string | null;
+  state: SideThreadState;
+  active_attempt_id: string | null;
+  runtime: string | null;
+  runtime_version: string | null;
+  topology: string | null;
+  evidence_revision: string | null;
+  attachments_json: string;
+  created_at: number;
+  updated_at: number;
+};
+type AttemptRow = {
+  attempt_id: string;
+  request_key: string;
+  parent_attempt_id: string | null;
+  thread_id: string | null;
+  turn_id: string | null;
+  state: SideThreadAttemptState;
+  result_text: string | null;
+  error_text: string | null;
+  attachments_json: string;
+  created_at: number;
+  updated_at: number;
+};
+
+export class SideThreadStore {
+  constructor(readonly db: DbAdapter) {
+    installSideThreadSchema(db);
+  }
+
+  getOwned(
+    sideChatId: string,
+    actor: SideThreadActor,
+  ): SideThreadRecord | undefined {
+    const row = this.db.get<SideChatRow>(
+      "SELECT * FROM side_chats WHERE side_chat_id = ?1 AND owner_user_id = ?2",
+      sideChatId,
+      actor.userId,
+    );
+    if (!row) return undefined;
+    if (actor.kind === "node" && actor.boundNodeId !== row.node_id)
+      return undefined;
+    if (actor.boundNetworkId && actor.boundNetworkId !== row.network_id)
+      return undefined;
+    return this.hydrate(row);
+  }
+
+  getByCreateKey(
+    actor: SideThreadActor,
+    requestKey: string,
+  ): { record: SideThreadRecord; fingerprint: string } | undefined {
+    const row = this.db.get<SideChatRow & { create_fingerprint: string }>(
+      "SELECT * FROM side_chats WHERE owner_user_id = ?1 AND create_request_key = ?2",
+      actor.userId,
+      requestKey,
+    );
+    if (!row) return undefined;
+    if (actor.kind === "node" && actor.boundNodeId !== row.node_id)
+      return undefined;
+    return { record: this.hydrate(row), fingerprint: row.create_fingerprint };
+  }
+
+  listOwned(
+    actor: SideThreadActor,
+    filters: { networkId?: string; nodeId?: string; limit?: number } = {},
+  ): SideThreadRecord[] {
+    let sql = "SELECT * FROM side_chats WHERE owner_user_id = ?1";
+    const params: unknown[] = [actor.userId];
+    const networkId = actor.boundNetworkId ?? filters.networkId;
+    if (networkId) {
+      params.push(networkId);
+      sql += ` AND network_id = ?${params.length}`;
+    }
+    const nodeId = actor.kind === "node" ? actor.boundNodeId : filters.nodeId;
+    if (nodeId) {
+      params.push(nodeId);
+      sql += ` AND node_id = ?${params.length}`;
+    }
+    params.push(Math.min(Math.max(filters.limit ?? 50, 1), 100));
+    sql += ` ORDER BY updated_at DESC, side_chat_id DESC LIMIT ?${params.length}`;
+    return this.db
+      .all<SideChatRow>(sql, ...params)
+      .map((row) => this.hydrate(row));
+  }
+
+  hydrate(row: SideChatRow): SideThreadRecord {
+    const attempts = this.db
+      .all<AttemptRow>(
+        "SELECT attempt_id,request_key,parent_attempt_id,thread_id,turn_id,state,result_text,error_text,attachments_json,created_at,updated_at FROM side_chat_attempts WHERE side_chat_id = ?1 ORDER BY created_at,attempt_id",
+        row.side_chat_id,
+      )
+      .map((a) => ({
+        attemptId: a.attempt_id,
+        requestKey: a.request_key,
+        parentAttemptId: a.parent_attempt_id ?? undefined,
+        threadId: a.thread_id ?? undefined,
+        turnId: a.turn_id ?? undefined,
+        state: a.state,
+        result: a.result_text ?? undefined,
+        error: a.error_text ?? undefined,
+        attachments: parseAttachmentJson(a.attachments_json),
+        createdAt: a.created_at,
+        updatedAt: a.updated_at,
+      }));
+    let attachments: SideThreadAttachmentRef[] = [];
+    try {
+      attachments = JSON.parse(row.attachments_json);
+    } catch {}
+    const bringBacks = this.db
+      .all<any>(
+        "SELECT bring_back_id,attempt_id,request_key,destination_thread_id,destination_turn_id,state,created_at,updated_at,completed_at FROM side_chat_bring_backs WHERE side_chat_id=?1 ORDER BY created_at,bring_back_id",
+        row.side_chat_id,
+      )
+      .map((b) => ({
+        bringBackId: b.bring_back_id,
+        attemptId: b.attempt_id,
+        requestKey: b.request_key,
+        destinationThreadId: b.destination_thread_id,
+        destinationTurnId: b.destination_turn_id ?? undefined,
+        state: b.state,
+        createdAt: b.created_at,
+        updatedAt: b.updated_at,
+        completedAt: b.completed_at ?? undefined,
+      }));
+    const operations = this.db
+      .all<any>(
+        "SELECT operation_id,attempt_id,operation_kind,request_key,state,thread_id,turn_id,error_code,created_at,updated_at FROM side_chat_operations WHERE side_chat_id=?1 ORDER BY created_at,rowid",
+        row.side_chat_id,
+      )
+      .map((op) => ({
+        operationId: op.operation_id,
+        attemptId: op.attempt_id ?? undefined,
+        kind: op.operation_kind,
+        requestKey: op.request_key,
+        state: op.state,
+        threadId: op.thread_id ?? undefined,
+        turnId: op.turn_id ?? undefined,
+        errorCode: op.error_code ?? undefined,
+        createdAt: op.created_at,
+        updatedAt: op.updated_at,
+      }));
+    return {
+      sideChatId: row.side_chat_id,
+      requestKey: row.create_request_key,
+      networkId: row.network_id,
+      nodeId: row.node_id,
+      ownerUserId: row.owner_user_id,
+      sourceThreadId: row.source_thread_id,
+      question: row.question_text,
+      boundary: {
+        kind: row.boundary_kind,
+        turnId: row.boundary_turn_id,
+      } as SideThreadBoundary,
+      threadId: row.derived_thread_id ?? undefined,
+      state: row.state,
+      activeAttemptId: row.active_attempt_id ?? undefined,
+      runtime: row.runtime ?? undefined,
+      runtimeVersion: row.runtime_version ?? undefined,
+      topology: row.topology ?? undefined,
+      evidenceRevision: row.evidence_revision ?? undefined,
+      attachments,
+      attempts,
+      bringBacks,
+      operations,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  events(sideChatId: string, after = 0): SideThreadEventRecord[] {
+    return this.db
+      .all<any>(
+        "SELECT event_id,side_chat_id,attempt_id,thread_id,turn_id,event_type,state,reason,created_at FROM side_chat_events WHERE side_chat_id = ?1 AND event_id > ?2 ORDER BY event_id LIMIT 500",
+        sideChatId,
+        after,
+      )
+      .map((e) => ({
+        eventId: e.event_id,
+        sideChatId: e.side_chat_id,
+        attemptId: e.attempt_id ?? undefined,
+        threadId: e.thread_id ?? undefined,
+        turnId: e.turn_id ?? undefined,
+        type: e.event_type,
+        state: e.state ?? undefined,
+        reason: e.reason ?? undefined,
+        createdAt: e.created_at,
+      }));
+  }
+}
+
+type CreateInput = {
+  requestKey: string;
+  networkId: string;
+  nodeId: string;
+  sourceThreadId: string;
+  boundary: SideThreadBoundary;
+  prompt: string;
+  attachments?: SideThreadAttachmentRef[];
+};
+
+export class SideThreadCoordinator {
+  private readonly emitter = new EventEmitter();
+  private readonly unsubscribe: () => void;
+  private readonly inFlight = new Map<string, Promise<unknown>>();
+  constructor(
+    readonly store: SideThreadStore,
+    readonly port: SideThreadExecutionPort,
+    private readonly opts: {
+      enabled: boolean;
+      authorizeNode: (
+        actor: SideThreadActor,
+        networkId: string,
+        nodeId: string,
+      ) => boolean;
+      authorizeAttachment?: (
+        actor: SideThreadActor,
+        networkId: string,
+        ref: SideThreadAttachmentRef,
+      ) => boolean;
+      now?: () => number;
+      id?: () => string;
+    },
+  ) {
+    this.unsubscribe = port.subscribe((event) => {
+      void this.acceptRuntimeEvent(event);
+    });
+  }
+
+  close(): void {
+    this.unsubscribe();
+    this.emitter.removeAllListeners();
+  }
+  private now(): number {
+    return (this.opts.now ?? Date.now)();
+  }
+  private id(prefix: string): string {
+    return `${prefix}_${(this.opts.id ?? randomUUID)().replace(/-/g, "")}`;
+  }
+
+  private assertEnabled(): void {
+    if (!this.opts.enabled)
+      throw new SideThreadError(
+        "SIDE_THREAD_DISABLED",
+        "SideThread API is disabled",
+        404,
+      );
+  }
+  private assertActor(actor: SideThreadActor): void {
+    requireIdentity(actor.userId, "actor.userId");
+    requireIdentity(actor.tokenId, "actor.tokenId");
+  }
+  private async assertCapability(
+    nodeId: string,
+    boundary?: SideThreadBoundary,
+  ): Promise<SideThreadCapability> {
+    const cap = await this.port.capability(nodeId);
+    if (!cap.supported)
+      throw new SideThreadError(
+        "SIDE_THREAD_UNSUPPORTED",
+        capabilityReason(cap.reason),
+        501,
+      );
+    if (cap.mode !== "native-exact-fork")
+      throw new SideThreadError(
+        "SIDE_THREAD_UNSUPPORTED",
+        "verified native exact-fork mode unavailable",
+        501,
+      );
+    if (boundary && !cap.exactBoundary?.[boundary.kind]) {
+      throw new SideThreadError(
+        "SIDE_THREAD_UNSUPPORTED",
+        `exact '${boundary.kind}' boundary unavailable`,
+        501,
+      );
+    }
+    return cap;
+  }
+
+  async create(
+    actor: SideThreadActor,
+    input: CreateInput,
+  ): Promise<SideThreadRecord> {
+    this.assertEnabled();
+    this.assertActor(actor);
+    validateCreateInput(input);
+    if (!this.opts.authorizeNode(actor, input.networkId, input.nodeId)) {
+      throw new SideThreadError("SIDE_THREAD_NOT_FOUND", "node not found", 404);
+    }
+    const attachments = normalizeAttachments(input.attachments);
+    for (const ref of attachments) {
+      if (!this.opts.authorizeAttachment?.(actor, input.networkId, ref)) {
+        throw new SideThreadError(
+          "SIDE_THREAD_ATTACHMENT_NOT_FOUND",
+          "attachment not found",
+          404,
+        );
+      }
+    }
+    const fingerprint = hashJson([
+      input.networkId,
+      input.nodeId,
+      input.sourceThreadId,
+      input.boundary,
+      input.prompt,
+      attachments,
+    ]);
+    const existing = this.store.getByCreateKey(actor, input.requestKey);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint)
+        throw conflict("idempotency key reused with different create payload");
+      return existing.record;
+    }
+    return this.singleFlight(
+      `create:${actor.userId}:${input.requestKey}`,
+      async () => {
+        const replay = this.store.getByCreateKey(actor, input.requestKey);
+        if (replay) {
+          if (replay.fingerprint !== fingerprint)
+            throw conflict(
+              "idempotency key reused with different create payload",
+            );
+          return replay.record;
+        }
+        const capability = await this.assertCapability(
+          input.nodeId,
+          input.boundary,
+        );
+        const sideChatId = this.id("sch");
+        const attemptId = this.id("sat");
+        const forkOperationId = stableOperationId(
+          sideChatId,
+          "fork",
+          input.requestKey,
+        );
+        const now = this.now();
+        try {
+          this.store.db.transaction(() => {
+            this.store.db.run(
+              `INSERT INTO side_chats (side_chat_id,network_id,node_id,owner_user_id,created_by_token_id,create_request_key,create_fingerprint,source_thread_id,question_text,boundary_kind,boundary_turn_id,state,active_attempt_id,runtime,runtime_version,topology,evidence_revision,attachments_json,created_at,updated_at)
+           VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,'creating',?12,?13,?14,?15,?16,?17,?18,?18)`,
+              [
+                sideChatId,
+                input.networkId,
+                input.nodeId,
+                actor.userId,
+                actor.tokenId,
+                input.requestKey,
+                fingerprint,
+                input.sourceThreadId,
+                input.prompt,
+                input.boundary.kind,
+                input.boundary.turnId,
+                attemptId,
+                capability.runtime ?? null,
+                capability.runtimeVersion ?? null,
+                capability.topology ?? null,
+                capability.evidenceRevision ?? null,
+                JSON.stringify(attachments),
+                now,
+              ],
+            );
+            this.store.db.run(
+              `INSERT INTO side_chat_attempts (attempt_id,side_chat_id,request_key,request_fingerprint,prompt_hash,attachments_json,state,created_at,updated_at)
+           VALUES (?1,?2,?3,?4,?5,?6,'starting',?7,?7)`,
+              [
+                attemptId,
+                sideChatId,
+                input.requestKey,
+                fingerprint,
+                hashText(input.prompt),
+                JSON.stringify(attachments),
+                now,
+              ],
+            );
+            this.insertOperation({
+              operationId: forkOperationId,
+              sideChatId,
+              attemptId,
+              kind: "fork",
+              requestKey: input.requestKey,
+              fingerprint,
+              at: now,
+            });
+            this.emitStored(
+              sideChatId,
+              attemptId,
+              undefined,
+              undefined,
+              "side_chat.created",
+              "creating",
+              undefined,
+              now,
+            );
+          });
+        } catch (error) {
+          const winner = this.store.getByCreateKey(actor, input.requestKey);
+          if (winner) {
+            if (winner.fingerprint !== fingerprint)
+              throw conflict(
+                "idempotency key reused with different create payload",
+              );
+            return winner.record;
+          }
+          throw error;
+        }
+        let activeOperationId = forkOperationId;
+        try {
+          const forked = await this.port.fork({
+            operationId: forkOperationId,
+            requestKey: input.requestKey,
+            sideChatId,
+            nodeId: input.nodeId,
+            sourceThreadId: input.sourceThreadId,
+            boundary: input.boundary,
+          });
+          requireRuntimeIdentity(forked.threadId, "threadId");
+          if (forked.threadId === input.sourceThreadId)
+            throw runtimeProtocol(
+              "runtime returned source thread as side thread",
+            );
+          this.store.db.transaction(() => {
+            const t = this.now();
+            this.store.db.run(
+              "UPDATE side_chats SET derived_thread_id=?1,updated_at=?2 WHERE side_chat_id=?3 AND state='creating'",
+              [forked.threadId, t, sideChatId],
+            );
+            this.store.db.run(
+              "UPDATE side_chat_attempts SET thread_id=?1,updated_at=?2 WHERE attempt_id=?3 AND state='starting'",
+              [forked.threadId, t, attemptId],
+            );
+            this.settleOperation(forkOperationId, "completed", {
+              threadId: forked.threadId,
+            });
+          });
+          const startOperationId = stableOperationId(
+            sideChatId,
+            "start",
+            input.requestKey,
+          );
+          activeOperationId = startOperationId;
+          this.insertOperation({
+            operationId: startOperationId,
+            sideChatId,
+            attemptId,
+            kind: "start",
+            requestKey: input.requestKey,
+            fingerprint,
+            threadId: forked.threadId,
+            at: this.now(),
+          });
+          const started = await this.port.start({
+            operationId: startOperationId,
+            requestKey: input.requestKey,
+            sideChatId,
+            attemptId,
+            nodeId: input.nodeId,
+            threadId: forked.threadId,
+            prompt: input.prompt,
+            attachments,
+          });
+          requireRuntimeIdentity(started.turnId, "turnId");
+          this.store.db.transaction(() => {
+            const attempt = this.store.db.get<any>(
+              "SELECT state,turn_id FROM side_chat_attempts WHERE attempt_id=?1",
+              attemptId,
+            );
+            if (!attempt) throw conflict("attempt disappeared during start");
+            if (attempt.turn_id && attempt.turn_id !== started.turnId)
+              throw runtimeProtocol(
+                "runtime turn identity changed during start",
+              );
+            this.settleOperation(startOperationId, "completed", {
+              threadId: forked.threadId,
+              turnId: started.turnId,
+            });
+            if (attempt.state === "starting") {
+              const t = this.now();
+              this.store.db.run(
+                "UPDATE side_chat_attempts SET state='running',turn_id=?1,updated_at=?2 WHERE attempt_id=?3 AND state='starting'",
+                [started.turnId, t, attemptId],
+              );
+              this.store.db.run(
+                "UPDATE side_chats SET state='running',derived_thread_id=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id=?4",
+                [forked.threadId, t, sideChatId, attemptId],
+              );
+              this.emitStored(
+                sideChatId,
+                attemptId,
+                forked.threadId,
+                started.turnId,
+                "attempt.running",
+                "running",
+                undefined,
+                t,
+              );
+            }
+          });
+        } catch (error) {
+          if (isAmbiguousRuntimeError(error)) {
+            if (this.operationState(activeOperationId) === "completed")
+              return this.mustOwned(sideChatId, actor);
+            this.markAmbiguous(sideChatId, attemptId, activeOperationId, error);
+            throw ambiguousError(activeOperationId, sideChatId, attemptId);
+          }
+          this.settleOperation(activeOperationId, "failed", {
+            errorCode: auditErrorReason(error),
+          });
+          this.failStarting(sideChatId, attemptId, error);
+          throw normalizePortError(error);
+        }
+        return this.mustOwned(sideChatId, actor);
+      },
+    );
+  }
+
+  get(actor: SideThreadActor, sideChatId: string): SideThreadRecord {
+    this.assertEnabled();
+    this.assertActor(actor);
+    requireIdentity(sideChatId, "sideChatId");
+    return this.mustOwned(sideChatId, actor);
+  }
+
+  list(
+    actor: SideThreadActor,
+    filters: { networkId?: string; nodeId?: string; limit?: number } = {},
+  ): SideThreadRecord[] {
+    this.assertEnabled();
+    this.assertActor(actor);
+    if (filters.networkId) requireIdentity(filters.networkId, "networkId");
+    if (filters.nodeId) requireIdentity(filters.nodeId, "nodeId");
+    return this.store
+      .listOwned(actor, filters)
+      .filter((record) =>
+        this.opts.authorizeNode(actor, record.networkId, record.nodeId),
+      );
+  }
+
+  isEnabled(): boolean {
+    return this.opts.enabled;
+  }
+
+  async capability(
+    actor: SideThreadActor,
+    networkId: string,
+    nodeId: string,
+    boundary: SideThreadBoundary,
+  ): Promise<SideThreadCapability> {
+    this.assertEnabled();
+    this.assertActor(actor);
+    requireIdentity(networkId, "networkId");
+    requireIdentity(nodeId, "nodeId");
+    requireIdentity(boundary.turnId, "boundary.turnId");
+    if (!this.opts.authorizeNode(actor, networkId, nodeId))
+      throw new SideThreadError("SIDE_THREAD_NOT_FOUND", "node not found", 404);
+    const capability = await this.port.capability(nodeId);
+    if (!capability.supported)
+      return {
+        supported: false,
+        reason: capabilityReasonCode(capability.reason),
+      };
+    if (capability.mode !== "native-exact-fork")
+      return { supported: false, reason: "native-exact-fork-unavailable" };
+    if (!capability.exactBoundary?.[boundary.kind])
+      return { supported: false, reason: `exact-${boundary.kind}-unavailable` };
+    return capability;
+  }
+
+  async cancel(
+    actor: SideThreadActor,
+    sideChatId: string,
+  ): Promise<SideThreadRecord> {
+    this.assertEnabled();
+    return this.singleFlight(`cancel:${sideChatId}`, async () => {
+      const record = this.mustOwned(sideChatId, actor);
+      const attempt = record.attempts.find(
+        (a) => a.attemptId === record.activeAttemptId,
+      );
+      if (
+        !attempt?.threadId ||
+        !attempt.turnId ||
+        !["running", "ambiguous", "reconciling"].includes(attempt.state)
+      )
+        throw conflict("side chat has no cancellable attempt");
+      await this.assertCapability(record.nodeId);
+      const operationRequestKey = `cancel:${attempt.attemptId}`;
+      const prepared = this.prepareStableOperation({
+        sideChatId,
+        attemptId: attempt.attemptId,
+        kind: "cancel",
+        requestKey: operationRequestKey,
+        fingerprint: hashJson([
+          sideChatId,
+          attempt.attemptId,
+          attempt.threadId,
+          attempt.turnId,
+        ]),
+        threadId: attempt.threadId,
+        turnId: attempt.turnId,
+      });
+      if (prepared.state === "completed") return record;
+      if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+        throw ambiguousError(
+          prepared.operationId,
+          sideChatId,
+          attempt.attemptId,
+        );
+      // A second coordinator observing the durable pending claim must never
+      // issue another RPC. Returning its current owner projection is an
+      // honest in-progress replay; ambiguous is handled above and is typed.
+      if (!prepared.callable) return this.mustOwned(sideChatId, actor);
+      const claimedAt = this.now();
+      const claim = this.store.db.run(
+        "UPDATE side_chat_attempts SET cancel_requested_at=?1,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4 AND cancel_requested_at IS NULL",
+        [claimedAt, attempt.attemptId, attempt.threadId, attempt.turnId],
+      );
+      if (claim.changes === 0) {
+        this.markAmbiguous(
+          sideChatId,
+          attempt.attemptId,
+          prepared.operationId,
+          { code: "SIDE_THREAD_RESPONSE_LOST" },
+        );
+        throw ambiguousError(
+          prepared.operationId,
+          sideChatId,
+          attempt.attemptId,
+        );
+      }
+      try {
+        await this.port.cancel({
+          operationId: prepared.operationId,
+          sideChatId,
+          attemptId: attempt.attemptId,
+          nodeId: record.nodeId,
+          threadId: attempt.threadId,
+          turnId: attempt.turnId,
+        });
+      } catch (error) {
+        if (isAmbiguousRuntimeError(error)) {
+          this.markAmbiguous(
+            sideChatId,
+            attempt.attemptId,
+            prepared.operationId,
+            error,
+          );
+          throw ambiguousError(
+            prepared.operationId,
+            sideChatId,
+            attempt.attemptId,
+          );
+        }
+        this.settleOperation(prepared.operationId, "failed", {
+          errorCode: auditErrorReason(error),
+        });
+        this.store.db.run(
+          "UPDATE side_chat_attempts SET cancel_requested_at=NULL,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
+          [this.now(), attempt.attemptId, attempt.threadId, attempt.turnId],
+        );
+        throw normalizePortError(error);
+      }
+      this.store.db.transaction(() => {
+        const t = this.now();
+        const changed = this.store.db.run(
+          "UPDATE side_chat_attempts SET state='cancelled',updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
+          [t, attempt.attemptId, attempt.threadId, attempt.turnId],
+        );
+        if (changed.changes > 0) {
+          this.store.db.run(
+            "UPDATE side_chats SET state='cancelled',active_attempt_id=NULL,updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3",
+            [t, sideChatId, attempt.attemptId],
+          );
+          this.emitStored(
+            sideChatId,
+            attempt.attemptId,
+            attempt.threadId,
+            attempt.turnId,
+            "attempt.cancelled",
+            "cancelled",
+            undefined,
+            t,
+          );
+        }
+        this.settleOperation(prepared.operationId, "completed", {
+          threadId: attempt.threadId,
+          turnId: attempt.turnId,
+        });
+      });
+      return this.mustOwned(sideChatId, actor);
+    });
+  }
+
+  async retry(
+    actor: SideThreadActor,
+    sideChatId: string,
+    input: {
+      requestKey: string;
+      prompt: string;
+      attachments?: SideThreadAttachmentRef[];
+    },
+  ): Promise<SideThreadRecord> {
+    this.assertEnabled();
+    requireKey(input.requestKey);
+    requirePrompt(input.prompt);
+    return this.singleFlight(
+      `retry:${sideChatId}:${input.requestKey}`,
+      async () => {
+        const record = this.mustOwned(sideChatId, actor);
+        if (!record.threadId) throw conflict("side chat has no derived thread");
+        const attachments = normalizeAttachments(
+          input.attachments ?? record.attachments,
+        );
+        for (const ref of attachments)
+          if (!this.opts.authorizeAttachment?.(actor, record.networkId, ref))
+            throw new SideThreadError(
+              "SIDE_THREAD_ATTACHMENT_NOT_FOUND",
+              "attachment not found",
+              404,
+            );
+        const fingerprint = hashJson([sideChatId, input.prompt, attachments]);
+        const old = this.store.db.get<any>(
+          "SELECT attempt_id,request_fingerprint FROM side_chat_attempts WHERE side_chat_id=?1 AND request_key=?2",
+          sideChatId,
+          input.requestKey,
+        );
+        if (old) {
+          if (old.request_fingerprint !== fingerprint)
+            throw conflict(
+              "idempotency key reused with different retry payload",
+            );
+          return this.mustOwned(sideChatId, actor);
+        }
+        if (record.activeAttemptId)
+          throw conflict("side chat already has an active attempt");
+        if (record.state === "archived" || record.state === "purged")
+          throw conflict(`cannot retry ${record.state} side chat`);
+        await this.assertCapability(record.nodeId);
+        const parent = record.attempts.at(-1);
+        if (!parent) throw conflict("side chat has no prior attempt");
+        const attemptId = this.id("sat"),
+          startOperationId = stableOperationId(
+            sideChatId,
+            "start",
+            input.requestKey,
+          ),
+          t = this.now();
+        try {
+          this.store.db.transaction(() => {
+            this.store.db.run(
+              "INSERT INTO side_chat_attempts (attempt_id,side_chat_id,parent_attempt_id,request_key,request_fingerprint,prompt_hash,attachments_json,thread_id,state,created_at,updated_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,'starting',?9,?9)",
+              [
+                attemptId,
+                sideChatId,
+                parent.attemptId,
+                input.requestKey,
+                fingerprint,
+                hashText(input.prompt),
+                JSON.stringify(attachments),
+                record.threadId,
+                t,
+              ],
+            );
+            this.insertOperation({
+              operationId: startOperationId,
+              sideChatId,
+              attemptId,
+              kind: "start",
+              requestKey: input.requestKey,
+              fingerprint,
+              threadId: record.threadId,
+              at: t,
+            });
+            this.store.db.run(
+              "UPDATE side_chats SET state='running',active_attempt_id=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id IS NULL",
+              [attemptId, t, sideChatId],
+            );
+            this.emitStored(
+              sideChatId,
+              attemptId,
+              record.threadId,
+              undefined,
+              "attempt.retrying",
+              "starting",
+              undefined,
+              t,
+            );
+          });
+        } catch (error) {
+          const winner = this.store.db.get<any>(
+            "SELECT request_fingerprint FROM side_chat_attempts WHERE side_chat_id=?1 AND request_key=?2",
+            sideChatId,
+            input.requestKey,
+          );
+          if (winner) {
+            if (winner.request_fingerprint !== fingerprint)
+              throw conflict(
+                "idempotency key reused with different retry payload",
+              );
+            return this.mustOwned(sideChatId, actor);
+          }
+          const active = this.store.db.get<{ attempt_id: string }>(
+            "SELECT attempt_id FROM side_chat_attempts WHERE side_chat_id=?1 AND state IN ('starting','running') LIMIT 1",
+            sideChatId,
+          );
+          if (active) throw conflict("side chat already has an active attempt");
+          throw error;
+        }
+        try {
+          const started = await this.port.start({
+            operationId: startOperationId,
+            requestKey: input.requestKey,
+            sideChatId,
+            attemptId,
+            nodeId: record.nodeId,
+            threadId: record.threadId,
+            prompt: input.prompt,
+            attachments,
+          });
+          requireRuntimeIdentity(started.turnId, "turnId");
+          this.store.db.transaction(() => {
+            const now = this.now();
+            const attempt = this.store.db.get<any>(
+              "SELECT state,turn_id FROM side_chat_attempts WHERE attempt_id=?1",
+              attemptId,
+            );
+            if (attempt?.turn_id && attempt.turn_id !== started.turnId)
+              throw runtimeProtocol(
+                "runtime turn identity changed during retry",
+              );
+            this.settleOperation(startOperationId, "completed", {
+              threadId: record.threadId,
+              turnId: started.turnId,
+            });
+            if (attempt?.state === "starting") {
+              this.store.db.run(
+                "UPDATE side_chat_attempts SET state='running',turn_id=?1,updated_at=?2 WHERE attempt_id=?3",
+                [started.turnId, now, attemptId],
+              );
+              this.emitStored(
+                sideChatId,
+                attemptId,
+                record.threadId,
+                started.turnId,
+                "attempt.running",
+                "running",
+                undefined,
+                now,
+              );
+            }
+          });
+        } catch (error) {
+          if (isAmbiguousRuntimeError(error)) {
+            if (this.operationState(startOperationId) === "completed")
+              return this.mustOwned(sideChatId, actor);
+            this.markAmbiguous(sideChatId, attemptId, startOperationId, error);
+            throw ambiguousError(startOperationId, sideChatId, attemptId);
+          }
+          this.settleOperation(startOperationId, "failed", {
+            errorCode: auditErrorReason(error),
+          });
+          this.failStarting(sideChatId, attemptId, error);
+          throw normalizePortError(error);
+        }
+        return this.mustOwned(sideChatId, actor);
+      },
+    );
+  }
+
+  async archive(
+    actor: SideThreadActor,
+    sideChatId: string,
+  ): Promise<SideThreadRecord> {
+    return this.lifecycle(actor, sideChatId, "archive");
+  }
+  async purge(
+    actor: SideThreadActor,
+    sideChatId: string,
+  ): Promise<SideThreadRecord> {
+    return this.lifecycle(actor, sideChatId, "purge");
+  }
+  private async lifecycle(
+    actor: SideThreadActor,
+    sideChatId: string,
+    action: "archive" | "purge",
+  ): Promise<SideThreadRecord> {
+    this.assertEnabled();
+    return this.singleFlight(`${action}:${sideChatId}`, async () => {
+      const r = this.mustOwned(sideChatId, actor);
+      if (r.activeAttemptId)
+        throw conflict(`cannot ${action} a running side chat`);
+      if (!r.threadId) throw conflict("side chat has no derived thread");
+      if (r.state === "purged") return r;
+      if (action === "archive" && r.state === "archived") return r;
+      await this.assertCapability(r.nodeId);
+      const operationRequestKey = `${action}:${sideChatId}`;
+      const prepared = this.prepareStableOperation({
+        sideChatId,
+        kind: action,
+        requestKey: operationRequestKey,
+        fingerprint: hashJson([action, sideChatId, r.nodeId, r.threadId]),
+        threadId: r.threadId,
+      });
+      if (prepared.state === "completed") return r;
+      if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+        throw ambiguousError(prepared.operationId, sideChatId);
+      if (!prepared.callable)
+        throw conflict("side chat lifecycle operation already in progress");
+      const claim = this.store.db.run(
+        "UPDATE side_chats SET lifecycle_operation=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id IS NULL AND lifecycle_operation IS NULL",
+        [action, this.now(), sideChatId],
+      );
+      if (claim.changes === 0) {
+        const current = this.mustOwned(sideChatId, actor);
+        if (current.state === "purged") return current;
+        if (action === "archive" && current.state === "archived")
+          return current;
+        this.markAmbiguous(sideChatId, undefined, prepared.operationId, {
+          code: "SIDE_THREAD_RESPONSE_LOST",
+        });
+        throw ambiguousError(prepared.operationId, sideChatId);
+      }
+      try {
+        if (action === "archive")
+          await this.port.archive({
+            operationId: prepared.operationId,
+            sideChatId,
+            nodeId: r.nodeId,
+            threadId: r.threadId,
+          });
+        else
+          await this.port.purge({
+            operationId: prepared.operationId,
+            sideChatId,
+            nodeId: r.nodeId,
+            threadId: r.threadId,
+          });
+      } catch (error) {
+        if (isAmbiguousRuntimeError(error)) {
+          this.markAmbiguous(
+            sideChatId,
+            undefined,
+            prepared.operationId,
+            error,
+          );
+          throw ambiguousError(prepared.operationId, sideChatId);
+        }
+        this.settleOperation(prepared.operationId, "failed", {
+          errorCode: auditErrorReason(error),
+        });
+        this.store.db.run(
+          "UPDATE side_chats SET lifecycle_operation=NULL,updated_at=?1 WHERE side_chat_id=?2 AND lifecycle_operation=?3",
+          [this.now(), sideChatId, action],
+        );
+        throw normalizePortError(error);
+      }
+      const state = action === "archive" ? "archived" : "purged",
+        t = this.now();
+      this.store.db.transaction(() => {
+        if (action === "purge") {
+          this.store.db.run(
+            "UPDATE side_chats SET state='purged',question_text='',attachments_json='[]',lifecycle_operation=NULL,updated_at=?1,purged_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='purge'",
+            [t, sideChatId],
+          );
+          this.store.db.run(
+            "UPDATE side_chat_attempts SET result_text=NULL,error_text=NULL,updated_at=?1 WHERE side_chat_id=?2",
+            [t, sideChatId],
+          );
+        } else {
+          this.store.db.run(
+            "UPDATE side_chats SET state='archived',lifecycle_operation=NULL,updated_at=?1,archived_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='archive'",
+            [t, sideChatId],
+          );
+        }
+        this.settleOperation(prepared.operationId, "completed", {
+          threadId: r.threadId,
+        });
+        this.emitStored(
+          sideChatId,
+          undefined,
+          r.threadId,
+          undefined,
+          `side_chat.${state}`,
+          state,
+          undefined,
+          t,
+        );
+      });
+      return this.mustOwned(sideChatId, actor);
+    });
+  }
+
+  async bringBack(
+    actor: SideThreadActor,
+    sideChatId: string,
+    input: {
+      requestKey: string;
+      destinationThreadId: string;
+      attemptId?: string;
+    },
+  ): Promise<{ bringBackId: string; destinationTurnId: string }> {
+    this.assertEnabled();
+    requireKey(input.requestKey);
+    requireIdentity(input.destinationThreadId, "destinationThreadId");
+    return this.singleFlight(
+      `bring-back:${sideChatId}:${input.requestKey}`,
+      async () => {
+        const r = this.mustOwned(sideChatId, actor);
+        if (r.state === "purged")
+          throw conflict("cannot bring back a purged side chat");
+        if (input.destinationThreadId !== r.sourceThreadId)
+          throw conflict(
+            "bring-back destination must be the original source thread",
+          );
+        const attempt = input.attemptId
+          ? r.attempts.find((a) => a.attemptId === input.attemptId)
+          : [...r.attempts].reverse().find((a) => a.state === "completed");
+        if (
+          !attempt ||
+          attempt.state !== "completed" ||
+          !attempt.result ||
+          !attempt.threadId ||
+          !attempt.turnId
+        )
+          throw conflict("bring-back requires a completed owned attempt");
+        const fp = hashJson([
+          sideChatId,
+          attempt.attemptId,
+          input.destinationThreadId,
+        ]);
+        const old = this.store.db.get<any>(
+          "SELECT bring_back_id,destination_turn_id,request_fingerprint,state FROM side_chat_bring_backs WHERE side_chat_id=?1 AND request_key=?2",
+          sideChatId,
+          input.requestKey,
+        );
+        if (old) {
+          if (old.request_fingerprint !== fp)
+            throw conflict(
+              "idempotency key reused with different bring-back payload",
+            );
+          if (old.state !== "completed" || !old.destination_turn_id) {
+            const operation = this.store.db.get<{
+              operation_id: string;
+              state: string;
+            }>(
+              "SELECT operation_id,state FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='bring-back' AND request_key=?2",
+              sideChatId,
+              input.requestKey,
+            );
+            if (
+              operation &&
+              (operation.state === "ambiguous" ||
+                operation.state === "reconciling")
+            )
+              throw ambiguousError(
+                operation.operation_id,
+                sideChatId,
+                attempt.attemptId,
+              );
+            throw conflict("bring-back is already in progress or failed");
+          }
+          return {
+            bringBackId: old.bring_back_id,
+            destinationTurnId: old.destination_turn_id,
+          };
+        }
+        const priorDestination = this.store.db.get<any>(
+          "SELECT bring_back_id,destination_turn_id,state FROM side_chat_bring_backs WHERE side_chat_id=?1 AND attempt_id=?2 AND destination_thread_id=?3",
+          sideChatId,
+          attempt.attemptId,
+          input.destinationThreadId,
+        );
+        if (priorDestination) {
+          if (
+            priorDestination.state === "completed" &&
+            priorDestination.destination_turn_id
+          )
+            return {
+              bringBackId: priorDestination.bring_back_id,
+              destinationTurnId: priorDestination.destination_turn_id,
+            };
+          throw conflict(
+            "bring-back for this attempt is already in progress or failed",
+          );
+        }
+        await this.assertCapability(r.nodeId);
+        const prepared = this.prepareStableOperation({
+          sideChatId,
+          attemptId: attempt.attemptId,
+          kind: "bring-back",
+          requestKey: input.requestKey,
+          fingerprint: fp,
+          threadId: attempt.threadId,
+          turnId: attempt.turnId,
+        });
+        if (prepared.state === "completed") {
+          const completed = this.store.db.get<any>(
+            "SELECT bring_back_id,destination_turn_id FROM side_chat_bring_backs WHERE side_chat_id=?1 AND request_key=?2 AND state='completed'",
+            sideChatId,
+            input.requestKey,
+          );
+          if (completed?.destination_turn_id)
+            return {
+              bringBackId: completed.bring_back_id,
+              destinationTurnId: completed.destination_turn_id,
+            };
+        }
+        if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+          throw ambiguousError(
+            prepared.operationId,
+            sideChatId,
+            attempt.attemptId,
+          );
+        if (!prepared.callable)
+          throw conflict("bring-back operation is already in progress");
+        const bringBackId = this.id("sbb"),
+          t = this.now();
+        try {
+          this.store.db.run(
+            "INSERT INTO side_chat_bring_backs (bring_back_id,side_chat_id,attempt_id,owner_user_id,request_key,request_fingerprint,destination_thread_id,state,created_at,updated_at) VALUES (?1,?2,?3,?4,?5,?6,?7,'starting',?8,?8)",
+            [
+              bringBackId,
+              sideChatId,
+              attempt.attemptId,
+              actor.userId,
+              input.requestKey,
+              fp,
+              input.destinationThreadId,
+              t,
+            ],
+          );
+        } catch (error) {
+          const winner = this.store.db.get<any>(
+            "SELECT bring_back_id,destination_turn_id,state,request_key,request_fingerprint FROM side_chat_bring_backs WHERE side_chat_id=?1 AND (request_key=?2 OR (attempt_id=?3 AND destination_thread_id=?4)) LIMIT 1",
+            sideChatId,
+            input.requestKey,
+            attempt.attemptId,
+            input.destinationThreadId,
+          );
+          if (
+            winner?.request_key === input.requestKey &&
+            winner.request_fingerprint !== fp
+          )
+            throw conflict(
+              "idempotency key reused with different bring-back payload",
+            );
+          if (winner?.state === "completed" && winner.destination_turn_id)
+            return {
+              bringBackId: winner.bring_back_id,
+              destinationTurnId: winner.destination_turn_id,
+            };
+          if (winner)
+            throw conflict(
+              "bring-back for this attempt is already in progress or failed",
+            );
+          throw error;
+        }
+        try {
+          const out = await this.port.bringBack({
+            operationId: prepared.operationId,
+            sideChatId,
+            attemptId: attempt.attemptId,
+            nodeId: r.nodeId,
+            sourceThreadId: attempt.threadId,
+            sourceTurnId: attempt.turnId,
+            destinationThreadId: input.destinationThreadId,
+            requestKey: input.requestKey,
+            text: attempt.result,
+          });
+          requireRuntimeIdentity(out.destinationTurnId, "destinationTurnId");
+          const now = this.now();
+          this.store.db.transaction(() => {
+            this.store.db.run(
+              "UPDATE side_chat_bring_backs SET state='completed',destination_turn_id=?1,updated_at=?2,completed_at=?2 WHERE bring_back_id=?3 AND state='starting'",
+              [out.destinationTurnId, now, bringBackId],
+            );
+            this.settleOperation(prepared.operationId, "completed", {
+              threadId: input.destinationThreadId,
+              turnId: out.destinationTurnId,
+            });
+            this.emitStored(
+              sideChatId,
+              attempt.attemptId,
+              attempt.threadId,
+              attempt.turnId,
+              "side_chat.brought_back",
+              "completed",
+              undefined,
+              now,
+            );
+          });
+          return { bringBackId, destinationTurnId: out.destinationTurnId };
+        } catch (error) {
+          const operation = this.store.db.get<{ operation_id: string }>(
+            "SELECT operation_id FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='bring-back' AND request_key=?2",
+            sideChatId,
+            input.requestKey,
+          );
+          if (operation && isAmbiguousRuntimeError(error)) {
+            this.markAmbiguous(
+              sideChatId,
+              attempt.attemptId,
+              operation.operation_id,
+              error,
+            );
+            throw ambiguousError(
+              operation.operation_id,
+              sideChatId,
+              attempt.attemptId,
+            );
+          }
+          if (operation)
+            this.settleOperation(operation.operation_id, "failed", {
+              errorCode: auditErrorReason(error),
+            });
+          this.store.db.run(
+            "UPDATE side_chat_bring_backs SET state='failed',error_text=?1,updated_at=?2 WHERE bring_back_id=?3 AND state='starting'",
+            [
+              safeReason(
+                error instanceof Error ? error.message : String(error),
+              ),
+              this.now(),
+              bringBackId,
+            ],
+          );
+          throw normalizePortError(error);
+        }
+      },
+    );
+  }
+
+  listEvents(
+    actor: SideThreadActor,
+    sideChatId: string,
+    after = 0,
+  ): SideThreadEventRecord[] {
+    this.mustOwned(sideChatId, actor);
+    return this.store.events(sideChatId, after);
+  }
+  subscribe(
+    sideChatId: string,
+    listener: (event: SideThreadEventRecord) => void,
+  ): () => void {
+    const key = `side:${sideChatId}`;
+    this.emitter.on(key, listener);
+    return () => this.emitter.off(key, listener);
+  }
+
+  private insertOperation(input: {
+    operationId: string;
+    sideChatId: string;
+    attemptId?: string;
+    kind: SideThreadOperationRecord["kind"];
+    requestKey: string;
+    fingerprint: string;
+    threadId?: string;
+    turnId?: string;
+    at: number;
+  }): void {
+    this.store.db.run(
+      "INSERT INTO side_chat_operations (operation_id,side_chat_id,attempt_id,operation_kind,request_key,request_fingerprint,state,thread_id,turn_id,created_at,updated_at) VALUES (?1,?2,?3,?4,?5,?6,'pending',?7,?8,?9,?9)",
+      [
+        input.operationId,
+        input.sideChatId,
+        input.attemptId ?? null,
+        input.kind,
+        input.requestKey,
+        input.fingerprint,
+        input.threadId ?? null,
+        input.turnId ?? null,
+        input.at,
+      ],
+    );
+  }
+
+  private prepareStableOperation(input: {
+    sideChatId: string;
+    attemptId?: string;
+    kind: SideThreadOperationRecord["kind"];
+    requestKey: string;
+    fingerprint: string;
+    threadId?: string;
+    turnId?: string;
+  }): {
+    operationId: string;
+    state: SideThreadOperationRecord["state"];
+    callable: boolean;
+  } {
+    const operationId = stableOperationId(
+      input.sideChatId,
+      input.kind,
+      input.requestKey,
+    );
+    const existing = this.store.db.get<any>(
+      "SELECT operation_id,request_fingerprint,state FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind=?2 AND request_key=?3",
+      input.sideChatId,
+      input.kind,
+      input.requestKey,
+    );
+    if (existing) {
+      if (existing.request_fingerprint !== input.fingerprint)
+        throw conflict("operation request key reused with different payload");
+      if (existing.state === "failed") {
+        this.store.db.run(
+          "UPDATE side_chat_operations SET state='pending',error_code=NULL,updated_at=?1 WHERE operation_id=?2 AND state='failed'",
+          [this.now(), existing.operation_id],
+        );
+        return {
+          operationId: existing.operation_id,
+          state: "pending",
+          callable: true,
+        };
+      }
+      return {
+        operationId: existing.operation_id,
+        state: existing.state,
+        callable: false,
+      };
+    }
+    this.insertOperation({
+      operationId,
+      sideChatId: input.sideChatId,
+      attemptId: input.attemptId,
+      kind: input.kind,
+      requestKey: input.requestKey,
+      fingerprint: input.fingerprint,
+      threadId: input.threadId,
+      turnId: input.turnId,
+      at: this.now(),
+    });
+    return { operationId, state: "pending", callable: true };
+  }
+
+  private settleOperation(
+    operationId: string,
+    state: "completed" | "failed",
+    fields: { threadId?: string; turnId?: string; errorCode?: string } = {},
+  ): void {
+    this.store.db.run(
+      "UPDATE side_chat_operations SET state=?1,thread_id=COALESCE(?2,thread_id),turn_id=COALESCE(?3,turn_id),error_code=?4,updated_at=?5 WHERE operation_id=?6 AND state IN ('pending','ambiguous','reconciling')",
+      [
+        state,
+        fields.threadId ?? null,
+        fields.turnId ?? null,
+        fields.errorCode ?? null,
+        this.now(),
+        operationId,
+      ],
+    );
+  }
+
+  private operationState(operationId: string): string | undefined {
+    return this.store.db.get<{ state: string }>(
+      "SELECT state FROM side_chat_operations WHERE operation_id=?1",
+      operationId,
+    )?.state;
+  }
+
+  private markAmbiguous(
+    sideChatId: string,
+    attemptId: string | undefined,
+    operationId: string,
+    error: unknown,
+  ): void {
+    const at = this.now();
+    this.store.db.transaction(() => {
+      this.store.db.run(
+        "UPDATE side_chat_operations SET state='ambiguous',error_code=?1,updated_at=?2 WHERE operation_id=?3 AND state IN ('pending','reconciling')",
+        [auditErrorReason(error), at, operationId],
+      );
+      if (attemptId)
+        this.store.db.run(
+          "UPDATE side_chat_attempts SET state='ambiguous',updated_at=?1 WHERE attempt_id=?2 AND state IN ('starting','running','reconciling')",
+          [at, attemptId],
+        );
+      this.store.db.run(
+        "UPDATE side_chats SET state='ambiguous',updated_at=?1 WHERE side_chat_id=?2 AND state != 'purged'",
+        [at, sideChatId],
+      );
+      this.emitStored(
+        sideChatId,
+        attemptId,
+        undefined,
+        undefined,
+        "operation.ambiguous",
+        "ambiguous",
+        "SIDE_THREAD_AMBIGUOUS",
+        at,
+      );
+    });
+  }
+
+  private async acceptRuntimeEvent(
+    event: SideThreadRuntimeEvent,
+  ): Promise<void> {
+    try {
+      requireIdentity(event.sideChatId, "event.sideChatId");
+      requireIdentity(event.attemptId, "event.attemptId");
+      requireIdentity(event.threadId, "event.threadId");
+      requireIdentity(event.turnId, "event.turnId");
+      this.store.db.transaction(() => {
+        const owned = this.store.db.get<any>(
+          `SELECT c.active_attempt_id,c.derived_thread_id,a.state,a.turn_id FROM side_chats c JOIN side_chat_attempts a ON a.side_chat_id=c.side_chat_id AND a.attempt_id=?2 WHERE c.side_chat_id=?1`,
+          event.sideChatId,
+          event.attemptId,
+        );
+        const starting =
+          (owned?.state === "starting" ||
+            owned?.state === "ambiguous" ||
+            owned?.state === "reconciling") &&
+          !owned?.turn_id;
+        if (!owned) return;
+        if (
+          owned.active_attempt_id !== event.attemptId ||
+          owned.derived_thread_id !== event.threadId ||
+          (!starting && owned.turn_id !== event.turnId) ||
+          !(
+            owned.state === "running" ||
+            owned.state === "ambiguous" ||
+            owned.state === "reconciling" ||
+            starting
+          )
+        ) {
+          this.emitStored(
+            event.sideChatId,
+            event.attemptId,
+            event.threadId,
+            event.turnId,
+            "runtime_event.dropped",
+            undefined,
+            "ownership-mismatch",
+            this.now(),
+          );
+          return;
+        }
+        const state =
+          event.status === "completed"
+            ? "completed"
+            : event.status === "interrupted"
+              ? "cancelled"
+              : "failed";
+        const t = this.now();
+        const startOperation = this.store.db.get<{ operation_id: string }>(
+          "SELECT operation_id FROM side_chat_operations WHERE side_chat_id=?1 AND attempt_id=?2 AND operation_kind='start' ORDER BY created_at DESC LIMIT 1",
+          event.sideChatId,
+          event.attemptId,
+        );
+        if (startOperation)
+          this.settleOperation(startOperation.operation_id, "completed", {
+            threadId: event.threadId,
+            turnId: event.turnId,
+          });
+        this.store.db.run(
+          "UPDATE side_chat_attempts SET state=?1,turn_id=COALESCE(turn_id,?2),result_text=?3,error_text=?4,updated_at=?5 WHERE attempt_id=?6 AND state IN ('starting','running','ambiguous','reconciling')",
+          [
+            state,
+            event.turnId,
+            event.status === "completed" ? safeResult(event.text) : null,
+            event.status === "failed" ? safeReason(event.error) : null,
+            t,
+            event.attemptId,
+          ],
+        );
+        this.store.db.run(
+          "UPDATE side_chats SET state=?1,active_attempt_id=NULL,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id=?4",
+          [state, t, event.sideChatId, event.attemptId],
+        );
+        this.emitStored(
+          event.sideChatId,
+          event.attemptId,
+          event.threadId,
+          event.turnId,
+          "attempt.terminal",
+          state,
+          event.status,
+          t,
+        );
+      });
+    } catch {
+      /* malformed runtime events are untrusted and ignored */
+    }
+  }
+
+  private failStarting(
+    sideChatId: string,
+    attemptId: string,
+    error: unknown,
+  ): void {
+    const t = this.now(),
+      reason = safeReason(
+        error instanceof Error ? error.message : String(error),
+      );
+    this.store.db.transaction(() => {
+      const changed = this.store.db.run(
+        "UPDATE side_chat_attempts SET state='failed',error_text=?1,updated_at=?2 WHERE attempt_id=?3 AND state='starting'",
+        [reason, t, attemptId],
+      );
+      if (changed.changes > 0) {
+        this.store.db.run(
+          "UPDATE side_chats SET state='failed',active_attempt_id=NULL,updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3",
+          [t, sideChatId, attemptId],
+        );
+        this.emitStored(
+          sideChatId,
+          attemptId,
+          undefined,
+          undefined,
+          "attempt.failed",
+          "failed",
+          auditErrorReason(error),
+          t,
+        );
+      }
+    });
+  }
+  private emitStored(
+    sideChatId: string,
+    attemptId: string | undefined,
+    threadId: string | undefined,
+    turnId: string | undefined,
+    type: string,
+    state: string | undefined,
+    reason: string | undefined,
+    at: number,
+  ): void {
+    this.store.db.run(
+      "INSERT INTO side_chat_events (side_chat_id,attempt_id,thread_id,turn_id,event_type,state,reason,created_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+      [
+        sideChatId,
+        attemptId ?? null,
+        threadId ?? null,
+        turnId ?? null,
+        type,
+        state ?? null,
+        safeReason(reason) ?? null,
+        at,
+      ],
+    );
+    const row = this.store.db.get<any>(
+      "SELECT event_id FROM side_chat_events WHERE side_chat_id=?1 ORDER BY event_id DESC LIMIT 1",
+      sideChatId,
+    );
+    this.emitter.emit(`side:${sideChatId}`, {
+      eventId: row?.event_id ?? 0,
+      sideChatId,
+      attemptId,
+      threadId,
+      turnId,
+      type,
+      state,
+      reason: safeReason(reason),
+      createdAt: at,
+    } satisfies SideThreadEventRecord);
+  }
+  private mustOwned(
+    sideChatId: string,
+    actor: SideThreadActor,
+  ): SideThreadRecord {
+    const r = this.store.getOwned(sideChatId, actor);
+    if (!r || !this.opts.authorizeNode(actor, r.networkId, r.nodeId))
+      throw new SideThreadError(
+        "SIDE_THREAD_NOT_FOUND",
+        "side chat not found",
+        404,
+      );
+    return r;
+  }
+  private async singleFlight<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prior = this.inFlight.get(key);
+    if (prior) return prior as Promise<T>;
+    const op = fn();
+    this.inFlight.set(key, op);
+    try {
+      return await op;
+    } finally {
+      if (this.inFlight.get(key) === op) this.inFlight.delete(key);
+    }
+  }
+}
+
+function validateCreateInput(input: CreateInput): void {
+  requireKey(input.requestKey);
+  requireIdentity(input.networkId, "networkId");
+  requireIdentity(input.nodeId, "nodeId");
+  requireIdentity(input.sourceThreadId, "sourceThreadId");
+  if (input.boundary?.kind !== "through" && input.boundary?.kind !== "before")
+    throw conflict("invalid exact boundary");
+  requireIdentity(input.boundary.turnId, "boundary.turnId");
+  requirePrompt(input.prompt);
+}
+function requireIdentity(
+  value: unknown,
+  label: string,
+): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    !value ||
+    value.length > 512 ||
+    /[\r\n\0]/.test(value)
+  )
+    throw conflict(`invalid ${label}`);
+}
+function requireRuntimeIdentity(
+  value: unknown,
+  label: string,
+): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    !value ||
+    value.length > 512 ||
+    /[\r\n\0]/.test(value)
+  )
+    throw runtimeProtocol(`runtime returned invalid ${label}`);
+}
+function requireKey(value: unknown): asserts value is string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9._:-]{8,160}$/.test(value))
+    throw conflict("invalid idempotency key");
+}
+function requirePrompt(value: unknown): asserts value is string {
+  if (typeof value !== "string" || !value.trim() || value.length > 100_000)
+    throw conflict("invalid prompt");
+}
+function normalizeAttachments(value: unknown): SideThreadAttachmentRef[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > 16)
+    throw conflict("invalid attachments");
+  const seen = new Set<string>();
+  return value.map((v) => {
+    if (
+      !v ||
+      typeof v !== "object" ||
+      Object.keys(v as object).some((k) => k !== "fileId") ||
+      typeof (v as any).fileId !== "string" ||
+      !/^[A-Za-z0-9_-]{8,64}$/.test((v as any).fileId)
+    )
+      throw conflict("attachments must contain fileId references only");
+    const fileId = (v as any).fileId;
+    if (seen.has(fileId)) throw conflict("duplicate attachment reference");
+    seen.add(fileId);
+    return { fileId };
+  });
+}
+function parseAttachmentJson(value: string): SideThreadAttachmentRef[] {
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (entry) =>
+          entry &&
+          typeof entry === "object" &&
+          typeof entry.fileId === "string" &&
+          /^[A-Za-z0-9_-]{8,64}$/.test(entry.fileId),
+      )
+      .map((entry) => ({ fileId: entry.fileId }));
+  } catch {
+    return [];
+  }
+}
+function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+function hashJson(value: unknown): string {
+  return hashText(JSON.stringify(value));
+}
+function stableOperationId(
+  sideChatId: string,
+  kind: SideThreadOperationRecord["kind"],
+  requestKey: string,
+): string {
+  return `sop_${hashJson([sideChatId, kind, requestKey]).slice(0, 40)}`;
+}
+function safeReason(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(
+      /(?:Bearer\s+)?(?:(?:a|n|u)tok_|sk-)[A-Za-z0-9._-]+/gi,
+      "[redacted]",
+    )
+    .slice(0, 300);
+}
+function safeResult(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.slice(0, 1_000_000);
+}
+function capabilityReason(reason: unknown): string {
+  return typeof reason === "string" && /^[a-z0-9-]{1,80}$/.test(reason)
+    ? `native SideThread unavailable: ${reason}`
+    : "native SideThread capability unavailable";
+}
+function capabilityReasonCode(reason: unknown): string {
+  return typeof reason === "string" && /^[a-z0-9-]{1,80}$/.test(reason)
+    ? reason
+    : "runtime-adapter-unavailable";
+}
+function auditErrorReason(error: unknown): string {
+  const code = (error as any)?.code;
+  return typeof code === "string" && /^[A-Z][A-Z0-9_]{2,80}$/.test(code)
+    ? code
+    : "runtime-error";
+}
+function conflict(message: string): SideThreadError {
+  return new SideThreadError("SIDE_THREAD_CONFLICT", message, 409);
+}
+function runtimeProtocol(message: string): SideThreadError {
+  return new SideThreadError("SIDE_THREAD_AMBIGUOUS", message, 202);
+}
+function isAmbiguousRuntimeError(error: unknown): boolean {
+  const code = (error as any)?.code;
+  return (
+    code === "SIDE_THREAD_AMBIGUOUS" || code === "SIDE_THREAD_RESPONSE_LOST"
+  );
+}
+function ambiguousError(
+  operationId: string,
+  sideChatId: string,
+  attemptId?: string,
+): SideThreadError {
+  return new SideThreadError(
+    "SIDE_THREAD_AMBIGUOUS",
+    "runtime acceptance is ambiguous; reconcile this stable operation before retrying",
+    202,
+    operationId,
+    sideChatId,
+    attemptId,
+  );
+}
+function normalizePortError(error: unknown): SideThreadError {
+  if (error instanceof SideThreadError) return error;
+  const code = (error as any)?.code;
+  if (code === "SIDE_THREAD_UNSUPPORTED")
+    return new SideThreadError(
+      "SIDE_THREAD_UNSUPPORTED",
+      "verified native SideThread adapter became unavailable",
+      501,
+    );
+  return new SideThreadError(
+    "SIDE_THREAD_RUNTIME_ERROR",
+    "SideThread runtime operation failed",
+    502,
+  );
+}

--- a/server/src/side-thread.ts
+++ b/server/src/side-thread.ts
@@ -1030,80 +1030,77 @@ export class SideThreadCoordinator {
   async cancel(
     actor: SideThreadActor,
     sideChatId: string,
+    input: { requestKey: string },
   ): Promise<SideThreadRecord> {
     this.assertEnabled();
-    return this.singleFlight(`cancel:${sideChatId}`, async () => {
-      const record = this.mustOwned(sideChatId, actor);
-      const attempt = record.attempts.find(
-        (a) => a.attemptId === record.activeAttemptId,
-      );
-      if (
-        !attempt?.threadId ||
-        !attempt.turnId ||
-        !["running", "ambiguous", "reconciling"].includes(attempt.state)
-      )
-        throw conflict("side chat has no cancellable attempt");
-      await this.assertCapability(record.nodeId);
-      const operationRequestKey = `cancel:${attempt.attemptId}`;
-      const prepared = this.prepareStableOperation({
-        sideChatId,
-        attemptId: attempt.attemptId,
-        kind: "cancel",
-        requestKey: operationRequestKey,
-        fingerprint: hashJson([
+    requireKey(input.requestKey);
+    return this.singleFlight(
+      `cancel:${sideChatId}:${input.requestKey}`,
+      async () => {
+        const record = this.mustOwned(sideChatId, actor);
+        const replay = this.store.db.get<{
+          operation_id: string;
+          attempt_id: string | null;
+          state: SideThreadOperationRecord["state"];
+        }>(
+          "SELECT operation_id,attempt_id,state FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='cancel' AND request_key=?2",
           sideChatId,
-          attempt.attemptId,
-          attempt.threadId,
-          attempt.turnId,
-        ]),
-        threadId: attempt.threadId,
-        turnId: attempt.turnId,
-      });
-      if (prepared.state === "completed") return record;
-      if (prepared.state === "ambiguous" || prepared.state === "reconciling")
-        throw ambiguousError(
-          prepared.operationId,
-          sideChatId,
-          attempt.attemptId,
+          input.requestKey,
         );
-      // A second coordinator observing the durable pending claim must never
-      // issue another RPC. Returning its current owner projection is an
-      // honest in-progress replay; ambiguous is handled above and is typed.
-      if (!prepared.callable) return this.mustOwned(sideChatId, actor);
-      const claimedAt = this.now();
-      const claim = this.store.db.run(
-        "UPDATE side_chat_attempts SET cancel_requested_at=?1,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4 AND cancel_requested_at IS NULL",
-        [claimedAt, attempt.attemptId, attempt.threadId, attempt.turnId],
-      );
-      if (claim.changes === 0) {
-        this.markAmbiguous(
-          sideChatId,
-          attempt.attemptId,
-          prepared.operationId,
-          { code: "SIDE_THREAD_RESPONSE_LOST" },
+        if (replay?.state === "completed" || replay?.state === "pending")
+          return record;
+        if (replay?.state === "ambiguous" || replay?.state === "reconciling")
+          throw ambiguousError(
+            replay.operation_id,
+            sideChatId,
+            replay.attempt_id ?? undefined,
+          );
+        const attempt = record.attempts.find(
+          (a) => a.attemptId === record.activeAttemptId,
         );
-        throw ambiguousError(
-          prepared.operationId,
-          sideChatId,
-          attempt.attemptId,
-        );
-      }
-      try {
-        await this.port.cancel({
-          operationId: prepared.operationId,
+        if (
+          !attempt?.threadId ||
+          !attempt.turnId ||
+          !["running", "ambiguous", "reconciling"].includes(attempt.state)
+        )
+          throw conflict("side chat has no cancellable attempt");
+        await this.assertCapability(record.nodeId);
+        const prepared = this.prepareStableOperation({
           sideChatId,
           attemptId: attempt.attemptId,
-          nodeId: record.nodeId,
+          kind: "cancel",
+          requestKey: input.requestKey,
+          fingerprint: hashJson([
+            sideChatId,
+            attempt.attemptId,
+            attempt.threadId,
+            attempt.turnId,
+          ]),
           threadId: attempt.threadId,
           turnId: attempt.turnId,
         });
-      } catch (error) {
-        if (isAmbiguousRuntimeError(error)) {
+        if (prepared.state === "completed") return record;
+        if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+          throw ambiguousError(
+            prepared.operationId,
+            sideChatId,
+            attempt.attemptId,
+          );
+        // A second coordinator observing the durable pending claim must never
+        // issue another RPC. Returning its current owner projection is an
+        // honest in-progress replay; ambiguous is handled above and is typed.
+        if (!prepared.callable) return this.mustOwned(sideChatId, actor);
+        const claimedAt = this.now();
+        const claim = this.store.db.run(
+          "UPDATE side_chat_attempts SET cancel_requested_at=?1,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4 AND cancel_requested_at IS NULL",
+          [claimedAt, attempt.attemptId, attempt.threadId, attempt.turnId],
+        );
+        if (claim.changes === 0) {
           this.markAmbiguous(
             sideChatId,
             attempt.attemptId,
             prepared.operationId,
-            error,
+            { code: "SIDE_THREAD_RESPONSE_LOST" },
           );
           throw ambiguousError(
             prepared.operationId,
@@ -1111,44 +1108,68 @@ export class SideThreadCoordinator {
             attempt.attemptId,
           );
         }
-        this.settleOperation(prepared.operationId, "failed", {
-          errorCode: auditErrorReason(error),
-        });
-        this.store.db.run(
-          "UPDATE side_chat_attempts SET cancel_requested_at=NULL,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
-          [this.now(), attempt.attemptId, attempt.threadId, attempt.turnId],
-        );
-        throw normalizePortError(error);
-      }
-      this.store.db.transaction(() => {
-        const t = this.now();
-        const changed = this.store.db.run(
-          "UPDATE side_chat_attempts SET state='cancelled',updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
-          [t, attempt.attemptId, attempt.threadId, attempt.turnId],
-        );
-        if (changed.changes > 0) {
-          this.store.db.run(
-            "UPDATE side_chats SET state='cancelled',active_attempt_id=NULL,updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3",
-            [t, sideChatId, attempt.attemptId],
-          );
-          this.emitStored(
+        try {
+          await this.port.cancel({
+            operationId: prepared.operationId,
             sideChatId,
-            attempt.attemptId,
-            attempt.threadId,
-            attempt.turnId,
-            "attempt.cancelled",
-            "cancelled",
-            undefined,
-            t,
+            attemptId: attempt.attemptId,
+            nodeId: record.nodeId,
+            threadId: attempt.threadId,
+            turnId: attempt.turnId,
+          });
+        } catch (error) {
+          if (isAmbiguousRuntimeError(error)) {
+            this.markAmbiguous(
+              sideChatId,
+              attempt.attemptId,
+              prepared.operationId,
+              error,
+            );
+            throw ambiguousError(
+              prepared.operationId,
+              sideChatId,
+              attempt.attemptId,
+            );
+          }
+          this.settleOperation(prepared.operationId, "failed", {
+            errorCode: auditErrorReason(error),
+          });
+          this.store.db.run(
+            "UPDATE side_chat_attempts SET cancel_requested_at=NULL,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
+            [this.now(), attempt.attemptId, attempt.threadId, attempt.turnId],
           );
+          throw normalizePortError(error);
         }
-        this.settleOperation(prepared.operationId, "completed", {
-          threadId: attempt.threadId,
-          turnId: attempt.turnId,
+        this.store.db.transaction(() => {
+          const t = this.now();
+          const changed = this.store.db.run(
+            "UPDATE side_chat_attempts SET state='cancelled',updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
+            [t, attempt.attemptId, attempt.threadId, attempt.turnId],
+          );
+          if (changed.changes > 0) {
+            this.store.db.run(
+              "UPDATE side_chats SET state='cancelled',active_attempt_id=NULL,updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3",
+              [t, sideChatId, attempt.attemptId],
+            );
+            this.emitStored(
+              sideChatId,
+              attempt.attemptId,
+              attempt.threadId,
+              attempt.turnId,
+              "attempt.cancelled",
+              "cancelled",
+              undefined,
+              t,
+            );
+          }
+          this.settleOperation(prepared.operationId, "completed", {
+            threadId: attempt.threadId,
+            turnId: attempt.turnId,
+          });
         });
-      });
-      return this.mustOwned(sideChatId, actor);
-    });
+        return this.mustOwned(sideChatId, actor);
+      },
+    );
   }
 
   async retry(
@@ -1330,124 +1351,130 @@ export class SideThreadCoordinator {
   async archive(
     actor: SideThreadActor,
     sideChatId: string,
+    input: { requestKey: string },
   ): Promise<SideThreadRecord> {
-    return this.lifecycle(actor, sideChatId, "archive");
+    return this.lifecycle(actor, sideChatId, "archive", input);
   }
   async purge(
     actor: SideThreadActor,
     sideChatId: string,
+    input: { requestKey: string },
   ): Promise<SideThreadRecord> {
-    return this.lifecycle(actor, sideChatId, "purge");
+    return this.lifecycle(actor, sideChatId, "purge", input);
   }
   private async lifecycle(
     actor: SideThreadActor,
     sideChatId: string,
     action: "archive" | "purge",
+    input: { requestKey: string },
   ): Promise<SideThreadRecord> {
     this.assertEnabled();
-    return this.singleFlight(`${action}:${sideChatId}`, async () => {
-      const r = this.mustOwned(sideChatId, actor);
-      if (r.activeAttemptId)
-        throw conflict(`cannot ${action} a running side chat`);
-      if (!r.threadId) throw conflict("side chat has no derived thread");
-      if (r.state === "purged") return r;
-      if (action === "archive" && r.state === "archived") return r;
-      await this.assertCapability(r.nodeId);
-      const operationRequestKey = `${action}:${sideChatId}`;
-      const prepared = this.prepareStableOperation({
-        sideChatId,
-        kind: action,
-        requestKey: operationRequestKey,
-        fingerprint: hashJson([action, sideChatId, r.nodeId, r.threadId]),
-        threadId: r.threadId,
-      });
-      if (prepared.state === "completed") return r;
-      if (prepared.state === "ambiguous" || prepared.state === "reconciling")
-        throw ambiguousError(prepared.operationId, sideChatId);
-      if (!prepared.callable)
-        throw conflict("side chat lifecycle operation already in progress");
-      const claim = this.store.db.run(
-        "UPDATE side_chats SET lifecycle_operation=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id IS NULL AND lifecycle_operation IS NULL",
-        [action, this.now(), sideChatId],
-      );
-      if (claim.changes === 0) {
-        const current = this.mustOwned(sideChatId, actor);
-        if (current.state === "purged") return current;
-        if (action === "archive" && current.state === "archived")
-          return current;
-        this.markAmbiguous(sideChatId, undefined, prepared.operationId, {
-          code: "SIDE_THREAD_RESPONSE_LOST",
-        });
-        throw ambiguousError(prepared.operationId, sideChatId);
-      }
-      try {
-        if (action === "archive")
-          await this.port.archive({
-            operationId: prepared.operationId,
-            sideChatId,
-            nodeId: r.nodeId,
-            threadId: r.threadId,
-          });
-        else
-          await this.port.purge({
-            operationId: prepared.operationId,
-            sideChatId,
-            nodeId: r.nodeId,
-            threadId: r.threadId,
-          });
-      } catch (error) {
-        if (isAmbiguousRuntimeError(error)) {
-          this.markAmbiguous(
-            sideChatId,
-            undefined,
-            prepared.operationId,
-            error,
-          );
-          throw ambiguousError(prepared.operationId, sideChatId);
-        }
-        this.settleOperation(prepared.operationId, "failed", {
-          errorCode: auditErrorReason(error),
-        });
-        this.store.db.run(
-          "UPDATE side_chats SET lifecycle_operation=NULL,updated_at=?1 WHERE side_chat_id=?2 AND lifecycle_operation=?3",
-          [this.now(), sideChatId, action],
-        );
-        throw normalizePortError(error);
-      }
-      const state = action === "archive" ? "archived" : "purged",
-        t = this.now();
-      this.store.db.transaction(() => {
-        if (action === "purge") {
-          this.store.db.run(
-            "UPDATE side_chats SET state='purged',question_text='',attachments_json='[]',lifecycle_operation=NULL,updated_at=?1,purged_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='purge'",
-            [t, sideChatId],
-          );
-          this.store.db.run(
-            "UPDATE side_chat_attempts SET result_text=NULL,error_text=NULL,updated_at=?1 WHERE side_chat_id=?2",
-            [t, sideChatId],
-          );
-        } else {
-          this.store.db.run(
-            "UPDATE side_chats SET state='archived',lifecycle_operation=NULL,updated_at=?1,archived_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='archive'",
-            [t, sideChatId],
-          );
-        }
-        this.settleOperation(prepared.operationId, "completed", {
+    requireKey(input.requestKey);
+    return this.singleFlight(
+      `${action}:${sideChatId}:${input.requestKey}`,
+      async () => {
+        const r = this.mustOwned(sideChatId, actor);
+        if (r.activeAttemptId)
+          throw conflict(`cannot ${action} a running side chat`);
+        if (!r.threadId) throw conflict("side chat has no derived thread");
+        if (r.state === "purged") return r;
+        if (action === "archive" && r.state === "archived") return r;
+        await this.assertCapability(r.nodeId);
+        const prepared = this.prepareStableOperation({
+          sideChatId,
+          kind: action,
+          requestKey: input.requestKey,
+          fingerprint: hashJson([action, sideChatId, r.nodeId, r.threadId]),
           threadId: r.threadId,
         });
-        this.emitStored(
-          sideChatId,
-          undefined,
-          r.threadId,
-          undefined,
-          `side_chat.${state}`,
-          state,
-          undefined,
-          t,
+        if (prepared.state === "completed") return r;
+        if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+          throw ambiguousError(prepared.operationId, sideChatId);
+        if (!prepared.callable)
+          throw conflict("side chat lifecycle operation already in progress");
+        const claim = this.store.db.run(
+          "UPDATE side_chats SET lifecycle_operation=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id IS NULL AND lifecycle_operation IS NULL",
+          [action, this.now(), sideChatId],
         );
-      });
-      return this.mustOwned(sideChatId, actor);
-    });
+        if (claim.changes === 0) {
+          const current = this.mustOwned(sideChatId, actor);
+          if (current.state === "purged") return current;
+          if (action === "archive" && current.state === "archived")
+            return current;
+          this.markAmbiguous(sideChatId, undefined, prepared.operationId, {
+            code: "SIDE_THREAD_RESPONSE_LOST",
+          });
+          throw ambiguousError(prepared.operationId, sideChatId);
+        }
+        try {
+          if (action === "archive")
+            await this.port.archive({
+              operationId: prepared.operationId,
+              sideChatId,
+              nodeId: r.nodeId,
+              threadId: r.threadId,
+            });
+          else
+            await this.port.purge({
+              operationId: prepared.operationId,
+              sideChatId,
+              nodeId: r.nodeId,
+              threadId: r.threadId,
+            });
+        } catch (error) {
+          if (isAmbiguousRuntimeError(error)) {
+            this.markAmbiguous(
+              sideChatId,
+              undefined,
+              prepared.operationId,
+              error,
+            );
+            throw ambiguousError(prepared.operationId, sideChatId);
+          }
+          this.settleOperation(prepared.operationId, "failed", {
+            errorCode: auditErrorReason(error),
+          });
+          this.store.db.run(
+            "UPDATE side_chats SET lifecycle_operation=NULL,updated_at=?1 WHERE side_chat_id=?2 AND lifecycle_operation=?3",
+            [this.now(), sideChatId, action],
+          );
+          throw normalizePortError(error);
+        }
+        const state = action === "archive" ? "archived" : "purged",
+          t = this.now();
+        this.store.db.transaction(() => {
+          if (action === "purge") {
+            this.store.db.run(
+              "UPDATE side_chats SET state='purged',question_text='',attachments_json='[]',lifecycle_operation=NULL,updated_at=?1,purged_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='purge'",
+              [t, sideChatId],
+            );
+            this.store.db.run(
+              "UPDATE side_chat_attempts SET result_text=NULL,error_text=NULL,updated_at=?1 WHERE side_chat_id=?2",
+              [t, sideChatId],
+            );
+          } else {
+            this.store.db.run(
+              "UPDATE side_chats SET state='archived',lifecycle_operation=NULL,updated_at=?1,archived_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='archive'",
+              [t, sideChatId],
+            );
+          }
+          this.settleOperation(prepared.operationId, "completed", {
+            threadId: r.threadId,
+          });
+          this.emitStored(
+            sideChatId,
+            undefined,
+            r.threadId,
+            undefined,
+            `side_chat.${state}`,
+            state,
+            undefined,
+            t,
+          );
+        });
+        return this.mustOwned(sideChatId, actor);
+      },
+    );
   }
 
   async bringBack(

--- a/tests/test1190-codex-btw-wire-probe/Dockerfile
+++ b/tests/test1190-codex-btw-wire-probe/Dockerfile
@@ -9,6 +9,7 @@ RUN npm install -g --no-audit --no-fund @openai/codex@0.148.0
 
 WORKDIR /probe
 COPY tests/test1190-codex-btw-wire-probe /probe/
+COPY tests/lib /tests/lib/
 RUN chmod +x /probe/run.sh
 
 CMD ["/probe/run.sh"]

--- a/tests/test1190-codex-btw-wire-probe/Dockerfile
+++ b/tests/test1190-codex-btw-wire-probe/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# PR0 deliberately pins the protocol under test. A version bump requires a
+# fresh golden capture and review; "latest" would make the evidence mutable.
+RUN npm install -g --no-audit --no-fund @openai/codex@0.148.0
+
+WORKDIR /probe
+COPY tests/test1190-codex-btw-wire-probe /probe/
+RUN chmod +x /probe/run.sh
+
+CMD ["/probe/run.sh"]

--- a/tests/test1190-codex-btw-wire-probe/NOT-IN-CI.md
+++ b/tests/test1190-codex-btw-wire-probe/NOT-IN-CI.md
@@ -1,0 +1,16 @@
+# Why test1190 is not in the default CI matrix
+
+Verified: 2026-08-26
+Revisit-when: RFC-036's version pin/capability golden changes, or a protected CI job gains a disposable authenticated CODEX_HOME.
+
+This is a version-transition protocol capture, not a product regression suite.
+Its authoritative live half needs an authenticated, disposable `CODEX_HOME`
+and makes real model calls. Repository CI must not receive or persist that
+credential. The credential-free schema half is useful only together with the
+same exact `@openai/codex@0.148.0` live capture; running it on every unrelated
+change would download the large vendor binary without increasing confidence.
+
+Run both halves manually when RFC-036's Codex pin, capability contract, or
+golden changes. A later SideChat adapter PR must add its own credential-free
+mock/contract regression suite to normal CI; this exemption does not apply to
+that implementation.

--- a/tests/test1190-codex-btw-wire-probe/NOT-IN-CI.md
+++ b/tests/test1190-codex-btw-wire-probe/NOT-IN-CI.md
@@ -4,13 +4,14 @@ Verified: 2026-08-26
 Revisit-when: RFC-036's version pin/capability golden changes, or a protected CI job gains a disposable authenticated CODEX_HOME.
 
 This is a version-transition protocol capture, not a product regression suite.
-Its authoritative live half needs an authenticated, disposable `CODEX_HOME`
+Its authoritative live half needs an authenticated, sentinel-marked disposable `CODEX_HOME`
 and makes real model calls. Repository CI must not receive or persist that
 credential. The credential-free schema half is useful only together with the
 same exact `@openai/codex@0.148.0` live capture; running it on every unrelated
 change would download the large vendor binary without increasing confidence.
 
-Run both halves manually when RFC-036's Codex pin, capability contract, or
-golden changes. A later SideChat adapter PR must add its own credential-free
+Run both normal/experimental schema captures, the live trace, and the
+witnessed-red variant manually when RFC-036's Codex pin, capability contract,
+or golden changes. A later SideChat adapter PR must add its own credential-free
 mock/contract regression suite to normal CI; this exemption does not apply to
 that implementation.

--- a/tests/test1190-codex-btw-wire-probe/assert-live.mjs
+++ b/tests/test1190-codex-btw-wire-probe/assert-live.mjs
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+const x = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const b = x.observations?.forkBoundary ?? {};
+const c = x.observations?.concurrentAndCancel ?? {};
+const r = x.observations?.retention ?? {};
+const checks = {
+  pinnedVersion: x.version === "codex-cli 0.148.0",
+  exactCompletedBoundary: b.completedLastTurnWhileLaterActive === true,
+  exactBeforeActiveBoundary: b.beforeActiveTurn === true,
+  activeLastTurnFailsClosed: b.activeLastTurnRejected === true,
+  exactCancelAccepted: c.independentInterruptAccepted === true,
+  cancelledOnlyDerived: c.cancelledForkStatus === "interrupted",
+  siblingCompleted: c.siblingForkStatus === "completed",
+  sourceCompleted: c.sourceStatus === "completed",
+  distinctThreads: c.allThreadIdsDistinct === true,
+  archiveAccepted: r.archiveAccepted === true,
+  archiveIsNotDelete: r.archivedStillReadable === true,
+  deleteAccepted: r.deleteAccepted === true,
+  deletedCannotRead: r.deletedReadRejected === true,
+};
+const failed = Object.entries(checks).filter(([, ok]) => !ok).map(([name]) => name);
+if (failed.length) {
+  console.error(JSON.stringify({ ok: false, failed, observations: x.observations }, null, 2));
+  process.exit(1);
+}
+console.log(JSON.stringify({ ok: true, checks }, null, 2));

--- a/tests/test1190-codex-btw-wire-probe/assert-live.mjs
+++ b/tests/test1190-codex-btw-wire-probe/assert-live.mjs
@@ -1,26 +1,28 @@
 import fs from "node:fs";
 const x = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-const b = x.observations?.forkBoundary ?? {};
-const c = x.observations?.concurrentAndCancel ?? {};
-const r = x.observations?.retention ?? {};
+const b = x.forkBoundary ?? {}, c = x.concurrencyCancel ?? {}, o = x.reverseCompletion ?? {}, r = x.retention ?? {};
 const checks = {
-  pinnedVersion: x.version === "codex-cli 0.148.0",
-  exactCompletedBoundary: b.completedLastTurnWhileLaterActive === true,
-  exactBeforeActiveBoundary: b.beforeActiveTurn === true,
-  activeLastTurnFailsClosed: b.activeLastTurnRejected === true,
-  exactCancelAccepted: c.independentInterruptAccepted === true,
-  cancelledOnlyDerived: c.cancelledForkStatus === "interrupted",
-  siblingCompleted: c.siblingForkStatus === "completed",
-  sourceCompleted: c.sourceStatus === "completed",
-  distinctThreads: c.allThreadIdsDistinct === true,
-  archiveAccepted: r.archiveAccepted === true,
-  archiveIsNotDelete: r.archivedStillReadable === true,
-  deleteAccepted: r.deleteAccepted === true,
-  deletedCannotRead: r.deletedReadRejected === true,
+  reviewedEvidenceRevision: x.evidenceRevision === "test1190-wire-v2",
+  exactArtifact: x.artifact?.codexCli === "0.148.0" && /^[a-f0-9]{64}$/.test(x.artifact?.binarySha256),
+  topology: x.topology === "owned-stdio",
+  sourceWasActiveAtFork: b.sourceStatusAtFork === "active",
+  authoritativeSourceTurns: JSON.stringify(b.sourceTurnsBefore) === JSON.stringify(["seed", "sourceActive"]),
+  exactThroughTurns: JSON.stringify(b.throughTurns) === JSON.stringify(["seed"]),
+  exactBeforeTurns: JSON.stringify(b.beforeTurns) === JSON.stringify(["seed"]),
+  forkedFromMatches: b.throughForkedFromMatches && b.beforeForkedFromMatches,
+  exactIncludeExclude: b.seedIncluded && b.activeExcluded,
+  activeInclusiveRejected: b.activeInclusiveBoundaryRejected && b.activeInclusiveBoundaryErrorCode === -32600,
+  threeWayActive: c.sourceStartedBeforeForks && c.allThreeActiveBeforeCancel,
+  cancelPrecedesAllTerminals: c.cancelRequestedBeforeTargetTerminal && c.cancelRequestedBeforeSiblingTerminal && c.cancelRequestedBeforeSourceTerminal,
+  isolatedStatuses: c.targetStatus === "interrupted" && c.siblingStatus === "completed" && c.sourceStatus === "completed",
+  cancelReadIsolation: c.sourceReadableAfterCancel && c.siblingReadableAfterCancel,
+  reverseSuccessfulCompletion: JSON.stringify(o.creationOrder) === JSON.stringify(["forkSlow", "forkFast"])
+    && JSON.stringify(o.completionOrder) === JSON.stringify(["forkFast", "forkSlow"])
+    && o.fastStatus === "completed" && o.slowStatus === "completed",
+  archiveUnarchive: r.archivedReadable && r.unarchivedReadable,
+  deleteAndIsolation: r.deleteReadRejected && r.deleteReadErrorCode === -32600
+    && r.sourceIsolatedFromDelete && r.unarchivedSiblingIsolatedFromDelete,
 };
 const failed = Object.entries(checks).filter(([, ok]) => !ok).map(([name]) => name);
-if (failed.length) {
-  console.error(JSON.stringify({ ok: false, failed, observations: x.observations }, null, 2));
-  process.exit(1);
-}
+if (failed.length) { console.error(JSON.stringify({ ok: false, failed }, null, 2)); process.exit(1); }
 console.log(JSON.stringify({ ok: true, checks }, null, 2));

--- a/tests/test1190-codex-btw-wire-probe/disposable-home.sentinel
+++ b/tests/test1190-codex-btw-wire-probe/disposable-home.sentinel
@@ -1,0 +1,1 @@
+test1190-disposable-v2

--- a/tests/test1190-codex-btw-wire-probe/golden/live-result.json
+++ b/tests/test1190-codex-btw-wire-probe/golden/live-result.json
@@ -1,0 +1,25 @@
+{
+  "version": "codex-cli 0.148.0",
+  "observations": {
+    "forkBoundary": {
+      "completedLastTurnWhileLaterActive": true,
+      "beforeActiveTurn": true,
+      "activeLastTurnRejected": true,
+      "activeLastTurnErrorCode": -32600
+    },
+    "concurrentAndCancel": {
+      "independentInterruptAccepted": true,
+      "cancelledForkStatus": "interrupted",
+      "siblingForkStatus": "completed",
+      "sourceStatus": "completed",
+      "allThreadIdsDistinct": true
+    },
+    "retention": {
+      "archiveAccepted": true,
+      "archivedStillReadable": true,
+      "deleteAccepted": true,
+      "deletedReadRejected": true,
+      "deletedReadErrorCode": -32600
+    }
+  }
+}

--- a/tests/test1190-codex-btw-wire-probe/golden/live-result.json
+++ b/tests/test1190-codex-btw-wire-probe/golden/live-result.json
@@ -1,25 +1,49 @@
 {
-  "version": "codex-cli 0.148.0",
-  "observations": {
-    "forkBoundary": {
-      "completedLastTurnWhileLaterActive": true,
-      "beforeActiveTurn": true,
-      "activeLastTurnRejected": true,
-      "activeLastTurnErrorCode": -32600
-    },
-    "concurrentAndCancel": {
-      "independentInterruptAccepted": true,
-      "cancelledForkStatus": "interrupted",
-      "siblingForkStatus": "completed",
-      "sourceStatus": "completed",
-      "allThreadIdsDistinct": true
-    },
-    "retention": {
-      "archiveAccepted": true,
-      "archivedStillReadable": true,
-      "deleteAccepted": true,
-      "deletedReadRejected": true,
-      "deletedReadErrorCode": -32600
-    }
+  "evidenceRevision": "test1190-wire-v2",
+  "artifact": {
+    "codexCli": "0.148.0",
+    "packageBoundary": "probe-only; agent-node lock remains 0.133.0",
+    "os": "linux",
+    "arch": "x64",
+    "binarySha256": "134063e133f0b4244fa3b251acf973d4fe4b4aeeacbdc135211bf480f59f1477"
+  },
+  "topology": "owned-stdio",
+  "forkBoundary": {
+    "sourceStatusAtFork": "active",
+    "sourceTurnsBefore": ["seed", "sourceActive"],
+    "throughTurns": ["seed"],
+    "beforeTurns": ["seed"],
+    "throughForkedFromMatches": true,
+    "beforeForkedFromMatches": true,
+    "seedIncluded": true,
+    "activeExcluded": true,
+    "activeInclusiveBoundaryRejected": true,
+    "activeInclusiveBoundaryErrorCode": -32600
+  },
+  "concurrencyCancel": {
+    "sourceStartedBeforeForks": true,
+    "allThreeActiveBeforeCancel": true,
+    "cancelRequestedBeforeTargetTerminal": true,
+    "cancelRequestedBeforeSiblingTerminal": true,
+    "cancelRequestedBeforeSourceTerminal": true,
+    "targetStatus": "interrupted",
+    "siblingStatus": "completed",
+    "sourceStatus": "completed",
+    "sourceReadableAfterCancel": true,
+    "siblingReadableAfterCancel": true
+  },
+  "reverseCompletion": {
+    "creationOrder": ["forkSlow", "forkFast"],
+    "completionOrder": ["forkFast", "forkSlow"],
+    "fastStatus": "completed",
+    "slowStatus": "completed"
+  },
+  "retention": {
+    "archivedReadable": true,
+    "unarchivedReadable": true,
+    "deleteReadRejected": true,
+    "deleteReadErrorCode": -32600,
+    "sourceIsolatedFromDelete": true,
+    "unarchivedSiblingIsolatedFromDelete": true
   }
 }

--- a/tests/test1190-codex-btw-wire-probe/golden/schema-result.json
+++ b/tests/test1190-codex-btw-wire-probe/golden/schema-result.json
@@ -1,0 +1,57 @@
+{
+  "protocolVersion": "codex-cli 0.148.0",
+  "methods": {
+    "threadFork": true,
+    "threadArchive": true,
+    "threadDelete": true,
+    "turnInterrupt": true
+  },
+  "threadFork": {
+    "experimentalApiRequiredForExactBoundary": true,
+    "properties": [
+      "approvalPolicy",
+      "approvalsReviewer",
+      "baseInstructions",
+      "beforeTurnId",
+      "config",
+      "cwd",
+      "deferGoalContinuation",
+      "developerInstructions",
+      "ephemeral",
+      "excludeTurns",
+      "lastTurnId",
+      "model",
+      "modelProvider",
+      "path",
+      "permissions",
+      "runtimeWorkspaceRoots",
+      "sandbox",
+      "serviceTier",
+      "threadId",
+      "threadSource"
+    ],
+    "required": [
+      "threadId"
+    ],
+    "exactBoundaryFields": [
+      "beforeTurnId",
+      "lastTurnId"
+    ]
+  },
+  "threadArchive": {
+    "required": [
+      "threadId"
+    ]
+  },
+  "threadDelete": {
+    "required": [
+      "threadId"
+    ]
+  },
+  "turnInterrupt": {
+    "required": [
+      "threadId",
+      "turnId"
+    ]
+  }
+}

--- a/tests/test1190-codex-btw-wire-probe/golden/schema-result.json
+++ b/tests/test1190-codex-btw-wire-probe/golden/schema-result.json
@@ -1,57 +1,28 @@
 {
-  "protocolVersion": "codex-cli 0.148.0",
-  "methods": {
-    "threadFork": true,
-    "threadArchive": true,
-    "threadDelete": true,
-    "turnInterrupt": true
+  "artifact": { "codexCli": "0.148.0", "schemaMode": "normal+experimental" },
+  "forkBoundary": {
+    "lastTurnId": { "normalSchema": true, "experimentalSchema": true, "requiresExperimental": false },
+    "beforeTurnId": { "normalSchema": false, "experimentalSchema": true, "requiresExperimental": true },
+    "requestRequired": ["threadId"]
   },
-  "threadFork": {
-    "experimentalApiRequiredForExactBoundary": true,
-    "properties": [
-      "approvalPolicy",
-      "approvalsReviewer",
-      "baseInstructions",
-      "beforeTurnId",
-      "config",
-      "cwd",
-      "deferGoalContinuation",
-      "developerInstructions",
-      "ephemeral",
-      "excludeTurns",
-      "lastTurnId",
-      "model",
-      "modelProvider",
-      "path",
-      "permissions",
-      "runtimeWorkspaceRoots",
-      "sandbox",
-      "serviceTier",
-      "threadId",
-      "threadSource"
-    ],
-    "required": [
-      "threadId"
-    ],
-    "exactBoundaryFields": [
-      "beforeTurnId",
-      "lastTurnId"
-    ]
+  "initialize": {
+    "capabilitiesProperties": ["experimentalApi", "extensions", "mcpServerOpenaiFormElicitation", "optOutNotificationMethods", "requestAttestation"],
+    "experimentalApiDefault": false
   },
-  "threadArchive": {
-    "required": [
-      "threadId"
-    ]
+  "responseShape": {
+    "threadFork": {
+      "properties": ["activePermissionProfile", "approvalPolicy", "approvalsReviewer", "cwd", "instructionSources", "model", "modelProvider", "multiAgentMode", "reasoningEffort", "runtimeWorkspaceRoots", "sandbox", "serviceTier", "thread"],
+      "required": ["approvalPolicy", "approvalsReviewer", "cwd", "model", "modelProvider", "sandbox", "thread"]
+    },
+    "threadRead": { "properties": ["thread"], "required": ["thread"] }
   },
-  "threadDelete": {
-    "required": [
-      "threadId"
-    ]
-  },
-  "turnInterrupt": {
-    "required": [
-      "threadId",
-      "turnId"
-    ]
+  "ownershipShape": {
+    "thread": {
+      "properties": ["agentNickname", "agentRole", "canAcceptDirectInput", "cliVersion", "createdAt", "cwd", "ephemeral", "extra", "forkedFromId", "gitInfo", "historyMode", "id", "modelProvider", "name", "parentThreadId", "path", "preview", "recencyAt", "section", "sectionEnteredAt", "sessionId", "source", "status", "threadSource", "turns", "updatedAt"],
+      "required": ["cliVersion", "createdAt", "cwd", "ephemeral", "id", "modelProvider", "preview", "sessionId", "source", "status", "turns", "updatedAt"]
+    },
+    "turn": { "properties": ["completedAt", "durationMs", "error", "id", "items", "itemsView", "startedAt", "status"], "required": ["id", "items", "status"] },
+    "turnStarted": { "properties": ["threadId", "turn"], "required": ["threadId", "turn"] },
+    "turnCompleted": { "properties": ["threadId", "turn"], "required": ["threadId", "turn"] }
   }
 }

--- a/tests/test1190-codex-btw-wire-probe/live-probe.mjs
+++ b/tests/test1190-codex-btw-wire-probe/live-probe.mjs
@@ -1,0 +1,143 @@
+import { spawn } from "node:child_process";
+import readline from "node:readline";
+
+const child = spawn("codex", [
+  "app-server", "--stdio",
+  "-c", "approval_policy=never",
+  "-c", "sandbox_mode=danger-full-access",
+], { stdio: ["pipe", "pipe", "pipe"], env: process.env });
+
+let seq = 0;
+const pending = new Map();
+const events = [];
+const rl = readline.createInterface({ input: child.stdout });
+rl.on("line", (line) => {
+  let msg;
+  try { msg = JSON.parse(line); } catch { return; }
+  if (msg.id != null && !msg.method) {
+    const p = pending.get(msg.id);
+    if (!p) return;
+    pending.delete(msg.id);
+    msg.error ? p.reject(Object.assign(new Error(msg.error.message), { rpc: msg.error })) : p.resolve(msg.result);
+    return;
+  }
+  if (msg.method) events.push(msg);
+});
+
+const rpc = (method, params, timeoutMs = 120_000) => new Promise((resolve, reject) => {
+  const id = ++seq;
+  const timer = setTimeout(() => {
+    pending.delete(id);
+    reject(new Error(`${method} timed out`));
+  }, timeoutMs);
+  pending.set(id, {
+    resolve: (v) => { clearTimeout(timer); resolve(v); },
+    reject: (e) => { clearTimeout(timer); reject(e); },
+  });
+  child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+});
+const notify = (method, params) => child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+const idOfThread = (x) => x?.thread?.id ?? x?.threadId;
+const idOfTurn = (x) => x?.turn?.id ?? x?.turnId;
+const statusOf = (x) => x?.turn?.status ?? x?.status;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitEvent = async (method, predicate, timeoutMs = 120_000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const at = events.findIndex((e) => e.method === method && predicate(e.params ?? {}));
+    if (at >= 0) return events.splice(at, 1)[0].params;
+    await sleep(25);
+  }
+  throw new Error(`notification ${method} timed out`);
+};
+const terminal = async (threadId, turnId) => waitEvent("turn/completed", (p) =>
+  (p.threadId ?? p.thread_id) === threadId && idOfTurn(p) === turnId, 180_000);
+const tryRpc = async (method, params) => {
+  try { return { ok: true, value: await rpc(method, params) }; }
+  catch (e) { return { ok: false, code: e.rpc?.code ?? null, message: String(e.message).slice(0, 240) }; }
+};
+
+const result = { version: "codex-cli 0.148.0", observations: {} };
+try {
+  await rpc("initialize", {
+    clientInfo: { name: "anet-btw-wire-probe", version: "0.1.0" },
+    capabilities: { experimentalApi: true },
+  });
+  notify("initialized", {});
+
+  const source = idOfThread(await rpc("thread/start", { ephemeral: false }));
+  if (!source) throw new Error("thread/start returned no id");
+
+  const seed = idOfTurn(await rpc("turn/start", {
+    threadId: source,
+    input: [{ type: "text", text: "Reply with exactly SEED_OK and nothing else." }],
+  }));
+  if (!seed) throw new Error("seed turn/start returned no id");
+  const seedDone = await terminal(source, seed);
+  if (statusOf(seedDone) !== "completed") throw new Error(`seed status=${statusOf(seedDone)}`);
+
+  const active = idOfTurn(await rpc("turn/start", {
+    threadId: source,
+    input: [{ type: "text", text: "Run the shell command `sleep 12`, then reply exactly MAIN_OK." }],
+  }));
+  if (!active) throw new Error("active turn/start returned no id");
+  await waitEvent("turn/started", (p) => (p.threadId ?? p.thread_id) === source && idOfTurn(p) === active);
+
+  // Exact completed boundary while the source has a later active turn.
+  const forkAResp = await rpc("thread/fork", { threadId: source, lastTurnId: seed, ephemeral: false });
+  const forkA = idOfThread(forkAResp);
+  const forkBResp = await rpc("thread/fork", { threadId: source, beforeTurnId: active, ephemeral: false });
+  const forkB = idOfThread(forkBResp);
+  if (!forkA || !forkB || forkA === forkB || forkA === source || forkB === source) {
+    throw new Error("fork ids are not independent");
+  }
+  const activeAsBoundary = await tryRpc("thread/fork", { threadId: source, lastTurnId: active, ephemeral: true });
+  result.observations.forkBoundary = {
+    completedLastTurnWhileLaterActive: true,
+    beforeActiveTurn: true,
+    activeLastTurnRejected: !activeAsBoundary.ok,
+    activeLastTurnErrorCode: activeAsBoundary.code,
+  };
+
+  // Two derived threads execute concurrently. B is short; A is cancelled.
+  const turnA = idOfTurn(await rpc("turn/start", {
+    threadId: forkA,
+    input: [{ type: "text", text: "Run `sleep 9`, then reply exactly FORK_A_SHOULD_NOT_FINISH." }],
+  }));
+  const turnB = idOfTurn(await rpc("turn/start", {
+    threadId: forkB,
+    input: [{ type: "text", text: "Reply exactly FORK_B_OK and nothing else." }],
+  }));
+  await Promise.all([
+    waitEvent("turn/started", (p) => (p.threadId ?? p.thread_id) === forkA && idOfTurn(p) === turnA),
+    waitEvent("turn/started", (p) => (p.threadId ?? p.thread_id) === forkB && idOfTurn(p) === turnB),
+  ]);
+  const interrupted = await tryRpc("turn/interrupt", { threadId: forkA, turnId: turnA });
+  const [aDone, bDone, mainDone] = await Promise.all([
+    terminal(forkA, turnA), terminal(forkB, turnB), terminal(source, active),
+  ]);
+  result.observations.concurrentAndCancel = {
+    independentInterruptAccepted: interrupted.ok,
+    cancelledForkStatus: statusOf(aDone),
+    siblingForkStatus: statusOf(bDone),
+    sourceStatus: statusOf(mainDone),
+    allThreadIdsDistinct: new Set([source, forkA, forkB]).size === 3,
+  };
+
+  const archived = await tryRpc("thread/archive", { threadId: forkA });
+  const readArchived = await tryRpc("thread/read", { threadId: forkA, includeTurns: true });
+  const deleted = await tryRpc("thread/delete", { threadId: forkB });
+  const readDeleted = await tryRpc("thread/read", { threadId: forkB, includeTurns: true });
+  result.observations.retention = {
+    archiveAccepted: archived.ok,
+    archivedStillReadable: readArchived.ok,
+    deleteAccepted: deleted.ok,
+    deletedReadRejected: !readDeleted.ok,
+    deletedReadErrorCode: readDeleted.code,
+  };
+} finally {
+  try { await rpc("shutdown", {}, 5_000); } catch {}
+  child.kill("SIGTERM");
+}
+
+process.stdout.write(JSON.stringify(result, null, 2) + "\n");

--- a/tests/test1190-codex-btw-wire-probe/live-probe.mjs
+++ b/tests/test1190-codex-btw-wire-probe/live-probe.mjs
@@ -1,143 +1,153 @@
-import { spawn } from "node:child_process";
+import { spawn, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
 import readline from "node:readline";
 
-const child = spawn("codex", [
-  "app-server", "--stdio",
-  "-c", "approval_policy=never",
-  "-c", "sandbox_mode=danger-full-access",
-], { stdio: ["pipe", "pipe", "pipe"], env: process.env });
+const child = spawn("codex", ["app-server", "--stdio", "-c", "approval_policy=never", "-c", "sandbox_mode=danger-full-access"], { stdio: ["pipe", "pipe", "pipe"], env: process.env });
+let stderrTail = "";
+child.stderr.on("data", (chunk) => { stderrTail = (stderrTail + String(chunk)).slice(-2000); });
 
-let seq = 0;
-const pending = new Map();
-const events = [];
+let rpcId = 0, semanticSeq = 0;
+const pending = new Map(), events = [], trace = [], aliases = new Map();
+const alias = (id) => aliases.get(id) ?? "unknown";
+const mark = (kind, fields = {}) => trace.push({ seq: ++semanticSeq, kind, ...fields });
 const rl = readline.createInterface({ input: child.stdout });
 rl.on("line", (line) => {
-  let msg;
-  try { msg = JSON.parse(line); } catch { return; }
+  let msg; try { msg = JSON.parse(line); } catch { return; }
   if (msg.id != null && !msg.method) {
-    const p = pending.get(msg.id);
-    if (!p) return;
+    const p = pending.get(msg.id); if (!p) return;
     pending.delete(msg.id);
+    mark("rpc_response", { method: p.method, class: msg.error ? "error" : "success", errorCode: msg.error?.code });
     msg.error ? p.reject(Object.assign(new Error(msg.error.message), { rpc: msg.error })) : p.resolve(msg.result);
     return;
   }
-  if (msg.method) events.push(msg);
+  if (msg.method === "turn/started" || msg.method === "turn/completed") {
+    const event = { seq: ++semanticSeq, method: msg.method, params: msg.params, used: false };
+    events.push(event);
+    trace.push({ seq: event.seq, kind: "notification", method: msg.method, threadId: msg.params?.threadId, turnId: msg.params?.turn?.id, status: msg.params?.turn?.status });
+  }
 });
-
-const rpc = (method, params, timeoutMs = 120_000) => new Promise((resolve, reject) => {
-  const id = ++seq;
-  const timer = setTimeout(() => {
-    pending.delete(id);
-    reject(new Error(`${method} timed out`));
-  }, timeoutMs);
-  pending.set(id, {
-    resolve: (v) => { clearTimeout(timer); resolve(v); },
-    reject: (e) => { clearTimeout(timer); reject(e); },
-  });
+const rpc = (method, params, timeoutMs = 180_000) => new Promise((resolve, reject) => {
+  const id = ++rpcId;
+  mark("rpc_request", { method, threadId: params?.threadId, turnId: params?.turnId,
+    boundaryTurnId: params?.lastTurnId ?? params?.beforeTurnId,
+    boundaryKind: params?.lastTurnId ? "through" : params?.beforeTurnId ? "before" : undefined });
+  const timer = setTimeout(() => { pending.delete(id); reject(new Error(`${method} timed out; stderr=${stderrTail}`)); }, timeoutMs);
+  pending.set(id, { method, resolve: (v) => { clearTimeout(timer); resolve(v); }, reject: (e) => { clearTimeout(timer); reject(e); } });
   child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
 });
 const notify = (method, params) => child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
-const idOfThread = (x) => x?.thread?.id ?? x?.threadId;
-const idOfTurn = (x) => x?.turn?.id ?? x?.turnId;
-const statusOf = (x) => x?.turn?.status ?? x?.status;
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-const waitEvent = async (method, predicate, timeoutMs = 120_000) => {
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitEvent = async (method, threadId, turnId, timeoutMs = 180_000) => {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const at = events.findIndex((e) => e.method === method && predicate(e.params ?? {}));
-    if (at >= 0) return events.splice(at, 1)[0].params;
-    await sleep(25);
+    const event = events.find((x) => !x.used && x.method === method && x.params?.threadId === threadId && x.params?.turn?.id === turnId);
+    if (event) { event.used = true; return event; }
+    await sleep(20);
   }
-  throw new Error(`notification ${method} timed out`);
+  throw new Error(`${method} timed out for ${alias(threadId)}/${alias(turnId)}`);
 };
-const terminal = async (threadId, turnId) => waitEvent("turn/completed", (p) =>
-  (p.threadId ?? p.thread_id) === threadId && idOfTurn(p) === turnId, 180_000);
-const tryRpc = async (method, params) => {
-  try { return { ok: true, value: await rpc(method, params) }; }
-  catch (e) { return { ok: false, code: e.rpc?.code ?? null, message: String(e.message).slice(0, 240) }; }
+const strictThread = (response, method) => {
+  if (!response?.thread?.id || Object.hasOwn(response, "threadId")) throw new Error(`${method} response shape drift`);
+  return response.thread;
+};
+const strictTurn = (response) => {
+  if (!response?.turn?.id || Object.hasOwn(response, "turnId")) throw new Error("turn/start response shape drift");
+  return response.turn;
+};
+const read = async (threadId) => strictThread(await rpc("thread/read", { threadId, includeTurns: true }), "thread/read");
+const statusType = (thread) => thread?.status?.type;
+const turnIds = (thread) => (thread.turns ?? []).map((turn) => turn.id);
+const tryRpc = async (method, params) => { try { return { ok: true, value: await rpc(method, params) }; } catch (error) { return { ok: false, code: error.rpc?.code ?? null }; } };
+const started = (threadId, turnId) => waitEvent("turn/started", threadId, turnId);
+const terminal = (threadId, turnId) => waitEvent("turn/completed", threadId, turnId);
+const completedStatus = (event) => event.params.turn.status;
+const logicalTurns = (ids) => ids.map(alias);
+const sanitizeTrace = () => trace.map((entry) => {
+  const output = { ...entry };
+  if (entry.threadId) output.thread = alias(entry.threadId);
+  if (entry.turnId) output.turn = alias(entry.turnId);
+  if (entry.boundaryTurnId) output.boundaryTurn = alias(entry.boundaryTurnId);
+  delete output.threadId; delete output.turnId; delete output.boundaryTurnId;
+  return output;
+});
+
+const binary = execFileSync("sh", ["-c", "command -v codex"], { encoding: "utf8" }).trim();
+const binarySha256 = createHash("sha256").update(fs.readFileSync(fs.realpathSync(binary))).digest("hex");
+const result = {
+  evidenceRevision: "test1190-wire-v2",
+  artifact: { codexCli: "0.148.0", packageBoundary: "probe-only; agent-node lock remains 0.133.0", os: os.platform(), arch: os.arch(), binarySha256 },
+  topology: "owned-stdio", forkBoundary: {}, concurrencyCancel: {}, reverseCompletion: {}, retention: {},
 };
 
-const result = { version: "codex-cli 0.148.0", observations: {} };
 try {
-  await rpc("initialize", {
-    clientInfo: { name: "anet-btw-wire-probe", version: "0.1.0" },
-    capabilities: { experimentalApi: true },
-  });
+  await rpc("initialize", { clientInfo: { name: "anet-btw-wire-probe", version: "0.2.0" }, capabilities: { experimentalApi: true } });
   notify("initialized", {});
+  const source = strictThread(await rpc("thread/start", { ephemeral: false }), "thread/start").id; aliases.set(source, "source");
+  const seed = strictTurn(await rpc("turn/start", { threadId: source, input: [{ type: "text", text: "Reply exactly SEED_OK." }] })).id; aliases.set(seed, "seed");
+  await terminal(source, seed);
+  const active = strictTurn(await rpc("turn/start", { threadId: source, input: [{ type: "text", text: "Run `sleep 15`, then reply MAIN_OK." }] })).id; aliases.set(active, "sourceActive");
+  const sourceStarted = await started(source, active);
+  if (process.env.BTW_WITNESS_SOURCE_FIRST === "1") await terminal(source, active);
+  const sourceBefore = await read(source);
+  if (statusType(sourceBefore) !== "active") throw new Error("WITNESS_RED: source was not active at fork boundary");
 
-  const source = idOfThread(await rpc("thread/start", { ephemeral: false }));
-  if (!source) throw new Error("thread/start returned no id");
-
-  const seed = idOfTurn(await rpc("turn/start", {
-    threadId: source,
-    input: [{ type: "text", text: "Reply with exactly SEED_OK and nothing else." }],
-  }));
-  if (!seed) throw new Error("seed turn/start returned no id");
-  const seedDone = await terminal(source, seed);
-  if (statusOf(seedDone) !== "completed") throw new Error(`seed status=${statusOf(seedDone)}`);
-
-  const active = idOfTurn(await rpc("turn/start", {
-    threadId: source,
-    input: [{ type: "text", text: "Run the shell command `sleep 12`, then reply exactly MAIN_OK." }],
-  }));
-  if (!active) throw new Error("active turn/start returned no id");
-  await waitEvent("turn/started", (p) => (p.threadId ?? p.thread_id) === source && idOfTurn(p) === active);
-
-  // Exact completed boundary while the source has a later active turn.
-  const forkAResp = await rpc("thread/fork", { threadId: source, lastTurnId: seed, ephemeral: false });
-  const forkA = idOfThread(forkAResp);
-  const forkBResp = await rpc("thread/fork", { threadId: source, beforeTurnId: active, ephemeral: false });
-  const forkB = idOfThread(forkBResp);
-  if (!forkA || !forkB || forkA === forkB || forkA === source || forkB === source) {
-    throw new Error("fork ids are not independent");
-  }
-  const activeAsBoundary = await tryRpc("thread/fork", { threadId: source, lastTurnId: active, ephemeral: true });
-  result.observations.forkBoundary = {
-    completedLastTurnWhileLaterActive: true,
-    beforeActiveTurn: true,
-    activeLastTurnRejected: !activeAsBoundary.ok,
-    activeLastTurnErrorCode: activeAsBoundary.code,
+  const forkCancel = strictThread(await rpc("thread/fork", { threadId: source, lastTurnId: seed, ephemeral: false }), "thread/fork").id; aliases.set(forkCancel, "forkCancel");
+  const forkCancelRead = await read(forkCancel);
+  if (statusType(await read(source)) !== "active") throw new Error("source stopped before beforeTurnId fork");
+  const forkSibling = strictThread(await rpc("thread/fork", { threadId: source, beforeTurnId: active, ephemeral: false }), "thread/fork").id; aliases.set(forkSibling, "forkSibling");
+  const forkSiblingRead = await read(forkSibling);
+  const activeBoundary = await tryRpc("thread/fork", { threadId: source, lastTurnId: active, ephemeral: true });
+  result.forkBoundary = {
+    sourceStatusAtFork: statusType(sourceBefore), sourceTurnsBefore: logicalTurns(turnIds(sourceBefore)),
+    throughTurns: logicalTurns(turnIds(forkCancelRead)), beforeTurns: logicalTurns(turnIds(forkSiblingRead)),
+    throughForkedFromMatches: forkCancelRead.forkedFromId === source, beforeForkedFromMatches: forkSiblingRead.forkedFromId === source,
+    seedIncluded: turnIds(forkCancelRead).includes(seed) && turnIds(forkSiblingRead).includes(seed),
+    activeExcluded: !turnIds(forkCancelRead).includes(active) && !turnIds(forkSiblingRead).includes(active),
+    activeInclusiveBoundaryRejected: !activeBoundary.ok, activeInclusiveBoundaryErrorCode: activeBoundary.code,
   };
 
-  // Two derived threads execute concurrently. B is short; A is cancelled.
-  const turnA = idOfTurn(await rpc("turn/start", {
-    threadId: forkA,
-    input: [{ type: "text", text: "Run `sleep 9`, then reply exactly FORK_A_SHOULD_NOT_FINISH." }],
-  }));
-  const turnB = idOfTurn(await rpc("turn/start", {
-    threadId: forkB,
-    input: [{ type: "text", text: "Reply exactly FORK_B_OK and nothing else." }],
-  }));
-  await Promise.all([
-    waitEvent("turn/started", (p) => (p.threadId ?? p.thread_id) === forkA && idOfTurn(p) === turnA),
-    waitEvent("turn/started", (p) => (p.threadId ?? p.thread_id) === forkB && idOfTurn(p) === turnB),
-  ]);
-  const interrupted = await tryRpc("turn/interrupt", { threadId: forkA, turnId: turnA });
-  const [aDone, bDone, mainDone] = await Promise.all([
-    terminal(forkA, turnA), terminal(forkB, turnB), terminal(source, active),
-  ]);
-  result.observations.concurrentAndCancel = {
-    independentInterruptAccepted: interrupted.ok,
-    cancelledForkStatus: statusOf(aDone),
-    siblingForkStatus: statusOf(bDone),
-    sourceStatus: statusOf(mainDone),
-    allThreadIdsDistinct: new Set([source, forkA, forkB]).size === 3,
+  const cancelTurn = strictTurn(await rpc("turn/start", { threadId: forkCancel, input: [{ type: "text", text: "Run `sleep 12`, then reply CANCEL_BAD." }] })).id; aliases.set(cancelTurn, "cancelTurn");
+  const siblingTurn = strictTurn(await rpc("turn/start", { threadId: forkSibling, input: [{ type: "text", text: "Run `sleep 8`, then reply SIBLING_OK." }] })).id; aliases.set(siblingTurn, "siblingTurn");
+  const [cancelStarted, siblingStarted] = await Promise.all([started(forkCancel, cancelTurn), started(forkSibling, siblingTurn)]);
+  const activeReads = await Promise.all([read(source), read(forkCancel), read(forkSibling)]);
+  if (activeReads.some((thread) => statusType(thread) !== "active")) throw new Error("three-way active precondition failed");
+  mark("cancel_requested", { threadId: forkCancel, turnId: cancelTurn }); const cancelRequestedSeq = semanticSeq;
+  await rpc("turn/interrupt", { threadId: forkCancel, turnId: cancelTurn });
+  const [cancelDone, siblingDone, sourceDone] = await Promise.all([terminal(forkCancel, cancelTurn), terminal(forkSibling, siblingTurn), terminal(source, active)]);
+  const sourceAfterCancel = await read(source), siblingAfterCancel = await read(forkSibling);
+  result.concurrencyCancel = {
+    sourceStartedBeforeForks: sourceStarted.seq < cancelStarted.seq && sourceStarted.seq < siblingStarted.seq,
+    allThreeActiveBeforeCancel: true,
+    cancelRequestedBeforeTargetTerminal: cancelRequestedSeq < cancelDone.seq,
+    cancelRequestedBeforeSiblingTerminal: cancelRequestedSeq < siblingDone.seq,
+    cancelRequestedBeforeSourceTerminal: cancelRequestedSeq < sourceDone.seq,
+    targetStatus: completedStatus(cancelDone), siblingStatus: completedStatus(siblingDone), sourceStatus: completedStatus(sourceDone),
+    sourceReadableAfterCancel: sourceAfterCancel.id === source, siblingReadableAfterCancel: siblingAfterCancel.id === forkSibling,
   };
 
-  const archived = await tryRpc("thread/archive", { threadId: forkA });
-  const readArchived = await tryRpc("thread/read", { threadId: forkA, includeTurns: true });
-  const deleted = await tryRpc("thread/delete", { threadId: forkB });
-  const readDeleted = await tryRpc("thread/read", { threadId: forkB, includeTurns: true });
-  result.observations.retention = {
-    archiveAccepted: archived.ok,
-    archivedStillReadable: readArchived.ok,
-    deleteAccepted: deleted.ok,
-    deletedReadRejected: !readDeleted.ok,
-    deletedReadErrorCode: readDeleted.code,
+  const slowThread = strictThread(await rpc("thread/fork", { threadId: source, lastTurnId: seed, ephemeral: false }), "thread/fork").id;
+  const fastThread = strictThread(await rpc("thread/fork", { threadId: source, lastTurnId: seed, ephemeral: false }), "thread/fork").id;
+  aliases.set(slowThread, "forkSlow"); aliases.set(fastThread, "forkFast");
+  const slowTurn = strictTurn(await rpc("turn/start", { threadId: slowThread, input: [{ type: "text", text: "Run `sleep 6`, then reply SLOW_OK." }] })).id;
+  const fastTurn = strictTurn(await rpc("turn/start", { threadId: fastThread, input: [{ type: "text", text: "Reply FAST_OK." }] })).id;
+  aliases.set(slowTurn, "slowTurn"); aliases.set(fastTurn, "fastTurn");
+  const [fastDone, slowDone] = await Promise.all([terminal(fastThread, fastTurn), terminal(slowThread, slowTurn)]);
+  result.reverseCompletion = { creationOrder: ["forkSlow", "forkFast"], completionOrder: fastDone.seq < slowDone.seq ? ["forkFast", "forkSlow"] : ["forkSlow", "forkFast"], fastStatus: completedStatus(fastDone), slowStatus: completedStatus(slowDone) };
+
+  await rpc("thread/archive", { threadId: forkCancel }); const archivedRead = await read(forkCancel);
+  await rpc("thread/unarchive", { threadId: forkCancel }); const unarchivedRead = await read(forkCancel);
+  await rpc("thread/delete", { threadId: forkSibling }); const deletedRead = await tryRpc("thread/read", { threadId: forkSibling, includeTurns: true });
+  const sourceAfterDelete = await read(source), unarchivedAfterDelete = await read(forkCancel);
+  result.retention = {
+    archivedReadable: archivedRead.id === forkCancel, unarchivedReadable: unarchivedRead.id === forkCancel,
+    deleteReadRejected: !deletedRead.ok, deleteReadErrorCode: deletedRead.code,
+    sourceIsolatedFromDelete: sourceAfterDelete.id === source, unarchivedSiblingIsolatedFromDelete: unarchivedAfterDelete.id === forkCancel,
   };
+  fs.writeFileSync(process.env.BTW_TRACE_PATH, JSON.stringify({ evidenceRevision: result.evidenceRevision, topology: result.topology, trace: sanitizeTrace() }, null, 2) + "\n", { mode: 0o600 });
 } finally {
   try { await rpc("shutdown", {}, 5_000); } catch {}
   child.kill("SIGTERM");
 }
-
 process.stdout.write(JSON.stringify(result, null, 2) + "\n");

--- a/tests/test1190-codex-btw-wire-probe/run.sh
+++ b/tests/test1190-codex-btw-wire-probe/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPORT_DIR="${REPORT_DIR:-/probe/out}"
+mkdir -p "$REPORT_DIR"
+
+version=$(codex --version)
+test "$version" = "codex-cli 0.148.0"
+
+schema_dir=$(mktemp -d)
+trap 'rm -rf "$schema_dir"' EXIT
+codex app-server generate-json-schema --experimental --out "$schema_dir"
+node /probe/schema-probe.mjs "$schema_dir/ClientRequest.json" \
+  > "$REPORT_DIR/schema-result.json"
+diff -u /probe/golden/schema-result.json "$REPORT_DIR/schema-result.json"
+
+if [[ "${BTW_LIVE_PROBE:-0}" != "1" ]]; then
+  echo "PASS schema capability probe (live probe skipped; set BTW_LIVE_PROBE=1 with an authenticated CODEX_HOME)"
+  exit 0
+fi
+
+# Never print auth/config contents. The caller supplies an isolated CODEX_HOME
+# mount; the probe writes rollouts only below that directory.
+test -n "${CODEX_HOME:-}"
+node /probe/live-probe.mjs > "$REPORT_DIR/live-result.json"
+diff -u /probe/golden/live-result.json "$REPORT_DIR/live-result.json"
+node /probe/assert-live.mjs "$REPORT_DIR/live-result.json"
+echo "PASS real codex app-server 0.148.0 BTW wire probe"

--- a/tests/test1190-codex-btw-wire-probe/run.sh
+++ b/tests/test1190-codex-btw-wire-probe/run.sh
@@ -8,12 +8,16 @@ mkdir -p "$REPORT_DIR"
 version=$(codex --version)
 test "$version" = "codex-cli 0.148.0"
 
-schema_dir=$(mktemp -d)
-trap 'safe_rm_rf "$schema_dir"' EXIT
-codex app-server generate-json-schema --experimental --out "$schema_dir"
-node /probe/schema-probe.mjs "$schema_dir/ClientRequest.json" \
+normal_schema_dir=$(mktemp -d)
+experimental_schema_dir=$(mktemp -d)
+cleanup_schema() { safe_rm_rf "$normal_schema_dir"; safe_rm_rf "$experimental_schema_dir"; }
+trap cleanup_schema EXIT
+codex app-server generate-json-schema --out "$normal_schema_dir"
+codex app-server generate-json-schema --experimental --out "$experimental_schema_dir"
+node /probe/schema-probe.mjs "$normal_schema_dir" "$experimental_schema_dir" \
   > "$REPORT_DIR/schema-result.json"
-diff -u /probe/golden/schema-result.json "$REPORT_DIR/schema-result.json"
+jq -e --slurpfile actual "$REPORT_DIR/schema-result.json" '. == $actual[0]' \
+  /probe/golden/schema-result.json >/dev/null
 
 if [[ "${BTW_LIVE_PROBE:-0}" != "1" ]]; then
   echo "PASS schema capability probe (live probe skipped; set BTW_LIVE_PROBE=1 with an authenticated CODEX_HOME)"
@@ -23,7 +27,33 @@ fi
 # Never print auth/config contents. The caller supplies an isolated CODEX_HOME
 # mount; the probe writes rollouts only below that directory.
 test -n "${CODEX_HOME:-}"
+test -f "$CODEX_HOME/.anet-btw-probe-sentinel"
+test "$(cat "$CODEX_HOME/.anet-btw-probe-sentinel")" = "test1190-disposable-v2"
+cleanup_live_home() {
+  test -f "$CODEX_HOME/.anet-btw-probe-sentinel" || return 1
+  test "$(cat "$CODEX_HOME/.anet-btw-probe-sentinel")" = "test1190-disposable-v2"
+  # Runs as container root, so app-server's root-owned caches cannot strand
+  # credentials or rollouts on the host-mounted disposable directory.
+  find "$CODEX_HOME" -mindepth 1 -delete
+}
+trap 'cleanup_live_home; cleanup_schema' EXIT
+export BTW_TRACE_PATH="$REPORT_DIR/wire-trace.json"
 node /probe/live-probe.mjs > "$REPORT_DIR/live-result.json"
-diff -u /probe/golden/live-result.json "$REPORT_DIR/live-result.json"
+jq -e --slurpfile actual "$REPORT_DIR/live-result.json" '. == $actual[0]' \
+  /probe/golden/live-result.json >/dev/null
 node /probe/assert-live.mjs "$REPORT_DIR/live-result.json"
+
+# Witnessed red: the old probe stayed green if source completed before fork.
+# Force exactly that mutation and require the active-at-fork invariant to fail.
+if BTW_WITNESS_SOURCE_FIRST=1 BTW_TRACE_PATH="$REPORT_DIR/witness-trace.json" \
+    node /probe/live-probe.mjs >"$REPORT_DIR/witness-result.json" 2>"$REPORT_DIR/witness-error.txt"; then
+  echo "FAIL source-first mutation survived"
+  exit 1
+fi
+grep -q 'WITNESS_RED: source was not active at fork boundary' "$REPORT_DIR/witness-error.txt"
+
+# Sanitized trace is inspectable but must contain no UUIDs, prompts or paths.
+test -s "$REPORT_DIR/wire-trace.json"
+! grep -Eq '[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}' "$REPORT_DIR/wire-trace.json"
+! grep -Eq 'SEED_OK|MAIN_OK|SIBLING_OK|/root/|/home/' "$REPORT_DIR/wire-trace.json"
 echo "PASS real codex app-server 0.148.0 BTW wire probe"

--- a/tests/test1190-codex-btw-wire-probe/run.sh
+++ b/tests/test1190-codex-btw-wire-probe/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+source /tests/lib/safe-rm.sh
 
 REPORT_DIR="${REPORT_DIR:-/probe/out}"
 mkdir -p "$REPORT_DIR"
@@ -8,7 +9,7 @@ version=$(codex --version)
 test "$version" = "codex-cli 0.148.0"
 
 schema_dir=$(mktemp -d)
-trap 'rm -rf "$schema_dir"' EXIT
+trap 'safe_rm_rf "$schema_dir"' EXIT
 codex app-server generate-json-schema --experimental --out "$schema_dir"
 node /probe/schema-probe.mjs "$schema_dir/ClientRequest.json" \
   > "$REPORT_DIR/schema-result.json"

--- a/tests/test1190-codex-btw-wire-probe/schema-probe.mjs
+++ b/tests/test1190-codex-btw-wire-probe/schema-probe.mjs
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+
+const schema = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const defs = schema.definitions ?? {};
+const methods = new Set();
+const visit = (value) => {
+  if (!value || typeof value !== "object") return;
+  if (value.const && typeof value.const === "string") methods.add(value.const);
+  if (Array.isArray(value.enum)) {
+    for (const member of value.enum) if (typeof member === "string") methods.add(member);
+  }
+  for (const child of Object.values(value)) visit(child);
+};
+visit(schema);
+
+const props = (name) => Object.keys(defs[name]?.properties ?? {}).sort();
+const required = (name) => [...(defs[name]?.required ?? [])].sort();
+const output = {
+  protocolVersion: "codex-cli 0.148.0",
+  methods: {
+    threadFork: methods.has("thread/fork"),
+    threadArchive: methods.has("thread/archive"),
+    threadDelete: methods.has("thread/delete"),
+    turnInterrupt: methods.has("turn/interrupt"),
+  },
+  threadFork: {
+    experimentalApiRequiredForExactBoundary: true,
+    properties: props("ThreadForkParams"),
+    required: required("ThreadForkParams"),
+    exactBoundaryFields: ["beforeTurnId", "lastTurnId"].filter((x) => props("ThreadForkParams").includes(x)),
+  },
+  threadArchive: { required: required("ThreadArchiveParams") },
+  threadDelete: { required: required("ThreadDeleteParams") },
+  turnInterrupt: { required: required("TurnInterruptParams") },
+};
+process.stdout.write(JSON.stringify(output, null, 2) + "\n");

--- a/tests/test1190-codex-btw-wire-probe/schema-probe.mjs
+++ b/tests/test1190-codex-btw-wire-probe/schema-probe.mjs
@@ -1,36 +1,40 @@
 import fs from "node:fs";
+import path from "node:path";
 
-const schema = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-const defs = schema.definitions ?? {};
-const methods = new Set();
-const visit = (value) => {
-  if (!value || typeof value !== "object") return;
-  if (value.const && typeof value.const === "string") methods.add(value.const);
-  if (Array.isArray(value.enum)) {
-    for (const member of value.enum) if (typeof member === "string") methods.add(member);
-  }
-  for (const child of Object.values(value)) visit(child);
-};
-visit(schema);
+const [normalDir, experimentalDir] = process.argv.slice(2);
+const read = (dir, file) => JSON.parse(fs.readFileSync(path.join(dir, file), "utf8"));
+const normalRequest = read(normalDir, "ClientRequest.json");
+const expRequest = read(experimentalDir, "ClientRequest.json");
+const expNotification = read(experimentalDir, "ServerNotification.json");
+const expForkResponse = read(experimentalDir, "v2/ThreadForkResponse.json");
+const expReadResponse = read(experimentalDir, "v2/ThreadReadResponse.json");
+const props = (schema, name) => Object.keys(schema.definitions?.[name]?.properties ?? {}).sort();
+const required = (schema, name) => [...(schema.definitions?.[name]?.required ?? [])].sort();
+const has = (schema, name, property) => props(schema, name).includes(property);
+const rootProps = (schema) => Object.keys(schema.properties ?? {}).sort();
+const rootRequired = (schema) => [...(schema.required ?? [])].sort();
 
-const props = (name) => Object.keys(defs[name]?.properties ?? {}).sort();
-const required = (name) => [...(defs[name]?.required ?? [])].sort();
 const output = {
-  protocolVersion: "codex-cli 0.148.0",
-  methods: {
-    threadFork: methods.has("thread/fork"),
-    threadArchive: methods.has("thread/archive"),
-    threadDelete: methods.has("thread/delete"),
-    turnInterrupt: methods.has("turn/interrupt"),
+  artifact: { codexCli: "0.148.0", schemaMode: "normal+experimental" },
+  forkBoundary: {
+    lastTurnId: { normalSchema: has(normalRequest, "ThreadForkParams", "lastTurnId"), experimentalSchema: has(expRequest, "ThreadForkParams", "lastTurnId"), requiresExperimental: false },
+    beforeTurnId: { normalSchema: has(normalRequest, "ThreadForkParams", "beforeTurnId"), experimentalSchema: has(expRequest, "ThreadForkParams", "beforeTurnId"), requiresExperimental: true },
+    requestRequired: required(expRequest, "ThreadForkParams"),
   },
-  threadFork: {
-    experimentalApiRequiredForExactBoundary: true,
-    properties: props("ThreadForkParams"),
-    required: required("ThreadForkParams"),
-    exactBoundaryFields: ["beforeTurnId", "lastTurnId"].filter((x) => props("ThreadForkParams").includes(x)),
+  initialize: {
+    capabilitiesProperties: props(expRequest, "InitializeCapabilities"),
+    experimentalApiDefault: expRequest.definitions.InitializeCapabilities.properties.experimentalApi.default,
   },
-  threadArchive: { required: required("ThreadArchiveParams") },
-  threadDelete: { required: required("ThreadDeleteParams") },
-  turnInterrupt: { required: required("TurnInterruptParams") },
+  responseShape: {
+    threadFork: { properties: rootProps(expForkResponse), required: rootRequired(expForkResponse) },
+    threadRead: { properties: rootProps(expReadResponse), required: rootRequired(expReadResponse) },
+  },
+  ownershipShape: {
+    thread: { properties: props(expNotification, "Thread"), required: required(expNotification, "Thread") },
+    turn: { properties: props(expNotification, "Turn"), required: required(expNotification, "Turn") },
+    turnStarted: { properties: props(expNotification, "TurnStartedNotification"), required: required(expNotification, "TurnStartedNotification") },
+    turnCompleted: { properties: props(expNotification, "TurnCompletedNotification"), required: required(expNotification, "TurnCompletedNotification") },
+  },
 };
+if (!output.forkBoundary.lastTurnId.normalSchema || output.forkBoundary.beforeTurnId.normalSchema) throw new Error("normal/experimental boundary classification drifted");
 process.stdout.write(JSON.stringify(output, null, 2) + "\n");

--- a/tests/test1193-side-thread-contract/Dockerfile
+++ b/tests/test1193-side-thread-contract/Dockerfile
@@ -1,0 +1,11 @@
+FROM oven/bun:1.3.14-debian
+
+WORKDIR /app
+ARG TEST1193_SOURCE_COMMIT=unknown
+ENV TEST1193_SOURCE_COMMIT=${TEST1193_SOURCE_COMMIT}
+
+COPY agent-node/src/runtime/side-thread /app/agent-node/src/runtime/side-thread
+COPY tests/test1193-side-thread-contract /app/tests/test1193-side-thread-contract
+RUN chmod +x /app/tests/test1193-side-thread-contract/run.sh
+
+CMD ["/app/tests/test1193-side-thread-contract/run.sh"]

--- a/tests/test1193-side-thread-contract/run.sh
+++ b/tests/test1193-side-thread-contract/run.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 cd /app
 echo "source_commit=${TEST1193_SOURCE_COMMIT}"
-bun test agent-node/src/runtime/side-thread/domain.test.ts \
-  agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+bun test agent-node/src/runtime/side-thread/*.test.ts
 
 # Witness red: if the exact pinned-version gate is weakened, the capability
 # matrix test must fail. Work only on the container copy.

--- a/tests/test1193-side-thread-contract/run.sh
+++ b/tests/test1193-side-thread-contract/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+echo "source_commit=${TEST1193_SOURCE_COMMIT}"
+bun test agent-node/src/runtime/side-thread/domain.test.ts \
+  agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts
+
+# Witness red: if the exact pinned-version gate is weakened, the capability
+# matrix test must fail. Work only on the container copy.
+cp agent-node/src/runtime/side-thread/codex-app-server-adapter.ts /tmp/adapter.ts
+sed -i 's/this\.opts\.runtimeVersion !== "0\.148\.0"/false/' \
+  agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+if bun test agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts \
+    >/tmp/mutation.log 2>&1; then
+  echo "FAIL version fail-closed mutation survived"
+  exit 1
+fi
+mv /tmp/adapter.ts agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+
+echo "PASS test1193 side-thread domain/adapter contract + witnessed red"

--- a/tests/test1195-side-thread-hub-contract/Dockerfile
+++ b/tests/test1195-side-thread-hub-contract/Dockerfile
@@ -8,6 +8,7 @@ COPY server/src/side-thread.ts /app/server/src/side-thread.ts
 COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
 COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
 COPY contracts/side-thread/v1/golden.json /app/contracts/side-thread/v1/golden.json
+COPY contracts/side-thread/v1/schema.json /app/contracts/side-thread/v1/schema.json
 COPY tests/test1195-side-thread-hub-contract/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 

--- a/tests/test1195-side-thread-hub-contract/Dockerfile
+++ b/tests/test1195-side-thread-hub-contract/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1.3.14-debian
+
+WORKDIR /app
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+COPY server/src/db-adapter.ts /app/server/src/db-adapter.ts
+COPY server/src/side-thread.ts /app/server/src/side-thread.ts
+COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
+COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
+COPY contracts/side-thread/v1/golden.json /app/contracts/side-thread/v1/golden.json
+COPY tests/test1195-side-thread-hub-contract/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/test1195-side-thread-hub-contract/run.sh
+++ b/tests/test1195-side-thread-hub-contract/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+echo "source_commit=${SOURCE_COMMIT}"
+bun test server/src/side-thread.test.ts -t 'feature flag|create is payload|cross-window|authoritative vendorable|routes use|disabled surface|capability flips'
+
+# Witness red: removing the explicit native-exact-fork mode gate must make the
+# unverified/shared adapter case fail.
+cp server/src/side-thread.ts /tmp/side-thread.ts
+sed -i 's/cap\.mode !== "native-exact-fork"/false/' server/src/side-thread.ts
+grep -F 'if (false)' server/src/side-thread.ts >/dev/null
+if bun test server/src/side-thread.test.ts -t 'feature flag and missing runtime adapter' >/tmp/contract-mutation.log 2>&1; then
+  echo "FAIL: native-mode mutation survived"
+  cat /tmp/contract-mutation.log
+  exit 1
+fi
+mv /tmp/side-thread.ts server/src/side-thread.ts
+
+echo "PASS test1195 SideThread Hub contract + witnessed red"

--- a/tests/test1195-side-thread-hub-contract/run.sh
+++ b/tests/test1195-side-thread-hub-contract/run.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 cd /app
 echo "source_commit=${SOURCE_COMMIT}"
-bun test server/src/side-thread.test.ts -t 'feature flag|create is payload|cross-window|authoritative vendorable|routes use|disabled surface|capability flips'
+bun test server/src/side-thread.test.ts -t 'feature flag|create is payload|cross-window|authoritative vendorable|routes use|every mutating|disabled surface|capability flips'
 
 # Witness red: removing the explicit native-exact-fork mode gate must make the
 # unverified/shared adapter case fail.

--- a/tests/test1195-side-thread-hub-race/Dockerfile
+++ b/tests/test1195-side-thread-hub-race/Dockerfile
@@ -8,6 +8,7 @@ COPY server/src/side-thread.ts /app/server/src/side-thread.ts
 COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
 COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
 COPY contracts/side-thread/v1/golden.json /app/contracts/side-thread/v1/golden.json
+COPY contracts/side-thread/v1/schema.json /app/contracts/side-thread/v1/schema.json
 COPY tests/test1195-side-thread-hub-race/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 

--- a/tests/test1195-side-thread-hub-race/Dockerfile
+++ b/tests/test1195-side-thread-hub-race/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14-debian
+
+WORKDIR /app
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+COPY server/src/db-adapter.ts /app/server/src/db-adapter.ts
+COPY server/src/side-thread.ts /app/server/src/side-thread.ts
+COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
+COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
+COPY tests/test1195-side-thread-hub-race/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/test1195-side-thread-hub-race/Dockerfile
+++ b/tests/test1195-side-thread-hub-race/Dockerfile
@@ -7,6 +7,7 @@ COPY server/src/db-adapter.ts /app/server/src/db-adapter.ts
 COPY server/src/side-thread.ts /app/server/src/side-thread.ts
 COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
 COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
+COPY contracts/side-thread/v1/golden.json /app/contracts/side-thread/v1/golden.json
 COPY tests/test1195-side-thread-hub-race/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 

--- a/tests/test1195-side-thread-hub-race/run.sh
+++ b/tests/test1195-side-thread-hub-race/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+echo "source_commit=${SOURCE_COMMIT}"
+bun test server/src/side-thread.test.ts -t 'terminal events|terminal event arriving|cancel is exact|cross-coordinator|retry persists|archive/purge|bring-back|response loss|ambiguous cancel'
+
+# Witness red: weaken one member of the four-part terminal ownership tuple.
+cp server/src/side-thread.ts /tmp/side-thread.ts
+sed -i 's/owned\.derived_thread_id !== event\.threadId/false/' server/src/side-thread.ts
+grep -F 'false ||' server/src/side-thread.ts >/dev/null
+if bun test server/src/side-thread.test.ts -t 'terminal events require' >/tmp/race-mutation.log 2>&1; then
+  echo "FAIL: event ownership mutation survived"
+  cat /tmp/race-mutation.log
+  exit 1
+fi
+mv /tmp/side-thread.ts server/src/side-thread.ts
+
+echo "PASS test1195 SideThread Hub races + witnessed red"

--- a/tests/test1195-side-thread-hub-security/Dockerfile
+++ b/tests/test1195-side-thread-hub-security/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1.3.14-debian
+
+WORKDIR /app/server
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+COPY server/package.json server/package-lock.json ./
+RUN bun install --frozen-lockfile
+COPY server/src ./src
+
+WORKDIR /app
+COPY tests/test1195-side-thread-hub-security/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/test1195-side-thread-hub-security/run.sh
+++ b/tests/test1195-side-thread-hub-security/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app/server
+echo "source_commit=${SOURCE_COMMIT}"
+bun test src/side-thread-http-integration.test.ts
+
+# Witness red: accepting a query-string token would expose the persisted owner
+# question across browser/log boundaries. The integration assertion must catch it.
+cp src/server.ts /tmp/server.ts
+sed -i 's/resolveRequestAuth(req, { allowQueryToken: false })/resolveRequestAuth(req)/' src/server.ts
+grep -F 'actor: resolveSideThreadActor(req, resolveRequestAuth(req), isAdmin)' src/server.ts >/dev/null
+if bun test src/side-thread-http-integration.test.ts >/tmp/security-mutation.log 2>&1; then
+  echo "FAIL: query-token auth mutation survived"
+  cat /tmp/security-mutation.log
+  exit 1
+fi
+mv /tmp/server.ts src/server.ts
+
+echo "PASS test1195 SideThread Hub auth/SSE security + witnessed red"

--- a/tests/test638-server-aggregate-isolation/Dockerfile
+++ b/tests/test638-server-aggregate-isolation/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
 WORKDIR /work
 
 COPY server/ server/
+COPY contracts/side-thread/v1/ contracts/side-thread/v1/
 COPY agent-node/src/ agent-node/src/
 COPY tests/test601-hub-scheduled-tasks/ tests/test601-hub-scheduled-tasks/
 RUN cd server && bun install

--- a/tests/test798-server-unit-ci/Dockerfile
+++ b/tests/test798-server-unit-ci/Dockerfile
@@ -25,6 +25,7 @@ COPY server/package.json server/package-lock.json ./server/
 RUN cd server && npm ci
 
 COPY server ./server
+COPY contracts/side-thread/v1 ./contracts/side-thread/v1
 # RFC-026 G9 / RFC-028 P1 的漂移门比对 hub 与 daemon 的同名共享源码,
 # 要读同级 agent-node/src/shared。只带这个目录,不带整个包。
 # 若干 server 测试跨包 import agent-node 的源码(hub↔daemon 漂移门比对


### PR DESCRIPTION
## Summary

Implements #175 PR2 as a stacked Draft on #1194. Adds the feature-gated Hub SideThread REST/SSE surface, durable SQLite records/attempt lineage/operation and bring-back receipts, exact owner/node/attachment authorization, and vendorable public contract fixtures.

## Safety boundary

- Defaults to `SIDE_THREAD_UNSUPPORTED` until a verified native exact-fork adapter is explicitly installed.
- The execution port has no task/inbox/FIFO fallback.
- Every mutating POST persists the caller `requestKey`, including cancel/archive/purge; response loss is durable `ambiguous` with stable `operationId`, and identical retries never issue a second RPC.
- SSE/audit contain metadata and allow-listed codes only, never question/result/runtime exception bodies.
- Public JSON is frozen under `contracts/side-thread/v1/` (`sideThreadId`, `question`, canonical nulls).
- Schema SHA256: `0a520e7173727bbcdf7b9220b114a42b41ebb6db0cfc73828bef9888473882ff`; golden SHA256: `de2387b61d2aab52cfe537ae38bd2671b31ddcadc33d87623f55ffafdd0e975b`.

## Stack dependency

Base branch #1194 is now repaired at exact `e0c702f1` (runtime fix `f9bc6e96`) with independent fault review PASS. This PR remains decoupled through `SideThreadExecutionPort`; production adapter wiring is intentionally not installed here. Keep this PR stacked Draft and unmerged until a later integration slice supplies the dedicated command transport, attachment materialization, and journaled bring-back.

## Docker evidence

Contract implementation/schema commit: `0744c312f9188278f243d4266ddd8acab8493c7b`.

- contract: 8 pass / 35 assertions + witnessed-red
- auth/SSE security: 5 pass / 19 assertions + witnessed-red
- races/faults: 9 pass / 60 assertions + witnessed-red
- total: 22 pass / 114 assertions / 3 witnessed-red
- complete server unit domain: 74/74 files, 0 failures + witnessed-red
- aggregate isolation exact fix `c207d353`: 74 files / 984 pass / 3235 assertions / 0 fail, all isolation and process-failure witnessed-red PASS
- suite registration, L1 path sync, bare-rm lint, and diff-check: PASS
- `server.ts` stack diff: 83 additions, 0 deletions ignoring EOL whitespace

Evidence: `docs/tests/report-test1195-side-thread-hub.txt`.

Independent protocol/security review of `17b73617`: PASS, no blocker. The later commits only add the test638 fixture COPY and its evidence.

Draft only: do not merge or release.