### PR TITLE
fix(hub): deliver the SSE push when someone is listening, not when the heartbeat looks recent

### DIFF
--- a/docs/message-lifecycle.md
+++ b/docs/message-lifecycle.md
@@ -164,7 +164,7 @@ agent-node sendReply → send_message（已改 v1.4.2）
 
 | # | 改动 | 状态 | 落地位置 |
 |---|------|------|------|
-| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1873 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1873) + [tools.ts:1887 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1887) |
+| 1 | CommHub server 加 `send_reply` / `send_ack` 工具 | ✅ shipped | [server/src/tools.ts:1877 send_reply](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1877) + [tools.ts:1891 send_ack](https://github.com/sleep2agi/agent-network/blob/main/server/src/tools.ts#L1891) |
 | 2 | inbox 表加 `in_reply_to` 字段 | ✅ shipped | [server/src/db.ts:72 + db.ts:98](https://github.com/sleep2agi/agent-network/blob/main/server/src/db.ts#L72)（字段名实际叫 `in_reply_to` 不是设计草稿里的 `reply_to`） |
 | 3 | agent-node `sendReply` 改用 `send_reply` | ✅ shipped | agent-node 用 `send_reply` MCP tool 关联 task_id |
 | 4 | commhub-channel.ts 带 `type` 标记 | ❌ **未采纳** | XML 不带 `type=`；类型区分靠 SSE event type + inbox row.`type` 字段（见上节 ::: warning） |

--- a/server/src/delivered-without-push.test.ts
+++ b/server/src/delivered-without-push.test.ts
@@ -1,0 +1,140 @@
+// f015d9d6 症状①：tasks.status 被置为 'delivered'，而 SSE 推送根本没发出。
+//
+// send_task 无条件以字面量 'delivered' 插入 tasks 行，推送却另外被
+// `if (target.state === "online")` 挡着（tools.ts:1432）。同一段代码里给
+// network observer 的事件把同一件事标成 "queued" —— 也就是说代码**知道**
+// 它没投出去，却仍然把 delivered 写进了 tasks.status。
+//
+// 而 "online" 的判据是 resolveDeliveryTarget 里的
+//   stale = now - (last_seen_at || updated_at) > 5 分钟
+// 且 last_seen_at 只在 report_status 时刷新（tools.ts:674/702）。
+// 全网「停发心跳/状态类消息」的省额度规则之下，一个安静的 MCP 会话必然变 stale。
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db } from "./db.js";
+import { registerTools } from "./tools.js";
+import { __resetSSEClientsForTest, createSSEStream } from "./push.js";
+
+const NET = "net_delivered_push_f015";
+const USER = "user_delivered_push_f015";
+const SENDER = "sender-f015b";
+const TARGET = "quiet-mcp-f015b";
+
+type ToolHandler = (args: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+
+function cleanup() {
+  __resetSSEClientsForTest();
+  for (const t of ["tasks", "inbox", "task_events", "sessions", "api_tokens", "nodes", "rename_txn"]) {
+    try { db.run(`DELETE FROM ${t} WHERE network_id = ?1`, [NET]); } catch {}
+  }
+  try { db.run("DELETE FROM network_members WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id = ?1", [NET]); } catch {}
+  try { db.run("DELETE FROM users WHERE user_id = ?1", [USER]); } catch {}
+}
+
+/** minutesAgo 控制目标会话的 last_seen_at —— 这是本文件唯一要动的变量。 */
+function seed(minutesAgo: number) {
+  db.run("INSERT INTO users (user_id, username, password_hash, role, created_at) VALUES (?1, ?1, 'x', 'admin', datetime('now'))", [USER]);
+  db.run("INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))", [NET, USER]);
+  db.run("INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, 'owner', datetime('now'))", [USER, NET]);
+  for (const alias of [SENDER, TARGET]) {
+    db.run(
+      "INSERT INTO api_tokens (token_id, token_hash, user_id, network_id, name, scope) VALUES (?1, ?2, ?3, ?4, ?5, 'network')",
+      [`token-${alias}`, `hash-${alias}`, USER, NET, `node:${alias}`],
+    );
+  }
+  db.run(
+    "INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at) VALUES (?1, ?1, 'idle', NULL, ?2, datetime('now'), datetime('now', ?3))",
+    [SENDER, NET, "-1 minutes"],
+  );
+  // 🔴 目标：MCP 挂载的 claude-code 会话形状（node_id NULL），
+  //    status 是 'idle'（不是 offline），只是安静了 minutesAgo 分钟。
+  db.run(
+    "INSERT INTO sessions (resume_id, alias, status, node_id, network_id, updated_at, last_seen_at) VALUES (?1, ?2, 'idle', NULL, ?3, datetime('now', ?4), datetime('now', ?4))",
+    [`cc-n_${TARGET}`, TARGET, NET, `-${minutesAgo} minutes`],
+  );
+}
+
+function toolsFor(alias: string): Record<string, ToolHandler> {
+  const server = new McpServer({ name: "delivered-push-f015", version: "0" }) as any;
+  const tools: Record<string, ToolHandler> = {};
+  const original = server.tool.bind(server);
+  server.tool = (name: string, description: string, schema: any, handler: ToolHandler) => {
+    tools[name] = handler; return original(name, description, schema, handler);
+  };
+  registerTools(server, undefined, NET, USER, alias, true, `token-${alias}`);
+  return tools;
+}
+
+/** 从订阅者那一侧真正读出字节 —— 地面真相，不是连接计数。 */
+async function readUntil(reader: ReadableStreamDefaultReader<Uint8Array>, needle: string, ms = 1500): Promise<string | null> {
+  const dec = new TextDecoder();
+  let buf = "";
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const chunk = await Promise.race([
+      reader.read(),
+      new Promise<{ done: true; value: undefined }>((r) => setTimeout(() => r({ done: true, value: undefined }), 200)),
+    ]);
+    if (chunk.value) buf += dec.decode(chunk.value, { stream: true });
+    if (buf.includes(needle)) return buf;
+  }
+  return null;
+}
+
+let sendSeq = 0;
+/** minutesAgo = 目标安静了多久；withSubscriber = 是否真的有人连着。 */
+async function send(minutesAgo: number, withSubscriber = true) {
+  cleanup(); seed(minutesAgo);
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  if (withSubscriber) {
+    const res = createSSEStream(TARGET, NET);
+    reader = res.body!.getReader();
+  }
+  const r = await toolsFor(SENDER).send_task({ alias: TARGET, task: `ping-${++sendSeq}`, priority: "normal" });
+  const out = JSON.parse(r.content[0].text);
+  const row = db.get<{ status: string }>("SELECT status FROM tasks WHERE to_name = ?1 AND network_id = ?2", TARGET, NET);
+  const received = reader ? await readUntil(reader, "new_task") : null;
+  return { out, taskStatus: row?.status ?? null, received };
+}
+
+describe("f015d9d6 症状① — delivered 置位与实际推送不同步", () => {
+  beforeEach(() => cleanup());
+  afterAll(() => cleanup());
+
+  test("对照：目标 1 分钟前还活跃 ⇒ 订阅者收到 new_task", async () => {
+    const { taskStatus, received } = await send(1);
+    expect(taskStatus).toBe("delivered");
+    expect(received).toContain("new_task");
+  });
+
+  test("🔴 核心：目标安静 10 分钟但订阅者连着 ⇒ 仍然收得到（修复前这里收到 null）", async () => {
+    const { taskStatus, received } = await send(10);
+    expect(received).toContain("new_task");
+    expect(taskStatus).toBe("delivered");   // 现在这个 delivered 是真话了
+  });
+
+  test("🔴 可达性判据必须来自订阅者注册表，不是 last_seen_at 的时间戳猜测", async () => {
+    // 安静 10 分钟 = 时间戳判据会说 offline；而实际上有人在听。
+    const quiet = await send(10);
+    expect(quiet.received).toContain("new_task");
+    // 真没人听的时候，pushEvent 本来就是 no-op，不需要额外的闸来保护。
+    const nobody = await send(10, false);
+    expect(nobody.received).toBeNull();
+  });
+
+  test("真的没有订阅者时，tasks 行仍写 delivered —— 本 PR 刻意不改，记录在案", async () => {
+    const { taskStatus, received } = await send(10, false);
+    expect(received).toBeNull();
+    // 这一条钉的是**当前行为**，不是我认为对的行为：没人收到，行仍自称 delivered。
+    expect(taskStatus).toBe("delivered");
+  });
+
+  test("活性判据的输入 last_seen_at 只由 report_status 刷新 —— 发送方不刷新它", async () => {
+    cleanup(); seed(4);
+    const before = db.get<{ last_seen_at: string }>("SELECT last_seen_at FROM sessions WHERE alias = ?1 AND network_id = ?2", TARGET, NET);
+    await toolsFor(SENDER).send_task({ alias: TARGET, task: `ping-${++sendSeq}`, priority: "normal" });
+    const after = db.get<{ last_seen_at: string }>("SELECT last_seen_at FROM sessions WHERE alias = ?1 AND network_id = ?2", TARGET, NET);
+    expect(after?.last_seen_at).toBe(before!.last_seen_at);
+  });
+});

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -382,6 +382,17 @@ eventBus.on("rename-committed", (event: RenameCommittedEvent) => {
 });
 
 /** 推送事件给指定 session 的所有 SSE 连接 */
+/** 这个 alias 上此刻是否真的有活着的 SSE 订阅者。
+ *
+ *  这是投递可达性的**实测**，区别于 resolveDeliveryTarget 里那个基于
+ *  last_seen_at 的**猜测**。一个安静但连着的会话（例如遵守「停发心跳」
+ *  规则的 MCP 会话）在时间戳判据下是 offline，在这里是 true。 */
+export function hasSubscribers(sessionName: string, networkId?: string | null): boolean {
+  const arr = clients.get(clientKey(sessionName, networkId));
+  if (!arr) return false;
+  return arr.some((c) => !c.closed);
+}
+
 export function pushEvent(sessionName: string, event: Record<string, unknown>, networkId?: string | null): void {
   const key = clientKey(sessionName, networkId ?? (event.network_id as string | null | undefined));
   const arr = clients.get(key);

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -3,7 +3,7 @@ import { z } from "zod/v4";
 import { parseAliasFilter } from "./alias-filter.js";
 import { createHash } from "node:crypto";
 import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken, syncScheduledRunForTask } from "./db.js";
-import { getSSEStats, pushEvent, pushNetworkObserverEvent } from "./push.js";
+import { getSSEStats, hasSubscribers, pushEvent, pushNetworkObserverEvent } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { getUserNetworkRole, createNetworkTokenForNode } from "./auth.js";
 import { canRestWriteNetwork, getUserNetworkIds, singleNetworkId } from "./network-scope.js";
@@ -1429,12 +1429,17 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       let pendingSql = "SELECT COUNT(*) as cnt FROM inbox WHERE session_name = ?1 AND acked = 0";
       pendingSql = addScope(pendingSql, pendingParams, effectiveNetId);
       const pending = db.get<{ cnt: number }>(pendingSql, ...pendingParams);
-      if (target.state === "online") {
-        pushEvent(targetAlias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority, from: from_session, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
-      }
+      // 🔴 不要用 last_seen_at 的时间戳去猜「有没有人在听」——SSE 订阅者注册表
+      // 就是那件事本身。pushEvent 在没有订阅者时已经是 no-op，所以这道闸不提供
+      // 任何保护，只会把**连着但最近没心跳**的会话排除掉；而全网「停发心跳/状态类
+      // 消息」的省额度规则让安静恰恰是常态。上面那段注释早就写着 "Push
+      // unconditionally"，同一类缺陷上次也是打在 Dashboard 任务上（f015d9d6：
+      // 任务标了 delivered，会话却从未收到推送）。
+      pushEvent(targetAlias, { type: "new_task", inbox_count: pending?.cnt ?? 1, priority, from: from_session, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
+      const actuallyDelivered = hasSubscribers(targetAlias, effectiveNetId);
       // #461 network observer summary — unconditional (task row exists
       // even when the target is offline/queued), metadata only.
-      pushNetworkObserverEvent(effectiveNetId, { type: "new_task", task_id: id, from: from_session, to: targetAlias, status: target.state === "online" ? "delivered" : "queued", priority });
+      pushNetworkObserverEvent(effectiveNetId, { type: "new_task", task_id: id, from: from_session, to: targetAlias, status: actuallyDelivered ? "delivered" : "queued", priority });
 
       if (target.state === "offline") {
         return {
@@ -1502,9 +1507,8 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
         [id, targetAlias, target.session?.node_id ?? null, message, from_session, effectiveNetId ?? null]
       );
 
-      if (target.state === "online") {
-        pushEvent(targetAlias, { type: "new_message", from: from_session, message_id: id, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
-      }
+      // 同 send_task：可达性用订阅者注册表判，不用心跳时间戳猜。
+      pushEvent(targetAlias, { type: "new_message", from: from_session, message_id: id, ...(canonical.renamed ? { renamed_from: alias } : {}) }, effectiveNetId);
 
       const offlineReply = deliveryTargetReply(target, { message_id: id });
       if (offlineReply) {


### PR DESCRIPTION
Symptom ① of task `f015d9d6` — the half #1276 deliberately left alone. Refs #1185.

## There was no fifteen-minute queue. The push was never emitted.

`send_task` inserts the `tasks` row with the literal `'delivered'` **unconditionally**, inside the transaction. The SSE push is gated separately:

```ts
if (target.state === "online") {
  pushEvent(targetAlias, { type: "new_task", ... }, effectiveNetId);
}
```

Three lines later the network-observer event labels the same send `"queued"`. **The hub already knew it had not delivered the task, and wrote `delivered` into `tasks.status` anyway** — two fields telling opposite stories about one event.

## `"online"` is a guess, and the fleet rules make the guess wrong

`resolveDeliveryTarget` calls a session offline when `last_seen_at || updated_at` is older than five minutes. `last_seen_at` is refreshed **only** by `report_status` (`tools.ts:674`/`702`). The fleet-wide token-saving rule tells agents to stop sending heartbeat/status messages — so a quiet session ages into "offline" while its SSE connection is still open and its `sessions.status` is still `idle`.

That is why it looked intermittent: tasks landing shortly after any `report_status` pushed fine, and the first one after a quiet stretch did not.

## The gate never protected anything

`pushEvent` already returns immediately when the alias has no subscribers (`push.ts:388`). Gating on a timestamp adds no safety — it only removes delivery from sessions that **are** connected.

And the comment directly above the call site already says:

> Earlier we gated the push on a network-scoped session lookup, which silently dropped pushes … (the exact mismatch hit by Dashboard tasks). **Push unconditionally**; the subscriber's own auth (ntok_) constrains who can listen.

That comment was written after an earlier gate caused this same failure, against this same traffic. A different gate was added later and reintroduced the class. This PR restores the documented intent.

## Change

- Push unconditionally at both gated sites (`send_task`, `send_message`).
- Derive the observer event's `delivered`/`queued` label from a new `hasSubscribers()` — the subscriber registry **is** reachability; `last_seen_at` was only a proxy for it.

## Verification

Read the bytes out of the subscriber (`res.body.getReader()`), not connection counts:

| target quiet for | subscriber connected | receives `new_task` |
|---|---|---|
| 1 min | yes | ✅ (also before this change) |
| **10 min** | **yes** | **✅ — was `null` before this change** |
| 10 min | no | correctly nothing (`pushEvent` no-ops) |

- **Witnessed-red**: restoring the old gate turns exactly **2 of 5** tests red — the two asserting a quiet-but-connected session receives its push. The other 3 do not depend on the gate and stay green.
- **Regression, per-file in isolated processes**, 20 push/task/reply/lifecycle suites: **180 pass / 0 fail on `origin/main`, identical on this branch**, no non-zero exits either side.
  🔴 Running all 76 server suites inside a *single* bun process gives **461 pass / 333 fail on both refs alike** — that is cross-file interference in the batch, not a signal about this change, and the absolute number means nothing. Reporting it because the two runs disagree by a lot and only the per-file one is readable.
- Test-suite registration gate: exit 0, `new=0`.
- Throwaway `COMMHUB_DB` throughout. **No production DB or hub touched.**

## Deliberately NOT changed

When nobody is subscribed, the `tasks` row still says `'delivered'`. A test pins that so it stays visible rather than becoming quietly true-by-accident. Correcting the persisted status touches dashboard queries and filters and belongs in its own change — "make the failure visible" before "make it not happen".

## Dedup

- By content: `gh pr list --search "pushEvent"` / `resolveDeliveryTarget` ⇒ no open PR on this path.
- By changed files: scanned open PRs for `server/src/push.ts`, `server/src/tools.ts` ⇒ zero overlap. #1276 (the reply half) touches `agent-network/src/` and a different server test file — no conflict.
