### PR TITLE
fix(#1286): daemon「备份 → ack」那段埋点 + 关键路径 execSync 加 timeout/maxBuffer

### DIFF
--- a/agent-node/src/runtime/stop-daemon.test.ts
+++ b/agent-node/src/runtime/stop-daemon.test.ts
@@ -5,7 +5,7 @@ import {
   handleStopDoorbell,
   recordSpawnedChild,
 } from "./stop-daemon";
-import { mkdtempSync, mkdirSync, readdirSync, statSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, statSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -577,5 +577,68 @@ describe("#1286 handleStopDoorbell — stop 之后再 delete", () => {
     });
     await handleStopDoorbell({ request_id: "req-stop-miss" }, h.deps as any);
     expect(h.acks.at(-1)!.args.status).toBe("noop_not_my_child");
+  });
+});
+
+// ─── #1286 —— 备份到 ack 之间那段的可观测性 ────────────────────────────
+//
+// 真机复现（两次，行为一致）：新建子节点 → 直接 delete_node，daemon 日志**每次都停在**
+// `backed up child workdir`，之后 48 秒零输出，hub 行永远停在 lifecycle_state=deleting。
+// 那段里只有三步（residual sweep → childrenMap.delete → ack_stop_request），
+// 但三步在源码上都有 try/catch 或 .catch 保护，**静态读不出是哪一步**。
+//
+// 🔴 这两条测试不断言「#1286 已修好」—— 它没修好。它们断言的是：下一次复现能
+//    直接从日志读出停在哪一步，而不是又一次「停住了」。
+describe("#1286 — 备份到 ack 之间的每一步都要留痕", () => {
+  test("delete 路径按顺序打出 进入清扫 / 清扫返回 / 已出 map / ack 被接受", async () => {
+    const workdirRoot = join(scratch, "nodes");
+    const deletedRoot = join(scratch, "deleted");
+    mkdirSync(workdirRoot, { recursive: true });
+    mkdirSync(join(workdirRoot, "alias-obs"));
+
+    recordSpawnedChild("node_obs", "alias-obs", 5556);
+    const { acks, deps } = makeDeps({
+      workdirRoot, deletedRoot,
+      getStopReturn: {
+        ok: true, request_id: "sr_obs",
+        child_node_id: "node_obs", child_alias: "alias-obs",
+        action: "delete", delete_config: true, grace_seconds: 10, force: false,
+      },
+    });
+    const lines: string[] = [];
+    (deps as any).log = (m: string) => lines.push(m);
+    (deps as any).warn = (m: string) => lines.push(m);
+
+    await handleStopDoorbell({ request_id: "sr_obs" }, deps);
+    expect(acks.length).toBe(1);
+
+    const joined = lines.join("\n");
+    // 复现时日志停在这一行 —— 它是这段的起点，必须还在。
+    const iBackup = lines.findIndex(l => l.includes("backed up child workdir"));
+    const iEnter  = lines.findIndex(l => l.includes("entering residual sweep"));
+    const iReturn = lines.findIndex(l => l.includes("residual sweep returned"));
+    const iMap    = lines.findIndex(l => l.includes("dropped from children map"));
+    const iAck    = lines.findIndex(l => l.includes("ack accepted"));
+    for (const [name, i] of [["backup", iBackup], ["enter", iEnter], ["return", iReturn], ["map", iMap], ["ack", iAck]] as const) {
+      expect(`${name}=${i}\n${joined}`).not.toContain(`${name}=-1`);
+    }
+    // 顺序本身就是判据：只有严格递增，日志停在哪一行才等于停在哪一步。
+    expect(iBackup).toBeLessThan(iEnter);
+    expect(iEnter).toBeLessThan(iReturn);
+    expect(iReturn).toBeLessThan(iMap);
+    expect(iMap).toBeLessThan(iAck);
+  });
+
+  test("🔴 关键路径上的 execSync 必须带 timeout 和 maxBuffer", () => {
+    const src = readFileSync(new URL("./stop-daemon.ts", import.meta.url), "utf8");
+    // 正控：这一行确实在（否则下面的断言在文件被改名/重构后会空过）
+    expect(src).toContain("pgrep -af 'agent-node'");
+    const i = src.indexOf("pgrep -af 'agent-node'");
+    const call = src.slice(i, i + 240);
+    // 无 timeout ⇒ pgrep 卡住时 ack 永不发出，用户侧就是「删不掉」，且不报任何错。
+    expect(call).toContain("timeout:");
+    // 无 maxBuffer ⇒ 默认 1MB；`pgrep -af` 打完整命令行，进程多的机器会 ENOBUFS，
+    // 那条路径被 catch 住 ⇒ 清扫**静默失效**（ack 照发，所以不会自曝）。
+    expect(call).toContain("maxBuffer:");
   });
 });

--- a/agent-node/src/runtime/stop-daemon.ts
+++ b/agent-node/src/runtime/stop-daemon.ts
@@ -334,12 +334,21 @@ export async function handleStopDoorbell(
   // path could change in the future and this assertion would still
   // hold). Verifies via /proc/<pid>/cmdline argv-adjacency to avoid
   // PR1.1's alias-substring footgun.
+  // #1286 埋点 —— 复现时 daemon 日志**每次都停在** `backed up child workdir`,
+  // 之后 48 秒零输出。备份到 ack 之间只有三步,但三步在源码上都有保护,静态读不出
+  // 是哪一步。这三行把那段变成可读的:下次复现直接看日志停在哪一行,就定位到哪一步。
+  // 🔴 它们不改变任何行为,唯一作用是让下一次复现能给出答案而不是又一次「停住了」。
+  deps.log(`[stop-daemon] entering residual sweep alias=${entry.alias}`);
   await sweepOrphansForAlias(entry.alias, signalProcess, deps, "post-pgid-signal residual sweep");
+  deps.log(`[stop-daemon] residual sweep returned alias=${entry.alias}`);
 
   childrenMap.delete(child_node_id);
+  deps.log(`[stop-daemon] dropped from children map child_node_id=${child_node_id}, sending ack action=${action}`);
 
   await deps.callCommHub("ack_stop_request", {
     request_id, status: "stopped", exit_signal, ...(backup_path ? { backup_path } : {}),
+  }).then(() => {
+    deps.log(`[stop-daemon] ack accepted request_id=${request_id} action=${action}`);
   }).catch((e: any) => {
     deps.warn(`[stop-daemon] ack failed: ${e?.message || e}`);
   });
@@ -378,7 +387,17 @@ async function sweepOrphansForAlias(
     // check to filter substring-collision false positives.
     let out: string;
     try {
-      out = execSync(`pgrep -af 'agent-node' || true`, { encoding: "utf8" });
+      // #1286 —— 🔴 这个 execSync 原来既没有 timeout 也没有 maxBuffer,而它坐在
+      // 「备份完 workdir」到「发 ack_stop_request」这条路径的正中间。两个后果:
+      //   · 无 timeout:pgrep 卡住 ⇒ 整个 doorbell 永不到达 ack ⇒ hub 行永远停在
+      //     lifecycle_state=deleting,用户侧表现为「删不掉」,而 daemon 日志最后一行
+      //     就停在 `backed up child workdir`,不报任何错。
+      //   · 无 maxBuffer:默认 1MB。`pgrep -af` 打印**完整命令行**,agent-node 的命令行
+      //     很长;进程多的机器上会 ENOBUFS 抛出 —— 那条路径是被 catch 住的(会 return,
+      //     ack 照发),所以它不是挂死的成因,但会让清扫**静默失效**。
+      // 🔴 我没有证据说这就是 #1286 的成因 —— 见本 PR 说明。这是独立成立的硬化:
+      //    daemon 关键路径上不该有无上限的同步子进程调用。
+      out = execSync(`pgrep -af 'agent-node' || true`, { encoding: "utf8", timeout: 10_000, maxBuffer: 32 * 1024 * 1024 });
     } catch {
       return;
     }


### PR DESCRIPTION
## 这个 PR 不修 #1286 —— 它让下一次复现能给出答案

复现（真机两次，行为一致）：新建子节点 → 直接 `delete_node`，daemon 日志**每次都停在**
`backed up child workdir`，之后 48 秒零输出，hub 行永远停在 `lifecycle_state=deleting`。

备份到 ack 之间只有三步：

```
sweepOrphansForAlias(...)      ← 全函数 try/catch
childrenMap.delete(...)        ← 不会抛
callCommHub("ack_stop_request") ← 失败会 warn（日志里没有这条 ⇒ 没走到）
```

🔴 **三步在源码上都有保护，静态读不出是哪一步。** 所以本 PR 做两件事，分开说：

### 1) 埋点（不改行为）

三步之间各一行日志，ack 成功也打一行。下次复现直接看日志停在哪一行 ⇒ 停在哪一步。

### 2) 硬化（独立成立，🔴 **不声称**是 #1286 的成因）

```js
execSync(`pgrep -af 'agent-node' || true`, { encoding: "utf8" })   // 改前：既无 timeout 也无 maxBuffer
```

它就坐在 backup 与 ack 之间：

| 缺的东西 | 后果 | 会自曝吗 |
|---|---|---|
| `timeout` | pgrep 卡住 ⇒ ack 永不发出 ⇒ 用户侧「删不掉」 | ❌ 一行错都不报 |
| `maxBuffer` | 默认 1MB，`pgrep -af` 打**完整命令行** ⇒ 进程多的机器 ENOBUFS | ❌ 该路径被 catch，**清扫静默失效而 ack 照发** |

🔴 我**没有证据**说这就是 #1286 的成因 —— 我没有观测到 pgrep 卡住。这是一条独立成立的
硬化：daemon 关键路径上不该有无上限的同步子进程调用。**如果埋点跑出来指向别处，
这条改动也依然该留。**

## witnessed-red

| 状态 | 结果 |
|---|---|
| **未改动的 main** | 20 pass / **2 fail**（两条新测试都红） |
| 加上本 PR | 22 pass / 0 fail |
| 单独变异「去掉 timeout/maxBuffer」 | 只有 execSync 那一条红 |

🔴 那个「未改动的 main 上两条都红」是**意外拿到的**：我用 `git checkout -- <file>` 想还原
一次变异，但改动**还没提交**，于是它把我全部源码改动一起丢回了 main。
教训照录：**未提交时 `git checkout --` 不是「还原变异」，是「丢弃工作」。**

Refs #1286
