### PR TITLE
docs(runtimes): channel table described 2.2.21, npm latest is now 2.3.0-preview.47

### DIFF
--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -6,15 +6,24 @@ Every Agent Node has a **Runtime** (engine kernel) that decides how the node cal
 
 > This table is the **single source of truth** for runtimes across the entire site. Other pages (`cli` / `agent-node` / `getting-started` / `clean-server`) reference it — they do not duplicate the full table.
 
-::: tip Which runtimes are available in which channel (real-machine verified)
-- **Stable** (`npm i -g @sleep2agi/agent-network`): **Production runtimes** — `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`. Follow npm's `latest` dist-tag for the exact version.
-- **Preview** (`@preview`): adds `codex-app-server` / `opencode-cli` on top of the 4 (**6 total**), and rejects unknown runtimes with an explicit error (stable **silently falls back** to the default runtime instead).
+::: tip Which runtimes are available in which channel (verified on a real install, 2026-08-27)
+Measured against that day's npm `latest` = **2.3.0-preview.47** (`preview` = 2.3.0-preview.51).
+After installing, the `anet node create` runtime picker lists **all seven**:
 
-Rows tagged `(preview)` below are **preview-only** and not selectable on stable.
+`claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `codex-app-server` / `grok-build-acp` / `grok-build-cli` / `opencode-cli`
+
+`anet daemon` and `anet grok attach` are present in that same version.
+
+🔴 **What this page said before — "codex-app-server / opencode-cli are preview-only", "grok-build-cli is in no package" — no longer holds for this version.** `latest` sat on 2.2.21 for a long time, and back then those statements were correct. **Read any behavioural claim together with its version**: change the dist-tag and the answer can invert.
 :::
 
-::: warning Grok TUI co-presence has not shipped
-`grok-build-cli` / `anet grok attach` are not in the current `latest` or `preview` packages, so they are not selectable runtimes in the table below. Use `grok-build-acp` for now; it does not support attach. See the [Grok TUI status page](/en/guide/grok-copresence).
+::: warning "Selectable in the picker" is neither "production-ready" nor "creatable by a daemon"
+Two things this page does not promise:
+
+- **Maturity**: `grok-build-cli` still describes itself in the picker as an experimental preview that only accepts trusted tasks. Listed is not stable.
+- **The daemon path**: when a node is created for you through `anet daemon`'s `create_node`, `grok-build-cli` / `codex-app-server` / `opencode-cli` are rejected by the daemon-side runtime gate ([#1298](https://github.com/sleep2agi/agent-network/issues/1298)). **Usable via a local `anet node create`, not usable via daemon** — until that fix reaches the version you have, the two paths give different answers.
+
+For the current state of Grok TUI co-presence see the [Grok TUI status page](/en/guide/grok-copresence); `grok-build-acp` does not support attach.
 :::
 
 | Runtime | npm package / engine | When to pick | Default models | Prereq auth | Wizard behavior (`anet node create`) |

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -6,15 +6,24 @@
 
 > 本表是全站 runtime 信息的**单一权威来源**, 其他页面 (`cli` / `agent-node` / `getting-started` / `clean-server`) 都引用这里, 别在那些页面里重复整表.
 
-::: tip 哪些 runtime 在哪个版本可用（真机实测）
-- **正式版**（`npm i -g @sleep2agi/agent-network`）：**正式 runtime** —— `claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `grok-build-acp`。具体版本以 npm `latest` dist-tag 为准。
-- **预览版**（`@preview`）：在正式版之外再加 `codex-app-server` / `opencode-cli`；且对未知 runtime 会明确报错拦截（正式版会**静默退化**成默认 runtime，不报错）。
+::: tip 哪些 runtime 在哪个通道可用（容器内真机实测，2026-08-27）
+实测对象是当天的 npm `latest` = **2.3.0-preview.47**（`preview` = 2.3.0-preview.51）。
+装好后跑 `anet node create` 的 runtime 选单，**7 个全部列出**：
 
-下表标 `(preview)` 的行**仅预览版可用**，正式版选不到。
+`claude-agent-sdk` / `claude-code-cli` / `codex-sdk` / `codex-app-server` / `grok-build-acp` / `grok-build-cli` / `opencode-cli`
+
+同一版本里 `anet daemon` 与 `anet grok attach` 也都存在。
+
+🔴 **本页此前写的「codex-app-server / opencode-cli 仅预览版」「grok-build-cli 不在任何包中」对这个版本都不再成立** —— `latest` 曾长期停在 2.2.21，那时的说法是对的。**行为类说法请连版本号一起读**：换一个 dist-tag 结论就可能反过来。
 :::
 
-::: warning Grok TUI 共存尚未发布
-`grok-build-cli` / `anet grok attach` 不在当前 `latest` 或 `preview` 包中，因此不属于下面的可选 runtime。当前请使用 `grok-build-acp`；它不支持 attach。详见 [Grok TUI 状态页](/guide/grok-copresence)。
+::: warning 「选单里能选到」不等于「已生产就绪」，也不等于「daemon 能创建」
+两件事本页不替你打包票：
+
+- **成熟度**：`grok-build-cli` 在选单里仍自称「实验性 preview，仅可接收可信任务」。列出 ≠ 稳定。
+- **daemon 路径**：经 `anet daemon` 的 `create_node` 代创节点时，`grok-build-cli` / `codex-app-server` / `opencode-cli` 会被 daemon 侧的 runtime 闸拒掉（[#1298](https://github.com/sleep2agi/agent-network/issues/1298)）。**本机 `anet node create` 可用，daemon 代创不可用** —— 修复未进入你手上那个版本之前，这两条路径的结论不同。
+
+Grok TUI 共存的当前状态见 [Grok TUI 状态页](/guide/grok-copresence)；`grok-build-acp` 不支持 attach。
 :::
 
 | Runtime | npm 包 / 内核 | 适用场景 | 主推模型 | 前置 auth | wizard 行为 (`anet node create`) |

--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -24,7 +24,12 @@
 > anet 会自动跟随，无需改 cli.ts。两者都属于 release management 数据，**不是业务逻辑**。
 
 ::: tip R261 校准：docs 已无 hardcoded npm 版本，移出 Live versions
-R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md` + `agent-node.md` + `sdk-deep-dive.md` + `upgrade.md` + `deploy/npm.md` + `faq.md` 等 user-facing doc 内的 hardcoded npm 版本号（`@2.1.7` / `@2.3.0` / `MiniMax-M2.7` / Bun `>= 1.0` 等）**全部清除**，改成「查 npm latest tag / npm 包页 dist-tags」或 vendor 名（无版本）。原 docs reference 两行（runtimes / agent-node + agent-network 跨 6 doc）已经不再需要 release sync。
+R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md` + `agent-node.md` + `sdk-deep-dive.md` + `upgrade.md` + `deploy/npm.md` + `faq.md` 等 user-facing doc 内的 hardcoded npm 版本号（`@2.1.7` / `@2.3.0` / `MiniMax-M2.7` / Bun `>= 1.0` 等）**全部清除**，改成「查 npm latest tag / npm 包页 dist-tags」或 vendor 名（无版本）。原 docs reference 两行（runtimes / agent-node + agent-network 跨 6 doc）当时不再需要 release sync。
+> 🔴 **2026-08-27 起 `runtimes.md`（中英）重新需要**：#1298 把「哪些 runtime 在哪个通道可用」的实测结论连同 npm `latest` 的**具体版本号**写回了那一页，
+> 因为不带版本的写法让旧结论比它描述的对象活得更久（`latest` 从 2.2.21 跳到 2.3.0-preview.47 之后，那页三条陈述同时变假而没有任何门发现）。
+> 两份已登记进下表，发版时按表逐条重核。
+> 注意这道门的判据是**整文件子串匹配**（`f not in sop`），所以「路径在本文里出现过」就算登记 ——
+> 中文那份此前正是靠上面这句散文被判为已登记的，而那句话说的恰恰是它不需要重核。**登记要落在表里，不要只靠正文提到过。**
 
 未来加新 doc 时**不要再写硬版本号**（reviewer 拦截，rationale：每 release drift 一次维护负担，让 doc 引导用户去 npm 包页查最新 latest 比 doc 自己钉死可靠）。
 
@@ -66,9 +71,11 @@ R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md`
 > | `docs-site/docs/en/guide/architecture.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
 > | `docs-site/docs/en/guide/feishu.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
 > | `docs-site/docs/en/guide/grok-copresence.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/en/guide/runtimes.md` | 见门输出 | 信道断言 —— 通道表钉了 npm `latest` 的**具体版本号**(#1298)，换 dist-tag 即失真 |
 > | `docs-site/docs/en/preview/index.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
 > | `docs-site/docs/en/troubleshooting/case-feishu-silent-deny.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
 > | `docs-site/docs/guide/architecture.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
+> | `docs-site/docs/guide/runtimes.md` | 见门输出 | 信道断言 —— 同上(中文) |
 > | `docs-site/docs/guide/feishu.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
 > | `docs-site/docs/guide/grok-copresence.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |
 > | `docs-site/docs/preview/index.md` | 见门输出 | 信道断言(由 check-release-channel-assertions.py 扫出) |


### PR DESCRIPTION
第 2 条（#1298）。这页的通道表描述的是 `latest` 还停在 2.2.21 的时候。

## 三条对今天的 `latest` 都不成立

- 「`codex-app-server` / `opencode-cli` 仅预览版」
- 「`grok-build-cli` / `anet grok attach` 不在当前 `latest` 或 `preview` 包中」
- 「正式版 4 个 runtime」

容器里对当天的 `latest` = **2.3.0-preview.47** 实测（`preview` = 2.3.0-preview.51）：`anet node create` 的 runtime 选单 **7 个全部列出**，`anet daemon` 与 `anet grok attach` 也都存在。

## 替换文本刻意**不**说的两件事

两条都没实测，说了会误导：

- **列出 ≠ 生产就绪**：`grok-build-cli` 在选单里仍自称「实验性 preview，仅可接收可信任务」。
- **列出 ≠ daemon 能创建**：经 `anet daemon` 的 `create_node` 代创时，三个共存 runtime 仍被 daemon 侧闸拒（#1298 / PR #1301）。**本机 `anet node create` 可用、daemon 代创不可用** —— 修复进入用户手上那个版本之前，两条路径结论不同。这一格对读者很实际：他在选单里看得到，却会在 daemon 上失败。

## 版本号进了正文

旧文案**不带版本**，这正是它比它所描述的对象活得更久的原因。新块开头就写明「实测对象 = 2.3.0-preview.47 / 2026-08-27」，并提示行为类说法要连版本一起读 —— 换个 dist-tag 结论可能反过来。

## 验证

`cd docs-site && ./node_modules/.bin/vitepress build docs` ⇒ exit **0**。
中英对称：两份都是 **+15 / −6**。

## 查重

按内容搜过：`runtimes.md` / `codex-app-server` 通道标注 ⇒ 无 open PR 碰这两个文件。按文件查重过：扫 open PR ⇒ 零重叠（PR #1301 动的是 `agent-network/bin/cli.ts` 与 `agent-node/`，与本 PR 无交集，可并行合）。
