### PR TITLE
chore(release): @sleep2agi/agent-node 2.5.0-preview.35

### DIFF
--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -19,7 +19,7 @@ import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
 export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.47";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.34";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.35";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.34",
+  "version": "2.5.0-preview.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.34",
+      "version": "2.5.0-preview.35",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.34",
+  "version": "2.5.0-preview.35",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"


### PR DESCRIPTION
## 为什么

`@sleep2agi/agent-network@2.3.0-preview.47` 刚发出去并**已端到端验证**:

```
干净目录 npm i @sleep2agi/agent-network@preview  →  2.3.0-preview.47
anet --version                                   →  anet v2.3.0-preview.47
dist 里 GrokModelSwitchRoute 命中                 →  1     (#1240 热切路由)
node-server.js bun 语法检查                       →  OK    (#1227/#1233)
```

**但今晚大部分实现在 `agent-node` 包里**,而它的 npm preview 仍停在 `.34`:

| PR | 落在哪个包 |
|---|---|
| #1240 grok 热切 + 回退 + route 可观测 | `agent-node/src/runtime/grok-copresence/` |
| #1242 OpenCode macOS 进程组身份 | `agent-node/src/runtime/opencode-copresence/` |
| #1239 飞书 correlation store | `agent-network/src/im/` |

⇒ 装 `agent-node@preview` 的用户拿不到 #1240 / #1242。

## 照 RELEASE-SOP 执行

| 步骤 | 结果 |
|---|---|
| §1.3 dry-run | 命中 **1 处**(`PAIRED_AGENT_NODE_VERSION`)。升不降 ✅ 未误伤 `PAIRED_AGENT_NETWORK_VERSION` ✅ |
| §2.1 | `.34` → `.35` |
| §2.2 | sync `--apply`,1 文件 |
| §2.3 | `npm run build` 退出码 **0**;`npm pack` → `sleep2agi-agent-node-2.5.0-preview.35.tgz` |
| §2.4 | **2 文件 2 行**,零 untracked |

首次 build 报 `Could not resolve: "zod"` —— 那是 worktree 里 `agent-node/` 没跑 `npm ci`,
**不是代码问题**;装完依赖退出码 0。记在这里免得下一个人误判。

**只发 preview,不动 latest。**