### PR TITLE
chore(release): publish BTW previews .31/.36/.50

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1701,7 +1701,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // refetch). A `latest` agent-network release must pin a *stable* server.
 // `anet upgrade` (#88) surfaces this constant in its plan output so users
 // understand global-install version != version anet hub start actually runs.
-const PINNED_SERVER_VERSION = "0.9.0-preview.30";
+const PINNED_SERVER_VERSION = "0.9.0-preview.31";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.49",
+  "version": "2.3.0-preview.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.49",
+      "version": "2.3.0-preview.50",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.49",
+  "version": "2.3.0-preview.50",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.49";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.35";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.50";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.36";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.35",
+  "version": "2.5.0-preview.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.35",
+      "version": "2.5.0-preview.36",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.35",
+  "version": "2.5.0-preview.36",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs/tests/report-release-btw-preview-31-36-50.txt
+++ b/docs/tests/report-release-btw-preview-31-36-50.txt
@@ -1,0 +1,25 @@
+BTW preview package release candidate
+Date: 2026-08-27
+
+Source
+- Base: eb28d04a2184c7ce3a11e35694768d41eedde068
+- Candidate: 3280001524952fe740f7a8703397fd7830e1876d
+
+Versions
+- @sleep2agi/commhub-server 0.9.0-preview.31
+- @sleep2agi/agent-node 2.5.0-preview.36
+- @sleep2agi/agent-network 2.3.0-preview.50
+- CLI server pin: 0.9.0-preview.31
+- Paired network/node: 2.3.0-preview.50 / 2.5.0-preview.36
+- Registry preflight: all three exact versions were absent.
+
+Docker gates
+- test1183 release version sync: PASS, including witnessed-red controls.
+- test766 pinned Hub preflight and production bundle: PASS (4/0).
+- test1204 BTW production wiring: PASS; 58 baseline tests, real Hub +
+  agent-node two-process E2E, 12 witnessed-red mutations, and two bundles.
+
+Safety
+- This candidate changes versions and exact package pins only.
+- No npm package or dist-tag was changed by the preparation gates.
+- Publish order must be server, agent-node, then agent-network.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.30",
+  "version": "0.9.0-preview.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.30",
+      "version": "0.9.0-preview.31",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.30",
+  "version": "0.9.0-preview.31",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -84,7 +84,7 @@ probe_bunx(){
   rc=0
   [[ -s "$capture" ]] || rc=1
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.30' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.31' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- commhub-server 0.9.0-preview.31
- agent-node 2.5.0-preview.36
- agent-network 2.3.0-preview.50
- update exact Hub and paired package pins

## Docker gates
- version sync PASS
- pinned Hub preflight/build PASS
- BTW production wiring: 58 tests, real two-process E2E, 12 witnessed-red, two bundles PASS

## Publish order
server → agent-node → agent-network. No package or dist-tag has been changed yet.