### PR TITLE
fix(release): 包名 != 目录名（commhub-server 住在 server/）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
     outputs:
       package: ${{ steps.resolve.outputs.package }}
       version: ${{ steps.resolve.outputs.version }}
+      dir: ${{ steps.resolve.outputs.dir }}
       tarball: ${{ steps.pack.outputs.tarball }}
     steps:
       - uses: actions/checkout@v4
@@ -139,24 +140,36 @@ jobs:
               *)                echo "::error::unknown tag shape: $tag"; exit 1 ;;
             esac
           fi
+          # 🔴 包名 ≠ 目录名。agent-network/ 和 agent-node/ 恰好同名，
+          # 于是 workflow 一直直接拿包名当 working-directory —— 而
+          # commhub-server 住在 server/。2026-08-27 第一次用本 workflow 发它时：
+          #   An error occurred trying to start process '/usr/bin/bash'
+          #   with working directory '/home/runner/work/.../commhub-server'
+          # 两个包碰巧同名，把这个区分隐藏了三个包那么久。
+          case "$pkg" in
+            commhub-server) dir=server ;;
+            *)              dir="$pkg" ;;
+          esac
+          [ -f "$dir/package.json" ] || { echo "::error::resolved dir '$dir' has no package.json (pkg=$pkg)"; exit 1; }
           echo "package=$pkg" >> "$GITHUB_OUTPUT"
           echo "version=$ver" >> "$GITHUB_OUTPUT"
-          echo "Gating $pkg @ $ver"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "Gating $pkg @ $ver (dir=$dir)"
 
       - name: Install + build target package
-        working-directory: ${{ steps.resolve.outputs.package }}
+        working-directory: ${{ steps.resolve.outputs.dir }}
         run: |
           bun install --frozen-lockfile
           bun run build
 
       - name: Pack tarball
         id: pack
-        working-directory: ${{ steps.resolve.outputs.package }}
+        working-directory: ${{ steps.resolve.outputs.dir }}
         run: |
           set -euo pipefail
           # npm pack honors prepublishOnly + .npmignore, exactly what `npm publish` would ship
           tarball=$(npm pack --json | bun -e 'const a=JSON.parse(require("fs").readFileSync(0,"utf8"));console.log(a[0].filename)')
-          echo "tarball=${{ steps.resolve.outputs.package }}/$tarball" >> "$GITHUB_OUTPUT"
+          echo "tarball=${{ steps.resolve.outputs.dir }}/$tarball" >> "$GITHUB_OUTPUT"
           ls -la "$tarball"
 
       - name: Upload tarball


### PR DESCRIPTION
接 #1305 第二段。#1305 开通了 commhub-server 的 dispatch 选项，但第一次真发就在 build tarball 挂了：working directory '/home/runner/work/.../commhub-server' 不存在。

根因：三处 working-directory 直接拿包名当目录名。agent-network/ 与 agent-node/ 恰好同名，把这个区分隐藏了三个包那么久；commhub-server 的目录叫 server/。

改动：resolve 新增 dir 输出（commhub-server->server），三处 working-directory 与 tarball 路径改用它，并加 [ -f $dir/package.json ] 前置断言，目录解析错时立刻指名报错。

这是「没人走过的路不会留下坏掉的证据」的第二段：补上选项后真走一次，才发现下一步也是坏的。