### PR TITLE
docs(release-sop): PINNED_SERVER_VERSION 必须滞后到「已发布」—— 原措辞「需随 release sync」正好指向会卡死发版的做法

### DIFF
--- a/docs/RELEASE-SOP.md
+++ b/docs/RELEASE-SOP.md
@@ -20,6 +20,28 @@
 | `@sleep2agi/agent-network-dashboard` | `agent-network/bin/cli.ts` `dashboardReleaseTag()` 函数 | code function（默认返回 npm dist-tag `preview`，`ANET_DASHBOARD_VERSION` env 可覆盖）|
 | `@sleep2agi/commhub-server` | `tests/test766-bunx-preflight/run.sh` 里的 `grep -Fxq '@sleep2agi/commhub-server@<版本>'` | **test fixture**（字面量，漏改则 `L0 + L1` 红，且回显看起来像装包失败）|
 
+
+🔴 **「需随 release sync」不等于「跟这次发版一起改」—— 顺序反了会把发版卡死。**
+
+`release-gate` 的 **gate 2** 会拿 `PINNED_SERVER_VERSION` 去 `npm view` 核对**是否已发布**，
+而 `publish` job 要求**四门全绿**（release.yml 的 `if:` 里逐个断言 success）。
+所以**本次要发的那个版本，不能提前写进这个常量** —— 否则发它的那个 run 会被自己的 pin 卡死。
+
+**正确顺序（两步，别合成一步）：**
+
+1. 先发 `commhub-server X`。此时 `PINNED_SERVER_VERSION` 必须仍指向**上一个已发布版本**。
+2. `X` 出现在 npm 上之后，再把常量改成 `X`，随 `agent-network` 一起发。
+
+**2026-08-27 实测代价**：把 `server/package.json` 和 `PINNED_SERVER_VERSION` 在同一个 PR 里
+都提到 `.33`，结果发 `.33` 的 run 挂在
+`gate 2 → PINNED_SERVER_VERSION=0.9.0-preview.33 not published on npm`，`publish` 直接 skipped。
+**tarball 已经构建成功也没用。** 之后要专门开一个 PR 把常量退回 `.32` 才解开。
+
+🔴 **顺带纠正一个当时看起来像缺陷的现象**：如果你发现 main 上
+`PINNED_SERVER_VERSION` 比 `server/package.json` **低一个版本**，
+**那通常是正确状态，不是漏改** —— 它就该滞后到目标版本发布之后。
+（当天有人把这个正常滞后报成了「静默回落」，并"修好"了它，然后被自己修出来的死锁挡住。）
+
 > commhub-server 走 `PINNED_SERVER_VERSION` 常量（钉死具体版本号，需随 release sync）；dashboard
 > **不钉版本** —— `dashboardReleaseTag()` 默认拉 `@preview` dist-tag，所以 dashboard 发新 preview 后
 > anet 会自动跟随，无需改 cli.ts。两者都属于 release management 数据，**不是业务逻辑**。


### PR DESCRIPTION
docs(release-sop): 写清 PINNED_SERVER_VERSION 必须滞后到「已发布」—— SOP 原措辞指向错误动作

## SOP 原来是怎么说的，为什么它会把人带错

> commhub-server 走 `PINNED_SERVER_VERSION` 常量（钉死具体版本号，**需随 release sync**）

「需随 release sync」**照字面读就是「跟这次发版一起改」** —— 而那正是会把发版卡死的做法。
全文搜过：`滞后` / `鸡生蛋` / `gate 2` / `未发布` 在 SOP 里各 **0 处**。
这条规则今天只存在于 `cli.ts` 那个常量上方的注释里 —— **而按 SOP 走的人不会读到那里。**

## 规则本身

`release-gate` 的 **gate 2** 拿这个常量去 `npm view` 核对**是否已发布**，
而 `publish` 要求四门全绿。⇒ **本次要发的版本不能提前写进常量**，否则发它的 run 被自己的 pin 卡死。

两步，别合成一步：

    1. 先发 commhub-server X（常量仍指向上一个已发布版本）
    2. X 出现在 npm 上之后，再把常量改成 X，随 agent-network 一起发

## 2026-08-27 的实测代价（写进去，因为它不便宜）

把 `server/package.json` 和 `PINNED_SERVER_VERSION` 在同一个 PR 里都提到 `.33` ⇒
发 `.33` 的 run 挂在 `gate 2 → not published on npm`，`publish` 直接 **skipped**。
**tarball 已经构建成功也没用。** 之后要专门开一个 PR 把常量退回 `.32` 才解开。

## 🔴 附带纠正一个"看起来像缺陷"的正常现象

如果发现 main 上 `PINNED_SERVER_VERSION` 比 `server/package.json` **低一个版本**，
**那通常是正确状态，不是漏改**。当天有人（是我）把这个正常滞后报成了「静默回落」、
"修好"了它，然后被自己修出来的死锁挡住。**把这句写进 SOP，是为了让下一个人
在动手"修"之前先怀疑一下自己。**

已跑：`check-release-channel-assertions.py`、`check-doc-symbol-pins.py`、
`check-doc-version-claims.py` 均 rc=0。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


---
**查重**：SOP 全文搜过 `滞后` / `鸡生蛋` / `gate 2` / `未发布` —— 各 0 处命中，无重复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
