### PR TITLE
docs(skillhub): add public seed skills

### DIFF
--- a/docs-site/docs/en/skillhub/contribute.md
+++ b/docs-site/docs/en/skillhub/contribute.md
@@ -28,7 +28,20 @@ Private publication does not mean public publication.
    └── SKILL.md
    ```
 
-5. Run `node scripts/build-public-skillhub.mjs`, commit the source files and updated `catalog.json`, and open a pull request.
+5. From `docs-site/`, validate and regenerate the catalog:
+
+   ```bash
+   npm run skillhub:build
+   npm run skillhub:check
+   ```
+
+   Commit the source files and updated `docs/public/skillhub/catalog.json`, then
+   open a pull request.
+
+The PR should name the added or updated `slug@version`, license, public source,
+and local `skillhub:check` result. Public maintainers review reusability,
+license, privacy, and safety with `public-skill-review-checklist` from the
+public catalog.
 
 Updates use a new version instead of replacing already published content.
 

--- a/docs-site/docs/en/skillhub/index.md
+++ b/docs-site/docs/en/skillhub/index.md
@@ -9,7 +9,15 @@ This catalog contains `SKILL.md` files that passed a second public repository re
 It is isolated from every private Dashboard SkillHub: publishing inside a network never
 makes a skill public or exposes node identity, network metadata, or private review records.
 
+Public SkillHub is also a static registry. `/skillhub/catalog.json` lists each
+public skill's `slug`, `version`, license, publisher, tags, `content_sha256`,
+and `content_url`. Tools can read the catalog, download the pinned `SKILL.md`
+through `content_url`, and verify the content with SHA-256.
+
+Published versions are immutable. Content corrections should use a new version.
+The build regenerates the catalog, and `skillhub:check` rejects stale or
+manually edited catalog output.
+
 [How to contribute a public skill →](/en/skillhub/contribute)
 
 <PublicSkillHub lang="en" />
-

--- a/docs-site/docs/public/skillhub/catalog.json
+++ b/docs-site/docs/public/skillhub/catalog.json
@@ -4,6 +4,46 @@
   "skills": [
     {
       "schema_version": 1,
+      "slug": "content-search-before-pr",
+      "name": "Content search before PR",
+      "description": "Check for overlapping work by changed identifiers instead of shared author identity.",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "publisher": {
+        "name": "Agent Network maintainers",
+        "url": "https://github.com/sleep2agi/agent-network"
+      },
+      "tags": [
+        "github",
+        "review",
+        "coordination"
+      ],
+      "published_at": "2026-08-26",
+      "content_sha256": "240f8f75d56f88b2595abd6351f5f774f6886993cc98c4139be2946ccd617593",
+      "content_url": "/skillhub/skills/content-search-before-pr/1.0.0/SKILL.md"
+    },
+    {
+      "schema_version": 1,
+      "slug": "invariant-denominator-check",
+      "name": "Invariant denominator check",
+      "description": "Verify that a correct count is measuring the intended object, not a broader or narrower set.",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "publisher": {
+        "name": "Agent Network maintainers",
+        "url": "https://github.com/sleep2agi/agent-network"
+      },
+      "tags": [
+        "analysis",
+        "testing",
+        "review"
+      ],
+      "published_at": "2026-08-26",
+      "content_sha256": "bcab7db153908a0372af0ca4f2942893b6f76d57edc1bb5ed791e0d8ab74d9a5",
+      "content_url": "/skillhub/skills/invariant-denominator-check/1.0.0/SKILL.md"
+    },
+    {
+      "schema_version": 1,
       "slug": "public-skill-review-checklist",
       "name": "Public skill review checklist",
       "description": "Safe promotion checklist from private SkillHub to the public catalog.",
@@ -41,6 +81,46 @@
       "published_at": "2026-08-08",
       "content_sha256": "d452b0bd216f97f3b1c36c1c1c71f0c03d7b4516dcba591663143b3ab023e639",
       "content_url": "/skillhub/skills/skill-writing-guide/1.0.0/SKILL.md"
+    },
+    {
+      "schema_version": 1,
+      "slug": "stop-chain-discipline",
+      "name": "Stop-chain discipline",
+      "description": "Stop acknowledgement loops when a message contains no new reading, action, or question.",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "publisher": {
+        "name": "Agent Network maintainers",
+        "url": "https://github.com/sleep2agi/agent-network"
+      },
+      "tags": [
+        "communication",
+        "coordination",
+        "safety"
+      ],
+      "published_at": "2026-08-26",
+      "content_sha256": "3068ad5ba9d00246e2283b08221f6eec98a24f98132a275012f787706b365562",
+      "content_url": "/skillhub/skills/stop-chain-discipline/1.0.0/SKILL.md"
+    },
+    {
+      "schema_version": 1,
+      "slug": "witnessed-red-regression-gate",
+      "name": "Witnessed red regression gate",
+      "description": "Prove a test or guard fails for the intended reason before accepting the green result.",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "publisher": {
+        "name": "Agent Network maintainers",
+        "url": "https://github.com/sleep2agi/agent-network"
+      },
+      "tags": [
+        "testing",
+        "regression",
+        "review"
+      ],
+      "published_at": "2026-08-26",
+      "content_sha256": "25af0f736a9a6caebb00e84ead97b0f32d2317cc8cd48949aef5564f78e206f4",
+      "content_url": "/skillhub/skills/witnessed-red-regression-gate/1.0.0/SKILL.md"
     }
   ]
 }

--- a/docs-site/docs/public/skillhub/skills/content-search-before-pr/1.0.0/SKILL.md
+++ b/docs-site/docs/public/skillhub/skills/content-search-before-pr/1.0.0/SKILL.md
@@ -1,0 +1,42 @@
+# Content search before PR
+
+Use this workflow before opening a pull request in a shared repository where
+multiple agents may use the same GitHub account or automation identity.
+
+## Search by identifiers
+
+Do not rely on author filters to find overlapping work when several agents can
+share one account. Search by the content that two independent implementations
+would both touch:
+
+1. file names;
+2. function, class, command, or constant names;
+3. route names, test suite names, or public option names.
+
+Example:
+
+```bash
+gh pr list --repo <owner>/<repo> --state all --search "<identifier>"
+```
+
+Choose identifiers from the actual diff, not from a prose description of the
+task. Two agents may describe the same work differently, but the touched
+identifier is often the same.
+
+## Record the result
+
+Add one line to the PR body:
+
+```text
+Content search: <identifier> => <hits or zero hits>
+```
+
+Zero hits must be written down too. Otherwise "I searched and found nothing"
+and "I did not search" look the same during review.
+
+## Reconcile hits
+
+If a hit exists, open it before pushing ahead. Decide whether the new PR should
+reuse, replace, split, or close against that work. Link the related PR or issue
+so reviewers can verify the decision.
+

--- a/docs-site/docs/public/skillhub/skills/content-search-before-pr/1.0.0/metadata.json
+++ b/docs-site/docs/public/skillhub/skills/content-search-before-pr/1.0.0/metadata.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "slug": "content-search-before-pr",
+  "name": "Content search before PR",
+  "description": "Check for overlapping work by changed identifiers instead of shared author identity.",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "publisher": {
+    "name": "Agent Network maintainers",
+    "url": "https://github.com/sleep2agi/agent-network"
+  },
+  "tags": [
+    "github",
+    "review",
+    "coordination"
+  ],
+  "published_at": "2026-08-26"
+}

--- a/docs-site/docs/public/skillhub/skills/invariant-denominator-check/1.0.0/SKILL.md
+++ b/docs-site/docs/public/skillhub/skills/invariant-denominator-check/1.0.0/SKILL.md
@@ -1,0 +1,48 @@
+# Invariant denominator check
+
+Use this workflow when a result is a count, ratio, percentage, coverage number,
+or pass/fail total.
+
+## Name the measured object
+
+Before trusting the number, write the object being counted:
+
+```text
+numerator: <what increments the count>
+denominator: <the complete set it is divided by or compared against>
+scope: <repo, network, account, runtime, date range, or file set>
+```
+
+A number can be arithmetically correct and still answer the wrong question.
+
+## Check same-value traps
+
+Look for cases where two different states produce the same output:
+
+1. not checked vs checked and zero;
+2. no data vs data unavailable;
+3. no matching item vs matching item hidden by permissions;
+4. all targets passed vs only a subset ran;
+5. same author account vs same human or agent.
+
+If two states share one value, add a separate field, log line, or exit code to
+make them distinguishable.
+
+## Verify the denominator
+
+Use an independent listing command for the denominator before interpreting the
+result. Examples include a file list, account list, test inventory, task list,
+or PR search result. Record the command when the denominator is part of the
+claim.
+
+## Report with scope
+
+Phrase the result with its denominator:
+
+```text
+41/41 checks passed for <exact suite>
+```
+
+Do not shorten it to "all checks passed" unless the exact universe of checks is
+obvious from the same sentence.
+

--- a/docs-site/docs/public/skillhub/skills/invariant-denominator-check/1.0.0/metadata.json
+++ b/docs-site/docs/public/skillhub/skills/invariant-denominator-check/1.0.0/metadata.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "slug": "invariant-denominator-check",
+  "name": "Invariant denominator check",
+  "description": "Verify that a correct count is measuring the intended object, not a broader or narrower set.",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "publisher": {
+    "name": "Agent Network maintainers",
+    "url": "https://github.com/sleep2agi/agent-network"
+  },
+  "tags": [
+    "analysis",
+    "testing",
+    "review"
+  ],
+  "published_at": "2026-08-26"
+}

--- a/docs-site/docs/public/skillhub/skills/stop-chain-discipline/1.0.0/SKILL.md
+++ b/docs-site/docs/public/skillhub/skills/stop-chain-discipline/1.0.0/SKILL.md
@@ -1,0 +1,37 @@
+# Stop-chain discipline
+
+Use this workflow when an agent receives a message whose only content is an
+acknowledgement, closure note, or confirmation of a previous confirmation.
+
+## Classify the message
+
+Remove quoted or forwarded context and inspect the new content. Continue the
+conversation only if it contains at least one of:
+
+1. a new reading;
+2. a new action taken;
+3. a new question;
+4. a correction to a previous fact;
+5. a required handoff or escalation.
+
+If none are present, the message is a terminal confirmation.
+
+## Stop without losing state
+
+Do not reply to a terminal confirmation. Record locally that it was seen and
+intentionally not answered. This separates "not replied because no reply was
+needed" from "not seen".
+
+## Keep future messages bounded
+
+When forwarding a result or linking a parent task, include message IDs or
+artifact IDs instead of embedding the full previous body. IDs stay bounded;
+quoted bodies grow with each hop.
+
+## Sender rule
+
+When sending a message whose conclusion is that the receiver has no action,
+state that no reply is required at the start of the message. The sender knows
+whether a reply is needed, and making that explicit prevents unnecessary work
+on the receiver side.
+

--- a/docs-site/docs/public/skillhub/skills/stop-chain-discipline/1.0.0/metadata.json
+++ b/docs-site/docs/public/skillhub/skills/stop-chain-discipline/1.0.0/metadata.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "slug": "stop-chain-discipline",
+  "name": "Stop-chain discipline",
+  "description": "Stop acknowledgement loops when a message contains no new reading, action, or question.",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "publisher": {
+    "name": "Agent Network maintainers",
+    "url": "https://github.com/sleep2agi/agent-network"
+  },
+  "tags": [
+    "communication",
+    "coordination",
+    "safety"
+  ],
+  "published_at": "2026-08-26"
+}

--- a/docs-site/docs/public/skillhub/skills/witnessed-red-regression-gate/1.0.0/SKILL.md
+++ b/docs-site/docs/public/skillhub/skills/witnessed-red-regression-gate/1.0.0/SKILL.md
@@ -1,0 +1,36 @@
+# Witnessed red regression gate
+
+Use this workflow when a change adds or repairs a test, validator, CI gate, or
+runtime guard.
+
+## Decide the failure being guarded
+
+Name the exact bad state the guard must catch. The bad state should be
+observable from command output, an exit code, a response field, or a persisted
+artifact.
+
+## Capture the red
+
+Run the guard against an input or code state that still contains the defect.
+Record:
+
+1. the command;
+2. the non-zero exit code or failed assertion;
+3. the output line that proves it failed for the intended reason.
+
+If the command fails for setup, missing dependencies, timeout, or unrelated
+noise, that is not witnessed red. Fix the harness first.
+
+## Capture the green
+
+Apply the minimal fix, rerun the same guard, and record the passing command.
+The green result is meaningful only when it is paired with the witnessed red
+from the same behavior.
+
+## Preserve the evidence
+
+Put the red and green commands in the PR body, test report, or review note. If
+the evidence is too large, link to the artifact and quote only the decisive
+line. Do not use "tests pass" as evidence for a behavior the tests did not
+observe.
+

--- a/docs-site/docs/public/skillhub/skills/witnessed-red-regression-gate/1.0.0/metadata.json
+++ b/docs-site/docs/public/skillhub/skills/witnessed-red-regression-gate/1.0.0/metadata.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "slug": "witnessed-red-regression-gate",
+  "name": "Witnessed red regression gate",
+  "description": "Prove a test or guard fails for the intended reason before accepting the green result.",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "publisher": {
+    "name": "Agent Network maintainers",
+    "url": "https://github.com/sleep2agi/agent-network"
+  },
+  "tags": [
+    "testing",
+    "regression",
+    "review"
+  ],
+  "published_at": "2026-08-26"
+}

--- a/docs-site/docs/skillhub/contribute.md
+++ b/docs-site/docs/skillhub/contribute.md
@@ -27,9 +27,20 @@ description: 从私有 SkillHub 导出并向 anet.sh 公共目录投稿。
    └── SKILL.md
    ```
 
-5. 运行 `node scripts/build-public-skillhub.mjs`，提交源文件与更新后的 `catalog.json`，然后发起 Pull Request。
+5. 在 `docs-site/` 目录运行校验并重新生成 catalog：
 
-公共维护者会检查可复用性、许可证、隐私和安全边界。修改已公开内容时必须发布新版本，不得覆盖原版本。
+   ```bash
+   npm run skillhub:build
+   npm run skillhub:check
+   ```
+
+   提交源文件与更新后的 `docs/public/skillhub/catalog.json`，然后发起 Pull Request。
+
+PR 里应写明新增或更新的 `slug@version`、许可证、公开来源，以及本地
+`skillhub:check` 的结果。公共维护者会用公开 catalog 中的
+`public-skill-review-checklist` 复核可复用性、许可证、隐私和安全边界。
+
+修改已公开内容时必须发布新版本，不得覆盖原版本。
 
 ## 不会上传的内容
 

--- a/docs-site/docs/skillhub/index.md
+++ b/docs-site/docs/skillhub/index.md
@@ -8,7 +8,14 @@ description: 经二次审核、任何人都可读取和下载的 Agent Network S
 这里展示经过公共仓库二次审核的 `SKILL.md`。它与私有 Dashboard 的
 网络内 SkillHub 相互隔离：网络内发布不会自动公开，也不会把节点身份、网络信息或审核记录带到这里。
 
+公共 SkillHub 同时也是静态注册表：`/skillhub/catalog.json` 列出每个公开
+Skill 的 `slug`、`version`、许可证、发布者、标签、`content_sha256` 和
+`content_url`。工具可以读取 catalog，再按 `content_url` 下载固定版本的
+`SKILL.md`，并用 SHA-256 校验内容。
+
+公开版本不可原地覆盖；内容修订应发布新版本。构建时会重新生成 catalog，
+`skillhub:check` 会拒绝过期或手工改写的 catalog。
+
 [如何投稿公共 Skill →](/skillhub/contribute)
 
 <PublicSkillHub lang="zh" />
-

--- a/tests/test831-doc-source-pins/run.sh
+++ b/tests/test831-doc-source-pins/run.sh
@@ -12,7 +12,11 @@ set -euo pipefail
 #    （同一个 job 名、同样没有断言输出），最容易被当成"哪里真的坏了"去查。
 first_md_under() {
   local _list
-  _list=$(find "$1" -name '*.md' | sort)
+  _list=$(find "$1" \
+    -path '*/node_modules/*' -prune -o \
+    -path '*/.vitepress/cache/*' -prune -o \
+    -path '*/.vitepress/dist/*' -prune -o \
+    -name '*.md' -print | sort)
   [ -n "$_list" ] || { echo "FAIL: $1 下一个 .md 都没有 —— 夹具取集塌了" >&2; exit 1; }
   printf '%s' "${_list%%$'\n'*}"
 }
@@ -121,12 +125,24 @@ broken=$(printf '%s' "$out" | sed -nE 's/^broken_pins=([0-9]+)$/\1/p')
 #     docs/tests/report-test1178-codex-upgrade-recovery.txt
 # 它没有新增源码行号 pin，所以仍然只有 files 增加，uniq=11、occ=28 不变。
 #
-# 抬的是**分母**(111 > 110),覆盖面变大不是变小。反过来那种「把数改小让门变绿」
+# 2026-08-26:111 → 119。公共 SkillHub 新增 4 个 reviewed seed skills,
+# 每个版本包含一个 SKILL.md 与一个 metadata.json:
+#     docs-site/docs/public/skillhub/skills/content-search-before-pr/1.0.0/SKILL.md
+#     docs-site/docs/public/skillhub/skills/content-search-before-pr/1.0.0/metadata.json
+#     docs-site/docs/public/skillhub/skills/invariant-denominator-check/1.0.0/SKILL.md
+#     docs-site/docs/public/skillhub/skills/invariant-denominator-check/1.0.0/metadata.json
+#     docs-site/docs/public/skillhub/skills/stop-chain-discipline/1.0.0/SKILL.md
+#     docs-site/docs/public/skillhub/skills/stop-chain-discipline/1.0.0/metadata.json
+#     docs-site/docs/public/skillhub/skills/witnessed-red-regression-gate/1.0.0/SKILL.md
+#     docs-site/docs/public/skillhub/skills/witnessed-red-regression-gate/1.0.0/metadata.json
+# 这些是 public catalog 的源文件,不是 .vitepress/dist 构建产物;所以分母应抬升。
+#
+# 抬的是**分母**(119 > 111),覆盖面变大不是变小。反过来那种「把数改小让门变绿」
 # 的动作要当红线看:分母变小意味着有文件被移出取集,而假绿和真绿的输出逐字相同。
-[[ "$files" -eq 111 ]] || fail "预期扫 111 个文档文件(= git ls-files 的结果),实际 $files"
+[[ "$files" -eq 119 ]] || fail "预期扫 119 个文档文件(= git ls-files 的结果),实际 $files"
 [[ "$uniq"  -eq 11  ]] || fail "预期 11 个唯一 pin,实际 $uniq"
 [[ "$occ"   -eq 28 ]] || fail "预期 28 处原始出现,实际 $occ"
-echo "  OK  walk 路径与 git 路径给出同一份清单(111 文件 / 11 唯一 pin / 28 处)"
+echo "  OK  walk 路径与 git 路径给出同一份清单(119 文件 / 11 唯一 pin / 28 处)"
 
 # ---------------------------------------------------------------------------
 # L1 — 干净树上必须绿


### PR DESCRIPTION
## Summary

- add 4 reviewed public SkillHub seed skills:
  - `content-search-before-pr@1.0.0`
  - `invariant-denominator-check@1.0.0`
  - `stop-chain-discipline@1.0.0`
  - `witnessed-red-regression-gate@1.0.0`
- regenerate the public SkillHub catalog from 2 entries to 6 entries
- document that public SkillHub is a static machine-readable registry, not only a docs page
- tighten the contribution guide with `skillhub:build` / `skillhub:check` validation commands
- update test831 doc source-pin denominator from 111 to 119 for the 8 new public SkillHub source files and keep its fixture selection out of generated `.vitepress/dist`

## Coordination

- Does not edit `docs-site/docs/.vitepress/config.ts`.
- Main already includes PR #1226 (`11277f54`) for the SkillHub navigation layer.

## Validation

- `npm run skillhub:check` => `public-skillhub: PASS (6 entries, catalog current)`
- `npm run build` => passed; VitePress emitted the existing chunk-size warning only
- `sg docker -c "docker build ... tests/test831-doc-source-pins/Dockerfile . && docker run --rm --network none anet-test831-doc-source-pins"` => `RESULT: PASS`, `scanned_doc_files=119`

Closes #1219
