### PR TITLE
fix(deploy): hub min_uptime 20s sits below its own 30s failure path, so backoff never engages

### DIFF
--- a/deploy/hub/ecosystem.config.cjs
+++ b/deploy/hub/ecosystem.config.cjs
@@ -12,7 +12,22 @@ module.exports = {
       interpreter: "bash",
       exec_mode: "fork",
       autorestart: true,
-      min_uptime: 20_000,
+      // min_uptime 必须大于「进程失败退出所需时间」。低于它，PM2 会把这次启动
+      // 算成功、不计入失败，backoff 永不触发 —— 崩溃循环看起来像正常重启。
+      //
+      // 🔴 这里原本是 20_000，而 hub-daemon.sh 的每一条预检失败都走 fail_slow()：
+      //    `sleep 30` 之后才 `exit 1`，所以一次失败启动要 ~30 秒才退出。20_000 < 30s
+      //    ⇒ 这道保护是死的。容器里拿真 PM2 对同一个「30 秒后失败退出」脚本实测
+      //    （100 秒，约 3 个周期）：
+      //      min_uptime=20000 → restarts 3, unstable restarts 【0】← 退避从不触发
+      //      min_uptime=45000 → restarts 3, unstable restarts  3
+      //    unstable restarts 停在 0 = PM2 认为每次都启动成功，max_restarts: 20
+      //    永远累加不上。核对时要看这个字段，只看 restarts 两种情况长得一样。
+      //
+      //    deploy/dashboard/ecosystem.config.cjs 早已因同一原因从 20_000 对齐到
+      //    45000（dash-start.sh 的失败路径同样是 sleep 30），当时漏了 hub 这份 ——
+      //    而 hub 是全网单点。这里补上。
+      min_uptime: 45_000,
       max_restarts: 20,
       exp_backoff_restart_delay: 200,
     },


### PR DESCRIPTION
🔴 **This file is the Git authority for a production process definition. Merging it needs confirmation from whoever deploys the Hub** — opening the PR makes the reading reviewable; it does not deploy anything.

## The defect

`hub-daemon.sh` routes **every** failed precheck (missing bun / missing pinned install / missing vault key / port already listening) through `fail_slow()`, which sleeps 30 seconds and then `exit 1`.

PM2 only counts a restart as *unstable* when the process dies **sooner** than `min_uptime`. With `min_uptime: 20_000`, a start that fails at ~30s looks like a **successful** start:

- `max_restarts: 20` never accumulates
- `exp_backoff_restart_delay: 200` never engages
- a Hub failing every precheck restarts at full speed, while `pm2` reports it `online` and merely "restarted a few times"

So the protection was inert — and the panel did not say "unknown", it said "fine".

## Measured, not inferred

PM2 in a `node:22-bookworm-slim` container, same "exit 1 after 30 seconds" script, observed 100s (~3 cycles), real values:

| `min_uptime` | `restarts` | `unstable restarts` |
|---|---|---|
| `20000` | 3 | **0** — backoff never engages |
| `45000` | 3 | 3 |

`unstable restarts` stuck at 0 is the reading that distinguishes the two cases. `restarts` alone is identical in both, which is why this survived.

## This is not a new rule — it is an existing one that was applied unevenly

`deploy/dashboard/ecosystem.config.cjs` **already** moved from `20_000` to `45000` for exactly this reason, and its comment says so:

> `min_uptime` 必须大于「进程失败退出所需时间」…… 这里原本是 20_000，比 `docs-site/docs/deploy/daemon.md` 记录的 45000 小，照本仓重建出来的 dashboard 会正好落进那个盲区。对齐到 45000。

`dash-start.sh` has the same `sleep 30` failure path. The Hub was missed at the time — and the Hub is the single point for the whole network, so it is the one where this matters most.

Swept `deploy/` for other instances: only these two `min_uptime` values exist, and both are now `45000`.

## Verification

- `node -e "require('./deploy/hub/ecosystem.config.cjs')"` parses; `min_uptime=45000`, `max_restarts=20` — and 45000 > 30000, the failure-path duration it has to clear.
- The derivation is written into the comment so a later edit does not quietly lower it again.

## Merge order

#1230 (documentation: states the criterion and names `unstable restarts` as the field to check) should land **first** — "make the failure visible" before "make it not happen". If this config change went in alone and the threshold were still wrong somewhere else, nothing would report it.

## Dedup

- By content: `gh pr list --state all --search "min_uptime"` ⇒ #912 / #738 / #897 / #480, all MERGED, none open.
- By changed files: scanned open PRs for `deploy/hub/` ⇒ zero overlap.

Refs #1223.
