### PR TITLE
chore(release): preview .52/.38/.33 —— 19 个已合入 main 的 PR 一个都还没发出去（含用户报的未读数 BUG，且它住在 hub 包里）

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1701,7 +1701,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // refetch). A `latest` agent-network release must pin a *stable* server.
 // `anet upgrade` (#88) surfaces this constant in its plan output so users
 // understand global-install version != version anet hub start actually runs.
-const PINNED_SERVER_VERSION = "0.9.0-preview.31";
+const PINNED_SERVER_VERSION = "0.9.0-preview.33";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.51",
+  "version": "2.3.0-preview.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.51",
+      "version": "2.3.0-preview.52",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.51",
+  "version": "2.3.0-preview.52",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.51";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.37";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.52";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.38";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.37",
+  "version": "2.5.0-preview.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.37",
+      "version": "2.5.0-preview.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.37",
+  "version": "2.5.0-preview.38",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.51 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.52 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,7 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.51` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.52` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.51 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.52 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,7 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.51`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.52`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -18,10 +18,20 @@
 |---|---|---|
 | `@sleep2agi/commhub-server` | `agent-network/bin/cli.ts` `PINNED_SERVER_VERSION` 常量 | code constant（钉死具体版本）|
 | `@sleep2agi/agent-network-dashboard` | `agent-network/bin/cli.ts` `dashboardReleaseTag()` 函数 | code function（默认返回 npm dist-tag `preview`，`ANET_DASHBOARD_VERSION` env 可覆盖）|
+| `@sleep2agi/commhub-server` | `tests/test766-bunx-preflight/run.sh` 里的 `grep -Fxq '@sleep2agi/commhub-server@<版本>'` | **test fixture**（字面量，漏改则 `L0 + L1` 红，且回显看起来像装包失败）|
 
 > commhub-server 走 `PINNED_SERVER_VERSION` 常量（钉死具体版本号，需随 release sync）；dashboard
 > **不钉版本** —— `dashboardReleaseTag()` 默认拉 `@preview` dist-tag，所以 dashboard 发新 preview 后
 > anet 会自动跟随，无需改 cli.ts。两者都属于 release management 数据，**不是业务逻辑**。
+
+> 🔴 **`test766-bunx-preflight` 这一行是 2026-08-27 发 `.33` 时被它拦下来才补进这张表的。**
+> 它验的是「CLI 实际传给 `bunx` 的包版本 == `PINNED_SERVER_VERSION`」，
+> **判据只能是字面量** —— 改成从源码读那个常量就变成同源比较，恒真。
+> 代价是它必须随每次 bump 手工同步；收益是它真的拦住了一次不一致。
+> 🔴 它红的时候**表象具有欺骗性**：CI 只回显 `--bun` 和 `@sleep2agi/commhub-server@<新版本>`
+> 两行（判定行被 `tail -60` 截掉），看起来像「新版本还没发布所以装不上」，
+> 实际是字符串比对不过。**别顺着「装包失败」那条线查。**
+
 
 ::: tip R261 校准：docs 已无 hardcoded npm 版本，移出 Live versions
 R212/R213/R215/R225/R251/R253 chain 已经把 `docs-site/docs/guide/runtimes.md` + `agent-node.md` + `sdk-deep-dive.md` + `upgrade.md` + `deploy/npm.md` + `faq.md` 等 user-facing doc 内的 hardcoded npm 版本号（`@2.1.7` / `@2.3.0` / `MiniMax-M2.7` / Bun `>= 1.0` 等）**全部清除**，改成「查 npm latest tag / npm 包页 dist-tags」或 vendor 名（无版本）。原 docs reference 两行（runtimes / agent-node + agent-network 跨 6 doc）当时不再需要 release sync。

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.32",
+  "version": "0.9.0-preview.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.32",
+      "version": "0.9.0-preview.33",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.32",
+  "version": "0.9.0-preview.33",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -84,7 +84,9 @@ probe_bunx(){
   rc=0
   [[ -s "$capture" ]] || rc=1
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.31' "$capture" || rc=1
+  # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
+  #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.33' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
## 为什么现在发

`preview.51` 发布于 2026-08-27T12:58Z。**在那之后合入 main 的 PR 有 19 个,
一个都没有产物**,其中包括用户直接报过的那个 BUG:

- #1304 桌面推送 + 未读数(「客户端不显示新收到消息数」)—— **实现主体在 `server/`**
  (`push.ts` 新增、`server.ts` +46、`tools.ts` +93),也就是说它属于 **hub 包**,
  装 agent-network / agent-node 拿不到,必须发 `commhub-server`。
- #1292 delete_node stop 后失效
- #1301 三处 runtime 闸口带着同一份过期的 trust 表
- #1312 「哪个运行时复用哪种外部登录态」收敛到一处
- #1305/#1307/#1308/#1309/#1310 —— release 通道本身的五段修复,
  **这五个没发出去,下一次发版就会在同样的地方再断一次**

## 🔴 顺带修掉一处静默漂移(不是本次改动引入的)

发这版之前核对时发现,**main 上这两个值互相矛盾**:

    server/package.json            0.9.0-preview.32
    cli.ts PINNED_SERVER_VERSION   0.9.0-preview.31     ← 落后一版

`PINNED_SERVER_VERSION` 决定 `anet hub start` 去装哪个 hub(cli.ts:7370)。
所以在这次修好之前,**任何走 `anet hub start` 的人拿到的都是 .31,不是 .32** ——
而 .32 才是带 hub 侧可达性/时区修复的那一版。#1294 当时改过这一行,
但 main 上它现在是 .31:一次「纯新增也会撞键」式的静默回落,没有任何东西会报错。

pin 全部用 `scripts/sync-pinned-versions.sh --apply` 设置,不手改。

## 已跑

- `python3 .github/scripts/check-release-channel-assertions.py` → rc=0
- `python3 scripts/check-doc-version-claims.py` → rc=0(4 个 stamp / 2 个 doc)
- `bash scripts/verify-published-pins.sh` → **rc=3 零覆盖**,不是绿:
  产物 minified,常量不保留,该脚本按设计**拒绝把「查不到」当成「一致」**。
  这一格无法在发版前判定,记录在此,不当作通过。

## 合入后的短暂不自洽(与历次发版同形)

merge 到 publish 之间,`PINNED_SERVER_VERSION=.33` 与 `PAIRED_AGENT_NODE_VERSION=.38`
指向尚未发布的版本。只影响**从 main 现构建**的用法,不影响任何已发布包;
上一版 #1294 也是同一顺序。发布后即自洽。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
**查重**：按改动文件求交集查过 —— 当前 open PR 里改到 `*/package.json` 的只有 #460（草稿·opencode stop orphan，改的是 test fixture 的 package.json，非版本 bump），无重复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)