### PR TITLE
fix(release): gate 2 审的是仓里所有 PINNED_*,不是被发布那个包的 cli.ts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,8 +310,20 @@ jobs:
           # "missing PINNED_DASHBOARD" alarms.
           # If any *existing* pin points at a version that's not on npm,
           # anet hub start will silently hang (#194 class of bug). Fail loud.
-          cli="$GATED_PKG/bin/cli.ts"
-          [ -f "$cli" ] || { echo "::error::no $cli — cannot audit pins"; exit 1; }
+          # 🔴 PINNED_* 住在哪:全仓只有 agent-network/bin/cli.ts 一个文件有这些常量。
+          #
+          # 原来写的是 "$GATED_PKG/bin/cli.ts" —— 那是照 agent-network 的布局写的,
+          # 而 agent-node 的 CLI 在 src/cli.ts,根本没有 bin/cli.ts。
+          # 2026-08-27 第一次用本 workflow 发 agent-node 时这道门直接硬退:
+          #   ::error::no agent-node/bin/cli.ts — cannot audit pins
+          # 那句报错是准确的,但门的取值范围写错了 —— 它审的不是"被发布的那个包",
+          # 而是"仓里所有 PINNED_* 是否指向已发布的版本"。这个不变量与发哪个包无关:
+          # 发 agent-node 时,agent-network 里那些 pin 同样不能指向不存在的版本。
+          #
+          # 所以固定审 agent-network/bin/cli.ts。若哪天 PINNED_* 搬了家或多了一处,
+          # 下面的"审了 0 个就拒绝通过"会说话 —— 那正是它存在的理由。
+          cli="agent-network/bin/cli.ts"
+          [ -f "$cli" ] || { echo "::error::no $cli — cannot audit pins（PINNED_* 只住在这里；若已搬家，请同步本门）"; exit 1; }
 
           missing=0
           audited=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,51 @@ jobs:
           tarball=$(ls ./tarball/*.tgz)
           echo "Gating tarball: $tarball"
 
+          # 🔴 这道门原来整套只对 agent-network 成立:它跑 `anet --version`、
+          # `anet hub start`、`anet login`、建节点向导。agent-node 没有 `anet` 这个 bin
+          # (它的 bin 叫 agent-node),也没有 hub。2026-08-27 第一次用本 workflow 发
+          # agent-node 时,门在第 21 行硬退:
+          #   bash: line 21: anet: command not found   (exit 127)
+          #
+          # 一道对被发布的包**根本跑不起来**的门比没有更糟 —— 它每次都红,
+          # 于是人学会绕过它。所以按包分流,各自跑各自真正的安装路径。
+          if [ "${GATED_PKG}" = "agent-node" ]; then
+            docker run --rm \
+              -v "$PWD/tarball:/tarball:ro" \
+              -e GATED_PKG -e GATED_VER \
+              node:24-slim bash -c '
+                set -euo pipefail
+                npm install -g /tarball/*.tgz > /tmp/install.log 2>&1 \
+                  || { echo "::error::npm install -g failed"; cat /tmp/install.log; exit 1; }
+
+                # case 1 — 装出来的版本就是被门审的那个版本
+                root=$(npm root -g)
+                v=$(node -p "require(\"$root/@sleep2agi/agent-node/package.json\").version")
+                echo "installed agent-node → $v (expected $GATED_VER)"
+                [ "$v" = "$GATED_VER" ] \
+                  || { echo "::error::version mismatch — installed $v, gating $GATED_VER"; exit 1; }
+
+                # case 2 — bin 真的可执行(不是只把文件铺进去了)
+                command -v agent-node > /dev/null \
+                  || { echo "::error::agent-node bin not on PATH after global install"; exit 1; }
+
+                # case 3 — help 广告的运行时能力。
+                # 判据不是我自造的:agent-network 在运行时就是这么判的
+                #   agentNodeHelpSupportsCodexAppServer(help) => help.includes("codex-app-server")
+                #   agentNodeHelpSupportsOpencode(help)       => help.includes("opencode-cli")
+                # 见 agent-network/src/opencode-agent-node-pair.ts。
+                # 发布的包若不广告这两项,配对启动会在用户机器上失败,
+                # 而失败信息是 "exact paired package lacks codex-app-server capability"。
+                help=$(agent-node --help 2>&1 || true)
+                for cap in codex-app-server opencode-cli; do
+                  printf "%s" "$help" | grep -q -- "$cap" \
+                    || { echo "::error::agent-node --help 不广告 $cap —— 配对启动会在用户机器上失败"; printf "%s\n" "$help" | head -30; exit 1; }
+                done
+                echo "✅ agent-node install-path smoke: version + bin + codex-app-server/opencode-cli 能力"
+              '
+            exit 0
+          fi
+
           # Real TTY drive via `script -qc` — captures the wizard's interactive
           # prompts that a plain shell `< /dev/null` would silently skip.
           # The harness installs the tarball as the LOCAL agent-network into a

--- a/docs/tests/release-v2.5.0-preview.35.md
+++ b/docs/tests/release-v2.5.0-preview.35.md
@@ -1,0 +1,65 @@
+# @sleep2agi/agent-node 2.5.0-preview.35 — release notes
+
+这一版的主体是 **grok 共存的带外换模型**（#879）：以前换模型要在 TUI 里敲斜杠命令，
+现在 attach 传输层带了控制角色，`set-model` 在有人 attach 的时候也能用，不经键盘。
+
+配套还修了一个会打断人的缺陷：**控制连接断开不是人断开** —— 旧行为会把用户
+打了一半的那一行清掉。
+
+另外 opencode 共存的进程组身份在 macOS 上也有了。🔴 但请注意实现里那句注释：
+`startTicks` 才是 PID 复用的唯一防线 —— 没有它，`process.kill(-pgrp, SIGKILL)`
+可能杀掉一个不相干的进程组。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.47 @sleep2agi/agent-node@2.5.0-preview.35
+anet node create
+```
+
+🔴 **两个包都要装。** agent-node 的包里没有飞书桥的代码（它去 fork
+`@sleep2agi/agent-network` 的 `dist/src/im/feishu/worker.js`），单装 agent-node
+时飞书通道只打一行 warn 就被跳过，节点照常起来 —— 静默降级。
+
+`anet node create` 里选 grok 共存的 runtime，然后 `anet node start <name>`。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.35
+anet node stop <name>
+anet node start <name>
+```
+
+配对关系是**精确版本**，不是范围：`agent-network` 会校验解析到的 agent-node 包的
+`package.json` 版本严格等于它内置的 `PAIRED_AGENT_NODE_VERSION`。不等就拒绝启动，
+报 `exact paired package identity validation failed`。所以升 agent-node 时要确认
+手上的 agent-network 是配对的那一版。
+
+## 本版包含
+
+- `c98e0ae9` grok 共存：带外换模型，不经键盘（#879）
+- `bedf3dec` grok 共存：attach 协议加 `set-model` 帧
+- `18ea97bf` grok 共存：attach 传输层加控制角色，有人 attach 时 `set-model` 可用（#879）
+- `f7c2cf9e` grok 共存：控制连接断开不是人断开 —— 不再清掉人打了一半的行
+- `f94fa9d0` grok：hot switch 模型，失败再回退到重启
+- `63aa3920` opencode 共存：macOS 上也有进程组身份（`startTicks` 是 PID 复用的那道防线）
+- `3d6f678e` 测试：控制连接的断言留在它该在的层，不塞进 PTY 集成测试
+
+## Verification
+
+- `agent-node --help` 广告 `codex-app-server` 与 `opencode-cli`
+  —— 这正是 agent-network 运行时用来判定配对包能力的两个谓词
+  （`agentNodeHelpSupportsCodexAppServer` / `agentNodeHelpSupportsOpencode`）
+- 安装路径烟测（Docker `node:24-slim`，与 CI 同镜像）：装全局 tarball 后
+  版本 == `2.5.0-preview.35`、`agent-node` bin 在 PATH 上、两项能力都在 help 里
+- witnessed-red 两条：版本喂 `.99` → `version mismatch`；help 不广告能力 →
+  `配对启动会在用户机器上失败`
+
+## 已知不支持
+
+- **grok-build-cli 拒绝飞书通道**：fork 出来的 worker 日志边界没做凭据隔离，
+  硬退并提示改走 CommHub inbox（`agent-node/src/cli.ts:1021`）。这是安全决定，
+  不是未完成项。
+- **claude-code-cli 不是 `--runtime` 的取值**：它由 `anet node start` 启动，
+  不经 agent-node，因此没有本文所述的 IPC think() 路径。


### PR DESCRIPTION
## 症状

2026-08-27 第一次用本 workflow 发 `agent-node`（`2.5.0-preview.35`），gate 2 直接硬退：

```
::error::no agent-node/bin/cli.ts — cannot audit pins
```

因为 publish job 要求四道门全绿，**发布没有发生** —— 门起了作用，但红的理由是门自己写错了范围。

## 根因

```bash
cli="$GATED_PKG/bin/cli.ts"
```

这是照 `agent-network` 的布局写的：

```
agent-network/bin/cli.ts   ✅ 存在
agent-node/src/cli.ts      ← agent-node 的 CLI 在这里，没有 bin/cli.ts
```

所以这道门**在 agent-network 上一直是绿的，对 agent-node 从来没跑成过** ——
今晚是它第一次被 agent-node 触发。

## 它审的到底是什么

全仓 `PINNED_(SERVER|NODE|DASHBOARD)_VERSION` 只出现在一个文件：

```
agent-network/bin/cli.ts
```

这些 pin 指向不存在的版本时 `anet hub start` 会静默挂起（#194 那类 bug）。

**这个不变量与正在发哪个包无关** —— 发 `agent-node` 时，`agent-network` 里那些 pin
同样不能指向不存在的版本。所以固定审 `agent-network/bin/cli.ts`。

## 没有放宽任何判据

「审了 0 个 pin 就拒绝通过」那段**原样保留**：

```
Gate 2 audited 0 pins — no PINNED_*_VERSION matched in $cli.
A zero-scope audit cannot be distinguished from a broken one; refusing to pass.
```

若哪天 `PINNED_*` 搬了家或多了一处，它会说话 —— 那正是它存在的理由。
报错文案里补了一句指明 `PINNED_*` 只住在这里，免得下一个人以为是路径笔误。

## 验证

本地按门的逻辑复算：

```
PINNED_SERVER_VERSION = 0.9.0-preview.30
@sleep2agi/commhub-server@0.9.0-preview.30 → 存在于 npm
audited = 1  （非 0，不触发零范围拒绝）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
