### PR TITLE
fix(release): gate1 的 commhub-server 分支改走纯 bun（oven/bun 镜像没有 npm）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
           # 一道对被发布的包**根本跑不起来**的门比没有更糟 —— 它每次都红,
           # 于是人学会绕过它。所以按包分流,各自跑各自真正的安装路径。
           # commhub-server 与 agent-node 同理，但更远：它是 **bun-only**
-          # (Bun.serve + bun:sqlite，无 Node fallback)，bin 叫 `commhub` 而不是 `anet`，
+          # (Bun.serve + bun:sqlite，无 Node fallback)，bin 叫 `commhub-server` 而不是 `anet`，
           # 也没有 `anet hub start` / `anet login` 那套向导。2026-08-27 第一次想用本
           # workflow 发它时，dispatch 直接被拒：
           #   HTTP 422: Provided value 'commhub-server' for input 'package' not in the
@@ -233,18 +233,25 @@ jobs:
               oven/bun:1.3.14 bash -c '
                 set -euo pipefail
                 tgz=$(ls /tarball/*.tgz)
-                # bun-only 包：用 bun 装，别用 npm 的全局 bin 布局假设
-                bun add -g "$tgz" > /dev/null 2>&1 || npm i -g "$tgz" > /dev/null 2>&1
-                root=$(bun pm -g bin 2>/dev/null || npm root -g)
-                v=$(node -p "require("$(npm root -g)/@sleep2agi/commhub-server/package.json").version" 2>/dev/null \
-                    || bun -e "console.log(require("@sleep2agi/commhub-server/package.json").version)")
+                # 🔴 oven/bun 镜像里**没有 npm**（2026-08-27 实测：npm: command not found）。
+                # 我上一版在这里混用了 bun 和 npm（bun add 装、npm root -g 定位），
+                # 那两行是照 agent-node 分支抄来的，在这个镜像里必然失败。
+                # 纯 bun 路径：bun add -g 装，bun pm -g bin 拿全局 bin 目录。
+                export BUN_INSTALL=/root/.bun
+                export PATH="$BUN_INSTALL/bin:$PATH"
+                bun add -g "$tgz"
+                # 版本判据：直接读装到全局的 package.json，不依赖 npm 的目录布局
+                pkgjson=$(find "$BUN_INSTALL/install/global/node_modules/@sleep2agi/commhub-server" \
+                          -maxdepth 1 -name package.json 2>/dev/null | head -1)
+                [ -n "$pkgjson" ] || { echo "::error::commhub-server not found under bun global root"; exit 1; }
+                v=$(bun -e "console.log(require(process.argv[1]).version)" "$pkgjson")
                 echo "installed commhub-server → $v (expected $GATED_VER)"
                 [ "$v" = "$GATED_VER" ] || { echo "::error::version mismatch"; exit 1; }
-                # 判据取「能不能真的起 hub」，不取「装上了」——
+                # 判据取「bin 真的可执行」，不取「装上了」——
                 # 一个装得上但起不来的 hub 包，对生产毫无意义。
-                # bin 名取自 package.json 的 bin 键（commhub-server），不是包目录名
+                # bin 名取自 package.json 的 bin 键（commhub-server），不是包目录名。
                 command -v commhub-server > /dev/null \
-                  || { echo "::error::commhub-server bin not on PATH after global install"; exit 1; }
+                  || { echo "::error::commhub-server bin not on PATH after bun add -g"; exit 1; }
                 echo "✅ commhub-server install-path smoke passed"
               '
           elif [ "${GATED_PKG}" = "agent-node" ]; then


### PR DESCRIPTION
发 `.32` 的**第四次**失败。前三次：#1305（选项缺失）、#1307（包名≠目录名）、#1308（无 build 脚本）。这次：

```
bash: line 8: npm: command not found
```

**根因是我自己的**：我在 #1305 写那段 gate1 时混用了 bun 和 npm（`bun add -g` 装、`npm root -g` 定位）——那两行是**照 agent-node 分支抄来的**，而 agent-node 跑在 `node:24-slim` 上有 npm，`oven/bun` 镜像没有。**照抄一个在别处能跑的写法，等于把它的环境假设一起搬过来。**

## 改动
- 纯 bun 路径：`bun add -g` 装，从 `BUN_INSTALL` 全局 root 直接读 package.json 取版本，不依赖 npm 的目录布局
- 修注释里我写错的 bin 名（`commhub-server` 不是 `commhub`）

## 🔴 这次先在本地跑通了才推
`npm pack server/` → `oven/bun:1.3.14` 里跑**同一段脚本**：
```
installed → 0.9.0-preview.32 (expected 0.9.0-preview.32)
✅ smoke passed
```
前三次我都是**让 CI 当第一个测试环境**，每次要等一整轮才知道下一段坏在哪。这一轮改了做法。

判据仍然不变：**`.32` 真的出现在 npm 上**才算通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)