### PR TITLE
Add desktop user push and inbox count

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -127,6 +127,7 @@ on:
       - 'tests/test671-task-runtime-evidence-hub/**'
       - 'tests/test688-owner-gated-schedule-hub/**'
       - 'tests/test629-mcp-schema-policy/**'
+      - 'tests/test1280-desktop-user-push/**'
       - 'tests/qa-anet-daemon-cmd/**'
       - 'tests/qa-hub-16-rest-task-api/**'
       - 'tests/qa-node-04-codex-app-server-reply-routing/**'
@@ -287,6 +288,7 @@ on:
       - 'tests/test671-task-runtime-evidence-hub/**'
       - 'tests/test688-owner-gated-schedule-hub/**'
       - 'tests/test629-mcp-schema-policy/**'
+      - 'tests/test1280-desktop-user-push/**'
       - 'tests/qa-anet-daemon-cmd/**'
       - 'tests/qa-hub-16-rest-task-api/**'
       - 'tests/qa-node-04-codex-app-server-reply-routing/**'
@@ -935,6 +937,7 @@ jobs:
           - test671-task-runtime-evidence-hub
           - test688-owner-gated-schedule-hub
           - test629-mcp-schema-policy
+          - test1280-desktop-user-push
           - qa-anet-daemon-cmd
           - qa-hub-16-rest-task-api
           - qa-node-04-codex-app-server-reply-routing

--- a/docs/tests/report-test-desktop-user-push.txt
+++ b/docs/tests/report-test-desktop-user-push.txt
@@ -1,0 +1,22 @@
+Test: Desktop user-targeted SSE push
+Date: 2026-08-27
+Scope: Non-production local verification on clean worktree from origin/main.
+
+Commands:
+- sg docker -c 'docker build --build-arg SOURCE_COMMIT=$(git rev-parse HEAD) -t anet-test1280-desktop-user-push -f tests/test1280-desktop-user-push/Dockerfile . && docker run --rm anet-test1280-desktop-user-push'
+
+Results:
+- PASS: user-keyed SSE stream uses a separate \0user:<networkId>:<userId> key space.
+- PASS: same user + same network fan out reaches two live clients; after one reader cancels, the other still receives.
+- PASS: /events/users/me requires utok_, explicit network_id, and current network membership.
+- PASS: send_desktop_message succeeds for same-network user targets.
+- PASS: ntok caller cannot cross network via network_id/to_user_id; no audit or push is emitted before denial.
+- PASS: missing, conflicting, and unknown desktop targets fail closed before audit.
+- PASS: legacy /events/:alias and /events/network/:network_id paths remain live and isolated from the new user key space.
+- PASS: /api/messages?alias=... now filters to the requested inbox and returns pending_count from unacked rows.
+- PASS: Bun test reported 33 pass / 0 fail across observer-push, desktop-message, and observer-avatar-http.
+- PASS: anet-client-app production build completed.
+
+Notes:
+- This did not touch production Hub state.
+- Legacy /events/:alias client path is kept for backward compatibility.

--- a/prototype/anet-client-app/src/App.tsx
+++ b/prototype/anet-client-app/src/App.tsx
@@ -1,4 +1,6 @@
 import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { streamUserEvents } from "./api";
 import { selfAlias, useAuth } from "./auth";
 import { Login } from "./pages/Login";
 import { NodeList } from "./pages/NodeList";
@@ -39,11 +41,66 @@ function Topbar() {
   );
 }
 
+type DesktopNotice = {
+  id: string;
+  title?: string;
+  message: string;
+  severity: string;
+};
+
+function DesktopPushListener() {
+  const { utok, networkId } = useAuth();
+  const [notices, setNotices] = useState<DesktopNotice[]>([]);
+
+  useEffect(() => {
+    if (!utok || !networkId) return;
+    const ctrl = new AbortController();
+    (async () => {
+      try {
+        for await (const ev of streamUserEvents(utok, networkId, ctrl.signal)) {
+          if (ev.type !== "desktop_message") continue;
+          const id = String(ev.message_id ?? crypto.randomUUID());
+          setNotices((items) => [
+            ...items.slice(-2),
+            {
+              id,
+              title: typeof ev.title === "string" ? ev.title : undefined,
+              message: String(ev.message ?? ""),
+              severity: typeof ev.severity === "string" ? ev.severity : "info"
+            }
+          ]);
+          window.setTimeout(() => {
+            setNotices((items) => items.filter((item) => item.id !== id));
+          }, 8000);
+        }
+      } catch (e) {
+        if (!ctrl.signal.aborted) {
+          console.warn("[desktop] user SSE stream ended:", e);
+        }
+      }
+    })();
+    return () => ctrl.abort();
+  }, [utok, networkId]);
+
+  if (notices.length === 0) return null;
+  return (
+    <div className="desktop-notices" aria-live="polite">
+      {notices.map((notice) => (
+        <div key={notice.id} className={`desktop-notice ${notice.severity}`}>
+          {notice.title ? <strong>{notice.title}</strong> : null}
+          <span>{notice.message}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function App() {
   const utok = useAuth((s) => s.utok);
   return (
     <div className="app">
       <Topbar />
+      {utok ? <DesktopPushListener /> : null}
       <Routes>
         <Route path="/login" element={utok ? <Navigate to="/" replace /> : <Login />} />
         <Route

--- a/prototype/anet-client-app/src/api.ts
+++ b/prototype/anet-client-app/src/api.ts
@@ -265,16 +265,20 @@ export function sendTask(
 export type MessageRow = {
   id: string;
   session_name: string;
+  to_alias?: string;
+  from_alias?: string;
   type: string;
   priority?: string;
   content: string;
   from_session?: string;
+  acked?: number;
   created_at?: string;
 };
 
 export type MessagesResp = {
   ok: boolean;
   messages: MessageRow[];
+  pending_count?: number;
 };
 
 export function getMessages(
@@ -296,15 +300,9 @@ export type SseEvent = {
   [k: string]: unknown;
 };
 
-export async function* streamEvents(
-  alias: string,
-  ntok: string,
-  networkId: string,
-  signal?: AbortSignal
-): AsyncGenerator<SseEvent, void, void> {
-  const url = `${COMMHUB_URL}/events/${encodeURIComponent(alias)}?network_id=${encodeURIComponent(networkId)}`;
+async function* readSse(url: string, token: string, signal?: AbortSignal): AsyncGenerator<SseEvent, void, void> {
   const res = await fetch(url, {
-    headers: { authorization: `Bearer ${ntok}` },
+    headers: { authorization: `Bearer ${token}` },
     signal
   });
   if (!res.ok || !res.body) {
@@ -333,6 +331,25 @@ export async function* streamEvents(
       }
     }
   }
+}
+
+export async function* streamEvents(
+  alias: string,
+  ntok: string,
+  networkId: string,
+  signal?: AbortSignal
+): AsyncGenerator<SseEvent, void, void> {
+  const url = `${COMMHUB_URL}/events/${encodeURIComponent(alias)}?network_id=${encodeURIComponent(networkId)}`;
+  yield* readSse(url, ntok, signal);
+}
+
+export async function* streamUserEvents(
+  utok: string,
+  networkId: string,
+  signal?: AbortSignal
+): AsyncGenerator<SseEvent, void, void> {
+  const url = `${COMMHUB_URL}/events/users/me?network_id=${encodeURIComponent(networkId)}`;
+  yield* readSse(url, utok, signal);
 }
 
 // ── Live log — tmux capture-pane ──

--- a/prototype/anet-client-app/src/pages/Chat.tsx
+++ b/prototype/anet-client-app/src/pages/Chat.tsx
@@ -19,6 +19,7 @@ export function Chat() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showLog, setShowLog] = useState(false);
+  const [pendingCount, setPendingCount] = useState(0);
   const streamRef = useRef<AbortController | null>(null);
 
   const refresh = useCallback(async () => {
@@ -38,6 +39,7 @@ export function Chat() {
       // Only include messages between me and target alias (filter by from/to via inbox semantics)
       // /api/messages?alias=<me> returns my inbox; for the prototype we just show everything received.
       setMessages(next);
+      setPendingCount(resp.pending_count ?? next.filter((m) => m.kind === "agent").length);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : String(e));
     }
@@ -56,6 +58,9 @@ export function Chat() {
       try {
         for await (const ev of streamEvents(myAlias, ntok, networkId, ctrl.signal)) {
           if (ev.type === "new_task") {
+            if (typeof ev.inbox_count === "number") {
+              setPendingCount(ev.inbox_count);
+            }
             await refresh();
           }
         }
@@ -115,7 +120,10 @@ export function Chat() {
       >
         <div>
           <strong>{targetAlias}</strong>
-          <div className="muted">chat as {myAlias}</div>
+          <div className="chat-subhead">
+            <span className="muted">chat as {myAlias}</span>
+            {pendingCount > 0 ? <span className="unread-badge">{pendingCount} new</span> : null}
+          </div>
         </div>
         <button className="secondary" onClick={() => navigate("/")}>← Nodes</button>
       </div>

--- a/prototype/anet-client-app/src/styles.css
+++ b/prototype/anet-client-app/src/styles.css
@@ -135,6 +135,24 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
 .msg.me { align-self: flex-end; background: #1e3a8a; }
 .msg.agent { align-self: flex-start; background: var(--panel); border: 1px solid var(--border); }
 .msg .meta { font-size: 10px; color: var(--muted); margin-top: 4px; }
+.chat-subhead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.unread-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: white;
+  font-size: 12px;
+  line-height: 20px;
+  white-space: nowrap;
+}
 
 .composer {
   display: flex;
@@ -162,6 +180,29 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
   margin-top: 12px;
 }
 .live-log-toggle { background: transparent; color: var(--accent); border: 1px solid var(--border); margin-top: 8px; }
+
+.desktop-notices {
+  position: fixed;
+  right: 16px;
+  top: 64px;
+  z-index: 20;
+  display: grid;
+  gap: 8px;
+  width: min(360px, calc(100vw - 32px));
+}
+.desktop-notice {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.24);
+}
+.desktop-notice.success { border-left-color: var(--good); }
+.desktop-notice.warning { border-left-color: #f59e0b; }
+.desktop-notice.error { border-left-color: var(--bad); }
 
 @media (max-width: 560px) {
   .list-header, .node-row {

--- a/server/src/desktop-message.test.ts
+++ b/server/src/desktop-message.test.ts
@@ -1,0 +1,222 @@
+// Desktop user push contract.
+//
+// Pins the new user-keyed SSE path and send_desktop_message MCP tool:
+// - user streams are keyed by networkId:userId, never alias
+// - ntok callers cannot cross network by supplying a foreign to_user_id/network_id
+// - target ambiguity/miss is fail-closed before audit/push
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { db } from "./db.js";
+import { registerTools } from "./tools.js";
+import {
+  __resetSSEClientsForTest,
+  createUserEventStream,
+  pushUserEvent,
+} from "./push.js";
+
+const NET_A = "net_desktop_a";
+const NET_B = "net_desktop_b";
+const NODE_USER = "u_desktop_node_owner";
+const SENDER_USER = "u_desktop_sender";
+const TARGET_A = "u_desktop_target_a";
+const TARGET_B = "u_desktop_target_b";
+const TARGET_BOTH = "u_desktop_target_both";
+const ALL_USERS = [NODE_USER, SENDER_USER, TARGET_A, TARGET_B, TARGET_BOTH];
+
+type ToolHandler = (args: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+
+function cleanup() {
+  try { db.run("DELETE FROM audit_log WHERE action = 'send_desktop_message' OR network_id IN (?1, ?2)", [NET_A, NET_B]); } catch {}
+  try { db.run("DELETE FROM network_members WHERE network_id IN (?1, ?2)", [NET_A, NET_B]); } catch {}
+  try { db.run("DELETE FROM networks WHERE network_id IN (?1, ?2)", [NET_A, NET_B]); } catch {}
+  for (const u of ALL_USERS) {
+    try { db.run("DELETE FROM users WHERE user_id = ?1", [u]); } catch {}
+  }
+}
+
+function seed() {
+  for (const u of ALL_USERS) {
+    db.run(
+      `INSERT INTO users (user_id, username, password_hash, role, created_at)
+       VALUES (?1, ?2, 'x', 'user', datetime('now'))`,
+      [u, `${u}_name`],
+    );
+  }
+  db.run(`INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))`, [NET_A, SENDER_USER]);
+  db.run(`INSERT INTO networks (network_id, network_name, owner_id, created_at) VALUES (?1, ?1, ?2, datetime('now'))`, [NET_B, TARGET_B]);
+  const member = (userId: string, networkId: string, role: string) =>
+    db.run(`INSERT INTO network_members (user_id, network_id, role, joined_at) VALUES (?1, ?2, ?3, datetime('now'))`, [userId, networkId, role]);
+  member(NODE_USER, NET_A, "member");
+  member(SENDER_USER, NET_A, "owner");
+  member(TARGET_A, NET_A, "member");
+  member(TARGET_B, NET_B, "member");
+  member(TARGET_BOTH, NET_A, "member");
+  member(TARGET_BOTH, NET_B, "member");
+}
+
+beforeEach(() => { cleanup(); seed(); });
+afterEach(() => { __resetSSEClientsForTest(); });
+afterAll(cleanup);
+
+function buildHandlers(opts: { netId?: string | null; userId?: string | null; alias?: string | null; isNetwork?: boolean }) {
+  const server = new McpServer({ name: "test", version: "0" }) as any;
+  const tools: Record<string, ToolHandler> = {};
+  const origTool = server.tool.bind(server);
+  server.tool = (name: string, _desc: string, schema: any, handler: ToolHandler) => {
+    tools[name] = handler;
+    return origTool(name, _desc, schema, handler);
+  };
+  registerTools(
+    server,
+    undefined,
+    opts.netId ?? null,
+    opts.userId ?? null,
+    opts.alias ?? opts.userId ?? null,
+    opts.isNetwork ?? false,
+    "tok_desktop_test",
+  );
+  return tools;
+}
+
+async function call(handler: ToolHandler, args: any): Promise<Record<string, any>> {
+  const r = await handler(args);
+  return JSON.parse(r.content[0].text);
+}
+
+async function readFrame(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs = 2_000,
+): Promise<Record<string, any>> {
+  const decoder = new TextDecoder();
+  let buf = "";
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, rej) =>
+        setTimeout(() => rej(new Error(`no SSE frame within ${timeoutMs}ms`)), deadline - Date.now()),
+      ),
+    ]);
+    if (result.done) throw new Error("SSE stream ended unexpectedly");
+    buf += decoder.decode(result.value, { stream: true });
+    const sep = buf.indexOf("\n\n");
+    if (sep === -1) continue;
+    const rawFrame = buf.slice(0, sep);
+    buf = buf.slice(sep + 2);
+    const dataLine = rawFrame.split("\n").find((l) => l.startsWith("data: "));
+    if (!dataLine) continue;
+    return JSON.parse(dataLine.slice(6));
+  }
+  throw new Error(`no SSE frame within ${timeoutMs}ms`);
+}
+
+function auditCount() {
+  return db.get<{ n: number }>("SELECT COUNT(*) AS n FROM audit_log WHERE action = 'send_desktop_message'")?.n ?? 0;
+}
+
+describe("send_desktop_message", () => {
+  test("ntok caller can push to a user in the same bound network", async () => {
+    const stream = createUserEventStream(NET_A, TARGET_A);
+    const reader = stream.body!.getReader();
+    await readFrame(reader);
+
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const result = await call(tools.send_desktop_message, {
+      to_user_id: TARGET_A,
+      message: "desktop hello",
+      severity: "success",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.message_id).toStartWith("dm_");
+    expect(auditCount()).toBe(1);
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("desktop_message");
+    expect(evt.message_id).toBe(result.message_id);
+    expect(evt.message).toBe("desktop hello");
+    expect(evt.from).toBe("node-a");
+    expect(evt.network_id).toBe(NET_A);
+    expect(evt.user_id).toBe(TARGET_A);
+    expect(evt.scope).toBe("user");
+    await reader.cancel();
+  });
+
+  test("utok caller can push with explicit network_id to a member user", async () => {
+    const stream = createUserEventStream(NET_A, TARGET_A);
+    const reader = stream.body!.getReader();
+    await readFrame(reader);
+
+    const tools = buildHandlers({ userId: SENDER_USER, alias: "sender-user" });
+    const result = await call(tools.send_desktop_message, {
+      to_username: `${TARGET_A}_name`,
+      network_id: NET_A,
+      title: "Heads up",
+      message: "from user token",
+    });
+
+    expect(result.ok).toBe(true);
+    const evt = await readFrame(reader);
+    expect(evt.title).toBe("Heads up");
+    expect(evt.message).toBe("from user token");
+    expect(evt.network_id).toBe(NET_A);
+    await reader.cancel();
+  });
+
+  test("ntok caller cannot cross network with foreign network_id and to_user_id; no audit or push happens first", async () => {
+    const stream = createUserEventStream(NET_B, TARGET_B);
+    const reader = stream.body!.getReader();
+    await readFrame(reader);
+
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const result = await call(tools.send_desktop_message, {
+      to_user_id: TARGET_B,
+      network_id: NET_B,
+      message: "must not cross",
+    });
+
+    expect(result).toEqual({ ok: false, error: "desktop_target_not_in_network", network_id: NET_A });
+    expect(auditCount()).toBe(0);
+
+    pushUserEvent(NET_B, TARGET_B, { type: "desktop_message", message_id: "marker_after_denied" });
+    expect((await readFrame(reader)).message_id).toBe("marker_after_denied");
+    await reader.cancel();
+  });
+
+  test("missing target is fail-closed before audit", async () => {
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const result = await call(tools.send_desktop_message, { message: "nobody" });
+    expect(result).toEqual({
+      ok: false,
+      error: "desktop_target_required",
+      message: "to_user_id or to_username is required",
+    });
+    expect(auditCount()).toBe(0);
+  });
+
+  test("conflicting to_user_id and to_username is fail-closed before audit", async () => {
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const result = await call(tools.send_desktop_message, {
+      to_user_id: TARGET_A,
+      to_username: `${TARGET_BOTH}_name`,
+      message: "conflict",
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: "desktop_target_mismatch",
+      to_user_id: TARGET_A,
+      to_username: `${TARGET_BOTH}_name`,
+    });
+    expect(auditCount()).toBe(0);
+  });
+
+  test("unknown target is fail-closed before audit", async () => {
+    const tools = buildHandlers({ netId: NET_A, userId: NODE_USER, alias: "node-a", isNetwork: true });
+    const result = await call(tools.send_desktop_message, {
+      to_username: "not_a_real_user",
+      message: "lost",
+    });
+    expect(result).toEqual({ ok: false, error: "desktop_target_not_found", field: "to_username" });
+    expect(auditCount()).toBe(0);
+  });
+});

--- a/server/src/observer-avatar-http.test.ts
+++ b/server/src/observer-avatar-http.test.ts
@@ -187,6 +187,81 @@ describe("#461 GET /events/network/:id — auth", () => {
   });
 });
 
+describe("GET /events/users/me — Desktop user stream auth", () => {
+  test("anonymous → 401", async () => {
+    const res = await fetch(`${BASE}/events/users/me?network_id=${encodeURIComponent(memberNetworkId)}`);
+    expect(res.status).toBe(401);
+  });
+
+  test("ntok is refused for user stream", async () => {
+    const minted = createNetworkTokenForNode(memberUserId, memberNetworkId, "desktop-ntok-probe");
+    expect(minted.ok).toBe(true);
+    const res = await fetch(`${BASE}/events/users/me?network_id=${encodeURIComponent(memberNetworkId)}`, { headers: auth(minted.token!) });
+    expect(res.status).toBe(403);
+    const body = await res.json() as any;
+    expect(body.error).toBe("user_token_required");
+  });
+
+  test("utok without network_id → 400", async () => {
+    const res = await fetch(`${BASE}/events/users/me`, { headers: auth(memberToken) });
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.error).toBe("network_id required");
+  });
+
+  test("non-member utok → 403", async () => {
+    const res = await fetch(`${BASE}/events/users/me?network_id=${encodeURIComponent(memberNetworkId)}`, { headers: auth(outsiderToken) });
+    expect(res.status).toBe(403);
+    const body = await res.json() as any;
+    expect(body.error).toBe("not a member of this network");
+  });
+
+  test("member utok → user stream connected frame keyed to authenticated user", async () => {
+    const res = await fetch(`${BASE}/events/users/me?network_id=${encodeURIComponent(memberNetworkId)}`, { headers: auth(memberToken) });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") || "").toContain("text/event-stream");
+    const reader = res.body!.getReader();
+    const connected = await readFrame(reader);
+    expect(connected.type).toBe("connected");
+    expect(connected.user).toBe(true);
+    expect(connected.network_id).toBe(memberNetworkId);
+    expect(connected.user_id).toBe(memberUserId);
+    await reader.cancel();
+  });
+});
+
+describe("GET /api/messages — client inbox count", () => {
+  test("alias filter returns only that inbox and pending_count for unacked rows", async () => {
+    const selfAlias = `user-${memberUserId}`;
+    db.run(
+      `INSERT INTO inbox (id, session_name, type, priority, content, from_session, acked, network_id, created_at)
+       VALUES (?1, ?2, 'task', 'normal', 'unread self', 'agent-a', 0, ?3, datetime('now'))`,
+      [`msg_self_unread_${Date.now()}`, selfAlias, memberNetworkId],
+    );
+    db.run(
+      `INSERT INTO inbox (id, session_name, type, priority, content, from_session, acked, network_id, created_at)
+       VALUES (?1, ?2, 'task', 'normal', 'read self', 'agent-a', 1, ?3, datetime('now'))`,
+      [`msg_self_read_${Date.now()}`, selfAlias, memberNetworkId],
+    );
+    db.run(
+      `INSERT INTO inbox (id, session_name, type, priority, content, from_session, acked, network_id, created_at)
+       VALUES (?1, 'other-alias', 'task', 'normal', 'other inbox', 'agent-b', 0, ?2, datetime('now'))`,
+      [`msg_other_${Date.now()}`, memberNetworkId],
+    );
+
+    const res = await fetch(`${BASE}/api/messages?alias=${encodeURIComponent(selfAlias)}&network_id=${encodeURIComponent(memberNetworkId)}&limit=20`, {
+      headers: auth(memberToken),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.ok).toBe(true);
+    expect(body.pending_count).toBe(1);
+    expect(body.messages.length).toBeGreaterThanOrEqual(2);
+    expect(body.messages.every((m: any) => m.to_alias === selfAlias)).toBe(true);
+    expect(body.messages.some((m: any) => m.content === "other inbox")).toBe(false);
+  });
+});
+
 describe("#461 observer receives third-party traffic summaries", () => {
   test("REST /api/task dispatch → observer gets new_task summary, no content", async () => {
     const res = await fetch(`${BASE}/events/network/${memberNetworkId}`, { headers: auth(memberToken) });

--- a/server/src/observer-push.test.ts
+++ b/server/src/observer-push.test.ts
@@ -11,8 +11,10 @@ import {
   __resetSSEClientsForTest,
   createNetworkObserverStream,
   createSSEStream,
+  createUserEventStream,
   pushEvent,
   pushNetworkObserverEvent,
+  pushUserEvent,
 } from "./push";
 
 afterEach(() => {
@@ -171,6 +173,80 @@ describe("#461 network observer stream", () => {
     expect((await readFrame(reader1)).task_id).toBe("fanout");
     expect((await readFrame(reader2)).task_id).toBe("fanout");
     await reader1.cancel();
+    await reader2.cancel();
+  });
+});
+
+describe("Desktop user SSE stream", () => {
+  test("user stream receives connected frame, then desktop_message", async () => {
+    const res = createUserEventStream("net_user_a", "u_user_a");
+    const reader = res.body!.getReader();
+
+    const connected = await readFrame(reader);
+    expect(connected.type).toBe("connected");
+    expect(connected.user).toBe(true);
+    expect(connected.network_id).toBe("net_user_a");
+    expect(connected.user_id).toBe("u_user_a");
+
+    pushUserEvent("net_user_a", "u_user_a", {
+      type: "desktop_message",
+      message_id: "dm_one",
+      from: "agent-a",
+      message: "hello",
+    });
+
+    const evt = await readFrame(reader);
+    expect(evt.type).toBe("desktop_message");
+    expect(evt.message_id).toBe("dm_one");
+    expect(evt.from).toBe("agent-a");
+    expect(evt.message).toBe("hello");
+    expect(evt.network_id).toBe("net_user_a");
+    expect(evt.user_id).toBe("u_user_a");
+    expect(evt.scope).toBe("user");
+    await reader.cancel();
+  });
+
+  test("user stream is isolated from alias and observer key spaces", async () => {
+    const userRes = createUserEventStream("net_user_iso", "u_iso");
+    const userReader = userRes.body!.getReader();
+    await readFrame(userReader);
+
+    const sessionRes = createSSEStream("u_iso", "net_user_iso");
+    const sessionReader = sessionRes.body!.getReader();
+    await readFrame(sessionReader);
+
+    const observerRes = createNetworkObserverStream("net_user_iso");
+    const observerReader = observerRes.body!.getReader();
+    await readFrame(observerReader);
+
+    pushEvent("u_iso", { type: "alias_marker", marker: "alias" }, "net_user_iso");
+    pushNetworkObserverEvent("net_user_iso", { type: "observer_marker", marker: "observer" });
+    pushUserEvent("net_user_iso", "u_iso", { type: "desktop_message", marker: "user" });
+
+    expect((await readFrame(sessionReader)).marker).toBe("alias");
+    expect((await readFrame(observerReader)).marker).toBe("observer");
+    expect((await readFrame(userReader)).marker).toBe("user");
+
+    await userReader.cancel();
+    await sessionReader.cancel();
+    await observerReader.cancel();
+  });
+
+  test("same user and network fan out to multiple live clients; cancelling one leaves the other live", async () => {
+    const r1 = createUserEventStream("net_user_multi", "u_multi");
+    const r2 = createUserEventStream("net_user_multi", "u_multi");
+    const reader1 = r1.body!.getReader();
+    const reader2 = r2.body!.getReader();
+    await readFrame(reader1);
+    await readFrame(reader2);
+
+    pushUserEvent("net_user_multi", "u_multi", { type: "desktop_message", message_id: "dm_fanout_1" });
+    expect((await readFrame(reader1)).message_id).toBe("dm_fanout_1");
+    expect((await readFrame(reader2)).message_id).toBe("dm_fanout_1");
+
+    await reader1.cancel();
+    pushUserEvent("net_user_multi", "u_multi", { type: "desktop_message", message_id: "dm_fanout_2" });
+    expect((await readFrame(reader2)).message_id).toBe("dm_fanout_2");
     await reader2.cancel();
   });
 });

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -109,6 +109,7 @@ function clientKey(sessionName: string, networkId?: string | null): string {
 // master-token caller could even inject a NUL into network_id via the
 // legacy ?network_id= path, and master token is root already.
 const OBSERVER_KEY_PREFIX = "\u0000netobs:";
+const USER_KEY_PREFIX = "\u0000user:";
 
 /** Printable form of `OBSERVER_KEY_PREFIX` — the shape emitted by
  *  `printableKey()` (below) and therefore the shape callers see via
@@ -121,6 +122,10 @@ export const PRINTABLE_OBSERVER_KEY_PREFIX = "\\0netobs:";
 
 function observerKey(networkId: string): string {
   return `${OBSERVER_KEY_PREFIX}${networkId}`;
+}
+
+function userKey(networkId: string, userId: string): string {
+  return `${USER_KEY_PREFIX}${networkId}:${userId}`;
 }
 
 /** Render a client key for logs / stats. Observer keys embed a raw NUL
@@ -262,6 +267,15 @@ export function createNetworkObserverStream(networkId: string): Response {
   return createStreamForKey(
     observerKey(networkId),
     { type: "connected", observer: true, network_id: networkId },
+  );
+}
+
+/** Desktop/user client SSE stream. Keyed by authenticated user_id, not
+ *  alias/session, so Desktop does not need to mint a pseudo node token. */
+export function createUserEventStream(networkId: string, userId: string): Response {
+  return createStreamForKey(
+    userKey(networkId, userId),
+    { type: "connected", user: true, network_id: networkId, user_id: userId },
   );
 }
 
@@ -433,6 +447,34 @@ export function pushNetworkObserverEvent(
   if (!arr || arr.length === 0) return;
 
   const data = `data: ${JSON.stringify({ ...event, network_id: networkId, scope: "network" })}\n\n`;
+  let needPrune = false;
+
+  for (const c of arr) {
+    if (c.closed) {
+      needPrune = true;
+      continue;
+    }
+    const result = tryEnqueueBytes(c, c.encoder.encode(data));
+    if (result === "dead") needPrune = true;
+  }
+
+  if (needPrune) pruneClosed(key);
+}
+
+/** Push an event to every active Desktop/web client for one user in one
+ *  network. No-op for falsy network/user ids; auth must be enforced by
+ *  the caller before invoking this helper. */
+export function pushUserEvent(
+  networkId: string | null | undefined,
+  userId: string | null | undefined,
+  event: Record<string, unknown>,
+): void {
+  if (!networkId || !userId) return;
+  const key = userKey(networkId, userId);
+  const arr = clients.get(key);
+  if (!arr || arr.length === 0) return;
+
+  const data = `data: ${JSON.stringify({ ...event, network_id: networkId, user_id: userId, scope: "user" })}\n\n`;
   let needPrune = false;
 
   for (const c of arr) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -6,7 +6,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { z } from "zod/v4";
 import { registerTools } from "./tools.js";
 import { db, logTaskEvent, logAudit, syncScheduledRunForTask } from "./db.js";
-import { createSSEStream, createNetworkObserverStream, pushEvent, pushNetworkObserverEvent, getSSEStats, PRINTABLE_OBSERVER_KEY_PREFIX } from "./push.js";
+import { createSSEStream, createNetworkObserverStream, createUserEventStream, pushEvent, pushNetworkObserverEvent, getSSEStats, PRINTABLE_OBSERVER_KEY_PREFIX } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { addNetworkScope, canRestWriteNetwork, getUserNetworkIds, resolveRestNetworkScope, resolveRestWriteNetworkId, singleNetworkId, type RestNetworkScope } from "./network-scope.js";
 import { validateAvatarUrl } from "./avatar-validate.js";
@@ -869,6 +869,32 @@ return Bun.serve({
         return withCors(req, Response.json({ ok: false, error: "not a member of this network" }, { status: 403 }));
       }
       return createNetworkObserverStream(observedNetId);
+    }
+
+    // GET /events/users/me?network_id=... → Desktop/user-client stream.
+    // This is intentionally keyed by authenticated user_id, not alias.
+    // Desktop must use its utok_; ntok_ is a node credential and cannot
+    // subscribe to user channels.
+    if (url.pathname === "/events/users/me" && req.method === "GET") {
+      const authErr = requireAuth(req);
+      if (authErr) return authErr;
+      const token = requestToken(req);
+      if (!token?.startsWith("utok_")) {
+        return withCors(req, Response.json({ ok: false, error: "user_token_required" }, { status: 403 }));
+      }
+      const authCtx = resolveRequestAuth(req);
+      if (!authCtx) {
+        return withCors(req, Response.json({ ok: false, error: "auth required" }, { status: 403 }));
+      }
+      const networkId = url.searchParams.get("network_id");
+      if (!networkId) {
+        return withCors(req, Response.json({ ok: false, error: "network_id required" }, { status: 400 }));
+      }
+      const role = getUserNetworkRole(authCtx.userId, networkId);
+      if (!role) {
+        return withCors(req, Response.json({ ok: false, error: "not a member of this network" }, { status: 403 }));
+      }
+      return createUserEventStream(networkId, authCtx.userId);
     }
 
     // ── SSE push: Agent 实时接收任务推送 ──
@@ -2599,13 +2625,27 @@ return Bun.serve({
     if (url.pathname === "/api/messages") {
       const limit = Math.min(Number(url.searchParams.get("limit")) || 100, 500);
       const since = url.searchParams.get("since") ?? new Date(Date.now() - 3600000).toISOString().replace("T", " ").slice(0, 19);
+      const alias = url.searchParams.get("alias")?.trim() || null;
       const params: any[] = [since];
-      let sql = "SELECT id, session_name as to_alias, from_session as from_alias, type, priority, content, created_at, network_id FROM inbox WHERE created_at >= ?1";
+      let sql = "SELECT id, session_name as to_alias, from_session as from_alias, type, priority, content, acked, created_at, network_id FROM inbox WHERE created_at >= ?1";
+      if (alias) {
+        params.push(alias);
+        sql += ` AND session_name = ?${params.length}`;
+      }
       sql = addNetworkScope(sql, params, restScope);
       sql += ` ORDER BY created_at DESC LIMIT ?${params.length + 1}`;
       params.push(limit);
       const rows = db.all(sql, ...params);
-      return withCors(req, Response.json({ ok: true, messages: rows }));
+
+      let pendingCount: number | undefined;
+      if (alias) {
+        const countParams: any[] = [alias];
+        let countSql = "SELECT COUNT(*) AS cnt FROM inbox WHERE session_name = ?1 AND acked = 0";
+        countSql = addNetworkScope(countSql, countParams, restScope);
+        pendingCount = db.get<{ cnt: number }>(countSql, ...countParams)?.cnt ?? 0;
+      }
+
+      return withCors(req, Response.json({ ok: true, messages: rows, ...(alias ? { pending_count: pendingCount ?? 0 } : {}) }));
     }
 
     // ── REST: stats summary ──

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -4,7 +4,7 @@ import { z } from "zod/v4";
 import { parseAliasFilter } from "./alias-filter.js";
 import { createHash } from "node:crypto";
 import { db, uuidv4, logTaskEvent, chainReplyToParent, hashToken, generateId, generateNetworkToken, syncScheduledRunForTask } from "./db.js";
-import { getSSEStats, hasSubscribers, pushEvent, pushNetworkObserverEvent } from "./push.js";
+import { getSSEStats, hasSubscribers, pushEvent, pushNetworkObserverEvent, pushUserEvent } from "./push.js";
 import { assertNodeActive } from "./lifecycle-guard.js";
 import { getUserNetworkRole, createNetworkTokenForNode } from "./auth.js";
 import { canRestWriteNetwork, getUserNetworkIds, singleNetworkId } from "./network-scope.js";
@@ -2179,6 +2179,97 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       pushNetworkObserverEvent(effectiveNetId ?? task.network_id ?? null, { type: "new_task", task_id, from: from_session, to: reassignedAlias, status: "delivered", priority: task.priority });
       return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, task_id, reassigned_from: oldAlias, reassigned_to: reassignedAlias, ...(canonical.renamed ? { renamed_from: new_alias, renamed_to: reassignedAlias } : {}) }) }] };
     }
+  );
+
+  server.tool(
+    "send_desktop_message",
+    "Push a message to a user's active Desktop/web clients in one network. Targets user identity, not node alias.",
+    {
+      to_user_id: z.string().min(1).max(200).optional().describe("Target user_id. Mutually checked with to_username when both are supplied."),
+      to_username: z.string().min(1).max(50).optional().describe("Target username. Mutually checked with to_user_id when both are supplied."),
+      title: z.string().max(200).optional(),
+      message: z.string().min(1).max(10000),
+      severity: z.enum(["info", "success", "warning", "error"]).optional().default("info"),
+      kind: z.string().min(1).max(80).optional().default("agent_message"),
+      meta: z.record(z.unknown()).optional(),
+      from_session: z.string().max(200).optional(),
+      network_id: z.string().max(200).optional().describe("Network scope (auto-resolved for single-network user tokens; ntok stays bound to its network)."),
+    },
+    async ({ to_user_id, to_username, title, message, severity, kind, meta, from_session: _fromIn, network_id: netId }) => {
+      const fromMismatch = fromIdentityMismatchReply(_fromIn);
+      if (fromMismatch) return fromMismatch;
+      const from_session = defaultFrom(_fromIn);
+      const effectiveNetId = getNetworkId(netId);
+      if (!canWrite(effectiveNetId)) return writeDeniedReply(effectiveNetId, "write");
+      if (!effectiveNetId) return writeDeniedReply(effectiveNetId, "write");
+
+      if (!to_user_id && !to_username) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "desktop_target_required", message: "to_user_id or to_username is required" }) }] };
+      }
+
+      const byId = to_user_id
+        ? db.get<{ user_id: string; username: string }>("SELECT user_id, username FROM users WHERE user_id = ?1", to_user_id)
+        : null;
+      const byName = to_username
+        ? db.get<{ user_id: string; username: string }>("SELECT user_id, username FROM users WHERE username = ?1", to_username)
+        : null;
+
+      if (to_user_id && !byId) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "desktop_target_not_found", field: "to_user_id" }) }] };
+      }
+      if (to_username && !byName) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "desktop_target_not_found", field: "to_username" }) }] };
+      }
+      if (byId && byName && byId.user_id !== byName.user_id) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "desktop_target_mismatch", to_user_id, to_username }) }] };
+      }
+
+      const target = byId ?? byName;
+      if (!target) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "desktop_target_not_found" }) }] };
+      }
+
+      const targetRole = getUserNetworkRole(target.user_id, effectiveNetId);
+      if (!targetRole) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "desktop_target_not_in_network", network_id: effectiveNetId }) }] };
+      }
+
+      const messageId = `dm_${uuidv4()}`;
+      const event = {
+        type: "desktop_message",
+        message_id: messageId,
+        kind,
+        from: from_session,
+        title: title || null,
+        message,
+        severity,
+        created_at: new Date().toISOString(),
+        ...(meta && Object.keys(meta).length ? { meta } : {}),
+      };
+
+      db.run(
+        `INSERT INTO audit_log (user_id, username, action, target_type, target_id, detail, network_id)
+         VALUES (?1, ?2, 'send_desktop_message', 'user', ?3, ?4, ?5)`,
+        [
+          enforceUserId || null,
+          callerAlias || null,
+          target.user_id,
+          JSON.stringify({
+            message_id: messageId,
+            to_username: target.username,
+            from: from_session,
+            severity,
+            kind,
+            title: title || null,
+            meta_keys: meta && typeof meta === "object" ? Object.keys(meta) : [],
+          }),
+          effectiveNetId,
+        ],
+      );
+      pushUserEvent(effectiveNetId, target.user_id, event);
+
+      return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, message_id: messageId, delivered_to_user_id: target.user_id, network_id: effectiveNetId }) }] };
+    },
   );
 
   server.tool(

--- a/tests/test1280-desktop-user-push/Dockerfile
+++ b/tests/test1280-desktop-user-push/Dockerfile
@@ -1,0 +1,21 @@
+ARG SOURCE_COMMIT
+FROM oven/bun:1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY server /app/server
+COPY prototype/anet-client-app /app/prototype/anet-client-app
+COPY tests/test1280-desktop-user-push/run.sh /app/tests/test1280-desktop-user-push/run.sh
+
+RUN chmod +x /app/tests/test1280-desktop-user-push/run.sh
+RUN cd /app/server && npm ci
+RUN cd /app/prototype/anet-client-app && npm ci
+
+ARG SOURCE_COMMIT
+ENV TEST1280_SOURCE_COMMIT=$SOURCE_COMMIT
+
+CMD ["/app/tests/test1280-desktop-user-push/run.sh"]

--- a/tests/test1280-desktop-user-push/run.sh
+++ b/tests/test1280-desktop-user-push/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /app/server
+COMMHUB_DB="/tmp/desktop-user-push-$$.db" \
+  bun test src/observer-push.test.ts src/desktop-message.test.ts src/observer-avatar-http.test.ts
+
+cd /app/prototype/anet-client-app
+npm run build

--- a/tests/test629-mcp-schema-policy/probe.ts
+++ b/tests/test629-mcp-schema-policy/probe.ts
@@ -13,7 +13,7 @@ const expectedTools = [
   "mark_tasks_runtime_submitted", "mark_tasks_consumed", "get_all_status", "get_session_status",
   "send_task", "send_message", "send_reply", "send_peer_reply",
   "send_ack", "retry_task", "get_task", "list_tasks",
-  "cancel_task", "reassign_task", "broadcast", "get_completions",
+  "cancel_task", "reassign_task", "send_desktop_message", "broadcast", "get_completions",
   "update_node_config", "get_config_update", "ack_config_update", "restart_node",
   "list_host_supervisors", "create_node", "get_create_request", "ack_create_request",
   "stop_node", "delete_node", "get_stop_request", "ack_stop_request",

--- a/tests/test629-mcp-schema-policy/run.sh
+++ b/tests/test629-mcp-schema-policy/run.sh
@@ -16,7 +16,7 @@ if [[ "$inventory_rc" -eq 0 ]]; then
   echo "MUTATION_FALSE_GREEN: unreviewed tool escaped the explicit inventory" >&2
   exit 1
 fi
-grep -Fq "all 46 production MCP registrations are explicitly inventoried" /tmp/test629-inventory-red.log
+grep -Fq "all 47 production MCP registrations are explicitly inventoried" /tmp/test629-inventory-red.log
 echo "MUTATION_RED: unreviewed-tool-inventory rc=${inventory_rc}"
 
 # 第二条变异：registerTool 风格。


### PR DESCRIPTION
## Summary
- add user-keyed Desktop/web SSE stream at `/events/users/me` using `\0user:<networkId>:<userId>` keys
- add `send_desktop_message` MCP tool with same-network authorization, fail-closed target resolution, audit logging, and multi-client fanout
- keep legacy `/events/:alias` and `/events/network/:network_id` paths live and isolated
- fix client unread count path by making `/api/messages?alias=...` actually filter by alias and return `pending_count`, then render the count in Chat

## Review gates covered
- cross-network auth is tested for user stream and `send_desktop_message`
- unknown/missing/conflicting desktop targets fail closed before audit/push
- fanout test reads real SSE bytes from two live user subscriptions and verifies one cancelled client does not break the other

## Test
- `sg docker -c 'docker build --build-arg SOURCE_COMMIT=$(git rev-parse HEAD) -t anet-test1280-desktop-user-push -f tests/test1280-desktop-user-push/Dockerfile . && docker run --rm anet-test1280-desktop-user-push'`\n- Result: 33 pass / 0 fail across server tests; `anet-client-app` production build passed\n\nReport: `docs/tests/report-test-desktop-user-push.txt`