### PR TITLE
docs(test638): 刷新 ARTIFACT_DIR 注释 —— 取出已由 #1328 补上,旧注释按显示名指错了 job

### DIFF
--- a/tests/test638-server-aggregate-isolation/run.sh
+++ b/tests/test638-server-aggregate-isolation/run.sh
@@ -57,9 +57,14 @@ dump_agg_failure() {
   echo "--- last 40 lines of $output ---"
   tail -40 "$output" || true
   # 兜底,不依赖任何输出格式假设。ARTIFACT_DIR 是本仓既有约定(test225/234/697
-  # 都在用)。⚠️ 目前 qa.yml 的 hub-semantics 矩阵是 `docker run --rm`,没有取出
-  # 步骤,所以这几份现在只落在容器里 —— 取出需要照 test225 的做法
-  # (`--name` + `docker cp` + `docker rm -f`,qa.yml:745-755)。先写,取出另议。
+  # 都在用)。
+  #
+  # ✅ #1324/#1328 已补上取出:本套件跑在 qa.yml 的 `hub-orphan-gates` job
+  #    (**显示名是 `hub semantics + guards (Docker)`** —— key 和 name 不同,
+  #    上一版注释按显示名写成了「hub-semantics 矩阵」,查的人按那个名字在 qa.yml
+  #    里 grep 是找不到的),该 step 现在是 `--name` → `docker cp` → `docker rm -f`,
+  #    再由 `Upload ... artifacts`(`if: failure()`)传成 artifact。
+  #    ⇒ 红的时候,整份聚合输出可以从该 run 的 Artifacts 里下到,不再只剩 tail -40。
   if [ -n "${ARTIFACT_DIR:-}" ]; then
     mkdir -p "$ARTIFACT_DIR" 2>/dev/null || true
     cp -- "$output" "$ARTIFACT_DIR/$(basename "$output")" 2>/dev/null \


### PR DESCRIPTION
纯注释改动，`bash -n` 通过，不改任何行为。

## 改什么

`tests/test638-server-aggregate-isolation/run.sh` 里 `dump_agg_failure` 末尾那段注释，两句话现在都不成立：

> ⚠️ 目前 qa.yml 的 hub-semantics 矩阵是 `docker run --rm`，没有取出步骤 …先写，取出另议。

### ① 取出已经有了

#1328（`43ef1602`）把该 step 改成 `--name` → `docker cp` → `docker rm -f`，配合既有的 `Upload … artifacts`（`if: failure()`）。诊断四环现在齐了，逐环位置见 #1319 的最新评论。

### ② 🔴 旧注释按**显示名**指了 job，按那个名字在 qa.yml 里 grep 是 0 命中

```
job key   : hub-orphan-gates                  ← 只在 qa.yml 里出现
显示 name : hub semantics + guards (Docker)   ← 只在 CI 界面出现
```

注释是照着 CI 界面上看到的名字写的，而读注释的人下一步是去 qa.yml 里搜 —— **搜不到**。他会得出两种结论之一：这个 job 不存在（于是重做一遍已经做完的事），或者去改另一个名字相近的 job。

这一格值得单独记：**一个对象有两个名字、而两个名字各自只在一处出现时，注释里必须写清哪个是哪个** —— 否则注释在写的时候是对的，在被读的时候是错的。

ref #1319 #1324