### PR TITLE
ci(test): 接入 qa-rfc027-stop-delete —— 59 断言的孤儿套件,实跑全绿(附 qa-rfc026 跑不通的证据)

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -99,6 +99,7 @@ on:
       - 'tests/test679-task-trace/**'
       - 'tests/qa-daemon-lifecycle-e2e/**'
       - 'tests/qa-rfc024-config-apply/**'
+      - 'tests/qa-rfc027-stop-delete/**'
       - 'tests/lib/**'
       - 'docs-site/**'
       - 'docs/doc-source-pins-baseline.txt'
@@ -260,6 +261,7 @@ on:
       - 'tests/test679-task-trace/**'
       - 'tests/qa-daemon-lifecycle-e2e/**'
       - 'tests/qa-rfc024-config-apply/**'
+      - 'tests/qa-rfc027-stop-delete/**'
       - 'tests/lib/**'
       - 'docs-site/**'
       - 'docs/doc-source-pins-baseline.txt'
@@ -534,6 +536,28 @@ jobs:
           mkdir -p "$RUNNER_TEMP/suite-artifacts"
           docker run --rm anet-qa-rfc024-config-apply \
             2>&1 | tee "$RUNNER_TEMP/suite-artifacts/qa-rfc024-config-apply.log"
+
+      # RFC-027 stop/delete lifecycle. Was an orphan; 59 assertions, all green
+      # on today's main — no bit-rot. Wired here rather than left unrun because
+      # it already covers two things that were about to be written from scratch:
+      # sibling isolation asserted down to the grandchild PID (each child is
+      # detached:true, so the stop's pgid scope is the wrapper's, not the
+      # daemon's), and cross-tenant refusal (forbidden_cross_tenant /
+      # daemon_not_resolvable / per-network list_my_children).
+      # Exit-code semantics verified by mutation, not by reading: injecting one
+      # `bad` turns rc 0 -> 1.
+      - name: Build qa-rfc027-stop-delete
+        run: |
+          docker build \
+            -t anet-qa-rfc027-stop-delete \
+            -f tests/qa-rfc027-stop-delete/Dockerfile .
+
+      - name: Run qa-rfc027-stop-delete
+        run: |
+          set -o pipefail
+          mkdir -p "$RUNNER_TEMP/suite-artifacts"
+          docker run --rm anet-qa-rfc027-stop-delete \
+            2>&1 | tee "$RUNNER_TEMP/suite-artifacts/qa-rfc027-stop-delete.log"
 
       - name: Build test224-grok-preview-security
         run: |


### PR DESCRIPTION
> 依赖:与 **#1295** 改的是 `qa.yml` 同一区域(`recovered-suites`,`test224` 之前),**后合的那个需要 rebase**。

## 为什么值得接

`qa-rfc027-stop-delete` 不被任何 CI 引用。在今天的 main 上实跑:

```
RFC-027 PR1.2 stop/delete e2e — PASS=59 FAIL=0 SKIP=0     rc=0    47s
```

**没有 bit-rot。** 而且它**已经覆盖了正准备从零写的两项**(@通信牛 清单里的 ①②):

**① 同一 daemon 下多子节点隔离 —— 断到孙进程 PID,并写明了机制**

```
· sibling pids captured: wrapper=216 grandchild=259 (will assert ALIVE after A.3 stop)
· SIBLING wrapper pid=216 still alive after CHILD_A stop
     (each child detached:true → separate session/pgid — siblings unaffected)
· SIBLING grandchild pid=259 still alive after CHILD_A stop
· DAEMON agent-node pid=115 still alive after CHILD_A stop
     (pgid scope is wrapper's, not daemon's — daemon survived)
· pgrep agent-node --alias rfc027-child-l1 = 1 after stop (sibling process tree intact)
```

**② 跨租户 / 越权 fail-closed**

```
· L.2 cross-tenant omit-daemon rejected at SEC-1: forbidden_cross_tenant
· L.3 omit-daemon on phantom node: daemon_not_resolvable
· CN list_my_children — stranger network 的 daemon 只看得到自己的子节点
· A.5.0 delete_node confirm_alias mismatch refused
· A.3.0 D4 in-flight 闸拒绝 stop(node_busy_in_flight)
· A.3.0 no audit row created by D4-refused dispatch  ← fail-closed,不是 fail-open 带审计
```

最后一条尤其难从零写对:它断的是**拒绝路径不留审计行**,而不只是"拒绝了"。

## 退出码语义用变异验过,不是读出来的

| | FAIL | rc |
|---|---|---|
| 基线 | 0 | 0 |
| 注入一个 `bad` | 1 | **1** |

静态面另核:结尾 `[[ "$FAIL" -eq 0 ]]`、**0 个 trap**、**0 处 `kill "${X:-0}"`**。

同族的 `qa-rfc024` 正是栽在最后一项(`kill 0` 打自己进程组 ⇒ 恒 `rc=143`),见 #1295 —— 所以这三项是分别核过的,不是"看着像就行"。

## 预算

`recovered-suites` 实测 **252s / 预算 720s ⇒ 余量 468s**。

本套件本地 `build 206s + run 47s`;**CI 比本机快约 2.5 倍**(同一形状的 `qa-daemon-lifecycle-e2e`:本地 206s、CI 83s)⇒ 估 CI 约 **100s**。合入 #1295(`qa-rfc024`,估 ~120s)后仍余约 246s。

**这是估计值**,合入后按真实步骤耗时复核,再决定 `qa-rfc026` 何时接。

## `qa-rfc026` 本 PR 不接 —— 它今天跑不通

两个子套件都失败(`TOTAL FAILED SUITES: 2`):

**失败 1 — `run.sh` 的 cross-net 断言允许值集合过时**

```
断言(run.sh:199): [[ $ERR == cross_network_node || $ERR == permission_denied ]]
实际返回:         access_denied — "access denied to requested network (not a member)"
```

**产品确实拒绝了,安全不变量成立** —— 是测试的允许集少了一个值。修的时候要确认 `access_denied` 是哪一层给的、是不是同等强度的拒绝,**不能改成「只要 error 非空就算拒绝」**:那会让这条断言对任何无关错误也变绿。

**失败 2 — `nvm-sendtask-smoke.sh` 的 daemon 起不来**

```
app-level rejection: alias_identity_mismatch
error: 'alias_identity_mismatch'   reported_alias: 'daemon-309'
```

现象明确,**根因(fixture 过时 vs 产品回归)我未确认,不下结论。**

跑不通的不接进去让它天天红。

## 门与查重

```
check-test-suite-registration.py   registered 154→155  orphans 60→59  new=0
                                   分母 suites=227 不变
check-l1-paths-sync.py             rc=0
```

按【改动文件】求交集:`tests/qa-rfc027-stop-delete/**` 本 PR **未改动其内容**(只加 CI 引用);`.github/workflows/qa.yml` 与 #1295 / #1273 / #1200 / #1196 / #1180 重叠,其中只有 **#1295 与本 PR 改同一区域**,已在顶部标注。
