### PR TITLE
docs(daemon): 把「ok:true 不是成功判据」放到用户看起来成功的那一刻（§5，原本零提醒）

### DIFF
--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -204,7 +204,7 @@ hub 侧一切看着都对，Dashboard 的「选服务器」也会把它列为可
 `[create-node] spawned child '<name>' pid=…` 和 `+5000ms capability check OK`，
 且新节点自己注册回 hub。**看不到这两行就是没配对**——它不会重试。
 
-### 4. 确认它真的起来了
+### 4. 确认它**进程**起来了
 
 ```bash
 anet daemon list
@@ -227,6 +227,9 @@ Hub 那一侧每 3 分钟能看到它的心跳：
 要确认「hub 真的看见了」，看上面那两行 `SSE ←` / `report_status`，
 或到 Dashboard 的节点列表里找 `daemon`。
 
+🔴 **但这一节确认的只是「进程活着、hub 看得见」，不是「它能替你干活」。**
+心跳正常的 daemon 仍然可能**创建不了任何节点** —— 见下一节的验收判据。
+
 ### 5. 从 Dashboard 远程操作它
 
 daemon 起来并连上 hub 之后，打开 Dashboard：
@@ -238,6 +241,31 @@ anet hub dashboard        # 默认 http://localhost:3000
 在节点列表里能看到 `daemon`（`role=host_supervisor`）。
 它与普通节点的区别是：**可以代你在这台机器上创建和启动别的节点** ——
 这正是「远程建节点」这条路径的落点，不必再 ssh 上机器敲 `anet node create`。
+
+::: danger 🔴 第一次创建节点：`ok:true` **不是**成功判据
+走到这一步时，所有你看得见的信号都会告诉你"成了"：daemon 在线、心跳正常、
+Dashboard 把它列进「选服务器」、点下去 `create_node` 返回 **`ok:true` + request_id**。
+
+**而节点可能根本没被创建**，失败只写在 **daemon 那台机器的本机日志**里
+（hub 不知情，Dashboard 也不会变红）。**不知道要去看那份日志的人，会卡在这里。**
+
+**所以第一次创建，请按日志验收，别按界面验收**：
+
+```bash
+# 在跑 daemon 的那台机器上
+tail -f ~/daemon-<name>.log        # 或你启动时重定向到的那个文件
+```
+
+| 看到 | 含义 |
+|---|---|
+| `[create-node] spawned child '<name>' pid=…`<br>`+5000ms capability check OK` | ✅ 真的创建了，新节点会自己注册回 hub |
+| `[create-node] anet_bin_unsafe_path: …` | ❌ `ANET_BIN` 没配对 → [3.6 节](#anet-bin-pin)。**它不会重试** |
+| 什么都没有 | ❌ doorbell 没到，检查 daemon 是否真的连着 hub（§4） |
+
+⚠️ **Windows 上这一步目前必失败**，且症状同样具有欺骗性（注册、心跳、`ok:true` 全正常）——
+见 [3.6 节末尾](#anet-bin-pin) 与 [#1290](https://github.com/sleep2agi/agent-network/issues/1290)。
+在 #1290 修好之前，Windows 机器可以跑 daemon，但**不要指望它 fork 出子节点**。
+:::
 
 ---
 

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -218,7 +218,7 @@ telemetry, but do not expect it to fork child nodes.**
 node must register itself back to the hub. **Without those two lines it is not wired up** —
 it will not retry.
 
-### 4. Confirm it actually came up
+### 4. Confirm the **process** came up
 
 ```bash
 anet daemon list
@@ -241,6 +241,10 @@ On the Hub side you get a heartbeat every 3 minutes:
 hub knows about it. For that, look at the `SSE ←` / `report_status` lines above, or find
 `daemon` in the Dashboard node list.
 
+🔴 **But this section only confirms "the process is alive and the hub can see it" — not
+"it can do work for you."** A daemon with a healthy heartbeat can still be **unable to
+create any node**. The acceptance check for that is in the next section.
+
 ### 5. Drive it remotely from the Dashboard
 
 Once the daemon is up and connected, open the Dashboard:
@@ -253,6 +257,34 @@ anet hub dashboard        # http://localhost:3000 by default
 ordinary node: **it can create and start other nodes on that machine for you** — which is
 the point of remote node creation. You no longer need to ssh in and run `anet node create`
 by hand.
+
+::: danger 🔴 Your first node creation: `ok:true` is **not** the success criterion
+At this step every signal you can see says it worked: the daemon is online, the heartbeat
+is healthy, the Dashboard lists it under "choose a server", and clicking through makes
+`create_node` return **`ok:true` plus a request_id**.
+
+**And the node may not have been created at all.** The failure is written only to the
+**local log on the daemon's own machine** — the hub never learns about it and the
+Dashboard never turns red. **Anyone who does not know to open that log gets stuck here.**
+
+**So verify your first creation from the log, not from the UI:**
+
+```bash
+# on the machine running the daemon
+tail -f ~/daemon-<name>.log        # or whatever file you redirected to at startup
+```
+
+| What you see | Meaning |
+|---|---|
+| `[create-node] spawned child '<name>' pid=…`<br>`+5000ms capability check OK` | ✅ really created; the new node registers itself with the hub |
+| `[create-node] anet_bin_unsafe_path: …` | ❌ `ANET_BIN` is not pinned correctly → [§3.6](#anet-bin-pin). **It does not retry** |
+| nothing at all | ❌ the doorbell never arrived — check the daemon is really connected (§4) |
+
+⚠️ **On Windows this step currently always fails**, with the same deceptive symptoms
+(registration, heartbeat and `ok:true` all look fine) — see [the end of §3.6](#anet-bin-pin)
+and [#1290](https://github.com/sleep2agi/agent-network/issues/1290). Until #1290 is fixed a
+Windows machine can run a daemon, but **do not expect it to fork child nodes**.
+:::
 
 ---
 


### PR DESCRIPTION
按「傻瓜式」标准复审 daemon 页 —— 判据不是「信息全不全」，是**一个新用户从零照着做会不会卡住**。

信息是全的。**位置不对。**

**按内容搜过**（不按作者）：`anet_bin_unsafe_path` ⇒ 零命中 · `ok:true` / `spawned child` ⇒ #1292（`agent-node` 运行时代码 + 测试，**零文件重叠**，已核 files 清单）。

---

## 问题：警告写在 §3.6，而「看起来成功」发生在 §5

`ANET_BIN`（#1289/#1291）那一节写得很完整，含「症状具有欺骗性」和验收判据。但**用户产生错觉的那一刻在 §5**，而 §5 原文只有：

> 「可以代你在这台机器上创建和启动别的节点 —— 不必再 ssh 上机器敲 `anet node create`」

**零提醒。** 新用户的实际路径：

| 步骤 | 他会怎么做 |
|---|---|
| §3.6 | 一张 5 行校验表 + `chmod` + 环境变量 + Windows 例外 ⇒ 读起来像**进阶配置**，而它的触发条件（"第一次通过 hub 创建节点时"）**还没发生** ⇒ 跳过或略读 |
| §4「确认它真的起来了」 | 起来了 ⇒ 觉得完事了 |
| §5 | Dashboard 列出它 + 文档说它"可以创建节点" ⇒ 点下去 ⇒ hub 返回 `ok:true` ⇒ **什么也没发生** ⇒ 不知道要去看 daemon 本机日志 |

一条规则只有落在**读者真会读到的那一行**才会生效。这条落在了他跳过的那一节。

## 改法（不重复 §3.6，只加验收）

**1. §4 标题：「确认它真的起来了」→「确认它*进程*起来了」**

它确认的是「进程活着 + hub 看得见」，不是「能干活」。页面自己在 §3.6 就写了 **「daemon 起来 ≠ 能干活」** —— 标题不该许诺更多。节末补一句指向下一节的验收。

**2. §5 加 danger 块，就放在"可以代你创建节点"这句之后**

- `ok:true` **不是**成功判据 —— daemon 在线、心跳正常、Dashboard 列出、`create_node` 返回 `ok:true` + request_id，**而节点可能根本没被创建**
- 失败**只写在 daemon 本机日志**里：hub 不知情，Dashboard 不变红
- 三行对照表：

| 看到 | 含义 |
|---|---|
| `[create-node] spawned child '<name>' pid=…` + `+5000ms capability check OK` | ✅ 真的创建了 |
| `[create-node] anet_bin_unsafe_path: …` | ❌ `ANET_BIN` 没配对 → §3.6。**它不会重试** |
| 什么都没有 | ❌ doorbell 没到，回 §4 查连接 |

- Windows（#1290）在这里**再点一次** —— 因为这正是它表现出欺骗性的那一步

## 🔴 写法刻意与 ANET_BIN 自动化解耦

验收判据（"看 daemon 日志有没有 `spawned child`"）**不依赖配置方式** —— 无论 `ANET_BIN` 是手配、还是将来被自动配好，这一条都成立。

配置细节仍然**只在 §3.6 一处**。自动化落地后只需要改那一处，**§5 这段不用动**（把"教你怎么配"换成"它会自动处理"即可，验收那段原样保留）。

## 门

```
check-docs-integrity.py      rc=0
check-doc-symbol-anchors.py  rc=0
页内锚点                      中英 unresolved=none（复用已有的显式 {#anet-bin-pin}）
```

中英同步。