### PR TITLE
deploy(docs-site): 把 Vercel 项目关联入库（只入不透明 ID，不入含人名的 org slug）

### DIFF
--- a/deploy/docs-site/README.md
+++ b/deploy/docs-site/README.md
@@ -102,6 +102,32 @@ vercel promote <上一个部署的 URL>            # 或 vercel redeploy <URL>
 按 §19,在隔离环境演练并把证据记进 `docs/tests/` 之前,**不得宣称"可恢复"** ——
 当前地位是「已知正确的操作手册」。
 
-其中**登录态与项目关联**是最大的未覆盖项:`.vercel/project.json` 里的
-`projectId` / `orgId` 可以入库(不是密钥),但 CLI 的登录凭据不能,
+其中**登录态**仍是未覆盖项:CLI 的登录凭据不能入库,
 只记录"需要有权限的账号登录"这一事实与获取方式。
+
+**项目关联已经入库了**(2026-08-27),见下一节 —— 那一半的 bus-factor 已经消掉。
+
+## 恢复项目关联
+
+`docs-site/.vercel/` 被 gitignore(**那条 ignore 是安全属性,别为了这三个字段撤掉它** ——
+它挡的是 `vercel link` 之后把登录态之类的东西顺手提交进来)。
+所以项目关联单独存在 [`vercel-project.json`](./vercel-project.json):
+
+```bash
+mkdir -p docs-site/.vercel
+python3 - <<'EOF'
+import json
+src = json.load(open('deploy/docs-site/vercel-project.json'))
+json.dump({k: src[k] for k in ('projectId', 'orgId', 'projectName')},
+          open('docs-site/.vercel/project.json', 'w'), indent=2)
+EOF
+```
+
+之后 `vercel --prod --yes` 就能认到项目;**登录仍需一个有权限的账号**(`vercel login`)。
+
+🔴 **那三个字段不是密钥** —— 没有 Vercel token,它们不授予任何权限。
+入库的理由是降 bus-factor:在此之前**项目关联只存在于某一台机器上**,
+跟"部署要靠某个人记得跑"是同一个单点,而这一半**不需要任何 Vercel 权限就能修**。
+
+🔴 **只收录不透明 ID,不收录 CLI 输出里那个组织 slug** —— 那个 slug 含人名,
+两个 ID 不含。降 bus-factor 不必以新增一处真实标识为代价。

--- a/deploy/docs-site/vercel-project.json
+++ b/deploy/docs-site/vercel-project.json
@@ -1,0 +1,20 @@
+{
+  "_comment": [
+    "anet.sh 那个 Vercel 项目的关联信息。放在这里而不是 docs-site/.vercel/project.json,",
+    "是因为 .vercel/ 被 gitignore —— 那条 ignore 是一道安全属性(防止 vercel link 之后",
+    "把登录态之类的东西顺手提交进来),不应该为了这三个字段把它撤掉。",
+    "",
+    "这三个字段不是密钥:没有 Vercel token,它们不授予任何权限。",
+    "把它们入库是为了降 bus-factor —— 在此之前,项目关联只存在于某一台机器上,",
+    "跟『部署要靠某个人记得跑』是同一个单点。",
+    "",
+    "🔴 刻意只收录不透明 ID,不收录 CLI 输出里那个组织 slug:那个 slug 含人名,",
+    "而这两个 ID 不含。降 bus-factor 不需要以新增一处真实标识为代价。",
+    "(这条注释本身也不写出那个 slug —— 否则等于一边说不收录一边把它写进仓里。)",
+    "",
+    "用法见同目录 README.md 的『恢复项目关联』一节。"
+  ],
+  "projectId": "prj_1NXR34ug3vfHfAsykG4I2XIxsuk6",
+  "orgId": "team_3SDh1gZJ7SR2jSWEAsB6oXDq",
+  "projectName": "docs-site"
+}


### PR DESCRIPTION
部署这条链有两个单点：① "要有人记得跑"（→ #1300 方案 D / 方案 A）；② **"项目关联只存在于某一台机器上"**。②**不需要任何 Vercel 权限就能修**，本 PR 修的是 ②。

ID 由 通信龙 提供并核过（`project.json` 里只有三个字段，无任何凭据）。

**按内容搜过**：`projectId` ⇒ 零命中 · `vercel-project` ⇒ 零命中 · `orgId` ⇒ 零命中。

## 放在哪、为什么不放回 `.vercel/`

`docs-site/.vercel/` 被 gitignore。**那条 ignore 是一道安全属性** —— 它挡的是 `vercel link` 之后把登录态之类的东西顺手提交进来。不该为了三个字段撤掉它。

所以关联信息单独放 `deploy/docs-site/vercel-project.json`，README 里给出重建 `.vercel/project.json` 的命令 —— **那段命令我实跑过**，输出：

```
reconstructed project.json = {"projectId": "prj_…", "orgId": "team_…", "projectName": "docs-site"}
```

## 只收录不透明 ID

| 字段 | 入库 |
|---|---|
| `projectId` (`prj_…`) | ✅ |
| `orgId` (`team_…`) | ✅ |
| `projectName` (`docs-site`) | ✅ |
| 组织 slug | ❌ **它含人名，上面三个不含** |

🔴 **写这个文件时自己踩了一次**：第一版的注释里为了说明"刻意不收录 slug"，**把那个 slug 写进了注释** —— 一边说不收录，一边把它写进仓里。

是文件自带的断言当场拦下的，不是我读出来的：

```
AssertionError: org slug leaked!
```

所以现在**注释本身也不写出它**。

## 这三个字段不是密钥

没有 Vercel token，它们不授予任何权限。`deploy/docs-site/README.md` 原本就写着「`projectId` / `orgId` 可以入库（不是密钥），CLI 的登录凭据不能」—— 本 PR 只是把那句话真正落地，并把 README 的"未覆盖项"从「登录态**与项目关联**」收窄成「登录态」。

## 门（🔴 先 `git add` 再跑）

```
home-path-baseline   rc=0   scanned 2343 → 2344 tracked file(s)
docs-integrity       rc=0   406 .md UTF-8 + 288 相对链接
no-memory-slugs      rc=0
```

🔴 第一次跑时新文件**还没 `git add`**，而这几道门数的是 **`tracked file(s)`** —— 未跟踪的新文件不在取集里，门会**绿得毫无意义**。`git add` 之后分母 2343 → **2344**：**分母变了才证明它真的被扫到了**，而不是被跳过。