### PR TITLE
test(btw): add production recovery and real Codex E2E gate

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -33,6 +33,7 @@ on:
       - 'tests/test1195-side-thread-hub-security/**'
       - 'tests/test1195-side-thread-hub-race/**'
       - 'tests/test1200-side-thread-command-transport/**'
+      - 'tests/test1203-btw-production-e2e/**'
       # A test directory belongs here exactly when CI executes it — otherwise
       # editing the test cannot re-run the gate that runs it. The four below are
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other

--- a/docs/tests/report-test1203-btw-production-e2e.txt
+++ b/docs/tests/report-test1203-btw-production-e2e.txt
@@ -1,0 +1,29 @@
+test1203 /btw production E2E gate
+Date: 2026-08-26
+Base: PR #1202 head 8ad03b1ea3c9fcfae085d85070213c9d2dffb5ac
+
+Scope:
+- real Codex 0.148 owned-stdio active-main / double-fork / reverse-completion / cancel isolation: delegated to reviewed test1190 live gate
+- durable command ACK loss and restart: executable offline gate
+- terminal WAL response loss and restart-before-pull ordering: executable offline gate
+- bring-back accepted replay exactly once and ambiguous response fail-closed: executable offline gate
+- attachment node-token / byte-count / SHA-256 / 0600 materialization: executable offline gate
+- persisted receipt redaction: executable offline gate
+
+Honest gap:
+The production Codex adapter does not yet serialize materialized attachments
+into turn/start. Therefore this gate does not claim model-side attachment
+consumption. It is a merge gate for the follow-up production wiring, not proof
+that wiring already exists.
+
+Executed evidence:
+- Docker image `anet-test1203`, pinned `codex-cli 0.148.0`
+- offline recovery layer: 5 passed, 0 failed, 20 assertions
+- live owned-stdio layer: PASS, reviewed evidence `test1190-wire-v2`
+- source active at fork; three threads concurrently active
+- cancelled target `interrupted`; source and sibling `completed`
+- created slow then fast; completed fast then slow
+- witnessed-red source-first mutation rejected
+- disposable CODEX_HOME files after exit: 0
+- sanitized wire trace scan: no prompt markers, local home paths, tokens,
+  bearer values, or raw UUIDs

--- a/docs/tests/report-test1203-btw-production-e2e.txt
+++ b/docs/tests/report-test1203-btw-production-e2e.txt
@@ -18,6 +18,8 @@ that wiring already exists.
 
 Executed evidence:
 - Docker image `anet-test1203`, pinned `codex-cli 0.148.0`
+- registered L1 image is bound to the exact 40-character lowercase source SHA;
+  missing and malformed bindings are both witnessed-red
 - offline recovery layer: 5 passed, 0 failed, 20 assertions
 - live owned-stdio layer: PASS, reviewed evidence `test1190-wire-v2`
 - source active at fork; three threads concurrently active

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -70,6 +70,7 @@ L1_TESTS=(
   "test1195-side-thread-hub-security"
   "test1195-side-thread-hub-race"
   "test1200-side-thread-command-transport"
+  "test1203-btw-production-e2e"
   "qa-cli-01-hub-start"
   "qa-cli-02-network-create"
   "qa-dash-07-auth-boundary"

--- a/tests/test1203-btw-production-e2e/Dockerfile
+++ b/tests/test1203-btw-production-e2e/Dockerfile
@@ -4,6 +4,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && npm install -g --no-audit --no-fund @openai/codex@0.148.0 \
     && rm -rf /var/lib/apt/lists/*
 
+ARG TEST1203_SOURCE_COMMIT=dev
+ENV TEST1203_SOURCE_COMMIT=$TEST1203_SOURCE_COMMIT
+LABEL org.opencontainers.image.revision=$TEST1203_SOURCE_COMMIT
+
 WORKDIR /repo
 COPY agent-node/package.json agent-node/package.json
 COPY agent-node/src agent-node/src

--- a/tests/test1203-btw-production-e2e/Dockerfile
+++ b/tests/test1203-btw-production-e2e/Dockerfile
@@ -1,0 +1,16 @@
+FROM oven/bun:1.2.22-debian
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates jq nodejs npm \
+    && npm install -g --no-audit --no-fund @openai/codex@0.148.0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo
+COPY agent-node/package.json agent-node/package.json
+COPY agent-node/src agent-node/src
+COPY tests/lib tests/lib
+COPY tests/lib /tests/lib
+COPY tests/test1190-codex-btw-wire-probe /probe
+COPY tests/test1203-btw-production-e2e tests/test1203-btw-production-e2e
+RUN chmod +x /probe/run.sh tests/test1203-btw-production-e2e/run.sh
+
+CMD ["tests/test1203-btw-production-e2e/run.sh"]

--- a/tests/test1203-btw-production-e2e/README.md
+++ b/tests/test1203-btw-production-e2e/README.md
@@ -1,0 +1,30 @@
+# test1203 — `/btw` production E2E gate
+
+This suite layers the production command/WAL implementation from PR #1202 on
+top of the reviewed real Codex 0.148.0 owned-stdio wire capture in test1190.
+It never connects to CommHub production and never reuses a node's live
+`CODEX_HOME`.
+
+The credential-free layer runs in every invocation and proves ACK-loss replay,
+terminal-WAL restart ordering, accepted and ambiguous bring-back semantics,
+attachment grant materialization, and persisted-evidence redaction. The opt-in
+live layer delegates the destructive disposable-home guard and native wire
+journey to test1190; it proves an active main turn, two native exact forks,
+reverse completion and cancellation isolation against the exact 0.148.0 binary.
+
+```sh
+sg docker -c 'docker build -f tests/test1203-btw-production-e2e/Dockerfile -t anet-test1203 .'
+sg docker -c 'docker run --rm anet-test1203'
+```
+
+For the live layer, first copy only the required Codex authentication into a
+new one-use directory and add `.anet-btw-probe-sentinel` with the exact content
+`test1190-disposable-v2`. Then mount it at `/codex-home`, set
+`CODEX_HOME=/codex-home` and `BTW_LIVE_PROBE=1`. test1190 deletes every file in
+that mounted directory on exit. Never mount `~/.codex` or a node's real home.
+
+Known production-wiring gate still intentionally missing: the Codex adapter's
+`start()` currently accepts materialized attachment metadata but does not put
+it into `turn/start`. This suite proves grant/materialization and refuses to
+claim that the model consumed the attachment. Enable that assertion only when
+the production adapter wiring exists.

--- a/tests/test1203-btw-production-e2e/README.md
+++ b/tests/test1203-btw-production-e2e/README.md
@@ -13,9 +13,14 @@ journey to test1190; it proves an active main turn, two native exact forks,
 reverse completion and cancellation isolation against the exact 0.148.0 binary.
 
 ```sh
-sg docker -c 'docker build -f tests/test1203-btw-production-e2e/Dockerfile -t anet-test1203 .'
+sg docker -c 'docker build --build-arg TEST1203_SOURCE_COMMIT=$(git rev-parse HEAD) -f tests/test1203-btw-production-e2e/Dockerfile -t anet-test1203 .'
 sg docker -c 'docker run --rm anet-test1203'
 ```
+
+The registered L1 runner supplies `TEST1203_SOURCE_COMMIT` from the exact
+checked-out Git SHA. Direct builds must supply the same 40-character lowercase
+SHA with `--build-arg TEST1203_SOURCE_COMMIT=$(git rev-parse HEAD)`; the suite
+fails closed when the binding is missing or malformed.
 
 For the live layer, first copy only the required Codex authentication into a
 new one-use directory and add `.anet-btw-probe-sentinel` with the exact content

--- a/tests/test1203-btw-production-e2e/recovery-gate.test.ts
+++ b/tests/test1203-btw-production-e2e/recovery-gate.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PrivateFileCommandReceiptStore } from "../../agent-node/src/runtime/side-thread/command-receipts";
+import { SideThreadCommandConsumer } from "../../agent-node/src/runtime/side-thread/command-consumer";
+import { SideThreadCommandExecutor, SIDE_THREAD_COMMAND_PROTOCOL } from "../../agent-node/src/runtime/side-thread/command-transport";
+import { PrivateFileForkLeaseStore } from "../../agent-node/src/runtime/side-thread/fork-lease";
+import { JournaledBringBackExecutor } from "../../agent-node/src/runtime/side-thread/bring-back-journal";
+import { materializeCommandAttachment } from "../../agent-node/src/runtime/side-thread/materialize-command-attachment";
+import { PrivateFileTerminalOutbox } from "../../agent-node/src/runtime/side-thread/terminal-outbox";
+import type { SideThreadRuntimeAdapter } from "../../agent-node/src/runtime/side-thread/domain";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+const root = () => { const value = mkdtempSync(join(tmpdir(), "btw-prod-gate-")); roots.push(value); return value; };
+const command = (kind: string, payload: unknown, attemptId: string | null = null) => ({
+  protocol: SIDE_THREAD_COMMAND_PROTOCOL, commandId: `cmd-${kind}`, operationId: `op-${kind}`,
+  requestKey: `rk-${kind}`, nodeId: "node-e2e", sideThreadId: "side-e2e", attemptId, kind, payload,
+});
+
+function fixture(dir = root()) {
+  let forks = 0; let starts = 0; let listener: (event: any) => void = () => {};
+  const adapter: SideThreadRuntimeAdapter = {
+    capability: () => ({ supported: true, runtime: "codex-app-server", runtimeVersion: "0.148.0", topology: "owned-stdio", evidenceRevision: "test1190-wire-v2", mode: "native-exact-fork", exactBoundary: { through: true, before: true } }),
+    async fork() { forks++; return { derivedThreadId: "derived-e2e" }; },
+    async start() { starts++; return { turnId: "turn-e2e" }; },
+    async cancel() {}, async archive() {}, async delete() {},
+    subscribe(fn) { listener = fn; return () => { listener = () => {}; }; },
+  };
+  const terminalOutbox = new PrivateFileTerminalOutbox(join(dir, "terminal-wal"));
+  const options = { nodeId: "node-e2e", adapter, receipts: new PrivateFileCommandReceiptStore(join(dir, "receipts")),
+    claimExecution: (x: any) => new PrivateFileForkLeaseStore(join(dir, "claims")).claimOperation(x.nodeId, x.sideThreadId, x.operationId), terminalOutbox };
+  return { dir, adapter, options, terminalOutbox, emit: (x: any) => listener(x), counts: () => ({ forks, starts }) };
+}
+
+describe("/btw production recovery gate", () => {
+  test("ACK loss plus process restart replays receipt, never native fork", async () => {
+    const f = fixture(); const raw = command("fork", { sourceThreadId: "main", boundary: { kind: "through", turnId: "boundary" } });
+    let posts = 0;
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/pending")) return Response.json({ ok: true, command: raw });
+      if (url.endsWith("/ack")) return ++posts === 1 ? new Response("lost", { status: 503 }) : Response.json({ ok: true });
+      throw new Error(`unexpected ${url}`);
+    }) as typeof fetch;
+    const make = () => new SideThreadCommandConsumer({ hubUrl: "https://hub.invalid", nodeId: "node-e2e", token: "ntok_e2e", executor: new SideThreadCommandExecutor({ ...f.options, receipts: new PrivateFileCommandReceiptStore(join(f.dir, "receipts")) }), terminalOutbox: f.terminalOutbox, fetchImpl });
+    await expect(make().trigger()).rejects.toThrow("ACK failed");
+    await make().trigger();
+    expect(f.counts().forks).toBe(1); expect(posts).toBe(2);
+  });
+
+  test("terminal WAL drains after restart before another command is pulled", async () => {
+    const f = fixture(); new SideThreadCommandExecutor(f.options);
+    f.emit({ sideThreadId: "side-e2e", attemptId: "attempt-e2e", threadId: "derived-e2e", turnId: "turn-e2e", status: "completed", text: "done", identityBound: true });
+    await Bun.sleep(0); expect(f.terminalOutbox.list()).toHaveLength(1);
+    const order: string[] = []; let terminalPosts = 0;
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/terminals")) { order.push("terminal"); return ++terminalPosts === 1 ? new Response("lost", { status: 503 }) : Response.json({ ok: true, idempotent: true }); }
+      if (url.endsWith("/pending")) { order.push("pending"); return Response.json({ ok: true, command: null }); }
+      throw new Error(`unexpected ${url}`);
+    }) as typeof fetch;
+    const make = () => new SideThreadCommandConsumer({ hubUrl: "https://hub.invalid", nodeId: "node-e2e", token: "ntok_e2e", executor: new SideThreadCommandExecutor(f.options), terminalOutbox: new PrivateFileTerminalOutbox(join(f.dir, "terminal-wal")), fetchImpl });
+    await expect(make().trigger()).rejects.toThrow("terminal POST failed");
+    await make().trigger();
+    expect(order).toEqual(["terminal", "terminal", "pending"]); expect(f.terminalOutbox.list()).toHaveLength(0);
+  });
+
+  test("bring-back is exactly once on accepted replay and fail-closed on lost response", async () => {
+    const dir = root(); let sends = 0;
+    const accepted = new JournaledBringBackExecutor(join(dir, "accepted"), async () => ({ destinationTurnId: `ordinary-main-turn-${++sends}` }));
+    const input = { operationId: "bring-accepted", destinationThreadId: "main", text: "BTW result" };
+    expect(await accepted.execute(input)).toEqual({ destinationTurnId: "ordinary-main-turn-1" });
+    expect(await new JournaledBringBackExecutor(join(dir, "accepted"), async () => ({ destinationTurnId: `duplicate-${++sends}` })).execute(input)).toEqual({ destinationTurnId: "ordinary-main-turn-1" });
+    expect(sends).toBe(1);
+    const lostRoot = join(dir, "lost"); let lostSends = 0;
+    await expect(new JournaledBringBackExecutor(lostRoot, async () => { lostSends++; throw new Error("response lost"); }).execute({ ...input, operationId: "bring-lost" })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    await expect(new JournaledBringBackExecutor(lostRoot, async () => ({ destinationTurnId: `duplicate-${++lostSends}` })).execute({ ...input, operationId: "bring-lost" })).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(lostSends).toBe(1);
+  });
+
+  test("attachment grant materializes exact bytes privately and rejects digest drift", async () => {
+    const bytes = new TextEncoder().encode("e2e-image-fixture"); const sha256 = createHash("sha256").update(bytes).digest("hex"); const cache = join(root(), "cache");
+    const grant = { fileId: "file_fixture", grantId: "grant_fixture", sha256, size: bytes.byteLength, mediaType: "image/png" };
+    const result = await materializeCommandAttachment(grant, { hubUrl: "https://hub.invalid", nodeToken: "ntok_e2e", cacheDir: cache, fetchImpl: (async (_u, init) => {
+      expect((init?.headers as any).Authorization).toBe("Bearer ntok_e2e"); return new Response(bytes, { headers: { "content-length": String(bytes.byteLength) } });
+    }) as typeof fetch });
+    expect(readFileSync(result.path)).toEqual(Buffer.from(bytes)); expect(statSync(result.path).mode & 0o777).toBe(0o600);
+    await expect(materializeCommandAttachment({ ...grant, grantId: "grant_bad", sha256: "0".repeat(64) }, { hubUrl: "https://hub.invalid", nodeToken: "ntok_e2e", cacheDir: cache, fetchImpl: (async () => new Response(bytes)) as typeof fetch })).rejects.toThrow("digest mismatch");
+  });
+
+  test("persisted receipt drops unknown prompt fields and contains no bearer or local path", async () => {
+    const f = fixture(); const prompt = "TOP_SECRET_PROMPT";
+    await new SideThreadCommandExecutor(f.options).execute(command("fork", { sourceThreadId: "123e4567-e89b-42d3-a456-426614174000", boundary: { kind: "through", turnId: "boundary" }, prompt }));
+    const persisted = readFileSync(join(f.dir, "receipts", "cmd-fork.json"), "utf8");
+    expect(persisted).not.toContain(prompt); expect(persisted).not.toContain("ntok_"); expect(persisted).not.toContain("/home/");
+  });
+});

--- a/tests/test1203-btw-production-e2e/run.sh
+++ b/tests/test1203-btw-production-e2e/run.sh
@@ -1,6 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+assert_source_commit() {
+  [[ "${TEST1203_SOURCE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]] || {
+    echo 'FAIL: TEST1203_SOURCE_COMMIT must be one full lowercase Git SHA' >&2
+    exit 1
+  }
+}
+
+assert_source_commit
+printf 'source_commit=%s\n' "$TEST1203_SOURCE_COMMIT"
+
+if [[ "${TEST1203_SHA_SELFTEST_ONLY:-0}" == "1" ]]; then
+  exit 0
+fi
+
+# Witnessed red: both ways qa.sh can fail to bind the image must fail closed.
+if env -u TEST1203_SOURCE_COMMIT TEST1203_SHA_SELFTEST_ONLY=1 "$0" >/tmp/test1203-sha-missing.log 2>&1; then
+  echo 'FAIL: missing source SHA survived' >&2
+  exit 1
+fi
+grep -Fq 'must be one full lowercase Git SHA' /tmp/test1203-sha-missing.log
+if TEST1203_SOURCE_COMMIT=ABC123 TEST1203_SHA_SELFTEST_ONLY=1 "$0" >/tmp/test1203-sha-invalid.log 2>&1; then
+  echo 'FAIL: invalid source SHA survived' >&2
+  exit 1
+fi
+grep -Fq 'must be one full lowercase Git SHA' /tmp/test1203-sha-invalid.log
+echo 'PASS source SHA binding + 2 witnessed-red cases'
+
 test "$(codex --version)" = "codex-cli 0.148.0"
 bun test tests/test1203-btw-production-e2e/recovery-gate.test.ts
 

--- a/tests/test1203-btw-production-e2e/run.sh
+++ b/tests/test1203-btw-production-e2e/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test "$(codex --version)" = "codex-cli 0.148.0"
+bun test tests/test1203-btw-production-e2e/recovery-gate.test.ts
+
+# The real-model half is deliberately opt-in. It accepts only a disposable,
+# sentinel-marked CODEX_HOME and test1190 deletes that whole home on exit.
+if [[ "${BTW_LIVE_PROBE:-0}" != "1" ]]; then
+  echo "PASS BTW production recovery gate (real Codex gate skipped)"
+  exit 0
+fi
+
+test -n "${CODEX_HOME:-}"
+test -f "$CODEX_HOME/.anet-btw-probe-sentinel"
+test "$(cat "$CODEX_HOME/.anet-btw-probe-sentinel")" = "test1190-disposable-v2"
+
+export REPORT_DIR="${REPORT_DIR:-/probe/out}"
+mkdir -p "$REPORT_DIR"
+/probe/run.sh
+
+# test1190 owns and erases the disposable home, so a second authenticated
+# app-server must never be started here. Its checked live result is the native
+# fork/cancel/reverse-completion evidence; this suite adds transport recovery.
+jq -e '
+  .forkBoundary.sourceStatusAtFork == "active" and
+  .concurrencyCancel.targetStatus == "interrupted" and
+  .concurrencyCancel.siblingStatus == "completed" and
+  .concurrencyCancel.sourceStatus == "completed" and
+  .reverseCompletion.completionOrder == ["forkFast", "forkSlow"]
+' "$REPORT_DIR/live-result.json" >/dev/null
+
+echo "PASS BTW production E2E gate"


### PR DESCRIPTION
## Scope

Stacked on #1202. Adds an isolated Docker gate for `/btw` production wiring without touching CommHub production or any node's live `CODEX_HOME`.

- real Codex 0.148.0 owned-stdio: active main turn, two exact forks, reverse completion, cancel isolation
- ACK response loss + executor restart: one native mutation
- terminal POST loss + restart: WAL drains before command pull
- bring-back: accepted replay exactly once; response loss fails closed
- attachment grant: bound token, exact size/SHA-256, private 0600 materialization
- sanitized wire trace and disposable-home deletion checks

## Evidence

- exact head: `f04a6116c2af3f83a3f2b1c8a4ae1f19fe2ceeda`
- rebase base: main `c447927a20b851859d272f5bb47029a5ce2558d4`
- rebase equivalence: pre-rebase `bc1632a3` and rebased `8282f74d` have identical stable patch-id `46576f04cab12b8fd12d77e26aa8a18afb58e0f4`
- L1 registration: qa path trigger + `scripts/qa.sh`; SHA binding checker 59/59 bound, 0 unbound
- exact-source Docker: `source_commit=f04a6116c2af3f83a3f2b1c8a4ae1f19fe2ceeda`
- source SHA fail-closed: missing and malformed values both witnessed-red
- Docker offline: 5 passed / 0 failed / 20 assertions
- real Codex live gate: PASS (`test1190-wire-v2`)
- source active at fork; all three active before cancel
- cancel target interrupted; main and sibling completed
- slow created before fast; fast completed before slow
- source-first witnessed-red rejected
- disposable `CODEX_HOME` empty after exit
- trace scan contains no prompt markers, local home paths, token shapes, bearer values or UUIDs

## Honest gap / merge gate

The current Codex adapter accepts materialized attachment metadata in its interface but does not serialize it into `turn/start`. This PR deliberately does **not** claim model-side attachment consumption. The fixture is ready to add that assertion when production wiring lands.

Draft only; do not merge independently of its stack.