### PR TITLE
feat(feishu): route replies through commhub task dispatch

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -83,6 +83,7 @@ on:
       - 'tests/test686-rest-shape-golden/**'
       - 'tests/test765-batch-runtime-gate/**'
       - 'tests/test766-bunx-preflight/**'
+      - 'tests/test1241-feishu-commhub-routing/**'
       # test823 是这道 L1 并发闸门自己的回归,跑的是真的 scripts/qa.sh
       # (把 docker/npm 换成 PATH 上的桩)。改它必须能重跑跑它的 workflow。
       - 'tests/test823-l1-concurrency-cap/**'
@@ -239,6 +240,7 @@ on:
       - 'tests/test686-rest-shape-golden/**'
       - 'tests/test765-batch-runtime-gate/**'
       - 'tests/test766-bunx-preflight/**'
+      - 'tests/test1241-feishu-commhub-routing/**'
       # test823 是这道 L1 并发闸门自己的回归,跑的是真的 scripts/qa.sh
       # (把 docker/npm 换成 PATH 上的桩)。改它必须能重跑跑它的 workflow。
       - 'tests/test823-l1-concurrency-cap/**'

--- a/agent-network/src/im/feishu/bridge-commhub-routing.test.ts
+++ b/agent-network/src/im/feishu/bridge-commhub-routing.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { JsonIMCorrelationStore } from "../correlation-store";
+import type { NormalizedIMEvent, NormalizedIMMessage } from "../types";
+import {
+  createCommHubEventHandler,
+  type IMBridgeCommHubClient,
+  type IMBridgeCommHubInboxMessage,
+} from "./bridge";
+
+function event(overrides: Partial<NormalizedIMEvent> = {}): NormalizedIMEvent {
+  return {
+    platform: "feishu",
+    connectionId: "node-a#feishu",
+    conversation: {
+      platform: "feishu",
+      conversationId: "oc_test",
+      conversationType: "group",
+      threadRootId: "om_root",
+    },
+    sender: { id: "ou_sender" },
+    messageId: "om_source",
+    mentioned: true,
+    content: { text: "hello" },
+    receivedAt: Date.now(),
+    idempotencyKey: "feishu:node-a#feishu:om_source",
+    ...overrides,
+  };
+}
+
+function fakeCommHub(messages: IMBridgeCommHubInboxMessage[] = []) {
+  const sentTasks: any[] = [];
+  const acked: string[] = [];
+  const client: IMBridgeCommHubClient = {
+    async sendTask(args) {
+      sentTasks.push(args);
+      return { taskId: "task_commhub_1" };
+    },
+    async getInbox() {
+      return messages;
+    },
+    async ackInbox(_alias, messageId) {
+      acked.push(messageId);
+      const index = messages.findIndex((message) => message.id === messageId);
+      if (index >= 0) messages.splice(index, 1);
+    },
+  };
+  return { client, sentTasks, acked };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("Feishu bridge CommHub route", () => {
+  test("dispatches inbound IM as a CommHub task and routes one final text reply", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "anet-feishu-commhub-"));
+    const store = new JsonIMCorrelationStore(join(scratch, "state.json"));
+    const messages: IMBridgeCommHubInboxMessage[] = [];
+    const hub = fakeCommHub(messages);
+    const sent: NormalizedIMMessage[] = [];
+    const handler = createCommHubEventHandler(
+      "node-a",
+      {
+        connectionName: "node-a",
+        send: async (message: NormalizedIMMessage) => {
+          sent.push(message);
+          return { messageId: `om_${sent.length}` };
+        },
+      } as any,
+      60_000,
+      false,
+      store,
+      hub.client,
+      5,
+    );
+
+    try {
+      await handler(event());
+      messages.push({
+        id: "reply_1",
+        type: "reply",
+        content: "final answer",
+        from_session: "node-a",
+        in_reply_to: "task_commhub_1",
+      });
+      await sleep(30);
+
+      expect(hub.sentTasks).toHaveLength(1);
+      expect(hub.sentTasks[0].alias).toBe("node-a");
+      expect((hub.sentTasks[0].meta as any).im.bridge).toBe("feishu");
+      expect(sent.map((message) => message.text)).toEqual(["final answer"]);
+      expect(hub.acked).toEqual(["reply_1"]);
+      expect((await store.getCorrelation("task_commhub_1"))?.status).toBe("completed");
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  test("deduplicates repeated CommHub replies for the same task across marker-fallback dispatch", async () => {
+    const scratch = mkdtempSync(join(tmpdir(), "anet-feishu-commhub-file-"));
+    const store = new JsonIMCorrelationStore(join(scratch, "state.json"));
+    const filePath = "/tmp/not-under-feishu-outbound/report.pdf";
+    const messages: IMBridgeCommHubInboxMessage[] = [
+      {
+        id: "reply_1",
+        type: "reply",
+        content: `see attached\n[[send-file:${filePath}]]`,
+        from_session: "node-a",
+        in_reply_to: "task_commhub_1",
+      },
+      {
+        id: "reply_2",
+        type: "reply",
+        content: `see attached\n[[send-file:${filePath}]]`,
+        from_session: "node-a",
+        in_reply_to: "task_commhub_1",
+      },
+    ];
+    const hub = fakeCommHub(messages);
+    const sent: NormalizedIMMessage[] = [];
+    const handler = createCommHubEventHandler(
+      "node-a",
+      {
+        connectionName: "node-a",
+        send: async (message: NormalizedIMMessage) => {
+          sent.push(message);
+          return { messageId: `om_${sent.length}` };
+        },
+      } as any,
+      60_000,
+      false,
+      store,
+      hub.client,
+      5,
+    );
+
+    try {
+      await handler(event());
+      await sleep(50);
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0].text).toBe("see attached");
+      expect(hub.acked).toEqual(["reply_1", "reply_2"]);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+
+  test("acks orphan replies after correlation gc instead of silently leaving them unread", async () => {
+    const messages: IMBridgeCommHubInboxMessage[] = [
+      {
+        id: "reply_orphan",
+        type: "reply",
+        content: "late answer",
+        from_session: "node-a",
+        in_reply_to: "missing-task",
+      },
+    ];
+    const hub = fakeCommHub(messages);
+    const sent: NormalizedIMMessage[] = [];
+    createCommHubEventHandler(
+      "node-a",
+      {
+        connectionName: "node-a",
+        send: async (message: NormalizedIMMessage) => {
+          sent.push(message);
+          return { messageId: `om_${sent.length}` };
+        },
+      } as any,
+      60_000,
+      false,
+      undefined,
+      hub.client,
+      5,
+    );
+
+    await sleep(30);
+
+    expect(sent).toEqual([]);
+    expect(hub.acked).toEqual(["reply_orphan"]);
+  });
+});

--- a/agent-network/src/im/feishu/bridge.ts
+++ b/agent-network/src/im/feishu/bridge.ts
@@ -29,7 +29,8 @@
  *   M4: agent-node spawn integration (fork(this) wired by agent-node).
  *   M5: group @bot trigger refinement, image up/down, Docker smoke.
  */
-import type { NormalizedIMEvent } from "../types.js";
+import type { IMCorrelationStore, NormalizedIMEvent } from "../types.js";
+import { createJsonIMCorrelationStore } from "../correlation-store.js";
 import { FeishuAdapter } from "./adapter.js";
 import { loadFeishuChannelConfig } from "./config.js";
 import {
@@ -40,6 +41,27 @@ import {
 } from "./outbound-marker.js";
 import { feishuOutboundDir } from "./outbound-paths.js";
 import * as fs from "node:fs";
+
+export type IMBridgeCommHubInboxMessage = {
+  id: string;
+  type?: string;
+  content: string;
+  from_session?: string;
+  in_reply_to?: string;
+  meta?: unknown;
+};
+
+export interface IMBridgeCommHubClient {
+  sendTask(args: {
+    alias: string;
+    task: string;
+    priority?: "high" | "normal" | "low";
+    ttlSeconds?: number;
+    meta?: unknown;
+  }): Promise<{ taskId: string }>;
+  getInbox(alias: string): Promise<IMBridgeCommHubInboxMessage[]>;
+  ackInbox(alias: string, messageId: string): Promise<void>;
+}
 
 export interface FeishuBridgeOptions {
   /** Absolute path to `.anet/nodes/<node>/channels/feishu/`. */
@@ -56,6 +78,12 @@ export interface FeishuBridgeOptions {
   onEvent?: (event: NormalizedIMEvent) => Promise<void>;
   /** Fatal WS failure after initial readiness (for worker lifecycle ownership). */
   onTerminalError?: (error: Error) => void;
+  /** Persistent task/message correlation state. Defaults to channelDir/state.json. */
+  correlationStore?: IMCorrelationStore;
+  /** CommHub task transport. Defaults to COMMHUB_URL/COMMHUB_TOKEN when available. */
+  commhubClient?: IMBridgeCommHubClient;
+  /** Poll interval for CommHub replies. Defaults to 1500ms. */
+  commhubPollMs?: number;
 }
 
 // ── IPC contract with the agent-node parent (M3) ─────────────────────────
@@ -122,9 +150,19 @@ export async function startFeishuBridge(
   });
 
   const ttlMs = channelConfig.taskTimeoutMs || DEFAULT_REPLY_PENDING_TTL_MS;
+  const correlationStore =
+    opts.correlationStore ?? createJsonIMCorrelationStore(`${opts.channelDir}/state.json`);
   const onEvent =
     opts.onEvent ??
-    selectDefaultEventHandler(adapter, ttlMs, channelConfig.ackPlaceholder);
+    selectDefaultEventHandler(
+      opts.nodeAlias,
+      adapter,
+      ttlMs,
+      channelConfig.ackPlaceholder,
+      correlationStore,
+      opts.commhubClient,
+      opts.commhubPollMs,
+    );
   // Middleware order: dedup → rate-limit → think.
   // Dedup runs first so socket-replay events don't burn rate-limit quota.
   // Rate-limit runs before `onEvent` (IPC handoff to think) so over-limit
@@ -396,12 +434,28 @@ const RATE_LIMIT_GC_THRESHOLD = 50;
 const RATE_LIMIT_HARD_CAP = 10_000;
 
 function selectDefaultEventHandler(
+  nodeAlias: string,
   adapter: FeishuAdapter,
   ttlMs: number,
   ackPlaceholder: boolean,
+  correlationStore?: IMCorrelationStore,
+  commhubClient?: IMBridgeCommHubClient,
+  commhubPollMs?: number,
 ): (event: NormalizedIMEvent) => Promise<void> {
+  const client = commhubClient ?? createEnvCommHubClient();
+  if (client) {
+    return createCommHubEventHandler(
+      nodeAlias,
+      adapter,
+      ttlMs,
+      ackPlaceholder,
+      correlationStore,
+      client,
+      commhubPollMs,
+    );
+  }
   if (typeof process.send === "function") {
-    return createIPCEventHandler(adapter, ttlMs, ackPlaceholder);
+    return createIPCEventHandler(adapter, ttlMs, ackPlaceholder, correlationStore);
   }
   return defaultEventLogger;
 }
@@ -450,6 +504,7 @@ export function createIPCEventHandler(
   adapter: FeishuAdapter,
   ttlMs: number,
   ackPlaceholder: boolean,
+  correlationStore?: IMCorrelationStore,
 ): (event: NormalizedIMEvent) => Promise<void> {
   if (typeof process.send !== "function") {
     throw new Error(
@@ -458,6 +513,7 @@ export function createIPCEventHandler(
   }
 
   const pending = new Map<string, PendingEntry>();
+  const delivered = new Set<string>();
 
   process.on("message", (raw: unknown) => {
     if (!isReplyEnvelope(raw)) return;
@@ -465,160 +521,7 @@ export function createIPCEventHandler(
     if (!entry) return;
     pending.delete(raw.eventKey);
 
-    const replyText = raw.text;
-    const eventKey = raw.eventKey;
-    const { event, placeholderMessageId } = entry;
-    void (async () => {
-      // Vincent 2026-06-26 design lock — always send a NEW message for the
-      // reply (no adapter.edit). The placeholderMessageId is logged for
-      // traceability but is not used to mutate the placeholder. Users get
-      // a second push notification when the reply lands.
-      //
-      // RFC-020 §15 (Vincent UAT 2026-06-29 PDF case): parse outbound
-      // `[[send-file:/abs/path]]` markers, strip from visible text, validate
-      // paths per-conversation, and dispatch each file as its own message
-      // (text first if non-empty, then files in source order). adapter.send()
-      // takes one payload at a time — this loop is the multi-dispatch site.
-      const { cleanedText, files: markerRequests } = parseOutboundMarkers(replyText);
-      // convKey: open_chat_id for groups, open_id (sender) for DMs. The
-      // /work/feishu-attachments/<connection>/<convKey>/ directory is the
-      // single allowed outbound root the agent can write into.
-      // 2026-06-29 Vincent UAT path-unify fix: use the SAME directory
-      // helper as inbound downloads (adapter.ts → downloadImage) and the
-      // system-prompt path the agent is taught (cli.ts injection). One
-      // function, one input shape — eliminates the inbound/outbound
-      // divergence that rejected every PDF Vincent's bot produced.
-      //
-      // Inputs:
-      //   - connectionName: adapter.connectionName (raw, no `#feishu` suffix
-      //     — that suffix lives on the IDEMPOTENCY KEY, not the directory
-      //     name).
-      //   - rawConvId: event.conversation.conversationId — the open_chat_id
-      //     Feishu assigns. Present for both DMs and group chats. Always
-      //     used, NEVER the sender.id (sender.id is per-user, not per-
-      //     conversation, and inbound downloads never used it).
-      const connectionName = adapter.connectionName || "feishu";
-      const expectedDir = feishuOutboundDir(
-        connectionName,
-        event.conversation.conversationId,
-      );
-      // Validate every marker request; collect successes + failures.
-      const validFiles: Array<{ path: string; kind: "image" | "file" }> = [];
-      const failureReasons: string[] = [];
-      for (const req of markerRequests) {
-        const reason = validateOutboundPath({
-          p: req.normalized,
-          expectedDir,
-        });
-        if (reason) {
-          process.stderr.write(
-            `[feishu:bridge] outbound-marker rejected ${req.normalized} for ${eventKey}: ${reason}\n`,
-          );
-          failureReasons.push(reason);
-          continue;
-        }
-        // Read first 16 bytes to magic-byte sniff the kind.
-        let kind: "image" | "file" = "file";
-        try {
-          const fd = fs.openSync(req.normalized, "r");
-          try {
-            const head = Buffer.alloc(16);
-            const n = fs.readSync(fd, head, 0, 16, 0);
-            kind = sniffFileKind(head.subarray(0, n));
-          } finally {
-            fs.closeSync(fd);
-          }
-        } catch (e: any) {
-          process.stderr.write(
-            `[feishu:bridge] outbound-marker sniff failed for ${req.normalized}: ${e?.message ?? e}\n`,
-          );
-          failureReasons.push("[文件附件未发送] 读取文件失败");
-          continue;
-        }
-        validFiles.push({ path: req.normalized, kind });
-      }
-
-      const note = placeholderMessageId
-        ? ` (after placeholder=${placeholderMessageId})`
-        : "";
-
-      // If the agent produced ONLY markers + no surrounding text AND every
-      // marker failed validation, we still owe the user a friendly reply
-      // (silent drop is the worst outcome — user thinks bot is hung).
-      const haveAnyOutbound = validFiles.length > 0 || cleanedText.length > 0;
-      let textToSend = cleanedText;
-      if (!haveAnyOutbound) {
-        textToSend = failureReasons[0] || ALL_FILES_FAILED_FALLBACK;
-      } else if (
-        !cleanedText &&
-        validFiles.length > 0 &&
-        failureReasons.length > 0
-      ) {
-        // Some files dispatched, some failed — let the user know.
-        textToSend = `(${failureReasons[0]})`;
-      }
-
-      try {
-        // Send text first if non-empty (puts the file in context for the user).
-        // Caption-mode (RFC-020 §15.2): when there's at least one valid
-        // attachment in THIS dispatch, the text is a caption — skip the
-        // markdown→PNG renderer (looks like "the bot sent another image"
-        // instead of "the bot sent my file") + skip markdown-card render.
-        if (textToSend) {
-          const { messageId } = await adapter.send({
-            target: event.conversation,
-            text: textToSend,
-            replyToMessageId: event.messageId,
-            correlation: { taskId: eventKey },
-            forceTextOnly: validFiles.length > 0,
-          });
-          process.stderr.write(
-            `[feishu:bridge] reply text sent (messageId=${messageId})${note} for ${eventKey}\n`,
-          );
-        }
-        // Then each file as its own outbound message — magic-byte routing
-        // decides image_key vs file_key.
-        for (const f of validFiles) {
-          try {
-            const filename = f.path.split("/").pop() || "file";
-            const sendArgs: any = {
-              target: event.conversation,
-              replyToMessageId: event.messageId,
-              correlation: { taskId: eventKey },
-            };
-            if (f.kind === "image") {
-              sendArgs.imagePath = f.path;
-            } else {
-              sendArgs.files = [{ path: f.path, name: filename }];
-            }
-            const { messageId } = await adapter.send(sendArgs);
-            process.stderr.write(
-              `[feishu:bridge] outbound ${f.kind} sent (messageId=${messageId}, path=${f.path}) for ${eventKey}\n`,
-            );
-          } catch (e: any) {
-            const msg = e instanceof Error ? e.message : String(e);
-            process.stderr.write(
-              `[feishu:bridge] outbound file send failed (${f.path}): ${msg}\n`,
-            );
-            // Friendly fallback: don't surface the raw vendor error.
-            try {
-              await adapter.send({
-                target: event.conversation,
-                text: `[文件附件发送失败] ${f.path.split("/").pop()} — 稍后再试`,
-                replyToMessageId: event.messageId,
-                correlation: { taskId: eventKey },
-              });
-            } catch {
-              // If even the friendly fallback fails, give up silently;
-              // we've already logged the underlying error.
-            }
-          }
-        }
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(`[feishu:bridge] reply delivery failed: ${msg}\n`);
-      }
-    })();
+    void deliverFinalReplyOnce(adapter, delivered, raw.eventKey, entry, raw.text, correlationStore);
   });
 
   return async (event: NormalizedIMEvent) => {
@@ -627,7 +530,7 @@ export function createIPCEventHandler(
     pending.set(event.idempotencyKey, { event });
 
     // TTL — sends a NEW timeout notice (no edit, per Vincent 2026-06-26).
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       const entry = pending.get(event.idempotencyKey);
       if (!entry) return; // reply already arrived
       pending.delete(event.idempotencyKey);
@@ -654,6 +557,7 @@ export function createIPCEventHandler(
         }
       })();
     }, ttlMs);
+    timeout.unref?.();
 
     // Optional placeholder — gives the user an immediate push notification
     // ("bot saw my message"). Awaited so logs stay chronological. Failure
@@ -670,6 +574,20 @@ export function createIPCEventHandler(
         const entry = pending.get(event.idempotencyKey);
         if (entry) {
           entry.placeholderMessageId = messageId;
+          try {
+            await correlationStore?.putCorrelation(event.idempotencyKey, {
+              conversationRef: event.conversation,
+              sourceMessageId: event.messageId,
+              placeholderMessageId: messageId,
+              status: "pending",
+              createdAt: Date.now(),
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(
+              `[feishu:bridge] placeholder correlation persist failed: ${msg}\n`,
+            );
+          }
           process.stderr.write(
             `[feishu:bridge] placeholder sent (messageId=${messageId}) for ${event.idempotencyKey}\n`,
           );
@@ -691,6 +609,355 @@ export function createIPCEventHandler(
     );
     const envelope: BridgeIncomingEnvelope = { type: "event", event, outboundDir };
     process.send!(envelope);
+  };
+}
+
+export function createCommHubEventHandler(
+  nodeAlias: string,
+  adapter: FeishuAdapter,
+  ttlMs: number,
+  ackPlaceholder: boolean,
+  correlationStore: IMCorrelationStore | undefined,
+  commhubClient: IMBridgeCommHubClient,
+  pollMs = 1500,
+): (event: NormalizedIMEvent) => Promise<void> {
+  const pending = new Map<string, PendingEntry>();
+  const delivered = new Set<string>();
+
+  const poll = setInterval(() => {
+    void (async () => {
+      const messages = await commhubClient.getInbox(nodeAlias);
+      for (const msg of messages) {
+        if (msg.type !== "reply" || !msg.in_reply_to) continue;
+        let entry = pending.get(msg.in_reply_to);
+        if (!entry) {
+          const persisted = await correlationStore?.getCorrelation(msg.in_reply_to);
+          if (!persisted) {
+            await sendOrphanReplyNotice(adapter, msg.in_reply_to, msg.content);
+            await commhubClient.ackInbox(nodeAlias, msg.id);
+            continue;
+          }
+          entry = {
+            event: {
+              platform: persisted.conversationRef.platform,
+              connectionId: `${nodeAlias}#feishu`,
+              conversation: persisted.conversationRef,
+              sender: { id: "unknown" },
+              messageId: persisted.sourceMessageId,
+              mentioned: true,
+              content: {},
+              receivedAt: persisted.createdAt,
+              idempotencyKey: msg.in_reply_to,
+            },
+            placeholderMessageId: persisted.placeholderMessageId,
+          };
+        }
+        pending.delete(msg.in_reply_to);
+        await deliverFinalReplyOnce(adapter, delivered, msg.in_reply_to, entry, msg.content, correlationStore);
+        await commhubClient.ackInbox(nodeAlias, msg.id);
+      }
+    })().catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[feishu:bridge] commhub reply poll failed: ${msg}\n`);
+    });
+  }, pollMs);
+  poll.unref?.();
+
+  return async (event: NormalizedIMEvent) => {
+    pending.set(event.idempotencyKey, { event });
+    await sendPlaceholderIfNeeded(adapter, event, pending, ackPlaceholder, correlationStore);
+
+    let pendingKey = event.idempotencyKey;
+    const timeout = setTimeout(() => {
+      const entry = pending.get(pendingKey);
+      if (!entry) return;
+      pending.delete(pendingKey);
+      void sendTimeoutNotice(adapter, event, entry.placeholderMessageId, ttlMs, correlationStore);
+    }, ttlMs);
+    timeout.unref?.();
+
+    const outboundDir = feishuOutboundDir(
+      adapter.connectionName || "feishu",
+      event.conversation.conversationId,
+    );
+    const task = [
+      event.content.text || "",
+      outboundDir ? `\n\n[Feishu outbound directory]\n${outboundDir}` : "",
+    ].join("").trim();
+    const created = await commhubClient.sendTask({
+      alias: nodeAlias,
+      task,
+      priority: "normal",
+      ttlSeconds: Math.max(1, Math.ceil(ttlMs / 1000)),
+      meta: {
+        im: {
+          bridge: "feishu",
+          eventKey: event.idempotencyKey,
+          sourceMessageId: event.messageId,
+          conversation: event.conversation,
+        },
+        attachments: event.content.attachments,
+      },
+    });
+    await correlationStore?.recordSeen(event.idempotencyKey, created.taskId);
+    const existing = pending.get(event.idempotencyKey);
+    if (created.taskId !== event.idempotencyKey && existing) {
+      pending.delete(event.idempotencyKey);
+      pending.set(created.taskId, existing);
+      pendingKey = created.taskId;
+    }
+    await correlationStore?.putCorrelation(created.taskId, {
+      conversationRef: event.conversation,
+      sourceMessageId: event.messageId,
+      placeholderMessageId: existing?.placeholderMessageId,
+      status: "pending",
+      createdAt: Date.now(),
+    });
+  };
+}
+
+async function deliverFinalReplyOnce(
+  adapter: FeishuAdapter,
+  delivered: Set<string>,
+  eventKey: string,
+  entry: PendingEntry,
+  replyText: string,
+  correlationStore?: IMCorrelationStore,
+): Promise<void> {
+  if (delivered.has(eventKey)) {
+    process.stderr.write(`[feishu:bridge] duplicate final reply ignored for ${eventKey}\n`);
+    return;
+  }
+  delivered.add(eventKey);
+  await deliverFinalReply(adapter, eventKey, entry, replyText);
+  await correlationStore?.updateStatus(eventKey, "completed");
+}
+
+async function deliverFinalReply(
+  adapter: FeishuAdapter,
+  eventKey: string,
+  entry: PendingEntry,
+  replyText: string,
+): Promise<void> {
+  const { event, placeholderMessageId } = entry;
+  const { cleanedText, files: markerRequests } = parseOutboundMarkers(replyText);
+  const expectedDir = feishuOutboundDir(
+    adapter.connectionName || "feishu",
+    event.conversation.conversationId,
+  );
+  const validFiles: Array<{ path: string; kind: "image" | "file" }> = [];
+  const failureReasons: string[] = [];
+  for (const req of markerRequests) {
+    const reason = validateOutboundPath({ p: req.normalized, expectedDir });
+    if (reason) {
+      process.stderr.write(
+        `[feishu:bridge] outbound-marker rejected ${req.normalized} for ${eventKey}: ${reason}\n`,
+      );
+      failureReasons.push(reason);
+      continue;
+    }
+    let kind: "image" | "file" = "file";
+    try {
+      const fd = fs.openSync(req.normalized, "r");
+      try {
+        const head = Buffer.alloc(16);
+        const n = fs.readSync(fd, head, 0, 16, 0);
+        kind = sniffFileKind(head.subarray(0, n));
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch (e: any) {
+      process.stderr.write(
+        `[feishu:bridge] outbound-marker sniff failed for ${req.normalized}: ${e?.message ?? e}\n`,
+      );
+      failureReasons.push("[文件附件未发送] 读取文件失败");
+      continue;
+    }
+    validFiles.push({ path: req.normalized, kind });
+  }
+
+  const note = placeholderMessageId ? ` (after placeholder=${placeholderMessageId})` : "";
+  const haveAnyOutbound = validFiles.length > 0 || cleanedText.length > 0;
+  let textToSend = cleanedText;
+  if (!haveAnyOutbound) textToSend = failureReasons[0] || ALL_FILES_FAILED_FALLBACK;
+  else if (!cleanedText && validFiles.length > 0 && failureReasons.length > 0) {
+    textToSend = `(${failureReasons[0]})`;
+  }
+
+  try {
+    if (textToSend) {
+      const { messageId } = await adapter.send({
+        target: event.conversation,
+        text: textToSend,
+        replyToMessageId: event.messageId,
+        correlation: { taskId: eventKey },
+        forceTextOnly: validFiles.length > 0,
+      });
+      process.stderr.write(
+        `[feishu:bridge] reply text sent (messageId=${messageId})${note} for ${eventKey}\n`,
+      );
+    }
+    for (const f of validFiles) {
+      try {
+        const filename = f.path.split("/").pop() || "file";
+        const sendArgs: any = {
+          target: event.conversation,
+          replyToMessageId: event.messageId,
+          correlation: { taskId: eventKey },
+        };
+        if (f.kind === "image") sendArgs.imagePath = f.path;
+        else sendArgs.files = [{ path: f.path, name: filename }];
+        const { messageId } = await adapter.send(sendArgs);
+        process.stderr.write(
+          `[feishu:bridge] outbound ${f.kind} sent (messageId=${messageId}, path=${f.path}) for ${eventKey}\n`,
+        );
+      } catch (e: any) {
+        const msg = e instanceof Error ? e.message : String(e);
+        process.stderr.write(`[feishu:bridge] outbound file send failed (${f.path}): ${msg}\n`);
+        try {
+          await adapter.send({
+            target: event.conversation,
+            text: `[文件附件发送失败] ${f.path.split("/").pop()} — 稍后再试`,
+            replyToMessageId: event.messageId,
+            correlation: { taskId: eventKey },
+          });
+        } catch {}
+      }
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[feishu:bridge] reply delivery failed: ${msg}\n`);
+  }
+}
+
+async function sendPlaceholderIfNeeded(
+  adapter: FeishuAdapter,
+  event: NormalizedIMEvent,
+  pending: Map<string, PendingEntry>,
+  ackPlaceholder: boolean,
+  correlationStore?: IMCorrelationStore,
+): Promise<void> {
+  if (!ackPlaceholder) return;
+  try {
+    const { messageId } = await adapter.send({
+      target: event.conversation,
+      text: ACK_PLACEHOLDER_TEXT,
+      replyToMessageId: event.messageId,
+      correlation: { taskId: event.idempotencyKey },
+    });
+    const entry = pending.get(event.idempotencyKey);
+    if (!entry) return;
+    entry.placeholderMessageId = messageId;
+    await correlationStore?.putCorrelation(event.idempotencyKey, {
+      conversationRef: event.conversation,
+      sourceMessageId: event.messageId,
+      placeholderMessageId: messageId,
+      status: "pending",
+      createdAt: Date.now(),
+    });
+    process.stderr.write(
+      `[feishu:bridge] placeholder sent (messageId=${messageId}) for ${event.idempotencyKey}\n`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[feishu:bridge] placeholder send failed: ${msg} — reply will still send as a new message\n`,
+    );
+  }
+}
+
+async function sendTimeoutNotice(
+  adapter: FeishuAdapter,
+  event: NormalizedIMEvent,
+  placeholderMessageId: string | undefined,
+  ttlMs: number,
+  correlationStore?: IMCorrelationStore,
+): Promise<void> {
+  try {
+    await adapter.send({
+      target: event.conversation,
+      text: TIMEOUT_NOTICE_TEXT,
+      replyToMessageId: event.messageId,
+      correlation: { taskId: event.idempotencyKey },
+    });
+    await correlationStore?.updateStatus(event.idempotencyKey, "timeout");
+    const note = placeholderMessageId ? ` (after placeholder=${placeholderMessageId})` : "";
+    process.stderr.write(
+      `[feishu:bridge] timeout-notify sent${note} for ${event.idempotencyKey} after ${ttlMs}ms\n`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[feishu:bridge] timeout-notify send failed: ${msg}\n`);
+  }
+}
+
+async function sendOrphanReplyNotice(
+  adapter: FeishuAdapter,
+  taskId: string,
+  text: string,
+): Promise<void> {
+  process.stderr.write(
+    `[feishu:bridge] orphan commhub reply for ${taskId}: ${text.slice(0, 120)}\n`,
+  );
+}
+
+function createEnvCommHubClient(): IMBridgeCommHubClient | null {
+  const url = (process.env.COMMHUB_URL || process.env.ANET_HUB_URL || "").replace(/\/$/, "");
+  const token =
+    process.env.ANET_HUB_TOKEN ||
+    process.env.COMMHUB_TOKEN ||
+    process.env.COMMHUB_AUTH_TOKEN ||
+    "";
+  if (!url) return null;
+
+  async function call(tool: string, args: Record<string, unknown>): Promise<any> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const res = await fetch(`${url}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: Date.now(),
+        method: "tools/call",
+        params: { name: tool, arguments: args },
+      }),
+    });
+    const raw = await res.text();
+    if (!res.ok) throw new Error(`CommHub ${tool} failed: HTTP ${res.status}`);
+    const match = raw.match(/data: (.+)/);
+    const data = match ? JSON.parse(match[1]) : JSON.parse(raw);
+    const textResult = data?.result?.content?.[0]?.text;
+    const parsed = textResult ? JSON.parse(textResult) : data;
+    if (parsed?.ok === false) {
+      throw new Error(parsed.message || parsed.error || `CommHub ${tool} rejected request`);
+    }
+    return parsed;
+  }
+
+  return {
+    async sendTask(args) {
+      const result = await call("send_task", {
+        alias: args.alias,
+        task: args.task,
+        priority: args.priority ?? "normal",
+        ttl_seconds: args.ttlSeconds,
+        meta: args.meta,
+      });
+      const taskId = result?.task_id || result?.message_id || result?.id;
+      if (!taskId) throw new Error("CommHub send_task returned no task_id");
+      return { taskId };
+    },
+    async getInbox(alias) {
+      const result = await call("get_inbox", { alias, limit: 20 });
+      return Array.isArray(result?.messages) ? result.messages : [];
+    },
+    async ackInbox(alias, messageId) {
+      await call("ack_inbox", { alias, message_id: messageId });
+    },
   };
 }
 

--- a/agent-node/src/cli.ts
+++ b/agent-node/src/cli.ts
@@ -4879,8 +4879,15 @@ function isLowValueText(text: string, isReply = false): boolean {
   return false;
 }
 
-function shouldSkipMessage(from: string, content: string, msgType?: string): string | null {
-  if (from === ALIAS) return "self";
+function isIMBridgeMessage(msg: any): boolean {
+  const meta = msg?.meta || (() => {
+    try { return msg?.meta_json ? JSON.parse(msg.meta_json) : null; } catch { return null; }
+  })();
+  return meta?.im?.bridge === "feishu";
+}
+
+function shouldSkipMessage(from: string, content: string, msgType?: string, msg?: any): string | null {
+  if (from === ALIAS && !isIMBridgeMessage(msg)) return "self";
   if (content.startsWith(`[${ALIAS}]`)) return "own-prefix";
   const actionable = msgType === "task" || msgType === "broadcast" || msgType === "reply";
   // Don't cooldown explicit tasks — humans often send rapid follow-ups from
@@ -4966,6 +4973,11 @@ async function processInbox() {
         : ` ${content.slice(0, 100)}`;
       log(`← [${from}] (${msgType}/${msg.priority || "normal"})${images.length ? ` +${images.length} attachment(s)` : ""}${inboundLogSuffix}`);
 
+      if (msgType === "reply" && from === ALIAS) {
+        debug(`leave self reply unacked for channel bridge: ${msg.id.slice(0, 8)}`);
+        return;
+      }
+
       // Other non-task / non-broadcast messages retain their historical
       // ack-only behavior; send_message never implies an LLM response.
       if (!deliveryPolicy.deliverToRuntime) {
@@ -4979,7 +4991,7 @@ async function processInbox() {
         return;
       }
 
-      const skip = shouldSkipMessage(from, content, msgType);
+      const skip = shouldSkipMessage(from, content, msgType, msg);
       if (skip) {
         log(formatInboxSkipLog({
           sender: from,

--- a/docs/tests/report-test1241-feishu-commhub-routing.txt
+++ b/docs/tests/report-test1241-feishu-commhub-routing.txt
@@ -1,7 +1,7 @@
 # test1241 Feishu CommHub routing
 
-Date: 2026-08-26T23:14:09Z
-HEAD: unknown
+Date: 2026-08-26T23:25:45Z
+HEAD: cfe1bf45
 
 [1] witnessed-red fixture: legacy IPC + CommHub reply paths send twice when both are active
 [feishu:bridge] reply text sent (messageId=om_1) for feishu:node-a#feishu:om_source
@@ -12,18 +12,18 @@ bun test v1.3.14 (0d9b296a)
 
 src/im/feishu/bridge-commhub-routing.test.ts:
 [feishu:bridge] reply text sent (messageId=om_1) for task_commhub_1
-(pass) Feishu bridge CommHub route > dispatches inbound IM as a CommHub task and routes one final text reply [58.31ms]
+(pass) Feishu bridge CommHub route > dispatches inbound IM as a CommHub task and routes one final text reply [45.54ms]
 [feishu:bridge] outbound-marker rejected /tmp/not-under-feishu-outbound/report.pdf for task_commhub_1: [文件附件未发送] 路径不在允许的会话目录内 (必须在 /work/feishu-attachments/node-a/oc_test/ 下)
 [feishu:bridge] reply text sent (messageId=om_1) for task_commhub_1
 [feishu:bridge] duplicate final reply ignored for task_commhub_1
-(pass) Feishu bridge CommHub route > deduplicates repeated CommHub replies for the same task across marker-fallback dispatch [62.19ms]
+(pass) Feishu bridge CommHub route > deduplicates repeated CommHub replies for the same task across marker-fallback dispatch [66.29ms]
 [feishu:bridge] orphan commhub reply for missing-task: late answer
-(pass) Feishu bridge CommHub route > acks orphan replies after correlation gc instead of silently leaving them unread [31.51ms]
+(pass) Feishu bridge CommHub route > acks orphan replies after correlation gc instead of silently leaving them unread [36.67ms]
 
  3 pass
  0 fail
  11 expect() calls
-Ran 3 tests across 1 file. [909.00ms]
+Ran 3 tests across 1 file. [821.00ms]
 [3] docker-only file dispatch: valid /work marker sends exactly one file despite duplicate replies
 [feishu:bridge] reply text sent (messageId=om_1) for task_file
 [feishu:bridge] outbound file sent (messageId=om_2, path=/work/feishu-attachments/node-a/oc_test/report.pdf) for task_file

--- a/docs/tests/report-test1241-feishu-commhub-routing.txt
+++ b/docs/tests/report-test1241-feishu-commhub-routing.txt
@@ -1,0 +1,32 @@
+# test1241 Feishu CommHub routing
+
+Date: 2026-08-26T23:14:09Z
+HEAD: unknown
+
+[1] witnessed-red fixture: legacy IPC + CommHub reply paths send twice when both are active
+[feishu:bridge] reply text sent (messageId=om_1) for feishu:node-a#feishu:om_source
+[feishu:bridge] reply text sent (messageId=om_2) for task_commhub
+{"sendCount":2}
+[2] unit route tests: CommHub task dispatch, duplicate reply guard, orphan reply ack
+bun test v1.3.14 (0d9b296a)
+
+src/im/feishu/bridge-commhub-routing.test.ts:
+[feishu:bridge] reply text sent (messageId=om_1) for task_commhub_1
+(pass) Feishu bridge CommHub route > dispatches inbound IM as a CommHub task and routes one final text reply [58.31ms]
+[feishu:bridge] outbound-marker rejected /tmp/not-under-feishu-outbound/report.pdf for task_commhub_1: [文件附件未发送] 路径不在允许的会话目录内 (必须在 /work/feishu-attachments/node-a/oc_test/ 下)
+[feishu:bridge] reply text sent (messageId=om_1) for task_commhub_1
+[feishu:bridge] duplicate final reply ignored for task_commhub_1
+(pass) Feishu bridge CommHub route > deduplicates repeated CommHub replies for the same task across marker-fallback dispatch [62.19ms]
+[feishu:bridge] orphan commhub reply for missing-task: late answer
+(pass) Feishu bridge CommHub route > acks orphan replies after correlation gc instead of silently leaving them unread [31.51ms]
+
+ 3 pass
+ 0 fail
+ 11 expect() calls
+Ran 3 tests across 1 file. [909.00ms]
+[3] docker-only file dispatch: valid /work marker sends exactly one file despite duplicate replies
+[feishu:bridge] reply text sent (messageId=om_1) for task_file
+[feishu:bridge] outbound file sent (messageId=om_2, path=/work/feishu-attachments/node-a/oc_test/report.pdf) for task_file
+[feishu:bridge] duplicate final reply ignored for task_file
+{"ok":true,"sent":[{"text":"ready"},{"files":[{"path":"/work/feishu-attachments/node-a/oc_test/report.pdf","name":"report.pdf"}]}]}
+PASS test1241

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -288,6 +288,11 @@ L1_TESTS=(
   "test765-batch-runtime-gate"
   "test766-bunx-preflight"
   "test746-setup-bun-pin"
+  # 2026-08-27 补注册。Feishu CommHub route 是纯 mock/本地 Docker 验证：
+  # 不需要 FEISHU_APP_SECRET，不连接真实飞书，不往生产 IM 发探针。
+  # 它锁住三件事：legacy IPC + CommHub 双路径同时活着时 witnessed-red 为
+  # sendCount:2；CommHub reply 只发一次；orphan reply 明确日志+ack，不回落默认会话。
+  "test1241-feishu-commhub-routing"
   # 2026-08-13 扫出三个从没进 CI 的完整 Docker 门(test224 / test597 / test679),
   # 一度想加在这里,但 L1 是「~16s 并行」的快层、job 预算 5 分钟,实测在 CI 上
   # 已经用掉 141–148s;而 qa.sh 的 build 是**串行**的(只有 docker run 并行),

--- a/tests/test1241-feishu-commhub-routing/Dockerfile
+++ b/tests/test1241-feishu-commhub-routing/Dockerfile
@@ -1,5 +1,8 @@
 FROM oven/bun:latest
 
+ARG SOURCE_COMMIT=unknown
+ENV SOURCE_COMMIT=$SOURCE_COMMIT
+
 WORKDIR /src
 COPY . .
 

--- a/tests/test1241-feishu-commhub-routing/Dockerfile
+++ b/tests/test1241-feishu-commhub-routing/Dockerfile
@@ -1,0 +1,8 @@
+FROM oven/bun:latest
+
+WORKDIR /src
+COPY . .
+
+RUN cd agent-network && bun install --ignore-scripts
+
+CMD ["bash", "tests/test1241-feishu-commhub-routing/run.sh"]

--- a/tests/test1241-feishu-commhub-routing/run.sh
+++ b/tests/test1241-feishu-commhub-routing/run.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ART=/src/docs/tests
+REPORT="$ART/report-test1241-feishu-commhub-routing.txt"
+mkdir -p "$ART"
+
+{
+  echo "# test1241 Feishu CommHub routing"
+  echo
+  echo "Date: $(date -u +%FT%TZ)"
+  echo "HEAD: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  echo
+} > "$REPORT"
+
+cd /src/agent-network
+
+echo "[1] witnessed-red fixture: legacy IPC + CommHub reply paths send twice when both are active" | tee -a "$REPORT"
+cat > /tmp/feishu-commhub-witnessed-red.mjs <<'JSEOF'
+import { createCommHubEventHandler, createIPCEventHandler } from "/src/agent-network/src/im/feishu/bridge.ts";
+import { JsonIMCorrelationStore } from "/src/agent-network/src/im/correlation-store.ts";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const scratch = mkdtempSync(join(tmpdir(), "feishu-witnessed-red-"));
+const oldSend = process.send;
+const event = {
+  platform: "feishu",
+  connectionId: "node-a#feishu",
+  conversation: { platform: "feishu", conversationId: "oc_test", conversationType: "group", threadRootId: "om_root" },
+  sender: { id: "ou_sender" },
+  messageId: "om_source",
+  mentioned: true,
+  content: { text: "hello" },
+  receivedAt: Date.now(),
+  idempotencyKey: "feishu:node-a#feishu:om_source",
+};
+const messages = [
+  { id: "reply_commhub", type: "reply", content: "final from commhub", from_session: "node-a", in_reply_to: "task_commhub" },
+];
+const client = {
+  async sendTask() { return { taskId: "task_commhub" }; },
+  async getInbox() { return messages; },
+  async ackInbox(_alias, id) {
+    const idx = messages.findIndex((m) => m.id === id);
+    if (idx >= 0) messages.splice(idx, 1);
+  },
+};
+let sendCount = 0;
+const adapter = {
+  connectionName: "node-a",
+  send: async () => {
+    sendCount++;
+    return { messageId: `om_${sendCount}` };
+  },
+};
+
+try {
+  process.send = () => true;
+  const store = new JsonIMCorrelationStore(join(scratch, "state.json"));
+  const ipc = createIPCEventHandler(adapter, 60000, false, store);
+  const commhub = createCommHubEventHandler("node-a", adapter, 60000, false, store, client, 5);
+
+  await ipc(event);
+  await commhub(event);
+  process.emit("message", { type: "reply", eventKey: event.idempotencyKey, text: "final from ipc" });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  console.log(JSON.stringify({ sendCount }));
+  if (sendCount !== 2) throw new Error(`expected witnessed-red sendCount:2, got ${sendCount}`);
+} finally {
+  if (oldSend === undefined) delete process.send;
+  else process.send = oldSend;
+  rmSync(scratch, { recursive: true, force: true });
+}
+JSEOF
+bun run /tmp/feishu-commhub-witnessed-red.mjs 2>&1 | tee -a "$REPORT"
+
+echo "[2] unit route tests: CommHub task dispatch, duplicate reply guard, orphan reply ack" | tee -a "$REPORT"
+bun test src/im/feishu/bridge-commhub-routing.test.ts 2>&1 | tee -a "$REPORT"
+
+echo "[3] docker-only file dispatch: valid /work marker sends exactly one file despite duplicate replies" | tee -a "$REPORT"
+cat > /tmp/feishu-commhub-file-dispatch.mjs <<'JSEOF'
+import { createCommHubEventHandler } from "/src/agent-network/src/im/feishu/bridge.ts";
+import { JsonIMCorrelationStore } from "/src/agent-network/src/im/correlation-store.ts";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const scratch = mkdtempSync(join(tmpdir(), "feishu-file-dispatch-"));
+const filePath = "/work/feishu-attachments/node-a/oc_test/report.pdf";
+mkdirSync("/work/feishu-attachments/node-a/oc_test", { recursive: true });
+writeFileSync(filePath, "%PDF-1.7\n");
+
+const messages = [
+  { id: "reply_a", type: "reply", content: `ready\n[[send-file:${filePath}]]`, from_session: "node-a", in_reply_to: "task_file" },
+  { id: "reply_b", type: "reply", content: `ready\n[[send-file:${filePath}]]`, from_session: "node-a", in_reply_to: "task_file" },
+];
+const acked = [];
+const sent = [];
+const client = {
+  async sendTask() { return { taskId: "task_file" }; },
+  async getInbox() { return messages; },
+  async ackInbox(_alias, id) {
+    acked.push(id);
+    const idx = messages.findIndex((m) => m.id === id);
+    if (idx >= 0) messages.splice(idx, 1);
+  },
+};
+const adapter = {
+  connectionName: "node-a",
+  send: async (message) => {
+    sent.push(message);
+    return { messageId: `om_${sent.length}` };
+  },
+};
+const event = {
+  platform: "feishu",
+  connectionId: "node-a#feishu",
+  conversation: { platform: "feishu", conversationId: "oc_test", conversationType: "group", threadRootId: "om_root" },
+  sender: { id: "ou_sender" },
+  messageId: "om_source",
+  mentioned: true,
+  content: { text: "hello" },
+  receivedAt: Date.now(),
+  idempotencyKey: "feishu:node-a#feishu:om_source",
+};
+
+try {
+  const store = new JsonIMCorrelationStore(join(scratch, "state.json"));
+  const handler = createCommHubEventHandler("node-a", adapter, 60000, false, store, client, 5);
+  await handler(event);
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  const fileSends = sent.filter((message) => message.files?.[0]?.path === filePath);
+  if (sent.length !== 2) throw new Error(`expected text+file sends once, got ${sent.length}`);
+  if (sent[0].text !== "ready") throw new Error(`expected text first, got ${JSON.stringify(sent[0])}`);
+  if (fileSends.length !== 1) throw new Error(`expected one file send, got ${fileSends.length}`);
+  if (acked.join(",") !== "reply_a,reply_b") throw new Error(`expected both replies acked, got ${acked.join(",")}`);
+  console.log(JSON.stringify({ ok: true, sent: sent.map((m) => ({ text: m.text, files: m.files })) }));
+} finally {
+  rmSync(scratch, { recursive: true, force: true });
+}
+JSEOF
+bun run /tmp/feishu-commhub-file-dispatch.mjs 2>&1 | tee -a "$REPORT"
+
+echo "PASS test1241" | tee -a "$REPORT"

--- a/tests/test1241-feishu-commhub-routing/run.sh
+++ b/tests/test1241-feishu-commhub-routing/run.sh
@@ -9,7 +9,7 @@ mkdir -p "$ART"
   echo "# test1241 Feishu CommHub routing"
   echo
   echo "Date: $(date -u +%FT%TZ)"
-  echo "HEAD: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  echo "HEAD: ${SOURCE_COMMIT:-unknown}"
   echo
 } > "$REPORT"
 


### PR DESCRIPTION
## Summary

- route Feishu bridge inbound IM through CommHub `send_task` when CommHub env/client is available, keeping IPC only as fallback
- route CommHub replies back to the original IM conversation via `IMCorrelationStore`
- dedupe duplicate final replies and make orphan replies explicit: log + ack, no default-conversation fallback
- let agent-node process same-alias Feishu bridge tasks while leaving same-alias replies for the bridge to ack

## Witnessed red

The Docker suite includes the dual-path fixture requested in review. When legacy IPC and CommHub reply handlers are both active for the same IM event, the user-visible send happens twice:

```json
{"sendCount":2}
```

That proves the behavioral failure mode directly: two live reply routes produce two `adapter.send` outputs.

## Tests

- `bun test src/im/feishu/bridge-commhub-routing.test.ts src/im/feishu/bridge-placeholder-persistence.test.ts src/im/correlation-store.test.ts`
- `sg docker -c 'docker build -f tests/test1241-feishu-commhub-routing/Dockerfile -t anet-test1241-feishu-commhub-routing . && docker run --rm -v "$PWD/docs/tests:/src/docs/tests" anet-test1241-feishu-commhub-routing'`

Report: `docs/tests/report-test1241-feishu-commhub-routing.txt`
