### PR TITLE
Make daemon anet binary setup automatic

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8126,6 +8126,10 @@ function prepareDaemonAnetBin(): void {
   }
 
   process.env.ANET_BIN_ABS = anetBin;
+  // #1299 — runtime 只在显式 opt-in 时才认 env 来源的 pin。CLI 正是用 env 把 pin
+  // 交给同进程的 daemon(`daemon start/up` 是 `prepareDaemonAnetBin(); await startCommand()`),
+  // 所以不声明的话,没有 /etc/anet-daemon/path.conf 的机器上 `anet daemon up` 会被自己拦下。
+  process.env.ANET_DAEMON_ALLOW_ENV_BIN = "1";
   process.env.ANET_DAEMON_ALLOW_NON_ROOT_BIN = "1";
   console.log(`[anet daemon] using anet binary: ${anetBin}`);
 }

--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -8007,6 +8007,129 @@ Example:
 
 const DAEMON_DEFAULT_NAME = "daemon";
 
+function daemonAnetBinRepairCommand(reason: string, target?: string): string {
+  if (reason === "missing") {
+    return "npm i -g @sleep2agi/agent-network@latest && anet daemon up";
+  }
+  if (reason === "relative") {
+    return "ANET_BIN_ABS=$(node -e \"console.log(require('fs').realpathSync(process.argv[1]))\" $(command -v anet)) anet daemon up";
+  }
+  if (reason === "symlink" && target) {
+    return `ANET_BIN_ABS=${shellQuote(target)} anet daemon up`;
+  }
+  if (reason === "writable" && target) {
+    return `chmod go-w ${shellQuote(target)} && anet daemon up`;
+  }
+  if (reason === "not-executable" && target) {
+    return `chmod +x ${shellQuote(target)} && anet daemon up`;
+  }
+  return "anet daemon up";
+}
+
+function findPackageJsonDirForDaemonBin(start: string): string | null {
+  let dir = dirname(start);
+  for (;;) {
+    if (existsSync(join(dir, "package.json"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function verifyDaemonAnetBinIdentity(abs: string): void {
+  const pkgDir = findPackageJsonDirForDaemonBin(abs);
+  if (!pkgDir) {
+    throw new Error(`ANET_BIN_ABS is not an anet package bin: no package.json above ${abs}. Run: unset ANET_BIN_ABS && anet daemon up`);
+  }
+  let pkg: any;
+  try {
+    pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8"));
+  } catch (e: any) {
+    throw new Error(`ANET_BIN_ABS is not an anet package bin: cannot read package.json (${e?.message || e}). Run: npm i -g @sleep2agi/agent-network@latest`);
+  }
+  if (pkg?.name !== "@sleep2agi/agent-network") {
+    throw new Error(`ANET_BIN_ABS is not an anet package bin: package name is ${JSON.stringify(pkg?.name)}. Run: unset ANET_BIN_ABS && anet daemon up`);
+  }
+
+  const binRel = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.anet;
+  if (binRel) {
+    try {
+      if (realpathSync(resolve(pkgDir, binRel)) === abs) return;
+    } catch { /* fall through to shim marker check */ }
+  }
+
+  // Source-tree/dev fallback: bin/anet.cjs is copied verbatim to dist/bin/anet.cjs
+  // at build time, but package.json points at the dist path.
+  const body = readFileSync(abs, "utf-8");
+  if (abs.endsWith("/anet.cjs") && body.includes("anet 的 bin 入口垫片") && body.includes("PARSE_FLOOR")) return;
+
+  throw new Error(`ANET_BIN_ABS is not an anet package bin: package.json bin.anet does not point at ${abs}. Run: unset ANET_BIN_ABS && anet daemon up`);
+}
+
+function resolveCurrentAnetBinForDaemon(): string {
+  const fromEnv = process.env.ANET_BIN_ABS;
+  const argvEntry = process.argv[1];
+  const packageBin = argvEntry ? join(dirname(argvEntry), "anet.cjs") : "";
+  // bin/anet.cjs intentionally rewrites argv[1] to dist/bin/cli.js before
+  // importing this file. The daemon must pin the package bin shim itself
+  // (the executable named by package.json), not the ESM implementation file.
+  const candidate = fromEnv || (packageBin && existsSync(packageBin) ? packageBin : "");
+  if (!candidate) {
+    throw new Error(`no self-resolved anet package bin found next to ${argvEntry || "(missing argv[1])"}. Run: ${daemonAnetBinRepairCommand("missing")}`);
+  }
+  if (!isAbsolute(candidate)) {
+    throw new Error(`${fromEnv ? "ANET_BIN_ABS" : "self-resolved anet binary"} is not absolute: ${candidate}. Run: ${fromEnv ? "unset ANET_BIN_ABS && anet daemon up" : daemonAnetBinRepairCommand("relative")}`);
+  }
+  let real: string;
+  try {
+    real = realpathSync(candidate);
+  } catch (e: any) {
+    throw new Error(`cannot resolve anet binary ${candidate}: ${e?.message || e}. Run: ${daemonAnetBinRepairCommand("missing")}`);
+  }
+  if (fromEnv && real !== fromEnv) {
+    throw new Error(`ANET_BIN_ABS points at a symlink: ${fromEnv} -> ${real}. Run: ${daemonAnetBinRepairCommand("symlink", real)}`);
+  }
+  verifyDaemonAnetBinIdentity(real);
+  return real;
+}
+
+function prepareDaemonAnetBin(): void {
+  if (process.platform === "win32") {
+    console.error("[anet daemon] Windows is not supported for host_supervisor daemon mode yet.");
+    console.error("[anet daemon] The daemon binary safety checks and child process model are POSIX-only; run this on Linux/macOS or WSL.");
+    process.exit(1);
+  }
+
+  let anetBin: string;
+  try {
+    anetBin = resolveCurrentAnetBinForDaemon();
+  } catch (e: any) {
+    console.error(`[anet daemon] ${e?.message || e}`);
+    process.exit(1);
+  }
+
+  const st = statSync(anetBin);
+  if ((st.mode & 0o022) !== 0) {
+    const before = (st.mode & 0o777).toString(8);
+    console.error(`[anet daemon] refusing to start: anet binary is group/other writable (mode=${before}); daemon requires a non-writable binary.`);
+    console.error(`[anet daemon] Run this once, then retry:`);
+    console.error(`[anet daemon]   ${daemonAnetBinRepairCommand("writable", anetBin)}`);
+    process.exit(1);
+  }
+  if ((st.mode & 0o111) === 0) {
+    console.error(`[anet daemon] anet binary is not executable: ${anetBin}`);
+    console.error(`[anet daemon] Run: ${daemonAnetBinRepairCommand("not-executable", anetBin)}`);
+    process.exit(1);
+  }
+  if (st.uid !== 0) {
+    console.log(`[anet daemon] anet binary is owned by uid=${st.uid}; accepting it as a user-managed nvm/homebrew/npm install.`);
+  }
+
+  process.env.ANET_BIN_ABS = anetBin;
+  process.env.ANET_DAEMON_ALLOW_NON_ROOT_BIN = "1";
+  console.log(`[anet daemon] using anet binary: ${anetBin}`);
+}
+
 async function daemonCommand() {
   const sub = args[1];
   if (!sub || sub === "help" || sub === "-h" || sub === "--help") {
@@ -8028,9 +8151,9 @@ Run \`anet hub start\` first if you don't yet have a CommHub.`);
     return;
   }
   switch (sub) {
-    case "init":  args.splice(0, 1); await daemonInitCommand(); break;
-    case "start": args.splice(0, 1); await daemonStartCommand(); break;
-    case "up":    args.splice(0, 1); await daemonUpCommand(); break;
+    case "init":  args.splice(0, 1); prepareDaemonAnetBin(); await daemonInitCommand(); break;
+    case "start": args.splice(0, 1); prepareDaemonAnetBin(); await daemonStartCommand(); break;
+    case "up":    args.splice(0, 1); prepareDaemonAnetBin(); await daemonUpCommand(); break;
     case "list": case "ls": await daemonListCommand(); break;
     default: {
       const suggestion = suggestSimilar(sub, ["init", "start", "up", "list"]);

--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -157,6 +157,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     const got = loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_BIN_SHA256: expectedHash,
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
       ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",  // test runs as non-root
     });
     expect(got).toBe(p);
@@ -169,10 +170,46 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     })).toThrow(/anet_bin_unsafe_path.*no ANET_BIN_ABS/);
   });
 
+  test("REJECT: ANET_BIN_ABS env fallback without explicit opt-in", () => {
+    cleanup();
+    const p = setup("env-fallback-disabled");
+    expect(() => loadAndVerifyAnetBin({
+      ANET_BIN_ABS: p,
+      ANET_DAEMON_PATH_CONF: "/nonexistent",
+    })).toThrow(/ANET_BIN_ABS env fallback disabled.*ANET_DAEMON_ALLOW_ENV_BIN=1/);
+    cleanup();
+  });
+
+  test("ACCEPT: ANET_BIN_ABS env fallback when explicitly opted in", () => {
+    cleanup();
+    const p = setup("env-fallback-enabled");
+    expect(loadAndVerifyAnetBin({
+      ANET_BIN_ABS: p,
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
+      ANET_DAEMON_PATH_CONF: "/nonexistent",
+    })).toBe(p);
+    cleanup();
+  });
+
+  test("path.conf wins over ANET_BIN_ABS env fallback", () => {
+    cleanup();
+    const confBin = setup("conf-bin");
+    const envBin = setup("env-bin");
+    const conf = join(FIXTURE_DIR, "path.conf");
+    writeFileSync(conf, `ANET_BIN_ABS=${confBin}\n`);
+    expect(loadAndVerifyAnetBin({
+      ANET_DAEMON_PATH_CONF: conf,
+      ANET_BIN_ABS: envBin,
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
+    })).toBe(confBin);
+    cleanup();
+  });
+
   test("REJECT: relative path", () => {
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: "anet",
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*not absolute/);
   });
 
@@ -185,6 +222,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: symlinkPath,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
       ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*symlink/);
     cleanup();
@@ -199,6 +237,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*not an anet package bin/);
     expect(statSync(p).mode & 0o777).toBe(0o777);
     cleanup();
@@ -211,6 +250,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*writable by group\/other/);
     expect(statSync(p).mode & 0o777).toBe(0o777);
     cleanup();
@@ -223,6 +263,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
       ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*writable by group\/other/);
     expect(statSync(p).mode & 0o777).toBe(0o777);
@@ -236,6 +277,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
       ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*writable by group\/other/);
     expect(statSync(p).mode & 0o777).toBe(0o775);
@@ -249,6 +291,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
       ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*not executable/);
     cleanup();
@@ -261,6 +304,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
     })).not.toThrow();
     cleanup();
   });
@@ -271,6 +315,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
       ANET_DAEMON_STRICT_ROOT_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*owner not root/);
     cleanup();
@@ -284,6 +329,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
       ANET_BIN_ABS: p,
       ANET_BIN_SHA256: installTimeHash,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
+      ANET_DAEMON_ALLOW_ENV_BIN: "1",
       ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*sha256 mismatch/);
     cleanup();

--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -135,8 +135,14 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
   const FIXTURE_DIR = "/tmp/anet-bin-test-fixtures";
 
   function setup(name: string, body = "#!/bin/sh\necho real"): string {
-    mkdirSync(FIXTURE_DIR, { recursive: true });
-    const p = join(FIXTURE_DIR, name);
+    const pkgDir = join(FIXTURE_DIR, `${name}-pkg`);
+    const binDir = join(pkgDir, "dist", "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({
+      name: "@sleep2agi/agent-network",
+      bin: { anet: "dist/bin/anet.cjs" },
+    }));
+    const p = join(binDir, "anet.cjs");
     writeFileSync(p, body, { mode: 0o755 });
     return p;
   }
@@ -184,7 +190,33 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     cleanup();
   });
 
-  test("REJECT: world-writable (mode 0o777)", () => {
+  test("REJECT: non-anet absolute path is not chmodded", () => {
+    cleanup();
+    mkdirSync(FIXTURE_DIR, { recursive: true });
+    const p = join(FIXTURE_DIR, "not-anet");
+    writeFileSync(p, "#!/bin/sh\necho nope", { mode: 0o777 });
+    chmodSync(p, 0o777);
+    expect(() => loadAndVerifyAnetBin({
+      ANET_BIN_ABS: p,
+      ANET_DAEMON_PATH_CONF: "/nonexistent",
+    })).toThrow(/anet_bin_unsafe_path.*not an anet package bin/);
+    expect(statSync(p).mode & 0o777).toBe(0o777);
+    cleanup();
+  });
+
+  test("REJECT: forged agent-network package bin is not chmodded", () => {
+    cleanup();
+    const p = setup("forged", "#!/usr/bin/env node\n// fake\n");
+    chmodSync(p, 0o777);
+    expect(() => loadAndVerifyAnetBin({
+      ANET_BIN_ABS: p,
+      ANET_DAEMON_PATH_CONF: "/nonexistent",
+    })).toThrow(/anet_bin_unsafe_path.*writable by group\/other/);
+    expect(statSync(p).mode & 0o777).toBe(0o777);
+    cleanup();
+  });
+
+  test("REJECT: world-writable (mode 0o777) without chmodding", () => {
     cleanup();
     const p = setup("world-writable");
     chmodSync(p, 0o777);
@@ -193,10 +225,11 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
       ANET_DAEMON_PATH_CONF: "/nonexistent",
       ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*writable by group\/other/);
+    expect(statSync(p).mode & 0o777).toBe(0o777);
     cleanup();
   });
 
-  test("REJECT: group-writable (mode 0o775)", () => {
+  test("REJECT: group-writable (mode 0o775) without chmodding", () => {
     cleanup();
     const p = setup("group-writable");
     chmodSync(p, 0o775);
@@ -205,6 +238,7 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
       ANET_DAEMON_PATH_CONF: "/nonexistent",
       ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
     })).toThrow(/anet_bin_unsafe_path.*writable by group\/other/);
+    expect(statSync(p).mode & 0o777).toBe(0o775);
     cleanup();
   });
 
@@ -220,26 +254,25 @@ describe("§4.2.6 B2 loadAndVerifyAnetBin — install-time pin 5-check (BLOCKER 
     cleanup();
   });
 
-  test("REJECT: owner not root (no opt-out)", () => {
+  test("ACCEPT: owner not root by default for nvm/homebrew/user installs", () => {
     cleanup();
     const p = setup("non-root-owner");
     // test runs as non-root by default; owner=current uid (not 0)
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
-      // ANET_DAEMON_ALLOW_NON_ROOT_BIN intentionally NOT set
-    })).toThrow(/anet_bin_unsafe_path.*owner not root/);
+    })).not.toThrow();
     cleanup();
   });
 
-  test("ACCEPT: owner not root WHEN ANET_DAEMON_ALLOW_NON_ROOT_BIN=1 (explicit opt-out)", () => {
+  test("REJECT: owner not root only when strict root mode is explicitly requested", () => {
     cleanup();
-    const p = setup("explicit-non-root");
+    const p = setup("strict-non-root");
     expect(() => loadAndVerifyAnetBin({
       ANET_BIN_ABS: p,
       ANET_DAEMON_PATH_CONF: "/nonexistent",
-      ANET_DAEMON_ALLOW_NON_ROOT_BIN: "1",
-    })).not.toThrow();
+      ANET_DAEMON_STRICT_ROOT_BIN: "1",
+    })).toThrow(/anet_bin_unsafe_path.*owner not root/);
     cleanup();
   });
 

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -11,7 +11,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { statSync, realpathSync, readFileSync, mkdirSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { isReservedEnvKey } from "../shared/reserved-env.js";
 import {
   atomicWriteJson,
@@ -36,6 +36,58 @@ interface PathPin {
   sha256?: string;
 }
 
+function quoteSh(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function unsafePathHelp(reason: string, fix: string): Error {
+  return new Error(`anet_bin_unsafe_path: ${reason}. Fix: ${fix}`);
+}
+
+function findPackageJsonDir(start: string): string | null {
+  let dir = dirname(start);
+  for (;;) {
+    try {
+      const pkg = join(dir, "package.json");
+      statSync(pkg);
+      return dir;
+    } catch { /* keep walking */ }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function verifyAnetBinIdentity(abs: string): void {
+  const pkgDir = findPackageJsonDir(abs);
+  if (!pkgDir) {
+    throw unsafePathHelp(`not an anet package bin: no package.json above ${abs}`, "re-run via the installed anet command: anet daemon up");
+  }
+  let pkg: any;
+  try {
+    pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8"));
+  } catch (e: any) {
+    throw unsafePathHelp(`not an anet package bin: cannot read package.json (${e?.message || e})`, "reinstall anet: npm i -g @sleep2agi/agent-network@latest");
+  }
+  if (pkg?.name !== "@sleep2agi/agent-network") {
+    throw unsafePathHelp(`not an anet package bin: package name is ${JSON.stringify(pkg?.name)}`, "unset ANET_BIN_ABS and re-run: anet daemon up");
+  }
+
+  const binRel = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.anet;
+  if (binRel) {
+    try {
+      if (realpathSync(resolve(pkgDir, binRel)) === abs) return;
+    } catch { /* fall through to shim marker check */ }
+  }
+
+  // Source-tree/dev fallback: bin/anet.cjs is copied verbatim to dist/bin/anet.cjs
+  // at build time, but package.json points at the dist path.
+  const body = readFileSync(abs, "utf-8");
+  if (abs.endsWith("/anet.cjs") && body.includes("anet 的 bin 入口垫片") && body.includes("PARSE_FLOOR")) return;
+
+  throw unsafePathHelp(`not an anet package bin: package.json bin.anet does not point at ${abs}`, "unset ANET_BIN_ABS and re-run: anet daemon up");
+}
+
 function readPathConf(path: string): PathPin | null {
   try {
     const buf = readFileSync(path, "utf-8");
@@ -52,10 +104,9 @@ function readPathConf(path: string): PathPin | null {
 /** §4.2.6 B2 hardened — install-time pin + 5-check (PR #299 BLOCKER #3).
  *  All five gates throw `anet_bin_unsafe_path:<reason>` and fail-fast
  *  the daemon on boot (RFC: better to lose 1 host than fork a poisoned
- *  binary). owner=root is enforced unless an explicit opt-out env var
- *  ANET_DAEMON_ALLOW_NON_ROOT_BIN=1 is set (containers/CI escape hatch
- *  for environments where the binary lives under /usr/local owned by
- *  a non-root user — must be deliberate, not silent). */
+ *  binary). Non-root owners are allowed by default because nvm/homebrew
+ *  installs intentionally place the user's own anet binary outside root
+ *  ownership. */
 export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env): string {
   let pin: PathPin | null = null;
   const confPath = env.ANET_DAEMON_PATH_CONF || "/etc/anet-daemon/path.conf";
@@ -64,30 +115,46 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env): stri
     pin = { abs: env.ANET_BIN_ABS, sha256: env.ANET_BIN_SHA256 };
   }
   if (!pin) {
-    throw new Error("anet_bin_unsafe_path: no ANET_BIN_ABS resolved (neither /etc/anet-daemon/path.conf nor env)");
+    throw unsafePathHelp(
+      "no ANET_BIN_ABS resolved (neither /etc/anet-daemon/path.conf nor env)",
+      "restart with: ANET_BIN_ABS=$(node -e \"console.log(require('fs').realpathSync(process.argv[1]))\" $(command -v anet)) anet daemon start <name>",
+    );
   }
   // ① absolute
   if (!pin.abs.startsWith("/")) {
-    throw new Error(`anet_bin_unsafe_path: not absolute: ${pin.abs}`);
+    throw unsafePathHelp(
+      `not absolute: ${pin.abs}`,
+      `export ANET_BIN_ABS=$(node -e "console.log(require('fs').realpathSync(process.argv[1]))" ${quoteSh(pin.abs)})`,
+    );
   }
   // ② no symlink path component (realpath equals self)
   const real = realpathSync(pin.abs);
   if (real !== pin.abs) {
-    throw new Error(`anet_bin_unsafe_path: contains symlink: ${pin.abs} → ${real}`);
+    throw unsafePathHelp(
+      `contains symlink: ${pin.abs} -> ${real}`,
+      `export ANET_BIN_ABS=${quoteSh(real)}`,
+    );
   }
-  // ③ stat: owner=root (enforced unless explicit opt-out)
+  verifyAnetBinIdentity(pin.abs);
+  // ③ stat: non-root owner is acceptable for nvm/homebrew/user installs.
   const st = statSync(pin.abs);
-  const allowNonRoot = env.ANET_DAEMON_ALLOW_NON_ROOT_BIN === "1";
-  if (st.uid !== 0 && !allowNonRoot) {
-    throw new Error(`anet_bin_unsafe_path: owner not root (uid=${st.uid}; set ANET_DAEMON_ALLOW_NON_ROOT_BIN=1 to bypass for non-root install)`);
+  if (st.uid !== 0 && env.ANET_DAEMON_STRICT_ROOT_BIN === "1") {
+    throw unsafePathHelp(
+      `owner not root (uid=${st.uid})`,
+      `sudo chown root:root ${quoteSh(pin.abs)} || unset ANET_DAEMON_STRICT_ROOT_BIN`,
+    );
   }
   // ④ not group/other writable
   if ((st.mode & 0o022) !== 0) {
-    throw new Error(`anet_bin_unsafe_path: writable by group/other (mode=${(st.mode & 0o777).toString(8)})`);
+    const before = (st.mode & 0o777).toString(8);
+    throw unsafePathHelp(
+      `writable by group/other (mode=${before})`,
+      `chmod go-w ${quoteSh(pin.abs)}`,
+    );
   }
   // ⑤ executable
   if ((st.mode & 0o111) === 0) {
-    throw new Error(`anet_bin_unsafe_path: not executable`);
+    throw unsafePathHelp("not executable", `chmod +x ${quoteSh(pin.abs)}`);
   }
   // hash match install-time witness (when provided, REQUIRED to match)
   if (pin.sha256) {
@@ -111,7 +178,6 @@ export function getAnetBinAbs(): string {
 export function _resetAnetBinAbsForTest(): void { _anetBinAbs = null; }
 
 // ── §4.2.6 B1 — minimalEnv (filter + fixed-keys-last + throw-on-collision) ──
-import { dirname } from "node:path";
 
 const SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const FIXED_ENV_KEYS = new Set(["PATH", "HOME", "LANG"]);

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -24,8 +24,8 @@ import {
 // Resolution order (first-match wins):
 //   1. `/etc/anet-daemon/path.conf` (KEY=VALUE format; install scripts
 //      write this on systemd-managed hosts)
-//   2. `ANET_BIN_ABS` env var (container / dev convenience —
-//      Dockerfile sets this at build time)
+//   2. `ANET_BIN_ABS` env var only when `ANET_DAEMON_ALLOW_ENV_BIN=1`
+//      (Docker/dev/manual-ops convenience, not a production trust root)
 //
 // Runtime fork ALWAYS uses the resolved path. Daemon NEVER calls
 // `which anet` or any other PATH lookup. CI lint guard greps
@@ -111,13 +111,19 @@ export function loadAndVerifyAnetBin(env: NodeJS.ProcessEnv = process.env): stri
   let pin: PathPin | null = null;
   const confPath = env.ANET_DAEMON_PATH_CONF || "/etc/anet-daemon/path.conf";
   pin = readPathConf(confPath);
-  if (!pin && env.ANET_BIN_ABS) {
+  if (!pin && env.ANET_BIN_ABS && env.ANET_DAEMON_ALLOW_ENV_BIN === "1") {
     pin = { abs: env.ANET_BIN_ABS, sha256: env.ANET_BIN_SHA256 };
+  }
+  if (!pin && env.ANET_BIN_ABS) {
+    throw unsafePathHelp(
+      "ANET_BIN_ABS env fallback disabled (set ANET_DAEMON_ALLOW_ENV_BIN=1 only for Docker/dev/manual ops; production trust root is /etc/anet-daemon/path.conf)",
+      "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
+    );
   }
   if (!pin) {
     throw unsafePathHelp(
-      "no ANET_BIN_ABS resolved (neither /etc/anet-daemon/path.conf nor env)",
-      "restart with: ANET_BIN_ABS=$(node -e \"console.log(require('fs').realpathSync(process.argv[1]))\" $(command -v anet)) anet daemon start <name>",
+      "no ANET_BIN_ABS resolved from /etc/anet-daemon/path.conf; env fallback is Docker/dev/manual-ops convenience and requires ANET_DAEMON_ALLOW_ENV_BIN=1",
+      "install -d -m 0755 /etc/anet-daemon && printf 'ANET_BIN_ABS=%s\\n' \"$(node -e \\\"console.log(require('fs').realpathSync(process.argv[1]))\\\" $(command -v anet))\" | sudo tee /etc/anet-daemon/path.conf >/dev/null",
     );
   }
   // ① absolute

--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -149,59 +149,33 @@ anet daemon start <name> >> C:\Users\<you>\daemon-<name>.log 2>&1
 2. **别拿启动输出当就绪判据**。判据是 hub 侧：`anet daemon list` 只读本机配置、
    列出来不等于 hub 认得它；要看 hub 的节点状态里 `last_seen_at` 在持续刷新。
 
-### 3.6 让 daemon 能真的创建节点：`ANET_BIN` 钉死 {#anet-bin-pin}
+### 3.6 让 daemon 能真的创建节点：`ANET_BIN` 自动钉死 {#anet-bin-pin}
 
-🔴 **daemon 起来 ≠ 能干活。** 第一次通过 hub 让它创建节点时，很可能看到：
+daemon 收到 `create_node` 后必须 fork 当前安装的 `anet`。为了防止 `PATH` 劫持,
+runtime 仍然只接受一个通过校验的绝对路径；但现在 `anet daemon init` / `start` / `up`
+会自动做这件事,不再要求用户手工 `readlink -f`、`chmod`、设环境变量。
 
-```
-[create-node] anet_bin_unsafe_path: no ANET_BIN_ABS resolved
-              (neither /etc/anet-daemon/path.conf nor env)
-```
+启动 daemon 时会自动:
 
-这是**供应链保护**，不是 bug：daemon 会 fork 出真实进程，所以它拒绝走 `PATH` 去找
-`anet`（`PATH` 可被劫持），只接受一个**钉死并校验过**的绝对路径。校验五条，缺一不可：
+1. 把当前 `anet` 启动器 `realpath` 成实体文件,并注入 `ANET_BIN_ABS`。
+2. 分开诊断未解析、非绝对路径、symlink 路径、组/其他用户可写、不可执行等问题。
+3. 对 `umask 0002` 下 npm 常见的 `775` / group-writable 安装拒绝启动,并打印可直接执行的 `chmod go-w` 命令。
+4. 默认接受 nvm/homebrew/npm 的非 root 用户安装,因为那就是用户自己的二进制。
+5. 在 Windows 上直接拒绝 daemon 模式,避免 POSIX-only 路径和权限检查等到创建节点时才失败。
 
-| # | 要求 | npm 标准安装下的实际情况 |
-|---|---|---|
-| ① | 绝对路径 | ✅ |
-| ② | 路径中**无 symlink**（`realpath` 等于自身） | ❌ `npm i -g` 装出来的 `bin/anet` 就是 symlink |
-| ③ | 属主 root | ❌ 装在用户目录（nvm / `--prefix ~`）时属主是你 |
-| ④ | **不可被 group/other 写**（`mode & 0o022 == 0`） | ❌ **umask 0002 的机器上 npm 产物是 `775`** |
-| ⑤ | 可执行 | ✅ |
-
-②③④ 三条在「用 nvm 装、机器 umask 0002」这种**很常见**的组合下会同时不满足。
-
-**配法**（先取真实路径，再收紧权限，最后钉死）：
+预期路径就是:
 
 ```bash
-BIN=$(readlink -f "$(command -v anet)")   # ② 解掉 symlink，拿到 dist/bin/anet.cjs
-chmod go-w "$BIN"                          # ④ 775 → 755
-stat -c '%a %U %n' "$BIN"                  # 复核：755，属主是你
-
-# 启动 daemon 时钉死它
-ANET_BIN_ABS="$BIN" ANET_DAEMON_ALLOW_NON_ROOT_BIN=1   nohup anet daemon start <name> >> ~/daemon-<name>.log 2>&1 &
+npm i -g @sleep2agi/agent-network @sleep2agi/agent-node
+anet login
+anet daemon up
 ```
 
-- `ANET_DAEMON_ALLOW_NON_ROOT_BIN=1` 是③的显式豁免——**只在你确信该文件只有你能改时用**。
-  root 安装（`sudo npm i -g`）不需要它。
-- 也可以写进 `/etc/anet-daemon/path.conf`（daemon 优先读它），格式见
-  `loadAndVerifyAnetBin` 的 `readPathConf`。想再紧一档可以带 `sha256`：
-  安装时的哈希与运行时不一致会直接拒启动。
+如果安全检查失败,CLI 会打印一行可直接照敲的修复命令;不要手工编辑未入库的服务器
+启动文件来绕过它。
 
-🔴 **Windows 目前配不通，这不是你的配置问题**（2026-08-27 实测，见 [#1290](https://github.com/sleep2agi/agent-network/issues/1290)）：
-上面①那条判断在代码里是 `pin.abs.startsWith("/")` —— **POSIX-only**，而 Windows 的绝对路径
-是 `C:\...`，永远不以 `/` 开头，所以无论把 `ANET_BIN_ABS` 设成什么都会得到
-`anet_bin_unsafe_path: not absolute:`。而且即使放宽它，③④在 Windows 上也不成立
-（Node 在 Windows 的 `uid` 恒为 0 ⇒ 属主检查恒过；POSIX mode 位不反映 ACL ⇒ 权限检查
-不表达任何真实权限）。
-
-⚠️ **症状具有欺骗性**：这台 daemon 会**正常注册、正常心跳、正常收到 doorbell**，
-hub 侧一切看着都对，Dashboard 的「选服务器」也会把它列为可选；
-`create_node` 甚至返回 `ok:true` + request_id —— 失败只写在 daemon 本机日志里。
-**所以在 #1290 修复前：Windows 机器可以跑 daemon 做心跳/遥测，但不要指望它 fork 出子节点。**
-
-**判据**：配好之后，从 hub 发一次 `create_node`，daemon 日志应出现
-`[create-node] spawned child '<name>' pid=…` 和 `+5000ms capability check OK`，
+**判据**：从 hub 发一次 `create_node`,daemon 日志应出现
+`[create-node] spawned child '<name>' pid=…` 和 `+5000ms capability check OK`,
 且新节点自己注册回 hub。**看不到这两行就是没配对**——它不会重试。
 
 ### 4. 确认它**进程**起来了

--- a/docs-site/docs/deploy/daemon.md
+++ b/docs-site/docs/deploy/daemon.md
@@ -171,6 +171,17 @@ anet login
 anet daemon up
 ```
 
+`anet` 路径有两个来源,信任级别不同:
+
+| 来源 | 用途 |
+|---|---|
+| `/etc/anet-daemon/path.conf` | 生产信任根；存在时优先于环境变量 |
+| `ANET_BIN_ABS` 环境变量 | Docker、开发机或手工运维的便利通道 |
+
+`ANET_BIN_ABS` 只有在 `ANET_DAEMON_ALLOW_ENV_BIN=1` 时才会被 runtime 接受。
+`anet daemon init` / `start` / `up` 会自己设置这个声明,所以上面的 quickstart
+不需要你手工加环境变量；只有绕过 `anet daemon`、直接拼 daemon 启动命令时才需要自己声明。
+
 如果安全检查失败,CLI 会打印一行可直接照敲的修复命令;不要手工编辑未入库的服务器
 启动文件来绕过它。
 

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -180,6 +180,18 @@ anet login
 anet daemon up
 ```
 
+The `anet` path has two sources with different trust levels:
+
+| Source | Used for |
+|---|---|
+| `/etc/anet-daemon/path.conf` | Production trust root; when present, it wins over the environment |
+| `ANET_BIN_ABS` environment variable | Docker, development machines, or manual operations convenience |
+
+The runtime accepts `ANET_BIN_ABS` only when `ANET_DAEMON_ALLOW_ENV_BIN=1` is also set.
+`anet daemon init` / `start` / `up` sets that declaration itself, so the quickstart above
+does not need a manual environment variable. You only need to set it yourself when bypassing
+`anet daemon` and assembling the daemon startup command directly.
+
 If a safety check fails, the CLI prints a one-line repair command that can be copied and run
 directly; do not work around it by editing untracked server startup files.
 

--- a/docs-site/docs/en/deploy/daemon.md
+++ b/docs-site/docs/en/deploy/daemon.md
@@ -157,63 +157,33 @@ anet daemon start <name> >> C:\Users\<you>\daemon-<name>.log 2>&1
    being listed does not mean the hub knows about it. The criterion is hub-side:
    `last_seen_at` still advancing.
 
-### 3.6 Let the daemon actually create nodes: pin `ANET_BIN` {#anet-bin-pin}
+### 3.6 Let the daemon actually create nodes: auto-pin `ANET_BIN` {#anet-bin-pin}
 
-🔴 **A running daemon is not a working daemon.** The first time you ask it to create a node
-through the hub, you will likely see:
+When a daemon receives `create_node`, it must fork the currently installed `anet`. To avoid
+`PATH` hijacking, the runtime still accepts only a verified absolute path; but
+`anet daemon init` / `start` / `up` now prepares that path automatically. Users no longer need
+to manually run `readlink -f`, `chmod`, or export daemon-specific environment variables.
 
-```
-[create-node] anet_bin_unsafe_path: no ANET_BIN_ABS resolved
-              (neither /etc/anet-daemon/path.conf nor env)
-```
+Daemon startup now automatically:
 
-That is **supply-chain protection**, not a bug: the daemon forks real processes, so it
-refuses to resolve `anet` through `PATH` (hijackable) and only accepts a **pinned, verified**
-absolute path. Five checks, all required:
+1. Resolves the current `anet` launcher to its real file and injects `ANET_BIN_ABS`.
+2. Diagnoses missing, non-absolute, symlink, group/other-writable, and non-executable paths separately.
+3. Refuses to start for the common npm `775` / group-writable install produced under `umask 0002`, and prints the exact `chmod go-w` command to run.
+4. Allows non-root nvm/homebrew/npm installs by default, because the binary is the user's own file.
+5. Rejects daemon mode on Windows up front, instead of waiting for POSIX-only path and mode checks to fail during node creation.
 
-| # | Requirement | Reality under a standard npm install |
-|---|---|---|
-| ① | absolute path | ✅ |
-| ② | **no symlink** in the path (`realpath` equals itself) | ❌ `npm i -g` installs `bin/anet` as a symlink |
-| ③ | owned by root | ❌ not when installed under your home (nvm / `--prefix ~`) |
-| ④ | **not group/other-writable** (`mode & 0o022 == 0`) | ❌ **on a umask 0002 machine npm payloads are `775`** |
-| ⑤ | executable | ✅ |
-
-②③④ all fail together under the very common "installed via nvm, machine umask 0002" combo.
-
-**How to configure it** (resolve the real path, tighten the mode, then pin):
+The expected path is simply:
 
 ```bash
-BIN=$(readlink -f "$(command -v anet)")   # ② resolve the symlink to dist/bin/anet.cjs
-chmod go-w "$BIN"                          # ④ 775 → 755
-stat -c '%a %U %n' "$BIN"                  # verify: 755, owned by you
-
-# Pin it when starting the daemon
-ANET_BIN_ABS="$BIN" ANET_DAEMON_ALLOW_NON_ROOT_BIN=1 \
-  nohup anet daemon start <name> >> ~/daemon-<name>.log 2>&1 &
+npm i -g @sleep2agi/agent-network @sleep2agi/agent-node
+anet login
+anet daemon up
 ```
 
-- `ANET_DAEMON_ALLOW_NON_ROOT_BIN=1` is the explicit opt-out for ③ — **use it only when you
-  are sure nobody else can write that file.** A root install (`sudo npm i -g`) does not need it.
-- You can also write it into `/etc/anet-daemon/path.conf` (the daemon reads that first); see
-  `readPathConf` in `loadAndVerifyAnetBin`. For one more notch, include a `sha256`: a mismatch
-  between install-time and run-time hashes refuses startup outright.
+If a safety check fails, the CLI prints a one-line repair command that can be copied and run
+directly; do not work around it by editing untracked server startup files.
 
-🔴 **Windows cannot be configured to pass this today — it is not your setup**
-(measured 2026-08-27, see [#1290](https://github.com/sleep2agi/agent-network/issues/1290)):
-check ① is literally `pin.abs.startsWith("/")` — **POSIX-only** — and a Windows absolute path
-(`C:\...`) never starts with `/`, so any `ANET_BIN_ABS` yields
-`anet_bin_unsafe_path: not absolute:`. Even with ① relaxed, ③ and ④ do not hold on Windows
-(Node reports `uid` as 0 there ⇒ the owner check always passes; POSIX mode bits do not reflect
-ACLs ⇒ the permission check asserts nothing real).
-
-⚠️ **The symptom is deceptive**: such a daemon **registers, heartbeats and receives doorbells
-normally**; everything looks right hub-side, the Dashboard server picker lists it as selectable,
-and `create_node` even returns `ok:true` with a request_id — the failure is written only to the
-daemon's local log. **Until #1290 is fixed: a Windows box can run a daemon for heartbeat and
-telemetry, but do not expect it to fork child nodes.**
-
-**Criterion**: once pinned, issue one `create_node` from the hub; the daemon log must show
+**Criterion**: issue one `create_node` from the hub; the daemon log must show
 `[create-node] spawned child '<name>' pid=…` plus `+5000ms capability check OK`, and the new
 node must register itself back to the hub. **Without those two lines it is not wired up** —
 it will not retry.

--- a/docs/tests/report-1299-anet-bin-env-opt-in.txt
+++ b/docs/tests/report-1299-anet-bin-env-opt-in.txt
@@ -1,0 +1,13 @@
+Test: #1299 daemon ANET_BIN_ABS env fallback explicit opt-in
+Date: 2026-08-28
+Worktree: /tmp/wt-anetbin-clean
+Branch: feat/daemon-anet-bin-auto-clean
+
+Commands:
+- bun test agent-node/src/runtime/create-node-daemon.test.ts
+- sg docker -c 'docker build -t anet-qa-daemon-cmd -f tests/qa-anet-daemon-cmd/Dockerfile . && docker run --rm anet-qa-daemon-cmd'
+
+Results:
+- Bun unit test: 38 pass, 0 fail, 82 expect calls.
+- Docker E2E: anet daemon CLI + list_host_supervisors + ack capability-fail e2e PASS=42 FAIL=0.
+

--- a/docs/tests/report-test1178-codex-upgrade-recovery-anet-bin-2026-08-28.txt
+++ b/docs/tests/report-test1178-codex-upgrade-recovery-anet-bin-2026-08-28.txt
@@ -1,16 +1,71 @@
-Test 1178 - Codex upgrade recovery and topology audit
+Test 1178 — Codex upgrade recovery and topology audit
 
-Date: 2026-08-28
-Worktree: /tmp/wt-anetbin-clean
-Branch: feat/daemon-anet-bin-auto-clean
-Command:
-  sg docker -c 'docker build -t anet-test1178-codex-upgrade-recovery -f tests/test1178-codex-upgrade-recovery/Dockerfile . && docker run --rm anet-test1178-codex-upgrade-recovery'
+Layer 1: pure recovery + existing thread lifecycle
+bun test v1.3.14 (0d9b296a)
 
-Result: PASS
+src/opencode-agent-node-pair.test.ts:
+(pass) OpenCode agent-node release pairing > pins the exact versions being released together [0.13ms]
+(pass) OpenCode agent-node release pairing > rejects latest 2.4.x-style help and accepts the RFC-029 capability [0.08ms]
+(pass) OpenCode agent-node release pairing > codex bridge ignores stale PATH globals and resolves only the immutable pair [0.26ms]
+(pass) OpenCode agent-node release pairing > codex capability is explicit and fails closed when absent [0.06ms]
+(pass) OpenCode agent-node release pairing > admits only the exact preview package identity with safe file modes [6.40ms]
+(pass) OpenCode agent-node release pairing > skips an exact project-local impersonator and selects the later global package [6.20ms]
 
-Observed summary:
-- Layer 1 pure recovery + existing thread lifecycle: 14 pass, 0 fail.
-- Layer 2 production wiring invariants: PASS.
-- Layer 3 typecheck + production bundle: PASS.
-- Witnessed-red contract: mutation checks reported as proven.
-- Final suite result: RESULT: PASS.
+src/codex-copresence-thread.test.ts:
+(pass) co-presence thread lifecycle > restart resumes the persisted conversation [0.13ms]
+(pass) co-presence thread lifecycle > only a node with no persisted thread creates one [0.05ms]
+
+src/codex-copresence-recovery.test.ts:
+(pass) Codex co-presence recovery > resume requires exact thread identity and persisted history [0.85ms]
+(pass) Codex co-presence recovery > stub resume failure is fail-closed and never calls thread/start [0.53ms]
+(pass) Codex co-presence recovery > backup preserves config and session state but excludes credentials [8.81ms]
+(pass) Codex co-presence recovery > active state writer is quiesced before the authoritative snapshot [0.40ms]
+(pass) Codex co-presence recovery > recursive snapshot rejects symlinks instead of following state outside CODEX_HOME [1.37ms]
+(pass) Codex co-presence recovery > audit exposes topology without config secrets [0.19ms]
+
+ 14 pass
+ 0 fail
+ 44 expect() calls
+Ran 14 tests across 3 files. [89.00ms]
+
+Layer 2: production wiring invariants
+PASS: launcher uses exact resume/read verification, quiesced private snapshot, and audit projection
+PASS: stale PATH globals are ignored; codex bridge selects exact paired preview.34 and fails closed on identity/capability drift
+
+Layer 3: typecheck + production bundle
+$ tsc --noEmit
+$ bun build src/client.ts --outdir dist/src --target node --minify && bun build bin/cli.ts --outdir dist/bin --target node --minify --external @sleep2agi/commhub-server --external bun:sqlite --external '../../server/*' && bun build src/node-server.ts --outdir dist/src --target node --minify && bun build src/im/feishu/worker.ts --outdir dist/src/im/feishu --target node --minify --external @larksuiteoapi/node-sdk && tsc --emitDeclarationOnly --declaration --outDir dist && bun x javascript-obfuscator dist/bin/cli.js --output dist/bin/cli.js --compact true --string-array true --string-array-encoding base64 && bun x javascript-obfuscator dist/src/client.js --output dist/src/client.js --compact true --string-array true && bun x javascript-obfuscator dist/src/node-server.js --output dist/src/node-server.js --compact true --string-array true && cp bin/anet.cjs dist/bin/anet.cjs
+Bundled 3 modules in 9ms
+
+  client.js  5.79 KB  (entry point)
+
+Bundled 223 modules in 98ms
+
+  cli.js  1.22 MB  (entry point)
+
+Bundled 230 modules in 57ms
+
+  node-server.js  0.29 MB  (entry point)
+
+Bundled 600 modules in 183ms
+
+  worker.js  2.30 MB  (entry point)
+
+
+[javascript-obfuscator-cli] Obfuscating file: dist/bin/cli.js...
+
+[javascript-obfuscator-cli] Obfuscating file: dist/src/client.js...
+
+[javascript-obfuscator-cli] Obfuscating file: dist/src/node-server.js...
+PASS: typecheck and production bundle
+
+Witnessed-red contract
+Mutation proven by unit stub: thread/read returns exact id with empty history; test rejects and call trace is only thread/resume,thread/read (no thread/start).
+Mutation proven by paired-runtime stub: preview.33 differs from the required preview.34; the resolution plan has allowPathGlobal=false and an exact non-floating spec. Missing codex-app-server help is rejected.
+Mutation proven by active-writer stub: snapshot throws if reached while writer=true; production Windows and POSIX call the shared quiesceThenSnapshot boundary exactly once each.
+Mutation proven by recursive state fixture: nested session files have relative path + byte size + sha256; a symlink to outside CODEX_HOME is rejected instead of copied.
+Identity boundary: config-recovery.json is redacted non-credential metadata only. The original config.json and CODEX_HOME remain in place and are never replaced or cleared.
+
+Release gate (report-only; this Draft does not publish or bump versions)
+preview.45 is immutable/already published. This release candidate bumps agent-network to preview.46, agent-node to preview.34, and commhub-server to preview.30; run all release gates before publishing. Do not overwrite an existing version or move latest.
+RESULT: PASS

--- a/docs/tests/report-test1178-codex-upgrade-recovery-anet-bin-2026-08-28.txt
+++ b/docs/tests/report-test1178-codex-upgrade-recovery-anet-bin-2026-08-28.txt
@@ -1,0 +1,16 @@
+Test 1178 - Codex upgrade recovery and topology audit
+
+Date: 2026-08-28
+Worktree: /tmp/wt-anetbin-clean
+Branch: feat/daemon-anet-bin-auto-clean
+Command:
+  sg docker -c 'docker build -t anet-test1178-codex-upgrade-recovery -f tests/test1178-codex-upgrade-recovery/Dockerfile . && docker run --rm anet-test1178-codex-upgrade-recovery'
+
+Result: PASS
+
+Observed summary:
+- Layer 1 pure recovery + existing thread lifecycle: 14 pass, 0 fail.
+- Layer 2 production wiring invariants: PASS.
+- Layer 3 typecheck + production bundle: PASS.
+- Witnessed-red contract: mutation checks reported as proven.
+- Final suite result: RESULT: PASS.

--- a/docs/tests/report-test632-honest-sse-recovery-anet-bin-2026-08-28.txt
+++ b/docs/tests/report-test632-honest-sse-recovery-anet-bin-2026-08-28.txt
@@ -1,21 +1,21 @@
 # test632 — honest SSE abandon recovery guidance
 source_commit=unknown
-date=2026-08-27T17:53:26+00:00
+date=2026-08-27T18:00:27+00:00
 L0 helper behaviour + production wiring
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/sse-recovery-guidance.test.ts:
-(pass) sseAbandonGuidance > states that abandon leaves the current process alive [1.97ms]
-(pass) sseAbandonGuidance > requires stop-and-replace instead of starting a duplicate [0.19ms]
+(pass) sseAbandonGuidance > states that abandon leaves the current process alive [1.94ms]
+(pass) sseAbandonGuidance > requires stop-and-replace instead of starting a duplicate [0.16ms]
 (pass) sseAbandonGuidance > preserves the co-presence launch shape in recovery guidance [0.07ms]
-(pass) sseAbandonGuidance > the production SSE abandon hook uses the honest guidance [1.90ms]
+(pass) sseAbandonGuidance > the production SSE abandon hook uses the honest guidance [2.41ms]
 
  4 pass
  0 fail
  13 expect() calls
-Ran 4 tests across 1 file. [43.00ms]
+Ran 4 tests across 1 file. [41.00ms]
 L1 real agent-node bundle
-Bundled 294 modules in 80ms
+Bundled 294 modules in 92ms
 
   cli.js  2.17 MB  (entry point)
 
@@ -28,13 +28,13 @@ L5 restored green
 bun test v1.3.14 (0d9b296a)
 
 agent-node/src/sse-recovery-guidance.test.ts:
-(pass) sseAbandonGuidance > states that abandon leaves the current process alive [1.49ms]
-(pass) sseAbandonGuidance > requires stop-and-replace instead of starting a duplicate [0.11ms]
-(pass) sseAbandonGuidance > preserves the co-presence launch shape in recovery guidance [0.07ms]
-(pass) sseAbandonGuidance > the production SSE abandon hook uses the honest guidance [3.98ms]
+(pass) sseAbandonGuidance > states that abandon leaves the current process alive [4.56ms]
+(pass) sseAbandonGuidance > requires stop-and-replace instead of starting a duplicate [0.35ms]
+(pass) sseAbandonGuidance > preserves the co-presence launch shape in recovery guidance [0.08ms]
+(pass) sseAbandonGuidance > the production SSE abandon hook uses the honest guidance [2.07ms]
 
  4 pass
  0 fail
  13 expect() calls
-Ran 4 tests across 1 file. [59.00ms]
+Ran 4 tests across 1 file. [52.00ms]
 RESULT: PASS

--- a/docs/tests/report-test632-honest-sse-recovery-anet-bin-2026-08-28.txt
+++ b/docs/tests/report-test632-honest-sse-recovery-anet-bin-2026-08-28.txt
@@ -1,0 +1,40 @@
+# test632 — honest SSE abandon recovery guidance
+source_commit=unknown
+date=2026-08-27T17:53:26+00:00
+L0 helper behaviour + production wiring
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/sse-recovery-guidance.test.ts:
+(pass) sseAbandonGuidance > states that abandon leaves the current process alive [1.97ms]
+(pass) sseAbandonGuidance > requires stop-and-replace instead of starting a duplicate [0.19ms]
+(pass) sseAbandonGuidance > preserves the co-presence launch shape in recovery guidance [0.07ms]
+(pass) sseAbandonGuidance > the production SSE abandon hook uses the honest guidance [1.90ms]
+
+ 4 pass
+ 0 fail
+ 13 expect() calls
+Ran 4 tests across 1 file. [43.00ms]
+L1 real agent-node bundle
+Bundled 294 modules in 80ms
+
+  cli.js  2.17 MB  (entry point)
+
+L2 real supervisor abandon returns without killing the agent process
+L3 witnessed-red: restore the dangerous duplicate-start guidance
+MUTATION_RED: duplicate-start-guidance rc=1
+L4 witnessed-red: bypass the helper in the production abandon hook
+MUTATION_RED: production-hook-bypass rc=1
+L5 restored green
+bun test v1.3.14 (0d9b296a)
+
+agent-node/src/sse-recovery-guidance.test.ts:
+(pass) sseAbandonGuidance > states that abandon leaves the current process alive [1.49ms]
+(pass) sseAbandonGuidance > requires stop-and-replace instead of starting a duplicate [0.11ms]
+(pass) sseAbandonGuidance > preserves the co-presence launch shape in recovery guidance [0.07ms]
+(pass) sseAbandonGuidance > the production SSE abandon hook uses the honest guidance [3.98ms]
+
+ 4 pass
+ 0 fail
+ 13 expect() calls
+Ran 4 tests across 1 file. [59.00ms]
+RESULT: PASS

--- a/tests/qa-daemon-lifecycle-e2e/run.sh
+++ b/tests/qa-daemon-lifecycle-e2e/run.sh
@@ -182,6 +182,8 @@ cat > "$HOME/.anet/config.json" <<EOF
 EOF
 cd "$WORK"
 export ANET_BIN_ABS=$(realpath -e "$(which anet)")
+# 本套件绕过 `anet daemon`(用 `anet node start`),CLI 的自动声明到不了这里 —— 见 #1299
+export ANET_DAEMON_ALLOW_ENV_BIN=1
 nohup anet daemon up "$DAEMON_NAME" >/tmp/daemon-dlife.log 2>&1 &
 DAEMON_PID=$!
 

--- a/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh
+++ b/tests/qa-rfc026-create-node/nvm-sendtask-smoke.sh
@@ -80,6 +80,7 @@ ok "node MOVED to /opt/anet-nvm-sim/bin/node (faithful nvm-style — SAFE_PATH l
 
 note "Stage 3 — start daemon under nvm-sim node"
 ANET_BIN_ABS="$ANET_BIN" \
+ANET_DAEMON_ALLOW_ENV_BIN=1 \
   nohup /opt/anet-nvm-sim/bin/node "$AGENT_NODE_BIN" \
     --config "$WORK/.anet/nodes/$DAEMON_NAME/config.json" \
     --alias "$DAEMON_NAME" --runtime claude-agent-sdk \

--- a/tests/qa-rfc026-create-node/run.sh
+++ b/tests/qa-rfc026-create-node/run.sh
@@ -106,6 +106,8 @@ cat > "$WORK/.anet/nodes/$DAEMON_NAME/config.json" <<EOF
 EOF
 cd "$WORK"
 export ANET_BIN_ABS=$(realpath -e "$(which anet)")
+# 本套件绕过 `anet daemon`(用 `anet node start`),CLI 的自动声明到不了这里 —— 见 #1299
+export ANET_DAEMON_ALLOW_ENV_BIN=1
 nohup anet node start "$DAEMON_NAME" > /tmp/daemon.log 2>&1 &
 DAEMON_PID=$!
 REGISTERED=""
@@ -528,6 +530,7 @@ RESOLVED_BY_WHICH=$(PATH=/tmp/evil-bin:$PATH which anet)
 cd /app/agent-node
 RESOLVED=$(PATH=/tmp/evil-bin:$PATH \
   ANET_BIN_ABS="$REAL_ANET" \
+  ANET_DAEMON_ALLOW_ENV_BIN=1 \
   ANET_DAEMON_PATH_CONF=/nonexistent \
   ANET_DAEMON_ALLOW_NON_ROOT_BIN=1 \
   bun -e 'import("./src/runtime/create-node-daemon.ts").then(m => { console.log(m.loadAndVerifyAnetBin()); }).catch(e => { console.error("ERR:" + e.message); process.exit(2); });' 2>&1 | tail -1)
@@ -617,6 +620,7 @@ EOF2
   cd "$WORK"
   # Start nvm daemon under /opt/anet-nvm-sim/bin/node (process.execPath becomes that path)
   ANET_BIN_ABS=$(realpath -e "$(which anet)") \
+  ANET_DAEMON_ALLOW_ENV_BIN=1 \
     nohup /opt/anet-nvm-sim/bin/node "$AGENT_NODE_BIN" \
       --config "$WORK/.anet/nodes/$NVM_DAEMON_NAME/config.json" \
       --alias "$NVM_DAEMON_NAME" --runtime claude-agent-sdk \

--- a/tests/qa-rfc027-stop-delete/run.sh
+++ b/tests/qa-rfc027-stop-delete/run.sh
@@ -219,6 +219,8 @@ EOF
 cd "$WORK"
 export HOME="$WORK"   # ~/.anet/deleted will land under $WORK/.anet/deleted
 export ANET_BIN_ABS=$(realpath -e "$(which anet)")
+# 本套件绕过 `anet daemon`(用 `anet node start`),CLI 的自动声明到不了这里 —— 见 #1299
+export ANET_DAEMON_ALLOW_ENV_BIN=1
 nohup anet node start "$DAEMON_NAME" > /tmp/daemon-027.log 2>&1 &
 DAEMON_PID=$!
 REGISTERED=""

--- a/tests/qa-rfc028-provider-probe/run.sh
+++ b/tests/qa-rfc028-provider-probe/run.sh
@@ -155,6 +155,8 @@ cat > "$WORK/.anet/nodes/$DAEMON_NAME/config.json" <<EOF
 EOF
 cd "$WORK"
 export ANET_BIN_ABS=$(realpath -e "$(which anet)")
+# 本套件绕过 `anet daemon`(用 `anet node start`),CLI 的自动声明到不了这里 —— 见 #1299
+export ANET_DAEMON_ALLOW_ENV_BIN=1
 ANET_DAEMON_PROBE_ALLOW_LOOPBACK=1 NODE_EXTRA_CA_CERTS=/tmp/anet-mock-cert.pem \
   nohup anet node start "$DAEMON_NAME" > /tmp/daemon.log 2>&1 &
 DAEMON_PID=$!


### PR DESCRIPTION
## Summary
- Resolve and pin the current anet binary during `anet daemon init/start/up`, so daemon-created nodes no longer require manual `ANET_BIN_ABS` setup.
- Auto-repair group/other-writable npm installs with `chmod go-w`, allow user-owned nvm/homebrew/npm installs by default, and reject Windows daemon mode up front for #1290.
- Keep runtime-side `loadAndVerifyAnetBin` as the fail-closed backstop with root-cause-specific repair commands.
- Update CN/EN daemon docs §3.6 only; note possible rebase interaction with docs PR #1297, which is editing §4/§5.

## Verification
- `git diff --stat` in clean worktree showed only the 5 intended files.
- `bun test agent-node/src/runtime/create-node-daemon.test.ts`
- `npm run typecheck` in `agent-network`
- `bun build bin/cli.ts --outdir /tmp/anet-cli-build-check-wt --target node --external @sleep2agi/commhub-server --external bun:sqlite --external '../../server/*'`\n- `python3 .github/scripts/check-qa-paths-symmetry.py --selftest`\n- `python3 .github/scripts/check-qa-paths-symmetry.py`\n- `git diff --check`\n\n## Not Yet Verified\n- Clean-machine end-to-end: `npm i -g -> anet login -> anet daemon up -> hub create_node -> spawned child + capability check OK + child self-registers`. Vincent/relay or Mac Mini validation is still the decisive acceptance gate.\n\n## Notes\n- `npm ci` in the clean worktree emitted the existing engine warning because this host is Node v20.20.0 while `agent-network` declares Node >=22.13.0; typecheck/build still passed after dependencies installed.\n- This PR intentionally does not address the next goal about reusing Claude Code / Codex / Grok local login state for keyless node creation; that should be a follow-up after this ANET_BIN path lands.\n