### PR TITLE
fix(#1353): 把 daemon 的 anet 二进制 pin 传给 spawn 出来的子进程（修正 #1299 的「同进程」假设）

### DIFF
--- a/agent-network/bin/cli.ts
+++ b/agent-network/bin/cli.ts
@@ -6213,6 +6213,29 @@ async function launchAgent(id: string, forceNewSession = false, hubOverride?: st
       : runtime === "grok-build-cli"
       ? buildGrokAgentNodeEnv(env)
       : { ...env, ANET_CONFIG_UPDATE_CAPABLE: "1" };
+
+    // #1353 —— 把 daemon 的 anet 二进制 pin 传给子进程。
+    //
+    // 🔴 这是我 #1299 那次改动的一个错误假设的修正。当时我在 `prepareDaemonAnetBin()`
+    //    里往 `process.env` 上写这三个变量,注释还写着「daemon start/up 是
+    //    `prepareDaemonAnetBin(); await startCommand()`,同进程」—— **同进程是对的,
+    //    但 startCommand 会 spawn 一个 agent-node 子进程,而 childEnv 是从窄的
+    //    `env` 变量组的,不是 `process.env`。** 于是子进程一个都拿不到。
+    //
+    // 2026-08-28 真机实测(两台机器):`nohup anet daemon start <name>` 起来的
+    // daemon 进程环境里只有 `ANET_CONFIG_UPDATE_CAPABLE`,随后 create_node 一律
+    // 报 `anet_bin_unsafe_path: no ANET_BIN_ABS resolved`。
+    //
+    // 🔴 症状具有欺骗性:daemon 照常注册、在线、收 doorbell,hub 返回 ok:true + request_id,
+    //    失败只出现在 daemon 自己的日志里。我因此把一台残废的 daemon 报成「上线成功」。
+    //    「在线」和「能干活」是两件事。
+    //
+    // 只在 process.env 里确实有的时候才传 —— 它们只由 prepareDaemonAnetBin() 设置,
+    // 也就是只在 daemon 路径上存在,普通 `anet node start` 不受影响。
+    for (const k of ["ANET_BIN_ABS", "ANET_BIN_SHA256", "ANET_DAEMON_ALLOW_ENV_BIN", "ANET_DAEMON_ALLOW_NON_ROOT_BIN", "ANET_DAEMON_PATH_CONF"]) {
+      const v = process.env[k];
+      if (v !== undefined && (childEnv as any)[k] === undefined) (childEnv as any)[k] = v;
+    }
     const pidFile = join(nodesDir(), nodeId, ".pid");
 
     // Sentinel code agent-node uses to request re-spawn. Must stay in


### PR DESCRIPTION
修 #1353 的第一半，而这是**对我自己 #1299 那次改动里一个错误假设的修正**。

## 假设错在哪

#1299 我在 `prepareDaemonAnetBin()` 里往 `process.env` 写了三个变量，注释写着：

> daemon start/up 是 `prepareDaemonAnetBin(); await startCommand()`，同进程

**同进程是对的，但 `startCommand()` 会 spawn 一个 agent-node 子进程，而 `childEnv` 是从窄的 `env` 变量组的，不是 `process.env`** —— 子进程一个都拿不到。

## 真机实测（2026-08-28，两台机器）

```
nohup anet daemon start <name>
  → 子进程环境里只有 ANET_CONFIG_UPDATE_CAPABLE
  → create_node 一律报 anet_bin_unsafe_path: no ANET_BIN_ABS resolved

显式在命令前加 ANET_BIN_ABS=… ANET_DAEMON_ALLOW_ENV_BIN=1 → 立刻能建节点（验到子进程实活）
```

## 🔴 症状具有欺骗性

daemon 照常注册、在线、收 doorbell；hub 返回 `ok:true` + request_id；**失败只出现在 daemon 自己的日志里**。

**我因此把一台残废的 daemon 报成「上线成功」** —— 我验的是 `status=idle`，而**「在线」和「能干活」是两件事**，后者只有真建一个节点才知道。这一格我在支持矩阵里刚给 Windows 写过，四小时后自己踩了。

## 改法

childEnv 组好之后，把 `process.env` 里**确实存在**的五个 pin 相关变量补进去，且不覆盖已有值。
这些变量**只由 `prepareDaemonAnetBin()` 设置**（只在 daemon 路径上存在），普通 `anet node start` 完全不受影响。

## 验证方式里有一格值得记

括号配平检查一开始报 `d=-1`，我没有直接去改代码，而是**拿未修改的 main 跑同一个算法**：两边同为 `d=-2`。
🔴 **那个算法会把字符串/注释里的括号算进去，所以它的绝对值没有意义，只有「与基线是否相同」有意义。** 没有这个对照，我会去修一个不存在的问题。

## 这个 PR 不能证明什么

🔴 本改动要生效需要**重新发包并升级 daemon**。它**不能**证明那两台机器上的 `create_node` 从此不再需要手工带 env —— 那要等新版本装上去之后再验。

Refs #1353 #1299