### PR TITLE
chore(release): previews agent-network .51 / agent-node .37

### DIFF
--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.50",
+  "version": "2.3.0-preview.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.50",
+      "version": "2.3.0-preview.51",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.50",
+  "version": "2.3.0-preview.51",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.50";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.36";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.51";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.37";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.36",
+  "version": "2.5.0-preview.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.36",
+      "version": "2.5.0-preview.37",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.36",
+  "version": "2.5.0-preview.37",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"


### PR DESCRIPTION
版本 bump，为发 preview 做准备（用 scripts/sync-pinned-versions.sh --apply 生成，未手改任何版本字段）。

## 这一版带什么
今天下午合入 main、在 .50 之后的四单：
- **#1276** 节点回执 originator 未命中不再误断言成 `hub`（回执被拒/投错频道）
- **#1277** hub 推送不再被 `last_seen` 老化闸静默吞掉（安静会话收不到消息）
- **#1279** `list_host_supervisors` 的 online 按 UTC 解析 + 窗口 60s→5min（daemon 恒显示离线）
- **#1280** daemon 生命周期 E2E 进 CI

前两条合起来是「消息可达性」两半根因；第三条是 Dashboard 选服务器不可用的根因。

## 发布方式
合入后走 `release-gate (v0)` workflow_dispatch，`publish=true`（该输入只发 **preview** 通道，永不发 latest），分支来源 **main** —— 符合今日新增的 CLAUDE.md 规则「对外发布一律从 main 分支出」。

升级生产 hub 是**另一件事**，需 owner 明确点头，不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)