### PR TITLE
fix(daemon): three runtime gates carried the same stale trio, so no TUI co-presence node could be created

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -2054,6 +2054,7 @@ interface Profile {
 import {
   normalizeRuntime,
   normalizeRuntimeStrict,
+  SUPPORTED_RUNTIME_NAMES,
   type RuntimeName,
 } from "../src/normalize-runtime";
 import { findEnvironAliasMatches } from "../src/environ-alias";
@@ -8130,7 +8131,10 @@ async function daemonInitCommand() {
     hub: gc.hub,
     token: mintedToken,
     network_id: gc.network_id,
-    runtimes_supported: ["claude-agent-sdk", "codex-sdk", "grok-build-acp"],
+    // #1298 — 引用 canonical 集合，不再手写。这里曾经是硬编码的三元组，
+    // 于是 grok-build-cli / codex-app-server / opencode-cli 三个共存 runtime
+    // 永远不会出现在 daemon 的能力声明里，hub 据此把 create_node 拒掉。
+    runtimes_supported: [...SUPPORTED_RUNTIME_NAMES],
     allowed_secret_keys: allowedSecretKeys,
     max_concurrent_children: 20,
     channels: [],

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -163,7 +163,28 @@ export function minimalEnv(extra: Record<string, string> = {}): NodeJS.ProcessEn
 
 const NAME_RE = /^[a-z][a-z0-9_-]{0,63}$/;
 const MODEL_RE = /^[a-zA-Z0-9._:\-]+$/;
-const VALID_RUNTIMES = new Set(["claude-agent-sdk", "codex-sdk", "grok-build-acp"]);
+// #1298 — 必须与 agent-network/src/normalize-runtime.ts 的 SUPPORTED_RUNTIME_NAMES
+// 逐字一致。两个包之间没有依赖关系（agent-node 不 import agent-network），所以这里
+// 只能是一份副本；而副本靠纪律会漂 —— 本仓 im/access-resolve.ts 那对镜像就没有门。
+// 因此 runtime-set-parity.test.ts 会跨包 import 两边并断言相等：改了 canonical 而
+// 忘了这里，那条测试立刻红并告诉你差哪几个。
+//
+// 🔴 这个集合不能删。agent-network 的 createCommand 对未知 runtime 走的是
+// else 分支（当作 claude-agent-sdk 继续），也就是**静默降级不报错**，所以
+// launcher 目前不是权威。让 launcher 走 normalizeRuntimeStrict 是独立的一条。
+const VALID_RUNTIMES = new Set([
+  "claude-agent-sdk",
+  "claude-code-cli",
+  "codex-sdk",
+  "codex-app-server",
+  "grok-build-acp",
+  "grok-build-cli",
+  "opencode-cli",
+]);
+/** 测试钩子 —— 让 runtime-set-parity.test.ts 能拿到这份副本做跨包等价断言。
+ *  只读用途，不要在产品代码里用它绕过 VALID_RUNTIMES 本身的检查。 */
+export const _internals = { VALID_RUNTIMES };
+
 const PERMISSION_MODES = new Set(["default", "acceptEdits", "plan", "bypassPermissions"]);
 
 // §4.2.2 daemon-side flag VALUE validator — defense in depth, mirrors

--- a/agent-node/src/runtime/runtime-set-parity.test.ts
+++ b/agent-node/src/runtime/runtime-set-parity.test.ts
@@ -1,0 +1,41 @@
+// #1298 — 跨包等价门。
+//
+// daemon 的 create_node 有三道闸，历史上三道各自硬编码了同一份三元组，于是
+// grok-build-cli / codex-app-server / opencode-cli 三个共存 runtime 在 CLI 上
+// 可用、在 daemon 上一个都创建不出来。收敛之后 canonical 只有一处：
+//   agent-network/src/normalize-runtime.ts → SUPPORTED_RUNTIME_NAMES
+//
+// 但 agent-node 不依赖 agent-network（两个 npm 包，无 workspace），所以
+// create-node-daemon.ts 里那份有效性集合只能是副本。本仓已有的镜像做法
+// （im/access-resolve.ts）只有一句「MUST stay in sync」注释、没有门 —— 那正是
+// 产生这个 bug 的机制。这条测试就是那道门：改了 canonical 而没同步副本，它红。
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { SUPPORTED_RUNTIME_NAMES } from "../../../agent-network/src/normalize-runtime";
+import { _internals } from "./create-node-daemon";
+
+describe("#1298 runtime 集合跨包一致", () => {
+  test("daemon 的 VALID_RUNTIMES 与 canonical 逐字相等", () => {
+    const daemon = [..._internals.VALID_RUNTIMES].sort();
+    const canonical = [...SUPPORTED_RUNTIME_NAMES].sort();
+    // 用 toEqual 而不是比长度：长度相等但内容不同的漂移必须也能红。
+    expect(daemon).toEqual(canonical);
+  });
+
+  test("三个 TUI 共存 runtime 都在里面（这是 #1298 的验收面）", () => {
+    for (const rt of ["grok-build-cli", "codex-app-server", "opencode-cli"]) {
+      expect(_internals.VALID_RUNTIMES.has(rt)).toBe(true);
+      expect(SUPPORTED_RUNTIME_NAMES).toContain(rt as any);
+    }
+  });
+
+  test("anet daemon init 写进配置的能力声明引用 canonical，而不是又一份手写数组", () => {
+    // 判据落在源码文本上：这里要断言的是「没有第二份清单」这件结构事实，
+    // 而运行 daemon init 需要 hub + 登录态，在单测里够不到。
+    const cliSrc = readFileSync(join(import.meta.dir, "../../../agent-network/bin/cli.ts"), "utf8");
+    expect(cliSrc).toContain("runtimes_supported: [...SUPPORTED_RUNTIME_NAMES]");
+    // 旧的硬编码三元组不能再出现在能力声明里
+    expect(cliSrc).not.toContain('runtimes_supported: ["claude-agent-sdk", "codex-sdk", "grok-build-acp"]');
+  });
+});

--- a/tests/qa-anet-daemon-cmd/run.sh
+++ b/tests/qa-anet-daemon-cmd/run.sh
@@ -71,8 +71,21 @@ anet daemon init "$DAEMON_NAME" 2>&1 | tee /tmp/init.log >/dev/null
 ROLE=$(jq -r '.role' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
 [[ "$ROLE" == "host_supervisor" ]] && ok "config.role == host_supervisor (no vim required)" || bad "role='$ROLE' expected host_supervisor"
 
-RUNTIMES=$(jq -r '.runtimes_supported | join(",")' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
-[[ "$RUNTIMES" == "claude-agent-sdk,codex-sdk,grok-build-acp" ]] && ok "runtimes_supported defaults set" || bad "runtimes_supported='$RUNTIMES'"
+# #1298 — 判据引用 canonical，不再把名字硬编码进测试。
+# 这条断言以前钉死 "claude-agent-sdk,codex-sdk,grok-build-acp"，于是把 daemon 能力
+# 声明锁在旧三元组上：三个 TUI 共存 runtime 一旦加进来，这里就红。把清单再抄一遍
+# 到测试里会造出第四份副本，下次加 runtime 仍要改两处 —— 所以直接问 canonical。
+CANONICAL_RUNTIMES=$(cd /app/agent-network && bun -e 'import("./src/normalize-runtime.ts").then((m)=>console.log([...m.SUPPORTED_RUNTIME_NAMES].sort().join(",")))' 2>/dev/null)
+RUNTIMES=$(jq -r '.runtimes_supported | sort | join(",")' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
+# 🔴 先断言 canonical 真的取到了：取不到会让下面变成 ""=="" 的恒真比较，
+#    那是一条永远绿、什么都不证明的断言。
+[[ -n "$CANONICAL_RUNTIMES" ]] && ok "canonical runtime list resolved ($CANONICAL_RUNTIMES)" \
+  || bad "could not read SUPPORTED_RUNTIME_NAMES from agent-network/src/normalize-runtime.ts"
+# 比较**集合**（两边都 sort 过）而不是书写顺序：顺序不是这条断言要守的性质，
+# 而按顺序比会让一次无害的重排变成假红。
+[[ -n "$CANONICAL_RUNTIMES" && "$RUNTIMES" == "$CANONICAL_RUNTIMES" ]] \
+  && ok "runtimes_supported defaults == canonical SUPPORTED_RUNTIME_NAMES" \
+  || bad "runtimes_supported='$RUNTIMES' != canonical='$CANONICAL_RUNTIMES'"
 
 ALLOWED=$(jq -r '.allowed_secret_keys | length' "$WORK/.anet/nodes/$DAEMON_NAME/config.json")
 [[ "$ALLOWED" == "0" ]] && ok "allowed_secret_keys fail-closed (empty by default per §9.7)" || bad "allowed_secret_keys length=$ALLOWED expected 0"


### PR DESCRIPTION
第 1 条（#1298）。Vincent goal 的第一条压在这里：三个 TUI 共存 runtime 在 daemon 上一个都创建不出来。

## 问题

`create_node` 经过三道独立的闸，**三道都硬编码了同一份三元组** `["claude-agent-sdk", "codex-sdk", "grok-build-acp"]`。于是 `grok-build-cli` / `codex-app-server` / `opencode-cli` 在 CLI 上可用、经 daemon 一个都建不出来。

## canonical 早就存在，而且早就是全的

`agent-network/src/normalize-runtime.ts` 的 `SUPPORTED_RUNTIME_NAMES` 列了全部 7 个，而且那个模块的注释写着它就是为了「让别处能 import 而不触发 CLI 副作用」被抽出来的。**三道闸只是没用它。** 所以这不是新机制，是本仓已经写下的规则没被一致应用。

| 闸 | 位置 | 改动 |
|---|---|---|
| 1 | `agent-network/bin/cli.ts` — `anet daemon init` 把三元组写进 `runtimes_supported`，成为 hub 过滤所依据的 daemon capability | → `[...SUPPORTED_RUNTIME_NAMES]`，真引用 |
| 2 | `create-node-daemon.ts` 运维 allowlist 复核 | 机制不变；内容来自闸 1 的配置，因而已 canonical |
| 3 | `create-node-daemon.ts` `VALID_RUNTIMES`，抛 `runtime_invalid` 的那个写死 Set | 补齐为 7 个 |

## 闸 3 为什么仍是副本 —— 以及为什么这次副本带门

agent-node **不依赖** agent-network（两个 npm 包，无 workspace）。本仓对这种情况的既有答案是 MIRROR 注释：`im/access-resolve.ts` 写着「both files MUST stay in lockstep」，**没有任何东西强制它**。靠纪律正是产生本 bug 的机制。

所以这份副本配了 `runtime-set-parity.test.ts`：跨包 import 两边并断言相等。改了 canonical 而忘了副本 ⇒ 它红，并指出差哪几个。

## 闸 3 为什么不能干脆删掉，让 launcher 当权威

因为 launcher 今天**不是**权威。`agent-network` 的 `createCommand` 用 if/else 链匹配 runtime，而它的 `else` 分支把**任何未知值当成 `claude-agent-sdk` 继续执行** —— 静默降级，不报错。删掉闸 3 等于开一条静默降级通道：hub 传来一个拼错的 runtime，会创建出一个悄悄跑着 claude-agent-sdk 的节点。

让 `createCommand` 走 `normalizeRuntimeStrict`（那个模块自己的 docblock 就写着 create 边界应当用 strict）是**独立的一条**，已记录，未打包进来。

## 验证

- **双向变异**：从副本里删掉一个 runtime ⇒ 3 条红 2 条；把闸 1 改回硬编码三元组 ⇒ 红第 3 条。还原后 3/3 绿。
- `agent-network` tsc：exit **0**，0 errors。
- **回归**：28 个 runtime/create-node/normalize/stop-daemon/config-apply 套件，**逐文件独立进程** ⇒ **523 pass / 0 fail**。

## 刻意没做

hub 侧 `runtime: z.string()` **完全没有 allowlist**。要不要在 hub 边界也收口是另一个决策，记录在 #1298，不在这里私自定。

## 查重

按内容搜过：`SUPPORTED_RUNTIME_NAMES` / `VALID_RUNTIMES` / `runtimes_supported` ⇒ 无 open PR 碰这条路径。按文件查重过：扫 open PR 的 `agent-network/bin/cli.ts`、`create-node-daemon.ts` ⇒ 零重叠（#1292 也动 `agent-node/src/runtime/`，但改的是 `stop-daemon.ts`，与本 PR 不同文件）。
