### PR TITLE
feat(hub): rebuild durable SideThread API stack on merged PR1

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -29,6 +29,9 @@ on:
       - 'tests/test751-codex-copresence-windows/**'
       - 'tests/test1183-sync-pinned-dryrun/**'
       - 'tests/test1193-side-thread-contract/**'
+      - 'tests/test1195-side-thread-hub-contract/**'
+      - 'tests/test1195-side-thread-hub-security/**'
+      - 'tests/test1195-side-thread-hub-race/**'
       # A test directory belongs here exactly when CI executes it — otherwise
       # editing the test cannot re-run the gate that runs it. The four below are
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other

--- a/contracts/side-thread/v1/README.md
+++ b/contracts/side-thread/v1/README.md
@@ -1,0 +1,16 @@
+# SideThread HTTP contract v1
+
+This directory is the authoritative, vendorable wire contract shared by the
+Hub and App. Public JSON uses `sideThreadId`/`question`; internal
+`side_chat_id`/`question_text` names never cross the HTTP or SSE boundary.
+
+Routes are `POST /api/side-threads`, `GET /api/side-threads`,
+`GET /api/side-threads/:sideThreadId`, `GET /:sideThreadId/events`, and
+`POST /:sideThreadId/{cancel,retry,archive,purge,bring-back}`. Capability is
+`GET /api/side-threads/capability` with `alias` or `nodeId`, plus `networkId`,
+`sourceThreadId`, `boundaryKind`, and `boundaryTurnId`.
+
+Create and retry bodies call owner-readable text `question`. Optional record
+fields are always present as JSON `null`; optional error correlation fields
+are absent. A supported capability always includes its exact `context`.
+Only a completed bring-back receipt makes `broughtBack` true.

--- a/contracts/side-thread/v1/golden.json
+++ b/contracts/side-thread/v1/golden.json
@@ -1,0 +1,148 @@
+{
+  "contractVersion": 1,
+  "nullablePolicy": "Optional projection fields are present with JSON null; optional error correlation fields are absent.",
+  "sideThreadActions": ["create", "get", "cancel", "retry", "archive", "purge"],
+  "requests": {
+    "capabilityQuery": {
+      "alias": "node-a",
+      "networkId": "net_a",
+      "sourceThreadId": "source_thread",
+      "boundaryKind": "through",
+      "boundaryTurnId": "source_turn"
+    },
+    "create": {
+      "requestKey": "create-request-0001",
+      "networkId": "net_a",
+      "nodeId": "node_a",
+      "sourceThreadId": "source_thread",
+      "boundary": { "kind": "through", "turnId": "source_turn" },
+      "question": "Original question",
+      "attachments": [{ "fileId": "file_ref_0001" }]
+    },
+    "retry": {
+      "requestKey": "retry-request-0001",
+      "question": "Try again",
+      "attachments": [{ "fileId": "file_ref_0001" }]
+    },
+    "bringBack": {
+      "requestKey": "bring-request-0001",
+      "attemptId": "sat_1",
+      "destinationThreadId": "source_thread"
+    }
+  },
+  "capabilityResponse": {
+    "ok": true,
+    "capability": {
+      "enabled": true,
+      "supported": true,
+      "mode": "native-exact-fork",
+      "runtime": "codex",
+      "runtimeVersion": "0.148.0",
+      "topology": "owned-stdio",
+      "evidenceRevision": "reviewed",
+      "exactBoundary": { "through": true, "before": true },
+      "reason": null,
+      "context": {
+        "networkId": "net_a",
+        "nodeId": "node_a",
+        "sourceThreadId": "source_thread",
+        "boundary": { "kind": "through", "turnId": "source_turn" }
+      }
+    }
+  },
+  "sideThreadEnvelope": {
+    "ok": true,
+    "sideThread": {
+      "sideThreadId": "sth_1",
+      "requestKey": "create-request-0001",
+      "networkId": "net_a",
+      "nodeId": "node_a",
+      "sourceThreadId": "source_thread",
+      "question": "Original question",
+      "title": "Original question",
+      "boundary": { "kind": "through", "turnId": "source_turn" },
+      "threadId": "derived_thread",
+      "state": "running",
+      "activeAttemptId": "sat_1",
+      "capability": {
+        "runtime": "codex",
+        "runtimeVersion": "0.148.0",
+        "topology": "owned-stdio",
+        "evidenceRevision": "reviewed"
+      },
+      "attachments": [{ "fileId": "file_ref_0001" }],
+      "attempts": [
+        {
+          "attemptId": "sat_1",
+          "requestKey": "create-request-0001",
+          "parentAttemptId": null,
+          "threadId": "derived_thread",
+          "turnId": "turn_1",
+          "state": "running",
+          "result": null,
+          "error": null,
+          "attachments": [{ "fileId": "file_ref_0001" }],
+          "broughtBack": false,
+          "createdAt": 1700000000000,
+          "updatedAt": 1700000000001
+        }
+      ],
+      "bringBacks": [],
+      "operations": [
+        {
+          "operationId": "sop_fork",
+          "attemptId": "sat_1",
+          "kind": "fork",
+          "requestKey": "create-request-0001",
+          "state": "completed",
+          "threadId": "derived_thread",
+          "turnId": null,
+          "errorCode": null,
+          "createdAt": 1700000000000,
+          "updatedAt": 1700000000001
+        },
+        {
+          "operationId": "sop_start",
+          "attemptId": "sat_1",
+          "kind": "start",
+          "requestKey": "create-request-0001",
+          "state": "completed",
+          "threadId": "derived_thread",
+          "turnId": "turn_1",
+          "errorCode": null,
+          "createdAt": 1700000000001,
+          "updatedAt": 1700000000002
+        }
+      ],
+      "createdAt": 1700000000000,
+      "updatedAt": 1700000000002
+    }
+  },
+  "listResponse": { "ok": true, "sideThreads": [], "count": 0 },
+  "bringBackResponse": {
+    "ok": true,
+    "bringBack": {
+      "bringBackId": "sbb_1",
+      "destinationTurnId": "destination_turn"
+    }
+  },
+  "ambiguousError": {
+    "ok": false,
+    "error": "SIDE_THREAD_AMBIGUOUS",
+    "message": "runtime acceptance is ambiguous; reconcile this stable operation before retrying",
+    "operationId": "sop_start",
+    "sideThreadId": "sth_1",
+    "attemptId": "sat_1"
+  },
+  "sseEvent": {
+    "eventId": 1,
+    "sideThreadId": "sth_1",
+    "attemptId": "sat_1",
+    "threadId": "derived_thread",
+    "turnId": "turn_1",
+    "type": "attempt.running",
+    "state": "running",
+    "reason": null,
+    "createdAt": 1700000000002
+  }
+}

--- a/contracts/side-thread/v1/golden.json
+++ b/contracts/side-thread/v1/golden.json
@@ -24,6 +24,9 @@
       "question": "Try again",
       "attachments": [{ "fileId": "file_ref_0001" }]
     },
+    "cancel": { "requestKey": "cancel-request-0001" },
+    "archive": { "requestKey": "archive-request-0001" },
+    "purge": { "requestKey": "purge-request-0001" },
     "bringBack": {
       "requestKey": "bring-request-0001",
       "attemptId": "sat_1",

--- a/contracts/side-thread/v1/schema.json
+++ b/contracts/side-thread/v1/schema.json
@@ -199,6 +199,154 @@
         "updatedAt": { "type": "number" }
       }
     },
+    "createRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requestKey",
+        "networkId",
+        "nodeId",
+        "sourceThreadId",
+        "boundary",
+        "question"
+      ],
+      "properties": {
+        "requestKey": { "type": "string" },
+        "networkId": { "type": "string" },
+        "nodeId": { "type": "string" },
+        "sourceThreadId": { "type": "string" },
+        "boundary": { "$ref": "#/$defs/boundary" },
+        "question": { "type": "string" },
+        "attachments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attachment" }
+        }
+      }
+    },
+    "retryRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requestKey", "question"],
+      "properties": {
+        "requestKey": { "type": "string" },
+        "question": { "type": "string" },
+        "attachments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attachment" }
+        }
+      }
+    },
+    "bringBackRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requestKey", "destinationThreadId"],
+      "properties": {
+        "requestKey": { "type": "string" },
+        "destinationThreadId": { "type": "string" },
+        "attemptId": { "type": "string" }
+      }
+    },
+    "capabilityResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "capability"],
+      "properties": {
+        "ok": { "const": true },
+        "capability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "supported",
+            "mode",
+            "runtime",
+            "runtimeVersion",
+            "topology",
+            "evidenceRevision",
+            "exactBoundary",
+            "reason",
+            "context"
+          ],
+          "properties": {
+            "enabled": { "const": true },
+            "supported": { "type": "boolean" },
+            "mode": { "type": ["string", "null"] },
+            "runtime": { "type": ["string", "null"] },
+            "runtimeVersion": { "type": ["string", "null"] },
+            "topology": { "type": ["string", "null"] },
+            "evidenceRevision": { "type": ["string", "null"] },
+            "exactBoundary": { "type": ["object", "null"] },
+            "reason": { "type": ["string", "null"] },
+            "context": { "type": ["object", "null"] }
+          }
+        }
+      }
+    },
+    "sideThreadResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "sideThread"],
+      "properties": {
+        "ok": { "const": true },
+        "sideThread": { "$ref": "#/$defs/sideThread" }
+      }
+    },
+    "sideThreadsResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "sideThreads", "count"],
+      "properties": {
+        "ok": { "const": true },
+        "sideThreads": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/sideThread" }
+        },
+        "count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "bringBackResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "bringBack"],
+      "properties": {
+        "ok": { "const": true },
+        "bringBack": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["bringBackId", "destinationTurnId"],
+          "properties": {
+            "bringBackId": { "type": "string" },
+            "destinationTurnId": { "type": "string" }
+          }
+        }
+      }
+    },
+    "sseEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eventId",
+        "sideThreadId",
+        "attemptId",
+        "threadId",
+        "turnId",
+        "type",
+        "state",
+        "reason",
+        "createdAt"
+      ],
+      "properties": {
+        "eventId": { "type": "integer" },
+        "sideThreadId": { "type": "string" },
+        "attemptId": { "type": ["string", "null"] },
+        "threadId": { "type": ["string", "null"] },
+        "turnId": { "type": ["string", "null"] },
+        "type": { "type": "string" },
+        "state": { "type": ["string", "null"] },
+        "reason": { "type": ["string", "null"] },
+        "createdAt": { "type": "number" }
+      }
+    },
     "error": {
       "type": "object",
       "additionalProperties": false,

--- a/contracts/side-thread/v1/schema.json
+++ b/contracts/side-thread/v1/schema.json
@@ -236,6 +236,12 @@
         }
       }
     },
+    "actionRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requestKey"],
+      "properties": { "requestKey": { "type": "string" } }
+    },
     "bringBackRequest": {
       "type": "object",
       "additionalProperties": false,

--- a/contracts/side-thread/v1/schema.json
+++ b/contracts/side-thread/v1/schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-network.local/contracts/side-thread/v1/schema.json",
+  "title": "CommHub SideThread public HTTP contract v1",
+  "$defs": {
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "turnId"],
+      "properties": {
+        "kind": { "enum": ["through", "before"] },
+        "turnId": { "type": "string" }
+      }
+    },
+    "attachment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fileId"],
+      "properties": { "fileId": { "type": "string" } }
+    },
+    "recordCapability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtime", "runtimeVersion", "topology", "evidenceRevision"],
+      "properties": {
+        "runtime": { "type": ["string", "null"] },
+        "runtimeVersion": { "type": ["string", "null"] },
+        "topology": { "type": ["string", "null"] },
+        "evidenceRevision": { "type": ["string", "null"] }
+      }
+    },
+    "attempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attemptId",
+        "requestKey",
+        "parentAttemptId",
+        "threadId",
+        "turnId",
+        "state",
+        "result",
+        "error",
+        "attachments",
+        "broughtBack",
+        "createdAt",
+        "updatedAt"
+      ],
+      "properties": {
+        "attemptId": { "type": "string" },
+        "requestKey": { "type": "string" },
+        "parentAttemptId": { "type": ["string", "null"] },
+        "threadId": { "type": ["string", "null"] },
+        "turnId": { "type": ["string", "null"] },
+        "state": {
+          "enum": [
+            "starting",
+            "running",
+            "completed",
+            "failed",
+            "cancelled",
+            "ambiguous",
+            "reconciling"
+          ]
+        },
+        "result": { "type": ["string", "null"] },
+        "error": { "type": ["string", "null"] },
+        "attachments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attachment" }
+        },
+        "broughtBack": { "type": "boolean" },
+        "createdAt": { "type": "number" },
+        "updatedAt": { "type": "number" }
+      }
+    },
+    "bringBack": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "bringBackId",
+        "attemptId",
+        "requestKey",
+        "destinationThreadId",
+        "destinationTurnId",
+        "state",
+        "broughtBack",
+        "createdAt",
+        "updatedAt",
+        "completedAt"
+      ],
+      "properties": {
+        "bringBackId": { "type": "string" },
+        "attemptId": { "type": "string" },
+        "requestKey": { "type": "string" },
+        "destinationThreadId": { "type": "string" },
+        "destinationTurnId": { "type": ["string", "null"] },
+        "state": { "enum": ["starting", "completed", "failed"] },
+        "broughtBack": { "type": "boolean" },
+        "createdAt": { "type": "number" },
+        "updatedAt": { "type": "number" },
+        "completedAt": { "type": ["number", "null"] }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operationId",
+        "attemptId",
+        "kind",
+        "requestKey",
+        "state",
+        "threadId",
+        "turnId",
+        "errorCode",
+        "createdAt",
+        "updatedAt"
+      ],
+      "properties": {
+        "operationId": { "type": "string" },
+        "attemptId": { "type": ["string", "null"] },
+        "kind": {
+          "enum": ["fork", "start", "cancel", "archive", "purge", "bring-back"]
+        },
+        "requestKey": { "type": "string" },
+        "state": {
+          "enum": ["pending", "ambiguous", "reconciling", "completed", "failed"]
+        },
+        "threadId": { "type": ["string", "null"] },
+        "turnId": { "type": ["string", "null"] },
+        "errorCode": { "type": ["string", "null"] },
+        "createdAt": { "type": "number" },
+        "updatedAt": { "type": "number" }
+      }
+    },
+    "sideThread": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sideThreadId",
+        "requestKey",
+        "networkId",
+        "nodeId",
+        "sourceThreadId",
+        "question",
+        "title",
+        "boundary",
+        "threadId",
+        "state",
+        "activeAttemptId",
+        "capability",
+        "attachments",
+        "attempts",
+        "bringBacks",
+        "operations",
+        "createdAt",
+        "updatedAt"
+      ],
+      "properties": {
+        "sideThreadId": { "type": "string" },
+        "requestKey": { "type": "string" },
+        "networkId": { "type": "string" },
+        "nodeId": { "type": "string" },
+        "sourceThreadId": { "type": "string" },
+        "question": { "type": "string" },
+        "title": { "type": "string" },
+        "boundary": { "$ref": "#/$defs/boundary" },
+        "threadId": { "type": ["string", "null"] },
+        "state": {
+          "enum": [
+            "creating",
+            "running",
+            "completed",
+            "failed",
+            "cancelled",
+            "ambiguous",
+            "reconciling",
+            "archived",
+            "purged"
+          ]
+        },
+        "activeAttemptId": { "type": ["string", "null"] },
+        "capability": { "$ref": "#/$defs/recordCapability" },
+        "attachments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/attachment" }
+        },
+        "attempts": { "type": "array", "items": { "$ref": "#/$defs/attempt" } },
+        "bringBacks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/bringBack" }
+        },
+        "operations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/operation" }
+        },
+        "createdAt": { "type": "number" },
+        "updatedAt": { "type": "number" }
+      }
+    },
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "error", "message"],
+      "properties": {
+        "ok": { "const": false },
+        "error": { "type": "string" },
+        "message": { "type": "string" },
+        "operationId": { "type": "string" },
+        "sideThreadId": { "type": "string" },
+        "attemptId": { "type": "string" }
+      }
+    }
+  }
+}

--- a/docs/design/side-thread-pr2-hub-contract.md
+++ b/docs/design/side-thread-pr2-hub-contract.md
@@ -1,0 +1,40 @@
+# SideThread PR2 Hub contract
+
+Status: Draft, feature-gated, stacked on PR1 #1194. This change is not an
+authorization to merge or release.
+
+The Hub owns durable SideThread records, attempts, operation receipts,
+bring-back receipts, and metadata-only events. `question_text` and result text
+are returned only through an exact owner/node authorization projection. Audit
+and SSE events contain identifiers, state, and allow-listed reason codes but
+never question/result bodies or runtime exception text.
+
+The runtime boundary is `SideThreadExecutionPort`. It exposes only verified
+native exact-fork operations and has no task/inbox/FIFO method. The default
+adapter returns `SIDE_THREAD_UNSUPPORTED`; the HTTP surface is additionally
+guarded by `COMMHUB_ENABLE_SIDE_THREADS=1`.
+
+Every runtime mutation has a stable `operationId` and a durable operation row.
+An accepted request followed by response loss becomes `ambiguous` and returns
+`SIDE_THREAD_AMBIGUOUS` with correlation IDs. Replaying the same request key
+does not issue a second RPC. A later authoritative event may reconcile an
+ambiguous start using the exact `(sideThreadId, attemptId, threadId, turnId)`
+ownership tuple.
+
+Public wire names and nullability are frozen in
+`contracts/side-thread/v1/schema.json` and `golden.json`. Public JSON uses
+`sideThreadId` and `question`; DB/domain `side_chat_id` names do not leak.
+Only completed bring-back receipts set `broughtBack=true`, and a unique DB
+constraint prevents a second write to the same attempt/destination even when
+the caller supplies a new request key.
+
+The capability endpoint requires the requested source thread and exact
+boundary in addition to the authorized node. A supported response echoes that
+context. This prevents a generic runtime capability from being mistaken for
+evidence that one particular exact-boundary fork is supported.
+
+Stack dependency: PR1 rev4 supplies the native runtime adapter's persistent
+fork lease, pre-fork snapshot/reconciliation, and runtime operation journal.
+PR2 remains decoupled through the execution port; production wiring must map
+the Hub's stable operation identity into that adapter and must never substitute
+ordinary task delivery.

--- a/docs/design/side-thread-pr2-hub-contract.md
+++ b/docs/design/side-thread-pr2-hub-contract.md
@@ -28,6 +28,13 @@ Only completed bring-back receipts set `broughtBack=true`, and a unique DB
 constraint prevents a second write to the same attempt/destination even when
 the caller supplies a new request key.
 
+Purge erases all persisted free-form content: the root question, root and
+per-attempt attachment references, attempt result/error text, and any
+bring-back error text. It intentionally retains identifiers, timestamps,
+state, hashes, completed bring-back receipts, and allow-listed operation/event
+codes so lifecycle replay and audit remain durable without retaining readable
+user content.
+
 The capability endpoint requires the requested source thread and exact
 boundary in addition to the authorized node. A supported response echoes that
 context. This prevents a generic runtime capability from being mistaken for

--- a/docs/tests/report-test1195-side-thread-hub.txt
+++ b/docs/tests/report-test1195-side-thread-hub.txt
@@ -1,12 +1,12 @@
 SideThread Hub PR2 Docker evidence
 Date: 2026-08-26 Asia/Shanghai
-Tested source commit: 72fe67b983c390e77cb81a461739886b4e85cb61
+Tested source commit: a07effabd9e5b752e9a094681d52af5c6f646284
 Stack base: c0981ecc26b8b570ff29a30da2d926fdc8ec4a09 (PR #1194 rev4)
 
 Layer 1 — contract
   image: anet-test1195-contract-final
   result: PASS
-  tests: 7 pass, 0 fail, 30 assertions
+  tests: 7 pass, 0 fail, 31 assertions
   witnessed-red: native exact-fork mode gate mutation rejected
   includes schema/golden projection drift check
 
@@ -27,7 +27,7 @@ Layer 3 — races/faults
   uniqueness, response-loss ambiguity/reconciliation, and no-repeat
   cancel/archive/purge RPCs
 
-Total final Docker evidence: 21 pass, 0 fail, 109 assertions, 3 witnessed-red.
+Total final Docker evidence: 21 pass, 0 fail, 110 assertions, 3 witnessed-red.
 
 Preflight:
   check-test-suite-registration.py PASS (no new unregistered suite)

--- a/docs/tests/report-test1195-side-thread-hub.txt
+++ b/docs/tests/report-test1195-side-thread-hub.txt
@@ -1,17 +1,18 @@
 SideThread Hub PR2 Docker evidence
 Date: 2026-08-26 Asia/Shanghai
-Tested source commit: a07effabd9e5b752e9a094681d52af5c6f646284
+Tested source commit: 0744c312f9188278f243d4266ddd8acab8493c7b
 Stack base: c0981ecc26b8b570ff29a30da2d926fdc8ec4a09 (PR #1194 rev4)
 
 Layer 1 — contract
-  image: anet-test1195-contract-final
+  image: anet-test1195-contract-actions
   result: PASS
-  tests: 7 pass, 0 fail, 31 assertions
+  tests: 8 pass, 0 fail, 35 assertions
   witnessed-red: native exact-fork mode gate mutation rejected
-  includes schema/golden projection drift check
+  includes schema/golden projection drift check and caller requestKey coverage
+  for every mutating POST action
 
 Layer 2 — auth/SSE security
-  image: anet-test1195-security-final
+  image: anet-test1195-security-actions
   result: PASS
   tests: 5 pass, 0 fail, 19 assertions
   witnessed-red: query-string token acceptance mutation rejected
@@ -19,7 +20,7 @@ Layer 2 — auth/SSE security
   and no-FIFO unsupported behavior
 
 Layer 3 — races/faults
-  image: anet-test1195-race-final
+  image: anet-test1195-race-actions
   result: PASS
   tests: 9 pass, 0 fail, 60 assertions
   witnessed-red: weakened four-tuple runtime event ownership mutation rejected
@@ -27,7 +28,14 @@ Layer 3 — races/faults
   uniqueness, response-loss ambiguity/reconciliation, and no-repeat
   cancel/archive/purge RPCs
 
-Total final Docker evidence: 21 pass, 0 fail, 110 assertions, 3 witnessed-red.
+Total final Docker evidence: 22 pass, 0 fail, 114 assertions, 3 witnessed-red.
+
+Complete server unit domain:
+  image: anet-test798-pr1196-actions
+  result: PASS
+  discovered/executed files: 74/74, failed files: 0
+  witnessed-red: weakened registration password floor rejected
+  confirms the schema/golden fixture is present in the CI image
 
 Preflight:
   check-test-suite-registration.py PASS (no new unregistered suite)

--- a/docs/tests/report-test1195-side-thread-hub.txt
+++ b/docs/tests/report-test1195-side-thread-hub.txt
@@ -37,6 +37,16 @@ Complete server unit domain:
   witnessed-red: weakened registration password floor rejected
   confirms the schema/golden fixture is present in the CI image
 
+Aggregate isolation CI image:
+  image: anet-test638-pr1196-exact
+  tested fix commit: c207d3538d4f28d774f165c9eebac46ae732772c
+  result: PASS
+  aggregate: 74 files, 984 pass, 0 fail, 3235 assertions
+  covers normal/reverse concurrent aggregate order, syscall DB isolation,
+  nonzero/timeout/signal/missing-summary/spawn/slug witnessed-red, and the
+  per-file DB isolation mutation
+  root cause fixed: test638 now explicitly copies contracts/side-thread/v1
+
 Preflight:
   check-test-suite-registration.py PASS (no new unregistered suite)
   check-l1-paths-sync.py PASS

--- a/docs/tests/report-test1195-side-thread-hub.txt
+++ b/docs/tests/report-test1195-side-thread-hub.txt
@@ -1,0 +1,42 @@
+SideThread Hub PR2 Docker evidence
+Date: 2026-08-26 Asia/Shanghai
+Tested source commit: 72fe67b983c390e77cb81a461739886b4e85cb61
+Stack base: c0981ecc26b8b570ff29a30da2d926fdc8ec4a09 (PR #1194 rev4)
+
+Layer 1 — contract
+  image: anet-test1195-contract-final
+  result: PASS
+  tests: 7 pass, 0 fail, 30 assertions
+  witnessed-red: native exact-fork mode gate mutation rejected
+  includes schema/golden projection drift check
+
+Layer 2 — auth/SSE security
+  image: anet-test1195-security-final
+  result: PASS
+  tests: 5 pass, 0 fail, 19 assertions
+  witnessed-red: query-string token acceptance mutation rejected
+  covers owner hydration, opaque cross-owner reads, node binding, metadata-only SSE,
+  and no-FIFO unsupported behavior
+
+Layer 3 — races/faults
+  image: anet-test1195-race-final
+  result: PASS
+  tests: 9 pass, 0 fail, 60 assertions
+  witnessed-red: weakened four-tuple runtime event ownership mutation rejected
+  covers terminal-before-ACK, cross-coordinator claims, retry lineage, bring-back
+  uniqueness, response-loss ambiguity/reconciliation, and no-repeat
+  cancel/archive/purge RPCs
+
+Total final Docker evidence: 21 pass, 0 fail, 109 assertions, 3 witnessed-red.
+
+Preflight:
+  check-test-suite-registration.py PASS (no new unregistered suite)
+  check-l1-paths-sync.py PASS
+  lint-no-bare-rm-rf.sh PASS
+  git diff --check PASS
+  server.ts minimal diff: 83 additions, 0 deletions ignoring EOL whitespace
+
+An earlier race image attempt failed before test collection because its
+Dockerfile omitted the vendored golden fixture. Commit 72fe67b9 added that
+explicit COPY; all three layers above were then rebuilt and rerun against the
+same exact source commit. No failed pre-fix run is counted as evidence.

--- a/docs/tests/report-test1195-side-thread-hub.txt
+++ b/docs/tests/report-test1195-side-thread-hub.txt
@@ -58,3 +58,16 @@ An earlier race image attempt failed before test collection because its
 Dockerfile omitted the vendored golden fixture. Commit 72fe67b9 added that
 explicit COPY; all three layers above were then rebuilt and rerun against the
 same exact source commit. No failed pre-fix run is counted as evidence.
+
+Rebase + purge regression follow-up (2026-08-26 Asia/Shanghai):
+  code/test commit: 6c3c50a01276a70beb26a673a7ac8a2944c9c137
+  rebase base: 57bd606d52129d2a78360dda2dd68e8c968541bd (merged PR #1194)
+  provenance: old PR2 9a074ccb..new PR2 96c131ff is 9/9 patch-equivalent;
+              the two final trees are byte-identical
+  contract Docker: 8 pass, 0 fail, 35 assertions
+  security Docker: 5 pass, 0 fail, 19 assertions
+  race Docker: 9 pass, 0 fail, 62 assertions
+  witnessed-red: 4 total, including removal of per-attempt attachment purge
+  aggregate Docker: 74 files, 984 pass, 0 fail, 3237 assertions
+  purge boundary: readable question/result/error and root/per-attempt file
+                  references are erased; durable identity/audit receipts remain

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -64,6 +64,11 @@ L1_TESTS=(
   # RFC-036 PR1: credential-free SideThread state machine + Codex adapter
   # contract. Exact-version fail-closed has a witnessed-red mutation.
   "test1193-side-thread-contract"
+  # #175 PR2: Hub contract, authenticated HTTP/SSE security, and lifecycle
+  # races are separate Docker layers. Each has its own witnessed-red mutation.
+  "test1195-side-thread-hub-contract"
+  "test1195-side-thread-hub-security"
+  "test1195-side-thread-hub-race"
   "qa-cli-01-hub-start"
   "qa-cli-02-network-create"
   "qa-dash-07-auth-boundary"

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -48,6 +48,8 @@ import { diagnoseTask } from "./task-diagnostic.js";
 import { assertScheduledTaskBackendSupported, handleScheduledTaskRequest, startScheduledTaskScheduler } from "./scheduled-tasks.js";
 import { handleExternalScheduleEditRequest } from "./external-schedule-edits.js";
 import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
+import { SIDE_THREAD_FEATURE_FLAG, SideThreadCoordinator, SideThreadPortRegistry, SideThreadStore, type SideThreadActor, type SideThreadAttachmentRef, type SideThreadExecutionPort } from "./side-thread.js";
+import { handleSideThreadHttpRequest } from "./side-thread-http.js";
 
 const PORT = resolvePort(process.env.PORT);
 const HOST = process.env.HOST || "127.0.0.1";
@@ -62,6 +64,18 @@ const TMUX_ALLOWLIST = new Set(
     .filter(Boolean)
 );
 let masterTokenDeprecationLogged = false;
+
+// #175 PR2 starts fail-closed. Only a verified native adapter can be installed;
+// the execution port deliberately has no ordinary task/FIFO delivery method.
+export const sideThreadPortRegistry = new SideThreadPortRegistry();
+export function installSideThreadExecutionPort(port: SideThreadExecutionPort): () => void {
+  return sideThreadPortRegistry.install(port);
+}
+const sideThreadCoordinator = new SideThreadCoordinator(new SideThreadStore(db), sideThreadPortRegistry, {
+  enabled: process.env[SIDE_THREAD_FEATURE_FLAG] === "1",
+  authorizeNode: (actor, networkId, nodeId) => authorizeSideThreadNode(actor, networkId, nodeId),
+  authorizeAttachment: (actor, networkId, ref) => authorizeSideThreadAttachment(actor, networkId, ref),
+});
 
 if (AUTH_TOKEN) {
   console.warn("[commhub] COMMHUB_AUTH_TOKEN is deprecated and will be removed in v1.0. See RFC-001.");
@@ -235,6 +249,25 @@ function resolveRequestAuth(req: Request, options: RequestTokenOptions = {}): { 
   return { userId: resolved.user.user_id, networkId: resolved.networkId, username: resolved.user.username, tokenName: resolved.tokenName, tokenId: resolved.tokenId };
 }
 
+function resolveSideThreadActor(req: Request, auth: ReturnType<typeof resolveRequestAuth>, isAdmin: boolean): SideThreadActor | null {
+  // Legacy master and DEV_OPEN cannot own durable records because neither
+  // supplies a stable per-user identity for later window hydration.
+  if (!auth?.userId || !auth.tokenId) return null;
+  const nodeCredential = requestToken(req).startsWith("ntok_");
+  const tokenRow = nodeCredential
+    ? db.get<{ bound_node_id: string | null }>("SELECT bound_node_id FROM api_tokens WHERE token_id = ?1", auth.tokenId)
+    : null;
+  return {
+    userId: auth.userId,
+    username: auth.username,
+    tokenId: auth.tokenId,
+    kind: nodeCredential ? "node" : "user",
+    ...(auth.networkId ? { boundNetworkId: auth.networkId } : {}),
+    ...(tokenRow?.bound_node_id ? { boundNodeId: tokenRow.bound_node_id } : {}),
+    isAdmin,
+  };
+}
+
 // #503 — the credential kinds that authorization decisions branch on.
 // Resolved once per request at the handler, so the authz helpers stay
 // pure functions of (principal, entry) and every credential kind is a
@@ -335,6 +368,46 @@ export function authorizeFileDownload(
   // tightening the local-dev carve-out.
   if (entry.ownerId === null && DEV_OPEN) return true;
   return false;
+}
+
+function authorizeSideThreadNode(actor: SideThreadActor, networkId: string, nodeId: string): boolean {
+  const node = db.get<{ network_id: string | null; owner_user_id: string | null }>(
+    "SELECT network_id, owner_user_id FROM nodes WHERE node_id = ?1", nodeId,
+  );
+  if (!node || node.network_id !== networkId) return false;
+  if (!getUserNetworkRole(actor.userId, networkId)) return false;
+  if (!node.owner_user_id || node.owner_user_id !== actor.userId) return false;
+  if (actor.boundNetworkId && actor.boundNetworkId !== networkId) return false;
+  if (actor.kind === "node" && actor.boundNodeId !== nodeId) return false;
+  return true;
+}
+
+function resolveSideThreadCapabilityTarget(input: { actor: SideThreadActor; alias?: string; nodeId?: string; networkId?: string }): { nodeId: string; networkId: string } | undefined {
+  if ((!input.alias && !input.nodeId) || (input.alias && input.nodeId)) return undefined;
+  const networkId = input.actor.boundNetworkId ?? input.networkId;
+  const params: unknown[] = [input.nodeId ?? input.alias];
+  let sql = input.nodeId
+    ? "SELECT node_id,network_id FROM nodes WHERE node_id=?1"
+    : "SELECT node_id,network_id FROM nodes WHERE alias=?1";
+  if (networkId) { params.push(networkId); sql += " AND network_id=?2"; }
+  const authorized = db.all<{ node_id: string; network_id: string | null }>(sql, ...params)
+    .filter(row => !!row.network_id && authorizeSideThreadNode(input.actor, row.network_id, row.node_id));
+  if (authorized.length !== 1) return undefined;
+  return { nodeId: authorized[0].node_id, networkId: authorized[0].network_id! };
+}
+
+function authorizeSideThreadAttachment(actor: SideThreadActor, networkId: string, ref: SideThreadAttachmentRef): boolean {
+  if (!FILE_ID_REGEX.test(ref.fileId)) return false;
+  const path = indexEntryPath(ref.fileId);
+  if (!path || !existsSync(path)) return false;
+  try {
+    const entry = JSON.parse(readFileSync(path, "utf8"));
+    if (!validateIndexEntry(entry) || entry.file_id !== ref.fileId) return false;
+    if (entry.network_id !== networkId || entry.owner_id !== actor.userId) return false;
+    if (!isValidCalendarBucket(entry.date_bucket)) return false;
+    const storage = pathForExistingBlob(entry.date_bucket, entry.file_id, entry.ext);
+    return isPathInsideUploadsRoot(storage.absolutePath) && existsSync(storage.absolutePath);
+  } catch { return false; }
 }
 
 type ByteRange =
@@ -1442,6 +1515,16 @@ return Bun.serve({
     if (restScope.denied) {
       return withCors(req, Response.json({ ok: false, error: restScope.denied }, { status: 403 }));
     }
+
+    const sideThreadResponse = await handleSideThreadHttpRequest({
+      req,
+      url,
+      // Durable prompts/results never accept query-string credentials.
+      actor: resolveSideThreadActor(req, resolveRequestAuth(req, { allowQueryToken: false }), isAdmin),
+      coordinator: sideThreadCoordinator,
+      resolveCapabilityTarget: resolveSideThreadCapabilityTarget,
+    });
+    if (sideThreadResponse) return withCors(req, sideThreadResponse);
 
     // RFC-036 owner-gated host schedule edits. This handler independently
     // verifies exact node ownership and node-token binding; network admin is

--- a/server/src/side-thread-http-integration.test.ts
+++ b/server/src/side-thread-http-integration.test.ts
@@ -1,0 +1,229 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  SideThreadExecutionPort,
+  SideThreadRuntimeEvent,
+} from "./side-thread.js";
+
+const suffix = randomUUID().replace(/-/g, "");
+const dbPath = `/tmp/anet-side-thread-http-${suffix}.db`;
+const ownerToken = `utok_${suffix}`;
+const otherToken = `utok_other_${suffix}`;
+const nodeToken = `ntok_${suffix}`;
+let hub: any;
+let db: any;
+let detachPort: () => void = () => {};
+let base = "";
+
+class HttpFakePort implements SideThreadExecutionPort {
+  listeners = new Set<(event: SideThreadRuntimeEvent) => void>();
+  capability() {
+    return {
+      supported: true,
+      mode: "native-exact-fork" as const,
+      runtime: "codex",
+      runtimeVersion: "0.148.0",
+      topology: "owned-stdio",
+      evidenceRevision: "reviewed",
+      exactBoundary: { through: true, before: true },
+    };
+  }
+  async fork(input: any) {
+    return { threadId: `derived_${input.sideChatId}` };
+  }
+  async start(input: any) {
+    return { turnId: `turn_${input.attemptId}` };
+  }
+  async cancel() {}
+  async archive() {}
+  async purge() {}
+  async bringBack() {
+    return { destinationTurnId: "destination_turn" };
+  }
+  subscribe(listener: (event: SideThreadRuntimeEvent) => void) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+}
+
+function hash(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+function headers(token = ownerToken) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.COMMHUB_DB = dbPath;
+  process.env.COMMHUB_ENABLE_SIDE_THREADS = "1";
+  delete process.env.DATABASE_URL;
+  const dbModule = await import("./db.js");
+  db = dbModule.db;
+  db.run(
+    "INSERT INTO users (user_id,username,password_hash,role) VALUES ('usr_owner','owner','x','user')",
+  );
+  db.run(
+    "INSERT INTO users (user_id,username,password_hash,role) VALUES ('usr_other','other','x','user')",
+  );
+  db.run(
+    "INSERT INTO networks (network_id,network_name,owner_id) VALUES ('net_a','A','usr_owner')",
+  );
+  db.run(
+    "INSERT INTO network_members (network_id,user_id,role) VALUES ('net_a','usr_owner','owner')",
+  );
+  db.run(
+    "INSERT INTO network_members (network_id,user_id,role) VALUES ('net_a','usr_other','member')",
+  );
+  db.run(
+    "INSERT INTO nodes (node_id,node_name,alias,network_id,owner_user_id) VALUES ('node_a','node-a','node-a','net_a','usr_owner')",
+  );
+  db.run(
+    "INSERT INTO nodes (node_id,node_name,alias,network_id,owner_user_id) VALUES ('node_b','node-b','node-b','net_a','usr_owner')",
+  );
+  db.run(
+    "INSERT INTO api_tokens (token_id,token_hash,user_id,name,scope) VALUES ('tok_owner',?1,'usr_owner','owner','user')",
+    [hash(ownerToken)],
+  );
+  db.run(
+    "INSERT INTO api_tokens (token_id,token_hash,user_id,name,scope) VALUES ('tok_other',?1,'usr_other','other','user')",
+    [hash(otherToken)],
+  );
+  db.run(
+    "INSERT INTO api_tokens (token_id,token_hash,user_id,network_id,name,scope,bound_node_id) VALUES ('tok_node',?1,'usr_owner','net_a','node:node-a','network','node_a')",
+    [hash(nodeToken)],
+  );
+  const serverModule = await import("./server.js");
+  detachPort = serverModule.installSideThreadExecutionPort(new HttpFakePort());
+  hub = serverModule.bootServer({ port: 0, hostname: "127.0.0.1" });
+  base = `http://127.0.0.1:${hub.port}`;
+});
+
+afterAll(() => {
+  detachPort();
+  try {
+    hub?.stop(true);
+  } catch {}
+  try {
+    db?.close();
+  } catch {}
+});
+
+describe("SideThread authenticated Hub HTTP", () => {
+  let sideChatId = "";
+  test("POST create and GET hydrate the complete question", async () => {
+    const response = await fetch(`${base}/api/side-threads`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        requestKey: "http-create-0001",
+        networkId: "net_a",
+        nodeId: "node_a",
+        sourceThreadId: "source_thread",
+        boundary: { kind: "through", turnId: "source_turn" },
+        prompt: "完整原问题\n第二行",
+      }),
+    });
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as any;
+    sideChatId = body.sideThread.sideThreadId;
+    expect(body.sideThread).toMatchObject({
+      requestKey: "http-create-0001",
+      question: "完整原问题\n第二行",
+      title: "完整原问题",
+      state: "running",
+    });
+    const hydrated = await fetch(`${base}/api/side-threads/${sideChatId}`, {
+      headers: headers(),
+    });
+    expect(((await hydrated.json()) as any).sideThread.question).toBe(
+      "完整原问题\n第二行",
+    );
+    const listed = await fetch(
+      `${base}/api/side-threads?network_id=net_a&limit=20`,
+      { headers: headers() },
+    );
+    expect(await listed.json()).toMatchObject({
+      count: 1,
+      sideThreads: [{ question: "完整原问题\n第二行", bringBacks: [] }],
+    });
+  });
+
+  test("cross-owner and query-token reads cannot recover the question", async () => {
+    const cross = await fetch(`${base}/api/side-threads/${sideChatId}`, {
+      headers: headers(otherToken),
+    });
+    expect(cross.status).toBe(404);
+    expect(JSON.stringify(await cross.json())).not.toContain("完整原问题");
+    const crossList = await fetch(`${base}/api/side-threads`, {
+      headers: headers(otherToken),
+    });
+    const crossListBody = await crossList.json();
+    expect(crossListBody).toMatchObject({ count: 0, sideThreads: [] });
+    expect(JSON.stringify(crossListBody)).not.toContain("完整原问题");
+    const queryOnly = await fetch(
+      `${base}/api/side-threads/${sideChatId}?token=${ownerToken}`,
+    );
+    expect(queryOnly.status).toBe(401);
+  });
+
+  test("SSE replays metadata without question/result bodies", async () => {
+    const response = await fetch(
+      `${base}/api/side-threads/${sideChatId}/events`,
+      { headers: { Authorization: `Bearer ${ownerToken}` } },
+    );
+    expect(response.status).toBe(200);
+    const reader = response.body!.getReader();
+    const chunk = await reader.read();
+    const text = new TextDecoder().decode(chunk.value);
+    await reader.cancel();
+    expect(text).toContain("side_thread");
+    expect(text).toContain("sideThreadId");
+    expect(text).not.toContain("sideChatId");
+    expect(text).not.toContain("完整原问题");
+  });
+
+  test("node token is bound to its exact node", async () => {
+    const response = await fetch(`${base}/api/side-threads`, {
+      method: "POST",
+      headers: headers(nodeToken),
+      body: JSON.stringify({
+        request_key: "http-create-node2",
+        network_id: "net_a",
+        node_id: "node_b",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "must fail",
+      }),
+    });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error: "SIDE_THREAD_NOT_FOUND",
+    });
+  });
+
+  test("removing the verified port yields typed unsupported, never a task row", async () => {
+    detachPort();
+    const before = db.get("SELECT COUNT(*) AS n FROM tasks").n;
+    const response = await fetch(`${base}/api/side-threads`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({
+        request_key: "http-no-port-01",
+        network_id: "net_a",
+        node_id: "node_a",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "no fallback",
+      }),
+    });
+    expect(response.status).toBe(501);
+    expect(await response.json()).toMatchObject({
+      error: "SIDE_THREAD_UNSUPPORTED",
+    });
+    expect(db.get("SELECT COUNT(*) AS n FROM tasks").n).toBe(before);
+  });
+});

--- a/server/src/side-thread-http.ts
+++ b/server/src/side-thread-http.ts
@@ -1,0 +1,503 @@
+import {
+  SIDE_THREAD_API_ACTIONS,
+  SIDE_THREAD_API_ROOT,
+  SideThreadCoordinator,
+  SideThreadError,
+  type SideThreadActor,
+  type SideThreadRecord,
+} from "./side-thread.js";
+
+export interface SideThreadHttpContext {
+  req: Request;
+  url: URL;
+  actor: SideThreadActor | null;
+  coordinator: SideThreadCoordinator;
+  resolveCapabilityTarget?: (input: {
+    actor: SideThreadActor;
+    alias?: string;
+    nodeId?: string;
+    networkId?: string;
+  }) => { nodeId: string; networkId: string } | undefined;
+}
+
+export async function handleSideThreadHttpRequest(
+  ctx: SideThreadHttpContext,
+): Promise<Response | null> {
+  const root = ctx.url.pathname === SIDE_THREAD_API_ROOT;
+  const capabilityPath =
+    ctx.url.pathname === `${SIDE_THREAD_API_ROOT}/capability`;
+  const match = ctx.url.pathname.match(
+    new RegExp(
+      `^${SIDE_THREAD_API_ROOT}/([^/]+)(?:/(${SIDE_THREAD_API_ACTIONS.join("|")}))?$`,
+    ),
+  );
+  if (!root && !capabilityPath && !match) return null;
+  if (!ctx.coordinator.isEnabled())
+    return json({ ok: false, error: "SIDE_THREAD_DISABLED" }, 404);
+  if (!ctx.actor)
+    return json({ ok: false, error: "SIDE_THREAD_AUTH_REQUIRED" }, 401);
+
+  try {
+    if (capabilityPath) {
+      if (ctx.req.method !== "GET") return methodNotAllowed("GET");
+      const target = ctx.resolveCapabilityTarget?.({
+        actor: ctx.actor,
+        alias: query(ctx.url, "alias"),
+        nodeId: query(ctx.url, "nodeId", "node_id"),
+        networkId: query(ctx.url, "networkId", "network_id"),
+      });
+      if (!target)
+        throw new SideThreadError(
+          "SIDE_THREAD_NOT_FOUND",
+          "node not found",
+          404,
+        );
+      const sourceThreadId = requiredQueryIdentity(ctx.url, "sourceThreadId");
+      const boundaryKind = query(ctx.url, "boundaryKind");
+      const boundaryTurnId = requiredQueryIdentity(ctx.url, "boundaryTurnId");
+      if (boundaryKind !== "through" && boundaryKind !== "before")
+        throw new SideThreadError(
+          "SIDE_THREAD_INVALID_CONTEXT",
+          "boundaryKind must be through or before",
+          400,
+        );
+      const boundary = { kind: boundaryKind, turnId: boundaryTurnId } as const;
+      const capability = await ctx.coordinator.capability(
+        ctx.actor,
+        target.networkId,
+        target.nodeId,
+        boundary,
+      );
+      return json({
+        ok: true,
+        capability: serializeCapability(capability, {
+          networkId: target.networkId,
+          nodeId: target.nodeId,
+          sourceThreadId,
+          boundary,
+        }),
+      });
+    }
+    if (root && ctx.req.method === "GET") {
+      const rawLimit = ctx.url.searchParams.get("limit");
+      const limit = rawLimit === null ? undefined : parseLimit(rawLimit);
+      if (rawLimit !== null && limit === null)
+        throw new SideThreadError(
+          "SIDE_THREAD_INVALID_LIMIT",
+          "invalid list limit",
+          400,
+        );
+      const records = ctx.coordinator.list(ctx.actor, {
+        networkId: query(ctx.url, "networkId", "network_id"),
+        nodeId: query(ctx.url, "nodeId", "node_id"),
+        limit: limit ?? undefined,
+      });
+      return json({
+        ok: true,
+        sideThreads: records.map(serialize),
+        count: records.length,
+      });
+    }
+    if (root && ctx.req.method === "POST") {
+      const body = await requestJson(ctx.req);
+      const record = await ctx.coordinator.create(ctx.actor, {
+        requestKey: field(body, "requestKey", "request_key"),
+        networkId: field(body, "networkId", "network_id"),
+        nodeId: field(body, "nodeId", "node_id"),
+        sourceThreadId: field(body, "sourceThreadId", "source_thread_id"),
+        boundary: {
+          kind: body.boundary?.kind,
+          turnId: field(body.boundary, "turnId", "turn_id"),
+        },
+        prompt: field(body, "question", "prompt"),
+        attachments: mapAttachments(body.attachments),
+      });
+      return json({ ok: true, sideThread: serialize(record) }, 201);
+    }
+    if (root) return methodNotAllowed("GET, POST");
+
+    const sideChatId = decodeSegment(match![1]);
+    const action = match![2];
+    if (!action && ctx.req.method === "GET") {
+      return json({
+        ok: true,
+        sideThread: serialize(ctx.coordinator.get(ctx.actor, sideChatId)),
+      });
+    }
+    if (!action) return methodNotAllowed("GET");
+
+    if (action === "events" && ctx.req.method === "GET") {
+      // Authorize before opening a long-lived stream. A non-owner gets the
+      // same 404 as an unknown id and cannot infer another user's side chat.
+      ctx.coordinator.get(ctx.actor, sideChatId);
+      const headerCursor = ctx.req.headers.get("Last-Event-ID");
+      const queryCursor = ctx.url.searchParams.get("after");
+      const after = parseCursor(headerCursor ?? queryCursor);
+      if (after === null)
+        throw new SideThreadError(
+          "SIDE_THREAD_INVALID_CURSOR",
+          "invalid event cursor",
+          400,
+        );
+      return sideThreadEventStream(
+        ctx.coordinator,
+        ctx.actor,
+        sideChatId,
+        after,
+      );
+    }
+
+    if (ctx.req.method !== "POST") return methodNotAllowed("POST");
+    if (action === "cancel") {
+      return json({
+        ok: true,
+        sideThread: serialize(
+          await ctx.coordinator.cancel(ctx.actor, sideChatId),
+        ),
+      });
+    }
+    if (action === "archive") {
+      return json({
+        ok: true,
+        sideThread: serialize(
+          await ctx.coordinator.archive(ctx.actor, sideChatId),
+        ),
+      });
+    }
+    if (action === "purge") {
+      return json({
+        ok: true,
+        sideThread: serialize(
+          await ctx.coordinator.purge(ctx.actor, sideChatId),
+        ),
+      });
+    }
+    const body = await requestJson(ctx.req);
+    if (action === "retry") {
+      return json({
+        ok: true,
+        sideThread: serialize(
+          await ctx.coordinator.retry(ctx.actor, sideChatId, {
+            requestKey: field(body, "requestKey", "request_key"),
+            prompt: field(body, "question", "prompt"),
+            attachments:
+              body.attachments === undefined
+                ? undefined
+                : mapAttachments(body.attachments),
+          }),
+        ),
+      });
+    }
+    const broughtBack = await ctx.coordinator.bringBack(ctx.actor, sideChatId, {
+      requestKey: field(body, "requestKey", "request_key"),
+      destinationThreadId: field(
+        body,
+        "destinationThreadId",
+        "destination_thread_id",
+      ),
+      attemptId: field(body, "attemptId", "attempt_id"),
+    });
+    return json({ ok: true, bringBack: broughtBack });
+  } catch (error) {
+    if (error instanceof SideThreadError) {
+      return json(
+        {
+          ok: false,
+          error: error.code,
+          message: error.message,
+          ...(error.operationId ? { operationId: error.operationId } : {}),
+          ...(error.sideChatId ? { sideThreadId: error.sideChatId } : {}),
+          ...(error.attemptId ? { attemptId: error.attemptId } : {}),
+        },
+        error.status,
+      );
+    }
+    return json({ ok: false, error: "SIDE_THREAD_INTERNAL_ERROR" }, 500);
+  }
+}
+
+function serialize(record: SideThreadRecord) {
+  const completedBringBackAttempts = new Set(
+    record.bringBacks
+      .filter((receipt) => receipt.state === "completed")
+      .map((receipt) => receipt.attemptId),
+  );
+  return {
+    sideThreadId: record.sideChatId,
+    requestKey: record.requestKey,
+    networkId: record.networkId,
+    nodeId: record.nodeId,
+    sourceThreadId: record.sourceThreadId,
+    question: record.question,
+    title: record.question.split(/\r?\n/, 1)[0].slice(0, 120),
+    boundary: { kind: record.boundary.kind, turnId: record.boundary.turnId },
+    threadId: record.threadId ?? null,
+    state: record.state,
+    activeAttemptId: record.activeAttemptId ?? null,
+    capability: {
+      runtime: record.runtime ?? null,
+      runtimeVersion: record.runtimeVersion ?? null,
+      topology: record.topology ?? null,
+      evidenceRevision: record.evidenceRevision ?? null,
+    },
+    attachments: record.attachments.map((a) => ({ fileId: a.fileId })),
+    attempts: record.attempts.map((a) => ({
+      attemptId: a.attemptId,
+      requestKey: a.requestKey,
+      parentAttemptId: a.parentAttemptId ?? null,
+      threadId: a.threadId ?? null,
+      turnId: a.turnId ?? null,
+      state: a.state,
+      result: a.result ?? null,
+      error: a.error ?? null,
+      attachments: a.attachments.map((attachment) => ({
+        fileId: attachment.fileId,
+      })),
+      broughtBack: completedBringBackAttempts.has(a.attemptId),
+      createdAt: a.createdAt,
+      updatedAt: a.updatedAt,
+    })),
+    bringBacks: record.bringBacks.map((receipt) => ({
+      bringBackId: receipt.bringBackId,
+      attemptId: receipt.attemptId,
+      requestKey: receipt.requestKey,
+      destinationThreadId: receipt.destinationThreadId,
+      destinationTurnId: receipt.destinationTurnId ?? null,
+      state: receipt.state,
+      broughtBack: receipt.state === "completed",
+      createdAt: receipt.createdAt,
+      updatedAt: receipt.updatedAt,
+      completedAt: receipt.completedAt ?? null,
+    })),
+    operations: record.operations.map((operation) => ({
+      operationId: operation.operationId,
+      attemptId: operation.attemptId ?? null,
+      kind: operation.kind,
+      requestKey: operation.requestKey,
+      state: operation.state,
+      threadId: operation.threadId ?? null,
+      turnId: operation.turnId ?? null,
+      errorCode: operation.errorCode ?? null,
+      createdAt: operation.createdAt,
+      updatedAt: operation.updatedAt,
+    })),
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+function serializeCapability(
+  capability: Awaited<ReturnType<SideThreadCoordinator["capability"]>>,
+  context: {
+    networkId: string;
+    nodeId: string;
+    sourceThreadId: string;
+    boundary: { kind: "through" | "before"; turnId: string };
+  },
+) {
+  return {
+    enabled: true,
+    supported: capability.supported,
+    mode: capability.mode ?? null,
+    runtime: capability.runtime ?? null,
+    runtimeVersion: capability.runtimeVersion ?? null,
+    topology: capability.topology ?? null,
+    evidenceRevision: capability.evidenceRevision ?? null,
+    exactBoundary: capability.exactBoundary ?? null,
+    reason: capability.reason ?? null,
+    context: capability.supported ? context : null,
+  };
+}
+
+function sideThreadEventStream(
+  coordinator: SideThreadCoordinator,
+  actor: SideThreadActor,
+  sideChatId: string,
+  after: number,
+): Response {
+  const encoder = new TextEncoder();
+  let unsubscribe = () => {};
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  let closed = false;
+  const cleanup = () => {
+    if (closed) return;
+    closed = true;
+    unsubscribe();
+    if (heartbeat) clearInterval(heartbeat);
+  };
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      start(controller) {
+        const send = (
+          event: ReturnType<SideThreadCoordinator["listEvents"]>[number],
+        ) => {
+          if (closed) return;
+          if ((controller.desiredSize ?? -262_145) < -262_144) {
+            cleanup();
+            try {
+              controller.close();
+            } catch {}
+            return;
+          }
+          try {
+            controller.enqueue(
+              encoder.encode(
+                `id: ${event.eventId}\nevent: side_thread\ndata: ${JSON.stringify(serializeEvent(event))}\n\n`,
+              ),
+            );
+          } catch {
+            cleanup();
+          }
+        };
+        for (const event of coordinator.listEvents(actor, sideChatId, after))
+          send(event);
+        if (closed) return;
+        unsubscribe = coordinator.subscribe(sideChatId, send);
+        heartbeat = setInterval(() => {
+          if ((controller.desiredSize ?? -262_145) < -262_144) {
+            cleanup();
+            try {
+              controller.close();
+            } catch {}
+            return;
+          }
+          try {
+            controller.enqueue(encoder.encode(": keepalive\n\n"));
+          } catch {
+            cleanup();
+          }
+        }, 30_000);
+      },
+      cancel() {
+        cleanup();
+      },
+    },
+    { highWaterMark: 64 * 1024, size: (chunk) => chunk.byteLength },
+  );
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+function serializeEvent(
+  event: ReturnType<SideThreadCoordinator["listEvents"]>[number],
+) {
+  return {
+    eventId: event.eventId,
+    sideThreadId: event.sideChatId,
+    attemptId: event.attemptId ?? null,
+    threadId: event.threadId ?? null,
+    turnId: event.turnId ?? null,
+    type: event.type,
+    state: event.state ?? null,
+    reason: event.reason ?? null,
+    createdAt: event.createdAt,
+  };
+}
+
+function mapAttachments(value: unknown): Array<{ fileId: string }> | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value))
+    throw new SideThreadError(
+      "SIDE_THREAD_CONFLICT",
+      "invalid attachments",
+      409,
+    );
+  return value.map((entry: any) => {
+    if (!entry || typeof entry !== "object")
+      return { fileId: undefined as any };
+    // Do not forward path/url/name fields even temporarily. The coordinator
+    // rejects the original shape when extra keys are present.
+    const allowed = Object.keys(entry).every(
+      (key) => key === "fileId" || key === "file_id",
+    );
+    return allowed
+      ? { fileId: field(entry, "fileId", "file_id") }
+      : { ...(entry as any), fileId: field(entry, "fileId", "file_id") };
+  });
+}
+
+function field(value: any, camel: string, legacy: string): any {
+  return value?.[camel] ?? value?.[legacy];
+}
+
+function query(url: URL, camel: string, legacy?: string): string | undefined {
+  return (
+    url.searchParams.get(camel) ??
+    (legacy ? url.searchParams.get(legacy) : null) ??
+    undefined
+  );
+}
+
+function requiredQueryIdentity(url: URL, name: string): string {
+  const value = query(url, name);
+  if (!value || value.length > 512 || /[\r\n\0]/.test(value))
+    throw new SideThreadError(
+      "SIDE_THREAD_INVALID_CONTEXT",
+      `invalid ${name}`,
+      400,
+    );
+  return value;
+}
+
+async function requestJson(req: Request): Promise<any> {
+  const contentType = req.headers.get("Content-Type") ?? "";
+  if (!/^application\/json(?:;|$)/i.test(contentType)) {
+    throw new SideThreadError(
+      "SIDE_THREAD_INVALID_BODY",
+      "application/json required",
+      415,
+    );
+  }
+  try {
+    const value = await req.json();
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new SideThreadError(
+        "SIDE_THREAD_INVALID_BODY",
+        "JSON object required",
+        400,
+      );
+    }
+    return value;
+  } catch {
+    throw new SideThreadError("SIDE_THREAD_INVALID_BODY", "invalid JSON", 400);
+  }
+}
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new SideThreadError(
+      "SIDE_THREAD_NOT_FOUND",
+      "side chat not found",
+      404,
+    );
+  }
+}
+function parseCursor(value: string | null): number | null {
+  if (value === null || value === "") return 0;
+  if (!/^\d+$/.test(value)) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) ? n : null;
+}
+function parseLimit(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) && n >= 1 && n <= 100 ? n : null;
+}
+function json(body: unknown, status = 200): Response {
+  return Response.json(body, {
+    status,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+function methodNotAllowed(allow: string): Response {
+  return Response.json(
+    { ok: false, error: "SIDE_THREAD_METHOD_NOT_ALLOWED" },
+    { status: 405, headers: { Allow: allow } },
+  );
+}

--- a/server/src/side-thread-http.ts
+++ b/server/src/side-thread-http.ts
@@ -148,11 +148,13 @@ export async function handleSideThreadHttpRequest(
     }
 
     if (ctx.req.method !== "POST") return methodNotAllowed("POST");
+    const body = await requestJson(ctx.req);
+    const requestKey = field(body, "requestKey", "request_key");
     if (action === "cancel") {
       return json({
         ok: true,
         sideThread: serialize(
-          await ctx.coordinator.cancel(ctx.actor, sideChatId),
+          await ctx.coordinator.cancel(ctx.actor, sideChatId, { requestKey }),
         ),
       });
     }
@@ -160,7 +162,7 @@ export async function handleSideThreadHttpRequest(
       return json({
         ok: true,
         sideThread: serialize(
-          await ctx.coordinator.archive(ctx.actor, sideChatId),
+          await ctx.coordinator.archive(ctx.actor, sideChatId, { requestKey }),
         ),
       });
     }
@@ -168,17 +170,16 @@ export async function handleSideThreadHttpRequest(
       return json({
         ok: true,
         sideThread: serialize(
-          await ctx.coordinator.purge(ctx.actor, sideChatId),
+          await ctx.coordinator.purge(ctx.actor, sideChatId, { requestKey }),
         ),
       });
     }
-    const body = await requestJson(ctx.req);
     if (action === "retry") {
       return json({
         ok: true,
         sideThread: serialize(
           await ctx.coordinator.retry(ctx.actor, sideChatId, {
-            requestKey: field(body, "requestKey", "request_key"),
+            requestKey,
             prompt: field(body, "question", "prompt"),
             attachments:
               body.attachments === undefined
@@ -189,7 +190,7 @@ export async function handleSideThreadHttpRequest(
       });
     }
     const broughtBack = await ctx.coordinator.bringBack(ctx.actor, sideChatId, {
-      requestKey: field(body, "requestKey", "request_key"),
+      requestKey,
       destinationThreadId: field(
         body,
         "destinationThreadId",

--- a/server/src/side-thread.test.ts
+++ b/server/src/side-thread.test.ts
@@ -356,7 +356,9 @@ describe("SideThread Hub contract", () => {
         text: "won race",
       });
     };
-    const after = await f.coordinator.cancel(owner, r.sideChatId);
+    const after = await f.coordinator.cancel(owner, r.sideChatId, {
+      requestKey: "cancel-key-race1",
+    });
     expect(after.state).toBe("completed");
     expect(after.attempts[0].result).toBe("won race");
     expect(
@@ -408,9 +410,13 @@ describe("SideThread Hub contract", () => {
       cancelEntered();
       await cancelGate;
     };
-    const firstCancel = f.coordinator.cancel(owner, created.sideChatId);
+    const firstCancel = f.coordinator.cancel(owner, created.sideChatId, {
+      requestKey: "cancel-key-cross1",
+    });
     await cancelStarted;
-    const concurrent = await second.cancel(owner, created.sideChatId);
+    const concurrent = await second.cancel(owner, created.sideChatId, {
+      requestKey: "cancel-key-cross1",
+    });
     expect(concurrent.state).toBe("running");
     expect(f.port.calls.cancel).toBe(1);
     releaseCancel();
@@ -429,10 +435,14 @@ describe("SideThread Hub contract", () => {
       archiveEntered();
       await archiveGate;
     };
-    const firstArchive = f.coordinator.archive(owner, created.sideChatId);
+    const firstArchive = f.coordinator.archive(owner, created.sideChatId, {
+      requestKey: "archive-key-cross1",
+    });
     await archiveStarted;
     await expect(
-      second.archive(owner, created.sideChatId),
+      second.archive(owner, created.sideChatId, {
+        requestKey: "archive-key-cross1",
+      }),
     ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
     expect(f.port.calls.archive).toBe(1);
     releaseArchive();
@@ -480,7 +490,9 @@ describe("SideThread Hub contract", () => {
     const r = await f.coordinator.create(owner, createInput());
     const a = r.attempts[0];
     await expect(
-      f.coordinator.archive(owner, r.sideChatId),
+      f.coordinator.archive(owner, r.sideChatId, {
+        requestKey: "archive-key-running1",
+      }),
     ).rejects.toMatchObject({
       code: "SIDE_THREAD_CONFLICT",
     });
@@ -492,15 +504,27 @@ describe("SideThread Hub contract", () => {
       status: "completed",
       text: "done",
     });
-    expect((await f.coordinator.archive(owner, r.sideChatId)).state).toBe(
-      "archived",
-    );
-    expect((await f.coordinator.archive(owner, r.sideChatId)).state).toBe(
-      "archived",
-    );
-    expect((await f.coordinator.purge(owner, r.sideChatId)).state).toBe(
-      "purged",
-    );
+    expect(
+      (
+        await f.coordinator.archive(owner, r.sideChatId, {
+          requestKey: "archive-key-0001",
+        })
+      ).state,
+    ).toBe("archived");
+    expect(
+      (
+        await f.coordinator.archive(owner, r.sideChatId, {
+          requestKey: "archive-key-0001",
+        })
+      ).state,
+    ).toBe("archived");
+    expect(
+      (
+        await f.coordinator.purge(owner, r.sideChatId, {
+          requestKey: "purge-key-0001",
+        })
+      ).state,
+    ).toBe("purged");
     const purged = f.coordinator.get(owner, r.sideChatId);
     expect(purged.question).toBe("");
     expect(purged.attachments).toEqual([]);
@@ -663,13 +687,17 @@ describe("SideThread Hub contract", () => {
     );
     let cancelOperationId = "";
     try {
-      await cancelFixture.coordinator.cancel(owner, running.sideChatId);
+      await cancelFixture.coordinator.cancel(owner, running.sideChatId, {
+        requestKey: "cancel-key-lost1",
+      });
     } catch (error) {
       expect(error).toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
       cancelOperationId = (error as SideThreadError).operationId!;
     }
     await expect(
-      cancelFixture.coordinator.cancel(owner, running.sideChatId),
+      cancelFixture.coordinator.cancel(owner, running.sideChatId, {
+        requestKey: "cancel-key-lost1",
+      }),
     ).rejects.toMatchObject({
       code: "SIDE_THREAD_AMBIGUOUS",
       operationId: cancelOperationId,
@@ -698,13 +726,17 @@ describe("SideThread Hub contract", () => {
       });
       let operationId = "";
       try {
-        await current.coordinator[action](owner, record.sideChatId);
+        await current.coordinator[action](owner, record.sideChatId, {
+          requestKey: `${action}-key-lost1`,
+        });
       } catch (error) {
         operationId = (error as SideThreadError).operationId!;
         expect(error).toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
       }
       await expect(
-        current.coordinator[action](owner, record.sideChatId),
+        current.coordinator[action](owner, record.sideChatId, {
+          requestKey: `${action}-key-lost1`,
+        }),
       ).rejects.toMatchObject({
         code: "SIDE_THREAD_AMBIGUOUS",
         operationId,
@@ -718,6 +750,7 @@ describe("SideThread HTTP contract", () => {
   test("authoritative vendorable golden fixtures cannot drift from HTTP projection", async () => {
     expect(Object.keys(contractSchema.$defs).sort()).toEqual(
       [
+        "actionRequest",
         "attachment",
         "attempt",
         "boundary",
@@ -839,6 +872,40 @@ describe("SideThread HTTP contract", () => {
       coordinator: f.coordinator,
     });
     expect(denied?.status).toBe(404);
+  });
+
+  test("every mutating action binds the caller requestKey into its durable operation", async () => {
+    const f = fixture();
+    const record = await f.coordinator.create(owner, createInput());
+    for (const action of ["cancel", "archive", "purge"] as const) {
+      const request = new Request(
+        `http://hub/api/side-threads/${record.sideChatId}/${action}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(contractGolden.requests[action]),
+        },
+      );
+      const response = await handleSideThreadHttpRequest({
+        req: request,
+        url: new URL(request.url),
+        actor: owner,
+        coordinator: f.coordinator,
+      });
+      expect(response?.status).toBe(200);
+    }
+    const hydrated = f.coordinator.get(owner, record.sideChatId);
+    expect(
+      hydrated.operations
+        .filter((operation) =>
+          ["cancel", "archive", "purge"].includes(operation.kind),
+        )
+        .map((operation) => [operation.kind, operation.requestKey]),
+    ).toEqual([
+      ["cancel", contractGolden.requests.cancel.requestKey],
+      ["archive", contractGolden.requests.archive.requestKey],
+      ["purge", contractGolden.requests.purge.requestKey],
+    ]);
   });
 
   test("disabled surface is 404 before auth and unsupported adapter is typed 501", async () => {

--- a/server/src/side-thread.test.ts
+++ b/server/src/side-thread.test.ts
@@ -19,6 +19,12 @@ const contractGolden = JSON.parse(
     "utf8",
   ),
 );
+const contractSchema = JSON.parse(
+  readFileSync(
+    new URL("../../contracts/side-thread/v1/schema.json", import.meta.url),
+    "utf8",
+  ),
+);
 
 function jsonShape(value: unknown): unknown {
   if (value === null) return null;
@@ -710,6 +716,26 @@ describe("SideThread Hub contract", () => {
 
 describe("SideThread HTTP contract", () => {
   test("authoritative vendorable golden fixtures cannot drift from HTTP projection", async () => {
+    expect(Object.keys(contractSchema.$defs).sort()).toEqual(
+      [
+        "attachment",
+        "attempt",
+        "boundary",
+        "bringBack",
+        "bringBackRequest",
+        "bringBackResponse",
+        "capabilityResponse",
+        "createRequest",
+        "error",
+        "operation",
+        "recordCapability",
+        "retryRequest",
+        "sideThread",
+        "sideThreadResponse",
+        "sideThreadsResponse",
+        "sseEvent",
+      ].sort(),
+    );
     const f = fixture();
     const capabilityReq = new Request(
       "http://hub/api/side-threads/capability?alias=node-a&networkId=net_a&sourceThreadId=source_thread&boundaryKind=through&boundaryTurnId=source_turn",

--- a/server/src/side-thread.test.ts
+++ b/server/src/side-thread.test.ts
@@ -1,0 +1,919 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { readFileSync } from "node:fs";
+import { SQLiteAdapter } from "./db-adapter.js";
+import {
+  SideThreadCoordinator,
+  SideThreadError,
+  SideThreadStore,
+  UnsupportedSideThreadPort,
+  type SideThreadActor,
+  type SideThreadExecutionPort,
+  type SideThreadRuntimeEvent,
+} from "./side-thread.js";
+import { handleSideThreadHttpRequest } from "./side-thread-http.js";
+
+const contractGolden = JSON.parse(
+  readFileSync(
+    new URL("../../contracts/side-thread/v1/golden.json", import.meta.url),
+    "utf8",
+  ),
+);
+
+function jsonShape(value: unknown): unknown {
+  if (value === null) return null;
+  if (Array.isArray(value)) return value.map(jsonShape);
+  if (typeof value === "object")
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        jsonShape(entry),
+      ]),
+    );
+  return typeof value;
+}
+
+const owner: SideThreadActor = {
+  userId: "usr_owner",
+  username: "owner",
+  tokenId: "tok_owner_1",
+  kind: "user",
+};
+const stranger: SideThreadActor = {
+  userId: "usr_other",
+  username: "other",
+  tokenId: "tok_other_1",
+  kind: "user",
+};
+const nodeActor: SideThreadActor = {
+  userId: "usr_owner",
+  username: "owner",
+  tokenId: "tok_node_1",
+  kind: "node",
+  boundNetworkId: "net_a",
+  boundNodeId: "node_a",
+};
+
+class FakePort implements SideThreadExecutionPort {
+  listeners = new Set<(event: SideThreadRuntimeEvent) => void>();
+  calls = { fork: 0, start: 0, cancel: 0, archive: 0, purge: 0, bringBack: 0 };
+  turn = 0;
+  onStart?: (
+    input: Parameters<SideThreadExecutionPort["start"]>[0],
+    turnId: string,
+  ) => void;
+  capability() {
+    return {
+      supported: true,
+      mode: "native-exact-fork" as const,
+      runtime: "codex",
+      runtimeVersion: "0.148.0",
+      topology: "owned-stdio",
+      evidenceRevision: "reviewed",
+      exactBoundary: { through: true, before: true },
+    };
+  }
+  async fork(input: Parameters<SideThreadExecutionPort["fork"]>[0]) {
+    this.calls.fork++;
+    return { threadId: `derived_${input.sideChatId}` };
+  }
+  async start(input: Parameters<SideThreadExecutionPort["start"]>[0]) {
+    this.calls.start++;
+    const turnId = `turn_${++this.turn}`;
+    this.onStart?.(input, turnId);
+    return { turnId };
+  }
+  async cancel() {
+    this.calls.cancel++;
+  }
+  async archive() {
+    this.calls.archive++;
+  }
+  async purge() {
+    this.calls.purge++;
+  }
+  async bringBack() {
+    this.calls.bringBack++;
+    return { destinationTurnId: `destination_${this.calls.bringBack}` };
+  }
+  subscribe(listener: (event: SideThreadRuntimeEvent) => void) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+  emit(event: SideThreadRuntimeEvent) {
+    for (const listener of this.listeners) listener(event);
+  }
+}
+
+const closers: Array<() => void> = [];
+afterEach(() => {
+  while (closers.length) closers.pop()!();
+});
+
+function fixture(
+  options: {
+    enabled?: boolean;
+    port?: SideThreadExecutionPort;
+    attachment?: (fileId: string) => boolean;
+  } = {},
+) {
+  const raw = new Database(":memory:");
+  const db = new SQLiteAdapter(raw);
+  const store = new SideThreadStore(db);
+  const port = options.port ?? new FakePort();
+  let serial = 0;
+  const coordinator = new SideThreadCoordinator(store, port, {
+    enabled: options.enabled ?? true,
+    authorizeNode: (actor, networkId, nodeId) =>
+      actor.userId === owner.userId &&
+      networkId === "net_a" &&
+      nodeId === "node_a" &&
+      (actor.kind !== "node" || actor.boundNodeId === nodeId),
+    authorizeAttachment: (_actor, networkId, ref) =>
+      networkId === "net_a" && (options.attachment?.(ref.fileId) ?? true),
+    now: () => 1_700_000_000_000 + serial,
+    id: () => `id${++serial}`,
+  });
+  closers.push(
+    () => coordinator.close(),
+    () => db.close(),
+  );
+  return { db, store, port: port as FakePort, coordinator };
+}
+
+function createInput(overrides: Record<string, unknown> = {}) {
+  return {
+    requestKey: "create-key-0001",
+    networkId: "net_a",
+    nodeId: "node_a",
+    sourceThreadId: "source_thread",
+    boundary: { kind: "through" as const, turnId: "source_turn_5" },
+    prompt: "原问题第一行\n完整问题必须跨窗口保留",
+    attachments: [{ fileId: "file_ref_0001" }],
+    ...overrides,
+  };
+}
+
+describe("SideThread Hub contract", () => {
+  test("feature flag and missing runtime adapter fail closed without a FIFO fallback", async () => {
+    const disabled = fixture({ enabled: false });
+    await expect(
+      disabled.coordinator.create(owner, createInput()),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_DISABLED", status: 404 });
+    expect(disabled.port.calls.fork).toBe(0);
+
+    const unsupported = fixture({ port: new UnsupportedSideThreadPort() });
+    await expect(
+      unsupported.coordinator.create(owner, createInput()),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_UNSUPPORTED", status: 501 });
+    expect(
+      unsupported.db.get<{ n: number }>("SELECT COUNT(*) n FROM side_chats")?.n,
+    ).toBe(0);
+
+    const unverified = new FakePort();
+    unverified.capability = () => ({
+      supported: true,
+      runtime: "codex",
+      runtimeVersion: "unknown",
+      topology: "shared",
+      evidenceRevision: "unreviewed",
+      exactBoundary: { through: true, before: true },
+    });
+    const unverifiedFixture = fixture({ port: unverified });
+    await expect(
+      unverifiedFixture.coordinator.create(owner, createInput()),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_UNSUPPORTED", status: 501 });
+    expect(unverified.calls.fork).toBe(0);
+  });
+
+  test("create is payload-bound idempotent and stores exact four-part ownership", async () => {
+    const f = fixture();
+    const first = await f.coordinator.create(owner, createInput());
+    const replay = await f.coordinator.create(owner, createInput());
+    expect(replay.sideChatId).toBe(first.sideChatId);
+    expect(f.port.calls).toMatchObject({ fork: 1, start: 1 });
+    expect(first.state).toBe("running");
+    expect(first.attempts[0]).toMatchObject({
+      attemptId: first.activeAttemptId,
+      threadId: first.threadId,
+      turnId: "turn_1",
+      state: "running",
+    });
+    await expect(
+      f.coordinator.create(owner, createInput({ prompt: "different" })),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+  });
+
+  test("cross-window hydration returns the complete owner question and cross-owner reads are opaque", async () => {
+    const f = fixture();
+    const created = await f.coordinator.create(owner, createInput());
+    f.coordinator.close();
+    const reopened = new SideThreadCoordinator(
+      new SideThreadStore(f.db),
+      f.port,
+      {
+        enabled: true,
+        authorizeNode: (actor, networkId, nodeId) =>
+          actor.userId === owner.userId &&
+          networkId === "net_a" &&
+          nodeId === "node_a",
+        authorizeAttachment: () => true,
+      },
+    );
+    closers.push(() => reopened.close());
+    expect(reopened.get(owner, created.sideChatId).question).toBe(
+      createInput().prompt,
+    );
+    expect(() => reopened.get(stranger, created.sideChatId)).toThrow(
+      new SideThreadError("SIDE_THREAD_NOT_FOUND", "side chat not found", 404),
+    );
+    expect(() =>
+      reopened.get({ ...nodeActor, boundNodeId: "node_b" }, created.sideChatId),
+    ).toThrow();
+  });
+
+  test("attachments accept authorized fileId references only", async () => {
+    const f = fixture({ attachment: (id) => id === "file_ref_0001" });
+    await f.coordinator.create(owner, createInput());
+    await expect(
+      f.coordinator.create(
+        owner,
+        createInput({
+          requestKey: "create-key-0002",
+          attachments: [{ fileId: "file_missing_01" }],
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_ATTACHMENT_NOT_FOUND" });
+    await expect(
+      f.coordinator.create(
+        owner,
+        createInput({
+          requestKey: "create-key-0003",
+          attachments: [{ fileId: "file_ref_0001", path: "/etc/passwd" }],
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+  });
+
+  test("terminal events require sideChatId + attemptId + threadId + turnId", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const a = r.attempts[0];
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.sourceThreadId,
+      turnId: a.turnId!,
+      status: "completed",
+      text: "wrong source",
+    });
+    expect(f.coordinator.get(owner, r.sideChatId).state).toBe("running");
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: "turn_sibling",
+      status: "completed",
+      text: "wrong turn",
+    });
+    expect(f.coordinator.get(owner, r.sideChatId).state).toBe("running");
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: a.turnId!,
+      status: "completed",
+      text: "answer",
+    });
+    expect(f.coordinator.get(owner, r.sideChatId)).toMatchObject({
+      state: "completed",
+      activeAttemptId: undefined,
+      attempts: [{ state: "completed", result: "answer" }],
+    });
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: a.turnId!,
+      status: "failed",
+      error: "late",
+    });
+    expect(f.coordinator.get(owner, r.sideChatId).state).toBe("completed");
+    expect(
+      f.coordinator
+        .listEvents(owner, r.sideChatId)
+        .filter((e) => e.type === "runtime_event.dropped"),
+    ).toHaveLength(3);
+  });
+
+  test("a terminal event arriving before start returns settles once", async () => {
+    const f = fixture();
+    f.port.onStart = (input, turnId) =>
+      f.port.emit({
+        sideChatId: input.sideChatId,
+        attemptId: input.attemptId,
+        threadId: input.threadId,
+        turnId,
+        status: "completed",
+        text: "fast",
+      });
+    const r = await f.coordinator.create(owner, createInput());
+    expect(r).toMatchObject({
+      state: "completed",
+      activeAttemptId: undefined,
+      attempts: [{ state: "completed", turnId: "turn_1", result: "fast" }],
+    });
+    expect(
+      f.coordinator
+        .listEvents(owner, r.sideChatId)
+        .filter((e) => e.type === "attempt.terminal"),
+    ).toHaveLength(1);
+    expect(
+      f.coordinator
+        .listEvents(owner, r.sideChatId)
+        .filter((e) => e.type === "attempt.running"),
+    ).toHaveLength(0);
+  });
+
+  test("cancel is exact and cannot regress a terminal race", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const a = r.attempts[0];
+    f.port.cancel = async () => {
+      f.port.calls.cancel++;
+      f.port.emit({
+        sideChatId: r.sideChatId,
+        attemptId: a.attemptId,
+        threadId: r.threadId!,
+        turnId: a.turnId!,
+        status: "completed",
+        text: "won race",
+      });
+    };
+    const after = await f.coordinator.cancel(owner, r.sideChatId);
+    expect(after.state).toBe("completed");
+    expect(after.attempts[0].result).toBe("won race");
+    expect(
+      f.coordinator
+        .listEvents(owner, r.sideChatId)
+        .filter((e) => e.type === "attempt.cancelled"),
+    ).toHaveLength(0);
+  });
+
+  test("cross-coordinator create and cancel claims execute the runtime once", async () => {
+    const f = fixture();
+    let forkEntered!: () => void;
+    const entered = new Promise<void>((resolve) => (forkEntered = resolve));
+    let releaseFork!: () => void;
+    const forkGate = new Promise<void>((resolve) => (releaseFork = resolve));
+    f.port.fork = async (input) => {
+      f.port.calls.fork++;
+      forkEntered();
+      await forkGate;
+      return { threadId: `derived_${input.sideChatId}` };
+    };
+    const second = new SideThreadCoordinator(f.store, f.port, {
+      enabled: true,
+      authorizeNode: (actor, networkId, nodeId) =>
+        actor.userId === owner.userId &&
+        networkId === "net_a" &&
+        nodeId === "node_a",
+      authorizeAttachment: () => true,
+    });
+    closers.push(() => second.close());
+    const firstCreate = f.coordinator.create(owner, createInput());
+    await entered;
+    const replay = await second.create(owner, createInput());
+    expect(replay.state).toBe("creating");
+    releaseFork();
+    const created = await firstCreate;
+    expect(f.port.calls.fork).toBe(1);
+
+    let cancelEntered!: () => void;
+    const cancelStarted = new Promise<void>(
+      (resolve) => (cancelEntered = resolve),
+    );
+    let releaseCancel!: () => void;
+    const cancelGate = new Promise<void>(
+      (resolve) => (releaseCancel = resolve),
+    );
+    f.port.cancel = async () => {
+      f.port.calls.cancel++;
+      cancelEntered();
+      await cancelGate;
+    };
+    const firstCancel = f.coordinator.cancel(owner, created.sideChatId);
+    await cancelStarted;
+    const concurrent = await second.cancel(owner, created.sideChatId);
+    expect(concurrent.state).toBe("running");
+    expect(f.port.calls.cancel).toBe(1);
+    releaseCancel();
+    expect((await firstCancel).state).toBe("cancelled");
+
+    let archiveEntered!: () => void;
+    const archiveStarted = new Promise<void>(
+      (resolve) => (archiveEntered = resolve),
+    );
+    let releaseArchive!: () => void;
+    const archiveGate = new Promise<void>(
+      (resolve) => (releaseArchive = resolve),
+    );
+    f.port.archive = async () => {
+      f.port.calls.archive++;
+      archiveEntered();
+      await archiveGate;
+    };
+    const firstArchive = f.coordinator.archive(owner, created.sideChatId);
+    await archiveStarted;
+    await expect(
+      second.archive(owner, created.sideChatId),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+    expect(f.port.calls.archive).toBe(1);
+    releaseArchive();
+    expect((await firstArchive).state).toBe("archived");
+  });
+
+  test("retry persists parent attempt lineage and blocks concurrent active retries", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const first = r.attempts[0];
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: first.attemptId,
+      threadId: r.threadId!,
+      turnId: first.turnId!,
+      status: "failed",
+      error: "boom",
+    });
+    const retried = await f.coordinator.retry(owner, r.sideChatId, {
+      requestKey: "retry-key-0001",
+      prompt: "try again",
+    });
+    expect(retried.attempts[1]).toMatchObject({
+      parentAttemptId: first.attemptId,
+      state: "running",
+      threadId: r.threadId,
+      turnId: "turn_2",
+    });
+    await expect(
+      f.coordinator.retry(owner, r.sideChatId, {
+        requestKey: "retry-key-0002",
+        prompt: "parallel",
+      }),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+    const replay = await f.coordinator.retry(owner, r.sideChatId, {
+      requestKey: "retry-key-0001",
+      prompt: "try again",
+    });
+    expect(replay.attempts).toHaveLength(2);
+    expect(f.port.calls.start).toBe(2);
+  });
+
+  test("archive/purge are terminal-safe and idempotent", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const a = r.attempts[0];
+    await expect(
+      f.coordinator.archive(owner, r.sideChatId),
+    ).rejects.toMatchObject({
+      code: "SIDE_THREAD_CONFLICT",
+    });
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: a.turnId!,
+      status: "completed",
+      text: "done",
+    });
+    expect((await f.coordinator.archive(owner, r.sideChatId)).state).toBe(
+      "archived",
+    );
+    expect((await f.coordinator.archive(owner, r.sideChatId)).state).toBe(
+      "archived",
+    );
+    expect((await f.coordinator.purge(owner, r.sideChatId)).state).toBe(
+      "purged",
+    );
+    const purged = f.coordinator.get(owner, r.sideChatId);
+    expect(purged.question).toBe("");
+    expect(purged.attachments).toEqual([]);
+    expect(purged.attempts[0].result).toBeUndefined();
+    expect(f.port.calls).toMatchObject({ archive: 1, purge: 1 });
+  });
+
+  test("bring-back is completed-attempt-only and payload-bound idempotent", async () => {
+    const f = fixture();
+    const r = await f.coordinator.create(owner, createInput());
+    const a = r.attempts[0];
+    await expect(
+      f.coordinator.bringBack(owner, r.sideChatId, {
+        requestKey: "bring-key-0001",
+        destinationThreadId: "source_thread",
+      }),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+    f.port.emit({
+      sideChatId: r.sideChatId,
+      attemptId: a.attemptId,
+      threadId: r.threadId!,
+      turnId: a.turnId!,
+      status: "completed",
+      text: "answer",
+    });
+    const one = await f.coordinator.bringBack(owner, r.sideChatId, {
+      requestKey: "bring-key-0001",
+      destinationThreadId: "source_thread",
+    });
+    const replay = await f.coordinator.bringBack(owner, r.sideChatId, {
+      requestKey: "bring-key-0001",
+      destinationThreadId: "source_thread",
+    });
+    expect(replay).toEqual(one);
+    expect(f.port.calls.bringBack).toBe(1);
+    const differentRequest = await f.coordinator.bringBack(
+      owner,
+      r.sideChatId,
+      {
+        requestKey: "bring-key-0002",
+        destinationThreadId: "source_thread",
+      },
+    );
+    expect(differentRequest).toEqual(one);
+    expect(f.port.calls.bringBack).toBe(1);
+    await expect(
+      f.coordinator.bringBack(owner, r.sideChatId, {
+        requestKey: "bring-key-0003",
+        destinationThreadId: "other_thread",
+      }),
+    ).rejects.toMatchObject({ code: "SIDE_THREAD_CONFLICT" });
+
+    f.coordinator.close();
+    const reopened = new SideThreadCoordinator(f.store, f.port, {
+      enabled: true,
+      authorizeNode: (actor, networkId, nodeId) =>
+        actor.userId === owner.userId &&
+        networkId === "net_a" &&
+        nodeId === "node_a",
+      authorizeAttachment: () => true,
+    });
+    closers.push(() => reopened.close());
+    const hydrated = reopened.get(owner, r.sideChatId);
+    expect(hydrated.bringBacks).toHaveLength(1);
+    expect(hydrated.bringBacks[0]).toMatchObject({
+      attemptId: a.attemptId,
+      destinationThreadId: "source_thread",
+      destinationTurnId: one.destinationTurnId,
+      requestKey: "bring-key-0001",
+      state: "completed",
+    });
+    expect(hydrated.bringBacks[0].completedAt).toBeNumber();
+    expect(reopened.list(owner)).toHaveLength(1);
+    expect(reopened.list(stranger)).toHaveLength(0);
+  });
+
+  test("response loss is durable ambiguous and reconciles without a second start RPC", async () => {
+    const port = new FakePort();
+    let accepted: Parameters<SideThreadExecutionPort["start"]>[0] | undefined;
+    port.start = async (input) => {
+      port.calls.start++;
+      accepted = input;
+      throw Object.assign(new Error("secret transport detail"), {
+        code: "SIDE_THREAD_RESPONSE_LOST",
+      });
+    };
+    const f = fixture({ port });
+    await expect(
+      f.coordinator.create(owner, createInput()),
+    ).rejects.toMatchObject({
+      code: "SIDE_THREAD_AMBIGUOUS",
+      operationId: expect.stringMatching(/^sop_/),
+    });
+    const ambiguous = f.store.getByCreateKey(owner, "create-key-0001")!.record;
+    const startOperation = ambiguous.operations.find(
+      (operation) => operation.kind === "start",
+    )!;
+    expect(ambiguous).toMatchObject({
+      requestKey: "create-key-0001",
+      state: "ambiguous",
+      attempts: [{ state: "ambiguous" }],
+    });
+    expect(startOperation).toMatchObject({
+      operationId: accepted!.operationId,
+      state: "ambiguous",
+      errorCode: "SIDE_THREAD_RESPONSE_LOST",
+    });
+    expect(await f.coordinator.create(owner, createInput())).toMatchObject({
+      sideChatId: ambiguous.sideChatId,
+      state: "ambiguous",
+    });
+    expect(port.calls).toMatchObject({ fork: 1, start: 1 });
+
+    f.coordinator.close();
+    const reopened = new SideThreadCoordinator(f.store, port, {
+      enabled: true,
+      authorizeNode: (actor, networkId, nodeId) =>
+        actor.userId === owner.userId &&
+        networkId === "net_a" &&
+        nodeId === "node_a",
+    });
+    closers.push(() => reopened.close());
+    port.emit({
+      sideChatId: ambiguous.sideChatId,
+      attemptId: accepted!.attemptId,
+      threadId: accepted!.threadId,
+      turnId: "turn_authoritative",
+      status: "completed",
+      text: "authoritative answer",
+    });
+    const reconciled = reopened.get(owner, ambiguous.sideChatId);
+    expect(reconciled).toMatchObject({
+      state: "completed",
+      attempts: [{ state: "completed", result: "authoritative answer" }],
+    });
+    expect(
+      reconciled.operations.find((operation) => operation.kind === "start"),
+    ).toMatchObject({ state: "completed", turnId: "turn_authoritative" });
+    expect(port.calls.start).toBe(1);
+    expect(
+      JSON.stringify(reopened.listEvents(owner, ambiguous.sideChatId)),
+    ).not.toContain("secret transport detail");
+  });
+
+  test("ambiguous cancel/archive/purge keep stable claims and never issue a second RPC", async () => {
+    const lose = () =>
+      Object.assign(new Error("accepted but ACK lost"), {
+        code: "SIDE_THREAD_RESPONSE_LOST",
+      });
+
+    const cancelPort = new FakePort();
+    cancelPort.cancel = async () => {
+      cancelPort.calls.cancel++;
+      throw lose();
+    };
+    const cancelFixture = fixture({ port: cancelPort });
+    const running = await cancelFixture.coordinator.create(
+      owner,
+      createInput(),
+    );
+    let cancelOperationId = "";
+    try {
+      await cancelFixture.coordinator.cancel(owner, running.sideChatId);
+    } catch (error) {
+      expect(error).toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+      cancelOperationId = (error as SideThreadError).operationId!;
+    }
+    await expect(
+      cancelFixture.coordinator.cancel(owner, running.sideChatId),
+    ).rejects.toMatchObject({
+      code: "SIDE_THREAD_AMBIGUOUS",
+      operationId: cancelOperationId,
+    });
+    expect(cancelPort.calls.cancel).toBe(1);
+
+    for (const action of ["archive", "purge"] as const) {
+      const port = new FakePort();
+      port[action] = async () => {
+        port.calls[action]++;
+        throw lose();
+      };
+      const current = fixture({ port });
+      const record = await current.coordinator.create(
+        owner,
+        createInput({ requestKey: `create-key-${action}` }),
+      );
+      const attempt = record.attempts[0];
+      port.emit({
+        sideChatId: record.sideChatId,
+        attemptId: attempt.attemptId,
+        threadId: record.threadId!,
+        turnId: attempt.turnId!,
+        status: "completed",
+        text: "done",
+      });
+      let operationId = "";
+      try {
+        await current.coordinator[action](owner, record.sideChatId);
+      } catch (error) {
+        operationId = (error as SideThreadError).operationId!;
+        expect(error).toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+      }
+      await expect(
+        current.coordinator[action](owner, record.sideChatId),
+      ).rejects.toMatchObject({
+        code: "SIDE_THREAD_AMBIGUOUS",
+        operationId,
+      });
+      expect(port.calls[action]).toBe(1);
+    }
+  });
+});
+
+describe("SideThread HTTP contract", () => {
+  test("authoritative vendorable golden fixtures cannot drift from HTTP projection", async () => {
+    const f = fixture();
+    const capabilityReq = new Request(
+      "http://hub/api/side-threads/capability?alias=node-a&networkId=net_a&sourceThreadId=source_thread&boundaryKind=through&boundaryTurnId=source_turn",
+    );
+    const capability = await handleSideThreadHttpRequest({
+      req: capabilityReq,
+      url: new URL(capabilityReq.url),
+      actor: owner,
+      coordinator: f.coordinator,
+      resolveCapabilityTarget: () => ({ nodeId: "node_a", networkId: "net_a" }),
+    });
+    expect(await capability!.json()).toEqual(contractGolden.capabilityResponse);
+
+    const request = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(contractGolden.requests.create),
+    });
+    const created = await handleSideThreadHttpRequest({
+      req: request,
+      url: new URL(request.url),
+      actor: owner,
+      coordinator: f.coordinator,
+    });
+    expect(jsonShape(await created!.json())).toEqual(
+      jsonShape(contractGolden.sideThreadEnvelope),
+    );
+    const empty = fixture();
+    const listReq = new Request("http://hub/api/side-threads");
+    const listed = await handleSideThreadHttpRequest({
+      req: listReq,
+      url: new URL(listReq.url),
+      actor: owner,
+      coordinator: empty.coordinator,
+    });
+    expect(await listed!.json()).toEqual(contractGolden.listResponse);
+  });
+
+  test("routes use the stable REST shape and return owner-readable question", async () => {
+    const f = fixture();
+    const req = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        requestKey: "create-key-http1",
+        networkId: "net_a",
+        nodeId: "node_a",
+        sourceThreadId: "source_thread",
+        boundary: { kind: "through", turnId: "source_turn" },
+        prompt: "full question",
+        attachments: [{ fileId: "file_ref_0001" }],
+      }),
+    });
+    const created = await handleSideThreadHttpRequest({
+      req,
+      url: new URL(req.url),
+      actor: owner,
+      coordinator: f.coordinator,
+    });
+    expect(created?.status).toBe(201);
+    const body = (await created!.json()) as any;
+    expect(body.sideThread).toMatchObject({
+      requestKey: "create-key-http1",
+      question: "full question",
+      title: "full question",
+      state: "running",
+    });
+    const getReq = new Request(
+      `http://hub/api/side-threads/${body.sideThread.sideThreadId}`,
+    );
+    const got = await handleSideThreadHttpRequest({
+      req: getReq,
+      url: new URL(getReq.url),
+      actor: owner,
+      coordinator: f.coordinator,
+    });
+    expect(((await got!.json()) as any).sideThread.question).toBe(
+      "full question",
+    );
+    const listReq = new Request("http://hub/api/side-threads?network_id=net_a");
+    const listed = await handleSideThreadHttpRequest({
+      req: listReq,
+      url: new URL(listReq.url),
+      actor: owner,
+      coordinator: f.coordinator,
+    });
+    expect((await listed!.json()) as any).toMatchObject({
+      count: 1,
+      sideThreads: [
+        {
+          question: "full question",
+          bringBacks: [],
+          operations: expect.any(Array),
+        },
+      ],
+    });
+    const denied = await handleSideThreadHttpRequest({
+      req: getReq,
+      url: new URL(getReq.url),
+      actor: stranger,
+      coordinator: f.coordinator,
+    });
+    expect(denied?.status).toBe(404);
+  });
+
+  test("disabled surface is 404 before auth and unsupported adapter is typed 501", async () => {
+    const off = fixture({ enabled: false });
+    const getReq = new Request("http://hub/api/side-threads/anything");
+    expect(
+      (
+        await handleSideThreadHttpRequest({
+          req: getReq,
+          url: new URL(getReq.url),
+          actor: null,
+          coordinator: off.coordinator,
+        })
+      )?.status,
+    ).toBe(404);
+    const unsupported = fixture({ port: new UnsupportedSideThreadPort() });
+    const req = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        request_key: "create-key-http2",
+        network_id: "net_a",
+        node_id: "node_a",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "question",
+      }),
+    });
+    const response = await handleSideThreadHttpRequest({
+      req,
+      url: new URL(req.url),
+      actor: owner,
+      coordinator: unsupported.coordinator,
+    });
+    expect(response?.status).toBe(501);
+    expect(await response!.json()).toMatchObject({
+      error: "SIDE_THREAD_UNSUPPORTED",
+    });
+  });
+
+  test("capability flips and ambiguous runtime identities are typed failures", async () => {
+    const flippedPort = new FakePort();
+    flippedPort.fork = async () => {
+      const error = new Error("capability disappeared");
+      (error as any).code = "SIDE_THREAD_UNSUPPORTED";
+      throw error;
+    };
+    const flipped = fixture({ port: flippedPort });
+    const flipReq = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        request_key: "create-key-flip1",
+        network_id: "net_a",
+        node_id: "node_a",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "flip",
+      }),
+    });
+    const flipResponse = await handleSideThreadHttpRequest({
+      req: flipReq,
+      url: new URL(flipReq.url),
+      actor: owner,
+      coordinator: flipped.coordinator,
+    });
+    expect(flipResponse?.status).toBe(501);
+    expect(await flipResponse!.json()).toMatchObject({
+      error: "SIDE_THREAD_UNSUPPORTED",
+    });
+
+    const ambiguousPort = new FakePort();
+    ambiguousPort.fork = async () => ({ threadId: undefined as any });
+    const ambiguous = fixture({ port: ambiguousPort });
+    const ambiguousReq = new Request("http://hub/api/side-threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        request_key: "create-key-ambig1",
+        network_id: "net_a",
+        node_id: "node_a",
+        source_thread_id: "source_thread",
+        boundary: { kind: "through", turn_id: "source_turn" },
+        prompt: "ambiguous",
+      }),
+    });
+    const ambiguousResponse = await handleSideThreadHttpRequest({
+      req: ambiguousReq,
+      url: new URL(ambiguousReq.url),
+      actor: owner,
+      coordinator: ambiguous.coordinator,
+    });
+    expect(ambiguousResponse?.status).toBe(202);
+    expect(await ambiguousResponse!.json()).toMatchObject({
+      error: "SIDE_THREAD_AMBIGUOUS",
+      operationId: expect.stringMatching(/^sop_/),
+      sideThreadId: expect.stringMatching(/^sch_/),
+      attemptId: expect.stringMatching(/^sat_/),
+    });
+    expect(
+      ambiguous.store.getByCreateKey(owner, "create-key-ambig1")?.record.state,
+    ).toBe("ambiguous");
+  });
+});

--- a/server/src/side-thread.test.ts
+++ b/server/src/side-thread.test.ts
@@ -518,6 +518,13 @@ describe("SideThread Hub contract", () => {
         })
       ).state,
     ).toBe("archived");
+    // A failed receipt may contain a scrubbed runtime reason from an earlier
+    // process/version. Purge must remove it even though it is not projected by
+    // the public record.
+    f.db.run(
+      "INSERT INTO side_chat_bring_backs (bring_back_id,side_chat_id,attempt_id,owner_user_id,request_key,request_fingerprint,destination_thread_id,state,error_text,created_at,updated_at) VALUES ('sbb_failed',?1,?2,?3,'bring-failed-0001','fingerprint','source_thread','failed','private runtime detail',1,1)",
+      [r.sideChatId, a.attemptId, owner.userId],
+    );
     expect(
       (
         await f.coordinator.purge(owner, r.sideChatId, {
@@ -528,7 +535,26 @@ describe("SideThread Hub contract", () => {
     const purged = f.coordinator.get(owner, r.sideChatId);
     expect(purged.question).toBe("");
     expect(purged.attachments).toEqual([]);
-    expect(purged.attempts[0].result).toBeUndefined();
+    expect(purged.attempts[0]).toMatchObject({
+      result: undefined,
+      error: undefined,
+      attachments: [],
+    });
+    expect(
+      f.db.get<{
+        result_text: string | null;
+        error_text: string | null;
+        attachments_json: string;
+      }>(
+        "SELECT result_text,error_text,attachments_json FROM side_chat_attempts WHERE attempt_id=?1",
+        a.attemptId,
+      ),
+    ).toEqual({ result_text: null, error_text: null, attachments_json: "[]" });
+    expect(
+      f.db.get<{ error_text: string | null }>(
+        "SELECT error_text FROM side_chat_bring_backs WHERE bring_back_id='sbb_failed'",
+      ),
+    ).toEqual({ error_text: null });
     expect(f.port.calls).toMatchObject({ archive: 1, purge: 1 });
   });
 

--- a/server/src/side-thread.ts
+++ b/server/src/side-thread.ts
@@ -1,0 +1,2203 @@
+import { createHash, randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import type { DbAdapter } from "./db-adapter.js";
+
+export const SIDE_THREAD_FEATURE_FLAG = "COMMHUB_ENABLE_SIDE_THREADS";
+export const SIDE_THREAD_API_ROOT = "/api/side-threads";
+export const SIDE_THREAD_EVENTS_SUFFIX = "/events";
+export const SIDE_THREAD_API_ACTIONS = [
+  "cancel",
+  "retry",
+  "archive",
+  "purge",
+  "bring-back",
+  SIDE_THREAD_EVENTS_SUFFIX.slice(1),
+] as const;
+
+export type SideThreadState =
+  | "creating"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "ambiguous"
+  | "reconciling"
+  | "archived"
+  | "purged";
+export type SideThreadAttemptState =
+  | "starting"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "ambiguous"
+  | "reconciling";
+export type SideThreadBoundary =
+  { kind: "through"; turnId: string } | { kind: "before"; turnId: string };
+
+export interface SideThreadActor {
+  userId: string;
+  username: string;
+  tokenId: string;
+  kind: "user" | "node";
+  boundNetworkId?: string;
+  boundNodeId?: string;
+  isAdmin?: boolean;
+}
+
+export interface SideThreadAttachmentRef {
+  fileId: string;
+}
+
+export interface SideThreadCapability {
+  supported: boolean;
+  mode?: "native-exact-fork";
+  runtime?: string;
+  runtimeVersion?: string;
+  topology?: string;
+  evidenceRevision?: string;
+  exactBoundary?: { through: boolean; before: boolean };
+  reason?: string;
+}
+
+export interface SideThreadRuntimeEvent {
+  sideChatId: string;
+  attemptId: string;
+  threadId: string;
+  turnId: string;
+  status: "completed" | "failed" | "interrupted";
+  text?: string;
+  error?: string;
+}
+
+/**
+ * The only bridge from Hub state into a runtime. Implementations must use a
+ * native exact-boundary side-thread mechanism. Ordinary task/inbox/FIFO
+ * delivery is deliberately absent from this interface.
+ */
+export interface SideThreadExecutionPort {
+  capability(
+    nodeId: string,
+  ): Promise<SideThreadCapability> | SideThreadCapability;
+  fork(input: {
+    operationId: string;
+    requestKey: string;
+    sideChatId: string;
+    nodeId: string;
+    sourceThreadId: string;
+    boundary: SideThreadBoundary;
+  }): Promise<{ threadId: string }>;
+  start(input: {
+    operationId: string;
+    requestKey: string;
+    sideChatId: string;
+    attemptId: string;
+    nodeId: string;
+    threadId: string;
+    prompt: string;
+    attachments: SideThreadAttachmentRef[];
+  }): Promise<{ turnId: string }>;
+  cancel(input: {
+    operationId: string;
+    sideChatId: string;
+    attemptId: string;
+    nodeId: string;
+    threadId: string;
+    turnId: string;
+  }): Promise<void>;
+  archive(input: {
+    operationId: string;
+    sideChatId: string;
+    nodeId: string;
+    threadId: string;
+  }): Promise<void>;
+  purge(input: {
+    operationId: string;
+    sideChatId: string;
+    nodeId: string;
+    threadId: string;
+  }): Promise<void>;
+  bringBack(input: {
+    operationId: string;
+    sideChatId: string;
+    attemptId: string;
+    nodeId: string;
+    sourceThreadId: string;
+    sourceTurnId: string;
+    destinationThreadId: string;
+    requestKey: string;
+    text: string;
+  }): Promise<{ destinationTurnId: string }>;
+  subscribe(listener: (event: SideThreadRuntimeEvent) => void): () => void;
+}
+
+export class SideThreadError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly status: number,
+    readonly operationId?: string,
+    readonly sideChatId?: string,
+    readonly attemptId?: string,
+  ) {
+    super(message);
+    this.name = "SideThreadError";
+  }
+}
+
+export class UnsupportedSideThreadPort implements SideThreadExecutionPort {
+  capability(): SideThreadCapability {
+    return { supported: false, reason: "runtime-adapter-unavailable" };
+  }
+  private unsupported(): never {
+    throw new SideThreadError(
+      "SIDE_THREAD_UNSUPPORTED",
+      "verified native SideThread adapter is unavailable",
+      501,
+    );
+  }
+  async fork(): Promise<never> {
+    return this.unsupported();
+  }
+  async start(): Promise<never> {
+    return this.unsupported();
+  }
+  async cancel(): Promise<never> {
+    return this.unsupported();
+  }
+  async archive(): Promise<never> {
+    return this.unsupported();
+  }
+  async purge(): Promise<never> {
+    return this.unsupported();
+  }
+  async bringBack(): Promise<never> {
+    return this.unsupported();
+  }
+  subscribe(): () => void {
+    return () => {};
+  }
+}
+
+/**
+ * Process-local adapter seam. Production starts unsupported; a node/runtime
+ * integration may install one verified adapter explicitly. Replacing it also
+ * rewires terminal-event subscribers, so the coordinator never subscribes to
+ * an untracked transport.
+ */
+export class SideThreadPortRegistry implements SideThreadExecutionPort {
+  private delegate: SideThreadExecutionPort = new UnsupportedSideThreadPort();
+  private readonly listeners = new Set<
+    (event: SideThreadRuntimeEvent) => void
+  >();
+  private detach: () => void = () => {};
+  install(port: SideThreadExecutionPort): () => void {
+    this.detach();
+    this.delegate = port;
+    this.detach = port.subscribe((event) => {
+      for (const listener of this.listeners) listener(event);
+    });
+    return () => {
+      if (this.delegate !== port) return;
+      this.detach();
+      this.detach = () => {};
+      this.delegate = new UnsupportedSideThreadPort();
+    };
+  }
+  capability(nodeId: string) {
+    return this.delegate.capability(nodeId);
+  }
+  fork(input: Parameters<SideThreadExecutionPort["fork"]>[0]) {
+    return this.delegate.fork(input);
+  }
+  start(input: Parameters<SideThreadExecutionPort["start"]>[0]) {
+    return this.delegate.start(input);
+  }
+  cancel(input: Parameters<SideThreadExecutionPort["cancel"]>[0]) {
+    return this.delegate.cancel(input);
+  }
+  archive(input: Parameters<SideThreadExecutionPort["archive"]>[0]) {
+    return this.delegate.archive(input);
+  }
+  purge(input: Parameters<SideThreadExecutionPort["purge"]>[0]) {
+    return this.delegate.purge(input);
+  }
+  bringBack(input: Parameters<SideThreadExecutionPort["bringBack"]>[0]) {
+    return this.delegate.bringBack(input);
+  }
+  subscribe(listener: (event: SideThreadRuntimeEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+}
+
+export interface SideThreadRecord {
+  sideChatId: string;
+  requestKey: string;
+  networkId: string;
+  nodeId: string;
+  ownerUserId: string;
+  sourceThreadId: string;
+  /** Owner-readable original BTW question, durably restored across windows. */
+  question: string;
+  boundary: SideThreadBoundary;
+  threadId?: string;
+  state: SideThreadState;
+  activeAttemptId?: string;
+  runtime?: string;
+  runtimeVersion?: string;
+  topology?: string;
+  evidenceRevision?: string;
+  attachments: SideThreadAttachmentRef[];
+  attempts: SideThreadAttemptRecord[];
+  bringBacks: SideThreadBringBackRecord[];
+  operations: SideThreadOperationRecord[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SideThreadAttemptRecord {
+  attemptId: string;
+  requestKey: string;
+  parentAttemptId?: string;
+  threadId?: string;
+  turnId?: string;
+  state: SideThreadAttemptState;
+  result?: string;
+  error?: string;
+  attachments: SideThreadAttachmentRef[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SideThreadBringBackRecord {
+  bringBackId: string;
+  attemptId: string;
+  requestKey: string;
+  destinationThreadId: string;
+  destinationTurnId?: string;
+  state: "starting" | "completed" | "failed";
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface SideThreadOperationRecord {
+  operationId: string;
+  attemptId?: string;
+  kind: "fork" | "start" | "cancel" | "archive" | "purge" | "bring-back";
+  requestKey: string;
+  state: "pending" | "ambiguous" | "reconciling" | "completed" | "failed";
+  threadId?: string;
+  turnId?: string;
+  errorCode?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SideThreadEventRecord {
+  eventId: number;
+  sideChatId: string;
+  attemptId?: string;
+  threadId?: string;
+  turnId?: string;
+  type: string;
+  state?: string;
+  reason?: string;
+  createdAt: number;
+}
+
+export function installSideThreadSchema(database: DbAdapter): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS side_chats (
+      side_chat_id       TEXT PRIMARY KEY,
+      network_id         TEXT NOT NULL,
+      node_id            TEXT NOT NULL,
+      owner_user_id      TEXT NOT NULL,
+      created_by_token_id TEXT NOT NULL,
+      create_request_key TEXT NOT NULL,
+      create_fingerprint TEXT NOT NULL,
+      source_thread_id   TEXT NOT NULL,
+      question_text      TEXT NOT NULL,
+      boundary_kind      TEXT NOT NULL CHECK(boundary_kind IN ('through','before')),
+      boundary_turn_id   TEXT NOT NULL,
+      derived_thread_id  TEXT,
+      state              TEXT NOT NULL,
+      active_attempt_id  TEXT,
+      lifecycle_operation TEXT,
+      runtime            TEXT,
+      runtime_version    TEXT,
+      topology           TEXT,
+      evidence_revision  TEXT,
+      attachments_json   TEXT NOT NULL DEFAULT '[]',
+      created_at         INTEGER NOT NULL,
+      updated_at         INTEGER NOT NULL,
+      archived_at        INTEGER,
+      purged_at          INTEGER,
+      UNIQUE(owner_user_id, create_request_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_side_chats_owner_network
+      ON side_chats(owner_user_id, network_id, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_side_chats_node
+      ON side_chats(node_id, state, updated_at DESC);
+
+    CREATE TABLE IF NOT EXISTS side_chat_attempts (
+      attempt_id         TEXT PRIMARY KEY,
+      side_chat_id       TEXT NOT NULL,
+      parent_attempt_id  TEXT,
+      request_key        TEXT NOT NULL,
+      request_fingerprint TEXT NOT NULL,
+      prompt_hash        TEXT NOT NULL,
+      attachments_json   TEXT NOT NULL DEFAULT '[]',
+      thread_id          TEXT,
+      turn_id            TEXT,
+      cancel_requested_at INTEGER,
+      state              TEXT NOT NULL,
+      result_text        TEXT,
+      error_text         TEXT,
+      created_at         INTEGER NOT NULL,
+      updated_at         INTEGER NOT NULL,
+      UNIQUE(side_chat_id, request_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_side_attempts_chat_time
+      ON side_chat_attempts(side_chat_id, created_at, attempt_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_side_attempt_active
+      ON side_chat_attempts(side_chat_id)
+      WHERE state IN ('starting','running');
+
+    CREATE TABLE IF NOT EXISTS side_chat_events (
+      event_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+      side_chat_id  TEXT NOT NULL,
+      attempt_id    TEXT,
+      thread_id     TEXT,
+      turn_id       TEXT,
+      event_type    TEXT NOT NULL,
+      state         TEXT,
+      reason        TEXT,
+      created_at    INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_side_events_chat_id
+      ON side_chat_events(side_chat_id, event_id);
+
+    CREATE TABLE IF NOT EXISTS side_chat_operations (
+      operation_id       TEXT PRIMARY KEY,
+      side_chat_id       TEXT NOT NULL,
+      attempt_id         TEXT,
+      operation_kind     TEXT NOT NULL,
+      request_key        TEXT NOT NULL,
+      request_fingerprint TEXT NOT NULL,
+      state              TEXT NOT NULL,
+      thread_id          TEXT,
+      turn_id            TEXT,
+      error_code         TEXT,
+      created_at         INTEGER NOT NULL,
+      updated_at         INTEGER NOT NULL,
+      UNIQUE(side_chat_id, operation_kind, request_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_side_operations_chat_time
+      ON side_chat_operations(side_chat_id, created_at, operation_id);
+
+    CREATE TABLE IF NOT EXISTS side_chat_bring_backs (
+      bring_back_id       TEXT PRIMARY KEY,
+      side_chat_id        TEXT NOT NULL,
+      attempt_id          TEXT NOT NULL,
+      owner_user_id       TEXT NOT NULL,
+      request_key         TEXT NOT NULL,
+      request_fingerprint TEXT NOT NULL,
+      destination_thread_id TEXT NOT NULL,
+      destination_turn_id TEXT,
+      state               TEXT NOT NULL,
+      error_text          TEXT,
+      created_at          INTEGER NOT NULL,
+      updated_at          INTEGER NOT NULL,
+      completed_at        INTEGER,
+      UNIQUE(side_chat_id, request_key)
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_side_bring_back_destination
+      ON side_chat_bring_backs(side_chat_id, attempt_id, destination_thread_id);
+  `);
+  // Additive development migration for databases created by an earlier PR2
+  // draft before cross-coordinator cancel claiming was introduced.
+  try {
+    database.exec(
+      "ALTER TABLE side_chat_attempts ADD COLUMN cancel_requested_at INTEGER",
+    );
+  } catch (error: any) {
+    if (!/duplicate column|already exists/i.test(error?.message ?? ""))
+      throw error;
+  }
+  try {
+    database.exec(
+      "ALTER TABLE side_chat_attempts ADD COLUMN attachments_json TEXT NOT NULL DEFAULT '[]'",
+    );
+  } catch (error: any) {
+    if (!/duplicate column|already exists/i.test(error?.message ?? ""))
+      throw error;
+  }
+  try {
+    database.exec(
+      "ALTER TABLE side_chat_bring_backs ADD COLUMN completed_at INTEGER",
+    );
+  } catch (error: any) {
+    if (!/duplicate column|already exists/i.test(error?.message ?? ""))
+      throw error;
+  }
+  try {
+    database.exec("ALTER TABLE side_chats ADD COLUMN lifecycle_operation TEXT");
+  } catch (error: any) {
+    if (!/duplicate column|already exists/i.test(error?.message ?? ""))
+      throw error;
+  }
+}
+
+type SideChatRow = {
+  side_chat_id: string;
+  create_request_key: string;
+  network_id: string;
+  node_id: string;
+  owner_user_id: string;
+  source_thread_id: string;
+  question_text: string;
+  boundary_kind: "through" | "before";
+  boundary_turn_id: string;
+  derived_thread_id: string | null;
+  state: SideThreadState;
+  active_attempt_id: string | null;
+  runtime: string | null;
+  runtime_version: string | null;
+  topology: string | null;
+  evidence_revision: string | null;
+  attachments_json: string;
+  created_at: number;
+  updated_at: number;
+};
+type AttemptRow = {
+  attempt_id: string;
+  request_key: string;
+  parent_attempt_id: string | null;
+  thread_id: string | null;
+  turn_id: string | null;
+  state: SideThreadAttemptState;
+  result_text: string | null;
+  error_text: string | null;
+  attachments_json: string;
+  created_at: number;
+  updated_at: number;
+};
+
+export class SideThreadStore {
+  constructor(readonly db: DbAdapter) {
+    installSideThreadSchema(db);
+  }
+
+  getOwned(
+    sideChatId: string,
+    actor: SideThreadActor,
+  ): SideThreadRecord | undefined {
+    const row = this.db.get<SideChatRow>(
+      "SELECT * FROM side_chats WHERE side_chat_id = ?1 AND owner_user_id = ?2",
+      sideChatId,
+      actor.userId,
+    );
+    if (!row) return undefined;
+    if (actor.kind === "node" && actor.boundNodeId !== row.node_id)
+      return undefined;
+    if (actor.boundNetworkId && actor.boundNetworkId !== row.network_id)
+      return undefined;
+    return this.hydrate(row);
+  }
+
+  getByCreateKey(
+    actor: SideThreadActor,
+    requestKey: string,
+  ): { record: SideThreadRecord; fingerprint: string } | undefined {
+    const row = this.db.get<SideChatRow & { create_fingerprint: string }>(
+      "SELECT * FROM side_chats WHERE owner_user_id = ?1 AND create_request_key = ?2",
+      actor.userId,
+      requestKey,
+    );
+    if (!row) return undefined;
+    if (actor.kind === "node" && actor.boundNodeId !== row.node_id)
+      return undefined;
+    return { record: this.hydrate(row), fingerprint: row.create_fingerprint };
+  }
+
+  listOwned(
+    actor: SideThreadActor,
+    filters: { networkId?: string; nodeId?: string; limit?: number } = {},
+  ): SideThreadRecord[] {
+    let sql = "SELECT * FROM side_chats WHERE owner_user_id = ?1";
+    const params: unknown[] = [actor.userId];
+    const networkId = actor.boundNetworkId ?? filters.networkId;
+    if (networkId) {
+      params.push(networkId);
+      sql += ` AND network_id = ?${params.length}`;
+    }
+    const nodeId = actor.kind === "node" ? actor.boundNodeId : filters.nodeId;
+    if (nodeId) {
+      params.push(nodeId);
+      sql += ` AND node_id = ?${params.length}`;
+    }
+    params.push(Math.min(Math.max(filters.limit ?? 50, 1), 100));
+    sql += ` ORDER BY updated_at DESC, side_chat_id DESC LIMIT ?${params.length}`;
+    return this.db
+      .all<SideChatRow>(sql, ...params)
+      .map((row) => this.hydrate(row));
+  }
+
+  hydrate(row: SideChatRow): SideThreadRecord {
+    const attempts = this.db
+      .all<AttemptRow>(
+        "SELECT attempt_id,request_key,parent_attempt_id,thread_id,turn_id,state,result_text,error_text,attachments_json,created_at,updated_at FROM side_chat_attempts WHERE side_chat_id = ?1 ORDER BY created_at,attempt_id",
+        row.side_chat_id,
+      )
+      .map((a) => ({
+        attemptId: a.attempt_id,
+        requestKey: a.request_key,
+        parentAttemptId: a.parent_attempt_id ?? undefined,
+        threadId: a.thread_id ?? undefined,
+        turnId: a.turn_id ?? undefined,
+        state: a.state,
+        result: a.result_text ?? undefined,
+        error: a.error_text ?? undefined,
+        attachments: parseAttachmentJson(a.attachments_json),
+        createdAt: a.created_at,
+        updatedAt: a.updated_at,
+      }));
+    let attachments: SideThreadAttachmentRef[] = [];
+    try {
+      attachments = JSON.parse(row.attachments_json);
+    } catch {}
+    const bringBacks = this.db
+      .all<any>(
+        "SELECT bring_back_id,attempt_id,request_key,destination_thread_id,destination_turn_id,state,created_at,updated_at,completed_at FROM side_chat_bring_backs WHERE side_chat_id=?1 ORDER BY created_at,bring_back_id",
+        row.side_chat_id,
+      )
+      .map((b) => ({
+        bringBackId: b.bring_back_id,
+        attemptId: b.attempt_id,
+        requestKey: b.request_key,
+        destinationThreadId: b.destination_thread_id,
+        destinationTurnId: b.destination_turn_id ?? undefined,
+        state: b.state,
+        createdAt: b.created_at,
+        updatedAt: b.updated_at,
+        completedAt: b.completed_at ?? undefined,
+      }));
+    const operations = this.db
+      .all<any>(
+        "SELECT operation_id,attempt_id,operation_kind,request_key,state,thread_id,turn_id,error_code,created_at,updated_at FROM side_chat_operations WHERE side_chat_id=?1 ORDER BY created_at,rowid",
+        row.side_chat_id,
+      )
+      .map((op) => ({
+        operationId: op.operation_id,
+        attemptId: op.attempt_id ?? undefined,
+        kind: op.operation_kind,
+        requestKey: op.request_key,
+        state: op.state,
+        threadId: op.thread_id ?? undefined,
+        turnId: op.turn_id ?? undefined,
+        errorCode: op.error_code ?? undefined,
+        createdAt: op.created_at,
+        updatedAt: op.updated_at,
+      }));
+    return {
+      sideChatId: row.side_chat_id,
+      requestKey: row.create_request_key,
+      networkId: row.network_id,
+      nodeId: row.node_id,
+      ownerUserId: row.owner_user_id,
+      sourceThreadId: row.source_thread_id,
+      question: row.question_text,
+      boundary: {
+        kind: row.boundary_kind,
+        turnId: row.boundary_turn_id,
+      } as SideThreadBoundary,
+      threadId: row.derived_thread_id ?? undefined,
+      state: row.state,
+      activeAttemptId: row.active_attempt_id ?? undefined,
+      runtime: row.runtime ?? undefined,
+      runtimeVersion: row.runtime_version ?? undefined,
+      topology: row.topology ?? undefined,
+      evidenceRevision: row.evidence_revision ?? undefined,
+      attachments,
+      attempts,
+      bringBacks,
+      operations,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  events(sideChatId: string, after = 0): SideThreadEventRecord[] {
+    return this.db
+      .all<any>(
+        "SELECT event_id,side_chat_id,attempt_id,thread_id,turn_id,event_type,state,reason,created_at FROM side_chat_events WHERE side_chat_id = ?1 AND event_id > ?2 ORDER BY event_id LIMIT 500",
+        sideChatId,
+        after,
+      )
+      .map((e) => ({
+        eventId: e.event_id,
+        sideChatId: e.side_chat_id,
+        attemptId: e.attempt_id ?? undefined,
+        threadId: e.thread_id ?? undefined,
+        turnId: e.turn_id ?? undefined,
+        type: e.event_type,
+        state: e.state ?? undefined,
+        reason: e.reason ?? undefined,
+        createdAt: e.created_at,
+      }));
+  }
+}
+
+type CreateInput = {
+  requestKey: string;
+  networkId: string;
+  nodeId: string;
+  sourceThreadId: string;
+  boundary: SideThreadBoundary;
+  prompt: string;
+  attachments?: SideThreadAttachmentRef[];
+};
+
+export class SideThreadCoordinator {
+  private readonly emitter = new EventEmitter();
+  private readonly unsubscribe: () => void;
+  private readonly inFlight = new Map<string, Promise<unknown>>();
+  constructor(
+    readonly store: SideThreadStore,
+    readonly port: SideThreadExecutionPort,
+    private readonly opts: {
+      enabled: boolean;
+      authorizeNode: (
+        actor: SideThreadActor,
+        networkId: string,
+        nodeId: string,
+      ) => boolean;
+      authorizeAttachment?: (
+        actor: SideThreadActor,
+        networkId: string,
+        ref: SideThreadAttachmentRef,
+      ) => boolean;
+      now?: () => number;
+      id?: () => string;
+    },
+  ) {
+    this.unsubscribe = port.subscribe((event) => {
+      void this.acceptRuntimeEvent(event);
+    });
+  }
+
+  close(): void {
+    this.unsubscribe();
+    this.emitter.removeAllListeners();
+  }
+  private now(): number {
+    return (this.opts.now ?? Date.now)();
+  }
+  private id(prefix: string): string {
+    return `${prefix}_${(this.opts.id ?? randomUUID)().replace(/-/g, "")}`;
+  }
+
+  private assertEnabled(): void {
+    if (!this.opts.enabled)
+      throw new SideThreadError(
+        "SIDE_THREAD_DISABLED",
+        "SideThread API is disabled",
+        404,
+      );
+  }
+  private assertActor(actor: SideThreadActor): void {
+    requireIdentity(actor.userId, "actor.userId");
+    requireIdentity(actor.tokenId, "actor.tokenId");
+  }
+  private async assertCapability(
+    nodeId: string,
+    boundary?: SideThreadBoundary,
+  ): Promise<SideThreadCapability> {
+    const cap = await this.port.capability(nodeId);
+    if (!cap.supported)
+      throw new SideThreadError(
+        "SIDE_THREAD_UNSUPPORTED",
+        capabilityReason(cap.reason),
+        501,
+      );
+    if (cap.mode !== "native-exact-fork")
+      throw new SideThreadError(
+        "SIDE_THREAD_UNSUPPORTED",
+        "verified native exact-fork mode unavailable",
+        501,
+      );
+    if (boundary && !cap.exactBoundary?.[boundary.kind]) {
+      throw new SideThreadError(
+        "SIDE_THREAD_UNSUPPORTED",
+        `exact '${boundary.kind}' boundary unavailable`,
+        501,
+      );
+    }
+    return cap;
+  }
+
+  async create(
+    actor: SideThreadActor,
+    input: CreateInput,
+  ): Promise<SideThreadRecord> {
+    this.assertEnabled();
+    this.assertActor(actor);
+    validateCreateInput(input);
+    if (!this.opts.authorizeNode(actor, input.networkId, input.nodeId)) {
+      throw new SideThreadError("SIDE_THREAD_NOT_FOUND", "node not found", 404);
+    }
+    const attachments = normalizeAttachments(input.attachments);
+    for (const ref of attachments) {
+      if (!this.opts.authorizeAttachment?.(actor, input.networkId, ref)) {
+        throw new SideThreadError(
+          "SIDE_THREAD_ATTACHMENT_NOT_FOUND",
+          "attachment not found",
+          404,
+        );
+      }
+    }
+    const fingerprint = hashJson([
+      input.networkId,
+      input.nodeId,
+      input.sourceThreadId,
+      input.boundary,
+      input.prompt,
+      attachments,
+    ]);
+    const existing = this.store.getByCreateKey(actor, input.requestKey);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint)
+        throw conflict("idempotency key reused with different create payload");
+      return existing.record;
+    }
+    return this.singleFlight(
+      `create:${actor.userId}:${input.requestKey}`,
+      async () => {
+        const replay = this.store.getByCreateKey(actor, input.requestKey);
+        if (replay) {
+          if (replay.fingerprint !== fingerprint)
+            throw conflict(
+              "idempotency key reused with different create payload",
+            );
+          return replay.record;
+        }
+        const capability = await this.assertCapability(
+          input.nodeId,
+          input.boundary,
+        );
+        const sideChatId = this.id("sch");
+        const attemptId = this.id("sat");
+        const forkOperationId = stableOperationId(
+          sideChatId,
+          "fork",
+          input.requestKey,
+        );
+        const now = this.now();
+        try {
+          this.store.db.transaction(() => {
+            this.store.db.run(
+              `INSERT INTO side_chats (side_chat_id,network_id,node_id,owner_user_id,created_by_token_id,create_request_key,create_fingerprint,source_thread_id,question_text,boundary_kind,boundary_turn_id,state,active_attempt_id,runtime,runtime_version,topology,evidence_revision,attachments_json,created_at,updated_at)
+           VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,'creating',?12,?13,?14,?15,?16,?17,?18,?18)`,
+              [
+                sideChatId,
+                input.networkId,
+                input.nodeId,
+                actor.userId,
+                actor.tokenId,
+                input.requestKey,
+                fingerprint,
+                input.sourceThreadId,
+                input.prompt,
+                input.boundary.kind,
+                input.boundary.turnId,
+                attemptId,
+                capability.runtime ?? null,
+                capability.runtimeVersion ?? null,
+                capability.topology ?? null,
+                capability.evidenceRevision ?? null,
+                JSON.stringify(attachments),
+                now,
+              ],
+            );
+            this.store.db.run(
+              `INSERT INTO side_chat_attempts (attempt_id,side_chat_id,request_key,request_fingerprint,prompt_hash,attachments_json,state,created_at,updated_at)
+           VALUES (?1,?2,?3,?4,?5,?6,'starting',?7,?7)`,
+              [
+                attemptId,
+                sideChatId,
+                input.requestKey,
+                fingerprint,
+                hashText(input.prompt),
+                JSON.stringify(attachments),
+                now,
+              ],
+            );
+            this.insertOperation({
+              operationId: forkOperationId,
+              sideChatId,
+              attemptId,
+              kind: "fork",
+              requestKey: input.requestKey,
+              fingerprint,
+              at: now,
+            });
+            this.emitStored(
+              sideChatId,
+              attemptId,
+              undefined,
+              undefined,
+              "side_chat.created",
+              "creating",
+              undefined,
+              now,
+            );
+          });
+        } catch (error) {
+          const winner = this.store.getByCreateKey(actor, input.requestKey);
+          if (winner) {
+            if (winner.fingerprint !== fingerprint)
+              throw conflict(
+                "idempotency key reused with different create payload",
+              );
+            return winner.record;
+          }
+          throw error;
+        }
+        let activeOperationId = forkOperationId;
+        try {
+          const forked = await this.port.fork({
+            operationId: forkOperationId,
+            requestKey: input.requestKey,
+            sideChatId,
+            nodeId: input.nodeId,
+            sourceThreadId: input.sourceThreadId,
+            boundary: input.boundary,
+          });
+          requireRuntimeIdentity(forked.threadId, "threadId");
+          if (forked.threadId === input.sourceThreadId)
+            throw runtimeProtocol(
+              "runtime returned source thread as side thread",
+            );
+          this.store.db.transaction(() => {
+            const t = this.now();
+            this.store.db.run(
+              "UPDATE side_chats SET derived_thread_id=?1,updated_at=?2 WHERE side_chat_id=?3 AND state='creating'",
+              [forked.threadId, t, sideChatId],
+            );
+            this.store.db.run(
+              "UPDATE side_chat_attempts SET thread_id=?1,updated_at=?2 WHERE attempt_id=?3 AND state='starting'",
+              [forked.threadId, t, attemptId],
+            );
+            this.settleOperation(forkOperationId, "completed", {
+              threadId: forked.threadId,
+            });
+          });
+          const startOperationId = stableOperationId(
+            sideChatId,
+            "start",
+            input.requestKey,
+          );
+          activeOperationId = startOperationId;
+          this.insertOperation({
+            operationId: startOperationId,
+            sideChatId,
+            attemptId,
+            kind: "start",
+            requestKey: input.requestKey,
+            fingerprint,
+            threadId: forked.threadId,
+            at: this.now(),
+          });
+          const started = await this.port.start({
+            operationId: startOperationId,
+            requestKey: input.requestKey,
+            sideChatId,
+            attemptId,
+            nodeId: input.nodeId,
+            threadId: forked.threadId,
+            prompt: input.prompt,
+            attachments,
+          });
+          requireRuntimeIdentity(started.turnId, "turnId");
+          this.store.db.transaction(() => {
+            const attempt = this.store.db.get<any>(
+              "SELECT state,turn_id FROM side_chat_attempts WHERE attempt_id=?1",
+              attemptId,
+            );
+            if (!attempt) throw conflict("attempt disappeared during start");
+            if (attempt.turn_id && attempt.turn_id !== started.turnId)
+              throw runtimeProtocol(
+                "runtime turn identity changed during start",
+              );
+            this.settleOperation(startOperationId, "completed", {
+              threadId: forked.threadId,
+              turnId: started.turnId,
+            });
+            if (attempt.state === "starting") {
+              const t = this.now();
+              this.store.db.run(
+                "UPDATE side_chat_attempts SET state='running',turn_id=?1,updated_at=?2 WHERE attempt_id=?3 AND state='starting'",
+                [started.turnId, t, attemptId],
+              );
+              this.store.db.run(
+                "UPDATE side_chats SET state='running',derived_thread_id=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id=?4",
+                [forked.threadId, t, sideChatId, attemptId],
+              );
+              this.emitStored(
+                sideChatId,
+                attemptId,
+                forked.threadId,
+                started.turnId,
+                "attempt.running",
+                "running",
+                undefined,
+                t,
+              );
+            }
+          });
+        } catch (error) {
+          if (isAmbiguousRuntimeError(error)) {
+            if (this.operationState(activeOperationId) === "completed")
+              return this.mustOwned(sideChatId, actor);
+            this.markAmbiguous(sideChatId, attemptId, activeOperationId, error);
+            throw ambiguousError(activeOperationId, sideChatId, attemptId);
+          }
+          this.settleOperation(activeOperationId, "failed", {
+            errorCode: auditErrorReason(error),
+          });
+          this.failStarting(sideChatId, attemptId, error);
+          throw normalizePortError(error);
+        }
+        return this.mustOwned(sideChatId, actor);
+      },
+    );
+  }
+
+  get(actor: SideThreadActor, sideChatId: string): SideThreadRecord {
+    this.assertEnabled();
+    this.assertActor(actor);
+    requireIdentity(sideChatId, "sideChatId");
+    return this.mustOwned(sideChatId, actor);
+  }
+
+  list(
+    actor: SideThreadActor,
+    filters: { networkId?: string; nodeId?: string; limit?: number } = {},
+  ): SideThreadRecord[] {
+    this.assertEnabled();
+    this.assertActor(actor);
+    if (filters.networkId) requireIdentity(filters.networkId, "networkId");
+    if (filters.nodeId) requireIdentity(filters.nodeId, "nodeId");
+    return this.store
+      .listOwned(actor, filters)
+      .filter((record) =>
+        this.opts.authorizeNode(actor, record.networkId, record.nodeId),
+      );
+  }
+
+  isEnabled(): boolean {
+    return this.opts.enabled;
+  }
+
+  async capability(
+    actor: SideThreadActor,
+    networkId: string,
+    nodeId: string,
+    boundary: SideThreadBoundary,
+  ): Promise<SideThreadCapability> {
+    this.assertEnabled();
+    this.assertActor(actor);
+    requireIdentity(networkId, "networkId");
+    requireIdentity(nodeId, "nodeId");
+    requireIdentity(boundary.turnId, "boundary.turnId");
+    if (!this.opts.authorizeNode(actor, networkId, nodeId))
+      throw new SideThreadError("SIDE_THREAD_NOT_FOUND", "node not found", 404);
+    const capability = await this.port.capability(nodeId);
+    if (!capability.supported)
+      return {
+        supported: false,
+        reason: capabilityReasonCode(capability.reason),
+      };
+    if (capability.mode !== "native-exact-fork")
+      return { supported: false, reason: "native-exact-fork-unavailable" };
+    if (!capability.exactBoundary?.[boundary.kind])
+      return { supported: false, reason: `exact-${boundary.kind}-unavailable` };
+    return capability;
+  }
+
+  async cancel(
+    actor: SideThreadActor,
+    sideChatId: string,
+  ): Promise<SideThreadRecord> {
+    this.assertEnabled();
+    return this.singleFlight(`cancel:${sideChatId}`, async () => {
+      const record = this.mustOwned(sideChatId, actor);
+      const attempt = record.attempts.find(
+        (a) => a.attemptId === record.activeAttemptId,
+      );
+      if (
+        !attempt?.threadId ||
+        !attempt.turnId ||
+        !["running", "ambiguous", "reconciling"].includes(attempt.state)
+      )
+        throw conflict("side chat has no cancellable attempt");
+      await this.assertCapability(record.nodeId);
+      const operationRequestKey = `cancel:${attempt.attemptId}`;
+      const prepared = this.prepareStableOperation({
+        sideChatId,
+        attemptId: attempt.attemptId,
+        kind: "cancel",
+        requestKey: operationRequestKey,
+        fingerprint: hashJson([
+          sideChatId,
+          attempt.attemptId,
+          attempt.threadId,
+          attempt.turnId,
+        ]),
+        threadId: attempt.threadId,
+        turnId: attempt.turnId,
+      });
+      if (prepared.state === "completed") return record;
+      if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+        throw ambiguousError(
+          prepared.operationId,
+          sideChatId,
+          attempt.attemptId,
+        );
+      // A second coordinator observing the durable pending claim must never
+      // issue another RPC. Returning its current owner projection is an
+      // honest in-progress replay; ambiguous is handled above and is typed.
+      if (!prepared.callable) return this.mustOwned(sideChatId, actor);
+      const claimedAt = this.now();
+      const claim = this.store.db.run(
+        "UPDATE side_chat_attempts SET cancel_requested_at=?1,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4 AND cancel_requested_at IS NULL",
+        [claimedAt, attempt.attemptId, attempt.threadId, attempt.turnId],
+      );
+      if (claim.changes === 0) {
+        this.markAmbiguous(
+          sideChatId,
+          attempt.attemptId,
+          prepared.operationId,
+          { code: "SIDE_THREAD_RESPONSE_LOST" },
+        );
+        throw ambiguousError(
+          prepared.operationId,
+          sideChatId,
+          attempt.attemptId,
+        );
+      }
+      try {
+        await this.port.cancel({
+          operationId: prepared.operationId,
+          sideChatId,
+          attemptId: attempt.attemptId,
+          nodeId: record.nodeId,
+          threadId: attempt.threadId,
+          turnId: attempt.turnId,
+        });
+      } catch (error) {
+        if (isAmbiguousRuntimeError(error)) {
+          this.markAmbiguous(
+            sideChatId,
+            attempt.attemptId,
+            prepared.operationId,
+            error,
+          );
+          throw ambiguousError(
+            prepared.operationId,
+            sideChatId,
+            attempt.attemptId,
+          );
+        }
+        this.settleOperation(prepared.operationId, "failed", {
+          errorCode: auditErrorReason(error),
+        });
+        this.store.db.run(
+          "UPDATE side_chat_attempts SET cancel_requested_at=NULL,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
+          [this.now(), attempt.attemptId, attempt.threadId, attempt.turnId],
+        );
+        throw normalizePortError(error);
+      }
+      this.store.db.transaction(() => {
+        const t = this.now();
+        const changed = this.store.db.run(
+          "UPDATE side_chat_attempts SET state='cancelled',updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
+          [t, attempt.attemptId, attempt.threadId, attempt.turnId],
+        );
+        if (changed.changes > 0) {
+          this.store.db.run(
+            "UPDATE side_chats SET state='cancelled',active_attempt_id=NULL,updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3",
+            [t, sideChatId, attempt.attemptId],
+          );
+          this.emitStored(
+            sideChatId,
+            attempt.attemptId,
+            attempt.threadId,
+            attempt.turnId,
+            "attempt.cancelled",
+            "cancelled",
+            undefined,
+            t,
+          );
+        }
+        this.settleOperation(prepared.operationId, "completed", {
+          threadId: attempt.threadId,
+          turnId: attempt.turnId,
+        });
+      });
+      return this.mustOwned(sideChatId, actor);
+    });
+  }
+
+  async retry(
+    actor: SideThreadActor,
+    sideChatId: string,
+    input: {
+      requestKey: string;
+      prompt: string;
+      attachments?: SideThreadAttachmentRef[];
+    },
+  ): Promise<SideThreadRecord> {
+    this.assertEnabled();
+    requireKey(input.requestKey);
+    requirePrompt(input.prompt);
+    return this.singleFlight(
+      `retry:${sideChatId}:${input.requestKey}`,
+      async () => {
+        const record = this.mustOwned(sideChatId, actor);
+        if (!record.threadId) throw conflict("side chat has no derived thread");
+        const attachments = normalizeAttachments(
+          input.attachments ?? record.attachments,
+        );
+        for (const ref of attachments)
+          if (!this.opts.authorizeAttachment?.(actor, record.networkId, ref))
+            throw new SideThreadError(
+              "SIDE_THREAD_ATTACHMENT_NOT_FOUND",
+              "attachment not found",
+              404,
+            );
+        const fingerprint = hashJson([sideChatId, input.prompt, attachments]);
+        const old = this.store.db.get<any>(
+          "SELECT attempt_id,request_fingerprint FROM side_chat_attempts WHERE side_chat_id=?1 AND request_key=?2",
+          sideChatId,
+          input.requestKey,
+        );
+        if (old) {
+          if (old.request_fingerprint !== fingerprint)
+            throw conflict(
+              "idempotency key reused with different retry payload",
+            );
+          return this.mustOwned(sideChatId, actor);
+        }
+        if (record.activeAttemptId)
+          throw conflict("side chat already has an active attempt");
+        if (record.state === "archived" || record.state === "purged")
+          throw conflict(`cannot retry ${record.state} side chat`);
+        await this.assertCapability(record.nodeId);
+        const parent = record.attempts.at(-1);
+        if (!parent) throw conflict("side chat has no prior attempt");
+        const attemptId = this.id("sat"),
+          startOperationId = stableOperationId(
+            sideChatId,
+            "start",
+            input.requestKey,
+          ),
+          t = this.now();
+        try {
+          this.store.db.transaction(() => {
+            this.store.db.run(
+              "INSERT INTO side_chat_attempts (attempt_id,side_chat_id,parent_attempt_id,request_key,request_fingerprint,prompt_hash,attachments_json,thread_id,state,created_at,updated_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,'starting',?9,?9)",
+              [
+                attemptId,
+                sideChatId,
+                parent.attemptId,
+                input.requestKey,
+                fingerprint,
+                hashText(input.prompt),
+                JSON.stringify(attachments),
+                record.threadId,
+                t,
+              ],
+            );
+            this.insertOperation({
+              operationId: startOperationId,
+              sideChatId,
+              attemptId,
+              kind: "start",
+              requestKey: input.requestKey,
+              fingerprint,
+              threadId: record.threadId,
+              at: t,
+            });
+            this.store.db.run(
+              "UPDATE side_chats SET state='running',active_attempt_id=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id IS NULL",
+              [attemptId, t, sideChatId],
+            );
+            this.emitStored(
+              sideChatId,
+              attemptId,
+              record.threadId,
+              undefined,
+              "attempt.retrying",
+              "starting",
+              undefined,
+              t,
+            );
+          });
+        } catch (error) {
+          const winner = this.store.db.get<any>(
+            "SELECT request_fingerprint FROM side_chat_attempts WHERE side_chat_id=?1 AND request_key=?2",
+            sideChatId,
+            input.requestKey,
+          );
+          if (winner) {
+            if (winner.request_fingerprint !== fingerprint)
+              throw conflict(
+                "idempotency key reused with different retry payload",
+              );
+            return this.mustOwned(sideChatId, actor);
+          }
+          const active = this.store.db.get<{ attempt_id: string }>(
+            "SELECT attempt_id FROM side_chat_attempts WHERE side_chat_id=?1 AND state IN ('starting','running') LIMIT 1",
+            sideChatId,
+          );
+          if (active) throw conflict("side chat already has an active attempt");
+          throw error;
+        }
+        try {
+          const started = await this.port.start({
+            operationId: startOperationId,
+            requestKey: input.requestKey,
+            sideChatId,
+            attemptId,
+            nodeId: record.nodeId,
+            threadId: record.threadId,
+            prompt: input.prompt,
+            attachments,
+          });
+          requireRuntimeIdentity(started.turnId, "turnId");
+          this.store.db.transaction(() => {
+            const now = this.now();
+            const attempt = this.store.db.get<any>(
+              "SELECT state,turn_id FROM side_chat_attempts WHERE attempt_id=?1",
+              attemptId,
+            );
+            if (attempt?.turn_id && attempt.turn_id !== started.turnId)
+              throw runtimeProtocol(
+                "runtime turn identity changed during retry",
+              );
+            this.settleOperation(startOperationId, "completed", {
+              threadId: record.threadId,
+              turnId: started.turnId,
+            });
+            if (attempt?.state === "starting") {
+              this.store.db.run(
+                "UPDATE side_chat_attempts SET state='running',turn_id=?1,updated_at=?2 WHERE attempt_id=?3",
+                [started.turnId, now, attemptId],
+              );
+              this.emitStored(
+                sideChatId,
+                attemptId,
+                record.threadId,
+                started.turnId,
+                "attempt.running",
+                "running",
+                undefined,
+                now,
+              );
+            }
+          });
+        } catch (error) {
+          if (isAmbiguousRuntimeError(error)) {
+            if (this.operationState(startOperationId) === "completed")
+              return this.mustOwned(sideChatId, actor);
+            this.markAmbiguous(sideChatId, attemptId, startOperationId, error);
+            throw ambiguousError(startOperationId, sideChatId, attemptId);
+          }
+          this.settleOperation(startOperationId, "failed", {
+            errorCode: auditErrorReason(error),
+          });
+          this.failStarting(sideChatId, attemptId, error);
+          throw normalizePortError(error);
+        }
+        return this.mustOwned(sideChatId, actor);
+      },
+    );
+  }
+
+  async archive(
+    actor: SideThreadActor,
+    sideChatId: string,
+  ): Promise<SideThreadRecord> {
+    return this.lifecycle(actor, sideChatId, "archive");
+  }
+  async purge(
+    actor: SideThreadActor,
+    sideChatId: string,
+  ): Promise<SideThreadRecord> {
+    return this.lifecycle(actor, sideChatId, "purge");
+  }
+  private async lifecycle(
+    actor: SideThreadActor,
+    sideChatId: string,
+    action: "archive" | "purge",
+  ): Promise<SideThreadRecord> {
+    this.assertEnabled();
+    return this.singleFlight(`${action}:${sideChatId}`, async () => {
+      const r = this.mustOwned(sideChatId, actor);
+      if (r.activeAttemptId)
+        throw conflict(`cannot ${action} a running side chat`);
+      if (!r.threadId) throw conflict("side chat has no derived thread");
+      if (r.state === "purged") return r;
+      if (action === "archive" && r.state === "archived") return r;
+      await this.assertCapability(r.nodeId);
+      const operationRequestKey = `${action}:${sideChatId}`;
+      const prepared = this.prepareStableOperation({
+        sideChatId,
+        kind: action,
+        requestKey: operationRequestKey,
+        fingerprint: hashJson([action, sideChatId, r.nodeId, r.threadId]),
+        threadId: r.threadId,
+      });
+      if (prepared.state === "completed") return r;
+      if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+        throw ambiguousError(prepared.operationId, sideChatId);
+      if (!prepared.callable)
+        throw conflict("side chat lifecycle operation already in progress");
+      const claim = this.store.db.run(
+        "UPDATE side_chats SET lifecycle_operation=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id IS NULL AND lifecycle_operation IS NULL",
+        [action, this.now(), sideChatId],
+      );
+      if (claim.changes === 0) {
+        const current = this.mustOwned(sideChatId, actor);
+        if (current.state === "purged") return current;
+        if (action === "archive" && current.state === "archived")
+          return current;
+        this.markAmbiguous(sideChatId, undefined, prepared.operationId, {
+          code: "SIDE_THREAD_RESPONSE_LOST",
+        });
+        throw ambiguousError(prepared.operationId, sideChatId);
+      }
+      try {
+        if (action === "archive")
+          await this.port.archive({
+            operationId: prepared.operationId,
+            sideChatId,
+            nodeId: r.nodeId,
+            threadId: r.threadId,
+          });
+        else
+          await this.port.purge({
+            operationId: prepared.operationId,
+            sideChatId,
+            nodeId: r.nodeId,
+            threadId: r.threadId,
+          });
+      } catch (error) {
+        if (isAmbiguousRuntimeError(error)) {
+          this.markAmbiguous(
+            sideChatId,
+            undefined,
+            prepared.operationId,
+            error,
+          );
+          throw ambiguousError(prepared.operationId, sideChatId);
+        }
+        this.settleOperation(prepared.operationId, "failed", {
+          errorCode: auditErrorReason(error),
+        });
+        this.store.db.run(
+          "UPDATE side_chats SET lifecycle_operation=NULL,updated_at=?1 WHERE side_chat_id=?2 AND lifecycle_operation=?3",
+          [this.now(), sideChatId, action],
+        );
+        throw normalizePortError(error);
+      }
+      const state = action === "archive" ? "archived" : "purged",
+        t = this.now();
+      this.store.db.transaction(() => {
+        if (action === "purge") {
+          this.store.db.run(
+            "UPDATE side_chats SET state='purged',question_text='',attachments_json='[]',lifecycle_operation=NULL,updated_at=?1,purged_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='purge'",
+            [t, sideChatId],
+          );
+          this.store.db.run(
+            "UPDATE side_chat_attempts SET result_text=NULL,error_text=NULL,updated_at=?1 WHERE side_chat_id=?2",
+            [t, sideChatId],
+          );
+        } else {
+          this.store.db.run(
+            "UPDATE side_chats SET state='archived',lifecycle_operation=NULL,updated_at=?1,archived_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='archive'",
+            [t, sideChatId],
+          );
+        }
+        this.settleOperation(prepared.operationId, "completed", {
+          threadId: r.threadId,
+        });
+        this.emitStored(
+          sideChatId,
+          undefined,
+          r.threadId,
+          undefined,
+          `side_chat.${state}`,
+          state,
+          undefined,
+          t,
+        );
+      });
+      return this.mustOwned(sideChatId, actor);
+    });
+  }
+
+  async bringBack(
+    actor: SideThreadActor,
+    sideChatId: string,
+    input: {
+      requestKey: string;
+      destinationThreadId: string;
+      attemptId?: string;
+    },
+  ): Promise<{ bringBackId: string; destinationTurnId: string }> {
+    this.assertEnabled();
+    requireKey(input.requestKey);
+    requireIdentity(input.destinationThreadId, "destinationThreadId");
+    return this.singleFlight(
+      `bring-back:${sideChatId}:${input.requestKey}`,
+      async () => {
+        const r = this.mustOwned(sideChatId, actor);
+        if (r.state === "purged")
+          throw conflict("cannot bring back a purged side chat");
+        if (input.destinationThreadId !== r.sourceThreadId)
+          throw conflict(
+            "bring-back destination must be the original source thread",
+          );
+        const attempt = input.attemptId
+          ? r.attempts.find((a) => a.attemptId === input.attemptId)
+          : [...r.attempts].reverse().find((a) => a.state === "completed");
+        if (
+          !attempt ||
+          attempt.state !== "completed" ||
+          !attempt.result ||
+          !attempt.threadId ||
+          !attempt.turnId
+        )
+          throw conflict("bring-back requires a completed owned attempt");
+        const fp = hashJson([
+          sideChatId,
+          attempt.attemptId,
+          input.destinationThreadId,
+        ]);
+        const old = this.store.db.get<any>(
+          "SELECT bring_back_id,destination_turn_id,request_fingerprint,state FROM side_chat_bring_backs WHERE side_chat_id=?1 AND request_key=?2",
+          sideChatId,
+          input.requestKey,
+        );
+        if (old) {
+          if (old.request_fingerprint !== fp)
+            throw conflict(
+              "idempotency key reused with different bring-back payload",
+            );
+          if (old.state !== "completed" || !old.destination_turn_id) {
+            const operation = this.store.db.get<{
+              operation_id: string;
+              state: string;
+            }>(
+              "SELECT operation_id,state FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='bring-back' AND request_key=?2",
+              sideChatId,
+              input.requestKey,
+            );
+            if (
+              operation &&
+              (operation.state === "ambiguous" ||
+                operation.state === "reconciling")
+            )
+              throw ambiguousError(
+                operation.operation_id,
+                sideChatId,
+                attempt.attemptId,
+              );
+            throw conflict("bring-back is already in progress or failed");
+          }
+          return {
+            bringBackId: old.bring_back_id,
+            destinationTurnId: old.destination_turn_id,
+          };
+        }
+        const priorDestination = this.store.db.get<any>(
+          "SELECT bring_back_id,destination_turn_id,state FROM side_chat_bring_backs WHERE side_chat_id=?1 AND attempt_id=?2 AND destination_thread_id=?3",
+          sideChatId,
+          attempt.attemptId,
+          input.destinationThreadId,
+        );
+        if (priorDestination) {
+          if (
+            priorDestination.state === "completed" &&
+            priorDestination.destination_turn_id
+          )
+            return {
+              bringBackId: priorDestination.bring_back_id,
+              destinationTurnId: priorDestination.destination_turn_id,
+            };
+          throw conflict(
+            "bring-back for this attempt is already in progress or failed",
+          );
+        }
+        await this.assertCapability(r.nodeId);
+        const prepared = this.prepareStableOperation({
+          sideChatId,
+          attemptId: attempt.attemptId,
+          kind: "bring-back",
+          requestKey: input.requestKey,
+          fingerprint: fp,
+          threadId: attempt.threadId,
+          turnId: attempt.turnId,
+        });
+        if (prepared.state === "completed") {
+          const completed = this.store.db.get<any>(
+            "SELECT bring_back_id,destination_turn_id FROM side_chat_bring_backs WHERE side_chat_id=?1 AND request_key=?2 AND state='completed'",
+            sideChatId,
+            input.requestKey,
+          );
+          if (completed?.destination_turn_id)
+            return {
+              bringBackId: completed.bring_back_id,
+              destinationTurnId: completed.destination_turn_id,
+            };
+        }
+        if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+          throw ambiguousError(
+            prepared.operationId,
+            sideChatId,
+            attempt.attemptId,
+          );
+        if (!prepared.callable)
+          throw conflict("bring-back operation is already in progress");
+        const bringBackId = this.id("sbb"),
+          t = this.now();
+        try {
+          this.store.db.run(
+            "INSERT INTO side_chat_bring_backs (bring_back_id,side_chat_id,attempt_id,owner_user_id,request_key,request_fingerprint,destination_thread_id,state,created_at,updated_at) VALUES (?1,?2,?3,?4,?5,?6,?7,'starting',?8,?8)",
+            [
+              bringBackId,
+              sideChatId,
+              attempt.attemptId,
+              actor.userId,
+              input.requestKey,
+              fp,
+              input.destinationThreadId,
+              t,
+            ],
+          );
+        } catch (error) {
+          const winner = this.store.db.get<any>(
+            "SELECT bring_back_id,destination_turn_id,state,request_key,request_fingerprint FROM side_chat_bring_backs WHERE side_chat_id=?1 AND (request_key=?2 OR (attempt_id=?3 AND destination_thread_id=?4)) LIMIT 1",
+            sideChatId,
+            input.requestKey,
+            attempt.attemptId,
+            input.destinationThreadId,
+          );
+          if (
+            winner?.request_key === input.requestKey &&
+            winner.request_fingerprint !== fp
+          )
+            throw conflict(
+              "idempotency key reused with different bring-back payload",
+            );
+          if (winner?.state === "completed" && winner.destination_turn_id)
+            return {
+              bringBackId: winner.bring_back_id,
+              destinationTurnId: winner.destination_turn_id,
+            };
+          if (winner)
+            throw conflict(
+              "bring-back for this attempt is already in progress or failed",
+            );
+          throw error;
+        }
+        try {
+          const out = await this.port.bringBack({
+            operationId: prepared.operationId,
+            sideChatId,
+            attemptId: attempt.attemptId,
+            nodeId: r.nodeId,
+            sourceThreadId: attempt.threadId,
+            sourceTurnId: attempt.turnId,
+            destinationThreadId: input.destinationThreadId,
+            requestKey: input.requestKey,
+            text: attempt.result,
+          });
+          requireRuntimeIdentity(out.destinationTurnId, "destinationTurnId");
+          const now = this.now();
+          this.store.db.transaction(() => {
+            this.store.db.run(
+              "UPDATE side_chat_bring_backs SET state='completed',destination_turn_id=?1,updated_at=?2,completed_at=?2 WHERE bring_back_id=?3 AND state='starting'",
+              [out.destinationTurnId, now, bringBackId],
+            );
+            this.settleOperation(prepared.operationId, "completed", {
+              threadId: input.destinationThreadId,
+              turnId: out.destinationTurnId,
+            });
+            this.emitStored(
+              sideChatId,
+              attempt.attemptId,
+              attempt.threadId,
+              attempt.turnId,
+              "side_chat.brought_back",
+              "completed",
+              undefined,
+              now,
+            );
+          });
+          return { bringBackId, destinationTurnId: out.destinationTurnId };
+        } catch (error) {
+          const operation = this.store.db.get<{ operation_id: string }>(
+            "SELECT operation_id FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='bring-back' AND request_key=?2",
+            sideChatId,
+            input.requestKey,
+          );
+          if (operation && isAmbiguousRuntimeError(error)) {
+            this.markAmbiguous(
+              sideChatId,
+              attempt.attemptId,
+              operation.operation_id,
+              error,
+            );
+            throw ambiguousError(
+              operation.operation_id,
+              sideChatId,
+              attempt.attemptId,
+            );
+          }
+          if (operation)
+            this.settleOperation(operation.operation_id, "failed", {
+              errorCode: auditErrorReason(error),
+            });
+          this.store.db.run(
+            "UPDATE side_chat_bring_backs SET state='failed',error_text=?1,updated_at=?2 WHERE bring_back_id=?3 AND state='starting'",
+            [
+              safeReason(
+                error instanceof Error ? error.message : String(error),
+              ),
+              this.now(),
+              bringBackId,
+            ],
+          );
+          throw normalizePortError(error);
+        }
+      },
+    );
+  }
+
+  listEvents(
+    actor: SideThreadActor,
+    sideChatId: string,
+    after = 0,
+  ): SideThreadEventRecord[] {
+    this.mustOwned(sideChatId, actor);
+    return this.store.events(sideChatId, after);
+  }
+  subscribe(
+    sideChatId: string,
+    listener: (event: SideThreadEventRecord) => void,
+  ): () => void {
+    const key = `side:${sideChatId}`;
+    this.emitter.on(key, listener);
+    return () => this.emitter.off(key, listener);
+  }
+
+  private insertOperation(input: {
+    operationId: string;
+    sideChatId: string;
+    attemptId?: string;
+    kind: SideThreadOperationRecord["kind"];
+    requestKey: string;
+    fingerprint: string;
+    threadId?: string;
+    turnId?: string;
+    at: number;
+  }): void {
+    this.store.db.run(
+      "INSERT INTO side_chat_operations (operation_id,side_chat_id,attempt_id,operation_kind,request_key,request_fingerprint,state,thread_id,turn_id,created_at,updated_at) VALUES (?1,?2,?3,?4,?5,?6,'pending',?7,?8,?9,?9)",
+      [
+        input.operationId,
+        input.sideChatId,
+        input.attemptId ?? null,
+        input.kind,
+        input.requestKey,
+        input.fingerprint,
+        input.threadId ?? null,
+        input.turnId ?? null,
+        input.at,
+      ],
+    );
+  }
+
+  private prepareStableOperation(input: {
+    sideChatId: string;
+    attemptId?: string;
+    kind: SideThreadOperationRecord["kind"];
+    requestKey: string;
+    fingerprint: string;
+    threadId?: string;
+    turnId?: string;
+  }): {
+    operationId: string;
+    state: SideThreadOperationRecord["state"];
+    callable: boolean;
+  } {
+    const operationId = stableOperationId(
+      input.sideChatId,
+      input.kind,
+      input.requestKey,
+    );
+    const existing = this.store.db.get<any>(
+      "SELECT operation_id,request_fingerprint,state FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind=?2 AND request_key=?3",
+      input.sideChatId,
+      input.kind,
+      input.requestKey,
+    );
+    if (existing) {
+      if (existing.request_fingerprint !== input.fingerprint)
+        throw conflict("operation request key reused with different payload");
+      if (existing.state === "failed") {
+        this.store.db.run(
+          "UPDATE side_chat_operations SET state='pending',error_code=NULL,updated_at=?1 WHERE operation_id=?2 AND state='failed'",
+          [this.now(), existing.operation_id],
+        );
+        return {
+          operationId: existing.operation_id,
+          state: "pending",
+          callable: true,
+        };
+      }
+      return {
+        operationId: existing.operation_id,
+        state: existing.state,
+        callable: false,
+      };
+    }
+    this.insertOperation({
+      operationId,
+      sideChatId: input.sideChatId,
+      attemptId: input.attemptId,
+      kind: input.kind,
+      requestKey: input.requestKey,
+      fingerprint: input.fingerprint,
+      threadId: input.threadId,
+      turnId: input.turnId,
+      at: this.now(),
+    });
+    return { operationId, state: "pending", callable: true };
+  }
+
+  private settleOperation(
+    operationId: string,
+    state: "completed" | "failed",
+    fields: { threadId?: string; turnId?: string; errorCode?: string } = {},
+  ): void {
+    this.store.db.run(
+      "UPDATE side_chat_operations SET state=?1,thread_id=COALESCE(?2,thread_id),turn_id=COALESCE(?3,turn_id),error_code=?4,updated_at=?5 WHERE operation_id=?6 AND state IN ('pending','ambiguous','reconciling')",
+      [
+        state,
+        fields.threadId ?? null,
+        fields.turnId ?? null,
+        fields.errorCode ?? null,
+        this.now(),
+        operationId,
+      ],
+    );
+  }
+
+  private operationState(operationId: string): string | undefined {
+    return this.store.db.get<{ state: string }>(
+      "SELECT state FROM side_chat_operations WHERE operation_id=?1",
+      operationId,
+    )?.state;
+  }
+
+  private markAmbiguous(
+    sideChatId: string,
+    attemptId: string | undefined,
+    operationId: string,
+    error: unknown,
+  ): void {
+    const at = this.now();
+    this.store.db.transaction(() => {
+      this.store.db.run(
+        "UPDATE side_chat_operations SET state='ambiguous',error_code=?1,updated_at=?2 WHERE operation_id=?3 AND state IN ('pending','reconciling')",
+        [auditErrorReason(error), at, operationId],
+      );
+      if (attemptId)
+        this.store.db.run(
+          "UPDATE side_chat_attempts SET state='ambiguous',updated_at=?1 WHERE attempt_id=?2 AND state IN ('starting','running','reconciling')",
+          [at, attemptId],
+        );
+      this.store.db.run(
+        "UPDATE side_chats SET state='ambiguous',updated_at=?1 WHERE side_chat_id=?2 AND state != 'purged'",
+        [at, sideChatId],
+      );
+      this.emitStored(
+        sideChatId,
+        attemptId,
+        undefined,
+        undefined,
+        "operation.ambiguous",
+        "ambiguous",
+        "SIDE_THREAD_AMBIGUOUS",
+        at,
+      );
+    });
+  }
+
+  private async acceptRuntimeEvent(
+    event: SideThreadRuntimeEvent,
+  ): Promise<void> {
+    try {
+      requireIdentity(event.sideChatId, "event.sideChatId");
+      requireIdentity(event.attemptId, "event.attemptId");
+      requireIdentity(event.threadId, "event.threadId");
+      requireIdentity(event.turnId, "event.turnId");
+      this.store.db.transaction(() => {
+        const owned = this.store.db.get<any>(
+          `SELECT c.active_attempt_id,c.derived_thread_id,a.state,a.turn_id FROM side_chats c JOIN side_chat_attempts a ON a.side_chat_id=c.side_chat_id AND a.attempt_id=?2 WHERE c.side_chat_id=?1`,
+          event.sideChatId,
+          event.attemptId,
+        );
+        const starting =
+          (owned?.state === "starting" ||
+            owned?.state === "ambiguous" ||
+            owned?.state === "reconciling") &&
+          !owned?.turn_id;
+        if (!owned) return;
+        if (
+          owned.active_attempt_id !== event.attemptId ||
+          owned.derived_thread_id !== event.threadId ||
+          (!starting && owned.turn_id !== event.turnId) ||
+          !(
+            owned.state === "running" ||
+            owned.state === "ambiguous" ||
+            owned.state === "reconciling" ||
+            starting
+          )
+        ) {
+          this.emitStored(
+            event.sideChatId,
+            event.attemptId,
+            event.threadId,
+            event.turnId,
+            "runtime_event.dropped",
+            undefined,
+            "ownership-mismatch",
+            this.now(),
+          );
+          return;
+        }
+        const state =
+          event.status === "completed"
+            ? "completed"
+            : event.status === "interrupted"
+              ? "cancelled"
+              : "failed";
+        const t = this.now();
+        const startOperation = this.store.db.get<{ operation_id: string }>(
+          "SELECT operation_id FROM side_chat_operations WHERE side_chat_id=?1 AND attempt_id=?2 AND operation_kind='start' ORDER BY created_at DESC LIMIT 1",
+          event.sideChatId,
+          event.attemptId,
+        );
+        if (startOperation)
+          this.settleOperation(startOperation.operation_id, "completed", {
+            threadId: event.threadId,
+            turnId: event.turnId,
+          });
+        this.store.db.run(
+          "UPDATE side_chat_attempts SET state=?1,turn_id=COALESCE(turn_id,?2),result_text=?3,error_text=?4,updated_at=?5 WHERE attempt_id=?6 AND state IN ('starting','running','ambiguous','reconciling')",
+          [
+            state,
+            event.turnId,
+            event.status === "completed" ? safeResult(event.text) : null,
+            event.status === "failed" ? safeReason(event.error) : null,
+            t,
+            event.attemptId,
+          ],
+        );
+        this.store.db.run(
+          "UPDATE side_chats SET state=?1,active_attempt_id=NULL,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id=?4",
+          [state, t, event.sideChatId, event.attemptId],
+        );
+        this.emitStored(
+          event.sideChatId,
+          event.attemptId,
+          event.threadId,
+          event.turnId,
+          "attempt.terminal",
+          state,
+          event.status,
+          t,
+        );
+      });
+    } catch {
+      /* malformed runtime events are untrusted and ignored */
+    }
+  }
+
+  private failStarting(
+    sideChatId: string,
+    attemptId: string,
+    error: unknown,
+  ): void {
+    const t = this.now(),
+      reason = safeReason(
+        error instanceof Error ? error.message : String(error),
+      );
+    this.store.db.transaction(() => {
+      const changed = this.store.db.run(
+        "UPDATE side_chat_attempts SET state='failed',error_text=?1,updated_at=?2 WHERE attempt_id=?3 AND state='starting'",
+        [reason, t, attemptId],
+      );
+      if (changed.changes > 0) {
+        this.store.db.run(
+          "UPDATE side_chats SET state='failed',active_attempt_id=NULL,updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3",
+          [t, sideChatId, attemptId],
+        );
+        this.emitStored(
+          sideChatId,
+          attemptId,
+          undefined,
+          undefined,
+          "attempt.failed",
+          "failed",
+          auditErrorReason(error),
+          t,
+        );
+      }
+    });
+  }
+  private emitStored(
+    sideChatId: string,
+    attemptId: string | undefined,
+    threadId: string | undefined,
+    turnId: string | undefined,
+    type: string,
+    state: string | undefined,
+    reason: string | undefined,
+    at: number,
+  ): void {
+    this.store.db.run(
+      "INSERT INTO side_chat_events (side_chat_id,attempt_id,thread_id,turn_id,event_type,state,reason,created_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+      [
+        sideChatId,
+        attemptId ?? null,
+        threadId ?? null,
+        turnId ?? null,
+        type,
+        state ?? null,
+        safeReason(reason) ?? null,
+        at,
+      ],
+    );
+    const row = this.store.db.get<any>(
+      "SELECT event_id FROM side_chat_events WHERE side_chat_id=?1 ORDER BY event_id DESC LIMIT 1",
+      sideChatId,
+    );
+    this.emitter.emit(`side:${sideChatId}`, {
+      eventId: row?.event_id ?? 0,
+      sideChatId,
+      attemptId,
+      threadId,
+      turnId,
+      type,
+      state,
+      reason: safeReason(reason),
+      createdAt: at,
+    } satisfies SideThreadEventRecord);
+  }
+  private mustOwned(
+    sideChatId: string,
+    actor: SideThreadActor,
+  ): SideThreadRecord {
+    const r = this.store.getOwned(sideChatId, actor);
+    if (!r || !this.opts.authorizeNode(actor, r.networkId, r.nodeId))
+      throw new SideThreadError(
+        "SIDE_THREAD_NOT_FOUND",
+        "side chat not found",
+        404,
+      );
+    return r;
+  }
+  private async singleFlight<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prior = this.inFlight.get(key);
+    if (prior) return prior as Promise<T>;
+    const op = fn();
+    this.inFlight.set(key, op);
+    try {
+      return await op;
+    } finally {
+      if (this.inFlight.get(key) === op) this.inFlight.delete(key);
+    }
+  }
+}
+
+function validateCreateInput(input: CreateInput): void {
+  requireKey(input.requestKey);
+  requireIdentity(input.networkId, "networkId");
+  requireIdentity(input.nodeId, "nodeId");
+  requireIdentity(input.sourceThreadId, "sourceThreadId");
+  if (input.boundary?.kind !== "through" && input.boundary?.kind !== "before")
+    throw conflict("invalid exact boundary");
+  requireIdentity(input.boundary.turnId, "boundary.turnId");
+  requirePrompt(input.prompt);
+}
+function requireIdentity(
+  value: unknown,
+  label: string,
+): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    !value ||
+    value.length > 512 ||
+    /[\r\n\0]/.test(value)
+  )
+    throw conflict(`invalid ${label}`);
+}
+function requireRuntimeIdentity(
+  value: unknown,
+  label: string,
+): asserts value is string {
+  if (
+    typeof value !== "string" ||
+    !value ||
+    value.length > 512 ||
+    /[\r\n\0]/.test(value)
+  )
+    throw runtimeProtocol(`runtime returned invalid ${label}`);
+}
+function requireKey(value: unknown): asserts value is string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9._:-]{8,160}$/.test(value))
+    throw conflict("invalid idempotency key");
+}
+function requirePrompt(value: unknown): asserts value is string {
+  if (typeof value !== "string" || !value.trim() || value.length > 100_000)
+    throw conflict("invalid prompt");
+}
+function normalizeAttachments(value: unknown): SideThreadAttachmentRef[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > 16)
+    throw conflict("invalid attachments");
+  const seen = new Set<string>();
+  return value.map((v) => {
+    if (
+      !v ||
+      typeof v !== "object" ||
+      Object.keys(v as object).some((k) => k !== "fileId") ||
+      typeof (v as any).fileId !== "string" ||
+      !/^[A-Za-z0-9_-]{8,64}$/.test((v as any).fileId)
+    )
+      throw conflict("attachments must contain fileId references only");
+    const fileId = (v as any).fileId;
+    if (seen.has(fileId)) throw conflict("duplicate attachment reference");
+    seen.add(fileId);
+    return { fileId };
+  });
+}
+function parseAttachmentJson(value: string): SideThreadAttachmentRef[] {
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (entry) =>
+          entry &&
+          typeof entry === "object" &&
+          typeof entry.fileId === "string" &&
+          /^[A-Za-z0-9_-]{8,64}$/.test(entry.fileId),
+      )
+      .map((entry) => ({ fileId: entry.fileId }));
+  } catch {
+    return [];
+  }
+}
+function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+function hashJson(value: unknown): string {
+  return hashText(JSON.stringify(value));
+}
+function stableOperationId(
+  sideChatId: string,
+  kind: SideThreadOperationRecord["kind"],
+  requestKey: string,
+): string {
+  return `sop_${hashJson([sideChatId, kind, requestKey]).slice(0, 40)}`;
+}
+function safeReason(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(
+      /(?:Bearer\s+)?(?:(?:a|n|u)tok_|sk-)[A-Za-z0-9._-]+/gi,
+      "[redacted]",
+    )
+    .slice(0, 300);
+}
+function safeResult(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.slice(0, 1_000_000);
+}
+function capabilityReason(reason: unknown): string {
+  return typeof reason === "string" && /^[a-z0-9-]{1,80}$/.test(reason)
+    ? `native SideThread unavailable: ${reason}`
+    : "native SideThread capability unavailable";
+}
+function capabilityReasonCode(reason: unknown): string {
+  return typeof reason === "string" && /^[a-z0-9-]{1,80}$/.test(reason)
+    ? reason
+    : "runtime-adapter-unavailable";
+}
+function auditErrorReason(error: unknown): string {
+  const code = (error as any)?.code;
+  return typeof code === "string" && /^[A-Z][A-Z0-9_]{2,80}$/.test(code)
+    ? code
+    : "runtime-error";
+}
+function conflict(message: string): SideThreadError {
+  return new SideThreadError("SIDE_THREAD_CONFLICT", message, 409);
+}
+function runtimeProtocol(message: string): SideThreadError {
+  return new SideThreadError("SIDE_THREAD_AMBIGUOUS", message, 202);
+}
+function isAmbiguousRuntimeError(error: unknown): boolean {
+  const code = (error as any)?.code;
+  return (
+    code === "SIDE_THREAD_AMBIGUOUS" || code === "SIDE_THREAD_RESPONSE_LOST"
+  );
+}
+function ambiguousError(
+  operationId: string,
+  sideChatId: string,
+  attemptId?: string,
+): SideThreadError {
+  return new SideThreadError(
+    "SIDE_THREAD_AMBIGUOUS",
+    "runtime acceptance is ambiguous; reconcile this stable operation before retrying",
+    202,
+    operationId,
+    sideChatId,
+    attemptId,
+  );
+}
+function normalizePortError(error: unknown): SideThreadError {
+  if (error instanceof SideThreadError) return error;
+  const code = (error as any)?.code;
+  if (code === "SIDE_THREAD_UNSUPPORTED")
+    return new SideThreadError(
+      "SIDE_THREAD_UNSUPPORTED",
+      "verified native SideThread adapter became unavailable",
+      501,
+    );
+  return new SideThreadError(
+    "SIDE_THREAD_RUNTIME_ERROR",
+    "SideThread runtime operation failed",
+    502,
+  );
+}

--- a/server/src/side-thread.ts
+++ b/server/src/side-thread.ts
@@ -1030,80 +1030,77 @@ export class SideThreadCoordinator {
   async cancel(
     actor: SideThreadActor,
     sideChatId: string,
+    input: { requestKey: string },
   ): Promise<SideThreadRecord> {
     this.assertEnabled();
-    return this.singleFlight(`cancel:${sideChatId}`, async () => {
-      const record = this.mustOwned(sideChatId, actor);
-      const attempt = record.attempts.find(
-        (a) => a.attemptId === record.activeAttemptId,
-      );
-      if (
-        !attempt?.threadId ||
-        !attempt.turnId ||
-        !["running", "ambiguous", "reconciling"].includes(attempt.state)
-      )
-        throw conflict("side chat has no cancellable attempt");
-      await this.assertCapability(record.nodeId);
-      const operationRequestKey = `cancel:${attempt.attemptId}`;
-      const prepared = this.prepareStableOperation({
-        sideChatId,
-        attemptId: attempt.attemptId,
-        kind: "cancel",
-        requestKey: operationRequestKey,
-        fingerprint: hashJson([
+    requireKey(input.requestKey);
+    return this.singleFlight(
+      `cancel:${sideChatId}:${input.requestKey}`,
+      async () => {
+        const record = this.mustOwned(sideChatId, actor);
+        const replay = this.store.db.get<{
+          operation_id: string;
+          attempt_id: string | null;
+          state: SideThreadOperationRecord["state"];
+        }>(
+          "SELECT operation_id,attempt_id,state FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='cancel' AND request_key=?2",
           sideChatId,
-          attempt.attemptId,
-          attempt.threadId,
-          attempt.turnId,
-        ]),
-        threadId: attempt.threadId,
-        turnId: attempt.turnId,
-      });
-      if (prepared.state === "completed") return record;
-      if (prepared.state === "ambiguous" || prepared.state === "reconciling")
-        throw ambiguousError(
-          prepared.operationId,
-          sideChatId,
-          attempt.attemptId,
+          input.requestKey,
         );
-      // A second coordinator observing the durable pending claim must never
-      // issue another RPC. Returning its current owner projection is an
-      // honest in-progress replay; ambiguous is handled above and is typed.
-      if (!prepared.callable) return this.mustOwned(sideChatId, actor);
-      const claimedAt = this.now();
-      const claim = this.store.db.run(
-        "UPDATE side_chat_attempts SET cancel_requested_at=?1,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4 AND cancel_requested_at IS NULL",
-        [claimedAt, attempt.attemptId, attempt.threadId, attempt.turnId],
-      );
-      if (claim.changes === 0) {
-        this.markAmbiguous(
-          sideChatId,
-          attempt.attemptId,
-          prepared.operationId,
-          { code: "SIDE_THREAD_RESPONSE_LOST" },
+        if (replay?.state === "completed" || replay?.state === "pending")
+          return record;
+        if (replay?.state === "ambiguous" || replay?.state === "reconciling")
+          throw ambiguousError(
+            replay.operation_id,
+            sideChatId,
+            replay.attempt_id ?? undefined,
+          );
+        const attempt = record.attempts.find(
+          (a) => a.attemptId === record.activeAttemptId,
         );
-        throw ambiguousError(
-          prepared.operationId,
-          sideChatId,
-          attempt.attemptId,
-        );
-      }
-      try {
-        await this.port.cancel({
-          operationId: prepared.operationId,
+        if (
+          !attempt?.threadId ||
+          !attempt.turnId ||
+          !["running", "ambiguous", "reconciling"].includes(attempt.state)
+        )
+          throw conflict("side chat has no cancellable attempt");
+        await this.assertCapability(record.nodeId);
+        const prepared = this.prepareStableOperation({
           sideChatId,
           attemptId: attempt.attemptId,
-          nodeId: record.nodeId,
+          kind: "cancel",
+          requestKey: input.requestKey,
+          fingerprint: hashJson([
+            sideChatId,
+            attempt.attemptId,
+            attempt.threadId,
+            attempt.turnId,
+          ]),
           threadId: attempt.threadId,
           turnId: attempt.turnId,
         });
-      } catch (error) {
-        if (isAmbiguousRuntimeError(error)) {
+        if (prepared.state === "completed") return record;
+        if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+          throw ambiguousError(
+            prepared.operationId,
+            sideChatId,
+            attempt.attemptId,
+          );
+        // A second coordinator observing the durable pending claim must never
+        // issue another RPC. Returning its current owner projection is an
+        // honest in-progress replay; ambiguous is handled above and is typed.
+        if (!prepared.callable) return this.mustOwned(sideChatId, actor);
+        const claimedAt = this.now();
+        const claim = this.store.db.run(
+          "UPDATE side_chat_attempts SET cancel_requested_at=?1,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4 AND cancel_requested_at IS NULL",
+          [claimedAt, attempt.attemptId, attempt.threadId, attempt.turnId],
+        );
+        if (claim.changes === 0) {
           this.markAmbiguous(
             sideChatId,
             attempt.attemptId,
             prepared.operationId,
-            error,
+            { code: "SIDE_THREAD_RESPONSE_LOST" },
           );
           throw ambiguousError(
             prepared.operationId,
@@ -1111,44 +1108,68 @@ export class SideThreadCoordinator {
             attempt.attemptId,
           );
         }
-        this.settleOperation(prepared.operationId, "failed", {
-          errorCode: auditErrorReason(error),
-        });
-        this.store.db.run(
-          "UPDATE side_chat_attempts SET cancel_requested_at=NULL,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
-          [this.now(), attempt.attemptId, attempt.threadId, attempt.turnId],
-        );
-        throw normalizePortError(error);
-      }
-      this.store.db.transaction(() => {
-        const t = this.now();
-        const changed = this.store.db.run(
-          "UPDATE side_chat_attempts SET state='cancelled',updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
-          [t, attempt.attemptId, attempt.threadId, attempt.turnId],
-        );
-        if (changed.changes > 0) {
-          this.store.db.run(
-            "UPDATE side_chats SET state='cancelled',active_attempt_id=NULL,updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3",
-            [t, sideChatId, attempt.attemptId],
-          );
-          this.emitStored(
+        try {
+          await this.port.cancel({
+            operationId: prepared.operationId,
             sideChatId,
-            attempt.attemptId,
-            attempt.threadId,
-            attempt.turnId,
-            "attempt.cancelled",
-            "cancelled",
-            undefined,
-            t,
+            attemptId: attempt.attemptId,
+            nodeId: record.nodeId,
+            threadId: attempt.threadId,
+            turnId: attempt.turnId,
+          });
+        } catch (error) {
+          if (isAmbiguousRuntimeError(error)) {
+            this.markAmbiguous(
+              sideChatId,
+              attempt.attemptId,
+              prepared.operationId,
+              error,
+            );
+            throw ambiguousError(
+              prepared.operationId,
+              sideChatId,
+              attempt.attemptId,
+            );
+          }
+          this.settleOperation(prepared.operationId, "failed", {
+            errorCode: auditErrorReason(error),
+          });
+          this.store.db.run(
+            "UPDATE side_chat_attempts SET cancel_requested_at=NULL,updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
+            [this.now(), attempt.attemptId, attempt.threadId, attempt.turnId],
           );
+          throw normalizePortError(error);
         }
-        this.settleOperation(prepared.operationId, "completed", {
-          threadId: attempt.threadId,
-          turnId: attempt.turnId,
+        this.store.db.transaction(() => {
+          const t = this.now();
+          const changed = this.store.db.run(
+            "UPDATE side_chat_attempts SET state='cancelled',updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
+            [t, attempt.attemptId, attempt.threadId, attempt.turnId],
+          );
+          if (changed.changes > 0) {
+            this.store.db.run(
+              "UPDATE side_chats SET state='cancelled',active_attempt_id=NULL,updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3",
+              [t, sideChatId, attempt.attemptId],
+            );
+            this.emitStored(
+              sideChatId,
+              attempt.attemptId,
+              attempt.threadId,
+              attempt.turnId,
+              "attempt.cancelled",
+              "cancelled",
+              undefined,
+              t,
+            );
+          }
+          this.settleOperation(prepared.operationId, "completed", {
+            threadId: attempt.threadId,
+            turnId: attempt.turnId,
+          });
         });
-      });
-      return this.mustOwned(sideChatId, actor);
-    });
+        return this.mustOwned(sideChatId, actor);
+      },
+    );
   }
 
   async retry(
@@ -1330,124 +1351,130 @@ export class SideThreadCoordinator {
   async archive(
     actor: SideThreadActor,
     sideChatId: string,
+    input: { requestKey: string },
   ): Promise<SideThreadRecord> {
-    return this.lifecycle(actor, sideChatId, "archive");
+    return this.lifecycle(actor, sideChatId, "archive", input);
   }
   async purge(
     actor: SideThreadActor,
     sideChatId: string,
+    input: { requestKey: string },
   ): Promise<SideThreadRecord> {
-    return this.lifecycle(actor, sideChatId, "purge");
+    return this.lifecycle(actor, sideChatId, "purge", input);
   }
   private async lifecycle(
     actor: SideThreadActor,
     sideChatId: string,
     action: "archive" | "purge",
+    input: { requestKey: string },
   ): Promise<SideThreadRecord> {
     this.assertEnabled();
-    return this.singleFlight(`${action}:${sideChatId}`, async () => {
-      const r = this.mustOwned(sideChatId, actor);
-      if (r.activeAttemptId)
-        throw conflict(`cannot ${action} a running side chat`);
-      if (!r.threadId) throw conflict("side chat has no derived thread");
-      if (r.state === "purged") return r;
-      if (action === "archive" && r.state === "archived") return r;
-      await this.assertCapability(r.nodeId);
-      const operationRequestKey = `${action}:${sideChatId}`;
-      const prepared = this.prepareStableOperation({
-        sideChatId,
-        kind: action,
-        requestKey: operationRequestKey,
-        fingerprint: hashJson([action, sideChatId, r.nodeId, r.threadId]),
-        threadId: r.threadId,
-      });
-      if (prepared.state === "completed") return r;
-      if (prepared.state === "ambiguous" || prepared.state === "reconciling")
-        throw ambiguousError(prepared.operationId, sideChatId);
-      if (!prepared.callable)
-        throw conflict("side chat lifecycle operation already in progress");
-      const claim = this.store.db.run(
-        "UPDATE side_chats SET lifecycle_operation=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id IS NULL AND lifecycle_operation IS NULL",
-        [action, this.now(), sideChatId],
-      );
-      if (claim.changes === 0) {
-        const current = this.mustOwned(sideChatId, actor);
-        if (current.state === "purged") return current;
-        if (action === "archive" && current.state === "archived")
-          return current;
-        this.markAmbiguous(sideChatId, undefined, prepared.operationId, {
-          code: "SIDE_THREAD_RESPONSE_LOST",
-        });
-        throw ambiguousError(prepared.operationId, sideChatId);
-      }
-      try {
-        if (action === "archive")
-          await this.port.archive({
-            operationId: prepared.operationId,
-            sideChatId,
-            nodeId: r.nodeId,
-            threadId: r.threadId,
-          });
-        else
-          await this.port.purge({
-            operationId: prepared.operationId,
-            sideChatId,
-            nodeId: r.nodeId,
-            threadId: r.threadId,
-          });
-      } catch (error) {
-        if (isAmbiguousRuntimeError(error)) {
-          this.markAmbiguous(
-            sideChatId,
-            undefined,
-            prepared.operationId,
-            error,
-          );
-          throw ambiguousError(prepared.operationId, sideChatId);
-        }
-        this.settleOperation(prepared.operationId, "failed", {
-          errorCode: auditErrorReason(error),
-        });
-        this.store.db.run(
-          "UPDATE side_chats SET lifecycle_operation=NULL,updated_at=?1 WHERE side_chat_id=?2 AND lifecycle_operation=?3",
-          [this.now(), sideChatId, action],
-        );
-        throw normalizePortError(error);
-      }
-      const state = action === "archive" ? "archived" : "purged",
-        t = this.now();
-      this.store.db.transaction(() => {
-        if (action === "purge") {
-          this.store.db.run(
-            "UPDATE side_chats SET state='purged',question_text='',attachments_json='[]',lifecycle_operation=NULL,updated_at=?1,purged_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='purge'",
-            [t, sideChatId],
-          );
-          this.store.db.run(
-            "UPDATE side_chat_attempts SET result_text=NULL,error_text=NULL,updated_at=?1 WHERE side_chat_id=?2",
-            [t, sideChatId],
-          );
-        } else {
-          this.store.db.run(
-            "UPDATE side_chats SET state='archived',lifecycle_operation=NULL,updated_at=?1,archived_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='archive'",
-            [t, sideChatId],
-          );
-        }
-        this.settleOperation(prepared.operationId, "completed", {
+    requireKey(input.requestKey);
+    return this.singleFlight(
+      `${action}:${sideChatId}:${input.requestKey}`,
+      async () => {
+        const r = this.mustOwned(sideChatId, actor);
+        if (r.activeAttemptId)
+          throw conflict(`cannot ${action} a running side chat`);
+        if (!r.threadId) throw conflict("side chat has no derived thread");
+        if (r.state === "purged") return r;
+        if (action === "archive" && r.state === "archived") return r;
+        await this.assertCapability(r.nodeId);
+        const prepared = this.prepareStableOperation({
+          sideChatId,
+          kind: action,
+          requestKey: input.requestKey,
+          fingerprint: hashJson([action, sideChatId, r.nodeId, r.threadId]),
           threadId: r.threadId,
         });
-        this.emitStored(
-          sideChatId,
-          undefined,
-          r.threadId,
-          undefined,
-          `side_chat.${state}`,
-          state,
-          undefined,
-          t,
+        if (prepared.state === "completed") return r;
+        if (prepared.state === "ambiguous" || prepared.state === "reconciling")
+          throw ambiguousError(prepared.operationId, sideChatId);
+        if (!prepared.callable)
+          throw conflict("side chat lifecycle operation already in progress");
+        const claim = this.store.db.run(
+          "UPDATE side_chats SET lifecycle_operation=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id IS NULL AND lifecycle_operation IS NULL",
+          [action, this.now(), sideChatId],
         );
-      });
-      return this.mustOwned(sideChatId, actor);
-    });
+        if (claim.changes === 0) {
+          const current = this.mustOwned(sideChatId, actor);
+          if (current.state === "purged") return current;
+          if (action === "archive" && current.state === "archived")
+            return current;
+          this.markAmbiguous(sideChatId, undefined, prepared.operationId, {
+            code: "SIDE_THREAD_RESPONSE_LOST",
+          });
+          throw ambiguousError(prepared.operationId, sideChatId);
+        }
+        try {
+          if (action === "archive")
+            await this.port.archive({
+              operationId: prepared.operationId,
+              sideChatId,
+              nodeId: r.nodeId,
+              threadId: r.threadId,
+            });
+          else
+            await this.port.purge({
+              operationId: prepared.operationId,
+              sideChatId,
+              nodeId: r.nodeId,
+              threadId: r.threadId,
+            });
+        } catch (error) {
+          if (isAmbiguousRuntimeError(error)) {
+            this.markAmbiguous(
+              sideChatId,
+              undefined,
+              prepared.operationId,
+              error,
+            );
+            throw ambiguousError(prepared.operationId, sideChatId);
+          }
+          this.settleOperation(prepared.operationId, "failed", {
+            errorCode: auditErrorReason(error),
+          });
+          this.store.db.run(
+            "UPDATE side_chats SET lifecycle_operation=NULL,updated_at=?1 WHERE side_chat_id=?2 AND lifecycle_operation=?3",
+            [this.now(), sideChatId, action],
+          );
+          throw normalizePortError(error);
+        }
+        const state = action === "archive" ? "archived" : "purged",
+          t = this.now();
+        this.store.db.transaction(() => {
+          if (action === "purge") {
+            this.store.db.run(
+              "UPDATE side_chats SET state='purged',question_text='',attachments_json='[]',lifecycle_operation=NULL,updated_at=?1,purged_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='purge'",
+              [t, sideChatId],
+            );
+            this.store.db.run(
+              "UPDATE side_chat_attempts SET result_text=NULL,error_text=NULL,updated_at=?1 WHERE side_chat_id=?2",
+              [t, sideChatId],
+            );
+          } else {
+            this.store.db.run(
+              "UPDATE side_chats SET state='archived',lifecycle_operation=NULL,updated_at=?1,archived_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL AND lifecycle_operation='archive'",
+              [t, sideChatId],
+            );
+          }
+          this.settleOperation(prepared.operationId, "completed", {
+            threadId: r.threadId,
+          });
+          this.emitStored(
+            sideChatId,
+            undefined,
+            r.threadId,
+            undefined,
+            `side_chat.${state}`,
+            state,
+            undefined,
+            t,
+          );
+        });
+        return this.mustOwned(sideChatId, actor);
+      },
+    );
   }
 
   async bringBack(

--- a/server/src/side-thread.ts
+++ b/server/src/side-thread.ts
@@ -1449,7 +1449,14 @@ export class SideThreadCoordinator {
               [t, sideChatId],
             );
             this.store.db.run(
-              "UPDATE side_chat_attempts SET result_text=NULL,error_text=NULL,updated_at=?1 WHERE side_chat_id=?2",
+              "UPDATE side_chat_attempts SET result_text=NULL,error_text=NULL,attachments_json='[]',updated_at=?1 WHERE side_chat_id=?2",
+              [t, sideChatId],
+            );
+            // Purge removes every persisted free-form content field. Keep only
+            // receipt/operation identities and allow-listed audit codes so a
+            // replay can remain idempotent without retaining user content.
+            this.store.db.run(
+              "UPDATE side_chat_bring_backs SET error_text=NULL,updated_at=?1 WHERE side_chat_id=?2",
               [t, sideChatId],
             );
           } else {

--- a/tests/test1195-side-thread-hub-contract/Dockerfile
+++ b/tests/test1195-side-thread-hub-contract/Dockerfile
@@ -8,6 +8,7 @@ COPY server/src/side-thread.ts /app/server/src/side-thread.ts
 COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
 COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
 COPY contracts/side-thread/v1/golden.json /app/contracts/side-thread/v1/golden.json
+COPY contracts/side-thread/v1/schema.json /app/contracts/side-thread/v1/schema.json
 COPY tests/test1195-side-thread-hub-contract/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 

--- a/tests/test1195-side-thread-hub-contract/Dockerfile
+++ b/tests/test1195-side-thread-hub-contract/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1.3.14-debian
+
+WORKDIR /app
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+COPY server/src/db-adapter.ts /app/server/src/db-adapter.ts
+COPY server/src/side-thread.ts /app/server/src/side-thread.ts
+COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
+COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
+COPY contracts/side-thread/v1/golden.json /app/contracts/side-thread/v1/golden.json
+COPY tests/test1195-side-thread-hub-contract/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/test1195-side-thread-hub-contract/run.sh
+++ b/tests/test1195-side-thread-hub-contract/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+echo "source_commit=${SOURCE_COMMIT}"
+bun test server/src/side-thread.test.ts -t 'feature flag|create is payload|cross-window|authoritative vendorable|routes use|disabled surface|capability flips'
+
+# Witness red: removing the explicit native-exact-fork mode gate must make the
+# unverified/shared adapter case fail.
+cp server/src/side-thread.ts /tmp/side-thread.ts
+sed -i 's/cap\.mode !== "native-exact-fork"/false/' server/src/side-thread.ts
+grep -F 'if (false)' server/src/side-thread.ts >/dev/null
+if bun test server/src/side-thread.test.ts -t 'feature flag and missing runtime adapter' >/tmp/contract-mutation.log 2>&1; then
+  echo "FAIL: native-mode mutation survived"
+  cat /tmp/contract-mutation.log
+  exit 1
+fi
+mv /tmp/side-thread.ts server/src/side-thread.ts
+
+echo "PASS test1195 SideThread Hub contract + witnessed red"

--- a/tests/test1195-side-thread-hub-contract/run.sh
+++ b/tests/test1195-side-thread-hub-contract/run.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 cd /app
 echo "source_commit=${SOURCE_COMMIT}"
-bun test server/src/side-thread.test.ts -t 'feature flag|create is payload|cross-window|authoritative vendorable|routes use|disabled surface|capability flips'
+bun test server/src/side-thread.test.ts -t 'feature flag|create is payload|cross-window|authoritative vendorable|routes use|every mutating|disabled surface|capability flips'
 
 # Witness red: removing the explicit native-exact-fork mode gate must make the
 # unverified/shared adapter case fail.

--- a/tests/test1195-side-thread-hub-race/Dockerfile
+++ b/tests/test1195-side-thread-hub-race/Dockerfile
@@ -8,6 +8,7 @@ COPY server/src/side-thread.ts /app/server/src/side-thread.ts
 COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
 COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
 COPY contracts/side-thread/v1/golden.json /app/contracts/side-thread/v1/golden.json
+COPY contracts/side-thread/v1/schema.json /app/contracts/side-thread/v1/schema.json
 COPY tests/test1195-side-thread-hub-race/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 

--- a/tests/test1195-side-thread-hub-race/Dockerfile
+++ b/tests/test1195-side-thread-hub-race/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.3.14-debian
+
+WORKDIR /app
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+COPY server/src/db-adapter.ts /app/server/src/db-adapter.ts
+COPY server/src/side-thread.ts /app/server/src/side-thread.ts
+COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
+COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
+COPY tests/test1195-side-thread-hub-race/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/test1195-side-thread-hub-race/Dockerfile
+++ b/tests/test1195-side-thread-hub-race/Dockerfile
@@ -7,6 +7,7 @@ COPY server/src/db-adapter.ts /app/server/src/db-adapter.ts
 COPY server/src/side-thread.ts /app/server/src/side-thread.ts
 COPY server/src/side-thread-http.ts /app/server/src/side-thread-http.ts
 COPY server/src/side-thread.test.ts /app/server/src/side-thread.test.ts
+COPY contracts/side-thread/v1/golden.json /app/contracts/side-thread/v1/golden.json
 COPY tests/test1195-side-thread-hub-race/run.sh /app/run.sh
 RUN chmod +x /app/run.sh
 

--- a/tests/test1195-side-thread-hub-race/run.sh
+++ b/tests/test1195-side-thread-hub-race/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app
+echo "source_commit=${SOURCE_COMMIT}"
+bun test server/src/side-thread.test.ts -t 'terminal events|terminal event arriving|cancel is exact|cross-coordinator|retry persists|archive/purge|bring-back|response loss|ambiguous cancel'
+
+# Witness red: weaken one member of the four-part terminal ownership tuple.
+cp server/src/side-thread.ts /tmp/side-thread.ts
+sed -i 's/owned\.derived_thread_id !== event\.threadId/false/' server/src/side-thread.ts
+grep -F 'false ||' server/src/side-thread.ts >/dev/null
+if bun test server/src/side-thread.test.ts -t 'terminal events require' >/tmp/race-mutation.log 2>&1; then
+  echo "FAIL: event ownership mutation survived"
+  cat /tmp/race-mutation.log
+  exit 1
+fi
+mv /tmp/side-thread.ts server/src/side-thread.ts
+
+echo "PASS test1195 SideThread Hub races + witnessed red"

--- a/tests/test1195-side-thread-hub-race/run.sh
+++ b/tests/test1195-side-thread-hub-race/run.sh
@@ -16,4 +16,16 @@ if bun test server/src/side-thread.test.ts -t 'terminal events require' >/tmp/ra
 fi
 mv /tmp/side-thread.ts server/src/side-thread.ts
 
+# Witness red: purge must scrub attachment references from every attempt, not
+# merely from the root side-chat record.
+cp server/src/side-thread.ts /tmp/side-thread.ts
+sed -i "s/SET result_text=NULL,error_text=NULL,attachments_json='\[\]'/SET result_text=NULL,error_text=NULL/" server/src/side-thread.ts
+! grep -F "result_text=NULL,error_text=NULL,attachments_json='[]'" server/src/side-thread.ts >/dev/null
+if bun test server/src/side-thread.test.ts -t 'archive/purge are terminal-safe' >/tmp/purge-mutation.log 2>&1; then
+  echo "FAIL: attempt attachment purge mutation survived"
+  cat /tmp/purge-mutation.log
+  exit 1
+fi
+mv /tmp/side-thread.ts server/src/side-thread.ts
+
 echo "PASS test1195 SideThread Hub races + witnessed red"

--- a/tests/test1195-side-thread-hub-security/Dockerfile
+++ b/tests/test1195-side-thread-hub-security/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1.3.14-debian
+
+WORKDIR /app/server
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
+COPY server/package.json server/package-lock.json ./
+RUN bun install --frozen-lockfile
+COPY server/src ./src
+
+WORKDIR /app
+COPY tests/test1195-side-thread-hub-security/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/test1195-side-thread-hub-security/run.sh
+++ b/tests/test1195-side-thread-hub-security/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app/server
+echo "source_commit=${SOURCE_COMMIT}"
+bun test src/side-thread-http-integration.test.ts
+
+# Witness red: accepting a query-string token would expose the persisted owner
+# question across browser/log boundaries. The integration assertion must catch it.
+cp src/server.ts /tmp/server.ts
+sed -i 's/resolveRequestAuth(req, { allowQueryToken: false })/resolveRequestAuth(req)/' src/server.ts
+grep -F 'actor: resolveSideThreadActor(req, resolveRequestAuth(req), isAdmin)' src/server.ts >/dev/null
+if bun test src/side-thread-http-integration.test.ts >/tmp/security-mutation.log 2>&1; then
+  echo "FAIL: query-token auth mutation survived"
+  cat /tmp/security-mutation.log
+  exit 1
+fi
+mv /tmp/server.ts src/server.ts
+
+echo "PASS test1195 SideThread Hub auth/SSE security + witnessed red"

--- a/tests/test638-server-aggregate-isolation/Dockerfile
+++ b/tests/test638-server-aggregate-isolation/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
 WORKDIR /work
 
 COPY server/ server/
+COPY contracts/side-thread/v1/ contracts/side-thread/v1/
 COPY agent-node/src/ agent-node/src/
 COPY tests/test601-hub-scheduled-tasks/ tests/test601-hub-scheduled-tasks/
 RUN cd server && bun install

--- a/tests/test798-server-unit-ci/Dockerfile
+++ b/tests/test798-server-unit-ci/Dockerfile
@@ -25,6 +25,7 @@ COPY server/package.json server/package-lock.json ./server/
 RUN cd server && npm ci
 
 COPY server ./server
+COPY contracts/side-thread/v1 ./contracts/side-thread/v1
 # RFC-026 G9 / RFC-028 P1 的漂移门比对 hub 与 daemon 的同名共享源码,
 # 要读同级 agent-node/src/shared。只带这个目录,不带整个包。
 # 若干 server 测试跨包 import agent-node 的源码(hub↔daemon 漂移门比对


### PR DESCRIPTION
## Draft / rebased stack

Rebuilds the product and evidence commits from Draft #1196 on top of merged PR1 #1194, whose squash commit on `main` is `57bd606d52129d2a78360dda2dd68e8c968541bd`.

- current tip: `c23598347cdad6ba524d722f5958a771702a37e2`
- rebased PR2 tip before follow-up: `96c131ff1be5f883ea57b4fb85097f47d8971f56`
- old PR2 tip: `9a074ccb62d7829e5602ea6b14232b7e467e0cb4`
- provenance: the nine original PR2 commits are 9/9 patch-equivalent after rebase, and the old/new final trees are byte-identical
- follow-up fix: purge now scrubs per-attempt attachment references and bring-back error text; exact Docker evidence is recorded in `docs/tests/report-test1195-side-thread-hub.txt`
- feature remains disabled/fail-closed
- no merge/release authorization

This Draft supersedes #1196 for subsequent stacking. Independent review is still required.