### PR TITLE
fix(test638): 失败时吐出用例名 —— tail -40 只够到输出尾巴,失败在中间就丢了(#1319)

### DIFF
--- a/tests/test638-server-aggregate-isolation/run.sh
+++ b/tests/test638-server-aggregate-isolation/run.sh
@@ -36,8 +36,35 @@ dump_agg_failure() {
   echo "FAIL: $label aggregate exited rc=$rc — offending files:"
   grep '^TEST_FILE_RESULT' "$output" \
     | awk -F'\t' '{bad=0; for(i=1;i<=NF;i++){if($i=="timeout=true")bad=1; if($i ~ /^exit=/ && $i!="exit=0")bad=1}; if(bad)print}' || true
+  # #1319: 上面那行能报出**是哪个文件**,但接着的 `tail -40` 吐的是整份聚合输出的
+  # 尾巴 —— 实测里那 40 行全是后续文件的 (pass),失败用例名根本不在范围内。
+  # 于是「文件名有了、用例名没了」,查的人只能猜。
+  #
+  # bun 把断言详情打在 `(fail)` 行**之前**,所以往前取上下文。实测(bun 1.3.14,
+  # 各造一份不同断言深度的失败输出):
+  #   源码上下文固定 6 行(断言在文件第 6 行和第 152 行,输出都是 6 行)
+  #   error: → (fail) 距离:toBe 断言 6 行;toEqual 对象断言 13 行
+  # 🔴 -B30 是「够用」,**不是保证**:变量是 diff 长度,而对象越大 diff 越长,
+  #    没有上限。真正的兜底是把整份 $output 传成 artifact(见 ARTIFACT_DIR 一段)。
+  echo "--- failing cases in $output ---"
+  if grep -q '^(fail)' "$output"; then
+    grep -B30 '^(fail)' "$output" || true
+  else
+    echo "  (没有 '(fail)' 行 —— 这次失败不是用例级断言,"
+    echo "   可能是文件级 crash / import 失败 / 进程被杀,看下面的 tail)"
+  fi
+  # 保留原有的 tail:两者互补 —— 上面给用例名,下面给文件级 crash 的现场。
   echo "--- last 40 lines of $output ---"
   tail -40 "$output" || true
+  # 兜底,不依赖任何输出格式假设。ARTIFACT_DIR 是本仓既有约定(test225/234/697
+  # 都在用)。⚠️ 目前 qa.yml 的 hub-semantics 矩阵是 `docker run --rm`,没有取出
+  # 步骤,所以这几份现在只落在容器里 —— 取出需要照 test225 的做法
+  # (`--name` + `docker cp` + `docker rm -f`,qa.yml:745-755)。先写,取出另议。
+  if [ -n "${ARTIFACT_DIR:-}" ]; then
+    mkdir -p "$ARTIFACT_DIR" 2>/dev/null || true
+    cp -- "$output" "$ARTIFACT_DIR/$(basename "$output")" 2>/dev/null \
+      && echo "--- saved full output to \$ARTIFACT_DIR/$(basename "$output") ---" || true
+  fi
 }
 
 rm -rf -- /tmp/test638-run1 /tmp/test638-run2 /tmp/test638-run3


### PR DESCRIPTION
关闭 #1319 的诊断缺口:失败时能吐出**用例名**,而不只是文件名。

## 问题

`dump_agg_failure` 已经能报出「是哪个文件」(`TEST_FILE_RESULT` 里 `exit!=0` 那行),但紧接着的 `tail -40` 吐的是**整份聚合输出的尾巴**,不是那个文件的失败段。#1319 里 CI 的真实 dump:最后 40 行里 **7 个用例全是 pass**,失败那条在文件的前 6 个用例里,名字不在范围内。

## 见红先于见绿

造一个真会失败的用例塞进聚合,**同一份输出、只换 dump 方式**:

| 判据 | 旧 `tail -40` | 新 `grep -B30 '^(fail)'` |
|---|---|---|
| 用例名命中 | **0** | **2** |
| `error:` 断言原文命中 | **0** | **1** |

失败在第 42 行 / 总 220 行 ⇒ **距尾部 178 行**,`tail -40` 完全够不着。

🔴 **第一次做这个对照时我做错了,记在这里**:我把探针命名为 `zz-…`,**字母序排最后,输出正好落在 `tail -40` 的窗口里** —— 于是旧写法"也能拿到用例名"(2 次),看起来这个补丁没必要。**一个位置选错的 fixture 给出了反向的假结论。** 改名 `aa-…` 排到最前(后面还有 84 个文件的输出)才是 CI 上的真实形状:失败文件在中间。上表是修正后的。

## `-B30` 从哪来,以及**它不是保证**

bun 把断言详情打在 `(fail)` 行**之前**,所以往前取上下文。实测(bun 1.3.14,各造一份不同形状的失败):

```
源码上下文     固定 6 行(断言在文件第 6 行 / 第 152 行,输出都是 6 行)

error: → (fail) 距离:
  toBe 标量断言                        6 行
  toEqual 小对象(2 字段)             13 行   ← 原提案的 -B12 正好截掉 error: 行
  toEqual 大对象(4 字段+数组+嵌套)   25 行
```

⇒ **变量不是文件深度,是 diff 长度 —— 而对象越大 diff 越长,没有上限。** `-B30` 在实测最长的 25 行上只剩 5 行余量。**任何 `-B<N>` 都只是「够用」,不是保证**,注释里写明了这一点。

`^(fail)` 的锚定也实测过:BRE 下括号是字面量,`grep -c '^(fail)'` 与 `grep -cE '^\(fail\)'` 命中数相同,不用转义。

## 因此同时写 artifact

grep 方案的正确性依赖一个**会变的外部格式**(bun 的输出布局)。所以在 `ARTIFACT_DIR` 存在时把整份 `$output` 落盘 —— 不依赖任何格式假设,这才是兜底。

⚠️ **取出那一步不在本 PR**:`qa.yml` 的 hub-semantics 是 **60+ 套件共用一条 `docker run --rm`**,没有取出步骤。照 test225 的做法(`--name` + `docker cp` + `docker rm -f`,`qa.yml:745-755`)可以取出,但那是跨全部矩阵项的改动,应单独议。

顺带一个调研中发现、超出本 PR 范围的事实:`ARTIFACT_DIR` 是既有约定(test234 / test697 / test601 都在往里写报告),但 `qa.yml` 里带 `-v` 的 `docker run` 是 **0** 个、`docker cp` 只有 **1** 处 —— **除 test225 外,那些报告一直随 `--rm` 删掉了**。

## 保留原有 `tail -40`

两者互补:grep 给**用例名**,tail 给**文件级 crash / import 失败 / 进程被杀**的现场 —— 那种情况根本不会有 `(fail)` 行,新增分支会显式打印这一点,而不是静默什么都不输出。

## 范围

只改一个文件,`tests/test638-server-aggregate-isolation/run.sh`,**+27 行,无删除**。不改任何被测代码,不改 workflow(因此与正在排队的其他 `qa.yml` 改动无冲突)。
