### PR TITLE
fix(tests): 配对版本从 agent-node/package.json 派生,并补上从未被执行的版本分支

### DIFF
--- a/agent-network/src/opencode-agent-node-pair.test.ts
+++ b/agent-network/src/opencode-agent-node-pair.test.ts
@@ -112,6 +112,25 @@ describe("OpenCode agent-node release pairing", () => {
         OPENCODE_AGENT_NODE_VERSION,
       )).toBe(entrypoint);
 
+      // 🔴 版本这条分支此前从未被任何用例执行过。上面两个 throw 用例改的是 name
+      // 和 publishConfig.tag —— 而产品代码里五个身份条件**共用同一句错误文案**
+      // (`resolved agent-node package is not exact version X`),所以断言那句话
+      // 对 name/tag/bin 任何一项失败都成立,唯独不证明版本被比较过。
+      // 下面这个用例只改 version,其余字段全部合法,是唯一能让版本比较独自变红的形状。
+      writePackage({ version: `${OPENCODE_AGENT_NODE_VERSION}-not-the-paired-one` });
+      expect(() => validateAgentNodePackageEntrypoint(
+        entrypoint,
+        OPENCODE_AGENT_NODE_SPEC,
+        OPENCODE_AGENT_NODE_VERSION,
+      )).toThrow(`not exact version ${OPENCODE_AGENT_NODE_VERSION}`);
+
+      // 不传 expectedVersion 时判据换成「是不是 preview 通道」,这条同样没被覆盖过。
+      writePackage({ version: "2.5.0" });
+      expect(() => validateAgentNodePackageEntrypoint(
+        entrypoint,
+        OPENCODE_AGENT_NODE_SPEC,
+      )).toThrow("not a preview-channel candidate");
+
       writePackage({ name: "attacker/agent-node" });
       expect(() => validateAgentNodePackageEntrypoint(
         entrypoint,

--- a/tests/test1191-windows-steer-contract/linux-e2e.mjs
+++ b/tests/test1191-windows-steer-contract/linux-e2e.mjs
@@ -6,6 +6,11 @@ import { pathToFileURL } from "node:url";
 process.umask(0o022);
 
 const repo = "/workspace";
+// 配对版本从 agent-node/package.json 派生。写死在这里的话,每条发版 PR
+// (它只改 package.json 的版本和 PAIRED_AGENT_NODE_VERSION) 都会让本门变红:
+// cli.ts 拿新版本去校验,而 fixture 还声明着上一个版本。这不是配对失效,
+// 是同一个事实被抄了第三份。真实安装出来的包版本就等于 package.json 里那个。
+const pairedVersion = JSON.parse(readFileSync(join(repo, "agent-node", "package.json"), "utf8")).version;
 const runId = process.env.ANET_TEST1191_RUN_ID || "baseline";
 const port = Number(process.env.ANET_TEST1191_HUB_PORT || "19352");
 const alias = `linux-steer-${runId}`;
@@ -39,7 +44,7 @@ const exactNodeEntrypoint = join(exactNodeDist, "cli.js");
 mkdirSync(exactNodeDist, { recursive: true });
 writeFileSync(join(exactNodeRoot, "package.json"), JSON.stringify({
   name: "@sleep2agi/agent-node",
-  version: "2.5.0-preview.34",
+  version: pairedVersion,
   publishConfig: { tag: "preview" },
   bin: { "agent-node": "dist/cli.js" },
 }));

--- a/tests/test1212-windows-real-codex-gate/windows-real-e2e.mjs
+++ b/tests/test1212-windows-real-codex-gate/windows-real-e2e.mjs
@@ -8,6 +8,11 @@ import { assistantItems, assistantSnapshot, pollCompletedAssistant } from "./thr
 
 if (process.platform !== "win32") throw new Error("real gate requires native Windows ConPTY");
 const repo = resolve(import.meta.dirname, "../..");
+// 配对版本从 agent-node/package.json 派生。写死在这里的话,每条发版 PR
+// (它只改 package.json 的版本和 PAIRED_AGENT_NODE_VERSION) 都会让本门变红:
+// cli.ts 拿新版本去校验,而 fixture 还声明着上一个版本。这不是配对失效,
+// 是同一个事实被抄了第三份。真实安装出来的包版本就等于 package.json 里那个。
+const pairedVersion = JSON.parse(readFileSync(join(repo, "agent-node", "package.json"), "utf8")).version;
 const privateRoot = process.env.ANET_TEST1212_PRIVATE;
 const artifacts = process.env.ANET_TEST1212_ARTIFACTS;
 const expectedSha = process.env.ANET_EXPECTED_SOURCE_SHA;
@@ -48,7 +53,7 @@ try {
   writeFileSync(join(nodeHome, "auth.json"), readFileSync(join(codexHome, "auth.json")), { mode: 0o600 });
   const exactRoot = join(privateRoot, "exact", "node_modules", "@sleep2agi", "agent-node"), exactDist = join(exactRoot, "dist");
   mkdirSync(exactDist, { recursive: true });
-  writeFileSync(join(exactRoot, "package.json"), JSON.stringify({ name: "@sleep2agi/agent-node", version: "2.5.0-preview.34", publishConfig: { tag: "preview" }, bin: { "agent-node": "dist/cli.js" } }));
+  writeFileSync(join(exactRoot, "package.json"), JSON.stringify({ name: "@sleep2agi/agent-node", version: pairedVersion, publishConfig: { tag: "preview" }, bin: { "agent-node": "dist/cli.js" } }));
   writeFileSync(join(exactDist, "cli.js"), `await import(${JSON.stringify(pathToFileURL(join(repo, "agent-node", "dist", "cli.js")).href)});\n`);
   env.ANET_AGENT_NODE_BIN = join(exactDist, "cli.js");
   // Pin the executable without installing it globally. The cmd shim is private.

--- a/tests/test750-codex-copresence-onecommand/run.sh
+++ b/tests/test750-codex-copresence-onecommand/run.sh
@@ -44,15 +44,19 @@ node --version >>"$REPORT"
 bun --version >>"$REPORT"
 pass "environment (no host state; tmux + codex stub present so the launcher reaches its decisions)"
 
-# Exact package-owned preview.34 fixture. A stale `agent-node` may exist on
+# Exact package-owned paired fixture. A stale `agent-node` may exist on
 # PATH, but codex-app-server compatibility must be checked against this paired
 # identity and never against a floating dist-tag.
+# 版本从 agent-node/package.json 派生,不写死:发版 PR 只改那个文件和
+# PAIRED_AGENT_NODE_VERSION,写死的第三份会让每次发版都红。
+PAIRED_VERSION="$(node -p "require('$ROOT/agent-node/package.json').version")"
+[ -n "$PAIRED_VERSION" ] || fail "无法从 agent-node/package.json 读出配对版本"
 PAIR_BASE="/run/user/$(id -u)/test750-paired-agent-node"
 PAIR_ROOT="$PAIR_BASE/node_modules/@sleep2agi/agent-node"
 mkdir -p "$PAIR_ROOT/dist"
 chmod 700 "/run/user/$(id -u)" "$PAIR_BASE"
-cat >"$PAIR_ROOT/package.json" <<'JSON'
-{"name":"@sleep2agi/agent-node","version":"2.5.0-preview.34","publishConfig":{"tag":"preview"},"bin":{"agent-node":"dist/cli.js"}}
+cat >"$PAIR_ROOT/package.json" <<JSON
+{"name":"@sleep2agi/agent-node","version":"$PAIRED_VERSION","publishConfig":{"tag":"preview"},"bin":{"agent-node":"dist/cli.js"}}
 JSON
 cat >"$PAIR_ROOT/dist/cli.js" <<'JS'
 #!/usr/bin/env node

--- a/tests/test751-codex-copresence-windows/windows-e2e.mjs
+++ b/tests/test751-codex-copresence-windows/windows-e2e.mjs
@@ -6,6 +6,11 @@ import pty from "../../agent-network/node_modules/node-pty/lib/index.js";
 
 if (process.platform !== "win32") throw new Error("windows-e2e must run on Windows");
 const repo = resolve(import.meta.dirname, "../..");
+// 配对版本从 agent-node/package.json 派生。写死在这里的话,每条发版 PR
+// (它只改 package.json 的版本和 PAIRED_AGENT_NODE_VERSION) 都会让本门变红:
+// cli.ts 拿新版本去校验,而 fixture 还声明着上一个版本。这不是配对失效,
+// 是同一个事实被抄了第三份。真实安装出来的包版本就等于 package.json 里那个。
+const pairedVersion = JSON.parse(readFileSync(join(repo, "agent-node", "package.json"), "utf8")).version;
 const cli = join(repo, "agent-network", "bin", "cli.ts");
 const root = join(process.env.RUNNER_TEMP, "anet-test751-e2e");
 const project = join(root, "project");
@@ -22,7 +27,7 @@ writeFileSync(join(userHome, ".anet", "config.json"), JSON.stringify({ hub: "htt
 writeFileSync(join(bin, "codex.cmd"), `@echo off\r\nbun "${join(import.meta.dirname, "fake-codex.mjs")}" %*\r\n`);
 writeFileSync(join(bin, "agent-node.cmd"), `@echo off\r\nbun "${join(import.meta.dirname, "fake-agent-node.mjs")}" %*\r\n`);
 // Deliberately leave the PATH shim above as a stale-global witness. The Codex
-// bridge must use this exact package-owned preview.34 entrypoint instead. The
+// bridge must use this exact package-owned paired entrypoint instead. The
 // package-owned wrapper imports the repository's REAL built agent-node: the
 // old Windows gate imported fake-agent-node.mjs (an infinite sleep), so it
 // could never prove SSE admission or turn/steer while the TUI was busy.
@@ -32,7 +37,7 @@ const exactNodeEntrypoint = join(exactNodeDist, "cli.js");
 mkdirSync(exactNodeDist, { recursive: true });
 writeFileSync(join(exactNodeRoot, "package.json"), JSON.stringify({
   name: "@sleep2agi/agent-node",
-  version: "2.5.0-preview.34",
+  version: pairedVersion,
   publishConfig: { tag: "preview" },
   bin: { "agent-node": "dist/cli.js" },
 }));


### PR DESCRIPTION
## 症状

`release/agent-node-2.5.0-preview.35`（#1246）上 Windows Codex 共存门 **2/2 稳定红**，
而同一个 job 在 main 上 **3/3 全绿**。那条 PR 只有 **+2/-2**：agent-node 的版本号和
`PAIRED_AGENT_NODE_VERSION`。

跨分支聚合失败率是 5/14 = 36%，看着像 flake。**按分支分组后不是**：

| 分支 | 结果 |
|---|---|
| main | 3/3 绿 |
| release/agent-node-...preview.35 | **2/2 红** |
| feat/tui-second-client-health-* | 4 红 / 1 绿（另一条真问题，不在本 PR 范围） |
| 其余 | 绿 |

## 根因：版本这个事实被抄了三份

发版 PR 改前两份：

```
agent-node/package.json                        .34 -> .35
agent-network/src/opencode-agent-node-pair.ts  .34 -> .35
```

第三份没人改，是 e2e fixture 里写死的那个"已安装的配对包"：

```
tests/test751-codex-copresence-windows/windows-e2e.mjs:35        .34
tests/test1191-windows-steer-contract/linux-e2e.mjs:42           .34
tests/test1212-windows-real-codex-gate/windows-real-e2e.mjs:51   .34
tests/test750-codex-copresence-onecommand/run.sh:55              .34
```

于是 `cli.ts:3082` 拿 `.35` 去校验一个声明 `.34` 的包，
`opencode-agent-node-pair.ts` 里这行抛错：

```js
|| (expectedVersion ? pkg.version !== expectedVersion : !pkg.version.includes("-preview."))
```

bridge 因此从未启动，外层症状是 `bridge did not attach to the shared app-server before TUI launch`。

**直接证据**（失败 artifact `report-test751-windows.txt` 的 fake rpc log）：

```
appsrv-home:D:\a\_temp\...\codex-home
rpc:initialize
rpc:thread/start
rpc:turn/start:thread_windows_e2e
```

有 app-server 侧全部 rpc，**唯独没有 `bridge-home:` 那行** —— 而那行正是
`windows-e2e.mjs:39` 造的配对 entrypoint 一启动就写的。
它缺席 = 配对 entrypoint 从未被执行，**不是握手超时**。

## 改动

四个 fixture 改成从 `agent-node/package.json` 读版本。
真实安装出来的包版本本来就等于那个文件里的值，**这是还原事实，不是放宽判据**。

模拟发版验证（把 agent-node 版本临时改成 `2.5.0-preview.99`）：

```
test751  -> 2.5.0-preview.99
test1191 -> 2.5.0-preview.99
test1212 -> 2.5.0-preview.99
test750  -> 2.5.0-preview.99
```

## 顺带修掉一条不成立的断言

`opencode-agent-node-pair.test.ts` 里两个 throw 用例改的是 `name` 和
`publishConfig.tag`，却都断言 `.toThrow("not exact version")`。
产品代码里**五个身份条件共用同一句错误文案**，所以那句话对任何一项失败都成立 ——
而**没有任何一个用例改过 version**，版本比较那条分支从未被执行过。

补两个只改 version 的用例（其余字段全部合法）：

- 传 `expectedVersion`：版本不等 → `not exact version`
- 不传 `expectedVersion`：非 preview 通道 → `not a preview-channel candidate`

**witnessed-red**：把产品里版本比较那条替换成 `|| false` 后：

```
5 pass  1 fail
(fail) admits only the exact preview package identity with safe file modes
Expected substring: "not exact version 2.5.0-preview.34"
```

**只有新加的用例红，既有 5 条全部保持绿** —— 这正好量出旧用例对版本分支的覆盖为零。
还原后 6 pass 0 fail，残留 MUTANT 行数 0。

## 影响

不修的话**每一条发版 PR 都会红这道门**，而红的理由和发版内容无关。

Fixes 阻塞 #1246。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
