### PR TITLE
docs(runtimes): the daemon caveat added yesterday expired when #1301 merged

### DIFF
--- a/docs-site/docs/en/guide/runtimes.md
+++ b/docs-site/docs/en/guide/runtimes.md
@@ -21,7 +21,8 @@ After installing, the `anet node create` runtime picker lists **all seven**:
 Two things this page does not promise:
 
 - **Maturity**: `grok-build-cli` still describes itself in the picker as an experimental preview that only accepts trusted tasks. Listed is not stable.
-- **The daemon path**: when a node is created for you through `anet daemon`'s `create_node`, `grok-build-cli` / `codex-app-server` / `opencode-cli` are rejected by the daemon-side runtime gate ([#1298](https://github.com/sleep2agi/agent-network/issues/1298)). **Usable via a local `anet node create`, not usable via daemon** — until that fix reaches the version you have, the two paths give different answers.
+- **The daemon path**: since [#1301](https://github.com/sleep2agi/agent-network/pull/1301) the three co-presence runtimes are in the daemon-side runtime set, so `create_node` no longer refuses them. Before that they were refused ([#1298](https://github.com/sleep2agi/agent-network/issues/1298)), **so the answer depends on the version you have**: on an install from before the fix, a local `anet node create` works while daemon-side creation does not.
+- **You still have to supply a `model`**: `node_spec.model` is required by `create_node`, yet a runtime that reuses a subscription login — `claude-code-cli`, for instance — has no model picker at all and uses whatever the subscription gives it. Keys and URLs are not required (they travel through the optional `env_refs`); **the model still is.**
 
 For the current state of Grok TUI co-presence see the [Grok TUI status page](/en/guide/grok-copresence); `grok-build-acp` does not support attach.
 :::

--- a/docs-site/docs/guide/runtimes.md
+++ b/docs-site/docs/guide/runtimes.md
@@ -21,7 +21,8 @@
 两件事本页不替你打包票：
 
 - **成熟度**：`grok-build-cli` 在选单里仍自称「实验性 preview，仅可接收可信任务」。列出 ≠ 稳定。
-- **daemon 路径**：经 `anet daemon` 的 `create_node` 代创节点时，`grok-build-cli` / `codex-app-server` / `opencode-cli` 会被 daemon 侧的 runtime 闸拒掉（[#1298](https://github.com/sleep2agi/agent-network/issues/1298)）。**本机 `anet node create` 可用，daemon 代创不可用** —— 修复未进入你手上那个版本之前，这两条路径的结论不同。
+- **daemon 路径**：[#1301](https://github.com/sleep2agi/agent-network/pull/1301) 起，三个共存 runtime 已经进入 daemon 侧的 runtime 集合，`create_node` 不再拒它们。此前它们会被拒（[#1298](https://github.com/sleep2agi/agent-network/issues/1298)），**所以结论取决于你手上那个版本**：修复尚未进入你安装的版本时，本机 `anet node create` 可用而 daemon 代创不可用。
+- **仍然要自己给 `model`**：`create_node` 的 `node_spec.model` 是必填，而 `claude-code-cli` 这类复用订阅登录态的 runtime 并没有模型选择器（用订阅自带的模型）。key 和 url 不必给（走可选的 `env_refs`），**model 目前还得给一个**。
 
 Grok TUI 共存的当前状态见 [Grok TUI 状态页](/guide/grok-copresence)；`grok-build-acp` 不支持 attach。
 :::


### PR DESCRIPTION
#1303 加的那条警告说三个共存 runtime 会被 daemon 侧闸拒。#1301 合入后它们不再被拒，**那条警告本身成了新的过时断言** —— 和这页刚修好的那个毛病一模一样，只隔了一天。

没有直接删掉，而是改成**依版本而定**：装的是修复之前那个版本的读者，拿到的仍然是旧行为，所以真话是「取决于你的版本」，不是「已经能用了」。

顺带补上**没有随之消失的那个约束**：`create_node` 的 `node_spec.model` 是必填，而复用订阅登录态的 runtime 压根没有模型选择器 —— `agent-network/bin/cli.ts` 声明 `claude-code-cli` 时 `models: []` 并注明「用 Claude Code 订阅的模型」。key 和 url 确实不必给（走可选的 `env_refs`），**model 目前还得给**。这是「不输 key 和 url 就能创建」尚未完成的那一半，页面不该暗示它已经做完。

验证：`check-release-channel-assertions.py` exit 0、`check-docs-integrity.py` exit 0、`vitepress build docs` exit 0。中英同为 +2/−1。