### PR TITLE
docs(introduction): 架构图加上 Desktop 客户端(Vincent 圈图)

### DIFF
--- a/docs-site/docs/en/guide/introduction.md
+++ b/docs-site/docs/en/guide/introduction.md
@@ -11,11 +11,12 @@ flowchart LR
   B -->|result| H
   H --> A
   D[Dashboard] --> H
+  C[Desktop app] --> H
 ```
 
 - **CommHub** stores network, node, and task state and routes work; agents call its collaboration tools over MCP (full list in the [MCP tools reference](/en/api/mcp-tools)).
 - **Agent Node** connects one local AI runtime and processes incoming tasks.
-- **Dashboard / CLI** configure the system, show status, and dispatch work.
+- **Dashboard / Desktop app / CLI** configure the system, show status, and dispatch work. The Desktop app (macOS/Windows installers) operates the same Hub as the Dashboard.
 
 The Hub, Dashboard, and SQLite data run on hardware you control. Members and tasks are isolated between Networks.
 

--- a/docs-site/docs/guide/introduction.md
+++ b/docs-site/docs/guide/introduction.md
@@ -11,11 +11,12 @@ flowchart LR
   B -->|结果| H
   H --> A
   D[Dashboard] --> H
+  C[Desktop 客户端] --> H
 ```
 
 - **CommHub** 保存网络、节点和任务状态，并负责路由；Agent 通过 MCP 调用它的协作工具（完整清单见 [MCP 工具参考](/api/mcp-tools)）。
 - **Agent Node** 连接一种本地 AI runtime，接收并处理任务。
-- **Dashboard / CLI** 用于配置、观察和人工派工。
+- **Dashboard / Desktop 客户端 / CLI** 用于配置、观察和人工派工。Desktop 客户端（macOS/Windows 安装包）与 Dashboard 操作同一个 Hub。
 
 Hub、Dashboard 和 SQLite 数据都运行在你控制的机器上。不同 Network 之间的成员和任务相互隔离。
 


### PR DESCRIPTION
Vincent 2026-08-27 圈图指出：「它怎么工作」的架构图里操作 CommHub 的只画了 Dashboard，
而 **Desktop 客户端**（macOS/Windows 安装包）同样直接操作 Hub —— 用户从图上看不到这条入口。

zh / en 同步：

- mermaid 图加 `Desktop 客户端 / Desktop app --> CommHub`
- bullet「Dashboard / CLI」→「Dashboard / Desktop 客户端 / CLI」，并注明桌面端与 Dashboard 操作同一个 Hub

文档门本地全过（symbol-pins / doc-claims / version-claims 只读 / slug）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
