### PR TITLE
docs(api): latest 移走了,rest.md 那几句当场变假 —— 改成按版本描述

### DIFF
--- a/docs-site/docs/api/rest.md
+++ b/docs-site/docs/api/rest.md
@@ -50,14 +50,18 @@ curl http://localhost:9200/health
 >
 > **两条线的键不一样,解析 `/health` 的脚本要按信道分别处理:**
 >
-> | 键 | latest `0.8.8` | preview `0.9.0-preview.29` |
+> 🔴 **`latest` 已于 2026-08-27 从 `0.8.8` 移到 `0.9.0-preview.30`(含脱敏修复 `7bacb729`)。**
+> 下面按**版本**描述,不按信道 —— 信道会移动,版本不会。
+> 现在指向哪个版本:`npm view @sleep2agi/commhub-server dist-tags`。
+>
+> | 键 | `0.8.8` | `0.9.0-preview.29` |
 > |---|---|---|
 > | `sse_sessions` | **未认证也会返回,且未脱敏** | 未认证不返回 |
 > | `limits` | 没有 | 有 |
 >
 > **本次实测中**,其余 13 个键两条线都有 —— 每条线各一个样本,不是永久契约。
 
-::: danger latest `0.8.8` 的 `sse_sessions` 会向匿名调用方泄露全部在线 agent
+::: danger `0.8.8` 的 `sse_sessions` 会向匿名调用方泄露全部在线 agent
 上面那个样本里 `sse_sessions` 是 `{}`,**只是因为那个干净容器一条 SSE 连接都没有**。
 **不要把它读成「latest 不泄露」。**
 
@@ -71,7 +75,7 @@ curl http://localhost:9200/health
 
 所以两条线的差别不是「有键 / 没键」,是:
 
-- **latest `0.8.8`** —— 未认证可读全部在线会话明细(空 hub 上恰好为空);
+- **`0.8.8`** —— 未认证可读全部在线会话明细(空 hub 上恰好为空);
 - **preview `0.9.0-preview.22` 及以后** —— 匿名只给聚合计数,明细移到需鉴权的 `GET /api/stats/sse`;
 - ⚠️ **preview `0.9.0-preview.0` ~ `.21` 同样会泄露** —— 它们发布于 2026-06-28 ~ 07-04,**早于修复**。
   别把「preview」整条线当成安全的。
@@ -82,7 +86,7 @@ curl http://localhost:9200/health
 另外,如果你的解析代码用「键是否存在」来判断权限,两条线的行为也不同。
 
 未认证请求的行为**按线区分**(见上表与上面的告警):preview 上只返回聚合数据、
-不含 `sse_sessions`;latest `0.8.8` 上该键**未脱敏**返回 —— 空 hub 上恰好为空,
+不含 `sse_sessions`;`0.8.8` 上该键**未脱敏**返回 —— 空 hub 上恰好为空,
 一旦有连接就是完整的 `{networkId}:{alias}` 明细。携带有效 token 时：
 - system-admin、legacy master 或 DEV_OPEN 调用方可看到完整 `sse_sessions`；
 - 普通 `utok_` / `ntok_` 只看到其有权访问网络的 session；无网络成员关系时返回空对象。

--- a/docs-site/docs/en/api/rest.md
+++ b/docs-site/docs/en/api/rest.md
@@ -51,7 +51,11 @@ curl http://localhost:9200/health
 >
 > **The two channels return different keys** — parse `/health` per channel:
 >
-> | Key | latest `0.8.8` | preview `0.9.0-preview.29` |
+> 🔴 **`latest` moved from `0.8.8` to `0.9.0-preview.30` on 2026-08-27 (contains the redaction fix `7bacb729`).**
+> The text below describes **versions**, not channels — channels move, versions do not.
+> Check the current pointer with `npm view @sleep2agi/commhub-server dist-tags`.
+>
+> | Key | `0.8.8` | `0.9.0-preview.29` |
 > |---|---|---|
 > | `sse_sessions` | **returned even unauthenticated, and unredacted** | not returned unauthenticated |
 > | `limits` | absent | present |
@@ -59,7 +63,7 @@ curl http://localhost:9200/health
 > The other 13 keys were present on both **in this capture** — one sample per
 > channel, not a permanent contract.
 
-::: danger On latest `0.8.8`, `sse_sessions` exposes every connected agent to anonymous callers
+::: danger On `0.8.8`, `sse_sessions` exposes every connected agent to anonymous callers
 The sample above shows `{}` **only because that clean container had zero SSE
 connections**. **Do not read it as "latest leaks nothing."**
 
@@ -74,7 +78,7 @@ request; see `server/src/health-redaction.test.ts`.
 
 So the difference between channels is not "key present / key absent":
 
-- **latest `0.8.8`** — anonymous callers can read the full live-session breakdown
+- **`0.8.8`** — anonymous callers can read the full live-session breakdown
   (which is empty only on an idle hub);
 - **preview `0.9.0-preview.22` and later** — anonymous callers get aggregate counts
   only; the breakdown moved behind auth at `GET /api/stats/sse`;
@@ -89,7 +93,7 @@ differently across the two channels.
 
 Read the anonymous response **per channel**, per the table and the warning above:
 on preview the key is absent entirely and anonymous callers get aggregate counts
-only; on latest `0.8.8` the key is emitted **unredacted** — empty on an idle hub,
+only; on `0.8.8` the key is emitted **unredacted** — empty on an idle hub,
 and a full `{networkId}:{alias}` breakdown as soon as anything connects.
 
 With a valid token, a system admin, legacy master, or DEV_OPEN


### PR DESCRIPTION
## 触发

我刚把 `@sleep2agi/commhub-server` 的 `latest` 从 `0.8.8` 移到 `0.9.0-preview.30`
(含脱敏修复 `7bacb729`,该修复比 `0.8.8` 晚 35 天)。

```
promote 前  latest=0.8.8            ← 匿名 GET /health 返回 {networkId}:{alias} 明细
promote 后  latest=0.9.0-preview.30 ← 已脱敏
```

**这个动作让 `api/rest.md` 中英两份里四类句子当场变假**,而且是**危险方向**的假:

> 「latest `0.8.8` 的 `sse_sessions` 会向匿名调用方泄露全部在线 agent」

`latest` 现在不再泄露 —— 这句话会**吓唬用户一个已经不存在的问题**,也会让人以为不必升级。

## 改法:按版本描述,不按信道

不是把 `0.8.8` 换成新版本号(下次移动又会假),而是把信道从事实里摘出去:

```
latest `0.8.8` 的 …            →   `0.8.8` 的 …
| 键 | latest `0.8.8` | …       →   | 键 | `0.8.8` | …
```
并在对照表前加一句:latest 已移动、现在指向哪个用 `npm view … dist-tags` 查。

## 🔴 对照:同一份文档里写对了的地方,我一个字没动

`concepts/security.md` 与 `deploy/npm.md`:

> 「**受影响版本:`0.8.8`**(发布于 2026-06-24);`latest` 现在指向哪个版本用
> `npm view @sleep2agi/commhub-server dist-tags` 查」

**它把事实(哪个版本有洞)和信道(latest 指向谁)分开写了** —— 所以我移动 `latest`
之后它**仍然正确**,不需要改。

这就是 RELEASE-SOP 那张 31 项表(#1244 刚补齐并加了自动门)真正想保护的东西:
**不是禁止写版本号,是别把信道钉进事实里。**

信道断言门改后仍绿(exit 0)。