### PR TITLE
ci(qa): push 段补齐只在 pull_request 段登记的 11 条 path(#1062)

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -336,6 +336,20 @@ on:
       - 'tests/test30-v0.8-auth-deprecation/**'
       - 'deploy/hub/hub-daemon.sh'
       - 'tests/test626-grok-model-switch-fallback/**'
+      # 🔴 以下条目此前只在 pull_request 段登记(#1062 普查,2026-08-27):
+      # 新增条目时只加 PR 段的系统性习惯 —— 改动这些目标在 PR 上会触发门、
+      # 合进 main 后不触发,main 上那道门失明(#1243 同形状)。两段必须同步增删。
+      - 'scripts/sync-pinned-versions.sh'
+      - 'docs/qa/**'
+      - 'tests/test1183-sync-pinned-dryrun/**'
+      - 'tests/test1193-side-thread-contract/**'
+      - 'tests/test1195-side-thread-hub-contract/**'
+      - 'tests/test1195-side-thread-hub-security/**'
+      - 'tests/test1195-side-thread-hub-race/**'
+      - 'tests/test1200-side-thread-command-transport/**'
+      - 'tests/test1203-btw-production-e2e/**'
+      - 'tests/test1181-codex-durable-poll/**'
+      - 'tests/test1210-actual-target-contract/**'
 
 # Older runs on the same ref get cancelled — saves minutes when a PR is
 # updated rapidly. main pushes run independently.


### PR DESCRIPTION
## 修 #1062：`push` 段补齐只在 `pull_request` 段登记的 11 条 path

普查方法：**按事件归属逐行解析** `qa.yml`（不是数字符串出现次数）。`origin/main` 上：

```
pull_request paths  150 条
push         paths  139 条
仅 PR 有 11 条 / 仅 push 有 0 条    ← 差集单向
```

单向说明这是「新增条目时只加 PR 段」的系统性习惯，不是两边各自演化。

## 后果（为什么值得修）

改动这 11 个目标 —— 含 `tests/test1195-side-thread-hub-security/**`（**安全契约门**）——
在 PR 上会触发门、合进 main 后**不触发**：

- 「这个改动在 main 上是好的」没有任何证据支持
- 而 PR 上的绿看起来完全正常

🔴 #1243 同形状：`deploy/**` 只登记一半，一条 PR 检查数从 ~92 掉到 16（比例反而更好看），main 红了约 6 小时没人看见。

## 范围

**只做机械补齐**，不加棘轮门（#1062 里已提议基线式的差集门，另做 —— 要求清零的门第一天就是红的）。

## 验证

```
补完差集: PR=151 push=151 仅PR=0 仅push=0
YAML 解析 OK
check-l1-paths-sync          : every L1 suite has a matching trigger.
check-qa-trigger-coverage    : all 63 CI-executed test directory/ies can re-trigger qa.yml.
check-test-suite-registration: no new unregistered test suite.
```

Closes 的判定留给 #1062（棘轮门那半还没做）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
