### PR TITLE
feat(feishu): add IM correlation store

### DIFF
--- a/agent-network/src/im/correlation-store.test.ts
+++ b/agent-network/src/im/correlation-store.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, lstatSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { JsonIMCorrelationStore } from "./correlation-store";
+import type { IMTaskCorrelation } from "./types";
+
+let scratch = "";
+let now = 1_000;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "anet-im-correlation-"));
+  now = 1_000;
+});
+
+afterEach(() => {
+  if (scratch) rmSync(scratch, { recursive: true, force: true });
+});
+
+function statePath(): string {
+  return join(scratch, "channels", "feishu", "state.json");
+}
+
+function store(options: ConstructorParameters<typeof JsonIMCorrelationStore>[1] = {}) {
+  return new JsonIMCorrelationStore(statePath(), {
+    now: () => now,
+    seenTtlMs: 500,
+    terminalTtlMs: 700,
+    ...options,
+  });
+}
+
+function correlation(overrides: Partial<IMTaskCorrelation> = {}): IMTaskCorrelation {
+  return {
+    conversationRef: {
+      platform: "feishu",
+      conversationId: "oc_test_chat",
+      conversationType: "group",
+      threadRootId: "om_root",
+    },
+    sourceMessageId: "om_source",
+    placeholderMessageId: "om_placeholder",
+    status: "pending",
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+describe("JsonIMCorrelationStore", () => {
+  test("records and reads idempotency keys across store instances", async () => {
+    const first = store();
+    await first.recordSeen("feishu:conn:message-1", "task-1");
+
+    const second = store();
+    expect(await second.hasSeen("feishu:conn:message-1")).toBe("task-1");
+    expect(await second.hasSeen("feishu:conn:missing")).toBeNull();
+  });
+
+  test("stores task correlation needed to route a reply back to IM", async () => {
+    const first = store();
+    const value = correlation();
+
+    await first.putCorrelation("task-1", value);
+
+    const second = store();
+    expect(await second.getCorrelation("task-1")).toEqual(value);
+    expect(await second.getCorrelation("task-missing")).toBeNull();
+  });
+
+  test("updates task status without losing conversation routing fields", async () => {
+    const s = store();
+    await s.putCorrelation("task-1", correlation());
+
+    now = 1_200;
+    await s.updateStatus("task-1", "completed");
+
+    expect(await s.getCorrelation("task-1")).toEqual({
+      ...correlation({ status: "completed" }),
+      createdAt: 1_000,
+    });
+  });
+
+  test("gc removes expired seen keys and terminal correlations only", async () => {
+    const s = store();
+    await s.recordSeen("old-event", "task-old");
+    await s.putCorrelation("pending-task", correlation({ status: "pending" }));
+    await s.putCorrelation("done-task", correlation({ status: "completed" }));
+
+    now = 1_100;
+    await s.updateStatus("done-task", "completed");
+
+    const result = await s.gc(1_900);
+
+    expect(result).toEqual({ removed: 2 });
+    expect(await s.hasSeen("old-event")).toBeNull();
+    expect(await s.getCorrelation("done-task")).toBeNull();
+    expect(await s.getCorrelation("pending-task")).toEqual({
+      ...correlation({ status: "pending" }),
+      createdAt: 1_000,
+    });
+  });
+
+  test("gc keeps fresh entries and does not rewrite when nothing is removed", async () => {
+    const s = store();
+    await s.recordSeen("fresh-event", "task-1");
+    await s.putCorrelation("task-1", correlation({ status: "failed" }));
+    const before = readFileSync(statePath(), "utf-8");
+
+    const result = await s.gc(1_200);
+
+    expect(result).toEqual({ removed: 0 });
+    expect(readFileSync(statePath(), "utf-8")).toBe(before);
+    expect(await s.hasSeen("fresh-event")).toBe("task-1");
+    expect(await s.getCorrelation("task-1")).toEqual({
+      ...correlation({ status: "failed" }),
+      createdAt: 1_000,
+    });
+  });
+
+  test("creates parent directories and writes a JSON state file atomically", async () => {
+    const path = statePath();
+    expect(existsSync(path)).toBe(false);
+
+    await store().recordSeen("event-1", "task-1");
+
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    expect(parsed.version).toBe(1);
+    expect(parsed.seen["event-1"].taskId).toBe("task-1");
+    if (process.platform !== "win32") {
+      expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/agent-network/src/im/correlation-store.ts
+++ b/agent-network/src/im/correlation-store.ts
@@ -1,0 +1,162 @@
+import { existsSync, readFileSync } from "node:fs";
+import type { IMCorrelationStore, IMTaskCorrelation } from "./types";
+import { atomicWritePrivateJson, repairPrivateFilePermissions } from "../private-state";
+
+type TerminalStatus = "completed" | "failed" | "timeout";
+
+interface SeenEntry {
+  taskId: string;
+  seenAt: number;
+}
+
+interface StoredCorrelation extends IMTaskCorrelation {
+  updatedAt: number;
+}
+
+interface StoreFile {
+  version: 1;
+  seen: Record<string, SeenEntry>;
+  correlations: Record<string, StoredCorrelation>;
+}
+
+export interface JsonIMCorrelationStoreOptions {
+  now?: () => number;
+  /** How long idempotency keys remain valid. Defaults to 24h. */
+  seenTtlMs?: number;
+  /** How long terminal correlations remain queryable. Defaults to 24h. */
+  terminalTtlMs?: number;
+}
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const TERMINAL_STATUSES = new Set<string>(["completed", "failed", "timeout"]);
+
+/**
+ * Small durable store for RFC-020 §2.9④ / §4.4 correlation state.
+ *
+ * The first gateway PR needs this as a standalone data structure before the
+ * bridge is rewired: idempotency keys survive process restart, and task replies
+ * can be routed back to their originating IM conversation.
+ */
+export class JsonIMCorrelationStore implements IMCorrelationStore {
+  private readonly now: () => number;
+  private readonly seenTtlMs: number;
+  private readonly terminalTtlMs: number;
+
+  constructor(
+    private readonly path: string,
+    options: JsonIMCorrelationStoreOptions = {},
+  ) {
+    this.now = options.now ?? Date.now;
+    this.seenTtlMs = options.seenTtlMs ?? DEFAULT_TTL_MS;
+    this.terminalTtlMs = options.terminalTtlMs ?? DEFAULT_TTL_MS;
+  }
+
+  async hasSeen(idempotencyKey: string): Promise<string | null> {
+    const state = this.load();
+    const entry = state.seen[idempotencyKey];
+    if (!entry) return null;
+    if (this.isExpired(entry.seenAt, this.seenTtlMs, this.now())) return null;
+    return entry.taskId;
+  }
+
+  async recordSeen(idempotencyKey: string, taskId: string): Promise<void> {
+    const state = this.load();
+    state.seen[idempotencyKey] = { taskId, seenAt: this.now() };
+    this.save(state);
+  }
+
+  async getCorrelation(taskId: string): Promise<IMTaskCorrelation | null> {
+    const state = this.load();
+    const entry = state.correlations[taskId];
+    if (!entry) return null;
+    const { updatedAt: _updatedAt, ...correlation } = entry;
+    return correlation;
+  }
+
+  async putCorrelation(taskId: string, correlation: IMTaskCorrelation): Promise<void> {
+    const state = this.load();
+    state.correlations[taskId] = {
+      ...correlation,
+      updatedAt: this.now(),
+    };
+    this.save(state);
+  }
+
+  async updateStatus(taskId: string, status: IMTaskCorrelation["status"]): Promise<void> {
+    const state = this.load();
+    const entry = state.correlations[taskId];
+    if (!entry) return;
+    state.correlations[taskId] = {
+      ...entry,
+      status,
+      updatedAt: this.now(),
+    };
+    this.save(state);
+  }
+
+  async gc(now: number): Promise<{ removed: number }> {
+    const state = this.load();
+    let removed = 0;
+
+    for (const [key, entry] of Object.entries(state.seen)) {
+      if (this.isExpired(entry.seenAt, this.seenTtlMs, now)) {
+        delete state.seen[key];
+        removed++;
+      }
+    }
+
+    for (const [taskId, entry] of Object.entries(state.correlations)) {
+      if (isTerminalStatus(entry.status) && this.isExpired(entry.updatedAt, this.terminalTtlMs, now)) {
+        delete state.correlations[taskId];
+        removed++;
+      }
+    }
+
+    if (removed > 0) this.save(state);
+    return { removed };
+  }
+
+  private isExpired(timestamp: number, ttlMs: number, now: number): boolean {
+    return now - timestamp >= ttlMs;
+  }
+
+  private load(): StoreFile {
+    if (!existsSync(this.path)) return emptyStore();
+    repairPrivateFilePermissions(this.path);
+    const parsed = JSON.parse(readFileSync(this.path, "utf-8")) as Partial<StoreFile>;
+    return {
+      version: 1,
+      seen:
+        parsed && typeof parsed.seen === "object" && parsed.seen
+          ? parsed.seen as Record<string, SeenEntry>
+          : {},
+      correlations:
+        parsed && typeof parsed.correlations === "object" && parsed.correlations
+          ? parsed.correlations as Record<string, StoredCorrelation>
+          : {},
+    };
+  }
+
+  private save(state: StoreFile): void {
+    atomicWritePrivateJson(this.path, state);
+  }
+}
+
+export function createJsonIMCorrelationStore(
+  path: string,
+  options?: JsonIMCorrelationStoreOptions,
+): IMCorrelationStore {
+  return new JsonIMCorrelationStore(path, options);
+}
+
+function emptyStore(): StoreFile {
+  return {
+    version: 1,
+    seen: {},
+    correlations: {},
+  };
+}
+
+function isTerminalStatus(status: IMTaskCorrelation["status"]): status is TerminalStatus {
+  return TERMINAL_STATUSES.has(status);
+}

--- a/docs/tests/report-test1239-feishu-correlation-store.txt
+++ b/docs/tests/report-test1239-feishu-correlation-store.txt
@@ -1,0 +1,18 @@
+Test: test1239-feishu-correlation-store
+Date: 2026-08-27
+Scope: Feishu IM correlation store, pure logic only.
+
+Commands:
+- cd agent-network && bun test src/im/correlation-store.test.ts
+- cd agent-network && npm run typecheck
+
+Result:
+- PASS: 6 tests, 17 assertions.
+- PASS: TypeScript typecheck.
+
+Notes:
+- Docker was intentionally not run for this step: the change is a standalone
+  data-structure/store PR and current ops guidance pauses Docker builds.
+- No real Feishu/Lark app was contacted.
+- No production IM probe messages were sent.
+- No FEISHU_APP_SECRET values were used or logged.


### PR DESCRIPTION
## Summary

- add a durable JSON-backed `IMCorrelationStore` implementation for RFC-020 §2.9④ / §4.4
- persist idempotency keys and `task_id -> IM conversation` routing records across process restarts
- add GC for expired idempotency entries and terminal task correlations
- keep this PR scoped to the store only: no bridge dispatch wiring, no send-path changes, no gateway alias / ntok provisioning

## Safety

- state writes use existing private-state atomic writer, so the store file is owner-only on POSIX
- no real Feishu/Lark app is contacted
- no production IM probe messages were sent
- no `FEISHU_APP_SECRET` values are used or logged

## Verification

- `cd agent-network && bun test src/im/correlation-store.test.ts`
- `cd agent-network && npm run typecheck`

Saved report: `docs/tests/report-test1239-feishu-correlation-store.txt`

Related: #1217
