### PR TITLE
fix(#1237): 漂移门拼错了 public/ 的地址,且从不采样产物文件（附一处对 issue 机制描述的更正）

### DIFF
--- a/.github/scripts/check-docs-site-drift.py
+++ b/.github/scripts/check-docs-site-drift.py
@@ -42,6 +42,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
@@ -56,10 +57,70 @@ TIMEOUT = 25
 
 
 def md_to_url(rel: str) -> str:
-    u = "/" + rel[: -len(".md")]
-    if u.endswith("/index"):
-        u = u[: -len("index")]
-    return u or "/"
+    """`docs-site/docs` 下的相对路径 → 站点上的地址。
+
+    🔴 `docs/public/` 是 VitePress 的**静态资源根**:发布时剥掉 `public/`
+    这一段,**并且保留原扩展名**(`…/SKILL.md` 就是 `…/SKILL.md`,不是 `…/SKILL`)。
+    原来这里对所有路径一律走「去掉末尾 3 个字符」,于是:
+
+        public/skillhub/skills/x/1.0.0/SKILL.md → /public/skillhub/…/SKILL   ← 多了 /public、丢了 .md
+        public/skillhub/catalog.json            → /public/skillhub/catalog.j ← 把 "son" 也切掉了
+
+    第二种是无条件的垃圾地址 —— 因为切长度写死成 `len(".md")`,
+    对任何非 `.md` 的产物文件都会砍掉三个字符。
+    """
+    if rel.startswith("public/"):
+        return "/" + rel[len("public/"):]
+    if rel.endswith(".md"):
+        u = "/" + rel[: -len(".md")]
+        if u.endswith("/index"):
+            u = u[: -len("index")]
+        return u or "/"
+    return "/" + rel
+
+
+# 产物类文件:不是 markdown,判据也不是「指纹出现在渲染后的页面里」。
+# 🔴 覆盖面缺口:`recent_docs()` 原来只收 `.md`,而 `catalog.json` 不是 `.md`
+# ⇒ skillhub 目录漂移(线上 2 条 / main 6 条)**从来不在这道门的判据里**。
+ARTIFACT_NAMES = ("catalog.json",)
+ARTIFACT_LIMIT = 4
+
+
+def recent_artifacts(limit: int = ARTIFACT_LIMIT) -> list[str]:
+    """最近改动过的**产物类**文件(相对 docs-site/docs)。
+
+    单独给预算,不跟 markdown 抢 `SAMPLE_LIMIT` —— 扩覆盖面不能以缩小另一半为代价。
+    """
+    out = subprocess.run(
+        ["git", "log", "-n", "80", "--name-only", "--pretty=format:", "--", "docs-site/docs"],
+        capture_output=True, text=True,
+    ).stdout
+    seen: list[str] = []
+    for line in out.split("\n"):
+        line = line.strip()
+        if not line.startswith("docs-site/docs/"):
+            continue
+        rel = line[len("docs-site/docs/"):]
+        if Path(rel).name not in ARTIFACT_NAMES or rel in seen:
+            continue
+        if not (DOCS / rel).exists():
+            continue
+        seen.append(rel)
+        if len(seen) >= limit:
+            break
+    return seen
+
+
+def catalog_entries(payload) -> list[str]:
+    """catalog.json → 条目名列表(两种可能的外形都收)。"""
+    items = payload if isinstance(payload, list) else payload.get("skills", [])
+    names = []
+    for it in items:
+        if isinstance(it, dict):
+            names.append(str(it.get("name") or it.get("id") or it))
+        else:
+            names.append(str(it))
+    return sorted(names)
 
 
 def recent_docs(limit: int) -> list[str]:
@@ -128,10 +189,24 @@ def fingerprint(text: str) -> str | None:
     return None
 
 
+class SiteMissing(Exception):
+    """站点对这个地址回了 404 —— 服务器答了话,只是没有这一页。"""
+
+
 def fetch(url: str) -> str:
     req = urllib.request.Request(url, headers={"User-Agent": "anet-docs-drift-check"})
-    with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
-        return r.read().decode("utf-8", errors="replace")
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+            return r.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        # 🔴 404 与「连不上」不是同一件事,不该给同一个退出码。
+        # main 上存在、线上 404 ⇒ 这**正是**这道门要抓的漂移(exit 1),
+        # 而不是「说不清楚」(exit 2)。原来两者都走 exit 2,于是真漂移被
+        # 报成 `cannot fetch … refusing to pass` —— 读起来像网络抽风,
+        # 这正是它连红 8 天没人处理的原因之一:**错的不是判定,是判定被归到了错的层**。
+        if exc.code == 404:
+            raise SiteMissing(url) from exc
+        raise
 
 
 def run() -> int:
@@ -161,6 +236,11 @@ def run() -> int:
         url = SITE + md_to_url(rel)
         try:
             html = fetch(url)
+        except SiteMissing:
+            checked += 1
+            print(f"  MISS {rel}  →  {md_to_url(rel)}   [404 — 线上没有这一页]")
+            missing.append((rel, md_to_url(rel), "整页在线上不存在(404)"))
+            continue
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
             print(f"::error::cannot fetch {url}: {exc} — refusing to pass", file=sys.stderr)
             return 2
@@ -174,6 +254,37 @@ def run() -> int:
             print(f"  MISS {rel}  →  {md_to_url(rel)}   [{source}]")
             missing.append((rel, md_to_url(rel), fp))
 
+    # --- 产物类文件:判据是「条目集合」,不是「指纹出现在渲染页里」 ---
+    for rel in recent_artifacts():
+        url = SITE + md_to_url(rel)
+        try:
+            raw = fetch(url)
+        except SiteMissing:
+            checked += 1
+            print(f"  MISS {rel}  →  {md_to_url(rel)}   [404 — 产物在线上不存在]")
+            missing.append((rel, md_to_url(rel), "产物在线上不存在(404)"))
+            continue
+        except (urllib.error.URLError, OSError, TimeoutError) as exc:
+            print(f"::error::cannot fetch {url}: {exc} — refusing to pass", file=sys.stderr)
+            return 2
+        checked += 1
+        try:
+            live = catalog_entries(json.loads(raw))
+            mine = catalog_entries(json.loads((DOCS / rel).read_text(encoding="utf-8")))
+        except (ValueError, AttributeError) as exc:
+            print(f"::error::cannot parse {rel} on either side: {exc} — refusing to pass",
+                  file=sys.stderr)
+            return 2
+        only_main = [n for n in mine if n not in live]
+        if only_main:
+            print(f"  MISS {rel}  →  {md_to_url(rel)}   "
+                  f"[main {len(mine)} 条 / 线上 {len(live)} 条]")
+            missing.append((rel, md_to_url(rel),
+                            f"main 有而线上没有:{', '.join(only_main)}"))
+        else:
+            print(f"  ok   {rel}  →  {md_to_url(rel)}   "
+                  f"[main {len(mine)} 条 / 线上 {len(live)} 条]")
+
     if checked == 0:
         print("::error::no page could be sampled (every candidate lacked a usable "
               "fingerprint) — refusing to pass", file=sys.stderr)
@@ -182,10 +293,12 @@ def run() -> int:
     print(f"\nsampled {checked} recently-changed page(s) against {SITE}")
     if missing:
         for rel, url, fp in missing:
-            print(f"::error file=docs-site/docs/{rel}::this sentence is on main but NOT on "
-                  f"{SITE}{url} — the site was not redeployed after the merge. "
-                  f"Run `vercel --prod` from a worktree at origin/main "
-                  f"(see deploy/docs-site/README.md). Missing: {fp[:80]!r}")
+            # 三种缺法的文案不一样:整页 404 / 产物条目少 / 指纹句缺失。
+            # 原来一律写死成 "this sentence is on main…",对前两种是错的描述。
+            print(f"::error file=docs-site/docs/{rel}::main 上的这一份没有出现在 "
+                  f"{SITE}{url} —— 合并后站点没有重新部署。"
+                  f"在 origin/main 的工作树里跑 `vercel --prod`"
+                  f"(见 deploy/docs-site/README.md)。差异:{fp[:100]!r}")
         print(f"\n{len(missing)} page(s) behind main.")
         return 1
     print("every sampled page on the live site matches main.")
@@ -202,6 +315,28 @@ def selftest() -> int:
     check("md → url: 英文页", md_to_url("en/deploy/npm.md") == "/en/deploy/npm")
     check("md → url: 目录首页", md_to_url("guide/index.md") == "/guide/")
     check("md → url: 站点首页", md_to_url("index.md") == "/")
+
+    # 🔴 `docs/public/` = VitePress 静态资源根:剥 `public/`、**保留扩展名**。
+    # 这三条是本次修的那个 bug 的红夹具 —— 修之前它们全部 FAIL。
+    check("public/ 下的 .md:剥 public/、保留 .md",
+          md_to_url("public/skillhub/skills/x/1.0.0/SKILL.md")
+          == "/skillhub/skills/x/1.0.0/SKILL.md",
+          f"got={md_to_url('public/skillhub/skills/x/1.0.0/SKILL.md')!r}")
+    check("public/ 下的 .json:扩展名不许被切",
+          md_to_url("public/skillhub/catalog.json") == "/skillhub/catalog.json",
+          f"got={md_to_url('public/skillhub/catalog.json')!r}")
+    check("非 .md 且不在 public/:原样保留扩展名",
+          md_to_url("assets/data.json") == "/assets/data.json",
+          f"got={md_to_url('assets/data.json')!r}")
+
+    # 产物判据:两种外形都要能读出条目名,且能看出 main 比线上多
+    check("catalog: list 形状", catalog_entries([{"name": "b"}, {"name": "a"}]) == ["a", "b"])
+    check("catalog: {'skills': …} 形状",
+          catalog_entries({"skills": [{"name": "b"}, {"name": "a"}]}) == ["a", "b"])
+    live_ = catalog_entries({"skills": [{"name": "a"}]})
+    main_ = catalog_entries({"skills": [{"name": "a"}, {"name": "b"}]})
+    check("catalog: 认得出 main 多出来的条目",
+          [n for n in main_ if n not in live_] == ["b"])
 
     # 指纹:必须跳过标题/列表/引用/链接/强调,选一句纯正文
     text = ("# 标题\n"


### PR DESCRIPTION
Closes 第 2、3 条 of #1237。**`published-build-paths` 那个红没查也没碰**（#1237 明确写了别当作已解释）—— 一个 PR 一件事。

**按内容搜过**（不按作者）：`md_to_url` ⇒ 零命中 · `check-docs-site-drift` ⇒ 零命中 · `catalog.json` ⇒ 零命中 · `recent_docs` ⇒ 零命中。

---

## 🔴 先更正 issue 里的一处机制描述（实测，可复核）

issue 说：`/public/` + 去掉 `.md` 的形式**「在任何情况下都是 404」**，所以只要采样到 `public/**/*.md` 门就永久红。

**实测不成立：**

```
$ curl -sL -o /dev/null -w '%{http_code}' \
    "https://anet.sh/public/skillhub/skills/skill-writing-guide/1.0.0/SKILL"
200
```

VitePress **也把 `public/**/*.md` 渲染成页面**。所以对**已部署过**的 skill，那个错地址会 200，正文里就有指纹，**旧脚本对它报 `ok`**：

```
$ python3 -c "...旧脚本..."   # 见下方证据段
  wrong-form url: https://anet.sh/public/skillhub/skills/skill-writing-guide/1.0.0/SKILL
  fetch OK; fingerprint found = True     ← 修之前就是绿的
```

⇒ **issue 里指定的正控做不出来**：拿 `skill-writing-guide` 做「修前红 / 修后绿」不成立，它修前已经是绿的。

**结论（修 `md_to_url`）是对的，机制不是「永久红」**，而是：对**尚未部署**的内容 404 → 走 `exit 2 refusing to pass` ⇒ **真漂移被报成基础设施故障**。这才是它连红 8 天没人处理的那一格。

⇒ 所以我换了一个有分辨力的正控：**`catalog.json`**（线上真实 200、且 main 与线上确有差异）。

## witnessed-red（四段，命令与输出）

### ① 修前：catalog 漂移对这道门**结构性不可见**

```
$ git show HEAD:.github/scripts/check-docs-site-drift.py > /tmp/gate_before.py
  md_to_url(catalog.json) = /public/skillhub/catalog.j        ← 连 "son" 都被切掉
  catalog.json sampled by recent_docs()? -> False               (过滤器是 line.endswith('.md'))
  fetch: HTTPError HTTP Error 404: Not Found
```

两重失明：**过滤器根本不收它**，且即便收了，地址也是垃圾。

### ② 修后：采到了，地址对了，**读出了真实差异**

```
  md_to_url(catalog.json) = /skillhub/catalog.json
  sampled by recent_artifacts()? -> True
  live=2 main=6  only-on-main=['Content search before PR', 'Invariant denominator check',
                               'Stop-chain discipline', 'Witnessed red regression gate']
```

线上真实 200 的资源，**差 4 条**。

### ③ 精确变异：只停用 `public/` 那一支，selftest 必须红

```
$ # if False: 停用 public/ 分支
$ python3 .github/scripts/check-docs-site-drift.py --selftest ; echo rc=$?
  FAIL public/ 下的 .md:剥 public/、保留 .md      got='/public/skillhub/skills/x/1.0.0/SKILL'
  FAIL public/ 下的 .json:扩展名不许被切          got='/public/skillhub/catalog.json'
selftest: 11/13 ok
rc=1

$ # 还原
selftest: 13/13 ok
rc=0
```

失败的是**那两条新断言**、报出的是**那个 bug 的真实产物**，不是笼统的红。

### ④ 整道门 live：从「说不清楚」变成「说得出要做什么」

```
修前   rc=2    只采到 2 页就中断
       ::error::cannot fetch …/SKILL: HTTP Error 404 — refusing to pass

修后   rc=1    采到 7 页，逐条可执行
  MISS en/skillhub/contribute.md                  [recent-added]
  MISS en/skillhub/index.md                       [recent-added]
  MISS …/content-search-before-pr/1.0.0/SKILL.md  [404 — 线上没有这一页]
  MISS …/invariant-denominator-check/1.0.0/SKILL.md
  MISS …/stop-chain-discipline/1.0.0/SKILL.md
  MISS …/witnessed-red-regression-gate/1.0.0/SKILL.md
  MISS public/skillhub/catalog.json               [main 6 条 / 线上 2 条]
7 page(s) behind main.
```

**同一个现实**（站点确实旧了），但覆盖面 2 → 7，且结论从「取不到，拒绝通过」变成「这 7 项落后，去跑 `vercel --prod`」。

## 改了什么

| # | 改动 | 为什么 |
|---|---|---|
| 1 | `md_to_url()` 对 `public/` 特判：剥 `public/`、**保留扩展名** | `docs/public/` 是 VitePress 静态资源根；原来写死切 3 个字符，对任何非 `.md` 产物都会砍掉三个字符 |
| 2 | 新增 `recent_artifacts()` + `ARTIFACT_NAMES` + `catalog_entries()` | `catalog.json` 不是 `.md`，此前被过滤掉 ⇒ 目录漂移从不在判据内。判据用**条目集合**（main 有而线上没有的） |
| 3 | `ARTIFACT_LIMIT` **独立预算** | 🔴 扩覆盖面不能以缩小另一半为代价 —— 产物不跟 `SAMPLE_LIMIT` 抢名额，markdown 覆盖面一条没少 |
| 4 | 404 → `SiteMissing` → 计入 missing（exit 1）；只有连不上/超时才 exit 2 | main 上有、线上 404 **就是**这道门要抓的漂移。归到 exit 2 会让它读起来像网络抽风 |
| 5 | `::error` 文案按三种缺法分开 | 原来一律写死 "this sentence is on main…"，对「整页 404」「产物条目少」是错的描述 |

新增 6 条 selftest（`public/` 的 `.md` / `.json` / 非 public 非 md / catalog 两种外形 / 差集识别）：**13/13 ok**。

## 没做的

- **没有为了让门变绿去缩小采样范围** —— 方向只有扩大（2 → 7 项）。这个 PR 合了之后**门仍然是红的**，因为站点确实旧了；红的理由现在是准确的、且指向 `vercel --prod`。
- 没碰 `published-build-paths`。
- 没重跑任何历史 run（GitHub 仍挂 major_outage），只会跑本分支新推的。