### PR TITLE
test(codex): use absolute Bun path in Windows real gate

### DIFF
--- a/tests/test1212-windows-real-codex-gate/run.ps1
+++ b/tests/test1212-windows-real-codex-gate/run.ps1
@@ -63,6 +63,9 @@ try {
   $env:ANET_TEST1212_VENDOR_SHA256 = $vendorSha
   $env:ANET_TEST1212_PRIVATE = $privateRoot
   $env:ANET_TEST1212_ARTIFACTS = $artifacts
+  $bunExe = (Get-Command bun -CommandType Application -ErrorAction Stop).Source
+  if (-not $bunExe -or -not (Test-Path -LiteralPath $bunExe -PathType Leaf)) { throw "trusted Bun executable unavailable" }
+  $env:ANET_TEST1212_BUN = $bunExe
 
   Push-Location (Join-Path $repo "agent-network")
   bun install --frozen-lockfile
@@ -82,5 +85,6 @@ try {
   throw
 } finally {
   Remove-Item Env:ANET_TEST1212_CODEX -ErrorAction SilentlyContinue
+  Remove-Item Env:ANET_TEST1212_BUN -ErrorAction SilentlyContinue
   Remove-Item -LiteralPath $privateRoot -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/tests/test1212-windows-real-codex-gate/static-contract.mjs
+++ b/tests/test1212-windows-real-codex-gate/static-contract.mjs
@@ -19,6 +19,8 @@ function audit(w, r, j, e) {
   requireContract(gate >= 0 && r.indexOf("& $codexCmd") > gate, "Codex executed before allowlist");
   requireContract(r.includes("(?:%~dp0|%dp0%)"), "current npm cmd-shim canonical launcher form unsupported");
   requireContract(!/Get-ChildItem[^\n]+-Recurse|Select-Object -First/i.test(r), "vendor decoy accepted");
+  requireContract(/Get-Command bun -CommandType Application/.test(r) && /ANET_TEST1212_BUN/.test(r), "absolute Bun executable handoff missing");
+  requireContract(/const bun = process\.env\.ANET_TEST1212_BUN/.test(j) && /pty\.spawn\(bun,/.test(j) && !/pty\.spawn\("bun"/.test(j), "ConPTY uses a PATH-only Bun name");
   requireContract(/thread\/read/.test(j) && /pollCompletedAssistant/.test(j), "authoritative bounded read missing");
   requireContract(!/output\.match\(new RegExp\(marker/.test(j), "ConPTY redraw accepted");
   requireContract(/steered !== 2/.test(j) && /role === "bridge"/.test(j), "same-turn/single-bridge missing");
@@ -34,6 +36,7 @@ const mutations = [
   ["secret during npm", workflow, replaceRequired(runner, "Remove-Item Env:ANET_CODEX_AUTH_JSON", "# removed", "secret"), journey, evidence],
   ["prehash execution", workflow, replaceRequired(runner, "$codexInstall =", "& $codexCmd --version\n  $codexInstall =", "prehash"), journey, evidence],
   ["new cmd-shim form", workflow, replaceRequired(runner, "(?:%~dp0|%dp0%)", "%~dp0", "cmd-shim"), journey, evidence],
+  ["PATH-only ConPTY Bun", workflow, replaceRequired(runner, "Get-Command bun -CommandType Application", "Write-Output bun", "absolute bun"), journey, evidence],
   ["vendor decoy", workflow, replaceRequired(runner, "$vendorPath =", "Get-ChildItem $codexInstall -Recurse | Select-Object -First 1\n  $vendorPath =", "decoy"), journey, evidence],
   ["ConPTY redraw", workflow, runner, replaceRequired(journey, "if (!injected", "if ((output.match(new RegExp(marker, 'g')) || []).length >= 2) activeTurnId='redraw';\n if (!injected", "redraw"), evidence],
   ["no authoritative read", workflow, runner, replaceRequired(journey, "thread/read", "screen/read", "read"), evidence],

--- a/tests/test1212-windows-real-codex-gate/windows-real-e2e.mjs
+++ b/tests/test1212-windows-real-codex-gate/windows-real-e2e.mjs
@@ -16,14 +16,15 @@ const pairedVersion = JSON.parse(readFileSync(join(repo, "agent-node", "package.
 const privateRoot = process.env.ANET_TEST1212_PRIVATE;
 const artifacts = process.env.ANET_TEST1212_ARTIFACTS;
 const expectedSha = process.env.ANET_EXPECTED_SOURCE_SHA;
-if (!privateRoot || !artifacts || !expectedSha) throw new Error("protected harness environment incomplete");
+const bun = process.env.ANET_TEST1212_BUN;
+if (!privateRoot || !artifacts || !expectedSha || !bun || !existsSync(bun)) throw new Error("protected harness environment incomplete");
 const work = join(privateRoot, "work"), home = process.env.HOME, codexHome = process.env.CODEX_HOME;
 const project = join(work, "project"), nodeHome = join(project, ".anet", "nodes", "windows-real", "codex-home");
 mkdirSync(project, { recursive: true });
 const port = 19000 + Math.floor(Math.random() * 1000);
 const token = `test1212-${randomUUID()}`;
 const hubEnv = { ...process.env, PORT: String(port), COMMHUB_AUTH_TOKEN: token, DATABASE_URL: join(privateRoot, "hub.db") };
-const hub = spawn("bun", ["run", "src/index.ts"], { cwd: join(repo, "server"), env: hubEnv, stdio: "ignore", windowsHide: true });
+const hub = spawn(bun, ["run", "src/index.ts"], { cwd: join(repo, "server"), env: hubEnv, stdio: "ignore", windowsHide: true });
 const cli = join(repo, "agent-network", "bin", "cli.ts");
 const env = { ...process.env, HOME: home, USERPROFILE: home };
 const marker = `WINDOWS_REAL_${randomUUID().replaceAll("-", "")}`;
@@ -31,8 +32,8 @@ const sleepSeconds = 70;
 const evidence = { schema: "anet/windows-real-codex-gate/v1", result: "FAIL", notInCi: true, sourceSha: expectedSha, codexVersion: "0.148.0", platform: process.platform, conpty: true };
 const delay = ms => new Promise(r => setTimeout(r, ms));
 async function wait(label, fn, ms = 30000) { const end = Date.now() + ms; while (Date.now() < end) { if (await fn()) return; await delay(200); } throw new Error(`timeout: ${label}`); }
-function run(args, input = "") { const r = spawnSync("bun", [cli, ...args], { cwd: project, env, input, encoding: "utf8", timeout: 60000 }); if (r.status) throw new Error(`anet ${args.join(" ")} failed`); return `${r.stdout}${r.stderr}`; }
-function terminal(args, drive, ms = 180000) { return new Promise((ok, bad) => { const child = pty.spawn("bun", [cli, ...args], { cwd: project, env, cols: 140, rows: 45 }); let out = ""; const timer = setTimeout(() => { child.kill(); bad(new Error("ConPTY timeout")); }, ms); child.onData(d => { out += d; drive?.(child, out); }); child.onExit(({ exitCode }) => { clearTimeout(timer); exitCode === 0 ? ok(out) : bad(new Error(`ConPTY exit ${exitCode}`)); }); }); }
+function run(args, input = "") { const r = spawnSync(bun, [cli, ...args], { cwd: project, env, input, encoding: "utf8", timeout: 60000 }); if (r.status) throw new Error(`anet ${args.join(" ")} failed`); return `${r.stdout}${r.stderr}`; }
+function terminal(args, drive, ms = 180000) { return new Promise((ok, bad) => { const child = pty.spawn(bun, [cli, ...args], { cwd: project, env, cols: 140, rows: 45 }); let out = ""; const timer = setTimeout(() => { child.kill(); bad(new Error("ConPTY timeout")); }, ms); child.onData(d => { out += d; drive?.(child, out); }); child.onExit(({ exitCode }) => { clearTimeout(timer); exitCode === 0 ? ok(out) : bad(new Error(`ConPTY exit ${exitCode}`)); }); }); }
 async function task(auth, network, priority) { const r = await fetch(`http://127.0.0.1:${port}/api/task`, { method: "POST", headers: { Authorization: `Bearer ${auth}`, "Content-Type": "application/json" }, body: JSON.stringify({ alias: "windows-real", from: "test1212", network_id: network, priority, task: `${priority} gate message; reply with ${priority.toUpperCase()}_OK`, meta: { source: "dashboard-chat", client_request_id: randomUUID() } }) }); const b = await r.json(); if (!r.ok || !b.task_id) throw new Error("task post failed"); return b.task_id; }
 async function readThread(remote, threadId) {
   const ws = new WebSocket(remote);


### PR DESCRIPTION
Fixes the protected Windows real-Codex harness after run 33033657545 proved node-pty cannot resolve a PATH-only `bun` executable under ConPTY. PowerShell now resolves and validates the exact Bun application path, and every child/PTY launch uses it. Product co-presence code and health criteria are unchanged.\n\nLocal gates: node syntax PASS; LF+CRLF static contract PASS; prompt-only red; late assistant green; 11 weakening mutations red.