### PR TITLE
fix(release): gate1 分支跑完就结束（否则会再跑一遍 agent-network 的检查）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,18 @@ jobs:
             exit 0
           fi
 
+          # 🔴 上面的 if/elif 只是**加了分支**，fi 之后这一整段是 agent-network
+          # 专属的（npm install -g、anet --version、anet hub start、anet login、
+          # expect 驱动的 node-create 向导）。2026-08-27 发 commhub-server 时，
+          # 我那条分支确实命中并通过了，然后**继续往下走**，撞在这里：
+          #   bash: line 21: anet: command not found
+          # 分支跑完就该结束这一步 —— 否则「加一条分支」实际变成了
+          # 「加一条分支，再跑一遍别人的检查」。
+          if [ "${GATED_PKG}" != "agent-network" ]; then
+            echo "✅ Gate 1 — ${GATED_PKG} 的安装路径冒烟已在上面的分支内完成"
+            exit 0
+          fi
+
           # Real TTY drive via `script -qc` — captures the wizard's interactive
           # prompts that a plain shell `< /dev/null` would silently skip.
           # The harness installs the tarball as the LOCAL agent-network into a


### PR DESCRIPTION
发 `.32` 的**第五次**失败：`bash: line 21: anet: command not found`。

**但日志显示我那条 commhub-server 分支确实命中并通过了**（`installed @sleep2agi/commhub-server` → 版本匹配 → bin 在 PATH）。问题在于 `fi` 之后还有**一整段无条件的 agent-network 专属冒烟**（`npm install -g` / `anet --version` / `anet hub start` / `anet login` / expect 驱动的向导），分支跑完继续往下走就撞上了。

## 我的判断错在哪
我在 #1305 里「**加了一条分支**」，却没意识到**这一步不是只有那个 if** —— 于是「加一条分支」实际变成了「加一条分支，**再跑一遍别人的检查**」。`agent-node` 那条分支其实一直有同样的问题，只是它此前只发过一次、没人注意。

## 改动
`fi` 之后加一条 early exit：`[ "$GATED_PKG" != "agent-network" ] && exit 0`。

## 本地验证（三种包各走一遍）
```
commhub-server → commhub 分支   → early exit ✅
agent-node     → agent-node 分支 → early exit ✅
agent-network  → 落到主路径      → 继续跑 anet 向导（正确，不受影响）
```

这是同一条链路的**第五段**。判据不变：**`.32` 出现在 npm 上**才算通。

🤖 Generated with [Claude Code](https://claude.com/claude-code)