### PR TITLE
fix(release): sync 脚本登记 JSON 版本位,修 agent-network lock 漂移,补两个包的一致性门

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.46",
+  "version": "2.3.0-preview.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.46",
+      "version": "2.3.0-preview.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/src/package-version-consistency.test.ts
+++ b/agent-network/src/package-version-consistency.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type PackageManifest = { version: string };
+type PackageLock = {
+  version: string;
+  packages: { "": { version: string } };
+};
+
+const readJson = <T>(name: string): T =>
+  JSON.parse(readFileSync(join(import.meta.dir, "..", name), "utf8")) as T;
+
+describe("agent-network package version consistency", () => {
+  const manifest = readJson<PackageManifest>("package.json");
+  const lock = readJson<PackageLock>("package-lock.json");
+
+  test("package-lock top-level version matches package.json", () => {
+    expect(lock.version).toBe(manifest.version);
+  });
+
+  test("package-lock root package version matches package.json", () => {
+    expect(lock.packages[""].version).toBe(manifest.version);
+  });
+});

--- a/scripts/sync-pinned-versions.sh
+++ b/scripts/sync-pinned-versions.sh
@@ -229,49 +229,37 @@ apply_json_target() {
   fi
   local out rc
   set +e
-  out="$(JSON_FILE="$file" JSON_PATH="$jpath" JSON_NEW="$NEW_VERSION" JSON_MODE="$MODE" python3 - <<'PYEOF'
-import json, os, sys, collections, difflib
-
-path_s = os.environ["JSON_PATH"]
-f = os.environ["JSON_FILE"]
-new = os.environ["JSON_NEW"]
-mode = os.environ["JSON_MODE"]
-
-raw = open(f, encoding="utf-8").read()
-doc = json.loads(raw, object_pairs_hook=collections.OrderedDict)
-
-segs = [("" if seg == '""' else seg) for seg in path_s.split("/")]
-node = doc
-for seg in segs[:-1]:
-    if not isinstance(node, dict) or seg not in node:
-        print("MISSING", flush=True); sys.exit(3)
-    node = node[seg]
-leaf = segs[-1]
-if not isinstance(node, dict) or leaf not in node:
-    print("MISSING", flush=True); sys.exit(3)
-
-old = node[leaf]
-if old == new:
-    print("UNCHANGED", flush=True); sys.exit(0)
-
-node[leaf] = new
-after = json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
-
-diff = list(difflib.unified_diff(raw.splitlines(), after.splitlines(), lineterm="", n=0))
-changed = [l for l in diff if (l.startswith("+") or l.startswith("-")) and not l.startswith(("+++", "---"))]
-if len(changed) != 2:
-    print("REFORMAT %d" % len(changed), flush=True)
-    for l in changed[:8]:
-        print("   %s" % l[:120], flush=True)
-    sys.exit(4)
-
-if mode == "apply":
-    open(f, "w", encoding="utf-8").write(after)
-    print("WROTE %s -> %s" % (old, new), flush=True)
-else:
-    print("WOULD-WRITE %s -> %s" % (old, new), flush=True)
-PYEOF
-)"
+  out="$(JSON_FILE="$file" JSON_PATH="$jpath" JSON_NEW="$NEW_VERSION" JSON_MODE="$MODE" node -e '
+// 用 node 不用 python3:这个脚本改的是 package.json,跑它的地方一定有 node
+// (test1183 的镜像是 node:22-bookworm-slim,里面没有 python3 —— 2026-08-27
+// 第一版用 python3 写,在容器里 command not found,红的理由和被测行为无关)。
+const fs = require("fs");
+const f = process.env.JSON_FILE, pathS = process.env.JSON_PATH;
+const nv = process.env.JSON_NEW, mode = process.env.JSON_MODE;
+const raw = fs.readFileSync(f, "utf8");
+const doc = JSON.parse(raw);
+const segs = pathS.split("/").map((x) => (x === "\"\"" ? "" : x));
+let node = doc;
+for (const seg of segs.slice(0, -1)) {
+  if (node === null || typeof node !== "object" || !(seg in node)) { console.log("MISSING"); process.exit(3); }
+  node = node[seg];
+}
+const leaf = segs[segs.length - 1];
+if (node === null || typeof node !== "object" || !(leaf in node)) { console.log("MISSING"); process.exit(3); }
+const old = node[leaf];
+if (old === nv) { console.log("UNCHANGED"); process.exit(0); }
+node[leaf] = nv;
+const after = JSON.stringify(doc, null, 2) + "\n";
+// 只允许恰好一行变化;多于一行说明 JSON.stringify 的格式和原文件不一致,
+// 整个文件会被重排 —— 那种"成功"必须当失败。
+const a = raw.split("\n"), b = after.split("\n");
+let changed = 0;
+if (a.length !== b.length) { changed = Math.abs(a.length - b.length) + a.length; }
+else { for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) changed++; }
+if (changed !== 1) { console.log("REFORMAT " + changed); process.exit(4); }
+if (mode === "apply") { fs.writeFileSync(f, after); console.log("WROTE " + old + " -> " + nv); }
+else { console.log("WOULD-WRITE " + old + " -> " + nv); }
+')"
   rc=$?
   set -e
   case "$rc" in

--- a/scripts/sync-pinned-versions.sh
+++ b/scripts/sync-pinned-versions.sh
@@ -71,6 +71,25 @@ register "@sleep2agi/agent-network" "agent-network/src/opencode-agent-node-pair.
 # @sleep2agi/agent-node — paired runtime release
 register "@sleep2agi/agent-node" "agent-network/src/opencode-agent-node-pair.ts:PAIRED_AGENT_NODE_VERSION"
 
+# ---- 各包自身的 package.json / package-lock.json ----
+#
+# 为什么必须登记:2026-08-27 的 agent-node 2.5.0-preview.35 发版 PR 只改了
+# package.json 和 PAIRED_AGENT_NODE_VERSION,package-lock.json 里那两处留在
+# .34,于是 agent-node unit 门红在 package-version-consistency.test.ts。
+# 同一天普查发现 agent-network 的 lock 停在 preview.46 而 package.json 已是
+# preview.47 —— 那个包没有对应断言,所以漂移一直没被看见。
+#
+# lock 里的版本有两处:顶层 version 和 packages[""].version,npm 两处都写。
+register "@sleep2agi/agent-node" "json:agent-node/package.json:version"
+register "@sleep2agi/agent-node" "json:agent-node/package-lock.json:version"
+register "@sleep2agi/agent-node" "json:agent-node/package-lock.json:packages/\"\"/version"
+register "@sleep2agi/agent-network" "json:agent-network/package.json:version"
+register "@sleep2agi/agent-network" "json:agent-network/package-lock.json:version"
+register "@sleep2agi/agent-network" "json:agent-network/package-lock.json:packages/\"\"/version"
+register "@sleep2agi/commhub-server" "json:server/package.json:version"
+register "@sleep2agi/commhub-server" "json:server/package-lock.json:version"
+register "@sleep2agi/commhub-server" "json:server/package-lock.json:packages/\"\"/version"
+
 # @sleep2agi/commhub-server — agent-network CLI 内 PINNED_SERVER_VERSION 常量
 register "@sleep2agi/commhub-server" "agent-network/bin/cli.ts:PINNED_SERVER_VERSION"
 
@@ -189,6 +208,97 @@ apply_or_preview() {
   fi
 }
 
+# ---------- JSON 目标 ----------
+#
+# 形式: json:<file>:<path>,path 用 / 分段,空字符串键写作 ""
+#   json:agent-node/package-lock.json:packages/""/version
+#
+# 为什么不用 sed:JSON 里同一个版本串会在多处出现(依赖、resolved URL),
+# 按文本替换会打到不该动的地方。按路径定位只改那一个键。
+#
+# 写回后校验"改动行数恰好是 1" —— 若 json.dumps 的格式化和原文件不一致,
+# 整个文件会被重排,那种改动必须当成失败而不是成功。
+apply_json_target() {
+  local file="$1" jpath="$2"
+  echo ""
+  echo "[$PKG → $file ($jpath)]"
+  if [[ ! -f "$file" ]]; then
+    echo "  🔴 MISSING TARGET: $file 不存在 —— 注册表已过期"
+    MISSING_TARGETS=$((MISSING_TARGETS + 1))
+    return
+  fi
+  local out rc
+  set +e
+  out="$(JSON_FILE="$file" JSON_PATH="$jpath" JSON_NEW="$NEW_VERSION" JSON_MODE="$MODE" python3 - <<'PYEOF'
+import json, os, sys, collections, difflib
+
+path_s = os.environ["JSON_PATH"]
+f = os.environ["JSON_FILE"]
+new = os.environ["JSON_NEW"]
+mode = os.environ["JSON_MODE"]
+
+raw = open(f, encoding="utf-8").read()
+doc = json.loads(raw, object_pairs_hook=collections.OrderedDict)
+
+segs = [("" if seg == '""' else seg) for seg in path_s.split("/")]
+node = doc
+for seg in segs[:-1]:
+    if not isinstance(node, dict) or seg not in node:
+        print("MISSING", flush=True); sys.exit(3)
+    node = node[seg]
+leaf = segs[-1]
+if not isinstance(node, dict) or leaf not in node:
+    print("MISSING", flush=True); sys.exit(3)
+
+old = node[leaf]
+if old == new:
+    print("UNCHANGED", flush=True); sys.exit(0)
+
+node[leaf] = new
+after = json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
+
+diff = list(difflib.unified_diff(raw.splitlines(), after.splitlines(), lineterm="", n=0))
+changed = [l for l in diff if (l.startswith("+") or l.startswith("-")) and not l.startswith(("+++", "---"))]
+if len(changed) != 2:
+    print("REFORMAT %d" % len(changed), flush=True)
+    for l in changed[:8]:
+        print("   %s" % l[:120], flush=True)
+    sys.exit(4)
+
+if mode == "apply":
+    open(f, "w", encoding="utf-8").write(after)
+    print("WROTE %s -> %s" % (old, new), flush=True)
+else:
+    print("WOULD-WRITE %s -> %s" % (old, new), flush=True)
+PYEOF
+)"
+  rc=$?
+  set -e
+  case "$rc" in
+    0)
+      case "$out" in
+        UNCHANGED) echo "  unchanged: $file" ;;
+        WROTE*)    echo "  WROTE: $file (${out#WROTE })"; CHANGED_FILES+=("$file") ;;
+        *)         echo "  ${out}" ;;
+      esac
+      ;;
+    3)
+      echo "  🔴 MISSING TARGET: $file 里找不到路径 \`$jpath\` —— 注册表已过期"
+      MISSING_TARGETS=$((MISSING_TARGETS + 1))
+      ;;
+    4)
+      echo "  🔴 REFORMAT REFUSED: 写回会重排 $file,拒绝改动"
+      printf '%s\n' "$out" | sed 's/^/    /'
+      MISSING_TARGETS=$((MISSING_TARGETS + 1))
+      ;;
+    *)
+      echo "  ERROR: JSON 处理失败 ($file, rc=$rc)" >&2
+      printf '%s\n' "$out" | sed 's/^/    /' >&2
+      return "$rc"
+      ;;
+  esac
+}
+
 # ---------- 执行 ----------
 
 echo "============================================================"
@@ -200,7 +310,11 @@ echo "  repo    : $REPO_ROOT"
 echo "============================================================"
 
 for target in "${TARGETS[@]}"; do
-  if [[ "$target" == *":"* ]]; then
+  if [[ "$target" == json:* ]]; then
+    # json:<file>:<path> 形式
+    rest="${target#json:}"
+    apply_json_target "${rest%%:*}" "${rest#*:}"
+  elif [[ "$target" == *":"* ]]; then
     # cli.ts:CONST_NAME 形式
     file="${target%%:*}"
     const_name="${target#*:}"

--- a/server/src/package-version-consistency.test.ts
+++ b/server/src/package-version-consistency.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type PackageManifest = { version: string };
+type PackageLock = {
+  version: string;
+  packages: { "": { version: string } };
+};
+
+const readJson = <T>(name: string): T =>
+  JSON.parse(readFileSync(join(import.meta.dir, "..", name), "utf8")) as T;
+
+describe("server package version consistency", () => {
+  const manifest = readJson<PackageManifest>("package.json");
+  const lock = readJson<PackageLock>("package-lock.json");
+
+  test("package-lock top-level version matches package.json", () => {
+    expect(lock.version).toBe(manifest.version);
+  });
+
+  test("package-lock root package version matches package.json", () => {
+    expect(lock.packages[""].version).toBe(manifest.version);
+  });
+});

--- a/tests/test1183-sync-pinned-dryrun/Dockerfile
+++ b/tests/test1183-sync-pinned-dryrun/Dockerfile
@@ -9,6 +9,16 @@ COPY scripts/sync-pinned-versions.sh scripts/sync-pinned-versions.sh
 COPY agent-network/src/opencode-agent-node-pair.ts agent-network/src/opencode-agent-node-pair.ts
 COPY docs-site/docs/guide/runtimes.md docs-site/docs/guide/runtimes.md
 COPY docs-site/docs/en/guide/runtimes.md docs-site/docs/en/guide/runtimes.md
+# 🔴 这份 COPY 清单编码了 sync 脚本注册表的范围。
+# 注册表里多一个文件,这里就必须多一行 —— 否则脚本在容器里报
+# MISSING TARGET,dry-run 非零退出,而红的理由和被测行为无关。
+# (2026-08-27 就是这样红的:注册了三包的 package.json/lock,镜像里没有。)
+COPY agent-node/package.json agent-node/package.json
+COPY agent-node/package-lock.json agent-node/package-lock.json
+COPY agent-network/package.json agent-network/package.json
+COPY agent-network/package-lock.json agent-network/package-lock.json
+COPY server/package.json server/package.json
+COPY server/package-lock.json server/package-lock.json
 COPY tests/test1183-sync-pinned-dryrun/run.sh tests/test1183-sync-pinned-dryrun/run.sh
 
 RUN git init -q && git config user.email test@example.invalid && git config user.name test \


### PR DESCRIPTION
## 起因

`agent-node@2.5.0-preview.35` 的发版 PR（#1246）红在 `agent-node unit`：

```
(fail) agent-node package version consistency > package-lock root package version matches package.json
Expected: "2.5.0-preview.35"
```

发版 PR 改了 `package.json` 和 `PAIRED_AGENT_NODE_VERSION`，
**没改 `package-lock.json`** —— 同一个版本事实在这个包里有三份拷贝。

`scripts/sync-pinned-versions.sh` 本该是"硬编码版本位的权威枚举"
（RELEASE-SOP 就是这么用它的），但它对 agent-node **只登记了一处**，
dry-run 显示 `unchanged` 也不会提醒还有另外三处。

原因是它第 158 行只认 TS 的 `const X = "...";` 形状，**登记不了 JSON 文件**。

## 改动一：脚本支持 JSON 目标

新目标形式 `json:<file>:<path>`，path 用 `/` 分段，空字符串键写作 `""`：

```bash
register "@sleep2agi/agent-node" "json:agent-node/package-lock.json:packages/\"\"/version"
```

**为什么不用 sed**：JSON 里同一个版本串会在多处出现（依赖、resolved URL），
按文本替换会打到不该动的地方。按路径定位只改那一个键。

**写回护栏**：改完校验"变化行数恰好是 1"，否则拒绝写入 ——
`json.dumps` 的格式化若和原文件不符会重排整个文件，那种"成功"必须当失败。

三个包共 9 个版本位全部登记（agent-node / agent-network / commhub-server
各 3 处：`package.json:version`、`package-lock.json:version`、`package-lock.json:packages/""/version`）。

## 改动二：修 main 上一个没人看见的漂移

```
agent-network/package.json       2.3.0-preview.47
agent-network/package-lock.json  2.3.0-preview.46   ← 落后一版
```

`agent-node` 有一致性断言所以会说话；**`agent-network` 和 `server` 没有**，
所以同一类漂移在 main 上一直活着。用本 PR 的新能力修的，diff 恰好 2 行。

## 改动三：给另外两个包补上那道门

照 `agent-node` 那份各补一份。

## 验证

**dry-run 对已知答案**（今晚实际漏掉的就是这些）：

```
[agent-node → agent-network/src/opencode-agent-node-pair.ts (PAIRED_AGENT_NODE_VERSION)]  WOULD-WRITE
[agent-node → agent-node/package.json (version)]                        WOULD-WRITE .34 -> .35
[agent-node → agent-node/package-lock.json (version)]                   WOULD-WRITE .34 -> .35
[agent-node → agent-node/package-lock.json (packages/""/version)]       WOULD-WRITE .34 -> .35
```

从 1 处变成 4 处。

**apply 实跑**：lock 的 diff 恰好 4 行（2 处改动），断言 2 pass。

**MISSING TARGET 守卫**（把注册的 path 改成不存在的 `versionXX`）：

```
🔴 MISSING TARGET: agent-node/package.json 里找不到路径 `versionXX` —— 注册表已过期
```

**REFORMAT 守卫**（把 lock 改成 4 空格缩进）：

```
🔴 REFORMAT REFUSED: 写回会重排 agent-node/package-lock.json,拒绝改动
   REFORMAT 3318
```

**新门的 witnessed-red**（把 agent-network 的 lock 退回 `.46`）：

```
agent-network  0 pass 2 fail   Expected "2.3.0-preview.47" / Received "2.3.0-preview.46"
agent-node     2 pass 0 fail   ← 保持绿
server         2 pass 0 fail   ← 保持绿
```

三份各读各的包，没有串台。还原后全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
