### PR TITLE
fix(test336): 变异必须真的注入 —— 锚点还在不等于替换生效

### DIFF
--- a/tests/test336-feishu-bridge-wire/run.sh
+++ b/tests/test336-feishu-bridge-wire/run.sh
@@ -14,6 +14,33 @@ expect_red(){
   if "$@" >"$ART/$name.log" 2>&1; then bad "mutation $name stayed green"; else ok "mutation $name witnessed red"; fi
 }
 
+# 🔴 变异必须真的注入,否则 expect_red 拿的是一份没被改过的源码,恒绿。
+#
+# 原来的守卫是 `grep -Fq '<锚点>' <file>` —— 它只证明锚点还在,
+# **不证明替换生效**。2026-08-27 #1252 就栽在这:那条 PR 把
+#   const connectionName = adapter.connectionName || "feishu";
+#   ... feishuOutboundDir(connectionName, ...)
+# 内联成
+#   ... feishuOutboundDir(adapter.connectionName || "feishu", ...)
+# 语义完全没变,但 perl 模式字面要求 `connectionName,` 那一行,于是不匹配 =
+# no-op。锚点当然还在,grep 照过,然后 expect_red 跑未变异的代码 → 恒绿 →
+# 报成 "mutation stayed green",读起来像"这条规则没人守了",
+# 而真相是"这个变异从来没被注入过"。这两种结论指向完全相反的修法。
+#
+# 改成比对文件内容:变异前后必须不同。
+mutate(){
+  local name="$1" file="$2"; shift 2
+  local before after
+  before="$(sha256sum "$file" | cut -d" " -f1)"
+  "$@"
+  after="$(sha256sum "$file" | cut -d" " -f1)"
+  if [[ "$before" == "$after" ]]; then
+    bad "mutation $name NO-OP —— 模式没匹配到任何东西,变异从未注入($file 未改变)"
+    return 1
+  fi
+  return 0
+}
+
 printf 'source_commit=%s\n' "${TEST336_SOURCE_COMMIT:-unknown}"
 cd "$ROOT"
 
@@ -31,28 +58,31 @@ ok "agent-node production bundle"
 
 cp agent-network/src/im/feishu/bridge.ts /tmp/test336-bridge.orig
 
-perl -0pi -e 's/(const outboundDir = feishuOutboundDir\(\n\s*adapter\.connectionName \|\| "feishu",\n\s*)event\.conversation\.conversationId,/${1}event.sender.id,/' \
-  agent-network/src/im/feishu/bridge.ts
-grep -Fq 'const outboundDir = feishuOutboundDir(' agent-network/src/im/feishu/bridge.ts
-expect_red envelope-uses-sender-id bun agent-network/tests/feishu-bridge-ipc.test.ts
+mutate envelope-uses-sender-id agent-network/src/im/feishu/bridge.ts \
+  perl -0pi -e 's/(const outboundDir = feishuOutboundDir\(\n\s*(?:adapter\.connectionName \|\| "feishu"|connectionName),\n\s*)event\.conversation\.conversationId,/${1}event.sender.id,/' \
+  agent-network/src/im/feishu/bridge.ts \
+  && expect_red envelope-uses-sender-id bun agent-network/tests/feishu-bridge-ipc.test.ts
 cp /tmp/test336-bridge.orig agent-network/src/im/feishu/bridge.ts
 
-perl -0pi -e 's/(const expectedDir = feishuOutboundDir\(\n\s*connectionName,\n\s*)event\.conversation\.conversationId,/${1}event.sender.id,/' \
-  agent-network/src/im/feishu/bridge.ts
-grep -Fq 'const expectedDir = feishuOutboundDir(' agent-network/src/im/feishu/bridge.ts
-expect_red reply-whitelist-uses-sender-id bun agent-network/tests/feishu-bridge-ipc.test.ts
+# 模式同时容忍两种形状:main 上的局部变量 `connectionName,` 和
+# #1252 内联后的 `adapter.connectionName || "feishu",`。语义一致,
+# 变异要的是把 conversationId 换成 sender.id,和这个参数怎么写无关。
+mutate reply-whitelist-uses-sender-id agent-network/src/im/feishu/bridge.ts \
+  perl -0pi -e 's/(const expectedDir = feishuOutboundDir\(\n\s*(?:adapter\.connectionName \|\| "feishu"|connectionName),\n\s*)event\.conversation\.conversationId,/${1}event.sender.id,/' \
+  agent-network/src/im/feishu/bridge.ts \
+  && expect_red reply-whitelist-uses-sender-id bun agent-network/tests/feishu-bridge-ipc.test.ts
 cp /tmp/test336-bridge.orig agent-network/src/im/feishu/bridge.ts
 
 cp agent-node/src/runtime/feishu-outbound-dir.ts /tmp/test336-outbound.orig
-sed -i 's/const connection = connectionName || "feishu";/const connection = process.env.ANET_NODE_ALIAS || connectionName || "feishu";/' \
-  agent-node/src/runtime/feishu-outbound-dir.ts
-grep -Fq 'process.env.ANET_NODE_ALIAS || connectionName' agent-node/src/runtime/feishu-outbound-dir.ts
-expect_red ambient-alias-overrides-binding bun test agent-node/src/runtime/feishu-outbound-dir.test.ts
+mutate ambient-alias-overrides-binding agent-node/src/runtime/feishu-outbound-dir.ts \
+  sed -i 's/const connection = connectionName || "feishu";/const connection = process.env.ANET_NODE_ALIAS || connectionName || "feishu";/' \
+  agent-node/src/runtime/feishu-outbound-dir.ts \
+  && expect_red ambient-alias-overrides-binding bun test agent-node/src/runtime/feishu-outbound-dir.test.ts
 cp /tmp/test336-outbound.orig agent-node/src/runtime/feishu-outbound-dir.ts
 
-sed -i 's/binding.connectionName,/"wrong-node-alias",/' agent-node/src/runtime/feishu-outbound-dir.ts
-grep -Fq '"wrong-node-alias",' agent-node/src/runtime/feishu-outbound-dir.ts
-expect_red worker-binding-diverges bun test agent-node/src/runtime/feishu-outbound-dir.test.ts
+mutate worker-binding-diverges agent-node/src/runtime/feishu-outbound-dir.ts \
+  sed -i 's/binding.connectionName,/"wrong-node-alias",/' agent-node/src/runtime/feishu-outbound-dir.ts \
+  && expect_red worker-binding-diverges bun test agent-node/src/runtime/feishu-outbound-dir.test.ts
 cp /tmp/test336-outbound.orig agent-node/src/runtime/feishu-outbound-dir.ts
 
 printf 'RESULT pass=%s fail=%s\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## 症状

#1252 上：

```
FAIL mutation reply-whitelist-uses-sender-id stayed green
RESULT pass=7 fail=1
```

八个变异里七个 witnessed red，只有这一个"存活"。读起来像
**"那条白名单规则没有任何测试在守它了"** —— 我第一反应也是这么判的，
并据此给作者派了"补测试"的方向。

## 真相相反：那个变异从来没被注入过

变异是个 perl 正则，字面要求第二行是 `connectionName,`：

```perl
s/(const expectedDir = feishuOutboundDir\(\n\s*connectionName,\n\s*)event\.conversation\.conversationId,/${1}event.sender.id,/
```

而 #1252 把 main 上的局部变量内联了：

```
main   501行:  feishuOutboundDir(
                   connectionName,                        ← 匹配
#1252  744行:  feishuOutboundDir(
                   adapter.connectionName || "feishu",    ← 不匹配
```

语义完全一致（main 上那个局部变量的赋值就是 `adapter.connectionName || "feishu"`），
但模式对不上 → **perl 是 no-op**。

而守卫只检查锚点还在：

```bash
grep -Fq 'const expectedDir = feishuOutboundDir(' ...
```

锚点当然还在。于是 `expect_red` 拿一份**没被变异的源码**去跑，当然恒绿。

🔴 **"变异没生效"和"覆盖丢了"在输出上完全一样，却指向完全相反的修法。**

## 改动

新增 `mutate` 包裹：变异前后比对文件 sha256，不同才继续，相同直接判 NO-OP。

四个变异全部改用它，删掉只验锚点的 `grep`。用 `&&` 串联 `expect_red`，
所以一个 no-op 只是记账并跳过那次 `expect_red`，**不中断整轮** ——
取证要的是失败的**分布**，不是停在第一个。

`reply-whitelist` 的模式同时容忍两种形状（局部变量 / 内联），
这样 #1252 rebase 后不用再改它。

## 验证（Docker 实跑，三组）

| 输入 | 结果 |
|---|---|
| main 源码 | `RESULT pass=8 fail=0` rc=0 — 四个变异全部 witnessed red |
| 一个模式改成匹配不到 | `FAIL … NO-OP —— 模式没匹配到任何东西,变异从未注入` |
| 两个模式改成匹配不到 | `RESULT pass=6 fail=2` rc=1 — 两条 NO-OP 各自点名，另两条仍 witnessed red |

第三组证明了 `&&` 串联确实给出**完整分布**而不是停在第一个失败。

## 仓级情况（本 PR 不动，另开 issue）

30 个套件用 `expect_red` + 文本变异。抽样：

```
test689  变异=7   守卫=0
test671  变异=7   守卫=0
test659  变异=3   守卫=0
test688  变异=13  守卫=9
test336  变异=4   守卫=4   ← 本 PR 修的
```

守卫为 0 的比只验锚点更弱。仓级棘轮（记下今天的存量、只对新增变红）另开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
