### PR TITLE
docs(getting-started): preview 版本戳 .49 → .51（解开 gate 4 对 .51 发布的拦截）

### DIFF
--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.49 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.51 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,6 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
+| `2.3.0-preview.51` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.49 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.51 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,6 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
+| `2.3.0-preview.51`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 


### PR DESCRIPTION
## 为什么
`release-gate (v0)` 对 agent-network@2.3.0-preview.51 红在 **gate 4 — 上手指南里的版本断言**：中英两份 getting-started 的 `version-claim` 戳仍写着 preview=`2.3.0-preview.49`。

（agent-node@2.5.0-preview.37 **已发布成功**，npm preview 通道已更新；卡住的只有 agent-network 这一个。）

## 怎么改的
门的原话：「🔴 不要只改戳 —— 戳和正文不一致时这道门也会红」。所以正文也动了：表格新增 `.51` 一行。

🔴 **没有假装重测**：那一行如实写明依据是「生成 bootstrap 密码的 `server/src/auth.ts` 自 `.49` 发布（2026-08-27T02:25Z）起**零提交**，逻辑逐字未变」，而不是一次并未发生的容器实测。原本要真跑一遍，但 `.51` 还没上 npm（正是被这道门挡着），从源码 pack 的 tarball 在容器里 `npm i -g` 后 `anet` 不在 PATH——那是另一个问题，不在本 PR 范围。

## 验证
跑那道门本身（不自造判据）：
```
python3 scripts/check-doc-version-claims.py --package agent-network --version 2.3.0-preview.51
checked 4 version-claim stamp(s) across 2 doc(s); releasing agent-network@2.3.0-preview.51 (preview)
每一条被标记的版本断言都指着正在发的那个版本。   rc=0
```
中英同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)