### PR TITLE
docs(release): 补 .52 / .38 的发版说明 —— gate 3 还会再拦两次，这次是查出来的不是撞出来的

### DIFF
--- a/docs/tests/release-v2.3.0-preview.52.md
+++ b/docs/tests/release-v2.3.0-preview.52.md
@@ -1,0 +1,49 @@
+# @sleep2agi/agent-network 2.3.0-preview.52 — release notes
+
+本版与 `@sleep2agi/agent-node@2.5.0-preview.38` **配对发布**（两个包的版本必须成对，
+`opencode-agent-node-pair.ts` 里的 `PAIRED_*` 常量把它们钉在一起）。
+**只发 `preview` 通道**；promote 到 `latest` 需要 owner ACK。
+
+## 本版包含
+
+相对 `2.3.0-preview.51`，触及这两个包的改动（按合入 main 的提交列，不按印象）：
+
+- **#1314** `create_node` 的 `model` 变成可选 —— 不传就不生成 `--model`，传了仍校验非空且合法。
+  这是「复用已有登录态、不必自己填 key/url」那条路上的一步。
+- **#1312** 「哪个运行时复用哪种外部登录态」收敛到单一来源。
+- **#1301** 三处 runtime 闸口带着同一份过期的 trust 表，导致 **TUI 共存节点建不出来**。
+- **#1292** `delete_node` 在 stop 之后什么都没做，却照样 ack。
+- 版本号与 pin 同步（`PINNED_SERVER_VERSION` / `PAIRED_*`）。
+
+## Install
+
+```bash
+npm install -g bun @sleep2agi/agent-network@2.3.0-preview.52 @sleep2agi/agent-node@2.5.0-preview.38
+anet --version
+```
+
+🔴 **两个包必须同版本对装。** 只升其中一个会让 `PAIRED_*` 常量指向一个没装上的版本。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.52 @sleep2agi/agent-node@2.5.0-preview.38
+```
+
+🔴 **hub 不在这两个包里。** `anet hub start` 按 `PINNED_SERVER_VERSION` 去拉
+`@sleep2agi/commhub-server`；**hub 侧的修复（时区/在线判定、未读数、桌面推送）要单独升 hub**，
+装这两个包拿不到。
+
+## Verification
+
+判据是**产物存在 + 运行版本**，不是安装命令的退出码：
+
+```bash
+npm view @sleep2agi/agent-network@2.3.0-preview.52 version
+anet --version
+```
+
+## 已知不支持
+
+- `latest` 通道未动（promote 需 owner ACK）。
+- Windows 上 `anet daemon` 仍被显式拒绝（#1290）。

--- a/docs/tests/release-v2.5.0-preview.38.md
+++ b/docs/tests/release-v2.5.0-preview.38.md
@@ -1,0 +1,49 @@
+# @sleep2agi/agent-node 2.5.0-preview.38 — release notes
+
+本版与 `@sleep2agi/agent-network@2.3.0-preview.52` **配对发布**（两个包的版本必须成对，
+`opencode-agent-node-pair.ts` 里的 `PAIRED_*` 常量把它们钉在一起）。
+**只发 `preview` 通道**；promote 到 `latest` 需要 owner ACK。
+
+## 本版包含
+
+相对 `2.5.0-preview.37`，触及这两个包的改动（按合入 main 的提交列，不按印象）：
+
+- **#1314** `create_node` 的 `model` 变成可选 —— 不传就不生成 `--model`，传了仍校验非空且合法。
+  这是「复用已有登录态、不必自己填 key/url」那条路上的一步。
+- **#1312** 「哪个运行时复用哪种外部登录态」收敛到单一来源。
+- **#1301** 三处 runtime 闸口带着同一份过期的 trust 表，导致 **TUI 共存节点建不出来**。
+- **#1292** `delete_node` 在 stop 之后什么都没做，却照样 ack。
+- 版本号与 pin 同步（`PINNED_SERVER_VERSION` / `PAIRED_*`）。
+
+## Install
+
+```bash
+npm install -g bun @sleep2agi/agent-network@2.3.0-preview.52 @sleep2agi/agent-node@2.5.0-preview.38
+anet --version
+```
+
+🔴 **两个包必须同版本对装。** 只升其中一个会让 `PAIRED_*` 常量指向一个没装上的版本。
+
+## Upgrade
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.52 @sleep2agi/agent-node@2.5.0-preview.38
+```
+
+🔴 **hub 不在这两个包里。** `anet hub start` 按 `PINNED_SERVER_VERSION` 去拉
+`@sleep2agi/commhub-server`；**hub 侧的修复（时区/在线判定、未读数、桌面推送）要单独升 hub**，
+装这两个包拿不到。
+
+## Verification
+
+判据是**产物存在 + 运行版本**，不是安装命令的退出码：
+
+```bash
+npm view @sleep2agi/agent-network@2.3.0-preview.52 version
+anet --version
+```
+
+## 已知不支持
+
+- `latest` 通道未动（promote 需 owner ACK）。
+- Windows 上 `anet daemon` 仍被显式拒绝（#1290）。


### PR DESCRIPTION
今天 `.33` 已经被 gate 3 拦过一次（`ls docs/tests/release-v$VER*.md` 找不到 → publish 不执行）。
我当时只补了 `.33`。**这次去查了这一类**：

    release-v0.9.0-preview.33*.md   命中 1   ✅（已补）
    release-v2.3.0-preview.52*.md   命中 0   ❌ 会红
    release-v2.5.0-preview.38*.md   命中 0   ❌ 会红
    回退分支 grep 'v2.3.0-preview.52' / 'v2.5.0-preview.38'   命中 0 个文件

⇒ **接下来发 agent-network / agent-node 会在同一道门上再挂两次。** 现在一次补齐。

（`.33` 那次是等它红了才知道；这两次是查出来的 —— 今天第四次撞见
「查的是那一颗，不是那一类」，这回换成先枚举再动手。）

## 内容按事实写，不按印象

相对 `.51/.37`，触及这两个包目录的提交实际只有 4 件功能改动：
`#1314` model 可选 / `#1312` 登录态来源收敛 / `#1301` 三处过期 trust 表 /
`#1292` delete_node 空转仍 ack —— 逐条用
`git log origin/main --since=<.51 发布时刻> -- agent-network/ agent-node/` 列出来核过。

两份说明里都写死了两句每次都成立、而每次都有人漏读的话：

1. **两个包必须同版本对装**（`PAIRED_*` 常量把它们钉在一起，只升一个会指向没装上的版本）。
2. 🔴 **hub 不在这两个包里** —— hub 侧的修复要单独升 `commhub-server`。
   今天生产上正是因为这一条被误导过一次。

Verification 一节的判据是**产物存在 + 运行版本**，不是安装命令的退出码。

本地已跑：`check-release-channel-assertions.py`、`check-doc-version-claims.py`、
`check-doc-symbol-pins.py` 均 rc=0。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---
**查重**：按内容查过 `release-v2.3.0-preview.52` / `release-v2.5.0-preview.38` —— 仓里都是 0 命中，无重复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
