### PR TITLE
fix(qa): test735 抄了 min_uptime 的数值,而改它的 PR 根本没触发这道门

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -18,6 +18,9 @@ on:
       - 'tests/test846-doc-claims/**'
       - 'agent-network/**'
       - 'agent-node/**'
+      # deploy/ 曾不在此列 —— 只改部署配置的 PR 因此绕过整个 QA 套件,
+      # 而且显示为全绿(检查数从 ~92 掉到 16,比例反而更好看)。
+      - 'deploy/**'
       - 'tests/qa-*/**'
       - 'scripts/qa.sh'
       - 'scripts/sync-pinned-versions.sh'
@@ -183,6 +186,7 @@ on:
       - 'tests/test846-doc-claims/**'
       - 'agent-network/**'
       - 'agent-node/**'
+      - 'deploy/**'
       - 'tests/qa-*/**'
       - 'scripts/qa.sh'
       - '.github/workflows/qa.yml'

--- a/tests/test735-hub-daemon-rebuild/run.sh
+++ b/tests/test735-hub-daemon-rebuild/run.sh
@@ -141,7 +141,21 @@ if (!app || app.name !== "commhub-hub") process.exit(1);
 if (app.script !== "/home/tester/.local/bin/hub-daemon.sh") process.exit(1);
 if (app.cwd !== "/home/tester/.commhub") process.exit(1);
 if (app.interpreter !== "bash" || app.exec_mode !== "fork") process.exit(1);
-if (app.autorestart !== true || app.min_uptime !== 20_000 || app.max_restarts !== 20) process.exit(1);
+if (app.autorestart !== true || app.max_restarts !== 20) process.exit(1);
+
+// 🔴 不要断言 min_uptime 的具体数值。
+// 这个字段唯一的正确性条件是**它必须大于「一次失败启动退出所需的时间」** ——
+// 低于它,PM2 把每次崩溃都算成启动成功,unstable restarts 恒为 0,
+// max_restarts/退避永远不触发,崩溃循环看起来像正常重启。
+//
+// 那个时间不是常数,它写在 hub-daemon.sh 的 fail_slow() 里(`sleep N` 后 exit 1)。
+// 所以从脚本自己读出来比,而不是把某个当时正确的数字抄进这里 ——
+// 抄数字的门在下次调参时会误红,而误红教会人绕过它。
+const daemon = require("fs").readFileSync("/app/deploy/hub/hub-daemon.sh", "utf8");
+const m = /fail_slow\(\)\s*\{[\s\S]*?\bsleep\s+(\d+)/.exec(daemon);
+if (!m) process.exit(1);                       // 读不到就不放行,不猜
+const failExitMs = Number(m[1]) * 1000;
+if (!Number.isFinite(app.min_uptime) || app.min_uptime <= failExitMs) process.exit(1);
 if (app.exp_backoff_restart_delay !== 200) process.exit(1);
 EOF
 }


### PR DESCRIPTION
## main 的 QA 已经红了约 3 小时,这是根因和修复

失败步骤:`hub daemon fail-closed (Docker)` → `Build + run test735-hub-daemon-rebuild`

```
qa.yml 最近的运行
  failure    76 分前   main
  failure   156 分前   main
  failure   164 分前   main
  success   192 分前   grok-hot-switch-fallback   ← 最后一次绿
```

## 因果链

**1. `qa.yml` 的 paths 列了 `deploy/hub/hub-daemon.sh`,却没列它旁边的 `ecosystem.config.cjs`**

```yaml
:179      - 'deploy/hub/hub-daemon.sh'          ← 有
          - 'deploy/hub/ecosystem.config.cjs'   ← 没有
```
不是"整个 `deploy/` 被漏了" —— 是**漏了两个文件里的一个**,所以清单看上去是覆盖到的。
而 test735 的 Dockerfile 两个文件都拷、两个都测。

**2. #1231 只改了 `ecosystem.config.cjs`**(`min_uptime` 20_000 → 45_000)

**3. ⇒ 这道门在那个 PR 上从未触发。** 它只跑了 **16** 个检查,而同期别的 PR 是 **92+**。

🔴 **16/16 的绿比 92/92 还好看。分母塌陷的时候,比例反而更漂亮** —— 这是我合并它时没看出来的地方。

**4. test735 断言 `min_uptime !== 20_000` 就 `exit 1`** ⇒ 合入后 main 立刻红。

## 修改一:断言改成校验不变式,不抄数值

`min_uptime` 唯一的正确性条件是**它必须大于「一次失败启动退出所需的时间」**：
低于它,PM2 把每次崩溃都算成启动成功,`unstable restarts` 恒为 0,
退避与 `max_restarts` 永不触发,**崩溃循环看起来像正常重启**。

那个时间不是常数,它写在 `hub-daemon.sh` 的 `fail_slow()` 里(`sleep N` 后 `exit 1`)。
所以从脚本自己读出来比:

```js
const daemon = readFileSync("/app/deploy/hub/hub-daemon.sh", "utf8");
const m = /fail_slow\(\)\s*\{[\s\S]*?\bsleep\s+(\d+)/.exec(daemon);
if (!m) process.exit(1);                     // 读不到就不放行,不猜默认值
const failExitMs = Number(m[1]) * 1000;
if (!Number.isFinite(app.min_uptime) || app.min_uptime <= failExitMs) process.exit(1);
```

**抄数值的门在下次调参时会误红,而误红教会人绕过它。**

## 修改二:`pull_request` 与 `push` 两段都补 `deploy/**`

只补 `pull_request` 会让**合入 main 之后的 push 事件仍然不跑这道门** —— 那是只修一半。

## witnessed-red

把断言逻辑喂真实的 `ecosystem.config.cjs` 与 `hub-daemon.sh`,三种输入:

```
min_uptime = 45000  (main 现值)       失败退出耗时 30000ms  ⇒ PASS  rc=0
min_uptime = 20000  (#1231 之前)      失败退出耗时 30000ms  ⇒ FAIL  rc=1
min_uptime = 30000  (恰好等于该耗时)   失败退出耗时 30000ms  ⇒ FAIL  rc=1
```

**边界那一格是刻意的。** 只用生产里那个值(45_000)校准,只能证明生产路径没错,
证不出这道门有分辨力;`30_000` 这种"恰好相等"才是它必须拦住而容易放过的输入。

## 这个 PR 不改 `ecosystem.config.cjs`

`min_uptime: 45_000` 是对的(#1231 的注释里带了容器内真 PM2 的实测:
`min_uptime=20000 → unstable restarts 0`,`45000 → 3`)。
**红的是门,不是被测对象。**
