### PR TITLE
feat(hub): expose canonical actual task target

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -108,6 +108,7 @@ on:
       - 'tests/test661-explicit-bootstrap-db/**'
       - 'tests/test683-hub-lifecycle-watcher/**'
       - 'tests/qa-hub-17-rename-canonicalization/**'
+      - 'tests/test1210-actual-target-contract/**'
       - 'tests/qa-hub-19-login-guard/**'
       - 'tests/test635-daemon-private-state/**'
       - 'tests/test643-transient-hub-legacy-repair/**'
@@ -848,6 +849,7 @@ jobs:
       matrix:
         suite:
           - qa-hub-17-rename-canonicalization
+          - test1210-actual-target-contract
           - qa-hub-19-login-guard
           - test635-daemon-private-state
           - test643-transient-hub-legacy-repair

--- a/docs-site/docs/api/mcp-tools.md
+++ b/docs-site/docs/api/mcp-tools.md
@@ -236,9 +236,19 @@ Hub 先用 `id = message_id`，或对任务消息用 `task_id = message_id`，�
 {
   "ok": true,
   "message_id": "uuid-xxx",
+  "actual_to": {
+    "alias": "代码1号",
+    "to_node_id": "node_xxx",
+    "network_id": "net_xxx"
+  },
   "session_status": "idle"
 }
 ```
+
+`actual_to` 表示 Hub 在调用方有权访问的 network 内实际解析到的 canonical
+目标；在线成功、离线排队和幂等重放均使用同一 shape。改名兼容字段
+`renamed_from` / `renamed_to` 继续保留。not-found 与权限拒绝不会返回该对象，
+因此不能借失败响应枚举其他 network 的 alias、node ID 或 network ID。
 
 **示例**：
 

--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -1434,11 +1434,26 @@ curl -X POST http://localhost:9200/api/task \
 **响应**（成功）：
 
 ```json
-{ "ok": true, "task_id": "uuid-xxx", "message_id": "uuid-xxx" }
+{
+  "ok": true,
+  "task_id": "uuid-xxx",
+  "message_id": "uuid-xxx",
+  "actual_to": {
+    "alias": "代码1号",
+    "to_node_id": "node_xxx",
+    "network_id": "net_xxx"
+  }
+}
 ```
 
 `task_id` 是 canonical task identifier；`message_id` 为兼容旧调用方保留，
 当前与 `task_id` 相同。
+
+`actual_to` 是 Hub 完成权限检查和 network-scoped alias 解析后的权威投递目标。
+它在在线成功和离线排队（HTTP 202、`alias_offline`）响应中使用同一 shape；
+alias 被改名时这里给 canonical alias，旧 `renamed_from` / `renamed_to` 字段仍保留。
+`to_node_id` 对尚未上报稳定 node identity 的旧节点可为 `null`。`alias_not_found`
+和权限拒绝响应不返回 `actual_to`，避免把错误接口变成跨 network 枚举入口。
 
 ### MCP 优先与 REST fallback
 

--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1816 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1816) + [tools.ts:1830 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1830) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1835 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1835) + [tools.ts:1849 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1849) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:72 + db.ts:98](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L72)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/docs/tests/report-test1210-actual-target-contract.txt
+++ b/docs/tests/report-test1210-actual-target-contract.txt
@@ -1,0 +1,38 @@
+test1210 — canonical actual target dispatch acknowledgement
+============================================================
+
+Base: origin/main 3f88c9699b620597a6357bfc6eed6a02264152c7
+Environment: isolated Docker; Bun 1.2.22; ephemeral SQLite and loopback Hub
+
+WITNESSED RED (before implementation)
+-------------------------------------
+Command:
+  sg docker -c 'docker build -t anet-test1210-red -f tests/test1210-actual-target-contract/Dockerfile . && docker run --rm anet-test1210-red'
+
+The baseline reached:
+  [0] environment -> authenticated Hub
+  [1] REST success returns the scoped canonical actual target
+
+It then exited non-zero because the baseline success response had no
+`actual_to`. This proves the suite discriminates the intended wire change.
+
+GREEN acceptance coverage
+-------------------------
+- REST online success returns actual_to {alias,to_node_id,network_id}.
+- MCP online success returns the identical object shape.
+- MCP idempotent replay returns the same authoritative target and task ID.
+- The same alias in two networks resolves to different scoped node IDs.
+- An old alias after rename reports the canonical alias while preserving
+  renamed_from / renamed_to compatibility fields.
+- REST and MCP offline/queued responses still identify the durable target.
+- Not-found responses omit actual_to.
+- A user without membership gets HTTP 403 and no alias/node/network leakage.
+
+Docker result: PASS
+  PASS test1210 actual target contract
+
+Focused regression tests (inside the same Docker image):
+  37 pass, 0 fail, 80 expect() calls
+  - task-network-resolution-http.test.ts
+  - mcp-write-network-resolution.test.ts
+  - task-idempotency.test.ts

--- a/docs/tests/report-test1210-actual-target-contract.txt
+++ b/docs/tests/report-test1210-actual-target-contract.txt
@@ -1,8 +1,9 @@
 test1210 — canonical actual target dispatch acknowledgement
 ============================================================
 
-Base: origin/main 3f88c9699b620597a6357bfc6eed6a02264152c7
-Environment: isolated Docker; Bun 1.2.22; ephemeral SQLite and loopback Hub
+Base: origin/main f962d72fef7ee11078be7e94e423c42ac65fdc21
+Candidate before this report update: 7a213929d3f5b92425a10ee04a67a4feff55574f
+Environment: isolated Docker; ephemeral SQLite and loopback Hub
 
 WITNESSED RED (before implementation)
 -------------------------------------
@@ -39,3 +40,18 @@ Focused regression tests (inside the same Docker image):
   - task-network-resolution-http.test.ts
   - mcp-write-network-resolution.test.ts
   - task-idempotency.test.ts
+
+Full server aggregate (test798, isolated Docker): PASS
+  L0 executed_files=76 discovered_files=76 failed_files=0
+  L1 witnessed-red registration-password-floor-weakened rc=1
+
+Node stop convergence package gate (test225, immutable git archive): PASS
+  Summary: PASS
+  package_e2e=PASS
+  npx_preview_fallback=PASS
+  global_agent_node_resume=PASS
+  known-failure ratchet: 11 PASS lines, 0 FAIL lines, empty baseline
+
+The test225 result verifies that the stop-convergence fix already merged in
+the pinned base removes the previous residual-process/socket failure. No
+waiver or known-failure entry was added.

--- a/docs/tests/report-test1210-actual-target-contract.txt
+++ b/docs/tests/report-test1210-actual-target-contract.txt
@@ -21,6 +21,8 @@ GREEN acceptance coverage
 - REST online success returns actual_to {alias,to_node_id,network_id}.
 - MCP online success returns the identical object shape.
 - MCP idempotent replay returns the same authoritative target and task ID.
+  The pre-existing exact-equality replay test is pinned to the additive
+  `actual_to` object, so future response drift is visible rather than ignored.
 - The same alias in two networks resolves to different scoped node IDs.
 - An old alias after rename reports the canonical alias while preserving
   renamed_from / renamed_to compatibility fields.
@@ -32,7 +34,8 @@ Docker result: PASS
   PASS test1210 actual target contract
 
 Focused regression tests (inside the same Docker image):
-  37 pass, 0 fail, 80 expect() calls
+  41 pass, 0 fail, 92 expect() calls
+  - task-idempotency-mcp.test.ts
   - task-network-resolution-http.test.ts
   - mcp-write-network-resolution.test.ts
   - task-idempotency.test.ts

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -559,6 +559,17 @@ type RestDeliveryTarget =
   | { state: "offline"; alias: string; session: any; message: string }
   | { state: "not_found"; alias: string; message: string };
 
+// Build this only after authorization and a network-scoped lookup succeeded.
+// In particular, not-found and permission-denied responses must not become a
+// cross-network alias/node enumeration oracle.
+function restActualTo(target: Exclude<RestDeliveryTarget, { state: "not_found" }>, networkId: string | null) {
+  return {
+    alias: target.alias,
+    to_node_id: target.session?.node_id ?? null,
+    network_id: networkId,
+  };
+}
+
 function resolveRestDeliveryTarget(alias: string, networkId: string | null): RestDeliveryTarget {
   const params: any[] = [alias];
   let sql = "SELECT status, updated_at, last_seen_at, node_id FROM sessions WHERE alias = ?1";
@@ -2354,6 +2365,7 @@ return Bun.serve({
       const ttlSeconds = (body as any).ttl_seconds || 3600;
       const fromNodeId = resolveRestNodeIdForAlias(fromSession, taskNetId);
       const targetNodeId = target.session?.node_id ?? null;
+      const actualTo = restActualTo(target, taskNetId);
       // #221 — fold top-level `attachments` into `meta.attachments` so
       // the REST and MCP send_task transports produce identical
       // tasks.meta_json shape downstream. Top-level wins over any
@@ -2454,10 +2466,17 @@ return Bun.serve({
           task_id: id,
           message_id: id,
           session_status: target.session.status ?? "offline",
+          actual_to: actualTo,
           ...(canonical.renamed ? { renamed_from: body.alias, renamed_to: targetAlias } : {}),
         }, { status: 202 }));
       }
-      return withCors(req, Response.json({ ok: true, task_id: id, message_id: id, ...(canonical.renamed ? { renamed_from: body.alias, renamed_to: targetAlias } : {}) }));
+      return withCors(req, Response.json({
+        ok: true,
+        task_id: id,
+        message_id: id,
+        actual_to: actualTo,
+        ...(canonical.renamed ? { renamed_from: body.alias, renamed_to: targetAlias } : {}),
+      }));
     }
 
     // ── REST: broadcast ──

--- a/server/src/task-idempotency-mcp.test.ts
+++ b/server/src/task-idempotency-mcp.test.ts
@@ -114,6 +114,11 @@ describe("send_task durable idempotency", () => {
       task_id: first.message_id,
       task_status: "delivered",
       idempotent_replay: true,
+      actual_to: {
+        alias: TARGET,
+        to_node_id: "id_node_chat_idem",
+        network_id: NET,
+      },
     });
     expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM tasks WHERE network_id = ?1", [NET])?.count).toBe(1);
     expect(db.get<{ count: number }>("SELECT COUNT(*) AS count FROM inbox WHERE network_id = ?1", [NET])?.count).toBe(1);

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -364,6 +364,14 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
     | { state: "offline"; alias: string; session: any; message: string }
     | { state: "not_found"; alias: string; message: string };
 
+  // Only call after the authenticated, network-scoped lookup resolved a
+  // concrete target. Error paths intentionally omit this identity object.
+  const actualTo = (target: Exclude<DeliveryTarget, { state: "not_found" }>, networkId?: string | null) => ({
+    alias: target.alias,
+    to_node_id: target.session?.node_id ?? null,
+    network_id: networkId ?? null,
+  });
+
   const scopedSessionStatus = (alias: string, networkId?: string | null) => {
     const params: any[] = [alias];
     let sql = "SELECT status, updated_at, last_seen_at, node_id FROM sessions WHERE alias = ?1";
@@ -1315,8 +1323,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         ? idempotentTaskId(effectiveNetId ?? null, from_session, clientRequestId)
         : uuidv4();
       if (clientRequestId) {
-        const existing = db.get<StoredIdempotentTask>(
-          "SELECT task_id, from_name, to_name, priority, content, network_id, meta_json, status FROM tasks WHERE task_id = ?1",
+        const existing = db.get<StoredIdempotentTask & { to_node_id: string | null }>(
+          "SELECT task_id, from_name, to_node_id, to_name, priority, content, network_id, meta_json, status FROM tasks WHERE task_id = ?1",
           [id],
         );
         if (existing) {
@@ -1332,6 +1340,14 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           return { content: [{ type: "text" as const, text: JSON.stringify({
             ok: true, message_id: existing.task_id, task_id: existing.task_id,
             task_status: existing.status, idempotent_replay: true,
+            // A replay acknowledges the already-persisted dispatch. Use that
+            // row rather than today's session record so alias reuse or a
+            // restarted process cannot rewrite historical recipient identity.
+            actual_to: {
+              alias: existing.to_name,
+              to_node_id: existing.to_node_id ?? null,
+              network_id: existing.network_id ?? null,
+            },
           }) }] };
         }
       }
@@ -1365,6 +1381,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       console.log(`[${ts()}] ${from_session} → send_task → ${targetAlias}: ${task.slice(0, 60)}${priority === "high" ? " [HIGH]" : ""}${canonical.renamed ? ` [renamed from ${alias}]` : ""}`);
       const fromNodeId = resolveNodeIdForAlias(from_session, effectiveNetId);
       const targetNodeId = target.session?.node_id ?? null;
+      const resolvedActualTo = actualTo(target, effectiveNetId);
       // 事务：inbox + tasks 双写 + 触碰目标 session 的 task/updated_at（让
       // dashboard 在派任务一刻就反映出"任务已下发"，不再等 agent 的
       // report_status 心跳；status 字段交给 agent，避免与 working/idle
@@ -1422,6 +1439,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
               task_id: id,
               message_id: id,
               session_status: target.session.status ?? "offline",
+              actual_to: resolvedActualTo,
               ...(canonical.renamed ? { renamed_from: alias, renamed_to: targetAlias } : {}),
             }),
           }],
@@ -1435,6 +1453,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
             text: JSON.stringify({
               ok: true,
               message_id: id,
+              actual_to: resolvedActualTo,
               ...(canonical.renamed ? { renamed_from: alias, renamed_to: targetAlias } : {}),
               session_status: target.session?.status ?? "unknown",
             }),

--- a/tests/test1210-actual-target-contract/Dockerfile
+++ b/tests/test1210-actual-target-contract/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1.2.22-debian
+
+RUN apt-get update && apt-get install -y --no-install-recommends bash curl jq ca-certificates && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app/server
+COPY server/package.json ./
+RUN bun install --frozen-lockfile
+COPY server/src ./src
+
+WORKDIR /app
+COPY tests/test1210-actual-target-contract/run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+
+CMD ["/app/run.sh"]

--- a/tests/test1210-actual-target-contract/run.sh
+++ b/tests/test1210-actual-target-contract/run.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+PORT=19210
+BASE="http://127.0.0.1:${PORT}"
+DB=/tmp/test1210.db
+LOG=/tmp/test1210-hub.log
+rm -f "$DB" "$LOG"
+
+cleanup() {
+  set +e
+  [[ -n "${HUB_PID:-}" ]] && kill "$HUB_PID" >/dev/null 2>&1
+  [[ -n "${HUB_PID:-}" ]] && wait "$HUB_PID" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+post() {
+  local path="$1" token="$2" body="$3"
+  curl -sS -X POST "$BASE$path" -H 'Content-Type: application/json' \
+    ${token:+-H "Authorization: Bearer $token"} -d "$body"
+}
+
+mcp() {
+  local token="$1" tool="$2" args="$3"
+  jq -nc --arg tool "$tool" --argjson args "$args" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:$tool,arguments:$args}}' \
+    | curl -sS -X POST "$BASE/mcp" -H "Authorization: Bearer $token" \
+        -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+        -H 'MCP-Protocol-Version: 2025-03-26' --data-binary @- \
+    | sed -n 's/^data: //p' | head -1 | jq -r '.result.content[0].text // empty'
+}
+
+register_user() {
+  local username="$1"
+  post /api/auth/register '' "{\"username\":\"$username\",\"password\":\"StrongPassw0rd!\"}"
+}
+
+create_network() {
+  local token="$1" name="$2"
+  post /api/networks "$token" "{\"name\":\"$name\"}" | jq -r '.network_id'
+}
+
+register_node() {
+  local user_token="$1" network_id="$2" alias="$3" node_id="$4" status="${5:-idle}"
+  local node_token args
+  node_token=$(post /api/auth/node-token "$user_token" \
+    "{\"network_id\":\"$network_id\",\"node_name\":\"$alias\"}" | jq -r '.token')
+  args=$(jq -nc --arg net "$network_id" --arg alias "$alias" --arg node "$node_id" --arg status "$status" \
+    '{resume_id:("resume-"+$node),alias:$alias,node_id:$node,node_name:$alias,status:$status,network_id:$net}')
+  mcp "$node_token" report_status "$args" | jq -e '.ok == true' >/dev/null
+  printf '%s' "$node_token"
+}
+
+echo '[0] environment -> authenticated Hub'
+(
+  cd /app/server
+  HOST=127.0.0.1 PORT="$PORT" COMMHUB_DB="$DB" COMMHUB_AUTH_TOKEN=test1210 bun run src/index.ts
+) >"$LOG" 2>&1 &
+HUB_PID=$!
+for _ in $(seq 1 60); do curl -fsS "$BASE/health" >/dev/null 2>&1 && break; sleep 0.25; done
+curl -fsS "$BASE/health" >/dev/null
+
+OWNER=$(register_user owner1210)
+OWNER_TOKEN=$(jq -r '.token' <<<"$OWNER")
+NET_A=$(jq -r '.network_id' <<<"$OWNER")
+NET_B=$(create_network "$OWNER_TOKEN" net-b-1210)
+OUTSIDER=$(register_user outsider1210)
+OUTSIDER_TOKEN=$(jq -r '.token' <<<"$OUTSIDER")
+
+NODE_A_TOKEN=$(register_node "$OWNER_TOKEN" "$NET_A" shared-agent node-a-1210 idle)
+register_node "$OWNER_TOKEN" "$NET_B" shared-agent node-b-1210 idle >/dev/null
+register_node "$OWNER_TOKEN" "$NET_A" offline-agent node-offline-1210 offline >/dev/null
+
+echo '[1] REST success returns the scoped canonical actual target'
+REST_A=$(post /api/task "$OWNER_TOKEN" "{\"alias\":\"shared-agent\",\"task\":\"rest a\",\"network_id\":\"$NET_A\"}")
+jq -e --arg net "$NET_A" '.ok == true and .actual_to == {alias:"shared-agent",to_node_id:"node-a-1210",network_id:$net}' <<<"$REST_A" >/dev/null
+
+REST_B=$(post /api/task "$OWNER_TOKEN" "{\"alias\":\"shared-agent\",\"task\":\"rest b\",\"network_id\":\"$NET_B\"}")
+jq -e --arg net "$NET_B" '.ok == true and .actual_to == {alias:"shared-agent",to_node_id:"node-b-1210",network_id:$net}' <<<"$REST_B" >/dev/null
+
+echo '[2] MCP success has exactly the same actual_to shape'
+MCP_A=$(mcp "$NODE_A_TOKEN" send_task "$(jq -nc --arg net "$NET_A" '{alias:"shared-agent",task:"mcp a",network_id:$net,from_session:"shared-agent"}')")
+jq -e --arg net "$NET_A" '.ok == true and .actual_to == {alias:"shared-agent",to_node_id:"node-a-1210",network_id:$net}' <<<"$MCP_A" >/dev/null
+
+IDEM_ARGS=$(jq -nc --arg net "$NET_A" '{alias:"shared-agent",task:"idempotent mcp",network_id:$net,from_session:"shared-agent",meta:{client_request_id:"dreq_test1210_retry_0001"}}')
+IDEM_FIRST=$(mcp "$NODE_A_TOKEN" send_task "$IDEM_ARGS")
+IDEM_REPLAY=$(mcp "$NODE_A_TOKEN" send_task "$IDEM_ARGS")
+jq -e --arg net "$NET_A" '.ok == true and .idempotent_replay == true and .actual_to == {alias:"shared-agent",to_node_id:"node-a-1210",network_id:$net}' <<<"$IDEM_REPLAY" >/dev/null
+[[ "$(jq -r '.message_id' <<<"$IDEM_FIRST")" == "$(jq -r '.message_id' <<<"$IDEM_REPLAY")" ]]
+
+echo '[3] rename resolves actual alias while preserving compatibility fields'
+PREP=$(post /api/node-rename/prepare "$OWNER_TOKEN" "{\"network_id\":\"$NET_A\",\"old_alias\":\"shared-agent\",\"new_alias\":\"canonical-agent\"}")
+TXN=$(jq -r '.txn_id' <<<"$PREP")
+post /api/node-rename/commit "$OWNER_TOKEN" "{\"txn_id\":\"$TXN\"}" | jq -e '.ok == true' >/dev/null
+RENAMED=$(post /api/task "$OWNER_TOKEN" "{\"alias\":\"shared-agent\",\"task\":\"renamed rest\",\"network_id\":\"$NET_A\"}")
+jq -e --arg net "$NET_A" '.renamed_from == "shared-agent" and .renamed_to == "canonical-agent" and .actual_to == {alias:"canonical-agent",to_node_id:"node-a-1210",network_id:$net}' <<<"$RENAMED" >/dev/null
+
+echo '[4] offline queued response still identifies the durable target'
+OFF_REST=$(post /api/task "$OWNER_TOKEN" "{\"alias\":\"offline-agent\",\"task\":\"queued rest\",\"network_id\":\"$NET_A\"}")
+jq -e --arg net "$NET_A" '.ok == false and .queued == true and .error == "alias_offline" and .actual_to == {alias:"offline-agent",to_node_id:"node-offline-1210",network_id:$net}' <<<"$OFF_REST" >/dev/null
+OFF_MCP=$(mcp "$NODE_A_TOKEN" send_task "$(jq -nc --arg net "$NET_A" '{alias:"offline-agent",task:"queued mcp",network_id:$net,from_session:"canonical-agent"}')")
+jq -e --arg net "$NET_A" '.ok == false and .queued == true and .error == "alias_offline" and .actual_to == {alias:"offline-agent",to_node_id:"node-offline-1210",network_id:$net}' <<<"$OFF_MCP" >/dev/null
+
+echo '[5] not-found and cross-network denial disclose no target identity'
+MISSING=$(post /api/task "$OWNER_TOKEN" "{\"alias\":\"ghost-1210\",\"task\":\"missing\",\"network_id\":\"$NET_A\"}")
+jq -e '(.error == "alias_not_found") and (has("actual_to") | not) and (has("to_node_id") | not)' <<<"$MISSING" >/dev/null
+
+HTTP=$(curl -sS -o /tmp/denied.json -w '%{http_code}' -X POST "$BASE/api/task" \
+  -H "Authorization: Bearer $OUTSIDER_TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"alias\":\"canonical-agent\",\"task\":\"denied\",\"network_id\":\"$NET_A\"}")
+[[ "$HTTP" == 403 ]]
+jq -e '(has("actual_to") | not) and (tostring | contains("node-a-1210") | not) and (tostring | contains("canonical-agent") | not)' /tmp/denied.json >/dev/null
+
+echo 'PASS test1210 actual target contract'


### PR DESCRIPTION
## Summary

Adds one permission-safe acknowledgement object to REST `POST /api/task` and MCP `send_task`:

```json
"actual_to": {
  "alias": "canonical-alias",
  "to_node_id": "node_xxx",
  "network_id": "net_xxx"
}
```

The object is present for online success, offline/queued delivery, and MCP idempotent replay. Existing fields and status semantics remain unchanged. Not-found and authorization failures omit it.

Closes #1208.

## Scope

Hub protocol only (`server.ts` + `tools.ts`), docs, and isolated Docker gate. No agent-node/Codex steer/polling paths and no App repository changes; this is intentionally independent from #1193 and #1207.

For idempotent replay, `actual_to` comes from the persisted task row rather than today's session, so alias reuse/restart cannot rewrite historical recipient identity.

## Evidence

- Witnessed red: baseline exited at the first REST success assertion because `actual_to` was absent.
- `test1210-actual-target-contract` Docker E2E: PASS
  - REST/MCP parity
  - same alias across two networks → distinct scoped node IDs
  - canonical rename + legacy `renamed_*` compatibility
  - offline queued REST/MCP
  - idempotent replay
  - not-found omission
  - cross-network HTTP 403 with no identity leakage
- Focused server tests in Docker: 37 pass, 0 fail, 80 assertions.
- Saved report: `docs/tests/report-test1210-actual-target-contract.txt`

## Compatibility/security

Additive response fields only. Old `task_id`, `message_id`, `renamed_from`, `renamed_to`, `session_status`, `queued`, and HTTP codes are preserved. Construction happens only after authorization and network-scoped resolution.
