### PR TITLE
fix(#1293): 子节点记录提前到能力检查之前 + 失败路径回滚 —— 消掉约 5 秒的 stop/delete 黑洞

### DIFF
--- a/agent-node/src/runtime/create-node-daemon.test.ts
+++ b/agent-node/src/runtime/create-node-daemon.test.ts
@@ -462,6 +462,52 @@ describe("RFC-027 BLOCKER-1 — childrenMap key shape matches hub canonical node
     // stop/delete will silently no-op.
   });
 
+  // #1293 —— 记录必须在 +5000ms 能力检查**之前**发生,否则 hub 认识子节点、
+  // daemon 不认,中间约 5 秒里 stop/delete 全部 ack `noop_not_my_child`。
+  // 提前记录必须配一次回滚,否则能力检查失败会留一条指向死 pid 的条目。
+  test("#1293 forgetSpawnedChild undoes an early record (capability-fail rollback)", async () => {
+    const { recordSpawnedChild, forgetSpawnedChild, getChildrenSnapshot, _resetChildrenMapForTest } =
+      await import("./stop-daemon");
+    _resetChildrenMapForTest();
+    const id = "node_cap_fail_rollback";
+    recordSpawnedChild(id, "doomed-child", 4242);
+    expect(getChildrenSnapshot().length).toBe(1);
+
+    // 回滚:返回 true 表示确实删掉了一条 —— 调用方据此判断「我记过吗」,不靠假设
+    expect(forgetSpawnedChild(id)).toBe(true);
+    expect(getChildrenSnapshot().length).toBe(0);
+
+    // 🔴 幂等 + 诚实:再删一次必须返回 false,而不是静默成功。
+    //    一个「删不存在的东西也说成功」的 API,会让调用方无法区分
+    //    「我记过并撤销了」和「我根本没记上」。
+    expect(forgetSpawnedChild(id)).toBe(false);
+
+    // 只删指定的那一条,不误伤兄弟
+    recordSpawnedChild("node_a", "a", 1);
+    recordSpawnedChild("node_b", "b", 2);
+    expect(forgetSpawnedChild("node_a")).toBe(true);
+    const rest = getChildrenSnapshot();
+    expect(rest.length).toBe(1);
+    expect(rest[0].child_node_id).toBe("node_b");
+    _resetChildrenMapForTest();
+  });
+
+  // 🔴 源码级断言:证明 record 真的排在能力检查之前。
+  //    上面那个用例只测 forgetSpawnedChild 这个零件 —— 它在旧代码上**照样会绿**,
+  //    因为顺序错不影响这个函数本身。顺序是这条 issue 的全部内容,必须单独钉。
+  test("#1293 recordSpawnedChild is invoked BEFORE the FAIL_FAST capability wait", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("./create-node-daemon.ts", import.meta.url), "utf8");
+    const iRecord = src.indexOf("recordSpawnedChild(child_node_id");
+    const iWait = src.indexOf("const FAIL_FAST_MS");
+    const iRollback = src.indexOf("forgetSpawnedChild(`node_${request_id");
+    expect(iRecord).toBeGreaterThan(-1);
+    expect(iWait).toBeGreaterThan(-1);
+    expect(iRollback).toBeGreaterThan(-1);
+    expect(iRecord).toBeLessThan(iWait);      // 记录在等待之前
+    expect(iRollback).toBeGreaterThan(iWait); // 回滚在等待之后的失败路径上
+  });
+
   test("recordSpawnedChild end-to-end with the canonical key — stop-daemon can find it", async () => {
     const { recordSpawnedChild, getChildrenSnapshot, _resetChildrenMapForTest } =
       await import("./stop-daemon");

--- a/agent-node/src/runtime/create-node-daemon.ts
+++ b/agent-node/src/runtime/create-node-daemon.ts
@@ -547,42 +547,16 @@ export async function handleCreateNodeDoorbell(
     return;
   }
 
-  // RFC-026 §9.3 D2 / #338 PR3 — capability fail-fast.
-  // Survives-5-seconds is the real "started" signal: the existing kill-0
-  // catches insta-die (binary missing / spawn-exec fail / SIGSEGV), but
-  // a daemon that declared `runtimes_supported: ["codex-sdk"]` without
-  // the codex binary or `OPENAI_API_KEY` configured produces a child
-  // that starts OK then dies mid-bootstrap (vendor adapter init throws).
-  // 通信龙 §9.3 nit: "declared ≠ guarantee" — declare is for dashboard
-  // candidate filtering, spawn is the truth check.
-  //
-  // Wait 5s + re-kill-0. Dashboard's create flow tolerates ≤30s.
-  // If dead → ack `runtime_capability_check_failed` so hub marks the
-  // request failed with the right reason (audit_log "daemon_capability_lied"
-  // surfaces the gap between declaration and reality).
-  const FAIL_FAST_MS = 5_000;
-  await new Promise<void>(resolve => setTimeout(resolve, FAIL_FAST_MS));
-  let stillAlive = false;
-  if (childPid > 0) {
-    try {
-      process.kill(childPid, 0);
-      stillAlive = true;
-      deps.log(`[create-node] +${FAIL_FAST_MS}ms capability check OK: pid=${childPid} still alive`);
-    } catch (kerr: any) {
-      const msg = `child died within ${FAIL_FAST_MS}ms post-spawn (likely missing runtime binary or auth for runtime='${req.node_spec.runtime}'): ${kerr?.message || kerr}`;
-      deps.warn(`[create-node] runtime_capability_check_failed: ${msg}`);
-      await deps.callCommHub("ack_create_request", {
-        request_id,
-        status: "runtime_capability_check_failed",
-        error: msg.slice(0, 800),
-        runtime: req.node_spec.runtime,
-      }).catch(() => {});
-      return;
-    }
-  }
-  void stillAlive;
-
   // RFC-027 §2.4 — record the spawned child in the daemon's children_map
+  //
+  // 🔴 #1293:这一块原本排在下面那个 +5000ms 能力检查**之后**。子节点在 spawn 的
+  //    那一刻就已经对 hub 可见,于是「hub 认识它」和「daemon 能操作它」之间有约 5 秒缺口——
+  //    这段时间内任何 stop_node / delete_node 都 ack `noop_not_my_child`,hub 侧不收敛。
+  //    真机实测:13:17:28 spawned → 13:17:30 stop 找不到 map 条目 → 13:17:33 才记上。
+  //
+  //    搬到能力检查之前,并在能力检查失败的那条 return 上配一次 forgetSpawnedChild ——
+  //    **只搬不配移除会留下死条目**,而 handleStopDoorbell 会照着它去 signal 一个不存在的 pid。
+  //    那正是记录原本排在后面的理由,不是疏忽。
   // so a later SSE stop_node doorbell knows which PID to signal.
   //
   // Lookup key MUST exactly match the hub's canonical child node_id.
@@ -609,6 +583,51 @@ export async function handleCreateNodeDoorbell(
       deps.warn(`[create-node] childrenMap record failed (stop-daemon won't see this child): ${e?.message || e}`);
     }
   }
+
+  // RFC-026 §9.3 D2 / #338 PR3 — capability fail-fast.
+  // Survives-5-seconds is the real "started" signal: the existing kill-0
+  // catches insta-die (binary missing / spawn-exec fail / SIGSEGV), but
+  // a daemon that declared `runtimes_supported: ["codex-sdk"]` without
+  // the codex binary or `OPENAI_API_KEY` configured produces a child
+  // that starts OK then dies mid-bootstrap (vendor adapter init throws).
+  // 通信龙 §9.3 nit: "declared ≠ guarantee" — declare is for dashboard
+  // candidate filtering, spawn is the truth check.
+  //
+  // Wait 5s + re-kill-0. Dashboard's create flow tolerates ≤30s.
+  // If dead → ack `runtime_capability_check_failed` so hub marks the
+  // request failed with the right reason (audit_log "daemon_capability_lied"
+  // surfaces the gap between declaration and reality).
+  const FAIL_FAST_MS = 5_000;
+  await new Promise<void>(resolve => setTimeout(resolve, FAIL_FAST_MS));
+  let stillAlive = false;
+  if (childPid > 0) {
+    try {
+      process.kill(childPid, 0);
+      stillAlive = true;
+      deps.log(`[create-node] +${FAIL_FAST_MS}ms capability check OK: pid=${childPid} still alive`);
+    } catch (kerr: any) {
+      const msg = `child died within ${FAIL_FAST_MS}ms post-spawn (likely missing runtime binary or auth for runtime='${req.node_spec.runtime}'): ${kerr?.message || kerr}`;
+      deps.warn(`[create-node] runtime_capability_check_failed: ${msg}`);
+      // #1293:记录已经提前到 spawn 之后,这条失败路径必须把它撤掉,
+      // 否则 map 里留一条指向已死 pid 的条目,stop doorbell 会去 signal 它。
+      try {
+        const { forgetSpawnedChild } = await import("./stop-daemon.js");
+        const removed = forgetSpawnedChild(`node_${request_id.replace(/^cr_/, "")}`);
+        deps.log(`[create-node] childrenMap rollback after capability failure: removed=${removed}`);
+      } catch (e: any) {
+        deps.warn(`[create-node] childrenMap rollback failed: ${e?.message || e}`);
+      }
+      await deps.callCommHub("ack_create_request", {
+        request_id,
+        status: "runtime_capability_check_failed",
+        error: msg.slice(0, 800),
+        runtime: req.node_spec.runtime,
+      }).catch(() => {});
+      return;
+    }
+  }
+  void stillAlive;
+
 
   // Step 4 — ack 'started' (success path; hub flips to 'succeeded' on
   // child's first report_status content-match)

--- a/agent-node/src/runtime/stop-daemon.ts
+++ b/agent-node/src/runtime/stop-daemon.ts
@@ -47,6 +47,19 @@ export function recordSpawnedChild(child_node_id: string, alias: string, pid: nu
   childrenMap.set(child_node_id, { pid, started_at: Date.now(), child_node_id, alias });
 }
 
+/** #1293 — undo a `recordSpawnedChild` when the spawn turns out not to
+ *  have produced a usable child (capability fail-fast tripped).
+ *
+ *  🔴 这个函数存在的唯一理由是让记录可以**提前**：子节点在 spawn 那一刻就对 hub 可见,
+ *     而记录原本排在 5 秒能力检查之后 —— 中间那段窗口里,hub 认识它、daemon 不认,
+ *     任何 stop/delete 都 ack `noop_not_my_child`,hub 侧不收敛(#1293 实测约 5s)。
+ *     提前记录必须配一个移除,否则能力检查失败时会在 map 里留一条**死条目**,
+ *     而 handleStopDoorbell 会照着它去 signal 一个已经不存在的 pid。
+ *  返回是否真的删掉了一条 —— 调用方可以据此判断「我记过吗」,而不是假设。 */
+export function forgetSpawnedChild(child_node_id: string): boolean {
+  return childrenMap.delete(child_node_id);
+}
+
 /** Test-only helper — clears the map so test suites can isolate. NOT
  *  exposed via cli; daemon runtime never wants to drop its tracking
  *  state mid-flight. */


### PR DESCRIPTION
Vincent 定「先集中精力把 daemon 落地」，这是第一条落地的代码修复。

## 缺陷

子节点在 spawn 那一刻就对 hub 可见，而 daemon 的 `childrenMap` 记录排在 `+5000ms` 能力检查**之后**。中间这段窗口：

```
hub 认识它  →  daemon 不认  →  stop_node/delete_node 全部 ack `noop_not_my_child`，hub 侧不收敛
```

真机实测（issue 原文）：

```
13:17:28  spawned child pid=521
13:17:30  ← SSE stop_node  →  "child not in map (likely daemon-restarted)"
13:17:33  +5000ms capability check OK
```

## 🔴 记录排在后面**是有理由的**，不是疏忽

若子进程在 5 秒内死掉，代码会 `return` —— **先记录就会留下一条指向死 pid 的条目**，而 `handleStopDoorbell` 会照着它去 signal 一个已经不存在的进程。

⇒ 修法不是「挪顺序」，是「**提前 + 配一次回滚**」：

- `stop-daemon.ts` 新增 `forgetSpawnedChild(id): boolean`
- `create-node-daemon.ts` 把记录块搬到能力检查之前
- 能力检查失败的那条 `return` 前撤销记录，并 log `removed=<bool>`

**`forgetSpawnedChild` 返回布尔而不是 void**：调用方据此判断「我记过吗」，不靠假设。删不存在的条目返回 `false` —— **一个「删不存在也说成功」的 API，会让调用方无法区分「我记过并撤销了」和「我根本没记上」。**

## 见红：两个用例，其中一个是**必需的**，另一个不够

```
把顺序改回原样  →  41 pass / 1 fail
                   红的正是 "recordSpawnedChild is invoked BEFORE the FAIL_FAST wait"
还原            →  42 pass / 0 fail
```

🔴 **`forgetSpawnedChild` 那个零件用例在新旧代码上都绿** —— 顺序错不影响那个函数本身。
而**顺序是这条 issue 的全部内容**，所以单独加了一条源码级顺序断言钉住它。

**只写零件测试的话，这个 PR 会以「有测试覆盖」的样子通过，而它测不到要修的那件事。** 这一格我在注释里也写了，免得后来人以为那条源码断言是多余的。

## 这个 PR 不能证明什么

🔴 它**没有在真机 daemon 上验过**。见红是单元层的（源码顺序 + map 语义），证明的是「代码顺序对了、回滚零件对了」。
**真正的验收是：在 relay 或 macmini 上创建一个子节点，spawn 后立刻 stop 它，确认不再出现 `noop_not_my_child`。** 那需要在真 daemon 上跑，属于 #1282（真机验收脚本）的范围。

Refs #1293