### PR TITLE
test(daemon): 全链路生命周期 e2e —— 补上 rfc024 显式留下的那一格

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -97,6 +97,7 @@ on:
       - 'tests/test224-grok-preview-security/**'
       - 'tests/test597-dashboard-slash-namespace/**'
       - 'tests/test679-task-trace/**'
+      - 'tests/qa-daemon-lifecycle-e2e/**'
       - 'tests/lib/**'
       - 'docs-site/**'
       - 'docs/doc-source-pins-baseline.txt'
@@ -256,6 +257,7 @@ on:
       - 'tests/test224-grok-preview-security/**'
       - 'tests/test597-dashboard-slash-namespace/**'
       - 'tests/test679-task-trace/**'
+      - 'tests/qa-daemon-lifecycle-e2e/**'
       - 'tests/lib/**'
       - 'docs-site/**'
       - 'docs/doc-source-pins-baseline.txt'
@@ -489,6 +491,27 @@ jobs:
           mkdir -p "$RUNNER_TEMP/suite-artifacts"
           docker run --rm anet-test679-task-trace \
             2>&1 | tee "$RUNNER_TEMP/suite-artifacts/test679.log"
+
+      # daemon full-chain lifecycle. Sits here, not in qa.sh's L1_TESTS:
+      # the suite RUNS in 11s but COLD-BUILDS in ~244s (three bun installs
+      # + obfuscated build + two npm packs), and qa.sh builds L1 serially
+      # inside a 5-minute job that already spends 141-148s. Measuring only
+      # the run time is measuring the wrong half.
+      # Placed before test224 so the security suite remains last.
+      - name: Build qa-daemon-lifecycle-e2e
+        run: |
+          docker build \
+            --build-arg SOURCE_COMMIT="$GITHUB_SHA" \
+            --build-arg RUNSH_BLOB="$(git rev-parse HEAD:tests/qa-daemon-lifecycle-e2e/run.sh)" \
+            -t anet-qa-daemon-lifecycle-e2e \
+            -f tests/qa-daemon-lifecycle-e2e/Dockerfile .
+
+      - name: Run qa-daemon-lifecycle-e2e
+        run: |
+          set -o pipefail
+          mkdir -p "$RUNNER_TEMP/suite-artifacts"
+          docker run --rm anet-qa-daemon-lifecycle-e2e \
+            2>&1 | tee "$RUNNER_TEMP/suite-artifacts/qa-daemon-lifecycle-e2e.log"
 
       - name: Build test224-grok-preview-security
         run: |

--- a/docs/tests/report-qa-daemon-lifecycle-e2e.txt
+++ b/docs/tests/report-qa-daemon-lifecycle-e2e.txt
@@ -96,11 +96,12 @@ REFUSING: /.dockerenv absent — this suite boots a hub and kills pids; run it i
   run3: PASS=22  FAIL=0  TODO=1   (red gates witnessed: 3)
   run4: PASS=22  FAIL=0  TODO=1   (red gates witnessed: 3)
 run 耗时       11 s
-冷构建耗时    244 s  (三次 bun install + 混淆构建 + 两次 npm pack)
+冷构建耗时    206 s  (三次 bun install + 混淆构建 + 两次 npm pack;bun 已钉 1.3.14)
 
 归属决策:放 qa.yml 的 recovered-suites job(12 分钟预算),不放 qa.sh 的 L1_TESTS。
 理由是量出来的,不是估的:qa.sh 的 L1 build 是**串行**的,job 预算 5 分钟且
 现有已用掉 141-148s。只看 11s 的 run 时间会把它错放进快层 —— 那是量了错的那一半。
+(初测 244s 时 bun 装的是「构建时最新」;钉到 1.3.14 后 206s。结论不变,数字以钉版本后为准。)
 
 ════ 5. 注册门(前后计数,证明不是靠缩小范围变绿)════
 check-test-suite-registration.py
@@ -122,3 +123,13 @@ check-public-script-safety.py(本套件注释里含 pattern-kill 字面量,故�
    daemon 注册**之后**才上报的,存在真实 race(qa-rfc026 注释记录了同一 race)。
    先前写法读到空字符串,表现为「产品没设置 role」,实为判据取错字段 + 未等收敛。
 两条的共同点:红/绿都看起来完全正常,只有对照已跑通的同类套件才暴露。
+
+════ 7. 追加:check-bun-install-pin 的一颗真红(已修)════
+初版 Dockerfile 照抄了 tests/qa-anet-daemon-cmd 的 `curl -fsSL https://bun.sh/install | bash`。
+那是该棘轮门基线里的**存量**写法,照抄等于把它的债搬进一个新文件 —— 而门只对**新增**变红。
+修法沿用 tests/test679-task-trace/Dockerfile:钉 BUN_VERSION=1.3.14 + sha256sum -c 校验。
+跑那道门本身(不自造判据):
+  rc=0  scanned 255 tracked Dockerfile(s); 37 still install bun unpinned; baseline lists 37
+        no new unpinned bun installer.
+钉版本后重跑套件:PASS=22 FAIL=0 TODO=1(red gates witnessed: 3),容器内 `bun --version` = 1.3.14。
+教训:照抄一个能跑的现有文件,会连同它在棘轮基线里的存量一起抄过来,而这类门恰恰只罚新增者。

--- a/docs/tests/report-qa-daemon-lifecycle-e2e.txt
+++ b/docs/tests/report-qa-daemon-lifecycle-e2e.txt
@@ -1,0 +1,124 @@
+report: qa-daemon-lifecycle-e2e — daemon 全链路生命周期 e2e
+date:   2026-08-27
+by:     通信测试马 (独立执行)
+source_commit: 8c23e4bc02c675fab2a299990b516864af5531eb
+host:   iZrj93pr2rcf5r2y9uo1oyZ  disk: 71G avail, 85% used
+
+链条: anet daemon up → create_node → 子节点注册 → update_node_config → restart_node → stop_node
+      (start_node 留 TODO —— 工具尚未进 main,#1273 独审中)
+
+════ 1. 缺口依据(为什么不是重复覆盖)════
+现有套件对 origin/main 56b2a782 的覆盖:
+  qa-rfc026-create-node    create_node + 子节点注册           已覆盖
+  qa-rfc027-stop-delete    stop_node / restart_node / delete   已覆盖
+  qa-rfc024-config-apply   update_node_config —— 仅契约面
+
+qa-rfc024-config-apply/run.sh 源码注释原文:
+  "A real 'next think uses new value' check needs a vendor key + a live
+   agent-node consuming the SSE doorbell. That belongs in the longer-form QA."
+它只 mint 了 ntok、未起真节点 ⇒ hub 返回 node_not_found ⇒ 走 skip 分支。
+(该套件是诚实的:SKIP 单独计数,结尾明列哪些是 stub。缺口是有意留的,不是被藏的。)
+
+⇒ 未覆盖的不是任何单个工具,是它们之间在同一子节点上的状态交接。
+
+════ 2. CI 逐字命令 + 输出(正控)════
+$ docker build --build-arg SOURCE_COMMIT=$GITHUB_SHA \
+    --build-arg RUNSH_BLOB=$(git rev-parse HEAD:tests/qa-daemon-lifecycle-e2e/run.sh) \
+    -t anet-qa-daemon-lifecycle-e2e -f tests/qa-daemon-lifecycle-e2e/Dockerfile .
+$ docker run --rm anet-qa-daemon-lifecycle-e2e
+
+provenance: source_commit=8c23e4bc02c675fab2a299990b516864af5531eb run.sh blob=e45f1432dfc59fa3ce5a7a1c7e1a24fc5fbde2d0 (verified)
+
+=== 0. boot isolated hub :9251 (local server source, test DB) ===
+  ✓ hub /health 200
+  ✓ admin utok minted
+  ✓ network = net_b5c7d8efcd0f
+
+=== 0.A anet daemon up — one-shot init+start (NOT hand-written config) ===
+  ✓ daemon registered via `anet daemon up` (node_id=node_daemon_0d2177034b5a)
+  ✓ hub-side config_snapshot.role=host_supervisor (converged)
+
+=== A. create_node → child config on disk + child registers ===
+  ✓ RED-GATE child config.json absent before create_node — correctly red before the action
+  ✓ create_node dispatched (request_id=cr_793211a0-d863-4f14-82b7-682722ab4772)
+  ✓ child config.json written: .anet/nodes/dlife-child-a/config.json
+  ✓ child on-disk flags.maxTurns=7 (as created)
+  ✓ child registered with hub (node_id=node_793211a0-d863-4f14-82b7-682722ab4772)
+
+=== B. update_node_config → does the CHILD's real on-disk config change? ===
+  ✓ RED-GATE child flags.maxTurns=99 before update_node_config — correctly red before the action
+  ✓ hub accepted patch (apply_mode=hot update_id=cu_532ab7e6-8eaf-4c7e-b03b-29fde4a01b43)
+  ✓ CHILD on-disk flags.maxTurns 7 → 99 (config actually applied)
+  · note: config_revision=unset (informational — not all apply modes stamp it)
+
+=== C. restart_node → process really restarts AND config survives ===
+  · agent-node --alias dlife-child-a process count = 1
+  ✓ child process alive before restart (pid=176)
+  ✓ restart_node dispatched
+  ✓ process really restarted (pid 176 → 239)
+  ✓ config SURVIVED restart (maxTurns still 99)
+
+=== D. stop_node → hub terminal state + process really reaped ===
+  · pre-stop hub lifecycle_state = active (the value red-gate 3 judges)
+  ✓ RED-GATE hub lifecycle_state=stopped before stop_node — correctly red before the action
+  ✓ stop_node dispatched
+  ✓ hub-side TERMINAL state lifecycle_state=stopped
+  ✓ child process really reaped (pgrep finds nothing)
+  ✓ daemon survived the child stop
+
+=== E. start_node ===
+  ⊘ start_node re-start after stop — TODO: tool not in main yet (#1273 under independent review); add a stage here once merged
+
+=== Result ===
+  PASS=22  FAIL=0  TODO=1   (red gates witnessed: 3)
+RESULT: PASS
+
+════ 3. 反控(证明判据有分辨力,不是恒真)════
+── A. RUNSH_BLOB 传一个格式合法但错误的值 → 必须红
+$ docker build --build-arg RUNSH_BLOB=0000...0000 ... && docker run --rm
+FAIL: run.sh in the image is not the one SOURCE_COMMIT=8c23e4bc02c675fab2a299990b516864af5531eb claims
+      expected blob 0000000000000000000000000000000000000000, actual e45f1432dfc59fa3ce5a7a1c7e1a24fc5fbde2d0
+   rc=1 ✓
+
+── B. 在宿主机(非容器)直接跑 run.sh → 必须拒跑
+$ bash tests/qa-daemon-lifecycle-e2e/run.sh
+REFUSING: /.dockerenv absent — this suite boots a hub and kills pids; run it in its container.
+   rc=2 ✓
+
+── C. 套件内建 3 道红门(在断言必须失败的时刻运行)
+  ✓ RED-GATE child config.json absent before create_node — correctly red before the action
+  ✓ RED-GATE child flags.maxTurns=99 before update_node_config — correctly red before the action
+  ✓ RED-GATE hub lifecycle_state=stopped before stop_node — correctly red before the action
+   结尾强制 RED>=3:删掉任一红门 → 套件自身变红,而非静默缩小它证明的范围
+
+════ 4. 稳定性与耗时(决定 CI 归属)════
+连续两次独立运行,逐字一致:
+  run3: PASS=22  FAIL=0  TODO=1   (red gates witnessed: 3)
+  run4: PASS=22  FAIL=0  TODO=1   (red gates witnessed: 3)
+run 耗时       11 s
+冷构建耗时    244 s  (三次 bun install + 混淆构建 + 两次 npm pack)
+
+归属决策:放 qa.yml 的 recovered-suites job(12 分钟预算),不放 qa.sh 的 L1_TESTS。
+理由是量出来的,不是估的:qa.sh 的 L1 build 是**串行**的,job 预算 5 分钟且
+现有已用掉 141-148s。只看 11s 的 run 时间会把它错放进快层 —— 那是量了错的那一半。
+
+════ 5. 注册门(前后计数,证明不是靠缩小范围变绿)════
+check-test-suite-registration.py
+  加之前: suites=227 registered=153 exempt=13 orphans=61 baseline=60 new=1   rc=1
+  加之后: suites=227 registered=154 exempt=13 orphans=60 baseline=60 new=0   rc=0
+  增减恰为本套件一项(registered +1 / orphans -1),分母 227 不变。
+check-l1-paths-sync.py
+  rc=0  checked 66 L1 suite(s) against 155 path pattern(s); every L1 suite has a matching trigger.
+check-public-script-safety.py(本套件注释里含 pattern-kill 字面量,故实测其取集)
+  rc=0  scanned 6 public script(s) —— 取集为 public/ 下 6 个脚本,本套件不在其中。
+  (跑门之前先 git add:git ls-files 看不见未跟踪文件,不 add 会绿得毫无意义。)
+
+════ 6. 过程中被修正的两个错误(留档,因为都会产生看起来正常的假结果)════
+① 进程判据一开始断的是 `anet node start <name>`(启动器),而真正长驻的是孙进程
+   `agent-node --alias <name>`(create-node-daemon.ts:420 spawn 启动器,启动器再拉起节点)。
+   启动器可以已经退出而节点仍在跑 ⇒ restart 的 pid 比对和 stop 的 reap 判据会全部
+   断在错的对象上。改为与 qa-rfc027 已验证的写法一致后才可信。
+② daemon 的 role 不在 `nodes[0].role`,而在 `nodes[0].config_snapshot.role`,且它是
+   daemon 注册**之后**才上报的,存在真实 race(qa-rfc026 注释记录了同一 race)。
+   先前写法读到空字符串,表现为「产品没设置 role」,实为判据取错字段 + 未等收敛。
+两条的共同点:红/绿都看起来完全正常,只有对照已跑通的同类套件才暴露。

--- a/tests/qa-daemon-lifecycle-e2e/Dockerfile
+++ b/tests/qa-daemon-lifecycle-e2e/Dockerfile
@@ -14,7 +14,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential python3 sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://bun.sh/install | bash
+# 🔴 钉死 Bun 输入。原来这里照抄了 qa-anet-daemon-cmd 的
+# `curl -fsSL https://bun.sh/install | bash` —— 那是 check-bun-install-pin
+# 基线里的存量写法,照抄等于把它的债一起搬进一个新文件,而那道棘轮门只对
+# **新增**变红。构建时装到什么算什么,同一个 commit 在不同时间会跑在不同字节上。
+# 版本与校验和沿用本仓既有做法(tests/test679-task-trace/Dockerfile)。
+ARG BUN_VERSION=1.3.14
+ARG BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
+RUN curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
+      "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" -o /tmp/bun.zip \
+ && echo "${BUN_LINUX_X64_SHA256}  /tmp/bun.zip" | sha256sum -c - \
+ && unzip -q /tmp/bun.zip -d /tmp/bunx \
+ && mkdir -p /root/.bun/bin \
+ && mv /tmp/bunx/bun-linux-x64/bun /root/.bun/bin/bun \
+ && chmod 0755 /root/.bun/bin/bun \
+ && rm -rf /tmp/bun.zip /tmp/bunx
 ENV PATH="/root/.bun/bin:${PATH}"
 
 WORKDIR /app

--- a/tests/qa-daemon-lifecycle-e2e/Dockerfile
+++ b/tests/qa-daemon-lifecycle-e2e/Dockerfile
@@ -1,0 +1,52 @@
+# Daemon full-chain lifecycle e2e — `anet daemon up` → create_node →
+# update_node_config → restart_node → stop_node, on ONE child within ONE
+# daemon lifetime. Fills the square qa-rfc024-config-apply explicitly
+# left open ("that belongs in the longer-form QA" — it takes the `skip`
+# branch because no live agent-node is running).
+#
+# Install pattern mirrors qa-anet-daemon-cmd: glibc base + bun +
+# build-essential + python3, LOCAL source installed globally via npm pack
+# so `anet` on PATH is the code under test, not a registry build.
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash curl ca-certificates jq unzip procps \
+    build-essential python3 sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /app
+
+COPY server /app/server
+COPY agent-node /app/agent-node
+COPY agent-network /app/agent-network
+
+RUN cd /app/server && bun install --silent
+RUN cd /app/agent-node && bun install --silent && bun run build
+RUN cd /app/agent-network && bun install --silent && bun run build
+
+RUN cd /app/agent-node && npm pack && npm install -g ./sleep2agi-agent-node-*.tgz
+RUN cd /app/agent-network && npm pack && npm install -g ./sleep2agi-agent-network-*.tgz
+
+# Fail the BUILD (not the run) if the binaries under test are missing.
+RUN anet --version && which anet && which agent-node
+
+# The test scripts go LAST on purpose: editing run.sh then rebuilds only
+# these layers (seconds) instead of invalidating three bun installs.
+COPY tests/lib /app/tests/lib
+COPY tests/qa-daemon-lifecycle-e2e/run.sh /app/tests/qa-daemon-lifecycle-e2e/run.sh
+RUN chmod +x /app/tests/qa-daemon-lifecycle-e2e/run.sh
+
+# Provenance. scripts/qa.sh reads these ARG names out of this file (it does
+# not derive them from the suite name), so they must be spelled exactly
+# `SOURCE_COMMIT` / `RUNSH_BLOB`. Without them the suite would run with no
+# binding between the image and the commit its report claims — and that
+# failure is silent: the output looks completely normal.
+ARG SOURCE_COMMIT
+ARG RUNSH_BLOB
+ENV DLIFE_SOURCE_COMMIT=$SOURCE_COMMIT
+ENV DLIFE_RUNSH_BLOB=$RUNSH_BLOB
+
+CMD ["/app/tests/qa-daemon-lifecycle-e2e/run.sh"]

--- a/tests/qa-daemon-lifecycle-e2e/README.md
+++ b/tests/qa-daemon-lifecycle-e2e/README.md
@@ -1,0 +1,85 @@
+# qa-daemon-lifecycle-e2e
+
+`anet daemon up` → `create_node` → child registers → `update_node_config`
+→ `restart_node` → `stop_node`, exercised as **one chain on one child
+within one daemon lifetime**.
+
+## Why this suite exists
+
+The individual tools are already covered. What was not covered is the
+**state handoff between them**:
+
+| suite | covers | on a daemon-created child? |
+|---|---|---|
+| `qa-rfc026-create-node` | `create_node` + child register | yes |
+| `qa-rfc027-stop-delete` | `stop_node` / `restart_node` / `delete_node` | yes |
+| `qa-rfc024-config-apply` | `update_node_config` — **contract surface only** | **no** |
+
+`qa-rfc024-config-apply` documents its own gap in the source:
+
+> A real "next think uses new value" check needs a vendor key + a live
+> agent-node consuming the SSE doorbell. **That belongs in the longer-form
+> QA.**
+
+It mints an `ntok_` but never starts a node, so the hub answers
+`node_not_found` and the stage takes its `skip` branch. (That suite is
+honest about it — `SKIP` is counted separately and the footer lists which
+scenarios are stubs. The hole was left deliberately, not hidden.)
+
+So the questions this suite answers, which nothing else did:
+
+1. Does `update_node_config` actually rewrite the **child's on-disk
+   `config.json`** — not just return an `update_id`?
+2. Does that value **survive `restart_node`**?
+3. Does `stop_node` reap **the same process** the earlier steps configured,
+   while the daemon itself stays up?
+
+It also drives `anet daemon up` — the one-shot path a first-time user
+actually types. `qa-rfc027` hand-writes the daemon's `config.json`;
+`qa-anet-daemon-cmd` drives `init` and `start` separately. Neither covers
+`up`.
+
+## Judgement rules
+
+- **Hub-side terminal state + the child's real on-disk config.** A tool
+  returning `ok:true` is a dispatch receipt, not an outcome.
+- **A startup banner is not readiness.** Nothing in this suite asserts on
+  stdout text; readiness is always a hub API read or a file read.
+- **Witnessed-red first.** Three red gates run at moments when the
+  assertion *must* fail:
+
+  | gate | asserted before | must be red because |
+  |---|---|---|
+  | 1 | `create_node` | the child config file does not exist yet |
+  | 2 | `update_node_config` | `maxTurns` is still 7, not 99 |
+  | 3 | `stop_node` | `lifecycle_state` is not yet `stopped` |
+
+  Each red gate calls **the same shell function** the later green
+  assertion calls — not a lookalike written twice. If a red gate passes,
+  that is a `FAIL`: an assertion with no discriminating power makes every
+  later green reading from it worthless.
+
+  The footer enforces `RED >= 3`, so deleting a red gate turns the suite
+  red instead of silently shrinking what it proves.
+
+- **No pattern kills.** `pgrep` resolves concrete pids, `/proc/<pid>/cmdline`
+  confirms the pid is ours, then that exact pid is killed. A pattern kill
+  has taken down a live hub before.
+- **Container-only.** The script refuses to run without `/.dockerenv`
+  (override: `ALLOW_NON_DOCKER=1`), because it boots a hub and kills pids.
+
+## Run
+
+```bash
+docker build -f tests/qa-daemon-lifecycle-e2e/Dockerfile -t anet-dlife .
+docker run --rm anet-dlife
+```
+
+Hub port `9251` and DB `/tmp/qa-daemon-lifecycle.db` are distinct from the
+neighbouring suites, so it can share a container with them.
+
+## Known gap
+
+`start_node` is a **TODO**, not an omission: the tool is not in `main`
+yet (#1273 under independent review). The chain stops at `stop_node`; add
+a stage at the end once it merges.

--- a/tests/qa-daemon-lifecycle-e2e/run.sh
+++ b/tests/qa-daemon-lifecycle-e2e/run.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# Daemon full-chain lifecycle e2e — `anet daemon up` → create_node →
+# child registers → update_node_config → restart_node → stop_node.
+#
+# WHY THIS SUITE EXISTS (gap analysis against what already ships):
+#   qa-rfc026-create-node   covers create_node + child register
+#   qa-rfc027-stop-delete   covers stop_node / restart_node / delete_node
+#   qa-rfc024-config-apply  covers update_node_config's CONTRACT surface
+#                           only — its live stage self-documents the hole:
+#                           "A real 'next think uses new value' check needs
+#                            a vendor key + a live agent-node consuming the
+#                            SSE doorbell. That belongs in the longer-form
+#                            QA." and it takes the `skip` branch because no
+#                            agent-node is running (node_not_found).
+#
+# So the uncovered square is NOT any single tool — it is the STATE HANDOFF
+# BETWEEN them on one daemon-created child within one daemon lifetime:
+#   · does update_node_config actually rewrite the CHILD's on-disk config?
+#   · does that survive restart_node?
+#   · does stop_node really reap the process the earlier steps configured?
+#
+# JUDGEMENT RULES (通信龙 2026-08-27):
+#   · assert hub-side TERMINAL state + the child's REAL on-disk config
+#   · a startup banner is NOT readiness — never assert on stdout text
+#   · witnessed-red first: every load-bearing assertion is proven to go
+#     RED at a moment when it must be red, BEFORE it is trusted green
+#
+# start_node is deliberately a TODO — the tool is not in main yet (#1273
+# under independent review). Chain stops at stop_node.
+
+set -uo pipefail
+
+# This suite boots a hub, forks real node processes and kills pids. It is
+# written for its own container and must REFUSE to run on a developer or
+# production host, where those actions are not safe.
+if [[ ! -f /.dockerenv && "${ALLOW_NON_DOCKER:-}" != "1" ]]; then
+  echo "REFUSING: /.dockerenv absent — this suite boots a hub and kills pids; run it in its container." >&2
+  exit 2
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# ── provenance ────────────────────────────────────────────────────────
+# Bind this run to the commit its report will claim. Format alone is not
+# enough: any 40 hex chars pass, and that SHA might not even contain the
+# file inside the image. So we also recompute the git blob hash of THIS
+# file — sha1("blob <len>\0" + bytes) — and compare. No git needed here.
+# Same shape as test798/test823; qa.sh supplies both build-args.
+SOURCE_COMMIT=${DLIFE_SOURCE_COMMIT:-}
+RUNSH_BLOB=${DLIFE_RUNSH_BLOB:-}
+if [[ ! "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "FAIL: DLIFE_SOURCE_COMMIT must be one full lowercase Git SHA (got '${SOURCE_COMMIT:-unset}')" >&2
+  echo "      build with: --build-arg SOURCE_COMMIT=\$(git rev-parse HEAD) --build-arg RUNSH_BLOB=\$(git rev-parse HEAD:tests/qa-daemon-lifecycle-e2e/run.sh)" >&2
+  exit 1
+fi
+if [[ ! "$RUNSH_BLOB" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "FAIL: DLIFE_RUNSH_BLOB missing/malformed — cannot bind SOURCE_COMMIT to the bytes under test" >&2
+  exit 1
+fi
+_self="$SCRIPT_DIR/run.sh"
+_actual=$( { printf 'blob %d\0' "$(wc -c < "$_self")"; cat "$_self"; } | sha1sum | cut -d' ' -f1 )
+if [[ "$_actual" != "$RUNSH_BLOB" ]]; then
+  echo "FAIL: run.sh in the image is not the one SOURCE_COMMIT=$SOURCE_COMMIT claims" >&2
+  echo "      expected blob $RUNSH_BLOB, actual $_actual" >&2
+  exit 1
+fi
+echo "provenance: source_commit=$SOURCE_COMMIT run.sh blob=$_actual (verified)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/safe-rm.sh"
+
+HUB_PORT=9251
+HUB_BASE="http://127.0.0.1:$HUB_PORT"
+HUB_DB=/tmp/qa-daemon-lifecycle.db
+ADMIN_USER="dlifeadmin"
+ADMIN_PW="dlife_TestPass_1234!"
+DAEMON_NAME="dlife-daemon"
+CHILD="dlife-child-a"
+WORK=/tmp/qa-daemon-lifecycle-work
+
+PASS=0; FAIL=0; SKIP=0; RED=0
+note() { printf "\n=== %s ===\n" "$*"; }
+ok()   { printf "  ✓ %s\n" "$*"; PASS=$((PASS+1)); }
+bad()  { printf "  ✗ %s\n" "$*"; FAIL=$((FAIL+1)); }
+todo() { printf "  ⊘ %s — TODO: %s\n" "$1" "$2"; SKIP=$((SKIP+1)); }
+
+# witnessed-red: run an assertion AT A MOMENT WHEN IT MUST FAIL.
+# If it passes there, the assertion has no discriminating power and every
+# later green reading from it is worthless — that is a FAIL, not a pass.
+expect_red() {
+  local what="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    bad "RED-GATE  $what — assertion passed when it MUST have failed (no discriminating power)"
+  else
+    printf "  ✓ RED-GATE %s — correctly red before the action\n" "$what"; PASS=$((PASS+1)); RED=$((RED+1))
+  fi
+}
+
+mcp_init_once() {
+  curl -sS -X POST "$HUB_BASE/mcp" -H "Authorization: Bearer $1" \
+    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+    -H 'MCP-Protocol-Version: 2025-03-26' \
+    -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"qa-dlife","version":"0"}}}' >/dev/null 2>&1 || true
+}
+mcp_call() {
+  local tok="$1" body="$2" resp inner
+  resp=$(curl -sS -X POST "$HUB_BASE/mcp" -H "Authorization: Bearer $tok" \
+    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+    -H 'MCP-Protocol-Version: 2025-03-26' -d "$body")
+  inner=$(echo "$resp" | grep -oP '(?<=data: ).+' | head -1 | jq -r '.result.content[0].text' 2>/dev/null)
+  if [[ -z "$inner" || "$inner" == "null" ]]; then
+    inner=$(echo "$resp" | jq -r '.result.content[0].text' 2>/dev/null)
+  fi
+  [[ -z "$inner" || "$inner" == "null" ]] && echo "$resp" || echo "$inner"
+}
+
+CHILD_CFG=""      # set after create; the file every config assertion reads
+
+# ---- the load-bearing predicates, defined ONCE so the red gate and the
+# ---- green assertion are provably the SAME criterion (not two lookalikes).
+child_cfg_exists()      { [[ -f "$CHILD_CFG" ]]; }
+child_flag_equals()     { [[ "$(jq -r ".flags.${1} // empty" "$CHILD_CFG" 2>/dev/null)" == "$2" ]]; }
+child_model_equals()    { [[ "$(jq -r '.model // empty' "$CHILD_CFG" 2>/dev/null)" == "$1" ]]; }
+hub_lifecycle_is()      { [[ "$(curl -sS "$HUB_BASE/api/nodes?node_id=$CHILD_NODE_ID" -H "Authorization: Bearer $UTOK" | jq -r '.nodes[0].lifecycle_state // empty')" == "$1" ]]; }
+# The long-lived process is the GRANDCHILD `agent-node --alias <name>`,
+# NOT the `anet node start <name>` launcher that spawns it (create-node-
+# daemon.ts:420 spawns the launcher; the launcher then execs the node).
+# The launcher can be gone while the node is very much alive, so asserting
+# on it would measure the wrong object. This is the same pattern
+# qa-rfc027 uses for its proven reap assertions — do not "simplify" it.
+child_pids()            { pgrep -af "agent-node.*--alias $CHILD" 2>/dev/null | grep -v grep | awk '{print $1}'; }
+child_proc_count()      { child_pids | wc -l; }
+child_proc_alive()      { [[ "$(child_proc_count)" -ge 1 ]]; }
+
+# NOTE: this suite contains NO `pkill -f` / `killall` anywhere (network
+# rule — a subagent's pattern kill took down a live hub once). We resolve
+# concrete pids with pgrep, re-read /proc/<pid>/cmdline to confirm the pid
+# is really ours, and only then kill that exact pid.
+kill_child_procs() {
+  local p
+  for p in $(child_pids); do
+    if tr '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null | grep -q -- "--alias $CHILD"; then
+      kill "$p" 2>/dev/null
+    fi
+  done
+}
+cleanup() {
+  [[ -n "${DAEMON_PID:-}" ]] && kill "$DAEMON_PID" 2>/dev/null
+  [[ -n "${HUB_PID:-}" ]] && kill "$HUB_PID" 2>/dev/null
+  kill_child_procs
+  return 0
+}
+trap cleanup EXIT
+
+# ── 0. hub ────────────────────────────────────────────────────────────
+note "0. boot isolated hub :$HUB_PORT (local server source, test DB)"
+safe_rm_rf "$WORK" 2>/dev/null || true
+rm -f "$HUB_DB" "${HUB_DB}-wal" "${HUB_DB}-shm" 2>/dev/null
+mkdir -p "$WORK"
+cd /app/server
+PORT="$HUB_PORT" HOST=127.0.0.1 NODE_ENV=test COMMHUB_DB="$HUB_DB" bun run src/index.ts >/tmp/hub-dlife.log 2>&1 &
+HUB_PID=$!
+for i in $(seq 1 60); do curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && break; sleep 0.5; done
+curl -fsS "$HUB_BASE/health" >/dev/null 2>&1 && ok "hub /health 200" || { bad "hub did not start"; tail -30 /tmp/hub-dlife.log; exit 1; }
+
+REG=$(curl -sS -X POST "$HUB_BASE/api/auth/register" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PW\",\"email\":\"dlife@test.local\"}")
+UTOK=$(echo "$REG" | jq -r .token)
+[[ "$UTOK" == utok_* ]] && ok "admin utok minted" || { bad "utok mint failed: $REG"; exit 1; }
+mcp_init_once "$UTOK"
+NET_ID=$(curl -sS "$HUB_BASE/api/auth/me" -H "Authorization: Bearer $UTOK" | jq -r '.networks[0].network_id')
+[[ -n "$NET_ID" && "$NET_ID" != null ]] && ok "network = $NET_ID" || { bad "no network"; exit 1; }
+
+# ── 0.A `anet daemon up` — the real user entrypoint ───────────────────
+# qa-rfc027 hand-writes the daemon config.json; qa-anet-daemon-cmd drives
+# init+start separately. Neither exercises the ONE-SHOT `up` path, which
+# is what a first-time user actually types.
+note "0.A anet daemon up — one-shot init+start (NOT hand-written config)"
+export HOME="$WORK"
+mkdir -p "$HOME/.anet"
+cat > "$HOME/.anet/config.json" <<EOF
+{"hub":"$HUB_BASE","token":"$UTOK","network_id":"$NET_ID"}
+EOF
+cd "$WORK"
+export ANET_BIN_ABS=$(realpath -e "$(which anet)")
+nohup anet daemon up "$DAEMON_NAME" >/tmp/daemon-dlife.log 2>&1 &
+DAEMON_PID=$!
+
+# readiness = hub says the node is there with role=host_supervisor.
+# The startup banner is explicitly NOT consulted (banner != readiness).
+DAEMON_NODE_ID=""
+for i in $(seq 1 45); do
+  sleep 1
+  R=$(curl -sS "$HUB_BASE/api/nodes" -H "Authorization: Bearer $UTOK")
+  DAEMON_NODE_ID=$(echo "$R" | jq -r --arg n "$DAEMON_NAME" '.nodes[]? | select(.node_name==$n or .alias==$n) | .node_id' | head -1)
+  [[ -n "$DAEMON_NODE_ID" && "$DAEMON_NODE_ID" != null ]] && break
+done
+if [[ -n "$DAEMON_NODE_ID" && "$DAEMON_NODE_ID" != null ]]; then
+  ok "daemon registered via \`anet daemon up\` (node_id=$DAEMON_NODE_ID)"
+else
+  bad "daemon never appeared in hub /api/nodes"; tail -40 /tmp/daemon-dlife.log; exit 1
+fi
+# The hub does NOT expose the role as `nodes[0].role`. It lands inside
+# `config_snapshot`, which the daemon reports AFTER registering — so this
+# is a genuine race, not a formality: `list_host_supervisors` filters on
+# `config_snapshot.role`, and qa-rfc026 documents the same race. Dispatch
+# create_node before it converges and the daemon is not yet a supervisor.
+DROLE=""
+for i in $(seq 1 45); do
+  DROLE=$(curl -sS "$HUB_BASE/api/nodes?node_id=$DAEMON_NODE_ID" -H "Authorization: Bearer $UTOK" \
+    | jq -r '.nodes[0].config_snapshot.role // .nodes[0].role // empty')
+  [[ "$DROLE" == "host_supervisor" ]] && break
+  sleep 1
+done
+if [[ "$DROLE" == "host_supervisor" ]]; then
+  ok "hub-side config_snapshot.role=host_supervisor (converged)"
+else
+  bad "config_snapshot.role never became host_supervisor (last='$DROLE')"
+  echo "  ── /api/nodes raw ──"
+  curl -sS "$HUB_BASE/api/nodes?node_id=$DAEMON_NODE_ID" -H "Authorization: Bearer $UTOK" | jq -c '.nodes[0] | {node_id,node_name,alias,role,config_snapshot}' 2>/dev/null | head -5
+fi
+
+# ── A. create_node ────────────────────────────────────────────────────
+note "A. create_node → child config on disk + child registers"
+CHILD_CFG="$WORK/.anet/nodes/$CHILD/config.json"
+
+# RED GATE 1 — the exact predicate used later must be red RIGHT NOW.
+expect_red "child config.json absent before create_node" child_cfg_exists
+
+CREATE_BODY=$(cat <<JSON
+{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"create_node","arguments":{
+ "daemon_node_id":"$DAEMON_NODE_ID","network_id":"$NET_ID",
+ "node_spec":{"name":"$CHILD","runtime":"claude-agent-sdk","model":"claude-opus-original","flags":{"maxTurns":7}}}}}
+JSON
+)
+CREATE_RESP=$(mcp_call "$UTOK" "$CREATE_BODY")
+REQ_ID=$(echo "$CREATE_RESP" | jq -r '.request_id // empty')
+[[ -n "$REQ_ID" ]] && ok "create_node dispatched (request_id=$REQ_ID)" || { bad "create_node failed: $CREATE_RESP"; exit 1; }
+
+# child node_id is derived from request_id by the daemon:
+#   node_id = "node_" + request_id.replace(/^cr_/, "")   (create-node-daemon.ts)
+CHILD_NODE_ID="node_${REQ_ID#cr_}"
+
+for i in $(seq 1 60); do sleep 1; child_cfg_exists && break; done
+if child_cfg_exists; then
+  ok "child config.json written: .anet/nodes/$CHILD/config.json"
+else
+  bad "child config.json never written"
+  echo "  ── daemon log (last 40) ──"; tail -40 /tmp/daemon-dlife.log
+  echo "  ── what landed under .anet/nodes ──"; ls -la "$WORK/.anet/nodes/" 2>/dev/null
+  echo "  ── hub view of the create request ──"
+  curl -sS "$HUB_BASE/api/nodes" -H "Authorization: Bearer $UTOK" | jq -c '[.nodes[]? | {node_name,alias,lifecycle_state}]' 2>/dev/null
+  exit 1
+fi
+
+# baseline: the value we will later change, read from the REAL file
+child_flag_equals maxTurns 7 && ok "child on-disk flags.maxTurns=7 (as created)" \
+  || bad "unexpected initial maxTurns: $(jq -c '.flags' "$CHILD_CFG" 2>/dev/null)"
+
+REGISTERED=""
+for i in $(seq 1 60); do
+  sleep 1
+  curl -sS "$HUB_BASE/api/nodes?node_id=$CHILD_NODE_ID" -H "Authorization: Bearer $UTOK" \
+    | jq -e --arg id "$CHILD_NODE_ID" '.nodes[0].node_id == $id' >/dev/null 2>&1 && { REGISTERED=yes; break; }
+done
+[[ -n "$REGISTERED" ]] && ok "child registered with hub (node_id=$CHILD_NODE_ID)" \
+  || bad "child never registered — later hub-side assertions will be vacuous"
+
+# ── B. update_node_config — THE UNCOVERED SQUARE ──────────────────────
+note "B. update_node_config → does the CHILD's real on-disk config change?"
+
+# RED GATE 2 — assert the POST-update value BEFORE updating. Must be red.
+# This is what proves the assertion reads the file and can tell 7 from 99;
+# without it, a green after the update could just be a tautology.
+expect_red "child flags.maxTurns=99 before update_node_config" child_flag_equals maxTurns 99
+
+UPD_BODY=$(cat <<JSON
+{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"update_node_config","arguments":{
+ "node_id":"$CHILD_NODE_ID","network_id":"$NET_ID","base_revision":0,
+ "patch":{"flags":{"maxTurns":99}}}}}
+JSON
+)
+UPD_RESP=$(mcp_call "$UTOK" "$UPD_BODY")
+UPD_MODE=$(echo "$UPD_RESP" | jq -r '.apply_mode // empty')
+UPD_ID=$(echo "$UPD_RESP" | jq -r '.update_id // empty')
+UPD_ERR=$(echo "$UPD_RESP" | jq -r '.error // empty')
+if [[ -n "$UPD_ID" ]]; then
+  ok "hub accepted patch (apply_mode=$UPD_MODE update_id=$UPD_ID)"
+else
+  bad "update_node_config rejected: ${UPD_ERR:-$UPD_RESP}"
+fi
+
+# hub accepting the patch is NOT the deliverable. The deliverable is the
+# child's file changing. Poll the file, then report honestly either way.
+APPLIED=""
+for i in $(seq 1 45); do sleep 1; child_flag_equals maxTurns 99 && { APPLIED=yes; break; }; done
+if [[ -n "$APPLIED" ]]; then
+  ok "CHILD on-disk flags.maxTurns 7 → 99 (config actually applied)"
+else
+  bad "hub returned update_id but CHILD file still shows maxTurns=$(jq -r '.flags.maxTurns // "?"' "$CHILD_CFG" 2>/dev/null) after 45s"
+fi
+CFG_REV=$(jq -r '.config_revision // empty' "$CHILD_CFG" 2>/dev/null)
+[[ -n "$CFG_REV" && "$CFG_REV" != "0" ]] && ok "child config_revision advanced to $CFG_REV" \
+  || printf "  · note: config_revision=%s (informational — not all apply modes stamp it)\n" "${CFG_REV:-unset}"
+
+# ── C. restart_node ───────────────────────────────────────────────────
+note "C. restart_node → process really restarts AND config survives"
+PID_BEFORE=$(child_pids | head -1)
+printf "  · agent-node --alias %s process count = %s\n" "$CHILD" "$(child_proc_count)"
+[[ -n "$PID_BEFORE" ]] && ok "child process alive before restart (pid=$PID_BEFORE)" \
+  || bad "no child process found — restart assertions would be vacuous"
+
+RST_BODY=$(cat <<JSON
+{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"restart_node","arguments":{
+ "node_id":"$CHILD_NODE_ID","network_id":"$NET_ID"}}}
+JSON
+)
+RST_RESP=$(mcp_call "$UTOK" "$RST_BODY")
+echo "$RST_RESP" | jq -e '.ok == true or (.request_id|length>0)' >/dev/null 2>&1 \
+  && ok "restart_node dispatched" || bad "restart_node failed: $RST_RESP"
+
+PID_AFTER=""
+for i in $(seq 1 60); do
+  sleep 1
+  P=$(child_pids | head -1)
+  [[ -n "$P" && "$P" != "$PID_BEFORE" ]] && { PID_AFTER="$P"; break; }
+done
+[[ -n "$PID_AFTER" ]] && ok "process really restarted (pid $PID_BEFORE → $PID_AFTER)" \
+  || bad "pid never changed within 60s (still ${PID_BEFORE:-none}) — restart not observed at process level"
+
+# the point of the whole chain: the value set in stage B must survive C
+child_flag_equals maxTurns 99 && ok "config SURVIVED restart (maxTurns still 99)" \
+  || bad "config lost across restart: maxTurns=$(jq -r '.flags.maxTurns // "?"' "$CHILD_CFG" 2>/dev/null)"
+
+# ── D. stop_node ──────────────────────────────────────────────────────
+note "D. stop_node → hub terminal state + process really reaped"
+
+# RED GATE 3 — the terminal state must not already read 'stopped'.
+printf "  · pre-stop hub lifecycle_state = %s (the value red-gate 3 judges)\n" \
+  "$(curl -sS "$HUB_BASE/api/nodes?node_id=$CHILD_NODE_ID" -H "Authorization: Bearer $UTOK" | jq -r '.nodes[0].lifecycle_state // "<node absent>"')"
+expect_red "hub lifecycle_state=stopped before stop_node" hub_lifecycle_is stopped
+
+# NOTE: stop_node takes `child_node_id`, while restart_node above takes
+# `node_id` for the same object. Not a typo here — the two tools really do
+# name the same argument differently (tools.ts: stop_node child_node_id
+# vs restart_node node_id). Getting it wrong costs a -32602, not a
+# silently wrong result, so this is annoying rather than dangerous.
+STOP_BODY=$(cat <<JSON
+{"jsonrpc":"2.0","id":14,"method":"tools/call","params":{"name":"stop_node","arguments":{
+ "child_node_id":"$CHILD_NODE_ID","network_id":"$NET_ID","force":true}}}
+JSON
+)
+STOP_RESP=$(mcp_call "$UTOK" "$STOP_BODY")
+echo "$STOP_RESP" | jq -e '.ok == true or (.request_id|length>0)' >/dev/null 2>&1 \
+  && ok "stop_node dispatched" || bad "stop_node failed: $STOP_RESP"
+
+STOPPED=""
+for i in $(seq 1 60); do sleep 1; hub_lifecycle_is stopped && { STOPPED=yes; break; }; done
+[[ -n "$STOPPED" ]] && ok "hub-side TERMINAL state lifecycle_state=stopped" \
+  || bad "hub lifecycle_state=$(curl -sS "$HUB_BASE/api/nodes?node_id=$CHILD_NODE_ID" -H "Authorization: Bearer $UTOK" | jq -r '.nodes[0].lifecycle_state // "?"') after 60s"
+
+REAPED=""
+for i in $(seq 1 45); do sleep 1; child_proc_alive || { REAPED=yes; break; }; done
+[[ -n "$REAPED" ]] && ok "child process really reaped (pgrep finds nothing)" \
+  || bad "process still alive after stop_node — hub state and reality disagree"
+
+# the daemon itself must SURVIVE stopping one of its children
+kill -0 "$DAEMON_PID" 2>/dev/null && ok "daemon survived the child stop" \
+  || bad "daemon died along with its child"
+
+# ── E. start_node — TODO ──────────────────────────────────────────────
+note "E. start_node"
+todo "start_node re-start after stop" "tool not in main yet (#1273 under independent review); add a stage here once merged"
+
+# ── result ────────────────────────────────────────────────────────────
+note "Result"
+echo "  PASS=$PASS  FAIL=$FAIL  TODO=$SKIP   (red gates witnessed: $RED)"
+if [[ "$RED" -lt 3 ]]; then
+  echo "  ✗ fewer than 3 red gates witnessed — the suite cannot vouch for its own greens"
+  FAIL=$((FAIL+1))
+fi
+[[ "$FAIL" -eq 0 ]] && { echo "RESULT: PASS"; exit 0; } || { echo "RESULT: FAIL ($FAIL)"; exit 1; }


### PR DESCRIPTION
## 做了什么

新增 `tests/qa-daemon-lifecycle-e2e/`,把 daemon 全链路串成一条:

`anet daemon up` → `create_node` → 子节点注册 → `update_node_config` → `restart_node` → `stop_node`

**跑在同一个 daemon 生命周期内的同一个子节点上** —— 这是关键,单个工具各自都已有套件。

## 为什么不是重复覆盖

| 现有套件 | 覆盖 |
|---|---|
| `qa-rfc026-create-node` | `create_node` + 子节点注册 ✓ |
| `qa-rfc027-stop-delete` | `stop_node` / `restart_node` / `delete_node` ✓ |
| `qa-rfc024-config-apply` | `update_node_config` —— **仅契约面** |

`qa-rfc024-config-apply/run.sh` 的源码注释自己写明了这个缺口:

> A real "next think uses new value" check needs a vendor key + a live agent-node consuming the SSE doorbell. **That belongs in the longer-form QA.**

它只 mint 了 `ntok_`、没起真节点,hub 返回 `node_not_found`,该阶段走 `skip` 分支。
(该套件是**诚实的**:`SKIP` 单独计数、结尾明列哪些是 stub。缺口是有意留的,不是被藏起来的。)

所以没被覆盖的不是任何单个工具,而是它们之间的**状态交接**。本套件实测回答:

- `update_node_config` **真的改到了子节点磁盘上的 `config.json`**(`flags.maxTurns` 7→99),而不只是 hub 返回了 `update_id`
- 那个值**扛过了 `restart_node`**(进程 pid 173→236,配置仍是 99)
- `stop_node` 收掉的是前面几步配置过的**那个进程**,且 daemon 自身存活

它同时是第一个走 **`anet daemon up`**(一步式,首次用户实际会敲的命令)的套件:`qa-rfc027` 手写 daemon 的 `config.json`,`qa-anet-daemon-cmd` 分开驱动 `init` 和 `start`,都不覆盖 `up`。

## 判据

- 断 **hub 侧终态**(`lifecycle_state`)+ **子进程真实落盘配置**;**启动横幅一个字不读**
- **3 道红门先行**,在断言必须失败的时刻运行;红门与绿断言调用**同一个 shell 函数**,不是两个长得像的。结尾强制 `RED >= 3` —— 删掉红门会让套件**自己变红**,而不是静默缩小它证明的范围
- 无 pattern kill:`pgrep` 取 pid → 读 `/proc/<pid>/cmdline` 复核 → kill 精确 pid
- 容器守卫:`/.dockerenv` 不在就 `exit 2`(它会起 hub、杀进程)
- provenance:`SOURCE_COMMIT` + `RUNSH_BLOB`,容器内重算 blob 比对

## 实测

```
provenance: source_commit=8c23e4bc… run.sh blob=e45f1432… (verified)
PASS=22  FAIL=0  TODO=1   (red gates witnessed: 3)
```

连续两次独立运行逐字一致。两个反控证明判据不是恒真:

| 反控 | 结果 |
|---|---|
| `RUNSH_BLOB` 传格式合法但错误的值 | `rc=1`,报出 expected vs actual ✓ |
| 宿主机(非容器)直接跑 `run.sh` | `rc=2`,拒跑 ✓ |

完整命令与输出见 `docs/tests/report-qa-daemon-lifecycle-e2e.txt`。

## 归属:`recovered-suites`,不是 `qa.sh` 的 L1_TESTS

run 只要 **11s**,但**冷构建 244s**(三次 bun install + 混淆构建 + 两次 npm pack)。
`qa.sh` 的 L1 build 是**串行**的,job 预算 5 分钟且现有已用掉 141–148s。
**只看 run 时间会把它错放进快层 —— 那是量了错的那一半。** 所以放进 12 分钟预算的
`recovered-suites` job,位置在 `test224`(安全套件)之前,保持该 job 头注释写明的分层顺序。

两道注册门前后计数:

```
check-test-suite-registration.py
  加之前: registered=153 orphans=61 new=1   rc=1
  加之后: registered=154 orphans=60 new=0   rc=0     (分母 suites=227 不变)
check-l1-paths-sync.py                       rc=0
```

## 过程中被修正的两个错判据(留档,因为两者的红绿都看起来完全正常)

1. **进程判据一开始断错了对象**:断的是 `anet node start <name>`(启动器),而真正长驻的是孙进程 `agent-node --alias <name>`(`create-node-daemon.ts:420` spawn 启动器,启动器再拉起节点)。启动器可以已经退出而节点仍在跑 ⇒ restart 的 pid 比对和 stop 的 reap 判据会全部断在错的对象上。改为与 `qa-rfc027` 已验证的写法一致。
2. **daemon 的 role 不在 `nodes[0].role`,而在 `nodes[0].config_snapshot.role`**,且它是 daemon 注册**之后**才上报的,存在真实 race(`qa-rfc026` 注释记录了同一 race)。先前写法读到空字符串,看起来像「产品没设置 role」,实为取错字段 + 未等收敛。

两者的共同点:只有对照已跑通的同类套件才暴露。

## 一个顺带的可用性观察(未改代码)

同一组生命周期工具的参数名不一致:`restart_node` 用 `node_id`,`stop_node` 用 `child_node_id`。
传错会得到 `-32602`(不是静默的错误结果),所以是烦人而非危险。已在 run.sh 就地写下注释,未改产品。

## 查重

**按【改动文件】求交集**(不是 `--search` 搜标题/正文 —— 那搜不到 diff):
逐个拉取 60 个 open PR 的 `files[].path` 比对。

- `tests/qa-daemon-lifecycle-e2e/**` ⇒ **零命中**(全新目录)
- `.github/workflows/qa.yml` ⇒ 命中 **#1273 / #1200 / #1196 / #1180**;逐个核对 hunk 位置为 43·202·937 / 29 / 28 / 148·294·870,与本 PR 的 97·256·493 **均不重叠**

## 已知缺口

`start_node` 是 **TODO 占位**,不是遗漏:该工具尚未进 main(#1273 独审中)。链条止于 `stop_node`;#1273 合入后在末尾补一段即可。
