### PR TITLE
fix(#1337): 附件下载中止路径挂上 writer error 监听器 —— 确定性复现 199/200,消掉 L1 里 4/5 的红

### DIFF
--- a/agent-node/src/runtime/fetch-attachment.test.ts
+++ b/agent-node/src/runtime/fetch-attachment.test.ts
@@ -335,6 +335,45 @@ describe("resolveAttachmentToLocalPath — cache hit", () => {
   });
 });
 
+describe("mid-stream abort leaves no unhandled writer error", () => {
+  // 🔴 见证红:改这个测试之前,产品在中止路径上不挂 error 监听器 ⇒ 200 轮里 199 轮
+  //    抛出未处理的 ENOENT。修复后 0/200。
+  //
+  //    机制:小块写时 `open` 系统调用还挂着 write 就返回了;命中上限 → writer.destroy()
+  //    (异步,不取消 pending open) → 文件/目录被删 → open 之后才落到已消失的路径 → emit "error"。
+  //
+  //    🔴 为什么参数必须是**小块**:用 1 MiB 大块复现是 0/60 —— 背压会强制 open 先完成。
+  //    CHUNK/CAP 取的就是上面 "Content-Length lies" 那个用例的真值,不要随手调大。
+  test("abort under a cleanup that deletes the cache dir emits no unhandled error", async () => {
+    const N = 60, CHUNK = 80, CAP = 100;
+    const errs: string[] = [];
+    const onErr = (e: any) => errs.push(String(e?.message || e));
+    process.on("uncaughtException", onErr);
+    process.on("unhandledRejection", onErr);
+    try {
+      for (let i = 0; i < N; i++) {
+        const cacheDir = freshCacheDir();
+        let sent = 0;
+        const fakeFetch: typeof fetch = async () =>
+          new Response(new ReadableStream({
+            pull(c) { sent++; c.enqueue(new Uint8Array(CHUNK).fill(0x42)); if (sent >= 5) c.close(); },
+          }), { status: 200, headers: { "Content-Length": "1" } });
+        const r = await resolveAttachmentToLocalPath(
+          { file_id: "aborttest_xyz123" },
+          { hubUrl: "http://hub.test:9200", authToken: "ntok_x", cacheDir, maxBytes: CAP, fetch: fakeFetch },
+        );
+        expect(r.ok).toBe(false);
+        cleanupCacheRoot();   // 模拟 afterEach:在写者可能还活着时删掉整棵根
+      }
+      await new Promise(r => setTimeout(r, 300));
+    } finally {
+      process.off("uncaughtException", onErr);
+      process.off("unhandledRejection", onErr);
+    }
+    expect(errs.filter(e => e.includes("ENOENT"))).toEqual([]);
+  });
+});
+
 describe("sweepAttachmentCacheOnce", () => {
   test("purges files older than TTL, keeps fresh", () => {
     const cacheDir = freshCacheDir();

--- a/agent-node/src/runtime/fetch-attachment.ts
+++ b/agent-node/src/runtime/fetch-attachment.ts
@@ -237,6 +237,14 @@ async function fetchAndCache(
   try {
     const reader = res.body.getReader();
     const writer = createWriteStream(tmpPath, { mode: 0o600 });
+    // 🔴 挂 error 监听器,否则中止路径会留下一个**没人接的异步 ENOENT**。
+    //    机制(已确定性复现 199/200):小块写时 `open` 系统调用还挂着就 write 返回了;
+    //    命中体积上限 → `writer.destroy()`(异步,不取消 pending open)→ 目录/文件被删 →
+    //    那个 open 之后才落到已消失的路径上 → emit "error"。没有监听器 = 未处理异常。
+    //    大块写复现不出来,因为背压会强制 open 先完成 —— 这正是前三次复现失败的原因。
+    // 不吞掉错误:记下来,成功路径上仍然把它冒泡成 write_failed。
+    let writerErr: any = null;
+    writer.on("error", (e) => { writerErr = writerErr ?? e; });
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -260,6 +268,7 @@ async function fetchAndCache(
     await new Promise<void>((resolve, reject) => {
       writer.end((err?: any) => err ? reject(err) : resolve());
     });
+    if (writerErr) throw writerErr;   // 正常路径上的写错误照样冒泡,不被上面的监听器吞掉
   } catch (e: any) {
     try { rmSync(tmpPath, { force: true }); } catch { /* ok */ }
     return { ok: false, code: "fetch_failed", error: `stream-to-disk failed: ${e?.message || e}` };


### PR DESCRIPTION
修 #1337。**机制是确定性复现出来的（199/200），不是推断** —— 这条很重要，因为我在 issue 里先后写过**两个**机制故事，**两个都是错的**。

## 症状与那个错误的用例名

```
(fail) resolveAttachmentToLocalPath — cache hit > same file_id + different size → cache miss, re-fetches
ENOENT: no such file or directory, open '…/lyinghub_xyz123.tmp-<pid>-<ts>'
```

🔴 报出来的用例名**不是肇事者**：该用例的 `file_id` 是 `stalecache_xyz123`；`lyinghub_xyz123` 属于**前一个**用例（`Content-Length lies → mid-stream abort`）。ENOENT 是前一个用例遗留的**未处理异步错误**，落到了当时正在跑的下一个用例头上。

## 机制

小块写时 `open` 系统调用**还挂着**，`writer.write()` 就返回了。命中体积上限 → `writer.destroy()`（异步，**不取消 pending open**）→ 文件/目录被删 → 那个 `open` 之后才落到已消失的路径上 → 流 emit `"error"`。**没有 error 监听器 = 未处理异常。**

报错自己说了是 `syscall: "open"` —— 这一格是我第四次才读进去的。

## 🔴 三次失败的复现，和它们教会的那件事

| # | 假设 | 构造 | 结果 |
|---|---|---|---|
| 1 | 竞速是 `open` vs `rmSync(tmpPath)` | 上限在第一块就触发 | **0 / 40** |
| 2 | 竞速是已排队的 `write()` 落盘 | 1 MiB 块，chunk2 触发 | **0 / 60** |
| 3 | 真凶是测试的 `rm -rf TEST_ROOT` | 1 MiB 块 + 共享根 rm -rf | **0 / 60** |
| **4** | **小块写让 `open` 来不及完成** | **CHUNK=80 / CAP=100（真值）** | **199 / 200** ✅ |

前三次全用 **1 MiB 大块** —— **背压会强制 `open` 先完成**，所以恒绿。

🔴 **缺的变量是「写块大小」，不是「谁删的文件」。** 我前三次都在换"删除者"这个维度找，而那个维度上三种答案都对不上；真正决定成败的参数我一直保持在一个会掩盖 bug 的值上。

⇒ 新测试里 `CHUNK=80 / CAP=100` 取的是真值。**不要随手调大 —— 调大就恒绿，而且看起来完全正常。** 注释里写了这句。

## 改法：记录而不是吞掉

只挂一个 no-op 监听器会把**真实的**写失败（磁盘满等）一起吃掉。所以记下来，正常路径上仍旧冒泡：

```ts
let writerErr: any = null;
writer.on("error", (e) => { writerErr = writerErr ?? e; });
…
await new Promise<void>((resolve, reject) => writer.end(err => err ? reject(err) : resolve()));
if (writerErr) throw writerErr;
```

## 证据

```
修复前  200 轮复现 → ENOENT 199 次
修复后  200 轮复现 → ENOENT   0 次
原测试文件         → 20 pass 0 fail
见证红(撤掉监听器) → 19 pass 1 fail，报的正是那条 ENOENT
```

## 影响面

按 **attempt 遍历** `main` 的 `L0 + L1`（不是看最终 conclusion —— 那会漏掉每一次被重跑掉的红）：

```
真实执行 16 次，failure 3 次 = 18.8%
其中 3 次全部是 test520-dashboard-attachment-read
加上 #1329 上的两次 → 5 个样本里 4 个是它
```

⇒ 修掉后该门红率应从 **~18.8% 降到 ~4%**。

🔴 **这一句是预测，不是已验证。** 验收在合入后的一段时间：继续按 attempt 统计，看 `test520` 是否从失败清单里消失。合了就当修好是错的判据 —— 对一个 19% 概率的东西，「没再看到」需要足够多的样本才成立。