### PR TITLE
docs(daemon): ANET_BIN 钉死配置（否则 daemon 起得来却创建不了节点）

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -149,6 +149,49 @@ anet daemon start <name> >> C:\Users\<you>\daemon-<name>.log 2>&1
 2. **别拿启动输出当就绪判据**。判据是 hub 侧：`anet daemon list` 只读本机配置、
    列出来不等于 hub 认得它；要看 hub 的节点状态里 `last_seen_at` 在持续刷新。
 
+### 3.6 让 daemon 能真的创建节点：`ANET_BIN` 钉死 {#anet-bin-pin}
+
+🔴 **daemon 起来 ≠ 能干活。** 第一次通过 hub 让它创建节点时，很可能看到：
+
+```
+[create-node] anet_bin_unsafe_path: no ANET_BIN_ABS resolved
+              (neither /etc/anet-daemon/path.conf nor env)
+```
+
+这是**供应链保护**，不是 bug：daemon 会 fork 出真实进程，所以它拒绝走 `PATH` 去找
+`anet`（`PATH` 可被劫持），只接受一个**钉死并校验过**的绝对路径。校验五条，缺一不可：
+
+| # | 要求 | npm 标准安装下的实际情况 |
+|---|---|---|
+| ① | 绝对路径 | ✅ |
+| ② | 路径中**无 symlink**（`realpath` 等于自身） | ❌ `npm i -g` 装出来的 `bin/anet` 就是 symlink |
+| ③ | 属主 root | ❌ 装在用户目录（nvm / `--prefix ~`）时属主是你 |
+| ④ | **不可被 group/other 写**（`mode & 0o022 == 0`） | ❌ **umask 0002 的机器上 npm 产物是 `775`** |
+| ⑤ | 可执行 | ✅ |
+
+②③④ 三条在「用 nvm 装、机器 umask 0002」这种**很常见**的组合下会同时不满足。
+
+**配法**（先取真实路径，再收紧权限，最后钉死）：
+
+```bash
+BIN=$(readlink -f "$(command -v anet)")   # ② 解掉 symlink，拿到 dist/bin/anet.cjs
+chmod go-w "$BIN"                          # ④ 775 → 755
+stat -c '%a %U %n' "$BIN"                  # 复核：755，属主是你
+
+# 启动 daemon 时钉死它
+ANET_BIN_ABS="$BIN" ANET_DAEMON_ALLOW_NON_ROOT_BIN=1   nohup anet daemon start <name> >> ~/daemon-<name>.log 2>&1 &
+```
+
+- `ANET_DAEMON_ALLOW_NON_ROOT_BIN=1` 是③的显式豁免——**只在你确信该文件只有你能改时用**。
+  root 安装（`sudo npm i -g`）不需要它。
+- 也可以写进 `/etc/anet-daemon/path.conf`（daemon 优先读它），格式见
+  `loadAndVerifyAnetBin` 的 `readPathConf`。想再紧一档可以带 `sha256`：
+  安装时的哈希与运行时不一致会直接拒启动。
+
+**判据**：配好之后，从 hub 发一次 `create_node`，daemon 日志应出现
+`[create-node] spawned child '<name>' pid=…` 和 `+5000ms capability check OK`，
+且新节点自己注册回 hub。**看不到这两行就是没配对**——它不会重试。
+
 ### 4. 确认它真的起来了
 
 ```bash

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -157,6 +157,53 @@ anet daemon start <name> >> C:\Users\<you>\daemon-<name>.log 2>&1
    being listed does not mean the hub knows about it. The criterion is hub-side:
    `last_seen_at` still advancing.
 
+### 3.6 Let the daemon actually create nodes: pin `ANET_BIN` {#anet-bin-pin}
+
+🔴 **A running daemon is not a working daemon.** The first time you ask it to create a node
+through the hub, you will likely see:
+
+```
+[create-node] anet_bin_unsafe_path: no ANET_BIN_ABS resolved
+              (neither /etc/anet-daemon/path.conf nor env)
+```
+
+That is **supply-chain protection**, not a bug: the daemon forks real processes, so it
+refuses to resolve `anet` through `PATH` (hijackable) and only accepts a **pinned, verified**
+absolute path. Five checks, all required:
+
+| # | Requirement | Reality under a standard npm install |
+|---|---|---|
+| ① | absolute path | ✅ |
+| ② | **no symlink** in the path (`realpath` equals itself) | ❌ `npm i -g` installs `bin/anet` as a symlink |
+| ③ | owned by root | ❌ not when installed under your home (nvm / `--prefix ~`) |
+| ④ | **not group/other-writable** (`mode & 0o022 == 0`) | ❌ **on a umask 0002 machine npm payloads are `775`** |
+| ⑤ | executable | ✅ |
+
+②③④ all fail together under the very common "installed via nvm, machine umask 0002" combo.
+
+**How to configure it** (resolve the real path, tighten the mode, then pin):
+
+```bash
+BIN=$(readlink -f "$(command -v anet)")   # ② resolve the symlink to dist/bin/anet.cjs
+chmod go-w "$BIN"                          # ④ 775 → 755
+stat -c '%a %U %n' "$BIN"                  # verify: 755, owned by you
+
+# Pin it when starting the daemon
+ANET_BIN_ABS="$BIN" ANET_DAEMON_ALLOW_NON_ROOT_BIN=1 \
+  nohup anet daemon start <name> >> ~/daemon-<name>.log 2>&1 &
+```
+
+- `ANET_DAEMON_ALLOW_NON_ROOT_BIN=1` is the explicit opt-out for ③ — **use it only when you
+  are sure nobody else can write that file.** A root install (`sudo npm i -g`) does not need it.
+- You can also write it into `/etc/anet-daemon/path.conf` (the daemon reads that first); see
+  `readPathConf` in `loadAndVerifyAnetBin`. For one more notch, include a `sha256`: a mismatch
+  between install-time and run-time hashes refuses startup outright.
+
+**Criterion**: once pinned, issue one `create_node` from the hub; the daemon log must show
+`[create-node] spawned child '<name>' pid=…` plus `+5000ms capability check OK`, and the new
+node must register itself back to the hub. **Without those two lines it is not wired up** —
+it will not retry.
+
 ### 4. Confirm it actually came up
 
 ```bash


### PR DESCRIPTION
## 实测触发
2026-08-27 在中继机上铺好 daemon 后，第一次从 hub 发 `create_node`：

```
[create-node] anet_bin_unsafe_path: no ANET_BIN_ABS resolved
              (neither /etc/anet-daemon/path.conf nor env)
```

daemon 在线、SSE connected、doorbell 也收到了 —— **但不能干活**。文档此前**完全没有提到 `ANET_BIN`**。

## 为什么这不是边缘情况
五条校验中的 ②③④ 在「用 nvm 装 + 机器 umask 0002」这个很常见的组合下**同时**不满足：
- ② `npm i -g` 的 `bin/anet` 是 symlink
- ③ 装在用户目录 ⇒ 属主不是 root
- ④ umask 0002 ⇒ npm 产物 `775`，group 可写

也就是说**每一台按标准方式装 anet 的机器**都会在第一次创建节点时撞上这堵墙。

## 内容
完整配法（`readlink -f` 解 symlink → `chmod go-w` → `ANET_BIN_ABS` + 非 root 显式豁免），说明 `/etc/anet-daemon/path.conf` 与可选 `sha256` 的更严一档，并写明**判据**：daemon 日志出现 `spawned child` + `+5000ms capability check OK` 才算配对，看不到就是没配上 —— **它不会重试**。

中英同步。纯文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)