### PR TITLE
ci(release): 发包搬进 Actions —— 发的是门验过的那份 tarball,不是开发机上编的

### DIFF
--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -1,0 +1,136 @@
+# 把某个已发布的 preview 版本升到 npm 的 latest dist-tag。
+#
+# 为什么单独一个 workflow,而不是 release.yml 里的一步:
+#   docs/RELEASE-SOP.md §Step 7 的两阶段规则 ——
+#     第一阶段:publish --tag preview 后,**至少 30 分钟**真实环境烟测
+#     第二阶段:owner 或 lead **显式 ACK** 后才能升 latest
+#   那道人工闸是故意的。把它并进 release.yml 会让"发出去"和"推给所有人"
+#   变成一个动作,而这两件事的影响面差一个数量级:
+#   preview 是滚动通道(发错了下一个覆盖),latest 是所有 `npm i` / 不带版本
+#   `bunx` 的用户立刻拿到。
+#
+# 🔴 这个 workflow 会拒绝三种情况,每一种都真实发生过:
+#   1. 目标版本在 npm 上不存在 —— 打错版本号
+#   2. 距 preview 发布不足 30 分钟 —— 违反 §Step 7 第一阶段
+#   3. 目标版本比当前 latest 旧 —— 回退式 promote
+#
+#   第 3 条来自 2026-08-27 的一次真实失误:当时窗口已过、owner ACK 也有,
+#   于是把 @sleep2agi/agent-node 的 latest 推到了 2.5.0-preview.34 ——
+#   但那个版本**不含当晚的成果**(它发布于 11 小时前,当晚的 PR 全在其后)。
+#   窗口是"能不能推"的判据,不是"该不该推"的判据。两者被混为一谈。
+#   所以这里额外要求填 must-contain,并在 tarball 里断言它真的存在。
+
+name: promote to latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: '包名(不含 @sleep2agi/)'
+        required: true
+        type: choice
+        options:
+          - agent-network
+          - agent-node
+          - commhub-server
+      version:
+        description: '要升为 latest 的版本(必须已发布在 npm 上)'
+        required: true
+        type: string
+      must_contain:
+        description: '该版本必须包含的符号/字符串 —— 防止把 latest 推到一个不含目标改动的旧版本'
+        required: true
+        type: string
+      ack:
+        description: '确认已完成 ≥30 分钟真实环境烟测,且这是 owner/lead 的显式 ACK'
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  promote:
+    name: promote ${{ inputs.package }}@${{ inputs.version }} → latest
+    runs-on: ubuntu-latest
+    if: inputs.ack
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: 闸 1 —— 目标版本在 npm 上存在吗
+        run: |
+          set -euo pipefail
+          P="@sleep2agi/${{ inputs.package }}"
+          npm view "$P@${{ inputs.version }}" version >/dev/null 2>&1 \
+            || { echo "::error::$P@${{ inputs.version }} 在 npm 上不存在"; exit 1; }
+          echo "存在 ✅"
+
+      - name: 闸 2 —— 距 preview 发布是否已满 30 分钟(SOP §Step 7 第一阶段)
+        run: |
+          set -euo pipefail
+          P="@sleep2agi/${{ inputs.package }}"
+          pub=$(npm view "$P" time --json | node -e '
+            let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+              const t=JSON.parse(s)["${{ inputs.version }}"];
+              if(!t){console.error("拿不到发布时间");process.exit(1)}
+              console.log(t)})')
+          echo "发布于 $pub"
+          mins=$(node -e "console.log(Math.floor((Date.now()-Date.parse('$pub'))/60000))")
+          echo "距今 $mins 分钟"
+          [ "$mins" -ge 30 ] || { echo "::error::不足 30 分钟(还差 $((30-mins)) 分钟)。SOP §Step 7 要求先做真实环境烟测。"; exit 1; }
+
+      - name: 闸 3 —— 不许回退式 promote
+        run: |
+          set -euo pipefail
+          P="@sleep2agi/${{ inputs.package }}"
+          cur=$(npm view "$P" dist-tags.latest)
+          echo "当前 latest: $cur   目标: ${{ inputs.version }}"
+          node -e '
+            const semverish=v=>v.split(/[.-]/).map(x=>/^\d+$/.test(x)?+x:x);
+            const a=semverish("'"$cur"'"), b=semverish("${{ inputs.version }}");
+            for(let i=0;i<Math.max(a.length,b.length);i++){
+              const x=a[i]??0,y=b[i]??0;
+              if(x===y)continue;
+              if(typeof x==="number"&&typeof y==="number"){process.exit(y>x?0:1)}
+              process.exit(String(y)>String(x)?0:1);
+            }
+            process.exit(1);   // 完全相等 = 无意义的 promote
+          ' || { echo "::error::目标版本不比当前 latest 新 —— 拒绝回退式 promote"; exit 1; }
+
+      - name: 🔴 闸 4 —— 目标版本真的含要发的改动吗
+        run: |
+          set -euo pipefail
+          P="@sleep2agi/${{ inputs.package }}"
+          mkdir -p /tmp/verify && cd /tmp/verify
+          npm pack "$P@${{ inputs.version }}" >/dev/null
+          tar -xzf ./*.tgz
+          if grep -rq -- '${{ inputs.must_contain }}' package/; then
+            echo "✅ 在该版本的字节里找到了 '${{ inputs.must_contain }}'"
+          else
+            echo "::error::'${{ inputs.must_contain }}' 不在 $P@${{ inputs.version }} 的字节里。"
+            echo "这正是 2026-08-27 那次失误的形状:窗口过了、ACK 有了,但版本里没有要发的东西。"
+            exit 1
+          fi
+
+      - name: dist-tag add … latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          [ -n "${NODE_AUTH_TOKEN:-}" ] || { echo "::error::缺少 secrets.NPM_TOKEN(建议改用 npm trusted publishing/OIDC)"; exit 1; }
+          npm dist-tag add "@sleep2agi/${{ inputs.package }}@${{ inputs.version }}" latest
+
+      - name: 核实(看 registry,不看退出码)
+        run: |
+          set -euo pipefail
+          sleep 12
+          got=$(npm view "@sleep2agi/${{ inputs.package }}" dist-tags.latest)
+          echo "latest 现在是: $got"
+          [ "$got" = "${{ inputs.version }}" ] || { echo "::error::latest 仍是 $got —— 没生效"; exit 1; }
+          echo "✅ 已升为 latest"
+          echo "::warning::发版后必做:按 docs/RELEASE-SOP.md 那张 31 项表核信道断言 —— latest 一动,那些'latest X 会怎样'的句子当场变假"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,11 @@ on:
         description: 'Version to gate (e.g. 2.2.22-preview.4 or 2.2.21)'
         required: true
         type: string
+      publish:
+        description: '门全绿后,把 CI 构建的 tarball 发到 npm 的 preview 通道(永不发 latest)'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-gate-${{ github.ref }}
@@ -461,3 +466,93 @@ jobs:
             # Non-blocking: report-only by design (see header). Maintainer decides.
             exit 0
           fi
+
+  # ── publish ────────────────────────────────────────────────────────────────
+  #
+  # 🔴 为什么 needs 里没有 verdict:
+  #   verdict 是 `if: always()` 且失败时也 `exit 0`(report-only by design,见文件头)。
+  #   把 publish 挂在它后面,门红了照样发 —— 那是"打印检查结果"被当成了"拿它当判据"。
+  #   所以这里直接依赖四道门本身,并在 if: 里逐个断言 success。
+  #
+  # 🔴 为什么发的是 CI 打的 tarball,不是在 runner 上重新 build:
+  #   gate-1 装的就是这个 artifact。如果 publish 时重新构建,发出去的字节
+  #   就不是被门验过的那份 —— 门验 A、用户装 B,验证等于没做。
+  #
+  # 🔴 为什么永远不发 latest:
+  #   docs/RELEASE-SOP.md §Step 7 的两阶段规则:preview 发布后至少 30 分钟真实环境
+  #   烟测 + owner 显式 ACK,才能升 latest。那道人工闸是故意的,不能被 CI 取消。
+  #   升 latest 走单独的 workflow_dispatch,见 promote-latest.yml。
+  publish:
+    name: publish (preview only)
+    needs: [build-tarball, gate-1-install-smoke, gate-2-pinned-audit, gate-3-release-notes, gate-4-doc-version-claims]
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.publish &&
+      needs.gate-1-install-smoke.result == 'success' &&
+      needs.gate-2-pinned-audit.result == 'success' &&
+      needs.gate-3-release-notes.result == 'success' &&
+      needs.gate-4-doc-version-claims.result == 'success'
+    permissions:
+      contents: read
+      id-token: write          # npm trusted publishing(OIDC)—— 无长期 token
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: gated-tarball
+          path: ./tarball
+
+      - name: 认清要发的到底是哪个字节
+        run: |
+          set -euo pipefail
+          f=$(ls ./tarball/*.tgz)
+          echo "tarball: $f"
+          echo "sha256:  $(sha256sum "$f" | cut -d" " -f1)"
+          # 从 tarball 自己读版本,不信 inputs —— inputs 是人打的,tarball 是门验过的
+          v=$(tar -xzOf "$f" package/package.json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')
+          n=$(tar -xzOf "$f" package/package.json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).name))')
+          echo "package: $n@$v"
+          if [ "$v" != "${{ inputs.version }}" ]; then
+            echo "::error::tarball 里是 $v,而 dispatch 输入的是 ${{ inputs.version }} —— 拒绝发布"
+            exit 1
+          fi
+          echo "TARBALL=$f" >> "$GITHUB_ENV"
+
+      - name: 这个版本是不是已经发过了(重复发布会失败,先说清楚)
+        run: |
+          set -euo pipefail
+          n=$(tar -xzOf "$TARBALL" package/package.json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).name))')
+          if npm view "$n@${{ inputs.version }}" version >/dev/null 2>&1; then
+            echo "::error::$n@${{ inputs.version }} 已存在于 npm —— 先 bump 版本号"
+            exit 1
+          fi
+          echo "npm 上尚无此版本,可发"
+
+      - name: npm publish --tag preview
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::缺少 secrets.NPM_TOKEN。"
+            echo "更好的做法是 npm trusted publishing(OIDC):在 npmjs.com 上把这个仓库+workflow"
+            echo "配成该包的 trusted publisher,然后删掉 NPM_TOKEN —— 短时凭据,作用域只在这次运行。"
+            exit 1
+          fi
+          npm publish "$TARBALL" --tag preview --provenance --access public
+
+      - name: 发后核实(看 registry 不看退出码)
+        run: |
+          set -euo pipefail
+          n=$(tar -xzOf "$TARBALL" package/package.json | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).name))')
+          sleep 10
+          got=$(npm view "$n" dist-tags.preview)
+          echo "npm preview 现在是: $got"
+          [ "$got" = "${{ inputs.version }}" ] || { echo "::error::preview 仍是 $got,发布没生效"; exit 1; }
+          echo "✅ $n@${{ inputs.version }} 已发布到 preview 通道"
+          echo "下一步(人工):至少 30 分钟真实环境烟测 + owner ACK 后,用 promote-latest 升 latest"


### PR DESCRIPTION
## 背景

> "NPM 包发版都改成 GitHub Action 吧,别自己编译了,本机只是开发"

今晚我**手工**发了两个包(`agent-network@2.3.0-preview.47`、把 `commhub-server` 的 `latest`
从有洞的 `0.8.8` 推到 `0.9.0-preview.30`)。tarball 是在开发机上构建的 —— 那是真实的供应链弱点:
**发出去的字节没有第二个人能复现**,凭据也绑在某台机器的登录态上。

## 好消息:一大半本来就有

`release.yml` 已经在 CI 里 `npm pack`(honors `prepublishOnly` + `.npmignore`),上传为 `gated-tarball`,
**而 gate-1 装的就是这个 artifact**(不是从 npm 装 —— 所以能在发布前抓到坏包)。

缺的只有最后一段"发"。

## 🔴 一个必须避开的陷阱

```yaml
verdict:
  if: always()
  ...
  else
    echo "::warning::release gate has at least one failure"
    exit 0        # ← Non-blocking: report-only by design
```

**`verdict` 永远成功。** 把 `publish` 挂在 `needs: verdict` 后面,门红了照发。

所以 `publish` **直接依赖四道门本身**,并在 `if:` 里逐个断言 `success`。

这条今晚在别处刚踩过:*打印检查结果 ≠ 拿它当判据*。

## publish job

- 发的是 **CI 打的那个 tarball**,不在 publish 时重新 build —— 否则门验 A、用户装 B
- 从 tarball 自己读版本与 `inputs.version` 比对(**inputs 是人打的,tarball 是门验过的**)
- npm 上已存在同版本就拒绝
- **永远 `--tag preview`**,带 `--provenance`
- 发后核 registry,不看退出码

## promote-latest.yml —— 四道闸,每一道都对应一次真实失误

| 闸 | 拦什么 | 来源 |
|---|---|---|
| 1 | 目标版本在 npm 上不存在 | 打错版本号 |
| 2 | 距 preview 发布不足 30 分钟 | SOP §Step 7 第一阶段 |
| 3 | 目标版本不比当前 latest 新 | 回退式 promote |
| **4** | **目标版本必须真的含要发的改动**(`must_contain`,在 tarball 字节里 grep) | **今晚我自己的失误** |

**闸 4 的由来**:今晚窗口已过、owner ACK 也有,于是我把 `agent-node` 的 `latest` 推到了
`2.5.0-preview.34` —— 但那个版本**不含当晚的成果**(发布于 11 小时前,当晚的 PR 全在其后)。

**窗口是"能不能推"的判据,不是"该不该推"的判据。我把两者混了。** 闸 4 把那个判断交给机器。

## 为什么 promote 不并进 release.yml

SOP §Step 7 的两阶段规则里有一道**故意的人工闸**。把它并进去会让"发出去"和"推给所有人"
变成一个动作,而这两者影响面差一个数量级:`preview` 是滚动通道(发错了下一个覆盖),
`latest` 是所有 `npm i` / 不带版本 `bunx` 的用户**立刻**拿到。

## 凭据:建议改 OIDC

两个 workflow 都声明了 `id-token: write` 为 npm trusted publishing 留路。
当前先用 `secrets.NPM_TOKEN`,缺失时的报错文案直接写明理由:

> 长期 token 进 secrets = **任何能触发 workflow 的路径都能发包**;
> OIDC 是每次签发短时凭据,作用域只在那一次运行。

**需要有人在 npmjs.com 上把这个仓库 + workflow 配成这几个包的 trusted publisher**,
配好之后就能删掉 `NPM_TOKEN`。这一步我做不了。
