### PR TITLE
docs(daemon): cross-reference deploy/ authority and derive min_uptime from failure time

### DIFF
--- a/deploy/fleet/README.md
+++ b/deploy/fleet/README.md
@@ -214,3 +214,8 @@ weixin。**这正是那次加固要防的事,而加固没有部署。**
 这次的变异测试没提供什么信息:基线**本来就是红的**,人为改坏之后还是 `rc=1`,
 两次输出区分不出来。**真正验到判据的是那条 fail-closed**:把 `HOME` 指向一个空目录,
 `checked=0 drift=0 missing=4 → exit 2`,而不是「干净」。
+
+## 相关
+
+面向用户的进程守护说明见文档站 [部署 / 让 Hub 常驻](https://anet.sh/deploy/daemon)；
+本目录是它引用的 **Git 权威**（systemd user unit + 军团启动链）。

--- a/deploy/hub/README.md
+++ b/deploy/hub/README.md
@@ -1,5 +1,8 @@
 # 生产 Hub 换版本
 
+> 面向用户的守护说明（PM2 入口、`min_uptime` 怎么定、自动恢复四项验证）在文档站
+> [部署 / 让 Hub 常驻](https://anet.sh/deploy/daemon)。本目录是那一页所引用的 **Git 权威**。
+
 对应 `AGENTS.md` §19。与 `deploy/dashboard/` 同一套「固化安装 + 指针切换」模式,
 但 Hub 是**全网唯一**的,所以每一步的代价更高。
 

--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -85,8 +85,10 @@ module.exports = {
 };
 ```
 
-文件名必须是 `*.config.js`、`*.json` 或 `*.yaml`。PM2 会把普通 `.cjs`
-文件当脚本执行，界面可能显示 `online`，但 Hub 根本没有监听。
+文件名要让 PM2 认出这是**配置**而不是**脚本**：`*.config.js`、`*.config.cjs`、
+`*.json`、`*.yaml` 都可以（本仓 `deploy/` 下用的就是 `ecosystem.config.cjs`）。
+若文件名不匹配这些形态，PM2 会把它当普通脚本执行，界面可能显示 `online`，
+但 Hub 根本没有监听。
 
 启动并核验：
 
@@ -97,6 +99,41 @@ curl -fsS http://127.0.0.1:9200/health
 ```
 
 不要只看 PM2 的绿色状态；`/health` 才证明服务真的响应。
+
+## 本仓的权威配置在 `deploy/`
+
+上面的示例是通用起点。本仓生产环境实际在用的那一份已经在仓里，不需要照着手抄：
+
+- [`deploy/hub/ecosystem.config.cjs`](https://github.com/sleep2agi/agent-network/blob/main/deploy/hub/ecosystem.config.cjs) — Hub 的 PM2 进程定义（不含密钥）
+- [`deploy/hub/hub-daemon.sh`](https://github.com/sleep2agi/agent-network/blob/main/deploy/hub/hub-daemon.sh) — 被守护的启动脚本，四道 fail-closed 预检（bun / 固化安装 / vault 密钥 / 端口占用）
+- [`deploy/fleet/`](https://github.com/sleep2agi/agent-network/blob/main/deploy/fleet) — 开机自启的 systemd **user** unit 与军团启动链
+- [`deploy/hub/README.md`](https://github.com/sleep2agi/agent-network/blob/main/deploy/hub/README.md) — Hub 换版本流程（已演练）
+
+生产机 `~/.local/bin/` 下的是**部署副本**，Git 权威在 `deploy/`。两边要一起改，
+漂移用 [`deploy/check-deployed-copies.sh`](https://github.com/sleep2agi/agent-network/blob/main/deploy/check-deployed-copies.sh) 检。
+
+## `min_uptime` 按「失败退出耗时」定，不是按感觉定
+
+规则：`min_uptime` 必须**大于**一次失败启动走到退出所需的时间。小于它，PM2 会把这次
+失败当成「启动成功」——`max_restarts` 不累加、`exp_backoff_restart_delay` 不触发，
+于是崩溃循环看起来就是正常重启。
+
+**怎么算这个时间**：看被守护脚本失败路径上的固定延时。`hub-daemon.sh` 的预检失败走
+`fail_slow()`，它 `sleep 30` 之后 `exit 1`，所以失败退出耗时约 30 秒 ⇒ 守它的
+`min_uptime` 必须大于 `30000`。守裸 `anet hub start` 时失败退出通常快得多，
+所以本页示例用的 `45000` 对两种入口都够。
+
+实测（`node:22-bookworm-slim` 容器里的 PM2，同一个「30 秒后失败退出」的脚本，
+观察 100 秒约 3 个周期）：
+
+| `min_uptime` | `restarts` | `unstable restarts` |
+|---|---|---|
+| `20000` | 3 | **0** ← 退避从不触发 |
+| `45000` | 3 | 3 |
+
+`unstable restarts` 停在 0，就是这道保护已经失效的读数：PM2 认为每次都启动成功了。
+所以核对守护配置时要看这个字段，不要只看 `restarts`。（本仓当前取值的复核见
+[#1223](https://github.com/sleep2agi/agent-network/issues/1223)。）
 
 ## 安全边界
 
@@ -155,3 +192,4 @@ curl -fsS http://127.0.0.1:9200/health
 - [生产部署 / 公网部署安全](/deploy/production)
 - [升级指南](/guide/upgrade)
 - [故障排查](/troubleshooting)
+- [`deploy/` — 本仓部署资产的 Git 权威](https://github.com/sleep2agi/agent-network/blob/main/deploy)

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -93,8 +93,11 @@ module.exports = {
 };
 ```
 
-The filename must end in `*.config.js`, `*.json`, or `*.yaml`. PM2 may execute a
-plain `.cjs` file as a script, show it as `online`, and never start the Hub.
+The filename has to let PM2 recognise the file as a **config** rather than a
+**script**: `*.config.js`, `*.config.cjs`, `*.json`, and `*.yaml` all work (the
+files under `deploy/` in this repo are named `ecosystem.config.cjs`). A name that
+matches none of those shapes is executed as a plain script — PM2 may show it as
+`online` and never start the Hub.
 
 Start and verify it:
 
@@ -105,6 +108,47 @@ curl -fsS http://127.0.0.1:9200/health
 ```
 
 Do not treat PM2's green status as proof; `/health` proves that the service responds.
+
+## This repo's authoritative config lives in `deploy/`
+
+The example above is a generic starting point. The configuration this project
+actually runs in production is already committed — there is no need to retype it:
+
+- [`deploy/hub/ecosystem.config.cjs`](https://github.com/sleep2agi/agent-network/blob/main/deploy/hub/ecosystem.config.cjs) — the Hub's PM2 process definition (no secrets)
+- [`deploy/hub/hub-daemon.sh`](https://github.com/sleep2agi/agent-network/blob/main/deploy/hub/hub-daemon.sh) — the guarded launcher, with four fail-closed prechecks (bun / pinned install / vault key / port already listening)
+- [`deploy/fleet/`](https://github.com/sleep2agi/agent-network/blob/main/deploy/fleet) — the systemd **user** units and the fleet boot chain
+- [`deploy/hub/README.md`](https://github.com/sleep2agi/agent-network/blob/main/deploy/hub/README.md) — the Hub version-switch procedure (rehearsed)
+
+What sits in `~/.local/bin/` on the production host is a **deployed copy**; the Git
+authority is `deploy/`. Change both together, and check for drift with
+[`deploy/check-deployed-copies.sh`](https://github.com/sleep2agi/agent-network/blob/main/deploy/check-deployed-copies.sh).
+
+## Derive `min_uptime` from how long a failing start takes to exit
+
+The rule: `min_uptime` must be **greater** than the time a failing start needs to
+reach its exit. Set it lower and PM2 records the failure as a successful start —
+`max_restarts` never accumulates, `exp_backoff_restart_delay` never engages, and a
+crash loop looks like ordinary restarts.
+
+**How to obtain that number**: read the fixed delays on the guarded script's failure
+path. `hub-daemon.sh` routes every failed precheck through `fail_slow()`, which
+sleeps 30 seconds and then exits 1 — so a failing start takes about 30 seconds, and
+anything guarding it needs `min_uptime` above `30000`. A bare `anet hub start`
+usually fails much faster, so the `45000` used in the example above clears both
+entry points.
+
+Measured (PM2 inside a `node:22-bookworm-slim` container, the same "exit 1 after 30
+seconds" script, observed for 100 seconds — roughly three cycles):
+
+| `min_uptime` | `restarts` | `unstable restarts` |
+|---|---|---|
+| `20000` | 3 | **0** — backoff never engages |
+| `45000` | 3 | 3 |
+
+An `unstable restarts` stuck at 0 is the reading that says this protection is
+already inert: PM2 believes every start succeeded. Check that field when reviewing a
+supervisor config — `restarts` alone will not tell you. (The review of this repo's
+current value is tracked in [#1223](https://github.com/sleep2agi/agent-network/issues/1223).)
 
 ## Security boundaries
 
@@ -165,3 +209,4 @@ unclear, stop and identify which supervisor controls the Hub first.
 - [Production and public-internet security](/en/deploy/production)
 - [Upgrade guide](/en/guide/upgrade)
 - [Troubleshooting](/en/troubleshooting)
+- [`deploy/` — the Git authority for this repo's deployment assets](https://github.com/sleep2agi/agent-network/blob/main/deploy)


### PR DESCRIPTION
Step 1 of the daemon lane laid out in #1223 — the zero-behavior-change half.

The guide (`docs-site/docs/deploy/daemon.md`) and the deployment assets this project actually runs (`deploy/`) never referenced each other. A reader following the guide hand-writes an ecosystem config while a battle-calibrated one is already committed. Both language versions now point at `deploy/`, and `deploy/hub/README.md` + `deploy/fleet/README.md` point back.

## Two corrections that came from measuring, not from reading

### 1. `min_uptime` — the guide stated the rule but not how to obtain the number

The rule was already there: `min_uptime` must exceed how long a *failing* start takes to exit, or PM2 records the failure as a successful start and backoff never engages. What was missing is how to compute it for a given entry point.

`hub-daemon.sh` routes every failed precheck through `fail_slow()`, which sleeps 30s then `exit 1` — so a failing start takes ~30s, and anything guarding it needs `min_uptime` above `30000`.

Measured with PM2 in a `node:22-bookworm-slim` container, against the same "exit 1 after 30 seconds" script, observed for 100s (~3 cycles):

| `min_uptime` | `restarts` | `unstable restarts` |
|---|---|---|
| `20000` | 3 | **0** — backoff never engages |
| `45000` | 3 | 3 |

`unstable restarts` stuck at 0 is the reading that says the protection is already inert — PM2 believes every start succeeded, so `max_restarts` never accumulates. The guide now names that field, because `restarts` alone does not distinguish the two cases.

🔴 **This PR changes no config.** Reviewing this repo's own committed value against that threshold is tracked separately in #1223 and will come as its own PR — "make the failure visible" first, "make it not happen" second.

### 2. The `.cjs` claim was wrong in a way that would make people rename working files

The guide said PM2 executes a `.cjs` file as a script and that the filename must be `*.config.js` / `.json` / `.yaml`. The same container run used `eco-prod.config.cjs` and PM2 read it as a **config** (it created the app and counted restarts). So `*.config.cjs` is fine — which matters, because every ecosystem file under `deploy/` is named exactly that. Rewritten to describe the config-vs-script distinction instead of listing extensions.

## Verification

- `cd docs-site && ./node_modules/.bin/vitepress build docs` ⇒ exit **0**.
- 🔴 That green does **not** cover the links added here — they are external (GitHub blob URLs, `anet.sh`), and VitePress only checks internal links. So each was fetched directly: all 7 return **200** (5 blob URLs, the `deploy/` directory URL, and `https://anet.sh/deploy/daemon`).
- ZH 157 → 195 lines, EN 167 → 212; both gained the same two sections and the same "相关/Related" entry.

## Dedup

- By content: `gh pr list --state all --search "min_uptime"` ⇒ #912 / #738 / #897 / #480, all **MERGED**, none open.
- By changed files: scanned **19** open PRs for overlap with `deploy/daemon.md`, `deploy/hub/`, `deploy/fleet/README.md` ⇒ **zero overlap**.

(Searching PR text alone would not be enough — it only finds identifiers the other author happened to write down, which is why the file-overlap pass is here too.)

Zero behavior change: documentation and READMEs only.
