### PR TITLE
fix(node-server): stop inventing "hub" as the reply recipient when the originator map misses

### DIFF
--- a/agent-network/src/node-server.ts
+++ b/agent-network/src/node-server.ts
@@ -95,6 +95,7 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { decideReplyAlias, replyAliasArgs } from "./reply-originator.js";
 
 // ── Load ~/.anet/config.json for token fallback ──────
 function loadAnetConfig(): Record<string, string> {
@@ -355,9 +356,14 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req: any) => {
     // V2: terminal statuses use send_reply to close task lifecycle
     if (status === "completed" || status === "failed" || status === "cancelled") {
       const replyStatus = status === "completed" ? "replied" : status;
-      const originator = task_id ? (taskOriginators.get(task_id) || "hub") : "hub";
+      // #1185 / f015d9d6 — 映射未命中时不要编一个收件人。taskOriginators 是纯内存的，
+      // 进程重启会清空，任务在 SSE 推送到达之前被得知也不会写入。旧写法 `|| "hub"`
+      // 在这两种情况下都断言「发起方是 hub」，于是 hub 侧要么拒（reply_target_mismatch，
+      // 任务永远终结不了），要么在 from_name 恰好是 hub 时把回执静默投错频道。
+      // 省略 alias 让 hub 从 in_reply_to 反查 tasks.from_name（服务端 #1085 的推导路径）。
+      const aliasArgs = replyAliasArgs(decideReplyAlias(task_id, (id) => taskOriginators.get(id)));
       const result = await callCommHub("send_reply", {
-        alias: originator,
+        ...aliasArgs,
         text,
         in_reply_to: task_id || undefined,
         status: replyStatus,

--- a/agent-network/src/reply-originator.test.ts
+++ b/agent-network/src/reply-originator.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { decideReplyAlias, replyAliasArgs } from "./reply-originator.js";
+
+const map = new Map<string, string>();
+const lookup = (id: string) => map.get(id);
+
+describe("#1185 / f015d9d6 — send_reply 的 alias 决策", () => {
+  test("命中：把记住的发起方显式发出去", () => {
+    map.set("t1", "admin-user");
+    expect(decideReplyAlias("t1", lookup)).toEqual({ kind: "known", alias: "admin-user" });
+    expect(replyAliasArgs(decideReplyAlias("t1", lookup))).toEqual({ alias: "admin-user" });
+  });
+
+  test("🔴 未命中：省略 alias，且【绝不】发出字面量 hub", () => {
+    const d = decideReplyAlias("t-unknown", lookup);
+    expect(d).toEqual({ kind: "derive" });
+    const args = replyAliasArgs(d);
+    // 判据落在「键不存在」上，不是「值不是 hub」——发 alias:undefined 与省略不同，
+    // 前者过不了服务端那句 `typeof alias === "string" && alias.trim()` 之外的意图检查。
+    expect("alias" in args).toBe(false);
+    expect(args).toEqual({});
+    // 这一行是这个 bug 的直接回归钉：旧写法在这里会给出 "hub"。
+    expect((args as { alias?: string }).alias).not.toBe("hub");
+  });
+
+  test("未命中的两个触发条件产出同一个决策（重启清空 / 推送尚未到达）", () => {
+    // 1. 进程重启：Map 是空的
+    const emptyMap = new Map<string, string>();
+    expect(decideReplyAlias("t-after-restart", (id) => emptyMap.get(id))).toEqual({ kind: "derive" });
+    // 2. 推送迟到：任务已存在于 hub，但本会话还没被推送过，所以没写进 Map
+    expect(decideReplyAlias("t-push-pending", lookup)).toEqual({ kind: "derive" });
+  });
+
+  test("推送到达后（Map 被写上）同一个 task_id 转为 known —— 复现「重试就成功」", () => {
+    expect(decideReplyAlias("t-late", lookup)).toEqual({ kind: "derive" });
+    map.set("t-late", "admin-user");            // SSE 落地时 node-server 会做的事
+    expect(decideReplyAlias("t-late", lookup)).toEqual({ kind: "known", alias: "admin-user" });
+  });
+
+  test("空串/空白视为未命中，不当成合法 alias 发出去", () => {
+    map.set("t-empty", "");
+    map.set("t-blank", "   ");
+    expect(decideReplyAlias("t-empty", lookup)).toEqual({ kind: "derive" });
+    expect(decideReplyAlias("t-blank", lookup)).toEqual({ kind: "derive" });
+  });
+
+  test("没有 task_id 可推导时保持历史行为：发给 hub", () => {
+    expect(decideReplyAlias(undefined, lookup)).toEqual({ kind: "hub", alias: "hub" });
+    expect(decideReplyAlias(null, lookup)).toEqual({ kind: "hub", alias: "hub" });
+    expect(decideReplyAlias("", lookup)).toEqual({ kind: "hub", alias: "hub" });
+    expect(replyAliasArgs(decideReplyAlias(null, lookup))).toEqual({ alias: "hub" });
+  });
+});

--- a/agent-network/src/reply-originator.ts
+++ b/agent-network/src/reply-originator.ts
@@ -1,0 +1,48 @@
+// 决定 send_reply 的 `alias` 参数 —— 见 #1185 与任务 f015d9d6。
+//
+// 背景：node-server 用一个纯内存 Map（taskOriginators）记住 task_id → 发起方 alias，
+// 只在 SSE 把任务推进本会话时写入。原来的取值是：
+//
+//     const originator = task_id ? (taskOriginators.get(task_id) || "hub") : "hub";
+//
+// 🔴 那个 `|| "hub"` 是一个**编出来的收件人**。映射未命中时它并不是"不知道"，
+//    而是断言发起方是 hub。于是 hub 侧拿 "hub" 去比任务真正的 from_name：
+//      · from_name 不是 hub ⇒ reply_target_mismatch，任务永远终结不了
+//      · from_name 恰好是 hub ⇒ 更糟：回执静默投进错误的频道
+//
+// 映射未命中有**两个**触发条件，不止一个：
+//   1. MCP/节点进程重启，Map 清空（#1185 记录的那个）
+//   2. 会话在 SSE 推送到达**之前**就得知了任务（例如任务投递滞后、而 agent 从别处
+//      发现它）。任务 f015d9d6 就是这一种：等推送迟到约 15 分钟落地之后，
+//      同一个 task_id 重试立刻成功 —— 因为那时 Map 才被写上。
+//
+// 修法不是给 fallback 换一个更好的猜测，而是**不猜**：省略 alias，让 hub 从
+// in_reply_to 反查 tasks.from_name（服务端 #1085 已经支持这条推导路径，
+// server/src/tools.ts 的 "derive the reply target when the caller omitted alias"）。
+// hub 掌握权威事实，节点内存不掌握。
+
+export type ReplyAliasDecision =
+  /** 把 alias 显式发出去 */
+  | { readonly kind: "known"; readonly alias: string }
+  /** 省略 alias，交给 hub 从 in_reply_to 推导 */
+  | { readonly kind: "derive" }
+  /** 没有 task_id 可推导：保持历史行为，发给 hub */
+  | { readonly kind: "hub"; readonly alias: "hub" };
+
+export function decideReplyAlias(
+  taskId: string | null | undefined,
+  lookup: (taskId: string) => string | undefined,
+): ReplyAliasDecision {
+  if (!taskId) return { kind: "hub", alias: "hub" };
+  const known = lookup(taskId);
+  // 空串/空白同样算未命中：一个空 alias 发出去会被 hub 当成「省略」以外的东西。
+  if (typeof known === "string" && known.trim() !== "") {
+    return { kind: "known", alias: known };
+  }
+  return { kind: "derive" };
+}
+
+/** 把决策摊成 send_reply 的参数片段。`derive` 时**不含** alias 键。 */
+export function replyAliasArgs(d: ReplyAliasDecision): { alias?: string } {
+  return d.kind === "derive" ? {} : { alias: d.alias };
+}

--- a/server/src/reply-target-derivation.test.ts
+++ b/server/src/reply-target-derivation.test.ts
@@ -1,0 +1,96 @@
+// f015d9d6 根因隔离：admin(dashboard/人类) 发给「无 node_id 的 MCP 会话」的任务，
+// 其回执被 reply_target_mismatch 拒绝。
+//
+// 上报时给出的假设是「校验依赖投递绑定 ⇒ 任务还没真正 deliver 进会话时回执会被拒」。
+// 本文件把两个变量分开量，一次只动一个：
+//   变量 1 = 任务是否已投递（status created vs delivered，有无 SSE 订阅者）
+//   变量 2 = 调用方是否显式传 alias
+// 如果假设成立，变量 1 应当决定结果；如果 alias 推导才是决定因素，变量 2 才会。
+import { beforeEach, afterAll, describe, expect, test } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db } from "./db.js";
+import { registerTools } from "./tools.js";
+import { __resetSSEClientsForTest, createSSEStream } from "./push.js";
+
+const NET = "net_admin_reply_f015";
+const USER = "user_admin_reply_f015";
+const ADMIN = "admin-f015";           // 人类/dashboard 发起方，无 node
+const AGENT = "agent-mcp-f015";       // MCP 会话：sessions 行 node_id = NULL
+const AGENT_NODE = "node-agent-f015"; // token 绑定的 node（会话本身仍无 node_id）
+
+type ToolHandler = (args: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+
+function cleanup() {
+  __resetSSEClientsForTest();
+  for (const t of ["tasks", "inbox", "task_events", "sessions", "api_tokens", "nodes", "rename_txn"]) {
+    try { db.run(`DELETE FROM ${t} WHERE network_id = ?1`, [NET]); } catch {}
+  }
+  try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [USER]); } catch {}
+}
+
+function seed() {
+  db.run("INSERT INTO users (user_id, username, password_hash, role, created_at) VALUES (?1, ?1, 'x', 'admin', datetime('now'))", [USER]);
+  db.run("INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))", [NET, USER]);
+  db.run("INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))", [USER, NET]);
+  db.run(
+    "INSERT INTO nodes (node_id, node_name, alias, network_id, hostname, config_snapshot, created_at, updated_at, lifecycle_state) VALUES (?1, ?2, ?2, ?3, 'host', '{}', datetime('now'), datetime('now'), 'active')",
+    [AGENT_NODE, AGENT, NET],
+  );
+  // 🔴 关键夹具属性：会话行 node_id 为 NULL —— 这正是 MCP 挂载的 claude-code 会话的形状
+  db.run(
+    "INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at) VALUES (?1, ?2, 'idle', NULL, ?3, datetime('now'), datetime('now'))",
+    [`cc-n_${AGENT}`, AGENT, NET],
+  );
+  db.run(
+    "INSERT INTO api_tokens (token_id, token_hash, user_id, network_id, name, scope, bound_node_id) VALUES (?1, ?2, ?3, ?4, ?5, 'network', ?6)",
+    [`token-${AGENT}`, `hash-${AGENT}`, USER, NET, `node:${AGENT}`, AGENT_NODE],
+  );
+}
+
+function toolsFor(alias: string): Record<string, ToolHandler> {
+  const server = new McpServer({ name: "admin-reply-f015", version: "0" }) as any;
+  const tools: Record<string, ToolHandler> = {};
+  const original = server.tool.bind(server);
+  server.tool = (name: string, description: string, schema: any, handler: ToolHandler) => {
+    tools[name] = handler; return original(name, description, schema, handler);
+  };
+  registerTools(server, undefined, NET, USER, alias, true, `token-${alias}`);
+  return tools;
+}
+
+function parse(res: { content: Array<{ text: string }> }) { return JSON.parse(res.content[0].text); }
+
+/** 造一条 admin(人类) → AGENT 的任务；delivered 控制「是否已投递」这一个变量。 */
+function seedAdminTask(taskId: string, delivered: boolean) {
+  db.run(
+    `INSERT INTO tasks (task_id, from_name, from_node_id, to_name, to_node_id, content, status, priority, network_id, created_at)
+     VALUES (?1, ?2, NULL, ?3, NULL, 'ping', ?4, 'normal', ?5, datetime('now'))`,
+    [taskId, ADMIN, AGENT, delivered ? "delivered" : "created", NET],
+  );
+}
+
+describe("f015d9d6 — admin→无 node_id 的 MCP 会话，回执绑定", () => {
+  beforeEach(() => { cleanup(); seed(); });
+  afterAll(() => cleanup());
+
+  test("变量1：任务【未投递】+ 省略 alias（走 #1085 推导）⇒ 回执应当成功", async () => {
+    seedAdminTask("t-undelivered", false);
+    const r = parse(await toolsFor(AGENT).send_reply({ in_reply_to: "t-undelivered", text: "done", status: "completed" }));
+    expect(r).toEqual(expect.objectContaining({ ok: true }));
+  });
+
+  test("变量1 对照：任务【已投递且有 SSE 订阅者】+ 省略 alias ⇒ 同样成功", async () => {
+    seedAdminTask("t-delivered", true);
+    createSSEStream(AGENT, NET);
+    const r = parse(await toolsFor(AGENT).send_reply({ in_reply_to: "t-delivered", text: "done", status: "completed" }));
+    expect(r).toEqual(expect.objectContaining({ ok: true }));
+  });
+
+  test("变量2：显式传一个不等于任务发起方的 alias ⇒ reply_target_mismatch", async () => {
+    seedAdminTask("t-wrong-alias", true);
+    const r = parse(await toolsFor(AGENT).send_reply({ alias: "someone-else", in_reply_to: "t-wrong-alias", text: "done", status: "completed" }));
+    expect(r).toEqual(expect.objectContaining({ ok: false, error: "reply_target_mismatch" }));
+  });
+});


### PR DESCRIPTION
Root-causes task `f015d9d6` (admin→MCP-session reply rejected with `reply_target_mismatch`). Refs #1185.

## The bug is client-side, not in the hub

`agent-network/src/node-server.ts:358` built the `send_reply` target from an in-memory map:

```ts
const originator = task_id ? (taskOriginators.get(task_id) || "hub") : "hub";
```

`taskOriginators` is populated **only** when the SSE push delivers the task into this session. On a miss, `|| "hub"` does not mean "unknown" — it **asserts the originator was hub**. The hub then compares `"hub"` against the task's real `from_name` and either:

- refuses the reply (`reply_target_mismatch`) — the task can never be terminalized, or
- when `from_name` really *is* `hub`, routes the reply into the **wrong channel with no error at all**.

## Two triggers, not one

#1185 documented trigger 1. This PR adds trigger 2, which needs no restart:

1. the MCP/node process restarted and the map is empty (#1185)
2. **the session learned about the task before its SSE push arrived.** `f015d9d6` is this one — the push landed ~15 min late, and retrying the *same* `task_id` immediately after it landed succeeded, because only then had the map been written.

## 🔴 The reported hypothesis does not survive measurement

The report proposed that *"reply validation depends on delivery binding, so a legitimate reply inside the latency window is refused."* The correlation with delivery timing is real, but the mechanism is not: **nothing on the reply path reads delivery or SSE state.**

`server/src/reply-target-derivation.test.ts` separates the two variables that were conflated, using a `sessions` row with `node_id NULL` (the shape of an MCP-mounted claude-code session) and an admin-originated task (`from_node_id NULL`):

| task state | `alias` argument | result |
|---|---|---|
| **not delivered** (`created`, no subscriber) | omitted | `ok: true` |
| delivered + live SSE subscriber | omitted | `ok: true` |
| delivered | explicit, ≠ origin | `reply_target_mismatch` |

Delivery state does not affect the outcome. The trigger is purely **the alias the caller sends** — which is exactly why this looked like a hub bug from outside.

That distinction matters for routing the work: a fix aimed at hub-side reply validation would have changed code that is behaving correctly.

## The fix: stop guessing

When the map misses, omit `alias` and let the hub derive the target from `in_reply_to` — `server/src/tools.ts` has supported that since #1085. The hub holds the authoritative fact; node memory does not. The map-hit path and the no-`task_id` path are deliberately unchanged.

The decision is extracted into `agent-network/src/reply-originator.ts` because `node-server.ts` exports nothing and cannot be unit-tested as-is.

## Verification

- **Witnessed-red**: mutating the new miss-branch back to `|| "hub"` turns **4 of 6** unit tests red. The 2 that stay green are the map-hit and no-`task_id` cases — unchanged by design.
- `bun test` on both new files: **9 pass / 0 fail**.
- `tsc --noEmit` in `agent-network`: exit **0**, 0 errors — matched against an `origin/main` baseline worktree, also exit 0.
  🔴 An earlier run of this check was worthless and looked clean: `agent-network/node_modules` was not linked, so `npx tsc` fetched a stub that printed *"This is not the tsc command you are looking for"* and compiled nothing. The zero error count came from having no compiler output at all. Re-run with the real compiler, it caught a genuine syntax break in my own import placement — which the passing tests had not, because neither test imports `node-server.ts`.
- Test-suite registration gate: `--selftest` 10/10, real run exit 0, `suites=226 registered=153 orphans=60 baseline=60 **new=0**` — the two new suites are registered, not orphans.
- Ran against a throwaway `COMMHUB_DB`; the product's own test-default-prod guard was left intact (it fired first and was obeyed, not worked around). **No production DB was touched.**

## Not fixed here

The ~15-minute delivery latency itself (symptom ①: `status=delivered` set while the SSE push had not reached the session). That is a separate defect and this PR does not address it. What this PR does guarantee is the acceptance criterion asked for: **a reply issued inside the latency window now succeeds instead of being refused with a misleading `mismatch`.**

## Dedup

- By content: `gh issue list --search "taskOriginators"` / `reply_target_mismatch` ⇒ **#1185**, same root cause and same file:line — commenting there rather than opening a duplicate.
- By changed files: scanned open PRs for `agent-network/src/node-server.ts` and `server/src/` ⇒ zero overlap.
