### PR TITLE
fix(grok-copresence): 进程回收断言避开 zombie 窗口,并加一格钉住它的回归测试(#1315)

### DIFF
--- a/agent-node/src/runtime/grok-copresence/leader-lifecycle.test.ts
+++ b/agent-node/src/runtime/grok-copresence/leader-lifecycle.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   captureOwnedGrokLeader,
   assertGrokLeaderCommandIdentity,
+  processGenerationGone,
   terminateOwnedGrokLeader,
   type OwnedGrokLeaderIdentity,
 } from "./leader-lifecycle";
@@ -114,13 +115,80 @@ describe("Grok auto-Leader lifecycle identity", () => {
     expect(existsSync(fixture.socket)).toBe(true);
   });
 
+  /** Poll until the exact generation is gone, or the bound elapses.
+   *
+   * 🔴 Asserting `!existsSync(/proc/<pid>)` is wrong here: between SIGKILL
+   * landing and the parent reaping, the process is in state `Z` and its
+   * `/proc` entry still exists. `processGenerationGone` excludes `Z`/`X`, so
+   * it is the same question the product itself answers (#1315).
+   *
+   * The bound is generous on purpose — polling returns as soon as the
+   * condition holds, so a wide ceiling costs nothing when things are fast,
+   * and does not turn a slow machine into a false failure.
+   */
+  async function waitGenerationGone(id: { pid: number; startTime: string }, boundMs = 5_000): Promise<boolean> {
+    const deadline = Date.now() + boundMs;
+    while (Date.now() < deadline) {
+      if (processGenerationGone(id.pid, id.startTime)) return true;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    return processGenerationGone(id.pid, id.startTime);
+  }
+
+  // 🔴 This test pins the bug behind #1315 permanently: if anyone ever swaps
+  // processGenerationGone back for an `existsSync(/proc/<pid>)` existence
+  // check, this goes red. It asserts the two DISAGREE on a zombie — which is
+  // precisely the window that made the escalation test intermittently fail.
+  test("processGenerationGone reports a zombie as gone while /proc still exists", async () => {
+    // A child that exits while its parent never waits stays in state Z.
+    //
+    // 🔴 A shell CANNOT be used to build this: measured on this host, dash,
+    // bash and `setsid bash` all reap the background job before the next
+    // command runs, so `/proc/<pid>` is gone entirely rather than showing Z.
+    // A bare `fork()` whose parent never waits is the only form that holds —
+    // hence python3 (present in the agent-node test image).
+    const holder = spawn(
+      "python3",
+      ["-c", "import os,sys,time\npid=os.fork()\nif pid==0: os._exit(0)\nprint(pid, flush=True)\ntime.sleep(30)"],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
+    try {
+      const zombiePid = await new Promise<number>((resolve, reject) => {
+        holder.stdout!.once("data", (d) => resolve(Number(String(d).trim())));
+        holder.once("error", reject);
+      });
+      // give the child time to exit and become a zombie
+      let state = "";
+      let startTime = "";
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        const raw = readFileSync(`/proc/${zombiePid}/stat`, "utf8");
+        const fields = raw.slice(raw.lastIndexOf(")") + 2).trim().split(/\s+/);
+        state = fields[0] || "";
+        startTime = fields[19] || "";
+        if (state === "Z") break;
+      }
+      expect(state).toBe("Z");
+
+      // the existence check the test used to rely on: still true
+      expect(existsSync(`/proc/${zombiePid}`)).toBe(true);
+      // the predicate the product actually uses: already "gone"
+      expect(processGenerationGone(zombiePid, startTime)).toBe(true);
+    } finally {
+      holder.kill("SIGKILL");
+    }
+  });
+
   test("revalidates the exact identity before escalating a TERM-resistant Leader", async () => {
     const fixture = await startLeader(false, true);
     const identity = await capture(fixture);
 
     await terminateOwnedGrokLeader(identity, 500);
 
-    expect(existsSync(`/proc/${identity.pid}`)).toBe(false);
+    // Assert the CONDITION, not the clock. On timeout this still reports the
+    // predicate's value, so a failure reads "still not reaped after the bound"
+    // rather than "the sleep was too short".
+    expect(await waitGenerationGone(identity)).toBe(true);
     expect(existsSync(fixture.socket)).toBe(false);
   });
 

--- a/agent-node/src/runtime/grok-copresence/leader-lifecycle.ts
+++ b/agent-node/src/runtime/grok-copresence/leader-lifecycle.ts
@@ -378,6 +378,27 @@ function sameRealPath(candidate: string, expected: string): boolean {
   try { return realpathSync(candidate) === expected; } catch { return false; }
 }
 
+/** Has the exact process generation identified by (pid, startTime) gone?
+ *
+ * Exported for tests. It deliberately answers the QUESTION ("is it gone?")
+ * rather than exposing the internal predicate, so the export surface stays
+ * one function wide.
+ *
+ * 🔴 Why tests must call this instead of checking `existsSync(/proc/<pid>)`:
+ * between SIGKILL landing and the parent reaping, the process sits in state
+ * `Z`. Its `/proc/<pid>` entry still exists, so an existence check reports
+ * "still alive" while this predicate — which excludes `Z`/`X` — correctly
+ * reports "gone". On a fast machine the reap is near-instant and the two
+ * agree; under load the window widens and they disagree. That window is
+ * exactly what made leader-lifecycle.test.ts intermittently red (#1315).
+ *
+ * Measured: a forked child that exits without being waited on shows
+ * `state=Z`, `existsSync(/proc/<pid>)=true`, and this function `true`.
+ */
+export function processGenerationGone(pid: number, startTime: string): boolean {
+  return !sameProcessGenerationExists(pid, startTime);
+}
+
 function sameProcessGenerationExists(pid: number, startTime: string): boolean {
   try {
     const current = readProcessStat(pid);

--- a/tests/test233-grok-main-integration/Dockerfile
+++ b/tests/test233-grok-main-integration/Dockerfile
@@ -1,7 +1,11 @@
 FROM oven/bun:1.3.1
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends gcc libc6-dev \
+  # python3: leader-lifecycle.test.ts 的 zombie 回归用例需要一个裸 fork()
+  # 来造 zombie(#1315)。实测 sh / bash / setsid bash 三种 shell 都会在下一条
+  # 命令前 reap 掉后台作业,/proc 条目直接消失而不是显示 Z,所以造不出来。
+  # 本套件跑的是整个 src/runtime/grok-copresence 目录,因此也会执行到那条用例。
+  && apt-get install -y --no-install-recommends gcc libc6-dev python3 \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace


### PR DESCRIPTION
关闭 #1315。方案 **(B)**:导出窄 helper,测试轮询与产品同一个谓词。

## 根因:测试自造的判据漏掉了产品已经处理的一格

```
产品  leader-lifecycle.ts:384
      current.startTime === startTime && state !== "Z" && state !== "X"

测试  expect(existsSync(`/proc/${identity.pid}`)).toBe(false)
```

`SIGKILL` 送达后、父进程 `reap` 完成前,进程处于 **`Z`**:

| | 对 zombie 的判定 |
|---|---|
| 产品谓词(排除 `Z`/`X`) | **false —— 已消失**(对) |
| `existsSync(/proc/<pid>)` | **true —— 还在**(错,`/proc` 条目仍在) |

**实测**(fork 一个不被 wait 的子进程):`state=Z` / `existsSync=true` / 产品谓词=已消失。

快机器 reap 近乎瞬时,两者一致;负载高时窗口拉长就分歧 —— 与 #1315 上半部分测到的「CI 比本机慢 10 倍」是同一件事的两面。

## 改动(3 处)

1. **导出 `processGenerationGone(pid, startTime)`** —— 语义正向的窄 helper,回答「没了吗」这个问题,而不是把内部谓词整个暴露。导出面 +1。
2. **那条用例改为有界轮询该谓词**,超时后仍断言谓词本身,失败读作「轮询 N ms 后仍未回收」而不是「sleep 太短」。上限放宽到 5s —— 轮询早成立就早返回,**宽上限不再意味着慢**。
3. **新增 zombie 回归测试**:断言 `processGenerationGone`=true 而 `existsSync(/proc/pid)`=true,即**两者在 zombie 上必须分歧**。

🔴 **只改断「已消失」的那一条。** 同文件 `:112` 断 `/proc` **存在**(`toBe(true)`)的那条不受该窗口影响 —— 它要的是「没被杀」,而 `/proc` 还在恰好就是没被杀。**同一个探针,断存在是安全的,断不存在才有窗口。**

## 三次见红,含两次没验到的,如实记录

| | 变异 | 结果 |
|---|---|---|
| 红门 1 | 谓词退回存在性检查 | **zombie 测试红(仅它红)** ✓ |
| 红门 2 | 不发 SIGKILL(进程真的不被回收) | 红,但红在 `terminateOwnedGrokLeader` 自抛的 `did not exit after SIGKILL` |
| 红门 3 | 不发信号 + 内部轮询谎报成功 | 仍红在产品另一处检查 `listener remained after process termination` |

⇒ **红门 2/3 没有验证到新断言本身**:产品有多重内部检查,任一失败都先抛错,测试走不到那一行。

**所以改动 2 的价值是「正确性」(消除 zombie 假红),不是「新增检测能力」;新增检测能力的是改动 3 那个 zombie 回归测试** —— 红门 1 证明了它:谁把谓词换回 `/proc` 存在性,它就红。**不把这个补丁说成比实际更强。**

## 验证

`bun test leader-lifecycle.test.ts` → **10 pass 0 fail**。

中途出现过一次 `8 pass 2 fail`:红门 2/3 的变异留下了孤儿 fixture 进程(**fixture 本身就是 TERM-resistant,`SIGTERM` 杀不掉**),干扰了后续运行。按精确 PID 复核 `/proc/<pid>/cmdline` 后 `SIGKILL` 清理,重跑即全绿 —— **不是代码问题**。

## 范围

`leader-lifecycle.ts` +21 行(一个导出 helper + 注释),`leader-lifecycle.test.ts` +70/-1。不改任何产品行为,不碰 workflow。
