### PR TITLE
chore(release): @sleep2agi/agent-network 2.3.0-preview.47

### DIFF
--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.46",
+  "version": "2.3.0-preview.47",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.46";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.47";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.34";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.


### PR DESCRIPTION
今晚合入 main 的 **20 个 PR** 全部在 `preview.46`(今天 11:07 UTC)之后,两个 npm 通道一个都拿不到:

```
latest   2.2.21             2026-06-24
preview  2.3.0-preview.46   今天 11:07 UTC
```

**本次只发 preview,不动 latest** —— 先在滚动通道验证可装可跑,再考虑推 `latest`。

## 照 docs/RELEASE-SOP.md 执行

| 步骤 | 结果 |
|---|---|
| §1.1 四个包 dist-tags | 已核 |
| §1.3 dry-run | 命中 **1 处**(`PAIRED_AGENT_NETWORK_VERSION`)。方向升不降 ✅ 包名边界正确(未误伤 `PAIRED_AGENT_NODE_VERSION` 与 dashboard)✅ 位置在 Live versions 表内 ✅ |
| §2.1 | `package.json` version `.46` → `.47` |
| §2.2 | `sync-pinned-versions.sh --apply`,改动 1 文件 |
| §2.3 build verify | `npm run build` 退出码 **0**;`npm pack` → 1.7 MB / 80 文件 |
| §2.4 人工 review | **2 文件 2 行**,零 untracked 混入 |

## 合并后的动作

`npm publish --tag preview`(SOP 明确:`release.yml` 是 report-only gate,**不发布**,
publish 是手工步骤)。发完立刻按 **RELEASE-SOP 那张 31 项表**核信道断言 ——
该表刚在 #1244 补齐并加了自动门,新增断言不登记即红。