### PR TITLE
chore(release): agent-network 2.3.0-preview.49 —— .48 的飞书默认走了 commhub,不能升 latest

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.48",
+  "version": "2.3.0-preview.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.48",
+      "version": "2.3.0-preview.49",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.48",
+  "version": "2.3.0-preview.49",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,7 +18,7 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.48";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.49";
 export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.35";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.48 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.49 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -99,7 +99,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 | installed version | printed password |
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
-| `2.3.0-preview.48` (`preview` at the time) | `anet-25c07c8cba0740f4a005bf` — **random**, same notice |
+| `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.48 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.49 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -97,7 +97,7 @@ anet hub dashboard
 | 装到的版本 | 打印出来的密码 |
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
-| `2.3.0-preview.48`(当时的 `preview`) | `anet-25c07c8cba0740f4a005bf` —— **随机串**,同上 |
+| `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.49.md
+++ b/docs/tests/release-v2.3.0-preview.49.md
@@ -1,0 +1,63 @@
+# @sleep2agi/agent-network 2.3.0-preview.49 — release notes
+
+这一版只做一件事：**修正飞书出站传输的默认路径**。`.48` 不要升 latest，原因见下。
+
+## `.48` 里发生了什么
+
+`2.3.0-preview.48` 打包时的 main 含 #1252（飞书回复走 CommHub 任务分发）、
+不含 #1262（把选路改成显式声明）。于是已发布的 `.48` 里的选路是：
+
+```js
+process.env.COMMHUB_URL || process.env.ANET_HUB_URL   // 有 hub 地址就走 commhub
+```
+
+每个真实节点都设了 hub 地址 ⇒ **`.48` 上启用飞书的节点默认走 CommHub** ——
+与 2026-08-27 指挥室的明确决定（默认非 commhub）相反。
+证据是已发布 tarball 的字节：worker.js（minified）里含该选路串与 `in_reply_to`。
+
+## 本版（`.49`）的行为
+
+```ts
+export type FeishuBridgeMode = "commhub" | "direct";
+export const DEFAULT_FEISHU_BRIDGE_MODE = "direct";
+```
+
+- 默认 `direct`：bridge → parent IPC → `think()`，**不进 CommHub 任务分发**，
+  也不出现在 Dashboard 拓扑 / Chat
+- `commhub` 必须显式 `ANET_FEISHU_BRIDGE_MODE=commhub` 打开
+- **设了 `COMMHUB_URL` / `ANET_HUB_URL` 也不改变模式**
+- `commhub` 模式拿不到客户端硬退，不悄悄回落；写错值直接抛
+
+七条单测守着（`bridge-mode.test.ts`），三个变异各被对应一条抓住。
+文档见 guide/feishu.md §8.4。
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.49 @sleep2agi/agent-node@2.5.0-preview.35
+anet node create
+```
+
+🔴 **两个版本必须成对**：本版内置 `PAIRED_AGENT_NODE_VERSION = 2.5.0-preview.35`，
+共存路径按精确版本校验，不等则拒绝启动。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.49 @sleep2agi/agent-node@2.5.0-preview.35
+anet node stop <name>
+anet node start <name>
+```
+
+从 `.48` 升级：若你显式依赖了"有 hub 地址就走 commhub"的行为，
+现在要改设 `ANET_FEISHU_BRIDGE_MODE=commhub` —— 静默依赖不再成立。
+
+## 本版包含（相对 `.48`）
+
+- `f682d9d3` feat(feishu): 出站传输模式显式声明，默认 direct（#1262）
+- `5b1b402c` test(feishu): 模式解析的七条单测（变异验证过）
+- `5c61ee5b` feat(feishu): 回复走 CommHub 任务分发（#1252，现在是**可选模式**）
+- 版本位 4 处由 `scripts/sync-pinned-versions.sh` 一次改全
+
+`.48 → .49` 对 `agent-network/` 的全部改动只有 feishu bridge 与其测试 ——
+引导密码等 getting-started 断言的代码路径未被触碰。


### PR DESCRIPTION
## 🔴 为什么需要 `.49`：已发布的 `.48` 不能升 latest

`.48` 打包时的 main（`8e10123b`）**含 #1252、不含 #1262**。已发布 tarball 的字节证据（`worker.js`，minified）：

```js
process.env.COMMHUB_URL||process.env.ANET_HUB_URL   → commhub client
in_reply_to / tools/call 均在
DEFAULT_FEISHU_BRIDGE_MODE : 0 命中
```

每个真实节点都设了 hub 地址 ⇒ **`.48` 上启用飞书的节点默认走 CommHub** ——
与指挥室 2026-08-27 的明确决定（默认非 commhub）相反。

取证时踩过的两个坑（都已在提交里记下）：先把 `COMMHUB_URL`（CLI 里到处有）和
`createEnvCommHubClient` 混在一个 grep 模式里数；后又被 minified 改名骗出 0 命中假阴。
**grep minified dist 要用行为串，不用函数名。**

## `.49` 的内容

相对 `.48` 只有飞书 bridge：**#1262 显式模式（默认 `direct`）**，#1252 降为可选模式。
`PAIRED_AGENT_NODE_VERSION` 保持 `2.5.0-preview.35`，版本位 4 处由 sync 脚本一次改全。

## gate 4 的第二判据这次真的拦了我一次

只把戳改成 `.49` → 门红：**「戳说 preview=.49，但正文里一次都没出现这个串 —— 戳更新了正文没改?」**

按门的要求在 `.49` tarball 上**实测**（与 `.48` 同一探针）：

```
password: anet-7fe4eddb08f648dcbd7fcd    随机串,无 anethub 字面量
```

正文表格 preview 行换成 `.49` 的实测值 —— **不是改数字**。

## 本地验证

```
gate3: Install / Upgrade / 版本串       ✅
gate4: 每一条被标记的版本断言都指着正在发的那个版本 ✅
配对 + 一致性 + bridge-mode 测试:  15 pass 0 fail
```

## 合入后

CI 发 `.49` → 配对烟测（`.49` + `agent-node@2.5.0-preview.35`）→ owner ACK → **升一对 latest**。
`.48` 留在 registry 但永不升 latest。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
