### PR TITLE
fix(grok-copresence): 剩余 4 处「断进程已消失」改用同一谓词(#1315 收口,9 处断存在的不动)

### DIFF
--- a/agent-node/src/runtime/grok-copresence/leader-lifecycle.test.ts
+++ b/agent-node/src/runtime/grok-copresence/leader-lifecycle.test.ts
@@ -85,7 +85,11 @@ describe("Grok auto-Leader lifecycle identity", () => {
 
     await terminateOwnedGrokLeader(identity);
 
-    expect(existsSync(`/proc/${identity.pid}`)).toBe(false);
+    // 语义是「这一代进程没了」,不是「/proc 目录没了」—— 用与产品同一个谓词。
+    // SIGTERM 之后到父进程 reap 之前进程处于 Z,`/proc` 条目仍在(#1315)。
+    // 这条的 fixture 不是 TERM-resistant,但窗口与是否升级 SIGKILL 无关:
+    // 任何被 fork 的子进程退出后、父进程 wait 之前都是 Z。
+    expect(await waitGenerationGone(identity)).toBe(true);
     expect(existsSync(fixture.socket)).toBe(false);
   });
 

--- a/agent-node/src/runtime/grok-copresence/leader-lifecycle.ts
+++ b/agent-node/src/runtime/grok-copresence/leader-lifecycle.ts
@@ -395,6 +395,18 @@ function sameRealPath(candidate: string, expected: string): boolean {
  * Measured: a forked child that exits without being waited on shows
  * `state=Z`, `existsSync(/proc/<pid>)=true`, and this function `true`.
  */
+/** Snapshot which generation a pid currently is, or null if it is not there.
+ *
+ * Companion to `processGenerationGone`: to later assert "that generation is
+ * gone" a caller must first be able to say which generation it meant. Without
+ * this, callers re-parse /proc/<pid>/stat themselves — and a re-implementation
+ * is exactly how the #1315 bug arose (the test's own predicate missed the `Z`
+ * case that the product handles).
+ */
+export function readProcessGeneration(pid: number): string | null {
+  try { return readProcessStat(pid).startTime; } catch { return null; }
+}
+
 export function processGenerationGone(pid: number, startTime: string): boolean {
   return !sameProcessGenerationExists(pid, startTime);
 }

--- a/agent-node/src/runtime/grok-copresence/runtime.test.ts
+++ b/agent-node/src/runtime/grok-copresence/runtime.test.ts
@@ -21,6 +21,27 @@ import { mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { basename, join, resolve } from "path";
 import { describe, expect, test } from "bun:test";
+import { processGenerationGone, readProcessGeneration } from "./leader-lifecycle";
+
+/** 轮询到「这一代进程没了」,或到上界为止;返回的是**条件**不是时间。
+ *
+ * 🔴 为什么不能用 `existsSync(/proc/<pid>)`:SIGTERM/SIGKILL 送达后、父进程
+ * reap 之前进程处于 `Z`,`/proc` 条目仍在,而产品侧 `sameProcessGenerationExists`
+ * 把 `Z`/`X` 当作「已消失」。两者在那个窗口里给出相反的答案(#1315)。
+ * 窗口与是否升级 SIGKILL 无关 —— 任何被 fork 的子进程退出后、父进程 wait
+ * 之前都是 `Z`。
+ *
+ * 与 leader-lifecycle.test.ts 里那份是同一个模式;这里保留一份局部实现,是
+ * 因为为八行代码新增一个共享文件、再让两个测试文件各 import 一次,反而更绕。
+ */
+async function waitGenerationGone(pid: number, startTime: string, boundMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + boundMs;
+  while (Date.now() < deadline) {
+    if (processGenerationGone(pid, startTime)) return true;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  return processGenerationGone(pid, startTime);
+}
 import { connectGrokAttach } from "../../../../agent-network/src/grok-attach-client";
 import {
   describeGrokCopresenceLiveness,
@@ -537,10 +558,13 @@ describe("Grok copresence runtime integration", () => {
       expect(leaderPid).toBeGreaterThan(1);
       expect(existsSync(`/proc/${leaderPid}`)).toBe(true);
       expect(existsSync(fixture.leaderSocket)).toBe(true);
+      // 先拍下「这一代」,close 之后才能断言正是这一代没了(#1315)。
+      const leaderGen = readProcessGeneration(leaderPid);
+      expect(leaderGen).not.toBeNull();
 
       await runtime.close();
       runtime = undefined;
-      expect(existsSync(`/proc/${leaderPid}`)).toBe(false);
+      expect(await waitGenerationGone(leaderPid, leaderGen!)).toBe(true);
       expect(existsSync(fixture.leaderSocket)).toBe(false);
     } finally {
       await runtime?.close();
@@ -1308,12 +1332,18 @@ describe("Grok copresence runtime integration", () => {
       runtime = await fixture.open();
       const footprint = seedPostStopFootprint(fixture);
       const firstLeader = fixture.currentLeaderPid();
+      // 必须在 crash 之前拍下这一代:之后它可能已是 Z、甚至已被 reap,
+      // 那时再读就分不清「拍的是哪一代」了。
+      const firstGen = readProcessGeneration(firstLeader);
+      expect(firstGen).not.toBeNull();
       await fixture.crashCurrent();
       await waitFor(() => fixture.recoverySpawnBlocked, 5_000);
       expect(existsSync(footprint.promptHistory)).toBe(true);
       const secondLeader = fixture.currentLeaderPid();
       expect(secondLeader).not.toBe(firstLeader);
       expect(existsSync(`/proc/${secondLeader}`)).toBe(true);
+      const secondGen = readProcessGeneration(secondLeader);
+      expect(secondGen).not.toBeNull();
 
       const closing = runtime.close();
       fixture.releaseRecoverySpawn();
@@ -1322,8 +1352,10 @@ describe("Grok copresence runtime integration", () => {
 
       for (const path of footprint.removedPaths) expect(existsSync(path), path).toBe(false);
 
-      expect(existsSync(`/proc/${firstLeader}`)).toBe(false);
-      expect(existsSync(`/proc/${secondLeader}`)).toBe(false);
+      // 断的是「那两代进程没了」,不是「/proc 目录没了」——
+      // crash / close 之后到父进程 reap 之前都是 Z,存在性检查会误判为「还在」。
+      expect(await waitGenerationGone(firstLeader, firstGen!)).toBe(true);
+      expect(await waitGenerationGone(secondLeader, secondGen!)).toBe(true);
       expect(existsSync(fixture.leaderSocket)).toBe(false);
     } finally {
       fixture.releaseRecoverySpawn();


### PR DESCRIPTION
收口 #1315:#1327 只修了 issue 点名的那一条,同族还有 **4 处**,其中一处就在同一个文件里。

> **一个修得很彻底的单点修复,和一个覆盖了整类的修复,读起来一样像「修好了」。**

## 逐条判过,不是全局替换

全仓 13 处 `existsSync(/proc/<pid>)`:

| 断言方向 | 语义 | 处数 | 处置 |
|---|---|---|---|
| `toBe(false)` | 「这一代进程没了」 | **4** | 全部改 |
| `toBe(true)` | 「还没被杀」 | **9** | **一处不动** |

🔴 其中 `leader-lifecycle.test.ts:174` 那条 `toBe(true)` 是 #1327 加的 **zombie 钉子**,它**故意**断 `/proc` 仍在(用来证明两个谓词在 `Z` 上分歧)。**一次全局 sed 会把它改反,那颗钉子就废了。** 改完复核:`toBe(false)` 剩 **0**,`toBe(true)` 仍 **9**。

## 四处的判据:有没有可能正处于 `Z`

```
leader-lifecycle.test.ts:88     terminateOwnedGrokLeader() 后立刻断
runtime.test.ts:543             runtime.close() 后立刻断
runtime.test.ts:1325 / :1326    同上(recovery 场景的两代 Leader)
```

②③④ 的路径是 `close()` → `teardownOwnedLeader()` → **`await terminateOwnedGrokLeader()`**,而该函数内部用 `sameProcessGenerationExists`,**`state !== "Z"` 就算「已消失」** —— **产品按设计不等 reap**。

⇒ **四处全部落在同一个窗口里,没有一处例外。** ①的 fixture 甚至不是 TERM-resistant,但**窗口与是否升级 SIGKILL 无关**:任何被 fork 的子进程退出后、父进程 `wait` 之前都是 `Z`。

## 新增一个配套导出 `readProcessGeneration(pid)`

测试要断「**那一代**没了」,就必须先能「拍下那一代」。三条路:

- 在测试里重新解析 `/proc/<pid>/stat` ⇒ **又是自造判据,而 #1315 正是这么来的**
- 改 `processGenerationGone` 的签名语义 ⇒ 动到已合入的产品谓词,风险大
- **导出配套的「拍一代」函数** ⇒ 采用

它是 `processGenerationGone` 的配套(**先拍、后判**),不是内部实现泄漏。

🔴 recovery 那条里 `firstLeader` 的 generation **必须在 `crashCurrent()` 之前拍** —— 之后它可能已是 `Z`、甚至已被 reap,那时再读就分不清拍的是哪一代。

## 见红

变异 `processGenerationGone` 恒返回 `false`(谓词恒说「还在」):

```
71 pass / 5 fail
  (fail) terminates one exact generation…                      ← ① leader-lifecycle:88
  (fail) processGenerationGone reports a zombie…               ← #1327 的 zombie 钉子
  (fail) revalidates the exact identity…                       ← #1327 修的那条
  (fail) terminates the independently persistent auto-Leader…  ← ② runtime:543
  (fail) close waits for and tears down a Leader…              ← ③④ runtime:1325/1326
```

5 个红用例正好覆盖本次 4 处 + zombie 钉子 + #1327 那条 ⇒ **这四处断言真的依赖那个谓词,不是恒过。**

🔴 **诚实标注**:这证明的是「断言依赖谓词」,**不是**「断言能发现进程没被回收」—— 后者会先撞上产品自身的内部检查抛错,#1327 的红门 2/3 已记录同一现象。不把它说成比实际更强。

未变异时:**76 pass 0 fail**(两个文件,115s)。

## 范围

`leader-lifecycle.ts` +12(一个配套导出 + 注释),`leader-lifecycle.test.ts` / `runtime.test.ts` 共 +40/-4。不改任何产品行为,不碰 workflow。
