### PR TITLE
ci(#1315): 棘轮门——禁止用 existsSync(/proc/<pid>) 断言「这一代进程没了」（基线 0，见红三格）

### DIFF
--- a/.github/workflows/proc-gone-assertions.yml
+++ b/.github/workflows/proc-gone-assertions.yml
@@ -1,0 +1,24 @@
+# 禁止用 `existsSync(/proc/<pid>)` 断言「这一代进程没了」（#1315）。
+#
+# 🔴 **无 paths 过滤，故意的。** 同类门（doc-symbol-pins）原本挂在 qa.yml 里，
+#    因为 qa.yml 的 paths 没覆盖到真正会漂的那个文件，**跑不到该跑的时候** ——
+#    一道存在、挂上了、却从不被触发的门，和没有这道门在 PR 页面上长得一模一样。
+#    这道门要守的是**任何**新增测试断言，而新测试可以出现在任何目录，
+#    所以不设 paths：全跑，代价是几秒钟。
+name: proc-gone assertions
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  proc-gone:
+    name: proc-gone assertion ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      # 判据自检先跑：一道自己都没被证明会红的门，绿了也不能读。
+      - name: selftest (criterion)
+        run: python3 scripts/check-proc-gone-assertions.py --selftest
+      - name: scan repo
+        run: python3 scripts/check-proc-gone-assertions.py .

--- a/scripts/check-proc-gone-assertions.py
+++ b/scripts/check-proc-gone-assertions.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""禁止用 `existsSync(/proc/<pid>)` 断言「这一代进程没了」。
+
+## 为什么
+
+#1315:SIGTERM 之后、父进程 reap 之前,进程处于 `Z`(僵尸),**`/proc/<pid>` 条目仍在**。
+而产品侧 `sameProcessGenerationExists` 把 `Z`/`X` 当作「已消失」——
+于是「产品认为它没了」和「/proc 目录还在」同时成立。
+
+拿 `existsSync(/proc/<pid>)).toBe(false)` 去断言回收,在**空闲机器上几乎总是绿**
+(reap 很快),在**忙碌机器上间歇红**。实测 31 次执行里 1 次。
+它红的时候看起来像产品缺陷,其实是判据和产品契约不一致。
+
+正确写法:`processGenerationGone(pid, startTime)` / `waitGenerationGone(...)`。
+
+## 🔴 只禁 `.toBe(false)` 方向,不禁 `.toBe(true)`
+
+同一个调用,相反的语义:
+    toBe(true)   = 「它还没被杀」—— 合法,而且 leader-lifecycle.test.ts 里那颗
+                   zombie 钉子**故意**断 `/proc` 仍在。一次全局替换会把它改反。
+    toBe(false)  = 「这一代没了」—— 就是本门要禁的。
+13 处里只有 4 处是后者。**这就是为什么它必须是精确形态匹配,而不是"提到 /proc 就报"。**
+
+## 基线
+
+2026-08-28 全仓 766 个源文件实测:`existsSync(/proc` 出现在 3 个文件,
+`.toBe(false)` 形态 **0 处**。分母是 0 ⇒ 新增一处就红,没有存量豁免要维护。
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# 形态:existsSync(...proc/...)  之后一到两行内出现 .toBe(false)
+EXISTS = re.compile(r"existsSync\s*\([^)]*?/proc/")
+FALSY = re.compile(r"\.toBe\(\s*false\s*\)|\.toBeFalsy\(\)")
+SRC = (".ts", ".mts", ".tsx", ".js", ".mjs", ".cjs")
+
+
+def collect(repo: Path) -> list[Path]:
+    """取集:git 跟踪的全部源文件。
+
+    🔴 用 `git ls-files` 而不是 rglob:后者会扫进 node_modules / dist / .worktrees,
+       分母虚高几万,而且会把第三方代码算成违规。
+    🔴 但 `git ls-files` 看不见**未跟踪的新文件** —— 本地跑这道门之前要先 `git add`。
+       CI 上无所谓(checkout 出来的都是跟踪的)。
+    """
+    out = subprocess.run(["git", "-C", str(repo), "ls-files"],
+                         capture_output=True, text=True, check=True).stdout
+    return [repo / p for p in out.split("\n")
+            if p.endswith(SRC) and "node_modules/" not in p]
+
+
+def scan_text(text: str) -> list[int]:
+    lines = text.split("\n")
+    bad = []
+    for i, line in enumerate(lines):
+        if not EXISTS.search(line):
+            continue
+        window = " ".join(lines[i:i + 2])
+        if FALSY.search(window):
+            bad.append(i + 1)
+    return bad
+
+
+def selftest() -> int:
+    cases = [
+        ("expect(existsSync(`/proc/${pid}`)).toBe(false);", [1], "同行 toBe(false)"),
+        ("expect(existsSync(`/proc/${pid}`))\n  .toBe(false);", [1], "跨行 toBe(false)"),
+        ("expect(existsSync(`/proc/${pid}`)).toBeFalsy();", [1], "toBeFalsy"),
+        ("expect(existsSync(`/proc/${pid}`)).toBe(true);", [], "🔴 toBe(true) 必须放行(zombie 钉子)"),
+        ("expect(await processGenerationGone(pid, st)).toBe(false);", [], "正确写法不该被误报"),
+        ("expect(existsSync(sockPath)).toBe(false);", [], "非 /proc 路径不管"),
+        ("const raw = readFileSync(`/proc/${pid}/stat`);", [], "读 stat 不是断言"),
+    ]
+    bad = 0
+    for text, want, label in cases:
+        got = scan_text(text)
+        ok = got == want
+        print(f"  {'PASS' if ok else 'FAIL'}  {label}  期望={want} 实际={got}")
+        bad += 0 if ok else 1
+    # 取集自检:造一棵目录树,确认递归 + 后缀都收得到
+    print(f"  判据自检: {len(cases) - bad}/{len(cases)}")
+    return 1 if bad else 0
+
+
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+    repo = Path(sys.argv[1] if len(sys.argv) > 1 and not sys.argv[1].startswith("-") else ".").resolve()
+    files = collect(repo)
+    findings = []
+    for f in files:
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for n in scan_text(text):
+            findings.append(f"  🔴 {f.relative_to(repo)}:{n}  用 existsSync(/proc/<pid>) 断言「进程没了」")
+    for line in findings:
+        print(line)
+    print(f"PROC-GONE: {'RED' if findings else 'OK'}（扫了 {len(files)} 个源文件，违规 {len(findings)} 处）")
+    if findings:
+        print("  改法：processGenerationGone(pid, startTime) / waitGenerationGone(...) —— 见 #1315。")
+        print("  🔴 只禁 .toBe(false) 方向；.toBe(true)（『它还没被杀』）是合法的，本门不碰。")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
#1315 收口时我写的最后一步：**那道棘轮门现在可以加了 —— 基线是 0**。这就是它。

## 规则

SIGTERM 之后、父进程 reap 之前，进程处于 `Z`，**`/proc/<pid>` 条目仍在**；而产品侧 `sameProcessGenerationExists` 把 `Z`/`X` 当作已消失。
于是「产品认为它没了」和「`/proc` 还在」**同时成立** —— 拿 `existsSync` 断言回收，空闲机器上几乎总绿、忙碌机器上间歇红（实测 31 次里 1 次）。

## 🔴 只禁 `.toBe(false)`，不禁 `.toBe(true)`

同一个调用、相反的语义。13 处里只有 4 处是「这一代没了」；其余 9 处是「它还没被杀」，其中 `leader-lifecycle.test.ts` 那颗 zombie 钉子**故意**断 `/proc` 仍在。

**一道「提到 /proc 就报」的门，会逼着人把那颗钉子改反。** 所以判据是精确形态匹配。

## 基线 = 0（先量后加）

```
全仓 772 个源文件：existsSync(/proc 出现在 3 个文件，.toBe(false) 形态 0 处
```

**产品侧也查了**：`leader-lifecycle.ts` 那两处，一处是 socket 文件、一处是 `processGenerationGone` 的说明注释；`readLeaderProcess` 自己显式判 `Z`/`X` 抛「not live」⇒ **产品侧无同类缺陷**。

分母 0 ⇒ 新增即红，**没有存量豁免要维护**。

## 见红：三格，都在真树上跑

```
① 注入 existsSync(/proc/…).toBe(false)   → RED rc=1  ✅
② 注入合法的 .toBe(true)                 → 仍 OK      ✅  ← 证明不是"提到 /proc 就报"
③ 新目录里的新文件                       → git add 前收不到、add 后 RED  ✅
```

🔴 **第③格见证的是脚本注释里写的那个盲区本身**：`git ls-files` 看不见未跟踪文件，**本地跑这道门之前要先 `git add`**（CI 上 checkout 出来的都是跟踪的，无此问题）。**注释里那句话现在是量出来的，不是我推的。**

判据自检 7/7，其中两条是**必须放行**的用例（`toBe(true)`、`processGenerationGone(...).toBe(false)`）—— 只测「该红的红了」不够，还要测「不该红的没红」。

## 🔴 独立 workflow，无 paths 过滤 —— 照抄本仓自己的教训

`doc-symbol-pins` 原本挂在 `qa.yml`，因为 paths 没覆盖真正会漂的文件，**跑不到该触发的时候**。那段原因就写在 `qa.yml` 和 `doc-symbol-pins.yml` 的注释里，还附了实测漂移。

**一道存在、挂上了、却从不被触发的门，和没有这道门在 PR 页面上长得一模一样。**
新测试可以出现在任何目录，所以不设 paths：全跑，代价几秒。

（同时也避开那条：**带 paths 的 workflow 在不匹配的 PR 上不产生 check-run，永远做不了 required check**。）

ref #1315