### PR TITLE
fix(#1358): ack_stop_request 的六条出口全部埋点 —— 与 create-node finalize 对称

### DIFF
--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -3737,6 +3737,12 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       error: z.string().max(1000).optional(),
     },
     async ({ request_id, status, exit_signal, backup_path, error: ackError }) => {
+      // #1358 —— 🔴 在此之前,这个工具的**每一条出口都是静默的**:到达不记、
+      // 三条拒绝不记、成功收尾也不记。而隔壁 create-node 的收尾**是记的**
+      // (`✓ create-node finalize`)。这种不对称最坑人:读日志的人看到 create 有、
+      // delete 没有,第一反应是「delete 没发生」—— 但两者的日志覆盖面本来就不同,
+      // 那条推论没有依据。排查 #1286 时我自己就差点这样读。
+      console.log(`[commhub] ← ack_stop_request request=${request_id} status=${status}${exit_signal ? ` exit_signal=${exit_signal}` : ""}`);
       const callerDaemon = resolveCallerDaemonTokenBound();
       if (!callerDaemon.ok) {
         return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: callerDaemon.error }) }] };
@@ -3748,11 +3754,16 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
       }>(`SELECT daemon_node_id, status, network_id, child_node_id, child_alias, action,
                  in_flight_at_dispatch, force
             FROM node_stop_requests WHERE request_id = ?1`, request_id);
-      if (!row) return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "request_not_found" }) }] };
+      if (!row) {
+        console.warn(`[commhub] ✕ ack_stop_request rejected: request_not_found request=${request_id}`);
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "request_not_found" }) }] };
+      }
       if (row.daemon_node_id !== callerDaemon.daemonNodeId) {
+        console.warn(`[commhub] ✕ ack_stop_request rejected: not_your_request request=${request_id} row_daemon=${row.daemon_node_id} caller=${callerDaemon.daemonNodeId}`);
         return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "not_your_request" }) }] };
       }
       if (row.network_id !== callerDaemon.networkId) {
+        console.warn(`[commhub] ✕ ack_stop_request rejected: cross_network_request request=${request_id} row_net=${row.network_id} caller_net=${callerDaemon.networkId}`);
         return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "cross_network_request" }) }] };
       }
       const now = Date.now();
@@ -3807,9 +3818,20 @@ export function registerTools(server: McpServer, clientIP?: string, enforceNetwo
           // sweeper / next reconciliation will pick it up. Don't transition.
         });
       } catch (e: any) {
+        console.warn(`[commhub] ✕ ack_stop_request finalize_tx_failed request=${request_id} action=${row.action} child=${row.child_alias}: ${e?.message || e}`);
         return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "finalize_tx_failed", message: e?.message || String(e) }) }] };
       }
 
+      // 🔴 关键的是最后那半句「据此做了什么」。#1286 里 hub 的代码路径经核对是
+      // 正确的,缺的正是「它到底走没走那条分支」—— 只说「收到了 ack」回答不了。
+      const did = status === "stopped" && row.action === "delete"
+        ? "revoked ntok + DELETE FROM nodes"
+        : status === "stopped" && row.action === "stop"
+        ? "lifecycle_state=stopped"
+        : status === "stop_failed"
+        ? "lifecycle_state=stop_failed"
+        : "no lifecycle transition (noop_not_my_child)";
+      console.log(`[commhub] ✓ ${row.action}-node finalize: request=${request_id} child=${row.child_alias} (${row.child_node_id}) status=${status} → ${did}`);
       return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, status }) }] };
     },
   );


### PR DESCRIPTION
## 问题不是「少一行日志」，是**只覆盖了一半的成功路径**

`ack_stop_request` 在此之前**每一条出口都是静默的**：到达不记、三条拒绝不记、事务失败不记、成功收尾也不记。

而隔壁 create-node 的收尾**是记的**：

```
[commhub] ✓ create-node finalize: request=cr_… child=… (node_…) daemon=…
```

🔴 **这种不对称比完全没日志更容易误导**：读日志的人看到 create 有、delete 没有，
第一反应是「delete 没发生」—— 但两者的覆盖面本来就不同，**那条推论没有依据**。

排查 #1286 时我自己就差点这样读。躲开它靠的是**正控**：`grep -c 'create_node'` 也是 **0**
（而 create 确实成功过）⇒ 那个 0 是空的，hub 根本不记这类工具调用。

## 新增的六行

| 时机 | 日志 |
|---|---|
| 到达 | `← ack_stop_request request=… status=… [exit_signal=…]` |
| 拒绝 1 | `✕ rejected: request_not_found request=…` |
| 拒绝 2 | `✕ rejected: not_your_request request=… row_daemon=… caller=…` |
| 拒绝 3 | `✕ rejected: cross_network_request request=… row_net=… caller_net=…` |
| 事务失败 | `✕ finalize_tx_failed request=… action=… child=…: <err>` |
| 成功 | `✓ <action>-node finalize: request=… child=… status=… → <据此做了什么>` |

🔴 **最后那半句「据此做了什么」是关键**（`revoked ntok + DELETE FROM nodes` / `lifecycle_state=stopped` / …）。
#1286 里 hub 的代码路径经核对**是正确的**，缺的正是「它到底走没走那条分支」——
只说「收到了 ack」回答不了这个问题。

## 与 #1356 配对

| PR | 埋在哪 | 回答什么 |
|---|---|---|
| #1356 | daemon 侧 | ack **发没发** |
| 本 PR | hub 侧 | ack **到没到**，到了之后**做了什么** |

两个合起来，下一次复现就是确定的。

## 改动范围的一个坑

`request_not_found` 在 `server/src/tools.ts` 里出现 **4 次**（四个不同的 handler）。
🔴 本 PR **只改 `ack_stop_request` 那一个** —— 先按 handler 段落切出来、断言段内各锚点命中数为 1，
再回填。**没有用 replace_all。**

## 验证

```
bun build --target=node --no-bundle server/src/tools.ts   → rc=0（转译通过）
正控：先喂一份语法坏掉的副本                                → rc=1（判据有效）
```

🔴 **未跑 tsc**：worktree 里缺 `bun-types`，那是**环境缺口不是产品缺陷**，交给 CI。
（顺带记一笔：`npx tsc` 在这里拿到的是占位包，会打印 "This is not the tsc command you are looking for" —— 它**输出 0 行时会伪装成通过**。）

Refs #1358
Refs #1286