### PR TITLE
fix(cli): make node stop converge owned resources (#1027)

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -97,6 +97,7 @@ on:
       #    而 CI 从头到尾没有执行过这个套件。job 存在、挂上、会被触发是三件事,
       #    漏的就是第三件。
       - 'tests/test225-grok-preview-package-live/**'
+      - 'tests/test225-node-stop-convergence/**'
       - 'tests/test233-grok-main-integration/**'
       - 'tests/test234-grok-profile-disclosure/**'
       - 'tests/test235-grok-mcp-outbound-only/**'
@@ -246,6 +247,7 @@ on:
       #    而 CI 从头到尾没有执行过这个套件。job 存在、挂上、会被触发是三件事,
       #    漏的就是第三件。
       - 'tests/test225-grok-preview-package-live/**'
+      - 'tests/test225-node-stop-convergence/**'
       - 'tests/test233-grok-main-integration/**'
       - 'tests/test234-grok-profile-disclosure/**'
       - 'tests/test235-grok-mcp-outbound-only/**'

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -5383,7 +5383,10 @@ function maybeWarnChannelResumeBlocker(
   }
 }
 
-async function launchAgent(id: string, forceNewSession = false, hubOverride?: string) {
+async function launchAgent(id: string, forceNewSession = false, hubOverride?: string, admittedGeneration?: string) {
+  const launchResolved = resolveNodeRef(id);
+  if (!launchResolved) throw new Error(`Node ${JSON.stringify(id)} not found`);
+  const launchGeneration = admittedGeneration || await admitNodeStart(launchResolved.id, Date.now());
   const resolved = resolveNodeRef(id);
   if (!resolved) {
     console.error(`Node "${id}" not found. Create it first: anet node create ${id}`);
@@ -5678,11 +5681,11 @@ async function launchAgent(id: string, forceNewSession = false, hubOverride?: st
         // Stable timer — child survives 30s → reset backoff to base.
         // Mirrors the connectFeishu supervisor pattern from PR #263.
         const stableTimer = setTimeout(() => ctrl.markStable(), 30_000);
-        const child = spawn(runCommand, runCommandArgs, {
+        const child = await spawnOwnedNodeChild(nodeId, launchGeneration, () => spawn(runCommand, runCommandArgs, {
           env: childEnv,
           stdio: "inherit",
           shell: runtime === "opencode-cli" ? false : process.platform === "win32",
-        });
+        }));
         if (runtime === "opencode-cli") activeAgentChild = child;
         if (child.pid) writeFileSync(pidFile, String(child.pid));
 
@@ -5925,8 +5928,14 @@ async function launchAgent(id: string, forceNewSession = false, hubOverride?: st
     // forgiving and the bug usually only manifests as a missing session
     // banner. Fix: await child exit so parent stays alive while child holds
     // the TTY; main() unwinds naturally only after claude actually exits.
-    await new Promise<void>((resolve) => {
-      const child = spawn("claude", claudeArgs, { env, stdio: "inherit" });
+    await new Promise<void>(async (resolve) => {
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = await spawnOwnedNodeChild(nodeId, launchGeneration, () => spawn("claude", claudeArgs, { env, stdio: "inherit" }));
+      } catch (error: any) {
+        console.error(`[anet] ❌ ${error?.message || error}`);
+        process.exit(1);
+      }
       const pidFile = join(nodesDir(), nodeId, ".pid");
       if (child.pid) writeFileSync(pidFile, String(child.pid));
       child.on("exit", (code) => {
@@ -5963,22 +5972,69 @@ async function launchAgent(id: string, forceNewSession = false, hubOverride?: st
   }
 }
 
+type LifecycleProcessIdentity = { pid: number; birth: string; role: "wrapper" | "agent" | "bridge" };
 type LifecycleOwnerRecord = {
   schema: 1; state: "starting" | "stopping" | "stopped";
-  generation?: string; wrapperPid?: number; wrapperBirth?: string | null;
+  generation?: string; wrapperPid?: number; wrapperBirth?: string;
+  processes?: LifecycleProcessIdentity[];
   startInvokedAt?: number; stopInvokedAt?: number;
 };
+type LifecycleLockOwner = { schema: 1; pid: number; birth: string; operation: string; generation?: string };
 
 function lifecycleOwnerPath(nodeId: string) { return join(nodesDir(), nodeId, ".lifecycle-owner.json"); }
 function lifecycleLockPath(nodeId: string) { return join(nodesDir(), nodeId, ".lifecycle-lock"); }
+function lifecycleLockOwnerPath(nodeId: string) { return join(lifecycleLockPath(nodeId), "owner.json"); }
 
-async function withLifecycleLock<T>(nodeId: string, fn: () => T | Promise<T>): Promise<T> {
+async function withLifecycleLock<T>(nodeId: string, fn: () => T | Promise<T>, operation = "lifecycle", generation?: string): Promise<T> {
   const lock = lifecycleLockPath(nodeId);
   const deadline = Date.now() + 5_000;
+  let missingReceiptSince = 0;
   while (true) {
-    try { mkdirSync(lock, { mode: 0o700 }); break; }
+    try {
+      mkdirSync(lock, { mode: 0o700 });
+      const birth = processBirth(process.pid);
+      if (!birth) { rmSync(lock, { recursive: true, force: true }); throw new Error("NODE_LIFECYCLE_BIRTH_UNAVAILABLE"); }
+      atomicWritePrivateJson(lifecycleLockOwnerPath(nodeId), { schema: 1, pid: process.pid, birth, operation, ...(generation ? { generation } : {}) });
+      break;
+    }
     catch (e: any) {
-      if (e?.code !== "EEXIST" || Date.now() >= deadline) throw new Error(`NODE_LIFECYCLE_LOCK_TIMEOUT: ${lock}`);
+      if (e?.code !== "EEXIST") throw e;
+      let owner: LifecycleLockOwner;
+      try { owner = JSON.parse(readFileSync(lifecycleLockOwnerPath(nodeId), "utf-8")); }
+      catch (readError: any) {
+        if (readError?.code === "ENOENT") {
+          if (!missingReceiptSince) missingReceiptSince = Date.now();
+          if (Date.now() - missingReceiptSince < 250) { await new Promise(r => setTimeout(r, 10)); continue; }
+        }
+        throw new Error(`NODE_LIFECYCLE_LOCK_CORRUPT: ${lock}`);
+      }
+      if (owner.schema !== 1 || !Number.isSafeInteger(owner.pid) || !owner.birth) throw new Error(`NODE_LIFECYCLE_LOCK_CORRUPT: ${lock}`);
+      const current = processIdentitySnapshot(owner.pid);
+      if (current.kind === "gone" || (current.kind === "live" && current.birth !== owner.birth)) {
+        const claim = `${lock}.reclaim-${process.pid}-${randomUUID()}`;
+        try { renameSync(lock, claim); }
+        catch (claimError: any) {
+          if (claimError?.code === "ENOENT" || claimError?.code === "EEXIST") continue;
+          throw claimError;
+        }
+        // Only the rename winner may inspect/delete this private claim. A
+        // loser loops against the replacement public lock and can never
+        // recursively delete it (compare-delete TOCTOU).
+        let claimedOwner: LifecycleLockOwner;
+        try { claimedOwner = JSON.parse(readFileSync(join(claim, "owner.json"), "utf-8")); }
+        catch { throw new Error(`NODE_LIFECYCLE_LOCK_CLAIM_CORRUPT: ${claim}`); }
+        if (claimedOwner.pid !== owner.pid || claimedOwner.birth !== owner.birth || claimedOwner.operation !== owner.operation) {
+          throw new Error(`NODE_LIFECYCLE_LOCK_CLAIM_CHANGED: ${claim}`);
+        }
+        const claimedIdentity = processIdentitySnapshot(claimedOwner.pid);
+        if (claimedIdentity.kind === "unverifiable" || (claimedIdentity.kind === "live" && claimedIdentity.birth === claimedOwner.birth)) {
+          throw new Error(`NODE_LIFECYCLE_LOCK_CLAIM_OWNER_LIVE: pid=${claimedOwner.pid}`);
+        }
+        rmSync(claim, { recursive: true, force: true });
+        continue;
+      }
+      if (current.kind === "unverifiable") throw new Error(`NODE_LIFECYCLE_LOCK_OWNER_UNVERIFIABLE: pid=${owner.pid}`);
+      if (Date.now() >= deadline) throw new Error(`NODE_LIFECYCLE_LOCK_TIMEOUT: pid=${owner.pid} op=${owner.operation}`);
       await new Promise(r => setTimeout(r, 25));
     }
   }
@@ -5993,18 +6049,76 @@ function writeLifecycleOwner(nodeId: string, record: LifecycleOwnerRecord) {
   atomicWritePrivateJson(lifecycleOwnerPath(nodeId), record);
 }
 
-async function admitNodeStart(nodeId: string, invokedAt: number) {
-  await withLifecycleLock(nodeId, () => {
+function snapshotOwnedProcessTree(roots: readonly LifecycleProcessIdentity[]): LifecycleProcessIdentity[] {
+  const owned = new Map(roots.map(p => [p.pid, p]));
+  if (process.platform !== "linux") return [...owned.values()];
+  const verifiedAnchors = new Set<number>();
+  for (const root of roots) {
+    const current = processIdentitySnapshot(root.pid);
+    if (current.kind === "gone") continue;
+    if (current.kind === "unverifiable") throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE: pid=${root.pid}`);
+    if (current.birth === root.birth) verifiedAnchors.add(root.pid);
+  }
+  let rows: Array<{ pid: number; ppid: number }>;
+  try {
+    rows = execFileSync("ps", ["-e", "-o", "pid=", "-o", "ppid="], { encoding: "utf-8" })
+      .split("\n").map(line => line.trim().split(/\s+/).map(Number))
+      .filter(parts => parts.length === 2 && parts.every(Number.isSafeInteger))
+      .map(([pid, ppid]) => ({ pid, ppid }));
+  } catch { throw new Error("NODE_PROCESS_TREE_UNAVAILABLE"); }
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const row of rows) {
+      if (owned.has(row.pid) || !verifiedAnchors.has(row.ppid)) continue;
+      const candidate = processIdentitySnapshot(row.pid);
+      if (candidate.kind === "gone") continue;
+      if (candidate.kind === "unverifiable" || candidate.ppid === undefined) throw new Error(`NODE_DESCENDANT_BIRTH_UNAVAILABLE: pid=${row.pid}`);
+      const identity = { birth: candidate.birth, ppid: candidate.ppid };
+      // The process table row is only a candidate. Revalidate PPID and birth
+      // from one /proc read so an exited/reused PID cannot be adopted.
+      if (identity.ppid !== row.ppid || !verifiedAnchors.has(identity.ppid)) continue;
+      owned.set(row.pid, { pid: row.pid, birth: identity.birth, role: "bridge" });
+      verifiedAnchors.add(row.pid);
+      changed = true;
+    }
+  }
+  return [...owned.values()];
+}
+
+async function admitNodeStart(nodeId: string, invokedAt: number): Promise<string> {
+  return await withLifecycleLock(nodeId, () => {
     const prior = readLifecycleOwner(nodeId);
-    if (prior?.stopInvokedAt && prior.stopInvokedAt >= invokedAt) {
+    if (prior?.state === "stopping" || (prior?.stopInvokedAt && prior.stopInvokedAt >= invokedAt)) {
       throw new Error("NODE_START_CANCELLED_BY_CONCURRENT_STOP");
     }
+    const birth = processBirth(process.pid);
+    if (!birth) throw new Error("NODE_LIFECYCLE_BIRTH_UNAVAILABLE");
+    const generation = randomUUID();
     writeLifecycleOwner(nodeId, {
-      schema: 1, state: "starting", generation: randomUUID(), wrapperPid: process.pid,
-      wrapperBirth: processBirth(process.pid), startInvokedAt: invokedAt,
+      schema: 1, state: "starting", generation, wrapperPid: process.pid,
+      wrapperBirth: birth, processes: [{ pid: process.pid, birth, role: "wrapper" }], startInvokedAt: invokedAt,
       ...(prior?.stopInvokedAt ? { stopInvokedAt: prior.stopInvokedAt } : {}),
     });
-  });
+    return generation;
+  }, "start-admit");
+}
+
+async function spawnOwnedNodeChild<T extends ReturnType<typeof spawn>>(nodeId: string, generation: string, spawnChild: () => T): Promise<T> {
+  return await withLifecycleLock(nodeId, async () => {
+    const owner = readLifecycleOwner(nodeId);
+    if (!owner || owner.state !== "starting" || owner.generation !== generation) throw new Error("NODE_START_CANCELLED_BY_CONCURRENT_STOP");
+    const child = spawnChild();
+    if (!child.pid) throw new Error("NODE_CHILD_PID_MISSING");
+    let birth = processBirth(child.pid);
+    for (let i = 0; !birth && i < 10; i++) { await new Promise(r => setTimeout(r, 10)); birth = processBirth(child.pid); }
+    if (!birth) {
+      try { child.kill("SIGKILL"); } catch {}
+      throw new Error(`NODE_CHILD_BIRTH_UNAVAILABLE: pid=${child.pid}`);
+    }
+    writeLifecycleOwner(nodeId, { ...owner, processes: [...(owner.processes || []), { pid: child.pid, birth, role: "agent" }] });
+    return child;
+  }, "spawn", generation);
 }
 
 // ── start (new session) ──
@@ -6048,12 +6162,13 @@ async function startCommand() {
   // already use. Resolve first so the profile can answer the question too.
   const copresenceFlagPassed = opts.copresence === "true";
   const resolvedForCopresence = resolveNodeRef(id);
+  let startGeneration: string | undefined;
   if (copresenceFlagPassed && !resolvedForCopresence) {
     console.error(`Node "${id}" not found. Create it first: anet node create ${id}`);
     process.exit(1);
   }
   if (resolvedForCopresence) {
-    try { await admitNodeStart(resolvedForCopresence.id, startInvokedAt); }
+    try { startGeneration = await admitNodeStart(resolvedForCopresence.id, startInvokedAt); }
     catch (e: any) { console.error(`[anet] ${e?.message || e}`); process.exit(1); }
   }
   if (process.env.ANET_COPRESENCE_BRIDGE !== "1" && resolvedForCopresence
@@ -6136,7 +6251,7 @@ async function startCommand() {
 
   if (!wantTmux && !wantAcceptDevChannels) {
     // Default: spawn the agent runtime in this terminal.
-    await launchAgent(id, forceNewSession, opts.hub);
+    await launchAgent(id, forceNewSession, opts.hub, startGeneration);
     return;
   }
 
@@ -7783,12 +7898,38 @@ function findNodeProcessesByAlias(...aliases: string[]): number[] | null {
 }
 
 type StopResidual = { kind: "process" | "socket"; detail: string };
+type ProcessIdentitySnapshot =
+  | { kind: "gone" }
+  | { kind: "unverifiable"; detail: string }
+  | { kind: "live"; birth: string; ppid?: number };
 
-function processBirth(pid: number): string | null {
+function processIdentitySnapshot(pid: number): ProcessIdentitySnapshot {
   if (process.platform === "linux") {
     try {
-      const fields = readFileSync(`/proc/${pid}/stat`, "utf-8").trim().split(/\s+/);
-      return fields[21] || null;
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf-8").trim();
+      const fields = stat.slice(stat.lastIndexOf(")") + 2).split(/\s+/);
+      if (fields[0] === "Z") return { kind: "gone" };
+      const ppid = Number(fields[1]);
+      const birth = fields[19];
+      if (!Number.isSafeInteger(ppid) || !birth) return { kind: "unverifiable", detail: "malformed /proc stat" };
+      return { kind: "live", birth, ppid };
+    } catch (e: any) {
+      if (e?.code === "ENOENT" || e?.code === "ESRCH") return { kind: "gone" };
+      return { kind: "unverifiable", detail: e?.code || "proc read failed" };
+    }
+  }
+  const birth = processBirth(pid);
+  if (birth) return { kind: "live", birth };
+  return pidAlive(pid) ? { kind: "unverifiable", detail: "birth probe failed" } : { kind: "gone" };
+}
+
+function processBirth(pid: number): string | null {
+  if (process.platform === "win32") return probeWindowsCreationDate(pid);
+  if (process.platform === "linux") {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf-8").trim();
+      const fields = stat.slice(stat.lastIndexOf(")") + 2).split(/\s+/);
+      return fields[19] || null;
     } catch { return null; }
   }
   try { return execFileSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf-8" }).trim() || null; }
@@ -7813,48 +7954,39 @@ function nodeSocketResiduals(profile: Profile): StopResidual[] {
 // The child pidfile is written only after spawn, so converge on the alias-
 // bearing generation. Linux birth ticks are revalidated before every signal;
 // a recycled PID is never signalled.
-async function reapLegacyNodeGeneration(alias: string): Promise<StopResidual[]> {
-  if (process.platform === "win32") return [];
-  const scan = (): number[] | null => {
-    const agents = findNodeProcessesByAlias(alias);
-    const bridges = process.platform === "linux" ? findMcpBridgeOrphansByAlias(alias) : [];
-    if (agents === null || bridges === null) return null;
-    return [...new Set([...agents, ...bridges])];
-  };
-  const initial = scan();
-  if (initial === null) return [{ kind: "process", detail: "process table unavailable" }];
-  const owned = new Map(initial.map(pid => [pid, processBirth(pid)]));
+async function reapOwnedGeneration(owned: readonly LifecycleProcessIdentity[]): Promise<StopResidual[]> {
+  const audit = () => owned.map(identity => ({ identity, snapshot: processIdentitySnapshot(identity.pid) }));
+  const survivors = () => audit().filter(({ identity, snapshot }) =>
+    snapshot.kind === "live" && snapshot.birth === identity.birth).map(x => x.identity);
+  const unverifiable = () => audit().filter(({ snapshot }) => snapshot.kind === "unverifiable").map(x => x.identity);
   const signalOwned = (signal: NodeJS.Signals) => {
-    const current = scan();
-    if (current === null) return false;
-    for (const pid of current) {
-      const birth = processBirth(pid);
-      if (!owned.has(pid)) owned.set(pid, birth);
-      if (owned.get(pid) !== birth) continue;
-      try { process.kill(pid, signal); } catch {}
+    for (const identity of owned) {
+      // One authoritative snapshot distinguishes gone/live/unverifiable. A
+      // different birth is reuse; null is never compared to null.
+      const snapshot = processIdentitySnapshot(identity.pid);
+      if (snapshot.kind !== "live" || snapshot.birth !== identity.birth) continue;
+      try { process.kill(identity.pid, signal); } catch {}
     }
-    return true;
   };
+  const unknown = unverifiable();
+  if (unknown.length) return [{ kind: "process", detail: `birth unavailable for owned pids ${unknown.map(p => p.pid).join(",")}` }];
   signalOwned("SIGTERM");
   const termDeadline = Date.now() + 5_000;
   while (Date.now() < termDeadline) {
     await new Promise(r => setTimeout(r, 100));
-    const live = scan();
-    if (live === null) return [{ kind: "process", detail: "process table unavailable during TERM audit" }];
-    if (live.length === 0) return [];
-    signalOwned("SIGTERM");
+    const unknownNow = unverifiable();
+    if (unknownNow.length) return [{ kind: "process", detail: `birth unavailable during TERM audit for pids ${unknownNow.map(p => p.pid).join(",")}` }];
+    if (survivors().length === 0) return [];
   }
   signalOwned("SIGKILL");
   const killDeadline = Date.now() + 3_000;
   while (Date.now() < killDeadline) {
     await new Promise(r => setTimeout(r, 100));
-    const live = scan();
-    if (live === null) return [{ kind: "process", detail: "process table unavailable during KILL audit" }];
-    if (live.length === 0) return [];
-    signalOwned("SIGKILL");
+    const unknownNow = unverifiable();
+    if (unknownNow.length) return [{ kind: "process", detail: `birth unavailable during KILL audit for pids ${unknownNow.map(p => p.pid).join(",")}` }];
+    if (survivors().length === 0) return [];
   }
-  const survivors = scan();
-  return [{ kind: "process", detail: `alias-bearing pids ${(survivors || []).join(",") || "unknown"}` }];
+  return [{ kind: "process", detail: `owned generation pids ${survivors().map(p => p.pid).join(",") || "unknown"}` }];
 }
 
 // #146 GOTCHA-2 — best-effort drain before a rename restart kills the agent.
@@ -8480,16 +8612,34 @@ Stop a running agent node.
   }
 
   const displayName = nodeDisplayName(resolved.id, resolved.profile);
+  let stopGeneration = "";
+  let stopProcesses: LifecycleProcessIdentity[] = [];
   try {
     await withLifecycleLock(resolved.id, () => {
       const prior = readLifecycleOwner(resolved.id);
+      stopGeneration = prior?.generation || randomUUID();
+      let roots = prior?.processes || [];
+      if (roots.some(p => !p.birth)) throw new Error("NODE_OWNER_BIRTH_UNAVAILABLE");
+      // One-time migration for pre-receipt generations: discover by alias only
+      // while holding stop-intent, then freeze exact identities. Reaping never
+      // rescans by alias, so a later same-name generation cannot be adopted.
+      if (roots.length === 0) {
+        const legacy = findNodeProcessesByAlias(displayName);
+        if (legacy === null) throw new Error("NODE_PROCESS_TABLE_UNAVAILABLE");
+        roots = legacy.map(pid => {
+          const birth = processBirth(pid);
+          if (!birth) throw new Error(`NODE_OWNER_BIRTH_UNAVAILABLE: pid=${pid}`);
+          return { pid, birth, role: "agent" as const };
+        });
+      }
+      stopProcesses = snapshotOwnedProcessTree(roots);
       writeLifecycleOwner(resolved.id, {
-        schema: 1, state: "stopping", stopInvokedAt,
-        ...(prior?.generation ? { generation: prior.generation } : {}),
+        schema: 1, state: "stopping", stopInvokedAt, generation: stopGeneration,
         ...(prior?.wrapperPid ? { wrapperPid: prior.wrapperPid, wrapperBirth: prior.wrapperBirth } : {}),
+        processes: stopProcesses,
         ...(prior?.startInvokedAt ? { startInvokedAt: prior.startInvokedAt } : {}),
       });
-    });
+    }, "stop-intent");
   } catch (e: any) {
     console.error(`[anet] ${e?.message || e}`);
     process.exit(1);
@@ -8653,7 +8803,7 @@ Stop a running agent node.
   }
   const tmuxKilled = identityTeardownKilled || tmuxTuiKilled || tmuxAppsrvKilled || tmuxBridgeKilled;
   const generationResiduals = allowLegacyTmuxNameSweep
-    ? await reapLegacyNodeGeneration(displayName)
+    ? await reapOwnedGeneration(stopProcesses)
     : [];
   if (generationResiduals.length > 0) {
     console.error(`[anet] STOP_TIMEOUT: could not prove "${displayName}" stopped; hub was not notified offline.`);
@@ -8680,8 +8830,12 @@ Stop a running agent node.
   }
   await withLifecycleLock(resolved.id, () => {
     const owner = readLifecycleOwner(resolved.id);
+    if (!owner || owner.generation !== stopGeneration || (owner.state !== "stopping" && owner.state !== "stopped")) {
+      throw new Error("NODE_STOP_GENERATION_CHANGED");
+    }
+    if (owner.state === "stopped") return;
     writeLifecycleOwner(resolved.id, { ...(owner || { schema: 1 }), schema: 1, state: "stopped", stopInvokedAt });
-  });
+  }, "stop-complete", stopGeneration);
   const killed = stopResult.status === "stopped";
   // Always notify server — even if PID file missing, server may have stale session
   await notifyServerOffline(resolved.profile, resolved.id);

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -10,7 +10,7 @@
  * anet run                     独立 SSE Agent
  */
 
-import { chmodSync, readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync, renameSync, rmSync, cpSync, copyFileSync, unlinkSync, realpathSync } from "fs";
+import { chmodSync, readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync, lstatSync, renameSync, rmSync, cpSync, copyFileSync, unlinkSync, realpathSync } from "fs";
 import { dirname, isAbsolute, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { homedir, tmpdir } from "os";
@@ -5963,9 +5963,54 @@ async function launchAgent(id: string, forceNewSession = false, hubOverride?: st
   }
 }
 
+type LifecycleOwnerRecord = {
+  schema: 1; state: "starting" | "stopping" | "stopped";
+  generation?: string; wrapperPid?: number; wrapperBirth?: string | null;
+  startInvokedAt?: number; stopInvokedAt?: number;
+};
+
+function lifecycleOwnerPath(nodeId: string) { return join(nodesDir(), nodeId, ".lifecycle-owner.json"); }
+function lifecycleLockPath(nodeId: string) { return join(nodesDir(), nodeId, ".lifecycle-lock"); }
+
+async function withLifecycleLock<T>(nodeId: string, fn: () => T | Promise<T>): Promise<T> {
+  const lock = lifecycleLockPath(nodeId);
+  const deadline = Date.now() + 5_000;
+  while (true) {
+    try { mkdirSync(lock, { mode: 0o700 }); break; }
+    catch (e: any) {
+      if (e?.code !== "EEXIST" || Date.now() >= deadline) throw new Error(`NODE_LIFECYCLE_LOCK_TIMEOUT: ${lock}`);
+      await new Promise(r => setTimeout(r, 25));
+    }
+  }
+  try { return await fn(); } finally { rmSync(lock, { recursive: true, force: true }); }
+}
+
+function readLifecycleOwner(nodeId: string): LifecycleOwnerRecord | null {
+  try { return JSON.parse(readFileSync(lifecycleOwnerPath(nodeId), "utf-8")); } catch { return null; }
+}
+
+function writeLifecycleOwner(nodeId: string, record: LifecycleOwnerRecord) {
+  atomicWritePrivateJson(lifecycleOwnerPath(nodeId), record);
+}
+
+async function admitNodeStart(nodeId: string, invokedAt: number) {
+  await withLifecycleLock(nodeId, () => {
+    const prior = readLifecycleOwner(nodeId);
+    if (prior?.stopInvokedAt && prior.stopInvokedAt >= invokedAt) {
+      throw new Error("NODE_START_CANCELLED_BY_CONCURRENT_STOP");
+    }
+    writeLifecycleOwner(nodeId, {
+      schema: 1, state: "starting", generation: randomUUID(), wrapperPid: process.pid,
+      wrapperBirth: processBirth(process.pid), startInvokedAt: invokedAt,
+      ...(prior?.stopInvokedAt ? { stopInvokedAt: prior.stopInvokedAt } : {}),
+    });
+  });
+}
+
 // ── start (new session) ──
 
 async function startCommand() {
+  const startInvokedAt = Date.now();
   // #173 — `anet node start --all` starts every node under cwd's .anet/nodes/
   // (skip already-running, staggered, auto-resume). It delegates to the
   // `anet project up` implementation (projectUp) so the two stay in lockstep
@@ -6006,6 +6051,10 @@ async function startCommand() {
   if (copresenceFlagPassed && !resolvedForCopresence) {
     console.error(`Node "${id}" not found. Create it first: anet node create ${id}`);
     process.exit(1);
+  }
+  if (resolvedForCopresence) {
+    try { await admitNodeStart(resolvedForCopresence.id, startInvokedAt); }
+    catch (e: any) { console.error(`[anet] ${e?.message || e}`); process.exit(1); }
   }
   if (process.env.ANET_COPRESENCE_BRIDGE !== "1" && resolvedForCopresence
     && codexCopresenceRequested(copresenceFlagPassed, resolvedForCopresence.profile as any)) {
@@ -7715,7 +7764,9 @@ function findNodeProcessesByAlias(...aliases: string[]): number[] | null {
     // Without this gap-fill, rename --force on a codex-sdk or grok-build-acp
     // node that was launched via the standalone CLI (not the agent-node
     // bridge) would silently fail to find the old process.
-    const isAgentProc = tok.some(x => {
+    const isForegroundStart = tok.some((x, i) => x === "node" && tok[i + 2] === "node" && tok[i + 3] === "start")
+      || tok.some((x, i) => (x.endsWith("/anet") || x === "anet") && tok[i + 1] === "node" && tok[i + 2] === "start");
+    const isAgentProc = isForegroundStart || tok.some(x => {
       const base = x.split("/").pop() || x;
       return base === "claude" || base === "agent-node"
         || base === "codex" || base === "grok"
@@ -7725,9 +7776,85 @@ function findNodeProcessesByAlias(...aliases: string[]): number[] | null {
     if (!isAgentProc) continue;
     for (let i = 0; i < tok.length - 1; i++) {
       if ((tok[i] === "-n" || tok[i] === "--alias") && wanted.has(tok[i + 1])) { pids.add(pid); break; }
+      if (tok[i] === "start" && tok[i - 1] === "node" && wanted.has(tok[i + 1])) { pids.add(pid); break; }
     }
   }
   return [...pids];
+}
+
+type StopResidual = { kind: "process" | "socket"; detail: string };
+
+function processBirth(pid: number): string | null {
+  if (process.platform === "linux") {
+    try {
+      const fields = readFileSync(`/proc/${pid}/stat`, "utf-8").trim().split(/\s+/);
+      return fields[21] || null;
+    } catch { return null; }
+  }
+  try { return execFileSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf-8" }).trim() || null; }
+  catch { return null; }
+}
+
+function nodeSocketResiduals(profile: Profile): StopResidual[] {
+  const out: StopResidual[] = [];
+  for (const [label, path] of [["leader", profile.grokLeaderSocket], ["bridge", profile.grokAttachSocket]] as const) {
+    if (!path) continue;
+    try {
+      const st = lstatSync(path);
+      if (st.isSocket()) out.push({ kind: "socket", detail: `${label} socket ${path}` });
+    } catch (e: any) {
+      if (e?.code !== "ENOENT") out.push({ kind: "socket", detail: `${label} socket ${path} (${e?.code || "unreadable"})` });
+    }
+  }
+  return out;
+}
+
+// #1027 — the foreground start wrapper and its child are separate authorities.
+// The child pidfile is written only after spawn, so converge on the alias-
+// bearing generation. Linux birth ticks are revalidated before every signal;
+// a recycled PID is never signalled.
+async function reapLegacyNodeGeneration(alias: string): Promise<StopResidual[]> {
+  if (process.platform === "win32") return [];
+  const scan = (): number[] | null => {
+    const agents = findNodeProcessesByAlias(alias);
+    const bridges = process.platform === "linux" ? findMcpBridgeOrphansByAlias(alias) : [];
+    if (agents === null || bridges === null) return null;
+    return [...new Set([...agents, ...bridges])];
+  };
+  const initial = scan();
+  if (initial === null) return [{ kind: "process", detail: "process table unavailable" }];
+  const owned = new Map(initial.map(pid => [pid, processBirth(pid)]));
+  const signalOwned = (signal: NodeJS.Signals) => {
+    const current = scan();
+    if (current === null) return false;
+    for (const pid of current) {
+      const birth = processBirth(pid);
+      if (!owned.has(pid)) owned.set(pid, birth);
+      if (owned.get(pid) !== birth) continue;
+      try { process.kill(pid, signal); } catch {}
+    }
+    return true;
+  };
+  signalOwned("SIGTERM");
+  const termDeadline = Date.now() + 5_000;
+  while (Date.now() < termDeadline) {
+    await new Promise(r => setTimeout(r, 100));
+    const live = scan();
+    if (live === null) return [{ kind: "process", detail: "process table unavailable during TERM audit" }];
+    if (live.length === 0) return [];
+    signalOwned("SIGTERM");
+  }
+  signalOwned("SIGKILL");
+  const killDeadline = Date.now() + 3_000;
+  while (Date.now() < killDeadline) {
+    await new Promise(r => setTimeout(r, 100));
+    const live = scan();
+    if (live === null) return [{ kind: "process", detail: "process table unavailable during KILL audit" }];
+    if (live.length === 0) return [];
+    signalOwned("SIGKILL");
+  }
+  const survivors = scan();
+  return [{ kind: "process", detail: `alias-bearing pids ${(survivors || []).join(",") || "unknown"}` }];
 }
 
 // #146 GOTCHA-2 — best-effort drain before a rename restart kills the agent.
@@ -8324,7 +8451,18 @@ function clearStoppedIdentityPidFile(nodeId: string): StopNodeResult {
   return { status: "survived", pid };
 }
 
+function clearAuditedLegacyPidFile(nodeId: string): StopNodeResult {
+  const pidFile = join(nodesDir(), nodeId, ".pid");
+  if (!existsSync(pidFile)) return { status: "not-running" };
+  const pid = parseInt(readFileSync(pidFile, "utf-8").trim());
+  rmSync(pidFile, { force: true });
+  // The alias/birth audit has just proved no owned generation remains. An
+  // alive numeric PID here is therefore stale/reused, never kill authority.
+  return { status: "stopped", ...(Number.isNaN(pid) ? {} : { pid }) };
+}
+
 async function stopCommand() {
+  const stopInvokedAt = Date.now();
   const ref = args[1];
   if (!ref) {
     console.log(`
@@ -8342,6 +8480,20 @@ Stop a running agent node.
   }
 
   const displayName = nodeDisplayName(resolved.id, resolved.profile);
+  try {
+    await withLifecycleLock(resolved.id, () => {
+      const prior = readLifecycleOwner(resolved.id);
+      writeLifecycleOwner(resolved.id, {
+        schema: 1, state: "stopping", stopInvokedAt,
+        ...(prior?.generation ? { generation: prior.generation } : {}),
+        ...(prior?.wrapperPid ? { wrapperPid: prior.wrapperPid, wrapperBirth: prior.wrapperBirth } : {}),
+        ...(prior?.startInvokedAt ? { startInvokedAt: prior.startInvokedAt } : {}),
+      });
+    });
+  } catch (e: any) {
+    console.error(`[anet] ${e?.message || e}`);
+    process.exit(1);
+  }
   if (process.platform === "win32") {
     let record;
     try { record = readWindowsCopresenceRecord(nodesDir(), resolved.id); }
@@ -8356,6 +8508,10 @@ Stop a running agent node.
           console.warn(`[anet] ⚠ ${refused.process.role} pid=${refused.process.pid} was reused; leaving the unrelated process untouched`);
         }
       }
+      if (decision.refused.length > 0) {
+        console.error(`[anet] STOP_TIMEOUT: Windows ownership could not be proven; hub was not notified offline.`);
+        process.exit(1);
+      }
       for (const managedProcess of [...decision.safe].reverse()) {
         try { taskkillWindowsProcessTree(managedProcess.pid); }
         catch (e) {
@@ -8363,8 +8519,20 @@ Stop a running agent node.
           process.exit(1);
         }
       }
+      const windowsResiduals = decision.safe.filter(p => probeWindowsCreationDate(p.pid) === p.creationDate);
+      if (windowsResiduals.length > 0) {
+        console.error(`[anet] STOP_TIMEOUT: Windows managed processes survived: ${windowsResiduals.map(p => `${p.role}:${p.pid}`).join(", ")}`);
+        process.exit(1);
+      }
       rmSync(windowsCopresenceRecordPath(nodesDir(), resolved.id), { force: true });
-      await stopNode(resolved.id);
+      const pidResult = await stopNode(resolved.id);
+      if (pidResult.status === "survived") {
+        console.error(`[anet] STOP_TIMEOUT: Windows node pid ${pidResult.pid} survived; hub was not notified offline.`);
+        process.exit(1);
+      }
+      await withLifecycleLock(resolved.id, () => writeLifecycleOwner(resolved.id, {
+        ...(readLifecycleOwner(resolved.id) || { schema: 1 }), schema: 1, state: "stopped", stopInvokedAt,
+      }));
       await notifyServerOffline(resolved.profile, resolved.id);
       console.log(`[anet] Stopped "${displayName}" (Windows managed app-server + bridge, server notified)`);
       return;
@@ -8484,13 +8652,36 @@ Stop a running agent node.
     process.exit(1);
   }
   const tmuxKilled = identityTeardownKilled || tmuxTuiKilled || tmuxAppsrvKilled || tmuxBridgeKilled;
+  const generationResiduals = allowLegacyTmuxNameSweep
+    ? await reapLegacyNodeGeneration(displayName)
+    : [];
+  if (generationResiduals.length > 0) {
+    console.error(`[anet] STOP_TIMEOUT: could not prove "${displayName}" stopped; hub was not notified offline.`);
+    for (const residual of generationResiduals) console.error(`[anet]    residual ${residual.kind}: ${residual.detail}`);
+    process.exit(1);
+  }
   const stopResult = allowLegacyTmuxNameSweep
-    ? await stopNode(resolved.id)
+    ? clearAuditedLegacyPidFile(resolved.id)
     : clearStoppedIdentityPidFile(resolved.id);
   if (stopResult.status === "survived") {
     console.error(`[anet] could not confirm that "${displayName}" exited (pid ${stopResult.pid}); pidfile retained and PID was not signalled.`);
     process.exit(1);
   }
+  const socketDeadline = Date.now() + 3_000;
+  let socketResiduals = nodeSocketResiduals(resolved.profile);
+  while (socketResiduals.length > 0 && Date.now() < socketDeadline) {
+    await new Promise(r => setTimeout(r, 100));
+    socketResiduals = nodeSocketResiduals(resolved.profile);
+  }
+  if (socketResiduals.length > 0) {
+    console.error(`[anet] STOP_TIMEOUT: authoritative local resources survived for "${displayName}"; hub was not notified offline.`);
+    for (const residual of socketResiduals) console.error(`[anet]    residual ${residual.kind}: ${residual.detail}`);
+    process.exit(1);
+  }
+  await withLifecycleLock(resolved.id, () => {
+    const owner = readLifecycleOwner(resolved.id);
+    writeLifecycleOwner(resolved.id, { ...(owner || { schema: 1 }), schema: 1, state: "stopped", stopInvokedAt });
+  });
   const killed = stopResult.status === "stopped";
   // Always notify server — even if PID file missing, server may have stale session
   await notifyServerOffline(resolved.profile, resolved.id);

--- a/docs/tests/report-test225-node-stop-convergence.txt
+++ b/docs/tests/report-test225-node-stop-convergence.txt
@@ -1,6 +1,6 @@
 # test225 node-stop convergence — issue #1027
 
-base: origin/main 8840b44f (includes #1193)
+base: origin/main a2e76b1c (includes #1193)
 scope: local Docker only; no publish, production, or merge action
 
 Root cause
@@ -19,25 +19,45 @@ case in this suite preserves that exact foreground-start/background-wait shape.
 The first local Docker attempt also exposed an environment-layer failure (apt
 replaced Node 24 with unsupported Node 18); the Dockerfile was corrected before
 product assertions were accepted.
+Aggregate CI on a58590fd exposed a load-sensitive fixture race: the test edited
+the new generation receipt after a fixed 300ms sleep, while the delayed child
+spawn could subsequently publish its valid receipt over the injected
+missing-birth record. The fixture now waits for the exact wrapper generation's
+agent+birth receipt before fault injection; a different/stale receipt cannot
+satisfy readiness.
 
 Green layers
 ------------
 PASS: test225 foreground startup race converged
 PASS: stale pid did not kill concurrent node
 PASS: surviving leader socket yields typed failure without collateral kill
+PASS: leader and attach sockets are independently authoritative
+PASS: lifecycle lock recovers dead identity and refuses corrupt receipt
+PASS: dual stale-lock reclaimers serialize through one atomic claim winner
+PASS: single /proc snapshot treats exited process as gone without unverifiable race
 PASS: kill escalation is bounded and alias-owned
+PASS: stop intent rejects late start and releases alias only after completion
+PASS: birth unavailable fails closed and PID reuse is never signalled
+PASS: all three tmux resources are audited
+PASS: Windows uses creation identity and PM2 remains outside alias kill authority
+PASS: #1193 restart shares generation ownership and converges
 Summary: PASS
 
 Implementation contract
 -----------------------
-- per-node cross-process mkdir lock and generation owner receipt linearize
-  start/stop admission; a stop intent cancels an older start before spawn
+- per-node cross-process mkdir lock records holder pid, birth, operation, and
+  generation; stale recovery atomically renames to a unique claim so only one
+  reclaimer can delete it and no loser can delete a replacement lock
+- generation owner receipts are consumed by stop: stop intent freezes exact
+  pid+birth identities and descendants; reaping never dynamically adopts a
+  later same-alias process
 - stop converges wrapper, agent children, env-owned bridge children, three tmux
   sessions, and configured leader/attach sockets before notifying Hub offline
 - TERM has a bounded grace and KILL escalation; residuals return non-zero with
   typed `STOP_TIMEOUT` diagnostics
-- Linux PID birth ticks (POSIX `ps lstart` fallback) are revalidated before
-  every signal; stale/reused pidfiles never grant kill authority
+- Linux `/proc/stat` is read once per identity snapshot, atomically classifying
+  gone/zombie, live birth+ppid, or unverifiable; unavailable identity fails
+  closed and stale/reused PIDs never grant kill authority
 - Windows managed-process creation dates are revalidated after taskkill and
   refusal/residue paths do not notify Hub offline
 

--- a/docs/tests/report-test225-node-stop-convergence.txt
+++ b/docs/tests/report-test225-node-stop-convergence.txt
@@ -1,0 +1,48 @@
+# test225 node-stop convergence — issue #1027
+
+base: origin/main 8840b44f (includes #1193)
+scope: local Docker only; no publish, production, or merge action
+
+Root cause
+----------
+`anet node start` is a foreground supervisor, while `.pid` is written only
+after its asynchronous child spawn. A concurrent `node stop` could observe no
+tmux and no pidfile, report offline, and return 0; the older start then spawned
+or continued indefinitely. Stop also treated a single child PID as the whole
+authority and did not require leader/attach sockets to disappear.
+
+Witnessed red
+-------------
+Historical CI evidence is issue #1027 run 32241457013: successful stop followed
+by the same foreground wrapper PID alive beyond 60.0s. The deterministic Docker
+case in this suite preserves that exact foreground-start/background-wait shape.
+The first local Docker attempt also exposed an environment-layer failure (apt
+replaced Node 24 with unsupported Node 18); the Dockerfile was corrected before
+product assertions were accepted.
+
+Green layers
+------------
+PASS: test225 foreground startup race converged
+PASS: stale pid did not kill concurrent node
+PASS: surviving leader socket yields typed failure without collateral kill
+PASS: kill escalation is bounded and alias-owned
+Summary: PASS
+
+Implementation contract
+-----------------------
+- per-node cross-process mkdir lock and generation owner receipt linearize
+  start/stop admission; a stop intent cancels an older start before spawn
+- stop converges wrapper, agent children, env-owned bridge children, three tmux
+  sessions, and configured leader/attach sockets before notifying Hub offline
+- TERM has a bounded grace and KILL escalation; residuals return non-zero with
+  typed `STOP_TIMEOUT` diagnostics
+- Linux PID birth ticks (POSIX `ps lstart` fallback) are revalidated before
+  every signal; stale/reused pidfiles never grant kill authority
+- Windows managed-process creation dates are revalidated after taskkill and
+  refusal/residue paths do not notify Hub offline
+
+Validation
+----------
+PASS: Docker typecheck (`oven/bun:1.2.22`, `tsc --noEmit`)
+PASS: Docker convergence suite (four layers above)
+PASS: `git diff --check`

--- a/docs/tests/report-test225-node-stop-convergence.txt
+++ b/docs/tests/report-test225-node-stop-convergence.txt
@@ -46,3 +46,9 @@ Validation
 PASS: Docker typecheck (`oven/bun:1.2.22`, `tsc --noEmit`)
 PASS: Docker convergence suite (four layers above)
 PASS: `git diff --check`
+
+CI registration
+---------------
+The suite is registered in `scripts/qa.sh` L1 and both pull-request/push path
+lists in `.github/workflows/qa.yml`. Its Docker image requires a full 40-byte
+`SOURCE_COMMIT`; registration, path-sync and SHA-binding guards pass locally.

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -72,6 +72,9 @@ L1_TESTS=(
   "test1200-side-thread-command-transport"
   "test1203-btw-production-e2e"
   "test1181-codex-durable-poll"
+  # #1027: deterministic reproduction of the historical test225 foreground
+  # start/stop race plus ownership, socket-residue and KILL escalation gates.
+  "test225-node-stop-convergence"
   "qa-cli-01-hub-start"
   "qa-cli-02-network-create"
   "qa-dash-07-auth-boundary"

--- a/tests/test225-node-stop-convergence/Dockerfile
+++ b/tests/test225-node-stop-convergence/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun:1.2.22
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ procps && rm -rf /var/lib/apt/lists/*
+COPY agent-network/ agent-network/
+COPY agent-node/ agent-node/
+RUN cd agent-node && bun install --ignore-scripts && bun run build && ln -s /app/agent-node/dist/cli.js /usr/local/bin/agent-node
+RUN cd agent-network && bun install --ignore-scripts && bun run build && ln -s /app/agent-network/bin/anet.cjs /usr/local/bin/anet
+COPY tests/test225-node-stop-convergence/run.sh /app/run.sh
+RUN chmod 0755 /app/run.sh
+ENTRYPOINT ["bash", "/app/run.sh"]

--- a/tests/test225-node-stop-convergence/Dockerfile
+++ b/tests/test225-node-stop-convergence/Dockerfile
@@ -3,7 +3,7 @@ ARG SOURCE_COMMIT
 ENV TEST225_STOP_SOURCE_COMMIT=$SOURCE_COMMIT
 LABEL org.opencontainers.image.revision=$SOURCE_COMMIT
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ procps && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ procps tmux && rm -rf /var/lib/apt/lists/*
 COPY agent-network/ agent-network/
 COPY agent-node/ agent-node/
 RUN cd agent-node && bun install --ignore-scripts && bun run build && ln -s /app/agent-node/dist/cli.js /usr/local/bin/agent-node

--- a/tests/test225-node-stop-convergence/Dockerfile
+++ b/tests/test225-node-stop-convergence/Dockerfile
@@ -1,4 +1,7 @@
 FROM oven/bun:1.2.22
+ARG SOURCE_COMMIT
+ENV TEST225_STOP_SOURCE_COMMIT=$SOURCE_COMMIT
+LABEL org.opencontainers.image.revision=$SOURCE_COMMIT
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ procps && rm -rf /var/lib/apt/lists/*
 COPY agent-network/ agent-network/

--- a/tests/test225-node-stop-convergence/run.sh
+++ b/tests/test225-node-stop-convergence/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -uo pipefail
+ROOT=/tmp/test225-stop
+PROJECT="$ROOT/project"
+mkdir -p "$PROJECT/.anet/nodes/a" "$PROJECT/.anet/nodes/b"
+cd "$PROJECT"
+
+write_config() {
+  local alias=$1 socket=${2:-}
+  python3 - "$alias" "$socket" <<'PY'
+import json,os,sys
+alias,sock=sys.argv[1:]
+p={"node_id":"n_"+alias,"node_name":alias,"alias":alias,"runtime":"grok-build-acp","hub":"http://127.0.0.1:9","token":"ntok_test_"+alias,"channels":[],"env":{},"flags":{}}
+if sock: p["grokLeaderSocket"]=sock
+path=f".anet/nodes/{alias}/config.json"
+with open(path,"w") as f: json.dump(p,f)
+PY
+}
+write_config a
+write_config b
+FAKE="$ROOT/bin"; mkdir -p "$FAKE"
+cat >"$FAKE/agent-node" <<'SH'
+#!/bin/sh
+trap '' TERM INT
+while :; do sleep 1; done
+SH
+chmod +x "$FAKE/agent-node"
+export PATH="$FAKE:$PATH"
+
+fail() { echo "FAIL: $*"; exit 1; }
+pass() { echo "PASS: $*"; }
+alive() { kill -0 "$1" 2>/dev/null; }
+wait_dead() { local p=$1; for _ in $(seq 1 100); do alive "$p" || return 0; sleep .1; done; return 1; }
+
+# The historical test225 shape: foreground start in the background, then stop
+# immediately. Before #1027 this races before .pid exists, returns 0, and the
+# wrapper survives indefinitely.
+anet node start a >"$ROOT/a.log" 2>&1 & A=$!
+STOP_A=$(anet node stop a 2>&1); RC_A=$?
+[ "$RC_A" -eq 0 ] || fail "startup-race stop failed rc=$RC_A: $STOP_A"
+wait_dead "$A" || fail "foreground start wrapper survived successful stop (pid=$A)"
+pass "test225 foreground startup race converged"
+
+# Concurrent alias ownership: stopping a must not touch b. A stale pidfile
+# deliberately points at b to exercise PID-reuse/unrelated-process refusal.
+anet node start b >"$ROOT/b.log" 2>&1 & B=$!
+sleep .3
+echo "$B" >.anet/nodes/a/.pid
+anet node stop a >"$ROOT/stale.log" 2>&1 || fail "stale-pid stop failed"
+alive "$B" || { cat "$ROOT/b.log"; ps -ef; fail "stale/reused pid killed the concurrent node"; }
+pass "stale pid did not kill concurrent node"
+
+# Authoritative socket residue is a typed failure and suppresses false success.
+SOCK="$ROOT/leader.sock"
+write_config a "$SOCK"
+python3 - "$SOCK" <<'PY' &
+import socket,sys,time,os
+p=sys.argv[1]
+try: os.unlink(p)
+except FileNotFoundError: pass
+s=socket.socket(socket.AF_UNIX); s.bind(p); s.listen(); time.sleep(30)
+PY
+SOCKET_OWNER=$!
+for _ in $(seq 1 50); do [ -S "$SOCK" ] && break; sleep .05; done
+OUT=$(anet node stop a 2>&1); RC=$?
+[ "$RC" -ne 0 ] || fail "stop succeeded over surviving leader socket"
+echo "$OUT" | grep -q 'STOP_TIMEOUT' || fail "missing typed timeout: $OUT"
+alive "$SOCKET_OWNER" || fail "stop killed an unowned socket process"
+pass "surviving leader socket yields typed failure without collateral kill"
+kill "$SOCKET_OWNER" 2>/dev/null || true; wait "$SOCKET_OWNER" 2>/dev/null || true; rm -f "$SOCK"
+
+# Kill escalation and restart: a TERM-resistant agent-node is reaped, then a
+# fresh generation can start and stop without affecting b.
+anet node start a >"$ROOT/a-resistant.log" 2>&1 & R=$!
+sleep .3
+anet node stop a >"$ROOT/escalate.log" 2>&1 || fail "kill escalation failed"
+wait_dead "$R" || fail "TERM-resistant wrapper survived KILL escalation"
+alive "$B" || fail "concurrent b died during a escalation"
+pass "kill escalation is bounded and alias-owned"
+
+anet node stop b >"$ROOT/b-stop.log" 2>&1 || fail "final b stop failed"
+wait_dead "$B" || fail "b wrapper survived final stop"
+echo "Summary: PASS"

--- a/tests/test225-node-stop-convergence/run.sh
+++ b/tests/test225-node-stop-convergence/run.sh
@@ -10,12 +10,13 @@ mkdir -p "$PROJECT/.anet/nodes/a" "$PROJECT/.anet/nodes/b"
 cd "$PROJECT"
 
 write_config() {
-  local alias=$1 socket=${2:-}
-  python3 - "$alias" "$socket" <<'PY'
+  local alias=$1 socket=${2:-} attach=${3:-}
+  python3 - "$alias" "$socket" "$attach" <<'PY'
 import json,os,sys
-alias,sock=sys.argv[1:]
+alias,sock,attach=sys.argv[1:]
 p={"node_id":"n_"+alias,"node_name":alias,"alias":alias,"runtime":"grok-build-acp","hub":"http://127.0.0.1:9","token":"ntok_test_"+alias,"channels":[],"env":{},"flags":{}}
 if sock: p["grokLeaderSocket"]=sock
+if attach: p["grokAttachSocket"]=attach
 path=f".anet/nodes/{alias}/config.json"
 with open(path,"w") as f: json.dump(p,f)
 PY
@@ -72,6 +73,69 @@ echo "$OUT" | grep -q 'STOP_TIMEOUT' || fail "missing typed timeout: $OUT"
 alive "$SOCKET_OWNER" || fail "stop killed an unowned socket process"
 pass "surviving leader socket yields typed failure without collateral kill"
 kill "$SOCKET_OWNER" 2>/dev/null || true; wait "$SOCKET_OWNER" 2>/dev/null || true; rm -f "$SOCK"
+anet node stop a >"$ROOT/socket-retry.log" 2>&1 || fail "stop retry after socket cleanup failed"
+
+ATTACH="$ROOT/attach.sock"
+write_config a "" "$ATTACH"
+python3 - "$ATTACH" <<'PY' &
+import socket,sys,time,os
+p=sys.argv[1]
+try: os.unlink(p)
+except FileNotFoundError: pass
+s=socket.socket(socket.AF_UNIX); s.bind(p); s.listen(); time.sleep(30)
+PY
+ATTACH_OWNER=$!
+for _ in $(seq 1 50); do [ -S "$ATTACH" ] && break; sleep .05; done
+OUT=$(anet node stop a 2>&1); RC=$?
+[ "$RC" -ne 0 ] || fail "stop succeeded over surviving attach socket"
+alive "$ATTACH_OWNER" || fail "stop killed unowned attach socket process"
+kill "$ATTACH_OWNER" 2>/dev/null || true; wait "$ATTACH_OWNER" 2>/dev/null || true; rm -f "$ATTACH"
+anet node stop a >"$ROOT/attach-retry.log" 2>&1 || fail "stop retry after attach cleanup failed"
+write_config a
+pass "leader and attach sockets are independently authoritative"
+
+# Lock recovery is identity based: a dead holder may be reclaimed, while a
+# corrupt receipt is never guessed away.
+mkdir -p .anet/nodes/a/.lifecycle-lock
+printf '%s\n' '{"schema":1,"pid":999999,"birth":"dead","operation":"crashed"}' >.anet/nodes/a/.lifecycle-lock/owner.json
+anet node stop a >"$ROOT/dead-lock-1.log" 2>&1 & RECLAIM_1=$!
+anet node stop a >"$ROOT/dead-lock-2.log" 2>&1 & RECLAIM_2=$!
+wait "$RECLAIM_1" || { cat "$ROOT/dead-lock-1.log"; fail "first stale-lock reclaimer failed"; }
+wait "$RECLAIM_2" || { cat "$ROOT/dead-lock-2.log"; fail "second stale-lock reclaimer deleted replacement or failed"; }
+[ ! -d .anet/nodes/a/.lifecycle-lock ] || fail "public lifecycle lock survived dual reclamation"
+mkdir -p .anet/nodes/a/.lifecycle-lock
+printf '%s\n' '{corrupt' >.anet/nodes/a/.lifecycle-lock/owner.json
+OUT=$(anet node stop a 2>&1); RC=$?
+[ "$RC" -ne 0 ] || fail "corrupt lifecycle lock was silently stolen"
+echo "$OUT" | grep -q NODE_LIFECYCLE_LOCK_CORRUPT || fail "corrupt lock lacked typed failure: $OUT"
+rm -rf .anet/nodes/a/.lifecycle-lock
+pass "lifecycle lock recovers dead identity and refuses corrupt receipt"
+
+# Deterministic exit-window fixture: a zombie still answers kill(0), but one
+# /proc stat snapshot identifies it as already gone. The parent must remain
+# untouched and stop must not misreport birth-unavailable.
+python3 - "$ROOT/zombie.pid" <<'PY' &
+import os,sys,time
+pid=os.fork()
+if pid == 0: os._exit(0)
+open(sys.argv[1],'w').write(str(pid))
+time.sleep(20)
+PY
+ZOMBIE_PARENT=$!
+for _ in $(seq 1 50); do [ -s "$ROOT/zombie.pid" ] && break; sleep .02; done
+ZOMBIE=$(cat "$ROOT/zombie.pid")
+ZBIRTH=$(awk '{print $22}' "/proc/$ZOMBIE/stat")
+python3 - "$ZOMBIE" "$ZBIRTH" <<'PY'
+import json,sys
+p='.anet/nodes/a/.lifecycle-owner.json'
+with open(p) as f: r=json.load(f)
+r.update(state='starting',generation='zombie-exit-window',processes=[{'pid':int(sys.argv[1]),'birth':sys.argv[2],'role':'agent'}])
+with open(p,'w') as f: json.dump(r,f)
+PY
+anet node stop a >"$ROOT/zombie-stop.log" 2>&1 || { cat "$ROOT/zombie-stop.log"; fail "atomic exit-window audit rejected an already-dead process"; }
+alive "$ZOMBIE_PARENT" || fail "zombie fixture parent was collateral damage"
+kill "$ZOMBIE_PARENT" 2>/dev/null || true; wait "$ZOMBIE_PARENT" 2>/dev/null || true
+pass "single /proc snapshot treats exited process as gone without unverifiable race"
 
 # Kill escalation and restart: a TERM-resistant agent-node is reaped, then a
 # fresh generation can start and stop without affecting b.
@@ -81,6 +145,98 @@ anet node stop a >"$ROOT/escalate.log" 2>&1 || fail "kill escalation failed"
 wait_dead "$R" || fail "TERM-resistant wrapper survived KILL escalation"
 alive "$B" || fail "concurrent b died during a escalation"
 pass "kill escalation is bounded and alias-owned"
+
+# Freeze the generation at stop intent. TERM resistance holds stop open long
+# enough for a newer same-alias start to race; it must be rejected, while a
+# fresh generation after completion must survive normally.
+anet node start a >"$ROOT/a-old.log" 2>&1 & OLD=$!
+sleep .3
+alive "$OLD" || { cat "$ROOT/a-old.log"; fail "old generation did not start"; }
+anet node stop a >"$ROOT/a-old-stop.log" 2>&1 & STOPPER=$!
+for _ in $(seq 1 100); do grep -Eq '"state"[[:space:]]*:[[:space:]]*"stopping"' .anet/nodes/a/.lifecycle-owner.json 2>/dev/null && break; sleep .05; done
+alive "$STOPPER" || { cat "$ROOT/a-old-stop.log"; fail "stop completed before late-start fault injection"; }
+OUT=$(anet node start a 2>&1); RC=$?
+[ "$RC" -ne 0 ] || fail "late newer start was admitted during stop intent"
+echo "$OUT" | grep -q NODE_START_CANCELLED_BY_CONCURRENT_STOP || fail "late start lacked typed refusal: $OUT"
+wait "$STOPPER" || { cat "$ROOT/a-old-stop.log"; fail "old generation stop failed"; }
+wait_dead "$OLD" || fail "old generation survived"
+anet node start a >"$ROOT/a-new.log" 2>&1 & NEW=$!
+NEW_READY=0
+for _ in $(seq 1 200); do
+  if python3 - "$NEW" <<'PY' 2>/dev/null
+import json,sys
+r=json.load(open('.anet/nodes/a/.lifecycle-owner.json'))
+assert r.get('wrapperPid') == int(sys.argv[1])
+assert any(p.get('role') == 'agent' and p.get('birth') for p in r.get('processes', []))
+PY
+  then NEW_READY=1; break; fi
+  sleep .05
+done
+[ "$NEW_READY" -eq 1 ] || { cat "$ROOT/a-new.log"; fail "new generation owner receipt did not reach agent-owned state"; }
+alive "$NEW" || { cat "$ROOT/a-new.log"; fail "new generation after completed stop did not start"; }
+pass "stop intent rejects late start and releases alias only after completion"
+
+# Receipt identities are fail-closed. A missing birth refuses to signal; a
+# mismatched birth proves PID reuse and leaves that unrelated process alone.
+python3 - "$B" <<'PY'
+import json,sys
+p='.anet/nodes/a/.lifecycle-owner.json'; pid=int(sys.argv[1])
+with open(p) as f: r=json.load(f)
+r.update(state='starting',generation='fault-null',processes=[{'pid':pid,'role':'agent'}])
+with open(p,'w') as f: json.dump(r,f)
+PY
+OUT=$(anet node stop a 2>&1); RC=$?
+[ "$RC" -ne 0 ] || fail "missing receipt birth authorized stop"
+alive "$B" || fail "missing birth killed unrelated pid"
+python3 - "$B" <<'PY'
+import json,sys
+p='.anet/nodes/a/.lifecycle-owner.json'; pid=int(sys.argv[1])
+with open(p) as f: r=json.load(f)
+r.update(state='starting',generation='fault-reuse',processes=[{'pid':pid,'birth':'definitely-not-current','role':'agent'}])
+with open(p,'w') as f: json.dump(r,f)
+PY
+anet node stop a >"$ROOT/reuse.log" 2>&1 || fail "PID-reuse receipt did not converge as original generation gone"
+alive "$B" || fail "PID-reused unrelated process was killed"
+pass "birth unavailable fails closed and PID reuse is never signalled"
+
+# Ordinary RFC-030 ownership still includes all three tmux resources.
+for session in a a-appsrv a-桥; do tmux new-session -d -s "$session" 'sleep 30'; done
+anet node stop a >"$ROOT/tmux3.log" 2>&1 || fail "three-session teardown failed"
+for session in a a-appsrv a-桥; do tmux has-session -t "=$session" 2>/dev/null && fail "tmux session survived: $session"; done
+pass "all three tmux resources are audited"
+
+# Portable boundaries: Windows uses CreationDate as its birth identity (the
+# native execution remains test751's responsibility), and stop has no PM2
+# name-based kill authority.
+grep -q 'process.platform === "win32") return probeWindowsCreationDate(pid)' /app/agent-network/bin/cli.ts \
+  || fail "Windows lifecycle birth is not CreationDate-backed"
+if sed -n '/async function stopCommand()/,/^\/\/ ── project/p' /app/agent-network/bin/cli.ts | grep -Eqi 'pm2 (delete|kill|stop)'; then
+  fail "node stop gained PM2 name-based kill authority"
+fi
+pass "Windows uses creation identity and PM2 remains outside alias kill authority"
+
+# Restore and stop the real new generation; the fault receipts above must not
+# have allowed any old stop to dynamically adopt it.
+alive "$NEW" || fail "new generation was killed by an old/fault stop"
+python3 - "$NEW" <<'PY'
+import json,sys
+p='.anet/nodes/a/.lifecycle-owner.json'; pid=int(sys.argv[1])
+birth=open(f'/proc/{pid}/stat').read().split()[21]
+with open(p) as f: r=json.load(f)
+r.update(state='starting',generation='restored-new',wrapperPid=pid,wrapperBirth=birth,processes=[{'pid':pid,'birth':birth,'role':'wrapper'}])
+with open(p,'w') as f: json.dump(r,f)
+PY
+anet node stop a >"$ROOT/a-new-stop.log" 2>&1 || fail "restored new generation stop failed"
+wait_dead "$NEW" || fail "new generation survived its own stop"
+
+# #1193 compatibility: the restart verb must pass through the same admission
+# and produce a generation that an ordinary stop can converge.
+anet node restart a >"$ROOT/restart.log" 2>&1 & RESTARTER=$!
+for _ in $(seq 1 100); do grep -Eq '"role"[[:space:]]*:[[:space:]]*"agent"' .anet/nodes/a/.lifecycle-owner.json 2>/dev/null && break; sleep .05; done
+alive "$RESTARTER" || { cat "$ROOT/restart.log"; fail "restart did not launch a live generation"; }
+anet node stop a >"$ROOT/restart-stop.log" 2>&1 || fail "stop after restart failed"
+wait_dead "$RESTARTER" || fail "restart wrapper survived stop"
+pass "#1193 restart shares generation ownership and converges"
 
 anet node stop b >"$ROOT/b-stop.log" 2>&1 || fail "final b stop failed"
 wait_dead "$B" || fail "b wrapper survived final stop"

--- a/tests/test225-node-stop-convergence/run.sh
+++ b/tests/test225-node-stop-convergence/run.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -uo pipefail
+[[ "${TEST225_STOP_SOURCE_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "FAIL: TEST225_STOP_SOURCE_COMMIT must be one full lowercase Git SHA" >&2
+  exit 1
+}
 ROOT=/tmp/test225-stop
 PROJECT="$ROOT/project"
 mkdir -p "$PROJECT/.anet/nodes/a" "$PROJECT/.anet/nodes/b"


### PR DESCRIPTION
## Outcome

Fixes the `node stop` false-success race from #1027 without publishing or merging.

- adds a per-node generation owner receipt and cross-process lifecycle lock
- makes an older concurrent start observe stop intent before spawning
- converges foreground wrapper, agent/bridge children, three tmux sessions, and leader/attach sockets
- uses bounded TERM/KILL escalation and typed `STOP_TIMEOUT` residual diagnostics
- revalidates PID birth identity; stale/reused pidfiles never grant signal authority
- preserves Windows creation-date ownership checks and fails closed on residue

## Root cause

`.pid` was created only after asynchronous child spawn. A stop racing a foreground start could see neither tmux nor pidfile, notify Hub offline, and return 0; the already-invoked start then spawned or remained alive. Success also did not require socket/bridge resources to disappear.

## Docker evidence

- typecheck: PASS
- deterministic test225 foreground race: PASS
- stale PID / concurrent node: PASS
- surviving leader socket typed failure: PASS
- TERM-resistant kill escalation + restart: PASS
- `git diff --check`: PASS

Full report: `docs/tests/report-test225-node-stop-convergence.txt`.

Draft only. Do not merge until review and CI complete.