### PR TITLE
fix(test): 发 agent-node 的 PR 会被这条抄死版本号的断言自己撞红

### DIFF
--- a/agent-network/src/opencode-agent-node-pair.test.ts
+++ b/agent-network/src/opencode-agent-node-pair.test.ts
@@ -55,7 +55,17 @@ describe("OpenCode agent-node release pairing", () => {
     const staleGlobal = "@sleep2agi/agent-node@2.5.0-preview.32";
     const resolution = pairedAgentNodeResolution();
     expect(staleGlobal).not.toBe(PAIRED_AGENT_NODE_SPEC);
-    expect(PAIRED_AGENT_NODE_VERSION).toBe("2.5.0-preview.34");
+    // 🔴 不要把版本号抄进断言。
+    // 这个常量每次发 agent-node 都会被 sync-pinned-versions.sh 改，
+    // 而抄数值的断言会让**改它的那个 PR 自己红** ——
+    // sync 脚本只改源码不改测试，于是每次发版都要人记得手补一处。
+    // 今晚 test735 就是同一个形状：min_uptime 20_000 抄进断言，
+    // #1231 改它之后 main 红了近 6 小时。
+    //
+    // 真正要守的不变式是**形状**：它必须是一个 preview 版本号，
+    // 且与 PAIRED_AGENT_NODE_SPEC 拼出来的一致 —— 两条都不随版本变。
+    expect(PAIRED_AGENT_NODE_VERSION).toMatch(/^\d+\.\d+\.\d+-preview\.\d+$/);
+    expect(PAIRED_AGENT_NODE_SPEC).toBe(`@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`);
     expect(resolution).toEqual({
       spec: PAIRED_AGENT_NODE_SPEC,
       args: ["-y", PAIRED_AGENT_NODE_SPEC, "--print-entrypoint"],


### PR DESCRIPTION
## #1246 为什么红

#1246(发 `@sleep2agi/agent-node 2.5.0-preview.35`)红在 `agent-network unit (Docker, non-root)`。根因:

```
agent-network/src/opencode-agent-node-pair.test.ts:58
  expect(PAIRED_AGENT_NODE_VERSION).toBe("2.5.0-preview.34");
```

`sync-pinned-versions.sh` 会把那个常量改成 `.35`,但它**只改 Live versions 表登记的源码位置,不改测试** ——
于是**每次发 agent-node,发版 PR 都会被这一行自己撞红**,而修法只能靠人记得手补一处。

## 这和今晚 test735 是同一个形状

`min_uptime: 20_000` 抄进 test735 的断言,#1231 改它之后 **main 红了近 6 小时**。
我修了 test735 那一处,**没有去找同一个仓里还有几处同样的写法** —— 这是我的疏漏。

## 改法:校验形状,不校验数值

```ts
expect(PAIRED_AGENT_NODE_VERSION).toMatch(/^\d+\.\d+\.\d+-preview\.\d+$/);
expect(PAIRED_AGENT_NODE_SPEC).toBe(`@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`);
```

两条都**不随版本变**。

**同文件第 37 行我一个字没动**:

```ts
expect(OPENCODE_AGENT_NODE_VERSION).toBe(nodePackage.version);
```

它读 `agent-node/package.json` 比一致性 —— **写得对**,不是抄死的。

## witnessed-red(按 #1246 的真实形状:常量与 package.json 两个文件一起改)

```
修复在 + .34(main 现状)     6 pass  0 fail
修复在 + .35(#1246 的改动)   6 pass  0 fail   ← 修好了
撤掉修复 + .35              5 pass  1 fail   ← 复现了 #1246 的红
```

变异只动一个变量(有没有这处修复),红绿翻转。

### 🔴 我第一次的 witnessed-red 是错的,记在这里

第一次我**只改了常量、没改 `package.json`**,人为造出两者不一致,于是第 37 行(那条正确的断言)
也红了 —— 我差点据此认为它也需要修。

**复现要按被测 PR 的真实形状,不是按我以为的形状。**

## 顺带普查到的,本 PR 不动

```
opencode-pin.test.ts:28          OPENCODE_BUILTIN_PIN  "1.18.1"
claude-native-binary.test.ts:20  version               "0.3.226"
```

它们钉的是**外部依赖**版本(不随我们发版而变),性质不同 —— 但下次升那两个依赖时会遇到同样的问题。
