### PR TITLE
fix(test): qa-rfc024 的 EXIT trap 里 `kill 0` 杀掉自己(恒 rc=143)—— 修复并接入 CI

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -98,6 +98,7 @@ on:
       - 'tests/test597-dashboard-slash-namespace/**'
       - 'tests/test679-task-trace/**'
       - 'tests/qa-daemon-lifecycle-e2e/**'
+      - 'tests/qa-rfc024-config-apply/**'
       - 'tests/lib/**'
       - 'docs-site/**'
       - 'docs/doc-source-pins-baseline.txt'
@@ -258,6 +259,7 @@ on:
       - 'tests/test597-dashboard-slash-namespace/**'
       - 'tests/test679-task-trace/**'
       - 'tests/qa-daemon-lifecycle-e2e/**'
+      - 'tests/qa-rfc024-config-apply/**'
       - 'tests/lib/**'
       - 'docs-site/**'
       - 'docs/doc-source-pins-baseline.txt'
@@ -512,6 +514,26 @@ jobs:
           mkdir -p "$RUNNER_TEMP/suite-artifacts"
           docker run --rm anet-qa-daemon-lifecycle-e2e \
             2>&1 | tee "$RUNNER_TEMP/suite-artifacts/qa-daemon-lifecycle-e2e.log"
+
+      # RFC-024 config-apply contract. Was an orphan (no CI reference at all)
+      # and could not have been added as-is: its EXIT trap ran
+      # `kill "${HUB_PID:-0}" "${NODE_PID:-0}"`, and NODE_PID is never assigned
+      # anywhere in that file — so `kill 0` signalled the whole process group,
+      # the script SIGTERM'd itself, and the exit code was 143 REGARDLESS of
+      # FAIL. Fixed in the same PR; witnessed both ways (FAIL=0 → rc=0,
+      # one injected failure → rc=1) before wiring it here.
+      - name: Build qa-rfc024-config-apply
+        run: |
+          docker build \
+            -t anet-qa-rfc024-config-apply \
+            -f tests/qa-rfc024-config-apply/Dockerfile .
+
+      - name: Run qa-rfc024-config-apply
+        run: |
+          set -o pipefail
+          mkdir -p "$RUNNER_TEMP/suite-artifacts"
+          docker run --rm anet-qa-rfc024-config-apply \
+            2>&1 | tee "$RUNNER_TEMP/suite-artifacts/qa-rfc024-config-apply.log"
 
       - name: Build test224-grok-preview-security
         run: |

--- a/tests/qa-rfc024-config-apply/run.sh
+++ b/tests/qa-rfc024-config-apply/run.sh
@@ -66,7 +66,15 @@ bad()  { echo "  ✗ $1" >&2; FAIL=$((FAIL+1)); }
 skip() { echo "  ⊘ $1 (skipped — $2)"; SKIP=$((SKIP+1)); }
 
 cleanup() {
-  kill "${HUB_PID:-0}" "${NODE_PID:-0}" 2>/dev/null || true
+  # 🔴 不能写 kill "${X:-0}" —— POSIX 里 `kill 0` 是「向当前进程组的每个成员
+  # 发信号」,脚本自己就在那个组里。本套件的 NODE_PID **从不被赋值**(全文 0 处
+  # 赋值),所以每次退出都会走到 `kill 0`,把自己 SIGTERM 掉。
+  # 后果:退出码恒为 143,**与 FAIL 无关** —— PASS=23 FAIL=0 也照样 143。
+  # `2>/dev/null || true` 只吞掉 kill 的报错,信号早已送出,救不了。
+  # 实测 A/B:kill "${A:-0}" → rc=143;换成不存在的高 PID → rc=0。
+  for _pid in "${HUB_PID:-}" "${NODE_PID:-}"; do
+    [[ -n "$_pid" ]] && kill "$_pid" 2>/dev/null
+  done
   echo
   echo "── Result ──"
   echo "  PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"


### PR DESCRIPTION
## 起因

@通信龙 批准我把三个 CI 孤儿套件(`qa-rfc026-create-node` / `qa-rfc027-stop-delete` / `qa-rfc024-config-apply`)接进 CI,要求**接之前逐个跑一遍**,确认它们没有 bit-rot,跑不通的不要接进去天天红。

跑第一个就撞到了。

## `qa-rfc024-config-apply` 接不进去,因为它恒定 `rc=143`

实测:**`PASS=23 FAIL=0`,退出码 `143`**。

根因在 EXIT trap:

```bash
cleanup() {
  kill "${HUB_PID:-0}" "${NODE_PID:-0}" 2>/dev/null || true
  ...
  [[ "$FAIL" -eq 0 ]] || exit 1
}
trap cleanup EXIT
```

`NODE_PID` 在该文件里**从不被赋值**(全文 0 处),于是展开成 **`kill 0`**。POSIX 里 `kill 0` 是「向**当前进程组的每个成员**发信号」——脚本自己就在那个组里。它把自己 SIGTERM 掉,**退出码恒为 143,与 `FAIL` 无关**。

`2>/dev/null || true` 只吞掉 kill 的报错,**信号早已送出**,救不了。

**A/B 最小复现**:

```
kill "${A:-0}"        → rc=143
kill "${A:-999999}"   → rc=0     ← 唯一变量是那个 0
```

**容器内诊断**:`HUB_PID=13  NODE_PID=UNSET  AGENT_PID=126`

## 修完两个方向都验过,不只验「变绿」

| | FAIL | rc |
|---|---|---|
| 修复前 | 0 | **143**(假红) |
| 修复后 · 正控 | 0 | **0** |
| 修复后 · 反控(注入一个 `bad`) | 1 | **1** |

第三行才说明退出码**真的反映 FAIL**,而不是被改成恒 0。一个只验了「变绿」的修复,和把判据删掉长得一模一样。

## 同族写法逐条看过 —— 只有这一处是缺陷

全仓 `kill "${X:-0}"` 共 **10 处 / 7 个套件**。逐个查变量赋值:

- 🔴 **只有本文件的 `NODE_PID` 是 0 处赋值 ⇒ 必然发生**
- 其余 9 处变量都有赋值,仅在「赋值前退出」的失败路径上才 unset —— 那时会把真实退出码换成 143、**掩盖失败原因**,但仍非 0,所以 CI 仍会红

**不把候选当缺陷**:那 9 处本 PR 不动。若要收敛成一道门,是另一件事。

## 接入 CI 的预算 —— 用 CI 的真实耗时,不用本地外推

`recovered-suites` 实测 **252s / 预算 720s ⇒ 余量 468s**:

```
25s  test597 build   + 10s run
32s  test679 build   + 22s run
83s  qa-daemon-lifecycle-e2e build + 9s run
47s  test224 build   + 22s run
```

🔴 **CI 比本机快约 2.5 倍**(同一个套件:本地 build 206s、CI 83s)。所以我本地量到的 `qa-rfc024` 冷构建 261s **不能直接外推**;按同比例估 CI 上约 110–120s,余量够。

**这是估计,不是实测。** 合入后看它的真实步骤耗时,再决定 `qa-rfc026` / `qa-rfc027` 接不接 —— 那两个我还没量(宿主机磁盘 91%,同族镜像每个 4.16GB,不能同时开三个构建;且 `qa-rfc027` 此刻正被 #1286 的工作占用)。

## 一处我要更正自己的判断

我先前在群里报的是「`qa-rfc024` 结尾没有 `exit $FAIL`,接进 CI 会是一道**永远绿**的门」。**这个结论是错的,方向正好相反。** 判据其实在 `trap cleanup EXIT` 里(`[[ "$FAIL" -eq 0 ]] || exit 1`),我只看了文件结尾就下了结论;实测是**永远红**。

形状和 `CLAUDE.md` 复核纪律第 ⑥ 条一样:**一个查得到的事实(结尾确实是 `echo`),外面接了一个没查的推论(所以没有基于 FAIL 的退出码)**。

## 门与查重

```
check-test-suite-registration.py   registered 154→155  orphans 60→59  new=0  rc=0
                                   (分母 suites=227 不变 —— 不是靠缩范围变绿)
check-l1-paths-sync.py             rc=0
```

查重按【改动文件】求交集,60 个 open PR:`tests/qa-rfc024-config-apply/**` **零命中**;`.github/workflows/qa.yml` 命中 #1273/#1200/#1196/#1180,本 PR 的改动点与已合入的 #1280 同位置(`test224` 之前),与它们的 hunk 不重叠。

## 未做

`qa-rfc024` 的 Dockerfile 没有 `ARG SOURCE_COMMIT` / `RUNSH_BLOB` provenance 绑定(邻近套件有)。**本 PR 不加** —— 那会把范围从「修 bug + 接 CI」扩到「补 provenance」,值得单独一条。
