### PR TITLE
fix(daemon): delete_node did nothing after a stop, then acked anyway

### DIFF
--- a/agent-node/src/runtime/stop-daemon.test.ts
+++ b/agent-node/src/runtime/stop-daemon.test.ts
@@ -462,3 +462,120 @@ describe("rebuildChildrenMapOnBoot — real subprocess primitive (no pgrep mocks
     }
   });
 });
+
+// ── #1286 — 「先 stop 后 delete」这条真实路径 ───────────────────────
+//
+// stop 成功之后条目会被移出 childrenMap（本文件设计如此），而 delete 复用
+// 同一张表 ⇒ 未命中是**必然**不是偶发。而未命中分支原本对两个 action 共用
+// 一个早返回，于是 delete 什么都不做却 ack 出去，调用方零信号。
+//
+// 拿进程表决定文件系统清理是范畴错误：childrenMap 记的是运行中的进程，
+// 配置目录是盘上的事实，两者生命周期不同。
+describe("#1286 handleStopDoorbell — stop 之后再 delete", () => {
+  function seedWorkdir(root: string, alias: string) {
+    const dir = join(root, alias);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "config.json"), JSON.stringify({ alias }), "utf8");
+    return dir;
+  }
+
+  test("🔴 stop 成功（条目已移除）后 delete：配置目录必须真的被移走，而不是静默 no-op", async () => {
+    const workdirRoot = join(scratch, "nodes");
+    const deletedRoot = join(scratch, "deleted");
+    const alias = "child-1286";
+    const childId = "node_child_1286";
+    seedWorkdir(workdirRoot, alias);
+
+    // 第一步：stop —— 走命中路径，结束后条目被移除
+    recordSpawnedChild(childId, alias, 4242);
+    const stopH = makeDeps({
+      workdirRoot, deletedRoot,
+      getStopReturn: {
+        ok: true, request_id: "req-stop", child_node_id: childId, child_alias: alias,
+        action: "stop", delete_config: false, grace_seconds: 10, force: false,
+      },
+    });
+    await handleStopDoorbell({ request_id: "req-stop" }, stopH.deps as any);
+    expect(stopH.acks.at(-1)!.args.status).toBe("stopped");
+    // 前提断言：这条路径确实把条目移除了 —— 否则下面测的就不是那个场景
+    expect(getChildrenSnapshot().length).toBe(0);
+
+    // 第二步：delete —— childrenMap 必然未命中
+    const delH = makeDeps({
+      workdirRoot, deletedRoot,
+      getStopReturn: {
+        ok: true, request_id: "req-del", child_node_id: childId, child_alias: alias,
+        action: "delete", delete_config: true, grace_seconds: 10, force: false,
+      },
+    });
+    await handleStopDoorbell({ request_id: "req-del" }, delH.deps as any);
+
+    const ack = delH.acks.at(-1)!.args;
+    expect(ack.status).toBe("stopped");                 // hub 才会收敛（行删除 + 撤 ntok）
+    expect(ack.backup_path).toBeTruthy();
+    // 判据落在字节上：源目录消失、备份目录里能读到原文件
+    expect(() => statSync(join(workdirRoot, alias))).toThrow();
+    const moved = readdirSync(deletedRoot);
+    expect(moved.length).toBe(1);
+    expect(readdirSync(join(deletedRoot, moved[0]))).toContain("config.json");
+  });
+
+  // 🔴 这条我一开始写成期望 noop_not_my_child，验 hub 侧才发现那会复现原 bug：
+  //    server/src/tools.ts 的 ack_stop_request 对 noop_not_my_child **没有分支**，
+  //    只更新 request 行，nodes.lifecycle_state 停在 'deleting' —— 正是上报的症状。
+  //    delete 的终态是「不在跑 + 配置不在」，盘上本来就没有时该终态已成立 ⇒ 必须收敛。
+  test("未命中 + 盘上也没有该目录 ⇒ 仍 ack stopped 让 hub 收敛，但不给 backup_path", async () => {
+    const workdirRoot = join(scratch, "nodes");
+    const deletedRoot = join(scratch, "deleted");
+    mkdirSync(workdirRoot, { recursive: true });
+    const h = makeDeps({
+      workdirRoot, deletedRoot,
+      getStopReturn: {
+        ok: true, request_id: "req-none", child_node_id: "node_absent", child_alias: "absent-1286",
+        action: "delete", delete_config: true, grace_seconds: 10, force: false,
+      },
+    });
+    await handleStopDoorbell({ request_id: "req-none" }, h.deps as any);
+    const ack = h.acks.at(-1)!.args;
+    expect(ack.status).toBe("stopped");
+    expect(ack.backup_path).toBeUndefined();   // 区分「搬走了」和「本来就没有」
+  });
+
+  // 🔴 这条同样修正过：命中路径对「移动失败」的既有立场是**不让 delete 失败**
+  //    （子进程已不在，行仍应收敛，本地回收站泄漏靠 warn 暴露）。新分支若更严，
+  //    同一个条件在两条路径上就会有两种行为 —— 比任一种单独选择都差。
+  test("未命中 + 移动失败 ⇒ 与命中路径同立场：仍 ack stopped、无 backup_path、warn 里有原因", async () => {
+    const workdirRoot = join(scratch, "nodes");
+    const deletedRoot = join(scratch, "deleted");
+    const alias = "child-mvfail-1286";
+    seedWorkdir(workdirRoot, alias);
+    const h = makeDeps({
+      workdirRoot, deletedRoot,
+      getStopReturn: {
+        ok: true, request_id: "req-mvfail", child_node_id: "node_mvfail", child_alias: alias,
+        action: "delete", delete_config: true, grace_seconds: 10, force: false,
+      },
+    });
+    const warns: string[] = [];
+    (h.deps as any).warn = (m: string) => warns.push(m);
+    (h.deps as any).renameDir = () => { throw new Error("EXDEV cross-device"); };
+    await handleStopDoorbell({ request_id: "req-mvfail" }, h.deps as any);
+    const ack = h.acks.at(-1)!.args;
+    expect(ack.status).toBe("stopped");
+    expect(ack.backup_path).toBeUndefined();
+    expect(warns.join("\n")).toContain("EXDEV");
+    // 目录没被搬走这件事必须仍然看得见，而不是被 ack 盖掉
+    expect(statSync(join(workdirRoot, alias)).isDirectory()).toBe(true);
+  });
+
+  test("回归钉：action=stop 未命中时行为不变，仍是 noop_not_my_child", async () => {
+    const h = makeDeps({
+      getStopReturn: {
+        ok: true, request_id: "req-stop-miss", child_node_id: "node_absent", child_alias: "absent-1286",
+        action: "stop", delete_config: false, grace_seconds: 10, force: false,
+      },
+    });
+    await handleStopDoorbell({ request_id: "req-stop-miss" }, h.deps as any);
+    expect(h.acks.at(-1)!.args.status).toBe("noop_not_my_child");
+  });
+});

--- a/agent-node/src/runtime/stop-daemon.ts
+++ b/agent-node/src/runtime/stop-daemon.ts
@@ -126,6 +126,37 @@ async function waitForExit(
   return !isAlive(pid, signalProcess);
 }
 
+
+/** 把子节点的配置目录搬进回收站。命中与未命中两条 delete 路径共用它，
+ *  这样「移动失败怎么办」不会在两处各写一遍然后慢慢漂开。
+ *
+ *  立场沿用命中路径原有的选择：移动失败**不**让整个 delete 失败 —— 子进程
+ *  此时已经不在了，hub 侧的行应当收敛（删行 + 撤 ntok），本地回收站泄漏
+ *  通过 warn 暴露。调用方靠 backup_path 在与不在来区分「真搬走了」和
+ *  「盘上本来就没有」。 */
+function moveWorkdirToTrash(
+  child_alias: string,
+  workdirRoot: string,
+  deletedRoot: string,
+  deps: StopDoorbellDeps,
+  ensureDir: (p: string, mode: number) => void,
+  chmod: (p: string, mode: number) => void,
+  renameDir: (src: string, dst: string) => void,
+): string | null {
+  try {
+    ensureDir(deletedRoot, 0o700);
+    try { chmod(deletedRoot, 0o700); } catch { /* best-effort */ }
+    const dst = join(deletedRoot, `${Date.now()}-${child_alias}`);
+    renameDir(join(workdirRoot, child_alias), dst);
+    chmod(dst, 0o700);
+    deps.log(`[stop-daemon] backed up child workdir → ${dst} (chmod 700)`);
+    return dst;
+  } catch (e: any) {
+    deps.warn(`[stop-daemon] backup mv failed for ${child_alias}: ${e?.message || e}`);
+    return null;
+  }
+}
+
 export async function handleStopDoorbell(
   event: { request_id: string },
   deps: StopDoorbellDeps,
@@ -154,14 +185,50 @@ export async function handleStopDoorbell(
   const { child_node_id, child_alias, action, delete_config = true, grace_seconds = 10 } = req;
 
   const entry = childrenMap.get(child_node_id);
-  if (!entry) {
+  if (!entry && action !== "delete") {
     // §2.4 — degraded path, not an error. Daemon restart + pre-boot-
-    // rebuild scenario. Ack so hub can move on.
+    // rebuild scenario. Nothing to signal, so ack and let hub move on.
+    //
+    // 🔴 This early return is correct for `stop` and wrong for `delete`.
+    // childrenMap tracks RUNNING PROCESSES; a delete also has to remove an
+    // ON-DISK config directory, and those two have different lifetimes.
+    // Letting a process table decide a filesystem cleanup is a category
+    // error. See the delete branch below.
     deps.log(`[stop-daemon] child not in map (likely daemon-restarted): ${child_node_id}`);
     await deps.callCommHub("ack_stop_request", {
       request_id, status: "noop_not_my_child",
       error: "child not in children_map; daemon likely restarted before rebuild",
     }).catch(() => { /* ack failure → next sweeper picks up */ });
+    return;
+  }
+  if (!entry) {
+    // #1286 — delete without a map entry. This is not the rare
+    // daemon-restart case: a successful `stop` removes the entry, so
+    // stop-then-delete makes the miss GUARANTEED, not incidental.
+    //
+    // Nothing here needs the map. `child_alias` comes from the hub request
+    // (not from `entry`), and sweepOrphansForAlias finds processes by alias.
+    // The map only ever supplied `entry.pid`, which just the pgid signal in
+    // `stop` requires. So do the work instead of returning.
+    deps.log(`[stop-daemon] delete without map entry (expected after stop): ${child_node_id}`);
+    if (child_alias) {
+      await sweepOrphansForAlias(child_alias, signalProcess, deps, "delete without map entry");
+    }
+    const backup = (delete_config && child_alias)
+      ? moveWorkdirToTrash(child_alias, workdirRoot, deletedRoot, deps, ensureDir, chmod, renameDir)
+      : null;
+    // Ack `stopped` either way: the child is not running and its config is
+    // not in place, which IS delete's end state, so the hub must converge
+    // (row deleted + ntok revoked). Acking noop_not_my_child here would
+    // leave lifecycle_state stuck at 'deleting' — the reported symptom.
+    // `backup_path` present vs absent is what distinguishes "moved it" from
+    // "nothing was on disk"; a failed move is surfaced by warn, matching the
+    // stance the hit path already takes.
+    await deps.callCommHub("ack_stop_request", {
+      request_id, status: "stopped", ...(backup ? { backup_path: backup } : {}),
+    }).catch((e: any) => {
+      deps.warn(`[stop-daemon] ack failed: ${e?.message || e}`);
+    });
     return;
   }
 
@@ -241,26 +308,11 @@ export async function handleStopDoorbell(
   // §2.4 / §4.4 — for delete branch with delete_config=true, move the
   // child's workdir into the trash. chmod 700 on both the parent
   // (~/.anet/deleted) and the moved dir so secrets don't leak.
-  let backup_path: string | null = null;
-  if (action === "delete" && delete_config && child_alias) {
-    try {
-      ensureDir(deletedRoot, 0o700);
-      // chmod the parent too in case it pre-existed with looser perms.
-      try { chmod(deletedRoot, 0o700); } catch { /* best-effort */ }
-      backup_path = join(deletedRoot, `${Date.now()}-${child_alias}`);
-      const srcDir = join(workdirRoot, child_alias);
-      renameDir(srcDir, backup_path);
-      chmod(backup_path, 0o700);
-      deps.log(`[stop-daemon] backed up child workdir → ${backup_path} (chmod 700)`);
-    } catch (e: any) {
-      deps.warn(`[stop-daemon] backup mv failed for ${child_alias}: ${e?.message || e}`);
-      // Don't fail the whole stop — child process is already gone. Ack
-      // 'stopped' with backup_path=null so hub still finalizes; row is
-      // deleted, ntok revoked, and the daemon's local trash leak is
-      // surfaced via the warn log + next sweeper run.
-      backup_path = null;
-    }
-  }
+  // Shared with the no-map-entry delete branch above so the two paths cannot
+  // drift on "what happens when the move fails".
+  const backup_path: string | null = (action === "delete" && delete_config && child_alias)
+    ? moveWorkdirToTrash(child_alias, workdirRoot, deletedRoot, deps, ensureDir, chmod, renameDir)
+    : null;
 
   // PR1.2 e2e defense-in-depth: even after pgid signaling, sweep any
   // residual agent-node process matching this alias. Catches the case

--- a/tests/qa-rfc027-stop-delete/run.sh
+++ b/tests/qa-rfc027-stop-delete/run.sh
@@ -124,6 +124,31 @@ build_list_my_children_body() {
 JSON
 }
 
+# wait_child_in_daemon_map: block until the daemon has actually recorded the
+# child in its in-memory childrenMap.
+#
+# 🔴 Registering with the hub is NOT that moment. create-node-daemon.ts calls
+# recordSpawnedChild (:512) AFTER the +FAIL_FAST_MS capability check (:475),
+# so there is a ~5s window in which the hub knows the node and the daemon
+# cannot stop it — every stop/delete in that window acks noop_not_my_child.
+# That window is a separate defect from #1286; this helper keeps this suite
+# from silently testing it instead of what it means to test.
+#
+# The capability-check log line is emitted immediately before the record, so
+# waiting on it (for THIS child's pid) is tied to the real ordering rather
+# than to a guessed sleep.
+wait_child_in_daemon_map() {
+  local alias="$1" deadline=$(( $(date +%s) + ${2:-40} )) pid=""
+  while [[ $(date +%s) -lt $deadline ]]; do
+    pid=$(grep -oE "spawned child '$alias' pid=[0-9]+" /tmp/daemon-027.log 2>/dev/null | tail -1 | grep -oE '[0-9]+$')
+    if [[ -n "$pid" ]] && grep -q "capability check OK: pid=$pid " /tmp/daemon-027.log 2>/dev/null; then
+      echo "$pid"; return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
 # wait_stop_request_done: poll until node_stop_requests.status terminal.
 wait_stop_request_done() {
   local req_id="$1" deadline=$(( $(date +%s) + ${2:-30} ))
@@ -536,6 +561,79 @@ fi
 # node_create_requests.daemon_node_id keyed by child_node_id.
 # 3 cases from 通信龙 #348 ack: L1 normal / L2 cross-tenant / L3 missing.
 # (CHILD_L1 was spawned at A.1.SIBLING; it survived A.3 — now we stop it.)
+note "A.7 (#1286) stop THEN delete the SAME child — the path that actually breaks"
+# A.5 deletes a child that was never stopped, so the daemon's childrenMap
+# still has it (hit path). In real use the client stops a node and then
+# deletes it, and a successful stop REMOVES the entry — so the delete arrives
+# with the map already empty. That made the miss guaranteed, not incidental,
+# and the old shared early-return acked without doing anything.
+# Assertions below are the A.5 ones reused verbatim, against a child that took
+# the stop-then-delete route.
+CHILD_SD="rfc027-child-stopdel"
+BODY=$(build_create_node_body "$DAEMON_NODE_ID" "$CHILD_SD" "claude-agent-sdk" "claude-opus-rfc027-sd" "$NET_ID")
+RESP=$(mcp_call "$UTOK" "$BODY")
+REQ_ID_SD=$(echo "$RESP" | jq -r .request_id 2>/dev/null)
+CHILD_SD_NODE_ID="node_${REQ_ID_SD#cr_}"
+CHILD_SD_REG=""
+for _ in $(seq 1 40); do
+  if curl -sS "$HUB_BASE/api/nodes?node_id=$CHILD_SD_NODE_ID" -H "Authorization: Bearer $UTOK" \
+       | jq -e ".nodes[0].node_id == \"$CHILD_SD_NODE_ID\"" >/dev/null 2>&1; then
+    CHILD_SD_REG=yes; break
+  fi
+  sleep 1
+done
+[[ -n "$CHILD_SD_REG" ]] && ok "A.7 child registered ($CHILD_SD / $CHILD_SD_NODE_ID)" \
+  || bad "A.7 child never registered"
+# Premise: the daemon must actually have this child in childrenMap before we
+# stop it, otherwise A.7.1 measures the ~5s record-after-capability-check
+# window instead of the stop-then-delete path this section is about.
+SD_PID=$(wait_child_in_daemon_map "$CHILD_SD" 40) \
+  && ok "A.7 daemon recorded child in childrenMap (pid=$SD_PID)" \
+  || bad "A.7 daemon never recorded child within 40s — stop/delete below would test the wrong thing"
+
+# --- step 1: stop it (this is what empties the daemon's childrenMap entry) ---
+BODY=$(build_stop_node_body "$CHILD_SD_NODE_ID" "$DAEMON_NODE_ID" "$NET_ID")
+RESP=$(mcp_call "$UTOK" "$BODY")
+SD_STOP_REQ=$(echo "$RESP" | jq -r .request_id 2>/dev/null)
+SD_STOP_STATUS=$(wait_stop_request_done "$SD_STOP_REQ" 40)
+[[ "$SD_STOP_STATUS" == "stopped" ]] && ok "A.7.1 stop_node finalized (status=stopped)" \
+  || bad "A.7.1 stop_node did not finalize (status='$SD_STOP_STATUS')"
+SD_STOPPED_COUNT=$(alias_pgrep_count "$CHILD_SD")
+[[ "$SD_STOPPED_COUNT" -eq 0 ]] && ok "A.7.1 pgrep $CHILD_SD = 0 after stop" \
+  || bad "A.7.1 pgrep $CHILD_SD = $SD_STOPPED_COUNT after stop"
+# Premise assertion: the config dir must still be there, otherwise the delete
+# below would pass for the wrong reason.
+[[ -d "$HOME/.anet/nodes/$CHILD_SD" ]] && ok "A.7.1 config dir still present after stop (delete has something to do)" \
+  || bad "A.7.1 config dir already gone after stop — A.7.2 would pass vacuously"
+
+# --- step 2: delete the same child; daemon's map no longer has it ---
+BODY=$(build_delete_node_body "$CHILD_SD_NODE_ID" "$DAEMON_NODE_ID" "$CHILD_SD" "$NET_ID")
+RESP=$(mcp_call "$UTOK" "$BODY")
+SD_DEL_REQ=$(echo "$RESP" | jq -r .request_id 2>/dev/null)
+SD_DEL_STATUS=$(wait_stop_request_done "$SD_DEL_REQ" 40)
+[[ "$SD_DEL_STATUS" == "stopped" ]] && ok "A.7.2 delete after stop finalized (status=stopped, not stuck in 'deleting')" \
+  || { bad "A.7.2 delete after stop did not finalize (status='$SD_DEL_STATUS')"; tail -30 /tmp/daemon-027.log; }
+
+SD_BACKUPS=( "$HOME/.anet/deleted"/*-"$CHILD_SD" )
+if [[ -d "${SD_BACKUPS[0]:-}" ]]; then
+  ok "A.7.2 backup dir present: ${SD_BACKUPS[0]}"
+  [[ -f "${SD_BACKUPS[0]}/config.json" ]] && ok "A.7.2 backup carries config.json (real move, not empty dir)" \
+    || bad "A.7.2 backup dir has no config.json"
+  SD_MODE=$(stat -c '%a' "${SD_BACKUPS[0]}")
+  [[ "$SD_MODE" == "700" ]] && ok "A.7.2 backup dir mode = 700" || bad "A.7.2 backup dir mode = $SD_MODE"
+else
+  bad "A.7.2 no backup dir for $CHILD_SD — delete did nothing (this is #1286)"
+  ls -la "$HOME/.anet/deleted" 2>/dev/null || true
+fi
+[[ ! -d "$HOME/.anet/nodes/$CHILD_SD" ]] && ok "A.7.2 original config dir gone (no residue on the target machine)" \
+  || bad "A.7.2 original config dir $HOME/.anet/nodes/$CHILD_SD still present after delete"
+
+SD_ROW=$(sqlite3 "$HUB_DB" "SELECT COUNT(*) FROM nodes WHERE node_id='$CHILD_SD_NODE_ID';" 2>/dev/null)
+[[ "$SD_ROW" == "0" ]] && ok "A.7.2 nodes row deleted (hub converged)" \
+  || bad "A.7.2 nodes row still present (count=$SD_ROW) — hub stuck"
+SD_NTOK=$(sqlite3 "$HUB_DB" "SELECT COUNT(*) FROM api_tokens WHERE name='node:$CHILD_SD' AND revoked_at IS NOT NULL;" 2>/dev/null)
+[[ "$SD_NTOK" -ge 1 ]] && ok "A.7.2 child ntok revoked" || bad "A.7.2 child ntok not revoked"
+
 note "L.1 stop_node with daemon_node_id OMITTED → hub auto-resolves"
 BODY=$(build_stop_node_body "$CHILD_L1_NODE_ID" "" "$NET_ID")
 RESP=$(mcp_call "$UTOK" "$BODY")


### PR DESCRIPTION
Closes #1286.

## What was wrong

`stop_node` and `delete_node` share one early return: when `child_node_id` is not in the daemon's in-memory `childrenMap`, the handler logs `child not in map` and acks `noop_not_my_child`.

That return is right for `stop` — there is no process to signal. It is wrong for `delete`.

**`childrenMap` tracks running processes. A delete also has to remove an on-disk config directory, and those two have different lifetimes. Letting a process table decide a filesystem cleanup is a category error.**

And the miss is not the rare daemon-restart case the existing comment describes: **a successful `stop` removes the entry, so stop-then-delete — what a client actually does — makes the miss guaranteed, not incidental.** Result: `ok:true` with nothing done — hub stuck at `lifecycle_state='deleting'`, `~/.anet/nodes/<name>/` left on the target machine, zero signal to the caller.

## Why this is small

Nothing on the delete path needed the map:

- the workdir move already used `req.child_alias`, **not** `entry.alias`
- `sweepOrphansForAlias` finds processes by alias

Both already live in this file and are used by `rebuildChildrenMapOnBoot`. The map only ever supplied `entry.pid`, which only `stop`'s pgid signal requires. So this is not a new mechanism — it is an existing rule in this file that was not applied consistently. The two delete paths now share one `moveWorkdirToTrash()` so "what happens when the move fails" cannot drift between them.

## Ack semantics — checked against the hub, not assumed

`ack_stop_request` accepts exactly `stopped` / `stop_failed` / `noop_not_my_child`, and it has **no branch for `noop_not_my_child` on a delete**: it updates the request row and leaves `nodes.lifecycle_state` at `'deleting'`.

🔴 My first draft of these tests expected `noop_not_my_child` for "nothing on disk". Reading the hub showed that would **reproduce the reported symptom**. The delete branch acks `stopped` — delete's real end state is *not running + config not in place* — and the hub then deletes the row and revokes the ntok. `backup_path` present vs absent distinguishes "moved it" from "nothing was on disk".

A failed move stays non-fatal, matching the stance the hit path already took (child is gone, row should still converge, trash leak surfaces via `warn`). Making the new branch stricter would give one condition two behaviours depending on which path reached it.

## Verification — real processes in Docker

`tests/qa-rfc027-stop-delete`, built `--no-cache` from this source:

| | result |
|---|---|
| with this fix | **PASS=71 FAIL=0** |
| fix reverted, tests unchanged | **PASS=64 FAIL=5**, `A.7.2` failing with the reported `status='noop_not_my_child'` |

The new **A.7** section stops and then deletes the **same** child, reusing A.5's assertions rather than restating them — A.5 deletes a child that was never stopped, so it only ever exercised the hit path.

Unit: 4 new cases, **20/20**. Restoring the shared early return turns exactly the 3 behavioural ones red; the 4th pins that `stop`'s miss path is unchanged.

## Found while writing the e2e — separate defect, not fixed here

`create-node-daemon.ts` calls `recordSpawnedChild` (`:512`) only **after** the `+FAIL_FAST_MS` capability check (`:475`). So for ~5s after a child registers with the hub, the daemon cannot stop it — every stop/delete in that window acks `noop_not_my_child`. Observed directly:

```
13:17:28 spawned child 'rfc027-child-stopdel' pid=521
13:17:28 post-spawn kill-0 verify OK: pid=521 alive
13:17:30 ← SSE stop_node sr_7cb7ce541f5b
13:17:30 [stop-daemon] child not in map: node_37fd2501-...
13:17:33 [create-node] +5000ms capability check OK: pid=521 still alive
```

My first e2e run hit it and looked like a failure of this PR. The suite's new `wait_child_in_daemon_map()` waits on that capability-check line for **this child's pid** — tied to the real ordering rather than a guessed sleep — so A.7 measures the stop-then-delete path instead of that window. Filed separately.

## Dedup

- By content: `gh issue list --search "noop_not_my_child"` ⇒ #1286 only.
- By changed files: scanned open PRs for `agent-node/src/runtime/stop-daemon.ts` and `tests/qa-rfc027-stop-delete/` ⇒ zero overlap. #1276 touches `agent-network/src/`; #1277 touches `server/src/` — no conflict with either.

Red line respected: everything ran in Docker or temp dirs. **No production hub or DB touched.**
