### PR TITLE
fix(release): 不是每个包都要编译（commhub-server 是源码分发）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,8 +159,18 @@ jobs:
       - name: Install + build target package
         working-directory: ${{ steps.resolve.outputs.dir }}
         run: |
+          set -euo pipefail
           bun install --frozen-lockfile
-          bun run build
+          # 🔴 不是每个包都要编译。commhub-server 是**源码分发**
+          # (package.json: files=[src,bin]、main=src/index.ts、bin 指向 .ts —— bun 直接跑)，
+          # 它根本没有 build 脚本。2026-08-27 第一次发它时无条件跑 `bun run build` 得到：
+          #   error: Script not found "build"
+          # 判据取「package.json 里有没有这个脚本」，而不是按包名写死谁该编译。
+          if node -e 'process.exit(((require("./package.json").scripts)||{}).build?0:1)'; then
+            bun run build
+          else
+            echo "no build script in $(pwd)/package.json — source-distributed package, skipping build"
+          fi
 
       - name: Pack tarball
         id: pack
@@ -232,8 +242,9 @@ jobs:
                 [ "$v" = "$GATED_VER" ] || { echo "::error::version mismatch"; exit 1; }
                 # 判据取「能不能真的起 hub」，不取「装上了」——
                 # 一个装得上但起不来的 hub 包，对生产毫无意义。
-                command -v commhub > /dev/null \
-                  || { echo "::error::commhub bin not on PATH after global install"; exit 1; }
+                # bin 名取自 package.json 的 bin 键（commhub-server），不是包目录名
+                command -v commhub-server > /dev/null \
+                  || { echo "::error::commhub-server bin not on PATH after global install"; exit 1; }
                 echo "✅ commhub-server install-path smoke passed"
               '
           elif [ "${GATED_PKG}" = "agent-node" ]; then


### PR DESCRIPTION
发 commhub-server .32 的**第三次**失败。前两次：#1305（package 选项里没有它）、#1307（包名≠目录名，它住在 server/）。这次：

```
error: Script not found "build"
```

`server/package.json` 的 scripts 只有 start/dev/test，**没有 build** —— 它是**源码分发**：`files=[src,bin]`、`main=src/index.ts`、bin 指向 `bin/commhub.ts`，bun 直接跑 .ts 不编译。而 workflow 无条件 `bun run build`，那是照 agent-network/agent-node 的形态写的。

## 改动
1. **build 步骤改为「有 build 脚本才跑」** —— 判据取*脚本存不存在*，不按包名写死谁该编译，下一个源码分发的包不用再改这里
2. **修 #1305 里我自己写错的 bin 名**：是 `commhub-server`（package.json 的 bin 键），不是 `commhub`。🔴 那一行当时**没被执行过**，所以错误没暴露 —— 又一个「没人走过的路不会留下坏掉的证据」的实例，只是这次那条路是我自己刚铺的

## 关于判据
这是同一条链路的第三段。**前两段各修完后我都没有宣布「通了」**，因为判据是 **`.32` 真的出现在 npm 上**，而不是某一步过了。这次也一样 —— 合入后我继续发，发成了才算。

🤖 Generated with [Claude Code](https://claude.com/claude-code)