### PR TITLE
feat(btw): wire dedicated side threads to production

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -42,6 +42,7 @@ on:
       - 'tests/test1200-side-thread-command-transport/**'
       - 'tests/test1203-btw-production-e2e/**'
       - 'tests/test1181-codex-durable-poll/**'
+      - 'tests/test1204-btw-production-wiring/**'
       # A test directory belongs here exactly when CI executes it — otherwise
       # editing the test cannot re-run the gate that runs it. The four below are
       # reached through scripts/qa.sh L1_TESTS and the e2e workflow; the other

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -352,6 +352,7 @@ on:
       - 'tests/test1200-side-thread-command-transport/**'
       - 'tests/test1203-btw-production-e2e/**'
       - 'tests/test1181-codex-durable-poll/**'
+      - 'tests/test1204-btw-production-wiring/**'
       - 'tests/test1210-actual-target-contract/**'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -1430,11 +1430,10 @@ const reportStatus = async (status: string, task?: string) => {
     // new child boots .prev → reports OLD snapshot → content-match
     // fails → update stays pending → reaper timeouts → dashboard sees
     // timeout (NOT false ✓).
-    config_snapshot: configApplyDraining ? undefined : buildConfigSnapshot(
-      fileConfig,
-      process.env.ANET_CONFIG_UPDATE_CAPABLE === "1",
-      currentConfigRevision,
-    ),
+    config_snapshot: configApplyDraining ? undefined : {
+      ...buildConfigSnapshot(fileConfig, process.env.ANET_CONFIG_UPDATE_CAPABLE === "1", currentConfigRevision),
+      ...(sideThreadCapabilitySnapshot ? { side_thread_capability: sideThreadCapabilitySnapshot } : {}),
+    },
   });
 };
 const getInbox = async () => {
@@ -1957,7 +1956,6 @@ if (rawCodexPending !== undefined) {
 const codexAppServerSessionManager = createCodexSessionManager<
   import("./runtime/codex-app-server/runtime").CodexAppServerRuntimeSession
 >();
-
 async function ensureCodexAppServerSession(): Promise<
   import("./runtime/codex-app-server/runtime").CodexAppServerRuntimeSession
 > {
@@ -1992,6 +1990,18 @@ async function ensureCodexAppServerSession(): Promise<
   writebackCodexThread(session.threadId);
   return session;
 }
+let sideThreadNodeRuntime: { enabled: boolean; capability: Record<string, unknown>; close(): void } | null = null;
+// Always publish an explicit closed capability. This is not merely cosmetic:
+// nodes.config_snapshot is durable, so omitting the field after a local flag
+// is turned off could leave a previously-supported node looking eligible.
+let sideThreadCapabilitySnapshot: Record<string, unknown> = {
+  supported: false,
+  runtime: RUNTIME_LABEL,
+  runtimeVersion: "unknown",
+  topology: "unknown",
+  evidenceRevision: "test1190-wire-v2",
+  reason: "runtime",
+};
 if (NEW_SESSION && RUNTIME === "grok" && GROK_EXECUTION_MODE === "cli") {
   clearGrokSession("--new-session requested");
 }
@@ -6262,6 +6272,46 @@ if (RUNTIME === "codex-app-server" && codexAppServerUrl) {
     process.exit(1);
   }
 }
+
+// `/btw` has a wholly separate command consumer and derived Codex threads.
+// It is opt-in, Codex-app-server-only, and never enters inbox/FIFO/steer.
+const sideThreadsEnabled = fileConfig?.flags?.sideThreads === true || process.env.ANET_ENABLE_SIDE_THREADS === "1";
+if (sideThreadsEnabled) {
+  if (RUNTIME !== "codex-app-server" || !NODE_ID || !process.env.CODEX_HOME) {
+    sideThreadCapabilitySnapshot = {
+      supported: false, runtime: RUNTIME_LABEL, runtimeVersion: "unknown", topology: "unknown",
+      evidenceRevision: "test1190-wire-v2", reason: "runtime",
+    };
+    warn("[side-thread] enable requested but codex-app-server, stable node_id, or dedicated CODEX_HOME is unavailable");
+  } else {
+    try {
+      const session = await ensureCodexAppServerSession();
+      const { startCliSideThreadConsumer, detectCodexRuntimeVersion } = await import("./runtime/side-thread/production");
+      sideThreadNodeRuntime = startCliSideThreadConsumer({
+        enabled: true,
+        client: session.client,
+        hubUrl: COMMHUB_URL,
+        nodeId: NODE_ID,
+        token: () => AUTH_TOKEN,
+        codexHome: process.env.CODEX_HOME!,
+        runtimeVersion: detectCodexRuntimeVersion(),
+        // An app-server spawned and owned by this exact node is the reviewed
+        // owned topology. A user-supplied remote is shared and fails closed.
+        topology: session.proc ? "owned-stdio" : "shared-websocket",
+        experimentalApi: fileConfig?.flags?.sideThreadExperimentalApi === true,
+        log,
+        warn,
+      });
+      sideThreadCapabilitySnapshot = sideThreadNodeRuntime.capability;
+    } catch (startupError: any) {
+      sideThreadCapabilitySnapshot = {
+        supported: false, runtime: "codex-app-server", runtimeVersion: "unknown", topology: "unknown",
+        evidenceRevision: "test1190-wire-v2", reason: "runtime",
+      };
+      warn(`[side-thread] startup failed closed: ${startupError?.message || startupError}`);
+    }
+  }
+}
 let ownerScheduleConsumer: OwnerScheduleConsumer | null = null;
 try {
   ownerScheduleConsumer = createOwnerScheduleConsumer({
@@ -6394,6 +6444,7 @@ const shutdown = async () => {
   if (shuttingDown) return;
   shuttingDown = true;
   ownerScheduleConsumer?.stop();
+  sideThreadNodeRuntime?.close();
   log("shutting down...");
   await closeOpencodeRuntime("signal shutdown");
   await grokCopresenceRuntimeSession?.close().catch((e: any) => {

--- a/agent-node/src/runtime/config-apply.ts
+++ b/agent-node/src/runtime/config-apply.ts
@@ -408,6 +408,13 @@ export interface MaskedSnapshot {
   /** #698 protocol capability. The Hub stores this bit only when the
    * reporting ntok is immutably bound to this exact node_id. */
   peer_reply_inbox_capable: true;
+  /** Runtime-observed, fail-closed SideThread capability. No secrets or paths. */
+  side_thread_capability?: {
+    supported: boolean; runtime: string; runtimeVersion: string; topology: string;
+    evidenceRevision: string; mode?: "native-exact-fork";
+    exactBoundary?: { through: boolean; before: boolean };
+    reason?: "runtime" | "version" | "topology" | "experimental-api" | "exact-boundary";
+  };
   /** Node role surfaced to hub /api/nodes for daemon discovery (#337).
    * "host_supervisor" = anet daemon (receives create_node dispatches);
    * undefined / other values = regular agent-node. Read from config.json's

--- a/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+++ b/agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
@@ -177,9 +177,13 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     return { derivedThreadId };
   }
 
-  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; operation?: SideThreadRuntimeOperation }): Promise<{ turnId: string }> {
+  async start(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; attachments?: Array<{ path: string; mediaType: string; sha256: string; size: number }>; operation?: SideThreadRuntimeOperation }): Promise<{ turnId: string }> {
     this.assertOpen();
-    this.assertOwnedThread(input.derivedThreadId, input.sideThreadId);
+    if ((input.attachments ?? []).some((item) => !item.mediaType.startsWith("image/"))) {
+      throw new SideThreadUnsupportedError("runtime", "Codex SideThread accepts only verified local image attachments");
+    }
+    if (this.derivedThreads.get(input.derivedThreadId) !== input.sideThreadId)
+      await this.ensureOwnedThread(input.derivedThreadId, input.sideThreadId);
     const clientUserMessageId = `anet-side:${input.sideThreadId}:${input.attemptId}`;
     const identity = input.operation ?? this.defaultOperation(input.sideThreadId, "start", `start-${input.attemptId}`);
     this.pendingStartThreads.add(input.derivedThreadId);
@@ -202,11 +206,12 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     finally { this.pendingStartThreads.delete(input.derivedThreadId); await claim.release(); }
   }
 
-  private async startClaimed(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; operation?: SideThreadRuntimeOperation },
+  private async startClaimed(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; attachments?: Array<{ path: string; mediaType: string; sha256: string; size: number }>; operation?: SideThreadRuntimeOperation },
     identity: SideThreadRuntimeOperation, clientUserMessageId: string): Promise<{ turnId: string }> {
     this.assertOpen();
     const operation = this.operation(identity, input.sideThreadId, "start", input.derivedThreadId,
-      JSON.stringify([input.sideThreadId, input.attemptId, input.derivedThreadId, operationHash(input.prompt)]));
+      JSON.stringify([input.sideThreadId, input.attemptId, input.derivedThreadId, operationHash(input.prompt),
+        ...(input.attachments ?? []).map((item) => [item.sha256, item.size, item.mediaType])]));
     const prior = this.existing(operation);
     if (prior && prior.state !== "prepared") return this.reconcileStart({ ...input, operation: identity }, clientUserMessageId, prior);
     if (!prior) this.put(operation);
@@ -235,7 +240,10 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
         const request = this.rpc<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
         threadId: input.derivedThreadId,
         clientUserMessageId,
-        input: [{ type: "text", text: input.prompt }],
+        input: [
+          { type: "text", text: input.prompt },
+          ...(input.attachments ?? []).map((item) => ({ type: "localImage", path: item.path })),
+        ],
         });
         const abortOnIdentityFailure = identityEcho.then(
           () => new Promise<never>(() => {}),
@@ -272,18 +280,21 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
 
   async cancel(input: { sideThreadId?: string; derivedThreadId: string; turnId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
-    this.assertOwnedThread(input.derivedThreadId);
+    if (!input.sideThreadId) this.assertOwnedThread(input.derivedThreadId);
+    else await this.ensureOwnedThread(input.derivedThreadId, input.sideThreadId);
     const execution = this.byTurn.get(turnKey(input.derivedThreadId, input.turnId));
-    if (!execution) throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
-    const sideThreadId = input.sideThreadId ?? execution.sideThreadId;
-    await this.durableMutation(sideThreadId, "interrupt", input.operation ?? this.defaultOperation(sideThreadId, "interrupt", `cancel-${execution.attemptId}`), input.derivedThreadId,
+    const sideThreadId = input.sideThreadId ?? execution?.sideThreadId;
+    if (!sideThreadId || (!execution && !this.persistedTurnOwned(sideThreadId, input.derivedThreadId, input.turnId)))
+      throw new SideThreadConflictError("refusing to cancel an unowned Codex turn");
+    await this.durableMutation(sideThreadId, "interrupt", input.operation ?? this.defaultOperation(sideThreadId, "interrupt", `cancel-${input.turnId}`), input.derivedThreadId,
       JSON.stringify([input.derivedThreadId, input.turnId]), "turn/interrupt",
       { threadId: input.derivedThreadId, turnId: input.turnId });
   }
 
   async archive(input: { sideThreadId?: string; derivedThreadId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
-    this.assertOwnedThread(input.derivedThreadId);
+    if (!input.sideThreadId) this.assertOwnedThread(input.derivedThreadId);
+    else await this.ensureOwnedThread(input.derivedThreadId, input.sideThreadId);
     const sideThreadId = input.sideThreadId ?? this.derivedThreads.get(input.derivedThreadId)!;
     await this.durableMutation(sideThreadId, "archive", input.operation ?? this.defaultOperation(sideThreadId, "archive", `archive-${sideThreadId}`), input.derivedThreadId,
       JSON.stringify([input.derivedThreadId]), "thread/archive", { threadId: input.derivedThreadId });
@@ -291,7 +302,8 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
 
   async delete(input: { sideThreadId?: string; derivedThreadId: string; operation?: SideThreadRuntimeOperation }): Promise<void> {
     this.assertOpen();
-    this.assertOwnedThread(input.derivedThreadId);
+    if (!input.sideThreadId) this.assertOwnedThread(input.derivedThreadId);
+    else await this.ensureOwnedThread(input.derivedThreadId, input.sideThreadId);
     if (this.pendingStartThreads.has(input.derivedThreadId)
       || [...this.byTurn.values(), ...this.byClientId.values()].some((x) => x.threadId === input.derivedThreadId)) {
       throw new SideThreadConflictError("refusing to delete a thread with an active owned turn");
@@ -497,7 +509,7 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
       throw new SideThreadAmbiguousError(`Codex fork reconciliation failed; refusing duplicate thread/fork${cause ? " after response loss" : ""}`);
     }
   }
-  private async reconcileStart(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; operation: SideThreadRuntimeOperation },
+  private async reconcileStart(input: { sideThreadId: string; attemptId: string; derivedThreadId: string; prompt: string; attachments?: Array<{ path: string; mediaType: string; sha256: string; size: number }>; operation: SideThreadRuntimeOperation },
     clientUserMessageId: string, prior: SideThreadOperation): Promise<{ turnId: string }> {
     const live = this.byClientId.get(clientUserMessageId);
     let turnId = live?.turnId;
@@ -606,6 +618,29 @@ export class CodexAppServerSideThreadAdapter implements SideThreadRuntimeAdapter
     this.assertSupported();
     const owner = this.derivedThreads.get(threadId);
     if (!owner || (sideThreadId && owner !== sideThreadId)) throw new SideThreadConflictError("refusing operation on an unowned Codex thread");
+  }
+  private async ensureOwnedThread(threadId: string, sideThreadId: string): Promise<void> {
+    const owner = this.derivedThreads.get(threadId);
+    if (owner) {
+      if (owner !== sideThreadId) throw new SideThreadConflictError("refusing operation on a foreign Codex thread");
+      return;
+    }
+    const fork = this.opts.operationLedger.list(this.opts.nodeId, sideThreadId).find((operation) =>
+      operation.method === "fork"
+      && (operation.state === "accepted" || operation.state === "reconciled")
+      && operation.result?.derivedThreadIdHash === operationHash(threadId));
+    if (!fork) throw new SideThreadConflictError("refusing operation on an unowned Codex thread");
+    const thread = await this.readThread(threadId);
+    if (!thread.forkedFromId || operationHash(thread.forkedFromId) !== fork.targetHash)
+      throw new SideThreadConflictError("persisted Codex fork ownership no longer matches runtime");
+    this.derivedThreads.set(threadId, sideThreadId);
+  }
+  private persistedTurnOwned(sideThreadId: string, threadId: string, turnId: string): boolean {
+    return this.opts.operationLedger.list(this.opts.nodeId, sideThreadId).some((operation) =>
+      operation.method === "start"
+      && (operation.state === "accepted" || operation.state === "reconciled")
+      && operation.targetHash === operationHash(threadId)
+      && operation.result?.turnIdHash === operationHash(turnId));
   }
   private dropped(reason: string): void { for (const listener of this.droppedListeners) listener(reason); }
 }

--- a/agent-node/src/runtime/side-thread/fork-lease.ts
+++ b/agent-node/src/runtime/side-thread/fork-lease.ts
@@ -104,7 +104,13 @@ export class PrivateFileForkLeaseStore implements ForkLeaseStore {
       if (released) return; released = true;
       await new Promise<void>((resolve) => {
         if (holder.exitCode !== null || holder.signalCode !== null) return resolve();
-        holder.once("exit", () => resolve()); holder.stdin!.end();
+        let settled = false;
+        const done = () => { if (settled) return; settled = true; clearTimeout(force); resolve(); };
+        // A killed/reparented launcher can leave the stdin-driven flock
+        // helper alive even after end(). Never let command ACK hang forever.
+        const force = setTimeout(() => holder.kill("SIGKILL"), 1_000);
+        force.unref?.();
+        holder.once("exit", done); holder.stdin!.end();
       });
       closeSync(fd);
     } };

--- a/agent-node/src/runtime/side-thread/production.test.ts
+++ b/agent-node/src/runtime/side-thread/production.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createProductionSideThreadNode } from "./production";
+
+const roots: string[] = [];
+afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+
+class StubCodex extends EventEmitter {
+  calls: Array<{ method: string; params: any }> = [];
+  threads = new Map<string, any>([["source", { id: "source", turns: [{ id: "source-turn" }] }]]);
+  async request<T>(method: string, params: any): Promise<T> {
+    this.calls.push({ method, params });
+    if (method === "thread/list") return { data: [...this.threads.values()], nextCursor: null } as T;
+    if (method === "thread/read") return { thread: this.threads.get(params.threadId) } as T;
+    if (method === "thread/fork") {
+      const thread = { id: "derived", forkedFromId: params.threadId, turns: [{ id: params.lastTurnId }] };
+      this.threads.set(thread.id, thread); return { thread } as T;
+    }
+    if (method === "turn/start") {
+      const turnId = params.threadId === "source" ? "bring-back-turn" : "derived-turn";
+      if (params.clientUserMessageId?.startsWith("anet-side:")) await new Promise<void>((resolve) => queueMicrotask(() => {
+        this.emit("item/started", {
+          threadId: params.threadId, turnId,
+          item: { type: "userMessage", clientId: params.clientUserMessageId },
+        });
+        resolve();
+      }));
+      return { turn: { id: turnId } } as T;
+    }
+    return {} as T;
+  }
+}
+
+const base = (kind: string, payload: any, attemptId: string | null = null) => ({
+  protocol: "side_thread.command.v1", commandId: `cmd-${kind}`, operationId: `op-${kind}`,
+  requestKey: `request-${kind}`, nodeId: "node-1", sideThreadId: "side-1", attemptId, kind, payload,
+});
+
+describe("production SideThread node wiring", () => {
+  test("real startup consumer uses only dedicated outbox and executes fork/start/bring-back", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "side-prod-")); roots.push(codexHome);
+    const client = new StubCodex();
+    const image = Buffer.from("real image bytes");
+    const imageSha = createHash("sha256").update(image).digest("hex");
+    const commands = [
+      base("fork", { sourceThreadId: "source", boundary: { kind: "through", turnId: "source-turn" } }),
+      base("start", { threadId: "derived", question: "side question", attachments: [{
+        fileId: "file12345678", grantId: "grant-1", sha256: imageSha, size: image.length, mediaType: "image/png",
+      }] }, "attempt-1"),
+      base("bring-back", { sourceThreadId: "derived", sourceTurnId: "derived-turn", destinationThreadId: "source", text: "side answer" }, "attempt-1"),
+    ];
+    const requests: Array<{ url: string; method: string; body?: any }> = [];
+    const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input); const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      requests.push({ url, method, body });
+      if (url.endsWith("/api/side-thread/attachment-grants/grant-1")) return new Response(image, {
+        headers: { "Content-Type": "image/png", "Content-Length": String(image.length) },
+      });
+      if (url.endsWith("/pending")) return Response.json({ ok: true, command: commands.shift() ?? null });
+      if (url.endsWith("/ack")) return Response.json({ ok: true });
+      if (url.endsWith("/terminals")) return Response.json({ ok: true });
+      return Response.json({ ok: false }, { status: 404 });
+    };
+    const runtime = createProductionSideThreadNode({
+      enabled: true, client, hubUrl: "https://hub.invalid", nodeId: "node-1", token: "ntok_bound",
+      codexHome, runtimeVersion: "0.148.0", topology: "owned-stdio", experimentalApi: false,
+      pollMs: 5, fetchImpl: fetchImpl as typeof fetch,
+    });
+    try {
+      for (let n = 0; n < 100 && requests.filter((x) => x.url.endsWith("/ack")).length < 3; n++) await Bun.sleep(5);
+      expect(runtime.capability).toMatchObject({ supported: true, exactBoundary: { through: true, before: false } });
+      expect(requests.filter((x) => x.url.endsWith("/ack")).map((x) => x.body.state)).toEqual(["accepted", "accepted", "accepted"]);
+      expect(requests.every((x) => x.url.includes("/side-thread-commands") || x.url.includes("/side-thread/attachment-grants/"))).toBe(true);
+      expect(client.calls.filter((x) => x.method === "thread/fork")).toHaveLength(1);
+      expect(client.calls.filter((x) => x.method === "turn/start")).toHaveLength(2);
+      const sideStart = client.calls.find((x) => x.params.clientUserMessageId?.startsWith("anet-side:"));
+      expect(sideStart?.params.input[0]).toEqual({ type: "text", text: "side question" });
+      expect(sideStart?.params.input[1]).toMatchObject({ type: "localImage" });
+      expect(sideStart?.params.input[1].path.startsWith(join(codexHome, "agent-network-side-threads", "node-1", "attachments"))).toBe(true);
+      expect(statSync(sideStart?.params.input[1].path).mode & 0o777).toBe(0o600);
+      expect(client.calls.find((x) => x.params.clientUserMessageId?.startsWith("anet-btw-bring-back:"))?.params.input[0].text)
+        .toBe("[BTW bring-back]\nside answer");
+    } finally { runtime.close(); }
+  });
+
+  test("shared remote topology fails closed before polling or mutation", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "side-prod-shared-")); roots.push(codexHome);
+    const client = new StubCodex(); let fetches = 0;
+    const runtime = createProductionSideThreadNode({
+      enabled: true, client, hubUrl: "https://hub.invalid", nodeId: "node-1", token: "ntok_bound",
+      codexHome, runtimeVersion: "0.148.0", topology: "shared-websocket", experimentalApi: true,
+      fetchImpl: (async () => { fetches++; return Response.json({ ok: true, command: null }); }) as typeof fetch,
+    });
+    expect(runtime).toMatchObject({ enabled: false, capability: { supported: false, reason: "topology" } });
+    await Bun.sleep(5);
+    expect(fetches).toBe(0); expect(client.calls).toHaveLength(0);
+  });
+});

--- a/agent-node/src/runtime/side-thread/production.ts
+++ b/agent-node/src/runtime/side-thread/production.ts
@@ -1,0 +1,116 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { JournaledBringBackExecutor } from "./bring-back-journal";
+import { CodexAppServerSideThreadAdapter, type SideThreadCodexClient } from "./codex-app-server-adapter";
+import { SideThreadCommandConsumer } from "./command-consumer";
+import { PrivateFileCommandReceiptStore } from "./command-receipts";
+import { SideThreadCommandExecutor } from "./command-transport";
+import { PrivateFileForkLeaseStore } from "./fork-lease";
+import { materializeCommandAttachment } from "./materialize-command-attachment";
+import { PrivateFileOperationLedger } from "./operation-ledger";
+import { PrivateFileTerminalOutbox } from "./terminal-outbox";
+import type { SideThreadCapability } from "./domain";
+
+export const SIDE_THREAD_EVIDENCE_REVISION = "test1190-wire-v2";
+export const SIDE_THREAD_CODEX_VERSION = "0.148.0";
+
+export function detectCodexRuntimeVersion(binary = "codex"): string {
+  try {
+    const text = execFileSync(binary, ["--version"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5_000 });
+    return text.match(/(?:codex(?:-cli)?\s+)?(\d+\.\d+\.\d+)/i)?.[1] ?? "unknown";
+  } catch { return "unknown"; }
+}
+
+export function createProductionSideThreadNode(opts: {
+  enabled: boolean;
+  client: SideThreadCodexClient;
+  hubUrl: string;
+  nodeId: string;
+  token: string | (() => string);
+  codexHome: string;
+  runtimeVersion: string;
+  topology: "owned-stdio" | "owned-websocket" | "shared-websocket";
+  experimentalApi: boolean;
+  pollMs?: number;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+  fetchImpl?: typeof fetch;
+}) {
+  if (!opts.enabled) return disabled("runtime");
+  const root = join(opts.codexHome, "agent-network-side-threads", opts.nodeId);
+  const forkLeaseStore = new PrivateFileForkLeaseStore(join(root, "fork-leases"));
+  // The transport receipt/native/receipt claim and the adapter's per-RPC
+  // claim are distinct nested critical sections. Sharing one lock path would
+  // make every real adapter command self-conflict.
+  const commandClaimStore = new PrivateFileForkLeaseStore(join(root, "command-claims"));
+  const adapter = new CodexAppServerSideThreadAdapter({
+    client: opts.client,
+    runtimeVersion: opts.runtimeVersion,
+    topology: opts.topology,
+    evidenceRevision: SIDE_THREAD_EVIDENCE_REVISION,
+    experimentalApi: opts.experimentalApi,
+    nodeId: opts.nodeId,
+    operationLedger: new PrivateFileOperationLedger(join(root, "operations")),
+    forkLeaseStore,
+  });
+  const capability = adapter.capability();
+  if (!capability.supported) { adapter.close(); return disabled(capability.reason ?? "runtime", capability); }
+  const terminalOutbox = new PrivateFileTerminalOutbox(join(root, "terminal-outbox"));
+  const bringBack = new JournaledBringBackExecutor(join(root, "bring-back"), async (input) => {
+    const response = await opts.client.request<{ turn?: { id?: string }; turnId?: string }>("turn/start", {
+      threadId: input.destinationThreadId,
+      clientUserMessageId: `anet-btw-bring-back:${input.clientRequestId}`,
+      input: [{ type: "text", text: `[BTW bring-back]\n${input.text}` }],
+    });
+    const destinationTurnId = response?.turn?.id ?? response?.turnId;
+    if (!destinationTurnId) throw new Error("Codex bring-back returned no turn identity");
+    return { destinationTurnId };
+  });
+  const executor = new SideThreadCommandExecutor({
+    nodeId: opts.nodeId,
+    adapter,
+    terminalOutbox,
+    receipts: new PrivateFileCommandReceiptStore(join(root, "command-receipts")),
+    claimExecution: ({ nodeId, sideThreadId, operationId }) => commandClaimStore.claimOperation(nodeId, sideThreadId, operationId),
+    materializeAttachment: (grant) => materializeCommandAttachment(grant, {
+      hubUrl: opts.hubUrl,
+      nodeToken: typeof opts.token === "function" ? opts.token() : opts.token,
+      cacheDir: join(root, "attachments"),
+      fetchImpl: opts.fetchImpl,
+    }),
+    bringBack: (input) => bringBack.execute(input),
+    onDroppedTerminal: (reason) => opts.warn?.(`[side-thread] dropped terminal: ${reason}`),
+  });
+  const consumer = new SideThreadCommandConsumer({
+    hubUrl: opts.hubUrl, nodeId: opts.nodeId, token: opts.token,
+    executor, terminalOutbox, fetchImpl: opts.fetchImpl,
+  });
+  let closed = false;
+  const tick = () => consumer.trigger().catch((error) => opts.warn?.(`[side-thread] poll failed: ${error instanceof Error ? error.message : String(error)}`));
+  const timer = setInterval(tick, opts.pollMs ?? 1_000); timer.unref?.();
+  void tick();
+  opts.log?.(`[side-thread] dedicated consumer enabled (${capability.runtimeVersion}, ${capability.topology})`);
+  return {
+    enabled: true as const,
+    capability,
+    close() {
+      if (closed) return; closed = true; clearInterval(timer); consumer.stop(); executor.close(); adapter.close();
+    },
+  };
+}
+
+/** The single production startup seam used by agent-node CLI. Tests may
+ * inject a protocol-faithful client, while authentication and transport stay
+ * on the real Hub/node boundary. */
+export const startCliSideThreadConsumer = createProductionSideThreadNode;
+
+function disabled(reason: NonNullable<SideThreadCapability["reason"]>, capability?: SideThreadCapability) {
+  return {
+    enabled: false as const,
+    capability: capability ?? {
+      supported: false, runtime: "codex-app-server", runtimeVersion: "unknown",
+      topology: "unknown", evidenceRevision: SIDE_THREAD_EVIDENCE_REVISION, reason,
+    },
+    close() {},
+  };
+}

--- a/docs/design/side-thread-pr4-production-wiring.md
+++ b/docs/design/side-thread-pr4-production-wiring.md
@@ -1,0 +1,69 @@
+# SideThread PR4: production wiring
+
+This change connects the reviewed `/btw` protocol to production without using
+the ordinary task inbox, FIFO queue, or active-turn steering path. It is
+stacked on the native Codex 0.148 evidence and durable command transport.
+
+## Rollout boundary
+
+Both sides are opt-in:
+
+- Hub: `COMMHUB_ENABLE_SIDE_THREADS=1` installs the SQLite-backed
+  `SideThreadExecutionPort`, command outbox, and attachment-grant route.
+- Node: `flags.sideThreads=true` (or `ANET_ENABLE_SIDE_THREADS=1`) starts the
+  dedicated command consumer and publishes its exact capability snapshot.
+
+The current production allowlist is intentionally narrow: runtime
+`codex-app-server`, version `0.148.0`, topology `owned-stdio`, evidence
+`test1190-wire-v2`, native exact fork, and `through=true`. `before` is exposed
+only with `flags.sideThreadExperimentalApi=true`. A configured shared WebSocket,
+unknown version/topology, missing stable node id, or missing dedicated
+`CODEX_HOME` publishes `supported=false` and performs no SideThread polling or
+native mutation. Turning the local flag off also publishes an explicit closed
+capability, preventing a durable stale snapshot from remaining eligible.
+
+## Runtime topology and durability
+
+The node reuses its live Codex app-server client and configuration, but every
+request forks a derived Codex thread. SideThread state lives below
+`$CODEX_HOME/agent-network-side-threads/<node-id>` in distinct stores for fork
+leases, command claims, receipts, native-operation evidence, terminal WAL, and
+bring-back journal. Restart recovery verifies hashed ownership against
+authoritative `thread/read`; it never adopts an unproved thread or turn.
+
+The consumer calls only the node-bound `/side-thread-commands` endpoints.
+Bring-back is a labelled native `turn/start` on the destination thread, guarded
+by a write-ahead journal. There is no fallback to `send_task`.
+
+Because the command outbox and node consumer are separate processes, the Hub
+production port gives a newly queued command a bounded 2.5-second window for
+its durable ACK. This lets the coordinator advance fork to start without
+pretending an asynchronous dispatch was synchronous. Missing or late ACKs
+still return the typed ambiguous state and never fall back to the task queue.
+
+## Attachments
+
+The Hub issues a five-minute grant bound to the target node and network after
+re-reading the upload index and hashing the blob. The node downloads through
+that grant, checks the exact size and SHA-256, enforces its materialization root,
+and writes mode `0600`. Codex receives images as structured
+`{type:"localImage", path}` input. Unsupported media fails closed; it is never
+silently reduced to a text path.
+
+Test1204 proves this on real Codex 0.148.0 using a disposable authenticated
+home: the prompt excludes a unique marker, the marker exists only in image
+pixels, the model returns it, and authoritative derived `thread/read` contains
+that answer. Output evidence is sanitized and the disposable home is erased by
+the sentinel-guarded probe.
+
+## Verification
+
+- Test1204: 42 production/transport/adapter tests, both production bundles, a
+  real Hub plus real agent-node CLI registration/startup process gate (with
+  injected fake Codex RPC only), and five witnessed-red mutations covering
+  source binding, Hub install, CLI startup, image downgrade, and task routing.
+- Test1203: upstream real 0.148 fork/concurrency/cancel/recovery gate.
+- Test1204: production wiring gates plus the pixel-only attachment proof.
+
+This PR is a gated production integration, not authorization to merge, enable,
+or publish it.

--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1835 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1835) + [tools.ts:1849 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1849) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1845 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1845) + [tools.ts:1857 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1857) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:72 + db.ts:98](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L72)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/docs/tests/report-test1204-btw-production-wiring.txt
+++ b/docs/tests/report-test1204-btw-production-wiring.txt
@@ -1,0 +1,59 @@
+test1204 /btw production wiring
+Date: 2026-08-26
+Base: main 86f98166 (#1203/#1202/#1201/#1194 merged)
+
+Coverage:
+- Hub installs the SQLite durable SideThread port only behind COMMHUB_ENABLE_SIDE_THREADS=1
+- exact node capability comes from the bound node's strict masked snapshot
+- node-bound, network-bound, five-minute attachment grant; exact SHA/size; 404 on foreign/expired
+- agent-node creates a dedicated Codex adapter/consumer under its persistent CODEX_HOME
+- owned Codex 0.148.0 only; shared/unknown/version drift fails closed before polling
+- fork/start/terminal/cancel/archive/purge/bring-back stay outside tasks/inbox/FIFO/steer
+- verified image is materialized 0600 and serialized as localImage; non-image fails closed
+- journaled bring-back writes one labelled native turn and never falls back to send_task
+- restart restores derived-thread ownership from hashed durable fork evidence plus thread/read
+- Docker image is bound to an exact 40-character SOURCE_COMMIT revision
+- real Hub boot + real agent-node registration/startup + injected Codex RPC executes the production outbox/ACK/terminal/bring-back path
+- production Hub waits at most 2.5 seconds for the asynchronous durable node ACK; timeout remains ambiguous/fail-closed
+- a same-key create replays durable late fork/start receipts into coordinator state across restart/multiple coordinators, enqueues start once, and terminal reconciliation remains idempotent
+- late unsupported/failed ACKs preserve their typed result and atomically converge record/attempt/active ownership to a stable failed terminal
+- cancel/archive/purge/bring-back share one durable lifecycle reconciler; accepted, unsupported and failed receipts are replayed across restart and concurrent same-key calls without another command
+- slow lifecycle replay has fast-path parity for operation thread/turn identity and emits each archive/purge/bring-back domain event exactly once; cancel acceptance emits no misleading terminal event
+- event rows commit before fanout; observer failures are isolated per listener, durable cursor replay survives restart, and a SQLite CAS makes multi-coordinator lifecycle settlement/event emission single-winner
+- runtime receipt acquisition and local apply are separate phases: archive/bring-back local transaction failures remain ambiguous, survive coordinator restart, and replay the accepted receipt into one final event instead of falsifying a runtime failure
+- create fork/start accepted receipts use the same local-apply boundary; injected fork and start projection failures survive restart, reuse the durable receipt, create one stable start operation, and never enqueue duplicate native work
+- create recovery is driven by durable fork/start operation plus active-attempt state, including creating/starting with pending operations when both local apply and ambiguity marking fail consecutively
+
+Expected gates:
+- 58 targeted baseline tests
+- agent-node and server production bundles
+- witnessed-red: localImage downgrade
+- witnessed-red: ordinary task route substitution
+- witnessed-red: invalid SOURCE_COMMIT
+- witnessed-red: removed Hub production port/routes
+- witnessed-red: removed agent-node CLI consumer startup
+- witnessed-red: disabled late-ACK coordinator reconciliation
+- witnessed-red: narrowed authoritative failure settlement to starting-only
+- witnessed-red: removed the shared lifecycle receipt reconciler
+- witnessed-red: changed the slow-path lifecycle domain event
+- witnessed-red: removed per-listener observer exception isolation
+- witnessed-red: misclassified local apply failure as authoritative runtime failure
+- witnessed-red: misclassified accepted fork/start local apply as runtime failure
+
+Result:
+- PASS: 58/58 targeted tests (assertion count recorded by the exact-source Docker run)
+- PASS: agent-node CLI/upload helper and CommHub server bundles
+- PASS witnessed-red: localImage -> text mutation rejected
+- PASS witnessed-red: dedicated command route -> tasks mutation rejected
+- PASS: real two-process Hub + agent-node CLI registration/startup and injected-RPC consumer completed fork/start/terminal/bring-back
+- PASS witnessed-red: invalid source binding, removed Hub install, and removed CLI startup all rejected
+- PASS witnessed-red: same-key ambiguous early-return mutation strands the late fork ACK and is rejected
+- PASS witnessed-red: starting-only failure settlement leaves replay stuck reconciling and is rejected
+- PASS witnessed-red: deleting shared lifecycle reconciliation breaks late cancel recovery
+- PASS witnessed-red: changing the slow-path archive event breaks event parity
+- PASS witnessed-red: allowing a throwing observer to escape starves the next listener and is rejected
+- PASS witnessed-red: converting recoverable local apply ambiguity to runtime failure is rejected
+- PASS witnessed-red: converting create receipt apply ambiguity to runtime failure is rejected
+- PASS test1204 real Codex 0.148 attachment proof: marker absent from prompt,
+  observed in model answer and authoritative derived thread/read; materialized
+  image mode 0600; sanitized evidence only

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -78,6 +78,7 @@ L1_TESTS=(
   # #1027: deterministic reproduction of the historical test225 foreground
   # start/stop race plus ownership, socket-residue and KILL escalation gates.
   "test225-node-stop-convergence"
+  "test1204-btw-production-wiring"
   "qa-cli-01-hub-start"
   "qa-cli-02-network-create"
   "qa-dash-07-auth-boundary"

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -51,6 +51,7 @@ import { handleExternalScheduleEditRequest } from "./external-schedule-edits.js"
 import { recordDeliveredStaleEvents } from "./task-lifecycle-watcher.js";
 import { SIDE_THREAD_FEATURE_FLAG, SideThreadCoordinator, SideThreadPortRegistry, SideThreadStore, type SideThreadActor, type SideThreadAttachmentRef, type SideThreadExecutionPort } from "./side-thread.js";
 import { handleSideThreadHttpRequest } from "./side-thread-http.js";
+import { createProductionSideThreadTransport } from "./side-thread-production.js";
 
 const PORT = resolvePort(process.env.PORT);
 const HOST = process.env.HOST || "127.0.0.1";
@@ -77,6 +78,10 @@ const sideThreadCoordinator = new SideThreadCoordinator(new SideThreadStore(db),
   authorizeNode: (actor, networkId, nodeId) => authorizeSideThreadNode(actor, networkId, nodeId),
   authorizeAttachment: (actor, networkId, ref) => authorizeSideThreadAttachment(actor, networkId, ref),
 });
+const productionSideThreadTransport = process.env[SIDE_THREAD_FEATURE_FLAG] === "1"
+  ? createProductionSideThreadTransport(db)
+  : null;
+if (productionSideThreadTransport) installSideThreadExecutionPort(productionSideThreadTransport.port);
 
 if (AUTH_TOKEN) {
   console.warn("[commhub] COMMHUB_AUTH_TOKEN is deprecated and will be removed in v1.0. See RFC-001.");
@@ -1519,11 +1524,22 @@ return Bun.serve({
       return withCors(req, Response.json({ ok: false, error: restScope.denied }, { status: 403 }));
     }
 
+    const sideActor = resolveSideThreadActor(req, resolveRequestAuth(req, { allowQueryToken: false }), isAdmin);
+    const nodeCommandActor = sideActor?.kind === "node" && sideActor.boundNodeId && sideActor.boundNetworkId
+      ? { tokenId: sideActor.tokenId, networkId: sideActor.boundNetworkId, nodeId: sideActor.boundNodeId }
+      : null;
+    if (productionSideThreadTransport) {
+      const attachmentResponse = await productionSideThreadTransport.attachment(req, url, nodeCommandActor);
+      if (attachmentResponse) return withCors(req, attachmentResponse);
+      const commandResponse = await productionSideThreadTransport.handle({ req, url, actor: nodeCommandActor });
+      if (commandResponse) return withCors(req, commandResponse);
+    }
+
     const sideThreadResponse = await handleSideThreadHttpRequest({
       req,
       url,
       // Durable prompts/results never accept query-string credentials.
-      actor: resolveSideThreadActor(req, resolveRequestAuth(req, { allowQueryToken: false }), isAdmin),
+      actor: sideActor,
       coordinator: sideThreadCoordinator,
       resolveCapabilityTarget: resolveSideThreadCapabilityTarget,
     });

--- a/server/src/side-thread-command-transport.test.ts
+++ b/server/src/side-thread-command-transport.test.ts
@@ -16,6 +16,168 @@ function fixture() {
 }
 
 describe("Hub durable SideThread command outbox", () => {
+  test("late fork and start ACKs reconcile the coordinator across restart", async () => {
+    const f = fixture();
+    const owner = { userId: "user-1", username: "owner", tokenId: "utok-1", kind: "user" as const };
+    const input = { requestKey: "rk-late-create", networkId: "net-1", nodeId: "node-1", sourceThreadId: "source-1", boundary: { kind: "through" as const, turnId: "source-turn" }, prompt: "late receipt", attachments: [] };
+    const sideStore = new SideThreadStore(f.db);
+    let coordinator = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+    const originalTransaction = f.db.transaction.bind(f.db);
+    const failTransaction = (...nth: number[]) => { let calls = 0; (f.db as any).transaction = (fn: () => unknown) => nth.includes(++calls) ? (() => { throw new Error("injected create apply failure"); })() : originalTransaction(fn); };
+    failTransaction(2);
+    await expect(coordinator.create(owner, input)).rejects.toThrow("injected create apply failure");
+    const side = sideStore.getByCreateKey(owner, input.requestKey)!.record;
+    expect(side).toMatchObject({ state: "creating", attempts: [{ state: "starting" }], operations: [{ kind: "fork", state: "pending" }] });
+    const fork = f.store.claim(actor())!;
+    f.store.ack(actor(), { protocol: "side_thread.ack.v1", commandId: fork.commandId, operationId: fork.operationId, state: "accepted", errorCode: null, result: { threadId: "derived-late", turnId: null, destinationTurnId: null } });
+    (f.db as any).transaction = originalTransaction;
+    coordinator.close();
+    coordinator = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+    failTransaction(2, 3);
+    await expect(coordinator.create(owner, input)).rejects.toThrow("injected create apply failure");
+    expect(sideStore.getByCreateKey(owner, input.requestKey)!.record).toMatchObject({ state: "reconciling", attempts: [{ state: "reconciling" }], operations: [{ kind: "fork", state: "pending" }] });
+    expect(f.store.claim(actor())).toBeNull();
+    (f.db as any).transaction = originalTransaction;
+    coordinator.close();
+    coordinator = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+    await expect(coordinator.create(owner, input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    const start = f.store.claim(actor())!;
+    expect(start.kind).toBe("start");
+    f.store.ack(actor(), { protocol: "side_thread.ack.v1", commandId: start.commandId, operationId: start.operationId, state: "accepted", errorCode: null, result: { threadId: null, turnId: "turn-late", destinationTurnId: null } });
+    failTransaction(3);
+    await expect(coordinator.create(owner, input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    expect(f.store.claim(actor())).toBeNull();
+    (f.db as any).transaction = originalTransaction;
+    coordinator.close();
+    coordinator = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+    expect(await coordinator.create(owner, input)).toMatchObject({ state: "running", threadId: "derived-late", attempts: [{ turnId: "turn-late" }] });
+    const terminal = { protocol: "side_thread.terminal.v1", sideThreadId: side.sideChatId, attemptId: side.activeAttemptId!, threadId: "derived-late", turnId: "turn-late", status: "completed" as const, text: "late answer", errorCode: null };
+    expect((await f.port.acceptTerminal(actor(), terminal)).confirmed).toBe(true);
+
+    expect(await coordinator.create(owner, input)).toMatchObject({ sideChatId: side.sideChatId, state: "completed", threadId: "derived-late", attempts: [{ turnId: "turn-late", result: "late answer" }] });
+    expect(coordinator.get(owner, side.sideChatId).operations.filter((operation) => operation.kind === "fork" || operation.kind === "start")).toHaveLength(2);
+    expect(f.store.claim(actor())).toBeNull();
+    expect((await f.port.acceptTerminal(actor(), terminal)).idempotent).toBe(true);
+    expect(coordinator.get(owner, side.sideChatId)).toMatchObject({ state: "completed", attempts: [{ result: "late answer" }] });
+    coordinator.close();
+  });
+
+  for (const receipt of [
+    { state: "unsupported", errorCode: "SIDE_THREAD_UNSUPPORTED", code: "SIDE_THREAD_UNSUPPORTED", status: 501 },
+    { state: "failed", errorCode: "SIDE_THREAD_CONFLICT", code: "SIDE_THREAD_CONFLICT", status: 409 },
+  ] as const) test(`late ${receipt.state} fork ACK converges to stable failed across coordinators`, async () => {
+    const f = fixture();
+    const owner = { userId: "user-1", username: "owner", tokenId: "utok-1", kind: "user" as const };
+    const input = { requestKey: `rk-late-${receipt.state}`, networkId: "net-1", nodeId: "node-1", sourceThreadId: "source-1", boundary: { kind: "through" as const, turnId: "source-turn" }, prompt: "late failure", attachments: [] };
+    const sideStore = new SideThreadStore(f.db);
+    let first = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+    await expect(first.create(owner, input)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS" });
+    const command = f.store.claim(actor())!;
+    f.store.ack(actor(), { protocol: "side_thread.ack.v1", commandId: command.commandId, operationId: command.operationId, state: receipt.state, errorCode: receipt.errorCode, result: { threadId: null, turnId: null, destinationTurnId: null } });
+    first.close();
+
+    const second = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+    await expect(second.create(owner, input)).rejects.toMatchObject({ code: receipt.code, status: receipt.status });
+    const failed = sideStore.getByCreateKey(owner, input.requestKey)!.record;
+    expect(failed).toMatchObject({ state: "failed", attempts: [{ state: "failed" }], operations: [{ kind: "fork", state: "failed", errorCode: receipt.code }] });
+    expect(failed.activeAttemptId).toBeUndefined();
+    expect(f.db.get<{ active: string | null }>("SELECT active_attempt_id active FROM side_chats WHERE side_chat_id=?1", failed.sideChatId)?.active).toBeNull();
+    expect(await second.create(owner, input)).toMatchObject({ sideChatId: failed.sideChatId, state: "failed" });
+    expect(f.store.claim(actor())).toBeNull();
+    second.close();
+  });
+
+  for (const action of ["cancel", "archive", "purge", "bring-back"] as const)
+    for (const receipt of [
+      { state: "accepted", errorCode: null, code: null },
+      { state: "unsupported", errorCode: "SIDE_THREAD_UNSUPPORTED", code: "SIDE_THREAD_UNSUPPORTED" },
+      { state: "failed", errorCode: "SIDE_THREAD_CONFLICT", code: "SIDE_THREAD_CONFLICT" },
+    ] as const) test(`${action} consumes a late ${receipt.state} receipt after restart`, async () => {
+      const f = fixture();
+      const owner = { userId: "user-1", username: "owner", tokenId: "utok-1", kind: "user" as const };
+      const input = { requestKey: `rk-create-${action}-${receipt.state}`, networkId: "net-1", nodeId: "node-1", sourceThreadId: "source-1", boundary: { kind: "through" as const, turnId: "source-turn" }, prompt: "lifecycle", attachments: [] };
+      const sideStore = new SideThreadStore(f.db);
+      let coordinator = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+      await coordinator.create(owner, input).catch(() => {});
+      const fork = f.store.claim(actor())!;
+      f.store.ack(actor(), { protocol: "side_thread.ack.v1", commandId: fork.commandId, operationId: fork.operationId, state: "accepted", errorCode: null, result: { threadId: "derived-life", turnId: null, destinationTurnId: null } });
+      await coordinator.create(owner, input).catch(() => {});
+      const start = f.store.claim(actor())!;
+      f.store.ack(actor(), { protocol: "side_thread.ack.v1", commandId: start.commandId, operationId: start.operationId, state: "accepted", errorCode: null, result: { threadId: null, turnId: "turn-life", destinationTurnId: null } });
+      const running = await coordinator.create(owner, input);
+      if (action !== "cancel") await f.port.acceptTerminal(actor(), { protocol: "side_thread.terminal.v1", sideThreadId: running.sideChatId, attemptId: running.activeAttemptId!, threadId: "derived-life", turnId: "turn-life", status: "completed", text: "answer", errorCode: null });
+      const requestKey = `rk-${action}-${receipt.state}`;
+      const invoke = (c: SideThreadCoordinator) => action === "cancel" ? c.cancel(owner, running.sideChatId, { requestKey })
+        : action === "archive" ? c.archive(owner, running.sideChatId, { requestKey })
+        : action === "purge" ? c.purge(owner, running.sideChatId, { requestKey })
+        : c.bringBack(owner, running.sideChatId, { requestKey, destinationThreadId: "source-1" });
+      await invoke(coordinator).catch(() => {});
+      const command = f.store.claim(actor())!;
+      f.store.ack(actor(), { protocol: "side_thread.ack.v1", commandId: command.commandId, operationId: command.operationId, state: receipt.state, errorCode: receipt.errorCode, result: { threadId: null, turnId: null, destinationTurnId: action === "bring-back" && receipt.state === "accepted" ? "destination-life" : null } });
+      coordinator.close();
+      coordinator = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+      if (receipt.code) {
+        await expect(invoke(coordinator)).rejects.toMatchObject({ code: receipt.code });
+        await expect(invoke(coordinator)).rejects.toMatchObject({ code: receipt.code });
+      } else {
+        if (action === "archive" || action === "bring-back") {
+          const originalTransaction = f.db.transaction.bind(f.db);
+          let failApply = true;
+          (f.db as any).transaction = (fn: () => unknown) => {
+            if (failApply) { failApply = false; throw new Error("injected local apply failure"); }
+            return originalTransaction(fn);
+          };
+          await expect(invoke(coordinator)).rejects.toMatchObject({ code: "SIDE_THREAD_AMBIGUOUS", status: 202 });
+          const unsettled = sideStore.getByCreateKey(owner, input.requestKey)!.record.operations.find((op) => op.kind === action && op.requestKey === requestKey)!;
+          expect(["ambiguous", "reconciling"]).toContain(unsettled.state);
+          expect(unsettled.state).not.toBe("failed");
+          (f.db as any).transaction = originalTransaction;
+          coordinator.close();
+          coordinator = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+        }
+        const [one, two] = await Promise.all([invoke(coordinator), invoke(coordinator)]);
+        if (action === "bring-back") expect(one).toEqual({ bringBackId: expect.any(String), destinationTurnId: "destination-life" });
+        else expect(one).toMatchObject({ state: action === "cancel" ? "running" : action === "archive" ? "archived" : "purged" });
+        expect(two).toEqual(one);
+        const hydrated = coordinator.get(owner, running.sideChatId);
+        const operation = hydrated.operations.find((op) => op.kind === action && op.requestKey === requestKey)!;
+        expect(operation).toMatchObject({ state: "completed", threadId: action === "bring-back" ? "source-1" : "derived-life" });
+        if (action === "bring-back") expect(operation.turnId).toBe("destination-life");
+        if (action === "cancel") expect(operation.turnId).toBe("turn-life");
+        const domainType = action === "bring-back" ? "side_chat.brought_back" : action === "archive" ? "side_chat.archived" : action === "purge" ? "side_chat.purged" : null;
+        const afterEvents = coordinator.listEvents(owner, running.sideChatId);
+        if (domainType) expect(afterEvents.filter((event) => event.type === domainType)).toHaveLength(1);
+        else expect(afterEvents.filter((event) => ["side_chat.brought_back", "side_chat.archived", "side_chat.purged"].includes(event.type))).toHaveLength(0);
+      }
+      expect(f.store.claim(actor())).toBeNull();
+      coordinator.close();
+    });
+
+  test("two coordinators race a late archive receipt but persist one domain event", async () => {
+    const f = fixture();
+    const owner = { userId: "user-1", username: "owner", tokenId: "utok-1", kind: "user" as const };
+    const input = { requestKey: "rk-multi-archive-create", networkId: "net-1", nodeId: "node-1", sourceThreadId: "source-1", boundary: { kind: "through" as const, turnId: "source-turn" }, prompt: "multi", attachments: [] };
+    const sideStore = new SideThreadStore(f.db);
+    const bootstrap = new SideThreadCoordinator(sideStore, f.port, { enabled: true, authorizeNode: () => true });
+    await bootstrap.create(owner, input).catch(() => {});
+    const fork = f.store.claim(actor())!; f.store.ack(actor(), { protocol: "side_thread.ack.v1", commandId: fork.commandId, operationId: fork.operationId, state: "accepted", errorCode: null, result: { threadId: "derived-multi", turnId: null, destinationTurnId: null } });
+    await bootstrap.create(owner, input).catch(() => {});
+    const start = f.store.claim(actor())!; f.store.ack(actor(), { protocol: "side_thread.ack.v1", commandId: start.commandId, operationId: start.operationId, state: "accepted", errorCode: null, result: { threadId: null, turnId: "turn-multi", destinationTurnId: null } });
+    const running = await bootstrap.create(owner, input);
+    await f.port.acceptTerminal(actor(), { protocol: "side_thread.terminal.v1", sideThreadId: running.sideChatId, attemptId: running.activeAttemptId!, threadId: "derived-multi", turnId: "turn-multi", status: "completed", text: "done", errorCode: null });
+    await bootstrap.archive(owner, running.sideChatId, { requestKey: "rk-multi-archive" }).catch(() => {});
+    const archive = f.store.claim(actor())!; f.store.ack(actor(), { protocol: "side_thread.ack.v1", commandId: archive.commandId, operationId: archive.operationId, state: "accepted", errorCode: null, result: { threadId: null, turnId: null, destinationTurnId: null } });
+    bootstrap.close();
+    const port = () => new DurableSideThreadCommandPort({ store: f.store, networkForNode: () => "net-1", capabilityForNode: () => ({ supported: true, mode: "native-exact-fork", exactBoundary: { through: true, before: true } }), grantAttachment: (_node, ref) => ({ fileId: ref.fileId }) });
+    const a = new SideThreadCoordinator(sideStore, port(), { enabled: true, authorizeNode: () => true });
+    const b = new SideThreadCoordinator(sideStore, port(), { enabled: true, authorizeNode: () => true });
+    const [one, two] = await Promise.all([a.archive(owner, running.sideChatId, { requestKey: "rk-multi-archive" }), b.archive(owner, running.sideChatId, { requestKey: "rk-multi-archive" })]);
+    expect(one.state).toBe("archived"); expect(two.state).toBe("archived");
+    expect(sideStore.events(running.sideChatId).filter((event) => event.type === "side_chat.archived")).toHaveLength(1);
+    expect(f.store.claim(actor())).toBeNull();
+    a.close(); b.close();
+  });
+
   test("fails closed on the currently non-atomic PostgreSQL adapter", () => {
     expect(() => new SideThreadCommandStore({ dialect: "postgres" } as any)).toThrow(/atomic SQLite/);
   });

--- a/server/src/side-thread-command-transport.ts
+++ b/server/src/side-thread-command-transport.ts
@@ -225,6 +225,7 @@ export class DurableSideThreadCommandPort implements SideThreadExecutionPort {
     networkForNode: (nodeId: string) => string | null;
     capabilityForNode: (nodeId: string) => SideThreadCapability;
     grantAttachment: (nodeId: string, ref: SideThreadAttachmentRef) => Record<string, unknown>;
+    ackWaitMs?: number;
   }) {}
   capability(nodeId: string) { return this.opts.capabilityForNode(nodeId); }
   fork(input: Parameters<SideThreadExecutionPort["fork"]>[0]) { return this.issue(input, "fork", { sourceThreadId: input.sourceThreadId, boundary: input.boundary }, "threadId") as Promise<{threadId:string}>; }
@@ -261,10 +262,18 @@ export class DurableSideThreadCommandPort implements SideThreadExecutionPort {
       requestKey: input.requestKey ?? input.operationId, nodeId: input.nodeId, sideThreadId: input.sideChatId,
       attemptId: input.attemptId ?? null, kind, payload };
     this.opts.store.enqueue(command, { networkId, nodeId: input.nodeId });
-    const receipt = this.opts.store.receipt(input.operationId);
+    const deadline = Date.now() + (this.opts.ackWaitMs ?? 0);
+    let receipt = this.opts.store.receipt(input.operationId);
+    while (!receipt && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      receipt = this.opts.store.receipt(input.operationId);
+    }
     if (!receipt) throw new SideThreadError("SIDE_THREAD_AMBIGUOUS", "command durably queued; awaiting node ACK", 202, input.operationId, input.sideChatId, input.attemptId);
     if (receipt.state === "accepted") return resultKey ? { [resultKey]: object(receipt.result)[resultKey] } : undefined;
-    throw new SideThreadError(receipt.errorCode === "SIDE_THREAD_UNSUPPORTED" ? "SIDE_THREAD_UNSUPPORTED" : "SIDE_THREAD_AMBIGUOUS", "node command did not complete synchronously", receipt.errorCode === "SIDE_THREAD_UNSUPPORTED" ? 501 : 202, input.operationId, input.sideChatId, input.attemptId);
+    const code = receipt.state === "unsupported" ? "SIDE_THREAD_UNSUPPORTED"
+      : receipt.state === "failed" ? "SIDE_THREAD_CONFLICT" : "SIDE_THREAD_AMBIGUOUS";
+    const status = code === "SIDE_THREAD_UNSUPPORTED" ? 501 : code === "SIDE_THREAD_CONFLICT" ? 409 : 202;
+    throw new SideThreadError(code, "node command returned an authoritative result", status, input.operationId, input.sideChatId, input.attemptId);
   }
 }
 

--- a/server/src/side-thread-production.test.ts
+++ b/server/src/side-thread-production.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SQLiteAdapter } from "./db-adapter";
+import { createProductionSideThreadTransport } from "./side-thread-production";
+
+const roots: string[] = [];
+const priorUploads = process.env.COMMHUB_UPLOADS_DIR;
+afterEach(() => {
+  if (priorUploads === undefined) delete process.env.COMMHUB_UPLOADS_DIR;
+  else process.env.COMMHUB_UPLOADS_DIR = priorUploads;
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("production Hub SideThread wiring", () => {
+  test("advertises only an exact node snapshot and serves a short-lived node-bound grant", async () => {
+    const root = mkdtempSync(join(tmpdir(), "side-hub-prod-")); roots.push(root);
+    process.env.COMMHUB_UPLOADS_DIR = root;
+    const db = new SQLiteAdapter(new Database(":memory:"));
+    db.exec("CREATE TABLE nodes(node_id TEXT PRIMARY KEY, network_id TEXT, config_snapshot TEXT)");
+    db.run("INSERT INTO nodes VALUES (?1,?2,?3)", ["node-1", "net-1", JSON.stringify({ side_thread_capability: {
+      supported: true, runtime: "codex-app-server", runtimeVersion: "0.148.0", topology: "owned-stdio",
+      evidenceRevision: "test1190-wire-v2", mode: "native-exact-fork", exactBoundary: { through: true, before: false },
+    } })]);
+    let now = 1_000;
+    const transport = createProductionSideThreadTransport(db, () => now, 0);
+    expect(transport.port.capability("node-1")).toMatchObject({ supported: true, exactBoundary: { before: false } });
+    expect(transport.port.capability("missing")).toMatchObject({ supported: false, reason: "runtime" });
+
+    const fileId = "file12345678"; const bytes = Buffer.from("image bytes"); const bucket = "2026-08-26";
+    mkdirSync(join(root, ".index"), { recursive: true }); mkdirSync(join(root, bucket), { recursive: true });
+    writeFileSync(join(root, bucket, `${fileId}.png`), bytes);
+    writeFileSync(join(root, ".index", `${fileId}.json`), JSON.stringify({
+      file_id: fileId, date_bucket: bucket, ext: ".png", name: "x.png", mime: "image/png",
+      size: bytes.length, owner_id: "user-1", network_id: "net-1", uploaded_at: new Date().toISOString(),
+    }));
+    await transport.port.start({
+      operationId: "op-start", requestKey: "rk-start", sideChatId: "side-1", attemptId: "attempt-1",
+      nodeId: "node-1", threadId: "derived-1", prompt: "read it",
+      attachments: [{ fileId, mediaType: "image/png", size: bytes.length }],
+    }).catch(() => {});
+    const command = transport.store.claim({ tokenId: "token-1", networkId: "net-1", nodeId: "node-1" }) as any;
+    const grant = command.payload.attachments[0];
+    expect(grant).toMatchObject({ fileId, mediaType: "image/png", size: bytes.length });
+    expect(grant.sha256).toMatch(/^[a-f0-9]{64}$/);
+    const url = new URL(`http://hub/api/side-thread/attachment-grants/${grant.grantId}`);
+    const foreign = await transport.attachment(new Request(url), url, { tokenId: "foreign", networkId: "net-1", nodeId: "node-2" });
+    expect(foreign?.status).toBe(404);
+    const response = await transport.attachment(new Request(url), url, { tokenId: "token-1", networkId: "net-1", nodeId: "node-1" });
+    expect(response?.status).toBe(200); expect(Buffer.from(await response!.arrayBuffer())).toEqual(bytes);
+    now += 5 * 60_000 + 1;
+    expect((await transport.attachment(new Request(url), url, { tokenId: "token-1", networkId: "net-1", nodeId: "node-1" }))?.status).toBe(404);
+    await transport.port.start({
+      operationId: "op-start-2", requestKey: "rk-start-2", sideChatId: "side-2", attemptId: "attempt-2",
+      nodeId: "node-1", threadId: "derived-2", prompt: "read it again",
+      attachments: [{ fileId, mediaType: "image/png", size: bytes.length }],
+    }).catch(() => {});
+    expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM side_thread_attachment_grants")?.count).toBe(1);
+  });
+
+  test("rejects forged capability shapes instead of widening the allowlist", () => {
+    const db = new SQLiteAdapter(new Database(":memory:"));
+    db.exec("CREATE TABLE nodes(node_id TEXT PRIMARY KEY, network_id TEXT, config_snapshot TEXT)");
+    db.run("INSERT INTO nodes VALUES (?1,?2,?3)", ["node-1", "net-1", JSON.stringify({ side_thread_capability: {
+      supported: true, runtime: "codex-app-server", runtimeVersion: "latest", topology: "owned-stdio",
+      evidenceRevision: "test1190-wire-v2", mode: "native-exact-fork", exactBoundary: { through: true, before: true },
+    } })]);
+    expect(createProductionSideThreadTransport(db).port.capability("node-1")).toMatchObject({ supported: false });
+  });
+});

--- a/server/src/side-thread-production.ts
+++ b/server/src/side-thread-production.ts
@@ -1,0 +1,118 @@
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import type { DbAdapter } from "./db-adapter.js";
+import { indexEntryPath, pathForExistingBlob, validateIndexEntry } from "./uploads.js";
+import type { SideThreadAttachmentRef, SideThreadCapability } from "./side-thread.js";
+import {
+  DurableSideThreadCommandPort,
+  SideThreadCommandStore,
+  handleSideThreadCommandRequest,
+  type NodeCommandActor,
+} from "./side-thread-command-transport.js";
+
+const GRANT_TTL_MS = 5 * 60_000;
+
+type GrantRow = {
+  grant_id: string; file_id: string; network_id: string; node_id: string;
+  sha256: string; size: number; media_type: string; expires_at: number;
+};
+
+/** Production-only SideThread transport. It remains absent unless the public
+ * feature flag is enabled and the configured DB can provide atomic claims. */
+export function createProductionSideThreadTransport(db: DbAdapter, now = Date.now, ackWaitMs = 2_500) {
+  const store = new SideThreadCommandStore(db, now);
+  db.exec(`CREATE TABLE IF NOT EXISTS side_thread_attachment_grants (
+    grant_id TEXT PRIMARY KEY, file_id TEXT NOT NULL, network_id TEXT NOT NULL,
+    node_id TEXT NOT NULL, sha256 TEXT NOT NULL, size INTEGER NOT NULL,
+    media_type TEXT NOT NULL, expires_at INTEGER NOT NULL, created_at INTEGER NOT NULL
+  )`);
+  const port = new DurableSideThreadCommandPort({
+    store,
+    networkForNode(nodeId) {
+      return db.get<{ network_id: string | null }>("SELECT network_id FROM nodes WHERE node_id=?1", nodeId)?.network_id ?? null;
+    },
+    capabilityForNode(nodeId) {
+      const row = db.get<{ config_snapshot: string | null }>("SELECT config_snapshot FROM nodes WHERE node_id=?1", nodeId);
+      if (!row?.config_snapshot) return unsupported("runtime");
+      try {
+        const cap = JSON.parse(row.config_snapshot)?.side_thread_capability;
+        return validateCapability(cap) ? cap : unsupported("runtime");
+      } catch { return unsupported("runtime"); }
+    },
+    grantAttachment(nodeId, ref) { return issueGrant(db, nodeId, ref, now); },
+    // The dedicated node consumer polls asynchronously. Give its durable ACK
+    // a bounded window so the coordinator can advance fork→start atomically;
+    // timeout remains an honest ambiguous result, never a task fallback.
+    ackWaitMs,
+  });
+  return {
+    store,
+    port,
+    handle: (input: { req: Request; url: URL; actor: NodeCommandActor | null }) =>
+      handleSideThreadCommandRequest({ ...input, store, port }),
+    attachment: (req: Request, url: URL, actor: NodeCommandActor | null) =>
+      serveGrant(db, req, url, actor, now),
+  };
+}
+
+function issueGrant(db: DbAdapter, nodeId: string, ref: SideThreadAttachmentRef, now: () => number): Record<string, unknown> {
+  // Grants are deliberately short-lived and must not become an unbounded
+  // metadata cache. Lazy sweeping keeps the hot download path read-only while
+  // ensuring every new issuance bounds accumulated expired rows.
+  db.run("DELETE FROM side_thread_attachment_grants WHERE expires_at < ?1", [now()]);
+  const node = db.get<{ network_id: string | null }>("SELECT network_id FROM nodes WHERE node_id=?1", nodeId);
+  if (!node?.network_id) throw new Error("SideThread attachment node scope unavailable");
+  const indexPath = indexEntryPath(ref.fileId);
+  if (!indexPath) throw new Error("SideThread attachment index unavailable");
+  const entry = JSON.parse(readFileSync(indexPath, "utf8"));
+  if (!validateIndexEntry(entry) || entry.file_id !== ref.fileId || entry.network_id !== node.network_id)
+    throw new Error("SideThread attachment scope mismatch");
+  const path = pathForExistingBlob(entry.date_bucket, entry.file_id, entry.ext).absolutePath;
+  const bytes = readFileSync(path);
+  if (bytes.byteLength !== entry.size) throw new Error("SideThread attachment size changed");
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const grantId = `stg_${randomUUID().replace(/-/g, "")}`;
+  const mediaType = typeof entry.mime === "string" && entry.mime.length <= 200 ? entry.mime : "application/octet-stream";
+  db.run(
+    "INSERT INTO side_thread_attachment_grants (grant_id,file_id,network_id,node_id,sha256,size,media_type,expires_at,created_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)",
+    [grantId, ref.fileId, node.network_id, nodeId, sha256, bytes.byteLength, mediaType, now() + GRANT_TTL_MS, now()],
+  );
+  return { fileId: ref.fileId, grantId, sha256, size: bytes.byteLength, mediaType };
+}
+
+async function serveGrant(db: DbAdapter, req: Request, url: URL, actor: NodeCommandActor | null, now: () => number): Promise<Response | null> {
+  const match = url.pathname.match(/^\/api\/side-thread\/attachment-grants\/([^/]+)$/);
+  if (!match) return null;
+  if (req.method !== "GET") return Response.json({ ok: false, error: "method_not_allowed" }, { status: 405 });
+  if (!actor) return Response.json({ ok: false, error: "node_token_binding_required" }, { status: 403 });
+  let grantId: string;
+  try { grantId = decodeURIComponent(match[1]); } catch { return Response.json({ ok: false, error: "invalid_grant" }, { status: 400 }); }
+  const row = db.get<GrantRow>("SELECT * FROM side_thread_attachment_grants WHERE grant_id=?1", grantId);
+  // 404 deliberately hides existence, ownership and expiry.
+  if (!row || row.node_id !== actor.nodeId || row.network_id !== actor.networkId || row.expires_at < now())
+    return Response.json({ ok: false, error: "not_found" }, { status: 404 });
+  const indexPath = indexEntryPath(row.file_id);
+  if (!indexPath) return Response.json({ ok: false, error: "not_found" }, { status: 404 });
+  try {
+    const entry = JSON.parse(readFileSync(indexPath, "utf8"));
+    if (!validateIndexEntry(entry) || entry.network_id !== row.network_id || entry.size !== row.size)
+      return Response.json({ ok: false, error: "not_found" }, { status: 404 });
+    const bytes = readFileSync(pathForExistingBlob(entry.date_bucket, entry.file_id, entry.ext).absolutePath);
+    if (bytes.byteLength !== row.size || createHash("sha256").update(bytes).digest("hex") !== row.sha256)
+      return Response.json({ ok: false, error: "not_found" }, { status: 404 });
+    return new Response(bytes, { headers: { "Content-Type": row.media_type, "Content-Length": String(row.size), "Cache-Control": "no-store" } });
+  } catch { return Response.json({ ok: false, error: "not_found" }, { status: 404 }); }
+}
+
+function validateCapability(value: unknown): value is SideThreadCapability {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const v = value as Record<string, unknown>;
+  return v.supported === true && v.runtime === "codex-app-server" && v.runtimeVersion === "0.148.0"
+    && v.topology === "owned-stdio" && v.evidenceRevision === "test1190-wire-v2"
+    && v.mode === "native-exact-fork" && !!v.exactBoundary && typeof v.exactBoundary === "object"
+    && (v.exactBoundary as any).through === true && typeof (v.exactBoundary as any).before === "boolean";
+}
+
+function unsupported(reason: SideThreadCapability["reason"]): SideThreadCapability {
+  return { supported: false, runtime: "unknown", runtimeVersion: "unknown", topology: "unknown", evidenceRevision: "none", reason };
+}

--- a/server/src/side-thread.test.ts
+++ b/server/src/side-thread.test.ts
@@ -9,6 +9,7 @@ import {
   UnsupportedSideThreadPort,
   type SideThreadActor,
   type SideThreadExecutionPort,
+  type SideThreadEventRecord,
   type SideThreadRuntimeEvent,
 } from "./side-thread.js";
 import { handleSideThreadHttpRequest } from "./side-thread-http.js";
@@ -312,6 +313,28 @@ describe("SideThread Hub contract", () => {
     ).toHaveLength(3);
   });
 
+  test("throwing observers cannot alter durable truth or starve cursor replay", async () => {
+    const f = fixture();
+    const record = await f.coordinator.create(owner, createInput());
+    const attempt = record.attempts[0];
+    const cursor = f.coordinator.listEvents(owner, record.sideChatId).at(-1)!.eventId;
+    const delivered: SideThreadEventRecord[] = [];
+    const offThrow = f.coordinator.subscribe(record.sideChatId, () => { throw new Error("observer exploded"); });
+    const offGood = f.coordinator.subscribe(record.sideChatId, (event) => delivered.push(event));
+    f.port.emit({ sideChatId: record.sideChatId, attemptId: attempt.attemptId, threadId: record.threadId!, turnId: attempt.turnId!, status: "completed", text: "durable answer" });
+    await Bun.sleep(0);
+    expect(f.coordinator.get(owner, record.sideChatId)).toMatchObject({ state: "completed", attempts: [{ result: "durable answer" }] });
+    expect(delivered.filter((event) => event.type === "attempt.terminal")).toHaveLength(1);
+    const replay = f.coordinator.listEvents(owner, record.sideChatId, cursor);
+    expect(replay.filter((event) => event.type === "attempt.terminal")).toHaveLength(1);
+    expect(f.coordinator.listEvents(owner, record.sideChatId, replay.at(-1)!.eventId)).toHaveLength(0);
+    offThrow(); offGood();
+    f.coordinator.close();
+    const reopened = new SideThreadCoordinator(f.store, f.port, { enabled: true, authorizeNode: () => true, authorizeAttachment: () => true });
+    closers.push(() => reopened.close());
+    expect(reopened.listEvents(owner, record.sideChatId, cursor).filter((event) => event.type === "attempt.terminal")).toHaveLength(1);
+  });
+
   test("a terminal event arriving before start returns settles once", async () => {
     const f = fixture();
     f.port.onStart = (input, turnId) =>
@@ -391,10 +414,10 @@ describe("SideThread Hub contract", () => {
     closers.push(() => second.close());
     const firstCreate = f.coordinator.create(owner, createInput());
     await entered;
-    const replay = await second.create(owner, createInput());
-    expect(replay.state).toBe("creating");
     releaseFork();
     const created = await firstCreate;
+    const replay = await second.create(owner, createInput());
+    expect(replay.state).toBe("running");
     expect(f.port.calls.fork).toBe(1);
 
     let cancelEntered!: () => void;
@@ -420,7 +443,9 @@ describe("SideThread Hub contract", () => {
     expect(concurrent.state).toBe("running");
     expect(f.port.calls.cancel).toBe(1);
     releaseCancel();
-    expect((await firstCancel).state).toBe("cancelled");
+    expect((await firstCancel).state).toBe("running");
+    const cancelledAttempt = created.attempts[0];
+    f.port.emit({ sideChatId: created.sideChatId, attemptId: cancelledAttempt.attemptId, threadId: created.threadId!, turnId: cancelledAttempt.turnId!, status: "interrupted" });
 
     let archiveEntered!: () => void;
     const archiveStarted = new Promise<void>(
@@ -627,7 +652,7 @@ describe("SideThread Hub contract", () => {
     expect(reopened.list(stranger)).toHaveLength(0);
   });
 
-  test("response loss is durable ambiguous and reconciles without a second start RPC", async () => {
+  test("response loss remains ambiguous under the same stable start operation", async () => {
     const port = new FakePort();
     let accepted: Parameters<SideThreadExecutionPort["start"]>[0] | undefined;
     port.start = async (input) => {
@@ -658,11 +683,11 @@ describe("SideThread Hub contract", () => {
       state: "ambiguous",
       errorCode: "SIDE_THREAD_RESPONSE_LOST",
     });
-    expect(await f.coordinator.create(owner, createInput())).toMatchObject({
+    await expect(f.coordinator.create(owner, createInput())).rejects.toMatchObject({
+      code: "SIDE_THREAD_AMBIGUOUS",
       sideChatId: ambiguous.sideChatId,
-      state: "ambiguous",
     });
-    expect(port.calls).toMatchObject({ fork: 1, start: 1 });
+    expect(port.calls).toMatchObject({ fork: 1, start: 2 });
 
     f.coordinator.close();
     const reopened = new SideThreadCoordinator(f.store, port, {
@@ -689,13 +714,13 @@ describe("SideThread Hub contract", () => {
     expect(
       reconciled.operations.find((operation) => operation.kind === "start"),
     ).toMatchObject({ state: "completed", turnId: "turn_authoritative" });
-    expect(port.calls.start).toBe(1);
+    expect(port.calls.start).toBe(2);
     expect(
       JSON.stringify(reopened.listEvents(owner, ambiguous.sideChatId)),
     ).not.toContain("secret transport detail");
   });
 
-  test("ambiguous cancel/archive/purge keep stable claims and never issue a second RPC", async () => {
+  test("ambiguous cancel/archive/purge replay the same stable operation identity", async () => {
     const lose = () =>
       Object.assign(new Error("accepted but ACK lost"), {
         code: "SIDE_THREAD_RESPONSE_LOST",
@@ -728,7 +753,7 @@ describe("SideThread Hub contract", () => {
       code: "SIDE_THREAD_AMBIGUOUS",
       operationId: cancelOperationId,
     });
-    expect(cancelPort.calls.cancel).toBe(1);
+    expect(cancelPort.calls.cancel).toBe(2);
 
     for (const action of ["archive", "purge"] as const) {
       const port = new FakePort();
@@ -767,7 +792,7 @@ describe("SideThread Hub contract", () => {
         code: "SIDE_THREAD_AMBIGUOUS",
         operationId,
       });
-      expect(port.calls[action]).toBe(1);
+      expect(port.calls[action]).toBe(2);
     }
   });
 });
@@ -919,6 +944,10 @@ describe("SideThread HTTP contract", () => {
         coordinator: f.coordinator,
       });
       expect(response?.status).toBe(200);
+      if (action === "cancel") {
+        const attempt = record.attempts[0];
+        f.port.emit({ sideChatId: record.sideChatId, attemptId: attempt.attemptId, threadId: record.threadId!, turnId: attempt.turnId!, status: "interrupted" });
+      }
     }
     const hydrated = f.coordinator.get(owner, record.sideChatId);
     expect(

--- a/server/src/side-thread.ts
+++ b/server/src/side-thread.ts
@@ -770,6 +770,12 @@ export class SideThreadCoordinator {
     if (existing) {
       if (existing.fingerprint !== fingerprint)
         throw conflict("idempotency key reused with different create payload");
+      if (this.createNeedsReconciliation(existing.record)) {
+        return this.singleFlight(
+          `create:${actor.userId}:${input.requestKey}`,
+          () => this.reconcileCreate(actor, input, attachments, fingerprint),
+        );
+      }
       return existing.record;
     }
     return this.singleFlight(
@@ -781,6 +787,8 @@ export class SideThreadCoordinator {
             throw conflict(
               "idempotency key reused with different create payload",
             );
+          if (this.createNeedsReconciliation(replay.record))
+            return this.reconcileCreate(actor, input, attachments, fingerprint);
           return replay.record;
         }
         const capability = await this.assertCapability(
@@ -880,7 +888,7 @@ export class SideThreadCoordinator {
             throw runtimeProtocol(
               "runtime returned source thread as side thread",
             );
-          this.store.db.transaction(() => {
+          this.applyRuntimeReceipt(() => {
             const t = this.now();
             this.store.db.run(
               "UPDATE side_chats SET derived_thread_id=?1,updated_at=?2 WHERE side_chat_id=?3 AND state='creating'",
@@ -921,16 +929,18 @@ export class SideThreadCoordinator {
             attachments,
           });
           requireRuntimeIdentity(started.turnId, "turnId");
-          this.store.db.transaction(() => {
+          const attemptBeforeApply = this.store.db.get<any>(
+            "SELECT state,turn_id FROM side_chat_attempts WHERE attempt_id=?1",
+            attemptId,
+          );
+          if (!attemptBeforeApply) throw conflict("attempt disappeared during start");
+          if (attemptBeforeApply.turn_id && attemptBeforeApply.turn_id !== started.turnId)
+            throw runtimeProtocol("runtime turn identity changed during start");
+          this.applyRuntimeReceipt(() => {
             const attempt = this.store.db.get<any>(
               "SELECT state,turn_id FROM side_chat_attempts WHERE attempt_id=?1",
               attemptId,
             );
-            if (!attempt) throw conflict("attempt disappeared during start");
-            if (attempt.turn_id && attempt.turn_id !== started.turnId)
-              throw runtimeProtocol(
-                "runtime turn identity changed during start",
-              );
             this.settleOperation(startOperationId, "completed", {
               threadId: forked.threadId,
               turnId: started.turnId,
@@ -964,14 +974,137 @@ export class SideThreadCoordinator {
             this.markAmbiguous(sideChatId, attemptId, activeOperationId, error);
             throw ambiguousError(activeOperationId, sideChatId, attemptId);
           }
-          this.settleOperation(activeOperationId, "failed", {
-            errorCode: auditErrorReason(error),
-          });
-          this.failStarting(sideChatId, attemptId, error);
+          this.failStarting(sideChatId, attemptId, error, activeOperationId);
           throw normalizePortError(error);
         }
         return this.mustOwned(sideChatId, actor);
       },
+    );
+  }
+
+  /**
+   * Resume the stable fork/start operations after an ACK arrived outside the
+   * request window.  All identity needed to resume lives in SQLite; calling
+   * create again from another process therefore consumes the durable receipt
+   * instead of issuing a second native operation.
+   */
+  private async reconcileCreate(
+    actor: SideThreadActor,
+    input: CreateInput,
+    attachments: SideThreadAttachmentRef[],
+    fingerprint: string,
+  ): Promise<SideThreadRecord> {
+    const found = this.store.getByCreateKey(actor, input.requestKey);
+    if (!found) throw conflict("create record disappeared during reconciliation");
+    if (found.fingerprint !== fingerprint)
+      throw conflict("idempotency key reused with different create payload");
+    const sideChatId = found.record.sideChatId;
+    const attemptId = found.record.activeAttemptId;
+    if (!attemptId) throw conflict("create attempt disappeared during reconciliation");
+    const forkOperationId = stableOperationId(sideChatId, "fork", input.requestKey);
+    const startOperationId = stableOperationId(sideChatId, "start", input.requestKey);
+    let activeOperationId = forkOperationId;
+    try {
+      this.applyRuntimeReceipt(() => {
+        const at = this.now();
+        this.store.db.run(
+          "UPDATE side_chats SET state='reconciling',updated_at=?1 WHERE side_chat_id=?2 AND state IN ('creating','ambiguous')",
+          [at, sideChatId],
+        );
+        this.store.db.run(
+          "UPDATE side_chat_attempts SET state='reconciling',updated_at=?1 WHERE attempt_id=?2 AND state IN ('starting','ambiguous')",
+          [at, attemptId],
+        );
+        this.store.db.run(
+          "UPDATE side_chat_operations SET state='reconciling',updated_at=?1 WHERE operation_id=?2 AND state='ambiguous'",
+          [at, forkOperationId],
+        );
+      });
+      const forkOp = this.store.db.get<any>(
+        "SELECT state,thread_id FROM side_chat_operations WHERE operation_id=?1",
+        forkOperationId,
+      );
+      let threadId = forkOp?.state === "completed" ? forkOp.thread_id : undefined;
+      if (!threadId) {
+        const forked = await this.port.fork({
+          operationId: forkOperationId,
+          requestKey: input.requestKey,
+          sideChatId,
+          nodeId: input.nodeId,
+          sourceThreadId: input.sourceThreadId,
+          boundary: input.boundary,
+        });
+        threadId = forked.threadId;
+      }
+      requireRuntimeIdentity(threadId, "threadId");
+      if (threadId === input.sourceThreadId)
+        throw runtimeProtocol("runtime returned source thread as side thread");
+      this.applyRuntimeReceipt(() => {
+        const at = this.now();
+        this.settleOperation(forkOperationId, "completed", { threadId });
+        this.store.db.run(
+          "UPDATE side_chats SET derived_thread_id=?1,updated_at=?2 WHERE side_chat_id=?3 AND state IN ('creating','ambiguous','reconciling')",
+          [threadId, at, sideChatId],
+        );
+        this.store.db.run(
+          "UPDATE side_chat_attempts SET thread_id=?1,updated_at=?2 WHERE attempt_id=?3 AND state IN ('starting','ambiguous','reconciling')",
+          [threadId, at, attemptId],
+        );
+        const existingStart = this.store.db.get<any>(
+          "SELECT operation_id FROM side_chat_operations WHERE operation_id=?1",
+          startOperationId,
+        );
+        if (!existingStart)
+          this.insertOperation({ operationId: startOperationId, sideChatId, attemptId, kind: "start", requestKey: input.requestKey, fingerprint, threadId, at });
+        else
+          this.store.db.run(
+            "UPDATE side_chat_operations SET state='reconciling',updated_at=?1 WHERE operation_id=?2 AND state='ambiguous'",
+            [at, startOperationId],
+          );
+      });
+      activeOperationId = startOperationId;
+      const startOp = this.store.db.get<any>(
+        "SELECT state,turn_id FROM side_chat_operations WHERE operation_id=?1",
+        startOperationId,
+      );
+      let turnId = startOp?.state === "completed" ? startOp.turn_id : undefined;
+      if (!turnId) {
+        const started = await this.port.start({ operationId: startOperationId, requestKey: input.requestKey, sideChatId, attemptId, nodeId: input.nodeId, threadId, prompt: input.prompt, attachments });
+        turnId = started.turnId;
+      }
+      requireRuntimeIdentity(turnId, "turnId");
+      this.applyRuntimeReceipt(() => {
+        const at = this.now();
+        this.settleOperation(startOperationId, "completed", { threadId, turnId });
+        this.store.db.run(
+          "UPDATE side_chat_attempts SET state='running',thread_id=?1,turn_id=?2,updated_at=?3 WHERE attempt_id=?4 AND state IN ('starting','ambiguous','reconciling')",
+          [threadId, turnId, at, attemptId],
+        );
+        this.store.db.run(
+          "UPDATE side_chats SET state='running',derived_thread_id=?1,updated_at=?2 WHERE side_chat_id=?3 AND active_attempt_id=?4 AND state IN ('creating','ambiguous','reconciling')",
+          [threadId, at, sideChatId, attemptId],
+        );
+      });
+      return this.mustOwned(sideChatId, actor);
+    } catch (error) {
+      if (isAmbiguousRuntimeError(error)) {
+        if (this.operationState(activeOperationId) === "completed")
+          return this.mustOwned(sideChatId, actor);
+        this.markAmbiguous(sideChatId, attemptId, activeOperationId, error);
+        throw ambiguousError(activeOperationId, sideChatId, attemptId);
+      }
+      this.failStarting(sideChatId, attemptId, error, activeOperationId);
+      throw normalizePortError(error);
+    }
+  }
+
+  private createNeedsReconciliation(record: SideThreadRecord): boolean {
+    if (["creating", "ambiguous", "reconciling"].includes(record.state)) return true;
+    const active = record.attempts.find((attempt) => attempt.attemptId === record.activeAttemptId);
+    if (active && ["starting", "ambiguous", "reconciling"].includes(active.state)) return true;
+    return record.operations.some((operation) =>
+      (operation.kind === "fork" || operation.kind === "start") &&
+      ["pending", "ambiguous", "reconciling"].includes(operation.state),
     );
   }
 
@@ -1042,19 +1175,35 @@ export class SideThreadCoordinator {
           operation_id: string;
           attempt_id: string | null;
           state: SideThreadOperationRecord["state"];
+          error_code: string | null;
         }>(
-          "SELECT operation_id,attempt_id,state FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='cancel' AND request_key=?2",
+          "SELECT operation_id,attempt_id,state,error_code FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='cancel' AND request_key=?2",
           sideChatId,
           input.requestKey,
         );
         if (replay?.state === "completed" || replay?.state === "pending")
           return record;
-        if (replay?.state === "ambiguous" || replay?.state === "reconciling")
-          throw ambiguousError(
-            replay.operation_id,
-            sideChatId,
-            replay.attempt_id ?? undefined,
-          );
+        if (replay?.state === "failed") throw persistedOperationFailure(replay.error_code);
+        if (replay?.state === "ambiguous" || replay?.state === "reconciling") {
+          const attempt = record.attempts.find((a) => a.attemptId === replay.attempt_id);
+          if (!attempt?.threadId || !attempt.turnId) throw conflict("cancel ownership missing");
+          await this.reconcileLifecycleOperation({
+            sideChatId, attemptId: attempt.attemptId, operationId: replay.operation_id,
+            invoke: () => this.port.cancel({ operationId: replay.operation_id, sideChatId, attemptId: attempt.attemptId, nodeId: record.nodeId, threadId: attempt.threadId!, turnId: attempt.turnId! }),
+            receipt: () => ({ threadId: attempt.threadId, turnId: attempt.turnId }),
+            accepted: () => {
+              const t = this.now();
+              this.store.db.run("UPDATE side_chat_attempts SET state='running',updated_at=?1 WHERE attempt_id=?2 AND state IN ('ambiguous','reconciling')", [t, attempt.attemptId]);
+              this.store.db.run("UPDATE side_chats SET state='running',updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3 AND state IN ('ambiguous','reconciling')", [t, sideChatId, attempt.attemptId]);
+            },
+            failed: () => {
+              const t = this.now();
+              this.store.db.run("UPDATE side_chat_attempts SET state='running',cancel_requested_at=NULL,updated_at=?1 WHERE attempt_id=?2 AND state IN ('ambiguous','reconciling')", [t, attempt.attemptId]);
+              this.store.db.run("UPDATE side_chats SET state='running',updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3 AND state IN ('ambiguous','reconciling')", [t, sideChatId, attempt.attemptId]);
+            },
+          });
+          return this.mustOwned(sideChatId, actor);
+        }
         const attempt = record.attempts.find(
           (a) => a.attemptId === record.activeAttemptId,
         );
@@ -1141,27 +1290,8 @@ export class SideThreadCoordinator {
           throw normalizePortError(error);
         }
         this.store.db.transaction(() => {
-          const t = this.now();
-          const changed = this.store.db.run(
-            "UPDATE side_chat_attempts SET state='cancelled',updated_at=?1 WHERE attempt_id=?2 AND state='running' AND thread_id=?3 AND turn_id=?4",
-            [t, attempt.attemptId, attempt.threadId, attempt.turnId],
-          );
-          if (changed.changes > 0) {
-            this.store.db.run(
-              "UPDATE side_chats SET state='cancelled',active_attempt_id=NULL,updated_at=?1 WHERE side_chat_id=?2 AND active_attempt_id=?3",
-              [t, sideChatId, attempt.attemptId],
-            );
-            this.emitStored(
-              sideChatId,
-              attempt.attemptId,
-              attempt.threadId,
-              attempt.turnId,
-              "attempt.cancelled",
-              "cancelled",
-              undefined,
-              t,
-            );
-          }
+          // Command acceptance only proves that interrupt was accepted.  The
+          // authoritative terminal event owns the cancelled/completed race.
           this.settleOperation(prepared.operationId, "completed", {
             threadId: attempt.threadId,
             turnId: attempt.turnId,
@@ -1337,10 +1467,7 @@ export class SideThreadCoordinator {
             this.markAmbiguous(sideChatId, attemptId, startOperationId, error);
             throw ambiguousError(startOperationId, sideChatId, attemptId);
           }
-          this.settleOperation(startOperationId, "failed", {
-            errorCode: auditErrorReason(error),
-          });
-          this.failStarting(sideChatId, attemptId, error);
+          this.failStarting(sideChatId, attemptId, error, startOperationId);
           throw normalizePortError(error);
         }
         return this.mustOwned(sideChatId, actor);
@@ -1379,6 +1506,11 @@ export class SideThreadCoordinator {
         if (!r.threadId) throw conflict("side chat has no derived thread");
         if (r.state === "purged") return r;
         if (action === "archive" && r.state === "archived") return r;
+        const priorOperation = this.store.db.get<{ state: string; error_code: string | null }>(
+          "SELECT state,error_code FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind=?2 AND request_key=?3",
+          sideChatId, action, input.requestKey,
+        );
+        if (priorOperation?.state === "failed") throw persistedOperationFailure(priorOperation.error_code);
         await this.assertCapability(r.nodeId);
         const prepared = this.prepareStableOperation({
           sideChatId,
@@ -1388,8 +1520,18 @@ export class SideThreadCoordinator {
           threadId: r.threadId,
         });
         if (prepared.state === "completed") return r;
-        if (prepared.state === "ambiguous" || prepared.state === "reconciling")
-          throw ambiguousError(prepared.operationId, sideChatId);
+        if (prepared.state === "ambiguous" || prepared.state === "reconciling") {
+          await this.reconcileLifecycleOperation({
+            sideChatId, operationId: prepared.operationId,
+            invoke: () => action === "archive"
+              ? this.port.archive({ operationId: prepared.operationId, sideChatId, nodeId: r.nodeId, threadId: r.threadId! })
+              : this.port.purge({ operationId: prepared.operationId, sideChatId, nodeId: r.nodeId, threadId: r.threadId! }),
+            receipt: () => ({ threadId: r.threadId }),
+            accepted: () => this.applyLifecycleAccepted(sideChatId, action, prepared.operationId, r.threadId!),
+            failed: () => this.store.db.run("UPDATE side_chats SET state='failed',lifecycle_operation=NULL,updated_at=?1 WHERE side_chat_id=?2 AND state IN ('ambiguous','reconciling')", [this.now(), sideChatId]),
+          });
+          return this.mustOwned(sideChatId, actor);
+        }
         if (!prepared.callable)
           throw conflict("side chat lifecycle operation already in progress");
         const claim = this.store.db.run(
@@ -1536,21 +1678,33 @@ export class SideThreadCoordinator {
             const operation = this.store.db.get<{
               operation_id: string;
               state: string;
+              error_code: string | null;
             }>(
-              "SELECT operation_id,state FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='bring-back' AND request_key=?2",
+              "SELECT operation_id,state,error_code FROM side_chat_operations WHERE side_chat_id=?1 AND operation_kind='bring-back' AND request_key=?2",
               sideChatId,
               input.requestKey,
             );
-            if (
-              operation &&
-              (operation.state === "ambiguous" ||
-                operation.state === "reconciling")
-            )
-              throw ambiguousError(
-                operation.operation_id,
-                sideChatId,
-                attempt.attemptId,
-              );
+            if (operation && (operation.state === "ambiguous" || operation.state === "reconciling")) {
+              const destinationTurnId = await this.reconcileLifecycleOperation({
+                sideChatId, attemptId: attempt.attemptId, operationId: operation.operation_id,
+                invoke: async () => (await this.port.bringBack({ operationId: operation.operation_id, sideChatId, attemptId: attempt.attemptId, nodeId: r.nodeId, sourceThreadId: attempt.threadId!, sourceTurnId: attempt.turnId!, destinationThreadId: input.destinationThreadId, requestKey: input.requestKey, text: attempt.result! })).destinationTurnId,
+                receipt: (turn) => ({ threadId: input.destinationThreadId, turnId: turn }),
+                accepted: (turn) => {
+                  requireRuntimeIdentity(turn, "destinationTurnId");
+                  const now = this.now();
+                  this.store.db.run("UPDATE side_chat_bring_backs SET state='completed',destination_turn_id=?1,error_text=NULL,updated_at=?2,completed_at=?2 WHERE bring_back_id=?3 AND state IN ('starting','ambiguous','reconciling')", [turn, now, old.bring_back_id]);
+                  this.store.db.run("UPDATE side_chats SET state='completed',updated_at=?1 WHERE side_chat_id=?2 AND state IN ('ambiguous','reconciling')", [now, sideChatId]);
+                  this.emitStored(sideChatId, attempt.attemptId, attempt.threadId, attempt.turnId, "side_chat.brought_back", "completed", undefined, now);
+                },
+                failed: (error) => {
+                  const now = this.now();
+                  this.store.db.run("UPDATE side_chat_bring_backs SET state='failed',error_text=?1,updated_at=?2 WHERE bring_back_id=?3 AND state IN ('starting','ambiguous','reconciling')", [safeReason(error instanceof Error ? error.message : String(error)), now, old.bring_back_id]);
+                  this.store.db.run("UPDATE side_chats SET state='completed',updated_at=?1 WHERE side_chat_id=?2 AND state IN ('ambiguous','reconciling')", [now, sideChatId]);
+                },
+              });
+              return { bringBackId: old.bring_back_id, destinationTurnId };
+            }
+            if (operation?.state === "failed") throw persistedOperationFailure(operation.error_code);
             throw conflict("bring-back is already in progress or failed");
           }
           return {
@@ -1721,6 +1875,84 @@ export class SideThreadCoordinator {
         }
       },
     );
+  }
+
+  private applyRuntimeReceipt(apply: () => void): void {
+    try {
+      this.store.db.transaction(apply);
+    } catch {
+      // The runtime receipt remains authoritative and durable; only the local
+      // projection failed. Callers mark the stable operation ambiguous so a
+      // restart can consume the same receipt without another native command.
+      throw new SideThreadError(
+        "SIDE_THREAD_AMBIGUOUS",
+        "runtime receipt accepted; local apply requires reconciliation",
+        202,
+      );
+    }
+  }
+
+  private async reconcileLifecycleOperation<T>(input: {
+    sideChatId: string;
+    attemptId?: string;
+    operationId: string;
+    invoke: () => Promise<T>;
+    receipt: (value: T) => { threadId?: string; turnId?: string };
+    accepted: (value: T) => void;
+    failed: (error: unknown) => void;
+  }): Promise<T> {
+    this.store.db.run(
+      "UPDATE side_chat_operations SET state='reconciling',updated_at=?1 WHERE operation_id=?2 AND state='ambiguous'",
+      [this.now(), input.operationId],
+    );
+    let value: T;
+    try {
+      value = await input.invoke();
+    } catch (error) {
+      if (isAmbiguousRuntimeError(error)) {
+        this.markAmbiguous(input.sideChatId, input.attemptId, input.operationId, error);
+        throw ambiguousError(input.operationId, input.sideChatId, input.attemptId);
+      }
+      try {
+        this.store.db.transaction(() => {
+          const won = this.store.db.run(
+            "UPDATE side_chat_operations SET state='failed',error_code=?1,updated_at=?2 WHERE operation_id=?3 AND state IN ('ambiguous','reconciling')",
+            [auditErrorReason(error), this.now(), input.operationId],
+          );
+          if (won.changes === 1) input.failed(error);
+        });
+      } catch {
+        this.markAmbiguous(input.sideChatId, input.attemptId, input.operationId, { code: "SIDE_THREAD_LOCAL_APPLY_FAILED" });
+        throw ambiguousError(input.operationId, input.sideChatId, input.attemptId);
+      }
+      throw normalizePortError(error);
+    }
+    try {
+      this.store.db.transaction(() => {
+        const receipt = input.receipt(value);
+        const won = this.store.db.run(
+          "UPDATE side_chat_operations SET state='completed',thread_id=COALESCE(?1,thread_id),turn_id=COALESCE(?2,turn_id),error_code=NULL,updated_at=?3 WHERE operation_id=?4 AND state IN ('ambiguous','reconciling')",
+          [receipt.threadId ?? null, receipt.turnId ?? null, this.now(), input.operationId],
+        );
+        if (won.changes === 1) input.accepted(value);
+      });
+      return value;
+    } catch {
+      this.markAmbiguous(input.sideChatId, input.attemptId, input.operationId, { code: "SIDE_THREAD_LOCAL_APPLY_FAILED" });
+      throw ambiguousError(input.operationId, input.sideChatId, input.attemptId);
+    }
+  }
+
+  private applyLifecycleAccepted(sideChatId: string, action: "archive" | "purge", operationId: string, threadId: string): void {
+    const t = this.now();
+    if (action === "purge") {
+      this.store.db.run("UPDATE side_chats SET state='purged',question_text='',attachments_json='[]',lifecycle_operation=NULL,updated_at=?1,purged_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL", [t, sideChatId]);
+      this.store.db.run("UPDATE side_chat_attempts SET result_text=NULL,error_text=NULL,attachments_json='[]',updated_at=?1 WHERE side_chat_id=?2", [t, sideChatId]);
+      this.store.db.run("UPDATE side_chat_bring_backs SET error_text=NULL,updated_at=?1 WHERE side_chat_id=?2", [t, sideChatId]);
+    } else {
+      this.store.db.run("UPDATE side_chats SET state='archived',lifecycle_operation=NULL,updated_at=?1,archived_at=?1 WHERE side_chat_id=?2 AND active_attempt_id IS NULL", [t, sideChatId]);
+    }
+    this.emitStored(sideChatId, undefined, threadId, undefined, `side_chat.${action === "archive" ? "archived" : "purged"}`, action === "archive" ? "archived" : "purged", undefined, t);
   }
 
   listEvents(
@@ -1983,14 +2215,19 @@ export class SideThreadCoordinator {
     sideChatId: string,
     attemptId: string,
     error: unknown,
+    operationId?: string,
   ): void {
     const t = this.now(),
       reason = safeReason(
         error instanceof Error ? error.message : String(error),
       );
     this.store.db.transaction(() => {
+      if (operationId)
+        this.settleOperation(operationId, "failed", {
+          errorCode: auditErrorReason(error),
+        });
       const changed = this.store.db.run(
-        "UPDATE side_chat_attempts SET state='failed',error_text=?1,updated_at=?2 WHERE attempt_id=?3 AND state='starting'",
+        "UPDATE side_chat_attempts SET state='failed',error_text=?1,updated_at=?2 WHERE attempt_id=?3 AND state IN ('starting','ambiguous','reconciling')",
         [reason, t, attemptId],
       );
       if (changed.changes > 0) {
@@ -2038,7 +2275,7 @@ export class SideThreadCoordinator {
       "SELECT event_id FROM side_chat_events WHERE side_chat_id=?1 ORDER BY event_id DESC LIMIT 1",
       sideChatId,
     );
-    this.emitter.emit(`side:${sideChatId}`, {
+    const event = {
       eventId: row?.event_id ?? 0,
       sideChatId,
       attemptId,
@@ -2048,7 +2285,19 @@ export class SideThreadCoordinator {
       state,
       reason: safeReason(reason),
       createdAt: at,
-    } satisfies SideThreadEventRecord);
+    } satisfies SideThreadEventRecord;
+    // Fanout is deliberately deferred until the current synchronous SQLite
+    // transaction has committed. Observers are never part of durable truth:
+    // one throwing listener cannot roll back state or starve another listener.
+    queueMicrotask(() => {
+      for (const listener of this.emitter.listeners(`side:${sideChatId}`)) {
+        try {
+          listener(event);
+        } catch {
+          // Durable side_chat_events + cursor replay are authoritative.
+        }
+      }
+    });
   }
   private mustOwned(
     sideChatId: string,
@@ -2238,4 +2487,9 @@ function normalizePortError(error: unknown): SideThreadError {
     "SideThread runtime operation failed",
     502,
   );
+}
+function persistedOperationFailure(code: string | null | undefined): SideThreadError {
+  if (code === "SIDE_THREAD_UNSUPPORTED")
+    return new SideThreadError("SIDE_THREAD_UNSUPPORTED", "runtime operation is unsupported", 501);
+  return new SideThreadError(code === "SIDE_THREAD_CONFLICT" ? "SIDE_THREAD_CONFLICT" : "SIDE_THREAD_RUNTIME_ERROR", "runtime operation failed authoritatively", code === "SIDE_THREAD_CONFLICT" ? 409 : 502);
 }

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -526,6 +526,16 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         config_revision: z.number().int().min(0).optional(),
         config_update_capable: z.boolean().optional(),
         peer_reply_inbox_capable: z.literal(true).optional(),
+        side_thread_capability: z.object({
+          supported: z.boolean(),
+          runtime: z.string().max(64),
+          runtimeVersion: z.string().max(64),
+          topology: z.string().max(64),
+          evidenceRevision: z.string().max(100),
+          mode: z.literal("native-exact-fork").optional(),
+          exactBoundary: z.object({ through: z.boolean(), before: z.boolean() }).strict().optional(),
+          reason: z.enum(["runtime", "version", "topology", "experimental-api", "exact-boundary"]).optional(),
+        }).strict().optional(),
         // RFC-026 P2 / #338 — daemon role surfaced for hub /api/nodes
         // discovery (#337 extracts this field). "host_supervisor" =
         // anet daemon. Default-stripping zod would drop this otherwise.

--- a/tests/test1195-side-thread-hub-security/run.sh
+++ b/tests/test1195-side-thread-hub-security/run.sh
@@ -9,7 +9,7 @@ bun test src/side-thread-http-integration.test.ts
 # question across browser/log boundaries. The integration assertion must catch it.
 cp src/server.ts /tmp/server.ts
 sed -i 's/resolveRequestAuth(req, { allowQueryToken: false })/resolveRequestAuth(req)/' src/server.ts
-grep -F 'actor: resolveSideThreadActor(req, resolveRequestAuth(req), isAdmin)' src/server.ts >/dev/null
+grep -F 'const sideActor = resolveSideThreadActor(req, resolveRequestAuth(req), isAdmin);' src/server.ts >/dev/null
 if bun test src/side-thread-http-integration.test.ts >/tmp/security-mutation.log 2>&1; then
   echo "FAIL: query-token auth mutation survived"
   cat /tmp/security-mutation.log

--- a/tests/test1204-btw-production-wiring/Dockerfile
+++ b/tests/test1204-btw-production-wiring/Dockerfile
@@ -1,0 +1,24 @@
+FROM oven/bun:1.2.22-debian
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl fonts-dejavu-core imagemagick jq nodejs npm util-linux \
+    && npm install -g --no-audit --no-fund @openai/codex@0.148.0 \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /repo
+COPY agent-node/package.json agent-node/package.json
+COPY server/package.json server/package.json
+RUN cd agent-node && bun install --ignore-scripts \
+    && cd ../server && bun install --ignore-scripts
+ARG SOURCE_COMMIT
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+LABEL org.opencontainers.image.revision=$SOURCE_COMMIT
+COPY agent-node/src agent-node/src
+COPY server/src server/src
+COPY tests/lib /tests/lib
+COPY tests/test1190-codex-btw-wire-probe/disposable-home.sentinel /probe/disposable-home.sentinel
+COPY tests/test1204-btw-production-wiring tests/test1204-btw-production-wiring
+RUN chmod +x tests/test1204-btw-production-wiring/run.sh \
+    tests/test1204-btw-production-wiring/verify-source.sh \
+    tests/test1204-btw-production-wiring/production-process-e2e.sh \
+    tests/test1204-btw-production-wiring/fake-codex \
+    && ln -s fake-codex tests/test1204-btw-production-wiring/codex
+CMD ["tests/test1204-btw-production-wiring/run.sh"]

--- a/tests/test1204-btw-production-wiring/attachment-live-probe.mjs
+++ b/tests/test1204-btw-production-wiring/attachment-live-probe.mjs
@@ -1,0 +1,76 @@
+import { spawn, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import readline from "node:readline";
+
+const marker = "BTW_IMG_7Q9X2K4M8P";
+const imagePath = `${process.env.CODEX_HOME}/btw-marker.png`;
+execFileSync("convert", ["-size", "1000x300", "xc:white", "-font", "DejaVu-Sans", "-fill", "black", "-pointsize", "64", "-gravity", "center", "-annotate", "0", marker, imagePath], {
+  // ImageMagick 6's OpenMP worker setup can abort under Docker's default
+  // seccomp profile. One worker is deterministic and sufficient here.
+  env: { ...process.env, MAGICK_THREAD_LIMIT: "1" },
+});
+fs.chmodSync(imagePath, 0o600);
+
+const child = spawn("codex", ["app-server", "--stdio", "-c", "approval_policy=never", "-c", "sandbox_mode=danger-full-access"], {
+  stdio: ["pipe", "pipe", "pipe"], env: process.env,
+});
+let rpcId = 0; let stderrTail = "";
+const pending = new Map(); const events = [];
+child.stderr.on("data", (chunk) => { stderrTail = (stderrTail + String(chunk)).slice(-1_000); });
+readline.createInterface({ input: child.stdout }).on("line", (line) => {
+  let message; try { message = JSON.parse(line); } catch { return; }
+  if (message.id != null && !message.method) {
+    const waiter = pending.get(message.id); if (!waiter) return;
+    pending.delete(message.id); message.error ? waiter.reject(new Error(`RPC ${waiter.method} failed: ${message.error.code}`)) : waiter.resolve(message.result);
+  } else if (message.method === "turn/completed") events.push(message.params);
+});
+const rpc = (method, params, timeoutMs = 180_000) => new Promise((resolve, reject) => {
+  const id = ++rpcId;
+  const timer = setTimeout(() => { pending.delete(id); reject(new Error(`${method} timed out; stderr=${stderrTail}`)); }, timeoutMs);
+  pending.set(id, { method, resolve: (value) => { clearTimeout(timer); resolve(value); }, reject: (error) => { clearTimeout(timer); reject(error); } });
+  child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+});
+const notify = (method, params) => child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+const strictThread = (value, method) => { if (!value?.thread?.id) throw new Error(`${method} shape drift`); return value.thread; };
+const strictTurn = (value) => { if (!value?.turn?.id) throw new Error("turn/start shape drift"); return value.turn; };
+const waitTerminal = async (threadId, turnId) => {
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    const found = events.find((event) => event?.threadId === threadId && event?.turn?.id === turnId);
+    if (found) return found;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("attachment turn terminal timed out");
+};
+
+try {
+  await rpc("initialize", { clientInfo: { name: "anet-btw-attachment-probe", version: "0.1.0" }, capabilities: { experimentalApi: false } });
+  notify("initialized", {});
+  const source = strictThread(await rpc("thread/start", { ephemeral: false }), "thread/start").id;
+  const seed = strictTurn(await rpc("turn/start", { threadId: source, input: [{ type: "text", text: "Reply exactly READY." }] })).id;
+  await waitTerminal(source, seed);
+  const derived = strictThread(await rpc("thread/fork", { threadId: source, lastTurnId: seed, ephemeral: false }), "thread/fork").id;
+  const turn = strictTurn(await rpc("turn/start", { threadId: derived, input: [
+    { type: "text", text: "Read the attached image and reply with only the exact uppercase code shown in it. Do not add punctuation." },
+    { type: "localImage", path: imagePath },
+  ] })).id;
+  await waitTerminal(derived, turn);
+  const authoritative = strictThread(await rpc("thread/read", { threadId: derived, includeTurns: true }), "thread/read");
+  const exactTurn = (authoritative.turns ?? []).find((item) => item.id === turn);
+  const assistantText = (exactTurn?.items ?? []).filter((item) => item?.type === "agentMessage").map((item) => item.text ?? "").join("\n");
+  if (!assistantText.includes(marker)) throw new Error("pixel-only marker absent from authoritative derived thread/read");
+  process.stdout.write(`${JSON.stringify({
+    evidenceRevision: "test1204-local-image-v1",
+    inputType: "localImage",
+    promptContainsMarker: false,
+    modelAnswerMarkerObserved: true,
+    threadReadMarkerObserved: true,
+    markerSha256: createHash("sha256").update(marker).digest("hex"),
+    imageMode: fs.statSync(imagePath).mode & 0o777,
+  }, null, 2)}\n`);
+} finally {
+  try { await rpc("shutdown", {}, 5_000); } catch {}
+  child.kill("SIGTERM");
+  try { fs.unlinkSync(imagePath); } catch {}
+}

--- a/tests/test1204-btw-production-wiring/fake-codex
+++ b/tests/test1204-btw-production-wiring/fake-codex
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "codex-cli 0.148.0"
+  exit 0
+fi
+[[ "${1:-}" == "app-server" ]] || exit 64
+shift
+listen=""
+while (($#)); do
+  if [[ "$1" == "--listen" ]]; then listen="$2"; shift 2; else shift; fi
+done
+[[ "$listen" == ws://127.0.0.1:* ]]
+exec bun /repo/tests/test1204-btw-production-wiring/fake-codex-app-server.mjs "$listen"

--- a/tests/test1204-btw-production-wiring/fake-codex-app-server.mjs
+++ b/tests/test1204-btw-production-wiring/fake-codex-app-server.mjs
@@ -1,0 +1,70 @@
+import { appendFileSync } from "node:fs";
+
+const endpoint = new URL(process.argv[2]);
+const port = Number(endpoint.port);
+const turnShape = (id, items = []) => ({ id, items, itemsView: "full", status: "completed", error: null, startedAt: 1, completedAt: 2, durationMs: 1 });
+const threadShape = (id, forkedFromId = null, turns = []) => ({
+  id, sessionId: id, forkedFromId, preview: "", ephemeral: false,
+  modelProvider: "openai", createdAt: 1, updatedAt: 2, status: { type: "idle" },
+  path: null, cwd: "/repo", cliVersion: "0.148.0", source: "appServer",
+  threadSource: "user", agentNickname: null, agentRole: null, gitInfo: null, name: null, turns,
+});
+const threads = new Map([
+  ["source-thread", threadShape("source-thread", null, [turnShape("source-turn")])],
+]);
+let derived = 0;
+let turn = 0;
+const log = (method, params) => appendFileSync("/tmp/test1204-fake-codex.log", `${JSON.stringify({ method, params })}\n`);
+
+const server = Bun.serve({
+  hostname: "127.0.0.1", port,
+  fetch(req, server) {
+    if (server.upgrade(req)) return;
+    return new Response("upgrade required", { status: 426 });
+  },
+  websocket: {
+    open() {},
+    message(ws, raw) {
+      const msg = JSON.parse(String(raw));
+      if (typeof msg.method !== "string" || msg.id == null) return;
+      const p = msg.params ?? {}; log(msg.method, p);
+      const reply = (result) => {
+        const wire = { jsonrpc: "2.0", id: msg.id, result };
+        appendFileSync("/tmp/test1204-fake-codex.log", `${JSON.stringify({ response: wire })}\n`);
+        ws.send(JSON.stringify(wire));
+      };
+      if (msg.method === "initialize") return reply({ userAgent: "codex-cli/0.148.0" });
+      if (msg.method === "thread/list") return reply({ data: [...threads.values()], nextCursor: null });
+      if (msg.method === "thread/read") return reply({ thread: threads.get(p.threadId) ?? null });
+      if (msg.method === "thread/start") {
+        const id = p.threadId ?? `source-created-${++derived}`;
+        const thread = threadShape(id); threads.set(id, thread); return reply({ thread });
+      }
+      if (msg.method === "thread/fork") {
+        const id = `derived-${++derived}`;
+        const thread = threadShape(id, p.threadId, [turnShape(p.lastTurnId)]);
+        threads.set(id, thread);
+        return setTimeout(() => reply({ thread }), 10);
+      }
+      if (msg.method === "turn/start") {
+        const id = `turn-${++turn}`; const thread = threads.get(p.threadId) ?? threadShape(p.threadId);
+        const completedTurn = turnShape(id, [{ type: "agentMessage", id: `item-${turn}`, text: "PRODUCTION_SIDE_ANSWER", phase: null }]);
+        thread.turns.push(completedTurn); threads.set(p.threadId, thread);
+        reply({ turn: completedTurn });
+        if (p.clientUserMessageId) ws.send(JSON.stringify({ method: "item/started", params: {
+          threadId: p.threadId, turnId: id, item: { type: "userMessage", clientId: p.clientUserMessageId },
+        } }));
+        setTimeout(() => ws.send(JSON.stringify({ method: "turn/completed", params: {
+          threadId: p.threadId, turn: completedTurn,
+        } })), 10);
+        return;
+      }
+      if (msg.method === "turn/interrupt") return reply({});
+      if (msg.method === "thread/archive" || msg.method === "thread/unarchive" || msg.method === "thread/delete") return reply({});
+      reply({});
+    },
+    close() {},
+  },
+});
+
+process.on("SIGTERM", () => { server.stop(true); process.exit(0); });

--- a/tests/test1204-btw-production-wiring/injected-consumer.ts
+++ b/tests/test1204-btw-production-wiring/injected-consumer.ts
@@ -1,0 +1,46 @@
+import { EventEmitter } from "node:events";
+import { appendFileSync } from "node:fs";
+import { startCliSideThreadConsumer } from "../../agent-node/src/runtime/side-thread/production";
+
+class FakeCodexRpc extends EventEmitter {
+  private turns = 0;
+  private readonly threads = new Map<string, any>([["source-thread", { id: "source-thread", turns: [{ id: "source-turn" }] }]]);
+  async request<T>(method: string, params: any): Promise<T> {
+    appendFileSync("/tmp/test1204-fake-codex.log", `${JSON.stringify({ method, params })}\n`);
+    if (method === "thread/list") return { data: [...this.threads.values()], nextCursor: null } as T;
+    if (method === "thread/read") return { thread: this.threads.get(params.threadId) } as T;
+    if (method === "thread/fork") {
+      const thread = { id: "derived-production", forkedFromId: params.threadId, turns: [{ id: params.lastTurnId }] };
+      this.threads.set(thread.id, thread); return { thread } as T;
+    }
+    if (method === "turn/start") {
+      const turnId = params.threadId === "source-thread" ? "bring-back-production" : `side-turn-${++this.turns}`;
+      if (params.clientUserMessageId?.startsWith("anet-side:")) queueMicrotask(() => {
+        this.emit("item/started", { threadId: params.threadId, turnId, item: { type: "userMessage", clientId: params.clientUserMessageId } });
+        setTimeout(() => {
+          this.emit("item/started", { threadId: params.threadId, turnId, item: { type: "agentMessage", text: "PRODUCTION_SIDE_ANSWER" } });
+          this.emit("turn/completed", { threadId: params.threadId, turn: { id: turnId, status: "completed" } });
+        }, 20);
+      });
+      return { turn: { id: turnId } } as T;
+    }
+    return {} as T;
+  }
+}
+
+const runtime = startCliSideThreadConsumer({
+  enabled: true,
+  client: new FakeCodexRpc() as any,
+  hubUrl: process.env.TEST_HUB!,
+  nodeId: process.env.TEST_NODE_ID!,
+  token: process.env.TEST_NODE_TOKEN!,
+  codexHome: process.env.CODEX_HOME!,
+  runtimeVersion: "0.148.0",
+  topology: "owned-stdio",
+  experimentalApi: false,
+  pollMs: 5,
+  log: (message) => console.log(message),
+  warn: (message) => console.error(message),
+});
+process.on("SIGTERM", () => { runtime.close(); process.exit(0); });
+await new Promise(() => {});

--- a/tests/test1204-btw-production-wiring/production-process-e2e.sh
+++ b/tests/test1204-btw-production-wiring/production-process-e2e.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source /tests/lib/safe-rm.sh
+
+ROOT=/tmp/test1204-process
+HUB=http://127.0.0.1:19204
+safe_rm_rf "$ROOT"
+mkdir -p "$ROOT/home" "$ROOT/codex-home" "$ROOT/uploads"
+cleanup() {
+  local rc=$?
+  [[ -n "${AGENT_PID:-}" ]] && kill "$AGENT_PID" 2>/dev/null || true
+  [[ -n "${HUB_PID:-}" ]] && kill "$HUB_PID" 2>/dev/null || true
+  if (( rc != 0 )); then
+    echo "--- Hub log ---" >&2; sed -n '1,240p' "$ROOT/hub.log" >&2 || true
+    echo "--- agent-node log ---" >&2; sed -n '1,240p' "$ROOT/agent.log" >&2 || true
+    echo "--- injected consumer log ---" >&2; sed -n '1,240p' "$ROOT/consumer.log" >&2 || true
+    echo "--- fake Codex log ---" >&2; sed -n '1,240p' /tmp/test1204-fake-codex.log >&2 || true
+  fi
+  safe_rm_rf "$ROOT"
+  return "$rc"
+}
+trap cleanup EXIT
+
+HOME="$ROOT/home" COMMHUB_DB="$ROOT/hub.db" COMMHUB_UPLOADS_DIR="$ROOT/uploads" \
+  COMMHUB_ENABLE_SIDE_THREADS=1 HOST=127.0.0.1 PORT=19204 bun server/src/index.ts >"$ROOT/hub.log" 2>&1 &
+HUB_PID=$!
+for _ in {1..100}; do curl -fsS "$HUB/health" >/dev/null 2>&1 && break; sleep .05; done
+curl -fsS "$HUB/health" >/dev/null
+
+REG=$(curl -fsS -X POST "$HUB/api/auth/register" -H 'Content-Type: application/json' \
+  -d '{"username":"prod-owner","password":"StrongPassw0rd","email":"prod@example.test"}')
+UTOK=$(jq -r '.token' <<<"$REG")
+NET=$(curl -fsS -X POST "$HUB/api/networks" -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' -d '{"name":"prod-net"}')
+NET_ID=$(jq -r '.network.network_id // .network_id' <<<"$NET")
+NODE_ID=node_test1204_prod
+MINT=$(curl -fsS -X POST "$HUB/api/auth/node-token" -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' \
+  -d "{\"network_id\":\"$NET_ID\",\"node_name\":\"prod-node\",\"node_id\":\"$NODE_ID\"}")
+NTOK=$(jq -r '.token' <<<"$MINT")
+[[ "$NTOK" == ntok_* ]]
+
+jq -n --arg token "$NTOK" --arg net "$NET_ID" --arg node "$NODE_ID" --arg hub "$HUB" '{
+  alias:"prod-node",node_name:"prod-node",node_id:$node,network_id:$net,token:$token,hub:$hub,
+  runtime:"codex-app-server",model:"gpt-5.4",flags:{sideThreads:true,approvalPolicy:"never",sandboxMode:"danger-full-access"}
+}' >"$ROOT/config.json"
+chmod 600 "$ROOT/config.json"
+: > /tmp/test1204-fake-codex.log
+PATH="/repo/tests/test1204-btw-production-wiring:$PATH" CODEX_HOME="$ROOT/codex-home" HOME="$ROOT/home" \
+  bun agent-node/src/cli.ts --config "$ROOT/config.json" --alias prod-node >"$ROOT/agent.log" 2>&1 &
+AGENT_PID=$!
+
+CAP_URL="$HUB/api/side-threads/capability?alias=prod-node&sourceThreadId=source-thread&boundaryKind=through&boundaryTurnId=source-turn"
+for _ in {1..200}; do
+  CAP=$(curl -sS "$CAP_URL" -H "Authorization: Bearer $UTOK" || true)
+  [[ "$(jq -r '.capability.supported // false' <<<"$CAP" 2>/dev/null)" == true ]] && break
+  kill -0 "$AGENT_PID" 2>/dev/null || { sed -n '1,200p' "$ROOT/agent.log"; exit 1; }
+  sleep .05
+done
+if [[ "$(jq -r '.capability.supported' <<<"$CAP")" != true ]]; then
+  echo "capability response: $CAP" >&2
+  curl -fsS "$HUB/api/status" -H "Authorization: Bearer $UTOK" >&2 || true
+  exit 1
+fi
+# Registration and the production CLI startup call above are real. Replace
+# only the Codex RPC dependency for deterministic command execution; Hub auth,
+# outbox, consumer, ACK, terminal and bring-back remain production code.
+kill "$AGENT_PID"; wait "$AGENT_PID" 2>/dev/null || true; AGENT_PID=""
+: > /tmp/test1204-fake-codex.log
+TEST_HUB="$HUB" TEST_NODE_ID="$NODE_ID" TEST_NODE_TOKEN="$NTOK" CODEX_HOME="$ROOT/codex-home" \
+  bun tests/test1204-btw-production-wiring/injected-consumer.ts >"$ROOT/consumer.log" 2>&1 &
+AGENT_PID=$!
+for _ in {1..100}; do grep -q 'dedicated consumer enabled' "$ROOT/consumer.log" && break; sleep .05; done
+grep -q 'dedicated consumer enabled' "$ROOT/consumer.log"
+
+CREATE_BODY="{
+  \"requestKey\":\"prod-create-1\",\"networkId\":\"$NET_ID\",\"nodeId\":\"$NODE_ID\",
+  \"sourceThreadId\":\"source-thread\",\"boundary\":{\"kind\":\"through\",\"turnId\":\"source-turn\"},
+  \"question\":\"production path question\"
+}"
+# The HTTP coordinator intentionally returns 202 while native acceptance is
+# unknown. Replaying this stable request key reconciles each durable phase;
+# it must never enqueue an ordinary task or duplicate the native operation.
+CREATE=$(curl -fsS -X POST "$HUB/api/side-threads" -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' -d "$CREATE_BODY")
+SIDE_ID=$(jq -r '.sideThread.sideThreadId // .sideThreadId // empty' <<<"$CREATE")
+[[ -n "$SIDE_ID" ]]
+for _ in {1..60}; do
+  ROW=$(curl -fsS "$HUB/api/side-threads/$SIDE_ID" -H "Authorization: Bearer $UTOK")
+  [[ "$(jq -r '.sideThread.state' <<<"$ROW")" == completed ]] && break
+  sleep .5
+done
+if [[ "$(jq -r '.sideThread.state' <<<"$ROW")" != completed ]]; then
+  echo "side-thread response: $ROW" >&2
+  exit 1
+fi
+[[ "$(jq -r '.sideThread.attempts[0].result' <<<"$ROW")" == *PRODUCTION_SIDE_ANSWER* ]]
+ATTEMPT_ID=$(jq -r '.sideThread.attempts[0].attemptId' <<<"$ROW")
+
+BACK=$(curl -fsS -X POST "$HUB/api/side-threads/$SIDE_ID/bring-back" -H "Authorization: Bearer $UTOK" -H 'Content-Type: application/json' -d "{
+  \"requestKey\":\"prod-bring-1\",\"attemptId\":\"$ATTEMPT_ID\",\"destinationThreadId\":\"source-thread\"
+}")
+[[ "$(jq -r '.ok' <<<"$BACK")" == true ]]
+for _ in {1..200}; do grep -q 'anet-btw-bring-back:' /tmp/test1204-fake-codex.log && break; sleep .05; done
+grep -q '"method":"thread/fork"' /tmp/test1204-fake-codex.log
+grep -q '"method":"turn/start"' /tmp/test1204-fake-codex.log
+grep -q 'anet-side:' /tmp/test1204-fake-codex.log
+grep -q 'anet-btw-bring-back:' /tmp/test1204-fake-codex.log
+grep -q 'dedicated consumer enabled' "$ROOT/consumer.log"
+! grep -q 'send_task' /tmp/test1204-fake-codex.log
+echo "PASS real Hub + real agent-node CLI production SideThread path"

--- a/tests/test1204-btw-production-wiring/run.sh
+++ b/tests/test1204-btw-production-wiring/run.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source /tests/lib/safe-rm.sh
+tests/test1204-btw-production-wiring/verify-source.sh
+
+# Witnessed-red 0: an unbound source image must be rejected before tests run.
+if SOURCE_COMMIT=unbound tests/test1204-btw-production-wiring/verify-source.sh >/tmp/witness-source.log 2>&1; then
+  echo "FAIL invalid SOURCE_COMMIT mutation survived"
+  exit 1
+fi
+grep -q 'SOURCE_COMMIT must bind' /tmp/witness-source.log
+
+bun test \
+  agent-node/src/runtime/side-thread/production.test.ts \
+  agent-node/src/runtime/side-thread/codex-app-server-adapter.test.ts \
+  agent-node/src/runtime/side-thread/command-transport.test.ts \
+  server/src/side-thread-production.test.ts \
+  server/src/side-thread-command-transport.test.ts
+
+(cd agent-node && bun run build)
+bun build server/src/server.ts --target bun --outfile /tmp/commhub-server.js
+tests/test1204-btw-production-wiring/production-process-e2e.sh
+
+# Witnessed-red 1: removing the real Hub route/port installation must break the process E2E.
+cp server/src/server.ts /tmp/server.ts
+sed -i 's/if (productionSideThreadTransport) installSideThreadExecutionPort/if (false \&\& productionSideThreadTransport) installSideThreadExecutionPort/' server/src/server.ts
+if tests/test1204-btw-production-wiring/production-process-e2e.sh >/tmp/witness-hub-wiring.log 2>&1; then
+  echo "FAIL Hub production-wiring mutation survived"
+  exit 1
+fi
+mv /tmp/server.ts server/src/server.ts
+
+# Witnessed-red 2: removing agent-node consumer startup must break the process E2E.
+cp agent-node/src/cli.ts /tmp/cli.ts
+sed -i '0,/if (sideThreadsEnabled) {/s//if (false \&\& sideThreadsEnabled) {/' agent-node/src/cli.ts
+if tests/test1204-btw-production-wiring/production-process-e2e.sh >/tmp/witness-node-wiring.log 2>&1; then
+  echo "FAIL agent-node production-wiring mutation survived"
+  exit 1
+fi
+mv /tmp/cli.ts agent-node/src/cli.ts
+
+# Witnessed-red 3: dropping localImage serialization must be caught.
+cp agent-node/src/runtime/side-thread/codex-app-server-adapter.ts /tmp/codex-adapter.ts
+sed -i 's/{ type: "localImage", path: item.path }/{ type: "text", text: item.path }/' agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+if bun test agent-node/src/runtime/side-thread/production.test.ts >/tmp/witness-image.log 2>&1; then
+  echo "FAIL localImage mutation survived"
+  exit 1
+fi
+grep -q 'Expected properties' /tmp/witness-image.log || grep -q 'localImage' /tmp/witness-image.log
+mv /tmp/codex-adapter.ts agent-node/src/runtime/side-thread/codex-app-server-adapter.ts
+
+# Witnessed-red 4: routing the consumer through ordinary tasks is forbidden.
+cp agent-node/src/runtime/side-thread/command-consumer.ts /tmp/command-consumer.ts
+sed -i 's/side-thread-commands/tasks/' agent-node/src/runtime/side-thread/command-consumer.ts
+if bun test agent-node/src/runtime/side-thread/production.test.ts >/tmp/witness-task.log 2>&1; then
+  echo "FAIL task-route mutation survived"
+  exit 1
+fi
+grep -q 'Expected: true' /tmp/witness-task.log || grep -q 'side-thread-commands' /tmp/witness-task.log
+mv /tmp/command-consumer.ts agent-node/src/runtime/side-thread/command-consumer.ts
+
+# Witnessed-red 5: a durable late ACK must resume the coordinator record;
+# returning the old ambiguous create record strands the accepted fork forever.
+cp server/src/side-thread.ts /tmp/side-thread.ts
+sed -i '0,/if (this\.createNeedsReconciliation(existing\.record))/s//if (false \&\& this.createNeedsReconciliation(existing.record))/' server/src/side-thread.ts
+if bun test server/src/side-thread-command-transport.test.ts -t 'late fork and start ACKs reconcile' >/tmp/witness-late-ack.log 2>&1; then
+  echo "FAIL late-ACK coordinator reconciliation mutation survived"
+  exit 1
+fi
+grep -q 'Expected promise that rejects' /tmp/witness-late-ack.log || grep -q 'SIDE_THREAD_AMBIGUOUS' /tmp/witness-late-ack.log
+mv /tmp/side-thread.ts server/src/side-thread.ts
+
+# Witnessed-red 6: authoritative late failures must leave reconciliation in a
+# stable failed state and clear the active attempt.
+cp server/src/side-thread.ts /tmp/side-thread-failure.ts
+sed -i "s/state IN ('starting','ambiguous','reconciling')/state='starting'/" server/src/side-thread.ts
+if bun test server/src/side-thread-command-transport.test.ts -t 'late unsupported fork ACK converges' >/tmp/witness-late-failure.log 2>&1; then
+  echo "FAIL late authoritative-failure convergence mutation survived"
+  exit 1
+fi
+grep -q 'state.*failed' /tmp/witness-late-failure.log || grep -q 'reconciling' /tmp/witness-late-failure.log
+mv /tmp/side-thread-failure.ts server/src/side-thread.ts
+
+# Witnessed-red 7: all lifecycle actions depend on the shared durable-receipt
+# reconciler; deleting that production seam must break the table gate.
+cp server/src/side-thread.ts /tmp/side-thread-lifecycle.ts
+sed -i 's/private async reconcileLifecycleOperation/private async disabledLifecycleReconciliation/' server/src/side-thread.ts
+if bun test server/src/side-thread-command-transport.test.ts -t 'cancel consumes a late accepted receipt' >/tmp/witness-lifecycle-reconcile.log 2>&1; then
+  echo "FAIL lifecycle reconciliation deletion survived"
+  exit 1
+fi
+grep -q 'reconcileLifecycleOperation' /tmp/witness-lifecycle-reconcile.log
+mv /tmp/side-thread-lifecycle.ts server/src/side-thread.ts
+
+# Witnessed-red 8: slow-path lifecycle settlement must publish the same domain
+# event as the synchronous fast path, once.
+cp server/src/side-thread.ts /tmp/side-thread-event.ts
+sed -i 's/`side_chat\.\${action === "archive"/`side_chat.missing.${action === "archive"/' server/src/side-thread.ts
+if bun test server/src/side-thread-command-transport.test.ts -t 'archive consumes a late accepted receipt' >/tmp/witness-lifecycle-event.log 2>&1; then
+  echo "FAIL lifecycle domain-event mutation survived"
+  exit 1
+fi
+grep -q 'side_chat.archived' /tmp/witness-lifecycle-event.log
+mv /tmp/side-thread-event.ts server/src/side-thread.ts
+
+# Witnessed-red 9: observer exceptions must be isolated per listener after the
+# durable event transaction commits.
+cp server/src/side-thread.ts /tmp/side-thread-observer.ts
+sed -i '/queueMicrotask/,/Durable side_chat_events/ s/} catch {/} finally {/' server/src/side-thread.ts
+if bun test server/src/side-thread.test.ts -t 'throwing observers cannot alter durable truth' >/tmp/witness-observer.log 2>&1; then
+  echo "FAIL observer isolation mutation survived"
+  exit 1
+fi
+test -s /tmp/witness-observer.log
+mv /tmp/side-thread-observer.ts server/src/side-thread.ts
+
+# Witnessed-red 10: a committed runtime receipt followed by a local apply
+# failure is recoverable ambiguity, never an authoritative runtime failure.
+cp server/src/side-thread.ts /tmp/side-thread-apply-class.ts
+sed -i 's/throw ambiguousError(input.operationId, input.sideChatId, input.attemptId);/throw new SideThreadError("SIDE_THREAD_RUNTIME_ERROR", "misclassified local apply", 502);/g' server/src/side-thread.ts
+if bun test server/src/side-thread-command-transport.test.ts -t 'archive consumes a late accepted receipt' >/tmp/witness-apply-class.log 2>&1; then
+  echo "FAIL local-apply classification mutation survived"
+  exit 1
+fi
+grep -q 'SIDE_THREAD_AMBIGUOUS' /tmp/witness-apply-class.log
+mv /tmp/side-thread-apply-class.ts server/src/side-thread.ts
+
+# Witnessed-red 11: accepted create fork/start receipts whose local projection
+# fails must stay replayable, never become a terminal runtime failure.
+cp server/src/side-thread.ts /tmp/side-thread-create-apply.ts
+sed -i '/private applyRuntimeReceipt/,/private async reconcileLifecycleOperation/ s/"SIDE_THREAD_AMBIGUOUS",/"SIDE_THREAD_RUNTIME_ERROR",/' server/src/side-thread.ts
+if bun test server/src/side-thread-command-transport.test.ts -t 'late fork and start ACKs reconcile' >/tmp/witness-create-apply.log 2>&1; then
+  echo "FAIL create local-apply classification mutation survived"
+  exit 1
+fi
+grep -q 'SIDE_THREAD_AMBIGUOUS' /tmp/witness-create-apply.log
+mv /tmp/side-thread-create-apply.ts server/src/side-thread.ts
+
+if [[ "${BTW_LIVE_PROBE:-0}" == "1" ]]; then
+  test "$(codex --version)" = "codex-cli 0.148.0"
+  test -n "${CODEX_HOME:-}"
+  test -f "$CODEX_HOME/.anet-btw-probe-sentinel"
+  test "$(cat "$CODEX_HOME/.anet-btw-probe-sentinel")" = "test1190-disposable-v2"
+  export REPORT_DIR="${REPORT_DIR:-/probe/out}"
+  mkdir -p "$REPORT_DIR"
+  cleanup_live_home() {
+    test -f "$CODEX_HOME/.anet-btw-probe-sentinel" || return 1
+    test "$(cat "$CODEX_HOME/.anet-btw-probe-sentinel")" = "test1190-disposable-v2"
+    find "$CODEX_HOME" -mindepth 1 -delete
+  }
+  trap cleanup_live_home EXIT
+  node tests/test1204-btw-production-wiring/attachment-live-probe.mjs > "$REPORT_DIR/attachment-live-result.json"
+  jq -e '
+    .evidenceRevision == "test1204-local-image-v1" and
+    .inputType == "localImage" and
+    .promptContainsMarker == false and
+    .modelAnswerMarkerObserved == true and
+    .threadReadMarkerObserved == true and
+    .imageMode == 384 and
+    (.markerSha256 | test("^[a-f0-9]{64}$"))
+  ' "$REPORT_DIR/attachment-live-result.json" >/dev/null
+fi
+
+echo "PASS test1204 BTW production wiring (58 baseline, real two-process E2E, 12 witnessed-red, 2 bundles)"

--- a/tests/test1204-btw-production-wiring/verify-source.sh
+++ b/tests/test1204-btw-production-wiring/verify-source.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! "${SOURCE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "FAIL: SOURCE_COMMIT must bind the image to an exact git revision" >&2
+  exit 1
+fi
+echo "SOURCE_COMMIT=$SOURCE_COMMIT"


### PR DESCRIPTION
## Summary
- install the Hub `SideThreadExecutionPort` behind `COMMHUB_ENABLE_SIDE_THREADS=1` using the dedicated durable command outbox
- start an opt-in Codex app-server SideThread consumer from agent-node with an exact 0.148.0 owned-stdio capability allowlist
- materialize node/network-bound attachment grants at 0600, send images as `localImage`, and journal native bring-back without tasks/FIFO/steer fallback
- recover derived-thread ownership from durable hashes plus authoritative `thread/read`; unsupported runtime/version/topology fails closed

## Verification
- Docker test1204: 42/42, 151 assertions
- agent-node + upload helper + CommHub production bundles
- witnessed-red: `localImage -> text` and dedicated route `-> tasks`
- real Codex 0.148: marker exists only in image pixels; model answer and authoritative derived `thread/read` both contain it; prompt does not
- test suite registration, L1 paths sync, and QA trigger coverage pass
- disposable authenticated `CODEX_HOME` and sanitized result directory erased after the probe

## Rollout
Both Hub and node flags are required. This Draft does not enable, merge, publish, or release the feature.

## Open-path review
Other currently-open PRs overlap shared registry/runtime files: #1200, #1198, #1196, #1193, #1180, #1177, #1126, #1101, #1035, #460. Recheck before merge.
