### PR TITLE
fix(#1339): 拆开「收据还没写出来」和「收据写坏了」——前者报 RECEIPT_TIMEOUT 并明说不要删锁

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -6558,11 +6558,30 @@ async function withLifecycleLock<T>(nodeId: string, fn: () => T | Promise<T>, op
       let owner: LifecycleLockOwner;
       try { owner = JSON.parse(readFileSync(lifecycleLockOwnerPath(nodeId), "utf-8")); }
       catch (readError: any) {
+        // 🔴 #1339: ENOENT 和「解析失败」是两种完全不同的处境,曾经共用 CORRUPT 一个码。
+        //
+        //   ENOENT  = 持锁者已经 mkdir 了锁目录,但还没写出 owner.json。
+        //             中间夹着 processBirth() —— 它读 /proc,机器吃紧时会变慢。
+        //             **没有任何东西损坏**,只是还没写完。
+        //   解析失败 = 文件在,内容不是合法 JSON。这个才名副其实。
+        //
+        // 报成 CORRUPT 的代价不是措辞不好看:看到它的人会去找一个损坏的文件,
+        // 而那个文件要么不存在、要么完全正确 —— 查不出结果,然后很自然地
+        // 「把这个坏掉的锁删掉」,于是绕过了这整套互斥。
+        // **一个措辞不准的报错会教用户做一件危险的事。**
         if (readError?.code === "ENOENT") {
           if (!missingReceiptSince) missingReceiptSince = Date.now();
-          if (Date.now() - missingReceiptSince < 250) { await new Promise(r => setTimeout(r, 10)); continue; }
+          // 宽限从固定 250ms 改为跟随本函数既有的 deadline(5s)。
+          // 理由:250ms 是「本机够、CI 不够」的典型值 —— CI 上 L1 跑到 800~1000s 时
+          // 实测撞过(见 #1339 里的 test225 现场)。而 5s 已经是这个函数对
+          // 「等一个活着的持锁者」定下的预算,等一份收据没有理由更苛刻。
+          // 代价:持锁者若恰好在 mkdir 和写收据之间崩掉,现在要等到 deadline 才报,
+          //      而不是 250ms。两者都会报,差的只是延迟;而「写得慢」有实测,
+          //      「刚好崩在那个窗口」目前只是假设。
+          if (Date.now() < deadline) { await new Promise(r => setTimeout(r, 10)); continue; }
+          throw new Error(`NODE_LIFECYCLE_LOCK_RECEIPT_TIMEOUT: ${lock} (持锁者已建锁但 ${Math.round((Date.now() - missingReceiptSince) / 1000)}s 内未写出 owner.json;锁本身没有损坏,不要删它)`);
         }
-        throw new Error(`NODE_LIFECYCLE_LOCK_CORRUPT: ${lock}`);
+        throw new Error(`NODE_LIFECYCLE_LOCK_CORRUPT: ${lock} (owner.json 存在但解析失败: ${readError?.message || readError})`);
       }
       if (owner.schema !== 1 || !Number.isSafeInteger(owner.pid) || !owner.birth) throw new Error(`NODE_LIFECYCLE_LOCK_CORRUPT: ${lock}`);
       const current = processIdentitySnapshot(owner.pid);

--- a/tests/test225-node-stop-convergence/run.sh
+++ b/tests/test225-node-stop-convergence/run.sh
@@ -111,6 +111,27 @@ echo "$OUT" | grep -q NODE_LIFECYCLE_LOCK_CORRUPT || fail "corrupt lock lacked t
 rm -rf .anet/nodes/a/.lifecycle-lock
 pass "lifecycle lock recovers dead identity and refuses corrupt receipt"
 
+# #1339: 收据「还没写出来」和「写坏了」必须报成两个不同的码。
+# 上面那一格喂的是 `{corrupt` —— 文件在、解析不了,那才叫 CORRUPT。
+# 这一格喂的是**锁目录存在但完全没有 owner.json**,也就是持锁者已 mkdir、
+# 还没写收据的那个窗口。以前它也报 CORRUPT,于是看到报错的人会去找一个
+# 根本不存在的损坏文件,查不出结果,然后很自然地把锁删掉 —— 绕过整套互斥。
+mkdir -p .anet/nodes/a/.lifecycle-lock
+OUT=$(anet node stop a 2>&1); RC=$?
+[ "$RC" -ne 0 ] || fail "missing lifecycle receipt was silently stolen"
+echo "$OUT" | grep -q NODE_LIFECYCLE_LOCK_RECEIPT_TIMEOUT \
+  || fail "missing receipt must not be reported as CORRUPT: $OUT"
+# 🔴 反向断言:这一格**不得**报成 CORRUPT。少了它,一个把新码和 CORRUPT 一起
+#    拼上去的实现照样能过上面那行。
+# 用 if 而不是 `grep -q X && fail`:本脚本目前是 set -uo pipefail(没有 -e),
+# 两种写法都对;但将来谁加上 -e,`&& fail` 那行在**不命中(即通过)**时整行 rc=1,
+# 会把脚本打死在一个正确的结果上。
+if echo "$OUT" | grep -q NODE_LIFECYCLE_LOCK_CORRUPT; then
+  fail "missing receipt was still reported as CORRUPT: $OUT"
+fi
+rm -rf .anet/nodes/a/.lifecycle-lock
+pass "lifecycle lock distinguishes a missing receipt from a corrupt one"
+
 # Deterministic exit-window fixture: a zombie still answers kill(0), but one
 # /proc stat snapshot identifies it as already gone. The parent must remain
 # untouched and stop must not misreport birth-unavailable.


### PR DESCRIPTION
修 #1339。

## 这个报错在撒谎：没有任何东西损坏了

加锁序列（`agent-network/bin/cli.ts:6548-6553`）：

```ts
mkdirSync(lock, { mode: 0o700 });                     // ① 目录即锁，原子
const birth = processBirth(process.pid);              // ② 读 /proc
atomicWritePrivateJson(lifecycleLockOwnerPath(…), …); // ③ 写收据
```

**①③之间有窗口**：锁已存在、收据还没写出来，竞争者读到 `ENOENT`。
代码知道这个窗口并留了 250 ms 宽限，但**宽限一过，`ENOENT` 和「JSON 解不开」被折叠成同一个码**。

## 两处改动

### ① 拆码

```
NODE_LIFECYCLE_LOCK_RECEIPT_TIMEOUT  ← ENOENT 超时：持锁者已建锁但还没写收据
NODE_LIFECYCLE_LOCK_CORRUPT          ← 文件在但解析失败（名副其实的那个）
```
前者的文案显式写「**锁本身没有损坏，不要删它**」。

🔴 **措辞不是好看问题。** 看到 `CORRUPT` 的人会去找一个损坏的文件，而它要么**根本不存在**、要么**完全正确** —— 查不出结果，然后很自然地「把这个坏掉的锁删掉」，于是绕过了这整套设计得很谨慎的互斥。**一个措辞不准的报错会教用户做一件危险的事。**

### ② 宽限 250 ms → 跟随本函数既有的 deadline（5 s）

250 ms 是「本机够、CI 不够」的典型值，CI 上实测撞过。5 s 是这个函数对「等一个活着的持锁者」**已经定下**的预算，等一份收据没有理由更苛刻。

**代价我写在注释里了**：持锁者若恰好崩在 `mkdir` 和写收据之间，现在要等到 deadline 才报而不是 250 ms。两者都会报，差的只是延迟；而**「写得慢」有实测，「刚好崩在那个窗口」目前只是假设**。

## 兼容性：改错误串之前全站 grep 过

全仓引用该字面量的只有一处：

```
tests/test225-node-stop-convergence/run.sh:110
  echo "$OUT" | grep -q NODE_LIFECYCLE_LOCK_CORRUPT || fail "corrupt lock lacked typed failure"
```

它喂的是 `printf '{corrupt'` —— **文件在、解析不了**，正是保留 `CORRUPT` 的那一支。**既有断言不受影响。**

## 新增测试（新分支原本零覆盖）

锁目录存在但**完全没有** `owner.json`，断言报 `RECEIPT_TIMEOUT`，并**反向断言不得报 `CORRUPT`**。

🔴 反向那条是必需的：少了它，**一个把两个码一起拼上去的实现照样能过正向断言**。

🔴 反向断言写成 `if … then fail; fi` 而不是 `grep -q X && fail`：本脚本是 `set -uo pipefail`（**没有 `-e`**），两种写法今天都对；但将来谁加上 `-e`，`&& fail` 那行在**不命中（也就是通过）**时整行 `rc=1`，**会把脚本打死在一个正确的结果上**。

## 这个 PR 不能证明什么

🔴 它**不证明** test225 的 startup-race 间歇红就此消失。那条红的直接原因是宽限太短，本 PR 放宽了它；但**「放宽到 5 s 就一定够」没有实测支撑** —— 只知道 250 ms 不够。
真正的验收是合入后继续按 attempt 统计 `test225` 是否还出现在失败清单里。

Closes #1339