### PR TITLE
chore(release): PINNED_SERVER_VERSION → 0.9.0-preview.33（.33 已发布，滞后条件满足）

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1705,7 +1705,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.32";
+const PINNED_SERVER_VERSION = "0.9.0-preview.33";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.32' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.33' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
chore(release): PINNED_SERVER_VERSION → 0.9.0-preview.33（.33 已发布，滞后条件已满足）

#1318 把这个常量退回 `.32`，是因为 gate 2 会拿它去 `npm view` 核对，
而当时 `.33` 还没发布 —— **发 .33 的那个 run 会被自己的 pin 卡死**。

现在 `.33` 已经在 npm 上（`npm view @sleep2agi/commhub-server@0.9.0-preview.33`
返回 `0.9.0-preview.33`），**滞后条件满足了**，可以提上来：

    cli.ts PINNED_SERVER_VERSION   0.9.0-preview.33
    test766 里的字面量断言          0.9.0-preview.33
    server/package.json            0.9.0-preview.33   （三处一致，已自检）

这一步是必需的：`anet hub start` 按这个常量拉 hub，**不提的话走这条路的用户
拿到的仍是 `.32`**，而未读数 / 桌面推送只在 `.33` 里。

pin 用 `scripts/sync-pinned-versions.sh --apply` 设置，不手改。
`test766` 那条字面量今天刚被补进 `docs/RELEASE-SOP.md` 的必改清单，这次是照清单走的
（上一次是被它拦红才发现）。

已跑：`check-doc-symbol-pins.py`、`check-doc-version-claims.py`、
`check-release-channel-assertions.py` 均 rc=0；`bash -n test766` 通过。

## 下一步（记在这里，避免又靠记忆）

本 PR 合入后即可发 `agent-network 2.3.0-preview.52` 与 `agent-node 2.5.0-preview.38`
（两者版本号已在 main 上，发版说明由 #1321 补齐，gate 2 需要的 `.33` 也已发布）。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---
**查重**：当前 open PR 里改 `PINNED_SERVER_VERSION` 的只有本 PR；#1299 改的是 daemon 的 ANET_BIN 路径，不碰这个常量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
