### PR TITLE
ci(hub-orphan-gates): 接出 ARTIFACT_DIR —— 报告一直随 --rm 删掉,失败时取不到现场(#1324 第一步)

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1044,8 +1044,33 @@ jobs:
           done < <(grep -oE '^ARG [A-Z0-9_]+' "$DF" | awk '{print $2}')
           echo "detected build args: ${BUILD_ARGS[*]:-(none)}"
           docker build "${BUILD_ARGS[@]}" -t "anet-${{ matrix.suite }}" -f "$DF" .
-          docker run --rm -e EXPECTED_SOURCE_COMMIT="$GITHUB_SHA" \
-            -e ARTIFACT_DIR=/tmp/art "anet-${{ matrix.suite }}"
+          # #1324: ARTIFACT_DIR 一直传进来,但容器带 --rm 直接删掉,套件写的报告
+          # 从没被取出过 —— 全仓只有 test225 那一处有 docker cp。这里补上取出。
+          #
+          # 🔴 不能沿用 `docker run --rm ... ` 一行式:本步骤在 set -euo pipefail 下,
+          #    docker run 一旦非零就立刻中断,后面的 cp 根本不执行 —— 而**失败恰恰是
+          #    唯一需要 artifact 的时刻**。所以先把退出码收进 rc,取完再原样退出。
+          # 参照实现:qa.yml 的 test225 那一步(--name → docker cp → docker rm -f)。
+          rc=0
+          docker run --name "run-${{ matrix.suite }}" \
+            -e EXPECTED_SOURCE_COMMIT="$GITHUB_SHA" \
+            -e ARTIFACT_DIR=/tmp/art "anet-${{ matrix.suite }}" || rc=$?
+          mkdir -p "$RUNNER_TEMP/suite-artifacts"
+          # 多数套件不写 ARTIFACT_DIR,取不到是正常的,只 warning 不改变判定。
+          docker cp "run-${{ matrix.suite }}:/tmp/art/." "$RUNNER_TEMP/suite-artifacts/" 2>/dev/null \
+            || echo "::warning::no artifacts under /tmp/art in ${{ matrix.suite }}"
+          docker rm -f "run-${{ matrix.suite }}" >/dev/null 2>&1 || true
+          ls -la "$RUNNER_TEMP/suite-artifacts/" 2>/dev/null || true
+          exit $rc
+
+      # 只在失败时上传:成功的运行不需要现场,而失败时这是唯一的现场。
+      - name: Upload ${{ matrix.suite }} artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.suite }}
+          path: ${{ runner.temp }}/suite-artifacts/
+          if-no-files-found: ignore
 
   windows-codex-copresence:
     name: Windows Codex co-presence native smoke


### PR DESCRIPTION
#1324 的第一步:**先只接一个 job**,把参照实现坐实再推广。

## 为什么从 `hub-orphan-gates` 开始

它 **58 个矩阵项**,而且今天在 #1299 和 #1314 上各红过一次 —— **两次都拿不到现场**。#1319 那颗 flake 至今没能定位到具体用例,原因之一就是失败输出取不出来。

一次性改 6 个 job(共 10 处 `docker run`)会让冲突面和复核成本都跳一个量级,而 `qa.yml` 现在是全队都在碰的文件。

## 🔴 不能沿用一行式 `docker run --rm`

本步骤跑在 `set -euo pipefail` 下:

```bash
docker run --rm … "anet-${{ matrix.suite }}"   # 非零 → 立刻中断
docker cp …                                     # 永远执行不到
```

**而失败恰恰是唯一需要 artifact 的时刻。** 所以改成先收退出码、取完再原样退出:

```bash
rc=0
docker run --name "run-${{ matrix.suite }}" … || rc=$?
docker cp "run-${{ matrix.suite }}:/tmp/art/." "$RUNNER_TEMP/suite-artifacts/" 2>/dev/null \
  || echo "::warning::no artifacts under /tmp/art in ${{ matrix.suite }}"
docker rm -f "run-${{ matrix.suite }}" >/dev/null 2>&1 || true
exit $rc
```

参照实现是仓库里已有的 test225 那一步(`--name` → `docker cp` → `docker rm -f`)。

## 红绿对照(本地实测)

fixture 是一个**必失败且会写 `ARTIFACT_DIR`** 的镜像:

| | 旧写法 `--rm` | 新写法 `--name` + `cp` |
|---|---|---|
| 套件 rc | 1 | **1(原样传递)** |
| `docker cp` 结果 | `No such container: run-old` | 成功 |
| **取到的文件数** | **0** | **1**(`report.txt`) |
| 内容 | — | `EVIDENCE FROM A FAILING SUITE` |

三个判据分别验的是:**失败时 cp 仍执行**、**取出的内容非空**、**退出码没被吞掉**。

🔴 只验"新写法能取到"是不够的 —— 那证明不了它解决了问题。上表左列是同一个 fixture 在旧写法下的读数:**0 个文件**。

## upload 只在失败时触发

成功的运行不需要现场;失败时这是唯一的现场。`if-no-files-found: ignore` 是因为**多数套件并不写 `ARTIFACT_DIR`**,取不到属正常,只 `::warning::`、不改变判定。

## 范围

只改 `.github/workflows/qa.yml` 的 `hub-orphan-gates` 一个 job,**+27/-2**。不碰其余 5 个 job,不碰任何套件代码。

合入后按同样形状推广到 `grok-green-suites` / `hub-boundary-gates` / `security-orphan-gates` / `private-config-gates` / `hub-daemon-gate`(共 9 处 `docker run`),**每处要各自确认 `/tmp/art` 在该容器内可写** —— test225 的注释专门记过这一格(它把 `ARTIFACT_DIR` 指到 Dockerfile 里 chown 过的目录),**路径不能照抄**。
