### PR TITLE
ci(#1333): L1 每个套件完成即打印偏移 —— 被 kill 的那一跑正是最需要它的那一跑

### DIFF
--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -468,7 +468,14 @@ if [[ $RUN_L1 -eq 1 ]]; then
       _s=$(( $(date +%s) - START ))
       dockerrun "docker run --rm anet-$t" >/tmp/qa-l1-$t-run.log 2>&1
       _rc=$?
-      printf '%s\t%s\t%s\n' "$t" "$_s" "$(( $(date +%s) - START ))" >> /tmp/qa-l1-timing.tsv
+      _e=$(( $(date +%s) - START ))
+      printf '%s\t%s\t%s\n' "$t" "$_s" "$_e" >> /tmp/qa-l1-timing.tsv
+      # 🔴 **完成即打印**,不要只留给结尾的汇总。
+      #    2026-08-27 一次 L0+L1 顶到 30 分天花板被 kill(run 33126449082,1815s):
+      #    18 个 build 起来了,而时间线**一行都没有** —— 因为汇总只在所有 wait 结束后才跑,
+      #    而那一跑根本没走到那里。**唯一需要这条时间线的场合,正是它打不出来的场合。**
+      #    (被 kill 的观测本身也只是下界:1815s 不是它跑完要多久,是它被杀时已经跑了多久。)
+      printf '· L1 done %s  [L1+%ss..%ss, %ss] rc=%s\n' "$t" "$_s" "$_e" "$(( _e - _s ))" "$_rc"
       exit $_rc
     ) &
     pid=$!


### PR DESCRIPTION
#1341 的时间线只在结尾汇总打印。**它合入后的第一次 L0+L1 就撞上了这个死角。**

## 现场

```
run 33126449082   sha=9e9f700b（正是 #1341 的合并提交）
L0 + L1   conclusion=cancelled   1815s —— 顶到 timeout-minutes: 30 的天花板
日志里 18 个 `· build …` 起来了，✓ L1 / ✗ L1 和时间线一行都没有
```

🔴 **唯一需要这条时间线的场合（被杀、卡住），正是它打不出来的场合。**

改法：每个套件的子 shell 在**自己结束时立刻**打印 `· L1 done <suite> [L1+Xs..Ys, Zs] rc=N`。TSV 与结尾汇总照旧 —— 两者互补：一个流式、被杀也留得下，一个排好序、给全景。

## 两条这次的读数纪律

**① `1815s` 是下界不是测量。** job 是被 kill 的，那是「它被杀时已经跑了多久」，不是「它跑完要多久」。拿它和 784–1021s 的正常样本比「慢了几倍」会高估。

**② 我先把自己当嫌疑人，然后被数据洗清。**

那次慢的 run 恰好**就是 #1341 的合并提交**，时间相关性极强（run 创建于合入后 4 秒）。我没有停在「机制上说不通」，而是去找决定性判据 —— **下一个 run**：

```
9e9f700b  (#1341 合并)  1815s  cancelled
60ef7ae0  (#1343 合并，同样带这段代码)   790s  success
```

同一份代码一次 1815s 一次 790s ⇒ **不是代码**。

🔴 **只有一个样本时，「它就是从我这次改动之后开始的」和「它恰好发生在我这次改动之后」长得一模一样。分辨它们要的是下一个样本，不是更仔细地读同一个。**

## 对 #1333 的意义

那次 1815s 本来是**最有价值的一个样本**（它正好回答「机器在一次 job 内越跑越慢到什么程度」），而我们**什么读数都没拿到**。改完之后下一次再撞墙，至少能知道它死在第几个套件、那个套件跑了多久。