### PR TITLE
ci: curl 重试窗口 8s → 25s —— 8 秒扛不住 GitHub release 的瞬时 404

### DIFF
--- a/tests/qa-daemon-lifecycle-e2e/Dockerfile
+++ b/tests/qa-daemon-lifecycle-e2e/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # 版本与校验和沿用本仓既有做法(tests/test679-task-trace/Dockerfile)。
 ARG BUN_VERSION=1.3.14
 ARG BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
-RUN curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
+RUN curl --fail --silent --show-error --location --retry 5 --retry-delay 5 --retry-all-errors \
       "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" -o /tmp/bun.zip \
  && echo "${BUN_LINUX_X64_SHA256}  /tmp/bun.zip" | sha256sum -c - \
  && unzip -q /tmp/bun.zip -d /tmp/bunx \

--- a/tests/test1220-codex-tui-client-health/Dockerfile
+++ b/tests/test1220-codex-tui-client-health/Dockerfile
@@ -5,7 +5,7 @@ ENV BUN_VERSION=1.3.14
 ENV BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl procps tmux unzip \
     && rm -rf /var/lib/apt/lists/*
-RUN curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
+RUN curl --fail --silent --show-error --location --retry 5 --retry-delay 5 --retry-all-errors \
       "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" \
       --output /tmp/bun.zip \
  && echo "${BUN_LINUX_X64_SHA256}  /tmp/bun.zip" | sha256sum --check --strict \

--- a/tests/test626-grok-model-switch-fallback/Dockerfile
+++ b/tests/test626-grok-model-switch-fallback/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
 # 同一个 Dockerfile 今天和下周构建出不同的运行时,红了无从复现。
 ARG BUN_VERSION=1.3.14
 ARG BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
-RUN curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
+RUN curl --fail --silent --show-error --location --retry 5 --retry-delay 5 --retry-all-errors \
       "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" -o /tmp/bun.zip \
  && echo "${BUN_LINUX_X64_SHA256}  /tmp/bun.zip" | sha256sum -c - \
  && unzip -q /tmp/bun.zip -d /tmp/bunx \

--- a/tests/test679-task-trace/Dockerfile
+++ b/tests/test679-task-trace/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash curl ca-ce
 # 隔离验证过:改前改后都得到 bun 1.3.14、同在 /root/.bun/bin/bun,产出等价。
 ARG BUN_VERSION=1.3.14
 ARG BUN_LINUX_X64_SHA256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
-RUN curl --fail --silent --show-error --location --retry 3 --retry-delay 2 --retry-all-errors \
+RUN curl --fail --silent --show-error --location --retry 5 --retry-delay 5 --retry-all-errors \
       "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" -o /tmp/bun.zip \
  && echo "${BUN_LINUX_X64_SHA256}  /tmp/bun.zip" | sha256sum -c - \
  && unzip -q /tmp/bun.zip -d /tmp/bunx \


### PR DESCRIPTION
起因是 PR #1273 那条 `curl: (22) 404` —— 四次尝试挤在 8 秒内。

**逐个排除**：URL 写错（展开 `${BUN_VERSION}` 后实打 **HTTP 200**；🔴 我第一次直接 grep 出的 URL 含未展开的变量，那次探测本身是错的）、版本当时不存在（资产上传 `2026-05-12`，build 在 `2026-08-27`，早三个多月）⇒ **GitHub release 的瞬时 404**。#1273 重跑后三条红全绿，佐证。

```
--retry 3 --retry-delay 2   窗口  8s
--retry 5 --retry-delay 5   窗口 25s
```
main 上 4 处，改后 0 处仍 ≤10 秒。

## 🔴 证据强度：只有 1 次观测，我不假装它多

值得做的理由**不是「flake 很多」**，是：改动是两个数字、单调更安全、代价只有「真坏的构建多等 17 秒」，而 CDN 抖动经常长于 8 秒。

**如果哪天量到「25 秒也不够」，该做的是换分发方式**（仓里 `p-214` 那份用的是 `bun.sh/install`），不是继续加大这两个数。**这条改动买的是时间，不是根治。**

## 取集有一处要注意

🔴 真正 flake 的那个文件 `tests/test1271-daemon-start-node/Dockerfile` **在 #1273 的分支上，不在 main** —— 本 PR 改不到它。已在 #1273 上说明由该 PR 自己同步，**否则合入后又多一处 8 秒窗口**。

Refs #1273