### PR TITLE
chore(daemon): 真机 daemon 验收脚本(交审 · 默认 dry-run · 未在任何真机执行)

### DIFF
--- a/scripts/daemon-live-acceptance.sh
+++ b/scripts/daemon-live-acceptance.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Real-machine daemon acceptance — 查看 / 创建 / 编辑 / 操作 / 删除 一个节点
+# against a REAL daemon registered on the PRODUCTION hub.
+#
+# 🔴 THIS SCRIPT TOUCHES PRODUCTION. Read the guard section before running.
+#
+# Scope (Vincent's goal): prove that from a client one can 查看/创建/编辑/
+# 删除/操作 nodes on a real host daemon (daemon-relay / daemon-macmini).
+#
+# What it does NOT do, on purpose:
+#   · never touches an existing node — it creates ONE temporary child of its
+#     own and only ever addresses that one by the node_id it recorded
+#   · never asserts anything file-level or process-level. The child runs on
+#     another machine; the container e2e (tests/qa-daemon-lifecycle-e2e) can
+#     stat its config.json and pgrep its process only because it shares a
+#     filesystem and PID namespace with the child. Claiming the same here
+#     without SSH would be asserting something weaker and calling it equal.
+#     Config application is therefore judged at the hub's contract surface,
+#     and that limitation is PRINTED, not hidden.
+#
+# Exit codes follow deploy/check-deployed-copies.sh:
+#   0 = acceptance passed
+#   1 = a step failed (real finding)
+#   2 = refused to run / cannot judge (fail-closed)
+#
+# ── judge criteria come from tests/lib/daemon-hub-assertions.sh, the same
+#    file tests/qa-daemon-lifecycle-e2e is to source once #1280 lands. Two
+#    scripts calling one function cannot drift; two scripts "asserting the
+#    same thing" always do.
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+LIB="$REPO_ROOT/tests/lib/daemon-hub-assertions.sh"
+[[ -f "$LIB" ]] || { echo "::error::judge library missing: $LIB — refusing (cannot判断)"; exit 2; }
+# shellcheck disable=SC1090
+source "$LIB"
+
+# ── defaults: everything that writes is OFF ──────────────────────────
+MODE="dryrun"            # dryrun | execute
+HUB=""                   # must be passed explicitly; no env fallback
+TOKEN_ENV="ANET_ACCEPT_UTOK"
+DAEMON_NAME=""
+AUTHORIZED_BY=""
+NETWORK_ID=""
+EXTRA_ALLOWED_DAEMON=""
+
+# 🔴 Allow-list of daemons this script may target. A typo in --daemon must
+# not silently point the run at some other machine's supervisor.
+ALLOWED_DAEMONS=("daemon-relay" "daemon-macmini")
+
+usage() {
+  cat <<USAGE
+Usage:
+  $0 --hub <url> --daemon <name> [--network <id>] [--selftest]
+  $0 --hub <url> --daemon <name> --execute --i-am-authorized-by <who>
+
+  --hub <url>                REQUIRED. Full base URL of the target hub.
+                             No environment fallback on purpose: a default
+                             would let a mistyped flag hit production.
+  --daemon <name>            REQUIRED. One of: ${ALLOWED_DAEMONS[*]}
+  --network <id>             Network id to scope calls to (optional).
+  --execute                  Perform writes. Without it NOTHING is written.
+  --i-am-authorized-by <who> REQUIRED with --execute. Recorded in the report.
+  --allow-daemon <name>      Extend the allow-list for this run (explicit).
+  --selftest                 Verify the guards themselves. Contacts no hub.
+
+  Token is read from \$$TOKEN_ENV (never a flag — flags land in shell history
+  and in ps output).
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --hub) HUB="${2:-}"; shift 2 ;;
+    --daemon) DAEMON_NAME="${2:-}"; shift 2 ;;
+    --network) NETWORK_ID="${2:-}"; shift 2 ;;
+    --execute) MODE="execute"; shift ;;
+    --i-am-authorized-by) AUTHORIZED_BY="${2:-}"; shift 2 ;;
+    --allow-daemon) EXTRA_ALLOWED_DAEMON="${2:-}"; shift 2 ;;
+    --selftest) MODE="selftest"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "::error::unknown argument: $1"; usage; exit 2 ;;
+  esac
+done
+
+PASS=0; FAIL=0
+note() { printf "\n=== %s ===\n" "$*"; }
+ok()   { printf "  ✓ %s\n" "$*"; PASS=$((PASS+1)); }
+bad()  { printf "  ✗ %s\n" "$*"; FAIL=$((FAIL+1)); }
+refuse() { echo "::error::REFUSING — $*"; exit 2; }
+
+daemon_is_allowed() {
+  local want="$1" d
+  [[ -n "$EXTRA_ALLOWED_DAEMON" && "$want" == "$EXTRA_ALLOWED_DAEMON" ]] && return 0
+  for d in "${ALLOWED_DAEMONS[@]}"; do [[ "$d" == "$want" ]] && return 0; done
+  return 1
+}
+
+# ── guard self-test — no hub contacted ───────────────────────────────
+# 🔴 A guard that has never been seen refusing is not known to refuse.
+if [[ "$MODE" == "selftest" ]]; then
+  note "guard selftest (contacts no hub)"
+  SPASS=0; SFAIL=0
+  # 🔴 print the ARGUMENT, not just the function name. With only "$1" every
+  # line reads "daemon_is_allowed" and the output is byte-identical no matter
+  # what the allow-list contains — a green that cannot be told from a broken one.
+  st() { if "$@" >/dev/null 2>&1; then printf "  ✗ [%s] guard did NOT fire — this input would be ACCEPTED\n" "$*"; SFAIL=$((SFAIL+1));
+         else printf "  ✓ [%s] correctly refused\n" "$*"; SPASS=$((SPASS+1)); fi; }
+  stn(){ if "$@" >/dev/null 2>&1; then printf "  ✓ [%s] correctly accepted\n" "$*"; SPASS=$((SPASS+1));
+         else printf "  ✗ [%s] guard fired on a VALID input\n" "$*"; SFAIL=$((SFAIL+1)); fi; }
+
+  st  daemon_is_allowed "daemon-relayy"          # typo must not pass
+  st  daemon_is_allowed "daemon-macmini-old"     # prefix of an allowed name
+  st  daemon_is_allowed ""                       # empty
+  st  daemon_is_allowed "prod-hub"               # unrelated node
+  stn daemon_is_allowed "daemon-relay"           # the real thing must pass
+  stn daemon_is_allowed "daemon-macmini"
+
+  # temp child naming must be unique per run and carry the acceptance prefix,
+  # because the cleanup step keys on that prefix as a second safety net.
+  N1=$(printf 'acc-%s-%s' "$(date +%s)" "$RANDOM")
+  N2=$(printf 'acc-%s-%s' "$(date +%s)" "$RANDOM")
+  if [[ "$N1" == acc-* && "$N2" == acc-* && "$N1" != "$N2" ]]; then
+    printf "  ✓ temp child names are prefixed and unique (%s != %s)\n" "$N1" "$N2"; SPASS=$((SPASS+1))
+  else
+    printf "  ✗ temp child naming is not unique — cleanup could target the wrong node\n"; SFAIL=$((SFAIL+1))
+  fi
+
+  # the set-difference used to prove "left nothing behind" must actually
+  # notice an extra id; a comparison that always says "equal" would make the
+  # cleanup proof vacuous.
+  BEFORE=$'node_a\nnode_b'; AFTER_OK=$'node_a\nnode_b'; AFTER_BAD=$'node_a\nnode_b\nnode_c'
+  [[ "$(comm -13 <(echo "$BEFORE") <(echo "$AFTER_OK"))" == "" ]] \
+    && { printf "  ✓ residue check: identical sets → no residue\n"; SPASS=$((SPASS+1)); } \
+    || { printf "  ✗ residue check flagged an identical set\n"; SFAIL=$((SFAIL+1)); }
+  [[ "$(comm -13 <(echo "$BEFORE") <(echo "$AFTER_BAD"))" == "node_c" ]] \
+    && { printf "  ✓ residue check: extra node_c detected\n"; SPASS=$((SPASS+1)); } \
+    || { printf "  ✗ residue check MISSED a leftover node — cleanup proof would be vacuous\n"; SFAIL=$((SFAIL+1)); }
+
+  printf "\n  selftest PASS=%d FAIL=%d\n" "$SPASS" "$SFAIL"
+  [[ "$SFAIL" -eq 0 ]] && { echo "SELFTEST: PASS"; exit 0; } || { echo "SELFTEST: FAIL"; exit 1; }
+fi
+
+# ── guards ───────────────────────────────────────────────────────────
+note "guards"
+[[ -n "$HUB" ]] || refuse "--hub is required (no default: a default would let a typo hit production)"
+[[ "$HUB" =~ ^https?:// ]] || refuse "--hub must be a full URL, got '$HUB'"
+[[ -n "$DAEMON_NAME" ]] || refuse "--daemon is required"
+daemon_is_allowed "$DAEMON_NAME" || refuse "daemon '$DAEMON_NAME' is not in the allow-list (${ALLOWED_DAEMONS[*]}); pass --allow-daemon to extend deliberately"
+UTOK="${!TOKEN_ENV:-}"
+[[ -n "$UTOK" ]] || refuse "\$$TOKEN_ENV is empty — cannot authenticate"
+[[ "$UTOK" == utok_* ]] || refuse "\$$TOKEN_ENV does not look like a user token"
+if [[ "$MODE" == "execute" ]]; then
+  [[ -n "$AUTHORIZED_BY" ]] || refuse "--execute requires --i-am-authorized-by <who> (recorded in the report)"
+fi
+ok "flags validated (mode=$MODE daemon=$DAEMON_NAME)"
+
+hub_reachable "$HUB" || refuse "hub $HUB is not reachable (/health) — cannot judge"
+ok "hub reachable: $HUB"
+
+# ── P0. identify the daemon, and prove it is the right KIND of thing ──
+note "P0. target daemon identity"
+DAEMON_NODE_ID=$(curl -sS --max-time 20 "$HUB/api/nodes" -H "Authorization: Bearer $UTOK" \
+  | jq -r --arg n "$DAEMON_NAME" '.nodes[]? | select(.node_name==$n or .alias==$n) | .node_id' | head -1)
+[[ -n "$DAEMON_NODE_ID" ]] || refuse "daemon '$DAEMON_NAME' not found on $HUB — wrong hub, or it is not registered"
+ok "resolved $DAEMON_NAME → $DAEMON_NODE_ID"
+hub_role_is "$HUB" "$UTOK" "$DAEMON_NODE_ID" "host_supervisor" \
+  || refuse "'$DAEMON_NAME' is not a host_supervisor — refusing to send create_node to a non-daemon node"
+ok "role=host_supervisor confirmed (config_snapshot.role)"
+
+# ── P0.5 baseline snapshot — the ONLY way to later prove we left nothing ──
+note "P0.5 baseline node set"
+BEFORE_SET=$(hub_node_id_set "$HUB" "$UTOK")
+BEFORE_N=$(printf '%s\n' "$BEFORE_SET" | grep -c . || true)
+[[ "$BEFORE_N" -gt 0 ]] || refuse "baseline node set is empty — 0 nodes and 'could not read nodes' print identically; refusing (fail-closed)"
+ok "baseline: $BEFORE_N node(s) recorded"
+
+NET_ARG=""
+[[ -n "$NETWORK_ID" ]] && NET_ARG=",\"network_id\":\"$NETWORK_ID\""
+
+CHILD_NAME="acc-$(date +%s)-$RANDOM"
+CHILD_NODE_ID=""        # set only after create; cleanup keys on THIS value
+CREATED=0
+
+# 🔴 cleanup addresses exactly the node_id this run created, and refuses to
+# act if that variable is empty or does not carry our prefix. It never
+# enumerates-and-deletes, because an enumeration that goes wrong deletes
+# someone else's node.
+cleanup() {
+  [[ "$CREATED" -eq 1 && -n "$CHILD_NODE_ID" ]] || return 0
+  if ! hub_node_exists "$HUB" "$UTOK" "$CHILD_NODE_ID"; then return 0; fi
+  echo "  · cleanup: removing $CHILD_NODE_ID ($CHILD_NAME)"
+  mcp_call "delete_node" "{\"node_id\":\"$CHILD_NODE_ID\",\"confirm_alias\":\"$CHILD_NAME\"$NET_ARG}" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+mcp_call() {
+  local tool="$1" args="$2" resp inner
+  if [[ "$MODE" != "execute" ]]; then
+    echo "{\"dryrun\":true,\"tool\":\"$tool\"}"; return 0
+  fi
+  resp=$(curl -sS --max-time 30 -X POST "$HUB/mcp" -H "Authorization: Bearer $UTOK" \
+    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+    -H 'MCP-Protocol-Version: 2025-03-26' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$RANDOM,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}")
+  inner=$(echo "$resp" | grep -oP '(?<=data: ).+' | head -1 | jq -r '.result.content[0].text' 2>/dev/null)
+  [[ -z "$inner" || "$inner" == "null" ]] && inner=$(echo "$resp" | jq -r '.result.content[0].text' 2>/dev/null)
+  [[ -z "$inner" || "$inner" == "null" ]] && echo "$resp" || echo "$inner"
+}
+
+if [[ "$MODE" != "execute" ]]; then
+  note "DRY RUN — no write will be issued"
+  cat <<PLAN
+  Would run, against $HUB, daemon $DAEMON_NAME ($DAEMON_NODE_ID):
+    P1 查看   list nodes (read-only, already done above)
+    P2 创建   create_node → temp child "$CHILD_NAME"
+    P3 编辑   update_node_config on that child only
+    P4 操作   restart_node on that child only
+    P5 停止   stop_node   (arg name is child_node_id — see issue #1281)
+    P6 删除   delete_node (confirm_alias="$CHILD_NAME")
+    P7 证明   node-id set must equal the $BEFORE_N recorded above, exactly
+
+  Re-run with:  --execute --i-am-authorized-by <who>
+PLAN
+  echo; echo "RESULT: DRY-RUN OK (nothing written)"; exit 0
+fi
+
+# ── P1..P7 (execute mode) ────────────────────────────────────────────
+note "P1. 查看 — node list is readable"
+ok "listed $BEFORE_N node(s) (read-only)"
+
+note "P2. 创建 — create_node (temp child only)"
+CREATE_RESP=$(mcp_call "create_node" "{\"daemon_node_id\":\"$DAEMON_NODE_ID\",\"node_spec\":{\"name\":\"$CHILD_NAME\",\"runtime\":\"claude-agent-sdk\",\"model\":\"claude-opus-original\",\"flags\":{\"maxTurns\":7}}$NET_ARG}")
+REQ_ID=$(echo "$CREATE_RESP" | jq -r '.request_id // empty')
+if [[ -z "$REQ_ID" ]]; then bad "create_node failed: $CREATE_RESP"; echo "RESULT: FAIL"; exit 1; fi
+CHILD_NODE_ID="node_${REQ_ID#cr_}"; CREATED=1
+ok "dispatched; child node_id = $CHILD_NODE_ID"
+hub_wait_until 90 hub_node_exists "$HUB" "$UTOK" "$CHILD_NODE_ID" \
+  && ok "child registered with hub" || bad "child never registered within 90s"
+
+note "P3. 编辑 — update_node_config"
+UPD=$(mcp_call "update_node_config" "{\"node_id\":\"$CHILD_NODE_ID\",\"base_revision\":0,\"patch\":{\"flags\":{\"maxTurns\":99}}$NET_ARG}")
+UPD_ID=$(echo "$UPD" | jq -r '.update_id // empty')
+[[ -n "$UPD_ID" ]] && ok "hub accepted patch (apply_mode=$(echo "$UPD" | jq -r '.apply_mode // "?"') update_id=$UPD_ID)" \
+  || bad "update_node_config rejected: $UPD"
+# 🔴 Honest scope note, printed rather than quietly skipped.
+if hub_wait_until 60 bash -c "[[ \"\$(hub_node_field '$HUB' '$UTOK' '$CHILD_NODE_ID' '.nodes[0].config_snapshot.flags.maxTurns')\" == '99' ]]"; then
+  ok "hub's config_snapshot converged to maxTurns=99 (child reported it back)"
+else
+  echo "  · NOT PROVEN HERE: the child's on-disk config was not read."
+  echo "    config_snapshot did not surface flags.maxTurns within 60s. That may mean"
+  echo "    the hub does not mirror this flag, not that the patch failed."
+  echo "    On-disk application is proven in tests/qa-daemon-lifecycle-e2e (container,"
+  echo "    same filesystem). Proving it HERE requires SSH to $DAEMON_NAME — out of scope."
+fi
+
+note "P4. 操作 — restart_node"
+RST=$(mcp_call "restart_node" "{\"node_id\":\"$CHILD_NODE_ID\"$NET_ARG}")
+echo "$RST" | jq -e '.ok == true or (.request_id|length>0)' >/dev/null 2>&1 \
+  && ok "restart_node accepted" || bad "restart_node failed: $RST"
+hub_wait_until 90 hub_lifecycle_is "$HUB" "$UTOK" "$CHILD_NODE_ID" "active" \
+  && ok "lifecycle_state=active after restart" || bad "lifecycle_state did not return to active"
+
+note "P5. 停止 — stop_node"
+# arg is child_node_id here but node_id above — see issue #1281.
+STOP=$(mcp_call "stop_node" "{\"child_node_id\":\"$CHILD_NODE_ID\",\"force\":true$NET_ARG}")
+echo "$STOP" | jq -e '.ok == true or (.request_id|length>0)' >/dev/null 2>&1 \
+  && ok "stop_node accepted" || bad "stop_node failed: $STOP"
+hub_wait_until 90 hub_lifecycle_is "$HUB" "$UTOK" "$CHILD_NODE_ID" "stopped" \
+  && ok "hub TERMINAL state lifecycle_state=stopped" || bad "lifecycle_state never became stopped"
+
+note "P6. 删除 — delete_node"
+DEL=$(mcp_call "delete_node" "{\"node_id\":\"$CHILD_NODE_ID\",\"confirm_alias\":\"$CHILD_NAME\"$NET_ARG}")
+echo "$DEL" | jq -e '.ok == true' >/dev/null 2>&1 && ok "delete_node accepted" || bad "delete_node failed: $DEL"
+hub_wait_until 60 bash -c "! hub_node_exists '$HUB' '$UTOK' '$CHILD_NODE_ID'" \
+  && { ok "child row gone from hub"; CREATED=0; } || bad "child row still present after delete"
+
+# ── P7. residue proof — the point of the whole guard design ───────────
+note "P7. 证明没留下任何东西"
+AFTER_SET=$(hub_node_id_set "$HUB" "$UTOK")
+EXTRA=$(comm -13 <(printf '%s\n' "$BEFORE_SET") <(printf '%s\n' "$AFTER_SET"))
+MISSING=$(comm -23 <(printf '%s\n' "$BEFORE_SET") <(printf '%s\n' "$AFTER_SET"))
+[[ -z "$EXTRA" ]] && ok "no node added that was not there before" \
+  || bad "LEFTOVER node(s): $(echo "$EXTRA" | tr '\n' ' ')"
+[[ -z "$MISSING" ]] && ok "no pre-existing node disappeared" \
+  || bad "🔴 PRE-EXISTING node(s) VANISHED: $(echo "$MISSING" | tr '\n' ' ')"
+
+note "Result"
+echo "  authorized_by=$AUTHORIZED_BY  hub=$HUB  daemon=$DAEMON_NAME"
+echo "  PASS=$PASS  FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] && { echo "RESULT: PASS"; exit 0; } || { echo "RESULT: FAIL ($FAIL)"; exit 1; }

--- a/scripts/daemon-live-acceptance.sh
+++ b/scripts/daemon-live-acceptance.sh
@@ -51,9 +51,14 @@ SSH_HOST=""             # resolved only when --ssh-verify is given
 
 # 🔴 Allow-list of daemons this script may target. A typo in --daemon must
 # not silently point the run at some other machine's supervisor.
-# daemon-vanisn (Windows host VANISN) is listed deliberately rather than left
-# undefined. Note its --ssh-verify support differs — see ssh_alias_for below.
-ALLOWED_DAEMONS=("daemon-relay" "daemon-macmini" "daemon-vanisn")
+# daemon-vanisn (Windows host VANISN) is deliberately NOT here. It is not
+# "unverified" — it is PROVEN not to work: issue #1290 shows
+# loadAndVerifyAnetBin's startsWith("/") is POSIX-only, so `C:\...` can never
+# satisfy it; and even if relaxed, uid is constantly 0 on Windows and POSIX
+# mode does not reflect ACLs, making the remaining checks false-positive or
+# vacuous. Listing it and refusing with a reason beats leaving it undefined.
+ALLOWED_DAEMONS=("daemon-relay" "daemon-macmini")
+KNOWN_UNSUPPORTED_DAEMONS=("daemon-vanisn")
 
 usage() {
   cat <<USAGE
@@ -117,6 +122,8 @@ ssh_alias_for() {
   case "$1" in
     daemon-relay)   echo "relay" ;;
     daemon-macmini) echo "mac" ;;
+    # kept so the mapping survives if #1290 is ever fixed; today the run is
+    # refused at the allow-list, well before this is consulted.
     daemon-vanisn)  echo "win" ;;
     *)              echo "" ;;
   esac
@@ -152,6 +159,7 @@ if [[ "$MODE" == "selftest" ]]; then
   st  daemon_is_allowed "daemon-macmini-old"     # prefix of an allowed name
   st  daemon_is_allowed ""                       # empty
   st  daemon_is_allowed "prod-hub"               # unrelated node
+  st  daemon_is_allowed "daemon-vanisn"          # Windows: proven unsupported (#1290)
   stn daemon_is_allowed "daemon-relay"           # the real thing must pass
   stn daemon_is_allowed "daemon-macmini"
 
@@ -198,6 +206,9 @@ note "guards"
 [[ -n "$HUB" ]] || refuse "--hub is required (no default: a default would let a typo hit production)"
 [[ "$HUB" =~ ^https?:// ]] || refuse "--hub must be a full URL, got '$HUB'"
 [[ -n "$DAEMON_NAME" ]] || refuse "--daemon is required"
+for _u in "${KNOWN_UNSUPPORTED_DAEMONS[@]}"; do
+  [[ "$DAEMON_NAME" == "$_u" ]] && refuse "daemon '$DAEMON_NAME' is a Windows host and is PROVEN unsupported (issue #1290: loadAndVerifyAnetBin's startsWith(\"/\") is POSIX-only; uid is constantly 0; POSIX mode does not reflect ACLs). This is not 'unverified' — do not --allow-daemon around it."
+done
 daemon_is_allowed "$DAEMON_NAME" || refuse "daemon '$DAEMON_NAME' is not in the allow-list (${ALLOWED_DAEMONS[*]}); pass --allow-daemon to extend deliberately"
 UTOK="${!TOKEN_ENV:-}"
 [[ -n "$UTOK" ]] || refuse "\$$TOKEN_ENV is empty — cannot authenticate"
@@ -225,6 +236,17 @@ ok "resolved $DAEMON_NAME → $DAEMON_NODE_ID"
 hub_role_is "$HUB" "$UTOK" "$DAEMON_NODE_ID" "host_supervisor" \
   || refuse "'$DAEMON_NAME' is not a host_supervisor — refusing to send create_node to a non-daemon node"
 ok "role=host_supervisor confirmed (config_snapshot.role)"
+# 🔴 A daemon being UP does not mean it can create nodes. Without ANET_BIN_ABS
+# at daemon start (plus ANET_DAEMON_ALLOW_NON_ROOT_BIN=1 when not root),
+# create_node fails with anet_bin_unsafe_path.
+# This cannot be checked ahead of time: the hub never learns the pin state
+# (capability() carries runtime/version/topology/evidenceRevision only), and
+# reading the daemon's environment over SSH is not portable — /proc/<pid>/environ
+# does not exist on the Mac host. Rather than assert something weaker and call
+# it a pre-check, P2 below recognises the error and attributes it precisely.
+echo "  · note: this script cannot pre-verify the daemon's ANET_BIN_ABS pin."
+echo "    If P2 fails with anet_bin_unsafe_path, that is a HOST CONFIG issue,"
+echo "    not a broken create_node — the message below will say which of the four."
 
 # ── P0.5 baseline snapshot — the ONLY way to later prove we left nothing ──
 note "P0.5 baseline node set"
@@ -290,7 +312,27 @@ ok "listed $BEFORE_N node(s) (read-only)"
 note "P2. 创建 — create_node (temp child only)"
 CREATE_RESP=$(mcp_call "create_node" "{\"daemon_node_id\":\"$DAEMON_NODE_ID\",\"node_spec\":{\"name\":\"$CHILD_NAME\",\"runtime\":\"claude-agent-sdk\",\"model\":\"claude-opus-original\",\"flags\":{\"maxTurns\":7}}$NET_ARG}")
 REQ_ID=$(echo "$CREATE_RESP" | jq -r '.request_id // empty')
-if [[ -z "$REQ_ID" ]]; then bad "create_node failed: $CREATE_RESP"; echo "RESULT: FAIL"; exit 1; fi
+if [[ -z "$REQ_ID" ]]; then
+  if echo "$CREATE_RESP" | grep -Fq "anet_bin_unsafe_path"; then
+    bad "create_node rejected by the daemon's binary pin — HOST CONFIG, not a create_node defect"
+    echo "    full error: $CREATE_RESP"
+    # 🔴 Four distinct causes share this one error string. Do NOT collapse them
+    # into \"the pin is missing\" — same text, same guard, different root cause.
+    cat <<'CAUSES'
+    anet_bin_unsafe_path has FOUR causes; the message above says which:
+      · "no ANET_BIN_ABS"            → daemon started without the env var
+      · "not absolute"               → ANET_BIN_ABS is a relative path
+      · "symlink"                    → the pinned path is a symlink
+      · "writable by group/other"    → mode & 0o022 != 0 (a umask of 0002 during
+                                       `npm install -g` produces exactly this)
+    Also required when the daemon does not run as root:
+      ANET_DAEMON_ALLOW_NON_ROOT_BIN=1
+CAUSES
+  else
+    bad "create_node failed: $CREATE_RESP"
+  fi
+  echo "RESULT: FAIL"; exit 1
+fi
 CHILD_NODE_ID="node_${REQ_ID#cr_}"; CREATED=1
 ok "dispatched; child node_id = $CHILD_NODE_ID"
 hub_wait_until 90 hub_node_exists "$HUB" "$UTOK" "$CHILD_NODE_ID" \
@@ -356,16 +398,38 @@ hub_wait_until 90 hub_lifecycle_is "$HUB" "$UTOK" "$CHILD_NODE_ID" "stopped" \
 note "P6. 删除 — delete_node"
 DEL=$(mcp_call "delete_node" "{\"node_id\":\"$CHILD_NODE_ID\",\"confirm_alias\":\"$CHILD_NAME\"$NET_ARG}")
 echo "$DEL" | jq -e '.ok == true' >/dev/null 2>&1 && ok "delete_node accepted" || bad "delete_node failed: $DEL"
-hub_wait_until 60 bash -c "! hub_node_exists '$HUB' '$UTOK' '$CHILD_NODE_ID'" \
-  && { ok "child row gone from hub"; CREATED=0; } || bad "child row still present after delete"
+# 🔴 KNOWN DEFECT #1286: delete_node returns ok:true on an already-stopped node
+# while doing nothing. So today this step is EXPECTED not to remove the row.
+# It is written to speak up in BOTH directions — a step that quietly turns
+# green once someone fixes #1286 teaches nobody anything, and a red with no
+# stated cause gets re-diagnosed from scratch by the next person.
+if hub_wait_until 60 bash -c "! hub_node_exists '$HUB' '$UTOK' '$CHILD_NODE_ID'"; then
+  ok "child row gone from hub"
+  CREATED=0
+  echo "  🔔 NOTE: this SUCCEEDED. #1286 (delete_node no-ops on a stopped node)"
+  echo "     may now be fixed — if so, delete this note and drop the expectation below."
+else
+  echo "  · EXPECTED FAILURE (#1286): delete_node reported ok but the row is still there."
+  echo "    Not counted as a regression of this run. Tracking: #1286 (SDK马 fixing)."
+  echo "    🔴 Consequence: cleanup below cannot remove it either — see P7."
+fi
 
 # ── P7. residue proof — the point of the whole guard design ───────────
 note "P7. 证明没留下任何东西"
 AFTER_SET=$(hub_node_id_set "$HUB" "$UTOK")
 EXTRA=$(comm -13 <(printf '%s\n' "$BEFORE_SET") <(printf '%s\n' "$AFTER_SET"))
 MISSING=$(comm -23 <(printf '%s\n' "$BEFORE_SET") <(printf '%s\n' "$AFTER_SET"))
-[[ -z "$EXTRA" ]] && ok "no node added that was not there before" \
-  || bad "LEFTOVER node(s): $(echo "$EXTRA" | tr '\n' ' ')"
+if [[ -z "$EXTRA" ]]; then
+  ok "no node added that was not there before"
+else
+  # Deliberately NOT relaxed for #1286. A leftover row on the production hub is
+  # a leftover row whatever caused it; softening this would make the check
+  # useless for the case it exists to catch.
+  bad "LEFTOVER node(s): $(echo "$EXTRA" | tr '\n' ' ')"
+  echo "    🔴 ACTION REQUIRED — remove manually; this run added it and could not take it back:"
+  echo "       node_id=$CHILD_NODE_ID  alias=$CHILD_NAME"
+  echo "    Likely cause while #1286 is open: delete_node no-ops on a stopped node."
+fi
 [[ -z "$MISSING" ]] && ok "no pre-existing node disappeared" \
   || bad "🔴 PRE-EXISTING node(s) VANISHED: $(echo "$MISSING" | tr '\n' ' ')"
 

--- a/scripts/daemon-live-acceptance.sh
+++ b/scripts/daemon-live-acceptance.sh
@@ -45,10 +45,15 @@ DAEMON_NAME=""
 AUTHORIZED_BY=""
 NETWORK_ID=""
 EXTRA_ALLOWED_DAEMON=""
+SSH_VERIFY=0            # 🔴 default OFF — real-machine SSH is a separate authz surface
+SSH_HOST_OVERRIDE=""
+SSH_HOST=""             # resolved only when --ssh-verify is given
 
 # 🔴 Allow-list of daemons this script may target. A typo in --daemon must
 # not silently point the run at some other machine's supervisor.
-ALLOWED_DAEMONS=("daemon-relay" "daemon-macmini")
+# daemon-vanisn (Windows host VANISN) is listed deliberately rather than left
+# undefined. Note its --ssh-verify support differs — see ssh_alias_for below.
+ALLOWED_DAEMONS=("daemon-relay" "daemon-macmini" "daemon-vanisn")
 
 usage() {
   cat <<USAGE
@@ -64,6 +69,13 @@ Usage:
   --execute                  Perform writes. Without it NOTHING is written.
   --i-am-authorized-by <who> REQUIRED with --execute. Recorded in the report.
   --allow-daemon <name>      Extend the allow-list for this run (explicit).
+  --ssh-verify               ALSO read the child's config.json on the target
+                             machine over SSH, so "the patch reached disk" is
+                             proven rather than inferred from the hub. OFF by
+                             default: SSH to a real host is a separate authz
+                             surface from calling the hub API.
+  --ssh-host <alias>         Override the ssh alias (default: derived from
+                             --daemon; see ssh_alias_for).
   --selftest                 Verify the guards themselves. Contacts no hub.
 
   Token is read from \$$TOKEN_ENV (never a flag — flags land in shell history
@@ -79,6 +91,8 @@ while [[ $# -gt 0 ]]; do
     --execute) MODE="execute"; shift ;;
     --i-am-authorized-by) AUTHORIZED_BY="${2:-}"; shift 2 ;;
     --allow-daemon) EXTRA_ALLOWED_DAEMON="${2:-}"; shift 2 ;;
+    --ssh-verify) SSH_VERIFY=1; shift ;;
+    --ssh-host) SSH_HOST_OVERRIDE="${2:-}"; shift 2 ;;
     --selftest) MODE="selftest"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "::error::unknown argument: $1"; usage; exit 2 ;;
@@ -90,6 +104,29 @@ note() { printf "\n=== %s ===\n" "$*"; }
 ok()   { printf "  ✓ %s\n" "$*"; PASS=$((PASS+1)); }
 bad()  { printf "  ✗ %s\n" "$*"; FAIL=$((FAIL+1)); }
 refuse() { echo "::error::REFUSING — $*"; exit 2; }
+
+# Maps a daemon to the ssh alias for its host. Returns "" when there is no
+# known alias — callers must refuse rather than guess a hostname.
+#
+# 🔴 daemon-vanisn is a WINDOWS host. The remote lookup below is POSIX
+# (`find`/`cat` under $HOME); Windows path and shell semantics differ, and an
+# untested remote command that happens to exit 0 would look exactly like a
+# successful verification. So --ssh-verify against it is reported as
+# NOT PROVEN instead of being attempted. Implementing it is a separate task.
+ssh_alias_for() {
+  case "$1" in
+    daemon-relay)   echo "relay" ;;
+    daemon-macmini) echo "mac" ;;
+    daemon-vanisn)  echo "win" ;;
+    *)              echo "" ;;
+  esac
+}
+ssh_verify_supported() {
+  case "$1" in
+    daemon-relay|daemon-macmini) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 daemon_is_allowed() {
   local want="$1" d
@@ -117,6 +154,19 @@ if [[ "$MODE" == "selftest" ]]; then
   st  daemon_is_allowed "prod-hub"               # unrelated node
   stn daemon_is_allowed "daemon-relay"           # the real thing must pass
   stn daemon_is_allowed "daemon-macmini"
+
+  # ssh alias mapping: a wrong/absent alias must never fall back to a guess
+  for pair in "daemon-relay:relay" "daemon-macmini:mac" "daemon-vanisn:win"; do
+    d="${pair%%:*}"; want="${pair##*:}"; got=$(ssh_alias_for "$d")
+    [[ "$got" == "$want" ]] && { printf "  ✓ [ssh_alias_for %s] → %s\n" "$d" "$got"; SPASS=$((SPASS+1)); } \
+                            || { printf "  ✗ [ssh_alias_for %s] → '%s', expected '%s'\n" "$d" "$got" "$want"; SFAIL=$((SFAIL+1)); }
+  done
+  [[ -z "$(ssh_alias_for "some-other-node")" ]] \
+    && { printf "  ✓ [ssh_alias_for some-other-node] → empty (refuses to guess a hostname)\n"; SPASS=$((SPASS+1)); } \
+    || { printf "  ✗ [ssh_alias_for some-other-node] returned a hostname — would ssh somewhere unintended\n"; SFAIL=$((SFAIL+1)); }
+  st  ssh_verify_supported "daemon-vanisn"    # Windows: must NOT claim support
+  stn ssh_verify_supported "daemon-relay"
+  stn ssh_verify_supported "daemon-macmini"
 
   # temp child naming must be unique per run and carry the acceptance prefix,
   # because the cleanup step keys on that prefix as a second safety net.
@@ -154,6 +204,12 @@ UTOK="${!TOKEN_ENV:-}"
 [[ "$UTOK" == utok_* ]] || refuse "\$$TOKEN_ENV does not look like a user token"
 if [[ "$MODE" == "execute" ]]; then
   [[ -n "$AUTHORIZED_BY" ]] || refuse "--execute requires --i-am-authorized-by <who> (recorded in the report)"
+fi
+if [[ "$SSH_VERIFY" -eq 1 ]]; then
+  SSH_HOST="${SSH_HOST_OVERRIDE:-$(ssh_alias_for "$DAEMON_NAME")}"
+  [[ -n "$SSH_HOST" ]] || refuse "--ssh-verify: no ssh alias known for '$DAEMON_NAME' (pass --ssh-host explicitly; do not let it guess a hostname)"
+  ssh_verify_supported "$DAEMON_NAME" \
+    || refuse "--ssh-verify is not implemented for '$DAEMON_NAME' (Windows host: POSIX find/cat do not apply). Re-run without --ssh-verify, or implement it deliberately."
 fi
 ok "flags validated (mode=$MODE daemon=$DAEMON_NAME)"
 
@@ -253,7 +309,33 @@ else
   echo "    config_snapshot did not surface flags.maxTurns within 60s. That may mean"
   echo "    the hub does not mirror this flag, not that the patch failed."
   echo "    On-disk application is proven in tests/qa-daemon-lifecycle-e2e (container,"
-  echo "    same filesystem). Proving it HERE requires SSH to $DAEMON_NAME — out of scope."
+  echo "    same filesystem). Pass --ssh-verify to prove it here too."
+fi
+
+if [[ "$SSH_VERIFY" -eq 1 ]]; then
+  echo "  · --ssh-verify: reading the child's config.json on '$SSH_HOST' (read-only)"
+  # We do NOT guess the path. The daemon's workDir never reaches the hub
+  # (cli.ts's `nodeDir` feeds the grok MCP wiring, not a hub field), so the
+  # target machine is asked to locate the file under $HOME instead.
+  # BatchMode=yes so it can never sit waiting on a passphrase prompt;
+  # bounded depth; both commands are strictly read-only.
+  REMOTE_CFG=$(ssh -o BatchMode=yes -o ConnectTimeout=10 "$SSH_HOST" \
+    "find \"\$HOME\" -maxdepth 8 -path '*/.anet/nodes/$CHILD_NAME/config.json' -type f 2>/dev/null | head -1" 2>/dev/null)
+  if [[ -z "$REMOTE_CFG" ]]; then
+    # 🔴 NOT a failure. A different directory layout and a failed patch look
+    # identical from here, and calling this red would be asserting more than
+    # we measured. It is also not a pass — it is printed as unproven.
+    echo "  · NOT PROVEN: could not locate the child's config.json under \$HOME on '$SSH_HOST'."
+    echo "    That may be a different layout, not a failed patch. Not counted either way."
+  else
+    REMOTE_VAL=$(ssh -o BatchMode=yes -o ConnectTimeout=10 "$SSH_HOST" "cat '$REMOTE_CFG'" 2>/dev/null | jq -r '.flags.maxTurns // empty')
+    if [[ "$REMOTE_VAL" == "99" ]]; then
+      ok "ON-DISK on '$SSH_HOST': flags.maxTurns=99 — the patch reached the real machine ($REMOTE_CFG)"
+    else
+      # Found the file and the value is wrong: that IS a finding.
+      bad "on-disk value on '$SSH_HOST' is '${REMOTE_VAL:-<absent>}', expected 99 — file: $REMOTE_CFG"
+    fi
+  fi
 fi
 
 note "P4. 操作 — restart_node"

--- a/tests/lib/daemon-hub-assertions.sh
+++ b/tests/lib/daemon-hub-assertions.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Hub-side terminal-state assertions for daemon node lifecycle.
+#
+# WHY THIS FILE EXISTS
+# These predicates started life inside tests/qa-daemon-lifecycle-e2e/run.sh
+# (#1280). They are extracted here so the container e2e and the real-machine
+# acceptance script judge node state with THE SAME criterion rather than two
+# lookalikes written months apart. When two scripts "assert the same thing"
+# by convention, they drift; when they call the same function, they cannot.
+#
+# 🔴 Follow-up once #1280 lands: change tests/qa-daemon-lifecycle-e2e/run.sh
+# to source this file too. Until then the e2e keeps its own copies and the
+# sameness is by inspection, not by mechanism — which is exactly the weaker
+# guarantee this file exists to replace.
+#
+# SCOPE — read this before reusing.
+# Everything here judges the HUB's view. It deliberately contains no
+# file-level or process-level predicate, because those cannot be evaluated
+# for a node running on another machine: the e2e can stat the child's
+# config.json and pgrep its process only because container and child share
+# a filesystem and a PID namespace. A real-machine run would need SSH to the
+# target host to make the same claims. Do not paper over that difference by
+# asserting something weaker and calling it equivalent.
+#
+# Contract: every function takes the hub base URL and a user token as its
+# first two arguments — no globals — so a caller cannot accidentally judge
+# one hub while believing it judged another.
+
+# Raw single field of one node, or the empty string. Never fails the caller;
+# an unreachable hub and a missing field both yield "" — so callers that need
+# to tell those apart must check reachability separately (see hub_reachable).
+hub_node_field() {
+  local base="$1" tok="$2" node_id="$3" jqpath="$4"
+  curl -sS --max-time 15 "$base/api/nodes?node_id=$node_id" \
+    -H "Authorization: Bearer $tok" 2>/dev/null \
+    | jq -r "$jqpath // empty" 2>/dev/null
+}
+
+hub_reachable() {
+  local base="$1"
+  curl -fsS --max-time 10 "$base/health" >/dev/null 2>&1
+}
+
+hub_node_exists() {
+  local base="$1" tok="$2" node_id="$3"
+  [[ -n "$(hub_node_field "$base" "$tok" "$node_id" '.nodes[0].node_id')" ]]
+}
+
+# lifecycle_state is the terminal state stop_node/restart_node converge to.
+# Same predicate the e2e uses for its red gate (asserted BEFORE stop, where
+# it must be false) and for its green assertion (asserted after).
+hub_lifecycle_is() {
+  local base="$1" tok="$2" node_id="$3" want="$4"
+  [[ "$(hub_node_field "$base" "$tok" "$node_id" '.nodes[0].lifecycle_state')" == "$want" ]]
+}
+
+# 🔴 The daemon's role is NOT nodes[0].role — it lands in config_snapshot,
+# which the daemon reports AFTER registering. Reading the wrong field yields
+# "" and looks exactly like "the product did not set a role". The fallback to
+# .role is kept only so a hub that later promotes the field keeps working.
+hub_role_is() {
+  local base="$1" tok="$2" node_id="$3" want="$4"
+  [[ "$(hub_node_field "$base" "$tok" "$node_id" '.nodes[0].config_snapshot.role // .nodes[0].role')" == "$want" ]]
+}
+
+# Poll until a predicate holds. Returns 1 on timeout — callers must not
+# treat a timeout as success. Prints nothing; the caller reports.
+hub_wait_until() {
+  local timeout="$1"; shift
+  local i
+  for ((i=0; i<timeout; i++)); do
+    "$@" && return 0
+    sleep 1
+  done
+  return 1
+}
+
+# The full set of node_ids the hub currently knows about, sorted, one per
+# line. Used to prove an acceptance run left nothing behind: comparing this
+# before and after is a claim about REALITY, whereas "we called delete_node"
+# is only a claim about what we asked for.
+hub_node_id_set() {
+  local base="$1" tok="$2"
+  curl -sS --max-time 20 "$base/api/nodes" -H "Authorization: Bearer $tok" 2>/dev/null \
+    | jq -r '.nodes[]?.node_id' 2>/dev/null | sort
+}


### PR DESCRIPTION
> ### 🔴 前提状态更新（2026-08-27 晚）
>
> 原文写的是「真机执行时机由 @通信龙 确认（**生产 hub 升级 #1279 之前跑没有意义**）」。
> **那句话今天已经过期**，阻塞点换了一格：
>
> | | 当时 | 现在 |
> |---|---|---|
> | #1279 的修复有没有产物 | ❌ 没发 | ✅ 已随 `commhub-server@0.9.0-preview.32/.33` 发到 npm |
> | 生产 hub 跑的版本 | `.31` | **仍是 `.31`** ← 现在卡在这里 |
>
> ⇒ **不再是「等发版」，是「等生产 hub 升级并重启」。** 升上去之前跑这个脚本仍然没有意义
> （它的 P1–P7 判据里包含在线判定与时区那部分行为）。
>
> 依旧 **请勿合并、请勿执行**。

> **交审用,请勿合并、请勿执行。** 本脚本**未对任何真机或生产 hub 执行过**。
> 真机执行时机由 @通信龙 确认(生产 hub 升级 #1279 之前跑没有意义)。

## 目标

Vincent 的目标:从客户端对 relay / Mac Mini 上的真 daemon 完成 **查看 / 创建 / 编辑 / 操作 / 删除** 一个节点。脚本按这五步排成 P1–P6,外加 P0 身份确认与 **P7 残留证明**。

## 判据不重写

hub 侧判据抽到 `tests/lib/daemon-hub-assertions.sh`,与 `tests/qa-daemon-lifecycle-e2e`(#1280)**共用同一组函数**。两个脚本调用同一个函数不会漂移;「各自断同一件事」一定会。

🔴 **#1280 合入后应改为 source 同一个 lib**(单独一个小 PR)。在那之前,一致性靠人对照 —— 正是这个 lib 想替换掉的那种弱保证。

## 明确不做的事(写在脚本里,没藏)

**不做任何文件级 / 进程级断言。** 子节点跑在另一台机器上;容器 e2e 能 `stat` 它的 `config.json`、`pgrep` 它的进程,**只因为共享文件系统和 PID 命名空间**。在这里声称同样的结论需要 SSH 到目标机。**不用一个更弱的断言冒充等价的。**

具体到 P3(编辑):脚本先断 hub 接受了 patch,再尝试等 `config_snapshot.flags.maxTurns` 收敛。若未收敛,它**打印**「这一格未被证明,可能只是 hub 不镜像该字段,不等于 patch 失败」,而不是静默跳过 —— 磁盘生效那一格由 #1280 在容器里证明。

## 护栏(全部 fail-closed;`exit 2` = 拒跑 / 无法判断)

| 护栏 | 为什么 |
|---|---|
| 默认 dry-run,写操作需 `--execute` **且** `--i-am-authorized-by <who>` | 授权人记进报告 |
| `--hub` 必须显式传,**无环境变量兜底** | 一个默认值会让手滑打到生产 |
| 目标 daemon 必须在白名单,**校验排在联网之前** | 打错名字不该先连上去再说 |
| 必须确认 `role=host_supervisor` | 拒绝向非 daemon 发 `create_node` |
| 临时子节点名 `acc-<ts>-<rand>`;清理**只针对本次记录的 node_id** | **绝不枚举后删除** —— 枚举一旦出错删的是别人的节点 |
| 基线节点集为空则拒跑 | 0 个节点和「读不到节点」打印出来一样 |
| P7 前后节点全集比对 | `comm -13` 查残留、`comm -23` 查**是否误删了原有节点**。「我调用了 delete」只是关于请求的主张,不是关于现实的 |
| token 从环境变量读,不走 flag | flag 会进 shell history 和 `ps` |

## 护栏已见证会拒(不是"写了就算")

`--selftest`(纯本地,不连任何 hub)**9/9**,每行打印实际输入而不只是函数名 —— 否则改了白名单输出会一模一样。

端到端 8 条无效输入,**全部 `rc=2`,且 8 条理由互不相同**:

```
rc=2  缺 --hub                  | --hub is required (no default: a default would let a typo hit production)
rc=2  daemon 拼错              | daemon 'daemon-relayy' is not in the allow-list
rc=2  daemon 不在白名单        | daemon 'prod-hub' is not in the allow-list
rc=2  token 未设               | $ANET_ACCEPT_UTOK is empty — cannot authenticate
rc=2  token 格式不对           | $ANET_ACCEPT_UTOK does not look like a user token
rc=2  --execute 缺授权人       | --execute requires --i-am-authorized-by <who>
rc=2  hub 不是 URL             | --hub must be a full URL, got 'notaurl'
rc=2  hub 不可达               | hub http://127.0.0.1:1 is not reachable (/health) — cannot judge
```

目标地址用 `127.0.0.1:1`(保留端口,必然不可达),token 用假值 —— **全程未接触任何真实服务**。`daemon-relayy` 那条尤其值得看:它在**联网之前**就被拒了。

## 四个需要你拍板的点

1. **白名单名字对不对**:我按你消息里写的 `daemon-relay` / `daemon-macmini`。如果真机上的 `node_name`/`alias` 不是这两个字符串,脚本会在 P0 拒跑(这是期望行为,但你先确认更省一轮)。
2. **hub 地址**:仓库政策不写死真实域名,所以只能 `--hub` 传参。执行时由你给。
3. **P3 要不要 SSH 版本**:如果要在真机上也证明「磁盘上的 config.json 真的变了」,需要 SSH 到 relay/macmini。那是另一套授权,我没做。你说要,我再加一个显式 `--ssh-verify` 分支。
4. **执行时机**:等 #1279(online 恒 false)合入并升级生产 hub 之后。

## 查重

按【改动文件】求交集,60 个 open PR:`scripts/daemon-live-acceptance.sh` 与 `tests/lib/daemon-hub-assertions.sh` **均零命中**。`tests/lib/` 下现有 5 个文件无同名、无同职责。

