### PR TITLE
fix(anet): #1227 修的不是实际生效的那处；而且转译不够，要打包 (#1216 续)

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -5306,7 +5306,16 @@ function ensureMcpJson(profile: Profile) {
   for (const p of candidates) {
     if (existsSync(p)) {
       mkdirSync(anetDir, { recursive: true });
-      const src = readFileSync(p, "utf-8");
+      // 🔴 issue #1216, second writer. The candidate list below falls back to
+      // `.ts` sources (a source checkout has no dist/), and the target is
+      // always `.js` — bun picks its parser from the extension, so copying
+      // verbatim produced a file that could not be parsed. #1227 fixed the
+      // *other* resolver in this same file (`refreshNodeServerJsAt`); that one
+      // only runs for `grok-build-acp`, so this path — which serves
+      // claude-code-cli, codex-sdk and grok-build-cli — kept writing
+      // TypeScript and kept failing three layers later as
+      // "CommHub MCP readiness preflight failed (1)".
+      const src = nodeServerPayloadFor(readFileSync(p, "utf-8"), p, ambientTypeScriptTranspiler());
       const dst = existsSync(serverTs) ? readFileSync(serverTs, "utf-8") : "";
       if (src !== dst) {
         writeFileSync(serverTs, src);

--- a/agent-network/src/node-server-payload.test.ts
+++ b/agent-network/src/node-server-payload.test.ts
@@ -16,14 +16,28 @@ describe("nodeServerPayloadFor", () => {
     expect(nodeServerPayloadFor(compiled, "/pkg/dist/src/node-server.js", null)).toBe(compiled);
   });
 
-  test("🔴 transpiles a .ts source, because the target extension makes types a parse error", () => {
-    const out = nodeServerPayloadFor(TS_SOURCE, "/repo/src/node-server.ts", ambientTypeScriptTranspiler());
-    expect(out).not.toContain(": string");
-    expect(out).not.toContain(": void");
-    expect(out).toContain("loadEnvFile");
-  });
+  test("🔴 bundles a .ts source — types stripped AND relative imports inlined", async () => {
+    // Both halves matter. Stripping types alone left `import "./channel-meta.js"`
+    // pointing at a sibling that does not exist beside the destination, and the
+    // node still died on "CommHub MCP readiness preflight failed (1)".
+    const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const root = mkdtempSync(join(tmpdir(), "nsp-bundle-"));
+    try {
+      writeFileSync(join(root, "sibling.ts"), 'export const MARK: string = "from-sibling";\n');
+      const entry = join(root, "entry.ts");
+      writeFileSync(entry, 'import { MARK } from "./sibling";\nfunction f(x: string): void { console.log(MARK, x); }\nf("hi");\n');
+      const out = nodeServerPayloadFor("unused", entry, ambientTypeScriptTranspiler());
+      expect(out).not.toContain(": string");
+      expect(out).toContain("from-sibling");        // 兄弟模块被内联了
+      expect(out).not.toContain('from "./sibling"'); // 相对 import 没有留下
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 30_000);
 
-  test("🔴 refuses a .ts source when no transpiler exists, instead of writing a doomed file", () => {
+  test("🔴 refuses a .ts source when it cannot bundle, instead of writing a doomed file", () => {
     // Writing it anyway is what issue #1216 was: the file landed, the node
     // started, and died three layers later on "CommHub MCP readiness preflight
     // failed (1)" — a message naming neither the file nor the reason.
@@ -43,7 +57,7 @@ describe("nodeServerPayloadFor", () => {
     expect(message).toContain("dist/src/node-server.js");
   });
 
-  test("only the .ts extension triggers transpilation, not the word appearing in the path", () => {
+  test("only the .ts extension triggers bundling, not the word appearing in the path", () => {
     // A directory called `.../typescript/` or a file `node-server.tsx.js`
     // must not be mistaken for a TypeScript source.
     const js = "const x=1;\n";
@@ -96,7 +110,9 @@ describe("the bug this module exists to prevent", () => {
     const root = mkdtempSync(join(tmpdir(), "node-server-payload-fixed-"));
     try {
       const target = join(root, "payload.js");
-      writeFileSync(target, nodeServerPayloadFor(TS_SOURCE, "/repo/src/node-server.ts", ambientTypeScriptTranspiler()));
+      const entry = join(root, "entry.ts");
+      writeFileSync(entry, TS_SOURCE);
+      writeFileSync(target, nodeServerPayloadFor("unused", entry, ambientTypeScriptTranspiler()));
       const proc = Bun.spawn(["bun", target], { stdout: "pipe", stderr: "pipe" });
       const [code, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
       expect(code, stderr).toBe(0);

--- a/agent-network/src/node-server-payload.ts
+++ b/agent-network/src/node-server-payload.ts
@@ -26,9 +26,10 @@
  * neither a file nor a parse error.
  */
 
-/** Minimal shape of the transpiler this module needs; injected so it is testable. */
-export interface TypeScriptTranspiler {
-  transformSync(source: string): string;
+/** Injected so the decision is testable without spawning anything. */
+export interface TypeScriptBundler {
+  /** Returns the self-contained JavaScript for `entryPath`, or throws. */
+  bundleSync(entryPath: string): string;
 }
 
 export class NodeServerPayloadError extends Error {
@@ -41,41 +42,69 @@ export class NodeServerPayloadError extends Error {
 /**
  * Decide what bytes belong at the `.js` target for a given source path.
  *
- * A `.js` source is passed through untouched — it is already what the target
- * expects, and re-processing a compiled bundle risks changing it for no gain.
- * A `.ts` source must be transpiled, because the destination extension makes
- * type syntax a parse error rather than something the runtime ignores.
+ * A `.js` source is passed through untouched — the published package ships a
+ * compiled bundle there, and re-processing it risks changing bytes for no gain.
+ *
+ * 🔴 A `.ts` source must be **bundled, not merely transpiled**. Stripping types
+ * fixes the parse error but leaves the file's relative imports pointing at
+ * siblings that do not exist beside the destination:
+ *
+ *     import { inboundChannelMeta } from "./channel-meta.js";
+ *     → Cannot find module './channel-meta.js' from '<project>/.anet/node-server.js'
+ *
+ * That second failure is why transpiling alone still ended at
+ * "CommHub MCP readiness preflight failed (1)". The published
+ * `dist/src/node-server.js` works precisely because it is a self-contained
+ * bundle, so a source checkout has to produce the same shape.
  */
 export function nodeServerPayloadFor(
   source: string,
   sourcePath: string,
-  transpiler: TypeScriptTranspiler | null,
+  bundler: TypeScriptBundler | null,
 ): string {
   if (!sourcePath.endsWith(".ts")) return source;
-  if (!transpiler) {
-    // 🔴 Refuse rather than write a file that is certain to fail at spawn
-    // time. Writing it "and letting the runtime complain" is what produced the
-    // unreadable MCP-readiness failure this module is named after: the error
-    // surfaced in a different process, three layers up, naming neither the
-    // file nor the reason.
+  if (!bundler) {
+    // Refuse rather than write a file that is certain to fail at spawn time.
+    // Writing it "and letting the runtime complain" is what issue #1216 was:
+    // the error surfaced in another process, three layers up, naming neither
+    // the file nor the reason.
     throw new NodeServerPayloadError(
       `cannot generate the .anet/node-server.js payload from the TypeScript source at ${sourcePath}: `
-      + `this runtime has no TypeScript transpiler. Build the package first `
+      + `this runtime cannot bundle. Build the package first `
       + `(\`bun run build\` in agent-network produces dist/src/node-server.js), or run the CLI under bun.`,
     );
   }
-  return transpiler.transformSync(source);
+  return bundler.bundleSync(sourcePath);
 }
 
 /**
- * The transpiler available on this runtime, or null.
+ * The bundler available on this runtime, or null.
  *
- * bun exposes one; the published CLI runs under node and does not — but the
- * published CLI also never resolves a `.ts` candidate, so null there is
+ * bun can bundle; the published CLI runs under node and cannot — but it also
+ * never resolves a `.ts` candidate (its `dist/` copy wins), so null there is
  * correct rather than a gap.
+ *
+ * `spawnSync` rather than `Bun.build()` because both call sites are
+ * synchronous, and making them async would change the ordering of the file
+ * writes around them.
  */
-export function ambientTypeScriptTranspiler(): TypeScriptTranspiler | null {
-  const bun = (globalThis as { Bun?: { Transpiler?: new (opts: { loader: string }) => TypeScriptTranspiler } }).Bun;
-  if (!bun?.Transpiler) return null;
-  return new bun.Transpiler({ loader: "ts" });
+export function ambientTypeScriptTranspiler(): TypeScriptBundler | null {
+  const bun = (globalThis as { Bun?: { spawnSync?: unknown } }).Bun;
+  if (!bun?.spawnSync) return null;
+  return {
+    bundleSync(entryPath: string): string {
+      const spawnSync = (bun as { spawnSync: (cmd: string[], opts?: unknown) => { exitCode: number; stdout: Uint8Array; stderr: Uint8Array } }).spawnSync;
+      const result = spawnSync(["bun", "build", entryPath, "--target", "bun"], { stdout: "pipe", stderr: "pipe" });
+      if (result.exitCode !== 0) {
+        throw new NodeServerPayloadError(
+          `bundling ${entryPath} failed: ${new TextDecoder().decode(result.stderr).trim() || `exit ${result.exitCode}`}`,
+        );
+      }
+      const out = new TextDecoder().decode(result.stdout);
+      if (!out.trim()) {
+        throw new NodeServerPayloadError(`bundling ${entryPath} produced no output`);
+      }
+      return out;
+    },
+  };
 }


### PR DESCRIPTION
## 我上一个 PR 修错了地方，这里如实写清楚

#1227（**已合入 main**）修的是 `refreshNodeServerJsAt`。它是**真 bug**，但**不是 `grok-build-cli` 走的那条路**。

合完之后我做端到端复验，生成的 `.anet/node-server.js` 仍然是 **29858 B / 3 处 TS 标注 / 3 处语法错误**，和修之前 **md5 逐字节相同**。

### 第一处错：同一个文件里有**两份**写 node-server.js 的实现

```
1795-1830  findBundledNodeServerJs + refreshNodeServerJsAt   ← #1227 修的
           只在 runtime === "grok-build-acp" 时调用

5286-5322  另一份内联实现，自带候选表                        ← 实际生效的
           条件是 claude-code-cli | codex-sdk | grok-build-cli
```

本 PR 把第二处也接到同一个模块上。

### 第二处错：只转译不够，必须**打包**

把 TS 转译成 JS 之后，文件仍然起不来：

```
Cannot find module './channel-meta.js' from '<proj>/.anet/node-server.js'
```

`node-server.ts` 有 **6 个相对 import**（`channel-meta` / `outbound-tool-names` / `commhub-response` / `project-key` / `owner-env-file` / `channel-task-trace`），单文件拷到 `.anet/` 之后兄弟模块根本不在那儿。

发布的 `dist/src/node-server.js` 之所以能用，是因为它是**自包含打包产物**。

⇒ 模块改成 `bundleSync`（`Bun.spawnSync` 跑 `bun build --target bun`；用 spawnSync 而不是 `Bun.build()` 是因为两个调用点都是同步的，改成 async 会改变它们周围写文件的顺序）。

🔴 **有一条变异专门守这一格**：把 `bun build` 改成 `--no-bundle`（即只转译）⇒ **7 pass 1 fail**。也就是说这组测试**本来就能抓住我第一版那个不完整的修复**。

## 端到端验证（隔离 scratch hub + 真 `anet node create`，不碰生产）

**修之前：**
```
❌ the grok leader did not open .../attach.sock within 45s
   node-server.js 29858 B / TS 标注 3 行 / 语法错误 3 处
```

**修之后：**
```
✅ [anet] ① node READY — attach socket live at .../attach.sock
✅ [anet] ② TUI tmux=grok-e3 ready to attach
✅ 节点在 scratch hub 上注册成功(sessions=1 sse=1)
   node-server.js 533135 B / 语法错误 0 / 缺模块 0 / MCP stdio connected
```

TUI 进程随后退出是因为夹具**没有 grok 登录凭据** —— **anet 能控制的那一整段全通了**，这一点我不夸大成"grok 共存已可用"。

## 其余验证

`agent-network` **615 pass / 0 fail**；`bun tsc --noEmit` 干净。

见证红：

```
不看扩展名一律原样   4 pass  4 fail
没打包器也不报错     6 pass  2 fail
只转译不打包         7 pass  1 fail  ← 守住"转译≠打包"这一格
```

## 为什么值得记这一笔

#1227 的教训不是"我不小心漏了一处"，而是：**一句错话在同一个文件里有两份实现，我修掉的那份是读代码时先看到的那份，而不是实际会被执行的那份。** 只有端到端跑一遍才把它暴露出来 —— 单元测试全绿、CI 97/97 全绿，都没有发现修的是不生效的那处。

Refs #1216