### PR TITLE
fix(test638): 聚合失败时吐出指名诊断，消除无声红 (#1274)

### DIFF
--- a/tests/test638-server-aggregate-isolation/run.sh
+++ b/tests/test638-server-aggregate-isolation/run.sh
@@ -30,6 +30,15 @@ cleanup() {
   rmdir server/src/test639 2>/dev/null || true
 }
 trap cleanup EXIT
+dump_agg_failure() {
+  # #1274: aggregate 失败时把诊断吐给 CI —— 否则 set -e 无声死，红无任何指名信息
+  local label="$1" output="$2" rc="$3"
+  echo "FAIL: $label aggregate exited rc=$rc — offending files:"
+  grep '^TEST_FILE_RESULT' "$output" | awk -F'\t' '$0 !~ /exit=0/ || $0 ~ /timeout=true/' || true
+  echo "--- last 40 lines of $output ---"
+  tail -40 "$output" || true
+}
+
 rm -rf -- /tmp/test638-run1 /tmp/test638-run2 /tmp/test638-run3
 rm -f -- "$OUT1" "$OUT2" "$OUT3" "$TRACE1" "$SHARED_DB" "$SHARED_DB-wal" "$SHARED_DB-shm"
 
@@ -43,9 +52,13 @@ run_one() {
 }
 
 echo "L1: normal order under strace"
+set +e
 NODE_ENV=test DATABASE_URL='postgres://must-not-be-inherited.invalid/prod' COMMHUB_DB="$SHARED_DB" \
   ANET_SERVER_TEST_ROOT="$RUN1" ANET_SERVER_TEST_KEEP_ROOT=1 \
   strace -f -e trace=openat -o "$TRACE1" bun run --cwd server test >"$OUT1" 2>&1
+rc1=$?
+set -e
+[[ $rc1 -eq 0 ]] || { dump_agg_failure "L1" "$OUT1" "$rc1"; exit 1; }
 
 echo "L2: concurrent normal + reverse order"
 set +e
@@ -54,6 +67,8 @@ run_one "$RUN3" "$OUT3" reverse & p3=$!
 wait "$p2"; rc2=$?
 wait "$p3"; rc3=$?
 set -e
+[[ $rc2 -eq 0 ]] || dump_agg_failure "L2-normal" "$OUT2" "$rc2"
+[[ $rc3 -eq 0 ]] || dump_agg_failure "L2-reverse" "$OUT3" "$rc3"
 [[ $rc2 -eq 0 && $rc3 -eq 0 ]] || { echo "FAIL: concurrent aggregate rc2=$rc2 rc3=$rc3"; exit 1; }
 
 summary_key() {

--- a/tests/test638-server-aggregate-isolation/run.sh
+++ b/tests/test638-server-aggregate-isolation/run.sh
@@ -34,7 +34,8 @@ dump_agg_failure() {
   # #1274: aggregate 失败时把诊断吐给 CI —— 否则 set -e 无声死，红无任何指名信息
   local label="$1" output="$2" rc="$3"
   echo "FAIL: $label aggregate exited rc=$rc — offending files:"
-  grep '^TEST_FILE_RESULT' "$output" | awk -F'\t' '$0 !~ /exit=0/ || $0 ~ /timeout=true/' || true
+  grep '^TEST_FILE_RESULT' "$output" \
+    | awk -F'\t' '{bad=0; for(i=1;i<=NF;i++){if($i=="timeout=true")bad=1; if($i ~ /^exit=/ && $i!="exit=0")bad=1}; if(bad)print}' || true
   echo "--- last 40 lines of $output ---"
   tail -40 "$output" || true
 }


### PR DESCRIPTION
Closes #1274。

## 问题
test638 L1 段 `bun run --cwd server test >"$OUT1" 2>&1` 处于 `set -euo pipefail` 下：聚合一旦非零，脚本无声死亡，唯一的诊断（OUT1）永不打印。PR #1101 实撞：CI 停在 `L1: normal order under strace` 后裸 exit 1，零指名信息（同「红要说得清是哪一种」判据纪律，#990 家族）。

## 修法
新增 `dump_agg_failure`：失败时先打印 `TEST_FILE_RESULT` 中 `exit!=0` 或 `timeout=true` 的行 + `tail -40 OUT`，再退出。L1 改为 rc 捕获；L2 两腿失败时各自吐诊断。判据零变化——只加诊断，不改任何断言。

## 验证
- `bash -n` 过
- fixture 双向：红路径点名 `b.test.ts(exit=1)` / `c.test.ts(timeout=true)`、排除 `a.test.ts(exit=0)`；绿路径穿透无扰
- 按内容搜过重复 PR：关键词 test638/silent ⇒ 零命中

🤖 Generated with [Claude Code](https://claude.com/claude-code)