### PR TITLE
fix(hub): list_host_supervisors 的 online 恒为 false（naive UTC 串按本地时区解析）

### DIFF
--- a/server/src/db-timestamp.test.ts
+++ b/server/src/db-timestamp.test.ts
@@ -30,9 +30,9 @@ describe("parseDbTimestampMs", () => {
     expect(parseDbTimestampMs("2026-08-27T19:23:54+08:00")).toBe(EXPECTED);
   });
 
-  it("an online window of 60s holds for a heartbeat written 1s ago", () => {
+  it("an online window of 5min holds for a heartbeat written 1s ago", () => {
     const now = Date.now();
     const iso = new Date(now - 1000).toISOString().slice(0, 19).replace("T", " ");
-    expect(now - parseDbTimestampMs(iso)).toBeLessThanOrEqual(60_000);
+    expect(now - parseDbTimestampMs(iso)).toBeLessThanOrEqual(5 * 60_000);
   });
 });

--- a/server/src/db-timestamp.test.ts
+++ b/server/src/db-timestamp.test.ts
@@ -5,9 +5,10 @@ const NAIVE = "2026-08-27 11:23:54";
 const EXPECTED = Date.UTC(2026, 7, 27, 11, 23, 54);
 
 describe("parseDbTimestampMs", () => {
-  // ⚠ 这条在 `bun test` 下**没有分辨力**：bun test 进程的解析时区固定为 UTC
-  // （实测 Intl…resolvedOptions().timeZone === "UTC"，即便系统是 Asia/Shanghai），
-  // 裸 Date.parse 在那里恰好正确。真正的门是下面那条子进程断言。
+  // ⚠ 这条在 **TZ=UTC 的环境**下没有分辨力：裸 Date.parse 在 UTC 下恰好正确。
+  // CI runner 与容器默认就是 UTC（本仓 Docker 套件亦然），所以缺陷在常规跑法里
+  // 恒绿。（更正：Bun 是尊重 TZ 的，不存在"bun test 固定 UTC"——通信评审牛 #1279
+  // 独审③ 独立复跑证伪了我最初的说法。）真正稳定见红的门是下面那条强制子进程。
   it("treats a naive SQLite timestamp as UTC", () => {
     expect(parseDbTimestampMs(NAIVE)).toBe(EXPECTED);
   });

--- a/server/src/db-timestamp.test.ts
+++ b/server/src/db-timestamp.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { parseDbTimestampMs } from "./db-timestamp.js";
+
+const NAIVE = "2026-08-27 11:23:54";
+const EXPECTED = Date.UTC(2026, 7, 27, 11, 23, 54);
+
+describe("parseDbTimestampMs", () => {
+  // ⚠ 这条在 `bun test` 下**没有分辨力**：bun test 进程的解析时区固定为 UTC
+  // （实测 Intl…resolvedOptions().timeZone === "UTC"，即便系统是 Asia/Shanghai），
+  // 裸 Date.parse 在那里恰好正确。真正的门是下面那条子进程断言。
+  it("treats a naive SQLite timestamp as UTC", () => {
+    expect(parseDbTimestampMs(NAIVE)).toBe(EXPECTED);
+  });
+
+  // 分辨力关键：宿主是 UTC 时,裸 Date.parse 与正确写法结果相同,断言恒绿。
+  // 强制子进程 TZ=Asia/Shanghai,让缺陷在任何 CI 时区下都显形。
+  it("is unaffected by a non-UTC host timezone (child process TZ=Asia/Shanghai)", () => {
+    const r = Bun.spawnSync({
+      cmd: ["bun", "-e",
+        `const {parseDbTimestampMs} = await import("${import.meta.dir}/db-timestamp.ts");` +
+        `console.log(parseDbTimestampMs("${NAIVE}"));`],
+      env: { ...process.env, TZ: "Asia/Shanghai" },
+    });
+    expect(Number(r.stdout.toString().trim())).toBe(EXPECTED);
+  });
+
+  it("keeps explicit-offset timestamps intact", () => {
+    expect(parseDbTimestampMs("2026-08-27T11:23:54Z")).toBe(EXPECTED);
+    expect(parseDbTimestampMs("2026-08-27T19:23:54+08:00")).toBe(EXPECTED);
+  });
+
+  it("an online window of 60s holds for a heartbeat written 1s ago", () => {
+    const now = Date.now();
+    const iso = new Date(now - 1000).toISOString().slice(0, 19).replace("T", " ");
+    expect(now - parseDbTimestampMs(iso)).toBeLessThanOrEqual(60_000);
+  });
+});

--- a/server/src/db-timestamp.ts
+++ b/server/src/db-timestamp.ts
@@ -1,0 +1,15 @@
+/**
+ * SQLite 里的时间戳列（sessions.last_seen_at、tasks.created_at 等）存的是
+ * **无时区标记的 UTC 串**（`YYYY-MM-DD HH:MM:SS`，由 SQLite `datetime('now')` 写入）。
+ *
+ * 裸 `Date.parse("2026-08-27 11:23:54")` 会按**宿主机本地时区**解释这个串。
+ * 生产机 TZ=CST+0800 时，它比真实 UTC 时刻早 8 小时——所以 `now - parsed`
+ * 恒为 +480 分钟，任何「最近 N 秒内算在线」的判据都会恒判离线。
+ * 在 TZ=UTC 的机器上两种写法结果相同，缺陷不会显形。
+ */
+export function parseDbTimestampMs(value: string): number {
+  const s = String(value).trim();
+  // 已带时区标记（ISO 的 Z / ±HH:MM）就原样交给 Date
+  if (/[Zz]$|[+-]\d{2}:?\d{2}$/.test(s)) return Date.parse(s);
+  return Date.parse(s.replace(" ", "T") + "Z");
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { parseDbTimestampMs } from "./db-timestamp.js";
 import { resolvePort } from "./resolve-port.js";
 import { normalizeSessionRuntime } from "./runtime-label.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
@@ -3026,7 +3027,7 @@ return Bun.serve({
           let lastSeenAt: string | null = null;
           if (r.session_last_seen) {
             lastSeenAt = r.session_last_seen;
-            const t = Date.parse(r.session_last_seen);
+            const t = parseDbTimestampMs(r.session_last_seen);
             if (!isNaN(t)) online = (nowMs - t) <= ONLINE_MS;
           }
           let runtimes: string[] = [];

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3009,7 +3009,10 @@ return Bun.serve({
       `, effectiveNetId);
 
       const nowMs = Date.now();
-      const ONLINE_MS = 60_000;
+      // 心跳周期是 3 分钟（agent-node/src/cli.ts 的 report_status 定时器），
+      // 窗口必须大于它，否则每次心跳后的 60s~180s 之间必然抖成 offline
+      // （通信评审牛 #1279 独审④）。取 5min，与仓内既有 stale 口径一致。
+      const ONLINE_MS = 5 * 60_000;
       const daemons = sqlRows
         .map(r => {
           let snapRole: string | null = null;

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { parseDbTimestampMs } from "./db-timestamp.js";
 import { z } from "zod/v4";
 import { parseAliasFilter } from "./alias-filter.js";
 import { createHash } from "node:crypto";
@@ -2828,7 +2829,7 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           let lastSeenAt: string | null = null;
           if (r.session_last_seen) {
             lastSeenAt = r.session_last_seen;
-            const t = Date.parse(r.session_last_seen);
+            const t = parseDbTimestampMs(r.session_last_seen);
             if (!isNaN(t)) online = (nowMs - t) <= ONLINE_MS;
           }
           // Parse self-declare arrays (default to [] for pre-PR2 daemons)

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -2810,7 +2810,10 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       // schema-promoted columns runtimes_supported/allowed_secret_keys
       // are pre-extracted but role isn't a first-class column).
       const nowMs = Date.now();
-      const ONLINE_MS = 60_000;
+      // 心跳周期是 3 分钟（agent-node/src/cli.ts 的 report_status 定时器），
+      // 窗口必须大于它，否则每次心跳后的 60s~180s 之间必然抖成 offline
+      // （通信评审牛 #1279 独审④）。取 5min，与仓内既有 stale 口径一致。
+      const ONLINE_MS = 5 * 60_000;
       const daemons = rows
         .map(r => {
           let snapRole: string | null = null;


### PR DESCRIPTION
## 症状（生产实测，2026-08-27）
两台刚铺好的 daemon（daemon-relay / daemon-vanisn）心跳都在 1 分钟内、`/api/status` 显示 `idle`，但 `list_host_supervisors` 一律返回 `online: false`。Dashboard 创建向导第一步（RFC-026 P2，dash#36 刚合）按 online 门控可选服务器 ⇒ **「选服务器创建节点」整条功能不可用**。

## 根因
`sessions.last_seen_at` 是 SQLite `datetime('now')` 写入的**无时区 UTC 串**。两处调用点用裸 `Date.parse` 解析：
- `server/src/tools.ts:2832`（MCP）
- `server/src/server.ts:3030`（REST）

裸解析按**宿主本地时区**解释该串。生产机 TZ=CST+0800 → `now - parsed` 恒 ≈ **+483 分钟**，而 `ONLINE_MS = 60_000` ⇒ online 恒 false。

同文件 `tools.ts:399` 早就有正确写法；本次抽成 `parseDbTimestampMs()` 统一两处。

## 🔴 为什么它能活到今天（也是本 PR 测试设计的理由）
`bun test` 进程的解析时区**固定为 UTC**（实测 `Intl.DateTimeFormat().resolvedOptions().timeZone === "UTC"`，即便系统是 Asia/Shanghai）。所以裸 `Date.parse` 在单测里恰好正确 —— **任何常规单测对这个缺陷零分辨力**。

因此测试里唯一有效的门是**强制子进程 `TZ=Asia/Shanghai`** 那条。

## 验证
- 见绿 4/4；**见红**：把 helper 变异回 `Date.parse(s)` → 恰好子进程 TZ 那条变红（1 fail），其余 3 条不受影响 —— 分辨力落在预期的断言上
- 生产侧实测数据：naive 串 `2026-08-27 11:23:54`，bun 按本地解析得 `03:23:54Z`（差 483 分钟），按 UTC 解析差 1 分钟
- hub 进程环境无 TZ 变量 ⇒ 取系统 CST，与复现条件一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)