### PR TITLE
chore(release): prepare BTW node.39 and CLI.53 previews

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -1742,7 +1742,7 @@ async function startOpencodeCopresenceOrchestration(nodeId: string, hubOverride?
 // 去 `npm view` 核对,而 publish 要求四门全绿 —— 所以「本次要发的版本」不能提前
 // 写在这里,否则发它的那个 run 会被自己的 pin 卡死(鸡生蛋)。
 // 顺序:先发 commhub-server X → 再把这里改成 X 并发 agent-network。
-const PINNED_SERVER_VERSION = "0.9.0-preview.33";
+const PINNED_SERVER_VERSION = "0.9.0-preview.34";
 
 // Canonical SkillHub URL: https://anet.sh/skillhub/catalog.json currently
 // returns 307 to this www host. Pin the direct 200 URL so catalog fetch

--- a/agent-network/package-lock.json
+++ b/agent-network/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.52",
+  "version": "2.3.0-preview.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-network",
-      "version": "2.3.0-preview.52",
+      "version": "2.3.0-preview.53",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.3",

--- a/agent-network/package.json
+++ b/agent-network/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-network",
-  "version": "2.3.0-preview.52",
+  "version": "2.3.0-preview.53",
   "description": "AI Agent Network CLI — Local-first multi-agent orchestration across 6 runtimes (Claude Code CLI / Claude Agent SDK / Codex SDK / Codex app-server / Grok Build ACP / OpenCode CLI) and 8+ LLM providers. Apache 2.0.",
   "type": "module",
   "main": "dist/src/client.js",

--- a/agent-network/src/opencode-agent-node-pair.ts
+++ b/agent-network/src/opencode-agent-node-pair.ts
@@ -18,8 +18,8 @@ import { basename, delimiter, dirname, isAbsolute, join, relative, resolve } fro
 import { opencodeOwnedPathModeIsSafe } from "./opencode-owner-mode";
 import { describeUnsafePath } from "./unsafe-package-path-reason";
 
-export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.52";
-export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.38";
+export const PAIRED_AGENT_NETWORK_VERSION = "2.3.0-preview.53";
+export const PAIRED_AGENT_NODE_VERSION = "2.5.0-preview.39";
 export const PAIRED_AGENT_NODE_SPEC = `@sleep2agi/agent-node@${PAIRED_AGENT_NODE_VERSION}`;
 // Backward-compatible names for the first consumer of the shared pair.
 export const OPENCODE_AGENT_NETWORK_VERSION = PAIRED_AGENT_NETWORK_VERSION;

--- a/agent-node/package-lock.json
+++ b/agent-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.38",
+  "version": "2.5.0-preview.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleep2agi/agent-node",
-      "version": "2.5.0-preview.38",
+      "version": "2.5.0-preview.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.226",

--- a/agent-node/package.json
+++ b/agent-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleep2agi/agent-node",
-  "version": "2.5.0-preview.38",
+  "version": "2.5.0-preview.39",
   "description": "AI Agent runtime for CommHub networks. Supports Claude Code CLI, Claude Agent SDK, Codex SDK, Codex app-server, Grok Build ACP, and OpenCode CLI.",
   "bin": {
     "agent-node": "dist/cli.js"

--- a/docs-site/docs/en/guide/getting-started.md
+++ b/docs-site/docs/en/guide/getting-started.md
@@ -7,7 +7,7 @@
      Change the prose, change the stamp — the gate also fails when the two disagree.
      Only "current state" claims are stamped; historical references (e.g. `<= 2.3.0-preview.37`) are not. -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.52 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.53 -->
 
 The minimum path for a brand-new user — **5 steps, 5 minutes**. One command + one verification per step.
 
@@ -100,7 +100,7 @@ Measured 2026-08-27 (one `anet hub start` per version in a clean container, no `
 |---|---|
 | `2.3.0-preview.47` (`latest` at the time) | `anet-3ce2750defe04d9ab3baf0` — **random**, with a change-on-first-login notice |
 | `2.3.0-preview.49` (`preview` at the time) | `anet-7fe4eddb08f648dcbd7fcd` — **random**, same notice |
-| `2.3.0-preview.52` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
+| `2.3.0-preview.53` (current `preview`) | Also **random** — not re-measured per version: `server/src/auth.ts`, which generates it, has had **zero commits** since `.49` shipped (2026-08-27T02:25Z); the logic is byte-identical |
 
 Neither run printed the literal `anethub` anywhere.
 

--- a/docs-site/docs/guide/getting-started.md
+++ b/docs-site/docs/guide/getting-started.md
@@ -6,7 +6,7 @@
      每一处需要改的行。改了正文也要改戳,反之亦然 —— 两边不一致时门同样会红。
      只标"现状"断言;讲历史的版本引用(如 `≤ 2.3.0-preview.37`)故意不标。 -->
 <!-- version-claim: package=agent-network channel=latest version=2.2.21 -->
-<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.52 -->
+<!-- version-claim: package=agent-network channel=preview version=2.3.0-preview.53 -->
 
 新用户首次跑通的最小路径——**5 步, 5 分钟**。每步一条命令 + 一句验证。
 
@@ -98,7 +98,7 @@ anet hub dashboard
 |---|---|
 | `2.3.0-preview.47`(当时的 `latest`) | `anet-3ce2750defe04d9ab3baf0` —— **随机串**,并提示首次登录后要改 |
 | `2.3.0-preview.49`(当时的 `preview`) | `anet-7fe4eddb08f648dcbd7fcd` —— **随机串**,同上 |
-| `2.3.0-preview.52`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
+| `2.3.0-preview.53`(当前 `preview`) | 同为**随机串** —— 未逐版本重测:生成密码的 `server/src/auth.ts` 自 `.49` 发布(2026-08-27T02:25Z)起**零提交**,逻辑逐字未变 |
 
 两次都没有出现字面量 `anethub`。
 

--- a/docs/tests/release-v2.3.0-preview.53.md
+++ b/docs/tests/release-v2.3.0-preview.53.md
@@ -1,0 +1,32 @@
+# agent-network v2.3.0-preview.53 — paired BTW boundary release
+
+**Channel:** `preview` only
+
+**Date:** 2026-08-28
+
+This CLI release pairs `agent-node@2.5.0-preview.39` with
+`commhub-server@0.9.0-preview.34`. New Codex app-server tasks can therefore
+surface an exact `thread_id` / `turn_id` to the existing BTW drawer instead of
+showing the compatibility message that no precise side-thread boundary exists.
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-network@2.3.0-preview.53
+```
+
+The CLI resolves the exact paired node `.39`, and `anet hub start` resolves the
+already-published Hub `.34`; it does not float either dependency.
+
+## Upgrade
+
+```bash
+anet upgrade --preview
+```
+
+Restart upgraded nodes so the new runtime process is active. Operators upgrading
+an existing deployment should upgrade the Hub first, then node runtimes, then the
+CLI. Only newly consumed tasks on the upgraded path receive exact boundaries;
+historical rows remain explicitly absent rather than inferred.
+
+Preview only; no `latest` promotion is part of this release.

--- a/docs/tests/release-v2.5.0-preview.39.md
+++ b/docs/tests/release-v2.5.0-preview.39.md
@@ -1,0 +1,34 @@
+# agent-node v2.5.0-preview.39 — exact BTW runtime boundary
+
+**Channel:** `preview` only
+
+**Date:** 2026-08-28
+
+This runtime release reports the exact Codex app-server `thread_id` and
+attributable `turn_id` when a Hub task is consumed. The evidence is sent once
+with the consumed transition; the Hub independently revalidates ownership and
+conflicts. Other runtimes and older Hubs retain their existing compatible path.
+
+## Install
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.39
+```
+
+For the user-facing paired installation, install
+`@sleep2agi/agent-network@2.3.0-preview.53`; it pins this exact runtime and the
+already-published `commhub-server@0.9.0-preview.34`.
+
+## Upgrade
+
+Upgrade the CLI/runtime pair on a node, then stop and start that node so its
+running agent-node process loads `.39`. Upgrade the Hub to `.34` first. Existing
+and historical tasks without an exact boundary remain valid and are not guessed.
+
+```bash
+npm install -g @sleep2agi/agent-node@2.5.0-preview.39
+```
+
+Preview only; do not move `latest` until the paired artifacts have passed a real
+new-task BTW boundary check.
+

--- a/tests/test766-bunx-preflight/run.sh
+++ b/tests/test766-bunx-preflight/run.sh
@@ -86,7 +86,7 @@ probe_bunx(){
   [[ "$(sed -n '1p' "$capture" 2>/dev/null || true)" == "--bun" ]] || rc=1
   # 🔴 这一行写死了 PINNED_SERVER_VERSION —— 每次 bump 都必须同步改，否则本套件红。
   #    判据就是「CLI 传给 bunx 的包版本 == cli.ts 里的 PINNED」,所以它只能是字面量。
-  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.33' "$capture" || rc=1
+  grep -Fxq '@sleep2agi/commhub-server@0.9.0-preview.34' "$capture" || rc=1
   grep -Fq 'Server running on http://127.0.0.1:27668' "$log" || rc=1
 
   kill "$cli_pid" 2>/dev/null || true


### PR DESCRIPTION
## Outcome

Prepare the paired runtime/CLI release for BTW exact task boundaries:

- `@sleep2agi/agent-node@2.5.0-preview.39`
- `@sleep2agi/agent-network@2.3.0-preview.53`
- `PINNED_SERVER_VERSION=0.9.0-preview.34`

Hub `.34` was published first from main by release run 33130766069. Registry/tarball readback confirms the exact version and the shipped `thread_id`, `turn_id`, and `task_contexts` implementation. This PR now safely points the CLI at an already-resolvable Hub and pairs the exact node runtime.

## Exact evidence

Source: `99d331d6967f933e8da55c6e8df811fe801305fb`

- sync-pinned dry-run Docker: PASS; normal/current controls and mutations PASS
- test766 bunx preflight + production network build: 4/0, mutations red
- test725 complete agent-node domain: 1489/0, 113/113 source files, 6/6 tests, mutation red
- test745 complete agent-network domain: 660/0, 75/75 source files, 19/19 tests, mutation red
- test520 BTW runtime evidence: 139/0 + Grok focused 1/0; 13/13 mutations red
- doc version claims and symbol pins: PASS, 0 drift
- `git diff --check`: clean

## Publish order after merge

1. publish node `.39` from exact main through the four release gates;
2. verify registry tarball;
3. publish network `.53` from the same main through the four release gates;
4. verify published pins and clean-container `@preview` install.

Preview only. No `latest` change and no publish from this branch.
