### PR TITLE
docs(daemon): 新增「让 daemon 在后台活下去」一节（中英）

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -100,11 +100,54 @@ anet daemon up
 ```
 
 🔴 **`anet daemon up` 会一直占着这个终端**（daemon 是常驻进程）。
-要放后台就另开一个终端，或用本页下半部分的 PM2 方案守护它。
+要放后台见下面一节 [让 daemon 在后台活下去](#keep-daemon-alive)。
 
 ⚠️ 注意那段 **Permission posture**：daemon 默认带
 `dangerouslySkipPermissions` + `teammateMode`，并且能通过 hub 派生子节点。
 **只在你信得过的机器上跑它。** 要收紧就改 `.anet/nodes/daemon/config.json`。
+
+### 3.5 让 daemon 在后台活下去 {#keep-daemon-alive}
+
+`anet daemon start` 是前台常驻进程。**如果你是 SSH 上去起的，会话一断它就没了** ——
+下面三条是 2026-08-27 在三台真机上逐台踩通的（每条都用「断开会话后再查 hub 心跳」验过，
+不是靠启动横幅判断）。
+
+**Linux / macOS —— `nohup` 起，验心跳**
+
+```bash
+cd ~                       # daemon 配置是 cwd 相关的，起在 init 时的同一个目录
+nohup anet daemon start <name> > ~/daemon-<name>.log 2>&1 &
+sleep 25 && tail -5 ~/daemon-<name>.log      # 看到「已注册到 CommHub」+「SSE connected」
+```
+断开 SSH 后隔 3 分钟以上再查 hub 的 `last_seen_at`：**还在刷新才算真常驻**。
+要崩溃自动拉起，用本页下半部分的 PM2 方案（把 `anet daemon start <name>` 当作被守护的命令）。
+
+**Windows —— 不能用 PowerShell Job**
+
+```powershell
+# ✗ Start-Job：SSH 会话结束时连同 Job 一起被回收，daemon 静默消失
+# ✓ WMI 创建进程：脱离会话树
+Invoke-CimMethod -ClassName Win32_Process -MethodName Create `
+  -Arguments @{ CommandLine = "C:\Users\<you>\start-daemon.bat" }
+```
+`start-daemon.bat` 内容（**用 .bat 包装，别把长命令行直接塞给 WMI**——带引号和
+重定向的长命令行会返回 `ReturnValue=21`「参数非法」）：
+```bat
+@echo off
+cd /d C:\Users\<you>
+anet daemon start <name> >> C:\Users\<you>\daemon-<name>.log 2>&1
+```
+
+🔴 **两个真踩过的坑**：
+
+1. **cwd 决定 daemon 找不找得到自己**。`anet daemon init` 把配置写在**当时的工作目录**下的
+   `.anet/nodes/<name>/`。用后台方式启动时如果工作目录变了，会报
+   `Daemon "<name>" not found. Create it first:` —— 配置其实在，只是没在那儿找。
+   所以后台命令里要显式 `cd` 回 init 时的目录。
+   （Windows 上尤其容易中：SSH 登录的 cwd 可能不是 `C:\Users\<用户名>` ——
+   用户名和 profile 目录名不一定同名。）
+2. **别拿启动输出当就绪判据**。判据是 hub 侧：`anet daemon list` 只读本机配置、
+   列出来不等于 hub 认得它；要看 hub 的节点状态里 `last_seen_at` 在持续刷新。
 
 ### 4. 确认它真的起来了
 

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -103,12 +103,59 @@ Real output:
 ```
 
 🔴 **`anet daemon up` holds the terminal** — a daemon is a long-running process.
-Use a second terminal, or supervise it with the PM2 setup in the rest of this page.
+To background it, see [Keeping a daemon alive](#keep-daemon-alive) below.
 
 ⚠️ Note the **Permission posture** block: a daemon runs with
 `dangerouslySkipPermissions` + `teammateMode` and can fork child nodes through the hub.
 **Only run one on a machine you trust to act on your behalf.** To tighten it, edit
 `.anet/nodes/daemon/config.json`.
+
+### 3.5 Keeping a daemon alive {#keep-daemon-alive}
+
+`anet daemon start` runs in the foreground. **If you started it over SSH, it dies with the
+session.** The three recipes below were each walked through on a real machine on 2026-08-27
+and verified the same way: **disconnect, then check that the hub-side heartbeat is still
+advancing** — never by trusting the startup banner.
+
+**Linux / macOS — `nohup`, then verify the heartbeat**
+
+```bash
+cd ~                       # daemon config is cwd-relative: start it where you ran init
+nohup anet daemon start <name> > ~/daemon-<name>.log 2>&1 &
+sleep 25 && tail -5 ~/daemon-<name>.log   # expect "registered to CommHub" + "SSE connected"
+```
+After disconnecting, wait 3+ minutes and re-read `last_seen_at` on the hub:
+**only a still-advancing heartbeat proves it survived.** For crash-restart, use the PM2
+setup in the rest of this page with `anet daemon start <name>` as the supervised command.
+
+**Windows — a PowerShell Job will not survive**
+
+```powershell
+# ✗ Start-Job: reclaimed together with the SSH session; the daemon vanishes silently
+# ✓ WMI process creation: detaches from the session tree
+Invoke-CimMethod -ClassName Win32_Process -MethodName Create `
+  -Arguments @{ CommandLine = "C:\Users\<you>\start-daemon.bat" }
+```
+`start-daemon.bat` (**wrap it in a .bat** — passing a long command line with quotes and
+redirection straight to WMI returns `ReturnValue=21`, "invalid parameter"):
+```bat
+@echo off
+cd /d C:\Users\<you>
+anet daemon start <name> >> C:\Users\<you>\daemon-<name>.log 2>&1
+```
+
+🔴 **Two traps hit for real:**
+
+1. **cwd decides whether the daemon can find itself.** `anet daemon init` writes the config
+   under the **working directory at that moment** (`.anet/nodes/<name>/`). Start it in the
+   background from somewhere else and you get
+   `Daemon "<name>" not found. Create it first:` — the config exists, it just isn't there.
+   So the background command must `cd` back to the init directory.
+   (Easy to hit on Windows: the SSH login cwd may not be `C:\Users\<username>` — the
+   account name and the profile directory name need not match.)
+2. **Startup output is not a readiness check.** `anet daemon list` only reads local config;
+   being listed does not mean the hub knows about it. The criterion is hub-side:
+   `last_seen_at` still advancing.
 
 ### 4. Confirm it actually came up
 


### PR DESCRIPTION
## 缺口
`docs-site/docs/deploy/daemon.md` 讲了「让 **Hub** 常驻」（PM2/systemd），但没讲「让 **daemon** 常驻」——而 daemon 恰恰是大家 SSH 上去起的那个进程，**会话一断就没**。原文只有一句「另开一个终端」。

## 内容
三条配方，都是 2026-08-27 在三台真机上逐台踩通的（中继机 Linux / Mac Mini / Windows VANISN），判据统一：**断开会话后 hub 侧 `last_seen_at` 仍在推进**才算数，不认启动横幅。

两个真撞过的坑：
1. **cwd 决定 daemon 找不找得到自己** —— `anet daemon init` 把配置写在当时的工作目录下；后台启动换了目录就报 `Daemon "<name>" not found`，而配置其实在。Windows 上更易中（SSH 登录 cwd 未必是 `C:\Users\<用户名>`，账号名与 profile 目录名可以不同）。
2. **Windows 上 PowerShell Job 会随 SSH 会话被回收** —— 要用 WMI `Win32_Process.Create`；且长命令行直传会 `ReturnValue=21`（参数非法），必须用 `.bat` 包装。

中英同步更新（qa-paths-symmetry 口径）。纯文档，无代码改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)