### PR TITLE
fix(release): 发版会让哪些句子当场变假 —— 这份清单第四次数错了(7→8→12→31)

### DIFF
--- a/.github/scripts/check-release-channel-assertions.py
+++ b/.github/scripts/check-release-channel-assertions.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""发版会让哪些文档句子当场变假 —— 这份清单不能靠手工维护。
+
+## 为什么需要它
+
+docs 里有一类版本号是**故意**留着的:限定信道的**行为断言** ——
+「latest `2.2.21` 会裸崩,preview 会被 preflight 拦下」。
+去掉版本号这句话就没有意义,所以它们不能像别的 doc 那样清版本号。
+
+代价是:**latest 或 preview 一发布,它们立刻变成假的**,
+而且是危险的那种假 —— 会告诉用户一道已经存在的安全 preflight 不存在。
+
+`docs/RELEASE-SOP.md` 里有一张「逐次发版必须重新核对」的表。
+**那张表的分母已经错过三次:7 → 8 → 12 → 实测 20。**
+SOP 自己写着「加新断言时同时加进这张表」,而那条纪律靠人记,记不住。
+
+## 判据
+
+扫 `docs-site/docs/**/*.md`,找出**同一行里同时出现**
+`latest`/`preview` 字样与一个具体版本号的行 —— 那就是信道断言的形状。
+每一个这样的文件都必须在 SOP 表里登记。**没登记 = 红。**
+
+## 🔴 刻意不做的两件事
+
+1. **不扫「只出现版本号」的行。** 那样会把带日期的实测记录也算进来
+   (例:`deploy/daemon.md` 的「实测 2026-08-18,用当时的 latest 2.2.21」)——
+   那种句子**不会因为发版变假**,它说的就是那一天的事。把它拉进清单
+   会让清单变长而信号变弱,而变弱的清单下次就没人逐条核了。
+2. **不校验版本号是不是最新。** 那是发版时的动作,不是常态门的职责;
+   把它做成常态门会在每次发版后立刻全红,变成必须绕过的墙纸。
+"""
+from __future__ import annotations
+import re, sys
+from pathlib import Path
+
+DOCS = Path("docs-site/docs")
+SOP = Path("docs/RELEASE-SOP.md")
+VERSION = re.compile(r"\b\d+\.\d+\.\d+(?:-preview\.\d+)?\b")
+CHANNEL = re.compile(r"\blatest\b|\bpreview\b", re.IGNORECASE)
+
+def assertion_files() -> dict[str, list[int]]:
+    found: dict[str, list[int]] = {}
+    for p in sorted(DOCS.rglob("*.md")):
+        rel = p.as_posix()
+        for i, line in enumerate(p.read_text(encoding="utf-8").splitlines(), 1):
+            if VERSION.search(line) and CHANNEL.search(line):
+                found.setdefault(rel, []).append(i)
+    return found
+
+def main() -> int:
+    if not DOCS.is_dir() or not SOP.is_file():
+        print("::error::取集塌了:找不到 docs-site/docs 或 RELEASE-SOP.md —— 拒绝通过", file=sys.stderr)
+        return 2                                  # 说不清楚就不说「没问题」
+    sop = SOP.read_text(encoding="utf-8")
+    found = assertion_files()
+    if not found:
+        print("::error::零命中。信道断言不可能一条都没有 —— 更可能是扫描范围错了", file=sys.stderr)
+        return 2
+    missing = [f for f in found if f not in sop]
+    print(f"扫到带信道断言的文件 {len(found)} 个;RELEASE-SOP 已登记 {len(found) - len(missing)} 个")
+    for f in sorted(found):
+        mark = "MISS" if f in missing else "ok  "
+        print(f"  {mark} {f}  行 {found[f][:6]}")
+    if missing:
+        print(f"\n::error::{len(missing)} 个文件带信道断言但没登记进 docs/RELEASE-SOP.md。", file=sys.stderr)
+        print("发版当刻它们会静默变假,而没有任何清单会提醒任何人。", file=sys.stderr)
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -28,12 +28,16 @@ on:
     paths:
       - '**/*.md'
       - '.github/scripts/check-docs-integrity.py'
+      - '.github/scripts/check-release-channel-assertions.py'
+      - 'docs/RELEASE-SOP.md'
       - '.github/workflows/docs-integrity.yml'
   push:
     branches: [main]
     paths:
       - '**/*.md'
       - '.github/scripts/check-docs-integrity.py'
+      - '.github/scripts/check-release-channel-assertions.py'
+      - 'docs/RELEASE-SOP.md'
       - '.github/workflows/docs-integrity.yml'
 
 jobs:
@@ -52,3 +56,5 @@ jobs:
       # targets were invisible, and both broken links in scope were among them.
       - run: python3 .github/scripts/check-docs-integrity.py --selftest
       - run: python3 .github/scripts/check-docs-integrity.py
+      - name: 信道断言清单未登记即红
+        run: python3 .github/scripts/check-release-channel-assertions.py

--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -55,6 +55,31 @@ R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md`
 > | `docs-site/docs/en/guide/windows.md` | 102 | 同上(英文) |
 > | `docs-site/docs/guide/dashboard.md` | 313、328 | `anet -v` 应显示 `2.3.0-preview.N` / preview 不自动 promote |
 > | `docs-site/docs/en/guide/dashboard.md` | 314、329 | 同上(英文) |
+> | `docs-site/docs/api/rest.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/concepts/security.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/deploy/daemon.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/deploy/npm.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/api/rest.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/concepts/security.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/deploy/daemon.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/deploy/npm.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/guide/architecture.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/guide/feishu.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/guide/grok-copresence.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/preview/index.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/troubleshooting/case-feishu-silent-deny.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/guide/architecture.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/guide/feishu.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/guide/grok-copresence.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/preview/index.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/troubleshooting/case-feishu-silent-deny.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+>
+> 🔴 **这张表第四次被修正:7 → 8 → 12 → 31。**
+> 前三次都是有人踩到之后手工补的,而 SOP 里那句「加新断言时同时加进这张表」靠人记 —— 记不住。
+> 现在由 `.github/scripts/check-release-channel-assertions.py` 扫出来:
+> 判据是「同一行里同时出现 `latest`/`preview` 与一个具体版本号」——那是断言的形状,
+> 不是某几个具体数字(上一次手工数就是只 grep 了三个版本号,因此又漏了一批)。
+> **新增断言不登记 = 门红。分母不会再靠自觉。**
 >
 > **核对方法不是 grep,是真机装。但不同断言要各跑各的 —— 一次探针不能替所有:**
 >


### PR DESCRIPTION
## 发版会让哪些文档句子当场变假 —— 这份清单第四次数错了

docs 里有一类版本号是**故意**留着的:限定信道的**行为断言** ——
「latest `2.2.21` 会裸崩,preview 会被 preflight 拦下」。去掉版本号这句话就没有意义,
所以它们不能像别的 doc 那样清掉版本号。

代价是:**latest 或 preview 一发布,它们立刻全部变假**,
而且是危险的那种假 —— 会告诉用户**一道已经存在的安全 preflight 不存在**。

`docs/RELEASE-SOP.md` 有一张「逐次发版必须重新核对」的表。它的分母:

```
7  →  8  →  12   (SOP 自述被修正过两次)
              →  31   (本次扫描实测)
```

SOP 里明写着「加新断言时,同时把它加进这张表」。**那条纪律靠人记,而三次修正
都是有人踩到之后手工补的** —— 包括我。本次调查中我先手工 grep 了三个版本号
(`2.2.21` / `0.8.8` / `2.4.13`),数出 18,**又漏了一批**,因为用别的版本号写的断言
不在我的 grep 里。

## 新增 `.github/scripts/check-release-channel-assertions.py`

判据是**「同一行里同时出现 `latest`/`preview` 与一个具体版本号」** ——
那是**断言的形状**,不是某几个具体数字。分母不再靠自觉。

## 🔴 刻意不做的两件事(写在脚本文件头里)

**1. 不扫「只出现版本号」的行。**
那会把带日期的实测记录也算进来,例如
`deploy/daemon.md`:「实测 2026-08-18,用当时的 `latest` `2.2.21` ……」——
**那种句子不会因为发版变假**,它说的就是那一天的事。
把它拉进清单会让清单变长而信号变弱,**而变弱的清单下次就没人逐条核了**。

**2. 不校验版本号是不是最新。**
那是发版时的动作,不是常态门的职责。做成常态门会在**每次发版后立刻全红**,
变成必须绕过的墙纸。

## fail-closed

- 找不到 `docs-site/docs` 或 `RELEASE-SOP.md` → **exit 2**(取集塌了,说不清楚就不说没问题)
- 零命中 → **exit 2**(信道断言不可能一条都没有,更可能是扫描范围错了)
- 有未登记项 → exit 1,并逐个打印文件与行号

## witnessed-red

只改一处:把 SOP 表里 `docs-site/docs/preview/index.md` 那一行改名。

```
补齐 31 项后          rc=0
移除该项              rc=1   MISS 恰好 1 个,就是它,其余 30 个不受影响
还原                  rc=0
```

## paths 也补了 —— 这是今晚同一个形状的第二次

`docs-integrity.yml` 原本只收 `check-docs-integrity.py`,
**新脚本不在内** ⇒ 改了这道门自己,它不会触发。

这和今晚 `qa.yml` 漏 `deploy/` 是同一个形状:清单里已经有一个同目录条目,
看上去这块是被覆盖的。那次的后果是 `#1231` 只跑了 16 个检查(别的 PR 92+),
而 **16/16 的绿比 92/92 还好看**,于是被合进 main,main 红了近 6 小时。

(注:`paths` 里本就有 `'**/*.md'`,所以我补的 `docs/RELEASE-SOP.md` 那行是冗余的 ——
不影响正确性,但说明我补的时候没先看全清单。留着不删,因为显式列出被判据读取的
文件比依赖通配更容易读。)
