### PR TITLE
docs(daemon): ANET_BIN 补 Windows 现状说明（配不通 + 症状具欺骗性）

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -188,6 +188,18 @@ ANET_BIN_ABS="$BIN" ANET_DAEMON_ALLOW_NON_ROOT_BIN=1   nohup anet daemon start <
   `loadAndVerifyAnetBin` 的 `readPathConf`。想再紧一档可以带 `sha256`：
   安装时的哈希与运行时不一致会直接拒启动。
 
+🔴 **Windows 目前配不通，这不是你的配置问题**（2026-08-27 实测，见 [#1290](https://github.com/sleep2agi/agent-network/issues/1290)）：
+上面①那条判断在代码里是 `pin.abs.startsWith("/")` —— **POSIX-only**，而 Windows 的绝对路径
+是 `C:\...`，永远不以 `/` 开头，所以无论把 `ANET_BIN_ABS` 设成什么都会得到
+`anet_bin_unsafe_path: not absolute:`。而且即使放宽它，③④在 Windows 上也不成立
+（Node 在 Windows 的 `uid` 恒为 0 ⇒ 属主检查恒过；POSIX mode 位不反映 ACL ⇒ 权限检查
+不表达任何真实权限）。
+
+⚠️ **症状具有欺骗性**：这台 daemon 会**正常注册、正常心跳、正常收到 doorbell**，
+hub 侧一切看着都对，Dashboard 的「选服务器」也会把它列为可选；
+`create_node` 甚至返回 `ok:true` + request_id —— 失败只写在 daemon 本机日志里。
+**所以在 #1290 修复前：Windows 机器可以跑 daemon 做心跳/遥测，但不要指望它 fork 出子节点。**
+
 **判据**：配好之后，从 hub 发一次 `create_node`，daemon 日志应出现
 `[create-node] spawned child '<name>' pid=…` 和 `+5000ms capability check OK`，
 且新节点自己注册回 hub。**看不到这两行就是没配对**——它不会重试。

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -199,6 +199,20 @@ ANET_BIN_ABS="$BIN" ANET_DAEMON_ALLOW_NON_ROOT_BIN=1 \
   `readPathConf` in `loadAndVerifyAnetBin`. For one more notch, include a `sha256`: a mismatch
   between install-time and run-time hashes refuses startup outright.
 
+🔴 **Windows cannot be configured to pass this today — it is not your setup**
+(measured 2026-08-27, see [#1290](https://github.com/sleep2agi/agent-network/issues/1290)):
+check ① is literally `pin.abs.startsWith("/")` — **POSIX-only** — and a Windows absolute path
+(`C:\...`) never starts with `/`, so any `ANET_BIN_ABS` yields
+`anet_bin_unsafe_path: not absolute:`. Even with ① relaxed, ③ and ④ do not hold on Windows
+(Node reports `uid` as 0 there ⇒ the owner check always passes; POSIX mode bits do not reflect
+ACLs ⇒ the permission check asserts nothing real).
+
+⚠️ **The symptom is deceptive**: such a daemon **registers, heartbeats and receives doorbells
+normally**; everything looks right hub-side, the Dashboard server picker lists it as selectable,
+and `create_node` even returns `ok:true` with a request_id — the failure is written only to the
+daemon's local log. **Until #1290 is fixed: a Windows box can run a daemon for heartbeat and
+telemetry, but do not expect it to fork child nodes.**
+
 **Criterion**: once pinned, issue one `create_node` from the hub; the daemon log must show
 `[create-node] spawned child '<name>' pid=…` plus `+5000ms capability check OK`, and the new
 node must register itself back to the hub. **Without those two lines it is not wired up** —


### PR DESCRIPTION
补 #1289 的缺口。我在那个 PR 里写了 `ANET_BIN` 的 Linux/macOS 配法，但**没说 Windows 根本配不通** —— 读者照着配只会撞死在 `anet_bin_unsafe_path: not absolute`，还会以为是自己路径写错了。

依据是 #1290 的真机实测：
- ① `pin.abs.startsWith("/")` 是 **POSIX-only**，Windows 的 `C:\...` 永远不满足
- 即使放宽 ①，③④ 在 Windows 上也不成立（Node 在 Windows `uid` 恒为 0 ⇒ 属主检查恒过；POSIX mode 位不反映 ACL ⇒ 权限检查不表达任何真实权限）

**并写明症状形态**：这台 daemon 会正常注册、正常心跳、正常收 doorbell，hub 侧看不出异常，Dashboard 的「选服务器」会把它列为可选，`create_node` 还返回 `ok:true` —— 失败只写在 daemon 本机日志里。

给出明确边界：**修复前，Windows 可以跑 daemon 做心跳/遥测，但不要指望它 fork 子节点。**

中英同步。纯文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)