### PR TITLE
chore(release): prepare BTW Hub preview.34

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 ## 开发规则
 
 - **不频繁发 npm preview**：本地源码开发，大版本完成时统一发
+- **对外 npm 产物只从 main 发布**：功能分支可构建、打包和测试，但不得向 npm 发布包或 executable；release 变更必须先合入 `main`，再从该 `main` 精确提交发布
 - **不改本地全局 npm 包**：只改 git 仓库源码
 - **Docker 先验证**：所有改动 Docker E2E 通过后再合并
 - **向后兼容**：旧 atok_ token 仍然有效

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -1,5 +1,11 @@
 # 更新日志
 
+## BTW 精确任务边界——Hub preview（2026-08-28）
+
+`commhub-server@0.9.0-preview.34` 为任务记录增加可选的 `thread_id` / `turn_id`，并在 REST 与 MCP 任务投影中返回它们。Hub 只接受节点对已消费任务上报的、归属一致且不冲突的边界；旧节点和历史任务继续兼容，缺失时明确保持为空，不做猜测或回填。配套的 `agent-node@2.5.0-preview.39` 与 `agent-network@2.3.0-preview.53` 将在 Hub 发布后按依赖顺序跟进。
+
+---
+
 ## Codex 共存 TUI 耐久化与安全停机——preview（2026-08-26）
 
 本轮 preview 三包配对发布：`agent-network@2.3.0-preview.46` / `agent-node@2.5.0-preview.34` / `commhub-server@0.9.0-preview.30`。Hub 增加不可变节点游标和终态序列，丢失 SSE 门铃后可耐久补偿；任务投递返回经 network 权限校验的 `actual_to`。Codex 共存路径保留单 bridge、共享 `CODEX_HOME` 与 thread/history，`node stop` 会收敛受管的 app-server / bridge / TUI 资源。Linux 与受保护 Windows Codex 0.148 门禁覆盖升级恢复、活跃 turn steer 和历史保留。

--- a/docs-site/docs/en/changelog.md
+++ b/docs-site/docs/en/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Exact BTW task boundary — Hub preview (2026-08-28)
+
+`commhub-server@0.9.0-preview.34` adds optional `thread_id` / `turn_id` fields to task records and returns them through REST and MCP task projections. The Hub accepts a boundary only when the consuming node reports it for an owned task without conflict. Older nodes and historical tasks remain compatible; absent boundaries stay explicitly absent and are never guessed or backfilled. The paired `agent-node@2.5.0-preview.39` and `agent-network@2.3.0-preview.53` will follow after the Hub is published, in dependency order.
+
+---
+
 ## Durable Codex co-presence and safe teardown — preview (2026-08-26)
 
 This paired preview release is `agent-network@2.3.0-preview.46` / `agent-node@2.5.0-preview.34` / `commhub-server@0.9.0-preview.30`. The Hub adds immutable node cursors and a monotonic terminal journal for durable recovery after a missed SSE notification, while task delivery returns the network-authorized `actual_to`. Codex co-presence keeps one bridge and a shared `CODEX_HOME` plus thread/history; `node stop` now converges the managed app-server, bridge, and TUI resources. Linux and protected Windows Codex 0.148 gates cover upgrade recovery, active-turn steering, and history preservation.

--- a/docs/tests/release-v0.9.0-preview.34.md
+++ b/docs/tests/release-v0.9.0-preview.34.md
@@ -1,0 +1,45 @@
+# commhub-server v0.9.0-preview.34 — BTW exact task boundary
+
+**Channel:** `preview` only
+
+**Source:** merged `main` after PR #1335
+
+**Date:** 2026-08-28
+
+This Hub release persists the exact Codex task boundary reported by an upgraded
+agent-node and exposes it as optional `thread_id` / `turn_id` fields through
+REST and MCP task projections. Context is accepted only for an owned, consumed
+task and is write-once for that task lifetime; duplicate, foreign, conflicting,
+or unrequested context is rejected. Older nodes and historical tasks remain
+compatible and are never backfilled by guessing.
+
+## Install
+
+For a direct, reproducible Hub install:
+
+```bash
+npm install -g @sleep2agi/commhub-server@0.9.0-preview.34
+```
+
+The user-facing `anet hub start` command remains pinned to the already published
+`.33` until this package exists on npm. A follow-up main release will update the
+CLI pin to `.34` together with `agent-node@2.5.0-preview.39` and
+`agent-network@2.3.0-preview.53`.
+
+## Upgrade
+
+Hub operators should back up the SQLite database, stop the existing Hub, install
+the exact preview, and restart it with the same database and configuration. The
+schema migration is additive (`tasks.thread_id`, `tasks.turn_id`) and old clients
+remain supported.
+
+Do not promote this preview to `latest`. After the paired node and CLI release,
+verify a newly consumed task has non-empty exact boundary fields before treating
+BTW deep-linking as deployed.
+
+## Verification before publish
+
+- `test798-server-unit-ci`: 84/84 server test files, 0 failures.
+- Registration-password mutation: witnessed red, then restored green.
+- PR #1335 exact head: 102/102 GitHub checks successful before merge.
+- App BTW suite on exact app main: 62/62 test files, typecheck and Expo export.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.33",
+  "version": "0.9.0-preview.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/commhub-server",
-      "version": "0.9.0-preview.33",
+      "version": "0.9.0-preview.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/commhub-server",
-  "version": "0.9.0-preview.33",
+  "version": "0.9.0-preview.34",
   "description": "CommHub Server — AI Agent communication hub with MCP protocol, multi-network isolation, user auth, and MCP tools (17 collaboration-core + node/provider ops tools; authoritative list: docs-site/docs/api/mcp-tools.md).",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Outcome

Prepare `@sleep2agi/commhub-server@0.9.0-preview.34` from merged main for the exact BTW task-boundary contract landed in #1335.

This is intentionally phase 1 of a two-phase release:

1. publish Hub `.34` from main;
2. only after npm can resolve `.34`, update `PINNED_SERVER_VERSION` and publish paired `agent-node@2.5.0-preview.39` / `agent-network@2.3.0-preview.53`.

The CLI remains pinned to the already-published Hub `.33` in this PR, so release gate 2 cannot deadlock on a not-yet-published target.

Also records the requested repository rule that external npm packages/executables may only be published from `main`; feature branches are build/test only.

## Exact evidence

- source: `5dd0e356a4f4df4c72f6c8821400389360840d5c`
- npm preflight: `.34` is E404/free
- `scripts/sync-pinned-versions.sh` dry-run: manifests already `.34`; only the deliberately deferred CLI pin remains WOULD-WRITE
- Docker `test798-server-unit-ci`: 84/84 files, 0 failures
- mutation: registration-password-floor weakening witnessed red
- doc version claims: 4 stamps checked
- doc symbol pins: 0 drift
- `git diff --check`: clean

## Safety

- preview only; no `latest` change
- no npm publish performed from this branch
- no production Hub/database/node touched
- additive task columns remain backward-compatible; absent historical boundaries stay absent
