### PR TITLE
feat(opencode-copresence): macOS 上也有进程组身份 —— 但 startTicks 才是那道防线

### DIFF
--- a/agent-node/src/runtime/opencode-copresence/process-group-darwin.test.ts
+++ b/agent-node/src/runtime/opencode-copresence/process-group-darwin.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseDarwinProcessGroupLine,
+  readProcessGroupIdentity,
+  sameLinuxProcessGroupIdentity,
+} from "./process-group";
+
+// `ps -o pgid=,lstart= -p 4242` 在 macOS 上的真实形状(LC_ALL=C):
+const PS_LINE = "  4242 Tue Aug 26 19:04:11 2026\n";
+
+describe("darwin process-group identity", () => {
+  test("parses the pgid and the start time out of a real ps line", () => {
+    expect(parseDarwinProcessGroupLine(4242, PS_LINE)).toEqual({
+      pid: 4242, pgrp: 4242, startTicks: "Tue Aug 26 19:04:11 2026",
+    });
+  });
+
+  test("🔴 PID 复用防线:pid 与 pgrp 全同、只有启动时刻不同 ⇒ 不是同一个进程", () => {
+    // 这是这整个模块存在的理由。原进程死了、pid 被复用时,
+    // pid 和 pgrp 都会对上 —— 只有启动时刻不会。
+    // 若身份比对漏掉 startTicks,下面这条就会变成 true,
+    // 而那意味着 process.kill(-pgrp, SIGKILL) 会杀掉一整个不相干的进程组。
+    const before = parseDarwinProcessGroupLine(4242, "4242 Tue Aug 26 19:04:11 2026")!;
+    const after  = parseDarwinProcessGroupLine(4242, "4242 Tue Aug 26 21:58:02 2026")!;
+    expect(before.pid).toBe(after.pid);
+    expect(before.pgrp).toBe(after.pgrp);
+    expect(sameLinuxProcessGroupIdentity(before, after)).toBe(false);
+  });
+
+  test("同一读数与自己比对是 true(正控:上一条不是恒假)", () => {
+    const id = parseDarwinProcessGroupLine(4242, PS_LINE)!;
+    expect(sameLinuxProcessGroupIdentity(id, id)).toBe(true);
+  });
+
+  test("pgid <= 1 被拒(与 linux 分支同一组下界)", () => {
+    expect(parseDarwinProcessGroupLine(4242, "1 Tue Aug 26 19:04:11 2026")).toBeUndefined();
+    expect(parseDarwinProcessGroupLine(4242, "0 Tue Aug 26 19:04:11 2026")).toBeUndefined();
+  });
+
+  test("空的启动时刻被拒 —— 没有它就没有复用防线", () => {
+    expect(parseDarwinProcessGroupLine(4242, "4242")).toBeUndefined();
+    expect(parseDarwinProcessGroupLine(4242, "4242   ")).toBeUndefined();
+  });
+
+  test("ps 取不到(进程已消失)⇒ undefined,不抛", () => {
+    expect(parseDarwinProcessGroupLine(4242, undefined)).toBeUndefined();
+    expect(parseDarwinProcessGroupLine(4242, "")).toBeUndefined();
+  });
+
+  test("按平台分派:darwin 走探针,win32 一律 undefined", () => {
+    const probe = () => PS_LINE;
+    expect(readProcessGroupIdentity(4242, "darwin", probe)?.pgrp).toBe(4242);
+    expect(readProcessGroupIdentity(4242, "win32", probe)).toBeUndefined();
+  });
+
+  test("pid <= 1 在分派前就被拒(不去 spawn ps)", () => {
+    let called = 0;
+    const probe = () => { called++; return PS_LINE; };
+    expect(readProcessGroupIdentity(1, "darwin", probe)).toBeUndefined();
+    expect(called).toBe(0);
+  });
+});

--- a/agent-node/src/runtime/opencode-copresence/process-group.ts
+++ b/agent-node/src/runtime/opencode-copresence/process-group.ts
@@ -1,13 +1,42 @@
 import { readFileSync } from "fs";
+import { execFileSync } from "node:child_process";
 
+/**
+ * 进程组身份 = pid + pgrp + 启动时刻。
+ *
+ * 🔴 `startTicks` 不是装饰:它是 **PID 复用的唯一防线**。
+ * 原进程死掉、系统把同一个 pid 分给别人时,pid 和 pgrp 都可能对得上 ——
+ * 只有启动时刻对不上。少了它,`process.kill(-pgrp, SIGKILL)` 会杀掉
+ * 一整个不相干的进程组。
+ *
+ * Linux 从 `/proc/<pid>/stat` 读(字段 22,0-based index 19)。
+ * macOS 没有 /proc,用 `ps -o pgid=,lstart=`;`lstart` 扮演同一个角色。
+ */
 export interface LinuxProcessGroupIdentity {
   pid: number;
   pgrp: number;
   startTicks: string;
 }
 
-export function readLinuxProcessGroupIdentity(pid: number): LinuxProcessGroupIdentity | undefined {
-  if (process.platform !== "linux" || !Number.isSafeInteger(pid) || pid <= 1) return undefined;
+/** 注入点:测试用假的 ps,生产用 execFileSync。 */
+export type ProcessGroupProbe = (pid: number) => string | undefined;
+
+const defaultDarwinProbe: ProcessGroupProbe = (pid) => {
+  try {
+    // 🔴 LC_ALL=C:lstart 的格式随 locale 变。不钉住它,同一台机器换个语言
+    // 环境就会产出不同的字符串,而这个字符串正是身份比对的一部分 ——
+    // 那会让「同一个进程」在两次读取之间看起来像是换了一个。
+    return execFileSync("ps", ["-o", "pgid=,lstart=", "-p", String(pid)], {
+      encoding: "utf8",
+      env: { ...process.env, LC_ALL: "C" },
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return undefined;
+  }
+};
+
+function readLinuxIdentity(pid: number): LinuxProcessGroupIdentity | undefined {
   try {
     const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
     const close = stat.lastIndexOf(")");
@@ -20,6 +49,39 @@ export function readLinuxProcessGroupIdentity(pid: number): LinuxProcessGroupIde
   } catch {
     return undefined;
   }
+}
+
+/** `ps -o pgid=,lstart= -p N` 的一行 → 身份。导出只为可测。 */
+export function parseDarwinProcessGroupLine(
+  pid: number,
+  raw: string | undefined,
+): LinuxProcessGroupIdentity | undefined {
+  if (!raw) return undefined;
+  const line = raw.split("\n").map((l) => l.trim()).filter(Boolean)[0];
+  if (!line) return undefined;
+  const m = /^(\d+)\s+(.+)$/.exec(line);
+  if (!m) return undefined;
+  const pgrp = Number(m[1]);
+  const startTicks = m[2].trim();
+  // 与 Linux 分支同一组下界:pgrp 必须是真实进程组,启动时刻必须非空。
+  if (!Number.isSafeInteger(pgrp) || pgrp <= 1 || startTicks.length === 0) return undefined;
+  return { pid, pgrp, startTicks };
+}
+
+export function readProcessGroupIdentity(
+  pid: number,
+  platform: NodeJS.Platform = process.platform,
+  probe: ProcessGroupProbe = defaultDarwinProbe,
+): LinuxProcessGroupIdentity | undefined {
+  if (!Number.isSafeInteger(pid) || pid <= 1) return undefined;
+  if (platform === "linux") return readLinuxIdentity(pid);
+  if (platform === "darwin") return parseDarwinProcessGroupLine(pid, probe(pid));
+  return undefined;
+}
+
+/** 保留旧名,调用方无需改动。 */
+export function readLinuxProcessGroupIdentity(pid: number): LinuxProcessGroupIdentity | undefined {
+  return readProcessGroupIdentity(pid);
 }
 
 export function sameLinuxProcessGroupIdentity(


### PR DESCRIPTION
## 背景

`opencode-copresence` 的收尾靠**进程组身份**:`readLinuxProcessGroupIdentity` 从
`/proc/<pid>/stat` 取 `pgrp` 和启动时刻,`signalExactLinuxProcessGroup` **先校验身份、
再** `process.kill(-pgrp, sig)`。

macOS 没有 `/proc`,那个函数直接返回 `undefined`。追了调用点确认现状是 **fail-safe 的**:

```ts
runtime.ts:553  if (identity) await stopProcessGroup(child, identity);
                else try { child.kill("SIGKILL"); } catch {}
runtime.ts:563  同上
```
⇒ 进程会死,但**没有「整组一起收」的保证**(子孙进程可能留下)。是缺功能,不是有 bug。

## 🔴 为什么必须连 `startTicks` 一起做,不能只拿 pgid

`startTicks` 不是装饰,它是 **PID 复用的唯一防线**。
原进程死掉、系统把同一个 pid 分给别人时,`pid` 和 `pgrp` **都可能对得上** ——
只有启动时刻对不上。

⇒ 「darwin 上只加 pgid、用 `kill(-pgid, 0)` 判存活」**不是少做一半**,
   是把一个**保守但正确**的行为(`child.kill`)换成一个**可能误杀整个进程组**的行为。

macOS 上的等价物是 `ps -o pgid=,lstart=`,`lstart` 扮演 `startTicks` 的角色。
三元组结构不变,`readLinuxProcessGroupIdentity` 旧名保留,**调用方一行未改**。

## 🔴 `LC_ALL=C`

`lstart` 的格式随 locale 变,而这个字符串**正是身份比对的一部分**。
不钉住它,同一台机器换个语言环境就会让同一个进程在两次读取之间看起来像换了一个。

## witnessed-red

只改一个变量:移除 `sameLinuxProcessGroupIdentity` 里的 `startTicks` 比对。

```
正常                8 pass  0 fail
移除该行            7 pass  1 fail
  (fail) PID 复用防线:pid 与 pgrp 全同、只有启动时刻不同 ⇒ 不是同一个进程
         Expected: false   Received: true
还原后 opencode 全域  27 pass  0 fail  (3 个文件)
```
**只有那一条红**,其余 7 条不动 —— 红在被测的那件事上,不是笼统地红。

测试里另外放了两条:
- **正控** `sameLinuxProcessGroupIdentity(id, id) === true`。没有它,上面那条"必须 false"
  可能是**恒假**,而恒假的断言在变异下同样会红,看起来一样有效。
- `pid <= 1` **不去 spawn `ps`**(计数探针断言 `called === 0`)——
  不对不合法输入发起外部进程调用。

## ⚠️ 未验的部分

**没有 macOS 真机**(全队确认无可登录的 macOS、无 macOS Codex 凭据)。
本 PR 交的是**实现 + 注入式测试**;`ps -o pgid=,lstart=` 的真实输出形状是照文档与
常见形态写的,**未在真机上跑过**。

合并前若能在任一台 macOS 上跑一次
`bun test agent-node/src/runtime/opencode-copresence/` 会更稳妥;
若拿不到机器,建议按"实现已交、真机未验"记录,而不是当作完成。

## 影响面

- Linux 路径**零改动**(19/19 原有测试全绿)
- Windows 仍返回 `undefined` → 保持现有 `child.kill` 兜底
- darwin 从「永远走 `child.kill` 兜底」变为「走身份校验过的进程组收尾」
