### PR TITLE
ci(docs-site-drift): 门红了要开 issue —— 「Actions 里变红」已被实测证明不是通知渠道（方案 D）

### DIFF
--- a/.github/scripts/docs-site-drift-notify.sh
+++ b/.github/scripts/docs-site-drift-notify.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# 把 docs-site-drift 的结果送到人眼前 —— 而不是只在 Actions 里变红。
+#
+# ## 为什么需要它
+#
+# `check-docs-site-drift.py` 判定一直是对的,问题在**没有任何渠道**能让它的结论
+# 到达人:**那道门连红 8 天没人动**(2026-08-19 ~ 08-27)。
+# ⇒ 「Actions 里变红」**已被实测证明不是一个通知渠道**。
+#
+# 而这道门红了指向的动作是唯一且明确的(从 origin/main 的 worktree 跑
+# `vercel --prod`),所以它值得被送出来。
+#
+# ## 判据:一条 tracker issue,开/更新/关,不刷屏
+#
+# 定时每天跑一次 ⇒ 若每次红都新开一条,8 天就是 8 条。
+# 用 body 里的隐藏标记找那条已存在的 issue,有则更新、无则新建;绿了则关掉。
+#
+# ## 🔴 rc=1 与 rc=2 必须给不同的话
+#
+#   rc=1  站点落后于 main          → 动作:部署
+#   rc=2  取不到/量不了(网络等)     → 动作:去查为什么量不了,**不是**去部署
+#
+# 这两个在原来的实现里都会走 `exit 2 refusing to pass`,把真漂移报成基础设施故障;
+# #1238 把它们分开了。通知这一层**不能把它们又合回去** —— 对着一个量不出来的站点
+# 喊"快去部署"是**假指令**,而人会照做。
+#
+# ## 这一层不改判定
+#
+# 通知是附加的:job 的红/绿仍由脚本自己的退出码决定(workflow 里最后一步重放它)。
+set -uo pipefail
+
+MARK='<!-- docs-site-drift-tracker -->'
+OUT="${DRIFT_OUT:-drift.out}"
+RC="${RC:-1}"
+REPO="${GITHUB_REPOSITORY:-sleep2agi/agent-network}"
+RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/actions/runs/${GITHUB_RUN_ID:-0}"
+
+find_tracker() {
+  gh issue list --repo "$REPO" --state open --search "\"docs-site-drift-tracker\" in:body" \
+     --json number --jq '.[0].number // empty' 2>/dev/null
+}
+
+body_for() {
+  local rc="$1" detail="$2"
+  printf '%s\n\n' "$MARK"
+  if [ "$rc" = "1" ]; then
+    cat <<EOF
+**anet.sh 落后于 \`main\`。** 这道门检查的是**已部署的站点**,不是仓库内容 ——
+所以它红了不代表有人写错了什么,而是**合并之后没有人跑部署**。
+
+anet.sh 没有接 git 自动部署:**合并进 main 不会让站点更新**。
+
+### 要做的事(唯一且明确)
+
+\`\`\`bash
+git fetch origin main
+git worktree add --detach /tmp/anet-site origin/main
+cd /tmp/anet-site/docs-site
+cp -r <主checkout>/docs-site/.vercel .vercel
+ln -sfn <主checkout>/docs-site/node_modules node_modules
+npm run build          # ignoreDeadLinks 未设,有死链会 fail —— 别带着死链上线
+vercel --prod --yes    # 期望结尾 Aliased: https://www.anet.sh
+\`\`\`
+
+### 验收:验内容,不验状态码
+
+\`200\` 只说明站点活着。\`age:\` 头**两个方向都偏向「已经好了」**,不能当判据。
+部署完重跑这道门,或直接抓刚改过的那句话:
+
+\`\`\`bash
+python3 .github/scripts/check-docs-site-drift.py
+\`\`\`
+
+详见 \`deploy/docs-site/README.md\`。
+EOF
+  else
+    cat <<EOF
+🔴 **这道门这次「量不出来」,不是「站点落后」。**
+
+退出码 \`$rc\` 的含义是**取不到样本 / 抓不到页面**(网络、站点不可达、采样集塌了)——
+**不要据此去部署**。对着一个量不出来的站点部署,既修不了问题,也会把
+「我们其实不知道现状」这件事掩盖掉。
+
+### 要做的事
+
+先弄清**为什么量不了**,再决定要不要部署。
+EOF
+  fi
+  printf '\n### 本次输出\n\n```\n%s\n```\n\n[完整 run](%s)\n' "$detail" "$RUN_URL"
+  printf '\n---\n*这条 issue 由 `docs-site-drift` 自动开/更新;门变绿时它会自动关闭。*\n'
+}
+
+detail="$( [ -f "$OUT" ] && tail -c 3000 "$OUT" || echo '(no output captured)' )"
+tracker="$(find_tracker)"
+
+if [ "$RC" = "0" ]; then
+  if [ -n "$tracker" ]; then
+    gh issue comment "$tracker" --repo "$REPO" \
+      --body "✅ 门已变绿:anet.sh 上的采样页面与 \`main\` 一致。自动关闭。
+
+[完整 run]($RUN_URL)"
+    gh issue close "$tracker" --repo "$REPO" >/dev/null
+    echo "closed tracker #$tracker (gate green)"
+  else
+    echo "gate green, no tracker open — nothing to do"
+  fi
+  exit 0
+fi
+
+title="$( [ "$RC" = "1" ] && echo '[docs-site-drift] anet.sh 落后于 main —— 需要有人跑一次部署' \
+                          || echo "[docs-site-drift] 这道门量不出来(exit $RC) —— 先查为什么" )"
+
+if [ -n "$tracker" ]; then
+  body_for "$RC" "$detail" > /tmp/drift-body.md
+  gh issue edit "$tracker" --repo "$REPO" --title "$title" --body-file /tmp/drift-body.md >/dev/null
+  gh issue comment "$tracker" --repo "$REPO" --body "🔁 仍未解决(exit \`$RC\`)。已更新正文为最新一次结果。
+
+[完整 run]($RUN_URL)"
+  echo "updated tracker #$tracker"
+else
+  body_for "$RC" "$detail" > /tmp/drift-body.md
+  n="$(gh issue create --repo "$REPO" --title "$title" --body-file /tmp/drift-body.md \
+       --json number --jq .number 2>/dev/null || gh issue create --repo "$REPO" \
+       --title "$title" --body-file /tmp/drift-body.md)"
+  echo "opened tracker: $n"
+fi

--- a/.github/workflows/published-artifact-drift.yml
+++ b/.github/workflows/published-artifact-drift.yml
@@ -151,10 +151,37 @@ jobs:
     name: docs-site-drift
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # 🔴 只给这一个 job、只给它要用的那一格权限。
+    #    通知需要开/更新 issue;它不需要写仓库内容。
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:
           # 需要历史才能取「最近新增的行」——指纹只从那里选,见脚本注释。
           fetch-depth: 80
       - run: python3 .github/scripts/check-docs-site-drift.py --selftest
-      - run: python3 .github/scripts/check-docs-site-drift.py
+      - name: check anet.sh against main
+        id: drift
+        run: |
+          set +e
+          python3 .github/scripts/check-docs-site-drift.py > drift.out 2>&1
+          rc=$?
+          set -e
+          # 🔴 退出码不穿管道:先落进变量,再写 output。
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          cat drift.out
+      # 方案 D:把结论送到人眼前。那道门连红 8 天没人动 ⇒
+      # 「Actions 里变红」已被实测证明不是一个通知渠道。
+      - name: open / update / close the tracking issue
+        if: always() && steps.drift.outputs.rc != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RC: ${{ steps.drift.outputs.rc }}
+          DRIFT_OUT: drift.out
+        run: bash .github/scripts/docs-site-drift-notify.sh
+      # 🔴 判定仍由脚本自己的退出码决定 —— 通知是附加的,不改红绿。
+      - name: re-raise the check's exit code
+        if: always()
+        run: exit ${{ steps.drift.outputs.rc }}


### PR DESCRIPTION
方案 D，按 通信龙 的决定实施。**不碰 Vercel 侧、不加任何凭据**（方案 A 由有 Vercel 权限的人试）。

**按内容搜过**：`docs-site-drift` ⇒ 零命中 · `tracker issue` ⇒ 零命中 · `issues: write` ⇒ #808（文档记录，无关）。

---

## 为什么

`check-docs-site-drift.py` 的**判定一直是对的**。缺的是**渠道**：

> **那道门连红 8 天没人动**（2026-08-19 ~ 08-27），期间 anet.sh 一直在给用户一句我们已经证伪并删掉的话（「`anet daemon` 只在 preview 通道上存在」），而 Vincent 两次问「daemon 如何体验」。

⇒ **「Actions 里变红」已被实测证明不是一个通知渠道。**

这道门红了指向的动作**唯一且明确**（从 `origin/main` 的 worktree 跑 `vercel --prod`），所以它值得被送出来。

## 怎么做

新增 `.github/scripts/docs-site-drift-notify.sh`，由 `docs-site-drift` job 调用。

**一条 tracker issue，开 / 更新 / 关。** 用 body 里的隐藏标记定位它 —— 定时每天跑，若每次红都新开，8 天就是 8 条。**门变绿时自动关闭**并留一条说明 comment，让 issue 的开关状态跟着现实走（而不是修好了还挂着变成墙纸）。

🔴 **rc=1 与 rc=2 必须给不同的话：**

| rc | 含义 | 通知里给的动作 |
|---|---|---|
| `1` | 站点落后于 main | **去部署**（附完整命令 + 内容验收） |
| `2` | 取不到 / 量不了 | **先查为什么量不了 —— 不是去部署** |

#1238 刚把这两者分开（原来都走 `exit 2`，把真漂移报成基础设施故障）。**通知这一层不能把它们又合回去** —— 对着一个量不出来的站点喊"快去部署"是**假指令**，而人会照做。

**不改判定。** job 的红/绿仍由脚本自己的退出码决定，最后一步原样重放；通知纯附加。

**最小权限**：`issues: write` 只加在这一个 job 上，不加 `contents: write`，不加在 top-level。

**不引第三方 action**，用 `gh` CLI —— 不给 `check-action-pins` 增加供应链面。

## 测过（stub 掉 `gh`，五条路径 + 两侧正控）

```
rc=0 无 tracker   → 什么都不做
rc=0 有 tracker   → comment + close
rc=1 无 tracker   → create
rc=1 有 tracker   → edit + comment   ← 不 create，所以不会每天刷一条
rc=2              → create，但换一套话
```

**正控放在两侧**（只验"看起来对"证明不了什么）：

```
rc=2 正文里 `vercel --prod` 出现次数 = 0    ← 绝不能教人去部署
rc=1 正文里 `vercel --prod` 出现次数 = 1    ← 必须给出那条命令
```

## 门

```
check-workflow-structure  rc=0   27 workflow / 53 job, problems=0
check-action-pins         rc=0   71 个 action 引用全部钉 SHA
check-home-path-baseline  rc=0   无文件超出基线
bash -n                   通过
```

## 不在本 PR 里

- **方案 A（Vercel Git 集成）** —— 需要 Vercel 侧操作。⚠️ 实施时注意 通信龙 查到的一条：该项目 **Root Directory 目前是 `.` 而不是 `docs-site`**，接 Git 集成时**必须一起改**，否则 Vercel 会在仓根构建（vitepress 项目在 `docs-site/`）。
- **`projectId` / `orgId` 入库**（已获批准）—— 我手上只有名称（org `vansins-projects`、project `docs-site`），**没有那两个 ID 本身**，它们在 `.vercel/project.json` 里而该目录被 gitignore。拿到值我另开一个 PR。建议**只入库那两个不透明 ID，不要入库 org slug** —— slug 里含人名，而 ID 不含。